### PR TITLE
refactor(#1984): index-space freeze-point discipline

### DIFF
--- a/plan/issues/1984-index-space-freeze-point.md
+++ b/plan/issues/1984-index-space-freeze-point.md
@@ -1,10 +1,12 @@
 ---
 id: 1984
 title: "freeze-point discipline: indexSpaceFrozen flag — late addImport/ensureLateImport after final flush throws at the producer (#2043 Option 3)"
-status: ready
+status: done
+assignee: ttraenkler/tld-2139
 sprint: 63
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-16
+completed: 2026-06-16
 priority: medium
 feasibility: medium
 reasoning_effort: high
@@ -60,3 +62,65 @@ mutation throws **at the mutating call site** with its own stack.
 - Corpus sweep outcomes unchanged (no false freezes) on gc/wasi/standalone.
 - A regression test that forces a post-freeze `ensureLateImport` and asserts
   the named producer-site error.
+
+## Resolution (2026-06-16)
+
+Implemented the freeze-point flag + producer-site guards.
+
+### What landed
+
+- **`ctx.indexSpaceFrozen: boolean`** added to `CodegenContext`
+  (`context/types.ts`), initialized `false` in `createCodegenContext`
+  (`context/create-context.ts`).
+- **Single per-mode freeze point.** Set `ctx.indexSpaceFrozen = true`
+  immediately **before `stackBalance(mod)`** in BOTH `generateModule` and
+  `generateMultiModule` (`index.ts`). This is the true final boundary: every
+  legitimate late import mutation (`addUnionImports` / `addStringImports` /
+  `reconcileNativeStrFinalizeShift`, across gc/wasi/standalone — they all run
+  earlier in the body) is complete by then, and the remaining passes
+  (`stackBalance`, `fixupExternConvertAny`, emit) add **no** imports (verified:
+  `fixupExternConvertAny` has zero `addImport`/`ensureLateImport`/`addUnion`
+  calls). So a single placement covers all modes — no per-mode tracing needed.
+- **Producer-site guards (throw, own stack):**
+  - `addImport` (`registry/imports.ts`) — the chokepoint all import additions
+    flow through — throws `"import space frozen (#1984): '<module>.<name>' added
+    after finalize …"` when frozen, before the `ctx.mod.imports.push`.
+  - `ensureLateImport` (`expressions/late-imports.ts`) — throws its own named
+    error **after** the existing-name early-return, so a post-freeze *lookup* of
+    an already-registered import (shifts nothing) is still allowed; only a new
+    registration throws. The throw is caught by the `generate*` try/catch and
+    surfaced as a `Codegen error:` (compile fails loudly; never ships a poisoned
+    binary).
+- No `unfreezeForTest()` escape — tests build contexts before finalize like
+  production (and the unit test sets the flag directly to drive the guard).
+
+### Acceptance criteria — verified
+
+- ✅ **Flag exists, set at the per-mode finalize boundary, both entry points
+  throw the named error when frozen** — `tests/issue-1984.test.ts` (5 tests):
+  default false; pre-freeze `addImport` registers; frozen `addImport` and
+  frozen-new `ensureLateImport` both throw the named `#1984` error (and the
+  import is NOT registered); a frozen lookup of an already-registered import is
+  still allowed.
+- ✅ **Corpus sweep unchanged — no false freezes** — direct sweep of the
+  playground examples across **gc / wasi / standalone** (39 compiles) →
+  **0 false freezes**; `check:ir-fallbacks` passes; wasi suite 29/29.
+- ✅ **Regression test forcing post-freeze `ensureLateImport`** asserts the
+  named producer-site error (above).
+
+### No regression
+
+Behaviour-neutral on the import-boundary-sensitive suites: 53 pass / 1 fail in
+the union-import/standalone/closed-import set, and the 1 failure
+(`closed-imports > includes extern class imports`, `expected undefined to be
+defined`) reproduces **identically on `origin/main`** (verified by reverting
+the 5 changed src files) — pre-existing and unrelated to freezing (not an
+"import space frozen" error).
+
+### Mode note (per the risk callout)
+
+All modes that compile through `generateModule`/`generateMultiModule` (gc, wasi,
+standalone, multi-module) share the one freeze point before `stackBalance` and
+were corpus-validated. The linear backend (`generateLinearModule`) has its own
+pipeline and is out of scope here; it can adopt the same flag in a follow-up if
+its import space ever needs the same discipline.

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -152,6 +152,7 @@ export function createCodegenContext(
     anyHelpers: new Map(),
     anyHelpersEmitted: false,
     moduleInitGuardApplied: false,
+    indexSpaceFrozen: false, // #1984 — set true at the per-mode finalize boundary
     shapeMap: new Map(),
     templateCacheCounter: 0,
     templateVecTypeIdx: -1,

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1024,6 +1024,17 @@ export interface CodegenContext {
   /** (#1789) Whether the WASI module-init guard (idempotent __module_init +
    *  prepended init call on exports) has been applied. */
   moduleInitGuardApplied: boolean;
+  /**
+   * #1984 — freeze-point discipline (child of #2043 Option 3). Set to `true`
+   * by `generateModule`/`generateMultiModule` once the module's index spaces
+   * are final (right before `stackBalance`, after the last legitimate
+   * `addUnionImports`/`addStringImports`/`reconcileNativeStrFinalizeShift`
+   * mutation in every mode). While set, `addImport`/`ensureLateImport` throw a
+   * named producer-site error instead of silently mutating a finalized import
+   * space — so the producer that added an import too late self-identifies with
+   * its own stack, rather than #2043's emit-time validation only naming the
+   * downstream symptom. Default `false`. */
+  indexSpaceFrozen: boolean;
   /** Shape-inferred array-like variables */
   shapeMap: Map<string, { vecTypeIdx: number; arrTypeIdx: number; elemType: ValType }>;
   /** Set of function names that failed during hoisting pre-pass */

--- a/src/codegen/expressions/late-imports.ts
+++ b/src/codegen/expressions/late-imports.ts
@@ -325,6 +325,18 @@ export function ensureLateImport(
 ): number | undefined {
   const existing = ctx.funcMap.get(name);
   if (existing !== undefined) return existing;
+  // #1984 — freeze-point discipline. A name already in funcMap is a pure
+  // lookup (handled above, always safe). Reaching here means this call would
+  // REGISTER a new import — which after the index-space freeze is a producer
+  // bug that shifts already-emitted indices. Throw at the producer site (its
+  // own stack) rather than silently poisoning the import space. The throw is
+  // caught by the generate* try/catch and surfaced as a `Codegen error:`.
+  if (ctx.indexSpaceFrozen) {
+    throw new Error(
+      `import space frozen (#1984): late import '${name}' requested after finalize — ` +
+        `this producer must register its import before the freeze point or refuse loudly`,
+    );
+  }
   // #1471: under no-JS-host mode, the box/unbox/typeof/is_truthy helpers have
   // Wasm-native implementations emitted by addUnionImports. Route there so the
   // module needs no unsatisfiable `env::*` host import. addUnionImports is

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1666,6 +1666,14 @@ export function generateModule(
     // Peephole optimization: remove redundant ref.as_non_null after ref.cast, etc.
     peepholeOptimize(mod);
 
+    // #1984 — freeze the index spaces. Every legitimate late import mutation
+    // (addUnionImports / addStringImports / reconcileNativeStrFinalizeShift,
+    // across gc/wasi/standalone) has run by this point; the remaining passes
+    // (stackBalance, fixupExternConvertAny, emit) do NOT add imports. Any
+    // addImport/ensureLateImport after here is a producer bug and throws at
+    // its own call site (see imports.ts / late-imports.ts).
+    ctx.indexSpaceFrozen = true;
+
     // Stack-balancing fixup: ensure all branches in if/try/block have matching stack states
     stackBalance(mod);
     // #1918 — drain fixup telemetry: per-compile debug log + optional strict mode.
@@ -5255,6 +5263,12 @@ export function generateMultiModule(
 
     // Peephole optimization: remove redundant ref.as_non_null after ref.cast, etc.
     peepholeOptimize(mod);
+
+    // #1984 — freeze the index spaces (multi-module path). Same boundary as the
+    // single-module generateModule: all legitimate late import mutations have
+    // run; stackBalance / fixupExternConvertAny / emit add no imports. Any
+    // addImport/ensureLateImport after here throws at the producer site.
+    ctx.indexSpaceFrozen = true;
 
     // Stack-balancing fixup: ensure all branches in if/try/block have matching stack states
     stackBalance(mod);

--- a/src/codegen/registry/imports.ts
+++ b/src/codegen/registry/imports.ts
@@ -32,6 +32,21 @@ import { addFuncType } from "./types.js";
  * dedicated error pointing the user at the nativeStrings option.
  */
 export function addImport(ctx: CodegenContext, module: string, name: string, desc: Import["desc"]): void {
+  // #1984 — freeze-point discipline. Once the module's index spaces are
+  // declared final (set right before `stackBalance` in generateModule/
+  // generateMultiModule), any further import mutation is a producer bug:
+  // it shifts indices that downstream code already emitted as final, the
+  // #2043-class poisoning. Throw HERE so the offending producer self-identifies
+  // with its own stack, instead of #2043's emit-time validation only naming the
+  // downstream symptom. The throw is caught by the generate* try/catch and
+  // surfaced as a `Codegen error:` (the compile fails loudly, never ships a
+  // poisoned binary).
+  if (ctx.indexSpaceFrozen) {
+    throw new Error(
+      `import space frozen (#1984): '${module}.${name}' added after finalize — ` +
+        `this producer must register its import before the freeze point or refuse loudly`,
+    );
+  }
   if (ctx.strictNoHostImports) {
     const decision = isHostImportAllowed(module, name);
     if (!decision.allowed) {

--- a/tests/issue-1984.test.ts
+++ b/tests/issue-1984.test.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1984 — Index-space freeze-point discipline (child of #2043 Option 3).
+ *
+ * #2043's emit-time validation names the *symptom* (which function held a
+ * poisoned index). This freeze-point makes the *producer* self-identify: once
+ * `ctx.indexSpaceFrozen` is set (right before `stackBalance` in
+ * generateModule/generateMultiModule, after every legitimate late import
+ * mutation), any further `addImport`/`ensureLateImport` throws at the mutating
+ * call site with its own stack instead of silently shifting already-emitted
+ * indices.
+ *
+ * These unit tests drive the two mutation entry points directly with a frozen
+ * context and assert the named producer-site error, plus the non-firing cases:
+ * a pre-freeze add succeeds, and a frozen *lookup* of an already-registered
+ * import is still allowed (it shifts nothing).
+ */
+import { describe, expect, it } from "vitest";
+import { createEmptyModule } from "../src/ir/types.js";
+import { createCodegenContext } from "../src/codegen/index.js";
+import { addImport } from "../src/codegen/registry/imports.js";
+import { ensureLateImport } from "../src/codegen/expressions/late-imports.js";
+import ts from "typescript";
+
+function makeCtx() {
+  return createCodegenContext(createEmptyModule(), {} as unknown as ts.TypeChecker);
+}
+
+describe("#1984 — index-space freeze-point discipline", () => {
+  it("defaults to not frozen", () => {
+    expect(makeCtx().indexSpaceFrozen).toBe(false);
+  });
+
+  it("addImport works before the freeze and registers the import", () => {
+    const ctx = makeCtx();
+    addImport(ctx, "env", "before_freeze", { kind: "func", typeIdx: 0 });
+    expect(ctx.mod.imports.some((i) => i.name === "before_freeze")).toBe(true);
+    expect(ctx.funcMap.get("before_freeze")).toBe(0);
+  });
+
+  it("addImport throws the named producer-site error once frozen", () => {
+    const ctx = makeCtx();
+    ctx.indexSpaceFrozen = true;
+    expect(() => addImport(ctx, "env", "too_late", { kind: "func", typeIdx: 0 })).toThrow(
+      /import space frozen \(#1984\).*'env\.too_late' added after finalize/,
+    );
+    // The import must NOT have been registered (the throw is before the push).
+    expect(ctx.mod.imports.some((i) => i.name === "too_late")).toBe(false);
+  });
+
+  it("ensureLateImport throws the named producer-site error once frozen (new import)", () => {
+    const ctx = makeCtx();
+    ctx.indexSpaceFrozen = true;
+    expect(() => ensureLateImport(ctx, "late_helper", [], [])).toThrow(
+      /import space frozen \(#1984\): late import 'late_helper' requested after finalize/,
+    );
+  });
+
+  it("a frozen lookup of an ALREADY-registered import is still allowed (no shift)", () => {
+    const ctx = makeCtx();
+    // Register before freezing, then freeze and look it up — pure lookup, safe.
+    const idx = ensureLateImport(ctx, "preexisting", [], []);
+    expect(typeof idx).toBe("number");
+    ctx.indexSpaceFrozen = true;
+    expect(ensureLateImport(ctx, "preexisting", [], [])).toBe(idx);
+  });
+});


### PR DESCRIPTION
## Summary

#2043's emit-time validation names the *symptom* (which function held a poisoned index); the **producer** that mutated the import space after it should be final is still found by reading codegen. This freeze-point makes the producer self-identify — once the index spaces are declared final, any further `addImport`/`ensureLateImport` throws **at the mutating call site with its own stack**.

## Changes

- **`ctx.indexSpaceFrozen`** flag on `CodegenContext` (default `false`).
- **Single per-mode freeze point**: set `true` immediately before `stackBalance(mod)` in **both** `generateModule` and `generateMultiModule`. That's the true final boundary — every legitimate late mutation (`addUnionImports`/`addStringImports`/`reconcileNativeStrFinalizeShift`, across gc/wasi/standalone) has run, and `stackBalance`/`fixupExternConvertAny`/emit add **no** imports (verified). One placement covers all modes; no per-mode tracing needed.
- **Producer-site guards (throw, own stack):** `addImport` (the chokepoint) and `ensureLateImport` (after its existing-name early-return, so a frozen *lookup* of an already-registered import is still allowed) throw `"import space frozen (#1984): … added after finalize"`. Caught by the `generate*` try/catch → surfaced as a `Codegen error:` (fails loudly, never ships a poisoned binary).

## Acceptance criteria — verified (`tests/issue-1984.test.ts`, 5 tests)

- ✅ Flag exists, set at the finalize boundary, both entry points throw the named error when frozen (and the import is NOT registered); a frozen lookup of an existing import is still allowed.
- ✅ **Corpus sweep unchanged — 0 false freezes** across **gc / wasi / standalone** (39 compiles); `check:ir-fallbacks` passes; wasi 29/29.
- ✅ Regression test forcing a post-freeze `ensureLateImport` asserts the named producer-site error.

## No regression

Behaviour-neutral on the import-boundary suites (53 pass / 1 fail); the 1 failure (`closed-imports > includes extern class imports`) reproduces **identically on `origin/main`** — pre-existing, unrelated to freezing (not an "import space frozen" error).

Mode note: the linear backend has its own pipeline and is out of scope here (follow-up if its import space ever needs the same discipline).

Closes #1984.

🤖 Generated with [Claude Code](https://claude.com/claude-code)