### PR TITLE
feat(#2143): validate default-pipeline output in the diff harness (malformed_wasm lane)

### DIFF
--- a/plan/issues/2143-validate-unoptimized-output-lane.md
+++ b/plan/issues/2143-validate-unoptimized-output-lane.md
@@ -1,10 +1,12 @@
 ---
 id: 2143
 title: "WebAssembly.validate lane for unoptimized pipeline output (split of #1858-C5)"
-status: ready
+status: done
 sprint: 63
 created: 2026-06-12
-updated: 2026-06-12
+updated: 2026-06-16
+completed: 2026-06-16
+assignee: ttraenkler/tld-1921
 priority: medium
 feasibility: easy
 reasoning_effort: low
@@ -40,3 +42,44 @@ hard-error stability bucket.
 ## Notes
 
 S-size, routine dev; ride along with #1853 in the same lane.
+
+## Resolution (2026-06-16)
+
+The default (unoptimized) pipeline's output is now validated in the
+differential harness, and a validation failure is classified as a distinct
+`malformed_wasm` outcome.
+
+- **`scripts/diff-test.ts`** — after a successful compile, `runJs2wasm` now runs
+  `WebAssembly.validate(r.binary)` BEFORE instantiating. A failure returns the
+  new `outcome: "malformed_wasm"` (instead of surfacing as an
+  indistinguishable `runtime_error` at instantiate time, only when the program
+  happened to be executed). The `FileResult.outcome` union and the `Summary`
+  counters/console output gained the `malformed_wasm` bucket. This runs in BOTH
+  lanes — the default pipeline AND the `-O3` lane (`optimize.ts` already
+  validated its own output; the default path did not).
+- **`scripts/diff-test-gate.ts` / `diff-test-optimize-gate.ts`** — the
+  per-file delta gate already fails on any `match → non-match` flip, so a
+  corpus program regressing from `match` to `malformed_wasm` now fails CI
+  loudly (acceptance criterion 2). Their `outcome` types were extended to
+  include `malformed_wasm` for type-correctness.
+- The **equivalence-test helper** (`tests/equivalence/helpers.ts`) already
+  validates the binary (pre-existing) — the test-side lane the issue asked for
+  is in place.
+
+The 2 known invalid-unoptimized corpus programs (#1941's corpus work) now
+surface as `malformed_wasm`: `array/02-push-pop.js` and
+`control/12-for-in-object.js` (both compile `success: true` but fail
+`WebAssembly.validate`). Neither was `match` in the baseline
+(`runtime_error` / `mismatch` respectively), so reclassifying them is a
+better-signal change, not a new gate failure.
+
+### Test Results
+
+- `tests/issue-2143-validate-unoptimized.test.ts` — 3/3 pass: the 2
+  known-malformed programs are detected (`success: true` + `validate: false`),
+  and a clean program (`numeric/01-basic-arithmetic.js`) still compiles AND
+  validates (the detection isn't over-eager). The pin ratchets: if a future fix
+  makes one of the two validate cleanly, the test flags it for removal from
+  `KNOWN_MALFORMED`.
+- `npx tsx scripts/diff-test.ts` locally reports `Malformed wasm: 2`.
+- `npm run typecheck` + `npm run lint` (Biome) clean.

--- a/scripts/diff-test-gate.ts
+++ b/scripts/diff-test-gate.ts
@@ -21,7 +21,11 @@ const ROOT = resolve(fileURLToPath(import.meta.url), "..", "..");
 
 interface FileResult {
   file: string;
-  outcome: "match" | "mismatch" | "compile_error" | "runtime_error" | "v8_error";
+  // #2143 — `malformed_wasm`: compiler reported success but WebAssembly.validate
+  // rejected the binary. The per-file delta below treats it like any other
+  // non-match outcome, so a corpus program that regresses from `match` to
+  // `malformed_wasm` fails the gate loudly.
+  outcome: "match" | "mismatch" | "compile_error" | "runtime_error" | "v8_error" | "malformed_wasm";
   error?: string;
 }
 

--- a/scripts/diff-test-optimize-gate.ts
+++ b/scripts/diff-test-optimize-gate.ts
@@ -31,7 +31,7 @@ import { fileURLToPath } from "node:url";
 
 const ROOT = resolve(fileURLToPath(import.meta.url), "..", "..");
 
-type Outcome = "match" | "mismatch" | "compile_error" | "runtime_error" | "v8_error";
+type Outcome = "match" | "mismatch" | "compile_error" | "runtime_error" | "v8_error" | "malformed_wasm";
 interface FileResult {
   file: string;
   outcome: Outcome;

--- a/scripts/diff-test.ts
+++ b/scripts/diff-test.ts
@@ -61,7 +61,7 @@ interface FileResult {
   /** Compile-error or runtime-error message (only set on `error` outcome) */
   error?: string;
   /** Outcome bucket */
-  outcome: "match" | "mismatch" | "compile_error" | "runtime_error" | "v8_error";
+  outcome: "match" | "mismatch" | "compile_error" | "runtime_error" | "v8_error" | "malformed_wasm";
   /** Wall-clock millis spent on each lane (for triage) */
   ms_v8: number;
   ms_js2wasm: number;
@@ -74,6 +74,8 @@ interface Summary {
   compile_error: number;
   runtime_error: number;
   v8_error: number;
+  /** #2143 — compiler reported success but WebAssembly.validate rejected the binary. */
+  malformed_wasm: number;
   /** Mismatches bucketed by top-level category */
   by_category: Record<string, { total: number; match: number; mismatch: number; error: number }>;
   /** Wall-clock seconds */
@@ -130,9 +132,12 @@ function runV8(file: string): { stdout: string; error?: string; ms: number } {
 }
 
 /** Compile a JS file with js2wasm, instantiate, capture console.log output. */
-async function runJs2wasm(
-  file: string,
-): Promise<{ stdout: string; error?: string; ms: number; outcome: "match" | "compile_error" | "runtime_error" }> {
+async function runJs2wasm(file: string): Promise<{
+  stdout: string;
+  error?: string;
+  ms: number;
+  outcome: "match" | "compile_error" | "runtime_error" | "malformed_wasm";
+}> {
   const t0 = Date.now();
   let source: string;
   try {
@@ -147,6 +152,22 @@ async function runJs2wasm(
       error: `compile: ${r.errors[0]?.message ?? "unknown"}`,
       ms: Date.now() - t0,
       outcome: "compile_error",
+    };
+  }
+  // #2143 — validate the compiled binary BEFORE instantiating. Previously a
+  // malformed binary (compiler reported success but the engine rejects it)
+  // surfaced only as a `runtime_error` at instantiate time, indistinguishable
+  // from a genuine trap and only when this program happened to be executed.
+  // Classify it as a distinct `malformed_wasm` outcome so the gate buckets it
+  // as a hard-error-stability signal (#1853) rather than burying it in runtime
+  // noise. Both lanes (default + `-O3`) run this — the optimizer already
+  // validates its own output (optimize.ts), but the DEFAULT pipeline did not.
+  if (!WebAssembly.validate(r.binary)) {
+    return {
+      stdout: "",
+      error: `malformed_wasm: js2wasm reported success but WebAssembly.validate rejected the ${OPTIMIZE ? "-O3" : "default-pipeline"} binary`,
+      ms: Date.now() - t0,
+      outcome: "malformed_wasm",
     };
   }
   // Monkey-patch console.log so we capture the side effects of top-level code
@@ -261,6 +282,7 @@ async function main(): Promise<void> {
     compile_error: 0,
     runtime_error: 0,
     v8_error: 0,
+    malformed_wasm: 0,
     by_category: {},
     duration_s: 0,
     results,
@@ -287,6 +309,7 @@ async function main(): Promise<void> {
   console.log(`  Mismatch:        ${summary.mismatch.toString().padStart(4)}`);
   console.log(`  Compile error:   ${summary.compile_error.toString().padStart(4)}`);
   console.log(`  Runtime error:   ${summary.runtime_error.toString().padStart(4)}`);
+  console.log(`  Malformed wasm:  ${summary.malformed_wasm.toString().padStart(4)}`);
   console.log(`  V8 error:        ${summary.v8_error.toString().padStart(4)}`);
   console.log("");
   console.log("By category:");

--- a/tests/issue-2143-validate-unoptimized.test.ts
+++ b/tests/issue-2143-validate-unoptimized.test.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2143 — the differential harness validates DEFAULT-pipeline output, not just
+ * optimizer output. Previously a binary the compiler reported as `success:
+ * true` but the engine rejects (`WebAssembly.validate` → false) was invisible:
+ * it surfaced only as an instantiate-time `runtime_error`, and only when a test
+ * happened to execute it.
+ *
+ * `scripts/diff-test.ts` now runs `WebAssembly.validate(r.binary)` after a
+ * successful compile and classifies a failure as the distinct `malformed_wasm`
+ * outcome (feeding #1853's hard-error-stability bucket); the per-file delta gate
+ * (`scripts/diff-test-gate.ts`) then fails CI loudly if any corpus program
+ * regresses from `match` to `malformed_wasm`.
+ *
+ * This test pins the two known invalid-unoptimized corpus programs (#1941's
+ * corpus work) so the detection can't silently regress. If a future fix makes
+ * one of these validate cleanly, this test will flag it — move the now-valid
+ * program out of `KNOWN_MALFORMED` (ratchet direction).
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { compile } from "../src/index.js";
+
+const CORPUS_DIR = resolve(import.meta.dirname, "differential", "corpus");
+
+// Programs that compile (`success: true`) but whose DEFAULT-pipeline binary
+// fails WebAssembly.validate — the malformed-wasm class #2143 makes visible.
+const KNOWN_MALFORMED = ["array/02-push-pop.js", "control/12-for-in-object.js"];
+
+// A representative valid program: must compile AND validate (guards against the
+// detection over-firing / a regression breaking a clean program).
+const KNOWN_VALID = "numeric/01-basic-arithmetic.js";
+
+describe("#2143 — default-pipeline Wasm validation", () => {
+  for (const rel of KNOWN_MALFORMED) {
+    it(`${rel}: compiles success:true but the default binary fails WebAssembly.validate`, async () => {
+      const src = readFileSync(resolve(CORPUS_DIR, rel), "utf-8");
+      const r = await compile(src, { fileName: rel });
+      // The whole point of #2143: `success` is NOT a sufficient signal of a
+      // valid binary. (If `success` ever becomes false here the program now
+      // hard-errors — also acceptable, but then update this list.)
+      expect(r.success).toBe(true);
+      expect(WebAssembly.validate(r.binary)).toBe(false);
+    });
+  }
+
+  it(`${KNOWN_VALID}: a clean program still compiles AND validates (detection isn't over-eager)`, async () => {
+    const src = readFileSync(resolve(CORPUS_DIR, KNOWN_VALID), "utf-8");
+    const r = await compile(src, { fileName: KNOWN_VALID });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+  });
+});


### PR DESCRIPTION
## #2143 — malformed default-pipeline Wasm is only caught if a test happens to instantiate it

Only **optimizer** output was validated (`src/optimize.ts`). A malformed binary from the **default** pipeline — the compiler reports `success: true` but `WebAssembly.validate` rejects it — was invisible: it surfaced only as an instantiate-time `runtime_error`, indistinguishable from a genuine trap, and only when a test happened to execute that module. #1941's corpus work found 2 such programs.

### Change

- **`scripts/diff-test.ts`** — `runJs2wasm` now runs `WebAssembly.validate(r.binary)` after a successful compile, **before** instantiating. A failure returns the new `outcome: "malformed_wasm"` (added to the `FileResult.outcome` union, the `Summary` counter, and the console summary). Runs in **both** the default and the `-O3` lane.
- **`scripts/diff-test-gate.ts` / `diff-test-optimize-gate.ts`** — `outcome` types extended with `malformed_wasm`. The existing per-file delta gate already fails CI on any `match → non-match` flip, so a corpus program regressing from `match` to `malformed_wasm` now fails loudly.
- The **equivalence-test helper** (`tests/equivalence/helpers.ts`) already validates the binary (pre-existing) — the test-side lane the issue asked for is in place.

### Acceptance criteria

- [x] The 2 known invalid-unoptimized corpus programs surface as bucketed hard errors — `array/02-push-pop.js` and `control/12-for-in-object.js` now classify as `malformed_wasm` (both `success: true`, `validate: false`). Neither was `match` in the baseline (`runtime_error`/`mismatch`), so this is better signal, not a new gate failure.
- [x] A regression emitting invalid Wasm on any corpus program fails CI loudly — via the existing per-file delta gate, now that `malformed_wasm` is a non-match outcome.

### Validation

- `tests/issue-2143-validate-unoptimized.test.ts` — 3/3: pins the 2 malformed programs (`success: true` + `validate: false`) and a clean program (`numeric/01-basic-arithmetic.js`) that still validates (detection not over-eager). Ratchets: if one is later fixed, the test flags it for removal from `KNOWN_MALFORMED`.
- `npx tsx scripts/diff-test.ts` locally reports `Malformed wasm: 2`.
- `npm run typecheck` + `npm run lint` (Biome) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)