### PR TITLE
fix(#2184): linear &&/|| yield operand value, not 0/1 constant

### DIFF
--- a/plan/issues/2184-linear-logical-operator-operand-values.md
+++ b/plan/issues/2184-linear-logical-operator-operand-values.md
@@ -1,10 +1,12 @@
 ---
 id: 2184
 title: "linear backend: &&/|| yield 0/1 constants instead of operand values (needs result-type unification)"
-status: ready
+status: done
+completed: 2026-06-17
+assignee: ttraenkler/dev-resume
 sprint: 63
 created: 2026-06-16
-updated: 2026-06-16
+updated: 2026-06-17
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -76,3 +78,33 @@ shipped; this is the carved-out remainder.
 ## Notes
 
 GC backend already yields operand values correctly; this is linear-only.
+
+## Resolution (2026-06-17, PR for #2184)
+
+Fixed in `src/codegen-linear/index.ts`:
+
+- **Same-typed operands** (`string||string`, `number||number`, `bool&&bool`):
+  the lowering now tees the LHS into a temp, runs `emitTruthyCoercion` on the
+  tee'd value for the branch condition, and yields the **actual operand** —
+  `local.get leftTemp` on the short-circuit arm, the RHS on the other. The `if`
+  result ValType is the operand's native type (string `i32`-pointer / `f64` /
+  bool `i32`), so no `0`/`1` constants and no value loss. `inferExprType` gained
+  a matching `&&`/`||` case so callers (var decl, return) allocate a local of
+  the same type.
+- **Mixed-type operands** (e.g. string `i32` vs number `f64`): kept the legacy
+  boolean-producing lowering. Coercing a string pointer to `f64` to share one
+  `if` result type would corrupt both the value and downstream truthiness (a
+  nonzero pointer reads truthy even for `""`). This is the documented
+  same-typed-first scope; covering mixed-type *values* needs a boxed/`any`
+  representation and is left as a follow-up. Boolean-context mixed use stays
+  correct (the #1975 path).
+
+## Test Results
+
+`tests/issue-2184.test.ts` — 12/12 pass (operand-value `&&`/`||` for numeric +
+string operands, chains, typed-local flow, plus #1975 boolean-context regression
+guards). `tests/issue-1975.test.ts` — 8/8 still pass.
+`tests/equivalence/{logical-operators,coalesce-operator,boolean-relational-comparison}.test.ts`
+pass unchanged. (Pre-existing, unrelated failures confirmed on pristine
+upstream/main: `ir-numeric-bool-equivalence` `__unbox_number` link errors;
+`logical-conditional-identity` `void x` NaN cases.)

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -2163,30 +2163,90 @@ function compileBinaryExpression(ctx: LinearContext, fctx: LinearFuncContext, ex
     }
   }
 
-  // Logical AND / OR: short-circuit evaluation producing f64
+  // Logical AND / OR: short-circuit evaluation yielding the OPERAND value
+  // (#2184). JS `a || b` ⇒ `ToBoolean(a) ? a : b`; `a && b` ⇒
+  // `ToBoolean(a) ? b : a`. The result is an *operand*, not a 0/1 boolean —
+  // earlier lowering coerced to f64 and pushed `0`/`1` constants on the
+  // short-circuit arm, which discarded the value (`"" || "x"` returned `0`
+  // instead of `"x"`, `0 || 42` returned `1` instead of `42`).
+  //
+  // The boolean-context use (`if (a || b)`, `while`, `?:` condition) is handled
+  // by callers that run emitTruthyCoercion on the result, so yielding the real
+  // operand value stays correct there too (ToBoolean(operand) is what JS does).
   if (op === ts.SyntaxKind.AmpersandAmpersandToken || op === ts.SyntaxKind.BarBarToken) {
-    compileExpression(ctx, fctx, expr.left);
     const leftType = inferExprType(ctx, fctx, expr.left);
+    const rightType = inferExprType(ctx, fctx, expr.right);
+
+    // Mixed-type operands (e.g. string `i32` vs number `f64`) can't share a
+    // single `if` result ValType without a boxed/`any` representation: coercing
+    // a string POINTER to f64 would corrupt both the value and its downstream
+    // truthiness (a nonzero pointer reads as truthy even for `""`). This is the
+    // documented same-typed-first scope (#2184) — for mixed types keep the
+    // legacy boolean-producing lowering, which is correct in boolean context
+    // (the dominant mixed-type use; #1975). A follow-up covers mixed values.
+    if (leftType.kind !== rightType.kind) {
+      compileExpression(ctx, fctx, expr.left);
+      emitTruthyCoercion(fctx, leftType, { ctx, expr: expr.left });
+      const thenBodyM: Instr[] = [];
+      const elseBodyM: Instr[] = [];
+      const savedBodyM = fctx.body;
+      if (op === ts.SyntaxKind.AmpersandAmpersandToken) {
+        fctx.body = thenBodyM;
+        compileExprToF64(ctx, fctx, expr.right);
+        fctx.body = savedBodyM;
+        elseBodyM.push({ op: "f64.const", value: 0 });
+      } else {
+        thenBodyM.push({ op: "f64.const", value: 1 });
+        fctx.body = elseBodyM;
+        compileExprToF64(ctx, fctx, expr.right);
+        fctx.body = savedBodyM;
+      }
+      fctx.body.push({
+        op: "if",
+        blockType: { kind: "val", type: { kind: "f64" } },
+        then: thenBodyM,
+        else: elseBodyM,
+      });
+      return;
+    }
+
+    // Same-typed operands carry their native value type (string i32-pointer,
+    // f64, bool i32). Hold the LHS in a temp so its value is available on the
+    // short-circuit arm after it has been consumed by the truthiness test.
+    const resultType: ValType = leftType;
+    const leftTemp = addLocal(fctx, `__logical_lhs_${fctx.locals.length}`, leftType);
+    compileExpression(ctx, fctx, expr.left);
+    fctx.body.push({ op: "local.tee", index: leftTemp });
     emitTruthyCoercion(fctx, leftType, { ctx, expr: expr.left });
+
+    const emitLeftAsResult = () => {
+      fctx.body.push({ op: "local.get", index: leftTemp });
+    };
+    const emitRightAsResult = () => {
+      compileExpression(ctx, fctx, expr.right);
+    };
+
     const thenBody: Instr[] = [];
     const elseBody: Instr[] = [];
     const savedBody = fctx.body;
     if (op === ts.SyntaxKind.AmpersandAmpersandToken) {
-      // &&: if left truthy → evaluate right; else → 0
+      // &&: left truthy → right; else → left
       fctx.body = thenBody;
-      compileExprToF64(ctx, fctx, expr.right);
-      fctx.body = savedBody;
-      elseBody.push({ op: "f64.const", value: 0 });
-    } else {
-      // ||: if left truthy → 1; else → evaluate right
-      thenBody.push({ op: "f64.const", value: 1 });
+      emitRightAsResult();
       fctx.body = elseBody;
-      compileExprToF64(ctx, fctx, expr.right);
+      emitLeftAsResult();
+      fctx.body = savedBody;
+    } else {
+      // ||: left truthy → left; else → right
+      fctx.body = thenBody;
+      emitLeftAsResult();
+      fctx.body = elseBody;
+      emitRightAsResult();
       fctx.body = savedBody;
     }
     fctx.body.push({
       op: "if",
-      blockType: { kind: "val", type: { kind: "f64" } },
+      blockType: { kind: "val", type: resultType },
       then: thenBody,
       else: elseBody,
     });
@@ -3888,6 +3948,21 @@ function inferExprType(ctx: LinearContext, fctx: LinearFuncContext, expr: ts.Exp
     if (isStringExpr(ctx, fctx, expr.left) || isStringExpr(ctx, fctx, expr.right)) {
       return { kind: "i32" };
     }
+  }
+
+  // #2184: `&&`/`||` yield an OPERAND value, not a 0/1 boolean. The codegen
+  // emits an `if` whose result ValType is the unified operand type (same-typed
+  // operands carry their native type; mixed i32/f64 falls back to f64). This
+  // inference MUST mirror the `resultType` computed in the lowering above so
+  // callers (variable declaration, return) allocate a matching local.
+  if (
+    ts.isBinaryExpression(expr) &&
+    (expr.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken ||
+      expr.operatorToken.kind === ts.SyntaxKind.BarBarToken)
+  ) {
+    const lt = inferExprType(ctx, fctx, expr.left);
+    const rt = inferExprType(ctx, fctx, expr.right);
+    return lt.kind === rt.kind ? lt : { kind: "f64" };
   }
 
   // `this` is always an i32 pointer

--- a/tests/issue-2184.test.ts
+++ b/tests/issue-2184.test.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2184 — linear-backend `&&`/`||` discarded the operand value.
+ *
+ * JS `a || b` ⇒ `ToBoolean(a) ? a : b`; `a && b` ⇒ `ToBoolean(a) ? b : a`.
+ * Both yield an *operand*, not a 0/1 boolean. The linear backend's logical
+ * lowering coerced its result to f64 and pushed the constants `0`/`1` on the
+ * short-circuit arm, so `"" || "x"` returned `0` instead of `"x"` and
+ * `0 || 42` returned `1` instead of `42`.
+ *
+ * The fix tees the LHS into a temp and yields the actual operand value, with
+ * the `if` result type unified to the (same-typed) operand ValType. Mixed-type
+ * operands (string `i32` vs number `f64`) keep the legacy boolean-producing
+ * lowering — they can't share a single `if` result type without a boxed
+ * representation, and that path is correct in boolean context (#1975). Covering
+ * mixed-type *values* is carved out as a follow-up.
+ *
+ * The boolean-context use (#1975, PR #1412) must stay correct — guarded here.
+ *
+ * Validated on `target: "linear"` against Node operand-value semantics.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runLinear(body: string): Promise<number> {
+  const src = `export function test(): number { ${body} }`;
+  const r = await compile(src, { fileName: "test.ts", target: "linear" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2184 linear backend && / || yield the operand value", () => {
+  it("|| yields the RHS when the LHS is falsy (numeric)", async () => {
+    expect(await runLinear(`const r = 0 || 42; return r;`)).toBe(42);
+  });
+
+  it("|| yields the LHS when it is truthy (numeric)", async () => {
+    expect(await runLinear(`const r = 5 || 42; return r;`)).toBe(5);
+  });
+
+  it("&& yields the RHS when the LHS is truthy (numeric)", async () => {
+    expect(await runLinear(`const r = 3 && 7; return r;`)).toBe(7);
+  });
+
+  it("&& yields the LHS when it is falsy (numeric)", async () => {
+    expect(await runLinear(`const r = 0 && 7; return r;`)).toBe(0);
+  });
+
+  it("|| yields the RHS string operand when the LHS string is empty", async () => {
+    // "" is falsy → r === "x", length 1.
+    expect(await runLinear(`const r = "" || "x"; return r.length;`)).toBe(1);
+  });
+
+  it("&& yields the RHS string operand when the LHS string is truthy", async () => {
+    // "a" is truthy → r === "bb", length 2.
+    expect(await runLinear(`const r = "a" && "bb"; return r.length;`)).toBe(2);
+  });
+
+  it("|| yields the (truthy) LHS string operand", async () => {
+    expect(await runLinear(`const r = "ab" || "x"; return r.length;`)).toBe(2);
+  });
+
+  it("&& yields the (falsy, empty) LHS string operand", async () => {
+    expect(await runLinear(`const r = "" && "x"; return r.length;`)).toBe(0);
+  });
+
+  it("chains evaluate left-to-right and yield the final operand", async () => {
+    expect(await runLinear(`const r = 0 || 0 || 9; return r;`)).toBe(9);
+    expect(await runLinear(`const r = 1 && 2 && 3; return r;`)).toBe(3);
+  });
+
+  it("the operand value flows into a typed local", async () => {
+    expect(await runLinear(`let x = 0 || 7; x = x + 1; return x;`)).toBe(8);
+  });
+
+  // ── boolean-context regression guards (#1975 path must stay correct) ──
+  it("numeric boolean-context && / || unchanged", async () => {
+    expect(await runLinear(`if (0 || 5) return 1; return 0;`)).toBe(1);
+    expect(await runLinear(`if (3 && 0) return 1; return 0;`)).toBe(0);
+  });
+
+  it("mixed string/number boolean-context unchanged (#1975)", async () => {
+    expect(await runLinear(`const s = "a"; if (s && 2) return 1; return 0;`)).toBe(1);
+    expect(await runLinear(`const s = ""; if (s || 0) return 1; return 0;`)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem (#2184)

JS `a || b` => `ToBoolean(a) ? a : b`; `a && b` => `ToBoolean(a) ? b : a` — both yield an **operand**, not a 0/1 boolean. The linear backend coerced the result to f64 and pushed `0`/`1` constants on the short-circuit arm, discarding the value:

| probe | before | node |
|---|---|---|
| `"" || "x"` | `0` | `"x"` |
| `"a" && "b"` | `1` | `"b"` |
| `0 || 42` | `1` | `42` |

Split from #1975 (the ToBoolean half shipped in PR #1412); this is the carved-out operand-value remainder.

## Fix (`src/codegen-linear/index.ts`)

- **Same-typed operands**: tee the LHS into a temp, run `emitTruthyCoercion` on the tee'd value for the branch condition, and yield the actual operand (`local.get leftTemp` / RHS). The `if` result ValType is the operand's native type (string `i32`-pointer / `f64` / bool `i32`) — no `0`/`1` constants. `inferExprType` gained a matching `&&`/`||` case so callers allocate a same-typed local.
- **Mixed-type operands** (string `i32` vs number `f64`): keep the legacy boolean-producing lowering — coercing a string pointer to f64 would corrupt the value and downstream truthiness. Documented same-typed-first scope; mixed-type *values* are a follow-up. Boolean-context use (#1975) stays correct.

## Tests

- `tests/issue-2184.test.ts` — 12/12 pass (numeric + string operand values, chains, typed-local flow, #1975 boolean-context regression guards).
- `tests/issue-1975.test.ts` — 8/8 unchanged.
- `tests/equivalence/{logical-operators,coalesce-operator,boolean-relational-comparison}.test.ts` pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)