### PR TITLE
fix(#2118): self-recursive const/let arrow closures emit valid Wasm

### DIFF
--- a/plan/issues/2118-const-arrow-self-mutual-recursion-invalid-wasm.md
+++ b/plan/issues/2118-const-arrow-self-mutual-recursion-invalid-wasm.md
@@ -2,10 +2,12 @@
 id: 2118
 renumbered_from: 1951
 title: "self/mutually-recursive const-arrow closures emit invalid Wasm (struct.get type mismatch) or runtime ref.cast traps"
-status: ready
+status: done
+completed: 2026-06-17
+assignee: sendev-closures
 sprint: 63
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-17
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -77,3 +79,52 @@ Grepped `recursive closure|self-recursive|arrow.*recursive`, `mutual`,
 `factorial|fibonacci`: #897 (top-level fib, done), #1312 (nested async
 fn-decl with captures, done), #1314/#1301/#1063 (other closure codegen, done),
 #1178 (stack exhaustion, done). Const-arrow self/mutual recursion is untracked.
+
+## Resolution (2026-06-17 — self-recursion fixed; mutual split out)
+
+**Root cause (confirmed):** `compileArrowAsClosure` captured the closure's own
+binding `f` as an ordinary variable. The outer slot for `f` is `externref`
+(function types resolve to externref) and is still *uninitialized* when the
+closure is built, so the self-capture was boxed into a `__ref_cell_externref`;
+the construction prologue then `ref.cast`s that ref-cell to the closure struct,
+which fails Wasm validation (`struct.get expected (ref null N) found (ref null
+M)`). Named function expressions already routed self-refs through the `__self`
+lifted param (index 0); arrow-bound names did not.
+
+**Fix (`src/codegen/closures.ts`, all in `compileArrowAsClosure`):**
+1. Detect the **self-binding name** — the arrow is the `initializer` of a
+   `const`/`let` `VariableDeclaration` with an identifier name.
+2. **Skip capturing** that name (alongside the existing named-funcexpr
+   self-skip).
+3. Register the name against `__self` (param 0) in the lifted `localMap` and a
+   temporary `closureMap` entry whose `structTypeIdx = selfTypeIdx` (the
+   `__self` param's *actual* type — the wrapper **base** struct on the
+   capture-subtype path, else the specific struct), `funcTypeIdx =
+   liftedFuncTypeIdx`. Recursive `f(...)` calls then dispatch via `call_ref`
+   through the closure's own struct.
+4. Save/restore the outer `closureMap` entry so the temporary self entry does
+   not leak into the enclosing scope (where `f` still resolves to its slot).
+
+The `selfTypeIdx`-not-`structTypeIdx` choice is load-bearing: when the
+recursive arrow *also captures another variable* (`captures.length > 0`),
+`__self` is typed as the wrapper base, not the concrete subtype, so the
+funcref `struct.get` must run against the base type. Covered by the
+`self-recursive arrow that also captures an outer variable` test.
+
+**Validated** (`tests/issue-2118.test.ts`, 6 cases): const/let factorial → 120,
+fib (two self-calls) → 55, self+capture → 48, nested-fn self-recursion → 10,
+non-recursive arrow regression guard → 42. Typecheck clean; closure-test sweep
+(80 tests across 12 files) green (the `illegal-cast-closures-585` LinkError
+failures are a pre-existing test-harness import gap on `upstream/main`,
+reproduced identically without this change).
+
+**Mutual recursion deferred to a follow-up (not regressed — never worked).**
+`const a = (n)=>b(n-1); const b = (n)=>a(n)` is a distinct *forward-reference*
+defect: when `a` is built, the not-yet-declared peer `b` is force-boxed as an
+externref ref-cell, but `b`'s closure struct is later stored directly, leaving
+two conflicting "box for b" representations → runtime `illegal cast` at the
+*construction* site in the outer function. Fixing it cleanly needs the peer
+bindings hoisted/typed against a shared wrapper supertype before either
+closure is constructed (the architect-level "recursive closure environment
+typing" noted under Fix direction). Tracked as a follow-up; acceptance
+criterion 2 (mutual pair → 0) intentionally left for that issue.

--- a/plan/issues/2185-mutual-recursive-const-arrow-forward-reference-illegal-cast.md
+++ b/plan/issues/2185-mutual-recursive-const-arrow-forward-reference-illegal-cast.md
@@ -1,0 +1,79 @@
+---
+id: 2185
+title: "mutually-recursive const-arrow pair traps with runtime `illegal cast` (forward-reference closure boxing)"
+status: ready
+sprint: Backlog
+created: 2026-06-17
+updated: 2026-06-17
+priority: medium
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: codegen
+language_feature: closures
+goal: compilable
+related: [2118, 897, 1312, 1314, 1178]
+origin: "2026-06-17 — split out of #2118 (self-recursion fixed there); mutual case is a distinct forward-reference defect"
+---
+
+# #2185 — mutual const-arrow recursion: `illegal cast` at construction
+
+## Problem
+
+A pair of mutually-recursive const/let arrows traps at runtime with
+`illegal cast` (the trap is in the *outer* function at closure-construction
+time, not inside either arrow):
+
+```ts
+export function test(): number {
+  const a = (n: number): number => n === 0 ? 0 : b(n - 1);
+  const b = (n: number): number => a(n);
+  return a(3);
+}
+```
+
+Expected `0`. Self-recursion (`const f = (n) => ... f(n-1)`) was fixed in
+#2118; this mutual/forward-reference case was explicitly split out.
+
+## Root cause (analysis from #2118)
+
+`a`'s closure (`__closure_0`) references `b`, which is **declared after** `a`.
+At the moment `a` is constructed, `b`'s outer slot is an uninitialized
+`externref`, and `b` is written-in-outer (TDZ) so the capture is **force-boxed
+as a `__ref_cell_externref`**. The construction prologue for `a` boxes the
+(undefined) `b` and immediately `ref.cast`s it toward a closure-struct type.
+Later, when `const b = (...)` runs, `b`'s closure struct is stored *directly*
+into the `__boxed_b` slot rather than into the externref ref-cell that `a`
+holds — so there are **two conflicting representations of "the box for b"**:
+`a` reads `b` through a `__ref_cell_externref`, but the outer scope wrote a raw
+closure struct. The mismatched `ref.cast` traps `illegal cast`.
+
+(Verified: capture analysis records `b` as `{kind: externref}, mutable=true,
+boxed=false` inside `a`; the outer assignment path overwrites the box with the
+closure struct.)
+
+## Fix direction
+
+The peer bindings in a mutual-recursion cycle must be **hoisted and typed
+against a shared wrapper supertype before either closure is constructed**, so
+that:
+- the ref-cell that `a` captures for `b` and the slot the outer scope writes
+  `b` into are the *same* cell with a *consistent* value type, and
+- call sites cast the captured peer to the shared `__fn_wrap_N` supertype
+  (which every peer closure subtypes), never to a sibling's concrete struct.
+
+This is the architect-level "recursive closure environment typing" noted in
+#2118's Fix direction. Likely touches: capture force-boxing in
+`compileArrowAsClosure`, the variable-init boxing/assignment path in
+`src/codegen/statements/variables.ts`, and `compileClosureCall` cast targets.
+
+## Acceptance criteria
+
+- `const a = (n)=>n===0?0:b(n-1); const b = (n)=>a(n); a(3)` returns `0`
+- Deeper cycles (3+ mutually-recursive arrows) validate and run
+- #2118 self-recursion tests remain green; named-funcexpr fast path unregressed
+
+## Test
+
+Extend `tests/issue-2118.test.ts` (or a new `tests/issue-2185.test.ts`) with
+the mutual pair and a 3-cycle case.

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -1453,6 +1453,30 @@ export function compileArrowAsClosure(
   collectFunctionOwnLocals(arrow, ownLocals);
   if (ts.isFunctionExpression(arrow) && arrow.name) ownLocals.add(arrow.name.text);
 
+  // (#2118) Self-recursive const/let arrow: `const f = (n) => ... f(n-1)`.
+  // The closure references its own binding `f`. Without special handling the
+  // binding is captured as an ordinary variable; but the outer slot for `f` is
+  // typed `externref` (function types resolve to externref) and is still
+  // uninitialized at the moment the closure is constructed, so the capture is
+  // boxed into a `__ref_cell_externref` and the construction path emits an
+  // invalid `ref.cast` between the ref-cell struct and the closure struct
+  // (struct.get type-mismatch validation failure). Detect the self-binding and
+  // route the self-reference through `__self` (lifted param 0) — exactly the
+  // mechanism named function expressions already use — so the recursive call
+  // dispatches through the closure's own struct and the name is NOT captured.
+  let selfBindingName: string | undefined;
+  if (ts.isArrowFunction(arrow) || (ts.isFunctionExpression(arrow) && !arrow.name)) {
+    const declParent = arrow.parent;
+    if (
+      declParent &&
+      ts.isVariableDeclaration(declParent) &&
+      declParent.initializer === arrow &&
+      ts.isIdentifier(declParent.name)
+    ) {
+      selfBindingName = declParent.name.text;
+    }
+  }
+
   const referencedNames = new Set<string>();
   if (ts.isBlock(body)) {
     for (const stmt of body.statements) {
@@ -1595,6 +1619,8 @@ export function compileArrowAsClosure(
     if (isOwnParamName(arrow, name)) continue;
     // Skip if the name is a named function expression's own name (self-reference)
     if (ts.isFunctionExpression(arrow) && arrow.name && arrow.name.text === name) continue;
+    // (#2118) Skip the self-recursive const/let arrow binding — routed via __self.
+    if (selfBindingName !== undefined && name === selfBindingName) continue;
     // #1177: Also fall back to scanning for a `__tdz_<name>` slot when
     // tdzFlagLocals was cleared by block-scope shadow management.
     if (!fctx.tdzFlagLocals?.has(name)) {
@@ -1906,6 +1932,16 @@ export function compileArrowAsClosure(
     liftedFctx.readOnlyBindings.add(funcExprName);
   }
 
+  // (#2118) Self-recursive const/let arrow binding: map the binding name to the
+  // __self param so recursive `f(...)` calls inside the body dispatch through
+  // the closure's own struct via call_ref (mirrors the named-funcexpr path).
+  // The name is NOT registered as read-only — unlike a funcexpr's own name, a
+  // `let f` binding may legitimately be reassigned in the outer scope; inside
+  // the closure body, however, the reference is the recursive self.
+  if (selfBindingName !== undefined && !liftedFctx.localMap.has(selfBindingName)) {
+    liftedFctx.localMap.set(selfBindingName, 0);
+  }
+
   const savedFunc = ctx.currentFunc;
   if (savedFunc) ctx.parentBodiesStack.push(savedFunc.body);
   if (savedFunc) ctx.funcStack.push(savedFunc);
@@ -1921,6 +1957,26 @@ export function compileArrowAsClosure(
   };
   if (funcExprName) {
     ctx.closureMap.set(funcExprName, closureInfoForSelf);
+  }
+
+  // (#2118) Register the self-recursive const/let arrow binding so recursive
+  // calls compile as closure calls dispatched through __self. The struct.get
+  // that fetches the funcref runs against __self's *actual* param type
+  // (selfTypeIdx — the wrapper base struct when capture-subtyping is used, else
+  // the specific struct), not necessarily the concrete subtype, so use
+  // selfTypeIdx as the call-site struct type. Field 0 (funcref) is inherited
+  // from the wrapper base, so the lifted func type still drives call_ref.
+  let savedSelfBindingClosureInfo: ClosureInfo | undefined;
+  let hadSavedSelfBindingClosureInfo = false;
+  if (selfBindingName !== undefined && selfBindingName !== funcExprName) {
+    hadSavedSelfBindingClosureInfo = ctx.closureMap.has(selfBindingName);
+    savedSelfBindingClosureInfo = ctx.closureMap.get(selfBindingName);
+    ctx.closureMap.set(selfBindingName, {
+      structTypeIdx: selfTypeIdx,
+      funcTypeIdx: liftedFuncTypeIdx,
+      returnType: closureReturnType,
+      paramTypes: arrowParams,
+    });
   }
 
   // Emit default-value initialization for simple params with defaults
@@ -2327,6 +2383,17 @@ export function compileArrowAsClosure(
   // Clean up the temporary closure map entry for named function expressions
   if (funcExprName) {
     ctx.closureMap.delete(funcExprName);
+  }
+
+  // (#2118) Restore the outer closureMap entry for the self-recursive binding —
+  // the temporary self entry must not leak into the enclosing scope's view of
+  // the name (where the binding still resolves to the local/global slot).
+  if (selfBindingName !== undefined && selfBindingName !== funcExprName) {
+    if (hadSavedSelfBindingClosureInfo) {
+      ctx.closureMap.set(selfBindingName, savedSelfBindingClosureInfo!);
+    } else {
+      ctx.closureMap.delete(selfBindingName);
+    }
   }
 
   // Ensure return value for non-void functions (skip if concise body already left a value)

--- a/tests/issue-2118.test.ts
+++ b/tests/issue-2118.test.ts
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2118 — Self-recursive const/let arrow closures emitted an invalid module.
+//
+// Repro: `const f = (n) => n <= 1 ? 1 : n * f(n - 1)`.
+//
+// Root cause: `compileArrowAsClosure` (src/codegen/closures.ts) captured the
+// closure's *own* binding (`f`) as an ordinary variable. The outer slot for `f`
+// is typed `externref` (function types resolve to externref) and is still
+// uninitialized at the moment the closure is constructed, so the self-capture
+// was boxed into a `__ref_cell_externref` and the construction path emitted an
+// invalid `ref.cast` between the ref-cell struct and the closure struct —
+// `WebAssembly.Module(): struct.get expected (ref null N) found local.get of
+// (ref null M)` at validation time. Named function expressions already routed
+// self-references through the `__self` lifted param (index 0); arrow bindings
+// did not.
+//
+// Fix: detect that an arrow is the initializer of a `const`/`let` variable
+// declaration whose name the body references (the self-binding), skip capturing
+// that name, and register it against `__self` in the lifted function's localMap
+// + closureMap so recursive calls dispatch through the closure's own struct via
+// call_ref — mirroring the named-funcexpr mechanism.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+interface RunResult {
+  exports: Record<string, Function>;
+}
+
+async function run(src: string): Promise<RunResult> {
+  const result = await compile(src, { fileName: "test.ts" });
+  if (!result.success) {
+    throw new Error(`compile failed:\n${result.errors.map((e) => `  L${e.line}:${e.column} ${e.message}`).join("\n")}`);
+  }
+  // The bug surfaced at module-validation time (struct.get type mismatch).
+  const importResult = buildImports(result.imports as never, undefined, result.stringPool);
+  const inst = await WebAssembly.instantiate(result.binary, importResult as never);
+  if (typeof (importResult as { setExports?: Function }).setExports === "function") {
+    (importResult as { setExports: Function }).setExports(inst.instance.exports);
+  }
+  return { exports: inst.instance.exports as Record<string, Function> };
+}
+
+describe("#2118 self-recursive const/let arrow closures", () => {
+  it("const arrow factorial validates and returns 120", async () => {
+    const { exports } = await run(`
+      export function test(): number {
+        const f = (n: number): number => n <= 1 ? 1 : n * f(n - 1);
+        return f(5);
+      }
+    `);
+    expect(exports.test!()).toBe(120);
+  });
+
+  it("let arrow factorial validates and returns 120", async () => {
+    const { exports } = await run(`
+      export function test(): number {
+        let f = (n: number): number => n <= 1 ? 1 : n * f(n - 1);
+        return f(5);
+      }
+    `);
+    expect(exports.test!()).toBe(120);
+  });
+
+  it("recursive arrow with two self-calls (fib) returns 55", async () => {
+    const { exports } = await run(`
+      export function test(): number {
+        const fib = (n: number): number => n < 2 ? n : fib(n - 1) + fib(n - 2);
+        return fib(10);
+      }
+    `);
+    expect(exports.test!()).toBe(55);
+  });
+
+  it("self-recursive arrow that also captures an outer variable returns 48", async () => {
+    // Exercises the wrapper-subtype path: captures.length > 0 so __self is the
+    // wrapper base struct, distinct from the specific closure subtype.
+    const { exports } = await run(`
+      export function test(): number {
+        const base = 2;
+        const f = (n: number): number => n <= 1 ? base : n * f(n - 1);
+        return f(4);
+      }
+    `);
+    expect(exports.test!()).toBe(48);
+  });
+
+  it("self-recursion inside a nested function returns 10", async () => {
+    const { exports } = await run(`
+      export function outer(): number {
+        const h = (n: number): number => n <= 0 ? 0 : n + h(n - 1);
+        return h(4);
+      }
+      export function test(): number { return outer(); }
+    `);
+    expect(exports.test!()).toBe(10);
+  });
+
+  it("non-recursive const arrow is unaffected (regression guard)", async () => {
+    const { exports } = await run(`
+      export function test(): number {
+        const g = (n: number): number => n * 2;
+        return g(21);
+      }
+    `);
+    expect(exports.test!()).toBe(42);
+  });
+
+  // Mutual recursion between two forward-referenced const arrows
+  // (`const a = (n) => b(...); const b = (n) => a(...)`) is a deeper
+  // forward-reference closure-typing problem tracked separately as a follow-up
+  // to #2118 (the first arrow boxes the not-yet-declared peer as an externref
+  // ref-cell while the peer's closure struct is stored directly, producing
+  // conflicting box representations → runtime `illegal cast`). Self-recursion,
+  // the dominant pattern, is fixed here.
+});


### PR DESCRIPTION
## #2118 — self/mutually-recursive const-arrow closures emit invalid Wasm

`const f = (n) => ... f(n-1)` failed Wasm validation with
`struct.get expected (ref null N) found (ref null M)`.

### Root cause
`compileArrowAsClosure` captured the closure's **own binding** `f` as an
ordinary variable. The outer slot for `f` is `externref` (function types
resolve to externref) and is still uninitialized when the closure is built, so
the self-capture was boxed into a `__ref_cell_externref`; the construction
prologue then `ref.cast`s that ref-cell to the closure struct → validation
failure. Named function expressions already routed self-refs through the
`__self` lifted param; arrow-bound names did not.

### Fix (`src/codegen/closures.ts`)
1. Detect the **self-binding** — the arrow is the `initializer` of a const/let
   `VariableDeclaration` whose identifier name the body references.
2. **Skip capturing** that name (alongside the existing named-funcexpr skip).
3. Register it against `__self` (param 0) in the lifted `localMap` + a temporary
   `closureMap` entry typed with `selfTypeIdx` (the `__self` param's *actual*
   type — wrapper base on the capture-subtype path, else the specific struct),
   so recursive `f(...)` dispatches via `call_ref` through the closure's own
   struct.
4. Save/restore the outer `closureMap` entry so the temporary self entry does
   not leak into the enclosing scope.

The `selfTypeIdx`-not-`structTypeIdx` choice is load-bearing for a recursive
arrow that *also captures another variable* (then `__self` is the wrapper base,
not the concrete subtype).

### Validation
`tests/issue-2118.test.ts` (6 cases): const/let factorial → 120, fib → 55,
self+capture → 48, nested-fn self-recursion → 10, non-recursive regression
guard → 42. Typecheck clean; closure-test sweep (80 tests / 12 files) green
(the `illegal-cast-closures-585` LinkError failures pre-exist on `main` — a
test-harness import gap, reproduced identically without this change).

### Scope
Mutual/forward-reference recursion (`const a=...b...; const b=...a...`) is a
distinct defect (conflicting box representations for the not-yet-declared peer
→ runtime `illegal cast`) — split out as **#2185** and left for a dedicated
fix. It never worked and is **not regressed** by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)