### PR TITLE
feat(#2136): IR loop conditions lower non-i32 conds through ToBoolean

### DIFF
--- a/plan/issues/2136-ir-loop-cond-toboolean.md
+++ b/plan/issues/2136-ir-loop-cond-toboolean.md
@@ -1,10 +1,12 @@
 ---
 id: 2136
 title: "IR loop conditions: lower non-i32 conds through ToBoolean instead of bailing to legacy"
-status: ready
+status: done
+completed: 2026-06-17
+assignee: ttraenkler/dev-resume
 sprint: 63
 created: 2026-06-12
-updated: 2026-06-12
+updated: 2026-06-17
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -41,3 +43,32 @@ claims and runs correctly through IR.
 
 Routine dev work (no Fable needed); sequence after #1980's correctness fix
 lands.
+
+## Resolution (2026-06-17, PR for #2136)
+
+Fixed in `src/ir/from-ast.ts`. New `coerceLoopCondToBool(condValue, cx, kind)`
+helper: an i32 condition passes through; an **f64** condition is coerced to an
+i32 bool via the NaN-safe ToBoolean `abs(x) > 0` (`f64.abs; f64.const 0;
+f64.gt` — `-0`→0, `NaN > 0` is false, matching #1937 and the linear backend's
+`emitTruthyCoercion`); any other type (ref/string) still bails to legacy with
+the same diagnostic (out of #2136's numeric scope). `lowerWhileStatement` and
+`lowerForStatement` now call it **inside** the cond-buffer `collectBodyInstrs`
+closure (so the coercion re-runs each iteration) and use the coerced i32 SSA
+value as `condValue`, replacing the #1980 bail-to-legacy throw. The
+`while.loop`/`for.loop` verifier rule (i32 `condValue`, #1850) is satisfied
+because the coercion yields an i32.
+
+## Test Results
+
+- `tests/issue-2136.test.ts` (new) — 5/5 pass: `while (k)` / `for (;k;)` with an
+  f64 counter run correctly AND record **no** "condition must be bool"
+  post-claim demotion (i.e. they claim through IR); falsy `0` and `NaN`
+  conditions skip the body; an i32-comparison loop still claims unchanged.
+- `tests/issue-1980.test.ts` — 5/5 pass (correctness regression guard).
+- `pnpm run check:ir-fallbacks` — OK; `body-shape-rejected` and post-claim
+  buckets unchanged (no growth).
+- Pre-existing, unrelated failures (confirmed identical on pristine
+  upstream/main): the `ir-*-equivalence` / `i32-loop-inference` suites fail on a
+  minimal-ENV harness gap (`__unbox_number` / `string_constants` imports not
+  supplied); `loop-condition-falsy` / `for-loop-computed-values` import a
+  missing `./helpers.js`. None touched by this change.

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -3073,24 +3073,52 @@ function lowerForOfStatement(stmt: ts.ForOfStatement, cx: LowerCtx): void {
  * the body reassigns as slot-bound, so cross-iteration writes go
  * through `slot.read` / `slot.write` and survive the loop.
  */
+/**
+ * #2136 — coerce a loop condition SSA value to an i32 boolean via ToBoolean.
+ *
+ * The `{while,for}.loop` lowerer emits `<condValue>; i32.eqz; br_if 1`, which
+ * requires an i32 condValue. An f64 (numeric) condition is converted with the
+ * NaN-safe ToBoolean `abs(x) > 0` — `f64.abs` folds `-0` to `0` and `NaN > 0`
+ * is false, so `0`, `-0` and `NaN` are all falsy (matching JS ToBoolean and
+ * the linear backend's `emitTruthyCoercion`, #1937). An i32 value is already a
+ * bool and passes through. Any other value type (ref/string) is out of scope
+ * for this slice and keeps the legacy fallback by throwing the same diagnostic
+ * the loops used before (#1980).
+ *
+ * MUST be called inside the `collectBodyInstrs` closure that builds the cond
+ * buffer so the coercion instructions re-run each iteration.
+ */
+function coerceLoopCondToBool(condValue: IrValueId, cx: LowerCtx, loopKind: "while" | "for"): IrValueId {
+  const kind = asVal(cx.builder.typeOf(condValue))?.kind;
+  if (kind === "i32") return condValue;
+  if (kind === "f64") {
+    // ToBoolean(f64) = abs(x) > 0  (false for 0, -0, NaN; true otherwise).
+    const absV = cx.builder.emitUnary("f64.abs", condValue, irVal({ kind: "f64" }));
+    const zero = cx.builder.emitConst({ kind: "f64", value: 0 }, irVal({ kind: "f64" }));
+    return cx.builder.emitBinary("f64.gt", absV, zero, irVal({ kind: "i32" }));
+  }
+  // ref/string/other — not yet supported; bail to legacy (#2136 scopes numeric).
+  throw new Error(`ir/from-ast: ${loopKind} condition must be bool in ${cx.funcName}`);
+}
+
 function lowerWhileStatement(stmt: ts.WhileStatement, cx: LowerCtx): void {
   // Capture the value id `lowerExpr` returns rather than the cond buffer's
   // last instruction result — the latter is fragile (e.g. a trailing store
   // produces no value). (#1980)
-  let condResult: number | null = null;
+  let condResult: IrValueId | null = null;
   const condInstrs = cx.builder.collectBodyInstrs(() => {
-    condResult = lowerExpr(stmt.expression, cx, irVal({ kind: "i32" }));
+    const raw = lowerExpr(stmt.expression, cx, irVal({ kind: "i32" }));
+    // #2136 — an f64 (numeric-truthiness) condition was previously bailed to
+    // legacy (#1980) because the lowerer's unconditional `i32.eqz` on an f64
+    // emitted invalid Wasm. Instead, coerce it to an i32 bool via ToBoolean
+    // INSIDE the cond buffer (so the coercion re-runs each iteration) and use
+    // the coerced value as `condValue`. Non-numeric, non-bool conditions
+    // (ref/string) still bail — those need a different ToBoolean path (#2136
+    // scopes to numeric).
+    condResult = coerceLoopCondToBool(raw, cx, "while");
   });
   if (condResult === null || condResult === undefined) {
     throw new Error(`ir/from-ast: while cond produced no SSA value (${cx.funcName})`);
-  }
-  // `if`/ternary throw a clean fallback when the condition isn't already an
-  // i32 bool; loops skipped that check and the lowerer's unconditional
-  // `i32.eqz` then emitted invalid Wasm (e.g. a numeric-truthiness `while (k)`
-  // with an f64 `k`). Throw the same fallback so the legacy path handles
-  // ToBoolean lowering until the IR grows its own. (#1980)
-  if (asVal(cx.builder.typeOf(condResult))?.kind !== "i32") {
-    throw new Error(`ir/from-ast: while condition must be bool in ${cx.funcName}`);
   }
   const bodyCx: LowerCtx = { ...cx, scope: new Map(cx.scope) };
   const bodyInstrs = cx.builder.collectBodyInstrs(() => {
@@ -3136,18 +3164,16 @@ function lowerForStatement(stmt: ts.ForStatement, cx: LowerCtx): void {
   // 2. Cond — collect its IR into a buffer.
   // Capture the value id `lowerExpr` returns rather than the buffer's last
   // instruction result (fragile — see #1980).
-  let condResult: number | null = null;
+  let condResult: IrValueId | null = null;
   const condInstrs = innerCx.builder.collectBodyInstrs(() => {
-    condResult = lowerExpr(stmt.condition!, innerCx, irVal({ kind: "i32" }));
+    const raw = lowerExpr(stmt.condition!, innerCx, irVal({ kind: "i32" }));
+    // #2136 — coerce a numeric-truthiness `for` cond (e.g. `for (...; k; ...)`
+    // with f64 `k`) to an i32 bool via ToBoolean inside the cond buffer,
+    // instead of bailing to legacy (#1980). Mirrors the while-loop arm.
+    condResult = coerceLoopCondToBool(raw, innerCx, "for");
   });
   if (condResult === null || condResult === undefined) {
     throw new Error(`ir/from-ast: for cond produced no SSA value (${cx.funcName})`);
-  }
-  // Same i32-bool fallback as `if`/ternary — a numeric-truthiness `for` cond
-  // (e.g. `for (...; k; ...)` with f64 `k`) otherwise reaches the lowerer's
-  // unconditional `i32.eqz` and emits invalid Wasm. (#1980)
-  if (asVal(innerCx.builder.typeOf(condResult))?.kind !== "i32") {
-    throw new Error(`ir/from-ast: for condition must be bool in ${cx.funcName}`);
   }
 
   // 3. Body — collect into a buffer.

--- a/tests/issue-2136.test.ts
+++ b/tests/issue-2136.test.ts
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2136 — numeric-truthiness loop conditions should CLAIM through IR, not demote.
+//
+// #1980 fixed the correctness bug (an f64 `while (k)` cond reached the lowerer's
+// unconditional `i32.eqz` and emitted invalid Wasm) by *bailing to legacy* — it
+// threw "condition must be bool", which left every numeric-truthiness loop
+// permanently in the post-claim fallback bucket. #2136 instead lowers a non-i32
+// loop condition through ToBoolean (`abs(x) > 0`, NaN-safe — matches #1937 and
+// the linear backend's emitTruthyCoercion) inside the cond buffer, so the loop
+// claims and runs correctly on the IR path.
+//
+// These tests assert BOTH that (a) the loop produces the correct value and
+// (b) the compile no longer records a "condition must be bool" post-claim
+// demotion (i.e. the function stayed on the IR path).
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+interface IrResult {
+  value: unknown;
+  loopBailed: boolean;
+}
+
+async function runIr(src: string, arg: number): Promise<IrResult> {
+  const r = (await compile(src, { fileName: "test.ts", experimentalIR: true })) as Awaited<
+    ReturnType<typeof compile>
+  > & { irPostClaimErrors?: { kind: string; func: string; message: string }[] };
+  if (!r.success) {
+    throw new Error(`compile failed:\n${r.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const loopBailed = (r.irPostClaimErrors ?? []).some((e) => /condition must be bool/.test(e.message));
+  const imps = buildImports(r.imports as never, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imps as never);
+  if (typeof (imps as { setExports?: (e: unknown) => void }).setExports === "function") {
+    (imps as { setExports: (e: unknown) => void }).setExports(instance.exports);
+  }
+  return { value: (instance.exports as { f: (n: number) => unknown }).f(arg), loopBailed };
+}
+
+const whileTruthy = `export function f(n: number): number {
+  let s = 0; let k = n;
+  while (k) { s = s + k; k = k - 1; }
+  return s;
+}`;
+
+const forTruthy = `export function f(n: number): number {
+  let s = 0;
+  for (let k = n; k; k = k - 1) { s = s + k; }
+  return s;
+}`;
+
+const whileCmp = `export function f(n: number): number {
+  let s = 0; let k = n;
+  while (k > 0) { s = s + k; k = k - 1; }
+  return s;
+}`;
+
+describe("#2136 numeric-truthiness loops claim through IR", () => {
+  it("while (k) sums n..1 AND stays on the IR path", async () => {
+    const { value, loopBailed } = await runIr(whileTruthy, 4);
+    expect(value).toBe(10); // 4+3+2+1
+    expect(loopBailed).toBe(false);
+  });
+
+  it("while (k) terminates immediately when k is 0 (falsy)", async () => {
+    const { value, loopBailed } = await runIr(whileTruthy, 0);
+    expect(value).toBe(0);
+    expect(loopBailed).toBe(false);
+  });
+
+  it("for (; k; ) sums n..1 AND stays on the IR path", async () => {
+    const { value, loopBailed } = await runIr(forTruthy, 3);
+    expect(value).toBe(6); // 3+2+1
+    expect(loopBailed).toBe(false);
+  });
+
+  it("NaN condition is falsy — loop body never runs", async () => {
+    const src = `export function f(n: number): number {
+      let k = 0 / 0; let s = 7;
+      while (k) { s = s + 1; }
+      return s;
+    }`;
+    const { value, loopBailed } = await runIr(src, 0);
+    expect(value).toBe(7);
+    expect(loopBailed).toBe(false);
+  });
+
+  it("does not regress an i32-comparison while loop (still claims, no coercion needed)", async () => {
+    const { value, loopBailed } = await runIr(whileCmp, 4);
+    expect(value).toBe(10);
+    expect(loopBailed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem (#2136)

#1980 fixed the f64 loop-condition correctness bug (an f64 `while (k)` reached the lowerer's unconditional `i32.eqz` and emitted invalid Wasm) by **bailing to legacy** — throwing `condition must be bool`. That left every numeric-truthiness `while (k)` / `for (;k;)` permanently in the post-claim `body-shape-rejected`/demotion bucket.

## Fix (`src/ir/from-ast.ts`)

New `coerceLoopCondToBool(condValue, cx, kind)`:
- **i32** condition → passes through unchanged.
- **f64** condition → coerced to i32 bool via NaN-safe ToBoolean `abs(x) > 0` (`f64.abs; f64.const 0; f64.gt` — folds `-0`→0, `NaN > 0` is false; matches #1937 and the linear backend's `emitTruthyCoercion`).
- **ref/string** → still bails to legacy (out of #2136's numeric scope).

`lowerWhileStatement` / `lowerForStatement` call it **inside** the cond-buffer `collectBodyInstrs` closure (so the coercion re-runs each iteration) and use the coerced i32 SSA value as `condValue`, replacing the #1980 throw. The `while.loop`/`for.loop` verifier rule (i32 `condValue`, #1850) is satisfied since the coercion yields i32.

## Acceptance criteria

- `while (k)` with `k: number` claims through IR and runs correctly — done (asserted via no "condition must be bool" post-claim demotion).
- `body-shape-rejected` bucket does not grow — `check:ir-fallbacks` clean.

## Tests

- `tests/issue-2136.test.ts` (new) — 5/5: f64 `while`/`for` run correctly AND stay on the IR path (no demotion); falsy `0`/`NaN` skip the body; i32-comparison loop still claims.
- `tests/issue-1980.test.ts` — 5/5 (correctness regression guard).
- `pnpm run check:ir-fallbacks` — OK, no bucket growth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)