### PR TITLE
fix(#2023): new.target identity comparisons through super chains

### DIFF
--- a/plan/issues/2023-new-target-constant-one.md
+++ b/plan/issues/2023-new-target-constant-one.md
@@ -1,10 +1,12 @@
 ---
 id: 2023
 title: "new.target compiles to constant i32 1 — identity comparisons (new.target === A) always wrong"
-status: ready
+status: done
+completed: 2026-06-17
+assignee: sendev-recur
 sprint: 63
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-17
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -51,3 +53,48 @@ should yield undefined.
 
 #189 done (introduced the stub); #538 older. Wrong-value semantics not
 filed; nearest live anchor #1366. New.
+
+## Implementation notes (#2023, sendev-recur, 2026-06-17)
+
+**Root cause (confirmed).** `new.target` lowered to `i32.const 1` inside any
+constructor (the #189 truthiness stub). The same class body is compiled *once*
+and reused both for `new C()` and for the `super()` path of a subclass, so the
+value genuinely varies at runtime — there is no per-constructor constant. A
+purely static fold cannot express this; a runtime carry is required.
+
+**Design — compile-away runtime carry (no host import, no signature churn).**
+A single mutable i32 module global `__new_target_classid` holds the class-id of
+the class named at the *outermost* `new` site:
+- each local class gets a stable 1-based i32 id (`classNewTargetIds`);
+- `new C(...)` sites (legacy `compileNewExpression`, struct path) save the
+  previous global into a temp, set it to `C`'s id *after* args are on the stack
+  but *before* the `_new` call, then restore the saved value after the call —
+  so a nested `new` inside a ctor body nests correctly;
+- `super(...)` lowers to a direct `_init` call and deliberately never touches
+  the global, so the derived-most id survives the whole super chain;
+- the `new.target` expression inside a ctor reads the global (i32, non-zero ⇒
+  truthiness uses unchanged); `new.target === SomeClass` lowers in
+  `compileBinaryExpression` to an i32 compare against the class id *before*
+  operands compile (a bare class identifier does not lower to a value).
+
+**Gated on `usesNewTarget`** (a cheap one-shot AST pre-scan in `generateModule`/
+`generateMultiModule`). When false — the overwhelming common case — none of the
+machinery is emitted and class call sites are byte-for-byte unchanged.
+
+**IR interaction.** The IR `new`-expression lowering does not thread the id, so
+when `usesNewTarget` is set, the IR function selection is emptied and every
+function compiles via legacy (which carries the threading). new.target is rare,
+so the throughput cost is negligible; this avoids a parallel IR implementation.
+
+**Files:** `src/codegen/new-target.ts` (new — scan, id registry, global,
+emitters), `src/codegen/expressions.ts` (read in ctor), `src/codegen/
+binary-ops.ts` (`new.target === Class` compare), `src/codegen/expressions/
+new-super.ts` (save/set/restore at new sites), `src/codegen/class-bodies.ts`
+(id assignment), `src/codegen/index.ts` (pre-scan + IR gate), `src/codegen/
+registry/imports.ts` (global-index fixup), context type + create-context.
+
+**Tests:** `tests/issue-2023.test.ts` — identity through 3-level super chains,
+truthiness, nested `new` in a ctor body (restore correctness), outside-ctor
+falsy, named-funcexpr self-recursion control unregressed.
+
+**Not in scope:** mutual/self-recursive const-arrow closures (#2118, separate).

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -33,6 +33,7 @@ import {
 import { ensureExternIsUndefinedImport, ensureLateImport } from "./expressions/late-imports.js";
 import { ensureFmod } from "./fmod.js";
 import { ensureNativeStringHelpers } from "./native-strings.js";
+import { emitNewTargetClassId, getOrAssignClassNewTargetId } from "./new-target.js"; // (#2023)
 import { compileLogicalAnd, compileLogicalOr, compileNullishCoalescing } from "./expressions/logical-ops.js";
 import { tryStaticToNumber } from "./expressions/misc.js";
 import { emitNativeParseNumber } from "./parse-number-native.js";
@@ -339,6 +340,20 @@ export function compileBinaryExpression(
   ) {
     const typeofResult = compileTypeofComparison(ctx, fctx, expr);
     if (typeofResult !== null) return typeofResult;
+  }
+
+  // (#2023) `new.target === SomeClass` / `new.target !== SomeClass` (either
+  // operand order). `new.target` is the class-id of the outermost `new` site;
+  // compare it against the named class's stable id. Must run before the operands
+  // are compiled (a bare class identifier `SomeClass` does not lower to a value).
+  if (
+    op === ts.SyntaxKind.EqualsEqualsEqualsToken ||
+    op === ts.SyntaxKind.EqualsEqualsToken ||
+    op === ts.SyntaxKind.ExclamationEqualsEqualsToken ||
+    op === ts.SyntaxKind.ExclamationEqualsToken
+  ) {
+    const ntResult = compileNewTargetClassComparison(ctx, fctx, expr, op);
+    if (ntResult !== null) return ntResult;
   }
 
   // Null comparison shortcut: x === null, x !== null, null === x, null !== x
@@ -3572,4 +3587,62 @@ function compileBooleanBinaryOp(ctx: CodegenContext, fctx: FunctionContext, op: 
     default:
       return { kind: "i32" };
   }
+}
+
+/**
+ * (#2023) `new.target === SomeClass` / `!==` (either operand order). Returns an
+ * i32 (0/1) when one operand is the `new.target` meta-property and the other is
+ * an identifier naming a local class; otherwise null (let the generic path run).
+ *
+ * Inside a constructor, `new.target` is the class-id of the outermost `new`
+ * site, so the comparison reduces to `globalNewTargetId (==|!=) classId`.
+ * Outside a constructor `new.target` is `undefined`, so it never equals a class:
+ * `===` folds to const 0, `!==` to const 1 (operands have no side effects — a
+ * bare identifier and a meta-property).
+ */
+function compileNewTargetClassComparison(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.BinaryExpression,
+  op: ts.SyntaxKind,
+): InnerResult | null {
+  const unwrap = (e: ts.Expression): ts.Expression => {
+    let cur = e;
+    while (ts.isParenthesizedExpression(cur) || ts.isAsExpression(cur) || ts.isNonNullExpression(cur)) {
+      cur = cur.expression;
+    }
+    return cur;
+  };
+  const isNewTarget = (e: ts.Expression): boolean =>
+    ts.isMetaProperty(e) && e.keywordToken === ts.SyntaxKind.NewKeyword && e.name.text === "target";
+
+  const left = unwrap(expr.left);
+  const right = unwrap(expr.right);
+  let classIdent: ts.Expression | undefined;
+  if (isNewTarget(left) && !isNewTarget(right)) classIdent = right;
+  else if (isNewTarget(right) && !isNewTarget(left)) classIdent = left;
+  else return null;
+
+  if (!ts.isIdentifier(classIdent)) return null;
+  // Resolve to a concrete local class name (handle class-expression aliasing).
+  let className: string | undefined = classIdent.text;
+  if (!ctx.classSet.has(className)) {
+    const mapped = ctx.classExprNameMap.get(className);
+    className = mapped && ctx.classSet.has(mapped) ? mapped : undefined;
+  }
+  if (!className) return null;
+
+  const isNeq = op === ts.SyntaxKind.ExclamationEqualsEqualsToken || op === ts.SyntaxKind.ExclamationEqualsToken;
+
+  // Outside a constructor, new.target is undefined — never a class.
+  if (!fctx.isConstructor || !ctx.usesNewTarget) {
+    fctx.body.push({ op: "i32.const", value: isNeq ? 1 : 0 });
+    return { kind: "i32" };
+  }
+
+  const classId = getOrAssignClassNewTargetId(ctx, className);
+  emitNewTargetClassId(ctx, fctx.body);
+  fctx.body.push({ op: "i32.const", value: classId });
+  fctx.body.push({ op: isNeq ? "i32.ne" : "i32.eq" });
+  return { kind: "i32" };
 }

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -9,6 +9,7 @@ import { isVoidType, unwrapPromiseType } from "../checker/type-mapper.js";
 import type { FieldDef, Instr, StructTypeDef, ValType } from "../ir/types.js";
 import { isHostConstructibleBuiltin } from "./builtin-tags.js";
 import { classMemberFuncKey } from "./class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
+import { getOrAssignClassNewTargetId } from "./new-target.js"; // (#2023)
 import { popBody, pushBody } from "./context/bodies.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal, deduplicateLocals } from "./context/locals.js";
@@ -443,6 +444,13 @@ export function collectClassDeclaration(
   const className = syntheticName ?? decl.name!.text;
   ctx.classSet.add(className);
   ctx.classDeclarationMap.set(className, decl);
+
+  // (#2023) Assign a stable new.target class-id so `new C()` sites and
+  // `new.target === C` comparisons agree on the id. Only when the program uses
+  // new.target at all (otherwise no machinery is emitted).
+  if (ctx.usesNewTarget) {
+    getOrAssignClassNewTargetId(ctx, className);
+  }
 
   // Register the class .name value for ES-spec compliance
   // Named class expressions keep their declared name (class X {} → name = "X")

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -74,6 +74,9 @@ export function createCodegenContext(
     capturedGlobals: new Map(),
     capturedGlobalsWidened: new Set(),
     classSet: new Set(),
+    usesNewTarget: false, // (#2023) set by the pre-scan in generateModule
+    newTargetGlobalIdx: undefined, // (#2023)
+    classNewTargetIds: new Map(), // (#2023) className → stable 1-based i32 id
     classThrowsOnEval: new Set(),
     topLevelFunctionNames: new Set(), // (#1983) for class-member funcMap key collision detection
     classMethodSet: new Set(),

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -634,6 +634,20 @@ export interface CodegenContext {
   capturedGlobalsWidened: Set<string>;
   /** Set of class names (local classes compiled to Wasm GC structs) */
   classSet: Set<string>;
+  /**
+   * (#2023) `new.target` support. When the program references `new.target`
+   * anywhere, a single mutable i32 module global holds the class-id of the
+   * class named at the *outermost* `new` site (set/restored around each `new`
+   * call; `super()` deliberately leaves it untouched so it reflects the
+   * derived-most constructor). `classNewTargetIds` assigns each local class a
+   * stable 1-based i32 id so `new.target === SomeClass` lowers to an i32
+   * compare against this global. `newTargetGlobalIdx` is the global's index
+   * (undefined until allocated). Gated on `usesNewTarget` so programs without
+   * `new.target` emit none of this machinery.
+   */
+  usesNewTarget: boolean;
+  newTargetGlobalIdx: number | undefined;
+  classNewTargetIds: Map<string, number>;
   /** Classes that must throw TypeError at evaluation time */
   classThrowsOnEval: Set<string>;
   /**

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -53,6 +53,7 @@ import { compilePostfixUnary, compilePrefixUnary } from "./expressions/unary.js"
 import { compileCallExpression } from "./expressions/calls.js";
 
 import { compileClassExpression, compileNewExpression } from "./expressions/new-super.js";
+import { emitNewTargetClassId } from "./new-target.js"; // (#2023)
 
 import { compileConditionalExpression, compileYieldExpression } from "./expressions/misc.js";
 
@@ -1242,6 +1243,15 @@ function compileExpressionInner(
 
   if (ts.isMetaProperty(expr) && expr.keywordToken === ts.SyntaxKind.NewKeyword && expr.name.text === "target") {
     if (fctx.isConstructor) {
+      // (#2023) Read the live new.target class-id (set at the outermost `new`
+      // site, preserved through super()). Non-zero inside a construction, so
+      // truthiness uses (`if (new.target)`) stay correct; identity comparisons
+      // (`new.target === SomeClass`) are handled in compileBinaryExpression and
+      // never reach here.
+      if (ctx.usesNewTarget) {
+        emitNewTargetClassId(ctx, fctx.body);
+        return { kind: "i32" };
+      }
       fctx.body.push({ op: "i32.const", value: 1 });
       return { kind: "i32" };
     } else {

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -25,6 +25,7 @@ import {
   resolveWasmType,
 } from "../index.js";
 import { ensureMapHelpers } from "../map-runtime.js";
+import { emitSetNewTargetBeforeCall, ensureNewTargetGlobal } from "../new-target.js"; // (#2023)
 import { ensureObjectRuntime } from "../object-runtime.js"; // (#1100) standalone Proxy native runtime
 import { ensureSetHelpers } from "../set-runtime.js";
 import { ensureWeakCollectionHelpers } from "../weak-collections-runtime.js";
@@ -3132,6 +3133,17 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
     const ctorRestInfo = ctx.funcRestParams.get(ctorName);
     let ctorActualArgCount = args.length;
 
+    // (#2023) Save the current new.target class-id before evaluating args, so a
+    // nested `new` inside an argument expression — and after this construction
+    // returns — sees the correct (outer) target. Restored after the call.
+    let ntPrevLocal: number | undefined;
+    if (ctx.usesNewTarget && !ctx.classExternrefBackedSet.has(className)) {
+      const ntGlobalIdx = ensureNewTargetGlobal(ctx);
+      ntPrevLocal = allocTempLocal(fctx, { kind: "i32" });
+      fctx.body.push({ op: "global.get", index: ntGlobalIdx } as Instr);
+      fctx.body.push({ op: "local.set", index: ntPrevLocal });
+    }
+
     // Check for spread arguments
     const hasSpreadCtorArg = args.some((a) => ts.isSpreadElement(a));
     if (hasSpreadCtorArg && paramTypes) {
@@ -3190,6 +3202,12 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       }
     }
 
+    // (#2023) With args on the stack, set new.target to THIS class's id right
+    // before the call. The ctor body (and the super() chain it drives, which
+    // calls `_init` and never touches the global) reads this id.
+    if (ntPrevLocal !== undefined) {
+      emitSetNewTargetBeforeCall(ctx, fctx.body, className);
+    }
     // Re-lookup funcIdx: argument compilation may trigger addUnionImports
     // which shifts defined-function indices, making the earlier lookup stale.
     const finalCtorIdx = ctx.funcMap.get(classMemberFuncKey(ctx, ctorName)) ?? funcIdx; // (#1983)
@@ -3201,6 +3219,18 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       return { kind: "externref" };
     }
     const structTypeIdx = ctx.structMap.get(className)!;
+    // (#2023) Restore the saved new.target id, preserving the instance on the
+    // stack across the global write.
+    if (ntPrevLocal !== undefined) {
+      const ntGlobalIdx = ensureNewTargetGlobal(ctx);
+      const resultLocal = allocTempLocal(fctx, { kind: "ref", typeIdx: structTypeIdx });
+      fctx.body.push({ op: "local.set", index: resultLocal });
+      fctx.body.push({ op: "local.get", index: ntPrevLocal });
+      fctx.body.push({ op: "global.set", index: ntGlobalIdx } as Instr);
+      fctx.body.push({ op: "local.get", index: resultLocal });
+      releaseTempLocal(fctx, resultLocal);
+      releaseTempLocal(fctx, ntPrevLocal);
+    }
     return { kind: "ref", typeIdx: structTypeIdx };
   }
 

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1347,6 +1347,16 @@ export function generateModule(
         funcs: new Set<string>([...selection.funcs].filter((n) => overrideMap.has(n))),
         classMembers: selection.classMembers,
       };
+      // (#2023) The IR `new C(...)` lowering does not thread the new.target
+      // class-id (that machinery lives only on the legacy path). When the
+      // program uses `new.target`, route every function through legacy so the
+      // outermost-`new` global is set/restored at each construction site. This
+      // is a coarse but safe gate — `new.target` is rare, so the perf cost is
+      // negligible and it avoids a parallel IR implementation of the threading.
+      if (ctx.usesNewTarget) {
+        safeSelection.funcs.clear();
+        safeSelection.classMembers = new Set();
+      }
       const report = compileIrPathFunctions(ctx, ast.sourceFile, safeSelection, overrideMap, classShapes);
       // Slice 12 (#1169o) — most IR-path failures are NOT compile errors. The
       // legacy path has already produced a working `body` for every function

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -38,6 +38,7 @@ import type {
 import type { NodeBuiltinImport } from "../import-resolver.js";
 import { eliminateDeadImports } from "./dead-elimination.js";
 import { ensureMapRuntimeTypes } from "./map-runtime.js";
+import { scanForNewTarget } from "./new-target.js"; // (#2023)
 import { ensureNativeIteratorRuntime, fillNativeIteratorUserArms } from "./iterator-native.js";
 import { fillClosedMethodDispatch } from "./closed-method-dispatch.js";
 import { emitUndefined, reconcileNativeStrFinalizeShift } from "./expressions/late-imports.js";
@@ -1176,6 +1177,11 @@ export function generateModule(
     if (sourceOverridesArrayIterator(ast.sourceFile)) {
       ctx.arrayIteratorMaybeOverridden = true;
     }
+
+    // (#2023) Detect any `new.target` use up front so class collection assigns
+    // class-ids and `new`/comparison sites emit the threading global. Off by
+    // default — programs without `new.target` are byte-identical.
+    scanForNewTarget(ctx, ast.sourceFile);
 
     collectDeclarations(ctx, ast.sourceFile);
 
@@ -5113,6 +5119,11 @@ export function generateMultiModule(
     }
 
     // Phase 2: Collect all declarations — only entry file gets Wasm exports
+    // (#2023) Whole-realm new.target detection — OR across all source files.
+    for (const sf of multiAst.sourceFiles) {
+      scanForNewTarget(ctx, sf);
+    }
+
     for (const sf of multiAst.sourceFiles) {
       const isEntry = sf === multiAst.entryFile;
       collectDeclarations(ctx, sf, isEntry);

--- a/src/codegen/new-target.ts
+++ b/src/codegen/new-target.ts
@@ -1,0 +1,97 @@
+// (#2023) `new.target` support.
+//
+// `new.target` is the constructor that `new` was invoked on. Inside a derived
+// chain it stays the *outermost* (derived-most) class, because `super()` does
+// not start a fresh construction — it continues the same one. The compiler
+// emits a class body **once** and reuses it both for `new C()` and for the
+// `super()` path of a subclass, so the value genuinely varies at runtime and
+// cannot be folded to a per-constructor constant (the #189 `i32.const 1` stub
+// did exactly that, which is the bug this fixes).
+//
+// Strategy — a single mutable i32 module global holds the class-id of the class
+// named at the outermost `new` site:
+//   * each local class gets a stable 1-based i32 id (`classNewTargetIds`);
+//   * `new C(...)` sites save the previous global, set it to C's id right
+//     before the `_new` call (args already on the stack), and restore it after
+//     the call returns (so nested `new` inside a ctor body nests correctly);
+//   * `super(...)` calls `_init` directly and deliberately does NOT touch the
+//     global, so the derived-most id is preserved through the super chain;
+//   * `new.target` inside a ctor reads the global; `new.target === SomeClass`
+//     lowers to an i32 compare against that class's id.
+//
+// All of this is gated on `ctx.usesNewTarget` (a cheap AST pre-scan), so a
+// program that never mentions `new.target` emits none of the machinery and the
+// class call sites are byte-for-byte unchanged.
+
+import { ts, forEachChild } from "../ts-api.js";
+import type { CodegenContext } from "./context/types.js";
+import type { Instr } from "../ir/types.js";
+
+/**
+ * Pre-scan the source for any `new.target` meta-property. Sets
+ * `ctx.usesNewTarget`. Cheap structural walk; runs once before body compilation.
+ */
+export function scanForNewTarget(ctx: CodegenContext, root: ts.Node): void {
+  const visit = (node: ts.Node): void => {
+    if (ctx.usesNewTarget) return;
+    if (ts.isMetaProperty(node) && node.keywordToken === ts.SyntaxKind.NewKeyword && node.name.text === "target") {
+      ctx.usesNewTarget = true;
+      return;
+    }
+    forEachChild(node, visit);
+  };
+  visit(root);
+}
+
+/**
+ * Assign (or look up) the stable 1-based class-id for a local class. Ids start
+ * at 1 so the global's `0` initial value never matches a real class — which
+ * keeps `new.target === SomeClass` false when read outside any construction.
+ */
+export function getOrAssignClassNewTargetId(ctx: CodegenContext, className: string): number {
+  let id = ctx.classNewTargetIds.get(className);
+  if (id === undefined) {
+    id = ctx.classNewTargetIds.size + 1;
+    ctx.classNewTargetIds.set(className, id);
+  }
+  return id;
+}
+
+/**
+ * Allocate the mutable i32 `new.target` class-id global if not already present.
+ * Returns its absolute Wasm global index. Only call when `ctx.usesNewTarget`.
+ */
+export function ensureNewTargetGlobal(ctx: CodegenContext): number {
+  if (ctx.newTargetGlobalIdx !== undefined) return ctx.newTargetGlobalIdx;
+  const absIdx = ctx.numImportGlobals + ctx.mod.globals.length;
+  ctx.mod.globals.push({
+    name: "__new_target_classid",
+    type: { kind: "i32" },
+    mutable: true,
+    init: [{ op: "i32.const", value: 0 }],
+  });
+  ctx.newTargetGlobalIdx = absIdx;
+  return absIdx;
+}
+
+/**
+ * Emit the load of the current `new.target` class-id (an i32). Only meaningful
+ * inside a constructor.
+ */
+export function emitNewTargetClassId(ctx: CodegenContext, body: Instr[]): void {
+  const idx = ensureNewTargetGlobal(ctx);
+  body.push({ op: "global.get", index: idx } as Instr);
+}
+
+/**
+ * Emit `i32.const <classId>; global.set __new_target_classid`. Call this right
+ * before pushing the constructor `call` instruction (args already on the
+ * stack). No-op when `new.target` is unused.
+ */
+export function emitSetNewTargetBeforeCall(ctx: CodegenContext, body: Instr[], className: string): void {
+  if (!ctx.usesNewTarget) return;
+  const globalIdx = ensureNewTargetGlobal(ctx);
+  const classId = getOrAssignClassNewTargetId(ctx, className);
+  body.push({ op: "i32.const", value: classId });
+  body.push({ op: "global.set", index: globalIdx } as Instr);
+}

--- a/src/codegen/registry/imports.ts
+++ b/src/codegen/registry/imports.ts
@@ -159,6 +159,12 @@ function fixupModuleGlobalIndices(ctx: CodegenContext, threshold: number, delta:
   // in a saved body via a manual swap pattern). Without per-call dedup, each
   // additional reachability path applies an extra +delta, over-shifting the
   // index past the declared global range (#1302 — lodash flow.js).
+  // (#2023) Keep the cached new.target global index in step with the shift, so
+  // call sites compiled after a later string-constant import still target it.
+  if (ctx.newTargetGlobalIdx !== undefined && ctx.newTargetGlobalIdx >= threshold) {
+    ctx.newTargetGlobalIdx += delta;
+  }
+
   const visitedInstrs = new WeakSet<object>();
   const visitedArrays = new WeakSet<Instr[]>();
   function shiftGlobalIndices(instrs: Instr[]): void {

--- a/tests/issue-2023.test.ts
+++ b/tests/issue-2023.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { compileAndInstantiate } from "../src/runtime-instantiate.js";
+
+// (#2023) `new.target` used to lower to a constant `i32.const 1` truthiness
+// stub, so identity comparisons (`new.target === SomeClass`) were always wrong
+// — `new A()` and `new B() extends A` both reported the same target.
+//
+// The fix threads a class-id through a module global set at the outermost `new`
+// site (and preserved across `super()`), so `new.target === Class` is an honest
+// runtime identity check while truthiness uses stay correct.
+
+async function run<T = unknown>(src: string, fn: string, args: unknown[] = []): Promise<T> {
+  const exports = (await compileAndInstantiate(src)) as Record<string, (...a: unknown[]) => T>;
+  return exports[fn]!(...args);
+}
+
+describe("#2023 new.target identity", () => {
+  it("new.target === DirectClass is true; via subclass super() is false", async () => {
+    const src = `
+      class A {
+        tag: number;
+        constructor() { this.tag = (new.target === A) ? 1 : 2; }
+        getTag(): number { return this.tag; }
+      }
+      class B extends A {}
+      export function ta(): number { return new A().getTag(); }
+      export function tb(): number { return new B().getTag(); }
+    `;
+    expect(await run<number>(src, "ta")).toBe(1);
+    expect(await run<number>(src, "tb")).toBe(2);
+  });
+
+  it("matches Node through the super chain (string repro from the issue)", async () => {
+    const src = `
+      class A {
+        tag: string;
+        constructor() { this.tag = new.target === A ? "direct" : "sub"; }
+      }
+      class B extends A {}
+      export function r(): string { return new A().tag + "|" + new B().tag; }
+    `;
+    expect(await run<string>(src, "r")).toBe("direct|sub");
+  });
+
+  it("resolves the derived-most class three levels deep", async () => {
+    const src = `
+      class A {
+        id: number;
+        constructor() { this.id = (new.target === A) ? 1 : (new.target === B ? 2 : 3); }
+        get(): number { return this.id; }
+      }
+      class B extends A {}
+      class C extends B {}
+      export function a(): number { return new A().get(); }
+      export function b(): number { return new B().get(); }
+      export function c(): number { return new C().get(); }
+    `;
+    expect(await run<number>(src, "a")).toBe(1);
+    expect(await run<number>(src, "b")).toBe(2);
+    expect(await run<number>(src, "c")).toBe(3);
+  });
+
+  it("keeps new.target truthy inside a constructor", async () => {
+    const src = `
+      class A {
+        v: number;
+        constructor() { this.v = new.target ? 10 : 20; }
+        get(): number { return this.v; }
+      }
+      export function t(): number { return new A().get(); }
+    `;
+    expect(await run<number>(src, "t")).toBe(10);
+  });
+
+  it("restores the outer new.target after a nested `new` in a ctor body", async () => {
+    const src = `
+      class Inner {
+        tag: number;
+        constructor() { this.tag = (new.target === Inner) ? 1 : 9; }
+        g(): number { return this.tag; }
+      }
+      class Outer {
+        r: number;
+        constructor() {
+          const i = new Inner();
+          this.r = (new.target === Outer ? 100 : 0) + i.g();
+        }
+        g(): number { return this.r; }
+      }
+      export function o(): number { return new Outer().g(); }
+    `;
+    // Inner sees Inner (1); Outer's new.target is correctly restored after the
+    // nested construction (100), so the result is 101.
+    expect(await run<number>(src, "o")).toBe(101);
+  });
+
+  it("new.target is falsy when read outside a constructor", async () => {
+    const src = `
+      function g(): number { return new.target ? 1 : 0; }
+      export function h(): number { return g(); }
+    `;
+    expect(await run<number>(src, "h")).toBe(0);
+  });
+
+  it("does not regress the named-function-expression self-recursion control", async () => {
+    const src = `
+      export function f(): number {
+        const fact = function fact(n: number): number { return n <= 1 ? 1 : n * fact(n - 1); };
+        return fact(5);
+      }
+    `;
+    expect(await run<number>(src, "f")).toBe(120);
+  });
+});


### PR DESCRIPTION
## #2023 — new.target was a truthiness stub

`new.target` lowered to a constant `i32.const 1` inside any constructor (the
#189 stub), so identity comparisons were always wrong:

```ts
class A { tag: string; constructor() { this.tag = new.target === A ? "direct" : "sub"; } }
class B extends A {}
new A().tag + "|" + new B().tag
// before: "sub|sub"   node: "direct|sub"   after: "direct|sub" ✓
```

## Fix

A single mutable i32 module global (`__new_target_classid`) holds the class-id
of the class named at the *outermost* `new` site:

- each local class gets a stable 1-based i32 id;
- `new C(...)` sites save/set/restore the global around the `_new` call (so
  nested `new` inside a ctor body nests correctly);
- `super(...)` calls `_init` directly and never touches the global, so the
  derived-most id survives the whole super chain;
- `new.target` inside a ctor reads the global (non-zero ⇒ truthiness uses
  unchanged); `new.target === SomeClass` lowers to an i32 compare.

All gated on a cheap `new.target` AST pre-scan — programs that don't use
`new.target` are byte-for-byte unchanged. The IR `new`-lowering doesn't thread
the id, so `new.target` programs route through legacy (rare → negligible cost).

## Tests

`tests/issue-2023.test.ts`: identity through 3-level super chains, truthiness,
nested `new` restore correctness, outside-ctor falsy, named-funcexpr control.

Closes #2023.

🤖 Generated with [Claude Code](https://claude.com/claude-code)