### PR TITLE
fix(#2179): post-delete struct read consults the tombstone (JS-host)

### DIFF
--- a/plan/issues/2179-delete-post-read-struct-fastpath-tombstone.md
+++ b/plan/issues/2179-delete-post-read-struct-fastpath-tombstone.md
@@ -1,10 +1,12 @@
 ---
 id: 2179
 title: "post-delete struct READ returns stale value — inline struct.get fast-path bypasses the runtime tombstone"
-status: ready
+status: done
+completed: 2026-06-17
+assignee: sendev-closures
 sprint: 63
 created: 2026-06-16
-updated: 2026-06-16
+updated: 2026-06-17
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -105,3 +107,53 @@ Split from #2130 (Stage A `in`/hasOwnProperty fix is `done`). This is the
 codegen + representation-steering remainder. Coordinate the `moduleUsesDelete`
 pre-scan with any other delete-aware lowering. See #2130's `## Resolution`
 note and the architect addenda A6/A7 in #2130's Implementation Plan.
+
+## Resolution (2026-06-17 — A6 JS-host landed; A7 standalone split out)
+
+**A6 (JS-host) — implemented.** All JS-host read-path acceptance criteria pass.
+
+- **`moduleUsesDelete` pre-scan** (`src/codegen/index.ts` `sourceContainsDelete`,
+  set on `ctx.moduleUsesDelete`): true only when the module contains
+  `delete <PropertyAccess|ElementAccess>`. Delete-free modules keep the
+  byte-identical inline `ref.test`+`struct.get` fast-path (verified: a
+  delete-free `any` read still emits `struct.get`/`ref.test`); zero overhead.
+- **Read routing** (`src/codegen/property-access.ts` `tryEmitDeleteAwareDynamicGet`,
+  called at the top of `compilePropertyAccess`): when `moduleUsesDelete &&
+  !standalone` and the receiver is `any`/`unknown`, the read is lowered to
+  `__extern_get(obj, "prop") -> externref` instead of the inline struct.get
+  fast-path. Returning `externref` is load-bearing: a tombstoned key reads real
+  `undefined` (so `o.a === undefined` is no longer constant-folded — the prior
+  fold fired because the f64-typed field can never be undefined). Tightly
+  scoped: skips reserved accessors (`length`/`constructor`/`__proto__`/
+  `prototype`/`name`) and method/function-typed accesses, and never fires for
+  concrete (non-`any`) struct/class receivers.
+- **Runtime tombstone gates** (`src/runtime.ts`): the two `__extern_get`
+  bindings (the by-name `if (name === "__extern_get")` and the `case
+  "extern_get"` switch arm) each consulted the `__sget_<key>` struct-field
+  getter fallback **without** checking the tombstone, resurrecting the deleted
+  field even though `_safeGet` had already returned `undefined`. Added a
+  `_wasmStructDeletedKeys` check before the `__sget_<key>` fallback in both.
+  Also added the tombstone filter to `__object_keys`/`__object_values`/
+  `__object_entries` (the #2130 A4 enumeration gap) so `Object.keys(o)` /
+  `for..in` omit the deleted key.
+
+Acceptance criteria met (JS-host): `delete o.a; o.a` → `undefined`;
+`o.a === undefined` → `true`; `delete o.a; o.a = 5; o.a` → `5` and `"a" in o` →
+`true`; `Object.keys` / `for..in` omit the deleted key; delete-free modules emit
+byte-identical wasm (fast-path retained). Sibling reads, typed (non-`any`)
+receivers, and method dispatch on an `any` receiver in a delete-using module are
+unregressed. Tests: `tests/issue-2179.test.ts` (10 cases). Existing delete/keys
+suites green (42 tests across 6 files: `issue-2130-delete-in-presence`,
+`issue-1821-delete-struct-fastpath`, `issue-1364b-class-method-delete`,
+`issue-2131`, `issue-786-object-keys-dynamic`, `object-keys-values-entries`).
+Typecheck clean.
+
+**A7 (standalone) — split to follow-up #2186.** `__extern_get` is a JS host
+import, unavailable under `--target standalone`. The architect's answer
+(addendum A7) is **representation steering**: lower delete-touched object
+literals to the dynamic `$Object` representation (which already has spec-correct
+`FLAG_TOMBSTONE` tombstones + proto-walk `in` + insertion-order enumeration),
+NOT a wasm-side `(obj,key)` tombstone registry (WasmGC has no weak refs → would
+strongly retain every deleted-from object). This change gates on `!ctx.standalone`
+so standalone is unaffected (still compiles; keeps prior behavior). Tracked as
+#2186.

--- a/plan/issues/2186-standalone-delete-touched-object-representation-steering.md
+++ b/plan/issues/2186-standalone-delete-touched-object-representation-steering.md
@@ -1,0 +1,73 @@
+---
+id: 2186
+title: "standalone: post-delete struct read returns stale value — steer delete-touched object literals to $Object"
+status: ready
+sprint: Backlog
+created: 2026-06-17
+updated: 2026-06-17
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: object-literals
+goal: property-model
+related: [2179, 2130]
+origin: "2026-06-17 — A7 standalone half split out of #2179 (A6 JS-host landed)"
+---
+
+# #2186 — standalone post-delete read: $Object representation steering
+
+## Problem
+
+`#2179` fixed the post-delete struct READ for `any` receivers in **JS-host**
+mode by routing reads through the tombstone-aware `__extern_get` host helper.
+That helper is a JS host import and is unavailable under `--target standalone` /
+WASI, so the fix is gated `!ctx.standalone` and standalone still returns the
+stale value:
+
+```ts
+const o: any = { a: 1, b: 2 };
+delete o.a;
+o.a               // standalone wasm: 1   node: undefined
+o.a === undefined // standalone wasm: false
+```
+
+## Root cause
+
+In standalone mode an object literal with a resolvable shape is lowered to a
+WasmGC struct. `delete o.a` sets a runtime tombstone but cannot clear the struct
+field, and the read fast-path (`struct.get`) reads the live field. There is no
+host `__extern_get` to reroute through, and a wasm-side `(obj,key)` tombstone
+registry is rejected (architect addendum A7): WasmGC has no weak refs, so it
+would strongly retain every deleted-from object.
+
+## Fix direction (architect addendum A7, from #2130)
+
+**Representation steering.** Reuse the `moduleUsesDelete` pre-scan
+(`ctx.moduleUsesDelete`, `src/codegen/index.ts`, landed in #2179) to find the
+object-literal struct types that are targeted by `delete`, and in standalone
+mode lower **those** literals to the dynamic `$Object` representation
+(`src/codegen/object-runtime.ts`) instead of a WasmGC struct. `$Object` already
+has spec-correct `FLAG_TOMBSTONE` tombstones, proto-walk `in`, and #1837
+insertion-order enumeration. Zero overhead for untouched objects; full fidelity
+for delete-touched ones.
+
+Likely scope: a per-literal "is a delete target?" analysis (which object
+literals flow into a `delete <member>` whose base resolves to that literal),
+then steer those literals' lowering to `$Object` in standalone; the read/`in`/
+keys paths then go through the existing `$Object` ops.
+
+## Acceptance criteria
+
+- `const o:any={a:1,b:2}; delete o.a; o.a` → `undefined` under `--target standalone`.
+- `o.a === undefined` after delete → `true` (standalone).
+- `delete o.a; o.a = 5; o.a` → `5`; `"a" in o` → `true` (standalone re-add).
+- `Object.keys(o)` / `for (const k in o)` omit the deleted key (standalone).
+- Non-delete-touched object literals keep their WasmGC struct lowering (no
+  perf/representation change); JS-host behavior (#2179) unregressed.
+
+## Notes
+
+Split from #2179 (A6 JS-host read-path fix is `done`). See #2179's
+`## Resolution` and #2130's architect addendum A7.

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1203,6 +1203,15 @@ export interface CodegenContext {
    *  `__unbox_string`, `__str_from_mem`, `__str_to_mem`,
    *  `__str_extern_len`). Implies `nativeStrings === true`. */
   standalone: boolean;
+  /** (#2179) True when the module body contains any `delete` of a property or
+   *  element access (e.g. `delete o.a` / `delete o[k]`). Pre-scanned once at
+   *  module setup. When true, `any`/`unknown`-typed property READS in JS-host
+   *  mode are routed through the tombstone-aware `__extern_get` host helper
+   *  instead of the inline `ref.test`+`struct.get` fast-path — the fast-path
+   *  reads the live WasmGC field and bypasses the runtime delete tombstone, so
+   *  a post-delete read returned the stale value (#2179). Delete-free modules
+   *  keep the byte-identical inline fast-path (zero overhead). */
+  moduleUsesDelete?: boolean;
   /** (#1472 Phase A) Set of dynamic-shape object/property host-import names
    *  already refused under `--target standalone`, used to deduplicate the
    *  compile-error so a single source construct emits at most one error per

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -225,6 +225,31 @@ function sourceContainsClass(sourceFile: ts.SourceFile): boolean {
 }
 
 /**
+ * (#2179) True when the source contains a `delete` operating on a property or
+ * element access (`delete o.a` / `delete o[k]`). `delete x` of a bare
+ * identifier and `delete <other expr>` (no-op deletes) do NOT count — only
+ * member deletes can leave a runtime tombstone that the inline struct.get
+ * read fast-path would bypass. Used to gate the tombstone-aware read routing
+ * so delete-free modules emit byte-identical wasm.
+ */
+function sourceContainsDelete(sourceFile: ts.SourceFile): boolean {
+  let found = false;
+  function walk(node: ts.Node): void {
+    if (found) return;
+    if (
+      ts.isDeleteExpression(node) &&
+      (ts.isPropertyAccessExpression(node.expression) || ts.isElementAccessExpression(node.expression))
+    ) {
+      found = true;
+      return;
+    }
+    forEachChild(node, walk);
+  }
+  walk(sourceFile);
+  return found;
+}
+
+/**
  * #1623 — true when the source contains any object/array binding pattern
  * (destructuring) in a parameter, variable declaration, or assignment target.
  * Used to decide whether to pre-emit the WASI/standalone TypeError constructor
@@ -975,6 +1000,11 @@ export function generateModule(
       ctx.topLevelFunctionNames.add(stmt.name.text);
     }
   }
+  // (#2179) Pre-scan for `delete <member>` so `any`-receiver property reads can
+  // be routed through the tombstone-aware `__extern_get` host helper instead of
+  // the inline struct.get fast-path (which reads the live field and ignores the
+  // runtime delete tombstone). Delete-free modules keep byte-identical output.
+  ctx.moduleUsesDelete = sourceContainsDelete(ast.sourceFile);
   try {
     // WASI target: register linear memory, bump pointer global, and WASI imports
     if (ctx.wasi) {

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -1573,6 +1573,70 @@ function receiverIsCatchClauseBinding(ctx: CodegenContext, recv: ts.Expression):
   );
 }
 
+/**
+ * (#2179) When the module uses `delete <member>` (JS-host mode only), route an
+ * `any`/`unknown`-typed property READ through the tombstone-aware `__extern_get`
+ * host helper instead of the inline `ref.test`+`struct.get` fast-path. Returns
+ * the emitted result type (always `externref`) when it handled the read, or
+ * `undefined` to let the normal path run.
+ *
+ * Tightly scoped so it never hijacks reads that the fast-path handles correctly:
+ * only `any`/`unknown` receivers, never a method/function-typed access, never a
+ * reserved accessor (`length`/`constructor`/`__proto__`/`prototype`), and never
+ * when the receiver resolves to a concrete (non-`any`) struct/class/array type.
+ */
+function tryEmitDeleteAwareDynamicGet(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.PropertyAccessExpression,
+  objType: ts.Type,
+  propName: string,
+): ValType | null | undefined {
+  if (!ctx.moduleUsesDelete || ctx.standalone) return undefined;
+  // Only dynamic (`any`/`unknown`) receivers take the bypassed fast-path that
+  // ignores the tombstone. Concrete struct/class/array receivers are typed and
+  // unaffected by the `any`-read path this guards.
+  const isAnyOrUnknown = (objType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
+  if (!isAnyOrUnknown) return undefined;
+  // Reserved accessors have dedicated lowerings (array length, proto walk,
+  // constructor identity) — never reroute them.
+  if (
+    propName === "length" ||
+    propName === "constructor" ||
+    propName === "__proto__" ||
+    propName === "prototype" ||
+    propName === "name"
+  ) {
+    return undefined;
+  }
+  // A method/function-typed access (e.g. `o.fn` where `fn` is callable, or a
+  // built-in method) must keep its closure/funcref lowering — `__extern_get`
+  // would box it as a plain value.
+  const accessType = ctx.checker.getTypeAtLocation(expr);
+  if (accessType.getCallSignatures && accessType.getCallSignatures().length > 0) return undefined;
+
+  const getIdx = ensureLateImport(
+    ctx,
+    "__extern_get",
+    [{ kind: "externref" }, { kind: "externref" }],
+    [{ kind: "externref" }],
+  );
+  flushLateImportShifts(ctx, fctx);
+  if (getIdx === undefined) return undefined;
+
+  // Evaluate the receiver, coerce to externref, then __extern_get(obj, "prop").
+  const objResult = compileExpression(ctx, fctx, expr.expression);
+  if (objResult && objResult.kind !== "externref") {
+    coerceType(ctx, fctx, objResult, { kind: "externref" });
+  } else if (!objResult) {
+    fctx.body.push({ op: "ref.null.extern" } as Instr);
+  }
+  addStringConstantGlobal(ctx, propName);
+  fctx.body.push(...stringConstantExternrefInstrs(ctx, propName));
+  fctx.body.push({ op: "call", funcIdx: getIdx } as Instr);
+  return { kind: "externref" };
+}
+
 export function compilePropertyAccess(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -1591,6 +1655,23 @@ export function compilePropertyAccess(
 
   const objType = ctx.checker.getTypeAtLocation(expr.expression);
   const propName = ts.isPrivateIdentifier(expr.name) ? "__priv_" + expr.name.text.slice(1) : expr.name.text;
+
+  // (#2179) Tombstone-aware read for `any`/`unknown` receivers in delete-using
+  // JS-host modules. The default `any`-receiver read resolves to an inline
+  // `ref.test`+`struct.get` fast-path that reads the LIVE WasmGC field, ignoring
+  // the runtime delete tombstone — so `delete o.a; o.a` returned the stale
+  // value, and `o.a === undefined` constant-folded to `false` because the
+  // field's static type is `f64` (never undefined). Route the read through the
+  // tombstone-aware `__extern_get` host helper, which returns an `externref`
+  // (real `undefined` when tombstoned, so `=== undefined` is no longer folded)
+  // and re-add via `__extern_set`/`_safeSet` clears the tombstone. Gated on the
+  // `moduleUsesDelete` pre-scan so delete-free modules keep the byte-identical
+  // fast-path; standalone has no `__extern_get` host import (#2179 A7 covers it
+  // via $Object representation steering — separate follow-up).
+  {
+    const dyn = tryEmitDeleteAwareDynamicGet(ctx, fctx, expr, objType, propName);
+    if (dyn !== undefined) return dyn;
+  }
 
   const jsonParsePropertyType = tryEmitJsonParsePropertyAccess(ctx, fctx, expr);
   if (jsonParsePropertyType !== undefined) return jsonParsePropertyType;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -6680,6 +6680,12 @@ assert._isSameValue = isSameValue;
             if ((sc && key in sc) || descs?.has(_normalizeDescKey(key))) return undefined;
           }
           if (_isWasmStruct(obj) && typeof key === "string") {
+            // (#2179) A deleted key must NOT be resurrected by the struct-field
+            // getter fast-path: `delete o.a` sets the tombstone but cannot clear
+            // the underlying WasmGC field, so `__sget_a` still returns the stale
+            // value. Consult the tombstone before reading the live field.
+            const tomb = _wasmStructDeletedKeys.get(obj);
+            if (tomb && tomb.has(key)) return undefined;
             const exports = callbackState?.getExports();
             const getter = exports?.[`__sget_${key}`];
             if (typeof getter === "function") return getter(obj);
@@ -7295,8 +7301,12 @@ assert._isSameValue = isSameValue;
             const fieldNames = _getStructFieldNames(obj, exports);
             if (fieldNames) {
               const descs = _wasmPropDescs.get(obj);
+              // (#2179) Drop deleted keys — the static struct shape still carries
+              // the field, but `delete o.k` tombstoned it.
+              const tomb = _wasmStructDeletedKeys.get(obj);
               return _orderOwnKeysSpec(
                 fieldNames.filter((k) => {
+                  if (tomb && tomb.has(k)) return false;
                   if (!descs) return true;
                   const flags = descs.get(k);
                   return flags === undefined || !!(flags & _SC_ENUMERABLE);
@@ -7315,8 +7325,10 @@ assert._isSameValue = isSameValue;
             const fieldNames = _getStructFieldNames(obj, exports);
             if (fieldNames) {
               const descs = _wasmPropDescs.get(obj);
+              const tomb = _wasmStructDeletedKeys.get(obj); // (#2179) skip deleted keys
               return _orderOwnKeysSpec(
                 fieldNames.filter((k) => {
+                  if (tomb && tomb.has(k)) return false;
                   if (!descs) return true;
                   const flags = descs.get(k);
                   return flags === undefined || !!(flags & _SC_ENUMERABLE);
@@ -7338,8 +7350,10 @@ assert._isSameValue = isSameValue;
             const fieldNames = _getStructFieldNames(obj, exports);
             if (fieldNames) {
               const descs = _wasmPropDescs.get(obj);
+              const tomb = _wasmStructDeletedKeys.get(obj); // (#2179) skip deleted keys
               return _orderOwnKeysSpec(
                 fieldNames.filter((k) => {
+                  if (tomb && tomb.has(k)) return false;
                   if (!descs) return true;
                   const flags = descs.get(k);
                   return flags === undefined || !!(flags & _SC_ENUMERABLE);
@@ -10998,6 +11012,12 @@ assert._isSameValue = isSameValue;
         const descs = _wasmPropDescs.get(obj);
         if ((sc && key in sc) || descs?.has(_normalizeDescKey(key))) return undefined;
         if (typeof key === "string") {
+          // (#2179) A deleted key must NOT be resurrected by the struct-field
+          // getter fast-path: `delete o.a` sets the tombstone but cannot clear
+          // the underlying WasmGC field, so `__sget_a` still returns the stale
+          // value. Consult the tombstone before reading the live field.
+          const tomb = _wasmStructDeletedKeys.get(obj);
+          if (tomb && tomb.has(key)) return undefined;
           const exports = callbackState?.getExports();
           const getter = exports?.[`__sget_${key}`];
           if (typeof getter === "function") return getter(obj);

--- a/tests/issue-2179.test.ts
+++ b/tests/issue-2179.test.ts
@@ -44,65 +44,85 @@ async function run<T = unknown>(src: string): Promise<T> {
 
 describe("#2179 post-delete struct read consults the tombstone (JS-host)", () => {
   it("read of a deleted property returns undefined", async () => {
-    expect(await run<string>(`export function test(): string {
+    expect(
+      await run<string>(`export function test(): string {
       const o: any = { a: 1, b: 2 }; delete o.a; return String(o.a);
-    }`)).toBe("undefined");
+    }`),
+    ).toBe("undefined");
   });
 
   it("`o.a === undefined` after delete is true (not constant-folded)", async () => {
     // Boolean exports return the i32 representation (1 = true), matching the
     // #2130 read-half assertions.
-    expect(await run<number>(`export function test(): boolean {
+    expect(
+      await run<number>(`export function test(): boolean {
       const o: any = { a: 1, b: 2 }; delete o.a; return o.a === undefined;
-    }`)).toBe(1);
+    }`),
+    ).toBe(1);
   });
 
   it("delete then re-add reads the new value", async () => {
-    expect(await run<number>(`export function test(): number {
+    expect(
+      await run<number>(`export function test(): number {
       const o2: any = { a: 1 }; delete o2.a; o2.a = 5; return o2.a;
-    }`)).toBe(5);
+    }`),
+    ).toBe(5);
   });
 
   it("dynamic-key delete tombstones the read too", async () => {
-    expect(await run<string>(`export function test(): string {
+    expect(
+      await run<string>(`export function test(): string {
       const o: any = { a: 1 }; const k = "a"; delete o[k]; return String(o.a);
-    }`)).toBe("undefined");
+    }`),
+    ).toBe("undefined");
   });
 
   it("a sibling property is unaffected by the delete", async () => {
-    expect(await run<number>(`export function test(): number {
+    expect(
+      await run<number>(`export function test(): number {
       const o: any = { a: 1, b: 2 }; delete o.a; return o.b;
-    }`)).toBe(2);
+    }`),
+    ).toBe(2);
   });
 
   it("Object.keys omits the deleted key", async () => {
-    expect(await run<string>(`export function test(): string {
+    expect(
+      await run<string>(`export function test(): string {
       const o: any = { a: 1, b: 2 }; delete o.a; return Object.keys(o).join(",");
-    }`)).toBe("b");
+    }`),
+    ).toBe("b");
   });
 
   it("for-in omits the deleted key", async () => {
-    expect(await run<string>(`export function test(): string {
+    expect(
+      await run<string>(`export function test(): string {
       const o: any = { a: 1, b: 2 }; delete o.a; let s = ""; for (const k in o) s += k; return s;
-    }`)).toBe("b");
+    }`),
+    ).toBe("b");
   });
 
   it("string-valued field reads undefined after delete", async () => {
-    expect(await run<string>(`export function test(): string {
+    expect(
+      await run<string>(`export function test(): string {
       const o: any = { s: "hi", t: "bye" }; delete o.s; return o.t + String(o.s);
-    }`)).toBe("byeundefined");
+    }`),
+    ).toBe("byeundefined");
   });
 
   // Regression guards: the gate must not perturb non-delete reads.
 
   it("typed (non-any) receiver reads are unchanged", async () => {
-    expect(await run<number>(`interface P { x: number; y: number; }
-      export function test(): number { const p: P = { x: 3, y: 4 }; return p.x + p.y; }`)).toBe(7);
+    expect(
+      await run<number>(`interface P { x: number; y: number; }
+      export function test(): number { const p: P = { x: 3, y: 4 }; return p.x + p.y; }`),
+    ).toBe(7);
   });
 
   it("method dispatch on an any receiver in a delete-using module works", async () => {
-    expect(await run<number>(`export function test(): number {
+    expect(
+      await run<number>(`export function test(): number {
       const o: any = { f: (n: number) => n * 2 }; delete o.g; return o.f(21);
-    }`)).toBe(42);
+    }`),
+    ).toBe(42);
   });
 });

--- a/tests/issue-2179.test.ts
+++ b/tests/issue-2179.test.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2179 — post-delete struct READ returned the stale value for a
+// statically-resolvable `any` receiver (JS-host mode).
+//
+// `const o: any = { a: 1, b: 2 }; delete o.a; o.a` compiled the read to an
+// inline `ref.test`+`struct.get` fast-path that read the LIVE WasmGC field and
+// bypassed the runtime delete tombstone, so the read returned `1`, and
+// `o.a === undefined` constant-folded to `false` (the field's static type is
+// `f64`, which can never be `undefined`).
+//
+// Fix (#2179 A6, JS-host):
+//  - A `moduleUsesDelete` pre-scan (`src/codegen/index.ts`) gates the routing so
+//    delete-free modules keep the byte-identical inline fast-path.
+//  - When the module uses `delete <member>`, `any`/`unknown`-typed property reads
+//    route through the tombstone-aware `__extern_get` host helper
+//    (`src/codegen/property-access.ts` `tryEmitDeleteAwareDynamicGet`), which
+//    returns an `externref` — real `undefined` when tombstoned (so `=== undefined`
+//    is no longer folded) and re-add via `__extern_set`/`_safeSet` clears it.
+//  - The `__extern_get` struct-field getter fallback and `Object.keys`/`values`/
+//    `entries` now consult `_wasmStructDeletedKeys` before reading the live field
+//    (`src/runtime.ts`), so a tombstoned key never resurfaces.
+//
+// Standalone mode (A7 — $Object representation steering) is a separate follow-up;
+// this change is JS-host-only (gated on `!ctx.standalone`).
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run<T = unknown>(src: string): Promise<T> {
+  const result = await compile(src, { fileName: "test.ts" });
+  if (!result.success) {
+    throw new Error(`compile failed:\n${result.errors.map((e) => `  L${e.line}:${e.column} ${e.message}`).join("\n")}`);
+  }
+  const importResult = buildImports(result.imports as never, undefined, result.stringPool);
+  const inst = await WebAssembly.instantiate(result.binary, importResult as never);
+  if (typeof (importResult as { setExports?: Function }).setExports === "function") {
+    (importResult as { setExports: Function }).setExports(inst.instance.exports);
+  }
+  return (inst.instance.exports as Record<string, Function>).test!() as T;
+}
+
+describe("#2179 post-delete struct read consults the tombstone (JS-host)", () => {
+  it("read of a deleted property returns undefined", async () => {
+    expect(await run<string>(`export function test(): string {
+      const o: any = { a: 1, b: 2 }; delete o.a; return String(o.a);
+    }`)).toBe("undefined");
+  });
+
+  it("`o.a === undefined` after delete is true (not constant-folded)", async () => {
+    // Boolean exports return the i32 representation (1 = true), matching the
+    // #2130 read-half assertions.
+    expect(await run<number>(`export function test(): boolean {
+      const o: any = { a: 1, b: 2 }; delete o.a; return o.a === undefined;
+    }`)).toBe(1);
+  });
+
+  it("delete then re-add reads the new value", async () => {
+    expect(await run<number>(`export function test(): number {
+      const o2: any = { a: 1 }; delete o2.a; o2.a = 5; return o2.a;
+    }`)).toBe(5);
+  });
+
+  it("dynamic-key delete tombstones the read too", async () => {
+    expect(await run<string>(`export function test(): string {
+      const o: any = { a: 1 }; const k = "a"; delete o[k]; return String(o.a);
+    }`)).toBe("undefined");
+  });
+
+  it("a sibling property is unaffected by the delete", async () => {
+    expect(await run<number>(`export function test(): number {
+      const o: any = { a: 1, b: 2 }; delete o.a; return o.b;
+    }`)).toBe(2);
+  });
+
+  it("Object.keys omits the deleted key", async () => {
+    expect(await run<string>(`export function test(): string {
+      const o: any = { a: 1, b: 2 }; delete o.a; return Object.keys(o).join(",");
+    }`)).toBe("b");
+  });
+
+  it("for-in omits the deleted key", async () => {
+    expect(await run<string>(`export function test(): string {
+      const o: any = { a: 1, b: 2 }; delete o.a; let s = ""; for (const k in o) s += k; return s;
+    }`)).toBe("b");
+  });
+
+  it("string-valued field reads undefined after delete", async () => {
+    expect(await run<string>(`export function test(): string {
+      const o: any = { s: "hi", t: "bye" }; delete o.s; return o.t + String(o.s);
+    }`)).toBe("byeundefined");
+  });
+
+  // Regression guards: the gate must not perturb non-delete reads.
+
+  it("typed (non-any) receiver reads are unchanged", async () => {
+    expect(await run<number>(`interface P { x: number; y: number; }
+      export function test(): number { const p: P = { x: 3, y: 4 }; return p.x + p.y; }`)).toBe(7);
+  });
+
+  it("method dispatch on an any receiver in a delete-using module works", async () => {
+    expect(await run<number>(`export function test(): number {
+      const o: any = { f: (n: number) => n * 2 }; delete o.g; return o.f(21);
+    }`)).toBe(42);
+  });
+});


### PR DESCRIPTION
## #2179 — post-delete struct READ returned the stale value

`const o: any = { a: 1, b: 2 }; delete o.a; o.a` returned `1` (not `undefined`)
and `o.a === undefined` constant-folded to `false`. The read compiled to an
inline `ref.test`+`struct.get` fast-path that read the live WasmGC field,
bypassing the runtime delete tombstone; the `=== undefined` fold fired because
the field's static type is `f64` (never undefined).

### A6 — JS-host fix (this PR)
- **`moduleUsesDelete` pre-scan** (`src/codegen/index.ts` `sourceContainsDelete`):
  true only when the module contains `delete <member>`. Delete-free modules keep
  the **byte-identical** inline fast-path (verified).
- **`tryEmitDeleteAwareDynamicGet`** (`src/codegen/property-access.ts`): routes
  `any`/`unknown` reads through the tombstone-aware `__extern_get` host helper,
  returning an `externref` (real `undefined` when tombstoned → `=== undefined`
  no longer folds; re-add via `_safeSet` clears the tombstone). Tightly scoped:
  skips reserved accessors (`length`/`constructor`/`__proto__`/`prototype`/
  `name`) and method/function-typed accesses; never fires for concrete struct
  receivers or in standalone mode.
- **`src/runtime.ts`**: both `__extern_get` bindings consulted the
  `__sget_<key>` struct-field getter fallback **without** a tombstone check
  (resurrecting the deleted field after `_safeGet` already returned `undefined`)
  — added a `_wasmStructDeletedKeys` gate to both. `__object_keys`/`values`/
  `entries` now filter the tombstone too (#2130 A4 enumeration gap).

### Acceptance (JS-host)
`delete o.a; o.a` → `undefined`; `o.a === undefined` → `true`; `delete o.a;
o.a = 5; o.a` → `5` and `"a" in o` → `true`; `Object.keys`/`for..in` omit the
deleted key; delete-free modules byte-identical; sibling reads / typed receivers
/ method dispatch unregressed.

### Scope
A7 (standalone `$Object` representation steering) is split to **#2186** —
`__extern_get` is a host import unavailable under `--target standalone`, and a
wasm-side weak tombstone registry is rejected by the architect addendum
(WasmGC has no weak refs). Gated `!ctx.standalone`, so standalone is unaffected.

### Tests
`tests/issue-2179.test.ts` (10 cases). Existing delete/keys suites green (42
tests / 6 files); IR-fallback gate + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)