### PR TITLE
refactor(#2182): detached-body funcIdx-shift hazard — audit + liveBodies coverage + balance assertion

### DIFF
--- a/plan/issues/2182-detached-body-late-import-audit.md
+++ b/plan/issues/2182-detached-body-late-import-audit.md
@@ -1,9 +1,12 @@
 ---
 id: 2182
 title: "collectInstrs detached-array audit + liveBodies-empty assertion (funcIdx-shift hazard completeness)"
-status: ready
+status: done
+completed: 2026-06-17
+assignee: ttraenkler/dev-resume
 sprint: 63
 created: 2026-06-16
+updated: 2026-06-17
 priority: low
 feasibility: medium
 reasoning_effort: medium
@@ -69,3 +72,57 @@ the box's load cap) is the **completeness/hardening** half.
 Pure hardening — no known live bug remains (verified in #1257). Low priority;
 its value is preventing silent re-introduction of the funcIdx-shift class as
 new detached-array codegen patterns are added.
+
+## Resolution (2026-06-17, PR for #2182)
+
+### Audit (the detaching primitive is already safe)
+
+`collectInstrs` (`statements/shared.ts:27`) is **inherently covered**: it pushes
+the prior body onto `fctx.savedBodies` for the duration of `emitFn()` (the only
+window a late import can fire), and `shiftLateImportIndices` walks
+`fctx.savedBodies` + `ctx.currentFunc.savedBodies` + every `funcStack[]`
+savedBodies. Same for `pushBody`/`popBody` (`context/bodies.ts`) and the
+`parentBodiesStack` idiom. The walked coverage set is: `fctx.body`,
+`fctx.savedBodies`, `ctx.currentFunc.{body,savedBodies}`, `funcStack[].{body,
+savedBodies}`, `ctx.parentBodiesStack`, `ctx.liveBodies`, `ctx.pendingInitBody`,
+`ctx.mod.functions[].body`.
+
+The residual hazard is the **raw `const saved = fctx.body; fctx.body = <other>`
+swap** that bypasses all of the above and holds `saved` (the *outer* body, which
+may already carry shiftable `call` funcIdxs) across an emit that can trigger a
+late import. Audited every such site; three were uncovered and are now fixed by
+registering `saved` in `ctx.liveBodies` for the swap's lifetime:
+
+| site | swap | fix |
+|------|------|-----|
+| `builtin-static-globals.ts:177` | `fctx.body = initBody` across `emitBuiltinStaticMethodValue` | `liveBodies.add(savedBody)` / `.delete` in `finally` |
+| `type-coercion.ts:2449` | `fctx.body = scratch` across `normaliseToString` | `liveBodies.add(savedBody)` / `.delete` |
+| `generators-native.ts:1245` (resume-state build) | `fctx.body = body` across `compileStatement`/`emitYieldValueAsElem` | `liveBodies.add(saved)` / `.delete` |
+
+(The `then`/`else` capture-after-emit patterns and `fctx.body.length`/`splice`
+snapshots are safe — they operate on the live `fctx.body`, which is always
+walked.)
+
+### Defensive assertion
+
+`compileFunctionBody` (`function-body.ts`) snapshots `ctx.liveBodies.size` at
+entry and asserts the size is restored at exit. A non-zero delta means a
+detached-body `liveBodies.add` was not balanced by a `.delete` — the exact gap
+that re-introduces the funcIdx-shift class. Scoped to the **delta** (not "must be
+empty") so it never false-positives on a parent body legitimately registered by
+an enclosing compile while a lifted closure / nested function compiles.
+
+### Test Results
+
+- `tests/issue-2182.test.ts` (new) — 5/5: stress fixtures triggering many late
+  imports during nested destructuring-default builtins, generator resume-state
+  builds, interleaved string+numeric imports, and nested loop+destructuring all
+  compile AND run to the expected value (every `call` funcIdx still resolves);
+  plus a closures+builtins case proving the balance assertion does not
+  false-positive.
+- `tests/issue-1257.test.ts` — pass (original regression net).
+- `tests/generators.test.ts` + generator/destructuring/closure suites — pass,
+  **zero `#2182` invariant throws** (assertion produces no false positives).
+- Pre-existing, unrelated failures: several `tests/`-root files import
+  `./helpers.js` (the helper lives at `tests/equivalence/helpers.ts`) — a path
+  bug in those files, unmodified here; CI's setup resolves it.

--- a/src/codegen/builtin-static-globals.ts
+++ b/src/codegen/builtin-static-globals.ts
@@ -176,6 +176,13 @@ export function emitBuiltinNamespaceObject(
 
   const savedBody = fctx.body;
   fctx.body = initBody;
+  // (#2182) `savedBody` is the outer body, detached for the duration of the
+  // swap. `emitBuiltinStaticMethodValue` below can trigger a late import (e.g.
+  // a host builtin), and `shiftLateImportIndices` only walks `fctx.body` (=
+  // initBody here) plus the registered body sets — NOT this raw local. Register
+  // it in `liveBodies` so any `call` funcIdx already accumulated in the outer
+  // body is shifted too; otherwise a late import here would over-shift it.
+  ctx.liveBodies.add(savedBody);
   try {
     for (const prop of props) {
       fctx.body.push({ op: "local.get", index: objLocal });
@@ -189,6 +196,7 @@ export function emitBuiltinNamespaceObject(
     fctx.body.push({ op: "global.set", index: globalIdx });
   } finally {
     fctx.body = savedBody;
+    ctx.liveBodies.delete(savedBody);
   }
 
   fctx.body.push({ op: "global.get", index: globalIdx });

--- a/src/codegen/function-body.ts
+++ b/src/codegen/function-body.ts
@@ -651,6 +651,16 @@ export function compileFunctionBody(ctx: CodegenContext, decl: ts.FunctionDeclar
   }
   const retType = ctx.checker.getReturnTypeOfSignature(sig);
 
+  // (#2182) Defensive balance check for the detached-body funcIdx-shift hazard.
+  // Every `ctx.liveBodies.add(...)` during this function's compilation MUST be
+  // matched by a `.delete(...)`. A missing delete leaves a stale detached array
+  // registered, which a LATER late import would over-shift (silent funcIdx
+  // corruption — the #1257 bug class). Snapshot the size here and assert it's
+  // restored at the end. Scoped to the delta (not "must be empty") so it never
+  // false-positives on a parent body legitimately registered by an enclosing
+  // compile while a lifted closure / nested function compiles.
+  const liveBodiesAtEntry = ctx.liveBodies.size;
+
   // For async functions, unwrap Promise<T> to get T
   const isAsync = ctx.asyncFunctions.has(func.name);
   const isGenerator = ctx.generatorFunctions.has(func.name);
@@ -1163,6 +1173,18 @@ export function compileFunctionBody(ctx: CodegenContext, decl: ts.FunctionDeclar
   deduplicateLocals(fctx);
   func.locals = fctx.locals;
   func.body = fctx.body;
+
+  // (#2182) See the snapshot at function entry. A non-zero delta means a
+  // detached-body `liveBodies.add` was not balanced by a `.delete` — a
+  // funcIdx-shift hazard. Throw in dev/test builds so it surfaces immediately
+  // rather than corrupting a later late import silently.
+  if (ctx.liveBodies.size !== liveBodiesAtEntry) {
+    throw new Error(
+      `codegen invariant (#2182): liveBodies unbalanced after compiling '${func.name}' ` +
+        `(entry=${liveBodiesAtEntry}, exit=${ctx.liveBodies.size}) — a detached-body ` +
+        `liveBodies.add() is missing its matching .delete(), risking funcIdx over-shift.`,
+    );
+  }
 
   ctx.currentFunc = null;
 }

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -1245,6 +1245,12 @@ function compileState(
   const saved = fctx.body;
   const body: Instr[] = [];
   fctx.body = body;
+  // (#2182) `saved` is detached for the whole resume-state build, which runs
+  // `compileStatement` / `emitYieldValueAsElem` — both can trigger a late
+  // import. The shifter walks `fctx.body` (= body) but not this raw local, so
+  // register `saved` in liveBodies for the swap's lifetime; otherwise a late
+  // import would over-shift any `call` funcIdx already in the outer body.
+  ctx.liveBodies.add(saved);
 
   // Abrupt-resume (.return()) handling: if we resumed into this state in mode 1
   // (return), run finalizers, store spills, and complete with the abrupt value.
@@ -1445,6 +1451,7 @@ function compileState(
   }
 
   fctx.body = saved;
+  ctx.liveBodies.delete(saved);
   return body;
 }
 

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -2449,8 +2449,14 @@ export function tryStructToString(ctx: CodegenContext, fctx: FunctionContext, fr
           const savedBody = fctx.body;
           const scratch: Instr[] = [];
           fctx.body = scratch;
+          // (#2182) Register the detached outer body in liveBodies so a late
+          // import triggered inside `normaliseToString` shifts its accumulated
+          // `call` funcIdxs too (the shifter only walks fctx.body = scratch
+          // here, not this raw local).
+          ctx.liveBodies.add(savedBody);
           normaliseToString(info.returnType?.kind);
           fctx.body = savedBody;
+          ctx.liveBodies.delete(savedBody);
           thenInstrs.push(...scratch);
           return [
             { op: "local.get", index: eqLocal } as Instr,

--- a/tests/issue-2182.test.ts
+++ b/tests/issue-2182.test.ts
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2182 — detached-array funcIdx-shift hazard: completeness hardening.
+//
+// #1257 fixed the observable funcIdx-shift corruption (a detached instruction
+// array held across a late import, whose `call` funcIdxs got over-shifted). This
+// is the deferred completeness half: a balance assertion in `compileFunctionBody`
+// (every `liveBodies.add` must be matched by a `.delete`), `liveBodies`
+// registration of the remaining raw `const saved = fctx.body` body-swaps
+// (builtin-static-globals, type-coercion toString dispatch, native-generator
+// resume-state build), and this stress test.
+//
+// The stress test compiles fixtures that trigger MANY late imports during deeply
+// nested detached-array compilation (nested destructuring with defaults that call
+// host builtins, generators, loop conditions) and asserts the module both
+// compiles AND runs to the expected value — i.e. every `call` funcIdx still
+// resolves to the intended function after all the late-import shifts.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runFn<T = unknown>(src: string, fnName: string, ...args: number[]): Promise<T> {
+  const r = await compile(src, { fileName: "test.ts" });
+  if (!r.success) {
+    throw new Error(`compile failed:\n${r.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imps = buildImports(r.imports as never, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imps as never);
+  if (typeof (imps as { setExports?: (e: unknown) => void }).setExports === "function") {
+    (imps as { setExports: (e: unknown) => void }).setExports(instance.exports);
+  }
+  return (instance.exports as Record<string, (...a: number[]) => T>)[fnName](...args);
+}
+
+describe("#2182 detached-body funcIdx-shift hazard — stress + balance", () => {
+  it("nested destructuring defaults calling host builtins (many late imports) resolve correctly", async () => {
+    // Each `Math.*` default in the destructuring pattern is a late import fired
+    // while the destructuring buffers are detached. If a funcIdx over-shifted,
+    // one of these calls would resolve to the wrong function and the result
+    // would diverge from the expected sum.
+    const src = `
+      export function f(): number {
+        const { a = Math.floor(3.7), b = Math.ceil(2.1), c = Math.abs(-4), d = Math.max(5, 1) } =
+          {} as { a?: number; b?: number; c?: number; d?: number };
+        const { e = Math.min(9, 6), g = Math.round(7.4), h = Math.sqrt(16) } =
+          {} as { e?: number; g?: number; h?: number };
+        return a + b + c + d + e + g + h;
+      }`;
+    // 3 + 3 + 4 + 5 + 6 + 7 + 4 = 32
+    expect(await runFn<number>(src, "f")).toBe(32);
+  });
+
+  it("generator with builtin calls in body (resume-state detached build) resolves correctly", async () => {
+    const src = `
+      export function f(): number {
+        function* gen(): Generator<number> {
+          yield Math.floor(1.9);
+          yield Math.abs(-2);
+          yield Math.max(3, 0);
+        }
+        let total = 0;
+        for (const v of gen()) { total = total + v; }
+        return total;
+      }`;
+    // 1 + 2 + 3 = 6
+    expect(await runFn<number>(src, "f")).toBe(6);
+  });
+
+  it("many interleaved string + numeric builtin late imports keep call targets intact", async () => {
+    const src = `
+      export function f(): number {
+        let s = "";
+        let n = 0;
+        for (let i = 0; i < 5; i = i + 1) {
+          s = s + "x";
+          n = n + Math.floor(i + 0.5);
+        }
+        // s.length exercises a late string import; n sums the floor results.
+        return s.length + n;
+      }`;
+    // s.length = 5; n = 0+1+2+3+4 = 10 → 15
+    expect(await runFn<number>(src, "f")).toBe(15);
+  });
+
+  it("deeply nested loop + destructuring-default builtins (compound late-import nesting)", async () => {
+    const src = `
+      export function f(): number {
+        let acc = 0;
+        for (let i = 0; i < 3; i = i + 1) {
+          const { p = Math.abs(-1), q = Math.floor(2.5) } = {} as { p?: number; q?: number };
+          let j = 2;
+          while (j) {
+            acc = acc + p + q;
+            j = j - 1;
+          }
+        }
+        return acc;
+      }`;
+    // per outer iter: (1+2) added twice = 6; ×3 = 18
+    expect(await runFn<number>(src, "f")).toBe(18);
+  });
+
+  it("balance assertion does not false-positive on closures + builtins", async () => {
+    // A lifted closure capturing a local, plus a builtin late import, exercises
+    // the liveBodies add/delete discipline across function boundaries; this must
+    // compile cleanly (no #2182 invariant throw) and run correctly.
+    const src = `
+      export function f(): number {
+        let base = Math.floor(9.5);
+        const add = (x: number): number => x + base;
+        return add(Math.abs(-2));
+      }`;
+    // base = 9, add(2) = 2 + 9 = 11
+    expect(await runFn<number>(src, "f")).toBe(11);
+  });
+});


### PR DESCRIPTION
## Context (#2182)

#1257 closed the observable funcIdx over-shift (a detached instruction array held across a late import whose `call` funcIdxs got shifted). This is the deferred completeness/hardening half — no known live bug.

## Audit

`collectInstrs` / `pushBody` / `parentBodiesStack` are **already covered**: the shifter walks `savedBodies` + `funcStack` + `liveBodies` + `parentBodiesStack`. The residual hazard is the raw `const saved = fctx.body; fctx.body = other` swap that holds the *outer* body (which may carry shiftable `call` funcIdxs) across a late-import-capable emit. Three uncovered sites now register `saved` in `ctx.liveBodies` for the swap lifetime:

| site | swap across | fix |
|------|------|------|
| `builtin-static-globals.ts:177` | `emitBuiltinStaticMethodValue` | `liveBodies.add`/`.delete` in `finally` |
| `type-coercion.ts:2449` | `normaliseToString` | `liveBodies.add`/`.delete` |
| `generators-native.ts:1245` | resume-state `compileStatement`/`emitYieldValueAsElem` | `liveBodies.add`/`.delete` |

(`then`/`else` capture-after-emit and `.length`/`splice` snapshots are safe — they operate on the live `fctx.body`, always walked.)

## Defensive assertion

`compileFunctionBody` snapshots `ctx.liveBodies.size` at entry and asserts it is restored at exit — a missing `.delete()` (the funcIdx-shift gap) throws immediately. Scoped to the **delta** so it never false-positives on a parent body legitimately live while a nested function compiles.

## Tests

- `tests/issue-2182.test.ts` (new) — 5/5: stress fixtures triggering many late imports during nested destructuring-default builtins, generator resume builds, interleaved string+numeric imports; each compiles AND runs correctly (every `call` funcIdx resolves). Plus a closures+builtins case proving the assertion doesn't false-positive.
- `tests/issue-1257.test.ts` + `generators.test.ts` + destructuring/closure suites — pass, **zero #2182 invariant throws**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)