### PR TITLE
test(#2171): promote SF-4 string-yield generator to live test; reconcile status

### DIFF
--- a/plan/issues/2171-standalone-generator-non-numeric-yields.md
+++ b/plan/issues/2171-standalone-generator-non-numeric-yields.md
@@ -1,7 +1,9 @@
 ---
 id: 2171
 title: "standalone: native generator only supports numeric yields — string/boolean/object yields bail (#680)"
-status: ready
+status: done
+completed: 2026-06-17
+assignee: sendev-closures
 sprint: 63
 created: 2026-06-15
 priority: medium
@@ -120,3 +122,35 @@ it mid-flight risks a hard-to-debug interaction with those in-queue PRs (the
 shared `info.resultTypeIdx` they read). The spec is de-risked (the per-generator
 result-type finding is the crux and is confirmed), so the next dev — or me once
 #1492/#1493 land — can implement the string slice in one focused pass.
+
+## Resolution (2026-06-17)
+
+**Implemented and merged** in `c3eb18936` ("feat(#2171): string-yield native
+generators in standalone (SF-4 of #2157)"), exactly per the spec above:
+`generatorElemValType` / `isStringYieldExpression` choose a per-generator
+`elemValType` (f64 for numeric, the native `$AnyString` ref for all-string
+generators); `ensureNativeGeneratorResultType` keys the result struct
+(`__NativeGeneratorResult_<kind>`) and value field on the elem type; the resume
+function, state-struct spills, and the for-of driver
+(`tryCompileNativeGeneratorForOf`) all thread `info.elemValType`. Mixed/object
+yields still `fail()` cleanly (numeric path byte-identical).
+
+The issue file's `status` was left at `ready` (the impl commit didn't flip it).
+Reconciled to `done` here, and the SF-4 acceptance test was promoted from
+`it.todo` to a live test (+ two value-correctness guards: concat length, first
+char code). Verified on `upstream/main`: SF-4 string yields iterate 2× with zero
+host imports, and `s += v` concatenation produces the correct `$AnyString`
+(`"ab"`, length 2, first char `'a'`).
+
+### Known residual → follow-up #2187
+
+A **per-element string method on an `any`-typed loop variable** in standalone
+(e.g. `for (const v of g()) n += v.length` where TS infers `v: any` because no
+lib types resolve the generator's element type) routes through the generic
+externref property path instead of the native `$AnyString` path, yielding `0`.
+The loop var's *local ValType* is the string ref, but `compilePropertyAccess`
+gates the native-string `.length`/method fast-path on the *TS static type*
+(`isStringType(tsObjType)`), which is `any` here. This is the broader value-rep
+concern (#2072 family) — string-method dispatch keyed on local ValType when the
+TS type is `any` — not specific to generators. Tracked as #2187; out of scope
+for SF-4 (whose acceptance is iteration + concat, both correct).

--- a/plan/issues/2187-any-typed-local-string-method-dispatch-by-valtype.md
+++ b/plan/issues/2187-any-typed-local-string-method-dispatch-by-valtype.md
@@ -1,0 +1,75 @@
+---
+id: 2187
+title: "standalone: string methods on an any-typed local with a native-string ValType take the generic externref path (v.length → 0)"
+status: ready
+sprint: Backlog
+created: 2026-06-17
+updated: 2026-06-17
+priority: low
+feasibility: hard
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: strings
+goal: standalone-mode
+related: [2171, 2072, 2157]
+origin: "2026-06-17 — residual found while closing #2171 SF-4 (string-yield generators)"
+---
+
+# #2187 — string method on `any`-typed local with a string-ref ValType
+
+## Problem
+
+When a local's **TS static type is `any`** but its **Wasm ValType is the native
+`$AnyString` ref**, a string method/property on it takes the generic
+externref/`any` property path instead of the native-string fast-path, returning
+wrong results. Surfaced via #2171 string-yield generators in standalone (no lib
+types → the for-of loop var infers `any`):
+
+```ts
+function* g(){ yield "a"; yield "b"; }
+export function test(): number {
+  let n = 0; for (const v of g()) n += v.length; return n;  // standalone: 0   expected: 2
+}
+```
+
+Counts and concatenation are correct (`s += v` → `"ab"`); only a per-element
+string method/property (`v.length`, `v.charCodeAt(0)`, …) on the `any`-typed
+loop var is wrong. `String(o.a)`-style concat works because the concat path keys
+off the operand ValType, not the TS type.
+
+## Root cause
+
+`compilePropertyAccess` (`src/codegen/property-access.ts`) gates the native
+`.length` fast-path on `isStringType(tsObjType)` (the **TS static type**, ~line
+1418). For an `any`-typed receiver whose *local ValType* is `(ref null
+$AnyString)`, this is false, so the read falls to the generic
+`extern.convert_any` + null-check + `__extern_get` path (which the WAT shows
+throwing/returning 0). The single-yield case happens to hit a different
+`.length` arm that consults the local ValType, so it returns the right value —
+the divergence is exactly "TS type vs local ValType" disagreement.
+
+## Fix direction
+
+When the receiver is an identifier whose local/param **ValType is a native
+string ref** (or, more generally, a concrete non-`any` Wasm representation),
+route string property/method access by the **local ValType**, not the TS static
+type — so `any`-typed-but-string-ref locals use the native `$AnyString` path.
+Coordinate with the #2072 value-rep family (the general "compiled value has a
+concrete representation even though TS says `any`" problem). Likely a shared
+helper `receiverNativeStringValType(ctx, fctx, expr)` consulted before the
+`isStringType(tsObjType)` gate, applied to `.length` and the string-method
+dispatch sites.
+
+## Acceptance criteria
+
+- `for (const v of g()) n += v.length` (string generator, standalone) → correct
+  sum; `v.charCodeAt(0)` correct.
+- No regression on TS-typed `string` receivers or on numeric generators.
+- JS-host mode unaffected.
+
+## Notes
+
+Split from #2171 (string-yield generators, SF-4 of #2157 — landed in
+`c3eb18936`). #2171's own acceptance (iterate + concat) is met; this is the
+per-element string-method residual.

--- a/tests/issue-2157-iterator-generator-residual.test.ts
+++ b/tests/issue-2157-iterator-generator-residual.test.ts
@@ -103,11 +103,30 @@ export function test(): number { let s=0; for (const v of g()) s+=v; return s; }
     ).toBe(6);
   });
 
-  // SF-4 (#2171) — non-numeric (string) yields.
-  it.todo("SF-4 #2171: string yields iterate 2 times", async () => {
+  // SF-4 (#2171) — non-numeric (string) yields. Landed in c3eb18936; the
+  // generator result/value slot is typed per the yield elem type (the native
+  // `$AnyString` ref for all-string generators), so string yields iterate and
+  // concatenate correctly with zero host imports.
+  it("SF-4 #2171: string yields iterate 2 times", async () => {
     expect(
       await runStandalone(`function* g(){ yield "a"; yield "b"; }
 export function test(): number { let n=0; for (const v of g()) n++; return n; }`),
     ).toBe(2);
+  });
+
+  it("SF-4 #2171: string yields concatenate to the right length", async () => {
+    // Value-correctness, not just count: "a"+"b" → "ab" (length 2). Exercises
+    // the per-yield string value flowing through the result `value` slot.
+    expect(
+      await runStandalone(`function* g(){ yield "a"; yield "b"; }
+export function test(): number { let s=""; for (const v of g()) s+=v; return s.length; }`),
+    ).toBe(2);
+  });
+
+  it("SF-4 #2171: first yielded char code is preserved", async () => {
+    expect(
+      await runStandalone(`function* g(){ yield "a"; yield "b"; }
+export function test(): number { let s=""; for (const v of g()) s+=v; return s.charCodeAt(0); }`),
+    ).toBe(97); // 'a'
   });
 });


### PR DESCRIPTION
## #2171 — non-numeric (string) yields in standalone native generators

The string-yield native generator feature (SF-4 of #2157) was **already
implemented and merged** in `c3eb18936` ("feat(#2171): string-yield native
generators in standalone"). The issue file, however, stayed at `status: ready`
(the impl commit didn't flip it) and the SF-4 acceptance test was still
`it.todo`. This PR reconciles that and adds value-correctness guards.

### Verified on `upstream/main` (zero host imports)
- `function* g(){ yield "a"; yield "b" }` — `for..of` iterates 2×
- `s += v` concatenation → `"ab"` (length 2, first char `'a'`)

### Changes (no source — feature already on main)
- Promote the SF-4 `it.todo` → live test; add two value-correctness guards
  (concat length, first char code).
- Reconcile the issue to `status: done` with a resolution note → `c3eb18936`.
- File **#2187** for the residual: a per-element string method on an
  `any`-typed loop var (TS infers `any` with no lib types) over a string
  generator routes through the generic externref path (`v.length` → 0) instead
  of the native `$AnyString` path. That is the #2072 value-rep concern (string
  method dispatch by local ValType when the TS type is `any`) — out of scope for
  SF-4's iterate+concat acceptance, which is met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)