### PR TITLE
fix(#2025): catchable TypeError for extracted this-using method

### DIFF
--- a/plan/issues/2025-extracted-method-trap-not-catchable-typeerror.md
+++ b/plan/issues/2025-extracted-method-trap-not-catchable-typeerror.md
@@ -1,10 +1,12 @@
 ---
 id: 2025
 title: "calling an extracted method (const f = a.m; f()) traps uncatchably instead of throwing catchable TypeError"
-status: ready
+status: done
+completed: 2026-06-17
+assignee: sd-b
 sprint: 63
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-17
 priority: low
 feasibility: medium
 reasoning_effort: medium
@@ -88,3 +90,43 @@ narrower and path-agnostic. Reference branch (preserved):
 Given #2025 is `priority: low`, this is parked back at `ready` pending a
 this-deref-site approach; not worth iterating against the invisible regressed
 cluster under the trampoline approach.
+
+## Attempt 2 — null-`this` arm in the trampoline, gated (sd-b, 2026-06-17) ✓
+
+Took the attempt-1 reviewer recommendation's intent (path-agnostic, no blanket
+trampoline throw) but kept it inside `buildTrampolineThisSlot` with two precise
+gates that attempt 1 lacked — which is why this does not reproduce the 75-test
+regression cluster:
+
+1. **Null-only, not ref.test-failure.** The trampoline resolves `this` from
+   `__current_this`. The throw fires ONLY when that global is genuinely
+   `ref.is_null` (the unbound-extraction case `const f = a.m; f()`, dispatched
+   via `__call_fn_N` which leaves the global null). A merely
+   structurally-different receiver (subclass/boxed instance — non-null global
+   that just doesn't `ref.test` as the exact struct, and the #2015
+   `__call_fn_method_N` dispatch which installs a real receiver) keeps the prior
+   `ref.null` passthrough UNCHANGED. Attempt 1 threw on the whole
+   ref.test-failure arm, which fired for those legitimate receivers.
+2. **Only methods that read `this`.** `methodBodyReadsThis` (a `local.get 0`
+   body scan) gates the throw, so `m(){ return 7 }` extraction still returns 7
+   (callable with a null receiver, matching JS) instead of throwing.
+
+The catchable TypeError uses the shared `$exc` tag + `__new_TypeError` (or the
+in-module WASI TypeError ctor under `--target standalone/wasi`). Helpers are
+registered at trampoline-build time; because that registration can add a late
+import that shifts defined-function indices, the forwarding `call methodFuncIdx`
+is bumped by the import delta at each build site (the body isn't yet attached to
+`ctx.mod.functions`, so the global shift-walker can't reach it), and
+`methodUsesThis` is captured PRE-shift and threaded through
+`pendingMethodTrampolines` so the finalize rebuild reuses it rather than
+re-scanning against a possibly-stale index.
+
+**Files:** `src/codegen/closures.ts` (`buildTrampolineThisSlot` null-`this` arm,
+`buildNullThisTypeErrorThrow`, `ensureNullThisTypeError`, `methodBodyReadsThis`,
+import-delta adjust + pending-record `methodUsesThis` at both trampoline build
+sites and the finalize rebuild), context type + create-context flag.
+
+**Tests:** `tests/issue-2025.test.ts` — this-using extraction throws catchably;
+non-this extraction returns its value; direct / `bind` / `call` receivers
+unchanged; object-literal extraction also covered. Regression-checked
+generators, method dispatch (#2015), #1366a/b builtin-subclass, #1602 coercion.

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -18,6 +18,10 @@ import { ts, forEachChild } from "../ts-api.js";
 import { isVoidType, unwrapPromiseType } from "../checker/type-mapper.js";
 import type { FieldDef, Instr, LocalDef, StructTypeDef, ValType } from "../ir/types.js";
 import { classMemberFuncKey } from "./class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
+import { addStringConstantGlobal } from "./registry/imports.js"; // (#2025)
+import { stringConstantExternrefInstrs } from "./native-strings.js"; // (#2025)
+import { noJsHost } from "./expressions/helpers.js"; // (#2025)
+import { emitWasiErrorConstructor } from "./registry/error-types.js"; // (#2025)
 import { pushBody } from "./context/bodies.js";
 import { reportError } from "./context/errors.js";
 import { reportSilentFallback } from "./fallback-telemetry.js";
@@ -3531,10 +3535,115 @@ export function emitFuncRefAsClosure(
  * trampoline. Emits a sequence leaving exactly one `(ref null objStructTypeIdx)`
  * on the stack.
  */
-function buildTrampolineThisSlot(ctx: CodegenContext, objStructTypeIdx: number, anyTempLocalIdx: number): Instr[] {
+/**
+ * (#2025) Message thrown when an extracted method (`const f = a.m; f()`) is
+ * called with no receiver — `this` is `undefined`. Matches the spirit of
+ * Node's "Cannot read properties of undefined".
+ */
+const NULL_THIS_TYPEERROR_MSG = "Cannot read properties of undefined (reading a class field)";
+
+/**
+ * (#2025) Eagerly register the `__new_TypeError` import + the message string
+ * the first time an extractable method-as-closure trampoline is built, so the
+ * trampoline's null-`this` arm can emit a CATCHABLE TypeError throw with
+ * stable, shift-tracked indices (no late-import registration during the
+ * fragile finalize rebuild). Idempotent. Requires a live `fctx` so the flush
+ * lands the deferred index shift onto the surrounding function being compiled.
+ */
+export function ensureNullThisTypeError(ctx: CodegenContext, fctx: FunctionContext | null): void {
+  if (ctx.nullThisTypeErrorReady) return;
+  // In no-JS-host mode, define `__new_TypeError` in-module (no env import).
+  if (noJsHost(ctx)) {
+    emitWasiErrorConstructor(ctx, "TypeError", 1);
+  }
+  addStringConstantGlobal(ctx, NULL_THIS_TYPEERROR_MSG);
+  ensureLateImportShared(ctx, "__new_TypeError", [{ kind: "externref" }], [{ kind: "externref" }]);
+  flushLateImportShiftsShared(ctx, fctx);
+  ensureExnTag(ctx);
+  ctx.nullThisTypeErrorReady = true;
+}
+
+/**
+ * (#2025) The catchable-TypeError throw sequence for a genuinely-absent
+ * receiver, or `null` when the helpers were not eagerly registered (in which
+ * case the trampoline falls back to the legacy `ref.null` passthrough rather
+ * than risk an unregistered call). Pure lookups — no registration, so it is
+ * safe to call from the finalize rebuild (post-body, pre-freeze).
+ */
+function buildNullThisTypeErrorThrow(ctx: CodegenContext): Instr[] | null {
+  if (!ctx.nullThisTypeErrorReady) return null;
+  const newTypeErrorIdx = ctx.funcMap.get("__new_TypeError");
+  if (newTypeErrorIdx === undefined || ctx.exnTagIdx < 0) return null;
+  return [
+    ...stringConstantExternrefInstrs(ctx, NULL_THIS_TYPEERROR_MSG),
+    { op: "call", funcIdx: newTypeErrorIdx } as Instr,
+    { op: "throw", tagIdx: ctx.exnTagIdx } as Instr,
+  ];
+}
+
+/**
+ * (#2025) Does the method's compiled body read its receiver (`this` = param 0)?
+ * A method that never touches `this` is safely callable with a null receiver
+ * (no struct.get on null), so the trampoline must NOT throw for it. We detect a
+ * `local.get 0` anywhere in the body (including nested blocks). Conservative:
+ * if the body isn't available yet (idx out of range), assume it does use `this`
+ * so we don't silently regress the trap→TypeError fix.
+ */
+function methodBodyReadsThis(ctx: CodegenContext, methodFuncIdx: number): boolean {
+  const localIdx = methodFuncIdx - ctx.numImportFuncs;
+  const fn = localIdx >= 0 ? ctx.mod.functions[localIdx] : undefined;
+  if (!fn || !Array.isArray(fn.body)) return true;
+  const walk = (instrs: Instr[]): boolean => {
+    for (const instr of instrs) {
+      if (instr.op === "local.get" && (instr as { index?: number }).index === 0) return true;
+      for (const key of ["body", "then", "else", "catchAll"] as const) {
+        const nested = (instr as Record<string, unknown>)[key];
+        if (Array.isArray(nested) && walk(nested as Instr[])) return true;
+      }
+      const catches = (instr as { catches?: { body?: Instr[] }[] }).catches;
+      if (Array.isArray(catches)) {
+        for (const c of catches) if (Array.isArray(c.body) && walk(c.body)) return true;
+      }
+    }
+    return false;
+  };
+  return walk(fn.body);
+}
+
+function buildTrampolineThisSlot(
+  ctx: CodegenContext,
+  objStructTypeIdx: number,
+  anyTempLocalIdx: number,
+  methodUsesThis: boolean,
+): Instr[] {
   const currentThisGlobalIdx = ensureCurrentThisGlobal(ctx);
   const nullThis: Instr[] = [{ op: "ref.null", typeIdx: objStructTypeIdx } as Instr];
   if (currentThisGlobalIdx < 0) return nullThis;
+  // (#2025) When the resolved `this` isn't the method's struct, distinguish a
+  // GENUINELY-ABSENT receiver (`__current_this` null — the unbound extraction
+  // `const f = a.m; f()`) from a merely structurally-different receiver (e.g. a
+  // subclass/boxed instance, where `__current_this` is non-null but doesn't
+  // `ref.test` as THIS exact struct). The first case is a spec TypeError; throw
+  // a CATCHABLE one instead of passing `ref.null` (which traps inside the
+  // method body on the first `this`-deref). The second case is left UNCHANGED
+  // (`ref.null` passthrough) — throwing there is what regressed PR #1571 (it
+  // fired for legitimate non-exact-struct receivers). Also only when the method
+  // actually READS `this` — a method that ignores its receiver (`m(){return 7}`)
+  // is callable with a null `this` (no deref, no trap), matching JS. Finally,
+  // only when the throw helpers were eagerly registered; else legacy passthrough.
+  const throwInstrs = methodUsesThis ? buildNullThisTypeErrorThrow(ctx) : null;
+  const elseArm: Instr[] = throwInstrs
+    ? [
+        { op: "local.get", index: anyTempLocalIdx } as Instr,
+        { op: "ref.is_null" } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "ref_null", typeIdx: objStructTypeIdx } },
+          then: throwInstrs, // genuinely no receiver → catchable TypeError
+          else: nullThis, // different struct → unchanged passthrough
+        } as unknown as Instr,
+      ]
+    : nullThis;
   return [
     { op: "global.get", index: currentThisGlobalIdx } as Instr,
     { op: "any.convert_extern" } as Instr,
@@ -3547,7 +3656,7 @@ function buildTrampolineThisSlot(ctx: CodegenContext, objStructTypeIdx: number, 
         { op: "local.get", index: anyTempLocalIdx } as Instr,
         { op: "ref.cast", typeIdx: objStructTypeIdx } as Instr,
       ],
-      else: nullThis,
+      else: elseArm,
     } as unknown as Instr,
   ];
 }
@@ -3604,7 +3713,24 @@ export function emitObjectMethodAsClosure(
   const trampolineName = `__obj_meth_tramp_${methodName}_${ctx.closureCounter++}`;
   // anyref temp at the first slot past the params (closure_self + userParams).
   const anyTempLocalIdx = 1 + userParams.length;
-  const trampolineBody: Instr[] = buildTrampolineThisSlot(ctx, objStructTypeIdx, anyTempLocalIdx);
+  // (#2025) Decide whether the method reads `this` BEFORE registering the
+  // TypeError helpers — `ensureNullThisTypeError` adds a late import that shifts
+  // defined-function indices, which would make `methodFuncIdx` stale for the
+  // body lookup. Then register the helpers (with a live fctx so the import-index
+  // flush lands here) so the null-`this` arm throws instead of trapping and
+  // finalize never registers an import mid-rebuild.
+  // (#2025) Capture this-usage, then register the TypeError throw helpers. The
+  // registration may add a late import that shifts every DEFINED function index
+  // up by `ntShift`; the forwarding `call methodFuncIdx` we emit just below is in
+  // a body not yet attached to `ctx.mod.functions`, so the import-shift walker
+  // can't reach it — bump the captured index by the delta ourselves (import
+  // targets, < the pre-shift import count, are never shifted).
+  const methodUsesThis = methodBodyReadsThis(ctx, methodFuncIdx);
+  const importsBeforeNT = ctx.numImportFuncs;
+  ensureNullThisTypeError(ctx, fctx);
+  const ntShift = ctx.numImportFuncs - importsBeforeNT;
+  if (ntShift > 0 && methodFuncIdx >= importsBeforeNT) methodFuncIdx += ntShift;
+  const trampolineBody: Instr[] = buildTrampolineThisSlot(ctx, objStructTypeIdx, anyTempLocalIdx, methodUsesThis);
   for (let i = 0; i < userParams.length; i++) {
     // Skip closure_self at param 0; user params start at index 1
     trampolineBody.push({ op: "local.get", index: i + 1 } as Instr);
@@ -3634,6 +3760,7 @@ export function emitObjectMethodAsClosure(
     userParamCount: userParams.length,
     wrapperUserParams: userParams,
     wrapperResult: results[0],
+    methodUsesThis, // (#2025) captured pre-shift; finalize reuses it
     // (#1809) Record whether the target is already an import at registration.
     // Import indices stay stable across late-import batches (new imports append
     // at the end, so indices < importsBefore are never shifted), so an import
@@ -3766,7 +3893,12 @@ export function finalizeMethodTrampolines(ctx: CodegenContext): void {
       newBody = [];
     } else {
       const anyTempLocalIdx = allocTempLocal(tFctx, { kind: "anyref" });
-      newBody = buildTrampolineThisSlot(ctx, t.objStructTypeIdx, anyTempLocalIdx);
+      // (#2025) Reuse the registration-time `methodUsesThis` (captured before
+      // the TypeError-helper import shifted function indices, so it is reliable
+      // here where `t.methodFuncIdx` may be stale). Fall back to a fresh body
+      // scan only when it wasn't recorded.
+      const usesThis = t.methodUsesThis ?? methodBodyReadsThis(ctx, t.methodFuncIdx);
+      newBody = buildTrampolineThisSlot(ctx, t.objStructTypeIdx, anyTempLocalIdx, usesThis);
     }
     for (let i = 0; i < methodUserParams.length; i++) {
       newBody.push({ op: "local.get", index: i + 1 } as Instr);
@@ -3908,7 +4040,20 @@ export function emitCachedMethodClosureAccess(
     // null receiver propagates the spec-mandated TypeError on `this.field`
     // access), then forward user params, then call the method.
     const anyTempLocalIdx = 1 + userParams.length;
-    const trampolineBody: Instr[] = buildTrampolineThisSlot(ctx, objStructTypeIdx, anyTempLocalIdx);
+    // (#2025) Capture this-usage, register the throw helpers, then adjust the
+    // forwarding index by any import-shift the registration caused (see the
+    // matching note in emitObjectMethodAsClosure).
+    const methodUsesThisCached = methodBodyReadsThis(ctx, methodFuncIdx);
+    const importsBeforeNT = ctx.numImportFuncs;
+    ensureNullThisTypeError(ctx, fctx);
+    const ntShift = ctx.numImportFuncs - importsBeforeNT;
+    if (ntShift > 0 && methodFuncIdx >= importsBeforeNT) methodFuncIdx += ntShift;
+    const trampolineBody: Instr[] = buildTrampolineThisSlot(
+      ctx,
+      objStructTypeIdx,
+      anyTempLocalIdx,
+      methodUsesThisCached,
+    );
     for (let i = 0; i < userParams.length; i++) {
       trampolineBody.push({ op: "local.get", index: i + 1 } as Instr);
     }
@@ -3943,6 +4088,7 @@ export function emitCachedMethodClosureAccess(
       userParamCount: userParams.length,
       wrapperUserParams: userParams,
       wrapperResult: results[0],
+      methodUsesThis: methodUsesThisCached, // (#2025) captured pre-shift
       // (#1809) See the per-call-site push for rationale.
       methodTargetsImport: methodFuncIdx < ctx.numImportFuncs,
     });

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -190,6 +190,7 @@ export function createCodegenContext(
     classStaticMethodsCsvGlobal: new Map(),
     builtinObjectGlobals: new Map(),
     methodClosureGlobals: new Map(),
+    nullThisTypeErrorReady: false, // (#2025)
     funcClosureGlobals: new Map(),
     wasi: options?.wasi ?? false,
     standalone: options?.standalone ?? false,

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1115,6 +1115,14 @@ export interface CodegenContext {
      * function at registration resolves to an import at finalize.
      */
     methodTargetsImport?: boolean;
+    /**
+     * (#2025) Whether the method body reads `this` (param 0), computed at
+     * registration BEFORE the TypeError-helper late import shifts function
+     * indices (which would make a finalize-time `methodFuncIdx` lookup point at
+     * the wrong function). Finalize reuses this captured value to decide whether
+     * the trampoline's null-`this` arm throws a catchable TypeError.
+     */
+    methodUsesThis?: boolean;
   }[];
   /** True if Math.clz32 or Math.imul is used — requires ToUint32 Wasm helper */
   needsToUint32: boolean;
@@ -1189,6 +1197,14 @@ export interface CodegenContext {
    *  `__obj_meth_tramp_${className}_${methodName}_cached` and is also reused
    *  across all access sites to avoid bloating mod.functions. */
   methodClosureGlobals: Map<string, number>;
+  /**
+   * (#2025) Once an extractable method-as-closure trampoline is emitted, the
+   * `__new_TypeError` import + message string are registered eagerly so the
+   * trampoline's null-`this` arm can throw a CATCHABLE TypeError (instead of
+   * trapping on a null `struct.get`) with stable, shift-tracked indices.
+   * Pure-lookup after that — the trampoline never registers mid-finalize.
+   */
+  nullThisTypeErrorReady: boolean;
   /** (#1340) Singleton closure-struct externref globals for top-level function
    *  declarations used as first-class values. Keyed by function name. Ensures
    *  `foo === foo` and so sidecar writes on `foo.prototype` are observed by

--- a/tests/issue-2025.test.ts
+++ b/tests/issue-2025.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { compileAndInstantiate } from "../src/runtime-instantiate.js";
+
+// (#2025) Calling an extracted method whose body reads `this`
+// (`const f = a.m; f()`) used to TRAP uncatchably ("dereferencing a null
+// pointer") because the extraction trampoline passed a `ref.null` receiver and
+// the method's `struct.get this` trapped. JS spec throws a *catchable*
+// TypeError there (`this` is undefined). The fix makes the trampoline detect a
+// GENUINELY-absent receiver and throw a catchable TypeError — only for methods
+// that actually read `this`, and only for a truly-null receiver (a merely
+// structurally-different receiver keeps its prior behaviour, which is what
+// regressed the earlier trampoline-throw attempt #1571).
+
+async function run<T = unknown>(src: string, fn: string): Promise<T> {
+  const exports = (await compileAndInstantiate(src)) as Record<string, () => T>;
+  return exports[fn]!();
+}
+
+describe("#2025 extracted-method null-this", () => {
+  it("extracted this-using method throws a CATCHABLE TypeError (not a trap)", async () => {
+    const src = `
+      class A { x: number = 42; m(): number { return this.x; } }
+      export function t(): string {
+        const a = new A();
+        const f = a.m;
+        try { return "got:" + f(); } catch (e) { return "threw"; }
+      }
+    `;
+    expect(await run<string>(src, "t")).toBe("threw");
+  });
+
+  it("extracted method that ignores `this` still runs (no spurious throw)", async () => {
+    const src = `
+      class A { m(): number { return 7; } }
+      export function t(): number { const a = new A(); const f = a.m; return f(); }
+    `;
+    expect(await run<number>(src, "t")).toBe(7);
+  });
+
+  it("direct method call is unchanged", async () => {
+    const src = `
+      class A { x: number = 5; m(): number { return this.x; } }
+      export function t(): number { return new A().m(); }
+    `;
+    expect(await run<number>(src, "t")).toBe(5);
+  });
+
+  it("bound extraction (a.m.bind(a)) is unchanged", async () => {
+    const src = `
+      class A { x: number = 9; m(): number { return this.x; } }
+      export function t(): number { const a = new A(); const f = a.m.bind(a); return f(); }
+    `;
+    expect(await run<number>(src, "t")).toBe(9);
+  });
+
+  it("extracted this-using method that is then re-bound via call() works", async () => {
+    const src = `
+      class A { x: number = 11; m(): number { return this.x; } }
+      export function t(): number { const a = new A(); const f = a.m; return f.call(a); }
+    `;
+    expect(await run<number>(src, "t")).toBe(11);
+  });
+
+  it("object-literal extracted method reading `this` throws catchably", async () => {
+    const src = `
+      const o = { v: 3, m(): number { return this.v; } };
+      export function t(): string {
+        const f = o.m;
+        try { return "got:" + f(); } catch (e) { return "threw"; }
+      }
+    `;
+    expect(await run<string>(src, "t")).toBe("threw");
+  });
+});


### PR DESCRIPTION
## #2025 — extracted method trap escapes try/catch

```ts
class A { x = 42; m(): number { return this.x; } }
const a = new A(); const f = a.m;
try { return "got:" + f(); } catch (e) { return "threw"; }
// before: trap "dereferencing a null pointer" escapes try/catch
// node:   "threw" (TypeError: this is undefined)
// after:  "threw" ✓
```

The method-extraction trampoline passed `ref.null` for `this`, so the method's
`struct.get this` trapped uncatchably.

## Fix

In `buildTrampolineThisSlot`, throw a **catchable** TypeError instead of passing
a null receiver — but only under two precise gates, which is why this avoids the
75-test regression cluster of the earlier trampoline-throw attempt (#1571):

1. **Genuinely-null receiver only** — throw only when `__current_this` is
   `ref.is_null` (true unbound extraction). A non-null receiver that merely
   isn't the exact struct (subclass/boxed, and the #2015 method-dispatch path)
   keeps its prior `ref.null` passthrough unchanged.
2. **Method reads `this`** — `methodBodyReadsThis` gates the throw, so
   `m(){return 7}` extraction still returns 7.

Helpers (`__new_TypeError` + message) registered at trampoline-build time;
forwarding `call` index adjusted for the resulting import shift, and the
this-usage flag captured pre-shift + threaded to the finalize rebuild.

## Tests

`tests/issue-2025.test.ts`: this-using extraction throws catchably; non-this
extraction returns its value; direct / `bind` / `call` receivers unchanged;
object-literal extraction covered.

Closes #2025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)