### PR TITLE
fix(#1536c): standalone-native user Error subclass (zero host imports)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,7 +339,7 @@ The issue frontmatter `status:` field tracks where an issue is, set by whichever
 3. Update `plan/issues/backlog/backlog.md` if the issue was listed there
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,353 / 43,135 (72.7 %) — baseline a3fd74c7, 2026-06-16T10:35:16Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
 <!-- AUTO:conformance-end -->
 
 ### Sprint History

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ STATUS.md rather than duplicating numbers that go stale. Standalone
 README until the current standalone regression is fixed.
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,353 / 43,135 (72.7 %) — baseline a3fd74c7, 2026-06-16T10:35:16Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
 <!-- AUTO:conformance-end -->
 
 ## Current Status

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ Over 31 development sprints and **784 closed issues**, js2wasm has grown from a 
 ### Conformance
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,353 / 43,135 (72.7 %) — baseline a3fd74c7, 2026-06-16T10:35:16Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
 <!-- AUTO:conformance-end -->
 
 - Automated conformance tracking with historical trend data and a public [conformance report](https://loopdive.github.io/js2wasm/benchmarks/report.html)

--- a/plan/goals/goal-graph.md
+++ b/plan/goals/goal-graph.md
@@ -5,7 +5,7 @@ Unlike a linear roadmap, multiple independent goals can be worked on in parallel
 and a goal being "ready" doesn't mean it should be worked on immediately.
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,353 / 43,135 (72.7 %) — baseline a3fd74c7, 2026-06-16T10:35:16Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
 <!-- AUTO:conformance-end -->
 
 ## DAG

--- a/plan/issues/1536c-standalone-native-user-error-subclass.md
+++ b/plan/issues/1536c-standalone-native-user-error-subclass.md
@@ -1,10 +1,12 @@
 ---
 id: 1536c
 title: "standalone-native user Error subclass: instance creation via __new_<Parent> + native instanceof tag chain (no host imports)"
-status: ready
+status: done
+completed: 2026-06-17
+assignee: sendev-closures
 sprint: 63
 created: 2026-06-16
-updated: 2026-06-16
+updated: 2026-06-17
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -81,3 +83,44 @@ regression. The architect's plan explicitly sanctioned splitting it here.
 Route to **senior-developer**. Gated `ctx.wasi || ctx.standalone`; JS-host path
 untouched. Local checks: `tsc --noEmit` + a `tests/issue-1536c.test.ts` that
 asserts the three standalone behaviors above with an env-import assertion.
+
+## Resolution (2026-06-17)
+
+All acceptance criteria pass under `--target standalone` with **zero `env::`
+imports**; JS-host mode unchanged. Three gated change-sites (all
+`ctx.wasi || ctx.standalone`):
+
+1. **Instance creation** — `src/codegen/class-bodies.ts`, both the implicit
+   derived-ctor block (`!ctor && isExternrefBacked`) and `compileSuperCall`:
+   when the externref-backed subclass's builtin parent is a WASI error name,
+   emit the native `__new_<Parent>` internal function via
+   `emitWasiErrorConstructor(ctx, parent, arity)` and call it from `ctx.funcMap`
+   instead of `ensureLateImport` (the host import). Produces a real
+   `$Error_struct` (parent `$tag`, `.message`, `.name`). JS-host keeps the
+   import.
+2. **`instanceof`** — `src/codegen/expressions/identifiers.ts`: the host
+   `__tag_user_class` tagging block (`class-bodies.ts`) is skipped standalone;
+   `instance instanceof MyError` / `instanceof Error` resolve natively. The
+   `$Error_struct` `$tag`-discrimination path (#1473) now also fires for a
+   user class whose builtin parent is an error (`userErrorParent`), using the
+   parent's `collectErrorInstanceOfTags` set — guarded by `ref.test
+   $Error_struct` so a non-Error value yields `false`.
+3. **`.message`/`.name`/`.stack`** — `src/codegen/property-access.ts`: the
+   native struct-field read fast-path (`isErrorLhs`) now also treats a
+   user-Error-subclass receiver (`classBuiltinParentMap` → error) as an Error
+   LHS, reading `$Error_struct` fields directly instead of the generic
+   `__extern_get` host path (which returns null standalone).
+
+Verified (`tests/issue-1536c.test.ts`, 7 cases): `new MyError("boom").message`
+=== "boom"; `instanceof Error`/`instanceof MyError` true; non-Error not an
+instance; explicit `super(m)` ctor; `class MyTE extends TypeError` chains to
+both `TypeError` and `Error`. Host mode spot-checked unchanged. Typecheck +
+IR-fallback gate clean.
+
+**Precision note (follow-up #2188):** `instance instanceof MyError` resolves to
+"is an Error-family struct compatible with MyError's *builtin parent*" — exact
+for a single subclass, but two distinct `extends Error` siblings are not
+mutually distinguished (both share the parent `$tag`). Full per-user-class
+discrimination needs a brand on the instance (the `$ClassMeta`/`$parentTag`
+work, #2101). Filed as #2188; out of scope for #1536c's single-subclass
+acceptance.

--- a/plan/issues/2188-standalone-sibling-error-subclass-instanceof-precision.md
+++ b/plan/issues/2188-standalone-sibling-error-subclass-instanceof-precision.md
@@ -1,0 +1,69 @@
+---
+id: 2188
+title: "standalone: sibling Error subclasses share the parent $tag — instanceof can't distinguish them (per-user-class brand)"
+status: ready
+sprint: Backlog
+created: 2026-06-17
+updated: 2026-06-17
+priority: low
+feasibility: hard
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: errors, classes
+goal: standalone-mode
+related: [1536c, 1536, 1455, 2101]
+origin: "2026-06-17 — precision residual found while closing #1536c (standalone user Error subclass)"
+---
+
+# #2188 — standalone Error-subclass instanceof precision
+
+## Problem
+
+`#1536c` made `class MyError extends Error {}` instantiate and resolve
+`instanceof` natively in standalone (zero host imports). The instance is the
+parent's `$Error_struct`, discriminated by the parent's `$tag`. That is exact
+for a single subclass, but **two distinct `extends Error` siblings share the
+same parent `$tag`**, so `instanceof` cannot tell them apart:
+
+```ts
+class A extends Error {}
+class B extends Error {}
+export function test(): number {
+  return (new A("x")) instanceof B ? 1 : 0;  // standalone wasm: 1   node: 0
+}
+```
+
+(`#1536c`'s acceptance — single subclass, `instanceof Self`/`instanceof Parent`
+— is correct; this is the sibling-disambiguation residual.)
+
+## Root cause
+
+`emitWasiErrorConstructor`'s `$Error_struct` carries the **builtin** type tag
+(`Error` / `TypeError` / …), not a per-user-class brand. The standalone
+instanceof path (identifiers.ts, `userErrorParent`, #1536c) compares against the
+parent's `collectErrorInstanceOfTags` set, which is identical for every direct
+subclass of the same builtin error.
+
+## Fix direction
+
+Give externref-backed user Error subclasses a **per-class brand** on the
+instance (or a `$ClassMeta`/`$parentTag` slot) so `instanceof Sub` checks the
+brand chain, not only the builtin parent tag. This is the `$ClassMeta` /
+`$parentTag` externref-backed-subclass discrimination work tracked under #2101;
+#1536c deliberately used the coarser parent-tag check to ship the
+single-subclass case host-free. Coordinate with #2101 and the host-mode
+`__tag_user_class` chain (#1455) so JS-host and standalone agree.
+
+## Acceptance criteria
+
+- `class A extends Error {}; class B extends Error {}; (new A()) instanceof B`
+  → `false` (standalone), `(new A()) instanceof A` → `true`,
+  `(new A()) instanceof Error` → `true`.
+- Multi-level user chains (`class C extends A {}`) resolve correctly.
+- #1536c single-subclass tests stay green; JS-host mode unaffected.
+
+## Notes
+
+Split from #1536c (single-subclass standalone Error subclass — `done`). See
+#1536c's `## Resolution` and #2101 for the brand machinery.

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -31,6 +31,7 @@ import {
 } from "./index.js";
 import { emitUndefined } from "./expressions/late-imports.js";
 import { addStringConstantGlobal, ensureExnTag, nextModuleGlobalIdx } from "./registry/imports.js";
+import { emitWasiErrorConstructor, isWasiErrorName } from "./registry/error-types.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
 import {
   cacheParamDefaultArgc,
@@ -1500,8 +1501,20 @@ function compileClassBodiesInner(
       if (parentName) {
         const importName = `__new_${parentName}`;
         const forwardParams = externrefParams(implicitForwarderArity);
-        const funcIdx = ensureLateImport(ctx, importName, forwardParams, [{ kind: "externref" }]);
-        flushLateImportShifts(ctx, fctx);
+        // (#1536c) Standalone / WASI: route the parent instance creation through
+        // the native `__new_<Parent>` internal function (a real `$Error_struct`
+        // with the parent's `$tag`, `.message`, `.name`) instead of a host
+        // import, so `class MyError extends Error {}` instantiates with zero
+        // env:: imports. The native function is emitted idempotently and
+        // registered in `ctx.funcMap`. JS-host mode keeps the host import.
+        let funcIdx: number | undefined;
+        if ((ctx.wasi || ctx.standalone) && isWasiErrorName(parentName)) {
+          emitWasiErrorConstructor(ctx, parentName, implicitForwarderArity);
+          funcIdx = ctx.funcMap.get(importName);
+        } else {
+          funcIdx = ensureLateImport(ctx, importName, forwardParams, [{ kind: "externref" }]);
+          flushLateImportShifts(ctx, fctx);
+        }
         if (funcIdx !== undefined) {
           for (let i = 0; i < implicitForwarderArity; i++) {
             fctx.body.push({ op: "local.get", index: i });
@@ -1648,7 +1661,12 @@ function compileClassBodiesInner(
     // `instance instanceof Sub` by walking the registered tag chain. The
     // direct user-class parent (or null when the direct parent is a builtin)
     // is registered idempotently on first call.
-    if (isExternrefBacked) {
+    // (#1536c) Skipped under standalone / WASI: `__tag_user_class` is a JS host
+    // import (it would leak `env::__tag_user_class` and fail to instantiate).
+    // Standalone resolves `instance instanceof Sub`/`Parent` natively via the
+    // `$Error_struct` `$tag` discrimination (identifiers.ts) — no host tagging
+    // needed.
+    if (isExternrefBacked && !(ctx.wasi || ctx.standalone)) {
       const builtinParent = ctx.classBuiltinParentMap.get(className);
       // Direct user-class parent: classParentMap[className] is set to the
       // immediate parent name; if it equals the builtin parent, the user
@@ -2264,8 +2282,17 @@ export function compileSuperCall(
     const importName = `__new_${builtinParent}`;
     const forwardArity = getBuiltinConstructorForwardArity(ctx, builtinParent);
     const forwardParams = externrefParams(forwardArity);
-    const funcIdx = ensureLateImport(ctx, importName, forwardParams, [{ kind: "externref" }]);
-    flushLateImportShifts(ctx, fctx);
+    // (#1536c) Standalone / WASI: emit the native `__new_<Parent>` internal
+    // function (real `$Error_struct`) and call it instead of a host import, so
+    // `super(msg)` in a user Error subclass works with zero env:: imports.
+    let funcIdx: number | undefined;
+    if ((ctx.wasi || ctx.standalone) && isWasiErrorName(builtinParent)) {
+      emitWasiErrorConstructor(ctx, builtinParent, forwardArity);
+      funcIdx = ctx.funcMap.get(importName);
+    } else {
+      funcIdx = ensureLateImport(ctx, importName, forwardParams, [{ kind: "externref" }]);
+      flushLateImportShifts(ctx, fctx);
+    }
     if (funcIdx !== undefined) {
       const flatArgs = hasSpread ? flattenStaticallyKnownArgs(args) : [...args];
       if (flatArgs) {

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -1107,7 +1107,23 @@ function compileHostInstanceOf(ctx: CodegenContext, fctx: FunctionContext, expr:
     return emitConstantInstanceOf(ctx, fctx, expr, staticResult);
   }
 
-  if (ts.isIdentifier(expr.right) && !isBuiltinTypeName(ctorName) && identifierHasSourceDeclaration(ctx, expr.right)) {
+  // (#1536c) Standalone / WASI: `instance instanceof MyError` where
+  // `class MyError extends Error {}` is an externref-backed user subclass. The
+  // instance is the parent's `$Error_struct` (created natively by
+  // `__new_<Parent>`, #1536c), so discriminate by the parent error's `$tag`
+  // set — natively, no `__instanceof`/`__tag_user_class` host import. Run this
+  // BEFORE the generic `emitDynamicInstanceOf` route below, which would emit a
+  // host import. Precision note: this resolves `instanceof MyError` to "is an
+  // Error-family struct compatible with MyError's builtin parent" — exact for a
+  // single subclass; distinguishing sibling subclasses needs a per-user-class
+  // brand (broader $ClassMeta work, #2101). Captured in #1536c's resolution.
+  let userErrorParent: string | undefined;
+  if (noJsHost(ctx) && !isBuiltinTypeName(ctorName)) {
+    const bp = ctx.classBuiltinParentMap.get(ctorName);
+    if (bp && (bp === "Error" || isWasiErrorName(bp))) userErrorParent = bp;
+  }
+
+  if (ts.isIdentifier(expr.right) && !isBuiltinTypeName(ctorName) && identifierHasSourceDeclaration(ctx, expr.right) && userErrorParent === undefined) {
     return emitDynamicInstanceOf(ctx, fctx, expr);
   }
 
@@ -1116,8 +1132,10 @@ function compileHostInstanceOf(ctx: CodegenContext, fctx: FunctionContext, expr:
   // `$Error_struct` externref produced by emitWasiErrorConstructor; discriminate
   // by reading its `$tag` field (fieldIdx 0) and comparing against the set of
   // tags compatible with `ctorName`. No `__instanceof` host import.
-  if (noJsHost(ctx) && (ctorName === "Error" || isWasiErrorName(ctorName))) {
-    const compatTags = collectErrorInstanceOfTags(ctorName);
+  // (#1536c) `userErrorParent` extends this to externref-backed user Error
+  // subclasses: discriminate against the *parent* error's compatible tag set.
+  if (noJsHost(ctx) && (ctorName === "Error" || isWasiErrorName(ctorName) || userErrorParent !== undefined)) {
+    const compatTags = collectErrorInstanceOfTags(userErrorParent ?? ctorName);
     const structIdx = getOrRegisterErrorStructType(ctx);
     const leftType = compileExpression(ctx, fctx, expr.left);
     if (leftType && leftType.kind !== "externref") {

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -1123,7 +1123,12 @@ function compileHostInstanceOf(ctx: CodegenContext, fctx: FunctionContext, expr:
     if (bp && (bp === "Error" || isWasiErrorName(bp))) userErrorParent = bp;
   }
 
-  if (ts.isIdentifier(expr.right) && !isBuiltinTypeName(ctorName) && identifierHasSourceDeclaration(ctx, expr.right) && userErrorParent === undefined) {
+  if (
+    ts.isIdentifier(expr.right) &&
+    !isBuiltinTypeName(ctorName) &&
+    identifierHasSourceDeclaration(ctx, expr.right) &&
+    userErrorParent === undefined
+  ) {
     return emitDynamicInstanceOf(ctx, fctx, expr);
   }
 

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -1745,11 +1745,21 @@ export function compilePropertyAccess(
   // (`null.message` throws), so the trap is acceptable Phase 1/2 semantics.
   if ((ctx.wasi || ctx.standalone) && (propName === "message" || propName === "name" || propName === "stack")) {
     const lhsTsName = objType.getSymbol()?.name;
+    // (#1536c) A user subclass of a built-in Error (`class MyError extends
+    // Error {}`) is externref-backed; its instance is the parent's
+    // `$Error_struct` (created natively by `__new_<Parent>`). Treat it as an
+    // Error LHS so `.message`/`.name`/`.stack` read the struct field directly
+    // instead of the generic `__extern_get` host path (unavailable standalone,
+    // returns null). The struct field layout is the parent's.
+    const lhsUserErrorParent =
+      lhsTsName !== undefined && !isBuiltinTypeName(lhsTsName) ? ctx.classBuiltinParentMap.get(lhsTsName) : undefined;
     const isErrorLhs =
-      lhsTsName !== undefined &&
-      isBuiltinTypeName(lhsTsName) &&
-      isWasiErrorName(lhsTsName) &&
-      isBuiltinSubtype(lhsTsName, "Error");
+      (lhsTsName !== undefined &&
+        isBuiltinTypeName(lhsTsName) &&
+        isWasiErrorName(lhsTsName) &&
+        isBuiltinSubtype(lhsTsName, "Error")) ||
+      (lhsUserErrorParent !== undefined &&
+        (lhsUserErrorParent === "Error" || isWasiErrorName(lhsUserErrorParent)));
     // #2077: a `catch (e)` binding is typed `any` (or `unknown`), so the static
     // `isErrorLhs` gate above never fires even though the caught value IS the
     // `$Error` struct at runtime — the field read then fell through to the

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -1839,8 +1839,7 @@ export function compilePropertyAccess(
         isBuiltinTypeName(lhsTsName) &&
         isWasiErrorName(lhsTsName) &&
         isBuiltinSubtype(lhsTsName, "Error")) ||
-      (lhsUserErrorParent !== undefined &&
-        (lhsUserErrorParent === "Error" || isWasiErrorName(lhsUserErrorParent)));
+      (lhsUserErrorParent !== undefined && (lhsUserErrorParent === "Error" || isWasiErrorName(lhsUserErrorParent)));
     // #2077: a `catch (e)` binding is typed `any` (or `unknown`), so the static
     // `isErrorLhs` gate above never fires even though the caught value IS the
     // `$Error` struct at runtime — the field read then fell through to the

--- a/tests/issue-1536c.test.ts
+++ b/tests/issue-1536c.test.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1536c — a user subclass of a built-in Error (`class MyError extends Error {}`)
+// must compile, instantiate, and run under `--target standalone` with ZERO
+// `env::` host imports.
+//
+// Before: the externref-backed subclass routed instance creation through the
+// `__new_<Parent>` JS host import and `instanceof` through `__tag_user_class` +
+// `__instanceof` host imports — so standalone leaked `env::__new_Error` /
+// `env::__tag_user_class` and failed to instantiate.
+//
+// Fix (gated `ctx.wasi || ctx.standalone`; JS-host path untouched):
+//  1. Instance creation (implicit derived ctor + `compileSuperCall`,
+//     `class-bodies.ts`) emits the native `__new_<Parent>` internal function
+//     (`emitWasiErrorConstructor`) and calls it — a real `$Error_struct` with
+//     the parent `$tag`, `.message`, `.name`.
+//  2. The host `__tag_user_class` tagging is skipped standalone; `instanceof`
+//     resolves natively via the `$Error_struct` `$tag` set — both
+//     `instanceof MyError` and `instanceof Error` (identifiers.ts).
+//  3. `.message`/`.name`/`.stack` on a user-Error-subclass receiver read the
+//     `$Error_struct` field directly (property-access.ts), not the generic
+//     `__extern_get` host path.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/** Compile standalone, assert zero host imports, instantiate, return test(). */
+async function runStandalone<T = number>(src: string): Promise<T> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const imports = WebAssembly.Module.imports(mod).map((i) => `${i.module}::${i.name}`);
+  expect(imports, "standalone module must have zero host imports").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): T }).test();
+}
+
+describe("#1536c user Error subclass — standalone (zero host imports)", () => {
+  it("new MyError(msg).message reads back correctly", async () => {
+    // length + char code, since the standalone string is an opaque $AnyString.
+    expect(
+      await runStandalone(`class MyError extends Error {}
+        export function test(): number { return new MyError("boom").message.length; }`),
+    ).toBe(4);
+    expect(
+      await runStandalone(`class MyError extends Error {}
+        export function test(): number { return new MyError("boom").message.charCodeAt(0); }`),
+    ).toBe(98); // 'b'
+  });
+
+  it("new MyError(msg).message === literal", async () => {
+    expect(
+      await runStandalone(`class MyError extends Error {}
+        export function test(): number { return new MyError("boom").message === "boom" ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("instance instanceof Error is true (subtype of built-in parent)", async () => {
+    expect(
+      await runStandalone(`class MyError extends Error {}
+        export function test(): number { return (new MyError("x")) instanceof Error ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("instance instanceof MyError is true (user subclass)", async () => {
+    expect(
+      await runStandalone(`class MyError extends Error {}
+        export function test(): number { return (new MyError("x")) instanceof MyError ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("a non-Error value is NOT instanceof MyError", async () => {
+    expect(
+      await runStandalone(`class MyError extends Error {}
+        export function test(): number { const o = { x: 1 }; return (o as any) instanceof MyError ? 1 : 0; }`),
+    ).toBe(0);
+  });
+
+  it("explicit constructor with super(msg) works standalone", async () => {
+    expect(
+      await runStandalone(`class MyError extends Error { constructor(m: string) { super(m); } }
+        export function test(): number { return new MyError("hello").message.length; }`),
+    ).toBe(5);
+    expect(
+      await runStandalone(`class MyError extends Error { constructor(m: string) { super(m); } }
+        export function test(): number { return (new MyError("x")) instanceof MyError ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("subclass of a non-Error built-in error (TypeError) chains both ways", async () => {
+    expect(
+      await runStandalone(`class MyTE extends TypeError {}
+        export function test(): number { return (new MyTE("x")) instanceof TypeError ? 1 : 0; }`),
+    ).toBe(1);
+    expect(
+      await runStandalone(`class MyTE extends TypeError {}
+        export function test(): number { return (new MyTE("x")) instanceof Error ? 1 : 0; }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## #1536c — `class MyError extends Error {}` must run standalone

An externref-backed user subclass of a built-in Error leaked
`env::__new_Error` + `env::__tag_user_class` under `--target standalone`/`wasi`
and failed to instantiate. This makes the whole surface host-free. **All
changes gated `ctx.wasi || ctx.standalone`; JS-host path untouched.**

### Three change-sites
1. **Instance creation** (`class-bodies.ts`, implicit derived ctor +
   `compileSuperCall`): emit the native `__new_<Parent>` internal function
   (`emitWasiErrorConstructor`) and call it from `funcMap` instead of
   `ensureLateImport` — a real `$Error_struct` (parent `$tag`, `.message`,
   `.name`) instead of the broken single-arg fallback.
2. **`instanceof`** (`identifiers.ts`): host `__tag_user_class` tagging skipped
   standalone; the `$Error_struct` `$tag`-discrimination path (#1473) now also
   fires for a user class whose builtin parent is an error, guarded by
   `ref.test $Error_struct` (non-Error → false).
3. **`.message`/`.name`/`.stack`** (`property-access.ts`): native struct-field
   read fast-path now treats a user-Error-subclass receiver as an Error LHS,
   reading the field directly instead of the generic `__extern_get` host path.

### Acceptance (standalone, zero `env::` imports)
- `new MyError("boom").message === "boom"` ✓
- `new MyError("x") instanceof Error` / `instanceof MyError` ✓; non-Error → false ✓
- explicit `constructor(m){ super(m); }` ✓
- `class MyTE extends TypeError {}` chains to both `TypeError` and `Error` ✓

### Tests / checks
`tests/issue-1536c.test.ts` (7 cases). Host mode spot-checked unchanged.
Typecheck + IR-fallback gate clean. (Pre-existing `instanceof.test.ts` /
`issue-1455.test.ts` failures on `main` are unrelated host-mode `env:{}`
breakage — reproduced identically without this change.)

### Scope
Sibling-subclass `instanceof` precision (two `extends Error` classes share the
parent `$tag`) split to **#2188** — needs a per-user-class brand (`$ClassMeta`,
#2101). Out of scope for #1536c's single-subclass acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)