### PR TITLE
fix(#1694): compiled-fn capability constructor for Promise combinators (A.i / #1632b-1)

### DIFF
--- a/plan/issues/1632-spec-gap-function-bind-tostring-internals.md
+++ b/plan/issues/1632-spec-gap-function-bind-tostring-internals.md
@@ -472,9 +472,20 @@ sentinel — a host-side `try` around `inst.exports.go()` is unreliable.
 
 ## Suggested split
 
-- **#1632b-1** (closes #1694 A.i, dev-appropriate once specced): steps 1–3 +
-  the ordinary-`[[Construct]]` fallback (sub-case 2). No codegen change — pure
-  `src/runtime.ts`. This alone flips the A.i `NotPromise` family.
+- **#1632b-1** ✅ **DONE 2026-06-17** (closes #1694 A.i, shipped with the #1694
+  PR): `_wrapCallableForHost` + `_hostCallableCache` in `src/runtime.ts`
+  (a `Proxy` over a real `function` target with `apply`/`construct` traps that
+  dispatch through `_wrapWasmClosureUnknownArity`; all other traps delegate to
+  the existing `_wrapForHost(closure)` proxy, so no extraction of `_wrapForHost`
+  was needed — lower risk than the spec's step-1 option). The `construct` trap
+  implements the ordinary-`[[Construct]]` fallback (sub-case 2). Hooked into
+  `_resolveCtor` for `directCall === 0` + `__is_closure === 1`. No codegen
+  change. The A.i `NotPromise` capability-constructor family is flipped; the
+  `ctx-non-object`/`ctx-non-ctor` TypeErrors and the B/A.ii subclass paths are
+  preserved. See `plan/issues/1694-promise-subclass-capability.md`
+  "Implemented #1632b-1".
 - **#1632b-2** (compiled-class-as-dynamic-ctor, needs codegen): step 4
   (`__construct_closure` export). Only if test262 evidence shows a
   compiled-*class* reaching a dynamic construct site uncovered by #1682.
+  Still open — out of scope for the #1694 PR (A.i's `NotPromise` is an
+  ordinary function, not a class).

--- a/plan/issues/1694-promise-subclass-capability.md
+++ b/plan/issues/1694-promise-subclass-capability.md
@@ -1,9 +1,11 @@
 ---
 id: 1694
 title: "Promise.any/all/allSettled/race: non-Promise capability `this` + extends-Promise codegen (~50 fails)"
-status: ready
+status: done
+assignee: ttraenkler/cs-1694
 created: 2026-05-28
-updated: 2026-06-03
+updated: 2026-06-17
+completed: 2026-06-17
 revalidated: 2026-06-03
 priority: medium
 feasibility: hard
@@ -208,3 +210,64 @@ combinator hook is in `_resolveCtor` (runtime.ts:7822): for the
 `.call(closure, …)` case it must return `_wrapCallableForHost(thisArg,
 exports)` so V8's `NewPromiseCapability(C)` can `Construct(C, [executor])`.
 Sub-task **#1632b-1** (runtime-only, no codegen) closes this A.i family.
+
+## Implemented #1632b-1 (2026-06-17, senior-developer cs-1694) — A.i closed
+
+The sole genuine remaining gap (A.i — a **compiled function** used as the
+capability constructor) is now fixed, runtime-only, in `src/runtime.ts`.
+
+**What shipped:**
+
+1. `_wrapCallableForHost(closure, callbackState)` — a sibling of
+   `_wrapForHost` whose Proxy target is a real `function compiledFnTarget(){}`
+   (so the Proxy may legally carry `apply` + `construct` traps and
+   `typeof proxy === "function"` holds — both required by V8's
+   `IsCallable`/`IsConstructor`). The wrapper is cached per closure
+   (`_hostCallableCache` WeakMap) and mirrored into `_hostProxyReverse` so
+   `_unwrapForHost` round-trips the raw struct back into Wasm.
+   - `apply` / `construct` dispatch through `_wrapWasmClosureUnknownArity`
+     (the existing dynamic-arity `__call_fn_*` bridge) — no new export, no
+     codegen.
+   - `construct` implements **ordinary `[[Construct]]`** (ECMA-262 §10.2.2):
+     run the body with a fresh `{}` as `this`, return the body's value if it
+     is an object else the fresh receiver; a throw from the body propagates so
+     `NewPromiseCapability`'s abrupt-completion ordering is observed.
+   - Every other trap (`get`/`set`/`has`/`ownKeys`/`getOwnPropertyDescriptor`/
+     `defineProperty`/`deleteProperty`) **delegates to the standard
+     `_wrapForHost(closure)` proxy** — its read/has/enumerate machinery is
+     reused verbatim, so NOTHING in `_wrapForHost` had to be extracted or
+     touched (lower regression risk than the spec's step-1 extraction option).
+     `getPrototypeOf` returns `Function.prototype`.
+
+2. **Hook in `_resolveCtor`** (the combinator capability-resolver): for
+   `directCall === 0` (`Promise.METHOD.call(thisArg, …)`), when `thisArg` is a
+   WasmGC struct AND `__is_closure(thisArg) === 1`, return
+   `_wrapCallableForHost(thisArg, callbackState)`. **Why the `__is_closure`
+   gate is load-bearing:** a plain object (`ctx-non-ctor`) or a non-closure
+   named struct must stay non-constructible so V8's NewPromiseCapability still
+   throws the spec §27.2.4.X step-2 TypeError. Only genuine closures get the
+   callable wrap; primitives/null/undefined never reach the struct branch.
+
+**Why ordinary-[[Construct]] only (no `__construct_closure` export):** A.i's
+`NotPromise` is always an *ordinary function*, never a compiled *class*. The
+compiled-class-as-dynamic-constructor case is #1632b-2 (needs codegen) and has
+no test262 coverage reaching this site uncovered by #1682, so it is
+intentionally deferred.
+
+**Verification (two-step `WebAssembly.compile` + `instantiate` + `setExports`,
+matching `tests/promise-combinators.test.ts`):**
+- A.i positive: `Promise.all.call(Cap, [])` with `function Cap(executor){…}`
+  → the compiled body now RUNS (was `[object Object] is not a constructor`).
+- `ctx-non-object` (`Promise.all.call(5, [])`) → still TypeError.
+- `ctx-non-ctor` (`Promise.all.call({}, [])`) → still TypeError.
+- B/A.ii (`class X extends Promise {}; X.all([])`) → still resolves.
+- 4 new tests added to `tests/promise-combinators.test.ts`
+  (`describe("… compiled-fn capability constructor (#1694 A.i)")`).
+- Adjacent suites green: #1632a, #1596, #1732-S1, #1337-bind-call,
+  #1712, #1896-typeof-closure, #2174 (53 tests).
+
+**Harness gotcha (cost ~30 min):** the verification harness MUST call
+`imports.setExports(instance.exports)` after `WebAssembly.instantiate`, or
+`callbackState.getExports()` stays `undefined`, `__is_closure` is unreachable,
+and the wrap silently no-ops. Raw `WebAssembly.instantiate(binary, imports)`
+without `setExports` gives a false "body never ran" reading.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -3964,6 +3964,11 @@ function _safeSet(
  */
 const _hostProxyCache = new WeakMap<object, any>();
 const _hostProxyReverse = new WeakMap<object, any>();
+// (#1694 A.i / #1632b-1) Per-closure cache of the callable+constructible
+// host wrapper produced by `_wrapCallableForHost`, so repeated wraps of the
+// same closure return the same Proxy (constructor identity / @@species stays
+// stable).
+const _hostCallableCache = new WeakMap<object, any>();
 
 /**
  * #1047 — registered prototype refs → method-only own-key list. Populated by
@@ -4687,6 +4692,140 @@ function _unwrapForHost(v: any): any {
   if (v == null || typeof v !== "object") return v;
   const orig = _hostProxyReverse.get(v);
   return orig ?? v;
+}
+
+// (#1694 A.i / #1632b-1) Host-callable/constructible representation of a
+// compiled Wasm closure.
+//
+// `_wrapForHost` wraps an opaque WasmGC struct in a Proxy whose target is
+// `Object.create(null)` — a plain, NON-callable object. A JS Proxy is
+// `[[Call]]`-able / `[[Construct]]`-able only when its *target* is itself
+// callable, so a closure wrapped that way is neither callable nor
+// constructible. When such a value reaches a host built-in that must call or
+// construct it — the canonical case is `Promise.all.call(NotPromise, …)`,
+// where V8's NewPromiseCapability(C) performs `Construct(C, «executor»)` — V8
+// rejects it with "… is not a constructor".
+//
+// `_wrapCallableForHost` wraps the closure in a Proxy whose target is a real
+// `function`, so the Proxy may legally carry `apply` and `construct` traps and
+// `typeof proxy === "function"` holds (required for V8's IsCallable /
+// IsConstructor checks). All property operations (.prototype, .name, static
+// members, has, ownKeys, …) delegate to the SAME `_wrapForHost(closure)` proxy,
+// reusing its read/has/enumerate machinery verbatim — no logic is duplicated or
+// extracted. Cached per closure so repeated wraps return the same Proxy
+// (constructor identity / @@species comparisons stay stable) and mirrored into
+// `_hostProxyReverse` so `_unwrapForHost` round-trips the value back to the raw
+// struct when it flows back into Wasm.
+//
+// This is the ordinary-`[[Construct]]` representation (#1632b-1, runtime-only):
+// the `construct` trap emulates ECMA-262 §10.2.2 OrdinaryCallEvaluateBody for a
+// plain compiled function used with `new` — invoke the closure body with a
+// fresh ordinary object as the implicit receiver, then return the body's value
+// if it is an object, else the fresh receiver. The compiled-*class*-as-dynamic-
+// constructor case (a dedicated `__construct_closure` export) is the separate
+// codegen follow-up #1632b-2 and is intentionally NOT handled here; A.i's
+// `NotPromise` is always an ordinary function, so this fallback closes it.
+function _wrapCallableForHost(
+  closure: any,
+  callbackState: { getExports: () => Record<string, Function> | undefined } | undefined,
+): any {
+  if (closure == null || typeof closure !== "object") return closure;
+  if (!_isWasmStruct(closure)) return closure;
+  const cached = _hostCallableCache.get(closure);
+  if (cached) return cached;
+
+  // Reuse the full property-read/has/enumerate proxy unchanged: the callable
+  // wrapper forwards every non-call/construct trap to it.
+  const exports = callbackState?.getExports();
+  const propProxy = _wrapForHost(closure, exports);
+
+  // The Proxy target must itself be callable+constructible for the traps to be
+  // installable and for `typeof proxy === "function"` to hold. A bare
+  // `function(){}` is both [[Call]] and [[Construct]] capable.
+  const fnTarget = function compiledFnTarget() {};
+  // Surface .name / .length when the codegen stamped them on the closure
+  // sidecar, so Function.prototype.toString / .name stay spec-shaped.
+  // Best-effort; non-fatal if absent.
+  const meta = _wasmStructProps.get(closure);
+  if (meta) {
+    if (typeof meta.name === "string") {
+      try {
+        Object.defineProperty(fnTarget, "name", { value: meta.name, configurable: true });
+      } catch {
+        /* Function.name redefinition is best-effort. */
+      }
+    }
+    if (typeof meta.length === "number") {
+      try {
+        Object.defineProperty(fnTarget, "length", { value: meta.length, configurable: true });
+      } catch {
+        /* Function.length redefinition is best-effort. */
+      }
+    }
+  }
+
+  const handler: ProxyHandler<any> = {
+    apply(_t, thisArg, args) {
+      // Dispatch through the dynamic-arity bridge: it selects the highest
+      // emitted `__call_fn_<arity>` and threads `thisArg` via the method
+      // variant exactly like the rest of the host glue.
+      const wrapped = _wrapWasmClosureUnknownArity(closure, callbackState);
+      if (typeof wrapped !== "function") {
+        throw new TypeError("compiled function is not callable (no __call_fn_* export)");
+      }
+      return wrapped.apply(thisArg, args);
+    },
+    construct(_t, args, _newTarget) {
+      // Ordinary [[Construct]] (ECMA-262 §10.2.2) for a compiled function used
+      // with `new` — the case V8 reaches inside NewPromiseCapability(C). Run the
+      // body with a fresh ordinary object as the implicit `this`; return the
+      // body's result if it is an object, else the fresh object. A throw from
+      // the compiled body (e.g. the executor protocol abrupt-completion paths in
+      // `capability-*` tests) MUST propagate so V8 observes spec ordering.
+      const wrapped = _wrapWasmClosureUnknownArity(closure, callbackState);
+      if (typeof wrapped !== "function") {
+        throw new TypeError("compiled function is not a constructor (no __call_fn_* export)");
+      }
+      const self: Record<string, any> = {};
+      const r = wrapped.apply(self, args);
+      return r != null && typeof r === "object" ? r : self;
+    },
+    // Property reads / writes / enumeration delegate to the standard
+    // `_wrapForHost` proxy so `.prototype`, `.name`, static members, `has`,
+    // `ownKeys`, descriptors, etc. behave identically to a non-callable wrap.
+    get(_t, key, _recv) {
+      return (propProxy as any)[key];
+    },
+    set(_t, key, val) {
+      (propProxy as any)[key] = val;
+      return true;
+    },
+    has(_t, key) {
+      return key in (propProxy as any);
+    },
+    getOwnPropertyDescriptor(_t, key) {
+      const d = Object.getOwnPropertyDescriptor(propProxy as any, key);
+      if (d) d.configurable = true; // a Proxy target's non-config props must be reported configurable
+      return d;
+    },
+    defineProperty(_t, key, desc) {
+      return Reflect.defineProperty(propProxy as any, key, desc);
+    },
+    deleteProperty(_t, key) {
+      return Reflect.deleteProperty(propProxy as any, key);
+    },
+    ownKeys() {
+      return Reflect.ownKeys(propProxy as any);
+    },
+    getPrototypeOf() {
+      return Function.prototype;
+    },
+  };
+
+  const proxy = new Proxy(fnTarget, handler);
+  _hostCallableCache.set(closure, proxy);
+  _hostProxyReverse.set(proxy, closure); // so _unwrapForHost round-trips
+  return proxy;
 }
 
 // ── #2180 — host-mode user `new Proxy` / `Proxy.revocable` construction ──────
@@ -9736,6 +9875,30 @@ assert._isSameValue = isSameValue;
         // `ctx-non-object.js` / `ctx-non-ctor.js` files exercise for
         // undefined/null/primitive/non-constructor values.
         if (directCall) return Promise;
+        // (#1694 A.i / #1632b-1) When the user passes a COMPILED FUNCTION as the
+        // capability constructor — `Promise.all.call(NotPromise, …)` where
+        // `NotPromise` is an ordinary `function` lowered to a Wasm closure
+        // struct — V8's NewPromiseCapability(C) does `Construct(C, «executor»)`.
+        // A bare `_wrapForHost` proxy is non-constructible, so V8 throws
+        // "… is not a constructor". Wrap it in the callable/constructible proxy
+        // so the construct succeeds and the closure body runs (executor
+        // protocol). Only genuine closures (`__is_closure === 1`) get the
+        // callable wrap; a plain object or non-closure struct stays
+        // non-constructible, so the spec TypeError for `ctx-non-object` /
+        // `ctx-non-ctor` still fires per §27.2.4.X step 2.
+        if (thisArg != null && typeof thisArg === "object" && _isWasmStruct(thisArg)) {
+          const exports = callbackState?.getExports();
+          const isClosureFn = exports?.__is_closure as ((v: any) => number) | undefined;
+          let isClosure = false;
+          if (typeof isClosureFn === "function") {
+            try {
+              isClosure = isClosureFn(thisArg) === 1;
+            } catch {
+              isClosure = false;
+            }
+          }
+          if (isClosure) return _wrapCallableForHost(thisArg, callbackState);
+        }
         return thisArg;
       };
       // (#1116b) Synthesize (and cache) a JS subclass of Promise for a

--- a/tests/promise-combinators.test.ts
+++ b/tests/promise-combinators.test.ts
@@ -96,3 +96,85 @@ describe("Promise.all / Promise.race", () => {
     expect(result.wat).toContain("Promise_race");
   });
 });
+
+// (#1694 A.i / #1632b-1) A COMPILED FUNCTION used as the capability constructor
+// `this` of a combinator — `Promise.all.call(NotPromise, …)` where `NotPromise`
+// is an ordinary `function` lowered to a Wasm closure struct. Spec
+// §27.2.4.1 step 6 → NewPromiseCapability(C) → Construct(C, «executor»). Before
+// the fix, the host wrapped the closure as a non-constructible proxy and V8
+// threw "… is not a constructor". `_wrapCallableForHost` now makes it
+// constructible (ordinary [[Construct]]), so the closure body runs.
+describe("Promise combinators — compiled-fn capability constructor (#1694 A.i)", () => {
+  // Instantiate + wire setExports so the host's __is_closure / __call_fn_*
+  // dispatchers are live (raw WebAssembly.instantiate alone leaves them unset).
+  async function instantiateWired(binary: Uint8Array, imports: any) {
+    const mod = await WebAssembly.compile(binary);
+    const inst = await WebAssembly.instantiate(mod, imports as WebAssembly.Imports);
+    if (imports.setExports) imports.setExports(inst.exports);
+    return inst.exports as any;
+  }
+
+  it("invokes a compiled function passed as the capability constructor", async () => {
+    const result = await compile(`
+      let ran = 0;
+      function Cap(executor: any): void {
+        ran = ran + 1;
+        executor(function (v: any) {}, function (e: any) {});
+      }
+      export async function go(): Promise<number> {
+        try { Promise.all.call(Cap as any, []); } catch (e) {}
+        return ran;
+      }
+    `);
+    expect(
+      result.success,
+      `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`,
+    ).toBe(true);
+    const imports = buildImports(result.imports, {}, result.stringPool);
+    const exports = await instantiateWired(result.binary, imports);
+    // Construct(Cap, «executor») must have run the compiled body → ran === 1.
+    expect(await exports.go()).toBe(1);
+  });
+
+  it("still throws TypeError for a primitive capability this (ctx-non-object)", async () => {
+    const result = await compile(`
+      export async function go(): Promise<number> {
+        try { Promise.all.call(5 as any, []); return 0; }
+        catch (e) { return 1; }
+      }
+    `);
+    expect(result.success).toBe(true);
+    const imports = buildImports(result.imports, {}, result.stringPool);
+    const exports = await instantiateWired(result.binary, imports);
+    // A non-object capability stays non-constructible → spec step-2 TypeError.
+    expect(await exports.go()).toBe(1);
+  });
+
+  it("still throws TypeError for a plain-object capability this (ctx-non-ctor)", async () => {
+    const result = await compile(`
+      export async function go(): Promise<number> {
+        try { Promise.all.call({} as any, []); return 0; }
+        catch (e) { return 1; }
+      }
+    `);
+    expect(result.success).toBe(true);
+    const imports = buildImports(result.imports, {}, result.stringPool);
+    const exports = await instantiateWired(result.binary, imports);
+    // A non-closure struct is not callable-wrapped → NewPromiseCapability throws.
+    expect(await exports.go()).toBe(1);
+  });
+
+  it("class X extends Promise still resolves through X.all (B / A.ii unbroken)", async () => {
+    const result = await compile(`
+      class X extends Promise {}
+      export async function go(): Promise<number> {
+        const r = await X.all([]);
+        return Array.isArray(r) ? 7 : -1;
+      }
+    `);
+    expect(result.success).toBe(true);
+    const imports = buildImports(result.imports, {}, result.stringPool);
+    const exports = await instantiateWired(result.binary, imports);
+    expect(await exports.go()).toBe(7);
+  });
+});


### PR DESCRIPTION
## #1694 A.i — compiled function as Promise-combinator capability constructor

Closes the sole genuine remaining gap of **#1694** (per its two independent
re-validations) and delivers **#1632b-1** (runtime-only, no codegen).

### Problem
`Promise.all.call(NotPromise, …)` — and `race`/`any`/`allSettled` — where
`NotPromise` is an ordinary `function` lowered to a Wasm closure struct threw
`[object Object] is not a constructor`. V8's `NewPromiseCapability(C)` performs
`Construct(C, «executor»)`, but the host wrapped the closure via `_wrapForHost`
(a `Proxy` over `Object.create(null)`), which is non-constructible.

### Fix
- **`_wrapCallableForHost(closure, callbackState)`** in `src/runtime.ts`: a
  `Proxy` over a real `function` target carrying `apply` + `construct` traps
  that dispatch through the existing `_wrapWasmClosureUnknownArity`
  (`__call_fn_*`) bridge. `construct` implements ordinary `[[Construct]]`
  (ECMA-262 §10.2.2) — run the body with a fresh `{}` receiver, return its
  object result or the fresh object; throws propagate so abrupt-completion
  ordering is observed. Every other trap delegates to the standard
  `_wrapForHost(closure)` proxy, so its read/has/enumerate logic is reused
  verbatim (no extraction, lower regression risk). Cached per closure;
  mirrored into `_hostProxyReverse` for round-tripping.
- **Hook in `_resolveCtor`**: for `directCall === 0` and a closure
  (`__is_closure === 1`) `thisArg`, return the callable wrap. The
  `__is_closure` gate keeps primitives (`ctx-non-object`) and
  plain-object/non-closure structs (`ctx-non-ctor`) non-constructible, so the
  spec §27.2.4.X step-2 TypeError still fires.

The compiled-class-as-dynamic-constructor case is the deferred **#1632b-2**
(needs a `__construct_closure` codegen export); A.i's `NotPromise` is always an
ordinary function, so this fallback alone closes the family.

### Verification
- A.i positive: `Promise.all.call(Cap, [])` now runs the compiled `Cap` body.
- `ctx-non-object` (`call(5, [])`) and `ctx-non-ctor` (`call({}, [])`) → still
  TypeError.
- B / A.ii (`class X extends Promise {}; X.all([])`) → still resolves.
- 4 new tests in `tests/promise-combinators.test.ts`.
- Adjacent suites green: #1632a, #1596, #1732-S1, #1337, #1712, #1896, #2174
  (53 tests). `pnpm run lint` + `format:check` + `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)