### PR TITLE
fix(#2011): module-level accessor-literal global must be externref

### DIFF
--- a/plan/issues/2011-object-literal-accessor-closures-capture-copies.md
+++ b/plan/issues/2011-object-literal-accessor-closures-capture-copies.md
@@ -1,10 +1,12 @@
 ---
 id: 2011
 title: "object-literal getter/setter closures capture copies — writes through accessors never reach the outer scope, getter pairs don't share state"
-status: ready
+status: done
 sprint: 63
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-17
+completed: 2026-06-17
+assignee: ttraenkler/cs-2161
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -12,7 +14,7 @@ task_type: bugfix
 area: codegen
 language_feature: objects
 goal: core-semantics
-related: [1971, 1239, 1999]
+related: [1971, 1239, 1999, 2128]
 origin: "2026-06-10 spec-conformance sweep (objects agent): verified on main"
 ---
 
@@ -58,3 +60,54 @@ environment used by ordinary closures.
 Overlaps #1971 item 3 (#1239 residual "setters not invoked") but refines
 it: setters fire, capture sharing is what's broken. Filed separately with
 cross-ref.
+
+## Resolution (2026-06-17, cs-2161)
+
+The original symptoms (`"1,2,0"`, getter/setter pair not sharing a cell)
+were already fixed at **function scope** by #2128 (shared per-literal ref
+cells in `compileArrowAsCallback` + writeback re-sync at property-access /
+assignment sites in `expressions.ts`). Re-verifying on main showed the
+function-local repros all pass once the runtime harness wires `setExports`.
+
+The residual that remained was a **module-scope-only** regression with a
+different root cause: a top-level `const o = { get x() {...} }` returned
+`NaN` and never observed captures even for a *read-only* capture of a
+module-level variable.
+
+**Root cause — representation/routing asymmetry between scopes.** Object
+literals carrying get/set accessors are always compiled through the
+JS-host plain-object (externref) path (`compileObjectLiteral` →
+`compileObjectLiteralWithAccessors`, #1239/#1433). The **function-local**
+let/const/var pre-pass (`index.ts` `walkStmtForLetConst` / `hoistVarDecl`,
+~12573-12586) recognises this and forces the receiving local to
+`externref` *and* tags `ctx.externrefAccessorVars` so later `o.x` reads
+route to host `__extern_get`. The **module-level** registration path
+(`declarations.ts registerModuleGlobal` callers, ~3338-3429) did **not**:
+it typed the global via `resolveWasmType`, which infers the WasmGC *struct*
+type. Result: the host externref object produced by the literal was stored
+into a struct-typed global, and `o.x` mis-routed to `__extern_get` against
+a struct (or a stub struct getter that read field 0) → `undefined`/`NaN`,
+and no capture writebacks ran.
+
+**Fix.** `src/codegen/declarations.ts`: added `moduleInitForcesExternref`
+(detects accessor / `[Symbol.dispose]` / `[Symbol.asyncDispose]` literal
+initializers) and `moduleGlobalWasmType` (returns `externref` + tags
+`ctx.externrefAccessorVars` for those, else the prior
+standalone-regexp/inferred type). Routed both module-global registration
+sites (the `var`-hoist `registerVarDeclListGlobals` and the source-order
+let/const loop) through it. This mirrors the function-local override
+exactly, so the two scopes now agree on representation.
+
+Scoped to accessor/dispose literals only — plain data-property module
+literals keep the struct path (regression-guarded).
+
+**Tests.** `tests/issue-2011.test.ts` (7 cases: read-only let/const
+capture, mutate+observe, setter, get/set pair shared backing, the
+multi-read repro, and a plain-struct guard). Pre-existing accessor suites
+(`accessor-side-effects`, `issue-2128`, equivalence object-literal getter)
+stay green. `tsc --noEmit` clean; biome clean on changed files.
+
+NOTE: a *separate* pre-existing bug — `this._val` data-field access inside
+an object-literal accessor (`tests/equivalence/object-literal-getters-setters.test.ts`
+"setter stores value") — is out of scope here (not a closure capture) and
+was failing on main before this change.

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -3330,6 +3330,56 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
     return ctx.checker.getTypeAtLocation(decl);
   }
 
+  /**
+   * (#2011) True when a module-level variable's initializer is an object
+   * literal carrying get/set accessor declarations (or a `[Symbol.dispose]`
+   * / `[Symbol.asyncDispose]` computed method). Such literals compile through
+   * the JS-host plain-object (externref) path in `compileObjectLiteral`
+   * (#1239/#1433), so the receiving global MUST be typed `externref` — never
+   * the inferred WasmGC struct type. Otherwise the host object is stored into
+   * a struct-typed global and `obj.v` reads mis-route to `__extern_get` against
+   * a struct (returning undefined → NaN). Mirrors the function-local pre-pass
+   * in index.ts (`walkStmtForLetConst` / `hoistVarDecl`, ~12573-12586) that
+   * already forces externref + tags `externrefAccessorVars` at function scope.
+   */
+  function moduleInitForcesExternref(decl: ts.VariableDeclaration): boolean {
+    if (!decl.initializer || !ts.isObjectLiteralExpression(decl.initializer)) return false;
+    for (const p of decl.initializer.properties) {
+      if (ts.isGetAccessorDeclaration(p) || ts.isSetAccessorDeclaration(p)) return true;
+      if (ts.isMethodDeclaration(p) && ts.isComputedPropertyName(p.name)) {
+        const inner = p.name.expression;
+        if (
+          ts.isPropertyAccessExpression(inner) &&
+          ts.isIdentifier(inner.expression) &&
+          inner.expression.text === "Symbol" &&
+          (inner.name.text === "dispose" || inner.name.text === "asyncDispose")
+        ) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Resolve the module-global wasm type for a simple identifier declaration,
+   * honoring the accessor-literal externref override (#2011) and tagging the
+   * name in `externrefAccessorVars` so later property accesses route to the
+   * host get/set path. Shared by the `var`-hoist walk and the source-order
+   * let/const pass so both scopes register the same type.
+   */
+  function moduleGlobalWasmType(decl: ts.VariableDeclaration, varType: ts.Type): ValType {
+    if (moduleInitForcesExternref(decl) && ts.isIdentifier(decl.name)) {
+      ctx.externrefAccessorVars.add(decl.name.text);
+      return { kind: "externref" };
+    }
+    // #1914 — `var m = re.exec(s)` under standalone gets the precise
+    // match-vec ref type so indexed reads stay on the static vec path
+    // (externref-widened globals round-trip through __extern_get_idx,
+    // which can't see typed vecs and returns null).
+    return inferStandaloneRegExpMatchGlobalType(ctx, decl) ?? resolveWasmType(ctx, varType);
+  }
+
   /** Register var declarations from a variable declaration list as module globals. */
   function registerVarDeclListGlobals(list: ts.VariableDeclarationList): void {
     // Only hoist `var` (not let/const) — let/const are block-scoped
@@ -3337,11 +3387,7 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
     for (const decl of list.declarations) {
       if (ts.isIdentifier(decl.name)) {
         const varType = moduleVarDeclType(decl);
-        // #1914 — `var m = re.exec(s)` under standalone gets the precise
-        // match-vec ref type so indexed reads stay on the static vec path
-        // (externref-widened globals round-trip through __extern_get_idx,
-        // which can't see typed vecs and returns null).
-        const wasmType = inferStandaloneRegExpMatchGlobalType(ctx, decl) ?? resolveWasmType(ctx, varType);
+        const wasmType = moduleGlobalWasmType(decl, varType);
         registerModuleGlobal(decl.name.text, wasmType);
       } else if (ts.isObjectBindingPattern(decl.name) || ts.isArrayBindingPattern(decl.name)) {
         registerBindingNames(decl.name);
@@ -3421,11 +3467,10 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
       for (const decl of stmt.declarationList.declarations) {
         if (ts.isIdentifier(decl.name)) {
           const varType = moduleVarDeclType(decl);
-          // #1914 — `var m = re.exec(s)` under standalone gets the precise
-          // match-vec ref type so indexed reads stay on the static vec path
-          // (externref-widened globals round-trip through __extern_get_idx,
-          // which can't see typed vecs and returns null).
-          const wasmType = inferStandaloneRegExpMatchGlobalType(ctx, decl) ?? resolveWasmType(ctx, varType);
+          // (#2011) Accessor/dispose object-literal initializers force an
+          // externref global (+ externrefAccessorVars tag); otherwise fall back
+          // to the standalone-regexp / inferred type. See moduleGlobalWasmType.
+          const wasmType = moduleGlobalWasmType(decl, varType);
           registerModuleGlobal(decl.name.text, wasmType);
           if (isLetOrConst) {
             ctx.tdzLetConstNames.add(decl.name.text);

--- a/tests/issue-2011.test.ts
+++ b/tests/issue-2011.test.ts
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2011 — object-literal getter/setter closures at MODULE scope captured the
+// wrong representation. A `const o = { get x() {...} }` declared at top level
+// was registered as a WasmGC *struct* global (resolveWasmType), while the
+// literal itself compiled through the JS-host plain-object/accessor path
+// (compileObjectLiteral routes any accessor literal to
+// compileObjectLiteralWithAccessors). The two disagreed: `o.x` reads then
+// mis-routed to __extern_get against a struct and returned undefined → NaN,
+// and outer captures never re-synced.
+//
+// The function-local pre-pass (index.ts walkStmtForLetConst / hoistVarDecl)
+// already forced externref + tagged externrefAccessorVars for accessor
+// literals; the module-level registration path (declarations.ts) did not.
+// The fix mirrors that override for module-level let/const/var.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(source: string, fn = "test"): Promise<unknown> {
+  const r = await compile(source);
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors[0]?.message ?? "<unknown>"}`);
+  }
+  // Accessor callbacks dispatch through __cb_N exports — the imports object
+  // must be wired back to the instance via setExports or every getter/setter
+  // bridge silently returns undefined.
+  const imports = buildImports(r.imports, {}, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  (imports as { setExports?: (e: object) => void }).setExports?.(instance.exports as object);
+  return (instance.exports as any)[fn]();
+}
+
+describe("#2011 — module-level object-literal accessor closures", () => {
+  it("getter reads a module-level let (read-only capture)", async () => {
+    const out = await run(`
+      let val = 42;
+      const obj = { get v(): number { return val; } };
+      export function test(): number { return obj.v; }
+    `);
+    expect(out).toBe(42);
+  });
+
+  it("getter reads a module-level const (read-only capture)", async () => {
+    const out = await run(`
+      const val = 42;
+      const obj = { get v(): number { return val; } };
+      export function test(): number { return obj.v; }
+    `);
+    expect(out).toBe(42);
+  });
+
+  it("getter increments a module-level var; outer scope observes the writes", async () => {
+    const out = await run(`
+      let count = 0;
+      const obj = { get v(): number { count = count + 1; return count; } };
+      export function test(): number { obj.v; obj.v; return count; }
+    `);
+    expect(out).toBe(2);
+  });
+
+  it("setter writes a module-level var through the accessor", async () => {
+    const out = await run(`
+      let captured = 0;
+      const o: any = { set x(v: number) { captured = v * 2; } };
+      export function test(): number { o.x = 10; return captured; }
+    `);
+    expect(out).toBe(20);
+  });
+
+  it("module-level get/set pair shares the captured backing", async () => {
+    const out = await run(`
+      let backing = 100;
+      const o: any = {
+        get x(): number { return backing; },
+        set x(v: number) { backing = v; },
+      };
+      export function test(): string { o.x = 105; return o.x + "," + backing; }
+    `);
+    expect(out).toBe("105,105");
+  });
+
+  it("repro: distinct getter reads return distinct values; count is observed", async () => {
+    const out = await run(`
+      let count = 0;
+      const o: any = { get x(): number { count = count + 1; return count; } };
+      export function test(): string {
+        const a = o.x; const b = o.x;
+        return a + "," + b + "," + count;
+      }
+    `);
+    expect(out).toBe("1,2,2");
+  });
+
+  it("plain (non-accessor) module-level literal still uses the struct path", async () => {
+    // Guard against over-broad externref forcing: a literal with only data
+    // properties must remain a typed struct read, not a host get.
+    const out = await run(`
+      const o = { a: 3, b: 4 };
+      export function test(): number { return o.a + o.b; }
+    `);
+    expect(out).toBe(7);
+  });
+});


### PR DESCRIPTION
## #2011 — module-level object-literal accessor closures

Top-level `const o = { get x() {...} }` returned `NaN` and never observed closure captures, even for a **read-only** capture of a module-level variable. The function-scope symptoms originally filed under #2011 were already fixed by **#2128**; this PR closes the **module-scope residual**, which has a distinct root cause.

### Root cause — representation/routing asymmetry between scopes

Object literals carrying get/set accessors always compile through the JS-host plain-object (externref) path (`compileObjectLiteral` → `compileObjectLiteralWithAccessors`, #1239/#1433).

- **Function scope** (`index.ts` `walkStmtForLetConst` / `hoistVarDecl`, ~12573-12586) already recognises this: it forces the receiving local to `externref` **and** tags `ctx.externrefAccessorVars` so later `o.x` reads route to host `__extern_get`.
- **Module scope** (`declarations.ts` `registerModuleGlobal` callers, ~3338-3429) did **not**: it typed the global via `resolveWasmType`, which infers the WasmGC **struct** type.

Result: the host externref object produced by the literal was stored into a struct-typed global, and `o.x` mis-routed to `__extern_get` against a struct → `undefined`/`NaN`, with no capture writebacks.

### Fix

`src/codegen/declarations.ts`:
- `moduleInitForcesExternref` — detects accessor / `[Symbol.dispose]` / `[Symbol.asyncDispose]` literal initializers.
- `moduleGlobalWasmType` — returns `externref` + tags `ctx.externrefAccessorVars` for those, else the prior standalone-regexp / inferred type.
- Both module-global registration sites (the `var`-hoist `registerVarDeclListGlobals` and the source-order let/const loop) now route through it.

This mirrors the function-local override exactly, so the two scopes agree on representation. Scoped to accessor/dispose literals only — plain data-property module literals keep the struct path (regression-guarded).

### Tests

`tests/issue-2011.test.ts` — 7 cases: read-only let/const capture, mutate+observe, setter, get/set pair shared backing, the multi-read repro, plus a plain-struct guard. Pre-existing accessor suites (`accessor-side-effects`, `issue-2128`, equivalence object-literal getter) stay green. `tsc --noEmit` clean; biome clean on changed files.

Out of scope (pre-existing, failing on main before this change): `this._val` data-field access inside an object-literal accessor — not a closure capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)