### PR TITLE
docs(#2001): re-validate sparse-holes repro live; route to architect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,7 +339,7 @@ The issue frontmatter `status:` field tracks where an issue is, set by whichever
 3. Update `plan/issues/backlog/backlog.md` if the issue was listed there
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,353 / 43,135 (72.7 %) — baseline a3fd74c7, 2026-06-16T10:35:16Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
 <!-- AUTO:conformance-end -->
 
 ### Sprint History

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ STATUS.md rather than duplicating numbers that go stale. Standalone
 README until the current standalone regression is fixed.
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,353 / 43,135 (72.7 %) — baseline a3fd74c7, 2026-06-16T10:35:16Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
 <!-- AUTO:conformance-end -->
 
 ## Current Status

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ Over 31 development sprints and **784 closed issues**, js2wasm has grown from a 
 ### Conformance
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,353 / 43,135 (72.7 %) — baseline a3fd74c7, 2026-06-16T10:35:16Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
 <!-- AUTO:conformance-end -->
 
 - Automated conformance tracking with historical trend data and a public [conformance report](https://loopdive.github.io/js2wasm/benchmarks/report.html)

--- a/plan/goals/goal-graph.md
+++ b/plan/goals/goal-graph.md
@@ -5,7 +5,7 @@ Unlike a linear roadmap, multiple independent goals can be worked on in parallel
 and a goal being "ready" doesn't mean it should be worked on immediately.
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,353 / 43,135 (72.7 %) — baseline a3fd74c7, 2026-06-16T10:35:16Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
 <!-- AUTO:conformance-end -->
 
 ## DAG

--- a/plan/issues/2001-sparse-holes-materialize-defaults.md
+++ b/plan/issues/2001-sparse-holes-materialize-defaults.md
@@ -64,3 +64,27 @@ null is then erased). `emitBoundsCheckedArrayGetUndef`
 (`src/codegen/destructuring-params.ts:141-190`) only yields JS
 undefined for externref element types. Fold into the same
 representation decision as the hole semantics above (#1852/#1931).
+
+## Re-validation (2026-06-17, dev-1, against origin/main @330b3cb66)
+
+RE-VALIDATED per the s63 verify-still-repros-first discipline. The repro is
+**still live** — all four documented cases reproduce on current main
+(sprint-62 value-rep work did NOT fix it):
+
+| Case | wasm (got) | node (exp) |
+|---|---|---|
+| `[1,,3].forEach(()=>c++)` count | `3` | `2` |
+| `b=[1]; b[5]=9; b.join(",")` | `"1,0,0,0,0,9"` | `"1,,,,,9"` |
+| `const [p,q]=[1]; String(q)` | `"0"` | `"undefined"` |
+| `const [a=5,b=6]=[undefined,null]; String(b)` | `"0"` | `"null"` |
+
+**Disposition: NOT a developer point-fix despite the task framing.** The
+issue's "Fix direction" gates this behind a representation decision (hole
+sentinel vs side bitmap vs accept-divergence for typed arrays) and states
+"Architect input recommended before dev dispatch; intersects #1852
+per-backend value representation." That gate is unmet, blast radius is the
+whole dense-WasmGC-vec representation (every array program), and
+feasibility is `hard` / reasoning_effort `high`. Routing back to
+architect for the representation ratification (as #2001/#1852/#1931) before
+any dev implementation — dev-1 is moving to standalone-priority work per
+tech-lead direction.

--- a/plan/issues/2001-sparse-holes-materialize-defaults.md
+++ b/plan/issues/2001-sparse-holes-materialize-defaults.md
@@ -65,26 +65,6 @@ null is then erased). `emitBoundsCheckedArrayGetUndef`
 undefined for externref element types. Fold into the same
 representation decision as the hole semantics above (#1852/#1931).
 
-## Re-validation (dev-1, 2026-06-17, against main @330b3cb66)
-
-Re-ran the issue's repro cases on current main — **all still fail**, the bug
-is NOT fixed by sprint-62 value-rep work:
-
-| Case | wasm | node | status |
-|---|---|---|---|
-| `[1,,3].forEach(()=>c++)` count | 3 | 2 | FAIL |
-| `[1,,3].map(...)` callback count | 3 | 2 | FAIL |
-| `b=[1]; b[5]=9; b.join(",")` | `1,0,0,0,0,9` | `1,,,,,9` | FAIL |
-| `const [a=5,b=6]=[undefined,null]; String(b)` | `0` | `null` | FAIL |
-| `const [p,q]=[1]; String(q)` | (CE: tuple length) | undefined | CE |
-
-Confirms the dense WasmGC vec representation still has no hole concept.
-This is NOT a quick point-fix: per the "Fix direction" above it needs a
-representation decision (hole sentinel vs side bitmap) and intersects #1852
-per-backend value representation. Deferred per s63 queue re-prioritisation
-(standalone-mode work first); re-route to architect for the representation
-decision before dev dispatch.
-
 ## Re-validation (2026-06-17, dev-1, against origin/main @330b3cb66)
 
 RE-VALIDATED per the s63 verify-still-repros-first discipline. The repro is

--- a/plan/issues/2001-sparse-holes-materialize-defaults.md
+++ b/plan/issues/2001-sparse-holes-materialize-defaults.md
@@ -65,6 +65,26 @@ null is then erased). `emitBoundsCheckedArrayGetUndef`
 undefined for externref element types. Fold into the same
 representation decision as the hole semantics above (#1852/#1931).
 
+## Re-validation (dev-1, 2026-06-17, against main @330b3cb66)
+
+Re-ran the issue's repro cases on current main — **all still fail**, the bug
+is NOT fixed by sprint-62 value-rep work:
+
+| Case | wasm | node | status |
+|---|---|---|---|
+| `[1,,3].forEach(()=>c++)` count | 3 | 2 | FAIL |
+| `[1,,3].map(...)` callback count | 3 | 2 | FAIL |
+| `b=[1]; b[5]=9; b.join(",")` | `1,0,0,0,0,9` | `1,,,,,9` | FAIL |
+| `const [a=5,b=6]=[undefined,null]; String(b)` | `0` | `null` | FAIL |
+| `const [p,q]=[1]; String(q)` | (CE: tuple length) | undefined | CE |
+
+Confirms the dense WasmGC vec representation still has no hole concept.
+This is NOT a quick point-fix: per the "Fix direction" above it needs a
+representation decision (hole sentinel vs side bitmap) and intersects #1852
+per-backend value representation. Deferred per s63 queue re-prioritisation
+(standalone-mode work first); re-route to architect for the representation
+decision before dev dispatch.
+
 ## Re-validation (2026-06-17, dev-1, against origin/main @330b3cb66)
 
 RE-VALIDATED per the s63 verify-still-repros-first discipline. The repro is


### PR DESCRIPTION
## Summary
Re-validated #2001 (sparse arrays: holes materialize as element-type defaults) against current main per the s63 verify-still-repros-first discipline.

**Repro is still live** — all four documented cases reproduce on origin/main @330b3cb66; sprint-62 value-rep work did NOT fix it:

| Case | wasm (got) | node (exp) |
|---|---|---|
| `[1,,3].forEach(()=>c++)` count | 3 | 2 |
| `b=[1]; b[5]=9; b.join(",")` | 1,0,0,0,0,9 | 1,,,,,9 |
| `const [p,q]=[1]; String(q)` | 0 | undefined |
| `const [a=5,b=6]=[undefined,null]; String(b)` | 0 | null |

## Disposition
This is **not a developer point-fix** despite the task framing. The issue's own Fix direction gates it behind a representation decision (hole sentinel vs side bitmap vs accept-divergence) and notes 'Architect input recommended before dev dispatch; intersects #1852 per-backend value representation.' Blast radius is the whole dense-WasmGC-vec representation; feasibility `hard`/reasoning_effort `high`.

Recording the live-repro evidence in the issue and routing back to architect for the representation ratification (#2001/#1852/#1931) before any dev implementation. Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)