### PR TITLE
feat(#2162): native standalone Set runtime (slice 1)

### DIFF
--- a/plan/issues/2162-standalone-map-set-weak-collections-residual.md
+++ b/plan/issues/2162-standalone-map-set-weak-collections-residual.md
@@ -1,0 +1,86 @@
+---
+id: 2162
+title: "Standalone Map/Set/WeakMap/WeakSet conformance residual (~532 tests)"
+status: in-progress
+sprint: 62
+created: 2026-06-15
+updated: 2026-06-16
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: conformance
+area: standalone
+language_feature: collections
+goal: standalone-mode
+parent: 1103
+---
+
+# Standalone Map/Set/Weak collections conformance residual
+
+## Problem
+
+Wasm-native Map/Set/WeakMap collections landed in #1103 (`done`, sprint 58).
+The host-vs-standalone baseline diff (sha `31fa7e099`, 2026-06-15) shows
+**532 tests pass in host mode but fail standalone**, attributed to the
+collection types — currently **untracked/unscheduled**.
+
+## Evidence
+
+- Gap categories: `built-ins/Set` 286, `built-ins/Map` 148,
+  `built-ins/WeakMap` 101, plus WeakSet/WeakRef/FinalizationRegistry tails.
+- `Set_new` and related host-import leaks plus `(none)`-leak compile errors.
+
+## Acceptance criteria
+
+- Standalone pass count for Map/Set/WeakMap/WeakSet rises toward host parity.
+- No collection host-import leak (e.g. `Set_new`) for the covered cases.
+- Gap-diff repros added as standalone equivalence tests.
+
+## Notes
+
+Parent (done): #1103. Part of sprint-62 standalone catch-up (rank 7 by gap
+impact).
+
+## Triage (2026-06-16)
+
+Probed each collection in standalone (`target: standalone`). Findings:
+
+- **Map is already fully functional** in standalone — `new/set/get/has/
+  delete/size/clear` all return correct values when the result is read into a
+  typed binding. The apparent Map failures in casual probing were
+  `m.get(k) === <literal>` confounds (the `any === literal` boxed-compare gap,
+  not Map). No Map work needed for the core methods.
+- **Set had NO native standalone runtime** — `new Set()` / `add` / `has` /
+  `size` leaked `Set_new` / `Set_add` / `Set_has` / `Set_get_size` host imports
+  the standalone module can't satisfy, so every Set program failed. This is the
+  dominant slice of the gap (`built-ins/Set` ≈ 286).
+
+## Slice 1 — native Set runtime (this PR)
+
+A Set is a Map with `value === key`, so the entire #1103a Map backing store
+(`map-runtime.ts`: ordered hash table, SameValueZero key equality, tombstone
+deletion) is reused. New module `src/codegen/set-runtime.ts` adds only
+`__set_add(m, v) = __map_set(m, v, v)` and the dispatch interceptors; `has` /
+`delete` / `clear` / `size` route straight to the `__map_*` helpers.
+
+Wiring (mirrors Map): `new Set()` → `__map_new` (new-super.ts); method calls →
+`tryCompileNativeSetMethodCall` (extern.ts); `.size` →
+`tryCompileNativeSetSizeGet` (property-access.ts); `Set` resolves to `ref $Map`
+(resolveWasmType, index.ts); and the `Set` externClass registration is skipped
+under `nativeStrings` so no `Set_*` host import is emitted. Host/gc mode is
+unchanged (still uses the externClass path).
+
+**Verified** (`tests/issue-2162-standalone-set.test.ts`, 6/6, `--target wasi`,
+zero `Set_*`/`Map_*` imports): add+has, size dedup, delete + return value,
+clear, string-element dedup, chained `add().add()`.
+
+### Remaining slices (follow-up; issue stays in-progress)
+
+- Set iteration: `forEach`, `for-of`, `keys`/`values`/`entries`,
+  `new Set(iterable)` — needs the `$MapIter` drive (Map slice 2 territory too).
+- ES2025 set-algebra: `union`/`intersection`/`difference`/
+  `symmetricDifference`/`isSubsetOf`/`isSupersetOf`/`isDisjointFrom`.
+- `WeakMap` / `WeakSet` standalone (101+ tests) — separate representation
+  (no iteration, identity keys); not covered by the Map backing store reuse.
+- The `Set === literal` / Set-of-`any` comparison confounds depend on the
+  value-rep work (#2104/#2106), out of scope here.

--- a/src/codegen/expressions/extern.ts
+++ b/src/codegen/expressions/extern.ts
@@ -11,6 +11,7 @@ import { allocLocal } from "../context/locals.js";
 import type { CodegenContext, ExternClassInfo, FunctionContext, RestParamInfo } from "../context/types.js";
 import { addUnionImports, getArrTypeIdxFromVec } from "../index.js";
 import { tryCompileNativeMapMethodCall } from "../map-runtime.js";
+import { tryCompileNativeSetMethodCall } from "../set-runtime.js";
 import { addStringConstantGlobal } from "../registry/imports.js";
 import type { InnerResult } from "../shared.js";
 import { coerceType, compileExpression, valTypesMatch, VOID_RESULT } from "../shared.js";
@@ -61,6 +62,16 @@ function compileExternMethodCall(
     addUnionImports(ctx);
     const mapResult = tryCompileNativeMapMethodCall(ctx, fctx, propAccess, callExpr);
     if (mapResult !== undefined) return mapResult;
+  }
+
+  // (#2162) Native Set method dispatch in standalone / nativeStrings mode.
+  // Without this, `s.add(...)` etc. emit `Set_add` host imports the standalone
+  // runtime can't satisfy. Route to the WasmGC-native Set runtime (which reuses
+  // the Map backing store). Same up-front addUnionImports rationale as Map.
+  if (className === "Set" && ctx.nativeStrings) {
+    addUnionImports(ctx);
+    const setResult = tryCompileNativeSetMethodCall(ctx, fctx, propAccess, callExpr);
+    if (setResult !== undefined) return setResult;
   }
 
   if (!className) return null;

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -25,6 +25,7 @@ import {
   resolveWasmType,
 } from "../index.js";
 import { ensureMapHelpers } from "../map-runtime.js";
+import { ensureSetHelpers } from "../set-runtime.js";
 import { resolveComputedKeyExpression } from "../literals.js";
 import { stringConstantExternrefInstrs } from "../native-strings.js";
 import {
@@ -1654,6 +1655,25 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
   ) {
     addUnionImports(ctx);
     ensureMapHelpers(ctx);
+    const mapNewIdx = ctx.mapHelpers.get("__map_new");
+    if (mapNewIdx !== undefined && ctx.mapTypeIdx >= 0) {
+      fctx.body.push({ op: "call", funcIdx: mapNewIdx });
+      return { kind: "ref", typeIdx: ctx.mapTypeIdx };
+    }
+  }
+
+  // (#2162) `new Set()` in standalone / nativeStrings mode → the WasmGC-native
+  // Set runtime, which reuses the Map backing store (`__map_new` yields the
+  // same empty `$Map` a Set wraps). No-arg form only; `new Set(iterable)` needs
+  // the iterator drive (follow-up slice) and falls through.
+  if (
+    ctx.nativeStrings &&
+    ts.isIdentifier(expr.expression) &&
+    expr.expression.text === "Set" &&
+    (expr.arguments?.length ?? 0) === 0
+  ) {
+    addUnionImports(ctx);
+    ensureSetHelpers(ctx);
     const mapNewIdx = ctx.mapHelpers.get("__map_new");
     if (mapNewIdx !== undefined && ctx.mapTypeIdx >= 0) {
       fctx.body.push({ op: "call", funcIdx: mapNewIdx });

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -8982,6 +8982,15 @@ export function resolveWasmType(ctx: CodegenContext, tsType: ts.Type, _depth = 0
       if (ctx.mapTypeIdx >= 0) return { kind: "ref", typeIdx: ctx.mapTypeIdx };
     }
 
+    // (#2162) Set → the SAME native `$Map` struct in standalone / nativeStrings
+    // mode (a Set is a Map with key === value). A `Set`-typed binding becomes
+    // `ref $Map` so `new Set()` stores directly and method/.size dispatch reads
+    // a typed receiver. JS-host mode keeps Set as an externref externClass.
+    if (sym?.name === "Set" && ctx.nativeStrings) {
+      ensureMapRuntimeTypes(ctx);
+      if (ctx.mapTypeIdx >= 0) return { kind: "ref", typeIdx: ctx.mapTypeIdx };
+    }
+
     // Check externref AFTER Array check — Array is declared in lib but should use wasm GC arrays
     if (isExternalDeclaredClass(tsType, ctx.checker)) return { kind: "externref" };
 
@@ -9385,8 +9394,14 @@ function externMethod(
  * (e.g., bundled/browser environments where readLibFile returns empty strings).
  */
 export function registerBuiltinExternClasses(ctx: CodegenContext): void {
-  // Set methods — all take (self: externref, ...args: externref) → externref
-  if (!ctx.externClasses.has("Set")) {
+  // Set methods — all take (self: externref, ...args: externref) → externref.
+  // (#2162) In standalone / nativeStrings mode `Set` is served by the
+  // WasmGC-native runtime (src/codegen/set-runtime.ts, reusing the Map backing
+  // store), intercepted at the new-expression / method-call / .size sites.
+  // Registering it as an externClass here would eagerly emit a `Set_new` host
+  // import the standalone module can't satisfy, so skip it in that mode (mirrors
+  // the Map gating below). JS-host mode keeps the externClass path unchanged.
+  if (!ctx.externClasses.has("Set") && !ctx.nativeStrings) {
     const methods = new Map<string, { params: ValType[]; results: ValType[]; requiredParams: number }>();
     // ES2015 methods
     methods.set("add", externMethod(1)); // add(value) → Set

--- a/src/codegen/map-runtime.ts
+++ b/src/codegen/map-runtime.ts
@@ -912,6 +912,14 @@ export function ensureMapHelpers(ctx: CodegenContext): void {
  * assume); native strings and other GC refs are already anyref subtypes;
  * externrefs externalize via `any.convert_extern`.
  */
+/**
+ * (#2162) Re-exported for the Set runtime, which reuses the Map backing store
+ * and needs the identical key/value → anyref boxing for its element arg.
+ */
+export function coerceSetArgToAnyref(ctx: CodegenContext, fctx: FunctionContext, t: ValType | null): void {
+  coerceArgToAnyref(ctx, fctx, t);
+}
+
 function coerceArgToAnyref(ctx: CodegenContext, fctx: FunctionContext, t: ValType | null): void {
   if (t === null) {
     // Absent value (e.g. compileExpression produced nothing) — push a null

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -28,6 +28,7 @@ import { patchStructNewForAddedField } from "./expressions/late-imports.js";
 import { addUnionImports, resolveWasmType } from "./index.js";
 import { tryCompileNativeGeneratorResultProperty } from "./generators-native.js";
 import { tryCompileNativeMapSizeGet } from "./map-runtime.js";
+import { tryCompileNativeSetSizeGet } from "./set-runtime.js";
 import { tryEmitLinearU8ElementGet, tryEmitLinearU8Length } from "./linear-uint8-codegen.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import {
@@ -3504,6 +3505,15 @@ function compileExternPropertyGet(
   if (className === "Map" && propName === "size" && ctx.nativeStrings) {
     addUnionImports(ctx);
     const sizeResult = tryCompileNativeMapSizeGet(ctx, fctx, expr.expression);
+    if (sizeResult !== undefined) return sizeResult as ValType;
+  }
+
+  // (#2162) Native Set `.size` accessor in standalone / nativeStrings mode →
+  // `__map_size` (the Set reuses the Map backing store) instead of the
+  // `Set_get_size` host import.
+  if (className === "Set" && propName === "size" && ctx.nativeStrings) {
+    addUnionImports(ctx);
+    const sizeResult = tryCompileNativeSetSizeGet(ctx, fctx, expr.expression);
     if (sizeResult !== undefined) return sizeResult as ValType;
   }
 

--- a/src/codegen/set-runtime.ts
+++ b/src/codegen/set-runtime.ts
@@ -1,0 +1,158 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2162 — Wasm-native `Set` runtime for standalone / WASI targets.
+ *
+ * In JS-host mode `new Set()` and every method call route through the
+ * `builtinCtors` host table and `ctx.externClasses`, emitting `Set_new` /
+ * `Set_add` / … host imports. Under `--target standalone` / `--target wasi`
+ * there is no JS host to satisfy those imports, so this module provides a
+ * pure-WasmGC Set by REUSING the native Map runtime (`map-runtime.ts`): a Set
+ * is a Map whose every entry has `value === key`. The `$Map` struct, ordered
+ * hash table, SameValueZero key equality, and tombstone deletion are all
+ * shared — only `add` (store `(v, v)`) is new.
+ *
+ * Backing representation: the native `$Map` struct (`ctx.mapTypeIdx`). A
+ * `Set`-typed binding therefore resolves to `ref $Map` (see `resolveWasmType`),
+ * exactly like `Map`. Interception mirrors the Map sites:
+ *   - `new Set()`  → `__map_new`            (new-super.ts)
+ *   - `s.add(v)`   → `__set_add(m, v)`       (this module; wraps `__map_set`)
+ *   - `s.has(v)`   → `__map_has(m, v)`
+ *   - `s.delete(v)`→ `__map_delete(m, v)`
+ *   - `s.clear()`  → `__map_clear(m)`
+ *   - `s.size`     → `__map_size(m)`
+ *
+ * Everything is emitted lazily and only when the native-collections path is
+ * active (`ctx.nativeStrings`). The JS-host path is untouched.
+ *
+ * Slice 1 covers number/string/object elements with
+ * new/add/has/delete/clear/size. Iteration (`forEach`, `for-of`,
+ * `new Set(iterable)`, `keys`/`values`/`entries`) and ES2025 set-algebra
+ * (`union`/`intersection`/…) are follow-up slices.
+ */
+import { ts } from "../ts-api.js";
+import type { Instr, ValType } from "../ir/types.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { addFuncType } from "./registry/types.js";
+import type { InnerResult } from "./shared.js";
+import { compileExpression, VOID_RESULT } from "./shared.js";
+import { coerceSetArgToAnyref, ensureMapHelpers } from "./map-runtime.js";
+
+/**
+ * Emit the `__set_add(m, v) -> ref $Map` helper (idempotent). `Set.add` stores
+ * the element as both key and value so the shared Map lookup/iteration sees a
+ * normal entry; the return value is the map itself (Set.add is chainable and
+ * returns the Set, spec 24.2.3.1).
+ */
+export function ensureSetHelpers(ctx: CodegenContext): void {
+  ensureMapHelpers(ctx);
+  if (ctx.mapHelpers.has("__set_add")) return;
+  if (ctx.mapTypeIdx < 0) return;
+
+  const mref: ValType = { kind: "ref", typeIdx: ctx.mapTypeIdx };
+  const anyref: ValType = { kind: "anyref" };
+  const mapSetIdx = ctx.mapHelpers.get("__map_set");
+  if (mapSetIdx === undefined) return;
+
+  // __set_add(m, v): return __map_set(m, v, v)
+  const body: Instr[] = [
+    { op: "local.get", index: 0 }, // m
+    { op: "local.get", index: 1 }, // key = v
+    { op: "local.get", index: 1 }, // value = v
+    { op: "call", funcIdx: mapSetIdx } as Instr,
+  ];
+  const typeIdx = addFuncType(ctx, [mref, anyref], [mref]);
+  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  ctx.mapHelpers.set("__set_add", funcIdx);
+  ctx.mod.functions.push({ name: "__set_add", typeIdx, locals: [], body, exported: false });
+}
+
+/**
+ * Cast a compiled receiver expression to `ref $Map` (the Set backing store).
+ * Returns false when the receiver is a different concrete struct (so the
+ * generic extern/host path can try). Mirrors the Map receiver-cast logic.
+ */
+function castReceiverToMap(ctx: CodegenContext, fctx: FunctionContext, recvType: ValType | null): boolean {
+  if (recvType === null) return false;
+  if (recvType.kind === "externref") {
+    fctx.body.push({ op: "any.convert_extern" } as Instr);
+    fctx.body.push({ op: "ref.cast", typeIdx: ctx.mapTypeIdx } as Instr);
+  } else if (recvType.kind === "anyref" || recvType.kind === "eqref") {
+    fctx.body.push({ op: "ref.cast", typeIdx: ctx.mapTypeIdx } as Instr);
+  } else if ((recvType.kind === "ref" || recvType.kind === "ref_null") && recvType.typeIdx !== ctx.mapTypeIdx) {
+    return false; // wrong struct — not our Set
+  }
+  return true;
+}
+
+/**
+ * (#2162) Intercept a `Set.prototype.*` method call in standalone /
+ * `nativeStrings` mode and route it to the WasmGC-native Set/Map runtime.
+ * Returns the result `InnerResult` when handled, or `undefined` to let the
+ * generic extern/host path proceed (JS-host mode, or unsupported methods).
+ *
+ * Receiver and arguments are compiled here.
+ */
+export function tryCompileNativeSetMethodCall(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  propAccess: ts.PropertyAccessExpression,
+  callExpr: ts.CallExpression,
+): InnerResult | undefined {
+  if (!ctx.nativeStrings) return undefined;
+  const methodName = propAccess.name.text;
+  const handled = methodName === "add" || methodName === "has" || methodName === "delete" || methodName === "clear";
+  if (!handled) return undefined;
+
+  ensureSetHelpers(ctx);
+  if (ctx.mapTypeIdx < 0) return undefined;
+  const helperName = methodName === "add" ? "__set_add" : `__map_${methodName}`;
+  const helperIdx = ctx.mapHelpers.get(helperName);
+  if (helperIdx === undefined) return undefined;
+
+  // Receiver → ref $Map.
+  const recvType = compileExpression(ctx, fctx, propAccess.expression);
+  if (!castReceiverToMap(ctx, fctx, recvType)) return undefined;
+
+  const args = callExpr.arguments;
+  switch (methodName) {
+    case "add": {
+      const vt = args.length > 0 ? compileExpression(ctx, fctx, args[0]!) : null;
+      coerceSetArgToAnyref(ctx, fctx, vt);
+      fctx.body.push({ op: "call", funcIdx: helperIdx });
+      // __set_add returns ref $Map (the set) — chainable.
+      return { kind: "ref", typeIdx: ctx.mapTypeIdx } as ValType;
+    }
+    case "has":
+    case "delete": {
+      const vt = args.length > 0 ? compileExpression(ctx, fctx, args[0]!) : null;
+      coerceSetArgToAnyref(ctx, fctx, vt);
+      fctx.body.push({ op: "call", funcIdx: helperIdx });
+      // has/delete → i32 (boolean).
+      return { kind: "i32" } as ValType;
+    }
+    case "clear": {
+      fctx.body.push({ op: "call", funcIdx: helperIdx });
+      return VOID_RESULT;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * (#2162) Intercept the `Set.prototype.size` accessor in standalone /
+ * `nativeStrings` mode → `__map_size` (returns i32). Receiver compiled here.
+ */
+export function tryCompileNativeSetSizeGet(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  receiver: ts.Expression,
+): InnerResult | undefined {
+  if (!ctx.nativeStrings) return undefined;
+  ensureSetHelpers(ctx);
+  const sizeIdx = ctx.mapHelpers.get("__map_size");
+  if (sizeIdx === undefined || ctx.mapTypeIdx < 0) return undefined;
+  const recvType = compileExpression(ctx, fctx, receiver);
+  if (!castReceiverToMap(ctx, fctx, recvType)) return undefined;
+  fctx.body.push({ op: "call", funcIdx: sizeIdx });
+  return { kind: "i32" } as ValType;
+}

--- a/tests/issue-2162-standalone-set.test.ts
+++ b/tests/issue-2162-standalone-set.test.ts
@@ -1,0 +1,122 @@
+// #2162 — Wasm-native Set dispatch (standalone / nativeStrings).
+//
+// A standalone `Set` had no Wasm-native runtime, so `new Set()` + add/has/
+// delete/size leaked `Set_*` host imports a pure-Wasm engine can't satisfy
+// (286 standalone Set test262 failures). This adds a native Set that REUSES the
+// #1103a Map backing store (a Set is a Map with `value === key`). This file is
+// the regression net for the wiring that routes `new Set()` +
+// `.add/.has/.delete/.clear/.size` onto that runtime under `--target wasi`.
+//
+// Slice 1 scope: no-arg `new Set()`, number + native-string + chained add,
+// add/has/delete/clear/size. Iteration (for-of / forEach / `new Set(iterable)`)
+// and ES2025 set-algebra are follow-up slices.
+//
+// Each test compiles with `target: "wasi"` and asserts (a) the module is valid
+// Wasm, (b) it carries ZERO `Set_*`/`Map_*` host imports, and (c) it returns
+// the expected value when instantiated against the WASI polyfill and run.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildWasiPolyfill } from "../src/runtime.js";
+
+/** Compile `source` with `--target wasi`, run `test()`, return its value. */
+async function runSet(source: string): Promise<{ value: number; collImports: number; valid: boolean }> {
+  const result = await compile(source, { fileName: "test.ts", target: "wasi" });
+  if (!result.success) {
+    throw new Error(`compile failed: ${result.errors?.[0]?.message ?? "unknown error"}`);
+  }
+  const valid = WebAssembly.validate(result.binary);
+  const module = await WebAssembly.compile(result.binary);
+  const collImports = WebAssembly.Module.imports(module).filter((i) => /^(Set|Map)_/.test(i.name)).length;
+
+  const wasi = buildWasiPolyfill();
+  const instance = await WebAssembly.instantiate(module, { wasi_snapshot_preview1: wasi });
+  const exports = instance.exports as Record<string, unknown>;
+  if (exports.memory) wasi.setMemory(exports.memory as WebAssembly.Memory);
+  const value = (exports.test as () => number)();
+  return { value, collImports, valid };
+}
+
+describe("#2162 native Set dispatch (standalone)", () => {
+  it("add + has for number elements — host-import-free", async () => {
+    const { value, collImports, valid } = await runSet(
+      `export function test(): number {
+         const s = new Set<number>();
+         s.add(5);
+         return (s.has(5) ? 1 : 0) + (s.has(9) ? 10 : 0);
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(collImports).toBe(0);
+    expect(value).toBe(1); // has(5)=true, has(9)=false
+  });
+
+  it("size dedups equal elements", async () => {
+    const { value, collImports, valid } = await runSet(
+      `export function test(): number {
+         const s = new Set<number>();
+         s.add(1); s.add(1); s.add(2);
+         return s.size;
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(collImports).toBe(0);
+    expect(value).toBe(2);
+  });
+
+  it("delete removes the element and returns whether it was present", async () => {
+    const { value, collImports, valid } = await runSet(
+      `export function test(): number {
+         const s = new Set<number>();
+         s.add(7);
+         const first = s.delete(7) ? 1 : 0;   // present → true
+         const second = s.delete(7) ? 1 : 0;  // already gone → false
+         const stillHas = s.has(7) ? 1 : 0;   // false
+         return first * 100 + second * 10 + stillHas;
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(collImports).toBe(0);
+    expect(value).toBe(100); // 1,0,0
+  });
+
+  it("clear empties the set", async () => {
+    const { value, collImports, valid } = await runSet(
+      `export function test(): number {
+         const s = new Set<number>();
+         s.add(1); s.add(2); s.add(3);
+         s.clear();
+         return s.size;
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(collImports).toBe(0);
+    expect(value).toBe(0);
+  });
+
+  it("string elements dedup by content", async () => {
+    const { value, collImports, valid } = await runSet(
+      `export function test(): number {
+         const s = new Set<string>();
+         s.add("a"); s.add("b"); s.add("a");
+         return s.size * 10 + (s.has("b") ? 1 : 0);
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(collImports).toBe(0);
+    expect(value).toBe(21); // size 2, has("b") true
+  });
+
+  it("add is chainable and returns the set", async () => {
+    const { value, collImports, valid } = await runSet(
+      `export function test(): number {
+         const s = new Set<number>();
+         s.add(1).add(2).add(3);
+         return s.size;
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(collImports).toBe(0);
+    expect(value).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

Slice 1 of #2162 (standalone Map/Set/WeakMap/WeakSet conformance gap, ~532 tests). Adds a Wasm-native standalone `Set` runtime — the dominant slice (`built-ins/Set` ≈ 286 tests).

Standalone `Set` had **no** native runtime: `new Set()`/`add`/`has`/`delete`/`size` leaked `Set_new`/`Set_add`/`Set_has`/`Set_get_size` host imports a pure-Wasm module can't satisfy, so every standalone Set program failed to instantiate.

A Set is a Map with `value === key`, so this **reuses the entire #1103a Map backing store** (`map-runtime.ts`: ordered hash table, SameValueZero key equality, tombstone deletion). New `src/codegen/set-runtime.ts` adds only `__set_add(m,v) = __map_set(m,v,v)` plus dispatch interceptors; `has`/`delete`/`clear`/`size` route straight to the `__map_*` helpers.

## Wiring (mirrors Map)
- `new Set()` → `__map_new` (new-super.ts)
- method calls → `tryCompileNativeSetMethodCall` (extern.ts)
- `.size` → `tryCompileNativeSetSizeGet` (property-access.ts)
- `Set` resolves to `ref $Map` (resolveWasmType, index.ts)
- `Set` externClass registration skipped under `nativeStrings` so no `Set_*` host import is emitted

**Host/gc mode is unchanged** (still uses the externClass path, byte-identical).

## Tests
`tests/issue-2162-standalone-set.test.ts` — 6/6 (`--target wasi`, asserts zero `Set_*`/`Map_*` imports): add+has, size dedup, delete + return value, clear, string-element dedup, chained `add().add()`. Existing #1103a Map + linear-map/set tests stay green (verified locally).

## Scope / follow-up
This is **slice 1**; the issue stays `in-progress`. Remaining slices: Set iteration (forEach/for-of/keys/values/entries, `new Set(iterable)`), ES2025 set-algebra, and standalone WeakMap/WeakSet (separate identity-key representation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)