### PR TITLE
chore: sync test262 conformance numbers to current baseline (31,357)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,7 +339,7 @@ The issue frontmatter `status:` field tracks where an issue is, set by whichever
 3. Update `plan/issues/backlog/backlog.md` if the issue was listed there
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,353 / 43,135 (72.7 %) — baseline a3fd74c7, 2026-06-16T10:35:16Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
 <!-- AUTO:conformance-end -->
 
 ### Sprint History

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ STATUS.md rather than duplicating numbers that go stale. Standalone
 README until the current standalone regression is fixed.
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,353 / 43,135 (72.7 %) — baseline a3fd74c7, 2026-06-16T10:35:16Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
 <!-- AUTO:conformance-end -->
 
 ## Current Status

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ Over 31 development sprints and **784 closed issues**, js2wasm has grown from a 
 ### Conformance
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,353 / 43,135 (72.7 %) — baseline a3fd74c7, 2026-06-16T10:35:16Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
 <!-- AUTO:conformance-end -->
 
 - Automated conformance tracking with historical trend data and a public [conformance report](https://loopdive.github.io/js2wasm/benchmarks/report.html)

--- a/plan/goals/goal-graph.md
+++ b/plan/goals/goal-graph.md
@@ -5,7 +5,7 @@ Unlike a linear roadmap, multiple independent goals can be worked on in parallel
 and a goal being "ready" doesn't mean it should be worked on immediately.
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,353 / 43,135 (72.7 %) — baseline a3fd74c7, 2026-06-16T10:35:16Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
 <!-- AUTO:conformance-end -->
 
 ## DAG


### PR DESCRIPTION
## Problem

`upstream/main` currently **fails** the `quality` job's *Conformance numbers in sync (#1522)* gate. The FORCED baseline-refresh bot commit (`330b3cb66`, `[skip ci]`) bumped `benchmarks/results/test262-current.json` to **31,357 / 43,135** but skipped CI, so the sync gate never ran and README / ROADMAP / CLAUDE.md / goal-graph were left at the stale **31,353** count.

Because the merge queue merges `main` into every PR before testing, this drift poisons the `quality` check for **every open PR** (#1595, #1604, #1605, #1613, #1614 all fail on exactly this).

## Fix

Ran `pnpm run sync:conformance` to realign the four doc files with the committed baseline. Pure docs change.

Note: the rendered string shows "baseline unknown" because the bot left `baseline_sha: ""` in the JSON — that self-corrects on the next real `promote-baseline` run; out of scope here.

Once this lands, the other open PRs clear the gate on their normal merge-main step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)