### PR TITLE
fix(#2151): spread-of-array-literal any-receiver method dispatch (slice 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,7 +339,7 @@ The issue frontmatter `status:` field tracks where an issue is, set by whichever
 3. Update `plan/issues/backlog/backlog.md` if the issue was listed there
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,353 / 43,135 (72.7 %) — baseline a3fd74c7, 2026-06-16T10:35:16Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
 <!-- AUTO:conformance-end -->
 
 ### Sprint History

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ STATUS.md rather than duplicating numbers that go stale. Standalone
 README until the current standalone regression is fixed.
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,353 / 43,135 (72.7 %) — baseline a3fd74c7, 2026-06-16T10:35:16Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
 <!-- AUTO:conformance-end -->
 
 ## Current Status

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ Over 31 development sprints and **784 closed issues**, js2wasm has grown from a 
 ### Conformance
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,353 / 43,135 (72.7 %) — baseline a3fd74c7, 2026-06-16T10:35:16Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
 <!-- AUTO:conformance-end -->
 
 - Automated conformance tracking with historical trend data and a public [conformance report](https://loopdive.github.io/js2wasm/benchmarks/report.html)

--- a/plan/goals/goal-graph.md
+++ b/plan/goals/goal-graph.md
@@ -5,7 +5,7 @@ Unlike a linear roadmap, multiple independent goals can be worked on in parallel
 and a goal being "ready" doesn't mean it should be worked on immediately.
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,353 / 43,135 (72.7 %) — baseline a3fd74c7, 2026-06-16T10:35:16Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
 <!-- AUTO:conformance-end -->
 
 ## DAG

--- a/plan/issues/2151-standalone-any-receiver-method-dispatch.md
+++ b/plan/issues/2151-standalone-any-receiver-method-dispatch.md
@@ -194,3 +194,33 @@ the Slice 1 0-arg path (`next()`=7) intact. Test: `tests/issue-2151-nary.test.ts
   function") — pre-existing host limitation (verified on main), out of scope
   (this fix is gated on standalone/wasi).
 - Spread-arg method calls (`o.m(...xs)`).
+
+## Slice 3 RESULT (2026-06-17, dev-3) — spread-of-array-literal — IMPLEMENTED & GREEN
+
+The any-receiver dispatch site (`calls.ts` ~`:8276`) previously bailed to the
+generic host-import path whenever ANY arg was a spread, so `o.m(...[2,3])`
+returned 0 standalone. A spread of an **array literal** has a
+statically-known argument list, so it can use the same arity-specialized
+dispatcher: the gate now runs `flattenCallArgs(expr.arguments)` (the existing
+helper that expands `...[a,b]` into `a, b`, returning null for a dynamic
+spread). When it returns a flat list, the dispatch arity + per-arg compilation
+use that list; a dynamic spread (`o.m(...xs)`) still returns null → falls
+through to the generic path (would need runtime variable-arity dispatch).
+
+Re-validation on main also confirmed Slices 1–2 are landed and the previously
+"deferred" **built-in-method-name collision** cases (`o.add(5)`→25,
+`o.push(3)`→6) now pass too — only spread args remained.
+
+### Test Results
+
+- `tests/issue-2151-spread-literal.test.ts` — 5/5, zero host imports:
+  two-element / `this`-threading / mixed `m(1, ...[2,3])` / single-element /
+  empty `...[]`.
+- No regression: `issue-2151-nary` + `issue-2025` + `object-methods` +
+  `object-literals` — 46/46. Host mode unaffected (gated `standalone||wasi`).
+  `npm run typecheck` + Biome lint clean (no warnings on edited lines).
+
+### Still carried forward (issue stays in-progress)
+
+- Dynamic-spread method calls `o.m(...xs)` (runtime variable-arity dispatch).
+- Host-mode any-method on a closed object literal (pre-existing host limitation).

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -8271,11 +8271,17 @@ function compileCallExpression(
           ts.isIdentifier(propAccess.expression) && BUILTIN_CLASS_NAMES.has(propAccess.expression.text);
         // (#2151 Slice 2) N-ary: the dispatcher is arity-specialized
         // `__call_m_<name>_<arity>(recv, arg0..arg{arity-1})` (all externref).
-        // Spread args fall through to the generic path (the dispatcher has a
-        // fixed arity).
+        // (#2151 Slice 3) Spread of an ARRAY LITERAL (`o.m(...[2,3])`) flattens
+        // to a fixed argument list at compile time, so it can use the same
+        // arity-specialized dispatcher. A spread of a DYNAMIC source
+        // (`o.m(...xs)`) has no statically-known arity → flattenCallArgs returns
+        // null and it falls through to the generic path.
         const hasSpreadArg = expr.arguments.some((a) => ts.isSpreadElement(a));
-        if ((ctx.standalone || ctx.wasi) && !hasSpreadArg && !recvIsBuiltinClass) {
-          const arity = expr.arguments.length;
+        const dispatchArgs: ts.Expression[] | null = hasSpreadArg
+          ? flattenCallArgs(expr.arguments)
+          : [...expr.arguments];
+        if ((ctx.standalone || ctx.wasi) && dispatchArgs !== null && !recvIsBuiltinClass) {
+          const arity = dispatchArgs.length;
           const dispatchIdx = reserveClosedMethodDispatch(ctx, methodName, arity);
           flushLateImportShifts(ctx, fctx);
           // Receiver as externref.
@@ -8287,7 +8293,7 @@ function compileCallExpression(
           }
           // Each argument compiled and boxed to externref (the dispatcher unboxes
           // to the method's declared param type per candidate struct).
-          for (const arg of expr.arguments) {
+          for (const arg of dispatchArgs) {
             const at = compileExpression(ctx, fctx, arg, { kind: "externref" });
             if (at && at.kind !== "externref") coerceType(ctx, fctx, at, { kind: "externref" });
             else if (at === null) fctx.body.push({ op: "ref.null.extern" });

--- a/tests/issue-2151-spread-literal.test.ts
+++ b/tests/issue-2151-spread-literal.test.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2151 Slice 3 — spread of an array LITERAL in an any-receiver method call.
+ *
+ * Slices 1/2 added the arity-specialized closed-struct method dispatcher
+ * (`__call_m_<name>_<arity>`) for `o.m(a, b)` on an `any`/externref
+ * object-literal receiver, but spread args fell through to the generic
+ * (host-import) path and returned 0 standalone. A spread of an array LITERAL
+ * (`o.m(...[2, 3])`) has a statically-known argument list — `flattenCallArgs`
+ * expands it before the arity check so it uses the same dispatcher.
+ *
+ * Spread of a DYNAMIC source (`o.m(...xs)`) has no statically-known arity and
+ * still falls through (would need runtime variable-arity dispatch — out of
+ * scope for this slice).
+ *
+ * Every case compiles standalone with ZERO host imports.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const imports = WebAssembly.Module.imports(mod).map((i) => `${i.module}::${i.name}`);
+  expect(imports, "standalone module must have zero host imports").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2151 Slice 3 — spread-of-array-literal any-receiver method call", () => {
+  it("two-element literal spread: o.m(...[2,3])", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o:any={m(a:number,b:number){return a+b}}; return o.m(...[2,3]); }`,
+      ),
+    ).toBe(5);
+  });
+
+  it("literal spread threads through to a method using this", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o:any={base:10,plus(a:number,b:number){return this.base+a+b}}; return o.plus(...[2,3]); }`,
+      ),
+    ).toBe(15);
+  });
+
+  it("mixed fixed + literal spread: o.m(1, ...[2,3])", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o:any={m(a:number,b:number,c:number){return a*100+b*10+c}}; return o.m(1, ...[2,3]); }`,
+      ),
+    ).toBe(123);
+  });
+
+  it("single-element literal spread: o.f(...[5])", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o:any={f(n:number){return n+4}}; return o.f(...[5]); }`,
+      ),
+    ).toBe(9);
+  });
+
+  it("empty literal spread: o.next(...[])", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o:any={next(){return 7}}; return o.next(...[]); }`,
+      ),
+    ).toBe(7);
+  });
+});

--- a/tests/issue-2151-spread-literal.test.ts
+++ b/tests/issue-2151-spread-literal.test.ts
@@ -63,9 +63,7 @@ describe("#2151 Slice 3 — spread-of-array-literal any-receiver method call", (
 
   it("empty literal spread: o.next(...[])", async () => {
     expect(
-      await runStandalone(
-        `export function test(): number { const o:any={next(){return 7}}; return o.next(...[]); }`,
-      ),
+      await runStandalone(`export function test(): number { const o:any={next(){return 7}}; return o.next(...[]); }`),
     ).toBe(7);
   });
 });


### PR DESCRIPTION
## Summary

Slice 3 of standalone any-receiver method dispatch (#2151). Slices 1/2 (on main)
added the arity-specialized closed-struct method dispatcher
(`__call_m_<name>_<arity>`) for `o.m(a, b)` on an `any`/externref object-literal
receiver, but the dispatch site bailed to the generic host-import path whenever
**any** arg was a spread, so `o.m(...[2,3])` returned 0 standalone.

## Fix

A spread of an array **literal** has a statically-known argument list, so it can
use the same dispatcher. The gate at `calls.ts` ~`:8276` now runs
`flattenCallArgs(expr.arguments)` (the existing helper expanding `...[a,b]` into
`a, b`, returning null for a dynamic spread). When non-null, the dispatch arity
+ per-arg compilation use the flattened list. A **dynamic** spread
(`o.m(...xs)`) still returns null → falls through to the generic path (runtime
variable-arity dispatch is out of scope).

While re-validating I also confirmed Slices 1–2 are landed and the previously
"deferred" built-in-method-name-collision cases (`o.add(5)`→25, `o.push(3)`→6)
now pass too — spread args were the last standalone residual.

## Tests

`tests/issue-2151-spread-literal.test.ts` — 5 cases (two-element /
`this`-threading / mixed `m(1, ...[2,3])` / single-element / empty `...[]`), all
**zero host imports**. No regression: `issue-2151-nary` + `issue-2025` +
`object-methods` + `object-literals` = **46/46**. Host mode unaffected (gated
`standalone||wasi`). `npm run typecheck` + Biome lint clean.

## Scope

Issue stays `in-progress` — dynamic-spread (`o.m(...xs)`) and host-mode
any-method on a closed object literal are carried forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)