### PR TITLE
fix(#2029): retire __new_<Builtin> + __tag_user_class host-import leaks for standalone extends-Error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,7 +339,7 @@ The issue frontmatter `status:` field tracks where an issue is, set by whichever
 3. Update `plan/issues/backlog/backlog.md` if the issue was listed there
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,353 / 43,135 (72.7 %) — baseline a3fd74c7, 2026-06-16T10:35:16Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
 <!-- AUTO:conformance-end -->
 
 ### Sprint History

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ STATUS.md rather than duplicating numbers that go stale. Standalone
 README until the current standalone regression is fixed.
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,353 / 43,135 (72.7 %) — baseline a3fd74c7, 2026-06-16T10:35:16Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
 <!-- AUTO:conformance-end -->
 
 ## Current Status

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ Over 31 development sprints and **784 closed issues**, js2wasm has grown from a 
 ### Conformance
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,353 / 43,135 (72.7 %) — baseline a3fd74c7, 2026-06-16T10:35:16Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
 <!-- AUTO:conformance-end -->
 
 - Automated conformance tracking with historical trend data and a public [conformance report](https://loopdive.github.io/js2wasm/benchmarks/report.html)

--- a/plan/goals/goal-graph.md
+++ b/plan/goals/goal-graph.md
@@ -5,7 +5,7 @@ Unlike a linear roadmap, multiple independent goals can be worked on in parallel
 and a goal being "ready" doesn't mean it should be worked on immediately.
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,353 / 43,135 (72.7 %) — baseline a3fd74c7, 2026-06-16T10:35:16Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
 <!-- AUTO:conformance-end -->
 
 ## DAG

--- a/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
+++ b/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
@@ -4,7 +4,7 @@ title: "standalone: `Binary emit error: u32 out of range: -1` on builtin subclas
 status: in-progress
 sprint: 63
 created: 2026-06-10
-updated: 2026-06-15
+updated: 2026-06-17
 priority: critical
 feasibility: medium
 reasoning_effort: high
@@ -170,3 +170,40 @@ standalone still leaks the `__new_<Builtin>` HOST import (`class-bodies.ts:1423/
 — a host-import-retirement concern, not the emit crash. Kept #2029 `in-progress`:
 the emit-crash cluster (the headline) is fixed; the `__new_<Builtin>` standalone
 runtime path is the residual. Reassess closing once that lands.
+
+## PR-2 landed (2026-06-17, dev-1) — `extends Error` runtime host-import retirement
+
+Retired the `__new_<Builtin>` + `__tag_user_class` host-import leaks for
+`extends Error/TypeError/RangeError/…` subclasses under `--target standalone`
+(and `wasi`). The subclass instance now constructs, satisfies `instanceof`, and
+reads `.message`/`.name`/`.stack` natively with ZERO `env.*` imports — the module
+instantiates with a truly empty `{}` import object.
+
+Three coordinated fixes (`src/codegen/class-bodies.ts` + `property-access.ts`):
+1. **Both subclass ctor sites** (implicit-ctor `isExternrefBacked` path ~1506,
+   explicit `super(msg)` path ~2272) now call `emitWasiErrorConstructor` (native
+   `$Error_struct` builder, registers `__new_<Parent>` as a DEFINED func) before
+   the `ensureLateImport(ctx, "__new_<Parent>", …)` lookup when
+   `(ctx.wasi||ctx.standalone) && isWasiErrorName(parent)`. The lookup then
+   resolves to the native func — no host import added. Mirrors new-super.ts:1981
+   for direct `new Error(...)`. Host mode unchanged.
+2. **`__tag_user_class` registration skipped** under no-JS-host: it only feeds the
+   `__instanceof` HOST import (itself unavailable standalone); standalone
+   instanceof resolves at compile time (`tryStaticInstanceOf`) or via the native
+   `$Error_struct` `$tag` field, so the call was pure dead-weight leak. Mirrors
+   the emitSetSubclassProto standalone-skip from PR-1.
+3. **`.message`/`.name`/`.stack` read** (property-access.ts ~1827) now recognises
+   a user error subclass (`class E extends Error`) by walking
+   classBuiltinParentMap → classParentMap to a builtin-error ancestor, so the
+   field read hits the native struct instead of the null `__extern_get` path.
+
+Test: `tests/issue-2029-subclass-builtin-standalone-emit.test.ts` (new
+"runs standalone with zero host imports" block — empty-`{}` instantiation
+proves no `env.*` leak). tsc + prettier clean; no host-mode change.
+
+**Still-residual (pre-existing, NOT introduced — separate follow-up):** a
+**multi-level** user error subclass (`class B extends A extends Error`) returns
+`b instanceof Error === false` (the `tryStaticInstanceOf` transitive
+builtin-ancestor walk doesn't climb `classParentMap` past the direct parent).
+Confirmed 0 on main pre-fix too; only the leak differs (PR-2 removes it, the
+static-instanceof gap remains). Direct (1-level) `instanceof Error` is correct.

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -33,6 +33,7 @@ import {
 import { emitUndefined } from "./expressions/late-imports.js";
 import { addStringConstantGlobal, ensureExnTag, nextModuleGlobalIdx } from "./registry/imports.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
+import { emitWasiErrorConstructor, isWasiErrorName } from "./registry/error-types.js";
 import {
   cacheParamDefaultArgc,
   emitF64ParamSentinelCheck,
@@ -1507,6 +1508,19 @@ function compileClassBodiesInner(
       const parentName = ctx.classBuiltinParentMap.get(className);
       if (parentName) {
         const importName = `__new_${parentName}`;
+        // (#2029) Standalone/WASI: a `extends Error/TypeError/…` subclass with no
+        // explicit ctor previously leaked `env.__new_<Parent>` here. Register the
+        // Wasm-native `__new_<Parent>` (builds a $Error_struct, no host import)
+        // so the `ensureLateImport` lookup below resolves to it instead of adding
+        // an unsatisfiable host import. Mirrors new-super.ts:1981 for direct
+        // `new Error(...)`. Host mode is unchanged (isWasiErrorName-gated on the
+        // no-JS-host flags).
+        if ((ctx.wasi || ctx.standalone) && isWasiErrorName(parentName)) {
+          // The native ctor's Wasm signature must match the args the call site
+          // below pushes (exactly `implicitForwarderArity` externref locals); the
+          // ctor reads arg 0 as the message and handles a 0-arg signature.
+          emitWasiErrorConstructor(ctx, parentName, implicitForwarderArity);
+        }
         const forwardParams = externrefParams(implicitForwarderArity);
         const funcIdx = ensureLateImport(ctx, importName, forwardParams, [{ kind: "externref" }]);
         flushLateImportShifts(ctx, fctx);
@@ -1656,7 +1670,18 @@ function compileClassBodiesInner(
     // `instance instanceof Sub` by walking the registered tag chain. The
     // direct user-class parent (or null when the direct parent is a builtin)
     // is registered idempotently on first call.
-    if (isExternrefBacked) {
+    //
+    // (#2029) Skipped under --target standalone/wasi: the `__tag_user_class`
+    // registration ONLY feeds the `__instanceof` HOST import, which is itself
+    // unavailable with no JS host. Standalone `instance instanceof Sub` resolves
+    // at compile time (tryStaticInstanceOf, identifiers.ts) for these
+    // externref-backed error subclasses, and `instanceof Error`/`<WasiError>`
+    // reads the native `$Error_struct` $tag field (identifiers.ts #1473 path) —
+    // neither consults the runtime tag chain. Emitting the call here only leaked
+    // an unsatisfiable `env.__tag_user_class` host import (the residual after the
+    // `__new_<Parent>` fix above). Mirrors the emitSetSubclassProto standalone
+    // skip from #2029 PR-1.
+    if (isExternrefBacked && !(ctx.wasi || ctx.standalone)) {
       const builtinParent = ctx.classBuiltinParentMap.get(className);
       // Direct user-class parent: classParentMap[className] is set to the
       // immediate parent name; if it equals the builtin parent, the user
@@ -2271,6 +2296,14 @@ export function compileSuperCall(
     const hasSpread = args.some((a) => ts.isSpreadElement(a));
     const importName = `__new_${builtinParent}`;
     const forwardArity = getBuiltinConstructorForwardArity(ctx, builtinParent);
+    // (#2029) Standalone/WASI: an explicit `super(msg)` into a builtin-error
+    // parent previously leaked `env.__new_<Parent>`. Register the Wasm-native
+    // `__new_<Parent>` (builds a $Error_struct, no host import) so the lookup
+    // below resolves to it. Signature matches the `forwardArity` args the call
+    // site pushes. Host mode unchanged (isWasiErrorName-gated on no-JS-host).
+    if ((ctx.wasi || ctx.standalone) && isWasiErrorName(builtinParent)) {
+      emitWasiErrorConstructor(ctx, builtinParent, forwardArity);
+    }
     const forwardParams = externrefParams(forwardArity);
     const funcIdx = ensureLateImport(ctx, importName, forwardParams, [{ kind: "externref" }]);
     flushLateImportShifts(ctx, fctx);

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -1826,11 +1826,33 @@ export function compilePropertyAccess(
   // (`null.message` throws), so the trap is acceptable Phase 1/2 semantics.
   if ((ctx.wasi || ctx.standalone) && (propName === "message" || propName === "name" || propName === "stack")) {
     const lhsTsName = objType.getSymbol()?.name;
+    // (#2029) A user error subclass (`class E extends Error {}`) has an instance
+    // that IS the native `$Error_struct` (super() sets __self = __new_<Parent>),
+    // so `e.message`/`.name`/`.stack` must read the struct field directly — but
+    // the static type name `E` is not a builtin, so the builtin-name gate below
+    // misses it. Resolve the user class to its builtin error ancestor by walking
+    // classBuiltinParentMap (direct) then the classParentMap chain (transitive,
+    // for `class B extends A extends Error`). Returns the WasiErrorName ancestor
+    // or undefined.
+    const resolveUserErrorParent = (name: string | undefined): string | undefined => {
+      if (name === undefined || !ctx.classTagMap?.has(name)) return undefined;
+      const seen = new Set<string>();
+      let cur: string | undefined = name;
+      while (cur !== undefined && !seen.has(cur)) {
+        seen.add(cur);
+        const bp = ctx.classBuiltinParentMap?.get(cur);
+        if (bp !== undefined && (bp === "Error" || isWasiErrorName(bp))) return bp;
+        cur = ctx.classParentMap?.get(cur);
+      }
+      return undefined;
+    };
+    const userErrorParent = resolveUserErrorParent(lhsTsName);
     const isErrorLhs =
-      lhsTsName !== undefined &&
-      isBuiltinTypeName(lhsTsName) &&
-      isWasiErrorName(lhsTsName) &&
-      isBuiltinSubtype(lhsTsName, "Error");
+      (lhsTsName !== undefined &&
+        isBuiltinTypeName(lhsTsName) &&
+        isWasiErrorName(lhsTsName) &&
+        isBuiltinSubtype(lhsTsName, "Error")) ||
+      userErrorParent !== undefined;
     // #2077: a `catch (e)` binding is typed `any` (or `unknown`), so the static
     // `isErrorLhs` gate above never fires even though the caught value IS the
     // `$Error` struct at runtime — the field read then fell through to the

--- a/tests/issue-2029-subclass-builtin-standalone-emit.test.ts
+++ b/tests/issue-2029-subclass-builtin-standalone-emit.test.ts
@@ -83,3 +83,72 @@ describe("#2029 — builtin subclass compiles under --target standalone", () => 
     await compilesStandalone(`class A { x: number = 5; } export function test(): number { return new A().x; }`);
   });
 });
+
+/**
+ * #2029 residual — `extends Error` standalone RUNTIME path must not leak the
+ * `env.__new_<Builtin>` / `env.__tag_user_class` HOST imports (the emit crash
+ * was the prior slice). The subclass ctor now registers the Wasm-native
+ * `__new_<Parent>` (`emitWasiErrorConstructor`, $Error_struct) instead of the
+ * host import, the dead `__tag_user_class` tagging is skipped standalone, and
+ * `e.message`/`.name` on a user error subclass read the native struct field.
+ *
+ * These instantiate with a TRULY empty import object ({}) — any leaked
+ * `env.*` import would make `WebAssembly.instantiate(binary, {})` throw, so a
+ * passing run proves zero host imports.
+ */
+describe("#2029 — extends Error runs standalone with zero host imports", () => {
+  async function runStandalone(src: string): Promise<number | string> {
+    const r = await compile(src, { fileName: "repro-2029.ts", target: "standalone" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    const mod = await WebAssembly.compile(r.binary);
+    const envImports = WebAssembly.Module.imports(mod)
+      .filter((i) => i.module === "env")
+      .map((i) => i.name);
+    expect(envImports, `leaked host imports: ${envImports.join(", ")}`).toEqual([]);
+    // Empty import object — proves true standalone instantiability.
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    return (instance.exports as Record<string, () => number | string>).test();
+  }
+
+  it("class extends Error — instance is instanceof the subclass (implicit ctor)", async () => {
+    expect(
+      await runStandalone(
+        `class MyErr extends Error {} export function test(): number { const e = new MyErr("x"); return e instanceof MyErr ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("class extends TypeError — instance is instanceof the subclass", async () => {
+    expect(
+      await runStandalone(
+        `class MyTE extends TypeError {} export function test(): number { const e = new MyTE("x"); return e instanceof MyTE ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("class extends Error (explicit super) — instance is instanceof Error", async () => {
+    expect(
+      await runStandalone(
+        `class E extends Error { constructor(m: string){ super(m); } } export function test(): number { const e = new E("hi"); return e instanceof Error ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("class extends RangeError — instanceof the subclass", async () => {
+    expect(
+      await runStandalone(
+        `class R extends RangeError {} export function test(): number { const e = new R("y"); return e instanceof R ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("user error subclass `.message` reads the native struct field", async () => {
+    // Compare in-Wasm (returns i32) — a raw string export marshals to {} under
+    // an empty import object, so assert the native string equality instead.
+    expect(
+      await runStandalone(
+        `class E extends Error { constructor(m: string){ super(m); } } export function test(): number { const e = new E("hi"); return e.message === "hi" ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Under `--target standalone`/`wasi`, a `class X extends Error/TypeError/RangeError/…` subclass leaked the `env.__new_<Parent>` and `env.__tag_user_class` HOST imports, making the module non-instantiable without a JS runtime. This is the runtime residual of #2029 after PR-1 fixed the emit crash.

## Fix (3 coordinated changes)

**`src/codegen/class-bodies.ts`**
1. Both subclass ctor sites (implicit-ctor `isExternrefBacked` ~1506, explicit `super(msg)` ~2272) register the Wasm-native `__new_<Parent>` via `emitWasiErrorConstructor` (builds a `$Error_struct`) before the `ensureLateImport` lookup, gated on `(wasi||standalone) && isWasiErrorName(parent)`. The lookup resolves to the native func → no host import. Mirrors `new-super.ts:1981` for direct `new Error(...)`.
2. `__tag_user_class` registration skipped under no-JS-host — it only feeds the `__instanceof` HOST import (unavailable standalone); standalone instanceof resolves at compile time / via the native `$tag` field. Mirrors the PR-1 `emitSetSubclassProto` skip.

**`src/codegen/property-access.ts`**
3. `.message`/`.name`/`.stack` on a user error subclass resolves the receiver to its builtin error ancestor (`classBuiltinParentMap`→`classParentMap` walk), reading the native struct field instead of the null `__extern_get` path.

## Validation

`extends Error` subclasses now construct, satisfy `instanceof`, and read `.message` natively standalone with **ZERO `env.*` imports** — verified by instantiating with a truly empty `{}` import object. Host mode unchanged (all gates on no-JS-host flags). `tsc --noEmit` clean; prettier clean. Test: `tests/issue-2029-subclass-builtin-standalone-emit.test.ts` (new 'runs standalone with zero host imports' block, 13/13 pass).

## Scope

Residual (pre-existing, NOT introduced): a multi-level `B extends A extends Error` returns `instanceof Error === false` (the `tryStaticInstanceOf` transitive-ancestor walk gap) — confirmed 0 on main pre-fix; this PR removes the leak, not that gap. Direct (1-level) `instanceof Error` is correct. Issue stays `in-progress`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)