### PR TITLE
fix(#42): box native-string ref as tag-5 string in boxToAny (standalone any concat)

### DIFF
--- a/src/codegen/value-tags.ts
+++ b/src/codegen/value-tags.ts
@@ -184,6 +184,19 @@ export function boxToAny(ctx: CodegenContext, fctx: FunctionContext, from: ValTy
     // downstream by the $BoxedNumber recovery arm in `__any_to_f64`. Keep tag-5.
     return emit("__any_box_string");
   }
+  // (#42) A native WasmGC string is a `ref $AnyString` (nativeStrings/standalone),
+  // not an externref — without this arm it fell through to `__any_box_ref` below
+  // and was boxed as a tag-6 OBJECT (refval), so `const s: any = "x"; s + s`
+  // mis-dispatched `__any_add` (object-ToString, not string concat). Recover the
+  // string by wrapping the ref to externref and boxing it as a tag-5 STRING, the
+  // same representation `const s: any = "x"` carries on a direct read.
+  if (
+    (from.kind === "ref" || from.kind === "ref_null") &&
+    ctx.anyStrTypeIdx >= 0 &&
+    (from as { typeIdx: number }).typeIdx === ctx.anyStrTypeIdx
+  ) {
+    return emit("__any_box_string", [{ op: "extern.convert_any" } as Instr]);
+  }
   if (from.kind === "ref" || from.kind === "ref_null") return emit("__any_box_ref");
   return false;
 }

--- a/tests/issue-2104-value-tags.test.ts
+++ b/tests/issue-2104-value-tags.test.ts
@@ -110,3 +110,61 @@ describe("#2104 boxToAny — behaviour preserved end-to-end", () => {
     expect(await run('export function test(): string { const v: any = "hi"; return String(v); }')).toBe("hi");
   });
 });
+
+describe("#42 boxToAny — native-string ref boxes as tag-5 STRING, not tag-6 object", () => {
+  // In standalone/nativeStrings mode a native string is a `ref $AnyString`
+  // (kind "ref"), so boxToAny used to fall through to the generic `ref →
+  // __any_box_ref` arm and box it as a tag-6 OBJECT. That mis-dispatched
+  // `__any_add` (any+any with a string operand took the object-ToString /
+  // numeric arm instead of string concat). The fix routes a native-string ref
+  // to the tag-5 `__any_box_string` path.
+  async function runStandalone(src: string): Promise<number> {
+    const r = await compile(src, { target: "standalone" });
+    expect(r.success, r.success ? "" : `CE: ${JSON.stringify(r.errors)}`).toBe(true);
+    expect(WebAssembly.validate(r.binary), "valid Wasm").toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    return (instance.exports as Record<string, () => number>).run();
+  }
+
+  it("genuine-any string operands concatenate (inline `as any`)", async () => {
+    expect(
+      await runStandalone(
+        'export function run(): number { const c: any = ("foo" as any) + ("bar" as any); return `${c}`.length; }',
+      ),
+    ).toBe(6);
+  });
+
+  it("genuine-any string operands compare equal to the concatenation", async () => {
+    expect(
+      await runStandalone(
+        'export function run(): number { const c: any = ("foo" as any) + ("bar" as any); return c === "foobar" ? 1 : 0; }',
+      ),
+    ).toBe(1);
+  });
+
+  it("typeof of the concatenation is string (tag-5, not tag-6 object)", async () => {
+    expect(
+      await runStandalone(
+        'export function run(): number { const c: any = ("x" as any) + ("y" as any); return typeof c === "string" ? 1 : 0; }',
+      ),
+    ).toBe(1);
+  });
+
+  it("any-typed (non-narrowed) locals concatenate", async () => {
+    // `let`/genuine-any locals are stored as $AnyValue; this also exercises the
+    // operand-coercion path through boxToAny when an operand isn't already boxed.
+    expect(
+      await runStandalone(
+        "function id(x: any): any { return x; } export function run(): number { const a: any = id('foo'); const b: any = id('bar'); const c: any = a + b; return `${c}`.length; }",
+      ),
+    ).toBe(6);
+  });
+
+  it("numeric any+any addition is unaffected (control)", async () => {
+    expect(
+      await runStandalone(
+        "function id(x: any): any { return x; } export function run(): number { const a: any = id(2); const b: any = id(3); const c: any = a + b; return c as number; }",
+      ),
+    ).toBe(5);
+  });
+});


### PR DESCRIPTION
## #42 (partial) — standalone any-typed string concatenation

### Root cause

In standalone / `nativeStrings` mode a native string is a `ref $AnyString` (Wasm kind `"ref"`). `boxToAny` (`src/codegen/value-tags.ts` — the #2104 canonical tag-policy home) had no native-string arm, so it fell through to the generic `ref → __any_box_ref` path and boxed the string as a **tag-6 OBJECT** (in `refval`). That mis-dispatched `__any_add`: an `any + any` expression with a string operand took the object-ToString / numeric arm instead of string concatenation, so `("foo" as any) + ("bar" as any)` produced `"NaN"` / `"[object Object]"` instead of `"foobar"`.

(`__any_add` itself was correct — genuine tag-5 `$AnyValue` params concatenate fine; the defect was purely the operand *boxing* tag.)

### Fix

Route a native-string ref (`typeIdx === ctx.anyStrTypeIdx`) to the tag-5 `__any_box_string` path, wrapping the ref to externref with `extern.convert_any` — the same tag-5 representation a direct `const s: any = "x"` read already carries.

### What this fixes

Genuine-`any` string operands now concatenate correctly:
- inline `("foo" as any) + ("bar" as any)` → `"foobar"` (len 6, `typeof === "string"`)
- `let`-any locals and any-returned-from-function operands
- numeric `any + any` unchanged (control)

### Scope / residual (deferred)

This is a **partial** fix for #42. Two symptoms remain, both sharing a separate **const-literal-narrowing** representation sub-path (a `const a: any = "lit"` is narrowed by TS to a string-*literal* type and takes a different `+` lowering):
- `const a: any = "foo"; const b: any = "bar"; a + b` still yields `"NaN"`
- `__unbox_number(boolean)` → NaN (`const b: any = true; b as number`)

These are deeper value-rep and recommended for the #2107/#2104 value-rep owner — documented in TaskList #42.

### Validation

- `tests/issue-2104-value-tags.test.ts` +5 cases (12/12 green)
- existing `tests/issue-1988.test.ts` any-add tests unchanged (10/10)
- full `tests/equivalence/` suite exit 0 (the new arm is gated on `anyStrTypeIdx`, so host/GC modes are untouched)
- tsc + biome lint + prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)