### PR TITLE
fix(#1522): drop volatile timestamp from conformance doc blocks (unblocks merge queue)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,7 +339,7 @@ The issue frontmatter `status:` field tracks where an issue is, set by whichever
 3. Update `plan/issues/backlog/backlog.md` if the issue was listed there
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown
 <!-- AUTO:conformance-end -->
 
 ### Sprint History

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ STATUS.md rather than duplicating numbers that go stale. Standalone
 README until the current standalone regression is fixed.
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown
 <!-- AUTO:conformance-end -->
 
 ## Current Status

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ Over 31 development sprints and **784 closed issues**, js2wasm has grown from a 
 ### Conformance
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown
 <!-- AUTO:conformance-end -->
 
 - Automated conformance tracking with historical trend data and a public [conformance report](https://loopdive.github.io/js2wasm/benchmarks/report.html)

--- a/plan/goals/goal-graph.md
+++ b/plan/goals/goal-graph.md
@@ -5,7 +5,7 @@ Unlike a linear roadmap, multiple independent goals can be worked on in parallel
 and a goal being "ready" doesn't mean it should be worked on immediately.
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:16:20.635Z
+**test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown
 <!-- AUTO:conformance-end -->
 
 ## DAG

--- a/scripts/sync-conformance-numbers.mjs
+++ b/scripts/sync-conformance-numbers.mjs
@@ -90,8 +90,12 @@ function renderBlock(report) {
   const totalStr = fmtNumber(report.total);
   const pct = fmtPercent(report.pass, report.total);
   const sha = shortSha(report.sha);
-  const ts = report.generatedAt || "unknown";
-  return `**test262 conformance**: ${passStr} / ${totalStr} (${pct} %) — baseline ${sha}, ${ts}`;
+  // Intentionally omit the volatile baseline-generated timestamp from the
+  // rendered block: the forced-baseline-refresh bot bumps that timestamp
+  // ~hourly with no change to pass/total, which made `sync:conformance:check`
+  // flag drift on every open PR and perpetually block the merge queue (#1522).
+  // The meaningful numbers (pass/total/percentage + baseline sha) stay.
+  return `**test262 conformance**: ${passStr} / ${totalStr} (${pct} %) — baseline ${sha}`;
 }
 
 /**


### PR DESCRIPTION
## Problem

The forced-baseline-refresh bot bumps `baseline_generated_at` ~hourly with **no change to pass/total** (31,357/43,135). But `renderBlock()` in `sync-conformance-numbers.mjs` embedded that timestamp in the 4 doc anchor blocks (ROADMAP/README/CLAUDE/goal-graph). `sync:conformance:check` (the #1522 `quality` gate) compares the **whole block**, so every open PR failed `quality` on a timestamp-only delta — perpetually blocking the merge queue (caused repeated wedges all of 2026-06-17).

## Fix

Render only the meaningful numbers — pass/total/percentage + baseline sha — and drop the volatile generated-at timestamp. Regenerated the 4 docs to the stable format.

## Self-consistency

This PR's own `quality` job runs the NEW script, which renders identically to the PR's updated docs → passes regardless of the bot. Verified locally: `node scripts/sync-conformance-numbers.mjs --check` → 0 updated, 4 unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)