### PR TITLE
feat(#2159): standalone DataView typed accessors (gate __dv_register_view host import)

### DIFF
--- a/plan/issues/2159-standalone-typedarray-dataview-buffer-residual.md
+++ b/plan/issues/2159-standalone-typedarray-dataview-buffer-residual.md
@@ -109,3 +109,47 @@ bucket. Larger; likely a senior-dev slice.
 **Not a slice:** Int8Array signed-read of an out-of-range store (`a[0]=200` →
 expect `-56`) reads unsigned — a separate signed/wrap concern, orthogonal to the
 above.
+
+---
+
+## Slice 3 (2026-06-17) — standalone DataView typed accessors (no host-import leak)
+
+**Landed.** `new DataView(buffer[, offset[, len]])` emitted the host
+`__dv_register_view` import **unconditionally** (so the JS-host runtime bridge
+could window a real native `DataView` on method dispatch). Under
+`--target standalone` / `--target wasi` there is no JS host, so the module
+carried an unsatisfiable `env::__dv_register_view` import and **every**
+`new DataView(...)` was a hard instantiate failure — the dominant `(none)`-leak
+class in the 336-test `built-ins/DataView` bucket.
+
+**Root cause** (`src/codegen/expressions/new-super.ts`, `new DataView` branch):
+the `ensureLateImport("__dv_register_view", …)` + call was emitted with no
+host-mode guard. The accessors themselves (`get/set{Int,Uint,Float}{8,16,32,64}`)
+already have a complete pure-Wasm lowering in `src/codegen/dataview-native.ts`
+(`emitDataViewAccessor`, wired for `noJsHost(ctx)` in `calls.ts`), reading/writing
+bytes directly on the `i32_byte` backing struct with a runtime `littleEndian`
+branch — so the host registration was pure dead weight standalone.
+
+**Fix:**
+1. Gate the `__dv_register_view` emission on `!noJsHost(ctx)`. Standalone still
+   evaluates the `byteOffset`/`byteLength` args for side-effects + the
+   ToIndex/RangeError checks, then operates on the struct directly.
+2. `emitWriteBytes` integer setters used `i32.trunc_sat_f64_s`, which
+   **saturates** (e.g. `setUint32(_, 4e9)` → `0x7FFFFFFF`). The spec
+   (`SetValueInBuffer` → `ToInt{8,16,32}`/`ToUint{8,16,32}`) is **modular**.
+   Switched to `i64.trunc_sat_f64_s` + `i32.wrap_i64` (value mod 2^32; the low
+   `bytes` are then stored), correct for 1/2/4-byte signed+unsigned setters
+   across the ±2^53 integer range, and NaN→0.
+
+Verified standalone: Int8/Uint8 (signed↔unsigned reinterpret), Int16/Uint16/
+Int32/Uint32 (both endiannesses, values ≥ 2^31), Float32/Float64 (both
+endiannesses), byte-order distinctness, modular wrap, NaN→0. Host mode emits the
+registration unchanged (no regression). Tests: `tests/issue-2159.test.ts`
+(`#2159 standalone DataView typed accessors`).
+
+**Out of this slice (offset windowing):** `new DataView(buf, n>0)` base-offset
+windowing is not yet applied to the standalone accessors (the i32_byte vec struct
+has no offset field). Offset-0 views — the dominant accessor-test pattern, where
+the index is the *accessor* argument — are fully native. Windowed-view base
+offset is a shared representation concern with TypedArray-on-buffer windowing
+(Slice 2c) and is a separate follow-up.

--- a/src/codegen/dataview-native.ts
+++ b/src/codegen/dataview-native.ts
@@ -581,7 +581,9 @@ function emitWriteBytes(
   arrTypeIdx: number,
 ): void {
   if (acc.bytes === 1) {
-    // arr[off] = trunc(val) & 0xff
+    // arr[off] = (value mod 256). Spec ToInt8/ToUint8 are modular; go via i64
+    // (`i64.trunc_sat_f64_s` + `i32.wrap_i64`) so large values wrap rather than
+    // saturate (`i32.trunc_sat_f64_s` would clamp ≥2^31), then mask the low byte.
     const out: Instr[] = [];
     emitStoreByte(
       out,
@@ -590,7 +592,8 @@ function emitWriteBytes(
       0,
       [
         { op: "local.get", index: valLocal } as Instr,
-        { op: "i32.trunc_sat_f64_s" } as Instr,
+        { op: "i64.trunc_sat_f64_s" } as Instr,
+        { op: "i32.wrap_i64" } as Instr,
         { op: "i32.const", value: 0xff } as Instr,
         { op: "i32.and" } as Instr,
       ],
@@ -640,9 +643,16 @@ function emitWriteBytes(
     fctx.body.push({ op: "f32.demote_f64" } as Instr);
     fctx.body.push({ op: "i32.reinterpret_f32" } as Instr);
   } else {
-    // Integer: truncate toward zero. trunc_sat_f64_s gives a 32-bit pattern;
-    // for unsigned/odd widths the low N bytes are what matters.
-    fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+    // Integer: the spec (SetValueInBuffer → ToInt{8,16,32}/ToUint{8,16,32}) is
+    // MODULAR (`value mod 2^(8*bytes)`), not saturating. `i32.trunc_sat_f64_s`
+    // *clamps* (e.g. setUint32(_, 4_000_000_000) → 0x7FFFFFFF), which is wrong
+    // for any value ≥ 2^31. Truncate toward zero into an i64 first, then
+    // `i32.wrap_i64` keeps the low 32 bits — i.e. `value mod 2^32`. Only the low
+    // `acc.bytes` of those are stored below, giving the correct modular result
+    // for 2- and 4-byte signed/unsigned setters across the ±2^53 integer range
+    // that conformance exercises.
+    fctx.body.push({ op: "i64.trunc_sat_f64_s" } as Instr);
+    fctx.body.push({ op: "i32.wrap_i64" } as Instr);
   }
   fctx.body.push({ op: "local.set", index: bitsLocal } as Instr);
 

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -3533,7 +3533,20 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       // Always register, even for externref buffers — ArrayBuffer variables
       // in user code are lowered to externref (see checker/type-mapper.ts),
       // but the actual wasmGC struct is what the bridge dispatches on.
-      {
+      //
+      // (#2159) Standalone / WASI mode has no JS host: the accessor
+      // (`get/set{Int,Uint,Float}N`) is lowered to pure-Wasm byte reads/writes
+      // directly on the i32_byte backing struct (see dataview-native.ts), so
+      // there is no runtime bridge to register with. Emitting the host call
+      // unconditionally leaked an unsatisfiable `env::__dv_register_view`
+      // import, making EVERY `new DataView(...)` a hard instantiate failure
+      // standalone. Gate the registration on JS-host mode; standalone evaluates
+      // the offset/length args above for their side effects + RangeError checks
+      // and then operates on the struct directly. (The view-window base offset
+      // for `new DataView(buf, n>0)` is a separate representation slice, shared
+      // with TypedArray-on-buffer windowing; offset-0 views — the dominant
+      // case — are fully native here.)
+      if (!noJsHost(ctx)) {
         const regIdx = ensureLateImport(
           ctx,
           "__dv_register_view",

--- a/tests/issue-2159.test.ts
+++ b/tests/issue-2159.test.ts
@@ -82,3 +82,101 @@ describe("#2159 standalone typed-array element write (packed i8/i16 local leak)"
     ).toBe(0);
   });
 });
+
+// Slice 3 (#2159) — standalone DataView get/set typed accessors.
+//
+// `new DataView(buf)` unconditionally emitted a host `__dv_register_view`
+// import (for the JS-host runtime bridge), so under `--target standalone` /
+// `--target wasi` every DataView was an unsatisfiable import → hard instantiate
+// failure (the 336-test DataView bucket, mostly `(none)`-leak compile errors).
+// Fix: gate the host registration on JS-host mode; standalone lowers the
+// accessors to pure-Wasm byte reads/writes on the i32_byte backing struct
+// (dataview-native.ts). Also fixed the integer setter to wrap modulo 2^(8*bytes)
+// (spec ToInt/ToUint) instead of saturating, so values ≥ 2^31 store correctly.
+describe("#2159 standalone DataView typed accessors (no __dv_register_view leak)", () => {
+  it("new DataView(buf) instantiates standalone with no host import", async () => {
+    const r = await compile(
+      `export function run(): number { const dv = new DataView(new ArrayBuffer(8)); dv.setInt32(0, 7, true); return dv.getInt32(0, true); }`,
+      { target: "standalone" },
+    );
+    expect(r.success, JSON.stringify(r.errors)).toBe(true);
+    expect((r.imports ?? []).some((i) => i.name === "__dv_register_view"), "no host-import leak").toBe(false);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as Record<string, () => number>).run()).toBe(7);
+  });
+
+  it("Int8/Uint8 round-trip + signed/unsigned reinterpretation", async () => {
+    expect(
+      await runStandalone(
+        `export function run(): number {
+           const dv = new DataView(new ArrayBuffer(8));
+           dv.setInt8(0, -56);
+           if (dv.getInt8(0) !== -56) return 1;
+           if (dv.getUint8(0) !== 200) return 2;
+           return 0;
+         }`,
+      ),
+    ).toBe(0);
+  });
+
+  it("Int16/Uint16/Int32/Uint32 round-trip, both endiannesses", async () => {
+    expect(
+      await runStandalone(
+        `export function run(): number {
+           const dv = new DataView(new ArrayBuffer(32));
+           dv.setInt16(0, -1000, true);   if (dv.getInt16(0, true)  !== -1000) return 1;
+           dv.setInt16(2, -1000, false);  if (dv.getInt16(2, false) !== -1000) return 2;
+           dv.setUint16(4, 40000, true);  if (dv.getUint16(4, true) !== 40000) return 3;
+           dv.setInt32(8, -2000000000, false); if (dv.getInt32(8, false) !== -2000000000) return 4;
+           dv.setUint32(12, 4000000000, true); if (dv.getUint32(12, true) !== 4000000000) return 5;
+           return 0;
+         }`,
+      ),
+    ).toBe(0);
+  });
+
+  it("Float32/Float64 round-trip, both endiannesses", async () => {
+    expect(
+      await runStandalone(
+        `export function run(): number {
+           const dv = new DataView(new ArrayBuffer(32));
+           dv.setFloat32(0, 1.5, true);   if (dv.getFloat32(0, true)  !== 1.5) return 1;
+           dv.setFloat32(4, 1.5, false);  if (dv.getFloat32(4, false) !== 1.5) return 2;
+           dv.setFloat64(8, -2.71828, true);  if (Math.abs(dv.getFloat64(8, true)  + 2.71828) > 1e-9) return 3;
+           dv.setFloat64(16, -2.71828, false); if (Math.abs(dv.getFloat64(16, false) + 2.71828) > 1e-9) return 4;
+           return 0;
+         }`,
+      ),
+    ).toBe(0);
+  });
+
+  it("endianness controls byte order (little vs big)", async () => {
+    expect(
+      await runStandalone(
+        `export function run(): number {
+           const dv = new DataView(new ArrayBuffer(8));
+           dv.setUint16(0, 0x0102, true);
+           if (dv.getUint8(0) !== 0x02 || dv.getUint8(1) !== 0x01) return 1;
+           dv.setUint16(2, 0x0102, false);
+           if (dv.getUint8(2) !== 0x01 || dv.getUint8(3) !== 0x02) return 2;
+           return 0;
+         }`,
+      ),
+    ).toBe(0);
+  });
+
+  it("integer setters apply modular wrap, NaN truncates to 0", async () => {
+    expect(
+      await runStandalone(
+        `export function run(): number {
+           const dv = new DataView(new ArrayBuffer(8));
+           dv.setInt32(0, NaN, true);   if (dv.getInt32(0, true) !== 0) return 1;
+           dv.setUint8(4, 256);         if (dv.getUint8(4) !== 0) return 2;
+           dv.setUint8(5, 257);         if (dv.getUint8(5) !== 1) return 3;
+           return 0;
+         }`,
+      ),
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Standalone-gap slice of #2159 — the `built-ins/DataView` bucket (336 tests, mostly `(none)`-leak compile errors).

`new DataView(buffer[, offset[, len]])` emitted the host `__dv_register_view` import **unconditionally** (for the JS-host runtime bridge). Under `--target standalone` / `--target wasi` there is no JS host, so the module carried an unsatisfiable `env::__dv_register_view` import and **every** `new DataView(...)` was a hard instantiate failure. The `get/set{Int,Uint,Float}{8,16,32,64}` accessors already have a complete pure-Wasm lowering in `src/codegen/dataview-native.ts` (wired for `noJsHost`), so the host registration was dead weight standalone.

## Changes
- **`src/codegen/expressions/new-super.ts`** — gate the `__dv_register_view` emission on `!noJsHost(ctx)`. Standalone still evaluates the `byteOffset`/`byteLength` args for side-effects + the ToIndex/RangeError checks, then operates on the `i32_byte` struct directly. Host mode unchanged.
- **`src/codegen/dataview-native.ts`** — integer setters used `i32.trunc_sat_f64_s`, which **saturates** (`setUint32(_, 4e9)` → `0x7FFFFFFF`). The spec (`SetValueInBuffer` → `ToInt/ToUint`) is **modular**. Switched to `i64.trunc_sat_f64_s` + `i32.wrap_i64` (value mod 2^32; low `bytes` stored) so values ≥ 2^31 wrap correctly and `NaN`→0.

## Tests
`tests/issue-2159.test.ts` — new `#2159 standalone DataView typed accessors` describe block (6 cases): no host-import leak, Int8/Uint8 signed↔unsigned reinterpret, Int16/Uint16/Int32/Uint32 both endiannesses incl. values ≥ 2^31, Float32/Float64 both endiannesses, byte-order distinctness, modular wrap + NaN→0. 14/14 in the file pass; host-mode emission verified unchanged.

## Scope
Distinct from PR #1623 (byteLength/byteOffset slice). `new DataView(buf, n>0)` base-offset windowing is a separate follow-up (shared representation concern with TypedArray-on-buffer windowing); offset-0 views — the dominant accessor-test pattern where the index is the *accessor* argument — are fully native here. Issue #2159 stays open for the remaining TypedArray-method slice (#14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)