### PR TITLE
docs(#2026,#2166): architect specs — class-as-value construct ABI + standalone JSON Phase-2 codec

### DIFF
--- a/plan/issues/2026-class-as-first-class-value.md
+++ b/plan/issues/2026-class-as-first-class-value.md
@@ -55,3 +55,233 @@ misses. Same descriptor backs `.constructor` identity and
 #1395 (static descriptor, done), #1116b (JS-side ctor bridge, done), #1721
 (subclass Function/Object, done). Class-through-variable `new` not filed.
 New.
+
+---
+
+## Implementation Plan
+
+> Architect spec, 2026-06-17. Based on `upstream/main` @ `79e16bb37`.
+> Anti-dup: no `## Implementation Plan` existed before this; PR #1647 is the
+> doc-only routing/validation PR (no spec). No open PR speccs this.
+
+### Root cause (precise)
+
+`compileNewExpression` (`src/codegen/expressions/new-super.ts`, the giant
+dispatcher starting ~line 1612) resolves the constructee **statically**: it
+needs `className` to land in `ctx.classSet` (line ~3201), `ctx.funcConstructorMap`
+(function-style ctor, line ~2899), or `ctx.externClasses` (line ~3317). For
+
+```ts
+function make(K: any): any { return new K(); }
+```
+
+`K` is a value-bound parameter. The type checker gives `new K` the type `any`,
+so `symbol?.name` is undefined and `ctx.classSet.has(K)` is false. Because
+`expr.expression` IS an identifier (`K`), the resolution at line ~2801 sets
+`className = "K"` only if `"K" ∈ classSet` — it isn't — so `className` stays
+`undefined`/`"K"`, the function-ctor and local-class arms miss, and execution
+reaches the **extern-class arm** (line ~3317) keyed on the literal name `"K"`.
+No `K_new` import exists, so either a compile-time `Missing import for
+constructor: K_new` fires, or (when an extern intent was registered) the
+runtime resolver at `src/runtime.ts:6230` throws `No dependency provided for
+extern class "K"`. Either way: the **value bound to the parameter is never
+consulted** — there is no runtime constructor representation to `call_ref`.
+
+The class VALUE that flows into `K` already exists and is correct: a class
+identifier as a value resolves to the `__class_<Name>` singleton
+(`emitLazyClassObjectGet`, `src/codegen/expressions/extern.ts:258`), an
+`extern.convert_any`'d `$ClassName` struct whose `__tag` field carries the
+class-id (`ctx.classTagMap`). So the descriptor is **present at the call site
+as an externref**; what is missing is a uniform **construct ABI** that, given
+that externref, dispatches to the right `<Class>_new` and returns a boxed
+instance.
+
+### Design: uniform boxed-instance construct ABI via a per-class ctor trampoline
+
+Add a **uniform constructor entry** for every WasmGC-struct-backed class, of a
+single shared signature, reachable by `call_ref` off a funcref keyed by the
+class-tag carried on the class-object descriptor. The static `new ClassName()`
+path is **left exactly as is** (no perf change, no boxing): only the *dynamic*
+`new <value>()` fallback changes.
+
+**Uniform ctor signature** (one func type, registered once):
+
+```wat
+(type $UniformCtor (func (param $argv (ref null $ObjVecArr)) (result externref)))
+```
+
+- `$argv` = the boxed-externref argument vector (reuse the existing
+  `$ObjVecArr` = `(array (mut externref))` from object-runtime.ts, the same
+  type Object.keys/values enumeration already uses — do NOT mint a new array
+  type, it invites the #2009 canonicalization hazard).
+- result = the constructed instance **boxed to externref** (`extern.convert_any`
+  on the `(ref $ClassName)` the real ctor returns; externref-backed subclasses
+  already return externref so they pass through).
+
+**Per-class trampoline** `__ctor_uniform_<Name>`: a generated function of type
+`$UniformCtor` that
+1. reads each `<Class>_new` param `i` from `$argv[i]` (null-extern when
+   `i >= argv.len`, matching the existing missing-arg padding), coercing the
+   boxed externref to the param's ValType via the **existing** unbox helpers
+   (`coerceType` externref→f64 uses `__unbox_number`/ToNumber; externref→ref
+   uses `any.convert_extern` + `ref.cast`; see type-coercion.ts). For
+   `any`-typed params keep externref.
+2. `call`s `<Class>_new` (re-resolve idx via `classMemberFuncKey`).
+3. boxes the result to externref and returns.
+
+This trampoline is the SAME shape as `emitFuncRefAsClosure`'s trampoline
+(`src/codegen/closures.ts:3285`) — model the arg-unpacking loop on that code.
+
+**Descriptor wiring.** The class-object descriptor singleton (the
+`__class_<Name>` global, built in `emitLazyClassObjectGet`) gains the ability to
+answer "give me your uniform ctor funcref". Two implementation options — pick
+**(A)** for the first PR (smaller blast radius), leave (B) as a noted
+follow-up:
+
+- **(A) class-tag → funcref table (recommended).** Build one module-level
+  `(table $ctorTable funcref)` (or an `(array funcref)` global) indexed by
+  class-tag (`ctx.classTagMap` values are dense small ints). At class
+  registration, `elem`/`array.set` slot `tag → ref.func $__ctor_uniform_<Name>`.
+  The dynamic path reads the tag off the descriptor externref
+  (`any.convert_extern` → `ref.cast` the class-object struct → `struct.get`
+  the `__tag` field), then `table.get $ctorTable` / `call_ref $UniformCtor`.
+  No host import; works standalone.
+- **(B) descriptor carries the funcref directly.** Add a `__ctor` funcref field
+  to the `$ClassName` class-object struct and `struct.new` it with
+  `ref.func $__ctor_uniform_<Name>`. Cleaner but mutates the class struct
+  shape used for instances too — higher regression surface
+  (`patchStructNewForDynamicField` territory). Defer.
+
+### Changes (sliced into dev-sized PRs)
+
+**PR-1 — uniform ctor trampolines + tag→funcref table (the core).**
+
+*File: `src/codegen/expressions/new-super.ts`*
+- New `emitUniformCtorTrampoline(ctx, className): number` — generates
+  `__ctor_uniform_<Name>` (type `$UniformCtor`), returns its funcIdx. Call it
+  once per WasmGC-struct class, right after the class ctor is registered (near
+  `class-bodies.ts:667` where `<Class>_new` is set up — or lazily on first
+  dynamic-new use, keyed in a `ctx.uniformCtorFuncIdx: Map<string,number>` to
+  avoid emitting for classes never used dynamically).
+- New `ensureCtorTable(ctx)` — registers the `$UniformCtor` func type + the
+  `(table funcref)` (or `(array funcref)` global) once; idempotent. Populate
+  slot `classTag → trampoline funcIdx` when a trampoline is emitted.
+
+*File: `src/codegen/expressions/new-super.ts`, `compileNewExpression`*
+- **New fallback arm**, inserted as the LAST resolution attempt — AFTER the
+  extern-class arm (line ~3317) and the builtin-ctor arms, immediately BEFORE
+  the terminal `reportError(... "Unsupported new expression ...")` at line
+  ~3822. Guard: `ts.isIdentifier(expr.expression)` (or `PropertyAccess`/`this`
+  per §below) AND the static resolution produced no class/func/extern match AND
+  the value's static type is a class-or-`any` (see Edge cases). Emit:
+  1. compile `expr.expression` → externref (the class descriptor value).
+  2. build `$argv`: `array.new_fixed $ObjVecArr` over the compiled+boxed args
+     (each arg `compileExpression(... {externref})`; spread → fall through to
+     refusal in PR-1, handle in PR-3).
+  3. read the class-tag off the descriptor, `table.get`/`call_ref $UniformCtor`.
+  4. result type `{ kind: "externref" }`.
+- Keep the existing static `classSet` arm (line ~3201) UNCHANGED — static
+  `new C()` keeps emitting the direct typed `call` + `(ref $struct)` result,
+  zero boxing, zero perf regression. This is the hard acceptance criterion.
+
+**PR-2 — `.constructor` identity through the descriptor (`new A().constructor === A`).**
+- `src/codegen/property-access.ts:3457` already routes `.constructor` on a
+  statically-typed instance to the `__class_<Name>` singleton via
+  `emitLazyClassObjectGet` — that path already makes `new A().constructor === A`
+  hold for the STATIC receiver. Verify the repro's failing case
+  (`new A().constructor === A → 0`) is the case where the instance type is
+  inferred (e.g. through `make(C)` returning `any`); for an `any`/externref
+  receiver `.constructor` can't statically know `typeName`. PR-2 scope: when the
+  receiver is externref and carries a boxed class instance, read the instance's
+  class-tag (instances already carry `__tag`? confirm — if not, this is the slot
+  to add) and map tag→`__class_<Name>` singleton. If instances do NOT carry a
+  tag, scope PR-2 to ONLY the statically-typed receiver (already works) and file
+  the externref-receiver `.constructor` as a follow-up; do not block PR-1.
+
+**PR-3 — spread / arity / derived-class args in the dynamic path.**
+- `new K(...args)` and arg-count mismatches: extend the `$argv` builder to
+  flatten spread (reuse `flattenCallArgs`); the trampoline already null-pads
+  missing params. Subclass-through-value (`new K()` where `K` is a derived
+  class value) works automatically because `<Class>_new` already drives the
+  super-chain — just confirm with a test.
+
+### Wasm IR pattern (dynamic-new fallback, option A)
+
+```wat
+;; new K(a, b)  where K is a value-bound class descriptor (externref)
+;; 1. evaluate descriptor
+local.get $K                       ;; externref class-object
+;; 2. read class-tag from descriptor  (any.convert_extern + ref.cast class-object struct + struct.get __tag)
+any.convert_extern
+ref.cast $ClassObjBase             ;; the class-object struct carrying __tag
+struct.get $ClassObjBase $__tag    ;; -> i32 classTag
+;; 3. build argv = [box(a), box(b)]
+<compile a -> externref>
+<compile b -> externref>
+array.new_fixed $ObjVecArr 2       ;; -> (ref $ObjVecArr)
+;; 4. dispatch: ctorTable[classTag](argv) -> externref
+local.set $argv
+local.get $tag
+table.get $ctorTable               ;; -> (ref $UniformCtor)  (or array.get on a funcref array)
+local.get $argv
+call_ref $UniformCtor              ;; -> externref instance
+```
+
+```wat
+;; __ctor_uniform_K  (type $UniformCtor): param $argv (ref null $ObjVecArr) -> externref
+;; for each K_new param i:  read argv[i] (null-extern when i>=len), coerce to param ValType
+local.get $argv  i32.const 0  ... <bounds + array.get + coerce>   ;; arg0
+local.get $argv  i32.const 1  ... <coerce>                        ;; arg1
+call $K_new                        ;; -> (ref $K)
+extern.convert_any                 ;; box instance
+;; (externref-backed subclass: K_new already returns externref — skip the box)
+```
+
+### Edge cases
+
+- **Static path untouched**: `new C()` on a directly-typed class must still hit
+  the `classSet` arm and return `(ref $struct)`, NOT externref. Gate the new
+  fallback so it only fires when static resolution genuinely missed — assert via
+  a test that `new C()` codegen is unchanged before/after.
+- **Non-class value** (`new K()` where `K` holds a number/string/plain object):
+  the descriptor has no valid class-tag. The trampoline table lookup must
+  trap-clean into a TypeError, not an illegal `call_ref`. Reserve tag 0 / a
+  null table slot → emit `throw TypeError("K is not a constructor")`. Use the
+  existing `emitThrowTypeError` path. (test262
+  `language/expressions/new/non-ctor*` patterns.)
+- **`null`/`undefined` descriptor**: `new K()` with `K == null` → TypeError, not
+  null-deref. Guard with `ref.is_null` before the tag read.
+- **new.target (#2023)**: the dynamic path should set new.target to the resolved
+  class id inside the trampoline (mirror `emitSetNewTargetBeforeCall`), so
+  `new.target === K` inside the body holds. Defer to a follow-up if it
+  complicates PR-1; note it.
+- **externref-backed subclasses** (`extends Error/Map/...`, `classBuiltinParentMap`):
+  these have no `$ClassName` struct and no class-object singleton, so they are
+  NOT registered in the ctor table — a dynamic `new K()` on such a value keeps
+  the current behaviour (out of scope; document).
+- **`new this(...)` in a static method (#1679)** already has a path
+  (line ~2831); leave it — the new fallback must run only after it misses.
+
+### Files to touch (summary)
+- `src/codegen/expressions/new-super.ts` — trampoline emit, ctor-table ensure,
+  dynamic-new fallback arm.
+- `src/codegen/class-bodies.ts` (~line 664) — emit/slot the uniform trampoline
+  when the class-object global is registered (or lazily; see PR-1).
+- `src/codegen/expressions/extern.ts` (`emitLazyClassObjectGet`, ~line 258) —
+  ensure the class-object struct exposes the `__tag` for the dynamic tag read
+  (it already carries `__tag`; confirm field index).
+- `src/codegen/property-access.ts` (~line 3457) — PR-2 only.
+
+### Test files to verify
+- New `tests/issue-2026.test.ts`:
+  - `function make(K:any){return new K()}; const C=class{v=3;m(){return this.v*2}}; make(C).m()` → 6
+  - `new A().constructor === A` → true (PR-2)
+  - `new K(1,2)` arg threading (PR-3)
+  - non-constructor value `new (42 as any)()` → throws TypeError
+  - `new (null as any)()` → throws TypeError (no null-deref)
+  - regression guard: `new C()` direct still returns a typed instance (no
+    externref widening) and its method calls keep working.
+- Host + standalone (`--target wasi` / nativeStrings) for each — the ABI is
+  pure-Wasm (no host import) so both modes must pass.
+- Confirm no test262 `built-ins/`/`language/` regressions in the
+  classes/new buckets (CI).

--- a/plan/issues/2166-standalone-json-residual.md
+++ b/plan/issues/2166-standalone-json-residual.md
@@ -111,3 +111,216 @@ host-import leak. Existing 8 boolean-slice cases + #1599/#1636 suites stay green
 **Still open (the bulk of the 76):** dynamic object-graph `JSON.stringify` /
 `JSON.parse` (runtime-built objects, runtime JSON text → object/array) — needs
 the #1599 Phase-2 pure-Wasm JSON codec + dynamic value rep (architect/senior).
+
+---
+
+## Implementation Plan
+
+> Architect spec, 2026-06-17. Based on `upstream/main` @ `79e16bb37`.
+> Anti-dup: no `## Implementation Plan` existed before this; no open PR speccs
+> the Phase-2 codec. This is the #1599 Phase-2 design the prior dev slices defer
+> to. **Architect/senior-scale, NOT a dev point-fix.**
+
+### Root cause / scope (what is actually missing)
+
+The remaining ~75 of the 76-test bucket are **dynamic object-graph**
+`JSON.stringify` and **runtime-text** `JSON.parse`. Today these hit the #1599
+Phase-1 refusal in `src/codegen/expressions/calls.ts` (~line 6016,
+`reportError(... "not yet supported in --target standalone/wasi (#1599)")`)
+because:
+- `tryEmitJsonStringifyStatic` (json-standalone.ts) only folds **compile-time-
+  constant** graphs — a runtime-built object (`const o = {}; o.x = f();
+  JSON.stringify(o)`) has no static value.
+- `tryEmitJsonParsePrimitive` only parses runtime strings whose value is a lone
+  number/`true`/`false`/`null`; objects/arrays/strings refuse.
+
+The good news: the **dynamic value representation already exists** in the
+standalone object runtime (`src/codegen/object-runtime.ts`,
+`ensureObjectRuntime`). The codec is a **traversal + formatter** over types that
+are already defined; almost no new representation work is required. Key existing
+building blocks:
+
+- **`$Object`** struct — `proto`, `props: (ref $PropMap)`, `count`, `nextSeq`.
+- **`$PropMap`** = `(array (ref null $PropEntry))`; **`$PropEntry`** =
+  `{ key: (ref $AnyString), value: anyref, flags: i32, seq: i32, get/set: anyref }`.
+- **`__obj_ordered(ref $Object) -> ref $PropMap`** (object-runtime.ts ~line 2619)
+  — returns a compacted `$PropMap` of **live + enumerable** entries in
+  **OrdinaryOwnPropertyKeys insertion order** (the exact order JSON.stringify
+  needs). This is the spine of the stringify walk.
+- **`__json_quote_string`** (calls.ts ~line 603 / a runtime helper) — quotes a
+  native string per §25.5.2 QuoteJSONString. Reuse verbatim for keys + string
+  values.
+- **`number_toString`** (`emitNativeNumberFormat`) — pure-Wasm f64→native-string,
+  Number::toString. JSON needs a thin wrapper (NaN/±Inf → `null`, `-0` → `0`).
+- **`$AnyValue`** tagged union (`any-helpers.ts`, fields tag/i32val/f64val/refval/
+  externval) — the natural carrier for JSON.parse output and for typing the
+  `anyref` values read out of `$PropEntry.value` during the stringify walk.
+- Native arrays are the `$ObjVec`/`__vec_*` structs (`{len, data}`) already used
+  by array codegen — the array arm of the walk reads `len` + element `i`.
+
+So Phase-2 is: **(1) a recursive pure-Wasm SerializeJSONValue over the runtime
+value rep, (2) a pure-Wasm parser producing that same rep, (3) routing the
+dynamic call sites to them instead of the refusal.** No host import; standalone +
+WASI only (host mode keeps `JSON_stringify`/`JSON_parse` imports unchanged).
+
+### Design
+
+New file `src/codegen/json-codec-native.ts` (companion to the static-fold
+`json-standalone.ts`), emitting lazily-registered runtime functions. Keep the
+emit-once / `ctx.funcMap.has(name)` guard idiom every other runtime in
+`object-runtime.ts` uses.
+
+#### A. Native `JSON.stringify` — `__json_stringify_value`
+
+Signature (pure Wasm, no host):
+```wat
+(func $__json_stringify_value
+  (param $v anyref)            ;; the value to serialize (instance/object/array/boxed primitive)
+  (param $gap (ref null $AnyString))  ;; indent unit ("" = compact); PR-2
+  (param $depth i32)           ;; current nesting depth, for indentation
+  (result (ref null $AnyString)))      ;; the JSON text, or null for "undefined"/function/symbol
+```
+
+Implements §25.5.2 SerializeJSONProperty by **runtime type discrimination** on
+`$v` (a sequence of `ref.test` guards, the same discipline the property
+front-guards use):
+1. `ref.is_null` → the value is JS `null`/absent. (Distinguish JSON `null`
+   literal from "omit" at the caller per array vs object context.)
+2. `ref.test $AnyValue` → unbox via tag: number → `number_toString` (with the
+   NaN/Inf→`null`, `-0`→`0` JSON rule), boolean → `"true"`/`"false"`, string →
+   `__json_quote_string`, null → `"null"`.
+3. `ref.test $NativeString` (or `$AnyString` subtype) → `__json_quote_string`.
+4. `ref.test $ObjVec`/native-array struct → **array arm**: emit `"["`, loop
+   `i in 0..len`: recurse on element `i` (a null/undefined/function element
+   serializes as `"null"` inside an array — §25.5.2), join with `","`, append
+   `"]"`. Apply indentation when `$gap != ""`.
+5. `ref.test $Object` → **object arm**: `__obj_ordered` → walk the compacted
+   `$PropMap`; for each entry, recurse on `$PropEntry.value`; **skip** entries
+   whose serialized value is null/undefined/function/symbol (§25.5.2 step: a
+   property with an undefined-serialization is omitted from an object); emit
+   `quote(key) ":" value`, join with `","`, wrap in `"{" … "}"`. Indentation as
+   §25.5.3.
+6. user-class **instances** (`(ref $ClassName)` structs): two routes —
+   - if the instance has a `toJSON` method, call it first (§25.5.2 step 2) and
+     serialize the result. Defer `toJSON` to a follow-up PR if it complicates
+     the first cut; note it.
+   - otherwise enumerate the instance's **own enumerable string-keyed fields**.
+     Closed-struct instances expose fields by name, not via `$PropMap`; the
+     simplest correct route is to reuse the **existing instance→`$Object`
+     reflection** the object runtime already does for `Object.keys(instance)`
+     (find that path — `__obj_ordered` works on `$Object`; instances may need
+     the `__to_object`/own-keys bridge). **Scope the first PR to plain `$Object`
+     graphs + arrays + boxed primitives**; instance-field stringify is a
+     separate slice (it overlaps the closed-struct reflection work in #2042).
+
+String building: reuse the native-string concat helpers
+(`ensureNativeStringHelpers`, the `__str_concat`/builder the array `join` path
+uses — see array-methods.ts ~line 4832). For large graphs prefer a growable
+builder over O(n²) concat; a simple concat is acceptable for the first cut.
+
+#### B. Native `JSON.parse` — `__json_parse_text`
+
+Signature:
+```wat
+(func $__json_parse_text
+  (param $text (ref $AnyString))
+  (result anyref))      ;; $AnyValue for primitives; $Object / $ObjVec for graphs; traps→throw SyntaxError
+```
+
+A standard recursive-descent JSON grammar (§25.5.1) over the native string's
+i16 code units:
+- a scanner reading code units by index (`array.get` on the native-string
+  backing array); skip insignificant whitespace (space/tab/LF/CR only — JSON is
+  strict).
+- `parseValue` dispatch on first non-ws char: `{` → object, `[` → array,
+  `"` → string, `-`/digit → number, `t`/`f`/`n` → literal.
+- object → build a fresh `$Object` via `__new_plain_object` + `__extern_set`
+  (or the lower-level `__obj_insert`) per member; preserve insertion order
+  (the runtime already records `seq`).
+- array → build `$ObjVec` (or the native array struct) via the existing array
+  push/append helper.
+- string → unescape per §25.5.1 (`\"` `\\` `\/` `\b\f\n\r\t` `\uXXXX`) into a
+  native string.
+- number → parse via the existing **`emitNativeParseNumber`**
+  (`parse-number-native.ts`) → f64 → box as `$AnyValue`.
+- on any grammar violation (or trailing non-ws): `throw SyntaxError` via the
+  existing `emitThrowTypeError`-style error path (use a SyntaxError variant —
+  `__new_SyntaxError` is already wired for standalone, see new-super.ts
+  `emitWasiErrorConstructor` / `isWasiErrorName`).
+
+The parser's output rep MUST be the SAME rep stringify consumes and the same rep
+the rest of standalone codegen reads `any`/object values as, so a round-trip
+`JSON.parse(JSON.stringify(o))` and downstream `.x` property reads work through
+`__extern_get`.
+
+#### C. Routing (calls.ts)
+
+In `compileCallExpression`'s JSON arm (`src/codegen/expressions/calls.ts`
+~line 5955), BEFORE the Phase-1 refusal at ~line 6016:
+- `stringify`: after the existing primitive (`tryEmitJsonStringifyPrimitive`)
+  and static-fold (`tryEmitJsonStringifyStatic`) attempts miss, and we are
+  `ctx.standalone || ctx.wasi`: compile arg0 to its natural rep (object/array/
+  any → `anyref`), ensure `__json_stringify_value`, push the gap (from a static
+  `space`, reusing `staticSpaceValue`; dynamic space → first cut passes `""` or
+  refuses — note), `depth=0`, `call`. Result native string.
+- `parse`: after `tryEmitJsonParseLiteral` / `tryEmitJsonParsePrimitive` miss
+  and standalone/WASI: compile arg0 to native string, ensure
+  `__json_parse_text`, `call`. Result `anyref` (the value graph). A `reviver`
+  arg (2nd) → first cut: refuse if present, or apply in a follow-up PR
+  (§25.5.1 InternalizeJSONProperty is a post-walk; defer).
+
+### Slicing into dev-sized PRs
+
+- **PR-A (stringify, plain graphs)** — `__json_stringify_value` for
+  `$Object` + native array + `$AnyValue`/boxed primitive, compact output only.
+  Route dynamic `JSON.stringify(obj)` / `(arr)`. Tests: runtime-built object,
+  nested object/array, numbers (incl. NaN/Inf→null, -0→0), strings with escapes,
+  booleans, null. This alone should reclaim a large chunk of the bucket.
+- **PR-B (stringify, indentation + space)** — thread `$gap`/`$depth` for
+  `JSON.stringify(o, null, 2)` dynamic form (the static form already works via
+  #2166 prior slice). Tests: indented nested output, string space, space 0.
+- **PR-C (parse, primitives + graphs)** — `__json_parse_text` full grammar →
+  `$Object`/`$ObjVec`/`$AnyValue`; route dynamic `JSON.parse(text)`. Tests:
+  parse object/array/nested/escapes/numbers; SyntaxError on malformed input;
+  round-trip `JSON.parse(JSON.stringify(o))`.
+- **PR-D (instance fields + toJSON + reviver/replacer)** — stringify of
+  user-class **instances** (own enumerable fields; reuse #2042 closed-struct
+  reflection), `toJSON`, and reviver/replacer. Larger; overlaps #2042/#1917.
+
+### Edge cases (§25.5)
+
+- `JSON.stringify(undefined)` / a function / a symbol at top level → returns
+  JS `undefined` (NOT the string "undefined"); inside an array → `"null"`;
+  as an object value → the key is omitted. The recursion's null-result return
+  encodes this; the caller picks array-vs-object behaviour.
+- Numbers: `NaN`/`±Infinity` → `null`; `-0` → `0`; otherwise Number::toString.
+- Strings: full QuoteJSONString escaping incl. control chars `\u00XX` and
+  surrogate handling — reuse `__json_quote_string` exactly (do not re-implement).
+- Property order: insertion order via `__obj_ordered`/`seq` — already correct.
+- Circular references → `JSON.stringify` must throw TypeError. First cut: bound
+  recursion depth and throw on overflow (note the limitation); a proper
+  seen-set is a follow-up.
+- Parse strictness: leading/trailing whitespace OK; trailing junk → SyntaxError;
+  no comments, no trailing commas, no single quotes.
+
+### Files to touch
+- NEW `src/codegen/json-codec-native.ts` — `ensure`/`emit` of
+  `__json_stringify_value` + `__json_parse_text`.
+- `src/codegen/expressions/calls.ts` (~line 5955–6020) — route dynamic
+  stringify/parse to the native codec before the Phase-1 refusal.
+- Reuse (no edit): `object-runtime.ts` (`__obj_ordered`, `$Object`/`$PropMap`/
+  `$PropEntry`, `__new_plain_object`, `__obj_insert`), `any-helpers.ts`
+  (`$AnyValue`), `parse-number-native.ts` (`emitNativeParseNumber`),
+  native-string helpers (`__json_quote_string`, concat builder), the
+  standalone SyntaxError constructor (`emitWasiErrorConstructor`).
+
+### Test files to verify
+- Extend `tests/issue-2166.test.ts` per-PR (host + `--target wasi`/standalone):
+  - dynamic-graph stringify (runtime-built object/array, nesting, escapes,
+    NaN/Inf→null, -0→0) — PR-A
+  - indented dynamic stringify — PR-B
+  - parse → graph, SyntaxError on malformed, round-trip — PR-C
+- Standalone-vs-host gap diff for `built-ins/JSON` should drop from ~75 toward
+  near-parity as PR-A/PR-C land (verify via CI test262 bucket).
+- No regression to the existing #1599/#1636 static-fold suites or the boolean/
+  space slices already merged.


### PR DESCRIPTION
Doc-only. Adds `## Implementation Plan` sections to two hard sprint-63 issues
that were blocked needing an architect spec before a senior-dev can build them.
No source changes.

### #2026 — classes as first-class values (`new K()` on a value-bound class)
Root cause: `compileNewExpression` resolves the constructee statically; a
value-bound `K: any` never matches `classSet`/`funcConstructorMap`/`externClasses`
and falls into the extern-class arm keyed on the literal name `"K"`, which the
runtime rejects (`No dependency provided for extern class "K"`). The class
value already flows in as the `__class_<Name>` descriptor externref (carrying a
`__tag` class-id) — what's missing is a uniform **construct ABI**.

Spec: per-class `$UniformCtor` trampoline (`__ctor_uniform_<Name>`,
`(ref null $ObjVecArr) -> externref`) reached by `call_ref` off a class-tag →
funcref table, dispatched from a NEW dynamic-`new` fallback arm inserted after
all static resolution misses. The static `new C()` path is left byte-identical
(no boxing, no perf regression — the hard acceptance criterion). Sliced PR-1
(core) / PR-2 (`.constructor` identity) / PR-3 (spread/arity). Models the
arg-unpacking on `emitFuncRefAsClosure`.

### #2166 — standalone JSON residual (~75 dynamic-graph tests)
The #1599 Phase-1 static fold only handles compile-time-constant graphs +
lone-primitive parse; dynamic object graphs and runtime JSON text refuse. The
**dynamic value rep already exists** in the standalone object runtime
(`$Object`/`$PropMap`/`$PropEntry`, `__obj_ordered` for insertion-ordered keys,
`$ObjVec`, `$AnyValue`, `__json_quote_string`, `emitNativeParseNumber`), so
Phase-2 is a traversal + formatter, not new representation work.

Spec: new `src/codegen/json-codec-native.ts` emitting recursive
`__json_stringify_value` + `__json_parse_text` over that rep; route the dynamic
JSON call sites in `calls.ts` to them before the Phase-1 refusal. Standalone/WASI
only (host `JSON_*` imports unchanged). Sliced PR-A (stringify graphs) / PR-B
(indent) / PR-C (parse + SyntaxError) / PR-D (instance fields + toJSON +
reviver/replacer). Covers §25.5 edge cases (NaN/Inf→null, -0→0, undefined/fn
omission, QuoteJSONString reuse, circular-ref note).

Based on `upstream/main` @ `79e16bb37`. Anti-dup verified: neither issue had an
`## Implementation Plan`; no open PR speccs either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)