### PR TITLE
fix(#2162): shift mapHelpers in lockstep with late imports (WeakMap/WeakSet standalone)

### DIFF
--- a/plan/issues/2162-standalone-map-set-weak-collections-residual.md
+++ b/plan/issues/2162-standalone-map-set-weak-collections-residual.md
@@ -171,3 +171,36 @@ true+false predicate cases, content checks, dedup. Test:
 `tests/issue-2162-set-algebra.test.ts` (10/10, operands built via `.add()` so the
 slice is independent of the `new Set([...])` constructor slice). tsc + prettier
 clean; Set Slice-1 unaffected.
+
+## Slice — WeakMap/WeakSet stale-`mapHelpers`-index fix (PR, dev-mech1, 2026-06-17)
+
+Standalone WeakMap/WeakSet **construction + methods already existed** upstream
+(`new WeakMap()`/`new WeakSet()` → `__map_new`; get/set/has/delete/add via
+`tryCompileNativeWeakMethodCall`, reusing the `$Map` backing store). But on the
+`standalone:true, nativeStrings:true` path they emitted **invalid Wasm**: e.g.
+`wm.has(k)` validated-failed with `if[0] expected i32, found call of anyref`.
+
+**Root cause** (not weak-specific — a latent bug in the function-index shift
+machinery): `shiftLateImportIndices` (`expressions/late-imports.ts`) and the two
+`addUnionImports` shift sites (`index.ts`) keep `funcMap` / `nativeStrHelpers`
+(#1677) / `nativeRegexHelpers` (#1913) in lockstep with the defined-function
+shift, but **never shifted `ctx.mapHelpers`**. So when a late import
+(`__box_number`, pulled in to coerce a numeric key/value) lands BETWEEN a
+map-helper's registration and its `call` site, every defined function moves up by
+`added` but the `mapHelpers` entries stay stale-low — `wm.has` then emits a
+`call` to `__map_get` (the function one slot lower, returning `anyref` where an
+`i32` boolean was expected) → invalid Wasm. WeakMap exposed it because its first
+method call is often the first `__box_number` trigger; plain Map/Set hit the same
+window whenever a numeric key/value forces a late box. `--target wasi` dodged it
+(box helpers import eagerly), which is why the wasi-compiled
+`issue-2162-standalone-weak` suite passed before.
+
+**Fix** (mirrors #1677/#1913 exactly): add a `mapHelpers` lockstep shift at all
+three shift sites. After the fix, all weak methods produce valid Wasm and correct
+runtime values (get=42, has/miss/delete correct, add/has/delete correct).
+
+Tests: `tests/issue-2162-weak-mapHelpers-shift.test.ts` (5/5) — compiles each
+WeakMap/WeakSet/Map case `standalone+nativeStrings` and asserts valid Wasm; the
+assertion is `false` without the three-site fix (verified by reverting). tsc
+clean; existing Map/Set/Weak standalone suites (34) + shift-sensitive #2131 +
+foreach/algebra (29) unaffected.

--- a/src/codegen/expressions/late-imports.ts
+++ b/src/codegen/expressions/late-imports.ts
@@ -253,6 +253,22 @@ export function shiftLateImportIndices(
       ctx.nativeRegexHelpers.set(name, idx + added);
     }
   }
+  // (#2162) Same lockstep for `mapHelpers` — the Map/Set/WeakMap/WeakSet
+  // lowering call sites (`__map_get`/`__map_has`/`__map_set`/`__weakset_add`/…
+  // in map-runtime.ts + weak-collections-runtime.ts) bake `call` funcIdx
+  // straight from this map. Leaving it stale-low meant a late import landing
+  // BETWEEN the helper registration and the call (e.g. `__box_number` pulled in
+  // while compiling a numeric Map/WeakMap key or value) shifted every defined
+  // function up by `added` but NOT these entries — so the call landed one
+  // function too early (`wm.has` → `__map_get`, returning anyref where i32 was
+  // expected) and the module failed validation. WeakMap exposes it because its
+  // first method call is often the first `__box_number` trigger; plain Map
+  // usually imports `__box_number` earlier and dodged the window.
+  for (const [name, idx] of ctx.mapHelpers) {
+    if (idx >= importsBefore) {
+      ctx.mapHelpers.set(name, idx + added);
+    }
+  }
   // (#2039 slice 2) Re-base the native-string finalize-shift regime. The loop
   // above plus the mod.functions body walk fully repaired the helpers for the
   // `added` imports of this batch, so the helpers are now consistent with the

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -7450,6 +7450,15 @@ export function addStringImports(ctx: CodegenContext): void {
         ctx.nativeRegexHelpers.set(name, idx + delta);
       }
     }
+    // (#2162) Map/Set/WeakMap/WeakSet helper map moves in lockstep too —
+    // map-runtime.ts / weak-collections-runtime.ts call sites bake `call`
+    // indices straight from this map (see shiftLateImportIndices for the full
+    // rationale / the WeakMap stale-index validation failure it fixes).
+    for (const [name, idx] of ctx.mapHelpers) {
+      if (idx >= importsBefore) {
+        ctx.mapHelpers.set(name, idx + delta);
+      }
+    }
     // (#2039 slice 2) Re-base so reconcileNativeStrFinalizeShift doesn't apply
     // the same `delta` a second time — this inline shift already repaired the
     // helper bodies and the map. Matches addUnionImports (#1677-fast-path) and
@@ -8780,6 +8789,19 @@ export function addUnionImports(ctx: CodegenContext): void {
     for (const [name, idx] of ctx.funcMap) {
       if (!newImportNames.has(name) && idx >= importsBefore) {
         ctx.funcMap.set(name, idx + delta);
+      }
+    }
+    // (#2162) `mapHelpers` (Map/Set/WeakMap/WeakSet helper funcIdx) is NOT a
+    // copy of funcMap — its entries are read directly by map-runtime.ts /
+    // weak-collections-runtime.ts call sites to bake `call` funcIdx. It must be
+    // shifted UNCONDITIONALLY in lockstep with the defined-function shift (the
+    // nativeStr/nativeRegex shifts below are gated on the string-helper base and
+    // would miss this in plain-Map programs). Leaving it stale let a late import
+    // (e.g. `__box_number` for a numeric key/value) land between helper
+    // registration and the call, so `wm.has` called `__map_get` → invalid Wasm.
+    for (const [name, idx] of ctx.mapHelpers) {
+      if (idx >= importsBefore) {
+        ctx.mapHelpers.set(name, idx + delta);
       }
     }
     // Update export indices

--- a/tests/issue-2162-weak-mapHelpers-shift.test.ts
+++ b/tests/issue-2162-weak-mapHelpers-shift.test.ts
@@ -1,0 +1,89 @@
+// #2162 — regression: `mapHelpers` must shift in lockstep with late imports.
+//
+// The function-index shift machinery (shiftLateImportIndices in
+// expressions/late-imports.ts + the two addUnionImports shift sites in
+// index.ts) kept ctx.funcMap / ctx.nativeStrHelpers / ctx.nativeRegexHelpers in
+// lockstep with the defined-function shift but NEVER shifted ctx.mapHelpers.
+// So when a late import (e.g. `__box_number`, pulled in to coerce a numeric
+// Map/WeakMap key or value) was added BETWEEN a map-helper's registration and
+// its `call` site, every defined function moved up by `added` but the
+// mapHelpers entries did not — so `wm.has(k)` emitted a `call` to `__map_get`
+// (the function one slot lower), which returns `anyref` where an `i32` boolean
+// was expected, and the module FAILED Wasm validation.
+//
+// The defect is observable as INVALID Wasm: `WebAssembly.validate(binary)` is
+// `false` without the fix and `true` with it (verified by reverting the three
+// shift-site edits). That is the precise, deterministic regression signal — far
+// more robust than a runtime value, and it is exactly the failure mode (a
+// `call` to the wrong-signature helper) the fix addresses.
+//
+// Reproducing condition: `standalone: true, nativeStrings: true` — this routes
+// the WasmGC-native Map/Set/Weak runtime AND defers `__box_number` to a late
+// import, so the numeric key/value coercion opens the stale-`mapHelpers` window
+// mid-method-call. (Under `--target wasi` the box helpers import eagerly, so the
+// window never opens — which is why the existing issue-2162-standalone-weak
+// suite, compiled for wasi, passed before this fix.)
+//
+// Mirrors the #1677 (nativeStrHelpers) / #1913 (nativeRegexHelpers) precedent:
+// add a mapHelpers lockstep shift at all three shift sites.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/** Compile `source` standalone + nativeStrings; assert the binary is VALID Wasm. */
+async function expectValidStandalone(source: string): Promise<void> {
+  const r = await compile(source, { fileName: "test.ts", standalone: true, nativeStrings: true });
+  expect(r.success).toBe(true);
+  // A stale mapHelpers index emits a `call` to the wrong-signature helper, which
+  // fails validation. This assertion is `false` without the three-site fix.
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+}
+
+describe("#2162 mapHelpers lockstep shift — stale-index produces invalid Wasm", () => {
+  it("WeakMap set/get of a numeric value (boxing forces a late import)", async () => {
+    await expectValidStandalone(
+      `const wm = new WeakMap<object, number>();
+       const k = {};
+       wm.set(k, 42);
+       export function test(): number { return wm.get(k) as number; }`,
+    );
+  });
+
+  it("WeakMap has — the call must land on __map_has (i32), not __map_get (anyref)", async () => {
+    await expectValidStandalone(
+      `const wm = new WeakMap<object, number>();
+       const k = {}; const k2 = {};
+       wm.set(k, 7);
+       export function test(): number { return (wm.has(k) ? 10 : 0) + (wm.has(k2) ? 1 : 0); }`,
+    );
+  });
+
+  it("WeakMap delete after a numeric set", async () => {
+    await expectValidStandalone(
+      `const wm = new WeakMap<object, number>();
+       const k = {};
+       wm.set(k, 1);
+       const d = wm.delete(k) ? 1 : 0;
+       const gone = wm.has(k) ? 1 : 0;
+       export function test(): number { return d * 10 + gone; }`,
+    );
+  });
+
+  it("WeakSet add/has round-trip", async () => {
+    await expectValidStandalone(
+      `const ws = new WeakSet<object>();
+       const a = {}; const b = {};
+       ws.add(a);
+       export function test(): number { return (ws.has(a) ? 10 : 0) + (ws.has(b) ? 1 : 0); }`,
+    );
+  });
+
+  it("plain Map in the same boxing window also stays valid (not weak-specific)", async () => {
+    await expectValidStandalone(
+      `const m = new Map<object, number>();
+       const k = {};
+       m.set(k, 99);
+       export function test(): number { return (m.get(k) as number) + (m.has(k) ? 1 : 0); }`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Standalone WeakMap/WeakSet methods emitted **invalid Wasm** on the `standalone+nativeStrings` path (e.g. `wm.has(k)` validated-failed: `if[0] expected i32, found call of anyref`). Construction + methods already existed upstream; this fixes a latent **function-index shift** bug that corrupted their call sites.

## Root cause
`shiftLateImportIndices` (`expressions/late-imports.ts`) and the two `addUnionImports` shift sites (`index.ts`) keep `funcMap` / `nativeStrHelpers` (#1677) / `nativeRegexHelpers` (#1913) in lockstep with the defined-function shift, but **never shifted `ctx.mapHelpers`**. So when a late import (`__box_number`, pulled in to coerce a numeric key/value) lands BETWEEN a map-helper's registration and its `call` site, every defined function moves up by `added` but the `mapHelpers` entries stay stale-low → `wm.has` emits a `call` to `__map_get` (one slot lower, returning `anyref` where an `i32` boolean was expected) → invalid Wasm.

WeakMap exposed it because its first method call is often the first `__box_number` trigger; **plain Map/Set hit the same window** with numeric keys/values. `--target wasi` dodged it (box helpers import eagerly), which is why the wasi-compiled `issue-2162-standalone-weak` suite passed before.

## Fix
Mirrors the #1677 / #1913 precedent exactly: add a `mapHelpers` lockstep shift at all three shift sites. After the fix, weak methods produce valid Wasm and correct runtime values (get=42; has/miss/delete and add/has/delete all correct).

## Tests
`tests/issue-2162-weak-mapHelpers-shift.test.ts` (5/5) compiles each WeakMap/WeakSet/Map case `standalone+nativeStrings` and asserts valid Wasm — the assertion is **`false` without the three-site fix** (verified by reverting). `tsc --noEmit` clean; existing Map/Set/Weak standalone (34) + #2131 + foreach/algebra (29) suites unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)