### PR TITLE
feat(#2161): standalone re[Symbol.match/matchAll/search](str) protocol calls

### DIFF
--- a/plan/issues/2161-standalone-regexp-engine-residual.md
+++ b/plan/issues/2161-standalone-regexp-engine-residual.md
@@ -214,3 +214,45 @@ TypedArray and other builtins will also need). The cleanly-isolated wins inside
 (a) are gated on the same `RegExp.prototype`-object representation, so there is
 no tail-end slice to peel off. sdev5 flagged this at the implementation boundary
 rather than half-building the prototype-object representation at session tail.
+
+## Sub-bucket (b), first slice — LANDED (2026-06-17, sdev-regex3)
+
+Re-validated against upstream/main (`fe0e21ba1`). Probed every RegExp form in
+standalone: only the explicit well-known-symbol protocol forms still refused
+(`re[Symbol.match/matchAll/search/replace/split](str)` at
+`calls.ts:~10414`). `RegExp.prototype.test.call(...)` and `String.prototype.*`
+native paths already work, so the prior (a)/(b) split holds: this PR is the
+first slice of (b).
+
+**Shipped — the READ protocol forms** `re[Symbol.match](s)`,
+`re[Symbol.matchAll](s)`, `re[Symbol.search](s)` for static / backend-created
+RegExp receivers route to the native engine, **zero host imports**:
+
+- `src/codegen/regexp-standalone.ts`: extracted operand-explicit cores
+  `emitStandaloneRegExpSearchCore` / `…MatchCore` / `…MatchAllCore` out of the
+  `tryCompileStandaloneStringSearch/Match/MatchAll` functions (which now
+  delegate), then added `tryCompileStandaloneRegExpSymbolCall` that calls those
+  same cores with **swapped operands** (regex = receiver, subject = argument).
+  The native lower-level emitters were already operand-order agnostic, so there
+  is no second engine path. Also taught `isStandaloneMatchResultCall` to
+  recognise the `re[Symbol.match](s)` shape so a `let m = …` local gets the
+  precise `$__regexp_match_vec` ref type (else `m[1]` routes through
+  `__extern_get_idx` and leaks `env::__extern_get` — the bug the runtime probe
+  caught).
+- `src/codegen/index.ts`: mirrored that recognition in
+  `inferStandaloneRegExpMatchArrayType` + `isStaticRegExpMatchArrayCallForImportScan`
+  (the let/const local-type + import-scan inferers).
+- `src/codegen/expressions/calls.ts`: at the standalone `@@`-refusal site, try
+  `tryCompileStandaloneRegExpSymbolCall` first; fall through to the existing
+  refusal (and JS-host `__regex_symbol_call` in host mode) when it returns
+  `undefined`.
+- Tests: `tests/issue-2161-regex-symbol-protocol.test.ts` (8 cases, all
+  standalone + empty importObject). 257 existing regex tests still green
+  (refactor is behaviour-preserving).
+
+**Deferred (still narrowed-refuse, NOT silently wrong):** `@@replace` / `@@split`
+(carry extra replacement / limit operands — their cores still need the
+operand-explicit extraction; next slice), dynamic-flag / `any`-typed receivers
+(fall through to host `__regex_symbol_call`), string-coercion arguments. The
+`RegExp.prototype` reflection bucket (a) remains gated on #2158's prototype-object
+representation. #2161 stays open for those.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -116,6 +116,7 @@ import {
   compileStandaloneRegExpConstructor,
   isGlobalRegExpIdentifier,
   tryCompileStandaloneRegExpExec,
+  tryCompileStandaloneRegExpSymbolCall,
   tryCompileStandaloneRegExpTest,
 } from "../regexp-standalone.js";
 import {
@@ -10413,6 +10414,21 @@ function compileCallExpression(
           const recvIsUnresolved = (receiverType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
           if ((isRegExpRecv || recvIsUnresolved) && !recvIsUserClass) {
             if (ctx.standalone) {
+              // (#2161) Route the well-known-symbol protocol READ forms
+              // (`re[Symbol.match/matchAll/search](str)`) to the native engine
+              // for static / backend-created RegExp receivers — the
+              // operand-swapped dual of the String.prototype.* native path.
+              // Returns undefined for forms not yet wired (dynamic receivers,
+              // @@replace/@@split, string-coercion args), which fall through to
+              // the refusal below.
+              const symResult = tryCompileStandaloneRegExpSymbolCall(
+                ctx,
+                fctx,
+                expr,
+                elemAccess.expression,
+                methodName,
+              );
+              if (symResult !== undefined) return symResult;
               reportError(
                 ctx,
                 expr,

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -12467,6 +12467,16 @@ function nativeStringVecTypeForStandaloneRegExp(ctx: CodegenContext): ValType | 
   return { kind: "ref_null", typeIdx: vecTypeIdx };
 }
 
+/** True for the computed key `Symbol.match` (the @@match well-known symbol). */
+function isSymbolMatchKeyForInference(arg: ts.Expression): boolean {
+  return (
+    ts.isPropertyAccessExpression(arg) &&
+    ts.isIdentifier(arg.expression) &&
+    arg.expression.text === "Symbol" &&
+    arg.name.text === "match"
+  );
+}
+
 function inferStandaloneRegExpMatchArrayType(
   ctx: CodegenContext,
   initializer: ts.Expression | undefined,
@@ -12474,28 +12484,47 @@ function inferStandaloneRegExpMatchArrayType(
   if (!ctx.standalone || !initializer) return null;
   const unwrapped = stripRegExpInferenceWrapper(initializer);
   if (!ts.isCallExpression(unwrapped)) return null;
-  if (!ts.isPropertyAccessExpression(unwrapped.expression)) return null;
-  const method = unwrapped.expression.name.text;
-  if (method === "exec") {
-    return isStaticRegExpExpressionForInference(ctx, unwrapped.expression.expression)
-      ? nativeStringVecTypeForStandaloneRegExp(ctx)
-      : null;
+  if (ts.isPropertyAccessExpression(unwrapped.expression)) {
+    const method = unwrapped.expression.name.text;
+    if (method === "exec") {
+      return isStaticRegExpExpressionForInference(ctx, unwrapped.expression.expression)
+        ? nativeStringVecTypeForStandaloneRegExp(ctx)
+        : null;
+    }
+    if (method === "match" && unwrapped.arguments.length === 1) {
+      return isStaticRegExpExpressionForInference(ctx, unwrapped.arguments[0]!)
+        ? nativeStringVecTypeForStandaloneRegExp(ctx)
+        : null;
+    }
+    return null;
   }
-  if (method === "match" && unwrapped.arguments.length === 1) {
-    return isStaticRegExpExpressionForInference(ctx, unwrapped.arguments[0]!)
-      ? nativeStringVecTypeForStandaloneRegExp(ctx)
-      : null;
+  // `re[Symbol.match](s)` (#2161) — symbol-protocol dual of `s.match(re)`.
+  if (ts.isElementAccessExpression(unwrapped.expression)) {
+    const elem = unwrapped.expression;
+    if (isSymbolMatchKeyForInference(elem.argumentExpression) && unwrapped.arguments.length === 1) {
+      return isStaticRegExpExpressionForInference(ctx, elem.expression)
+        ? nativeStringVecTypeForStandaloneRegExp(ctx)
+        : null;
+    }
   }
   return null;
 }
 
 function isStaticRegExpMatchArrayCallForImportScan(ctx: CodegenContext, call: ts.CallExpression): boolean {
   const callee = stripRegExpInferenceWrapper(call.expression);
-  if (!ts.isPropertyAccessExpression(callee)) return false;
-  const method = callee.name.text;
-  if (method === "exec") return isStaticRegExpExpressionForInference(ctx, callee.expression);
-  if (method === "match" && call.arguments.length === 1) {
-    return isStaticRegExpExpressionForInference(ctx, call.arguments[0]!);
+  if (ts.isPropertyAccessExpression(callee)) {
+    const method = callee.name.text;
+    if (method === "exec") return isStaticRegExpExpressionForInference(ctx, callee.expression);
+    if (method === "match" && call.arguments.length === 1) {
+      return isStaticRegExpExpressionForInference(ctx, call.arguments[0]!);
+    }
+    return false;
+  }
+  // `re[Symbol.match](s)` (#2161) — symbol-protocol dual of `s.match(re)`.
+  if (ts.isElementAccessExpression(callee)) {
+    if (isSymbolMatchKeyForInference(callee.argumentExpression) && call.arguments.length === 1) {
+      return isStaticRegExpExpressionForInference(ctx, callee.expression);
+    }
   }
   return false;
 }

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -1087,6 +1087,23 @@ export function tryCompileStandaloneStringSearch(
     return undefined;
   }
 
+  // String-method operand order: subject = receiver, regex = arg.
+  return emitStandaloneRegExpSearchCore(ctx, fctx, expr, propAccess.expression, argExpr);
+}
+
+/**
+ * Operand-explicit core for `@@search` semantics (§22.2.6.13): returns the
+ * match index (f64) or -1. Shared by `String.prototype.search` (subject is the
+ * receiver) and the `re[Symbol.search](str)` protocol form (subject is the
+ * argument) — only the operand wiring differs.
+ */
+function emitStandaloneRegExpSearchCore(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  subjExpr: ts.Expression,
+  regexExpr: ts.Expression,
+): ValType | null {
   if (!hasStandaloneRegExpEngine(ctx)) {
     reportStandaloneRegExpUnsupported(ctx, expr, "String.prototype.search without an enabled standalone engine");
     return null;
@@ -1095,7 +1112,7 @@ export function tryCompileStandaloneStringSearch(
   const i32Arr = regexI32ArrayType(ctx);
 
   // emit __regex_search(...) — leaves the i32 match flag on the stack.
-  const emitted = emitRegexSearchCall(ctx, fctx, argExpr, propAccess.expression);
+  const emitted = emitRegexSearchCall(ctx, fctx, regexExpr, subjExpr);
   if (emitted === null) return null;
 
   // matched ? f64(caps[0]) : -1
@@ -1145,9 +1162,27 @@ export function tryCompileStandaloneStringMatch(
     return undefined;
   }
 
-  const flags = staticRegExpFlags(ctx, argExpr);
+  // String-method operand order: subject = receiver, regex = arg.
+  return emitStandaloneRegExpMatchCore(ctx, fctx, expr, propAccess.expression, argExpr);
+}
+
+/**
+ * Operand-explicit core for `@@match` semantics (§22.2.6.8). Shared by
+ * `String.prototype.match` (subject is the receiver, regex is the argument) and
+ * the `re[Symbol.match](str)` protocol form (regex is the receiver, subject is
+ * the argument). Global match collects every [0] substring into a match-vec;
+ * non-global returns the single capture array (`.exec`-shaped).
+ */
+function emitStandaloneRegExpMatchCore(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  subjExpr: ts.Expression,
+  regexExpr: ts.Expression,
+): ValType | null {
+  const flags = staticRegExpFlags(ctx, regexExpr);
   if (flags === null) {
-    reportStandaloneRegExpUnsupported(ctx, argExpr, "String.prototype.match with dynamic RegExp flags");
+    reportStandaloneRegExpUnsupported(ctx, regexExpr, "String.prototype.match with dynamic RegExp flags");
     return null;
   }
 
@@ -1171,11 +1206,11 @@ export function tryCompileStandaloneStringMatch(
     const matchVecTypeIdx = ensureRegexMatchVecType(ctx);
     const strTypeIdx = ctx.nativeStrTypeIdx;
 
-    const loaded = loadStandaloneRegExpStruct(ctx, fctx, argExpr);
+    const loaded = loadStandaloneRegExpStruct(ctx, fctx, regexExpr);
     if (loaded === null) return null;
     const { regexpLocal, structTypeIdx } = loaded;
 
-    const subjType = compileExpression(ctx, fctx, propAccess.expression, nativeStringType(ctx));
+    const subjType = compileExpression(ctx, fctx, subjExpr, nativeStringType(ctx));
     if (subjType?.kind === "ref_null") fctx.body.push({ op: "ref.as_non_null" } as Instr);
     fctx.body.push({ op: "call", funcIdx: flattenIdx });
     const subjLocal = allocLocal(fctx, `__re_gm_subj_${fctx.locals.length}`, { kind: "ref", typeIdx: strTypeIdx });
@@ -1208,7 +1243,7 @@ export function tryCompileStandaloneStringMatch(
 
   // Non-global match = RegExpExec (§22.2.6.8 step 5) — sticky regexps read
   // and advance lastIndex through the shared exec path.
-  return emitRegexExecArrayCall(ctx, fctx, argExpr, propAccess.expression, {
+  return emitRegexExecArrayCall(ctx, fctx, regexExpr, subjExpr, {
     gyLastIndex: flagsHaveGlobalOrSticky(flags),
   });
 }
@@ -1246,9 +1281,27 @@ export function tryCompileStandaloneStringMatchAll(
     return undefined; // string-arg / non-RegExp form → generic / refusal path
   }
 
-  const flags = staticRegExpFlags(ctx, argExpr);
+  // String-method operand order: subject = receiver, regex = arg.
+  return emitStandaloneRegExpMatchAllCore(ctx, fctx, expr, propAccess.expression, argExpr);
+}
+
+/**
+ * Operand-explicit core for `@@matchAll` semantics (§22.2.6.9). Shared by
+ * `String.prototype.matchAll` and the `re[Symbol.matchAll](str)` protocol form.
+ * Requires a static global (`g`) RegExp — non-global matchAll is a runtime
+ * TypeError, left to the refusal path. Returns an iterable vec-of-capture-arrays
+ * (`undefined` when the form falls through, e.g. non-global, dynamic flags).
+ */
+function emitStandaloneRegExpMatchAllCore(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  subjExpr: ts.Expression,
+  regexExpr: ts.Expression,
+): ValType | null | undefined {
+  const flags = staticRegExpFlags(ctx, regexExpr);
   if (flags === null) {
-    reportStandaloneRegExpUnsupported(ctx, argExpr, "String.prototype.matchAll with dynamic RegExp flags");
+    reportStandaloneRegExpUnsupported(ctx, regexExpr, "String.prototype.matchAll with dynamic RegExp flags");
     return null;
   }
   // matchAll REQUIRES a global regex (non-global throws TypeError); only the
@@ -1270,11 +1323,11 @@ export function tryCompileStandaloneStringMatchAll(
   const outerVecTypeIdx = ensureRegexMatchAllVecType(ctx);
   const strTypeIdx = ctx.nativeStrTypeIdx;
 
-  const loaded = loadStandaloneRegExpStruct(ctx, fctx, argExpr);
+  const loaded = loadStandaloneRegExpStruct(ctx, fctx, regexExpr);
   if (loaded === null) return null;
   const { regexpLocal, structTypeIdx } = loaded;
 
-  const subjType = compileExpression(ctx, fctx, propAccess.expression, nativeStringType(ctx));
+  const subjType = compileExpression(ctx, fctx, subjExpr, nativeStringType(ctx));
   if (subjType?.kind === "ref_null") fctx.body.push({ op: "ref.as_non_null" } as Instr);
   fctx.body.push({ op: "call", funcIdx: flattenIdx });
   const subjLocal = allocLocal(fctx, `__re_gma_subj_${fctx.locals.length}`, { kind: "ref", typeIdx: strTypeIdx });
@@ -1528,6 +1581,75 @@ export function tryCompileStandaloneStringSplit(
     return null;
   }
   return { kind: "ref", typeIdx: nstrVecTypeIdx };
+}
+
+/**
+ * `re[Symbol.match](str)` / `re[Symbol.matchAll](str)` / `re[Symbol.search](str)`
+ * — the explicit well-known-symbol protocol forms (§22.2.6) — in standalone
+ * mode (#2161).
+ *
+ * These are the operand-swapped duals of `String.prototype.match/matchAll/
+ * search`: the RegExp is the **receiver** and the string is the **argument**.
+ * The native engine is operand-order agnostic (the lower-level emitters take an
+ * explicit regex expression + subject expression), so each method reuses the
+ * exact same core that backs the corresponding String.prototype method — there
+ * is no separate engine path and no host import.
+ *
+ * Gating mirrors the String.prototype path: the receiver must be a static /
+ * backend-created RegExp value (so the pattern + flags are known at compile
+ * time) and the argument must be string-like. Dynamic-flag receivers, string-
+ * coercion arguments, and `@@replace`/`@@split` (a follow-up slice) return
+ * `undefined`, so the caller falls through to the existing
+ * `__regex_symbol_call` host import (JS-host mode) or the standalone refusal.
+ *
+ * `methodName` is the `@@<id>` sentinel the element-access dispatcher resolved
+ * for the computed Symbol key (e.g. `"@@match"`).
+ */
+export function tryCompileStandaloneRegExpSymbolCall(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  regexExpr: ts.Expression,
+  methodName: string,
+): ValType | null | undefined {
+  if (!ctx.standalone) return undefined;
+
+  // Only the read protocol forms are wired in this slice; @@replace / @@split
+  // (which carry extra replacement/limit operands) fall through to the host /
+  // refusal path until their cores are operand-generalised.
+  const symbolMethod =
+    methodName === "@@match"
+      ? "match"
+      : methodName === "@@matchAll"
+        ? "matchAll"
+        : methodName === "@@search"
+          ? "search"
+          : undefined;
+  if (symbolMethod === undefined) return undefined;
+
+  // Receiver must be a static / backend-created RegExp (pattern + flags known
+  // at compile time); a dynamic / `any`-typed receiver falls through so the
+  // host import can do the fully-dynamic dispatch.
+  const recvType = ctx.checker.getTypeAtLocation(regexExpr);
+  if (!isGlobalRegExpType(recvType) && !isKnownBackendCreatedRegExpReceiver(ctx, regexExpr)) {
+    return undefined;
+  }
+
+  // Exactly one string argument; string-coercion (`re[Symbol.match](42)`)
+  // falls through to the host path which performs ToString.
+  if (expr.arguments.length !== 1) return undefined;
+  const strExpr = expr.arguments[0]!;
+  if (!isStringLikeArg(ctx, strExpr)) return undefined;
+
+  // Operand order: subject = the string ARGUMENT, regex = the RECEIVER.
+  switch (symbolMethod) {
+    case "search":
+      return emitStandaloneRegExpSearchCore(ctx, fctx, expr, strExpr, regexExpr);
+    case "match":
+      return emitStandaloneRegExpMatchCore(ctx, fctx, expr, strExpr, regexExpr);
+    case "matchAll":
+      return emitStandaloneRegExpMatchAllCore(ctx, fctx, expr, strExpr, regexExpr);
+  }
 }
 
 // ── #1914: RegExp reflection + match-result shape ─────────────────────
@@ -1969,15 +2091,38 @@ export function tryCompileStandaloneRegExpMatchResultRead(
  */
 function isStandaloneMatchResultCall(ctx: CodegenContext, expr: ts.Expression): boolean {
   const unwrapped = stripStaticWrapper(expr);
-  if (!ts.isCallExpression(unwrapped) || !ts.isPropertyAccessExpression(unwrapped.expression)) return false;
-  const method = unwrapped.expression.name.text;
-  if (method === "exec") {
-    return isKnownBackendCreatedRegExpReceiver(ctx, unwrapped.expression.expression);
+  if (!ts.isCallExpression(unwrapped)) return false;
+  if (ts.isPropertyAccessExpression(unwrapped.expression)) {
+    const method = unwrapped.expression.name.text;
+    if (method === "exec") {
+      return isKnownBackendCreatedRegExpReceiver(ctx, unwrapped.expression.expression);
+    }
+    if (method === "match" && unwrapped.arguments.length === 1) {
+      return isKnownBackendCreatedRegExpReceiver(ctx, unwrapped.arguments[0]!);
+    }
+    return false;
   }
-  if (method === "match" && unwrapped.arguments.length === 1) {
-    return isKnownBackendCreatedRegExpReceiver(ctx, unwrapped.arguments[0]!);
+  // `re[Symbol.match](s)` (#2161) — the symbol-protocol dual of `s.match(re)`:
+  // a non-global match yields the same `$__regexp_match_vec` ref result, so the
+  // declared local must carry that type too (else indexed reads route through
+  // __extern_get_idx and trap). Receiver is the static/backend RegExp.
+  if (ts.isElementAccessExpression(unwrapped.expression)) {
+    const elem = unwrapped.expression;
+    if (isSymbolMatchKey(elem.argumentExpression) && unwrapped.arguments.length === 1) {
+      return isKnownBackendCreatedRegExpReceiver(ctx, elem.expression);
+    }
   }
   return false;
+}
+
+/** True for the computed key `Symbol.match` (the @@match well-known symbol). */
+function isSymbolMatchKey(arg: ts.Expression): boolean {
+  return (
+    ts.isPropertyAccessExpression(arg) &&
+    ts.isIdentifier(arg.expression) &&
+    arg.expression.text === "Symbol" &&
+    arg.name.text === "match"
+  );
 }
 
 /** Is `expr` the `null` / `undefined` literal (fine for a ref_null global)? */

--- a/tests/issue-2161-regex-symbol-protocol.test.ts
+++ b/tests/issue-2161-regex-symbol-protocol.test.ts
@@ -23,8 +23,16 @@ async function standaloneExports(source: string) {
   expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
   // No JS-host string / regex protocol import may leak in standalone.
   const labels = r.imports.map((i) => `${i.module}::${i.name}`);
-  for (const re of [/^env::__extern_toString$/, /^wasm:js-string::/, /^env::__regex_symbol_call$/, /^env::__extern_get$/]) {
-    expect(labels.filter((l) => re.test(l)), `leaked ${re}`).toEqual([]);
+  for (const re of [
+    /^env::__extern_toString$/,
+    /^wasm:js-string::/,
+    /^env::__regex_symbol_call$/,
+    /^env::__extern_get$/,
+  ]) {
+    expect(
+      labels.filter((l) => re.test(l)),
+      `leaked ${re}`,
+    ).toEqual([]);
   }
   const { instance } = await WebAssembly.instantiate(r.binary, {});
   return instance.exports as Record<string, (...a: unknown[]) => number>;

--- a/tests/issue-2161-regex-symbol-protocol.test.ts
+++ b/tests/issue-2161-regex-symbol-protocol.test.ts
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2161 — standalone `re[Symbol.match/matchAll/search](str)` protocol calls.
+ *
+ * The explicit well-known-symbol READ protocol forms (§22.2.6) are the
+ * operand-swapped duals of `String.prototype.match/matchAll/search`: the RegExp
+ * is the **receiver** and the string is the **argument**. They were blanket-
+ * refused in `--target standalone` (calls.ts) even though the native engine is
+ * operand-order agnostic. This slice routes the static / backend-created RegExp
+ * forms to the exact same native cores that back the String.prototype methods —
+ * NO JS host import (`__regex_symbol_call` must not leak).
+ *
+ * Deferred (still narrowed — refused, not silently wrong):
+ *   - `@@replace` / `@@split` (carry extra replacement / limit operands);
+ *   - dynamic-flag / `any`-typed receivers (fall through to the host path);
+ *   - string-coercion arguments (`re[Symbol.match](42)`).
+ */
+async function standaloneExports(source: string) {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  // No JS-host string / regex protocol import may leak in standalone.
+  const labels = r.imports.map((i) => `${i.module}::${i.name}`);
+  for (const re of [/^env::__extern_toString$/, /^wasm:js-string::/, /^env::__regex_symbol_call$/, /^env::__extern_get$/]) {
+    expect(labels.filter((l) => re.test(l)), `leaked ${re}`).toEqual([]);
+  }
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return instance.exports as Record<string, (...a: unknown[]) => number>;
+}
+
+describe("#2161 — standalone re[Symbol.search](str)", () => {
+  it("returns the match index", async () => {
+    const ex = await standaloneExports(`
+      export function idx(): number { return /abc/[Symbol.search]("xyabc"); }
+    `);
+    expect(ex.idx()).toBe(2);
+  });
+
+  it("returns -1 on no match", async () => {
+    const ex = await standaloneExports(`
+      export function miss(): number { return /zzz/[Symbol.search]("xyabc"); }
+    `);
+    expect(ex.miss()).toBe(-1);
+  });
+});
+
+describe("#2161 — standalone re[Symbol.match](str)", () => {
+  it("non-global: exposes capture group m[1]", async () => {
+    const ex = await standaloneExports(`
+      export function cap(): number {
+        let m = /a(b)c/[Symbol.match]("xabc");
+        return m ? m[1].length : -9;
+      }
+    `);
+    expect(ex.cap()).toBe(1); // "b".length
+  });
+
+  it("non-global: exposes .index", async () => {
+    const ex = await standaloneExports(`
+      export function where(): number {
+        let m = /a(b)c/[Symbol.match]("xabc");
+        return m ? (m.index as number) : -9;
+      }
+    `);
+    expect(ex.where()).toBe(1);
+  });
+
+  it("non-global: null on no match (not a stray ref)", async () => {
+    const ex = await standaloneExports(`
+      export function none(): number {
+        let m = /zzz/[Symbol.match]("xabc");
+        return m ? 1 : 0;
+      }
+    `);
+    expect(ex.none()).toBe(0);
+  });
+
+  it("global: collects every [0] substring (length)", async () => {
+    const ex = await standaloneExports(`
+      export function count(): number {
+        let m = /X/g[Symbol.match]("aXbXcX");
+        return m ? m.length : -9;
+      }
+    `);
+    expect(ex.count()).toBe(3);
+  });
+});
+
+describe("#2161 — standalone re[Symbol.matchAll](str)", () => {
+  it("iterates every match, exposing capture groups", async () => {
+    const ex = await standaloneExports(`
+      export function sumDigits(): number {
+        let sum = 0;
+        for (const m of /(\\d)/g[Symbol.matchAll]("a1b2c3")) { sum = sum + Number(m[1]); }
+        return sum;
+      }
+    `);
+    expect(ex.sumDigits()).toBe(6); // 1 + 2 + 3
+  });
+
+  it("yields one iterator entry per match", async () => {
+    const ex = await standaloneExports(`
+      export function count(): number {
+        let c = 0;
+        for (const m of /X/g[Symbol.matchAll]("aXbX")) { c = c + 1; }
+        return c;
+      }
+    `);
+    expect(ex.count()).toBe(2);
+  });
+});


### PR DESCRIPTION
## What

Routes the well-known-symbol **READ** protocol forms to the native standalone
RegExp engine for static / backend-created RegExp receivers — `re[Symbol.match](s)`,
`re[Symbol.matchAll](s)`, `re[Symbol.search](s)`. Previously these were
blanket-refused under `--target standalone` (`calls.ts`), even though the native
engine is operand-order agnostic. **Zero host imports.**

This is the first slice of sub-bucket (b) from the #2161 data-backed triage
(~128 `@@`-protocol-call failures).

## How

- `regexp-standalone.ts`: extracted operand-explicit cores
  (`emitStandaloneRegExpSearchCore` / `…MatchCore` / `…MatchAllCore`) from the
  existing `tryCompileStandaloneStringSearch/Match/MatchAll` functions, which now
  delegate. Added `tryCompileStandaloneRegExpSymbolCall` that calls the same
  cores with **swapped operands** (regex = receiver, subject = argument). No
  second engine path.
- Taught the match-result-local type inferers (`isStandaloneMatchResultCall` in
  regexp-standalone.ts; `inferStandaloneRegExpMatchArrayType` +
  `isStaticRegExpMatchArrayCallForImportScan` in index.ts) to recognise the
  `re[Symbol.match](s)` shape, so `let m = …` carries the precise
  `$__regexp_match_vec` ref type and `m[1]` stays on the native vec path (else
  it leaks `env::__extern_get`).
- `calls.ts`: at the standalone `@@`-refusal site, try the native path first;
  fall through to the existing refusal / JS-host `__regex_symbol_call` when it
  returns `undefined`.

## Tests

`tests/issue-2161-regex-symbol-protocol.test.ts` — 8 cases, all standalone with
an empty importObject (asserts no `__regex_symbol_call` / `__extern_get` /
`wasm:js-string` leak): `@@search` index & -1, `@@match` non-global capture /
`.index` / null / global length, `@@matchAll` capture-sum & count.

257 existing regex tests stay green (the core extraction is behaviour-preserving;
host mode still uses `__regex_symbol_call`).

## Deferred (still narrowed-refuse, not silently wrong)

`@@replace` / `@@split` (extra replacement/limit operands — next slice),
dynamic-flag / `any`-typed receivers, string-coercion arguments. The
`RegExp.prototype` reflection bucket stays gated on #2158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)