### PR TITLE
feat(#1355): standalone Proxy deleteProperty trap (§10.5.10)

### DIFF
--- a/plan/issues/1355-spec-backlog-proxy-pure-wasm.md
+++ b/plan/issues/1355-spec-backlog-proxy-pure-wasm.md
@@ -1,9 +1,10 @@
 ---
 id: 1355
 title: "spec backlog: Proxy implementation beyond JS-host fallback (235 test262 fails)"
-status: ready
+status: in-progress
+assignee: ttraenkler/sdev-proxy3
 created: 2026-05-08
-updated: 2026-06-15
+updated: 2026-06-17
 priority: top
 feasibility: hard
 reasoning_effort: high
@@ -157,3 +158,56 @@ unchanged.
 depends_on #1100 (hard prereq); #797/#1460/#1462 descriptor attributes;
 cascade-unblocks standalone `Reflect.*` invariants (#1346). Implement strictly
 from fetched §10.5 spec text, cite the section in each helper + commit.
+
+## Implementation — Slice A: deleteProperty (sdev-proxy3, 2026-06-17, sprint 63)
+
+Re-validated vs upstream/main fe0e21ba1 before coding: the #1100 Phase-1
+substrate (`$Proxy`/`$ProxyTraps` standalone structs, get/set/has dispatch via
+`ref.test $Proxy` front-guards on `__extern_get/set/has`, traps invoked through
+the `__apply_closure` bridge with the handler bound as `this`) is present. A
+probe of each of the 8 remaining traps confirmed they all COMPILE + RUN cleanly
+today but the trap NEVER FIRES — it silently forwards to the target. So #1355 is
+pure feature-add on a proven dispatch substrate, not a bug hunt.
+
+Slice A wires the **deleteProperty** trap (§10.5.10 [[Delete]]). All in
+`src/codegen/object-runtime.ts`; `tests/issue-1355.test.ts` (7 tests, all green;
+tsc clean; every program `WebAssembly.validate`s true). #1100's 9 tests stay
+green; ordinary (non-proxy) standalone delete verified unaffected.
+
+### How it slots into #1100's architecture (no new machinery invented)
+1. **`$ProxyTraps`** gains a 5th field `deleteProperty` (externref closure),
+   APPENDED after the #1100 base four (get/set/has/apply) — never renumber the
+   base, per the architect note. `__proxy_create` reads it off the open handler
+   via `__extern_get` (undefined → null → forward) and stores it in the struct.
+2. **`__proxy_delete_dispatch(proxy, key, _recv)`** is built by the existing
+   `buildDispatch` helper, treated like `has`: a 2-arg `(target,key) -> i32`
+   forward target (`__delete_property`) whose result is boxed via `__box_boolean`
+   to keep the dispatch's uniform externref ABI. Takes 3 params (unused receiver
+   placeholder) purely so the local indices line up with `buildDispatch`'s
+   hardcoded p=local3/trap=local4 layout — the [[Delete]] trap signature itself
+   is `(target, key)`, no receiver.
+3. **`__proxy_call_delete`** driver (reserve-then-fill, #1719) routes the trap
+   through `__apply_closure(trap, handler, «target,key»)` — same bridge as
+   has/get/set; filled at FINALIZE by `fillProxyDispatch` (arity 2).
+4. **Front-guard** prepended to the native `__delete_property` helper: a
+   `ref.test $Proxy` on param0 diverts a proxy receiver to the dispatch and
+   coerces its booleanish result back to the delete operator's i32 via
+   `__is_truthy` (identical shape to the `__extern_has` front-guard). Because
+   BOTH `delete p.x` and `Reflect.deleteProperty(p,k)` lower to
+   `__delete_property`, this single guard covers both call forms; computed-key
+   `delete p[k]` too.
+
+### Verified semantics (probe + tests)
+- trap return value (`true`/`false`) becomes the `delete` operator result;
+- trap receives the correct `(target, key)` and can delete through the target;
+- absent trap forwards to the ordinary [[Delete]] on the target;
+- the revoked-proxy throw is shared with get/set/has (`throwRevoked()` arm), so
+  it is enforced — but cannot be exercised standalone until `Proxy.revocable`
+  call-site synthesis lands (deferred in #1100, still standalone-unsupported).
+
+### Out of scope for Slice A (later slices, tracked here)
+§10.5.10 result-invariant (trap must not report success for deleting a
+non-configurable own property → TypeError) deferred to the invariant slice.
+Remaining traps: B=ownKeys+getOwnPropertyDescriptor · C=getPrototypeOf+
+setPrototypeOf · D=isExtensible+preventExtensions+defineProperty · E=§10.5
+invariants + construct/apply.

--- a/scripts/coercion-sites-baseline.json
+++ b/scripts/coercion-sites-baseline.json
@@ -21,7 +21,7 @@
   "codegen/map-runtime.ts": 2,
   "codegen/number-format-native.ts": 8,
   "codegen/object-ops.ts": 4,
-  "codegen/object-runtime.ts": 19,
+  "codegen/object-runtime.ts": 20,
   "codegen/parse-number-native.ts": 4,
   "codegen/property-access.ts": 11,
   "codegen/stack-balance.ts": 1,

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -288,18 +288,21 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     ],
   });
 
-  // (#1100) `$ProxyTraps` — 4 trap fields for the standalone Proxy Phase 1
-  // (get/set/has/apply). A null field means "no trap" → forward to the ordinary
-  // operation on the proxy target. The fields hold the user trap handler as an
-  // **externref closure** (the boxed closure-wrapper struct produced by every
-  // compiled function expression), NOT a bare funcref: a user trap `(t,k,r) =>
-  // …` lowers to a GC closure struct whose own funcref takes the closure-self as
-  // arg0, so it cannot be `call_ref`-ed with `(target,key,receiver)` directly.
-  // Phase 1 invokes traps through the existing closure-call bridge
-  // (`__call_fn_method_N`, the same path accessors/`__apply_closure` use) which
-  // threads `this` and the closure-self correctly — see `ensureProxyRuntime` /
-  // `fillProxyDispatch`. This is the architect's "reuse the closure→funcref
-  // bridge, don't invent a calling convention" requirement.
+  // (#1100/#1355) `$ProxyTraps` — trap fields for the standalone Proxy. A null
+  // field means "no trap" → forward to the ordinary operation on the proxy
+  // target. The fields hold the user trap handler as an **externref closure**
+  // (the boxed closure-wrapper struct produced by every compiled function
+  // expression), NOT a bare funcref: a user trap `(t,k,r) => …` lowers to a GC
+  // closure struct whose own funcref takes the closure-self as arg0, so it cannot
+  // be `call_ref`-ed with `(target,key,receiver)` directly. Traps are invoked
+  // through the existing closure-call bridge (`__apply_closure`, the same path
+  // accessors use) which threads `this` and the closure-self correctly — see
+  // `ensureProxyRuntime` / `fillProxyDispatch`. This is the architect's "reuse
+  // the closure→funcref bridge, don't invent a calling convention" requirement.
+  //
+  // (#1355) APPEND new trap fields after the #1100 base four (get/set/has/apply);
+  // never renumber the base — the dispatch helpers and `__proxy_create` bake the
+  // field indices. `deleteProperty` is field index 4.
   const proxyTrapsTypeIdx = ctx.mod.types.length;
   ctx.mod.types.push({
     kind: "struct",
@@ -309,6 +312,8 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
       { name: "set", type: { kind: "externref" }, mutable: false },
       { name: "has", type: { kind: "externref" }, mutable: false },
       { name: "apply", type: { kind: "externref" }, mutable: false },
+      // (#1355 Slice A) deleteProperty — field index 4.
+      { name: "deleteProperty", type: { kind: "externref" }, mutable: false },
     ],
   });
 
@@ -4718,10 +4723,11 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
   return types;
 }
 
-/** (#1100) Reserved trap-invoke driver names — filled by `fillProxyDispatch`. */
+/** (#1100/#1355) Reserved trap-invoke driver names — filled by `fillProxyDispatch`. */
 const PROXY_CALL_GET = "__proxy_call_get";
 const PROXY_CALL_SET = "__proxy_call_set";
 const PROXY_CALL_HAS = "__proxy_call_has";
+const PROXY_CALL_DELETE = "__proxy_call_delete"; // (#1355 Slice A)
 
 /**
  * (#1100) Standalone Proxy meta-object dispatch runtime — Phase 1.
@@ -4808,10 +4814,11 @@ function ensureProxyRuntime(
   const F_PHANDLER = 2;
   const F_PTRAPS = 3;
   const F_REVOKED = 4;
-  // Field indices on $ProxyTraps: get(0) set(1) has(2) apply(3).
+  // Field indices on $ProxyTraps: get(0) set(1) has(2) apply(3) deleteProperty(4).
   const TRAP_GET = 0;
   const TRAP_SET = 1;
   const TRAP_HAS = 2;
+  const TRAP_DELETE = 4; // (#1355 Slice A)
 
   // ── Reserve the trap-invoke driver placeholders (filled by fillProxyDispatch) ──
   //
@@ -4843,6 +4850,9 @@ function ensureProxyRuntime(
   const callGetIdx = reserveDriver(PROXY_CALL_GET, [externref, externref, externref, externref, externref]);
   const callSetIdx = reserveDriver(PROXY_CALL_SET, [externref, externref, externref, externref, externref, externref]);
   const callHasIdx = reserveDriver(PROXY_CALL_HAS, [externref, externref, externref, externref]);
+  // (#1355 Slice A) deleteProperty driver — same arity as has: (handler, trap,
+  // target, key) → __call_fn_method_2 (§10.5.10 step 8 `Call(trap, handler, «O, P»)`).
+  const callDeleteIdx = reserveDriver(PROXY_CALL_DELETE, [externref, externref, externref, externref]);
   ctx.proxyDispatchReserved = true;
 
   // Builds a dispatch helper body. `trapFieldIdx` selects the trap closure;
@@ -4877,6 +4887,10 @@ function ensureProxyRuntime(
       trapArm.push({ op: "call", funcIdx: callSetIdx });
     } else if (trapFieldIdx === TRAP_HAS) {
       trapArm.push({ op: "call", funcIdx: callHasIdx });
+    } else if (trapFieldIdx === TRAP_DELETE) {
+      // (#1355) deleteProperty: driver(handler, trap, target, key) — same 2-arg
+      // shape as has (§10.5.10 step 8 `Call(trap, handler, «O, P»)`).
+      trapArm.push({ op: "call", funcIdx: callDeleteIdx });
     } else {
       // get: receiver = param 2
       trapArm.push({ op: "local.get", index: 2 });
@@ -4926,10 +4940,12 @@ function ensureProxyRuntime(
               { op: "call", funcIdx: forwardIdx },
               { op: "ref.null.extern" },
             ]
-          : trapFieldIdx === TRAP_HAS
+          : trapFieldIdx === TRAP_HAS || trapFieldIdx === TRAP_DELETE
             ? [
-                // __extern_has(target, key) -> i32 ; box back to a boolean any so
-                // the dispatch result stays uniform externref.
+                // has:    __extern_has(target, key)     -> i32
+                // delete: __delete_property(target, key) -> i32
+                // Both are 2-arg `(target,key) -> i32`; box back to a boolean any
+                // so the dispatch result stays uniform externref.
                 { op: "local.get", index: 3 },
                 { op: "struct.get", typeIdx: proxyTypeIdx, fieldIdx: F_PTARGET },
                 { op: "extern.convert_any" } as Instr,
@@ -4985,6 +5001,24 @@ function ensureProxyRuntime(
     dispatchLocals(),
     buildDispatch(TRAP_HAS, "__extern_has", false),
   );
+  // (#1355 Slice A) __proxy_delete_dispatch(proxyExtern, key, _recv) -> externref
+  // (booleanish). §10.5.10 [[Delete]]: revoked→throw; read deleteProperty trap;
+  // null→forward __delete_property on target (boxed boolean); else invoke trap
+  // with `(target, key)` and the handler as `this`. The `__delete_property`
+  // front-guard coerces the result back to i32 via `__is_truthy`. Phase-A scope:
+  // NO §10.5.10 result-invariant check (a trap may not report a delete of a
+  // non-configurable own property as successful) — that is a later invariant
+  // slice. Takes 3 params to match `buildDispatch`'s hardcoded local layout
+  // (p=local 3, trap=local 4 after the 3 params); the [[Delete]] trap signature
+  // has no receiver, so param 2 is an unused placeholder (the front-guard passes
+  // the proxy itself, never read on the delete path).
+  registerNative(
+    "__proxy_delete_dispatch",
+    [externref, externref, externref],
+    [externref],
+    dispatchLocals(),
+    buildDispatch(TRAP_DELETE, "__delete_property", false),
+  );
 
   // ── __proxy_create(target, handler) -> externref ──────────────────────────
   //
@@ -5030,7 +5064,7 @@ function ensureProxyRuntime(
       { op: "any.convert_extern" },
       { op: "ref.is_null" },
       { op: "if", blockType: { kind: "empty" }, then: throwNotObject() } as Instr,
-      // read the four traps off the (open) handler.
+      // read the traps off the (open) handler. (#1355) deleteProperty appended.
       ...readTrap("get"),
       { op: "local.set", index: 2 },
       ...readTrap("set"),
@@ -5039,17 +5073,20 @@ function ensureProxyRuntime(
       { op: "local.set", index: 4 },
       ...readTrap("apply"),
       { op: "local.set", index: 5 },
+      ...readTrap("deleteProperty"),
+      { op: "local.set", index: 6 },
       // proxy fields (standalone $Proxy struct):
       { op: "i32.const", value: 1 }, // ptag = PROXY_TAG (1; bare ref.test $Proxy is the real discriminator)
       { op: "local.get", index: 0 }, // ptarget (externref → anyref)
       { op: "any.convert_extern" } as Instr,
       { op: "local.get", index: 1 }, // phandler (externref → anyref; trap `this`)
       { op: "any.convert_extern" } as Instr,
-      // ptraps = struct.new $ProxyTraps (getT, setT, hasT, applyT)
+      // ptraps = struct.new $ProxyTraps (getT, setT, hasT, applyT, delT)
       { op: "local.get", index: 2 },
       { op: "local.get", index: 3 },
       { op: "local.get", index: 4 },
       { op: "local.get", index: 5 },
+      { op: "local.get", index: 6 },
       { op: "struct.new", typeIdx: proxyTrapsTypeIdx } as Instr,
       { op: "i32.const", value: 0 }, // revoked = 0
       { op: "struct.new", typeIdx: proxyTypeIdx } as Instr,
@@ -5064,6 +5101,7 @@ function ensureProxyRuntime(
         { name: "setT", type: externref },
         { name: "hasT", type: externref },
         { name: "applyT", type: externref },
+        { name: "delT", type: externref }, // (#1355 Slice A)
       ],
       proxyCreateBody,
     );
@@ -5114,6 +5152,7 @@ function ensureProxyRuntime(
   const getDispatchIdx = ctx.funcMap.get("__proxy_get_dispatch")!;
   const setDispatchIdx = ctx.funcMap.get("__proxy_set_dispatch")!;
   const hasDispatchIdx = ctx.funcMap.get("__proxy_has_dispatch")!;
+  const deleteDispatchIdx = ctx.funcMap.get("__proxy_delete_dispatch")!; // (#1355 Slice A)
 
   const findBody = (name: string): Instr[] | undefined => ctx.mod.functions.find((f) => f.name === name)?.body;
 
@@ -5187,6 +5226,34 @@ function ensureProxyRuntime(
       } as Instr,
     ];
     hasBody.unshift(...guard);
+  }
+
+  // (#1355 Slice A) __delete_property(obj, key) -> i32 : if proxy →
+  // ToBoolean(delete_dispatch(obj,key)). `delete p.x` / `Reflect.deleteProperty`
+  // both route through __delete_property, so this single front-guard covers both.
+  // The dispatch returns the deleteProperty trap's booleanish externref result;
+  // coerce to i32 via `__is_truthy` (same as the has guard).
+  const deleteBody = findBody("__delete_property");
+  if (deleteBody) {
+    const isTruthyIdx = ctx.funcMap.get("__is_truthy")!;
+    const guard: Instr[] = [
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "ref.test", typeIdx: proxyTypeIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 0 },
+          { op: "local.get", index: 1 },
+          { op: "local.get", index: 0 }, // unused receiver placeholder (3-param dispatch)
+          { op: "call", funcIdx: deleteDispatchIdx },
+          { op: "call", funcIdx: isTruthyIdx },
+          { op: "return" },
+        ],
+      } as Instr,
+    ];
+    deleteBody.unshift(...guard);
   }
 
   void objectTypeIdx;
@@ -5264,6 +5331,7 @@ export function fillProxyDispatch(ctx: CodegenContext): void {
   fill(PROXY_CALL_GET, 3); // (target, key, receiver)
   fill(PROXY_CALL_SET, 4); // (target, key, value, receiver)
   fill(PROXY_CALL_HAS, 2); // (target, key)
+  fill(PROXY_CALL_DELETE, 2); // (#1355 Slice A) deleteProperty (target, key)
 }
 
 /**

--- a/tests/issue-1355.test.ts
+++ b/tests/issue-1355.test.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1355 — Wasm-native Proxy, remaining traps (standalone). Builds on #1100
+// Phase 1 (get/set/has). This file covers the trap groups landed by #1355,
+// one `describe` block per slice.
+//
+// Slice A — `deleteProperty` (§10.5.10 [[Delete]]). `delete proxy.x` (and
+// `Reflect.deleteProperty`) route through the native `__delete_property`
+// runtime helper; a `ref.test $Proxy` front-guard prepended to that helper
+// diverts a proxy receiver to `__proxy_delete_dispatch`, which reads the
+// `deleteProperty` trap closure off `$ProxyTraps`, invokes it (handler bound
+// as `this`, args `(target, key)`) through the `__apply_closure` bridge, and
+// coerces the booleanish trap result back to the delete operator's i32. When
+// the trap is absent, the dispatch forwards to the ordinary [[Delete]] on the
+// target.
+//
+// Spec: ECMA-262 §10.5.10 (Proxy [[Delete]]), §13.5.1 (delete operator).
+//
+// NOTE: as in #1100, the proxy is bound to a `const p: any` local so member
+// access lowers to the dynamic `__delete_property` boundary (the path
+// test262's untyped JS always takes). A statically-typed proxy local bypasses
+// the meta-object — out of scope.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module failed WebAssembly.validate").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+describe("#1355 standalone Proxy — deleteProperty trap (§10.5.10)", () => {
+  it("deleteProperty trap intercepts `delete proxy.x`", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        let hit = 0;
+        const p: any = new Proxy({ x: 5 }, { deleteProperty: (t: any, k: any) => { hit = 1; return true; } });
+        delete p.x;
+        return hit;
+      }`),
+    ).toBe(1);
+  });
+
+  it("the trap's truthy result becomes the delete operator's result (true)", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const p: any = new Proxy({ x: 5 }, { deleteProperty: (t: any, k: any) => true });
+        return (delete p.x) ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("the trap's falsy result becomes the delete operator's result (false)", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const p: any = new Proxy({ x: 5 }, { deleteProperty: (t: any, k: any) => false });
+        return (delete p.x) ? 1 : 0;
+      }`),
+    ).toBe(0);
+  });
+
+  it("the trap receives the property key", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        let seen = "";
+        const p: any = new Proxy({}, { deleteProperty: (t: any, k: any) => { seen = k; return true; } });
+        delete p.foo;
+        return seen === "foo" ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("the trap receives the target and can delete through it", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const t: any = { x: 9 };
+        const p: any = new Proxy(t, { deleteProperty: (tt: any, k: any) => { delete tt[k]; return true; } });
+        delete p.x;
+        return t.x === undefined ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("an absent deleteProperty trap forwards to the ordinary [[Delete]] on the target", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const t: any = { x: 1 };
+        const p: any = new Proxy(t, {});
+        delete p.x;
+        return t.x === undefined ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("deleteProperty trap via computed-key access `delete proxy[k]`", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        let hit = 0;
+        const key: any = "y";
+        const p: any = new Proxy({ y: 2 }, { deleteProperty: (t: any, k: any) => { hit = 1; return true; } });
+        delete p[key];
+        return hit;
+      }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## #1355 Slice A — Proxy `deleteProperty` trap (standalone)

Builds on #1100 Phase 1 (standalone `$Proxy`/`$ProxyTraps` + get/set/has). Re-validated vs upstream/main `fe0e21ba1`: the #1100 dispatch substrate is present and all 8 remaining traps currently compile+run but **never fire** (silently forward to target). This slice wires the first one.

### What this lands
- **`$ProxyTraps`** gains a 5th field `deleteProperty` (appended after the #1100 base get/set/has/apply — base field indices unchanged, per the architect's "append, don't renumber" note). Read off the open handler in `__proxy_create`.
- **`__proxy_delete_dispatch`** built by the existing `buildDispatch` helper, treated like `has`: a 2-arg `(target,key) -> i32` forward (`__delete_property`) whose result is boxed via `__box_boolean` for the uniform-externref dispatch ABI.
- **`__proxy_call_delete`** driver (reserve-then-fill, #1719) routes the trap through the proven `__apply_closure(trap, handler, «target,key»)` bridge — handler bound as `this` (§10.5.10 step 8). No new calling convention.
- **Front-guard** prepended to the native `__delete_property` helper: `ref.test $Proxy` diverts a proxy receiver and coerces the booleanish trap result back to the `delete` operator's i32 via `__is_truthy`. Because `delete p.x`, `delete p[k]`, and `Reflect.deleteProperty(p,k)` all lower to `__delete_property`, this single guard covers every call form.

### Verified
- trap return (`true`/`false`) becomes the `delete` result; trap receives `(target, key)` and can delete through the target; absent trap forwards to ordinary [[Delete]]; computed-key form works.
- `tests/issue-1355.test.ts` — 7 tests, all green. #1100's 9 tests stay green. Ordinary (non-proxy) standalone delete verified unaffected by the front-guard. tsc clean; every program `WebAssembly.validate`s true.

### Scope / deferred
§10.5.10 result-invariant (trap may not report success for deleting a non-configurable own prop → TypeError) deferred to the invariant slice. Remaining traps follow in slices B–E. The revoked-proxy throw is shared with get/set/has but can't be exercised standalone until `Proxy.revocable` call-site synthesis lands (deferred in #1100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)