### PR TITLE
feat(#2166 PR-C): standalone dynamic JSON.parse pure-Wasm codec

### DIFF
--- a/plan/issues/2166-standalone-json-residual.md
+++ b/plan/issues/2166-standalone-json-residual.md
@@ -376,3 +376,70 @@ this PR (verified by stashing). PR #1653.
   blast radius, overlaps #1917; deferred.
 - **PR-B:** dynamic-space indentation. **PR-C:** `__json_parse_text`. **PR-D:**
   instance fields + toJSON + reviver/replacer.
+
+## Progress (2026-06-17, sdev-json2) — PR-C: dynamic JSON.parse codec
+
+PR-C of the Implementation Plan. Adds `emitJsonParseText` to
+`src/codegen/json-codec-native.ts`: a pure-Wasm recursive-descent JSON parser
+(ECMA-404 / §25.5.1) — `__json_parse_text(s: externref) -> anyref` plus mutually
+recursive `__json_parse_value` / `__json_parse_str` helpers sharing a cursor
+through a `$JsonP { $data, $pos(mut), $end }` state struct. Output uses the SAME
+standalone value rep stringify (PR-A) consumes and the property-read path
+unboxes:
+
+- objects → `$Object` via `__new_plain_object` + `__extern_set` (insertion order).
+- numbers → `$__box_number_struct`; booleans → `$__box_number_struct` 1.0/0.0
+  (matching how `o.x = true` stores a boolean in a standalone object — a distinct
+  boolean identity is the broader #1917 boolean-boxing gap); `null` → null eqref.
+- strings → native `$AnyString` with full §25.5.1 unescaping (`\" \\ \/ \b\f\n\r\t`
+  and `\uXXXX`), via a two-pass (size-scan then fill) over the flattened i16 backing.
+- arrays → `$ObjVec` via `__objvec_new` + `__objvec_push`.
+- malformed input / trailing junk → runtime `throw new SyntaxError(...)` through the
+  standalone `__new_SyntaxError` ctor + the shared exn tag (§25.5.1 step 3), not a trap.
+
+Routing (`src/codegen/expressions/calls.ts`): a runtime-string / `any`-typed
+`JSON.parse(text)` (1-arg) now routes to the codec, replacing the primitive-only
+`__json_parse_primitive` slice (a strict superset — it parsed only a lone
+number/true/false/null and trapped on `{`/`[`/`"`). A `reviver` (2nd arg) is
+deferred to PR-D (refused, not silently ignored).
+
+Tests: `tests/issue-2166.test.ts` (+14 PR-C cases — object number/string/nested
+reads, §25.5.1 escapes incl. `\uXXXX`, boolean truthy round-trip, null, top-level
+primitive, negative/fraction/exponent numbers, whitespace tolerance, object +
+nested round-trip `JSON.parse(JSON.stringify(o))`, `--target wasi`, and a
+malformed-input SyntaxError throw). Updated `tests/issue-1599-json-standalone-
+refuse.test.ts`: dynamic `JSON.parse(s).x` now COMPILES (was refused), both
+standalone and wasi; a dynamic `number[]` stringify still refuses (PR-A2).
+
+Two pre-existing host-mode failures (`tests/json.test.ts` number→host-import,
+array-of-structs) are upstream, not from this PR (the host `JSON_stringify`
+import path is untouched — every PR-C change is gated on `ctx.standalone ||
+ctx.wasi`).
+
+### Codegen note (WHY) — fresh GC struct in a lazy codegen pass
+A fresh struct type registered during a *lazy* call-expression codegen (here
+`$JsonP`) is fragile if its `typeIdx` is baked into many shared helper-`Instr`
+objects: the finalize dead-type-elimination remap (`remapTypeIdxInBody`)
+mutates `typeIdx` IN PLACE and re-visits a shared object once per occurrence,
+re-mapping an already-mapped index repeatedly (the #1302 shared-array
+double-shift hazard). It desynced the most-spread `$pos` `struct.get`/`set`
+operands (78→72→…→54 `$ProxyTraps`) from the cursor local's declared type. Fix:
+deep-clone each function body with a **JSON round-trip** (NOT `structuredClone`,
+which *preserves* internal aliasing) so every operand occurrence is an
+independent object and is remapped exactly once. The struct index is also kept
+off every function **signature** (helpers take `anyref` + `ref.cast` on entry)
+and its fields are `$`-prefixed (so the same-shape collision resolver skips it).
+
+### PR-C2 follow-up (array element indexing)
+Parsed arrays build a `$ObjVec`; `.length` and use as object-property values
+work, but **direct numeric element indexing on a parsed array** (`a[i]`) reads
+0 — the standalone element-access path does not route an `$ObjVec` numeric read
+through `__extern_get_idx` (it resolves `a[i]` as a string-keyed `__extern_get`,
+which an `$ObjVec` has no key for). PR-C2: route `$ObjVec` numeric element-access
+through `__extern_get_idx` (the helper already ref.tests `$ObjVec` and returns
+`data[i]`). Object graphs — the dominant `JSON.parse` shape — are fully working.
+
+### Still open
+- **PR-C2:** parsed-array element indexing (`a[i]`) via `__extern_get_idx`.
+- **PR-D:** instance fields + `toJSON` + reviver/replacer.
+- **PR-A2:** closed typed-array (`number[]`) stringify; proper boolean boxing.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -67,7 +67,7 @@ import {
 } from "../literals.js";
 import { tryEmitJsonParseLiteral, tryEmitJsonStringifyStatic } from "../json-standalone.js";
 import { emitJsonParsePrimitive, emitJsonQuoteString } from "../json-runtime.js";
-import { emitJsonStringifyValue } from "../json-codec-native.js";
+import { emitJsonParseText, emitJsonStringifyValue } from "../json-codec-native.js";
 import {
   compileObjectDefineProperties,
   compileObjectDefineProperty,
@@ -6047,14 +6047,51 @@ function compileCallExpression(
           if (parsedType !== undefined) {
             return parsedType;
           }
-          // (#1599 Phase 2) Runtime string-value JSON.parse → primitive slice
-          // (number / true / false / null) via pure-Wasm helper, boxed as
-          // $AnyValue. Strings / objects / arrays still fall through to refusal.
-          const primitiveParsed = tryEmitJsonParsePrimitive(ctx, fctx, expr, expr.arguments[0]!);
-          if (primitiveParsed !== undefined) {
-            return primitiveParsed;
+          // (#2166 PR-C) Dynamic-graph JSON.parse: a runtime JSON *text* →
+          // object / array / string / primitive value, parsed entirely in Wasm
+          // (no `env::JSON_parse` host import). The full recursive-descent
+          // grammar in json-codec-native.ts (`__json_parse_text`) builds the
+          // SAME value rep the object runtime + stringify codec consume, so a
+          // round-trip `JSON.parse(JSON.stringify(o))` and downstream property
+          // reads work. It is a strict superset of the older primitive-only
+          // `__json_parse_primitive` slice — which could only parse a lone
+          // number / true / false / null and *traps* on `{`/`[`/`"` — so it
+          // takes over the whole runtime-string case (the primitive helper
+          // stays for any caller that still routes to it directly). A `reviver`
+          // (2nd arg) is deferred to PR-D: refuse it rather than silently ignore
+          // it (§25.5.1 InternalizeJSONProperty is a post-parse walk).
+          if (expr.arguments.length === 1) {
+            let parseArgType: ts.Type | undefined;
+            try {
+              parseArgType = ctx.checker.getTypeAtLocation(expr.arguments[0]!);
+            } catch {
+              parseArgType = undefined;
+            }
+            // Route string-typed and `any`/`unknown`-typed (the common
+            // `JSON.parse(text)` where `text: string`) arguments. A non-string
+            // statically-typed arg (e.g. a number) is a type error in user code;
+            // let it fall through to the refusal below.
+            const isStringOrAny =
+              parseArgType === undefined ||
+              (parseArgType.flags & (ts.TypeFlags.StringLike | ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
+            if (isStringOrAny) {
+              const argResult = compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "externref" });
+              if (argResult === null) return null;
+              if (argResult.kind !== "externref") {
+                coerceType(ctx, fctx, argResult, { kind: "externref" });
+              }
+              emitJsonParseText(ctx);
+              flushLateImportShifts(ctx, fctx);
+              fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__json_parse_text")! } as Instr);
+              // The codec returns the value graph as anyref ($Object/$ObjVec/
+              // $NativeString widened, or a ref $AnyValue for primitives). The
+              // downstream coercion paths (object property read, AnyValue→
+              // primitive) dispatch on the concrete ref via ref.test.
+              return { kind: "anyref" };
+            }
           }
         }
+        void tryEmitJsonParsePrimitive;
         // (#1599 Phase 1) Refuse-and-document: in standalone (no-JS-host) /
         // WASI mode there is no `env::JSON_*` host import to fall back to.
         // The primitive `JSON.stringify` slice above (#1324) already handles

--- a/src/codegen/json-codec-native.ts
+++ b/src/codegen/json-codec-native.ts
@@ -1520,11 +1520,7 @@ export function emitJsonParseText(ctx: CodegenContext): number {
     {
       op: "if",
       blockType: { kind: "val", type: i32 },
-      then: [
-        { op: "local.get", index: S_C },
-        { op: "i32.const", value: 48 },
-        { op: "i32.sub" },
-      ],
+      then: [{ op: "local.get", index: S_C }, { op: "i32.const", value: 48 }, { op: "i32.sub" }],
       else: [
         { op: "local.get", index: S_C },
         { op: "i32.const", value: 97 },
@@ -1532,16 +1528,8 @@ export function emitJsonParseText(ctx: CodegenContext): number {
         {
           op: "if",
           blockType: { kind: "val", type: i32 },
-          then: [
-            { op: "local.get", index: S_C },
-            { op: "i32.const", value: 87 },
-            { op: "i32.sub" },
-          ],
-          else: [
-            { op: "local.get", index: S_C },
-            { op: "i32.const", value: 55 },
-            { op: "i32.sub" },
-          ],
+          then: [{ op: "local.get", index: S_C }, { op: "i32.const", value: 87 }, { op: "i32.sub" }],
+          else: [{ op: "local.get", index: S_C }, { op: "i32.const", value: 55 }, { op: "i32.sub" }],
         },
       ],
     },

--- a/src/codegen/json-codec-native.ts
+++ b/src/codegen/json-codec-native.ts
@@ -854,9 +854,16 @@ export function emitJsonParseText(ctx: CodegenContext): number {
   // `null` becomes a null eqref (reads back as `null`, distinct from a missing
   // property which reads `undefined`).
   const boxNullAny: Instr[] = [{ op: "ref.null", typeIdx: EQ_HEAP_TYPE }];
+  // JSON booleans box as a `$__box_number_struct` holding 1.0/0.0 — the SAME
+  // representation `o.t = true` produces in a standalone object (TS `true` is an
+  // i32 and the i32→externref store path boxes it as a number, #2166 PR-A note).
+  // Matching it keeps member reads/round-trips consistent (`o.t ? …` works); a
+  // distinct boolean identity (`o.t === true`) is the broader standalone
+  // boolean-boxing gap (overlaps #1917), out of PR-C scope.
+  void boxBoolTypeIdx;
   const boxBoolAny = (v: number): Instr[] => [
-    { op: "i32.const", value: v },
-    { op: "struct.new", typeIdx: boxBoolTypeIdx },
+    { op: "f64.const", value: v },
+    { op: "struct.new", typeIdx: boxNumTypeIdx },
   ];
   const boxF64AnyFromLocal = (local: number): Instr[] => [
     { op: "local.get", index: local },

--- a/src/codegen/json-codec-native.ts
+++ b/src/codegen/json-codec-native.ts
@@ -1873,17 +1873,22 @@ export function emitJsonParseText(ctx: CodegenContext): number {
 
   // ── push the three functions in the pre-registered order ──────────────────
   // Deep-clone each body so no `Instr` object is shared between (or within) the
-  // bodies. The helper consts above (`loadPos`, `cEqV(...)`, `castP`, …) are
-  // spread into many positions, so the same object can appear multiple times in
-  // one body and across all three. The finalize remap (`remapTypeIdxInBody` in
-  // dead-elimination.ts) mutates `typeIdx` in place and re-visits a shared
-  // object once per occurrence — re-mapping an already-remapped index a second
-  // time (the documented #1302 shared-array double-shift hazard). Cloning makes
-  // every occurrence a distinct object so each `typeIdx` is remapped exactly
-  // once. (`$JsonP` is the only fresh struct index threaded through these
-  // bodies, so an un-cloned double-remap desynced `struct.get`/`ref.cast`
-  // operands from the local's declared type.)
-  const cloneBody = (b: Instr[]): Instr[] => structuredClone(b);
+  // bodies. The helper consts above (`loadPos`, `storePos`, `cEqV(...)`, …) are
+  // shared `Instr[]` arrays spread into many positions, so the SAME object
+  // appears at multiple slots in one body. The finalize remap
+  // (`remapTypeIdxInBody` in dead-elimination.ts) mutates `typeIdx` IN PLACE and
+  // re-visits a shared object once per occurrence, re-mapping an already-mapped
+  // index a second (third, …) time — the documented #1302 shared-array
+  // double-shift hazard. It desynced the `$JsonP` `$pos` `struct.get`/`struct.set`
+  // operands (spread the most) from the cursor local's declared type
+  // (`expected (ref 54 $ProxyTraps), found (ref 72 $JsonP)`).
+  //
+  // NOTE: `structuredClone` is NOT sufficient — it *preserves* internal
+  // aliasing, so a shared object stays shared (just freshly) and is still
+  // re-visited N times. The JSON round-trip below *expands* every shared
+  // reference into an independent copy, so each `typeIdx` operand is remapped
+  // exactly once. Bodies hold only plain JSON-safe data (no funcs/cycles).
+  const cloneBody = (b: Instr[]): Instr[] => JSON.parse(JSON.stringify(b)) as Instr[];
 
   ctx.mod.functions.push({
     name: "__json_parse_value",

--- a/src/codegen/json-codec-native.ts
+++ b/src/codegen/json-codec-native.ts
@@ -43,11 +43,18 @@
 import type { Instr, ValType } from "../ir/types.js";
 import { ensureAnyValueType } from "./any-helpers.js";
 import type { CodegenContext } from "./context/types.js";
-import { ensureNativeStringHelpers, nativeStringLiteralInstrs, nativeStringType } from "./native-strings.js";
+import {
+  ensureNativeStringHelpers,
+  nativeStringLiteralInstrs,
+  nativeStringType,
+  stringConstantExternrefInstrs,
+} from "./native-strings.js";
 import { ensureObjectRuntime } from "./object-runtime.js";
 import { emitNativeNumberFormat } from "./number-format-native.js";
 import { addFuncType } from "./registry/types.js";
 import { emitJsonQuoteString } from "./json-runtime.js";
+import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
+import { emitWasiErrorConstructor } from "./registry/error-types.js";
 
 const EQ_HEAP_TYPE = -19; // signed LEB128 → 0x6d → TYPE.eq (for ref.null any/eq)
 
@@ -585,4 +592,1358 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
   } as unknown as (typeof ctx.mod.functions)[number]);
 
   return funcIdx;
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// PR-C: `JSON.parse` of a dynamic graph — `__json_parse_text`
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Emit the pure-Wasm recursive-descent `JSON.parse` codec (#2166 PR-C) and
+ * register `__json_parse_text(s: externref) -> anyref` in `ctx.funcMap`.
+ * Idempotent. Standalone / WASI only.
+ *
+ * The grammar is ECMA-404 / ECMA-262 §25.5.1 (strict JSON — no comments, no
+ * trailing commas, no single quotes). The output uses the SAME value
+ * representation the standalone object runtime and the `__json_stringify_value`
+ * codec consume, so a round-trip `JSON.parse(JSON.stringify(o))` and downstream
+ * property reads (`__extern_get`) work without conversion:
+ *
+ *   - object → a fresh `$Object` (built via `__new_plain_object` +
+ *     `__extern_set`), widened to `anyref`. Members preserve insertion order.
+ *   - array  → a fresh `$ObjVec` (built via `__objvec_new` + `__objvec_push`),
+ *     widened to `anyref`.
+ *   - string → a native `$AnyString` (the unescaped code units), widened to
+ *     `anyref` — the same carrier object/array element reads already see.
+ *   - number → boxed into the `$AnyValue` tagged union (tag 3, f64).
+ *   - true / false → `$AnyValue` tag 4; null → `$AnyValue` tag 0.
+ *
+ * A grammar violation (or trailing non-whitespace) throws a runtime
+ * `SyntaxError` via the standalone `__new_SyntaxError` constructor — matching
+ * §25.5.1 step 3 — instead of trapping. The result `anyref` flows through the
+ * existing `$AnyValue`/object coercion paths in type-coercion.ts.
+ *
+ * Implementation note: the mutually-recursive value/string parsers share a
+ * cursor through a `$JsonP` parser-state struct (`{ data, pos(mut), end }`).
+ * That struct is passed as a bare **`anyref`** parameter (and `ref.cast` back
+ * inside each helper) rather than as `ref $JsonP`. A fresh GC struct type that
+ * appears in a *function-signature* parameter has tripped the dead-type-
+ * elimination remap in this codebase (the func-type param and the in-body
+ * `struct.get` operand can diverge after compaction); keeping the fresh
+ * `$JsonP` index off every signature and confined to `struct.new`/`struct.get`/
+ * `struct.set`/`ref.cast` instruction operands — which `remapTypeIdxInBody`
+ * rewrites uniformly — sidesteps that hazard.
+ *
+ * Returns the `__json_parse_text` funcIdx.
+ */
+export function emitJsonParseText(ctx: CodegenContext): number {
+  const existing = ctx.funcMap.get("__json_parse_text");
+  if (existing !== undefined) return existing;
+
+  // Dependencies (all idempotent).
+  ensureNativeStringHelpers(ctx);
+  ensureAnyValueType(ctx);
+  ensureObjectRuntime(ctx);
+  // The standalone SyntaxError constructor + the exception tag for the throw.
+  emitWasiErrorConstructor(ctx, "SyntaxError", 1);
+
+  const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten")!;
+  const newObjIdx = ctx.funcMap.get("__new_plain_object")!;
+  const externSetIdx = ctx.funcMap.get("__extern_set")!;
+  const objVecNewIdx = ctx.funcMap.get("__objvec_new")!;
+  const objVecPushIdx = ctx.funcMap.get("__objvec_push")!;
+
+  const i32: ValType = { kind: "i32" };
+  const f64: ValType = { kind: "f64" };
+  const anyref: ValType = { kind: "anyref" };
+  const externref: ValType = { kind: "externref" };
+
+  const strTypeIdx = ctx.nativeStrTypeIdx; // $NativeString { len, off, data }
+  const strDataTypeIdx = ctx.nativeStrDataTypeIdx; // (array (mut i16))
+  const anyStrTypeIdx = ctx.anyStrTypeIdx;
+  const anyValueTypeIdx = ctx.anyValueTypeIdx;
+  const strDataRef: ValType = { kind: "ref", typeIdx: strDataTypeIdx };
+  const strRefNative: ValType = { kind: "ref", typeIdx: strTypeIdx };
+
+  // ── $JsonP parser-state struct: { data: ref $strData, pos: (mut i32), end: i32 } ──
+  // Confined to instruction operands only (never a function signature) — see the
+  // doc-comment above for why.
+  const jsonPTypeIdx = ctx.mod.types.length;
+  ctx.mod.types.push({
+    kind: "struct",
+    name: "$JsonP",
+    // `$`-prefixed field names so `resolveSameShapeFieldNameCollisions` (which
+    // skips `$`-prefixed fields) leaves this internal struct alone: a plain
+    // `data`/`pos`/`end` triple collides with other structs' field names and
+    // gets shape-canonicalised, which split the struct across two type indices
+    // and desynced the in-body `struct.get` operand from the local's declared
+    // type (`expected (ref 54), found (ref 72)`).
+    fields: [
+      { name: "$data", type: strDataRef, mutable: false },
+      { name: "$pos", type: i32, mutable: true },
+      { name: "$end", type: i32, mutable: false },
+    ],
+  } as unknown as (typeof ctx.mod.types)[number]);
+
+  // ── throwSyntaxError(msg): build & throw a standalone SyntaxError ──────────
+  // Mirrors emitThrowRegExpSyntaxError but as a body-level Instr[] (no fctx):
+  // intern the message global, construct via __new_SyntaxError, throw via the
+  // shared exception tag. A trailing `unreachable` makes the post-throw stack
+  // polymorphic so the enclosing block's declared result type still validates.
+  const tagIdx = ensureExnTag(ctx);
+  const ctorIdx = ctx.funcMap.get("__new_SyntaxError")!;
+  const throwSyntaxError = (msg: string): Instr[] => {
+    addStringConstantGlobal(ctx, msg);
+    return [
+      ...stringConstantExternrefInstrs(ctx, msg),
+      { op: "call", funcIdx: ctorIdx },
+      { op: "throw", tagIdx } as Instr,
+      { op: "unreachable" } as Instr,
+    ];
+  };
+
+  // ════════════════════════════════════════════════════════════════════════
+  // Pre-register the three recursive funcIdx values so the bodies can call
+  // each other / themselves. All signatures use only primitive/anyref/externref
+  // types — the fresh $JsonP index never reaches a func type.
+  // ════════════════════════════════════════════════════════════════════════
+  const valueTypeIdx = addFuncType(ctx, [anyref], [anyref]); // (p:anyref) -> value:anyref
+  const valueFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  ctx.funcMap.set("__json_parse_value", valueFuncIdx);
+
+  const strParseTypeIdx = addFuncType(ctx, [anyref], [strRefNative]); // (p:anyref) -> ref $NativeString
+  const strParseFuncIdx = valueFuncIdx + 1;
+  ctx.funcMap.set("__json_parse_str", strParseFuncIdx);
+
+  const textTypeIdx = addFuncType(ctx, [externref], [anyref]);
+  const textFuncIdx = valueFuncIdx + 2;
+  ctx.funcMap.set("__json_parse_text", textFuncIdx);
+
+  // ════════════════════════════════════════════════════════════════════════
+  // __json_parse_value(p: anyref) -> anyref
+  // ════════════════════════════════════════════════════════════════════════
+  // params: 0 p:anyref
+  const V_P = 0; // anyref (the $JsonP, re-cast on entry)
+  const V_PS = 1; // ref $JsonP (cast result)
+  const V_DATA = 2; // ref $strData
+  const V_POS = 3; // i32 cursor
+  const V_END = 4; // i32
+  const V_C = 5; // i32 current code unit
+  const V_OBJ = 6; // externref (object/array under construction)
+  const V_KEY = 7; // ref $NativeString (object key)
+  const V_VAL = 8; // anyref (recursive child)
+  const V_NUM = 9; // f64
+  const V_MANT = 10; // f64
+  const V_SIGN = 11; // f64
+  const V_EXP = 12; // i32
+  const V_EXPSIGN = 13; // i32
+  const V_EXPMAG = 14; // i32
+
+  // p (anyref) → ref $JsonP in V_PS, done once at entry.
+  const castP: Instr[] = [
+    { op: "local.get", index: V_P },
+    { op: "ref.cast", typeIdx: jsonPTypeIdx },
+    { op: "local.set", index: V_PS },
+  ];
+  const loadPos: Instr[] = [
+    { op: "local.get", index: V_PS },
+    { op: "struct.get", typeIdx: jsonPTypeIdx, fieldIdx: 1 },
+    { op: "local.set", index: V_POS },
+  ];
+  const storePos: Instr[] = [
+    { op: "local.get", index: V_PS },
+    { op: "local.get", index: V_POS },
+    { op: "struct.set", typeIdx: jsonPTypeIdx, fieldIdx: 1 },
+  ];
+  const loadC: Instr[] = [
+    { op: "local.get", index: V_DATA },
+    { op: "local.get", index: V_POS },
+    { op: "array.get_u", typeIdx: strDataTypeIdx },
+    { op: "local.set", index: V_C },
+  ];
+  const cEqV = (code: number): Instr[] => [
+    { op: "local.get", index: V_C },
+    { op: "i32.const", value: code },
+    { op: "i32.eq" },
+  ];
+
+  const skipWsV: Instr[] = [
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: V_POS },
+            { op: "local.get", index: V_END },
+            { op: "i32.ge_s" },
+            { op: "br_if", depth: 1 },
+            ...loadC,
+            ...cEqV(32),
+            ...cEqV(9),
+            { op: "i32.or" },
+            ...cEqV(10),
+            { op: "i32.or" },
+            ...cEqV(13),
+            { op: "i32.or" },
+            { op: "i32.eqz" },
+            { op: "br_if", depth: 1 },
+            { op: "local.get", index: V_POS },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: V_POS },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+  ];
+
+  // Expect data[pos]==code then advance; mismatch/EOF → SyntaxError(msg).
+  const expectChar = (code: number, msg: string): Instr[] => [
+    { op: "local.get", index: V_POS },
+    { op: "local.get", index: V_END },
+    { op: "i32.ge_s" },
+    { op: "if", blockType: { kind: "empty" }, then: throwSyntaxError(msg) },
+    ...loadC,
+    ...cEqV(code),
+    { op: "i32.eqz" },
+    { op: "if", blockType: { kind: "empty" }, then: throwSyntaxError(msg) },
+    { op: "local.get", index: V_POS },
+    { op: "i32.const", value: 1 },
+    { op: "i32.add" },
+    { op: "local.set", index: V_POS },
+  ];
+
+  // Match a literal keyword (true/false/null) at pos; advance, else SyntaxError.
+  const matchKeyword = (word: string): Instr[] => {
+    const out: Instr[] = [];
+    for (let k = 0; k < word.length; k++) {
+      out.push(
+        { op: "local.get", index: V_POS },
+        { op: "local.get", index: V_END },
+        { op: "i32.ge_s" },
+        { op: "if", blockType: { kind: "empty" }, then: throwSyntaxError("Unexpected end of JSON input") },
+        { op: "local.get", index: V_DATA },
+        { op: "local.get", index: V_POS },
+        { op: "array.get_u", typeIdx: strDataTypeIdx },
+        { op: "i32.const", value: word.charCodeAt(k) },
+        { op: "i32.ne" },
+        { op: "if", blockType: { kind: "empty" }, then: throwSyntaxError("Unexpected token in JSON") },
+        { op: "local.get", index: V_POS },
+        { op: "i32.const", value: 1 },
+        { op: "i32.add" },
+        { op: "local.set", index: V_POS },
+      );
+    }
+    return out;
+  };
+
+  // AnyValue box helpers
+  const boxNullAny: Instr[] = [
+    { op: "i32.const", value: 0 },
+    { op: "i32.const", value: 0 },
+    { op: "f64.const", value: 0 },
+    { op: "ref.null", typeIdx: EQ_HEAP_TYPE },
+    { op: "ref.null.extern" },
+    { op: "struct.new", typeIdx: anyValueTypeIdx },
+  ];
+  const boxBoolAny = (v: number): Instr[] => [
+    { op: "i32.const", value: 4 },
+    { op: "i32.const", value: v },
+    { op: "f64.const", value: 0 },
+    { op: "ref.null", typeIdx: EQ_HEAP_TYPE },
+    { op: "ref.null.extern" },
+    { op: "struct.new", typeIdx: anyValueTypeIdx },
+  ];
+  const boxF64AnyFromLocal = (local: number): Instr[] => [
+    { op: "i32.const", value: 3 },
+    { op: "i32.const", value: 0 },
+    { op: "local.get", index: local },
+    { op: "ref.null", typeIdx: EQ_HEAP_TYPE },
+    { op: "ref.null.extern" },
+    { op: "struct.new", typeIdx: anyValueTypeIdx },
+  ];
+
+  // number parser (cursor at '-'/digit) → f64 in V_NUM; advances V_POS.
+  const parseNumberV: Instr[] = [
+    { op: "f64.const", value: 1 },
+    { op: "local.set", index: V_SIGN },
+    { op: "f64.const", value: 0 },
+    { op: "local.set", index: V_MANT },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: V_EXP },
+    ...loadC,
+    ...cEqV(45),
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "f64.const", value: -1 },
+        { op: "local.set", index: V_SIGN },
+        { op: "local.get", index: V_POS },
+        { op: "i32.const", value: 1 },
+        { op: "i32.add" },
+        { op: "local.set", index: V_POS },
+      ],
+    },
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: V_POS },
+            { op: "local.get", index: V_END },
+            { op: "i32.ge_s" },
+            { op: "br_if", depth: 1 },
+            ...loadC,
+            { op: "local.get", index: V_C },
+            { op: "i32.const", value: 48 },
+            { op: "i32.lt_s" },
+            { op: "br_if", depth: 1 },
+            { op: "local.get", index: V_C },
+            { op: "i32.const", value: 57 },
+            { op: "i32.gt_s" },
+            { op: "br_if", depth: 1 },
+            { op: "local.get", index: V_MANT },
+            { op: "f64.const", value: 10 },
+            { op: "f64.mul" },
+            { op: "local.get", index: V_C },
+            { op: "i32.const", value: 48 },
+            { op: "i32.sub" },
+            { op: "f64.convert_i32_s" },
+            { op: "f64.add" },
+            { op: "local.set", index: V_MANT },
+            { op: "local.get", index: V_POS },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: V_POS },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+    // fraction
+    { op: "local.get", index: V_POS },
+    { op: "local.get", index: V_END },
+    { op: "i32.lt_s" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        ...loadC,
+        ...cEqV(46),
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "local.get", index: V_POS },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: V_POS },
+            {
+              op: "block",
+              blockType: { kind: "empty" },
+              body: [
+                {
+                  op: "loop",
+                  blockType: { kind: "empty" },
+                  body: [
+                    { op: "local.get", index: V_POS },
+                    { op: "local.get", index: V_END },
+                    { op: "i32.ge_s" },
+                    { op: "br_if", depth: 1 },
+                    ...loadC,
+                    { op: "local.get", index: V_C },
+                    { op: "i32.const", value: 48 },
+                    { op: "i32.lt_s" },
+                    { op: "br_if", depth: 1 },
+                    { op: "local.get", index: V_C },
+                    { op: "i32.const", value: 57 },
+                    { op: "i32.gt_s" },
+                    { op: "br_if", depth: 1 },
+                    { op: "local.get", index: V_MANT },
+                    { op: "f64.const", value: 10 },
+                    { op: "f64.mul" },
+                    { op: "local.get", index: V_C },
+                    { op: "i32.const", value: 48 },
+                    { op: "i32.sub" },
+                    { op: "f64.convert_i32_s" },
+                    { op: "f64.add" },
+                    { op: "local.set", index: V_MANT },
+                    { op: "local.get", index: V_EXP },
+                    { op: "i32.const", value: 1 },
+                    { op: "i32.sub" },
+                    { op: "local.set", index: V_EXP },
+                    { op: "local.get", index: V_POS },
+                    { op: "i32.const", value: 1 },
+                    { op: "i32.add" },
+                    { op: "local.set", index: V_POS },
+                    { op: "br", depth: 0 },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    // exponent
+    { op: "local.get", index: V_POS },
+    { op: "local.get", index: V_END },
+    { op: "i32.lt_s" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        ...loadC,
+        ...cEqV(101),
+        ...cEqV(69),
+        { op: "i32.or" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "local.get", index: V_POS },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: V_POS },
+            { op: "i32.const", value: 1 },
+            { op: "local.set", index: V_EXPSIGN },
+            { op: "local.get", index: V_POS },
+            { op: "local.get", index: V_END },
+            { op: "i32.lt_s" },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [
+                ...loadC,
+                ...cEqV(45),
+                {
+                  op: "if",
+                  blockType: { kind: "empty" },
+                  then: [
+                    { op: "i32.const", value: -1 },
+                    { op: "local.set", index: V_EXPSIGN },
+                    { op: "local.get", index: V_POS },
+                    { op: "i32.const", value: 1 },
+                    { op: "i32.add" },
+                    { op: "local.set", index: V_POS },
+                  ],
+                  else: [
+                    ...cEqV(43),
+                    {
+                      op: "if",
+                      blockType: { kind: "empty" },
+                      then: [
+                        { op: "local.get", index: V_POS },
+                        { op: "i32.const", value: 1 },
+                        { op: "i32.add" },
+                        { op: "local.set", index: V_POS },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            { op: "i32.const", value: 0 },
+            { op: "local.set", index: V_EXPMAG },
+            {
+              op: "block",
+              blockType: { kind: "empty" },
+              body: [
+                {
+                  op: "loop",
+                  blockType: { kind: "empty" },
+                  body: [
+                    { op: "local.get", index: V_POS },
+                    { op: "local.get", index: V_END },
+                    { op: "i32.ge_s" },
+                    { op: "br_if", depth: 1 },
+                    ...loadC,
+                    { op: "local.get", index: V_C },
+                    { op: "i32.const", value: 48 },
+                    { op: "i32.lt_s" },
+                    { op: "br_if", depth: 1 },
+                    { op: "local.get", index: V_C },
+                    { op: "i32.const", value: 57 },
+                    { op: "i32.gt_s" },
+                    { op: "br_if", depth: 1 },
+                    { op: "local.get", index: V_EXPMAG },
+                    { op: "i32.const", value: 10 },
+                    { op: "i32.mul" },
+                    { op: "local.get", index: V_C },
+                    { op: "i32.const", value: 48 },
+                    { op: "i32.sub" },
+                    { op: "i32.add" },
+                    { op: "local.set", index: V_EXPMAG },
+                    { op: "local.get", index: V_POS },
+                    { op: "i32.const", value: 1 },
+                    { op: "i32.add" },
+                    { op: "local.set", index: V_POS },
+                    { op: "br", depth: 0 },
+                  ],
+                },
+              ],
+            },
+            { op: "local.get", index: V_EXP },
+            { op: "local.get", index: V_EXPSIGN },
+            { op: "local.get", index: V_EXPMAG },
+            { op: "i32.mul" },
+            { op: "i32.add" },
+            { op: "local.set", index: V_EXP },
+          ],
+        },
+      ],
+    },
+    // result = sign*mant*10^exp → V_NUM (reuse V_NUM as running pow)
+    { op: "f64.const", value: 1 },
+    { op: "local.set", index: V_NUM },
+    { op: "local.get", index: V_EXP },
+    { op: "i32.const", value: 0 },
+    { op: "i32.ge_s" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        {
+          op: "block",
+          blockType: { kind: "empty" },
+          body: [
+            {
+              op: "loop",
+              blockType: { kind: "empty" },
+              body: [
+                { op: "local.get", index: V_EXP },
+                { op: "i32.eqz" },
+                { op: "br_if", depth: 1 },
+                { op: "local.get", index: V_NUM },
+                { op: "f64.const", value: 10 },
+                { op: "f64.mul" },
+                { op: "local.set", index: V_NUM },
+                { op: "local.get", index: V_EXP },
+                { op: "i32.const", value: 1 },
+                { op: "i32.sub" },
+                { op: "local.set", index: V_EXP },
+                { op: "br", depth: 0 },
+              ],
+            },
+          ],
+        },
+      ],
+      else: [
+        {
+          op: "block",
+          blockType: { kind: "empty" },
+          body: [
+            {
+              op: "loop",
+              blockType: { kind: "empty" },
+              body: [
+                { op: "local.get", index: V_EXP },
+                { op: "i32.eqz" },
+                { op: "br_if", depth: 1 },
+                { op: "local.get", index: V_NUM },
+                { op: "f64.const", value: 10 },
+                { op: "f64.div" },
+                { op: "local.set", index: V_NUM },
+                { op: "local.get", index: V_EXP },
+                { op: "i32.const", value: 1 },
+                { op: "i32.add" },
+                { op: "local.set", index: V_EXP },
+                { op: "br", depth: 0 },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    { op: "local.get", index: V_SIGN },
+    { op: "local.get", index: V_MANT },
+    { op: "f64.mul" },
+    { op: "local.get", index: V_NUM },
+    { op: "f64.mul" },
+    { op: "local.set", index: V_NUM },
+  ];
+
+  const valueBody: Instr[] = [
+    ...castP,
+    { op: "local.get", index: V_PS },
+    { op: "struct.get", typeIdx: jsonPTypeIdx, fieldIdx: 0 },
+    { op: "local.set", index: V_DATA },
+    ...loadPos,
+    { op: "local.get", index: V_PS },
+    { op: "struct.get", typeIdx: jsonPTypeIdx, fieldIdx: 2 },
+    { op: "local.set", index: V_END },
+    ...skipWsV,
+    { op: "local.get", index: V_POS },
+    { op: "local.get", index: V_END },
+    { op: "i32.ge_s" },
+    { op: "if", blockType: { kind: "empty" }, then: throwSyntaxError("Unexpected end of JSON input") },
+    ...loadC,
+    ...storePos,
+    // '{' → object
+    ...cEqV(123),
+    {
+      op: "if",
+      blockType: { kind: "val", type: anyref },
+      then: [
+        { op: "local.get", index: V_POS },
+        { op: "i32.const", value: 1 },
+        { op: "i32.add" },
+        { op: "local.set", index: V_POS },
+        ...storePos,
+        { op: "call", funcIdx: newObjIdx },
+        { op: "local.set", index: V_OBJ },
+        ...skipWsV,
+        ...storePos,
+        { op: "local.get", index: V_POS },
+        { op: "local.get", index: V_END },
+        { op: "i32.ge_s" },
+        { op: "if", blockType: { kind: "empty" }, then: throwSyntaxError("Unexpected end of JSON input") },
+        ...loadC,
+        ...cEqV(125), // '}'
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "local.get", index: V_POS },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: V_POS },
+            ...storePos,
+          ],
+          else: [
+            {
+              op: "block",
+              blockType: { kind: "empty" },
+              body: [
+                {
+                  op: "loop",
+                  blockType: { kind: "empty" },
+                  body: [
+                    ...skipWsV,
+                    ...storePos,
+                    // key = __json_parse_str(p)
+                    { op: "local.get", index: V_P },
+                    { op: "call", funcIdx: strParseFuncIdx },
+                    { op: "local.set", index: V_KEY },
+                    ...loadPos,
+                    ...skipWsV,
+                    ...storePos,
+                    ...expectChar(58, "Expected ':' after property name in JSON"),
+                    ...storePos,
+                    // val = __json_parse_value(p)
+                    { op: "local.get", index: V_P },
+                    { op: "call", funcIdx: valueFuncIdx },
+                    { op: "local.set", index: V_VAL },
+                    ...loadPos,
+                    // __extern_set(obj, key(externref), val(externref))
+                    { op: "local.get", index: V_OBJ },
+                    { op: "local.get", index: V_KEY },
+                    { op: "extern.convert_any" },
+                    { op: "local.get", index: V_VAL },
+                    { op: "extern.convert_any" },
+                    { op: "call", funcIdx: externSetIdx },
+                    ...skipWsV,
+                    ...storePos,
+                    { op: "local.get", index: V_POS },
+                    { op: "local.get", index: V_END },
+                    { op: "i32.ge_s" },
+                    {
+                      op: "if",
+                      blockType: { kind: "empty" },
+                      then: throwSyntaxError("Unexpected end of JSON input"),
+                    },
+                    ...loadC,
+                    ...cEqV(44), // ','
+                    {
+                      op: "if",
+                      blockType: { kind: "empty" },
+                      then: [
+                        { op: "local.get", index: V_POS },
+                        { op: "i32.const", value: 1 },
+                        { op: "i32.add" },
+                        { op: "local.set", index: V_POS },
+                        ...storePos,
+                        { op: "br", depth: 1 }, // continue member loop
+                      ],
+                    },
+                    ...cEqV(125), // '}'
+                    {
+                      op: "if",
+                      blockType: { kind: "empty" },
+                      then: [
+                        { op: "local.get", index: V_POS },
+                        { op: "i32.const", value: 1 },
+                        { op: "i32.add" },
+                        { op: "local.set", index: V_POS },
+                        ...storePos,
+                        { op: "br", depth: 2 }, // break member loop
+                      ],
+                    },
+                    ...throwSyntaxError("Expected ',' or '}' after property value in JSON"),
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        { op: "local.get", index: V_OBJ },
+        { op: "any.convert_extern" },
+      ],
+      else: [
+        // '[' → array
+        ...cEqV(91),
+        {
+          op: "if",
+          blockType: { kind: "val", type: anyref },
+          then: [
+            { op: "local.get", index: V_POS },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: V_POS },
+            ...storePos,
+            { op: "call", funcIdx: objVecNewIdx },
+            { op: "local.set", index: V_OBJ },
+            ...skipWsV,
+            ...storePos,
+            { op: "local.get", index: V_POS },
+            { op: "local.get", index: V_END },
+            { op: "i32.ge_s" },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: throwSyntaxError("Unexpected end of JSON input"),
+            },
+            ...loadC,
+            ...cEqV(93), // ']'
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [
+                { op: "local.get", index: V_POS },
+                { op: "i32.const", value: 1 },
+                { op: "i32.add" },
+                { op: "local.set", index: V_POS },
+                ...storePos,
+              ],
+              else: [
+                {
+                  op: "block",
+                  blockType: { kind: "empty" },
+                  body: [
+                    {
+                      op: "loop",
+                      blockType: { kind: "empty" },
+                      body: [
+                        ...storePos,
+                        { op: "local.get", index: V_P },
+                        { op: "call", funcIdx: valueFuncIdx },
+                        { op: "local.set", index: V_VAL },
+                        ...loadPos,
+                        { op: "local.get", index: V_OBJ },
+                        { op: "local.get", index: V_VAL },
+                        { op: "extern.convert_any" },
+                        { op: "call", funcIdx: objVecPushIdx },
+                        ...skipWsV,
+                        ...storePos,
+                        { op: "local.get", index: V_POS },
+                        { op: "local.get", index: V_END },
+                        { op: "i32.ge_s" },
+                        {
+                          op: "if",
+                          blockType: { kind: "empty" },
+                          then: throwSyntaxError("Unexpected end of JSON input"),
+                        },
+                        ...loadC,
+                        ...cEqV(44), // ','
+                        {
+                          op: "if",
+                          blockType: { kind: "empty" },
+                          then: [
+                            { op: "local.get", index: V_POS },
+                            { op: "i32.const", value: 1 },
+                            { op: "i32.add" },
+                            { op: "local.set", index: V_POS },
+                            ...storePos,
+                            { op: "br", depth: 1 }, // continue element loop
+                          ],
+                        },
+                        ...cEqV(93), // ']'
+                        {
+                          op: "if",
+                          blockType: { kind: "empty" },
+                          then: [
+                            { op: "local.get", index: V_POS },
+                            { op: "i32.const", value: 1 },
+                            { op: "i32.add" },
+                            { op: "local.set", index: V_POS },
+                            ...storePos,
+                            { op: "br", depth: 2 }, // break element loop
+                          ],
+                        },
+                        ...throwSyntaxError("Expected ',' or ']' after array element in JSON"),
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            { op: "local.get", index: V_OBJ },
+            { op: "any.convert_extern" },
+          ],
+          else: [
+            // '"' → string value
+            ...cEqV(34),
+            {
+              op: "if",
+              blockType: { kind: "val", type: anyref },
+              then: [
+                { op: "local.get", index: V_P },
+                { op: "call", funcIdx: strParseFuncIdx },
+              ],
+              else: [
+                // 't' → true
+                ...cEqV(116),
+                {
+                  op: "if",
+                  blockType: { kind: "val", type: anyref },
+                  then: [...matchKeyword("true"), ...storePos, ...boxBoolAny(1)],
+                  else: [
+                    // 'f' → false
+                    ...cEqV(102),
+                    {
+                      op: "if",
+                      blockType: { kind: "val", type: anyref },
+                      then: [...matchKeyword("false"), ...storePos, ...boxBoolAny(0)],
+                      else: [
+                        // 'n' → null
+                        ...cEqV(110),
+                        {
+                          op: "if",
+                          blockType: { kind: "val", type: anyref },
+                          then: [...matchKeyword("null"), ...storePos, ...boxNullAny],
+                          else: [
+                            // number: '-' or digit, else SyntaxError
+                            ...cEqV(45),
+                            { op: "local.get", index: V_C },
+                            { op: "i32.const", value: 48 },
+                            { op: "i32.ge_s" },
+                            { op: "local.get", index: V_C },
+                            { op: "i32.const", value: 57 },
+                            { op: "i32.le_s" },
+                            { op: "i32.and" },
+                            { op: "i32.or" },
+                            {
+                              op: "if",
+                              blockType: { kind: "val", type: anyref },
+                              then: [...parseNumberV, ...storePos, ...boxF64AnyFromLocal(V_NUM)],
+                              else: throwSyntaxError("Unexpected token in JSON"),
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  // ════════════════════════════════════════════════════════════════════════
+  // __json_parse_str(p: anyref) -> ref $NativeString
+  //   Cursor at opening '"'. Allocate a backing array sized to the raw span (an
+  //   upper bound — escapes only shrink), fill the unescaped code units, then
+  //   struct.new $NativeString(count, 0, data) with the real count (<= cap).
+  // ════════════════════════════════════════════════════════════════════════
+  const S_P = 0; // anyref
+  const S_PS = 1; // ref $JsonP
+  const S_DATA = 2; // ref $strData (input)
+  const S_POS = 3; // i32
+  const S_END = 4; // i32
+  const S_START = 5; // i32 span start (after '"')
+  const S_RAWEND = 6; // i32 closing '"' index
+  const S_OUT = 7; // ref $strData (output buffer)
+  const S_N = 8; // i32 output count
+  const S_C = 9; // i32
+  const S_HEX = 10; // i32 \uXXXX
+  const S_K = 11; // i32 hex loop counter
+  const S_SCAN = 12; // i32 first-pass scan cursor
+
+  const sLoadC: Instr[] = [
+    { op: "local.get", index: S_DATA },
+    { op: "local.get", index: S_POS },
+    { op: "array.get_u", typeIdx: strDataTypeIdx },
+    { op: "local.set", index: S_C },
+  ];
+  const sAdvance: Instr[] = [
+    { op: "local.get", index: S_POS },
+    { op: "i32.const", value: 1 },
+    { op: "i32.add" },
+    { op: "local.set", index: S_POS },
+  ];
+  const sEmit = (valueInstrs: Instr[]): Instr[] => [
+    { op: "local.get", index: S_OUT },
+    { op: "local.get", index: S_N },
+    ...valueInstrs,
+    { op: "array.set", typeIdx: strDataTypeIdx },
+    { op: "local.get", index: S_N },
+    { op: "i32.const", value: 1 },
+    { op: "i32.add" },
+    { op: "local.set", index: S_N },
+  ];
+  const sHexDigit: Instr[] = [
+    { op: "local.get", index: S_POS },
+    { op: "local.get", index: S_END },
+    { op: "i32.ge_s" },
+    { op: "if", blockType: { kind: "empty" }, then: throwSyntaxError("Unexpected end of JSON input") },
+    ...sLoadC,
+    { op: "local.get", index: S_HEX },
+    { op: "i32.const", value: 4 },
+    { op: "i32.shl" },
+    { op: "local.get", index: S_C },
+    { op: "i32.const", value: 58 },
+    { op: "i32.lt_s" },
+    {
+      op: "if",
+      blockType: { kind: "val", type: i32 },
+      then: [
+        { op: "local.get", index: S_C },
+        { op: "i32.const", value: 48 },
+        { op: "i32.sub" },
+      ],
+      else: [
+        { op: "local.get", index: S_C },
+        { op: "i32.const", value: 97 },
+        { op: "i32.ge_s" },
+        {
+          op: "if",
+          blockType: { kind: "val", type: i32 },
+          then: [
+            { op: "local.get", index: S_C },
+            { op: "i32.const", value: 87 },
+            { op: "i32.sub" },
+          ],
+          else: [
+            { op: "local.get", index: S_C },
+            { op: "i32.const", value: 55 },
+            { op: "i32.sub" },
+          ],
+        },
+      ],
+    },
+    { op: "i32.add" },
+    { op: "local.set", index: S_HEX },
+    ...sAdvance,
+  ];
+
+  const strParseBody: Instr[] = [
+    { op: "local.get", index: S_P },
+    { op: "ref.cast", typeIdx: jsonPTypeIdx },
+    { op: "local.set", index: S_PS },
+    { op: "local.get", index: S_PS },
+    { op: "struct.get", typeIdx: jsonPTypeIdx, fieldIdx: 0 },
+    { op: "local.set", index: S_DATA },
+    { op: "local.get", index: S_PS },
+    { op: "struct.get", typeIdx: jsonPTypeIdx, fieldIdx: 1 },
+    { op: "local.set", index: S_POS },
+    { op: "local.get", index: S_PS },
+    { op: "struct.get", typeIdx: jsonPTypeIdx, fieldIdx: 2 },
+    { op: "local.set", index: S_END },
+    // opening '"'
+    { op: "local.get", index: S_POS },
+    { op: "local.get", index: S_END },
+    { op: "i32.ge_s" },
+    { op: "if", blockType: { kind: "empty" }, then: throwSyntaxError("Unexpected end of JSON input") },
+    ...sLoadC,
+    { op: "local.get", index: S_C },
+    { op: "i32.const", value: 34 },
+    { op: "i32.ne" },
+    { op: "if", blockType: { kind: "empty" }, then: throwSyntaxError("Unexpected token in JSON") },
+    ...sAdvance,
+    { op: "local.get", index: S_POS },
+    { op: "local.set", index: S_START },
+    // first pass: scan to closing quote
+    { op: "local.get", index: S_POS },
+    { op: "local.set", index: S_SCAN },
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: S_SCAN },
+            { op: "local.get", index: S_END },
+            { op: "i32.ge_s" },
+            { op: "if", blockType: { kind: "empty" }, then: throwSyntaxError("Unterminated string in JSON") },
+            { op: "local.get", index: S_DATA },
+            { op: "local.get", index: S_SCAN },
+            { op: "array.get_u", typeIdx: strDataTypeIdx },
+            { op: "local.set", index: S_C },
+            { op: "local.get", index: S_C },
+            { op: "i32.const", value: 34 },
+            { op: "i32.eq" },
+            { op: "br_if", depth: 1 },
+            { op: "local.get", index: S_C },
+            { op: "i32.const", value: 92 },
+            { op: "i32.eq" },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [
+                { op: "local.get", index: S_SCAN },
+                { op: "i32.const", value: 1 },
+                { op: "i32.add" },
+                { op: "local.set", index: S_SCAN },
+              ],
+            },
+            { op: "local.get", index: S_SCAN },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: S_SCAN },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+    { op: "local.get", index: S_SCAN },
+    { op: "local.set", index: S_RAWEND },
+    // buffer capacity = rawEnd - start
+    { op: "local.get", index: S_RAWEND },
+    { op: "local.get", index: S_START },
+    { op: "i32.sub" },
+    { op: "array.new_default", typeIdx: strDataTypeIdx },
+    { op: "local.set", index: S_OUT },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: S_N },
+    // second pass: copy/unescape until rawEnd
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: S_POS },
+            { op: "local.get", index: S_RAWEND },
+            { op: "i32.ge_s" },
+            { op: "br_if", depth: 1 },
+            ...sLoadC,
+            { op: "local.get", index: S_C },
+            { op: "i32.const", value: 92 }, // '\'
+            { op: "i32.eq" },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [
+                ...sAdvance,
+                { op: "local.get", index: S_POS },
+                { op: "local.get", index: S_RAWEND },
+                { op: "i32.ge_s" },
+                {
+                  op: "if",
+                  blockType: { kind: "empty" },
+                  then: throwSyntaxError("Unterminated string in JSON"),
+                },
+                ...sLoadC,
+                { op: "local.get", index: S_C },
+                { op: "i32.const", value: 117 }, // 'u'
+                { op: "i32.eq" },
+                {
+                  op: "if",
+                  blockType: { kind: "empty" },
+                  then: [
+                    ...sAdvance,
+                    { op: "i32.const", value: 0 },
+                    { op: "local.set", index: S_HEX },
+                    { op: "i32.const", value: 0 },
+                    { op: "local.set", index: S_K },
+                    {
+                      op: "block",
+                      blockType: { kind: "empty" },
+                      body: [
+                        {
+                          op: "loop",
+                          blockType: { kind: "empty" },
+                          body: [
+                            { op: "local.get", index: S_K },
+                            { op: "i32.const", value: 4 },
+                            { op: "i32.ge_s" },
+                            { op: "br_if", depth: 1 },
+                            ...sHexDigit,
+                            { op: "local.get", index: S_K },
+                            { op: "i32.const", value: 1 },
+                            { op: "i32.add" },
+                            { op: "local.set", index: S_K },
+                            { op: "br", depth: 0 },
+                          ],
+                        },
+                      ],
+                    },
+                    ...sEmit([{ op: "local.get", index: S_HEX }]),
+                  ],
+                  else: [
+                    ...sEmit([
+                      { op: "local.get", index: S_C },
+                      { op: "i32.const", value: 98 }, // 'b'
+                      { op: "i32.eq" },
+                      {
+                        op: "if",
+                        blockType: { kind: "val", type: i32 },
+                        then: [{ op: "i32.const", value: 8 }],
+                        else: [
+                          { op: "local.get", index: S_C },
+                          { op: "i32.const", value: 102 }, // 'f'
+                          { op: "i32.eq" },
+                          {
+                            op: "if",
+                            blockType: { kind: "val", type: i32 },
+                            then: [{ op: "i32.const", value: 12 }],
+                            else: [
+                              { op: "local.get", index: S_C },
+                              { op: "i32.const", value: 110 }, // 'n'
+                              { op: "i32.eq" },
+                              {
+                                op: "if",
+                                blockType: { kind: "val", type: i32 },
+                                then: [{ op: "i32.const", value: 10 }],
+                                else: [
+                                  { op: "local.get", index: S_C },
+                                  { op: "i32.const", value: 114 }, // 'r'
+                                  { op: "i32.eq" },
+                                  {
+                                    op: "if",
+                                    blockType: { kind: "val", type: i32 },
+                                    then: [{ op: "i32.const", value: 13 }],
+                                    else: [
+                                      { op: "local.get", index: S_C },
+                                      { op: "i32.const", value: 116 }, // 't'
+                                      { op: "i32.eq" },
+                                      {
+                                        op: "if",
+                                        blockType: { kind: "val", type: i32 },
+                                        then: [{ op: "i32.const", value: 9 }],
+                                        else: [{ op: "local.get", index: S_C }],
+                                      },
+                                    ],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ]),
+                    ...sAdvance,
+                  ],
+                },
+              ],
+              else: [...sEmit([{ op: "local.get", index: S_C }]), ...sAdvance],
+            },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+    // advance past closing quote, write cursor back into p.pos
+    { op: "local.get", index: S_RAWEND },
+    { op: "i32.const", value: 1 },
+    { op: "i32.add" },
+    { op: "local.set", index: S_POS },
+    { op: "local.get", index: S_PS },
+    { op: "local.get", index: S_POS },
+    { op: "struct.set", typeIdx: jsonPTypeIdx, fieldIdx: 1 },
+    // struct.new $NativeString(len=S_N, off=0, data=S_OUT)
+    { op: "local.get", index: S_N },
+    { op: "i32.const", value: 0 },
+    { op: "local.get", index: S_OUT },
+    { op: "struct.new", typeIdx: strTypeIdx },
+  ];
+
+  // ════════════════════════════════════════════════════════════════════════
+  // __json_parse_text(s: externref) -> anyref  (entry)
+  // ════════════════════════════════════════════════════════════════════════
+  const T_S = 0;
+  const T_FLAT = 1; // ref $NativeString
+  const T_P = 2; // ref $JsonP
+  const T_RESULT = 3; // anyref
+  const T_POS = 4; // i32
+  const T_END = 5; // i32
+  const T_DATA = 6; // ref $strData
+  const T_C = 7; // i32
+
+  const textBody: Instr[] = [
+    { op: "local.get", index: T_S },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: anyStrTypeIdx },
+    { op: "call", funcIdx: flattenIdx },
+    { op: "ref.cast", typeIdx: strTypeIdx },
+    { op: "local.set", index: T_FLAT },
+    // p = struct.new $JsonP(flat.data, flat.off, flat.off+flat.len)
+    { op: "local.get", index: T_FLAT },
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 }, // data
+    { op: "local.get", index: T_FLAT },
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 }, // off
+    { op: "local.get", index: T_FLAT },
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 }, // off
+    { op: "local.get", index: T_FLAT },
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 0 }, // len
+    { op: "i32.add" },
+    { op: "struct.new", typeIdx: jsonPTypeIdx },
+    { op: "local.set", index: T_P },
+    // result = __json_parse_value(p)  — pass as anyref
+    { op: "local.get", index: T_P },
+    { op: "call", funcIdx: valueFuncIdx },
+    { op: "local.set", index: T_RESULT },
+    // trailing ws + EOF
+    { op: "local.get", index: T_P },
+    { op: "struct.get", typeIdx: jsonPTypeIdx, fieldIdx: 0 },
+    { op: "local.set", index: T_DATA },
+    { op: "local.get", index: T_P },
+    { op: "struct.get", typeIdx: jsonPTypeIdx, fieldIdx: 1 },
+    { op: "local.set", index: T_POS },
+    { op: "local.get", index: T_P },
+    { op: "struct.get", typeIdx: jsonPTypeIdx, fieldIdx: 2 },
+    { op: "local.set", index: T_END },
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: T_POS },
+            { op: "local.get", index: T_END },
+            { op: "i32.ge_s" },
+            { op: "br_if", depth: 1 },
+            { op: "local.get", index: T_DATA },
+            { op: "local.get", index: T_POS },
+            { op: "array.get_u", typeIdx: strDataTypeIdx },
+            { op: "local.set", index: T_C },
+            { op: "local.get", index: T_C },
+            { op: "i32.const", value: 32 },
+            { op: "i32.eq" },
+            { op: "local.get", index: T_C },
+            { op: "i32.const", value: 9 },
+            { op: "i32.eq" },
+            { op: "i32.or" },
+            { op: "local.get", index: T_C },
+            { op: "i32.const", value: 10 },
+            { op: "i32.eq" },
+            { op: "i32.or" },
+            { op: "local.get", index: T_C },
+            { op: "i32.const", value: 13 },
+            { op: "i32.eq" },
+            { op: "i32.or" },
+            { op: "i32.eqz" },
+            { op: "br_if", depth: 1 },
+            { op: "local.get", index: T_POS },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: T_POS },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+    { op: "local.get", index: T_POS },
+    { op: "local.get", index: T_END },
+    { op: "i32.lt_s" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: throwSyntaxError("Unexpected non-whitespace character after JSON"),
+    },
+    { op: "local.get", index: T_RESULT },
+  ];
+
+  // ── push the three functions in the pre-registered order ──────────────────
+  // Deep-clone each body so no `Instr` object is shared between (or within) the
+  // bodies. The helper consts above (`loadPos`, `cEqV(...)`, `castP`, …) are
+  // spread into many positions, so the same object can appear multiple times in
+  // one body and across all three. The finalize remap (`remapTypeIdxInBody` in
+  // dead-elimination.ts) mutates `typeIdx` in place and re-visits a shared
+  // object once per occurrence — re-mapping an already-remapped index a second
+  // time (the documented #1302 shared-array double-shift hazard). Cloning makes
+  // every occurrence a distinct object so each `typeIdx` is remapped exactly
+  // once. (`$JsonP` is the only fresh struct index threaded through these
+  // bodies, so an un-cloned double-remap desynced `struct.get`/`ref.cast`
+  // operands from the local's declared type.)
+  const cloneBody = (b: Instr[]): Instr[] => structuredClone(b);
+
+  ctx.mod.functions.push({
+    name: "__json_parse_value",
+    typeIdx: valueTypeIdx,
+    locals: [
+      { count: 1, type: { kind: "ref", typeIdx: jsonPTypeIdx } }, // V_PS
+      { count: 1, type: strDataRef }, // V_DATA
+      { count: 1, type: i32 }, // V_POS
+      { count: 1, type: i32 }, // V_END
+      { count: 1, type: i32 }, // V_C
+      { count: 1, type: externref }, // V_OBJ
+      { count: 1, type: strRefNative }, // V_KEY
+      { count: 1, type: anyref }, // V_VAL
+      { count: 1, type: f64 }, // V_NUM
+      { count: 1, type: f64 }, // V_MANT
+      { count: 1, type: f64 }, // V_SIGN
+      { count: 1, type: i32 }, // V_EXP
+      { count: 1, type: i32 }, // V_EXPSIGN
+      { count: 1, type: i32 }, // V_EXPMAG
+    ],
+    body: cloneBody(valueBody),
+    exported: false,
+  } as unknown as (typeof ctx.mod.functions)[number]);
+
+  ctx.mod.functions.push({
+    name: "__json_parse_str",
+    typeIdx: strParseTypeIdx,
+    locals: [
+      { count: 1, type: { kind: "ref", typeIdx: jsonPTypeIdx } }, // S_PS
+      { count: 1, type: strDataRef }, // S_DATA
+      { count: 1, type: i32 }, // S_POS
+      { count: 1, type: i32 }, // S_END
+      { count: 1, type: i32 }, // S_START
+      { count: 1, type: i32 }, // S_RAWEND
+      { count: 1, type: strDataRef }, // S_OUT
+      { count: 1, type: i32 }, // S_N
+      { count: 1, type: i32 }, // S_C
+      { count: 1, type: i32 }, // S_HEX
+      { count: 1, type: i32 }, // S_K
+      { count: 1, type: i32 }, // S_SCAN
+    ],
+    body: cloneBody(strParseBody),
+    exported: false,
+  } as unknown as (typeof ctx.mod.functions)[number]);
+
+  ctx.mod.functions.push({
+    name: "__json_parse_text",
+    typeIdx: textTypeIdx,
+    locals: [
+      { count: 1, type: strRefNative }, // T_FLAT
+      { count: 1, type: { kind: "ref", typeIdx: jsonPTypeIdx } }, // T_P
+      { count: 1, type: anyref }, // T_RESULT
+      { count: 1, type: i32 }, // T_POS
+      { count: 1, type: i32 }, // T_END
+      { count: 1, type: strDataRef }, // T_DATA
+      { count: 1, type: i32 }, // T_C
+    ],
+    body: cloneBody(textBody),
+    exported: false,
+  } as unknown as (typeof ctx.mod.functions)[number]);
+
+  return textFuncIdx;
 }

--- a/src/codegen/json-codec-native.ts
+++ b/src/codegen/json-codec-native.ts
@@ -661,7 +661,15 @@ export function emitJsonParseText(ctx: CodegenContext): number {
   const strTypeIdx = ctx.nativeStrTypeIdx; // $NativeString { len, off, data }
   const strDataTypeIdx = ctx.nativeStrDataTypeIdx; // (array (mut i16))
   const anyStrTypeIdx = ctx.anyStrTypeIdx;
-  const anyValueTypeIdx = ctx.anyValueTypeIdx;
+  // Box parsed primitives into the SAME standalone boxed structs the object
+  // runtime + `__unbox_number` understand (`$__box_number_struct {value:f64}`,
+  // `$__box_boolean_struct {value:i32}`), NOT `$AnyValue`. A value stored into a
+  // `$Object` via `__extern_set` is read back via the property path, whose
+  // externref→number/boolean coercion only unboxes the `$__box_*` structs — an
+  // `$AnyValue` would read back as NaN/undefined. (Top-level primitive parse
+  // results unbox fine either way, but object/array members must use these.)
+  const boxNumTypeIdx = ctx.nativeBoxNumberTypeIdx;
+  const boxBoolTypeIdx = ctx.nativeBoxBooleanTypeIdx;
   const strDataRef: ValType = { kind: "ref", typeIdx: strDataTypeIdx };
   const strRefNative: ValType = { kind: "ref", typeIdx: strTypeIdx };
 
@@ -841,30 +849,18 @@ export function emitJsonParseText(ctx: CodegenContext): number {
     return out;
   };
 
-  // AnyValue box helpers
-  const boxNullAny: Instr[] = [
-    { op: "i32.const", value: 0 },
-    { op: "i32.const", value: 0 },
-    { op: "f64.const", value: 0 },
-    { op: "ref.null", typeIdx: EQ_HEAP_TYPE },
-    { op: "ref.null.extern" },
-    { op: "struct.new", typeIdx: anyValueTypeIdx },
-  ];
+  // Primitive box helpers (leave an `anyref` on the stack). Numbers/booleans use
+  // the standalone boxed structs so object/array member reads unbox them; JSON
+  // `null` becomes a null eqref (reads back as `null`, distinct from a missing
+  // property which reads `undefined`).
+  const boxNullAny: Instr[] = [{ op: "ref.null", typeIdx: EQ_HEAP_TYPE }];
   const boxBoolAny = (v: number): Instr[] => [
-    { op: "i32.const", value: 4 },
     { op: "i32.const", value: v },
-    { op: "f64.const", value: 0 },
-    { op: "ref.null", typeIdx: EQ_HEAP_TYPE },
-    { op: "ref.null.extern" },
-    { op: "struct.new", typeIdx: anyValueTypeIdx },
+    { op: "struct.new", typeIdx: boxBoolTypeIdx },
   ];
   const boxF64AnyFromLocal = (local: number): Instr[] => [
-    { op: "i32.const", value: 3 },
-    { op: "i32.const", value: 0 },
     { op: "local.get", index: local },
-    { op: "ref.null", typeIdx: EQ_HEAP_TYPE },
-    { op: "ref.null.extern" },
-    { op: "struct.new", typeIdx: anyValueTypeIdx },
+    { op: "struct.new", typeIdx: boxNumTypeIdx },
   ];
 
   // number parser (cursor at '-'/digit) → f64 in V_NUM; advances V_POS.

--- a/tests/issue-1599-json-standalone-refuse.test.ts
+++ b/tests/issue-1599-json-standalone-refuse.test.ts
@@ -62,20 +62,23 @@ describe("#1599 --target standalone refuses dynamic unsupported JSON shapes", ()
     await expectAccepted(`export function f(n: number): string { return JSON.stringify(n); }`);
   });
 
-  it("rejects dynamic JSON.parse text", async () => {
-    await expectRefused(`export function f(s: string): number { return JSON.parse(s).x; }`);
+  it("compiles dynamic JSON.parse text (PR-C codec, no longer refused)", async () => {
+    // #2166 PR-C: a runtime-string `JSON.parse` now routes to the pure-Wasm
+    // recursive-descent `__json_parse_text` codec (host-import-free), so a
+    // dynamic-text parse + property read compiles instead of refusing.
+    await expectAccepted(`export function f(s: string): number { return JSON.parse(s).x; }`);
   });
 
   it("compiles JSON.parse of a static string literal property read", async () => {
     await expectAccepted(`export function f(): number { return JSON.parse('{"x":42}').x; }`);
   });
 
-  it("also refuses an unsupported shape under --target wasi", async () => {
-    // A dynamic array (closed typed-vec) and a dynamic JSON.parse text still
-    // refuse under wasi. (An object DOES route to the PR-A codec under wasi too,
-    // host-import-free — covered by the #2166 PR-A wasi test.)
+  it("still refuses a dynamic array (closed typed-vec) stringify under --target wasi", async () => {
+    // A dynamic array (closed typed-vec) still refuses (PR-A2 follow-up). A
+    // dynamic JSON.parse text now compiles under wasi too (PR-C, host-import-
+    // free — covered by the #2166 PR-C wasi test).
     await expectRefused(`export function f(a: number[]): string { return JSON.stringify(a); }`, "wasi");
-    await expectRefused(`export function f(s: string): number { return JSON.parse(s).x; }`, "wasi");
+    await expectAccepted(`export function f(s: string): number { return JSON.parse(s).x; }`, "wasi");
   });
 
   it("emits no env::JSON_* import when refused", async () => {

--- a/tests/issue-2166.test.ts
+++ b/tests/issue-2166.test.ts
@@ -306,12 +306,12 @@ describe("#2166 PR-C — standalone dynamic JSON.parse (object graphs + primitiv
   });
 
   it("parses a string value", async () => {
-    expect(await parseInternal(`const o: any = JSON.parse('{"s":"hi"}'); return (o.s as string) === "hi" ? 1 : 0;`)).toBe(
-      1,
-    );
+    expect(
+      await parseInternal(`const o: any = JSON.parse('{"s":"hi"}'); return (o.s as string) === "hi" ? 1 : 0;`),
+    ).toBe(1);
   });
 
-  it("parses §25.5.1 string escapes (\\n, \\\", \\\\, \\uXXXX)", async () => {
+  it('parses §25.5.1 string escapes (\\n, \\", \\\\, \\uXXXX)', async () => {
     // {"s":"a\nb\"c\\dA"}  →  a<LF>b"c\dA
     expect(
       await parseInternal(
@@ -321,13 +321,15 @@ describe("#2166 PR-C — standalone dynamic JSON.parse (object graphs + primitiv
   });
 
   it("parses a boolean property (truthy round-trip)", async () => {
-    expect(await parseInternal(`const o: any = JSON.parse('{"t":true,"f":false}'); return (o.t as boolean) ? 1 : 0;`)).toBe(
-      1,
-    );
+    expect(
+      await parseInternal(`const o: any = JSON.parse('{"t":true,"f":false}'); return (o.t as boolean) ? 1 : 0;`),
+    ).toBe(1);
   });
 
   it("parses a null property", async () => {
-    expect(await parseInternal(`const o: any = JSON.parse('{"n":null}'); return (o.n as any) === null ? 1 : 0;`)).toBe(1);
+    expect(await parseInternal(`const o: any = JSON.parse('{"n":null}'); return (o.n as any) === null ? 1 : 0;`)).toBe(
+      1,
+    );
   });
 
   it("parses a top-level primitive (number)", async () => {
@@ -343,7 +345,9 @@ describe("#2166 PR-C — standalone dynamic JSON.parse (object graphs + primitiv
   });
 
   it("tolerates leading/trailing whitespace", async () => {
-    expect(await parseInternal(`const o: any = JSON.parse('  {"x":1}  '); return (o.x as number) === 1 ? 1 : 0;`)).toBe(1);
+    expect(await parseInternal(`const o: any = JSON.parse('  {"x":1}  '); return (o.x as number) === 1 ? 1 : 0;`)).toBe(
+      1,
+    );
   });
 
   it("round-trips JSON.parse(JSON.stringify(o)) for an object graph", async () => {

--- a/tests/issue-2166.test.ts
+++ b/tests/issue-2166.test.ts
@@ -260,3 +260,121 @@ describe("#2166 PR-A — standalone dynamic object-graph JSON.stringify", () => 
     expect(await stringifyDynamic(`let o: any = { a: 1 }; o = { a: 1, b: 2 }; G = s(o);`)).toBe('{"a":1,"b":2}');
   });
 });
+
+/**
+ * #2166 PR-C — dynamic JSON.parse via the pure-Wasm recursive-descent codec
+ * (`__json_parse_text`, src/codegen/json-codec-native.ts). Parses a runtime JSON
+ * *text* into the SAME standalone value representation the object runtime and
+ * the PR-A stringify codec consume — `$Object` graphs (via `__new_plain_object`
+ * + `__extern_set`), boxed-number/boolean primitives (`$__box_*` structs, what
+ * the property-read coercion unboxes), native-string values (full §25.5.1
+ * escape handling incl. `\uXXXX`), and `null`. A round-trip
+ * `JSON.parse(JSON.stringify(o))` and downstream `r.x` reads work. Malformed
+ * input throws a runtime SyntaxError (§25.5.1 step 3) rather than trapping.
+ *
+ * Scope (PR-C): object graphs + primitives. Arrays are parsed structurally
+ * (`.length` works, nested arrays serialise as property values), but direct
+ * numeric element indexing on a parsed array (`a[i]`) needs the standalone
+ * element-access path to route `$ObjVec` reads through `__extern_get_idx`,
+ * tracked as the PR-C2 follow-up. A `reviver` argument is deferred to PR-D.
+ *
+ * Native strings don't marshal across the JS export boundary in standalone, so
+ * the harness compiles the assertion INTERNALLY and returns a number from
+ * `test()` (1 = pass), the same internal-comparison shape test262 needs.
+ */
+async function parseInternal(body: string, target: "standalone" | "wasi" = "standalone"): Promise<number> {
+  const src = `export function test(): number { ${body} }`;
+  const r = await compile(src, { target });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const labels = r.imports.map((i) => `${i.module}::${i.name}`);
+  expect(labels.some((l) => /JSON_stringify|JSON_parse/.test(l))).toBe(false);
+  const importObject: Record<string, unknown> = {};
+  const { instance } = await WebAssembly.instantiate(r.binary, importObject);
+  (importObject as { __setExports?: (e: unknown) => void }).__setExports?.(instance.exports);
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2166 PR-C — standalone dynamic JSON.parse (object graphs + primitives)", () => {
+  it("parses an object number property", async () => {
+    expect(await parseInternal(`const o: any = JSON.parse('{"x":7}'); return (o.x as number) === 7 ? 1 : 0;`)).toBe(1);
+  });
+
+  it("parses a nested object graph", async () => {
+    expect(
+      await parseInternal(`const o: any = JSON.parse('{"a":{"b":3}}'); return (o.a.b as number) === 3 ? 1 : 0;`),
+    ).toBe(1);
+  });
+
+  it("parses a string value", async () => {
+    expect(await parseInternal(`const o: any = JSON.parse('{"s":"hi"}'); return (o.s as string) === "hi" ? 1 : 0;`)).toBe(
+      1,
+    );
+  });
+
+  it("parses §25.5.1 string escapes (\\n, \\\", \\\\, \\uXXXX)", async () => {
+    // {"s":"a\nb\"c\\dA"}  →  a<LF>b"c\dA
+    expect(
+      await parseInternal(
+        `const o: any = JSON.parse('{"s":"a\\\\nb\\\\"c\\\\\\\\d\\\\u0041"}'); return (o.s as string) === "a\\nb\\"c\\\\dA" ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("parses a boolean property (truthy round-trip)", async () => {
+    expect(await parseInternal(`const o: any = JSON.parse('{"t":true,"f":false}'); return (o.t as boolean) ? 1 : 0;`)).toBe(
+      1,
+    );
+  });
+
+  it("parses a null property", async () => {
+    expect(await parseInternal(`const o: any = JSON.parse('{"n":null}'); return (o.n as any) === null ? 1 : 0;`)).toBe(1);
+  });
+
+  it("parses a top-level primitive (number)", async () => {
+    expect(await parseInternal(`return (JSON.parse("42") as number) === 42 ? 1 : 0;`)).toBe(1);
+  });
+
+  it("parses negative / fractional / exponent numbers", async () => {
+    expect(
+      await parseInternal(
+        `const o: any = JSON.parse('{"a":-2.5,"b":1e3,"c":1.5e-2}'); return ((o.a as number) === -2.5 && (o.b as number) === 1000 && (o.c as number) === 0.015) ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("tolerates leading/trailing whitespace", async () => {
+    expect(await parseInternal(`const o: any = JSON.parse('  {"x":1}  '); return (o.x as number) === 1 ? 1 : 0;`)).toBe(1);
+  });
+
+  it("round-trips JSON.parse(JSON.stringify(o)) for an object graph", async () => {
+    expect(
+      await parseInternal(
+        `let o: any = { x: 5, y: 9 }; const r: any = JSON.parse(JSON.stringify(o)); return ((r.x as number) + (r.y as number)) === 14 ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("round-trips a nested object graph", async () => {
+    expect(
+      await parseInternal(
+        `let o: any = { a: { b: 3 } }; const r: any = JSON.parse(JSON.stringify(o)); return (r.a.b as number) === 3 ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("parses an empty object", async () => {
+    expect(await parseInternal(`const o: any = JSON.parse('{}'); const r: any = o; return 1;`)).toBe(1);
+  });
+
+  it("works under --target wasi too (host-import-free)", async () => {
+    expect(
+      await parseInternal(`const o: any = JSON.parse('{"x":7}'); return (o.x as number) === 7 ? 1 : 0;`, "wasi"),
+    ).toBe(1);
+  });
+
+  it("throws a SyntaxError on malformed input (trailing junk)", async () => {
+    // The codec throws a standalone SyntaxError at runtime; the trap surfaces as
+    // a WebAssembly runtime error when test() runs.
+    await expect(parseInternal(`const o: any = JSON.parse('{"x":1} bogus'); return 1;`)).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## #2166 PR-C — standalone dynamic `JSON.parse`

Adds the pure-Wasm recursive-descent JSON parser (`__json_parse_text`, ECMA-404 / §25.5.1) in `src/codegen/json-codec-native.ts`, the parse half of the #1599 Phase-2 dynamic JSON codec. Output uses the SAME standalone value representation the PR-A stringify codec produces and the property-read path unboxes, so `JSON.parse(JSON.stringify(o))` round-trips and `r.x` reads work — no `env::JSON_*` host import (standalone + WASI).

- **objects** → `$Object` (`__new_plain_object` + `__extern_set`, insertion order)
- **numbers/booleans** → `$__box_number_struct` (booleans as 1.0/0.0, matching how a standalone object stores a boolean today)
- **strings** → native `$AnyString` with full §25.5.1 unescaping incl. `\uXXXX`
- **arrays** → `$ObjVec`
- **malformed input / trailing junk** → runtime `throw new SyntaxError(...)` (§25.5.1 step 3), not a trap

Routing (`expressions/calls.ts`): a runtime-string / `any`-typed `JSON.parse(text)` (1-arg) now routes to the codec, replacing the primitive-only `__json_parse_primitive` slice (a strict superset). A `reviver` arg is deferred to PR-D.

### Stacking
This is **stacked on PR-A (#1653)** which creates `json-codec-native.ts`. Until #1653 merges, this PR's diff includes PR-A's commits; once #1653 lands, GitHub recomputes the diff to just the PR-C net changes.

### Tests
+14 PR-C cases in `tests/issue-2166.test.ts` (object reads, escapes incl. `\uXXXX`, bool/null, top-level + negative/fraction/exponent numbers, whitespace, object + nested round-trip, `--target wasi`, malformed→SyntaxError). `tests/issue-1599-json-standalone-refuse.test.ts` updated: dynamic `JSON.parse(s).x` now compiles (std + wasi); a dynamic `number[]` stringify still refuses (PR-A2). 54 JSON tests green; typecheck clean.

### Notable fix (codegen robustness)
The fresh `$JsonP` cursor-struct `typeIdx` is baked into many shared helper-`Instr` objects; the finalize dead-type-elimination remap mutates `typeIdx` in place and re-visits a shared object once per occurrence (the #1302 shared-array double-shift hazard), which desynced the `struct.get` operands from the cursor local type. Fix: JSON-round-trip-clone each function body (NOT `structuredClone`, which preserves aliasing) so each operand is remapped exactly once.

### Follow-ups (in the issue file)
- **PR-C2:** parsed-array element indexing `a[i]` (route `$ObjVec` numeric reads through `__extern_get_idx`; `.length` and array-as-property-value already work)
- **PR-D:** reviver / `toJSON` / instance fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)