### PR TITLE
ci: cut test262 shard timeout 90m→25m (hung shards wedge the queue)

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -348,7 +348,12 @@ jobs:
     # --no-verify pushes and contributors without the hook.
     name: test262 ${{ matrix.target.name }} shard ${{ matrix.chunk }}
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # A shard normally finishes in ~5-8 min; the prior 90-min cap let a single
+    # hung shard (intermittent test262/runner stall, or the setup-node@v6 Node-25
+    # tool-cache miss → flaky direct download) wedge the whole merge queue for up
+    # to 90 min before failing. 25 min fails a hung shard fast so the merge_group
+    # ejects + re-runs instead of stalling every other PR behind it.
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Problem

A single hung test262 shard (intermittent test/runner stall, or the recurring `setup-node@v6` Node-25 tool-cache miss that falls back to a flaky direct download) blocks its `merge_group` run for up to **90 minutes** (the shard job's `timeout-minutes: 90`). Because the merge queue serializes, that wedges **every** queued PR behind it — observed today: the queue made zero merges for >1h with entries stuck `AWAITING_CHECKS`.

## Fix

Drop the shard `timeout-minutes` to **25** (normal shards finish in ~5-8 min). A hung shard now fails fast, the `merge_group` ejects + re-runs, and the queue keeps moving. Pure CI-timing change — no effect on build or test correctness.

Follow-up (not in this PR): pinning the shard runner to Node 24 (already used in auto-enqueue/approve-fork-runs/queue-unstick; `engines: >=20`) would remove the setup-node flake at its source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)