### PR TITLE
feat(#2166 PR-B): standalone dynamic-graph JSON.stringify(value, null, space) indentation

### DIFF
--- a/plan/issues/2166-standalone-json-residual.md
+++ b/plan/issues/2166-standalone-json-residual.md
@@ -376,3 +376,53 @@ this PR (verified by stashing). PR #1653.
   blast radius, overlaps #1917; deferred.
 - **PR-B:** dynamic-space indentation. **PR-C:** `__json_parse_text`. **PR-D:**
   instance fields + toJSON + reviver/replacer.
+
+---
+
+## Progress (2026-06-17, sdev-json3) — PR-B: dynamic-graph `space` indentation
+
+PR-B of the Implementation Plan. Threads §25.5.2 pretty-printing through the
+pure-Wasm dynamic stringify codec (`src/codegen/json-codec-native.ts`). PR-A
+emitted dynamic object graphs *compactly* only; any `space` argument forced the
+#1599 refusal (the static-fold path owns only the static-value form, which a
+runtime-built graph never reaches).
+
+**Codec (`json-codec-native.ts`):**
+- `__json_stringify_value` gains a third param `gap: ref null $AnyString` (the
+  per-level indent unit, e.g. `"  "`). A **null** gap selects the compact form
+  (PR-A behaviour, zero added work — the separators collapse to `""`); a
+  non-null gap drives indentation.
+- Each call computes three separator locals once (prologue): `L_NL_IN` =
+  `"\n" + __str_repeat(gap, depth+1)` (before every element/property),
+  `L_NL_OUT` = `"\n" + __str_repeat(gap, depth)` (before the closing brace),
+  `L_COLON` = `": "` (key/value). With a null gap all three are `""`/`":"`, so
+  the object/array arms emit **byte-identical** compact output (verified by the
+  1-arg regression guard). `__str_repeat` returns `""` for count 0, so the
+  top-level (depth 0) close indent is bare `"\n"`.
+- Empty object/array stays `{}` / `[]` (the close-indent is gated on
+  "≥1 member emitted", §25.5.2).
+- New entry `__json_stringify_root_indent(v, gap)` mirrors `__json_stringify_root`
+  with the gap forwarded.
+
+**Routing (`src/codegen/expressions/calls.ts`):** the dynamic-graph branch now
+resolves a *static* `space` arg (`staticSpaceValue` → `jsonGapFromStaticSpace`,
+both newly exported from `json-standalone.ts`) to the gap string per §25.5.2
+(`min(10, floor(n))` spaces / first 10 chars of a string; ≤0/"" → compact). An
+empty gap routes through the cheap compact root; a non-empty gap pushes the gap
+literal and calls `__json_stringify_root_indent`. A function/array replacer or a
+**dynamic** space still keeps the #1599 refusal (no silent wrong output).
+
+Tests: `tests/issue-2166.test.ts` (+12 PR-B cases — flat/nested/deeply-nested
+object with numeric space 2, string (tab) + multi-char space, numeric-space>10
+clamp, space 0 = compact, null property value, empty nested object stays
+compact, `--target wasi` host-import-free, and a 1-arg compact PR-A regression
+guard). Each result is read back char-by-char and compared to Node's own
+`JSON.stringify(value, null, space)` for exact parity. `#1599`/`#1636` refuse
+suites stay green; the two pre-existing host-mode `json.test.ts` failures are
+upstream (verified by stashing).
+
+**Still open after PR-B:** PR-C (`__json_parse_text`, separate branch #1657),
+PR-C2 (parsed-array `a[i]` indexing, #1658), PR-D (reviver/replacer/toJSON),
+PR-A2 (closed `number[]` array stringify — a literal `number[]` isn't an
+`$ObjVec`, so it still routes to refusal; the array *indent* arm is implemented
+and activates for `$ObjVec` arrays once those route through the codec).

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -65,7 +65,12 @@ import {
   resolveComputedKeyExpression,
   resolvePropertyNameText,
 } from "../literals.js";
-import { tryEmitJsonParseLiteral, tryEmitJsonStringifyStatic } from "../json-standalone.js";
+import {
+  jsonGapFromStaticSpace,
+  staticSpaceValue,
+  tryEmitJsonParseLiteral,
+  tryEmitJsonStringifyStatic,
+} from "../json-standalone.js";
 import { emitJsonParsePrimitive, emitJsonQuoteString } from "../json-runtime.js";
 import { emitJsonStringifyValue } from "../json-codec-native.js";
 import {
@@ -148,6 +153,7 @@ import {
   ensureNativeStringExternBridge,
   ensureStrToCharVecHelper,
   ensureTextEncodingHelpers,
+  nativeStringLiteralInstrs,
   stringConstantExternrefInstrs,
 } from "../native-strings.js";
 import { emitVariadicStringConcat, hostStringRepr, nativeStringRepr } from "../builtin-scaffold.js";
@@ -5994,15 +6000,13 @@ function compileCallExpression(
             if (staticStringType !== undefined) {
               return staticStringType;
             }
-            // (#2166 PR-A) Dynamic object-graph stringify. The static fold
+            // (#2166 PR-A/PR-B) Dynamic object-graph stringify. The static fold
             // declined (runtime-built graph), so serialise with the pure-Wasm
             // recursive codec over the standalone value rep ($Object/$ObjVec/
             // boxed primitives) instead of refusing or silently wrong-folding.
-            // Compact output only; a function/array replacer or a `space`
-            // argument is not yet threaded here (the static fold owns the
-            // static-space form, PR-B threads the dynamic-space form), so route
-            // only the 1-arg / null-replacer-no-space shape and let other
-            // shapes keep the refusal below.
+            // PR-B threads a *static* `space` argument (number/string literal)
+            // into the codec's indent path; a function/array replacer or a
+            // *dynamic* space still keeps the refusal below.
             const replacerArg = expr.arguments[1];
             const spaceArg = expr.arguments[2];
             const replacerNullish =
@@ -6026,7 +6030,17 @@ function compileCallExpression(
               // index type with only integer / `length` own keys looks array-like.
               (arg0Type.getNumberIndexType() !== undefined &&
                 arg0Type.getProperties().every((p) => /^\d+$/.test(p.name) || p.name === "length"));
-            if (replacerNullish && spaceArg === undefined && !isArrayLike) {
+            // (#2166 PR-B) Resolve a static `space` argument to the §25.5.2
+            // indent unit ("gap"). `undefined` space → compact (gap ""). A
+            // *dynamic* space arg stays unresolved → keep the refusal below
+            // (rare shape). An empty gap (space ≤0 / "") routes through the
+            // compact path.
+            let gap: string | undefined = "";
+            if (spaceArg !== undefined) {
+              const staticSpace = staticSpaceValue(ctx, spaceArg);
+              gap = staticSpace === undefined ? undefined : jsonGapFromStaticSpace(staticSpace);
+            }
+            if (replacerNullish && gap !== undefined && !isArrayLike) {
               const argResult = compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "anyref" });
               if (argResult === null) return null;
               // Bring the value to anyref so the codec can ref.test-discriminate
@@ -6038,7 +6052,17 @@ function compileCallExpression(
               }
               emitJsonStringifyValue(ctx);
               flushLateImportShifts(ctx, fctx);
-              fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__json_stringify_root")! } as Instr);
+              if (gap === "") {
+                // No indentation — the compact root (cheapest path).
+                fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__json_stringify_root")! } as Instr);
+              } else {
+                // Pretty-print: push the gap string and call the indent root.
+                for (const instr of nativeStringLiteralInstrs(ctx, gap)) fctx.body.push(instr);
+                fctx.body.push({
+                  op: "call",
+                  funcIdx: ctx.funcMap.get("__json_stringify_root_indent")!,
+                } as Instr);
+              }
               return nativeStringType(ctx);
             }
           }

--- a/src/codegen/json-codec-native.ts
+++ b/src/codegen/json-codec-native.ts
@@ -95,27 +95,37 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
   const strRefNull: ValType = { kind: "ref_null", typeIdx: anyStrTypeIdx };
   const strRef = nativeStringType(ctx); // ref $AnyString
 
+  const repeatIdx = ctx.nativeStrHelpers.get("__str_repeat")!; // (#2166 PR-B) indent builder
+
   // Pre-register the self funcIdx so the recursive calls in the body resolve.
-  const typeIdx = addFuncType(ctx, [anyref, i32], [strRefNull]);
+  // (#2166 PR-B) `gap` (param 2, `ref null $AnyString`) is the per-level indent
+  // unit (e.g. "  "). A null gap selects the compact form (PR-A behaviour, zero
+  // overhead); a non-null gap drives §25.5.2 pretty-printing.
+  const typeIdx = addFuncType(ctx, [anyref, i32, strRefNull], [strRefNull]);
   const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
   ctx.funcMap.set("__json_stringify_value", funcIdx);
 
   // ── Local plan ──────────────────────────────────────────────────────────
-  // params: 0 v:anyref  1 depth:i32
+  // params: 0 v:anyref  1 depth:i32  2 gap:ref null $AnyString
   const P_V = 0;
   const P_DEPTH = 1;
-  const L_ANY = 2; // anyref scratch (re-tested value)
-  const L_OBJ = 3; // ref null $Object
-  const L_ARR = 4; // ref null $PropMap (ordered) / loop reuse
-  const L_VEC = 5; // ref null $ObjVec
-  const L_CAP = 6; // i32 loop bound
-  const L_I = 7; // i32 loop index
-  const L_E = 8; // ref null $PropEntry
-  const L_OUT = 9; // ref $AnyString accumulator
-  const L_PIECE = 10; // ref null $AnyString per-element/prop serialisation
-  const L_FIRST = 11; // i32 — first-emitted flag (comma control)
-  const L_NUM = 12; // f64 number scratch
-  const L_DATA = 13; // ref $ObjVecArr (vec backing)
+  const P_GAP = 2;
+  const L_ANY = 3; // anyref scratch (re-tested value)
+  const L_OBJ = 4; // ref null $Object
+  const L_ARR = 5; // ref null $PropMap (ordered) / loop reuse
+  const L_VEC = 6; // ref null $ObjVec
+  const L_CAP = 7; // i32 loop bound
+  const L_I = 8; // i32 loop index
+  const L_E = 9; // ref null $PropEntry
+  const L_OUT = 10; // ref $AnyString accumulator
+  const L_PIECE = 11; // ref null $AnyString per-element/prop serialisation
+  const L_FIRST = 12; // i32 — first-emitted flag (comma control)
+  const L_NUM = 13; // f64 number scratch
+  const L_DATA = 14; // ref $ObjVecArr (vec backing)
+  // (#2166 PR-B) Precomputed separator strings (empty when gap is null):
+  const L_NL_IN = 15; // ref $AnyString — "\n" + indent at the *inner* (depth+1) level
+  const L_NL_OUT = 16; // ref $AnyString — "\n" + indent at *this* depth (before close)
+  const L_COLON = 17; // ref $AnyString — ": " when indented, ":" when compact
 
   const litStr = (s: string): Instr[] => nativeStringLiteralInstrs(ctx, s);
 
@@ -136,6 +146,66 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
     ...litStr(s),
     { op: "call", funcIdx: concatIdx },
     { op: "local.set", index: L_OUT },
+  ];
+
+  // (#2166 PR-B) out = __str_concat(out, <separator local — always non-null>)
+  // Used for the precomputed newline/indent separators (L_NL_IN/L_NL_OUT/
+  // L_COLON). They are the empty string when gap is null, so concatenating
+  // them in the compact form is a no-op (and `__str_concat` short-circuits an
+  // empty argument).
+  const appendSep = (sepLocal: number): Instr[] => [
+    { op: "local.get", index: L_OUT },
+    { op: "ref.as_non_null" },
+    { op: "local.get", index: sepLocal },
+    { op: "ref.as_non_null" },
+    { op: "call", funcIdx: concatIdx },
+    { op: "local.set", index: L_OUT },
+  ];
+
+  // (#2166 PR-B) Compute the per-call separator strings into L_NL_IN /
+  // L_NL_OUT / L_COLON. With a null gap every separator is "" (and the colon is
+  // ":"), so the loop bodies below emit byte-identical compact output. With a
+  // non-null gap: L_NL_IN = "\n" + repeat(gap, depth+1); L_NL_OUT = "\n" +
+  // repeat(gap, depth); L_COLON = ": ". `__str_repeat` returns "" for count 0,
+  // so the top-level (depth 0) close indent is just "\n" as §25.5.2 requires.
+  const setupSeparators: Instr[] = [
+    { op: "local.get", index: P_GAP },
+    { op: "ref.is_null" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        ...litStr(""),
+        { op: "local.set", index: L_NL_IN },
+        ...litStr(""),
+        { op: "local.set", index: L_NL_OUT },
+        ...litStr(":"),
+        { op: "local.set", index: L_COLON },
+      ],
+      else: [
+        // L_NL_IN = "\n" + repeat(gap, depth + 1)
+        ...litStr("\n"),
+        { op: "local.get", index: P_GAP },
+        { op: "ref.as_non_null" },
+        { op: "local.get", index: P_DEPTH },
+        { op: "i32.const", value: 1 },
+        { op: "i32.add" },
+        { op: "call", funcIdx: repeatIdx },
+        { op: "call", funcIdx: concatIdx },
+        { op: "local.set", index: L_NL_IN },
+        // L_NL_OUT = "\n" + repeat(gap, depth)
+        ...litStr("\n"),
+        { op: "local.get", index: P_GAP },
+        { op: "ref.as_non_null" },
+        { op: "local.get", index: P_DEPTH },
+        { op: "call", funcIdx: repeatIdx },
+        { op: "call", funcIdx: concatIdx },
+        { op: "local.set", index: L_NL_OUT },
+        // L_COLON = ": "
+        ...litStr(": "),
+        { op: "local.set", index: L_COLON },
+      ],
+    },
   ];
 
   // ── number arm: format f64 (in L_NUM) per JSON rules → push ref $AnyString ─
@@ -292,14 +362,16 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
             { op: "local.get", index: L_CAP },
             { op: "i32.ge_s" },
             { op: "br_if", depth: 1 },
-            // comma before every element after the first
+            // comma before every element after the first; then (#2166 PR-B) the
+            // newline+indent separator (L_NL_IN, "" when compact) before each.
             { op: "local.get", index: L_I },
             {
               op: "if",
               blockType: { kind: "empty" },
               then: [...appendLit(",")],
             },
-            // piece = __json_stringify_value(any.convert_extern(data[i]), depth+1)
+            ...appendSep(L_NL_IN),
+            // piece = __json_stringify_value(any.convert_extern(data[i]), depth+1, gap)
             { op: "local.get", index: L_DATA },
             { op: "local.get", index: L_I },
             { op: "array.get", typeIdx: objVecArrTypeIdx },
@@ -307,6 +379,7 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
             { op: "local.get", index: P_DEPTH },
             { op: "i32.const", value: 1 },
             { op: "i32.add" },
+            { op: "local.get", index: P_GAP },
             { op: "call", funcIdx },
             { op: "local.set", index: L_PIECE },
             // null piece (undefined element) → "null"
@@ -326,6 +399,15 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
           ],
         },
       ],
+    },
+    // (#2166 PR-B) closing-indent newline only for a non-empty array (§25.5.2:
+    // an empty array stays "[]"). L_NL_OUT is "" when compact, so this is a
+    // no-op there.
+    { op: "local.get", index: L_CAP },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [...appendSep(L_NL_OUT)],
     },
     ...appendLit("]"),
     { op: "local.get", index: L_OUT },
@@ -370,13 +452,14 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
             { op: "local.tee", index: L_E },
             { op: "ref.is_null" },
             { op: "br_if", depth: 1 },
-            // piece = __json_stringify_value(e.value, depth+1)
+            // piece = __json_stringify_value(e.value, depth+1, gap)
             { op: "local.get", index: L_E },
             { op: "ref.as_non_null" },
             { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 1 }, // value:anyref
             { op: "local.get", index: P_DEPTH },
             { op: "i32.const", value: 1 },
             { op: "i32.add" },
+            { op: "local.get", index: P_GAP },
             { op: "call", funcIdx },
             { op: "local.set", index: L_PIECE },
             // omit the property entirely if its value serialised to undefined
@@ -397,7 +480,9 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
                 },
                 { op: "i32.const", value: 0 },
                 { op: "local.set", index: L_FIRST },
-                // quote(key) : piece
+                // (#2166 PR-B) newline+indent before every property ("" compact)
+                ...appendSep(L_NL_IN),
+                // quote(key) <colon> piece — colon is ": " indented, ":" compact
                 { op: "local.get", index: L_OUT },
                 { op: "ref.as_non_null" },
                 { op: "local.get", index: L_E },
@@ -407,7 +492,7 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
                 { op: "call", funcIdx: quoteIdx },
                 { op: "call", funcIdx: concatIdx },
                 { op: "local.set", index: L_OUT },
-                ...appendLit(":"),
+                ...appendSep(L_COLON),
                 ...appendPiece,
               ],
             },
@@ -419,6 +504,16 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
           ],
         },
       ],
+    },
+    // (#2166 PR-B) closing-indent newline only when at least one property was
+    // emitted (L_FIRST == 0). An empty object stays "{}" (§25.5.2). L_NL_OUT is
+    // "" when compact.
+    { op: "local.get", index: L_FIRST },
+    { op: "i32.eqz" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [...appendSep(L_NL_OUT)],
     },
     ...appendLit("}"),
     { op: "local.get", index: L_OUT },
@@ -444,6 +539,9 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
       blockType: { kind: "empty" },
       then: [...litStr("null"), { op: "return" }],
     },
+    // (#2166 PR-B) compute the indent separators for the object/array arms.
+    // Only those arms read them; primitive arms below return before use.
+    ...setupSeparators,
     // any = v
     { op: "local.get", index: P_V },
     { op: "local.set", index: L_ANY },
@@ -547,6 +645,9 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
       { count: 1, type: i32 }, // L_FIRST
       { count: 1, type: f64 }, // L_NUM
       { count: 1, type: { kind: "ref", typeIdx: objVecArrTypeIdx } }, // L_DATA
+      { count: 1, type: strRef }, // L_NL_IN  (#2166 PR-B — always set in prologue)
+      { count: 1, type: strRef }, // L_NL_OUT
+      { count: 1, type: strRef }, // L_COLON
     ],
     body,
     exported: false,
@@ -571,6 +672,8 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
     body: [
       { op: "local.get", index: 0 },
       { op: "i32.const", value: 0 },
+      // (#2166 PR-B) compact form: null gap.
+      { op: "ref.null", typeIdx: anyStrTypeIdx },
       { op: "call", funcIdx },
       { op: "local.tee", index: 1 },
       { op: "ref.is_null" },
@@ -579,6 +682,35 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
         blockType: { kind: "val", type: strRef },
         then: [...litStr("null")],
         else: [{ op: "local.get", index: 1 }, { op: "ref.as_non_null" }],
+      },
+    ],
+    exported: false,
+  } as unknown as (typeof ctx.mod.functions)[number]);
+
+  // ── __json_stringify_root_indent(v: anyref, gap: ref null $AnyString) ──────
+  // (#2166 PR-B) The pretty-print entry: serialise at depth 0 with the caller's
+  // indent unit (`gap`). A null/empty gap behaves like the compact root
+  // (the worker's separators collapse to ""). Same null→"null" coalescing as
+  // the compact root.
+  const rootIndentTypeIdx = addFuncType(ctx, [anyref, strRefNull], [strRef]);
+  const rootIndentFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  ctx.funcMap.set("__json_stringify_root_indent", rootIndentFuncIdx);
+  ctx.mod.functions.push({
+    name: "__json_stringify_root_indent",
+    typeIdx: rootIndentTypeIdx,
+    locals: [{ count: 1, type: strRefNull }],
+    body: [
+      { op: "local.get", index: 0 },
+      { op: "i32.const", value: 0 },
+      { op: "local.get", index: 1 }, // gap
+      { op: "call", funcIdx },
+      { op: "local.tee", index: 2 },
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "val", type: strRef },
+        then: [...litStr("null")],
+        else: [{ op: "local.get", index: 2 }, { op: "ref.as_non_null" }],
       },
     ],
     exported: false,

--- a/src/codegen/json-standalone.ts
+++ b/src/codegen/json-standalone.ts
@@ -62,7 +62,7 @@ function staticStringValue(ctx: CodegenContext, expr: ts.Expression, seen = new 
  * first 10 characters of a string space (or `min(10, floor(n))` for a number)
  * are used; JS's own `JSON.stringify` applies that, so we just forward.
  */
-function staticSpaceValue(ctx: CodegenContext, expr: ts.Expression): number | string | undefined {
+export function staticSpaceValue(ctx: CodegenContext, expr: ts.Expression): number | string | undefined {
   const cur = unwrapTransparentExpression(expr);
   if (ts.isNumericLiteral(cur)) return Number(cur.text.replace(/_/g, ""));
   if (ts.isPrefixUnaryExpression(cur) && ts.isNumericLiteral(cur.operand)) {
@@ -76,6 +76,22 @@ function staticSpaceValue(ctx: CodegenContext, expr: ts.Expression): number | st
     if (init) return staticSpaceValue(ctx, init);
   }
   return undefined;
+}
+
+/**
+ * (#2166 PR-B) Resolve a static `space` argument to the per-level indent unit
+ * string (the "gap") per §25.5.2 step 6: a Number → `min(10, floor(n))` spaces
+ * (≤0 / NaN → ""); a String → its first 10 code units. Returns `""` for any
+ * gap that produces no indentation (the dynamic-graph codec then serialises
+ * compactly). The caller passes the gap to `__json_stringify_root_indent`.
+ */
+export function jsonGapFromStaticSpace(space: number | string): string {
+  if (typeof space === "number") {
+    if (!Number.isFinite(space)) return "";
+    const n = Math.min(10, Math.floor(space));
+    return n > 0 ? " ".repeat(n) : "";
+  }
+  return space.slice(0, 10);
 }
 
 function staticPropertyName(ctx: CodegenContext, name: ts.PropertyName): string | undefined {

--- a/tests/issue-2166.test.ts
+++ b/tests/issue-2166.test.ts
@@ -260,3 +260,126 @@ describe("#2166 PR-A — standalone dynamic object-graph JSON.stringify", () => 
     expect(await stringifyDynamic(`let o: any = { a: 1 }; o = { a: 1, b: 2 }; G = s(o);`)).toBe('{"a":1,"b":2}');
   });
 });
+
+/*
+ * #2166 PR-B — dynamic object-graph `JSON.stringify(value, null, space)` with
+ * §25.5.2 indentation. PR-A serialised dynamic graphs *compactly* only; a
+ * `space` argument forced the #1599 refusal (the static-fold path owns the
+ * static-value-static-space form, but a runtime-built graph never reaches it).
+ *
+ * PR-B threads a per-level indent unit ("gap") through the pure-Wasm recursive
+ * codec (`__json_stringify_root_indent`). A *static* number/string `space` is
+ * resolved at compile time to the gap (`min(10, floor(n))` spaces, or the first
+ * 10 chars of a string; ≤0/"" → compact). A function/array replacer or a
+ * *dynamic* space still keeps the refusal.
+ *
+ * Standalone native strings don't marshal across the export boundary, so the
+ * result is read back char-by-char and compared to Node's own
+ * `JSON.stringify(value, null, space)` — exact §25.5.2 parity.
+ */
+async function stringifyDynamicSpace(
+  build: string,
+  sBody: string,
+  target: "standalone" | "wasi" = "standalone",
+): Promise<string> {
+  const src =
+    `function s(o: any): string { return ${sBody}; }\n` +
+    `let G: string = "";\n` +
+    `export function len(): number { return G.length; }\n` +
+    `export function ch(i: number): number { return G.charCodeAt(i); }\n` +
+    `export function run(): void { ${build} }`;
+  const r = await compile(src, { target });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  // No JSON_* host import may leak into the standalone/wasi module.
+  const labels = r.imports.map((i) => `${i.module}::${i.name}`);
+  expect(labels.some((l) => /JSON_stringify|JSON_parse/.test(l))).toBe(false);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const ex = instance.exports as { run: () => void; len: () => number; ch: (i: number) => number };
+  ex.run();
+  let out = "";
+  const n = ex.len();
+  for (let i = 0; i < n; i++) out += String.fromCharCode(ex.ch(i));
+  return out;
+}
+
+describe("#2166 PR-B — standalone dynamic object-graph JSON.stringify indentation", () => {
+  it("indents a flat object with numeric space 2", async () => {
+    const want = JSON.stringify({ x: 7, y: 8 }, null, 2);
+    expect(await stringifyDynamicSpace(`let o: any = { x: 7, y: 8 }; G = s(o);`, `JSON.stringify(o, null, 2)`)).toBe(
+      want,
+    );
+  });
+
+  it("indents a nested object graph (per-level indent grows with depth)", async () => {
+    const want = JSON.stringify({ child: { k: 7 }, z: 9 }, null, 2);
+    expect(
+      await stringifyDynamicSpace(
+        `const n: any = { k: 7 }; const o: any = { child: n, z: 9 }; G = s(o);`,
+        `JSON.stringify(o, null, 2)`,
+      ),
+    ).toBe(want);
+  });
+
+  it("indents a deeply nested graph with space 2", async () => {
+    const want = JSON.stringify({ b: { c: { d: 4 } }, e: 5 }, null, 2);
+    expect(
+      await stringifyDynamicSpace(
+        `const a: any = { d: 4 }; const b: any = { c: a }; const o: any = { b: b, e: 5 }; G = s(o);`,
+        `JSON.stringify(o, null, 2)`,
+      ),
+    ).toBe(want);
+  });
+
+  it("uses a string space (tab) as the indent unit", async () => {
+    const want = JSON.stringify({ a: 1, b: 2 }, null, "\t");
+    expect(
+      await stringifyDynamicSpace(`let o: any = { a: 1, b: 2 }; G = s(o);`, `JSON.stringify(o, null, "\\t")`),
+    ).toBe(want);
+  });
+
+  it("uses a multi-char string space", async () => {
+    const want = JSON.stringify({ a: 1, b: 2 }, null, "xy");
+    expect(
+      await stringifyDynamicSpace(`let o: any = { a: 1, b: 2 }; G = s(o);`, `JSON.stringify(o, null, "xy")`),
+    ).toBe(want);
+  });
+
+  it("clamps a numeric space > 10 to 10 spaces (§25.5.2)", async () => {
+    const want = JSON.stringify({ x: 1 }, null, 15);
+    expect(await stringifyDynamicSpace(`let o: any = { x: 1 }; G = s(o);`, `JSON.stringify(o, null, 15)`)).toBe(want);
+  });
+
+  it("space 0 produces the compact form (no indentation)", async () => {
+    const want = JSON.stringify({ a: 1, b: 2 }, null, 0);
+    expect(await stringifyDynamicSpace(`let o: any = { a: 1, b: 2 }; G = s(o);`, `JSON.stringify(o, null, 0)`)).toBe(
+      want,
+    );
+    expect(want).toBe('{"a":1,"b":2}');
+  });
+
+  it("indents a null property value", async () => {
+    const want = JSON.stringify({ n: null, x: 1 }, null, 2);
+    expect(
+      await stringifyDynamicSpace(`let o: any = { n: null, x: 1 }; G = s(o);`, `JSON.stringify(o, null, 2)`),
+    ).toBe(want);
+  });
+
+  it("keeps an empty object compact even with a space (§25.5.2)", async () => {
+    const want = JSON.stringify({ a: {}, b: 2 }, null, 2);
+    expect(
+      await stringifyDynamicSpace(`const e: any = {}; let o: any = { a: e, b: 2 }; G = s(o);`, `JSON.stringify(o, null, 2)`),
+    ).toBe(want);
+  });
+
+  it("stays host-import-free under --target wasi with a space arg", async () => {
+    // As with PR-A, the wasi object-rep differs, so only assert no host-import
+    // leak (the assertion lives inside stringifyDynamicSpace).
+    await stringifyDynamicSpace(`let o: any = { x: 1, y: 2 }; G = s(o);`, `JSON.stringify(o, null, 2)`, "wasi");
+  });
+
+  it("a 1-arg dynamic stringify stays compact (PR-A regression guard)", async () => {
+    expect(await stringifyDynamicSpace(`let o: any = { a: 1, b: 2 }; G = s(o);`, `JSON.stringify(o)`)).toBe(
+      '{"a":1,"b":2}',
+    );
+  });
+});

--- a/tests/issue-2166.test.ts
+++ b/tests/issue-2166.test.ts
@@ -339,9 +339,9 @@ describe("#2166 PR-B — standalone dynamic object-graph JSON.stringify indentat
 
   it("uses a multi-char string space", async () => {
     const want = JSON.stringify({ a: 1, b: 2 }, null, "xy");
-    expect(
-      await stringifyDynamicSpace(`let o: any = { a: 1, b: 2 }; G = s(o);`, `JSON.stringify(o, null, "xy")`),
-    ).toBe(want);
+    expect(await stringifyDynamicSpace(`let o: any = { a: 1, b: 2 }; G = s(o);`, `JSON.stringify(o, null, "xy")`)).toBe(
+      want,
+    );
   });
 
   it("clamps a numeric space > 10 to 10 spaces (§25.5.2)", async () => {
@@ -359,15 +359,18 @@ describe("#2166 PR-B — standalone dynamic object-graph JSON.stringify indentat
 
   it("indents a null property value", async () => {
     const want = JSON.stringify({ n: null, x: 1 }, null, 2);
-    expect(
-      await stringifyDynamicSpace(`let o: any = { n: null, x: 1 }; G = s(o);`, `JSON.stringify(o, null, 2)`),
-    ).toBe(want);
+    expect(await stringifyDynamicSpace(`let o: any = { n: null, x: 1 }; G = s(o);`, `JSON.stringify(o, null, 2)`)).toBe(
+      want,
+    );
   });
 
   it("keeps an empty object compact even with a space (§25.5.2)", async () => {
     const want = JSON.stringify({ a: {}, b: 2 }, null, 2);
     expect(
-      await stringifyDynamicSpace(`const e: any = {}; let o: any = { a: e, b: 2 }; G = s(o);`, `JSON.stringify(o, null, 2)`),
+      await stringifyDynamicSpace(
+        `const e: any = {}; let o: any = { a: e, b: 2 }; G = s(o);`,
+        `JSON.stringify(o, null, 2)`,
+      ),
     ).toBe(want);
   });
 


### PR DESCRIPTION
## Summary

PR-B of the #2166 standalone JSON Phase-2 codec. Threads §25.5.2 pretty-printing through the pure-Wasm **dynamic** object-graph stringify codec. PR-A serialised runtime-built graphs **compactly only** — any `space` argument forced the #1599 standalone refusal (the static-fold path owns only the static-value form, which a runtime graph never reaches).

## Changes

- **`src/codegen/json-codec-native.ts`** — `__json_stringify_value` gains a `gap: ref null $AnyString` param (the per-level indent unit). A **null** gap = compact (PR-A behaviour, **byte-identical** output, zero added work). A non-null gap drives indentation: each call computes `L_NL_IN`/`L_NL_OUT`/`L_COLON` separators once via `__str_repeat`. Empty object/array stay `{}`/`[]` per §25.5.2. New `__json_stringify_root_indent(v, gap)` entry.
- **`src/codegen/json-standalone.ts`** — export `staticSpaceValue`; add `jsonGapFromStaticSpace` (number → `min(10,floor(n))` spaces; string → first 10 chars; ≤0/"" → compact).
- **`src/codegen/expressions/calls.ts`** — the dynamic-graph branch resolves a **static** `space` to the gap and routes to `__json_stringify_root_indent` (or the compact root for an empty gap). A function/array replacer or a **dynamic** space keeps the #1599 refusal (no silent wrong output).

## Tests

`tests/issue-2166.test.ts` +12 PR-B cases (flat/nested/deeply-nested object, numeric space 2, string/tab + multi-char space, numeric-space>10 clamp, space 0 = compact, null value, empty nested object stays compact, `--target wasi` host-import-free, 1-arg compact PR-A regression guard). Each result is read back char-by-char and compared to **Node's own** `JSON.stringify(value, null, space)` for exact parity. #1599/#1636 refuse suites stay green; two pre-existing host-mode `json.test.ts` failures are upstream (verified by stashing).

## Scope notes

Orthogonal to PR-C (#1657 parse) / PR-C2 (#1658 array indexing) — those touch parse/property-access; PR-B only touches stringify. The array *indent* arm is implemented and activates for `$ObjVec` arrays; a literal `number[]` isn't an `$ObjVec` (PR-A2, still refused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)