### PR TITLE
feat(#2166 PR-D1): standalone JSON.parse reviver (pure-Wasm InternalizeJSONProperty)

### DIFF
--- a/plan/issues/2166-standalone-json-residual.md
+++ b/plan/issues/2166-standalone-json-residual.md
@@ -544,3 +544,137 @@ This is multi-PR and overlaps #1636 (`__call_fn_method`) + #2042 (instance-field
 reflection), so it's tracked as the **architect-scoped follow-up (TaskList #32)**
 rather than appended to this issue's dev queue. The compiler primitives are
 in place; the work is the codec-side plumbing + the InternalizeJSONProperty walk.
+
+---
+
+## Implementation Plan (PR-D: reviver / toJSON / replacer) — sdev-json3, 2026-06-17
+
+> Architect spec for TaskList #32, written against `upstream/main` @ the #1661
+> merge. The other 4 codec slices are landed. PR-D is **dev-tractable in
+> standalone** — it reuses the existing `__call_fn_method_N` closure-invocation
+> machinery (already used standalone by accessor drivers + Proxy bridges via the
+> reserve/fill pattern). Sliced into D1 (reviver), D2 (`toJSON`), D3 (function/
+> array replacer); D1 is the most self-contained and lands first.
+
+### Shared infrastructure (used by all three slices)
+
+**The closure-call driver (reserve/fill).** `__call_fn_method_N` is an *export*
+emitted in FINALIZE (`emitClosureMethodCallExportN`, index.ts ~3367) only when a
+closure of arity ≤ N exists. Signature:
+`(thisVal: externref, closure: externref, arg0: externref, … : externref) -> externref`
+— it stores `thisVal` into the `__current_this` global across the inner
+`call_ref` (so the reviver/replacer/`toJSON` observes the right `this`). The
+codec is emitted LAZILY during call-expression codegen, before the dispatcher
+exists, so it cannot bake the dispatcher's funcIdx. Use the **proven reserve/
+fill driver** pattern (`accessor-driver.ts` `reserveAccessorGetDriver` /
+`fillAccessorDrivers`, mirrored from #1719):
+- At codec-emit time, reserve `__call_reviver` (D1) / `__call_to_json` (D2) /
+  `__call_replacer` (D3) placeholder funcs (bare `unreachable` body), funcIdx
+  fixed by append position + registered in `funcMap`; the codec emits a plain
+  `call <reserved funcIdx>`.
+- In post-processing (after `emitClosureMethodCallExportN`), fill each body as a
+  thin wrapper around `__call_fn_method_2` (reviver: `this`=holder, args key+
+  value) / `__call_fn_method_1` (`toJSON`/replacer arity-1 forms). Route through
+  `funcMap` (NOT a raw number) so `shiftLateImportIndices` patches it across
+  late-import shifts (#329/#1899 contract).
+- Guard: if no arity-2 (resp. arity-1) closure exists in the module,
+  `__call_fn_method_2` is never emitted → the fill step must degrade the driver
+  to "return value unchanged" (reviver identity / no replacer) rather than dangle.
+
+**Value ↔ externref marshalling.** Parsed members are `$Object`/`$ObjVec`/
+`$__box_*`/`$AnyString`/null as `anyref`; the reviver sees them as `externref`
+(`extern.convert_any`), and its result comes back `externref` →
+`any.convert_extern` to re-store. Boxed primitives round-trip as-is.
+
+### PR-D1 — `JSON.parse(text, reviver)` (§25.5.1 InternalizeJSONProperty)
+
+**Routing (`calls.ts`, the `method === "parse"` standalone block ~6088):** lift
+the `expr.arguments.length === 1` gate. When a 2nd arg is present and is a
+function-typed reviver, compile arg0 → externref AND arg1 (reviver) → externref,
+then call a new `__json_parse_text_reviver(text, reviver) -> anyref`. A
+non-function 2nd arg (e.g. an accidental object) keeps the refusal.
+
+**Codec (`json-codec-native.ts`), new `emitJsonParseTextReviver`:**
+1. `val = __json_parse_text(text)` — reuse the existing parser unchanged.
+2. Build the §25.5.1 root holder: `root = {"": val}` via `__new_plain_object` +
+   `__extern_set("", val)`.
+3. `return __internalize_json_property(root, "", reviver)`.
+
+**New recursive `__internalize_json_property(holder: externref, key: $AnyString,
+reviver: externref) -> externref`** (§25.5.1 InternalizeJSONProperty):
+- `val = __extern_get(holder, key)`.
+- If `val` is a `$Object`: for each own key `k` (snapshot via `__obj_ordered` —
+  take the key list FIRST since the walk mutates), `elem =
+  __internalize_json_property(val, k, reviver)`; if `elem` is `undefined`
+  (the reviver's delete sentinel) → `__delete_property(val, k)` else
+  `__extern_set(val, k, elem)`.
+- If `val` is a `$ObjVec`: same, iterating numeric indices `0..len-1` with string
+  keys; a deleted element becomes a hole → set to the parsed `undefined`/null per
+  §25.5.1 step 2.b.ii (CreateDataProperty of undefined).
+- Finally: `return __call_reviver(holder, key, val)` — the driver calls
+  `reviver.call(holder, key, val)`. The reviver's `undefined` return propagates
+  up as the delete sentinel.
+
+**Edge cases:** key order is the snapshot taken before recursion (a reviver that
+adds keys does not see them — §25.5.1); `this` inside the reviver is the holder
+(threaded by `__call_fn_method_2` via `__current_this`); a reviver returning the
+value unchanged is the identity (round-trip safe).
+
+**Tests (`tests/issue-2166.test.ts`):** reviver doubling numbers, dropping a key
+(undefined return), `this[key]` access in the reviver, nested-graph transform,
+array-element reviver, identity reviver round-trip, `--target wasi`. Compare the
+internal result (native strings don't marshal across the boundary).
+
+### PR-D2 — `toJSON` (§25.5.2 SerializeJSONProperty step 2)
+In `__json_stringify_value`, before the `$Object`/instance arms: `HasProperty`-
+check `toJSON` (via `__extern_get` of the method, ref-test for a closure); if
+present, `val = __call_to_json(val /*this*/, key)` (`__call_fn_method_1`) and
+serialise the result instead. Reserve/fill `__call_to_json` as above.
+
+### PR-D3 — function / array replacer (§25.5.2 steps 2.b / 3)
+Thread the replacer closure-ref / key-array into the stringify root; in the
+object/array arms call `replacer.call(holder, key, val)` (function form, via
+`__call_replacer` → `__call_fn_method_2`) or filter keys to the array form.
+Larger; lands last.
+
+---
+
+## Progress (2026-06-18, sdev-json3) — PR-D1: standalone JSON.parse reviver
+
+PR-D1 of the PR-D plan above. `JSON.parse(text, reviver)` now runs the §25.5.1
+InternalizeJSONProperty walk entirely in Wasm under `--target standalone`/`wasi`
+(previously refused). Implements the shared closure-call infrastructure the rest
+of PR-D (toJSON/replacer) will reuse.
+
+**Files:**
+- `src/codegen/accessor-driver.ts` — new `reserveReviverDriver` + a fill arm in
+  `fillAccessorDrivers`: the `__call_reviver(holder, reviver, key, value)` driver
+  wraps `__call_fn_method_2` (holder bound as `this`). Reserve/fill funcIdx-
+  authority pattern (shiftLateImportIndices-safe), identical to the accessor
+  drivers. Degrades to an identity (returns value) when no arity-2 closure exists.
+- `src/codegen/context/types.ts` — `reviverDriverReserved` flag.
+- `src/codegen/json-codec-native.ts` — new `emitJsonParseTextReviver`: the entry
+  `__json_parse_text_reviver(text, reviver)` (parse → wrap in root holder `{"":v}`
+  → internalize) and the recursive `__internalize_json_value(val, holder, key,
+  reviver)`. **Key design:** the walker takes the value DIRECTLY (already fetched)
+  — an `$ObjVec` array element can't be re-read via `__extern_get(vec,"i")` (no
+  string-keyed prop), so the object arm fetches children with `__extern_get` and
+  the array arm with `array.get`. Object: undefined return → `__delete_property`;
+  else `__extern_set`. Array: result written back via `array.set` in place.
+- `src/codegen/expressions/calls.ts` — routing: lift the 1-arg gate to accept a
+  2nd arg; a *callable* reviver compiles via the GC-closure path
+  (`compileArrowAsClosure`, NOT `__make_callback` — the host bridge leaks an
+  `env::` import and its JS wrapper fails the `__call_fn_method_2` ref.cast) and
+  routes to the reviver codec; a null/non-callable 2nd arg is IGNORED (§25.5.1
+  IsCallable gate) → plain parse. Also skip the static-literal fold when a 2nd
+  arg is present (it ignored the reviver, e.g. `JSON.parse('5', r)`).
+
+Tests: `tests/issue-2166.test.ts` (+9 PR-D1 cases — number transform, identity
+round-trip, key delete (undefined return), nested bottom-up transform, array-
+element transform, top-level primitive, string passthrough, null-reviver-ignored,
+`--target wasi`). All host-import-free (asserted). 61/61 in the suite green;
+#1599/#1636 refuse + PR-C2 suites unaffected. The one #2042 numeric-key failure
+is pre-existing on the base (verified by stashing).
+
+**Remaining PR-D:** D2 (`toJSON`) + D3 (function/array replacer) — same driver
+infra, on the stringify side.

--- a/src/codegen/accessor-driver.ts
+++ b/src/codegen/accessor-driver.ts
@@ -42,6 +42,11 @@ import { addFuncType } from "./registry/types.js";
 export const CALL_ACCESSOR_GET = "__call_accessor_get";
 /** Reserved name for the accessor-set driver (arity-1 setter wrapper). */
 export const CALL_ACCESSOR_SET = "__call_accessor_set";
+/**
+ * (#2166 PR-D1) Reserved name for the JSON reviver driver (arity-2 method
+ * wrapper: `reviver.call(holder, key, value)`).
+ */
+export const CALL_REVIVER = "__call_reviver";
 
 /**
  * Reserve the `__call_accessor_get` driver placeholder and return its funcIdx.
@@ -114,6 +119,46 @@ export function reserveAccessorSetDriver(ctx: CodegenContext): number {
 }
 
 /**
+ * (#2166 PR-D1) Reserve the `__call_reviver` driver placeholder and return its
+ * funcIdx.
+ *
+ * Signature: `(externref holder, externref key, externref value) -> externref`.
+ * Filled by `fillAccessorDrivers` to wrap `__call_fn_method_2(holder, reviver,
+ * key, value)` — but note the reviver closure itself is NOT a driver param: the
+ * §25.5.1 walk threads it separately and the driver receives `holder` as the
+ * `this` and `key`/`value` as the two reviver args, with the reviver closure
+ * passed as the dispatcher's 2nd operand by the codec via a 4th hidden param.
+ * To keep the driver arity fixed we instead make the reviver the FIRST arg and
+ * holder the receiver: see `fillAccessorDrivers`. Idempotent.
+ */
+export function reserveReviverDriver(ctx: CodegenContext): number {
+  const existing = ctx.funcMap.get(CALL_REVIVER);
+  if (existing !== undefined) return existing;
+  // (holder, reviver, key, value) -> externref. holder is bound as `this`.
+  const sigIdx = addFuncType(
+    ctx,
+    [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }, { kind: "externref" }],
+    [{ kind: "externref" }],
+    "$call_reviver_type",
+  );
+  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const placeholder: WasmFunction = {
+    name: CALL_REVIVER,
+    typeIdx: sigIdx,
+    // Placeholder; filled by fillAccessorDrivers once __call_fn_method_2 exists.
+    // A bare `unreachable` keeps the stub valid (externref result) if the fill
+    // is skipped (no arity-2 closure ⇒ no reviver could have been passed).
+    locals: [],
+    body: [{ op: "unreachable" } as Instr],
+    exported: false,
+  };
+  ctx.mod.functions.push(placeholder);
+  ctx.funcMap.set(CALL_REVIVER, funcIdx);
+  ctx.reviverDriverReserved = true;
+  return funcIdx;
+}
+
+/**
  * Fill the reserved accessor driver bodies in post-processing, AFTER
  * `emitClosureMethodCallExportN(0)` / `(1)` have registered
  * `__call_fn_method_0` / `__call_fn_method_1` in `funcMap`. Each driver is a
@@ -176,6 +221,33 @@ export function fillAccessorDrivers(ctx: CodegenContext): void {
             // __call_fn_method_1 returns an externref result; the setter's
             // return value is discarded per §10.1.5.3 (Set ignores it).
             { op: "drop" } as Instr,
+          ];
+        }
+      }
+    }
+  }
+
+  // (#2166 PR-D1) JSON reviver driver: holder bound as `this`, key+value the two
+  // reviver args. Wraps __call_fn_method_2(holder, reviver, key, value).
+  if (ctx.reviverDriverReserved) {
+    const driverIdx = ctx.funcMap.get(CALL_REVIVER);
+    if (driverIdx !== undefined) {
+      const driverFn = ctx.mod.functions[driverIdx - ctx.numImportFuncs];
+      if (driverFn) {
+        const callMethod2 = ctx.funcMap.get("__call_fn_method_2");
+        if (callMethod2 === undefined) {
+          // No arity-2 closure dispatcher ⇒ no reviver closure could have been
+          // passed; the driver is unreachable from any live walk. Keep a valid
+          // identity body: return the value arg unchanged (externref result).
+          driverFn.body = [{ op: "local.get", index: 3 } as Instr];
+        } else {
+          driverFn.body = [
+            { op: "local.get", index: 0 } as Instr, // holder (bound as `this`)
+            { op: "local.get", index: 1 } as Instr, // reviver closure
+            { op: "local.get", index: 2 } as Instr, // key (arg0)
+            { op: "local.get", index: 3 } as Instr, // value (arg1)
+            { op: "call", funcIdx: callMethod2 } as Instr,
+            // result (reviver's return, externref) is this driver's result
           ];
         }
       }

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -735,6 +735,13 @@ export interface CodegenContext {
   accessorGetDriverReserved?: boolean;
   accessorSetDriverReserved?: boolean;
   /**
+   * (#2166 PR-D1) True once the standalone `JSON.parse(text, reviver)` codec
+   * reserved its `__call_reviver(holder, key, value) -> externref` driver
+   * funcIdx — filled in finalize to wrap `__call_fn_method_2`. Same reserve/fill
+   * funcIdx-authority pattern as the accessor drivers above.
+   */
+  reviverDriverReserved?: boolean;
+  /**
    * (#1888 Slice 1) True once the standalone open-any method-dispatch bridge
    * `__apply_closure(fn, recv, args) -> externref` has reserved its funcIdx via
    * a placeholder function pushed during `ensureObjectRuntime` (registered in

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -72,7 +72,7 @@ import {
   tryEmitJsonStringifyStatic,
 } from "../json-standalone.js";
 import { emitJsonParsePrimitive, emitJsonQuoteString } from "../json-runtime.js";
-import { emitJsonParseText, emitJsonStringifyValue } from "../json-codec-native.js";
+import { emitJsonParseText, emitJsonParseTextReviver, emitJsonStringifyValue } from "../json-codec-native.js";
 import {
   compileObjectDefineProperties,
   compileObjectDefineProperty,
@@ -6068,9 +6068,14 @@ function compileCallExpression(
           }
         }
         if (method === "parse" && (ctx.standalone || ctx.wasi)) {
-          const parsedType = tryEmitJsonParseLiteral(ctx, fctx, expr);
-          if (parsedType !== undefined) {
-            return parsedType;
+          // (#2166 PR-D1) The static-literal fold ignores a reviver — skip it
+          // when a 2nd arg is present so `JSON.parse('5', reviver)` runs the
+          // reviver walk instead of folding to the bare parsed value.
+          if (expr.arguments.length < 2) {
+            const parsedType = tryEmitJsonParseLiteral(ctx, fctx, expr);
+            if (parsedType !== undefined) {
+              return parsedType;
+            }
           }
           // (#2166 PR-C) Dynamic-graph JSON.parse: a runtime JSON *text* →
           // object / array / string / primitive value, parsed entirely in Wasm
@@ -6083,9 +6088,9 @@ function compileCallExpression(
           // number / true / false / null and *traps* on `{`/`[`/`"` — so it
           // takes over the whole runtime-string case (the primitive helper
           // stays for any caller that still routes to it directly). A `reviver`
-          // (2nd arg) is deferred to PR-D: refuse it rather than silently ignore
-          // it (§25.5.1 InternalizeJSONProperty is a post-parse walk).
-          if (expr.arguments.length === 1) {
+          // (#2166 PR-D1) A `reviver` (2nd arg) routes to the reviver codec when
+          // it is a function; a non-function 2nd arg keeps the refusal below.
+          if (expr.arguments.length === 1 || expr.arguments.length === 2) {
             let parseArgType: ts.Type | undefined;
             try {
               parseArgType = ctx.checker.getTypeAtLocation(expr.arguments[0]!);
@@ -6099,11 +6104,53 @@ function compileCallExpression(
             const isStringOrAny =
               parseArgType === undefined ||
               (parseArgType.flags & (ts.TypeFlags.StringLike | ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
+            // A reviver is honoured only when it is callable (has call
+            // signatures). A null / undefined / any other non-callable 2nd arg
+            // is simply IGNORED per §25.5.1 (the reviver step is IsCallable-
+            // gated) — route through the plain parse path, never refuse. This
+            // matches the host JSON.parse behaviour for a non-function reviver.
+            const reviverArg = expr.arguments[1];
+            let reviverCallable = false;
+            if (reviverArg !== undefined) {
+              try {
+                reviverCallable = ctx.checker.getTypeAtLocation(reviverArg).getCallSignatures().length > 0;
+              } catch {
+                reviverCallable = false;
+              }
+            }
             if (isStringOrAny) {
               const argResult = compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "externref" });
               if (argResult === null) return null;
               if (argResult.kind !== "externref") {
                 coerceType(ctx, fctx, argResult, { kind: "externref" });
+              }
+              if (reviverCallable) {
+                // text already on the stack as externref; push the reviver as a
+                // GC closure widened to externref. CRITICAL: compile the closure
+                // via the GC-struct path (`compileArrowAsClosure`), NOT
+                // `compileExpression(..., externref)` — the latter routes an
+                // inline arrow at this non-user call site through the host
+                // `__make_callback` bridge (an `env::` import that breaks
+                // standalone and whose JS wrapper fails the `__call_fn_method_2`
+                // ref.cast). The driver consumes the GC closure as externref via
+                // extern.convert_any.
+                const revResult =
+                  ts.isArrowFunction(reviverArg!) || ts.isFunctionExpression(reviverArg!)
+                    ? compileArrowAsClosure(ctx, fctx, reviverArg!)
+                    : compileExpression(ctx, fctx, reviverArg!, { kind: "anyref" });
+                if (revResult === null) return null;
+                if (revResult.kind === "ref" || revResult.kind === "ref_null" || revResult.kind === "anyref") {
+                  fctx.body.push({ op: "extern.convert_any" } as Instr);
+                } else if (revResult.kind !== "externref") {
+                  coerceType(ctx, fctx, revResult, { kind: "externref" });
+                }
+                emitJsonParseTextReviver(ctx);
+                flushLateImportShifts(ctx, fctx);
+                fctx.body.push({
+                  op: "call",
+                  funcIdx: ctx.funcMap.get("__json_parse_text_reviver")!,
+                } as Instr);
+                return { kind: "anyref" };
               }
               emitJsonParseText(ctx);
               flushLateImportShifts(ctx, fctx);

--- a/src/codegen/json-codec-native.ts
+++ b/src/codegen/json-codec-native.ts
@@ -55,6 +55,7 @@ import { addFuncType } from "./registry/types.js";
 import { emitJsonQuoteString } from "./json-runtime.js";
 import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
 import { emitWasiErrorConstructor } from "./registry/error-types.js";
+import { reserveReviverDriver } from "./accessor-driver.js";
 
 const EQ_HEAP_TYPE = -19; // signed LEB128 → 0x6d → TYPE.eq (for ref.null any/eq)
 
@@ -2074,4 +2075,326 @@ export function emitJsonParseText(ctx: CodegenContext): number {
   } as unknown as (typeof ctx.mod.functions)[number]);
 
   return textFuncIdx;
+}
+
+/**
+ * (#2166 PR-D1) Emit the standalone `JSON.parse(text, reviver)` codec —
+ * `__json_parse_text_reviver(text: externref, reviver: externref) -> anyref` —
+ * and the recursive §25.5.1 InternalizeJSONProperty walk
+ * `__internalize_json_property(holder: externref, key: externref,
+ * reviver: externref) -> externref`. Idempotent. Standalone / WASI only.
+ *
+ * The reviver itself is a USER closure (externref). It is invoked via the
+ * reserve/fill `__call_reviver` driver (accessor-driver.ts) which wraps
+ * `__call_fn_method_2(holder, reviver, key, value)` — binding `holder` as `this`
+ * and passing `key`/`value` as the two reviver args (§25.5.1 step 2.c). The fill
+ * runs in finalize after `__call_fn_method_2` is registered; when no arity-2
+ * closure exists the driver degrades to an identity (returns the value), so a
+ * module with no reviver closure still verifies.
+ *
+ * Walk (§25.5.1 InternalizeJSONProperty(holder, key, reviver)):
+ *   val = holder[key]
+ *   if val is an Object: for each own key k (snapshot taken BEFORE recursion,
+ *     §25.5.1 step 2.a.i — a reviver that adds keys doesn't see them):
+ *       elem = InternalizeJSONProperty(val, k, reviver)
+ *       if elem is undefined → delete val[k]   else → val[k] = elem
+ *   if val is an Array ($ObjVec): same over numeric indices with string keys.
+ *   return reviver.call(holder, key, val)
+ *
+ * Returns the funcIdx of `__json_parse_text_reviver`.
+ */
+export function emitJsonParseTextReviver(ctx: CodegenContext): number {
+  const existing = ctx.funcMap.get("__json_parse_text_reviver");
+  if (existing !== undefined) return existing;
+
+  // Dependencies (all idempotent). The base parser + object runtime + the
+  // number formatter (for array index → string keys) + the reviver driver.
+  const parseTextIdx = emitJsonParseText(ctx);
+  ensureNativeStringHelpers(ctx);
+  const objTypes = ensureObjectRuntime(ctx);
+  emitNativeNumberFormat(ctx, new Set(["number_toString"]));
+  const reviverDriverIdx = reserveReviverDriver(ctx);
+
+  const newObjIdx = ctx.funcMap.get("__new_plain_object")!;
+  const externSetIdx = ctx.funcMap.get("__extern_set")!;
+  const externGetIdx = ctx.funcMap.get("__extern_get")!;
+  const deleteIdx = ctx.funcMap.get("__delete_property")!;
+  const orderedIdx = ctx.funcMap.get("__obj_ordered")!;
+  const numToStrIdx = ctx.funcMap.get("number_toString")!;
+
+  const i32: ValType = { kind: "i32" };
+  const f64: ValType = { kind: "f64" };
+  const anyref: ValType = { kind: "anyref" };
+  const externref: ValType = { kind: "externref" };
+
+  const objectTypeIdx = objTypes.objectTypeIdx;
+  const propMapTypeIdx = objTypes.propMapTypeIdx;
+  const propEntryTypeIdx = objTypes.propEntryTypeIdx;
+  const objVecTypeIdx = objTypes.objVecTypeIdx;
+  const objVecArrTypeIdx = objTypes.objVecArrTypeIdx;
+  const anyStrTypeIdx = ctx.anyStrTypeIdx;
+
+  // Pre-register the recursive internalize funcIdx so the body can call itself.
+  // (#2166 PR-D1) Signature takes the VALUE directly (already fetched by the
+  // caller) plus the holder+key for the reviver's `this`/key args. This is
+  // load-bearing: an `$ObjVec` array element CANNOT be re-read via
+  // `__extern_get(holder, "i")` (the vec has no string-keyed property), so each
+  // arm fetches its child with the right primitive (`__extern_get` for object
+  // props, `array.get` for array elements) and passes the value in.
+  //
+  // __internalize_json_value(val, holder, key, reviver) -> externref
+  const internTypeIdx = addFuncType(ctx, [externref, externref, externref, externref], [externref]);
+  const internFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  ctx.funcMap.set("__internalize_json_value", internFuncIdx);
+
+  // params: 0=val 1=holder 2=key 3=reviver
+  const P_VAL = 0;
+  const P_HOLDER = 1;
+  const P_KEY = 2;
+  const P_REVIVER = 3;
+  const L_ANY = 4; // anyref — val widened for ref.test
+  const L_ARR = 5; // ref null $PropMap — ordered key snapshot
+  const L_CAP = 6; // i32 — loop bound
+  const L_I = 7; // i32 — loop index
+  const L_E = 8; // ref null $PropEntry
+  const L_K = 9; // externref — current child key
+  const L_CHILD = 10; // externref — child value (pre-reviver)
+  const L_ELEM = 11; // externref — internalized child value
+  const L_VEC = 12; // ref null $ObjVec
+  const L_DATA = 13; // ref $ObjVecArr
+  const L_OBJREF = 14; // externref — the $Object/$ObjVec value re-as-externref
+
+  const internBody: Instr[] = [
+    // any = any.convert_extern(val)
+    { op: "local.get", index: P_VAL },
+    { op: "any.convert_extern" },
+    { op: "local.set", index: L_ANY },
+    // ── $Object arm ───────────────────────────────────────────────────────
+    { op: "local.get", index: L_ANY },
+    { op: "ref.test", typeIdx: objectTypeIdx },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        // objref = val (the object, as externref holder for its children)
+        { op: "local.get", index: P_VAL },
+        { op: "local.set", index: L_OBJREF },
+        // arr = __obj_ordered(cast<$Object>(any))  — snapshot BEFORE recursion
+        { op: "local.get", index: L_ANY },
+        { op: "ref.cast", typeIdx: objectTypeIdx },
+        { op: "call", funcIdx: orderedIdx },
+        { op: "local.set", index: L_ARR },
+        { op: "local.get", index: L_ARR },
+        { op: "array.len" },
+        { op: "local.set", index: L_CAP },
+        { op: "i32.const", value: 0 },
+        { op: "local.set", index: L_I },
+        {
+          op: "block",
+          blockType: { kind: "empty" },
+          body: [
+            {
+              op: "loop",
+              blockType: { kind: "empty" },
+              body: [
+                { op: "local.get", index: L_I },
+                { op: "local.get", index: L_CAP },
+                { op: "i32.ge_s" },
+                { op: "br_if", depth: 1 },
+                // e = arr[i]; ordered array is compacted — stop at first null
+                { op: "local.get", index: L_ARR },
+                { op: "local.get", index: L_I },
+                { op: "array.get", typeIdx: propMapTypeIdx },
+                { op: "local.tee", index: L_E },
+                { op: "ref.is_null" },
+                { op: "br_if", depth: 1 },
+                // k = extern.convert_any(e.key)
+                { op: "local.get", index: L_E },
+                { op: "ref.as_non_null" },
+                { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 0 }, // key: ref $AnyString
+                { op: "extern.convert_any" },
+                { op: "local.set", index: L_K },
+                // child = __extern_get(objref, k)
+                { op: "local.get", index: L_OBJREF },
+                { op: "local.get", index: L_K },
+                { op: "call", funcIdx: externGetIdx },
+                { op: "local.set", index: L_CHILD },
+                // elem = __internalize_json_value(child, objref, k, reviver)
+                { op: "local.get", index: L_CHILD },
+                { op: "local.get", index: L_OBJREF },
+                { op: "local.get", index: L_K },
+                { op: "local.get", index: P_REVIVER },
+                { op: "call", funcIdx: internFuncIdx },
+                { op: "local.set", index: L_ELEM },
+                // if elem is undefined (null externref) → delete; else set
+                { op: "local.get", index: L_ELEM },
+                { op: "ref.is_null" },
+                {
+                  op: "if",
+                  blockType: { kind: "empty" },
+                  then: [
+                    { op: "local.get", index: L_OBJREF },
+                    { op: "local.get", index: L_K },
+                    { op: "call", funcIdx: deleteIdx },
+                    { op: "drop" },
+                  ],
+                  else: [
+                    { op: "local.get", index: L_OBJREF },
+                    { op: "local.get", index: L_K },
+                    { op: "local.get", index: L_ELEM },
+                    { op: "call", funcIdx: externSetIdx },
+                  ],
+                },
+                { op: "local.get", index: L_I },
+                { op: "i32.const", value: 1 },
+                { op: "i32.add" },
+                { op: "local.set", index: L_I },
+                { op: "br", depth: 0 },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    // ── $ObjVec (array) arm ───────────────────────────────────────────────
+    { op: "local.get", index: L_ANY },
+    { op: "ref.test", typeIdx: objVecTypeIdx },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: L_ANY },
+        { op: "ref.cast", typeIdx: objVecTypeIdx },
+        { op: "local.tee", index: L_VEC },
+        { op: "struct.get", typeIdx: objVecTypeIdx, fieldIdx: 1 }, // data
+        { op: "local.set", index: L_DATA },
+        { op: "local.get", index: L_VEC },
+        { op: "struct.get", typeIdx: objVecTypeIdx, fieldIdx: 0 }, // len
+        { op: "local.set", index: L_CAP },
+        { op: "i32.const", value: 0 },
+        { op: "local.set", index: L_I },
+        {
+          op: "block",
+          blockType: { kind: "empty" },
+          body: [
+            {
+              op: "loop",
+              blockType: { kind: "empty" },
+              body: [
+                { op: "local.get", index: L_I },
+                { op: "local.get", index: L_CAP },
+                { op: "i32.ge_s" },
+                { op: "br_if", depth: 1 },
+                // k = number_toString(f64(i))  — array index → string key
+                { op: "local.get", index: L_I },
+                { op: "f64.convert_i32_s" },
+                { op: "call", funcIdx: numToStrIdx },
+                { op: "local.set", index: L_K },
+                // child = data[i]  (read the element directly — NOT via __extern_get)
+                { op: "local.get", index: L_DATA },
+                { op: "local.get", index: L_I },
+                { op: "array.get", typeIdx: objVecArrTypeIdx },
+                { op: "local.set", index: L_CHILD },
+                // elem = __internalize_json_value(child, val, k, reviver)
+                { op: "local.get", index: L_CHILD },
+                { op: "local.get", index: P_VAL },
+                { op: "local.get", index: L_K },
+                { op: "local.get", index: P_REVIVER },
+                { op: "call", funcIdx: internFuncIdx },
+                { op: "local.set", index: L_ELEM },
+                // §25.5.1 step 2.b.ii: a non-undefined result replaces the
+                // element in place; undefined → CreateDataProperty(undefined)
+                // (store the null externref / a JSON `null` hole).
+                { op: "local.get", index: L_DATA },
+                { op: "local.get", index: L_I },
+                { op: "local.get", index: L_ELEM },
+                { op: "array.set", typeIdx: objVecArrTypeIdx },
+                { op: "local.get", index: L_I },
+                { op: "i32.const", value: 1 },
+                { op: "i32.add" },
+                { op: "local.set", index: L_I },
+                { op: "br", depth: 0 },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    // ── return reviver.call(holder, key, val) via the driver ──────────────
+    { op: "local.get", index: P_HOLDER }, // holder (this)
+    { op: "local.get", index: P_REVIVER }, // reviver closure
+    { op: "local.get", index: P_KEY }, // key
+    { op: "local.get", index: P_VAL }, // value
+    { op: "call", funcIdx: reviverDriverIdx },
+  ];
+
+  ctx.mod.functions.push({
+    name: "__internalize_json_value",
+    typeIdx: internTypeIdx,
+    locals: [
+      { count: 1, type: anyref }, // L_ANY
+      { count: 1, type: { kind: "ref_null", typeIdx: propMapTypeIdx } }, // L_ARR
+      { count: 1, type: i32 }, // L_CAP
+      { count: 1, type: i32 }, // L_I
+      { count: 1, type: { kind: "ref_null", typeIdx: propEntryTypeIdx } }, // L_E
+      { count: 1, type: externref }, // L_K
+      { count: 1, type: externref }, // L_CHILD
+      { count: 1, type: externref }, // L_ELEM
+      { count: 1, type: { kind: "ref_null", typeIdx: objVecTypeIdx } }, // L_VEC
+      { count: 1, type: { kind: "ref", typeIdx: objVecArrTypeIdx } }, // L_DATA
+      { count: 1, type: externref }, // L_OBJREF
+    ],
+    body: internBody,
+    exported: false,
+  } as unknown as (typeof ctx.mod.functions)[number]);
+
+  // ── __json_parse_text_reviver(text, reviver) -> anyref ────────────────────
+  // val = __json_parse_text(text); root = { "": val };
+  // return any.convert_extern(
+  //          __internalize_json_value(val, root, "", reviver)).
+  const rootTypeIdx = addFuncType(ctx, [externref, externref], [anyref]);
+  const rootFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  ctx.funcMap.set("__json_parse_text_reviver", rootFuncIdx);
+
+  void anyStrTypeIdx;
+  const emptyKey = (): Instr[] => nativeStringLiteralInstrs(ctx, "");
+  const R_ROOT = 2; // externref
+  const R_VAL = 3; // externref — the parsed root value
+
+  const rootBody: Instr[] = [
+    // val = any.convert_extern(__json_parse_text(text))
+    { op: "local.get", index: 0 }, // text
+    { op: "call", funcIdx: parseTextIdx }, // -> anyref value graph
+    { op: "extern.convert_any" },
+    { op: "local.set", index: R_VAL },
+    // root = __new_plain_object(); root[""] = val
+    { op: "call", funcIdx: newObjIdx },
+    { op: "local.set", index: R_ROOT },
+    { op: "local.get", index: R_ROOT },
+    ...emptyKey(),
+    { op: "extern.convert_any" },
+    { op: "local.get", index: R_VAL },
+    { op: "call", funcIdx: externSetIdx },
+    // return any.convert_extern(__internalize_json_value(val, root, "", reviver))
+    { op: "local.get", index: R_VAL },
+    { op: "local.get", index: R_ROOT },
+    ...emptyKey(),
+    { op: "extern.convert_any" },
+    { op: "local.get", index: 1 }, // reviver
+    { op: "call", funcIdx: internFuncIdx },
+    { op: "any.convert_extern" }, // back to anyref (the parse codec's result type)
+  ];
+
+  ctx.mod.functions.push({
+    name: "__json_parse_text_reviver",
+    typeIdx: rootTypeIdx,
+    locals: [
+      { count: 1, type: externref }, // R_ROOT (index 2)
+      { count: 1, type: externref }, // R_VAL (index 3)
+    ],
+    body: rootBody,
+    exported: false,
+  } as unknown as (typeof ctx.mod.functions)[number]);
+
+  return rootFuncIdx;
 }

--- a/tests/issue-2166.test.ts
+++ b/tests/issue-2166.test.ts
@@ -508,3 +508,97 @@ describe("#2166 PR-C — standalone dynamic JSON.parse (object graphs + primitiv
     await expect(parseInternal(`const o: any = JSON.parse('{"x":1} bogus'); return 1;`)).rejects.toThrow();
   });
 });
+
+/*
+ * #2166 PR-D1 — standalone `JSON.parse(text, reviver)` (§25.5.1
+ * InternalizeJSONProperty). After the pure-Wasm parse builds the value graph,
+ * `__internalize_json_value` recursively walks it bottom-up calling
+ * `reviver.call(holder, key, value)` via the reserve/fill `__call_reviver`
+ * driver → `__call_fn_method_2` (so the reviver runs entirely in Wasm — the
+ * closure is a GC struct, NOT a host `__make_callback` bridge). A reviver that
+ * returns `undefined` deletes the property (object) / writes a hole (array);
+ * any other value replaces it.
+ *
+ * The reviver is compiled via the GC-closure path (`compileArrowAsClosure`),
+ * so no `env::*` host import leaks — `parseInternal` already asserts that.
+ */
+describe("#2166 PR-D1 — standalone JSON.parse reviver (InternalizeJSONProperty)", () => {
+  it("transforms number values (reviver doubles every number)", async () => {
+    expect(
+      await parseInternal(
+        `const o: any = JSON.parse('{"a":2,"b":3}', (k: string, v: any) => typeof v === "number" ? (v as number) * 2 : v);
+         return ((o.a as number) + (o.b as number)) === 10 ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("identity reviver round-trips an object graph", async () => {
+    expect(
+      await parseInternal(
+        `const o: any = JSON.parse('{"x":7,"y":{"z":8}}', (k: string, v: any) => v);
+         return ((o.x as number) === 7 && (o.y.z as number) === 8) ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("deletes a property when the reviver returns undefined", async () => {
+    expect(
+      await parseInternal(
+        `const o: any = JSON.parse('{"keep":1,"drop":2}', (k: string, v: any) => k === "drop" ? undefined : v);
+         return (o.keep as number) === 1 ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("transforms a nested object graph bottom-up", async () => {
+    expect(
+      await parseInternal(
+        `const o: any = JSON.parse('{"n":{"v":5}}', (k: string, v: any) => typeof v === "number" ? (v as number) + 1 : v);
+         return (o.n.v as number) === 6 ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("transforms array elements (each gets a string index key)", async () => {
+    expect(
+      await parseInternal(
+        `const o: any = JSON.parse('{"arr":[1,2,3]}', (k: string, v: any) => typeof v === "number" ? (v as number) * 10 : v);
+         return ((o.arr[0] as number) + (o.arr[2] as number)) === 40 ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("applies the reviver to a top-level primitive", async () => {
+    expect(
+      await parseInternal(
+        `const v: any = JSON.parse('5', (k: string, val: any) => typeof val === "number" ? (val as number) + 100 : val);
+         return (v as number) === 105 ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("leaves string values intact through a numeric reviver", async () => {
+    expect(
+      await parseInternal(
+        `const o: any = JSON.parse('{"s":"hi","n":4}', (k: string, v: any) => typeof v === "number" ? (v as number) + 1 : v);
+         return ((o.s as string) === "hi" && (o.n as number) === 5) ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("a null reviver argument is ignored (plain parse)", async () => {
+    expect(
+      await parseInternal(`const o: any = JSON.parse('{"x":7}', null as any); return (o.x as number) === 7 ? 1 : 0;`),
+    ).toBe(1);
+  });
+
+  it("works under --target wasi too (host-import-free)", async () => {
+    expect(
+      await parseInternal(
+        `const o: any = JSON.parse('{"a":2}', (k: string, v: any) => typeof v === "number" ? (v as number) * 3 : v);
+         return (o.a as number) === 6 ? 1 : 0;`,
+        "wasi",
+      ),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

PR-D1 of #2166. `JSON.parse(text, reviver)` now runs the §25.5.1 InternalizeJSONProperty walk **entirely in Wasm** under `--target standalone`/`wasi` (it previously hit the #1599 refusal). This also builds the **closure-invocation-from-codec** infrastructure the rest of PR-D (D2 toJSON, D3 replacer) reuses — confirming the architect feasibility note that PR-D is dev-tractable in standalone, not host-only.

## How it works

- **`src/codegen/accessor-driver.ts`** — `reserveReviverDriver` + a fill arm in `fillAccessorDrivers`. The `__call_reviver(holder, reviver, key, value)` driver wraps `__call_fn_method_2` (holder bound as `this` via `__current_this`). Same reserve/fill funcIdx-authority pattern as the accessor drivers (shiftLateImportIndices-safe); degrades to an identity when no arity-2 closure exists.
- **`src/codegen/json-codec-native.ts`** — `emitJsonParseTextReviver`: entry `__json_parse_text_reviver(text, reviver)` parses, wraps the value in a `{"":v}` root holder, then runs recursive `__internalize_json_value(val, holder, key, reviver)`. **Key design:** the walker takes the value DIRECTLY — an `$ObjVec` array element can't be re-read via `__extern_get(vec,"i")` (no string-keyed prop), so the object arm fetches children via `__extern_get` (undefined return → `__delete_property`, else `__extern_set`) and the array arm via `array.get`/`array.set` in place.
- **`src/codegen/expressions/calls.ts`** — a *callable* reviver compiles via the GC-closure path (`compileArrowAsClosure`, NOT the host `__make_callback` bridge which leaks an `env::` import and fails the dispatcher ref.cast); a null/non-callable 2nd arg is ignored per §25.5.1; the static-literal fold is skipped when a 2nd arg is present.

## Tests

`tests/issue-2166.test.ts` +9 PR-D1 cases (number transform, identity round-trip, key delete on undefined return, nested bottom-up transform, array-element transform, top-level primitive, string passthrough, null-reviver-ignored, `--target wasi`). All host-import-free (asserted). 61/61 in the suite green; #1599/#1636 refuse + PR-C2 suites unaffected. (The one #2042 numeric-key failure is pre-existing on the base — verified by stashing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)