### PR TITLE
ci: refresh coercion-sites baseline (unblock all PRs, #2108)

### DIFF
--- a/scripts/coercion-sites-baseline.json
+++ b/scripts/coercion-sites-baseline.json
@@ -18,7 +18,7 @@
   "codegen/host-import-allowlist.ts": 2,
   "codegen/index.ts": 31,
   "codegen/iterator-native.ts": 2,
-  "codegen/json-codec-native.ts": 3,
+  "codegen/json-codec-native.ts": 6,
   "codegen/map-runtime.ts": 2,
   "codegen/number-format-native.ts": 8,
   "codegen/object-ops.ts": 4,


### PR DESCRIPTION
## Problem

`upstream/main` itself **fails** the quality job's *Coercion-site drift gate (#2108)*: `codegen/json-codec-native.ts: 3 → 6`. The #2166 JSON-codec PRs (stringify-indent, parse codec, reviver) added engine-routed coercions but the baseline wasn't bumped, so **every PR that merges main inherits the drift and fails `quality`** (observed on unrelated PRs e.g. fix-discord-invite, #1595, #1605).

## Fix

`node scripts/check-coercion-sites.mjs --update` — the 3 new sites are all sanctioned engine primitives (`number_toString`, `__unbox_number`, `__extern_toString`, `emitBoolToString`), not a hand-rolled ToString/ToNumber matrix, so this is the intended baseline-refresh path the gate documents. One-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)