### PR TITLE
fix(#28): invoke inline new Promise(executor)

### DIFF
--- a/plan/issues/promise-async-capability-residual.md
+++ b/plan/issues/promise-async-capability-residual.md
@@ -4,7 +4,7 @@ title: "Promise residual: NewPromiseCapability(C) for custom constructors + reso
 status: ready
 sprint: 63
 created: 2026-06-17
-updated: 2026-06-17
+updated: 2026-06-18
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -107,3 +107,62 @@ Run each file in its **own** subprocess — async rejections from the host
 bridge (illegal-cast, bucket 2) escape try/catch onto the microtask queue and
 kill the process otherwise. Failing-file list derived from the baseline JSONL
 filtered to `test/built-ins/Promise` + `status != pass`.
+
+---
+
+## Implementation log (sdev-async2, 2026-06-18) — PR-A: executor invocation
+
+Re-validated on upstream/main @ 916169c87 (after #2026 PR-1b landed). The
+*first* concrete bug is narrower and more fundamental than the
+NewPromiseCapability framing: **the inline `new Promise(executor)` executor was
+never invoked at all** — independent of custom constructors / combinators.
+
+### Root cause (precise)
+
+`isHostCallbackArgument` (`src/codegen/closures.ts`) has a `NewExpression` arm
+that returns `true` for any constructor argument whose callee is not a
+user-defined class. So `new Promise((resolve, reject) => …)` routed its executor
+through the `__make_callback` host-callback path. For an **inline** executor
+that path emitted no `__call_fn_*` closure dispatcher export, so the host
+`Promise_new` import (`new Promise(_maybeWrapCallable(executor, 2, …))`) could
+not turn the wasm closure into a JS-callable — `_maybeWrapCallable` returned the
+raw struct, the executor was never called, and `resolve`/`reject` were
+`undefined`. This is the "executor param stripped + invocation elided" symptom.
+
+Proof: the **pre-assigned** form (`const exec = …; new Promise(exec)`) already
+worked, because the arrow is compiled as a first-class closure at the
+*assignment* site (parent is a VariableDeclaration, not the NewExpression),
+which emits `__call_fn_2`. Bucketed via probes:
+`new Promise(inlineArrow)` → no `__call_fn`/`__is_closure` exports, executor
+not invoked; `const e=…; new Promise(e)` → exports present, executor invoked
+(captured write visible).
+
+### Fix (PR-A — shipped)
+
+In `isHostCallbackArgument`, return `false` for the `Promise` constructor so the
+executor compiles as a first-class **closure** (same working path as the
+assigned form). The host `Promise_new` then wraps it via `__call_fn_2`. Now:
+executor invoked synchronously, captures mutate, `resolve`/`reject` are real
+callable functions, `new Promise(...)` returns a genuine object. Tests:
+`tests/issue-28-promise-executor-invocation.test.ts` (6 cases). No regression in
+`promise-combinators` (its 2 pre-existing `Compile failed` cases fail identically
+with/without this change — a worktree-harness artifact, not this fix).
+
+### Out of scope / follow-ups (still open under this issue / #1042 / #1326)
+
+- **await-resumption / microtask settling.** `resolve(v)` settles the host JS
+  Promise, but a compiled `await p` does not yet resume from it (the async
+  state-machine ↔ host-microtask wiring is #1042/#1326). PR-A fixes the
+  *synchronous* executor protocol only.
+- **Named inline executor** (`new Promise(function exec(resolve){…})`) still
+  fails ("Promise resolver [object Object] is not a function") — a *named*
+  function-expression is registered as a named func, not a first-class closure,
+  so it skips the `__call_fn` path. Anonymous fn-expr and arrow both work.
+  Narrow follow-up, separate from the closure-routing fix.
+- **Standalone (`--target wasi`/`standalone`)** still emits the allowlisted
+  `env.Promise_new` host import — `new Promise` is not yet pure-Wasm (that is the
+  #1326 microtask-queue work). PR-A compiles in standalone (executor is now a
+  proper closure) but a true no-host runtime needs the Wasm-native Promise.
+- **NewPromiseCapability(C) for custom constructors + resolver-element-function
+  object semantics** (the original ~163-fail combinator residual) — unchanged by
+  PR-A; remains the senior-scale body of this issue.

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -1227,6 +1227,19 @@ export function isHostCallbackArgument(node: ts.Node, ctx: CodegenContext): bool
       if (newFuncIdx !== undefined && newFuncIdx >= ctx.numImportFuncs) {
         return false;
       }
+      // (#28) `new Promise(executor)` — the executor must be invoked by the host
+      // `Promise_new` import (which does `new Promise(_maybeWrapCallable(executor,
+      // 2, …))`). The `__make_callback` host-callback path does NOT round-trip
+      // here: an INLINE executor (`new Promise((res, rej) => …)`) routed through
+      // it produced no callable wrapper, so the executor was silently never
+      // invoked (resolve/reject `undefined`). Compiling the executor as a
+      // first-class CLOSURE instead emits the `__call_fn_2` dispatcher that
+      // `_maybeWrapCallable` uses to make the wasm closure JS-callable — the same
+      // path the working `const exec = …; new Promise(exec)` form already takes.
+      // So treat the Promise executor as a closure value, not a host callback.
+      if (ctorName === "Promise") {
+        return false;
+      }
     }
     return true;
   }

--- a/tests/issue-28-promise-executor-invocation.test.ts
+++ b/tests/issue-28-promise-executor-invocation.test.ts
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #28 — `new Promise(executor)` with an INLINE executor must invoke the
+ * executor synchronously during construction (ECMA-262 §27.2.3.1).
+ *
+ * Before this fix, an inline executor (`new Promise((resolve, reject) => …)`)
+ * was routed through the `__make_callback` host-callback path by
+ * `isHostCallbackArgument` (its NewExpression arm treated any non-user-class
+ * ctor arg as a host callback). That path emitted no `__call_fn_*` dispatcher
+ * for the executor, so the host `Promise_new` import could not make the wasm
+ * closure JS-callable (`_maybeWrapCallable`), and the executor was therefore
+ * never invoked — `resolve`/`reject` were `undefined` and the body silently
+ * no-op'd ("executor param stripped + invocation elided").
+ *
+ * The pre-assigned form (`const exec = …; new Promise(exec)`) already worked
+ * because the arrow compiles as a first-class closure at the assignment, which
+ * DOES emit the `__call_fn_2` dispatcher. The fix routes the inline Promise
+ * executor through the same first-class-closure path.
+ *
+ * Scope: the synchronous executor-invocation protocol (executor runs, captures
+ * mutate, resolve/reject are callable, a real Promise is returned). The
+ * await-resumption / microtask settling (`resolve(v)` → `await` resumes) is the
+ * separate #1042 / #1326 async-machinery work and is not asserted here.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runHost(src: string, exportName = "test"): Promise<unknown> {
+  const r = await compile(src, { fileName: "test.ts", skipSemanticDiagnostics: true });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports as WebAssembly.Imports);
+  const setExports = (imports as { setExports?: (e: unknown) => void }).setExports;
+  if (typeof setExports === "function") setExports(instance.exports);
+  return (instance.exports as Record<string, () => unknown>)[exportName]!();
+}
+
+describe("#28 new Promise(inline executor) invocation", () => {
+  it("invokes an inline arrow executor synchronously (capture write is visible)", async () => {
+    const src = `
+export function test(): number {
+  let c = 0;
+  new Promise((resolve: any): void => { c = 7; });
+  return c;
+}
+`;
+    expect(await runHost(src)).toBe(7);
+  });
+
+  it("passes a callable resolve to the inline executor", async () => {
+    const src = `
+export function test(): number {
+  let isFn = 0;
+  new Promise((resolve: any, reject: any): void => {
+    if (typeof resolve === "function") isFn += 1;
+    if (typeof reject === "function") isFn += 10;
+  });
+  return isFn;
+}
+`;
+    expect(await runHost(src)).toBe(11);
+  });
+
+  it("calling resolve(v) inside the executor does not throw and code after it runs", async () => {
+    const src = `
+export function test(): number {
+  let after = 0;
+  new Promise((resolve: any): void => { resolve(1); after = 9; });
+  return after;
+}
+`;
+    expect(await runHost(src)).toBe(9);
+  });
+
+  it("new Promise(...) returns a real object (typeof === 'object')", async () => {
+    const src = `
+export function test(): string {
+  const p: any = new Promise((resolve: any): void => { resolve(1); });
+  return typeof p;
+}
+`;
+    expect(await runHost(src)).toBe("object");
+  });
+
+  it("inline anonymous function-expression executor is also invoked", async () => {
+    const src = `
+export function test(): number {
+  let c = 0;
+  new Promise(function (resolve: any): void { c = 42; });
+  return c;
+}
+`;
+    expect(await runHost(src)).toBe(42);
+    // NOTE: a *named* inline executor (`function exec(resolve) {…}`) is a
+    // separate named-function-expression closure-registration gap (the name
+    // routes it away from the first-class-closure path) and is out of scope
+    // for this fix — tracked as a follow-up in the issue file.
+  });
+
+  it("regression: pre-assigned executor still works (unchanged path)", async () => {
+    const src = `
+export function test(): number {
+  let c = 0;
+  const exec = function (resolve: any): void { c = 5; };
+  new Promise(exec);
+  return c;
+}
+`;
+    expect(await runHost(src)).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary

PR-A of the Promise async-capability issue: fixes the **most fundamental**
Promise bug — an **inline** `new Promise(executor)` executor was **never
invoked** (independent of the combinator / NewPromiseCapability residual). The
executor's `resolve`/`reject` were `undefined` and the body silently no-op'd
(the "executor param stripped + invocation elided" symptom).

## Root cause

`isHostCallbackArgument` (`src/codegen/closures.ts`) has a `NewExpression` arm
that returns `true` for any constructor argument whose callee is not a
user-defined class. So `new Promise((resolve, reject) => …)` routed its executor
through the `__make_callback` host-callback path. For an **inline** executor
that path emitted no `__call_fn_*` closure dispatcher export, so the host
`Promise_new` import (`new Promise(_maybeWrapCallable(executor, 2, …))`) could
not make the wasm closure JS-callable — `_maybeWrapCallable` returned the raw
struct and V8 never called the executor.

Proof: the **pre-assigned** form (`const exec = …; new Promise(exec)`) already
worked, because the arrow compiles as a first-class closure at the *assignment*
site (parent is a `VariableDeclaration`, not the `NewExpression`), which emits
`__call_fn_2`.

## Fix

In `isHostCallbackArgument`, return `false` for the `Promise` constructor so the
executor compiles as a first-class **closure** — the same working path as the
assigned form. The host `Promise_new` then wraps it via `__call_fn_2`. Now the
inline executor is invoked synchronously, captures mutate, `resolve`/`reject`
are real callable functions, and `new Promise(...)` returns a genuine object.

## Scope

This PR fixes the **synchronous executor-invocation protocol** only. Explicitly
out of scope (documented as follow-ups in the issue file):
- **await-resumption / microtask settling** (`resolve(v)` → `await` resumes) —
  the async state-machine ↔ host-microtask wiring (#1042 / #1326).
- **Named inline executor** (`new Promise(function exec(){…})`) — a named
  function-expression registers as a named func, not a closure; anonymous
  fn-expr + arrow both work.
- **Standalone pure-Wasm Promise** — `new Promise` still emits the allowlisted
  `env.Promise_new` host import (#1326).
- **NewPromiseCapability(C) for custom constructors** + resolver-element-function
  object semantics — the original ~163-fail combinator residual.

## Tests

`tests/issue-28-promise-executor-invocation.test.ts` (6 cases): arrow +
anonymous fn-expr executors invoked, capture write visible, resolve/reject
callable, `resolve(v)` non-throwing, real object returned, pre-assigned form
unchanged. `tsc --noEmit` clean; `async-await` suite green; `promise-combinators`
unchanged (its 2 pre-existing `Compile failed` cases fail identically with/without
this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)