### PR TITLE
fix(#2188): standalone sibling Error-subclass instanceof via per-class brand

### DIFF
--- a/plan/issues/2188-standalone-sibling-error-subclass-instanceof-precision.md
+++ b/plan/issues/2188-standalone-sibling-error-subclass-instanceof-precision.md
@@ -1,10 +1,11 @@
 ---
 id: 2188
 title: "standalone: sibling Error subclasses share the parent $tag — instanceof can't distinguish them (per-user-class brand)"
-status: ready
+status: in-progress
+assignee: ttraenkler/sdev-proxy3
 sprint: Backlog
 created: 2026-06-17
-updated: 2026-06-17
+updated: 2026-06-18
 priority: low
 feasibility: hard
 reasoning_effort: high
@@ -67,3 +68,50 @@ single-subclass case host-free. Coordinate with #2101 and the host-mode
 
 Split from #1536c (single-subclass standalone Error subclass — `done`). See
 #1536c's `## Resolution` and #2101 for the brand machinery.
+
+## Resolution (2026-06-18, sdev-proxy3 — PR on `issue-2188-sibling-error-brand`)
+
+**Scope shipped:** sibling discrimination for *direct* builtin-Error subclasses
+(`class A extends Error {}`, `class C extends TypeError {}`), the issue's primary
+repro + root cause. Implemented a minimal **additive per-class brand** instead of
+the full `$ClassMeta` migration (#2101) — that migration stays future work.
+
+**Why the brand, and why a new field (not field 0):** `$Error_struct.$tag`
+(field 0) is the *builtin* type tag — shared by every direct subclass of the same
+builtin Error, and immutable. Reusing it cannot separate siblings. So I appended a
+**mutable** `$userClassId` (fieldIdx 4, after `stack`) carrying the subclass's
+unique `classTagMap` id. Kept LAST so the existing positional field indices
+(0=tag, 1=message, 2=name, 3=stack) used across property-access.ts / identifiers.ts
+stay stable.
+
+**Three touch points (registry/error-types.ts, class-bodies.ts, identifiers.ts):**
+1. `$Error_struct` gains `$userClassId` (field 4); `__new_<Parent>` writes the
+   `-1` sentinel (a plain builtin Error / the shared parent ctor has no brand —
+   it cannot, because `__new_<Parent>` is shared by name across all siblings).
+2. `emitSetSubclassUserBrand` writes the subclass's id into field 4 **after**
+   construction at BOTH externref-backed-subclass sites (implicit derived ctor +
+   explicit `super()`), `ref.test`-guarded, standalone/WASI only. The brand can't
+   live in the shared parent ctor, so it's a post-`struct.new` `struct.set` at the
+   per-subclass site — no funcIdx-shift hazard (no body rebuild, no late import).
+3. The standalone `instanceof <UserSubclass>` path reads field 4 against the id
+   set {ctorName} ∪ {descendant subclasses} (`collectUserErrorSubclassBrandIds`,
+   walks `classParentMap`). Builtin RHS (`Error`/`TypeError`) keeps the field-0
+   tag check unchanged. A `-1`-branded plain Error never matches a subclass set
+   (ids ≥ 0), so `(new Error) instanceof MySubclass` is correctly false.
+
+**Verified:** `(new A) instanceof B` → false; self / parent / cross-family
+(`C extends TypeError instanceof TypeError|Error`, not `A`); three siblings
+mutually disjoint. 10/10 `tests/issue-2188.test.ts`; 25/25 existing exception
+suites (issue-2077/1536/1536c/2192); coercion-drift gate OK; tsc + prettier clean.
+
+**Pre-existing gap NOT addressed here (orthogonal, not a regression):** a
+*multi-level user chain* `class D extends A {}` where `A extends Error` does not
+construct `D` as a proper `$Error_struct` — D's direct parent A is a user class,
+so D's `super()` chains through A's `_init`, not `__new_Error`. On **both
+upstream/main and this branch**, `(new D) instanceof A` and `instanceof Error`
+return false (`(new D) instanceof D` works — D is branded). The acceptance
+criterion "multi-level user chains resolve correctly" therefore needs a separate
+construction-routing fix (transitively-derived Error subclasses must thread
+through `__new_<builtinAncestor>`); filing as a follow-up. The brand machinery
+here already supports the chain on the *read* side (descendant ids are collected)
+— only the *construction* side is missing for the >1-level case.

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -32,7 +32,7 @@ import {
 } from "./index.js";
 import { emitUndefined } from "./expressions/late-imports.js";
 import { addStringConstantGlobal, ensureExnTag, nextModuleGlobalIdx } from "./registry/imports.js";
-import { emitWasiErrorConstructor, isWasiErrorName } from "./registry/error-types.js";
+import { emitWasiErrorConstructor, getOrRegisterErrorStructType, isWasiErrorName } from "./registry/error-types.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
 import {
   cacheParamDefaultArgc,
@@ -416,6 +416,54 @@ function emitSetSubclassProto(
       { op: "call", funcIdx: setProtoIdx },
       { op: "local.set", index: selfLocal },
     ],
+  });
+}
+
+/**
+ * (#2188) Brand a standalone-native user Error subclass instance with its own
+ * `classTagMap` id, so sibling `extends Error` subclasses (which all share the
+ * SAME builtin parent `$tag`) can be told apart by `instanceof`.
+ *
+ * `selfLocal` holds the instance externref produced by `__new_<Parent>` (a real
+ * `$Error_struct`, see emitWasiErrorConstructor). We convert it back to anyref,
+ * `ref.test` that it is genuinely an `$Error_struct` (defensive — the standalone
+ * `__new_<Parent>` fallback can leave a non-struct value here), and when it is,
+ * write the subclass's unique tag into `$Error_struct.$userClassId` (fieldIdx 4).
+ * The standalone `instanceof <UserSubclass>` path (identifiers.ts) reads this
+ * field. No host import — pure WasmGC, so it works in `--target wasi`.
+ *
+ * Only emitted in standalone / WASI mode: in JS-host mode the instance is a real
+ * JS Error object (not an `$Error_struct`), `instanceof` routes through the host,
+ * and the brand field does not exist on it. Guarded by the caller.
+ */
+function emitSetSubclassUserBrand(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  selfLocal: number,
+  subName: string,
+): void {
+  if (!(ctx.wasi || ctx.standalone)) return;
+  const brand = ctx.classTagMap.get(subName);
+  if (brand === undefined) return;
+  const structIdx = getOrRegisterErrorStructType(ctx);
+  // anyref view of the instance, stash it so the `ref.test`-guarded write can
+  // re-read it without recomputing.
+  const anyLocalIdx = allocLocal(fctx, `__err_brand_${fctx.locals.length}`, { kind: "anyref" } as ValType);
+  fctx.body.push({ op: "local.get", index: selfLocal });
+  fctx.body.push({ op: "any.convert_extern" } as Instr);
+  fctx.body.push({ op: "local.set", index: anyLocalIdx });
+  fctx.body.push({ op: "local.get", index: anyLocalIdx });
+  fctx.body.push({ op: "ref.test", typeIdx: structIdx } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [
+      { op: "local.get", index: anyLocalIdx },
+      { op: "ref.cast", typeIdx: structIdx } as Instr,
+      { op: "i32.const", value: brand },
+      { op: "struct.set", typeIdx: structIdx, fieldIdx: 4 } as Instr,
+    ],
+    else: [],
   });
 }
 
@@ -1542,6 +1590,9 @@ function compileClassBodiesInner(
         // `instance instanceof Sub` walks through it, in addition to
         // `instance instanceof Parent` (already true via Parent.prototype).
         emitSetSubclassProto(ctx, fctx, selfLocal, className, parentName);
+        // (#2188) Brand the standalone instance with this subclass's tag so
+        // sibling `extends Error` subclasses are distinguishable by instanceof.
+        emitSetSubclassUserBrand(ctx, fctx, selfLocal, className);
       }
     }
 
@@ -2347,6 +2398,9 @@ export function compileSuperCall(
     // so `instance instanceof childClassName` returns true. Without this step
     // the chain only reaches `<builtinParent>.prototype`.
     emitSetSubclassProto(ctx, fctx, selfLocal, childClassName, builtinParent);
+    // (#2188) Brand the standalone instance with this subclass's tag so sibling
+    // `extends Error` subclasses are distinguishable by instanceof.
+    emitSetSubclassUserBrand(ctx, fctx, selfLocal, childClassName);
     return;
   }
 

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -66,6 +66,40 @@ function collectErrorInstanceOfTags(ctorName: string): number[] {
   return tags;
 }
 
+/**
+ * (#2188) Build the set of per-class brand ids (`classTagMap` values) that count
+ * as `instanceof <ctorName>` for a standalone-native user Error subclass, where
+ * `ctorName` is itself a user subclass of a builtin Error. The set is `ctorName`'s
+ * own id plus every user class that transitively extends `ctorName` (so an
+ * instance of `class C extends A {}` matches `instanceof A`). Sibling subclasses
+ * are excluded — that is the precision the brand restores (#2188): `(new A)` is
+ * branded with A's id, which is NOT in `B`'s id set, so `(new A) instanceof B`
+ * is false. Builtin parents (`Error`/`TypeError`) keep the field-0 tag check and
+ * never call this. Returns brand ids; empty only if `ctorName` is unregistered.
+ */
+function collectUserErrorSubclassBrandIds(ctx: CodegenContext, ctorName: string): number[] {
+  const ids: number[] = [];
+  const ownId = ctx.classTagMap.get(ctorName);
+  if (ownId !== undefined) ids.push(ownId);
+  // Every user class whose ancestor chain (via classParentMap) reaches ctorName
+  // is a descendant subclass — include its brand. Walk each registered class's
+  // parent chain rather than maintaining a children index.
+  for (const [cls, id] of ctx.classTagMap) {
+    if (cls === ctorName) continue;
+    let cursor: string | undefined = ctx.classParentMap.get(cls);
+    const seen = new Set<string>();
+    while (cursor !== undefined && !seen.has(cursor)) {
+      seen.add(cursor);
+      if (cursor === ctorName) {
+        ids.push(id);
+        break;
+      }
+      cursor = ctx.classParentMap.get(cursor);
+    }
+  }
+  return ids;
+}
+
 export function emitLocalTdzCheck(ctx: CodegenContext, fctx: FunctionContext, name: string, flagIdx: number): void {
   const msg = `${name} is not defined`;
   // #1473 — no JS host: build the TDZ flag check and emit a ReferenceError
@@ -1138,56 +1172,75 @@ function compileHostInstanceOf(ctx: CodegenContext, fctx: FunctionContext, expr:
   // by reading its `$tag` field (fieldIdx 0) and comparing against the set of
   // tags compatible with `ctorName`. No `__instanceof` host import.
   // (#1536c) `userErrorParent` extends this to externref-backed user Error
-  // subclasses: discriminate against the *parent* error's compatible tag set.
+  // subclasses.
   if (noJsHost(ctx) && (ctorName === "Error" || isWasiErrorName(ctorName) || userErrorParent !== undefined)) {
-    const compatTags = collectErrorInstanceOfTags(userErrorParent ?? ctorName);
     const structIdx = getOrRegisterErrorStructType(ctx);
-    const leftType = compileExpression(ctx, fctx, expr.left);
-    if (leftType && leftType.kind !== "externref") {
-      // Numeric / boolean primitives are never Error instances.
-      if (leftType.kind === "i32" || leftType.kind === "f64" || leftType.kind === "i64") {
-        fctx.body.push({ op: "drop" });
-        fctx.body.push({ op: "i32.const", value: 0 });
-        return { kind: "i32" };
+    // (#2188) When the RHS is a *user* Error subclass, sibling subclasses share
+    // the same builtin parent `$tag`, so the builtin-tag check (field 0) cannot
+    // tell `(new A) instanceof B` from `instanceof A`. Instead read the
+    // per-class brand (`$userClassId`, fieldIdx 4) written at the subclass
+    // construction site and compare it against the set of class ids that count
+    // as `instanceof ctorName`: ctorName's own id plus every user subclass that
+    // (transitively) extends it. `Error`/`TypeError` (builtin RHS) keep the
+    // field-0 tag check unchanged. The brand of a plain builtin Error is the
+    // `-1` sentinel, which never appears in `brandIds` (ids are >= 0), so
+    // `e instanceof MySubclass` is correctly false for a non-branded Error.
+    const useBrand = userErrorParent !== undefined;
+    const brandIds = useBrand ? collectUserErrorSubclassBrandIds(ctx, ctorName) : [];
+    // A user subclass with no resolvable brand id (should not happen — every
+    // class is in classTagMap) would make the test vacuously false; guard so we
+    // never emit an empty compare set. Fall through to the host path if so.
+    if (!useBrand || brandIds.length > 0) {
+      const compatTags = useBrand ? brandIds : collectErrorInstanceOfTags(ctorName);
+      const brandFieldIdx = useBrand ? 4 : 0;
+      const leftType = compileExpression(ctx, fctx, expr.left);
+      if (leftType && leftType.kind !== "externref") {
+        // Numeric / boolean primitives are never Error instances.
+        if (leftType.kind === "i32" || leftType.kind === "f64" || leftType.kind === "i64") {
+          fctx.body.push({ op: "drop" });
+          fctx.body.push({ op: "i32.const", value: 0 });
+          return { kind: "i32" };
+        }
+        coerceType(ctx, fctx, leftType, { kind: "externref" });
+      } else if (!leftType) {
+        fctx.body.push({ op: "ref.null.extern" });
       }
-      coerceType(ctx, fctx, leftType, { kind: "externref" });
-    } else if (!leftType) {
-      fctx.body.push({ op: "ref.null.extern" });
-    }
-    // externref -> anyref, store in temp, ref.test $Error_struct, then read tag.
-    fctx.body.push({ op: "any.convert_extern" } as Instr);
-    const anyLocalIdx = allocLocal(fctx, `__err_instanceof_${fctx.locals.length}`, { kind: "anyref" } as ValType);
-    fctx.body.push({ op: "local.set", index: anyLocalIdx });
-    const elseBody: Instr[] = [
-      { op: "local.get", index: anyLocalIdx },
-      { op: "ref.cast", typeIdx: structIdx } as Instr,
-      { op: "struct.get", typeIdx: structIdx, fieldIdx: 0 } as Instr,
-    ];
-    if (compatTags.length === 1) {
-      elseBody.push({ op: "i32.const", value: compatTags[0]! });
-      elseBody.push({ op: "i32.eq" });
-    } else {
-      const tagLocalIdx = allocLocal(fctx, `__err_tag_${fctx.locals.length}`, { kind: "i32" });
-      elseBody.push({ op: "local.set", index: tagLocalIdx });
-      elseBody.push({ op: "local.get", index: tagLocalIdx });
-      elseBody.push({ op: "i32.const", value: compatTags[0]! });
-      elseBody.push({ op: "i32.eq" });
-      for (let i = 1; i < compatTags.length; i++) {
-        elseBody.push({ op: "local.get", index: tagLocalIdx });
-        elseBody.push({ op: "i32.const", value: compatTags[i]! });
+      // externref -> anyref, store in temp, ref.test $Error_struct, then read
+      // the discriminating field (builtin tag = field 0, user brand = field 4).
+      fctx.body.push({ op: "any.convert_extern" } as Instr);
+      const anyLocalIdx = allocLocal(fctx, `__err_instanceof_${fctx.locals.length}`, { kind: "anyref" } as ValType);
+      fctx.body.push({ op: "local.set", index: anyLocalIdx });
+      const elseBody: Instr[] = [
+        { op: "local.get", index: anyLocalIdx },
+        { op: "ref.cast", typeIdx: structIdx } as Instr,
+        { op: "struct.get", typeIdx: structIdx, fieldIdx: brandFieldIdx } as Instr,
+      ];
+      if (compatTags.length === 1) {
+        elseBody.push({ op: "i32.const", value: compatTags[0]! });
         elseBody.push({ op: "i32.eq" });
-        elseBody.push({ op: "i32.or" });
+      } else {
+        const tagLocalIdx = allocLocal(fctx, `__err_tag_${fctx.locals.length}`, { kind: "i32" });
+        elseBody.push({ op: "local.set", index: tagLocalIdx });
+        elseBody.push({ op: "local.get", index: tagLocalIdx });
+        elseBody.push({ op: "i32.const", value: compatTags[0]! });
+        elseBody.push({ op: "i32.eq" });
+        for (let i = 1; i < compatTags.length; i++) {
+          elseBody.push({ op: "local.get", index: tagLocalIdx });
+          elseBody.push({ op: "i32.const", value: compatTags[i]! });
+          elseBody.push({ op: "i32.eq" });
+          elseBody.push({ op: "i32.or" });
+        }
       }
+      fctx.body.push({ op: "local.get", index: anyLocalIdx });
+      fctx.body.push({ op: "ref.test", typeIdx: structIdx } as Instr);
+      fctx.body.push({
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: elseBody,
+        else: [{ op: "i32.const", value: 0 }],
+      });
+      return { kind: "i32" };
     }
-    fctx.body.push({ op: "local.get", index: anyLocalIdx });
-    fctx.body.push({ op: "ref.test", typeIdx: structIdx } as Instr);
-    fctx.body.push({
-      op: "if",
-      blockType: { kind: "val", type: { kind: "i32" } },
-      then: elseBody,
-      else: [{ op: "i32.const", value: 0 }],
-    });
-    return { kind: "i32" };
   }
 
   // Ensure the __instanceof host import exists

--- a/src/codegen/registry/error-types.ts
+++ b/src/codegen/registry/error-types.ts
@@ -94,6 +94,18 @@ export function getOrRegisterErrorStructType(ctx: CodegenContext): number {
       // back as `undefined`, not a trap). Mutable so a future `err.stack = …`
       // write can land here without a struct-type change.
       { name: "stack", type: { kind: "externref" }, mutable: true },
+      // (#2188) $userClassId — fieldIdx 4. Per-user-Error-subclass brand that
+      // distinguishes sibling `extends Error` classes which all share the SAME
+      // builtin parent `$tag` (field 0). `__new_<Parent>` writes the sentinel
+      // `-1` (a plain builtin Error / the shared parent ctor has no user-class
+      // brand); the subclass `super()` site overwrites it with the subclass's
+      // `classTagMap` id (see emitSetSubclassUserBrand in class-bodies.ts). The
+      // standalone `instanceof <UserSubclass>` path reads this field instead of
+      // the shared builtin tag, so `(new A) instanceof B` is false for distinct
+      // siblings A,B. Mutable: the brand is written AFTER struct.new at the
+      // per-subclass construction site, not baked into the shared parent ctor.
+      // Kept LAST so fields 0..3 stay stable.
+      { name: "userClassId", type: { kind: "i32" }, mutable: true },
     ],
   });
   ctx.errorStructTypeIdx = idx;
@@ -152,6 +164,10 @@ export function emitWasiErrorConstructor(ctx: CodegenContext, errorName: WasiErr
     // $stack — (#1536) non-standard; standalone has no stack-capture
     // primitive, so initialize to null (reads back as `undefined`).
     { op: "ref.null.extern" },
+    // $userClassId — (#2188) -1 sentinel: a plain builtin Error (or the shared
+    // parent ctor of a user subclass) carries no per-user-class brand. The
+    // subclass `super()` site overwrites this field after construction.
+    { op: "i32.const", value: -1 },
     { op: "struct.new", typeIdx: structIdx },
     { op: "extern.convert_any" },
   ];

--- a/tests/issue-2188.test.ts
+++ b/tests/issue-2188.test.ts
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2188 — standalone: sibling Error subclasses must be distinguishable by
+ * `instanceof`.
+ *
+ * `#1536c` made `class MyError extends Error {}` instantiate + resolve
+ * `instanceof` natively in standalone mode. The instance is the parent's
+ * `$Error_struct`, discriminated by the parent's builtin `$tag` (field 0).
+ * That is exact for a single subclass, but TWO distinct `extends Error`
+ * siblings share the SAME parent tag, so `instanceof` could not tell them
+ * apart: `(new A) instanceof B` returned true (node: false).
+ *
+ * Fix (#2188): give each standalone-native user Error subclass instance a
+ * per-class brand — `$Error_struct.$userClassId` (field 4) = the subclass's
+ * unique `classTagMap` id, written at the subclass construction site
+ * (`emitSetSubclassUserBrand` in class-bodies.ts). The standalone
+ * `instanceof <UserSubclass>` path (identifiers.ts) reads the brand against the
+ * set {ctorName's id} ∪ {descendant subclass ids} instead of the shared builtin
+ * tag, so siblings are disjoint. `instanceof Error`/`instanceof TypeError`
+ * (builtin RHS) keep the field-0 builtin-tag check unchanged.
+ *
+ * The LHS in these tests is a `catch`-bound `any` (the realistic test262
+ * shape — catch an error, check its type), which exercises the dynamic
+ * externref instanceof path the brand targets. A statically-typed
+ * `new A() instanceof B` already resolves at compile time and is correct.
+ *
+ * Known pre-existing gap (NOT this issue): a multi-level *user* chain
+ * `class D extends A {}` where `A extends Error` does not construct `D` as a
+ * proper `$Error_struct` (D's direct parent is a user class, so D's `super()`
+ * chains through A's init, not `__new_Error`). On both upstream/main and this
+ * branch, `(new D) instanceof A` / `instanceof Error` return false. That is a
+ * construction-routing gap orthogonal to the sibling-brand fix here; this PR
+ * neither fixes nor regresses it. `(new D) instanceof D` works (D is branded).
+ */
+
+async function runStandalone(source: string): Promise<unknown> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#2188 — standalone sibling Error subclass instanceof precision", () => {
+  it("(new A) instanceof B is FALSE for distinct siblings A,B extends Error", async () => {
+    const got = await runStandalone(`
+      class A extends Error {}
+      class B extends Error {}
+      export function test(): number {
+        try { throw new A("x"); } catch (e) { return e instanceof B ? 1 : 0; }
+      }
+    `);
+    expect(got).toBe(0);
+  });
+
+  it("(new A) instanceof A is TRUE (self)", async () => {
+    const got = await runStandalone(`
+      class A extends Error {}
+      class B extends Error {}
+      export function test(): number {
+        try { throw new A("x"); } catch (e) { return e instanceof A ? 1 : 0; }
+      }
+    `);
+    expect(got).toBe(1);
+  });
+
+  it("(new A) instanceof Error is TRUE (builtin parent — field-0 tag path)", async () => {
+    const got = await runStandalone(`
+      class A extends Error {}
+      class B extends Error {}
+      export function test(): number {
+        try { throw new A("x"); } catch (e) { return e instanceof Error ? 1 : 0; }
+      }
+    `);
+    expect(got).toBe(1);
+  });
+
+  it("(new B) instanceof A is FALSE (reverse sibling direction)", async () => {
+    const got = await runStandalone(`
+      class A extends Error {}
+      class B extends Error {}
+      export function test(): number {
+        try { throw new B("x"); } catch (e) { return e instanceof A ? 1 : 0; }
+      }
+    `);
+    expect(got).toBe(0);
+  });
+
+  it("cross-family: (new C extends TypeError) instanceof TypeError is TRUE", async () => {
+    const got = await runStandalone(`
+      class A extends Error {}
+      class C extends TypeError {}
+      export function test(): number {
+        try { throw new C("x"); } catch (e) { return e instanceof TypeError ? 1 : 0; }
+      }
+    `);
+    expect(got).toBe(1);
+  });
+
+  it("cross-family: (new C extends TypeError) instanceof Error is TRUE (TypeError <: Error)", async () => {
+    const got = await runStandalone(`
+      class A extends Error {}
+      class C extends TypeError {}
+      export function test(): number {
+        try { throw new C("x"); } catch (e) { return e instanceof Error ? 1 : 0; }
+      }
+    `);
+    expect(got).toBe(1);
+  });
+
+  it("cross-family: (new C extends TypeError) instanceof A (extends Error) is FALSE", async () => {
+    const got = await runStandalone(`
+      class A extends Error {}
+      class C extends TypeError {}
+      export function test(): number {
+        try { throw new C("x"); } catch (e) { return e instanceof A ? 1 : 0; }
+      }
+    `);
+    expect(got).toBe(0);
+  });
+
+  it("a plain builtin Error (brand -1) is NOT an instance of any user subclass", async () => {
+    const got = await runStandalone(`
+      class A extends Error {}
+      export function test(): number {
+        try { throw new Error("x"); } catch (e) { return e instanceof A ? 1 : 0; }
+      }
+    `);
+    expect(got).toBe(0);
+  });
+
+  it("a plain builtin Error is still instanceof Error (no brand regression)", async () => {
+    const got = await runStandalone(`
+      class A extends Error {}
+      export function test(): number {
+        try { throw new Error("x"); } catch (e) { return e instanceof Error ? 1 : 0; }
+      }
+    `);
+    expect(got).toBe(1);
+  });
+
+  it("three siblings stay mutually disjoint", async () => {
+    const got = await runStandalone(`
+      class A extends Error {}
+      class B extends Error {}
+      class C extends Error {}
+      export function test(): number {
+        let n = 0;
+        try { throw new A("x"); } catch (e) {
+          if (e instanceof A) n += 1;          // +1
+          if (e instanceof B) n += 10;         // +0
+          if (e instanceof C) n += 100;        // +0
+          if (e instanceof Error) n += 1000;   // +1000
+        }
+        return n;
+      }
+    `);
+    expect(got).toBe(1001);
+  });
+});


### PR DESCRIPTION
## #2188 — standalone sibling Error subclasses must be distinguishable by `instanceof`

Two distinct `extends Error` siblings share the SAME builtin parent `$tag` on `$Error_struct` (field 0), so the standalone `instanceof` path could not tell them apart: `(new A) instanceof B` returned `true` (node: `false`). #1536c shipped the single-subclass case using that coarse parent-tag check; this restores **sibling precision** with a minimal additive per-class brand — **not** the full `$ClassMeta` migration (#2101, still future work).

### Fix — additive per-class brand (pure WasmGC, zero host imports)
- **`registry/error-types.ts`**: `$Error_struct` gains a mutable `$userClassId` (fieldIdx **4**, appended after `stack` so fields 0..3 stay stable). `__new_<Parent>` writes the `-1` sentinel — a plain builtin Error / the shared parent ctor carries no brand (it *can't*: `__new_<Parent>` is shared by name across all siblings).
- **`class-bodies.ts`**: `emitSetSubclassUserBrand` writes the subclass's unique `classTagMap` id into field 4 **after** construction, at BOTH externref-backed subclass sites (implicit derived ctor + explicit `super()`), `ref.test`-guarded, standalone/WASI only. A post-`struct.new` `struct.set` at the per-subclass site — **no funcIdx-shift hazard** (no body rebuild, no late import).
- **`identifiers.ts`**: the standalone `instanceof <UserSubclass>` path reads field 4 against the id set `{ctorName} ∪ {descendant subclasses}` (`collectUserErrorSubclassBrandIds`, walks `classParentMap`). Builtin RHS (`Error`/`TypeError`) keeps the field-0 tag check unchanged. A `-1`-branded plain Error never matches a subclass id set (ids ≥ 0).

### Verification
- **10/10** `tests/issue-2188.test.ts` — `(new A) instanceof B` false; self/parent correct; cross-family (`C extends TypeError`); three siblings mutually disjoint; plain-Error (brand -1) excluded from subclass; plain-Error still `instanceof Error`.
- **25/25** existing exception suites (issue-2077, issue-1536, issue-1536c, issue-2192) — no regression.
- coercion-drift gate OK; `tsc --noEmit` + prettier clean.

### Out of scope (pre-existing, NOT regressed)
A *multi-level user chain* `class D extends A {}` where `A extends Error` does not construct `D` as a proper `$Error_struct` (D's `super()` chains through A's `_init`, not `__new_Error`), so `(new D) instanceof A|Error` is false on **both upstream/main and this branch** (`(new D) instanceof D` works — D is branded). The brand **read** side here already supports the chain; the construction-routing fix is a separate follow-up, documented in the issue file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)