### PR TITLE
fix(#2192): standalone caught-Error string-field method calls (follow-up slice)

### DIFF
--- a/plan/issues/2192-standalone-caught-error-message-inline-coercion.md
+++ b/plan/issues/2192-standalone-caught-error-message-inline-coercion.md
@@ -88,15 +88,38 @@ operand**, so `e.message === "lit"` / `!==` routes to `compileStringBinaryOp`
 (`__str_equals`, content compare) instead of `ref.eq`. This is the dominant
 test262 assertion shape (`assert.sameValue(e.message, "...")`).
 
-## Deferred (follow-up) — non-equality consumers
+## Follow-up slice 1 (2026-06-18, sdev-proxy3 — PR `issue-2192b-…`): string METHODS
 
-`e.message.length`, `e.message.<method>()`, and `e.cause` still return null/empty
-inline (the `any`-typed property read isn't recognised as a string by `.length`/
-method dispatch / cause has its own field gap). The general fix is to make the
-caught-Error property read itself carry a string result type to ALL consumers
-(not just equality). Tracked here as the next slice. The pre-existing plain
-`const o:any={message:"abc"}; o.message.length` → 0 is a SEPARATE plain-object
-bug (reproduces on base, not introduced here).
+DONE: `e.message.<method>()` / `e.name.<method>()` now dispatch through the
+native-string method path for i32/boolean-returning methods (`charCodeAt`,
+`indexOf`, `includes`, `startsWith`, `endsWith`, …) on a caught-Error string
+field of an explicitly-thrown error.
+
+**Mechanism:** `receiverIsCaughtErrorStringRead(ctx, recv)` (property-access.ts)
+recognises a `<catchBinding>.message|name|stack` receiver; the string-method
+dispatch in `calls.ts` (the `isStringType(receiverType)` gate) ORs it in, so the
+call routes through `compileNativeStringMethodCall` — which compiles + flattens
+the receiver to a `$AnyString` ref (already the read's result type in standalone
+mode). No new host import; standalone/WASI-gated; `message`/`name`/`stack` only;
+inner receiver must be a bare catch binding (plain `obj.message` unaffected).
+9/9 `tests/issue-2192b-caught-error-string-methods.test.ts`; 27/27 with the
+#2192/#2077 suites; no regression.
+
+**Still deferred (intentionally NOT in this slice — broad blast radius):**
+- `e.message.length` — the `.length` dispatch is entangled with the generic
+  `any`-receiver length / `__extern_get` chain (earlier `.length` handlers
+  intercept before the string-length site). Plain
+  `const o:any={message:"abc"}; o.message.length` → 0 on base too: this is the
+  GENERAL `any`-typed-`.length` gap, not Error-specific. Needs the `any`-receiver
+  length dispatch to consult the codegen result type, not the static type alone.
+- chained string-RETURNING methods (`e.message.slice(1).charCodeAt(0)`) — the
+  intermediate `.slice()` result's type isn't carried to the next consumer.
+- `e.cause` — not a `$Error_struct` field yet (own field gap).
+- errors from a runtime TRAP (`null.x`) vs `new X()` — the trap-throw path does
+  not populate the `$Error_struct` string fields like the explicit ctor does
+  (separate construction gap).
+These together are the "string type to ALL consumers" type-propagation work;
+keeping them out preserves a bounded, low-risk slice.
 
 ## Acceptance criteria (this PR)
 

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -79,7 +79,12 @@ import {
   compileObjectKeysOrValues,
   compilePropertyIntrospection,
 } from "../object-ops.js";
-import { emitArrayIsArrayExternrefPredicate, emitNullCheckThrow, typeErrorThrowInstrs } from "../property-access.js";
+import {
+  emitArrayIsArrayExternrefPredicate,
+  emitNullCheckThrow,
+  receiverIsCaughtErrorStringRead,
+  typeErrorThrowInstrs,
+} from "../property-access.js";
 import type { InnerResult } from "../shared.js";
 import { coerceType, compileExpression, valTypesMatch, VOID_RESULT } from "../shared.js";
 import { compileStatement, hoistFunctionDeclarations } from "../statements.js";
@@ -7881,7 +7886,13 @@ function compileCallExpression(
     }
 
     // String method calls
-    if (isStringType(receiverType)) {
+    // (#2192 follow-up) Also fire for a caught-Error string-field read receiver
+    // (`e.message.charCodeAt(0)`, `e.name.slice(...)`) whose static type is `any`
+    // but which lowers to a native-string ref in standalone mode — the
+    // isStringType gate alone misses it, so the call fell through to the host
+    // `__extern_get`/dynamic path (null standalone). compileNativeStringMethodCall
+    // compiles + flattens the receiver, which already yields a $AnyString ref.
+    if (isStringType(receiverType) || receiverIsCaughtErrorStringRead(ctx, propAccess.expression)) {
       const method = propAccess.name.text;
 
       // string.toString() and string.valueOf() — identity, just return the string itself.

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -1576,6 +1576,36 @@ function receiverIsCatchClauseBinding(ctx: CodegenContext, recv: ts.Expression):
 }
 
 /**
+ * (#2192 follow-up) Recognize a receiver expression that is itself a caught-Error
+ * string-field read — i.e. `<catchBinding>.message` / `.name` / `.stack`. In
+ * standalone mode the #2077/#2192 fast path lowers that read to a `$Error_struct`
+ * `struct.get` coerced to a native-string ref (`$AnyString`), so at the VALUE
+ * level the result IS a string. But the receiver's static TS type is `any` (the
+ * catch binding is `any`), so the `.length` / string-method dispatch sites —
+ * which gate on `isStringType(<static type>)` — never fire, and
+ * `e.message.length` / `e.message.charCodeAt(0)` fall through to the host
+ * `__extern_get` path (null standalone → 0). This predicate lets those consumer
+ * sites treat such a receiver as string-typed and route through the
+ * native-string path.
+ *
+ * Scope: standalone/WASI only (the fast path that produces a string ref is
+ * standalone-gated), `message`/`name`/`stack` only (the fields the read fast path
+ * handles), and only when the inner receiver is a catch binding (so a plain
+ * `obj.message` on a real object is unaffected — it keeps its own typed path).
+ * `.cause` is intentionally NOT covered: it is not a `$Error_struct` field yet
+ * (deferred follow-up).
+ */
+export function receiverIsCaughtErrorStringRead(ctx: CodegenContext, recv: ts.Expression): boolean {
+  if (!(ctx.wasi || ctx.standalone)) return false;
+  if (!ts.isPropertyAccessExpression(recv)) return false;
+  const p = recv.name.text;
+  if (p !== "message" && p !== "name" && p !== "stack") return false;
+  if (!receiverIsCatchClauseBinding(ctx, recv.expression)) return false;
+  const innerType = ctx.checker.getTypeAtLocation(recv.expression);
+  return (innerType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
+}
+
+/**
  * (#2179) When the module uses `delete <member>` (JS-host mode only), route an
  * `any`/`unknown`-typed property READ through the tombstone-aware `__extern_get`
  * host helper instead of the inline `ref.test`+`struct.get` fast-path. Returns

--- a/tests/issue-2192b-caught-error-string-methods.test.ts
+++ b/tests/issue-2192b-caught-error-string-methods.test.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2192 follow-up — standalone: string METHODS on a caught-Error string field.
+ *
+ * #2192 made `e.message === "literal"` route through `__str_equals` for a
+ * `catch (e)` binding. But the read's RESULT TYPE was only consumed by the
+ * equality dispatch; a string METHOD call on the same read
+ * (`e.message.charCodeAt(0)`, `e.name.indexOf("Range")`) still keyed its dispatch
+ * off the receiver's STATIC type — `any` (the catch binding) — so it fell through
+ * to the host `__extern_get`/dynamic path, which returns null/0 in standalone
+ * mode.
+ *
+ * Fix: `receiverIsCaughtErrorStringRead` (property-access.ts) recognizes a
+ * `<catchBinding>.message|name|stack` receiver, and the string-method dispatch in
+ * calls.ts ORs it into the `isStringType` gate so the call routes through
+ * `compileNativeStringMethodCall` (which compiles + flattens the receiver to a
+ * `$AnyString` ref — already the read's result type in standalone mode).
+ *
+ * Scope (deliberately sliced — see the issue file): this covers i32/boolean-
+ * returning string methods (`charCodeAt`, `indexOf`, `includes`, `startsWith`,
+ * `endsWith`, …) on an EXPLICITLY-thrown error (`throw new X("…")`). Out of scope
+ * here (deferred — broad `any`-receiver value-propagation work):
+ *   - `e.message.length` — the `.length` dispatch is entangled with the generic
+ *     `any`-receiver length/extern-get path; it returns 0 on main for ALL
+ *     `any`-typed `.message.length` (not Error-specific).
+ *   - chained string-RETURNING methods (`e.message.slice(1).charCodeAt(0)`) —
+ *     the intermediate result's type isn't carried.
+ *   - `.cause` — not a `$Error_struct` field yet.
+ *   - errors from a runtime TRAP (`null.x`) rather than `new X()` — those don't
+ *     populate the `$Error_struct` string fields the same way (separate gap).
+ *
+ * Values are read IN wasm (returned as numbers/booleans): a native-string ref
+ * returned to a JS host reads as undefined, so assertions compute char codes /
+ * indices / predicates inside the module.
+ */
+
+async function runStandalone(source: string): Promise<unknown> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#2192 follow-up — caught-Error string-field method calls (standalone)", () => {
+  it("e.message.charCodeAt(0) reads the first code unit", async () => {
+    const got = await runStandalone(`
+      export function test(): number {
+        try { throw new Error("msg1"); } catch (e) { return e.message.charCodeAt(0); }
+      }
+    `);
+    expect(got).toBe(109); // 'm'
+  });
+
+  it("e.message.indexOf(substr) finds the index", async () => {
+    const got = await runStandalone(`
+      export function test(): number {
+        try { throw new Error("hello"); } catch (e) { return e.message.indexOf("ll"); }
+      }
+    `);
+    expect(got).toBe(2);
+  });
+
+  it("e.message.includes(substr) is a boolean predicate", async () => {
+    const got = await runStandalone(`
+      export function test(): number {
+        try { throw new Error("hello"); } catch (e) { return e.message.includes("ell") ? 1 : 0; }
+      }
+    `);
+    expect(got).toBe(1);
+  });
+
+  it("e.message.startsWith(prefix)", async () => {
+    const got = await runStandalone(`
+      export function test(): number {
+        try { throw new Error("hello"); } catch (e) { return e.message.startsWith("he") ? 1 : 0; }
+      }
+    `);
+    expect(got).toBe(1);
+  });
+
+  it("e.message.endsWith(suffix)", async () => {
+    const got = await runStandalone(`
+      export function test(): number {
+        try { throw new Error("hello"); } catch (e) { return e.message.endsWith("lo") ? 1 : 0; }
+      }
+    `);
+    expect(got).toBe(1);
+  });
+
+  it("e.name.charCodeAt(0) reads the error-type name", async () => {
+    const got = await runStandalone(`
+      export function test(): number {
+        try { throw new TypeError("x"); } catch (e) { return e.name.charCodeAt(0); }
+      }
+    `);
+    expect(got).toBe(84); // 'T' of TypeError
+  });
+
+  it("e.name.indexOf(substr) on a RangeError", async () => {
+    const got = await runStandalone(`
+      export function test(): number {
+        try { throw new RangeError("x"); } catch (e) { return e.name.indexOf("Range"); }
+      }
+    `);
+    expect(got).toBe(0);
+  });
+
+  it("no regression: a string method on a typed string still works", async () => {
+    const got = await runStandalone(`
+      export function test(): number {
+        const s = "hello";
+        return s.indexOf("ll");
+      }
+    `);
+    expect(got).toBe(2);
+  });
+
+  it("no regression: e.message === literal (the #2192 equality slice) still holds", async () => {
+    const got = await runStandalone(`
+      export function test(): number {
+        try { throw new Error("ab"); } catch (e) { return e.message === "ab" ? 1 : 0; }
+      }
+    `);
+    expect(got).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2192 follow-up — string METHODS on a caught-Error string field (standalone)

#2192 (merged, #1677) made `e.message === "literal"` route through `__str_equals` for a `catch (e)` binding. But a string **method** on the same read — `e.message.charCodeAt(0)`, `e.name.indexOf("Range")` — keyed its dispatch off the receiver's **static** type, which is `any` (the catch binding), so the call fell through to the host `__extern_get`/dynamic path → null/0 in standalone mode.

### Fix (narrow, host-free, standalone-gated)
- **`property-access.ts`**: new exported predicate `receiverIsCaughtErrorStringRead(ctx, recv)` recognises a `<catchBinding>.message|name|stack` receiver whose inner binding is a catch-clause `any` — the exact shape the #2077/#2192 read fast path lowers to a native-string `$AnyString` ref.
- **`calls.ts`**: the string-method dispatch (`isStringType(receiverType)` gate) ORs the predicate in, so the call routes through `compileNativeStringMethodCall`, which compiles + flattens the receiver to a `$AnyString` ref.

### Verification
- **9/9** `tests/issue-2192b-caught-error-string-methods.test.ts` — `charCodeAt`, `indexOf`, `includes`, `startsWith`, `endsWith` on `e.message`/`e.name` of explicitly-thrown errors.
- **27/27** with `tests/issue-2192.test.ts` + `tests/issue-2077.test.ts` — no regression. Typed-string + plain-object reads unaffected.
- `tsc --noEmit` + prettier clean.

### Deliberately sliced (broad blast radius deferred — see issue file)
- `e.message.length` — entangled with the generic `any`-receiver length / `__extern_get` chain; `const o:any={message:"abc"}; o.message.length` → 0 on base too (general `any`-`.length` gap, not Error-specific).
- chained string-RETURNING methods (`e.message.slice(1).charCodeAt(0)`).
- `e.cause` (not a `$Error_struct` field yet).
- runtime-trap-thrown errors (`null.x`) vs `new X()` (separate ctor gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)