### PR TITLE
feat(#2164): standalone Date.parse of RFC2822 / toString forms (round-trips the formatters)

### DIFF
--- a/plan/issues/2164-standalone-date-residual.md
+++ b/plan/issues/2164-standalone-date-residual.md
@@ -187,3 +187,46 @@ prettier + coercion-sites + any-box gates clean. The pre-existing
 Slice 3 (`__date_civil_from_days` for very negative days) and `getTimezoneOffset`
 already returns 0 standalone (correct for UTC). The big formatter placeholder —
 the dominant standalone Date string gap — is now closed.
+
+---
+
+## Slice 5 (2026-06-18, sdev-proxy3) — Date.parse RFC2822 / `toString` forms
+
+**Landed.** The pure-Wasm `__date_parse` (date-parse-native.ts) handled only the
+ECMAScript Date-Time-String (ISO) grammar, so `Date.parse` of an RFC2822 /
+`toString`-shaped string returned NaN standalone — e.g. the round-trip of the
+#1682 formatters: `Date.parse(d.toUTCString())` / `Date.parse(d.toString())` /
+`Date.parse(d.toDateString())` all NaN'd.
+
+**Fix:** the scanner now dispatches on the first char. A leading **letter**
+routes to a new RFC2822 arm that parses an optional weekday (`Www[,]`), then
+either `DD Mon YYYY` (toUTCString) or `Mon DD YYYY` (toString/toDateString),
+then an optional `HH:mm:ss`, then an optional timezone (`GMT`/`UTC`/`Z` or
+`±HHMM`). It fills the **same** field locals as the ISO arm, so the shared
+range-validate + compose tail handles either. New primitives: a branch-free
+case-insensitive 3-letter month-name matcher (12-way if-chain on lowercased
+chars via `select`), a weekday/month disambiguator (a leading 3-letter token is
+a weekday only when followed by `,` or ` `+letter — so `Nov 14` is a month, not
+a weekday), and space/`GMT`-skipping loops. All forms parse as **UTC**
+(standalone has no TZ DB), matching the formatter/clock decisions of slices 1–4.
+
+**Notable bug fixed in dev:** the month-name lowercaser first used an `if`
+with `blockType val i32` whose `then` arm did `i32.add` against the pre-`if`
+operand — but a value-result `if` arm has no implicit access to the stack below
+its frame, so this was an invalid-Wasm `i32.add need 2 got 1`. Rewrote it
+branch-free with `select(c+32, c, isUpper)`.
+
+**Validation.** `tests/issue-2164-date-parse-rfc2822.test.ts` (9/9): toUTCString
+/ toString / toDateString / month-first-no-weekday forms, all 12 month names,
+±HHMM offsets, garbage→NaN (no trap), ISO no-regression, and the round-trip of
+the #1682 formatters (to the second for toUTCString/toString since they carry no
+ms — exactly like V8; to the day for toDateString). 44/44 existing #2164 /
+#2164-iso / #2164-formatters suites unchanged. tsc + prettier + coercion-sites +
+any-box gates clean. No host-import leak.
+
+**Scope boundary (documented):** a bare `DD Mon YYYY` (day-first, NO weekday,
+e.g. `"14 Nov 2023"`) starts with a digit, so it routes to the ISO scanner and
+returns NaN. None of our formatters emit that form; it is a lenient V8 extra.
+Covering it would require the ISO scanner to detect a month-name mid-stream —
+deferred. The dominant value (round-tripping the formatters + RFC2822 GMT
+strings) is delivered.

--- a/src/codegen/date-parse-native.ts
+++ b/src/codegen/date-parse-native.ts
@@ -202,6 +202,258 @@ export function emitNativeDateParse(ctx: CodegenContext): void {
   // guard prelude: push `!fail` before the if.
   const guarded = (inner: Instr[]): Instr[] => [getI(L_FAIL), { op: "i32.eqz" } as Instr, guard(inner)];
 
+  // ── RFC2822 / toString-form helpers (#2164 Date.parse extension) ──────────
+  // skipSpaces(): advance `i` over any run of ASCII spaces (0x20). A `loop`
+  // that re-checks `i<len && data[i]==' '` each iteration.
+  const C_SPACE = 32;
+  const C_COMMA = 44;
+  const skipSpaces: Instr[] = [
+    {
+      op: "loop",
+      blockType: { kind: "empty" },
+      body: [
+        // if next char is a space: advance and re-loop (br depth 0 = loop top);
+        // otherwise fall through and exit the loop.
+        ...peekIs(C_SPACE),
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [getI(L_I), i32c(1), { op: "i32.add" } as Instr, setI(L_I), { op: "br", depth: 0 } as Instr],
+        } as Instr,
+      ],
+    } as Instr,
+  ];
+  // monthFromName(): read 3 letters at `i` (case-insensitive), set L_MONTH to
+  // 1–12, advance `i` by 3. On no-match set fail. Implemented as a chain of
+  // 3-letter comparisons against the lowercased first letters. We lowercase
+  // each of the 3 chars into m0/m1/m2 (reusing acc/ndig/days scratch as i32 is
+  // awkward; use dedicated reads).
+  const lc = (reg: number): Instr[] => [
+    // L_C already holds the char; produce lowercased char and store into `reg`.
+    // Uses `select(c+32, c, isUpper)` — branch-free, so no stack-frame issue
+    // with carrying the pre-`if` operand into an arm.
+    //   a = c + 32        (used when isUpper)
+    getI(L_C),
+    i32c(32),
+    { op: "i32.add" } as Instr,
+    //   b = c             (used otherwise)
+    getI(L_C),
+    //   cond = (c >= 'A') && (c <= 'Z')
+    getI(L_C),
+    i32c(65),
+    { op: "i32.ge_s" } as Instr,
+    getI(L_C),
+    i32c(90),
+    { op: "i32.le_s" } as Instr,
+    { op: "i32.and" } as Instr,
+    { op: "select" } as Instr,
+    setI(reg),
+  ];
+  // Read the char at i+k into L_C (no advance). Guarded by caller ensuring
+  // i+3<=len.
+  const loadAt = (k: number): Instr[] => [
+    getI(L_DATA),
+    getI(L_I),
+    i32c(k),
+    { op: "i32.add" } as Instr,
+    { op: "array.get_u", typeIdx: strDataTypeIdx } as Instr,
+    setI(L_C),
+  ];
+  // m0/m1/m2 lowercased month-name letters reuse L_TZH/L_TZM/L_DAYS-adjacent
+  // i32 scratch? They are i64. Use three fresh i32 locals.
+  const L_M0 = 22;
+  const L_M1 = 23;
+  const L_M2 = 24;
+  // monthMatch(a,b,c, monthNo): if (m0==a && m1==b && m2==c) L_MONTH=monthNo.
+  // `a,b,c` are lowercase char codes.
+  const monthMatch = (a: number, b: number, c: number, monthNo: number, elseArm: Instr[]): Instr[] => [
+    getI(L_M0),
+    i32c(a),
+    { op: "i32.eq" } as Instr,
+    getI(L_M1),
+    i32c(b),
+    { op: "i32.eq" } as Instr,
+    { op: "i32.and" } as Instr,
+    getI(L_M2),
+    i32c(c),
+    { op: "i32.eq" } as Instr,
+    { op: "i32.and" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [i64c(BigInt(monthNo)), setI(L_MONTH)],
+      else: elseArm,
+    } as Instr,
+  ];
+  // matchMonthName(): requires i+3<=len; lowercases the 3 chars; matches one of
+  // the 12 names; advances i by 3 on success, sets fail on no match.
+  const matchMonthName: Instr[] = [
+    ...guarded([
+      // bounds: i+3 <= len
+      getI(L_I),
+      i32c(3),
+      { op: "i32.add" } as Instr,
+      getI(L_LEN),
+      { op: "i32.gt_s" } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [i32c(1), setI(L_FAIL)],
+        else: [
+          ...loadAt(0),
+          ...lc(L_M0),
+          ...loadAt(1),
+          ...lc(L_M1),
+          ...loadAt(2),
+          ...lc(L_M2),
+          // chain: jan feb mar apr may jun jul aug sep oct nov dec, else fail
+          ...monthMatch(
+            106,
+            97,
+            110,
+            1, // jan
+            monthMatch(
+              102,
+              101,
+              98,
+              2, // feb
+              monthMatch(
+                109,
+                97,
+                114,
+                3, // mar
+                monthMatch(
+                  97,
+                  112,
+                  114,
+                  4, // apr
+                  monthMatch(
+                    109,
+                    97,
+                    121,
+                    5, // may
+                    monthMatch(
+                      106,
+                      117,
+                      110,
+                      6, // jun
+                      monthMatch(
+                        106,
+                        117,
+                        108,
+                        7, // jul
+                        monthMatch(
+                          97,
+                          117,
+                          103,
+                          8, // aug
+                          monthMatch(
+                            115,
+                            101,
+                            112,
+                            9, // sep
+                            monthMatch(
+                              111,
+                              99,
+                              116,
+                              10, // oct
+                              monthMatch(
+                                110,
+                                111,
+                                118,
+                                11, // nov
+                                monthMatch(100, 101, 99, 12, [i32c(1), setI(L_FAIL)]), // dec | fail
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          // advance i by 3 only if matched (fail stays 0)
+          ...guarded([getI(L_I), i32c(3), { op: "i32.add" } as Instr, setI(L_I)]),
+        ],
+      } as Instr,
+    ]),
+  ];
+  // peekLetter(): (i<len) && isAlpha(data[i]) — leaves i32 bool on stack.
+  const peekLetter: Instr[] = [
+    getI(L_I),
+    getI(L_LEN),
+    { op: "i32.lt_s" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "val", type: i32 },
+      then: [
+        ...loadC,
+        getI(L_C),
+        i32c(65),
+        { op: "i32.ge_s" } as Instr,
+        getI(L_C),
+        i32c(90),
+        { op: "i32.le_s" } as Instr,
+        { op: "i32.and" } as Instr,
+        getI(L_C),
+        i32c(97),
+        { op: "i32.ge_s" } as Instr,
+        getI(L_C),
+        i32c(122),
+        { op: "i32.le_s" } as Instr,
+        { op: "i32.and" } as Instr,
+        { op: "i32.or" } as Instr,
+      ],
+      else: [i32c(0)],
+    } as Instr,
+  ];
+  // readDigits1or2(dest): read one or two digits into `dest` (day-of-month).
+  const readDigits1or2 = (dest: number): Instr[] => [
+    // first digit (required)
+    ...readDigits(1, dest),
+    // optional second digit: if next is a digit, dest = dest*10 + d
+    ...guarded([
+      getI(L_I),
+      getI(L_LEN),
+      { op: "i32.lt_s" } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          ...loadC,
+          getI(L_C),
+          i32c(C_ZERO),
+          { op: "i32.ge_s" } as Instr,
+          getI(L_C),
+          i32c(C_NINE),
+          { op: "i32.le_s" } as Instr,
+          { op: "i32.and" } as Instr,
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              getI(dest),
+              i64c(10n),
+              { op: "i64.mul" } as Instr,
+              getI(L_C),
+              i32c(C_ZERO),
+              { op: "i32.sub" } as Instr,
+              { op: "i64.extend_i32_s" } as Instr,
+              { op: "i64.add" } as Instr,
+              setI(dest),
+              getI(L_I),
+              i32c(1),
+              { op: "i32.add" } as Instr,
+              setI(L_I),
+            ],
+          } as Instr,
+        ],
+      } as Instr,
+    ]),
+  ];
+
   const body: Instr[] = [
     // flatten
     getI(0),
@@ -246,6 +498,14 @@ export function emitNativeDateParse(ctx: CodegenContext): void {
     i32c(0),
     setI(L_HASTIME),
   ];
+
+  // (#2164) The original ECMAScript Date-Time-String scanner below fills the
+  // field locals for the ISO grammar. It is captured into `isoArm` and wrapped
+  // in a dispatch that routes a leading-letter string (RFC2822 / `toString` /
+  // `toDateString` form, e.g. "Tue, 14 Nov 2023 22:13:20 GMT") to `rfcArm`
+  // instead. Both arms fill the SAME field locals, so the shared
+  // `i==len` + range-validate + compose tail handles either.
+  const isoStart = body.length;
 
   // --- Year: optional sign + 6 digits (expanded) OR 4 digits ---
   body.push(
@@ -393,6 +653,259 @@ export function emitNativeDateParse(ctx: CodegenContext): void {
     ]),
   );
 
+  // Capture the ISO field-parse instructions emitted above into `isoArm`.
+  const isoArm: Instr[] = body.splice(isoStart);
+
+  // ── RFC2822 / `toString` / `toDateString` arm ────────────────────────────
+  // Grammars (all rendered UTC by our formatters, #1682):
+  //   toUTCString : "Www, DD Mon YYYY HH:mm:ss GMT"
+  //   toString    : "Www Mon DD YYYY HH:mm:ss GMT±HHMM (…)"
+  //   toDateString: "Www Mon DD YYYY"
+  // Shared shape: an optional weekday (3 letters, optional trailing comma),
+  // then EITHER `DD Mon YYYY` (toUTCString) OR `Mon DD YYYY` (toString/
+  // toDateString), then an optional `HH:mm:ss`, then an optional timezone
+  // (`GMT`, `UTC`, `Z`, or `±HHMM` / `GMT±HHMM`). Trailing `(…)` text is
+  // tolerated. All times are UTC (standalone has no TZ DB), matching the
+  // formatter/clock decisions of the earlier #2164 slices.
+  const parseHMSOptional: Instr[] = [
+    ...guarded([
+      ...skipSpaces,
+      // require a digit to start a time field
+      getI(L_I),
+      getI(L_LEN),
+      { op: "i32.lt_s" } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          ...loadC,
+          getI(L_C),
+          i32c(C_ZERO),
+          { op: "i32.ge_s" } as Instr,
+          getI(L_C),
+          i32c(C_NINE),
+          { op: "i32.le_s" } as Instr,
+          { op: "i32.and" } as Instr,
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              ...readDigits(2, L_HOUR),
+              ...expectChar(C_COLON),
+              ...readDigits(2, L_MIN),
+              // optional :ss
+              ...guarded([
+                ...peekIs(C_COLON),
+                {
+                  op: "if",
+                  blockType: { kind: "empty" },
+                  then: [getI(L_I), i32c(1), { op: "i32.add" } as Instr, setI(L_I), ...readDigits(2, L_SEC)],
+                } as Instr,
+              ]),
+            ],
+          } as Instr,
+        ],
+      } as Instr,
+    ]),
+  ];
+  // Optional explicit ±HHMM offset (after GMT/UTC or standalone). Sets tzSign /
+  // tzH / tzM. `GMT`/`UTC`/`Z` literals are skipped by the trailing-tolerance
+  // loop, so here we only handle a leading sign.
+  const parseTZOptional: Instr[] = [
+    ...guarded([
+      ...skipSpaces,
+      // skip a leading "GMT"/"UTC" (3 letters) if present, so a following
+      // ±HHMM is still read.
+      ...guarded([
+        ...peekLetter,
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            // advance over a run of letters (G M T / U T C / Z); tolerant loop:
+            // if next is a letter, advance + re-loop (br depth 0), else exit.
+            {
+              op: "loop",
+              blockType: { kind: "empty" },
+              body: [
+                ...peekLetter,
+                {
+                  op: "if",
+                  blockType: { kind: "empty" },
+                  then: [getI(L_I), i32c(1), { op: "i32.add" } as Instr, setI(L_I), { op: "br", depth: 0 } as Instr],
+                } as Instr,
+              ],
+            } as Instr,
+          ],
+        } as Instr,
+      ]),
+      // optional ±HHMM
+      ...guarded([
+        ...peekIs(C_PLUS),
+        {
+          op: "if",
+          blockType: { kind: "val", type: i32 },
+          then: [i32c(1)],
+          else: [...peekIs(C_MINUS)],
+        } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            // tzSign = (data[i]=='-') ? -1 : +1 ; i++
+            ...peekIs(C_MINUS),
+            {
+              op: "if",
+              blockType: { kind: "val", type: i64 },
+              then: [i64c(-1n)],
+              else: [i64c(1n)],
+            } as Instr,
+            setI(L_TZSIGN),
+            getI(L_I),
+            i32c(1),
+            { op: "i32.add" } as Instr,
+            setI(L_I),
+            ...readDigits(2, L_TZH),
+            // optional ':' then mm
+            ...guarded([
+              ...peekIs(C_COLON),
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [getI(L_I), i32c(1), { op: "i32.add" } as Instr, setI(L_I)],
+              } as Instr,
+            ]),
+            ...readDigits(2, L_TZM),
+          ],
+        } as Instr,
+      ]),
+    ]),
+  ];
+  // Tolerate any trailing characters (a `(Coordinated Universal Time)` suffix,
+  // stray spaces, or a `GMT`/`Z` we didn't consume) so the final `i==len`
+  // check passes: advance `i` to `len`.
+  const consumeRest: Instr[] = [...guarded([getI(L_LEN), setI(L_I)])];
+
+  const rfcArm: Instr[] = [
+    // optional weekday: 3 letters then optional ',' then spaces
+    ...guarded([
+      ...peekLetter,
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          // Disambiguate a weekday prefix from a leading MONTH (the toString /
+          // toDateString form starts with a 3-letter month, not a weekday).
+          // A weekday is present iff the 3-letter token is followed by:
+          //   ','                       (toUTCString: "Www, DD Mon …")
+          //   ' ' then a LETTER         (toString:    "Www Mon DD …")
+          // A leading month is followed by ' ' then a DIGIT ("Mon DD YYYY"),
+          // so that case is NOT treated as a weekday. Requires i+4 < len for the
+          // space-then-letter test; a too-short token defaults to "not weekday".
+          getI(L_I),
+          i32c(4),
+          { op: "i32.add" } as Instr,
+          getI(L_LEN),
+          { op: "i32.le_s" } as Instr,
+          {
+            op: "if",
+            blockType: { kind: "val", type: i32 },
+            then: [
+              // c3 = data[i+3]
+              getI(L_DATA),
+              getI(L_I),
+              i32c(3),
+              { op: "i32.add" } as Instr,
+              { op: "array.get_u", typeIdx: strDataTypeIdx } as Instr,
+              setI(L_C),
+              // isComma = c3 == ','
+              getI(L_C),
+              i32c(C_COMMA),
+              { op: "i32.eq" } as Instr,
+              // spaceThenLetter = (c3 == ' ') && isAlpha(data[i+4])
+              getI(L_C),
+              i32c(C_SPACE),
+              { op: "i32.eq" } as Instr,
+              // load c4 into L_C and test alpha
+              getI(L_DATA),
+              getI(L_I),
+              i32c(4),
+              { op: "i32.add" } as Instr,
+              { op: "array.get_u", typeIdx: strDataTypeIdx } as Instr,
+              setI(L_C),
+              getI(L_C),
+              i32c(65),
+              { op: "i32.ge_s" } as Instr,
+              getI(L_C),
+              i32c(90),
+              { op: "i32.le_s" } as Instr,
+              { op: "i32.and" } as Instr,
+              getI(L_C),
+              i32c(97),
+              { op: "i32.ge_s" } as Instr,
+              getI(L_C),
+              i32c(122),
+              { op: "i32.le_s" } as Instr,
+              { op: "i32.and" } as Instr,
+              { op: "i32.or" } as Instr, // isAlpha(c4)
+              { op: "i32.and" } as Instr, // (c3==' ') && isAlpha(c4)
+              { op: "i32.or" } as Instr, // isComma || spaceThenLetter
+            ],
+            else: [i32c(0)],
+          } as Instr,
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              // skip the 3 weekday letters
+              getI(L_I),
+              i32c(3),
+              { op: "i32.add" } as Instr,
+              setI(L_I),
+              // optional comma
+              ...guarded([
+                ...peekIs(C_COMMA),
+                {
+                  op: "if",
+                  blockType: { kind: "empty" },
+                  then: [getI(L_I), i32c(1), { op: "i32.add" } as Instr, setI(L_I)],
+                } as Instr,
+              ]),
+              ...skipSpaces,
+            ],
+          } as Instr,
+        ],
+      } as Instr,
+    ]),
+    // Now at either `DD Mon YYYY` (digit-first, toUTCString) or `Mon DD YYYY`
+    // (letter-first, toString/toDateString).
+    ...guarded([
+      ...peekLetter,
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        // letter-first: Mon DD YYYY
+        then: [...matchMonthName, ...skipSpaces, ...readDigits1or2(L_DAY), ...skipSpaces, ...readDigits(4, L_YEAR)],
+        // digit-first: DD Mon YYYY
+        else: [...readDigits1or2(L_DAY), ...skipSpaces, ...matchMonthName, ...skipSpaces, ...readDigits(4, L_YEAR)],
+      } as Instr,
+    ]),
+    ...parseHMSOptional,
+    ...parseTZOptional,
+    ...consumeRest,
+  ];
+
+  // Dispatch: a string whose first char (before any whitespace) is a letter is
+  // the RFC2822 / toString family; otherwise run the ISO scanner. (Leading
+  // spaces are uncommon for these forms; the ISO scanner already handles the
+  // numeric/sign-led ISO grammar.)
+  body.push(...peekLetter, {
+    op: "if",
+    blockType: { kind: "empty" },
+    then: rfcArm,
+    else: isoArm,
+  } as Instr);
+
   // --- require we consumed the whole string (i == len) ---
   body.push(
     ...guarded([
@@ -499,6 +1012,9 @@ export function emitNativeDateParse(ctx: CodegenContext): void {
       { name: "ndig", type: i32 },
       { name: "days", type: i64 },
       { name: "hasTime", type: i32 },
+      { name: "m0", type: i32 }, // (#2164) lowercased month-name letters
+      { name: "m1", type: i32 },
+      { name: "m2", type: i32 },
     ],
     body,
     exported: false,

--- a/tests/issue-2164-date-parse-rfc2822.test.ts
+++ b/tests/issue-2164-date-parse-rfc2822.test.ts
@@ -1,0 +1,115 @@
+// #2164 (Date.parse RFC2822 extension) — standalone Date.parse of the
+// RFC2822 / `toString` / `toDateString` string forms.
+//
+// The pure-Wasm `__date_parse` helper (date-parse-native.ts) previously handled
+// only the ECMAScript Date-Time-String (ISO) grammar, so `Date.parse` of an
+// RFC2822 / `toString`-shaped string ("Tue, 14 Nov 2023 22:13:20 GMT",
+// "Tue Nov 14 2023 …", "Nov 14 2023") returned NaN standalone. This slice adds
+// a month-name / weekday-aware arm: a leading-letter string routes to an
+// RFC2822 scanner that fills the SAME field locals as the ISO scanner, so the
+// shared range-validate + compose tail handles either. All forms are parsed as
+// UTC (standalone has no timezone DB), matching the formatter/clock decisions
+// of the earlier #2164 slices — so it ROUND-TRIPS the #1682 formatters:
+// `Date.parse(d.toUTCString())` / `Date.parse(d.toString())` recover the
+// timestamp (to second precision — toUTCString/toString carry no milliseconds,
+// exactly like V8).
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function parse(str: string): Promise<number> {
+  // Escape embedded quotes/backslashes defensively (none here, but safe).
+  const src = `export function run(): number { return Date.parse("${str}"); }`;
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  expect((r.imports ?? []).map((i) => i.name)).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { run(): number }).run();
+}
+
+describe("#2164 — standalone Date.parse of RFC2822 / toString forms", () => {
+  it("toUTCString form: 'Www, DD Mon YYYY HH:mm:ss GMT'", async () => {
+    expect(await parse("Tue, 14 Nov 2023 22:13:20 GMT")).toBe(1700000000000);
+    expect(await parse("Thu, 01 Jan 1970 00:00:00 GMT")).toBe(0);
+    expect(await parse("Wed, 31 Dec 1969 00:00:00 GMT")).toBe(-86400000);
+  });
+
+  it("toString form: 'Www Mon DD YYYY HH:mm:ss GMT+0000 (…)'", async () => {
+    expect(await parse("Tue Nov 14 2023 22:13:20 GMT+0000 (Coordinated Universal Time)")).toBe(1700000000000);
+    expect(await parse("Thu Jan 01 1970 00:00:00 GMT+0000")).toBe(0);
+  });
+
+  it("toDateString form: 'Www Mon DD YYYY' (date only, midnight UTC)", async () => {
+    expect(await parse("Tue Nov 14 2023")).toBe(1699920000000);
+    expect(await parse("Thu Jan 01 1970")).toBe(0);
+  });
+
+  it("month-first, no weekday: 'Mon DD YYYY'", async () => {
+    expect(await parse("Nov 14 2023")).toBe(1699920000000);
+    expect(await parse("Jan 1 1970")).toBe(0);
+    expect(await parse("Dec 31 1969")).toBe(-86400000);
+  });
+
+  it("an explicit ±HHMM offset is applied", async () => {
+    // 2023-11-14 22:13:20 at +0100 is 21:13:20 UTC = 1700000000000 - 3600000.
+    expect(await parse("Tue, 14 Nov 2023 22:13:20 +0100")).toBe(1700000000000 - 3600000);
+    expect(await parse("Tue, 14 Nov 2023 22:13:20 -0030")).toBe(1700000000000 + 30 * 60000);
+  });
+
+  it("all twelve month names resolve", async () => {
+    const months: Array<[string, number]> = [
+      ["Jan", 0],
+      ["Feb", 31],
+      ["Mar", 59],
+      ["Apr", 90],
+      ["May", 120],
+      ["Jun", 151],
+      ["Jul", 181],
+      ["Aug", 212],
+      ["Sep", 243],
+      ["Oct", 273],
+      ["Nov", 304],
+      ["Dec", 334],
+    ];
+    for (const [mon, dayOfYear] of months) {
+      // <Mon> 01 1970 → dayOfYear * 86400000 (1970 is not a leap year).
+      expect(await parse(`${mon} 01 1970`), mon).toBe(dayOfYear * 86400000);
+    }
+  });
+
+  it("ISO forms still parse (no regression)", async () => {
+    expect(await parse("2023-11-14T22:13:20Z")).toBe(1700000000000);
+    expect(await parse("2023-11-14")).toBe(1699920000000);
+    expect(await parse("2023-11-14T22:13:20.500Z")).toBe(1700000000500);
+  });
+
+  it("garbage / unsupported leading-letter strings are NaN, not a trap", async () => {
+    expect(Number.isNaN(await parse("Hello world"))).toBe(true);
+    expect(Number.isNaN(await parse("Xyz 99 2023"))).toBe(true);
+  });
+
+  it("round-trips the #1682 toUTCString/toString/toDateString formatters", async () => {
+    const src = `
+      export function rtUTC(ts: number): number { return Date.parse(new Date(ts).toUTCString()); }
+      export function rtStr(ts: number): number { return Date.parse(new Date(ts).toString()); }
+      export function rtDate(ts: number): number { return Date.parse(new Date(ts).toDateString()); }
+    `;
+    const r = await compile(src, { target: "standalone" });
+    expect(r.success, JSON.stringify(r.errors)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    const e = instance.exports as {
+      rtUTC(ts: number): number;
+      rtStr(ts: number): number;
+      rtDate(ts: number): number;
+    };
+    // toUTCString / toString carry seconds but no ms → round-trip to the second.
+    for (const ts of [0, 1700000000000, -86400000, 1000]) {
+      const sec = Math.floor(ts / 1000) * 1000;
+      expect(e.rtUTC(ts), `rtUTC(${ts})`).toBe(sec);
+      expect(e.rtStr(ts), `rtStr(${ts})`).toBe(sec);
+    }
+    // toDateString drops the time entirely → round-trip to the day.
+    for (const ts of [0, 1700000000000, -86400000]) {
+      expect(e.rtDate(ts), `rtDate(${ts})`).toBe(Math.floor(ts / 86400000) * 86400000);
+    }
+  });
+});


### PR DESCRIPTION
## #2164 (Date.parse RFC2822 extension) — standalone

The pure-Wasm `__date_parse` handled only the ECMAScript Date-Time-String (ISO) grammar, so `Date.parse` of an RFC2822 / `toString`-shaped string returned **NaN** standalone — including the round-trip of the #1682 formatters: `Date.parse(d.toUTCString())` / `d.toString()` / `d.toDateString()` all NaN'd.

### Fix
`__date_parse` now dispatches on the first char. A leading **letter** routes to a new RFC2822 arm parsing an optional weekday (`Www[,]`), then either `DD Mon YYYY` (toUTCString) or `Mon DD YYYY` (toString/toDateString), then an optional `HH:mm:ss`, then an optional timezone (`GMT`/`UTC`/`Z` or `±HHMM`). It fills the **same** field locals as the ISO arm, so the shared range-validate + compose tail handles either. New primitives: a branch-free case-insensitive 3-letter month-name matcher, a weekday/month disambiguator (a leading 3-letter token is a weekday only when followed by `,` or ` `+letter — so `Nov 14` is a month), and space/`GMT`-skipping loops. All UTC (standalone has no TZ DB), matching the formatter/clock decisions of slices 1–4.

**Dev note:** the month-name lowercaser first used an `if blockType val i32` whose `then` did `i32.add` against the pre-`if` operand — a value-result `if` arm has no implicit access to the stack below its frame, so this was an invalid-Wasm `i32.add need 2 got 1`. Rewrote branch-free with `select(c+32, c, isUpper)`.

### Verification
- **9/9** `tests/issue-2164-date-parse-rfc2822.test.ts` — toUTCString/toString/toDateString/month-first forms, **all 12 month names**, `±HHMM` offsets, garbage→NaN (no trap), ISO no-regression, and the **#1682 formatter round-trip** (to the second for toUTCString/toString since they carry no ms — like V8; to the day for toDateString).
- **44/44** existing `#2164` / `#2164-iso` / `#2164-formatters` suites — unchanged.
- `tsc` + prettier + coercion-sites + any-box gates clean; no host-import leak.

### Scope boundary (documented)
A bare `DD Mon YYYY` (day-first, **no** weekday, e.g. `"14 Nov 2023"`) starts with a digit → routes to the ISO scanner → NaN. No formatter emits that form; covering it needs the ISO scanner to detect a month-name mid-stream (deferred). The dominant value (round-tripping the formatters + RFC2822 GMT strings) is delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)