### PR TITLE
feat(#2193): standalone Array.prototype / Object.prototype value reads (PR-A)

### DIFF
--- a/plan/issues/2193-standalone-builtin-proto-value-read.md
+++ b/plan/issues/2193-standalone-builtin-proto-value-read.md
@@ -1,0 +1,130 @@
+---
+id: 2193
+title: "standalone: builtin .prototype / static-property value reads refuse (~83 tests) — register $NativeProto glue for Array/Object/Promise"
+status: in-progress
+assignee: ttraenkler/sdev-proxy3
+sprint: Backlog
+created: 2026-06-18
+updated: 2026-06-18
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: conformance
+area: codegen
+language_feature: builtins, reflection
+goal: standalone-mode
+related: [2175, 1907, 1888]
+origin: "2026-06-18 — #43 standalone failure-bucket harvest (2nd-biggest tractable bucket, ~83)"
+---
+
+# #2193 — standalone builtin `.prototype` / static-property value reads
+
+## Problem
+
+Reading a builtin's `.prototype` (or a static property) **as a value** refuses in
+standalone:
+
+```ts
+const p = Array.prototype; // Codegen error: Array.prototype ... not supported (#1907 / #1888 S6-b)
+const q = Object.prototype; // same
+const f = arr[Symbol.iterator]; // Symbol.iterator built-in static property value read ...
+const r = Promise.resolve; // Promise.resolve ... not supported
+```
+
+Confirmed live on current main (`Array.prototype` / `Object.prototype` both CE).
+
+## Root cause
+
+`property-access.ts:~2304` resolves a `<Builtin>.prototype` value read via
+`tryEnsureNativeProtoBrand(ctx, builtinName)` + `emitLazyNativeProtoGet` — but
+`tryEnsureNativeProtoBrand` only returns a brand for builtins whose
+**`NativeProtoBuiltinGlue` is already registered** (`getNativeProtoBuiltinGlue`).
+Only **RegExp** registers glue today (`ensureRegExpNativeProtoGlue`,
+regexp-standalone.ts). `Array` (brand `BUILTIN_BRAND_BASE+2`) and `Object`
+(`+18`) have **reserved brands but no glue**, so the read falls to
+`reportUnsupportedStandaloneBuiltinValueRead`.
+
+## Bucket (from the #43 harvest, 06-12 standalone JSONL, epics excluded)
+
+~83 standalone failures: `Array.prototype` value read (25) + `Symbol.iterator`
+read (40, many async-gen-adjacent — those stay blocked on #1373b) +
+`Object.prototype` (11) + `Promise.resolve` (7). The non-async slice is the
+genuinely tractable portion.
+
+## Implementation plan
+
+Model on `ensureRegExpNativeProtoGlue` (regexp-standalone.ts:1968) +
+`emitRegExpProtoMemberBody`:
+
+1. **`ensureArrayNativeProtoGlue(ctx)`** (new, in array-methods.ts or a new
+   `array-native-proto.ts`): `getBuiltinBrand(ctx,"Array")`, build a
+   `memberCsv` of `Array.prototype`'s own method names
+   (`at,concat,copyWithin,…,values,@@iterator`), `memberKind` (all `method`
+   except none — Array.prototype has no accessors except `@@unscopables` data),
+   `memberLength` from the spec arities, and `emitMemberBody(c,fctx,member,kind)`
+   that runs a brand-recovery prologue on the externref `this` (recover the
+   `$ObjVec`/array backing) then **delegates to the existing native array-method
+   lowering** (`compileArrayMethodCall`-equivalent body) where one exists, and
+   returns `null` (graceful refusal) for not-yet-native members. Call it from
+   `tryEnsureNativeProtoBrand` (add an `Array` arm beside the `RegExp` one).
+2. **`ensureObjectNativeProtoGlue(ctx)`**: same shape for `Object.prototype`
+   (`hasOwnProperty,isPrototypeOf,propertyIsEnumerable,toString,valueOf,
+toLocaleString`). Bodies are small; `hasOwnProperty`/`toString`/`valueOf`
+   already have native standalone forms to delegate to.
+3. **`arr[Symbol.iterator]` value read** (computed `@@iterator` member): route
+   through the same `$NativeProto` member lookup so the iterator-protocol value
+   read resolves host-free. (Overlaps task #42/#18 — the iterator consumer.)
+4. **`tryEnsureNativeProtoBrand`**: replace the RegExp-only special-case with a
+   small dispatch table `{ RegExp: ensureRegExp…, Array: ensureArray…, Object:
+ensureObject… }` so any registered builtin resolves.
+
+**Dual-mode:** host mode is unaffected (`__get_builtin` path stays). Pure Wasm,
+no new host import. Reuse existing native method lowerings — do NOT hand-roll a
+parallel array/object method matrix (respect the coercion-drift gate #2108 and
+the any-box gate).
+
+## Acceptance criteria
+
+- `const p = Array.prototype` / `Object.prototype` compile + read a stable
+  `$NativeProto` externref standalone (reference identity:
+  `Array.prototype === Array.prototype`).
+- `Array.prototype.slice` / `arr[Symbol.iterator]` as values resolve to a
+  closure (callable where the member body is native; graceful refusal otherwise).
+- The standalone `built-ins/Array/prototype/*` + `Object/prototype/*` value-read
+  failures drop; RegExp proto reflection (#2175) stays green.
+- No host-import leak; tsc + prettier + coercion + any-box gates clean.
+
+## Notes
+
+This is a sizable multi-method registration (Array.prototype alone has ~30
+members). Recommend slicing: PR-A `Array.prototype` value read + `@@iterator`
+
+- the 4–6 already-native methods; PR-B `Object.prototype`; PR-C the remaining
+  Array methods. The harvest ranked this the 2nd-biggest tractable bucket (#43).
+
+## PR-A (2026-06-18, sdev-proxy3) — the proto OBJECT value reads
+
+**Landed (this PR).** `Array.prototype` AND `Object.prototype` value reads now
+resolve to a host-free `$NativeProto` object in standalone, with reference
+identity, instead of the hard compile refusal. New module
+`src/codegen/array-object-proto.ts` registers lightweight `NativeProtoBuiltinGlue`
+for both (proto member-name CSV + brand name); `tryEnsureNativeProtoBrand`
+(property-access.ts) gains `Array`/`Object` arms beside the existing `RegExp`
+one. **Key insight:** `emitLazyNativeProtoGet` builds the `$NativeProto` struct
+purely from `glue.memberCsv` + `glue.name` and NEVER calls `emitMemberBody`, so
+the value-read object works immediately with just the CSV; per-member native
+closure bodies are deferred to PR-C and degrade to a catchable TypeError (not a
+compile refusal) meanwhile.
+
+High-value side effect: `Object.prototype.hasOwnProperty.call(o, key)` — the
+frequent `assert(Object.prototype.hasOwnProperty.call(...))` idiom (>=12 in the
+harvest) — now compiles + runs (the inner `Object.prototype` read no longer
+refuses).
+
+Verified: 7/7 `tests/issue-2193-builtin-proto-value-read.test.ts`; 17/17
+existing #2175 native-proto suites unchanged; coercion + any-box gates clean;
+no host-import leak.
+
+**Remaining (PR-B/PR-C, issue stays in-progress):** per-member native closure
+bodies for Array/Object.prototype (delegate to existing array/object-method
+lowering); `arr[Symbol.iterator]` computed read; `Promise.resolve` static read.

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#2193 / #43 harvest) Native `$NativeProto` glue for `Array.prototype` and
+ * `Object.prototype` so a bare `Array.prototype` / `Object.prototype` value read
+ * resolves host-free in `--target standalone` instead of refusing
+ * (`property-access.ts` `reportUnsupportedStandaloneBuiltinValueRead`,
+ * "#1907 / #1888 S6-b").
+ *
+ * Scope (PR-A): the PROTO OBJECT itself. `emitLazyNativeProtoGet` builds the
+ * `$NativeProto` struct purely from the glue's `memberCsv` + `name` — it never
+ * calls `emitMemberBody`. So registering glue with the correct member CSV makes
+ * `Array.prototype` / `Object.prototype` value reads (and their reference
+ * identity, `Array.prototype === Array.prototype`) work immediately. Reflective
+ * member-CLOSURE materialization (`Array.prototype.slice` as a callable value)
+ * still routes through `emitMemberBody`; until the per-member native bodies are
+ * filled in (PR-C), those degrade gracefully via a catchable TypeError rather
+ * than a hard compile refusal — see `emitMemberBody` below.
+ *
+ * Dual-mode: host mode is untouched (the `__get_builtin` path stays). Pure Wasm,
+ * no new host import.
+ */
+
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import type { ValType } from "../ir/types.js";
+import {
+  getBuiltinBrand,
+  getNativeProtoBuiltinGlue,
+  registerNativeProtoBuiltin,
+  type NativeProtoBuiltinGlue,
+} from "./native-proto.js";
+import { emitThrowTypeError } from "./expressions/helpers.js";
+
+/**
+ * `Array.prototype`'s own enumerable+non-enumerable method names (ES2024
+ * §23.1.3). `@@iterator` is the well-known-symbol member (the `$NativeProto`
+ * symbol-cell sentinel form is `@@<id>`; Symbol.iterator's id is threaded by the
+ * caller — for the value-read object we only need the string members in the CSV,
+ * the symbol member is resolved by the computed-access path).
+ */
+const ARRAY_PROTO_METHODS = [
+  "at",
+  "concat",
+  "copyWithin",
+  "entries",
+  "every",
+  "fill",
+  "filter",
+  "find",
+  "findIndex",
+  "findLast",
+  "findLastIndex",
+  "flat",
+  "flatMap",
+  "forEach",
+  "includes",
+  "indexOf",
+  "join",
+  "keys",
+  "lastIndexOf",
+  "map",
+  "pop",
+  "push",
+  "reduce",
+  "reduceRight",
+  "reverse",
+  "shift",
+  "slice",
+  "some",
+  "sort",
+  "splice",
+  "toLocaleString",
+  "toReversed",
+  "toSorted",
+  "toSpliced",
+  "toString",
+  "unshift",
+  "values",
+  "with",
+] as const;
+
+/** `Object.prototype`'s own method names (ES2024 §20.1.3). */
+const OBJECT_PROTO_METHODS = [
+  "hasOwnProperty",
+  "isPrototypeOf",
+  "propertyIsEnumerable",
+  "toLocaleString",
+  "toString",
+  "valueOf",
+] as const;
+
+/** Spec arity (`fn.length`) of the proto methods that differ from the default 1. */
+const PROTO_METHOD_LENGTH: Readonly<Record<string, number>> = {
+  concat: 1,
+  copyWithin: 2,
+  every: 1,
+  fill: 1,
+  forEach: 1,
+  push: 1,
+  reduce: 1,
+  splice: 2,
+  unshift: 1,
+  with: 2,
+  hasOwnProperty: 1,
+  isPrototypeOf: 1,
+  propertyIsEnumerable: 1,
+  // entries/keys/values/reverse/pop/shift/toString/valueOf/… default to 0 or 1;
+  // the value-read object does not depend on exact arities, only the member set.
+};
+
+/**
+ * Graceful member-body refusal: the value-read object (PR-A) does not need
+ * member bodies, but if a reflective member closure is materialized for a member
+ * whose native body isn't wired yet, emit a catchable TypeError instead of a
+ * hard compile error. Keeps `Array.prototype` reads compilable while the
+ * per-member native bodies land incrementally (#2193 PR-C).
+ */
+function emitProtoMemberBodyRefusal(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  brandName: string,
+  member: string,
+): ValType | null {
+  emitThrowTypeError(ctx, fctx, `${brandName}.prototype.${member} is not yet implemented in --target standalone`);
+  return null;
+}
+
+function makeGlue(
+  ctx: CodegenContext,
+  brand: number,
+  name: string,
+  members: readonly string[],
+): NativeProtoBuiltinGlue {
+  return {
+    brand,
+    name,
+    memberCsv: members.join(","),
+    // Array/Object.prototype members are all data methods (no accessor getters
+    // on the prototype itself; `length` is an own data property of an instance,
+    // not the proto).
+    memberKind: () => "method",
+    memberLength: (member) => PROTO_METHOD_LENGTH[member] ?? 1,
+    emitMemberBody: (c, fctx, member) => emitProtoMemberBodyRefusal(c, fctx, name, member),
+  };
+}
+
+/**
+ * Register `Array.prototype` glue (idempotent) and return its brand, or
+ * `undefined` if the Array brand isn't reserved (should not happen).
+ */
+export function ensureArrayNativeProtoGlue(ctx: CodegenContext): number | undefined {
+  const brand = getBuiltinBrand(ctx, "Array");
+  if (brand === undefined) return undefined;
+  if (!getNativeProtoBuiltinGlue(ctx, brand)) {
+    registerNativeProtoBuiltin(ctx, makeGlue(ctx, brand, "Array", ARRAY_PROTO_METHODS));
+  }
+  return brand;
+}
+
+/** Register `Object.prototype` glue (idempotent) and return its brand. */
+export function ensureObjectNativeProtoGlue(ctx: CodegenContext): number | undefined {
+  const brand = getBuiltinBrand(ctx, "Object");
+  if (brand === undefined) return undefined;
+  if (!getNativeProtoBuiltinGlue(ctx, brand)) {
+    registerNativeProtoBuiltin(ctx, makeGlue(ctx, brand, "Object", OBJECT_PROTO_METHODS));
+  }
+  return brand;
+}

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -49,6 +49,7 @@ import {
   getBuiltinBrand,
   getNativeProtoBuiltinGlue,
 } from "./native-proto.js";
+import { ensureArrayNativeProtoGlue, ensureObjectNativeProtoGlue } from "./array-object-proto.js";
 import { isBuiltinSubtype, isBuiltinTypeName } from "./builtin-tags.js";
 import { getOrRegisterErrorStructType, isWasiErrorName } from "./registry/error-types.js";
 import { addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "./registry/imports.js";
@@ -451,6 +452,17 @@ function ensureStandaloneNativeMethodClosureLocal(
 function tryEnsureNativeProtoBrand(ctx: CodegenContext, builtinName: string): number | undefined {
   if (builtinName === "RegExp") {
     return ensureRegExpNativeProtoGlue(ctx);
+  }
+  // (#2193) Array.prototype / Object.prototype value reads — register the
+  // native-proto glue on demand so the read resolves to a `$NativeProto` object
+  // host-free instead of refusing. The proto OBJECT only needs the member CSV +
+  // name (emitLazyNativeProtoGet never calls emitMemberBody); reflective member
+  // closures degrade to a catchable TypeError until their native bodies land.
+  if (builtinName === "Array") {
+    return ensureArrayNativeProtoGlue(ctx);
+  }
+  if (builtinName === "Object") {
+    return ensureObjectNativeProtoGlue(ctx);
   }
   // Other builtins: only resolve if some path already registered glue for them.
   const brand = getBuiltinBrand(ctx, builtinName);

--- a/tests/issue-2193-builtin-proto-value-read.test.ts
+++ b/tests/issue-2193-builtin-proto-value-read.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #2193 (PR-A) — standalone `Array.prototype` / `Object.prototype` value reads.
+//
+// Reading a builtin's `.prototype` AS A VALUE refused in standalone:
+//   "Codegen error: Array.prototype built-in static property value read is not
+//    supported (#1907 / #1888 S6-b)".
+// Root cause: property-access.ts resolves `<Builtin>.prototype` value reads only
+// for builtins whose $NativeProto glue is registered — only RegExp registered.
+// Fix: register native-proto glue for Array/Object (array-object-proto.ts) and
+// wire it into tryEnsureNativeProtoBrand, so the read resolves to a host-free
+// $NativeProto object (with reference identity). The proto OBJECT only needs the
+// member CSV + name (emitLazyNativeProtoGet never calls emitMemberBody); per-
+// member native bodies are a follow-up (#2193 PR-C). This was the #43 harvest's
+// 2nd-biggest tractable standalone bucket (~83).
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  expect((r.imports ?? []).map((i) => i.name)).toEqual([]);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2193 (PR-A) — standalone builtin .prototype value reads", () => {
+  it("Array.prototype reads to a truthy value (was a compile refusal)", async () => {
+    expect(await runStandalone(`export function test(): number { const p = Array.prototype; return p ? 1 : 0; }`)).toBe(
+      1,
+    );
+  });
+
+  it("Object.prototype reads to a truthy value", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const p = Object.prototype; return p ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("Array.prototype === Array.prototype (reference identity, single global)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return Array.prototype === Array.prototype ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("Object.prototype === Object.prototype (reference identity)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return Object.prototype === Object.prototype ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("Object.prototype.hasOwnProperty.call(o, key) — the common assert shape", async () => {
+    // `assert(Object.prototype.hasOwnProperty.call(o, "x"))` is a frequent
+    // test262 idiom; the inner Object.prototype value read used to refuse.
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const o: any = { x: 1 };
+          return Object.prototype.hasOwnProperty.call(o, "x") ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("no regression: instance array methods still work", async () => {
+    expect(await runStandalone(`export function test(): number { return [3, 1, 2].sort()[0]; }`)).toBe(1);
+  });
+
+  it("no regression: RegExp.prototype value read (the #2175 path) still resolves", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const p = RegExp.prototype; return p ? 1 : 0; }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2193 (PR-A) — standalone builtin `.prototype` value reads

#43 harvest's 2nd-biggest tractable standalone bucket (~83). Reading a builtin's `.prototype` **as a value** refused: *"Codegen error: Array.prototype built-in static property value read is not supported (#1907 / #1888 S6-b)"*. Confirmed live on main (`Array.prototype` / `Object.prototype` both CE).

### Root cause
`property-access.ts` `tryEnsureNativeProtoBrand` resolved `<Builtin>.prototype` value reads only for builtins with **registered `$NativeProto` glue** — only **RegExp** registered (#2175). `Array` (brand `BASE+2`) / `Object` (`BASE+18`) had reserved brands but **no glue** → refusal.

### Fix (PR-A — the proto OBJECT)
New `src/codegen/array-object-proto.ts` registers lightweight `NativeProtoBuiltinGlue` for Array/Object (proto member-name CSV + brand name); `tryEnsureNativeProtoBrand` gains `Array`/`Object` arms beside `RegExp`. **Key insight:** `emitLazyNativeProtoGet` builds the `$NativeProto` struct purely from `glue.memberCsv` + `glue.name` and **never** calls `emitMemberBody` — so `Array.prototype` / `Object.prototype` value reads (+ reference identity) work immediately with just the CSV. Per-member native closure bodies are deferred to PR-C and degrade to a catchable TypeError (not a compile refusal) meanwhile.

**High-value side effect:** `Object.prototype.hasOwnProperty.call(o, key)` — the frequent `assert(Object.prototype.hasOwnProperty.call(...))` test262 idiom (≥12 in the harvest) — now compiles + runs.

### Verification
- **7/7** `tests/issue-2193-builtin-proto-value-read.test.ts` — Array/Object `.prototype` reads, reference identity, `hasOwnProperty.call`, instance-method + RegExp.prototype no-regression.
- **17/17** existing `#2175` native-proto suites unchanged.
- `tsc` + prettier + coercion-sites + any-box gates clean; no host-import leak; host mode untouched.

### Follow-up (#2193 PR-B/PR-C, issue stays in-progress)
Per-member native closure bodies for Array/Object `.prototype` (delegate to existing array/object-method lowering), `arr[Symbol.iterator]` computed read, `Promise.resolve` static read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)