### PR TITLE
feat(#2357): standalone TypedArray subarray-aliasing via additive $__subview (zero hot-path cost)

### DIFF
--- a/plan/issues/2357-typedarray-subarray-aliasing-view-rep.md
+++ b/plan/issues/2357-typedarray-subarray-aliasing-view-rep.md
@@ -1,7 +1,7 @@
 ---
 id: 2357
 title: "Standalone TypedArray subarray-aliasing — offset-windowing view representation"
-status: ready
+status: done
 sprint: Backlog
 created: 2026-06-18
 priority: medium
@@ -288,3 +288,30 @@ their objType is the vec struct, not externref). Then wire the WRITE path
 (`compileElementAssignment`, assignment.ts:2693) with the same
 `data[byteOffset+i]` store, and add the scoped standalone tests. Branch
 `issue-2357-subarray-impl` (WIP 1–5).
+
+### DONE (WIP 6-8) — full subarray aliasing implemented, zero hot-path cost
+
+Implementation complete on `issue-2357-subarray-impl`. The two remaining wrinkles
+from WIP 5 are fixed:
+- **Read arm placement:** the `$__subview` element-read arm ran AFTER the
+  tuple/struct-field check, which intercepts any non-2-field struct. Moved it to run
+  right after `typeDef` resolves (before the tuple check), gated on
+  `isSubviewTypeIdx`. `s[i]` reads now route through `data[byteOffset+i]`.
+- **Write arm:** added the mirror arm in `compileElementAssignment` (also before the
+  2-field check); stashes index+value, stores into the SHARED backing array, and
+  re-pushes the value (assignment is an expression — fixes a `drop` stack imbalance).
+- **Nested subarray:** `compileTypedArraySubarray` elemKind derivation now strips
+  `__subview_` as well as `__vec_`, so `s.subarray()` on a subview accumulates the
+  offset over the same shared array.
+
+**Verified** (`tests/issue-2357-subarray-aliasing.test.ts`, 8 cases): write-through
+aliasing (`s[0]=99 → a[1]===99`), parent-write→view-read, view-read maps to
+`parent[begin]`, write/read round-trip, `.length` (explicit + default-end), nested
+subarray aliasing, and plain typed-array access unaffected. 38/38 existing
+typed-array + DataView tests pass; coercion-sites gate OK.
+
+**Hot-path cost = ZERO** (the #1673 discipline): WAT-diff of a plain
+`for (i) sum += a[i]` over a `Uint8Array` shows `array.get_u: 1` and **no**
+`__subview` / `ref.test` / `__sv_recv` instructions — the discrimination is entirely
+compile-time (the binding's static `$__subview` vs vec type), so regular arrays pay
+nothing.

--- a/plan/issues/2357-typedarray-subarray-aliasing-view-rep.md
+++ b/plan/issues/2357-typedarray-subarray-aliasing-view-rep.md
@@ -163,3 +163,41 @@ inserted (length must stay field 0). The DataView windowing slice (PR #1678)
 validated the additive-wrapper approach end-to-end; subarray differs only in that
 its accessor IS the generic `a[i]` path, which is why the discrimination strategy
 (above) is the load-bearing decision.
+
+## Implementation status (#47, 2026-06-18) — BLOCKED on type-index stability
+
+WIP on branch `issue-2357-subarray-impl` (commits "WIP 1/4", "WIP 2/4"). The
+representation + lowering are built and correct in isolation:
+
+- `$__subview_<elem> {length:i32, data:(ref null $__arr_<elem>), byteOffset:i32}`
+  registered (`getOrRegisterSubviewType`); deliberately holds the backing **array**
+  directly (uniquely deduped per elem kind) rather than a vec struct idx, to avoid
+  the dual-vec-registration hazard.
+- `compileTypedArraySubarray` builds a windowing `$__subview` sharing `parent.data`
+  (no copy), with offset accumulation for nested `subarray`; host mode keeps the copy.
+- `compileElementAccess` reads `$__subview.data[byteOffset + i]`, compile-time
+  discriminated via the receiver `typeIdx` (zero cost on the plain `a[i]` path).
+- `inferLetConstInitializerWasmType` resolves a `subarray`-result binding to the
+  subview type.
+
+**The blocker** is *not* in any of the above — it is **type-index stability across
+the compiler's two type-numbering passes**. The hoist pass sizes the binding's local
+from `inferLetConstInitializerWasmType` (which on-demand-registers the subview at,
+say, idx 45); the body pass re-numbers and the subview lands at a different idx (35),
+while the binding local was already pinned to the hoist-pass number. Result: the
+`s` local and the emitted `struct.new` disagree, so reads/`.length` return 0.
+
+A naive fix — eagerly registering the subview inside `getOrRegisterVecType` —
+**back-fires**: it shifts type indices so `resolveWasmType(Uint8Array)` resolves a
+plain `new Uint8Array()` to the *subview* idx, building the parent array itself as a
+subview (verified: `local $a (ref null <subview>)`). So index shifting is too fragile.
+
+**Recommended fix (next session):** reserve the `$__subview_<elem>` type slots in the
+**deterministic up-front type-init phase** — the same place `$__vec_base`,
+`$AnyString`/`$NativeString`/`$ConsString`, and the box-number/box-bool structs are
+registered (see `index.ts` ~9002–9016 and `registerNativeStringTypes`) — so the
+subview idx is identical in both passes. Then the existing inference + element-access
++ subarray-lowering wiring works unchanged. A symbol-keyed side-map is the fallback,
+but the binding local still needs the subview *type* to hold the struct, so the
+stable-reservation route is cleaner. Writes (`s[i] = v` → same `data[byteOffset+i]`
+store) and scoped standalone tests remain to wire once the binding type lands.

--- a/plan/issues/2357-typedarray-subarray-aliasing-view-rep.md
+++ b/plan/issues/2357-typedarray-subarray-aliasing-view-rep.md
@@ -201,3 +201,59 @@ subview idx is identical in both passes. Then the existing inference + element-a
 but the binding local still needs the subview *type* to hold the struct, so the
 stable-reservation route is cleaner. Writes (`s[i] = v` → same `data[byteOffset+i]`
 store) and scoped standalone tests remain to wire once the binding type lands.
+
+### Update (WIP 4/4) — reservation done, de-sync narrowed below the renumber pass
+
+`reserveTypedArraySubviewTypes(ctx)` is now called at the deterministic up-front
+point in `generateModule` (after the linear-u8 reservation). **This fixed the
+parent-as-subview regression** — plain `new Uint8Array()` resolves to the vec
+correctly again, and 38/38 typed-array + DataView tests pass. But the
+`s = a.subarray(...)` binding STILL gets the vec type, not the subview, so reads
+return 0.
+
+Narrowed the remaining de-sync: it is **NOT** the dead-type-elimination renumber.
+`dead-elimination.ts` remaps BOTH `func.locals[i].type` (line ~362) and body
+instructions through the same `tR` map, so a local and its `struct.new` stay in
+sync across elimination. The de-sync is **earlier**: a probe confirms
+`inferLetConstInitializerWasmType` runs for `s`, sees `recvName=__vec_i8_byte`, and
+RETURNS the subview ValType — yet the hoisted `s` local is allocated as the vec
+(`local $s (ref null <vec>)`, while the body emits `struct.new <subview>`). So
+`walkStmtForLetConst`'s allocation is not receiving / not honoring the subview
+ValType that inference returns for this binding. Next step: trace why
+`walkStmtForLetConst` (index.ts ~12669–12676) allocates the vec despite the
+`inferLetConstInitializerWasmType(...) ?? resolveWasmType(...)` expression.
+
+### ROOT CAUSE FOUND — exact fix location
+
+A probe on `allocLocal` (instrumented for subarray-result bindings) produced **no
+output**: the TDZ-hoist pre-pass allocation branch I'd wired (`walkStmtForLetConst`
+→ `inferLetConstInitializerWasmType`) is **never reached for `s`**. The binding's
+local is actually allocated at the **real variable-declaration compile site**,
+`compileVariableStatement` in `src/codegen/statements/variables.ts` (~line 590–641),
+where the `wasmType` chain ends in `localTypeForDeclaration(ctx, varType)` (= the
+vec) and does **not** consult subarray-subview inference. (That chain DOES already
+special-case the analogous `standaloneRegExpMatchArrayType` at line 590/600 — the
+exact pattern to mirror.)
+
+**THE FIX (localized, low-risk, mirrors existing code):**
+1. In `compileVariableStatement` (`variables.ts` ~590), compute a
+   `subarraySubviewType` for a `subarray`-result initializer (standalone/wasi) the
+   same way `inferLetConstInitializerWasmType` does — receiver `__vec_<elem>` /
+   `__subview_<elem>` name → `getOrRegisterSubviewType(elemKind)` — and add it to the
+   `wasmType` chain right after `standaloneRegExpMatchArrayType`.
+2. Keep the matching subview inference in the TDZ hoist pre-pass
+   (`inferLetConstInitializerWasmType`, already done) so a hoisted slot and the real
+   site agree (both resolve to the up-front-reserved, idx-stable subview).
+3. Then wire the WRITE path (`compileElementAssignment`, `assignment.ts:2693`) with
+   the same `$__subview` → `data[byteOffset+i]` store arm as the read path, and add
+   scoped standalone tests (sub-write visible in parent, parent-write visible in sub,
+   `.length`, byteOffset, negative/clamped begin/end, nested subarray, disjoint
+   windows).
+
+With the up-front reservation (WIP 4/4) the subview idx is stable and the
+parent-as-subview regression is gone (38/38 typed-array+DataView tests pass), so once
+the binding type is sourced at the real decl site the read/length/aliasing should
+land. Branch `issue-2357-subarray-impl` (commits WIP 1–4 + docs) has the full state.
+**Floor-gate hard** on the standalone baseline and **WAT-diff a plain Uint8Array
+for-loop before/after** to prove zero added instructions on the non-view path
+(the #1673 discipline).

--- a/plan/issues/2357-typedarray-subarray-aliasing-view-rep.md
+++ b/plan/issues/2357-typedarray-subarray-aliasing-view-rep.md
@@ -257,3 +257,34 @@ land. Branch `issue-2357-subarray-impl` (commits WIP 1–4 + docs) has the full 
 **Floor-gate hard** on the standalone baseline and **WAT-diff a plain Uint8Array
 for-loop before/after** to prove zero added instructions on the non-view path
 (the #1673 discipline).
+
+### Update (WIP 5) — `.length` WORKS; read-receiver flow is the last wrinkle
+
+Two root-cause fixes landed and verified:
+- **Binding type at the real decl site:** `inferSubarraySubviewType` in
+  `variables.ts` (~590) sources `s = a.subarray(...)` → `$__subview` (the TDZ-hoist
+  path was never reached for it; the live alloc is at `compileVariableStatement`).
+  `s`'s local is now `(ref null $__subview)` in the WAT and holds the
+  `struct.new $__subview` the lowering emits.
+- **`select` condition bug:** Wasm `select` returns the FIRST operand when the
+  condition is TRUE; the viewLen `max(end-begin,0)` used `i32.lt_s` (→ 0 for every
+  valid window). Fixed to `i32.ge_s`. **`s.length` now returns the correct window
+  length**, and plain `a[i]` is unaffected (no parent-as-subview regression). 40/40
+  non-pre-existing typed-array + DataView tests pass.
+
+**Last wrinkle:** `s[i]` element READ still leaks `env.__extern_get` — my
+`$__subview` read arm in `compileElementAccessBody` (property-access.ts ~4840) is
+NOT reached (`__sv_recv` absent from WAT). At the read site
+(`compileElementAccess` ~4529) `compileExpression(s)` evidently returns
+**externref**, not the subview ValType, so it takes the externref `__extern_get`
+fallback instead of the struct path. `compileIdentifier` returns the local's
+declared type (subview) — so either a later compile pass re-types `s` as externref
+(the TS type is `Uint8Array`), or a narrowing/coercion at the read site boxes it.
+Next: probe `objType.kind` at property-access.ts:4529 for `s[i]`; if externref,
+either (a) keep the local subview-typed through reads (suppress the
+externref-narrowing for subview-typed locals), or (b) add a `ref.test $__subview`
+runtime arm in the externref branch (still compile-time-free for plain arrays since
+their objType is the vec struct, not externref). Then wire the WRITE path
+(`compileElementAssignment`, assignment.ts:2693) with the same
+`data[byteOffset+i]` store, and add the scoped standalone tests. Branch
+`issue-2357-subarray-impl` (WIP 1–5).

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -7746,9 +7746,12 @@ function compileTypedArraySubarray(
   }
 
   // Standalone: build a windowing $__subview sharing the parent's data array.
-  const elemKind = ctx.typeIdxToStructName.get(vecTypeIdx)?.replace(/^__vec_/, "");
-  if (elemKind === undefined) {
-    // Defensive: unknown vec shape — fall back to the copy path.
+  // The receiver may be a plain vec (`__vec_<elem>`) or — for a nested subarray —
+  // itself a `$__subview_<elem>`; recover the element kind from either name.
+  const recvStructName = ctx.typeIdxToStructName.get(vecTypeIdx);
+  const elemKind = recvStructName?.replace(/^__vec_/, "").replace(/^__subview_/, "");
+  if (elemKind === undefined || elemKind === recvStructName) {
+    // Defensive: unknown shape — fall back to the copy path.
     return compileArraySlice(ctx, fctx, propAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType);
   }
   const subviewTypeIdx = getOrRegisterSubviewType(ctx, elemKind, elemType);

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -7822,6 +7822,9 @@ function compileTypedArraySubarray(
   }
 
   // viewLen = max(end - begin, 0); push as field 0.
+  // `select` returns the FIRST operand when the condition is non-zero (true), so
+  // with operands [(end-begin), 0] the condition must be `(end-begin) >= 0` to keep
+  // the difference and fall back to 0 when negative.
   fctx.body.push({ op: "local.get", index: endTmp });
   fctx.body.push({ op: "local.get", index: beginTmp });
   fctx.body.push({ op: "i32.sub" });
@@ -7830,7 +7833,7 @@ function compileTypedArraySubarray(
   fctx.body.push({ op: "local.get", index: beginTmp });
   fctx.body.push({ op: "i32.sub" });
   fctx.body.push({ op: "i32.const", value: 0 } as Instr);
-  fctx.body.push({ op: "i32.lt_s" });
+  fctx.body.push({ op: "i32.ge_s" });
   fctx.body.push({ op: "select" }); // max(end-begin, 0)
 
   // data = shared backing array (field 1).

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -15,7 +15,14 @@ import type { ClosureInfo, CodegenContext, FunctionContext } from "./context/typ
 import { addArrayIteratorImports, addStringImports, addUnionImports, resolveWasmType } from "./index.js";
 import { addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "./registry/imports.js";
 import { compileStringLiteral } from "./shared.js";
-import { getArrTypeIdxFromVec, getOrRegisterArrayType, getOrRegisterVecType } from "./registry/types.js";
+import {
+  getArrTypeIdxFromVec,
+  getOrRegisterArrayType,
+  getOrRegisterSubviewType,
+  getOrRegisterVecType,
+  getSubviewArrTypeIdx,
+} from "./registry/types.js";
+import { noJsHost } from "./expressions/helpers.js";
 import { ensureNativeIteratorRuntime, getOrRegisterIterRecType } from "./iterator-native.js";
 import { ensureObjVecBuilders } from "./object-runtime.js";
 import { ensureArgcGlobal, ensureCurrentThisGlobal, ensureExtrasArgvGlobal } from "./statements/nested-declarations.js";
@@ -7712,10 +7719,17 @@ function numericElemConvert(from: ValType, to: ValType): Instr[] {
 }
 
 /**
- * TypedArray.prototype.subarray(begin?, end?) (#1664) — returns a new vec over
- * the [begin, end) slice. The vec-struct model has no shared ArrayBuffer, so
- * this copies (matching `.slice` semantics); the acceptance criteria only
- * require correct element values + zero host imports, not buffer aliasing.
+ * TypedArray.prototype.subarray(begin?, end?) (#1664 / #2357 / #47).
+ *
+ * In standalone / WASI mode this returns a `$__subview` that SHARES the parent's
+ * backing `data` array (true aliasing per ECMA §23.2.3.30 — a write through the
+ * view is visible in the parent and vice-versa). The view carries `byteOffset`
+ * (element offset of `begin`) and the windowed `length`; element access on a
+ * `$__subview`-typed binding is discriminated at compile time and indexes
+ * `base.data[byteOffset + i]` (see compileElementAccess / compileElementAssignment).
+ *
+ * In JS-host mode the vec model has no shared-buffer concept on this path, so we
+ * keep the historical copy (`.slice` semantics) — aliasing there is a non-goal.
  */
 function compileTypedArraySubarray(
   ctx: CodegenContext,
@@ -7726,8 +7740,108 @@ function compileTypedArraySubarray(
   arrTypeIdx: number,
   elemType: ValType,
 ): ValType {
-  // subarray clamps the same way slice does; reuse the slice lowering.
-  return compileArraySlice(ctx, fctx, propAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType);
+  if (!noJsHost(ctx)) {
+    // Host mode: keep the copy (slice semantics) — no shared buffer here.
+    return compileArraySlice(ctx, fctx, propAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType);
+  }
+
+  // Standalone: build a windowing $__subview sharing the parent's data array.
+  const elemKind = ctx.typeIdxToStructName.get(vecTypeIdx)?.replace(/^__vec_/, "");
+  if (elemKind === undefined) {
+    // Defensive: unknown vec shape — fall back to the copy path.
+    return compileArraySlice(ctx, fctx, propAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType);
+  }
+  const subviewTypeIdx = getOrRegisterSubviewType(ctx, elemKind, elemType);
+
+  const parentVec = allocLocal(fctx, `__sub_parent_${fctx.locals.length}`, { kind: "ref_null", typeIdx: vecTypeIdx });
+  const lenTmp = allocLocal(fctx, `__sub_len_${fctx.locals.length}`, { kind: "i32" });
+  const beginTmp = allocLocal(fctx, `__sub_b_${fctx.locals.length}`, { kind: "i32" });
+  const endTmp = allocLocal(fctx, `__sub_e_${fctx.locals.length}`, { kind: "i32" });
+
+  // Compile receiver → parent vec ref. The receiver itself may be a $__subview
+  // (nested subarray); recover its base + accumulate offsets below.
+  const recvType = compileExpression(ctx, fctx, propAccess.expression);
+  // Nested-subarray support: if the receiver is itself a $__subview, unwrap to its
+  // base vec and carry its byteOffset forward as the parent offset baseline.
+  const baseOffsetTmp = allocLocal(fctx, `__sub_boff_${fctx.locals.length}`, { kind: "i32" });
+  // `dataTmp` holds the SHARED backing array (parent's `data`). For a plain-vec
+  // receiver it's `parent.data`; for a $__subview receiver (nested subarray) it's
+  // the already-shared `recv.data`, with the offset accumulated.
+  const subArrTypeIdx = getSubviewArrTypeIdx(ctx, subviewTypeIdx);
+  const dataTmp = allocLocal(fctx, `__sub_data_${fctx.locals.length}`, { kind: "ref_null", typeIdx: subArrTypeIdx });
+  if (recvType && (recvType.kind === "ref" || recvType.kind === "ref_null") && recvType.typeIdx === subviewTypeIdx) {
+    // receiver is $__subview: data = recv.data, baseOffset = recv.byteOffset, len = recv.length
+    const recvLocal = allocLocal(fctx, `__sub_recv_${fctx.locals.length}`, {
+      kind: "ref_null",
+      typeIdx: subviewTypeIdx,
+    });
+    fctx.body.push({ op: "local.set", index: recvLocal });
+    fctx.body.push({ op: "local.get", index: recvLocal });
+    fctx.body.push({ op: "struct.get", typeIdx: subviewTypeIdx, fieldIdx: 1 }); // shared data array
+    fctx.body.push({ op: "local.set", index: dataTmp });
+    fctx.body.push({ op: "local.get", index: recvLocal });
+    fctx.body.push({ op: "struct.get", typeIdx: subviewTypeIdx, fieldIdx: 2 }); // byteOffset
+    fctx.body.push({ op: "local.set", index: baseOffsetTmp });
+    fctx.body.push({ op: "local.get", index: recvLocal });
+    fctx.body.push({ op: "struct.get", typeIdx: subviewTypeIdx, fieldIdx: 0 }); // length
+    fctx.body.push({ op: "local.set", index: lenTmp });
+  } else {
+    fctx.body.push({ op: "local.set", index: parentVec });
+    emitReceiverNullGuard(ctx, fctx, parentVec);
+    fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+    fctx.body.push({ op: "local.set", index: baseOffsetTmp });
+    // data = parent.data (field 1) — SHARED, no copy
+    fctx.body.push({ op: "local.get", index: parentVec });
+    fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 });
+    fctx.body.push({ op: "local.set", index: dataTmp });
+    // len = parent.length (field 0)
+    fctx.body.push({ op: "local.get", index: parentVec });
+    fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 });
+    fctx.body.push({ op: "local.set", index: lenTmp });
+  }
+
+  // begin (default 0), §23.2.3.30: ToIntegerOrInfinity then negative-clamp to len.
+  if (callExpr.arguments.length >= 1) {
+    compileExpression(ctx, fctx, callExpr.arguments[0]!, { kind: "f64" });
+    fctx.body.push({ op: "i32.trunc_sat_f64_s" });
+  } else {
+    fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  }
+  fctx.body.push({ op: "local.set", index: beginTmp });
+  emitClampIndex(fctx, beginTmp, lenTmp);
+
+  // end (default len), same clamp.
+  if (callExpr.arguments.length >= 2) {
+    compileExpression(ctx, fctx, callExpr.arguments[1]!, { kind: "f64" });
+    fctx.body.push({ op: "i32.trunc_sat_f64_s" });
+    fctx.body.push({ op: "local.set", index: endTmp });
+    emitClampIndex(fctx, endTmp, lenTmp);
+  } else {
+    fctx.body.push({ op: "local.get", index: lenTmp });
+    fctx.body.push({ op: "local.set", index: endTmp });
+  }
+
+  // viewLen = max(end - begin, 0); push as field 0.
+  fctx.body.push({ op: "local.get", index: endTmp });
+  fctx.body.push({ op: "local.get", index: beginTmp });
+  fctx.body.push({ op: "i32.sub" });
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "local.get", index: endTmp });
+  fctx.body.push({ op: "local.get", index: beginTmp });
+  fctx.body.push({ op: "i32.sub" });
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "i32.lt_s" });
+  fctx.body.push({ op: "select" }); // max(end-begin, 0)
+
+  // data = shared backing array (field 1).
+  fctx.body.push({ op: "local.get", index: dataTmp });
+  // byteOffset = baseOffset + begin (field 2) — accumulates for nested subarrays.
+  fctx.body.push({ op: "local.get", index: baseOffsetTmp });
+  fctx.body.push({ op: "local.get", index: beginTmp });
+  fctx.body.push({ op: "i32.add" });
+
+  fctx.body.push({ op: "struct.new", typeIdx: subviewTypeIdx });
+  return { kind: "ref_null", typeIdx: subviewTypeIdx };
 }
 
 /**

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -161,6 +161,8 @@ export function createCodegenContext(
     templateVecTypeIdx: -1,
     vecBaseTypeIdx: -1, // (#2186) shared $__vec_base length supertype, lazy
     dvWindowTypeIdx: -1, // (#2159/#38) standalone DataView windowing wrapper, lazy
+    subviewTypeIdx: -1, // (#2159/#2357/#47) standalone TypedArray subarray view, lazy
+    subviewTypeMap: new Map(), // (#2357) per-elem-kind $__subview type idx
     errorStructTypeIdx: -1,
     widenedTypeProperties: new Map(),
     widenedVarStructMap: new Map(),

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1114,6 +1114,21 @@ export interface CodegenContext {
    * i32_byte vec representation (no wrapper, zero new cost).
    */
   dvWindowTypeIdx: number;
+  /**
+   * (#2159 / #2357 / #47) Type index for the standalone `$__subview` struct — a
+   * `{base: (ref null __vec_<elem>), byteOffset: i32, length: i32}` view produced
+   * by `TypedArray.prototype.subarray(begin, end)`. It SHARES the parent's backing
+   * `data` array (true aliasing — a sub-write is visible in the parent) and carries
+   * the element offset + windowed length. Element access discriminates view-vs-plain
+   * at COMPILE time via the receiver's resolved ValType (a binding initialised by
+   * `subarray` resolves to `$__subview`), so the plain-array `a[i]` hot path takes
+   * ZERO extra instructions — no per-access runtime branch. Keyed per element kind
+   * in `subviewTypeMap`; this scalar holds the most-recently-registered idx for
+   * back-compat. -1 = not yet registered. (Spec: plan/issues/2357.)
+   */
+  subviewTypeIdx: number;
+  /** (#2357) Per-element-kind `$__subview` struct type indices, keyed by elemKind. */
+  subviewTypeMap: Map<string, number>;
   /** Type index for the WasmGC `$Error_struct` used in standalone/WASI mode (#1104). -1 = not yet registered. */
   errorStructTypeIdx: number;
   /** Extra properties for empty object variables */

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -26,6 +26,7 @@ import {
   localGlobalIdx,
   resolveWasmType,
 } from "../index.js";
+import { getSubviewArrTypeIdx, isSubviewTypeIdx } from "../registry/types.js"; // (#2357/#47) subview write
 import { buildDestructureNullThrow, patternIteratorStepCount } from "../destructuring-params.js";
 import { resolveComputedKeyExpression } from "../literals.js";
 import {
@@ -2774,6 +2775,47 @@ function compileElementAssignment(
   }
   const typeIdx = (arrType as { typeIdx: number }).typeIdx;
   const typeDef = ctx.mod.types[typeIdx];
+
+  // (#2357/#47) `$__subview` target (TypedArray subarray): write through to the
+  // SHARED parent buffer at `data[byteOffset + i] = v` (true aliasing). Must run
+  // BEFORE the struct-field check below — a `$__subview` is a 3-field struct so the
+  // 2-field `isVecStructAssign` test is false and the field path would mis-handle
+  // it. Compile-time discriminated by the receiver typeIdx; plain vec arrays never
+  // reach this arm. The receiver ref is already on the stack (from line ~2765).
+  if (typeDef?.kind === "struct" && isSubviewTypeIdx(ctx, typeIdx)) {
+    const subArrTypeIdx = getSubviewArrTypeIdx(ctx, typeIdx);
+    const subArrDef = ctx.mod.types[subArrTypeIdx];
+    if (!subArrDef || subArrDef.kind !== "array") {
+      reportError(ctx, target, "Subview assignment: data is not an array");
+      return null;
+    }
+    const svLocal = allocLocal(fctx, `__sv_set_${fctx.locals.length}`, { kind: "ref_null", typeIdx });
+    fctx.body.push({ op: "local.set", index: svLocal } as Instr);
+    // absolute index = sv.byteOffset + i
+    fctx.body.push({ op: "local.get", index: svLocal } as Instr);
+    fctx.body.push({ op: "struct.get", typeIdx, fieldIdx: 2 } as Instr); // byteOffset
+    compileExpression(ctx, fctx, target.argumentExpression, { kind: "i32" });
+    fctx.body.push({ op: "i32.add" } as Instr);
+    const svIdxLocal = allocLocal(fctx, `__sv_idx_${fctx.locals.length}`, { kind: "i32" });
+    fctx.body.push({ op: "local.set", index: svIdxLocal } as Instr);
+    // value: unpack i8/i16 element kind into i32 for the value position (#2159
+    // Slice 1) — `array.set` re-packs into the packed element.
+    const valHint: ValType =
+      subArrDef.element.kind === "i8" || subArrDef.element.kind === "i16" ? { kind: "i32" } : subArrDef.element;
+    const valResult = compileExpression(ctx, fctx, value, valHint);
+    if (valResult && !valTypesMatch(valResult, valHint)) coerceType(ctx, fctx, valResult, valHint);
+    const svValLocal = allocLocal(fctx, `__sv_val_${fctx.locals.length}`, valHint);
+    fctx.body.push({ op: "local.set", index: svValLocal } as Instr);
+    // data[absIdx] = val  (shared backing array → aliases the parent)
+    fctx.body.push({ op: "local.get", index: svLocal } as Instr);
+    fctx.body.push({ op: "struct.get", typeIdx, fieldIdx: 1 } as Instr); // data array
+    fctx.body.push({ op: "local.get", index: svIdxLocal } as Instr);
+    fctx.body.push({ op: "local.get", index: svValLocal } as Instr);
+    fctx.body.push({ op: "array.set", typeIdx: subArrTypeIdx } as Instr);
+    // Assignment is an expression — re-push the value as its result.
+    fctx.body.push({ op: "local.get", index: svValLocal } as Instr);
+    return valHint;
+  }
 
   // Bracket assignment on struct: obj["prop"] = value → struct.set
   // Resolve field name from string/numeric literal, const variable, or constant expression

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1037,6 +1037,23 @@ export function generateModule(
       }
     }
 
+    // (#2357/#47) Reserve the standalone TypedArray `$__subview_<elem>` struct
+    // types up-front, here — at the SAME deterministic point in every codegen
+    // pass — so the subview type index is identical across the hoist pass (which
+    // sizes a `subarray`-result binding's local via
+    // `inferLetConstInitializerWasmType`) and the body/emit pass (which emits the
+    // matching `struct.new`). On-demand subview registration lands at
+    // pass-dependent indices, de-syncing the two; eager registration *inside*
+    // `getOrRegisterVecType` instead shifts the vec resolution itself (a plain
+    // `new Uint8Array()` then resolves to the subview). Reserving the subviews
+    // here — after the vec-independent linear-u8 reservation, before any function
+    // is compiled — gives a stable, isolated slot. `getOrRegisterSubviewType`
+    // pulls in only the backing array type (deduped per elem kind), so vec
+    // registration order is untouched. Standalone/WASI only; additive.
+    if (ctx.standalone || ctx.wasi) {
+      reserveTypedArraySubviewTypes(ctx);
+    }
+
     // $AnyValue struct type is now registered lazily via ensureAnyValueType()
 
     // Note: console imports handled by unified collector (skipped in WASI mode via registerWasiImports)
@@ -6017,6 +6034,20 @@ export function reserveLinearU8AllocType(ctx: CodegenContext): void {
   if (ctx.linearU8AllocTypeIdx !== undefined) return;
   if (!ctx.wasi) return;
   ctx.linearU8AllocTypeIdx = addFuncType(ctx, [{ kind: "i32" }], [{ kind: "i32" }]);
+}
+
+/**
+ * (#2357/#47) Reserve the standalone `$__subview_<elem>` struct types up-front so
+ * their indices are deterministic across codegen passes (see the call site in
+ * `generateModule`). Covers the element kinds standalone TypedArrays use for their
+ * backing arrays: `i8_byte` (Uint8Array) and `f64` (the other typed arrays).
+ * `getOrRegisterSubviewType` only forces the backing ARRAY type (uniquely deduped
+ * per element kind) — it does NOT register or reorder the vec struct, so plain
+ * typed-array resolution is unaffected. Idempotent.
+ */
+export function reserveTypedArraySubviewTypes(ctx: CodegenContext): void {
+  getOrRegisterSubviewType(ctx, "i8_byte", { kind: "i8" });
+  getOrRegisterSubviewType(ctx, "f64", { kind: "f64" });
 }
 
 export function ensureLinearU8AllocHelper(ctx: CodegenContext): number {

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -67,6 +67,7 @@ import {
   addFuncType,
   getArrTypeIdxFromVec,
   getOrRegisterArrayType,
+  getOrRegisterSubviewType,
   getOrRegisterTemplateVecType,
   getOrRegisterVecType,
 } from "./registry/types.js";
@@ -12586,7 +12587,25 @@ function inferLetConstInitializerWasmType(
     }
   }
   receiverType ??= resolveWasmType(ctx, ctx.checker.getTypeAtLocation(receiver));
-  return isVecStructType(ctx, receiverType) ? { kind: "ref_null", typeIdx: receiverType.typeIdx } : null;
+  if (!isVecStructType(ctx, receiverType)) return null;
+  // (#2357/#47) Standalone `subarray` produces a `$__subview` that shares the
+  // parent's backing array (true aliasing). Resolving the binding to the subview
+  // type here is what makes element access pick the windowed lowering at COMPILE
+  // time (so plain-array `a[i]` stays zero-cost). `slice` still returns an
+  // independent copy (a plain vec). The receiver may itself be a subview (nested
+  // subarray) — its element kind is recovered from the base vec.
+  if (methodName === "subarray" && (ctx.standalone || ctx.wasi)) {
+    const recvIdx = (receiverType as { typeIdx: number }).typeIdx;
+    // elemKind from the receiver's struct name: `__vec_<elem>` (plain typed array)
+    // or `__subview_<elem>` (nested subarray over a subview).
+    const recvName = ctx.typeIdxToStructName.get(recvIdx);
+    const elemKind = recvName?.replace(/^__vec_/, "").replace(/^__subview_/, "");
+    if (elemKind !== undefined && elemKind !== recvName) {
+      const svIdx = getOrRegisterSubviewType(ctx, elemKind);
+      return { kind: "ref_null", typeIdx: svIdx };
+    }
+  }
+  return { kind: "ref_null", typeIdx: receiverType.typeIdx };
 }
 
 function walkStmtForLetConst(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.Statement): void {

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -53,7 +53,7 @@ import { isBuiltinSubtype, isBuiltinTypeName } from "./builtin-tags.js";
 import { getOrRegisterErrorStructType, isWasiErrorName } from "./registry/error-types.js";
 import { addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "./registry/imports.js";
 import { getOrRegisterDvWindowType } from "./dataview-native.js"; // (#2159/#38) DataView windowing
-import { getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
+import { getArrTypeIdxFromVec, getOrRegisterVecType, getSubviewArrTypeIdx, isSubviewTypeIdx } from "./registry/types.js";
 import {
   coerceType,
   compileExpression,
@@ -4835,6 +4835,33 @@ export function compileElementAccessBody(
         }
       }
       return null;
+    }
+
+    // (#2357/#47) `$__subview` receiver (TypedArray subarray): read the SHARED
+    // parent buffer at `base.data[byteOffset + i]`. The receiver struct ref is on
+    // the stack. This arm is reached at COMPILE time only when the binding's static
+    // type is a subview, so plain-array access never pays for it.
+    if (isSubviewTypeIdx(ctx, typeIdx)) {
+      const subArrTypeIdx = getSubviewArrTypeIdx(ctx, typeIdx);
+      const subArrDef = ctx.mod.types[subArrTypeIdx];
+      if (!subArrDef || subArrDef.kind !== "array") {
+        reportErrorNoNode(ctx, "Element access: subview data is not an array");
+        return null;
+      }
+      const svLocal = allocLocal(fctx, `__sv_recv_${fctx.locals.length}`, { kind: "ref_null", typeIdx });
+      fctx.body.push({ op: "local.set", index: svLocal } as Instr);
+      // data = sv.data (the SHARED parent backing array, field 1)
+      fctx.body.push({ op: "local.get", index: svLocal } as Instr);
+      fctx.body.push({ op: "struct.get", typeIdx, fieldIdx: 1 } as Instr);
+      // index = sv.byteOffset + i
+      fctx.body.push({ op: "local.get", index: svLocal } as Instr);
+      fctx.body.push({ op: "struct.get", typeIdx, fieldIdx: 2 } as Instr); // byteOffset
+      compileExpression(ctx, fctx, expr.argumentExpression, { kind: "i32" });
+      fctx.body.push({ op: "i32.add" } as Instr);
+      const svValueType: ValType =
+        subArrDef.element.kind === "i8" || subArrDef.element.kind === "i16" ? { kind: "i32" } : subArrDef.element;
+      emitBoundsCheckedArrayGet(fctx, subArrTypeIdx, subArrDef.element);
+      return svValueType;
     }
 
     // Handle vec struct (array wrapped in {length, data})

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -4722,6 +4722,35 @@ export function compileElementAccessBody(
   const typeIdx = (objType as { typeIdx: number }).typeIdx;
   const typeDef = ctx.mod.types[typeIdx];
 
+  // (#2357/#47) `$__subview` receiver (TypedArray subarray) — read the SHARED
+  // parent buffer at `data[byteOffset + i]`. Must run BEFORE the tuple/struct-field
+  // check below: a `$__subview` is a 3-field struct {length, data, byteOffset}, so
+  // `isVecStructAccess` (exactly 2 fields) is false and the tuple path would
+  // mis-handle it. Compile-time discriminated by the receiver typeIdx, so plain
+  // arrays (vec struct, not subview) never reach this arm.
+  if (typeDef?.kind === "struct" && isSubviewTypeIdx(ctx, typeIdx)) {
+    const subArrTypeIdx = getSubviewArrTypeIdx(ctx, typeIdx);
+    const subArrDef = ctx.mod.types[subArrTypeIdx];
+    if (!subArrDef || subArrDef.kind !== "array") {
+      reportErrorNoNode(ctx, "Element access: subview data is not an array");
+      return null;
+    }
+    const svLocal = allocLocal(fctx, `__sv_recv_${fctx.locals.length}`, { kind: "ref_null", typeIdx });
+    fctx.body.push({ op: "local.set", index: svLocal } as Instr);
+    // data = sv.data (the SHARED parent backing array, field 1)
+    fctx.body.push({ op: "local.get", index: svLocal } as Instr);
+    fctx.body.push({ op: "struct.get", typeIdx, fieldIdx: 1 } as Instr);
+    // index = sv.byteOffset + i
+    fctx.body.push({ op: "local.get", index: svLocal } as Instr);
+    fctx.body.push({ op: "struct.get", typeIdx, fieldIdx: 2 } as Instr); // byteOffset
+    compileExpression(ctx, fctx, expr.argumentExpression, { kind: "i32" });
+    fctx.body.push({ op: "i32.add" } as Instr);
+    const svValueType: ValType =
+      subArrDef.element.kind === "i8" || subArrDef.element.kind === "i16" ? { kind: "i32" } : subArrDef.element;
+    emitBoundsCheckedArrayGet(fctx, subArrTypeIdx, subArrDef.element);
+    return svValueType;
+  }
+
   // Handle tuple struct — element access with literal index → struct.get
   if (typeDef?.kind === "struct") {
     const isVecStructAccess =
@@ -4835,33 +4864,6 @@ export function compileElementAccessBody(
         }
       }
       return null;
-    }
-
-    // (#2357/#47) `$__subview` receiver (TypedArray subarray): read the SHARED
-    // parent buffer at `base.data[byteOffset + i]`. The receiver struct ref is on
-    // the stack. This arm is reached at COMPILE time only when the binding's static
-    // type is a subview, so plain-array access never pays for it.
-    if (isSubviewTypeIdx(ctx, typeIdx)) {
-      const subArrTypeIdx = getSubviewArrTypeIdx(ctx, typeIdx);
-      const subArrDef = ctx.mod.types[subArrTypeIdx];
-      if (!subArrDef || subArrDef.kind !== "array") {
-        reportErrorNoNode(ctx, "Element access: subview data is not an array");
-        return null;
-      }
-      const svLocal = allocLocal(fctx, `__sv_recv_${fctx.locals.length}`, { kind: "ref_null", typeIdx });
-      fctx.body.push({ op: "local.set", index: svLocal } as Instr);
-      // data = sv.data (the SHARED parent backing array, field 1)
-      fctx.body.push({ op: "local.get", index: svLocal } as Instr);
-      fctx.body.push({ op: "struct.get", typeIdx, fieldIdx: 1 } as Instr);
-      // index = sv.byteOffset + i
-      fctx.body.push({ op: "local.get", index: svLocal } as Instr);
-      fctx.body.push({ op: "struct.get", typeIdx, fieldIdx: 2 } as Instr); // byteOffset
-      compileExpression(ctx, fctx, expr.argumentExpression, { kind: "i32" });
-      fctx.body.push({ op: "i32.add" } as Instr);
-      const svValueType: ValType =
-        subArrDef.element.kind === "i8" || subArrDef.element.kind === "i16" ? { kind: "i32" } : subArrDef.element;
-      emitBoundsCheckedArrayGet(fctx, subArrTypeIdx, subArrDef.element);
-      return svValueType;
     }
 
     // Handle vec struct (array wrapped in {length, data})

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -53,7 +53,12 @@ import { isBuiltinSubtype, isBuiltinTypeName } from "./builtin-tags.js";
 import { getOrRegisterErrorStructType, isWasiErrorName } from "./registry/error-types.js";
 import { addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "./registry/imports.js";
 import { getOrRegisterDvWindowType } from "./dataview-native.js"; // (#2159/#38) DataView windowing
-import { getArrTypeIdxFromVec, getOrRegisterVecType, getSubviewArrTypeIdx, isSubviewTypeIdx } from "./registry/types.js";
+import {
+  getArrTypeIdxFromVec,
+  getOrRegisterVecType,
+  getSubviewArrTypeIdx,
+  isSubviewTypeIdx,
+} from "./registry/types.js";
 import {
   coerceType,
   compileExpression,

--- a/src/codegen/registry/types.ts
+++ b/src/codegen/registry/types.ts
@@ -156,13 +156,17 @@ export function getOrRegisterVecType(ctx: CodegenContext, elemKind: string, elem
 /**
  * (#2159 / #2357 / #47) Get or register the `$__subview_<elemKind>` struct — a
  * TypedArray `subarray` view that SHARES the parent's backing array:
- *   `{length: i32, base: (ref null __vec_<elemKind>), byteOffset: i32}`.
+ *   `{length: i32, data: (ref null $__arr_<elemKind>), byteOffset: i32}`.
  *
  * `length` is field 0 (subtypes `$__vec_base`) so uniform `.length` reads and the
- * externref-length helper keep working. `base` points at the PARENT vec (whose
- * `data` array is shared — no copy), and `byteOffset` is the element offset of the
- * window into that array. Element access on a `$__subview` receiver reads
- * `base.data[byteOffset + i]`; on a plain vec it reads `data[i]` unchanged. The
+ * externref-length helper keep working. `data` holds the PARENT's backing array
+ * DIRECTLY (shared — no copy); `byteOffset` is the element offset of the window
+ * into that array. We deliberately store the array type (`$__arr_<elemKind>`,
+ * uniquely deduped per element kind) rather than a concrete vec struct idx,
+ * because the same element kind can be registered behind multiple vec struct
+ * indices in a module (hoist-time vs body-time) — pinning to the array type makes
+ * the subview idx-stable. Element access on a `$__subview` receiver reads
+ * `data[byteOffset + i]`; a plain vec reads `vec.data[i]` unchanged. The
  * discrimination is by the receiver's static ValType.typeIdx at COMPILE time, so
  * the plain-array hot path is untouched. Keyed per element kind. Idempotent.
  */
@@ -171,7 +175,7 @@ export function getOrRegisterSubviewType(ctx: CodegenContext, elemKind: string, 
   if (existing !== undefined) return existing;
 
   const vecBaseIdx = getOrRegisterVecBaseType(ctx);
-  const vecTypeIdx = getOrRegisterVecType(ctx, elemKind, elemTypeOverride);
+  const arrTypeIdx = getOrRegisterArrayType(ctx, elemKind, elemTypeOverride);
 
   const idx = ctx.mod.types.length;
   const name = `__subview_${elemKind}`;
@@ -181,7 +185,7 @@ export function getOrRegisterSubviewType(ctx: CodegenContext, elemKind: string, 
     superTypeIdx: vecBaseIdx, // length-prefix compatible with $__vec_base
     fields: [
       { name: "length", type: { kind: "i32" }, mutable: true },
-      { name: "base", type: { kind: "ref_null", typeIdx: vecTypeIdx }, mutable: false },
+      { name: "data", type: { kind: "ref_null", typeIdx: arrTypeIdx }, mutable: false },
       { name: "byteOffset", type: { kind: "i32" }, mutable: false },
     ],
   });
@@ -191,10 +195,19 @@ export function getOrRegisterSubviewType(ctx: CodegenContext, elemKind: string, 
   ctx.typeIdxToStructName.set(idx, name);
   ctx.structFields.set(name, [
     { name: "length", type: { kind: "i32" as const }, mutable: true },
-    { name: "base", type: { kind: "ref_null" as const, typeIdx: vecTypeIdx }, mutable: false },
+    { name: "data", type: { kind: "ref_null" as const, typeIdx: arrTypeIdx }, mutable: false },
     { name: "byteOffset", type: { kind: "i32" as const }, mutable: false },
   ]);
   return idx;
+}
+
+/** (#2357) The backing array type idx for a `$__subview_<elem>` struct (field 1). */
+export function getSubviewArrTypeIdx(ctx: CodegenContext, subviewTypeIdx: number): number {
+  const def = ctx.mod.types[subviewTypeIdx];
+  if (!def || def.kind !== "struct") return -1;
+  const dataField = def.fields[1];
+  if (!dataField || (dataField.type.kind !== "ref" && dataField.type.kind !== "ref_null")) return -1;
+  return (dataField.type as { typeIdx: number }).typeIdx;
 }
 
 /** (#2357) True iff `typeIdx` is a registered `$__subview_<elem>` struct. */

--- a/src/codegen/registry/types.ts
+++ b/src/codegen/registry/types.ts
@@ -154,6 +154,56 @@ export function getOrRegisterVecType(ctx: CodegenContext, elemKind: string, elem
 }
 
 /**
+ * (#2159 / #2357 / #47) Get or register the `$__subview_<elemKind>` struct — a
+ * TypedArray `subarray` view that SHARES the parent's backing array:
+ *   `{length: i32, base: (ref null __vec_<elemKind>), byteOffset: i32}`.
+ *
+ * `length` is field 0 (subtypes `$__vec_base`) so uniform `.length` reads and the
+ * externref-length helper keep working. `base` points at the PARENT vec (whose
+ * `data` array is shared — no copy), and `byteOffset` is the element offset of the
+ * window into that array. Element access on a `$__subview` receiver reads
+ * `base.data[byteOffset + i]`; on a plain vec it reads `data[i]` unchanged. The
+ * discrimination is by the receiver's static ValType.typeIdx at COMPILE time, so
+ * the plain-array hot path is untouched. Keyed per element kind. Idempotent.
+ */
+export function getOrRegisterSubviewType(ctx: CodegenContext, elemKind: string, elemTypeOverride?: ValType): number {
+  const existing = ctx.subviewTypeMap.get(elemKind);
+  if (existing !== undefined) return existing;
+
+  const vecBaseIdx = getOrRegisterVecBaseType(ctx);
+  const vecTypeIdx = getOrRegisterVecType(ctx, elemKind, elemTypeOverride);
+
+  const idx = ctx.mod.types.length;
+  const name = `__subview_${elemKind}`;
+  ctx.mod.types.push({
+    kind: "struct",
+    name,
+    superTypeIdx: vecBaseIdx, // length-prefix compatible with $__vec_base
+    fields: [
+      { name: "length", type: { kind: "i32" }, mutable: true },
+      { name: "base", type: { kind: "ref_null", typeIdx: vecTypeIdx }, mutable: false },
+      { name: "byteOffset", type: { kind: "i32" }, mutable: false },
+    ],
+  });
+  ctx.subviewTypeMap.set(elemKind, idx);
+  ctx.subviewTypeIdx = idx;
+  ctx.structMap.set(name, idx);
+  ctx.typeIdxToStructName.set(idx, name);
+  ctx.structFields.set(name, [
+    { name: "length", type: { kind: "i32" as const }, mutable: true },
+    { name: "base", type: { kind: "ref_null" as const, typeIdx: vecTypeIdx }, mutable: false },
+    { name: "byteOffset", type: { kind: "i32" as const }, mutable: false },
+  ]);
+  return idx;
+}
+
+/** (#2357) True iff `typeIdx` is a registered `$__subview_<elem>` struct. */
+export function isSubviewTypeIdx(ctx: CodegenContext, typeIdx: number): boolean {
+  for (const v of ctx.subviewTypeMap.values()) if (v === typeIdx) return true;
+  return false;
+}
+
+/**
  * Get or register the template vec struct type for tagged template string arrays.
  */
 export function getOrRegisterTemplateVecType(ctx: CodegenContext): number {

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -13,7 +13,7 @@ import { emitUndefined } from "../expressions/late-imports.js";
 import { needsTdzFlag, resolveWasmType } from "../index.js";
 import { resolveComputedKeyExpression } from "../literals.js";
 import { localGlobalIdx } from "../registry/imports.js";
-import { getOrRegisterArrayType, getOrRegisterVecType } from "../registry/types.js";
+import { getOrRegisterArrayType, getOrRegisterSubviewType, getOrRegisterVecType } from "../registry/types.js";
 import { coerceType, compileExpression, valTypesMatch } from "../shared.js";
 import { emitGuardedRefCast } from "../type-coercion.js";
 import { compileArrayDestructuring, compileObjectDestructuring } from "./destructuring.js";
@@ -161,6 +161,41 @@ function inferStandaloneRegExpMatchArrayType(
     return isStaticRegExpExpression(ctx, unwrapped.arguments[0]!) ? nativeStringVecType(ctx) : null;
   }
   return null;
+}
+
+/**
+ * (#2357/#47) A `let s = <typedArray>.subarray(...)` binding in standalone/WASI
+ * mode holds a `$__subview` that shares the parent's backing array (true aliasing).
+ * Resolve the binding's local type to that subview here — at the real
+ * variable-declaration site — so the local can hold the `struct.new $__subview` the
+ * subarray lowering emits, and so element access on `s` picks the windowed lowering
+ * at compile time. The receiver's element kind comes from its struct name
+ * (`__vec_<elem>` for a plain typed array, `__subview_<elem>` for a nested
+ * subarray). The subview type is reserved up-front (idx-stable), so this returns the
+ * same index the lowering + inference use. `slice` is excluded — it returns an
+ * independent copy (a plain vec), not a view.
+ */
+function inferSubarraySubviewType(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  initializer: ts.Expression | undefined,
+): ValType | null {
+  if (!(ctx.standalone || ctx.wasi) || !initializer) return null;
+  const unwrapped = stripInferenceWrapper(initializer);
+  if (!ts.isCallExpression(unwrapped) || !ts.isPropertyAccessExpression(unwrapped.expression)) return null;
+  if (unwrapped.expression.name.text !== "subarray") return null;
+  const receiver = unwrapped.expression.expression;
+  let receiverType: ValType | undefined;
+  if (ts.isIdentifier(receiver)) {
+    const localIdx = fctx.localMap.get(receiver.text);
+    if (localIdx !== undefined) receiverType = getLocalType(fctx, localIdx);
+  }
+  receiverType ??= resolveWasmType(ctx, ctx.checker.getTypeAtLocation(receiver));
+  if (receiverType.kind !== "ref" && receiverType.kind !== "ref_null") return null;
+  const recvName = ctx.typeIdxToStructName.get(receiverType.typeIdx);
+  const elemKind = recvName?.replace(/^__vec_/, "").replace(/^__subview_/, "");
+  if (elemKind === undefined || elemKind === recvName) return null;
+  return { kind: "ref_null", typeIdx: getOrRegisterSubviewType(ctx, elemKind) };
 }
 
 function nullishLiteralKind(expr: ts.Expression): "null" | "undefined" | null {
@@ -588,6 +623,7 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
     }
 
     const standaloneRegExpMatchArrayType = inferStandaloneRegExpMatchArrayType(ctx, decl.initializer);
+    const subarraySubviewType = inferSubarraySubviewType(ctx, fctx, decl.initializer);
     const wasmType: ValType = initIsAccessorLiteral
       ? { kind: "externref" as const }
       : isI32CoercedLocal
@@ -596,7 +632,8 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
           ? { kind: "ref_null" as const, typeIdx: getOrRegisterVecType(ctx, "i32", { kind: "i32" }) }
           : widenedTypeIdx !== undefined
             ? { kind: "ref_null" as const, typeIdx: widenedTypeIdx }
-            : (inferredVecType ??
+            : (subarraySubviewType ??
+              inferredVecType ??
               standaloneRegExpMatchArrayType ??
               (decl.initializer && isStringMethodReturningHostArray(ctx, decl.initializer)
                 ? { kind: "externref" as const }

--- a/tests/issue-2357-subarray-aliasing.test.ts
+++ b/tests/issue-2357-subarray-aliasing.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// (#2357 / #47) Standalone TypedArray.prototype.subarray offset-windowing.
+//
+// `a.subarray(begin, end)` must return a VIEW that shares the parent's backing
+// store (ECMA §23.2.3.30): a write through the view is visible in the parent and
+// vice-versa. Before this slice, standalone `subarray` returned a COPY.
+//
+// Representation (Option B from the #2357 architect spec): an additive
+// `$__subview {length, data:(ref null $__arr_<elem>), byteOffset}` struct that
+// holds the parent's backing array directly (shared) + the element window offset.
+// A `subarray`-result binding statically resolves to `$__subview`, so element
+// access discriminates view-vs-plain at COMPILE time — plain `a[i]` on a regular
+// typed array pays ZERO extra instructions (no per-access runtime branch).
+//
+// Standalone native buffers don't marshal across the JS boundary, so each case
+// returns an i32/number asserted directly.
+async function runNum(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  // No host import may leak (the view path is fully Wasm-native).
+  const labels = r.imports.map((i) => `${i.module}::${i.name}`);
+  expect(labels.some((l) => /__extern_get|__extern_set/.test(l))).toBe(false);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { t: () => number }).t();
+}
+
+describe("#2357 — standalone TypedArray subarray aliasing", () => {
+  it("write through the view is visible in the parent (aliasing)", async () => {
+    expect(
+      await runNum(`
+export function t(): number {
+  let a = new Uint8Array(4);
+  a[0]=10; a[1]=20; a[2]=30; a[3]=40;
+  let s = a.subarray(1, 3);
+  s[0] = 99;        // → parent byte 1
+  return a[1];
+}`),
+    ).toBe(99);
+  });
+
+  it("write to the parent is visible through the view", async () => {
+    expect(
+      await runNum(`
+export function t(): number {
+  let a = new Uint8Array(4);
+  a[2] = 77;
+  let s = a.subarray(1, 3);
+  return s[1];       // → parent byte 2
+}`),
+    ).toBe(77);
+  });
+
+  it("view read at index 0 maps to parent[begin]", async () => {
+    expect(
+      await runNum(`
+export function t(): number {
+  let a = new Uint8Array(4);
+  a[1] = 55;
+  let s = a.subarray(1, 3);
+  return s[0];
+}`),
+    ).toBe(55);
+  });
+
+  it("write-then-read through the view round-trips", async () => {
+    expect(
+      await runNum(`
+export function t(): number {
+  let a = new Uint8Array(4);
+  let s = a.subarray(1, 3);
+  s[1] = 88;
+  return s[1];
+}`),
+    ).toBe(88);
+  });
+
+  it("view length = end - begin", async () => {
+    expect(
+      await runNum(`
+export function t(): number {
+  let a = new Uint8Array(8);
+  let s = a.subarray(2, 6);
+  return s.length;
+}`),
+    ).toBe(4);
+  });
+
+  it("default end → bufferLength - begin", async () => {
+    expect(
+      await runNum(`
+export function t(): number {
+  let a = new Uint8Array(8);
+  let s = a.subarray(3);
+  return s.length;
+}`),
+    ).toBe(5);
+  });
+
+  it("nested subarray aliases the same backing store with accumulated offset", async () => {
+    expect(
+      await runNum(`
+export function t(): number {
+  let a = new Uint8Array(8);
+  let s = a.subarray(2, 6);   // window [2,6)
+  let s2 = s.subarray(1, 3);  // window [3,5) of the original
+  s2[0] = 42;                 // → parent byte 3
+  return a[3];
+}`),
+    ).toBe(42);
+  });
+
+  it("plain typed-array element access is unaffected (no view path)", async () => {
+    expect(
+      await runNum(`
+export function t(): number {
+  let a = new Uint8Array(4);
+  a[0]=1; a[1]=2; a[2]=3; a[3]=4;
+  let sum = 0;
+  for (let i = 0; i < 4; i++) sum = sum + a[i];
+  return sum;   // 1+2+3+4
+}`),
+    ).toBe(10);
+  });
+});


### PR DESCRIPTION
## What

`TypedArray.prototype.subarray(begin, end)` in standalone / WASI mode now returns a **view that shares the parent's backing store** (ECMA §23.2.3.30) — a write through the view is visible in the parent and vice-versa. Previously it returned a **copy**, losing the alias. Implements the #2357 architect spec (Option B).

## How — additive `$__subview` struct, compile-time discrimination

- New `$__subview_<elem> { length: i32, data: (ref null $__arr_<elem>), byteOffset: i32 }` — holds the parent's backing **array directly** (shared, no copy) + the element window offset. Holding the array (deduped per elem kind) rather than a vec struct idx sidesteps the dual-vec-registration hazard.
- Reserved **up-front** in the deterministic type-init phase (`reserveTypedArraySubviewTypes`, mirroring the #1886 `__lin_u8_alloc` precedent) so the type index is stable across the compiler's hoist/body passes. (Eager registration *inside* `getOrRegisterVecType` was tried and rejected — it shifts vec resolution so a plain `new Uint8Array()` resolves to the subview.)
- A `subarray`-result binding statically resolves to `$__subview` (`inferSubarraySubviewType` at the real variable-declaration site). So `compileElementAccess` / `compileElementAssignment` pick the windowed lowering (`data[byteOffset + i]`) at **COMPILE time** by the receiver's resolved typeIdx — a plain typed array keeps the bare-vec lowering. The subview arms run **before** the 2-field-vec/tuple-struct check (a `$__subview` is 3 fields).
- `subarray` lowering shares `parent.data` (or the nested subview's already-shared array, accumulating the offset); host mode keeps the copy.

## Zero hot-path cost (the #1673 discipline)

WAT-diff of a plain `for (i) sum += a[i]` over a `Uint8Array`: `array.get_u: 1`, and **zero** `__subview` / `ref.test` / `__sv_recv` instructions. The discrimination is entirely compile-time, so regular-array element access pays **nothing** extra. No per-access runtime branch on the hot path.

## Tests

`tests/issue-2357-subarray-aliasing.test.ts` — 8 standalone cases: write-through aliasing (`s[0]=99 → a[1]===99`), parent-write→view-read, view-read maps to `parent[begin]`, write/read round-trip, `.length` (explicit + default-end), **nested** subarray aliasing, and plain typed-array access unaffected. All pass; also asserts no `__extern_get`/`__extern_set` host import leaks.

## Gates
- 38/38 existing typed-array + DataView tests pass; coercion-sites gate OK; `tsc --noEmit` clean
- merged `upstream/main` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)