### PR TITLE
ci(#2108): auto-refresh coercion-site drift baseline post-merge

### DIFF
--- a/.github/workflows/baseline-summary-sync.yml
+++ b/.github/workflows/baseline-summary-sync.yml
@@ -137,6 +137,12 @@ jobs:
             echo "WARN: generate-editions failed (non-fatal) — edition buckets may lag"
           node scripts/sync-conformance-numbers.mjs || \
             echo "WARN: sync-conformance-numbers failed (non-fatal) — docs may drift"
+          # #2108 — coercion-site drift baseline (pure source-grep). The
+          # promote-baseline job in test262-sharded.yml is the primary refresher
+          # on every push to main; this hourly fallback re-anchors it too so a
+          # deferred/failed promote can't leave main drifted. Non-fatal.
+          node scripts/check-coercion-sites.mjs --update || \
+            echo "WARN: coercion-site baseline update failed (non-fatal)"
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -156,6 +162,8 @@ jobs:
               git add -f website/public/benchmarks/results/test262-editions.json || true
             [ -f website/public/benchmarks/results/test262-category-editions.json ] && \
               git add -f website/public/benchmarks/results/test262-category-editions.json || true
+            # #2108 — coercion-site drift baseline, refreshed just above.
+            git add -f scripts/coercion-sites-baseline.json 2>/dev/null || true
             git add -f README.md ROADMAP.md CLAUDE.md plan/goals/goal-graph.md \
               2>/dev/null || true
           }

--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -1640,6 +1640,24 @@ jobs:
           # (pre-#1853 summaries) — the gate treats absent as zero.
           node scripts/check-test262-hard-errors.mjs --update || \
             echo "WARN: hard-error baseline update failed (non-fatal)"
+          # #2108 — refresh the coercion-site drift baseline to the freshly
+          # merged source tree. The gate (scripts/check-coercion-sites.mjs) is a
+          # PURE source-grep over src/codegen/** — it has no dependency on the
+          # test262 run, so the merged HEAD's source IS the new ground truth.
+          # PRs cannot regenerate this committed baseline (a PR's own source is
+          # checked against the *old* committed baseline at PR time), so the
+          # gate's useful work — recording the new floor — must happen here,
+          # post-merge, exactly like the #1853 hard-error baseline above. Growth
+          # is still caught at PR time (a PR adding an un-sanctioned coercion
+          # site fails the gate); this banks sanctioned additions that landed via
+          # the merge so main never drifts internally inconsistent. Without this,
+          # an admin-bypass merge / concurrent-PR baseline conflict / lost manual
+          # bump leaves main's source ahead of its committed baseline and EVERY
+          # open PR fails the gate until someone hand-bumps it (the 2026-06-18
+          # #1670 wedge). Non-fatal — a transient grep failure must not block the
+          # baseline commit.
+          node scripts/check-coercion-sites.mjs --update || \
+            echo "WARN: coercion-site baseline update failed (non-fatal)"
           stage_files() {
             git add -f benchmarks/results/test262-current.json \
               benchmarks/results/test262-report.json \
@@ -1647,6 +1665,9 @@ jobs:
               public/benchmarks/results/test262-standalone-report.json
             # #1853 — hard-error stability baseline, refreshed just above.
             git add -f scripts/test262-hard-error-baseline.json 2>/dev/null || true
+            # #2108 — coercion-site drift baseline, refreshed just above. Staged
+            # so the new floor lands atomically with the merged source.
+            git add -f scripts/coercion-sites-baseline.json 2>/dev/null || true
             # #2097 — the standalone high-water mark (raised just above when
             # conformance improved). Staged so the new floor lands atomically
             # with the refreshed summary.


### PR DESCRIPTION
## Problem

The coercion-site drift gate (`scripts/check-coercion-sites.mjs`, run in `ci.yml`'s `quality` job) is the **only** baseline gate with no post-merge self-heal. Its baseline `scripts/coercion-sites-baseline.json` is consumed purely as a PR-time gate and **never regenerated on main**.

So any sanctioned coercion site that lands via:
- an admin-bypass merge,
- a concurrent-PR baseline merge conflict, or
- a lost manual bump

…leaves main's source **ahead of** its committed baseline — and then **every open PR fails the gate** until someone hand-bumps it. That is exactly the 2026-06-18 #1670 wedge (the #2166 JSON-codec PRs added sanctioned engine coercions without bumping the baseline; main went internally inconsistent and stalled the drain).

## Fix

Mirror the established **#1853 hard-error baseline** self-heal pattern. The `promote-baseline` job (runs on every push to main, incl. admin merges) now:

```sh
node scripts/check-coercion-sites.mjs --update || echo "WARN: …(non-fatal)"
…
git add -f scripts/coercion-sites-baseline.json   # in stage_files()
```

so the refreshed baseline lands **atomically** with the conformance summary. The gate is a **pure source-grep over `src/codegen/**`** with no test262 dependency, so the merged HEAD's source *is* the new ground truth:

- **Growth is still caught at PR time** — a PR adding an un-sanctioned coercion site still fails the gate against the old committed baseline.
- This only **banks sanctioned additions** that already merged, so main never drifts internally inconsistent.

Also mirrored in the hourly `baseline-summary-sync.yml` fallback (for when `promote-baseline` defers because the merge queue is non-empty).

## Why this is the durable answer to "will it happen again"

Before: the gate's baseline only ever moved by hand → recurring wedge.
After: every path that advances main also re-anchors the baseline → main is structurally always consistent, same invariant the conformance (#1636) and hard-error (#1853) baselines already enjoy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)