### PR TITLE
fix(#51): standalone -1 string-global sentinel baked into global.get crashes binary emit

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -4622,14 +4622,14 @@ function compileCallExpression(
             if (dpIdx !== undefined) {
               // obj
               fctx.body.push({ op: "local.get", index: objLocal });
-              // prop name as string constant
+              // prop name as string constant. (#51) Materialize via the dual-mode
+              // helper — under nativeStrings `addStringConstantGlobal` records a
+              // `-1` sentinel global (no host string-constant global), so a bare
+              // `global.get -1` reaches binary emit as "global index out of range
+              // — -1". `stringConstantExternrefInstrs` emits the inline
+              // NativeString externref standalone and the host `global.get` under GC.
               addStringConstantGlobal(ctx, propName);
-              const strGlobalIdx = ctx.stringGlobalMap.get(propName);
-              if (strGlobalIdx !== undefined) {
-                fctx.body.push({ op: "global.get", index: strGlobalIdx } as Instr);
-              } else {
-                fctx.body.push({ op: "ref.null.extern" });
-              }
+              fctx.body.push(...stringConstantExternrefInstrs(ctx, propName));
               // value (or null for accessor descriptors)
               if (valueExpr) {
                 const vt = compileExpression(ctx, fctx, valueExpr);
@@ -4689,13 +4689,10 @@ function compileCallExpression(
 
             if (dpDescIdx !== undefined) {
               fctx.body.push({ op: "local.get", index: objLocal });
+              // (#51) Dual-mode key materialization — nativeStrings stores a `-1`
+              // sentinel global, so a bare `global.get` crashes binary emit.
               addStringConstantGlobal(ctx, propName);
-              const strGlobalIdx = ctx.stringGlobalMap.get(propName);
-              if (strGlobalIdx !== undefined) {
-                fctx.body.push({ op: "global.get", index: strGlobalIdx } as Instr);
-              } else {
-                fctx.body.push({ op: "ref.null.extern" });
-              }
+              fctx.body.push(...stringConstantExternrefInstrs(ctx, propName));
               const descValType = compileExpression(ctx, fctx, prop.initializer);
               if (!descValType) {
                 fctx.body.push({ op: "ref.null.extern" });

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -31,6 +31,7 @@ import { coerceType, compileExpression } from "../shared.js";
 import { emitTdzCheck } from "../statements.js";
 import { ensureLateImport, flushLateImportShifts, shiftLateImportIndices } from "./late-imports.js";
 import { emitStringBuilderRead, getBuilderInfo } from "../string-builder.js";
+import { stringConstantExternrefInstrs } from "../native-strings.js";
 import { BUILTIN_TYPE_TAGS, isBuiltinSubtype, isBuiltinTypeName } from "../builtin-tags.js";
 import { getOrRegisterErrorStructType, isWasiErrorName } from "../registry/error-types.js";
 import { allocLocal } from "../context/locals.js";
@@ -1273,14 +1274,14 @@ function compileHostInstanceOf(ctx: CodegenContext, fctx: FunctionContext, expr:
     coerceType(ctx, fctx, leftType, { kind: "externref" });
   }
 
-  // Push constructor name as a string constant
+  // Push constructor name as a string constant. (#51) Materialize via the
+  // dual-mode helper — under nativeStrings `addStringConstantGlobal` records a
+  // `-1` sentinel global (no host string-constant global), so a bare
+  // `global.get -1` reaches binary emit as "global index out of range — -1".
+  // `stringConstantExternrefInstrs` emits the inline NativeString externref
+  // standalone and the host `global.get` only when a real import global exists.
   addStringConstantGlobal(ctx, ctorName);
-  const strGlobalIdx = ctx.stringGlobalMap.get(ctorName);
-  if (strGlobalIdx !== undefined) {
-    fctx.body.push({ op: "global.get", index: strGlobalIdx });
-  } else {
-    fctx.body.push({ op: "ref.null.extern" });
-  }
+  fctx.body.push(...stringConstantExternrefInstrs(ctx, ctorName));
 
   // Call __instanceof(value, ctorName) -> i32
   fctx.body.push({ op: "call", funcIdx: instanceofIdx });

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -486,11 +486,20 @@ function compileObjectLiteralWithAccessors(
         }
       } else {
         if (propName === undefined) continue;
+        // (#51) Materialize the data-property key via the dual-mode helper, not a
+        // bare `global.get <stringGlobalMap.get(propName)>`. Under
+        // standalone/nativeStrings `addStringConstantGlobal` records the `-1`
+        // sentinel (there is no host string-constant global), so a bare
+        // `global.get -1` reaches binary emit as "global index out of range — -1".
+        // `stringConstantExternrefInstrs` emits the NativeString inline (externref)
+        // path under standalone and the host `global.get` only when a real import
+        // global exists — exactly the fix already applied to the accessor-key path
+        // below (#1888 S5c).
         addStringConstantGlobal(ctx, propName);
-        const keyGlobal = ctx.stringGlobalMap.get(propName);
-        if (keyGlobal === undefined) continue;
         fctx.body.push({ op: "local.get", index: objLocal });
-        fctx.body.push({ op: "global.get", index: keyGlobal });
+        for (const instr of stringConstantExternrefInstrs(ctx, propName)) {
+          fctx.body.push(instr);
+        }
       }
       // Compile value and coerce to externref.
       let valType: ValType | null;

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -32,6 +32,7 @@ import { ensureNativeIteratorRuntime } from "../iterator-native.js";
 import { containsLinearU8Allocation, emitLinearU8ArenaMark, linearU8ArenaResetInstrs } from "../linear-uint8-arena.js";
 import { resolveComputedKeyExpression } from "../literals.js";
 import { emitCollectionIteratorVec } from "../map-runtime.js";
+import { stringConstantExternrefInstrs } from "../native-strings.js";
 import { addImport, addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "../registry/imports.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterRefCellType } from "../registry/types.js";
 import {
@@ -1213,7 +1214,13 @@ function compileForOfDestructuring(
               if (excludedStrIdx !== undefined) {
                 fctx.body.push({ op: "local.get", index: elemLocal });
                 fctx.body.push({ op: "extern.convert_any" } as Instr);
-                fctx.body.push({ op: "global.get", index: excludedStrIdx });
+                // (#51) `addStringConstantGlobal` stores a `-1` sentinel under
+                // nativeStrings (no host string-constant global); a bare
+                // `global.get -1` crashes binary emit ("global index out of
+                // range — -1"). Materialize the excluded-keys string inline via
+                // the dual-mode helper (inline NativeString externref standalone,
+                // host `global.get` under GC).
+                for (const instr of stringConstantExternrefInstrs(ctx, excludedStr)) fctx.body.push(instr);
                 fctx.body.push({ op: "call", funcIdx: restObjIdx });
                 fctx.body.push({ op: "local.set", index: restIdx });
               }
@@ -2159,14 +2166,10 @@ function compileForOfAssignDestructuringExternref(
       // Push key — string literal for `.prop`, computed value for `[expr]`
       if (ts.isPropertyAccessExpression(targetEl)) {
         const propName = targetEl.name.text;
+        // (#51) Materialize via the dual-mode helper — nativeStrings stores a
+        // `-1` sentinel global so a bare `global.get` crashes binary emit.
         addStringConstantGlobal(ctx, propName);
-        const keyGlobalIdx = ctx.stringGlobalMap.get(propName);
-        if (keyGlobalIdx !== undefined) {
-          fctx.body.push({ op: "global.get", index: keyGlobalIdx } as Instr);
-        } else {
-          // Fallback: skip — string-pool registration should cover all literal names
-          continue;
-        }
+        for (const instr of stringConstantExternrefInstrs(ctx, propName)) fctx.body.push(instr);
       } else {
         // ElementAccessExpression
         const keyType = compileExpression(ctx, fctx, targetEl.argumentExpression, { kind: "externref" });
@@ -3471,16 +3474,16 @@ function compileForOfIteratorAssignDestructuring(
 
       // Register string constant for property name
       addStringConstantGlobal(ctx, propName);
-      const strGlobalIdx = ctx.stringGlobalMap.get(propName);
-      if (strGlobalIdx === undefined) continue;
 
       // Refresh getIdx in case addStringConstantGlobal shifted indices
       getIdx = ctx.funcMap.get("__extern_get");
       if (getIdx === undefined) continue;
 
-      // Emit: __extern_get(elem, "propName") -> externref
+      // Emit: __extern_get(elem, "propName") -> externref. (#51) Materialize the
+      // key via the dual-mode helper — nativeStrings stores a `-1` sentinel global
+      // so a bare `global.get` would crash binary emit.
       fctx.body.push({ op: "local.get", index: elemLocal });
-      fctx.body.push({ op: "global.get", index: strGlobalIdx });
+      for (const instr of stringConstantExternrefInstrs(ctx, propName)) fctx.body.push(instr);
       fctx.body.push({ op: "call", funcIdx: getIdx });
 
       // Coerce externref to target local's type and set
@@ -3559,10 +3562,9 @@ function compileForOfIteratorAssignDestructuring(
         }
         if (ts.isPropertyAccessExpression(targetElIter)) {
           const propName = targetElIter.name.text;
+          // (#51) Dual-mode key materialization (nativeStrings `-1` sentinel).
           addStringConstantGlobal(ctx, propName);
-          const keyGlobalIdx = ctx.stringGlobalMap.get(propName);
-          if (keyGlobalIdx === undefined) continue;
-          fctx.body.push({ op: "global.get", index: keyGlobalIdx } as Instr);
+          for (const instr of stringConstantExternrefInstrs(ctx, propName)) fctx.body.push(instr);
         } else {
           const keyType = compileExpression(ctx, fctx, targetElIter.argumentExpression, { kind: "externref" });
           if (keyType && keyType.kind !== "externref") {
@@ -4431,10 +4433,9 @@ function emitForInMemberTargetWrite(
   // Key
   if (ts.isPropertyAccessExpression(target)) {
     const propName = target.name.text;
+    // (#51) Dual-mode key materialization (nativeStrings `-1` sentinel global).
     addStringConstantGlobal(ctx, propName);
-    const keyGlobalIdx = ctx.stringGlobalMap.get(propName);
-    if (keyGlobalIdx === undefined) return;
-    fctx.body.push({ op: "global.get", index: keyGlobalIdx } as Instr);
+    for (const instr of stringConstantExternrefInstrs(ctx, propName)) fctx.body.push(instr);
   } else {
     const keyType = compileExpression(ctx, fctx, target.argumentExpression, {
       kind: "externref",
@@ -4523,9 +4524,13 @@ export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext
     const props = exprType.getProperties();
     if (props.length === 0) return;
     for (const prop of props) {
-      const globalIdx = ctx.stringGlobalMap.get(prop.name);
-      if (globalIdx === undefined) continue;
-      fctx.body.push({ op: "global.get", index: globalIdx });
+      // (#51) Materialize each enumerated key via the dual-mode helper. Under
+      // nativeStrings `stringGlobalMap` holds a `-1` sentinel global, so the old
+      // `global.get <sentinel>` reached binary emit as "global index out of
+      // range — -1". `stringConstantExternrefInstrs` emits the NativeString
+      // inline (externref) standalone and a host `global.get` only under GC.
+      addStringConstantGlobal(ctx, prop.name);
+      for (const instr of stringConstantExternrefInstrs(ctx, prop.name)) fctx.body.push(instr);
       fctx.body.push({ op: "local.set", index: keyLocal });
       compileStatement(ctx, fctx, stmt.statement);
     }


### PR DESCRIPTION
Fixes the standalone (`--target wasi` / nativeStrings) **"global index out of range — -1"** binary-emit crash class (#51, harvest bucket from #43; the #2043 stale-index family).

## Root cause
In nativeStrings mode `addStringConstantGlobal` records a **-1 sentinel** in `stringGlobalMap` (there is no host `string_constants` global — the literal is materialized inline instead). Several codegen sites guarded only `!== undefined` before emitting `global.get <idx>`, so the `-1` sentinel passed the guard and baked `global.get -1`. The emitter rejects that at serialize time with `Codegen error: global index out of range — -1 (valid: [0, N))`, failing compilation.

## Fix
Route every affected key/name materialization through the sanctioned dual-mode helper `stringConstantExternrefInstrs` — inline NativeString externref under standalone, host `global.get` under GC (behaviour-identical to the old code in host mode). This mirrors the already-fixed accessor-key (#1888) and param-destructure (#1623) paths.

Sites fixed:
- **instanceof `<BuiltinCtor>` name** (`expressions/identifiers.ts`) — the shared harness producer: `obj instanceof Function`/`Object` in the test262 `callbackfn`, which is why the whole `Array.prototype.{some,forEach,every,reduce,…}` callback cluster crashed at the harness `L2:1`.
- **`Object.create(proto, descriptors)` key** (`expressions/calls.ts`) — both the literal-valued and expression-valued descriptor loops.
- **object-literal data-property key** via `__extern_set` (`literals.ts`).
- **for-of object-destructure target keys, for-in member-target / standalone fallback keys, for-of `{...rest}` excluded-keys** (`statements/loops.ts`).

## Validation
Standalone runs of the originally-crashing tests no longer crash the emitter — `Array.prototype.{some,forEach,every}`, `Object/create`, `for-of {...rest}` obj-rest, and `instanceof` all compile + reach runtime/assert; one (`Object/create/15.2.3.5-4-130.js`) flips to **pass**. The remaining failures on those files are separate semantic issues (array-like `.call` receivers, object-rest enumeration), out of this bucket's scope. `map`/`reduce`/`reduceRight` still hit a different, unrelated "array-like (non-array)" codegen error.

Host/GC mode is behaviour-identical (the helper emits the same `global.get` when a real import global exists). `tsc --noEmit` clean. `instanceof.test.ts` shows 7 pre-existing failures (harness `string_constants` import in the isolated vitest run) — identical before and after this change, i.e. not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)