### PR TITLE
docs(#2358): architect spec — standalone native __to_primitive over nominal object structs

### DIFF
--- a/plan/issues/2358-standalone-toprimitive-nominal-object-structs.md
+++ b/plan/issues/2358-standalone-toprimitive-nominal-object-structs.md
@@ -1,0 +1,158 @@
+---
+id: 2358
+title: "Standalone native __to_primitive can't reduce typed (nominal) object structs through the externref boundary"
+status: ready
+sprint: Backlog
+model: opus
+created: 2026-06-18
+updated: 2026-06-18
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: feature
+area: codegen, type-coercion
+language_feature: to-primitive, abstract-operations
+goal: standalone-mode
+related: [1917, 10, 50, 1673]
+folds_in: [10]
+origin: "2026-06-18 sdev-coerce root-cause of the #50 standalone ToPrimitive residual (re-scoped from #50)"
+---
+
+# #2358 — Standalone native `__to_primitive` over nominal object structs
+
+This is the **engine half** of the re-scoped #50. The arithmetic *headline*
+(typed object operands with `valueOf():number` across `*`, `-`, unary-minus)
+is already closed on `main`. The genuine residual is one engine gap, surfacing
+in several operators. It is a #1917-coercion-engine sub-task and wants this
+spec + its own properly-scoped impl session — **not** a session-tail change.
+
+## Problem
+
+In standalone / `--target wasi` (nativeStrings, no JS host), `ToPrimitive` on a
+value that reaches the coercion boundary as an **externref** is performed by the
+native runtime helper `__to_primitive` (`src/codegen/object-runtime.ts:1910`).
+That helper recognizes a runtime object **only** via
+`ref.test (objectTypeIdx)` — i.e. it only handles the *dynamic* `$Object`
+runtime struct. A **typed object literal** (e.g. `{ valueOf() { return 42 } }`)
+compiles to a **nominal** WasmGC struct. When that nominal struct is coerced to
+externref and handed to `__to_primitive`, `any.convert_extern` →
+`ref.test objectTypeIdx` **misses**, so the object is returned unchanged; the
+caller then `__unbox_number(object)` → **NaN** (or carries the raw object
+through).
+
+The working `*` / `-` / unary-minus path does **not** hit this: it uses
+**static** `valueOf` dispatch in `coerceType` (ref(struct)→f64,
+`type-coercion.ts:1723`), which reads the struct's TS fields at compile time and
+inlines the call — but that requires the concrete `typeIdx`, which is **erased**
+the moment an operand is coerced to externref. `+` (via `emitAnyAdd`,
+`binary-ops.ts:2845`) and any `any`-typed parameter path lose the typeIdx and
+must fall back to the runtime helper — which can't reduce nominal structs.
+
+## Repro (current `main`, `--target wasi`)
+
+A single engine fix closes all of these:
+
+| expr | actual | expected | path |
+|------|--------|----------|------|
+| `{valueOf:()=>4} + {valueOf:()=>3}` | raw object | `7` | `emitAnyAdd` → `__to_primitive` |
+| `{valueOf:()=>4} + 1` | raw object | `5` | `emitAnyAdd` → `__to_primitive` |
+| `1 + {valueOf:()=>4}` | raw object | `5` | `emitAnyAdd` → `__to_primitive` |
+| `function f(x:any){return x*2}` with object arg | `NaN` | `84` | `type-coercion.ts:1360` externref→f64 |
+
+**Correction to the #50 re-scope:** the re-scope stated `obj+obj`/`obj+7` were
+correct on main — they are NOT. `+` with object operands is broken (returns the
+raw object), because `+` routes through the externref/`__to_primitive` path, not
+the static struct-valueOf path. `-`/`*`/unary-minus ARE correct (static path).
+
+### Two latent codegen bugs in the same area (valueOf returns an object)
+Fold these into the impl — same root (the reduction must fall through
+valueOf→toString and the arms must stay well-typed):
+- `1 * ({valueOf:()=>({}),toString:()=>1} as any)` → **compile error**
+  "type error in fallthru[0] (expected f64, got externref)".
+- `"x" + ({toString:()=>({})} as any)` (object-returning toString) → **trap**
+  "illegal cast".
+
+## Exact sites
+
+- `src/codegen/object-runtime.ts:1910` — native `__to_primitive`; the
+  `ref.test objectTypeIdx` recognition that only matches `$Object`.
+- `src/codegen/type-coercion.ts:1360` — standalone externref→f64 arm; calls
+  `__to_primitive` then `__unbox_number`, degrading to `drop; f64.const NaN`
+  when the reduction yields a non-primitive.
+- `src/codegen/type-coercion.ts:1723` — the WORKING static struct-valueOf
+  dispatch (ref(struct)→f64); the reference behaviour to reproduce host-free
+  over the externref boundary.
+- `src/codegen/binary-ops.ts:2845` — `emitAnyAdd`; the `+` site that compiles
+  operands to externref (to preserve runtime strings for concat) and so loses
+  the static typeIdx.
+
+## Proposed approach — two representational options
+
+The crux: at the externref boundary the runtime needs a host-free way to (a)
+**detect** that an externref wraps a user object carrying `valueOf`/`toString`
+(or `@@toPrimitive`), and (b) **dispatch** that method. `$Object` already
+supports this; nominal structs do not.
+
+### Option A — brand/RTTI on nominal object structs (recommended)
+Give every nominal object-literal/class struct a detectable brand so
+`__to_primitive` can recognize it and dispatch its `valueOf`/`toString`
+host-free. Concretely: a shared supertype or a reserved tag/brand field that
+`__to_primitive` can `ref.test`/read, plus a small per-struct dispatch trampoline
+(reuse the `${name}_valueOf` / `${name}_@@toPrimitive` functions the static path
+at `type-coercion.ts:1723`/`1768` already emits — register them so the runtime
+helper can reach them by a brand→funcidx table, mirroring how `__call_@@toPrimitive`
+is exported at `index.ts:1596`).
+- **Pros:** additive; nominal structs keep their compact field layout and fast
+  static paths; only objects that actually cross the externref boundary pay; no
+  rep change to the hot WasmGC object model.
+- **Cons:** needs a brand allocation + a runtime brand→method dispatch table;
+  must keep the table in sync across late-import index shifts (use the
+  ensureLateImport / `funcMap.get(name)`-AFTER-flush discipline, never a baked
+  snapshot — see #1673 / the `reference_no_rebuild_helper_body_at_finalize`
+  lesson).
+
+### Option B — unify nominal object literals to `$Object`
+Compile object literals that can reach a dynamic boundary as `$Object` so
+`__to_primitive` already works.
+- **Pros:** no second mechanism; one object representation at the boundary.
+- **Cons:** broad blast radius and likely **hot-path regression** — every such
+  literal loses its nominal struct's compact layout / static field access; risks
+  the standalone high-water floor. Heavier and riskier than A.
+
+### Recommendation
+**Option A.** It is additive and confines cost to objects that actually cross
+the externref boundary, matching the #1673 "additive, zero hot-path cost"
+discipline. Option B is a representational change with a standalone-perf risk
+disproportionate to the bucket.
+
+## Guardrails (#1673 discipline)
+- **Additive only** — do not alter the existing `$Object` path or the nominal
+  struct field layout used by the fast static paths.
+- **Floor-gate the standalone high-water** (`benchmarks/results/test262-standalone-highwater.json`,
+  `scripts/check-standalone-highwater.mjs`) — coercion + object dispatch are hot.
+- **WAT-diff** a representative standalone module before/after to confirm the
+  hot static `*`/`-` paths are byte-identical (no accidental routing of
+  already-working operators through the new runtime path).
+- **Late-import index discipline:** resolve any new helper/dispatch funcidx by
+  name AFTER the last `flushLateImportShifts`/`addUnionImports`; never bake a
+  snapshot into a helper body (the #2043 / `reference_string_global_sentinel_guard`
+  family).
+
+## Scope folded in
+- **#10** (route `Number(array)`→primitive through the #1917 engine) — same
+  externref-boundary ToPrimitive reduction; do it on the same mechanism so the
+  `#2108` coercion-site gate stays flat (reuse the sanctioned shared helper, do
+  not hand-roll a new coercion site).
+
+## Acceptance
+- All four repro rows above return the spec-correct value standalone.
+- The two latent `as any` cases compile + run (no fallthru type error, no illegal
+  cast).
+- `Number([1])` / `Number(arr)` reduce correctly standalone (#10).
+- Standalone high-water floor not regressed; `*`/`-`/unary-minus WAT unchanged.
+- `#2108` coercion-drift gate stays flat (`node scripts/check-coercion-sites.mjs`).
+
+## Re-measure
+The 2026-06-12 standalone JSONL `object-to-primitive` bucket (107) is **stale**
+and the headline is partly closed — re-measure the true tractable count on a
+**fresh standalone shard** before sizing the impl.


### PR DESCRIPTION
Captures the architect-grade root-cause analysis from the re-scoped **#50** (the standalone ToPrimitive residual) as a proper spec so the engine impl is a separately-scoped effort off it, not a session-tail change. Folds in **#10** (Number(array)→primitive). Doc-only — no code.

## What it captures
Native `__to_primitive` (`object-runtime.ts:1910`) recognizes a runtime object **only** via `ref.test (objectTypeIdx)` — i.e. only the dynamic `$Object` struct. A **typed (nominal) object literal** reaching the coercion boundary as externref is never reduced → `__unbox_number(object)` → **NaN** / raw object. `+` (`emitAnyAdd`, `binary-ops.ts:2845`) and any `any`-typed-param path lose the static `typeIdx` and must use the runtime helper; `*`/`-`/unary-minus use the **static** struct-valueOf path (`type-coercion.ts:1723`) and already work.

Includes:
- exact sites (`object-runtime.ts:1910`, `type-coercion.ts:1360`/`1723`, `binary-ops.ts:2845`)
- repro table (`{valueOf:()=>4}+1` → raw object; `f(x:any){return x*2}` → NaN) + the **correction** that `+`-with-objects is broken on main (the #50 re-scope had it as working)
- two latent codegen bugs (valueOf/toString returning an object → "type error in fallthru"/"illegal cast")
- **both representational options** — (A) brand/RTTI on nominal structs [recommended, additive] vs (B) unify to `$Object` [broad blast radius, hot-path risk] — with a recommendation
- #1673 guardrails (additive, floor-gate standalone high-water, WAT-diff, late-import index discipline)
- acceptance + a "re-measure on a fresh standalone shard" note (the 06-12 bucket is stale)

`status: ready`, `feasibility: hard`, `sprint: Backlog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)