### PR TITLE
fix(#2164): negative-year standalone Date calendar fields + formatter year width

### DIFF
--- a/plan/issues/2164-standalone-date-residual.md
+++ b/plan/issues/2164-standalone-date-residual.md
@@ -1,11 +1,12 @@
 ---
 id: 2164
 title: "Standalone Date conformance residual (~234 tests)"
-status: in-progress
+status: done
+completed: 2026-06-18
 sprint: 63
 created: 2026-06-15
 updated: 2026-06-18
-assignee: ttraenkler/dev-date
+assignee: ttraenkler/cs-2164
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -230,3 +231,51 @@ returns NaN. None of our formatters emit that form; it is a lenient V8 extra.
 Covering it would require the ISO scanner to detect a month-name mid-stream —
 deferred. The dominant value (round-tripping the formatters + RFC2822 GMT
 strings) is delivered.
+
+---
+
+## Slice 6 (2026-06-18, cs-2164) — negative-year calendar fields + closes the issue
+
+**Landed — closes #2164.** The remaining slice flagged under Slices 3/4: the
+negative-year calendar getters. `__date_civil_from_days` returns
+`packed = year*10000 + month*100 + day` with month/day always positive, but for
+years < 0 the whole packed value is negative. Every decode site used Wasm
+`i64.div_s` / `i64.rem_s` (truncate toward zero), which corrupted both the year
+(off by one) *and* the month/day (returned **negative**) for any pre-year-0
+timestamp. e.g. `new Date(Date.UTC(-1,0,1))` returned `getUTCFullYear()=0`,
+`getUTCMonth()=-99`, `getUTCDate()=-99` standalone (should be -1 / 0 / 1). This
+hit the three calendar getters, the `setUTC*` component readback, and both the
+`__date_iso_string` and `__date_format_string` pure-Wasm helpers (so the string
+formatters were wrong too). The bug existed in **both** modes for the getters
+(calendar getters are computed natively regardless of host).
+
+**Fix** (`expressions/builtins.ts`): two shared emitters, `emitPackedYear` /
+`emitPackedMmdd`, decode the packed value with **floor** semantics —
+`year = floor(packed/10000)`; `mmdd = packed - year*10000` (guaranteed in
+[101, 1231]); `month = mmdd/100`, `day = mmdd%100`. Applied at all five decode
+sites (3 calendar getters, the `setUTC*` readback, the ISO helper, the
+format-string helper; the latter two overwrite `$packed` with the positive
+`mmdd` so their existing trunc-based month/day extraction works unchanged).
+
+**Also fixed** (same slice): the human-readable formatters (`toString` /
+`toUTCString` / `toDateString`) rendered out-of-[0,9999] years as the fixed ISO
+±6-digit form (`-000001`). Per V8 / ECMA-262 §21.4.4.41.1/§21.4.4.43, those use
+a sign-prefixed, **minimum-4-digit** decimal (`-0001`, `0099`, natural width for
+≥10000, no `+`); only `toISOString` (§21.4.1.18) uses the ±6-digit extended
+form. `writeYear` (format-string helper) now emits the min-4 form. This matches
+the host/runtime `_formatDate` behaviour already tested by #1343 Slice 5 — both
+paths now agree.
+
+**Validation.** New `tests/issue-2164-negative-year.test.ts` (42/42): the three
+calendar getters for years -1 / -100 / -271821 (near the §21.4.1.1 minimum),
+positive-year no-regression, `setUTCMonth` readback on a year -5 date, and exact
+string conformance (Node `TZ=UTC` output) for all five formatters across epoch,
+negative years, sub-1000 (`0099`), the 9999↔10000 boundary, and 275760 (near
+max) — covering the ISO `+010000`/`+275760` extended form vs the human-readable
+natural-width form. Existing #2164 / #2164-iso / #2164-formatters / #2164-rfc2822
+/ #1638 / #1343-negative-year suites: 69/69 unchanged. tsc + prettier + biome +
+stack-balance + coercion-sites + any-box gates clean. No host-import leak.
+
+With negative-year calendar fields correct, the standalone Date string +
+component surface reaches host parity for the full §21.4.1.1 year range; the
+issue is **done**.

--- a/src/codegen/expressions/builtins.ts
+++ b/src/codegen/expressions/builtins.ts
@@ -97,6 +97,69 @@ export function ensureDateStruct(ctx: CodegenContext): number {
   return typeIdx;
 }
 
+// ─── Packed civil-date decode (negative-year safe) ──────────────────────────
+//
+// `__date_civil_from_days` returns `packed = year*10000 + month*100 + day`
+// with month ∈ [1,12], day ∈ [1,31] (so the low four digits `month*100+day`
+// are always in [101, 1231], i.e. strictly positive). For years < 0 the whole
+// packed value is negative, and Wasm's `i64.div_s` / `i64.rem_s` truncate
+// toward zero — which corrupts the low digits (e.g. packed=-9899 for year -1
+// gives `-9899/10000 = 0` and `-9899%100 = -99`). Spec years run from about
+// -271821 to 275760 (§21.4.1.1), so negative years are reachable.
+//
+// The fix is floor semantics: `year = floor(packed/10000)` and
+// `mmdd = packed - year*10000` (guaranteed in [101, 1231]); `month = mmdd/100`,
+// `day = mmdd%100`. These emitters produce that decode given `packed` already
+// on the stack (consumed) and write the requested field. They assume the value
+// is `__date_civil_from_days`'s output so `mmdd` is non-negative.
+
+/**
+ * Emit `floor(packed / 10000)` (the calendar year) from a packed civil value
+ * on the stack. `tmpLocal` is a scratch i64 local. Leaves the year i64 on the
+ * stack.
+ */
+function emitPackedYear(out: Instr[], tmpLocal: number): void {
+  // tmp = packed
+  out.push({ op: "local.tee", index: tmpLocal } as Instr);
+  // q = packed / 10000  (trunc toward zero)
+  out.push({ op: "i64.const", value: 10000n } as Instr, { op: "i64.div_s" } as Instr);
+  // if packed < 0 and packed % 10000 != 0, subtract 1 to floor.
+  // correction = (packed % 10000 != 0) && (packed < 0) ? 1 : 0
+  out.push(
+    // q is on the stack; compute the correction and subtract it.
+    { op: "local.get", index: tmpLocal } as Instr, // packed
+    { op: "i64.const", value: 10000n } as Instr,
+    { op: "i64.rem_s" } as Instr, // packed % 10000
+    { op: "i64.const", value: 0n } as Instr,
+    { op: "i64.ne" } as Instr, // hasRem (i32)
+    { op: "local.get", index: tmpLocal } as Instr,
+    { op: "i64.const", value: 0n } as Instr,
+    { op: "i64.lt_s" } as Instr, // isNeg (i32)
+    { op: "i32.and" } as Instr, // correction (i32: 0/1)
+    { op: "i64.extend_i32_s" } as Instr,
+    { op: "i64.sub" } as Instr, // q - correction = floor(packed/10000)
+  );
+}
+
+/**
+ * Emit `packed - floor(packed/10000)*10000` (the `month*100+day` low part,
+ * always in [101, 1231]) from a packed civil value on the stack. `tmpLocal`
+ * holds the packed value; `yearTmp` is a scratch i64 local for the floored
+ * year. Leaves the `mmdd` i64 on the stack.
+ */
+function emitPackedMmdd(out: Instr[], tmpLocal: number, yearTmp: number): void {
+  emitPackedYear(out, tmpLocal); // floor year on stack; packed in tmpLocal
+  out.push({ op: "local.set", index: yearTmp } as Instr);
+  // mmdd = packed - year*10000
+  out.push(
+    { op: "local.get", index: tmpLocal } as Instr,
+    { op: "local.get", index: yearTmp } as Instr,
+    { op: "i64.const", value: 10000n } as Instr,
+    { op: "i64.mul" } as Instr,
+    { op: "i64.sub" } as Instr,
+  );
+}
+
 /**
  * Ensure the __date_civil_from_days helper function exists.
  * Signature: (i64 days_since_epoch) -> (i64 packed)
@@ -527,15 +590,26 @@ function ensureDateIsoStringHelper(ctx: CodegenContext): number {
     { op: "local.set", index: L_MSDAY } as Instr,
   );
 
-  // packed = civil_from_days(days); year = packed / 10000
+  // packed = civil_from_days(days); year = floor(packed / 10000). Negative-year
+  // safe: replace $packed with the always-positive low part (month*100+day)
+  // so the month/day extraction below works with plain truncating div/rem.
   body.push(
     { op: "local.get", index: L_DAYS } as Instr,
     { op: "call", funcIdx: civilIdx } as Instr,
     { op: "local.set", index: L_PACKED } as Instr,
+  );
+  // year = floor(packed / 10000)  (uses L_TMP as scratch)
+  body.push({ op: "local.get", index: L_PACKED } as Instr);
+  emitPackedYear(body, L_TMP);
+  body.push({ op: "local.set", index: L_YEAR } as Instr);
+  // packed = packed - year*10000  (month*100+day, always positive)
+  body.push(
     { op: "local.get", index: L_PACKED } as Instr,
+    { op: "local.get", index: L_YEAR } as Instr,
     { op: "i64.const", value: 10000n } as Instr,
-    { op: "i64.div_s" } as Instr,
-    { op: "local.set", index: L_YEAR } as Instr,
+    { op: "i64.mul" } as Instr,
+    { op: "i64.sub" } as Instr,
+    { op: "local.set", index: L_PACKED } as Instr,
   );
 
   /**
@@ -886,15 +960,26 @@ function ensureDateFormatStringHelper(ctx: CodegenContext): number {
     { op: "local.set", index: L_MSDAY } as Instr,
   );
 
-  // packed = civil_from_days(days); year = packed / 10000
+  // packed = civil_from_days(days); year = floor(packed / 10000). Negative-year
+  // safe: replace $packed with the always-positive low part (month*100+day) so
+  // the setMonthIdx/setDay extractions below work with truncating div/rem.
   body.push(
     { op: "local.get", index: L_DAYS } as Instr,
     { op: "call", funcIdx: civilIdx } as Instr,
     { op: "local.set", index: L_PACKED } as Instr,
+  );
+  // year = floor(packed / 10000)  (uses L_TMP as scratch)
+  body.push({ op: "local.get", index: L_PACKED } as Instr);
+  emitPackedYear(body, L_TMP);
+  body.push({ op: "local.set", index: L_YEAR } as Instr);
+  // packed = packed - year*10000  (month*100+day, always positive)
+  body.push(
     { op: "local.get", index: L_PACKED } as Instr,
+    { op: "local.get", index: L_YEAR } as Instr,
     { op: "i64.const", value: 10000n } as Instr,
-    { op: "i64.div_s" } as Instr,
-    { op: "local.set", index: L_YEAR } as Instr,
+    { op: "i64.mul" } as Instr,
+    { op: "i64.sub" } as Instr,
+    { op: "local.set", index: L_PACKED } as Instr,
   );
 
   // dow = ((days % 7) + 4 + 7) % 7   (epoch day 0 = Thursday = 4)
@@ -1005,90 +1090,89 @@ function ensureDateFormatStringHelper(ctx: CodegenContext): number {
     );
   };
   const writeYear = (): void => {
-    // 4-digit when 0..9999, else extended ±6 digits.
+    // Human-readable formatters (toString/toUTCString/toDateString) render the
+    // year as a sign-prefixed, minimum-4-digit decimal: V8 emits `-0001` for
+    // year -1, `0099` for year 99, `9999`/`10000`/`275760` at natural width
+    // for larger magnitudes — NOT the fixed ±6-digit ISO extended form (that
+    // is only for toISOString, §21.4.1.18). So: write `-` when year < 0, then
+    // abs(year) zero-padded to ≥4 digits (5 digits for |year| 10000..99999,
+    // 6 digits for ≥100000).
+    //
+    // Emit `-` if year < 0.
     body.push(
-      { op: "local.get", index: L_YEAR } as Instr,
-      { op: "i64.const", value: 0n } as Instr,
-      { op: "i64.ge_s" } as Instr,
-      { op: "local.get", index: L_YEAR } as Instr,
-      { op: "i64.const", value: 9999n } as Instr,
-      { op: "i64.le_s" } as Instr,
-      { op: "i32.and" } as Instr,
-    );
-    const buf4: Instr[] = [];
-    for (let d = 0; d < 4; d++) {
-      const div = 10n ** BigInt(3 - d);
-      buf4.push(
-        { op: "local.get", index: L_BUF } as Instr,
-        { op: "local.get", index: L_POS } as Instr,
-        { op: "local.get", index: L_YEAR } as Instr,
-      );
-      if (div !== 1n) buf4.push({ op: "i64.const", value: div } as Instr, { op: "i64.div_s" } as Instr);
-      buf4.push(
-        { op: "i64.const", value: 10n } as Instr,
-        { op: "i64.rem_s" } as Instr,
-        { op: "i32.wrap_i64" } as Instr,
-        { op: "i32.const", value: 0x30 } as Instr,
-        { op: "i32.add" } as Instr,
-        { op: "array.set", typeIdx: strDataTypeIdx } as Instr,
-        { op: "local.get", index: L_POS } as Instr,
-        { op: "i32.const", value: 1 } as Instr,
-        { op: "i32.add" } as Instr,
-        { op: "local.set", index: L_POS } as Instr,
-      );
-    }
-    const buf6: Instr[] = [];
-    buf6.push(
-      { op: "local.get", index: L_BUF } as Instr,
-      { op: "local.get", index: L_POS } as Instr,
       { op: "local.get", index: L_YEAR } as Instr,
       { op: "i64.const", value: 0n } as Instr,
       { op: "i64.lt_s" } as Instr,
       {
         op: "if",
-        blockType: { kind: "val", type: { kind: "i32" } },
-        then: [{ op: "i32.const", value: 0x2d } as Instr],
-        else: [{ op: "i32.const", value: 0x2b } as Instr],
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: L_BUF } as Instr,
+          { op: "local.get", index: L_POS } as Instr,
+          { op: "i32.const", value: 0x2d } as Instr, // '-'
+          { op: "array.set", typeIdx: strDataTypeIdx } as Instr,
+          { op: "local.get", index: L_POS } as Instr,
+          { op: "i32.const", value: 1 } as Instr,
+          { op: "i32.add" } as Instr,
+          { op: "local.set", index: L_POS } as Instr,
+        ],
       } as unknown as Instr,
-      { op: "array.set", typeIdx: strDataTypeIdx } as Instr,
-      { op: "local.get", index: L_POS } as Instr,
-      { op: "i32.const", value: 1 } as Instr,
-      { op: "i32.add" } as Instr,
-      { op: "local.set", index: L_POS } as Instr,
     );
-    buf6.push(
+    // L_TMP = abs(year)
+    body.push(
       { op: "i64.const", value: 0n } as Instr,
       { op: "local.get", index: L_YEAR } as Instr,
-      { op: "i64.sub" } as Instr,
-      { op: "local.get", index: L_YEAR } as Instr,
+      { op: "i64.sub" } as Instr, // -year
+      { op: "local.get", index: L_YEAR } as Instr, // year
       { op: "local.get", index: L_YEAR } as Instr,
       { op: "i64.const", value: 0n } as Instr,
-      { op: "i64.lt_s" } as Instr,
-      { op: "select" } as Instr,
+      { op: "i64.lt_s" } as Instr, // year < 0 ?
+      { op: "select" } as Instr, // abs(year)
       { op: "local.set", index: L_TMP } as Instr,
     );
-    for (let d = 0; d < 6; d++) {
-      const div = 10n ** BigInt(5 - d);
-      buf6.push(
-        { op: "local.get", index: L_BUF } as Instr,
-        { op: "local.get", index: L_POS } as Instr,
-        { op: "local.get", index: L_TMP } as Instr,
-      );
-      if (div !== 1n) buf6.push({ op: "i64.const", value: div } as Instr, { op: "i64.div_s" } as Instr);
-      buf6.push(
-        { op: "i64.const", value: 10n } as Instr,
-        { op: "i64.rem_s" } as Instr,
-        { op: "i32.wrap_i64" } as Instr,
-        { op: "i32.const", value: 0x30 } as Instr,
-        { op: "i32.add" } as Instr,
-        { op: "array.set", typeIdx: strDataTypeIdx } as Instr,
-        { op: "local.get", index: L_POS } as Instr,
-        { op: "i32.const", value: 1 } as Instr,
-        { op: "i32.add" } as Instr,
-        { op: "local.set", index: L_POS } as Instr,
-      );
-    }
-    body.push({ op: "if", blockType: { kind: "empty" }, then: buf4, else: buf6 } as unknown as Instr);
+    // Choose width: 4 (|y|<=9999), 5 (<=99999), else 6 (spec max year 275760).
+    const writeWidth = (w: number): Instr[] => {
+      const out: Instr[] = [];
+      for (let d = 0; d < w; d++) {
+        const div = 10n ** BigInt(w - 1 - d);
+        out.push(
+          { op: "local.get", index: L_BUF } as Instr,
+          { op: "local.get", index: L_POS } as Instr,
+          { op: "local.get", index: L_TMP } as Instr,
+        );
+        if (div !== 1n) out.push({ op: "i64.const", value: div } as Instr, { op: "i64.div_s" } as Instr);
+        out.push(
+          { op: "i64.const", value: 10n } as Instr,
+          { op: "i64.rem_s" } as Instr,
+          { op: "i32.wrap_i64" } as Instr,
+          { op: "i32.const", value: 0x30 } as Instr,
+          { op: "i32.add" } as Instr,
+          { op: "array.set", typeIdx: strDataTypeIdx } as Instr,
+          { op: "local.get", index: L_POS } as Instr,
+          { op: "i32.const", value: 1 } as Instr,
+          { op: "i32.add" } as Instr,
+          { op: "local.set", index: L_POS } as Instr,
+        );
+      }
+      return out;
+    };
+    // if abs <= 9999: 4 digits; else if abs <= 99999: 5 digits; else 6 digits.
+    body.push(
+      { op: "local.get", index: L_TMP } as Instr,
+      { op: "i64.const", value: 9999n } as Instr,
+      { op: "i64.le_s" } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: writeWidth(4),
+        else: [
+          { op: "local.get", index: L_TMP } as Instr,
+          { op: "i64.const", value: 99999n } as Instr,
+          { op: "i64.le_s" } as Instr,
+          { op: "if", blockType: { kind: "empty" }, then: writeWidth(5), else: writeWidth(6) } as unknown as Instr,
+        ],
+      } as unknown as Instr,
+    );
   };
   // hh:mm:ss into the buffer.
   const writeTimeHMS = (): void => {
@@ -1916,26 +2000,35 @@ function compileDateMethodCall(
     fctx.body.push({ op: "call", funcIdx: civilIdx } as Instr);
     fctx.body.push({ op: "local.set", index: tempPacked } as Instr);
 
-    // Extract curY, curMo (1-based), curD from packed.
-    // curY = packed / 10000
-    // curMo = (packed / 100) % 100
-    // curD = packed % 100
+    // Extract curY, curMo (1-based), curD from packed. Negative-year safe:
+    // curY = floor(packed/10000); curMmdd = packed - curY*10000 ∈ [101, 1231];
+    // curMo = curMmdd/100; curD = curMmdd%100 (see emitPackedYear/emitPackedMmdd).
     const tempCurY = allocTempLocal(fctx, { kind: "i64" });
+    const tempMmddScratch = allocTempLocal(fctx, { kind: "i64" });
     fctx.body.push({ op: "local.get", index: tempPacked } as Instr);
-    fctx.body.push({ op: "i64.const", value: 10000n } as Instr);
-    fctx.body.push({ op: "i64.div_s" } as Instr);
+    emitPackedYear(fctx.body, tempMmddScratch); // floor year on stack
     fctx.body.push({ op: "local.set", index: tempCurY } as Instr);
 
+    // curMmdd = packed - curY*10000  (always positive)
+    const tempCurMmdd = allocTempLocal(fctx, { kind: "i64" });
+    fctx.body.push(
+      { op: "local.get", index: tempPacked } as Instr,
+      { op: "local.get", index: tempCurY } as Instr,
+      { op: "i64.const", value: 10000n } as Instr,
+      { op: "i64.mul" } as Instr,
+      { op: "i64.sub" } as Instr,
+      { op: "local.set", index: tempCurMmdd } as Instr,
+    );
+    releaseTempLocal(fctx, tempMmddScratch);
+
     const tempCurMo = allocTempLocal(fctx, { kind: "i64" });
-    fctx.body.push({ op: "local.get", index: tempPacked } as Instr);
+    fctx.body.push({ op: "local.get", index: tempCurMmdd } as Instr);
     fctx.body.push({ op: "i64.const", value: 100n } as Instr);
     fctx.body.push({ op: "i64.div_s" } as Instr);
-    fctx.body.push({ op: "i64.const", value: 100n } as Instr);
-    fctx.body.push({ op: "i64.rem_s" } as Instr);
     fctx.body.push({ op: "local.set", index: tempCurMo } as Instr);
 
     const tempCurD = allocTempLocal(fctx, { kind: "i64" });
-    fctx.body.push({ op: "local.get", index: tempPacked } as Instr);
+    fctx.body.push({ op: "local.get", index: tempCurMmdd } as Instr);
     fctx.body.push({ op: "i64.const", value: 100n } as Instr);
     fctx.body.push({ op: "i64.rem_s" } as Instr);
     fctx.body.push({ op: "local.set", index: tempCurD } as Instr);
@@ -2218,25 +2311,27 @@ function compileDateMethodCall(
 
   if (methodName === "getFullYear" || methodName === "getUTCFullYear") {
     return wrapWithInvalidDateGuard(() => {
-      emitDaysToCivil();
-      fctx.body.push(
-        { op: "i64.const", value: 10000n } as Instr,
-        { op: "i64.div_s" } as Instr,
-        { op: "f64.convert_i64_s" } as Instr,
-      );
+      emitDaysToCivil(); // packed on stack
+      const tmp = allocTempLocal(fctx, { kind: "i64" });
+      emitPackedYear(fctx.body, tmp); // floor(packed/10000)
+      releaseTempLocal(fctx, tmp);
+      fctx.body.push({ op: "f64.convert_i64_s" } as Instr);
     });
   }
 
   if (methodName === "getMonth" || methodName === "getUTCMonth") {
     return wrapWithInvalidDateGuard(() => {
-      emitDaysToCivil();
+      emitDaysToCivil(); // packed on stack
+      const tmp = allocTempLocal(fctx, { kind: "i64" });
+      const yTmp = allocTempLocal(fctx, { kind: "i64" });
+      emitPackedMmdd(fctx.body, tmp, yTmp); // month*100+day (always positive)
+      releaseTempLocal(fctx, tmp);
+      releaseTempLocal(fctx, yTmp);
       fctx.body.push(
         { op: "i64.const", value: 100n } as Instr,
-        { op: "i64.div_s" } as Instr,
-        { op: "i64.const", value: 100n } as Instr,
-        { op: "i64.rem_s" } as Instr,
+        { op: "i64.div_s" } as Instr, // month (1-12)
         { op: "i64.const", value: 1n } as Instr,
-        { op: "i64.sub" } as Instr,
+        { op: "i64.sub" } as Instr, // 0-based
         { op: "f64.convert_i64_s" } as Instr,
       );
     });
@@ -2244,10 +2339,15 @@ function compileDateMethodCall(
 
   if (methodName === "getDate" || methodName === "getUTCDate") {
     return wrapWithInvalidDateGuard(() => {
-      emitDaysToCivil();
+      emitDaysToCivil(); // packed on stack
+      const tmp = allocTempLocal(fctx, { kind: "i64" });
+      const yTmp = allocTempLocal(fctx, { kind: "i64" });
+      emitPackedMmdd(fctx.body, tmp, yTmp); // month*100+day (always positive)
+      releaseTempLocal(fctx, tmp);
+      releaseTempLocal(fctx, yTmp);
       fctx.body.push(
         { op: "i64.const", value: 100n } as Instr,
-        { op: "i64.rem_s" } as Instr,
+        { op: "i64.rem_s" } as Instr, // day (1-31)
         { op: "f64.convert_i64_s" } as Instr,
       );
     });

--- a/tests/issue-2164-negative-year.test.ts
+++ b/tests/issue-2164-negative-year.test.ts
@@ -1,0 +1,174 @@
+// #2164 (final slice) — standalone Date negative-year calendar fields + year width.
+//
+// `__date_civil_from_days` returns `packed = year*10000 + month*100 + day` with
+// month/day always positive. For years < 0 the whole packed value is negative,
+// and Wasm's `i64.div_s` / `i64.rem_s` truncate toward zero — which corrupted
+// the year (off by one) AND the month/day (returned negative) for every
+// pre-year-0 timestamp standalone. e.g. `new Date(Date.UTC(-1,0,1))`
+// getUTCFullYear()/getUTCMonth()/getUTCDate() returned 0 / -99 / -99 instead of
+// -1 / 0 / 1. The same packed decode feeds the pure-Wasm `toISOString` and
+// `__date_format_string` helpers, so the formatters were wrong too.
+//
+// Fix (expressions/builtins.ts): decode the packed value with floor semantics —
+// `year = floor(packed/10000)`, `mmdd = packed - year*10000` (∈ [101,1231]),
+// `month = mmdd/100`, `day = mmdd%100` — applied at every decode site (the three
+// calendar getters, the setUTC* component readback, and both string helpers).
+//
+// Separately, the human-readable formatters (toString / toUTCString /
+// toDateString) had rendered out-of-[0,9999] years as the fixed ISO ±6-digit
+// form (`-000001`). V8 uses a sign-prefixed, minimum-4-digit decimal there
+// (`-0001`, `0099`, natural width for ≥10000) — only toISOString uses the
+// ±6-digit extended form (§21.4.1.18). writeYear now emits the min-4 form.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/** Compile standalone and run a numeric `run` export. */
+async function runNum(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  // Pure standalone module — no host-import leak.
+  expect((r.imports ?? []).map((i) => i.name)).toEqual([]);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as Record<string, () => number>).run();
+}
+
+/** Compile standalone and decode the native-string result of `new Date(ts).<method>()`. */
+async function dateStr(ts: number, method: string): Promise<string> {
+  const src = `
+    let g: string = "";
+    export function build(): void { g = new Date(${ts}).${method}(); }
+    export function len(): number { return g.length; }
+    export function at(i: number): number { return g.charCodeAt(i); }
+  `;
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  expect((r.imports ?? []).map((i) => i.name)).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const ex = instance.exports as {
+    build: () => void;
+    len: () => number;
+    at: (i: number) => number;
+  };
+  ex.build();
+  let out = "";
+  for (let i = 0; i < ex.len(); i++) out += String.fromCharCode(ex.at(i));
+  return out;
+}
+
+// Timestamps whose UTC year is < 0, plus boundary/positive controls. Values are
+// computed via Date.UTC so the expectations track the host JS Date exactly
+// (UTC-based — standalone has no timezone DB; deterministic regardless of host TZ).
+const NEG_YEAR_CASES: Array<[string, number]> = [
+  ["year -1", Date.UTC(-1, 5, 15, 10, 30, 45, 123)],
+  ["year -100", Date.UTC(-100, 0, 1)],
+  ["year -271821 (near min)", Date.UTC(-271821, 3, 20)],
+];
+
+describe("#2164 standalone Date negative-year calendar getters", () => {
+  for (const [label, ts] of NEG_YEAR_CASES) {
+    const ref = new Date(ts);
+    it(`getUTCFullYear is correct for ${label}`, async () => {
+      expect(await runNum(`export function run(): number { return new Date(${ts}).getUTCFullYear(); }`)).toBe(
+        ref.getUTCFullYear(),
+      );
+    });
+    it(`getUTCMonth is non-negative & correct for ${label}`, async () => {
+      expect(await runNum(`export function run(): number { return new Date(${ts}).getUTCMonth(); }`)).toBe(
+        ref.getUTCMonth(),
+      );
+    });
+    it(`getUTCDate is non-negative & correct for ${label}`, async () => {
+      expect(await runNum(`export function run(): number { return new Date(${ts}).getUTCDate(); }`)).toBe(
+        ref.getUTCDate(),
+      );
+    });
+  }
+
+  it("positive years still decode correctly (no regression)", async () => {
+    const ts = Date.UTC(2023, 5, 15);
+    const ref = new Date(ts);
+    expect(await runNum(`export function run(): number { return new Date(${ts}).getUTCFullYear(); }`)).toBe(
+      ref.getUTCFullYear(),
+    );
+    expect(await runNum(`export function run(): number { return new Date(${ts}).getUTCMonth(); }`)).toBe(
+      ref.getUTCMonth(),
+    );
+    expect(await runNum(`export function run(): number { return new Date(${ts}).getUTCDate(); }`)).toBe(
+      ref.getUTCDate(),
+    );
+  });
+});
+
+describe("#2164 setUTC* component readback on a negative-year date", () => {
+  it("setUTCMonth reads the current (negative) year back correctly", async () => {
+    const ts = Date.UTC(-5, 0, 1);
+    const rd = new Date(ts);
+    rd.setUTCMonth(5);
+    // Pack month and year into one number to assert both in a single run.
+    const ref = rd.getUTCMonth() * 100000 + (rd.getUTCFullYear() + 100000);
+    const got = await runNum(
+      `export function run(): number { const d = new Date(${ts}); d.setUTCMonth(5); return d.getUTCMonth() * 100000 + (d.getUTCFullYear() + 100000); }`,
+    );
+    expect(got).toBe(ref);
+  });
+});
+
+describe("#2164 standalone Date string formatters across the year range", () => {
+  // (ts, method, expected) — expected strings are Node's output under `TZ=UTC`.
+  // The standalone formatters always render UTC (no timezone DB), so a live
+  // `new Date(ts)[m]()` reference would diverge in a non-UTC CI host for the
+  // local-time forms (toString / toTimeString / toDateString). Hardcoding the
+  // UTC expectations keeps the assertion TZ-independent. Boundaries exercised:
+  // negative years (min-4-digit signed: `-0001`, `-0100`), sub-1000 (`0099`),
+  // and large positive years where toISOString uses the +6-digit extended form
+  // (`+010000`, `+275760`) but the human-readable forms use natural width
+  // (`10000`, `275760`, no `+`).
+  const STRING_CASES: Array<[number, string, string]> = [
+    // epoch
+    [0, "toISOString", "1970-01-01T00:00:00.000Z"],
+    [0, "toUTCString", "Thu, 01 Jan 1970 00:00:00 GMT"],
+    [0, "toString", "Thu Jan 01 1970 00:00:00 GMT+0000 (Coordinated Universal Time)"],
+    [0, "toDateString", "Thu Jan 01 1970"],
+    [0, "toTimeString", "00:00:00 GMT+0000 (Coordinated Universal Time)"],
+    // year -1
+    [-62184461354877, "toISOString", "-000001-06-15T10:30:45.123Z"],
+    [-62184461354877, "toUTCString", "Tue, 15 Jun -0001 10:30:45 GMT"],
+    [-62184461354877, "toString", "Tue Jun 15 -0001 10:30:45 GMT+0000 (Coordinated Universal Time)"],
+    [-62184461354877, "toDateString", "Tue Jun 15 -0001"],
+    [-62184461354877, "toTimeString", "10:30:45 GMT+0000 (Coordinated Universal Time)"],
+    // year -100
+    [-65322892800000, "toISOString", "-000100-01-01T00:00:00.000Z"],
+    [-65322892800000, "toUTCString", "Mon, 01 Jan -0100 00:00:00 GMT"],
+    [-65322892800000, "toDateString", "Mon Jan 01 -0100"],
+    // year -271821 (near the §21.4.1.1 minimum)
+    [-8640000000000000, "toISOString", "-271821-04-20T00:00:00.000Z"],
+    [-8640000000000000, "toUTCString", "Tue, 20 Apr -271821 00:00:00 GMT"],
+    [-8640000000000000, "toString", "Tue Apr 20 -271821 00:00:00 GMT+0000 (Coordinated Universal Time)"],
+    [-8640000000000000, "toDateString", "Tue Apr 20 -271821"],
+    // year 99 (sub-1000 zero-padding to 4 digits)
+    [-59042995200000, "toISOString", "0099-01-01T00:00:00.000Z"],
+    [-59042995200000, "toUTCString", "Thu, 01 Jan 0099 00:00:00 GMT"],
+    [-59042995200000, "toDateString", "Thu Jan 01 0099"],
+    // year 10000 (ISO extended +6 digit vs natural-width human form)
+    [253402300800000, "toISOString", "+010000-01-01T00:00:00.000Z"],
+    [253402300800000, "toUTCString", "Sat, 01 Jan 10000 00:00:00 GMT"],
+    [253402300800000, "toString", "Sat Jan 01 10000 00:00:00 GMT+0000 (Coordinated Universal Time)"],
+    [253402300800000, "toDateString", "Sat Jan 01 10000"],
+    // year 275760 (near the §21.4.1.1 maximum)
+    [8639977881600000, "toISOString", "+275760-01-01T00:00:00.000Z"],
+    [8639977881600000, "toUTCString", "Tue, 01 Jan 275760 00:00:00 GMT"],
+    [8639977881600000, "toDateString", "Tue Jan 01 275760"],
+    // year 2023 control
+    [1686825045123, "toISOString", "2023-06-15T10:30:45.123Z"],
+    [1686825045123, "toUTCString", "Thu, 15 Jun 2023 10:30:45 GMT"],
+    [1686825045123, "toString", "Thu Jun 15 2023 10:30:45 GMT+0000 (Coordinated Universal Time)"],
+    [1686825045123, "toDateString", "Thu Jun 15 2023"],
+  ];
+
+  for (const [ts, method, want] of STRING_CASES) {
+    it(`${method} renders "${want}" for ts=${ts}`, async () => {
+      expect(await dateStr(ts, method)).toBe(want);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Final slice of #2164 (standalone Date conformance residual). Fixes the
negative-year calendar getters flagged as remaining under Slices 3/4, plus the
human-readable formatter year-width.

**Root cause.** `__date_civil_from_days` returns
`packed = year*10000 + month*100 + day` with month/day always positive. For
years < 0 the whole packed value is negative, and every decode site used Wasm
`i64.div_s` / `i64.rem_s` (truncate toward zero) — which corrupted the year
(off by one) AND returned **negative** month/day. e.g.
`new Date(Date.UTC(-1,0,1))` returned `getUTCFullYear()=0`, `getUTCMonth()=-99`,
`getUTCDate()=-99` standalone (should be -1 / 0 / 1). The same packed decode
feeds the pure-Wasm `toISOString` and `__date_format_string` helpers, so the
string formatters were wrong for negative years too. (The calendar getters are
native in both modes, so the getter bug existed in host mode as well.)

**Fix.** New shared emitters `emitPackedYear` / `emitPackedMmdd` decode with
floor semantics — `year = floor(packed/10000)`; `mmdd = packed - year*10000`
(guaranteed in [101, 1231]); `month = mmdd/100`, `day = mmdd%100` — applied at
all five decode sites (3 calendar getters, the `setUTC*` component readback, and
both pure-Wasm string helpers).

**Also fixed.** The human-readable formatters (`toString`/`toUTCString`/
`toDateString`) rendered out-of-[0,9999] years as the fixed ISO ±6-digit form
(`-000001`). Per ECMA-262 §21.4.4.41.1/§21.4.4.43 those use a sign-prefixed
**minimum-4-digit** decimal (`-0001`, `0099`, natural width for ≥10000, no `+`);
only `toISOString` (§21.4.1.18) uses the ±6-digit extended form. `writeYear` now
emits the min-4 form, matching the host `_formatDate` path already covered by
#1343 Slice 5.

## Test plan

- New `tests/issue-2164-negative-year.test.ts` (42): calendar getters for years
  -1 / -100 / -271821 (near §21.4.1.1 min), positive-year no-regression,
  `setUTCMonth` readback on a year -5 date, and exact-string formatter
  conformance (Node `TZ=UTC`) across epoch, negative years, sub-1000 (`0099`),
  the 9999↔10000 boundary, and 275760 (near max) — exercising the ISO
  `+010000`/`+275760` extended form vs the human-readable natural-width form.
- Existing #2164 / #2164-iso / #2164-formatters / #2164-rfc2822 / #1638 /
  #1343-negative-year suites: 69/69 unchanged.
- tsc + prettier + biome + stack-balance + coercion-sites + any-box gates clean.
  No host-import leak.

Closes #2164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)