### PR TITLE
fix(#2158): dstr-param default with nested sub-pattern emits valid Wasm

### DIFF
--- a/plan/issues/2158-standalone-class-prototype-descriptor-residual.md
+++ b/plan/issues/2158-standalone-class-prototype-descriptor-residual.md
@@ -2,10 +2,10 @@
 id: 2158
 title: "Standalone class/prototype/private-name/descriptor conformance residual (~1,388 tests)"
 status: in-progress
-assignee: ttraenkler/sd1
+assignee: ttraenkler/cs-2158
 sprint: 63
 created: 2026-06-15
-updated: 2026-06-17
+updated: 2026-06-18
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -348,3 +348,81 @@ six; schedule after the CE families are cleared so the FAIL signal is clean.
 Add standalone equivalence regressions under
 `tests/issue-2158-*-standalone.test.ts` per slice (mirror
 `tests/issue-2158-class-identity-standalone.test.ts`).
+
+---
+
+## Implementation notes — Slice F-1 (2026-06-18, cs-2158): dstr-param default funcIdx-shift invalid-Wasm
+
+### What
+Fixes a concrete Family-F (invalid-Wasm-binary) defect that hit a large slice
+of the class `dstr/` failures (e.g.
+`class/dstr/meth-dflt-obj-ptrn-prop-ary`, `private-meth-dflt-obj-ptrn-prop-ary`,
+`gen-meth-dflt-obj-ptrn-prop-ary`, … — and the equivalent top-level functions).
+A function/method parameter whose binding pattern carries a **default value**
+(`= …`) AND binds a **nested sub-pattern** (an object property bound to an array
+sub-pattern, `{ x: [y] } = { x: [42] }`, or a nested array `[[y]] = …`) compiled
+to invalid Wasm: `if[0] expected type i32, found call of type externref`.
+
+This was diagnosed by WAT-tracing the standalone repro — the param-default
+missing-arg guard `(if (call $__extern_is_undefined …))` had its condition call
+pointing at `$__object_seal` (an externref producer) instead of
+`$__extern_is_undefined` (an i32 producer).
+
+### Root cause — a funcIdx index-shift orphan (addUnionImports/#1109 family)
+`destructureParamObject`'s externref **struct-fast-path**
+(`destructuring-params.ts`, the `ref.test structTypeIdx ? then : else` arm)
+detaches the OUTER function body to a then/else branch buffer with a **plain
+JS-local swap** (`const savedBody = fctx.body; fctx.body = then/elseInstrs; …;
+fctx.body = savedBody`). The then/else buffers are correctly tracked in
+`ctx.liveBodies` (#779d), but the **outer body itself is orphaned** — it is not
+on `fctx.savedBodies`, not in `ctx.liveBodies`, and not `fctx.body` during the
+recursive descent. When the nested array sub-pattern's recursive
+`destructureParamArray` adds a late import (`__array_from_iter_n` /
+`__extern_get_idx` / `__extern_length`, added at low import indices →
+`importsBefore=0`, shifting EVERY defined-function index up), the
+`shiftLateImportIndices` walk visited `fctx.body` + `savedBodies` + `liveBodies`
+but never the orphaned outer body. So the already-emitted
+`call __extern_is_undefined` (the param-default `if` condition, emitted into the
+outer body BEFORE the destructuring loop runs) kept its stale-low funcIdx and
+the `if` consumed an externref where an i32 was required → invalid Wasm.
+
+Confirmed via instrumentation: condition captured at idx 114; module-finalize
+moved `__extern_is_undefined` to 116 but the emitted call stayed at 114 (= now
+`__object_seal`); the two flushes that did the shift reported the call
+unreachable from the fctx body chain.
+
+### Fix
+`src/codegen/destructuring-params.ts` — in the struct-fast-path branch, track the
+orphaned outer `savedBody` in `ctx.liveBodies` for the recursion window
+(add before the then/else compile, delete after the `if` is assembled),
+mirroring the existing then/else #779d tracking. Guarded with
+`outerAlreadyLive` so a re-entrant call that already tracked the body does not
+double-delete (keeps the #2182 liveBodies-balance invariant intact). +16 lines,
+no behavior change to the non-orphan paths.
+
+### Verification
+- `tests/issue-2158-dstr-param-default-nested-pattern.test.ts` (8 cases):
+  standalone now VALIDATES (`WebAssembly.compile` succeeds — the direct
+  regression guard for the orphan) for object-prop→array, class-method,
+  2-element, nested-array-with-its-own-default+outer-default, and explicit-arg
+  shapes; plus host-mode runtime correctness (default fires → 42, explicit → 7,
+  nested+outer → 24).
+- The pre-existing `issue-1025-param-default-null.test.ts:78` assertion failure
+  reproduces identically on clean `origin/main` (verified) — NOT a regression of
+  this change.
+- The `array-rest-destructuring` / `destructuring-member-targets` /
+  `for-of-array-destructuring` suites fail to load on `origin/main` too
+  (they import a non-existent `./helpers.js`) — pre-existing, unrelated.
+
+### Remaining (still open under this umbrella)
+- **Host-import leak in standalone**: these shapes now compile to *valid* Wasm
+  but still emit `env::__array_from_iter_n` (+ `env::__get_undefined` via
+  `emitBoundsCheckedArrayGetUndef` bypassing `ensureGetUndefined`), which
+  standalone cannot satisfy at instantiation. Needs a Wasm-native array-from-iter
+  fallback (or to route the known-vec fast path so the import is never added).
+  Separate, larger slice.
+- **A deeper funcIdx orphan in larger modules**: the static-method variant
+  (`meth-static-dflt-obj-ptrn-prop-ary`, harness-sized module) surfaces a second
+  shift orphan (`call[0] expected (ref null N), found externref`) AFTER this fix
+  clears its `if[0]` error — i.e. this fix is strict progress that unmasks it.
+  Same family; another body-swap site to audit. Documented for a follow-up slice.

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -686,6 +686,21 @@ export function destructureParamObject(
         ctx.liveBodies.add(thenInstrs);
         ctx.liveBodies.add(elseInstrs);
         const savedBody = fctx.body;
+        // (#2158) Also track the OUTER body (savedBody) in liveBodies for the
+        // recursion window. This struct-fast-path swap detaches `fctx.body` to a
+        // branch buffer via a plain JS-local swap (not pushBody), so the outer
+        // body is NOT on `fctx.savedBodies`. A late-import shift triggered deep
+        // inside the recursive `destructureParamObjectExternref` /
+        // `destructureParamArray` calls (e.g. `__array_from_iter_n` /
+        // `__extern_get_idx` for a nested array sub-pattern `{ x: [y] } = …`)
+        // walks fctx.body + savedBodies + liveBodies, but the orphaned outer
+        // body was unreachable from all three — so a `call`/`ref.func` already
+        // emitted into it (the param-default `if (call __extern_is_undefined)`
+        // missing-arg guard) kept a stale-low funcIdx and the `if` consumed an
+        // externref where i32 was expected → invalid Wasm. Tracking the outer
+        // body closes that window (mirrors the then/else tracking above).
+        const outerAlreadyLive = ctx.liveBodies.has(savedBody);
+        if (!outerAlreadyLive) ctx.liveBodies.add(savedBody);
         fctx.body = thenInstrs;
         fctx.body.push({ op: "local.get", index: anyTmp });
         fctx.body.push({ op: "ref.cast", typeIdx: structTypeIdx });
@@ -701,6 +716,7 @@ export function destructureParamObject(
         fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: thenInstrs, else: elseInstrs });
         ctx.liveBodies.delete(thenInstrs);
         ctx.liveBodies.delete(elseInstrs);
+        if (!outerAlreadyLive) ctx.liveBodies.delete(savedBody);
       } else {
         // No struct type found — use __extern_get for all properties (#852)
         destructureParamObjectExternref(ctx, fctx, paramIdx, pattern, opts);

--- a/tests/issue-2158-dstr-param-default-nested-pattern.test.ts
+++ b/tests/issue-2158-dstr-param-default-nested-pattern.test.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2158 (slice — Family F, invalid-Wasm-binary) — a function/method parameter
+// whose binding pattern carries a DEFAULT value (`= …`) and whose pattern binds
+// a NESTED sub-pattern (an object property bound to an array sub-pattern, or a
+// nested array) emitted invalid Wasm: the param-missing default guard `if`
+// consumed an `externref` where an `i32` condition was expected
+// (`if[0] expected type i32, found call of type externref`).
+//
+// Root cause: a funcIdx index-shift orphan. `destructureParamObject`'s externref
+// struct-fast-path (destructuring-params.ts) detaches the OUTER function body to
+// a then/else branch buffer via a plain JS-local swap (not `pushBody`), so the
+// outer body is not on `fctx.savedBodies`. A late import added deep inside the
+// recursive `destructureParamObjectExternref` / `destructureParamArray` calls
+// for the nested sub-pattern (`__array_from_iter_n` / `__extern_get_idx` /
+// `__extern_length`) triggered a `shiftLateImportIndices` walk that never
+// reached the orphaned outer body — leaving the already-emitted
+// `call __extern_is_undefined` (the param-default missing-arg guard, an i32
+// producer) pointing one-or-more functions too low (e.g. at `__object_seal`,
+// an externref producer). Tracking the outer body in `ctx.liveBodies` for the
+// recursion window (mirroring the then/else #779d tracking) closes the orphan.
+//
+// Spec references:
+// - ECMA-262 §10.2.11 FunctionDeclarationInstantiation (default-param firing)
+// - ECMA-262 §8.6.2 BindingInitialization / §13.3.3 destructuring
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { instantiateWithRuntime } from "./equivalence/helpers.js";
+
+/**
+ * The slice's core assertion: the shapes that previously emitted invalid Wasm
+ * now produce a VALID module. `WebAssembly.compile` validates the binary
+ * without needing the (separate, still-open) standalone host-import fallback
+ * for `__array_from_iter_n`, so it isolates the funcIdx-shift fix. A regression
+ * of the orphan re-introduces a `CompileError` here.
+ */
+async function expectValidatesStandalone(src: string): Promise<void> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  // Throws CompileError if the binary is invalid Wasm (the bug).
+  await WebAssembly.compile(r.binary);
+}
+
+/** Host-mode runtime correctness — the env runtime satisfies the destructuring. */
+async function runHost(src: string): Promise<unknown> {
+  const r = await compile(src);
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const inst = await instantiateWithRuntime(r);
+  return (inst.exports as { test: () => unknown }).test();
+}
+
+describe("#2158 dstr-param default with nested sub-pattern emits valid Wasm", () => {
+  it("standalone validates: { x: [y] } = { x: [42] } (object prop → array sub-pattern)", async () => {
+    await expectValidatesStandalone(
+      `function f({ x: [y] } = { x: [42] }) { return y; }
+       export function test(): number { return f(); }`,
+    );
+  });
+
+  it("standalone validates: class method, same shape", async () => {
+    await expectValidatesStandalone(
+      `class C { method({ x: [y] } = { x: [42] }) { return y; } }
+       export function test(): number { return new C().method(); }`,
+    );
+  });
+
+  it("standalone validates: 2-element nested array + default", async () => {
+    await expectValidatesStandalone(
+      `function f({ x: [a, b] } = { x: [1, 2] }) { return a + b; }
+       export function test(): number { return f(); }`,
+    );
+  });
+
+  it("standalone validates: nested array w/ its own default + outer default", async () => {
+    await expectValidatesStandalone(
+      `function f({ w: [a, b, c] = [4, 5, 6] } = { w: [7, 8, 9] }) { return a + b + c; }
+       export function test(): number { return f(); }`,
+    );
+  });
+
+  it("standalone validates: explicit arg still validates (default not fired)", async () => {
+    await expectValidatesStandalone(
+      `function f({ x: [y] } = { x: [42] }) { return y; }
+       export function test(): number { return f({ x: [7] }); }`,
+    );
+  });
+
+  // Host-mode runtime correctness: the same shapes must produce the right value
+  // (the funcIdx fix must not have changed destructuring semantics).
+  it("host runtime: default fires when arg omitted → 42", async () => {
+    expect(
+      await runHost(
+        `function f({ x: [y] } = { x: [42] }) { return y; }
+         export function test(): number { return f(); }`,
+      ),
+    ).toBe(42);
+  });
+
+  it("host runtime: explicit arg overrides default → 7", async () => {
+    expect(
+      await runHost(
+        `function f({ x: [y] } = { x: [42] }) { return y; }
+         export function test(): number { return f({ x: [7] }); }`,
+      ),
+    ).toBe(7);
+  });
+
+  it("host runtime: nested array default + outer default → 15", async () => {
+    expect(
+      await runHost(
+        `function f({ w: [a, b, c] = [4, 5, 6] } = { w: [7, 8, 9] }) { return a + b + c; }
+         export function test(): number { return f(); }`,
+      ),
+    ).toBe(24); // [7,8,9] → 24 (outer default fires; nested w present so inner default does not)
+  });
+});


### PR DESCRIPTION
## Summary

Slice of #2158 (standalone class/prototype/descriptor residual), **Family F — invalid-Wasm-binary**.

A function/method parameter whose binding pattern carries a **default value** (`= …`) AND binds a **nested sub-pattern** (object property → array sub-pattern, e.g. `{ x: [y] } = { x: [42] }`, or a nested array) compiled to **invalid Wasm**: `if[0] expected type i32, found call of type externref`. This hit a large slice of the class `dstr/` failures (`meth-dflt-obj-ptrn-prop-ary`, `private-meth-dflt-obj-ptrn-prop-ary`, `gen-meth-dflt-obj-ptrn-prop-ary`, … and the equivalent top-level functions).

## Root cause — a funcIdx index-shift orphan (addUnionImports/#1109 family)

`destructureParamObject`'s externref **struct-fast-path** detaches the OUTER function body to a then/else branch buffer via a **plain JS-local swap** (`const savedBody = fctx.body; fctx.body = then/elseInstrs; …; fctx.body = savedBody`). The then/else buffers are tracked in `ctx.liveBodies` (#779d), but the **outer body is orphaned** — not on `fctx.savedBodies`, not in `liveBodies`, not `fctx.body` during the recursive descent.

When the nested array sub-pattern's recursive `destructureParamArray` adds a late import (`__array_from_iter_n` / `__extern_get_idx` / `__extern_length`, at low import indices → shifts EVERY defined-function index), the `shiftLateImportIndices` walk visited `fctx.body` + `savedBodies` + `liveBodies` but **never the orphaned outer body**. So the already-emitted `call __extern_is_undefined` (the param-default missing-arg guard `if` condition, an **i32** producer) kept its stale-low funcIdx and ended up pointing at `__object_seal` (an **externref** producer) → the `if` consumed an externref where i32 was required.

Confirmed by WAT-trace + instrumentation: condition captured at idx 114; finalize moved `__extern_is_undefined` to 116 but the emitted call stayed at 114 (= now `__object_seal`).

## Fix

`src/codegen/destructuring-params.ts` (+16 lines): in the struct-fast-path branch, track the orphaned outer `savedBody` in `ctx.liveBodies` for the recursion window (add before the then/else compile, delete after the `if` is assembled), mirroring the existing then/else #779d tracking. Guarded with `outerAlreadyLive` so a re-entrant call doesn't double-delete (preserves the #2182 liveBodies-balance invariant). No behavior change to non-orphan paths.

## Verification

- New `tests/issue-2158-dstr-param-default-nested-pattern.test.ts` (8 cases): standalone now **validates** (`WebAssembly.compile` succeeds — direct regression guard for the orphan), plus host-mode runtime correctness (default fires → 42, explicit → 7, nested+outer → 24).
- `npx tsc --noEmit` clean; prettier clean.
- The pre-existing `issue-1025-param-default-null.test.ts:78` assertion failure reproduces identically on clean `origin/main` (verified) — **not** a regression of this change.

## Remaining (still open under #2158)

- **Host-import leak in standalone**: these shapes now compile to *valid* Wasm but still emit `env::__array_from_iter_n` (+ `env::__get_undefined`), which standalone can't satisfy at instantiation. Needs a Wasm-native array-from-iter fallback. Separate, larger slice.
- **A deeper funcIdx orphan in larger modules**: the static-method variant surfaces a second shift orphan (`call[0] expected (ref null N), found externref`) AFTER this fix clears its `if[0]` error — strict progress that unmasks it. Documented for a follow-up slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)