### PR TITLE
feat(#2026 PR-3): dynamic-new spread + new.target edges

### DIFF
--- a/plan/issues/2026-class-as-first-class-value.md
+++ b/plan/issues/2026-class-as-first-class-value.md
@@ -2,7 +2,7 @@
 id: 2026
 title: "classes are not first-class values: new K() on a parameter throws 'No dependency provided for extern class', .constructor identity broken"
 status: in-progress
-assignee: ttraenkler/sdev-async2
+assignee: ttraenkler/sdev-ctor
 sprint: 63
 created: 2026-06-10
 updated: 2026-06-18
@@ -386,3 +386,54 @@ provided for extern class "K"` — confirmed. Traced the live path precisely:
   pure-Wasm (no host import) so both modes must pass.
 - Confirm no test262 `built-ins/`/`language/` regressions in the
   classes/new buckets (CI).
+
+### Implementation log (sdev-ctor, 2026-06-18) — PR-3a/PR-3b: arg & meta edges
+
+Re-validated on upstream/main @ 955552ecc (after PR-1/PR-1b landed via #1647/
+#1656/#1672). Measured the dynamic-new edges with an 8-case probe. Three genuine
+breakages remained on the `emitDynamicNewFallback` path:
+
+1. **Spread → INVALID Wasm (worst).** `new K(...[a,b])` AND `new K(...x)` both
+   failed module instantiation: `extern.convert_any[0] expected anyref, found
+   call of type i32`. Root cause: the per-arg eval loop compiled a
+   `SpreadElement` verbatim — the spread expression yields an i32 (array length)
+   / ref, not a boxed externref, so the downstream box hit a broken
+   `extern.convert_any`. `new K(4, ...[5])` silently returned `null`.
+2. **new.target read 0** inside a dynamically-constructed ctor (`new.target ===
+   K` → false). The dynamic path never set the new-target global.
+
+**PR-3a (spread).** In `emitDynamicNewFallback`, BEFORE emitting any code, detect
+spread args. Flatten an array-LITERAL spread via the existing shared
+`flattenCallArgs` (the same compile-time flatten the static class-`new` path
+uses); a non-flattenable (variable) spread returns `false` so the caller falls
+through to the legacy path — a runtime miss, NOT a broken module. The
+return-false-before-emit ordering is load-bearing: nothing is pushed to
+`fctx.body` for the fallback until after the spread check, so the bail is safe.
+Result: `new K(...[4,5])` → 9, `new K(4,...[5])` → 9, `new K(...someVar)` now
+instantiates cleanly (runtime miss; runtime variable-spread drive is a noted
+follow-up, mirroring how even the static path defers non-literal spread to
+`compileSpreadCallArgs`).
+
+**PR-3b (new.target).** In `buildCtorArm`, call the shared
+`emitSetNewTargetBeforeCall(ctx, fctx.body, className)` right before the
+`call <Class>_new`, mirroring the static path. The id-based comparison
+(`compileBinaryExpression`'s new.target arm vs `getOrAssignClassNewTargetId`)
+then matches. No-op unless `ctx.usesNewTarget`, so zero cost otherwise. Result:
+`new.target === K` → true inside a dynamically-constructed ctor; discriminates
+correctly between two classes.
+
+Files: `src/codegen/expressions/new-super.ts` only (additive; no struct-shape
+change; helpers by name). Tests: `tests/issue-2026-dynamic-new-edges.test.ts`
+(6 cases: array-lit spread, mixed spread, non-flattenable-spread no-crash,
+new.target true, new.target discrimination, plain-arg PR-1 regression guard).
+tsc + prettier + biome-lint clean. All 13 existing #2026 tests still green;
+`issue-2023` (new.target) + `class-expressions` regression-clean.
+(`classes.test.ts` `string_constants`-import failures are a pre-existing harness
+artifact, identical with this change stashed out — not a regression.)
+
+**Still open under this issue — PR-2:** `.constructor === A` for an
+externref/`any`-typed receiver (`make(A).constructor === A` still reads 0; the
+STATIC receiver `new A().constructor === A` already works). Needs a runtime
+`__tag`→`__class_<Name>`-singleton dispatch in `property-access.ts` when the
+receiver is externref — structurally the same tag-dispatch as PR-1 but mapping
+to the class-object getter. Separate slice; does not block the PR-3 edges.

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -1693,7 +1693,26 @@ function emitDynamicNewFallback(
   }
   if (candidates.length === 0) return false;
 
-  const args = expr.arguments ?? [];
+  const rawArgs = expr.arguments ?? [];
+
+  // (#2026 PR-3a) Spread arguments. `new K(...x)` must NOT reach the per-arg
+  // eval loop verbatim: a `SpreadElement` compiles to the array/iterator value
+  // (an i32 length / ref), not a boxed externref, so the downstream
+  // `extern.convert_any` produced INVALID Wasm (whole-module instantiate
+  // failure). Flatten an array-LITERAL spread (`new K(...[a, b])`) into its
+  // element expressions via the shared `flattenCallArgs` helper — the same
+  // compile-time flatten the static class-`new` path uses. A non-flattenable
+  // spread (`new K(...someVar)`) needs a runtime drive we don't yet have here;
+  // bail BEFORE emitting any code (no descriptor/args pushed yet) so the caller
+  // falls through to its legacy path instead of us emitting a broken module.
+  // Returning `false` is only safe here because nothing has been pushed to
+  // `fctx.body` for this fallback yet.
+  let args: readonly ts.Expression[] = rawArgs;
+  if (rawArgs.some((a) => ts.isSpreadElement(a))) {
+    const flat = flattenCallArgs(rawArgs);
+    if (flat === null) return false; // non-literal spread — leave to legacy path
+    args = flat;
+  }
 
   // Evaluate the callee descriptor once into an anyref local (the value to
   // type-test). null/undefined descriptors leave a null anyref → every
@@ -1788,6 +1807,14 @@ function emitDynamicNewFallback(
         pushDefaultValue(fctx, pType, ctx);
       }
     }
+    // (#2026 PR-3b) Set new.target to the DISPATCHED class id before the ctor
+    // call, mirroring the static `new C()` path (`emitSetNewTargetBeforeCall`).
+    // Without this the new-target global keeps whatever the enclosing frame
+    // left, so `new.target === K` inside a dynamically-constructed ctor read 0.
+    // The id-based comparison (`compileBinaryExpression`'s new.target arm) then
+    // matches `getOrAssignClassNewTargetId(className)`. No-op unless the module
+    // uses new.target (`ctx.usesNewTarget`), so zero cost otherwise.
+    emitSetNewTargetBeforeCall(ctx, fctx.body, className);
     fctx.body.push({ op: "call", funcIdx: ctorFuncIdx });
     // Box the instance to externref to match the dispatch `if` block type. Most
     // `<Class>_new` return `(ref $structIdx)` (an anyref subtype) → wrap with

--- a/tests/issue-2026-dynamic-new-edges.test.ts
+++ b/tests/issue-2026-dynamic-new-edges.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for issue #2026 (PR-3): conformance edges of the dynamic-`new`
+ * fallback (`new K(...)` where `K` is a value-bound class identifier).
+ *
+ * PR-1 shipped the core tag-dispatch (plain args, shape-collision, derived
+ * classes). PR-3 covers the argument/meta edges that PR-1 left broken:
+ *
+ * - **Spread arguments** (`new K(...[a, b])`). The PR-1 arg-eval loop compiled a
+ *   `SpreadElement` as a single argument, producing a non-externref (an i32
+ *   array length) that the downstream `extern.convert_any` rejected — the whole
+ *   module failed to instantiate (INVALID Wasm). PR-3a flattens an array-literal
+ *   spread via the shared `flattenCallArgs` before the loop; a non-flattenable
+ *   spread (`new K(...someVar)`) bails to the legacy path (a runtime error, NOT
+ *   a broken module).
+ * - **new.target** inside a dynamically-constructed ctor. PR-1 never set the
+ *   new-target global on the dynamic path, so `new.target === K` read 0. PR-3b
+ *   sets it to the dispatched class id before the ctor call (same as the static
+ *   `new C()` path via `emitSetNewTargetBeforeCall`).
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runTest(src: string, exportName = "test"): Promise<unknown> {
+  const r = await compile(src, { fileName: "test.ts" });
+  if (!r.success) throw new Error(`compile failed: ${r.errors[0]?.message}`);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  const exp = instance.exports as Record<string, () => unknown>;
+  if (typeof (imports as { setExports?: (e: unknown) => void }).setExports === "function") {
+    (imports as { setExports: (e: unknown) => void }).setExports(instance.exports);
+  }
+  return exp[exportName]!();
+}
+
+describe("issue #2026 (PR-3): dynamic-new argument & meta edges", () => {
+  it("threads an array-literal spread into the dynamic ctor", async () => {
+    // `new K(...[4, 5])` previously emitted INVALID Wasm. Now flattened.
+    const src = `
+class P { x: number; y: number; constructor(a: number, b: number) { this.x = a; this.y = b; } }
+function make(K: any): any { return new K(...[4, 5]); }
+export function test(): number { const p = make(P); return p.x + p.y; }
+`;
+    expect(await runTest(src)).toBe(9);
+  });
+
+  it("threads a mixed positional + array-literal spread", async () => {
+    // `new K(4, ...[5])` previously returned a wrong (null) instance.
+    const src = `
+class P { x: number; y: number; constructor(a: number, b: number) { this.x = a; this.y = b; } }
+function make(K: any): any { return new K(4, ...[5]); }
+export function test(): number { const p = make(P); return p.x + p.y; }
+`;
+    expect(await runTest(src)).toBe(9);
+  });
+
+  it("a non-flattenable (variable) spread does not crash the module", async () => {
+    // `new K(...someVar)` can't be flattened at compile time — it must degrade to
+    // the legacy path (a runtime miss), NOT produce a module that fails to
+    // instantiate. We assert the module COMPILES and instantiates (the dynamic
+    // construction itself is a documented follow-up). A guard class keeps the
+    // dynamic-new fallback active so we exercise the spread-bail path.
+    const src = `
+class P { x: number; constructor(a: number) { this.x = a; } }
+function make(K: any, args: number[]): any {
+  try { return new K(...args); } catch (e) { return null; }
+}
+export function test(): number { make(P, [3]); return 1; }
+`;
+    // The point of this test is that compile + instantiate succeed (runTest
+    // would throw a CompileError / instantiate error otherwise).
+    expect(await runTest(src)).toBe(1);
+  });
+
+  it("sets new.target to the dispatched class inside the dynamic ctor", async () => {
+    // `new.target === A` is an i32 boolean inside the ctor; surfaced through the
+    // externref boundary it reads as 1 (true) / 0 (false). PR-1 left it 0.
+    const src = `
+class A { hit: number; constructor() { this.hit = (new.target === A) ? 1 : 0; } }
+function make(K: any): any { return new K(); }
+export function test(): number { return make(A).hit; }
+`;
+    expect(await runTest(src)).toBe(1);
+  });
+
+  it("new.target discriminates between two dynamically-constructed classes", async () => {
+    const src = `
+class A { who: number; constructor() { this.who = (new.target === A) ? 1 : 0; } }
+class B { who: number; constructor() { this.who = (new.target === B) ? 2 : 0; } }
+function make(K: any): any { return new K(); }
+export function test(): number { return make(A).who + make(B).who; } // 1 + 2 = 3
+`;
+    expect(await runTest(src)).toBe(3);
+  });
+
+  it("regression guard: plain-arg dynamic new still works (PR-1)", async () => {
+    const src = `
+class P { x: number; y: number; constructor(a: number, b: number) { this.x = a; this.y = b; } }
+function make(K: any): any { return new K(7, 9); }
+export function test(): number { const p = make(P); return p.x + p.y; }
+`;
+    expect(await runTest(src)).toBe(16);
+  });
+});


### PR DESCRIPTION
## #2026 PR-3 — dynamic-`new` argument & meta edges

Follow-up to PR-1/PR-1b (the dynamic-`new K()` uniform ctor ABI, already on main via #1647/#1656/#1672). Two argument/meta edges of `emitDynamicNewFallback` were broken; this PR fixes both. Additive, `new-super.ts` only, no struct-shape change, helpers by name. The static `new C()` path is untouched.

### PR-3a — spread args (fixes an INVALID-Wasm crash)
`new K(...[a,b])` **and** `new K(...x)` previously emitted invalid Wasm (`extern.convert_any[0] expected anyref, found call of type i32`) — the whole module failed to instantiate. The per-arg eval loop compiled a `SpreadElement` verbatim, yielding an i32 (array length) that the downstream box rejected. `new K(4, ...[5])` silently returned `null`.

Fix: before emitting any code, flatten an array-literal spread via the existing shared `flattenCallArgs` (same compile-time flatten the static class-`new` path uses). A non-flattenable (variable) spread returns `false` so the caller falls through to the legacy path — a runtime miss, **not** a broken module. The bail-before-emit ordering is load-bearing.

Result: `new K(...[4,5])` → 9, `new K(4,...[5])` → 9, `new K(...someVar)` instantiates cleanly (runtime variable-spread drive is a noted follow-up, matching how even the static path defers non-literal spread to `compileSpreadCallArgs`).

### PR-3b — new.target
`new.target === K` read `0` inside a dynamically-constructed ctor (the dynamic path never set the new-target global). Fix: call the shared `emitSetNewTargetBeforeCall(ctx, fctx.body, className)` before the ctor call, mirroring the static path. No-op unless `ctx.usesNewTarget`, so zero cost otherwise.

### Validation
- New `tests/issue-2026-dynamic-new-edges.test.ts` (6 cases): array-lit spread, mixed spread, non-flattenable-spread no-crash, new.target true, new.target discrimination, plain-arg PR-1 regression guard.
- All 13 existing #2026 tests still green; `issue-2023` (new.target) + `class-expressions` regression-clean.
- tsc + prettier + biome-lint clean.

### Still open under #2026 (separate slice, not this PR)
PR-2: `.constructor === A` for an externref/`any`-typed receiver (`make(A).constructor` still reads 0; the static receiver already works). Needs a `__tag`→`__class_<Name>`-singleton dispatch in `property-access.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)