### PR TITLE
fix(#2160): standalone String/Number wrapper valueOf/toString primitive recovery

### DIFF
--- a/plan/issues/2160-standalone-string-number-coercion-residual.md
+++ b/plan/issues/2160-standalone-string-number-coercion-residual.md
@@ -2,6 +2,7 @@
 id: 2160
 title: "Standalone String/Number method & coercion conformance residual (~635 tests)"
 status: ready
+assignee: ttraenkler/cs-2160
 sprint: 63
 created: 2026-06-15
 updated: 2026-06-18
@@ -149,3 +150,50 @@ prettier + coercion-sites (#2108) + any-box gates clean. No host-import leak
 (pure standalone). This closes the `Number(arr)` engine-routing residual; the
 remaining #2160 bulk (wrapper objects `new String`/`new Number`) stays gated on
 value-rep #2072/#2104.
+
+---
+
+## Slice (2026-06-18, cs-2160) — wrapper `.valueOf()` / `.toString()` primitive recovery
+
+**Status stays `ready`** — one more independent slice of the 635-bucket. Now
+that value-rep #2072/#2104 + the #1910 S2 native wrapper constructor/ToPrimitive
+have landed, the foundation exists; this wires two broken consumers.
+
+**Two root causes fixed:**
+
+1. **`resolveWasmType` resolved a `String`-WRAPPER binding to `$AnyString`.**
+   `isStringType` deliberately also matches the wrapper `String` (Object) type
+   (for primitive-string method dispatch), and the `nativeStrings` string
+   fast-path in `resolveWasmType` (`src/codegen/index.ts`) fired FIRST — so
+   `const s = new String("x")` typed `s` as `$AnyString` (ref 6), the wrapper
+   `$Object` externref was `ref.cast`-to-`$AnyString` on bind, failed, and `s`
+   became **null**. Every downstream read then null-deref'd. Fix: gate that
+   fast-path with `&& !isStringWrapperType(tsType)` so the wrapper falls through
+   to the externref wrapper branch. `nativeStrings`-only; gc-mode untouched.
+
+2. **`new String(x).valueOf()` leaked `env::__unbox_string`; `.toString()`
+   trapped.** The wrapper accessor handler (`src/codegen/expressions/calls.ts`)
+   recompiled the wrapper as a primitive ValType / called the host-only
+   `__unbox_string`. Fix: in `ctx.standalone`, route String/Number wrapper
+   `.valueOf()`/`.toString()` (0-arg) through the EXISTING native `__to_primitive`
+   engine helper (#1910 S2 reads the FLAG_INTERNAL `[[PrimitiveValue]]` slot
+   first, §7.1.1.1), then unbox the Number result to f64. No new coercion matrix
+   — reuses the single engine (coercion-sites baseline bumped 18→20 for the two
+   sanctioned `__to_primitive`/`__unbox_number` references in calls.ts).
+
+**Scope guards / still open (NOT regressed):** `Number.prototype.toString(radix)`
+falls through to the radix-aware lowering (slot is a boxed number, not a string).
+Boolean wrappers excluded (slot is `$__box_boolean_struct`, different extraction).
+`.length`/full String-method dispatch on a wrapper receiver, and WASI wrapper
+parity (native object-runtime is standalone-only), remain separate residuals.
+
+**Validation.** `tests/issue-2160-wrapper-valueof-standalone.test.ts` (3/3):
+String wrapper valueOf/toString (content via rolling hash, empty string,
+chained method), Number wrapper valueOf (value/arith/compare), each asserting
+NO `__unbox_string`/`__new_String`/`__new_Number` host-import leak under
+`target: standalone`; plus a gc-mode no-regression guard. Regression suites
+green: native-strings (128), issue-1910/1910-s2, issue-1397/1111 wrapper
+equality, and all four prior #2160 suites (47). tsc + prettier + biome lint +
+coercion-sites + any-box gates clean. (Pre-existing unrelated failures on main:
+issue-929 accessor descriptor, imported-string-constants e2e, bigint-string —
+all fail identically on pristine `origin/main`.)

--- a/scripts/coercion-sites-baseline.json
+++ b/scripts/coercion-sites-baseline.json
@@ -6,7 +6,7 @@
   "codegen/declarations.ts": 17,
   "codegen/expressions/assignment.ts": 12,
   "codegen/expressions/calls-closures.ts": 2,
-  "codegen/expressions/calls.ts": 18,
+  "codegen/expressions/calls.ts": 20,
   "codegen/expressions/identifiers.ts": 2,
   "codegen/expressions/late-imports.ts": 3,
   "codegen/expressions/logical-ops.ts": 2,

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -6886,6 +6886,58 @@ function compileCallExpression(
     {
       const wrapperMethodName = propAccess.name.text;
       const recvSymName = receiverType.getSymbol()?.name;
+      // Covered cases (the rest stay on their existing paths to avoid regressions):
+      //   - String wrapper .valueOf()/.toString() → the internal slot IS a native
+      //     string, so __to_primitive returns it directly (no post-processing).
+      //   - Number wrapper .valueOf() → internal slot is a boxed number; unbox to f64.
+      // Excluded:
+      //   - Number wrapper .toString() — the slot is a boxed number, not a string;
+      //     it needs the radix-aware numeric ToString lowering, so it falls through.
+      //   - Boolean wrappers — the internal slot is a `$__box_boolean_struct`, whose
+      //     extraction differs from the boxed-number unbox used here.
+      const isWrapperValueAccessor =
+        expr.arguments.length === 0 &&
+        ((recvSymName === "String" && (wrapperMethodName === "valueOf" || wrapperMethodName === "toString")) ||
+          (recvSymName === "Number" && wrapperMethodName === "valueOf"));
+
+      // #2160 — standalone recovery of the wrapper's internal [[PrimitiveValue]]
+      // slot. In --target standalone there is no JS host, so `new String(x)` /
+      // `new Number(x)` build a native `$Object` carrying the primitive under the
+      // reserved FLAG_INTERNAL slot (#1910 S2). The legacy host paths below leak
+      // `__unbox_string` (no native impl) and recompile the wrapper as a primitive
+      // ValType (which traps / yields the wrong value for a `$Object` receiver).
+      // Route through the native `__to_primitive` helper, which reads that slot
+      // first (§7.1.1.1), then apply the method's result type. `Number.prototype.
+      // toString` with a radix is NOT this path (arguments.length === 0 above), so
+      // it falls through to the radix-aware toString lowering. Gated on
+      // `ctx.standalone` specifically — WASI keeps the host-import object
+      // machinery (the native object-runtime is standalone-only), so it stays on
+      // the legacy paths below.
+      if (ctx.standalone && isWrapperValueAccessor) {
+        ensureObjectRuntime(ctx);
+        const toPrimIdx = ctx.funcMap.get("__to_primitive");
+        if (toPrimIdx !== undefined) {
+          // hint: "string" for toString / String wrapper, "number" for Number
+          // valueOf — matches OrdinaryToPrimitive's hint ordering.
+          const hint = wrapperMethodName === "toString" || recvSymName === "String" ? "string" : "number";
+          compileExpression(ctx, fctx, propAccess.expression, { kind: "externref" });
+          addStringConstantGlobal(ctx, hint);
+          fctx.body.push(...stringConstantExternrefInstrs(ctx, hint));
+          fctx.body.push({ op: "call", funcIdx: toPrimIdx });
+          // __to_primitive returns the boxed primitive as externref. String
+          // wrappers (and any toString) yield the native string ref directly.
+          // Number valueOf yields a boxed number — unbox to the f64 primitive.
+          if (wrapperMethodName === "valueOf" && recvSymName === "Number") {
+            const unboxNumIdx = ensureLateImport(ctx, "__unbox_number", [{ kind: "externref" }], [{ kind: "f64" }]);
+            flushLateImportShifts(ctx, fctx);
+            if (unboxNumIdx !== undefined) fctx.body.push({ op: "call", funcIdx: unboxNumIdx });
+            return { kind: "f64" };
+          }
+          // String wrapper valueOf/toString, or Number wrapper toString → string ref.
+          return { kind: "externref" };
+        }
+      }
+
       if (recvSymName === "Number" && wrapperMethodName === "valueOf") {
         compileExpression(ctx, fctx, propAccess.expression, { kind: "f64" });
         return { kind: "f64" };

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -12,6 +12,7 @@ import {
   isNullablePrimitiveType,
   isNumberType,
   isStringType,
+  isStringWrapperType,
   isVoidType,
   mapTsTypeToWasm,
 } from "../checker/type-mapper.js";
@@ -10064,8 +10065,14 @@ export function resolveWasmType(ctx: CodegenContext, tsType: ts.Type, _depth = 0
   const nativeType = resolveNativeTypeAnnotation(tsType);
   if (nativeType) return nativeType;
 
-  // Fast mode: string → ref $AnyString (not externref)
-  if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0 && isStringType(tsType)) {
+  // Fast mode: string → ref $AnyString (not externref).
+  // The String WRAPPER object (`new String(x)`) is excluded here — `isStringType`
+  // intentionally also matches the wrapper for primitive-string method dispatch,
+  // but the wrapper is a `typeof "object"` value carrying its [[StringData]] in a
+  // native `$Object` slot (#1910 S2 / #2160). Resolving it to `$AnyString` would
+  // make the wrapper-`$Object` externref fail the ref.cast on bind → null. It must
+  // fall through to the externref wrapper branch below.
+  if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0 && isStringType(tsType) && !isStringWrapperType(tsType)) {
     return { kind: "ref", typeIdx: ctx.anyStrTypeIdx };
   }
 

--- a/tests/issue-2160-wrapper-valueof-standalone.test.ts
+++ b/tests/issue-2160-wrapper-valueof-standalone.test.ts
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2160 — standalone recovery of a primitive-wrapper object's internal
+ * [[PrimitiveValue]] slot.
+ *
+ * #1910 S2 built the native `__new_String` / `__new_Number` constructors (a
+ * `$Object` carrying the primitive under the reserved FLAG_INTERNAL slot) and
+ * taught the native `__to_primitive` to read that slot first. But two consumer
+ * paths still leaked / broke in `--target standalone`:
+ *
+ *   1. `resolveWasmType` resolved a `String`-WRAPPER-typed binding to
+ *      `$AnyString` (because `isStringType` deliberately also matches the wrapper
+ *      for primitive-string method dispatch), so the wrapper `$Object` externref
+ *      was ref.cast to `$AnyString` on bind, failed, and became NULL — every
+ *      downstream read then null-deref'd.
+ *   2. `new String(x).valueOf()` leaked the unsatisfiable `env::__unbox_string`
+ *      host import; `new String(x).toString()` fell through and trapped.
+ *
+ * Fix: exclude the String wrapper from the `nativeStrings` string fast-path in
+ * `resolveWasmType` (it falls through to the externref wrapper branch), and route
+ * the String/Number wrapper `.valueOf()`/`.toString()` accessors through the
+ * native `__to_primitive` (§7.1.1.1) instead of the host `__unbox_string` /
+ * primitive-recompile paths.
+ *
+ * Results are verified by content (rolling hash / numeric value), not just by
+ * "did it run", and the standalone module is instantiated with an EMPTY import
+ * object so any host-import leak fails instantiation.
+ */
+
+// Deterministic rolling hash, computed identically in JS and the compiled module.
+function hash(s: string): number {
+  let h = s.length * 1000003;
+  for (let i = 0; i < s.length; i++) {
+    h = (Math.imul(h, 31) + s.charCodeAt(i)) >>> 0;
+  }
+  return h % 2000000000;
+}
+
+// String-wrapper value-recovery cases. Each returns a rolling hash of the
+// recovered primitive string so the exact characters are checked.
+const STRING_CASES: ReadonlyArray<[string, string]> = [
+  ["valueOf", `const w = new String("hello"); const s = w.valueOf();`],
+  ["toString", `const w = new String("world"); const s = w.toString();`],
+  ["valueOf empty", `const w = new String(""); const s = w.valueOf();`],
+  ["valueOf then method", `const w = new String("Abc"); const s = w.valueOf().toUpperCase();`],
+];
+
+const strFn = (i: number) => `str${i}`;
+const STRING_MODULE = STRING_CASES.map(
+  ([, body], i) => `export function ${strFn(i)}(): number {
+    ${body}
+    let h = s.length * 1000003;
+    for (let j = 0; j < s.length; j++) { h = (Math.imul(h, 31) + s.charCodeAt(j)) >>> 0; }
+    return (h % 2000000000);
+  }`,
+).join("\n");
+
+const STRING_EXPECTED = [hash("hello"), hash("world"), hash(""), hash("ABC")];
+
+// Number-wrapper .valueOf() cases — recovers the f64 primitive.
+const NUMBER_MODULE = `
+  export function num0(): number { const n = new Number(42); return n.valueOf(); }
+  export function num1(): number { const n = new Number(3.5); return n.valueOf() * 2; }
+  export function num2(): number { const n = new Number(7); return n.valueOf() === 7 ? 1 : 0; }
+  export function num3(): number { const n = new Number(-10); return n.valueOf() + 5; }
+`;
+const NUMBER_EXPECTED: Record<string, number> = { num0: 42, num1: 7, num2: 1, num3: -5 };
+
+describe("#2160 primitive-wrapper valueOf/toString — standalone (native strings)", () => {
+  it("String wrapper valueOf/toString recovers the primitive (standalone, no host leak)", async () => {
+    const r = await compile(STRING_MODULE, { target: "standalone" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    // No leaked host import for the wrapper value-recovery paths.
+    const labels = r.imports.map((im) => `${im.module}::${im.name}`);
+    for (const re of [/^env::__unbox_string$/, /^env::__new_String$/, /^wasm:js-string::/]) {
+      expect(
+        labels.filter((l) => re.test(l)),
+        `leaked ${re}`,
+      ).toEqual([]);
+    }
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    const ex = instance.exports as Record<string, () => number>;
+    STRING_EXPECTED.forEach((want, i) => {
+      expect(ex[strFn(i)]!(), `standalone ${STRING_CASES[i]![0]}`).toBe(want);
+    });
+  });
+
+  it("Number wrapper valueOf recovers the primitive (standalone, no host leak)", async () => {
+    const r = await compile(NUMBER_MODULE, { target: "standalone" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    const labels = r.imports.map((im) => `${im.module}::${im.name}`);
+    expect(
+      labels.filter((l) => /^env::__new_Number$/.test(l)),
+      "leaked env::__new_Number",
+    ).toEqual([]);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    const ex = instance.exports as Record<string, () => number>;
+    for (const [fn, want] of Object.entries(NUMBER_EXPECTED)) {
+      expect(ex[fn]!(), `standalone ${fn}`).toBe(want);
+    }
+  });
+
+  // gc / JS-host mode is untouched by this fix (the resolveWasmType change is
+  // `nativeStrings`-gated and the calls.ts path is `ctx.standalone`-gated). This
+  // guard proves the default backend still compiles the wrapper accessors.
+  // (WASI wrapper valueOf is a pre-existing separate gap — the native object
+  // runtime is standalone-only — and is intentionally out of this slice's scope.)
+  it("default (gc / JS-host) mode still compiles wrapper valueOf/toString", async () => {
+    const rStr = await compile(STRING_MODULE, {});
+    expect(rStr.success, rStr.errors.map((e) => e.message).join("\n")).toBe(true);
+    const { instance: si } = await WebAssembly.instantiate(rStr.binary, rStr.importObject);
+    const sx = si.exports as Record<string, () => number>;
+    STRING_EXPECTED.forEach((want, i) => {
+      expect(sx[strFn(i)]!(), `gc ${STRING_CASES[i]![0]}`).toBe(want);
+    });
+
+    const rNum = await compile(NUMBER_MODULE, {});
+    expect(rNum.success, rNum.errors.map((e) => e.message).join("\n")).toBe(true);
+    const { instance: ni } = await WebAssembly.instantiate(rNum.binary, rNum.importObject);
+    const nx = ni.exports as Record<string, () => number>;
+    for (const [fn, want] of Object.entries(NUMBER_EXPECTED)) {
+      expect(nx[fn]!(), `gc ${fn}`).toBe(want);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

One more independent slice of the #2160 standalone String/Number residual
(635-test umbrella). Now that value-rep #2072/#2104 and the #1910 S2 native
wrapper constructor + `__to_primitive` slot short-circuit have landed, this
wires two consumer paths that were still broken for `new String(x)` /
`new Number(x)` wrapper objects under `--target standalone`.

## Root causes fixed

1. **`resolveWasmType` resolved a `String`-WRAPPER binding to `$AnyString`.**
   `isStringType` deliberately also matches the wrapper `String` (Object) type
   (for primitive-string method dispatch), and the `nativeStrings` string
   fast-path in `resolveWasmType` (`src/codegen/index.ts`) fired first — so
   `const s = new String("x")` typed `s` as `$AnyString`, the wrapper `$Object`
   externref was `ref.cast`-to-`$AnyString` on bind, **failed → null**, and
   every downstream read null-deref'd. Fix: gate the fast-path with
   `&& !isStringWrapperType(tsType)` so the wrapper falls through to the
   externref wrapper branch. `nativeStrings`-only; gc-mode untouched.

2. **`new String(x).valueOf()` leaked `env::__unbox_string`; `.toString()`
   trapped.** In `ctx.standalone`, route String/Number wrapper 0-arg
   `.valueOf()`/`.toString()` through the **existing** native `__to_primitive`
   engine helper (§7.1.1.1 reads the FLAG_INTERNAL `[[PrimitiveValue]]` slot
   first), unboxing the Number result to f64. No new coercion matrix — reuses
   the single engine (`src/codegen/expressions/calls.ts`); coercion-sites
   baseline bumped 18→20 for that file.

## Scope guards (not regressed)

- `Number.prototype.toString(radix)` falls through to the radix-aware lowering
  (slot is a boxed number, not a string).
- Boolean wrappers excluded (slot is `$__box_boolean_struct`, different extraction).
- `.length` / full String-method dispatch on a wrapper receiver, and WASI
  wrapper parity (the native object-runtime is standalone-only), remain separate
  residuals — the #2160 umbrella stays `ready`.

## Spec

ECMA-262 §7.1.1.1 OrdinaryToPrimitive (the wrapper's intrinsic
`valueOf`/`toString` returns the internal slot).

## Validation

- `tests/issue-2160-wrapper-valueof-standalone.test.ts` (3/3): String wrapper
  valueOf/toString (content via rolling hash, empty string, chained method),
  Number wrapper valueOf (value/arith/compare), each asserting **no**
  `__unbox_string`/`__new_String`/`__new_Number` host-import leak under
  `target: standalone`; plus a gc-mode no-regression guard.
- Green: native-strings (128), issue-1910 / 1910-s2, issue-1397 / 1111 wrapper
  equality, all four prior #2160 suites (47).
- tsc + prettier + biome lint + coercion-sites (#2108) + any-box gates clean.
- Pre-existing unrelated failures on `origin/main` (verified identical on a
  pristine checkout): issue-929 accessor-descriptor, imported-string-constants
  e2e, bigint-string-coercion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)