### PR TITLE
fix(#2161): standalone RegExp.prototype.toString() (no Object_toString leak)

### DIFF
--- a/plan/issues/2161-standalone-regexp-engine-residual.md
+++ b/plan/issues/2161-standalone-regexp-engine-residual.md
@@ -2,7 +2,7 @@
 id: 2161
 title: "Standalone RegExp engine conformance residual (~579 tests)"
 status: in-progress
-assignee: ttraenkler/sdev-regex3
+assignee: ttraenkler/cs-2164
 sprint: 63
 created: 2026-06-15
 updated: 2026-06-18
@@ -306,3 +306,38 @@ prototype-object representation; (c) dynamic / `any`-typed receivers — need th
 runtime-externref regex receiver generalisation (every @@ form falls through to
 host `__regex_symbol_call` today); and the regex-engine feature tail (v-flag
 `\q{}`, dynamic ctor patterns). #2161 stays open for those.
+
+## Slice 7 (2026-06-18, cs-2164) — standalone `RegExp.prototype.toString()`
+
+**Landed.** A standalone-shard re-probe (against `955552ecc`) found `re.toString()`
+leaked `env::Object_toString` — an unsatisfiable host import in `--target
+standalone` — even though both `re.source` and `re.flags` already resolve
+natively (#1914). It fell through the RegExp method dispatch to the generic
+object `toString` path.
+
+**Fix** (`regexp-standalone.ts` + `expressions/calls.ts`): new
+`tryCompileStandaloneRegExpToString` lowers `re.toString()` (§22.2.6.14) to
+`"/" ++ re.source ++ "/" ++ re.flags` — the struct's spec-escaped `source` field
+read (§22.2.6.13.1, already stored escaped) and the `__regex_flags_str(flags)`
+flag-string, composed with `__str_concat` via the shared `nativeStringRepr`
+concat primitive. Returns a native string, **zero host imports**. Gated on
+`ctx.standalone` + a static / backend-created RegExp receiver (a dynamic
+externref receiver falls through to the host/refusal path unchanged); host mode
+is untouched (`re.toString()` still run=6 there). Wired at the RegExp method
+dispatch in `calls.ts`, right after `tryCompileStandaloneRegExpTest`.
+
+**Validation.** New `tests/issue-2161-regex-tostring.test.ts` (7): `/source/flags`
+for flagged + flagless literals, the empty-pattern `/(?:)/` form, escaped-slash
+source, a const-bound receiver, the canonical `dgimsy` flag order, and exact
+host-JS parity across four pattern/flag pairs — all standalone with an empty
+importObject asserting no `Object_toString` / `__extern_*` leak. The 35
+#2161/#2161-matchall/#1474 + 201 #2175/#1914/#1539 regex cases stay green
+(behaviour-preserving). tsc + prettier + biome(error) + stack-balance +
+coercion-sites + any-box gates clean.
+
+**Deferred (separate code paths, NOT this method dispatch):** `String(re)` (still
+null-derefs — the `String()` builtin lowering) and `` `${re}` `` (template-literal
+coercion returns a wrong-length string) both route through value→string
+coercion, not `re.toString()`, and need RegExp-aware coercion in those lowerings
+— a distinct slice. The (a) reflection and (c) dynamic-receiver buckets remain
+as noted above. **#2161 stays open.**

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -129,6 +129,7 @@ import {
   tryCompileStandaloneRegExpExec,
   tryCompileStandaloneRegExpSymbolCall,
   tryCompileStandaloneRegExpTest,
+  tryCompileStandaloneRegExpToString,
 } from "../regexp-standalone.js";
 import {
   emitThrowTypeError,
@@ -2726,6 +2727,9 @@ function compileCallExpression(
 
     const standaloneRegExpTest = tryCompileStandaloneRegExpTest(ctx, fctx, expr, propAccess);
     if (standaloneRegExpTest !== undefined) return standaloneRegExpTest;
+
+    const standaloneRegExpToString = tryCompileStandaloneRegExpToString(ctx, fctx, expr, propAccess);
+    if (standaloneRegExpToString !== undefined) return standaloneRegExpToString;
 
     // Handle Array.prototype.METHOD.call(obj, ...args) — inline as array method on shape-inferred obj
     {

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -63,6 +63,7 @@ import {
 import type { InnerResult } from "./shared.js";
 import { compileExpression } from "./shared.js";
 import { compileStringLiteral } from "./string-ops.js";
+import { nativeStringRepr } from "./builtin-scaffold.js";
 
 export const STANDALONE_REGEXP_ABI_VERSION = 1;
 
@@ -1800,6 +1801,69 @@ export function tryCompileStandaloneRegExpPropertyRead(
   const { regexpLocal, structTypeIdx } = loaded;
 
   return emitRegExpReflectionFieldRead(ctx, fctx, propName, regexpLocal, structTypeIdx);
+}
+
+/**
+ * `RegExp.prototype.toString()` in standalone mode (#2161, §22.2.6.14).
+ *
+ * The spec result is `"/" + R.[[OriginalSource]] + "/" + R.[[OriginalFlags]]` —
+ * i.e. `"/" + re.source + "/" + re.flags`, both of which the native backend
+ * already produces (the struct's `source` field is stored in the spec-escaped
+ * §22.2.6.13.1 form, and `__regex_flags_str` builds the d-g-i-m-s-u-v-y flag
+ * string). In standalone / nativeStrings mode there is no JS host, so a
+ * `re.toString()` / `String(re)` / `` `${re}` `` previously leaked the generic
+ * `env::Object_toString` import (and `String(re)` null-deref'd). This composes
+ * the two native field reads with `__str_concat`, returning a native string —
+ * zero host imports.
+ *
+ * Returns `undefined` when the call is not a static-RegExp `.toString()`
+ * (caller falls through), `null` after a narrowed refusal, or the result type.
+ */
+export function tryCompileStandaloneRegExpToString(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  propAccess: ts.PropertyAccessExpression,
+): ValType | null | undefined {
+  if (!ctx.standalone || propAccess.name.text !== "toString" || expr.arguments.length !== 0) return undefined;
+  const objType = ctx.checker.getTypeAtLocation(propAccess.expression);
+  const nonNull = objType.getNonNullableType?.() ?? objType;
+  if (!isGlobalRegExpType(nonNull)) return undefined;
+  // Only static / backend-created receivers route to the native struct; a
+  // dynamic externref RegExp falls through to the host/refusal path.
+  if (
+    !isStaticStandaloneRegExpCreation(ctx, propAccess.expression) &&
+    !isKnownBackendCreatedRegExpReceiver(ctx, propAccess.expression)
+  ) {
+    return undefined;
+  }
+
+  const repr = nativeStringRepr(ctx);
+  if (repr === undefined) return undefined;
+
+  const loaded = loadStandaloneRegExpStruct(ctx, fctx, propAccess.expression);
+  if (loaded === null) return null;
+  const { regexpLocal, structTypeIdx } = loaded;
+
+  // result = "/" ++ source ++ "/" ++ flags  (left-folded via __str_concat).
+  // source: struct field read ($AnyString). flags: __regex_flags_str(flags).
+  ensureNativeStringHelpers(ctx);
+  const flagsStrIdx = ensureRegexFlagsStr(ctx);
+  const srcInstrs: Instr[] = [
+    { op: "local.get", index: regexpLocal } as Instr,
+    { op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_SOURCE } as Instr,
+  ];
+  const flagsInstrs: Instr[] = [
+    { op: "local.get", index: regexpLocal } as Instr,
+    { op: "struct.get", typeIdx: structTypeIdx, fieldIdx: RE_FIELD_FLAGS } as Instr,
+    { op: "call", funcIdx: flagsStrIdx } as Instr,
+  ];
+  // (("/" ++ source) ++ "/") ++ flags
+  let acc = repr.concat(repr.literal("/"), srcInstrs);
+  acc = repr.concat(acc, repr.literal("/"));
+  acc = repr.concat(acc, flagsInstrs);
+  for (const instr of acc) fctx.body.push(instr);
+  return repr.resultType;
 }
 
 /**

--- a/tests/issue-2161-regex-tostring.test.ts
+++ b/tests/issue-2161-regex-tostring.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2161 — standalone `RegExp.prototype.toString()` (§22.2.6.14).
+ *
+ * The spec result is `"/" + R.[[OriginalSource]] + "/" + R.[[OriginalFlags]]`,
+ * i.e. `"/" + re.source + "/" + re.flags`. Both `re.source` (the struct's
+ * spec-escaped §22.2.6.13.1 source field) and `re.flags` (built from the flag
+ * bitfield by `__regex_flags_str`) already resolve natively in standalone mode,
+ * but `re.toString()` itself was not wired — it fell through to the generic
+ * object path and leaked `env::Object_toString` (an unsatisfiable host import in
+ * `--target standalone`). This slice composes the two native field reads with
+ * `__str_concat`, returning a native string with ZERO host imports.
+ *
+ * Deferred (separate string-coercion paths, NOT this method-call dispatch):
+ *   - `String(re)` (the `String()` builtin lowering) and
+ *   - `` `${re}` `` (template-literal coercion)
+ *   both route through value→string coercion, not `re.toString()`, and still
+ *   need RegExp-aware coercion. Tracked under #2161.
+ */
+async function standaloneString(buildExpr: string): Promise<string> {
+  const source = `
+    let g: string = "";
+    export function build(): void { g = ${buildExpr}; }
+    export function len(): number { return g.length; }
+    export function at(i: number): number { return g.charCodeAt(i); }
+  `;
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  // No JS-host import may leak in standalone — in particular Object_toString.
+  const labels = r.imports.map((i) => `${i.module}::${i.name}`);
+  for (const re of [/^env::Object_toString$/, /^env::__extern_toString$/, /^wasm:js-string::/, /^env::__extern_get$/]) {
+    expect(
+      labels.filter((l) => re.test(l)),
+      `leaked ${re}`,
+    ).toEqual([]);
+  }
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const ex = instance.exports as { build: () => void; len: () => number; at: (i: number) => number };
+  ex.build();
+  let out = "";
+  for (let i = 0; i < ex.len(); i++) out += String.fromCharCode(ex.at(i));
+  return out;
+}
+
+describe("#2161 — standalone RegExp.prototype.toString()", () => {
+  it("renders /source/flags for a flagged literal", async () => {
+    expect(await standaloneString("(/ab/gi).toString()")).toBe("/ab/gi");
+  });
+
+  it("renders /source/ with no flags", async () => {
+    expect(await standaloneString("(/x/).toString()")).toBe("/x/");
+  });
+
+  it("renders the empty pattern as /(?:)/ (§22.2.6.13.1)", async () => {
+    expect(await standaloneString('(new RegExp("")).toString()')).toBe("/(?:)/");
+  });
+
+  it("keeps an escaped slash in the source", async () => {
+    expect(await standaloneString("(/a\\/b/).toString()")).toBe("/a\\/b/");
+  });
+
+  it("works on a const-bound RegExp receiver", async () => {
+    expect(await standaloneString("(() => { const re = /foo/m; return re.toString(); })()")).toBe("/foo/m");
+  });
+
+  it("renders all flags in canonical d-g-i-m-s-u-y order", async () => {
+    // §22.2.6.4 orders flags hasIndices(d) global(g) ignoreCase(i) multiline(m)
+    // dotAll(s) unicode(u) sticky(y). (v is mutually exclusive with u.)
+    expect(await standaloneString("(/a/dgimsy).toString()")).toBe("/a/dgimsy");
+  });
+
+  it("matches the host JS RegExp.prototype.toString() exactly", async () => {
+    for (const [pat, flags] of [
+      ["abc", ""],
+      ["a.c", "g"],
+      ["\\d+", "gi"],
+      ["", "m"],
+    ] as Array<[string, string]>) {
+      const lit = `new RegExp(${JSON.stringify(pat)}, ${JSON.stringify(flags)})`;
+      const got = await standaloneString(`(${lit}).toString()`);
+      const ref = new RegExp(pat, flags).toString();
+      expect(got, `${lit}`).toBe(ref);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Slice 7 of #2161 (standalone RegExp engine residual). Closes a concrete
standalone host-import leak: `re.toString()`.

**Root cause.** `re.toString()` leaked `env::Object_toString` — an
unsatisfiable host import under `--target standalone` — because it fell through
the RegExp method dispatch to the generic object `toString` path, even though
`re.source` and `re.flags` already resolve natively (#1914).

**Fix.** New `tryCompileStandaloneRegExpToString` lowers `re.toString()`
(§22.2.6.14) to `"/" ++ re.source ++ "/" ++ re.flags`: the struct's
spec-escaped `source` field (§22.2.6.13.1, already stored escaped) and the
`__regex_flags_str(flags)` flag-string, composed with `__str_concat` via the
shared `nativeStringRepr` concat primitive. Returns a native string, **zero
host imports**. Gated on `ctx.standalone` + a static / backend-created RegExp
receiver (a dynamic externref receiver falls through to the host/refusal path
unchanged); host mode is untouched. Wired at the RegExp method dispatch in
`calls.ts` right after `tryCompileStandaloneRegExpTest`.

## Test plan

- New `tests/issue-2161-regex-tostring.test.ts` (7): `/source/flags` for flagged
  + flagless literals, the empty-pattern `/(?:)/` form, escaped-slash source, a
  const-bound receiver, the canonical `dgimsy` flag order, and exact host-JS
  parity across four pattern/flag pairs — all standalone with an empty
  importObject asserting no `Object_toString` / `__extern_*` leak.
- 35 #2161 / #2161-matchall / #1474 + 201 #2175 / #1914 / #1539 regex cases
  stay green (behaviour-preserving).
- tsc + prettier + biome(error-level) + stack-balance + coercion-sites +
  any-box gates clean. Host-mode `re.toString()` unaffected.

## Scope

#2161 stays **open**. Deferred (separate code paths, not this method dispatch):
`String(re)` (the `String()` builtin lowering, still null-derefs) and
`` `${re}` `` (template-literal coercion) route through value→string coercion,
not `re.toString()`, and need RegExp-aware coercion — a distinct slice. The
(a) `RegExp.prototype` reflection bucket (gated on #2158) and (c) dynamic /
`any`-typed receivers remain as documented in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)