### PR TITLE
feat(#2358): standalone ToPrimitive over typed (nominal) object structs in `+`

### DIFF
--- a/plan/issues/2358-standalone-toprimitive-nominal-object-structs.md
+++ b/plan/issues/2358-standalone-toprimitive-nominal-object-structs.md
@@ -1,11 +1,13 @@
 ---
 id: 2358
 title: "Standalone native __to_primitive can't reduce typed (nominal) object structs through the externref boundary"
-status: ready
-sprint: Backlog
+status: done
+sprint: 63
+assignee: sdev-toprimitive
 model: opus
 created: 2026-06-18
 updated: 2026-06-18
+completed: 2026-06-18
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -48,9 +50,24 @@ the moment an operand is coerced to externref. `+` (via `emitAnyAdd`,
 `binary-ops.ts:2845`) and any `any`-typed parameter path lose the typeIdx and
 must fall back to the runtime helper — which can't reduce nominal structs.
 
-## Repro (current `main`, `--target wasi`)
+## Repro (original spec table — SEE 2026-06-18 CORRECTION BELOW)
 
-A single engine fix closes all of these:
+> ⚠️ **2026-06-18 re-measure (sdev-toprimitive) — the table below is PARTLY
+> STALE on current `main`.** When an object literal is written with an `as any`
+> cast *at the literal* (`({valueOf:()=>4} as any) + 1`), it now compiles to the
+> **dynamic `$Object`** representation (`__new_plain_object`), which
+> `__to_primitive` already reduces — so those `as any`-literal rows **PASS** on
+> current `main` (verified standalone). The genuine residual is the rows where
+> the object reaches `+` as a **typed nominal struct**: a typed LOCAL
+> (`const o = {valueOf:()=>4}; (o as any) + 1`) or a **class instance**
+> (`class C { valueOf(){return 9} }; (new C() as any) + 1`) — those compile to a
+> bare anon `(struct (field $valueOf eqref))` with no proto/brand, which
+> `__to_primitive`'s `ref.test objectTypeIdx` misses → null. **PR-1 (#1697)
+> fixes exactly those two** at `emitAnyAdd` operand-prep. The
+> `function f(x:any){return x*2}` row and `Number(obj)`/`Number([1])` (#10) are
+> NOT fixed by PR-1 — they reach the boundary already erased to externref (no
+> typeIdx) and need the general Option-A brand mechanism. Don't chase the rows
+> below as live repros without re-checking against `main` first.
 
 | expr | actual | expected | path |
 |------|--------|----------|------|
@@ -63,6 +80,9 @@ A single engine fix closes all of these:
 correct on main — they are NOT. `+` with object operands is broken (returns the
 raw object), because `+` routes through the externref/`__to_primitive` path, not
 the static struct-valueOf path. `-`/`*`/unary-minus ARE correct (static path).
+*(2026-06-18 refinement: the `obj+obj`/`obj+7` BREAKAGE is real only for the
+**typed-nominal-struct** form — the `as any`-at-literal form is now correct via
+the dynamic `$Object` path. See the re-measure note above.)*
 
 ### Two latent codegen bugs in the same area (valueOf returns an object)
 Fold these into the impl — same root (the reduction must fall through
@@ -156,3 +176,54 @@ disproportionate to the bucket.
 The 2026-06-12 standalone JSONL `object-to-primitive` bucket (107) is **stale**
 and the headline is partly closed — re-measure the true tractable count on a
 **fresh standalone shard** before sizing the impl.
+
+## Implementation notes — PR-1 (sdev-toprimitive, 2026-06-18)
+
+**Spec repro table was stale.** Re-measured every row standalone on current
+upstream/main (955552ecc). The `as any`-cast-at-the-literal forms
+(`({valueOf:()=>4} as any)+1`, `1+obj`, `obj+obj`, `function f(x:any){return x*2}`)
+ALL PASS already: an `as any` literal forces the **dynamic `$Object`**
+representation (`__new_plain_object`), which `__to_primitive` already reduces.
+The genuine residual is the **typed-LOCAL / class-instance** form, which compiles
+to a NOMINAL anon struct (`(struct (field $valueOf eqref))`) with no proto/brand/
+supertype — `__to_primitive`'s `ref.test objectTypeIdx` misses it → returned
+unchanged → `__unbox_number` → null.
+
+**What PR-1 ships (tractable, NOT the spec's Option A brand/RTTI).** A focused,
+additive change in `emitAnyAdd` (`binary-ops.ts`): the operand-prep is factored
+into `emitAddOperand`, which — when an operand statically resolves (through
+`as`/paren/non-null wrappers) to a nominal struct with a *number-producing*
+static ToPrimitive (`valueOf`/`@@toPrimitive`) — compiles the **unwrapped** inner
+expression WITHOUT the externref hint (so its concrete `typeIdx` survives) and
+reduces it to a boxed primitive via the shared #1917 `coerceType(ref-struct→f64,
+"default")` engine, *before* it crosses the externref boundary. Every other
+operand keeps the exact status-quo `{externref}`-hint path.
+
+Why the externref hint had to be conditionally dropped: `(o as any)` /
+`compileExpression(expr, {externref})` coerces the struct to externref *inside*
+compileExpression, erasing the typeIdx before the operand-prep can see it. Gating
+on the unwrapped operand's struct name (`resolveStructNameForExpr` on the inner
+expr) keeps the divergence surgical.
+
+**Guardrails verified:**
+- WAT byte-IDENTICAL on a battery of non-struct `+` (str+str, str+num, num+num,
+  arr+str, toString-only-obj) AND the static `*`/`-` paths (clean upstream/main
+  vs branch — empty diff). The new path only fires for nominal-struct valueOf in
+  `+`.
+- `node scripts/check-coercion-sites.mjs` flat; `check-any-box-sites` flat
+  (reused the existing coercion engine, no new site).
+- Standalone modules still instantiate host-free (`imports.length === 0` asserted
+  in the regression test).
+- Regression test `tests/issue-2358-toprimitive-nominal.test.ts` (6 cases,
+  including the two `as any`/any-param non-regression guards) — all green.
+- `tsc --noEmit` clean.
+
+**Deferred to a follow-up (the spec's Option A territory):** the
+any-typed-PARAMETER form where the struct is erased to externref at the call
+boundary BEFORE `+` (already works for valueOf via the dynamic-object box, but a
+typed nominal struct passed positionally would still strand), and `Number(obj)` /
+`Number([1])` (#10). Those need the GENERAL externref-boundary reduction — a
+shared-supertype brand + `ref.test` + brand→funcidx dispatch table — which
+requires re-declaring every object-literal struct as `sub` of a brand supertype
+(touches the hot static path) and is genuinely architect-scale. PR-1 closes the
+`+`-with-typed-object residual host-free without it.

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -41,6 +41,7 @@ import { ensureObjectRuntime } from "./object-runtime.js";
 import { addStringImports, addUnionImports, resolveNativeTypeAnnotation, resolveWasmType } from "./index.js";
 import type { InnerResult } from "./shared.js";
 import { coerceType, compileExpression, ensureAnyHelpers, flushLateImportShifts } from "./shared.js";
+import { resolveStructNameForExpr } from "./property-access.js";
 import { compileStringBinaryOp } from "./string-ops.js";
 import { compileInstanceOf, compileTypeofComparison } from "./typeof-delete.js";
 
@@ -2825,6 +2826,116 @@ function compileAnyBinaryDispatch(
 }
 
 /**
+ * (#2358) A typed object literal / class instance compiles to a NOMINAL WasmGC
+ * struct (`__anon_N` / `ClassName`), whose concrete `typeIdx` carries the static
+ * `valueOf` / `@@toPrimitive` the `coerceType(ref-struct → f64)` engine
+ * (`type-coercion.ts:1723`) can dispatch at compile time. The moment that struct
+ * is coerced to externref (`extern.convert_any`), the typeIdx is erased and the
+ * standalone native `__to_primitive` helper — which only recognises the dynamic
+ * `$Object` runtime struct via `ref.test objectTypeIdx` — can no longer reduce
+ * it (it returns the object unchanged → caller `__unbox_number` → NaN/null).
+ *
+ * So when an `emitAnyAdd` operand is a nominal struct with a *static*
+ * number-producing ToPrimitive (a `valueOf` or `@@toPrimitive`), reduce it to a
+ * primitive HERE, while the typeIdx is still known, reusing the single #1917
+ * coercion engine — then box. The result is an already-primitive externref, so
+ * the later `__to_primitive` call in the §13.15.3 dispatch is a no-op on it.
+ *
+ * Scoped to valueOf/@@toPrimitive (number-producing) only: a `toString`-only
+ * struct stays on the existing `extern.convert_any` path (no behaviour change),
+ * because the f64 reduction would lossily NaN a string-returning `toString`.
+ */
+function structHasStaticNumericToPrimitive(ctx: CodegenContext, name: string | undefined): boolean {
+  if (name === undefined || !ctx.structMap.has(name)) return false;
+  // Class / standalone-function form: ClassName_@@toPrimitive / ClassName_valueOf.
+  if (ctx.funcMap.get(`${name}_@@toPrimitive`) !== undefined) return true;
+  if (ctx.funcMap.get(`${name}_valueOf`) !== undefined) return true;
+  // Object-literal form: a `valueOf` field holding a callable zero-arg closure
+  // tracked for this struct (the eqref/ref closure path coerceType dispatches).
+  const fields = ctx.structFields.get(name);
+  if (fields) {
+    const vof = fields.find((f) => f.name === "valueOf");
+    if (vof) {
+      const tracked = ctx.valueOfClosureTypes.get(name);
+      if (tracked && tracked.length > 0) return true;
+      // A `valueOf` field holding a closure ref is still reduced by the static
+      // engine's closure-ref subpath even without separately-tracked types.
+      if (vof.type.kind === "ref" || vof.type.kind === "ref_null" || vof.type.kind === "eqref") return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * (#2358) Compile one `+` operand into a fresh externref temp and return its
+ * index (or null if the operand failed to compile).
+ *
+ * The common case keeps the status-quo `{externref}` expectedType, which keeps a
+ * runtime string boxed (no ToNumber coercion) so §13.15.3 can concatenate —
+ * byte-identical to before. The ONLY divergence is when the operand statically
+ * resolves (through `as`/parenthesized/non-null wrappers) to a NOMINAL object
+ * struct with a number-producing ToPrimitive (`valueOf`/`@@toPrimitive`): then it
+ * is compiled WITHOUT the hint (so the concrete `typeIdx` survives) and reduced
+ * to a boxed primitive via the shared #1917 coercion engine, while the typeIdx is
+ * still known. Crossing the externref boundary unreduced would strand the struct
+ * — the native `__to_primitive` helper only recognises the dynamic `$Object`, so
+ * it passes a nominal struct through → `__unbox_number` → NaN/null.
+ *
+ * Scoped to valueOf/@@toPrimitive (number-producing) so the §13.15.3 string-vs-
+ * numeric decision still sees the right primitive; a `toString`-only struct stays
+ * on the existing boxed-externref path (string concat unaffected).
+ */
+function emitAddOperand(ctx: CodegenContext, fctx: FunctionContext, expr: ts.Expression): number | null {
+  const noJsHost = ctx.standalone === true || ctx.wasi === true;
+  // Unwrap `as`/parenthesized/non-null/satisfies wrappers (e.g. `(o as any)`):
+  // the wrappers are type-only / identity, but they make TS report the operand
+  // type as `any` (so the struct name can't be resolved) and make
+  // `compileExpression` coerce the struct to externref internally (erasing the
+  // typeIdx). Resolving + compiling the UNWRAPPED inner expression recovers both.
+  let inner: ts.Expression = expr;
+  while (
+    ts.isParenthesizedExpression(inner) ||
+    ts.isAsExpression(inner) ||
+    ts.isNonNullExpression(inner) ||
+    ts.isSatisfiesExpression(inner) ||
+    ts.isTypeAssertionExpression(inner)
+  ) {
+    inner = (inner as ts.ParenthesizedExpression | ts.AsExpression | ts.NonNullExpression).expression;
+  }
+  const structName = noJsHost ? resolveStructNameForExpr(ctx, fctx, inner) : undefined;
+  if (noJsHost && structHasStaticNumericToPrimitive(ctx, structName)) {
+    const opType = compileExpression(ctx, fctx, inner);
+    if (!opType) return null;
+    if (opType.kind === "ref" || opType.kind === "ref_null") {
+      // Static ToPrimitive(default) → f64 (valueOf/@@toPrimitive ordering), box.
+      coerceType(ctx, fctx, opType, { kind: "f64" }, "default");
+      addUnionImports(ctx);
+      const boxIdx = ctx.funcMap.get("__box_number");
+      if (boxIdx !== undefined) {
+        fctx.body.push({ op: "call", funcIdx: boxIdx });
+      } else {
+        coerceType(ctx, fctx, { kind: "f64" }, { kind: "externref" });
+      }
+    } else if (opType.kind !== "externref") {
+      // The struct collapsed to a non-ref scalar (e.g. inlined) — coerce normally.
+      coerceType(ctx, fctx, opType, { kind: "externref" });
+    }
+    const tmp = allocTempLocal(fctx, { kind: "externref" });
+    fctx.body.push({ op: "local.set", index: tmp });
+    return tmp;
+  }
+  // Status-quo path: externref hint keeps runtime strings boxed for §13.15.3.
+  const opType = compileExpression(ctx, fctx, expr, { kind: "externref" });
+  if (!opType) return null;
+  if (opType.kind !== "externref") {
+    coerceType(ctx, fctx, opType, { kind: "externref" });
+  }
+  const tmp = allocTempLocal(fctx, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: tmp });
+  return tmp;
+}
+
+/**
  * (#2058) Emit `+` for two operands where at least one is a dynamic externref
  * (an `any`/`unknown`/boxed value). The operands are already on the Wasm stack
  * (left below right). Per §13.15.3 ApplyStringOrNumericBinaryOperator a runtime
@@ -2860,23 +2971,22 @@ export function emitAnyAdd(ctx: CodegenContext, fctx: FunctionContext, expr: ts.
 
   // Compile both operands to externref temps. Passing the externref hint keeps a
   // runtime string boxed (no ToNumber coercion) so §13.15.3 can concatenate.
-  const lType = compileExpression(ctx, fctx, expr.left, { kind: "externref" });
-  if (!lType) return { kind: "externref" };
-  if (lType.kind !== "externref") {
-    coerceType(ctx, fctx, lType, { kind: "externref" });
-  }
-  const lTmp = allocTempLocal(fctx, { kind: "externref" });
-  fctx.body.push({ op: "local.set", index: lTmp });
-  const rType = compileExpression(ctx, fctx, expr.right, { kind: "externref" });
-  if (!rType) {
+  // (#2358) EXCEPT when the operand statically resolves to a nominal object
+  // struct with a number-producing ToPrimitive (`valueOf`/`@@toPrimitive`): then
+  // compile it WITHOUT the externref hint (so its concrete typeIdx survives) and
+  // reduce it to a boxed primitive via the shared coercion engine, while the
+  // typeIdx is still known. Crossing the externref boundary unreduced strands the
+  // struct — the native `__to_primitive` helper only recognises the dynamic
+  // `$Object`, so it would pass the nominal struct through → `__unbox_number` →
+  // NaN/null. Every other operand keeps the exact status-quo `{externref}`-hint
+  // path (byte-identical), so string concat is unaffected.
+  const lTmp = emitAddOperand(ctx, fctx, expr.left);
+  if (lTmp === null) return { kind: "externref" };
+  const rTmp = emitAddOperand(ctx, fctx, expr.right);
+  if (rTmp === null) {
     releaseTempLocal(fctx, lTmp);
     return { kind: "externref" };
   }
-  if (rType.kind !== "externref") {
-    coerceType(ctx, fctx, rType, { kind: "externref" });
-  }
-  const rTmp = allocTempLocal(fctx, { kind: "externref" });
-  fctx.body.push({ op: "local.set", index: rTmp });
 
   // ── JS-host: JS `+` via __host_add ──
   if (!noJsHost) {

--- a/tests/issue-2358-toprimitive-nominal.test.ts
+++ b/tests/issue-2358-toprimitive-nominal.test.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2358 — standalone native ToPrimitive over typed (nominal) object structs.
+//
+// A typed object literal / class instance compiles to a NOMINAL WasmGC struct
+// (`__anon_N` / `ClassName`). The standalone `+` path (`emitAnyAdd`) compiled
+// each operand to externref before reducing it via the native `__to_primitive`
+// helper — but that helper only recognises the dynamic `$Object` runtime struct
+// (`ref.test objectTypeIdx`), so a nominal struct crossed the boundary
+// unreduced and `__unbox_number` produced null/NaN. The fix reduces such an
+// operand to a primitive via the shared coercion engine WHILE its concrete
+// typeIdx is still known (before it crosses the externref boundary).
+
+async function runStandaloneNum(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  // No JS host: standalone modules instantiate with an empty import object.
+  expect(r.imports.length).toBe(0);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { f: () => number }).f();
+}
+
+describe("#2358 standalone ToPrimitive over nominal object structs", () => {
+  it("reduces a typed object literal with valueOf through `obj + number`", async () => {
+    expect(
+      await runStandaloneNum(`
+        export function f(): number {
+          const o = { valueOf: () => 4 };
+          return (o as any) + 1;
+        }
+      `),
+    ).toBe(5);
+  });
+
+  it("reduces a typed object literal on the left of `number + obj`", async () => {
+    expect(
+      await runStandaloneNum(`
+        export function f(): number {
+          const o = { valueOf: () => 4 };
+          return 1 + (o as any);
+        }
+      `),
+    ).toBe(5);
+  });
+
+  it("reduces both operands in `obj + obj`", async () => {
+    expect(
+      await runStandaloneNum(`
+        export function f(): number {
+          const a = { valueOf: () => 4 };
+          const b = { valueOf: () => 3 };
+          return (a as any) + (b as any);
+        }
+      `),
+    ).toBe(7);
+  });
+
+  it("reduces a class instance with a valueOf method through `+`", async () => {
+    expect(
+      await runStandaloneNum(`
+        class C { valueOf(): number { return 9; } }
+        export function f(): number {
+          const c = new C();
+          return (c as any) + 1;
+        }
+      `),
+    ).toBe(10);
+  });
+
+  // Regression guards — these already worked and must keep working: the dynamic
+  // `$Object` literal form (forced by `as any` at the literal) and an any-typed
+  // parameter both flow through paths the fix does not touch.
+  it("still reduces an `as any` object literal (dynamic $Object path)", async () => {
+    expect(
+      await runStandaloneNum(`
+        export function f(): number {
+          return ({ valueOf: () => 4 } as any) + 1;
+        }
+      `),
+    ).toBe(5);
+  });
+
+  it("still reduces an any-typed parameter carrying a valueOf object", async () => {
+    expect(
+      await runStandaloneNum(`
+        function g(x: any): number { return x + 1; }
+        export function f(): number { return g({ valueOf: () => 4 }); }
+      `),
+    ).toBe(5);
+  });
+});


### PR DESCRIPTION
## #2358 — standalone native ToPrimitive over typed (nominal) object structs

Closes the genuine residual of the re-scoped #50 / #1917 (folds in #10's `+`-with-object surface).

### Root cause
A typed object literal / class instance compiles to a **nominal** WasmGC struct (`(struct (field $valueOf eqref))` — no proto/brand/supertype). The standalone `+` path (`emitAnyAdd`) coerced each operand to externref **before** reducing it via the native `__to_primitive` helper. That helper only recognises the **dynamic `$Object`** runtime struct (`ref.test objectTypeIdx`), so a nominal struct crossed the boundary unreduced → `__unbox_number(object)` → null/NaN.

```ts
const o = { valueOf: () => 4 };
(o as any) + 1   // standalone: was null, now 5
```

(The `as any`-cast-at-the-literal form already worked — it forces the dynamic `$Object` representation. The residual was the **typed-local / class-instance** form. The spec's original repro table was partly stale; re-measured on current main.)

### Fix (additive, reuses the #1917 single coercion engine)
Factor `emitAnyAdd`'s operand-prep into `emitAddOperand`. When an operand statically resolves (through `as`/paren/non-null wrappers) to a nominal struct with a **number-producing** static ToPrimitive (`valueOf`/`@@toPrimitive`), compile the **unwrapped inner expression WITHOUT** the externref hint (so the concrete `typeIdx` survives) and reduce it to a boxed primitive via `coerceType(ref-struct→f64, "default")` — *before* it crosses the externref boundary. Every other operand keeps the exact status-quo `{externref}`-hint path.

No brand/RTTI, no struct-layout change — that general mechanism (the spec's Option A, for any-typed params / `Number(obj)`) is architect-scale and deferred.

### Guardrails verified
- **WAT byte-identical** on a battery of non-struct `+` (str+str, str+num, num+num, arr+str, toString-only-obj) **and** the static `*`/`-` paths (clean upstream/main vs branch — empty diff). The new path fires only for nominal-struct valueOf in `+`.
- `scripts/check-coercion-sites.mjs` flat; `check-any-box-sites` flat; ir-fallbacks gate OK.
- Standalone host-free (`imports.length === 0` asserted).
- `tsc --noEmit` clean.
- Regression test `tests/issue-2358-toprimitive-nominal.test.ts` (6 cases incl. two non-regression guards) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)