### PR TITLE
feat(#2162): native Map/Set entries() [k, v] for-of (standalone)

### DIFF
--- a/plan/issues/2162-standalone-map-set-weak-collections-residual.md
+++ b/plan/issues/2162-standalone-map-set-weak-collections-residual.md
@@ -4,7 +4,7 @@ title: "Standalone Map/Set/WeakMap/WeakSet conformance residual (~532 tests)"
 status: in-progress
 sprint: 63
 created: 2026-06-15
-updated: 2026-06-17
+updated: 2026-06-18
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -141,17 +141,52 @@ control. Test: `tests/issue-2162-collection-from-array.test.ts` (10/10).
 
 ### Remaining slices (issue stays in-progress)
 
-- **`entries()` `[k, v]`-pair iteration + value spread** (`[...map.values()]`) —
-  the `$ObjVec` pair / spread consumer needs the `__iterator` pair route, not the
-  array fast path. The `entries` projection builder is in place
-  (`emitCollectionIteratorVec`, `kind: "entries"`) but not yet wired to a
-  consumer. Tracked as a #2162 follow-up.
+- ~~**`entries()` `[k, v]`-pair iteration**~~ — **done** in the entries-for-of
+  slice below.
+- **value/key/entries SPREAD** (`[...set]`, `[...map.values()]`,
+  `[...map.entries()]`) — the array-spread consumer reads the canonical externref
+  vec but stores into a scalar-typed array (externref↔f64 mismatch ⇒ invalid
+  Wasm). A separate spread-consumer slice; the for-of path is unaffected.
 - `new Map(iterable)` / `new Set(iterable)` over a NON-literal iterable — needs
   the general iterator drive (Slice 4 from-array covers only array literals).
 - ES2025 set-algebra: `union`/`intersection`/`difference`/
-  `symmetricDifference`/`isSubsetOf`/`isSupersetOf`/`isDisjointFrom`.
+  `symmetricDifference`/`isSubsetOf`/`isSupersetOf`/`isDisjointFrom` — **done**
+  (see the set-algebra slice).
 - The `Set === literal` / collection-of-`any` comparison confounds depend on the
   value-rep work (#2104/#2106), out of scope here.
+
+## Slice — native Map/Set `entries()` `[k, v]` for-of (PR, dev cs-2163, 2026-06-18)
+
+`for (const [k, v] of map.entries())` and the bare `for (const [k, v] of map)`
+(Map default → entries) — plus the Set `[v, v]` form — now iterate host-import-
+free standalone. Previously the bare-Map for-of CE'd ("element is not an array
+type"); routing it through the `$ObjVec` pair projection + generic `[k, v]`
+destructuring leaked `__array_from_iter_n` / `__get_undefined` / `__extern_get`
+(the pair element was read via the host extern-index arm).
+
+**Fix** — new `compileForOfNativeMapEntries` (`src/codegen/statements/loops.ts`):
+a dedicated native walk over the `$Map` entries vector that binds the STORED
+key/value DIRECTLY into the `[k, v]` targets per live entry (skipping tombstones)
+— no intermediate pair object, no host import. It mirrors
+`tryCompileNativeCollectionForEach`'s tombstone-skipping entry walk (cursor
+advanced before the body so a `continue`/tombstone-skip never re-reads a slot)
+and `compileForOfArray`'s block/loop/body-block break/continue depth
+bookkeeping. Entry fields are externalized (`extern.convert_any`) then coerced to
+the bound local's type via the shared `coercionInstrs` (numeric key → f64, string
+→ native string ref, etc.). The `$Map`/`$MapEntry` field layout is exported from
+`map-runtime.ts` as `MAP_LAYOUT` so the driver doesn't re-derive the constants.
+`compileForOfNativeCollection` now dispatches the `entries` kind here (the
+non-`[k,v]` shapes — single-identifier binding, holes, rest, assignment targets —
+fall back to the generic path). Gated on `ctx.nativeStrings`; host/gc unchanged
+(verified host Map entries for-of still returns the same value).
+
+**Verified** (`tests/issue-2162-entries-foreach.test.ts`, 9/9, `target:
+standalone`, ZERO host imports): explicit `.entries()` and bare-Map `[k, v]`
+for-of, Set `[v, v]` entries, numeric + string keys, tombstone-skip after delete,
+insertion order, `break`, `continue`, empty collection. tsc + lint +
+format:check clean; all prior #2162 standalone suites (iterators, set-foreach,
+collection-from-array, set-algebra, standalone-set, standalone-weak,
+weak-mapHelpers-shift = 50 tests) unaffected.
 
 ## Slice — ES2025 Set set-algebra (PR, dev-1, 2026-06-17)
 

--- a/src/codegen/map-runtime.ts
+++ b/src/codegen/map-runtime.ts
@@ -48,6 +48,23 @@ const INIT_CAP = 8;
 const TOMBSTONE_BIT = 0x40000000; // bit 30 — keeps hashes non-negative i32
 
 /**
+ * (#2162) `$Map` / `$MapEntry` field layout, exported so the for-of entries
+ * driver (statements/loops.ts) can walk the entries vector natively without
+ * re-deriving the constants. `entries` is the `$MapEntry[]` backing array;
+ * `entryCount` is the high-water mark (live + tombstoned); a `$MapEntry` stores
+ * `key`, `value`, and a `hash` whose top bit (`tombstoneBit`) flags deletion.
+ */
+export const MAP_LAYOUT = {
+  M_ENTRIES: 1,
+  M_ENTRYCOUNT: 2,
+  M_LIVECOUNT: 3,
+  F_KEY: 0,
+  F_VALUE: 1,
+  F_HASH: 3,
+  TOMBSTONE_BIT,
+} as const;
+
+/**
  * Register the WasmGC struct/array types backing the native Map. Idempotent.
  * Stores the type indices on `ctx`. Mirrors `ensureWrapperTypes` /
  * `ensureNativeStringHelpers` type-registration.

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -31,8 +31,9 @@ import {
 import { ensureNativeIteratorRuntime } from "../iterator-native.js";
 import { containsLinearU8Allocation, emitLinearU8ArenaMark, linearU8ArenaResetInstrs } from "../linear-uint8-arena.js";
 import { resolveComputedKeyExpression } from "../literals.js";
-import { emitCollectionIteratorVec } from "../map-runtime.js";
+import { emitCollectionIteratorVec, ensureMapHelpers, MAP_LAYOUT } from "../map-runtime.js";
 import { stringConstantExternrefInstrs } from "../native-strings.js";
+import { coercionInstrs } from "../type-coercion.js";
 import { addImport, addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "../registry/imports.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterRefCellType } from "../registry/types.js";
 import {
@@ -2458,11 +2459,18 @@ function compileForOfNativeCollection(
   if (!isMap && !isSet) return false;
 
   // Default projection: Set → values; Map → `entries` ([k, v] pairs). An explicit
-  // `.keys()/.values()/.entries()` call overrides. The `entries` pair projection
-  // needs the `__iterator` pair consumer (not the array fast path), so it is
-  // deferred to a #2162 follow-up — fall through here so the existing path tries.
+  // `.keys()/.values()/.entries()` call overrides.
   const kind: "keys" | "values" | "entries" = explicitKind ?? (isMap ? "entries" : "values");
-  if (kind === "entries") return false;
+
+  // `entries` with a `[k, v]` destructuring binding is driven by a dedicated
+  // native walk that binds the stored key/value directly per live entry — no
+  // intermediate `$ObjVec` pair (whose generic destructuring would route through
+  // the host `__extern_get` and leak imports). Falls back below for non-`[k,v]`
+  // shapes (a single-identifier binding over entries, holes, rest).
+  if (kind === "entries") {
+    if (compileForOfNativeMapEntries(ctx, fctx, stmt, receiver, isSet)) return true;
+    return false;
+  }
 
   // Confirm the receiver genuinely lowers to the native `$Map` struct (a Map/Set
   // typed value can still be a host externref in JS-host mode) without leaving
@@ -2490,6 +2498,189 @@ function compileForOfNativeCollection(
   const vecLocal = allocLocal(fctx, `__cof_vec_${fctx.locals.length}`, vecType);
   fctx.body.push({ op: "local.set", index: vecLocal });
   compileForOfArrayFromLocal(ctx, fctx, stmt, vecLocal, vecType);
+  return true;
+}
+
+/**
+ * (#2162) Drive `for (const [k, v] of map.entries())` / `for (const [k, v] of map)`
+ * (and the Set `[v, v]` form) natively in standalone / `nativeStrings` mode by
+ * walking the `$Map` entries vector and binding the stored key/value DIRECTLY
+ * into the destructuring targets per live entry — no intermediate `$ObjVec` pair
+ * (whose generic `[k, v]` destructuring would route through the host
+ * `__extern_get` and leak imports). Mirrors `tryCompileNativeCollectionForEach`'s
+ * tombstone-skipping walk and `compileForOfArray`'s block/loop/body-block
+ * break/continue bookkeeping.
+ *
+ * Returns `true` when it emitted the loop; `false` (leaving no code behind) when
+ * the binding is not a 2-element `[k, v]` identifier pattern (holes, rest, a
+ * single-identifier binding over entries, or an assignment target), so the
+ * caller can fall back to the generic path.
+ */
+function compileForOfNativeMapEntries(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  stmt: ts.ForOfStatement,
+  receiver: ts.Expression,
+  isSet: boolean,
+): boolean {
+  if (!ctx.nativeStrings) return false;
+  // Only the `const/let [k, v]` binding form (the dominant Map-entries shape).
+  if (!ts.isVariableDeclarationList(stmt.initializer)) return false;
+  const decl = stmt.initializer.declarations[0]!;
+  if (!ts.isArrayBindingPattern(decl.name)) return false;
+  const elements = decl.name.elements;
+  if (elements.length !== 2) return false;
+  const keyEl = elements[0]!;
+  const valEl = elements[1]!;
+  if (
+    !ts.isBindingElement(keyEl) ||
+    keyEl.dotDotDotToken ||
+    keyEl.initializer ||
+    !ts.isIdentifier(keyEl.name) ||
+    !ts.isBindingElement(valEl) ||
+    valEl.dotDotDotToken ||
+    valEl.initializer ||
+    !ts.isIdentifier(valEl.name)
+  ) {
+    return false;
+  }
+
+  ensureMapHelpers(ctx);
+  if (ctx.mapTypeIdx < 0) return false;
+
+  // Confirm the receiver genuinely lowers to the native `$Map` struct without
+  // leaving code behind (same probe as compileForOfNativeCollection).
+  const probeBody = fctx.body.length;
+  const probeLocals = snapshotLocals(fctx);
+  const recvProbe = compileExpression(ctx, fctx, receiver);
+  fctx.body.length = probeBody;
+  restoreLocals(fctx, probeLocals);
+  if (!recvProbe || (recvProbe.kind !== "ref" && recvProbe.kind !== "ref_null")) return false;
+  if (recvProbe.typeIdx !== ctx.mapTypeIdx) return false;
+
+  const { M_ENTRIES, M_ENTRYCOUNT, F_KEY, F_VALUE, F_HASH, TOMBSTONE_BIT } = MAP_LAYOUT;
+  const isConst = !!(stmt.initializer.flags & ts.NodeFlags.Const);
+  if (isConst) {
+    collectBindingNames(decl.name).forEach((n) => {
+      if (!fctx.constBindings) fctx.constBindings = new Set();
+      fctx.constBindings.add(n);
+    });
+  }
+
+  // Receiver → ref $Map in a temp.
+  const recvType = compileExpression(ctx, fctx, receiver);
+  if (!recvType) return false;
+  const mTmp = allocLocal(fctx, `__mef_m_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: ctx.mapTypeIdx,
+  });
+  fctx.body.push({ op: "local.set", index: mTmp });
+
+  // Bound key/value locals, typed from the binding-element TS types (a numeric
+  // Map key → f64, string → native string ref, etc.).
+  const keyType = resolveWasmType(ctx, ctx.checker.getTypeAtLocation(keyEl));
+  const valType = resolveWasmType(ctx, ctx.checker.getTypeAtLocation(valEl));
+  const keyLocal = allocLocal(fctx, keyEl.name.text, keyType);
+  const valLocal = allocLocal(fctx, valEl.name.text, valType);
+
+  const iTmp = allocLocal(fctx, `__mef_i_${fctx.locals.length}`, { kind: "i32" });
+  const entryTmp = allocLocal(fctx, `__mef_e_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: ctx.mapEntryTypeIdx,
+  });
+
+  // entry = (cast $MapEntry) m.entries[i]
+  const loadEntry: Instr[] = [
+    { op: "local.get", index: mTmp } as Instr,
+    { op: "struct.get", typeIdx: ctx.mapTypeIdx, fieldIdx: M_ENTRIES } as unknown as Instr,
+    { op: "local.get", index: iTmp } as Instr,
+    { op: "array.get", typeIdx: ctx.mapEntriesTypeIdx } as unknown as Instr,
+    { op: "ref.cast", typeIdx: ctx.mapEntryTypeIdx } as Instr,
+    { op: "local.set", index: entryTmp } as Instr,
+  ];
+
+  // Externalize a $MapEntry field then coerce to the bound local's type, mirroring
+  // the forEach driver (entry fields are stored anyref / boxed externref).
+  const bindFromEntry = (field: number, targetType: ValType, targetLocal: number): Instr[] => [
+    { op: "local.get", index: entryTmp } as Instr,
+    { op: "struct.get", typeIdx: ctx.mapEntryTypeIdx, fieldIdx: field } as unknown as Instr,
+    { op: "extern.convert_any" } as Instr,
+    ...coercionInstrs(ctx, { kind: "externref" }, targetType, fctx),
+    { op: "local.set", index: targetLocal } as Instr,
+  ];
+
+  // i = 0
+  fctx.body.push({ op: "i32.const", value: 0 });
+  fctx.body.push({ op: "local.set", index: iTmp });
+
+  // Build the loop body (block { loop { body-block } }) — 3 nesting levels, so
+  // adjust break/continue/return depths like compileForOfArray.
+  const savedBody = pushBody(fctx);
+  for (let i = 0; i < fctx.breakStack.length; i++) fctx.breakStack[i]! += 3;
+  for (let i = 0; i < fctx.continueStack.length; i++) fctx.continueStack[i]! += 3;
+  if (fctx.generatorReturnDepth !== undefined) fctx.generatorReturnDepth += 3;
+  adjustRethrowDepth(fctx, 3);
+  fctx.breakStack.push(2); // break = exit outer block
+  fctx.continueStack.push(0); // continue = exit body block, then increment
+
+  // if i >= entryCount → break
+  fctx.body.push({ op: "local.get", index: iTmp });
+  fctx.body.push({ op: "local.get", index: mTmp });
+  fctx.body.push({ op: "struct.get", typeIdx: ctx.mapTypeIdx, fieldIdx: M_ENTRYCOUNT } as unknown as Instr);
+  fctx.body.push({ op: "i32.ge_s" });
+  fctx.body.push({ op: "br_if", depth: 1 });
+
+  // entry = entries[i]; then i++ BEFORE the tombstone/body so a `continue`
+  // (br depth 0 → loop start) and a tombstone-skip both advance the cursor
+  // (mirrors the forEach driver — never re-reads the same slot).
+  fctx.body.push(...loadEntry);
+  fctx.body.push({ op: "local.get", index: iTmp });
+  fctx.body.push({ op: "i32.const", value: 1 });
+  fctx.body.push({ op: "i32.add" });
+  fctx.body.push({ op: "local.set", index: iTmp });
+
+  // tombstone → skip this slot (continue the loop; cursor already advanced).
+  fctx.body.push({ op: "local.get", index: entryTmp });
+  fctx.body.push({ op: "struct.get", typeIdx: ctx.mapEntryTypeIdx, fieldIdx: F_HASH } as unknown as Instr);
+  fctx.body.push({ op: "i32.const", value: TOMBSTONE_BIT });
+  fctx.body.push({ op: "i32.and" });
+  fctx.body.push({ op: "br_if", depth: 0 });
+
+  // Bind k ← entry.key (Set: value === key), v ← entry.value.
+  fctx.body.push(...bindFromEntry(isSet ? F_VALUE : F_KEY, keyType, keyLocal));
+  fctx.body.push(...bindFromEntry(F_VALUE, valType, valLocal));
+
+  // Compile the user body inside its own block so `continue` (br depth 0 from
+  // inside the body) exits the body block and falls through to the loop's `br`.
+  const savedLoopBody = pushBody(fctx);
+  if (ts.isBlock(stmt.statement)) {
+    const savedScope = saveBlockScopedShadows(fctx, stmt.statement);
+    for (const s of stmt.statement.statements) compileStatement(ctx, fctx, s);
+    restoreBlockScopedShadows(fctx, savedScope);
+  } else {
+    compileStatement(ctx, fctx, stmt.statement);
+  }
+  const bodyInstrs = fctx.body;
+  popBody(fctx, savedLoopBody);
+  fctx.body.push({ op: "block", blockType: { kind: "empty" }, body: bodyInstrs });
+
+  // continue loop (cursor was already advanced above).
+  fctx.body.push({ op: "br", depth: 0 });
+
+  const loopBody = fctx.body;
+  fctx.breakStack.pop();
+  fctx.continueStack.pop();
+  for (let i = 0; i < fctx.breakStack.length; i++) fctx.breakStack[i]! -= 3;
+  for (let i = 0; i < fctx.continueStack.length; i++) fctx.continueStack[i]! -= 3;
+  if (fctx.generatorReturnDepth !== undefined) fctx.generatorReturnDepth -= 3;
+  adjustRethrowDepth(fctx, -3);
+  popBody(fctx, savedBody);
+
+  fctx.body.push({
+    op: "block",
+    blockType: { kind: "empty" },
+    body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody }],
+  });
   return true;
 }
 

--- a/tests/issue-2162-entries-foreach.test.ts
+++ b/tests/issue-2162-entries-foreach.test.ts
@@ -1,0 +1,168 @@
+// #2162 — Wasm-native Map/Set `entries()` `[k, v]` for-of (standalone).
+//
+// Prior slices materialized Map/Set `keys()`/`values()` and bare Set for-of as a
+// canonical externref `$Vec` the array fast path drives. The `entries()` pair
+// projection was deferred: a Map's bare `for (const [k, v] of m)` defaults to the
+// entries projection, but building externref `$ObjVec` `[k, v]` pairs and then
+// destructuring them through the generic array-element path routed `pair[0]` /
+// `pair[1]` through the host `__extern_get` (+ `__array_from_iter_n` /
+// `__get_undefined`) — leaking imports standalone.
+//
+// This slice (`compileForOfNativeMapEntries`, statements/loops.ts): a dedicated
+// native walk over the `$Map` entries vector that binds the STORED key/value
+// directly into the `[k, v]` targets per live entry (skipping tombstones) — no
+// intermediate pair object, no host import. Mirrors the forEach driver's entry
+// walk and the array for-of break/continue bookkeeping.
+//
+// Covers `for (const [k, v] of m)` (Map default entries), explicit
+// `m.entries()`, the Set `[v, v]` form, numeric + string keys, tombstone-skip
+// after delete, insertion order, break / continue, and the empty collection.
+//
+// Each test compiles with `target: "standalone"` and asserts the module
+// instantiates with ZERO host imports and returns the expected value.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandaloneZeroImports(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const imports = WebAssembly.Module.imports(mod).map((i) => `${i.module}::${i.name}`);
+  expect(imports, "standalone module must have zero host imports").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as Record<string, () => number>).run();
+}
+
+describe("#2162 native Map/Set entries() [k, v] for-of (standalone)", () => {
+  it("explicit Map.entries() — sum k*100 + v", async () => {
+    // k=1,v=10→110; k=2,v=20→220; k=3,v=30→330 = 660
+    expect(
+      await runStandaloneZeroImports(
+        `export function run(): number {
+           const m = new Map<number, number>();
+           m.set(1, 10); m.set(2, 20); m.set(3, 30);
+           let s = 0;
+           for (const [k, v] of m.entries()) s += k * 100 + v;
+           return s;
+         }`,
+      ),
+    ).toBe(660);
+  });
+
+  it("bare Map for-of defaults to [k, v] entries", async () => {
+    expect(
+      await runStandaloneZeroImports(
+        `export function run(): number {
+           const m = new Map<number, number>();
+           m.set(5, 50);
+           let s = 0;
+           for (const [k, v] of m) s += k + v;
+           return s;
+         }`,
+      ),
+    ).toBe(55);
+  });
+
+  it("tombstone slots are skipped after delete", async () => {
+    // after delete(2): k=1,v=10→110; k=3,v=30→330 = 440
+    expect(
+      await runStandaloneZeroImports(
+        `export function run(): number {
+           const m = new Map<number, number>();
+           m.set(1, 10); m.set(2, 20); m.set(3, 30);
+           m.delete(2);
+           let s = 0;
+           for (const [k, v] of m) s += k * 100 + v;
+           return s;
+         }`,
+      ),
+    ).toBe(440);
+  });
+
+  it("break exits the entries loop", async () => {
+    expect(
+      await runStandaloneZeroImports(
+        `export function run(): number {
+           const m = new Map<number, number>();
+           m.set(1, 10); m.set(2, 20); m.set(3, 30);
+           let s = 0;
+           for (const [k, v] of m) { if (k === 2) break; s += k * 100 + v; }
+           return s;
+         }`,
+      ),
+    ).toBe(110);
+  });
+
+  it("continue skips an iteration (cursor still advances)", async () => {
+    // skip k=2: 110 + 330 = 440
+    expect(
+      await runStandaloneZeroImports(
+        `export function run(): number {
+           const m = new Map<number, number>();
+           m.set(1, 10); m.set(2, 20); m.set(3, 30);
+           let s = 0;
+           for (const [k, v] of m) { if (k === 2) continue; s += k * 100 + v; }
+           return s;
+         }`,
+      ),
+    ).toBe(440);
+  });
+
+  it("Set.entries() yields [value, value] pairs", async () => {
+    // 5,5→55; 7,7→77 = 132
+    expect(
+      await runStandaloneZeroImports(
+        `export function run(): number {
+           const set = new Set<number>();
+           set.add(5); set.add(7);
+           let s = 0;
+           for (const [a, b] of set.entries()) s += a * 10 + b;
+           return s;
+         }`,
+      ),
+    ).toBe(132);
+  });
+
+  it("string keys read back natively", async () => {
+    // a=97*10+1=971, b=98*10+2=982 = 1953
+    expect(
+      await runStandaloneZeroImports(
+        `export function run(): number {
+           const m = new Map<string, number>();
+           m.set("a", 1); m.set("b", 2);
+           let s = 0;
+           for (const [k, v] of m) s += k.charCodeAt(0) * 10 + v;
+           return s;
+         }`,
+      ),
+    ).toBe(1953);
+  });
+
+  it("entries iterate in insertion order", async () => {
+    expect(
+      await runStandaloneZeroImports(
+        `export function run(): number {
+           const m = new Map<number, number>();
+           m.set(3, 1); m.set(1, 1); m.set(2, 1);
+           let r = 0;
+           for (const [k, v] of m) r = r * 10 + k;
+           return r;
+         }`,
+      ),
+    ).toBe(312);
+  });
+
+  it("empty Map entries for-of is a no-op", async () => {
+    expect(
+      await runStandaloneZeroImports(
+        `export function run(): number {
+           const m = new Map<number, number>();
+           let s = 0;
+           for (const [k, v] of m) s += k + v;
+           return s;
+         }`,
+      ),
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## #2162 — standalone Map/Set residual: entries() for-of slice

Continues the standalone Map/Set catch-up. Prior slices landed Set/WeakMap/WeakSet runtimes, `keys()`/`values()` + bare for-of, `forEach`, set-algebra, and array-literal constructors. This slice adds **native `entries()` `[k, v]` for-of**.

### Problem
`for (const [k, v] of map.entries())` and bare `for (const [k, v] of map)` (Map default → entries) failed standalone: the bare-Map form CE'd ("element is not an array type"), and routing through the `$ObjVec` pair projection + generic `[k, v]` destructuring leaked `__array_from_iter_n` / `__get_undefined` / `__extern_get` (the pair element was read via the host extern-index arm).

### Fix
New `compileForOfNativeMapEntries` (`src/codegen/statements/loops.ts`): a dedicated native walk over the `$Map` entries vector that binds the **stored** key/value directly into the `[k, v]` targets per live entry (skipping tombstones) — no intermediate pair object, no host import. Mirrors the `forEach` driver's tombstone-skipping entry walk (cursor advanced before the body so `continue`/tombstone-skip never re-reads a slot) and `compileForOfArray`'s break/continue depth bookkeeping. Entry fields are externalized then coerced to the bound local's type via the shared `coercionInstrs`. The `$Map`/`$MapEntry` layout is exported from `map-runtime.ts` as `MAP_LAYOUT`.

Gated on `ctx.nativeStrings` — host/gc unchanged (verified host Map entries for-of returns the same value). Non-`[k,v]` shapes (single-identifier binding, holes, rest, assignment targets) fall back to the generic path.

### Tests
- `tests/issue-2162-entries-foreach.test.ts` — 9/9, `target: standalone`, zero host imports: explicit `.entries()` + bare-Map `[k,v]`, Set `[v,v]`, numeric + string keys, tombstone-skip after delete, insertion order, `break`, `continue`, empty collection.
- All prior #2162 standalone suites (iterators, set-foreach, collection-from-array, set-algebra, standalone-set, standalone-weak, weak-mapHelpers-shift = 50 tests) unaffected.
- typecheck + lint + format:check clean.

### Remaining (issue stays open)
value/key/entries SPREAD (`[...set]`, `[...map.values()]`) — a separate spread-consumer slice; `new Map/Set(non-literal iterable)`; value-rep comparison confounds (#2104/#2106, out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)