### PR TITLE
fix(#2029): standalone Error-subclass no longer leaks __get_undefined host import

### DIFF
--- a/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
+++ b/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
@@ -6,6 +6,7 @@ sprint: 63
 created: 2026-06-10
 updated: 2026-06-17
 priority: critical
+assignee: ttraenkler/cs-2160
 feasibility: medium
 reasoning_effort: high
 model: opus
@@ -170,3 +171,44 @@ standalone still leaks the `__new_<Builtin>` HOST import (`class-bodies.ts:1423/
 — a host-import-retirement concern, not the emit crash. Kept #2029 `in-progress`:
 the emit-crash cluster (the headline) is fixed; the `__new_<Builtin>` standalone
 runtime path is the residual. Reassess closing once that lands.
+
+## Slice (2026-06-18, cs-2160) — `extends Error` standalone `__get_undefined` leak
+
+**Status stays `in-progress`** — one more independent host-import-leak slice.
+
+The `__new_Error` leak noted above was already gone by current main (the WASI
+native Error constructor path covers `extends Error`/`TypeError`). The remaining
+leak for `class E extends Error {}` standalone was **`env::__get_undefined`** —
+the module instantiated FINE in gc/host mode but **failed to instantiate with an
+empty import object** standalone (`env: module is not an object or function`),
+so the whole subclass cluster produced zero standalone passes.
+
+**Root cause:** three `__get_undefined` emit sites called `ensureLateImport`
+DIRECTLY and only fell back to `ref.null.extern` when it returned `undefined` —
+but `ensureLateImport` does NOT refuse `__get_undefined` (it's not on any
+refusal/native list), so under `--target standalone` it REGISTERED and leaked
+the host import; the intended fallback never fired. The canonical
+`ensureGetUndefined` (`expressions/late-imports.ts`) already guards on
+`ctx.nativeStrings`; the direct sites did not.
+
+**Fix:** mirror the canonical guard at the two reachable direct sites —
+`emitUndefinedValue` (`src/codegen/type-coercion.ts`, the `pushDefaultValue`
+externref default used by the implicit derived-ctor forwarder) and
+`emitBoundsCheckedArrayGetUndef` (`src/codegen/destructuring-params.ts`). When
+`ctx.nativeStrings`, skip the import and emit `ref.null.extern` (undefined ≡
+null standalone, by design). gc/host mode keeps the host import (the guard is
+`nativeStrings`-only). The third site (`calls.ts` padStart/endsWith) is reached
+only on the JS-host string path and was left unchanged.
+
+**Validation.** `tests/issue-2029-error-subclass-get-undefined-standalone.test.ts`
+(3/3): `extends Error` / `extends TypeError` / `extends Error` with `super(msg)`,
+each instantiated with an EMPTY import object (proves no env leak) standalone +
+WASI, plus a gc-mode no-regression guard. Existing #2029 subclass-emit suite
+(8/8) and standalone string suites green. tsc + prettier + biome lint +
+coercion-sites + any-box gates clean. (Pre-existing unrelated failure on main:
+issue-1025 nested-pattern test — fails identically on pristine `origin/main`.)
+
+**Still open (the bucket):** TypedArray subclass (`class X extends Uint8Array {}`)
+still leaks `__new_<TypedArray>` — needs native vec-struct construction in the
+externref-backed implicit forwarder (overlaps #2159). `DisposableStack` /
+`AsyncDisposableStack` leak `DisposableStack_new`. Both are separate slices.

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -192,7 +192,13 @@ function emitBoundsCheckedArrayGetUndef(
     emitBoundsCheckedArrayGet(fctx, arrTypeIdx, elementType);
     return;
   }
-  const getUndefIdx = ensureLateImport(ctx, "__get_undefined", [], [{ kind: "externref" }]);
+  // (#2029) `ensureLateImport` does not refuse `__get_undefined`, so in
+  // standalone / native-strings mode it would register and LEAK the host import
+  // (module then fails to instantiate). Force the standalone fallback here, as
+  // the canonical `ensureGetUndefined` does.
+  const getUndefIdx = ctx.nativeStrings
+    ? undefined
+    : ensureLateImport(ctx, "__get_undefined", [], [{ kind: "externref" }]);
   if (getUndefIdx === undefined) {
     // standalone mode — can't get JS undefined, fall back to regular path
     emitBoundsCheckedArrayGet(fctx, arrTypeIdx, elementType);

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -2579,7 +2579,13 @@ export function emitSafeExternrefToF64(ctx: CodegenContext, fctx: FunctionContex
  * This is a local version to avoid circular deps with expressions.ts.
  */
 function emitUndefinedValue(ctx: CodegenContext, fctx: FunctionContext): void {
-  const funcIdx = ensureLateImport(ctx, "__get_undefined", [], [{ kind: "externref" }]);
+  // (#2029) Standalone / native-strings mode has no JS host to satisfy a
+  // `__get_undefined` import, and `ensureLateImport` does NOT refuse this name —
+  // so without this guard the import LEAKS and the module fails to instantiate
+  // with an empty import object (the `env: module is not an object` linker
+  // error). Mirror the canonical `ensureGetUndefined` guard: undefined collapses
+  // to `ref.null.extern` standalone (indistinguishable from null, by design).
+  const funcIdx = ctx.nativeStrings ? undefined : ensureLateImport(ctx, "__get_undefined", [], [{ kind: "externref" }]);
   if (funcIdx !== undefined) {
     flushLateImportShifts(ctx, fctx);
     fctx.body.push({ op: "call", funcIdx });

--- a/tests/issue-2029-error-subclass-get-undefined-standalone.test.ts
+++ b/tests/issue-2029-error-subclass-get-undefined-standalone.test.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2029 — standalone Error-subclass instantiation leaked `env::__get_undefined`.
+ *
+ * The builtin-subclass EMIT crash (`u32 out of range: -1`) was fixed earlier
+ * (PR-1, `emitSetSubclassProto` sentinel guard). But `class E extends Error {}`
+ * still leaked the JS-host `__get_undefined` import under `--target standalone`,
+ * so the module failed to instantiate with an empty import object
+ * (`env: module is not an object or function`).
+ *
+ * Root cause: three `__get_undefined` emit sites called `ensureLateImport`
+ * DIRECTLY (type-coercion.ts `emitUndefinedValue`, destructuring-params.ts
+ * `emitBoundsCheckedArrayGetUndef`) and only fell back to `ref.null.extern` when
+ * the helper returned `undefined`. But `ensureLateImport` does NOT refuse
+ * `__get_undefined`, so standalone registered + leaked the import — the fallback
+ * never fired. The canonical `ensureGetUndefined` guards on `ctx.nativeStrings`;
+ * the direct sites now mirror that guard (undefined collapses to
+ * `ref.null.extern` standalone, indistinguishable from null by design).
+ *
+ * Standalone modules are instantiated with an EMPTY import object so any leak
+ * fails the test at instantiation.
+ */
+
+const ERROR_SUBCLASS_MODULE = `
+  class MyError extends Error {}
+  class MyTypeError extends TypeError {}
+  class WithMsg extends Error { constructor() { super("boom"); } }
+  export function plain(): number { const e = new MyError(); return e instanceof MyError ? 1 : 0; }
+  export function typed(): number { const e = new MyTypeError(); return e instanceof MyTypeError ? 1 : 0; }
+  export function withMsg(): number { const e = new WithMsg(); return e instanceof Error ? 1 : 0; }
+`;
+
+describe("#2029 Error-subclass standalone — no __get_undefined leak", () => {
+  it("compiles + instantiates with no host imports (standalone)", async () => {
+    const r = await compile(ERROR_SUBCLASS_MODULE, { target: "standalone" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    const labels = r.imports.map((im) => `${im.module}::${im.name}`);
+    // The headline leak — plus a blanket no-env-import assertion for standalone.
+    expect(
+      labels.filter((l) => /^env::__get_undefined$/.test(l)),
+      "leaked env::__get_undefined",
+    ).toEqual([]);
+    expect(
+      labels.filter((l) => l.startsWith("env::")),
+      `unexpected env:: imports: ${labels.join(", ")}`,
+    ).toEqual([]);
+    // Empty import object proves zero host dependency.
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    const ex = instance.exports as Record<string, () => number>;
+    expect(ex.plain!()).toBe(1);
+    expect(ex.typed!()).toBe(1);
+    expect(ex.withMsg!()).toBe(1);
+  });
+
+  it("WASI target also instantiates Error subclasses with no env leak", async () => {
+    const r = await compile(ERROR_SUBCLASS_MODULE, { target: "wasi" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    const labels = r.imports.map((im) => `${im.module}::${im.name}`);
+    expect(
+      labels.filter((l) => /^env::__get_undefined$/.test(l)),
+      "leaked env::__get_undefined (WASI)",
+    ).toEqual([]);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    const ex = instance.exports as Record<string, () => number>;
+    expect(ex.plain!()).toBe(1);
+    expect(ex.typed!()).toBe(1);
+    expect(ex.withMsg!()).toBe(1);
+  });
+
+  it("default (gc / JS-host) mode keeps the __get_undefined host import", async () => {
+    // The nativeStrings guard is standalone/WASI-only — gc mode must still emit
+    // the host import (undefined vs null distinction matters with a JS runtime).
+    const r = await compile(ERROR_SUBCLASS_MODULE, {});
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, r.importObject);
+    const ex = instance.exports as Record<string, () => number>;
+    expect(ex.plain!()).toBe(1);
+    expect(ex.typed!()).toBe(1);
+    expect(ex.withMsg!()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

`class E extends Error {}` (and `TypeError`, and `extends Error` with
`super(msg)`) compiled under `--target standalone` but **failed to instantiate
with an empty import object** — it leaked `env::__get_undefined`
(`env: module is not an object or function`), so the whole Error-subclass cluster
in the #2029 bucket produced zero standalone passes. The emit crash
(`u32 out of range: -1`) was fixed in earlier slices; this closes the residual
host-import leak for that cluster.

## Root cause

Three `__get_undefined` emit sites called `ensureLateImport` **directly** and
only fell back to `ref.null.extern` when it returned `undefined`. But
`ensureLateImport` does NOT refuse `__get_undefined` (it's not on any
refusal/native-helper list), so under `--target standalone` it **registered and
leaked** the host import — the intended fallback never fired. The canonical
`ensureGetUndefined` (`expressions/late-imports.ts`) already guards on
`ctx.nativeStrings`; the direct sites did not.

## Fix

Mirror the canonical `nativeStrings` guard at the two reachable direct sites:
- `emitUndefinedValue` (`src/codegen/type-coercion.ts`) — the externref
  `pushDefaultValue` default used by the implicit derived-constructor forwarder.
- `emitBoundsCheckedArrayGetUndef` (`src/codegen/destructuring-params.ts`).

Standalone/native-strings collapses `undefined` to `ref.null.extern` (undefined ≡
null standalone, by design); gc/host mode keeps the host import (the guard is
`nativeStrings`-only). The third site (`calls.ts` padStart/endsWith) is reached
only on the JS-host string path and is unchanged.

## Validation

- `tests/issue-2029-error-subclass-get-undefined-standalone.test.ts` (3/3):
  `extends Error` / `extends TypeError` / `extends Error` with `super(msg)`, each
  instantiated with an **empty** import object (proves no env leak) standalone +
  WASI, plus a gc-mode no-regression guard.
- Existing `tests/issue-2029-subclass-builtin-standalone-emit.test.ts` (8/8) and
  standalone string suites green.
- tsc + prettier + biome lint + coercion-sites (#2108) + any-box gates clean.
- Pre-existing unrelated failure on `origin/main` (verified identical on a
  pristine checkout): issue-1025 nested-pattern test.

## Still open (the #2029 bucket — separate slices)

- TypedArray subclass `class X extends Uint8Array {}` still leaks
  `__new_<TypedArray>` — needs native vec-struct construction in the
  externref-backed implicit forwarder (overlaps #2159).
- `DisposableStack` / `AsyncDisposableStack` leak `DisposableStack_new`.

Issue #2029 stays `in-progress`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)