### PR TITLE
fix(#2045): linear Uint8Array compound element write + ++/-- silently lost (C.8)

### DIFF
--- a/plan/issues/2045-linear-uint8-soundness-holes.md
+++ b/plan/issues/2045-linear-uint8-soundness-holes.md
@@ -12,6 +12,7 @@ task_type: bugfix
 area: codegen, wasi
 language_feature: typed-arrays, linear-memory
 goal: standalone-mode
+assignee: ttraenkler/cs-2164
 related: [1886, 817]
 origin: "2026-06-10 sprint-61 code review of merged PR #1288 (#1886 Slice C): two pre-existing Slice-B silent-corruption routes were materially widened to function parameters, and the new interprocedural escape analysis has two fail-closed demotion gaps that break previously-valid WASI programs."
 ---
@@ -144,6 +145,51 @@ failures unrelated to this change — verified identical on main.)
   function-value escapes of rewritten helpers) — these are fail-closed
   `reportError`s on otherwise-valid WASI programs, a larger interprocedural
   change split out from the corruption fixes.
-- **C.5–C.8** loop-arena rewind ordering, the all-target while-loop
-  restructure gate, `process.stdin.read` offset clamp + errno, and compound
-  element writes (`b[i] += 1`).
+- **C.5–C.7** loop-arena rewind ordering, the all-target while-loop
+  restructure gate, `process.stdin.read` offset clamp + errno.
+
+## C.8 — compound element write + `++`/`--` on a linear buffer (LANDED 2026-06-18, cs-2164)
+
+**Done — another silent-corruption route.** `b[i] op= rhs` (`+=`, `-=`, `*=`,
+`&=`, …) and `b[i]++` / `++b[i]` / `b[i]--` on a linear-backed `Uint8Array`
+(WASI) **silently failed to update linear memory**: `b[0] = 5; b[0] += 1`
+read back `5`, and the `++`/`--` forms threw a `WebAssembly.Exception` at
+runtime.
+
+**Root cause.** The plain `b[i] = v` write goes through
+`compileElementAssignment`, which tries `tryEmitLinearU8ElementSet` first — but
+the *compound* and *update* forms have separate lowerings that had no linear
+path: `compileElementCompoundAssignment` (assignment.ts) compiled
+`target.expression` as a value (materialising the GC vec) and wrote the result
+through the externref/GC path — never touching linear memory; `compileMemberIncDec`
+(unary-updates.ts) required a `ref`/`ref_null` array and hit
+`compileExpression`'s `(ptr,len)` shape → runtime throw.
+
+**Fix** (`linear-uint8-codegen.ts` + the two call sites). Two new emitters do a
+bounds-checked read-modify-write at a single `addr = ptr + trunc(i)` (index
+evaluated once), mirroring the existing get/set:
+- `tryEmitLinearU8ElementCompound` — `i32.load8_u` → f64, run the caller's
+  compound op (a closure over `emitCompoundOp` + the rhs, threaded to dodge the
+  assignment.ts↔linear-uint8-codegen.ts import cycle), `i32.store8` the low
+  byte; leaves the (untruncated) f64 result for the expression value. Wired at
+  the top of `compileElementCompoundAssignment`.
+- `tryEmitLinearU8ElementUpdate` — `load → ±1 → store`, leaving the **new**
+  value (prefix) or **old** value (postfix) per §13.4. Wired into
+  `compileMemberIncDec` (the live `++`/`--` dispatch) **before** its
+  `compileExpression(operand.expression)`, plus defensive guards in the
+  `compilePrefix/PostfixIncrementElement` handlers (reached via the alt postfix
+  dispatch). Both fall through to the GC path for any non-linear element target.
+
+The store truncates to the byte, so `200 += 100 → 44` and `255++ → 0` wrap
+correctly (matching JS `Uint8Array` semantics).
+
+**Validation.** New `tests/issue-2045-linear-u8-compound.test.ts` (11, WASI run
+via the `runWasiMain` fd_write harness): `+=`/`-=`/`*=`/`&=`, byte-wrap on
+compound, `++`/`++`-prefix/`--`, postfix-returns-old, prefix-returns-new, and
+`255++`→0 wrap. The 14 #2045/#1886-slice-b and 150 linear/WASI suite cases stay
+green. tsc + prettier + biome(error) + coercion-sites + any-box + stack-balance
+gates clean.
+
+**Still open:** B.3/B.4 (escape-analysis demotion) and C.5–C.7 (loop-arena
+rewind ordering, all-target while-loop gate, `process.stdin.read` clamp/errno).
+**#2045 stays in-progress.**

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -6,7 +6,7 @@ import { ts, forEachChild } from "../../ts-api.js";
 import { isBooleanType, isExternalDeclaredClass, isStringType } from "../../checker/type-mapper.js";
 import type { FieldDef, Instr, ValType } from "../../ir/types.js";
 import { emitBoundsCheckedArrayGet, resolveArrayInfo } from "../array-methods.js";
-import { tryEmitLinearU8ElementSet } from "../linear-uint8-codegen.js";
+import { tryEmitLinearU8ElementCompound, tryEmitLinearU8ElementSet } from "../linear-uint8-codegen.js";
 import { emitAnyAdd, emitModulo, emitToInt32 } from "../binary-ops.js";
 import { pushBody } from "../context/bodies.js";
 import { reportError } from "../context/errors.js";
@@ -5562,6 +5562,18 @@ function compileElementCompoundAssignment(
   rhs: ts.Expression,
   op: ts.SyntaxKind,
 ): ValType | null {
+  // #2045 C.8: compound write `b[i] op= rhs` on a linear-backed Uint8Array must
+  // read-modify-write the linear memory. Without this it fell through to the
+  // GC/externref path below (which materialises the buffer as a value and never
+  // touches linear memory), so `b[0] += 1` silently kept the old byte. Try the
+  // linear read-modify-write first; falls through to GC for any other target.
+  const linU8Compound = tryEmitLinearU8ElementCompound(ctx, fctx, target, () => {
+    // current element value is already on the stack as f64; push rhs, apply op.
+    compileExpression(ctx, fctx, rhs, { kind: "f64" });
+    emitCompoundOp(ctx, fctx, op);
+  });
+  if (linU8Compound !== null) return linU8Compound;
+
   // Compile the object expression
   const objResult = compileExpression(ctx, fctx, target.expression);
   if (!objResult) return null;

--- a/src/codegen/expressions/unary-updates.ts
+++ b/src/codegen/expressions/unary-updates.ts
@@ -11,6 +11,7 @@ import { ts } from "../../ts-api.js";
 import { isSymbolType } from "../../checker/type-mapper.js";
 import type { Instr, ValType } from "../../ir/types.js";
 import { emitBoundsCheckedArrayGet } from "../array-methods.js";
+import { tryEmitLinearU8ElementUpdate } from "../linear-uint8-codegen.js";
 import { reportError } from "../context/errors.js";
 import { reportSilentFallback } from "../fallback-telemetry.js";
 import { allocLocal, getLocalType } from "../context/locals.js";
@@ -413,6 +414,21 @@ function compileMemberIncDec(
 
   // Handle obj[idx] — element access increment/decrement on arrays
   if (ts.isElementAccessExpression(operand)) {
+    // #2045 C.8: linear-backed Uint8Array element update (`b[i]++` / `--b[i]`) —
+    // read-modify-write the linear memory directly. Must run BEFORE
+    // `compileExpression(operand.expression)` below, which materialises the
+    // buffer as a value and routes the write through a path that never touches
+    // linear memory (the byte stayed unchanged / threw at runtime). Falls
+    // through for any non-linear element target.
+    const linU8 = tryEmitLinearU8ElementUpdate(
+      ctx,
+      fctx,
+      operand,
+      /* isIncrement */ arithOp === "add",
+      mode === "prefix",
+    );
+    if (linU8 !== null) return linU8;
+
     const objTsType = ctx.checker.getTypeAtLocation(operand.expression);
     const objResult = compileExpression(ctx, fctx, operand.expression);
     if (!objResult) return null;
@@ -1378,6 +1394,12 @@ function compilePrefixIncrementElement(
   target: ts.ElementAccessExpression,
   isIncrement: boolean,
 ): ValType | null {
+  // #2045 C.8: linear-backed Uint8Array element update — read-modify-write the
+  // linear memory directly (the GC path below requires a ref array and throws on
+  // a (ptr,len) buffer). Prefix → new value. Falls through for any other target.
+  const linU8 = tryEmitLinearU8ElementUpdate(ctx, fctx, target, isIncrement, /* isPrefix */ true);
+  if (linU8 !== null) return linU8;
+
   const arrType = compileExpression(ctx, fctx, target.expression);
   if (!arrType || (arrType.kind !== "ref" && arrType.kind !== "ref_null")) {
     reportError(ctx, target, "Prefix increment on non-array element access");
@@ -1580,6 +1602,11 @@ function compilePostfixIncrementElement(
   target: ts.ElementAccessExpression,
   isIncrement: boolean,
 ): ValType | null {
+  // #2045 C.8: linear-backed Uint8Array element update — read-modify-write the
+  // linear memory directly. Postfix → old value. Falls through for any other.
+  const linU8 = tryEmitLinearU8ElementUpdate(ctx, fctx, target, isIncrement, /* isPrefix */ false);
+  if (linU8 !== null) return linU8;
+
   const arrType = compileExpression(ctx, fctx, target.expression);
   if (!arrType || (arrType.kind !== "ref" && arrType.kind !== "ref_null")) {
     reportError(ctx, target, "Postfix increment on non-array element access");

--- a/src/codegen/linear-uint8-codegen.ts
+++ b/src/codegen/linear-uint8-codegen.ts
@@ -271,6 +271,127 @@ export function tryEmitLinearU8ElementSet(
   return VOID_RESULT;
 }
 
+/**
+ * #2045 C.8 — compound element write `b[i] op= rhs` (`+=`, `++`, `--`, …) for a
+ * linear-backed buffer → read-modify-write at a single computed address.
+ *
+ * Without this, `compileElementCompoundAssignment` compiled the buffer
+ * expression as a value (materialising the GC representation) and wrote the
+ * result back through the externref/GC path — which never touched the linear
+ * memory, so `b[0] += 1` silently kept the old byte (read 5, computed 6, stored
+ * nowhere). This emits the same `i32.load8_u` read and `i32.store8` write as the
+ * plain get/set, sharing one `addr = ptr + trunc(i)` so the index is evaluated
+ * once and the read and write hit the same byte.
+ *
+ * `emitOp` is invoked with the current element value already on the stack as
+ * f64; it must push the rhs and emit the compound operator, leaving the result
+ * f64 on the stack (the caller passes a closure over `emitCompoundOp` + the rhs
+ * expression to avoid an assignment.ts↔linear-uint8-codegen.ts import cycle).
+ *
+ * Leaves the **assigned f64 value** on the stack and returns `{kind:"f64"}` so
+ * `b[i] op= rhs` works in both statement and expression position (matching the
+ * GC/externref compound paths, which also push the result). Note the value is
+ * the full f64 result, not the truncated stored byte — same as the GC array
+ * path's compound result. Returns `null` if `b` is not a linear-backed buffer.
+ */
+export function tryEmitLinearU8ElementCompound(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  target: ts.ElementAccessExpression,
+  emitOp: () => void,
+): ValType | null {
+  const buf = lookupLinearU8Buffer(ctx, fctx, target.expression);
+  if (!buf) return null;
+
+  const idxLocal = allocLocal(fctx, `__linu8_cidx_${fctx.locals.length}`, { kind: "i32" });
+  const addrLocal = allocLocal(fctx, `__linu8_caddr_${fctx.locals.length}`, { kind: "i32" });
+
+  // idx = trunc(index); evaluate the index once (JS + GC order), bounds-check.
+  compileExpression(ctx, fctx, target.argumentExpression, { kind: "f64" });
+  fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  fctx.body.push({ op: "local.set", index: idxLocal } as Instr);
+  emitLinearU8BoundsCheck(fctx, idxLocal, buf.lenLocalIdx);
+  // addr = ptr + idx (shared by the read and the write).
+  fctx.body.push({ op: "local.get", index: buf.ptrLocalIdx } as Instr);
+  fctx.body.push({ op: "local.get", index: idxLocal } as Instr);
+  fctx.body.push({ op: "i32.add" } as Instr);
+  fctx.body.push({ op: "local.set", index: addrLocal } as Instr);
+
+  // result = (f64) mem[addr]  op  rhs
+  fctx.body.push({ op: "local.get", index: addrLocal } as Instr);
+  fctx.body.push({ op: "i32.load8_u", align: 0, offset: 0 } as Instr);
+  fctx.body.push({ op: "f64.convert_i32_u" } as Instr);
+  emitOp(); // pushes rhs, emits the compound op → result f64 on the stack
+  const valLocal = allocLocal(fctx, `__linu8_cval_${fctx.locals.length}`, { kind: "f64" });
+  fctx.body.push({ op: "local.set", index: valLocal } as Instr);
+  // mem[addr] = (u8) trunc(result)
+  fctx.body.push({ op: "local.get", index: addrLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: valLocal } as Instr);
+  fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  fctx.body.push({ op: "i32.store8", align: 0, offset: 0 } as Instr);
+  // Push the (untruncated) assigned value as the expression result, matching the
+  // GC/externref compound paths.
+  fctx.body.push({ op: "local.get", index: valLocal } as Instr);
+  return { kind: "f64" };
+}
+
+/**
+ * #2045 C.8 — prefix/postfix `++`/`--` on a linear-backed element
+ * (`b[i]++`, `++b[i]`, `b[i]--`, `--b[i]`) → read-modify-write at one address.
+ *
+ * The generic prefix/postfix element handlers begin with
+ * `compileExpression(target.expression)` and require a `ref`/`ref_null` array —
+ * a linear buffer is a `(ptr,len)` pair, so they error/throw. This emits the
+ * linear read-modify-write directly: load `b[i]`, add/sub 1, store the low byte,
+ * and leave the **old** value (postfix) or the **new** value (prefix) on the
+ * stack as f64 — matching JS update-expression semantics. Returns `null` if `b`
+ * is not a linear-backed buffer (caller falls through to the GC handlers).
+ */
+export function tryEmitLinearU8ElementUpdate(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  target: ts.ElementAccessExpression,
+  isIncrement: boolean,
+  isPrefix: boolean,
+): ValType | null {
+  const buf = lookupLinearU8Buffer(ctx, fctx, target.expression);
+  if (!buf) return null;
+
+  const idxLocal = allocLocal(fctx, `__linu8_uidx_${fctx.locals.length}`, { kind: "i32" });
+  const addrLocal = allocLocal(fctx, `__linu8_uaddr_${fctx.locals.length}`, { kind: "i32" });
+  const oldLocal = allocLocal(fctx, `__linu8_uold_${fctx.locals.length}`, { kind: "f64" });
+  const newLocal = allocLocal(fctx, `__linu8_unew_${fctx.locals.length}`, { kind: "f64" });
+
+  // idx = trunc(index) (once), bounds-check, addr = ptr + idx.
+  compileExpression(ctx, fctx, target.argumentExpression, { kind: "f64" });
+  fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  fctx.body.push({ op: "local.set", index: idxLocal } as Instr);
+  emitLinearU8BoundsCheck(fctx, idxLocal, buf.lenLocalIdx);
+  fctx.body.push({ op: "local.get", index: buf.ptrLocalIdx } as Instr);
+  fctx.body.push({ op: "local.get", index: idxLocal } as Instr);
+  fctx.body.push({ op: "i32.add" } as Instr);
+  fctx.body.push({ op: "local.set", index: addrLocal } as Instr);
+
+  // old = (f64) mem[addr]
+  fctx.body.push({ op: "local.get", index: addrLocal } as Instr);
+  fctx.body.push({ op: "i32.load8_u", align: 0, offset: 0 } as Instr);
+  fctx.body.push({ op: "f64.convert_i32_u" } as Instr);
+  fctx.body.push({ op: "local.set", index: oldLocal } as Instr);
+  // new = old ± 1
+  fctx.body.push({ op: "local.get", index: oldLocal } as Instr);
+  fctx.body.push({ op: "f64.const", value: 1 } as Instr);
+  fctx.body.push({ op: isIncrement ? "f64.add" : "f64.sub" } as Instr);
+  fctx.body.push({ op: "local.set", index: newLocal } as Instr);
+  // mem[addr] = (u8) trunc(new)
+  fctx.body.push({ op: "local.get", index: addrLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: newLocal } as Instr);
+  fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  fctx.body.push({ op: "i32.store8", align: 0, offset: 0 } as Instr);
+  // Result: prefix → new value, postfix → old value (JS §13.4).
+  fctx.body.push({ op: "local.get", index: isPrefix ? newLocal : oldLocal } as Instr);
+  return { kind: "f64" };
+}
+
 /** `b.length` for a linear-backed buffer → `len` widened to f64. */
 export function tryEmitLinearU8Length(
   ctx: CodegenContext,

--- a/tests/issue-2045-linear-u8-compound.test.ts
+++ b/tests/issue-2045-linear-u8-compound.test.ts
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2045 C.8 — compound element writes and `++`/`--` on a linear-backed
+ * `Uint8Array` (WASI) silently failed to update linear memory.
+ *
+ * `b[i] += rhs` routed through `compileElementCompoundAssignment`, which
+ * materialised the buffer as a value (the GC representation) and wrote the result
+ * back through the externref/GC path — never touching the linear memory, so the
+ * byte kept its old value (read 5, computed 6, stored nowhere). `b[i]++` /
+ * `++b[i]` / `b[i]--` routed through `compileMemberIncDec`, which required a
+ * `ref` array and threw at runtime on a `(ptr,len)` buffer.
+ *
+ * Fix: `tryEmitLinearU8ElementCompound` / `tryEmitLinearU8ElementUpdate`
+ * (linear-uint8-codegen.ts) emit a read-modify-write at a single
+ * `addr = ptr + trunc(i)` (`i32.load8_u` → op → `i32.store8`), bounds-checked
+ * like the get/set paths. Prefix yields the new value, postfix the old; the
+ * store truncates to the byte (so `200 += 100` wraps to 44).
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileWasi(source: string): Promise<Uint8Array> {
+  const result = await compile(source, { fileName: "test.ts", target: "wasi" });
+  if (!result.success) {
+    throw new Error(`compile failed: ${result.errors?.map((e) => e.message).join("; ") ?? "unknown"}`);
+  }
+  return result.binary;
+}
+
+/** Run a WASI module's `main`/`_start`, capturing the bytes written to fd 1. */
+async function runWasiMain(binary: Uint8Array): Promise<number[]> {
+  const module = await WebAssembly.compile(binary);
+  const memRef: { value?: WebAssembly.Memory } = {};
+  const out: number[] = [];
+  const view = () => new DataView(memRef.value!.buffer);
+  const memU8 = () => new Uint8Array(memRef.value!.buffer);
+  const wasi = {
+    fd_read: () => 0,
+    fd_write(_fd: number, iovsPtr: number, iovsLen: number, nwrittenPtr: number): number {
+      const dv = view();
+      let total = 0;
+      for (let i = 0; i < iovsLen; i++) {
+        const base = iovsPtr + i * 8;
+        const p = dv.getUint32(base, true);
+        const l = dv.getUint32(base + 4, true);
+        for (const b of memU8().subarray(p, p + l)) out.push(b);
+        total += l;
+      }
+      dv.setUint32(nwrittenPtr, total, true);
+      return 0;
+    },
+    proc_exit: () => {
+      throw new Error("__proc_exit");
+    },
+  };
+  const instance = await WebAssembly.instantiate(module, { wasi_snapshot_preview1: wasi });
+  const exports = instance.exports as Record<string, unknown>;
+  memRef.value = exports.memory as WebAssembly.Memory;
+  const entry = (exports.main ?? exports._start) as undefined | (() => void);
+  if (!entry) throw new Error("no main/_start export");
+  entry();
+  return out;
+}
+
+/** Compile + run, returning the single byte the program writes to stdout. */
+async function runByte(body: string): Promise<number> {
+  const src = `declare const process: { stdout: { write(b: Uint8Array): void } };
+    export function main(): void {
+      const b = new Uint8Array(4);
+      ${body}
+      const out = new Uint8Array(1);
+      out[0] = b[0];
+      process.stdout.write(out);
+    }`;
+  const got = await runWasiMain(await compileWasi(src));
+  return got[0]!;
+}
+
+describe("#2045 C.8 — linear Uint8Array compound element writes", () => {
+  it("b[0] += 1 stores the incremented byte", async () => {
+    expect(await runByte("b[0] = 5; b[0] += 1;")).toBe(6);
+  });
+
+  it("b[0] -= 2 stores the decremented byte", async () => {
+    expect(await runByte("b[0] = 5; b[0] -= 2;")).toBe(3);
+  });
+
+  it("b[0] *= 3 stores the product", async () => {
+    expect(await runByte("b[0] = 4; b[0] *= 3;")).toBe(12);
+  });
+
+  it("compound write truncates to the byte (200 += 100 → 44)", async () => {
+    expect(await runByte("b[0] = 200; b[0] += 100;")).toBe(44);
+  });
+
+  it("b[0] &= mask stores the masked byte", async () => {
+    expect(await runByte("b[0] = 0xff; b[0] &= 0x0f;")).toBe(0x0f);
+  });
+});
+
+describe("#2045 C.8 — linear Uint8Array ++ / --", () => {
+  it("b[0]++ stores the incremented byte", async () => {
+    expect(await runByte("b[0] = 5; b[0]++;")).toBe(6);
+  });
+
+  it("++b[0] stores the incremented byte", async () => {
+    expect(await runByte("b[0] = 5; ++b[0];")).toBe(6);
+  });
+
+  it("b[0]-- stores the decremented byte", async () => {
+    expect(await runByte("b[0] = 5; b[0]--;")).toBe(4);
+  });
+
+  it("postfix b[0]++ evaluates to the OLD value", async () => {
+    // capture the postfix result in b[1], then read it back.
+    const src = `declare const process: { stdout: { write(b: Uint8Array): void } };
+      export function main(): void {
+        const b = new Uint8Array(4);
+        b[0] = 5;
+        b[1] = b[0]++;          // b[1] = 5 (old), b[0] = 6
+        const out = new Uint8Array(2);
+        out[0] = b[1];
+        out[1] = b[0];
+        process.stdout.write(out);
+      }`;
+    expect(await runWasiMain(await compileWasi(src))).toEqual([5, 6]);
+  });
+
+  it("prefix ++b[0] evaluates to the NEW value", async () => {
+    const src = `declare const process: { stdout: { write(b: Uint8Array): void } };
+      export function main(): void {
+        const b = new Uint8Array(4);
+        b[0] = 5;
+        b[1] = ++b[0];          // b[1] = 6 (new), b[0] = 6
+        const out = new Uint8Array(2);
+        out[0] = b[1];
+        out[1] = b[0];
+        process.stdout.write(out);
+      }`;
+    expect(await runWasiMain(await compileWasi(src))).toEqual([6, 6]);
+  });
+
+  it("b[0]++ wraps at the byte boundary (255++ → 0)", async () => {
+    expect(await runByte("b[0] = 255; b[0]++;")).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

C.8 slice of #2045 (linear Uint8Array soundness holes). Fixes another
**silent-corruption** route: compound element writes and `++`/`--` on a
linear-backed `Uint8Array` (WASI) silently failed to update linear memory.

- `b[0] = 5; b[0] += 1` read back **5** (the store never landed).
- `b[0]++` / `++b[0]` / `b[0]--` **threw a `WebAssembly.Exception`** at runtime.

**Root cause.** The plain `b[i] = v` write routes through
`tryEmitLinearU8ElementSet`, but the *compound* (`compileElementCompoundAssignment`)
and *update* (`compileMemberIncDec`) forms have separate lowerings with no linear
path: the compound path compiled the buffer as a value (materialising the GC
vec) and wrote the result through the externref/GC path — never touching linear
memory; the update path required a `ref` array and hit `compileExpression`'s
`(ptr,len)` shape → runtime throw.

**Fix.** Two new emitters in `linear-uint8-codegen.ts` do a bounds-checked
read-modify-write at a single `addr = ptr + trunc(i)` (index evaluated once),
mirroring the existing get/set:
- `tryEmitLinearU8ElementCompound` — `i32.load8_u` → f64, run the compound op,
  `i32.store8` the low byte; leaves the f64 result for the expression value.
- `tryEmitLinearU8ElementUpdate` — `load → ±1 → store`, leaving the **new**
  value (prefix) or **old** value (postfix) per §13.4.

Wired into `compileElementCompoundAssignment` and `compileMemberIncDec` (the live
`++`/`--` dispatch) **before** their value-materialising `compileExpression`,
with defensive guards in the prefix/postfix element handlers; all fall through to
the GC path for non-linear targets. The store truncates to the byte, so
`200 += 100 → 44` and `255++ → 0` wrap like JS `Uint8Array`.

## Test plan

- New `tests/issue-2045-linear-u8-compound.test.ts` (11, WASI run via the
  `runWasiMain` fd_write harness): `+=`/`-=`/`*=`/`&=`, compound byte-wrap,
  `++`/prefix/`--`, postfix-returns-old, prefix-returns-new, `255++`→0 wrap.
- 14 #2045 / #1886-slice-b + 150 linear/WASI suite cases stay green.
- tsc + prettier + biome(error) + coercion-sites + any-box + stack-balance
  gates clean.

## Scope

#2045 stays **open** for B.3/B.4 (escape-analysis demotion gaps) and C.5–C.7
(loop-arena rewind ordering, all-target while-loop gate, `process.stdin.read`
clamp/errno), as documented in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)