### PR TITLE
fix(#2091): regex step-cap exhaustion throws catchable RangeError

### DIFF
--- a/plan/issues/2091-regex-step-cap-silent-nomatch.md
+++ b/plan/issues/2091-regex-step-cap-silent-nomatch.md
@@ -1,10 +1,11 @@
 ---
 id: 2091
 title: "REGEX_STEP_CAP overflow silently reports no-match — must throw RangeError"
-status: ready
-sprint: Backlog
+status: done
+sprint: 63
 created: 2026-06-11
-updated: 2026-06-11
+updated: 2026-06-18
+completed: 2026-06-18
 priority: medium
 feasibility: easy
 reasoning_effort: low
@@ -45,3 +46,47 @@ Same loud-cap policy as the for-of 1M guard (#2067).
 
 #1959 covers the quantifier-progress bug itself; the cap's silent-null
 behavior is unfiled. New (analysis program).
+
+---
+
+## Resolution (2026-06-18, cs-2163)
+
+**Landed.** Both regex VM cap-exhaustion sites now throw a catchable
+`RangeError` instead of silently reporting a no-match, and the cap constant is
+deduplicated.
+
+- **Native Wasm matcher** (`src/codegen/native-regex.ts`, `__regex_run`): the
+  cap-check arm (was `then: [{ i32.const 0 }, { return }]` — a silent
+  no-match) now throws via a new `regexCapExhaustionThrow(ctx)` helper that
+  builds a `RangeError` instance + `throw $exc` instruction sequence. Dual-mode:
+  JS-host mode routes through the `__new_RangeError` host import; standalone /
+  WASI emits the in-module `__new_RangeError` constructor (zero host imports).
+  The helper runs at the TOP of `ensureRegexRun`, BEFORE the `__regex_run` /
+  `classMatchIdx` funcIdx captures — registering `__new_RangeError` shifts
+  function indices, so doing it first keeps the captures correct (the
+  late-import-shift discipline).
+- **TS reference VM** (`src/codegen/regex/vm.ts`, `runAt`): the cap-exhaustion
+  `return null` now `throw new RangeError(...)`. A legitimate backtrack failure
+  still returns `null` — only the cap path throws, so the oracle matches the
+  Wasm runtime.
+- **Cap constant deduplicated** (#2091 secondary): `native-regex.ts` no longer
+  defines a second `REGEX_STEP_CAP = 1_000_000`; it imports the single source of
+  truth from `regex/vm.ts` (removes the drift smell).
+
+**Note on scope:** the cap applies only to the **native** regex VM (standalone /
+WASI). JS-host mode (`target: gc`, default) delegates `RegExp.prototype.test` to
+`env.RegExp_new`/`RegExp_test` (the host JS engine), which has its own ReDoS
+behavior — the native cap does not gate it.
+
+### Test Results
+
+- `tests/issue-2091-regex-step-cap-throw.test.ts` — 7/7. Part 1 (TS reference
+  VM): catastrophic `(a+)+b` over 40×`a` throws `RangeError`; normal match
+  returns its span; normal no-match returns `null` (cap untouched); the cap
+  constant is the single exported `1_000_000`. Part 2 (standalone Wasm, zero
+  host imports): catastrophic regex → caught `RangeError` (discriminant 2);
+  non-catastrophic match → `true`; non-catastrophic no-match → `false` (no
+  spurious throw).
+- Regex regression suites (`regex-bytecode`, `issue-1539-standalone-regex`,
+  `issue-1911-regex-phase2d`, `issue-1912-regex-phase2b`) — 605/605, no
+  regression. typecheck + lint + format:check clean.

--- a/src/codegen/native-regex.ts
+++ b/src/codegen/native-regex.ts
@@ -16,8 +16,40 @@
  */
 import type { Instr, ValType, WasmFunction } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
+import { noJsHost } from "./expressions/helpers.js";
+import { ensureLateImport } from "./expressions/late-imports.js";
+import { emitWasiErrorConstructor } from "./registry/error-types.js";
+import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
 import { addFuncType, getOrRegisterArrayType, getOrRegisterVecType } from "./registry/types.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { ReOp } from "./regex/bytecode.js";
+import { REGEX_STEP_CAP } from "./regex/vm.js";
+
+/** REGEX_STEP_CAP message (§22.2.6.x — cap exhaustion → catchable RangeError). */
+const REGEX_CAP_MESSAGE = "RangeError: regular expression step limit exceeded";
+
+/**
+ * (#2091) Build the instruction sequence for a regex VM step-cap-exhaustion
+ * throw — a catchable `RangeError` instance (via the shared `$exc` tag), NOT a
+ * silent `return 0` (which is indistinguishable from a genuine no-match).
+ *
+ * MUST be called at the TOP of `ensureRegexRun`, BEFORE the `__regex_run`
+ * funcIdx (and `classMatchIdx`) are captured: in JS-host mode `ensureLateImport`
+ * registers `__new_RangeError` as a host import, which shifts every defined
+ * function index. Ensuring it first keeps the later index captures correct.
+ * In no-JS-host mode the in-module `__new_RangeError` constructor is emitted
+ * (also a function push) — same ordering requirement.
+ */
+function regexCapExhaustionThrow(ctx: CodegenContext): Instr[] {
+  if (noJsHost(ctx)) emitWasiErrorConstructor(ctx, "RangeError", 1);
+  addStringConstantGlobal(ctx, REGEX_CAP_MESSAGE);
+  const ctorIdx = ensureLateImport(ctx, "__new_RangeError", [{ kind: "externref" }], [{ kind: "externref" }]);
+  const tagIdx = ensureExnTag(ctx);
+  const instrs: Instr[] = [...stringConstantExternrefInstrs(ctx, REGEX_CAP_MESSAGE)];
+  if (ctorIdx !== undefined) instrs.push({ op: "call", funcIdx: ctorIdx });
+  instrs.push({ op: "throw", tagIdx });
+  return instrs;
+}
 // NOTE: `__regex_replace` / `__regex_split` (below) reuse the native string
 // helpers registered by ensureNativeStringHelpers and never import a JS RegExp
 // or String.prototype host shim.
@@ -64,8 +96,8 @@ function ensureFrameTypes(ctx: CodegenContext): [number, number] {
   return [frameIdx, frameArrIdx];
 }
 
-/** Step cap mirrors `REGEX_STEP_CAP` in regex/vm.ts. */
-const REGEX_STEP_CAP = 1_000_000;
+// (#2091) Step cap is the single source of truth in regex/vm.ts — imported, no
+// longer a drift-prone duplicate constant.
 /** Initial backtrack-stack capacity (frames). Grows on demand. */
 const INITIAL_STACK_CAP = 64;
 
@@ -218,6 +250,12 @@ function emitClassMatch(ctx: CodegenContext): number {
 export function ensureRegexRun(ctx: CodegenContext): number {
   const existing = ctx.nativeRegexHelpers.get("__regex_run");
   if (existing !== undefined) return existing;
+
+  // (#2091) Build the cap-exhaustion RangeError throw FIRST — it may register
+  // the `__new_RangeError` ctor (host import in JS-host mode / in-module
+  // function in standalone), which shifts function indices. Doing it before the
+  // funcIdx captures below keeps those indices correct.
+  const capThrow = regexCapExhaustionThrow(ctx);
 
   const classMatchIdx = emitClassMatch(ctx);
   const [frameIdx, frameArrIdx] = ensureFrameTypes(ctx);
@@ -1202,14 +1240,15 @@ export function ensureRegexRun(ctx: CodegenContext): number {
       op: "loop",
       blockType: { kind: "empty" },
       body: [
-        // steps++; if steps > CAP return 0
+        // steps++; if steps > CAP throw RangeError (#2091 — was a silent
+        // `return 0`, indistinguishable from a genuine no-match).
         { op: "local.get", index: STEPS },
         { op: "i32.const", value: 1 },
         { op: "i32.add" },
         { op: "local.tee", index: STEPS },
         { op: "i32.const", value: REGEX_STEP_CAP },
         { op: "i32.gt_s" },
-        { op: "if", blockType: { kind: "empty" }, then: [{ op: "i32.const", value: 0 }, { op: "return" }] },
+        { op: "if", blockType: { kind: "empty" }, then: capThrow },
         // failed = 0
         { op: "i32.const", value: 0 },
         { op: "local.set", index: FAILED },

--- a/src/codegen/regex/vm.ts
+++ b/src/codegen/regex/vm.ts
@@ -108,7 +108,13 @@ export function runAt(
   const unit = (): number => input.charCodeAt(dir > 0 ? sp : sp - 1);
 
   for (;;) {
-    if (++steps > REGEX_STEP_CAP) return null;
+    // (#2091) Cap exhaustion is a hard error, NOT a no-match: a silent `return
+    // null` is indistinguishable from a genuine non-match. Throw a catchable
+    // RangeError so callers (and the Wasm `__regex_run` this VM mirrors) report
+    // it loudly. (A legitimate backtrack failure still returns `null` below.)
+    if (++steps > REGEX_STEP_CAP) {
+      throw new RangeError("regular expression step limit exceeded");
+    }
     const op = prog[pc * 3]!;
     const a = prog[pc * 3 + 1]!;
     const b = prog[pc * 3 + 2]!;

--- a/tests/issue-2091-regex-step-cap-throw.test.ts
+++ b/tests/issue-2091-regex-step-cap-throw.test.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2091 — regex step-cap exhaustion must throw a catchable RangeError, not
+ * silently report a no-match.
+ *
+ * Before this fix, a regex exceeding the 1M-VM-step cap returned `null` (TS
+ * reference VM) / `0` (Wasm `__regex_run`) — a silent wrong answer
+ * indistinguishable from a genuine no-match. Catastrophic-backtracking patterns
+ * (`(a+)+b` against a long all-`a` non-matching subject) burn the cap and hit
+ * this. Now both the reference VM (`regex/vm.ts`) and the native Wasm matcher
+ * (`native-regex.ts` `__regex_run`) throw a catchable `RangeError`.
+ *
+ * Part 1 unit-tests the TS reference VM directly (the spec the Wasm mirrors).
+ * Part 2 compiles `--target standalone` (which uses the native VM, not the JS
+ * host RegExp) and asserts the thrown value is caught and is a `RangeError`,
+ * with non-catastrophic regexes unaffected.
+ */
+import { describe, expect, it } from "vitest";
+import { compilePattern } from "../src/codegen/regex/compile.js";
+import { parseFlags } from "../src/codegen/regex/bytecode.js";
+import { search, REGEX_STEP_CAP } from "../src/codegen/regex/vm.js";
+import { compile } from "../src/index.js";
+
+describe("#2091 reference VM throws on step-cap exhaustion", () => {
+  it("catastrophic backtracking throws RangeError (not a silent null no-match)", () => {
+    // `(a+)+b` over an all-`a` subject with no trailing `b` is the classic
+    // exponential-backtracking ReDoS — it blows past REGEX_STEP_CAP.
+    const c = compilePattern("(a+)+b", parseFlags(""));
+    const subject = "a".repeat(40);
+    expect(() => search(c.prog, c.classTable, c.nGroups, subject, 0, false)).toThrow(RangeError);
+  });
+
+  it("a normal match does NOT throw and returns the match span", () => {
+    const c = compilePattern("a(b+)c", parseFlags(""));
+    const m = search(c.prog, c.classTable, c.nGroups, "abbbc", 0, false);
+    expect(m).not.toBeNull();
+    expect([m![0], m![1]]).toEqual([0, 5]);
+  });
+
+  it("a normal no-match returns null (NOT a throw — cap untouched)", () => {
+    const c = compilePattern("xyz", parseFlags(""));
+    expect(search(c.prog, c.classTable, c.nGroups, "abcabc", 0, false)).toBeNull();
+  });
+
+  it("the cap constant is the single source of truth (exported, 1M)", () => {
+    expect(REGEX_STEP_CAP).toBe(1_000_000);
+  });
+});
+
+describe("#2091 native (standalone) __regex_run throws on step-cap exhaustion", () => {
+  // Compile + run an i32-returning probe under --target standalone (native VM,
+  // zero host imports). 0 = no-throw, 1 = caught (non-RangeError), 2 = caught
+  // RangeError.
+  async function runStandalone(src: string): Promise<number> {
+    const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+    const mod = await WebAssembly.compile(r.binary);
+    // Native standalone — no JS-host RegExp import.
+    expect(WebAssembly.Module.imports(mod).filter((i) => /RegExp/.test(i.name))).toEqual([]);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    return (instance.exports as { run(): number }).run();
+  }
+
+  it("catastrophic backtracking throws a catchable RangeError", async () => {
+    expect(
+      await runStandalone(
+        `export function run(): number {
+           const re = /(a+)+b/;
+           try { re.test("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"); return 0; }
+           catch (e) { return (e instanceof RangeError) ? 2 : 1; }
+         }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("a non-catastrophic regex still matches (no spurious throw)", async () => {
+    expect(
+      await runStandalone(
+        `export function run(): number {
+           const re = /(a+)+b/;
+           try { return re.test("aaab") ? 10 : 11; }
+           catch (e) { return 1; }
+         }`,
+      ),
+    ).toBe(10);
+  });
+
+  it("a non-catastrophic no-match returns false (no spurious throw)", async () => {
+    expect(
+      await runStandalone(
+        `export function run(): number {
+           const re = /xyz/;
+           try { return re.test("abcabc") ? 10 : 11; }
+           catch (e) { return 1; }
+         }`,
+      ),
+    ).toBe(11);
+  });
+});


### PR DESCRIPTION
## #2091 — silent no-match on regex step-cap exhaustion

A regex exceeding the 1M VM-step cap returned `null` (TS reference VM) / `0` (Wasm `__regex_run`) — a **silent wrong answer** indistinguishable from a genuine no-match. Catastrophic-backtracking patterns (`(a+)+b` over a long all-`a` subject) burn the cap and hit this. Both VMs now throw a **catchable RangeError**.

### Changes
- **`native-regex.ts` `__regex_run`**: the cap-check arm (was a silent `return 0`) throws via a new `regexCapExhaustionThrow(ctx)` helper (RangeError instance + `throw $exc`). Dual-mode: JS-host `__new_RangeError` import / standalone in-module constructor (**zero host imports**). Built at the TOP of `ensureRegexRun`, BEFORE the `__regex_run`/`classMatchIdx` funcIdx captures, so the `__new_RangeError` registration's function-index shift doesn't desync them (late-import-shift discipline).
- **`regex/vm.ts` `runAt`**: cap-exhaustion `return null` → `throw new RangeError(...)`. A legitimate backtrack failure still returns `null`, so the reference oracle matches the Wasm runtime.
- **Deduped `REGEX_STEP_CAP`** (the issue's secondary drift smell): `native-regex.ts` now imports the single source of truth from `regex/vm.ts` instead of a second local copy.

### Scope
The cap gates only the **native** regex VM (standalone / WASI). JS-host mode (`target: gc`, default) delegates `RegExp.prototype.test` to `env.RegExp_*` (the host engine), which has its own ReDoS behavior — unaffected.

### Tests
- `tests/issue-2091-regex-step-cap-throw.test.ts` — 7/7. TS reference VM (catastrophic `(a+)+b` throws `RangeError`; normal match returns span; no-match returns null; cap constant is the single exported 1M) + standalone Wasm (catastrophic → caught `RangeError`; non-catastrophic match/no-match unaffected, zero host imports).
- Regex regression suites (`regex-bytecode`, `issue-1539-standalone-regex`, `issue-1911-regex-phase2d`, `issue-1912-regex-phase2b`) — 605/605, no regression. typecheck + lint + format:check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)