### PR TITLE
fix(#2051): optional element access a?.[i] short-circuits to undefined

### DIFF
--- a/plan/issues/2051-optional-chain-undefined-representation.md
+++ b/plan/issues/2051-optional-chain-undefined-representation.md
@@ -12,6 +12,7 @@ task_type: bugfix
 area: codegen
 language_feature: optional-chaining
 goal: core-semantics
+assignee: ttraenkler/cs-2164
 related: [16, 2049, 2050, 1603]
 origin: "2026-06-10 deep-audit sweep (eval-order agent): verified miscompile on main"
 ---
@@ -408,3 +409,51 @@ coercion (the call arm must box its primitive return only when widening fires,
 and VOID_RESULT calls must never widen). The standalone caveat (host `undefined`
 falls back to `ref.null.extern`, indistinguishable from null) is unchanged and
 out of scope, per the plan.
+
+## Element slice — LANDED (2026-06-18, cs-2164)
+
+**Done — optional ELEMENT access `a?.[i]`.** The element arm is the
+property-access-shaped half: `compileOptionalElementAccess`
+(`property-access.ts`) lowered the whole `a?.[i]` result to the element's bare
+value type (f64/i32) and fabricated a typed zero in both the non-ref
+short-circuit and the `ref.is_null` then-arm — so a nullish base gave
+`a?.[0] === undefined` false, `typeof a?.[0]` "number", `"" + a?.[0]` "0".
+
+**Why this slice is safe where the CALL arm is not.** The else (non-null) arm of
+`compileOptionalElementAccess` ends in `compileElementAccessBody` — an
+`array.get`/`struct.get`, **not** a `call`/`call_ref`. So pulling `__box_number`
+in as a late import after the read does NOT desync a baked-in funcIdx (the exact
+hazard the call-arm attempts hit). It is the **same** pattern the landed
+property-access fix uses, applied verbatim to the element arm.
+
+**Fix** (`compileOptionalElementAccess`): compute
+`widenToUndefinedExternref = (resultType is f64/i32) && isNullablePrimitiveType(tsResultType)`;
+when set, widen `resultType` to externref. The non-ref short-circuit and the
+`ref.is_null` then-arm now emit host `undefined` (`emitUndefined`, via the
+`fctx.body` swap so late-import flushes are safe) instead of the typed zero; the
+else arm's existing `coerceType(elseResultType, resultType)` boxes the element
+value (`__box_number`/`__box_boolean`) since `resultType` is now externref.
+Boxes into a plain externref, NOT AnyValue — #1888 tag-5 ABI intact.
+
+**Validation.** New `tests/issue-2051-optional-element-undefined.test.ts` (7,
+JS-host): nullish `a?.[0] === undefined` / `typeof` / `"" +` / `?? 42`; the
+non-null distinguishing case (element value `0` must NOT read as undefined →
+`=== undefined` false, `"" +` "0"); non-null real element; string-element array
+(nullish typeof "undefined", non-null "x"). The 17 #2051 / #2050
+optional-element / #2049 optional-call regression cases stay green. tsc +
+prettier + biome(error) + coercion-sites + any-box + stack-balance gates clean.
+(The pre-existing 2-case failure in `optional-direct-closure-call.test.ts` is on
+stock `main`, unrelated to this slice — verified by stashing the change.)
+
+**Type-inference note:** the widening gate keys on `a?.[i]` having the nullable
+static type `number | undefined`. A `getArr` body written as `b ? [...] : null`
+narrows TS's inference of `a?.[0]` to a bare `number` in some contexts (gate
+doesn't fire); the `if (b) return …; return null;` shape gives the
+reliably-nullable type. This is a pre-existing static-type limit **shared by the
+property-access gate** (not new to the element slice) — the broader fix is a
+type-resolution improvement, out of scope here.
+
+**Still open (the issue's `reasoning_effort: max` core):** the optional **CALL**
+short-circuit (`o?.f()`, `calls-optional.ts`) — blocked by the late-import
+index-shift hazard documented above; needs the pre-flush-box-helpers ordering and
+is architect-spec territory. **#2051 stays in-progress** for that arm.

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -4370,6 +4370,22 @@ export function compileOptionalElementAccess(
     resultType = { kind: "externref" };
   }
 
+  // (#2051) Same nullable-primitive widening as `compileOptionalPropertyAccess`:
+  // when the whole-chain static type is a nullable primitive (`number |
+  // undefined` etc., collapsed by `resolveWasmType` to a bare f64/i32 that can't
+  // represent `undefined`), widen the result to externref so the short-circuit
+  // arm carries host `undefined` (`emitUndefined`) and the non-null arm boxes the
+  // element value (`__box_number`/`__box_boolean` via the existing coerceType).
+  // The else arm here ends in an `array.get`/`struct.get` (not a `call`), so —
+  // unlike the optional-CALL arm (#2051 call-arm, deferred) — there is no
+  // late-import index-shift hazard from pulling in the box helper after the read.
+  // Boxes into a plain externref, NOT AnyValue, so the #1888 tag-5 ABI is intact.
+  const widenToUndefinedExternref =
+    (resultType.kind === "f64" || resultType.kind === "i32") && isNullablePrimitiveType(tsResultType);
+  if (widenToUndefinedExternref) {
+    resultType = { kind: "externref" };
+  }
+
   // A non-reference base is the compiler's representation of `undefined`/`null`
   // (e.g. a `const a = null` stored as an i32 global). Such a base always
   // short-circuits: drop it and emit the default result, never touching the
@@ -4381,7 +4397,9 @@ export function compileOptionalElementAccess(
     } else if (resultType.kind === "i32") {
       fctx.body.push({ op: "i32.const", value: 0 });
     } else {
-      fctx.body.push({ op: "ref.null.extern" });
+      // (#2051) externref result (incl. the nullable-primitive widening above) →
+      // host `undefined` so `=== undefined` / `typeof` / `+` read it correctly.
+      emitUndefined(ctx, fctx);
     }
     return resultType;
   }
@@ -4400,7 +4418,13 @@ export function compileOptionalElementAccess(
   } else if (resultType.kind === "i32") {
     thenInstrs = [{ op: "i32.const", value: 0 }];
   } else {
-    thenInstrs = [{ op: "ref.null.extern" }];
+    // (#2051) externref result → host `undefined`. Build via a body-swap because
+    // `emitUndefined` pushes to `fctx.body` and may flush late imports.
+    const savedForThen = fctx.body;
+    fctx.body = [];
+    emitUndefined(ctx, fctx);
+    thenInstrs = fctx.body;
+    fctx.body = savedForThen;
   }
 
   // else branch (non-null path): push the now-known-non-null base, then run

--- a/tests/issue-2051-optional-element-undefined.test.ts
+++ b/tests/issue-2051-optional-element-undefined.test.ts
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2051 — a short-circuited optional **element** access (`a?.[i]`) whose static
+ * type is a nullable primitive (`number | undefined`) must yield `undefined`,
+ * not the element type's default (`0`).
+ *
+ * The property-access slice (`o?.v`) landed earlier; this is the matching
+ * element slice. `compileOptionalElementAccess` lowered the whole `a?.[i]`
+ * result to the element's bare value type (f64/i32) and the short-circuit arm
+ * fabricated a typed zero — so a nullish base gave `a?.[0] === undefined`
+ * false, `typeof a?.[0]` "number", `"" + a?.[0]` "0".
+ *
+ * Fix (mirrors `compileOptionalPropertyAccess`): when the chain's static result
+ * type is a nullable primitive, widen the result to externref; the null arm
+ * emits host `undefined` and the non-null arm boxes the element value (the
+ * existing `coerceType` at the else-arm tail does `__box_number`). The else arm
+ * ends in an `array.get`/`struct.get` (not a `call`), so — unlike the optional-
+ * CALL arm (still deferred under #2051) — there is no late-import index-shift
+ * hazard.
+ *
+ * Default (JS-host) mode: relies on host `undefined` (`__get_undefined`),
+ * `__typeof`, `__extern_toString`, `__extern_is_undefined` — all already present.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function run(src: string): Promise<number | string> {
+  const r = await compile(src, { fileName: "test.ts" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject ?? {});
+  return (instance.exports as { test(): number | string }).test();
+}
+
+// Non-null base has element [0] === 0 so the v=0 distinguishing case (a real 0
+// must NOT read as undefined) is exercised by the non-nullish tests below.
+// The `if (b) return …; return null;` body shape gives `a?.[i]` the reliably
+// nullable static type (`number | undefined`) the widening gate keys on —
+// matching the issue repro and the landed property-access test. (A ternary
+// `b ? [...] : null` body narrows TS's inference of `a?.[0]` to a bare `number`
+// in some contexts, which is a pre-existing static-type-inference limit shared
+// by the property-access gate, orthogonal to this element slice.)
+const NUM = `function getArr(b: boolean): number[] | null { if (b) return [0, 20, 30]; return null; }`;
+const STR = `function getStrs(b: boolean): string[] | null { if (b) return ["x", "y"]; return null; }`;
+
+describe("#2051 optional element access yields undefined on short-circuit", () => {
+  it("nullish: a?.[0] === undefined", async () => {
+    expect(
+      await run(`${NUM}\nexport function test(): boolean { const a = getArr(false); return (a?.[0]) === undefined; }`),
+    ).toBe(1);
+  });
+
+  it("nullish: typeof a?.[0] === 'undefined'", async () => {
+    expect(
+      await run(
+        `${NUM}\nexport function test(): boolean { const a = getArr(false); return typeof (a?.[0]) === "undefined"; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it('nullish: "" + a?.[0] === "undefined"', async () => {
+    expect(
+      await run(
+        `${NUM}\nexport function test(): boolean { const a = getArr(false); return ("" + (a?.[0])) === "undefined"; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("nullish: a?.[0] ?? 42 === 42", async () => {
+    expect(
+      await run(`${NUM}\nexport function test(): number { const a = getArr(false); return (a?.[0]) ?? 42; }`),
+    ).toBe(42);
+  });
+
+  it("non-null: a?.[1] returns the real element (20)", async () => {
+    expect(
+      await run(
+        `${NUM}\nexport function test(): number { const a = getArr(true); const r = a?.[1]; return r === undefined ? -1 : r; }`,
+      ),
+    ).toBe(20);
+  });
+
+  it("non-null distinguishing case: element 0 is NOT undefined", async () => {
+    // a?.[0] is a real 0 → `=== undefined` must be false, `"" +` must be "0".
+    expect(
+      await run(`${NUM}\nexport function test(): boolean { const a = getArr(true); return (a?.[0]) === undefined; }`),
+    ).toBe(0);
+    expect(
+      await run(`${NUM}\nexport function test(): boolean { const a = getArr(true); return ("" + (a?.[0])) === "0"; }`),
+    ).toBe(1);
+  });
+
+  it("string-element array: nullish typeof is 'undefined', non-null is the value", async () => {
+    expect(
+      await run(
+        `${STR}\nexport function test(): boolean { const a = getStrs(false); return typeof (a?.[0]) === "undefined"; }`,
+      ),
+    ).toBe(1);
+    expect(
+      await run(
+        `${STR}\nexport function test(): string { const a = getStrs(true); const r = a?.[0]; return r === undefined ? "UNDEF" : r; }`,
+      ),
+    ).toBe("x");
+  });
+});


### PR DESCRIPTION
## Summary

Element slice of #2051. A short-circuited optional **element** access `a?.[i]`
whose static type is a nullable primitive (`number | undefined`) fabricated the
element type's default (a typed zero) instead of `undefined`:

| nullish base | was | should be |
|---|---|---|
| `a?.[0] === undefined` | `false` | `true` |
| `typeof a?.[0]` | `"number"` | `"undefined"` |
| `"" + a?.[0]` | `"0"` | `"undefined"` |

**Fix.** `compileOptionalElementAccess` (`property-access.ts`) now applies the
same nullable-primitive widening the landed property-access slice uses: widen the
chain result to externref when its static type is a nullable primitive, emit host
`undefined` (`emitUndefined`) in the non-ref short-circuit and the `ref.is_null`
then-arm, and let the existing else-arm `coerceType` box the element value
(`__box_number`/`__box_boolean`).

**Why this slice is safe** where the optional-**call** arm (still deferred) is
not: the else arm here ends in `compileElementAccessBody` — an
`array.get`/`struct.get`, **not** a `call`/`call_ref` — so pulling `__box_number`
in as a late import after the read does not desync a baked-in funcIdx (the
late-import index-shift hazard that blocked the call-arm attempts). Boxes into a
plain externref, not AnyValue, so the #1888 tag-5 comparator ABI is untouched.

## Test plan

- New `tests/issue-2051-optional-element-undefined.test.ts` (7, JS-host):
  nullish `=== undefined` / `typeof` / `"" +` / `?? 42`; the distinguishing
  case (a real element value `0` must NOT read as undefined); non-null real
  element; string-element array.
- 17 #2051 / #2050 optional-element / #2049 optional-call regression cases stay
  green.
- tsc + prettier + biome(error) + coercion-sites + any-box + stack-balance
  gates clean. (The pre-existing 2-case failure in
  `optional-direct-closure-call.test.ts` is on stock `main`, unrelated to this
  slice.)

## Scope

#2051 stays **open** for the optional-**call** short-circuit (`o?.f()`,
`calls-optional.ts`) — blocked by the late-import index-shift hazard documented
in the issue; needs a pre-flush-box-helpers ordering and is architect-spec
territory (`reasoning_effort: max`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)