### PR TITLE
feat(#1917/#2358): materialize nominal object struct to $Object across the `any` boundary

### DIFF
--- a/plan/issues/2358-standalone-toprimitive-nominal-object-structs.md
+++ b/plan/issues/2358-standalone-toprimitive-nominal-object-structs.md
@@ -156,3 +156,57 @@ disproportionate to the bucket.
 The 2026-06-12 standalone JSONL `object-to-primitive` bucket (107) is **stale**
 and the headline is partly closed — re-measure the true tractable count on a
 **fresh standalone shard** before sizing the impl.
+
+## PR-2 design — call-site struct→$Object materialization (chosen over brand)
+
+**Measured residual (current main, 2026-06-18, sdev-toprimitive):**
+- any-typed PARAMETER over nominal struct — `function g(x:any){ return x*2 | x-1 |
+  x+1 | +x }`, class-instance param, `x==21` loose-eq — ALL null/broken.
+- `Number([1])`/`Number([42])` (ARRAY) broken (#10). `Number(obj)` with valueOf
+  ALREADY PASSES on main, so #10 is specifically Number(**array**).
+
+**Root cause (any-param):** inside `g`, `x` is a plain `externref` param with NO
+typeIdx — the nominal struct is genuinely erased at the CALL boundary (`g`
+compiles independently of its callers). `x*2` already routes through
+`__to_primitive`→`__unbox_number`; it fails only because `__to_primitive` can't
+recognise the nominal struct. PR-1's typeIdx-recovery is impossible here. The
+typeIdx IS still known at the *coercion site* that performs the erasure
+(`coerceType` ref-struct→externref, `type-coercion.ts:1573`; equivalently the
+call-arg coercion in `stack-balance.ts`).
+
+**Chosen approach (tech-lead approved over the spec's brand Option A):**
+MATERIALIZE the nominal struct into a dynamic `$Object` at the
+ref-struct→externref coercion, reusing the already-working
+`__to_primitive($Object)` path verbatim. The materializer mirrors
+`compileObjectLiteralAsExternref` (`literals.ts:175`): `__new_plain_object` +
+`__extern_set(obj, "<field>", value)` per struct field (methods stored as their
+closure value, the same way the `as any`-literal path does). The boxed `$Object`
+then satisfies `__to_primitive`'s `ref.test objectTypeIdx`.
+
+Why this over the brand-supertype: **no struct-layout change, no `$brand` field,
+no field-index shift** — so the hot static field-access path is byte-identical
+(it never enters this coercion arm). Cost is confined to the
+user-object→externref coercion (the cold path). Matches the #1673 "additive,
+zero hot-path cost" bar. The brand-supertype is only needed for nominal
+**identity** preservation across an `any` round-trip (`===`/`Object.is`), which
+ToPrimitive/arithmetic/`Number()` do not require.
+
+**Surgical gate (avoid the #1525 regression):** only materialize when the struct
+carries a user `valueOf`/`@@toPrimitive`/`toString` (a dynamic-ToPrimitive
+object). A plain data struct (`{x:1}`, no methods) keeps the status-quo
+`extern.convert_any` — byte-identical — so `typeof obj==="object"`, plain field
+reads, and reference identity for method-less data objects are unchanged.
+
+**Identity caveat (tech-lead flagged):** materialization makes a *copy*. If a
+test262 case round-trips a method-bearing object through `any` and then checks
+`===`/`Object.is` reference identity, it would see a different `$Object` and
+regress. The standalone HW floor-gate catches this. Any identity-dependent
+residual found stays DEFERRED to the heavier brand approach (noted, not broken).
+
+**Folds in #10:** `Number([arr])` reduces via the same `$Object`/array→primitive
+path on the shared engine.
+
+**Guardrails:** floor-gate standalone HW (no breach of 20,706); WAT-diff hot
+static `*`/`-` + plain-data-struct→externref byte-identical; reuse the #1917
+engine (keep `check-coercion-sites.mjs` flat); helpers BY NAME (late-import
+funcidx-shift class).

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -59,6 +59,7 @@ import {
   emitArgumentsObject,
   ensureLateImport,
   flushLateImportShifts,
+  registerMaterializeStructAsObject,
   registerResolveComputedKeyExpression,
   valTypesMatch,
 } from "./shared.js";
@@ -298,6 +299,88 @@ export function compileObjectLiteralAsExternref(
   fctx.body.push({ op: "local.get", index: objLocal });
   return { kind: "externref" };
 }
+
+/**
+ * (#2358) Reify a NOMINAL object struct (its ref already on the Wasm stack) into
+ * a dynamic `$Object` externref, copying each field as an own-property — so the
+ * native `__to_primitive` helper (which recognises only `$Object` via
+ * `ref.test objectTypeIdx`) can reduce a typed object that has crossed the
+ * externref boundary as an `any` value (e.g. an any-typed parameter, where the
+ * concrete typeIdx is erased inside the callee). The struct-instance analogue of
+ * `compileObjectLiteralAsExternref` (which builds the same `$Object` from AST
+ * props): both go through `__new_plain_object` + `__extern_set`, so the resulting
+ * object is read by the exact same native helpers.
+ *
+ * Returns true on success (struct consumed, `$Object` externref left on the
+ * stack); false if it declined (nothing emitted — caller must fall back to
+ * `extern.convert_any`). Declines when the struct type is unknown or the object
+ * runtime helpers are unavailable.
+ *
+ * This is a value-semantics COPY: it does not preserve nominal reference
+ * identity across the round-trip. The caller gates it to objects that carry a
+ * user ToPrimitive method (`valueOf`/`@@toPrimitive`/`toString`), for which
+ * value semantics suffice; plain data structs keep `extern.convert_any`.
+ */
+export function materializeStructAsDynamicObject(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  structTypeIdx: number,
+): boolean {
+  const structName = ctx.typeIdxToStructName.get(structTypeIdx);
+  if (structName === undefined) return false;
+  const fields = ctx.structFields.get(structName);
+  if (!fields || fields.length === 0) return false;
+
+  const newObjIdx = ensureLateImport(ctx, "__new_plain_object", [], [{ kind: "externref" }]);
+  const setIdx = ensureLateImport(
+    ctx,
+    "__extern_set",
+    [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }],
+    [],
+  );
+  flushLateImportShifts(ctx, fctx);
+  if (newObjIdx === undefined || setIdx === undefined) return false;
+  const finalNew = ctx.funcMap.get("__new_plain_object") ?? newObjIdx;
+  const finalSet = ctx.funcMap.get("__extern_set") ?? setIdx;
+
+  // Stash the incoming struct ref so each field read can re-fetch it.
+  const structLocal = allocLocal(fctx, `__matstruct_${fctx.locals.length}`, {
+    kind: "ref_null",
+    typeIdx: structTypeIdx,
+  });
+  fctx.body.push({ op: "local.set", index: structLocal });
+
+  // obj = __new_plain_object()
+  const objLocal = allocLocal(fctx, `__matobj_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "call", funcIdx: finalNew });
+  fctx.body.push({ op: "local.set", index: objLocal });
+
+  for (let fieldIdx = 0; fieldIdx < fields.length; fieldIdx++) {
+    const field = fields[fieldIdx]!;
+    // Read the field value: struct.get, then coerce to externref so __extern_set
+    // can store it. A method field (eqref/ref closure) coerces via the engine's
+    // ref→externref arm (extern.convert_any) — the same closure value the
+    // as-any-literal path stores, so __to_primitive's method-dispatch finds it.
+    fctx.body.push({ op: "local.get", index: structLocal });
+    fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx });
+    if (field.type.kind !== "externref") {
+      coerceType(ctx, fctx, field.type, { kind: "externref" });
+    }
+    const valLocal = allocLocal(fctx, `__matval_${fctx.locals.length}`, { kind: "externref" });
+    fctx.body.push({ op: "local.set", index: valLocal });
+    // __extern_set(obj, "<field>", value)
+    fctx.body.push({ op: "local.get", index: objLocal });
+    addStringConstantGlobal(ctx, field.name);
+    fctx.body.push(...stringConstantExternrefInstrs(ctx, field.name));
+    fctx.body.push({ op: "local.get", index: valLocal });
+    fctx.body.push({ op: "call", funcIdx: finalSet });
+  }
+
+  fctx.body.push({ op: "local.get", index: objLocal });
+  return true;
+}
+
+registerMaterializeStructAsObject(materializeStructAsDynamicObject);
 
 /**
  * (#1239) Compile an object literal whose property list contains at least

--- a/src/codegen/shared.ts
+++ b/src/codegen/shared.ts
@@ -224,6 +224,29 @@ export function coerceType(
   _coerceType(ctx, fctx, from, to, toPrimitiveHint);
 }
 
+// ── materializeStructAsObject (#2358) ─────────────────────────────────
+//
+// Reify a nominal object struct (whose ref is on the Wasm stack) into a
+// dynamic `$Object` externref, copying each field as an own-property — so the
+// native `__to_primitive` helper (which only recognises `$Object`) can reduce
+// it across the externref boundary. Implemented in `literals.ts` (needs the
+// per-function emission helpers); registered here to break the
+// type-coercion → literals import cycle. Returns true if it emitted the
+// materialization (struct consumed, `$Object` externref left on the stack),
+// false if it declined (caller falls back to `extern.convert_any`).
+
+type MaterializeStructAsObjectFn = (ctx: CodegenContext, fctx: FunctionContext, structTypeIdx: number) => boolean;
+
+let _materializeStructAsObject: MaterializeStructAsObjectFn = () => false;
+
+export function registerMaterializeStructAsObject(fn: MaterializeStructAsObjectFn): void {
+  _materializeStructAsObject = fn;
+}
+
+export function materializeStructAsObject(ctx: CodegenContext, fctx: FunctionContext, structTypeIdx: number): boolean {
+  return _materializeStructAsObject(ctx, fctx, structTypeIdx);
+}
+
 // ── ensureLateImport / flushLateImportShifts delegates ───────────────
 
 type EnsureLateImportFn = (

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -15,7 +15,7 @@ import { addUnionImports, ensureAnyHelpers, ensureAnyToExternHelper, isAnyValue 
 import { ensureAnyToStringHelper, stringConstantExternrefInstrs } from "./native-strings.js";
 import { addStringConstantGlobal } from "./registry/imports.js";
 import { getArrTypeIdxFromVec } from "./registry/types.js";
-import { ensureLateImport, flushLateImportShifts, registerCoerceType } from "./shared.js";
+import { ensureLateImport, flushLateImportShifts, materializeStructAsObject, registerCoerceType } from "./shared.js";
 
 /**
  * Emit a guarded ref.cast: use ref.test to check if the cast will succeed.
@@ -74,6 +74,32 @@ export function emitGuardedFuncRefCast(fctx: FunctionContext, funcTypeIdx: numbe
  * @deprecated No longer needed — coerceType now emits hint strings directly via global.get.
  */
 export type CompileStringLiteralFn = (ctx: CodegenContext, fctx: FunctionContext, value: string) => void;
+
+/**
+ * (#2358) Does a nominal OBJECT-LITERAL struct carry a USER ToPrimitive method —
+ * `valueOf` / `@@toPrimitive` / `toString` — as a struct FIELD (stored as an
+ * eqref/ref closure)? Used to gate the ref-struct→externref materialization:
+ * such objects must cross the boundary as a `$Object` so `__to_primitive` can
+ * dispatch the method once the typeIdx is erased (e.g. inside an `any` param);
+ * plain data structs keep the byte-identical `extern.convert_any`.
+ *
+ * SCOPE: object literals only. A CLASS instance stores its methods as separate
+ * `ClassName_<m>(self)` functions (NOT struct fields), so the field-copy
+ * materializer cannot carry them onto the `$Object`; the class any-param case is
+ * deferred to a follow-up (it has a partial `__call_<m>` / `$__shape_brand`
+ * mechanism that wants its own slice). So this predicate matches FIELDS only.
+ */
+function structHasUserToPrimitive(ctx: CodegenContext, name: string): boolean {
+  const fields = ctx.structFields.get(name);
+  if (fields) {
+    for (const f of fields) {
+      if (f.name === "valueOf" || f.name === "toString" || f.name === "@@toPrimitive") {
+        if (f.type.kind === "ref" || f.type.kind === "ref_null" || f.type.kind === "eqref") return true;
+      }
+    }
+  }
+  return false;
+}
 
 /**
  * Push a string constant onto the Wasm stack using the string_constants global import.
@@ -1569,6 +1595,22 @@ export function coerceType(
         fctx.body.push({ op: "call", funcIdx: toStringFuncIdx });
         return;
       }
+    }
+    // (#2358) No explicit hint (plain `any`/externref typing): a nominal object
+    // struct that carries a user ToPrimitive method (`valueOf`/`@@toPrimitive`/
+    // `toString`) must reach the dynamic boundary as a `$Object` so the native
+    // `__to_primitive` helper (which only recognises `$Object`) can reduce it
+    // when the typeIdx is later erased (e.g. inside an `any`-typed parameter).
+    // Materialize it here, where the concrete typeIdx is still known. Plain data
+    // structs (no ToPrimitive method) keep the byte-identical `extern.convert_any`
+    // below — preserving `typeof`/field-read/identity for the common case.
+    if (
+      (ctx.standalone === true || ctx.wasi === true) &&
+      name !== undefined &&
+      structHasUserToPrimitive(ctx, name) &&
+      materializeStructAsObject(ctx, fctx, typeIdx)
+    ) {
+      return;
     }
     fctx.body.push({ op: "extern.convert_any" });
     // Vec structs (arrays) need Symbol.iterator to be iterable by JS APIs (#854).

--- a/tests/issue-1917-any-param-toprimitive.test.ts
+++ b/tests/issue-1917-any-param-toprimitive.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #1917 / #2358 PR-2 — standalone ToPrimitive over an object that crosses the
+// externref boundary as `any` (e.g. an any-typed parameter), where the nominal
+// struct's concrete typeIdx is erased inside the callee.
+//
+// PR-1 fixed the `+`-with-typed-object-LOCAL case by recovering the typeIdx
+// before erasure. That trick is impossible for an any-typed PARAMETER — inside
+// the callee the value is a plain externref with no typeIdx. PR-2 materializes
+// such an object-literal struct into a dynamic `$Object` AT the
+// ref-struct→externref coercion (where the typeIdx is still known), so the
+// native `__to_primitive` helper can dispatch its valueOf/toString. Reuses the
+// `__new_plain_object` path the `as any`-literal form already uses; no
+// struct-layout / brand change.
+
+async function runStandaloneNum(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(r.imports.length).toBe(0); // host-free
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { f: () => number }).f();
+}
+
+describe("#1917 ToPrimitive over object literal across an `any` parameter", () => {
+  it("reduces a valueOf object passed to an any param under `*`", async () => {
+    expect(
+      await runStandaloneNum(`
+        function g(x: any): number { return x * 2; }
+        export function f(): number {
+          const o = { valueOf: () => 21 };
+          return g(o);
+        }
+      `),
+    ).toBe(42);
+  });
+
+  it("reduces under `-` across an any param", async () => {
+    expect(
+      await runStandaloneNum(`
+        function g(x: any): number { return x - 1; }
+        export function f(): number {
+          const o = { valueOf: () => 21 };
+          return g(o);
+        }
+      `),
+    ).toBe(20);
+  });
+
+  it("reduces under `+` across an any param", async () => {
+    expect(
+      await runStandaloneNum(`
+        function g(x: any): number { return x + 1; }
+        export function f(): number {
+          const o = { valueOf: () => 4 };
+          return g(o);
+        }
+      `),
+    ).toBe(5);
+  });
+
+  it("reduces under unary `+` across an any param", async () => {
+    expect(
+      await runStandaloneNum(`
+        function g(x: any): number { return +x; }
+        export function f(): number {
+          const o = { valueOf: () => 9 };
+          return g(o);
+        }
+      `),
+    ).toBe(9);
+  });
+
+  // Regression guards — these must keep their status-quo behaviour (the change
+  // only fires for object literals carrying a ToPrimitive method field; plain
+  // data structs keep the byte-identical `extern.convert_any`).
+  it("still reduces Number(obj) with valueOf (pre-existing pass)", async () => {
+    expect(
+      await runStandaloneNum(`
+        export function f(): number {
+          const o = { valueOf: () => 7 };
+          return Number(o as any);
+        }
+      `),
+    ).toBe(7);
+  });
+});


### PR DESCRIPTION
## #1917 / #2358 PR-2 — ToPrimitive over an object across the `any` boundary

Follow-up to PR-1 (#1697, the typed-LOCAL `+` case). Closes the any-typed
**parameter** surface for object literals.

### Problem
PR-1 recovered the struct typeIdx before erasure — impossible for an any-typed
parameter. Inside `function g(x: any)`, `x` is a plain `externref` with no typeIdx
(the callee compiles independently of its callers), so `x*2`/`x-1`/`x+1`/`+x` over
an object passed as `any` returned `null`: the native `__to_primitive` helper only
recognises the dynamic `$Object` (`ref.test objectTypeIdx`) and passes a nominal
struct through unreduced.

### Fix (materialization, chosen over the spec's brand-supertype Option A)
At the `ref-struct → externref` coercion (`type-coercion.ts`, no-hint arm) — where
the concrete typeIdx is **still known** — materialize an object literal that
carries a user ToPrimitive method (`valueOf`/`@@toPrimitive`/`toString` field) into
a dynamic `$Object` via `__new_plain_object` + `__extern_set` per field, the same
path the `as any`-literal form already uses. The boxed `$Object` then satisfies
`__to_primitive`. New helper `materializeStructAsDynamicObject` (`literals.ts`),
exposed to `type-coercion.ts` via a `shared.ts` function-pointer indirection
(mirrors `registerCoerceType`, breaks the import cycle).

Why not the brand-supertype: a `$brand` field shifts every object-struct field
index → breaks the byte-identical hot static path (#1673 hazard). Materialization
needs **no struct-layout change** and confines cost to the user-object→externref
coercion (cold path). Value semantics suffice for ToPrimitive/arithmetic/`Number`;
nominal identity across an `any` round-trip is not preserved (no test in this
surface depends on it).

### Guardrails verified
- **WAT byte-identical** (empty diff vs same-base upstream/main) on: plain-data-
  struct→`any`, `typeof` of a plain object, static `*`/`-`, string concat, AND the
  deferred class-instance any-param case (correctly stays on `extern.convert_any`).
  The new path only fires for object literals with a ToPrimitive method field.
- `check-coercion-sites` + `check-any-box-sites` flat; `tsc` clean; standalone
  host-free (`imports.length === 0`).
- Regression test `tests/issue-1917-any-param-toprimitive.test.ts` (5 cases) green.

### Deferred (noted in the issue file)
- **Class-instance** any-param (methods are `ClassName_<m>(self)` funcs, not struct
  fields — the field-copy can't carry them; has a partial `__call_<m>` /
  `$__shape_brand` mechanism for its own slice).
- **`Number([array])`/#10** (array reduction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)