### PR TITLE
fix(#2036 S6 step 2): native standalone Array.prototype.filter over array-like receiver

### DIFF
--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -504,7 +504,11 @@ const STANDALONE_UNSUPPORTED_ARRAY_LIKE_METHODS = new Set([
   "indexOf",
   "lastIndexOf",
   "includes",
-  "filter",
+  // (#2036 S6 step 2) `filter` now has a native standalone arm — it builds its
+  // result via the native `$ObjVec` builder (`__objvec_new`/`__objvec_push`)
+  // instead of the host `__js_array_*`, so it no longer leaks a host import.
+  // Removed from the refusal set. map/reduce/reduceRight stay until their
+  // native result/accumulator arms land (map needs sparse-hole handling).
   "map",
   "reduce",
   "reduceRight",
@@ -1001,8 +1005,24 @@ export function compileArrayLikePrototypeCall(
     }
 
     case "filter": {
-      const arrNewIdx = ensureLateImport(ctx, "__js_array_new", [], [{ kind: "externref" }]);
-      const arrPushIdx = ensureLateImport(ctx, "__js_array_push", [{ kind: "externref" }, { kind: "externref" }], []);
+      // (#2036 S6 step 2) Result builder: in standalone/WASI build a native
+      // `$ObjVec` via `__objvec_new`/`__objvec_push` (host-import-free, and
+      // `[i]`/`.length`-readable post #2190/#35); in host/gc mode keep the host
+      // `__js_array_new`/`__js_array_push` JS-array builders. Both have the
+      // identical externref-new / `(externref,externref)->void`-push shape, so
+      // the loop body below is unchanged. filter's result is naturally dense
+      // (order-preserving compaction), so the sequential `push` is exact — no
+      // sparse-hole concern (that defers `map` to a follow-up slice).
+      let arrNewIdx: number | undefined;
+      let arrPushIdx: number | undefined;
+      if (ctx.standalone || ctx.wasi) {
+        const builders = ensureObjVecBuilders(ctx);
+        arrNewIdx = builders.newIdx;
+        arrPushIdx = builders.pushIdx;
+      } else {
+        arrNewIdx = ensureLateImport(ctx, "__js_array_new", [], [{ kind: "externref" }]);
+        arrPushIdx = ensureLateImport(ctx, "__js_array_push", [{ kind: "externref" }, { kind: "externref" }], []);
+      }
       if (arrNewIdx === undefined || arrPushIdx === undefined) return undefined;
       flushLateImportShifts(ctx, fctx);
       const resultTmp = allocLocal(fctx, `__ali_fl_res_${fctx.locals.length}`, { kind: "externref" });

--- a/tests/issue-2036.test.ts
+++ b/tests/issue-2036.test.ts
@@ -143,7 +143,10 @@ describe("#2036 S6 step 1 — borrowed search/result-building methods refuse lou
   // These methods previously emitted invalid Wasm / leaked a host import over a
   // borrowed array-like `$Object` receiver in standalone. They must now refuse
   // with a `Codegen error:` naming the method + #2036 — never a broken module.
-  for (const method of ["indexOf", "lastIndexOf", "includes", "filter", "map", "reduce", "reduceRight"]) {
+  // (#2036 S6 step 2) `filter` graduated to a native standalone arm (it builds
+  // its result via the native `$ObjVec` builder) — it is asserted to WORK below,
+  // not refuse. The remaining methods still refuse until their native arms land.
+  for (const method of ["indexOf", "lastIndexOf", "includes", "map", "reduce", "reduceRight"]) {
     it(`${method} over an array-like $Object refuses loudly in standalone`, async () => {
       const args =
         method === "filter" || method === "map"
@@ -179,6 +182,61 @@ describe("#2036 S6 step 1 — borrowed search/result-building methods refuse lou
          }`,
       ),
     ).toBe(11);
+  });
+
+  // (#2036 S6 step 2) filter over an array-like $Object now runs NATIVELY in
+  // standalone (host-import-free) — builds a `$ObjVec` result via
+  // __objvec_new/__objvec_push that is `[i]`/`.length`-readable.
+  it("filter over an array-like $Object runs natively in standalone (length)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const o: any = { 0: 1, 1: 2, 2: 3, length: 3 };
+           const r: any = Array.prototype.filter.call(o, (x: number) => x > 1);
+           return r.length;
+         }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("filter preserves element order + values standalone (r[0], r[1])", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const o: any = { 0: 10, 1: 20, 2: 30, length: 3 };
+           const r: any = Array.prototype.filter.call(o, (x: number) => x > 10);
+           return r[0] * 100 + r[1];
+         }`,
+      ),
+    ).toBe(2030);
+  });
+
+  it("filter over a sparse array-like skips holes standalone", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const o: any = { 0: 1, 2: 3, length: 3 };
+           const r: any = Array.prototype.filter.call(o, (x: number) => x > 0);
+           return r.length;
+         }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("filter threads thisArg standalone", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const o: any = { 0: 5, 1: 15, length: 2 };
+           const r: any = Array.prototype.filter.call(
+             o,
+             function (this: any, x: number) { return x > this.t; },
+             { t: 10 },
+           );
+           return r.length;
+         }`,
+      ),
+    ).toBe(1);
   });
 
   it("real native array receivers still work in standalone (not refused)", async () => {


### PR DESCRIPTION
## #2036 S6 step 2 (PR-1 of the #54 array-like cluster) — native `Array.prototype.filter` over an array-like receiver in standalone

`Array.prototype.filter.call(arrayLike, cb)` over a borrowed array-like `$Object`
receiver (`{0:…, length:n}`, `arguments`, …) loud-refused under `--target
standalone` (#2036 S6 step 1) because the result-building arm leaked the host
`__js_array_new` / `__js_array_push`.

### Fix

The iteration primitives (`__extern_length` / `__extern_get_idx` /
`__extern_has_idx`) already have native `$Object` arms in standalone (#2036
PR-1), and a native array builder — `__objvec_new` / `__objvec_push`, producing
a `$ObjVec` that is `[i]`/`.length`-readable post #2190/#35 — already exists
(used by the JSON codec + Map/Set entries). So filter's result builder just needs
to use the native builder in standalone instead of the host one:

```ts
if (ctx.standalone || ctx.wasi) {
  const b = ensureObjVecBuilders(ctx); arrNewIdx = b.newIdx; arrPushIdx = b.pushIdx;
} else { /* host __js_array_new / __js_array_push */ }
```

filter's result is naturally **dense** (order-preserving compaction), so the
sequential `__objvec_push` is exact — no sparse-hole concern. (That defers `map`,
which needs index-preserving placement, and the search methods, which need a
native SameValueZero, to follow-up slices — they stay in the refusal set.)

Host/gc mode is unchanged (gated on `ctx.standalone || ctx.wasi`); the unused
host pre-registration is dead-elim'd so there is no leak. `filter` is removed
from `STANDALONE_UNSUPPORTED_ARRAY_LIKE_METHODS`.

### Verification

- New standalone tests (issue-2036.test.ts): filter length, element order/values,
  sparse-hole skip, thisArg threading — all correct, **zero host-import leak**
  (each instantiates with an empty import object).
- issue-2036 suite **19/19** (the remaining 6 methods still assert the refusal);
  issue-1358 + array-call-arraylike **11/11**; host-mode filter unchanged.
- tsc + prettier + lint + coercion-sites + any-box gates clean.

Part of the #54 / #2036 array-like `.call` cluster (~600 standalone CEs). This PR
lands the cleanest method (filter); map (sparse) + search (native eq) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)