### PR TITLE
fix(#2188 follow-up): multi-level user Error chain construction routing

### DIFF
--- a/plan/issues/2188-standalone-sibling-error-subclass-instanceof-precision.md
+++ b/plan/issues/2188-standalone-sibling-error-subclass-instanceof-precision.md
@@ -115,3 +115,39 @@ construction-routing fix (transitively-derived Error subclasses must thread
 through `__new_<builtinAncestor>`); filing as a follow-up. The brand machinery
 here already supports the chain on the *read* side (descendant ids are collected)
 — only the *construction* side is missing for the >1-level case.
+
+## Resolution of the multi-level follow-up (2026-06-18, sendev-prb — `issue-2188-multilevel`)
+
+The construction-routing gap above is FIXED. `class D extends A {}` /
+`A extends Error` now constructs `D` as a real `$Error_struct`.
+
+**Root cause (located):** `compileSuperCall` (class-bodies.ts) gated the native
+`__new_<builtin>` super-routing on `classBuiltinParentMap.get(child)`, which the
+collection phase (class-bodies.ts ~545) only populated when the **direct** parent
+is a host-constructible builtin (`isHostConstructibleBuiltin(directParent)`). For
+`class D extends A` the direct parent A is a user class → no entry → D's `super()`
+chained through A's user `_init`, never threading to `__new_Error`, so D was
+un-tagged (`instanceof Error` false, `.message` unset, uncatchable as Error).
+
+**Fix (class-bodies.ts, additive):** make the resolution **transitive** — when
+the direct parent is itself an externref-backed user Error subclass
+(`classExternrefBackedSet.has(parent) && classBuiltinParentMap.has(parent)`),
+propagate the **builtin ANCESTOR** name (`classBuiltinParentMap.get(parent)`,
+not the immediate parent) into the child's `classBuiltinParentMap` and add the
+child to `classExternrefBackedSet`. We deliberately do NOT gate on
+`parentStructTypeIdx === undefined` here (the parent carries a vestigial struct
+slot; the discriminator is the parent's externref-backing, not struct presence).
+Parents are collected before children in source order, so the ancestor mapping is
+already present. Everything downstream (implicit forwarder, `super()` routing,
+`instanceof` brand reads) then fires through the existing externref-backed path.
+
+**Verified:** `.message` field, catchability (try/throw/catch instanceof Error),
+and #2188 sibling-disjointness all pass standalone; `tests/issue-2188-multilevel-error-chain.test.ts`
+(7 tests). tsc clean.
+
+**Dependency — #2029/#1702:** the implicit derived-ctor forwarder pads missing
+`super()` args via `pushDefaultValue`→`emitUndefinedValue` (type-coercion.ts),
+which leaks `env.__get_undefined` in standalone until #1702's `nativeStrings`
+guard lands (a PRE-EXISTING 1-level leak too, not introduced here). The 4
+no-arg-construction tests' `imports === []` assertion passes once #1702 merges;
+this PR is rebased on #1702.

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -545,6 +545,23 @@ export function collectClassDeclaration(
           if (parentStructTypeIdx === undefined && isHostConstructibleBuiltin(parentClassName)) {
             ctx.classBuiltinParentMap.set(className, parentClassName);
             ctx.classExternrefBackedSet.add(className);
+          } else if (ctx.classExternrefBackedSet.has(parentClassName) && ctx.classBuiltinParentMap.has(parentClassName)) {
+            // (#2188 follow-up) Multi-level user Error chain: the direct parent is
+            // itself a user class that is externref-backed by a builtin Error
+            // ancestor (e.g. `class D extends A {}` where `A extends Error`).
+            // The parent carries a vestigial struct slot, so we do NOT gate on
+            // `parentStructTypeIdx === undefined` here — the discriminator is the
+            // parent's externref-backing, not its struct presence. `super()` must
+            // thread through the SAME builtin ancestor's `__new_<builtin>` so D is
+            // constructed as a real `$Error_struct` (carrying the builtin Error
+            // `$tag`, `.message`, catchability, and `instanceof Error`) instead of
+            // chaining through A's user `_init`, which leaves D un-tagged. Parents
+            // are collected in source order before their children, so the
+            // ancestor's mapping is already present; propagate the builtin
+            // ANCESTOR name (not the immediate parent).
+            const builtinAncestor = ctx.classBuiltinParentMap.get(parentClassName)!;
+            ctx.classBuiltinParentMap.set(className, builtinAncestor);
+            ctx.classExternrefBackedSet.add(className);
           }
           // Mark parent struct as non-final so it can be extended
           if (parentStructTypeIdx !== undefined) {

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -545,7 +545,10 @@ export function collectClassDeclaration(
           if (parentStructTypeIdx === undefined && isHostConstructibleBuiltin(parentClassName)) {
             ctx.classBuiltinParentMap.set(className, parentClassName);
             ctx.classExternrefBackedSet.add(className);
-          } else if (ctx.classExternrefBackedSet.has(parentClassName) && ctx.classBuiltinParentMap.has(parentClassName)) {
+          } else if (
+            ctx.classExternrefBackedSet.has(parentClassName) &&
+            ctx.classBuiltinParentMap.has(parentClassName)
+          ) {
             // (#2188 follow-up) Multi-level user Error chain: the direct parent is
             // itself a user class that is externref-backed by a builtin Error
             // ancestor (e.g. `class D extends A {}` where `A extends Error`).

--- a/tests/issue-2188-multilevel-error-chain.test.ts
+++ b/tests/issue-2188-multilevel-error-chain.test.ts
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2188 follow-up — standalone: a MULTI-LEVEL user Error chain
+ * (`class D extends A {}` where `A extends Error`) must construct `D` as a real
+ * `$Error_struct`.
+ *
+ * #2188 fixed sibling discrimination for DIRECT builtin-Error subclasses. It
+ * left open (documented as a known gap in `issue-2188.test.ts`) the multi-level
+ * case: `D`'s direct parent `A` is a USER class, so `compileSuperCall` did not
+ * find `D` in `classBuiltinParentMap` (which was only populated when the DIRECT
+ * parent is a builtin). `D`'s `super()` therefore chained through `A`'s user
+ * `_init` instead of the builtin Error ancestor's `__new_<builtin>`, so `D` was
+ * never tagged with the builtin Error `$tag` (field 0): `instanceof Error` was
+ * false, `.message` unset, and a thrown `D` was not catchable as `Error`.
+ *
+ * Fix: make the builtin-parent / externref-backing resolution TRANSITIVE — when
+ * the direct parent is itself an externref-backed user Error subclass, propagate
+ * the builtin ANCESTOR name and mark the child externref-backed (parents are
+ * collected before their children in source order, so the ancestor's mapping is
+ * known). `super()` then threads through the builtin ancestor's
+ * `__new_<builtin>` and `D` is a proper `$Error_struct`.
+ *
+ * (Standalone host-import-freedom for the implicit forwarder's undefined-arg
+ * padding is provided by #2029/#1702's `emitUndefinedValue` nativeStrings guard;
+ * these modules instantiate with an EMPTY import object to prove no env leak.)
+ */
+
+async function runStandalone(source: string): Promise<unknown> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  expect((r.imports ?? []).map((i) => i.name)).toEqual([]); // no host-import leak
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#2188 follow-up — standalone multi-level user Error chain construction", () => {
+  it("(new D) instanceof Error is TRUE for `class D extends A {}` / `A extends Error`", async () => {
+    const got = await runStandalone(`
+      class A extends Error {}
+      class D extends A {}
+      export function test(): number {
+        return (new D()) instanceof Error ? 1 : 0;
+      }
+    `);
+    expect(got).toBe(1);
+  });
+
+  it("(new D) instanceof A AND instanceof D both hold (user-class chain still works)", async () => {
+    const got = await runStandalone(`
+      class A extends Error {}
+      class D extends A {}
+      export function test(): number {
+        const d = new D();
+        return (d instanceof A && d instanceof D) ? 1 : 0;
+      }
+    `);
+    expect(got).toBe(1);
+  });
+
+  it("D carries the builtin Error .message field (proves real $Error_struct)", async () => {
+    const got = await runStandalone(`
+      class A extends Error {}
+      class D extends A {}
+      export function test(): number {
+        const d = new D('boom');
+        return d.message === 'boom' ? 1 : 0;
+      }
+    `);
+    expect(got).toBe(1);
+  });
+
+  it("a thrown D is catchable as Error (try/throw/catch instanceof Error)", async () => {
+    const got = await runStandalone(`
+      class A extends Error {}
+      class D extends A {}
+      export function test(): number {
+        try { throw new D('x'); } catch (e) { return e instanceof Error ? 1 : 0; }
+        return -1;
+      }
+    `);
+    expect(got).toBe(1);
+  });
+
+  it("3-level chain: `E extends D extends A extends Error` is instanceof Error", async () => {
+    const got = await runStandalone(`
+      class A extends Error {}
+      class D extends A {}
+      class E extends D {}
+      export function test(): number {
+        return (new E()) instanceof Error ? 1 : 0;
+      }
+    `);
+    expect(got).toBe(1);
+  });
+
+  it("no regression: a DIRECT `class A extends Error {}` is still instanceof Error", async () => {
+    const got = await runStandalone(`
+      class A extends Error {}
+      export function test(): number {
+        return (new A()) instanceof Error ? 1 : 0;
+      }
+    `);
+    expect(got).toBe(1);
+  });
+
+  it("no regression: siblings of the chained class stay disjoint (#2188)", async () => {
+    const got = await runStandalone(`
+      class A extends Error {}
+      class D extends A {}
+      class B extends Error {}
+      export function test(): number {
+        try { throw new D('x'); } catch (e) { return e instanceof B ? 1 : 0; }
+        return -1;
+      }
+    `);
+    expect(got).toBe(0);
+  });
+});


### PR DESCRIPTION
## #2188 follow-up — standalone multi-level user Error chain

`class D extends A {}` where `A extends Error` did not construct `D` as a real
`$Error_struct` in standalone: `(new D) instanceof Error` was false, `.message`
unset, and a thrown `D` was not catchable as `Error`. (`instanceof D`/`instanceof A`
already worked — the read-side per-class brand from #2188 covers descendants;
only the *construction* side was missing for the >1-level chain.)

### Root cause

`compileSuperCall` (class-bodies.ts) gated the native `__new_<builtin>` super-routing
on `classBuiltinParentMap.get(child)`, which the collection phase only populated when
the **direct** parent is a host-constructible builtin (`isHostConstructibleBuiltin(directParent)`).
For `class D extends A`, the direct parent `A` is a user class → no entry → `D`'s
`super()` chained through `A`'s user `_init`, never threading to the builtin Error
ancestor's `__new_Error`.

### Fix (class-bodies.ts, additive)

Make the builtin-parent / externref-backing resolution **transitive**: when the
direct parent is itself an externref-backed user Error subclass
(`classExternrefBackedSet.has(parent) && classBuiltinParentMap.has(parent)`),
propagate the builtin **ancestor** name (not the immediate parent) into the child's
`classBuiltinParentMap` and mark the child externref-backed. We do *not* gate on
`parentStructTypeIdx === undefined` (the parent carries a vestigial struct slot;
the discriminator is the parent's externref-backing). Parents are collected before
their children in source order, so the ancestor mapping is already present.

### Verification

`tests/issue-2188-multilevel-error-chain.test.ts` (7/7): `instanceof Error`,
`instanceof A`/`instanceof D`, `.message`, catchability, 3-level chain
(`E extends D extends A extends Error`), + no-regression for direct `extends Error`
and #2188 sibling disjointness — each instantiates with an EMPTY import object
(no host-import leak). #2188 sibling + #1536c suites 17/17 unchanged. tsc clean.

### Dependency (now satisfied)

The implicit derived-ctor forwarder pads missing `super()` args via
`pushDefaultValue`→`emitUndefinedValue`, which leaked `env.__get_undefined` in
standalone until #2029/#1702's `nativeStrings` guard landed. This PR is rebased on
that merge, so the 4 no-arg-construction tests' `imports === []` assertion passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)