### PR TITLE
fix(#2199): standalone DataView accessors throw RangeError on bad offset

### DIFF
--- a/plan/issues/2199-standalone-dataview-accessor-bounds.md
+++ b/plan/issues/2199-standalone-dataview-accessor-bounds.md
@@ -1,0 +1,86 @@
+---
+id: 2199
+title: "Standalone DataView accessor bounds validation — get/set must throw RangeError, not trap OOB"
+status: done
+sprint: 64
+created: 2026-06-18
+updated: 2026-06-18
+completed: 2026-06-18
+assignee: ttraenkler/sdev-iter
+priority: medium
+feasibility: medium
+reasoning_effort: high
+task_type: conformance
+area: standalone
+language_feature: dataview-arraybuffer
+goal: standalone-mode
+parent: 2159
+---
+
+# Standalone DataView accessor bounds validation
+
+## Problem
+
+On standalone (`--target wasi`), the native DataView accessors trap instead of
+throwing the spec-mandated **RangeError**:
+
+```ts
+const dv = new DataView(new ArrayBuffer(10));
+dv.getFloat64(-1);        // standalone: TRAP "array element access out of bounds"
+dv.getFloat64(Infinity);  // standalone: TRAP        (both should throw RangeError)
+dv.getInt32(8);           // 8+4>8 OOB: TRAP          (should throw RangeError)
+```
+
+A Wasm trap is uncatchable, so the test262
+`built-ins/DataView/prototype/<accessor>/detached-buffer-after-toindex-byteoffset.js`
+cluster (~59 tests) — which `assert.throws(RangeError, …)` on a negative /
+`Infinity` `byteOffset` — all fail.
+
+## Root cause
+
+`emitDataViewAccessor` (`src/codegen/dataview-native.ts`) computed
+`trunc(byteOffset) + base` and immediately read/wrote the backing i32-byte
+array with **no argument validation** — no `ToIndex` RangeError check and no
+`getIndex + elementSize > viewByteLength` bounds check.
+
+## Fix (§24.2.1.1 GetViewValue / §24.2.1.2 SetViewValue)
+
+Additive guard prologue in `emitDataViewAccessor`, all standalone-native (zero
+new host imports):
+
+- New `emitDataViewRangeError(ctx)` — builds a catchable RangeError throw via the
+  shared `$exc` tag + the in-module `__new_RangeError` constructor
+  (`emitWasiErrorConstructor` in no-JS-host mode), mirroring `native-regex.ts`'s
+  `regexCapExhaustionThrow`. Pre-built + flushed BEFORE any operand compile so the
+  late-import funcIdx shift doesn't corrupt later captures.
+- `recoverDvBacking` gains a `viewLenLocal` out-param: the view's byte length —
+  the `$__dv_window.byteLength` field for a windowed view, or `array.len(data)`
+  for a bare offset-0 view.
+- The accessor captures the **f64** request, derives `getIndex =
+  i32.trunc_sat_f64_s(req)`, and throws RangeError when
+  `isNaN(req) || getIndex < 0 || (getIndex + elementSize) > viewByteLength`
+  (the last computed in i64 so the `trunc_sat(+Infinity)=i32.MAX` case can't
+  overflow). Valid accesses are byte-identical to before.
+
+### Known limitation (out of scope)
+
+For **setters**, §24.2.1.2 evaluates `ToNumber(value)` BEFORE the bounds throw;
+this fix throws before compiling the setter value, so a `value` with observable
+side effects would be skipped on an out-of-bounds set. None of the targeted
+detached-buffer cluster tests exercise that ordering; deferred.
+
+## Test Results
+
+- `tests/issue-2199-dataview-bounds.test.ts` — 11/11 green (`target: "standalone"`,
+  zero host imports asserted): getFloat64(-1)/(Infinity), getUint8(100),
+  getInt32(5)-on-8, setUint8(-1), setFloat64(100), windowed out-of-window all
+  throw RangeError; regression guards — last-valid-offset, round-trips, LE,
+  windowed valid read/write — unchanged.
+- Existing DataView suites (issue-38-dataview-window, issue-2159,
+  arraybuffer-dataview, issue-1654-wasi-dataview-arraybuffer) — unchanged.
+- `pnpm run check:ir-fallbacks` — OK. `npx tsc --noEmit` clean.
+
+## Source
+
+Harvest of the standalone failure buckets (2026-06-18, sdev-iter): the DataView
+detached-buffer cluster's headline is the missing ToIndex/bounds RangeError.

--- a/src/codegen/dataview-native.ts
+++ b/src/codegen/dataview-native.ts
@@ -28,7 +28,12 @@
 import type { Instr, ValType } from "../ir/types.js";
 import { allocLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { noJsHost } from "./expressions/helpers.js";
 import { getArrTypeIdxFromVec, getOrRegisterVecType } from "./index.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { emitWasiErrorConstructor } from "./registry/error-types.js";
+import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
+import { ensureLateImport, flushLateImportShifts } from "./shared.js";
 
 /** DataView accessor descriptor parsed from a method name like "getUint32". */
 interface DvAccessor {
@@ -308,6 +313,10 @@ function recoverDvBacking(
   baseLocal: number,
   vecTypeIdx: number,
   arrTypeIdx: number,
+  // (#2199) Optional: i32 local that receives the view's byte length (window's
+  // `byteLength` field for a windowed view; the backing array's `array.len` for
+  // a bare offset-0 view). Used by the §24.2.1.1 bounds check. Pass -1 to skip.
+  viewLenLocal = -1,
 ): boolean {
   const dvWinTypeIdx = getOrRegisterDvWindowType(ctx);
   // Normalize the receiver to an anyref-castable `(ref any)` on the stack.
@@ -335,6 +344,15 @@ function recoverDvBacking(
     { op: "struct.get", typeIdx: dvWinTypeIdx, fieldIdx: 1 } as Instr,
     { op: "local.set", index: baseLocal } as Instr,
   ];
+  if (viewLenLocal >= 0) {
+    // viewLen = (cast $__dv_window).byteLength
+    winBranch.push(
+      { op: "local.get", index: anyLocal } as Instr,
+      { op: "ref.cast", typeIdx: dvWinTypeIdx } as Instr,
+      { op: "struct.get", typeIdx: dvWinTypeIdx, fieldIdx: 2 } as Instr,
+      { op: "local.set", index: viewLenLocal } as Instr,
+    );
+  }
   const vecBranch: Instr[] = [
     // bare vec: arr = .data ; base = 0
     { op: "local.get", index: anyLocal } as Instr,
@@ -344,6 +362,14 @@ function recoverDvBacking(
     { op: "i32.const", value: 0 } as Instr,
     { op: "local.set", index: baseLocal } as Instr,
   ];
+  if (viewLenLocal >= 0) {
+    // viewLen = array.len(arr)  (offset-0 view spans the whole backing buffer)
+    vecBranch.push(
+      { op: "local.get", index: arrLocal } as Instr,
+      { op: "array.len" } as Instr,
+      { op: "local.set", index: viewLenLocal } as Instr,
+    );
+  }
   fctx.body.push({ op: "local.get", index: anyLocal } as Instr);
   fctx.body.push({ op: "ref.test", typeIdx: dvWinTypeIdx } as Instr);
   fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: winBranch, else: vecBranch } as Instr);
@@ -364,6 +390,35 @@ function recoverDvBacking(
  * `compileExpr`/`offsetArg`/`valueArg`/`leArg` are passed in so this module
  * stays decoupled from the big calls.ts dispatcher.
  */
+/** Message for the §24.2.1.1 GetViewValue / SetViewValue out-of-bounds throw. */
+const DV_RANGE_MESSAGE = "RangeError: Offset is outside the bounds of the DataView";
+
+/**
+ * (#2199) Build the instruction sequence for a DataView accessor bounds throw —
+ * a catchable `RangeError` instance via the shared `$exc` tag, mirroring
+ * `native-regex.ts`'s `regexCapExhaustionThrow`. §24.2.1.1 GetViewValue step 4/6
+ * (and SetViewValue): a negative / non-finite `byteOffset`, or
+ * `getIndex + elementSize > viewByteLength`, throws RangeError BEFORE the array
+ * access (which would otherwise trap `array element access out of bounds`).
+ *
+ * MUST be called BEFORE any later funcIdx is captured in the caller: in JS-host
+ * mode `ensureLateImport("__new_RangeError")` registers a host import (shifting
+ * every function index); in no-JS-host mode `emitWasiErrorConstructor` emits the
+ * in-module constructor (also a function push). Same ordering requirement as the
+ * regex cap-throw. The caller pre-builds this template before emitting the
+ * accessor body and flushes shifts.
+ */
+function emitDataViewRangeError(ctx: CodegenContext): Instr[] {
+  if (noJsHost(ctx)) emitWasiErrorConstructor(ctx, "RangeError", 1);
+  addStringConstantGlobal(ctx, DV_RANGE_MESSAGE);
+  const ctorIdx = ensureLateImport(ctx, "__new_RangeError", [{ kind: "externref" }], [{ kind: "externref" }]);
+  const tagIdx = ensureExnTag(ctx);
+  const instrs: Instr[] = [...stringConstantExternrefInstrs(ctx, DV_RANGE_MESSAGE)];
+  if (ctorIdx !== undefined) instrs.push({ op: "call", funcIdx: ctorIdx } as Instr);
+  instrs.push({ op: "throw", tagIdx } as Instr);
+  return instrs;
+}
+
 export function emitDataViewAccessor(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -378,26 +433,73 @@ export function emitDataViewAccessor(
   const { vecTypeIdx, arrTypeIdx } = i32ByteVec(ctx);
   if (arrTypeIdx < 0) return null;
 
+  // (#2199) Pre-build the §24.2.1.1 out-of-bounds RangeError template FIRST.
+  // `emitDataViewRangeError` registers `__new_RangeError` as a late import (and
+  // in no-JS-host mode emits the in-module constructor) — both push a function,
+  // shifting every funcIdx. Building + flushing it before any operand compile or
+  // backing-recovery keeps later funcIdx captures correct (same ordering rule as
+  // native-regex's cap-throw). When `dv.byteLength` is unavailable we skip the
+  // bounds check, so only register the template when we will emit it.
+  const rangeThrow = emitDataViewRangeError(ctx);
+  flushLateImportShifts(ctx, fctx);
+
   // Recover the i32_byte backing array AND the view's base byte offset from the
   // receiver. `dv` may be a `$__dv_window` wrapper (windowed view → base =
   // ctor byteOffset, sharing the parent's array) or a bare `$__vec_i32_byte`
-  // (offset-0 view / ArrayBuffer → base = 0). (#2159/#38)
+  // (offset-0 view / ArrayBuffer → base = 0). (#2159/#38). `viewLenLocal`
+  // receives the view's byte length for the #2199 bounds check.
   const arrLocal = allocLocal(fctx, `__dvn_arr_${fctx.locals.length}`, { kind: "ref", typeIdx: arrTypeIdx });
   const baseLocal = allocLocal(fctx, `__dvn_base_${fctx.locals.length}`, { kind: "i32" });
+  const viewLenLocal = allocLocal(fctx, `__dvn_vlen_${fctx.locals.length}`, { kind: "i32" });
   const recvType = compileExpr(receiver);
-  if (!recoverDvBacking(ctx, fctx, recvType, arrLocal, baseLocal, vecTypeIdx, arrTypeIdx)) {
+  if (!recoverDvBacking(ctx, fctx, recvType, arrLocal, baseLocal, vecTypeIdx, arrTypeIdx, viewLenLocal)) {
     return null;
   }
 
-  // byteOffset (arg 0) → i32 index, then add the view's base byte offset so a
-  // windowed accessor addresses the correct absolute byte in the shared buffer.
-  const offLocal = allocLocal(fctx, `__dvn_off_${fctx.locals.length}`, { kind: "i32" });
+  // byteOffset (arg 0) → §24.2.1.1 GetViewValue: ToIndex(requestIndex) then the
+  // `getIndex + elementSize > viewByteLength` bounds check, both throwing
+  // RangeError BEFORE any access. Capture the f64 request, derive the i32
+  // getIndex (the *view-relative* index, before adding base), then guard.
+  const reqLocal = allocLocal(fctx, `__dvn_req_${fctx.locals.length}`, { kind: "f64" });
   if (args.length >= 1) {
     compileExpr(args[0]!, { kind: "f64" });
-    fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
   } else {
-    fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+    fctx.body.push({ op: "f64.const", value: 0 } as Instr);
   }
+  fctx.body.push({ op: "local.set", index: reqLocal });
+
+  const getIdxLocal = allocLocal(fctx, `__dvn_gidx_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: reqLocal } as Instr);
+  fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  fctx.body.push({ op: "local.set", index: getIdxLocal });
+
+  // throwCond = isNaN(req) || getIndex < 0 || getIndex + elementSize > viewLen.
+  //   - NaN request → ToIndex throws (trunc_sat(NaN)=0 would otherwise slip
+  //     through): `req != req`.
+  //   - negative index (e.g. -1): `getIndex < 0`.
+  //   - OOB / +Infinity (trunc_sat(+Inf)=i32.MAX): `getIndex + bytes > viewLen`
+  //     (computed in i64 so the +Infinity-saturated MAX + bytes can't overflow).
+  fctx.body.push({ op: "local.get", index: reqLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: reqLocal } as Instr);
+  fctx.body.push({ op: "f64.ne" } as Instr); // req != req  (NaN)
+  fctx.body.push({ op: "local.get", index: getIdxLocal } as Instr);
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "i32.lt_s" } as Instr); // getIndex < 0
+  fctx.body.push({ op: "i32.or" } as Instr);
+  // getIndex + bytes > viewLen, in i64 to avoid i32 overflow at i32.MAX.
+  fctx.body.push({ op: "local.get", index: getIdxLocal } as Instr);
+  fctx.body.push({ op: "i64.extend_i32_s" } as Instr);
+  fctx.body.push({ op: "i64.const", value: BigInt(acc.bytes) } as Instr);
+  fctx.body.push({ op: "i64.add" } as Instr);
+  fctx.body.push({ op: "local.get", index: viewLenLocal } as Instr);
+  fctx.body.push({ op: "i64.extend_i32_s" } as Instr);
+  fctx.body.push({ op: "i64.gt_s" } as Instr); // (getIndex + bytes) > viewLen
+  fctx.body.push({ op: "i32.or" } as Instr);
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: rangeThrow, else: [] } as Instr);
+
+  // Validated: off = getIndex + base (absolute byte in the shared buffer).
+  const offLocal = allocLocal(fctx, `__dvn_off_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: getIdxLocal } as Instr);
   fctx.body.push({ op: "local.get", index: baseLocal } as Instr);
   fctx.body.push({ op: "i32.add" } as Instr);
   fctx.body.push({ op: "local.set", index: offLocal });

--- a/tests/issue-2199-dataview-bounds.test.ts
+++ b/tests/issue-2199-dataview-bounds.test.ts
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2199 — standalone DataView accessor §24.2.1.1 bounds validation.
+ *
+ * Before this slice, the native DataView get/set accessors
+ * (`emitDataViewAccessor`, src/codegen/dataview-native.ts) computed
+ * `trunc(byteOffset) + base` and read/wrote the backing i32-byte array with NO
+ * argument validation. A negative / non-finite `byteOffset`, or one whose
+ * `getIndex + elementSize` exceeds the view's byte length, **trapped**
+ * `array element access out of bounds` (an uncatchable Wasm trap) instead of
+ * throwing the spec-mandated **RangeError** — failing the whole
+ * `built-ins/DataView/prototype/<accessor>/detached-buffer-after-toindex-byteoffset.js`
+ * cluster (~59 tests), which asserts `RangeError` from `getX(-1)` / `getX(Infinity)`.
+ *
+ * Fix (§24.2.1.1 GetViewValue / §24.2.1.2 SetViewValue): an additive guard
+ * prologue throws a catchable RangeError (the standalone-native in-module
+ * `__new_RangeError` via the shared `$exc` tag — zero host imports) when the
+ * request is NaN, the truncated index is negative, or
+ * `getIndex + elementSize > viewByteLength`. `recoverDvBacking` now also yields
+ * the view's byte length (window's `byteLength` field, or `array.len` of the
+ * bare backing). Valid accesses are byte-identical to before.
+ *
+ * Standalone native byte buffers don't marshal across the export boundary, so
+ * each case returns a number the test asserts directly.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runNum(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const labels = WebAssembly.Module.imports(mod).map((i) => `${i.module}::${i.name}`);
+  expect(
+    labels.filter((l) => !l.startsWith("wasi")),
+    "standalone module must have zero host imports",
+  ).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#2199 standalone DataView accessor bounds → RangeError", () => {
+  it("getFloat64(-1) throws RangeError, not an OOB trap", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const dv=new DataView(new ArrayBuffer(10)); try{ dv.getFloat64(-1); }catch(e){ return (e instanceof RangeError)?1:2; } return 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("getFloat64(Infinity) throws RangeError", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const dv=new DataView(new ArrayBuffer(10)); try{ dv.getFloat64(Infinity); }catch(e){ return (e instanceof RangeError)?1:2; } return 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("getUint8(100) past the end throws RangeError", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const dv=new DataView(new ArrayBuffer(8)); try{ dv.getUint8(100); }catch(e){ return (e instanceof RangeError)?1:2; } return 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("getInt32(5) on an 8-byte view (5+4>8) throws RangeError", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const dv=new DataView(new ArrayBuffer(8)); try{ dv.getInt32(5); }catch(e){ return (e instanceof RangeError)?1:2; } return 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("setUint8(-1, v) throws RangeError", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const dv=new DataView(new ArrayBuffer(4)); try{ dv.setUint8(-1, 5); }catch(e){ return (e instanceof RangeError)?1:2; } return 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("setFloat64(100, v) past the end throws RangeError", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const dv=new DataView(new ArrayBuffer(8)); try{ dv.setFloat64(100, 1.5); }catch(e){ return (e instanceof RangeError)?1:2; } return 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("windowed view: out-of-window access throws RangeError", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const ab=new ArrayBuffer(16); const dv=new DataView(ab,4,8); try{ dv.getFloat64(4); }catch(e){ return (e instanceof RangeError)?1:2; } return 0; }`,
+      ),
+    ).toBe(1);
+  });
+});
+
+describe("#2199 regression guards — valid DataView access unchanged", () => {
+  it("getInt32 at the exact last valid offset (4 on 8-byte) works", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const dv=new DataView(new ArrayBuffer(8)); dv.setInt32(4, 77); return dv.getInt32(4); }`,
+      ),
+    ).toBe(77);
+  });
+
+  it("setFloat64/getFloat64 round-trip", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const dv=new DataView(new ArrayBuffer(8)); dv.setFloat64(0, 3.5); return dv.getFloat64(0); }`,
+      ),
+    ).toBe(3.5);
+  });
+
+  it("getUint16 little-endian round-trip", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const dv=new DataView(new ArrayBuffer(4)); dv.setUint16(0, 0x1234, true); return dv.getUint16(0, true); }`,
+      ),
+    ).toBe(0x1234);
+  });
+
+  it("windowed view: valid read/write through the base offset", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const ab=new ArrayBuffer(16); const dv=new DataView(ab,4,8); dv.setFloat64(0, 9.5); return dv.getFloat64(0); }`,
+      ),
+    ).toBe(9.5);
+  });
+});


### PR DESCRIPTION
## Summary

On standalone (`--target wasi`), the native DataView `get*`/`set*` accessors
trapped `array element access out of bounds` (an **uncatchable** Wasm trap)
instead of throwing the spec-mandated **RangeError** for a negative / non-finite
`byteOffset`, or one whose `getIndex + elementSize` exceeds the view byte length:

```ts
const dv = new DataView(new ArrayBuffer(10));
dv.getFloat64(-1);        // TRAP  (should throw RangeError)
dv.getFloat64(Infinity);  // TRAP  (should throw RangeError)
dv.getInt32(8);           // 8+4>8 OOB: TRAP  (should throw RangeError)
```

This fails the whole `built-ins/DataView/prototype/<acc>/detached-buffer-after-toindex-byteoffset.js`
test262 cluster (~59 tests), which `assert.throws(RangeError, …)`.

## Root cause

`emitDataViewAccessor` (`src/codegen/dataview-native.ts`) computed
`trunc(byteOffset) + base` and immediately read/wrote the backing i32-byte array
with **no §24.2.1.1 GetViewValue / §24.2.1.2 SetViewValue argument validation**.

## Fix (additive, standalone-native, zero new host imports)

- **`emitDataViewRangeError(ctx)`** — builds a catchable RangeError throw via the
  shared `$exc` tag + the in-module `__new_RangeError` constructor
  (`emitWasiErrorConstructor` in no-JS-host mode), mirroring `native-regex.ts`'s
  `regexCapExhaustionThrow`. Pre-built + flushed **before** any operand compile so
  the late-import funcIdx shift can't corrupt later captures.
- **`recoverDvBacking`** gains a `viewLenLocal` out-param: the view's byte length
  (the `$__dv_window.byteLength` field for a windowed view, or `array.len(data)`
  for a bare offset-0 view).
- The accessor captures the **f64** request, derives
  `getIndex = i32.trunc_sat_f64_s(req)`, and throws RangeError when
  `isNaN(req) || getIndex < 0 || (getIndex + elementSize) > viewByteLength`
  (the last in i64 so `trunc_sat(+Infinity)=i32.MAX` can't overflow). **Valid
  accesses are byte-identical to before.**

### Known limitation (deferred — not in the targeted cluster)

For setters, §24.2.1.2 evaluates `ToNumber(value)` BEFORE the bounds throw; this
fix throws before compiling the setter value, so a `value` with observable side
effects is skipped on an out-of-bounds set. None of the targeted tests exercise
that ordering.

## Tests

`tests/issue-2199-dataview-bounds.test.ts` — **11/11 green** (`target: "standalone"`,
zero host imports asserted): get/set negative / Infinity / past-end / windowed
out-of-window all throw RangeError; regression guards (last-valid-offset,
round-trips, LE, windowed valid read/write) unchanged.

Existing DataView suites (issue-38-dataview-window, issue-2159, etc.) unchanged.
The 6 `arraybuffer-dataview.test.ts` failures are **pre-existing** (verified
identical on the pristine base). `check:ir-fallbacks` OK; `tsc` + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)