### PR TITLE
fix(#2199b): DataView setter runs ToNumber(value) before the bounds RangeError

### DIFF
--- a/plan/issues/2199-standalone-dataview-accessor-bounds.md
+++ b/plan/issues/2199-standalone-dataview-accessor-bounds.md
@@ -1,0 +1,86 @@
+---
+id: 2199
+title: "Standalone DataView accessor bounds validation — get/set must throw RangeError, not trap OOB"
+status: done
+sprint: 64
+created: 2026-06-18
+updated: 2026-06-18
+completed: 2026-06-18
+assignee: ttraenkler/sdev-iter
+priority: medium
+feasibility: medium
+reasoning_effort: high
+task_type: conformance
+area: standalone
+language_feature: dataview-arraybuffer
+goal: standalone-mode
+parent: 2159
+---
+
+# Standalone DataView accessor bounds validation
+
+## Problem
+
+On standalone (`--target wasi`), the native DataView accessors trap instead of
+throwing the spec-mandated **RangeError**:
+
+```ts
+const dv = new DataView(new ArrayBuffer(10));
+dv.getFloat64(-1);        // standalone: TRAP "array element access out of bounds"
+dv.getFloat64(Infinity);  // standalone: TRAP        (both should throw RangeError)
+dv.getInt32(8);           // 8+4>8 OOB: TRAP          (should throw RangeError)
+```
+
+A Wasm trap is uncatchable, so the test262
+`built-ins/DataView/prototype/<accessor>/detached-buffer-after-toindex-byteoffset.js`
+cluster (~59 tests) — which `assert.throws(RangeError, …)` on a negative /
+`Infinity` `byteOffset` — all fail.
+
+## Root cause
+
+`emitDataViewAccessor` (`src/codegen/dataview-native.ts`) computed
+`trunc(byteOffset) + base` and immediately read/wrote the backing i32-byte
+array with **no argument validation** — no `ToIndex` RangeError check and no
+`getIndex + elementSize > viewByteLength` bounds check.
+
+## Fix (§24.2.1.1 GetViewValue / §24.2.1.2 SetViewValue)
+
+Additive guard prologue in `emitDataViewAccessor`, all standalone-native (zero
+new host imports):
+
+- New `emitDataViewRangeError(ctx)` — builds a catchable RangeError throw via the
+  shared `$exc` tag + the in-module `__new_RangeError` constructor
+  (`emitWasiErrorConstructor` in no-JS-host mode), mirroring `native-regex.ts`'s
+  `regexCapExhaustionThrow`. Pre-built + flushed BEFORE any operand compile so the
+  late-import funcIdx shift doesn't corrupt later captures.
+- `recoverDvBacking` gains a `viewLenLocal` out-param: the view's byte length —
+  the `$__dv_window.byteLength` field for a windowed view, or `array.len(data)`
+  for a bare offset-0 view.
+- The accessor captures the **f64** request, derives `getIndex =
+  i32.trunc_sat_f64_s(req)`, and throws RangeError when
+  `isNaN(req) || getIndex < 0 || (getIndex + elementSize) > viewByteLength`
+  (the last computed in i64 so the `trunc_sat(+Infinity)=i32.MAX` case can't
+  overflow). Valid accesses are byte-identical to before.
+
+### Known limitation (out of scope)
+
+For **setters**, §24.2.1.2 evaluates `ToNumber(value)` BEFORE the bounds throw;
+this fix throws before compiling the setter value, so a `value` with observable
+side effects would be skipped on an out-of-bounds set. None of the targeted
+detached-buffer cluster tests exercise that ordering; deferred.
+
+## Test Results
+
+- `tests/issue-2199-dataview-bounds.test.ts` — 11/11 green (`target: "standalone"`,
+  zero host imports asserted): getFloat64(-1)/(Infinity), getUint8(100),
+  getInt32(5)-on-8, setUint8(-1), setFloat64(100), windowed out-of-window all
+  throw RangeError; regression guards — last-valid-offset, round-trips, LE,
+  windowed valid read/write — unchanged.
+- Existing DataView suites (issue-38-dataview-window, issue-2159,
+  arraybuffer-dataview, issue-1654-wasi-dataview-arraybuffer) — unchanged.
+- `pnpm run check:ir-fallbacks` — OK. `npx tsc --noEmit` clean.
+
+## Source
+
+Harvest of the standalone failure buckets (2026-06-18, sdev-iter): the DataView
+detached-buffer cluster's headline is the missing ToIndex/bounds RangeError.

--- a/plan/issues/2199-standalone-dataview-accessor-bounds.md
+++ b/plan/issues/2199-standalone-dataview-accessor-bounds.md
@@ -62,12 +62,21 @@ new host imports):
   (the last computed in i64 so the `trunc_sat(+Infinity)=i32.MAX` case can't
   overflow). Valid accesses are byte-identical to before.
 
-### Known limitation (out of scope)
+### Follow-ups
 
-For **setters**, §24.2.1.2 evaluates `ToNumber(value)` BEFORE the bounds throw;
-this fix throws before compiling the setter value, so a `value` with observable
-side effects would be skipped on an out-of-bounds set. None of the targeted
-detached-buffer cluster tests exercise that ordering; deferred.
+- **Setter `ToNumber(value)` ordering** — §24.2.1.2 evaluates `ToNumber(value)`
+  BEFORE the bounds throw; this PR threw before compiling the setter value, so a
+  side-effecting value was skipped on an out-of-bounds set. **Fixed in #2199b**
+  (split the guard into index-throw → value compile → bounds-throw).
+- **Detached-buffer TypeError (§24.2.1.1 step 7)** — NOT addressed here and a
+  separate, larger slice: standalone has **no detached-ArrayBuffer
+  representation** at all (`ArrayBuffer.prototype.transfer` does not detach the
+  source — `ab.byteLength` stays non-zero, no detached-flag exists). A
+  detached-TypeError guard would need (a) a detached-flag field on the
+  ArrayBuffer i32-byte vec struct, (b) `transfer()`/`$DETACHBUFFER` setting it,
+  (c) a TypeError guard in the accessor prologue (after ToIndex's RangeError).
+  The targeted `…-after-toindex-byteoffset` cluster does NOT exercise it (ToIndex
+  RangeError fires first), so it's intentionally left for a follow-up issue.
 
 ## Test Results
 

--- a/plan/issues/2199b-dataview-setter-operation-order.md
+++ b/plan/issues/2199b-dataview-setter-operation-order.md
@@ -1,0 +1,75 @@
+---
+id: 2199b
+title: "Standalone DataView setter operation order — ToNumber(value) before the bounds RangeError"
+status: done
+sprint: 64
+created: 2026-06-18
+updated: 2026-06-18
+completed: 2026-06-18
+assignee: ttraenkler/sdev-iter
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: conformance
+area: standalone
+language_feature: dataview-arraybuffer
+goal: standalone-mode
+parent: 2199
+depends_on: [2199]
+---
+
+# Standalone DataView setter operation order
+
+## Problem
+
+#2199 added a single combined bounds guard to the DataView accessors, but it
+threw the bounds RangeError **before** compiling the setter `value`. §24.2.1.2
+SetViewValue splits into two throw points around `ToNumber(value)`:
+
+```
+step 4  getIndex = ToIndex(byteOffset)               -> RangeError (index)  BEFORE value
+step 5  numberValue = ToNumber(value)                   (value.valueOf runs here)
+step 8  getIndex + elementSize > viewByteLength       -> RangeError (bounds) AFTER value
+```
+
+So an out-of-bounds set must still RUN the value's `valueOf` (and propagate a
+throw from it) before the bounds RangeError fires — ~35 standalone-failing
+test262 cases (`DataView/prototype/set*/{return-abrupt-from-tonumber-value,
+range-check-after-value-conversion,index-check-before-value-conversion,…}`).
+
+## Fix
+
+`emitDataViewAccessor` (`src/codegen/dataview-native.ts`) — split the single
+guard into `emitIndexThrow()` (NaN/negative, ToIndex) and `emitBoundsThrow()`
+(`getIndex + elementSize > viewLen`, i64 math). Order:
+
+- **Getter** (no value): `emitIndexThrow()` then `emitBoundsThrow()` adjacent
+  (byte-identical to #2199's combined behaviour).
+- **Setter**: `emitIndexThrow()` → compile `value` (+ `littleEndian`) →
+  `emitBoundsThrow()` → write. The value/littleEndian coercions now run their
+  side effects after the index check but before the bounds check, matching the
+  spec.
+
+Additive same-file reorder, zero new host imports.
+
+### Out of scope (pre-existing, verified on the #2199 base)
+
+- An object-literal value with a throwing `valueOf` (`dv.setInt16(0,
+  {valueOf(){throw}})`) hits a separate `expected f64` object→f64 coercion gap —
+  fails identically on the #2199 base, not introduced here.
+- BigInt setters (`setBigInt64`/`setBigUint64`) are an unsupported-feature gap.
+
+## Test Results
+
+- `tests/issue-2199b-dataview-setter-order.test.ts` — 8/8 green (`target:
+  "standalone"`, zero host imports): OOB-set runs value side-effect + still
+  throws RangeError; negative-index set throws WITHOUT running the value; valid
+  round-trips, last-valid-offset, getter-OOB, setter-OOB unchanged.
+- `tests/issue-2199-dataview-bounds.test.ts` (the #2199 parent) + DataView
+  regression suites — unchanged.
+- `pnpm run check:ir-fallbacks` OK; `tsc` + prettier clean.
+
+## Source
+
+Deferred edge from #2199 (the targeted detached-buffer cluster didn't exercise
+setter value-ordering); picked up as a same-file follow-up (2026-06-18, sdev-iter).

--- a/src/codegen/dataview-native.ts
+++ b/src/codegen/dataview-native.ts
@@ -473,45 +473,60 @@ export function emitDataViewAccessor(
   fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
   fctx.body.push({ op: "local.set", index: getIdxLocal });
 
-  // throwCond = isNaN(req) || getIndex < 0 || getIndex + elementSize > viewLen.
-  //   - NaN request → ToIndex throws (trunc_sat(NaN)=0 would otherwise slip
-  //     through): `req != req`.
-  //   - negative index (e.g. -1): `getIndex < 0`.
-  //   - OOB / +Infinity (trunc_sat(+Inf)=i32.MAX): `getIndex + bytes > viewLen`
-  //     (computed in i64 so the +Infinity-saturated MAX + bytes can't overflow).
-  fctx.body.push({ op: "local.get", index: reqLocal } as Instr);
-  fctx.body.push({ op: "local.get", index: reqLocal } as Instr);
-  fctx.body.push({ op: "f64.ne" } as Instr); // req != req  (NaN)
-  fctx.body.push({ op: "local.get", index: getIdxLocal } as Instr);
-  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
-  fctx.body.push({ op: "i32.lt_s" } as Instr); // getIndex < 0
-  fctx.body.push({ op: "i32.or" } as Instr);
-  // getIndex + bytes > viewLen, in i64 to avoid i32 overflow at i32.MAX.
-  fctx.body.push({ op: "local.get", index: getIdxLocal } as Instr);
-  fctx.body.push({ op: "i64.extend_i32_s" } as Instr);
-  fctx.body.push({ op: "i64.const", value: BigInt(acc.bytes) } as Instr);
-  fctx.body.push({ op: "i64.add" } as Instr);
-  fctx.body.push({ op: "local.get", index: viewLenLocal } as Instr);
-  fctx.body.push({ op: "i64.extend_i32_s" } as Instr);
-  fctx.body.push({ op: "i64.gt_s" } as Instr); // (getIndex + bytes) > viewLen
-  fctx.body.push({ op: "i32.or" } as Instr);
-  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: rangeThrow, else: [] } as Instr);
+  // (#2199b) The two §24.2.1.2 SetViewValue / §24.2.1.1 GetViewValue throws fire
+  // at DIFFERENT points relative to `ToNumber(value)` for a setter:
+  //   - INDEX throw (step 4, ToIndex): `isNaN(req) || getIndex < 0` — fires
+  //     BEFORE `ToNumber(value)` (test: index-check-before-value-conversion).
+  //   - BOUNDS throw (step 8): `getIndex + elementSize > viewByteLength` — fires
+  //     AFTER `ToNumber(value)` runs (test: range-check-after-value-conversion;
+  //     a `value` whose valueOf/Symbol throws must throw FIRST). i64 math so the
+  //     +Infinity-saturated `getIndex=i32.MAX` + bytes can't overflow.
+  const emitIndexThrow = (): void => {
+    fctx.body.push({ op: "local.get", index: reqLocal } as Instr);
+    fctx.body.push({ op: "local.get", index: reqLocal } as Instr);
+    fctx.body.push({ op: "f64.ne" } as Instr); // req != req  (NaN)
+    fctx.body.push({ op: "local.get", index: getIdxLocal } as Instr);
+    fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+    fctx.body.push({ op: "i32.lt_s" } as Instr); // getIndex < 0
+    fctx.body.push({ op: "i32.or" } as Instr);
+    fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: rangeThrow, else: [] } as Instr);
+  };
+  const emitBoundsThrow = (): void => {
+    fctx.body.push({ op: "local.get", index: getIdxLocal } as Instr);
+    fctx.body.push({ op: "i64.extend_i32_s" } as Instr);
+    fctx.body.push({ op: "i64.const", value: BigInt(acc.bytes) } as Instr);
+    fctx.body.push({ op: "i64.add" } as Instr);
+    fctx.body.push({ op: "local.get", index: viewLenLocal } as Instr);
+    fctx.body.push({ op: "i64.extend_i32_s" } as Instr);
+    fctx.body.push({ op: "i64.gt_s" } as Instr); // (getIndex + bytes) > viewLen
+    fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: rangeThrow, else: [] } as Instr);
+  };
 
-  // Validated: off = getIndex + base (absolute byte in the shared buffer).
+  // off = getIndex + base (absolute byte in the shared buffer). Computed after
+  // the bounds throw at each call site.
   const offLocal = allocLocal(fctx, `__dvn_off_${fctx.locals.length}`, { kind: "i32" });
-  fctx.body.push({ op: "local.get", index: getIdxLocal } as Instr);
-  fctx.body.push({ op: "local.get", index: baseLocal } as Instr);
-  fctx.body.push({ op: "i32.add" } as Instr);
-  fctx.body.push({ op: "local.set", index: offLocal });
+  const setOff = (): void => {
+    fctx.body.push({ op: "local.get", index: getIdxLocal } as Instr);
+    fctx.body.push({ op: "local.get", index: baseLocal } as Instr);
+    fctx.body.push({ op: "i32.add" } as Instr);
+    fctx.body.push({ op: "local.set", index: offLocal });
+  };
 
   if (acc.kind === "get") {
-    // littleEndian flag is the 2nd arg for getters (getUintN(off, le)).
+    // Getter has no value to convert, so both throws are adjacent (ToIndex then
+    // bounds), before the read. littleEndian is the 2nd arg.
+    emitIndexThrow();
+    emitBoundsThrow();
+    setOff();
     const leLocal = emitLittleEndianFlag(ctx, fctx, args[1], compileExpr);
     emitReadBytes(ctx, fctx, acc, arrLocal, offLocal, leLocal, arrTypeIdx);
     return { kind: "get", result: { kind: "f64" } };
   }
 
-  // Setter: value is arg 1, littleEndian is arg 2.
+  // Setter: ToIndex throw → ToNumber(value) (+littleEndian) → bounds throw →
+  // write. Compiling the value/le runs their valueOf/Symbol coercions, which can
+  // throw and MUST do so after the index check but before the bounds check.
+  emitIndexThrow();
   const valLocal = allocLocal(fctx, `__dvn_val_${fctx.locals.length}`, { kind: "f64" });
   if (args.length >= 2) {
     compileExpr(args[1]!, { kind: "f64" });
@@ -520,6 +535,8 @@ export function emitDataViewAccessor(
   }
   fctx.body.push({ op: "local.set", index: valLocal });
   const leLocal = emitLittleEndianFlag(ctx, fctx, args[2], compileExpr);
+  emitBoundsThrow();
+  setOff();
   emitWriteBytes(ctx, fctx, acc, arrLocal, offLocal, valLocal, leLocal, arrTypeIdx);
   return { kind: "set" };
 }

--- a/src/codegen/dataview-native.ts
+++ b/src/codegen/dataview-native.ts
@@ -28,7 +28,12 @@
 import type { Instr, ValType } from "../ir/types.js";
 import { allocLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { noJsHost } from "./expressions/helpers.js";
 import { getArrTypeIdxFromVec, getOrRegisterVecType } from "./index.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { emitWasiErrorConstructor } from "./registry/error-types.js";
+import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
+import { ensureLateImport, flushLateImportShifts } from "./shared.js";
 
 /** DataView accessor descriptor parsed from a method name like "getUint32". */
 interface DvAccessor {
@@ -308,6 +313,10 @@ function recoverDvBacking(
   baseLocal: number,
   vecTypeIdx: number,
   arrTypeIdx: number,
+  // (#2199) Optional: i32 local that receives the view's byte length (window's
+  // `byteLength` field for a windowed view; the backing array's `array.len` for
+  // a bare offset-0 view). Used by the §24.2.1.1 bounds check. Pass -1 to skip.
+  viewLenLocal = -1,
 ): boolean {
   const dvWinTypeIdx = getOrRegisterDvWindowType(ctx);
   // Normalize the receiver to an anyref-castable `(ref any)` on the stack.
@@ -335,6 +344,15 @@ function recoverDvBacking(
     { op: "struct.get", typeIdx: dvWinTypeIdx, fieldIdx: 1 } as Instr,
     { op: "local.set", index: baseLocal } as Instr,
   ];
+  if (viewLenLocal >= 0) {
+    // viewLen = (cast $__dv_window).byteLength
+    winBranch.push(
+      { op: "local.get", index: anyLocal } as Instr,
+      { op: "ref.cast", typeIdx: dvWinTypeIdx } as Instr,
+      { op: "struct.get", typeIdx: dvWinTypeIdx, fieldIdx: 2 } as Instr,
+      { op: "local.set", index: viewLenLocal } as Instr,
+    );
+  }
   const vecBranch: Instr[] = [
     // bare vec: arr = .data ; base = 0
     { op: "local.get", index: anyLocal } as Instr,
@@ -344,6 +362,14 @@ function recoverDvBacking(
     { op: "i32.const", value: 0 } as Instr,
     { op: "local.set", index: baseLocal } as Instr,
   ];
+  if (viewLenLocal >= 0) {
+    // viewLen = array.len(arr)  (offset-0 view spans the whole backing buffer)
+    vecBranch.push(
+      { op: "local.get", index: arrLocal } as Instr,
+      { op: "array.len" } as Instr,
+      { op: "local.set", index: viewLenLocal } as Instr,
+    );
+  }
   fctx.body.push({ op: "local.get", index: anyLocal } as Instr);
   fctx.body.push({ op: "ref.test", typeIdx: dvWinTypeIdx } as Instr);
   fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: winBranch, else: vecBranch } as Instr);
@@ -364,6 +390,35 @@ function recoverDvBacking(
  * `compileExpr`/`offsetArg`/`valueArg`/`leArg` are passed in so this module
  * stays decoupled from the big calls.ts dispatcher.
  */
+/** Message for the §24.2.1.1 GetViewValue / SetViewValue out-of-bounds throw. */
+const DV_RANGE_MESSAGE = "RangeError: Offset is outside the bounds of the DataView";
+
+/**
+ * (#2199) Build the instruction sequence for a DataView accessor bounds throw —
+ * a catchable `RangeError` instance via the shared `$exc` tag, mirroring
+ * `native-regex.ts`'s `regexCapExhaustionThrow`. §24.2.1.1 GetViewValue step 4/6
+ * (and SetViewValue): a negative / non-finite `byteOffset`, or
+ * `getIndex + elementSize > viewByteLength`, throws RangeError BEFORE the array
+ * access (which would otherwise trap `array element access out of bounds`).
+ *
+ * MUST be called BEFORE any later funcIdx is captured in the caller: in JS-host
+ * mode `ensureLateImport("__new_RangeError")` registers a host import (shifting
+ * every function index); in no-JS-host mode `emitWasiErrorConstructor` emits the
+ * in-module constructor (also a function push). Same ordering requirement as the
+ * regex cap-throw. The caller pre-builds this template before emitting the
+ * accessor body and flushes shifts.
+ */
+function emitDataViewRangeError(ctx: CodegenContext): Instr[] {
+  if (noJsHost(ctx)) emitWasiErrorConstructor(ctx, "RangeError", 1);
+  addStringConstantGlobal(ctx, DV_RANGE_MESSAGE);
+  const ctorIdx = ensureLateImport(ctx, "__new_RangeError", [{ kind: "externref" }], [{ kind: "externref" }]);
+  const tagIdx = ensureExnTag(ctx);
+  const instrs: Instr[] = [...stringConstantExternrefInstrs(ctx, DV_RANGE_MESSAGE)];
+  if (ctorIdx !== undefined) instrs.push({ op: "call", funcIdx: ctorIdx } as Instr);
+  instrs.push({ op: "throw", tagIdx } as Instr);
+  return instrs;
+}
+
 export function emitDataViewAccessor(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -378,26 +433,73 @@ export function emitDataViewAccessor(
   const { vecTypeIdx, arrTypeIdx } = i32ByteVec(ctx);
   if (arrTypeIdx < 0) return null;
 
+  // (#2199) Pre-build the §24.2.1.1 out-of-bounds RangeError template FIRST.
+  // `emitDataViewRangeError` registers `__new_RangeError` as a late import (and
+  // in no-JS-host mode emits the in-module constructor) — both push a function,
+  // shifting every funcIdx. Building + flushing it before any operand compile or
+  // backing-recovery keeps later funcIdx captures correct (same ordering rule as
+  // native-regex's cap-throw). When `dv.byteLength` is unavailable we skip the
+  // bounds check, so only register the template when we will emit it.
+  const rangeThrow = emitDataViewRangeError(ctx);
+  flushLateImportShifts(ctx, fctx);
+
   // Recover the i32_byte backing array AND the view's base byte offset from the
   // receiver. `dv` may be a `$__dv_window` wrapper (windowed view → base =
   // ctor byteOffset, sharing the parent's array) or a bare `$__vec_i32_byte`
-  // (offset-0 view / ArrayBuffer → base = 0). (#2159/#38)
+  // (offset-0 view / ArrayBuffer → base = 0). (#2159/#38). `viewLenLocal`
+  // receives the view's byte length for the #2199 bounds check.
   const arrLocal = allocLocal(fctx, `__dvn_arr_${fctx.locals.length}`, { kind: "ref", typeIdx: arrTypeIdx });
   const baseLocal = allocLocal(fctx, `__dvn_base_${fctx.locals.length}`, { kind: "i32" });
+  const viewLenLocal = allocLocal(fctx, `__dvn_vlen_${fctx.locals.length}`, { kind: "i32" });
   const recvType = compileExpr(receiver);
-  if (!recoverDvBacking(ctx, fctx, recvType, arrLocal, baseLocal, vecTypeIdx, arrTypeIdx)) {
+  if (!recoverDvBacking(ctx, fctx, recvType, arrLocal, baseLocal, vecTypeIdx, arrTypeIdx, viewLenLocal)) {
     return null;
   }
 
-  // byteOffset (arg 0) → i32 index, then add the view's base byte offset so a
-  // windowed accessor addresses the correct absolute byte in the shared buffer.
-  const offLocal = allocLocal(fctx, `__dvn_off_${fctx.locals.length}`, { kind: "i32" });
+  // byteOffset (arg 0) → §24.2.1.1 GetViewValue: ToIndex(requestIndex) then the
+  // `getIndex + elementSize > viewByteLength` bounds check, both throwing
+  // RangeError BEFORE any access. Capture the f64 request, derive the i32
+  // getIndex (the *view-relative* index, before adding base), then guard.
+  const reqLocal = allocLocal(fctx, `__dvn_req_${fctx.locals.length}`, { kind: "f64" });
   if (args.length >= 1) {
     compileExpr(args[0]!, { kind: "f64" });
-    fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
   } else {
-    fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+    fctx.body.push({ op: "f64.const", value: 0 } as Instr);
   }
+  fctx.body.push({ op: "local.set", index: reqLocal });
+
+  const getIdxLocal = allocLocal(fctx, `__dvn_gidx_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: reqLocal } as Instr);
+  fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  fctx.body.push({ op: "local.set", index: getIdxLocal });
+
+  // throwCond = isNaN(req) || getIndex < 0 || getIndex + elementSize > viewLen.
+  //   - NaN request → ToIndex throws (trunc_sat(NaN)=0 would otherwise slip
+  //     through): `req != req`.
+  //   - negative index (e.g. -1): `getIndex < 0`.
+  //   - OOB / +Infinity (trunc_sat(+Inf)=i32.MAX): `getIndex + bytes > viewLen`
+  //     (computed in i64 so the +Infinity-saturated MAX + bytes can't overflow).
+  fctx.body.push({ op: "local.get", index: reqLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: reqLocal } as Instr);
+  fctx.body.push({ op: "f64.ne" } as Instr); // req != req  (NaN)
+  fctx.body.push({ op: "local.get", index: getIdxLocal } as Instr);
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "i32.lt_s" } as Instr); // getIndex < 0
+  fctx.body.push({ op: "i32.or" } as Instr);
+  // getIndex + bytes > viewLen, in i64 to avoid i32 overflow at i32.MAX.
+  fctx.body.push({ op: "local.get", index: getIdxLocal } as Instr);
+  fctx.body.push({ op: "i64.extend_i32_s" } as Instr);
+  fctx.body.push({ op: "i64.const", value: BigInt(acc.bytes) } as Instr);
+  fctx.body.push({ op: "i64.add" } as Instr);
+  fctx.body.push({ op: "local.get", index: viewLenLocal } as Instr);
+  fctx.body.push({ op: "i64.extend_i32_s" } as Instr);
+  fctx.body.push({ op: "i64.gt_s" } as Instr); // (getIndex + bytes) > viewLen
+  fctx.body.push({ op: "i32.or" } as Instr);
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: rangeThrow, else: [] } as Instr);
+
+  // Validated: off = getIndex + base (absolute byte in the shared buffer).
+  const offLocal = allocLocal(fctx, `__dvn_off_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: getIdxLocal } as Instr);
   fctx.body.push({ op: "local.get", index: baseLocal } as Instr);
   fctx.body.push({ op: "i32.add" } as Instr);
   fctx.body.push({ op: "local.set", index: offLocal });

--- a/tests/issue-2199-dataview-bounds.test.ts
+++ b/tests/issue-2199-dataview-bounds.test.ts
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2199 — standalone DataView accessor §24.2.1.1 bounds validation.
+ *
+ * Before this slice, the native DataView get/set accessors
+ * (`emitDataViewAccessor`, src/codegen/dataview-native.ts) computed
+ * `trunc(byteOffset) + base` and read/wrote the backing i32-byte array with NO
+ * argument validation. A negative / non-finite `byteOffset`, or one whose
+ * `getIndex + elementSize` exceeds the view's byte length, **trapped**
+ * `array element access out of bounds` (an uncatchable Wasm trap) instead of
+ * throwing the spec-mandated **RangeError** — failing the whole
+ * `built-ins/DataView/prototype/<accessor>/detached-buffer-after-toindex-byteoffset.js`
+ * cluster (~59 tests), which asserts `RangeError` from `getX(-1)` / `getX(Infinity)`.
+ *
+ * Fix (§24.2.1.1 GetViewValue / §24.2.1.2 SetViewValue): an additive guard
+ * prologue throws a catchable RangeError (the standalone-native in-module
+ * `__new_RangeError` via the shared `$exc` tag — zero host imports) when the
+ * request is NaN, the truncated index is negative, or
+ * `getIndex + elementSize > viewByteLength`. `recoverDvBacking` now also yields
+ * the view's byte length (window's `byteLength` field, or `array.len` of the
+ * bare backing). Valid accesses are byte-identical to before.
+ *
+ * Standalone native byte buffers don't marshal across the export boundary, so
+ * each case returns a number the test asserts directly.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runNum(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const labels = WebAssembly.Module.imports(mod).map((i) => `${i.module}::${i.name}`);
+  expect(
+    labels.filter((l) => !l.startsWith("wasi")),
+    "standalone module must have zero host imports",
+  ).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#2199 standalone DataView accessor bounds → RangeError", () => {
+  it("getFloat64(-1) throws RangeError, not an OOB trap", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const dv=new DataView(new ArrayBuffer(10)); try{ dv.getFloat64(-1); }catch(e){ return (e instanceof RangeError)?1:2; } return 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("getFloat64(Infinity) throws RangeError", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const dv=new DataView(new ArrayBuffer(10)); try{ dv.getFloat64(Infinity); }catch(e){ return (e instanceof RangeError)?1:2; } return 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("getUint8(100) past the end throws RangeError", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const dv=new DataView(new ArrayBuffer(8)); try{ dv.getUint8(100); }catch(e){ return (e instanceof RangeError)?1:2; } return 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("getInt32(5) on an 8-byte view (5+4>8) throws RangeError", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const dv=new DataView(new ArrayBuffer(8)); try{ dv.getInt32(5); }catch(e){ return (e instanceof RangeError)?1:2; } return 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("setUint8(-1, v) throws RangeError", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const dv=new DataView(new ArrayBuffer(4)); try{ dv.setUint8(-1, 5); }catch(e){ return (e instanceof RangeError)?1:2; } return 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("setFloat64(100, v) past the end throws RangeError", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const dv=new DataView(new ArrayBuffer(8)); try{ dv.setFloat64(100, 1.5); }catch(e){ return (e instanceof RangeError)?1:2; } return 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("windowed view: out-of-window access throws RangeError", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const ab=new ArrayBuffer(16); const dv=new DataView(ab,4,8); try{ dv.getFloat64(4); }catch(e){ return (e instanceof RangeError)?1:2; } return 0; }`,
+      ),
+    ).toBe(1);
+  });
+});
+
+describe("#2199 regression guards — valid DataView access unchanged", () => {
+  it("getInt32 at the exact last valid offset (4 on 8-byte) works", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const dv=new DataView(new ArrayBuffer(8)); dv.setInt32(4, 77); return dv.getInt32(4); }`,
+      ),
+    ).toBe(77);
+  });
+
+  it("setFloat64/getFloat64 round-trip", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const dv=new DataView(new ArrayBuffer(8)); dv.setFloat64(0, 3.5); return dv.getFloat64(0); }`,
+      ),
+    ).toBe(3.5);
+  });
+
+  it("getUint16 little-endian round-trip", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const dv=new DataView(new ArrayBuffer(4)); dv.setUint16(0, 0x1234, true); return dv.getUint16(0, true); }`,
+      ),
+    ).toBe(0x1234);
+  });
+
+  it("windowed view: valid read/write through the base offset", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const ab=new ArrayBuffer(16); const dv=new DataView(ab,4,8); dv.setFloat64(0, 9.5); return dv.getFloat64(0); }`,
+      ),
+    ).toBe(9.5);
+  });
+});

--- a/tests/issue-2199b-dataview-setter-order.test.ts
+++ b/tests/issue-2199b-dataview-setter-order.test.ts
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2199b — standalone DataView setter operation order (§24.2.1.2 SetViewValue).
+ *
+ * #2199 added a single combined bounds guard that threw the RangeError BEFORE
+ * compiling the setter `value`. But §24.2.1.2 splits into two throw points
+ * around `ToNumber(value)`:
+ *
+ *   step 4  ToIndex(byteOffset)          -> RangeError (index check) — BEFORE value
+ *   step 5  numberValue = ToNumber(value)            (value's valueOf runs here)
+ *   step 8  getIndex + elementSize > viewByteLength -> RangeError — AFTER value
+ *
+ * So `dv.setInt16(100, sideEffectingValue)` on an 8-byte view must still RUN the
+ * value's `valueOf` (and propagate a throw from it) before the bounds RangeError
+ * fires (test262 `range-check-after-value-conversion` /
+ * `return-abrupt-from-tonumber-value`), while `dv.setInt16(-1, …)` must throw the
+ * index RangeError WITHOUT running the value's `valueOf`
+ * (`index-check-before-value-conversion`).
+ *
+ * This slice splits the guard: the NaN/negative INDEX throw stays before the
+ * value compile; the BOUNDS throw moves after it. Getters (no value) keep both
+ * throws adjacent. Same file, additive reorder, zero new host imports.
+ *
+ * Standalone native byte buffers don't marshal across the export boundary, so
+ * each case returns a number the test asserts directly. (The side-effect is
+ * observed via a module-level counter the setter's value expression bumps; a
+ * throwing `valueOf` object literal as the setter value hits a separate,
+ * pre-existing object->f64 coercion limitation and is out of scope here.)
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runNum(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const labels = WebAssembly.Module.imports(mod).map((i) => `${i.module}::${i.name}`);
+  expect(
+    labels.filter((l) => !l.startsWith("wasi")),
+    "standalone module must have zero host imports",
+  ).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#2199b standalone DataView setter ToNumber-vs-bounds order", () => {
+  it("out-of-bounds set still runs the value's valueOf (range check after conversion)", async () => {
+    // A function-call value expression with an observable side effect; the side
+    // effect must run even though the offset is out of bounds.
+    expect(
+      await runNum(
+        `let ran = 0;
+         function v(): number { ran = 1; return 7; }
+         export function test(): number {
+           const dv = new DataView(new ArrayBuffer(8));
+           try { dv.setInt16(100, v()); } catch (e) {}
+           return ran;
+         }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("out-of-bounds set still throws RangeError after the value runs", async () => {
+    expect(
+      await runNum(
+        `function v(): number { return 7; }
+         export function test(): number {
+           const dv = new DataView(new ArrayBuffer(8));
+           try { dv.setInt16(100, v()); } catch (e) { return e instanceof RangeError ? 1 : 2; }
+           return 0;
+         }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("negative-index set throws the index RangeError WITHOUT running the value (index check first)", async () => {
+    expect(
+      await runNum(
+        `let ran = 0;
+         function v(): number { ran = 1; return 7; }
+         export function test(): number {
+           const dv = new DataView(new ArrayBuffer(8));
+           try { dv.setInt16(-1, v()); } catch (e) {}
+           return ran;
+         }`,
+      ),
+    ).toBe(0);
+  });
+
+  it("negative-index set throws RangeError", async () => {
+    expect(
+      await runNum(
+        `export function test(): number {
+           const dv = new DataView(new ArrayBuffer(8));
+           try { dv.setInt16(-1, 5); } catch (e) { return e instanceof RangeError ? 1 : 2; }
+           return 0;
+         }`,
+      ),
+    ).toBe(1);
+  });
+});
+
+describe("#2199b regression guards — valid + getter paths unchanged", () => {
+  it("valid setInt32/getInt32 round-trip", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const dv=new DataView(new ArrayBuffer(8)); dv.setInt32(0, 123); return dv.getInt32(0); }`,
+      ),
+    ).toBe(123);
+  });
+
+  it("valid setFloat64 at the last valid offset", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const dv=new DataView(new ArrayBuffer(16)); dv.setFloat64(8, 2.5); return dv.getFloat64(8); }`,
+      ),
+    ).toBe(2.5);
+  });
+
+  it("getter out-of-bounds still throws RangeError (#2199 unchanged)", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const dv=new DataView(new ArrayBuffer(8)); try{ dv.getInt32(100); }catch(e){ return e instanceof RangeError?1:2; } return 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("setter out-of-bounds (in-bounds value) throws RangeError", async () => {
+    expect(
+      await runNum(
+        `export function test(): number { const dv=new DataView(new ArrayBuffer(8)); try{ dv.setUint8(100, 5); }catch(e){ return e instanceof RangeError?1:2; } return 0; }`,
+      ),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #2199 (PR #1715). §24.2.1.2 SetViewValue throws at **two** points
around `ToNumber(value)`:

```
step 4  getIndex = ToIndex(byteOffset)          -> RangeError (index)  BEFORE value
step 5  numberValue = ToNumber(value)              (value.valueOf runs here)
step 8  getIndex + elementSize > viewByteLength  -> RangeError (bounds) AFTER value
```

#2199 added a single combined guard that threw the bounds RangeError **before**
compiling the setter `value`, so an out-of-bounds set skipped the value's
`valueOf` side effects (and a throw from it). ~35 standalone test262 cases fail:
`DataView/prototype/set*/{range-check-after-value-conversion,
return-abrupt-from-tonumber-value,index-check-before-value-conversion}`.

## Fix

`emitDataViewAccessor` (`src/codegen/dataview-native.ts`) — split the guard into
`emitIndexThrow()` (NaN / negative, ToIndex) and `emitBoundsThrow()`
(`getIndex + elementSize > viewByteLength`, i64 math):

- **Getter** (no value): both throws stay adjacent — byte-identical to #2199.
- **Setter**: `emitIndexThrow()` → compile `value` (+ `littleEndian`) →
  `emitBoundsThrow()` → write. Value/littleEndian coercions now run after the
  index check but before the bounds check, matching the spec.

Additive same-file reorder, zero new host imports.

### Out of scope (pre-existing, verified identical on the #2199 base)

- An object-literal value with a throwing `valueOf` hits a separate `expected
  f64` object→f64 coercion gap (not introduced here).
- BigInt setters (`setBigInt64`/`setBigUint64`) — unsupported-feature gap.

## Tests

`tests/issue-2199b-dataview-setter-order.test.ts` — **8/8 green** (`target:
"standalone"`, zero host imports): OOB-set runs the value side-effect AND still
throws RangeError; negative-index set throws WITHOUT running the value; valid
round-trips / last-valid-offset / getter-OOB / setter-OOB unchanged.

The #2199 bounds suite + DataView regression suites unchanged (42/42).
`check:ir-fallbacks` OK; `tsc` + prettier clean.

> Stacked on #1715 (#2199) — same file. The shared #2199 commit deduplicates
> once #1715 lands; this PR's net delta is the setter reorder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)