### PR TITLE
feat(#2169c): host-free Array.from(iterable) via native __iterator drain

### DIFF
--- a/plan/issues/2169b-arrayfrom-native-iterator-driver.md
+++ b/plan/issues/2169b-arrayfrom-native-iterator-driver.md
@@ -1,10 +1,11 @@
 ---
 id: 2169b
 title: "Standalone Array.from(<native array iterator>) — __iterator driver struct.new index desync (invalid struct index)"
-status: in-progress
+status: done
 sprint: 64
 created: 2026-06-18
 updated: 2026-06-18
+completed: 2026-06-18
 assignee: ttraenkler/sdev-iter
 priority: medium
 feasibility: hard
@@ -37,54 +38,55 @@ driver, which is where the break is. **Not entries-specific** — `.values()` /
 `.keys()` fail identically (the index differs only because entries registers
 extra `$ObjVec` types).
 
-## Root cause (fully traced, reproducible)
+## Root cause (CONFIRMED — shared-array aliasing → DCE double-remap)
 
-The `__iterator(obj)` native body (`src/codegen/iterator-native.ts`
-`buildIteratorBody`) builds `$IterRec` via `struct.new <iterRecTypeIdx>`, nested
-inside the `ref.test $Vec` `if`/`then` + `else` arms. The emitted body's
-`struct.new` operand **desyncs from the `$__IterRec` type-def's final index**:
+`buildIteratorBody` (`src/codegen/iterator-native.ts`) returns the `__iterator`
+body as `{ op:"if", then: vecArm, else: elseArm }`, and on the vec-only
+registration path (`deps === undefined`, the body that ships for `Array.from`)
+`elseArm = vecArm` — **the SAME `Instr[]` array object**, so the SAME
+`struct.new $__IterRec` instruction object is referenced by BOTH `then` and
+`else`.
 
-Single-compile trace (`Array.from(a.values())`):
+DCE (`eliminateDeadImports`) removes dead types and mutates each function body
+**in place** via `remapTypeIdxInBody` (`dead-elimination.ts`). Its walk visits the
+shared `struct.new` instruction TWICE (once via `then`, once via `else`) and
+applies the type remap each time. The remap table `tR` happens to contain a
+CHAIN — `46→40` AND `40→34` — so the two in-place applications compose:
+`46 → tR.get(46)=40 → tR.get(40)=34`. The body lands at `struct.new 34`
+(`$__box_boolean_struct`, a 1-field struct) while the `$__IterRec` type-def —
+remapped once via `surv.map(remapTD)` reading the original — correctly lands at
+`40`(/32 after later compaction). V8: `invalid struct index` (4 fields pushed at
+a 1-field struct).
 
-- **Registration** (`getOrRegisterIterRecType`): `$__IterRec` pushed at type idx
-  **46**; `buildIteratorBody` emits `struct.new 46` (×2, in the then/else arms).
-- **DCE** (`eliminateDeadImports`, the type-DCE half): builds `tR` mapping
-  46→**40**; `surv` places `$__IterRec` at pos **40**. Body remapped to
-  `struct.new 40`. **Internally consistent at this point (40 / 40).**
-- **Final emitted module**: `$__IterRec` type-def at idx **32**, but the
-  `__iterator` body emits `struct.new 34` → V8 `invalid struct index: 34` (type
-  34 is `$__box_boolean_struct`, a 1-field struct; the body pushes 4 fields).
+Object-identity probe (single compile, body tagged): DCE-entry body=`[46,46]`,
+`tR.get(46)=40`, `tR.get(40)=34`; SAME body object after DCE's loop=`[34,34]`;
+emit=same body, `[34,34]`. Confirms one shared array, double-applied.
 
-So a **SECOND type renumbering happens AFTER DCE** (between DCE-end and binary
-emit) that moves the `$__IterRec` type-def 40→32 (−8) but the body's nested
-`struct.new` 40→34 (−6). The −8/−6 split = a renumber that drops 8 dead types
-before `$__IterRec` but only re-remaps the body by −6 — i.e. the second
-renumbering does NOT consistently re-remap the `__iterator` body's nested
-`struct.new` operands. (DCE itself runs exactly once and is consistent; the
-desync is downstream of it.)
+This is the [[reference_no_rebuild_helper_body_at_finalize]] family. The
+**localized** fix (what this PR does): a `buildVecArm()` factory so `then` and the
+`deps===undefined` `else` each get a FRESH array + FRESH `struct.new` object —
+DCE then walks two distinct instructions, each remapped exactly once. Non-iterator
+paths are WAT-byte-identical (the change only differs where the chained-remap type
+shape exists). `buildIteratorNextBody`'s `vecStep` is NOT aliased (its `...vecStep`
+spread and `else: vecStep` are mutually-exclusive `!deps` branches), so no fix
+needed there.
 
-**Pass-bisect results (env-gating each finalize-tail pass):** disabling
-`peepholeOptimize` alone, `repairStructTypeMismatches` alone, and BOTH together
-ALL still VFAIL `invalid struct index: 34` — so the body's `struct.new` operand
-is **already wrong (34) before either pass runs**, i.e. the desync is produced
-**inside `eliminateDeadImports` (DCE) itself**, not downstream. (An earlier
-single-snapshot read suggested DCE left it consistent at 40/40, but the
-pass-gating disproves a post-DCE culprit — the inconsistency is in DCE's remap of
-the `__iterator` body vs the `$__IterRec` type-def. The `tR` remap is applied to
-both `mod.types` (line 353) and each body via `remapTypeIdxInBody` (359), so the
-divergence implies the `__iterator` body the remap walks is NOT the same body
-that ships — a likely body-aliasing / savedBody-swap issue where the iterator
-carrier body was rebuilt at finalize-fill into a NEW array that DCE's
-walk-and-mutate either missed or double-applied.) Next step: log `tR.get(46)`
-AND the identity (object ref) of the `__iterator` function's body array at DCE
-entry vs at emit — confirm they're the same array; if the finalize USER-arm fill
-(`fillNativeIteratorUserArms`) or the vec-only registration left a stale body
-reference, DCE remaps one copy while emit serializes the other.
+**Latent root hazard (flagged separately, NOT fixed here):**
+`remapTypeIdxInBody`'s in-place chained remap is non-idempotent — ANY aliased
+body double-remaps. The durable fix is to make the DCE body remap idempotent
+(skip an instruction already mapped this pass), but that changes the global DCE
+remap contract → architect-routed follow-on, not this PR.
 
-This is the [[reference_subview_type_idx_stability]] /
-[[reference_no_rebuild_helper_body_at_finalize]] family — a shared-helper
-type-index-stability invariant, NOT a one-arm fix. Blast radius: any helper body
-with a `struct.new`/`struct.get` whose type-def survives a post-DCE renumber.
+## Honest scope (this PR)
+
+The de-alias **fixes the `__iterator` driver miscompile** (the VALIDATE-FAIL).
+It is byte-identical elsewhere and unblocks the native-iterator path. It does
+**NOT** by itself make `Array.from(<native iterator>)` zero-host: once the driver
+validates, `Array.from(iter)` routes through the `__array_from` **host import**
+(`index.ts:1626`, "host `Array.from`"). Making standalone
+`Array.from(<native iterator>)` zero-host needs a **native `__array_from`** that
+drains the now-valid `__iterator` — a separate, larger producer slice (the
+original #2169 scope; dev-typed's stale claim). Filed as the follow-on.
 
 ## Scope
 

--- a/plan/issues/2169b-arrayfrom-native-iterator-driver.md
+++ b/plan/issues/2169b-arrayfrom-native-iterator-driver.md
@@ -1,0 +1,109 @@
+---
+id: 2169b
+title: "Standalone Array.from(<native array iterator>) — __iterator driver struct.new index desync (invalid struct index)"
+status: in-progress
+sprint: 64
+created: 2026-06-18
+updated: 2026-06-18
+assignee: ttraenkler/sdev-iter
+priority: medium
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: codegen
+language_feature: iterators-collections
+goal: standalone-mode
+parent: 2169
+---
+
+# Standalone `Array.from(<native array iterator>)` — `__iterator` struct.new index desync
+
+## Problem
+
+On standalone (`--target wasi`), `Array.from(x)` over **any native array
+iterator** VALIDATE-FAILs:
+
+```ts
+Array.from([10, 20].values()); // VFAIL: __iterator failed: invalid struct index: 34
+Array.from([10, 20].keys()); // VFAIL: invalid struct index: 34
+Array.from([10, 20].entries()); // VFAIL: invalid struct index: 37
+Array.from([10, 20]); // OK (plain array — does not go through __iterator)
+Array.from(new Set([7])); // separate VFAIL: struct.new need 4 got 2 (Set path — out of scope, #2162)
+```
+
+`[...arr.values()]` array-spread is fine (#2162b path); only the `Array.from`
+consumer routes the canonical externref `$Vec` through the native `__iterator`
+driver, which is where the break is. **Not entries-specific** — `.values()` /
+`.keys()` fail identically (the index differs only because entries registers
+extra `$ObjVec` types).
+
+## Root cause (fully traced, reproducible)
+
+The `__iterator(obj)` native body (`src/codegen/iterator-native.ts`
+`buildIteratorBody`) builds `$IterRec` via `struct.new <iterRecTypeIdx>`, nested
+inside the `ref.test $Vec` `if`/`then` + `else` arms. The emitted body's
+`struct.new` operand **desyncs from the `$__IterRec` type-def's final index**:
+
+Single-compile trace (`Array.from(a.values())`):
+
+- **Registration** (`getOrRegisterIterRecType`): `$__IterRec` pushed at type idx
+  **46**; `buildIteratorBody` emits `struct.new 46` (×2, in the then/else arms).
+- **DCE** (`eliminateDeadImports`, the type-DCE half): builds `tR` mapping
+  46→**40**; `surv` places `$__IterRec` at pos **40**. Body remapped to
+  `struct.new 40`. **Internally consistent at this point (40 / 40).**
+- **Final emitted module**: `$__IterRec` type-def at idx **32**, but the
+  `__iterator` body emits `struct.new 34` → V8 `invalid struct index: 34` (type
+  34 is `$__box_boolean_struct`, a 1-field struct; the body pushes 4 fields).
+
+So a **SECOND type renumbering happens AFTER DCE** (between DCE-end and binary
+emit) that moves the `$__IterRec` type-def 40→32 (−8) but the body's nested
+`struct.new` 40→34 (−6). The −8/−6 split = a renumber that drops 8 dead types
+before `$__IterRec` but only re-remaps the body by −6 — i.e. the second
+renumbering does NOT consistently re-remap the `__iterator` body's nested
+`struct.new` operands. (DCE itself runs exactly once and is consistent; the
+desync is downstream of it.)
+
+**Pass-bisect results (env-gating each finalize-tail pass):** disabling
+`peepholeOptimize` alone, `repairStructTypeMismatches` alone, and BOTH together
+ALL still VFAIL `invalid struct index: 34` — so the body's `struct.new` operand
+is **already wrong (34) before either pass runs**, i.e. the desync is produced
+**inside `eliminateDeadImports` (DCE) itself**, not downstream. (An earlier
+single-snapshot read suggested DCE left it consistent at 40/40, but the
+pass-gating disproves a post-DCE culprit — the inconsistency is in DCE's remap of
+the `__iterator` body vs the `$__IterRec` type-def. The `tR` remap is applied to
+both `mod.types` (line 353) and each body via `remapTypeIdxInBody` (359), so the
+divergence implies the `__iterator` body the remap walks is NOT the same body
+that ships — a likely body-aliasing / savedBody-swap issue where the iterator
+carrier body was rebuilt at finalize-fill into a NEW array that DCE's
+walk-and-mutate either missed or double-applied.) Next step: log `tR.get(46)`
+AND the identity (object ref) of the `__iterator` function's body array at DCE
+entry vs at emit — confirm they're the same array; if the finalize USER-arm fill
+(`fillNativeIteratorUserArms`) or the vec-only registration left a stale body
+reference, DCE remaps one copy while emit serializes the other.
+
+This is the [[reference_subview_type_idx_stability]] /
+[[reference_no_rebuild_helper_body_at_finalize]] family — a shared-helper
+type-index-stability invariant, NOT a one-arm fix. Blast radius: any helper body
+with a `struct.new`/`struct.get` whose type-def survives a post-DCE renumber.
+
+## Scope
+
+In scope: `Array.from(<native array iterator>)` (`.values()`/`.keys()`/
+`.entries()`). Out of scope: `Array.from(new Set(...))` (Set producer, separate
+`struct.new need 4 got 2` bug → #2162 Map/Set lane); the Map-iterator producer
+(`[...m.entries()]`/bare `[...map]`, #2162 / task #8).
+
+## Regression-guard strategy (REQUIRED, before AND after)
+
+- WAT-diff a plain `Array.from([1,2])` (the non-iterator path) byte-identical.
+- Full local iterator/spread/destructure suites (issue-2169-_, issue-42-_,
+  for-of-\*, basic/array-rest-destructuring).
+- `pnpm run check:ir-fallbacks` OK. Hard floor-gate the standalone HW shard.
+- Helpers BY NAME (#2191). No funcIdx captured before a later import-adding phase.
+
+## Source
+
+Root-caused 2026-06-18 (sdev-iter), filed as a distinct issue from the landed
+#2169 native-array-iterator slice (whose dev-typed claim is stale: no remote
+branch, no PR). This is a separate `__iterator`-driver type-index desync, not the
+#2169 producer work.

--- a/plan/issues/2169c-native-array-from.md
+++ b/plan/issues/2169c-native-array-from.md
@@ -1,0 +1,71 @@
+---
+id: 2169c
+title: "Standalone host-free Array.from(iterable) — drain via native __iterator instead of __array_from host import"
+status: done
+sprint: 64
+created: 2026-06-18
+updated: 2026-06-18
+completed: 2026-06-18
+assignee: ttraenkler/sdev-iter
+priority: medium
+feasibility: medium
+task_type: feature
+area: codegen
+language_feature: iterators-collections
+goal: standalone-mode
+parent: 2169
+depends_on: [2169b]
+---
+
+# Standalone host-free `Array.from(iterable)`
+
+## Problem
+
+`Array.from(x)` (no mapFn) over any iterable lowered to the `env::__array_from`
+JS-host import (`calls.ts`, the "Fallback: Array.from(externref/iterable)"
+branch). Standalone (`--target wasi`) has no JS host, so the binary pulled an
+import a hostless runtime can't satisfy. This is the producer half of #2169
+(the `__iterator` driver miscompile was fixed first in #2169b).
+
+## Fix
+
+When `noJsHost(ctx)` and there is no mapFn, drain the iterable natively instead
+of calling the host import:
+
+- `ensureNativeIteratorRuntime(ctx)` registers the native `__iterator` /
+  `__iterator_rest` funcs (standalone).
+- `__iterator(arg)` wraps the arg into an `$IterRec`; `__iterator_rest(rec)`
+  drains the remainder into a canonical externref `$Vec` — exactly the value the
+  host `__array_from` returned, host-free. (The drain reuses the same `$Vec`
+  runtime the for-of / spread consumers already use.)
+
+`Array.from(iter, mapFn)` is NOT handled natively (needs closure dispatch) and
+still delegates to the host path. The branch is `noJsHost`-gated, so JS-host mode
+is byte-identical/unchanged.
+
+**Depends on #2169b** — the native `__iterator` driver had a `struct.new`
+type-index miscompile (shared-arm aliasing → DCE double-remap); without that fix
+the drain would VFAIL. This work is built on the #2169b branch.
+
+## Verified (zero host imports, correct values)
+
+- `Array.from(arr.values())` / `.keys()` / `.entries()` — drained correctly.
+- `Array.from(generator)` — 33.
+- `Array.from(plain array)` — 37.
+- `Array.from("abc")` — strings are iterable, drained natively (bonus).
+- host-mode `Array.from` unchanged (still delegates, `noJsHost`-gated).
+- IR fallback gate OK. Test: `tests/issue-2169c-native-array-from.test.ts` (5/5).
+
+## Out of scope
+
+- `Array.from(new Set(...))` VFAILs with a separate Set-iterator producer bug
+  (`struct.new need 4 got 2` — confirmed pre-existing on the #2169b base, not
+  introduced here). Tracked under #2162 (Map/Set lane).
+- `Array.from(iter, mapFn)` native lowering (closure dispatch) — host-delegated
+  follow-on.
+
+## Source
+
+Built 2026-06-18 (sdev-iter) as the #2169 producer follow-on to #2169b, per
+tech-lead direction. Filed as a distinct issue (the #2169 claim was stale: no
+remote branch, no PR).

--- a/plan/issues/2370-dce-remap-non-idempotent-aliased-body.md
+++ b/plan/issues/2370-dce-remap-non-idempotent-aliased-body.md
@@ -1,0 +1,78 @@
+---
+id: 2370
+title: "[ARCH] DCE remapTypeIdxInBody is non-idempotent — any aliased helper body double-remaps (latent miscompile)"
+status: ready
+sprint: Backlog
+created: 2026-06-18
+assignee: ""
+priority: medium
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: codegen
+language_feature: codegen-infra
+goal: standalone-mode
+---
+
+# DCE `remapTypeIdxInBody` is non-idempotent — aliased bodies double-remap
+
+## Problem (latent landmine)
+
+`eliminateDeadImports` (`src/codegen/dead-elimination.ts`) removes dead types and
+remaps surviving type indices. It mutates each function body **in place** via
+`remapTypeIdxInBody(func.body, tR)` (`walkInstructions` + `a.typeIdx = tR.get(...)`).
+
+The remap is **non-idempotent**: it rewrites `a.typeIdx` to `tR.get(a.typeIdx)`
+without marking the instruction as already-mapped. When the remap table `tR`
+contains a CHAIN — e.g. `46→40` AND `40→34` (common: both 46 and 40 are live old
+indices that compact to different new positions) — and an instruction object is
+reachable **more than once** in the body walk, the rewrite composes:
+`46 → 40 → 34`. The instruction ends at the wrong type index while the type-def
+(remapped once via `surv.map(remapTD)`, which reads the original `td`) lands
+correctly. Result: `invalid struct index` / wrong-type miscompile.
+
+**Confirmed instance (#2169b):** `buildIteratorBody` aliased one `vecArm`
+`Instr[]` into BOTH the `if`'s `then` and `else` (`elseArm = vecArm` on the
+vec-only path), so its shared `struct.new $__IterRec` was walked twice and
+double-remapped `46→40→34` (34 = `$__box_boolean_struct`), breaking
+`Array.from(<native iterator>)`. That instance was fixed _locally_ (de-alias the
+arm — distinct instruction objects per branch). But the DCE pass itself is still
+non-idempotent, so **any** helper whose body aliases an instruction object across
+two reachable positions is a latent double-remap waiting to trigger whenever the
+type-table shape produces a chained `tR`.
+
+## Why this is architect-scale
+
+The durable fix changes the **global DCE remap contract**, not one helper:
+make `remapTypeIdxInBody` idempotent so a chained `tR` + any aliasing is safe.
+That touches every body the pass rewrites. Options:
+
+1. **Idempotent remap (recommended):** build `tR` so it is NOT chained — i.e.
+   compute the new index for each old index directly against the _original_
+   numbering (a single old→new map with no transitive composition), and/or apply
+   the map by **rebuilding** each instruction's `typeIdx` from a snapshot of the
+   pre-remap value rather than reading the possibly-already-mutated field. Since
+   `tR` is built old→new in one pass (`surv` enumeration), the chain only bites
+   when an instruction is VISITED twice — so the minimal robust fix is to ensure
+   `walkInstructions` visits each instruction object at most once, OR to guard the
+   mutation (`if (!instr.__remapped) { instr.typeIdx = tR.get(...); instr.__remapped = true; }`)
+   and clear the flag after. Prefer a clean "snapshot-then-write" that is immune
+   to aliasing.
+2. **Forbid body aliasing (defense-in-depth):** a dev-time invariant check that no
+   two reachable positions share an `Instr` object. Catches the class at its
+   source but doesn't fix the pass.
+
+## Acceptance
+
+- A repro where a helper body aliases a `struct.new` across two arms with a
+  chained `tR` no longer miscompiles (add a synthetic test that constructs such a
+  body, or re-introduce the #2169b alias and assert it stays valid post-fix).
+- Full equivalence suite + standalone HW floor green (the pass rewrites every
+  body — broad blast radius).
+- No funcIdx/type-idx churn regressions ([[reference_no_rebuild_helper_body_at_finalize]]).
+
+## Source
+
+Root-caused 2026-06-18 (sdev-iter) while fixing #2169b's `__iterator` aliasing.
+The localized #2169b fix landed separately; this is the durable global-invariant
+follow-on, routed to architect per tech-lead direction.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -21,6 +21,7 @@ import {
 import type { Instr, ValType } from "../../ir/types.js";
 import { compileArrayMethodCall, compileArrayPrototypeCall, resolveArrayInfo } from "../array-methods.js";
 import { classMemberFuncKey } from "../class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
+import { ensureNativeIteratorRuntime } from "../iterator-native.js"; // (#2169c) native Array.from drain
 import { reserveClosedMethodDispatch } from "../closed-method-dispatch.js";
 import { emitNativeDateParse } from "../date-parse-native.js"; // (#2164) pure-Wasm Date.parse / new Date(str)
 import { ensureObjVecBuilders, ensureObjectRuntime } from "../object-runtime.js";
@@ -4077,6 +4078,45 @@ function compileCallExpression(
           return { kind: "ref", typeIdx: vecTypeIdx };
         }
       }
+      // (#2169c) Native standalone drain: `Array.from(iterable)` with no mapFn,
+      // host-free. The native `__iterator` runtime (registered here) wraps the
+      // arg into an `$IterRec`; `__iterator_rest` drains it into a canonical
+      // externref `$Vec` — exactly the value the host `__array_from` returns, but
+      // with zero host imports. mapFn is NOT handled natively yet (it needs
+      // closure dispatch) — those fall through to the host path below.
+      if (noJsHost(ctx) && expr.arguments.length < 2) {
+        ensureNativeIteratorRuntime(ctx);
+        const argType = compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "externref" });
+        if (argType && argType.kind !== "externref") coerceType(ctx, fctx, argType, { kind: "externref" });
+        flushLateImportShifts(ctx, fctx);
+        const iterIdx = ctx.funcMap.get("__iterator");
+        const restIdx = ctx.funcMap.get("__iterator_rest");
+        if (iterIdx !== undefined && restIdx !== undefined) {
+          // rec = __iterator(arg) ; return __iterator_rest(rec)
+          fctx.body.push({ op: "call", funcIdx: iterIdx });
+          fctx.body.push({ op: "call", funcIdx: restIdx });
+          return { kind: "externref" };
+        }
+        // Native runtime unavailable — fall through to the host path with the
+        // arg already on the stack (push the null mapFn it expects).
+        fctx.body.push({ op: "ref.null.extern" });
+        const fromNativeFallbackIdx = ensureLateImport(
+          ctx,
+          "__array_from",
+          [{ kind: "externref" }, { kind: "externref" }],
+          [{ kind: "externref" }],
+        );
+        flushLateImportShifts(ctx, fctx);
+        if (fromNativeFallbackIdx !== undefined) {
+          fctx.body.push({ op: "call", funcIdx: fromNativeFallbackIdx });
+          return { kind: "externref" };
+        }
+        fctx.body.push({ op: "drop" });
+        fctx.body.push({ op: "drop" });
+        fctx.body.push({ op: "ref.null.extern" });
+        return { kind: "externref" };
+      }
+
       // Fallback: Array.from(externref/iterable) — delegate to host (#965)
       {
         const argType = compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "externref" });
@@ -4099,7 +4139,6 @@ function compileCallExpression(
           fctx.body.push({ op: "call", funcIdx: fromIdx });
           return { kind: "externref" };
         }
-        fctx.body.push({ op: "drop" });
         fctx.body.push({ op: "drop" });
         fctx.body.push({ op: "ref.null.extern" });
         return { kind: "externref" };

--- a/src/codegen/iterator-native.ts
+++ b/src/codegen/iterator-native.ts
@@ -304,7 +304,15 @@ function buildIteratorBody(types: IterRuntimeTypes, deps: UserCarrierDeps | unde
   const { iterRecTypeIdx, vecTypeIdx } = types;
   // VEC arm: $IterRec{VEC, vec, 0, userIter:null}. Field order/arity is
   // load-bearing — struct.new pushes all 4 fields (userIter = ref.null.extern).
-  const vecArm: Instr[] = [
+  //
+  // (#2169b) Build a FRESH arm each call — never reuse one `Instr[]`/`struct.new`
+  // object across the `then` and the `deps===undefined` `else` branches. A shared
+  // instruction object aliased into both branches is walked twice by any
+  // mutate-in-place body pass (DCE's `remapTypeIdxInBody`), which double-applies a
+  // chained type-index remap (e.g. 46→40 then 40→34) to the single `struct.new`,
+  // emitting it at the wrong type index → `invalid struct index`. Distinct objects
+  // per branch keep each `struct.new` remapped exactly once.
+  const buildVecArm = (): Instr[] => [
     { op: "i32.const", value: ITER_KIND_VEC },
     { op: "local.get", index: 1 },
     { op: "ref.cast", typeIdx: vecTypeIdx },
@@ -338,8 +346,10 @@ function buildIteratorBody(types: IterRuntimeTypes, deps: UserCarrierDeps | unde
         { op: "extern.convert_any" } as Instr,
       ]
     : // USER carrier not filled — preserve the legacy hard cast so the failure
-      // mode is unchanged (loud trap) rather than silently wrong.
-      vecArm;
+      // mode is unchanged (loud trap) rather than silently wrong. A FRESH vec arm
+      // (not the `then` arm's array) so the two branches never share a
+      // `struct.new` object (#2169b).
+      buildVecArm();
 
   return [
     // objAny = any.convert_extern(obj)
@@ -350,7 +360,7 @@ function buildIteratorBody(types: IterRuntimeTypes, deps: UserCarrierDeps | unde
     {
       op: "if",
       blockType: { kind: "val", type: { kind: "externref" } },
-      then: vecArm,
+      then: buildVecArm(),
       else: elseArm,
     },
   ];

--- a/tests/issue-2169b-arrayfrom-iterator-driver.test.ts
+++ b/tests/issue-2169b-arrayfrom-iterator-driver.test.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2169b — the native `__iterator` driver miscompiled `struct.new $__IterRec`
+ * at the wrong type index, so `Array.from(<native array iterator>)` (and any
+ * other consumer routed through the driver under a chained DCE type-remap)
+ * failed `WebAssembly.compile` with `invalid struct index`.
+ *
+ * Root cause: `buildIteratorBody` aliased one `vecArm` Instr[] into BOTH the
+ * `then` and (vec-only) `else` of the same `if`, so its shared `struct.new`
+ * instruction object was walked twice by DCE's in-place `remapTypeIdxInBody`,
+ * which double-applied a chained type-index remap (e.g. 46→40 then 40→34). The
+ * fix de-aliases via a `buildVecArm()` factory so each branch gets a FRESH
+ * instruction object, remapped exactly once.
+ *
+ * This test asserts the driver-routed forms now COMPILE + VALIDATE (no
+ * `invalid struct index`). `Array.from(<iterator>)` still pulls the
+ * `__array_from` host import (a separate native-`__array_from` follow-on, #2169),
+ * so it is checked for VALIDATION only; the zero-host for-of / spread paths over
+ * native iterators are checked end-to-end.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function validatesStandalone(src: string): Promise<void> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  // The load-bearing assertion: the binary must VALIDATE (no invalid struct index).
+  await expect(WebAssembly.compile(r.binary)).resolves.toBeDefined();
+}
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const imports = WebAssembly.Module.imports(mod).map((i) => `${i.module}::${i.name}`);
+  expect(imports, "standalone module must have zero host imports").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2169b __iterator driver struct.new index (standalone)", () => {
+  it("Array.from(arr.values()) validates (no invalid struct index)", async () => {
+    await validatesStandalone(
+      `export function test(): number { const a=[10,20]; const e=Array.from(a.values()); return e.length; }`,
+    );
+  });
+
+  it("Array.from(arr.keys()) validates", async () => {
+    await validatesStandalone(
+      `export function test(): number { const a=[10,20]; const e=Array.from(a.keys()); return e.length; }`,
+    );
+  });
+
+  it("Array.from(arr.entries()) validates", async () => {
+    await validatesStandalone(
+      `export function test(): number { const a=[10,20]; const e=Array.from(a.entries()); return e.length; }`,
+    );
+  });
+
+  it("for-of over a stored array iterator runs (zero host)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const it=[10,20].values(); let s=0; for(const v of it){ s+=v; } return s; }`,
+      ),
+    ).toBe(30);
+  });
+
+  it("spread of a generator runs (zero host)", async () => {
+    expect(
+      await runStandalone(
+        `function* g(){ yield 1; yield 2; yield 3; } export function test(): number { const e=[...g()]; return e.length*10 + e[2]; }`,
+      ),
+    ).toBe(33);
+  });
+
+  it("for-of over a custom iterable runs (zero host)", async () => {
+    expect(
+      await runStandalone(
+        `const obj = { [Symbol.iterator]() { let i = 0; return { next() { return i < 3 ? { value: i++, done: false } : { value: undefined, done: true }; } }; } }; export function test(): number { let s = 0; for (const v of obj) { s += v; } return s; }`,
+      ),
+    ).toBe(3);
+  });
+});

--- a/tests/issue-2169c-native-array-from.test.ts
+++ b/tests/issue-2169c-native-array-from.test.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2169c — host-free `Array.from(iterable)` in standalone mode.
+ *
+ * Previously `Array.from(x)` (no mapFn) over any iterable routed through the
+ * `env::__array_from` host import. Standalone (`--target wasi`) has no JS host,
+ * so it pulled an import that can't be satisfied. This drains the iterable
+ * natively instead: `__iterator(arg)` wraps it into an `$IterRec`, then
+ * `__iterator_rest(rec)` drains it into a canonical externref `$Vec` — the same
+ * value the host `__array_from` returned, with ZERO host imports. (Depends on
+ * the #2169b `__iterator` driver de-alias so the driver itself validates.)
+ *
+ * `Array.from(iter, mapFn)` is NOT handled natively (needs closure dispatch) and
+ * still delegates to the host path; host mode is `noJsHost`-gated and unchanged.
+ * `Array.from(new Set(...))` is gated by a separate Set-iterator producer bug
+ * (#2162) and is out of scope here.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const imports = WebAssembly.Module.imports(mod).map((i) => `${i.module}::${i.name}`);
+  expect(imports, "standalone module must have zero host imports").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2169c host-free Array.from(iterable) (standalone)", () => {
+  it("Array.from(arr.values()) — length and elements", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a=[10,20]; const e=Array.from(a.values()); return e.length*100 + (e[0] as number) + (e[1] as number); }`,
+      ),
+    ).toBe(230);
+  });
+
+  it("Array.from(arr.keys()) — indices", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a=[10,20,30]; const e=Array.from(a.keys()); return (e[0] as number)*100 + (e[1] as number)*10 + (e[2] as number); }`,
+      ),
+    ).toBe(12);
+  });
+
+  it("Array.from(generator)", async () => {
+    expect(
+      await runStandalone(
+        `function* g(){ yield 1; yield 2; yield 3; } export function test(): number { const e=Array.from(g()); return e.length*10 + (e[2] as number); }`,
+      ),
+    ).toBe(33);
+  });
+
+  it("Array.from(plain array)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const e=Array.from([5,6,7]); return e.length*10 + (e[2] as number); }`,
+      ),
+    ).toBe(37);
+  });
+
+  it("Array.from(string) — string is iterable", async () => {
+    expect(await runStandalone(`export function test(): number { const e=Array.from("abc"); return e.length; }`)).toBe(
+      3,
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Standalone (`--target wasi`) `Array.from(x)` (no mapFn) over any iterable lowered
to the `env::__array_from` JS-host import — which a hostless runtime can't
satisfy. This is the producer half of #2169.

## Fix

When `noJsHost(ctx)` and there is no mapFn, drain the iterable **natively**
instead of the host import:
- `ensureNativeIteratorRuntime(ctx)` registers the native `__iterator` /
  `__iterator_rest` funcs.
- `__iterator(arg)` wraps the arg into an `$IterRec`; `__iterator_rest(rec)`
  drains it into a canonical externref `$Vec` — exactly the value the host
  `__array_from` returned, with **zero host imports**.

The branch is `noJsHost`-gated, so JS-host mode is unchanged. `Array.from(iter,
mapFn)` (needs closure dispatch) still host-delegates.

## Depends on #2169b (PR #1720)

The native `__iterator` driver had a `struct.new` type-index miscompile
(shared-arm aliasing → DCE double-remap), fixed in #2169b / **PR #1720** (in the
merge queue). Without it the drain VFAILs. **This branch is built on #1720** —
once #1720 lands, a `git merge origin/main` drops the redundant commit and this
diff reduces to the `calls.ts` native branch + the test + the issue doc. Merge
#1720 first.

## Verification (zero host imports, correct values)

- `Array.from(arr.values()/.keys()/.entries())`, `Array.from(generator)`,
  `Array.from(plain array)`, `Array.from("abc")` — all drained correctly.
- host-mode `Array.from` unchanged (`noJsHost`-gated).
- IR fallback gate OK. Test: `tests/issue-2169c-native-array-from.test.ts` (5/5).

## Out of scope

- `Array.from(new Set(...))` VFAILs with a separate Set-iterator producer bug
  (`struct.new need 4 got 2` — confirmed pre-existing on the #2169b base, NOT
  introduced here; #2162 Map/Set lane).
- `Array.from(iter, mapFn)` native lowering (host-delegated follow-on).