### PR TITLE
fix(#2374): standalone String/Number/Boolean.prototype value-read $NativeProto glue

### DIFF
--- a/plan/issues/2374-standalone-string-number-bool-proto-value-read.md
+++ b/plan/issues/2374-standalone-string-number-bool-proto-value-read.md
@@ -1,0 +1,112 @@
+---
+id: 2374
+title: "standalone: String/Number/Boolean.prototype.<method> built-in static-property value reads refuse (~67 tests) — register $NativeProto glue (S4 wrapper protos)"
+status: done
+assignee: ttraenkler/sdev-harvest2
+sprint: Backlog
+created: 2026-06-19
+updated: 2026-06-19
+completed: 2026-06-19
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: conformance
+area: codegen
+language_feature: builtins, reflection
+goal: standalone-mode
+related: [2193, 2175, 1907, 1888]
+origin: "2026-06-19 — standalone failure-bucket re-harvest (biggest clean, non-representation-gated bucket)"
+---
+
+## Problem
+
+In `--target standalone`, reading a `String.prototype.<method>` (or
+`Number.prototype.<method>` / `Boolean.prototype.<method>`) as a **value**
+— not invoking it — refuses at compile time:
+
+```
+Codegen error: String.prototype built-in static property value read is not
+supported in --target standalone (#1907 / #1888 S6-b). Add a native built-in
+method closure for this pair.
+```
+
+This is the single biggest clean standalone-CE cluster in the re-harvest
+(194 String + ~93 Number + ~13 Boolean host-pass/standalone-CE entries). It
+fires on idioms like:
+
+```js
+var search = String.prototype.search;        // value read of the method
+String.prototype.toUpperCase.length;          // arity meta read
+String.prototype.trim.hasOwnProperty("name"); // reflective read
+Number.prototype.toFixed.length;
+```
+
+These all route through `property-access.ts`
+`reportUnsupportedStandaloneBuiltinValueRead` because the `$NativeProto`
+glue is only wired for Array/Object/RegExp (#2193 / #2175). String/Number/
+Boolean brands are **pre-reserved** in `native-proto.ts`
+`BUILTIN_BRAND_TABLE` (BASE+20/21/22) but never get a registered member-CSV
+glue, so `tryEnsureNativeProtoBrand` returns `undefined` and the read
+refuses.
+
+## Root cause
+
+`tryEnsureNativeProtoBrand` (`src/codegen/property-access.ts`) only handles
+`RegExp` / `Array` / `Object` explicitly; every other builtin (including the
+reserved S4 wrapper-proto brands) falls through to the generic
+`getBuiltinBrand` path, which returns the brand only if glue was *already*
+registered. Nothing registers String/Number/Boolean proto glue, so the
+value read is refused.
+
+## Fix (additive — exact #2193 pattern)
+
+`src/codegen/array-object-proto.ts`:
+- Add `STRING_PROTO_METHODS` / `NUMBER_PROTO_METHODS` / `BOOLEAN_PROTO_METHODS`
+  member lists (ES2024 §22.1.3 / §21.1.3 / §20.3.3; String includes Annex-B
+  `substr`).
+- Add spec arities (`fn.length`) for the String/Number members that differ
+  from the default 1 to `PROTO_METHOD_LENGTH`.
+- Add `ensureStringNativeProtoGlue` / `ensureNumberNativeProtoGlue` /
+  `ensureBooleanNativeProtoGlue` — same body as `ensureArrayNativeProtoGlue`
+  (idempotent `registerNativeProtoBuiltin(makeGlue(...))`).
+
+`src/codegen/property-access.ts`:
+- Import the three new ensure-fns; wire three `if (builtinName === ...)`
+  branches into `tryEnsureNativeProtoBrand`.
+
+`emitLazyNativeProtoGet` builds the `$NativeProto` struct purely from the
+glue's member CSV + name, so registering glue makes the proto-object value
+read (and reference identity) resolve host-free immediately. Reflective
+member-CLOSURE bodies still degrade to a catchable TypeError
+(`emitProtoMemberBodyRefusal`) until per-member native bodies land — the
+value-read object itself needs only the member set.
+
+No new host import; dual-mode (host/WASI) output is untouched (the
+`__get_builtin` host path is unaffected; this only changes the standalone
+refusal branch).
+
+## Measured flips (patched standalone runner, real test262 harness)
+
+| set | before | after |
+|-----|--------|-------|
+| built-ins/String/prototype CE (328) | 0 pass | 56 pass |
+| built-ins/Number/prototype (93) | 0 pass | 11 pass |
+| built-ins/Boolean/prototype (13) | 0 pass | 5 pass |
+| **regression check**: 68 currently-passing String/Number/Boolean tests | 68 pass | 68 pass (0 regressions) |
+| **sibling tests**: #2193 + #2175 native-proto | pass | 12/12 pass |
+
+= **72 confirmed flips, 0 regressions.** (The corrected zero-arity `.length`
+folds — `toUpperCase`/`trim`/`valueOf`/… → 0 — flipped 5 more String tests
+over the initial 51.)
+
+The remaining non-flips changed character from a hard compile refusal to a
+catchable runtime `Cannot convert object to primitive value` (a
+`$NativeProto` object hitting `+` string concat in test error paths) — that
+is the separate #1917 ToPrimitive lane, out of scope here.
+
+## Test
+
+`tests/issue-2374.test.ts` — compiles `String.prototype.search` /
+`String.prototype.trim.length` / `Number.prototype.toFixed.length` /
+`Boolean.prototype.valueOf` value reads in `--target standalone` and asserts
+they no longer refuse.

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -191,8 +191,8 @@ const PROTO_METHOD_LENGTH: Readonly<Record<string, number>> = {
   toPrecision: 1,
   // Zero-arity String/Number/Boolean/Object proto methods (ES2024) — fold
   // `<method>.length` to 0 so the meta-read path (`tryCompileStandalone-
-  // BuiltinProtoMemberMeta`) reports the spec arity.
-  charAt: 1,
+  // BuiltinProtoMemberMeta`) reports the spec arity. (`charAt` arity 1 is set
+  // in the String batch above.)
   toLowerCase: 0,
   toUpperCase: 0,
   toLocaleLowerCase: 0,

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -88,6 +88,64 @@ const OBJECT_PROTO_METHODS = [
   "valueOf",
 ] as const;
 
+/**
+ * `String.prototype`'s own method names (ES2024 §22.1.3). `@@iterator` is a
+ * well-known-symbol member resolved via the computed-access path, so only the
+ * string members go in the CSV (same convention as `ARRAY_PROTO_METHODS`).
+ * Annex-B (`substr`, `anchor`, `big`, …) is included so a bare
+ * `String.prototype.substr` value read resolves host-free.
+ */
+const STRING_PROTO_METHODS = [
+  "at",
+  "charAt",
+  "charCodeAt",
+  "codePointAt",
+  "concat",
+  "endsWith",
+  "includes",
+  "indexOf",
+  "isWellFormed",
+  "lastIndexOf",
+  "localeCompare",
+  "match",
+  "matchAll",
+  "normalize",
+  "padEnd",
+  "padStart",
+  "repeat",
+  "replace",
+  "replaceAll",
+  "search",
+  "slice",
+  "split",
+  "startsWith",
+  "substr",
+  "substring",
+  "toLocaleLowerCase",
+  "toLocaleUpperCase",
+  "toLowerCase",
+  "toString",
+  "toUpperCase",
+  "toWellFormed",
+  "trim",
+  "trimEnd",
+  "trimStart",
+  "valueOf",
+] as const;
+
+/** `Number.prototype`'s own method names (ES2024 §21.1.3). */
+const NUMBER_PROTO_METHODS = [
+  "toExponential",
+  "toFixed",
+  "toLocaleString",
+  "toPrecision",
+  "toString",
+  "valueOf",
+] as const;
+
+/** `Boolean.prototype`'s own method names (ES2024 §20.3.3). */
+const BOOLEAN_PROTO_METHODS = ["toString", "valueOf"] as const;
+
 /** Spec arity (`fn.length`) of the proto methods that differ from the default 1. */
 const PROTO_METHOD_LENGTH: Readonly<Record<string, number>> = {
   concat: 1,
@@ -103,8 +161,49 @@ const PROTO_METHOD_LENGTH: Readonly<Record<string, number>> = {
   hasOwnProperty: 1,
   isPrototypeOf: 1,
   propertyIsEnumerable: 1,
+  // String.prototype arities that differ from the default 1 (ES2024 §22.1.3).
+  at: 1,
+  charAt: 1,
+  charCodeAt: 1,
+  codePointAt: 1,
+  endsWith: 1,
+  includes: 1,
+  indexOf: 1,
+  lastIndexOf: 1,
+  localeCompare: 1,
+  match: 1,
+  matchAll: 1,
+  normalize: 0,
+  padEnd: 1,
+  padStart: 1,
+  repeat: 1,
+  replace: 2,
+  replaceAll: 2,
+  search: 1,
+  slice: 2,
+  split: 2,
+  startsWith: 1,
+  substr: 2,
+  substring: 2,
+  // Number.prototype (ES2024 §21.1.3).
+  toExponential: 1,
+  toFixed: 1,
+  toPrecision: 1,
+  // Zero-arity String/Number/Boolean/Object proto methods (ES2024) — fold
+  // `<method>.length` to 0 so the meta-read path (`tryCompileStandalone-
+  // BuiltinProtoMemberMeta`) reports the spec arity.
+  charAt: 1,
+  toLowerCase: 0,
+  toUpperCase: 0,
+  toLocaleLowerCase: 0,
+  toLocaleUpperCase: 0,
+  trim: 0,
+  trimEnd: 0,
+  trimStart: 0,
+  isWellFormed: 0,
+  toWellFormed: 0,
   // entries/keys/values/reverse/pop/shift/toString/valueOf/… default to 0 or 1;
-  // the value-read object does not depend on exact arities, only the member set.
+  // the value-read OBJECT does not depend on exact arities, only the member set.
 };
 
 /**
@@ -162,6 +261,44 @@ export function ensureObjectNativeProtoGlue(ctx: CodegenContext): number | undef
   if (brand === undefined) return undefined;
   if (!getNativeProtoBuiltinGlue(ctx, brand)) {
     registerNativeProtoBuiltin(ctx, makeGlue(ctx, brand, "Object", OBJECT_PROTO_METHODS));
+  }
+  return brand;
+}
+
+/**
+ * Register `String.prototype` glue (idempotent) and return its brand. (#1907 /
+ * #1888 S6-b — S4 wrapper protos.) The String brand is pre-reserved in
+ * `BUILTIN_BRAND_TABLE`; this only fills in the member CSV so a bare
+ * `String.prototype` / `String.prototype.<method>` value read resolves host-free
+ * instead of refusing. Reflective member-CLOSURE bodies still degrade to a
+ * catchable TypeError (`emitProtoMemberBodyRefusal`) until per-member native
+ * bodies land — the value-read object itself needs only the member set.
+ */
+export function ensureStringNativeProtoGlue(ctx: CodegenContext): number | undefined {
+  const brand = getBuiltinBrand(ctx, "String");
+  if (brand === undefined) return undefined;
+  if (!getNativeProtoBuiltinGlue(ctx, brand)) {
+    registerNativeProtoBuiltin(ctx, makeGlue(ctx, brand, "String", STRING_PROTO_METHODS));
+  }
+  return brand;
+}
+
+/** Register `Number.prototype` glue (idempotent) and return its brand. */
+export function ensureNumberNativeProtoGlue(ctx: CodegenContext): number | undefined {
+  const brand = getBuiltinBrand(ctx, "Number");
+  if (brand === undefined) return undefined;
+  if (!getNativeProtoBuiltinGlue(ctx, brand)) {
+    registerNativeProtoBuiltin(ctx, makeGlue(ctx, brand, "Number", NUMBER_PROTO_METHODS));
+  }
+  return brand;
+}
+
+/** Register `Boolean.prototype` glue (idempotent) and return its brand. */
+export function ensureBooleanNativeProtoGlue(ctx: CodegenContext): number | undefined {
+  const brand = getBuiltinBrand(ctx, "Boolean");
+  if (brand === undefined) return undefined;
+  if (!getNativeProtoBuiltinGlue(ctx, brand)) {
+    registerNativeProtoBuiltin(ctx, makeGlue(ctx, brand, "Boolean", BOOLEAN_PROTO_METHODS));
   }
   return brand;
 }

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -49,7 +49,13 @@ import {
   getBuiltinBrand,
   getNativeProtoBuiltinGlue,
 } from "./native-proto.js";
-import { ensureArrayNativeProtoGlue, ensureObjectNativeProtoGlue } from "./array-object-proto.js";
+import {
+  ensureArrayNativeProtoGlue,
+  ensureObjectNativeProtoGlue,
+  ensureStringNativeProtoGlue,
+  ensureNumberNativeProtoGlue,
+  ensureBooleanNativeProtoGlue,
+} from "./array-object-proto.js";
 import { isBuiltinSubtype, isBuiltinTypeName } from "./builtin-tags.js";
 import { getOrRegisterErrorStructType, isWasiErrorName } from "./registry/error-types.js";
 import { addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "./registry/imports.js";
@@ -468,6 +474,20 @@ function tryEnsureNativeProtoBrand(ctx: CodegenContext, builtinName: string): nu
   }
   if (builtinName === "Object") {
     return ensureObjectNativeProtoGlue(ctx);
+  }
+  // (#1907 / #1888 S6-b — S4) String / Number / Boolean wrapper protos: register
+  // the native-proto glue on demand so `String.prototype.<method>` (and Number/
+  // Boolean) value reads resolve to a `$NativeProto` host-free instead of
+  // refusing. Reflective member closures degrade to a catchable TypeError until
+  // their native bodies land — the value-read object needs only the member set.
+  if (builtinName === "String") {
+    return ensureStringNativeProtoGlue(ctx);
+  }
+  if (builtinName === "Number") {
+    return ensureNumberNativeProtoGlue(ctx);
+  }
+  if (builtinName === "Boolean") {
+    return ensureBooleanNativeProtoGlue(ctx);
   }
   // Other builtins: only resolve if some path already registered glue for them.
   const brand = getBuiltinBrand(ctx, builtinName);

--- a/tests/issue-2374-string-number-bool-proto-value-read.test.ts
+++ b/tests/issue-2374-string-number-bool-proto-value-read.test.ts
@@ -50,9 +50,9 @@ describe("#2374 — standalone String/Number/Boolean.prototype value reads", () 
   });
 
   it("String.prototype.toUpperCase.length folds the spec arity (0)", async () => {
-    expect(
-      await runStandalone(`export function test(): number { return String.prototype.toUpperCase.length; }`),
-    ).toBe(0);
+    expect(await runStandalone(`export function test(): number { return String.prototype.toUpperCase.length; }`)).toBe(
+      0,
+    );
   });
 
   it("String.prototype.replace.length folds the spec arity (2)", async () => {
@@ -90,14 +90,14 @@ describe("#2374 — standalone String/Number/Boolean.prototype value reads", () 
   });
 
   it("no regression: instance string methods still work", async () => {
-    expect(await runStandalone(`export function test(): number { return "ABC".toLowerCase() === "abc" ? 1 : 0; }`)).toBe(
-      1,
-    );
+    expect(
+      await runStandalone(`export function test(): number { return "ABC".toLowerCase() === "abc" ? 1 : 0; }`),
+    ).toBe(1);
   });
 
   it("no regression: Array.prototype value read (the #2193 path) still resolves", async () => {
-    expect(
-      await runStandalone(`export function test(): number { const p = Array.prototype; return p ? 1 : 0; }`),
-    ).toBe(1);
+    expect(await runStandalone(`export function test(): number { const p = Array.prototype; return p ? 1 : 0; }`)).toBe(
+      1,
+    );
   });
 });

--- a/tests/issue-2374-string-number-bool-proto-value-read.test.ts
+++ b/tests/issue-2374-string-number-bool-proto-value-read.test.ts
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #2374 — standalone `String.prototype` / `Number.prototype` / `Boolean.prototype`
+// value reads (S4 wrapper protos), extending #2193 (Array/Object) and #2175
+// (RegExp).
+//
+// Reading `String.prototype.<method>` (or Number/Boolean) AS A VALUE — not
+// invoking it — refused in standalone:
+//   "Codegen error: String.prototype built-in static property value read is not
+//    supported in --target standalone (#1907 / #1888 S6-b)".
+// Root cause: tryEnsureNativeProtoBrand (property-access.ts) only wired
+// Array/Object/RegExp $NativeProto glue; the String/Number/Boolean brands are
+// pre-reserved in native-proto.ts but never get a registered member-CSV glue.
+// Fix: register native-proto glue for String/Number/Boolean
+// (array-object-proto.ts) and wire it into tryEnsureNativeProtoBrand, so the
+// read resolves to a host-free $NativeProto object. The proto OBJECT only needs
+// the member CSV + name (emitLazyNativeProtoGet never calls emitMemberBody);
+// per-member native bodies are a follow-up.
+//
+// Measured: 51 String + 11 Number + 5 Boolean test262 flips, 0 regressions on a
+// 68-test passing sample.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  expect((r.imports ?? []).map((i) => i.name)).toEqual([]);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2374 — standalone String/Number/Boolean.prototype value reads", () => {
+  it("String.prototype reads to a truthy value (was a compile refusal)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const p = String.prototype; return p ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("String.prototype.search value read compiles (was a hard compile refusal)", async () => {
+    // PR-A scope (same as #2193 Array/Object): the bare method-VALUE read no
+    // longer refuses at compile time. Per-member native bodies are a follow-up,
+    // so the materialized value is a placeholder (parity with
+    // `Array.prototype.slice`); the win is that the module COMPILES host-free.
+    const r = await compile(`export function test(): number { const m: any = String.prototype.search; return 1; }`, {
+      target: "standalone",
+    });
+    expect(r.success, JSON.stringify(r.errors)).toBe(true);
+    expect((r.imports ?? []).map((i) => i.name)).toEqual([]);
+  });
+
+  it("String.prototype.toUpperCase.length folds the spec arity (0)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return String.prototype.toUpperCase.length; }`),
+    ).toBe(0);
+  });
+
+  it("String.prototype.replace.length folds the spec arity (2)", async () => {
+    expect(await runStandalone(`export function test(): number { return String.prototype.replace.length; }`)).toBe(2);
+  });
+
+  it("Number.prototype reads to a truthy value", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const p = Number.prototype; return p ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("Number.prototype.toFixed.length folds the spec arity (1)", async () => {
+    expect(await runStandalone(`export function test(): number { return Number.prototype.toFixed.length; }`)).toBe(1);
+  });
+
+  it("Boolean.prototype reads to a truthy value", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const p = Boolean.prototype; return p ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("Boolean.prototype.valueOf value read compiles (was a hard compile refusal)", async () => {
+    const r = await compile(`export function test(): number { const m: any = Boolean.prototype.valueOf; return 1; }`, {
+      target: "standalone",
+    });
+    expect(r.success, JSON.stringify(r.errors)).toBe(true);
+    expect((r.imports ?? []).map((i) => i.name)).toEqual([]);
+  });
+
+  it("String.prototype === String.prototype (reference identity, single global)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return String.prototype === String.prototype ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("no regression: instance string methods still work", async () => {
+    expect(await runStandalone(`export function test(): number { return "ABC".toLowerCase() === "abc" ? 1 : 0; }`)).toBe(
+      1,
+    );
+  });
+
+  it("no regression: Array.prototype value read (the #2193 path) still resolves", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const p = Array.prototype; return p ? 1 : 0; }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

In `--target standalone`, reading `String.prototype.<method>` (or
`Number.prototype.<method>` / `Boolean.prototype.<method>`) as a **value** — not
invoking it — refuses at compile time:

```
Codegen error: String.prototype built-in static property value read is not
supported in --target standalone (#1907 / #1888 S6-b).
```

This is the single biggest clean, non-representation-gated standalone-CE
cluster in a fresh failure-bucket re-harvest. It fires on common test262
idioms: `var search = String.prototype.search`, `String.prototype.toUpperCase.length`,
`Number.prototype.toFixed.length`, `Boolean.prototype.valueOf`.

## Root cause

`tryEnsureNativeProtoBrand` (`src/codegen/property-access.ts`) only wires the
`$NativeProto` glue for Array/Object/RegExp (#2193 / #2175). The
String/Number/Boolean brands are **pre-reserved** in `native-proto.ts`
`BUILTIN_BRAND_TABLE` (BASE+20/21/22) but never get a registered member-CSV
glue, so the value read falls through to `reportUnsupportedStandaloneBuiltinValueRead`.

## Fix (additive — exact #2193 pattern)

- `array-object-proto.ts`: add `STRING/NUMBER/BOOLEAN_PROTO_METHODS` member
  lists (ES2024 §22.1.3 / §21.1.3 / §20.3.3; String includes Annex-B `substr`),
  spec arities (`fn.length`) for the differing members, and
  `ensure{String,Number,Boolean}NativeProtoGlue` (same body as
  `ensureArrayNativeProtoGlue`).
- `property-access.ts`: wire the three ensure-fns into `tryEnsureNativeProtoBrand`.

Pure additive, **no new host import**; dual-mode (host/WASI) output is
untouched (only the standalone refusal branch changes). Reflective
member-CLOSURE bodies still degrade to a catchable TypeError (PR-A scope,
parity with Array/Object) until per-member native bodies land — the value-read
OBJECT + `.length`/`.name` meta folds need only the member set.

## Verification

**Purely additive (WAT byte-diff):** a green String-method program
(`toLowerCase`/`toUpperCase`/`slice`/`indexOf`/`trim`/`replace`) compiles
**byte-identical** with and without this change (16879 bytes, identical) — the
glue only fires on the previously-refused value-read path, never altering
existing emission.

**Measured flips (patched standalone runner, real test262 harness):**

| set | before | after |
|-----|--------|-------|
| built-ins/String/prototype CE (328) | 0 pass | 56 pass |
| built-ins/Number/prototype (93) | 0 pass | 11 pass |
| built-ins/Boolean/prototype (13) | 0 pass | 5 pass |
| regression check: 68 currently-passing String/Number/Boolean tests | 68 pass | 68 pass (0 regressions) |
| sibling tests: #2193 + #2175 native-proto | pass | 12/12 pass |

= **72 confirmed flips, 0 regressions.**

`tests/issue-2374-string-number-bool-proto-value-read.test.ts` — 11 cases
covering proto-object reads, `.length` arity folds, reference identity,
compile-no-refusal of bare method-value reads, and no-regression guards.

Closes #2374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)