### PR TITLE
fix(ci): drop volatile baseline-sha from synced conformance line — stop stranding the merge queue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,7 +339,7 @@ The issue frontmatter `status:` field tracks where an issue is, set by whichever
 3. Update `plan/issues/backlog/backlog.md` if the issue was listed there
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,365 / 43,135 (72.7 %) — baseline e9579720
+**test262 conformance**: 31,365 / 43,135 (72.7 %)
 <!-- AUTO:conformance-end -->
 
 ### Sprint History

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ STATUS.md rather than duplicating numbers that go stale. Standalone
 README until the current standalone regression is fixed.
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,365 / 43,135 (72.7 %) — baseline e9579720
+**test262 conformance**: 31,365 / 43,135 (72.7 %)
 <!-- AUTO:conformance-end -->
 
 ## Current Status

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ Over 31 development sprints and **784 closed issues**, js2wasm has grown from a 
 ### Conformance
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,365 / 43,135 (72.7 %) — baseline e9579720
+**test262 conformance**: 31,365 / 43,135 (72.7 %)
 <!-- AUTO:conformance-end -->
 
 - Automated conformance tracking with historical trend data and a public [conformance report](https://loopdive.github.io/js2wasm/benchmarks/report.html)

--- a/plan/goals/goal-graph.md
+++ b/plan/goals/goal-graph.md
@@ -5,7 +5,7 @@ Unlike a linear roadmap, multiple independent goals can be worked on in parallel
 and a goal being "ready" doesn't mean it should be worked on immediately.
 
 <!-- AUTO:conformance-start -->
-**test262 conformance**: 31,365 / 43,135 (72.7 %) — baseline e9579720
+**test262 conformance**: 31,365 / 43,135 (72.7 %)
 <!-- AUTO:conformance-end -->
 
 ## DAG

--- a/scripts/sync-conformance-numbers.mjs
+++ b/scripts/sync-conformance-numbers.mjs
@@ -48,11 +48,6 @@ function fmtPercent(pass, total) {
   return ((pass / total) * 100).toFixed(1);
 }
 
-function shortSha(sha) {
-  if (!sha) return "unknown";
-  return String(sha).slice(0, 8);
-}
-
 function loadReport() {
   if (!existsSync(REPORT_PATH)) {
     throw new Error(
@@ -75,8 +70,6 @@ function loadReport() {
   return {
     pass: summary.pass,
     total: summary.total,
-    sha: json.baseline_sha || json.gitHash || "",
-    generatedAt: json.baseline_generated_at || json.timestamp || "",
   };
 }
 
@@ -89,13 +82,26 @@ function renderBlock(report) {
   const passStr = fmtNumber(report.pass);
   const totalStr = fmtNumber(report.total);
   const pct = fmtPercent(report.pass, report.total);
-  const sha = shortSha(report.sha);
-  // Intentionally omit the volatile baseline-generated timestamp from the
-  // rendered block: the forced-baseline-refresh bot bumps that timestamp
-  // ~hourly with no change to pass/total, which made `sync:conformance:check`
-  // flag drift on every open PR and perpetually block the merge queue (#1522).
-  // The meaningful numbers (pass/total/percentage + baseline sha) stay.
-  return `**test262 conformance**: ${passStr} / ${totalStr} (${pct} %) — baseline ${sha}`;
+  // Render ONLY the stable pass/total/percentage — no volatile suffix.
+  //
+  // The earlier fix here dropped the baseline *timestamp* because the
+  // forced-baseline-refresh bot bumped it ~hourly with no change to
+  // pass/total, making `sync:conformance:check` flag drift on every open PR
+  // and perpetually block the merge queue (#1522). The `— baseline <sha>`
+  // suffix has the *same* defect: promote-baseline rewrites it into CLAUDE.md,
+  // README.md, ROADMAP.md and goal-graph.md on EVERY push to main, so the sha
+  // changes even when pass/total are unchanged. Every open PR that had merged
+  // main once then conflicted on this single line the next time main advanced
+  // — stranding the whole queue as DIRTY (the 2026-06-18 6-PR pile-up).
+  //
+  // Dropping the sha makes the line a pure function of pass/total: all
+  // branches and main render an IDENTICAL string for a given count, so a sha
+  // bump no longer diverges anything, and a real count change resolves
+  // cleanly via 3-way merge (the branch line equals the merge-base line, so
+  // git takes main's side without a conflict). The baseline sha is still
+  // authoritative in benchmarks/results/test262-current.json (committed) and
+  // surfaced on the landing page — it does not belong in branch-merged prose.
+  return `**test262 conformance**: ${passStr} / ${totalStr} (${pct} %)`;
 }
 
 /**


### PR DESCRIPTION
## Why open PRs were not getting auto-queued

When asked to drain the queue today, 6 open PRs (#1704/#1708/#1709/#1711/#1713 + churn) were stranded. `auto-enqueue.yml` was healthy and running every few minutes — it just (correctly) refuses to enqueue **non-mergeable** PRs. 4 of them were `DIRTY`, and `git merge-tree` showed the conflicts were almost entirely in **auto-generated doc files**: `CLAUDE.md`, `README.md`, `ROADMAP.md`, `plan/goals/goal-graph.md` — all on a *single line*:

```
- **test262 conformance**: 31,365 / 43,135 (72.7 %) — baseline e9579720
+ **test262 conformance**: 31,357 / 43,135 (72.7 %) — baseline unknown, 2026-06-17T03:03:44.073Z
```

## Structural root cause

`sync-conformance-numbers.mjs` (run by `promote-baseline` on **every push to main**) rewrites that line into 4 tracked, branch-merged docs, and the line carried a `— baseline <sha>` suffix. **The sha changes on every push even when pass/total are unchanged.** So any open PR that had merged main once then conflicted on this one line the next time main advanced → DIRTY → skipped by the backstop → whole queue stranded.

This is the *same* defect the earlier fix already handled for the baseline **timestamp** (dropped because the hourly refresh bot bumped it with no pass/total change, blocking the queue — #1522). The sha has identical behaviour; this completes that fix.

## Fix

Render only the stable `pass / total (pct %)` — drop the volatile `— baseline <sha>` suffix (and the now-dead `shortSha()`/sha/generatedAt code).

**Effect:** the line is now a pure function of pass/total, so every branch and main render an *identical* string for a given count. A sha bump no longer diverges anything, and a genuine count change resolves cleanly via 3-way merge (branch line == merge-base line → git takes main's side, no conflict). The baseline sha stays authoritative in `benchmarks/results/test262-current.json` (committed) and on the landing page — it does not belong in branch-merged prose.

`sync:conformance:check` is idempotent on the new line; biome lint clean. The 6 stranded PRs are being shepherded through their (now legacy) conflicts in parallel; after this lands, future conformance bumps stop stranding the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)