### PR TITLE
fix(#2161): standalone String(re) + template `${re}` RegExp→string coercion

### DIFF
--- a/plan/issues/2161-standalone-regexp-engine-residual.md
+++ b/plan/issues/2161-standalone-regexp-engine-residual.md
@@ -2,10 +2,10 @@
 id: 2161
 title: "Standalone RegExp engine conformance residual (~579 tests)"
 status: in-progress
-assignee: ttraenkler/cs-2164
+assignee: ttraenkler/sd1
 sprint: 64
 created: 2026-06-15
-updated: 2026-06-18
+updated: 2026-06-19
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -341,3 +341,52 @@ coercion returns a wrong-length string) both route through value→string
 coercion, not `re.toString()`, and need RegExp-aware coercion in those lowerings
 — a distinct slice. The (a) reflection and (c) dynamic-receiver buckets remain
 as noted above. **#2161 stays open.**
+
+## Slice 8 (2026-06-19, sd1) — standalone `String(re)` + template `` `${re}` `` coercion
+
+**Landed.** Closes the slice-7 deferral: the value→string COERCION paths now
+route through the native RegExp.prototype.toString rendering, matching the
+already-working `re.toString()` method form. Confirmed against `2af57ffc0`:
+
+| form | before | after |
+|---|---|---|
+| `String(/abc/gi)` | runtime null-deref (null string) | `/abc/gi` |
+| `` `x${/abc/gi}y` `` | `x[object Object]y` | `x/abc/giy` |
+| `re.toString()` | `/abc/gi` (slice 7) | unchanged |
+
+**Fix** — extracted a shared operand-explicit core from the slice-7 method
+helper, then wired it into the two coercion sites:
+
+- `src/codegen/regexp-standalone.ts`: factored
+  `emitStandaloneRegExpToStringFromExpr(ctx, fctx, regexpExpr)` out of
+  `tryCompileStandaloneRegExpToString` (§22.2.6.14 → `"/" + source + "/" +
+  flags` via `__regex_flags_str` + `__str_concat`). The method helper now
+  delegates to it; behaviour byte-identical for the `re.toString()` path. Gated
+  on `ctx.standalone` + a static / backend-created RegExp receiver (dynamic
+  externref receivers fall through unchanged).
+- `src/codegen/expressions/calls.ts`: in the `String(...)` builtin lowering,
+  try the core BEFORE `compileExpression` (so the RegExp receiver is compiled
+  by the core, not the generic ref→string `coerceType` that null-deref'd the
+  `$NativeRegExp` struct). Additive — falls through for non-RegExp args, mirrors
+  the adjacent `tryEmitArrayToStringNative` (#2160) String(arr) hook.
+- `src/codegen/string-ops.ts`: in `compileNativeTemplateExpression`, a static /
+  backend-created RegExp span routes through the core (BEFORE `compileExpression`)
+  instead of falling to the `$__any_to_string` `"[object Object]"` path, then
+  applies the shared concat-tail (head/literal). Guarded on
+  `standaloneNativeStrings` (= `noJsHost`), so host + fast-mode-with-host are
+  untouched.
+
+**Validation.** New `tests/issue-2161-regex-string-coercion.test.ts` (13):
+`String(re)` flagged/flagless/empty-pattern/escaped-slash/const-bound/canonical
+dgimsy + 4-pair host-JS parity; `` `${re}` `` head/flagless/leading-no-head/
+two-spans/const-bound + 3-pair host-JS parity — all standalone with an empty
+importObject asserting no `Object_toString` / `__extern_*` / `js-string` leak.
+The 28 #2161 (tostring/symbol-protocol/matchall) + 700 regex regression cases
+(#1539/#1913/#1914/#1911/#1912/#1474/#2175/#1328/#1329/#1330/#1830/regexp/
+regex-bytecode/#682) stay green (refactor is behaviour-preserving). tsc +
+prettier + biome(lint) + stack-balance + coercion-sites + any-box gates clean.
+
+**Still open under #2161:** (a) `RegExp.prototype` reflection — gated on #2158's
+standalone prototype-object representation; (c) dynamic / `any`-typed receivers
+(both coercion forms fall through to host for those); and the regex-engine
+feature tail (v-flag `\q{}`, dynamic ctor patterns). **#2161 stays open.**

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -126,6 +126,7 @@ import { tryStaticEvalInline } from "./eval-inline.js";
 import { compileExternMethodCall, compileSpreadCallArgs, emitLazyProtoGet } from "./extern.js";
 import {
   compileStandaloneRegExpConstructor,
+  emitStandaloneRegExpToStringFromExpr,
   isGlobalRegExpIdentifier,
   tryCompileStandaloneRegExpExec,
   tryCompileStandaloneRegExpSymbolCall,
@@ -9159,6 +9160,19 @@ function compileCallExpression(
         const strArg0TsType = ctx.checker.getTypeAtLocation(strArg0);
         const arrToStr = tryEmitArrayToStringNative(ctx, fctx, strArg0, strArg0TsType);
         if (arrToStr !== undefined) return arrToStr;
+      }
+
+      // #2161 — String(re) in standalone: a static / backend-created RegExp
+      // argument routes through its native RegExp.prototype.toString
+      // (§22.2.6.14 → "/" + source + "/" + flags) instead of the generic
+      // ref→string coercion, which null-derefs on the $NativeRegExp struct in
+      // native-strings mode (re.toString() already works; the String() builtin
+      // lowering did not detect it). Must run BEFORE compileExpression so the
+      // RegExp receiver is compiled by the toString core. Additive: returns
+      // undefined (falls through) for any non-static / dynamic RegExp.
+      {
+        const reToStr = emitStandaloneRegExpToStringFromExpr(ctx, fctx, strArg0);
+        if (reToStr !== undefined && reToStr !== null) return reToStr;
       }
 
       const argType = compileExpression(ctx, fctx, strArg0);

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -1804,44 +1804,45 @@ export function tryCompileStandaloneRegExpPropertyRead(
 }
 
 /**
- * `RegExp.prototype.toString()` in standalone mode (#2161, §22.2.6.14).
+ * Shared core for §22.2.6.14 `RegExp.prototype.toString()` rendering of a
+ * static / backend-created RegExp *receiver expression* — `"/" + source + "/" +
+ * flags` — emitting a native string with ZERO host imports.
  *
- * The spec result is `"/" + R.[[OriginalSource]] + "/" + R.[[OriginalFlags]]` —
- * i.e. `"/" + re.source + "/" + re.flags`, both of which the native backend
- * already produces (the struct's `source` field is stored in the spec-escaped
- * §22.2.6.13.1 form, and `__regex_flags_str` builds the d-g-i-m-s-u-v-y flag
- * string). In standalone / nativeStrings mode there is no JS host, so a
- * `re.toString()` / `String(re)` / `` `${re}` `` previously leaked the generic
- * `env::Object_toString` import (and `String(re)` null-deref'd). This composes
- * the two native field reads with `__str_concat`, returning a native string —
- * zero host imports.
+ * The spec result is `"/" + R.[[OriginalSource]] + "/" + R.[[OriginalFlags]]`,
+ * both of which the native backend already produces (the struct's `source`
+ * field is stored in the spec-escaped §22.2.6.13.1 form, and `__regex_flags_str`
+ * builds the d-g-i-m-s-u-v-y flag string). In standalone / nativeStrings mode
+ * there is no JS host, so the generic ref→string coercion path leaked
+ * `env::Object_toString` (or null-deref'd). This composes the two native field
+ * reads with `__str_concat`.
  *
- * Returns `undefined` when the call is not a static-RegExp `.toString()`
- * (caller falls through), `null` after a narrowed refusal, or the result type.
+ * Used by the `re.toString()` method dispatch (`tryCompileStandaloneRegExpToString`)
+ * AND by the value→string coercion paths (`String(re)`, `` `${re}` ``) which
+ * would otherwise null-deref or yield `"[object Object]"` (#2161).
+ *
+ * Returns the emitted native-string `ValType`, `null` after a reported refusal
+ * (e.g. a non-backend RegExp), or `undefined` when the expression is not a
+ * static / backend-created RegExp the caller should keep falling through for.
  */
-export function tryCompileStandaloneRegExpToString(
+export function emitStandaloneRegExpToStringFromExpr(
   ctx: CodegenContext,
   fctx: FunctionContext,
-  expr: ts.CallExpression,
-  propAccess: ts.PropertyAccessExpression,
+  regexpExpr: ts.Expression,
 ): ValType | null | undefined {
-  if (!ctx.standalone || propAccess.name.text !== "toString" || expr.arguments.length !== 0) return undefined;
-  const objType = ctx.checker.getTypeAtLocation(propAccess.expression);
+  if (!ctx.standalone) return undefined;
+  const objType = ctx.checker.getTypeAtLocation(regexpExpr);
   const nonNull = objType.getNonNullableType?.() ?? objType;
   if (!isGlobalRegExpType(nonNull)) return undefined;
   // Only static / backend-created receivers route to the native struct; a
   // dynamic externref RegExp falls through to the host/refusal path.
-  if (
-    !isStaticStandaloneRegExpCreation(ctx, propAccess.expression) &&
-    !isKnownBackendCreatedRegExpReceiver(ctx, propAccess.expression)
-  ) {
+  if (!isStaticStandaloneRegExpCreation(ctx, regexpExpr) && !isKnownBackendCreatedRegExpReceiver(ctx, regexpExpr)) {
     return undefined;
   }
 
   const repr = nativeStringRepr(ctx);
   if (repr === undefined) return undefined;
 
-  const loaded = loadStandaloneRegExpStruct(ctx, fctx, propAccess.expression);
+  const loaded = loadStandaloneRegExpStruct(ctx, fctx, regexpExpr);
   if (loaded === null) return null;
   const { regexpLocal, structTypeIdx } = loaded;
 
@@ -1864,6 +1865,16 @@ export function tryCompileStandaloneRegExpToString(
   acc = repr.concat(acc, flagsInstrs);
   for (const instr of acc) fctx.body.push(instr);
   return repr.resultType;
+}
+
+export function tryCompileStandaloneRegExpToString(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  propAccess: ts.PropertyAccessExpression,
+): ValType | null | undefined {
+  if (!ctx.standalone || propAccess.name.text !== "toString" || expr.arguments.length !== 0) return undefined;
+  return emitStandaloneRegExpToStringFromExpr(ctx, fctx, propAccess.expression);
 }
 
 /**

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -23,6 +23,7 @@ import {
   tryCompileNativeVecConcatOperand,
 } from "./native-strings.js";
 import {
+  emitStandaloneRegExpToStringFromExpr,
   tryCompileStandaloneStringMatch,
   tryCompileStandaloneStringMatchAll,
   tryCompileStandaloneStringReplace,
@@ -457,6 +458,28 @@ export function compileNativeTemplateExpression(
     // stringification rather than "0" (parallels the JS-host path).
     const spanNativeIsUndef = (spanNativeTsType.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void)) !== 0;
     const spanNativeIsNull = (spanNativeTsType.flags & ts.TypeFlags.Null) !== 0;
+
+    // #2161 — a static / backend-created RegExp substitution stringifies via its
+    // native RegExp.prototype.toString (§22.2.6.14 → "/" + source + "/" + flags),
+    // not the `$__any_to_string` "[object Object]" fallthrough below. The core
+    // compiles the receiver itself and leaves a native string ref on the stack,
+    // so route through it BEFORE compileExpression and skip the type cascade.
+    if (standaloneNativeStrings) {
+      const reStr = emitStandaloneRegExpToStringFromExpr(ctx, fctx, span.expression);
+      if (reStr !== undefined && reStr !== null) {
+        if (i === 0 && !expr.head.text) {
+          // no head — first span result is the running accumulator
+        } else {
+          fctx.body.push({ op: "call", funcIdx: concatIdx } as Instr);
+        }
+        if (span.literal.text) {
+          compileStringLiteral(ctx, fctx, span.literal.text, span.literal);
+          fctx.body.push({ op: "call", funcIdx: concatIdx } as Instr);
+        }
+        continue;
+      }
+    }
+
     const spanType = compileExpression(ctx, fctx, span.expression);
     const spanIsScalarNullish = (spanNativeIsUndef || spanNativeIsNull) && spanType && spanType.kind !== "externref";
     const spanIsBool = spanType && spanType.kind === "i32" && isBooleanType(spanNativeTsType);

--- a/tests/issue-2161-regex-string-coercion.test.ts
+++ b/tests/issue-2161-regex-string-coercion.test.ts
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2161 — standalone `String(re)` + template-literal `` `${re}` `` RegExp→string
+ * coercion (§22.2.6.14).
+ *
+ * `re.toString()` (the method-call form) already renders `"/" + re.source + "/"
+ * + re.flags` natively (slice 7), but the value→string COERCION paths did not
+ * route through it:
+ *   - `String(re)` — the `String()` builtin lowering null-deref'd on the
+ *     `$NativeRegExp` struct (the generic ref→string `coerceType` path).
+ *   - `` `${re}` `` — the native template-literal path fell through to
+ *     `$__any_to_string`, yielding `"[object Object]"`.
+ * Both now route to the shared `emitStandaloneRegExpToStringFromExpr` core,
+ * returning the spec `"/source/flags"` string with ZERO host imports.
+ */
+
+/** Compile `build()` to set a module-global string, read it back char-by-char. */
+async function standaloneString(buildExpr: string): Promise<{ out: string; leaks: string[] }> {
+  const source = `
+    let g: string = "";
+    export function build(): void { g = ${buildExpr}; }
+    export function len(): number { return g.length; }
+    export function at(i: number): number { return g.charCodeAt(i); }
+  `;
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  // No JS-host import may leak in standalone — in particular the generic object
+  // toString / extern coercion bridges that the coercion path would have used.
+  const labels = r.imports.map((i) => `${i.module}::${i.name}`);
+  const leaks = labels.filter((l) =>
+    /^env::Object_toString$|^env::__extern_toString$|^env::__extern_get$|^wasm:js-string::/.test(l),
+  );
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const ex = instance.exports as { build: () => void; len: () => number; at: (i: number) => number };
+  ex.build();
+  let out = "";
+  for (let i = 0; i < ex.len(); i++) out += String.fromCharCode(ex.at(i));
+  return { out, leaks };
+}
+
+describe("#2161 — standalone String(re) coercion", () => {
+  it("String(/ab/gi) → /ab/gi", async () => {
+    const { out, leaks } = await standaloneString("String(/ab/gi)");
+    expect(out).toBe("/ab/gi");
+    expect(leaks).toEqual([]);
+  });
+
+  it("String(/x/) (no flags) → /x/", async () => {
+    const { out, leaks } = await standaloneString("String(/x/)");
+    expect(out).toBe("/x/");
+    expect(leaks).toEqual([]);
+  });
+
+  it('String(new RegExp("")) → /(?:)/ (§22.2.6.13.1 empty source)', async () => {
+    const { out, leaks } = await standaloneString('String(new RegExp(""))');
+    expect(out).toBe("/(?:)/");
+    expect(leaks).toEqual([]);
+  });
+
+  it("String(/a\\/b/) preserves the escaped slash", async () => {
+    const { out, leaks } = await standaloneString("String(/a\\/b/)");
+    expect(out).toBe("/a\\/b/");
+    expect(leaks).toEqual([]);
+  });
+
+  it("String(re) on a const-bound receiver", async () => {
+    const { out, leaks } = await standaloneString("(() => { const rc = /zz/m; return String(rc); })()");
+    expect(out).toBe("/zz/m");
+    expect(leaks).toEqual([]);
+  });
+
+  it("renders the canonical dgimsy flag order", async () => {
+    const { out } = await standaloneString("String(/p/dgimsy)");
+    expect(out).toBe("/p/dgimsy");
+  });
+
+  it("matches host-JS String(re) exactly across pattern/flag pairs", async () => {
+    for (const [expr, host] of [
+      ["String(/foo/)", String(/foo/)],
+      ["String(/foo/g)", String(/foo/g)],
+      ["String(/a.b/is)", String(/a.b/is)],
+      ["String(/\\d+/gimsuy)", String(/\d+/gimsuy)],
+    ] as const) {
+      const { out } = await standaloneString(expr);
+      expect(out, expr).toBe(host);
+    }
+  });
+});
+
+describe("#2161 — standalone template-literal `${re}` coercion", () => {
+  it("`x${/abc/gi}y` → x/abc/giy", async () => {
+    const { out, leaks } = await standaloneString("`x${/abc/gi}y`");
+    expect(out).toBe("x/abc/giy");
+    expect(leaks).toEqual([]);
+  });
+
+  it("`<${/foo/}>` (flagless span) → </foo/>", async () => {
+    const { out, leaks } = await standaloneString("`<${/foo/}>`");
+    expect(out).toBe("</foo/>");
+    expect(leaks).toEqual([]);
+  });
+
+  it("a leading RegExp span with no head text", async () => {
+    const { out } = await standaloneString("`${/p/dgimsy}`");
+    expect(out).toBe("/p/dgimsy");
+  });
+
+  it("two RegExp spans in one template", async () => {
+    const { out, leaks } = await standaloneString("`${/a/g}-${/b/i}`");
+    expect(out).toBe("/a/g-/b/i");
+    expect(leaks).toEqual([]);
+  });
+
+  it("template on a const-bound receiver", async () => {
+    const { out } = await standaloneString("(() => { const rc = /zz/m; return `[${rc}]`; })()");
+    expect(out).toBe("[/zz/m]");
+  });
+
+  it("matches host-JS template coercion exactly", async () => {
+    for (const [expr, host] of [
+      ["`<${/foo/}>`", `<${/foo/}>`],
+      ["`${/a.b/is}`", `${/a.b/is}`],
+      ["`p=${/\\w+/gu};`", `p=${/\w+/gu};`],
+    ] as const) {
+      const { out } = await standaloneString(expr);
+      expect(out, expr).toBe(host);
+    }
+  });
+});


### PR DESCRIPTION
## #2161 — standalone `String(re)` + template-literal `` `${re}` `` RegExp→string coercion

Closes the slice-7 deferral. `re.toString()` already renders §22.2.6.14
`"/" + source + "/" + flags` natively in standalone mode, but the
value→string COERCION paths did not route through it:

| form | before | after |
|---|---|---|
| `String(/abc/gi)` | runtime null-deref (null string) | `/abc/gi` |
| `` `x${/abc/gi}y` `` | `x[object Object]y` | `x/abc/giy` |
| `re.toString()` | `/abc/gi` (slice 7) | unchanged |

### Fix
- `regexp-standalone.ts`: extract `emitStandaloneRegExpToStringFromExpr(ctx, fctx, regexpExpr)` from the slice-7 method helper (now delegates) — composes the struct's spec-escaped `source` field + `__regex_flags_str(flags)` via `__str_concat`.
- `expressions/calls.ts`: route a static / backend-created RegExp `String(...)` argument through the core BEFORE `compileExpression` (the generic ref→string `coerceType` null-deref'd the `$NativeRegExp` struct), mirroring the #2160 `String(arr)` hook.
- `string-ops.ts`: route a RegExp template span through the core before the `$__any_to_string` `"[object Object]"` fallthrough.

Gated on `ctx.standalone` + a static / backend-created RegExp receiver; dynamic externref receivers and host / fast-with-host modes fall through unchanged. **Zero host imports.**

### Tests
`tests/issue-2161-regex-string-coercion.test.ts` (13) — `String(re)` flagged/flagless/empty-pattern/escaped-slash/const-bound/canonical-dgimsy + host-JS parity; `` `${re}` `` head/flagless/leading-no-head/two-spans/const-bound + host-JS parity — all standalone with an empty importObject asserting no `Object_toString` / `__extern_*` / `js-string` leak.

700 regex regression cases + 28 existing #2161 cases stay green (refactor is behaviour-preserving). tsc + prettier + biome(lint) + stack-balance + coercion-sites + any-box gates clean.

**#2161 stays open** for: (a) `RegExp.prototype` reflection (gated on #2158's prototype-object representation); (c) dynamic / `any`-typed receivers; and the regex-engine feature tail (v-flag `\q{}`, dynamic ctor patterns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)