### PR TITLE
fix(#6408): object-literal method body host-import leak (__make_getter_callback) standalone

### DIFF
--- a/plan/issues/6408-standalone-objlit-data-method-key-sentinel-emit.md
+++ b/plan/issues/6408-standalone-objlit-data-method-key-sentinel-emit.md
@@ -1,11 +1,12 @@
 ---
 id: 6408
 title: "standalone object-literal data/method property keys emit `global.get -1` sentinel → binary emit error (~17 tests; subcluster of a 155-test #51-family residual)"
-status: in-progress
-assignee: ttraenkler/sdev-harvest
+status: done
+assignee: ttraenkler/sd2
 sprint: 64
 created: 2026-06-18
-updated: 2026-06-18
+updated: 2026-06-19
+completed: 2026-06-19
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -140,3 +141,61 @@ Recommend a dedicated follow-up issue (a systematic `global.get`-of-string-globa
 audit across `src/codegen/*.ts` under `ctx.standalone`) rather than folding it
 into this focused PR — each site is mechanically identical but the stack-type and
 GC-mode verification per site is what makes it broad-blast-radius.
+
+## Follow-up landed (2026-06-19, sd2) — object-literal METHOD body leaked `__make_getter_callback` standalone
+
+The key-sentinel PR #1710 (merged) fixed the **key** emit for the
+PropertyAssignment + MethodDeclaration arms. While re-probing the same
+accessor-path object-literal codegen on current main, found a **second,
+distinct** standalone defect in the *method-body* compilation (orthogonal to the
+key sentinel — the key was already host-free):
+
+**An object literal mixing a regular method with a getter/setter leaked the
+`env::__make_getter_callback` host import in `--target standalone`.** Probe on
+main:
+
+| literal shape | env import (standalone) |
+|---|---|
+| `{ get id() {…} }` | (none) ✓ |
+| `{ tag: 7, get id() {…} }` (data + getter, #6408 key fix) | (none) ✓ |
+| `{ describe() {…}, get id() {…} }` (method + getter) | **`__make_getter_callback`** ✗ |
+
+**Root cause** (`src/codegen/literals.ts`, `compileObjectLiteralWithAccessors`):
+the getter/setter arm routes through `emitObjectLiteralAccessorFn`, which is
+standalone-aware (#1888 S5b) — host-free `compileArrowAsClosure` under
+`ctx.standalone`. But the **three sibling MethodDeclaration arms** (well-known
+Symbol-key, runtime-computed-key, string/identifier-key) called
+`compileArrowAsCallback(prop, { needsThis: true })` **unconditionally**.
+`needsThis: true` selects the `__make_getter_callback` JS bridge
+(`closures.ts:2961` `makeCallbackName = needsThis ? "__make_getter_callback" :
+"__make_callback"`), an `env::` host import — so a method on an accessor-path
+literal imported the bridge even in pure-Wasm mode.
+
+**Fix:** new `emitObjectLiteralMethodFn` mirroring `emitObjectLiteralAccessorFn`
+— standalone → host-free `compileArrowAsClosure` (→ externref); GC / JS-host →
+the unchanged `compileArrowAsCallback(... needsThis)` bridge. The three method
+arms now route through it. The standalone method closure is dispatched via the
+same `__current_this`-bound closure-call path the getter closures already use,
+so `this` binds correctly. GC mode is unchanged (same `compileArrowAsCallback`).
+
+**Verified** (`tests/issue-6408-objlit-method-host-leak.test.ts`, 6 cases, all
+standalone, asserting BOTH zero `env` imports AND correct `this`-bound runtime
+values): getter-sibling still works; method reads `this` data (7); `this`-mutating
+method sees mutation (2); computed-key method (9); iterator-shaped `next()` method
++ getter (0); method-only-no-getter regression guard (4). The 4 existing
+`issue-6408-objlit-key-sentinel` cases stay green; `accessor-side-effects` +
+`object-literals` suites green (37). `tsc --noEmit` clean; prettier + biome clean.
+The two pre-existing failures (`issue-1888` 2-4-arg dispatch; the
+`object-*-getters-setters` / `object-define-property-accessors` `./helpers.js`
+harness-load errors) fail **identically** on `origin/main` with and without this
+change — not regressions.
+
+**Out of this slice (separate orthogonal standalone leaks, noted not fixed):**
+- A `[Symbol.iterator]()`/well-known-Symbol **computed method key** still pulls in
+  `env::__box_symbol` (the well-known-symbol key-boxing path, `literals.ts:548`) —
+  independent of the method-body bridge fixed here.
+- The broader 137-test `-1` string-global sentinel sweep across other emit sites
+  (above) remains; many of those sites are already `< 0`-guarded on current main
+  (`class-bodies.ts`, the `defineProperty` value path probed clean), so the live
+  residual is smaller than the original 155 tally and needs a fresh
+  baseline-diff bucket count before a dedicated sweep issue.

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -634,7 +634,7 @@ function compileObjectLiteralWithAccessors(
         fctx.body.push({ op: "local.get", index: objLocal });
         fctx.body.push({ op: "i32.const", value: wellKnownSymId });
         fctx.body.push({ op: "call", funcIdx: boxSymIdx });
-        const ok = compileArrowAsCallback(ctx, fctx, prop as unknown as ts.FunctionExpression, { needsThis: true });
+        const ok = emitObjectLiteralMethodFn(ctx, fctx, prop as unknown as ts.FunctionExpression);
         if (!ok) {
           fctx.body.push({ op: "ref.null.extern" });
         }
@@ -651,7 +651,7 @@ function compileObjectLiteralWithAccessors(
         } else if (keyType.kind !== "externref") {
           coerceType(ctx, fctx, keyType, { kind: "externref" });
         }
-        const okRt = compileArrowAsCallback(ctx, fctx, prop as unknown as ts.FunctionExpression, { needsThis: true });
+        const okRt = emitObjectLiteralMethodFn(ctx, fctx, prop as unknown as ts.FunctionExpression);
         if (okRt) {
           fctx.body.push({ op: "call", funcIdx: setIdx });
         } else {
@@ -673,7 +673,7 @@ function compileObjectLiteralWithAccessors(
       for (const instr of stringConstantExternrefInstrs(ctx, methodName)) {
         fctx.body.push(instr);
       }
-      const ok = compileArrowAsCallback(ctx, fctx, prop as unknown as ts.FunctionExpression, { needsThis: true });
+      const ok = emitObjectLiteralMethodFn(ctx, fctx, prop as unknown as ts.FunctionExpression);
       if (!ok) {
         fctx.body.push({ op: "ref.null.extern" });
       }
@@ -772,6 +772,36 @@ function emitObjectLiteralAccessorFn(
     return true;
   }
   return !!compileArrowAsCallback(ctx, fctx, fn, { needsThis: true, ...captureOptions });
+}
+
+/**
+ * (#6408 follow-up) Compile an object-literal METHOD body and leave a callable
+ * externref on the stack for `__extern_set`. Mirrors the getter/setter routing
+ * in `emitObjectLiteralAccessorFn`: standalone → host-free closure
+ * (`compileArrowAsClosure`, converted to externref) so the method does NOT leak
+ * the `__make_getter_callback` JS bridge; JS-host / GC → `compileArrowAsCallback`
+ * with `needsThis: true` (unchanged host bridge). Returns `false` when the caller
+ * should push `ref.null.extern`.
+ *
+ * Why: the three MethodDeclaration arms below previously called
+ * `compileArrowAsCallback(... { needsThis: true })` unconditionally, which routes
+ * through `__make_getter_callback` (an `env::` host import, closures.ts) even in
+ * `--target standalone`. The sibling get/set arm was already standalone-aware
+ * (#1888 S5b); a literal mixing a regular method with a getter therefore left the
+ * getter host-free but leaked the bridge for the method. The standalone method
+ * closure is invoked through the same `__current_this`-bound closure-call path the
+ * getter closures use, so `this` is bound correctly.
+ */
+function emitObjectLiteralMethodFn(ctx: CodegenContext, fctx: FunctionContext, fn: ts.FunctionExpression): boolean {
+  if (ctx.standalone) {
+    const closureType = compileArrowAsClosure(ctx, fctx, fn);
+    if (!closureType) return false;
+    if (closureType.kind !== "externref") {
+      fctx.body.push({ op: "extern.convert_any" } as Instr);
+    }
+    return true;
+  }
+  return !!compileArrowAsCallback(ctx, fctx, fn, { needsThis: true });
 }
 
 /**

--- a/tests/issue-6408-objlit-method-host-leak.test.ts
+++ b/tests/issue-6408-objlit-method-host-leak.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #6408 follow-up — a regular METHOD on an object literal that ALSO carries a
+ * getter/setter must not leak the `__make_getter_callback` JS host import in
+ * `--target standalone`.
+ *
+ * Defect: the object-literal accessor-path compiler
+ * (`compileObjectLiteralWithAccessors`, src/codegen/literals.ts) compiled its
+ * getter/setter arm through the standalone-aware `emitObjectLiteralAccessorFn`
+ * (host-free `compileArrowAsClosure` under `ctx.standalone`, #1888 S5b), but the
+ * three sibling MethodDeclaration arms called `compileArrowAsCallback(...,
+ * { needsThis: true })` UNCONDITIONALLY. With `needsThis: true` that routes
+ * through the `__make_getter_callback` `env::` host import (closures.ts:2961),
+ * so a literal that mixes a regular method with a getter compiled clean but
+ * IMPORTED `env::__make_getter_callback` — defeating standalone (pure-Wasm)
+ * output. (A getter-only literal, or a data-property + getter literal, were
+ * already host-free.)
+ *
+ * Fix: route the three method arms through `emitObjectLiteralMethodFn`, which
+ * mirrors `emitObjectLiteralAccessorFn`: standalone → host-free closure; GC /
+ * JS-host → the unchanged `compileArrowAsCallback` bridge. The standalone method
+ * closure is invoked through the same `__current_this`-bound closure-call path
+ * the getter closures use, so `this` is bound correctly.
+ */
+
+async function buildStandalone(body: string): Promise<{
+  result: number;
+  envImports: string[];
+}> {
+  const src = `export function test(): number { ${body} }`;
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const envImports = WebAssembly.Module.imports(new WebAssembly.Module(r.binary))
+    .filter((i) => i.module === "env")
+    .map((i) => i.name);
+  const importObject: Record<string, unknown> = {};
+  const { instance } = await WebAssembly.instantiate(r.binary, importObject);
+  (importObject as { __setExports?: (e: unknown) => void }).__setExports?.(instance.exports);
+  const result = (instance.exports as { test(): number }).test();
+  return { result, envImports };
+}
+
+describe("#6408 follow-up — object-literal method + getter is host-import-free standalone", () => {
+  it("the getter still works and no env import leaks", async () => {
+    const { result, envImports } = await buildStandalone(
+      `const o: any = { describe() { return 5; }, get id() { return 1; } }; return o.id as number;`,
+    );
+    expect(result).toBe(1);
+    expect(envImports).toEqual([]);
+  });
+
+  it("the method reads `this` data and no env import leaks", async () => {
+    const { result, envImports } = await buildStandalone(
+      `const o: any = { tag: 7, describe() { return this.tag; }, get id() { return 1; } }; return o.describe() as number;`,
+    );
+    expect(result).toBe(7);
+    expect(envImports).toEqual([]);
+  });
+
+  it("a `this`-mutating method + getter sees the mutation", async () => {
+    const { result, envImports } = await buildStandalone(
+      `const o: any = { count: 0, inc() { this.count = this.count + 1; return this.count; }, get c() { return this.count; } };
+       o.inc(); o.inc(); return o.c as number;`,
+    );
+    expect(result).toBe(2);
+    expect(envImports).toEqual([]);
+  });
+
+  it("a computed-key method + getter is host-free", async () => {
+    const { result, envImports } = await buildStandalone(
+      `const k = 'foo'; const o: any = { [k]() { return 9; }, get g() { return 1; } }; return o.foo() as number;`,
+    );
+    expect(result).toBe(9);
+    expect(envImports).toEqual([]);
+  });
+
+  it("an iterator-shaped object (next() method + getter) is host-free", async () => {
+    // The same shape the standalone-string-global-sentinel bucket flagged
+    // (iterators with a getter) — but with a STRING-named `next` method rather
+    // than a `[Symbol.iterator]` computed key, which would separately pull in
+    // the `__box_symbol` host import (an orthogonal well-known-Symbol-key leak,
+    // NOT the `__make_getter_callback` method-body leak this fix targets).
+    const { result, envImports } = await buildStandalone(
+      `const o: any = {
+         _i: 0,
+         get done() { return false; },
+         next() { return { value: this._i, done: true }; }
+       };
+       return o.next().value as number;`,
+    );
+    expect(result).toBe(0);
+    expect(envImports).toEqual([]);
+  });
+
+  it("method-only literal (no getter) stays host-free — regression guard", async () => {
+    const { result, envImports } = await buildStandalone(
+      `const o: any = { v: 3, get2() { return this.v + 1; } }; return o.get2() as number;`,
+    );
+    expect(result).toBe(4);
+    expect(envImports).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

A **second, distinct** standalone defect in the same accessor-path object-literal codegen that #6408's key-sentinel PR (#1710, merged) touched — orthogonal to the key sentinel (the key was already host-free).

**An object literal that mixes a regular method with a getter/setter leaked the `env::__make_getter_callback` host import in `--target standalone`** (pure-Wasm) mode.

| literal shape | env import (standalone, on main) |
|---|---|
| `{ get id() {…} }` | (none) |
| `{ tag: 7, get id() {…} }` (data + getter, #6408 key fix) | (none) |
| `{ describe() {…}, get id() {…} }` (method + getter) | **`__make_getter_callback`** |

## Root cause

`compileObjectLiteralWithAccessors` (`src/codegen/literals.ts`) routes the getter/setter arm through the standalone-aware `emitObjectLiteralAccessorFn` (host-free `compileArrowAsClosure` under `ctx.standalone`, #1888 S5b). But the three sibling **MethodDeclaration** arms called `compileArrowAsCallback(prop, { needsThis: true })` **unconditionally**. `needsThis: true` selects the `__make_getter_callback` JS bridge (`closures.ts:2961`), an `env::` host import — so a method on an accessor-path literal imported the bridge even standalone.

## Fix

New `emitObjectLiteralMethodFn` mirroring `emitObjectLiteralAccessorFn`: standalone → host-free `compileArrowAsClosure` (→ externref); GC / JS-host → the unchanged `compileArrowAsCallback` bridge. The three method arms route through it. The standalone method closure is invoked via the same `__current_this`-bound closure-call path the getter closures use, so `this` binds correctly.

## Validation

`tests/issue-6408-objlit-method-host-leak.test.ts` (6 cases, all standalone, asserting BOTH zero `env` imports AND correct `this`-bound runtime values): getter-sibling works; method reads `this` data (7); `this`-mutating method (2); computed-key method (9); iterator-shaped `next()`+getter (0); method-only regression guard (4). Existing `issue-6408-objlit-key-sentinel` (4) + `accessor-side-effects` + `object-literals` suites green (37). `tsc --noEmit` / prettier / biome clean. GC mode unchanged. The pre-existing `issue-1888` 2-4-arg-dispatch + `./helpers.js` harness-load failures are **identical on `origin/main`** with and without this change.

## Out of scope (separate orthogonal standalone leaks, documented in the issue)

- `[Symbol.iterator]` / well-known-Symbol **computed method keys** still pull `env::__box_symbol` (key-boxing path, `literals.ts:548`).
- The broader 137-test `-1` string-global sentinel sweep — many of those sites are already `< 0`-guarded on current main, so the live residual is smaller than the original 155 tally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)