### PR TITLE
fix(#1938): linear number[] f64 element storage (part 2)

### DIFF
--- a/plan/issues/1938-linear-number-array-i32-truncation-double-eval.md
+++ b/plan/issues/1938-linear-number-array-i32-truncation-double-eval.md
@@ -1,10 +1,12 @@
 ---
 id: 1938
 title: "Linear backend: number[] stores i32 elements ([1.5] → [1]) and element-assignment evaluates RHS twice"
-status: in-progress
+status: done
+completed: 2026-06-19
+assignee: ttraenkler/sd3
 sprint: 64
 created: 2026-06-10
-updated: 2026-06-11
+updated: 2026-06-19
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -413,3 +415,75 @@ Existing suites that must stay green: `tests/linear-element-assign.test.ts`
 
 Compiler quality review 2026-06. Related: #1937 (fail-loud companion),
 #1854 (cross-backend differential harness would have caught both).
+
+---
+
+## Part 2 — LANDED (2026-06-19, sd3)
+
+Implemented the architect's stride-8 uniform-f64-slot design in one atomic PR.
+`[1.5][0]` now returns `1.5`; `[0.1,0.2,0.3]` sums to `0.6`; `map(x=>x*2)` no
+longer truncates the intermediate. **`done`.**
+
+### What changed (representation: i32×4 → f64×8 slots)
+
+**`src/codegen-linear/runtime.ts`** — the array runtime element boundary is now
+typed **f64**, stride 8, slot bits opaque to the runtime:
+- `__arr_new`/`__arr_grow` allocate `16 + cap*8`; grow copies slots verbatim with
+  `f64.load`/`f64.store`.
+- `__arr_push(i32,f64)`, `__arr_get(i32,i32)→f64`, `__arr_set(i32,i32,f64)` — all
+  `f64.load`/`f64.store` at `idx*8`; OOB `__arr_get` returns `f64.const 0`;
+  `__arr_set` zero-fills the gap with `f64.const 0`. `__arr_len`/`__arr_slice`
+  unchanged in shape (slice is f64-clean for free via get→push).
+- `__arr_from_data` (C-ABI param input) widens each incoming packed i32 into the
+  low 4 bytes of an 8-byte slot (`i64.extend_i32_u`→`f64.reinterpret_i64`).
+- `__u8arr_from_arr` reads the source `number[]` element as an f64 slot and
+  truncates to a byte.
+- `__str_split` encodes each substring i32 pointer into the f64 slot before push.
+
+**`src/codegen-linear/index.ts`** — two helpers, `pushI32ToSlot` /
+`pushSlotToI32` (the i64-shuffle), thread the **existing per-site
+`elemIsI32`/`inferExprType` decision** (no new global routing). Sites updated:
+array literal, element read, element assign, for-of (incl. the
+`ArrayOrUint8Array` runtime-dispatch `if` reconciled to f64), array
+destructuring, `.push`, HOF (`map`/`filter`/`flatMap` load + push-back —
+**deleted the `i32.trunc_f64_s` truncation bugs**), and `join` (decode slot →
+string handle). **Booleans ride the f64 path** (they compile to `f64.const 0/1`
+in this backend), so only true reference (string/object) slots take the
+encode/decode path.
+
+**`src/codegen-linear/c-abi.ts`** — layout comment updated; number[] return
+payload is now 8-byte-strided (host reads it as `double*` / `Float64Array`).
+
+**`src/codegen-linear/simd.ts`** — `__arr_indexOf_simd` / `__arr_fill_simd`
+(dead helpers, no emit site, but kept internally consistent) rewritten from
+`i32x4` (4-lane, stride 4) to `f64x2` (2-lane, stride 16) over the new layout.
+
+### Verification (scoped, all green)
+
+- `tests/issue-1938-number-array-f64.test.ts` (17 cases): the `[1.5][0]`
+  headline, fractional sum/push/set/map/filter, for-of read, NaN, `-0`
+  (`1/-0 === -Infinity`), >2^31 integer, nested `number[][]`, `string[]` read +
+  join, `boolean[]`, store-beyond-length zero-fill, destructuring-rest slice.
+- `tests/issue-1835.test.ts` — C-ABI array return updated to read `Float64Array`
+  (8-byte stride) + a new fractional-element round-trip case.
+- `tests/linear-array.test.ts` + `tests/simd.test.ts` — updated to the f64
+  boundary (push/set/search/fill values become `f64.const`; gets return f64).
+- Full linear suite (126 tests across 15 files) + wasi/simd/c-abi all green.
+- `tsc --noEmit` clean.
+- The 2 pre-existing failures in this area (`issue-1655` `Uint8Array.subarray`
+  "illegal cast"; `real-world-wasi` `it.fails` process.argv) fail **identically
+  on clean `origin/main`** — not regressions from this change.
+
+### Out of scope (unchanged, documented limitations)
+
+- **Map/Set keys/values** still use i32 storage (`index.ts:1021-1033`,
+  `runtime.ts __map_*`/`__set_*`). A fractional Map key still truncates — a
+  distinct, larger surface (hash-bucket layout, `__nmap`/`__nset` variants). No
+  fail-loud diagnostic was added (the existing Map behaviour is unchanged, so no
+  regression); the representation fix belongs in a follow-up issue.
+- **`Array.prototype.slice`/`indexOf`/`fill` as method calls** are still not
+  wired into `compileArrayMethodCall` (a pre-existing gap, orthogonal to the
+  representation). The SIMD helpers exist but have no emit site.
+- **number[] C-ABI *param* input** still rehydrates from packed i32 (the host
+  would pass doubles for a real number array) — only reference/string array
+  params round-trip via `__arr_from_data`. Documented in the runtime comment.

--- a/src/codegen-linear/c-abi.ts
+++ b/src/codegen-linear/c-abi.ts
@@ -21,7 +21,12 @@ import type { FuncTypeDef, Instr, ValType, WasmModule } from "../ir/types.js";
 // ── Linear-memory aggregate header layout (mirrors runtime.ts) ───────
 //
 // String: [header 8B][len:u32 @ +8][utf8 bytes @ +12...]
-// Array:  [header 8B][len:u32 @ +8][cap:u32 @ +12][elements: i32×cap @ +16...]
+// Array:  [header 8B][len:u32 @ +8][cap:u32 @ +12][elements: 8B×cap @ +16...]
+//
+// #1938: array elements are 8-byte slots (f64 bit pattern). A number[] return
+// payload is therefore 8-byte-strided (read it as a `double*` / Float64Array
+// on the host); a reference/handle array stores the i32 in the low 4 bytes of
+// each 8-byte slot.
 //
 // These constants MUST stay in sync with addStringRuntime / addArrayRuntime
 // in src/codegen-linear/runtime.ts (#1835).

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -920,7 +920,9 @@ function compileForOfStatement(ctx: LinearContext, fctx: LinearFuncContext, stmt
   // Load element: x = getter(arr, idx)
   if (loopVarIdx !== undefined) {
     if (iterKind === "ArrayOrUint8Array") {
-      // Runtime dispatch: check tag byte at offset 0
+      // Runtime dispatch: check tag byte at offset 0. Both arms must yield the
+      // same type; __u8arr_get returns i32 (byte), __arr_get returns an f64 slot
+      // (#1938). Reconcile to f64 (u8 side: f64.convert_i32_u inside `then`).
       const arrGetIdx = ctx.funcMap.get("__arr_get")!;
       const u8GetIdx = ctx.funcMap.get("__u8arr_get")!;
       fctx.body.push({ op: "local.get", index: arrLocal });
@@ -929,11 +931,12 @@ function compileForOfStatement(ctx: LinearContext, fctx: LinearFuncContext, stmt
       fctx.body.push({ op: "i32.eq" });
       fctx.body.push({
         op: "if",
-        blockType: { kind: "val", type: { kind: "i32" } },
+        blockType: { kind: "val", type: { kind: "f64" } },
         then: [
           { op: "local.get", index: arrLocal },
           { op: "local.get", index: idxLocal },
           { op: "call", funcIdx: u8GetIdx },
+          { op: "f64.convert_i32_u" },
         ],
         else: [
           { op: "local.get", index: arrLocal },
@@ -941,15 +944,29 @@ function compileForOfStatement(ctx: LinearContext, fctx: LinearFuncContext, stmt
           { op: "call", funcIdx: arrGetIdx },
         ],
       });
+      // Slot is now f64. A ref/string element needs decoding to its i32 handle.
+      if (elementIsI32) {
+        pushSlotToI32(fctx);
+      }
+    } else if (iterKind === "Uint8Array") {
+      // u8 element is an i32 byte; convert to f64 unless the binding is i32.
+      const u8GetIdx = ctx.funcMap.get("__u8arr_get")!;
+      fctx.body.push({ op: "local.get", index: arrLocal });
+      fctx.body.push({ op: "local.get", index: idxLocal });
+      fctx.body.push({ op: "call", funcIdx: u8GetIdx });
+      if (!elementIsI32) {
+        fctx.body.push({ op: "f64.convert_i32_s" });
+      }
     } else {
-      const getFuncName = iterKind === "Uint8Array" ? "__u8arr_get" : "__arr_get";
-      const arrGetIdx = ctx.funcMap.get(getFuncName)!;
+      // Array element is an f64 slot (#1938). For a number/boolean binding the
+      // slot IS the value; for a ref/string binding decode to its i32 handle.
+      const arrGetIdx = ctx.funcMap.get("__arr_get")!;
       fctx.body.push({ op: "local.get", index: arrLocal });
       fctx.body.push({ op: "local.get", index: idxLocal });
       fctx.body.push({ op: "call", funcIdx: arrGetIdx });
-    }
-    if (!elementIsI32) {
-      fctx.body.push({ op: "f64.convert_i32_s" });
+      if (elementIsI32) {
+        pushSlotToI32(fctx);
+      }
     }
     fctx.body.push({ op: "local.set", index: loopVarIdx });
   }
@@ -2608,7 +2625,15 @@ function compileArrayLiteral(ctx: LinearContext, fctx: LinearFuncContext, expr: 
 
     for (const elem of elements) {
       fctx.body.push({ op: "local.get", index: tmpLocal });
-      compileExprToI32(ctx, fctx, elem); // value → i32 for storage
+      // #1938: __arr_push takes an f64 slot. A numeric element flows straight
+      // in as its f64 value (no truncation); a ref/bool element is compiled to
+      // i32 and encoded into the low 4 bytes of the slot.
+      if (inferExprType(ctx, fctx, elem).kind === "f64") {
+        compileExprToF64(ctx, fctx, elem);
+      } else {
+        compileExprToI32(ctx, fctx, elem);
+        pushI32ToSlot(fctx);
+      }
       fctx.body.push({ op: "call", funcIdx: arrPushIdx });
     }
 
@@ -2763,12 +2788,12 @@ function compileArrayDestructuring(
       const varName = element.name.text;
       const localIdx = addLocal(fctx, varName, elemIsI32 ? { kind: "i32" } : { kind: "f64" });
 
-      // x = __arr_get(arr, i)
+      // x = __arr_get(arr, i) → f64 slot (#1938)
       fctx.body.push({ op: "local.get", index: arrLocal });
       fctx.body.push({ op: "i32.const", value: i });
       fctx.body.push({ op: "call", funcIdx: arrGetIdx });
-      if (!elemIsI32) {
-        fctx.body.push({ op: "f64.convert_i32_s" });
+      if (elemIsI32) {
+        pushSlotToI32(fctx); // ref/string slot → i32 handle
       }
       fctx.body.push({ op: "local.set", index: localIdx });
     }
@@ -3050,12 +3075,14 @@ function compileElementAccess(ctx: LinearContext, fctx: LinearFuncContext, expr:
   const objKind = getExprCollectionKind(ctx, fctx, expr.expression);
 
   if (objKind === "Array") {
-    // arr[i] → __arr_get(arr, i) → i32
+    // arr[i] → __arr_get(arr, i) → f64 slot (#1938)
     const getIdx = ctx.funcMap.get("__arr_get")!;
     compileExpression(ctx, fctx, expr.expression); // arr ptr (i32)
     compileExprToI32(ctx, fctx, expr.argumentExpression); // index → i32
     fctx.body.push({ op: "call", funcIdx: getIdx });
-    // Only convert to f64 for number/boolean arrays; object/string arrays stay i32
+    // The slot is an f64 bit pattern. For a number/boolean element the slot IS
+    // the f64 value (no conversion). For an object/string element the i32
+    // handle lives in the low 4 bytes — decode it back to i32.
     let elemIsNum = true;
     try {
       const elemType = ctx.checker.getTypeAtLocation(expr);
@@ -3064,8 +3091,8 @@ function compileElementAccess(ctx: LinearContext, fctx: LinearFuncContext, expr:
     } catch {
       /* default: assume number */
     }
-    if (elemIsNum) {
-      fctx.body.push({ op: "f64.convert_i32_s" });
+    if (!elemIsNum) {
+      pushSlotToI32(fctx);
     }
   } else if (objKind === "Uint8Array") {
     // u8[i] → __u8arr_get(u8, i) → i32, convert to f64 (always numeric)
@@ -3140,17 +3167,16 @@ function compileElementAccessAssignment(
   const objKind = getExprCollectionKind(ctx, fctx, left.expression);
 
   if (objKind === "Array") {
-    // arr[i] = v → __arr_set(arr, i, v); leave v as the expression result.
+    // arr[i] = v → __arr_set(arr, i, slot(v)); leave v as the expression result.
     //
-    // For a numeric element the value is an f64; element storage is currently
-    // i32 (the truncation half of #1938 is a separate change), so we keep the
-    // f64 in a scratch local as the expression result (an assignment used as a
-    // value must yield the assigned value, not the i32-truncated form — and a
-    // numeric `arr[i] = v` flows into an f64 context) and truncate only for the
-    // store. Non-numeric (string/object) element arrays already produce an i32
-    // value; for those `compileExprToI32` is the identity and the scratch is i32.
+    // #1938: element storage is now an 8-byte f64 slot. A numeric (or boolean)
+    // RHS is an f64 and is stored verbatim — `[1.5][0]` no longer truncates. A
+    // reference (string/object) RHS is an i32 handle encoded into the low 4
+    // bytes of the slot. The scratch local holds the un-encoded value so the
+    // assignment-as-expression yields the assigned value (f64 for numeric,
+    // i32 for reference), matching the surrounding context.
     const setIdx = ctx.funcMap.get("__arr_set")!;
-    // A numeric RHS compiles to f64; a reference (string/object) RHS to i32.
+    // A numeric/boolean RHS compiles to f64; a reference (string/object) RHS to i32.
     const rightIsNumeric = inferExprType(ctx, fctx, right).kind === "f64";
     const valLocal = addScratch({ kind: rightIsNumeric ? "f64" : "i32" });
     compileExpression(ctx, fctx, right); // value — evaluated once
@@ -3158,8 +3184,8 @@ function compileElementAccessAssignment(
     compileExpression(ctx, fctx, left.expression); // arr ptr (i32)
     compileExprToI32(ctx, fctx, left.argumentExpression); // index → i32
     fctx.body.push({ op: "local.get", index: valLocal });
-    if (rightIsNumeric) {
-      fctx.body.push({ op: "i32.trunc_f64_s" }); // store i32 element (#1938 part 2 will store f64)
+    if (!rightIsNumeric) {
+      pushI32ToSlot(fctx); // encode i32 handle into the f64 slot
     }
     fctx.body.push({ op: "call", funcIdx: setIdx });
     fctx.body.push({ op: "local.get", index: valLocal }); // assigned value (f64 for numeric)
@@ -3332,10 +3358,15 @@ function compileArrayMethodCall(
   methodName: string,
 ): void {
   if (methodName === "push") {
-    // arr.push(val) → __arr_push(arr, i32(val))
+    // arr.push(val) → __arr_push(arr, slot(val)) (#1938: f64 slot)
     const pushIdx = ctx.funcMap.get("__arr_push")!;
     compileExpression(ctx, fctx, propAccess.expression); // arr ptr (i32)
-    compileExprToI32(ctx, fctx, expr.arguments[0]); // value → i32
+    if (inferExprType(ctx, fctx, expr.arguments[0]).kind === "f64") {
+      compileExprToF64(ctx, fctx, expr.arguments[0]); // numeric/boolean → f64 slot
+    } else {
+      compileExprToI32(ctx, fctx, expr.arguments[0]); // ref → i32
+      pushI32ToSlot(fctx); // → f64 slot
+    }
     fctx.body.push({ op: "call", funcIdx: pushIdx });
     // push returns void in runtime, but expression needs a value for drop
     fctx.body.push({ op: "f64.const", value: 0 });
@@ -3460,12 +3491,12 @@ function compileArrayHOF(
   fctx.body.push({ op: "i32.ge_s" });
   fctx.body.push({ op: "br_if", depth: 1 });
 
-  // elem = __arr_get(arr, i)
+  // elem = __arr_get(arr, i) → f64 slot (#1938)
   fctx.body.push({ op: "local.get", index: arrLocal });
   fctx.body.push({ op: "local.get", index: iLocal });
   fctx.body.push({ op: "call", funcIdx: arrGetIdx });
-  if (!elemIsI32) {
-    fctx.body.push({ op: "f64.convert_i32_s" });
+  if (elemIsI32) {
+    pushSlotToI32(fctx); // ref/string slot → i32 handle
   }
   fctx.body.push({ op: "local.set", index: elemLocal });
 
@@ -3498,20 +3529,24 @@ function compileArrayHOF(
     fctx.body = pushBody;
     fctx.body.push({ op: "local.get", index: resultLocal! });
     fctx.body.push({ op: "local.get", index: elemLocal });
-    if (!elemIsI32) {
-      fctx.body.push({ op: "i32.trunc_f64_s" });
+    // #1938: __arr_push takes an f64 slot. elemLocal is f64 for number/boolean
+    // (push verbatim) and i32 for ref/string (encode into the slot).
+    if (elemIsI32) {
+      pushI32ToSlot(fctx);
     }
     fctx.body.push({ op: "call", funcIdx: arrPushIdx });
     fctx.body = savedBody2;
     fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: pushBody });
   } else if (method === "map") {
-    // __arr_push(result, callback(elem))
+    // __arr_push(result, slot(callback(elem)))  (#1938: f64 slot — no truncation)
     fctx.body.push({ op: "local.get", index: resultLocal! });
     compileExpression(ctx, fctx, bodyExpr);
-    // Convert mapped value to i32 for storage
+    // A numeric/boolean mapped value is an f64 → store verbatim (the truncation
+    // that broke `[1.5,2.5].map(x=>x*2)` is gone). A ref mapped value is an i32
+    // → encode into the slot.
     const mappedType = inferExprType(ctx, fctx, bodyExpr);
-    if (mappedType.kind === "f64") {
-      fctx.body.push({ op: "i32.trunc_f64_s" });
+    if (mappedType.kind !== "f64") {
+      pushI32ToSlot(fctx);
     }
     fctx.body.push({ op: "call", funcIdx: arrPushIdx });
   } else if (method === "some") {
@@ -3703,7 +3738,11 @@ function compileArrayJoin(
   fctx.body.push({ op: "local.get", index: arrLocal });
   fctx.body.push({ op: "local.get", index: iLocal });
   fctx.body.push({ op: "call", funcIdx: arrGetIdx });
-  // arr[i] returns i32 (string pointer for string arrays)
+  // __arr_get returns an f64 slot (#1938); join concatenates string pointers,
+  // so decode the slot back to the i32 string handle. (Joining a number[] was
+  // already unsupported — it stringifies the raw handle — so this only changes
+  // the slot decode, not that pre-existing limitation.)
+  pushSlotToI32(fctx);
   fctx.body.push({ op: "call", funcIdx: strConcatIdx });
   fctx.body.push({ op: "local.set", index: resultLocal });
 
@@ -3930,6 +3969,29 @@ function compileExprToF64(ctx: LinearContext, fctx: LinearFuncContext, expr: ts.
   if (exprType.kind === "i32") {
     fctx.body.push({ op: "f64.convert_i32_s" });
   }
+}
+
+// ── Array element slot encode/decode (#1938) ─────────────────────────
+//
+// Linear array element slots are 8-byte raw bit patterns the runtime never
+// interprets (__arr_get/_set/_push take/return f64). The codegen owns the
+// interpretation per element kind:
+//   - number (f64): the slot IS the IEEE-754 value — no conversion.
+//   - reference/boolean (i32 handle / 0|1): the i32 lives in the low 4 bytes,
+//     shuffled in via i64.extend_i32_u → f64.reinterpret_i64 and out via the
+//     inverse. This keeps the hot numeric path conversion-free and confines the
+//     bit-cast to the rarer ref/bool sites.
+
+/** Encode an i32 (ref/bool handle) already on the stack into an f64 array slot. */
+function pushI32ToSlot(fctx: LinearFuncContext): void {
+  fctx.body.push({ op: "i64.extend_i32_u" });
+  fctx.body.push({ op: "f64.reinterpret_i64" });
+}
+
+/** Decode an f64 array slot already on the stack back into its i32 (ref/bool) handle. */
+function pushSlotToI32(fctx: LinearFuncContext): void {
+  fctx.body.push({ op: "i64.reinterpret_f64" });
+  fctx.body.push({ op: "i32.wrap_i64" });
 }
 
 // ── Type inference and resolution ────────────────────────────────────

--- a/src/codegen-linear/runtime.ts
+++ b/src/codegen-linear/runtime.ts
@@ -413,7 +413,8 @@ export function addUint8ArrayRuntime(mod: WasmModule): void {
 
   // __u8arr_from_arr(arrPtr: i32) → i32
   // Creates a Uint8Array from a number[] array.
-  // Array layout: [header 8B][len:u32 +8][cap:u32 +12][elements: i32×cap +16...]
+  // Array layout: [header 8B][len:u32 +8][cap:u32 +12][elements: 8B(f64)×cap +16...]
+  // Each source element is an f64 slot (#1938); truncate to a byte on copy.
   // Extra locals: local1 = len, local2 = newPtr, local3 = i
   addRuntimeFunc(
     mod,
@@ -455,18 +456,19 @@ export function addUint8ArrayRuntime(mod: WasmModule): void {
                 { op: "local.get", index: lenLocal },
                 { op: "i32.ge_u" },
                 { op: "br_if", depth: 1 },
-                // newPtr[12+i] = (u8) arrPtr[16 + i*4]
+                // newPtr[12+i] = (u8) arrPtr[16 + i*8]  (f64 slot → byte)
                 { op: "local.get", index: newPtrLocal },
                 { op: "local.get", index: iLocal },
                 { op: "i32.add" },
-                // Load element from array: arrPtr + 16 + i*4
+                // Load f64 element from array: arrPtr + 16 + i*8
                 { op: "local.get", index: 0 }, // arrPtr
                 { op: "local.get", index: iLocal },
-                { op: "i32.const", value: 4 },
+                { op: "i32.const", value: 8 },
                 { op: "i32.mul" },
                 { op: "i32.add" },
-                { op: "i32.load", align: 2, offset: 16 },
-                // Store as byte
+                { op: "f64.load", align: 3, offset: 16 },
+                // Truncate f64 → i32, store low byte
+                { op: "i32.trunc_f64_s" },
                 { op: "i32.store8", align: 0, offset: 12 },
                 // i++
                 { op: "local.get", index: iLocal },
@@ -531,14 +533,21 @@ function ensureArrayResolveRuntime(mod: WasmModule): void {
 
 /**
  * Add Array runtime functions to the module.
- * Layout: [header 8B][len:u32 at +8][cap:u32 at +12][elements: i32×cap at +16...]
+ * Layout: [header 8B][len:u32 at +8][cap:u32 at +12][elements: 8B×cap at +16...]
+ *
+ * #1938: element slots are 8 bytes (stride 8), holding a raw bit pattern the
+ * runtime never interprets. The runtime element boundary is typed **f64**:
+ * a numeric element flows in/out as its IEEE-754 f64 value (zero conversions),
+ * while a reference/boolean i32 is shuffled into the low 4 bytes of the slot by
+ * codegen (`i64.extend_i32_u` → `f64.reinterpret_i64` on store, inverse on
+ * load). Storing f64 slots fixes `[1.5][0]` → 1.5 (was truncated to i32).
  *
  * Functions added:
  * - __arr_new(cap: i32) → i32 (pointer)
  * - __arr_grow(ptr: i32, minCap: i32) → i32 (relocated pointer; forwards old header)
- * - __arr_push(ptr: i32, val: i32) → void
- * - __arr_get(ptr: i32, idx: i32) → i32
- * - __arr_set(ptr: i32, idx: i32, val: i32) → void
+ * - __arr_push(ptr: i32, val: f64) → void
+ * - __arr_get(ptr: i32, idx: i32) → f64
+ * - __arr_set(ptr: i32, idx: i32, val: f64) → void
  * - __arr_len(ptr: i32) → i32
  * - __arr_from_data(dataPtr: i32, len: i32) → i32 (header ptr)
  */
@@ -546,7 +555,7 @@ export function addArrayRuntime(mod: WasmModule): void {
   ensureArrayResolveRuntime(mod); // accessors below resolve forwarded arrays (#1977)
   const mallocIdx = findFuncIndex(mod, "__malloc");
 
-  // __arr_new: allocate header(8) + len(4) + cap(4) + elements(cap*4)
+  // __arr_new: allocate header(8) + len(4) + cap(4) + elements(cap*8)
   // Tag byte at offset 0: 0x01 = Array
   // extra locals: local 1 = ptr
   addRuntimeFunc(
@@ -556,10 +565,10 @@ export function addArrayRuntime(mod: WasmModule): void {
     [{ kind: "i32" }],
     [],
     (local1Idx) => [
-      // Allocate: 16 + cap*4
+      // Allocate: 16 + cap*8
       { op: "i32.const", value: 16 },
       { op: "local.get", index: 0 }, // cap
-      { op: "i32.const", value: 4 },
+      { op: "i32.const", value: 8 },
       { op: "i32.mul" },
       { op: "i32.add" },
       { op: "call", funcIdx: mallocIdx },
@@ -637,10 +646,10 @@ export function addArrayRuntime(mod: WasmModule): void {
           ],
           else: [],
         },
-        // newPtr = __malloc(16 + newCap*4)
+        // newPtr = __malloc(16 + newCap*8)
         { op: "i32.const", value: 16 },
         { op: "local.get", index: newCapLocal },
-        { op: "i32.const", value: 4 },
+        { op: "i32.const", value: 8 },
         { op: "i32.mul" },
         { op: "i32.add" },
         { op: "call", funcIdx: mallocIdx },
@@ -670,18 +679,19 @@ export function addArrayRuntime(mod: WasmModule): void {
                 { op: "local.get", index: lenLocal },
                 { op: "i32.ge_u" },
                 { op: "br_if", depth: 1 },
+                // newPtr[i] = ptr[i] (raw 8-byte slot copy; bits opaque)
                 { op: "local.get", index: newPtrLocal },
                 { op: "local.get", index: iLocal },
-                { op: "i32.const", value: 4 },
+                { op: "i32.const", value: 8 },
                 { op: "i32.mul" },
                 { op: "i32.add" },
                 { op: "local.get", index: 0 },
                 { op: "local.get", index: iLocal },
-                { op: "i32.const", value: 4 },
+                { op: "i32.const", value: 8 },
                 { op: "i32.mul" },
                 { op: "i32.add" },
-                { op: "i32.load", align: 2, offset: 16 },
-                { op: "i32.store", align: 2, offset: 16 },
+                { op: "f64.load", align: 3, offset: 16 },
+                { op: "f64.store", align: 3, offset: 16 },
                 { op: "local.get", index: iLocal },
                 { op: "i32.const", value: 1 },
                 { op: "i32.add" },
@@ -707,13 +717,13 @@ export function addArrayRuntime(mod: WasmModule): void {
 
   const arrGrowIdx = findFuncIndex(mod, "__arr_grow");
 
-  // __arr_push: store val at ptr+16+len*4, increment len.
+  // __arr_push: store val (f64 slot) at ptr+16+len*8, increment len.
   // Resolves forwarding and grows when len == cap (#1977 — was an unbounded
   // write into the bump arena that corrupted adjacent allocations).
   addRuntimeFunc(
     mod,
     "__arr_push",
-    [{ kind: "i32" }, { kind: "i32" }],
+    [{ kind: "i32" }, { kind: "f64" }],
     [],
     [],
     (local2Idx) => [
@@ -743,14 +753,14 @@ export function addArrayRuntime(mod: WasmModule): void {
         ],
         else: [],
       },
-      // Store val at ptr + 16 + len*4
+      // Store val at ptr + 16 + len*8 (f64 slot)
       { op: "local.get", index: 0 }, // ptr
       { op: "local.get", index: local2Idx }, // len
-      { op: "i32.const", value: 4 },
+      { op: "i32.const", value: 8 },
       { op: "i32.mul" },
       { op: "i32.add" },
-      { op: "local.get", index: 1 }, // val
-      { op: "i32.store", align: 2, offset: 16 },
+      { op: "local.get", index: 1 }, // val (f64)
+      { op: "f64.store", align: 3, offset: 16 },
       // Increment len: store len+1 at ptr+8
       { op: "local.get", index: 0 }, // ptr
       { op: "local.get", index: local2Idx }, // len
@@ -761,16 +771,16 @@ export function addArrayRuntime(mod: WasmModule): void {
     1,
   );
 
-  // __arr_get: load i32 at ptr + 16 + idx*4.
+  // __arr_get: load f64 slot at ptr + 16 + idx*8.
   // Resolves forwarding; OOB (idx >= len, unsigned — covers negative idx)
-  // returns 0, the backend's undefined representation (#1977 — was a raw
-  // load of neighbouring memory).
-  addRuntimeFunc(mod, "__arr_get", [{ kind: "i32" }, { kind: "i32" }], [{ kind: "i32" }], [], () => [
+  // returns 0.0, the backend's undefined representation (#1977 — was a raw
+  // load of neighbouring memory). Slot bits are opaque to the runtime (#1938).
+  addRuntimeFunc(mod, "__arr_get", [{ kind: "i32" }, { kind: "i32" }], [{ kind: "f64" }], [], () => [
     // ptr = __arr_resolve(ptr)
     { op: "local.get", index: 0 },
     { op: "call", funcIdx: arrResolveIdx },
     { op: "local.set", index: 0 },
-    // if idx >= len (unsigned): return 0 (undefined)
+    // if idx >= len (unsigned): return 0.0 (undefined)
     { op: "local.get", index: 1 },
     { op: "local.get", index: 0 },
     { op: "i32.load", align: 2, offset: 8 },
@@ -778,26 +788,26 @@ export function addArrayRuntime(mod: WasmModule): void {
     {
       op: "if",
       blockType: { kind: "empty" },
-      then: [{ op: "i32.const", value: 0 }, { op: "return" }],
+      then: [{ op: "f64.const", value: 0 }, { op: "return" }],
       else: [],
     },
     { op: "local.get", index: 0 }, // ptr
     { op: "local.get", index: 1 }, // idx
-    { op: "i32.const", value: 4 },
+    { op: "i32.const", value: 8 },
     { op: "i32.mul" },
     { op: "i32.add" },
-    { op: "i32.load", align: 2, offset: 16 },
+    { op: "f64.load", align: 3, offset: 16 },
   ]);
 
-  // __arr_set: store i32 at ptr + 16 + idx*4.
+  // __arr_set: store f64 slot at ptr + 16 + idx*8.
   // Resolves forwarding; grows when idx >= cap; extends len (zero-filling
   // the gap) when idx >= len, per JS store-beyond-length semantics (#1977).
   // A negative idx is a JS non-index property write — dropped (no-op) rather
-  // than corrupting header/neighbour memory.
+  // than corrupting header/neighbour memory. Slot bits are opaque (#1938).
   addRuntimeFunc(
     mod,
     "__arr_set",
-    [{ kind: "i32" }, { kind: "i32" }, { kind: "i32" }],
+    [{ kind: "i32" }, { kind: "i32" }, { kind: "f64" }],
     [],
     [],
     (firstLocalIdx) => {
@@ -853,11 +863,11 @@ export function addArrayRuntime(mod: WasmModule): void {
                 { op: "br_if", depth: 1 },
                 { op: "local.get", index: 0 },
                 { op: "local.get", index: fillLocal },
-                { op: "i32.const", value: 4 },
+                { op: "i32.const", value: 8 },
                 { op: "i32.mul" },
                 { op: "i32.add" },
-                { op: "i32.const", value: 0 },
-                { op: "i32.store", align: 2, offset: 16 },
+                { op: "f64.const", value: 0 },
+                { op: "f64.store", align: 3, offset: 16 },
                 { op: "local.get", index: fillLocal },
                 { op: "i32.const", value: 1 },
                 { op: "i32.add" },
@@ -884,14 +894,14 @@ export function addArrayRuntime(mod: WasmModule): void {
           ],
           else: [],
         },
-        // Store val
+        // Store val (f64 slot)
         { op: "local.get", index: 0 }, // ptr
         { op: "local.get", index: 1 }, // idx
-        { op: "i32.const", value: 4 },
+        { op: "i32.const", value: 8 },
         { op: "i32.mul" },
         { op: "i32.add" },
-        { op: "local.get", index: 2 }, // val
-        { op: "i32.store", align: 2, offset: 16 },
+        { op: "local.get", index: 2 }, // val (f64)
+        { op: "f64.store", align: 3, offset: 16 },
       ];
     },
     1,
@@ -908,7 +918,12 @@ export function addArrayRuntime(mod: WasmModule): void {
   // Build an internal array object from a raw, contiguous block of `len`
   // i32 elements at `dataPtr`. Used by the C ABI wrapper to rehydrate an
   // array parameter passed as a (ptr, len) pair (#1835).
-  // Layout written: [header 8B][len:u32 @ +8][cap:u32 @ +12][elems @ +16...]
+  // Layout written: [header 8B][len:u32 @ +8][cap:u32 @ +12][elems 8B @ +16...]
+  // Each incoming i32 is widened into the low 4 bytes of an 8-byte slot
+  // (i64.extend_i32_u → f64.reinterpret_i64), matching the codegen ref/bool
+  // slot encoding (#1938). Reference/string/handle array params round-trip;
+  // number[] params through the C ABI are a separate slice (the host passes
+  // raw doubles, not i32 handles).
   // extra locals: local 2 = ptr (result), local 3 = i (loop counter)
   addRuntimeFunc(
     mod,
@@ -920,10 +935,10 @@ export function addArrayRuntime(mod: WasmModule): void {
       const ptrLocal = firstLocalIdx;
       const iLocal = firstLocalIdx + 1;
       return [
-        // Allocate: 16 + len*4
+        // Allocate: 16 + len*8
         { op: "i32.const", value: 16 },
         { op: "local.get", index: 1 }, // len
-        { op: "i32.const", value: 4 },
+        { op: "i32.const", value: 8 },
         { op: "i32.mul" },
         { op: "i32.add" },
         { op: "call", funcIdx: mallocIdx },
@@ -940,7 +955,9 @@ export function addArrayRuntime(mod: WasmModule): void {
         { op: "local.get", index: ptrLocal },
         { op: "local.get", index: 1 },
         { op: "i32.store", align: 2, offset: 12 },
-        // Copy elements: for i=0; i<len; i++ { mem[ptr+16+i*4] = mem[dataPtr+i*4] }
+        // Copy elements: for i=0; i<len; i++ { slot[i] = widen(mem[dataPtr+i*4]) }
+        // The incoming block is packed i32 (4-byte stride); each i32 is widened
+        // into the low 4 bytes of the destination's 8-byte slot (#1938).
         { op: "i32.const", value: 0 },
         { op: "local.set", index: iLocal },
         {
@@ -956,21 +973,23 @@ export function addArrayRuntime(mod: WasmModule): void {
                 { op: "local.get", index: 1 }, // len
                 { op: "i32.ge_u" },
                 { op: "br_if", depth: 1 },
-                // dest addr = ptr + i*4 (offset 16 applied at store)
+                // dest addr = ptr + i*8 (offset 16 applied at store)
                 { op: "local.get", index: ptrLocal },
                 { op: "local.get", index: iLocal },
-                { op: "i32.const", value: 4 },
+                { op: "i32.const", value: 8 },
                 { op: "i32.mul" },
                 { op: "i32.add" },
-                // value = mem[dataPtr + i*4]
+                // value = widen(mem[dataPtr + i*4]) : i32 → f64 slot
                 { op: "local.get", index: 0 }, // dataPtr
                 { op: "local.get", index: iLocal },
                 { op: "i32.const", value: 4 },
                 { op: "i32.mul" },
                 { op: "i32.add" },
                 { op: "i32.load", align: 2, offset: 0 },
-                // store at dest+16
-                { op: "i32.store", align: 2, offset: 16 },
+                { op: "i64.extend_i32_u" },
+                { op: "f64.reinterpret_i64" },
+                // store at dest+16 (f64 slot)
+                { op: "f64.store", align: 3, offset: 16 },
                 // i++
                 { op: "local.get", index: iLocal },
                 { op: "i32.const", value: 1 },
@@ -2027,12 +2046,15 @@ export function addStringRuntime(mod: WasmModule): void {
                 { op: "i32.const", value: -1 },
                 { op: "i32.eq" },
                 { op: "br_if", depth: 1 },
-                // push substring [start, pos)
+                // push substring [start, pos) — encode the string i32 pointer
+                // into the low 4 bytes of the f64 element slot (#1938).
                 { op: "local.get", index: resultLocal },
                 { op: "local.get", index: 0 },
                 { op: "local.get", index: startLocal },
                 { op: "local.get", index: posLocal },
                 { op: "call", funcIdx: strSliceIdx },
+                { op: "i64.extend_i32_u" },
+                { op: "f64.reinterpret_i64" },
                 { op: "call", funcIdx: arrPushIdx },
                 // start = pos + sepLen
                 { op: "local.get", index: posLocal },
@@ -2044,12 +2066,15 @@ export function addStringRuntime(mod: WasmModule): void {
             },
           ],
         },
-        // push final substring [start, strLen)
+        // push final substring [start, strLen) — encode the string i32 pointer
+        // into the f64 element slot (#1938).
         { op: "local.get", index: resultLocal },
         { op: "local.get", index: 0 },
         { op: "local.get", index: startLocal },
         { op: "local.get", index: strLenLocal2 },
         { op: "call", funcIdx: strSliceIdx },
+        { op: "i64.extend_i32_u" },
+        { op: "f64.reinterpret_i64" },
         { op: "call", funcIdx: arrPushIdx },
         // return result
         { op: "local.get", index: resultLocal },

--- a/src/codegen-linear/simd.ts
+++ b/src/codegen-linear/simd.ts
@@ -559,33 +559,33 @@ function addSimdStringIndexOf(mod: WasmModule): void {
 }
 
 /**
- * __arr_indexOf_simd(arr: i32, val: i32) → i32
+ * __arr_indexOf_simd(arr: i32, val: f64) → i32
  *
- * SIMD-accelerated i32 array indexOf.
- * Splats the search value across i32x4 and compares 4 elements at a time.
+ * SIMD-accelerated number[] array indexOf.
+ * #1938: elements are 8-byte f64 slots, so the search value is splatted across
+ * an f64x2 and 2 elements are compared per 128-bit chunk (stride 16 bytes).
  * Returns the index of the first match, or -1 if not found.
- * Array layout: ptr+8 = length, ptr+16 = element data (i32[])
+ * Array layout: ptr+8 = length, ptr+16 = element data (f64[])
  */
 function addSimdArrayIndexOfI32(mod: WasmModule): void {
-  const params: ValType[] = [{ kind: "i32" }, { kind: "i32" }];
+  const params: ValType[] = [{ kind: "i32" }, { kind: "f64" }];
   const results: ValType[] = [{ kind: "i32" }];
 
   const typeIdx = mod.types.length;
   mod.types.push({ kind: "func", name: "$type___arr_indexOf_simd", params, results });
 
-  // params: arr(0), val(1)
-  // locals: len(2), i(3), valVec(4:v128), cmpVec(5:v128), mask(6)
+  // params: arr(0), val(1:f64)
+  // locals: len(2), i(3), valVec(4:v128), cmpVec(5:v128)
   const locals: LocalDef[] = [
     { name: "len", type: { kind: "i32" } },
     { name: "i", type: { kind: "i32" } },
     { name: "valVec", type: { kind: "v128" } },
     { name: "cmpVec", type: { kind: "v128" } },
-    { name: "mask", type: { kind: "i32" } },
   ];
 
   const len = 2,
     i = 3,
-    mask = 6;
+    cmpVec = 5;
 
   const body: Instr[] = [
     // len = arr.len
@@ -593,16 +593,16 @@ function addSimdArrayIndexOfI32(mod: WasmModule): void {
     { op: "i32.load", align: 2, offset: 8 },
     { op: "local.set", index: len },
 
-    // valVec = i32x4.splat(val)
+    // valVec = f64x2.splat(val)
     { op: "local.get", index: 1 },
-    { op: "i32x4.splat" },
+    { op: "f64x2.splat" },
     { op: "local.set", index: 4 }, // valVec
 
     // i = 0
     { op: "i32.const", value: 0 },
     { op: "local.set", index: i },
 
-    // SIMD loop: compare 4 elements at a time
+    // SIMD loop: compare 2 elements at a time (f64x2)
     {
       op: "block",
       blockType: { kind: "empty" },
@@ -611,82 +611,53 @@ function addSimdArrayIndexOfI32(mod: WasmModule): void {
           op: "loop",
           blockType: { kind: "empty" },
           body: [
-            // if i + 4 > len, break to scalar
+            // if i + 2 > len, break to scalar
             { op: "local.get", index: i },
-            { op: "i32.const", value: 4 },
+            { op: "i32.const", value: 2 },
             { op: "i32.add" },
             { op: "local.get", index: len },
             { op: "i32.gt_u" },
             { op: "br_if", depth: 1 },
 
-            // Load 4 elements: v128.load(arr + 16 + i*4)
+            // Load 2 elements: v128.load(arr + 16 + i*8)
             { op: "local.get", index: 0 },
             { op: "local.get", index: i },
-            { op: "i32.const", value: 4 },
+            { op: "i32.const", value: 8 },
             { op: "i32.mul" },
             { op: "i32.add" },
-            { op: "v128.load", align: 2, offset: 16 },
+            { op: "v128.load", align: 3, offset: 16 },
 
-            // Compare with valVec
+            // cmpVec = f64x2.eq(loaded, valVec) — matching lanes become all-1s
             { op: "local.get", index: 4 }, // valVec
-            { op: "i32x4.eq" },
+            { op: "f64x2.eq" },
+            { op: "local.set", index: cmpVec },
 
-            // Get bitmask
-            { op: "i32x4.bitmask" },
-            { op: "local.set", index: mask },
+            // lane 0 match? (i64x2.extract_lane 0 != 0)
+            { op: "local.get", index: cmpVec },
+            { op: "i64x2.extract_lane", lane: 0 },
+            { op: "i64.const", value: 0n },
+            { op: "i64.ne" },
+            { op: "if", blockType: { kind: "empty" }, then: [{ op: "local.get", index: i }, { op: "return" }] },
 
-            // If any match, find which lane
-            { op: "local.get", index: mask },
-            { op: "i32.const", value: 0 },
-            { op: "i32.ne" },
+            // lane 1 match? (i64x2.extract_lane 1 != 0)
+            { op: "local.get", index: cmpVec },
+            { op: "i64x2.extract_lane", lane: 1 },
+            { op: "i64.const", value: 0n },
+            { op: "i64.ne" },
             {
               op: "if",
               blockType: { kind: "empty" },
               then: [
-                // Check lane 0
-                { op: "local.get", index: mask },
-                { op: "i32.const", value: 1 },
-                { op: "i32.and" },
-                { op: "if", blockType: { kind: "empty" }, then: [{ op: "local.get", index: i }, { op: "return" }] },
-                // Check lane 1
-                { op: "local.get", index: mask },
-                { op: "i32.const", value: 2 },
-                { op: "i32.and" },
-                {
-                  op: "if",
-                  blockType: { kind: "empty" },
-                  then: [
-                    { op: "local.get", index: i },
-                    { op: "i32.const", value: 1 },
-                    { op: "i32.add" },
-                    { op: "return" },
-                  ],
-                },
-                // Check lane 2
-                { op: "local.get", index: mask },
-                { op: "i32.const", value: 4 },
-                { op: "i32.and" },
-                {
-                  op: "if",
-                  blockType: { kind: "empty" },
-                  then: [
-                    { op: "local.get", index: i },
-                    { op: "i32.const", value: 2 },
-                    { op: "i32.add" },
-                    { op: "return" },
-                  ],
-                },
-                // Must be lane 3
                 { op: "local.get", index: i },
-                { op: "i32.const", value: 3 },
+                { op: "i32.const", value: 1 },
                 { op: "i32.add" },
                 { op: "return" },
               ],
             },
 
-            // i += 4
+            // i += 2
             { op: "local.get", index: i },
-            { op: "i32.const", value: 4 },
+            { op: "i32.const", value: 2 },
             { op: "i32.add" },
             { op: "local.set", index: i },
             { op: "br", depth: 0 },
@@ -710,15 +681,15 @@ function addSimdArrayIndexOfI32(mod: WasmModule): void {
             { op: "i32.ge_u" },
             { op: "br_if", depth: 1 },
 
-            // if arr[16 + i*4] == val, return i
+            // if arr[16 + i*8] == val, return i
             { op: "local.get", index: 0 },
             { op: "local.get", index: i },
-            { op: "i32.const", value: 4 },
+            { op: "i32.const", value: 8 },
             { op: "i32.mul" },
             { op: "i32.add" },
-            { op: "i32.load", align: 2, offset: 16 },
+            { op: "f64.load", align: 3, offset: 16 },
             { op: "local.get", index: 1 },
-            { op: "i32.eq" },
+            { op: "f64.eq" },
             { op: "if", blockType: { kind: "empty" }, then: [{ op: "local.get", index: i }, { op: "return" }] },
 
             // i++
@@ -746,17 +717,18 @@ function addSimdArrayIndexOfI32(mod: WasmModule): void {
 }
 
 /**
- * __arr_fill_simd(arr: i32, val: i32, start: i32, end: i32) → void
+ * __arr_fill_simd(arr: i32, val: f64, start: i32, end: i32) → void
  *
- * SIMD-accelerated i32 array fill.
- * Splats the fill value across i32x4 and stores 4 elements at a time.
- * Falls back to scalar for the tail.
- * Array layout: ptr+16 = element data (i32[])
+ * SIMD-accelerated number[] array fill.
+ * #1938: elements are 8-byte f64 slots, so the fill value is splatted across an
+ * f64x2 and 2 elements are stored per 128-bit chunk (stride 16 bytes). Falls
+ * back to scalar for the tail.
+ * Array layout: ptr+16 = element data (f64[])
  */
 function addSimdArrayFillI32(mod: WasmModule): void {
   const params: ValType[] = [
     { kind: "i32" }, // arr
-    { kind: "i32" }, // val
+    { kind: "f64" }, // val
     { kind: "i32" }, // start
     { kind: "i32" }, // end
   ];
@@ -775,16 +747,16 @@ function addSimdArrayFillI32(mod: WasmModule): void {
   const i = 4;
 
   const body: Instr[] = [
-    // fillVec = i32x4.splat(val)
+    // fillVec = f64x2.splat(val)
     { op: "local.get", index: 1 },
-    { op: "i32x4.splat" },
+    { op: "f64x2.splat" },
     { op: "local.set", index: 5 }, // fillVec
 
     // i = start
     { op: "local.get", index: 2 },
     { op: "local.set", index: i },
 
-    // SIMD loop: store 4 elements at a time
+    // SIMD loop: store 2 elements at a time (f64x2)
     {
       op: "block",
       blockType: { kind: "empty" },
@@ -793,26 +765,26 @@ function addSimdArrayFillI32(mod: WasmModule): void {
           op: "loop",
           blockType: { kind: "empty" },
           body: [
-            // if i + 4 > end, break to scalar
+            // if i + 2 > end, break to scalar
             { op: "local.get", index: i },
-            { op: "i32.const", value: 4 },
+            { op: "i32.const", value: 2 },
             { op: "i32.add" },
             { op: "local.get", index: 3 }, // end
             { op: "i32.gt_u" },
             { op: "br_if", depth: 1 },
 
-            // v128.store(arr + 16 + i*4, fillVec)
+            // v128.store(arr + 16 + i*8, fillVec)
             { op: "local.get", index: 0 },
             { op: "local.get", index: i },
-            { op: "i32.const", value: 4 },
+            { op: "i32.const", value: 8 },
             { op: "i32.mul" },
             { op: "i32.add" },
             { op: "local.get", index: 5 }, // fillVec
-            { op: "v128.store", align: 2, offset: 16 },
+            { op: "v128.store", align: 3, offset: 16 },
 
-            // i += 4
+            // i += 2
             { op: "local.get", index: i },
-            { op: "i32.const", value: 4 },
+            { op: "i32.const", value: 2 },
             { op: "i32.add" },
             { op: "local.set", index: i },
             { op: "br", depth: 0 },
@@ -836,14 +808,14 @@ function addSimdArrayFillI32(mod: WasmModule): void {
             { op: "i32.ge_u" },
             { op: "br_if", depth: 1 },
 
-            // arr[16 + i*4] = val
+            // arr[16 + i*8] = val (f64 slot)
             { op: "local.get", index: 0 },
             { op: "local.get", index: i },
-            { op: "i32.const", value: 4 },
+            { op: "i32.const", value: 8 },
             { op: "i32.mul" },
             { op: "i32.add" },
-            { op: "local.get", index: 1 }, // val
-            { op: "i32.store", align: 2, offset: 16 },
+            { op: "local.get", index: 1 }, // val (f64)
+            { op: "f64.store", align: 3, offset: 16 },
 
             // i++
             { op: "local.get", index: i },

--- a/src/codegen-linear/simd.ts
+++ b/src/codegen-linear/simd.ts
@@ -647,12 +647,7 @@ function addSimdArrayIndexOfI32(mod: WasmModule): void {
             {
               op: "if",
               blockType: { kind: "empty" },
-              then: [
-                { op: "local.get", index: i },
-                { op: "i32.const", value: 1 },
-                { op: "i32.add" },
-                { op: "return" },
-              ],
+              then: [{ op: "local.get", index: i }, { op: "i32.const", value: 1 }, { op: "i32.add" }, { op: "return" }],
             },
 
             // i += 2

--- a/tests/issue-1835.test.ts
+++ b/tests/issue-1835.test.ts
@@ -105,9 +105,25 @@ describe("#1835 C ABI array return marshaling", () => {
     expect(Array.isArray(ret)).toBe(true);
     const [ptr, len] = ret;
     expect(len).toBe(3);
-    // Elements are stored as i32 in the linear array runtime.
-    const ints = new Int32Array(mem.buffer, ptr, len);
-    expect(Array.from(ints)).toEqual([10, 20, 30]);
+    // #1938: number[] elements are 8-byte f64 slots (stride 8) — the payload is
+    // a contiguous block of doubles, read it as a Float64Array (the C header
+    // advertises a `double*` for number-array returns).
+    const doubles = new Float64Array(mem.buffer, ptr, len);
+    expect(Array.from(doubles)).toEqual([10, 20, 30]);
+  });
+
+  it("preserves fractional number[] elements across the C ABI boundary (#1938)", async () => {
+    const result = await compile(`export function mk(): number[] { return [1.5, -2.25, 3.75]; }`, {
+      target: "linear",
+      abi: "c",
+    });
+    expect(result.success).toBe(true);
+    const { instance } = await WebAssembly.instantiate(result.binary);
+    const mem = instance.exports.memory as WebAssembly.Memory;
+    const [ptr, len] = (instance.exports.mk as () => [number, number])();
+    expect(len).toBe(3);
+    const doubles = new Float64Array(mem.buffer, ptr, len);
+    expect(Array.from(doubles)).toEqual([1.5, -2.25, 3.75]);
   });
 });
 

--- a/tests/issue-1938-number-array-f64.test.ts
+++ b/tests/issue-1938-number-array-f64.test.ts
@@ -12,10 +12,9 @@ import { compile } from "../src/index.js";
 
 async function compileLinear(source: string) {
   const result = await compile(source, { target: "linear" });
-  expect(
-    result.success,
-    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`,
-  ).toBe(true);
+  expect(result.success, `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
+    true,
+  );
   const { instance } = await WebAssembly.instantiate(result.binary);
   return instance.exports as Record<string, (...args: number[]) => number>;
 }
@@ -34,9 +33,7 @@ describe("#1938 linear number[] f64 element storage", () => {
   });
 
   it("push of a fractional value round-trips on index read", async () => {
-    const e = await compileLinear(
-      `export function f(): number { const a: number[] = []; a.push(1.25); return a[0]; }`,
-    );
+    const e = await compileLinear(`export function f(): number { const a: number[] = []; a.push(1.25); return a[0]; }`);
     expect(e.f()).toBe(1.25);
   });
 

--- a/tests/issue-1938-number-array-f64.test.ts
+++ b/tests/issue-1938-number-array-f64.test.ts
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1938 (part 2) — the linear backend stored `number[]` elements as i32, so
+// `[1.5][0]` silently truncated to 1. Element storage is now an 8-byte f64 slot
+// (`__arr_get`/`__arr_set`/`__arr_push` take/return f64); a fractional value
+// round-trips exactly, while reference/string elements keep their i32 handle in
+// the low 4 bytes of the slot (encode on store, decode on load).
+//
+// Part 1 (RHS-once) is covered separately in linear-element-assign.test.ts.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileLinear(source: string) {
+  const result = await compile(source, { target: "linear" });
+  expect(
+    result.success,
+    `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`,
+  ).toBe(true);
+  const { instance } = await WebAssembly.instantiate(result.binary);
+  return instance.exports as Record<string, (...args: number[]) => number>;
+}
+
+describe("#1938 linear number[] f64 element storage", () => {
+  it("[1.5][0] returns 1.5 (was 1) — the headline regression", async () => {
+    const e = await compileLinear(`export function f(): number { const a = [1.5]; return a[0]; }`);
+    expect(e.f()).toBe(1.5);
+  });
+
+  it("preserves fractional precision across a sum read", async () => {
+    const e = await compileLinear(
+      `export function f(): number { const a = [0.1, 0.2, 0.3]; return a[0] + a[1] + a[2]; }`,
+    );
+    expect(e.f()).toBeCloseTo(0.6, 12);
+  });
+
+  it("push of a fractional value round-trips on index read", async () => {
+    const e = await compileLinear(
+      `export function f(): number { const a: number[] = []; a.push(1.25); return a[0]; }`,
+    );
+    expect(e.f()).toBe(1.25);
+  });
+
+  it("element assignment stores the fractional value (set + read, RHS-once)", async () => {
+    const e = await compileLinear(`export function f(): number { const a = [0, 0]; a[0] = 3.75; return a[0]; }`);
+    expect(e.f()).toBe(3.75);
+  });
+
+  it("map stores fractional/doubled values without truncation", async () => {
+    // Was [3, 5] (truncated) — now [3, 5] exactly for these, but the doubled
+    // 1.5→3 path used to truncate the *intermediate* before storing.
+    const e = await compileLinear(
+      `export function f(): number { const a = [1.5, 2.5].map(x => x * 2); return a[0] + a[1]; }`,
+    );
+    expect(e.f()).toBe(8); // 3 + 5
+  });
+
+  it("map of a fractional transform keeps the fraction", async () => {
+    const e = await compileLinear(
+      `export function f(): number { const a = [2, 4].map(x => x / 4); return a[0] + a[1]; }`,
+    );
+    expect(e.f()).toBe(1.5); // 0.5 + 1.0
+  });
+
+  it("filter preserves fractional elements in the result array", async () => {
+    const e = await compileLinear(
+      `export function f(): number { const a = [1.5, 2.5, 3.5].filter(x => x > 2); return a[0] + a[1]; }`,
+    );
+    expect(e.f()).toBe(6); // 2.5 + 3.5
+  });
+
+  it("destructuring rest (__arr_slice) copies fractional elements via the raw 8-byte slot", async () => {
+    // The rest binding routes through __arr_slice, which copies slots verbatim
+    // via __arr_get → __arr_push — representation-correct for free once both are
+    // f64-typed (#1938).
+    const e = await compileLinear(`
+      export function f(): number {
+        const a = [9.25, 1.5, -2.5];
+        const [, ...rest] = a;
+        return rest[0] + rest[1];
+      }
+    `);
+    expect(e.f()).toBe(-1); // 1.5 + (-2.5)
+  });
+
+  it("for-of read yields fractional elements", async () => {
+    const e = await compileLinear(`
+      export function f(): number {
+        const a = [0.5, 1.25, 2.25];
+        let sum: number = 0;
+        for (const x of a) { sum = sum + x; }
+        return sum;
+      }
+    `);
+    expect(e.f()).toBe(4); // 0.5 + 1.25 + 2.25
+  });
+
+  it("NaN element round-trips (f64 store/load, no canonicalisation surprise)", async () => {
+    const e = await compileLinear(`export function f(): number { const a = [NaN]; return a[0]; }`);
+    expect(Number.isNaN(e.f())).toBe(true);
+  });
+
+  it("negative zero is preserved (was lost under i32 truncation)", async () => {
+    const e = await compileLinear(`
+      export function f(): number {
+        const a = [-0];
+        // 1 / -0 === -Infinity distinguishes -0 from +0
+        return 1 / a[0];
+      }
+    `);
+    expect(e.f()).toBe(-Infinity);
+  });
+
+  it("large integer beyond 2^31 is not truncated to i32 range", async () => {
+    const e = await compileLinear(`export function f(): number { const a = [3000000000]; return a[0]; }`);
+    expect(e.f()).toBe(3000000000); // would overflow i32
+  });
+
+  it("string[] element read still works (ref handle in low 4 bytes)", async () => {
+    const e = await compileLinear(`
+      export function f(): number {
+        const a = ["ab", "cde"];
+        // .length proves the slot decoded back to a valid string handle
+        return a[1].length;
+      }
+    `);
+    expect(e.f()).toBe(3);
+  });
+
+  it("string[] join round-trips through f64 slots", async () => {
+    const e = await compileLinear(`
+      export function f(): number {
+        const a = ["x", "yy", "zzz"];
+        return a.join("-").length;
+      }
+    `);
+    expect(e.f()).toBe(8); // "x-yy-zzz"
+  });
+
+  it("nested number[][] inner element keeps its fraction", async () => {
+    const e = await compileLinear(`
+      export function f(): number {
+        const a = [[1.5, 2.5], [3.5]];
+        return a[0][0] + a[1][0];
+      }
+    `);
+    expect(e.f()).toBe(5); // 1.5 + 3.5
+  });
+
+  it("boolean[] element reads back correctly (rides the f64 path)", async () => {
+    const e = await compileLinear(`
+      export function f(): number {
+        const a = [true, false, true];
+        let n: number = 0;
+        if (a[0]) n = n + 1;
+        if (a[1]) n = n + 10;
+        if (a[2]) n = n + 100;
+        return n;
+      }
+    `);
+    expect(e.f()).toBe(101);
+  });
+
+  it("store-beyond-length zero-fills the gap with f64 zeros", async () => {
+    const e = await compileLinear(`
+      export function f(): number {
+        const a: number[] = [1.5];
+        a[3] = 4.5;
+        // a[1], a[2] are the zero-filled gap; a[0]=1.5, a[3]=4.5
+        return a[0] + a[1] + a[2] + a[3];
+      }
+    `);
+    expect(e.f()).toBe(6); // 1.5 + 0 + 0 + 4.5
+  });
+});

--- a/tests/linear-array.test.ts
+++ b/tests/linear-array.test.ts
@@ -50,6 +50,7 @@ describe("linear-array: Array runtime", () => {
   });
 
   it("pushes elements and reads length", async () => {
+    // #1938: __arr_push takes an f64 element slot (was i32).
     const e = await buildWithArray((mod, fi) => {
       const typeIdx = mod.types.length;
       mod.types.push({
@@ -67,15 +68,15 @@ describe("linear-array: Array runtime", () => {
           { op: "i32.const", value: 8 },
           { op: "call", funcIdx: fi.__arr_new },
           { op: "local.set", index: 0 },
-          // push 3 elements
+          // push 3 elements (f64 slots)
           { op: "local.get", index: 0 },
-          { op: "i32.const", value: 10 },
+          { op: "f64.const", value: 10 },
           { op: "call", funcIdx: fi.__arr_push },
           { op: "local.get", index: 0 },
-          { op: "i32.const", value: 20 },
+          { op: "f64.const", value: 20 },
           { op: "call", funcIdx: fi.__arr_push },
           { op: "local.get", index: 0 },
-          { op: "i32.const", value: 30 },
+          { op: "f64.const", value: 30 },
           { op: "call", funcIdx: fi.__arr_push },
           // Get length
           { op: "local.get", index: 0 },
@@ -89,13 +90,15 @@ describe("linear-array: Array runtime", () => {
   });
 
   it("gets elements by index", async () => {
+    // #1938: __arr_push takes f64, __arr_get returns the f64 slot. Fractional
+    // values round-trip exactly (the whole point of part 2).
     const e = await buildWithArray((mod, fi) => {
       const typeIdx = mod.types.length;
       mod.types.push({
         kind: "func",
         name: "$type_test",
         params: [{ kind: "i32" }],
-        results: [{ kind: "i32" }],
+        results: [{ kind: "f64" }],
       });
       const funcIdx = mod.functions.length;
       mod.functions.push({
@@ -106,15 +109,15 @@ describe("linear-array: Array runtime", () => {
           { op: "i32.const", value: 8 },
           { op: "call", funcIdx: fi.__arr_new },
           { op: "local.set", index: 1 },
-          // push 100, 200, 300
+          // push 100, 200.5, 300
           { op: "local.get", index: 1 },
-          { op: "i32.const", value: 100 },
+          { op: "f64.const", value: 100 },
           { op: "call", funcIdx: fi.__arr_push },
           { op: "local.get", index: 1 },
-          { op: "i32.const", value: 200 },
+          { op: "f64.const", value: 200.5 },
           { op: "call", funcIdx: fi.__arr_push },
           { op: "local.get", index: 1 },
-          { op: "i32.const", value: 300 },
+          { op: "f64.const", value: 300 },
           { op: "call", funcIdx: fi.__arr_push },
           // Get at index param
           { op: "local.get", index: 1 },
@@ -126,18 +129,19 @@ describe("linear-array: Array runtime", () => {
       mod.exports.push({ name: "test_arr_get", desc: { kind: "func", index: funcIdx } });
     });
     expect(e.test_arr_get(0)).toBe(100);
-    expect(e.test_arr_get(1)).toBe(200);
+    expect(e.test_arr_get(1)).toBe(200.5);
     expect(e.test_arr_get(2)).toBe(300);
   });
 
   it("sets elements by index", async () => {
+    // #1938: __arr_set takes an f64 element slot; __arr_get returns it.
     const e = await buildWithArray((mod, fi) => {
       const typeIdx = mod.types.length;
       mod.types.push({
         kind: "func",
         name: "$type_test",
         params: [],
-        results: [{ kind: "i32" }],
+        results: [{ kind: "f64" }],
       });
       const funcIdx = mod.functions.length;
       mod.functions.push({
@@ -150,15 +154,15 @@ describe("linear-array: Array runtime", () => {
           { op: "local.set", index: 0 },
           // push 2 elements
           { op: "local.get", index: 0 },
-          { op: "i32.const", value: 0 },
+          { op: "f64.const", value: 0 },
           { op: "call", funcIdx: fi.__arr_push },
           { op: "local.get", index: 0 },
-          { op: "i32.const", value: 0 },
+          { op: "f64.const", value: 0 },
           { op: "call", funcIdx: fi.__arr_push },
-          // Set index 1 to 999
+          // Set index 1 to 999.25
           { op: "local.get", index: 0 },
           { op: "i32.const", value: 1 },
-          { op: "i32.const", value: 999 },
+          { op: "f64.const", value: 999.25 },
           { op: "call", funcIdx: fi.__arr_set },
           // Get index 1
           { op: "local.get", index: 0 },
@@ -169,6 +173,6 @@ describe("linear-array: Array runtime", () => {
       });
       mod.exports.push({ name: "test_arr_set", desc: { kind: "func", index: funcIdx } });
     });
-    expect(e.test_arr_set()).toBe(999);
+    expect(e.test_arr_set()).toBe(999.25);
   });
 });

--- a/tests/simd.test.ts
+++ b/tests/simd.test.ts
@@ -567,7 +567,9 @@ describe("SIMD string indexOf (__str_indexOf_simd)", () => {
 });
 
 describe("SIMD array indexOf (__arr_indexOf_simd)", () => {
-  it("finds element in first 4 (SIMD path)", async () => {
+  // #1938: number[] elements are f64 slots; the SIMD helper now takes an f64
+  // search value and compares 2 elements per f64x2 chunk.
+  it("finds element in first SIMD chunk", async () => {
     const e = await buildWithSimd((mod, fi) => {
       const typeIdx = mod.types.length;
       mod.types.push({
@@ -588,12 +590,12 @@ describe("SIMD array indexOf (__arr_indexOf_simd)", () => {
           { op: "local.set", index: 0 },
           ...[10, 20, 30, 40, 50, 60, 70, 80].flatMap((v) => [
             { op: "local.get" as const, index: 0 },
-            { op: "i32.const" as const, value: v },
+            { op: "f64.const" as const, value: v },
             { op: "call" as const, funcIdx: fi["__arr_push"] },
           ]),
           // Search for 30 (should be index 2)
           { op: "local.get", index: 0 },
-          { op: "i32.const", value: 30 },
+          { op: "f64.const", value: 30 },
           { op: "call", funcIdx: fi["__arr_indexOf_simd"] },
         ],
         exported: true,
@@ -603,7 +605,7 @@ describe("SIMD array indexOf (__arr_indexOf_simd)", () => {
     expect(e.test_arr_indexOf()).toBe(2);
   });
 
-  it("finds element in second SIMD chunk", async () => {
+  it("finds element in a later SIMD chunk", async () => {
     const e = await buildWithSimd((mod, fi) => {
       const typeIdx = mod.types.length;
       mod.types.push({
@@ -623,12 +625,12 @@ describe("SIMD array indexOf (__arr_indexOf_simd)", () => {
           { op: "local.set", index: 0 },
           ...[10, 20, 30, 40, 50, 60, 70, 80].flatMap((v) => [
             { op: "local.get" as const, index: 0 },
-            { op: "i32.const" as const, value: v },
+            { op: "f64.const" as const, value: v },
             { op: "call" as const, funcIdx: fi["__arr_push"] },
           ]),
-          // Search for 70 (should be index 6, in second SIMD chunk)
+          // Search for 70 (should be index 6)
           { op: "local.get", index: 0 },
-          { op: "i32.const", value: 70 },
+          { op: "f64.const", value: 70 },
           { op: "call", funcIdx: fi["__arr_indexOf_simd"] },
         ],
         exported: true,
@@ -636,6 +638,37 @@ describe("SIMD array indexOf (__arr_indexOf_simd)", () => {
       mod.exports.push({ name: "test_arr_indexOf2", desc: { kind: "func", index: funcIdx } });
     });
     expect(e.test_arr_indexOf2()).toBe(6);
+  });
+
+  it("finds a fractional element (f64 fidelity, not possible under i32)", async () => {
+    const e = await buildWithSimd((mod, fi) => {
+      const typeIdx = mod.types.length;
+      mod.types.push({ kind: "func", name: "$test_type", params: [], results: [{ kind: "i32" }] });
+      const funcIdx = mod.functions.length;
+      mod.functions.push({
+        name: "test_arr_indexOf_frac",
+        typeIdx,
+        locals: [{ name: "arr", type: { kind: "i32" } }],
+        body: [
+          { op: "i32.const", value: 16 },
+          { op: "call", funcIdx: fi["__arr_new"] },
+          { op: "local.set", index: 0 },
+          ...[1.5, 2.5, 3.5, 4.5, 5.5].flatMap((v) => [
+            { op: "local.get" as const, index: 0 },
+            { op: "f64.const" as const, value: v },
+            { op: "call" as const, funcIdx: fi["__arr_push"] },
+          ]),
+          // Search for 3.5 (should be index 2) — would be impossible if elements
+          // were i32-truncated to 3.
+          { op: "local.get", index: 0 },
+          { op: "f64.const", value: 3.5 },
+          { op: "call", funcIdx: fi["__arr_indexOf_simd"] },
+        ],
+        exported: true,
+      });
+      mod.exports.push({ name: "test_arr_indexOf_frac", desc: { kind: "func", index: funcIdx } });
+    });
+    expect(e.test_arr_indexOf_frac()).toBe(2);
   });
 
   it("returns -1 when element not found", async () => {
@@ -658,11 +691,11 @@ describe("SIMD array indexOf (__arr_indexOf_simd)", () => {
           { op: "local.set", index: 0 },
           ...[10, 20, 30].flatMap((v) => [
             { op: "local.get" as const, index: 0 },
-            { op: "i32.const" as const, value: v },
+            { op: "f64.const" as const, value: v },
             { op: "call" as const, funcIdx: fi["__arr_push"] },
           ]),
           { op: "local.get", index: 0 },
-          { op: "i32.const", value: 99 },
+          { op: "f64.const", value: 99 },
           { op: "call", funcIdx: fi["__arr_indexOf_simd"] },
         ],
         exported: true,
@@ -681,7 +714,7 @@ describe("SIMD array fill (__arr_fill_simd)", () => {
         kind: "func",
         name: "$test_type",
         params: [],
-        results: [{ kind: "i32" }],
+        results: [{ kind: "f64" }],
       });
       const funcIdx = mod.functions.length;
       mod.functions.push({
@@ -695,16 +728,16 @@ describe("SIMD array fill (__arr_fill_simd)", () => {
           { op: "local.set", index: 0 },
           ...[0, 0, 0, 0, 0, 0, 0, 0].flatMap((_) => [
             { op: "local.get" as const, index: 0 },
-            { op: "i32.const" as const, value: 0 },
+            { op: "f64.const" as const, value: 0 },
             { op: "call" as const, funcIdx: fi["__arr_push"] },
           ]),
-          // Fill with value 42 from index 0 to 8
+          // Fill with value 42.5 from index 0 to 8
           { op: "local.get", index: 0 },
-          { op: "i32.const", value: 42 },
+          { op: "f64.const", value: 42.5 },
           { op: "i32.const", value: 0 },
           { op: "i32.const", value: 8 },
           { op: "call", funcIdx: fi["__arr_fill_simd"] },
-          // Read element at index 5 (should be 42)
+          // Read element at index 5 (should be 42.5 — f64 fidelity)
           { op: "local.get", index: 0 },
           { op: "i32.const", value: 5 },
           { op: "call", funcIdx: fi["__arr_get"] },
@@ -713,7 +746,7 @@ describe("SIMD array fill (__arr_fill_simd)", () => {
       });
       mod.exports.push({ name: "test_arr_fill", desc: { kind: "func", index: funcIdx } });
     });
-    expect(e.test_arr_fill()).toBe(42);
+    expect(e.test_arr_fill()).toBe(42.5);
   });
 
   it("fills partial range", async () => {
@@ -725,7 +758,6 @@ describe("SIMD array fill (__arr_fill_simd)", () => {
         params: [],
         results: [{ kind: "i32" }],
       });
-      // Returns two values packed: arr[1] * 1000 + arr[3]
       const funcIdx = mod.functions.length;
       mod.functions.push({
         name: "test_arr_fill_partial",
@@ -737,30 +769,33 @@ describe("SIMD array fill (__arr_fill_simd)", () => {
           { op: "local.set", index: 0 },
           ...[1, 2, 3, 4, 5].flatMap((v) => [
             { op: "local.get" as const, index: 0 },
-            { op: "i32.const" as const, value: v },
+            { op: "f64.const" as const, value: v },
             { op: "call" as const, funcIdx: fi["__arr_push"] },
           ]),
           // Fill from index 1 to 3 with value 99
           { op: "local.get", index: 0 },
-          { op: "i32.const", value: 99 },
+          { op: "f64.const", value: 99 },
           { op: "i32.const", value: 1 },
           { op: "i32.const", value: 3 },
           { op: "call", funcIdx: fi["__arr_fill_simd"] },
-          // Return arr[0] * 10000 + arr[1] * 100 + arr[2]
+          // Return arr[0] * 10000 + arr[1] * 100 + arr[2] (truncate f64 → i32)
           { op: "local.get", index: 0 },
           { op: "i32.const", value: 0 },
           { op: "call", funcIdx: fi["__arr_get"] },
+          { op: "i32.trunc_f64_s" },
           { op: "i32.const", value: 10000 },
           { op: "i32.mul" },
           { op: "local.get", index: 0 },
           { op: "i32.const", value: 1 },
           { op: "call", funcIdx: fi["__arr_get"] },
+          { op: "i32.trunc_f64_s" },
           { op: "i32.const", value: 100 },
           { op: "i32.mul" },
           { op: "i32.add" },
           { op: "local.get", index: 0 },
           { op: "i32.const", value: 2 },
           { op: "call", funcIdx: fi["__arr_get"] },
+          { op: "i32.trunc_f64_s" },
           { op: "i32.add" },
           // Expected: 1 * 10000 + 99 * 100 + 99 = 19999
         ],


### PR DESCRIPTION
## #1938 part 2 — linear `number[]` stores i32 (`[1.5][0]` → 1)

The linear backend stored every array element in a 4-byte i32 slot, so
`number[]` reads converted i32→f64 on the way out and writes truncated f64→i32 —
`[1.5][0]` silently became `1`. This implements the architect's stride-8
uniform-f64-slot design (see the issue's `## Implementation Plan`).

### Approach
Array element slots are now **8 bytes**, holding a raw f64 bit pattern the
runtime never interprets (`__arr_get`/`__arr_set`/`__arr_push`/`__arr_from_data`
take/return f64, stride 8). Codegen owns interpretation per element kind:
- **number/boolean** → the slot *is* the f64 value (zero conversions, hot path).
- **reference (string/object)** → the i32 handle lives in the low 4 bytes,
  shuffled via `i64.extend_i32_u`→`f64.reinterpret_i64` on store and the inverse
  on load (`pushI32ToSlot`/`pushSlotToI32`).

Routing reuses the **existing per-site `elemIsI32`/`inferExprType` decision** —
no new global pass. Updated sites: array literal, element read/assign, for-of
(incl. the `ArrayOrUint8Array` runtime-dispatch `if` reconciled to f64), array
destructuring, `.push`, HOF map/filter/flatMap (**also removes 3
`i32.trunc_f64_s` truncation bugs**), `join`. Runtime helpers `__str_split` /
`__u8arr_from_arr` / `__arr_from_data` updated to the f64 slot. C-ABI `number[]`
return payloads are now 8-byte-strided (host reads `Float64Array`); the dead
`__arr_indexOf_simd`/`__arr_fill_simd` helpers rewritten `i32x4`→`f64x2` to stay
layout-consistent.

### Tests
- `tests/issue-1938-number-array-f64.test.ts` — 17 cases: `[1.5][0]`, fractional
  sum/push/set/map/filter, for-of, NaN, `-0`, `>2^31`, nested `number[][]`,
  `string[]` read+join, `boolean[]`, store-beyond-length zero-fill,
  destructuring-rest.
- `tests/issue-1835.test.ts` — C-ABI array return updated to `Float64Array`
  (8-byte stride) + a fractional round-trip case.
- `tests/linear-array.test.ts`, `tests/simd.test.ts` — low-level runtime tests
  updated to the f64 boundary.
- Full linear suite (126 tests / 15 files) + wasi/simd/c-abi all green; `tsc`
  clean. The 2 pre-existing failures in this area (`issue-1655`
  `Uint8Array.subarray` "illegal cast"; `real-world-wasi` `it.fails`
  `process.argv`) fail identically on clean `main` — not regressions.

### Out of scope (documented)
Map/Set keys/values still i32 (fractional key truncates — follow-up);
`Array.prototype.slice/indexOf/fill` method calls still unwired (pre-existing);
`number[]` C-ABI *param input* still rehydrates from packed i32.

Part 1 (RHS-once) already landed. Closes #1938.

🤖 Generated with [Claude Code](https://claude.com/claude-code)