### PR TITLE
fix(#1344): Generator next/return throw TypeError on non-generator receiver

### DIFF
--- a/plan/issues/1344-spec-gap-generator-prototype-receiver-checks.md
+++ b/plan/issues/1344-spec-gap-generator-prototype-receiver-checks.md
@@ -1,9 +1,10 @@
 ---
 id: 1344
 title: "spec gap: Generator/AsyncIterator prototype receiver TypeErrors + return/throw (52 + 12 test262 fails)"
-status: ready
+status: in-progress
+assignee: ttraenkler/sd3
 created: 2026-05-08
-updated: 2026-06-12
+updated: 2026-06-19
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -142,3 +143,48 @@ even though tests check just for its existence).
 ## Unblocked (2026-06-12)
 
 Blocker #1665 is done — flipped to `ready`, queued sprint 63. Re-validate the repro first (#2148).
+
+---
+
+## Slice 1 (2026-06-19, sd3) — `next`/`return` borrowed-receiver TypeError — LANDED
+
+Landed the dominant `this-val-not-generator` bucket: calling a borrowed
+generator method with a `this` that lacks `[[GeneratorState]]`
+(`GeneratorPrototype.next.call({})`) now throws a **catchable TypeError**
+(§27.5.3.2 GeneratorValidate step 2), instead of the prior **silent
+`{value: 0, done: true}` sentinel**.
+
+**Root cause / fix** (`src/codegen/generators-native.ts`
+`buildNativeGeneratorDispatch`): the dispatch tests the receiver against each
+known native-generator state type (`ref.test $stateType`) and, on no match, fell
+through to a hard-coded `{value:0, done:1}` result. That terminal `fallback`
+is exactly the "not a generator" case, so it now emits a real catchable
+TypeError via the shared `emitBrandCheckTypeError(ctx, body, msg)` helper (a
+`__new_TypeError` instance + `throw $exc`, never a `ref.cast` trap). `throw` is
+stack-polymorphic so it satisfies the enclosing block's result type without
+leaving a value. One disjoint change; the per-generator `next`/`return` branches
+are untouched.
+
+**Verified** (`tests/issue-1344.test.ts`, 5 cases): borrowed `.next.call({})`
+and `.return.call({}, v)` throw a `TypeError` *instance* (catchable in-module,
+not a host RuntimeError); real generator `.next()` sequence + `.return(v)`
+unchanged. `tsc --noEmit` clean; loadable generator suites
+(`generators`/`generator-methods*`-loadable/`gen-call-579`) green. (Several
+`generator-*.test.ts` files fail to even *load* on `origin/main` because they
+import a never-committed `tests/helpers.js` — pre-existing infra gap, not a
+regression from this change.)
+
+**Still open for #1344 (issue stays `in-progress`):**
+- **`.throw()`** is not routed through the native dispatch at all
+  (`tryCompileNativeGeneratorMethodCall` early-returns for `throw`, and
+  `compileDirectNativeGeneratorMethod` returns `undefined` for it) — the
+  `throw/from-state-completed` bucket is untouched.
+- **AsyncGenerator / AsyncIterator prototype** receiver checks + the
+  prototype-of-prototypes existence (the 12-fail async bucket).
+- **Reifying `GeneratorPrototype` as a first-class object** so the test262
+  `Object.getPrototypeOf(g).prototype.next` access path is exercised directly
+  (the current slice triggers via a borrowed method reference, which covers the
+  semantic but the test262 harness uses the prototype-object access).
+
+These remaining parts are the genuinely architectural half the 2026-05-28
+triage flagged ("NOT a localized fix") — route to senior-dev/architect.

--- a/plan/issues/1344-spec-gap-generator-prototype-receiver-checks.md
+++ b/plan/issues/1344-spec-gap-generator-prototype-receiver-checks.md
@@ -1,8 +1,8 @@
 ---
 id: 1344
 title: "spec gap: Generator/AsyncIterator prototype receiver TypeErrors + return/throw (52 + 12 test262 fails)"
-status: in-progress
-assignee: ttraenkler/sd3
+status: suspended
+assignee: ttraenkler/sen-1
 created: 2026-05-08
 updated: 2026-06-19
 priority: medium
@@ -188,3 +188,60 @@ regression from this change.)
 
 These remaining parts are the genuinely architectural half the 2026-05-28
 triage flagged ("NOT a localized fix") — route to senior-dev/architect.
+
+## Suspended Work (sd3 → sen-1, 2026-06-19)
+
+**Branch:** `issue-1344-generator-receiver-checks` (PR #1732, BLOCKED — net-53)
+**Worktree:** `/workspace/.claude/worktrees/issue-1344-generator-receiver-checks`
+**PR #1732:** parked — fails the standalone regression gate; NOT in the merge
+queue; do NOT enqueue.
+
+### What the branch does (and why it regressed)
+Slice 1 makes `buildNativeGeneratorDispatch`'s terminal `fallback`
+(`src/codegen/generators-native.ts`) throw a catchable TypeError via
+`emitBrandCheckTypeError` (native-proto.ts) instead of the silent
+`{value:0,done:true}` sentinel. **Semantically correct** — borrowed
+`Generator.prototype.{next,return}.call({})` now throws TypeError per §27.5.3.2;
+5 unit tests pass (`tests/issue-1344.test.ts`); tsc clean.
+
+**But CI standalone regression gate = net -53** (single bucket
+`37cbcb78aea838e8`, all "wasm-hash change"). Confirmed root cause:
+`emitBrandCheckTypeError` runs error-machinery side effects
+(`emitWasiErrorConstructor` pushes `__new_TypeError`, `addStringConstantGlobal`,
+`ensureExnTag`) **per generator dispatch site, inline in the fallback build**,
+which happens MID generator-body compilation. This perturbs **every** generator
+binary (+346 bytes for a one-generator program, verified) even when the throw is
+never reached, and for 53 standalone tests that perturbation flips pass→fail.
+Basic generator runtime behaviour (next/for-of/return/done/yield*) is
+byte-stable and value-identical to baseline; the 53 are a subtler
+harness/index-timing interaction.
+
+### Approved fix direction (tech-lead option A) — needs senior-dev
+Pre-register the TypeError-throw machinery **once** as a shared helper (mirror
+#2025's proven `ensureNullThisTypeError` + `buildNullThisTypeErrorThrow`):
+- a `ctx.generatorBrandTypeErrorReady` flag + idempotent
+  `ensureGeneratorBrandTypeError(ctx, fctx)` that registers
+  `__new_TypeError` / the message string / exn-tag ONCE with a correct
+  late-import flush (`ensureLateImport` + `flushLateImportShifts`);
+- a pure-lookup `buildGeneratorBrandTypeErrorThrow(ctx)` for the fallback arm;
+- a single SHARED message (not the per-`methodName` string the WIP uses).
+Then re-validate the standalone gate — **net ≥ 0 required before enqueue.**
+
+**Why senior-dev / the tripwire:** getting `ensure`'s late-import flush to land
+on the in-progress generator `fctx` at the right moment during the mid-body
+`buildNativeGeneratorDispatch` build is exactly the error-machinery **timing**
+protocol that #1726 / #2079 own. Done wrong it re-introduces the same index
+desync → another net-53 class. This is NOT just hoisting a throw to a stub.
+
+### Resume steps for sen-1
+1. `cd /workspace/.claude/worktrees/issue-1344-generator-receiver-checks`
+   (re-claim with `--force` if needed). PR #1732 is the existing impl PR.
+2. Replace the inline `emitBrandCheckTypeError(ctx, fallback, …)` call in
+   `buildNativeGeneratorDispatch` with `ensure…` (once, up front, before the
+   `branch(0)` build) + `build…` (pure) for the fallback instrs.
+3. Verify a single-generator program is byte-identical to baseline when the
+   throw is unreachable (the WIP is +346 b; the fix should be ~0).
+4. Re-run the standalone regression gate; only enqueue at net ≥ 0.
+5. Then (separate follow-on slices, still #1344): `.throw()` routing,
+   AsyncGenerator/AsyncIterator prototype checks, GeneratorPrototype-as-object
+   reification — see the remaining-parts list above.

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -33,6 +33,7 @@ import { popBody, pushBody } from "./context/bodies.js";
 import type { CodegenContext, FunctionContext, NativeGeneratorInfo } from "./context/types.js";
 import { reportError } from "./context/errors.js";
 import { nativeStringType } from "./native-strings.js";
+import { emitBrandCheckTypeError } from "./native-proto.js";
 import { addFuncType } from "./registry/types.js";
 import { coerceType, compileExpression, compileStatement, valTypesMatch } from "./shared.js";
 
@@ -1691,11 +1692,14 @@ function buildNativeGeneratorDispatch(
 ): Instr[] {
   const infos = Array.from(ctx.nativeGenerators.values());
   const resultType: ValType = { kind: "ref", typeIdx: ensureNativeGeneratorResultType(ctx) };
-  const fallback: Instr[] = [
-    { op: "f64.const", value: 0 },
-    { op: "i32.const", value: 1 },
-    { op: "struct.new", typeIdx: ctx.nativeGeneratorResultTypeIdx },
-  ];
+  // #1344 — the receiver matched NONE of the native generator state types, i.e.
+  // `[[GeneratorState]]` is absent (e.g. `GeneratorPrototype.next.call({})`).
+  // Per §27.5.3.2 GeneratorValidate step 2 / §27.5.1.2-4, throw a *catchable*
+  // TypeError (a real `__new_TypeError` instance + `throw $exc`), never the old
+  // silent `{value: 0, done: true}` sentinel. `throw` is stack-polymorphic, so
+  // it satisfies the enclosing block's `resultType` without leaving a value.
+  const fallback: Instr[] = [];
+  emitBrandCheckTypeError(ctx, fallback, `Generator.prototype.${methodName} requires that 'this' be a Generator`);
 
   function branch(index: number): Instr[] {
     if (index >= infos.length) return fallback;

--- a/tests/issue-1344.test.ts
+++ b/tests/issue-1344.test.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1344 — Generator.prototype.{next,return} must validate the receiver.
+// Per ECMAScript §27.5.3.2 GeneratorValidate (step 2), calling a borrowed
+// generator method with a `this` that lacks the [[GeneratorState]] internal
+// slot (e.g. `GeneratorPrototype.next.call({})`) throws a TypeError. The native
+// generator dispatch previously fell through to a silent `{value: 0, done:
+// true}` sentinel; it now throws a catchable TypeError instance.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function compileAndRun(source: string): Promise<Record<string, Function>> {
+  const result = await compile(source);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as unknown as WebAssembly.Imports);
+  return instance.exports as unknown as Record<string, Function>;
+}
+
+describe("#1344 generator prototype receiver validation", () => {
+  it("borrowed .next() on a non-generator receiver throws TypeError", async () => {
+    const e = await compileAndRun(`
+      export function* g(): Generator<number> { yield 1; }
+      export function test(): number {
+        const it = g();
+        const next = (it as any).next;
+        try { next.call({} as any); return 0; }
+        catch (err) { return (err instanceof TypeError) ? 1 : 2; }
+      }
+    `);
+    expect(e.test()).toBe(1);
+  });
+
+  it("borrowed .return() on a non-generator receiver throws TypeError", async () => {
+    const e = await compileAndRun(`
+      export function* g(): Generator<number> { yield 1; }
+      export function test(): number {
+        const it = g();
+        const ret = (it as any).return;
+        try { ret.call({} as any, 5); return 0; }
+        catch (err) { return (err instanceof TypeError) ? 1 : 2; }
+      }
+    `);
+    expect(e.test()).toBe(1);
+  });
+
+  it("does not regress a real generator's .next() round-trip", async () => {
+    const e = await compileAndRun(`
+      export function* count(): Generator<number> { yield 10; yield 20; }
+      export function test(): number {
+        const it = count();
+        const a = it.next();   // 10
+        const b = it.next();   // 20
+        const c = it.next();   // done
+        return a.value + b.value + (c.done ? 1000 : 0);
+      }
+    `);
+    expect(e.test()).toBe(1030); // 10 + 20 + 1000
+  });
+
+  it("does not regress a real generator's .return()", async () => {
+    const e = await compileAndRun(`
+      export function* g(): Generator<number> { yield 1; yield 2; }
+      export function test(): number {
+        const it = g();
+        it.next();
+        const r = it.return(99);
+        return r.done ? 99 : 0;
+      }
+    `);
+    expect(e.test()).toBe(99);
+  });
+
+  it("the borrowed-receiver TypeError is catchable (not an unreachable trap)", async () => {
+    // A trap would propagate out of the wasm call and surface as a host
+    // RuntimeError, not a catchable in-module TypeError. This asserts the
+    // throw is a real `__new_TypeError` + `throw $exc` the wasm catch handles.
+    const e = await compileAndRun(`
+      export function* g(): Generator<number> { yield 1; }
+      export function test(): number {
+        const it = g();
+        const next = (it as any).next;
+        let caught: number = 0;
+        try { next.call({} as any); } catch (err) { caught = 1; }
+        return caught;
+      }
+    `);
+    expect(e.test()).toBe(1);
+  });
+});


### PR DESCRIPTION
## #1344 slice 1 — `Generator.prototype.{next,return}` receiver validation

Per ECMAScript §27.5.3.2 GeneratorValidate (step 2), a borrowed generator
method called with a `this` that lacks `[[GeneratorState]]`
(`GeneratorPrototype.next.call({})`) must throw a **TypeError**. The native
generator dispatch previously fell through to a **silent `{value: 0, done:
true}` sentinel** — this is the dominant `this-val-not-generator` test262
bucket.

### Fix
`buildNativeGeneratorDispatch` (`src/codegen/generators-native.ts`) tests the
receiver against each known native-generator state type (`ref.test $stateType`)
and, on no match, returned a hard-coded `{value:0, done:1}`. That terminal
`fallback` arm is exactly the "not a generator" case, so it now emits a real
**catchable** TypeError via the shared `emitBrandCheckTypeError` helper
(`__new_TypeError` instance + `throw $exc`, never a `ref.cast` trap). `throw` is
stack-polymorphic, so it satisfies the enclosing block's result type without
leaving a value. One disjoint change; the per-generator `next`/`return` branches
are untouched.

### Tests (`tests/issue-1344.test.ts`, 5 cases)
- Borrowed `.next.call({})` and `.return.call({}, v)` throw a `TypeError`
  *instance* (catchable in-module — proves it's not an `unreachable` host trap).
- Real generator `.next()` sequence + `.return(v)` round-trips unchanged.
- `tsc --noEmit` clean; loadable generator suites green. (Several
  `generator-*.test.ts` files fail to *load* on `main` — they import a
  never-committed `tests/helpers.js`, a pre-existing infra gap unrelated to this
  change.)

### Still open (issue stays `in-progress`)
`.throw()` routing, AsyncGenerator/AsyncIterator prototype checks, and reifying
`GeneratorPrototype` as a first-class object — the architectural half the
2026-05-28 triage flagged as "NOT a localized fix", routed to senior-dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)