### PR TITLE
feat(#2400): Wasm-native encodeURI/encodeURIComponent (standalone) — S1+S2

### DIFF
--- a/plan/issues/2400-native-uri-percent-encoding.md
+++ b/plan/issues/2400-native-uri-percent-encoding.md
@@ -1,0 +1,131 @@
+---
+id: 2400
+title: "Wasm-native decodeURI / encodeURI / decodeURIComponent / encodeURIComponent (percent-encoding, ~133 test262)"
+status: in-progress
+assignee: ttraenkler/sd5
+sprint: 64
+created: 2026-06-19
+updated: 2026-06-19
+priority: medium
+feasibility: medium
+reasoning_effort: high
+task_type: feature
+area: codegen
+language_feature: global-functions
+goal: standalone-mode
+test262_bucket: uri-encoding
+test262_count: 133
+---
+
+# #2400 — Wasm-native URI percent-encoding
+
+## Problem
+
+`decodeURI` / `decodeURIComponent` / `encodeURI` / `encodeURIComponent` are
+dispatched to **host imports** (`env.decodeURI` etc., `calls.ts:8892` +
+`declarations.ts:504`). Under `--target standalone`/`wasi` there is no JS host,
+so each leaks an unsatisfiable `env.*` import → instantiation failure. ~133
+test262 `built-ins/{decodeURI,encodeURI,...}` fail.
+
+Per the dual-mode invariant these need a **pure-Wasm** implementation (no host),
+following the #679/#682 native-backend pattern.
+
+## Spec (ECMAScript §19.2.6)
+
+- **Encode** (§19.2.6.5 Encode): for each code point of the input string, if it
+  is in the *preserved set* emit it verbatim; otherwise UTF-8-encode it and emit
+  `%XX` (uppercase hex) per byte. Unpaired surrogate → **URIError**.
+  - `encodeURIComponent` preserved set (`uriUnescaped`):
+    `A-Z a-z 0-9 - _ . ! ~ * ' ( )`.
+  - `encodeURI` preserved set = `uriUnescaped` ∪ `uriReserved` ∪ `#`:
+    adds `; / ? : @ & = + $ , #`.
+- **Decode** (§19.2.6.4 Decode): scan; on `%`, read two hex digits → a byte,
+  validate UTF-8 multi-byte sequences (leading byte → N continuation `%XX`),
+  reassemble the code point; a non-preserved-on-decode reserved char that was
+  escaped stays escaped for `decodeURI` (reservedSet) but is unescaped for
+  `decodeURIComponent` (empty reserved set). Malformed (`%` not followed by two
+  hex digits / bad continuation / overlong / out-of-range) → **URIError**.
+  - `decodeURIComponent` reserved set = empty.
+  - `decodeURI` reserved set = `; / ? : @ & = + $ , #` (kept escaped).
+
+## Implementation plan
+
+Native string-engine helpers (mirror `__str_to_number` / `emitNativeParseNumber`
+in `any-helpers.ts`), registered once and called from the four call sites:
+
+1. **`__uri_encode(str: externref, preservedMask: i32) → externref`** — iterate
+   the input's UTF-16 code units, decode surrogate pairs to code points
+   (URIError on lone surrogate), UTF-8-encode each code point to 1-4 bytes,
+   and for each byte either pass through (if a single-byte ASCII code point in
+   the preserved set, keyed by `preservedMask`) or append `%` + 2 uppercase hex
+   digits. Build the result as a native string. `preservedMask` distinguishes
+   the encodeURI vs encodeURIComponent preserved sets (a small bitset/range
+   check helper).
+2. **`__uri_decode(str: externref, reservedMask: i32) → externref`** — scan code
+   units; on `%`, parse 2 hex digits → byte, determine UTF-8 length from the
+   leading byte, parse the continuation `%XX`s, validate + reassemble the code
+   point, re-encode to UTF-16 (surrogate pair if > 0xFFFF). A decoded char in
+   the reserved set (for decodeURI) is re-emitted as the original `%XX` escape
+   verbatim. Malformed → URIError.
+3. **URIError** — emit a catchable URIError instance (reuse
+   `emitWasiErrorConstructor("URIError", 1)` / the shared brand-throw helper),
+   not a trap.
+4. **Call sites** (`calls.ts:8892`): when `noJsHost(ctx)` (or always, with the
+   host import as the fast path otherwise), route to the native helper with the
+   per-function preserved/reserved mask instead of the env import.
+
+### Slices
+- S1: `encodeURIComponent` (smallest preserved set, ASCII-only fast path first,
+  then full UTF-8 multi-byte). Validate against
+  `built-ins/encodeURIComponent/*`.
+- S2: `encodeURI` (add the reserved-set passthrough).
+- S3: `decodeURIComponent` (the %XX → UTF-8 → code point reassembly + URIError).
+- S4: `decodeURI` (reserved-set re-escape).
+
+## Acceptance criteria
+
+- `encodeURIComponent("a b&c") === "a%20b%26c"`; `encodeURI("a b/c") === "a%20b/c"`.
+- `decodeURIComponent("a%20b%26c") === "a b&c"`; `decodeURI("a%20b%2Fc") === "a b%2Fc"`.
+- Multi-byte: `encodeURIComponent("€") === "%E2%82%AC"`; round-trips.
+- Malformed `decodeURIComponent("%")` / `"%E2%28"` throw `URIError`.
+- Lone surrogate `encodeURIComponent("\uD800")` throws `URIError`.
+- Standalone: no `env.{decode,encode}URI*` host import leaks.
+
+## Progress
+
+**S1 + S2 DONE (sd5, 2026-06-19, PR pending).** `encodeURIComponent` and
+`encodeURI` are implemented together — they share the single native helper
+`__uri_encode(s, preservedMask)` and differ only by the mask
+(`encodeURIComponent = 0b01`, `encodeURI = 0b11`). New module
+`src/codegen/uri-encoding-native.ts`; wired at the declarations URI finalize
+(`src/codegen/declarations.ts`) under `ctx.wasi || ctx.standalone`, and routed
+at the call site (`src/codegen/expressions/calls.ts`) with the per-function
+mask. Host mode is unchanged (still `env.*` imports). `decodeURI{,Component}`
+still fall through to the host import in standalone — that is **S3/S4** (next
+slice).
+
+**S3/S4 REMAINING:** native `__uri_decode(s, reservedMask)` — `%XX` → UTF-8 →
+code-point reassembly with surrogate re-encode, the decodeURI reserved-set
+re-escape, and URIError on malformed input (`%` not followed by 2 hex digits /
+bad continuation / overlong / out-of-range / decoded lone surrogate).
+
+## Test Results
+
+`tests/issue-2400-uri-encoding.test.ts` — both tests green. Standalone module
+compiled with `target: "wasi"`, instantiated with an **empty import object**
+(proving no host); exports return numbers (`.length`/`.charCodeAt`) so results
+read back without a string-marshaling host. Verified:
+
+- ASCII passthrough + percent-encoding (`encodeURIComponent("a b&c")` →
+  `a%20b%26c`), all `uriUnescaped` marks + alphanumerics preserved, reserved
+  chars escaped by `encodeURIComponent` but preserved by `encodeURI`.
+- Multi-byte UTF-8: 2-byte (`©` → `%C2%A9`), 3-byte (`€` → `%E2%82%AC`), 4-byte
+  astral (`😀` D83D DE00 → `%F0%9F%98%80`).
+- URIError on unpaired surrogates (lone high, lone low, high-then-ASCII).
+- Empty string, encodeURI space-escape, host-mode env-import regression.
+
+## Source
+
+#2376 jsonl sweep, sd3, 2026-06-19. Routed by tech-lead from the
+percent-encoding family (the largest bounded standalone-feature cluster).
+S1/S2 implemented by sd5.

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -54,6 +54,7 @@ import {
 } from "./index.js";
 import { ensureNativeStringExternBridge, ensureNativeStringHelpers } from "./native-strings.js";
 import { emitNativeParseNumber } from "./parse-number-native.js";
+import { emitNativeUriEncode } from "./uri-encoding-native.js";
 import { emitNativeNumberFormat } from "./number-format-native.js";
 import {
   isNativeGeneratorCandidate,
@@ -1205,10 +1206,34 @@ export function finalizeUnifiedCollector(ctx: CodegenContext, state: UnifiedColl
   }
 
   // ── collectURIImports finalize ──
-  for (const name of state.uriNeeded) {
-    if (ctx.funcMap.has(name)) continue;
-    const typeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "externref" }]);
-    addImport(ctx, "env", name, { kind: "func", typeIdx });
+  // #2400 — `encodeURI` / `encodeURIComponent` are JS-host `env.*` imports in
+  // host mode. Under `--target wasi`/`--target standalone` there is no host, so
+  // the call site previously fell through to a `ref.test`/`ref.cast` of the
+  // argument and returned `null`. Emit the pure-Wasm `__uri_encode` helper
+  // instead (registered as a DEFINED func; the batched late-import shift keeps
+  // its funcMap index + sibling-call targets correct as later imports register).
+  // The four function NAMES remain mapped to the host import in host mode; in
+  // standalone mode the call site (calls.ts) routes the encode names through
+  // `__uri_encode` with the per-function preserved-set mask.
+  {
+    let needsNativeEncode = false;
+    for (const name of state.uriNeeded) {
+      if (ctx.funcMap.has(name)) continue;
+      if (ctx.wasi || ctx.standalone) {
+        if (name === "encodeURI" || name === "encodeURIComponent") {
+          needsNativeEncode = true;
+          continue;
+        }
+        // decodeURI / decodeURIComponent native path (S3/S4) not yet emitted;
+        // fall through to the host import so host mode is unaffected and the
+        // standalone decode path is a follow-up slice.
+      }
+      const typeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "externref" }]);
+      addImport(ctx, "env", name, { kind: "func", typeIdx });
+    }
+    if (needsNativeEncode) {
+      emitNativeUriEncode(ctx);
+    }
   }
 
   // ── collectStringStaticImports finalize ──

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -165,6 +165,7 @@ import {
   stringConstantExternrefInstrs,
 } from "../native-strings.js";
 import { emitVariadicStringConcat, hostStringRepr, nativeStringRepr } from "../builtin-scaffold.js";
+import { URI_ENCODE_MASK } from "../uri-encoding-native.js";
 import { emitArrayBufferSlice, emitDataViewAccessor, isDataViewAccessor } from "../dataview-native.js";
 import {
   getLinearU8Buffer,
@@ -8889,7 +8890,11 @@ function compileCallExpression(
       }
     }
 
-    // decodeURI, decodeURIComponent, encodeURI, encodeURIComponent — host imports
+    // decodeURI, decodeURIComponent, encodeURI, encodeURIComponent.
+    // Host mode: per-name `env.*` import. Standalone/wasi (#2400): the encode
+    // names route to the pure-Wasm `__uri_encode(s, preservedMask)` helper
+    // emitted in declarations.ts, passing the per-function preserved-set mask
+    // (encodeURIComponent = uriUnescaped; encodeURI = + uriReserved ∪ #).
     if (
       (funcName === "decodeURI" ||
         funcName === "decodeURIComponent" ||
@@ -8897,6 +8902,19 @@ function compileCallExpression(
         funcName === "encodeURIComponent") &&
       expr.arguments.length >= 1
     ) {
+      const nativeEncodeIdx =
+        funcName === "encodeURI" || funcName === "encodeURIComponent"
+          ? ctx.funcMap.get("__uri_encode")
+          : undefined;
+      if (nativeEncodeIdx !== undefined) {
+        const arg0Type = compileExpression(ctx, fctx, expr.arguments[0]!);
+        if (arg0Type && arg0Type.kind !== "externref") {
+          coerceType(ctx, fctx, arg0Type, { kind: "externref" });
+        }
+        fctx.body.push({ op: "i32.const", value: URI_ENCODE_MASK[funcName]! });
+        fctx.body.push({ op: "call", funcIdx: nativeEncodeIdx });
+        return { kind: "externref" };
+      }
       const importFuncIdx = ctx.funcMap.get(funcName);
       if (importFuncIdx !== undefined) {
         const arg0Type = compileExpression(ctx, fctx, expr.arguments[0]!);

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -8903,9 +8903,7 @@ function compileCallExpression(
       expr.arguments.length >= 1
     ) {
       const nativeEncodeIdx =
-        funcName === "encodeURI" || funcName === "encodeURIComponent"
-          ? ctx.funcMap.get("__uri_encode")
-          : undefined;
+        funcName === "encodeURI" || funcName === "encodeURIComponent" ? ctx.funcMap.get("__uri_encode") : undefined;
       if (nativeEncodeIdx !== undefined) {
         const arg0Type = compileExpression(ctx, fctx, expr.arguments[0]!);
         if (arg0Type && arg0Type.kind !== "externref") {

--- a/src/codegen/uri-encoding-native.ts
+++ b/src/codegen/uri-encoding-native.ts
@@ -211,12 +211,7 @@ export function emitNativeUriEncode(ctx: CodegenContext): void {
   ];
 
   // getC: L_C = data[L_I]
-  const getC: Instr[] = [
-    get(L_DATA),
-    get(L_I),
-    { op: "array.get_u", typeIdx: strDataTypeIdx } as Instr,
-    set(L_C),
-  ];
+  const getC: Instr[] = [get(L_DATA), get(L_I), { op: "array.get_u", typeIdx: strDataTypeIdx } as Instr, set(L_C)];
 
   const body: Instr[] = [
     // flat = flatten(s); data = flat.data; i = flat.off; len = flat.off + flat.len

--- a/src/codegen/uri-encoding-native.ts
+++ b/src/codegen/uri-encoding-native.ts
@@ -1,0 +1,501 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Pure-Wasm `encodeURI` / `encodeURIComponent` for standalone / WASI targets
+ * (#2400). In JS-host mode these are `env.*` imports; under `--target
+ * wasi`/`--target standalone` there is no JS host, so the call sites silently
+ * fell through to a `ref.test`/`ref.cast` of the argument and returned `null`
+ * (~133 `built-ins/{encodeURI,encodeURIComponent,…}` test262 fail). This module
+ * emits a WasmGC-native implementation following the #679/#682 dual-backend
+ * pattern (mirrors `parse-number-native.ts` / `case-convert-native.ts`).
+ *
+ * Spec — ECMAScript §19.2.6.5 Encode( _string_, _unescapedSet_ ):
+ *   For each code point of the input UTF-16 string:
+ *     - if its single code unit is in _unescapedSet_, emit it verbatim;
+ *     - otherwise UTF-8-encode the code point (RFC 3629, 1–4 octets) and emit
+ *       `%XX` (uppercase hex) per octet. An unpaired surrogate → **URIError**.
+ *
+ *   `encodeURIComponent` _unescapedSet_ (`uriUnescaped`):
+ *       A-Z a-z 0-9 - _ . ! ~ * ' ( )
+ *   `encodeURI` _unescapedSet_ = `uriUnescaped` ∪ `uriReserved` ∪ `#`, adding:
+ *       ; / ? : @ & = + $ , #
+ *
+ * The two variants are selected by `preservedMask`:
+ *   bit 0 (always set) → include `uriUnescaped`
+ *   bit 1             → also include `uriReserved` ∪ `#` (the encodeURI extras)
+ */
+import type { Instr, ValType, WasmFunction } from "../ir/types.js";
+import type { CodegenContext } from "./context/types.js";
+import { ensureNativeStringHelpers, stringConstantExternrefInstrs } from "./native-strings.js";
+import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
+import { emitWasiErrorConstructor } from "./registry/error-types.js";
+import { addFuncType } from "./registry/types.js";
+
+/** Helper-name -> mask routed at the call site (calls.ts). */
+export const URI_ENCODE_MASK: Record<string, number> = {
+  encodeURIComponent: 0b01,
+  encodeURI: 0b11,
+};
+
+/**
+ * Emit the native `__uri_encode(s: externref, preservedMask: i32) -> externref`
+ * helper and register it in `ctx.funcMap`. Idempotent. Must run after
+ * `ensureNativeStringHelpers` (it calls it) so `__str_flatten` and the
+ * NativeString types exist, and before any function body that calls it.
+ */
+export function emitNativeUriEncode(ctx: CodegenContext): void {
+  if (ctx.funcMap.has("__uri_encode")) return;
+  ensureNativeStringHelpers(ctx);
+
+  const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten")!;
+  const strTypeIdx = ctx.nativeStrTypeIdx;
+  const strDataTypeIdx = ctx.nativeStrDataTypeIdx;
+  const i32: ValType = { kind: "i32" };
+  const extern: ValType = { kind: "externref" };
+
+  // Register the URIError constructor + the function type BEFORE computing
+  // `__uri_encode`'s funcIdx — `emitWasiErrorConstructor` appends `__new_URIError`
+  // to `ctx.mod.functions`, which would shift our slot. Compute funcIdx and set
+  // the funcMap entry only right before the push (see end of function), once no
+  // more dependency functions can be appended ahead of us.
+  emitWasiErrorConstructor(ctx, "URIError", 1);
+  addStringConstantGlobal(ctx, "URI malformed");
+  const uriErrCtorIdx = ctx.funcMap.get("__new_URIError")!;
+  const tagIdx = ensureExnTag(ctx);
+  // (externref, i32) -> externref  (the result string ref is widened to externref)
+  const realTypeIdx = addFuncType(ctx, [extern, i32], [extern]);
+
+  // ── params ──
+  const P_S = 0; // s: externref
+  const P_MASK = 1; // preservedMask: i32
+  // ── locals ──
+  const L_FLAT = 2; // flat: ref $NativeString
+  const L_DATA = 3; // data: ref $i16arr
+  const L_LEN = 4; // logical end index (off + len)
+  const L_I = 5; // scan cursor
+  const L_C = 6; // current code unit
+  const L_CP = 7; // decoded code point
+  const L_OUT = 8; // out: ref $i16arr (over-allocated)
+  const L_N = 9; // output length written so far
+  const L_B = 10; // a single UTF-8 byte
+  const L_LO = 11; // low surrogate
+  const L_CAP = 12; // out capacity
+
+  const get = (i: number): Instr => ({ op: "local.get", index: i }) as Instr;
+  const set = (i: number): Instr => ({ op: "local.set", index: i }) as Instr;
+  const tee = (i: number): Instr => ({ op: "local.tee", index: i }) as Instr;
+  const c = (value: number): Instr => ({ op: "i32.const", value }) as Instr;
+
+  // out[n++] = ch  (ch already on stack-free; pass via instrs producing the value)
+  const pushCh = (chInstrs: Instr[]): Instr[] => [
+    get(L_OUT),
+    get(L_N),
+    ...chInstrs,
+    { op: "array.set", typeIdx: strDataTypeIdx } as Instr,
+    get(L_N),
+    c(1),
+    { op: "i32.add" } as Instr,
+    set(L_N),
+  ];
+
+  // hexDigit(nibble 0..15) -> ASCII uppercase hex code unit, computed purely on
+  // the stack (no scratch local, so it never clobbers L_B): the nibble value `v`
+  // is mapped via `v + (v<10 ? '0' : 'A'-10)` using `select`. Both branch
+  // operands are constants, so no value-stack juggling is needed.
+  //   stack: [v] -> [hexCodeUnit]
+  const hexDigit = (vInstrs: Instr[]): Instr[] => {
+    // result = v + select('0', 'A'-10, v<10).
+    // select pops (cond, val2, val1) and pushes val1 when cond!=0 else val2, so
+    // the stack must be [val1='0', val2='A'-10, cond] at the select.
+    return [
+      ...vInstrs, // [v]              (addend lhs for the final i32.add)
+      c(48 /* '0' */), // [v, 48]
+      c(55 /* 'A'-10 */), // [v, 48, 55]
+      ...vInstrs, // [v, 48, 55, v]
+      c(10),
+      { op: "i32.lt_u" } as Instr, // [v, 48, 55, (v<10)]
+      { op: "select" } as Instr, // [v, base]
+      { op: "i32.add" } as Instr, // [v + base]
+    ];
+  };
+
+  // Emit one byte (in L_B) as %XX (uppercase). Consumes nothing; reads L_B.
+  const emitPercentByte: Instr[] = [
+    ...pushCh([c(37 /* '%' */)]),
+    ...pushCh(hexDigit([get(L_B), c(4), { op: "i32.shr_u" } as Instr, c(0xf), { op: "i32.and" } as Instr])),
+    ...pushCh(hexDigit([get(L_B), c(0xf), { op: "i32.and" } as Instr])),
+  ];
+
+  // isPreserved(c, mask): leaves i32 bool. Reads L_C and P_MASK.
+  // uriUnescaped: A-Z a-z 0-9 - _ . ! ~ * ' ( )
+  //   codes: 0x2D(-) 0x5F(_) 0x2E(.) 0x21(!) 0x7E(~) 0x2A(*) 0x27(') 0x28(() 0x29())
+  // uriReserved ∪ #: ; / ? : @ & = + $ , #
+  //   codes: 0x3B(;) 0x2F(/) 0x3F(?) 0x3A(:) 0x40(@) 0x26(&) 0x3D(=) 0x2B(+) 0x24($) 0x2C(,) 0x23(#)
+  const eqC = (code: number): Instr[] => [get(L_C), c(code), { op: "i32.eq" } as Instr];
+  const rangeC = (lo: number, hi: number): Instr[] => [
+    get(L_C),
+    c(lo),
+    { op: "i32.ge_u" } as Instr,
+    get(L_C),
+    c(hi),
+    { op: "i32.le_u" } as Instr,
+    { op: "i32.and" } as Instr,
+  ];
+  const isPreserved: Instr[] = [
+    // alphanumerics
+    ...rangeC(0x41, 0x5a), // A-Z
+    ...rangeC(0x61, 0x7a), // a-z
+    { op: "i32.or" } as Instr,
+    ...rangeC(0x30, 0x39), // 0-9
+    { op: "i32.or" } as Instr,
+    // uriUnescaped marks
+    ...eqC(0x2d),
+    { op: "i32.or" } as Instr,
+    ...eqC(0x5f),
+    { op: "i32.or" } as Instr,
+    ...eqC(0x2e),
+    { op: "i32.or" } as Instr,
+    ...eqC(0x21),
+    { op: "i32.or" } as Instr,
+    ...eqC(0x7e),
+    { op: "i32.or" } as Instr,
+    ...eqC(0x2a),
+    { op: "i32.or" } as Instr,
+    ...eqC(0x27),
+    { op: "i32.or" } as Instr,
+    ...eqC(0x28),
+    { op: "i32.or" } as Instr,
+    ...eqC(0x29),
+    { op: "i32.or" } as Instr,
+    // encodeURI extras gated by mask bit 1
+    get(P_MASK),
+    c(0b10),
+    { op: "i32.and" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "val", type: i32 },
+      then: [
+        ...eqC(0x3b),
+        ...eqC(0x2f),
+        { op: "i32.or" } as Instr,
+        ...eqC(0x3f),
+        { op: "i32.or" } as Instr,
+        ...eqC(0x3a),
+        { op: "i32.or" } as Instr,
+        ...eqC(0x40),
+        { op: "i32.or" } as Instr,
+        ...eqC(0x26),
+        { op: "i32.or" } as Instr,
+        ...eqC(0x3d),
+        { op: "i32.or" } as Instr,
+        ...eqC(0x2b),
+        { op: "i32.or" } as Instr,
+        ...eqC(0x24),
+        { op: "i32.or" } as Instr,
+        ...eqC(0x2c),
+        { op: "i32.or" } as Instr,
+        ...eqC(0x23),
+        { op: "i32.or" } as Instr,
+      ],
+      else: [c(0)],
+    } as Instr,
+    { op: "i32.or" } as Instr,
+  ];
+
+  // ── URIError throw sequence (raw Instrs) ──
+  // (ctor + string constant + exn tag were registered up top so they don't shift
+  // our funcIdx; reuse the captured `uriErrCtorIdx` / `tagIdx`.)
+  const throwURIError: Instr[] = [
+    ...stringConstantExternrefInstrs(ctx, "URI malformed"),
+    { op: "call", funcIdx: uriErrCtorIdx } as Instr,
+    { op: "throw", tagIdx } as Instr,
+  ];
+
+  // getC: L_C = data[L_I]
+  const getC: Instr[] = [
+    get(L_DATA),
+    get(L_I),
+    { op: "array.get_u", typeIdx: strDataTypeIdx } as Instr,
+    set(L_C),
+  ];
+
+  const body: Instr[] = [
+    // flat = flatten(s); data = flat.data; i = flat.off; len = flat.off + flat.len
+    get(P_S),
+    { op: "any.convert_extern" } as Instr,
+    { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx } as Instr,
+    { op: "call", funcIdx: flattenIdx } as Instr,
+    { op: "ref.cast", typeIdx: strTypeIdx } as Instr,
+    set(L_FLAT),
+    get(L_FLAT),
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 } as Instr,
+    set(L_DATA),
+    get(L_FLAT),
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 } as Instr,
+    set(L_I),
+    // len = off + flat.len
+    get(L_I),
+    get(L_FLAT),
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 0 } as Instr,
+    { op: "i32.add" } as Instr,
+    set(L_LEN),
+    // capacity = (len - off) * 9  (worst case: BMP char → 3 octets → 9 chars).
+    // Guard a 0-length string (cap=0 array is valid; loop won't run).
+    get(L_LEN),
+    get(L_FLAT),
+    { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 } as Instr,
+    { op: "i32.sub" } as Instr,
+    c(9),
+    { op: "i32.mul" } as Instr,
+    tee(L_CAP),
+    { op: "array.new_default", typeIdx: strDataTypeIdx } as Instr,
+    set(L_OUT),
+    c(0),
+    set(L_N),
+
+    // main scan
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            // if i>=len break
+            get(L_I),
+            get(L_LEN),
+            { op: "i32.ge_s" } as Instr,
+            { op: "br_if", depth: 1 } as Instr,
+            ...getC,
+            // if isPreserved(c): out[n++]=c; i++; continue
+            ...isPreserved,
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [
+                ...pushCh([get(L_C)]),
+                get(L_I),
+                c(1),
+                { op: "i32.add" } as Instr,
+                set(L_I),
+                { op: "br", depth: 1 } as Instr, // continue loop
+              ],
+            } as Instr,
+            // ── not preserved: decode code point ──
+            // default cp = c, advance 1
+            get(L_C),
+            set(L_CP),
+            get(L_I),
+            c(1),
+            { op: "i32.add" } as Instr,
+            set(L_I),
+            // high surrogate? 0xD800..0xDBFF
+            get(L_C),
+            c(0xd800),
+            { op: "i32.ge_u" } as Instr,
+            get(L_C),
+            c(0xdbff),
+            { op: "i32.le_u" } as Instr,
+            { op: "i32.and" } as Instr,
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [
+                // need a following low surrogate
+                get(L_I),
+                get(L_LEN),
+                { op: "i32.ge_s" } as Instr,
+                { op: "if", blockType: { kind: "empty" }, then: [...throwURIError] } as Instr,
+                // lo = data[i]
+                get(L_DATA),
+                get(L_I),
+                { op: "array.get_u", typeIdx: strDataTypeIdx } as Instr,
+                set(L_LO),
+                // lo in 0xDC00..0xDFFF ?
+                get(L_LO),
+                c(0xdc00),
+                { op: "i32.ge_u" } as Instr,
+                get(L_LO),
+                c(0xdfff),
+                { op: "i32.le_u" } as Instr,
+                { op: "i32.and" } as Instr,
+                { op: "i32.eqz" } as Instr,
+                { op: "if", blockType: { kind: "empty" }, then: [...throwURIError] } as Instr,
+                // cp = 0x10000 + ((c-0xD800)<<10) + (lo-0xDC00)
+                c(0x10000),
+                get(L_C),
+                c(0xd800),
+                { op: "i32.sub" } as Instr,
+                c(10),
+                { op: "i32.shl" } as Instr,
+                { op: "i32.add" } as Instr,
+                get(L_LO),
+                c(0xdc00),
+                { op: "i32.sub" } as Instr,
+                { op: "i32.add" } as Instr,
+                set(L_CP),
+                // consume the low surrogate
+                get(L_I),
+                c(1),
+                { op: "i32.add" } as Instr,
+                set(L_I),
+              ],
+            } as Instr,
+            // lone low surrogate (0xDC00..0xDFFF) → URIError
+            get(L_C),
+            c(0xdc00),
+            { op: "i32.ge_u" } as Instr,
+            get(L_C),
+            c(0xdfff),
+            { op: "i32.le_u" } as Instr,
+            { op: "i32.and" } as Instr,
+            { op: "if", blockType: { kind: "empty" }, then: [...throwURIError] } as Instr,
+
+            // ── UTF-8 encode cp into %XX bytes ──
+            // nbytes = cp<=0x7F?1 : cp<=0x7FF?2 : cp<=0xFFFF?3 : 4
+            get(L_CP),
+            c(0x7f),
+            { op: "i32.le_u" } as Instr,
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [
+                // 1 byte: cp
+                get(L_CP),
+                set(L_B),
+                ...emitPercentByte,
+              ],
+              else: [
+                get(L_CP),
+                c(0x7ff),
+                { op: "i32.le_u" } as Instr,
+                {
+                  op: "if",
+                  blockType: { kind: "empty" },
+                  then: [
+                    // 2 bytes: 110xxxxx 10xxxxxx
+                    get(L_CP),
+                    c(6),
+                    { op: "i32.shr_u" } as Instr,
+                    c(0xc0),
+                    { op: "i32.or" } as Instr,
+                    set(L_B),
+                    ...emitPercentByte,
+                    get(L_CP),
+                    c(0x3f),
+                    { op: "i32.and" } as Instr,
+                    c(0x80),
+                    { op: "i32.or" } as Instr,
+                    set(L_B),
+                    ...emitPercentByte,
+                  ],
+                  else: [
+                    get(L_CP),
+                    c(0xffff),
+                    { op: "i32.le_u" } as Instr,
+                    {
+                      op: "if",
+                      blockType: { kind: "empty" },
+                      then: [
+                        // 3 bytes: 1110xxxx 10xxxxxx 10xxxxxx
+                        get(L_CP),
+                        c(12),
+                        { op: "i32.shr_u" } as Instr,
+                        c(0xe0),
+                        { op: "i32.or" } as Instr,
+                        set(L_B),
+                        ...emitPercentByte,
+                        get(L_CP),
+                        c(6),
+                        { op: "i32.shr_u" } as Instr,
+                        c(0x3f),
+                        { op: "i32.and" } as Instr,
+                        c(0x80),
+                        { op: "i32.or" } as Instr,
+                        set(L_B),
+                        ...emitPercentByte,
+                        get(L_CP),
+                        c(0x3f),
+                        { op: "i32.and" } as Instr,
+                        c(0x80),
+                        { op: "i32.or" } as Instr,
+                        set(L_B),
+                        ...emitPercentByte,
+                      ],
+                      else: [
+                        // 4 bytes: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+                        get(L_CP),
+                        c(18),
+                        { op: "i32.shr_u" } as Instr,
+                        c(0xf0),
+                        { op: "i32.or" } as Instr,
+                        set(L_B),
+                        ...emitPercentByte,
+                        get(L_CP),
+                        c(12),
+                        { op: "i32.shr_u" } as Instr,
+                        c(0x3f),
+                        { op: "i32.and" } as Instr,
+                        c(0x80),
+                        { op: "i32.or" } as Instr,
+                        set(L_B),
+                        ...emitPercentByte,
+                        get(L_CP),
+                        c(6),
+                        { op: "i32.shr_u" } as Instr,
+                        c(0x3f),
+                        { op: "i32.and" } as Instr,
+                        c(0x80),
+                        { op: "i32.or" } as Instr,
+                        set(L_B),
+                        ...emitPercentByte,
+                        get(L_CP),
+                        c(0x3f),
+                        { op: "i32.and" } as Instr,
+                        c(0x80),
+                        { op: "i32.or" } as Instr,
+                        set(L_B),
+                        ...emitPercentByte,
+                      ],
+                    } as Instr,
+                  ],
+                } as Instr,
+              ],
+            } as Instr,
+            { op: "br", depth: 0 } as Instr,
+          ],
+        },
+      ],
+    },
+
+    // return struct.new $NativeString(len=n, off=0, data=out) widened to externref
+    get(L_N),
+    c(0),
+    get(L_OUT),
+    { op: "struct.new", typeIdx: strTypeIdx } as Instr,
+    { op: "extern.convert_any" } as Instr,
+  ];
+  // Now that no further dependency functions can be appended ahead of us,
+  // claim the slot: funcIdx = numImportFuncs + current functions length.
+  ctx.funcMap.set("__uri_encode", ctx.numImportFuncs + ctx.mod.functions.length);
+
+  ctx.mod.functions.push({
+    name: "__uri_encode",
+    typeIdx: realTypeIdx,
+    locals: [
+      { name: "flat", type: { kind: "ref", typeIdx: strTypeIdx } }, // L_FLAT
+      { name: "data", type: { kind: "ref", typeIdx: strDataTypeIdx } }, // L_DATA
+      { name: "len", type: i32 }, // L_LEN
+      { name: "i", type: i32 }, // L_I
+      { name: "ch", type: i32 }, // L_C
+      { name: "cp", type: i32 }, // L_CP
+      { name: "out", type: { kind: "ref", typeIdx: strDataTypeIdx } }, // L_OUT
+      { name: "n", type: i32 }, // L_N
+      { name: "b", type: i32 }, // L_B
+      { name: "lo", type: i32 }, // L_LO
+      { name: "cap", type: i32 }, // L_CAP
+    ],
+    body,
+    exported: false,
+  } as unknown as WasmFunction);
+}

--- a/tests/issue-2400-uri-encoding.test.ts
+++ b/tests/issue-2400-uri-encoding.test.ts
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2400 — Wasm-native `encodeURI` / `encodeURIComponent` (ECMAScript §19.2.6.5
+ * Encode) for standalone / WASI.
+ *
+ * In JS-host mode these are `env.*` imports. Under `--target wasi`/`--target
+ * standalone` there is no host, so the call site previously fell through to a
+ * `ref.test`/`ref.cast` of the argument and returned `undefined` (~133
+ * `built-ins/{encodeURI,encodeURIComponent}` test262 fail).
+ *
+ * S1 of the slice plan: the pure-Wasm `__uri_encode(s, preservedMask)` helper
+ * (`src/codegen/uri-encoding-native.ts`) — UTF-8 transcode (RFC 3629, 1–4
+ * octets) + surrogate-pair handling, the per-variant preserved-set mask
+ * (encodeURIComponent = `uriUnescaped`; encodeURI = + `uriReserved` ∪ `#`), and
+ * **URIError** on unpaired surrogates.
+ *
+ * Every standalone case instantiates with an EMPTY import object, proving no JS
+ * host is needed. Exported functions return NUMBERS (`.length` / `.charCodeAt`)
+ * so the result reads back without needing a string-marshaling host.
+ */
+
+// One module, one export per case — numeric returns only.
+type Case = { name: string; src: string; want: number };
+
+const CASES: ReadonlyArray<Case> = [
+  // ── encodeURIComponent: ASCII passthrough + percent-encoding ──
+  // "a b&c" -> "a%20b%26c" (length 9)
+  { name: "compLen", src: `return encodeURIComponent("a b&c").length;`, want: 9 },
+  { name: "compC0", src: `return encodeURIComponent("a b&c").charCodeAt(0);`, want: 97 /* 'a' */ },
+  { name: "compC1", src: `return encodeURIComponent("a b&c").charCodeAt(1);`, want: 37 /* '%' */ },
+  { name: "compC2", src: `return encodeURIComponent("a b&c").charCodeAt(2);`, want: 50 /* '2' */ },
+  { name: "compC3", src: `return encodeURIComponent("a b&c").charCodeAt(3);`, want: 48 /* '0' */ },
+  // uriUnescaped marks all pass through: - _ . ! ~ * ' ( )
+  { name: "unreserved", src: `return encodeURIComponent("-_.!~*'()").length;`, want: 9 },
+  // alphanumerics pass through
+  { name: "alnum", src: `return encodeURIComponent("abcXYZ0189").length;`, want: 10 },
+  // reserved chars ARE escaped by encodeURIComponent: / ? : @ & = + $ , #
+  { name: "compReserved", src: `return encodeURIComponent("/?:@&=+$,#").length;`, want: 30 /* 10 × %XX */ },
+
+  // ── multi-byte UTF-8 ──
+  // U+00A9 © -> %C2%A9 (2 octets, 6 chars)
+  { name: "twoByte", src: `return encodeURIComponent(String.fromCharCode(0xA9)).length;`, want: 6 },
+  // U+20AC € -> %E2%82%AC (3 octets, 9 chars)
+  { name: "threeByteLen", src: `return encodeURIComponent("€").length;`, want: 9 },
+  { name: "threeByteC1", src: `return encodeURIComponent("€").charCodeAt(1);`, want: 69 /* 'E' */ },
+  { name: "threeByteC2", src: `return encodeURIComponent("€").charCodeAt(2);`, want: 50 /* '2' */ },
+  // U+1F600 😀 (D83D DE00) -> %F0%9F%98%80 (4 octets, 12 chars)
+  { name: "fourByteLen", src: `return encodeURIComponent(String.fromCharCode(0xD83D, 0xDE00)).length;`, want: 12 },
+  { name: "fourByteC1", src: `return encodeURIComponent(String.fromCharCode(0xD83D, 0xDE00)).charCodeAt(1);`, want: 70 /* 'F' */ },
+
+  // ── encodeURI: reserved set ∪ # passes through ──
+  // "a b/c" -> "a%20b/c" (length 7, '/' preserved)
+  { name: "uriLen", src: `return encodeURI("a b/c").length;`, want: 7 },
+  { name: "uriC4", src: `return encodeURI("a b/c").charCodeAt(4);`, want: 98 /* 'b' */ },
+  // all reserved+# pass through unchanged: ; / ? : @ & = + $ , #
+  { name: "uriReserved", src: `return encodeURI(";/?:@&=+$,#").length;`, want: 11 },
+  // but space is still escaped by encodeURI
+  { name: "uriSpace", src: `return encodeURI(" ").length;`, want: 3 /* %20 */ },
+
+  // ── URIError on unpaired surrogates ──
+  {
+    name: "loneHigh",
+    src: `try { encodeURIComponent(String.fromCharCode(0xD800)); return 0; } catch (e) { return (e instanceof URIError) ? 1 : 2; }`,
+    want: 1,
+  },
+  {
+    name: "loneLow",
+    src: `try { encodeURIComponent(String.fromCharCode(0xDC00)); return 0; } catch (e) { return (e instanceof URIError) ? 1 : 2; }`,
+    want: 1,
+  },
+  {
+    name: "highThenAscii",
+    src: `try { encodeURIComponent(String.fromCharCode(0xD800, 0x41)); return 0; } catch (e) { return (e instanceof URIError) ? 1 : 2; }`,
+    want: 1,
+  },
+
+  // ── empty string ──
+  { name: "empty", src: `return encodeURIComponent("").length;`, want: 0 },
+];
+
+const MODULE_SRC = CASES.map((c) => `export function ${c.name}(): number { ${c.src} }`).join("\n");
+
+describe("#2400 Wasm-native encodeURI / encodeURIComponent (standalone)", () => {
+  it("compiles standalone with no host imports and matches the spec", async () => {
+    const result = await compile(MODULE_SRC, { fileName: "uri.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+
+    // No `env.{encode,decode}URI*` host import may leak in standalone mode.
+    const imports = WebAssembly.Module.imports(new WebAssembly.Module(result.binary));
+    expect(imports.filter((i) => /URI/i.test(i.name))).toEqual([]);
+
+    // EMPTY import object — proves the module is fully self-contained.
+    const { instance } = await WebAssembly.instantiate(result.binary, {});
+    const exports = instance.exports as Record<string, () => number>;
+    for (const c of CASES) {
+      expect(exports[c.name](), `${c.name}: ${c.src}`).toBe(c.want);
+    }
+  });
+
+  it("host mode still routes encodeURIComponent through the env import", async () => {
+    const result = await compile(`export function test(): string { return encodeURIComponent("a b&c"); }`, {
+      fileName: "uri.ts",
+    });
+    expect(result.success).toBe(true);
+    const importNames = WebAssembly.Module.imports(new WebAssembly.Module(result.binary)).map((i) => i.name);
+    expect(importNames).toContain("encodeURIComponent");
+  });
+});

--- a/tests/issue-2400-uri-encoding.test.ts
+++ b/tests/issue-2400-uri-encoding.test.ts
@@ -49,7 +49,11 @@ const CASES: ReadonlyArray<Case> = [
   { name: "threeByteC2", src: `return encodeURIComponent("€").charCodeAt(2);`, want: 50 /* '2' */ },
   // U+1F600 😀 (D83D DE00) -> %F0%9F%98%80 (4 octets, 12 chars)
   { name: "fourByteLen", src: `return encodeURIComponent(String.fromCharCode(0xD83D, 0xDE00)).length;`, want: 12 },
-  { name: "fourByteC1", src: `return encodeURIComponent(String.fromCharCode(0xD83D, 0xDE00)).charCodeAt(1);`, want: 70 /* 'F' */ },
+  {
+    name: "fourByteC1",
+    src: `return encodeURIComponent(String.fromCharCode(0xD83D, 0xDE00)).charCodeAt(1);`,
+    want: 70 /* 'F' */,
+  },
 
   // ── encodeURI: reserved set ∪ # passes through ──
   // "a b/c" -> "a%20b/c" (length 7, '/' preserved)


### PR DESCRIPTION
## #2400 — Wasm-native URI percent-encoding (S1 + S2: encode)

Under `--target wasi`/`--target standalone` there is no JS host, so
`encodeURI` / `encodeURIComponent` silently fell through to a `ref.test`/
`ref.cast` of the argument and returned `undefined` (~133
`built-ins/{encodeURI,encodeURIComponent}` test262 fail; the `env.*` import
was not even satisfiable).

This implements **S1 + S2** of sd3's 4-slice plan together — `encodeURI` and
`encodeURIComponent` share a single native helper and differ only by a mask.

### What changed
- **`src/codegen/uri-encoding-native.ts`** (new) — `__uri_encode(s, preservedMask)`,
  a pure-Wasm implementation of ECMAScript §19.2.6.5 Encode (hand-built
  `Instr[]`, #679/#682 dual-backend pattern): UTF-8 transcode (RFC 3629, 1–4
  octets), surrogate-pair handling, per-variant preserved-set mask
  (`encodeURIComponent = uriUnescaped`; `encodeURI = + uriReserved ∪ #`),
  uppercase `%XX` output, catchable **URIError** on unpaired surrogates.
- **`declarations.ts`** — register the helper at the URI finalize under
  `ctx.wasi || ctx.standalone`; host mode keeps the `env.*` imports unchanged.
- **`calls.ts`** — route the encode names to `__uri_encode` with the
  per-function mask (decode names still use the host import — that is S3/S4).

The helper's `funcIdx` is claimed only *after* `emitWasiErrorConstructor`
appends `__new_URIError`, so its module slot is never shifted out from under it.

### Validation
`tests/issue-2400-uri-encoding.test.ts` — 2 tests green. The standalone module
is compiled with `target: "wasi"` and instantiated with an **empty import
object** (proving no host); exports return numbers (`.length` / `.charCodeAt`)
so results read back without a string-marshaling host. Covers ASCII
passthrough + percent-encoding, all `uriUnescaped` marks, reserved-set
behavior (escaped by component, preserved by encodeURI), 2/3/4-byte UTF-8
(`©`/`€`/`😀`), URIError on lone/unpaired surrogates, empty string, and a
host-mode env-import regression check.

### Remaining (follow-on)
S3/S4 = native `__uri_decode` for `decodeURI`/`decodeURIComponent` (the
`%XX` → UTF-8 → code-point reassembly + URIError on malformed). The issue
stays `in-progress` until those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)