### PR TITLE
fix(#2009): R3b object-spread key insertion-order via host name-export CSV reorder

### DIFF
--- a/plan/issues/2009-same-shape-struct-field-name-collision.md
+++ b/plan/issues/2009-same-shape-struct-field-name-collision.md
@@ -1,10 +1,12 @@
 ---
 id: 2009
 title: "structurally identical struct types share field names at the host boundary — Object.assign/spread/JSON.stringify mislabel keys, spread override order broken"
-status: in-progress
+status: done
+assignee: ttraenkler/sen-1
+completed: 2026-06-19
 sprint: 64
 created: 2026-06-10
-updated: 2026-06-18
+updated: 2026-06-19
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -460,3 +462,60 @@ pass) to order an anon object-literal type's fields by JS insertion order
 higher blast radius (shared/canonical struct types, $shape, getters, dedup), so
 scoped OUT of PR-2. Tracked as `it.todo` in `tests/issue-2009.test.ts`. Keep
 #2009 in-progress until R3b lands.
+
+## R3b LANDED (2026-06-19, sen-1) — CSV-reorder, not struct-field reorder
+
+The prior R3b notes assumed the fix had to reorder the spread-result struct's
+**fields** (high blast radius: shared canonical types, `$shape`, getters, dedup).
+It does **not**. The host enumeration order is the **field-name CSV** in
+`__struct_field_names`, which `_structToPlainObject` (runtime.ts) reads BY NAME
+(`__sget_<name>` — slot-independent). So reordering only the CSV restores spec
+enumeration order while leaving slots/getters/dedup/`$shape` byte-identical. The
+struct field SLOT order stays last-spread-first; only the host's *view* of the
+key order changes. This is the lowest-blast-radius angle sd5 (cs-2158) identified.
+
+**Mechanism (4 files, +100/-2):**
+- `CodegenContext.structInsertionOrder: Map<structName, string[]>`
+  (`context/types.ts` + `create-context.ts`) — per anon-literal struct, the
+  field names in JS INSERTION order.
+- `compileObjectLiteralForStruct` (`literals.ts`): after `spreadSources` is
+  built, walk `expr.properties` in source order — named/shorthand/method/accessor
+  props contribute their key; a spread contributes its (already-resolved) source
+  struct's own field names in order. FIRST occurrence fixes a key's position
+  (`{...{a:1},...{b:2},...{a:3}}` → `a,b`). Recorded once per `typeName` (first
+  literal of a deduped canonical type wins → deterministic by compile order).
+- `orderNamesByInsertion(ctx, structName, slotNames)` (`index.ts`): pure permute
+  of `slotNames` into the recorded insertion order; **membership preserved
+  exactly** (never adds/drops a name, so every name still resolves to its
+  getter). No recorded order ⇒ unchanged.
+- Applied at the two CSV-build sites in `index.ts`: the legacy
+  `emitStructFieldNamesExport` arm AND the colliding-`$shape`
+  `resolveSameShapeFieldNameCollisions` arm (the structural-shape grouping key is
+  still slot-order `typeParts`, so same-shape grouping is unaffected; only the
+  enumerated `names`/shape-id CSV is reordered — two colliding structs with the
+  same insertion order now share a shape-id).
+
+**Fixed (asserted in `tests/issue-2009.test.ts`, R3b describe block):** inline +
+named-source two-spread (`{"x":1,"y":3,"z":4}`), leading/trailing named props
+interleaved with spreads, re-occurring-key first-position, Object.keys + for-in
+order via a binding. Plain-literal control unchanged. `tsc --noEmit` clean. The
+object/spread/json/destructuring equiv suites are unchanged vs main (the 4
+`object-mutability`/`object-literal-getters-setters` "setter stores value" /
+"is{Frozen,Sealed,Extensible} stub" FAILs are PRE-EXISTING on base, bisected by
+stashing the src change and re-running — identical 4 fail).
+
+**Known residual (acceptable, deterministic):** when two literals with the same
+field-name SET but DIFFERENT insertion order DEDUP to one canonical struct type
+(e.g. `{x:1,y:2}` and `{...{y:3},...{x:4}}` if the checker normalizes both to
+slot order `x,y`), the FIRST-recorded literal's order wins for both — so the
+second enumerates in the first's order (VALUES always correct, only key order
+differs). A per-instance fix would need `$shape`-style per-instance ordering =
+exactly the high blast radius this approach avoids; rare in practice, so left as
+the documented deterministic choice. The inline `Object.keys({...spread...})`
+direct-argument form still traps ("illegal cast") — a SEPARATE pre-existing
+`Object.keys` inline-spread-argument lowering bug (reproduced on main with the
+src change stashed), NOT an ordering issue; bind to a variable first. Carve
+separately if needed.
+
+All three original acceptance-criteria repros continue to match Node; R3b
+enumeration order now matches too. #2009 closed.

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -197,6 +197,7 @@ export function createCodegenContext(
     anonStructHash: new Map(),
     shapeIdByStructName: new Map(),
     shapeNameCsvById: [],
+    structInsertionOrder: new Map(),
     funcTypeCache: new Map(),
     pendingLateImportShift: null,
     protoGlobals: new Map(),

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1295,6 +1295,22 @@ export interface CodegenContext {
   shapeIdByStructName: Map<string, number>;
   /** (#2009) shape-id → ordered field-name CSV, for the host name export. */
   shapeNameCsvById: string[];
+  /**
+   * (#2009 R3b) anon object-literal struct name → its field names in JS
+   * INSERTION order (the order keys were first introduced while evaluating the
+   * literal source: named props left-to-right, spreads contributing each
+   * source's own keys in order, FIRST occurrence wins). The struct's slot order
+   * comes from `ts.Type.getProperties()`, which for spread-result types is
+   * last-spread-first and does NOT match JS enumeration order. Host enumeration
+   * (`Object.keys`/`JSON.stringify`/`for-in`) is driven by the field-name CSV in
+   * `__struct_field_names`, read BY NAME (slot-independent), so reordering the
+   * CSV by this list restores spec enumeration order without touching slots,
+   * getters, dedup, or the `$shape` field. First literal of a deduped canonical
+   * type wins (deterministic by compile order). Empty when a struct's checker
+   * order already matches insertion order (plain literals), so the reorder is a
+   * no-op for the common case.
+   */
+  structInsertionOrder: Map<string, string[]>;
   /** Pending late import shift state */
   pendingLateImportShift: { importsBefore: number } | null;
   /** Map from class name → global index of the prototype externref singleton */

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -2438,6 +2438,40 @@ function buildSetterStore(
  * operand patch is uniform across the legacy AND IR backends (it walks emitted
  * `Instr` streams, not a specific construction path).
  */
+
+/**
+ * (#2009 R3b) Permute a struct's slot-order field names into JS INSERTION order
+ * for the host name export, using the per-literal order recorded in
+ * `ctx.structInsertionOrder` (see its doc). MEMBERSHIP is preserved exactly:
+ * the returned list is `slotNames` reordered, never added to or filtered — every
+ * name still resolves to its `__sget_<name>` getter. Names present in the
+ * insertion-order list come first in that order; any slot name not in the list
+ * (defensive — should not happen for a literal-derived struct) keeps its
+ * original relative position at the end. No recorded order ⇒ `slotNames`
+ * unchanged (plain literals, IR-fresh structs, named classes).
+ */
+function orderNamesByInsertion(ctx: CodegenContext, structName: string, slotNames: string[]): string[] {
+  const order = ctx.structInsertionOrder.get(structName);
+  if (!order || order.length === 0) return slotNames;
+  const slotSet = new Set(slotNames);
+  const ordered: string[] = [];
+  const placed = new Set<string>();
+  for (const name of order) {
+    if (slotSet.has(name) && !placed.has(name)) {
+      ordered.push(name);
+      placed.add(name);
+    }
+  }
+  // Append any slot name the insertion list did not cover, in slot order.
+  for (const name of slotNames) {
+    if (!placed.has(name)) {
+      ordered.push(name);
+      placed.add(name);
+    }
+  }
+  return ordered;
+}
+
 function resolveSameShapeFieldNameCollisions(ctx: CodegenContext): void {
   // Host enumeration is JS-only; standalone/WASI has no host name export.
   if (ctx.nativeStrings) return;
@@ -2470,13 +2504,19 @@ function resolveSameShapeFieldNameCollisions(ctx: CodegenContext): void {
       typeParts.push(typeKindKey(f.type));
     }
     if (names.length === 0) continue; // no host-enumerable fields
+    // (#2009 R3b) The structural-shape key (`typeParts`) is built from slot order
+    // so same-shape grouping is unaffected, but the enumerated `names` are
+    // permuted to JS insertion order — so the shape-id CSV the host reads
+    // reflects spec enumeration order, and two colliding structs with the SAME
+    // insertion order share a shape-id.
+    const orderedNames = orderNamesByInsertion(ctx, structName, names);
     const shapeKey = typeParts.join("|");
     let group = byShape.get(shapeKey);
     if (!group) {
       group = [];
       byShape.set(shapeKey, group);
     }
-    group.push({ structName, typeIdx, names });
+    group.push({ structName, typeIdx, names: orderedNames });
   }
 
   // A group "collides" iff it contains 2+ DISTINCT field-name lists. (Two
@@ -2613,7 +2653,10 @@ function emitStructFieldNamesExport(
       if (field.name.startsWith("$") || field.name.startsWith("__")) continue;
       names.push(field.name);
     }
-    if (names.length > 0) legacyEntries.push({ typeIdx, names });
+    // (#2009 R3b) Permute to JS insertion order for spec-correct host
+    // enumeration; no-op when no literal-derived order was recorded.
+    const orderedNames = orderNamesByInsertion(ctx, structName, names);
+    if (orderedNames.length > 0) legacyEntries.push({ typeIdx, names: orderedNames });
   }
 
   if (legacyEntries.length === 0 && shapeEntries.length === 0) return;

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -1612,6 +1612,44 @@ export function compileObjectLiteralForStruct(
     }
   }
 
+  // (#2009 R3b) Record this literal's field names in JS INSERTION order so the
+  // host name export (`__struct_field_names`) can enumerate keys in spec order.
+  // The struct's slot order comes from `ts.Type.getProperties()`, which is
+  // last-spread-first for spread-result types and therefore does NOT match the
+  // §13.2.5 PropertyDefinitionEvaluation order. Walk `expr.properties` in source
+  // order: a named/shorthand/method/accessor prop contributes its key; a spread
+  // contributes its source's own field names in order. First occurrence fixes a
+  // key's position (a later duplicate or override keeps the earlier slot, e.g.
+  // `{...{a:1},...{b:2},...{a:3}}` → `a,b`). The first literal of a deduped
+  // canonical type wins, so the result is deterministic by compile order and a
+  // no-op for plain literals whose checker order already matches insertion order.
+  if (!ctx.structInsertionOrder.has(typeName)) {
+    const spreadByPropIndex = new Map<number, { name: string }[]>();
+    for (const src of spreadSources) spreadByPropIndex.set(src.propIndex, src.srcFields);
+    const insertionOrder: string[] = [];
+    const seen = new Set<string>();
+    const pushName = (n: string | undefined): void => {
+      if (n === undefined || n.startsWith("$") || n.startsWith("__")) return;
+      if (seen.has(n)) return;
+      seen.add(n);
+      insertionOrder.push(n);
+    };
+    for (let pi = 0; pi < expr.properties.length; pi++) {
+      const prop = expr.properties[pi]!;
+      if (ts.isSpreadAssignment(prop)) {
+        const srcFields = spreadByPropIndex.get(pi);
+        if (srcFields) for (const f of srcFields) pushName(f.name);
+        continue;
+      }
+      if (ts.isMethodDeclaration(prop) || ts.isGetAccessorDeclaration(prop) || ts.isSetAccessorDeclaration(prop)) {
+        if (prop.name) pushName(resolveAccessorPropName(ctx, prop.name));
+        continue;
+      }
+      pushName(resolvePropertyNameText(ctx, prop));
+    }
+    if (insertionOrder.length > 0) ctx.structInsertionOrder.set(typeName, insertionOrder);
+  }
+
   // (#1557) Per-literal method funcIdx overrides. When struct dedup collapses
   // multiple object literals that share a field shape but have methods with
   // different signatures (e.g. `{ validate(value) {} }` and `{ validate() {} }`

--- a/tests/issue-2009.test.ts
+++ b/tests/issue-2009.test.ts
@@ -202,12 +202,85 @@ describe("#2009 R3 — spread-source value resolution + source-order override", 
       `),
     ).toBe("5|1");
   });
+});
 
-  // R3b (separate follow-up): key INSERTION ORDER for spread-result structs.
-  // `{ ...{x:1,y:2}, ...{y:3,z:4} }` should stringify as `{"x":1,"y":3,"z":4}`
-  // but the spread-result anon struct's fields are ordered last-spread-first
-  // (`y,z,x`) by the TypeChecker, so JSON/Object.keys report `{"y":3,"z":4,"x":1}`.
-  // Pre-existing on main (affects named-source spreads too); fixing it needs the
-  // spread-result struct's field registration to follow JS insertion order.
-  it.todo("spread-result keys follow JS insertion order (R3b — struct field-order)");
+/**
+ * #2009 R3b — spread-result key INSERTION ORDER.
+ *
+ * `{ ...{x:1,y:2}, ...{y:3,z:4} }` must enumerate `x,y,z` (each key fixed at its
+ * FIRST occurrence in §13.2.5 PropertyDefinitionEvaluation order). The anon
+ * struct's slot order comes from `ts.Type.getProperties()`, which is
+ * last-spread-first (`y,z,x`), so JSON/Object.keys/for-in reported `y,z,x` and
+ * the named prop `a` landed last. Fix (lowest blast radius): record the literal's
+ * insertion-order name list at construction and permute the host name-export CSV
+ * by it — slots, getters, dedup, and `$shape` are untouched, and since host
+ * enumeration reads the CSV BY NAME the value mapping is unaffected.
+ */
+describe("#2009 R3b — spread-result key insertion order", () => {
+  const stringifyCases: { name: string; lit: string; expected: string }[] = [
+    { name: "two inline spreads", lit: `{ ...{ x: 1, y: 2 }, ...{ y: 3, z: 4 } }`, expected: '{"x":1,"y":3,"z":4}' },
+    {
+      name: "leading named prop then spreads",
+      lit: `{ a: 0, ...{ x: 1, y: 2 }, ...{ y: 3, z: 4 } }`,
+      expected: '{"a":0,"x":1,"y":3,"z":4}',
+    },
+    {
+      name: "trailing named override keeps first slot",
+      lit: `{ ...{ x: 1, y: 2 }, ...{ y: 3, z: 4 }, x: 9 }`,
+      expected: '{"x":9,"y":3,"z":4}',
+    },
+    {
+      name: "re-occurring key keeps first position",
+      lit: `{ ...{ a: 1 }, ...{ b: 2 }, ...{ a: 3 } }`,
+      expected: '{"a":3,"b":2}',
+    },
+    {
+      name: "named-source spreads (variables)",
+      lit: `(() => { const s1 = { x: 1, y: 2 }; const s2 = { y: 3, z: 4 }; return { ...s1, ...s2 }; })()`,
+      expected: '{"x":1,"y":3,"z":4}',
+    },
+    {
+      name: "named props interleaved with spread",
+      lit: `{ p: 0, ...{ q: 1 }, r: 2, ...{ q: 5, s: 6 } }`,
+      expected: '{"p":0,"q":5,"r":2,"s":6}',
+    },
+  ];
+
+  for (const { name, lit, expected } of stringifyCases) {
+    it(`JSON.stringify enumerates insertion order: ${name}`, async () => {
+      expect(await runWasm(`export function test(): string { const o: any = ${lit}; return JSON.stringify(o); }`)).toBe(
+        expected,
+      );
+    });
+  }
+
+  it("Object.keys via binding follows insertion order", async () => {
+    expect(
+      await runWasm(`
+        export function test(): string {
+          const o: any = { ...{ x: 1, y: 2 }, ...{ y: 3, z: 4 } };
+          return Object.keys(o).join(",");
+        }
+      `),
+    ).toBe("x,y,z");
+  });
+
+  it("for-in iterates insertion order", async () => {
+    expect(
+      await runWasm(`
+        export function test(): string {
+          const o: any = { ...{ x: 1, y: 2 }, ...{ y: 3, z: 4 } };
+          let s = "";
+          for (const k in o) s += k;
+          return s;
+        }
+      `),
+    ).toBe("xyz");
+  });
+
+  it("plain (non-spread) literal order is unchanged (no regression)", async () => {
+    expect(await runWasm(`export function test(): string { return JSON.stringify({ p: 1, q: 2, r: 3 }); }`)).toBe(
+      '{"p":1,"q":2,"r":3}',
+    );
+  });
 });


### PR DESCRIPTION
## #2009 R3b — spread-result key insertion order

`{ ...{x:1,y:2}, ...{y:3,z:4} }` enumerated keys last-spread-first
(`{"y":3,"z":4,"x":1}`) instead of Node's `{"x":1,"y":3,"z":4}`.
**Values were already correct (PR-2); only host key ENUMERATION order was wrong.**

### Root cause
The anon struct's field SLOT order comes from `ts.Type.getProperties()`, which
is last-spread-first for spread-result types. The `__struct_field_names` CSV
(what `Object.keys`/`JSON.stringify`/`for-in` read) was built from that slot
order, so it never matched §13.2.5 PropertyDefinitionEvaluation order.

### Fix (lowest blast radius)
`_structToPlainObject` reads the CSV **by name** (`__sget_<name>`,
slot-independent), so reordering **only the CSV** restores spec enumeration order
— slots, getters, dedup, and the `$shape` field are byte-identical.

- `ctx.structInsertionOrder` — per anon-literal struct, field names in JS
  insertion order (walk `expr.properties` source-order; spreads contribute their
  source's own keys in order; first-occurrence wins). First literal of a deduped
  canonical type wins → deterministic by compile order.
- `orderNamesByInsertion()` — pure permute of slot names into insertion order;
  **membership preserved exactly** (every name still resolves to its getter).
- Applied at both CSV-build sites in `index.ts`: legacy `typeIdx` arm AND the
  colliding-`$shape` arm (structural grouping key stays slot-order).

### Tests / validation
- `tests/issue-2009.test.ts` R3b block (JSON.stringify inline + named-source
  two-spread, leading/trailing named interleave, re-occurring-key first-position,
  Object.keys + for-in via binding, plain-literal control). All 27 pass.
- `tsc --noEmit` clean. Object/spread/json/destructuring equiv suites unchanged
  vs main (4 `object-mutability`/`getter-setter` FAILs verified pre-existing via
  stash-and-rerun).

### Known residual (documented, deterministic)
Two literals with the same name-SET but different insertion ORDER that dedup to
one canonical struct type take the first-recorded order (VALUES always correct).
Inline `Object.keys({...spread})` direct-argument form still traps — a SEPARATE
pre-existing inline-spread-argument lowering bug; bind to a variable first.

Closes #2009 (R3b was the last open slice; R1/R2/R3 landed in PR-1/1b/2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)