### PR TITLE
docs(#2375): re-ground vs main after #2026 — value-read glue still 0-flip, route to architect

### DIFF
--- a/plan/issues/2375-typedarray-nativeproto-value-read-init-trap.md
+++ b/plan/issues/2375-typedarray-nativeproto-value-read-init-trap.md
@@ -17,6 +17,59 @@ related: [2374, 2376, 2377, 2378, 2193, 2175, 1907, 1888, 2026]
 origin: "2026-06-19 — measure-first probe while extending #2374 value-read glue to the TypedArray family; root-caused 2026-06-19 spec-first deep-dive"
 ---
 
+## RE-GROUND vs current main 218375d60 (2026-06-19, after #2026 classes-as-first-class-values landed)
+
+The #2026 substrate (uniform constructor ABI / classes as first-class values)
+**did move the needle on the init-trap, but NOT on the conformance gate**. Wiring
+the full TypedArray + ArrayBuffer/SharedArrayBuffer/DataView `$NativeProto`
+value-read glue and re-measuring base-vs-patched on 400 TypedArray/DataView/
+ArrayBuffer prototype tests (`--target standalone`):
+
+| transition | count | meaning |
+|---|---|---|
+| pass → CE / pass → fail (regressions) | **0** | glue is clean, no regressions |
+| CE → **pass** | **0** | **zero real conformance wins** |
+| CE → fail / CE → runtime-exception | ~129 | CE removed, but test now FAILS at runtime |
+| CE → CE (still) | 26 | reflective member-body `.call` path, untouched |
+
+**Substrate effect (the one real change):** the pre-#2026 *instantiate-trap*
+(`wasm exception during module init`, from the unsatisfiable `[Float64Array,…]`
+host-import reflection in `testTypedArray.js` module scope) is GONE — those files
+now compile and run. The `forEach/*` harness cluster flipped CE→pass-compile.
+
+**But the conformance gate is unchanged:** the value-read glue alone flips **0
+tests to pass**. It only converts a clean, honest `compile_error` ("…value read
+is not supported") into a runtime `fail`. Even the 37 CE-base files that read a
+*static* concrete-view proto (`Int8Array.prototype.<m>`, no harness var) all land
+at fail/CE — never pass — because every such test then either (a) invokes the
+member (`.at()`, `byteLength`/`byteOffset` getters) whose native body isn't wired,
+or (b) does descriptor reflection (`verifyProperty(TypedArray.prototype,…)`) on
+the dynamically-obtained `%TypedArray%` proto. 118/155 CE-base files reach the
+proto via `Object.getPrototypeOf(Int8Array)` (the harness `TypedArray` var) — a
+**dynamic runtime** path the static value-read glue does not satisfy.
+
+**Decision: do NOT ship the value-read-only glue.** It is net-zero-or-negative
+(0 pass, CE→fail is *less* honest than CE). Confirmed the issue's original
+"flips 0 and just unmasks the trap" classification — only now it unmasks to
+`fail` instead of an init-trap. The glue itself is correct/clean and tsc-green;
+it is staged in this investigation only, not committed.
+
+### What IS now architect/runtime-scale (the real remaining gate)
+1. **Member bodies** for `%TypedArray%.prototype.<method>` (`at`, `map`, `slice`,
+   the index getters, `byteLength`/`byteOffset`/`length` accessor getters) as
+   native closures, so a reflected proto member is callable — same shape as the
+   #2374/#2377 *member-body* (PR-C) follow-ons, but over the live view receiver.
+2. **Dynamic `Object.getPrototypeOf(<builtin ctor>)` → working `%TypedArray%`
+   proto object** whose members resolve at runtime (not just a static
+   `Int8Array.prototype` identifier read). This is the harness's actual reflection
+   path and is the dominant gate (118/155 files).
+
+Route to architect: spec (1)+(2) as the TypedArray member-reflection runtime
+slice. The value-read object scaffold is ready to fold in once those land.
+Keep `status: blocked`, `needs_role: architect`.
+
+---
+
 ## PINNED ROOT CAUSE (2026-06-19 spec-first deep-dive — corrects the original hypothesis)
 
 The original hypothesis below ("the `$NativeProto` materialization for a


### PR DESCRIPTION
## Summary

Re-grounded #2375 (TypedArray/ArrayBuffer/DataView.prototype value-read cluster) against current main (218375d60) now that #2026 (classes as first-class values / uniform constructor ABI) landed — the substrate #2375 was waiting on.

## Measured result (base vs patched, 400 standalone tests)

Staged the full `$NativeProto` value-read glue for the TypedArray family + ArrayBuffer/SharedArrayBuffer/DataView and diffed per-file:

| transition | count |
|---|---|
| regressions (pass→CE / pass→fail) | **0** |
| **CE → pass** | **0** |
| CE → fail / runtime-exception | ~129 |
| CE → CE (still) | 26 |

- **#2026 DID clear the pre-existing instantiate-trap** — the masked `wasm exception during module init` is gone; the `forEach/*` harness cluster now compiles. That part of the original root cause is resolved.
- **The conformance gate is unchanged:** value-read glue alone flips **0 tests to pass**. It only converts a clean `compile_error` into a runtime `fail`. Even the 37 CE-base files that read a *static* concrete-view proto never reach pass.
- 118/155 CE-base files reach the proto via `Object.getPrototypeOf(Int8Array)` — a dynamic runtime path the static value-read glue does not satisfy.

## Decision

**Do NOT ship the value-read-only glue** (net-zero/negative — CE→fail is less honest than CE). The staged glue is correct + tsc-green but intentionally **not committed**. Routed to architect with the real remaining slice (member-body native closures + dynamic `Object.getPrototypeOf(<builtin>)` → working `%TypedArray%` proto) spec'd in the issue file.

Doc-only change. No source/test files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)