### PR TITLE
fix(#2505): standalone any[]/boxed-any join() & toString() invalid Wasm

### DIFF
--- a/scripts/coercion-sites-baseline.json
+++ b/scripts/coercion-sites-baseline.json
@@ -1,5 +1,5 @@
 {
-  "codegen/array-methods.ts": 19,
+  "codegen/array-methods.ts": 20,
   "codegen/async-scheduler.ts": 3,
   "codegen/binary-ops.ts": 37,
   "codegen/closed-method-dispatch.ts": 1,

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -4903,6 +4903,33 @@ function compileArrayJoinNative(
     }
   }
 
+  // #2505 — boxed-any element (`any[]`): each element is a generic boxed value
+  // (externref/anyref), stringified through `__extern_toString` (the same path
+  // `String(any)` uses) in the per-element fold below. Resolve the import index
+  // here, BEFORE the fold body is built, so the `call` baked into the repeated
+  // `elemToStr` sequence has a stable funcIdx (a late `ensureLateImport` mid-fold
+  // would shift indices under the already-emitted prelude). The shift is flushed
+  // against `fctx.body` before the fold runs.
+  const elemIsBoxedAny = elemType.kind === "externref" || elemType.kind === "anyref";
+  let externToStrIdx: number | undefined;
+  let externIsUndefIdx: number | undefined;
+  let boxedAnyElemTmp: number | undefined;
+  if (elemIsBoxedAny) {
+    externToStrIdx = ensureLateImport(ctx, "__extern_toString", [{ kind: "externref" }], [{ kind: "externref" }]);
+    // §23.1.3.18 step 7d: a `null`/`undefined` array element joins as the empty
+    // string (NOT "null"/"undefined" the way String(null) would). `null` is the
+    // structural `ref.null.extern`; `undefined` is a boxed sentinel externref —
+    // detect it with the runtime predicate. Resolve both imports up-front for
+    // funcIdx stability before the fold body is built.
+    externIsUndefIdx = ensureLateImport(ctx, "__extern_is_undefined", [{ kind: "externref" }], [{ kind: "i32" }]);
+    if (externToStrIdx === undefined || externIsUndefIdx === undefined) {
+      reportError(ctx, callExpr, "join of an any[] requires __extern_toString / __extern_is_undefined");
+      return null;
+    }
+    flushLateImportShifts(ctx, fctx);
+    boxedAnyElemTmp = allocLocal(fctx, `__njoin_elem_${fctx.locals.length}`, { kind: "externref" });
+  }
+
   const vecTmp = allocLocal(fctx, `__njoin_vec_${fctx.locals.length}`, { kind: "ref_null", typeIdx: vecTypeIdx });
   const dataTmp = allocLocal(fctx, `__njoin_data_${fctx.locals.length}`, { kind: "ref_null", typeIdx: arrTypeIdx });
   const foldLocals = allocJoinFoldLocals(fctx, repr, "njoin");
@@ -4962,6 +4989,46 @@ function compileArrayJoinNative(
     // number_toString returns the native string boxed as externref.
     elemToStr.push({ op: "any.convert_extern" } as Instr);
     elemToStr.push({ op: "ref.cast", typeIdx: anyStrTypeIdx } as Instr);
+  } else if (
+    elemIsBoxedAny &&
+    externToStrIdx !== undefined &&
+    externIsUndefIdx !== undefined &&
+    boxedAnyElemTmp !== undefined
+  ) {
+    // #2505 — boxed-any element (`any[]`): the element is a generic boxed value
+    // (externref/anyref), NOT a `(ref null $NativeString)`. `ref.as_non_null`
+    // would leave it typed externref/anyref, which can't `local.set` into the
+    // `(ref $AnyString)` fold result local — the invalid-Wasm `local.set[0]
+    // expected (ref null $AnyString)` defect.
+    //
+    // Spec §23.1.3.18 step 7d: a `null`/`undefined` element joins as the empty
+    // string. Otherwise route the element through `__extern_toString` (externref
+    // → externref), the SAME path `String(any)` uses — in standalone it is the
+    // native object-runtime ToString that correctly recovers a boxed number/
+    // boolean/string element (a bare `__any_to_string` over `any.convert_extern`
+    // misses the host-boxed-number externref shape and mis-renders `1` as
+    // "[object Object]"). Then bring the native-string externref back to
+    // `(ref $AnyString)` for the concat fold — mirroring the separator coercion.
+    if (elemType.kind === "anyref") {
+      elemToStr.push({ op: "extern.convert_any" } as Instr);
+    }
+    // tee element → temp; nullish? (ref.is_null OR __extern_is_undefined) → ""
+    elemToStr.push({ op: "local.tee", index: boxedAnyElemTmp } as Instr);
+    elemToStr.push({ op: "ref.is_null" } as Instr);
+    elemToStr.push({ op: "local.get", index: boxedAnyElemTmp } as Instr);
+    elemToStr.push({ op: "call", funcIdx: externIsUndefIdx } as Instr);
+    elemToStr.push({ op: "i32.or" } as Instr);
+    elemToStr.push({
+      op: "if",
+      blockType: { kind: "val", type: nativeStringType(ctx) },
+      then: nativeStringLiteralInstrs(ctx, ""),
+      else: [
+        { op: "local.get", index: boxedAnyElemTmp } as Instr,
+        { op: "call", funcIdx: externToStrIdx } as Instr,
+        { op: "any.convert_extern" } as Instr,
+        { op: "ref.cast", typeIdx: anyStrTypeIdx } as Instr,
+      ],
+    } as Instr);
   } else {
     // String element: a (ref null $NativeString) — non-null cast up to $AnyString.
     elemToStr.push({ op: "ref.as_non_null" } as Instr);

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -6654,11 +6654,25 @@ function compileArrayFind(
     "truthy",
   );
 
-  // Result local -- NaN (not found) or element value
-  const findResType: ValType = ctx.fast ? elemType : { kind: "f64" };
+  // Result local -- the not-found sentinel (`undefined`) or the element value.
+  // #2506 — a boxed-any element (`any[]`) is an externref/anyref/ref, NOT a
+  // numeric f64. The standalone (`!ctx.fast`) lane defaulted the result slot to
+  // f64 and `local.set` an externref element into it → invalid Wasm
+  // (`local.set[0] expected type f64, found ... externref`). For a ref-typed
+  // element keep the result slot as the element type and use `ref.null.extern`
+  // (the `undefined` sentinel) for not-found; numeric elements keep the f64/NaN
+  // path. number[]/string[]/boolean[] are unaffected.
+  const elemIsRef =
+    elemType.kind === "externref" ||
+    elemType.kind === "anyref" ||
+    elemType.kind === "ref" ||
+    elemType.kind === "ref_null";
+  const findResType: ValType = ctx.fast ? elemType : elemIsRef ? { kind: "externref" } : { kind: "f64" };
   const findResTmp = allocLocal(fctx, `__arr_find_res_${fctx.locals.length}`, findResType);
   if (ctx.fast) {
     fctx.body.push({ op: "i32.const", value: 0 });
+  } else if (elemIsRef) {
+    fctx.body.push({ op: "ref.null.extern" } as Instr); // not found → `undefined`
   } else {
     fctx.body.push({ op: "f64.const", value: 0 });
     fctx.body.push({ op: "f64.const", value: 0 });
@@ -6680,7 +6694,8 @@ function compileArrayFind(
       blockType: { kind: "empty" },
       then: [
         { op: "local.get", index: elemTmpLocal } as Instr,
-        ...(!ctx.fast && elemType.kind === "i32" ? [{ op: "f64.convert_i32_s" } as Instr] : []),
+        ...(!ctx.fast && !elemIsRef && elemType.kind === "i32" ? [{ op: "f64.convert_i32_s" } as Instr] : []),
+        ...(!ctx.fast && elemIsRef && elemType.kind !== "externref" ? [{ op: "extern.convert_any" } as Instr] : []),
         { op: "local.set", index: findResTmp } as Instr,
         { op: "br", depth: 2 } as Instr,
       ],
@@ -6692,7 +6707,7 @@ function compileArrayFind(
   emitArrayLoop(fctx, loopBody);
 
   fctx.body.push({ op: "local.get", index: findResTmp });
-  return ctx.fast ? elemType : { kind: "f64" };
+  return ctx.fast ? elemType : elemIsRef ? { kind: "externref" } : { kind: "f64" };
 }
 
 /**
@@ -6845,10 +6860,20 @@ function compileArrayFindLast(
     "truthy",
   );
 
-  const findResType: ValType = ctx.fast ? elemType : { kind: "f64" };
+  // #2506 — see compileArrayFind: a boxed-any (`any[]`) element is a ref, not a
+  // numeric f64; keep the result slot as an externref with a `ref.null.extern`
+  // not-found sentinel rather than mis-typing it f64 (invalid Wasm).
+  const elemIsRef =
+    elemType.kind === "externref" ||
+    elemType.kind === "anyref" ||
+    elemType.kind === "ref" ||
+    elemType.kind === "ref_null";
+  const findResType: ValType = ctx.fast ? elemType : elemIsRef ? { kind: "externref" } : { kind: "f64" };
   const findResTmp = allocLocal(fctx, `__arr_findLast_res_${fctx.locals.length}`, findResType);
   if (ctx.fast) {
     fctx.body.push({ op: "i32.const", value: 0 });
+  } else if (elemIsRef) {
+    fctx.body.push({ op: "ref.null.extern" } as Instr); // not found → `undefined`
   } else {
     fctx.body.push({ op: "f64.const", value: 0 });
     fctx.body.push({ op: "f64.const", value: 0 });
@@ -6870,7 +6895,8 @@ function compileArrayFindLast(
       blockType: { kind: "empty" },
       then: [
         { op: "local.get", index: elemTmpLocal } as Instr,
-        ...(!ctx.fast && elemType.kind === "i32" ? [{ op: "f64.convert_i32_s" } as Instr] : []),
+        ...(!ctx.fast && !elemIsRef && elemType.kind === "i32" ? [{ op: "f64.convert_i32_s" } as Instr] : []),
+        ...(!ctx.fast && elemIsRef && elemType.kind !== "externref" ? [{ op: "extern.convert_any" } as Instr] : []),
         { op: "local.set", index: findResTmp } as Instr,
         { op: "br", depth: 2 } as Instr,
       ],
@@ -6882,7 +6908,7 @@ function compileArrayFindLast(
   emitArrayLoop(fctx, loopBody);
 
   fctx.body.push({ op: "local.get", index: findResTmp });
-  return ctx.fast ? elemType : { kind: "f64" };
+  return ctx.fast ? elemType : elemIsRef ? { kind: "externref" } : { kind: "f64" };
 }
 
 /**

--- a/tests/issue-2505.test.ts
+++ b/tests/issue-2505.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2505 — standalone `any[]` / boxed-any element `Array.prototype.join` &
+ * `toString`.
+ *
+ * A boxed-any element array (`any[]`) stores each element as a generic boxed
+ * value (externref), NOT a `(ref null $NativeString)`. The native join's
+ * string-element arm took a bare `ref.as_non_null`, which left the value typed
+ * externref and could not `local.set` into the `(ref $AnyString)` fold result
+ * local — producing **invalid Wasm** (`local.set[0] expected (ref null
+ * $AnyString), found ...`). `number[]`/`string[]`/`boolean[]` were unaffected.
+ *
+ * Fix: route a boxed-any element through `__extern_toString` (the same ToString
+ * path `String(any)` uses), with the §23.1.3.18 step-7d `null`/`undefined` →
+ * empty-string guard.
+ *
+ * These assert: valid Wasm (the regression) + spec-correct joined value.
+ */
+async function joinResult(arrayLiteral: string, sep: string): Promise<string> {
+  const src = `
+const A: any[] = ${arrayLiteral};
+const R = A.join(${JSON.stringify(sep)});
+export function len(): number { return R.length; }
+export function ch(i: number): number { return R.charCodeAt(i); }
+`;
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const ex = instance.exports as { len: () => number; ch: (i: number) => number };
+  let s = "";
+  for (let i = 0; i < ex.len(); i++) s += String.fromCharCode(ex.ch(i));
+  return s;
+}
+
+async function toStringResult(arrayLiteral: string): Promise<string> {
+  const src = `
+const A: any[] = ${arrayLiteral};
+const R = A.toString();
+export function len(): number { return R.length; }
+export function ch(i: number): number { return R.charCodeAt(i); }
+`;
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const ex = instance.exports as { len: () => number; ch: (i: number) => number };
+  let s = "";
+  for (let i = 0; i < ex.len(); i++) s += String.fromCharCode(ex.ch(i));
+  return s;
+}
+
+describe("#2505 — standalone any[] join / toString (valid Wasm + spec value)", () => {
+  it("mixed number/string/boolean elements join correctly", async () => {
+    expect(await joinResult(`[1, "x", true]`, ",")).toBe("1,x,true");
+  });
+
+  it("all-numeric any[] elements stringify (not [object Object])", async () => {
+    expect(await joinResult(`[1, 2, 3]`, ",")).toBe("1,2,3");
+  });
+
+  it("null / undefined elements join as empty string (§23.1.3.18 step 7d)", async () => {
+    expect(await joinResult(`[1, null, undefined, 2]`, ",")).toBe("1,,,2");
+  });
+
+  it("object elements stringify as [object Object]", async () => {
+    expect(await joinResult(`[1, {a:1}, "z"]`, ",")).toBe("1,[object Object],z");
+  });
+
+  it("honours an explicit multi-char separator", async () => {
+    expect(await joinResult(`[1, "b", 3]`, " - ")).toBe("1 - b - 3");
+  });
+
+  it("toString() delegates to join(',') for any[]", async () => {
+    expect(await toStringResult(`[1, "x", true]`)).toBe("1,x,true");
+  });
+});

--- a/tests/issue-2506.test.ts
+++ b/tests/issue-2506.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2506 — standalone `any[]` / boxed-any element `Array.prototype.find` &
+ * `findLast`.
+ *
+ * `find`/`findLast` return the matched *element*. The standalone (`!ctx.fast`)
+ * lane defaulted the result local to f64 and `local.set` the element into it —
+ * but a boxed-any (`any[]`) element is an externref, producing **invalid Wasm**
+ * (`local.set[0] expected type f64, found ... externref`). `findIndex`/
+ * `findLastIndex` (return i32) and `number[]`/`string[]` find were unaffected.
+ *
+ * Fix: for a ref-typed element keep the find result slot + return type as an
+ * externref, with `ref.null.extern` (the `undefined` sentinel) for not-found.
+ *
+ * These assert valid Wasm + the spec-correct found / not-found behaviour.
+ */
+async function runStandalone(source: string): Promise<number> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as Record<string, () => number>).run();
+}
+
+describe("#2506 — standalone any[] find / findLast (valid Wasm + spec value)", () => {
+  it("find returns the matched numeric element", async () => {
+    expect(
+      await runStandalone(
+        `export function run(): number { const a: any[] = [1,2,3]; const v = a.find(x => x === 2); return typeof v === "number" ? (v as number) : -99; }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("find returns undefined (not NaN/0) when no element matches", async () => {
+    expect(
+      await runStandalone(
+        `export function run(): number { const a: any[] = [1,2,3]; const v = a.find(x => x === 9); return v === undefined ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("find returns a matched string element", async () => {
+    expect(
+      await runStandalone(
+        `export function run(): number { const a: any[] = ["a","bb","ccc"]; const v = a.find(x => (x as string).length === 2); return typeof v === "string" ? (v as string).length : -1; }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("findLast returns the last matched element", async () => {
+    expect(
+      await runStandalone(
+        `export function run(): number { const a: any[] = [1,2,2,3]; const v = a.findLast(x => x === 2); return typeof v === "number" ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("number[] find is unaffected (control)", async () => {
+    expect(
+      await runStandalone(
+        `export function run(): number { const a: number[] = [1,2,3]; const v = a.find(x => x === 2); return v ?? 0; }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("findIndex over any[] is unaffected (control)", async () => {
+    expect(
+      await runStandalone(
+        `export function run(): number { const a: any[] = [1,2,3]; return a.findIndex(x => x === 2); }`,
+      ),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

`any[].join(sep)` and `any[].toString()` emitted **invalid Wasm** under `--target standalone` (`local.set[0] expected (ref null \$AnyString), found ...`), failing instantiation.

**Root cause:** a boxed-any element array stores each element as a generic boxed value (externref), not a `(ref null \$NativeString)`. `compileArrayJoinNative`'s string-element arm took a bare `ref.as_non_null`, leaving the value typed externref — which can't `local.set` into the `(ref \$AnyString)` fold result local. `number[]`/`string[]`/`boolean[]`/`new Array(N)` were unaffected (#2505-class divergence, join lane).

**Fix:** route a boxed-any element through `__extern_toString` (the same ToString path `String(any)` uses, which correctly recovers a boxed number/boolean/string element — a bare `__any_to_string` over `any.convert_extern` misses the host-boxed-number externref shape and mis-renders `1` as `[object Object]`), with the §23.1.3.18 step-7d `null`/`undefined` → empty-string guard. `Array.prototype.toString` delegates to join, so it's fixed by the same change.

## Verification

`tests/issue-2505.test.ts` (6 new) — valid Wasm + spec-correct values:
- mixed `[1,"x",true]` → `"1,x,true"`
- numeric `[1,2,3]` → `"1,2,3"` (not `[object Object]`)
- `[1,null,undefined,2]` → `"1,,,2"` (§23.1.3.18 step 7d)
- object `[1,{a:1},"z"]` → `"1,[object Object],z"`
- explicit separator; `toString()` delegation

Controls unchanged (number[]/string[]/boolean[]); existing #2074 join tests (12) still green; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)