### PR TITLE
fix(#2507): standalone any[].find/findLast return externref element, not f64

### DIFF
--- a/plan/issues/2507-standalone-anyarray-find-externref-result.md
+++ b/plan/issues/2507-standalone-anyarray-find-externref-result.md
@@ -1,0 +1,69 @@
+---
+id: 2507
+title: "standalone: any[].find()/findLast() emit invalid Wasm (externref element stored into f64 result slot)"
+status: done
+assignee: ttraenkler/sdev-arrayrep
+created: 2026-06-19
+updated: 2026-06-19
+completed: 2026-06-19
+priority: medium
+feasibility: medium
+task_type: bugfix
+area: codegen
+language_feature: arrays, array-methods
+goal: standalone-mode
+related: [2505, 2506, 2106]
+origin: "2026-06-19 sdev-arrayrep: array-rep scan after #2505/#2506"
+---
+
+# #2507 — standalone `any[].find()` / `findLast()` invalid Wasm
+
+## Problem (file-verified, current main, `--target standalone`)
+
+```ts
+const a: any[] = [1, 2, 3];
+a.find((x: any) => (x as number) > 1);  // INVALID Wasm
+```
+
+```
+local.set[0] expected type f64, found local.get of type externref
+```
+
+`findIndex` / `findLastIndex` are VALID (they return an index, not the element);
+`number[].find` is VALID. The defect is specific to a **boxed-any (`externref`)
+element array** (`any[]`, `new Array(N)`) under `find` / `findLast`.
+
+## Root cause
+
+`compileArrayFind` / `compileArrayFindLast` (`src/codegen/array-methods.ts`)
+return the matched **element**. In non-fast (standalone) mode the result local
+was hard-typed `{ kind: "f64" }` with a NaN "not found" sentinel — fine for a
+numeric element array, but for an `any[]` the element loaded by `array.get` is an
+`externref`, so `local.set`ting it into the f64 result local fails validation.
+The found-branch only converts `i32 → f64`, never handles an `externref` element.
+Same boxed-any element-rep family as #2505 (sort) / #2506 (join), here in the
+find result slot.
+
+## Fix
+
+In both `compileArrayFind` and `compileArrayFindLast`: when `elemType.kind ===
+"externref"`, keep the result type `externref` and use `ref.null.extern` (the
+`undefined` value) as the "not found" sentinel — which is the correct spec result
+(`Array.prototype.find` returns `undefined` when nothing matches). Numeric /
+boolean / string-ref element finds are unchanged (still f64 with NaN sentinel in
+non-fast mode, elemType in fast mode).
+
+## Acceptance criteria
+
+1. `any[].find(cb)` returns the matched element value; VALID standalone Wasm.
+2. `any[].find` with no match returns `undefined`; `any[].findLast(cb)` returns
+   the last match; string-element any[] find works.
+3. No regression: `number[].find`/`findLast`, `findIndex`/`findLastIndex`.
+
+## Resolution (sdev-arrayrep, 2026-06-19)
+
+Two-site fix per above. `tests/issue-2507-anyarray-find.test.ts` (7) verifies
+any[] find/findLast element return + undefined-on-no-match + string-element;
+number[] find/findLast + findIndex regressions green. `tsc` clean. (The
+`functional-array-methods.test.ts` harness failures are the pre-existing
+`__unbox_number` LinkError, task #67 — confirmed unrelated by stashing the fix.)

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -6587,10 +6587,20 @@ function compileArrayFind(
     "truthy",
   );
 
-  // Result local -- NaN (not found) or element value
-  const findResType: ValType = ctx.fast ? elemType : { kind: "f64" };
+  // #2507 — a boxed-any (`externref`) element array (`any[]`, `new Array(N)`)
+  // returns the matched ELEMENT, which is an `externref`, not an f64. The
+  // non-fast default below assumes a numeric element and types the result local
+  // f64 with a NaN "not found" sentinel — which then `local.set`s the externref
+  // element into an f64 local ("expected f64, found externref"). Keep the result
+  // as `externref` for an externref element (and use `ref.null.extern` — the
+  // `undefined` sentinel — for "not found", which is the spec result anyway).
+  const elemIsExternref = elemType.kind === "externref";
+  // Result local -- NaN/undefined (not found) or element value
+  const findResType: ValType = ctx.fast || elemIsExternref ? elemType : { kind: "f64" };
   const findResTmp = allocLocal(fctx, `__arr_find_res_${fctx.locals.length}`, findResType);
-  if (ctx.fast) {
+  if (elemIsExternref) {
+    fctx.body.push({ op: "ref.null.extern" });
+  } else if (ctx.fast) {
     fctx.body.push({ op: "i32.const", value: 0 });
   } else {
     fctx.body.push({ op: "f64.const", value: 0 });
@@ -6625,7 +6635,7 @@ function compileArrayFind(
   emitArrayLoop(fctx, loopBody);
 
   fctx.body.push({ op: "local.get", index: findResTmp });
-  return ctx.fast ? elemType : { kind: "f64" };
+  return ctx.fast || elemIsExternref ? elemType : { kind: "f64" };
 }
 
 /**
@@ -6778,9 +6788,15 @@ function compileArrayFindLast(
     "truthy",
   );
 
-  const findResType: ValType = ctx.fast ? elemType : { kind: "f64" };
+  // #2507 — boxed-any (`externref`) element array returns the externref element,
+  // not an f64; keep the result type externref with a `ref.null.extern`
+  // (undefined) "not found" sentinel. See compileArrayFind.
+  const elemIsExternref = elemType.kind === "externref";
+  const findResType: ValType = ctx.fast || elemIsExternref ? elemType : { kind: "f64" };
   const findResTmp = allocLocal(fctx, `__arr_findLast_res_${fctx.locals.length}`, findResType);
-  if (ctx.fast) {
+  if (elemIsExternref) {
+    fctx.body.push({ op: "ref.null.extern" });
+  } else if (ctx.fast) {
     fctx.body.push({ op: "i32.const", value: 0 });
   } else {
     fctx.body.push({ op: "f64.const", value: 0 });
@@ -6815,7 +6831,7 @@ function compileArrayFindLast(
   emitArrayLoop(fctx, loopBody);
 
   fctx.body.push({ op: "local.get", index: findResTmp });
-  return ctx.fast ? elemType : { kind: "f64" };
+  return ctx.fast || elemIsExternref ? elemType : { kind: "f64" };
 }
 
 /**

--- a/tests/issue-2507-anyarray-find.test.ts
+++ b/tests/issue-2507-anyarray-find.test.ts
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2507 — standalone `any[].find(cb)` / `any[].findLast(cb)` emitted invalid
+// Wasm: `local.set[0] expected type f64, found local.get of type externref`.
+// `find`/`findLast` return the matched ELEMENT; for a boxed-any (`externref`)
+// element array (`any[]`, `new Array(N)`) the element is an `externref`, but the
+// non-fast (standalone) result local was typed f64 with a NaN "not found"
+// sentinel — so the externref element `local.set` into the f64 local failed
+// validation. `findIndex`/`findLastIndex` (which return an index, not the
+// element) were unaffected.
+//
+// Fix (compileArrayFind / compileArrayFindLast): when the element kind is
+// `externref`, keep the result type `externref` with a `ref.null.extern`
+// (undefined) "not found" sentinel — which is also the correct spec result.
+// Numeric / boolean / string-ref element finds are unchanged.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runStandalone(source: string): Promise<number> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports as unknown as WebAssembly.Imports);
+  return (instance.exports as Record<string, () => number>).run();
+}
+
+const fn = (body: string) => `export function run(): number { ${body} }`;
+
+describe("#2507 — standalone any[] find/findLast return the externref element", () => {
+  it("any[].find returns the matched element value", async () => {
+    expect(
+      await runStandalone(fn(`const a: any[] = [1, 2, 3]; return a.find((x: any) => (x as number) > 1) as number;`)),
+    ).toBe(2);
+  });
+
+  it("any[].find returns undefined when nothing matches", async () => {
+    expect(
+      await runStandalone(
+        fn(
+          `const a: any[] = [1, 2, 3]; const r = a.find((x: any) => (x as number) > 9); return r === undefined ? -1 : (r as number);`,
+        ),
+      ),
+    ).toBe(-1);
+  });
+
+  it("any[].findLast returns the last matched element", async () => {
+    expect(
+      await runStandalone(
+        fn(`const a: any[] = [1, 2, 3]; return a.findLast((x: any) => (x as number) > 1) as number;`),
+      ),
+    ).toBe(3);
+  });
+
+  it("any[] with string elements: find by predicate returns the element", async () => {
+    expect(
+      await runStandalone(
+        fn(
+          `const a: any[] = ["aa", "bbb"]; const r = a.find((x: any) => (x as string).length > 2); return (r as string).length;`,
+        ),
+      ),
+    ).toBe(3);
+  });
+
+  // ── regressions: typed-element finds + the index variants are unchanged ──
+  it("number[].find still returns the element value", async () => {
+    expect(await runStandalone(fn(`const a = [1, 2, 3]; return a.find((x) => x > 1) as number;`))).toBe(2);
+  });
+
+  it("number[].findLast still returns the last matching element", async () => {
+    expect(await runStandalone(fn(`const a = [5, 2, 8]; return a.findLast((x) => x > 3) as number;`))).toBe(8);
+  });
+
+  it("any[].findIndex still returns the index (unaffected)", async () => {
+    expect(
+      await runStandalone(fn(`const a: any[] = [1, 2, 3]; return a.findIndex((x: any) => (x as number) > 1);`)),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2507 — standalone `any[].find()` / `findLast()` emitted invalid Wasm

```ts
const a: any[] = [1, 2, 3];
a.find((x: any) => (x as number) > 1);  // INVALID Wasm (standalone)
```

```
local.set[0] expected type f64, found local.get of type externref
```

`findIndex`/`findLastIndex` (return an index) and `number[].find` were VALID — the defect is specific to a **boxed-any (`externref`) element array** (`any[]`, `new Array(N)`).

### Root cause
`compileArrayFind` / `compileArrayFindLast` (`src/codegen/array-methods.ts`) return the matched **element**. In non-fast (standalone) mode the result local was hard-typed `{ kind: "f64" }` with a NaN "not found" sentinel — fine for a numeric element array, but an `any[]` element loaded by `array.get` is an `externref`, so `local.set`ting it into the f64 local failed validation. Same boxed-any element-rep family as #2505 (sort) / #2506 (join).

### Fix
In both functions: when `elemType.kind === "externref"`, keep the result type `externref` with a `ref.null.extern` (`undefined`) "not found" sentinel — which is the correct spec result (`find` returns `undefined` when nothing matches). Numeric / boolean / string-ref element finds are unchanged.

### Tests
`tests/issue-2507-anyarray-find.test.ts` (7): `any[]` find/findLast element return + undefined-on-no-match + string-element; `number[]` find/findLast + `findIndex` regressions green. `tsc` clean. (The `functional-array-methods.test.ts` harness failures are the pre-existing `__unbox_number` LinkError — task #67, confirmed unrelated by stashing the fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)