### PR TITLE
fix(#67): repair array test harnesses masking regression signal

### DIFF
--- a/tests/array-methods.test.ts
+++ b/tests/array-methods.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { compile } from "../src/index.js";
-import { buildStringConstants } from "../src/runtime.js";
+import { buildImports } from "../src/runtime.js";
 
 async function run(source: string, fn: string, args: unknown[] = []): Promise<unknown> {
   const result = await compile(source);
@@ -9,27 +9,12 @@ async function run(source: string, fn: string, args: unknown[] = []): Promise<un
       `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
     );
   }
-  const env: Record<string, Function> = {
-    console_log_number: () => {},
-    console_log_bool: () => {},
-    console_log_string: () => {},
-  };
-  // number_toString
-  env["number_toString"] = (v: number) => String(v);
-
-  const jsStringPolyfill = {
-    concat: (a: string, b: string) => a + b,
-    length: (s: string) => s.length,
-    equals: (a: string, b: string) => (a === b ? 1 : 0),
-    substring: (s: string, start: number, end: number) => s.substring(start, end),
-    charCodeAt: (s: string, i: number) => s.charCodeAt(i),
-  };
-
-  const { instance } = await WebAssembly.instantiate(result.binary, {
-    env,
-    "wasm:js-string": jsStringPolyfill,
-    string_constants: buildStringConstants(result.stringPool),
-  } as WebAssembly.Imports);
+  // Use the shared host-import builder so every runtime helper the binary
+  // declares (e.g. __unbox_number, __box_number) is supplied — a hand-rolled
+  // env masks regressions when codegen starts importing a new helper.
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
   return (instance.exports as any)[fn](...args);
 }
 
@@ -127,7 +112,7 @@ describe("array methods", () => {
       const src = `
         export function test(): number {
           let arr = [10, 20, 30];
-          return arr.pop();
+          return arr.pop()!;
         }
       `;
       expect(await run(src, "test")).toBe(30);
@@ -150,7 +135,7 @@ describe("array methods", () => {
       const src = `
         export function test(): number {
           let arr = [10, 20, 30];
-          return arr.shift();
+          return arr.shift()!;
         }
       `;
       expect(await run(src, "test")).toBe(10);

--- a/tests/array-prototype-methods.test.ts
+++ b/tests/array-prototype-methods.test.ts
@@ -1,5 +1,5 @@
 import { describe, it } from "vitest";
-import { assertEquivalent } from "./helpers.js";
+import { assertEquivalent } from "./equivalence/helpers.js";
 
 describe("array prototype methods", () => {
   it("indexOf returns correct index", async () => {


### PR DESCRIPTION
## Problem

The array test harnesses no longer instantiated, masking regression signal for all array work:

- `tests/array-methods.test.ts` hand-rolled a minimal `env` import object that was missing `__unbox_number` (added to array codegen recently) → all 22 cases failed with `LinkError: __unbox_number ... requires a callable`.
- `tests/array-prototype-methods.test.ts` imported `assertEquivalent` from a non-existent `./helpers.js` → suite failed to collect entirely.

`sdev-arrayrep` repeatedly tripped this when running array suites; it hid real array regressions.

## Fix

- Point `array-methods.test.ts` at the shared `buildImports(result.imports, ...)` builder (the same one `fast-arrays.test.ts` uses). It supplies every runtime helper the binary declares, so the harness cannot silently fall behind codegen again — this is the structural fix, not just adding the one missing import.
- Fix the import path in `array-prototype-methods.test.ts` to `./equivalence/helpers.js`.
- Un-masking surfaced two dormant test-source typos (`arr.pop()`/`arr.shift()` return `number | undefined` assigned to a `number` return); fixed with the standard `!` non-null-assertion idiom used elsewhere.

## Scope

Test-harness import wiring only — **no `src/` changes**. `functional-array-methods.test.ts` has a separate pre-existing compile error (unrelated `number | undefined` typecheck in its test bodies) and is intentionally left untouched.

## Verification

Both suites now pass: **35/35** (was 22 failed + 1 uncollectable suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)