### PR TITLE
fix(#2510): standalone tagged template with bound result emits valid Wasm

### DIFF
--- a/plan/issues/2510-standalone-tagged-template-bound-result-invalid-wasm.md
+++ b/plan/issues/2510-standalone-tagged-template-bound-result-invalid-wasm.md
@@ -1,0 +1,91 @@
+---
+id: 2510
+title: "standalone: tagged template with a bound result emits invalid Wasm (array.new_fixed externref vs struct.new $NativeString)"
+status: done
+assignee: ttraenkler/sdev-protoglue
+sprint: Backlog
+created: 2026-06-19
+updated: 2026-06-19
+completed: 2026-06-19
+priority: medium
+feasibility: easy
+reasoning_effort: high
+task_type: conformance
+area: codegen
+language_feature: template-literals, strings
+goal: standalone-mode
+related: [2190, 35, 1470]
+origin: "2026-06-19 — non-array invalid-Wasm harvest (task #74): tagged-template strings array mistypes native-string elements"
+---
+
+## Problem
+
+In `--target standalone` (native strings), a tagged template whose result is
+**bound** to a variable emits an **invalid Wasm module**:
+
+```ts
+function t(s: any, ...v: any[]) { return s[0]; }
+const r = t`a${1}b`;   // INVALID
+```
+
+```
+array.new_fixed[0] expected type externref, found struct.new of (ref $NativeString)
+```
+
+(The discarded expression-statement form `t\`a${1}b\`;` happened to dodge it; the
+bound / returned form surfaces it.)
+
+## Root cause
+
+`compileTaggedTemplateExpression` (`string-ops.ts`) builds the template object's
+cooked + raw strings arrays as **`externref`-element** vecs (`elemKind =
+"externref"`). It fills them by calling `compileStringLiteral` for each part. In
+native-strings mode `compileStringLiteral` materializes a `(ref $NativeString)`
+GC struct (`struct.new`), **not** an externref — so pushing that struct straight
+into the externref-typed `array.new_fixed` mistypes element 0 and the module
+fails validation.
+
+## Fix (contained — one element-type bridge)
+
+Bridge each native-string literal to externref before `array.new_fixed`, gated
+on native-strings mode (host-string mode already yields externref, so it's a
+no-op there):
+
+```ts
+const pushStringElem = (text: string): void => {
+  compileStringLiteral(ctx, fctx, text, expr);
+  if (ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0) {
+    fctx.body.push({ op: "extern.convert_any" } as Instr);
+  }
+};
+```
+
+Applied to both the raw and cooked array-build loops. `extern.convert_any`
+(per the project's ref→externref coercion convention) lifts the `(ref
+$NativeString)` to the array's `externref` element type.
+
+## Measured (standalone, upstream/main 73d6c037d)
+
+- `const r = t\`a${1}b\`;` (bound), `t\`a${1}b${2}c\``, no-substitution
+  `w\`one\``: all now emit VALID, JS-host-free modules (were invalid).
+- Structurally observable shape is correct: `strings.length` = 3 cooked parts,
+  rest-substitutions = 2, no-substitution = 1 part.
+- **GC target unaffected** (change gated on `nativeStrings`): gc tagged
+  templates still valid + correct (partsCount=3, subsCount=1).
+- Coercion-sites gate OK (`extern.convert_any` is not a tracked coercion
+  token); typecheck + prettier clean.
+
+## Out of scope (separate, pre-existing)
+
+Reading an element's string **content** back (`strings[0].length` →
+`strings[0]` recovered as empty) is the externref-boundary `$Array`/`$ObjVec`
+introspection gap (**#2190 / #35** family) — it returns `0` on the **gc target
+too**, so it is NOT a standalone regression and NOT this fix's concern. This
+fix only removes the hard invalid-Wasm wall, bringing standalone tagged
+templates to parity with gc.
+
+## Test
+
+`tests/issue-2510-tagged-template-standalone.test.ts` — 3 cases: multi-
+substitution parts-count, no-substitution single-part, and the headline bound-
+result shape; each asserts a valid, host-free, instantiable module.

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -776,9 +776,24 @@ export function compileTaggedTemplateExpression(
   // Use savedBody pattern so compileStringLiteral pushes into a separate array
   const savedBody = pushBody(fctx);
 
+  // The strings array element type is `externref` (line above). In nativeStrings
+  // mode `compileStringLiteral` materializes a `(ref $NativeString)` struct, NOT
+  // an externref — pushing that struct straight into the externref-typed
+  // `array.new_fixed` emits an invalid module ("array.new_fixed[0] expected
+  // externref, found struct.new of (ref $NativeString)"). Bridge each native
+  // string element to externref with `extern.convert_any` so the element type
+  // matches. (Host-string mode already returns externref, so this is a no-op
+  // there.) Surfaced by `const r = tag\`a${1}b\`;` under --target standalone.
+  const pushStringElem = (text: string): void => {
+    compileStringLiteral(ctx, fctx, text, expr);
+    if (ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0) {
+      fctx.body.push({ op: "extern.convert_any" } as Instr);
+    }
+  };
+
   // First: build the raw strings array as a regular vec
   for (const raw of rawParts) {
-    compileStringLiteral(ctx, fctx, raw, expr);
+    pushStringElem(raw);
   }
   fctx.body.push({
     op: "array.new_fixed",
@@ -801,7 +816,7 @@ export function compileTaggedTemplateExpression(
 
   // Second: build the cooked strings array
   for (const str of stringParts) {
-    compileStringLiteral(ctx, fctx, str, expr);
+    pushStringElem(str);
   }
   fctx.body.push({
     op: "array.new_fixed",

--- a/tests/issue-2510-tagged-template-standalone.test.ts
+++ b/tests/issue-2510-tagged-template-standalone.test.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2510 — a tagged template whose result is BOUND (`const r = tag`…`;`) emitted
+ * an INVALID module under `--target standalone`:
+ *
+ *   array.new_fixed[0] expected type externref, found struct.new of (ref $NativeString)
+ *
+ * The strings/raw arrays of the template object are typed `externref`, but in
+ * native-strings mode `compileStringLiteral` materializes a `(ref $NativeString)`
+ * struct, not an externref — pushing the struct straight into the externref
+ * `array.new_fixed` mistyped the element. `compileTaggedTemplateExpression` now
+ * bridges each native-string literal to externref (`extern.convert_any`) before
+ * `array.new_fixed`, matching the array element type. (Host-string mode already
+ * returns externref, so the bridge is a no-op there.)
+ *
+ * These assert the module is VALID + JS-host-free and that the structurally
+ * observable template shape is correct: `strings.length` (number of cooked
+ * parts) and the rest-substitutions count. (Reading an element's string CONTENT
+ * back via `strings[0].length` is a separate externref-boundary introspection
+ * gap, #2190/#35 family — it returns 0 on the gc target too — so it is out of
+ * scope here.)
+ */
+
+async function instantiateStandalone(source: string) {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  // No JS-host string imports must leak.
+  const labels = r.imports.map((i) => `${i.module}::${i.name}`);
+  expect(
+    labels.filter((l) => l.startsWith("wasm:js-string::") || /^env::__(unbox|extern)_/.test(l)),
+    `leaked host imports: ${labels.join(", ")}`,
+  ).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return instance.exports as Record<string, () => number>;
+}
+
+describe("#2510 — tagged template (bound result) is valid standalone Wasm", () => {
+  it("multi-substitution tagged template: valid module, correct cooked-parts count", async () => {
+    // Pre-fix: invalid module ("array.new_fixed[0] expected externref, found
+    // struct.new"). `t` reads strings.length — the structurally observable shape.
+    const ex = await instantiateStandalone(`
+      function t(s: any, ...v: any[]): number { return s.length; }
+      export function partsCount(): number { return t\`a\${1}b\${2}c\`; }
+    `);
+    // "a${1}b${2}c" → 3 cooked parts ("a","b","c").
+    expect(ex.partsCount!()).toBe(3);
+  });
+
+  it("no-substitution tagged template: valid module, single cooked part", async () => {
+    const ex = await instantiateStandalone(`
+      function w(s: any): number { return s.length; }
+      export function noSubst(): number { return w\`just one part\`; }
+    `);
+    expect(ex.noSubst!()).toBe(1);
+  });
+
+  it("bound tagged-template result instantiates (the headline `const r = tag\`…\`` shape)", async () => {
+    const ex = await instantiateStandalone(`
+      function t(s: any, ...v: any[]): number { return s.length; }
+      export function run(): number { const bound = t\`x\${1}y\`; return bound; }
+    `);
+    // "x${1}y" → 2 cooked parts ("x","y"). The point is it INSTANTIATES (valid).
+    expect(ex.run!()).toBe(2);
+  });
+});


### PR DESCRIPTION
## Problem

In `--target standalone` (native strings), a tagged template whose result is **bound** emits an **invalid Wasm module**:
```ts
function t(s: any, ...v: any[]) { return s[0]; }
const r = t`a${1}b`;   // INVALID: array.new_fixed[0] expected externref, found struct.new of (ref $NativeString)
```
(The discarded expression-statement form dodged it; the bound/returned form surfaces it.)

## Root cause

`compileTaggedTemplateExpression` builds the template object's cooked + raw strings arrays as **externref-element** vecs, filling them via `compileStringLiteral`. In native-strings mode `compileStringLiteral` materializes a `(ref $NativeString)` struct (not externref) — pushing that struct into the externref `array.new_fixed` mistyped element 0 → validation failure.

## Fix (contained — one element-type bridge)

Bridge each native-string literal to externref (`extern.convert_any`) before `array.new_fixed`, gated on `nativeStrings` (host-string mode already yields externref → no-op). Applied to both the raw and cooked build loops.

## Measured (standalone, upstream/main 73d6c037d)

- `const r = t`a${1}b``, `t`a${1}b${2}c``, no-substitution `w`one``: all now VALID, host-free modules (were invalid); `strings.length` (3 parts) / subs-count (2) / no-subst (1) correct.
- **GC target unaffected** (gated on nativeStrings): still valid + correct.
- coercion-sites gate OK; typecheck + prettier clean.

## Out of scope (separate, pre-existing)

Reading an element's string **content** back (`strings[0].length`) is the externref-boundary `$Array`/`$ObjVec` introspection gap (#2190/#35) — returns 0 on the **gc target too**, so not a standalone regression. This fix removes the hard invalid-Wasm wall, bringing standalone tagged templates to parity with gc.

## Test

`tests/issue-2510-tagged-template-standalone.test.ts` — 3 cases (multi-substitution parts-count, no-substitution single-part, headline bound-result), each asserting a valid host-free instantiable module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)