### PR TITLE
docs(#2188/#48): re-validate multi-level Error chain follow-up (already fixed; field-storage out of scope)

### DIFF
--- a/plan/issues/2188-standalone-sibling-error-subclass-instanceof-precision.md
+++ b/plan/issues/2188-standalone-sibling-error-subclass-instanceof-precision.md
@@ -151,3 +151,28 @@ which leaks `env.__get_undefined` in standalone until #1702's `nativeStrings`
 guard lands (a PRE-EXISTING 1-level leak too, not introduced here). The 4
 no-arg-construction tests' `imports === []` assertion passes once #1702 merges;
 this PR is rebased on #1702.
+
+## Re-validation of the #48 follow-up (2026-06-19, sdev-protoglue)
+
+Re-measured the task #48 scope against current upstream/main (`129df118f`).
+**The scoped acceptance is already satisfied** — the construction-routing fix
+(PR #1713) is in place. Verified standalone, all green:
+
+- 3-level `D extends A extends Error`: `instanceof Error` / `instanceof A` /
+  `instanceof D` all `true`; `.message` carries the constructor arg (real
+  `$Error_struct`); a thrown `D` is catchable as `Error`.
+- 4-level `D extends B extends A extends Error`: `instanceof Error` and
+  `instanceof B` both `true`.
+- Explicit-`super(msg)` chains at every level: `.message` correct.
+- `tests/issue-2188-multilevel-error-chain.test.ts` (+ `issue-2188.test.ts`):
+  **17 tests pass.**
+
+**No code change needed.** The sole remaining gap is a *user-field* set in an
+intermediate ctor (`class A extends Error { code:number; constructor(m){
+super(m); this.code=42; } }; class D extends A {}` → `new D().code` is `0`).
+That is the **documented out-of-scope externref-backed own-field limitation**
+(`class-bodies.ts` ~1674: "user `prop = ...` declarations inside `class Sub
+extends Error` would need to be installed via host setters, which is out of
+scope") — the instance IS a `$Error_struct`, which has no slot for arbitrary
+user fields. This is the #2101 brand/representation lane, NOT the #48 scoped
+instanceof+message bug. Flagged, not fixed here.


### PR DESCRIPTION
## Summary

Re-validation of task #48 (multi-level user Error chain construction — `class D extends A extends Error` routing super() through A's \_init not \_\_new_Error). **Measure-first result: the scoped acceptance is ALREADY satisfied on current main** by PR #1713; no code change needed.

## Verified (standalone, upstream/main 129df118f)

- 3-level `D extends A extends Error`: `instanceof Error`/`A`/`D` all true; `.message` carries the ctor arg (real `$Error_struct`); thrown `D` catchable as `Error`.
- 4-level `D extends B extends A extends Error`: `instanceof Error` and `instanceof B` both true.
- Explicit `super(msg)` chains at every level: `.message` correct.
- `tests/issue-2188-multilevel-error-chain.test.ts` + `issue-2188.test.ts`: **17 tests pass.**

## Out of scope (flagged, not fixed)

A user-field set in an intermediate Error-subclass ctor (`class A extends Error { code:number; constructor(m){super(m);this.code=42;} }; class D extends A {}` → `new D().code === 0`) is the **documented externref-backed own-field limitation** (`class-bodies.ts` ~1674): the instance is a `$Error_struct` with no slot for arbitrary user fields. That's the #2101 brand/representation lane, not the #48 instanceof+message scope.

This PR adds a re-validation note to the #2188 issue file (doc-only). No source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)