### PR TITLE
fix(#1461/#54): standalone reduce/reduceRight.call(arrayLike, cb, init) — un-refuse with-initial-value form

### DIFF
--- a/plan/issues/1461-spec-gap-array-prototype-generic-arraylike.md
+++ b/plan/issues/1461-spec-gap-array-prototype-generic-arraylike.md
@@ -228,3 +228,25 @@ map,indexOf,lastIndexOf,includes}`). Real, large lever.
 
 Owner: sdev-ctorval. Status stays `done` for the host-mode #1461; this standalone
 residual is the #54 follow-on (tracked on the task, not re-opening #1461).
+
+## PR-A landed (2026-06-19, sdev-ctorval) — reduce/reduceRight with-initial-value un-refused
+
+Shipped the safe slice of the standalone residual: `Array.prototype.reduce`/
+`reduceRight.call(arrayLike, cb, init)` over a non-array receiver now compiles to
+valid, host-free Wasm and is removed from the standalone refusal set **when an
+initial value is supplied**. Measured base→patched on 260 reduce/reduceRight
+test262 files (`--target standalone`): **pass 30 → 39 (+9)**, refuse-CE 140 → 40,
+0 regressions (no pass→CE/fail).
+
+The **no-initial-value** form stays gracefully refused (clean compile error, NOT
+invalid Wasm) via `standaloneArrayLikeMethodRefused()` — its §23.1.3.21 forward
+hole-scan trips a **module-finalization func-index shift**: the baked
+`__extern_has_idx` call (funcMap idx stable at emit, verified 155=155) mis-resolves
+to `number_toString` in the final binary (`if` over an externref → invalid Wasm),
+while the adjacent `__extern_get_idx` survives — an `addUnionImports`/late-import
+finalization reorder, not a localizable array-methods.ts capture bug. That fix +
+`map` (sparse indexed result arm) + indexOf/lastIndexOf/includes (native-eq search
+arm) remain as PR-B/C/D follow-ons.
+
+Tests: `tests/issue-1461-standalone-reduce-arraylike.test.ts` (4 — with-init
+reduce/reduceRight/arguments valid+correct; no-init never emits invalid Wasm).

--- a/plan/issues/1461-spec-gap-array-prototype-generic-arraylike.md
+++ b/plan/issues/1461-spec-gap-array-prototype-generic-arraylike.md
@@ -182,3 +182,49 @@ Array `.concat` is unaffected.
 case stays `it.fails`-pinned, tracked under #1784 / #1788 (boolean i32
 struct-field representation), which is a cross-cutting WasmGC representation
 matter rather than the #1461 generic-receiver algorithm.
+
+## STANDALONE residual (2026-06-19, sdev-ctorval re-ground for task #54)
+
+The 2026-06-03 resolution closed the **host-mode** gap. The **standalone**
+(`--target standalone`/`wasi`) lane still refuses 6 array-like `.call(...)`
+methods loudly:
+
+```
+Codegen error: Array.prototype.<m>.call(...) over an array-like (non-array)
+receiver is not yet supported in --target standalone (#2036 S6)
+```
+
+`STANDALONE_UNSUPPORTED_ARRAY_LIKE_METHODS` (array-methods.ts:503) =
+`{indexOf, lastIndexOf, includes, map, reduce, reduceRight}`. `forEach`/`some`/
+`every`/`find`/`findIndex`/`filter` already have native `$Object`/`$ObjVec`
+arms and work.
+
+**Measured impact (2026-06-19):** 269 refuse-CE / 500 sampled files across the 6
+refused methods' test262 dirs (`built-ins/Array/prototype/{reduce,reduceRight,
+map,indexOf,lastIndexOf,includes}`). Real, large lever.
+
+### Per-method empirical status (refusal removed, compiled `--target standalone`)
+- **reduce.call(o, cb, init)** — VALID + correct, host-import-free (boxes via
+  native `__box_number`). ✅ Ready to un-refuse.
+- **reduceRight.call(o, cb, init)** — VALID + correct. ✅
+- **reduce.call(o, cb)** *(no initial value)* — **INVALID Wasm**:
+  `if[0] expected type i32, found call of type externref`. The §23.1.3.21
+  forward hole-scan (find first present index; array-methods.ts ~1144-1206)
+  emits an `if` whose condition gets an externref instead of i32. **This is the
+  one real binary-emitter bug** blocking reduce/reduceRight. Fix it, then
+  un-refuse both (the dominant ~520-test sub-slice in the distribution above).
+- **map.call** — still uses `__js_array_new`/`__extern_set` host imports +
+  index-addressed sparse set; needs a native indexed `$ObjVec`/`$Array` result
+  arm (filter's push-compaction doesn't fit map's sparse semantics). Defer.
+- **indexOf/lastIndexOf/includes.call** — search arm leaks `__host_eq`/
+  `__same_value_zero`; needs a native StrictEqualityComparison / SameValueZero
+  arm over the boxed elements. Separate sub-slice (#72-adjacent).
+
+### Recommended PR sequencing
+1. **PR-A (biggest lever):** fix the reduce-no-init scan invalid-Wasm, then drop
+   `reduce`+`reduceRight` from the refusal set. ~520-test sub-slice.
+2. **PR-B:** native search arm for indexOf/lastIndexOf/includes (native eq).
+3. **PR-C:** native indexed result arm for map (sparse-hole aware).
+
+Owner: sdev-ctorval. Status stays `done` for the host-mode #1461; this standalone
+residual is the #54 follow-on (tracked on the task, not re-opening #1461).

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -507,12 +507,35 @@ const STANDALONE_UNSUPPORTED_ARRAY_LIKE_METHODS = new Set([
   // (#2036 S6 step 2) `filter` now has a native standalone arm — it builds its
   // result via the native `$ObjVec` builder (`__objvec_new`/`__objvec_push`)
   // instead of the host `__js_array_*`, so it no longer leaks a host import.
-  // Removed from the refusal set. map/reduce/reduceRight stay until their
-  // native result/accumulator arms land (map needs sparse-hole handling).
+  // Removed from the refusal set.
+  //
+  // (#1461/#54) `map` stays until its native indexed (sparse-hole) result arm
+  // lands. `reduce`/`reduceRight` are special-cased in the dispatch
+  // (`standaloneArrayLikeMethodRefused`): the **with-initial-value** form is
+  // host-import-free (accumulator boxed through native `__box_number`) and
+  // ALLOWED; the **no-initial-value** form's §23.1.3.21 forward hole-scan still
+  // hits a module-finalization func-index shift (`__extern_has_idx` baked call
+  // mis-resolves to `number_toString` → `if` over an externref → invalid Wasm),
+  // so it stays refused until that finalization-shift bug is fixed.
   "map",
-  "reduce",
-  "reduceRight",
 ]);
+
+/**
+ * (#1461/#54) Whether an array-like `.call(...)` over a non-array receiver is
+ * refused under `--target standalone`/`wasi`. Beyond the static
+ * `STANDALONE_UNSUPPORTED_ARRAY_LIKE_METHODS` set, `reduce`/`reduceRight` are
+ * refused ONLY in their no-initial-value form (the forward hole-scan trips a
+ * module-finalization func-index shift → invalid Wasm). The with-initial-value
+ * form compiles to valid, host-free Wasm and is allowed through.
+ */
+function standaloneArrayLikeMethodRefused(methodName: string, callExpr: ts.CallExpression): boolean {
+  if (STANDALONE_UNSUPPORTED_ARRAY_LIKE_METHODS.has(methodName)) return true;
+  if (methodName === "reduce" || methodName === "reduceRight") {
+    // args: [receiver, callback, initialValue?]. No initial value ⇒ refuse.
+    return callExpr.arguments.length < 3;
+  }
+  return false;
+}
 
 /**
  * Compile Array.prototype.METHOD.call(anyReceiver, callback, ...args) for any-typed receivers.
@@ -591,7 +614,7 @@ export function compileArrayLikePrototypeCall(
   // arm (#2036 PR-1) and fall through unaffected. Host/gc mode is untouched
   // (gated on standalone||wasi). Step 2 (real generic arm + emitter fix) removes
   // entries from this set as native paths land.
-  if ((ctx.standalone || ctx.wasi) && STANDALONE_UNSUPPORTED_ARRAY_LIKE_METHODS.has(methodName)) {
+  if ((ctx.standalone || ctx.wasi) && standaloneArrayLikeMethodRefused(methodName, callExpr)) {
     reportError(
       ctx,
       callExpr,

--- a/tests/issue-1461-standalone-reduce-arraylike.test.ts
+++ b/tests/issue-1461-standalone-reduce-arraylike.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #1461 / #54 — standalone `Array.prototype.reduce`/`reduceRight.call(arrayLike,
+ * cb, init)` over a non-array receiver (`{0:…, 1:…, length:n}`, an `arguments`
+ * object, …).
+ *
+ * The standalone lane refused these loudly (the generic `$Object` arm would leak
+ * a host import / emit invalid Wasm). The **with-initial-value** form is in fact
+ * host-import-free (the accumulator boxes through the native `__box_number`), so
+ * it is allowed through and produces valid, correct Wasm. The **no-initial-value**
+ * form's §23.1.3.21 forward hole-scan still trips a module-finalization
+ * func-index shift (→ invalid Wasm), so it stays gracefully refused (compile
+ * error, NOT invalid Wasm) until that separate bug is fixed.
+ */
+async function runStandalone(source: string): Promise<number> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as Record<string, () => number>).run();
+}
+
+async function compileResult(source: string): Promise<{ success: boolean; validWasm: boolean }> {
+  const r = await compile(source, { target: "standalone" });
+  return { success: r.success, validWasm: r.success ? WebAssembly.validate(r.binary) : false };
+}
+
+describe("#1461/#54 — standalone reduce/reduceRight.call over an array-like receiver", () => {
+  it("reduce.call(arrayLike, cb, init) sums correctly", async () => {
+    expect(
+      await runStandalone(
+        `export function run(): number {
+           const o: any = {0:1, 1:2, 2:3, length:3};
+           const r: any = Array.prototype.reduce.call(o, (a:any,x:any)=>(a as number)+(x as number), 0);
+           return Number(r);
+         }`,
+      ),
+    ).toBe(6);
+  });
+
+  it("reduceRight.call(arrayLike, cb, init) folds from the right", async () => {
+    expect(
+      await runStandalone(
+        `export function run(): number {
+           const o: any = {0:1, 1:2, 2:3, length:3};
+           const r: any = Array.prototype.reduceRight.call(o, (a:any,x:any)=>(a as number)+(x as number), 10);
+           return Number(r);
+         }`,
+      ),
+    ).toBe(16);
+  });
+
+  it("reduce.call over an arguments object works with an initial value", async () => {
+    expect(
+      await runStandalone(
+        `function g(): number {
+           const r: any = Array.prototype.reduce.call(arguments, (a:any,x:any)=>(a as number)+(x as number), 100);
+           return Number(r);
+         }
+         export function run(): number { return g(); }`,
+      ),
+    ).toBe(100);
+  });
+
+  it("reduce.call with NO initial value gracefully refuses (compile error, not invalid Wasm)", async () => {
+    const { success, validWasm } = await compileResult(
+      `export function run(): number {
+         const o: any = {0:1, 1:2, length:2};
+         const r: any = Array.prototype.reduce.call(o, (a:any,x:any)=>(a as number)+(x as number));
+         return Number(r);
+       }`,
+    );
+    // Must NOT compile to an invalid module: either a clean compile error, or
+    // (once the finalization-shift bug is fixed) a valid module — never invalid Wasm.
+    expect(success ? validWasm : true).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

The standalone (`--target standalone`/`wasi`) lane refused **all** `Array.prototype.{reduce,reduceRight}.call(...)` over a non-array (array-like) receiver — `{0:…, 1:…, length:n}`, an `arguments` object, etc. (#2036 S6 / #1461 standalone residual).

The **with-initial-value** form is in fact host-import-free (the accumulator boxes through the native `__box_number`), so it now compiles to valid, correct Wasm and is removed from the refusal set via a new `standaloneArrayLikeMethodRefused()` predicate.

The **no-initial-value** form stays *gracefully* refused (clean compile error, never invalid Wasm): its §23.1.3.21 forward hole-scan trips a **module-finalization func-index shift** — the baked `__extern_has_idx` call (funcMap index verified stable at emit, 155=155) mis-resolves to `number_toString` in the final binary (`if` over an externref → invalid Wasm), while the adjacent `__extern_get_idx` survives. That's an `addUnionImports`/late-import finalization reorder, tracked as a PR-B follow-on — not a localizable capture bug.

## Measured impact

base→patched on 260 reduce/reduceRight test262 files (`--target standalone`):

| | pass | refuse-CE |
|---|---|---|
| base | 30 | 140 |
| patched | **39 (+9)** | 40 |

0 regressions (no pass→CE, no pass→fail).

## Verification

`tests/issue-1461-standalone-reduce-arraylike.test.ts` (4): with-init reduce/reduceRight/`arguments` valid + correct; no-init never emits invalid Wasm. Existing #2074 join tests (12) still green. tsc + stack-balance + codegen-fallbacks + coercion-sites + ir-fallbacks gates all green.

PR-B/C/D follow-ons (no-init finalization-shift fix, native-eq search arm for indexOf/lastIndexOf/includes, sparse indexed result arm for map) are scoped in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)