### PR TITLE
feat(#1910 R3): standalone Boolean-wrapper ToNumber/valueOf

### DIFF
--- a/plan/issues/1910-r3-boolean-wrapper-tonumber.md
+++ b/plan/issues/1910-r3-boolean-wrapper-tonumber.md
@@ -1,0 +1,71 @@
+---
+id: 1910-r3
+slug: boolean-wrapper-tonumber
+title: "standalone Boolean-wrapper ToNumber/valueOf — Number(new Boolean(true)) returned NaN"
+status: done
+sprint: Backlog
+parent: 1910
+assignee: sdev-boxrep
+feasibility: medium
+completed: 2026-06-19
+---
+
+## Problem
+
+In `--target standalone` (pure-Wasm, no JS host), coercing a `new Boolean(x)`
+wrapper object to a number gave the wrong answer:
+
+- `Number(new Boolean(true))` returned **NaN** (spec: `1`)
+- `Number(new Boolean(false))` returned **NaN** (spec: `0`)
+- `new Boolean(true).valueOf()` returned a non-boolean garbage value
+
+This broke `Boolean/prototype/valueOf/*` conformance and every numeric-context
+coercion of a Boolean wrapper.
+
+## Root cause (measure-first; the substrate had moved)
+
+The original spec hypothesis (arch-dynshape / #1472 refresh) was that
+`__new_Boolean` stored a **boxed f64** in the wrapper's internal slot. That is
+**no longer true on current main** — `__new_Boolean`
+(`src/codegen/object-runtime.ts:1090`) already boxes the truthy i32 via
+`__box_boolean` and stores a real boxed-boolean (`__box_boolean_struct`) in the
+`WRAPPER_PRIMITIVE_KEY` FLAG_INTERNAL slot. `__to_primitive` recovers that
+boxed-boolean externref correctly.
+
+The real, current bug was one layer downstream — in the **standalone native
+`__unbox_number`** body (`src/codegen/index.ts`,
+`addUnionImportsAsNativeFuncs`). Its arms were: `null → 0`,
+`$box_number_struct → value`, `native string → __str_to_number`, and
+**everything else → NaN**. A `$box_boolean_struct` fell into the NaN fallback.
+So `Number(new Boolean(true))` → `__to_primitive` returns boxed-bool →
+`__unbox_number(boxed_bool)` → **NaN**.
+
+`new Boolean(x).valueOf()` was a second, independent gap: the standalone
+wrapper-accessor block in `src/codegen/expressions/calls.ts` only handled
+`String`/`Number` wrapper `valueOf`; the Boolean arm fell through to a legacy
+`compileExpression(..., {kind:"i32"})` of the `$Object` receiver, yielding
+garbage.
+
+## Fix
+
+1. `src/codegen/index.ts` — add a `$box_boolean_struct` arm to the standalone
+   native `__unbox_number`: `ref.test` the boxed-boolean struct, read field 0
+   (the i32), `f64.convert_i32_s` → 1.0/0.0 (§7.1.4 ToNumber(true)=1,
+   ToNumber(false)=0). Inserted before the native-string arm; standalone/WASI
+   only (host mode uses the JS `__unbox_number` import — untouched).
+
+2. `src/codegen/expressions/calls.ts` — extend the standalone
+   wrapper-value-accessor path to cover `Boolean.prototype.valueOf`: route
+   through `__to_primitive` (slot read) then `__unbox_boolean` → i32 primitive
+   (§20.3.3.3).
+
+Both changes are additive and standalone-gated; no host-mode path changes.
+
+## Acceptance (all passing)
+
+- `Number(new Boolean(true)) === 1`, `Number(new Boolean(false)) === 0`
+- `new Boolean(true) + 0 === 1`, `new Boolean(false) + 0 === 0`
+- `new Boolean(true).valueOf()` truthy, `new Boolean(false).valueOf()` falsy
+
+Regression: `tests/issue-1910-boolean-wrapper-tonumber.test.ts` (6 cases).
+50 related wrapper/coercion tests still green.

--- a/plan/issues/1910b-boolean-wrapper-tonumber.md
+++ b/plan/issues/1910b-boolean-wrapper-tonumber.md
@@ -1,5 +1,5 @@
 ---
-id: 1910-r3
+id: 1910b
 slug: boolean-wrapper-tonumber
 title: "standalone Boolean-wrapper ToNumber/valueOf — Number(new Boolean(true)) returned NaN"
 status: done

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -6943,7 +6943,12 @@ function compileCallExpression(
       const isWrapperValueAccessor =
         expr.arguments.length === 0 &&
         ((recvSymName === "String" && (wrapperMethodName === "valueOf" || wrapperMethodName === "toString")) ||
-          (recvSymName === "Number" && wrapperMethodName === "valueOf"));
+          (recvSymName === "Number" && wrapperMethodName === "valueOf") ||
+          // #1910 R3 — Boolean wrapper .valueOf() in standalone: the internal
+          // slot holds a boxed boolean (`__box_boolean_struct`), recovered by
+          // `__to_primitive`; unbox it to the i32 primitive below (§20.3.3.3
+          // Boolean.prototype.valueOf returns the [[BooleanData]] slot).
+          (recvSymName === "Boolean" && wrapperMethodName === "valueOf"));
 
       // #2160 — standalone recovery of the wrapper's internal [[PrimitiveValue]]
       // slot. In --target standalone there is no JS host, so `new String(x)` /
@@ -6977,6 +6982,14 @@ function compileCallExpression(
             flushLateImportShifts(ctx, fctx);
             if (unboxNumIdx !== undefined) fctx.body.push({ op: "call", funcIdx: unboxNumIdx });
             return { kind: "f64" };
+          }
+          // #1910 R3 — Boolean wrapper valueOf → boxed boolean in the slot; unbox
+          // to the i32 primitive (true→1, false→0).
+          if (wrapperMethodName === "valueOf" && recvSymName === "Boolean") {
+            const unboxBoolIdx = ensureLateImport(ctx, "__unbox_boolean", [{ kind: "externref" }], [{ kind: "i32" }]);
+            flushLateImportShifts(ctx, fctx);
+            if (unboxBoolIdx !== undefined) fctx.body.push({ op: "call", funcIdx: unboxBoolIdx });
+            return { kind: "i32" };
           }
           // String wrapper valueOf/toString, or Number wrapper toString → string ref.
           return { kind: "externref" };

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -9180,6 +9180,24 @@ function addUnionImportsAsNativeFuncs(ctx: CodegenContext): void {
           { op: "return" },
         ],
       },
+      // #1910 R3 — a boxed boolean (the [[BooleanData]] slot of a
+      // `new Boolean(x)` wrapper, recovered by `__to_primitive`) coerces per
+      // §7.1.4 ToNumber(true)=1, ToNumber(false)=0. Without this arm a boxed
+      // boolean fell through to the opaque-ref NaN fallback, so
+      // `Number(new Boolean(true))` returned NaN instead of 1.
+      { op: "local.get", index: 1 },
+      { op: "ref.test", typeIdx: boxBoolStructIdx },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 1 },
+          { op: "ref.cast", typeIdx: boxBoolStructIdx },
+          { op: "struct.get", typeIdx: boxBoolStructIdx, fieldIdx: 0 },
+          { op: "f64.convert_i32_s" },
+          { op: "return" },
+        ],
+      },
       ...(strToNumberIdx !== undefined && ctx.anyStrTypeIdx >= 0
         ? ([
             // StringToNumber (§7.1.4.1): object ToPrimitive can yield a native

--- a/tests/issue-1910-boolean-wrapper-tonumber.test.ts
+++ b/tests/issue-1910-boolean-wrapper-tonumber.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #1910 R3 — standalone `new Boolean(x)` wrapper ToNumber.
+//
+// `new Boolean(x)` builds a `$Object` wrapper carrying its [[BooleanData]]
+// primitive in the reserved FLAG_INTERNAL slot as a BOXED boolean
+// (`__box_boolean_struct`). `__to_primitive` recovers that boxed-boolean
+// externref from the slot, and the ToNumber that `Number(...)` applies routes
+// it through `__unbox_number`. Before this fix `__unbox_number` had no
+// boxed-boolean arm, so it fell through to the opaque-ref NaN fallback and
+// `Number(new Boolean(true))` returned NaN instead of 1 (§7.1.4
+// ToNumber(true)=1, ToNumber(false)=0).
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { f: () => number }).f();
+}
+
+describe("#1910 R3 standalone Boolean-wrapper ToNumber", () => {
+  it("Number(new Boolean(true)) === 1", async () => {
+    expect(await runStandalone(`export function f(): number { return Number(new Boolean(true)); }`)).toBe(1);
+  });
+
+  it("Number(new Boolean(false)) === 0", async () => {
+    expect(await runStandalone(`export function f(): number { return Number(new Boolean(false)); }`)).toBe(0);
+  });
+
+  it("new Boolean(true) coerces to 1 in numeric context (+ 0)", async () => {
+    expect(await runStandalone(`export function f(): number { return (new Boolean(true) as any) + 0; }`)).toBe(1);
+  });
+
+  it("new Boolean(false) coerces to 0 in numeric context (+ 0)", async () => {
+    expect(await runStandalone(`export function f(): number { return (new Boolean(false) as any) + 0; }`)).toBe(0);
+  });
+
+  // §20.3.3.3 Boolean.prototype.valueOf returns the [[BooleanData]] slot. The
+  // standalone wrapper-accessor path routes through __to_primitive (slot read)
+  // then __unbox_boolean to recover the i32 primitive.
+  it("new Boolean(true).valueOf() is truthy → 1", async () => {
+    expect(await runStandalone(`export function f(): number { return new Boolean(true).valueOf() ? 1 : 0; }`)).toBe(1);
+  });
+
+  it("new Boolean(false).valueOf() is falsy → 0", async () => {
+    expect(await runStandalone(`export function f(): number { return new Boolean(false).valueOf() ? 1 : 0; }`)).toBe(0);
+  });
+});


### PR DESCRIPTION
## #1910 R3 — standalone Boolean-wrapper ToNumber/valueOf

`Number(new Boolean(true))` returned **NaN** in `--target standalone` (spec: `1`); `Number(new Boolean(false))` returned NaN (spec: `0`); `new Boolean(x).valueOf()` returned garbage.

### Root cause (measure-first — substrate had moved)
The original #1472-refresh hypothesis ("`__new_Boolean` boxes an f64") is **no longer true on main** — `__new_Boolean` already stores a real `$box_boolean_struct` in the wrapper slot, and `__to_primitive` recovers it correctly. The actual current bug was one layer downstream: the **standalone native `__unbox_number`** had no boxed-boolean arm, so a slot-recovered boxed boolean fell into the opaque-ref **NaN** fallback.

`new Boolean(x).valueOf()` was a second, independent gap — the standalone wrapper-accessor path in `calls.ts` only handled String/Number `valueOf`.

### Fix (both additive, standalone-gated)
1. `src/codegen/index.ts` — `__unbox_number` gains a `$box_boolean_struct` arm: `ref.test` → read i32 field → `f64.convert_i32_s` (§7.1.4 ToNumber(true)=1, ToNumber(false)=0). Host-mode `__unbox_number` import untouched.
2. `src/codegen/expressions/calls.ts` — `Boolean.prototype.valueOf` joins the standalone wrapper-value accessor: `__to_primitive` slot read + `__unbox_boolean` → i32 (§20.3.3.3).

### Acceptance (all green)
- `Number(new Boolean(true))===1`, `Number(new Boolean(false))===0`
- `new Boolean(true)+0===1`, `new Boolean(false)+0===0`
- `new Boolean(true).valueOf()` truthy, `new Boolean(false).valueOf()` falsy

`tests/issue-1910-boolean-wrapper-tonumber.test.ts` (6 cases). 50 related wrapper/coercion tests still green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)