### PR TITLE
fix(#2190-residual): standalone any[]-of-tuple nested access — widen string-first heterogeneous literal

### DIFF
--- a/plan/issues/2511-standalone-anyarray-tuple-nested-access.md
+++ b/plan/issues/2511-standalone-anyarray-tuple-nested-access.md
@@ -1,0 +1,83 @@
+---
+id: 2511
+title: "standalone: any[] of heterogeneous tuples — nested access e[0][1] traps null-deref (#2190 residual)"
+status: done
+assignee: ttraenkler/sdev-arrayrep
+created: 2026-06-19
+updated: 2026-06-19
+completed: 2026-06-19
+priority: medium
+feasibility: medium
+task_type: bugfix
+area: codegen
+language_feature: arrays, array-literal, element-representation
+goal: standalone-mode
+related: [2190, 2106, 2042]
+origin: "TaskList #86; surfaced from #85 Object.fromEntries blocker"
+---
+
+# #2511 — standalone `any[]` of heterogeneous tuples: nested access traps
+
+## Problem (file-verified, current main, `--target standalone`)
+
+```ts
+const e: any[] = [["a", 1], ["b", 2]];
+e[0][1];   // TRAP: "dereferencing a null pointer"
+```
+
+Reading a nested element of an `any[]` whose elements are **heterogeneous tuples**
+(`[string, number]`) traps. Discriminator:
+- `number[][]` → `e[0][1]` WORKS
+- `[string,number][]` (typed) → CE
+- `any[] = [["a",1]]` → `e[0][1]` TRAPS
+
+This is the canonical `Object.fromEntries([["a",1]])` entries shape — and a user
+hand-rolled `for (const p of e) { o[p[0]] = p[1]; }` over the same `any[]` also
+trapped, so it's upstream of `fromEntries` (which it was blocking, #85).
+
+## Root cause (WAT-pinned)
+
+`compileArrayLiteral` (`src/codegen/literals.ts`) infers the inner array's element
+type from the FIRST element. For `["a", 1]` element 0 is `"a"` → the heuristic
+picks `$AnyString` for the whole inner vec. The number `1` then can't be stored
+in a `$AnyString[]`, so codegen emits `f64.const 1; drop` and substitutes
+`ref.null $AnyString; ref.as_non_null` — a guaranteed null-deref when `e[i][1]`
+is later read.
+
+The existing heterogeneity widening only handled a NUMERIC first element with a
+later object/null element (`[0, 1, obj]` → externref via `hasObjectElem`). A
+STRING first element with a later non-string element (`["a", 1]`) fell through and
+stayed `$AnyString[]`.
+
+## Fix
+
+In `compileArrayLiteral`, add a mirror of the `hasObjectElem` widening: when the
+first-element heuristic picked a native-string element type (`$AnyString` /
+`$NativeString`) but the literal contains a NON-string element, widen the vec to
+`externref` so each element is boxed by its own static type at construction
+(`__box_number` / `__box_boolean` / native-string). Scoped to native-strings
+mode; `number[]` / `string[]` / homogeneous literals are byte-identical.
+
+## Acceptance criteria
+
+1. `any[] = [["a",1]]` → `e[0][1]` reads the number; `e[0][0]` reads the string.
+2. A hand-rolled `for`-loop fromEntries over the `any[]` tuples works end-to-end.
+3. No regression: `number[]`, `string[]`, `number[][]`, all-string `any[]`,
+   flat mixed-scalar `any[]` unchanged.
+
+## Resolution (sdev-arrayrep, 2026-06-19)
+
+One-arm widening per above. MEASURED: `[["a",1],["b",2]]` → `e[1][1]`=2, e[0][1]=1,
+e[0][0].length=1; hand-rolled fromEntries → correct; flat mixed-scalar any[]
+unchanged; number[]/string[]/number[][]/all-string-any[] regressions clean.
+`tests/issue-2190b-anytuple-nested.test.ts` (7) green; #2106/#2190/#786/#2014/#2505
+suites unchanged; `tsc` + coercion gate clean.
+
+**Unblocks #85** — with nested any[]-tuple access fixed, `Object.fromEntries([…])`
+over a literal-array entries arg now iterates correctly (the native helper from
+#85 can land on top).
+
+**Out of scope (separate residual):** a HOMOGENEOUS string sub-array
+(`[["a","b"]]`, a `$AnyString[]` stored into an `any[]`) still traps `e[0][0]` —
+broken on main without this change too; a distinct `$AnyString[]`-in-`any[]`
+read-back layer, not the heterogeneous-tuple fix.

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -3146,6 +3146,38 @@ export function compileArrayLiteral(
         if (hasObjectElem) {
           elemWasm = { kind: "externref" };
         }
+      } else if (
+        ctx.nativeStrings &&
+        ctx.anyStrTypeIdx >= 0 &&
+        (elemWasm.kind === "ref" || elemWasm.kind === "ref_null") &&
+        ((elemWasm as { typeIdx: number }).typeIdx === ctx.anyStrTypeIdx ||
+          (elemWasm as { typeIdx: number }).typeIdx === ctx.nativeStrTypeIdx)
+      ) {
+        // (#2190 residual) The first element is a native string, so the
+        // first-element heuristic picked `$AnyString` for the whole vec — but a
+        // heterogeneous literal like `["a", 1]` (a `[string, number]` tuple,
+        // common as an `Object.fromEntries` entry) then DROPS the non-string
+        // element (`f64.const 1; drop`) and substitutes `ref.null $AnyString;
+        // ref.as_non_null` → a guaranteed null-deref trap on a later read. Mirror
+        // the numeric-first `hasObjectElem` widening: if any element is NOT a
+        // native string, widen the vec to `externref` so each element is boxed by
+        // its own static type (`__box_number`/`__box_boolean`/native-string) at
+        // construction. Scoped to native-strings mode; number[]/struct[] etc. are
+        // untouched (their first element isn't a string).
+        const hasNonStringElem = expr.elements.some((el) => {
+          if (ts.isOmittedExpression(el) || ts.isSpreadElement(el)) return false;
+          if (el.kind === ts.SyntaxKind.StringLiteral) return false;
+          const t = resolveWasmType(ctx, ctx.checker.getTypeAtLocation(el));
+          if (t.kind === "ref" || t.kind === "ref_null") {
+            const ti = (t as { typeIdx: number }).typeIdx;
+            return ti !== ctx.anyStrTypeIdx && ti !== ctx.nativeStrTypeIdx;
+          }
+          // f64 / i32 / externref / etc. — a non-string element.
+          return true;
+        });
+        if (hasNonStringElem) {
+          elemWasm = { kind: "externref" };
+        }
       }
     }
   }

--- a/tests/issue-2190b-anytuple-nested.test.ts
+++ b/tests/issue-2190b-anytuple-nested.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2190-residual — standalone nested element access on an `any[]` whose elements
+// are HETEROGENEOUS tuples (`[["a", 1], ["b", 2]]`, the canonical
+// `Object.fromEntries` entries shape) trapped with "dereferencing a null
+// pointer". The array-literal first-element heuristic picked `$AnyString` for the
+// whole vec (element 0 is "a"), then the number element was emitted as
+// `f64.const 1; drop` and replaced with `ref.null $AnyString; ref.as_non_null`
+// — a guaranteed null-deref on a later read of `e[i][1]`.
+//
+// Fix (literals.ts compileArrayLiteral): when the first-element heuristic picked
+// a native-string element type but the literal contains a NON-string element,
+// widen the vec to `externref` (mirroring the existing numeric-first
+// `hasObjectElem` widening) so each element is boxed by its own static type at
+// construction (`__box_number` / native-string / …). number[] / string[] /
+// homogeneous literals are untouched.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runStandalone(source: string): Promise<number> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports as unknown as WebAssembly.Imports);
+  return (instance.exports as Record<string, () => number>).run();
+}
+
+const fn = (body: string) => `export function run(): number { ${body} }`;
+
+describe("#2190b — standalone nested access on an any[] of heterogeneous tuples", () => {
+  it("any[] of [string,number] tuples: e[0][1] reads the number (was null-deref)", async () => {
+    expect(await runStandalone(fn(`const e: any[] = [["a", 1]]; return e[0][1] as number;`))).toBe(1);
+  });
+
+  it("multiple tuples: e[1][1]", async () => {
+    expect(await runStandalone(fn(`const e: any[] = [["a", 1], ["b", 2]]; return e[1][1] as number;`))).toBe(2);
+  });
+
+  it("the string element of the tuple still reads correctly: e[0][0].length", async () => {
+    expect(await runStandalone(fn(`const e: any[] = [["a", 1]]; return (e[0][0] as string).length;`))).toBe(1);
+  });
+
+  it("a hand-rolled fromEntries over the any[] tuples now works end-to-end", async () => {
+    expect(
+      await runStandalone(
+        fn(
+          `const e: any[] = [["a", 1], ["b", 2]]; const o: any = {}; for (let i = 0; i < e.length; i++) { const p: any = e[i]; o[p[0]] = p[1]; } return o.a as number;`,
+        ),
+      ),
+    ).toBe(1);
+  });
+
+  it("flat mixed-scalar any[] still works (string + number + boolean)", async () => {
+    expect(await runStandalone(fn(`const a: any[] = [1, "x", true]; return (a[1] as string).length;`))).toBe(1);
+    expect(await runStandalone(fn(`const a: any[] = [0, "a"]; return a[0] as number;`))).toBe(0);
+  });
+
+  // ── regression: homogeneous literals untouched ──
+  it("number[] / string[] / number[][] unchanged", async () => {
+    expect(await runStandalone(fn(`const a = [1, 2, 3]; return a[1];`))).toBe(2);
+    expect(await runStandalone(fn(`const a = ["x", "yy"]; return a[1].length;`))).toBe(2);
+    expect(await runStandalone(fn(`const e: number[][] = [[1, 2]]; return e[0][1];`))).toBe(2);
+  });
+
+  it("all-string any[] unchanged", async () => {
+    expect(await runStandalone(fn(`const a: any[] = ["x", "y"]; return (a[0] as string).length;`))).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2190-residual (#2511) — standalone `any[]` of heterogeneous tuples: `e[0][1]` traps null-deref

```ts
const e: any[] = [["a", 1], ["b", 2]];
e[0][1];   // TRAP: "dereferencing a null pointer"  (standalone)
```

The canonical `Object.fromEntries` entries shape. A user hand-rolled `for (const p of e) { o[p[0]] = p[1]; }` over the same `any[]` also trapped — so it's upstream of `fromEntries` (which it was blocking, #85).

Discriminator: `number[][]` `e[0][1]` WORKS; `any[] = [["a",1]]` `e[0][1]` TRAPS.

### Root cause (WAT-pinned)
`compileArrayLiteral` (`src/codegen/literals.ts`) infers the inner array's element type from the **first element**. For `["a", 1]`, element 0 is `"a"` → the heuristic picks `$AnyString` for the whole inner vec; the number `1` then can't be stored, so codegen emits `f64.const 1; drop` and substitutes `ref.null $AnyString; ref.as_non_null` — a guaranteed null-deref on the later `e[i][1]` read. The existing heterogeneity widening only handled a **numeric** first element (`[0,1,obj]` via `hasObjectElem`); a **string** first element with a later non-string element fell through.

### Fix
Mirror the `hasObjectElem` widening: when the heuristic picked a native-string element type but the literal contains a NON-string element, widen the vec to `externref` so each element is boxed by its own static type at construction (`__box_number`/`__box_boolean`/native-string). Scoped to native-strings mode; `number[]`/`string[]`/homogeneous literals are byte-identical.

### Measured
`[["a",1],["b",2]]` → `e[1][1]`=2, `e[0][1]`=1, `e[0][0].length`=1; hand-rolled fromEntries → correct; flat mixed-scalar `any[]` (`[1,"x",true]`, `[0,"a"]`) unchanged; `number[]`/`string[]`/`number[][]`/all-string-`any[]` regressions clean.

### Tests / regression
`tests/issue-2190b-anytuple-nested.test.ts` (7) green; `#2106`/`#2190`/`#786`/`#2014`/`#2505` suites unchanged; `tsc` + coercion gate clean. **Unblocks #85** (Object.fromEntries over a literal-array entries arg).

### Out of scope
A HOMOGENEOUS string sub-array (`[["a","b"]]`, a `$AnyString[]` stored into an `any[]`) still traps `e[0][0]` — broken on main without this change too; a distinct `$AnyString[]`-in-`any[]` read-back layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)