### PR TITLE
fix(#1910d): standalone loose-eq Object↔primitive ToPrimitive arm (§7.2.13)

### DIFF
--- a/plan/issues/1910d-loose-eq-object-primitive.md
+++ b/plan/issues/1910d-loose-eq-object-primitive.md
@@ -1,0 +1,95 @@
+---
+id: 1910d
+title: "standalone loose-eq (==/!=) Object↔primitive ToPrimitive arm (§7.2.13 steps 11-12)"
+status: done
+created: 2026-06-19
+updated: 2026-06-19
+completed: 2026-06-19
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: codegen, type-coercion
+language_feature: loose-equality, to-primitive, abstract-operations
+goal: standalone-mode
+sprint: 61
+related: [1910, 1472, 1900, 1917, 1776, 2081, 1134]
+assignee: ttraenkler/sdev-looseeq
+test262_bucket: object-loose-equality
+---
+## Problem
+
+The standalone / WASI (`noJsHost`) loose-equality cascade in
+`src/codegen/binary-ops.ts` (the `noJsHost && (left|right === externref)`
+block, ~L2002) implements ECMA-262 §7.2.13 IsLooselyEqual for
+number / boolean / bigint / string / reference-identity — but had **no arm for
+"exactly one operand is an Object and the other a primitive"** (§7.2.13
+steps 11-12: `x is String/Number/BigInt/Symbol and y is Object ⇒ x ==
+ToPrimitive(y)`, symmetric). So under `--target standalone`:
+
+- `new Number(7) == 7` → `false` (should be `true`)
+- `new Boolean(true) == 1`, `"1" == new Boolean(true)` → `false`
+- `{ valueOf: () => 5 } == 5` → `false`
+
+…all fell through to the reference-identity fallback and returned `false`.
+(`new Number`/wrapper operands additionally went through a `__host_loose_eq`
+host path that leaks an unsatisfiable import in standalone — but that path is
+shadowed by the `noJsHost` block, so they reached the ref-identity arm and
+returned a wrong `false` rather than failing to instantiate.)
+
+## Fix
+
+Add the §7.2.13 step 11-12 Object↔primitive arm **inside the `noJsHost` block**,
+reusing the already-built native `__to_primitive` engine (#1900/#1917 — do NOT
+fork it). After both operands are coerced into the `lTmp`/`rTmp` externref
+temps, and gated on **loose `==`/`!=` only** (strict `===` never coerces,
+§7.2.16):
+
+1. Compute `__typeof_object(lTmp)` and `__typeof_object(rTmp)`.
+2. If **exactly one** is an object (`i32.ne` ≡ XOR), reduce BOTH operands in
+   place via `__to_primitive(operand, ref.null.extern /* default hint */)`.
+   `__to_primitive` is the identity on a primitive (its `returnIfPrimitive`
+   guard), so this only transforms the object side; the primitive side is
+   untouched. The existing number/boolean/bigint/string cascade then runs on the
+   reduced operands.
+
+The XOR gate is load-bearing for two spec corners:
+- **both objects** → §7.2.13 step 1 SameType ⇒ IsStrictlyEqual = reference
+  identity, NEVER ToPrimitive → the gate is false, the eqref arm handles it
+  (`{} == {}` stays `false`).
+- **neither object** → gate false, primitives flow through unchanged.
+
+`null`/`undefined` already short-circuit earlier (`looseNullish`), so they never
+reach the reduction (`null == {}` stays `false`). A `Symbol` operand passes
+through `__to_primitive` unchanged → compares unequal (correct).
+
+### Critical hazard (the #1890 finalization-shift class)
+
+`__to_primitive` is registered by `ensureObjectRuntime(ctx)`, which can add
+**late imports that shift function indices**. It MUST be called *before* the
+`addUnionImports` / `__typeof_*` funcIdx reads in the block — and **gated on
+`isLoose`**. An earlier draft called `ensureObjectRuntime` unconditionally
+(for strict `===` too) and that desynced the in-progress body, regressing
+`#1776` `isSameValue` (a strict-`===` standalone test, ~1,436 dependents). With
+the `isLoose` gate the strict path is byte-identical to before.
+
+## Acceptance
+
+- `new Number(7) == 7`, `"7" == new Number(7)`, `new Boolean(true) == 1`,
+  `"1" == new Boolean(true)`, `{valueOf:()=>5} == 5` all `true` (standalone).
+- `{valueOf:()=>5} == 6` → `false`; `new Number(7) === 7` → `false` (strict).
+- `#1776` and the existing equality/coercion suites unchanged (0 regressions).
+- Test: `tests/issue-1910d-loose-eq-object-primitive.test.ts`.
+
+## Out of scope (follow-up needed)
+
+Object→**String** reduction cases (`new String("x") == "x"`, `{toString}` vs a
+string literal) still fail — but the block is correctly producing the reduced
+string. They bottom out on a **separate pre-existing standalone defect**: an
+`any`/object operand compared `==` against a *statically string-typed* literal
+mis-coerces the string operand to `__box_number(__str_to_number(s))` = NaN, so
+`NaN ≠ NaN` makes equal strings compare unequal. This reproduces with **no
+objects involved** — `function eq(a:any){return a=="ab";} eq("ab")` returns
+`false` in standalone while `a==="ab"` (strict) returns `true`. The mis-coercion
+is in the operand-lowering / coercion-plan for `any`-vs-typed-string loose
+equality, upstream of the loose-eq dispatch. Should be filed as its own issue.

--- a/scripts/coercion-sites-baseline.json
+++ b/scripts/coercion-sites-baseline.json
@@ -1,7 +1,7 @@
 {
   "codegen/array-methods.ts": 19,
   "codegen/async-scheduler.ts": 3,
-  "codegen/binary-ops.ts": 37,
+  "codegen/binary-ops.ts": 38,
   "codegen/closed-method-dispatch.ts": 1,
   "codegen/declarations.ts": 17,
   "codegen/expressions/assignment.ts": 12,

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -2001,6 +2001,16 @@ export function compileBinaryExpression(
     const noJsHost = ctx.standalone === true || ctx.wasi === true;
     if (noJsHost && (leftType.kind === "externref" || rightType.kind === "externref")) {
       const EQ_HEAP = -19; // WasmGC `eq` abstract heap type (signed LEB 0x6d)
+      // (#1910 R1) §7.2.13 IsLooselyEqual steps 11-12 — the Object↔primitive arm
+      // is LOOSE-only (strict `===` never coerces, §7.2.16). Register the native
+      // ToPrimitive engine BEFORE `addUnionImports` / the typeof funcIdx reads so
+      // any late imports it adds can't desync the in-progress body — this is the
+      // #1890 finalization-shift class, and doing it after the funcIdx reads
+      // corrupted the strict `===` path (#1776 isSameValue regressed). Gated on
+      // `isLoose` so the strict path is byte-identical to before.
+      const isLoose =
+        !isStrict && (op === ts.SyntaxKind.EqualsEqualsToken || op === ts.SyntaxKind.ExclamationEqualsToken);
+      if (isLoose) ensureObjectRuntime(ctx);
       addUnionImports(ctx);
       const typeofNum = ctx.funcMap.get("__typeof_number")!;
       const typeofBool = ctx.funcMap.get("__typeof_boolean")!;
@@ -2020,6 +2030,43 @@ export function compileBinaryExpression(
         coerceType(ctx, fctx, leftType, { kind: "externref" });
       }
       fctx.body.push({ op: "local.set", index: lTmp });
+
+      // (#1910 R1) §7.2.13 steps 11-12 — reduce an Object operand to a primitive
+      // for LOOSE equality. We overwrite lTmp/rTmp in place with
+      // ToPrimitive(operand, default) when EXACTLY ONE side is an Object:
+      //   - both Objects → SameType(x,y) (step 1) → IsStrictlyEqual = reference
+      //     identity, NEVER ToPrimitive (so we must NOT reduce — the eqref arm at
+      //     the bottom of the cascade handles it). The XOR gate preserves this.
+      //   - neither Object → no reduction (the `if` is false), primitives flow on.
+      // `__to_primitive` is the identity on a primitive (its leading
+      // returnIfPrimitive guard returns null/number/boolean/string unchanged), so
+      // reducing BOTH operands inside the one-object branch only transforms the
+      // object side; the primitive side is untouched. The single ToPrimitive call
+      // matches the spec's single recursion: after it both operands are primitive
+      // and the recursion bottoms out in the number/string/bigint/boolean arms.
+      const toPrimIdx = ctx.funcMap.get("__to_primitive");
+      const typeofObject = ctx.funcMap.get("__typeof_object");
+      if (isLoose && toPrimIdx !== undefined && typeofObject !== undefined) {
+        const reduceOperand = (externLocal: number): Instr[] => [
+          { op: "local.get", index: externLocal },
+          { op: "ref.null.extern" } as Instr, // default hint
+          { op: "call", funcIdx: toPrimIdx } as Instr,
+          { op: "local.set", index: externLocal },
+        ];
+        fctx.body.push(
+          // lIsObj XOR rIsObj  ≡  lIsObj !== rIsObj
+          { op: "local.get", index: lTmp },
+          { op: "call", funcIdx: typeofObject } as Instr,
+          { op: "local.get", index: rTmp },
+          { op: "call", funcIdx: typeofObject } as Instr,
+          { op: "i32.ne" } as Instr,
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [...reduceOperand(lTmp), ...reduceOperand(rTmp)],
+          } as Instr,
+        );
+      }
 
       // (#2081) LOOSE null/undefined arm (§7.2.15 steps 2-3): `null == undefined`
       // (and null==null / undefined==undefined) ⇒ true; a nullish vs a

--- a/tests/issue-1910d-loose-eq-object-primitive.test.ts
+++ b/tests/issue-1910d-loose-eq-object-primitive.test.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1910d / #1472 R1 — standalone loose-equality (`==`/`!=`) Object↔primitive
+ * ToPrimitive arm (ECMA-262 §7.2.13 IsLooselyEqual steps 11-12).
+ *
+ * The standalone/WASI (`noJsHost`) loose-eq cascade in `binary-ops.ts` handled
+ * number/boolean/bigint/string/reference-identity but had NO arm for "exactly
+ * one operand is an Object, the other a primitive". So `new Number(7) == 7`,
+ * `new Boolean(true) == 1`, and `{ valueOf: () => 5 } == 5` all fell through to
+ * reference identity → wrong `false`. The fix reduces the object operand via the
+ * native `__to_primitive` engine (LOOSE only — strict `===` never coerces) and
+ * re-runs the primitive cascade.
+ *
+ * Number/Boolean wrapper + plain-valueOf object cases are covered here. The
+ * object→String reduction cases (`new String("x") == "x"`, `{toString}` vs a
+ * string literal) are blocked by a SEPARATE pre-existing standalone defect where
+ * an `any`/object operand compared `==` against a *statically string-typed*
+ * literal mis-coerces the string operand to NaN (reproduces with no objects
+ * involved) — tracked separately, not part of this arm.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runBool(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "issue-1910d.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+const cases: Array<[string, string, number]> = [
+  ["{valueOf} == number", `export function test(): boolean { const o = { valueOf: () => 5 }; return o == 5; }`, 1],
+  ["number == {valueOf}", `export function test(): boolean { const o = { valueOf: () => 5 }; return 5 == o; }`, 1],
+  ["{valueOf} != mismatch", `export function test(): boolean { const o = { valueOf: () => 5 }; return o != 6; }`, 1],
+  [
+    "{valueOf} == mismatch is false",
+    `export function test(): boolean { const o = { valueOf: () => 5 }; return o == 6; }`,
+    0,
+  ],
+  ["new Number(7) == 7", `export function test(): boolean { const n = new Number(7); return n == 7; }`, 1],
+  ['"7" == new Number(7)', `export function test(): boolean { const n = new Number(7); return "7" == n; }`, 1],
+  ["new Boolean(true) == 1", `export function test(): boolean { const b = new Boolean(true); return b == 1; }`, 1],
+  ['"1" == new Boolean(true)', `export function test(): boolean { const b = new Boolean(true); return "1" == b; }`, 1],
+  // strict === must NOT coerce a wrapper to its primitive (§7.2.16)
+  [
+    "new Number(7) === 7 is false",
+    `export function test(): boolean { const n = new Number(7); return (n as any) === 7; }`,
+    0,
+  ],
+];
+
+describe("#1910d standalone loose-eq Object↔primitive ToPrimitive arm (§7.2.13)", () => {
+  for (const [name, src, expected] of cases) {
+    it(name, async () => {
+      expect(await runBool(src)).toBe(expected);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Adds the ECMA-262 §7.2.13 IsLooselyEqual **steps 11-12 Object↔primitive arm** to the standalone/WASI (`noJsHost`) loose-equality cascade in `src/codegen/binary-ops.ts`. Sub-issue of #1910 / #1472 R1.

Before this, the standalone cascade handled number/boolean/bigint/string/reference-identity but had **no arm for "exactly one operand is an Object, the other a primitive"**, so under `--target standalone`:
- `new Number(7) == 7` → `false` (should be `true`)
- `new Boolean(true) == 1`, `"1" == new Boolean(true)` → `false`
- `{ valueOf: () => 5 } == 5` → `false`

…all fell through to reference identity.

## Approach

Reuse the already-built native `__to_primitive` engine (#1900/#1917 — **not** forked). Gated on **loose `==`/`!=` only** (strict `===` never coerces, §7.2.16): when exactly one operand is an object (`__typeof_object` XOR via `i32.ne`), reduce both operands in place via `__to_primitive(_, default)`. `__to_primitive` is the identity on a primitive, so only the object side is transformed; the existing primitive cascade then runs on the reduced pair (single ToPrimitive recursion, matching the spec).

The XOR gate is load-bearing:
- **both objects** → §7.2.13 step 1 SameType ⇒ reference identity, never ToPrimitive (`{} == {}` stays `false`).
- **null/undefined** already short-circuit via the earlier `looseNullish` arm.

### Critical hazard handled

`ensureObjectRuntime(ctx)` (registers `__to_primitive`, can add index-shifting late imports) is gated on `isLoose` so the **strict `===` path stays byte-identical**. An unconditional call desynced the in-progress body and regressed #1776 `isSameValue` — caught and fixed before this PR.

## Testing

- New: `tests/issue-1910d-loose-eq-object-primitive.test.ts` (9 cases incl. a strict-no-coerce guard) — all pass.
- 0 regressions across `#1776`, `#1134`, `#1986`, `equality-mixed-types`, `comparison-coercion`, `issue-1917-coercion-plan` suites (the 2 `issue-1320` `arr.entries()` for-of failures and the `helpers.js`-missing files are **pre-existing on baseline**, verified by reverting the change).

## Out of scope (documented follow-up)

Object→**String** reduction cases (`new String("x") == "x"`, `{toString}` vs a string literal) remain blocked by a **separate pre-existing standalone defect**: an `any`/object operand compared `==` against a *statically string-typed* literal mis-coerces the string to `__box_number(__str_to_number(s))` = NaN. This reproduces with **no objects** — `function eq(a:any){return a=="ab";} eq("ab")` returns `false` in standalone while `a==="ab"` (strict) returns `true`. Tracked in the issue file as a distinct operand-lowering bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)