### PR TITLE
feat(#2101a R5): standalone own-field storage on externref-backed Error subclass

### DIFF
--- a/plan/issues/2101a-externref-subclass-ownfield.md
+++ b/plan/issues/2101a-externref-subclass-ownfield.md
@@ -1,0 +1,108 @@
+---
+id: 2101a
+slug: externref-subclass-ownfield
+title: "standalone: own fields on externref-backed Error subclass TRAP construction (this.code=42 casts $Error to $A)"
+status: done
+completed: 2026-06-19
+assignee: sdev-boxrep
+sprint: Backlog
+parent: 2101
+created: 2026-06-19
+priority: low
+feasibility: hard
+reasoning_effort: max
+area: codegen
+language_feature: classes, error-subclass, standalone
+goal: standalone-mode
+related: [1472, 2188, 1536c, 1366a]
+origin: "2026-06-19 — #1472 R5 delta (arch-dynshape). Measure-first found the gap is a CONSTRUCTION TRAP, not silent-0; message/instanceof ALSO break when an own field is declared."
+---
+
+## Problem (measure-first — sharper than the original spec)
+
+`class A extends Error { code = 0; constructor(m){ super(m); this.code = 42 } }`
+in `--target standalone`:
+
+- `new A("z").code` → **TRAPS** (not silent 0 as the spec assumed).
+- `new A("z") instanceof Error` → **TRAPS**.
+- `new A("z").message` → **TRAPS**.
+
+i.e. declaring ANY own field on an externref-backed Error subclass corrupts
+*construction itself*, so message/name/stack + instanceof (which the spec
+claimed were unaffected) ALSO break. The instance is never validly produced.
+
+A subclass with NO own fields works fine (message + instanceof OK) — confirming
+the trigger is the own-field read/write codegen, not the Error-backing.
+
+## Root cause (from WAT)
+
+An Error subclass instance IS a `$Error_struct` (built by `__new_<Error>` via
+the `super()` chain; branded with `userClassId` field 4 — #2188). It has NO
+general property storage.
+
+The class ALSO gets a vestigial user struct `$A (struct $__tag i32, $code f64)`
+(struct registration bookkeeping, #1366a keeps `parentStructTypeIdx` undefined).
+The own-field assignment `this.code = 42` in the ctor body lowers through the
+ordinary member-assignment path (`assignment.ts`), which does:
+
+```
+local.get self            ;; the $Error_struct externref
+any.convert_extern
+ref.test  $A              ;; false — self is $Error_struct, not $A
+(if (result (ref null $A)) (then ref.cast $A) (else ref.null $A))
+... struct.set $A $code   ;; receiver is null → ref.is_null → throw TypeError
+```
+
+The `ref.test $A` is false, the else-branch yields `ref.null $A`, and the
+null-receiver guard throws. Construction aborts → the instance is never
+returned → every downstream read traps. The own-field READ path
+(`property-access.ts`) has the same `ref.cast $A` hazard.
+
+`emitOwnInstanceFieldInitializers` (class-bodies.ts ~L1674) DOES bail for
+externref-backed classes, but the ctor-BODY assignment `this.code = …` is a
+separate path that does not.
+
+## Fix (rep signed off — $Object-promotion via one trailing field on $Error_struct)
+
+Add ONE trailing `props: ref null $Object` field to `$Error_struct`
+(error-types.ts). Only ONE `struct.new $Error_struct` site exists
+(`emitWasiErrorConstructor`, error-types.ts ~L171) — it supplies `ref.null`.
+The brand/instanceof sites (class-bodies.ts ~L448, identifiers.ts ~L1178) only
+`struct.get/set` existing fields 0/4, untouched.
+
+Route own-field read/write on an externref-backed Error subclass through the
+LANDED open-`$Object` runtime instead of `$A`:
+- WRITE (`this.f = v`): `__obj_set(self.props ??= new $Object(), "f", box(v))`.
+- READ (`this.f` / `inst.f`): the message/name/stack struct fast-path stays
+  FIRST (zero-cost); an unknown own field routes through
+  `__obj_get(self.props)` (null/undefined when props is null).
+
+Scope R5 v1 to `$Error_struct` only (Error family). Map/Set/Promise/WeakMap
+follow-up.
+
+## Hazard
+
+Adding `props` shifts NO funcidx (struct fields positional), but the `struct.new`
+site must supply `ref.null` and the field must be registered with the type from
+the start — never push a field mid-class-collection (type-index-shift /
+dead-elim remap hazard, [[project_type_index_shift_and_deadelim]]).
+
+## Acceptance (R5 v1 — all passing)
+
+- `new A("z").code === 42` (own field on the instantiated Error subclass)
+- multiple own fields independent (`a.x`, `a.y`)
+- a subclass that declares its OWN field + ctor stores it (`class D extends A {
+  code }`)
+- inherited `.message` + `instanceof Error` survive when an own field is
+  declared — these were REGRESSED (construction trapped); this fix restores them.
+
+## Out of scope (deferred — #2188-family construction threading)
+
+`class D extends A {}` where the own field is declared on the ANCESTOR `A`
+(not on D) and D has only an IMPLICIT derived ctor: `new D("z").code` is still 0.
+Root cause is orthogonal to the R5 storage rep — the implicit `D_new` threads
+super() straight through the builtin ancestor's `__new_<Error>` and never runs
+A's constructor body (where `this.code = 42` lives), so the write never executes.
+That is the #2188 multi-level ctor-body-threading problem (see TaskList #48), not
+the own-field representation. The storage rep is correct: once A's body runs,
+the field lands. Filed as a follow-up.

--- a/plan/issues/2101b-externref-ancestor-implicit-ctor-fieldinit.md
+++ b/plan/issues/2101b-externref-ancestor-implicit-ctor-fieldinit.md
@@ -1,0 +1,75 @@
+---
+id: 2101b
+slug: externref-ancestor-implicit-ctor-fieldinit
+title: "standalone: implicit derived ctor on externref-backed subclass skips ancestor field-init (new D().code=0 where A declares the field)"
+status: ready
+sprint: Backlog
+parent: 2101
+priority: low
+feasibility: hard
+reasoning_effort: max
+area: codegen
+language_feature: classes, error-subclass, construction-abi
+goal: standalone-mode
+related: [2101, 2188, 1965, 1366a, 1536c]
+origin: "2026-06-19 — residual found while landing #2101a R5 (PR #1775). Containment-assessed: deep construction-ABI, NOT a contained fix."
+---
+
+## Problem
+
+After #2101a (PR #1775) gave externref-backed Error subclasses an own-field
+backing, the DIRECT case works (`class A extends Error { code }; new A().code`)
+and a subclass that declares its OWN field + ctor works. But the **inherited**
+case still returns 0:
+
+```ts
+class A extends Error { code = 0; constructor(m){ super(m); this.code = 42 } }
+class D extends A {}                 // implicit derived ctor
+new D("z").code                      // → 0  (want 42)
+```
+
+## Root cause (containment-assessed — NOT a contained fix)
+
+The implicit derived ctor for an externref-backed subclass
+(`class-bodies.ts` ~L1575, the `if (!ctor && isExternrefBacked)` arm) forwards
+its synthetic params straight to `__new_<builtinAncestor>(...)` (e.g.
+`__new_Error`) and **never runs A's constructor body** — where `this.code = 42`
+lives. So `D`'s instance is a fresh `$Error_struct` with `$props == null`, and
+`d.code` reads undefined → 0.
+
+Crucially, externref-backed classes have **no `_init` function**: the init-split
+(`${className}_init`, which the struct-class implicit ctor at ~L1626 *does* call
+via `implicitParentInitIdx`) is explicitly gated OUT for externref-backed
+classes (`class-bodies.ts` ~L827, `if (!isExternrefBackedClass) { …register
+_init… }`). So there is no `A_init` for `D_new` to call.
+
+Fixing this requires one of:
+1. **Build an `_init`-style ABI for externref-backed classes** so `A`'s field
+   initializers + ctor body run on a caller-allocated instance, and `D_new`
+   calls `A_init(args…, self)`. This is the externref-backed analog of the
+   #1965 struct init-split — a construction-ABI change with broad blast radius
+   (every externref-backed ctor + super() site).
+2. **Re-introduce the inline AST-replay** of ancestor field-inits + mined
+   `this.x = …` assignments — explicitly REMOVED for struct classes (#1965,
+   class-bodies.ts ~L1623) because it skipped every non-assignment statement of
+   the ancestor ctor body. Re-adding it for externref-backed classes would
+   re-introduce that latent correctness gap.
+
+Both are deep class-construction-ABI work, beyond the #2101a R5 "own-field
+storage rep" scope. The R5 storage rep is CORRECT — once A's body runs, the
+field lands in `$props`. The gap is purely that A's body never executes for the
+implicit-ctor multi-level case.
+
+## Recommendation
+
+Option 1 (externref-backed `_init` ABI) is the principled fix and dovetails with
+the broader #2188 multi-level construction-threading work. Treat as an
+architect-scale construction-ABI item, not a dev slice. LOW priority — the
+direct + self-declared cases (the common shape) already work via #2101a.
+
+## Repro
+
+`tests/issue-2101a-externref-subclass-ownfield.test.ts` covers the working
+cases. The deferred case (commented in #2101a's issue) is:
+`class A extends Error { code=0; constructor(m){super(m);this.code=42} } class D
+extends A {} ; new D("z").code` → currently 0, want 42.

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -65,6 +65,9 @@ import {
 import { emitMappedArgParamSync, emitMappedArgReverseSync } from "./logical-ops.js";
 import { resolveStructName, resolveStructNameForExpr } from "./misc.js";
 import { tryCompileStandaloneRegExpLastIndexWrite } from "../regexp-standalone.js";
+import { getOrRegisterErrorStructType } from "../registry/error-types.js";
+import { ensureObjectRuntime } from "../object-runtime.js";
+import { stringConstantExternrefInstrs } from "../native-strings.js";
 import { resolveEffectiveStructName } from "../property-access.js";
 import {
   compileStringBuilderAppend,
@@ -2148,6 +2151,98 @@ function emitArrayDestructureFromLocal(
   }
 }
 
+/**
+ * (#2101a R5) Emit an own-field WRITE (`this.code = v` / `inst.code = v`) on an
+ * externref-backed Error subclass, routing through the `$Error_struct.$props`
+ * (fieldIdx 5) open-`$Object` backing instead of the vestigial `$A` struct
+ * (which the receiver is NOT — casting to it traps).
+ *
+ * Lowers to: `props = self.$props; if (props == null) { props =
+ * __new_plain_object(); self.$props = props } __extern_set(props, "code",
+ * box(value))`, returning the RHS as the assignment-expression result.
+ *
+ * Returns the value's ValType on success, or `undefined` when the required
+ * helpers are unavailable (caller falls through to the legacy struct path).
+ */
+function emitExternrefBackedOwnFieldWrite(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  target: ts.PropertyAccessExpression,
+  value: ts.Expression,
+  fieldName: string,
+): ValType | null | undefined {
+  ensureObjectRuntime(ctx);
+  const newObjIdx = ctx.funcMap.get("__new_plain_object");
+  const externSetIdx = ensureLateImport(
+    ctx,
+    "__extern_set",
+    [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }],
+    [],
+  );
+  flushLateImportShifts(ctx, fctx);
+  if (newObjIdx === undefined || externSetIdx === undefined) return undefined;
+  const errStructIdx = getOrRegisterErrorStructType(ctx);
+
+  // self → a TYPED `(ref $Error_struct)` local, cast ONCE. Reused for both the
+  // `$props` read and the lazy-alloc write-back, avoiding repeated
+  // any.convert_extern/ref.cast round-trips (and their stack-typing pitfalls).
+  const selfResult = compileExpression(ctx, fctx, target.expression, { kind: "externref" });
+  if (!selfResult) {
+    reportError(ctx, target, "Failed to compile externref-backed own-field receiver");
+    return null;
+  }
+  if (selfResult.kind !== "externref") fctx.body.push({ op: "extern.convert_any" } as Instr);
+  const selfStructLocal = allocLocal(fctx, `__ownf_self_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: errStructIdx,
+  });
+  const propsLocal = allocLocal(fctx, `__ownf_props_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "any.convert_extern" } as Instr);
+  fctx.body.push({ op: "ref.cast", typeIdx: errStructIdx } as Instr);
+  fctx.body.push({ op: "local.set", index: selfStructLocal });
+
+  // props = self.$props (fieldIdx 5)
+  fctx.body.push({ op: "local.get", index: selfStructLocal });
+  fctx.body.push({ op: "struct.get", typeIdx: errStructIdx, fieldIdx: 5 } as Instr);
+  fctx.body.push({ op: "local.tee", index: propsLocal });
+  // if (props == null) { props = __new_plain_object(); self.$props = props }
+  fctx.body.push({ op: "ref.is_null" } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [
+      { op: "call", funcIdx: newObjIdx } as Instr,
+      { op: "local.set", index: propsLocal } as Instr,
+      // self.$props = props
+      { op: "local.get", index: selfStructLocal } as Instr,
+      { op: "local.get", index: propsLocal } as Instr,
+      { op: "struct.set", typeIdx: errStructIdx, fieldIdx: 5 } as Instr,
+    ],
+    else: [],
+  } as Instr);
+
+  // __extern_set(props, key, box(value))
+  fctx.body.push({ op: "local.get", index: propsLocal });
+  addStringConstantGlobal(ctx, fieldName);
+  fctx.body.push(...stringConstantExternrefInstrs(ctx, fieldName));
+  const valType = compileExpression(ctx, fctx, value);
+  if (!valType) return null;
+  // Box the value to externref for the open-`$Object` store.
+  if (valType.kind !== "externref") {
+    coerceType(ctx, fctx, valType, { kind: "externref" });
+  }
+  // stack: [props, key, value(externref)] — stash the boxed value as the
+  // assignment-expression result before consuming it in the call.
+  const tmpBoxed = allocLocal(fctx, `__ownf_boxed_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.tee", index: tmpBoxed });
+  fctx.body.push({ op: "call", funcIdx: externSetIdx });
+  // The result is the boxed externref. The common `this.code = 42;` statement
+  // drops it; an `x = (this.code = v)` consumer sees the boxed value (externref
+  // is the uniform own-field representation through this backing).
+  fctx.body.push({ op: "local.get", index: tmpBoxed });
+  return { kind: "externref" };
+}
+
 function compilePropertyAssignment(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -2473,6 +2568,19 @@ function compilePropertyAssignment(
       fctx.body.push({ op: "local.get", index: setterTmpVal });
       return setterValResult;
     }
+  }
+
+  // (#2101a R5) Own-field write on an externref-backed Error subclass
+  // (`class A extends Error { code = 0 }`). The instance is the parent's
+  // `$Error_struct` externref, NOT a `$A` WasmGC struct, so the struct.set path
+  // below casts `this` to `$A` and TRAPS at construction. Route the write
+  // through the `$props` backing field (fieldIdx 5) instead: lazily allocate an
+  // open `$Object` on first write, then `__extern_set(props, key, box(value))`.
+  // Standalone only — host mode keeps the host-object machinery.
+  if (ctx.standalone && ctx.classExternrefBackedSet.has(typeName)) {
+    const ownWrite = emitExternrefBackedOwnFieldWrite(ctx, fctx, target, value, fieldName);
+    if (ownWrite !== undefined) return ownWrite;
+    // undefined → not applicable (e.g. helper unavailable); fall through.
   }
 
   const structTypeIdx = ctx.structMap.get(typeName);

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -38,6 +38,7 @@ import { tryCompileNativeMapSizeGet } from "./map-runtime.js";
 import { tryCompileNativeSetSizeGet } from "./set-runtime.js";
 import { tryEmitLinearU8ElementGet, tryEmitLinearU8Length } from "./linear-uint8-codegen.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { ensureObjectRuntime } from "./object-runtime.js";
 import {
   ensureRegExpNativeProtoGlue,
   tryCompileStandaloneRegExpMatchResultRead,
@@ -1255,6 +1256,61 @@ export function emitNullGuardedStructGet(
  *
  * Stack: [externref] -> [fieldType]
  */
+/**
+ * (#2101a R5) Emit an own-field READ (`inst.code`) on an externref-backed Error
+ * subclass, routing through the `$Error_struct.$props` (fieldIdx 5) open-`$Object`
+ * backing instead of the vestigial `$A` struct (which the receiver is NOT).
+ *
+ * Lowers to: `props = self.$props; props == null ? undefined :
+ * __extern_get(props, "code")`, returning the value as externref. message/name/
+ * stack never reach here — they are served by the Error fast-path upstream.
+ *
+ * Returns the result ValType on success, or `undefined` when helpers are
+ * unavailable (caller falls through to the legacy struct read).
+ */
+function emitExternrefBackedOwnFieldRead(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.PropertyAccessExpression,
+  propName: string,
+): ValType | null | undefined {
+  ensureObjectRuntime(ctx);
+  const externGetIdx = ensureLateImport(
+    ctx,
+    "__extern_get",
+    [{ kind: "externref" }, { kind: "externref" }],
+    [{ kind: "externref" }],
+  );
+  flushLateImportShifts(ctx, fctx);
+  if (externGetIdx === undefined) return undefined;
+  const errStructIdx = getOrRegisterErrorStructType(ctx);
+
+  const selfResult = compileExpression(ctx, fctx, expr.expression, { kind: "externref" });
+  if (!selfResult) return null;
+  if (selfResult.kind !== "externref") fctx.body.push({ op: "extern.convert_any" } as Instr);
+
+  // props = self.$props (fieldIdx 5): cast externref → (ref $Error_struct) once.
+  const propsLocal = allocLocal(fctx, `__ownf_rprops_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "any.convert_extern" } as Instr);
+  fctx.body.push({ op: "ref.cast", typeIdx: errStructIdx } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: errStructIdx, fieldIdx: 5 } as Instr);
+  fctx.body.push({ op: "local.tee", index: propsLocal });
+  // props == null ? undefined : __extern_get(props, propName)
+  fctx.body.push({ op: "ref.is_null" } as Instr);
+  addStringConstantGlobal(ctx, propName);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "externref" } },
+    then: [{ op: "ref.null.extern" } as Instr],
+    else: [
+      { op: "local.get", index: propsLocal } as Instr,
+      ...stringConstantExternrefInstrs(ctx, propName),
+      { op: "call", funcIdx: externGetIdx } as Instr,
+    ],
+  } as Instr);
+  return { kind: "externref" };
+}
+
 export function emitExternrefToStructGet(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -3827,6 +3883,19 @@ export function compilePropertyAccess(
       }
       fctx.body.push({ op: "ref.null.extern" });
       return { kind: "externref" };
+    }
+
+    // (#2101a R5) Own-field READ on an externref-backed Error subclass. The
+    // instance is the parent `$Error_struct` externref, NOT a `$A` struct, so
+    // the struct.get-on-`$A` path below traps. message/name/stack were already
+    // handled by the Error fast-path above (~L2227); any other property is a
+    // user-declared own field living in the `$Error_struct.$props` (fieldIdx 5)
+    // open-`$Object` backing. Read it via `__extern_get(self.props, propName)`
+    // (null/undefined when props is null). Standalone only.
+    if (ctx.standalone && ctx.classExternrefBackedSet.has(typeName)) {
+      const ownRead = emitExternrefBackedOwnFieldRead(ctx, fctx, expr, propName);
+      if (ownRead !== undefined) return ownRead;
+      // undefined → helper unavailable; fall through to the legacy path.
     }
 
     // Handle struct field access (named or anonymous)

--- a/src/codegen/registry/error-types.ts
+++ b/src/codegen/registry/error-types.ts
@@ -106,6 +106,19 @@ export function getOrRegisterErrorStructType(ctx: CodegenContext): number {
       // per-subclass construction site, not baked into the shared parent ctor.
       // Kept LAST so fields 0..3 stay stable.
       { name: "userClassId", type: { kind: "i32" }, mutable: true },
+      // (#2101a R5) $props — fieldIdx 5. Backing store for user-declared OWN
+      // fields on an externref-backed Error subclass (`class A extends Error {
+      // code = 0 }`). Such an instance IS this `$Error_struct` (no per-subclass
+      // WasmGC struct), so own fields have nowhere to live — `this.code = …`
+      // previously cast `this` to the vestigial `$A` struct and trapped. Holds
+      // an externref to an open `$Object` (the LANDED object-runtime), lazily
+      // allocated via `__new_plain_object()` on the first own-field write;
+      // reads/writes route through `__extern_get`/`__extern_set`. `ref.null`
+      // until first written. Stored as externref (not `ref null $Object`) to
+      // avoid a forward type-reference to `$Object` here — `$Object` is
+      // registered lazily by the object-runtime, which may run AFTER this
+      // struct. Kept LAST so fields 0..4 stay stable.
+      { name: "props", type: { kind: "externref" }, mutable: true },
     ],
   });
   ctx.errorStructTypeIdx = idx;
@@ -168,6 +181,9 @@ export function emitWasiErrorConstructor(ctx: CodegenContext, errorName: WasiErr
     // parent ctor of a user subclass) carries no per-user-class brand. The
     // subclass `super()` site overwrites this field after construction.
     { op: "i32.const", value: -1 },
+    // $props — (#2101a R5) own-field backing store; null until the subclass's
+    // first own-field write lazily allocates an `$Object` here.
+    { op: "ref.null.extern" },
     { op: "struct.new", typeIdx: structIdx },
     { op: "extern.convert_any" },
   ];

--- a/tests/issue-2101a-externref-subclass-ownfield.test.ts
+++ b/tests/issue-2101a-externref-subclass-ownfield.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2101a R5 — standalone own-field storage on externref-backed Error subclasses.
+//
+// An Error subclass instance IS the parent `$Error_struct` externref (no
+// per-subclass WasmGC struct), so user-declared own fields (`class A extends
+// Error { code = 0 }`) had nowhere to live: `this.code = …` cast `this` to the
+// vestigial `$A` struct and TRAPPED at construction, taking message/instanceof
+// down with it. The fix gives `$Error_struct` a trailing `$props` (fieldIdx 5)
+// open-`$Object` backing, lazily allocated on first own-field write; reads/
+// writes route through `__extern_set`/`__extern_get`.
+async function runNum(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { f: () => number }).f();
+}
+
+describe("#2101a R5 standalone externref-subclass own-field", () => {
+  it("own field reads back the written value", async () => {
+    expect(
+      await runNum(`
+        class A extends Error { code: number = 0; constructor(m: string) { super(m); this.code = 42; } }
+        export function f(): number { const a = new A("z"); return a.code; }
+      `),
+    ).toBe(42);
+  });
+
+  it("multiple own fields are independent", async () => {
+    expect(
+      await runNum(`
+        class A extends Error { x: number = 0; y: number = 0; constructor(m: string) { super(m); this.x = 3; this.y = 5; } }
+        export function f(): number { const a = new A("z"); return a.x * 10 + a.y; }
+      `),
+    ).toBe(35);
+  });
+
+  it("a subclass declaring its own field + ctor stores it", async () => {
+    expect(
+      await runNum(`
+        class A extends Error { constructor(m: string) { super(m); } }
+        class D extends A { code: number = 0; constructor(m: string) { super(m); this.code = 7; } }
+        export function f(): number { const d = new D("z"); return d.code; }
+      `),
+    ).toBe(7);
+  });
+
+  // Regression guards: the own-field write previously TRAPPED construction,
+  // which broke the inherited Error machinery too. These confirm message +
+  // instanceof survive when an own field is present.
+  it("inherited .message still works when an own field is declared", async () => {
+    expect(
+      await runNum(`
+        class A extends Error { code: number = 0; constructor(m: string) { super(m); this.code = 42; } }
+        export function f(): number { const a = new A("hello"); return a.message.length; }
+      `),
+    ).toBe(5);
+  });
+
+  it("instanceof Error still holds when an own field is declared", async () => {
+    expect(
+      await runNum(`
+        class A extends Error { code: number = 0; constructor(m: string) { super(m); this.code = 42; } }
+        export function f(): number { const a = new A("z"); return (a instanceof Error) ? 1 : 0; }
+      `),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2101a R5 — own fields on externref-backed Error subclasses

`class A extends Error { code = 0; constructor(m){ super(m); this.code = 42 } }` **TRAPPED construction** in `--target standalone` (not the silent-0 the spec assumed — measure-first correction). The instance IS the parent `$Error_struct` externref (no per-subclass struct), so `this.code = 42` cast `this` to the vestigial `$A` struct → `ref.test` false → null receiver → TypeError throw at construction, taking `.message` AND `instanceof Error` down with it.

### Fix (rep signed off — `$Object`-promotion via one trailing `$Error_struct` field)
- `error-types.ts`: `$Error_struct` gains a trailing `$props` (fieldIdx 5) externref holding an open `$Object`; the **single** `struct.new $Error_struct` site supplies `ref.null`. Brand/instanceof sites (fields 0/4) untouched.
- `assignment.ts`: own-field WRITE on a `classExternrefBackedSet` class lazily allocates `self.$props` via `__new_plain_object()`, then `__extern_set(props, key, box(value))`.
- `property-access.ts`: own-field READ routes through `__extern_get(self.$props, key)`; `message`/`name`/`stack` keep the upstream Error fast-path.

Standalone-gated, additive. No `struct.new $Error_struct` site other than the ctor; no funcidx shift (positional fields).

### Acceptance (R5 v1 — all green, 5 cases)
- `new A("z").code === 42`; multiple own fields independent; subclass-declared own field + ctor stores it
- `.message` + `instanceof Error` survive when an own field is present (these were REGRESSED by the construction trap — restored here)

### Out of scope (deferred)
`class D extends A {}` where the field is declared on ancestor `A` and D has only an implicit derived ctor: `new D().code` is still 0 — the implicit `D_new` threads super() through `__new_<Error>` and never runs A's ctor body (where the write lives). That's the **#2188 multi-level ctor-body-threading** gap (TaskList #48), orthogonal to the storage rep. The rep is correct; once A's body runs the field lands. Filed as follow-up.

41 Error/subclass regression tests green; coercion-sites gate + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)