### PR TITLE
feat(#2042 S3): standalone Object.fromEntries over string-key array literal

### DIFF
--- a/plan/issues/2511-standalone-anyarray-tuple-nested-access.md
+++ b/plan/issues/2511-standalone-anyarray-tuple-nested-access.md
@@ -1,0 +1,83 @@
+---
+id: 2511
+title: "standalone: any[] of heterogeneous tuples — nested access e[0][1] traps null-deref (#2190 residual)"
+status: done
+assignee: ttraenkler/sdev-arrayrep
+created: 2026-06-19
+updated: 2026-06-19
+completed: 2026-06-19
+priority: medium
+feasibility: medium
+task_type: bugfix
+area: codegen
+language_feature: arrays, array-literal, element-representation
+goal: standalone-mode
+related: [2190, 2106, 2042]
+origin: "TaskList #86; surfaced from #85 Object.fromEntries blocker"
+---
+
+# #2511 — standalone `any[]` of heterogeneous tuples: nested access traps
+
+## Problem (file-verified, current main, `--target standalone`)
+
+```ts
+const e: any[] = [["a", 1], ["b", 2]];
+e[0][1];   // TRAP: "dereferencing a null pointer"
+```
+
+Reading a nested element of an `any[]` whose elements are **heterogeneous tuples**
+(`[string, number]`) traps. Discriminator:
+- `number[][]` → `e[0][1]` WORKS
+- `[string,number][]` (typed) → CE
+- `any[] = [["a",1]]` → `e[0][1]` TRAPS
+
+This is the canonical `Object.fromEntries([["a",1]])` entries shape — and a user
+hand-rolled `for (const p of e) { o[p[0]] = p[1]; }` over the same `any[]` also
+trapped, so it's upstream of `fromEntries` (which it was blocking, #85).
+
+## Root cause (WAT-pinned)
+
+`compileArrayLiteral` (`src/codegen/literals.ts`) infers the inner array's element
+type from the FIRST element. For `["a", 1]` element 0 is `"a"` → the heuristic
+picks `$AnyString` for the whole inner vec. The number `1` then can't be stored
+in a `$AnyString[]`, so codegen emits `f64.const 1; drop` and substitutes
+`ref.null $AnyString; ref.as_non_null` — a guaranteed null-deref when `e[i][1]`
+is later read.
+
+The existing heterogeneity widening only handled a NUMERIC first element with a
+later object/null element (`[0, 1, obj]` → externref via `hasObjectElem`). A
+STRING first element with a later non-string element (`["a", 1]`) fell through and
+stayed `$AnyString[]`.
+
+## Fix
+
+In `compileArrayLiteral`, add a mirror of the `hasObjectElem` widening: when the
+first-element heuristic picked a native-string element type (`$AnyString` /
+`$NativeString`) but the literal contains a NON-string element, widen the vec to
+`externref` so each element is boxed by its own static type at construction
+(`__box_number` / `__box_boolean` / native-string). Scoped to native-strings
+mode; `number[]` / `string[]` / homogeneous literals are byte-identical.
+
+## Acceptance criteria
+
+1. `any[] = [["a",1]]` → `e[0][1]` reads the number; `e[0][0]` reads the string.
+2. A hand-rolled `for`-loop fromEntries over the `any[]` tuples works end-to-end.
+3. No regression: `number[]`, `string[]`, `number[][]`, all-string `any[]`,
+   flat mixed-scalar `any[]` unchanged.
+
+## Resolution (sdev-arrayrep, 2026-06-19)
+
+One-arm widening per above. MEASURED: `[["a",1],["b",2]]` → `e[1][1]`=2, e[0][1]=1,
+e[0][0].length=1; hand-rolled fromEntries → correct; flat mixed-scalar any[]
+unchanged; number[]/string[]/number[][]/all-string-any[] regressions clean.
+`tests/issue-2190b-anytuple-nested.test.ts` (7) green; #2106/#2190/#786/#2014/#2505
+suites unchanged; `tsc` + coercion gate clean.
+
+**Unblocks #85** — with nested any[]-tuple access fixed, `Object.fromEntries([…])`
+over a literal-array entries arg now iterates correctly (the native helper from
+#85 can land on top).
+
+**Out of scope (separate residual):** a HOMOGENEOUS string sub-array
+(`[["a","b"]]`, a `$AnyString[]` stored into an `any[]`) still traps `e[0][0]` —
+broken on main without this change too; a distinct `$AnyString[]`-in-`any[]`
+read-back layer, not the heterogeneous-tuple fix.

--- a/plan/issues/2513-standalone-object-fromentries-array-literal.md
+++ b/plan/issues/2513-standalone-object-fromentries-array-literal.md
@@ -1,0 +1,74 @@
+---
+id: 2513
+title: "standalone: Object.fromEntries([[\"k\",\"v\"],…]) over a string-key array literal (#2042 S3 residual)"
+status: done
+assignee: ttraenkler/sdev-arrayrep
+created: 2026-06-19
+updated: 2026-06-19
+completed: 2026-06-19
+priority: medium
+feasibility: medium
+task_type: bugfix
+area: codegen
+language_feature: objects, Object.fromEntries
+goal: standalone-mode
+related: [2042, 2190, 1472]
+origin: "TaskList #85 (#2042 S3 residual)"
+---
+
+# #2513 — standalone Object.fromEntries over a string-key array literal
+
+## Problem (current main, `--target standalone`)
+
+```ts
+const o: any = Object.fromEntries([["a", 1], ["b", 2]]);
+o.a;   // refused: "Codegen error: '__object_fromEntries' … not supported"
+```
+
+`Object.fromEntries` of an array literal of pairs was a #1472-Phase-B refusal
+standalone. A native `__object_fromEntries` helper that iterates the entries via
+`__extern_get_idx` only works when the entries arg is a `$ObjVec` (e.g.
+`Object.fromEntries(Object.entries(o))`); a native array LITERAL is a typed vec,
+not a `$ObjVec`, and indexing it through the externref boundary mis-casts.
+
+## Fix
+
+Mirror `compileObjectAssignArg` (the array→`$Object` normalisation Object.assign
+uses): at the `Object.fromEntries` call site (`src/codegen/expressions/calls.ts`),
+when the entries arg is an **array literal of two-element pairs with STRING keys**,
+NORMALISE it into a `$ObjVec` of pair `$ObjVec`s
+(`__objvec_new`/`__objvec_push`), then hand the native `__object_fromEntries`
+helper that indexable shape. The helper builds the `$Object` via `__extern_set`
+(which ToPropertyKeys each key).
+
+Key scoping:
+- `__object_fromEntries` is registered in `ensureObjectRuntime` but **NOT** added
+  to `OBJECT_RUNTIME_HELPER_NAMES` — so the ordinary path (raw arg / Map /
+  non-string-key) keeps REFUSING (compile error) rather than routing native and
+  trapping on the non-`$ObjVec` representation. The call site resolves the helper
+  from `funcMap` only on the safe array-literal-of-string-key-pairs shape.
+- NUMERIC-key literals (`[[1,"a"]]`) and Maps keep the pre-existing refusal — a
+  numeric key round-trips through `__objvec_push`/`__extern_get_idx` and
+  mis-casts in `__to_property_key`; gating to string keys avoids introducing a
+  new trap there. (Numeric-key + Map/iterator are a #2190/iterator follow-up.)
+
+## Acceptance criteria
+
+1. `Object.fromEntries([["a",1],["b",2]])` builds the object standalone (no leak,
+   correct values, key count, last-wins, string/bool/mixed values).
+2. No regression: `Object.fromEntries(Object.entries(o))` ($ObjVec entries)
+   unchanged; the raw/Map/numeric-key shapes keep their compile-error refusal
+   (NOT a new trap).
+
+## Resolution (sdev-arrayrep, 2026-06-19)
+
+Call-site `$ObjVec` normalisation + funcMap-resolved native helper per above.
+MEASURED: `[["a",1]]`→1, multi-pair→2, key-count→3, last-wins→9, string-val→1,
+bool-val→1, mixed→6; `Object.entries` control→7; numeric-key literal still
+refuses (compile error, not a trap). wasm-opt `-O3` passes.
+`tests/issue-2042-fromentries-objvec.test.ts` (8) green; #2042 S1/S3 + object-keys
+suites unchanged (the one pre-existing `non-integer numeric key` failure is broken
+on main without this change). `tsc` + coercion gate clean.
+
+Depends on #2511 (any[]-of-tuple nested access) for the in-branch base, though the
+call-site conversion sidesteps the helper's raw-vec indexing entirely.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -5269,7 +5269,71 @@ function compileCallExpression(
       propAccess.name.text === "fromEntries" &&
       expr.arguments.length >= 1
     ) {
-      const argType = compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "externref" });
+      const entriesArg = expr.arguments[0]!;
+      // (#2042 S3) In standalone, the native `__object_fromEntries` helper iterates
+      // the entries arg + each pair via `__extern_get_idx`, which reliably indexes
+      // only a `$ObjVec`. A native ARRAY-LITERAL of pairs (`[["a",1],["b",2]]`) is
+      // a typed native vec, not a $ObjVec, and indexing it through the externref
+      // boundary mis-casts. So — mirroring `compileObjectAssignArg` for
+      // Object.assign — normalise an array-literal-of-pairs into a $ObjVec of pair
+      // $ObjVecs HERE (push each element's two slots), then hand the helper the
+      // indexable representation. (Map / generic-iterable args keep the old
+      // ordinary-externref path; their native iterator-protocol consumption is a
+      // larger #2190 follow-up.)
+      if (
+        ctx.standalone &&
+        ts.isArrayLiteralExpression(entriesArg) &&
+        entriesArg.elements.length > 0 &&
+        entriesArg.elements.every(
+          (el) =>
+            ts.isArrayLiteralExpression(el) &&
+            el.elements.length === 2 &&
+            // Gate to STRING-typed keys (string literal, or statically-string).
+            // A numeric/boxed key round-trips through __objvec_push/__extern_get_idx
+            // and then mis-casts in __to_property_key (illegal cast) — keep that
+            // (rare) shape on the ordinary path rather than introduce a new trap.
+            (el.elements[0]!.kind === ts.SyntaxKind.StringLiteral ||
+              isStringType(ctx.checker.getTypeAtLocation(el.elements[0]!))),
+        )
+      ) {
+        const { newIdx: objVecNewIdx, pushIdx: objVecPushIdx } = ensureObjVecBuilders(ctx);
+        const outerVecLocal = allocLocal(fctx, `__fe_entries_${fctx.locals.length}`, { kind: "externref" });
+        // outer = __objvec_new()
+        fctx.body.push({ op: "call", funcIdx: objVecNewIdx });
+        fctx.body.push({ op: "local.set", index: outerVecLocal });
+        for (const el of entriesArg.elements) {
+          const pair = el as ts.ArrayLiteralExpression;
+          const pairVecLocal = allocLocal(fctx, `__fe_pair_${fctx.locals.length}`, { kind: "externref" });
+          // pair = __objvec_new()
+          fctx.body.push({ op: "call", funcIdx: objVecNewIdx });
+          fctx.body.push({ op: "local.set", index: pairVecLocal });
+          // __objvec_push(pair, <key>); __objvec_push(pair, <value>)
+          for (const slot of pair.elements) {
+            fctx.body.push({ op: "local.get", index: pairVecLocal });
+            const slotType = compileExpression(ctx, fctx, slot, { kind: "externref" });
+            if (slotType && slotType.kind !== "externref") coerceType(ctx, fctx, slotType, { kind: "externref" });
+            if (slotType === null) fctx.body.push({ op: "ref.null.extern" });
+            fctx.body.push({ op: "call", funcIdx: objVecPushIdx });
+          }
+          // __objvec_push(outer, pair)
+          fctx.body.push({ op: "local.get", index: outerVecLocal });
+          fctx.body.push({ op: "local.get", index: pairVecLocal });
+          fctx.body.push({ op: "call", funcIdx: objVecPushIdx });
+        }
+        fctx.body.push({ op: "local.get", index: outerVecLocal });
+        // __object_fromEntries is registered by ensureObjectRuntime (via
+        // ensureObjVecBuilders above) but is NOT routed via OBJECT_RUNTIME_HELPER_NAMES
+        // (so the ordinary raw-arg path keeps refusing) — resolve it from funcMap.
+        const feIdx = ctx.funcMap.get("__object_fromEntries");
+        if (feIdx !== undefined) {
+          fctx.body.push({ op: "call", funcIdx: feIdx });
+          return { kind: "externref" };
+        }
+        fctx.body.push({ op: "drop" });
+        fctx.body.push({ op: "ref.null.extern" });
+        return { kind: "externref" };
+      }
+      const argType = compileExpression(ctx, fctx, entriesArg, { kind: "externref" });
       if (argType && argType.kind !== "externref") coerceType(ctx, fctx, argType, { kind: "externref" });
       const funcIdx = ensureLateImport(ctx, "__object_fromEntries", [{ kind: "externref" }], [{ kind: "externref" }]);
       flushLateImportShifts(ctx, fctx);

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -3146,6 +3146,38 @@ export function compileArrayLiteral(
         if (hasObjectElem) {
           elemWasm = { kind: "externref" };
         }
+      } else if (
+        ctx.nativeStrings &&
+        ctx.anyStrTypeIdx >= 0 &&
+        (elemWasm.kind === "ref" || elemWasm.kind === "ref_null") &&
+        ((elemWasm as { typeIdx: number }).typeIdx === ctx.anyStrTypeIdx ||
+          (elemWasm as { typeIdx: number }).typeIdx === ctx.nativeStrTypeIdx)
+      ) {
+        // (#2190 residual) The first element is a native string, so the
+        // first-element heuristic picked `$AnyString` for the whole vec — but a
+        // heterogeneous literal like `["a", 1]` (a `[string, number]` tuple,
+        // common as an `Object.fromEntries` entry) then DROPS the non-string
+        // element (`f64.const 1; drop`) and substitutes `ref.null $AnyString;
+        // ref.as_non_null` → a guaranteed null-deref trap on a later read. Mirror
+        // the numeric-first `hasObjectElem` widening: if any element is NOT a
+        // native string, widen the vec to `externref` so each element is boxed by
+        // its own static type (`__box_number`/`__box_boolean`/native-string) at
+        // construction. Scoped to native-strings mode; number[]/struct[] etc. are
+        // untouched (their first element isn't a string).
+        const hasNonStringElem = expr.elements.some((el) => {
+          if (ts.isOmittedExpression(el) || ts.isSpreadElement(el)) return false;
+          if (el.kind === ts.SyntaxKind.StringLiteral) return false;
+          const t = resolveWasmType(ctx, ctx.checker.getTypeAtLocation(el));
+          if (t.kind === "ref" || t.kind === "ref_null") {
+            const ti = (t as { typeIdx: number }).typeIdx;
+            return ti !== ctx.anyStrTypeIdx && ti !== ctx.nativeStrTypeIdx;
+          }
+          // f64 / i32 / externref / etc. — a non-string element.
+          return true;
+        });
+        if (hasNonStringElem) {
+          elemWasm = { kind: "externref" };
+        }
       }
     }
   }

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -4986,6 +4986,93 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     );
   }
 
+  // ── __object_fromEntries(externref entries) -> externref (#2042 S3 residual) ─
+  //
+  // `Object.fromEntries(entries)` where `entries` is a `$ObjVec` of `[key,value]`
+  // pair `$ObjVec`s. Builds a fresh `$Object` and, for each pair, sets
+  // `out[pair[0]] = pair[1]` via `__extern_set` (which ToPropertyKeys the key —
+  // #2042 R2/S1). Iterates via `__extern_length` / `__extern_get_idx` (which
+  // index a `$ObjVec` reliably). The CALL SITE (calls.ts) normalises a literal
+  // array-of-pairs arg into this `$ObjVec`-of-`$ObjVec` shape before calling, so
+  // the helper only ever sees the indexable representation (a raw native vec /
+  // Map is not reliably indexable through `__extern_get_idx` — that's why the
+  // call site converts first, mirroring `compileObjectAssignArg`).
+  //
+  // params: 0=entries(externref) ; locals: 1=len(f64) 2=i(i32) 3=pair 4=key 5=val 6=out
+  {
+    const newPlainObjectIdx = ctx.funcMap.get("__new_plain_object")!;
+    const externLengthIdx = ctx.funcMap.get("__extern_length")!;
+    const externGetIdxIdx = ctx.funcMap.get("__extern_get_idx")!;
+    const externSetIdx2 = ctx.funcMap.get("__extern_set")!;
+    const pairElem = (pairLocal: number, idx: number): Instr[] => [
+      { op: "local.get", index: pairLocal },
+      { op: "f64.const", value: idx },
+      { op: "call", funcIdx: externGetIdxIdx },
+    ];
+    const body: Instr[] = [
+      { op: "call", funcIdx: newPlainObjectIdx },
+      { op: "local.set", index: 6 },
+      { op: "local.get", index: 0 },
+      { op: "call", funcIdx: externLengthIdx },
+      { op: "local.set", index: 1 },
+      { op: "i32.const", value: 0 },
+      { op: "local.set", index: 2 },
+      {
+        op: "block",
+        blockType: { kind: "empty" },
+        body: [
+          {
+            op: "loop",
+            blockType: { kind: "empty" },
+            body: [
+              { op: "local.get", index: 2 },
+              { op: "f64.convert_i32_s" },
+              { op: "local.get", index: 1 },
+              { op: "f64.ge" },
+              { op: "br_if", depth: 1 },
+              // pair = __extern_get_idx(entries, i)
+              { op: "local.get", index: 0 },
+              { op: "local.get", index: 2 },
+              { op: "f64.convert_i32_s" },
+              { op: "call", funcIdx: externGetIdxIdx },
+              { op: "local.set", index: 3 },
+              // key = pair[0]; val = pair[1]
+              ...pairElem(3, 0),
+              { op: "local.set", index: 4 },
+              ...pairElem(3, 1),
+              { op: "local.set", index: 5 },
+              // __extern_set(out, key, val)
+              { op: "local.get", index: 6 },
+              { op: "local.get", index: 4 },
+              { op: "local.get", index: 5 },
+              { op: "call", funcIdx: externSetIdx2 },
+              { op: "local.get", index: 2 },
+              { op: "i32.const", value: 1 },
+              { op: "i32.add" },
+              { op: "local.set", index: 2 },
+              { op: "br", depth: 0 },
+            ],
+          },
+        ],
+      },
+      { op: "local.get", index: 6 },
+    ];
+    registerNative(
+      "__object_fromEntries",
+      [{ kind: "externref" }],
+      [{ kind: "externref" }],
+      [
+        { name: "len", type: { kind: "f64" } },
+        { name: "i", type: { kind: "i32" } },
+        { name: "pair", type: { kind: "externref" } },
+        { name: "key", type: { kind: "externref" } },
+        { name: "val", type: { kind: "externref" } },
+        { name: "out", type: { kind: "externref" } },
+      ],
+      body,
+    );
+  }
+
   // NOTE (#2042 S3): `__defineProperty_desc` (generic
   // `Object.defineProperty(o, k, runtimeDescObj)`) is intentionally NOT
   // registered here yet. Its body would delegate to the working native
@@ -6821,6 +6908,14 @@ export const OBJECT_RUNTIME_HELPER_NAMES: ReadonlySet<string> = new Set([
   "__getOwnPropertyNames",
   "__getOwnPropertySymbols",
   "__object_getOwnPropertyDescriptors",
+  // NOTE (#2042 S3): `__object_fromEntries` is intentionally NOT in this set. The
+  // native helper only iterates a `$ObjVec` of pair `$ObjVec`s, which the
+  // fromEntries call site BUILDS (and calls the helper via funcMap directly) only
+  // for a literal array-of-pairs with string keys. The ordinary path (raw arg /
+  // Map / non-string-key) must keep REFUSING (compile error) — routing it native
+  // here would make `ensureLateImport` register the helper for those args too and
+  // TRAP on the non-$ObjVec representation. So this name stays a refusal; the
+  // call site resolves the registered helper via funcMap only on the safe shape.
   // #1472 Phase C — `x === undefined` / default-parameter / destructuring-default
   // undefinedness check. Native impl is `ref.is_null` (standalone conflates
   // undefined and null, same as __typeof_undefined). This is the single largest

--- a/tests/issue-2042-fromentries-objvec.test.ts
+++ b/tests/issue-2042-fromentries-objvec.test.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2042 S3 residual — standalone `Object.fromEntries([["a", 1], ...])` over a
+// LITERAL array-of-pairs. It previously refused ("Codegen error:
+// '__object_fromEntries' ... not supported in --target standalone"): the native
+// helper iterates entries via `__extern_get_idx`, which reliably indexes only a
+// `$ObjVec` — a native array literal mis-casts through the externref boundary.
+//
+// Fix: mirror `compileObjectAssignArg` — when the entries arg is an array literal
+// of two-element pairs with STRING keys, the call site NORMALISES it into a
+// `$ObjVec` of pair `$ObjVec`s (`__objvec_new`/`__objvec_push`) and hands the
+// native `__object_fromEntries` helper that indexable shape, which builds the
+// `$Object` via `__extern_set` (ToPropertyKeys the key). The raw-arg / Map /
+// non-string-key shapes keep their pre-existing REFUSAL (compile error) — they
+// are NOT routed to the helper, so no new trap is introduced.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runStandalone(source: string): Promise<number> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const env = (r.imports ?? []).filter((i) => i.module === "env").map((i) => i.name);
+  expect(
+    env.filter((n) => n === "__object_fromEntries"),
+    `must not leak host import: ${env.join(", ")}`,
+  ).toEqual([]);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports as unknown as WebAssembly.Imports);
+  return (instance.exports as Record<string, () => number>).run();
+}
+
+const fn = (body: string) => `export function run(): number { ${body} }`;
+
+describe("#2042 S3 — standalone Object.fromEntries over a string-key array literal", () => {
+  it("single pair: o.a === 1", async () => {
+    expect(await runStandalone(fn(`const o: any = Object.fromEntries([["a", 1]]); return o.a as number;`))).toBe(1);
+  });
+
+  it("multiple pairs: o.b === 2", async () => {
+    expect(
+      await runStandalone(fn(`const o: any = Object.fromEntries([["a", 1], ["b", 2]]); return o.b as number;`)),
+    ).toBe(2);
+  });
+
+  it("key count is correct", async () => {
+    expect(
+      await runStandalone(
+        fn(`const o: any = Object.fromEntries([["a", 1], ["b", 2], ["c", 3]]); return Object.keys(o).length;`),
+      ),
+    ).toBe(3);
+  });
+
+  it("duplicate key — last wins", async () => {
+    expect(
+      await runStandalone(fn(`const o: any = Object.fromEntries([["a", 1], ["a", 9]]); return o.a as number;`)),
+    ).toBe(9);
+  });
+
+  it("string value preserved", async () => {
+    expect(
+      await runStandalone(fn(`const o: any = Object.fromEntries([["k", "v"]]); return (o.k as string).length;`)),
+    ).toBe(1);
+  });
+
+  it("boolean value preserved", async () => {
+    expect(
+      await runStandalone(fn(`const o: any = Object.fromEntries([["b", true]]); return (o.b as boolean) ? 1 : 0;`)),
+    ).toBe(1);
+  });
+
+  it("mixed value types", async () => {
+    expect(
+      await runStandalone(
+        fn(
+          `const o: any = Object.fromEntries([["n", 5], ["s", "x"]]); return (o.n as number) + (o.s as string).length;`,
+        ),
+      ),
+    ).toBe(6);
+  });
+
+  // ── regression: $ObjVec entries (Object.entries result) unchanged ──
+  it("Object.fromEntries(Object.entries(o)) still works", async () => {
+    expect(
+      await runStandalone(
+        fn(
+          `const src: any = { x: 7, y: 8 }; const o: any = Object.fromEntries(Object.entries(src)); return o.x as number;`,
+        ),
+      ),
+    ).toBe(7);
+  });
+});

--- a/tests/issue-2190b-anytuple-nested.test.ts
+++ b/tests/issue-2190b-anytuple-nested.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2190-residual — standalone nested element access on an `any[]` whose elements
+// are HETEROGENEOUS tuples (`[["a", 1], ["b", 2]]`, the canonical
+// `Object.fromEntries` entries shape) trapped with "dereferencing a null
+// pointer". The array-literal first-element heuristic picked `$AnyString` for the
+// whole vec (element 0 is "a"), then the number element was emitted as
+// `f64.const 1; drop` and replaced with `ref.null $AnyString; ref.as_non_null`
+// — a guaranteed null-deref on a later read of `e[i][1]`.
+//
+// Fix (literals.ts compileArrayLiteral): when the first-element heuristic picked
+// a native-string element type but the literal contains a NON-string element,
+// widen the vec to `externref` (mirroring the existing numeric-first
+// `hasObjectElem` widening) so each element is boxed by its own static type at
+// construction (`__box_number` / native-string / …). number[] / string[] /
+// homogeneous literals are untouched.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runStandalone(source: string): Promise<number> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports as unknown as WebAssembly.Imports);
+  return (instance.exports as Record<string, () => number>).run();
+}
+
+const fn = (body: string) => `export function run(): number { ${body} }`;
+
+describe("#2190b — standalone nested access on an any[] of heterogeneous tuples", () => {
+  it("any[] of [string,number] tuples: e[0][1] reads the number (was null-deref)", async () => {
+    expect(await runStandalone(fn(`const e: any[] = [["a", 1]]; return e[0][1] as number;`))).toBe(1);
+  });
+
+  it("multiple tuples: e[1][1]", async () => {
+    expect(await runStandalone(fn(`const e: any[] = [["a", 1], ["b", 2]]; return e[1][1] as number;`))).toBe(2);
+  });
+
+  it("the string element of the tuple still reads correctly: e[0][0].length", async () => {
+    expect(await runStandalone(fn(`const e: any[] = [["a", 1]]; return (e[0][0] as string).length;`))).toBe(1);
+  });
+
+  it("a hand-rolled fromEntries over the any[] tuples now works end-to-end", async () => {
+    expect(
+      await runStandalone(
+        fn(
+          `const e: any[] = [["a", 1], ["b", 2]]; const o: any = {}; for (let i = 0; i < e.length; i++) { const p: any = e[i]; o[p[0]] = p[1]; } return o.a as number;`,
+        ),
+      ),
+    ).toBe(1);
+  });
+
+  it("flat mixed-scalar any[] still works (string + number + boolean)", async () => {
+    expect(await runStandalone(fn(`const a: any[] = [1, "x", true]; return (a[1] as string).length;`))).toBe(1);
+    expect(await runStandalone(fn(`const a: any[] = [0, "a"]; return a[0] as number;`))).toBe(0);
+  });
+
+  // ── regression: homogeneous literals untouched ──
+  it("number[] / string[] / number[][] unchanged", async () => {
+    expect(await runStandalone(fn(`const a = [1, 2, 3]; return a[1];`))).toBe(2);
+    expect(await runStandalone(fn(`const a = ["x", "yy"]; return a[1].length;`))).toBe(2);
+    expect(await runStandalone(fn(`const e: number[][] = [[1, 2]]; return e[0][1];`))).toBe(2);
+  });
+
+  it("all-string any[] unchanged", async () => {
+    expect(await runStandalone(fn(`const a: any[] = ["x", "y"]; return (a[0] as string).length;`))).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2042 S3 residual — standalone `Object.fromEntries([["k","v"],…])` over an array literal

```ts
const o: any = Object.fromEntries([["a", 1], ["b", 2]]);   // was: Codegen-error refusal (standalone)
```

`Object.fromEntries` of an array literal of pairs was a #1472-Phase-B refusal standalone. The native `__object_fromEntries` helper iterates entries via `__extern_get_idx`, which reliably indexes only a `$ObjVec` — a native array **literal** is a typed vec, not a `$ObjVec`, and indexing it through the externref boundary mis-casts. (`Object.fromEntries(Object.entries(o))` already worked, because that's a `$ObjVec`.)

### Fix
Mirror `compileObjectAssignArg` (Object.assign's array→`$Object` normalisation): at the `Object.fromEntries` call site (`src/codegen/expressions/calls.ts`), when the entries arg is an **array literal of two-element pairs with STRING keys**, normalise it into a `$ObjVec` of pair `$ObjVec`s (`__objvec_new`/`__objvec_push`), then hand the native `__object_fromEntries` helper that indexable shape (it builds the `$Object` via `__extern_set`, which ToPropertyKeys the key).

**No new traps:** `__object_fromEntries` is registered in `ensureObjectRuntime` but **NOT** in `OBJECT_RUNTIME_HELPER_NAMES` — so the ordinary path (raw arg / Map / non-string-key) keeps **refusing** (compile error) rather than routing native and trapping on the non-`$ObjVec` representation. The call site resolves the helper from `funcMap` only on the safe array-literal-of-string-key-pairs shape. Numeric-key literals + Maps keep their pre-existing refusal (a numeric-key/iterator follow-up).

### Measured
`[["a",1]]`→1, multi-pair→2, key-count→3, last-wins→9, string/bool/mixed values; `Object.entries` control→7; numeric-key literal still **refuses** (compile error, not a trap); `wasm-opt -O3` passes.

### Tests / regression
`tests/issue-2042-fromentries-objvec.test.ts` (8) green; `#2042` S1/S3 + object-keys suites unchanged (the one pre-existing `non-integer numeric key` failure is broken on main without this change). `tsc` + coercion gate clean.

> Stacked on #1772 (#2511 any[]-tuple nested access) as a base, but the fromEntries fix is **independent** of #2511's literals.ts change (the call-site conversion sidesteps the helper's raw-vec indexing). Net diff reduces to the fromEntries change once #1772 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)