### PR TITLE
docs(issues): file #2512 Node host-APIs as linkable wasm modules + #2514 runtime helpers as shared module

### DIFF
--- a/plan/issues/2512-node-host-apis-as-separate-linkable-wasm-modules.md
+++ b/plan/issues/2512-node-host-apis-as-separate-linkable-wasm-modules.md
@@ -1,0 +1,76 @@
+---
+id: 2512
+title: "Node.js host APIs as separate, link-on-demand Wasm modules (process, fs, path, …)"
+status: backlog
+sprint: Backlog
+created: 2026-06-19
+updated: 2026-06-19
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: architecture
+area: codegen
+language_feature: node-host-apis
+goal: architecture
+related: [1044, 1046, 2514]
+---
+
+## Problem / proposal
+
+Node.js host-API support (`process`, and future `fs`, `path`, `url`, `os`, …)
+is currently lowered as **inline glue** baked into each compiled module:
+`node-process-api.ts` marshals buffers and emits the WASI syscall (`fd_read` /
+`fd_write`) directly into the user module. There is no separately-compiled,
+reusable Wasm module that implements the Node API surface and gets **linked when
+required**.
+
+Proposal: factor each Node host-API surface into its own linkable Wasm module
+(or host-import interface) that user modules import on demand, instead of
+re-emitting the glue per module. This keeps the user's binary focused on user
+code, lets the host-API implementations version independently, and gives a clean
+seam for the dual-mode story (WASI syscalls vs JS host).
+
+## Why this surface is the tractable half
+
+The IO core already lives outside the user module: `process.stdin/stdout/stderr`
+compile to `wasi_snapshot_preview1.fd_read` / `fd_write` **imports**, satisfied
+by the WASI host — and they're emitted only when `process` is used (DCE). What
+crosses the boundary is **byte buffers + counts** (linear memory + i32), which
+have **no cross-module type identity problem** (unlike GC objects — see #2514).
+So host APIs that pass bytes/scalars can be factored into a shared module or a
+stable host-import interface now, without waiting on WasmGC cross-module type
+sharing.
+
+The js2wasm-side glue that remains inline (buffer marshalling, the
+`process.stdin.read` read-loop shape, argv/env access #1490) is the candidate to
+extract behind a stable interface.
+
+## Scope
+
+- Define a stable host-API interface (Wasm imports / a `node:` runtime module)
+  per supported Node surface, starting with `process`.
+- Emit an *import of* that interface from the user module instead of inline glue,
+  gated on actual usage (preserve current DCE behavior).
+- Keep the dual-mode contract: WASI syscall backing in standalone, JS host
+  backing when a JS runtime is present (cf. #1044 Node-builtins-as-host-imports).
+- Out of scope: GC-typed runtime helpers (number_toString, string/array helpers)
+  — tracked separately in #2514, blocked on the cross-module GC type-identity
+  problem.
+
+## Open questions (route to architect)
+
+- Module-linking vs Component Model vs plain shared host-import namespace — which
+  seam, and how does it interact with `--target wasi` vs JS-host?
+- Relationship to #1044 (Node builtins as host imports) and #1046 (separate
+  ES-module compilation + consumer-driven linking) — is this a generalization of
+  #1044, or a distinct runtime-module layer?
+- Versioning / ABI stability of the interface across compiler versions.
+
+## Notes
+
+Discovered while investigating loopdive/js2#389 (Native Messaging host). For a
+single standalone binary the dedup payoff is small (the inlined glue is exactly
+what that host needs); the win is multi-module reuse and a clean dual-mode seam.
+Pairs with #2514 (runtime helpers as a shared module); split out because the two
+have different blockers — this one is value/byte-typed and tractable now, #2514
+is GC-typed and blocked.

--- a/plan/issues/2514-runtime-helpers-as-shared-linkable-module.md
+++ b/plan/issues/2514-runtime-helpers-as-shared-linkable-module.md
@@ -1,6 +1,6 @@
 ---
 id: 2514
-title: "Runtime helpers (number_toString, string/array/GC helpers) as a shared linkable module — blocked on WasmGC cross-module type identity"
+title: "Runtime helpers (number_toString, string/array/GC helpers) as a shared linkable module via a canonical runtime-type rec-group ABI"
 status: backlog
 sprint: Backlog
 created: 2026-06-19
@@ -13,7 +13,6 @@ area: codegen
 language_feature: runtime-helpers
 goal: architecture
 related: [2512, 1046]
-blocked_by: external
 ---
 
 ## Problem / proposal
@@ -26,50 +25,72 @@ compiled modules this duplicates the same helper code.
 Proposal: compile the runtime helpers once into a shared `runtime.wasm` and have
 user modules **import** them, instead of re-emitting per module.
 
-## The blocker: WasmGC nominal cross-module type identity
+## This is NOT blocked on a missing standard — it's an ABI engineering project
 
-Most of these helpers produce or consume **GC objects** (our strings, vecs,
-boxed values are WasmGC structs/arrays). WasmGC types are matched per-module: a
-String struct defined in `runtime.wasm` and a String struct defined in the user
-module are treated as **different types** even when their layout is identical,
-because identity is by declaring rec-group/canonicalization, not just structure.
-So a helper in a separate module that returns a String cannot hand it back across
-the module boundary — the type check fails.
+Earlier framing (this issue's first draft) called WasmGC "nominal" and treated
+cross-module GC sharing as blocked on a future standard. That was wrong. WasmGC
+is **structural with canonicalization**: the engine canonicalizes rec groups, so
+two **separately-compiled** modules that declare **structurally identical** types
+get the **same** runtime type identity. A `ref.cast` to module A's `String`
+succeeds on an object module B created — *if* the types canonicalize the same.
+So GC objects genuinely can interchange across modules today; no new proposal is
+required.
 
-Plain-English framing: two factories build a Widget from identical blueprints but
-each stamps its own brand; a machine that accepts "Acme Widgets" rejects an
-identical "Beta Widget" because it checks the brand. To interchange them, both
-modules must reference **one shared canonical type definition** (shared rec
-groups / a common type section), which the toolchain and the Component Model do
-not yet coordinate for GC types. This is exactly why the helpers are inlined
-today (so the GC types are always module-local and always match).
+### The actual approach: a canonical, versioned runtime-type rec-group ABI
 
-Contrast: scalar (`i32`/`f64`) and linear-memory (pointer + length) values have
-**no identity**, so helpers that only pass those across the boundary are not
-blocked — those could be split first.
+- Define a **fixed, versioned "js2wasm runtime type rec group"** — the closed set
+  of GC types that cross the boundary (`String`, `Vec`, boxed values, and their
+  transitive dependencies), in a frozen, canonical layout.
+- **Every** artifact emits that exact rec group: `runtime.wasm` (which also
+  exports the helper functions) AND every user module. Structural
+  canonicalization then unifies them, so `runtime.wasm`'s `String` IS the user
+  module's `String` — helpers take/return them with **no copy**.
+- A module links only against a `runtime.wasm` of a **matching ABI version**;
+  any change to a shared type bumps the version.
+
+### The real costs / risks (the crux of the work)
+
+1. **Rec-group granularity.** Our `String`/`Vec`/boxed types are
+   mutually-referential, so canonicalization matches the **entire rec group**,
+   not one type. You share the closed type graph the shared types belong to, not
+   an isolated `String`. Defining a tight, stable boundary group is the design
+   problem.
+2. **Binaryen must preserve the group verbatim.** `wasm-opt` merges, reorders,
+   and optimizes types, which perturbs rec-group structure and breaks canonical
+   equality. Need to pin/disable type-merging for the shared group, or
+   post-process to guarantee byte-stable identity. **This is the main risk.**
+3. **ABI versioning + distribution** of `runtime.wasm` and the matching type
+   group.
+
+### What ships sooner
+
+- **Non-GC helpers** (value-typed / linear-memory: pointer + length, scalars)
+  have no type-identity concern and can be factored into the shared module first.
+- The **linear-memory string backend** (`--nativeStrings` / linear target)
+  sidesteps the GC-string identity problem entirely (memory-typed strings carry
+  no GC identity), so a shared runtime could land there before the WasmGC path.
+
+## Standards context (verify before relying on)
+
+- The Component Model deliberately copies/serializes across component boundaries
+  (Canonical ABI) — it does **not** pass core GC objects across, so it is not the
+  vehicle for a zero-copy shared runtime.
+- An explicit **type-imports / type-import-export** direction would make
+  cross-module type sharing nominal/explicit, but as of 2026-06 its status is
+  unconfirmed here — a web check is queued (see the parent investigation). The
+  canonical-rec-group convention above does NOT depend on it.
 
 ## Scope / phasing
 
-- Phase 0 (research, architect): survey the state of WasmGC cross-module type
-  sharing (shared rec groups, canonical types, Component Model GC ABI) and decide
-  whether a shared-runtime module is feasible yet for GC-typed helpers.
-- Phase 1 (tractable now): factor out **non-GC** helpers — value-typed /
-  memory-based — into a shared module behind a stable interface.
-- Phase 2 (blocked): GC-typed helpers (string/array/boxed), pending a
-  cross-module GC type-identity mechanism.
-
-## Open questions (route to architect)
-
-- Is there a usable shared-rec-group / canonical-type story in current Binaryen +
-  wasmtime + the GC/Component-Model toolchain, or is this strictly future?
-- Does linear-memory string backend (`--nativeStrings` / linear target) change
-  the calculus (memory-typed strings have no GC identity problem)?
-- Dedup payoff is multi-module; quantify against a representative multi-module app
-  before investing.
+- Phase 0 (architect): design the canonical runtime-type rec-group ABI; confirm
+  Binaryen can be made to emit it stably (risk #2).
+- Phase 1: factor out **non-GC** helpers behind a stable interface (no
+  identity concern) — and/or the `--nativeStrings` linear path.
+- Phase 2: GC-typed helpers via the canonical rec-group ABI once #2 is solved.
 
 ## Notes
 
-Split from #2512 (Node host APIs as separate modules). Same overall direction
-("don't inline everything"), but a different blocker: #2512 is byte/scalar-typed
-and tractable now; this one is GC-typed and gated on cross-module type identity.
-Surfaced while investigating loopdive/js2#389.
+Split from #2512 (Node host APIs as separate modules). Different concern: #2512
+is byte/scalar-typed across the boundary and tractable now; this one needs the
+canonical-rec-group ABI + Binaryen cooperation. Surfaced while investigating
+loopdive/js2#389.

--- a/plan/issues/2514-runtime-helpers-as-shared-linkable-module.md
+++ b/plan/issues/2514-runtime-helpers-as-shared-linkable-module.md
@@ -70,15 +70,32 @@ required.
   sidesteps the GC-string identity problem entirely (memory-typed strings carry
   no GC identity), so a shared runtime could land there before the WasmGC path.
 
-## Standards context (verify before relying on)
+## Standards context (checked 2026-06-19)
 
-- The Component Model deliberately copies/serializes across component boundaries
-  (Canonical ABI) — it does **not** pass core GC objects across, so it is not the
-  vehicle for a zero-copy shared runtime.
-- An explicit **type-imports / type-import-export** direction would make
-  cross-module type sharing nominal/explicit, but as of 2026-06 its status is
-  unconfirmed here — a web check is queued (see the parent investigation). The
-  canonical-rec-group convention above does NOT depend on it.
+- **Engine-level canonicalization already solves cross-module GC type identity —
+  and it is shipped.** Per the WasmGC design and V8's implementation, the engine
+  canonicalizes *all* types from *all* modules in an isolate into a single global
+  type index; a struct type from module M1 is **equivalent** to a structurally
+  identical struct from M2 (isorecursive type canonicalization). So structurally
+  identical rec groups across separately-compiled modules unify to the same
+  runtime type today — which is exactly what makes the canonical-rec-group ABI
+  above viable without any new standard.
+  Refs: WasmGC overview <https://github.com/WebAssembly/gc/blob/main/proposals/gc/Overview.md>,
+  isorecursive canonicalization discussion <https://github.com/WebAssembly/gc/issues/292>.
+  **Engine-maturity asterisk:** this canonicalizer is security-sensitive and has
+  had real bugs (a Chrome RCE was filed against the cross-module
+  type-canonicalization machinery) — validate behavior on target engines.
+- **The Component Model is NOT the vehicle.** Its in-flight shared-module design,
+  Shared-Everything Dynamic Linking
+  <https://github.com/WebAssembly/component-model/blob/main/design/mvp/examples/SharedEverythingDynamicLinking.md>,
+  is the `.dll`/`.so`-style mechanism — but it is **purely linear-memory based and
+  does not address WasmGC types**. It shares *code*, not *GC objects*; each
+  instance gets its own memory. GC-object sharing would need separate extensions.
+- **Explicit alternative (not required):** the Type Imports & Exports proposal
+  <https://github.com/WebAssembly/proposal-type-imports> would let a module import
+  a type by reference (abstract/nominal sharing) and is slated to become part of
+  the future basis for GC. It is a separate, not-yet-shipped proposal; the
+  canonical-rec-group convention above does **not** depend on it.
 
 ## Scope / phasing
 

--- a/plan/issues/2514-runtime-helpers-as-shared-linkable-module.md
+++ b/plan/issues/2514-runtime-helpers-as-shared-linkable-module.md
@@ -1,0 +1,75 @@
+---
+id: 2514
+title: "Runtime helpers (number_toString, string/array/GC helpers) as a shared linkable module — blocked on WasmGC cross-module type identity"
+status: backlog
+sprint: Backlog
+created: 2026-06-19
+updated: 2026-06-19
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: architecture
+area: codegen
+language_feature: runtime-helpers
+goal: architecture
+related: [2512, 1046]
+blocked_by: external
+---
+
+## Problem / proposal
+
+js2wasm emits its runtime helpers — `number_toString`, `__str_concat`, native
+string/array/vec helpers, boxing helpers, GC struct accessors, etc. — **inline
+into every compiled module** (each only when used, via DCE). Across multiple
+compiled modules this duplicates the same helper code.
+
+Proposal: compile the runtime helpers once into a shared `runtime.wasm` and have
+user modules **import** them, instead of re-emitting per module.
+
+## The blocker: WasmGC nominal cross-module type identity
+
+Most of these helpers produce or consume **GC objects** (our strings, vecs,
+boxed values are WasmGC structs/arrays). WasmGC types are matched per-module: a
+String struct defined in `runtime.wasm` and a String struct defined in the user
+module are treated as **different types** even when their layout is identical,
+because identity is by declaring rec-group/canonicalization, not just structure.
+So a helper in a separate module that returns a String cannot hand it back across
+the module boundary — the type check fails.
+
+Plain-English framing: two factories build a Widget from identical blueprints but
+each stamps its own brand; a machine that accepts "Acme Widgets" rejects an
+identical "Beta Widget" because it checks the brand. To interchange them, both
+modules must reference **one shared canonical type definition** (shared rec
+groups / a common type section), which the toolchain and the Component Model do
+not yet coordinate for GC types. This is exactly why the helpers are inlined
+today (so the GC types are always module-local and always match).
+
+Contrast: scalar (`i32`/`f64`) and linear-memory (pointer + length) values have
+**no identity**, so helpers that only pass those across the boundary are not
+blocked — those could be split first.
+
+## Scope / phasing
+
+- Phase 0 (research, architect): survey the state of WasmGC cross-module type
+  sharing (shared rec groups, canonical types, Component Model GC ABI) and decide
+  whether a shared-runtime module is feasible yet for GC-typed helpers.
+- Phase 1 (tractable now): factor out **non-GC** helpers — value-typed /
+  memory-based — into a shared module behind a stable interface.
+- Phase 2 (blocked): GC-typed helpers (string/array/boxed), pending a
+  cross-module GC type-identity mechanism.
+
+## Open questions (route to architect)
+
+- Is there a usable shared-rec-group / canonical-type story in current Binaryen +
+  wasmtime + the GC/Component-Model toolchain, or is this strictly future?
+- Does linear-memory string backend (`--nativeStrings` / linear target) change
+  the calculus (memory-typed strings have no GC identity problem)?
+- Dedup payoff is multi-module; quantify against a representative multi-module app
+  before investing.
+
+## Notes
+
+Split from #2512 (Node host APIs as separate modules). Same overall direction
+("don't inline everything"), but a different blocker: #2512 is byte/scalar-typed
+and tractable now; this one is GC-typed and gated on cross-module type identity.
+Surfaced while investigating loopdive/js2#389.


### PR DESCRIPTION
Two separate architecture issues for modularizing what's currently inlined into every compiled module (split because they have different blockers). Surfaced while investigating loopdive/js2#389.

**#2512 — Node.js host APIs as separate, link-on-demand wasm modules** (process/fs/path/…). What crosses the boundary is byte buffers + counts (linear memory + scalars), which have no cross-module type-identity problem — so this is tractable now (the IO core already factors out via `wasi_snapshot_preview1.fd_read`/`fd_write` imports). Related: #1044, #1046.

**#2514 — runtime helpers (number_toString, string/array/GC helpers) as a shared linkable module.** Blocked on **WasmGC nominal cross-module type identity**: separately-compiled modules treat identical GC struct/array types as different types unless they share canonical rec-groups, which the toolchain/Component-Model don't coordinate yet — which is why these helpers are inlined today. Non-GC helpers could be split first.

Both are `status: backlog`, `feasibility: hard`, routed to architect. Docs-only: two new issue files, no source changes.