### PR TITLE
ci(#2519): debounce idempotent sweep workflows (cut redundant runs)

### DIFF
--- a/.github/workflows/auto-enqueue.yml
+++ b/.github/workflows/auto-enqueue.yml
@@ -49,7 +49,10 @@ permissions:
 
 concurrency:
   group: auto-enqueue
-  cancel-in-progress: false
+  # Idempotent sweep: the latest run enqueues every mergeable PR, so a burst of
+  # triggers should collapse to the most-recent run rather than serial-running
+  # each one (#2519 — cut redundant workflow runs). Safe to cancel in-flight.
+  cancel-in-progress: true
 
 jobs:
   enqueue:

--- a/.github/workflows/baseline-floor-staleness-alert.yml
+++ b/.github/workflows/baseline-floor-staleness-alert.yml
@@ -53,10 +53,12 @@ permissions:
   actions: write # gh workflow run refresh-baseline.yml (auto-heal)
 
 concurrency:
-  # Serialize the check; never cancel an in-flight one. Cheap job, so a queued
-  # backlog collapses to the latest (which is what we want — latest-wins).
+  # Latest-wins: an alert sweep is idempotent, so collapse a burst of triggers
+  # to the most-recent run. The prior comment said "collapses to the latest"
+  # but the setting was cancel-in-progress:false (which serial-runs each) — this
+  # aligns the setting with the documented intent and cuts redundant runs (#2519).
   group: baseline-floor-staleness-alert
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   check-floor:

--- a/plan/issues/2519-reduce-ci-workflow-runs.md
+++ b/plan/issues/2519-reduce-ci-workflow-runs.md
@@ -1,0 +1,88 @@
+---
+id: 2519
+title: "reduce redundant CI workflow runs (debounce idempotent sweeps + heavy test262 merge_group-only)"
+status: in-progress
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: ci
+area: ci
+goal: dev-velocity
+sprint: 64
+related: [2517]
+---
+
+# #2519 — Reduce redundant CI workflow runs
+
+## Problem
+
+During the 2026-06-19 merge-queue incident, workflow-run volume was very high
+(~70 runs/hr): `Auto-enqueue green PRs` 26×, `Approve trusted-fork runs` 30×,
+`Baseline floor staleness alert` 15×, vs only 1× `Test262 Sharded` / 1× `CI`.
+High event volume can contribute to GitHub soft-throttling webhook/event
+delivery (which manifested as merge_group events not firing). Separately, the
+heavy 57-shard test262 matrix runs **twice per PR** — once on `pull_request`
+(pre-queue validation) and again on `merge_group` (final gate) — doubling the
+most expensive CI cost.
+
+Two independent reductions:
+
+## Part 1 — debounce idempotent sweeps (DONE in this PR)
+
+`auto-enqueue.yml` and `baseline-floor-staleness-alert.yml` are **idempotent
+sweeps** (the latest run covers everything), but used `concurrency:
+cancel-in-progress: false`, which serial-runs every queued trigger instead of
+collapsing a burst to the most-recent run. Flipped both to
+`cancel-in-progress: true` (latest-wins). The baseline-alert's own comment
+already described latest-wins behaviour — the setting was simply mis-set.
+
+**Deliberately NOT changed: `approve-fork-runs.yml`.** Cancelling that workflow
+mid-run can drop a fork PR's run-approval and strand its CI, so it stays
+`cancel-in-progress: false`.
+
+## Part 2 — heavy test262 merge_group-only (SPEC — careful follow-up)
+
+Goal (stakeholder): *"only run CI on PRs when they are in front of the merge
+queue, to avoid duplicated runs."* Make the heavy `test262-shard` job
+(57-shard matrix) run **only** in `merge_group` (when the PR reaches the front
+of the queue and is about to merge) + `push` (baseline) + `workflow_dispatch`,
+**not** on `pull_request`. This halves the most expensive CI per PR.
+
+### Approach
+- In `.github/workflows/test262-sharded.yml`, remove the `pull_request` arm
+  from the `test262-shard` job's `if:` (lines ~337-341), keeping
+  `merge_group` / `push` / `workflow_dispatch`.
+- Keep the **cheap gate** (typecheck + lint, `cheap gate (main-ancestor +
+  lint)`) on `pull_request` — it's fast and gives authors early feedback at
+  negligible cost.
+- The required check **`merge shard reports`** must **green-skip on
+  `pull_request`** (since the shards no longer run there) so a PR is mergeable/
+  enqueueable, mirroring the existing merge_group no-shards skip path (see the
+  aggregate-job comment ~L312-315). In `merge_group` it runs the real shards.
+- Confirm ruleset `16700772` ("main: merge queue + required checks") sources
+  the required contexts from the **merge_group** run (it should — it is the
+  merge-queue ruleset). The PR enqueues without the heavy check having run at
+  PR-time; the merge_group produces it.
+
+### Trade-offs (must be acknowledged)
+- **No early heavy validation**: a PR with a real test262 regression is caught
+  only when it reaches the merge_group → it fails there and is ejected,
+  feedback is later than PR-time. Acceptable: the merge_group is the
+  authoritative gate; the PR-time run was duplicative pre-validation.
+- **More dependent on merge_group delivery**: if merge_group webhooks are
+  down (the #2517 / 2026-06-19 incident), NO heavy validation runs at all.
+  The cheap gate still runs at PR-time, limiting blast radius.
+
+### Validation (REQUIRED before merge)
+This changes the required-checks gate — a misconfiguration can block ALL
+merges (required check never satisfied) or let unvalidated PRs through.
+**Canary-test on a throwaway PR** (confirm: PR shows cheap-gate green +
+`merge shard reports` green-skipped; PR enqueues; merge_group runs the real
+shards; merges only when green) **before merging this change.** The canary
+needs a healthy merge queue, so Part 2 lands after the current wedge clears.
+
+## Acceptance criteria
+- [x] Part 1: `auto-enqueue` + `baseline-floor-staleness-alert` use
+      `cancel-in-progress: true`; `approve-fork-runs` unchanged.
+- [ ] Part 2: heavy `test262-shard` skips `pull_request`; `merge shard
+      reports` green-skips at PR-time; canary-validated; ruleset confirmed.


### PR DESCRIPTION
Part 1 (this PR): flip `auto-enqueue` + `baseline-floor-staleness-alert` to `concurrency: cancel-in-progress: true` — they're idempotent sweeps, so a burst of triggers should collapse to the latest run instead of serial-running each. Cuts redundant workflow runs (the 2026-06-19 queue incident saw ~70 runs/hr). `approve-fork-runs` intentionally left `false` (cancelling it mid-run can strand a fork PR's approval).

Part 2 (spec'd in #2519, NOT in this PR): make the heavy 57-shard test262 matrix run only in `merge_group` (when a PR is at the front of the queue) instead of also on `pull_request` — halves the most expensive CI per PR. It changes the required-checks gate, so it must be canary-validated on a healthy queue before merging; tracked as a follow-up.

Issue: #2519

🤖 Generated with [Claude Code](https://claude.com/claude-code)