### PR TITLE
docs(issues): file #2521 native-messaging re-chunk continuation marker

### DIFF
--- a/plan/issues/2521-native-messaging-rechunk-continuation-marker.md
+++ b/plan/issues/2521-native-messaging-rechunk-continuation-marker.md
@@ -121,10 +121,15 @@ caught loopdive/js2#389 and guards whichever fix (A or B) lands.
 
 ## Acceptance criteria
 
-- **Test (required):** a runtime test drives the actual example host and (a) a
-  >1 MiB message emits N ≤1 MiB frames, and (b) a multi-message sequence (>1 MiB
-  then small messages) is reassembled by a correct receiver with no desync. Fails
-  on current main (proving it reproduces #389), passes after the chosen fix.
+- **Test (DONE — `tests/issue-2521-native-messaging-rechunk.test.ts`):** drives
+  the actual example host via the `runWasiRaw` shim and covers the reporter's
+  cases — (a) ≤1 MiB message echoes verbatim in one frame, (b) a >1 MiB array is
+  split into N ≤1 MiB valid-JSON-array frames that reassemble to the original,
+  (c) the reporter's multi-message sequence (big then `"test"`/`""`/`1`/`{"0":97}`)
+  reassembles with every frame accounted for (no desync). Passes on current main
+  — it documents that the host's stream is correct/reassemblable and the #389
+  failure is the harness's 1:1 assumption, and gives the runtime coverage the
+  re-chunk path lacked. (If Option B lands, update it to the envelope shape.)
 - **Option A:** the reporter's `nm_standalone_test.js` sequence (64 MiB + ≤1 MiB
   messages), updated to reassemble-to-expected-size, round-trips cleanly — no host
   change.

--- a/plan/issues/2521-native-messaging-rechunk-continuation-marker.md
+++ b/plan/issues/2521-native-messaging-rechunk-continuation-marker.md
@@ -1,7 +1,7 @@
 ---
 id: 2521
-title: "Native Messaging host: re-chunked >1 MiB messages need an in-body continuation marker so the receiver can reassemble"
-status: ready
+title: "Native Messaging host: re-chunked >1 MiB messages desync a 1:1 receiver — contract gap (receiver reassembly vs in-body continuation marker) + missing runtime test"
+status: backlog
 sprint: Backlog
 created: 2026-06-20
 updated: 2026-06-20
@@ -43,60 +43,99 @@ The host wasm logic is otherwise correct (single messages of any size, and the
 full sequence via buffered/Node-pipe I/O, all round-trip cleanly). The gap is
 the **re-chunk contract**, not codegen.
 
-## Decision: in-body continuation marker (chosen over sender-waits-for-size)
+## This is a contract gap, fixable on EITHER side — two options
 
-A "sender knows the expected size, wait for the full echo" fix only covers
-request/response echo. A **continuation marker** fixes the general case
-(including an extension receiving an unsolicited large broadcast), so it's the
-chosen approach.
+It is **not** strictly a host defect. The fix can live entirely on the receiver,
+or on the host. Pick based on whether there is a non-echo consumer.
 
-**Constraint:** the marker MUST live inside the JSON body. In the browser Chrome
-owns the 4-byte framing and delivers each frame to the extension already
-JSON-parsed, so the length prefix's bits are unavailable — only the message
-*value* survives to the receiver.
+### Option A — receiver reassembles to expected size (no host change)
 
-### Recommended frame shape — envelope per frame
+For an **echo in request/response**, the sender knows exactly what it sent, so it
+can reassemble with **no marker**: read frames and concatenate `chunk` elements
+until the reassembled length equals the sent length, then send the next message.
+The expected size *is* the termination condition. The reporter's harness can do
+this unilaterally (loop in `echoNativeMessage` until `got.length === sent.length`;
+also lift its 1 MiB `buffer` cap). **If the reporter fixes his side this way, no
+host change is needed — prefer this and skip Option B.**
+
+Limitation: only works when the receiver originated the message (it knows the
+size). A receiver that didn't send it (an extension getting an unsolicited large
+broadcast) has no termination condition without a marker.
+
+### Option B — host emits an in-body continuation marker (general case)
+
+Needed only if there's a consumer that can't predict the size (broadcast), or as
+a convenience so receivers don't each track expected sizes. Each frame becomes an
+envelope:
 
 ```json
 { "chunk": [ …slice… ], "more": true  }   // non-final frame
 { "chunk": [ …slice… ], "more": false }   // final frame
 ```
 
-- Receiver reassembles by concatenating `chunk` (array elements) until
-  `more:false`. No need to know the total up front.
-- Single-frame (≤1 MiB) messages emit one envelope with `more:false`, for a
-  uniform receiver path. (Alternative: keep ≤1 MiB messages verbatim and only
-  envelope multi-frame, with the receiver branching on shape — uniform is
-  simpler and unambiguous; pick during implementation.)
-- Each envelope must stay ≤1 MiB: drop `MAX_RUN` by the envelope overhead
-  (`{"chunk":` … `,"more":true}` ≈ 25 bytes) so a full frame including the
-  wrapper never exceeds the cap.
-- Open design choice (architect): plain `{chunk,more}` vs a
-  `{seq,total,chunk}` form (explicit index/total — more robust, slightly larger).
+Receiver concatenates `chunk` until `more:false` — no size needed.
+
+**Constraint:** the marker MUST live inside the JSON body. In the browser Chrome
+owns the 4-byte framing and delivers each frame to the extension already
+JSON-parsed, so the length prefix's bits are unavailable — only the message
+*value* survives to the receiver. (Each envelope must stay ≤1 MiB → drop
+`MAX_RUN` by the ~25-byte envelope overhead.)
+
+### Decision
+
+Default to **Option A** (receiver-side). Only implement **Option B** if a
+non-request/response consumer needs it. Track but don't build Option B until then.
+
+If Option B is built: single-frame (≤1 MiB) messages emit one envelope with
+`more:false` for a uniform receiver path (alternative: keep ≤1 MiB verbatim and
+only envelope multi-frame — pick during implementation). Open design choice
+(architect): plain `{chunk,more}` vs `{seq,total,chunk}` (explicit index/total).
+
+## Test coverage gap (the reason this slipped through — fix regardless of A/B)
+
+Today **nothing runs the example host's re-chunk path**:
+- `tests/issue-1530.test.ts` first block is **compile-only** (module validity,
+  imports) — explicitly does not assert content.
+- Its `#1618/#1651` round-trip block runs a **toy inline host** (not the example's
+  `emitRun`/re-chunk loop) and feeds a **single 7-byte message** (`frame('{"a":1}')`).
+- So the >1 MiB re-chunking path and any **multi-message sequence** have zero
+  runtime coverage — exactly where the desync lives.
+
+Add a runtime test that drives the **actual example host** (via the existing
+`runWasiRaw` shim) with: (a) a >1 MiB message → assert it emits N ≤1 MiB frames,
+and (b) a **multi-message sequence** (a >1 MiB message followed by small ones) →
+assert a correct receiver reassembles each without desync. This test would have
+caught loopdive/js2#389 and guards whichever fix (A or B) lands.
 
 ## Scope
 
-- `examples/native-messaging/nm_js2wasm.ts`: `emitRun` (and the ≤1 MiB echo
-  path, if uniform) wrap output in the envelope; shrink `MAX_RUN` for headroom.
-- `examples/native-messaging/README.md`: document the marker + receiver
-  reassembly contract.
-- `examples/native-messaging/nm_js2wasm.sh` / background.js example: show the
-  reassembling receiver.
-- Tests: `tests/issue-1530.test.ts`, `tests/wasi-stdin.test.ts` — assert each
-  emitted frame is ≤1 MiB valid JSON carrying the marker, and that reassembly
-  reproduces the original.
+- **Test (do regardless):** add the runtime multi-message + >1 MiB re-chunk test
+  above to `tests/issue-1530.test.ts`.
+- **Option A (default):** update `examples/native-messaging/nm_standalone_test.js`
+  guidance / the README to reassemble-to-expected-size; lift the receiver's 1 MiB
+  buffer cap. No host change.
+- **Option B (only if a non-echo consumer needs it):**
+  `examples/native-messaging/nm_js2wasm.ts` `emitRun` wraps output in the
+  envelope + shrink `MAX_RUN`; README documents the marker; the background.js
+  example shows the reassembling receiver.
 
 ## Acceptance criteria
 
-- A >1 MiB request produces N frames, each ≤1 MiB valid JSON with a
-  continuation marker; a receiver that reassembles on the marker reproduces the
-  original message with no desync of subsequent messages.
-- The reporter's `nm_standalone_test.js` sequence (64 MiB + ≤1 MiB messages),
-  updated to reassemble on the marker, round-trips cleanly.
-- ≤1 MiB messages still round-trip (single final-marked frame).
+- **Test (required):** a runtime test drives the actual example host and (a) a
+  >1 MiB message emits N ≤1 MiB frames, and (b) a multi-message sequence (>1 MiB
+  then small messages) is reassembled by a correct receiver with no desync. Fails
+  on current main (proving it reproduces #389), passes after the chosen fix.
+- **Option A:** the reporter's `nm_standalone_test.js` sequence (64 MiB + ≤1 MiB
+  messages), updated to reassemble-to-expected-size, round-trips cleanly — no host
+  change.
+- **Option B (only if built):** each frame is ≤1 MiB valid JSON carrying the
+  marker; a size-agnostic receiver reassembles correctly; ≤1 MiB messages still
+  round-trip.
 
 ## Notes
 
-Surfaced + reproduced while investigating loopdive/js2#389 (with deno installed
-locally to run the reporter's harness). Pairs with the example's existing
-re-chunk design in #1530.
+Surfaced + reproduced while investigating loopdive/js2#389. The reproduction did
+NOT require running the reporter's deno harness — counting the host's emitted
+frames (Node) plus reading the harness's 1-frame-per-request reader was enough;
+deno (installed locally) only added end-to-end fidelity. Pairs with the example's
+existing re-chunk design in #1530.

--- a/plan/issues/2521-native-messaging-rechunk-continuation-marker.md
+++ b/plan/issues/2521-native-messaging-rechunk-continuation-marker.md
@@ -1,0 +1,102 @@
+---
+id: 2521
+title: "Native Messaging host: re-chunked >1 MiB messages need an in-body continuation marker so the receiver can reassemble"
+status: ready
+sprint: Backlog
+created: 2026-06-20
+updated: 2026-06-20
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: feature
+area: examples
+language_feature: native-messaging
+goal: usability
+related: [1530]
+---
+
+## Problem (reproduced)
+
+The Native Messaging example host (`examples/native-messaging/nm_js2wasm.ts`)
+splits any message larger than 1 MiB into multiple ≤1 MiB response frames —
+required, because Chrome caps a host→extension message at 1 MiB. Today each
+re-chunked frame is a bare JSON array (`[run]`) with no marker, so **one logical
+request produces N response frames with nothing tying them together**.
+
+A receiver that expects one response per request (the standalone test harness,
+and a naive extension) therefore desyncs: the big message's extra frames are
+read as the responses to the *following* messages.
+
+Reported on loopdive/js2#389. **Reproduced exactly** under deno 2.8.3 with the
+reporter's `nm_standalone_test.js`:
+
+- 64 MiB request (`Array(209715*64)`): the host emits ~64 frames of
+  `messageLength: 1048571`; the harness reads each as a separate message.
+- 2 MiB request: surfaces as the reporter's exact error
+  `ArrayBuffer.prototype.resize: Invalid length parameter` once the stream
+  desyncs.
+- Matches the reporter's symptom precisely: "64 MiB alone passes, 64 MiB **with**
+  the ≤1 MiB tests fails" — alone, the extra frames drain at EOF with nothing
+  after to desync.
+
+The host wasm logic is otherwise correct (single messages of any size, and the
+full sequence via buffered/Node-pipe I/O, all round-trip cleanly). The gap is
+the **re-chunk contract**, not codegen.
+
+## Decision: in-body continuation marker (chosen over sender-waits-for-size)
+
+A "sender knows the expected size, wait for the full echo" fix only covers
+request/response echo. A **continuation marker** fixes the general case
+(including an extension receiving an unsolicited large broadcast), so it's the
+chosen approach.
+
+**Constraint:** the marker MUST live inside the JSON body. In the browser Chrome
+owns the 4-byte framing and delivers each frame to the extension already
+JSON-parsed, so the length prefix's bits are unavailable — only the message
+*value* survives to the receiver.
+
+### Recommended frame shape — envelope per frame
+
+```json
+{ "chunk": [ …slice… ], "more": true  }   // non-final frame
+{ "chunk": [ …slice… ], "more": false }   // final frame
+```
+
+- Receiver reassembles by concatenating `chunk` (array elements) until
+  `more:false`. No need to know the total up front.
+- Single-frame (≤1 MiB) messages emit one envelope with `more:false`, for a
+  uniform receiver path. (Alternative: keep ≤1 MiB messages verbatim and only
+  envelope multi-frame, with the receiver branching on shape — uniform is
+  simpler and unambiguous; pick during implementation.)
+- Each envelope must stay ≤1 MiB: drop `MAX_RUN` by the envelope overhead
+  (`{"chunk":` … `,"more":true}` ≈ 25 bytes) so a full frame including the
+  wrapper never exceeds the cap.
+- Open design choice (architect): plain `{chunk,more}` vs a
+  `{seq,total,chunk}` form (explicit index/total — more robust, slightly larger).
+
+## Scope
+
+- `examples/native-messaging/nm_js2wasm.ts`: `emitRun` (and the ≤1 MiB echo
+  path, if uniform) wrap output in the envelope; shrink `MAX_RUN` for headroom.
+- `examples/native-messaging/README.md`: document the marker + receiver
+  reassembly contract.
+- `examples/native-messaging/nm_js2wasm.sh` / background.js example: show the
+  reassembling receiver.
+- Tests: `tests/issue-1530.test.ts`, `tests/wasi-stdin.test.ts` — assert each
+  emitted frame is ≤1 MiB valid JSON carrying the marker, and that reassembly
+  reproduces the original.
+
+## Acceptance criteria
+
+- A >1 MiB request produces N frames, each ≤1 MiB valid JSON with a
+  continuation marker; a receiver that reassembles on the marker reproduces the
+  original message with no desync of subsequent messages.
+- The reporter's `nm_standalone_test.js` sequence (64 MiB + ≤1 MiB messages),
+  updated to reassemble on the marker, round-trips cleanly.
+- ≤1 MiB messages still round-trip (single final-marked frame).
+
+## Notes
+
+Surfaced + reproduced while investigating loopdive/js2#389 (with deno installed
+locally to run the reporter's harness). Pairs with the example's existing
+re-chunk design in #1530.

--- a/tests/issue-2521-native-messaging-rechunk.test.ts
+++ b/tests/issue-2521-native-messaging-rechunk.test.ts
@@ -1,0 +1,179 @@
+// #2521 — runtime coverage for the Native Messaging example host's behaviour on
+// the cases the reporter exercises in loopdive/js2#389: a >1 MiB message (which
+// the host re-chunks into multiple <=1 MiB frames) and a multi-message sequence
+// (a large message followed by small ones).
+//
+// The pre-existing round-trip test (#1618/#1651 in issue-1530.test.ts) only drove
+// a *toy* single-message host with a 7-byte body, so the real example host's
+// emitRun / re-chunk loop and any multi-message sequence were untested — which is
+// why #389 slipped through. These tests drive the ACTUAL example host.
+//
+// They assert the host's current, correct-per-contract behaviour: <=1 MiB
+// messages echo verbatim in one frame; >1 MiB messages are split into a sequence
+// of <=1 MiB valid-JSON-array frames whose elements, concatenated, reproduce the
+// original (the documented contract). A receiver that reassembles to the expected
+// size round-trips the whole sequence with no desync — demonstrating the stream
+// is correct and the #389 failure is the harness's 1:1 assumption, not the host.
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { compile } from "../src/index.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const hostPath = join(here, "..", "examples", "native-messaging", "nm_js2wasm.ts");
+const FRAME_CHUNK = 1024 * 1024;
+
+// Minimal raw-byte WASI shim (mirrors issue-1530.test.ts): fd_read drains a
+// preloaded stdin buffer; fd_write captures the fd=1 byte stream in order.
+function runWasiRaw(binary: Uint8Array, stdin: Uint8Array): Uint8Array {
+  const ref: { mem: WebAssembly.Memory | undefined } = { mem: undefined };
+  const memView = () => new DataView(ref.mem!.buffer);
+  const writes: Array<[number, Uint8Array]> = [];
+  let pos = 0;
+  const wasi = {
+    fd_read(_fd: number, iovs: number, iovsLen: number, nread: number): number {
+      const view = memView();
+      let total = 0;
+      for (let i = 0; i < iovsLen; i++) {
+        const ptr = view.getUint32(iovs + i * 8, true);
+        const len = view.getUint32(iovs + i * 8 + 4, true);
+        const n = Math.min(len, stdin.length - pos);
+        new Uint8Array(ref.mem!.buffer, ptr, n).set(stdin.subarray(pos, pos + n));
+        pos += n;
+        total += n;
+        if (n < len) break;
+      }
+      view.setUint32(nread, total, true);
+      return 0;
+    },
+    fd_write(fd: number, iovs: number, iovsLen: number, nwritten: number): number {
+      const view = memView();
+      let total = 0;
+      for (let i = 0; i < iovsLen; i++) {
+        const ptr = view.getUint32(iovs + i * 8, true);
+        const len = view.getUint32(iovs + i * 8 + 4, true);
+        writes.push([fd, Uint8Array.from(new Uint8Array(ref.mem!.buffer, ptr, len))]);
+        total += len;
+      }
+      view.setUint32(nwritten, total, true);
+      return 0;
+    },
+    proc_exit(code: number): void {
+      throw new Error(`proc_exit(${code})`);
+    },
+    random_get(): number {
+      return 0;
+    },
+    clock_time_get(): number {
+      return 0;
+    },
+  };
+  const inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+    wasi_snapshot_preview1: wasi,
+    env: {},
+  });
+  ref.mem = inst.exports.memory as WebAssembly.Memory;
+  (inst.exports.main as () => void)();
+  const fd1 = writes.filter(([fd]) => fd === 1).flatMap(([, b]) => Array.from(b));
+  return Uint8Array.from(fd1);
+}
+
+// One Native Messaging frame: 4-byte LE length prefix + UTF-8 JSON body.
+function frame(jsonBody: string): Uint8Array {
+  const body = new TextEncoder().encode(jsonBody);
+  const out = new Uint8Array(4 + body.length);
+  new DataView(out.buffer).setUint32(0, body.length, true);
+  out.set(body, 4);
+  return out;
+}
+
+function concatBytes(parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    out.set(p, off);
+    off += p.length;
+  }
+  return out;
+}
+
+// Split a stdout byte stream into its framed bodies (4-byte LE length + body)*.
+function parseFrames(bytes: Uint8Array): string[] {
+  const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const frames: string[] = [];
+  let off = 0;
+  while (off + 4 <= bytes.length) {
+    const len = dv.getUint32(off, true);
+    off += 4;
+    frames.push(new TextDecoder().decode(bytes.subarray(off, off + len)));
+    off += len;
+  }
+  return frames;
+}
+
+describe("#2521 Native Messaging host — >1 MiB re-chunking + multi-message sequence", () => {
+  it("echoes a <=1 MiB message verbatim in a single frame", async () => {
+    const result = await compile(readFileSync(hostPath, "utf-8"), { fileName: "nm_js2wasm.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    const frames = parseFrames(runWasiRaw(result.binary, frame(JSON.stringify([1, 2, 3]))));
+    expect(frames).toEqual(["[1,2,3]"]);
+  });
+
+  it("re-chunks a >1 MiB array into multiple <=1 MiB JSON-array frames that reassemble to the original", async () => {
+    const result = await compile(readFileSync(hostPath, "utf-8"), { fileName: "nm_js2wasm.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    const N = 209715 * 2; // ~2 MiB JSON body — strictly above the 1 MiB cap
+    const big = Array(N); // sparse → JSON renders as [null, null, …]
+    const body = JSON.stringify(big);
+    expect(body.length).toBeGreaterThan(FRAME_CHUNK);
+
+    const frames = parseFrames(runWasiRaw(result.binary, frame(body)));
+    // The host MUST split it (Chrome caps a host→extension message at 1 MiB).
+    expect(frames.length).toBeGreaterThan(1);
+    for (const f of frames) {
+      expect(f.length).toBeLessThanOrEqual(FRAME_CHUNK); // every frame within the cap
+      expect(() => JSON.parse(f)).not.toThrow(); // every frame is a complete JSON value
+    }
+    // Concatenating the chunk elements reproduces the original array.
+    const reassembled = frames.flatMap((f) => JSON.parse(f) as unknown[]);
+    expect(reassembled.length).toBe(N);
+    expect(reassembled.every((x) => x === null)).toBe(true);
+  });
+
+  it("processes the reporter's multi-message sequence (big then small) with no desync", async () => {
+    const result = await compile(readFileSync(hostPath, "utf-8"), { fileName: "nm_js2wasm.ts", target: "wasi" });
+    expect(result.success).toBe(true);
+    const N = 209715 * 2; // ~2 MiB
+    const big = Array(N);
+    // The reporter's sequence: a large message followed by small ones.
+    // (Uint8Array([97]) JSON-stringifies to {"0":97}, matching the harness.)
+    const stdin = concatBytes([
+      frame(JSON.stringify(big)),
+      frame(JSON.stringify("test")),
+      frame(JSON.stringify("")),
+      frame(JSON.stringify(1)),
+      frame(JSON.stringify({ "0": 97 })),
+    ]);
+    const frames = parseFrames(runWasiRaw(result.binary, stdin));
+
+    // Reassemble per the documented contract: for an echo the receiver knows the
+    // expected size, so it concatenates the big message's chunk frames until the
+    // element count matches, then the four small echoes follow verbatim and in
+    // order — with no leftover/extra frames (i.e. the stream is correctly framed).
+    let i = 0;
+    let bigCount = 0; // track element count only (avoids spreading huge arrays)
+    while (bigCount < N) {
+      const chunk = JSON.parse(frames[i++]) as unknown[];
+      expect(chunk.every((x) => x === null)).toBe(true);
+      bigCount += chunk.length;
+    }
+    expect(bigCount).toBe(N);
+    expect(frames[i++]).toBe('"test"');
+    expect(frames[i++]).toBe('""');
+    expect(frames[i++]).toBe("1");
+    expect(frames[i++]).toBe('{"0":97}');
+    expect(i).toBe(frames.length); // every frame accounted for — no desync
+  });
+});


### PR DESCRIPTION
Reproduced the loopdive/js2#389 'fails in the browser' symptom exactly (deno 2.8.3 + the reporter's `nm_standalone_test.js`): the host splits any >1 MiB message into multiple un-marked ≤1 MiB frames (required — Chrome caps host→extension at 1 MiB), so a receiver that expects one response per request desyncs. 64 MiB → ~64 frames read as separate messages; 2 MiB → the reporter's exact `ArrayBuffer.prototype.resize: Invalid length parameter`.

Chosen fix (per maintainer): an **in-body continuation marker** — envelope `{chunk, more}` per frame — so the receiver reassembles without knowing the size up front (covers request/response AND unsolicited broadcast). The marker must live in the JSON body, since Chrome owns the 4-byte framing and hands the extension each frame already parsed.

Issue captures the reproduction, the design, scope (example host `emitRun` + README + harness + tests), and acceptance. Docs-only: one issue file.