### PR TITLE
ci(#2530): surface stale-base issue-ID collisions at PR time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,27 @@ jobs:
         # depends_on, or broken plan/issues/<id>-<slug>.md links in tracked *.md.
         run: pnpm run check:issues
 
+      - name: Issue integrity vs. merged main (#2530)
+        # Stale-base dup-ID gate. The check above runs on the PR's OWN tip, which
+        # was cut from an older main; an id that a sibling PR has since merged is
+        # invisible there, so it passes — and the collision only surfaces in the
+        # merge_group (main + PR), failing `quality` there and WEDGING the queue
+        # with "N duplicate IDs" (see project_merge_queue_dup_issue_id_churn).
+        # This step fetches fresh origin/main and runs the committed-integrity
+        # check against the SIMULATED MERGE of main into the PR head (via
+        # `git merge-tree --write-tree`, no index/worktree mutation), so the
+        # collision fails the PR's OWN checks before it can reach the queue.
+        # Skips cleanly on push/merge_group (the head already contains main) and
+        # whenever origin/main can't be resolved.
+        if: github.event_name == 'pull_request'
+        run: |
+          # Deepen so the real merge base between origin/main and the PR head is
+          # present and merge-tree can do a true 3-way merge. The script falls
+          # back to --allow-unrelated-histories (tree-union) if the base is still
+          # out of range, so the depth is a quality knob, not a correctness one.
+          git fetch --no-tags --depth=200 origin main 2>/dev/null || git fetch --no-tags origin main 2>/dev/null || true
+          node scripts/check-merged-issue-integrity.mjs origin/main HEAD
+
       - name: Issue→probe coverage gate (#2093)
         # A bugfix issue (created on/after the cutoff) cannot flip to
         # `status: done` without a permanent probe/test reference — either a

--- a/docs/ci-policy.md
+++ b/docs/ci-policy.md
@@ -33,7 +33,7 @@ case-sensitive and whitespace-sensitive.
 |---|---|---|
 | `cheap gate (main-ancestor + lint)` | `.github/workflows/test262-sharded.yml` | fast pre-flight: lint + typecheck on the PR branch (cheap reject before running the test262 matrix) |
 | `merge shard reports` | `.github/workflows/test262-sharded.yml` | aggregates the 57 test262 shards into a single pass/fail signal — the authoritative aggregate conformance gate. Hosts the HARD inline guards: the host catastrophic-regression guard (#1668), the **standalone net-regression guard (#1897)**, and the stale-baseline guard (#1668) — see §3 |
-| `quality` | `.github/workflows/ci.yml` | lint, format check, typecheck, IR fallback budget (#1376), planning-artifact regen |
+| `quality` | `.github/workflows/ci.yml` | lint, format check, typecheck, IR fallback budget (#1376), planning-artifact regen, issue integrity (#1616) **incl. the stale-base dup-ID gate against a simulated merge with `main` (#2530)** |
 | `equivalence-gate` | `.github/workflows/ci.yml` | merges the equivalence shards and fails if the shard baseline regresses |
 | `linear-tests` | `.github/workflows/ci.yml` | runs the linear-backend (`tests/linear-*.test.ts`), C-ABI (`tests/c-abi.test.ts`), and SIMD (`tests/simd*.test.ts`) suites — the 20 files that previously had no CI job, so every linear-memory lowering change landed ungated (#2139) |
 | `check for test262 regressions` | `.github/workflows/test262-sharded.yml` | full rolling-baseline test262 diff; required so pass→fail regressions cannot merge just because the aggregate hard guards stayed below threshold |

--- a/plan/issues/2530-pr-time-dup-id-gate.md
+++ b/plan/issues/2530-pr-time-dup-id-gate.md
@@ -1,0 +1,80 @@
+---
+id: 2530
+title: "ci: surface issue-ID collisions at PR time (merge with main), not only in the merge_group"
+status: done
+assignee: ttraenkler/sd3
+created: 2026-06-20
+updated: 2026-06-20
+completed: 2026-06-20
+priority: high
+feasibility: medium
+task_type: infrastructure
+area: ci
+related: [1616, 2522]
+origin: "merge-queue dup-ID churn incident 2026-06-20 (prevention a)"
+---
+
+# #2530 — PR-time duplicate issue-ID gate against a simulated merge with main
+
+## Problem
+
+A merge-queue incident on 2026-06-20 was caused by issue-ID collisions. A PR
+adds `plan/issues/<id>-<slug>.md` whose `id:` was free when the branch was cut,
+but a parallel PR merged that same id to `main` first. The PR-time `quality`
+job's "Issue integrity + link gate" (#1616,
+`scripts/check-committed-issue-integrity.mjs`) runs only on the PR's **stale
+branch tip**, where the colliding file from main is not present — so it passes.
+The collision then fails repeatedly in the `merge_group` (which validates
+`main + PR`) and wedges the queue with "N duplicate IDs"
+(see `.claude/memory/project_merge_queue_dup_issue_id_churn.md`).
+
+## Fix
+
+New step in the `quality` job (`.github/workflows/ci.yml`), gated to
+`pull_request` only, that runs `scripts/check-merged-issue-integrity.mjs`:
+
+1. Fetches fresh `origin/main` (deepened so the real merge base is present).
+2. Computes the tree that *would* result from merging `origin/main` into the PR
+   head via `git merge-tree --write-tree` — no index/worktree mutation.
+3. Runs the existing committed-integrity checker
+   (`check-committed-issue-integrity.mjs`) against that merged tree OID.
+
+A stale-base id collision therefore fails the PR's **own** `quality` check,
+before it can reach — and wedge — the merge queue. No new required check is
+added: the gate rides inside the already-required `quality` check.
+
+### Robustness
+
+- **Shallow clone**: a `git fetch --depth=1 origin main` updates `FETCH_HEAD`
+  but may not create `refs/remotes/origin/main`; the script falls back to
+  `FETCH_HEAD`. The CI step deepens to `--depth=200` so the common case gets a
+  true 3-way merge.
+- **Merge base outside shallow history**: `git merge-tree` errors with "refusing
+  to merge unrelated histories" and emits no tree, which would hard-fail every
+  PR. The script retries with `--allow-unrelated-histories`, which unions both
+  trees with an empty merge base — exactly (and conservatively) what dup-id
+  detection needs: it can never hide a collision and never invents one.
+- **Unresolvable base / missing `git merge-tree` (< 2.38)**: skips cleanly
+  (exit 0) — never blocks a build it cannot reason about. The per-branch #1616
+  check still gates.
+- Skipped on `push` / `merge_group` (the head already contains main there; the
+  existing #1616 check covers it).
+
+## Validation
+
+Hermetic git sandboxes (job tmp, not committed) reproduce the exact incident:
+
+| Scenario | Per-branch #1616 check | Merged-tree gate |
+|---|---|---|
+| Collision, shallow clone | PASS (blind spot) | **FAIL** — `DUPLICATE IDs (1): #9999` |
+| Collision, deep clone (3-way) | PASS (blind spot) | **FAIL** — same signal |
+| Clean PR (distinct ids), shallow clone | n/a | **PASS** — no false positive |
+
+So the gate catches exactly the collision class that wedges the queue and never
+false-positives on a clean PR.
+
+## Files
+
+- `scripts/check-merged-issue-integrity.mjs` — new wrapper.
+- `.github/workflows/ci.yml` — new "Issue integrity vs. merged main (#2530)"
+  step in the `quality` job.

--- a/scripts/check-merged-issue-integrity.mjs
+++ b/scripts/check-merged-issue-integrity.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+// PR-time issue-integrity gate against a SIMULATED MERGE with main (#2530).
+//
+// WHY THIS EXISTS
+// ---------------
+// `scripts/check-committed-issue-integrity.mjs` runs the duplicate-ID /
+// filename-mismatch / dangling-depends_on gate against a single committed tree
+// (default HEAD). On a `pull_request` event the `quality` job runs it on the
+// PR's own branch tip — but that branch was cut from an OLDER `main`. If a
+// sibling PR has since merged a `plan/issues/<id>-<slug>.md` with the SAME id,
+// the collision is invisible on the stale branch and the check passes. The
+// collision only surfaces later in the `merge_group` run (which validates
+// `main + PR`), where it fails the `quality` job repeatedly and WEDGES the
+// merge queue with "N duplicate IDs" (see
+// .claude/memory/project_merge_queue_dup_issue_id_churn.md).
+//
+// This wrapper closes that gap: it computes the tree that WOULD result from
+// merging current `origin/main` into the PR head (via `git merge-tree
+// --write-tree`, which touches neither the index nor the working tree), then
+// runs the committed-integrity check against that merged tree. A stale-base
+// id collision therefore fails the PR's OWN `quality` check, before it can
+// reach — and wedge — the merge queue.
+//
+// USAGE
+//   node scripts/check-merged-issue-integrity.mjs [<base-ref>] [<head-ref>]
+//     base-ref  default: origin/main  (the branch the PR will merge INTO)
+//     head-ref  default: HEAD         (the PR head)
+//
+// BEHAVIOUR
+//   - If the base ref cannot be resolved (e.g. `origin/main` not fetched in a
+//     shallow checkout, or a non-PR context), the check SKIPS cleanly (exit 0)
+//     with a diagnostic — it never blocks a build it cannot reason about.
+//   - If `git merge-tree` reports merge conflicts, the merged tree OID is still
+//     printed on its first line; we proceed to run the integrity check against
+//     it (a content conflict inside an issue file does not change its id, so the
+//     dup-id signal is still valid). We surface the conflict as a note.
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const argv = process.argv.slice(2);
+const baseRef = argv[0] || process.env.MERGED_INTEGRITY_BASE || "origin/main";
+const headRef = argv[1] || "HEAD";
+
+const SELF_DIR = dirname(fileURLToPath(import.meta.url));
+const INTEGRITY_SCRIPT = join(SELF_DIR, "check-committed-issue-integrity.mjs");
+
+function tryRevParse(ref) {
+  const r = spawnSync("git", ["rev-parse", "--verify", "--quiet", `${ref}^{commit}`], {
+    encoding: "utf8",
+  });
+  return r.status === 0 ? r.stdout.trim() : null;
+}
+
+// Resolve the base. A shallow `git fetch --depth=1 origin main` updates
+// FETCH_HEAD but does NOT always create the `refs/remotes/origin/main`
+// tracking ref (depends on the remote's fetch refspec — GitHub's
+// actions/checkout configures it, a bare `git clone --branch X` does not). So
+// fall back to FETCH_HEAD when the named base ref is missing. This keeps the
+// gate effective under a shallow CI checkout instead of silently skipping.
+let baseSha = tryRevParse(baseRef);
+let resolvedBaseDesc = baseRef;
+if (!baseSha) {
+  const viaFetchHead = tryRevParse("FETCH_HEAD");
+  if (viaFetchHead) {
+    baseSha = viaFetchHead;
+    resolvedBaseDesc = `${baseRef} (via FETCH_HEAD)`;
+  }
+}
+const headSha = tryRevParse(headRef);
+
+if (!baseSha) {
+  console.log(
+    `[merged-issue-integrity] base ref '${baseRef}' (and FETCH_HEAD) is unresolvable here — ` +
+      `skipping the merged-tree check (the per-branch committed check still runs).`,
+  );
+  process.exit(0);
+}
+if (!headSha) {
+  console.error(`[merged-issue-integrity] head ref '${headRef}' is unresolvable — cannot continue.`);
+  process.exit(1);
+}
+
+// If the PR head already contains base (fast-forward / already up to date),
+// the merged tree IS the head tree; merge-tree still returns it. We run it
+// unconditionally for a single, uniform code path.
+function mergeTreeWriteTree(extraArgs = []) {
+  return spawnSync("git", ["merge-tree", "--write-tree", ...extraArgs, baseSha, headSha], {
+    encoding: "utf8",
+  });
+}
+
+let mergeTree = mergeTreeWriteTree();
+
+// Under a shallow CI checkout (`actions/checkout` defaults to fetch-depth: 1
+// and the gate's `git fetch --depth=1 origin main` only deepens by one), the
+// real merge base can lie outside the fetched history. git then errors with
+// "refusing to merge unrelated histories" and produces NO tree — which would
+// hard-fail every PR, not just colliding ones. Retry with
+// `--allow-unrelated-histories`: with an empty merge base merge-tree does a
+// pure UNION of both trees, so any file present on either side appears — which
+// is exactly (and conservatively) what dup-id detection needs. It can never
+// hide a collision and never invents one. The CI step also deepens the fetch
+// so the common case still gets a true 3-way merge.
+if (!mergeTree.error && mergeTree.status !== 0 && /unrelated histories/i.test(mergeTree.stderr || "")) {
+  console.log(
+    `[merged-issue-integrity] note: merge base for '${baseRef}' is outside the ` +
+      `shallow history — retrying with --allow-unrelated-histories (tree-union; ` +
+      `dup-id detection is unaffected).`,
+  );
+  mergeTree = mergeTreeWriteTree(["--allow-unrelated-histories"]);
+}
+
+if (mergeTree.error) {
+  console.error(
+    `[merged-issue-integrity] 'git merge-tree --write-tree' is unavailable ` +
+      `(${mergeTree.error.message}). Needs git >= 2.38. Skipping merged-tree check.`,
+  );
+  // Don't hard-fail on toolchain gaps — the per-branch committed check still gates.
+  process.exit(0);
+}
+
+const stdoutLines = (mergeTree.stdout || "").split("\n");
+const mergedTreeOid = stdoutLines[0]?.trim();
+
+if (!mergedTreeOid || !/^[0-9a-f]{40,64}$/.test(mergedTreeOid)) {
+  console.error(
+    `[merged-issue-integrity] could not parse merged tree OID from 'git merge-tree' output:\n` +
+      (mergeTree.stdout || "(empty)") +
+      (mergeTree.stderr ? `\nstderr: ${mergeTree.stderr}` : ""),
+  );
+  process.exit(1);
+}
+
+// Exit status 1 from merge-tree = the merge has conflicts; the tree OID is
+// still printed first. A conflict inside an issue file does not alter its id,
+// so the dup-id / mismatch / dangling signals computed below stay valid.
+if (mergeTree.status !== 0) {
+  console.log(
+    `[merged-issue-integrity] note: merging '${baseRef}' into the PR head reports ` +
+      `conflicts. The dup-id check still runs against the merged tree; resolve the ` +
+      `conflict before merging regardless.`,
+  );
+}
+
+console.log(
+  `[merged-issue-integrity] checking issue integrity on the merge of ` +
+    `${resolvedBaseDesc} (${baseSha.slice(0, 9)}) into ${headRef} (${headSha.slice(0, 9)}) → tree ${mergedTreeOid.slice(0, 9)}`,
+);
+
+// Delegate to the existing committed-integrity checker, pointed at the merged
+// tree OID. It accepts any tree-ish as its first arg and uses `git ls-tree` /
+// `git show <ref>:<file>` internally — both consume a bare tree OID fine.
+const result = spawnSync("node", [INTEGRITY_SCRIPT, mergedTreeOid], {
+  encoding: "utf8",
+  stdio: "inherit",
+});
+
+if (result.status !== 0) {
+  console.error(
+    `\n[merged-issue-integrity] FAILED against the merge with ${baseRef}. ` +
+      `This is the collision that would otherwise wedge the merge queue. ` +
+      `Rename the colliding issue file to a fresh id (see ` +
+      `\`node scripts/next-issue-id.mjs\`) and re-push.`,
+  );
+}
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Problem

The 2026-06-20 merge-queue churn incident was caused by issue-ID collisions. A PR adds `plan/issues/<id>-<slug>.md` whose `id:` was free when the branch was cut, but a parallel PR merged that same id to `main` first. The PR-time **Issue integrity + link gate** (#1616, `scripts/check-committed-issue-integrity.mjs`) runs only on the PR's *stale branch tip*, where the colliding file from main isn't present — so it passes. The collision then fails repeatedly in the `merge_group` (which validates `main + PR`) and wedges the queue with "N duplicate IDs".

## Mechanism

New `pull_request`-only step in the already-required **`quality`** job (`.github/workflows/ci.yml`) running `scripts/check-merged-issue-integrity.mjs`:

1. Fetch fresh `origin/main` (deepened so the real merge base is present).
2. Compute the tree that *would* result from merging `origin/main` into the PR head via `git merge-tree --write-tree` — **no index/worktree mutation**.
3. Run the existing committed-integrity checker against that merged tree OID.

A stale-base id collision therefore fails the PR's **own** `quality` check, before it can reach — and wedge — the merge queue. **No new required check** is added; the gate rides inside the already-required `quality` check, so existing required checks are unchanged.

## Robustness

- **Shallow CI checkout**: falls back to `FETCH_HEAD` when `origin/main` isn't created as a tracking ref; CI deepens the fetch (`--depth=200`) for a true 3-way merge in the common case.
- **Merge base outside shallow history**: `git merge-tree` would error "refusing to merge unrelated histories" and emit no tree (which would hard-fail every PR); the script retries with `--allow-unrelated-histories` (tree-union — can never hide or invent a collision).
- **Unresolvable base / `git merge-tree` < 2.38**: skips cleanly (exit 0); the per-branch #1616 check still gates.
- Skipped on `push`/`merge_group` (the head already contains main there).

## Validation

Hermetic git sandboxes reproduce the exact incident:

| Scenario | Per-branch #1616 | Merged-tree gate |
|---|---|---|
| Collision, shallow clone | PASS (blind spot) | **FAIL** — `DUPLICATE IDs (1): #9999` |
| Collision, deep clone (3-way) | PASS (blind spot) | **FAIL** — same signal |
| Clean PR (distinct ids), shallow | n/a | **PASS** — no false positive |

Tracking issue: `plan/issues/2530-pr-time-dup-id-gate.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)