### PR TITLE
ci(issues): atomic issue-ID allocation + PR-time uniqueness gate (#2531)

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -80,6 +80,14 @@ These help the tech lead know you're alive and progressing, not stuck. Keep them
 2. If the issue has `status: suspended` + `## Suspended Work`, use the listed worktree and resume instructions
 3. If no claimable task survives the gate: message tech lead `"TaskList is empty (or all remaining tasks are owned/out-of-scope), need next task."`
 
+> **Creating a NEW issue file** (a follow-up, a `[CONFLICT]` spin-off, anything
+> not already in `plan/issues/`)? Get its id from
+> `NEW=$(node scripts/claim-issue.mjs --allocate)` — **never hand-pick a
+> number** (#2531). Hand-picking races a parallel PR for the same id; the dup
+> is green at PR time and only fails in the `merge_group`, wedging the queue.
+> The required CI gate `check:issue-ids:against-main` rejects any PR introducing
+> a main-colliding id, so a hand-picked collision can't merge anyway.
+
 ### Implement
 1. Read `plan/issues/sprints/{sprint}/{N}.md` + smoke-test 1-2 failing cases to confirm the bug reproduces
 2. Update issue frontmatter: `status: in-progress` **and `assignee: ttraenkler/<your-agent-name>`** (commit on your branch — this lazily reflects the lock onto `main` when your PR merges; the live lock is already held on the `issue-assignments` ref from the Start step)

--- a/.claude/agents/product-owner.md
+++ b/.claude/agents/product-owner.md
@@ -80,7 +80,17 @@ You are the Product Owner teammate on the ts2wasm project — a TypeScript-to-We
 ## Issue creation
 
 When creating new issues:
-- Use the next available issue number (check existing files in `plan/issues/`)
+- **Get the id from `node scripts/claim-issue.mjs --allocate` (#2531) — NEVER
+  hand-pick "the next number".** Hand-picking races: two creators on separate
+  branches pick the same id (neither file is on `main` yet), the dup is green at
+  PR time and only fails in the `merge_group`, wedging the queue. `--allocate`
+  reserves the next id atomically against `origin/main` ∪ every open PR's added
+  issue files ∪ ids already reserved on the orphan ref, and prints it to stdout:
+  ```bash
+  NEW=$(node scripts/claim-issue.mjs --allocate)   # then create plan/issues/$NEW-<slug>.md
+  ```
+  The required CI gate `check:issue-ids:against-main` rejects any PR introducing
+  an id already taken on `main`, so a hand-picked collision cannot merge.
 - Follow the frontmatter format (id, title, priority, feasibility, depends_on, goal)
 - Always include lifecycle dates in frontmatter:
   - `created: YYYY-MM-DD`

--- a/.claude/skills/create-issue.md
+++ b/.claude/skills/create-issue.md
@@ -11,11 +11,18 @@ Describe the failure pattern: error message, test category, approximate count.
 
 ## Steps
 
-1. Find the next available issue number:
+1. Reserve the next issue id **atomically** (#2531) — never hand-pick a number
+   (a parallel PR may grab the same one; the dup only fails in the merge_group
+   and wedges the queue):
 ```bash
-find plan/issues -maxdepth 1 -type f | grep -oE '[0-9]+[a-z]?(-[^/]+)?\.md$' | grep -oE '^[0-9]+' | sort -n | tail -1
+NEW=$(node scripts/claim-issue.mjs --allocate)   # prints the reserved id
+echo "$NEW"
 ```
-Add 1.
+This reserves the next id unique against `origin/main` ∪ every open PR's added
+issue files ∪ ids already reserved on the orphan ref, with first-push-wins
+atomicity. Use `$NEW` as `{N}` below. (The CI gate `check:issue-ids:against-main`
+rejects any PR that introduces a main-colliding id, so this is enforced, not
+just advised.)
 
 2. Find sample test files matching the pattern:
 ```bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,18 @@ jobs:
         # depends_on, or broken plan/issues/<id>-<slug>.md links in tracked *.md.
         run: pnpm run check:issues
 
+      - name: Issue-ID fresh-claim gate (#2531)
+        # Rejects a PR that introduces a plan/issues/<id>-*.md whose id already
+        # exists on origin/main under a different filename — the merge-queue-wedge
+        # collision (#2530/#2531). Allocation must go through
+        # `claim-issue.mjs --allocate` (atomic against main ∪ open PRs ∪ the
+        # reservation ref); this gate is the required-CI enforcement. Needs the
+        # base ref for the merge-base diff; skips cleanly if it can't be fetched.
+        # merge_group already carries base ancestry, so the fetch is best-effort.
+        run: |
+          git fetch --no-tags --depth=50 origin main 2>/dev/null || true
+          GATE_BASE=origin/main pnpm run check:issue-ids:against-main
+
       - name: Issue→probe coverage gate (#2093)
         # A bugfix issue (created on/after the cutoff) cannot flip to
         # `status: done` without a permanent probe/test reference — either a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,23 @@ TypeScript-to-WebAssembly compiler using WasmGC.
   - `sprints/{N}.md` (the sprint doc) lives directly under `sprints/`; the
     numbered issue files are flat under `plan/issues/`. See
     `plan/issues/SCHEMA.md`.
+  - **New issues MUST get their id from `claim-issue.mjs --allocate` (#2531) —
+    never hand-pick a number.** Hand-picking "next free off main" races: two
+    devs on separate branches each pick the same id (neither file is on `main`
+    yet), the dup is green at PR time and only fails in the `merge_group`,
+    wedging the queue. `--allocate` reserves the next id **atomically** against
+    `origin/main` ∪ every open PR's added issue files ∪ ids already reserved on
+    the orphan `issue-assignments` ref (first-push-wins; loser re-scans). Flow:
+    ```bash
+    NEW=$(node scripts/claim-issue.mjs --allocate)        # prints the reserved id
+    # (or: node scripts/claim-issue.mjs --allocate ttraenkler/<agent> --branch <b>
+    #  to reserve AND claim in one step)
+    # create plan/issues/$NEW-<slug>.md with frontmatter id: $NEW
+    ```
+    `--dry-run` previews without reserving; `--no-pr-scan` skips the slower
+    open-PR scan; `--json` for tooling. The required CI gate
+    `check:issue-ids:against-main` (in `quality`) rejects any PR that introduces
+    an id already taken on `main` — so a hand-picked collision can't merge.
 - Dependency graph: `plan/log/dependency-graph.md`
 - Goals (DAG): `plan/goals/goal-graph.md` — high-level goals with dependencies; issues belong to goals
   - Goals are not sequential milestones — they form a DAG and multiple can be active in parallel

--- a/package.json
+++ b/package.json
@@ -140,7 +140,9 @@
     "dispatch:inbox": "node scripts/dispatch-channel.mjs inbox",
     "claude:symphony-channel": "node scripts/claude-symphony-channel.mjs",
     "check:issue-ids": "node scripts/check-issue-ids.mjs",
-    "check:issue-ids:staged": "node scripts/check-issue-ids.mjs --staged"
+    "check:issue-ids:staged": "node scripts/check-issue-ids.mjs --staged",
+    "check:issue-ids:against-main": "node scripts/check-issue-ids.mjs --against-main",
+    "new:issue-id:allocate": "node scripts/claim-issue.mjs --allocate"
   },
   "dependencies": {
     "typescript": "^5.7"

--- a/plan/issues/2531-atomic-issue-id-allocation.md
+++ b/plan/issues/2531-atomic-issue-id-allocation.md
@@ -1,0 +1,95 @@
+---
+id: 2531
+title: "Atomic, collision-proof issue-ID allocation + PR-time uniqueness gate"
+status: done
+sprint: 64
+created: 2026-06-20
+completed: 2026-06-20
+priority: high
+feasibility: medium
+task_type: infrastructure
+area: tooling
+language_feature: n/a
+goal: correctness
+related: [2168, 2530, 1616, 1858]
+assignee: "ttraenkler/dev-allocation"
+---
+
+# #2531 — atomic issue-ID allocation + enforced uniqueness at source
+
+## Problem
+
+The 2026-06-20 merge-queue incident was caused by issue-ID collisions.
+Developers hand-pick the `plan/issues/<id>-<slug>.md` id optimistically
+("next free off `main`"), but multiple devs on separate branches each pick the
+same number because none of their new issue files are on `main` yet. The
+duplicate is green at PR time (the colliding file isn't on the branch) and only
+fails in the `merge_group`, wedging the queue (see
+`project_merge_queue_dup_issue_id_churn`).
+
+ID allocation must be collision-proof **at the source** (atomic reservation),
+and a required CI check must **reject** any PR that introduces a colliding id.
+
+## Fix (prevention b — allocation + uniqueness-at-source)
+
+### 1. Atomic allocation — `claim-issue.mjs --allocate`
+
+`scripts/claim-issue.mjs` gains an `--allocate` mode that reserves the next
+free id **atomically** against THREE populations, because no single one closes
+the race:
+
+- ids already on `origin/main` (the committed record);
+- ids added by **every currently-open PR** (in-flight files not yet merged —
+  the exact race the wedge came from), scanned via `gh pr view --json files`;
+- ids already **reserved on the orphan `issue-assignments` ref** (concurrent
+  allocators that won a push microseconds ago).
+
+The next id is `max(union) + 1` (monotonic; strays > 1000 above the contiguous
+body are dropped so a mistyped `6406` can't poison `max+1`, re: #1858). The
+reservation is written to the orphan ref with the SAME first-push-wins
+atomicity as a claim: the loser's push is rejected non-fast-forward, it
+re-fetches (now seeing the winner's reservation), and recomputes a fresh id.
+Two concurrent allocators therefore can **never** hand out the same number.
+
+- `node scripts/claim-issue.mjs --allocate` → prints the reserved id to stdout.
+- `node scripts/claim-issue.mjs --allocate ttraenkler/<agent> --branch <b>` →
+  reservation doubles as the claim lock.
+- `--dry-run` previews the candidate without reserving; `--no-pr-scan` skips
+  the (slower) open-PR scan; `--json` for machine consumption.
+
+### 2. Required CI gate — `check-issue-ids.mjs --against-main`
+
+`scripts/check-issue-ids.mjs` gains an `--against-main` mode (wired into the
+`quality` job as `check:issue-ids:against-main`). It diffs the ids this branch
+*introduced* (present at `HEAD`, absent at the merge-base with `origin/main`)
+against the ids on `origin/main` and FAILS the PR if any collide — before it
+can reach the merge queue, with a precise "reserve a fresh id via
+`claim-issue.mjs --allocate`" remediation message. Skips cleanly when the base
+ref isn't fetched (shallow clone) so it never blocks a build it can't reason
+about; the sibling merged-state dup gate (#2530) is the backstop there.
+
+### 3. Documented required flow
+
+CLAUDE.md ("Issues" section), `.claude/agents/product-owner.md`, and
+`.claude/agents/developer.md` now state that new issues MUST be created via
+`claim-issue.mjs --allocate`, never by hand-picking a number.
+
+## Acceptance criteria
+
+- [x] `claim-issue.mjs --allocate` reserves an id unique against main + open
+      PRs + ref reservations, atomically (first-push-wins, retry on contention).
+- [x] `check-issue-ids.mjs --against-main` rejects a PR introducing a
+      main-colliding id; passes when the branch introduces only fresh ids;
+      skips cleanly without the base ref.
+- [x] Gate wired into the `quality` CI job (required check).
+- [x] Required flow documented in CLAUDE.md + product-owner + developer defs.
+
+## Test Results
+
+- `--allocate --dry-run --no-pr-scan` → next free `#2532` (main ∪ ref).
+- `--allocate --dry-run` (PR scan on) → next free `#2541` (main ∪ ref ∪ open
+  PRs found ids 2532–2540 in-flight) — exactly the collision the naive
+  "next free off main" would have hit.
+- `--against-main` on a clean branch → OK (0 introduced).
+- `--against-main` with a simulated main-colliding id → FAILED with the
+  remediation message (verified locally).

--- a/plan/issues/SCHEMA.md
+++ b/plan/issues/SCHEMA.md
@@ -63,6 +63,15 @@ assignee: "ttraenkler/senior-dev-1"
   - Usually numeric, for example `1006`.
   - Preserve historical alphanumeric suffixes where they are part of the real
     record, for example `797a`.
+  - **A new id MUST be reserved atomically via `claim-issue.mjs --allocate`
+    (#2531), never hand-picked.** Hand-picking "next free off `main`" races: two
+    creators on separate branches pick the same number, the duplicate is green
+    at PR time and only fails in the `merge_group`, wedging the queue.
+    `--allocate` reserves the next id unique against `origin/main` ∪ every open
+    PR's added issue files ∪ ids already reserved on the orphan
+    `issue-assignments` ref (first-push-wins). The required CI gate
+    `check:issue-ids:against-main` rejects any PR introducing a main-colliding
+    id.
 - `title`
   - Human-readable issue title.
 - `status`

--- a/scripts/check-issue-ids.mjs
+++ b/scripts/check-issue-ids.mjs
@@ -4,9 +4,23 @@
  * Exits 1 if duplicates are found (for use as a pre-push or pre-commit hook).
  *
  * Usage:
- *   node scripts/check-issue-ids.mjs              # check workspace files
- *   node scripts/check-issue-ids.mjs --staged     # check git-staged files only (pre-commit)
- *   node scripts/check-issue-ids.mjs --committed  # check committed tree (HEAD)
+ *   node scripts/check-issue-ids.mjs               # check workspace files
+ *   node scripts/check-issue-ids.mjs --staged      # check git-staged files only (pre-commit)
+ *   node scripts/check-issue-ids.mjs --committed   # check committed tree (HEAD)
+ *   node scripts/check-issue-ids.mjs --against-main # PR-time fresh-claim gate (#2531)
+ *
+ * --against-main is the REQUIRED-CI half of the atomic-allocation defense
+ * (#2531). A PR that *introduces* a plan/issues/<id>-*.md whose id already
+ * exists on origin/main (under any filename) is a collision the merge_group
+ * would reject — but it can pass the PR's own self-consistency checks because
+ * the colliding file isn't on the PR branch yet at branch time. This mode
+ * diffs the branch's introduced ids (present at HEAD, absent at the
+ * merge-base with main) against the ids on origin/main and FAILS the PR before
+ * it reaches the queue. The base ref is GATE_BASE (default origin/main); CI
+ * fetches it shallowly. Complements the sibling merged-state dup gate (#2530):
+ * that one re-checks the simulated merge tree; this one rejects at PR time with
+ * a precise "use claim-issue.mjs --allocate" message so the dev never wedges
+ * the queue in the first place.
  */
 
 import { execSync } from "child_process";
@@ -14,7 +28,13 @@ import { readFileSync, readdirSync, statSync } from "fs";
 import { join } from "path";
 
 const args = process.argv.slice(2);
-const mode = args.includes("--staged") ? "staged" : args.includes("--committed") ? "committed" : "workspace";
+const mode = args.includes("--against-main")
+  ? "against-main"
+  : args.includes("--staged")
+    ? "staged"
+    : args.includes("--committed")
+      ? "committed"
+      : "workspace";
 
 /**
  * Extract the issue ID from a filename: "1799-foo.md" → "1799", "779a-bar.md" → "779a".
@@ -88,6 +108,105 @@ function collectFromCommitted() {
     map.get(id).push(fname);
   }
   return map;
+}
+
+// --against-main (#2531): map id -> Set(filenames) for the issue files in a
+// tree-ish ref. Returns null if the ref isn't present (shallow clone). We track
+// FILENAMES, not just ids, because the wedge collision is two *different* files
+// sharing one id (branch adds `2503-newslug.md`, main already has
+// `2503-otherslug.md`) — the merged tree then holds a duplicate id even though
+// neither id is "new".
+function fileIdsInRef(ref) {
+  let listing;
+  try {
+    listing = execSync(`git ls-tree -r --name-only ${ref} plan/issues/`, { encoding: "utf8" });
+  } catch {
+    return null; // ref not present (e.g. not fetched) — caller decides
+  }
+  const map = new Map(); // id -> Set(filename)
+  for (const line of listing.split("\n")) {
+    const path = line.trim();
+    if (!path.startsWith("plan/issues/") || !path.endsWith(".md")) continue;
+    const fname = path.slice("plan/issues/".length);
+    if (fname.includes("/") || NON_ISSUE.has(fname)) continue; // skip subdirs (sprints/, backlog/) + non-issues
+    const id = filenameId(fname);
+    if (!id) continue;
+    if (!map.has(id)) map.set(id, new Set());
+    map.get(id).add(fname);
+  }
+  return map;
+}
+
+function checkAgainstMain() {
+  const base = process.env.GATE_BASE || "origin/main";
+  const mainFiles = fileIdsInRef(base);
+  if (mainFiles === null) {
+    // Base ref unavailable (shallow clone without it). Skip cleanly rather than
+    // block a build we can't reason about — the merged-state gate (#2530) is the
+    // backstop. Mirrors the issue-spec-coverage gate's "skip when no base" rule.
+    console.log(
+      `✓ --against-main skipped: base ref '${base}' not present (shallow checkout); merged-state gate covers it`,
+    );
+    process.exit(0);
+  }
+
+  // Files this branch INTRODUCED = (id, filename) pairs present at HEAD but
+  // absent at the merge-base with base. Using the merge-base (not base itself)
+  // avoids flagging files an earlier `git merge origin/main` legitimately
+  // carried in — only files genuinely new on this branch count.
+  let mergeBase = "HEAD";
+  try {
+    mergeBase = execSync(`git merge-base ${base} HEAD`, { encoding: "utf8" }).trim() || "HEAD";
+  } catch {
+    /* fall back to HEAD (treats every HEAD file as introduced — safe, stricter) */
+  }
+  const headFiles = fileIdsInRef("HEAD") || new Map();
+  const baseFiles = fileIdsInRef(mergeBase) || new Map();
+
+  // collisions: an introduced filename whose id already exists on base under a
+  // DIFFERENT filename. (Same filename on base = the branch just modified an
+  // existing issue — fine. Different filename = the wedge dup.)
+  const collisions = [];
+  for (const [id, fnames] of headFiles) {
+    const baseFnamesForId = mainFiles.get(id);
+    if (!baseFnamesForId) continue; // id not on base at all → genuinely fresh, fine
+    const baseMergeFnames = baseFiles.get(id) || new Set();
+    for (const fname of fnames) {
+      // introduced on this branch?
+      if (baseMergeFnames.has(fname)) continue; // already at merge-base → not new
+      // does base/main carry this id under a DIFFERENT filename?
+      const conflictsOnMain = [...baseFnamesForId].filter((bf) => bf !== fname);
+      if (conflictsOnMain.length) {
+        collisions.push({ id, fname, conflictsOnMain });
+      }
+    }
+  }
+
+  if (collisions.length === 0) {
+    if (!args.includes("--quiet")) {
+      console.log(`✓ --against-main OK: no branch-introduced issue file collides with an id on ${base}`);
+    }
+    process.exit(0);
+  }
+
+  console.error(
+    `✗ --against-main FAILED: ${collisions.length} issue file${collisions.length > 1 ? "s" : ""} introduced by this branch reuse an id already on ${base}:`,
+  );
+  for (const { id, fname, conflictsOnMain } of collisions.sort((a, b) => +a.id - +b.id)) {
+    console.error(`  #${id}: this branch adds plan/issues/${fname}`);
+    for (const bf of conflictsOnMain) console.error(`         but ${base} already has plan/issues/${bf}`);
+  }
+  console.error("");
+  console.error("This is the merge-queue-wedge collision (#2531): the id is already taken on main.");
+  console.error("Fix: reserve a FRESH id atomically and rename your file —");
+  console.error("  NEW=$(node scripts/claim-issue.mjs --allocate)   # prints the reserved id");
+  console.error("  git mv plan/issues/<old>-<slug>.md plan/issues/$NEW-<slug>.md");
+  console.error("  # then update the file's frontmatter id: to $NEW");
+  process.exit(1);
+}
+
+if (mode === "against-main") {
+  checkAgainstMain();
 }
 
 const map =

--- a/scripts/claim-issue.mjs
+++ b/scripts/claim-issue.mjs
@@ -17,10 +17,26 @@
 //
 // Usage:
 //   node scripts/claim-issue.mjs <id> <assignee> [--branch <b>] [--force]
+//   node scripts/claim-issue.mjs --allocate [<assignee>] [--branch <b>] [--json]
 //   node scripts/claim-issue.mjs --check <id>
 //   node scripts/claim-issue.mjs --release <id> [<assignee>]
 //   node scripts/claim-issue.mjs --complete <id>
 //   node scripts/claim-issue.mjs --list
+//
+// ATOMIC ID ALLOCATION (#2531): `--allocate` is the canonical, collision-proof
+// way to reserve a FRESH issue id. Picking an id by hand ("next free off main")
+// races: two devs on separate branches each pick the same number because none
+// of their new `plan/issues/<id>-*.md` files are on `main` yet, the duplicate
+// is green at PR-time, and it only fails in the `merge_group` — wedging the
+// queue. `--allocate` closes that window by treating the orphan
+// `issue-assignments` ref as a RESERVATION REGISTRY: the next id is
+// max(ids on origin/main ∪ ids added by every currently-open PR ∪ ids already
+// reserved on the ref) + 1, and the reservation is written with the same
+// first-push-wins atomicity as a claim. Two concurrent allocators cannot both
+// win the same id — the loser's push is rejected non-fast-forward, it re-fetches
+// (now seeing the winner's reservation) and recomputes a fresh id. With an
+// `<assignee>` the reservation doubles as the claim lock; without one it writes
+// a bare `reserved` placeholder the eventual claim transitions in place.
 //
 // SLICE-LEVEL LOCKING (#41): for an issue the architect decomposed into
 // FILE-DISJOINT parallel slices, pass a slice-qualified id `<issue>:<slice>`
@@ -39,6 +55,7 @@
 //
 // Exit codes: 0 ok / free · 2 usage error · 3 already claimed by someone else
 //             4 issue already done/wont-fix on main · 5 push gave up after retries
+// (--allocate prints the reserved id to stdout on success and exits 0.)
 
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
@@ -80,13 +97,15 @@ const positional = argv.filter((a, i) => !a.startsWith("--") && argv[i - 1] !== 
 
 const mode = flags.has("--list")
   ? "list"
-  : flags.has("--check")
-    ? "check"
-    : flags.has("--release")
-      ? "release"
-      : flags.has("--complete")
-        ? "complete"
-        : "claim";
+  : flags.has("--allocate")
+    ? "allocate"
+    : flags.has("--check")
+      ? "check"
+      : flags.has("--release")
+        ? "release"
+        : flags.has("--complete")
+          ? "complete"
+          : "claim";
 
 function normalizeAssignee(raw) {
   if (!raw) return "";
@@ -155,6 +174,110 @@ function mainIssueStatus(id) {
   if (!cat.ok) return null;
   const m = cat.out.match(/^status:\s*([\w-]+)\s*$/m);
   return { file, status: m ? m[1] : null };
+}
+
+// --- id-universe scanning (for --allocate) ----------------------------------
+//
+// A fresh issue id must be unique against THREE populations, because none of
+// them alone closes the collision window:
+//   (1) ids already on origin/main          — the committed record;
+//   (2) ids added by every currently-open PR — in-flight files not yet merged
+//       (THE race the merge-queue wedge came from);
+//   (3) ids already reserved on this ref     — concurrent allocators that won
+//       a push microseconds ago.
+// `allUsedIds()` unions all three; the next id is max(union)+1 (monotonic — we
+// never reuse a gap that might be reserved on a branch this scan can't see).
+
+const ISSUE_ID_RE = /(?:^|\/)plan\/issues\/(\d+)[a-z]?-[^/]*\.md$/;
+
+// Stray ids separated from the contiguous body by a large gap (a mis-typed
+// 6406 when the real range is ~2500) must not poison max+1 and hand out a 6408
+// — the #1858 mis-allocation. Drop anything > GAP above the running max.
+const STRAY_GAP = 1000;
+
+function contiguousMax(idSet) {
+  const sorted = [...idSet].sort((a, b) => a - b);
+  let max = 0;
+  for (const id of sorted) {
+    if (max > 0 && id - max > STRAY_GAP) break;
+    max = id;
+  }
+  return max;
+}
+
+function idsFromMain() {
+  const out = new Set();
+  const ls = gitTry(["ls-tree", "-r", "--name-only", MAIN_REF, "plan/issues/"]);
+  if (!ls.ok) return out;
+  for (const f of ls.out.split("\n")) {
+    const m = f.match(ISSUE_ID_RE);
+    if (m) out.add(Number(m[1]));
+  }
+  return out;
+}
+
+// Ids reserved/claimed on the orphan ref. Every `<key>.json` entry's `id`
+// field counts — a `reserved` placeholder reserves the number just as firmly
+// as an in-progress claim, otherwise two allocators racing the same second
+// would both compute the same max+1.
+function idsFromAssignRef(sha) {
+  const out = new Set();
+  if (!sha) return out;
+  const ls = gitTry(["ls-tree", "--name-only", sha]);
+  if (!ls.ok) return out;
+  for (const f of ls.out.split("\n")) {
+    if (!f.endsWith(".json")) continue;
+    const e = readEntry(sha, f.replace(/\.json$/, ""));
+    if (e && e.id != null && /^\d+$/.test(String(e.id))) out.add(Number(e.id));
+  }
+  return out;
+}
+
+// Ids added by currently-open PRs. Uses `gh` when available (the only way to
+// see a fork-headed PR whose branch is NOT a refs/remotes/origin/* ref here).
+// Best-effort: on any gh failure (offline, unauthenticated, old gh) we return
+// an empty set and fall back to main ∪ ref — the PR-time CI gate
+// (check-issue-ids --against-main) is the hard backstop, this scan only shrinks
+// the race window at allocation time.
+function idsFromOpenPRs() {
+  const out = new Set();
+  const repo = process.env.CLAIM_PR_REPO || "loopdive/js2";
+  // List open PR numbers (cap to keep the per-PR file query bounded).
+  let prNumbers = [];
+  try {
+    const raw = execFileSync(
+      "gh",
+      ["pr", "list", "-R", repo, "--state", "open", "--limit", "200", "--json", "number"],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      },
+    );
+    prNumbers = JSON.parse(raw).map((p) => p.number);
+  } catch {
+    return out; // gh unavailable / unauthenticated — fall back to main ∪ ref
+  }
+  for (const n of prNumbers) {
+    try {
+      const raw = execFileSync("gh", ["pr", "view", String(n), "-R", repo, "--json", "files"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      for (const f of JSON.parse(raw).files || []) {
+        const m = (f.path || "").match(ISSUE_ID_RE);
+        if (m) out.add(Number(m[1]));
+      }
+    } catch {
+      /* skip this PR */
+    }
+  }
+  return out;
+}
+
+function allUsedIds(sha, { scanPRs }) {
+  const all = new Set([...idsFromMain(), ...idsFromAssignRef(sha)]);
+  if (scanPRs) for (const id of idsFromOpenPRs()) all.add(id);
+  return all;
 }
 
 // Build a new tree = base tree with `<id>.json` set to `content`, then
@@ -234,6 +357,75 @@ function nowIso() {
   return new Date().toISOString().replace(/\.\d+Z$/, "Z");
 }
 
+// Atomically reserve the next free issue id (#2531). Computes max(used)+1 over
+// origin/main ∪ open-PR-added ids ∪ ref-reserved ids, writes a reservation
+// entry, and pushes first-wins. On a non-ff rejection (another allocator landed
+// a reservation since we read), re-fetch and recompute a fresh id — so two
+// concurrent allocators can NEVER hand out the same number. Prints the reserved
+// id to stdout (machine-readable; the human/JSON detail goes to stderr or with
+// --json). `assignee` is optional: with one the reservation doubles as the claim
+// lock (status in-progress); without one it's a bare `reserved` placeholder the
+// real claim transitions in place.
+function doAllocate(assignee) {
+  const wantJson = flags.has("--json");
+  const scanPRs = !flags.has("--no-pr-scan");
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    const sha = remoteAssignSha();
+    fetchAssign(sha);
+
+    const used = allUsedIds(sha, { scanPRs });
+    // contiguousMax+1 is always strictly above the contiguous body, so it can
+    // never alias an in-use id (strays sit > STRAY_GAP above max, never at +1).
+    const id = String(contiguousMax(used) + 1);
+
+    // --dry-run: preview the candidate without reserving (no push). Useful to
+    // see "what id would I get" without burning a reservation. NOT collision-
+    // safe on its own — only the real reserve+push is atomic.
+    if (flags.has("--dry-run")) {
+      if (wantJson) process.stdout.write(JSON.stringify({ id: Number(id), dryRun: true }) + "\n");
+      else {
+        console.error(
+          `(dry-run) next free id would be #${id} (scanned ${used.size} used ids; PR-scan ${scanPRs ? "on" : "off"})`,
+        );
+        process.stdout.write(`${id}\n`);
+      }
+      return;
+    }
+
+    const entry = {
+      id,
+      assignee: assignee || "",
+      status: assignee ? "in-progress" : "reserved",
+      branch: assignee ? branch || "" : "",
+      reserved_at: nowIso(),
+      ...(assignee ? { claimed_at: nowIso() } : {}),
+      updated_at: nowIso(),
+    };
+    const verb = assignee ? `reserve+claim #${id} -> ${assignee}` : `reserve #${id}`;
+    const msg = `chore(assign): ${verb} [skip ci]`;
+    const content = JSON.stringify(entry, null, 2) + "\n";
+
+    if (commitAndPush(sha, id, content, msg)) {
+      // stdout = just the id (scriptable); details to stderr unless --json.
+      if (wantJson) {
+        process.stdout.write(
+          JSON.stringify({ id: Number(id), assignee: assignee || null, branch: entry.branch || null }) + "\n",
+        );
+      } else {
+        console.error(
+          `Reserved issue #${id}${assignee ? ` for ${assignee}${entry.branch ? ` (branch ${entry.branch})` : ""}` : ""}.`,
+        );
+        console.error(`(pushed to ${REMOTE}/${ASSIGN_REF}; main untouched, no CI triggered)`);
+        process.stdout.write(`${id}\n`);
+      }
+      return;
+    }
+    console.error(`allocate: ref moved (attempt ${attempt}/${MAX_RETRIES}) — re-scanning for a fresh id…`);
+  }
+  die(5, `Could not reserve a fresh id after ${MAX_RETRIES} attempts (heavy contention). Re-run.`);
+}
+
 function writeMode(target, assignee, kind) {
   const { base, slice, key, label } = target;
   // Pre-flight: refuse claiming an issue already closed on main. Resolve the
@@ -305,6 +497,9 @@ function writeMode(target, assignee, kind) {
 // --- dispatch ---------------------------------------------------------------
 if (mode === "list") {
   doList();
+} else if (mode === "allocate") {
+  // --allocate [<assignee>] — reserve the next fresh id. Assignee optional.
+  doAllocate(normalizeAssignee(positional[0] || process.env.CLAIM_ASSIGNEE || ""));
 } else if (mode === "check") {
   const id = positional[0];
   if (!id) die(2, "usage: claim-issue.mjs --check <id[:slice]>");

--- a/scripts/next-issue-id.mjs
+++ b/scripts/next-issue-id.mjs
@@ -9,12 +9,19 @@
 // max(all ids)+1 (monotonic — never reuses a gap that might be reserved on a
 // branch this scan can't see, e.g. an un-pushed worktree).
 //
-// Usage:  node scripts/next-issue-id.mjs        -> prints e.g. 1745
-//         pnpm run new:issue-id
+// DEPRECATED for allocation (#2531): this script only PREDICTS the next id, it
+// does NOT reserve it — so two callers racing still pick the same number, and
+// the dup only fails in the merge_group (wedging the queue). To allocate, use
+// the ATOMIC reserver instead, which writes a first-push-wins reservation on
+// the orphan ref and re-scans on contention:
 //
-// NOTE: there is still a small window between "pick id" and "push". Pair this
-// with the pre-push #1616 integrity check, which hard-blocks a dup/mismatch
-// before it can reach CI.
+//     node scripts/claim-issue.mjs --allocate     # reserves + prints the id
+//
+// This script remains only as a fast, no-push PREVIEW (≈ `claim-issue.mjs
+// --allocate --dry-run --no-pr-scan`); it does not consult open PRs.
+//
+// Usage:  node scripts/next-issue-id.mjs        -> prints e.g. 1745 (preview only)
+//         pnpm run new:issue-id
 
 import { execSync } from "node:child_process";
 import { readdirSync } from "node:fs";


### PR DESCRIPTION
## Problem

The 2026-06-20 merge-queue incident was caused by issue-ID collisions.
Developers hand-pick the \`plan/issues/<id>-<slug>.md\` id optimistically
("next free off \`main\`"), but multiple devs on separate branches pick the same
number because none of their new issue files are on \`main\` yet. The duplicate
is green at PR time and only fails in the \`merge_group\`, wedging the queue.

ID allocation must be collision-proof **at the source**, and a required CI
check must reject any PR introducing a colliding id.

## Changes (prevention b — allocation + uniqueness-at-source, #2531)

### 1. Atomic allocation — \`claim-issue.mjs --allocate\`
New mode reserves the next free id **atomically** against THREE populations
(none alone closes the race):
- ids on \`origin/main\` (committed record);
- ids added by **every currently-open PR** (in-flight, not yet merged — the
  exact wedge race), via \`gh pr view --json files\`;
- ids already **reserved on the orphan \`issue-assignments\` ref** (concurrent
  allocators that won a push moments ago).

Next id = \`max(union)+1\` (monotonic; strays >1000 above the contiguous body
dropped, re: #1858). The reservation is written with the same first-push-wins
atomicity as a claim — the loser's push is rejected non-ff, it re-fetches
(seeing the winner's reservation) and recomputes. Two concurrent allocators can
**never** hand out the same number. \`--dry-run\` previews; \`--no-pr-scan\` skips
the slower PR scan; \`--json\` for tooling; an optional assignee makes the
reservation double as the claim lock.

### 2. Required CI gate — \`check-issue-ids.mjs --against-main\`
Diffs the issue files this branch *introduced* (present at HEAD, absent at the
merge-base with \`origin/main\`) against the ids on \`origin/main\` and FAILS the
PR if an introduced file reuses an id already taken on main under a different
filename — with a precise "reserve a fresh id via \`claim-issue.mjs --allocate\`"
remediation. Skips cleanly when the base ref isn't fetched (shallow clone), so
it never blocks a build it can't reason about. Wired into the \`quality\` job as
a required check. Complements the sibling merged-state dup gate (#2530): that
re-checks the simulated merge tree; this rejects at PR time so the dev never
wedges the queue in the first place.

### 3. Documented required flow
CLAUDE.md ("Issues"), \`plan/issues/SCHEMA.md\`, the product-owner + developer
agent defs, and the \`/create-issue\` skill now state new issues MUST get their
id from \`claim-issue.mjs --allocate\`. \`next-issue-id.mjs\` is annotated as a
no-push *preview only* and points at the atomic allocator.

## Verification (local)
- \`--allocate --dry-run --no-pr-scan\` → \`#2532\` (main ∪ ref).
- \`--allocate --dry-run\` (PR scan on) → \`#2541\` (open PRs already hold
  2532–2540 in-flight) — exactly the collision the naive picker would hit.
- \`--against-main\` clean branch → OK; simulated main-colliding id → FAIL with
  remediation; missing base ref → skips cleanly.
- \`pnpm run check:issues\`, \`pnpm run lint\`, \`prettier --check\` on changed
  scripts all pass.

Coordinated with the sibling #2530 (merged-state dup gate): this PR owns
*allocation* + *uniqueness-at-source*; the \`check-issue-ids\` wiring is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)