### PR TITLE
ci(#2547): auto-park PRs that fail required CI in the merge_group

### DIFF
--- a/.github/workflows/auto-park-merge-group-failures.yml
+++ b/.github/workflows/auto-park-merge-group-failures.yml
@@ -1,0 +1,72 @@
+name: Auto-park merge_group CI failures
+
+# WHY (#2547): test262 now runs only in the merge_group (the #2519 slim-down),
+# so a PR can be fully green at PR-time yet carry a REAL test262/quality
+# regression that only surfaces when the merge queue validates it on the merged
+# state. GitHub ejects the PR, but `auto-enqueue` sees it is still PR-green and
+# re-adds it — it cycles forever, burning a ~15-minute merge_group CI run every
+# lap. This workflow breaks the loop: when a required workflow concludes
+# `failure` for a `merge_group` run, it parks the offending PR with the `hold`
+# label (which enqueue-green-prs.mjs skips via HOLD_LABELS) and posts one
+# idempotent comment.
+#
+# CRITICAL — REAL FAILURE vs CANCELLATION (the #1 footgun; see memory
+# project_merge_queue_requeue_cancels_run). When the queue rebuilds a group
+# (membership change) it CANCELS the in-flight runs, which GitHub ALSO surfaces
+# as a run-level `failure` conclusion but with ZERO failed JOBS. Parking on
+# those would wrongly hold healthy, merely-re-grouped PRs. So the script does
+# NOT trust the run-level conclusion: it fetches the run's jobs and parks ONLY
+# when >= 1 job has conclusion == "failure". 0 failed jobs => cancellation =>
+# do nothing. The job-level guard is the entire point of routing through the
+# helper script rather than reacting to `conclusion` inline.
+#
+# This is ADDITIVE — it does not modify auto-enqueue / queue-unstick /
+# merge-group-sweeper. Labelling + commenting do not need to trigger a
+# downstream workflow, so the default GITHUB_TOKEN is sufficient (no App token).
+
+on:
+  workflow_run:
+    # The workflows that produce the required merge_group checks: Test262
+    # Sharded (cheap gate, merge shard reports, check for test262 regressions)
+    # and CI (quality, equivalence-gate, linear-tests). Both run in the
+    # merge_group; a failure in either is a genuine merged-state regression.
+    workflows: ["Test262 Sharded", "CI"]
+    types: [completed]
+
+permissions:
+  pull-requests: write # add label + comment
+  issues: write # labels live on the issues API
+  actions: read # read the run's jobs to distinguish failure vs cancellation
+
+concurrency:
+  # Serialise per offending run so two completion events for the same run never
+  # double-act; the script is idempotent regardless (hold-label guard).
+  group: auto-park-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  park:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Gate at the workflow level FIRST: only merge_group runs that concluded
+    # failure are candidates. The script then does the real-vs-cancellation
+    # job-level check (a run-level failure can still be a cancellation).
+    if: >-
+      github.event.workflow_run.event == 'merge_group' &&
+      github.event.workflow_run.conclusion == 'failure'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/auto-park-merge-group-failure.mjs
+          sparse-checkout-cone-mode: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - name: Self-check the parking logic
+        run: node scripts/auto-park-merge-group-failure.mjs --self-check
+      - name: Park the offending PR (only on a genuine job failure)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: node scripts/auto-park-merge-group-failure.mjs "${{ github.event.workflow_run.id }}"

--- a/plan/issues/2547-auto-park-merge-group-failures.md
+++ b/plan/issues/2547-auto-park-merge-group-failures.md
@@ -1,0 +1,80 @@
+---
+id: 2547
+title: "Auto-park PRs that fail required CI in the merge_group"
+status: done
+sprint: 64
+created: 2026-06-20
+completed: 2026-06-20
+priority: high
+feasibility: medium
+task_type: infrastructure
+area: tooling
+language_feature: n/a
+goal: correctness
+related: [2519, 2531, 1758]
+assignee: "ttraenkler/dev"
+---
+
+# #2547 — auto-park PRs that fail required CI in the merge_group
+
+## Problem
+
+After the #2519 slim-down, the full test262 matrix runs **only in the
+merge_group**, not on the PR. So a PR can be fully green at PR-time yet carry a
+**real** test262/quality regression that surfaces only when the merge queue
+validates it on the merged-with-main state. GitHub ejects that PR from the
+queue, but `auto-enqueue` (`scripts/enqueue-green-prs.mjs`) still sees it as
+PR-green and re-enqueues it. The PR then cycles forever, burning a ~15-minute
+merge_group CI run every lap and starving the serial queue.
+
+There is no human or workflow that parks such a PR, so the cycle only stops when
+someone notices and hand-labels it.
+
+## Fix
+
+A new additive workflow `.github/workflows/auto-park-merge-group-failures.yml`
+listens for the required CI workflows completing (`Test262 Sharded`, `CI`). When
+a run was a `merge_group` run that concluded `failure`, it routes to
+`scripts/auto-park-merge-group-failure.mjs`, which:
+
+1. Maps the run's `head_branch` (`gh-readonly-queue/main/pr-<N>-<sha>`) → PR N.
+2. **Distinguishes a real failure from a cancellation** (see below).
+3. On a genuine failure, parks PR N: adds the `hold` label (which
+   `enqueue-green-prs.mjs` skips via `HOLD_LABELS`, stopping the re-enqueue
+   loop) and posts ONE idempotent comment (HTML-marker guarded) telling the
+   author to fix the failure and remove `hold` to re-enqueue.
+
+Labelling + commenting do not trigger a downstream workflow, so the default
+`GITHUB_TOKEN` is sufficient (no App token needed). The script is idempotent:
+if the PR already carries `hold`, it does nothing.
+
+### Real failure vs cancellation (the critical footgun)
+
+When the merge queue rebuilds a group (membership change: main advanced, a PR
+ahead was dequeued, a PR added/removed) it **cancels** the in-flight runs of the
+old group. GitHub surfaces that cancellation as a **run-level `failure`** too —
+but with **zero failed jobs** (jobs are `cancelled`/`success`/`skipped`, none
+`failure`). Parking on those would wrongly hold healthy, merely-re-grouped PRs.
+
+So the script never trusts the run-level conclusion. It fetches the run's jobs
+(`repos/<repo>/actions/runs/<id>/jobs`, paginated for the 114-job matrix) and
+parks **only when at least one job has `conclusion == "failure"`**. Zero failed
+jobs ⇒ cancellation ⇒ do nothing. This is exactly the failure mode recorded in
+memory `project_merge_queue_requeue_cancels_run`.
+
+## Acceptance criteria
+
+- New workflow triggers on `workflow_run` { `Test262 Sharded`, `CI` } completion
+  and acts only when `event == 'merge_group'` and `conclusion == 'failure'`.
+- A genuinely-failed merge_group run → offending PR gets `hold` + one comment.
+- A cancelled merge_group run (0 failed jobs) → no action.
+- Re-running on an already-parked PR is a no-op (no duplicate comment/label).
+- Additive: auto-enqueue / queue-unstick / merge-group-sweeper unchanged.
+- `node scripts/auto-park-merge-group-failure.mjs --self-check` passes (branch
+  parse + failure/cancellation classification, no network).
+
+## Files
+
+- `.github/workflows/auto-park-merge-group-failures.yml` — the trigger + gate.
+- `scripts/auto-park-merge-group-failure.mjs` — mapping, real-vs-cancellation
+  classification, parking, and the `--self-check` unit checks.

--- a/scripts/auto-park-merge-group-failure.mjs
+++ b/scripts/auto-park-merge-group-failure.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+// auto-park-merge-group-failure.mjs — park a PR that FAILED a required CI
+// workflow in the MERGE QUEUE, so the auto-enqueue sweep stops re-adding it.
+//
+// WHY THIS EXISTS (#2547): test262 now runs only in the merge_group (the #2519
+// slim-down), so a PR can be fully green at PR-time yet carry a REAL test262
+// regression that only surfaces when the queue validates it on the merged
+// state. GitHub ejects the PR from the queue, but `auto-enqueue` sees it is
+// still PR-green and re-enqueues it — it cycles forever, burning a ~15-minute
+// merge_group CI run every lap. This script breaks that loop: when a required
+// workflow concludes `failure` for a `merge_group` event, it parks the
+// offending PR by adding the `hold` label (which `enqueue-green-prs.mjs` skips
+// via HOLD_LABELS) and posts ONE idempotent comment telling the author to fix
+// the failure and remove `hold` to re-enqueue.
+//
+// CRITICAL — REAL FAILURE vs CANCELLATION (the #1 footgun; see memory
+// project_merge_queue_requeue_cancels_run / project_merge_queue_dup_issue_id_churn).
+// When the merge queue rebuilds a group (a membership change: main advanced, an
+// entry ahead was dequeued, a PR was added/removed) it CANCELS the in-flight
+// runs of the old group. GitHub surfaces that cancellation as a RUN-LEVEL
+// `failure` conclusion too — but with ZERO failed JOBS (every job is
+// `cancelled`/`success`, none `failure`). Parking on those would wrongly hold
+// healthy PRs that were merely re-grouped. So we NEVER trust the run-level
+// conclusion alone: we fetch the run's jobs and park ONLY when at least one job
+// has `conclusion === "failure"` (a genuinely failed shard/check). Zero failed
+// jobs ⇒ it was a cancellation ⇒ do nothing.
+//
+// USAGE
+//   node scripts/auto-park-merge-group-failure.mjs <run-id>
+//     Reads the run, maps gh-readonly-queue/main/pr-<N>-<sha> -> PR N, checks
+//     for a genuinely-failed job, and parks PR N. Requires `gh` authenticated
+//     with pull-requests:write, issues:write, actions:read (GITHUB_TOKEN is
+//     sufficient — labelling/commenting does not need to trigger a downstream
+//     workflow).
+//   node scripts/auto-park-merge-group-failure.mjs --self-check
+//     Runs the pure-logic unit checks (branch parse + real-vs-cancellation
+//     classification) with no network access and exits non-zero on failure.
+//   DRY_RUN=1 ... : log the decision without labelling/commenting.
+
+import { execFileSync } from "node:child_process";
+
+const REPO = process.env.GH_REPO || "loopdive/js2";
+const DRY = process.argv.includes("--dry-run") || process.env.DRY_RUN === "1";
+const HOLD_LABEL = "hold"; // matches enqueue-green-prs.mjs HOLD_LABELS
+const MARKER = "<!-- auto-park-bot:merge-group-failure -->";
+
+// IMPORTANT: invoke gh via execFileSync with an ARG ARRAY (never a shell
+// string) — args bypass the shell so refs/SHAs with special chars are safe.
+function gh(args) {
+  return execFileSync("gh", args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}
+function ghMaybe(args) {
+  try {
+    return { ok: true, stdout: gh(args), stderr: "" };
+  } catch (e) {
+    return { ok: false, stdout: String(e.stdout || ""), stderr: String(e.stderr || e.message || e) };
+  }
+}
+
+// --- pure logic (unit-tested via --self-check) ------------------------------
+
+// Parse a merge-queue ref into its PR number. The merge queue names its
+// synthetic branches `gh-readonly-queue/<base>/pr-<N>-<headSha>` (confirmed in
+// merge-group-sweeper.yml / queue-unstick.yml). Returns the PR number or null
+// for any branch that is not a queue ref (we must never park on those).
+export function prNumberFromQueueBranch(branch) {
+  if (typeof branch !== "string") return null;
+  const m = branch.match(/^gh-readonly-queue\/[^/]+\/pr-(\d+)-[0-9a-f]+$/);
+  return m ? Number(m[1]) : null;
+}
+
+// Classify a run from its jobs list. A merge-group run that the queue CANCELLED
+// (group rebuilt) reports run-level `failure` but has NO job with
+// conclusion === "failure" (jobs are cancelled/success/skipped). A GENUINE
+// failure has >= 1 failed job. Returns { realFailure, failedJobs }.
+export function classifyRun(jobs) {
+  const failedJobs = (jobs || []).filter((j) => j && j.conclusion === "failure").map((j) => j.name);
+  return { realFailure: failedJobs.length > 0, failedJobs };
+}
+
+// --- gh-backed actions ------------------------------------------------------
+
+function fetchJobs(runId) {
+  // Paginate so a 114-job test262 matrix is fully covered.
+  const out = gh([
+    "api",
+    "--paginate",
+    `repos/${REPO}/actions/runs/${runId}/jobs?per_page=100`,
+    "--jq",
+    ".jobs[] | {name, conclusion}",
+  ]);
+  // --jq with --paginate streams one JSON object per line.
+  return out
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .map((l) => JSON.parse(l));
+}
+
+function prHasHoldLabel(prNumber) {
+  const res = ghMaybe(["pr", "view", String(prNumber), "--repo", REPO, "--json", "labels", "--jq", "[.labels[].name]"]);
+  if (!res.ok) return false;
+  try {
+    const names = JSON.parse(res.stdout.trim() || "[]").map((n) => String(n).toLowerCase());
+    return names.includes(HOLD_LABEL);
+  } catch {
+    return false;
+  }
+}
+
+function park(prNumber, failedJobs) {
+  if (DRY) {
+    console.log(`auto-park: DRY RUN — would park #${prNumber} (failed: ${failedJobs.join(", ")})`);
+    return;
+  }
+  // Idempotent: if already held, do nothing (avoids re-commenting on requeues).
+  if (prHasHoldLabel(prNumber)) {
+    console.log(`auto-park: #${prNumber} already has \`${HOLD_LABEL}\` — nothing to do.`);
+    return;
+  }
+  // Add the hold label. REST API (not `gh pr edit --add-label`, which has hit a
+  // Projects-classic error on this repo — see memory
+  // project_merge_queue_dup_issue_id_churn).
+  const label = ghMaybe([
+    "api",
+    "-X",
+    "POST",
+    `repos/${REPO}/issues/${prNumber}/labels`,
+    "-f",
+    `labels[]=${HOLD_LABEL}`,
+  ]);
+  // Post one idempotent comment, guarded by the HTML marker.
+  const body = `${MARKER}
+auto-parked: failed required CI in the merge_group — a real test262/quality regression only surfaces on the merged state, so this PR cycles forever in the queue otherwise (#2547). Fix the failure and remove the \`${HOLD_LABEL}\` label to re-enqueue.
+
+Failed checks:
+${failedJobs.map((n) => `- ${n}`).join("\n")}`;
+  const comment = ghMaybe(["pr", "comment", String(prNumber), "--repo", REPO, "--body", body]);
+  console.log(
+    `auto-park: parked #${prNumber} (label=${label.ok} comment=${comment.ok}) — failed: ${failedJobs.join(", ")}`,
+  );
+  if (!label.ok) console.error(`  label error: ${(label.stderr || "").split("\n")[0].slice(0, 160)}`);
+  if (!comment.ok) console.error(`  comment error: ${(comment.stderr || "").split("\n")[0].slice(0, 160)}`);
+}
+
+// --- self-check (no network) ------------------------------------------------
+
+function selfCheck() {
+  let failures = 0;
+  const eq = (got, want, label) => {
+    const g = JSON.stringify(got);
+    const w = JSON.stringify(want);
+    if (g !== w) {
+      console.error(`FAIL ${label}: got ${g}, want ${w}`);
+      failures++;
+    } else {
+      console.log(`ok   ${label}`);
+    }
+  };
+
+  // Branch parsing.
+  eq(prNumberFromQueueBranch("gh-readonly-queue/main/pr-2547-0a1b2c3d4e5f"), 2547, "parse queue ref");
+  eq(prNumberFromQueueBranch("gh-readonly-queue/release/pr-12-abcdef0"), 12, "parse non-main base");
+  eq(prNumberFromQueueBranch("main"), null, "non-queue branch -> null");
+  eq(prNumberFromQueueBranch("issue-2547-foo"), null, "feature branch -> null");
+  eq(prNumberFromQueueBranch("gh-readonly-queue/main/pr-xx-abc"), null, "malformed N -> null");
+  eq(prNumberFromQueueBranch(undefined), null, "undefined -> null");
+
+  // Real-vs-cancellation classification.
+  eq(
+    classifyRun([
+      { name: "quality", conclusion: "success" },
+      { name: "merge shard reports", conclusion: "failure" },
+    ]),
+    { realFailure: true, failedJobs: ["merge shard reports"] },
+    "real failure: one failed job",
+  );
+  eq(
+    classifyRun([
+      { name: "quality", conclusion: "cancelled" },
+      { name: "test262 shard 1", conclusion: "cancelled" },
+      { name: "test262 shard 2", conclusion: "success" },
+    ]),
+    { realFailure: false, failedJobs: [] },
+    "cancellation: zero failed jobs (queue rebuild) -> do not park",
+  );
+  eq(classifyRun([]), { realFailure: false, failedJobs: [] }, "empty jobs -> do not park");
+  eq(
+    classifyRun([
+      { name: "a", conclusion: "failure" },
+      { name: "b", conclusion: "failure" },
+    ]),
+    { realFailure: true, failedJobs: ["a", "b"] },
+    "multiple failed jobs collected",
+  );
+
+  if (failures) {
+    console.error(`\n${failures} self-check(s) failed`);
+    process.exit(1);
+  }
+  console.log("\nall self-checks passed");
+  process.exit(0);
+}
+
+// --- entrypoint -------------------------------------------------------------
+
+function isMain() {
+  return process.argv[1] && process.argv[1].endsWith("auto-park-merge-group-failure.mjs");
+}
+
+if (isMain()) {
+  if (process.argv.includes("--self-check")) {
+    selfCheck();
+  }
+
+  const runId = process.argv.find((a) => /^\d+$/.test(a));
+  if (!runId) {
+    console.error("usage: auto-park-merge-group-failure.mjs <run-id> [--dry-run]");
+    process.exit(2);
+  }
+
+  // Resolve the run's head_branch + event so we can map and double-check it was
+  // a merge_group run (the workflow already gates on this, but be defensive).
+  const runJson = JSON.parse(
+    gh(["api", `repos/${REPO}/actions/runs/${runId}`, "--jq", "{head_branch, event, conclusion, name}"]),
+  );
+  if (runJson.event !== "merge_group") {
+    console.log(`auto-park: run ${runId} event=${runJson.event} (not merge_group) — skipping.`);
+    process.exit(0);
+  }
+  const prNumber = prNumberFromQueueBranch(runJson.head_branch);
+  if (!prNumber) {
+    console.log(`auto-park: run ${runId} head_branch="${runJson.head_branch}" is not a queue ref — skipping.`);
+    process.exit(0);
+  }
+
+  const jobs = fetchJobs(runId);
+  const { realFailure, failedJobs } = classifyRun(jobs);
+  if (!realFailure) {
+    console.log(
+      `auto-park: run ${runId} (PR #${prNumber}) has 0 failed jobs of ${jobs.length} — CANCELLATION (queue rebuild), NOT parking.`,
+    );
+    process.exit(0);
+  }
+  console.log(
+    `auto-park: run ${runId} (${runJson.name}) for PR #${prNumber} has ${failedJobs.length} genuinely-failed job(s) — parking.`,
+  );
+  park(prNumber, failedJobs);
+}


### PR DESCRIPTION
## Problem (#2547)

After the #2519 slim-down, the full test262 matrix runs **only in the merge_group**, not on the PR. So a PR can be fully green at PR-time yet carry a **real** test262/quality regression that surfaces only when the merge queue validates it on the merged-with-main state. GitHub ejects that PR from the queue, but `auto-enqueue` (`scripts/enqueue-green-prs.mjs`) still sees it as PR-green and re-enqueues it — it cycles forever, burning a ~15-minute merge_group CI run every lap and starving the serial queue. Nothing parks it today.

## Fix

New **additive** workflow `.github/workflows/auto-park-merge-group-failures.yml` listens for the required CI workflows completing (`Test262 Sharded`, `CI`). When a run was a `merge_group` run that concluded `failure`, it routes to `scripts/auto-park-merge-group-failure.mjs`, which:

1. Maps the run's `head_branch` (`gh-readonly-queue/main/pr-<N>-<sha>`) → PR N.
2. **Distinguishes a real failure from a cancellation** (see below).
3. On a genuine failure, parks PR N: adds the `hold` label (which `enqueue-green-prs.mjs` skips via `HOLD_LABELS`, stopping the re-enqueue loop) and posts **one** idempotent comment (HTML-marker guarded) telling the author to fix the failure and remove `hold` to re-enqueue.

`GITHUB_TOKEN` suffices — labelling/commenting do not trigger a downstream workflow, so no App token is needed. Idempotent: if the PR already carries `hold`, it does nothing.

## Real failure vs cancellation (the critical footgun)

When the merge queue rebuilds a group (membership change: main advanced, a PR ahead dequeued, a PR added/removed) it **cancels** the in-flight runs of the old group. GitHub surfaces that cancellation as a **run-level `failure`** too — but with **zero failed jobs** (jobs are `cancelled`/`success`/`skipped`, none `failure`). Parking on those would wrongly hold healthy, merely-re-grouped PRs (memory `project_merge_queue_requeue_cancels_run`).

So the script never trusts the run-level conclusion. It fetches the run's jobs (`repos/<repo>/actions/runs/<id>/jobs`, paginated for the 114-job matrix) and parks **only when at least one job has `conclusion == "failure"`**. Zero failed jobs ⇒ cancellation ⇒ do nothing.

## Validation

- `node scripts/auto-park-merge-group-failure.mjs --self-check` — branch-parse + failure/cancellation classification unit checks (no network). Also run as a CI step in the workflow itself before any action.
- `pnpm run check:issues` / `check:issue-ids --against-main` green (issue id 2547 allocated via `claim-issue.mjs --allocate`, #2531).
- `biome lint` + `prettier --check` clean.
- Additive: `auto-enqueue.yml` / `queue-unstick.yml` / `merge-group-sweeper.yml` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)