### PR TITLE
ci(security): author-trust gate for auto-enqueue (#2549)

### DIFF
--- a/plan/issues/2549-auto-enqueue-author-trust-gate.md
+++ b/plan/issues/2549-auto-enqueue-author-trust-gate.md
@@ -1,0 +1,80 @@
+---
+id: 2549
+title: "Author-trust gate for auto-enqueue: never auto-merge external PRs"
+status: done
+sprint: 64
+created: 2026-06-20
+completed: 2026-06-20
+priority: high
+feasibility: low
+task_type: infrastructure
+area: tooling
+language_feature: n/a
+goal: correctness
+related: [2547, 2531, 1758]
+assignee: "ttraenkler/dev-sd3"
+---
+
+# #2549 — author-trust gate for auto-enqueue
+
+## Problem
+
+We just decided (Option 1) that dev agents stop self-enqueuing their PRs;
+`auto-enqueue.yml` (running `scripts/enqueue-green-prs.mjs` with an App token)
+is now the **primary** enqueuer of green PRs. That makes auto-enqueue's trust
+boundary load-bearing.
+
+Before this change, `enqueue-green-prs.mjs` enqueued **any** open, non-draft,
+all-checks-green, non-`hold` PR — it did **not** filter by author. Strangers are
+normally blocked because arbitrary forks' CI does not run without a maintainer
+approving the workflow run (`approve-fork-runs.yml` only auto-approves the
+trusted `ttraenkler/js2` fork). But there is a real gap: **if a maintainer
+manually approves a stranger's CI run** — the normal way to *review* an external
+PR — **and it passes, auto-enqueue would then enqueue it → auto-merge.**
+"Approve CI to review" must NOT mean "approve merge."
+
+## Fix
+
+Add an **author-trust gate** to `scripts/enqueue-green-prs.mjs`: only auto-enqueue
+PRs whose `authorAssociation` is in `TRUSTED_AUTHOR_ASSOCIATIONS`
+(`OWNER` / `MEMBER` / `COLLABORATOR`). Everything else
+(`FIRST_TIME_CONTRIBUTOR` / `NONE` / `CONTRIBUTOR`-without-membership /
+`MANNEQUIN` / unknown) is **skipped** with a logged reason
+`untrusted-author:<assoc>`. So an external PR ALWAYS requires a deliberate human
+enqueue, no matter how green.
+
+Implementation notes:
+- `gh pr list --json authorAssociation` is **not supported** in the container's
+  gh (2.23 — errors `Unknown JSON field: "authorAssociation"`). The script
+  therefore fetches `authorAssociation` for all open PRs in one GraphQL page via
+  a new `authorAssociations()` helper that reuses the script's existing
+  `graphql()` wrapper, returning a `{ prNumber -> assoc }` map.
+- The gate **fails closed**: a PR missing from the map (assoc unknown) is treated
+  as untrusted and never enqueued.
+- It is an **additional** gate, layered after the existing
+  draft / hold-label / already-queued / `ENQUEUEABLE` checks and before the
+  expensive `visibleCheckState` / `greenSince` calls — so the green / grace /
+  back-off / CLA logic is untouched.
+- `cla-check` (a real merge gate now) remains the separate, deeper second line
+  of defense for external contributions; the author gate is the first line. Both
+  are referenced in the new code comments.
+
+## Acceptance criteria
+
+- [x] `enqueue-green-prs.mjs` skips any PR whose `authorAssociation` is not
+  `OWNER`/`MEMBER`/`COLLABORATOR`, with reason `untrusted-author:<assoc>`.
+- [x] `authorAssociation` is fetched via GraphQL (gh-json field unsupported).
+- [x] Trusted set is a clearly-named constant with the
+  "approve-CI ≠ approve-merge" rationale comment, and mentions `cla-check`.
+- [x] Existing green/hold/draft/grace-window/back-off logic unchanged.
+- [x] `node scripts/enqueue-green-prs.mjs --dry-run` runs without crashing and
+  trusted PRs still pass the gate.
+
+## Test results
+
+`node --check` passes. `--dry-run` against live open PRs runs clean (7 open, all
+skipped on prior-stage label/draft/state guards). A direct simulation of the
+gate against the live association map shows all `MEMBER` PRs as trusted
+(would-proceed) and synthetic `FIRST_TIME_CONTRIBUTOR` / `NONE` / `CONTRIBUTOR` /
+`MANNEQUIN` / unknown associations all rejected with `untrusted-author:<assoc>`.
+Prettier `--check` clean.

--- a/scripts/enqueue-green-prs.mjs
+++ b/scripts/enqueue-green-prs.mjs
@@ -43,6 +43,23 @@
 // Combined with the lowered cron (~30 min) + single-flight concurrency guard in
 // the workflow, this removes the high-frequency serial-queue poking entirely.
 //
+// AUTHOR-TRUST GATE (#2549). Auto-enqueue is the PRIMARY enqueuer of green PRs
+// now that dev agents no longer self-enqueue, so its trust boundary is
+// load-bearing. A stranger's fork normally can't even reach "all-green" because
+// arbitrary-fork CI does not run without a maintainer approving the workflow run
+// (approve-fork-runs.yml only auto-approves the trusted `ttraenkler/js2` fork).
+// But "approve CI to review an external PR" is a NORMAL maintainer action, and
+// if that run goes green this sweep would otherwise enqueue it → auto-merge.
+// "Approve CI" must NOT imply "approve merge." So this script ONLY enqueues PRs
+// whose `authorAssociation` is in TRUSTED_AUTHOR_ASSOCIATIONS (OWNER / MEMBER /
+// COLLABORATOR); every external PR (FIRST_TIME_CONTRIBUTOR / NONE / CONTRIBUTOR
+// without org membership) is SKIPPED with `untrusted-author:<assoc>` and ALWAYS
+// requires a deliberate human enqueue, no matter how green. `cla-check`
+// (a real merge gate now) is the separate, deeper line of defense for external
+// contributions; this author gate is the first line. NOTE: `gh pr list --json`
+// does NOT expose authorAssociation (gh 2.23), so it is fetched via GraphQL —
+// see authorAssociations() below.
+//
 // SAFETY: the merge queue re-runs the REQUIRED checks (cheap gate, merge shard
 // reports, quality, equivalence-gate, test262 regression gate) on the merged
 // state before landing, and GitHub branch protection is the hard block. The
@@ -68,6 +85,16 @@ const HOLD_LABELS = new Set(["hold", "do-not-merge", "do not merge", "wip", "blo
 // the state that allowed red PRs to enter the merge queue.
 const ENQUEUEABLE = new Set(["CLEAN", "HAS_HOOKS"]);
 const PASSING_CHECK_STATES = new Set(["pass", "skipping"]);
+// AUTHOR-TRUST GATE (#2549). Only PRs whose authorAssociation is one of these
+// are auto-enqueueable. The rationale: auto-enqueue is now the primary enqueuer
+// of green PRs, and a maintainer manually approving a STRANGER's CI run to
+// review their external PR ("approve CI") must NOT cascade into an auto-merge
+// ("approve merge"). OWNER/MEMBER/COLLABORATOR are people with write/org access
+// — work the merge queue may land unattended. Everything else
+// (FIRST_TIME_CONTRIBUTOR / NONE / CONTRIBUTOR-without-membership) is external
+// and ALWAYS requires a deliberate human enqueue. `cla-check` remains the
+// separate, deeper merge gate for external contributions; this is the first line.
+const TRUSTED_AUTHOR_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 
 const [OWNER, NAME] = REPO.split("/");
 
@@ -123,6 +150,26 @@ function openPrs() {
       "number,mergeStateStatus,isDraft,labels,id,title,headRefName,createdAt",
     ]),
   );
+}
+
+// AUTHOR-TRUST GATE (#2549). `gh pr list --json` cannot return authorAssociation
+// (unsupported field in gh 2.23 — it errors "Unknown JSON field"), so fetch it
+// for all open PRs in one GraphQL page and return a { prNumber -> assoc } map.
+// `authorAssociation` is OWNER / MEMBER / COLLABORATOR / CONTRIBUTOR /
+// FIRST_TIME_CONTRIBUTOR / FIRST_TIMER / MANNEQUIN / NONE (the actor's relation
+// to the BASE repo, loopdive/js2). A number missing from the map (e.g. >100 open
+// PRs, or a transient GraphQL hiccup) is treated as untrusted by the caller —
+// fail closed, never enqueue a PR whose association we could not confirm.
+function authorAssociations() {
+  const r = graphql(
+    `{ repository(owner:"${OWNER}",name:"${NAME}"){ pullRequests(first:100,states:OPEN){ nodes { number authorAssociation } } } }`,
+  );
+  const nodes = r?.data?.repository?.pullRequests?.nodes || [];
+  const byNumber = new Map();
+  for (const n of nodes) {
+    if (n?.number != null) byNumber.set(n.number, n.authorAssociation || "NONE");
+  }
+  return byNumber;
 }
 
 // "green since" = the most-recent completion time across the PR's check
@@ -237,6 +284,10 @@ if (forming.length > 0) {
 }
 
 const prs = openPrs();
+// AUTHOR-TRUST GATE (#2549). Fetch authorAssociation for all open PRs once (gh
+// pr list cannot return it). The enqueue loop fails closed: a PR missing from
+// this map, or whose association is not trusted, is never auto-enqueued.
+const authorAssoc = authorAssociations();
 const enqueued = [];
 const skipped = [];
 const updated = [];
@@ -296,6 +347,15 @@ for (const pr of prs) {
   }
   if (!ENQUEUEABLE.has(pr.mergeStateStatus)) {
     skipped.push([pr.number, pr.mergeStateStatus]); // BLOCKED/BEHIND/DIRTY/DRAFT/UNKNOWN
+    continue;
+  }
+  // AUTHOR-TRUST GATE (#2549). Fail closed: only OWNER/MEMBER/COLLABORATOR PRs
+  // auto-enqueue. An external PR — even one a maintainer manually approved CI
+  // for, to review it — ALWAYS needs a deliberate human enqueue. "Approve CI"
+  // ≠ "approve merge." A PR missing from the map (assoc unknown) is untrusted.
+  const assoc = authorAssoc.get(pr.number) || "UNKNOWN";
+  if (!TRUSTED_AUTHOR_ASSOCIATIONS.has(assoc)) {
+    skipped.push([pr.number, `untrusted-author:${assoc}`]);
     continue;
   }
   const checks = visibleCheckState(pr.number);


### PR DESCRIPTION
## Problem

We just decided (Option 1) that dev agents stop self-enqueuing PRs;
`auto-enqueue.yml` (App token, `scripts/enqueue-green-prs.mjs`) is now the
**primary** enqueuer of green PRs. That makes its trust boundary load-bearing.

Before this change the sweep enqueued **any** open, non-draft, all-green,
non-`hold` PR — **no author filter**. Strangers are normally blocked because
arbitrary-fork CI does not run without a maintainer approving the workflow run.
But there is a real gap: a maintainer manually approving a **stranger's** CI run
— the normal way to *review* an external PR — would, if it goes green, let
auto-enqueue queue it → **auto-merge**. "Approve CI to review" must NOT mean
"approve merge."

## Fix

Add an **author-trust gate**: only auto-enqueue PRs whose `authorAssociation` is
in `TRUSTED_AUTHOR_ASSOCIATIONS` = `{OWNER, MEMBER, COLLABORATOR}`. Every other
author (`FIRST_TIME_CONTRIBUTOR` / `NONE` / `CONTRIBUTOR`-without-membership /
`MANNEQUIN` / missing-from-map) is **skipped** with a logged
`untrusted-author:<assoc>` and always needs a deliberate human enqueue, no
matter how green. The gate **fails closed** — an association we can't confirm is
treated as untrusted.

Details:
- `gh pr list --json authorAssociation` is **unsupported** in the container's gh
  (2.23 — `Unknown JSON field`). A new `authorAssociations()` helper fetches it
  for all open PRs in one GraphQL page via the script's existing `graphql()`
  wrapper, returning a `{ prNumber -> assoc }` map.
- The gate is **additional**: layered after the existing
  draft / hold-label / already-queued / `ENQUEUEABLE` checks and **before** the
  expensive `visibleCheckState` / `greenSince` calls. The green / grace /
  back-off / CLA-rerun logic is untouched.
- The trusted set is a named constant with an "approve-CI ≠ approve-merge"
  rationale comment; `cla-check` (a real merge gate now) is noted as the
  separate, deeper second line of defense.

## Validation

- `node --check` passes; `node scripts/enqueue-green-prs.mjs --dry-run` runs
  clean (no crash).
- Direct simulation against the live association map: all `MEMBER` PRs are
  trusted (would-proceed); synthetic `FIRST_TIME_CONTRIBUTOR` / `NONE` /
  `CONTRIBUTOR` / `MANNEQUIN` / unknown are all rejected
  `untrusted-author:<assoc>`.
- `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA