### PR TITLE
fix(ci): allow the maintainer's fork through the author-trust gate (#2550)

### DIFF
--- a/plan/issues/2550-trust-gate-fork-allowlist.md
+++ b/plan/issues/2550-trust-gate-fork-allowlist.md
@@ -1,0 +1,84 @@
+---
+id: 2550
+title: "Author-trust gate must allow the maintainer's fork — auto-enqueue locked out ALL fork PRs"
+status: done
+sprint: 64
+created: 2026-06-20
+completed: 2026-06-20
+priority: high
+feasibility: low
+task_type: infrastructure
+area: tooling
+language_feature: n/a
+goal: correctness
+related: [2549, 2547, 1758]
+assignee: "ttraenkler/dev-gate"
+---
+
+# #2550 — author-trust gate fork allowlist
+
+## Problem
+
+The #2549 author-trust gate in `scripts/enqueue-green-prs.mjs` only auto-enqueues
+PRs whose `authorAssociation` is `OWNER` / `MEMBER` / `COLLABORATOR`. But GitHub
+classifies the maintainer `ttraenkler` — whose fork (`ttraenkler/js2`) the WHOLE
+team pushes to — as `authorAssociation=CONTRIBUTOR` on the base repo (they have
+merged PRs but are not an org MEMBER). So with the association check alone,
+**every** team fork PR was skipped with `untrusted-author:CONTRIBUTOR`,
+auto-enqueue was effectively disabled, and the tech-lead had to hand-enqueue
+every green PR. Confirmed live in the auto-enqueue log:
+`#1779 skip (untrusted-author:CONTRIBUTOR)`.
+
+## Fix (USER-APPROVED — approach a: code allowlist by login/fork)
+
+Layer a login/fork allowlist **alongside** the existing
+`TRUSTED_AUTHOR_ASSOCIATIONS` check, mirroring `approve-fork-runs.yml`'s existing
+"trusted `ttraenkler/js2` fork" notion. A PR is trusted if it satisfies **ANY**
+of:
+
+1. `authorAssociation ∈ {OWNER, MEMBER, COLLABORATOR}` (unchanged #2549 path), OR
+2. author login ∈ `TRUSTED_AUTHOR_LOGINS` (default `["ttraenkler"]`), OR
+3. head-repository owner ∈ `TRUSTED_FORK_OWNERS` (default `["ttraenkler"]`).
+
+Everything else still **FAILS CLOSED** — a stranger `CONTRIBUTOR`/`NONE`/unknown
+is never auto-enqueued and still requires a deliberate human enqueue.
+`cla-check` remains the deeper merge gate for external contributions.
+
+### Implementation notes
+
+- New pure exported helper `isTrustedAuthor({ assoc, authorLogin, headRepoOwner })`
+  → `{ trusted, reason }`. The inline gate now calls it. Exported so it can be
+  unit-tested without running the live `gh` sweep.
+- The live sweep body is wrapped in `runSweep()`, invoked only under an
+  `import.meta.url === pathToFileURL(process.argv[1])` main-module guard (the
+  convention used across `scripts/`). Importing the module makes **no** `gh`
+  call — required for the test to import `isTrustedAuthor` safely.
+- `openPrs()` now also fetches `author` and `headRepositoryOwner` (both ARE
+  supported by `gh 2.23`'s `pr list --json`, unlike `authorAssociation` which
+  needs GraphQL) to feed the allowlist.
+- Both `TRUSTED_AUTHOR_LOGINS` and `TRUSTED_FORK_OWNERS` are env-overridable,
+  comma-separated, lower-cased; the membership check is exact (no substring
+  trust). Kept narrow — a deliberate trust grant, not a convenience widening.
+
+## Acceptance criteria
+
+- [x] `ttraenkler` + `CONTRIBUTOR` now PASSES the gate (`trusted-login:ttraenkler`).
+- [x] A head-repo owned by `ttraenkler` passes even with a non-`ttraenkler`
+  author login (`trusted-fork:ttraenkler`).
+- [x] `OWNER`/`MEMBER`/`COLLABORATOR` still pass by association alone.
+- [x] A stranger (`CONTRIBUTOR`/`FIRST_TIME_CONTRIBUTOR`/`NONE`/`MANNEQUIN`/
+  unknown) with no allowlist match still SKIPS (`untrusted-author:<assoc>`) —
+  fail closed.
+- [x] Missing/empty input fails closed.
+- [x] Importing the script makes no `gh` calls; `--dry-run` runs without crashing.
+- [x] Unit test in `tests/issue-2550-trust-gate-fork-allowlist.test.ts`.
+
+## Test results
+
+`node --check` passes; `prettier --check` clean.
+`npx vitest run tests/issue-2550-trust-gate-fork-allowlist.test.ts` → 13/13 pass.
+`DRY_RUN=1 node scripts/enqueue-green-prs.mjs` against live open PRs runs clean —
+fork PRs are no longer skipped `untrusted-author:CONTRIBUTOR` (they now fall
+through to the ordinary green/state checks). Direct gate simulation:
+`ttraenkler`+`CONTRIBUTOR` → `{trusted:true, trusted-login:ttraenkler}`; stranger
+`NONE` → `{trusted:false, untrusted-author:NONE}`.

--- a/scripts/enqueue-green-prs.mjs
+++ b/scripts/enqueue-green-prs.mjs
@@ -74,6 +74,8 @@
 // Requires `gh` authenticated (GITHUB_TOKEN with pull-requests:write in CI).
 
 import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const REPO = process.env.GH_REPO || "loopdive/js2";
 const DRY = process.argv.includes("--dry-run") || process.env.DRY_RUN === "1";
@@ -95,6 +97,58 @@ const PASSING_CHECK_STATES = new Set(["pass", "skipping"]);
 // and ALWAYS requires a deliberate human enqueue. `cla-check` remains the
 // separate, deeper merge gate for external contributions; this is the first line.
 const TRUSTED_AUTHOR_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+
+// FORK-ALLOWLIST LAYER (#2550). The whole team works through the maintainer's
+// own fork `ttraenkler/js2`, but GitHub classifies that maintainer as
+// `authorAssociation=CONTRIBUTOR` on the base repo (they've had PRs merged but
+// are not an org MEMBER). With the association check alone, EVERY team fork PR
+// was skipped `untrusted-author:CONTRIBUTOR` — auto-enqueue was effectively
+// disabled and the tech-lead had to hand-enqueue every green PR. So we layer a
+// login/fork allowlist ALONGSIDE the association check, mirroring
+// approve-fork-runs.yml's "trusted ttraenkler/js2 fork" notion: a PR is trusted
+// if it satisfies ANY of (association ∈ trusted set) OR (author login ∈
+// TRUSTED_AUTHOR_LOGINS) OR (head repo owner ∈ TRUSTED_FORK_OWNERS). Everything
+// else still FAILS CLOSED — a stranger CONTRIBUTOR/NONE is never auto-enqueued,
+// and `cla-check` remains the deeper merge gate for external contributions. Keep
+// this allowlist narrow: it is a deliberate trust grant, not a convenience.
+const TRUSTED_AUTHOR_LOGINS = new Set(
+  (process.env.TRUSTED_AUTHOR_LOGINS || "ttraenkler")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean),
+);
+// The head-repository owner(s) we trust. Mirrors approve-fork-runs.yml's
+// TRUSTED_FORK (`ttraenkler/js2`) but compares only the OWNER, since a PR's head
+// repo is `<owner>/<any-repo-name>`.
+const TRUSTED_FORK_OWNERS = new Set(
+  (process.env.TRUSTED_FORK_OWNERS || "ttraenkler")
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean),
+);
+
+// Pure trust decision for the author-trust gate (#2549 + #2550 fork allowlist).
+// Returns { trusted: boolean, reason: string }. FAILS CLOSED: a PR is trusted
+// ONLY if it satisfies at least one allowlist condition; anything unrecognised
+// (unknown association, no login, no head-repo owner) is rejected. Exported so
+// the gate can be unit-tested without running the live sweep.
+export function isTrustedAuthor({ assoc, authorLogin, headRepoOwner } = {}) {
+  const a = (assoc || "UNKNOWN").toUpperCase();
+  if (TRUSTED_AUTHOR_ASSOCIATIONS.has(a)) {
+    return { trusted: true, reason: `association:${a}` };
+  }
+  const login = (authorLogin || "").toLowerCase();
+  if (login && TRUSTED_AUTHOR_LOGINS.has(login)) {
+    return { trusted: true, reason: `trusted-login:${login}` };
+  }
+  const owner = (headRepoOwner || "").toLowerCase();
+  if (owner && TRUSTED_FORK_OWNERS.has(owner)) {
+    return { trusted: true, reason: `trusted-fork:${owner}` };
+  }
+  // Fail closed — keep the original logged reason shape so existing log
+  // greps (`untrusted-author:<assoc>`) keep working.
+  return { trusted: false, reason: `untrusted-author:${a}` };
+}
 
 const [OWNER, NAME] = REPO.split("/");
 
@@ -147,7 +201,10 @@ function openPrs() {
       "--limit",
       "100",
       "--json",
-      "number,mergeStateStatus,isDraft,labels,id,title,headRefName,createdAt",
+      // author.login + headRepositoryOwner.login feed the #2550 fork-allowlist
+      // layer of the author-trust gate (both fields ARE supported by gh 2.23's
+      // `pr list --json`, unlike authorAssociation which needs GraphQL).
+      "number,mergeStateStatus,isDraft,labels,id,title,headRefName,createdAt,author,headRepositoryOwner",
     ]),
   );
 }
@@ -269,219 +326,242 @@ function rerunClaCheck(prNumber, branch) {
   return { ok: true, why: `reran cla-check run ${runId}` };
 }
 
-const { queued: inQueue, forming } = mergeQueueSnapshot();
+// The live sweep is wrapped in runSweep() and only invoked when this file is
+// run as the main module (see the import.meta.url guard at the bottom). That
+// keeps `import { isTrustedAuthor } from "./enqueue-green-prs.mjs"` side-effect
+// free so the gate can be unit-tested without making any `gh` calls.
+function runSweep() {
+  const { queued: inQueue, forming } = mergeQueueSnapshot();
 
-// GUARD 1 — back off while a head is forming. A merge group mid-formation is the
-// exact window where poking the serial queue wedges it (#1758). Skip the whole
-// sweep; the next cycle (or CI-completion trigger) retries once the queue is idle.
-if (forming.length > 0) {
+  // GUARD 1 — back off while a head is forming. A merge group mid-formation is the
+  // exact window where poking the serial queue wedges it (#1758). Skip the whole
+  // sweep; the next cycle (or CI-completion trigger) retries once the queue is idle.
+  if (forming.length > 0) {
+    console.log(
+      `enqueue-green-prs: BACK OFF — ${forming.length} queue entr${
+        forming.length === 1 ? "y is" : "ies are"
+      } AWAITING_CHECKS (head forming): ${forming.map((n) => `#${n}`).join(", ")}. Skipping sweep this cycle.`,
+    );
+    process.exit(0);
+  }
+
+  const prs = openPrs();
+  // AUTHOR-TRUST GATE (#2549). Fetch authorAssociation for all open PRs once (gh
+  // pr list cannot return it). The enqueue loop fails closed: a PR missing from
+  // this map, or whose association is not trusted, is never auto-enqueued.
+  const authorAssoc = authorAssociations();
+  const enqueued = [];
+  const skipped = [];
+  const updated = [];
+
+  // Auto-update BEHIND PRs: merge base branch in via GitHub API so they can
+  // re-run CI and eventually become CLEAN. DIRTY PRs (merge conflicts) are
+  // skipped — those need manual resolution.
+  //
+  // OPT-IN ONLY (ALLOW_UPDATE_BRANCH=1). update-branch pushes a merge commit
+  // authored by the CALLER'S token. From auto-enqueue.yml that caller is
+  // github-actions[bot], and GitHub parks pull_request runs triggered by bot
+  // pushes in `action_required` — a state that is neither approvable via API
+  // for same-repo branches nor rerunnable. The 21:05 sweep on 2026-06-11
+  // bot-updated 17 BEHIND PRs and stranded every one with a dead check set
+  // (the exact failure mode that got auto-refresh-prs.yml retired — see its
+  // header). The merge queue builds merge groups against main itself, so PR
+  // branches never need auto-updating from CI. A human running this script
+  // locally with their own token may opt in via ALLOW_UPDATE_BRANCH=1.
+  const ALLOW_UPDATE_BRANCH = process.env.ALLOW_UPDATE_BRANCH === "1";
+  for (const pr of prs) {
+    if (!ALLOW_UPDATE_BRANCH) break;
+    if (pr.mergeStateStatus !== "BEHIND") continue;
+    const labels = (pr.labels || []).map((l) => (l.name || "").toLowerCase());
+    if (pr.isDraft || labels.some((l) => HOLD_LABELS.has(l))) continue;
+    if (DRY) {
+      updated.push([pr.number, "would-update-branch (BEHIND)"]);
+      continue;
+    }
+    try {
+      // gh pr update-branch requires gh ≥ 2.20; fall back to REST API PUT
+      gh(["api", "--method", "PUT", `/repos/${REPO}/pulls/${pr.number}/update-branch`]);
+      updated.push([pr.number, "updated-branch (was BEHIND)"]);
+    } catch (e) {
+      const msg = String(e.stderr || e.message || e)
+        .split("\n")[0]
+        .slice(0, 120);
+      // Conflicts → DIRTY, can't auto-update — skip silently
+      if (!msg.includes("conflict")) {
+        updated.push([pr.number, `update-failed: ${msg}`]);
+      }
+    }
+  }
+
+  for (const pr of prs) {
+    const labels = (pr.labels || []).map((l) => (l.name || "").toLowerCase());
+    if (pr.isDraft) {
+      skipped.push([pr.number, "draft"]);
+      continue;
+    }
+    if (labels.some((l) => HOLD_LABELS.has(l))) {
+      skipped.push([pr.number, "hold-label"]);
+      continue;
+    }
+    if (inQueue.has(pr.number)) {
+      skipped.push([pr.number, "already-queued"]);
+      continue;
+    }
+    if (!ENQUEUEABLE.has(pr.mergeStateStatus)) {
+      skipped.push([pr.number, pr.mergeStateStatus]); // BLOCKED/BEHIND/DIRTY/DRAFT/UNKNOWN
+      continue;
+    }
+    // AUTHOR-TRUST GATE (#2549 + #2550 fork allowlist). Fail closed: a PR is
+    // auto-enqueueable only if its authorAssociation is OWNER/MEMBER/COLLABORATOR
+    // OR its author login is in TRUSTED_AUTHOR_LOGINS OR its head-repo owner is in
+    // TRUSTED_FORK_OWNERS (the maintainer's `ttraenkler` fork — CONTRIBUTOR on the
+    // base repo, so the association check alone locked out the whole team). An
+    // external PR — even one a maintainer manually approved CI for, to review it —
+    // ALWAYS needs a deliberate human enqueue. "Approve CI" ≠ "approve merge." A
+    // PR missing from the association map (assoc unknown) and not on the
+    // login/fork allowlist is untrusted. See isTrustedAuthor() for the decision.
+    const assoc = authorAssoc.get(pr.number) || "UNKNOWN";
+    const trust = isTrustedAuthor({
+      assoc,
+      authorLogin: pr.author?.login,
+      headRepoOwner: pr.headRepositoryOwner?.login,
+    });
+    if (!trust.trusted) {
+      skipped.push([pr.number, trust.reason]);
+      continue;
+    }
+    const checks = visibleCheckState(pr.number);
+    if (checks.error) {
+      skipped.push([pr.number, `checks-unavailable: ${checks.error}`]);
+      continue;
+    }
+    if (checks.failed.length > 0) {
+      skipped.push([pr.number, `failing-checks: ${checks.failed.slice(0, 5).join(", ")}`]);
+      continue;
+    }
+    if (checks.pending.length > 0) {
+      skipped.push([pr.number, `pending-checks: ${checks.pending.slice(0, 5).join(", ")}`]);
+      continue;
+    }
+    // GUARD 3 — grace window. Only enqueue a PR green-but-unqueued for > GRACE.
+    // Too-fresh PRs are left for a later cycle so we never race a dev's own
+    // GraphQL enqueue; this net only catches genuine strays.
+    let green;
+    try {
+      green = greenSince(pr.number);
+    } catch (e) {
+      const msg = String(e.stderr || e.message || e)
+        .split("\n")[0]
+        .slice(0, 120);
+      skipped.push([pr.number, `green-since-failed: ${msg}`]);
+      continue;
+    }
+    if (!green) {
+      skipped.push([pr.number, "no-green-timestamp"]);
+      continue;
+    }
+    const ageMin = (green.ageMs / 60000).toFixed(1);
+    if (green.ageMs < GRACE_MS) {
+      skipped.push([pr.number, `too-fresh (green ${ageMin}m < ${GRACE_MINUTES}m grace)`]);
+      continue;
+    }
+    if (DRY) {
+      enqueued.push([pr.number, `would-enqueue (green ${ageMin}m >= ${GRACE_MINUTES}m grace)`]);
+      continue;
+    }
+    try {
+      graphql(
+        `
+          mutation ($id: ID!) {
+            enqueuePullRequest(input: { pullRequestId: $id }) {
+              clientMutationId
+            }
+          }
+        `,
+        { id: pr.id },
+      );
+      enqueued.push([pr.number, `enqueued (green ${ageMin}m)`]);
+    } catch (e) {
+      // Most common benign error: required checks still in progress (PR just
+      // turned mergeable). Leave it — the next sweep / CI-completion run gets it.
+      const msg = String(e.stderr || e.message || e)
+        .split("\n")[0]
+        .slice(0, 120);
+      // CLA-CHECK SHA STRANDING (#1958a): if the ONLY blocker is a missing
+      // cla-check status on the current head (typical after a merge-main commit),
+      // rerun cla-check so the next sweep enqueues cleanly. We already verified
+      // above that every VISIBLE check is pass/skipping, so cla-check-expected
+      // here means the status is on a stale SHA, not a genuine CLA rejection.
+      if (isClaExpectedError(msg)) {
+        const r = DRY ? { ok: true, why: "would rerun cla-check" } : rerunClaCheck(pr.number, pr.headRefName);
+        skipped.push([pr.number, `cla-check stale on head — ${r.why}; retry next sweep`]);
+      } else {
+        skipped.push([pr.number, `enqueue-failed: ${msg}`]);
+      }
+    }
+  }
+
+  // DRAFT ROT (#1958d). Green drafts are invisible to auto-enqueue BY DESIGN —
+  // but nothing flags them, so a finished draft can rot for ~a day (PRs
+  // #1345/#1335 — the acorn dogfood blocker — sat green as drafts). This pass
+  // lists drafts older than DRAFT_AGE_HOURS whose visible checks are all green
+  // and, ONCE per PR (idempotent on the comment marker + label), nudges the
+  // author to mark it ready. It never un-drafts or enqueues — that stays a human
+  // decision.
+  const DRAFT_AGE_HOURS = Number(process.env.DRAFT_AGE_HOURS ?? "6");
+  const DRAFT_AGE_MS = DRAFT_AGE_HOURS * 60 * 60 * 1000;
+  const STALE_DRAFT_LABEL = "stale-draft";
+  const DRAFT_MARKER = "<!-- enqueue-bot:stale-draft -->";
+  const draftFlagged = [];
+  for (const pr of prs) {
+    if (!pr.isDraft) continue;
+    const labels = (pr.labels || []).map((l) => (l.name || "").toLowerCase());
+    if (labels.some((l) => HOLD_LABELS.has(l))) continue; // wip/hold drafts are intentional
+    if (labels.includes(STALE_DRAFT_LABEL)) {
+      draftFlagged.push([pr.number, "already-flagged"]);
+      continue; // idempotent — flagged on a prior sweep
+    }
+    const ageMs = Date.now() - Date.parse(pr.createdAt);
+    if (!Number.isFinite(ageMs) || ageMs < DRAFT_AGE_MS) continue; // too fresh
+    const checks = visibleCheckState(pr.number);
+    if (checks.error || checks.failed.length > 0 || checks.pending.length > 0) continue; // not green
+    const ageH = (ageMs / 3_600_000).toFixed(1);
+    if (DRY) {
+      draftFlagged.push([pr.number, `would-flag (green draft ${ageH}h old)`]);
+      continue;
+    }
+    // Post one comment + add the label. Both are guarded so re-running is a no-op.
+    const comment = ghMaybe([
+      "pr",
+      "comment",
+      String(pr.number),
+      "--repo",
+      REPO,
+      "--body",
+      `${DRAFT_MARKER}\nThis PR has been a green draft for ${ageH}h. If it is ready, mark it **Ready for review** so auto-enqueue can pick it up; otherwise add a \`wip\`/\`hold\` label so it stops showing up here.`,
+    ]);
+    const label = ghMaybe(["pr", "edit", String(pr.number), "--repo", REPO, "--add-label", STALE_DRAFT_LABEL]);
+    const why =
+      comment.ok && label.ok
+        ? `flagged (green draft ${ageH}h)`
+        : `flag-partial (comment=${comment.ok} label=${label.ok})`;
+    draftFlagged.push([pr.number, why]);
+  }
+
   console.log(
-    `enqueue-green-prs: BACK OFF — ${forming.length} queue entr${
-      forming.length === 1 ? "y is" : "ies are"
-    } AWAITING_CHECKS (head forming): ${forming.map((n) => `#${n}`).join(", ")}. Skipping sweep this cycle.`,
+    `enqueue-green-prs: ${prs.length} open, ${inQueue.size} already queued, grace=${GRACE_MINUTES}m${DRY ? " (DRY RUN)" : ""}`,
   );
+  for (const [n, why] of draftFlagged) console.log(`  ! #${n} draft ${why}`);
+  for (const [n, why] of updated) console.log(`  ~ #${n} ${why}`);
+  for (const [n, why] of enqueued) console.log(`  + #${n} ${why}`);
+  for (const [n, why] of skipped) console.log(`  - #${n} skip (${why})`);
+  console.log(`Done: ${updated.length} branch-updated, ${enqueued.length} ${DRY ? "would be " : ""}enqueued.`);
   process.exit(0);
 }
 
-const prs = openPrs();
-// AUTHOR-TRUST GATE (#2549). Fetch authorAssociation for all open PRs once (gh
-// pr list cannot return it). The enqueue loop fails closed: a PR missing from
-// this map, or whose association is not trusted, is never auto-enqueued.
-const authorAssoc = authorAssociations();
-const enqueued = [];
-const skipped = [];
-const updated = [];
-
-// Auto-update BEHIND PRs: merge base branch in via GitHub API so they can
-// re-run CI and eventually become CLEAN. DIRTY PRs (merge conflicts) are
-// skipped — those need manual resolution.
-//
-// OPT-IN ONLY (ALLOW_UPDATE_BRANCH=1). update-branch pushes a merge commit
-// authored by the CALLER'S token. From auto-enqueue.yml that caller is
-// github-actions[bot], and GitHub parks pull_request runs triggered by bot
-// pushes in `action_required` — a state that is neither approvable via API
-// for same-repo branches nor rerunnable. The 21:05 sweep on 2026-06-11
-// bot-updated 17 BEHIND PRs and stranded every one with a dead check set
-// (the exact failure mode that got auto-refresh-prs.yml retired — see its
-// header). The merge queue builds merge groups against main itself, so PR
-// branches never need auto-updating from CI. A human running this script
-// locally with their own token may opt in via ALLOW_UPDATE_BRANCH=1.
-const ALLOW_UPDATE_BRANCH = process.env.ALLOW_UPDATE_BRANCH === "1";
-for (const pr of prs) {
-  if (!ALLOW_UPDATE_BRANCH) break;
-  if (pr.mergeStateStatus !== "BEHIND") continue;
-  const labels = (pr.labels || []).map((l) => (l.name || "").toLowerCase());
-  if (pr.isDraft || labels.some((l) => HOLD_LABELS.has(l))) continue;
-  if (DRY) {
-    updated.push([pr.number, "would-update-branch (BEHIND)"]);
-    continue;
-  }
-  try {
-    // gh pr update-branch requires gh ≥ 2.20; fall back to REST API PUT
-    gh(["api", "--method", "PUT", `/repos/${REPO}/pulls/${pr.number}/update-branch`]);
-    updated.push([pr.number, "updated-branch (was BEHIND)"]);
-  } catch (e) {
-    const msg = String(e.stderr || e.message || e)
-      .split("\n")[0]
-      .slice(0, 120);
-    // Conflicts → DIRTY, can't auto-update — skip silently
-    if (!msg.includes("conflict")) {
-      updated.push([pr.number, `update-failed: ${msg}`]);
-    }
-  }
+// Only run the live sweep when invoked directly (`node scripts/enqueue-green-prs.mjs`).
+// When imported (e.g. by the gate unit test) this guard is false, so no `gh`
+// call is made on import. Mirrors the main-module convention used across scripts/.
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  runSweep();
 }
-
-for (const pr of prs) {
-  const labels = (pr.labels || []).map((l) => (l.name || "").toLowerCase());
-  if (pr.isDraft) {
-    skipped.push([pr.number, "draft"]);
-    continue;
-  }
-  if (labels.some((l) => HOLD_LABELS.has(l))) {
-    skipped.push([pr.number, "hold-label"]);
-    continue;
-  }
-  if (inQueue.has(pr.number)) {
-    skipped.push([pr.number, "already-queued"]);
-    continue;
-  }
-  if (!ENQUEUEABLE.has(pr.mergeStateStatus)) {
-    skipped.push([pr.number, pr.mergeStateStatus]); // BLOCKED/BEHIND/DIRTY/DRAFT/UNKNOWN
-    continue;
-  }
-  // AUTHOR-TRUST GATE (#2549). Fail closed: only OWNER/MEMBER/COLLABORATOR PRs
-  // auto-enqueue. An external PR — even one a maintainer manually approved CI
-  // for, to review it — ALWAYS needs a deliberate human enqueue. "Approve CI"
-  // ≠ "approve merge." A PR missing from the map (assoc unknown) is untrusted.
-  const assoc = authorAssoc.get(pr.number) || "UNKNOWN";
-  if (!TRUSTED_AUTHOR_ASSOCIATIONS.has(assoc)) {
-    skipped.push([pr.number, `untrusted-author:${assoc}`]);
-    continue;
-  }
-  const checks = visibleCheckState(pr.number);
-  if (checks.error) {
-    skipped.push([pr.number, `checks-unavailable: ${checks.error}`]);
-    continue;
-  }
-  if (checks.failed.length > 0) {
-    skipped.push([pr.number, `failing-checks: ${checks.failed.slice(0, 5).join(", ")}`]);
-    continue;
-  }
-  if (checks.pending.length > 0) {
-    skipped.push([pr.number, `pending-checks: ${checks.pending.slice(0, 5).join(", ")}`]);
-    continue;
-  }
-  // GUARD 3 — grace window. Only enqueue a PR green-but-unqueued for > GRACE.
-  // Too-fresh PRs are left for a later cycle so we never race a dev's own
-  // GraphQL enqueue; this net only catches genuine strays.
-  let green;
-  try {
-    green = greenSince(pr.number);
-  } catch (e) {
-    const msg = String(e.stderr || e.message || e)
-      .split("\n")[0]
-      .slice(0, 120);
-    skipped.push([pr.number, `green-since-failed: ${msg}`]);
-    continue;
-  }
-  if (!green) {
-    skipped.push([pr.number, "no-green-timestamp"]);
-    continue;
-  }
-  const ageMin = (green.ageMs / 60000).toFixed(1);
-  if (green.ageMs < GRACE_MS) {
-    skipped.push([pr.number, `too-fresh (green ${ageMin}m < ${GRACE_MINUTES}m grace)`]);
-    continue;
-  }
-  if (DRY) {
-    enqueued.push([pr.number, `would-enqueue (green ${ageMin}m >= ${GRACE_MINUTES}m grace)`]);
-    continue;
-  }
-  try {
-    graphql(
-      `
-        mutation ($id: ID!) {
-          enqueuePullRequest(input: { pullRequestId: $id }) {
-            clientMutationId
-          }
-        }
-      `,
-      { id: pr.id },
-    );
-    enqueued.push([pr.number, `enqueued (green ${ageMin}m)`]);
-  } catch (e) {
-    // Most common benign error: required checks still in progress (PR just
-    // turned mergeable). Leave it — the next sweep / CI-completion run gets it.
-    const msg = String(e.stderr || e.message || e)
-      .split("\n")[0]
-      .slice(0, 120);
-    // CLA-CHECK SHA STRANDING (#1958a): if the ONLY blocker is a missing
-    // cla-check status on the current head (typical after a merge-main commit),
-    // rerun cla-check so the next sweep enqueues cleanly. We already verified
-    // above that every VISIBLE check is pass/skipping, so cla-check-expected
-    // here means the status is on a stale SHA, not a genuine CLA rejection.
-    if (isClaExpectedError(msg)) {
-      const r = DRY ? { ok: true, why: "would rerun cla-check" } : rerunClaCheck(pr.number, pr.headRefName);
-      skipped.push([pr.number, `cla-check stale on head — ${r.why}; retry next sweep`]);
-    } else {
-      skipped.push([pr.number, `enqueue-failed: ${msg}`]);
-    }
-  }
-}
-
-// DRAFT ROT (#1958d). Green drafts are invisible to auto-enqueue BY DESIGN —
-// but nothing flags them, so a finished draft can rot for ~a day (PRs
-// #1345/#1335 — the acorn dogfood blocker — sat green as drafts). This pass
-// lists drafts older than DRAFT_AGE_HOURS whose visible checks are all green
-// and, ONCE per PR (idempotent on the comment marker + label), nudges the
-// author to mark it ready. It never un-drafts or enqueues — that stays a human
-// decision.
-const DRAFT_AGE_HOURS = Number(process.env.DRAFT_AGE_HOURS ?? "6");
-const DRAFT_AGE_MS = DRAFT_AGE_HOURS * 60 * 60 * 1000;
-const STALE_DRAFT_LABEL = "stale-draft";
-const DRAFT_MARKER = "<!-- enqueue-bot:stale-draft -->";
-const draftFlagged = [];
-for (const pr of prs) {
-  if (!pr.isDraft) continue;
-  const labels = (pr.labels || []).map((l) => (l.name || "").toLowerCase());
-  if (labels.some((l) => HOLD_LABELS.has(l))) continue; // wip/hold drafts are intentional
-  if (labels.includes(STALE_DRAFT_LABEL)) {
-    draftFlagged.push([pr.number, "already-flagged"]);
-    continue; // idempotent — flagged on a prior sweep
-  }
-  const ageMs = Date.now() - Date.parse(pr.createdAt);
-  if (!Number.isFinite(ageMs) || ageMs < DRAFT_AGE_MS) continue; // too fresh
-  const checks = visibleCheckState(pr.number);
-  if (checks.error || checks.failed.length > 0 || checks.pending.length > 0) continue; // not green
-  const ageH = (ageMs / 3_600_000).toFixed(1);
-  if (DRY) {
-    draftFlagged.push([pr.number, `would-flag (green draft ${ageH}h old)`]);
-    continue;
-  }
-  // Post one comment + add the label. Both are guarded so re-running is a no-op.
-  const comment = ghMaybe([
-    "pr",
-    "comment",
-    String(pr.number),
-    "--repo",
-    REPO,
-    "--body",
-    `${DRAFT_MARKER}\nThis PR has been a green draft for ${ageH}h. If it is ready, mark it **Ready for review** so auto-enqueue can pick it up; otherwise add a \`wip\`/\`hold\` label so it stops showing up here.`,
-  ]);
-  const label = ghMaybe(["pr", "edit", String(pr.number), "--repo", REPO, "--add-label", STALE_DRAFT_LABEL]);
-  const why =
-    comment.ok && label.ok
-      ? `flagged (green draft ${ageH}h)`
-      : `flag-partial (comment=${comment.ok} label=${label.ok})`;
-  draftFlagged.push([pr.number, why]);
-}
-
-console.log(
-  `enqueue-green-prs: ${prs.length} open, ${inQueue.size} already queued, grace=${GRACE_MINUTES}m${DRY ? " (DRY RUN)" : ""}`,
-);
-for (const [n, why] of draftFlagged) console.log(`  ! #${n} draft ${why}`);
-for (const [n, why] of updated) console.log(`  ~ #${n} ${why}`);
-for (const [n, why] of enqueued) console.log(`  + #${n} ${why}`);
-for (const [n, why] of skipped) console.log(`  - #${n} skip (${why})`);
-console.log(`Done: ${updated.length} branch-updated, ${enqueued.length} ${DRY ? "would be " : ""}enqueued.`);
-process.exit(0);

--- a/tests/issue-2550-trust-gate-fork-allowlist.test.ts
+++ b/tests/issue-2550-trust-gate-fork-allowlist.test.ts
@@ -1,0 +1,68 @@
+// #2550 — author-trust gate must allow the maintainer's fork.
+//
+// The #2549 author-trust gate in scripts/enqueue-green-prs.mjs only enqueued
+// PRs whose authorAssociation was OWNER/MEMBER/COLLABORATOR. But GitHub
+// classifies the maintainer `ttraenkler` (whose fork the whole team pushes to)
+// as authorAssociation=CONTRIBUTOR on the base repo, so EVERY fork PR was
+// skipped `untrusted-author:CONTRIBUTOR` and auto-enqueue was effectively
+// disabled. #2550 layers a login/fork allowlist ALONGSIDE the association check.
+//
+// These tests pin the trust decision (`isTrustedAuthor`) directly — they make
+// no `gh` calls (the live sweep is guarded behind an import.meta.url check).
+
+import { describe, expect, it } from "vitest";
+import { isTrustedAuthor } from "../scripts/enqueue-green-prs.mjs";
+
+describe("#2550 author-trust gate fork allowlist", () => {
+  // --- the bug being fixed: the maintainer's fork PRs (CONTRIBUTOR) must pass ---
+
+  it("trusts ttraenkler even as CONTRIBUTOR (login allowlist)", () => {
+    const r = isTrustedAuthor({ assoc: "CONTRIBUTOR", authorLogin: "ttraenkler", headRepoOwner: "ttraenkler" });
+    expect(r.trusted).toBe(true);
+    expect(r.reason).toContain("trusted-login:ttraenkler");
+  });
+
+  it("trusts a PR whose head repo is owned by the ttraenkler fork even if author login differs", () => {
+    // e.g. an agent identity opening from a branch on ttraenkler/js2.
+    const r = isTrustedAuthor({ assoc: "CONTRIBUTOR", authorLogin: "some-agent", headRepoOwner: "ttraenkler" });
+    expect(r.trusted).toBe(true);
+    expect(r.reason).toContain("trusted-fork:ttraenkler");
+  });
+
+  it("login allowlist is case-insensitive", () => {
+    const r = isTrustedAuthor({ assoc: "NONE", authorLogin: "TTraenkler", headRepoOwner: "TTraenkler" });
+    expect(r.trusted).toBe(true);
+  });
+
+  // --- the existing #2549 behaviour must still hold for org members ---
+
+  it.each(["OWNER", "MEMBER", "COLLABORATOR"])("still trusts %s by association alone", (assoc) => {
+    const r = isTrustedAuthor({ assoc, authorLogin: "anybody", headRepoOwner: "anybody" });
+    expect(r.trusted).toBe(true);
+    expect(r.reason).toBe(`association:${assoc}`);
+  });
+
+  // --- fail-closed: strangers stay untrusted no matter how green ---
+
+  it.each(["CONTRIBUTOR", "FIRST_TIME_CONTRIBUTOR", "NONE", "MANNEQUIN", "UNKNOWN"])(
+    "rejects a stranger with association %s (no allowlist match)",
+    (assoc) => {
+      const r = isTrustedAuthor({ assoc, authorLogin: "drive-by", headRepoOwner: "drive-by" });
+      expect(r.trusted).toBe(false);
+      expect(r.reason).toBe(`untrusted-author:${assoc}`);
+    },
+  );
+
+  it("rejects a missing/empty input (fails closed)", () => {
+    expect(isTrustedAuthor({}).trusted).toBe(false);
+    expect(isTrustedAuthor().trusted).toBe(false);
+    // No login and no head-repo owner → only the association decides; UNKNOWN.
+    expect(isTrustedAuthor({ assoc: "" }).reason).toBe("untrusted-author:UNKNOWN");
+  });
+
+  it("does NOT trust a stranger whose login merely contains 'ttraenkler' as a substring", () => {
+    // Set membership is exact — guard against accidental substring trust.
+    const r = isTrustedAuthor({ assoc: "NONE", authorLogin: "not-ttraenkler-evil", headRepoOwner: "evil-fork" });
+    expect(r.trusted).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

The #2549 author-trust gate in `scripts/enqueue-green-prs.mjs` only auto-enqueues PRs whose `authorAssociation` is `OWNER`/`MEMBER`/`COLLABORATOR`. GitHub classifies the maintainer `ttraenkler` — whose fork the **whole team** pushes to — as `authorAssociation=CONTRIBUTOR` on the base repo. So with the association check alone, **every** team fork PR was skipped `untrusted-author:CONTRIBUTOR`, auto-enqueue was effectively disabled, and the tech-lead had to hand-enqueue every green PR (confirmed live: `#1779 skip (untrusted-author:CONTRIBUTOR)`).

## Fix (user-approved — approach a: code allowlist by login/fork)

Layer a login/fork allowlist **alongside** the existing association check, mirroring `approve-fork-runs.yml`'s "trusted `ttraenkler/js2` fork" notion. A PR is trusted if it satisfies **ANY** of:

1. `authorAssociation ∈ {OWNER, MEMBER, COLLABORATOR}` (unchanged #2549 path), OR
2. author login ∈ `TRUSTED_AUTHOR_LOGINS` (default `["ttraenkler"]`), OR
3. head-repo owner ∈ `TRUSTED_FORK_OWNERS` (default `["ttraenkler"]`).

Everything else still **FAILS CLOSED** — a stranger `CONTRIBUTOR`/`NONE`/unknown is never auto-enqueued; `cla-check` stays the deeper merge gate for external contributions.

### Implementation
- New pure exported `isTrustedAuthor({ assoc, authorLogin, headRepoOwner })` → `{ trusted, reason }`; the inline gate now calls it.
- The live sweep is wrapped in `runSweep()`, invoked only under an `import.meta.url` main-module guard, so **importing the module makes no `gh` call** — lets the test import `isTrustedAuthor` without running the live sweep.
- `openPrs()` now also fetches `author` + `headRepositoryOwner` (both gh-json supported, unlike `authorAssociation`) to feed the allowlist.
- Allowlists are env-overridable, comma-separated, **exact-match** (no substring trust). Kept narrow — a deliberate trust grant, not a convenience widening.

## Tests
- New `tests/issue-2550-trust-gate-fork-allowlist.test.ts` — 13 cases: fork PR (CONTRIBUTOR) passes via login & via head-repo owner; org members still pass by association; strangers (`CONTRIBUTOR`/`FIRST_TIME_CONTRIBUTOR`/`NONE`/`MANNEQUIN`/unknown) + empty input fail closed; no substring trust.
- `node --check` + `prettier --check` clean; `biome lint` clean.
- `DRY_RUN=1 node scripts/enqueue-green-prs.mjs` against live PRs runs clean — fork PRs no longer skip `untrusted-author:CONTRIBUTOR`.

Security-sensitive: fail-closed default preserved; allowlist narrow and env-scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA