### PR TITLE
fix(#2551): standalone non-integer numeric-key read truncated the index

### DIFF
--- a/plan/issues/2551-standalone-noninteger-numeric-key-read-truncated.md
+++ b/plan/issues/2551-standalone-noninteger-numeric-key-read-truncated.md
@@ -1,0 +1,113 @@
+---
+id: 2551
+title: "standalone: computed non-integer numeric-key READ truncates the index (o[1.5] reads key \"1\")"
+status: done
+sprint: Backlog
+goal: standalone-conformance
+feasibility: easy
+assignee: ttraenkler/dev-2042
+completed: 2026-06-20
+---
+
+## Problem
+
+In `--target standalone`, a computed READ with a **non-integer numeric literal**
+index reads from the wrong property key:
+
+```ts
+const o: any = {};
+o[1.5] = 4;
+return o[1.5]; // → 0 (should be 4)
+```
+
+The **store** is correct: `o[1.5] = 4` keys the value under the canonical decimal
+string `"1.5"` (verified: `o["1.5"]` reads it back). The **read** truncates `1.5`
+to the integer `1`, stringifies that to `"1"`, and looks up `"1"` — which misses,
+returning `0`.
+
+Confirmed via probes (all on clean `origin/main` HEAD 0df91ffa3):
+
+| expression | before | after fix |
+|---|---|---|
+| `o[1.5]=4; o[1.5]` | 0 | 4 |
+| `{"1.5":4}; o[1.5]` | 0 | 4 |
+| `o["1.5"]=4; o[1.5]` | 0 | 4 |
+| `o["1"]=9; o[1.5]` | 9 (wrong alias) | 0 |
+| `o[3]=7; o[3]` (integer) | 7 | 7 |
+| `Object.values(o)[1]` ($ObjVec) | 20 | 20 |
+
+This was surfaced by the pre-existing failing assertion in
+`tests/issue-2042.test.ts` — `"non-integer numeric key uses canonical decimal
+string"` (`o[1.5]=4; return o[1.5]` expected 4, got 0). The assertion was
+**correct**; the codegen was wrong.
+
+## Root cause
+
+`src/codegen/property-access.ts` `compileElementAccessBody` routes a *provably
+numeric* index on a standalone externref through `__extern_get_idx(v, f64)`
+(#2166 PR-C2). For an array-like `$Object`, `__extern_get_idx`'s `$Object` arm is
+supposed to delegate to `__extern_get(v, ToString(idx))` with the **canonical
+decimal** key. But the arm truncated first:
+
+`src/codegen/object-runtime.ts` `buildExternGetIdxBody` (and a dead duplicate of
+the same arm inline in `ensureObjectRuntime`):
+
+```
+{ op: "local.get", index: 1 },   // idx (f64), e.g. 1.5
+{ op: "f64.trunc" },             // → 1.0   ← BUG
+{ op: "call", funcIdx: number_toString },  // "1" instead of "1.5"
+{ op: "call", funcIdx: __extern_get },     // __extern_get(o, "1") → miss
+```
+
+`ToPropertyKey` of a numeric index is `ToString(idx)` (ECMA-262 §7.1.19
+ToPropertyKey → §7.1.17 ToString → §6.1.6.1.20 Number::toString) — **no
+truncation**. The `f64.trunc` is correct for *positional* `$ObjVec`/typed-vec
+reads (those use a separate `i32.trunc_sat_f64_s` to index the backing array),
+but it is wrong for the string-keyed `$Object` delegation, where the index must
+stringify to its full canonical decimal to match how the store (`__extern_set` →
+`__to_property_key` → `number_toString(__unbox_number(key))`) keyed it.
+
+## Fix
+
+Drop the `f64.trunc` from the `$Object` array-like arm in `buildExternGetIdxBody`
+(`src/codegen/object-runtime.ts`). `number_toString` is canonical
+`Number::toString`, so an integer index still yields `"3"` (positional/array
+reads unregressed), while `1.5` now yields `"1.5"` and matches the store.
+
+Also removed a dead, never-referenced duplicate of the same arm
+(`const objIdxArm` built inline at the `__extern_get_idx` registration site — the
+body is built by `buildExternGetIdxBody`, so the inline copy was unused and
+carried a second buggy `f64.trunc`).
+
+Net: `src/codegen/object-runtime.ts` −24/+12 lines.
+
+## Tests
+
+- `tests/issue-2551.test.ts` (new) — 7 cases: non-integer round-trip (numeric,
+  literal-key, string-key store), the non-aliasing guard (`o["1"]` must NOT be
+  read by `o[1.5]`), integer-read no-regression, integer-literal-key read,
+  `$ObjVec` positional read no-regression. All pass.
+- `tests/issue-2042.test.ts` — the previously-failing `"non-integer numeric key
+  uses canonical decimal string"` assertion now passes; all 14 pass.
+
+## CI coverage gap (noted for follow-up)
+
+`tests/issue-NNN.test.ts` files are **NOT run by the required CI gates** — the
+`quality` job (ci.yml) and the test262-sharded gates do not invoke the per-issue
+vitest suites, so a red `issue-2042.test.ts` (and `issue-2036.test.ts`, see
+below) sat green in CI on `main`. This is why a real codegen bug went unnoticed.
+
+Separately observed while validating: `tests/issue-2036.test.ts` has **5
+pre-existing failures** on clean `origin/main` (`#2036 S6 step 1 — borrowed
+search/result-building methods refuse loudly in standalone`: `indexOf`,
+`lastIndexOf`, `includes`, `reduce`, `reduceRight` no longer compile-error). Same
+CI-coverage gap; unrelated to this fix (the failures reproduce with this change
+reverted). Flagged to the tech lead for a separate triage — these assert a
+*refusal* that no longer happens, so either the feature was implemented and the
+tests are stale, or a refusal regressed silently.
+
+## Spec references
+
+- ECMA-262 §7.1.19 ToPropertyKey
+- ECMA-262 §7.1.17 ToString
+- ECMA-262 §6.1.6.1.20 Number::toString ( x, radix )

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -3228,29 +3228,11 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
   //
   // params: 0=v(externref) 1=idx(f64) ; locals: 2=any(anyref) 3=vec(ref null $ObjVec) 4=i
   {
-    // #2036 — array-like $Object arm (standalone only): return
-    // __extern_get(v, ToString(idx)). number_toString gives the canonical decimal
-    // key ("0","5") matching how {0:x} stores numeric-literal keys; __extern_get
-    // does the proto-walk + value marshaling, returning null for absent (hole)
-    // indices. Omitted in gc/host mode (the host import owns the path).
-    const objIdxArm: Instr[] = objArrayLikeArms
-      ? [
-          { op: "local.get", index: 2 },
-          { op: "ref.test", typeIdx: objectTypeIdx },
-          {
-            op: "if",
-            blockType: { kind: "empty" },
-            then: [
-              { op: "local.get", index: 0 },
-              { op: "local.get", index: 1 },
-              { op: "f64.trunc" },
-              { op: "call", funcIdx: ctx.funcMap.get("number_toString")! },
-              { op: "call", funcIdx: ctx.funcMap.get("__extern_get")! },
-              { op: "return" },
-            ],
-          },
-        ]
-      : [];
+    // The array-like `$Object` arm (#2036) + the $ObjVec/typed-vec arms are all
+    // built by the shared `buildExternGetIdxBody` builder below — the `$Object`
+    // arm returns `__extern_get(v, number_toString(idx))` (the canonical decimal
+    // key, NOT a truncated one — see #2551). number_toString is canonical
+    // Number::toString, matching how `{0:x}` stores numeric-literal keys.
     // (#2190) The per-element-kind `__vec_<k>` indexing arms are NOT known yet
     // (array literals of a given element kind may be compiled AFTER this
     // runtime is emitted). They are appended at FINALIZE by
@@ -6881,7 +6863,13 @@ function buildExternGetIdxBody(p: ExternGetIdxBodyParams): Instr[] {
           then: [
             { op: "local.get", index: 0 },
             { op: "local.get", index: 1 },
-            { op: "f64.trunc" },
+            // #2551 — do NOT truncate: ToPropertyKey of a numeric index is
+            // ToString(idx) (§7.1.19 → §6.1.6.1.20), so a non-integer index must
+            // stringify to its canonical decimal ("1.5"), matching how the STORE
+            // path (`o[1.5] = …` → __extern_set → __to_property_key) keys it. A
+            // prior `f64.trunc` here read `o[1.5]` from key "1" (truncated) while
+            // the write stored under "1.5", so the read missed. number_toString is
+            // canonical Number::toString, so an integer index still yields "3".
             { op: "call", funcIdx: p.numberToStringIdx },
             { op: "call", funcIdx: p.externGetIdx },
             { op: "return" },

--- a/tests/issue-2551.test.ts
+++ b/tests/issue-2551.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2551 — standalone computed numeric-key READ truncated the index before
+// stringifying. `o[1.5]` read routed through `__extern_get_idx(v, f64)` whose
+// array-like `$Object` arm did `f64.trunc` BEFORE `number_toString`, so it read
+// from key "1" while the STORE (`o[1.5] = …` → __extern_set → __to_property_key)
+// keyed it under the canonical decimal "1.5". The read missed and returned 0.
+//
+// ToPropertyKey of a numeric index is ToString(idx) (§7.1.19 → §6.1.6.1.20) — no
+// truncation. The fix drops the `f64.trunc` in the `$Object` arm; an integer
+// index still stringifies to "3" (number_toString is canonical Number::toString),
+// so positional/array reads are unregressed.
+
+async function runStandalone(body: string): Promise<unknown> {
+  const r = await compile(body, { fileName: "test.ts", target: "standalone" });
+  if (!r.success) {
+    throw new Error(`Compile failed:\n${r.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+describe("#2551 standalone non-integer numeric-key read uses canonical decimal string", () => {
+  it("numeric non-integer set + read round-trips (was 0)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const o: any = {}; o[1.5] = 4; return o[1.5]; }`),
+    ).toBe(4);
+  });
+
+  it("literal-key store, numeric non-integer read", async () => {
+    expect(await runStandalone(`export function test(): number { const o: any = {"1.5": 4}; return o[1.5]; }`)).toBe(4);
+  });
+
+  it("string-key store, numeric non-integer read", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const o: any = {}; o["1.5"] = 4; return o[1.5]; }`),
+    ).toBe(4);
+  });
+
+  it('numeric read of 1.5 does NOT alias the truncated key "1"', async () => {
+    // Stored under "1" only; reading o[1.5] must miss (return 0), not read "1".
+    expect(
+      await runStandalone(`export function test(): number { const o: any = {}; o["1"] = 9; return o[1.5]; }`),
+    ).toBe(0);
+  });
+
+  it("integer numeric read still canonicalizes to its decimal string (no regression)", async () => {
+    expect(await runStandalone(`export function test(): number { const o: any = {}; o[3] = 7; return o[3]; }`)).toBe(7);
+  });
+
+  it("integer-literal-keyed object read via numeric index (no regression)", async () => {
+    expect(await runStandalone(`export function test(): number { const o: any = {3: 7}; return o[3]; }`)).toBe(7);
+  });
+
+  it("$ObjVec positional read via numeric index is unregressed", async () => {
+    // Object.values produces an $ObjVec; v[1] must still index positionally.
+    expect(
+      await runStandalone(
+        `export function test(): number { const o: any = { a: 10, b: 20 }; const v: any = Object.values(o); return v[1]; }`,
+      ),
+    ).toBe(20);
+  });
+});


### PR DESCRIPTION
## Problem

In `--target standalone`, a computed READ with a non-integer numeric literal index read from the wrong property key:

```ts
const o: any = {};
o[1.5] = 4;
return o[1.5]; // → 0 (should be 4)
```

The **store** correctly keyed the value under the canonical decimal string `"1.5"` (`o["1.5"]` reads it back), but the **read** truncated `1.5` → `1`, stringified to `"1"`, and missed.

This was surfaced by the pre-existing failing assertion in `tests/issue-2042.test.ts` — `"non-integer numeric key uses canonical decimal string"` (expected 4, got 0). The assertion was **correct**; the codegen was wrong. (That test file is not run by the required CI gates, so it sat red on `main` unnoticed — noted as a coverage gap in the issue file.)

## Root cause

A provably-numeric index on a standalone externref routes through `__extern_get_idx(v, f64)` (#2166 PR-C2). Its array-like `$Object` arm in `buildExternGetIdxBody` (`src/codegen/object-runtime.ts`) truncated the index before stringifying:

```
{ op: "local.get", index: 1 },   // idx (f64), e.g. 1.5
{ op: "f64.trunc" },             // → 1.0   ← BUG
{ op: "call", funcIdx: number_toString },  // "1" instead of "1.5"
{ op: "call", funcIdx: __extern_get },     // __extern_get(o, "1") → miss
```

`ToPropertyKey` of a numeric index is `ToString(idx)` (ECMA-262 §7.1.19 → §6.1.6.1.20 Number::toString) — no truncation.

## Fix

Drop the `f64.trunc` from the `$Object` arm. `number_toString` is canonical `Number::toString`, so an integer index still yields `"3"` — positional `$ObjVec`/typed-vec reads (which `i32.trunc_sat` separately) are unregressed. Also removed a dead, never-referenced duplicate of the same arm carrying a second buggy `f64.trunc`.

`src/codegen/object-runtime.ts`: −24 / +12.

## Tests

- `tests/issue-2551.test.ts` (new) — 7 cases: non-integer round-trip (numeric / literal-key / string-key store), a non-aliasing guard (`o["1"]` must NOT be read by `o[1.5]`), integer-read no-regression, integer-literal-key read, `$ObjVec` positional-read no-regression. All pass.
- `tests/issue-2042.test.ts` — previously-failing assertion now passes; all 14 pass.
- `tsc --noEmit` clean; prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)