### PR TITLE
fix(#2560): auto-enqueue appends trailing green PRs while a head forms

### DIFF
--- a/.github/workflows/auto-enqueue.yml
+++ b/.github/workflows/auto-enqueue.yml
@@ -14,10 +14,14 @@ name: Auto-enqueue green PRs
 # GitHub's `merge_group` formation — poking the serial head WHILE a merge group
 # is mid-formation wedged the queue twice on 2026-05-30/31 (stuck
 # AWAITING_CHECKS, no merge_group dispatched; only a ~10-min ruleset
-# disable/re-enable reset cleared it). So the sweep is now SURGICAL. The script
-# (scripts/enqueue-green-prs.mjs) applies three guards:
-#   1. BACK-OFF — if ANY queue entry is AWAITING_CHECKS (a head is forming), it
-#      skips the entire sweep and lets GitHub finish.
+# disable/re-enable reset cleared it). So the sweep is SURGICAL. The script
+# (scripts/enqueue-green-prs.mjs) applies these guards:
+#   1. TRAILING-ADD ONLY (#2560) — it only enqueues PRs NOT already in the queue,
+#      so every add is a trailing append to the queue tail and the forming head's
+#      merge group is never touched (only dequeuing/re-adding the HEAD cancels its
+#      run). It does NOT skip the whole sweep when a head is forming — that old
+#      over-broad back-off meant the serial queue (almost always has a forming
+#      head) was rarely fed and green PRs stranded until a human enqueued them.
 #   2. ALL-CHECKS GREEN — it rejects UNSTABLE PRs and any PR whose `gh pr
 #      checks` table contains a non-pass/non-skipping row.
 #   3. GRACE WINDOW — it only enqueues a PR whose checks have been green for

--- a/plan/issues/2560-autoenqueue-trailing-add-while-head-forms.md
+++ b/plan/issues/2560-autoenqueue-trailing-add-while-head-forms.md
@@ -1,0 +1,71 @@
+---
+id: 2560
+title: "Auto-enqueue: append trailing green PRs while a head forms (don't skip the whole sweep)"
+status: done
+sprint: 64
+created: 2026-06-20
+completed: 2026-06-20
+priority: high
+feasibility: low
+task_type: infrastructure
+area: tooling
+language_feature: n/a
+goal: correctness
+related: [2549, 2550, 1758]
+assignee: "ttraenkler/dev-backoff"
+---
+
+# #2560 — auto-enqueue must keep feeding the queue while a head is forming
+
+## Problem
+
+`scripts/enqueue-green-prs.mjs` had an over-broad back-off (GUARD 1): if ANY
+merge-queue entry was `AWAITING_CHECKS` ("a head is forming"), it logged
+`BACK OFF … Skipping sweep this cycle.` and `process.exit(0)` — skipping the
+ENTIRE sweep. Because the merge queue is SERIAL (`max_entries_to_build=1`), it
+almost always has a forming head, so auto-enqueue almost never added waiting
+green PRs. They stranded unqueued until a human enqueued them — defeating the
+purpose of the backstop.
+
+## Root cause / why the back-off existed
+
+The original wedge (#1758, `project_merge_queue_requeue_cancels_run`) was caused
+by **dequeuing or re-adding the HEAD** of a forming merge group: any membership
+change to a forming group makes GitHub rebuild it and cancels its in-flight
+`merge_group` run, which stuck the queue at `AWAITING_CHECKS` with no run. The
+back-off was a blunt fix: don't sweep at all while a head forms.
+
+But the sweep only ever enqueues PRs that are **not already in the queue** (the
+`already-queued` skip covers every entry — forming head OR stable — since the
+queue snapshot lists them all). So every enqueue is a **TRAILING APPEND** to the
+queue tail, which leaves the forming head's merge group untouched and does NOT
+cancel its run. The whole-sweep skip was therefore unnecessary for safety and
+harmful for throughput.
+
+## Fix
+
+- Removed the `process.exit(0)` whole-sweep back-off. When a head is forming we
+  now log it for visibility and **proceed** to append trailing green PRs.
+- Encoded the safety invariant as a pure, exported helper
+  `isTrailingAddCandidate(prNumber, queued)` (returns false for any PR already in
+  the queue) and routed the loop's `already-queued` skip through it, so the
+  forming head — and every other queued entry — is never re-touched.
+- Kept ALL other guards unchanged: author-trust gate (`isTrustedAuthor`,
+  #2549/#2550), all-checks-green, grace window, hold/draft/ENQUEUEABLE filters,
+  cla-check stale-SHA rerun, BEHIND auto-update opt-in, draft-rot nudge.
+- Updated the script header + `.github/workflows/auto-enqueue.yml` header to
+  describe the trailing-add reasoning (trailing append safe vs head churn unsafe),
+  referencing #1758.
+
+## Acceptance criteria
+
+- A green, unqueued, trusted PR is enqueued even while another PR's merge group is
+  forming. ✓ (invariant: `isTrailingAddCandidate(green, queued)` is true)
+- The forming head and any stable queued entry are never re-enqueued. ✓
+- Import of the script remains side-effect-free (no `gh` calls on import). ✓
+
+## Test Results
+
+`tests/issue-2560-autoenqueue-trailing-add.test.ts` (5 tests) +
+`tests/issue-2550-trust-gate-fork-allowlist.test.ts` (13 tests) — all 18 pass.
+`node --check` clean; importing the module makes no `gh` call.

--- a/scripts/enqueue-green-prs.mjs
+++ b/scripts/enqueue-green-prs.mjs
@@ -20,13 +20,21 @@
 // 2026-05-30/31 (it stuck AWAITING_CHECKS with no `merge_group` dispatched, and
 // only a ~10-min ruleset disable/re-enable reset cleared it). The mechanism
 // built to un-strand PRs became the thing that wedged the queue. So this sweep
-// is now SURGICAL — three guards keep it from poking a forming queue:
+// is SURGICAL — its guards keep it from poking the FORMING HEAD:
 //
-//   1. BACK-OFF WHILE A HEAD IS FORMING — before sweeping, query the merge
-//      queue. If ANY entry is AWAITING_CHECKS (a merge group is mid-formation),
-//      SKIP THE ENTIRE SWEEP this run and let GitHub finish. We only sweep when
-//      no entry is AWAITING_CHECKS (queue idle / stable / empty). This is the
-//      key anti-wedge guard.
+//   1. NEVER TOUCH A QUEUED ENTRY (trailing-add only). The wedge was caused by
+//      dequeuing / re-adding the HEAD of a forming merge group — that membership
+//      change makes GitHub rebuild the group and cancels its in-flight run
+//      (#1758, project_merge_queue_requeue_cancels_run). This sweep ONLY enqueues
+//      PRs that are NOT already in the queue (the `already-queued` skip below
+//      covers every entry — forming OR stable — since the queue snapshot lists
+//      them all). Every enqueue is therefore a TRAILING APPEND to the queue tail,
+//      which does NOT alter the forming head's group and does NOT cancel its run.
+//      So we do NOT skip the whole sweep just because a head is forming — that
+//      over-broad back-off (the old behaviour) meant the serial queue, which
+//      almost always has a forming head, was rarely fed, and green PRs stranded
+//      until a human enqueued them. We log the forming head for visibility and
+//      proceed to append the trailing green PRs.
 //   2. GRACE WINDOW — only enqueue a PR whose checks have all been
 //      green for at least GRACE_MINUTES (default 10). "green since" is the most
 //      recent completion across the PR's check runs. A PR green for
@@ -177,8 +185,11 @@ function graphql(query, vars = {}) {
 
 // Merge-queue snapshot: PR numbers already queued + whether any head is forming.
 // `state` on a mergeQueueEntry is AWAITING_CHECKS while its merge group is being
-// built — that is exactly the window in which a dequeue/enqueue poke wedges the
-// serial queue (#1758).
+// built. `queued` lists EVERY entry (forming OR stable); the enqueue loop uses it
+// to skip PRs already in the queue, so we never re-touch the forming head — only
+// append trailing green PRs (#2560). `forming` is now informational only (logged,
+// no longer triggers a whole-sweep back-off): poking the head wedges the serial
+// queue (#1758), but a trailing append does not.
 function mergeQueueSnapshot() {
   const r = graphql(
     `{ repository(owner:"${OWNER}",name:"${NAME}"){ mergeQueue(branch:"main"){ entries(first:100){ nodes { state pullRequest { number } } } } } }`,
@@ -187,6 +198,17 @@ function mergeQueueSnapshot() {
   const queued = new Set(nodes.map((n) => n.pullRequest?.number).filter(Boolean));
   const forming = nodes.filter((n) => n.state === "AWAITING_CHECKS").map((n) => n.pullRequest?.number);
   return { queued, forming };
+}
+
+// TRAILING-ADD SAFETY INVARIANT (#2560). A PR is a candidate for auto-enqueue
+// ONLY if it is not already in the merge queue. `queued` is the full set of
+// queued entries (forming HEAD included). Returning false for any queued PR is
+// what guarantees every enqueue is a TRAILING APPEND to the queue tail — never a
+// re-touch of the forming head, which is the only operation that cancels a head's
+// in-flight merge_group run and wedges the serial queue (#1758). Pure + exported
+// so the invariant can be unit-tested without any `gh` call.
+export function isTrailingAddCandidate(prNumber, queued) {
+  return !queued.has(prNumber);
 }
 
 function openPrs() {
@@ -333,16 +355,26 @@ function rerunClaCheck(prNumber, branch) {
 function runSweep() {
   const { queued: inQueue, forming } = mergeQueueSnapshot();
 
-  // GUARD 1 — back off while a head is forming. A merge group mid-formation is the
-  // exact window where poking the serial queue wedges it (#1758). Skip the whole
-  // sweep; the next cycle (or CI-completion trigger) retries once the queue is idle.
+  // GUARD 1 — TRAILING-ADD ONLY; never touch the forming head (#2560, was #1758).
+  // A merge group mid-formation must not have its membership changed: dequeuing or
+  // re-adding the HEAD rebuilds the group and cancels its in-flight run, which is
+  // what wedged the serial queue twice on 2026-05-30/31. But this sweep only
+  // enqueues PRs NOT already in the queue (every queue entry — forming OR stable —
+  // is in `inQueue` and hits the `already-queued` skip below), so every enqueue is
+  // a TRAILING APPEND to the queue tail. A trailing append leaves the forming
+  // head's merge group untouched and does NOT cancel its run. So we do NOT skip the
+  // whole sweep just because a head is forming (the old back-off did, which —
+  // because the serial queue nearly always has a forming head — meant green PRs
+  // almost never got auto-enqueued and stranded until a human intervened). We log
+  // the forming head for visibility and proceed to append the trailing green PRs.
   if (forming.length > 0) {
     console.log(
-      `enqueue-green-prs: BACK OFF — ${forming.length} queue entr${
+      `enqueue-green-prs: ${forming.length} queue entr${
         forming.length === 1 ? "y is" : "ies are"
-      } AWAITING_CHECKS (head forming): ${forming.map((n) => `#${n}`).join(", ")}. Skipping sweep this cycle.`,
+      } AWAITING_CHECKS (head forming): ${forming
+        .map((n) => `#${n}`)
+        .join(", ")}. Proceeding — only TRAILING green PRs are appended; the forming head is never touched.`,
     );
-    process.exit(0);
   }
 
   const prs = openPrs();
@@ -403,7 +435,11 @@ function runSweep() {
       skipped.push([pr.number, "hold-label"]);
       continue;
     }
-    if (inQueue.has(pr.number)) {
+    // TRAILING-ADD SAFETY (#2560): never re-touch a PR already in the queue
+    // (forming head OR stable entry). Skipping every queued PR is what keeps each
+    // enqueue a trailing append to the tail, so a forming head's merge_group run
+    // is never cancelled (#1758).
+    if (!isTrailingAddCandidate(pr.number, inQueue)) {
       skipped.push([pr.number, "already-queued"]);
       continue;
     }

--- a/tests/issue-2560-autoenqueue-trailing-add.test.ts
+++ b/tests/issue-2560-autoenqueue-trailing-add.test.ts
@@ -1,0 +1,53 @@
+// #2560 — auto-enqueue must keep feeding the queue while a head is forming.
+//
+// The old back-off in scripts/enqueue-green-prs.mjs skipped the ENTIRE sweep
+// whenever any merge-queue entry was AWAITING_CHECKS ("head forming"). Because
+// the SERIAL merge queue almost always has a forming head, auto-enqueue then
+// rarely added waiting green PRs, so they stranded until a human enqueued them.
+//
+// The fix: proceed with the sweep even while a head forms, and rely on the
+// trailing-add invariant — only enqueue PRs NOT already in the queue. A trailing
+// append to the queue tail does NOT change the forming head's merge group and so
+// does NOT cancel its in-flight run (only dequeuing/re-adding the HEAD does —
+// that was the #1758 cancellation wedge). These tests pin that invariant
+// (`isTrailingAddCandidate`) directly — they make no `gh` calls (the live sweep
+// is guarded behind an import.meta.url check).
+
+import { describe, expect, it } from "vitest";
+import { isTrailingAddCandidate } from "../scripts/enqueue-green-prs.mjs";
+
+describe("#2560 auto-enqueue trailing-add invariant", () => {
+  // The forming HEAD is in the queue snapshot's `queued` set, so it must never
+  // be a trailing-add candidate — re-touching it is exactly what cancels its run.
+  it("never re-touches the forming head (it is in the queue set)", () => {
+    const queued = new Set([101]); // #101 is the forming head
+    expect(isTrailingAddCandidate(101, queued)).toBe(false);
+  });
+
+  it("never re-touches a stable queued entry either", () => {
+    const queued = new Set([101, 102]); // #101 forming head, #102 stable behind it
+    expect(isTrailingAddCandidate(102, queued)).toBe(false);
+  });
+
+  // A green PR that is NOT in the queue IS a candidate — appending it to the tail
+  // is safe even while #101 forms, which is the whole point of dropping the
+  // over-broad back-off.
+  it("appends a green PR that is not yet queued, even while a head forms", () => {
+    const queued = new Set([101]); // #101 is forming
+    expect(isTrailingAddCandidate(200, queued)).toBe(true);
+  });
+
+  it("treats an empty queue as all-candidates", () => {
+    const queued = new Set<number>();
+    expect(isTrailingAddCandidate(200, queued)).toBe(true);
+    expect(isTrailingAddCandidate(201, queued)).toBe(true);
+  });
+
+  // The safety property holds for EVERY queued entry regardless of size: no PR in
+  // the queue is ever a candidate, so every enqueue is strictly a tail append.
+  it("excludes every queued PR no matter the queue size", () => {
+    const queued = new Set([10, 11, 12, 13, 14]);
+    for (const n of queued) expect(isTrailingAddCandidate(n, queued)).toBe(false);
+    expect(isTrailingAddCandidate(15, queued)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

`scripts/enqueue-green-prs.mjs` backed off the **entire** sweep whenever any
merge-queue entry was `AWAITING_CHECKS` ("a head is forming"). Because the merge
queue is SERIAL (`max_entries_to_build=1`) it almost always has a forming head,
so auto-enqueue rarely added waiting green PRs and they stranded until a human
enqueued them.

## Why trailing-add is safe

The original wedge (#1758) was caused by **dequeuing/re-adding the HEAD** of a
forming merge group — that membership change rebuilds the group and cancels its
in-flight `merge_group` run. But this sweep only ever enqueues PRs **not already
in the queue**, so every add is a **trailing append** to the queue tail, which
leaves the forming head's group untouched and does NOT cancel its run. The
whole-sweep skip was therefore unnecessary for safety and harmful for throughput.

## Change

- Drop the `process.exit(0)` whole-sweep back-off; log the forming head and
  proceed to append trailing green PRs.
- Add pure, exported `isTrailingAddCandidate(prNumber, queued)` encoding the
  invariant (false for any queued PR — forming head included); route the
  `already-queued` skip through it.
- Keep ALL other guards unchanged: author-trust gate (#2549/#2550),
  all-checks-green, grace window, hold/draft/ENQUEUEABLE, cla-check stale rerun,
  BEHIND auto-update opt-in, draft-rot nudge.
- Update the script + `.github/workflows/auto-enqueue.yml` headers to explain
  trailing-add-safe vs head-churn-unsafe, referencing #1758.

## Tests

`tests/issue-2560-autoenqueue-trailing-add.test.ts` (5 tests) pin the invariant;
`tests/issue-2550-trust-gate-fork-allowlist.test.ts` (13) still pass. Import of
the module remains side-effect-free (no `gh` call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA