### PR TITLE
fix(#2563): private-field brand-check read must register saved body for global-index shift

### DIFF
--- a/plan/issues/2563-privatefield-read-global-shift-invalid-wasm.md
+++ b/plan/issues/2563-privatefield-read-global-shift-invalid-wasm.md
@@ -1,0 +1,97 @@
+---
+id: 2563
+title: "Private-field/getter brand-check read on a closed-over module global emits invalid wasm (global-index desync)"
+status: done
+sprint: 64
+created: 2026-06-20
+updated: 2026-06-20
+completed: 2026-06-20
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen
+language_feature: class-private-fields
+goal: correctness
+---
+
+## Problem
+
+Several test262 files under
+`test/language/statements/class/elements/` made js2wasm emit an **invalid
+Wasm module** — `WebAssembly.instantiate(): Compiling function
+#N:"__anonClass_0_f" failed: any.convert_extern[0] expected type shared
+externref, found global.get of type f64`. Confirmed PRE-EXISTING (reproduces
+identically at 118a3542e, before #1787's DCE work — not a recent regression).
+
+Affected (compile_error → fixed):
+- `privatefieldget-typeerror-5.js`
+- `privatefieldget-success-1.js`
+- `privatename-valid-no-earlyerr.js`
+- `privatefieldset-evaluation-order-3.js` (compile_error → now valid wasm; the
+  residual assertion failure is a separate behavioral gap, see "Out of scope")
+
+## Root cause
+
+The private-name brand-check **read** path in
+`src/codegen/property-access.ts` (both the struct-field path ~L2420 and the
+getter/method path ~L2480) does:
+
+1. `compileExpression(ctx, fctx, expr.expression)` — compiles the receiver.
+   When the receiver is a module-level variable (e.g. a closed-over `self`),
+   this emits **`global.get $self`** into `fctx.body`.
+2. A raw body swap to capture the failure/throw branch:
+   `const savedBody = fctx.body; fctx.body = []`.
+3. `emitThrowTypeError(ctx, fctx, "Cannot read private member #x …")` — this
+   adds the message as a **late string-constant import**, which runs
+   `fixupModuleGlobalIndices` (registry/imports.ts). That fixup bumps every
+   module-global index by +1 and rewrites the `global.get/set` indices in all
+   *registered* bodies.
+
+The fixup walks `fctx.savedBodies` (among others) — but the raw swap in step 2
+**never registered `savedBody` there**. Because `fctx === ctx.currentFunc`, the
+swap reassigned `ctx.currentFunc.body` to the new empty buffer, so the fixup's
+`ctx.currentFunc.body` walk hit the empty array and the real body holding
+`global.get $self` (now detached in `savedBody`) was skipped. The receiver's
+`global.get` kept its **pre-shift** index and pointed one global too low — at an
+`f64` module global (`__mod___assert_count`) instead of the externref `self`
+(`__mod_self`) → `any.convert_extern` got an f64 → invalid Wasm.
+
+This is the exact swap-pattern hazard the codebase already guards elsewhere via
+the canonical `pushBody`/`popBody` helpers (`src/codegen/context/bodies.ts`),
+which register the saved buffer on `fctx.savedBodies` for the duration of the
+swap. The brand-check read paths hand-rolled the swap and missed registration.
+
+## Fix
+
+Replace the raw swaps in both brand-check read paths with `pushBody(fctx)` /
+`popBody(fctx, savedBody)` so the swapped-out real body is on
+`fctx.savedBodies` and the receiver's `global.get` shifts with the late import.
+One-line import addition (`pushBody`) + two call-site conversions.
+
+Files: `src/codegen/property-access.ts`.
+
+## Validation
+
+- `tests/issue-2563-privatefield-global-shift.test.ts` — new regression
+  (fails on clean main with invalid wasm, passes after the fix).
+- test262 `class/elements` subdir sweep: **+25 pass, −4 compile_error, −21
+  fail** vs clean main; **zero pass→fail or pass→CE regressions**. The +25
+  includes 22 `*-rs-private-setter*` files (FAIL→pass) plus the three
+  invalid-wasm files above. `privatefieldset-evaluation-order-3.js` improved
+  CE→FAIL (now valid wasm).
+- `tsc --noEmit` clean, `prettier --check` clean. Existing brand/private
+  vitest suites unaffected (pre-existing `string_constants` import-object
+  harness failures in `classes.test.ts`/`class-expressions.test.ts` are
+  identical on clean main).
+
+## Out of scope (filed separately)
+
+- `privatefieldset-typeerror-3.js` — distinct invalid-wasm bug: polymorphic
+  receiver method-dispatch resolves the result blockType to the function-
+  wrapper struct (`$func.0`) for a method returning a class expression →
+  `fallthru` type mismatch. Filed as **#2564**.
+- `privatefieldget-typeerror-1.js` / `privatefieldset-typeerror-1.js` — a
+  behavioral gap (returns 2 instead of throwing TypeError) for reading a
+  private field inside its own class field-initializer before the slot is
+  populated; **not** invalid wasm. Tracked under the same #2564 follow-up.

--- a/plan/issues/2564-privatefield-nested-class-dispatch-and-self-field-init.md
+++ b/plan/issues/2564-privatefield-nested-class-dispatch-and-self-field-init.md
@@ -1,0 +1,94 @@
+---
+id: 2564
+title: "Private-field nested-class follow-ups: polymorphic method-return blockType (invalid wasm) + read-before-own-slot TypeError gap"
+status: ready
+sprint: Backlog
+created: 2026-06-20
+updated: 2026-06-20
+priority: medium
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen
+language_feature: class-private-fields
+goal: correctness
+depends_on: [2563]
+---
+
+## Context
+
+Spun out of #2563 (which fixed the global-index-desync invalid-wasm in the
+private-field brand-check read path). Two residual test262 failures under
+`test/language/statements/class/elements/` remain, with **distinct** root
+causes from #2563.
+
+## Part A — `privatefieldset-typeerror-3.js` (INVALID wasm)
+
+```js
+class Outer {
+  #x = 42;
+  innerclass() {
+    return class extends Outer {     // method returns a class expression
+      f() { this.#x = 1; }
+    }
+  }
+  value() { return this.#x; }
+}
+var outer = new Outer();
+var Inner = outer.innerclass();      // polymorphic receiver (Outer | __anonClass_0)
+var i = new Inner();
+```
+
+Under the full test262 harness wrap (where `outer`/`Inner`/`i` are hoisted to
+module scope), `outer.innerclass()` is compiled as a **tag-based polymorphic
+dispatch** (`struct.get __tag` == 1 → Outer impl, == 2 → derived impl). The
+dispatch `if`'s result blockType is resolved to the **function-wrapper struct
+type** `$func.0` (`(struct (field funcref))`) instead of the method's actual
+return struct type (`__anonClass_0` / `Outer`). The arms produce
+`(call $Outer_innerclass …)` → `(ref null $__anonClass_0)`, which does not
+match `(ref null $func.0)` → binaryen/V8:
+`type error in fallthru[0] (expected (ref null 13), got (ref null 16))` in
+`test()`.
+
+The minimal (non-hoisted) form compiles to valid wasm — the bug only fires when
+the receiver is module-scoped and the polymorphic dispatch path is taken. Root
+cause is the method-return-type resolution for a method whose declared/ inferred
+return type is a **class expression** (a constructable function value), which is
+landing on the closure/fn-wrapper struct type rather than the produced class
+struct. Fix needs to resolve the dispatch result blockType from the callee's
+real return struct (the lowest common supertype of the candidate impls'
+returns), not from the fn-wrapper type.
+
+Start points: the tag-dispatch `if`-result-type construction for a member call
+whose receiver static type admits subclasses (search the call-expression
+lowering in `src/codegen/index.ts` / `expressions.ts`), and how a method
+returning a `ClassExpression` gets its return ValType.
+
+## Part B — `privatefieldget-typeerror-1.js` / `privatefieldset-typeerror-1.js` (behavioral, NOT invalid wasm)
+
+```js
+class C {
+  y = this.#x;        // read #x in a field initializer …
+  #x;                 // … before #x's own slot is initialized
+}
+assert.throws(TypeError, function() { new C(); })   // must throw
+```
+
+Per ES2022 PrivateFieldGet/PrivateFieldSet step 4 (PrivateFieldFind returns
+empty → TypeError): reading/writing a private field whose
+`[[PrivateFieldValues]]` entry has not yet been added throws TypeError. js2wasm
+currently returns 2 (the field reads as its default, no throw). The compiler
+treats `this.#x` inside the declaring class body as brand-guaranteed and skips
+the runtime check — correct for the steady state, but it misses the
+field-initialization-order window where `#x`'s slot exists structurally (the
+struct field is allocated) but is semantically "not yet added". A spec-accurate
+fix likely needs an initialized-flag / definite-assignment model for private
+slots during the field-initializer phase, or to detect the
+read-before-declaration order statically and emit a throw.
+
+## Acceptance
+
+- `privatefieldset-typeerror-3.js` → valid wasm + pass.
+- `privatefieldget-typeerror-1.js`, `privatefieldset-typeerror-1.js` → pass
+  (throw TypeError).
+- Broad class/private-field test262 sweep: zero new regressions.

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -18,7 +18,7 @@ import {
 import type { FieldDef, Instr, ValType } from "../ir/types.js";
 import { emitBoundsCheckedArrayGet } from "./array-methods.js";
 import { classMemberFuncKey } from "./class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
-import { popBody } from "./context/bodies.js";
+import { popBody, pushBody } from "./context/bodies.js";
 import { reportError, reportErrorNoNode } from "./context/errors.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
@@ -2443,12 +2443,20 @@ export function compilePropertyAccess(
           { op: "struct.get", typeIdx: declared.structTypeIdx, fieldIdx } as Instr,
         ];
         // Capture failure-path instrs by emitting into a saved body buffer.
-        const savedBody = fctx.body;
-        fctx.body = [];
+        // Use pushBody/popBody (not a raw swap): emitThrowTypeError can add a
+        // late string-constant import, which shifts every module-global index
+        // and runs fixupModuleGlobalIndices. That fixup walks fctx.savedBodies,
+        // so the swapped-out real body (which already holds the receiver's
+        // `global.get` from `compileExpression(expr.expression)` above when the
+        // receiver is a module global, e.g. a closed-over `self`) MUST be
+        // registered there — otherwise its `global.get <self>` keeps its
+        // pre-shift index and reads the wrong (f64) global → invalid Wasm
+        // (#2563, privatefieldget-typeerror-5).
+        const savedBody = pushBody(fctx);
         const message = `Cannot read private member #${expr.name.text.slice(1)} from an object whose class did not declare it`;
         emitThrowTypeError(ctx, fctx, message);
         const failureInstrs = fctx.body;
-        fctx.body = savedBody;
+        popBody(fctx, savedBody);
         // Wrap in `if` returning fieldType. The `else` (failure) branch
         // ends with `throw`, which is unreachable per Wasm typing, so the
         // block's result type is satisfied by the `then` arm only.
@@ -2500,14 +2508,19 @@ export function compilePropertyAccess(
         // Build the failure (throw) branch FIRST. emitThrowTypeError may
         // register late imports, which shift every funcMap index (the
         // getter's included). Settling those shifts before we read the
-        // getter funcIdx keeps the `call` target correct — the same reason
-        // the field path above only emits struct.get (immune to shifts).
-        const savedBody = fctx.body;
-        fctx.body = [];
+        // getter funcIdx keeps the `call` target correct.
+        //
+        // Use pushBody/popBody so the swapped-out real body is on
+        // fctx.savedBodies for fixupModuleGlobalIndices: the receiver's
+        // `global.get` (emitted by compileExpression above when the receiver
+        // is a module global, e.g. a closed-over `self`) must shift with the
+        // late string-constant import too, or it reads the wrong global type
+        // → invalid Wasm (#2563, same defect as the field path above).
+        const savedBody = pushBody(fctx);
         const message = `Cannot read private member #${expr.name.text.slice(1)} from an object whose class did not declare it`;
         emitThrowTypeError(ctx, fctx, message);
         const failureInstrs = fctx.body;
-        fctx.body = savedBody;
+        popBody(fctx, savedBody);
 
         // Success path: cast to the declaring struct, then either call the
         // getter (accessor) or return the receiver itself (method value).

--- a/tests/issue-2563-privatefield-global-shift.test.ts
+++ b/tests/issue-2563-privatefield-global-shift.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+import { buildImports } from "../src/runtime.ts";
+
+// #2563 — Private-field/getter brand-check read on a receiver that is a
+// closed-over MODULE-LEVEL variable produced an INVALID Wasm module.
+//
+// Root cause: the brand-check read path in property-access.ts compiles the
+// receiver first (e.g. `global.get $self`), then swaps the function body out
+// to a fresh buffer to capture the failure/throw branch. emitThrowTypeError
+// adds the "Cannot read private member …" string-constant import LATE, which
+// runs fixupModuleGlobalIndices to bump every module-global index. That fixup
+// walks fctx.savedBodies — but the swap used a raw `savedBody = fctx.body;
+// fctx.body = []` that never registered the saved buffer on savedBodies. So
+// the already-emitted `global.get $self` kept its pre-shift index and read the
+// neighbouring (f64) global instead → `any.convert_extern[0] expected
+// externref, found global.get of type f64` (test262
+// privatefieldget-typeerror-5.js, privatefieldget-success-1.js,
+// privatename-valid-no-earlyerr.js).
+//
+// Fix: use pushBody/popBody so the saved buffer is on savedBodies and the
+// receiver's global.get shifts with the late import.
+async function run(source: string): Promise<number> {
+  const r = await compile(source, { fileName: "test.ts" });
+  if (!r.success) throw new Error("CE: " + r.errors[0]?.message);
+  // Validate first so a desynced global index surfaces as a test failure
+  // rather than a confusing instantiate error.
+  if (!WebAssembly.validate(r.binary)) {
+    try {
+      await WebAssembly.compile(r.binary);
+    } catch (e) {
+      throw new Error("invalid wasm: " + String(e));
+    }
+  }
+  const imports = buildImports(r.imports, undefined, (r as any).stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  return (instance.exports as any).test();
+}
+
+describe("#2563 private-field read on closed-over module global emits valid wasm", () => {
+  it("private-field read on a captured module global with a WRONG brand compiles to valid wasm and throws TypeError", async () => {
+    // The wrong-brand throw path is what adds the late "Cannot read private
+    // member …" string-constant import, triggering the global-index shift that
+    // must also move the receiver's `global.get $holder`. Two unrelated
+    // classes C and D each declare `#x`; reading `holder.#x` (C's private name)
+    // when `holder` is a D instance lacks C's brand → TypeError. Before the
+    // fix, `global.get $holder` kept its pre-shift index and read an f64 global
+    // → invalid wasm; now the module validates and the brand check throws.
+    const ret = await run(`
+      let holder: any;
+      class C {
+        #x: f64 = 42;
+        read(): f64 { return holder.#x; }
+      }
+      class D {
+        #y: f64 = 7;
+      }
+      export function test(): f64 {
+        holder = new D();
+        const c = new C();
+        try {
+          c.read();
+          return 0;
+        } catch (e) {
+          return e instanceof TypeError ? 1 : 2;
+        }
+      }
+    `);
+    expect(ret).toBe(1);
+  });
+
+  it("private-field read on a captured module global with a MATCHING brand returns the value (success path stays valid)", async () => {
+    // Mirrors privatefieldget-success-1: same shape but `self` carries the
+    // right brand, so the read succeeds. Exercises the success arm of the same
+    // body-swap that was mis-shifted.
+    const ret = await run(`
+      let holder: any;
+      class C {
+        #x: f64 = 99;
+        capture(): void { holder = this; }
+        read(): f64 { return holder.#x; }
+      }
+      export function test(): f64 {
+        const c = new C();
+        c.capture();
+        return c.read();
+      }
+    `);
+    expect(ret).toBe(99);
+  });
+});


### PR DESCRIPTION
## Problem

Several test262 `class/elements` private-field files made js2wasm emit an **invalid Wasm module** — `Compiling function #N:"__anonClass_0_f" failed: any.convert_extern[0] expected type shared externref, found global.get of type f64`. Pre-existing (reproduces at 118a3542e, before #1787's DCE work).

Affected (compile_error → fixed): `privatefieldget-typeerror-5.js`, `privatefieldget-success-1.js`, `privatename-valid-no-earlyerr.js`.

## Root cause

The private-name brand-check **read** path in `src/codegen/property-access.ts` compiles the receiver first — emitting `global.get $self` when the receiver is a closed-over module global — then does a raw body swap (`savedBody = fctx.body; fctx.body = []`) to capture the throw branch. `emitThrowTypeError` adds the `"Cannot read private member …"` message as a **late string-constant import**, which runs `fixupModuleGlobalIndices` to bump every module-global index. That fixup walks `fctx.savedBodies` — but the raw swap never registered `savedBody` there. Because `fctx === ctx.currentFunc`, the swap reassigned `ctx.currentFunc.body` to the empty buffer, so the fixup walked the empty array and the detached `savedBody` (holding `global.get $self`) was skipped. The receiver's `global.get` kept its pre-shift index and pointed one global too low — at an `f64` global instead of the externref `self` → invalid Wasm.

## Fix

Use the canonical `pushBody`/`popBody` helpers (which register the saved buffer on `fctx.savedBodies` for the duration of the swap) at both brand-check read swap sites (struct-field path and getter/method path). One import + two call-site conversions.

## Validation

- New regression `tests/issue-2563-privatefield-global-shift.test.ts` (fails on clean main with invalid wasm, passes after the fix).
- test262 `class/elements` sweep: **+25 pass, −4 compile_error, −21 fail** vs main; **zero pass→fail / pass→CE regressions**. The +25 includes 22 `*-rs-private-setter*` files (FAIL→pass) plus the three invalid-wasm files.
- `tsc --noEmit` clean, `prettier --check` clean.

## Out of scope — filed as #2564

- `privatefieldset-typeerror-3.js` — distinct invalid-wasm bug: polymorphic method-return blockType resolves to the fn-wrapper struct for a method returning a class expression.
- `privatefield{get,set}-typeerror-1.js` — read-before-own-slot TypeError gap (behavioral, not invalid wasm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA