### PR TITLE
fix(#2564): give each virtual-dispatch if its own blockType (DCE double-remap)

### DIFF
--- a/plan/issues/2564-privatefield-nested-class-dispatch-and-self-field-init.md
+++ b/plan/issues/2564-privatefield-nested-class-dispatch-and-self-field-init.md
@@ -1,10 +1,12 @@
 ---
 id: 2564
 title: "Private-field nested-class follow-ups: polymorphic method-return blockType (invalid wasm) + read-before-own-slot TypeError gap"
-status: ready
-sprint: Backlog
+status: done
+sprint: 64
 created: 2026-06-20
-updated: 2026-06-20
+updated: 2026-06-21
+completed: 2026-06-21
+assignee: ttraenkler/sd3
 priority: medium
 feasibility: hard
 reasoning_effort: max
@@ -92,3 +94,76 @@ read-before-declaration order statically and emit a throw.
 - `privatefieldget-typeerror-1.js`, `privatefieldset-typeerror-1.js` → pass
   (throw TypeError).
 - Broad class/private-field test262 sweep: zero new regressions.
+
+## Resolution (2026-06-21, sd3)
+
+### Part A — DONE. Real root cause: shared-`blockType` double-remap in dead-elimination
+
+The framing in the original analysis ("blockType resolved to the fn-wrapper
+struct type instead of the method's real return struct") was a *symptom*. At
+**emit time** the dispatch was already correct: `emitVirtualMethodDispatchByTag`
+(`src/codegen/expressions/calls.ts`) resolves the result type via
+`getWasmFuncReturnType(firstCand.funcIdx)`, which for `Outer.innerclass` correctly
+returned `(ref $__anonClass_0)` — the SAME type the callee func returns. Verified by
+instrumenting the dispatch: `resultType` == the func's `results[0]` == `(ref 20)`.
+
+The divergence was introduced by `eliminateDeadImports` (`dead-elimination.ts`).
+The tag cascade builds **one distinct `if` instruction per candidate** but shared
+a **single `blockType` object** across all of them. `remapTypeIdxInBody`'s
+double-remap guard (`seen` WeakSet, #1302) keys on the **instruction object**, not
+on the `blockType.type` sub-object — so each aliasing `if` passed the guard and
+chain-remapped the shared block-type a second time. Under the survivor-compaction
+remap (`20→16`, `16→13`, each survivor shifts down) the cascade did `20→16` on the
+first `if`, then `16→13` on the second, landing the block-type on `$__fn_wrap_0`
+(the fn-wrapper) — while the callee func's result type, remapped exactly once in
+the type table, landed on `16` (`$__anonClass_0`). Hence
+`type error in fallthru[0] (expected (ref null 13), got (ref null 16))`. This is the
+type-index-shift hazard family (memory `project_type_index_shift_and_deadelim`).
+
+**Fix (2 files, complementary):**
+1. `emitVirtualMethodDispatchByTag` now mints a **fresh `blockType` object per
+   `if`** (`freshBlockType()` clones the result ValType) — producers must never
+   share an instruction-operand object across distinct instructions (the
+   #1302/iterator-native/json-codec convention).
+2. `remapTypeIdxInBody` now also guards on the **`blockType` object itself**
+   (`seen.add(a.blockType)`) so an aliased block-type is remapped exactly once
+   regardless of how many instructions reference it — defense-in-depth for any
+   other producer that shares a block-type.
+
+**Impact (class-category sweep, old main bundle vs. fixed, 4367 files):**
+PASS 2395 → 2433 (**+38**), INVALID 32 → 14 (**−18**), FAIL 768 → 746, **0
+regressions** (no PASS→worse, no new INVALID/CRASH). The fix is broad: besides
+`privatefieldset-typeerror-3.js` (INVALID→PASS) it flipped 12 `dstr/*-meth-*-obj-
+ptrn-prop-obj.js`, 5 `private-methods/prod-private-*`, and 22
+`elements/*-rs-private-setter*` from INVALID/FAIL → PASS — all the same
+shared-block-type bug surfacing through different class/method shapes.
+
+### Two unrelated pre-existing INVALID-wasm files (NOT this bug, out of scope)
+
+`privatefieldget-primitive-receiver.js` / `privatefieldput-primitive-receiver.js`
+(both `features: [..., BigInt]`) emit invalid wasm via a DIFFERENT path
+(`__closure_2`: `call[0] expected (ref null 20), found f64.const of type f64`).
+They are INVALID on plain main too (pre-existing), are not touched by the dispatch
+fix, and are a separate primitive-receiver/BigInt private-field bug. Left for a
+follow-up; not a #1711 blocker (they were already on main).
+
+### Part B — DEFERRED (read-before-own-slot TypeError)
+
+`privatefieldget-typeerror-1.js` / `privatefieldset-typeerror-1.js` still return
+the default (no throw) instead of throwing TypeError per ES2022
+PrivateFieldGet/Set step 4. A spec-accurate fix needs an
+initialized-flag / definite-assignment model for private slots during the
+field-initializer phase (the slot exists structurally but is semantically "not
+yet added"). That is a non-trivial design change, not cheap; the issue scoped
+Part B as "only if Part A is cheap to finish". Deferred to keep the
+invalid-wasm fix isolated and regression-free. Behavioral-only (2 tests).
+
+### STEP 3 — top-level-await `module-import-rejection` files: NON-ISSUE
+
+The 3 `language/module-code/top-level-await/module-import-rejection*.js` files
+compile to **valid wasm** on both old main and the fixed bundle (outcome: runtime
+`THROW`/`fail`, not `malformed_wasm`). They never tripped the hard-error gate
+(which counts only `malformed_wasm` / `missing_test_export`). They were a red
+herring in the #1711 ejection diagnosis: they're ordinary `fail` outcomes gated on
+dynamic `import()` rejection handling (an unrelated feature gap), not invalid-wasm
+blockers.

--- a/src/codegen/dead-elimination.ts
+++ b/src/codegen/dead-elimination.ts
@@ -176,8 +176,17 @@ function remapTypeIdxInBody(body: Instr[], remap: Map<number, number>): void {
     if (typeof a.srcTypeIdx === "number" && remap.has(a.srcTypeIdx)) {
       a.srcTypeIdx = remap.get(a.srcTypeIdx)!;
     }
-    // Remap blockType
-    if (a.blockType) {
+    // Remap blockType. (#2564) The double-remap guard above keys on the
+    // *instruction* object, but a `blockType` (and its `.type` ValType) can be
+    // ALIASED across several distinct `if`/`block` instructions — e.g. a
+    // tag-dispatch cascade that shares one `blockType` object across its nested
+    // arms. Each aliasing instruction passes the `seen` check (different `instr`)
+    // and would chain-remap the shared block-type a second time (20→16 then
+    // 16→13 under a compaction map). Guard on the `blockType` object itself so a
+    // shared block-type is remapped exactly once regardless of how many
+    // instructions alias it.
+    if (a.blockType && !seen.has(a.blockType)) {
+      seen.add(a.blockType);
       if (a.blockType.kind === "type" && remap.has(a.blockType.typeIdx)) {
         a.blockType.typeIdx = remap.get(a.blockType.typeIdx)!;
       }

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -2329,8 +2329,25 @@ function emitVirtualMethodDispatchByTag(
     resultType = VOID_RESULT;
   }
 
-  const blockType: { kind: "val"; type: ValType } | { kind: "empty" } =
-    resultType === VOID_RESULT ? { kind: "empty" } : { kind: "val", type: resultType };
+  const resultIsRef = resultType !== VOID_RESULT && (resultType.kind === "ref" || resultType.kind === "ref_null");
+
+  // (#2564) Each nested `if` in the tag cascade below MUST get its own
+  // `blockType` object — never a single shared one. `dead-elimination`'s
+  // `remapTypeIdxInBody` remaps a `ref`/`ref_null` block-type via `remapVT`,
+  // and its double-remap guard (`seen` WeakSet, #1302) keys on the *instruction*
+  // object, not on the `blockType.type` sub-object. The cascade builds one
+  // distinct `if` instruction per candidate; if they all alias the SAME
+  // `blockType.type` ValType, the second nested `if`'s visit chain-remaps the
+  // already-remapped index a second time (observed: 20→16 on the first `if`,
+  // then 16→13 on the second — the compaction map shifts each survivor down, so
+  // 13 is the fn-wrapper type), while the callee func's result type — remapped
+  // exactly once in the type table — lands on 16. The mismatch surfaces as
+  // `type error in fallthru[0] (expected (ref null 13), got (ref null 16))`.
+  // A fresh `{ ...resultType }` per `if` keeps each block-type remapped once.
+  const freshBlockType = (): { kind: "val"; type: ValType } | { kind: "empty" } =>
+    resultType === VOID_RESULT
+      ? { kind: "empty" }
+      : { kind: "val", type: resultIsRef ? { ...(resultType as ValType) } : (resultType as ValType) };
 
   // Build the call body for one candidate. We need to ref.cast the
   // receiver to the candidate's struct type before calling, so the
@@ -2367,7 +2384,7 @@ function emitVirtualMethodDispatchByTag(
       { op: "i32.eq" } as Instr,
       {
         op: "if",
-        blockType,
+        blockType: freshBlockType(),
         then: callBody(cand),
         else: elseInstrs,
       } as Instr,

--- a/tests/issue-2564-virtual-dispatch-blocktype-remap.test.ts
+++ b/tests/issue-2564-virtual-dispatch-blocktype-remap.test.ts
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2564 (regression) — the virtual-method-dispatch tag cascade must give each
+ * nested `if` its OWN `blockType` object, so dead-import elimination cannot
+ * double-remap a shared block-type.
+ *
+ * Root cause: `emitVirtualMethodDispatchByTag` (src/codegen/expressions/calls.ts)
+ * lowers a method call on a class-with-subclasses to a tag cascade —
+ * `struct.get __tag` == classTag → call <Class>_<method>, one nested `if` per
+ * candidate. The cascade originally shared a SINGLE `blockType` object across all
+ * the nested `if`s. `eliminateDeadImports`'s `remapTypeIdxInBody` then remaps the
+ * survivor-compacted type table AND every instruction's block-type; its
+ * double-remap guard (#1302 `seen` WeakSet) keys on the *instruction* object, not
+ * on the shared `blockType.type` sub-object — so each aliasing `if` chain-remapped
+ * the shared block-type a second time (20→16 on the first `if`, then 16→13 on the
+ * second, because the compaction map shifts each survivor down). The callee func's
+ * result type, remapped exactly once in the type table, landed on 16, so the `if`
+ * fall-through expected 13 (`$__fn_wrap_0`) but got 16 (the real return struct) →
+ * `type error in fallthru[0] (expected (ref null 13), got (ref null 16))`.
+ *
+ * The source below is the EXACT output of the test262 runner's `wrapTest` for
+ * `language/statements/class/elements/privatefieldset-typeerror-3.js` (the helper
+ * preamble + the function-local class whose method returns `class extends Outer`).
+ * The preamble's `Test262Error` class + `isSameValue`/`assert_*` helpers are
+ * load-bearing: they populate the type table so the survivor-compaction remap
+ * produces the specific chain (20→16→13) that lands the double-remapped block-type
+ * on a real-but-wrong type. A minimal hand-written class does not reproduce — the
+ * renumbering chain is shorter — so the fixture is reproduced verbatim. The
+ * assertion is module VALIDITY; only V8's index-resolved function-body validation
+ * rejects the double-remapped block-type.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// Verbatim `wrapTest(privatefieldset-typeerror-3.js)` output (2026-06-21).
+const WRAPPED_PRIVATEFIELDSET_TYPEERROR_3 = `
+let __fail: number = 0;
+let __assert_count: number = 1;
+
+class Test262Error {
+  message: string;
+  constructor(msg: string) {
+    this.message = msg;
+  }
+}
+
+function isSameValue(a: number, b: number): number {
+  if (a === b) { return 1; }
+  if (a !== a && b !== b) { return 1; }
+  return 0;
+}
+
+function assert_sameValue(actual: number, expected: number): void {
+  __assert_count = __assert_count + 1;
+  if (!isSameValue(actual, expected)) {
+    if (!__fail) __fail = __assert_count;
+  }
+}
+
+function assert_notSameValue(actual: number, expected: number): void {
+  __assert_count = __assert_count + 1;
+  if (isSameValue(actual, expected)) {
+    if (!__fail) __fail = __assert_count;
+  }
+}
+
+function assert_true(value: number): void {
+  __assert_count = __assert_count + 1;
+  if (!value) {
+    if (!__fail) __fail = __assert_count;
+  }
+}
+
+export function test(): number {
+
+  try {
+class Outer {
+  #x = 42;
+
+  innerclass() {
+    return class extends Outer {
+      f() {
+        this.#x = 1;
+      }
+    }
+  }
+
+  value() {
+    return this.#x;
+  }
+}
+
+var outer = new Outer();
+var Inner = outer.innerclass();
+var i = new Inner();
+
+assert_sameValue(outer.value(), 42);
+assert_sameValue(i.value(), 42);
+
+i.f();
+
+assert_sameValue(outer.value(), 42);
+assert_sameValue(i.value(), 1);
+  } catch (e) {
+    if (!__fail) __fail = -1;
+    throw e;
+  }
+  if (__fail) { return __fail; }
+  return 1;
+}
+`;
+
+describe("#2564 virtual-dispatch block-type DCE double-remap", () => {
+  it("method returning a subclass expression under the test262 wrap produces valid wasm", async () => {
+    const r = await compile(WRAPPED_PRIVATEFIELDSET_TYPEERROR_3, { skipSemanticDiagnostics: true });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    // `WebAssembly.validate` runs full function-body validation — it is what
+    // caught the double-remapped `if` block-type (`expected (ref null 13), got
+    // (ref null 16)`). A symbolic disassembly looks fine; only V8's
+    // index-resolved validation rejects the binary. Before the fix this was
+    // `false`; the runner reported the file as malformed_wasm / compile_error.
+    expect(WebAssembly.validate(r.binary), "compiled module must validate").toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the malformed-wasm bug where a class method that **returns a class
expression extending the receiver class** compiled to invalid wasm under the
test262 harness wrap:
`type error in fallthru[0] (expected (ref null 13), got (ref null 16))`.

This is a main-health fix: the malformed wasm trips the merge_group hard-error
gate, which is what kept ejecting unrelated PRs (e.g. #1711) from the queue.

## Root cause

`emitVirtualMethodDispatchByTag` (`src/codegen/expressions/calls.ts`) lowers a
method call on a class-with-subclasses to a tag cascade — one distinct `if`
instruction per candidate — but shared a **single `blockType` object** across
all the nested `if`s.

`eliminateDeadImports` then remaps the survivor-compacted type table and every
instruction's block-type via `remapTypeIdxInBody`. Its double-remap guard
(#1302 `seen` WeakSet) keys on the **instruction** object, not on the shared
`blockType.type` sub-object — so each aliasing `if` chain-remapped the shared
block-type a **second** time (`20→16` on the first `if`, then `16→13` on the
second, because the compaction map shifts each survivor down). The callee
func's result type — remapped exactly once in the type table — landed on `16`,
so the `if` fall-through expected `13` (`$__fn_wrap_0`, the fn-wrapper struct)
but got `16` (the real return struct). Hence the V8 fallthru type error. Same
type-index-shift family as #1302 / #2520.

## Fix (complementary, both in this PR)

1. **`emitVirtualMethodDispatchByTag`** mints a **fresh `blockType` object per
   `if`** (clones the result ValType) — producers must never share an
   instruction-operand object across distinct instructions.
2. **`remapTypeIdxInBody`** also guards on the **`blockType` object itself**, so
   an aliased block-type is remapped exactly once regardless of how many
   instructions reference it — defense-in-depth for any other producer.

## Validation (local sweeps, old main bundle vs. fixed)

- **`class/elements` (4367 files):** PASS 2395 → **2433 (+38)**, INVALID 32 →
  **14 (−18)**, FAIL 768 → 746, **0 regressions** (no PASS→worse, no new
  INVALID/CRASH).
- **broader (10552 files: `expressions/class` + `built-ins/Object` +
  `built-ins/Array`):** PASS +15, INVALID −16, **0 regressions**.
- Besides `privatefieldset-typeerror-3.js` (INVALID→PASS) the fix flips 12
  `dstr/*-meth-*-obj-ptrn-prop-obj.js`, 5 `private-methods/prod-private-*`, and
  22 `elements/*-rs-private-setter*` from INVALID/FAIL → PASS (all the same
  shared-block-type bug surfacing through different class/method shapes).
- `check-test262-hard-errors.mjs`: OK (0 hard errors). Prettier + biome-lint +
  `tsc --noEmit`: clean.

## Regression test

`tests/issue-2564-virtual-dispatch-blocktype-remap.test.ts` reproduces the
**exact** `wrapTest` output for `privatefieldset-typeerror-3.js` (the helper
preamble's type table is load-bearing for the renumbering chain). Verified:
**fails without the fix** (`expected false to be true` on `WebAssembly.validate`),
**passes with it**.

## Out of scope / findings (documented in the issue)

- `privatefieldget/put-primitive-receiver.js` (BigInt) emit invalid wasm via a
  **different** path (`__closure_2`: f64-vs-ref); pre-existing on main, not this
  bug — left for a follow-up.
- The 3 top-level-await `module-import-rejection*.js` files compile to **valid**
  wasm (runtime `fail`, not `malformed_wasm`) on both old and fixed — they never
  tripped the hard-error gate; a red herring in the #1711 ejection diagnosis.
- Part B (read-before-own-slot → TypeError, ES2022 PrivateFieldGet step 4) is
  **deferred**: it needs a definite-assignment model for private slots during
  field-init, not cheap, behavioral-only (2 tests).

Closes #2564.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA