### PR TITLE
docs(#2565): close as fixed-by-#2564 (re-measured: all 24 dstr files PASS)

### DIFF
--- a/plan/issues/2565-dstr-param-default-shape-id-arity.md
+++ b/plan/issues/2565-dstr-param-default-shape-id-arity.md
@@ -1,20 +1,60 @@
 ---
 id: 2565
 title: "nested destructuring-param default object emits struct.new one operand short of the $shape-bearing type — invalid Wasm (24 test262)"
-status: ready
+status: done
 sprint: 64
 created: 2026-06-19
+updated: 2026-06-21
+completed: 2026-06-21
+resolved_by: 2564
+assignee: ttraenkler/sd3
 priority: medium
 feasibility: medium
 task_type: bugfix
 area: codegen
 language_feature: destructuring
 goal: core-semantics
-related: [2009, 1224, 1451, 1543]
+related: [2009, 1224, 1451, 1543, 2564]
 test262_bucket: dstr-param-default-shape
 test262_count: 24
 origin: "2026-06-19 jsonl scout (sd5): 24 compile_errors, verified on current main"
 ---
+
+## Resolution (2026-06-21, sd3) — FIXED BY #2564, no separate code change
+
+Re-measured the full bucket on `origin/main` AFTER #2564 (PR #1803) landed. **All
+24 named files PASS** (verified exact set: 12 `language/statements/class/dstr/` +
+12 `language/expressions/class/dstr/` `*-dflt-obj-ptrn-prop-obj.js` — meth /
+static / gen / async-gen / private variants). The issue's own repro snippet now
+compiles to valid Wasm and returns 8. A wider sweep of all 1920 class-dstr
+default-param files shows 0 INVALID in the `dflt-obj-ptrn-prop-obj` bucket.
+
+**The root-cause hypothesis in this issue was a misdiagnosis.** It was NOT a
+`$shape`-arity gap in `__ext_dparam_nested` / `patchStructNewWithShapeId`
+coverage. The `not enough arguments on the stack for struct.new` symptom and
+#2564's `type error in fallthru[0]` were two faces of the **same** bug: the
+shared-`blockType` double-remap in `emitVirtualMethodDispatchByTag` +
+`eliminateDeadImports` (see #2564). The malformed `if` block-type desynced the
+WasmGC type table during dead-import renumbering, and in these
+destructuring-param-default class methods that desync surfaced downstream as a
+`struct.new` operand-count mismatch. Fixing the shared block-type (give each
+cascade `if` its own `blockType`, and guard the block-type object in
+`remapTypeIdxInBody`) cleared both symptom families at once. No additional
+shape-id-coverage change was needed.
+
+### Separate, pre-existing bug spun out (NOT this bucket)
+
+Two negative tests — `class/dstr/meth-dflt-obj-ptrn-list-err.js` and
+`meth-static-dflt-obj-ptrn-list-err.js` (statements + expressions) — still emit
+invalid Wasm, but with a DIFFERENT error
+(`C_method: not enough arguments on the stack for call (need 1, got 0)`) and a
+DIFFERENT shape: a default param whose initializer **calls a throwing function**
+(`method({ a, b = thrower(), c = ++initCount } = {})`), not a nested object
+pattern. They were INVALID on main BEFORE #2564 too (pre-existing) and are out of
+this bucket (`obj-ptrn-list-err`, not `obj-ptrn-prop-obj`). A
+missing-call-argument bug in the param-default throwing-initializer
+materialization path, unrelated to the `$shape` machinery — left for a
+follow-up issue.
 
 # #2565 — destructuring-param default object literal misses the `$shape` operand
 

--- a/plan/issues/2567-dstr-param-default-throwing-init-call-arity.md
+++ b/plan/issues/2567-dstr-param-default-throwing-init-call-arity.md
@@ -1,0 +1,79 @@
+---
+id: 2567
+title: "destructuring-param default whose initializer calls a function emits C_method one operand short for the call — invalid Wasm (4 test262)"
+status: ready
+sprint: Backlog
+created: 2026-06-21
+priority: low
+feasibility: medium
+task_type: bugfix
+area: codegen
+language_feature: destructuring
+goal: core-semantics
+related: [2565, 2564, 1224]
+test262_bucket: dstr-param-default-throwing-init
+test262_count: 4
+origin: "2026-06-21 sd3, spun out of #2565: pre-existing, distinct from the $shape bucket #2565 closed"
+---
+
+# #2567 — destructuring-param default with a function-call initializer is one call-arg short
+
+## Problem
+
+```ts
+var initCount = 0;
+function thrower() { throw new Test262Error(); }
+
+class C {
+  method({ a, b = thrower(), c = ++initCount } = {}) {}
+}
+new C().method();   // wasm: invalid binary — C_method call arity
+```
+
+The validator error (NOT the #2565 `struct.new` shape-id symptom):
+
+```
+invalid Wasm binary: Compiling function #N:"C_method" failed:
+not enough arguments on the stack for call (need 1, got 0)
+```
+
+## Affected files (4 test262, verified INVALID on origin/main 2026-06-21)
+
+- `language/statements/class/dstr/meth-dflt-obj-ptrn-list-err.js`
+- `language/statements/class/dstr/meth-static-dflt-obj-ptrn-list-err.js`
+- `language/expressions/class/dstr/meth-dflt-obj-ptrn-list-err.js`
+- `language/expressions/class/dstr/meth-static-dflt-obj-ptrn-list-err.js`
+
+These are negative-behaviour tests (`assert.throws(Test262Error, () => c.method())`)
+of left-to-right param-default evaluation: the **first** binding default (`b =
+thrower()`) must throw before the later default (`c = ++initCount`) runs, so
+`initCount` stays 0.
+
+## Root cause (distinct from #2565)
+
+Spun out of #2565, which was closed as fixed-by-#2564 (the `$shape`-arity
+symptom was a face of the shared-`blockType` DCE bug). This bug is **different**:
+it is NOT a nested object pattern (`obj-ptrn-prop-obj`) and NOT a `struct.new`
+shape-id arity mismatch. The shape is a **destructuring param whose binding
+default is a function CALL** (`b = thrower()`), and the emitted `call` to the
+default-initializer function lands one operand short (`need 1, got 0`) — the
+materialization of the default-value call in the param-destructuring prologue
+fails to push the callee's argument (or pushes the call before its receiver/arg
+is staged). Was INVALID on main BEFORE #2564 too — pre-existing, unrelated to
+the `$shape` collision-resolution pass.
+
+## Fix direction
+
+Inspect the destructuring-param default-initializer lowering (the
+`__ext_dparam` / class-method param-default prologue) for the case where the
+default value is a `CallExpression`: ensure the call's argument(s)/receiver are
+staged on the stack before the `call`. Likely the default-slot guard
+(`if arg === undefined → evaluate default`) emits the call body without first
+materializing its operands, or drops them when the default expression itself
+has side effects / throws.
+
+## Acceptance criteria
+
+- The 4 `*-list-err` files compile to valid Wasm and pass (the throwing default
+  throws `Test262Error`, `initCount` stays 0).
+- No regression in existing destructuring-param-default / class-method suites.


### PR DESCRIPTION
## Summary

#2565 (nested destructuring-param default object → `struct.new` one operand
short of the `$shape`-bearing type, 24 test262 `compile_error`s) is **fully
resolved by the already-merged #2564 (PR #1803)** — no separate code change.
This PR is doc-only: sets the issue `status: done` and records the finding.

## Re-measurement (the critical first step)

Re-ran the full bucket on `origin/main` AFTER #2564 landed:
- **All 24 named files PASS** (exact set: 12 `language/statements/class/dstr/` +
  12 `language/expressions/class/dstr/` `*-dflt-obj-ptrn-prop-obj.js` —
  meth / static / gen / async-gen / private variants).
- The issue's own repro snippet compiles to **valid wasm** and returns `8`.
- Wider sweep of **all 1920** class-dstr default-param files: **0 INVALID** in
  the `obj-ptrn-prop-obj` bucket.

## Why #2564 fixed it (the issue's root cause was a misdiagnosis)

It was **not** a `$shape`-arity gap in `__ext_dparam_nested` /
`patchStructNewWithShapeId` coverage. The `not enough arguments on the stack for
struct.new` symptom and #2564's `type error in fallthru[0]` were two faces of the
**same** bug — the shared-`blockType` double-remap in
`emitVirtualMethodDispatchByTag` + `eliminateDeadImports`. The malformed `if`
block-type desynced the WasmGC type table during dead-import renumbering; in these
destructuring-param-default class methods the desync surfaced downstream as a
`struct.new` operand-count mismatch. #2564's fix (fresh `blockType` per cascade
`if` + guard the block-type object in `remapTypeIdxInBody`) cleared both symptom
families at once.

## Spun out (NOT this bucket)

`class/dstr/meth-dflt-obj-ptrn-list-err.js` and
`meth-static-dflt-obj-ptrn-list-err.js` still emit invalid wasm via a
**different, pre-existing** bug (`C_method: not enough arguments on the stack for
call (need 1, got 0)`; a default param whose initializer **calls a throwing
function** — `method({ a, b = thrower(), c = ++initCount } = {})`, not a nested
object pattern). INVALID on main before #2564 too; out of this bucket
(`obj-ptrn-list-err`, not `obj-ptrn-prop-obj`). Left for a follow-up issue.

Closes #2565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA