### PR TITLE
fix(#2160): standalone Number.prototype.toLocaleString via native number_toString

### DIFF
--- a/plan/issues/2160-standalone-string-number-coercion-residual.md
+++ b/plan/issues/2160-standalone-string-number-coercion-residual.md
@@ -79,3 +79,46 @@ same helper to `parseNeeded`. Regression test:
 acceptance criteria's `__new_String`/`__new_Number` leak) plus the harder
 String/Number coercion edges that overlap the coercion engine (#1917). Those
 remain the value-rep / #1917 territory called out in the original notes.
+
+---
+
+## Slice (2026-06-21, dev-agent) — `Number.prototype.toLocaleString` for standalone
+
+**Status stays `ready`** — one more independent slice of the 635-bucket,
+unblocked (no wrapper substrate / #1917 dependency).
+
+**Bug:** `(n).toLocaleString()` on a number receiver CE'd in standalone / WASI
+with `'__extern_toLocaleString' (dynamic-shape object)`. The generic
+`toLocaleString` fallback (`src/codegen/expressions/calls.ts`) unconditionally
+routes the receiver to the host `__extern_toLocaleString` import; a bare number
+is not an extern object, so the standalone codegen refuses it. (Host mode worked
+via real Intl, returning grouped output like `"1,234"`.)
+
+**Fix (no-JS-host only):** §21.1.3.4 — there is no Intl in standalone/WASI, and
+the no-Intl default is implementation-defined. For a number receiver in
+no-JS-host targets, delegate `toLocaleString` to the base-10
+`Number.prototype.toString` (the existing native `number_toString`), mirroring
+the `toLocaleString → toString` delegation already used elsewhere. The
+import-collector (`src/codegen/declarations.ts`) pre-registers `number_toString`
+for the `toLocaleString` call shape (gated on `standalone || wasi`) so the call
+lowers without a late module-function shift; the call-site (calls.ts) emits the
+native call and unwraps to a native string. Locale/options args are ignored.
+**JS-host mode is untouched** — it keeps the Intl-backed `__extern_toLocaleString`
+(grouping preserved), so no host regression.
+
+**Scope guards:** number receiver only; non-number receivers (Array/TypedArray/
+Date/object) keep the host `__extern_toLocaleString` fallback unchanged.
+
+**Validation.** `tests/issue-2160-number-tolocalestring.test.ts` (11/11):
+integer/single-digit/fractional/negative number toLocaleString + string
+concat across host & standalone, plus a standalone no-`__extern_toLocaleString`-leak
+assertion. tsc + prettier clean.
+
+**Follow-ups noted (not in this slice):** the `new String`/`new Number` wrapper
+method-dispatch + `.length` + indexing residual is BLOCKED on a native wrapper
+constructor — `new String`/`new Number`/`new Boolean` always emit the host
+`__new_String`/`__new_Number` imports (new-super.ts), and `__unbox_string` is
+host-only, so there is no native wrapper struct / primitive slot to read. That
+slice needs the value-rep #2072/#2104/#1910-S2 native wrapper representation
+first (senior-dev/value-rep). Separately, `String.raw` emits an invalid
+standalone binary (distinct slice).

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -337,6 +337,16 @@ export function unifiedVisitNode(ctx: CodegenContext, state: UnifiedCollectorSta
         state.primitiveNeeded.add("number_toString");
       }
     }
+    // (#2160) Number.prototype.toLocaleString in no-JS-host targets — without an
+    // Intl implementation the default result is the base-10
+    // `Number.prototype.toString`, so register the same `number_toString` helper.
+    // Pre-registering here lets the codegen path (calls.ts) emit the call without
+    // a late module-function shift and keeps a number receiver off the
+    // `__extern_toLocaleString` host import (which CEs in standalone —
+    // `dynamic-shape object`). JS-host mode keeps the Intl-backed fallback.
+    if ((ctx.standalone || ctx.wasi) && isNumberType(receiverType) && methodName === "toLocaleString") {
+      state.primitiveNeeded.add("number_toString");
+    }
     // (#1644 Slice D) BigInt.prototype.toString — bigint-typed receiver routes
     // to bigint_toString / bigint_toString_radix (i64 → externref). Without
     // this registration the property-access path falls through and returns null.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -7444,6 +7444,33 @@ function compileCallExpression(
         return { kind: "externref" };
       }
     }
+    // (#2160) Number.prototype.toLocaleString in no-JS-host targets
+    // (standalone / WASI) — §21.1.3.4. There is no Intl implementation, and the
+    // generic `__extern_toLocaleString` host fallback below CEs on a number
+    // receiver (`dynamic-shape object` — a bare number is not an extern object).
+    // Per spec the no-Intl default is implementation-defined; delegating to the
+    // base-10 `Number.prototype.toString` (the decimal form) is conformant and
+    // matches the existing `toLocaleString → toString` delegation elsewhere
+    // (calls-closures.ts). Locale/options args are ignored. JS-host mode is left
+    // on the real Intl-backed `__extern_toLocaleString` (locale grouping). Mirrors
+    // the number `toString` native-string unwrap so consumers see a native ref.
+    if (noJsHost(ctx) && isNumberType(receiverType) && propAccess.name.text === "toLocaleString") {
+      const exprType = compileExpression(ctx, fctx, propAccess.expression);
+      if (exprType && exprType.kind === "i32") {
+        fctx.body.push({ op: "f64.convert_i32_s" });
+      }
+      const funcIdx = ctx.funcMap.get("number_toString");
+      if (funcIdx !== undefined) {
+        fctx.body.push({ op: "call", funcIdx });
+        const unwrapToNative = ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0 && (ctx.standalone || ctx.wasi);
+        if (unwrapToNative) {
+          fctx.body.push({ op: "any.convert_extern" } as Instr);
+          fctx.body.push({ op: "ref.cast", typeIdx: ctx.anyStrTypeIdx } as Instr);
+          return nativeStringType(ctx);
+        }
+        return { kind: "externref" };
+      }
+    }
     // (#1644 Slice D) BigInt.prototype.toString — bigint receivers cross the
     // boundary as i64. Mirror the number branch: validate radix range (2-36),
     // throw RangeError otherwise, then call bigint_toString_radix (or the

--- a/tests/issue-2160-number-tolocalestring.test.ts
+++ b/tests/issue-2160-number-tolocalestring.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2160 (slice) — `Number.prototype.toLocaleString()` (§21.1.3.4) on a number
+// receiver CE'd in standalone / WASI with `'__extern_toLocaleString'
+// (dynamic-shape object)`: the generic `toLocaleString` fallback in calls.ts
+// routes the receiver to the host `__extern_toLocaleString` import, but a bare
+// number is not an extern object so the standalone codegen refuses it.
+//
+// Fix: in no-JS-host targets (standalone / WASI, where there is no Intl), a
+// number receiver's `toLocaleString` delegates to the base-10
+// `Number.prototype.toString` (`number_toString`). Per spec the no-Intl default
+// is implementation-defined; the decimal form is conformant and matches the
+// existing `toLocaleString → toString` delegation. Locale / options arguments
+// are ignored. JS-host mode is untouched — it keeps the real Intl-backed
+// `__extern_toLocaleString` (locale grouping like "1,234").
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+type Mode = { label: string; opts: Record<string, unknown> };
+const MODES: Mode[] = [
+  { label: "host", opts: {} },
+  { label: "standalone", opts: { target: "standalone" } },
+];
+
+async function run(src: string, opts: Record<string, unknown>): Promise<unknown> {
+  const result = await compile(src, { fileName: "test.ts", ...opts });
+  expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#2160 — Number.prototype.toLocaleString", () => {
+  for (const { label, opts } of MODES) {
+    describe(`[${label}]`, () => {
+      it("integer toLocaleString length (decimal form)", async () => {
+        // "1234".length === 4 in standalone; host Intl ("1,234") has length 5.
+        // Assert via a comparison the receiver supports in both modes: the first
+        // char is '1' and the last char is '4' regardless of grouping.
+        expect(
+          await run(
+            `export function test(): boolean {
+               const s = (1234).toLocaleString();
+               return s.charCodeAt(0) === 49 && s.charCodeAt(s.length - 1) === 52;
+             }`,
+            opts,
+          ),
+        ).toBe(1);
+      });
+
+      it("single-digit toLocaleString === '5'", async () => {
+        expect(
+          await run(`export function test(): boolean { const s = (5).toLocaleString(); return s === "5"; }`, opts),
+        ).toBe(1);
+      });
+
+      it("fractional toLocaleString === '3.5'", async () => {
+        expect(
+          await run(`export function test(): boolean { const n = 3.5; return n.toLocaleString() === "3.5"; }`, opts),
+        ).toBe(1);
+      });
+
+      it("negative toLocaleString === '-7'", async () => {
+        expect(await run(`export function test(): boolean { return (-7).toLocaleString() === "-7"; }`, opts)).toBe(1);
+      });
+
+      it("toLocaleString result is concatenable as a string", async () => {
+        expect(
+          await run(
+            `export function test(): boolean { return ("n=" + (42).toLocaleString()).charCodeAt(0) === 110; }`,
+            opts,
+          ),
+        ).toBe(1);
+      });
+    });
+  }
+
+  it("standalone emits no __extern_toLocaleString host import for a number receiver", async () => {
+    const result = await compile(`export function test(): number { return (1234).toLocaleString().length; }`, {
+      fileName: "test.ts",
+      target: "standalone",
+    });
+    expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+    const leaked = (result.imports ?? []).some((i) => i.name === "__extern_toLocaleString");
+    expect(leaked).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`(n).toLocaleString()` on a **number receiver** CE'd in standalone / WASI with `'__extern_toLocaleString' (dynamic-shape object)`: the generic `toLocaleString` fallback routes the receiver to the host `__extern_toLocaleString` import, but a bare number is not an extern object so the standalone codegen refuses it. (Host mode worked via real Intl, e.g. `"1,234"`.)

## Fix (no-JS-host only)

§21.1.3.4 — there is no Intl in standalone/WASI and the no-Intl default is implementation-defined. For a number receiver in no-JS-host targets, delegate `toLocaleString` to the base-10 `Number.prototype.toString` (native `number_toString`), matching the `toLocaleString → toString` delegation already used elsewhere. The import-collector pre-registers `number_toString` for the `toLocaleString` call shape (gated `standalone || wasi`) so the call lowers without a late module-function shift; the call-site emits the native call and unwraps to a native string. Locale/options args are ignored.

**JS-host mode is untouched** — it keeps the Intl-backed `__extern_toLocaleString` (grouping preserved), so no host regression. Non-number receivers (Array/TypedArray/Date/object) also keep the host fallback unchanged.

## Scope

One independent slice of #2160. The `new String`/`new Number` wrapper method-dispatch residual is BLOCKED on a native wrapper constructor (value-rep #2072/#2104/#1910-S2, senior-dev) and is NOT in this PR; `String.raw` invalid-standalone-binary is a separate slice. #2160 stays `ready`.

## Test

`tests/issue-2160-number-tolocalestring.test.ts` (11/11): integer/single-digit/fractional/negative number toLocaleString + string concat across host & standalone, plus a standalone no-`__extern_toLocaleString`-leak assertion. tsc + prettier + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)