### PR TITLE
fix(#2029): standalone Object.create(proto, descriptors) emit crash

### DIFF
--- a/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
+++ b/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
@@ -170,3 +170,52 @@ standalone still leaks the `__new_<Builtin>` HOST import (`class-bodies.ts:1423/
 — a host-import-retirement concern, not the emit crash. Kept #2029 `in-progress`:
 the emit-crash cluster (the headline) is fixed; the `__new_<Builtin>` standalone
 runtime path is the residual. Reassess closing once that lands.
+
+## Slice (2026-06-21, dev-agent) — `Object.create(proto, descriptors)` emit crash
+
+**Status stays `in-progress`** — one independent emit-crash slice of the bucket.
+
+The PR-1 audit said `built-ins/Object/create` "all COMPILE in standalone", but
+that was the **1-arg** form. `Object.create(proto, descriptors)` with a
+**non-empty** properties object still died at emit with
+`Binary emit error: global index out of range — -1` (the documented #1174
+string-global -1 sentinel).
+
+**Producer (confirmed):** the compile-time descriptor expansion in the
+`Object.create` handler (`src/codegen/expressions/calls.ts`) materialized each
+property KEY with a raw `{ op: "global.get", index: stringGlobalMap.get(key) }`,
+guarding only `=== undefined`. Under standalone/nativeStrings the key string is
+stored as the -1 sentinel, so `global.get -1` reached the encoder and crashed.
+Two sites: the static `__defineProperty_value` arm and the dynamic-flag
+`__defineProperty_desc` arm.
+
+**Fix:** emit the key via the existing dual-mode `stringConstantExternrefInstrs`
+helper (native-string externref standalone; `global.get` for a valid host
+global; already guards the -1 sentinel) at both sites. Mirrors the
+`emitSetSubclassProto` fix shape from PR-1. gc/host mode is unchanged (real
+globals, never the sentinel).
+
+**Measured (60-file `built-ins/Object/create` standalone sample):**
+main `pass 3 / fail 1 / CE 49` → fix `pass 8 / fail 13 / CE 32` — **+5 pass,
+17 tests moved out of compile_error**. Zero host regressions (host
+`Object.create(null, {a:{value:1},b:{value:2}})` returns correctly before and
+after).
+
+**Validation.** `tests/issue-2029-object-create-descriptors-standalone-emit.test.ts`
+(9/9): single/multi/string-literal-key/static-flag descriptors compile
+standalone; value-descriptor read-back (42, 5); no `-1` global emitted; host
+no-regression guard. Existing `issue-2029-subclass-builtin-standalone-emit`
+(8/8) green. tsc + prettier + coercion-sites clean.
+
+**Still open (separate, NOT this slice):**
+- 4 `Object/create` files still emit `-1` via a DIFFERENT producer
+  (`Object.create({}, undefined)` + `instanceof Object` — the assert/instanceof
+  string-global path, not the descriptor path).
+- `o.a + o.b` arithmetic over TWO `any`-typed properties read off an
+  `Object.create(null, …)` result traps standalone with `illegal cast` — a
+  native dynamic-property-read/unbox gap on the `__object_create` result object
+  (reading `o.b` alone works; a plain `{}` two-prop add works). Overlaps the
+  value-rep / `__defineProperty_value` runtime, not the emit crash.
+- `__defineProperty_value` / `__defineProperty_desc` / `__getOwnPropertyDescriptor`
+  remain host-only imports refused standalone (`dynamic-shape`) — the
+  descriptor-read clusters need native runtime impls (separate slice).

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -4702,14 +4702,16 @@ function compileCallExpression(
             if (dpIdx !== undefined) {
               // obj
               fctx.body.push({ op: "local.get", index: objLocal });
-              // prop name as string constant
+              // prop name as string constant. (#2029) Use the dual-mode
+              // helper instead of a raw `global.get`: under standalone /
+              // nativeStrings `addStringConstantGlobal` stores the documented
+              // -1 sentinel in `stringGlobalMap` (#1174 — "no host import,
+              // materialize inline"), and emitting `global.get -1` crashed the
+              // encoder with `global index out of range — -1`. The helper
+              // materializes a native string externref standalone and falls
+              // back to `global.get` only for a valid host global.
               addStringConstantGlobal(ctx, propName);
-              const strGlobalIdx = ctx.stringGlobalMap.get(propName);
-              if (strGlobalIdx !== undefined) {
-                fctx.body.push({ op: "global.get", index: strGlobalIdx } as Instr);
-              } else {
-                fctx.body.push({ op: "ref.null.extern" });
-              }
+              fctx.body.push(...stringConstantExternrefInstrs(ctx, propName));
               // value (or null for accessor descriptors)
               if (valueExpr) {
                 const vt = compileExpression(ctx, fctx, valueExpr);
@@ -4769,13 +4771,11 @@ function compileCallExpression(
 
             if (dpDescIdx !== undefined) {
               fctx.body.push({ op: "local.get", index: objLocal });
+              // (#2029) dual-mode key materialization — see the
+              // __defineProperty_value arm above for why a raw `global.get`
+              // crashes the encoder standalone (the -1 string-global sentinel).
               addStringConstantGlobal(ctx, propName);
-              const strGlobalIdx = ctx.stringGlobalMap.get(propName);
-              if (strGlobalIdx !== undefined) {
-                fctx.body.push({ op: "global.get", index: strGlobalIdx } as Instr);
-              } else {
-                fctx.body.push({ op: "ref.null.extern" });
-              }
+              fctx.body.push(...stringConstantExternrefInstrs(ctx, propName));
               const descValType = compileExpression(ctx, fctx, prop.initializer);
               if (!descValType) {
                 fctx.body.push({ op: "ref.null.extern" });

--- a/tests/issue-2029-object-create-descriptors-standalone-emit.test.ts
+++ b/tests/issue-2029-object-create-descriptors-standalone-emit.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2029 — `Object.create(proto, descriptors)` standalone emit crash.
+//
+// The compile-time descriptor expansion in the `Object.create` handler
+// (`src/codegen/expressions/calls.ts`) materialized each property KEY with a
+// raw `{ op: "global.get", index: stringGlobalMap.get(key) }`. Under
+// `--target standalone` / nativeStrings, `addStringConstantGlobal` stores the
+// documented -1 sentinel ("no host import — materialize inline", #1174), so
+// the emitted `global.get -1` blew up the binary encoder:
+//   `Binary emit error: Codegen error: global index out of range — -1`
+// — a hard compile_error that loses the whole file. (gc/host mode kept real
+// globals, so it never hit the sentinel there.)
+//
+// Fix: emit the key via the dual-mode `stringConstantExternrefInstrs` helper
+// (native-string externref standalone; `global.get` for a valid host global),
+// which already guards the -1 sentinel. Both the static (`__defineProperty_value`)
+// and dynamic-flag (`__defineProperty_desc`) descriptor arms are covered.
+
+async function compileStandalone(src: string) {
+  return compile(src, { fileName: "test.ts", target: "standalone", skipSemanticDiagnostics: true });
+}
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compileStandalone(src);
+  if (!r.success) throw new Error("compile failed: " + (r.errors[0]?.message ?? "unknown"));
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports.test as () => number)();
+}
+
+describe("#2029 Object.create(proto, descriptors) standalone emit", () => {
+  it("single value descriptor compiles standalone (was: global index out of range -1)", async () => {
+    const r = await compileStandalone(
+      `export function test(): number { const o: any = Object.create(null, { x: { value: 1 } }); return 1; }`,
+    );
+    expect(r.success).toBe(true);
+  });
+
+  it("value descriptor with a non-null proto compiles standalone", async () => {
+    const r = await compileStandalone(
+      `const proto = {}; export function test(): number { const o: any = Object.create(proto, { x: { value: 1 } }); return 1; }`,
+    );
+    expect(r.success).toBe(true);
+  });
+
+  it("descriptor with a static boolean flag compiles standalone", async () => {
+    const r = await compileStandalone(
+      `export function test(): number { const o: any = Object.create(null, { x: { value: 1, writable: true, enumerable: true } }); return 1; }`,
+    );
+    expect(r.success).toBe(true);
+  });
+
+  it("string-literal descriptor key compiles standalone", async () => {
+    const r = await compileStandalone(
+      `export function test(): number { const o: any = Object.create(null, { "k-1": { value: 1 } }); return 1; }`,
+    );
+    expect(r.success).toBe(true);
+  });
+
+  it("multiple descriptor keys compile standalone", async () => {
+    const r = await compileStandalone(
+      `export function test(): number { const o: any = Object.create(null, { a: { value: 1 }, b: { value: 2 } }); return 1; }`,
+    );
+    expect(r.success).toBe(true);
+  });
+
+  it("does not emit a -1 string-global (no encoder crash)", async () => {
+    const r = await compileStandalone(
+      `export function test(): number { const o: any = Object.create(null, { x: { value: 1 } }); return 1; }`,
+    );
+    expect(r.success).toBe(true);
+    expect(r.errors.some((e) => /global index out of range/.test(e.message))).toBe(false);
+  });
+
+  it("reads back a single value-descriptor property standalone", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o: any = Object.create(null, { x: { value: 42 } }); return o.x; }`,
+      ),
+    ).toBe(42);
+  });
+
+  it("reads back a string-literal-key property standalone", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o: any = Object.create(null, { "k-1": { value: 5 } }); return o["k-1"]; }`,
+      ),
+    ).toBe(5);
+  });
+
+  it("host (gc) mode unaffected — Object.create descriptors still compile", async () => {
+    const r = await compile(
+      `export function test(): number { const o: any = Object.create(null, { a: { value: 1 }, b: { value: 2 } }); return 1; }`,
+      { fileName: "test.ts", skipSemanticDiagnostics: true },
+    );
+    expect(r.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`Object.create(proto, descriptors)` with a **non-empty** properties object died at emit time under `--target standalone` with `Binary emit error: Codegen error: global index out of range — -1` — a hard `compile_error` that loses the whole file. (The #2029 PR-1 audit marked `built-ins/Object/create` as compiling, but that was the **1-arg** form; the 2-arg descriptor form still crashed.)

## Producer

The compile-time descriptor expansion in the `Object.create` handler (`src/codegen/expressions/calls.ts`) materialized each property **key** with a raw `{ op: "global.get", index: stringGlobalMap.get(key) }`, guarding only `=== undefined`. Under standalone / nativeStrings, `addStringConstantGlobal` stores the documented **-1 sentinel** (#1174 — "no host import, materialize inline"), so `global.get -1` reached the binary encoder and crashed. Two sites: the static `__defineProperty_value` arm and the dynamic-flag `__defineProperty_desc` arm.

## Fix

Emit the key via the existing dual-mode `stringConstantExternrefInstrs` helper (native-string externref standalone; `global.get` for a valid host global; **already guards the -1 sentinel**) at both sites. Mirrors the `emitSetSubclassProto` fix shape from PR-1. gc/host mode is unchanged (real globals, never the sentinel).

## Measured impact

60-file `built-ins/Object/create` standalone sample:

| | pass | fail | CE |
|---|---:|---:|---:|
| main | 3 | 1 | 49 |
| this PR | 8 | 13 | 32 |

**+5 pass, 17 tests moved out of `compile_error`.** Zero host regressions (host `Object.create(null, {a:{value:1},b:{value:2}})` returns correctly before and after).

## Validation

- `tests/issue-2029-object-create-descriptors-standalone-emit.test.ts` (9/9): single / multi / string-literal-key / static-flag descriptors compile standalone; value-descriptor read-back (42, 5); no `-1` global emitted; host no-regression guard.
- Existing `tests/issue-2029-subclass-builtin-standalone-emit.test.ts` (8/8) green.
- tsc + prettier + coercion-sites gates clean.

## Still open (separate, not this slice)

- 4 `Object/create` files still emit `-1` via a **different** producer (`Object.create({}, undefined)` + `instanceof Object` — the assert/instanceof string-global path).
- `o.a + o.b` arithmetic over two `any`-typed props read off an `Object.create(null, …)` result traps standalone with `illegal cast` (native dynamic-read/unbox gap; reading `o.b` alone works; plain `{}` two-prop add works).
- `__defineProperty_value`/`__defineProperty_desc`/`__getOwnPropertyDescriptor` remain host-only imports refused standalone (`dynamic-shape`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)