### PR TITLE
fix(#2162): seed new Set() from a non-literal array argument (standalone)

### DIFF
--- a/plan/issues/2162-standalone-map-set-weak-collections-residual.md
+++ b/plan/issues/2162-standalone-map-set-weak-collections-residual.md
@@ -239,3 +239,35 @@ WeakMap/WeakSet/Map case `standalone+nativeStrings` and asserts valid Wasm; the
 assertion is `false` without the three-site fix (verified by reverting). tsc
 clean; existing Map/Set/Weak standalone suites (34) + shift-sensitive #2131 +
 foreach/algebra (29) unaffected.
+
+## Slice — `new Set(nonLiteralArray)` constructor (PR, dev-carla, 2026-06-21)
+
+The prior from-array slice seeded `new Set([1,2,3])` only from an array
+**literal**; a non-literal array-typed argument (`new Set(arr)` where `arr` is a
+variable / call result) fell through to the host path and **leaked env imports**
+(`env: module is not an object or function` on instantiate). Now seeded
+host-import-free.
+
+**Fix** — `seedNativeSetFromArrayArg` (`src/codegen/expressions/new-super.ts`):
+when the single `new Set(...)` argument is a checker-confirmed array/tuple type
+(`isArrayTypedArg`) that is NOT an array literal, compile it to its `$Vec`
+(`{length: i32, data: (ref $arr)}`), then emit a counted Wasm `block`/`loop` that
+walks `data[i]`, boxes each element to anyref via the existing
+`coerceMapKeyToAnyref` (spliced into the loop body), and calls `__set_add`. The
+element `array.get` uses the per-kind sign-extension (`array.get_u`/`_s` for
+packed i8/i16). On a non-vec / unsupported-element arg the helper gracefully
+leaves the empty Set on the stack — never a host-import leak or CE. Gated on
+`ctx.nativeStrings`; gc/host mode untouched.
+
+**Verified** (`tests/issue-2162-nonliteral-set-ctor.test.ts`, 7/7, `target:
+wasi`, ZERO `Set_*`/`Map_*` imports): numeric-array-variable seed + dedup,
+membership hit/miss, string-array seed + dedup, function-returned-array seed, and
+the no-arg + array-literal forms unaffected. tsc + prettier clean; all prior
+#2162 standalone suites (23 across set/iterators/collection-from-array) green.
+
+**Still open (this slice's siblings):** `new Map(pairsVariable)` — the inner
+`[K,V]` pair lowers to a typed tuple *struct* (`$__tuple_<n>`), not an inner vec,
+so its extraction is a distinct shape (per-field `struct.get`, varying field
+types) and falls through to an empty Map for now. `[...collection]`
+spread-of-Set/Map and `new Set(iterableNonArray)` (general iterator drive) also
+remain.

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -2081,6 +2081,162 @@ function emitDynamicNewFallback(
   return true;
 }
 
+/**
+ * (#2162) Seed a native Set (its `$Map` backing store, already built and held in
+ * `collTmp`) from a NON-LITERAL array-typed argument — `new Set(arr)`,
+ * `new Set(spreadVar)` — the dominant non-literal iterable form. The
+ * array-literal form is handled inline by the constructor block; this covers the
+ * variable / call-result vec.
+ *
+ * `arg` is compiled to a `$Vec` struct (`{length: i32, data: (ref $arr)}`); we
+ * walk it with a counted Wasm loop, box each element, and call `__set_add`.
+ *
+ * ALWAYS leaves the collection ref on the stack (the caller returns it directly).
+ * Returns true when the seed loop was emitted; false when the arg is not a usable
+ * vec (the collection is left empty — graceful: never a host-import leak / CE).
+ *
+ * NOTE — Map(pairsVar) is intentionally out of this slice: the inner `[K,V]` pair
+ * lowers to a typed *tuple struct* (`$__tuple_<n>`), not an inner vec, so its
+ * extraction is a distinct shape (struct.get per field, varying field types). The
+ * Map array-literal-of-pairs form is already handled inline; the non-literal Map
+ * variable form falls back to an empty Map (no leak/CE) and is a follow-up.
+ */
+function seedNativeSetFromArrayArg(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  arg: ts.Expression,
+  collTmp: number,
+  addFuncIdx: number,
+): boolean {
+  // Bail helper: drop a stray compiled value (if any) and restore the collection.
+  const bail = (dropArg: boolean): boolean => {
+    if (dropArg) fctx.body.push({ op: "drop" });
+    fctx.body.push({ op: "local.get", index: collTmp });
+    return false;
+  };
+  // Compile the argument to its vec value.
+  const argType = compileExpression(ctx, fctx, arg);
+  if (argType === null) return bail(false);
+  if (argType.kind !== "ref" && argType.kind !== "ref_null") return bail(true);
+  const vecTypeIdx = (argType as { typeIdx: number }).typeIdx;
+  const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+  if (arrTypeIdx < 0) return bail(true);
+  const arrDef = ctx.mod.types[arrTypeIdx];
+  if (!arrDef || arrDef.kind !== "array") return bail(true);
+  const elemType = arrDef.element;
+
+  // Locals: the source vec, its data array, the loop index, the length.
+  const vecLocal = allocLocal(fctx, `__collctor_vec_${fctx.locals.length}`, argType);
+  const dataLocal = allocLocal(fctx, `__collctor_data_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: arrTypeIdx,
+  });
+  const idxLocal = allocLocal(fctx, `__collctor_i_${fctx.locals.length}`, { kind: "i32" });
+  const lenLocal = allocLocal(fctx, `__collctor_len_${fctx.locals.length}`, { kind: "i32" });
+
+  // vec → local; data = vec.data (field 1); len = vec.length (field 0); i = 0.
+  fctx.body.push({ op: "local.set", index: vecLocal });
+  fctx.body.push({ op: "local.get", index: vecLocal });
+  fctx.body.push({ op: "ref.as_non_null" } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 } as Instr);
+  fctx.body.push({ op: "local.set", index: dataLocal });
+  fctx.body.push({ op: "local.get", index: vecLocal });
+  fctx.body.push({ op: "ref.as_non_null" } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr);
+  fctx.body.push({ op: "local.set", index: lenLocal });
+  fctx.body.push({ op: "i32.const", value: 0 });
+  fctx.body.push({ op: "local.set", index: idxLocal });
+
+  // Build the per-element body inside a block/loop. The body reads data[i],
+  // coerces to anyref, and calls __set_add with the collection.
+  const loopBody: Instr[] = [];
+  // break if i >= len
+  loopBody.push({ op: "local.get", index: idxLocal });
+  loopBody.push({ op: "local.get", index: lenLocal });
+  loopBody.push({ op: "i32.ge_s" });
+  loopBody.push({ op: "br_if", depth: 1 });
+  {
+    // __set_add(coll, box(data[i]))  (returns ref $Map → drop)
+    loopBody.push({ op: "local.get", index: collTmp });
+    loopBody.push({ op: "local.get", index: dataLocal });
+    loopBody.push({ op: "local.get", index: idxLocal });
+    loopBody.push(emitArrayGetForElem(arrTypeIdx, elemType));
+    emitCoerceElemToAnyrefInto(ctx, fctx, loopBody, elemType);
+    loopBody.push({ op: "call", funcIdx: addFuncIdx });
+    loopBody.push({ op: "drop" });
+  }
+
+  // i += 1; continue
+  loopBody.push({ op: "local.get", index: idxLocal });
+  loopBody.push({ op: "i32.const", value: 1 });
+  loopBody.push({ op: "i32.add" });
+  loopBody.push({ op: "local.set", index: idxLocal });
+  loopBody.push({ op: "br", depth: 0 });
+
+  fctx.body.push({
+    op: "block",
+    blockType: { kind: "empty" },
+    body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr],
+  } as Instr);
+
+  // Leave the collection on the stack.
+  fctx.body.push({ op: "local.get", index: collTmp });
+  return true;
+}
+
+/**
+ * (#2162) Is `arg`'s static type an array (`T[]` / `Array<T>` / readonly array /
+ * a tuple)? Used to recognise the non-literal iterable form of `new Set(arr)` /
+ * `new Map(pairs)`. Conservative: only a checker-confirmed array/tuple type
+ * qualifies, so a plain identifier of a non-array type never routes here.
+ */
+function isArrayTypedArg(ctx: CodegenContext, arg: ts.Expression): boolean {
+  // A spread inside the constructor arg list is grammatically not a single arg
+  // here (handled at the array-literal layer); guard anyway.
+  if (ts.isSpreadElement(arg)) return false;
+  const t = ctx.checker.getTypeAtLocation(arg);
+  // ts.TypeChecker exposes isArrayType/isTupleType on the internal API used
+  // elsewhere in the codebase; fall back to apparent-type number-index probing.
+  const checkerAny = ctx.checker as unknown as {
+    isArrayType?: (t: ts.Type) => boolean;
+    isTupleType?: (t: ts.Type) => boolean;
+    isArrayLikeType?: (t: ts.Type) => boolean;
+  };
+  if (checkerAny.isArrayType?.(t)) return true;
+  if (checkerAny.isTupleType?.(t)) return true;
+  // Apparent-type fallback: a numeric index signature + a `length` member is the
+  // array-like shape. Avoids matching plain objects (no number index sig).
+  const apparent = ctx.checker.getApparentType(t);
+  const numIndex = apparent.getNumberIndexType?.();
+  const hasLength = apparent.getProperty?.("length") !== undefined;
+  return numIndex !== undefined && hasLength;
+}
+
+/** array.get with the per-kind sign extension for packed element types. */
+function emitArrayGetForElem(arrTypeIdx: number, elemType: ValType): Instr {
+  const op = elemType.kind === "i8" ? "array.get_u" : elemType.kind === "i16" ? "array.get_s" : "array.get";
+  return { op, typeIdx: arrTypeIdx } as Instr;
+}
+
+/**
+ * Coerce a vec element (already on the stack, type `elemType`) to anyref for a
+ * collection key/value, appending into `out`. Mirrors `coerceMapKeyToAnyref` but
+ * targets an arbitrary instruction buffer (the loop body, not `fctx.body`).
+ */
+function emitCoerceElemToAnyrefInto(ctx: CodegenContext, fctx: FunctionContext, out: Instr[], elemType: ValType): void {
+  // Reuse coerceMapKeyToAnyref by temporarily swapping the body buffer: it pushes
+  // onto fctx.body. We splice those instructions into `out`.
+  const saved = fctx.body;
+  const scratch: Instr[] = [];
+  fctx.body = scratch;
+  try {
+    coerceMapKeyToAnyref(ctx, fctx, elemType);
+  } finally {
+    fctx.body = saved;
+  }
+  for (const instr of scratch) out.push(instr);
+}
+
 function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: ts.NewExpression): ValType | null {
   // Handle `new function() { ... }(args)` — constructor with function expression
   if (ts.isFunctionExpression(expr.expression)) {
@@ -2151,6 +2307,10 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       arrArg.elements.every(
         (e) => ts.isArrayLiteralExpression(e) && e.elements.length === 2 && !e.elements.some(ts.isSpreadElement),
       );
+    // (#2162) Map from a NON-literal array-of-pairs variable is a follow-up: the
+    // inner `[K,V]` pair lowers to a typed tuple *struct* (not an inner vec), so
+    // its extraction differs from the Set element walk. The array-literal-of-pairs
+    // form is handled below; a non-literal Map arg falls through to the empty map.
     if (args.length === 0 || seedablePairs) {
       addUnionImports(ctx);
       ensureMapHelpers(ctx);
@@ -2192,7 +2352,12 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
   if (ctx.nativeStrings && ts.isIdentifier(expr.expression) && expr.expression.text === "Set") {
     const args = expr.arguments ?? ([] as readonly ts.Expression[]);
     const arrArg = args.length === 1 && ts.isArrayLiteralExpression(args[0]!) ? args[0]! : undefined;
-    if (args.length === 0 || arrArg) {
+    // (#2162) A single NON-literal argument whose static type is an array (a
+    // variable, a spread that lowered to a vec, `[...set]`, a call result) is the
+    // dominant non-literal iterable form — seed it via a runtime vec walk.
+    const nonLiteralArrArg =
+      args.length === 1 && arrArg === undefined && isArrayTypedArg(ctx, args[0]!) ? args[0]! : undefined;
+    if (args.length === 0 || arrArg || nonLiteralArrArg) {
       addUnionImports(ctx);
       ensureSetHelpers(ctx);
       const mapNewIdx = ctx.mapHelpers.get("__map_new");
@@ -2214,6 +2379,15 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
             fctx.body.push({ op: "drop" }); // discard chained set
           }
           fctx.body.push({ op: "local.get", index: mTmp });
+        } else if (nonLiteralArrArg && setAddIdx !== undefined) {
+          const mTmp = allocLocal(fctx, `__setctor_m_${fctx.locals.length}`, {
+            kind: "ref",
+            typeIdx: ctx.mapTypeIdx,
+          });
+          fctx.body.push({ op: "local.set", index: mTmp });
+          // On a non-vec / unsupported-element arg the helper leaves the empty
+          // collection on the stack (graceful: empty Set, never a host-import leak).
+          seedNativeSetFromArrayArg(ctx, fctx, nonLiteralArrArg, mTmp, setAddIdx);
         }
         return { kind: "ref", typeIdx: ctx.mapTypeIdx };
       }

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -2155,16 +2155,14 @@ function seedNativeSetFromArrayArg(
   loopBody.push({ op: "local.get", index: lenLocal });
   loopBody.push({ op: "i32.ge_s" });
   loopBody.push({ op: "br_if", depth: 1 });
-  {
-    // __set_add(coll, box(data[i]))  (returns ref $Map → drop)
-    loopBody.push({ op: "local.get", index: collTmp });
-    loopBody.push({ op: "local.get", index: dataLocal });
-    loopBody.push({ op: "local.get", index: idxLocal });
-    loopBody.push(emitArrayGetForElem(arrTypeIdx, elemType));
-    emitCoerceElemToAnyrefInto(ctx, fctx, loopBody, elemType);
-    loopBody.push({ op: "call", funcIdx: addFuncIdx });
-    loopBody.push({ op: "drop" });
-  }
+  // __set_add(coll, box(data[i]))  (returns ref $Map → drop)
+  loopBody.push({ op: "local.get", index: collTmp });
+  loopBody.push({ op: "local.get", index: dataLocal });
+  loopBody.push({ op: "local.get", index: idxLocal });
+  loopBody.push(emitArrayGetForElem(arrTypeIdx, elemType));
+  emitCoerceElemToAnyrefInto(ctx, fctx, loopBody, elemType);
+  loopBody.push({ op: "call", funcIdx: addFuncIdx });
+  loopBody.push({ op: "drop" });
 
   // i += 1; continue
   loopBody.push({ op: "local.get", index: idxLocal });

--- a/tests/issue-2162-nonliteral-set-ctor.test.ts
+++ b/tests/issue-2162-nonliteral-set-ctor.test.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #2162 — `new Set(arr)` from a NON-LITERAL array-typed argument (a variable, a
+// call result) in standalone / nativeStrings mode.
+//
+// The prior slice seeded `new Set([1,2,3])` only from an array LITERAL; a
+// variable/expression argument (`new Set(arr)`) fell through to the host path and
+// leaked env imports (`env: module is not an object or function` on instantiate).
+// This slice walks the argument's `$Vec` at runtime (a counted loop reading
+// `data[i]`, boxing per element kind, calling `__set_add`) so the non-literal
+// form is host-import-free.
+//
+// Each test compiles `target: "wasi"` and asserts valid Wasm, ZERO
+// `Set_*`/`Map_*` host imports, and the expected value.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildWasiPolyfill } from "../src/runtime.js";
+
+async function run(source: string): Promise<{ value: number; collImports: number; valid: boolean }> {
+  const result = await compile(source, { fileName: "test.ts", target: "wasi" });
+  if (!result.success) {
+    throw new Error(`compile failed: ${result.errors?.[0]?.message ?? "unknown error"}`);
+  }
+  const valid = WebAssembly.validate(result.binary);
+  const module = await WebAssembly.compile(result.binary);
+  const collImports = WebAssembly.Module.imports(module).filter((i) => /^(Set|Map)_/.test(i.name)).length;
+  const wasi = buildWasiPolyfill();
+  const instance = await WebAssembly.instantiate(module, { wasi_snapshot_preview1: wasi });
+  const exports = instance.exports as Record<string, unknown>;
+  if (exports.memory) wasi.setMemory(exports.memory as WebAssembly.Memory);
+  const value = (exports.test as () => number)();
+  return { value, collImports, valid };
+}
+
+describe("#2162 new Set(nonLiteralArray) (standalone)", () => {
+  it("seeds from a numeric array variable and dedups — host-import-free", async () => {
+    const { value, collImports, valid } = await run(
+      `export function test(): number {
+        const arr = [1, 2, 3, 2, 1];
+        const s = new Set<number>(arr);
+        return s.size;
+      }`,
+    );
+    expect(valid).toBe(true);
+    expect(collImports).toBe(0);
+    expect(value).toBe(3); // dedup: {1,2,3}
+  });
+
+  it("membership holds for a value seeded from a variable", async () => {
+    const { value } = await run(
+      `export function test(): number {
+        const arr = [10, 20, 30];
+        const s = new Set<number>(arr);
+        return s.has(20) ? 1 : 0;
+      }`,
+    );
+    expect(value).toBe(1);
+  });
+
+  it("a value not in the source array is absent", async () => {
+    const { value } = await run(
+      `export function test(): number {
+        const arr = [10, 20, 30];
+        const s = new Set<number>(arr);
+        return s.has(99) ? 1 : 0;
+      }`,
+    );
+    expect(value).toBe(0);
+  });
+
+  it("seeds from a string array variable and dedups", async () => {
+    const { value, collImports } = await run(
+      `export function test(): number {
+        const arr = ["x", "y", "x", "z"];
+        const s = new Set<string>(arr);
+        return s.size;
+      }`,
+    );
+    expect(collImports).toBe(0);
+    expect(value).toBe(3); // {"x","y","z"}
+  });
+
+  it("seeds from a function-returned array", async () => {
+    const { value } = await run(
+      `function makeArr(): number[] { return [4, 5, 6]; }
+       export function test(): number {
+        const s = new Set<number>(makeArr());
+        return s.size;
+      }`,
+    );
+    expect(value).toBe(3);
+  });
+
+  it("the no-arg form is unaffected", async () => {
+    const { value } = await run(
+      `export function test(): number {
+        const s = new Set<number>();
+        s.add(7);
+        s.add(7);
+        return s.size;
+      }`,
+    );
+    expect(value).toBe(1);
+  });
+
+  it("the array-literal form is unaffected", async () => {
+    const { value, collImports } = await run(
+      `export function test(): number {
+        const s = new Set<number>([1, 2, 3]);
+        return s.size;
+      }`,
+    );
+    expect(collImports).toBe(0);
+    expect(value).toBe(3);
+  });
+});


### PR DESCRIPTION
## #2162 — `new Set(nonLiteralArray)` standalone

`new Set(arr)` where `arr` is a **variable / call result** (not an array literal) fell through to the host path under `--target standalone` and **leaked env imports** (instantiate failed with an empty import object). The prior from-array slice only seeded the array-**literal** form (`new Set([1,2,3])`).

### Change
`seedNativeSetFromArrayArg` (`src/codegen/expressions/new-super.ts`): when the single `new Set(...)` argument is a checker-confirmed array/tuple type (`isArrayTypedArg`) that is not an array literal, compile it to its `$Vec` (`{length: i32, data: (ref $arr)}`), then emit a counted `block`/`loop` that walks `data[i]`, boxes each element to anyref via the existing `coerceMapKeyToAnyref`, and calls `__set_add` — host-import-free. Per-kind `array.get_u`/`_s` for packed i8/i16. A non-vec / unsupported-element arg gracefully leaves an empty Set (never a leak/CE). Gated on `ctx.nativeStrings`; gc/host mode byte-identical.

### Scope
`new Map(pairsVariable)` is a documented follow-up — the inner `[K,V]` pair lowers to a typed tuple **struct** (`$__tuple_<n>`), not an inner vec, so its extraction is a distinct shape. `[...collection]` spread and the general non-array iterator drive also remain (noted in the issue). The issue stays `in-progress`.

### Validation
- `tests/issue-2162-nonliteral-set-ctor.test.ts` (7/7, `target: wasi`, **zero `Set_*`/`Map_*` imports**): numeric-array-variable seed + dedup, membership hit/miss, string-array seed + dedup, function-returned-array seed, no-arg + array-literal unaffected.
- All prior #2162 suites green (23 across set/iterators/collection-from-array). tsc + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)