### PR TITLE
docs(#2159,#2161): record s64 triage re-probe verdicts

### DIFF
--- a/plan/issues/2159-standalone-typedarray-dataview-buffer-residual.md
+++ b/plan/issues/2159-standalone-typedarray-dataview-buffer-residual.md
@@ -265,3 +265,17 @@ architect (pairs naturally with #46 `$__subview` since both rework the
 element-access representation). The read-signedness helper above is ready to fold
 in *as part of* that change. No code shipped from this triage — the prior
 slices (1, 2a, fill, #38 DataView windowing) stand. **#2159 stays open.**
+
+## Triage re-probe (2026-06-21, dev-carla) — verified residuals on upstream/main
+
+Probed against current upstream/main (`--target standalone`). **Working** (no leak):
+DataView get/set Int32/Float64 incl. little-endian, `Int16Array(buffer)` element
+read, `TypedArray.fill`, `DataView(buf, off, len).byteLength`, `subarray`,
+`Float64Array.set([...])`. **Still broken (genuine dev-tractable residuals):**
+- `Uint8Array.of(...)` / `Uint8Array.from([...])` → CE `__get_builtin` (the
+  static TypedArray factory methods aren't lowered standalone).
+- `new Uint8Array([1,2,3]).indexOf(2)` → `Binary emit error: encodeValType:
+  packed storage type "i8" is not valid` (the i8-element indexOf path emits an
+  invalid packed valType).
+Both are in #2159's lane (owner ttraenkler/sdev-json3, live claim) — flagged here
+for that owner, not claimed by triage.

--- a/plan/issues/2161-standalone-regexp-engine-residual.md
+++ b/plan/issues/2161-standalone-regexp-engine-residual.md
@@ -390,3 +390,13 @@ prettier + biome(lint) + stack-balance + coercion-sites + any-box gates clean.
 standalone prototype-object representation; (c) dynamic / `any`-typed receivers
 (both coercion forms fall through to host for those); and the regex-engine
 feature tail (v-flag `\q{}`, dynamic ctor patterns). **#2161 stays open.**
+
+## Triage re-probe (2026-06-21, dev-carla) — common patterns verified on upstream/main
+
+Probed against current upstream/main (`--target standalone`, empty/`wasm:js-string`
+imports, no env leak): `re.test`, `re.exec` with capture groups, `String.replace`
+global, `String.match` global, `String.split` with a regex, `re.flags`, and
+sticky (`/y/` + `lastIndex`) **all PASS host-import-free**. So the high-frequency
+RegExp surface is already correct standalone — **no quick dev win remains here**;
+the open residual is the documented feature/representation tail above (v-flag
+`\q{}`, dynamic ctor patterns, `any`-typed receivers). Not claimed.


### PR DESCRIPTION
Sprint-64 conformance pool triage (task #6) re-probed #2159/#2161 against current upstream/main and records the verdicts so they stop being re-dispatched as quick wins:

- **#2161 (RegExp):** common surface (test/exec+groups/replace-g/match-g/split-regex/flags/sticky) verified PASSING host-import-free standalone. No quick dev win — only the documented feature tail (v-flag `\q{}`, dynamic ctor) remains.
- **#2159 (TypedArray/DataView):** core verified working; two genuine dev-tractable residuals flagged for the owner (sdev-json3): `Uint8Array.of/from` CE (`__get_builtin`) and i8 `indexOf` emit error (`packed storage type i8 not valid`).

Docs-only; no source changes. (The first-with-genuine-work issue from this triage, #2162 `new Set(nonLiteralArray)`, shipped separately as PR #1811.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)