### PR TITLE
fix(#2151): Slice 5 — mixed-spread o.m(a, ...xs) any-receiver dispatch (standalone)

### DIFF
--- a/plan/issues/2151-standalone-any-receiver-method-dispatch.md
+++ b/plan/issues/2151-standalone-any-receiver-method-dispatch.md
@@ -276,3 +276,48 @@ regression):**
   scope here; the vararg path inherits it identically.
 
 #2151 stays in-progress for the mixed-spread + wasi + ref-arg residuals above.
+
+## Slice 5 RESULT (2026-06-21, sendev-funcidx) — MIXED-spread `o.m(a, ...xs)` — IMPLEMENTED & GREEN
+
+Mixed `o.m(a, ...xs)` (fixed leading args + a single trailing DYNAMIC spread)
+returned 0 standalone: the fixed-arity `__call_m_<name>_<arity>` dispatcher
+can't apply (`flattenCallArgs` returns null for a dynamic source) and the Slice 4
+pure-dynamic-spread vararg routing only fires for a single spread arg with NO
+fixed leading args.
+
+**Mechanism — build the combined arg vec at runtime, reuse the Slice 4 vararg
+dispatcher.** New routing in `src/codegen/expressions/calls.ts` (after the Slice 4
+`isSingleDynamicSpread` block): for `ctx.standalone`, a non-builtin-class
+receiver, `>= 2` args, exactly ONE spread which is the LAST arg
+(`isMixedTrailingSpread`), it
+1. reserves `__call_m_<name>_vararg` (the Slice 4 dispatcher) + pulls in
+   `__objvec_new`/`__objvec_push` + `__extern_length`/`__extern_get_idx`, then
+   `flushLateImportShifts` and **re-resolves every funcIdx by name** (the
+   `ensureLateImport`s shift defined-func indices incl. the just-reserved
+   dispatcher — #2043 late-import index-shift class);
+2. stashes the receiver in a local, builds `combined = __objvec_new()`, pushes
+   each fixed leading arg (boxed to externref), then loop-appends the spread
+   source's elements (`__extern_length` + `__extern_get_idx(src, i)` →
+   `__objvec_push`);
+3. calls `__call_m_<name>_vararg(recv, combined)` — the dispatcher reads each
+   declared param from the vec via `__extern_get_idx` (`$ObjVec` is exactly what
+   it indexes), threads the struct as `this`, coerces per declared param type,
+   and box-coerces the result.
+
+**Verified standalone, ZERO host imports** (`tests/issue-2151-mixed-spread.test.ts`,
+6 cases): `o.m(1, ...xs)`=123, two-fixed + `this`-thread `o.f(1,2,...xs)`=16,
+empty spread `o.m(5, ...[])`=50 (trailing numeric param reads 0 = missing-arg
+semantics, consistent with the typed-param model across all slices),
+function-returned-array spread `o.m(1, ...mk())`=132, zero-host-imports assertion,
+plus the Slice 1–4 regression guards (`next()`=7, static `o.m(...[2,3])`=23, pure
+dynamic `o.m(...xs)`=45). No regression: `issue-2151{,-nary,-spread-literal,
+-dynamic-spread}` + `issue-2025` (34/34), `object-methods` + `object-literals` +
+`issue-2009` (61/61). `pnpm run typecheck` + `format:check` + `lint` clean.
+
+**Still carried forward (issue stays in-progress):**
+- **`--target wasi`** (same gate as Slice 4 — array-like `__extern_get_idx` arms
+  are standalone-only; mixed-spread is gated `ctx.standalone`).
+- **ref/string-typed params** (`o.g("hi")`) — pre-existing any-receiver
+  ref-arg-coercion gap inherited identically.
+- Multiple spreads / leading-or-middle spread (`o.m(...xs, a)`, `o.m(...a, ...b)`)
+  — uncommon shapes, keep the existing fall-through (no regression).

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -9265,6 +9265,129 @@ function compileCallExpression(
           return { kind: "externref" };
         }
 
+        // (#2151 Slice 5) MIXED-spread any-receiver dispatch: `o.m(a, ...xs)` —
+        // fixed leading args followed by a single trailing DYNAMIC spread (arity
+        // unknown at compile time). The fixed-arity dispatcher cannot apply
+        // (flattenCallArgs returned null), and the pure-dynamic-spread vararg
+        // routing above requires exactly one spread arg with no fixed leading
+        // args. Here we build the combined arg vector at runtime — a fresh
+        // `$ObjVec`, push each fixed leading arg (boxed to externref), then
+        // loop-append the spread source's elements (`__extern_length` +
+        // `__extern_get_idx`) — and hand it to the SAME
+        // `__call_m_<name>_vararg(recv, args)` dispatcher, which reads each
+        // declared param from the vec via `__extern_get_idx`. (`$ObjVec` is
+        // exactly what `__extern_get_idx` and `__objvec_push` operate on.)
+        //
+        // Gated to `ctx.standalone` ONLY (same constraint as Slice 4 — the
+        // `__extern_get_idx` array-like / wasm-vec indexing arms the dispatcher
+        // and the loop-append rely on are emitted only under standalone). Scope:
+        // exactly ONE spread, which must be the LAST argument; any other spread
+        // shape (leading/middle spread, multiple spreads) keeps the existing
+        // fall-through (no regression).
+        const spreadCount = expr.arguments.filter((a) => ts.isSpreadElement(a)).length;
+        const lastArg = expr.arguments[expr.arguments.length - 1];
+        const isMixedTrailingSpread =
+          ctx.standalone &&
+          !recvIsBuiltinClass &&
+          expr.arguments.length >= 2 &&
+          spreadCount === 1 &&
+          lastArg !== undefined &&
+          ts.isSpreadElement(lastArg);
+        if (isMixedTrailingSpread) {
+          const dispatchIdx = reserveClosedMethodDispatchVararg(ctx, methodName);
+          ensureObjVecBuilders(ctx);
+          ensureLateImport(ctx, "__extern_length", [{ kind: "externref" }], [{ kind: "f64" }]);
+          ensureLateImport(ctx, "__extern_get_idx", [{ kind: "externref" }, { kind: "f64" }], [{ kind: "externref" }]);
+          flushLateImportShifts(ctx, fctx);
+          // Re-resolve every funcIdx by name AFTER the last shift (late-import
+          // index-shift class #2043): the `ensureLateImport`s above added imports,
+          // which shifted EVERY defined-function index — including the vararg
+          // dispatcher reserved above. funcMap holds the post-shift truth. These
+          // are all unconditionally registered in standalone (the object runtime
+          // provides `__objvec_*` / `__extern_*`); `!` is safe here.
+          const dispatchResolvedIdx = ctx.funcMap.get(`__call_m_${methodName}_vararg`) ?? dispatchIdx;
+          const objVecNew = ctx.funcMap.get("__objvec_new")!;
+          const objVecPush = ctx.funcMap.get("__objvec_push")!;
+          const lenFn = ctx.funcMap.get("__extern_length")!;
+          const getIdxFn = ctx.funcMap.get("__extern_get_idx")!;
+
+          // Receiver as externref → local (read once; the vec build below also
+          // pushes onto the value stack, so stash the receiver first).
+          const recvLocal = allocLocal(fctx, `__mspread_recv_${fctx.locals.length}`, { kind: "externref" });
+          const recvType = compileExpression(ctx, fctx, propAccess.expression, { kind: "externref" });
+          if (recvType && recvType.kind !== "externref") fctx.body.push({ op: "extern.convert_any" });
+          else if (recvType === null) fctx.body.push({ op: "ref.null.extern" });
+          fctx.body.push({ op: "local.set", index: recvLocal });
+
+          // combined = __objvec_new()
+          const argsVecLocal = allocLocal(fctx, `__mspread_args_${fctx.locals.length}`, { kind: "externref" });
+          fctx.body.push({ op: "call", funcIdx: objVecNew });
+          fctx.body.push({ op: "local.set", index: argsVecLocal });
+
+          // Push each fixed leading arg (all but the trailing spread).
+          for (let i = 0; i < expr.arguments.length - 1; i++) {
+            fctx.body.push({ op: "local.get", index: argsVecLocal });
+            const at = compileExpression(ctx, fctx, expr.arguments[i]!, { kind: "externref" });
+            if (at && at.kind !== "externref") coerceType(ctx, fctx, at, { kind: "externref" });
+            else if (at === null) fctx.body.push({ op: "ref.null.extern" });
+            fctx.body.push({ op: "call", funcIdx: objVecPush });
+          }
+
+          // Loop-append the spread source's elements.
+          const spreadSrcLocal = allocLocal(fctx, `__mspread_src_${fctx.locals.length}`, { kind: "externref" });
+          const spreadExpr = (lastArg as ts.SpreadElement).expression;
+          const srcType = compileExpression(ctx, fctx, spreadExpr, { kind: "externref" });
+          if (srcType && srcType.kind !== "externref") coerceType(ctx, fctx, srcType, { kind: "externref" });
+          else if (srcType === null) fctx.body.push({ op: "ref.null.extern" });
+          fctx.body.push({ op: "local.set", index: spreadSrcLocal });
+
+          const spreadLenLocal = allocLocal(fctx, `__mspread_len_${fctx.locals.length}`, { kind: "i32" });
+          fctx.body.push({ op: "local.get", index: spreadSrcLocal });
+          fctx.body.push({ op: "call", funcIdx: lenFn });
+          fctx.body.push({ op: "i32.trunc_sat_f64_s" });
+          fctx.body.push({ op: "local.set", index: spreadLenLocal });
+
+          const spreadIdxLocal = allocLocal(fctx, `__mspread_idx_${fctx.locals.length}`, { kind: "i32" });
+          fctx.body.push({ op: "i32.const", value: 0 });
+          fctx.body.push({ op: "local.set", index: spreadIdxLocal });
+          fctx.body.push({
+            op: "block",
+            blockType: { kind: "empty" },
+            body: [
+              {
+                op: "loop",
+                blockType: { kind: "empty" },
+                body: [
+                  // if idx >= len break
+                  { op: "local.get", index: spreadIdxLocal } as Instr,
+                  { op: "local.get", index: spreadLenLocal } as Instr,
+                  { op: "i32.ge_s" } as Instr,
+                  { op: "br_if", depth: 1 } as Instr,
+                  // __objvec_push(combined, __extern_get_idx(src, idx))
+                  { op: "local.get", index: argsVecLocal } as Instr,
+                  { op: "local.get", index: spreadSrcLocal } as Instr,
+                  { op: "local.get", index: spreadIdxLocal } as Instr,
+                  { op: "f64.convert_i32_s" } as Instr,
+                  { op: "call", funcIdx: getIdxFn } as Instr,
+                  { op: "call", funcIdx: objVecPush } as Instr,
+                  // idx++
+                  { op: "local.get", index: spreadIdxLocal } as Instr,
+                  { op: "i32.const", value: 1 } as Instr,
+                  { op: "i32.add" } as Instr,
+                  { op: "local.set", index: spreadIdxLocal } as Instr,
+                  { op: "br", depth: 0 } as Instr,
+                ],
+              } as Instr,
+            ],
+          } as Instr);
+
+          // __call_m_<name>_vararg(recv, combined)
+          fctx.body.push({ op: "local.get", index: recvLocal });
+          fctx.body.push({ op: "local.get", index: argsVecLocal });
+          fctx.body.push({ op: "call", funcIdx: dispatchResolvedIdx });
+          return { kind: "externref" };
+        }
+
         // (#799 WI3) Generic host-delegated method call for any/externref receivers.
         // Builds a JS array of arguments and calls __extern_method_call(obj, methodName, args).
         // (#965) For known built-in class identifiers (Object, Array, Proxy, etc.) that would

--- a/tests/issue-2151-mixed-spread.test.ts
+++ b/tests/issue-2151-mixed-spread.test.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2151 Slice 5 — MIXED-spread any-receiver method dispatch (standalone).
+ *
+ * `o.m(a, ...xs)` — fixed leading args followed by a single trailing DYNAMIC
+ * spread (arity unknown at compile time) — on an `any`/externref closed
+ * object-literal receiver returned 0 standalone. The fixed-arity dispatcher
+ * (Slices 1–3) can't apply (flattenCallArgs returns null for a dynamic source)
+ * and the pure-dynamic-spread vararg routing (Slice 4) only fires for a single
+ * spread arg with NO fixed leading args.
+ *
+ * Slice 5 builds the combined arg vector at runtime — a fresh `$ObjVec`, pushes
+ * each fixed leading arg (boxed to externref), then loop-appends the spread
+ * source's elements (`__extern_length` + `__extern_get_idx`) — and hands it to
+ * the SAME `__call_m_<name>_vararg(recv, args)` dispatcher introduced in Slice 4,
+ * which reads each declared param from the vec via `__extern_get_idx`.
+ *
+ * Gated to `ctx.standalone` ONLY (the `__extern_get_idx` array-like / wasm-vec
+ * indexing arms the dispatcher and loop-append rely on are emitted only under
+ * standalone). Host-mode any-method on a closed object literal remains a
+ * pre-existing limitation (out of scope, verified across all slices).
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { instantiateWithRuntime } from "./equivalence/helpers.js";
+
+async function runStandalone(src: string): Promise<{ value: number; imports: string[] }> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const inst = await instantiateWithRuntime(r);
+  return {
+    value: (inst.exports as { test(): number }).test(),
+    imports: (r.imports ?? []).map((i) => i.name),
+  };
+}
+
+describe("#2151 Slice 5 — mixed-spread any-receiver method dispatch (standalone)", () => {
+  it("one fixed arg + dynamic spread: o.m(1, ...xs)", async () => {
+    const { value } = await runStandalone(`export function test(): number {
+      const o: any = { m(a: number, b: number, c: number) { return a * 100 + b * 10 + c; } };
+      const xs = [2, 3];
+      return o.m(1, ...xs) as number; }`);
+    expect(value).toBe(123);
+  });
+
+  it("two fixed args + dynamic spread, threading this: o.f(1, 2, ...xs)", async () => {
+    const { value } = await runStandalone(`export function test(): number {
+      const o: any = { base: 10, f(a: number, b: number, c: number) { return this.base + a + b + c; } };
+      const xs = [3];
+      return o.f(1, 2, ...xs) as number; }`);
+    expect(value).toBe(16);
+  });
+
+  it("empty dynamic spread: trailing numeric param reads 0 (missing-arg semantics)", async () => {
+    const { value } = await runStandalone(`export function test(): number {
+      const o: any = { m(a: number, b: number) { return a * 10 + b; } };
+      const xs: number[] = [];
+      return o.m(5, ...xs) as number; }`);
+    expect(value).toBe(50); // a=5, b missing → 0
+  });
+
+  it("spread source from a function-returned array: o.m(1, ...mk())", async () => {
+    const { value } = await runStandalone(`export function test(): number {
+      function mk(): number[] { return [3, 2]; }
+      const o: any = { m(a: number, b: number, c: number) { return a * 100 + b * 10 + c; } };
+      return o.m(1, ...mk()) as number; }`);
+    expect(value).toBe(132);
+  });
+
+  it("emits ZERO host imports (pure standalone)", async () => {
+    const { imports } = await runStandalone(`export function test(): number {
+      const o: any = { m(a: number, b: number) { return a + b; } };
+      const xs = [2];
+      return o.m(1, ...xs) as number; }`);
+    expect(imports).toEqual([]);
+  });
+
+  it("Slice 1–4 regression guards still hold (0-arg, static spread, pure dynamic spread)", async () => {
+    const a = await runStandalone(`export function test(): number {
+      const o: any = { next() { return 7; } };
+      return o.next() as number; }`);
+    expect(a.value).toBe(7);
+    const b = await runStandalone(`export function test(): number {
+      const o: any = { m(a: number, b: number) { return a * 10 + b; } };
+      return o.m(...[2, 3]) as number; }`);
+    expect(b.value).toBe(23);
+    const c = await runStandalone(`export function test(): number {
+      const o: any = { m(a: number, b: number) { return a * 10 + b; } };
+      const xs = [4, 5];
+      return o.m(...xs) as number; }`);
+    expect(c.value).toBe(45);
+  });
+});


### PR DESCRIPTION
## #2151 Slice 5 — mixed-spread `o.m(a, ...xs)` any-receiver method dispatch (standalone)

Mixed `o.m(a, ...xs)` — fixed leading args followed by a single trailing **dynamic** spread — on an `any`/externref closed object-literal receiver returned **0** standalone. The fixed-arity `__call_m_<name>_<arity>` dispatcher (Slices 1–3) can't apply (`flattenCallArgs` returns null for a dynamic source), and the Slice 4 pure-dynamic-spread vararg routing only fires for a single spread arg with **no** fixed leading args.

### Fix
New `isMixedTrailingSpread` routing in `src/codegen/expressions/calls.ts` (after the Slice 4 block): for `ctx.standalone`, a non-builtin-class receiver, `>= 2` args, exactly one spread which is the **last** arg, it:
1. reserves the Slice 4 `__call_m_<name>_vararg` dispatcher + pulls in `__objvec_new`/`__objvec_push` + `__extern_length`/`__extern_get_idx`, then `flushLateImportShifts` and **re-resolves every funcIdx by name** (the late imports shift defined-func indices incl. the reserved dispatcher — #2043 class);
2. builds the combined arg vector at runtime — fresh `$ObjVec`, push each fixed leading arg (boxed externref), then loop-append the spread source's elements (`__extern_length` + `__extern_get_idx`);
3. calls `__call_m_<name>_vararg(recv, combined)` — the dispatcher reads each declared param from the vec via `__extern_get_idx`, threads the struct as `this`, and box-coerces the result.

### Verified (standalone, ZERO host imports)
`tests/issue-2151-mixed-spread.test.ts` (6 cases): `o.m(1, ...xs)`=123, two-fixed + `this`-thread `o.f(1,2,...xs)`=16, empty spread `o.m(5, ...[])`=50, function-returned-array spread `o.m(1, ...mk())`=132, zero-imports, plus Slice 1–4 regression guards.

No regression: `issue-2151{,-nary,-spread-literal,-dynamic-spread}` + `issue-2025` (34/34), `object-methods` + `object-literals` + `issue-2009` (61/61). `typecheck` + `format:check` + `lint` clean.

### Scope
Gated to `ctx.standalone` (same as Slice 4 — the array-like `__extern_get_idx` arms are standalone-only). #2151 stays in-progress for the wasi + ref-arg + multi-spread residuals. This is an incremental slice on the established #2151 multi-slice effort (PRs #1497/#1628/#1766).

🤖 Generated with [Claude Code](https://claude.com/claude-code)