### PR TITLE
fix(#2029): object-literal data-key + accessor standalone emit crash

### DIFF
--- a/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
+++ b/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
@@ -170,3 +170,41 @@ standalone still leaks the `__new_<Builtin>` HOST import (`class-bodies.ts:1423/
 — a host-import-retirement concern, not the emit crash. Kept #2029 `in-progress`:
 the emit-crash cluster (the headline) is fixed; the `__new_<Builtin>` standalone
 runtime path is the residual. Reassess closing once that lands.
+
+## Slice (2026-06-21, dev-agent) — object-literal data-key + accessor emit crash
+
+**Status stays `in-progress`** — another emit-crash slice (the `Iterator/prototype`
+cluster, ~49 standalone CE).
+
+The `built-ins/Iterator/prototype` failures are NOT about `extends Iterator` —
+they're driven by the throwing-iterator fixtures returning
+`{ done: true, get value() { … } }`: an object literal mixing a **data property**
+with an **accessor**. Such a literal is routed through the host-object (externref)
+path, and the DATA-property key was materialized with a raw
+`global.get <stringGlobalMap.get(key)>`, guarding only `=== undefined`. Under
+standalone/nativeStrings the key string is the `-1` sentinel (#1174), so
+`global.get -1` crashed the encoder (`global index out of range — -1` at function
+`<f>` / `<Class>_next`).
+
+Minimal trigger (no Iterator, no throw needed): `{ a: 1, get v() { return 5; } }`.
+Getter-only or data-only literals already worked — only the **mix** crashed.
+
+**Fix:** in `compileObjectLiteral`'s host-object path (`src/codegen/literals.ts`),
+materialize the data-property key via the dual-mode `stringConstantExternrefInstrs`
+helper — exactly mirroring the accessor-key path right below it (which already had
+this fix). gc/host mode unchanged.
+
+**Measured (60-file `built-ins/Iterator/prototype` standalone sample):** main
+`pass 4 / CE 28 (6 emit-CE)` → fix `pass 6 / CE 23 (1 emit-CE)`. The full-cluster
+scan had ~49 emit-CEs of this shape; this clears the bulk. Zero host regressions
+(emit fix is `-1`-sentinel-gated, never reached in gc mode).
+
+**Validation.** `tests/issue-2029-objlit-data-accessor-standalone-emit.test.ts`
+(7/7): data-before/after-getter, data+setter, multi-data+accessor, the Iterator
+throwing-iterator next() shape, no-`-1`-global assertion, host no-regression.
+tsc + prettier + coercion-sites clean.
+
+**Still open (separate):** the `o.a + o.v` arithmetic read-back over two `any`
+props of an accessor-routed object traps standalone (`illegal cast`) — the same
+native dynamic-read/unbox gap noted for the Object.create slice, not the emit
+crash. The 1 residual emit-CE in the sample is a different producer.

--- a/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
+++ b/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
@@ -208,3 +208,36 @@ tsc + prettier + coercion-sites clean.
 props of an accessor-routed object traps standalone (`illegal cast`) — the same
 native dynamic-read/unbox gap noted for the Object.create slice, not the emit
 crash. The 1 residual emit-CE in the sample is a different producer.
+
+## Slice (2026-06-21, dev-agent) — DisposableStack/AsyncDisposableStack static-read emit crash
+
+**Status stays `in-progress`.** Folded into the same PR as the object-literal
+slice above.
+
+`DisposableStack` and `AsyncDisposableStack` were missing from
+`BUILTIN_CTOR_NAMES` (`src/codegen/property-access.ts`). A static value read like
+`DisposableStack.prototype` fell through BOTH the standalone built-in handler
+(refuse-loud / native proto) AND the host `__get_builtin` fallback, into a
+generic member path that emitted `global.get -1` (the -1 string-global sentinel)
+→ `global index out of range — -1` encoder crash standalone (whole file lost).
+`new DisposableStack()` and `typeof` were fine; only the static `.prototype`/
+member reads crashed.
+
+**Fix:** add both names to `BUILTIN_CTOR_NAMES`. The read now routes to the
+dual-mode handler — a loud, located `reportUnsupportedStandaloneBuiltinValueRead`
+refusal standalone (no poisoned index, satisfies the #2029 "refuse loudly"
+criterion), `__get_builtin` under gc/host. This makes them behave identically to
+every other builtin ctor (`Map.prototype`/`Map.length` already refuse-loud
+standalone).
+
+**Measured (50-file DisposableStack/AsyncDisposableStack standalone sample):**
+main `emit-CE 19` → fix `emit-CE 3` (16 opaque encoder crashes converted to clean
+refusals). One test (`DisposableStack/length.js`) goes pass→compile_error — that
+"pass" was anomalous: `DisposableStack.length` returned 0 via the accidental
+generic fall-through, whereas `Map/length.js`, `Set/length.js`,
+`WeakMap/length.js` already refuse-loud standalone. The change normalizes
+DisposableStack to the standard builtin behavior. Zero host regressions.
+
+**Validation.** `tests/issue-2029-disposablestack-static-read-standalone.test.ts`
+(5/5): `.prototype` / chained `.prototype.move` no encoder crash + named refusal,
+host no-regression, `new DisposableStack()` unaffected.

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -485,11 +485,21 @@ function compileObjectLiteralWithAccessors(
         }
       } else {
         if (propName === undefined) continue;
+        // (#2029) Materialize the data-property key via the dual-mode helper.
+        // Under standalone/nativeStrings, `addStringConstantGlobal` records the
+        // `-1` sentinel (no host string-constant global), so the old
+        // `global.get <stringGlobalMap.get(propName)>` emitted `global.get -1`
+        // → "global index out of range — -1" at serialize time. This fired
+        // whenever a host-object-routed literal (one that ALSO carries an
+        // accessor — `{ a: 1, get v() {} }`) emitted a plain data key, e.g. the
+        // `Iterator.prototype` throwing-iterator fixtures. Mirror the accessor
+        // key path above: `stringConstantExternrefInstrs` emits the native
+        // string inline standalone and the host `global.get` under GC.
         addStringConstantGlobal(ctx, propName);
-        const keyGlobal = ctx.stringGlobalMap.get(propName);
-        if (keyGlobal === undefined) continue;
         fctx.body.push({ op: "local.get", index: objLocal });
-        fctx.body.push({ op: "global.get", index: keyGlobal });
+        for (const instr of stringConstantExternrefInstrs(ctx, propName)) {
+          fctx.body.push(instr);
+        }
       }
       // Compile value and coerce to externref.
       let valType: ValType | null;

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -118,6 +118,19 @@ const BUILTIN_CTOR_NAMES = new Set([
   "Float64Array",
   "BigInt64Array",
   "BigUint64Array",
+  // (#2029) Explicit-resource-management constructors. Without these, a
+  // `DisposableStack.prototype` / `AsyncDisposableStack.prototype` value read
+  // fell through BOTH the standalone built-in path (refuse-loud / native proto)
+  // AND the host `__get_builtin` fallback, landing in a generic member path that
+  // emitted `global.get -1` (the -1 string-global sentinel) → `global index out
+  // of range — -1` encoder crash standalone (whole file lost). Listing them
+  // routes the read to the dual-mode handler: a loud, located
+  // `reportUnsupportedStandaloneBuiltinValueRead` refusal standalone (no poisoned
+  // index), `__get_builtin` under gc/host. This brings them in line with every
+  // other builtin ctor — e.g. `Map.length`/`Map.prototype` already refuse-loud
+  // standalone, so DisposableStack static reads now behave identically.
+  "DisposableStack",
+  "AsyncDisposableStack",
 ]);
 
 // Well-known Symbol IDs (inlined from literals.ts to avoid circular deps)

--- a/tests/issue-2029-disposablestack-static-read-standalone.test.ts
+++ b/tests/issue-2029-disposablestack-static-read-standalone.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2029 — `DisposableStack`/`AsyncDisposableStack` static value reads crashed
+// the standalone binary emitter instead of refusing loudly.
+//
+// These two explicit-resource-management constructors were absent from
+// `BUILTIN_CTOR_NAMES` (`src/codegen/property-access.ts`). A static read such as
+// `DisposableStack.prototype` therefore fell through BOTH the standalone
+// built-in handler (refuse-loud / native proto) AND the host `__get_builtin`
+// fallback, landing in a generic member path that emitted `global.get -1` (the
+// -1 string-global sentinel) → `Binary emit error: global index out of range —
+// -1` standalone, losing the whole file (this drove ~16 DisposableStack /
+// AsyncDisposableStack standalone compile_errors).
+//
+// Listing them routes the read to the dual-mode handler: a loud, located
+// refusal standalone (no poisoned index — satisfies the #2029 "refuse loudly,
+// never poison the encoder" criterion) and `__get_builtin` under gc/host. This
+// matches every other builtin ctor (`Map.prototype`/`Map.length` already
+// refuse-loud standalone).
+
+async function compileStandalone(src: string) {
+  return compile(src, { fileName: "test.ts", target: "standalone", skipSemanticDiagnostics: true });
+}
+
+function hasEncoderRangeCrash(r: Awaited<ReturnType<typeof compile>>): boolean {
+  return r.errors.some((e) => /global index out of range/.test(e.message));
+}
+
+describe("#2029 DisposableStack/AsyncDisposableStack static read standalone", () => {
+  it("DisposableStack.prototype does not crash the encoder (refuses loudly)", async () => {
+    const r = await compileStandalone(
+      `export function test(): number { const p: any = DisposableStack.prototype; return 1; }`,
+    );
+    // Either compiles or refuses with a named message — but never the opaque
+    // `global index out of range -1` encoder crash.
+    expect(hasEncoderRangeCrash(r)).toBe(false);
+    if (!r.success) {
+      expect(r.errors[0]?.message).toMatch(/DisposableStack\.prototype built-in static/);
+    }
+  });
+
+  it("AsyncDisposableStack.prototype does not crash the encoder", async () => {
+    const r = await compileStandalone(
+      `export function test(): number { const p: any = AsyncDisposableStack.prototype; return 1; }`,
+    );
+    expect(hasEncoderRangeCrash(r)).toBe(false);
+  });
+
+  it("DisposableStack.prototype.move (chained) does not crash the encoder", async () => {
+    const r = await compileStandalone(
+      `export function test(): number { const p: any = DisposableStack.prototype.move; return 1; }`,
+    );
+    expect(hasEncoderRangeCrash(r)).toBe(false);
+  });
+
+  it("host (gc) mode still compiles DisposableStack.prototype", async () => {
+    const r = await compile(`export function test(): number { const p: any = DisposableStack.prototype; return 1; }`, {
+      fileName: "test.ts",
+      skipSemanticDiagnostics: true,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("new DisposableStack() still compiles standalone (unaffected)", async () => {
+    const r = await compileStandalone(`export function test(): number { const s = new DisposableStack(); return 1; }`);
+    expect(r.success).toBe(true);
+  });
+});

--- a/tests/issue-2029-objlit-data-accessor-standalone-emit.test.ts
+++ b/tests/issue-2029-objlit-data-accessor-standalone-emit.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2029 — object literal mixing a DATA property with an accessor crashed the
+// standalone binary emitter.
+//
+// An object literal that carries any get/set accessor is routed through the
+// host-object (externref) path. In that path each plain DATA property key was
+// materialized with a raw `{ op: "global.get", index: stringGlobalMap.get(key) }`.
+// Under `--target standalone` / nativeStrings, `addStringConstantGlobal` records
+// the -1 sentinel ("no host string-constant global — materialize inline", #1174),
+// so the emitted `global.get -1` blew up the encoder:
+//   `Binary emit error: Codegen error: global index out of range — -1`
+// — a hard compile_error losing the whole file. This drove the bulk of the
+// standalone `built-ins/Iterator/prototype` failures (their throwing-iterator
+// fixtures return `{ done: true, get value() { … } }` — a data key + accessor).
+//
+// The accessor key in the same path already used the dual-mode
+// `stringConstantExternrefInstrs` helper; the fix applies it to the data key too.
+// gc/host mode is unaffected (real globals, never the sentinel).
+
+async function compileStandalone(src: string) {
+  return compile(src, { fileName: "test.ts", target: "standalone", skipSemanticDiagnostics: true });
+}
+
+describe("#2029 object literal data-property + accessor standalone emit", () => {
+  it("data property before a getter compiles standalone (was: global index out of range -1)", async () => {
+    const r = await compileStandalone(
+      `function f(): any { return { a: 1, get v() { return 5; } }; } export function test(): number { return 1; }`,
+    );
+    expect(r.success).toBe(true);
+  });
+
+  it("data property after a getter compiles standalone", async () => {
+    const r = await compileStandalone(
+      `function f(): any { return { get v() { return 5; }, a: 1 }; } export function test(): number { return 1; }`,
+    );
+    expect(r.success).toBe(true);
+  });
+
+  it("data property mixed with a setter compiles standalone", async () => {
+    const r = await compileStandalone(
+      `function f(): any { return { a: 1, set v(x: number) {} }; } export function test(): number { return 1; }`,
+    );
+    expect(r.success).toBe(true);
+  });
+
+  it("multiple data properties + accessor compile standalone", async () => {
+    const r = await compileStandalone(
+      `function f(): any { return { a: 1, b: 2, get v() { return 3; } }; } export function test(): number { return 1; }`,
+    );
+    expect(r.success).toBe(true);
+  });
+
+  it("the Iterator throwing-iterator next() shape compiles standalone", async () => {
+    const r = await compileStandalone(
+      `class X extends Iterator { next(): any { return { done: true, get value() { throw new Error(); } }; } } export function test(): number { return 1; }`,
+    );
+    expect(r.success).toBe(true);
+  });
+
+  it("does not emit a -1 string-global for the data key (no encoder crash)", async () => {
+    const r = await compileStandalone(
+      `function f(): any { return { a: 1, get v() { return 5; } }; } export function test(): number { return 1; }`,
+    );
+    expect(r.success).toBe(true);
+    expect(r.errors.some((e) => /global index out of range/.test(e.message))).toBe(false);
+  });
+
+  it("host (gc) mode unaffected — data + accessor literal still compiles", async () => {
+    const r = await compile(
+      `function f(): any { return { a: 1, get v() { return 5; } }; } export function test(): number { return 1; }`,
+      { fileName: "test.ts", skipSemanticDiagnostics: true },
+    );
+    expect(r.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

An object literal mixing a **data property** with a get/set **accessor** (e.g. `{ a: 1, get v() {} }`) is routed through the host-object externref path. There the DATA-property key was materialized with a raw `global.get <stringGlobalMap.get(key)>`, guarding only `=== undefined`. Under `--target standalone` / nativeStrings the key string is the **-1 sentinel** (#1174 — no host string-constant global), so `global.get -1` crashed the binary encoder (`Binary emit error: global index out of range — -1`) — a hard `compile_error` losing the whole file.

This drove the bulk of the standalone `built-ins/Iterator/prototype` failures: their throwing-iterator fixtures return `{ done: true, get value() { … } }` — a data key + accessor. The trigger is NOT `extends Iterator`; the minimal repro is just `{ a: 1, get v() { return 5; } }` (getter-only or data-only literals already worked — only the **mix** crashed).

## Fix

In `compileObjectLiteral`'s host-object path (`src/codegen/literals.ts`), materialize the data-property key via the dual-mode `stringConstantExternrefInstrs` helper — mirroring the accessor-key path immediately below it (which already had this fix). gc/host mode unchanged (real globals, never the sentinel).

## Measured impact

60-file `built-ins/Iterator/prototype` standalone sample:

| | pass | CE | (emit-CE) |
|---|---:|---:|---:|
| main | 4 | 28 | 6 |
| this PR | 6 | 23 | 1 |

+2 pass, 5 emit-CEs cleared in the sample; the full-cluster scan found ~49 emit-CEs of this exact shape. Zero host regressions (the fix is -1-sentinel-gated, never reached in gc mode; host `{ a:7, get v(){return 5} }` → `o.a+o.v === 12` before and after).

## Validation

- `tests/issue-2029-objlit-data-accessor-standalone-emit.test.ts` (7/7): data-before/after-getter, data+setter, multi-data+accessor, the Iterator throwing-iterator `next()` shape, no-`-1`-global assertion, host no-regression.
- tsc + prettier + coercion-sites gates clean.

## Still open (separate)

- The `o.a + o.v` arithmetic read-back over two `any` props of an accessor-routed object traps standalone (`illegal cast`) — the same native dynamic-read/unbox gap noted for the Object.create slice (#1810), not the emit crash.
- 1 residual emit-CE in the sample is a different producer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)