### PR TITLE
fix(#2567): track dstr-param call-default buffer for late-import shifts

### DIFF
--- a/plan/issues/2567-dstr-param-default-throwing-init-call-arity.md
+++ b/plan/issues/2567-dstr-param-default-throwing-init-call-arity.md
@@ -1,9 +1,12 @@
 ---
 id: 2567
 title: "destructuring-param default whose initializer calls a function emits C_method one operand short for the call — invalid Wasm (4 test262)"
-status: ready
+status: done
 sprint: Backlog
 created: 2026-06-21
+updated: 2026-06-21
+completed: 2026-06-21
+assignee: ttraenkler/sd3
 priority: low
 feasibility: medium
 task_type: bugfix
@@ -77,3 +80,36 @@ has side effects / throws.
 - The 4 `*-list-err` files compile to valid Wasm and pass (the throwing default
   throws `Test262Error`, `initCount` stays 0).
 - No regression in existing destructuring-param-default / class-method suites.
+
+## Resolution (2026-06-21, sd3) — DONE
+
+The original "fix direction" was a near-miss: the call is NOT one operand short
+at emit time. It's a **late-import index-shift on a detached buffer** — the same
+hazard family as #2158 / #1553d / #1109.
+
+In `destructureParamObjectExternref` (`src/codegen/destructuring-params.ts`) the
+identifier-with-initializer arm compiles the default-value expression into a
+DETACHED `thenInstrs` buffer (swapped out of `fctx.body`) before splicing it into
+the `if (__extern_is_undefined) { …default… }` guard. When the default is a
+function CALL (`b = thrower()`), compiling it registers a late import and fires a
+func/global-index shift. That shift walks `fctx.body` + `fctx.savedBodies` +
+`ctx.liveBodies` — and the detached `thenInstrs` was on **none** of them. So the
+already-emitted `call <thrower>` (emit-time funcIdx, e.g. 66) missed the shift and
+was mis-remapped at finalize onto an unrelated import — observed landing on
+`__typeof_bigint` (i32-returning) + `__box_number` scaffolding, i.e.
+`call __typeof_bigint` with nothing on the stack →
+`C_method: not enough arguments on the stack for call (need 1, got 0)` → invalid
+Wasm. Verified by instrumentation: at emit `thrower()` compiled to a single clean
+`call:66` returning externref; the corruption was purely the missed shift.
+
+**Fix:** register the detached default buffers (`thenInstrs`, the `elseCoerce`
+buffer, and the OUTER `savedBody` for the recursion window) in `ctx.liveBodies`
+around the `compileExpression(element.initializer)` call, then remove them once
+the `if` is spliced into `fctx.body` (avoiding the #1109 double-shift). This
+mirrors the #2158 struct-fast-path then/else `liveBodies` tracking a few lines
+below in the same file. One-file change, ~15 lines.
+
+**Result:** all 4 `*-list-err` files → valid Wasm + PASS (throw Test262Error,
+`initCount` stays 0). Regression test `tests/issue-2567-dstr-param-default-call-arity.test.ts`
+(4 cases incl. a non-throwing call default) fails without the fix, passes with it.
+Broad class-category sweep (statements + expressions, ~8426 files): 0 regressions.

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -465,6 +465,21 @@ export function destructureParamObjectExternref(
 
         const savedBody = fctx.body;
         const thenInstrs: Instr[] = [];
+        // (#2567) Track the detached default-value buffer in `ctx.liveBodies`
+        // for the compile window. The initializer can be ANY expression —
+        // crucially a function CALL (`b = thrower()`) — whose compilation
+        // registers a late import and triggers a func/global-index shift. That
+        // shift walks `fctx.body` + `fctx.savedBodies` + `ctx.liveBodies`; while
+        // we emit into `thenInstrs` it is detached from `fctx.body` and not on
+        // `savedBodies`, so an already-emitted `call <thrower>` would keep its
+        // stale-high funcIdx and get mis-remapped at finalize (observed: the
+        // call landed on `__typeof_bigint`/`__box_number` scaffolding →
+        // `not enough arguments on the stack for call` in `C_method`). Also keep
+        // the OUTER body live for the same recursion window — mirrors the
+        // struct-fast-path then/else tracking at the `#2158` site below.
+        const outerAlreadyLive = ctx.liveBodies.has(savedBody);
+        if (!outerAlreadyLive) ctx.liveBodies.add(savedBody);
+        ctx.liveBodies.add(thenInstrs);
         fctx.body = thenInstrs;
         compileExpression(ctx, fctx, element.initializer, localType ?? elemType);
         fctx.body.push({ op: "local.set", index: localIdx! } as Instr);
@@ -474,6 +489,7 @@ export function destructureParamObjectExternref(
         if (localType && !valTypesMatch(elemType, localType)) {
           const savedBody2 = fctx.body;
           fctx.body = elseCoerce;
+          ctx.liveBodies.add(elseCoerce);
           coerceType(ctx, fctx, elemType, localType);
           fctx.body = savedBody2;
         }
@@ -488,6 +504,13 @@ export function destructureParamObjectExternref(
             { op: "local.set", index: localIdx! } as Instr,
           ],
         });
+        // The buffers are now reachable via `fctx.body` (spliced into the `if`),
+        // so drop the temporary `liveBodies` registrations to avoid the
+        // double-shift hazard (#1109) where a body reachable from both `fctx.body`
+        // and `liveBodies` is walked twice.
+        ctx.liveBodies.delete(thenInstrs);
+        ctx.liveBodies.delete(elseCoerce);
+        if (!outerAlreadyLive) ctx.liveBodies.delete(savedBody);
         if (isDecl) emitLocalTdzInit(fctx, localName);
       } else {
         if (localType && !valTypesMatch(elemType, localType)) {

--- a/tests/issue-2567-dstr-param-default-call-arity.test.ts
+++ b/tests/issue-2567-dstr-param-default-call-arity.test.ts
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2567 (regression) — a destructuring parameter whose binding default is a
+ * function CALL (`{ b = thrower() }`) must keep its `call` funcIdx tracked
+ * across late-import index shifts.
+ *
+ * Root cause: in `destructureParamObjectExternref`
+ * (src/codegen/destructuring-params.ts) the identifier-with-initializer path
+ * compiles the default-value expression into a DETACHED `thenInstrs` buffer
+ * (swapped out of `fctx.body`) before splicing it into the guard `if`. When the
+ * default is a function call, compiling it registers a late import and triggers
+ * a func/global-index shift. That shift walks `fctx.body` + `fctx.savedBodies` +
+ * `ctx.liveBodies`; the detached `thenInstrs` was on NONE of them, so the
+ * already-emitted `call <fn>` kept its stale-high funcIdx and was mis-remapped
+ * at finalize — the call landed on an unrelated import (`__typeof_bigint` /
+ * `__box_number` scaffolding), producing
+ * `C_method: not enough arguments on the stack for call (need 1, got 0)` →
+ * invalid Wasm.
+ *
+ * Fix: register the detached default buffers in `ctx.liveBodies` for the compile
+ * window (mirrors the #2158 struct-fast-path then/else tracking), so the shift
+ * reaches the in-flight `call`. The assertion is module VALIDITY — only V8's
+ * index-resolved function-body validation rejects the mis-remapped call.
+ *
+ * Mirrors `language/{statements,expressions}/class/dstr/meth-dflt-obj-ptrn-list-err.js`.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function expectValid(src: string): Promise<void> {
+  const r = await compile(src, { skipSemanticDiagnostics: true });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "compiled module must validate").toBe(true);
+}
+
+describe("#2567 dstr-param default with a function-call initializer", () => {
+  it("object-pattern param default calling a function validates (the *-list-err shape)", async () => {
+    // `b = thrower()` is the load-bearing case: a CALL default in a destructuring
+    // param, with the outer `= {}` forcing the externref destructuring path.
+    await expectValid(`
+      var initCount = 0;
+      function thrower(): never { throw new Error("x"); }
+      class C {
+        method({ a, b = thrower(), c = ++initCount } = {}) {}
+      }
+      export function test(): number { return 1; }
+    `);
+  });
+
+  it("static method variant validates", async () => {
+    await expectValid(`
+      var initCount = 0;
+      function thrower(): never { throw new Error("x"); }
+      class C {
+        static method({ a, b = thrower(), c = ++initCount } = {}) {}
+      }
+      export function test(): number { return 1; }
+    `);
+  });
+
+  it("class-expression variant validates", async () => {
+    await expectValid(`
+      var initCount = 0;
+      function thrower(): never { throw new Error("x"); }
+      var C = class {
+        method({ a, b = thrower(), c = ++initCount } = {}) {}
+      };
+      export function test(): number { return 1; }
+    `);
+  });
+
+  it("plain (non-throwing) function-call default still validates", async () => {
+    // Guard against over-narrowing the fix to `never`-returning calls: any
+    // call-valued default exercises the same detached-buffer shift path.
+    await expectValid(`
+      function make(): number { return 9; }
+      class C {
+        method({ a, b = make() } = {}) { return b; }
+      }
+      export function test(): number {
+        new C().method({ a: 1 });
+        return 1;
+      }
+    `);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes invalid-wasm for a destructuring parameter whose binding default is a
**function call** (`method({ b = thrower() } = {})`):
`C_method: not enough arguments on the stack for call (need 1, got 0)`.
4 test262 files (`meth` / `meth-static` `dflt-obj-ptrn-list-err`, statements +
expressions) were INVALID on main; this is a main-health codegen fix spun out of
#2565.

## Root cause (same family as #2158 / #1553d / #1109)

In `destructureParamObjectExternref` (`src/codegen/destructuring-params.ts`) the
identifier-with-initializer arm compiles the default-value expression into a
DETACHED `thenInstrs` buffer (swapped out of `fctx.body`) before splicing it into
the `if (__extern_is_undefined) { …default… }` guard. When the default is a
**call**, compiling it registers a late import and fires a func/global-index
shift. That shift walks `fctx.body` + `fctx.savedBodies` + `ctx.liveBodies` — and
the detached buffer was on **none** of them, so the already-emitted
`call <thrower>` kept its stale-high emit-time funcIdx and was mis-remapped at
finalize onto an unrelated import (`__typeof_bigint` / `__box_number`
scaffolding), so the call ran with nothing on the stack.

Verified by instrumentation: at emit time `thrower()` compiled to a single clean
`call:66` returning externref; the corruption was purely the missed shift.

## Fix

Register the detached default buffers (`thenInstrs`, the `elseCoerce` buffer, and
the outer `savedBody` for the recursion window) in `ctx.liveBodies` around
`compileExpression(element.initializer)`, then drop them once the `if` is spliced
into `fctx.body` (avoiding the #1109 double-shift). This mirrors the #2158
struct-fast-path then/else `liveBodies` tracking a few lines below in the same
file. One file, ~21 lines.

## Validation

- **Isolated** class-dstr sweep vs current main (which already has #2564), 3840
  files: exactly the **4** `*-list-err` files flip INVALID→PASS, **0
  regressions**.
- The 4 files now compile to valid wasm AND pass at runtime (throw
  `Test262Error`, `initCount` stays 0).
- Regression test `tests/issue-2567-dstr-param-default-call-arity.test.ts` (4
  cases incl. a non-throwing call default) **fails without the fix, passes with
  it**.
- `tsc --noEmit`, biome-lint, prettier: clean.

Closes #2567.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA