### PR TITLE
fix(#2029): builtin-subclass standalone host-import leaks (__get_undefined + __tag_user_class)

### DIFF
--- a/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
+++ b/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
@@ -170,3 +170,43 @@ standalone still leaks the `__new_<Builtin>` HOST import (`class-bodies.ts:1423/
 — a host-import-retirement concern, not the emit crash. Kept #2029 `in-progress`:
 the emit-crash cluster (the headline) is fixed; the `__new_<Builtin>` standalone
 runtime path is the residual. Reassess closing once that lands.
+
+## Slice (2026-06-21, dev-agent) — builtin-subclass host-import leak (__get_undefined + __tag_user_class)
+
+**Status stays `in-progress`.** Two of the three builtin-subclass standalone
+host-import leaks fixed; `__new_<Builtin>` construction remains a separate slice.
+
+A builtin subclass (`class X extends Uint8Array {}` / `extends Error` etc.) +
+`new X()` leaked THREE host imports standalone (module fails to instantiate with
+an empty import object): `__get_undefined`, `__tag_user_class`, `__new_<Builtin>`.
+This slice clears the first two:
+
+1. **`__get_undefined`** — `compileNewExpression` → `pushDefaultValue` →
+   `emitUndefinedValue` (`src/codegen/type-coercion.ts`) called `ensureLateImport`
+   DIRECTLY, bypassing the canonical `ensureGetUndefined` `ctx.nativeStrings`
+   guard (`ensureLateImport` does not refuse `__get_undefined`), so the host
+   import leaked into the implicit derived-ctor forwarder's externref default.
+   Fix: gate on `ctx.nativeStrings` → emit `ref.null.extern` (undefined ≡ null
+   standalone). Same defect class as the #1702 Error-subclass slice, different
+   site (the `new`-expression default path, not the destructuring/coercion one).
+
+2. **`__tag_user_class`** — the externref-backed-class instanceof tag
+   (`src/codegen/class-bodies.ts`, #1455) was emitted unconditionally. Its ONLY
+   consumer is the host `__instanceof` import, which does not exist standalone
+   (`instanceof` on a builtin subclass already routes host-only there; a plain
+   class uses native WasmGC type checks and needs no tag). So the tag was dead
+   weight that leaked. Fix: skip it under `ctx.nativeStrings` — mirrors the
+   #1500 `emitSetSubclassProto` host-only-adjustment skip. gc/host keeps it so
+   the host instanceof-tag-chain still resolves.
+
+Both fixes verified by direct import inspection (the test262 runner masks the
+leak because it doesn't instantiate the standalone lane with a strictly empty
+import object). `tests/issue-2029-ta-subclass-host-leak-standalone.test.ts` (5/5):
+TypedArray/Error subclass new X() asserts neither `__get_undefined` nor
+`__tag_user_class` is imported; empty-declaration guard; host no-regression
+(tag + import still present in gc mode). tsc + prettier + coercion-sites clean.
+
+**Still open (the harder remaining leak):** `__new_<Builtin>` (`__new_Uint8Array`,
+`__new_Error`, …) — the builtin base constructor. Needs a native WasmGC
+construction path for the externref-backed base (overlaps #2159). Even an empty
+`class X extends Uint8Array {}` declaration emits it. Separate slice.

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -1656,7 +1656,17 @@ function compileClassBodiesInner(
     // `instance instanceof Sub` by walking the registered tag chain. The
     // direct user-class parent (or null when the direct parent is a builtin)
     // is registered idempotently on first call.
-    if (isExternrefBacked) {
+    //
+    // (#2029) Skip this entirely under native-strings (standalone / wasi): the
+    // tag's ONLY consumer is the host `__instanceof` import, which does not
+    // exist standalone (`instanceof` on a builtin-subclass already routes to the
+    // host path there). Emitting it leaked the `__tag_user_class` host import
+    // into an otherwise host-free builtin-subclass `new X()`, so the module
+    // failed to instantiate with an empty import object. Mirrors the #1500
+    // `emitSetSubclassProto` skip (the host-only proto adjustment is likewise
+    // dropped standalone). The native instanceof story for builtin subclasses
+    // (a Wasm-side tag registry) is a separate slice.
+    if (isExternrefBacked && !ctx.nativeStrings) {
       const builtinParent = ctx.classBuiltinParentMap.get(className);
       // Direct user-class parent: classParentMap[className] is set to the
       // immediate parent name; if it equals the builtin parent, the user

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -2579,7 +2579,15 @@ export function emitSafeExternrefToF64(ctx: CodegenContext, fctx: FunctionContex
  * This is a local version to avoid circular deps with expressions.ts.
  */
 function emitUndefinedValue(ctx: CodegenContext, fctx: FunctionContext): void {
-  const funcIdx = ensureLateImport(ctx, "__get_undefined", [], [{ kind: "externref" }]);
+  // (#2029) Mirror the canonical `ensureGetUndefined` guard: under
+  // native-strings (auto-on for `--target standalone`/`wasi`) there is no JS
+  // host to satisfy `__get_undefined`, and undefined is conflated with null.
+  // Calling `ensureLateImport` directly here LEAKED the host import standalone
+  // (`ensureLateImport` does not refuse `__get_undefined`), so a builtin-subclass
+  // `new X()` whose implicit derived-ctor forwarder `pushDefaultValue`s an
+  // externref slot failed to instantiate with an empty import object. Emit the
+  // native `ref.null.extern` sentinel instead. gc/host keeps the host import.
+  const funcIdx = ctx.nativeStrings ? undefined : ensureLateImport(ctx, "__get_undefined", [], [{ kind: "externref" }]);
   if (funcIdx !== undefined) {
     flushLateImportShifts(ctx, fctx);
     fctx.body.push({ op: "call", funcIdx });

--- a/tests/issue-2029-ta-subclass-host-leak-standalone.test.ts
+++ b/tests/issue-2029-ta-subclass-host-leak-standalone.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2029 (ta-subclass slice) — a builtin (TypedArray / Error / …) subclass leaked
+// two host imports standalone that have no JS host to satisfy them:
+//
+//  1. `__get_undefined` — `compileNewExpression` → `pushDefaultValue` →
+//     `emitUndefinedValue` (type-coercion.ts) called `ensureLateImport` DIRECTLY,
+//     bypassing the canonical `ensureGetUndefined` `ctx.nativeStrings` guard, so
+//     the host import leaked into the implicit derived-ctor forwarder.
+//  2. `__tag_user_class` — the externref-backed-class instanceof tag (class-bodies.ts)
+//     was emitted unconditionally; its ONLY consumer is the host `__instanceof`
+//     import, which does not exist standalone, so it was dead weight that leaked.
+//
+// Both fixes are `ctx.nativeStrings`-gated: standalone emits the native
+// `ref.null.extern` sentinel / skips the tag; gc/host keeps the host imports.
+// The remaining `__new_<Builtin>` construction leak is a separate slice (native
+// vec-struct construction).
+
+async function compileStandalone(src: string) {
+  return compile(src, { fileName: "test.ts", target: "standalone", skipSemanticDiagnostics: true });
+}
+
+function leakedImports(r: Awaited<ReturnType<typeof compile>>): string[] {
+  return r.imports.map((i) => i.name);
+}
+
+describe("#2029 builtin-subclass host-import leak (standalone)", () => {
+  it("TypedArray subclass new X() no longer leaks __get_undefined", async () => {
+    const r = await compileStandalone(
+      `class X extends Uint8Array {} export function test(): number { const a: any = new X(); return 1; }`,
+    );
+    expect(r.success).toBe(true);
+    expect(leakedImports(r)).not.toContain("__get_undefined");
+  });
+
+  it("TypedArray subclass no longer leaks __tag_user_class", async () => {
+    const r = await compileStandalone(
+      `class X extends Int32Array {} export function test(): number { const a: any = new X(); return 1; }`,
+    );
+    expect(r.success).toBe(true);
+    expect(leakedImports(r)).not.toContain("__tag_user_class");
+  });
+
+  it("Error subclass no longer leaks __get_undefined or __tag_user_class", async () => {
+    const r = await compileStandalone(
+      `class E extends Error {} export function test(): number { const e: any = new E(); return 1; }`,
+    );
+    expect(r.success).toBe(true);
+    const names = leakedImports(r);
+    expect(names).not.toContain("__get_undefined");
+    expect(names).not.toContain("__tag_user_class");
+  });
+
+  it("empty TypedArray subclass declaration no longer leaks __tag_user_class", async () => {
+    const r = await compileStandalone(`class X extends Uint8Array {} export function test(): number { return 1; }`);
+    expect(r.success).toBe(true);
+    expect(leakedImports(r)).not.toContain("__tag_user_class");
+  });
+
+  it("host (gc) mode still emits the instanceof tag + __get_undefined (unchanged)", async () => {
+    // The fix is native-strings-gated; gc/host keeps the host-backed instanceof
+    // path so `instance instanceof Sub` still resolves via the tag chain.
+    const r = await compile(
+      `class X extends Uint8Array {} export function test(): number { const a: any = new X(); return (a instanceof X) ? 1 : 0; }`,
+      { fileName: "test.ts", skipSemanticDiagnostics: true },
+    );
+    expect(r.success).toBe(true);
+    expect(leakedImports(r)).toContain("__tag_user_class");
+  });
+});


### PR DESCRIPTION
## Summary

A builtin subclass (`class X extends Uint8Array {}` / `extends Error` …) + `new X()` leaked **three** host imports standalone, so the module fails to instantiate with an empty import object. This slice clears two of them (`__new_<Builtin>` is a separate, harder slice — see below).

### 1. `__get_undefined`

`compileNewExpression` → `pushDefaultValue` → `emitUndefinedValue` (`src/codegen/type-coercion.ts`) called `ensureLateImport` **directly**, bypassing the canonical `ensureGetUndefined` `ctx.nativeStrings` guard (`ensureLateImport` does not refuse `__get_undefined`). So the host import leaked into the implicit derived-ctor forwarder's externref default. Fix: gate on `ctx.nativeStrings` → emit `ref.null.extern` (undefined ≡ null standalone). Same defect class as the #1702 Error-subclass slice, different site (the `new`-expression default path).

### 2. `__tag_user_class`

The externref-backed-class instanceof tag (`src/codegen/class-bodies.ts`, #1455) was emitted unconditionally. Its **only** consumer is the host `__instanceof` import, which does not exist standalone (a plain class uses native WasmGC type checks and needs no tag). So the tag was dead weight that leaked. Fix: skip it under `ctx.nativeStrings` — mirrors the #1500 `emitSetSubclassProto` host-only-adjustment skip. gc/host keeps it so the host tag-chain still resolves `instanceof`.

## Validation

`tests/issue-2029-ta-subclass-host-leak-standalone.test.ts` (5/5): TypedArray/Error subclass `new X()` assert neither `__get_undefined` nor `__tag_user_class` is imported; empty-declaration guard; host (gc) no-regression (tag still present). Existing `issue-2029-subclass-builtin-standalone-emit` (8/8) green. tsc + prettier + coercion-sites clean. Zero host regressions (both fixes `nativeStrings`-gated).

Verified by direct import inspection — the test262 runner masks the leak because it doesn't instantiate the standalone lane with a strictly empty import object.

## Still open (separate slice)

`__new_<Builtin>` (`__new_Uint8Array`, `__new_Error`, …) — the builtin base constructor. Needs a native WasmGC construction path for the externref-backed base (overlaps #2159). Even an empty `class X extends Uint8Array {}` declaration emits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)