### PR TITLE
fix(#1633): native Array.of construction for standalone (no host leak)

### DIFF
--- a/plan/issues/1633-spec-gap-array-from-of-construct.md
+++ b/plan/issues/1633-spec-gap-array-from-of-construct.md
@@ -145,3 +145,28 @@ issue. Recommend: **keep #1633 blocked on #1320 + #1620**, and split out (a)
 subclass-constructor dispatch and (b) boxed-boolean externref as separate
 issues. No code change landed — a partial mapFn-thisArg/array-like patch
 would move 0 tests until the bridge exists.
+
+---
+
+## Slice (2026-06-21, dev-agent) — `Array.of` native standalone construction (PR pending)
+
+Independent, contained slice (NOT the blocked subclassing/iterable-bridge core).
+
+**Bug:** `Array.of(a, b, c)` (§23.1.2.3) leaked the host imports `__array_of` /
+`__js_array_new` / `__js_array_push` under `--target standalone` and returned a
+wrong/empty array (length 0, elements NaN), while `Array(a,b,c)` and `[a,b,c]`
+already built a native vec. Host mode worked.
+
+**Fix:** in `noJsHost` mode, the `Array.of` handler
+(`src/codegen/expressions/calls.ts`) builds a native vec directly — mirroring the
+multi-arg `Array(a,b,c)` branch of `compileArrayConstructorCall`. Every argument
+is an element; unlike `Array(n)` a single numeric arg is NOT a length
+(`Array.of(5)` → `[5]`, length 1). Element type from the contextual `Array<T>`
+type arg, else f64 when all args are static numbers, else externref. JS-host mode
+keeps the `__array_of` path unchanged. Spread args fall through to the existing
+path (standalone spread-of-Array.of is a separate concern).
+
+**Validation.** `tests/issue-1633-array-of-standalone.test.ts` (13/13):
+multi-arg length/element, single-arg `[5]` (not sparse), empty, typed fractional,
+string elements — host & standalone — plus a standalone no-host-leak assertion.
+tsc + prettier clean; issue-1338 regression green.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -4622,6 +4622,70 @@ function compileCallExpression(
       propAccess.expression.text === "Array" &&
       propAccess.name.text === "of"
     ) {
+      // (#1633 standalone slice) `Array.of(a, b, c)` ≡ `[a, b, c]` (§23.1.2.3:
+      // every arg is an element; unlike `Array(n)` a single numeric arg is NOT a
+      // length). In no-JS-host mode the host `__array_of` (+ `__js_array_new`/
+      // `__js_array_push`) imports don't exist — the old path leaked them and
+      // returned a wrong/empty array standalone. Build a native vec directly,
+      // mirroring the multi-arg `Array(a,b,c)` branch of
+      // `compileArrayConstructorCall` (no spread → fixed arity). Spread args keep
+      // the host path (handled by the generic spread-call lowering in host mode);
+      // a standalone spread of Array.of falls through to the existing path.
+      const hasSpreadArg = expr.arguments.some((a) => ts.isSpreadElement(a));
+      if (noJsHost(ctx) && !hasSpreadArg) {
+        // Element type: contextual `Array<T>` type arg, else f64 for a numeric
+        // arg set, else externref (mixed / non-numeric). Mirrors the untyped
+        // dense-array default in compileArrayConstructorCall.
+        const ctxType = ctx.checker.getContextualType(expr) ?? ctx.checker.getTypeAtLocation(expr);
+        const elemTsType = ctx.checker.getTypeArguments(ctxType as ts.TypeReference)?.[0];
+        let elemWasm: ValType;
+        if (elemTsType && (elemTsType.flags & ts.TypeFlags.Any) === 0) {
+          elemWasm = resolveWasmType(ctx, elemTsType);
+        } else {
+          // No resolvable element type: pick f64 only when every arg is a static
+          // number; otherwise box to externref so mixed/object elements survive.
+          const allNumeric = expr.arguments.every((a) => {
+            const t = ctx.checker.getTypeAtLocation(a);
+            return (t.flags & (ts.TypeFlags.Number | ts.TypeFlags.NumberLiteral)) !== 0;
+          });
+          elemWasm = expr.arguments.length > 0 && allNumeric ? { kind: "f64" } : { kind: "externref" };
+        }
+        const elemKey =
+          elemWasm.kind === "ref" || elemWasm.kind === "ref_null"
+            ? `ref_${(elemWasm as { typeIdx: number }).typeIdx}`
+            : elemWasm.kind;
+        const ofVecTypeIdx = getOrRegisterVecType(ctx, elemKey, elemWasm);
+        const ofArrTypeIdx = getArrTypeIdxFromVec(ctx, ofVecTypeIdx);
+        if (ofArrTypeIdx >= 0) {
+          if (expr.arguments.length === 0) {
+            fctx.body.push({ op: "i32.const", value: 0 });
+            fctx.body.push({ op: "i32.const", value: 0 });
+            fctx.body.push({ op: "array.new_default", typeIdx: ofArrTypeIdx });
+            fctx.body.push({ op: "struct.new", typeIdx: ofVecTypeIdx });
+            return { kind: "ref_null", typeIdx: ofVecTypeIdx };
+          }
+          for (const arg of expr.arguments) {
+            const at = compileExpression(ctx, fctx, arg, elemWasm);
+            if (at && !valTypesMatch(at, elemWasm)) coerceType(ctx, fctx, at, elemWasm);
+            else if (
+              at === null &&
+              (elemWasm.kind === "ref" || elemWasm.kind === "ref_null" || elemWasm.kind === "externref")
+            )
+              fctx.body.push({ op: "ref.null.extern" } as Instr);
+          }
+          fctx.body.push({ op: "array.new_fixed", typeIdx: ofArrTypeIdx, length: expr.arguments.length });
+          const ofDataLocal = allocLocal(fctx, `__arrof_data_${fctx.locals.length}`, {
+            kind: "ref",
+            typeIdx: ofArrTypeIdx,
+          });
+          fctx.body.push({ op: "local.set", index: ofDataLocal });
+          fctx.body.push({ op: "i32.const", value: expr.arguments.length });
+          fctx.body.push({ op: "local.get", index: ofDataLocal });
+          fctx.body.push({ op: "struct.new", typeIdx: ofVecTypeIdx });
+          return { kind: "ref_null", typeIdx: ofVecTypeIdx };
+        }
+        // vec type unavailable — fall through to the host path below.
+      }
       // Build a JS array of the arguments and delegate to host
       const arrNewIdx = ensureLateImport(ctx, "__js_array_new", [], [{ kind: "externref" }]);
       const arrPushIdx = ensureLateImport(ctx, "__js_array_push", [{ kind: "externref" }, { kind: "externref" }], []);

--- a/tests/issue-1633-array-of-standalone.test.ts
+++ b/tests/issue-1633-array-of-standalone.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1633 (standalone slice) — `Array.of(...items)` (§23.1.2.3) leaked the host
+// imports `__array_of` / `__js_array_new` / `__js_array_push` under
+// `--target standalone` and returned a wrong/empty array (length 0, elements
+// NaN), while `Array(a,b,c)` and `[a,b,c]` already built a native vec.
+//
+// Fix: in no-JS-host mode, lower `Array.of(a, b, c)` to a native vec directly
+// (mirroring the multi-arg `Array(a,b,c)` branch of `compileArrayConstructorCall`)
+// — every argument is an element (unlike `Array(n)`, a single numeric arg is NOT
+// a length). JS-host mode keeps the `__array_of` path unchanged. Spread args
+// keep the host/general path (a standalone spread of Array.of falls through).
+//
+// This is the contained standalone-construction slice of #1633; the hard
+// subclassing / iterable-bridge semantics (Array.from/of via `this`) stay in the
+// parent issue.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+type Mode = { label: string; opts: Record<string, unknown> };
+const MODES: Mode[] = [
+  { label: "host", opts: {} },
+  { label: "standalone", opts: { target: "standalone" } },
+];
+
+async function run(src: string, opts: Record<string, unknown>): Promise<unknown> {
+  const result = await compile(src, { fileName: "test.ts", skipSemanticDiagnostics: true, ...opts });
+  expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary), "binary should validate").toBe(true);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#1633 — Array.of native construction", () => {
+  for (const { label, opts } of MODES) {
+    describe(`[${label}]`, () => {
+      it("Array.of(1,2,3).length === 3", async () => {
+        expect(await run("export function test(): number { return Array.of(1, 2, 3).length; }", opts)).toBe(3);
+      });
+
+      it("Array.of(5,6,7)[1] === 6", async () => {
+        expect(await run("export function test(): number { const a = Array.of(5, 6, 7); return a[1]; }", opts)).toBe(6);
+      });
+
+      it("Array.of(5) is [5] (length 1, NOT a length-5 sparse array)", async () => {
+        expect(await run("export function test(): number { return Array.of(5).length; }", opts)).toBe(1);
+        expect(await run("export function test(): number { return Array.of(9)[0]; }", opts)).toBe(9);
+      });
+
+      it("Array.of() is empty", async () => {
+        expect(await run("export function test(): number { return Array.of().length; }", opts)).toBe(0);
+      });
+
+      it("typed Array.of preserves fractional values", async () => {
+        expect(
+          await run(
+            "export function test(): number { const a: number[] = Array.of(1.5, 2.5); return a[0] * 10; }",
+            opts,
+          ),
+        ).toBe(15);
+      });
+
+      it("Array.of of strings", async () => {
+        expect(
+          await run(
+            'export function test(): number { const a = Array.of("a", "bb", "ccc"); return a[2].length; }',
+            opts,
+          ),
+        ).toBe(3);
+      });
+    });
+  }
+
+  it("standalone Array.of emits no __array_of / __js_array_* host import", async () => {
+    const result = await compile("export function test(): number { return Array.of(1, 2, 3).length; }", {
+      fileName: "test.ts",
+      target: "standalone",
+    });
+    expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+    const leaked = (result.imports ?? [])
+      .filter((i) => i.module === "env")
+      .map((i) => i.name)
+      .filter((n) => n === "__array_of" || n === "__js_array_new" || n === "__js_array_push");
+    expect(leaked).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

`Array.of(a, b, c)` (§23.1.2.3) leaked the host imports `__array_of` / `__js_array_new` / `__js_array_push` under `--target standalone` and returned a **wrong/empty array** (length 0, elements NaN), while `Array(a,b,c)` and `[a,b,c]` already built a native vec. Host mode worked.

## Fix

In `noJsHost` mode, the `Array.of` handler (`src/codegen/expressions/calls.ts`) builds a native vec directly, mirroring the multi-arg `Array(a,b,c)` branch of `compileArrayConstructorCall`. Every argument is an element — unlike `Array(n)`, a single numeric arg is **NOT** a length (`Array.of(5)` → `[5]`, length 1). Element type comes from the contextual `Array<T>` type arg, else f64 when all args are static numbers, else externref. JS-host mode keeps the `__array_of` path unchanged. Spread args fall through to the existing path.

Contained standalone-construction slice of #1633 (claimed as `1633:array-of-standalone`) — **NOT** the blocked subclassing / iterable-bridge core (that stays in the parent issue, whose blockers #1320/#1620 are now done but whose remaining scope is `feasibility: hard`).

## Test

`tests/issue-1633-array-of-standalone.test.ts` (13/13): multi-arg length/element, single-arg `[5]` (not a length-5 sparse array), empty, typed fractional, string elements — host & standalone — plus a standalone no-`__array_of`/`__js_array_*`-leak assertion. tsc + prettier clean; issue-1338 regression green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)