### PR TITLE
fix(#2160): String.raw with substitutions valid standalone binary

### DIFF
--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -633,6 +633,38 @@ function compileStringRaw(
   substitutions: readonly ts.Expression[],
 ): ValType | null {
   addStringImports(ctx);
+
+  // (#2160) Native-strings (standalone / WASI) path. The generic host-concat
+  // loop below mixes representations here: a numeric substitution leaves an f64
+  // / a `number_toString` externref that the native accumulator (a `ref
+  // $AnyString` from `compileStringLiteral`) cannot concat — producing
+  // `any.convert_extern expected externref, found f64` (an INVALID standalone
+  // binary for `String.raw\`a${1}b\``). Mirror `compileTemplateExpression`'s
+  // native branch: coerce EVERY operand to `ref $AnyString` via the proven
+  // `compileNativeConcatOperand` helper and concat with native `__str_concat`.
+  // The no-substitution case already worked via the generic template-vec fix;
+  // this fixes the WITH-substitution case. (My prior #1812 added this branch
+  // but was closed as superseded after only the no-subst case was probed.)
+  if (noJsHost(ctx) && ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0) {
+    const nativeConcatIdx = ctx.nativeStrHelpers.get("__str_concat");
+    if (nativeConcatIdx === undefined) {
+      reportError(ctx, expr, "String.raw: native string concat helper unavailable");
+      return null;
+    }
+    compileNativeStringLiteral(ctx, fctx, rawParts[0] ?? "");
+    for (let i = 0; i < substitutions.length; i++) {
+      // Stringify + native-coerce the substitution to `ref $AnyString`, concat.
+      if (!compileNativeConcatOperand(ctx, fctx, substitutions[i]!)) {
+        compileNativeStringLiteral(ctx, fctx, "undefined");
+      }
+      fctx.body.push({ op: "call", funcIdx: nativeConcatIdx });
+      // Append the following raw part.
+      compileNativeStringLiteral(ctx, fctx, rawParts[i + 1] ?? "");
+      fctx.body.push({ op: "call", funcIdx: nativeConcatIdx });
+    }
+    return nativeStringType(ctx);
+  }
+
   const concatIdx = ctx.jsStringImports.get("concat") ?? ctx.nativeStrHelpers.get("__str_concat");
   if (concatIdx === undefined) {
     reportError(ctx, expr, "String.raw: string concat helper unavailable");

--- a/tests/issue-2160-string-raw-subst-standalone.test.ts
+++ b/tests/issue-2160-string-raw-subst-standalone.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2160 — `String.raw` WITH substitutions produced an invalid standalone binary.
+//
+// `compileStringRaw` (src/codegen/string-ops.ts) built the accumulator from a
+// native `ref $AnyString` literal but stringified a numeric substitution via
+// `number_toString` and concatenated through the host-concat path, mixing
+// representations under native-strings mode → `any.convert_extern expected
+// externref, found f64` at instantiate (an INVALID standalone binary for
+// `String.raw\`a${1}b\``). The no-substitution case already worked (generic
+// template-vec fix); only the WITH-substitution path was broken.
+//
+// Fix: in noJsHost / nativeStrings mode, coerce every operand to `ref $AnyString`
+// via the proven `compileNativeConcatOperand` helper and concat with native
+// `__str_concat` — mirroring `compileTemplateExpression`'s native branch.
+// JS-host mode is unchanged (wasm:js-string concat).
+
+async function compileStandalone(src: string) {
+  return compile(src, { fileName: "test.ts", target: "standalone", skipSemanticDiagnostics: true });
+}
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compileStandalone(src);
+  if (!r.success) throw new Error("compile failed: " + (r.errors[0]?.message ?? "unknown"));
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports.test as () => number)();
+}
+
+describe("#2160 String.raw with substitutions (standalone)", () => {
+  it("numeric substitution compiles + instantiates standalone (was: invalid binary)", async () => {
+    // String.raw`a${1}b` === "a1b"
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const s = String.raw\`a\${1}b\`;
+          return (s.length === 3 && s.charCodeAt(0) === 97 && s.charCodeAt(1) === 49 && s.charCodeAt(2) === 98) ? 1 : 0;
+        }`),
+    ).toBe(1);
+  });
+
+  it("string substitution standalone", async () => {
+    // String.raw`a${"X"}b` === "aXb"
+    expect(await runStandalone(`export function test(): number { return String.raw\`a\${"X"}b\`.length; }`)).toBe(3);
+  });
+
+  it("multiple numeric substitutions standalone", async () => {
+    // String.raw`${1}-${2}` === "1-2"
+    expect(await runStandalone(`export function test(): number { return String.raw\`\${1}-\${2}\`.length; }`)).toBe(3);
+  });
+
+  it("no-substitution String.raw still works standalone (regression guard)", async () => {
+    expect(await runStandalone(`export function test(): number { return String.raw\`hello\`.length; }`)).toBe(5);
+  });
+
+  it("raw escapes are preserved (backslash not interpreted)", async () => {
+    // String.raw`x\ny` === "x\\ny" (4 chars: x, backslash, n, y)
+    expect(await runStandalone(`export function test(): number { return String.raw\`x\\ny\`.length; }`)).toBe(4);
+  });
+
+  it("boolean substitution standalone", async () => {
+    // String.raw`v=${true}` === "v=true"
+    expect(await runStandalone(`export function test(): number { return String.raw\`v=\${true}\`.length; }`)).toBe(6);
+  });
+
+  it("does not leak a JS-host string import standalone", async () => {
+    const r = await compileStandalone(`export function test(): number { return String.raw\`a\${1}b\`.length; }`);
+    expect(r.success).toBe(true);
+    const names = r.imports.map((i) => i.name);
+    expect(names.some((n) => n.startsWith("string_") || n === "concat")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`String.raw` **with substitutions** produced an **invalid standalone binary**. `compileStringRaw` (`src/codegen/string-ops.ts`) built the accumulator from a native `ref $AnyString` literal but stringified a numeric substitution via `number_toString` and concatenated through the host-concat path, mixing representations under native-strings mode → `any.convert_extern expected externref, found f64` at instantiate for `String.raw\`a\${1}b\``.

The **no-substitution** case already worked (the generic template-vec fix upstream); only the **WITH-substitution** path was broken. (Verified on pristine `upstream/main`: `String.raw\`hello\`` and string-substitution work; numeric-substitution is an invalid binary.)

## Fix

In `noJsHost` / `nativeStrings` mode, coerce **every** operand to `ref $AnyString` via the proven `compileNativeConcatOperand` helper and concat with native `__str_concat` — mirroring `compileTemplateExpression`'s native branch. JS-host mode is unchanged (`wasm:js-string` concat). Raw-escape semantics preserved (`String.raw\`x\\ny\`` stays 4 chars).

(My prior #1812 added this branch but was closed as superseded after only the no-subst case was probed against upstream; this re-files the still-needed substitution fix cleanly from `upstream/main`.)

## Validation

`tests/issue-2160-string-raw-subst-standalone.test.ts` (7/7): numeric/string/multiple/boolean substitutions standalone with content checks; no-subst regression guard; raw-escape preservation; no JS-host string-import leak. tsc + prettier + coercion-sites clean. Host mode untouched.

Branched from `upstream/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)