### PR TITLE
fix(#2160): String.raw with substitution valid standalone binary

### DIFF
--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -633,6 +633,37 @@ function compileStringRaw(
   substitutions: readonly ts.Expression[],
 ): ValType | null {
   addStringImports(ctx);
+
+  // (#2160 standalone slice) Native-strings (standalone / WASI) path. Every
+  // operand fed to the native `__str_concat` must be a `ref $AnyString`.
+  // `compileStringLiteral` already yields one here, but a numeric / any
+  // substitution leaves an f64 / externref that the host externref-concat path
+  // below mishandles — a numeric substitution (`String.raw\`a${1}b\``) drove an
+  // f64 straight into `any.convert_extern` → an INVALID standalone binary. Reuse
+  // the proven `compileNativeConcatOperand` coercion (number_toString +
+  // ref-from-extern, bool→literal, string passthrough, any→ToString) so every
+  // operand is a native string ref before each `__str_concat`. JS-host mode keeps
+  // the wasm:js-string concat path below unchanged.
+  if (noJsHost(ctx) && ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0) {
+    const nativeConcatIdx = ctx.nativeStrHelpers.get("__str_concat");
+    if (nativeConcatIdx === undefined) {
+      reportError(ctx, expr, "String.raw: native string concat helper unavailable");
+      return null;
+    }
+    compileNativeStringLiteral(ctx, fctx, rawParts[0] ?? "");
+    for (let i = 0; i < substitutions.length; i++) {
+      if (!compileNativeConcatOperand(ctx, fctx, substitutions[i]!)) {
+        // Unknown operand kind — fall back to "undefined" so the module stays valid.
+        compileNativeStringLiteral(ctx, fctx, "undefined");
+      }
+      fctx.body.push({ op: "call", funcIdx: nativeConcatIdx });
+      // Append the following raw part.
+      compileNativeStringLiteral(ctx, fctx, rawParts[i + 1] ?? "");
+      fctx.body.push({ op: "call", funcIdx: nativeConcatIdx });
+    }
+    return nativeStringType(ctx);
+  }
+
   const concatIdx = ctx.jsStringImports.get("concat") ?? ctx.nativeStrHelpers.get("__str_concat");
   if (concatIdx === undefined) {
     reportError(ctx, expr, "String.raw: string concat helper unavailable");

--- a/tests/issue-2160-string-raw-subst-standalone.test.ts
+++ b/tests/issue-2160-string-raw-subst-standalone.test.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2160 (slice) — `String.raw` WITH a substitution emitted an INVALID standalone
+// binary. The no-substitution case was fixed upstream by the generic
+// tagged-template `pushStringElem` externref-array bridge, but
+// `compileStringRaw`'s substitution-concat path (src/codegen/string-ops.ts) still
+// mixed representations in native-strings mode: a numeric substitution
+// (`String.raw`a${1}b``) drove an f64 straight into `any.convert_extern`
+// ("expected externref, found f64.const") → invalid module under
+// `--target standalone`.
+//
+// Fix: in `noJsHost` / native-strings mode, `compileStringRaw` coerces every
+// operand to `ref $AnyString` via the existing `compileNativeConcatOperand`
+// helper (number_toString + ref-from-extern, bool→literal, string passthrough,
+// any→ToString) and concatenates with the native `__str_concat`. JS-host mode
+// keeps the wasm:js-string concat path unchanged.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+type Mode = { label: string; opts: Record<string, unknown> };
+const MODES: Mode[] = [
+  { label: "host", opts: {} },
+  { label: "standalone", opts: { target: "standalone" } },
+];
+
+async function run(src: string, opts: Record<string, unknown>): Promise<unknown> {
+  const result = await compile(src, { fileName: "test.ts", skipSemanticDiagnostics: true, ...opts });
+  expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary), "binary should validate").toBe(true);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#2160 — String.raw with substitution (standalone)", () => {
+  for (const { label, opts } of MODES) {
+    describe(`[${label}]`, () => {
+      it("no-substitution String.raw === 'abc'", async () => {
+        expect(await run('export function test(): boolean { return String.raw`abc` === "abc"; }', opts)).toBe(1);
+      });
+
+      it("single numeric substitution String.raw`a${1}b` === 'a1b'", async () => {
+        expect(await run('export function test(): boolean { return String.raw`a${1}b` === "a1b"; }', opts)).toBe(1);
+      });
+
+      it("multiple numeric substitutions String.raw`x${1}y${2}z` === 'x1y2z'", async () => {
+        expect(await run('export function test(): boolean { return String.raw`x${1}y${2}z` === "x1y2z"; }', opts)).toBe(
+          1,
+        );
+      });
+
+      it("raw escape is uncooked: String.raw`a\\nb`.length === 4", async () => {
+        expect(await run("export function test(): number { return String.raw`a\\nb`.length; }", opts)).toBe(4);
+      });
+
+      it("boolean substitution String.raw`v=${true}` === 'v=true'", async () => {
+        expect(await run('export function test(): boolean { return String.raw`v=${true}` === "v=true"; }', opts)).toBe(
+          1,
+        );
+      });
+
+      it("string substitution String.raw`<${m}>` === '<x>'", async () => {
+        expect(
+          await run('export function test(): boolean { const m = "x"; return String.raw`<${m}>` === "<x>"; }', opts),
+        ).toBe(1);
+      });
+    });
+  }
+
+  it("standalone String.raw with substitution validates (regression guard)", async () => {
+    const result = await compile("export function test(): number { return String.raw`a${1}b${2}c`.length; }", {
+      fileName: "test.ts",
+      target: "standalone",
+    });
+    expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(WebAssembly.validate(result.binary)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

On pristine upstream HEAD, `String.raw` **with a substitution** (`String.raw`a${1}b``) still emits an **INVALID standalone binary**: a numeric substitution drives an f64 straight into `any.convert_extern` ("expected externref, found f64.const"). The no-substitution case was already fixed upstream by the generic tagged-template `pushStringElem` externref-array bridge, but `compileStringRaw`'s substitution-concat path (`src/codegen/string-ops.ts`) still mixed representations in native-strings mode.

## Fix

In `noJsHost` / native-strings mode, `compileStringRaw` now coerces every operand to `ref $AnyString` via the existing `compileNativeConcatOperand` helper (number_toString + ref-from-extern, bool→literal, string passthrough, any→ToString) and concatenates with the native `__str_concat`. JS-host mode keeps the wasm:js-string concat path unchanged.

## Context

Re-files the still-needed substitution half of the **closed PR #1812**, which was branched off the stale fork ( ~1188 commits behind upstream) and got superseded after only the no-substitution case was probed. I verified the substitution crash on pristine  () before and after the fix, and **branched this PR from ** so it's not stale-based. Claimed at slice granularity (`2160:string-raw-subst`).

## Test

`tests/issue-2160-string-raw-subst-standalone.test.ts` (13/13): no-subst / single / multiple numeric substitutions, raw-escape length, boolean + string substitutions — host & standalone — plus a standalone-validates regression guard. `issue-2008` tagged-template suite 7/7 green. tsc + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)