### PR TITLE
fix(#2542): standalone dynamic property read/write by runtime string key

### DIFF
--- a/plan/issues/2542-standalone-dynamic-property-read-runtime-key.md
+++ b/plan/issues/2542-standalone-dynamic-property-read-runtime-key.md
@@ -2,10 +2,12 @@
 id: 2542
 renumbered_from: 2511
 title: "standalone: dynamic property read/write by a runtime string key (o[k]) returns default — needs native key enumeration + dynamic [[Get]]/[[Set]]"
-status: ready
+status: done
 sprint: 64
 created: 2026-06-19
-updated: 2026-06-19
+updated: 2026-06-21
+completed: 2026-06-21
+assignee: sd-2
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -14,7 +16,6 @@ area: codegen, standalone, runtime
 language_feature: property-access, dynamic-keys
 goal: standalone-mode
 related: [2371, 2151, 2001]
-needs: architect-spec
 origin: "2026-06-19 sd1 standalone host-import-leak hunt — the broad gap underlying #2371-phase2 (native for-in) and #2151 (any-receiver dispatch)"
 ---
 
@@ -80,3 +81,69 @@ representation/runtime change to the object model (dynamic [[Get]]/[[Set]] by
 string key), not a localized fix. Filed for the standalone epic pivot; do NOT
 attempt as a dev slice without a binding/representation design. Pairs naturally
 with #2371-phase2 and #2151.
+
+## Resolution (2026-06-21, sd-2) — representation routing, NOT a new runtime
+
+The dynamic [[Get]]/[[Set]]-by-string-key runtime the issue called for **already
+exists**: the native `$Object` open-object machinery (`__new_plain_object` /
+`__extern_get` / `__extern_set` / `__obj_find`, all emitted as defined Wasm
+functions under `--target standalone`, no host imports) services exactly this.
+The bug was a **representation mismatch**, not a missing runtime: index-signature
+objects were being lowered to a CLOSED nominal struct that those readers can't
+reach.
+
+### Root cause (confirmed by WAT inspection)
+
+For `const o: { [s: string]: number } = { a: 5, b: 7 }`:
+
+1. The literal `{ a: 5, b: 7 }` has an *inferred* type with named props `a,b`, so
+   `compileObjectLiteral` built it as `struct.new $Closed`, then
+   `extern.convert_any`-wrapped it to externref. `__extern_get`'s `ref.test
+   $Object` cannot match a closed struct → `o[k]` returned null → `0`; `o[k] = v`
+   targeted nothing → dropped.
+2. The index-signature TYPE `{ [s: string]: number }` (declared type of `o`,
+   params, returns) has an EMPTY `getProperties()`, so `resolveWasmType` →
+   `ensureStructForType` registered an **empty** WasmGC struct and resolved the
+   binding to `ref $empty`. A `$Object` argument then guard-cast to null at the
+   call boundary (the `idxSig-param` / `return-dict` cases returned `0`).
+
+(The issue text's "static-literal key works, runtime key returns 0" framing was
+imprecise — the real split is **plain inferred struct** `{a,b}` runtime-key reads
+*already worked* via the legacy externref-fallback path, while **index-signature
+typed** objects failed on both literal and runtime keys.)
+
+### Fix — three scoped, `ctx.standalone`-only routing changes
+
+A pure string-index-signature type (anonymous `{ [s:string]:T }`, a `type`-alias
+to one, or an `interface Dict { [s:string]:T }` — **no own named properties**) is
+semantically an open dictionary, so it must flow as a `$Object` externref end to
+end. Mirrors #1901's open-`$Object` routing.
+
+- **`src/codegen/literals.ts` `compileObjectLiteral`** — two gates extended to
+  fire when the contextual type has a string index signature + zero own props:
+  the non-empty `#1901` open-`$Object` gate (builds the literal via
+  `compileObjectLiteralAsExternref`), and the empty-`{}` `__new_plain_object`
+  arm (so `const o: Dict = {}` is a real `$Object` open to dynamic writes).
+- **`src/codegen/index.ts` `resolveWasmType`** — a pure string-index-signature
+  Object type resolves to `externref` (placed BEFORE the named-struct lookup so a
+  pure-index-signature *interface*, already registered as an empty struct by
+  `collectInterface`, still resolves to externref — the empty struct stays
+  registered but is never used as a value type, so **no type-index shift**).
+- **`src/codegen/index.ts` `ensureStructForType`** — skips registering such a
+  type as an empty anonymous struct (defense-in-depth for direct callers).
+
+A MIXED `{ a: number; [s: string]: T }` (own named props) is intentionally
+**excluded** — it has a static shape consumers read by field, so it keeps its
+struct (routing it to `$Object` would mismatch the struct-typed binding). gc /
+host / wasi are byte-identical (the open-object runtime is standalone-only).
+
+### Verified
+
+`tests/issue-2542-standalone-dynamic-key.test.ts` (15 cases): runtime-key
+read/write, write-then-read, brand-new absent key, static member, param, return,
+`type`-alias, `interface`, concatenated key, read-modify-write, empty-`{}` +
+dynamic write, spread, nested dict-of-dict — all correct value, valid Wasm, and
+**zero host-object-import leak** (the standalone contract). Plain-struct fast
+path preserved (regression guard). `string`/`boolean`-valued index sigs compile
+valid + leak-free. The pre-existing `for-in` `env.__for_in_*` leak is unchanged
+and remains #2371's job (this fix unblocks #2371-phase-2's value reads).

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -10587,6 +10587,37 @@ export function resolveWasmType(ctx: CodegenContext, tsType: ts.Type, _depth = 0
       }
     }
 
+    // (#2542) A PURE string-index-signature type — `{ [s: string]: T }`, a
+    // `type`-alias to one, or an `interface Dict { [s: string]: T }` — with no own
+    // named properties is an open dictionary. Its only access mode is runtime
+    // string-keyed [[Get]]/[[Set]] (`o[k]`), serviced by the native object runtime
+    // over a `$Object` externref (`__extern_get`/`__extern_set`). Without this
+    // guard the type lowers to an EMPTY WasmGC struct (anonymous → the auto-register
+    // below; named interface → `collectInterface`'s empty struct): a value typed
+    // that way (param, return, local) becomes `ref $empty`, so a `$Object` argument
+    // guard-casts to null at the call boundary and every `o[k]` read returns 0.
+    // Resolving to externref keeps such values flowing as `$Object`s end to end,
+    // matching the open-`$Object` literal lowering in compileObjectLiteral (#2542).
+    //
+    // Runs BEFORE the named-struct lookup so a pure-index-signature *interface*
+    // (already registered as an empty struct by `collectInterface`) still resolves
+    // to externref — the empty struct stays registered (harmless; dead-eliminated
+    // if unreferenced) but is never used as a value type, so no type-index shift.
+    //
+    // Standalone-only: the open-object runtime is emitted exclusively under
+    // `ctx.standalone` (see compileObjectLiteral's #1901/#2542 gate); gc/host/wasi
+    // keep their existing struct/externref mapping byte-identical. A MIXED
+    // `{ a: number; [s: string]: T }` (own named props) is intentionally excluded —
+    // it has a static shape consumers read by field, so it keeps its struct.
+    if (
+      ctx.standalone &&
+      tsType.getProperties().length === 0 &&
+      tsType.getCallSignatures().length === 0 &&
+      !!ctx.checker.getIndexInfoOfType(tsType, ts.IndexKind.String)
+    ) {
+      return { kind: "externref" };
+    }
+
     let name = sym?.name;
     // Map class expression symbol names to their synthetic names
     if (name && !ctx.structMap.has(name)) {
@@ -10746,6 +10777,19 @@ export function ensureStructForType(ctx: CodegenContext, tsType: ts.Type): void 
   }
   // Callable types (functions) are compiled as closures, not structs
   if (tsType.getCallSignatures().length > 0) return;
+  // (#2542) A pure string-index-signature type — `{ [s: string]: T }` with no own
+  // named properties — is an open dictionary that lowers to a `$Object` externref
+  // (see resolveWasmType's #2542 guard), NOT an empty WasmGC struct. Registering an
+  // empty struct here would make `resolveWasmType` pick `ref $empty` for the binding
+  // and break the call-boundary `$Object`→struct cast (every `o[k]` read returns 0).
+  // Standalone-only, matching the resolveWasmType guard's scope.
+  if (
+    ctx.standalone &&
+    tsType.getProperties().length === 0 &&
+    !!ctx.checker.getIndexInfoOfType(tsType, ts.IndexKind.String)
+  ) {
+    return;
+  }
   // Guard against infinite recursion on circular/self-referencing types.
   // Uses per-compilation ctx.ensureStructPending (not module-scoped) to avoid
   // leaking state between compile() calls in the same process (#923).

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -1049,11 +1049,8 @@ export function compileObjectLiteral(
     // mixed `{ a: number; [s: string]: T }` registers a concrete struct for the
     // binding (the `__type` anon-struct branch fires on `getProperties().length > 0`),
     // so diverting its literal to `$Object` would mismatch that struct local.
-    const strIndex = ctxTypeNonEmpty
-      ? ctx.checker.getIndexInfoOfType(ctxTypeNonEmpty, ts.IndexKind.String)
-      : undefined;
-    const isPureStringIndexContext =
-      !!strIndex && !!ctxTypeNonEmpty && ctxTypeNonEmpty.getProperties().length === 0;
+    const strIndex = ctxTypeNonEmpty ? ctx.checker.getIndexInfoOfType(ctxTypeNonEmpty, ts.IndexKind.String) : undefined;
+    const isPureStringIndexContext = !!strIndex && !!ctxTypeNonEmpty && ctxTypeNonEmpty.getProperties().length === 0;
     if (isAnyContextNonEmpty || isPureStringIndexContext) {
       const objResult = compileObjectLiteralAsExternref(ctx, fctx, expr);
       if (objResult) return objResult;

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -951,7 +951,19 @@ export function compileObjectLiteral(
       (ctxType.flags & ts.TypeFlags.Any) !== 0 ||
       (ctxType.flags & ts.TypeFlags.Unknown) !== 0 ||
       (ctxType.flags & ts.TypeFlags.NonPrimitive) !== 0; // TypeScript `object` keyword type
-    if (isAnyContext) {
+    // (#2542) An empty `{}` typed by a PURE string-index-signature contextual type
+    // (`const o: { [s: string]: number } = {}`) is an open dictionary that will be
+    // mutated by runtime string key (`o[k] = v`). Build it as an open `$Object`
+    // (same `__new_plain_object` as the any-context arm) so the binding — which
+    // resolveWasmType lowers to externref (#2542) — is a real `$Object` the native
+    // `__extern_set`/`__extern_get` service. Standalone-only (the open-object
+    // runtime is emitted only there); gc/host/wasi keep their existing lowering.
+    const isPureStringIndexEmpty =
+      ctx.standalone &&
+      !!ctxType &&
+      ctxType.getProperties().length === 0 &&
+      !!ctx.checker.getIndexInfoOfType(ctxType, ts.IndexKind.String);
+    if (isAnyContext || isPureStringIndexEmpty) {
       const funcIdx = ensureLateImport(ctx, "__new_plain_object", [], [{ kind: "externref" }]);
       flushLateImportShifts(ctx, fctx);
       if (funcIdx !== undefined) {
@@ -1023,7 +1035,26 @@ export function compileObjectLiteral(
       ((ctxTypeNonEmpty.flags & ts.TypeFlags.Any) !== 0 ||
         (ctxTypeNonEmpty.flags & ts.TypeFlags.Unknown) !== 0 ||
         (ctxTypeNonEmpty.flags & ts.TypeFlags.NonPrimitive) !== 0);
-    if (isAnyContextNonEmpty) {
+    // (#2542) A STRING-INDEX-SIGNATURE contextual type — `{ [s: string]: T }` — is
+    // semantically an open dictionary: its sole purpose is runtime string-keyed
+    // access (`o[k]` with a runtime `k`). `resolveWasmType` already lowers such a
+    // type to externref for the binding (no named properties → falls through to
+    // `mapTsTypeToWasm` → externref), so the consuming local is externref and ALL
+    // reads/writes route through `__extern_get`/`__extern_set`. But the closed-
+    // struct literal path builds a nominal `struct.new` and `extern.convert_any`-
+    // wraps it; `__extern_get`'s `ref.test $Object` then can't match the struct, so
+    // `o[k]` returns 0 and `o[k] = v` is dropped. Building the literal as an open
+    // `$Object` (same as #1901's any-context route) makes every native reader find
+    // the property. Restricted to a PURE dictionary (no own named properties): a
+    // mixed `{ a: number; [s: string]: T }` registers a concrete struct for the
+    // binding (the `__type` anon-struct branch fires on `getProperties().length > 0`),
+    // so diverting its literal to `$Object` would mismatch that struct local.
+    const strIndex = ctxTypeNonEmpty
+      ? ctx.checker.getIndexInfoOfType(ctxTypeNonEmpty, ts.IndexKind.String)
+      : undefined;
+    const isPureStringIndexContext =
+      !!strIndex && !!ctxTypeNonEmpty && ctxTypeNonEmpty.getProperties().length === 0;
+    if (isAnyContextNonEmpty || isPureStringIndexContext) {
       const objResult = compileObjectLiteralAsExternref(ctx, fctx, expr);
       if (objResult) return objResult;
       // fall through to the struct path if the $Object builder declined.

--- a/tests/issue-2542-standalone-dynamic-key.test.ts
+++ b/tests/issue-2542-standalone-dynamic-key.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2542 — standalone dynamic property read/write by a RUNTIME string key (`o[k]`).
+ *
+ * Under `--target standalone --nativeStrings`, reading or writing an object
+ * property by a runtime string *variable* key — `o[k]` where `k` is a `string`
+ * local, not a compile-time literal — failed when the object was typed by a
+ * STRING INDEX SIGNATURE (`{ [s: string]: number }`). The read returned the
+ * element-type default (0) and the write did not persist.
+ *
+ * Root cause: an index-signature-typed literal `{ a: 5, b: 7 }` was lowered to a
+ * closed nominal WasmGC `struct`, then `extern.convert_any`-wrapped to externref.
+ * The native `__extern_get`'s `ref.test $Object` could not match the closed struct,
+ * so `o[k]` returned null → 0. Separately, the index-signature TYPE itself resolved
+ * to an EMPTY WasmGC struct for params/returns (its `getProperties()` is empty), so
+ * a `$Object` argument guard-cast to null at the call boundary.
+ *
+ * Fix (mirrors #1901's open-`$Object` routing):
+ *   - `compileObjectLiteral` builds an index-signature-typed literal as an open
+ *     `$Object` (so reads/writes route through the native `__extern_get/_set`).
+ *   - `resolveWasmType` lowers a PURE string-index-signature type (anonymous,
+ *     `type`-alias, or `interface`, with no own named properties) to externref —
+ *     so the binding/param/return is a `$Object` end to end.
+ *   - `ensureStructForType` skips registering such a type as an empty struct.
+ *
+ * These tests assert BEHAVIOR (correct value) + zero host-object-import leak +
+ * valid module, independent of the fix mechanism. Mirrors issue-1901.test.ts.
+ */
+
+// Any leaked env::__extern_*/__object_*/__new_plain_object/__get_builtin/
+// __proto_method_call/__to_primitive under standalone is a failure.
+const BANNED = [
+  /^env::__extern_/,
+  /^env::__object_/,
+  /^env::__new_plain_object/,
+  /^env::__get_builtin/,
+  /^env::__proto_method_call/,
+  /^env::__to_primitive/,
+  /^env::__hasOwnProperty/,
+];
+function assertNoHostObjectImports(imports: ReadonlyArray<{ module: string; name: string }>): void {
+  const labels = imports.map((i) => `${i.module}::${i.name}`);
+  for (const re of BANNED) {
+    const hits = labels.filter((l) => re.test(l));
+    expect(hits, `--target standalone leaked ${re} (got ${hits.join(", ")})`).toEqual([]);
+  }
+}
+type NumExports = Record<string, () => number>;
+
+async function runStandalone(source: string): Promise<number> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  assertNoHostObjectImports(r.imports);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as NumExports).run();
+}
+
+describe("#2542 — standalone dynamic property read/write by runtime string key", () => {
+  it("headline: index-signature object read by runtime key reads the real value", async () => {
+    const v = await runStandalone(
+      `export function run(): number {
+         const o: { [s: string]: number } = { a: 5, b: 7 };
+         let k = "a";
+         return o[k];
+       }`,
+    );
+    expect(v).toBe(5);
+  });
+
+  it("write by runtime key persists (read back via static member)", async () => {
+    const v = await runStandalone(
+      `export function run(): number {
+         const o: { [s: string]: number } = { a: 5, b: 7 };
+         let k = "b";
+         o[k] = 42;
+         return o.b;
+       }`,
+    );
+    expect(v).toBe(42);
+  });
+
+  it("write then read back, both by runtime key", async () => {
+    const v = await runStandalone(
+      `export function run(): number {
+         const o: { [s: string]: number } = { a: 5, b: 7 };
+         let k = "b";
+         o[k] = 42;
+         let j = "b";
+         return o[j];
+       }`,
+    );
+    expect(v).toBe(42);
+  });
+
+  it("brand-new key absent at compile time can be written and read", async () => {
+    const v = await runStandalone(
+      `export function run(): number {
+         const o: { [s: string]: number } = { a: 5 };
+         let k = "z";
+         o[k] = 99;
+         let j = "z";
+         return o[j];
+       }`,
+    );
+    expect(v).toBe(99);
+  });
+
+  it("static member read off an index-signature object still works", async () => {
+    const v = await runStandalone(
+      `export function run(): number {
+         const o: { [s: string]: number } = { a: 5, b: 7 };
+         return o.a + o["b"];
+       }`,
+    );
+    expect(v).toBe(12);
+  });
+
+  it("index-signature object passed as a parameter is read by runtime key", async () => {
+    const v = await runStandalone(
+      `function lookup(o: { [s: string]: number }, k: string): number { return o[k]; }
+       export function run(): number {
+         const o: { [s: string]: number } = { x: 11, y: 22 };
+         return lookup(o, "y");
+       }`,
+    );
+    expect(v).toBe(22);
+  });
+
+  it("index-signature dict returned from a function is read by runtime key", async () => {
+    const v = await runStandalone(
+      `function make(): { [s: string]: number } {
+         const o: { [s: string]: number } = { a: 5, b: 7 };
+         return o;
+       }
+       export function run(): number {
+         const d = make();
+         let k = "b";
+         return d[k];
+       }`,
+    );
+    expect(v).toBe(7);
+  });
+
+  it("type-alias to an index signature behaves the same", async () => {
+    const v = await runStandalone(
+      `type Dict = { [s: string]: number };
+       export function run(): number {
+         const o: Dict = { a: 3, b: 4 };
+         let k = "a";
+         return o[k] + o["b"];
+       }`,
+    );
+    expect(v).toBe(7);
+  });
+
+  it("interface with only an index signature behaves the same", async () => {
+    const v = await runStandalone(
+      `interface Dict { [s: string]: number }
+       export function run(): number {
+         const o: Dict = { a: 3, b: 4 };
+         let k = "b";
+         return o[k];
+       }`,
+    );
+    expect(v).toBe(4);
+  });
+
+  it("computed (concatenated) runtime key resolves the property", async () => {
+    const v = await runStandalone(
+      `export function run(): number {
+         const o: { [s: string]: number } = { ab: 42 };
+         let p = "a";
+         let s = "b";
+         return o[p + s];
+       }`,
+    );
+    expect(v).toBe(42);
+  });
+
+  it("read-modify-write through a runtime key", async () => {
+    const v = await runStandalone(
+      `export function run(): number {
+         const o: { [s: string]: number } = { a: 1 };
+         let k = "a";
+         o[k] = o[k] + 10;
+         return o["a"];
+       }`,
+    );
+    expect(v).toBe(11);
+  });
+
+  it("empty index-signature object literal accepts dynamic writes", async () => {
+    const v = await runStandalone(
+      `export function run(): number {
+         const o: { [s: string]: number } = {};
+         let k = "x";
+         o[k] = 7;
+         return o[k];
+       }`,
+    );
+    expect(v).toBe(7);
+  });
+
+  it("spread into an index-signature literal copies and reads dynamically", async () => {
+    const v = await runStandalone(
+      `export function run(): number {
+         const base: { [s: string]: number } = { a: 1 };
+         const o: { [s: string]: number } = { ...base, b: 2 };
+         let ka = "a";
+         let kb = "b";
+         return o[ka] * 10 + o[kb];
+       }`,
+    );
+    expect(v).toBe(12);
+  });
+
+  it("nested dict-of-dict resolves both runtime keys", async () => {
+    const v = await runStandalone(
+      `export function run(): number {
+         const o: { [s: string]: { [t: string]: number } } = { x: { y: 9 } };
+         let k1 = "x";
+         let k2 = "y";
+         return o[k1][k2];
+       }`,
+    );
+    expect(v).toBe(9);
+  });
+
+  it("regression guard: a plain inferred struct still uses the fast struct path", async () => {
+    // No index signature, no any-context → closed-struct fast path. Static member
+    // reads must still resolve via struct.get; this must not regress to $Object.
+    const v = await runStandalone(
+      `export function run(): number {
+         const o = { a: 5, b: 7 };
+         return o.a + o.b;
+       }`,
+    );
+    expect(v).toBe(12);
+  });
+});


### PR DESCRIPTION
## #2542 — standalone dynamic property read/write by a runtime string key

In `--target standalone`, an index-signature object (`{ [s: string]: T }`) returned `0` on `o[k]` reads and dropped `o[k] = v` writes when `k` is a runtime string variable.

### Root cause (representation mismatch, not a missing runtime)

The native open-`$Object` machinery (`__new_plain_object` / `__extern_get` / `__extern_set` / `__obj_find` — all defined Wasm functions under standalone, **no host imports**) already services string-keyed [[Get]]/[[Set]]. The bug:

1. The literal `{ a: 5, b: 7 }` (inferred type has named props) was built as a **closed nominal struct** + `extern.convert_any`. `__extern_get`'s `ref.test $Object` can't match a closed struct → read 0, write dropped.
2. The index-signature **type** has an empty `getProperties()`, so it resolved to an **empty WasmGC struct**; a `$Object` argument guard-cast to null at the call boundary (param/return cases also returned 0).

### Fix — route pure string-index-signature types to the open `$Object` path

Mirrors #1901. A *pure* string-index-signature type (no own named props — anonymous, `type`-alias, or `interface`) is an open dictionary and must flow as a `$Object` externref end to end. Three `ctx.standalone`-scoped changes:

- **`literals.ts` `compileObjectLiteral`** — extend the #1901 non-empty open-`$Object` gate and the empty-`{}` `__new_plain_object` arm to fire on a string-index-signature contextual type.
- **`index.ts` `resolveWasmType`** — resolve such a type to `externref` (placed before the named-struct lookup so interfaces work; the empty struct stays registered but is never used as a value type → no type-index shift).
- **`index.ts` `ensureStructForType`** — skip registering it as an empty struct.

A **mixed** `{ a: number; [s: string]: T }` (own named props) keeps its struct (static shape its consumers read by field). gc / host / wasi are byte-identical.

### Tests

`tests/issue-2542-standalone-dynamic-key.test.ts` (15 cases): runtime-key read/write, write-then-read, brand-new absent key, static member, param, return, `type`-alias, `interface`, concatenated key, read-modify-write, empty-`{}` + dynamic write, spread, nested dict-of-dict — all assert correct value + valid Wasm + **zero host-object-import leak**. Plain-struct fast path preserved (regression guard).

The pre-existing `for-in` `env.__for_in_*` import leak is unchanged and remains #2371's scope; this fix unblocks #2371-phase-2's value reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA