### PR TITLE
fix(#2046): standalone Reflect.getOwnPropertyDescriptor → native (S5)

### DIFF
--- a/plan/issues/2046-standalone-reflect-spec-gaps.md
+++ b/plan/issues/2046-standalone-reflect-spec-gaps.md
@@ -4,7 +4,7 @@ title: "standalone Reflect: receiver arg silently dropped, deleteProperty ignore
 status: in-progress
 sprint: 64
 created: 2026-06-10
-updated: 2026-06-17
+updated: 2026-06-21
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -195,3 +195,47 @@ Reflect dispatch block)
 - Extend `tests/issue-2046.test.ts` / `tests/issue-1905.test.ts` with
   numeric-key get, `Reflect.defineProperty` data+accessor desc, and
   `Reflect.getOwnPropertyDescriptor` round-trip.
+
+## S5 slice landed — getOwnPropertyDescriptor + PR-D confirmation (2026-06-21)
+
+PROBE-VERIFIED against current main HEAD (075d90ee5) before any change:
+
+- **PR-D (numeric-key `Reflect.get`) — already fixed, no code change.** `#2042
+  S1`'s `__to_property_key` hardening landed, so `Reflect.get(o, 1)` returns
+  `o["1"]` (probe: `=> 42`) instead of trapping on the `ref.cast $AnyString` in
+  `__obj_hash`. Closed PR-D; pinned with a regression test.
+- **`Reflect.getOwnPropertyDescriptor` — was still refused; now routed.** The
+  native `__getOwnPropertyDescriptor` (registered in `OBJECT_RUNTIME_HELPER_NAMES`)
+  is now reachable end-to-end under standalone — verified independently via
+  `Object.getOwnPropertyDescriptor` (value/writable/missing all correct). The
+  stale registration comment near it (claiming "not reached end-to-end") predates
+  #2042's read-side wiring.
+
+**Change** (`src/codegen/expressions/calls.ts`, inside the `if (ctx.standalone)`
+Reflect dispatch block, after the `ownKeys` arm): replaced the
+`getOwnPropertyDescriptor` refusal with a route to the native
+`__getOwnPropertyDescriptor`, returning the descriptor `$Object` (or `undefined`
+for a missing own prop). §26.1.7 step 1 (non-object target → TypeError) is
+enforced at the CALL SITE with the same `ref.test $Object`-guard /
+`emitThrowTypeError` pattern PR-A introduced for `deleteProperty` — the shared
+native (which returns `undefined` for non-`$Object` receivers, correct for the
+`Object.*` caller) is untouched. ToPropertyKey on the key is handled inside the
+native via `__to_property_key`, so numeric keys work.
+
+New tests in `tests/issue-2046.test.ts` (16/16 green; 1905 4/4 unchanged): gOPD
+data value, writable+enumerable+configurable flags, missing-prop→undefined,
+numeric-key coercion, non-object→TypeError, and the PR-D numeric-key get pin.
+
+**Still refused (out of this PR, issue stays `in-progress`):**
+- **`Reflect.defineProperty`** — blocked on the write-side native
+  `__defineProperty_desc` (generic `{value|get|set, writable?, …}` descriptor),
+  which is deferred to **#2043** (see the NOTE near `__getOwnPropertyDescriptor`'s
+  registration in `object-runtime.ts`). Route it the moment that native lands;
+  remember the Reflect path returns `false` on a rejected define rather than
+  throwing.
+- **`Reflect.construct`** (152 rows, the big one) — gated on the standalone
+  construct machinery (coordinate with the #2158 class/construct owner). 2-arg
+  form → standalone `new X(...)` path; 3-arg `newTarget` form refuses loudly.
+- **PR-C (real receiver plumbing)** — senior/deferred, coordinates with #1888
+  Slice 5 accessor invocation; the explicit-receiver get/set refusal stays correct
+  meanwhile.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -6342,6 +6342,75 @@ function compileCallExpression(
           }
           return fallbackReturn(1, "extern-null");
         }
+
+        if (reflectMethod === "getOwnPropertyDescriptor" && expr.arguments.length >= 2) {
+          // (#2046 S5) Route to the native __getOwnPropertyDescriptor, the same
+          // helper backing standalone Object.getOwnPropertyDescriptor. It reads
+          // the $PropEntry back into a descriptor `$Object` (data → { value,
+          // writable, enumerable, configurable }, accessor → { get, set,
+          // enumerable, configurable }) and returns `undefined` for a missing own
+          // property — §26.1.7 step 3 (FromPropertyDescriptor over
+          // [[GetOwnProperty]]). The key is coerced with ToPropertyKey inside the
+          // native via __to_property_key (#2042 S1), so numeric keys work.
+          //
+          // §26.1.7 step 1 requires a TypeError when the target is not an Object.
+          // The native returns `undefined` for a non-$Object receiver (correct
+          // for Object.getOwnPropertyDescriptor, which forwards a coerced
+          // primitive wrapper), so — exactly as the deleteProperty PR-A guard —
+          // gate at the CALL SITE with a `ref.test $Object` and throw a catchable
+          // TypeError instead. The shared native is untouched.
+          const ort = ensureObjectRuntime(ctx);
+          const targetLocal = allocTempLocal(fctx, externRef);
+          {
+            const tArg = expr.arguments[0];
+            if (tArg !== undefined) {
+              const tTy = compileExpression(ctx, fctx, tArg, externRef);
+              if (tTy && tTy.kind !== "externref") coerceType(ctx, fctx, tTy, externRef);
+              else if (tTy === null) fctx.body.push({ op: "ref.null.extern" });
+            } else {
+              fctx.body.push({ op: "ref.null.extern" });
+            }
+          }
+          fctx.body.push({ op: "local.set", index: targetLocal });
+          // Pre-register the TypeError throw BEFORE the nested `if` so the splice
+          // that captures its instrs cannot interleave a late-import index shift
+          // into the block (same hazard handled in the deleteProperty guard).
+          const throwInstrs: Instr[] = (() => {
+            const before = fctx.body.length;
+            emitThrowTypeError(ctx, fctx, "Reflect.getOwnPropertyDescriptor called on non-object");
+            return fctx.body.splice(before);
+          })();
+          // if !ref.test $Object(target) → throw TypeError
+          fctx.body.push({ op: "local.get", index: targetLocal });
+          fctx.body.push({ op: "any.convert_extern" } as Instr);
+          fctx.body.push({ op: "ref.test", typeIdx: ort.objectTypeIdx } as Instr);
+          fctx.body.push({ op: "i32.eqz" });
+          fctx.body.push({
+            op: "if",
+            blockType: { kind: "empty" },
+            then: throwInstrs,
+          } as Instr);
+          // target is an $Object — push [target, key] and read the descriptor.
+          fctx.body.push({ op: "local.get", index: targetLocal });
+          releaseTempLocal(fctx, targetLocal);
+          {
+            const kArg = expr.arguments[1];
+            if (kArg !== undefined) {
+              const kTy = compileExpression(ctx, fctx, kArg, externRef);
+              if (kTy && kTy.kind !== "externref") coerceType(ctx, fctx, kTy, externRef);
+              else if (kTy === null) fctx.body.push({ op: "ref.null.extern" });
+            } else {
+              fctx.body.push({ op: "ref.null.extern" });
+            }
+          }
+          const funcIdx = ensureLateImport(ctx, "__getOwnPropertyDescriptor", [externRef, externRef], [externRef]);
+          flushLateImportShifts(ctx, fctx);
+          if (funcIdx !== undefined) {
+            fctx.body.push({ op: "call", funcIdx });
+            return { kind: "externref" };
+          }
+          return fallbackReturn(0, "extern-null");
+        }
         // Boolean-returning methods need an i32 on the stack; the rest return
         // externref. Pick the fallback shape per method so the surrounding
         // expression still type-checks even though the module is already marked

--- a/tests/issue-2046.test.ts
+++ b/tests/issue-2046.test.ts
@@ -153,4 +153,71 @@ describe("#2046 standalone Reflect spec gaps", () => {
       }`),
     ).toBe(1);
   });
+
+  // ── S5: Reflect.getOwnPropertyDescriptor → native __getOwnPropertyDescriptor ──
+  // §26.1.7 — routes the (target, key) pair to the same native that backs
+  // standalone Object.getOwnPropertyDescriptor, restoring a data-descriptor
+  // `$Object`. Replaces the #1472 Phase C refusal.
+  it("Reflect.getOwnPropertyDescriptor reads back the data value", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const o: any = { x: 7 };
+        const d: any = Reflect.getOwnPropertyDescriptor(o, "x");
+        return d.value as number;
+      }`),
+    ).toBe(7);
+  });
+
+  it("Reflect.getOwnPropertyDescriptor reports writable/enumerable/configurable for a plain data prop", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const o: any = { x: 7 };
+        const d: any = Reflect.getOwnPropertyDescriptor(o, "x");
+        const w = d.writable ? 1 : 0;
+        const e = d.enumerable ? 2 : 0;
+        const c = d.configurable ? 4 : 0;
+        return w + e + c; // expect 7 — all true for a literal data property
+      }`),
+    ).toBe(7);
+  });
+
+  it("Reflect.getOwnPropertyDescriptor returns undefined for a missing own property", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const o: any = { x: 7 };
+        const d: any = Reflect.getOwnPropertyDescriptor(o, "y");
+        return d === undefined ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("Reflect.getOwnPropertyDescriptor coerces a numeric key via ToPropertyKey (§7.1.19)", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const o: any = { "1": 5 };
+        const d: any = Reflect.getOwnPropertyDescriptor(o, 1);
+        return d.value as number;
+      }`),
+    ).toBe(5);
+  });
+
+  it("Reflect.getOwnPropertyDescriptor throws a TypeError on a non-object target (§26.1.7)", async () => {
+    await expectThrows(`export function test(): number {
+      const p: any = 5;
+      Reflect.getOwnPropertyDescriptor(p, "x");
+      return 0;
+    }`);
+  });
+
+  // PR-D (numeric-key Reflect.get) is now subsumed by #2042 S1's __to_property_key
+  // hardening — Reflect.get(o, 1) coerces the key to "1" instead of trapping on
+  // the ref.cast $AnyString in __obj_hash. Regression-pin it here.
+  it("Reflect.get coerces a numeric key via ToPropertyKey instead of trapping (PR-D / #2042 S1)", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const o: any = { "1": 42 };
+        return Reflect.get(o, 1) as number;
+      }`),
+    ).toBe(42);
+  });
 });


### PR DESCRIPTION
## #2046 S5 — route `Reflect.getOwnPropertyDescriptor` to the native helper

Replaces the `#1472` Phase C refusal for `Reflect.getOwnPropertyDescriptor`
under `--target standalone` with a route to the native
`__getOwnPropertyDescriptor` — the same helper that already backs standalone
`Object.getOwnPropertyDescriptor`. Returns the descriptor `$Object` (data →
`{ value, writable, enumerable, configurable }`) or `undefined` for a missing
own property.

### Spec (§26.1.7 Reflect.getOwnPropertyDescriptor)
- **Step 1** — non-object target → catchable `TypeError`, enforced at the
  CALL SITE via the same `ref.test $Object` guard + `emitThrowTypeError`
  pattern PR-A introduced for `deleteProperty`. The shared native (which
  returns `undefined` for a non-`$Object` receiver — correct for the
  `Object.*` caller) is left untouched.
- **ToPropertyKey** on the key is handled inside the native via
  `__to_property_key` (#2042 S1), so numeric keys (`Reflect.getOwnPropertyDescriptor(o, 1)`)
  work.

### PR-D (numeric-key `Reflect.get`) — confirmed already fixed
`#2042 S1`'s `__to_property_key` hardening landed, so `Reflect.get(o, 1)`
returns `o["1"]` instead of trapping on the `ref.cast $AnyString` in
`__obj_hash`. No code change needed — pinned with a regression test.

### Still refused (issue stays `in-progress`)
- **`Reflect.defineProperty`** — blocked on the write-side native
  `__defineProperty_desc` (deferred to **#2043**).
- **`Reflect.construct`** — gated on standalone construct machinery (**#2158**).
- **PR-C (real receiver plumbing)** — senior/deferred (#1888 Slice 5).

### Tests
- `tests/issue-2046.test.ts` — 16/16 (6 new: gOPD value, writable+enumerable+configurable
  flags, missing→undefined, numeric-key coercion, non-object→TypeError, PR-D get pin).
- `tests/issue-1905.test.ts` — 4/4 unchanged.
- `tsc --noEmit` clean; prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)