### PR TITLE
docs(#2186,#2572): close #2186 (post-delete read fixed) — carve standalone for-in host-import leak to #2572

### DIFF
--- a/plan/issues/2186-standalone-delete-touched-object-representation-steering.md
+++ b/plan/issues/2186-standalone-delete-touched-object-representation-steering.md
@@ -1,10 +1,12 @@
 ---
 id: 2186
 title: "standalone: post-delete struct read returns stale value — steer delete-touched object literals to $Object"
-status: ready
+status: done
 sprint: 64
 created: 2026-06-17
-updated: 2026-06-17
+updated: 2026-06-21
+completed: 2026-06-21
+assignee: sd-5
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -12,8 +14,9 @@ task_type: bugfix
 area: codegen
 language_feature: object-literals
 goal: property-model
-related: [2179, 2130]
+related: [2179, 2130, 2542, 2572]
 origin: "2026-06-17 — A7 standalone half split out of #2179 (A6 JS-host landed)"
+resolution: "2026-06-21 reproduction (sd-5): the post-delete READ is already fixed on origin/main. `any`/dynamic and index-signature object literals — and even optional-field interface literals — lower to the tombstone-aware $Object representation (the #2542 dynamic-property work), whose FLAG_TOMBSTONE makes `delete o.a; o.a===undefined` → true with NO host import. The A7 struct→$Object representation-steering this issue proposed turned out unnecessary (the literals already go to $Object). All acceptance criteria pass standalone EXCEPT `for (const k in o)`, which fails only because statement-form for-in leaks env.__for_in_* host imports — a general for-in-over-$Object gap, not delete-specific — carved to #2572. Closing #2186 done (read core fixed); #2572 owns the for-in leak."
 ---
 
 # #2186 — standalone post-delete read: $Object representation steering
@@ -67,7 +70,42 @@ keys paths then go through the existing `$Object` ops.
 - Non-delete-touched object literals keep their WasmGC struct lowering (no
   perf/representation change); JS-host behavior (#2179) unregressed.
 
+## Reproduction (sd-5, 2026-06-21, origin/main @ d619ce2a9)
+
+Compiled with `target: "standalone"`, instantiated with `{}`, validated. The
+post-delete read is **already fixed** — these all return the spec-correct value:
+
+| Case | Result | Expected |
+| --- | --- | --- |
+| `const o:any={a:1,b:2}; delete o.a; o.a===undefined` | `true` | true ✔ |
+| `delete o.a; (o.a as number)` | undefined/falsy (not stale `1`) | undefined ✔ |
+| `delete o.a; o.a=5; o.a===5` | `true` | true ✔ |
+| `delete o.a; "a" in o` | `false` | false ✔ |
+| `delete o.a; o.b===2` | `true` | true ✔ |
+| `const k="a"; delete o[k]; o.a===undefined` (computed) | `true` | true ✔ |
+| `Object.keys(o)` after delete → `["b"]` | len 1, `"b"` | ✔ |
+| `interface O{a?:number;b:number}` optional-field delete | `true` | true ✔ |
+| `{[k:string]:number}` index-sig delete | `true` | true ✔ |
+
+**Why the A7 steering wasn't needed:** the issue assumed delete-touched literals
+stay WasmGC structs (stale `struct.get`). In fact `any` / index-signature /
+optional-field literals already lower to the dynamic `$Object` representation
+(the #2542 dynamic-property landing), and `$Object` carries `FLAG_TOMBSTONE`, so
+`delete` + read is spec-correct with no host import and no struct→$Object
+steering pass. `ctx.moduleUsesDelete` is consumed only at
+`property-access.ts:1862`, which is gated OFF for standalone — confirming no
+standalone delete-aware read path runs, yet the result is correct because the
+representation is already `$Object`.
+
+**The one failing acceptance line → #2572:** `for (const k in o)` fails in
+standalone — but because **statement-form for-in leaks `env.__for_in_*` host
+imports** (validates, can't instantiate), independent of `delete`
+(`for-in` over a plain `{a,b}` with no delete leaks identically; `Object.keys`
+does not). Root cause: `declarations.ts:1438` registers the for-in host imports
+with no standalone guard. Carved to **#2572** with the full fix direction.
+
 ## Notes
 
 Split from #2179 (A6 JS-host read-path fix is `done`). See #2179's
-`## Resolution` and #2130's architect addendum A7.
+`## Resolution` and #2130's architect addendum A7. Read core fixed by #2542;
+for-in leak tracked by #2572.

--- a/plan/issues/2572-standalone-forin-object-hostimport-leak.md
+++ b/plan/issues/2572-standalone-forin-object-hostimport-leak.md
@@ -1,0 +1,97 @@
+---
+id: 2572
+title: "standalone: statement-form for-in over a dynamic object leaks env.__for_in_* host imports (no native $ObjVec walk)"
+status: ready
+sprint: Backlog
+created: 2026-06-21
+updated: 2026-06-21
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: bugfix
+area: codegen, runtime
+language_feature: for-in, objects
+goal: standalone-mode
+related: [2186, 1472, 1837, 2066, 2542]
+test262_bucket: standalone-forin-hostimport-leak
+es_edition: es5
+origin: "Carved from #2186 (sd-5 reproduction, 2026-06-21). #2186's post-delete READ is already fixed (any/dynamic literals lower to tombstone-aware $Object); the only failing #2186 acceptance line is `for (const k in o)`, which fails because statement-form for-in leaks env.__for_in_* host imports in standalone — a general for-in-over-$Object gap, NOT delete-specific."
+---
+
+# #2572 — standalone for-in over a dynamic object: host-import leak
+
+## Problem
+
+`for (const k in o)` over a dynamic / `any`-typed (`$Object`) receiver compiles
+to a module that **validates** but **cannot instantiate** under
+`--target standalone` / WASI:
+
+```ts
+const o: any = { a: 1, b: 2 };
+let s = "";
+for (const k in o) s += k;   // standalone: imports env.__for_in_keys/_len/_get/_has
+```
+
+```
+WebAssembly.instantiate(): Import #0 "env": module is not an object or function
+```
+
+Imports leaked: `env.__for_in_keys`, `env.__for_in_len`, `env.__for_in_get`,
+`env.__for_in_has`. The leak is **independent of `delete`** — it fires for any
+dynamic-object for-in. `Object.keys(o)` over the same receiver is already
+host-free (native `$ObjVec` walk), so the enumeration primitive exists; only
+the statement-form for-in is not routed through it.
+
+## Root cause
+
+1. `src/codegen/declarations.ts:1438` registers the for-in host imports
+   **unconditionally**:
+   ```ts
+   if (state.forInFound) { addForInImports(ctx); }
+   ```
+   — with **no `!ctx.standalone && !ctx.wasi` guard**, unlike the array-iterator
+   registration 9 lines above (`:1429`). So in a no-JS-host target the
+   `__for_in_*` imports get registered, `ctx.funcMap.has("__for_in_keys")` is
+   true, and `compileForInStatement` takes the host path.
+2. `compileForInStatement` (`src/codegen/statements/loops.ts:4707-4742`) only
+   falls to its standalone branch when `keysIdx === undefined`. Because of (1)
+   that never happens in standalone, so the host calls are always emitted.
+3. The existing standalone fallback (`loops.ts:4712-4742`) is also **wrong for a
+   dynamic `$Object`**: it statically unrolls the **static type's**
+   `getProperties()`, which ignores runtime-added/deleted keys and tombstones.
+   A `$Object` whose keys change at runtime (delete/add) must enumerate its
+   **runtime** key vector, not the static shape.
+
+## Fix direction
+
+- Gate `addForInImports` at `declarations.ts:1438` behind
+  `!ctx.standalone && !ctx.wasi` (mirror `:1429`).
+- In `compileForInStatement`, when the receiver lowers to a `$Object` (dynamic
+  representation) under a no-JS-host target, emit a runtime walk over the same
+  `$ObjVec` key vector that standalone `Object.keys/values/entries` already use
+  (`src/codegen/object-runtime.ts`), honouring `FLAG_TOMBSTONE` (skip deleted)
+  and `FLAG_ENUMERABLE`, in OrdinaryOwnPropertyKeys insertion order (#1837), and
+  applying the per-visit liveness check (#2066) so a key deleted mid-loop is
+  skipped.
+- Keep the static-unroll path only for receivers whose shape is a **closed
+  WasmGC struct with no `delete` reachability** (where the static key set is
+  exact) — or drop it in favour of the runtime walk for uniformity.
+
+## Acceptance criteria
+
+- `const o:any={a:1,b:2}; for (const k in o) …` compiles to a standalone module
+  with **zero `env.__for_in_*` imports**, instantiates, and enumerates `a`,`b`.
+- After `delete o.a`, the standalone for-in omits `a` (already true for
+  `Object.keys`; bring statement-for-in to parity).
+- Runtime-added keys (`o.c = 3`) appear; insertion order preserved (#1837).
+- A key deleted during the loop body is skipped (#2066 parity).
+- JS-host for-in behaviour unchanged (no regression); no new host imports.
+- Closed-struct (non-dynamic) for-in keeps working.
+
+## Notes
+
+Carved from #2186, whose post-delete READ path is already fixed and is being
+closed `done` separately. This is the residual that blocked #2186's
+`for (const k in o)` acceptance line. Distinct from #1472 (general standalone
+object/property host-import elimination, `done`) which did not cover the
+`__for_in_*` family.


### PR DESCRIPTION
## Summary

Reproduction of **#2186** (task #17) on origin/main shows the post-delete **read** it targets is **already fixed**; files **#2572** for the one residual that remains.

## #2186 — post-delete read is fixed

`any` / index-signature / optional-field object literals already lower to the **tombstone-aware `$Object`** representation (the #2542 dynamic-property landing), whose `FLAG_TOMBSTONE` makes `delete o.a; o.a===undefined` → `true` with **no host import**. The proposed A7 struct→`$Object` representation-steering was never needed — the literals already go to `$Object`. (`ctx.moduleUsesDelete` is consumed only at `property-access.ts:1862`, gated OFF for standalone, yet the result is correct because the representation is dynamic.)

All #2186 acceptance criteria pass standalone (read, `=== undefined`, re-add, `in`, `Object.keys`, computed-key delete, optional-field, index-sig) **except** `for (const k in o)`.

## #2572 — the residual: standalone for-in host-import leak

`for (const k in o)` over a dynamic object leaks `env.__for_in_keys/_len/_get/_has` in standalone (validates, can't instantiate), **independent of `delete`** (`Object.keys` over the same receiver is host-free; the native `$ObjVec` enumeration primitive exists). Root cause: `declarations.ts:1438` registers the for-in host imports with **no standalone guard** (unlike the array-iterator registration 9 lines above), defeating the static-unroll fallback — which is itself wrong for a runtime-mutated `$Object`. #2572 has the full fix direction (route standalone for-in through the native `$ObjVec` key vector with `FLAG_TOMBSTONE` + #1837 order + #2066 per-visit liveness).

## Changes

- `plan/issues/2186-…md` → `status: done` with the reproduction table.
- New `plan/issues/2572-standalone-forin-object-hostimport-leak.md` (Backlog, hard).

No compiler change → no test262 movement, no hard-error risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)