### PR TITLE
fix(#983d): dual-path dynamic dispatch for obj.<field>() host-method calls

### DIFF
--- a/plan/issues/2573-missing-property-read-returns-null-not-undefined-plain-object.md
+++ b/plan/issues/2573-missing-property-read-returns-null-not-undefined-plain-object.md
@@ -1,0 +1,66 @@
+---
+id: 2573
+title: "Reading a missing property on a plain `{}` object returns null, not undefined"
+status: ready
+created: 2026-06-21
+priority: medium
+feasibility: medium
+goal: test262-conformance
+parent: 983d
+test262_fail: 8
+---
+# #2573 — Missing-property read on a plain object yields `null` not `undefined`
+
+## Problem
+
+Reading an own property that does not exist on a plain object literal
+(`var obj = {}; obj.length`) returns JS `null` (`typeof === "object"`) where the
+spec requires `undefined` (§10.1.8 OrdinaryGet → returns `undefined` for a
+missing property).
+
+```js
+var obj = {};
+obj.length;   // expected: undefined ; actual: null
+```
+
+## How it surfaced (#983d residual)
+
+After #983d landed the dual-path dispatch for `obj.<field>()` host-method calls
+(`var o = {}; o.pop = Array.prototype.pop; o.pop()` now actually runs), the
+generic-Array-method-on-plain-object test262 cluster went 0 → 11/19. The
+remaining 8 fail at a **later** assertion — `obj.length === undefined` — because
+the missing-`length` read returns `null`:
+
+```
+S15.4.4.5_A2_T1.js  #2: ... obj.join(); obj.length === undefined.  Actual: null
+S15.4.4.7_A2_T1.js  #4: ... obj.push(...); ...
+S15.4.4.8_A2_T{1,2,3}.js, S15.4.4.13_A{2_T1,3_T2}.js, S15.4.4.7_A4_T3.js
+```
+
+Probe (`var obj={}; var b=obj.length; ... b===null, typeof==="object"`) confirms
+the read is `null`, independent of any method call — it is a **property-read**
+bug, not a method-dispatch or write-back bug.
+
+## Root cause (to confirm)
+
+`obj.length` on a `{}` struct lowers to a `struct.get` against a struct shape
+that has no `length` field (or reads field 0 of the wrong shape), and the
+missing-field path coerces to `ref.null.extern` (→ JS `null`) instead of the
+host `undefined`. The fix is to make the missing-own-property read on a
+plain-object struct yield `undefined` (e.g. `__get_undefined` / the
+externref-undefined representation), not a null externref. Audit the
+property-access codegen for plain-object structs (`src/codegen/property-access.ts`
+/ the member-read path in `expressions`) and the `__sget_`/`__extern_get`
+missing-field return.
+
+## Acceptance
+
+- `var obj = {}; obj.missing === undefined` (typeof `"undefined"`).
+- The 8 residual `…/S15.4.4.*` generic-method-on-plain-object fails flip to pass.
+- No regression in property reads that legitimately return `null`.
+
+## Notes
+
+Carved from #983d by sd-4 on 2026-06-21. Orthogonal to the dual-path dispatch
+fix that #983d delivered (the method now runs correctly; this is the missing
+sibling property read returning the wrong nullish value).

--- a/plan/issues/983d-live-mirror-writeback-via-sset-struct-setters.md
+++ b/plan/issues/983d-live-mirror-writeback-via-sset-struct-setters.md
@@ -1,8 +1,9 @@
 ---
 id: 983d
 title: "Live-mirror write-back: host mutations to a WasmGC struct's proxy sidecar never reach the struct field (~11 Array.prototype.*.call fails)"
-status: suspended
+status: done
 assignee: sd-4
+completed: 2026-06-21
 created: 2026-05-27
 updated: 2026-06-21
 priority: medium
@@ -184,17 +185,37 @@ branch (b) is missing — the call silently nulls.
    regressions in `this.callback()` callable-property calls and object-literal
    method calls (the same CPC / call-dispatch code).
 
-## Suspended Work
+## Resolution (sd-4, 2026-06-21) — dual-path dispatch landed, cluster 0 → 11/19
 
-- **Status:** `suspended` (was `in-progress`). sd-4 scoped + root-caused the
-  framing (Findings 1 & 2 above) but did not implement — the real fix needs
-  the dispatch-path pin (Finding 2) which needs fresh-context investigation.
-- **Branch / worktree:** `issue-983d-live-mirror-writeback` at
-  `/workspace/.claude/worktrees/issue-983d-live-mirror-writeback` (branched
-  from origin/main `075d90ee5`; only this issue-doc edit committed, no code
-  changes).
-- **Resume steps:** re-enter the worktree, start from "Suggested next-agent
-  plan" step 1. The repro file is trivial:
-  `var obj = {}; obj.pop = Array.prototype.pop; var r = obj.pop();` — assert
-  `r === undefined` (currently fails: `r === null`). Cluster = 19 fails,
-  grep the baseline for `var obj = \{\}; obj\.`.
+Implemented the fix from Finding 2's plan. The exact handler that dropped
+`obj.pop()` to null was the **graceful-null fallback** in
+`compileCallExpression` (`src/codegen/expressions/calls.ts`, the
+`compile callee → drop → ref.null.extern` block just before
+`compileConditionalCallee`). `obj.method()` where `method` is a host function
+value in a struct field fell past every static/struct handler and hit it.
+
+**Change:** before the graceful-null fallback, when the callee is a
+non-optional property access `obj.method` and we are in JS-host mode, route to
+`emitWrapperDynamicMethodCall(ctx, fctx, receiver, methodName, callExpr)` —
+which emits `__extern_method_call(receiver, "method", argsArray)` with the
+live-mirror `_wrapForHost` proxy as `this`. Syntactic gate only (no
+static-classification of the receiver, per #2501). ~20 LOC, additive, behind the
+fallback so nothing that already resolved is affected.
+
+**Result:** the generic-Array-method-on-plain-object cluster (`var o = {};
+o.m = Array.prototype.m; o.m()`) went **0 → 11/19** pass. The host now runs the
+generic method against the proxy, so the return value is correct AND mutations
+round-trip through the proxy's `set` trap → `_safeSet` → `__sset_<field>`
+(Finding 1: those setters already exist and `_safeSet` already wires them).
+
+Validation: 0 regressions (focused proxy/object-method sweep 7/7; 180-file
+isolated regression sample all pass — the batch-run `new Ctor` crash is a
+known multi-test-in-one-process state-pollution artifact present on base too,
+not a per-test regression; CI shards isolate); hard-error gate OK; new test
+`tests/issue-983d-generic-method-call.test.ts`.
+
+**Residual carved to #2573:** the remaining 8 fail at a *later* assertion
+`obj.length === undefined` — a **separate property-read bug** (reading a missing
+property on a plain `{}` object returns `null`, not `undefined`), orthogonal to
+this method-dispatch fix. See
+`plan/issues/2573-missing-property-read-returns-null-not-undefined-plain-object.md`.

--- a/plan/issues/983d-live-mirror-writeback-via-sset-struct-setters.md
+++ b/plan/issues/983d-live-mirror-writeback-via-sset-struct-setters.md
@@ -1,9 +1,10 @@
 ---
 id: 983d
 title: "Live-mirror write-back: host mutations to a WasmGC struct's proxy sidecar never reach the struct field (~11 Array.prototype.*.call fails)"
-status: ready
+status: suspended
+assignee: sd-4
 created: 2026-05-27
-updated: 2026-05-27
+updated: 2026-06-21
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -84,3 +85,116 @@ that Wasm subsequently re-reads.
   proxy trap + boundary coercion, and the indexed-store path for Arrays.
 - Overlaps the descriptor/struct-target-writeback design in #1630/#1631 —
   coordinate so both share one struct-setter export mechanism rather than two.
+
+## 2026-06-21 sd-4 investigation — cluster bounded + two findings that revise the framing
+
+Reproduced on origin/main (`075d90ee5`). The concrete, coherent slice is the
+**generic-Array-method-on-plain-object** cluster — **19 official fails** of the
+shape `var obj = {}; obj.m = Array.prototype.m; obj.m()`:
+
+```
+pop/{S15.4.4.6_A2_T1,S15.4.4.6_A3_T1,S15.4.4.6_A3_T2}, push/{A2_T1,A4_T1},
+shift/{A2_T1,A3_T3}, unshift/A3_T2, reverse/{A2_T1,A2_T2,A2_T3,A3_T3},
+sort/A4_T3, join/{A2_T1,A4_T3}, …  (19 total; grep error text
+"var obj = \{\}; obj.<method>" in the baseline jsonl)
+```
+
+The minimal repro (`var obj = {}; obj.pop = Array.prototype.pop; obj.pop()`)
+returns **JS `null`** (`typeof === "object"`) where the spec mandates
+**`undefined`** — that is the first assertion every one of these tests trips on
+(before they even check mutation-observability).
+
+### Finding 1 — `__sset_<field>` setters ALREADY exist (issue framing is partly stale)
+
+The issue's root-cause ("there is a `__sget_` export but **no `__sset_`**
+setter export") is **no longer true** on current main. Compiling
+`obj.pop = Array.prototype.pop; obj.pop()` emits BOTH `__sget_pop` (func 7,
+exported) AND **`__sset_pop`** (func 9, exported) — the struct-setter codegen
+half already landed. So the "emit `__sset_<field>` setters" step (Fix sketch
+#1) appears done for named fields; the remaining gap is narrower than the
+issue implies. (Indexed `data`-vec element-store, Fix sketch #4, still needs
+verification.)
+
+### Finding 2 — the call is a CODEGEN dispatch gap, NOT a host write-back / boundary bug. `obj.pop()` is compiled to **drop-the-method + push null** (the call is never emitted)
+
+This is the decisive finding and it **revises the whole issue framing**. The
+failure is NOT in the host runtime at all. Dumping the runner-wrapped WAT for
+`var obj = {}; obj.pop = Array.prototype.pop; var r = obj.pop();` shows the
+import table has **no `__extern_method_call`** (confirmed: instrumenting
+`src/runtime.ts:8439` never fires), and `$test` compiles `obj.pop()` to:
+
+```wasm
+local.get $obj
+struct.get $__anon_0 0     ;; read the `pop` field (the method value)
+drop                       ;; <-- the method value is DROPPED
+ref.null extern            ;; <-- r is set to null (the call is NEVER emitted)
+local.set $r
+```
+
+So `r === null` (typeof "object"), not `undefined`, and no Array.prototype.pop
+ever runs — hence the leading assertion `obj.pop() === undefined` fails, and
+the later mutation-observability assertions can never pass either (nothing
+mutated `obj`).
+
+**Why:** `obj` is a plain object literal `{}` → an anonymous WasmGC struct
+(`$__anon_0` with field `pop: externref`). `obj.pop = Array.prototype.pop`
+stores the **host function value** into the `pop` field (externref). `obj.pop()`
+is a call where the callee is a struct-field externref holding a HOST function
+(no wasm impl).
+
+The intended handler is `compileCallablePropertyCall`
+(`src/codegen/expressions/calls-closures.ts:449`) — but instrumenting it shows
+it is **NEVER reached** for this case (the `[CPC]` log never prints). Some
+earlier branch in `compileCallExpression`
+(`src/codegen/expressions/calls.ts:2708`) claims the call, reads the field,
+drops it, and emits `ref.null.extern`. Even if CPC *were* reached, its
+externref-field branch (calls-closures.ts:618) assumes the field holds a
+**wasm closure struct** and does `any.convert_extern` + `emitGuardedRefCast`
+to a wasm wrapper struct — which would null out for a host function anyway
+(a `Array.prototype.pop` externref is not a wasm `__fn_wrap_*` struct).
+
+**The real fix** is a dual-path dispatch for `obj.<field>()` when `<field>` is
+an externref method value: (a) if it ref.tests as a wasm closure wrapper →
+`call_ref` (existing path); (b) **else** → route to the host method bridge
+`__extern_method_call(receiver, "<field>", args)` (runtime.ts:8439), which runs
+the host function with the live-mirror `_wrapForHost` proxy as `this`. Today
+branch (b) is missing — the call silently nulls.
+
+### Suggested next-agent plan
+
+1. **Pin the exact handler** in `compileCallExpression`
+   (`src/codegen/expressions/calls.ts:2708`) that claims `obj.pop()` and emits
+   `struct.get; drop; ref.null.extern`. Instrument the branch returns (the
+   receiver-is-struct block around calls.ts:8163 calls CPC, but CPC isn't
+   reached — so an EARLIER branch wins; find it). Likely a "field exists but no
+   wasm method / not a known closure → undefined" fast path.
+2. **Add the host-bridge fallback (branch b above).** When the callee is a
+   struct-field externref that is NOT a wasm closure wrapper at runtime, emit
+   `__extern_method_call(receiver, methodName, argsArray)` instead of nulling.
+   This reuses the exact host bridge generic `Array.prototype.<m>.call`
+   patterns already use, with the live-mirror proxy receiver — so the host runs
+   `Array.prototype.pop` against the proxy and BOTH the return value AND the
+   mutation (via the proxy's set-trap → `__sset_`) round-trip. This single
+   change likely fixes most of the 19 (return value + observability together).
+3. Verify the proxy `set` trap actually calls `__sset_<field>` (Finding 1 — the
+   setters exist; confirm the trap is wired to them, not just the sidecar). If
+   the trap only writes the sidecar, wire it to `__sset_` so the post-mutation
+   `obj.length === 0` / element reads observe the change.
+4. Re-bucket: 19 generic-method-on-plain-object fails is the target; watch for
+   regressions in `this.callback()` callable-property calls and object-literal
+   method calls (the same CPC / call-dispatch code).
+
+## Suspended Work
+
+- **Status:** `suspended` (was `in-progress`). sd-4 scoped + root-caused the
+  framing (Findings 1 & 2 above) but did not implement — the real fix needs
+  the dispatch-path pin (Finding 2) which needs fresh-context investigation.
+- **Branch / worktree:** `issue-983d-live-mirror-writeback` at
+  `/workspace/.claude/worktrees/issue-983d-live-mirror-writeback` (branched
+  from origin/main `075d90ee5`; only this issue-doc edit committed, no code
+  changes).
+- **Resume steps:** re-enter the worktree, start from "Suggested next-agent
+  plan" step 1. The repro file is trivial:
+  `var obj = {}; obj.pop = Array.prototype.pop; var r = obj.pop();` — assert
+  `r === undefined` (currently fails: `r === null`). Cluster = 19 fails,
+  grep the baseline for `var obj = \{\}; obj\.`.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -12930,6 +12930,41 @@ function compileCallExpression(
     }
   }
 
+  // (#983d) Dynamic method call on a host/externref object before the graceful
+  // null fallback. A call `obj.method(args)` whose `method` is a *host function
+  // value* stored in `obj` (e.g. `var o = {}; o.pop = Array.prototype.pop;
+  // o.pop()`) falls past every static/struct-method handler above — there is no
+  // wasm impl to dispatch and `compileCallablePropertyCall` only matches wasm
+  // closures. The legacy behaviour (the fallback below) drops the method and
+  // returns `ref.null.extern`, so the call is never made: `o.pop()` yields
+  // `null` instead of `undefined`, and any mutation the method would perform on
+  // `o` never happens.
+  //
+  // Route it to `__extern_method_call(receiver, "method", argsArray)` instead,
+  // which runs the host function with the live-mirror `_wrapForHost` proxy as
+  // `this`. That gives BOTH the correct return value AND mutation
+  // observability: the proxy's get/set traps read/write the WasmGC struct
+  // fields (the `__sget_`/`__sset_` exports), so subsequent wasm reads of `o`
+  // observe the change. JS-host mode only — standalone has no
+  // `__extern_method_call` host function, so it falls through to the graceful
+  // null below (a Wasm-native dynamic dispatch is a separate follow-up).
+  //
+  // Syntactic gate only (never static-classify the receiver — a possibly-proxy
+  // value carries no TS-type brand, #2501): the callee is a non-optional
+  // property access with an identifier method name, and we are in host mode.
+  if (
+    !ctx.standalone &&
+    !ctx.wasi &&
+    ts.isPropertyAccessExpression(expr.expression) &&
+    !ts.isPrivateIdentifier(expr.expression.name) &&
+    !expr.questionDotToken &&
+    !ts.isOptionalChain(expr)
+  ) {
+    const propAccess = expr.expression;
+    const dyn = emitWrapperDynamicMethodCall(ctx, fctx, propAccess.expression, propAccess.name.text, expr);
+    if (dyn !== null) return dyn;
+  }
+
   // Graceful fallback: compile the callee expression and all arguments for side effects,
   // then push ref.null.extern. This avoids hard compile errors for unrecognized call patterns
   // (e.g. chained calls, dynamic dispatch, uncommon AST shapes).

--- a/tests/issue-983d-generic-method-call.test.ts
+++ b/tests/issue-983d-generic-method-call.test.ts
@@ -1,0 +1,37 @@
+import { existsSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { runTest262File } from "./test262-runner.js";
+
+// #983d — A call `obj.method(args)` where `method` is a HOST function value
+// stored in `obj` (the generic-Array-method-on-plain-object pattern
+// `var o = {}; o.pop = Array.prototype.pop; o.pop()`) used to fall past every
+// static / struct-method handler and hit the graceful-null fallback in
+// `compileCallExpression`, which DROPPED the method and returned
+// `ref.null.extern` — so the call was never made: `o.pop()` yielded `null`
+// instead of `undefined`, and any mutation the method would perform on `o`
+// never happened.
+//
+// The fix routes such calls to `__extern_method_call(receiver, method, args)`
+// (the live-mirror host bridge) before the fallback, so the host runs the
+// generic Array method with the `_wrapForHost` proxy as `this` — giving the
+// correct return value AND mutation observability.
+//
+// These test262 entries went 0 → pass with the dual-path dispatch (the residual
+// `obj.length === undefined` assertions in the longer variants are a separate
+// missing-field→null property-read bug, tracked separately).
+describe("#983d generic Array-method-on-plain-object dispatch", () => {
+  const TEST262 = "/workspace/test262/test";
+  const cases = [
+    "built-ins/Array/prototype/pop/S15.4.4.6_A2_T1.js",
+    "built-ins/Array/prototype/pop/S15.4.4.6_A3_T1.js",
+    "built-ins/Array/prototype/shift/S15.4.4.9_A2_T1.js",
+  ];
+  for (const rel of cases) {
+    const abs = `${TEST262}/${rel}`;
+    const name = rel.split("/").slice(-2).join("/");
+    (existsSync(abs) ? it : it.skip)(`test262: ${name} passes (was null-drop)`, async () => {
+      const r = await runTest262File(abs, rel.split("/").slice(0, 2).join("/"));
+      expect(r.status).toBe("pass");
+    });
+  }
+});


### PR DESCRIPTION
## #983d — dual-path dynamic dispatch for `obj.<field>()` host-method calls

Fixes the generic-Array-method-on-plain-object cluster (`var o = {}; o.pop =
Array.prototype.pop; o.pop()`): **0 → 11/19** test262 entries flip to pass.

### Root cause (revised from the issue's original framing)

The issue was filed as a "missing `__sset_` host write-back" build, but that
framing is stale — the `__sset_<field>` setters already exist and `_safeSet`
already wires them. The actual bug is a **codegen dispatch gap**:

`obj.method(args)` where `method` is a **host function value** stored in `obj`
(no wasm impl) falls past every static / struct-method handler and hits the
**graceful-null fallback** in `compileCallExpression`, which compiles the callee
property-access, **drops** the resulting method value, and pushes
`ref.null.extern`. So the call is never made — `o.pop()` yields `null` instead
of `undefined`, and any mutation the method would perform on `o` never happens.

### Fix

Before the graceful-null fallback, when the callee is a non-optional property
access `obj.method` and we are in JS-host mode, route to
`emitWrapperDynamicMethodCall` → `__extern_method_call(receiver, "method",
argsArray)`. The host runs the generic method with the live-mirror
`_wrapForHost` proxy as `this`, so BOTH the return value AND mutation
observability round-trip (the proxy's `set` trap → `_safeSet` → `__sset_`).

- Syntactic gate only — never static-classify the receiver (a possibly-proxy
  value carries no TS-type brand, #2501).
- JS-host mode only; standalone falls through to the graceful null (a
  Wasm-native dynamic dispatch is a separate follow-up).
- ~20 LOC, additive, behind the fallback — nothing that already resolved is
  affected.

### Validation

- Cluster **0 → 11/19** pass.
- **0 regressions**: focused proxy/object-method sweep 7/7 (Proxy get/set, Array
  HOF, Object.keys, eval-call); 180-file isolated regression sample all pass
  (the batch-run `new Ctor` crash is a known multi-test-in-one-process
  state-pollution artifact present on base too, not a per-test regression — CI
  shards isolate). Hard-error gate OK. Typecheck clean.
- New test: `tests/issue-983d-generic-method-call.test.ts`.

### Residual carved to #2573

The remaining 8 fail at a *later* assertion `obj.length === undefined` — a
**separate property-read bug** (reading a missing property on a plain `{}`
object returns `null`, not `undefined`), orthogonal to this method-dispatch fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
