### PR TITLE
fix(#2187): string method/.length by local ValType for any-typed native-string locals

### DIFF
--- a/plan/issues/2187-any-typed-local-string-method-dispatch-by-valtype.md
+++ b/plan/issues/2187-any-typed-local-string-method-dispatch-by-valtype.md
@@ -1,10 +1,12 @@
 ---
 id: 2187
 title: "standalone: string methods on an any-typed local with a native-string ValType take the generic externref path (v.length → 0)"
-status: ready
+status: done
+assignee: ttraenkler/sd-3
 sprint: 64
 created: 2026-06-17
-updated: 2026-06-17
+updated: 2026-06-21
+completed: 2026-06-21
 priority: low
 feasibility: hard
 reasoning_effort: high
@@ -73,3 +75,34 @@ dispatch sites.
 Split from #2171 (string-yield generators, SF-4 of #2157 — landed in
 `c3eb18936`). #2171's own acceptance (iterate + concat) is met; this is the
 per-element string-method residual.
+
+## Implementation (sd-3, 2026-06-21)
+
+Added `receiverIsNativeStringValType(ctx, fctx, recv)` in `property-access.ts`
+(mirrors the #2192 `receiverIsCaughtErrorStringRead` TS-type-vs-ValType pattern):
+true when the receiver is a bare identifier whose TS type is `any`/`unknown` but
+whose compiled local/param **ValType is the native string ref**
+(`anyStrTypeIdx`/`nativeStrTypeIdx`), standalone/WASI only. Wired it into the
+two dispatch gates the static `isStringType` check missed:
+1. `compilePropertyAccess` — an EARLY `.length` arm (before the Function/vec
+   `.length` arms, which else fall through to `__extern_length`→0) reads `len`
+   (field 0 of `$AnyString`) natively.
+2. `expressions/calls.ts` string-method gate (`||` next to the existing
+   `isStringType` / caught-error checks) → routes `v.charCodeAt(0)` etc. to
+   `compileNativeStringMethodCall`.
+
+Validated: the headline `for (const v of g()) n += v.length` + `v.charCodeAt(0)`
+(single-yield string generator, the #2171 origin) now pass; 9 scoped tests
+(`tests/issue-2187.test.ts`) green; no regression on typed `string`/literal
+receivers, numeric generators, or arrays (the 144-test string suite passes; the
+one `string-methods.test.ts` collection error is a pre-existing missing-`helpers.js`
+worktree artifact, identical on origin/main). Hard-error + any-box gates clean.
+
+**Out of scope (deferred, #2072 value-rep family):** an `any` local assigned
+from a string METHOD (`const v: any = s.slice(1)`) gets an **externref** ValType
+(the method returns externref), not `$AnyString`, so the ValType is opaque and
+`v.length` still routes generically — this needs the broader externref-carries-a-
+string tracking, not the bare ValType check. The multi-yield generator
+(`yield "a"; yield "b"`) value-binding residual is a separate generator-state bug
+(#2040 territory), NOT the `.length`/method DISPATCH this issue fixes (the WAT
+shows the native `len` read fires correctly; the yielded value reaches `v` wrong).

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -85,6 +85,7 @@ import {
   emitArrayIsArrayExternrefPredicate,
   emitNullCheckThrow,
   receiverIsCaughtErrorStringRead,
+  receiverIsNativeStringValType,
   typeErrorThrowInstrs,
 } from "../property-access.js";
 import type { InnerResult } from "../shared.js";
@@ -8727,7 +8728,11 @@ function compileCallExpression(
     // isStringType gate alone misses it, so the call fell through to the host
     // `__extern_get`/dynamic path (null standalone). compileNativeStringMethodCall
     // compiles + flattens the receiver, which already yields a $AnyString ref.
-    if (isStringType(receiverType) || receiverIsCaughtErrorStringRead(ctx, propAccess.expression)) {
+    if (
+      isStringType(receiverType) ||
+      receiverIsCaughtErrorStringRead(ctx, propAccess.expression) ||
+      receiverIsNativeStringValType(ctx, fctx, propAccess.expression)
+    ) {
       const method = propAccess.name.text;
 
       // string.toString() and string.valueOf() — identity, just return the string itself.

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -20,7 +20,7 @@ import { emitBoundsCheckedArrayGet } from "./array-methods.js";
 import { classMemberFuncKey } from "./class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
 import { popBody, pushBody } from "./context/bodies.js";
 import { reportError, reportErrorNoNode } from "./context/errors.js";
-import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
+import { allocLocal, allocTempLocal, getLocalType, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { emitCachedMethodClosureAccess, emitFuncRefAsClosure, getOrCreateFuncRefWrapperTypes } from "./closures.js";
 import { emitLazyClassObjectGet, emitLazyProtoGet, findExternInfoForMember } from "./expressions/extern.js";
@@ -1841,6 +1841,46 @@ export function receiverIsCaughtErrorStringRead(ctx: CodegenContext, recv: ts.Ex
 }
 
 /**
+ * (#2187) Recognize a receiver IDENTIFIER whose TS static type is `any`/`unknown`
+ * but whose compiled local/param **ValType is a native-string ref**
+ * (`$AnyString` / `$NativeString`). This is the general "TS type vs local
+ * ValType disagreement" case behind the #2072 value-rep family: e.g. a for-of
+ * loop var bound from a string-yielding generator (`for (const v of g())`)
+ * infers `any` (no lib types in standalone) yet is compiled to a `(ref null
+ * $AnyString)` local. Without this, `v.length` / `v.charCodeAt(0)` gate on
+ * `isStringType(<static type>)` → false → the read falls to the generic
+ * externref/`__extern_get` path and returns 0.
+ *
+ * Strictly gated: standalone/WASI only (where native string refs exist), only a
+ * bare identifier (so a `.foo` property read or a real object keeps its own
+ * typed path), only when the TS type is `any`/`unknown` (a concrete non-string
+ * type is unaffected), and only when the resolved local ValType is exactly the
+ * native string ref type. Returns false for everything else — byte-identical for
+ * the common case.
+ */
+export function receiverIsNativeStringValType(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  recv: ts.Expression,
+): boolean {
+  if (!(ctx.wasi || ctx.standalone)) return false;
+  if (!ctx.nativeStrings || ctx.anyStrTypeIdx < 0) return false;
+  if (!ts.isIdentifier(recv)) return false;
+  // Only when the static type genuinely lost the string info (`any`/`unknown`).
+  // A concrete `string` already routes through the existing isStringType gate;
+  // a concrete non-string type must NOT be hijacked.
+  const tsType = ctx.checker.getTypeAtLocation(recv);
+  if ((tsType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) === 0) return false;
+  const localIdx = fctx.localMap.get(recv.text);
+  if (localIdx === undefined) return false;
+  const localType = getLocalType(fctx, localIdx);
+  if (!localType) return false;
+  if (localType.kind !== "ref" && localType.kind !== "ref_null") return false;
+  const typeIdx = (localType as { typeIdx?: number }).typeIdx;
+  return typeIdx === ctx.anyStrTypeIdx || (ctx.nativeStrTypeIdx >= 0 && typeIdx === ctx.nativeStrTypeIdx);
+}
+
+/**
  * (#2179) When the module uses `delete <member>` (JS-host mode only), route an
  * `any`/`unknown`-typed property READ through the tombstone-aware `__extern_get`
  * host helper instead of the inline `ref.test`+`struct.get` fast-path. Returns
@@ -3143,6 +3183,22 @@ export function compilePropertyAccess(
     }
   }
 
+  // (#2187) `.length` on an `any`-typed identifier whose compiled local ValType
+  // is a native-string ref (e.g. a for-of var from a string-yielding generator).
+  // Must run BEFORE the Function/vec `.length` arms below: the static type is
+  // `any`, so those arms either miss or fall through to `__extern_length` (0
+  // standalone). At the VALUE level the receiver IS a string — read `len` (field
+  // 0 of `$AnyString`) natively. Tightly gated by `receiverIsNativeStringValType`
+  // (standalone + bare-identifier + any/unknown TS type + string-ref local).
+  if (propName === "length" && receiverIsNativeStringValType(ctx, fctx, expr.expression)) {
+    const recvType = compileExpression(ctx, fctx, expr.expression);
+    if (recvType && recvType.kind === "externref") {
+      coerceType(ctx, fctx, recvType, { kind: "ref_null", typeIdx: ctx.anyStrTypeIdx });
+    }
+    fctx.body.push({ op: "struct.get", typeIdx: ctx.anyStrTypeIdx, fieldIdx: 0 });
+    return { kind: "i32" };
+  }
+
   // Handle Function.length — return the number of formal parameters
   if (propName === "length") {
     // (#1632a) `.length` on the result of `.bind(...)` must NOT be statically
@@ -3751,7 +3807,10 @@ export function compilePropertyAccess(
   }
 
   // Handle string.length
-  if (isStringType(objType) && propName === "length") {
+  // (#2187) Also fire for an `any`-typed identifier whose compiled local ValType
+  // is a native-string ref (e.g. a for-of var from a string-yielding generator):
+  // the static type lost the string info, but at the VALUE level it IS a string.
+  if ((isStringType(objType) || receiverIsNativeStringValType(ctx, fctx, expr.expression)) && propName === "length") {
     const recvType = compileExpression(ctx, fctx, expr.expression);
     if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
       // The receiver must be a `$AnyString` ref before reading its `len`

--- a/tests/issue-2187.test.ts
+++ b/tests/issue-2187.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.ts";
+
+// #2187 — string method/property on an `any`-typed local whose compiled ValType
+// is a native `$AnyString` ref. Surfaced via #2171 string-yield generators in
+// standalone: the for-of loop var infers `any` (no lib types), but is compiled
+// to a `(ref null $AnyString)` local. The `.length`/string-method dispatch gated
+// on `isStringType(<static type>)` missed it, so `v.length` / `v.charCodeAt(0)`
+// fell to the generic externref path → 0. The fix routes by the local ValType
+// (receiverIsNativeStringValType) when the TS type is `any`/`unknown`.
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, { target: "standalone" } as never);
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#2187 string method on any-typed native-string local", () => {
+  it("for-of string generator var: v.length sums correctly", async () => {
+    expect(
+      await runStandalone(
+        `function* g(){ yield "ab"; } export function test(): number { let n = 0; for (const v of g()) n += v.length; return n; }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("for-of string generator var: v.charCodeAt(0)", async () => {
+    expect(
+      await runStandalone(
+        `function* g(){ yield "A"; } export function test(): number { let r = 0; for (const v of g()) r = v.charCodeAt(0); return r; }`,
+      ),
+    ).toBe(65);
+  });
+
+  it("v.length assigned to a typed local", async () => {
+    expect(
+      await runStandalone(
+        `function* g(){ yield "abc"; } export function test(): number { let r = 0; for (const v of g()) { const L = v.length; r = L; } return r; }`,
+      ),
+    ).toBe(3);
+  });
+
+  it("return v.length directly from the loop", async () => {
+    expect(
+      await runStandalone(
+        `function* g(){ yield "wxyz"; } export function test(): number { for (const v of g()) { return v.length; } return -1; }`,
+      ),
+    ).toBe(4);
+  });
+
+  // Regression guards — typed string / literal / numeric generator unchanged.
+  it("typed string .length unchanged", async () => {
+    expect(await runStandalone(`export function test(): number { const s: string = "hello"; return s.length; }`)).toBe(
+      5,
+    );
+  });
+
+  it("string literal .length unchanged", async () => {
+    expect(await runStandalone(`export function test(): number { return "world".length; }`)).toBe(5);
+  });
+
+  it("typed string charCodeAt unchanged", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const s: string = "A"; return s.charCodeAt(0); }`),
+    ).toBe(65);
+  });
+
+  it("numeric generator var is not string-routed", async () => {
+    expect(
+      await runStandalone(
+        `function* g(){ yield 10; yield 20; } export function test(): number { let s = 0; for (const v of g()) s += v; return s; }`,
+      ),
+    ).toBe(30);
+  });
+
+  it("array .length unchanged", async () => {
+    expect(await runStandalone(`export function test(): number { const a = [1,2,3]; return a.length; }`)).toBe(3);
+  });
+});


### PR DESCRIPTION
## #2187 — string method on an `any`-typed local with a native-string ValType

A local whose **TS static type is `any`** but whose **compiled ValType is the native `$AnyString` ref** (e.g. a for-of var from a string-yielding generator in standalone — no lib types, so the loop var infers `any`) took the generic externref/`__extern_get` path for `.length` / string methods, returning **0** (`v.length`→0, `v.charCodeAt(0)`→0). The dispatch gated on `isStringType(<static type>)`, which is false for `any`.

### Fix
Adds `receiverIsNativeStringValType(ctx, fctx, recv)` (`property-access.ts`) — mirrors the #2192 `receiverIsCaughtErrorStringRead` TS-type-vs-ValType pattern: true for a **bare identifier** with an `any`/`unknown` TS type whose **local/param ValType is the native string ref** (`anyStrTypeIdx`/`nativeStrTypeIdx`), **standalone/WASI only**. Wired into the two gates the static check missed:
1. `compilePropertyAccess` — an **early `.length` arm** (before the Function/vec `.length` arms, which else fall through to `__extern_length`→0) reads `len` (field 0 of `$AnyString`) natively.
2. `expressions/calls.ts` string-method gate — `||` next to the existing `isStringType`/caught-error checks, routing `v.charCodeAt(0)` etc. to `compileNativeStringMethodCall`.

### Validation
- Headline `for (const v of g()) n += v.length` + `v.charCodeAt(0)` (single-yield string generator, the #2171 origin) → pass.
- 9 scoped tests (`tests/issue-2187.test.ts`).
- No regression: typed `string`/literal receivers, numeric generators, arrays all unchanged (144-test string suite passes; the one `string-methods.test.ts` collection error is a pre-existing missing-`helpers.js` worktree artifact, identical on `origin/main`). Hard-error + any-box-sites gates clean.

### Out of scope (deferred, #2072 value-rep family)
- An `any` assigned from a string **method** (`const v: any = s.slice(1)`) gets an **externref** ValType (opaque), not `$AnyString` — needs the broader externref-carries-a-string tracking, not the bare ValType check.
- The **multi-yield** generator (`yield "a"; yield "b"`) value-binding residual is a separate generator-state bug (#2040 territory) — the WAT confirms the native `len` read fires correctly; the yielded value reaches `v` wrong. NOT this dispatch fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA