### PR TITLE
fix(#2572): standalone for-in over a dynamic object — native $ObjVec walk, no host-import leak

### DIFF
--- a/plan/issues/2572-standalone-forin-object-hostimport-leak.md
+++ b/plan/issues/2572-standalone-forin-object-hostimport-leak.md
@@ -1,10 +1,12 @@
 ---
 id: 2572
 title: "standalone: statement-form for-in over a dynamic object leaks env.__for_in_* host imports (no native $ObjVec walk)"
-status: ready
-sprint: Backlog
+status: done
+sprint: 64
 created: 2026-06-21
 updated: 2026-06-21
+completed: 2026-06-21
+assignee: sd-5
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -88,10 +90,43 @@ the statement-form for-in is not routed through it.
 - JS-host for-in behaviour unchanged (no regression); no new host imports.
 - Closed-struct (non-dynamic) for-in keeps working.
 
+## Resolution (sd-5, 2026-06-21)
+
+Implemented exactly as the fix direction above. Two-line change set:
+
+1. `src/codegen/declarations.ts` — the `__for_in_*` host imports are now
+   registered **only** in JS-host mode (`!ctx.standalone && !ctx.wasi`), mirroring
+   the array-iterator registration. In a no-JS-host target they are no longer
+   registered, so they cannot leak — and their absence selects the native path.
+2. `src/codegen/statements/loops.ts` `compileForInStatement` — in standalone /
+   WASI, when the receiver lowers to the dynamic representation
+   (`externref`/`anyref`/`ref_extern` per `resolveWasmType`), call
+   `ensureObjectRuntime(ctx)` and bind the four native helpers — `__object_keys`
+   (live + enumerable own keys, OrdinaryOwnPropertyKeys order #1837),
+   `__extern_length`, `__extern_get_idx`, `__extern_has` — whose signatures are
+   1:1 with `__for_in_keys/_len/_get/_has`, so the existing loop scaffolding
+   (incl. the #2066 per-visit `__extern_has` liveness guard) is reused unchanged.
+   A **closed WasmGC struct** receiver is not `externref`, so it keeps the exact
+   static-unroll path (correct for a non-mutated closed shape).
+
+Verified standalone (target:"standalone", `{}` imports, zero `env.__for_in_*`):
+`{a,b}` count → 2; insertion order `a,b` → 9798; after `delete o.b` → a,c (9799);
+runtime-added `o.b` included; key deleted mid-loop skipped (9799); per-key value
+read sums to 3; closed-interface struct enumerates its fields (2). JS-host mode
+still registers + uses the host imports (unchanged). New regression test:
+`tests/issue-2572-standalone-forin.test.ts` (7 cases). Existing for-in /
+#2066 / #1837 / #1613 / #1243 / #1271 suites unchanged (77 tests pass).
+
+**Known residual (pre-existing, out of scope):** for-in over an **array** in
+standalone still routes to the static-unroll path (the array type is not a
+`$Object`), which enumerates the array's static members rather than its numeric
+indices — but it now *instantiates* instead of leaking `__for_in_*` (the
+baseline crashed). Array for-in index enumeration is a separate gap; this issue
+fixes the dynamic-object and closed-struct cases.
+
 ## Notes
 
-Carved from #2186, whose post-delete READ path is already fixed and is being
-closed `done` separately. This is the residual that blocked #2186's
-`for (const k in o)` acceptance line. Distinct from #1472 (general standalone
-object/property host-import elimination, `done`) which did not cover the
-`__for_in_*` family.
+Carved from #2186, whose post-delete READ path is already fixed. This is the
+residual that blocked #2186's `for (const k in o)` acceptance line. Distinct
+from #1472 (general standalone object/property host-import elimination, `done`)
+which did not cover the `__for_in_*` family.

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -1435,7 +1435,13 @@ export function finalizeUnifiedCollector(ctx: CodegenContext, state: UnifiedColl
   }
 
   // ── collectForInStringLiterals finalize ──
-  if (state.forInFound) {
+  // (#2572) Only register the `__for_in_*` host imports in JS-host mode. A
+  // no-JS-host target (standalone / WASI) has no host to satisfy them — and they
+  // would otherwise leak into the module (validates, can't instantiate). In that
+  // mode `compileForInStatement` routes through the native object runtime
+  // (`__object_keys` + `__extern_length/_get_idx/_has`) instead, so leaving the
+  // host imports unregistered is exactly what selects the native path there.
+  if (state.forInFound && !ctx.standalone && !ctx.wasi) {
     addForInImports(ctx);
   }
   if (state.forInLiterals.size > 0) {

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -4734,9 +4734,7 @@ export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext
     // static-unroll path below, which is exact for a non-mutated closed shape.
     const recvWasmType = resolveWasmType(ctx, ctx.checker.getTypeAtLocation(stmt.expression));
     const isDynamicReceiver =
-      recvWasmType.kind === "externref" ||
-      recvWasmType.kind === "anyref" ||
-      recvWasmType.kind === "ref_extern";
+      recvWasmType.kind === "externref" || recvWasmType.kind === "anyref" || recvWasmType.kind === "ref_extern";
     if (isDynamicReceiver) {
       ensureObjectRuntime(ctx);
       keysIdx = ctx.funcMap.get("__object_keys");

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -33,6 +33,7 @@ import { containsLinearU8Allocation, emitLinearU8ArenaMark, linearU8ArenaResetIn
 import { resolveComputedKeyExpression } from "../literals.js";
 import { emitCollectionIteratorVec, ensureMapHelpers, MAP_LAYOUT } from "../map-runtime.js";
 import { stringConstantExternrefInstrs } from "../native-strings.js";
+import { ensureObjectRuntime } from "../object-runtime.js";
 import { coercionInstrs } from "../type-coercion.js";
 import { addImport, addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "../registry/imports.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterRefCellType } from "../registry/types.js";
@@ -4703,14 +4704,52 @@ export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext
     return;
   }
 
-  // Look up for-in host imports
-  const keysIdx = ctx.funcMap.get("__for_in_keys");
-  const lenIdx = ctx.funcMap.get("__for_in_len");
-  const getIdx = ctx.funcMap.get("__for_in_get");
-  const hasIdx = ctx.funcMap.get("__for_in_has");
+  // Resolve the four enumeration primitives. In JS-host mode these are the
+  // `__for_in_*` host imports. In a no-JS-host target (standalone / WASI) the
+  // host imports are unavailable, so route through the native object-runtime
+  // (#2572): `__object_keys` returns a `$ObjVec` of the live + enumerable own
+  // keys in OrdinaryOwnPropertyKeys order (#1837), and `__extern_length` /
+  // `__extern_get_idx` / `__extern_has` are `$ObjVec`-aware native helpers. The
+  // four have signatures 1:1 compatible with `__for_in_keys/_len/_get/_has`, so
+  // the loop scaffolding below is identical for both modes. This replaces the
+  // old static-unroll fallback, which enumerated the receiver's *static* shape
+  // and was therefore wrong for a runtime-mutated dynamic object (a key added
+  // or deleted at runtime was invisible / stale).
+  let keysIdx = ctx.funcMap.get("__for_in_keys");
+  let lenIdx = ctx.funcMap.get("__for_in_len");
+  let getIdx = ctx.funcMap.get("__for_in_get");
+  let hasIdx = ctx.funcMap.get("__for_in_has");
+
+  if ((keysIdx === undefined || lenIdx === undefined || getIdx === undefined) && (ctx.standalone || ctx.wasi)) {
+    // No-JS-host target: the `__for_in_*` host imports are intentionally not
+    // registered (#2572, declarations.ts). For a receiver that lowers to the
+    // dynamic `$Object` representation (an `any`/index-signature object whose
+    // keys are determined at runtime), route through the native object runtime:
+    // `__object_keys` returns a `$ObjVec` of the live + enumerable own keys in
+    // OrdinaryOwnPropertyKeys order (#1837); `__extern_length`/`__extern_get_idx`
+    // /`__extern_has` are `$ObjVec`-aware native helpers with signatures 1:1
+    // compatible with `__for_in_keys/_len/_get/_has`, so the loop scaffolding
+    // below is shared. A closed WasmGC struct or an array does NOT lower to
+    // `$Object` (so `__object_keys` would return empty) — those keep the
+    // static-unroll path below, which is exact for a non-mutated closed shape.
+    const recvWasmType = resolveWasmType(ctx, ctx.checker.getTypeAtLocation(stmt.expression));
+    const isDynamicReceiver =
+      recvWasmType.kind === "externref" ||
+      recvWasmType.kind === "anyref" ||
+      recvWasmType.kind === "ref_extern";
+    if (isDynamicReceiver) {
+      ensureObjectRuntime(ctx);
+      keysIdx = ctx.funcMap.get("__object_keys");
+      lenIdx = ctx.funcMap.get("__extern_length");
+      getIdx = ctx.funcMap.get("__extern_get_idx");
+      hasIdx = ctx.funcMap.get("__extern_has");
+    }
+  }
 
   if (keysIdx === undefined || lenIdx === undefined || getIdx === undefined) {
-    // Fallback: static unrolling when host imports are not available (standalone mode)
+    // Fallback: static unrolling. Used in standalone for a closed-shape receiver
+    // (WasmGC struct) — the static key set is exact — and as the historical
+    // fallback when no enumeration primitive is available.
     const exprType = ctx.checker.getTypeAtLocation(stmt.expression);
     const props = exprType.getProperties();
     if (props.length === 0) return;

--- a/tests/issue-2572-standalone-forin.test.ts
+++ b/tests/issue-2572-standalone-forin.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+
+/**
+ * #2572 — statement-form `for (const k in o)` over a dynamic (`$Object`)
+ * receiver used to leak the `env.__for_in_*` host imports under
+ * `--target standalone` / WASI: the module validated but could not instantiate
+ * (no JS host to satisfy the imports). It now routes through the native object
+ * runtime (`__object_keys` + `__extern_length`/`__extern_get_idx`/`__extern_has`),
+ * mirroring standalone `Object.keys`, so it is host-free, spec-ordered (#1837),
+ * tombstone-aware (delete), and honours per-visit liveness (#2066). A closed
+ * WasmGC struct keeps the exact static-unroll path.
+ */
+async function runStandalone(source: string): Promise<{ ret: number; leaked: string[]; valid: boolean }> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e: any) => e.message).join("\n")).toBe(true);
+  const valid = WebAssembly.validate(r.binary);
+  const mod = await WebAssembly.compile(r.binary);
+  const leaked = WebAssembly.Module.imports(mod)
+    .filter((i) => i.module === "env" && /^__for_in_/.test(i.name))
+    .map((i) => i.name);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const ret = (instance.exports as Record<string, () => number>).run();
+  return { ret, leaked, valid };
+}
+
+describe("#2572 — standalone for-in over a dynamic object (no host-import leak)", () => {
+  it("for-in over an `any` object instantiates and counts own keys", async () => {
+    const { ret, leaked, valid } = await runStandalone(
+      `export function run(): number { const o: any = { a: 1, b: 2 }; let n = 0; for (const k in o) n++; return n; }`,
+    );
+    expect(valid).toBe(true);
+    expect(leaked).toEqual([]); // no env.__for_in_* imports leaked
+    expect(ret).toBe(2);
+  });
+
+  it("enumerates keys in insertion order (#1837)", async () => {
+    // acc = ('a'=97) then ('b'=98) → 97*100 + 98 = 9798
+    const { ret, leaked } = await runStandalone(
+      `export function run(): number { const o: any = { a: 1, b: 2 }; let acc = 0; for (const k in o) { acc = acc * 100 + k.charCodeAt(0); } return acc; }`,
+    );
+    expect(leaked).toEqual([]);
+    expect(ret).toBe(9798);
+  });
+
+  it("omits a key deleted before the loop (tombstone-aware)", async () => {
+    // a,c survive after `delete o.b` → 97*100 + 99 = 9799
+    const { ret, leaked } = await runStandalone(
+      `export function run(): number { const o: any = { a: 1, b: 2, c: 3 }; delete o.b; let acc = 0; for (const k in o) { acc = acc * 100 + k.charCodeAt(0); } return acc; }`,
+    );
+    expect(leaked).toEqual([]);
+    expect(ret).toBe(9799);
+  });
+
+  it("includes a key added at runtime", async () => {
+    const { ret, leaked } = await runStandalone(
+      `export function run(): number { const o: any = { a: 1 }; o.b = 2; let n = 0; for (const k in o) n++; return n; }`,
+    );
+    expect(leaked).toEqual([]);
+    expect(ret).toBe(2);
+  });
+
+  it("skips a key deleted during enumeration (#2066 per-visit liveness)", async () => {
+    // on visiting 'a' we delete 'b'; only a,c are observed → 9799
+    const { ret, leaked } = await runStandalone(
+      `export function run(): number { const o: any = { a: 1, b: 2, c: 3 }; let acc = 0; for (const k in o) { acc = acc * 100 + k.charCodeAt(0); if (k === "a") delete o.b; } return acc; }`,
+    );
+    expect(leaked).toEqual([]);
+    expect(ret).toBe(9799);
+  });
+
+  it("reads the value for each enumerated key", async () => {
+    const { ret, leaked } = await runStandalone(
+      `export function run(): number { const o: any = { a: 1, b: 2 }; let sum = 0; for (const k in o) { sum += (o[k] as number); } return sum; }`,
+    );
+    expect(leaked).toEqual([]);
+    expect(ret).toBe(3);
+  });
+
+  it("a closed-shape (interface) receiver enumerates its fields via the static path", async () => {
+    const { ret, leaked, valid } = await runStandalone(
+      `interface P { a: number; b: number; } export function run(): number { const o: P = { a: 1, b: 2 }; let n = 0; for (const k in o) n++; return n; }`,
+    );
+    expect(valid).toBe(true);
+    expect(leaked).toEqual([]);
+    expect(ret).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

`for (const k in o)` over a dynamic (`$Object`) receiver leaked `env.__for_in_keys/_len/_get/_has` under `--target standalone` / WASI — the module **validated but could not instantiate** (no JS host to satisfy the imports). Carved from #2186 (whose post-delete read was already fixed); this is the residual that blocked #2186's `for (const k in o)` acceptance line.

## Fix (2-part, ~60 lines)

1. **`src/codegen/declarations.ts`** — register the `__for_in_*` host imports **only** in JS-host mode (`!ctx.standalone && !ctx.wasi`), mirroring the array-iterator registration 9 lines above. Their absence in a no-JS-host target selects the native path.
2. **`src/codegen/statements/loops.ts` `compileForInStatement`** — in standalone/WASI, when the receiver lowers to the dynamic representation (`externref`/`anyref`/`ref_extern`), call `ensureObjectRuntime` and bind the native helpers `__object_keys` (live + enumerable own keys in OrdinaryOwnPropertyKeys order, #1837), `__extern_length`, `__extern_get_idx`, `__extern_has`. Their signatures are **1:1** with `__for_in_keys/_len/_get/_has`, so the existing loop scaffolding — including the #2066 per-visit `__extern_has` liveness guard — is reused unchanged. A **closed WasmGC struct** is not `externref`, so it keeps the exact static-unroll path.

## Verification

Standalone (zero `env.__for_in_*` imports): `{a,b}` count → 2; insertion order `a,b`; tombstone-aware after `delete`; runtime-added key included; key deleted mid-loop skipped (#2066); per-key value read; closed-interface struct enumerates its fields. JS-host mode unchanged (still registers + uses the host imports).

- New test: `tests/issue-2572-standalone-forin.test.ts` (7 cases).
- Existing for-in / #2066 / #1837 / #1613 / #1243 / #1271 suites pass (77 tests).
- `check-test262-hard-errors.mjs` → OK (0 hard errors).

## Known pre-existing residual (out of scope)

Standalone for-in over an **array** still static-unrolls (enumerates members, not numeric indices) — but it now **instantiates** instead of leaking/crashing. Array for-in index enumeration is a separate gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)