### PR TITLE
fix(#2036): native-string array search compares by content, not ref.eq

### DIFF
--- a/plan/issues/2036-standalone-array-generics-arraylike-invalid-wasm.md
+++ b/plan/issues/2036-standalone-array-generics-arraylike-invalid-wasm.md
@@ -4,7 +4,7 @@ title: "standalone: Array.prototype generics over array-like receivers emit inva
 status: in-progress
 sprint: 64
 created: 2026-06-10
-updated: 2026-06-14
+updated: 2026-06-21
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -178,3 +178,63 @@ generic-receiver root. Fold into Step 2 (senior/infra) or file separately.
 
 Issue stays `in-progress` — Step 2 (the real generic `$Object` arm +
 binary-emitter local-type fix) is senior/infra and unshipped.
+
+## Step 2a — native-string element search equality (2026-06-21, sdev-reflect)
+
+PROBE-VERIFIED on current main HEAD (075d90ee5). The picture had shifted since
+the last update: the **S6 Step 1 loud refusal is no longer firing** (a later PR
+made the borrowed array-like `$Object` search/result methods compile + RUN
+instead of refuse — so the `issue-2036.test.ts` "refuses loudly" cases are now
+**stale and fail on clean main**, byte-identical with/without this change; that
+behavior question belongs to the array-like `$Object` value-read path, #2187).
+
+The probe surfaced a distinct, broader, in-scope root cause that the prior
+notes had folded into a vague "binary-emitter bug":
+
+**Native-string array elements were compared by reference identity, not
+content.** Under native strings (auto-enabled standalone/WASI) a `string[]`
+element ValType is `ref_null $AnyString` (typeIdx === `ctx.anyStrTypeIdx`), so
+the four search arms took their `ref`/`ref_null` → `ref.eq` branch. Every string
+literal/slice materialises a distinct `$AnyString` allocation, so value-equal
+strings never matched:
+- `['a','b','c'].indexOf('c')` → -1 (should be 2)
+- `['a','b','c'].includes('b')` → false; `lastIndexOf` likewise
+- `Array.prototype.indexOf.call(['a','b'], 'b')` → -1 (shape-inferred call path)
+
+This is NOT the #2187 dynamic-read substrate — it is a **static-type codegen
+bug** in the typed-array search path, independent of any `$Object` receiver, and
+affects everyday `string[].indexOf/includes/lastIndexOf`, not just array-likes.
+
+**Fix** (`src/codegen/array-methods.ts`): new `nativeStringElementEqInstrs(ctx,
+fctx, elemType)` helper — when `elemType` is a `ref`/`ref_null` to
+`ctx.anyStrTypeIdx` under native strings, it spills the two operands, null-guards
+(null===null via `ref.eq`; null-vs-string → false — `__str_equals` would trap on
+a null param), and otherwise routes to `__str_equals` (flattens cons-strings,
+compares code units, §7.2.16). Returns `undefined` for non-string refs so the
+existing `ref.eq` arm still serves genuine object-identity elements. Wired into
+all four search sites: `compileArrayIndexOf`, `compileArrayLastIndexOf`,
+`compileArrayIncludes`, and `compileArrayPrototypeIndexOf` (the shape-inferred
+`Array.prototype.indexOf.call(realArray, …)` arm). SameValueZero (`includes`)
+and Strict Equality coincide for strings, so one helper serves all three.
+
+Host/gc mode is untouched — the helper is gated on `ctx.nativeStrings` (false in
+host/fast mode, which uses `wasm:js-string`), so its output is byte-identical
+there.
+
+**Tests** (`tests/issue-2036.test.ts`, +9, new describe block): indexOf
+later/first/absent, includes match/absent, lastIndexOf last-duplicate, the
+borrowed real-array call form, a cons-string needle (flatten path), and a
+`number[]` control. All 9 green; object-identity element search verified
+unchanged by separate probe. tsc + prettier clean.
+
+**Pre-existing failures (NOT this change, identical on clean main HEAD):**
+`tests/issue-2036.test.ts` S6 "refuses loudly" cases (behavior changed
+upstream); `tests/issue-1360.test.ts` lastIndexOf null/undefined; the
+`tests/array-externref-indexof.test.ts` suite (imports the broken
+`tests/helpers.js`); `tests/issue-1131.test.ts` IR fib. Verified by running each
+on a clean `origin/main` worktree — same 9 failures with and without this PR.
+
+**Still out of scope (issue stays `in-progress`):** the array-like `$Object`
+search/result-method value path (number elements already work; string elements
+need the #2187 dynamic-read substrate); whether those should refuse vs run; and
+the broader #1888 Slice 4 generic-receiver arm.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -54,6 +54,78 @@ import { coerceType, coercionInstrs, defaultValueInstrs } from "./type-coercion.
 
 type ArrayMethodAccess = ts.PropertyAccessExpression | ts.ElementAccessExpression;
 
+/**
+ * #2036 — content-equality for native-string array elements in the search
+ * methods (`indexOf`/`lastIndexOf`/`includes`).
+ *
+ * For a `string[]` under native strings the element ValType is a
+ * `ref_null $AnyString` (typeIdx === ctx.anyStrTypeIdx). The search loops used
+ * `ref.eq` (reference identity) for the `ref`/`ref_null` arm, which is wrong for
+ * strings: every string literal/slice materialises a distinct `$AnyString`
+ * allocation, so `['a','b','c'].indexOf('c')` and
+ * `Array.prototype.indexOf.call(['a','b'], 'b')` returned -1 (and the `any`-vec
+ * `__host_eq` stub mismatched the other direction). Strict equality on strings
+ * is by content (§7.2.16), so route native-string elements to `__str_equals`
+ * (which flattens cons-strings and compares code units) instead.
+ *
+ * Returns `undefined` when `elemType` is NOT a native-string ref, so the caller
+ * keeps its existing `ref.eq` arm for genuine reference elements (objects).
+ *
+ * The returned Instrs consume TWO operands already on the stack — the element
+ * and the search value, both `ref_null $AnyString` — and leave an i32 (0/1).
+ * SameValueZero (`includes`) and Strict Equality (`indexOf`/`lastIndexOf`)
+ * coincide for strings (no NaN/±0 string subtlety), so one helper serves all
+ * three. A null element (array hole / explicit null search value) is handled by
+ * a ref.eq fast-path first: null===null → true, null vs a string → false,
+ * matching strict-equality semantics without trapping in `__str_equals`.
+ */
+function nativeStringElementEqInstrs(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  elemType: ValType,
+): Instr[] | undefined {
+  if (!ctx.nativeStrings || ctx.anyStrTypeIdx < 0) return undefined;
+  if (elemType.kind !== "ref" && elemType.kind !== "ref_null") return undefined;
+  if (elemType.typeIdx !== ctx.anyStrTypeIdx) return undefined;
+
+  ensureNativeStringHelpers(ctx);
+  const strEqIdx = ctx.nativeStrHelpers.get("__str_equals");
+  if (strEqIdx === undefined) return undefined;
+
+  const anyStrNull: ValType = { kind: "ref_null", typeIdx: ctx.anyStrTypeIdx };
+  const elemTmp = allocLocal(fctx, `__str_eq_el_${fctx.locals.length}`, anyStrNull);
+  const valTmp = allocLocal(fctx, `__str_eq_val_${fctx.locals.length}`, anyStrNull);
+
+  // Stack on entry: [elem, val]. Spill val then elem.
+  return [
+    { op: "local.set", index: valTmp } as Instr,
+    { op: "local.set", index: elemTmp } as Instr,
+    // Null fast-path: if either side is null, equality is ref.eq (null===null
+    // → true; null vs string → false). __str_equals would trap on a null param.
+    { op: "local.get", index: elemTmp } as Instr,
+    { op: "ref.is_null" } as Instr,
+    { op: "local.get", index: valTmp } as Instr,
+    { op: "ref.is_null" } as Instr,
+    { op: "i32.or" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "i32" } },
+      then: [
+        { op: "local.get", index: elemTmp } as Instr,
+        { op: "local.get", index: valTmp } as Instr,
+        { op: "ref.eq" } as Instr,
+      ],
+      else: [
+        { op: "local.get", index: elemTmp } as Instr,
+        { op: "ref.as_non_null" } as Instr,
+        { op: "local.get", index: valTmp } as Instr,
+        { op: "ref.as_non_null" } as Instr,
+        { op: "call", funcIdx: strEqIdx } as Instr,
+      ],
+    } as Instr,
+  ];
+}
+
 /** Emit throw with a string message (local version to avoid circular dep on expressions.ts) */
 function emitThrowString(ctx: CodegenContext, fctx: FunctionContext, message: string): void {
   addStringConstantGlobal(ctx, message);
@@ -2056,7 +2128,8 @@ function compileArrayPrototypeIndexOf(
     const equalsIdx = ctx.jsStringImports.get("equals")!;
     apcEqInstrs = [{ op: "call", funcIdx: equalsIdx } as Instr];
   } else if (elemType.kind === "ref" || elemType.kind === "ref_null") {
-    apcEqInstrs = [{ op: "ref.eq" }];
+    // #2036 — native-string elements compare by content (§7.2.16), not identity.
+    apcEqInstrs = nativeStringElementEqInstrs(ctx, fctx, elemType) ?? [{ op: "ref.eq" }];
   } else {
     const eqOp = elemType.kind === "f64" ? "f64.eq" : "i32.eq";
     apcEqInstrs = [{ op: eqOp } as Instr];
@@ -3757,7 +3830,8 @@ function compileArrayIndexOf(
     }
     eqInstrs = [{ op: "call", funcIdx: finalHostEqIdx } as Instr];
   } else if (elemType.kind === "ref" || elemType.kind === "ref_null") {
-    eqInstrs = [{ op: "ref.eq" }];
+    // #2036 — native-string elements compare by content (§7.2.16), not identity.
+    eqInstrs = nativeStringElementEqInstrs(ctx, fctx, elemType) ?? [{ op: "ref.eq" }];
   } else {
     const eqOp = elemType.kind === "f64" ? "f64.eq" : "i32.eq";
     eqInstrs = [{ op: eqOp } as Instr];
@@ -3973,12 +4047,15 @@ function compileArrayIncludes(
       { op: "call", funcIdx: finalSvzIdx } as Instr,
     ];
   } else if (elemType.kind === "ref" || elemType.kind === "ref_null") {
+    // #2036 — native-string elements use SameValueZero by content (which equals
+    // strict equality for strings — no NaN/±0 subtlety), not reference identity.
+    const strEq = nativeStringElementEqInstrs(ctx, fctx, elemType);
     comparisonInstrs = [
       { op: "local.get", index: dataTmp } as Instr,
       { op: "local.get", index: iTmp } as Instr,
       { op: getOp, typeIdx: arrTypeIdx } as Instr,
       { op: "local.get", index: valTmp } as Instr,
-      { op: "ref.eq" } as Instr,
+      ...(strEq ?? [{ op: "ref.eq" } as Instr]),
     ];
   } else {
     const eqOp = "i32.eq";
@@ -8261,7 +8338,8 @@ function compileArrayLastIndexOf(
     }
     liofEqInstrs = [{ op: "call", funcIdx: finalHostEqIdx } as Instr];
   } else if (elemType.kind === "ref" || elemType.kind === "ref_null") {
-    liofEqInstrs = [{ op: "ref.eq" }];
+    // #2036 — native-string elements compare by content (§7.2.16), not identity.
+    liofEqInstrs = nativeStringElementEqInstrs(ctx, fctx, elemType) ?? [{ op: "ref.eq" }];
   } else {
     const eqOp = elemType.kind === "f64" ? "f64.eq" : "i32.eq";
     liofEqInstrs = [{ op: eqOp } as Instr];

--- a/tests/issue-2036.test.ts
+++ b/tests/issue-2036.test.ts
@@ -264,3 +264,89 @@ describe("#2036 S6 step 1 — borrowed search/result-building methods refuse lou
     expect(r.success).toBe(true);
   });
 });
+
+// #2036 — native-string element search equality. Under native strings
+// (auto-enabled for standalone/WASI) a `string[]` element ValType is a
+// `ref_null $AnyString`, so the search loops (indexOf/lastIndexOf/includes)
+// took the `ref.eq` (reference-identity) arm. Every string literal/slice
+// materialises a distinct $AnyString allocation, so value-equal strings never
+// matched: `['a','b','c'].indexOf('c')` returned -1, and the borrowed
+// `Array.prototype.indexOf.call(realArray, str)` form likewise. Strict equality
+// on strings is by content (§7.2.16), so these now route to __str_equals.
+describe("#2036 native-string element search equality (indexOf/includes/lastIndexOf)", () => {
+  it("string[].indexOf finds a later element by content", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a: string[] = ['a','b','c']; return a.indexOf('c'); }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("string[].indexOf finds the first element", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a: string[] = ['a','b','c']; return a.indexOf('a'); }`,
+      ),
+    ).toBe(0);
+  });
+
+  it("string[].indexOf returns -1 when absent", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a: string[] = ['a','b','c']; return a.indexOf('z'); }`,
+      ),
+    ).toBe(-1);
+  });
+
+  it("string[].includes matches by content", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a: string[] = ['a','b','c']; return a.includes('b') ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("string[].includes returns false when absent", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a: string[] = ['a','b','c']; return a.includes('z') ? 1 : 0; }`,
+      ),
+    ).toBe(0);
+  });
+
+  it("string[].lastIndexOf finds the LAST duplicate by content", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a: string[] = ['a','b','b']; return a.lastIndexOf('b'); }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("Array.prototype.indexOf.call(realArray, str) compares by content", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a: string[] = ['a','b']; return Array.prototype.indexOf.call(a, 'b'); }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("matches a cons-string (flattened) needle", async () => {
+    // The needle is built by concatenation → a cons-string; __str_equals must
+    // flatten before comparing so it still matches the flat stored 'bc'.
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const a: string[] = ['ab','bc','cd'];
+           const needle = 'b' + 'c';
+           return a.indexOf(needle);
+         }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("number[] search is unchanged (control)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const a: number[] = [1,2,3]; return a.indexOf(3); }`),
+    ).toBe(2);
+  });
+});


### PR DESCRIPTION
## #2036 — native-string element search equality

Under native strings (auto-enabled standalone/WASI) a `string[]` element ValType
is a `ref_null $AnyString`, so the array search methods
(`indexOf`/`lastIndexOf`/`includes`) took their `ref`/`ref_null` → **`ref.eq`**
(reference-identity) arm. Every string literal/slice materialises a distinct
`$AnyString` allocation, so value-equal strings never matched:

- `['a','b','c'].indexOf('c')` → -1 (should be 2)
- `['a','b','c'].includes('b')` → false; `lastIndexOf` likewise
- `Array.prototype.indexOf.call(['a','b'], 'b')` → -1 (shape-inferred call path)

Strict equality on strings is **by content** (§7.2.16), and SameValueZero
(`includes`) coincides with it for strings (no NaN/±0 subtlety).

### Fix
New `nativeStringElementEqInstrs(ctx, fctx, elemType)` helper in
`src/codegen/array-methods.ts`: when `elemType` is a `ref`/`ref_null` to
`ctx.anyStrTypeIdx` under native strings, it spills the two operands,
null-guards (`null===null` via `ref.eq`; null-vs-string → false — `__str_equals`
would trap on a null param), then routes to `__str_equals` (flattens
cons-strings, compares code units). Returns `undefined` for non-string refs so
genuine object-identity elements keep `ref.eq`. Wired into all four search
sites: `compileArrayIndexOf`, `compileArrayLastIndexOf`, `compileArrayIncludes`,
`compileArrayPrototypeIndexOf`.

**Host/gc mode is byte-identical** — gated on `ctx.nativeStrings` (false in
host/fast mode, which uses `wasm:js-string`).

### Scope / context
Root-caused by probe-verify on main HEAD (075d90ee5). This is a **static-type
codegen bug**, independent of any `$Object` receiver — it affects everyday
`string[].indexOf/includes/lastIndexOf`, not just array-likes. The earlier
"refuse loud" approach (closed PR #1439, never merged) is superseded; its
`issue-2036.test.ts` "refuses loudly" cases now fail identically on clean main
(behavior changed upstream) and are unrelated to this change. The array-like
`$Object` *string* value-read path stays out of scope (#2187 substrate); number
elements there already work. Issue remains `in-progress`.

### Tests
- `tests/issue-2036.test.ts` +9 (new describe block): indexOf later/first/absent,
  includes match/absent, lastIndexOf last-duplicate, borrowed real-array call,
  cons-string needle (flatten path), `number[]` control — all green.
- native-strings suites 108/108; clean array suites 86/86; object-identity
  element search verified unchanged. `tsc --noEmit` + prettier clean.
- Pre-existing failures (identical on clean `origin/main`, NOT this change):
  issue-2036 S6 "refuses loudly", issue-1360 lastIndexOf null/undefined,
  array-externref-indexof (broken `tests/helpers.js`), issue-1131 IR fib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)