### PR TITLE
docs(#2040,#2574): root-cause cluster A = standalone __any_strict_eq/AnyValue tag-5 number bug

### DIFF
--- a/plan/issues/2040-standalone-generator-dstr-runtime-semantics.md
+++ b/plan/issues/2040-standalone-generator-dstr-runtime-semantics.md
@@ -119,7 +119,57 @@ fresh vec downstream: the untyped `$C_method` WAT has `array.copy:1`).
 
 Orthogonal smaller slice found: `const [a=9] = [undefined]` → NaN (default not
 applied when the element value is `undefined`); spec §8.5.3 applies the default on
-`undefined`, not just `done`. Independent of the rest-identity question.
+`undefined`, not just `done`. Filed as **#2574**.
+
+## ROOT CAUSE FOUND — standalone `__any_strict_eq`/`__any_eq` tag-5 number bug (sd-3, 2026-06-21, supersedes the "harness/marshaling" hypothesis above)
+
+NOT the runner, NOT marshaling, NOT destructuring. The harness `assert._isSameValue`
+(`if(a===b){return a!==0||1/a===1/b;} return a!==a && b!==b;`, `a`/`b` `any` params)
+miscompiles in **standalone ONLY** (wasi + host both correct).
+
+**Minimal repro (no if / no destructuring):**
+```ts
+function f(a:any,b:any){ const d=(1/a===1/b); const n=(a!==a); return n; }
+f(1,2)   // standalone: true (WRONG)   wasi/host: false
+```
+Also breaks with `String(a)` / `a*2` / `a-1` in place of `1/a` — i.e. **ANY
+`any`-op that ensures the AnyValue type before a self `===`/`!==`.**
+
+**Mechanism (WAT-proven):**
+1. `a!==a` ALONE → the correct abstract-eq cascade (`__typeof_number`→
+   `__unbox_number`→`f64.eq`, 15 calls) → right answer.
+2. After a preceding `any`-op, `ctx.anyValueTypeIdx >= 0`, so the gate at
+   `binary-ops.ts:967-980` routes the SAME `a!==a` through
+   `compileAnyBinaryDispatch` → `__any_strict_eq` instead.
+3. `compileAnyBinaryDispatch` boxes each operand via `boxToAny`
+   (`value-tags.ts:178-186`), which — by the **deliberate #1888 policy**
+   ("box-the-externref as tag-5"; honest recovery flipped −794 baseline) — boxes a
+   NUMBER externref as **tag 5 (string)**.
+4. The tag-5 arm of `__any_strict_eq` / `__any_eq` (`any-helpers.ts` ~1607 / ~1339)
+   compares the two field-4 externrefs with `__str_equals`. For two tag-5 boxes
+   wrapping the SAME number externref that is meaningless → "unequal" → `a!==a`
+   true. `_isSameValue` then wrongly returns true → EVERY `assert.sameValue`/
+   `notSameValue` over a numeric `any` fails (a huge fraction of test262 — likely
+   ≫ 450 rows). This is the true cluster-A driver.
+
+**Proven-viable fix direction (but #1888-pinned — needs full-baseline validation):**
+- `__any_to_f64(tag5BoxOfNumber)` DOES recover the number (its #1888 $BoxedNumber
+  arm) — confirmed: `a*2; return a+0` → 5 standalone. So the tag-5 EQUALITY arm in
+  BOTH helpers should disambiguate by the RUNTIME externref: `__str_equals` only
+  when BOTH field-4 externrefs `ref.test ctx.anyStrTypeIdx` (genuine native
+  strings); otherwise `__any_to_f64` both + `f64.eq`.
+- sd-3 attempted exactly this (both helpers, nativeStrings-gated) but the emitted
+  tag-5 arm still returned wrong in a way the local WAT couldn't fully explain (the
+  arm appeared dead/folded even with `optimize:false`), so it was **REVERTED** to
+  avoid a half-fix in the #1888-pinned representation. The boxing itself
+  (`__any_box_string` for externrefs) MUST NOT change (−794). The fix belongs in the
+  equality helpers' tag-5 arm and must be gated by the full standalone baseline
+  (merge_group), not a scoped local check.
+
+**ESCALATED to tech lead** — high value (top-tier standalone unlock), high risk
+(#1888 794-test representation). Wants an architect spec + full-baseline gate before
+landing. The `directCastInstrs` rest-copy theory was ruled out (the rest IS fresh;
+the failure is purely the equality helper).
 
 ## Acceptance criteria
 

--- a/plan/issues/2574-array-destructuring-default-not-applied-on-undefined-element.md
+++ b/plan/issues/2574-array-destructuring-default-not-applied-on-undefined-element.md
@@ -1,0 +1,63 @@
+---
+id: 2574
+title: "array destructuring default not applied when the element value is `undefined` (standalone)"
+status: ready
+sprint: Backlog
+created: 2026-06-21
+updated: 2026-06-21
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: destructuring, defaults
+goal: standalone-mode
+related: [2040, 2545, 2568]
+origin: "2026-06-21 sd-3 — found while root-causing #2040 cluster A. Orthogonal to the #2040 _isSameValue codegen bug."
+---
+
+# #2574 — array-destructuring default not applied on an `undefined` element
+
+## Problem
+
+Per ES §8.5.3 (IteratorBindingInitialization, `SingleNameBinding` with an
+Initializer), the default is applied when the bound value is `undefined` — NOT
+only when the iterator is `done`. In standalone mode the default is skipped when
+the element value is explicitly `undefined`:
+
+```ts
+const [a = 9] = [undefined];   // standalone: a === NaN   expected: a === 9
+```
+
+Compare (both already correct on main):
+
+```ts
+const [a = 9] = [5];   // a === 5   ✓
+const [a = 9] = [];    // a === 9   ✓ (done → default)
+```
+
+So the missing arm is specifically: element present in the iterator but its
+value is `undefined` ⇒ apply the default.
+
+## Repro (current main, `--target standalone`)
+
+```ts
+export function test(): number { const [a = 9] = [undefined as any]; return a; }
+// actual: NaN   expected: 9
+```
+
+## Suggested approach
+
+In the array-destructuring element lowering (`src/codegen/destructuring-params.ts`
+and/or the decl path in `statements/destructuring.ts`), the default-application
+guard must fire on `value === undefined`, not only on iterator-`done`. The
+`done`-only path already works; widen the predicate to
+`done || value === undefined` (the §8.5.3 "If v is undefined" step), then apply
+the Initializer. Scope to array binding patterns with a default; object-pattern
+defaults (§8.5.4) already cover the `undefined` case — verify both.
+
+## Acceptance criteria
+
+- `const [a = 9] = [undefined]` → `a === 9` standalone; host unchanged.
+- `const [a = 9] = [5]` / `const [a = 9] = []` stay correct (no regression).
+- Object-pattern default-on-undefined verified.


### PR DESCRIPTION
## #2040 cluster A — root cause found (docs-only; fix needs architect spec)

Definitively isolated the ~450+ `assert.notSameValue`/`_isSameValue` cluster-A failures. **NOT** the runner, **NOT** marshaling, **NOT** destructuring (all proven correct in pure standalone). It is a **standalone AnyValue-representation codegen bug**.

### Minimal repro (no if / no destructuring)
```ts
function f(a: any, b: any) { const d = (1/a === 1/b); const n = (a !== a); return n; }
f(1, 2)   // standalone: true (WRONG)   wasi/host: false
```
Breaks with `String(a)` / `a*2` / `a-1` too — **any `any`-op that ensures the AnyValue type before a self `===`/`!==`**.

### Mechanism (WAT-proven)
1. `a!==a` ALONE → correct abstract-eq cascade (`__typeof_number`→`__unbox_number`→`f64.eq`).
2. After a preceding `any`-op, `ctx.anyValueTypeIdx >= 0`, so `binary-ops.ts:967-980` routes the SAME `a!==a` through `compileAnyBinaryDispatch` → `__any_strict_eq`.
3. `boxToAny` (`value-tags.ts:178-186`) boxes a NUMBER externref as **tag-5 (string)** — the deliberate #1888 policy (honest recovery flipped −794 baseline).
4. The tag-5 arm of `__any_strict_eq`/`__any_eq` compares the field-4 externrefs via `__str_equals` → meaningless for two number boxes → `a!==a` true → `_isSameValue` wrong → **every numeric-`any` sameValue/notSameValue fails** (likely ≫ 450 rows).

Deeper: after `a*2`, `typeof a` returns neither `"number"` nor `"string"` — the AnyValue representation of `a` is corrupted across `typeof`/`===`, not just equality.

### Why docs-only (escalation)
`__any_to_f64` DOES recover a tag-5 number (`a*2; return a+0` → 5), so the tag-5 equality arm should disambiguate (`ref.test ctx.anyStrTypeIdx` → `__str_equals` for real strings, else `__any_to_f64`+`f64.eq`). I implemented exactly this in both helpers but the emitted arm still mis-returned locally (the AnyValue corruption runs deeper than the equality arm — `typeof` is wrong too), so I **reverted** rather than land a half-fix in the **#1888-pinned representation (794 tests)**. This is a top-tier standalone unlock but high-risk — it needs an **architect spec + full standalone-baseline (merge_group) gate**, not a scoped local patch.

This PR commits the complete diagnosis into `plan/issues/2040-*.md` and files the orthogonal `[a=9]=[undefined]→NaN` default slice as **#2574**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA