### PR TITLE
fix(#2515): S0 slice 2 — sentinel-safe string materialization in calls.ts

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -1577,7 +1577,10 @@ function resolvePromiseSubclassThisArg(ctx: CodegenContext, fctx: FunctionContex
   // string backends.
   addStringConstantGlobal(ctx, resolved);
   const nameIdx = ctx.stringGlobalMap.get(resolved);
-  if (nameIdx !== undefined) {
+  // (#2515 S0) `>= 0`, not `!== undefined`: standalone/nativeStrings stores the
+  // `-1` sentinel, which would bake `global.get -1` and fail binary emit. Fall
+  // to the inline-materializing `compileStringLiteral` for the sentinel.
+  if (nameIdx !== undefined && nameIdx >= 0) {
     fctx.body.push({ op: "global.get", index: nameIdx } as Instr);
   } else {
     compileStringLiteral(ctx, fctx, resolved);
@@ -5567,7 +5570,9 @@ function compileCallExpression(
         const builtinName = (arg0 as ts.Identifier).text;
         addStringConstantGlobal(ctx, builtinName);
         const strIdx = ctx.stringGlobalMap.get(builtinName);
-        if (strIdx !== undefined) {
+        // (#2515 S0) `>= 0`, not `!== undefined`: the standalone `-1` sentinel
+        // must fall to the inline-materializing path, not bake `global.get -1`.
+        if (strIdx !== undefined && strIdx >= 0) {
           fctx.body.push({ op: "global.get", index: strIdx } as Instr);
         } else {
           compileStringLiteral(ctx, fctx, builtinName);
@@ -9185,9 +9190,9 @@ function compileCallExpression(
       if (ts.isIdentifier(propAccess.expression)) {
         const captured = ctx.funcSourceText.get(propAccess.expression.text);
         if (captured) {
+          // (#2515 S0) sentinel-safe materialization (standalone bakes `-1`).
           addStringConstantGlobal(ctx, captured);
-          const idx = ctx.stringGlobalMap.get(captured)!;
-          fctx.body.push({ op: "global.get", index: idx });
+          fctx.body.push(...stringConstantExternrefInstrs(ctx, captured));
           return { kind: "externref" };
         }
       }
@@ -9238,14 +9243,14 @@ function compileCallExpression(
           const captured = ctx.funcSourceText.get(propAccess.expression.text);
           if (captured) toStrStr = captured;
         }
+        // (#2515 S0) sentinel-safe — standalone stores `-1` for the string
+        // constant, so materialize inline rather than baking `global.get -1`.
         addStringConstantGlobal(ctx, toStrStr);
-        const idx = ctx.stringGlobalMap.get(toStrStr)!;
-        fctx.body.push({ op: "global.get", index: idx });
+        fctx.body.push(...stringConstantExternrefInstrs(ctx, toStrStr));
       } else {
         const str = isArray ? "[object Array]" : "[object Object]";
         addStringConstantGlobal(ctx, str);
-        const idx = ctx.stringGlobalMap.get(str)!;
-        fctx.body.push({ op: "global.get", index: idx });
+        fctx.body.push(...stringConstantExternrefInstrs(ctx, str));
       }
       return { kind: "externref" };
     }

--- a/tests/issue-2515.test.ts
+++ b/tests/issue-2515.test.ts
@@ -145,6 +145,40 @@ describe("#2515 S0 — standalone late-import global-index-shift emit bug", () =
     // No `string_constants::*` global imports — standalone materializes inline.
     expect(hostImports.some((l) => l.startsWith("string_constants::"))).toBe(false);
   });
+
+  // ── S0 slice 2: calls.ts producers (toString fallback + builtin-name dispatch) ──
+
+  it(".toString() fallback string ('[object Object]') compiles + instantiates standalone (no -1 emit)", async () => {
+    // calls.ts materialized the toString fallback string via a raw
+    // `global.get <stringGlobalMap.get(str)!>` → `global.get -1` under standalone
+    // (the Number/Boolean.prototype.toString borrowed-method cluster). S0's claim
+    // is the emit-CE is gone: the module compiles + validates + instantiates
+    // under empty imports. (Exact `[object Object]` round-trip via native-string
+    // `.length` is a separate `.toString()`-semantics path, not S0.)
+    const obj = await compile(
+      `export function test(): number { const o: any = {}; const s = o.toString(); return s !== null ? 1 : 0; }`,
+      { fileName: "test.ts", target: "standalone" },
+    );
+    expect(obj.success, obj.success ? "" : obj.errors.map((e) => e.message).join("\n")).toBe(true);
+    const hostImports = obj.imports.map((i) => `${i.module}::${i.name}`);
+    expect(hostImports.some((l) => l.startsWith("string_constants::"))).toBe(false);
+    // Instantiates under empty imports without trapping (the S0 acceptance).
+    await WebAssembly.instantiate(obj.binary, {});
+  });
+
+  it("function .toString() (captured source) compiles standalone without a -1 global", async () => {
+    const r = await compile(
+      `function f(): number { return 1; } export function test(): number { return f.toString().length > 0 ? 1 : 0; }`,
+      { fileName: "test.ts", target: "standalone" },
+    );
+    if (!r.success) {
+      const msg = r.errors.map((e) => e.message).join("\n");
+      expect(msg).not.toMatch(/global index out of range/);
+    } else {
+      const { instance } = await WebAssembly.instantiate(r.binary, {});
+      expect((instance.exports as { test?: () => number }).test?.()).toBe(1);
+    }
+  });
 });
 
 describe("#2515 S0 — host (GC) mode unchanged", () => {


### PR DESCRIPTION
## #2515 S0 (slice 2) — calls.ts string-sentinel producers

Continuation of the #2515 S0 keystone (PR #1848, merged). Four more `calls.ts`
producers baked the standalone `-1` string-constant sentinel into a raw
`global.get`:

- the `.toString()` fallback strings (`"[object Object]"` / `"[object Array]"` /
  captured function source) — the `Number/Boolean.prototype.toString`
  borrowed-method cluster;
- the `Function.prototype.toString` captured-source path;
- two builtin-name / class-name dispatch sites guarded only on `!== undefined`,
  which let the in-pool `-1` sentinel through (now `>= 0`, falling to the
  inline-materializing `compileStringLiteral`).

All routed through `stringConstantExternrefInstrs` / `compileStringLiteral` (the
existing dual-mode helpers: inline `$NativeString` under standalone, real
`global.get` under host). Clears the toString + Promise-ctx-ctor sub-clusters
(S0 residual 26 → 20; combined with slice 1: **91 → 20**).

### Validation
- `tests/issue-2515.test.ts` — 10 cases (2 new for this slice), green.
- Host (`gc`) mode unchanged (`o.toString()` still returns `"[object Object]"`).
- `tsc` clean; `check:test262-hard-errors` OK (0, no growth).
- `issue-1463`'s 1 failure pre-exists on `main` (array `.toString()` routing, unrelated).

### Remaining S0 residual (out of this issue's scope)
The remaining 20 live `global.get -1` rows are the **built-in prototype-graph**
read cluster (`SuppressedError.prototype`, `DisposableStack`/`AsyncDisposableStack`
constructor checks) + `Set.prototype.<setop>` subclass-receiver dispatch — these
bake `-1` for a builtin-*static* string read, entangled with the OUT-OF-SCOPE
#2193/#2158/#49 built-in prototype-graph epic, not the open-object string-sentinel
bug. Noted in the issue file for that epic.

Note: S3 (`Object.prototype.toString.call` → `[object X]`) is **already done** by
#2501 (verified: `[object Array]`/`[object Number]` correct in both modes,
standalone via native `$NativeString`, no host import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)