### PR TITLE
fix(#2187): runtime-guarded native-string dispatch for any-typed receivers

### DIFF
--- a/plan/issues/2187-any-typed-local-string-method-dispatch-by-valtype.md
+++ b/plan/issues/2187-any-typed-local-string-method-dispatch-by-valtype.md
@@ -1,10 +1,12 @@
 ---
 id: 2187
 title: "standalone: string methods on an any-typed local with a native-string ValType take the generic externref path (v.length → 0)"
-status: ready
+status: done
 sprint: 64
 created: 2026-06-17
-updated: 2026-06-17
+updated: 2026-06-21
+completed: 2026-06-21
+assignee: sdev-strdispatch
 priority: low
 feasibility: hard
 reasoning_effort: high
@@ -73,3 +75,68 @@ dispatch sites.
 Split from #2171 (string-yield generators, SF-4 of #2157 — landed in
 `c3eb18936`). #2171's own acceptance (iterate + concat) is met; this is the
 per-element string-method residual.
+
+## Implementation (sdev-strdispatch, 2026-06-21)
+
+Generalizes the #2077/#2192 caught-Error precedent to *any* `any`/`unknown`
+receiver whose runtime value may be a native `$AnyString`. Native-string mode
+(`ctx.nativeStrings && ctx.anyStrTypeIdx >= 0`, i.e. standalone/WASI) only —
+host/gc mode is untouched. Probe on `origin/main` `075d90ee5` confirmed the bug
+is in the consumer **dispatch gate** (`isStringType(<TS type>)`), not the
+dynamic value reader.
+
+Two distinct receiver shapes needed two distinct fixes (the spec's single "add
+a guarded arm before L3754" missed that the bug splits by how the receiver
+compiles):
+
+1. **`.length` on an externref `any` value** (`o.v.length`, nested `o.a.b`,
+   `Object.values(o)[0]`, `Object.entries(o)[0][1]`, `catch(e:any).message`).
+   These already flowed through the existing **#1472 Phase B Blocker B Slice 2**
+   arm in `property-access.ts` (`compilePropertyAccess`, the `propName ===
+   "length"` / `ctx.standalone && isAnyOrUnknown` branch), which called
+   `__extern_length` (→ 0 for a bare string). Fix: wrap that call in a runtime
+   `ref.test $AnyString` guard (`emitGuardedNativeStringLength`) — a string hit
+   reads `$AnyString.len` (field 0, valid for FlatString **and** ConsString, no
+   flatten); a miss falls to the unchanged `__extern_length` array/$ObjVec
+   reader. The receiver externref is saved to a temp so both arms reuse it
+   (single eval).
+
+2. **`.length` on a typed `$AnyString` local with TS type `any`** (the
+   string-yield generator loop var `for (const v of g())`, which the backend
+   compiles to a `(ref null $AnyString)` local even though TS infers `any` with
+   no lib types). The generic multi-struct `.length` dispatch only tests **vec**
+   types, never `$AnyString`, so it fell to 0. Fix: in the local-ValType `.length`
+   arm, recognize the native-string family (`isNativeStringFamilyTypeIdx` —
+   `$AnyString`/`$NativeString`/`$ConsString`) and read field 0 directly.
+
+3. **Native string methods on an externref `any` value** (`o.v.charCodeAt(0)`,
+   `o.v.slice(1)`, `o.v.indexOf(...)`). New `compileGuardedNativeStringMethodCall`
+   in `string-ops.ts`: evaluate the receiver once → externref temp, `ref.test
+   $AnyString`; the then-arm casts to `$AnyString` and runs the normal native
+   method lowering via a new `receiverOverride` callback threaded into
+   `compileNativeStringMethodCall` (so the receiver is **not** re-compiled — no
+   double side effects); the else-arm emits the method's spec default for its
+   result ValType. Wired at the calls.ts string-method dispatch site, OR'd via a
+   new `receiverMayBeNativeStringAtRuntime` predicate, scoped to STRING_METHODS
+   names **plus `charCodeAt`** (which has a dedicated arm but is absent from the
+   STRING_METHODS table — otherwise it leaked to the generic `__call_m_<name>`
+   dispatcher and returned 0). `concat` deliberately excluded (collides with
+   `Array.prototype.concat` on an `any` array; out of #2187 scope).
+   `collectStringMethodImports` (index.ts) extended to register the native
+   helpers for `any`-receiver string-method calls so the guard's then-arm has a
+   funcMap target.
+
+Edge cases honored: boxed `String` wrapper stays on its #1910-R4 path (it is a
+`$Object`, `ref.test $AnyString` misses); `any` holding an array keeps
+array-length via the else-arm; null/undefined receiver → `ref.test` false → no
+deref; an `any` holding a number → no spurious string length.
+
+**Out of scope (unchanged, pre-existing on main):** an `any` (not `any[]`)
+holding an **array** calling a string-named array method (`.indexOf`/`.slice`)
+still returns 0 — these already returned 0 on `origin/main` and route through
+the any-receiver array-method dispatch slice, not this read-side fix.
+
+Changed files: `src/codegen/property-access.ts`,
+`src/codegen/expressions/calls.ts`, `src/codegen/string-ops.ts`,
+`src/codegen/index.ts`. Tests: `tests/issue-2187.test.ts` (12 cases incl. all
+ACs + non-regression guards + host-mode parity).

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -59,6 +59,7 @@ import {
   hoistVarDeclarations,
   nativeStringType,
   resolveWasmType,
+  STRING_METHODS,
 } from "../index.js";
 import {
   compileArrayConstructorCall,
@@ -85,6 +86,7 @@ import {
   emitArrayIsArrayExternrefPredicate,
   emitNullCheckThrow,
   receiverIsCaughtErrorStringRead,
+  receiverMayBeNativeStringAtRuntime,
   typeErrorThrowInstrs,
 } from "../property-access.js";
 import type { InnerResult } from "../shared.js";
@@ -99,7 +101,12 @@ import {
   ensureExtrasArgvGlobal,
   maybeSetArgcForKnownCall,
 } from "../statements/nested-declarations.js";
-import { compileNativeStringMethodCall, compileStringLiteral, emitBoolToString } from "../string-ops.js";
+import {
+  compileGuardedNativeStringMethodCall,
+  compileNativeStringMethodCall,
+  compileStringLiteral,
+  emitBoolToString,
+} from "../string-ops.js";
 import { tryCompileNodeProcessCall } from "../node-process-api.js";
 import { isSupportedBuiltinStaticProperty, resolveBuiltinNamespaceValueName } from "../builtin-static-globals.js";
 import {
@@ -8718,6 +8725,35 @@ function compileCallExpression(
         fctx.body.push({ op: "call", funcIdx });
         return { kind: "externref" };
       }
+    }
+
+    // (#2187) Runtime-guarded native string method on an `any`/unknown receiver
+    // whose value MAY be a native `$AnyString` at runtime (object property
+    // value, generator yield var, indexed element read, …). The static
+    // `isStringType` / caught-Error arms below miss these, so the call fell to
+    // the host/dynamic path (null/0 standalone) even though the value is a real
+    // string. Scoped tightly: native-string mode, a known STRING_METHODS name,
+    // and an `any`/unknown receiver that is NOT already a static string (those
+    // take the unconditional arm below). A runtime `ref.test $AnyString` keeps a
+    // non-string `any` (array, number, null) on its benign default.
+    if (
+      ctx.nativeStrings &&
+      ctx.nativeStrTypeIdx >= 0 &&
+      // `compileNativeStringMethodCall` handles the STRING_METHODS table plus
+      // `charCodeAt`, which has a dedicated arm but is not in the table. Gate on
+      // that union so an `any`-receiver `charCodeAt` (an explicit #2187
+      // acceptance criterion) is not left to the generic `__call_m_<name>`
+      // dispatcher. `concat` is deliberately excluded — it collides with
+      // `Array.prototype.concat` on an `any` array and is out of #2187 scope.
+      (Object.prototype.hasOwnProperty.call(STRING_METHODS, propAccess.name.text) ||
+        propAccess.name.text === "charCodeAt") &&
+      !isStringType(receiverType) &&
+      !receiverIsCaughtErrorStringRead(ctx, propAccess.expression) &&
+      receiverMayBeNativeStringAtRuntime(ctx, propAccess.expression)
+    ) {
+      const guarded = compileGuardedNativeStringMethodCall(ctx, fctx, expr, propAccess, propAccess.name.text);
+      if (guarded !== null) return guarded;
+      // Fall through to the generic dispatch on a build failure.
     }
 
     // String method calls

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -7370,7 +7370,21 @@ function collectStringMethodImports(ctx: CodegenContext, sourceFile: ts.SourceFi
       const prop = node.expression;
       const receiverType = ctx.checker.getTypeAtLocation(prop.expression);
       const methodName = prop.name.text;
-      if (isStringType(receiverType) && Object.prototype.hasOwnProperty.call(STRING_METHODS, methodName)) {
+      // (#2187) An `any`/unknown receiver in native-string mode may hold a
+      // native `$AnyString` at runtime; calls.ts emits a runtime-guarded native
+      // string method for it (compileGuardedNativeStringMethodCall). That guard's
+      // then-arm needs the same native helpers (`__str_charAt`, `__str_slice`,
+      // `__str_indexOf`, …) registered, so include `any`-typed receivers calling
+      // a STRING_METHODS name in the pre-scan. Without this the funcMap lookup
+      // misses and the guarded dispatch has no helper to call.
+      const anyReceiverNativeString =
+        (ctx.wasi || ctx.standalone) &&
+        ctx.nativeStrings &&
+        (receiverType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
+      if (
+        (isStringType(receiverType) || anyReceiverNativeString) &&
+        Object.prototype.hasOwnProperty.call(STRING_METHODS, methodName)
+      ) {
         needed.add(methodName);
         // Track if the method has a non-string arg (RegExp or custom object
         // implementing Symbol.replace/Symbol.match/etc). The native helpers

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -1841,6 +1841,89 @@ export function receiverIsCaughtErrorStringRead(ctx: CodegenContext, recv: ts.Ex
 }
 
 /**
+ * (#2187) Generalisation of {@link receiverIsCaughtErrorStringRead}: in
+ * standalone/WASI native-string mode, an `any`/`unknown`-typed receiver MAY hold
+ * a native `$AnyString` ref at runtime even though its TS static type does not
+ * say so (object property values, generator yield vars, catch bindings, indexed
+ * element reads, etc.). The string `.length` / method dispatch sites gate on
+ * `isStringType(<static type>)`, which is false for these, so they fall to the
+ * generic dynamic path (`__extern_get`/`__extern_length`), returning 0 in
+ * standalone even though the value IS a string (see the issue's probe table).
+ *
+ * Unlike the caught-Error predicate — which recognises a statically-known shape
+ * that ALWAYS lowers to a `$AnyString` and can be read unconditionally — the
+ * general `any` case is NOT statically a string, so callers that act on this
+ * predicate MUST emit a runtime `ref.test $AnyString` guard (see
+ * {@link emitGuardedNativeStringLength}) and keep the prior behaviour in the
+ * else arm for non-string values (arrays, numbers, null, …).
+ *
+ * Scope is kept narrow: `any`/`unknown` only (NOT `object`/`{}`, which keep the
+ * struct/host path, and NOT unions containing `string`, which TS already
+ * resolves via the existing `isStringType` arm), and native-string mode only
+ * (host/gc mode is untouched — there the generic `__extern_get` path already
+ * returns the correct length from the real JS value).
+ */
+/**
+ * (#2187) True when a Wasm type index is one of the native-string struct types
+ * (`$AnyString` supertype or its `$NativeString`/`$ConsString` subtypes). Used
+ * to recognize a local/param whose ValType is a native string ref even when its
+ * TS static type is `any`/unknown. Field 0 (`len`) is shared across all three,
+ * so a direct `struct.get <idx> 0` reads the length for any of them. Returns
+ * false outside native-string mode.
+ */
+function isNativeStringFamilyTypeIdx(ctx: CodegenContext, typeIdx: number): boolean {
+  if (!ctx.nativeStrings || ctx.anyStrTypeIdx < 0) return false;
+  return typeIdx === ctx.anyStrTypeIdx || typeIdx === ctx.nativeStrTypeIdx || typeIdx === ctx.consStrTypeIdx;
+}
+
+export function receiverMayBeNativeStringAtRuntime(ctx: CodegenContext, recv: ts.Expression): boolean {
+  if (!(ctx.wasi || ctx.standalone)) return false;
+  if (!ctx.nativeStrings || ctx.anyStrTypeIdx < 0) return false;
+  const t = ctx.checker.getTypeAtLocation(recv);
+  return (t.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
+}
+
+/**
+ * (#2187) Emit a runtime-guarded native-string `.length` read for an
+ * `any`-typed receiver. The receiver's value is assumed to already be on the
+ * stack as an `externref` (the dynamic read — `__extern_get` /
+ * `__extern_get_idx` / generator value / catch binding — yields it that way).
+ *
+ * The externref is saved to a temp; on a `ref.test $AnyString` hit the value is
+ * cast to `$AnyString` and its `len` (field 0, valid for both FlatString and
+ * ConsString — no flatten needed for length) is read; on a miss the
+ * caller-supplied builder produces the prior generic length behaviour (e.g.
+ * `__extern_length` for an array-in-`any`, or `i32.const 0`). The builder
+ * receives the externref temp's local index so it can re-push the original
+ * externref (the test/cast path consumed only the saved copy). Both arms produce
+ * an i32 length.
+ */
+function emitGuardedNativeStringLength(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  buildElseInstrs: (recvExternLocal: number) => Instr[],
+): void {
+  // Save the receiver externref so both arms can use it (the test/cast path
+  // reads a converted copy; the else builder re-pushes the original externref).
+  const recvExtern = allocLocal(fctx, `__strlen_ext_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: recvExtern });
+  fctx.body.push({ op: "local.get", index: recvExtern });
+  fctx.body.push({ op: "any.convert_extern" } as Instr);
+  fctx.body.push({ op: "ref.test", typeIdx: ctx.anyStrTypeIdx } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "i32" } },
+    then: [
+      { op: "local.get", index: recvExtern } as Instr,
+      { op: "any.convert_extern" } as Instr,
+      { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx } as Instr,
+      { op: "struct.get", typeIdx: ctx.anyStrTypeIdx, fieldIdx: 0 } as Instr,
+    ],
+    else: buildElseInstrs(recvExtern),
+  } as Instr);
+}
+
+/**
  * (#2179) When the module uses `delete <member>` (JS-host mode only), route an
  * `any`/`unknown`-typed property READ through the tombstone-aware `__extern_get`
  * host helper instead of the inline `ref.test`+`struct.get` fast-path. Returns
@@ -3426,6 +3509,20 @@ export function compilePropertyAccess(
         // obj.length is undefined on opaque externref objects in V8.
         if ((localType?.kind === "ref" || localType?.kind === "ref_null") && localType.typeIdx !== undefined) {
           const vecTypeIdx = (localType as { typeIdx: number }).typeIdx;
+          // (#2187) Native-string-ref local whose TS static type is `any`/unknown
+          // (e.g. a string-yield generator's `for (const v of g())` loop var, which
+          // has no lib types so it infers `any` but is compiled to a `$AnyString`
+          // ref). The `isStringType(objType)` `.length` arm misses (objType is
+          // `any`), and the generic multi-struct dispatch below only tests vec
+          // types — never `$AnyString` — so the read fell through to 0. Read
+          // `$AnyString.len` (field 0, valid for FlatString & ConsString) directly
+          // from the typed local. Standalone/WASI native-string mode only.
+          if (isNativeStringFamilyTypeIdx(ctx, vecTypeIdx)) {
+            fctx.body.push({ op: "local.get", index: localIdx });
+            fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 });
+            if (!ctx.fast) fctx.body.push({ op: "f64.convert_i32_s" });
+            return ctx.fast ? { kind: "i32" } : { kind: "f64" };
+          }
           const typeDef = ctx.mod.types[vecTypeIdx];
           if (
             typeDef?.kind === "struct" &&
@@ -3564,6 +3661,26 @@ export function compilePropertyAccess(
           }
           const lenFn = ensureLateImport(ctx, "__extern_length", [{ kind: "externref" }], [{ kind: "f64" }]);
           flushLateImportShifts(ctx, fctx);
+          // #2187 — the `any`/unknown value may actually be a native `$AnyString`
+          // (object string-value read, generator yield var, catch binding,
+          // indexed element read). `__extern_length` reads $ObjVec/array length
+          // and returns 0 for a bare string, so guard with `ref.test $AnyString`
+          // first: a string hit reads `$AnyString.len` (field 0); the miss falls
+          // to the existing `__extern_length` array/$ObjVec reader. Always
+          // computes an i32 length, converted to f64 once below in !fast mode.
+          if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
+            emitGuardedNativeStringLength(ctx, fctx, (recvExternLocal) =>
+              lenFn !== undefined
+                ? [
+                    { op: "local.get", index: recvExternLocal } as Instr,
+                    { op: "call", funcIdx: lenFn } as Instr,
+                    { op: "i32.trunc_sat_f64_s" } as Instr,
+                  ]
+                : [{ op: "i32.const", value: 0 } as Instr],
+            );
+            if (!ctx.fast) fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
+            return ctx.fast ? { kind: "i32" } : { kind: "f64" };
+          }
           if (lenFn !== undefined) {
             fctx.body.push({ op: "call", funcIdx: lenFn } as Instr);
             if (ctx.fast) fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -8,7 +8,7 @@ import type { Instr, ValType } from "../ir/types.js";
  */
 import { ts } from "../ts-api.js";
 import { compileNumericBinaryOp } from "./binary-ops.js";
-import { pushBody } from "./context/bodies.js";
+import { popBody, pushBody } from "./context/bodies.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal } from "./context/locals.js";
 import type { ClosureInfo, CodegenContext, FunctionContext } from "./context/types.js";
@@ -2099,10 +2099,25 @@ export function compileNativeStringMethodCall(
   expr: ts.CallExpression,
   propAccess: ts.PropertyAccessExpression,
   method: string,
+  /**
+   * (#2187) Optional receiver emitter. When provided, the method arms push the
+   * receiver via this callback instead of re-compiling `propAccess.expression`.
+   * Used by {@link compileGuardedNativeStringMethodCall} to feed a pre-evaluated,
+   * guard-cast `$AnyString` receiver (so an `any`-typed receiver is evaluated
+   * exactly once and only after a runtime `ref.test $AnyString` succeeds). The
+   * callback must push one value (a native-string ref / `$AnyString`) and return
+   * its ValType, mirroring `compileExpression`'s contract.
+   */
+  receiverOverride?: () => ValType | null,
 ): ValType | null {
   const strTypeIdx = ctx.nativeStrTypeIdx;
   const strDataTypeIdx = ctx.nativeStrDataTypeIdx;
   const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten")!;
+
+  // (#2187) Single indirection for emitting the receiver. Default re-compiles
+  // `propAccess.expression`; the guarded `any`-receiver path overrides it.
+  const emitReceiver = (): ValType | null =>
+    receiverOverride ? receiverOverride() : compileExpression(ctx, fctx, propAccess.expression);
 
   // Helper: emit a flatten call to convert ref $AnyString → ref $NativeString
   const emitFlatten = () => fctx.body.push({ op: "call", funcIdx: flattenIdx });
@@ -2135,7 +2150,7 @@ export function compileNativeStringMethodCall(
   // ECMA-262 §22.1.3.3: ToIntegerOrInfinity(pos), then return NaN when
   // the resulting position is outside [0, string length).
   if (method === "charCodeAt") {
-    compileExpression(ctx, fctx, propAccess.expression);
+    emitReceiver();
     // Flatten to FlatString (handles ConsString → FlatString)
     const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten")!;
     fctx.body.push({ op: "call", funcIdx: flattenIdx });
@@ -2178,7 +2193,7 @@ export function compileNativeStringMethodCall(
 
   // charAt: native helper
   if (method === "charAt") {
-    compileExpression(ctx, fctx, propAccess.expression);
+    emitReceiver();
     emitFlatten();
     if (expr.arguments.length > 0) {
       compileStringIntegerArg(ctx, fctx, expr.arguments[0]!);
@@ -2192,7 +2207,7 @@ export function compileNativeStringMethodCall(
 
   // at: like charAt but supports negative indices
   if (method === "at") {
-    compileExpression(ctx, fctx, propAccess.expression);
+    emitReceiver();
     emitFlatten();
     const strTmp = allocLocal(fctx, `__str_at_tmp_${fctx.locals.length}`, flatStringType(ctx));
     fctx.body.push({ op: "local.tee", index: strTmp });
@@ -2262,7 +2277,7 @@ export function compileNativeStringMethodCall(
   if (method === "concat") {
     const concatIdx = ctx.nativeStrHelpers.get("__str_concat")!;
     // Receiver is the running accumulator.
-    compileExpression(ctx, fctx, propAccess.expression);
+    emitReceiver();
     if (expr.arguments.length === 0) {
       // `"x".concat()` returns the receiver unchanged.
       return nativeStringType(ctx);
@@ -2277,7 +2292,7 @@ export function compileNativeStringMethodCall(
 
   // substring: native helper
   if (method === "substring") {
-    compileExpression(ctx, fctx, propAccess.expression);
+    emitReceiver();
     emitFlatten();
     // start
     if (expr.arguments.length > 0) {
@@ -2302,7 +2317,7 @@ export function compileNativeStringMethodCall(
 
   // slice: native helper (handles negative indices)
   if (method === "slice") {
-    compileExpression(ctx, fctx, propAccess.expression);
+    emitReceiver();
     emitFlatten();
     // start
     if (expr.arguments.length > 0) {
@@ -2325,7 +2340,7 @@ export function compileNativeStringMethodCall(
   // end index; an absent length means "to the end" → pass 0x7fffffff sentinel
   // and let __str_substr clamp to `len - start`.
   if (method === "substr") {
-    compileExpression(ctx, fctx, propAccess.expression);
+    emitReceiver();
     emitFlatten();
     // start
     if (expr.arguments.length > 0 && !isStaticUndefinedArg(expr.arguments[0])) {
@@ -2419,7 +2434,7 @@ export function compileNativeStringMethodCall(
 
   // trim, trimStart, trimEnd: native helpers
   if (method === "trim" || method === "trimStart" || method === "trimEnd") {
-    compileExpression(ctx, fctx, propAccess.expression);
+    emitReceiver();
     emitFlatten();
     const helperName = `__str_${method}`;
     const funcIdx = ctx.nativeStrHelpers.get(helperName)!;
@@ -2429,7 +2444,7 @@ export function compileNativeStringMethodCall(
 
   // repeat: native helper with RangeError validation
   if (method === "repeat") {
-    compileExpression(ctx, fctx, propAccess.expression);
+    emitReceiver();
     emitFlatten();
     if (expr.arguments.length > 0) {
       // BigInt / Symbol args → TypeError per ToNumber spec (#1445)
@@ -2486,7 +2501,7 @@ export function compileNativeStringMethodCall(
 
   // padStart: native helper
   if (method === "padStart") {
-    compileExpression(ctx, fctx, propAccess.expression);
+    emitReceiver();
     emitFlatten();
     // targetLength (ToLength per spec — throws TypeError on BigInt/Symbol)
     if (expr.arguments.length > 0) {
@@ -2517,7 +2532,7 @@ export function compileNativeStringMethodCall(
 
   // padEnd: native helper
   if (method === "padEnd") {
-    compileExpression(ctx, fctx, propAccess.expression);
+    emitReceiver();
     emitFlatten();
     // targetLength (ToLength per spec — throws TypeError on BigInt/Symbol)
     if (expr.arguments.length > 0) {
@@ -2557,7 +2572,7 @@ export function compileNativeStringMethodCall(
     // toLowerCase/toUpperCase except for locale-sensitive mappings, which a
     // standalone module has no ICU tables for). Previously these fell through
     // to "Unknown string method" and got demoted to a numeric-zero stub.
-    compileExpression(ctx, fctx, propAccess.expression);
+    emitReceiver();
     emitFlatten();
     // Locale arguments are still evaluated, in order, for side effects.
     for (const arg of expr.arguments) {
@@ -2578,7 +2593,7 @@ export function compileNativeStringMethodCall(
   // consistency requirement (every pair compared "equal"). The locales /
   // options arguments are evaluated for side effects and ignored.
   if (method === "localeCompare") {
-    compileExpression(ctx, fctx, propAccess.expression);
+    emitReceiver();
     const thatLocal = compileStringValueToLocal(expr.arguments[0], "undefined", "__lc_that");
     for (let ai = 1; ai < expr.arguments.length; ai++) {
       const argType = compileExpression(ctx, fctx, expr.arguments[ai]!);
@@ -2622,7 +2637,7 @@ export function compileNativeStringMethodCall(
 
   // replace(search, replacement): native helper
   if (method === "replace" && firstArgIsStringLike) {
-    compileExpression(ctx, fctx, propAccess.expression);
+    emitReceiver();
     emitFlatten();
     // search arg
     if (expr.arguments.length > 0) {
@@ -2653,7 +2668,7 @@ export function compileNativeStringMethodCall(
 
   // replaceAll(search, replacement): native helper
   if (method === "replaceAll" && firstArgIsStringLike) {
-    compileExpression(ctx, fctx, propAccess.expression);
+    emitReceiver();
     emitFlatten();
     // search arg
     if (expr.arguments.length > 0) {
@@ -2684,7 +2699,7 @@ export function compileNativeStringMethodCall(
 
   // split: native helper, returns native string array
   if (method === "split" && firstArgIsStringLike) {
-    compileExpression(ctx, fctx, propAccess.expression);
+    emitReceiver();
     emitFlatten();
     // separator arg
     if (expr.arguments.length > 0) {
@@ -2721,7 +2736,7 @@ export function compileNativeStringMethodCall(
   // sentinel, and combines a valid UTF-16 surrogate pair when one starts at
   // position.
   if (method === "codePointAt") {
-    compileExpression(ctx, fctx, propAccess.expression);
+    emitReceiver();
     emitFlatten();
     const tmpLocal = allocLocal(fctx, "__codePointAt_tmp", flatStringType(ctx));
     fctx.body.push({ op: "local.set", index: tmpLocal });
@@ -2839,7 +2854,7 @@ export function compileNativeStringMethodCall(
       // (preserving its side effects in order), then compile + drop the form
       // argument (still evaluated for its side effects, after the receiver),
       // then read the receiver temp back as the (identity) result.
-      const recvType = compileExpression(ctx, fctx, propAccess.expression);
+      const recvType = emitReceiver();
       const recvValType = (recvType ?? nativeStringType(ctx)) as ValType;
       const recvLocal = allocLocal(fctx, `__normalize_recv_${fctx.locals.length}`, recvValType);
       fctx.body.push({ op: "local.set", index: recvLocal });
@@ -2850,7 +2865,7 @@ export function compileNativeStringMethodCall(
       fctx.body.push({ op: "local.get", index: recvLocal });
       return recvType;
     }
-    return compileExpression(ctx, fctx, propAccess.expression);
+    return emitReceiver();
   }
 
   // #1474/#1539 — These host-routed string methods build/consume a JS RegExp
@@ -2933,7 +2948,7 @@ export function compileNativeStringMethodCall(
     ensureNativeStringExternBridge(ctx);
     flushLateImportShifts(ctx, fctx);
     // Marshal receiver: flatten + native string -> externref
-    compileExpression(ctx, fctx, propAccess.expression);
+    emitReceiver();
     emitFlatten();
     const toExternIdx = ctx.nativeStrHelpers.get("__str_to_extern")!;
     fctx.body.push({ op: "call", funcIdx: toExternIdx });
@@ -2975,6 +2990,90 @@ export function compileNativeStringMethodCall(
 
   reportError(ctx, expr, `Unknown string method: ${method}`);
   return null;
+}
+
+/**
+ * (#2187) Runtime-guarded native string method dispatch for an `any`/unknown
+ * receiver whose value MAY be a native `$AnyString` at runtime (object property
+ * values, generator yield vars, catch bindings, indexed element reads — see
+ * {@link receiverMayBeNativeStringAtRuntime}). The static `isStringType` gate
+ * misses these, so without this the call fell to the host/dynamic path
+ * (null/0 standalone).
+ *
+ * Evaluates the receiver EXACTLY ONCE into an externref temp (preserving side
+ * effects and ordering), then `ref.test $AnyString`:
+ *   - hit  → cast the saved externref to `$AnyString` and run the normal native
+ *            method lowering against it (via `compileNativeStringMethodCall`'s
+ *            receiver override — the receiver is NOT re-compiled),
+ *   - miss → the method's spec default for its result type (so a non-string
+ *            `any` — array, number, null — does not trap and yields a benign
+ *            default rather than a wrong value).
+ *
+ * Standalone/WASI native-string mode only; the caller gates on
+ * `ctx.nativeStrings && ctx.anyStrTypeIdx >= 0`.
+ */
+export function compileGuardedNativeStringMethodCall(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  propAccess: ts.PropertyAccessExpression,
+  method: string,
+): ValType | null {
+  // Evaluate the receiver once → externref temp (side effects happen here only).
+  const recvType = compileExpression(ctx, fctx, propAccess.expression);
+  if (recvType && recvType.kind !== "externref") {
+    // Box/convert whatever the dynamic read produced into an externref so the
+    // ref.test/cast operate on a uniform representation. A native-string ref
+    // round-trips losslessly via extern.convert_any.
+    fctx.body.push({ op: "extern.convert_any" } as Instr);
+  } else if (!recvType) {
+    fctx.body.push({ op: "ref.null.extern" } as Instr);
+  }
+  const recvExt = allocLocal(fctx, `__strm_ext_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: recvExt });
+
+  // Build the then-arm (native method on the cast $AnyString receiver) into a
+  // separate body so we can learn its result ValType before shaping the else.
+  const savedBody = pushBody(fctx);
+  const resultType = compileNativeStringMethodCall(ctx, fctx, expr, propAccess, method, () => {
+    // Receiver override: re-push the saved externref, cast to $AnyString.
+    fctx.body.push({ op: "local.get", index: recvExt } as Instr);
+    fctx.body.push({ op: "any.convert_extern" } as Instr);
+    fctx.body.push({ op: "ref.cast", typeIdx: ctx.anyStrTypeIdx } as Instr);
+    return { kind: "ref", typeIdx: ctx.anyStrTypeIdx };
+  });
+  const thenInstrs = fctx.body;
+  popBody(fctx, savedBody);
+
+  if (resultType === null) return null;
+
+  // else-arm: the spec default for the result ValType (non-string receiver).
+  const elseInstrs: Instr[] = [];
+  if (resultType.kind === "f64") {
+    // index-returning methods (indexOf/lastIndexOf/search) default to -1; the
+    // value-returning numeric methods (codePointAt) default to NaN. Use NaN as
+    // the conservative "no result" — these only fire on a non-string `any`,
+    // which is already out-of-contract, and NaN is the safe undefined-number.
+    elseInstrs.push({ op: "f64.const", value: NaN } as Instr);
+  } else if (resultType.kind === "i32") {
+    elseInstrs.push({ op: "i32.const", value: 0 } as Instr);
+  } else if (resultType.kind === "ref" || resultType.kind === "ref_null") {
+    elseInstrs.push({ op: "ref.null", typeIdx: (resultType as { typeIdx: number }).typeIdx } as Instr);
+  } else {
+    elseInstrs.push({ op: "ref.null.extern" } as Instr);
+  }
+
+  // Guard: if the saved value is a $AnyString, run the method; else default.
+  fctx.body.push({ op: "local.get", index: recvExt });
+  fctx.body.push({ op: "any.convert_extern" } as Instr);
+  fctx.body.push({ op: "ref.test", typeIdx: ctx.anyStrTypeIdx } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: resultType },
+    then: thenInstrs,
+    else: elseInstrs,
+  } as Instr);
+  return resultType;
 }
 
 // Register the compileStringLiteral delegate so property-access.ts can emit

--- a/tests/issue-2187.test.ts
+++ b/tests/issue-2187.test.ts
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+/**
+ * #2187 — string methods / `.length` on an `any`-typed receiver whose runtime
+ * value is a native `$AnyString` take the generic externref path and return 0
+ * in standalone mode.
+ *
+ * Root cause: `.length` / string-method dispatch gates on `isStringType(<TS
+ * static type>)`. For an `any`/unknown receiver that predicate is false, so the
+ * read fell to the host/dynamic path (null ⇒ 0 standalone), even though the
+ * value IS a real native string (`String(o.v)`-style concat already works
+ * because it keys off the operand ValType, not the TS type). The fix routes
+ * `.length` and the native string methods through a runtime `ref.test
+ * $AnyString` guard at the `any`-receiver dispatch sites (a string hit reads the
+ * native path; a miss keeps the prior generic behaviour), generalizing the
+ * #2077/#2192 caught-Error precedent. Native-string mode (standalone/WASI) only;
+ * host/gc mode is untouched.
+ */
+
+const BANNED_HOST_GET: ReadonlyArray<RegExp> = [
+  /^env::__extern_get$/,
+  /^env::__extern_get_idx$/,
+  /^env::__extern_length$/,
+];
+
+function assertNoHostObjectImports(imports: ReadonlyArray<{ module: string; name: string }>): void {
+  const labels = imports.map((i) => `${i.module}::${i.name}`);
+  for (const re of BANNED_HOST_GET) {
+    const hits = labels.filter((l) => re.test(l));
+    expect(hits, `--target standalone leaked ${re} (got ${hits.join(", ")})`).toEqual([]);
+  }
+}
+
+async function runStandalone(source: string): Promise<number> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module must validate").toBe(true);
+  assertNoHostObjectImports(r.imports);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as Record<string, () => number>).test();
+}
+
+describe("#2187 — string method / .length on an any-typed native-string receiver (standalone)", () => {
+  it("object string-value: o.v.length and o.v.charCodeAt(0)", async () => {
+    expect(await runStandalone(`export function test(): number { const o:any={v:"hi"}; return o.v.length; }`)).toBe(2);
+    expect(
+      await runStandalone(`export function test(): number { const o:any={v:"hi"}; return o.v.charCodeAt(0); }`),
+    ).toBe(104);
+  });
+
+  it("string-yield generator loop var (the #2187 own repro)", async () => {
+    expect(
+      await runStandalone(
+        `function* g(){ yield "a"; yield "b"; }
+         export function test(): number { let n = 0; for (const v of g()) n += v.length; return n; }`,
+      ),
+    ).toBe(2);
+    expect(
+      await runStandalone(
+        `function* g(){ yield "ab"; }
+         export function test(): number { let r = 0; for (const v of g()) r = v.charCodeAt(0); return r; }`,
+      ),
+    ).toBe(97);
+  });
+
+  it("caught-error any binding: e.message.length and e.message.charCodeAt(0)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { try { throw new Error("oops"); } catch(e:any){ return e.message.length; } }`,
+      ),
+    ).toBe(4);
+    expect(
+      await runStandalone(
+        `export function test(): number { try { throw new Error("oops"); } catch(e:any){ return e.message.charCodeAt(0); } }`,
+      ),
+    ).toBe(111);
+  });
+
+  it("nested any read: o.a.b.length", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const o:any={a:{b:"hi"}}; return o.a.b.length; }`),
+    ).toBe(2);
+  });
+
+  it("indexed element read-back: Object.values / Object.entries string elements", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o:any={a:"xx",b:"yy"}; return (Object.values(o)[0] as any).length; }`,
+      ),
+    ).toBe(2);
+    expect(
+      await runStandalone(
+        `export function test(): number { const o:any={k:"hi"}; return (Object.entries(o)[0][1] as any).length; }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("native string methods on an any receiver (slice/indexOf round-trip)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const o:any={v:"hello"}; return o.v.slice(1).length; }`),
+    ).toBe(4);
+    expect(
+      await runStandalone(`export function test(): number { const o:any={v:"hello"}; return o.v.indexOf("l"); }`),
+    ).toBe(2);
+  });
+
+  // ── Non-regression guards ────────────────────────────────────────────────
+
+  it("numeric any sibling still reads numeric", async () => {
+    expect(await runStandalone(`export function test(): number { const o:any={n:7}; return o.n; }`)).toBe(7);
+  });
+
+  it("Object.values(o).length (vec length) is unaffected by the string guard", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o:any={a:"xx",b:"yy"}; return Object.values(o).length; }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("String wrapper .length keeps its own path", async () => {
+    expect(await runStandalone(`export function test(): number { return new String("hi").length; }`)).toBe(2);
+  });
+
+  it("an any holding a number does not produce a spurious string length", async () => {
+    // A number value is not a native string → ref.test $AnyString misses → 0,
+    // not a wrong positive length.
+    expect(
+      await runStandalone(`export function test(): number { const o:any={n:5}; const x:any=o.n; return x.length; }`),
+    ).toBe(0);
+  });
+
+  it("statically string-typed receivers are unchanged", async () => {
+    expect(await runStandalone(`export function test(): number { const s="hello"; return s.length; }`)).toBe(5);
+    expect(await runStandalone(`export function test(): number { const s="hi"; return s.charCodeAt(0); }`)).toBe(104);
+    expect(await runStandalone(`export function test(): number { const s="hello"; return s.slice(1).length; }`)).toBe(
+      4,
+    );
+  });
+
+  it("host/gc mode: the same any string-value read still returns the length (path untouched)", async () => {
+    const exports = await compileToWasm(`export function test(): number { const o:any={v:"hi"}; return o.v.length; }`);
+    expect((exports as Record<string, () => number>).test()).toBe(2);
+  });
+});


### PR DESCRIPTION
## #2187 — string `.length` / methods on an `any`-typed native-string receiver (standalone)

String `.length` and string methods on an `any`/`unknown` receiver whose runtime value is a native `$AnyString` took the generic externref path and returned **0** in standalone, because dispatch gates on `isStringType(<TS static type>)` — false for an `any` receiver even though the value IS a real string (`String(o.v)`-style concat already works because it keys off the operand ValType).

Generalizes the #2077/#2192 caught-Error precedent with a runtime `ref.test $AnyString` guard at the any-receiver dispatch sites. **Native-string mode (standalone/WASI) only — host/gc mode is untouched.**

### Fixes (all verified)
- `o.v.length` → 2, `o.v.charCodeAt(0)` → 104
- string-yield generator: `for (const v of g()) n += v.length` → 2; `v.charCodeAt(0)` → 97
- `catch (e:any) { e.message.length / .charCodeAt(0) }` → 4 / 111
- nested `o.a.b.length` → 2
- indexed read-back: `Object.values(o)[0].length`, `Object.entries(o)[0][1].length` → 2
- native methods on `any`: `o.v.slice(1).length` → 4, `o.v.indexOf("l")` → 2

### Approach (3 receiver shapes)
1. **`.length` on an externref `any`** — guard the existing #1472 Slice-2 `__extern_length` arm: string hit → `$AnyString.len`; miss → unchanged array/$ObjVec reader.
2. **`.length` on a typed `$AnyString` local with TS type `any`** (generator loop var) — read field 0 directly via `isNativeStringFamilyTypeIdx`.
3. **native string methods on an externref `any`** — `compileGuardedNativeStringMethodCall` + a `receiverOverride` on `compileNativeStringMethodCall` (single receiver eval, no re-compile), wired through a new `receiverMayBeNativeStringAtRuntime` predicate. `collectStringMethodImports` registers the helpers.

### Non-regression
Boxed `String` wrapper keeps its #1910-R4 path; `any` holding an array keeps array-length; null/number `any` → benign default. `any` (not `any[]`) holding an **array** calling a string-named array method stays at 0 (pre-existing on `main`, out of scope). Full string-method + generator + property-access equivalence suites pass; the 9 pre-existing #1472 slice failures are identical on `main`.

Tests: `tests/issue-2187.test.ts` (12 cases incl. all ACs, non-regression guards, host-mode parity).

Changed: `src/codegen/property-access.ts`, `src/codegen/expressions/calls.ts`, `src/codegen/string-ops.ts`, `src/codegen/index.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)