### PR TITLE
fix(#2568): standalone two-level nested destructuring-param default reads 0 — struct-shape match

### DIFF
--- a/plan/issues/2568-standalone-nested-dstr-param-default-object.md
+++ b/plan/issues/2568-standalone-nested-dstr-param-default-object.md
@@ -1,9 +1,12 @@
 ---
 id: 2568
 title: "standalone: nested destructuring-param default OBJECT yields 0 — two-level `{ w: {x,y,z} = {…} } = { w: {…} }` reads sentinels in standalone mode"
-status: ready
+status: done
 sprint: 64
 created: 2026-06-21
+updated: 2026-06-21
+completed: 2026-06-21
+assignee: sd-5
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -11,8 +14,9 @@ task_type: bugfix
 area: codegen
 language_feature: destructuring
 goal: standalone-completeness
-related: [2545, 2544, 2158]
+related: [2545, 2544, 2158, 1712]
 origin: "2026-06-21 — found by sd-1 while regression-guarding #2545: the host nested-default value flow is correct, but the SAME source returns 0 in standalone mode."
+resolution: "2026-06-21 (sd-5): two struct-representation mismatches (a #1712-family bug). (1) OUTER default: the in-method/in-function default object literal was compiled against the externref param type, boxing the nested field to externref → a struct shape `{ w: externref }` that does NOT match the `{ w: (ref null $inner) }` shape the destructuring ref.test/ref.cast derives from the pattern type → ref.test fails → __extern_get else-branch reads 0. Fixed by compiling the default against the binding-pattern's STRUCT type (new structHintForBindingPattern) at both the class-method (class-bodies.ts) and plain-function (function-body.ts) param-default sites. (2) INNER default: in the externref destructuring path the nested default object was a closed struct, but bindings are read back via __extern_get (which only indexes a $Object) → 0. Fixed by materializing the inner default as a $Object via compileObjectLiteralAsExternref (destructuring-params.ts), mirroring literals.ts:272. Host mode uniform-JS-object, unaffected. Verified: outer→123, inner→456, provided→123, single-level→7, last-field→9, plain-function→1, all standalone. New test tests/issue-2568-standalone-nested-dstr-default.test.ts."
 ---
 
 # #2568 — standalone nested destructuring-param default object reads sentinels

--- a/plan/issues/2575-standalone-array-forin-index-enumeration.md
+++ b/plan/issues/2575-standalone-array-forin-index-enumeration.md
@@ -1,0 +1,72 @@
+---
+id: 2575
+title: "standalone: for-in over an array static-unrolls members, not numeric indices (no $ObjVec / index walk)"
+status: ready
+sprint: Backlog
+created: 2026-06-21
+updated: 2026-06-21
+priority: low
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen, runtime
+language_feature: for-in, arrays
+goal: standalone-mode
+related: [2572, 1837]
+test262_bucket: standalone-array-forin
+es_edition: es5
+origin: "Follow-up to #2572 (sd-5, 2026-06-21). #2572 fixed standalone for-in over a dynamic $Object via the native key walk and made array for-in *instantiate* instead of leaking, but array for-in still routes to the static-unroll path which enumerates the array type's static members, not its own numeric indices."
+---
+
+# #2575 — standalone for-in over an array enumerates members, not indices
+
+## Problem
+
+`for (const k in arr)` must enumerate the array's **own enumerable property
+keys** — the numeric indices `"0".."length-1"` (as strings), in ascending order
+(§13.7.5 / OrdinaryOwnPropertyKeys integer-index rule). In standalone mode an
+array for-in instead routes to the for-in **static-unroll** fallback
+(`src/codegen/statements/loops.ts` `compileForInStatement`), which enumerates the
+_static array type's_ `getProperties()` — i.e. `length` and the Array prototype
+members — not the live indices.
+
+```ts
+const a = [10, 20, 30];
+let n = 0;
+for (const k in a) n++;
+// expected: 3   standalone: enumerates static members (wrong count)
+```
+
+After #2572 this **instantiates** (the `__for_in_*` host-import leak is gone),
+but the enumerated key set is wrong.
+
+## Why separate from #2572
+
+#2572 routed the **dynamic `$Object`** receiver through the native object
+runtime (`__object_keys` walk). An array is not a `$Object` — it lowers to a
+WasmGC array/vec — so `__object_keys` would return empty and the static-unroll
+path was kept for it. Array index enumeration needs its own native key source.
+
+## Fix direction
+
+In `compileForInStatement`, when the standalone receiver lowers to an array/vec
+(not `$Object`, not a closed struct), enumerate the live indices: read the array
+length and emit each index `i` ToString'd to its decimal key (`number_toString`,
+the same helper `__object_keys` uses for integer keys), in ascending order
+(integer-index keys come first per OrdinaryOwnPropertyKeys, #1837). The loop
+scaffolding (counter, `$break`/`$continue`, #2066 liveness) can be shared with
+the existing path; only the key source differs. A sparse array (#2001 holes)
+must skip hole indices — coordinate with the $Hole representation.
+
+## Acceptance criteria
+
+- `const a=[10,20,30]; for (const k in a) …` enumerates `"0","1","2"` in order,
+  count 3, in `target: "standalone"`; no `env.__for_in_*` import.
+- Enumeration is ascending integer-index order.
+- A sparse array (`const a=[1,,3]`) skips the hole index (coordinate with #2001).
+- JS-host array for-in unchanged.
+
+## Notes
+
+Follow-up to #2572. Lower priority than the dynamic-object case (array for-in is
+less common). Found by sd-5's #2572 edge testing.

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -19,6 +19,7 @@ import {
   destructureParamArray,
   destructureParamObject,
   isNullOrUndefinedLiteral,
+  structHintForBindingPattern,
 } from "./destructuring-params.js";
 import { emitThrowReferenceError, getFuncParamTypes } from "./expressions/helpers.js";
 import { pushDefaultValue } from "./type-coercion.js";
@@ -1982,14 +1983,36 @@ function compileClassBodiesInner(
           if (isArrayPatternExternref) {
             (ctx as unknown as { _arrayLiteralForceVec?: boolean })._arrayLiteralForceVec = true;
           }
+          // (#2568) For an OBJECT binding pattern whose param lowers to externref
+          // (standalone / dynamic object), compile the default object literal
+          // against the binding pattern's STRUCT type rather than externref.
+          // Hinting externref boxes each nested field to externref, producing a
+          // struct shape (`{ w: externref }`) that does NOT match the shape the
+          // destructuring `ref.test`/`ref.cast` derives from the pattern's TS type
+          // (`{ w: (ref null $inner) }`). The mismatch makes the fast struct path's
+          // `ref.test` fail, dropping to the __extern_get else-branch which can't
+          // read the boxed nested fields → the bindings read 0. Materializing the
+          // default as the pattern's struct (then `extern.convert_any` to the
+          // externref param local, which preserves struct identity) makes the
+          // later `ref.test` succeed — exactly the shape the call-site (provided
+          // value) path already builds. Host mode is uniform-JS-object and uses
+          // the externref hint unchanged.
+          const objectPatternStructHint =
+            ts.isObjectBindingPattern(param.name) && paramType.kind === "externref"
+              ? structHintForBindingPattern(ctx, param.name)
+              : undefined;
           let methDfltType: ValType | null;
           try {
-            methDfltType = compileExpression(ctx, fctx, param.initializer, paramType);
+            methDfltType = compileExpression(ctx, fctx, param.initializer, objectPatternStructHint ?? paramType);
           } finally {
             if (isArrayPatternExternref) {
               (ctx as unknown as { _arrayLiteralForceVec?: boolean })._arrayLiteralForceVec = prevForceVec;
             }
           }
+          // Coerce the materialized value to the param's wasm type (externref).
+          // When we hinted a struct, this is the struct→externref `extern.convert_any`
+          // that boxes the struct ref into the externref param while preserving its
+          // concrete struct identity for the downstream `ref.test`.
           if (methDfltType && !valTypesMatch(methDfltType, paramType)) {
             coerceType(ctx, fctx, methDfltType, paramType);
           }

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -19,6 +19,7 @@ import {
 } from "./index.js";
 import { addImport, addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
 import { emitWasiErrorConstructor } from "./registry/error-types.js";
+import { compileObjectLiteralAsExternref } from "./literals.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { emitLocalTdzInit } from "./statements/tdz.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
@@ -536,7 +537,25 @@ export function destructureParamObjectExternref(
           const initThen: Instr[] = [];
           fctx.body = initThen;
           // Compile initializer; coerce to externref so we can store back.
-          const initType = compileExpression(ctx, fctx, element.initializer, elemType);
+          // (#2568) In a no-JS-host target the nested binding's value is read
+          // back through `__extern_get` (this is the externref destructuring
+          // path). A plain object-literal default compiled with the externref
+          // hint materializes as a CLOSED STRUCT (`extern.convert_any` of a
+          // WasmGC struct), which `__extern_get` cannot index → the inner
+          // bindings read 0. Build the default as a `$Object` instead (same fix
+          // as literals.ts:272 for nested struct-consumed literals) so the
+          // subsequent `__extern_get` reads its fields. Only for resolvable
+          // key/value object literals; everything else keeps the normal path.
+          const initIsPlainObjectLiteral =
+            (ctx.standalone || ctx.wasi) &&
+            ts.isObjectLiteralExpression(element.initializer) &&
+            element.initializer.properties.length > 0 &&
+            element.initializer.properties.every(
+              (p) => ts.isPropertyAssignment(p) || ts.isShorthandPropertyAssignment(p),
+            );
+          const initType = initIsPlainObjectLiteral
+            ? compileObjectLiteralAsExternref(ctx, fctx, element.initializer as ts.ObjectLiteralExpression)
+            : compileExpression(ctx, fctx, element.initializer, elemType);
           if (initType && initType.kind !== "externref") {
             if (initType.kind === "ref" || initType.kind === "ref_null") {
               fctx.body.push({ op: "extern.convert_any" } as Instr);
@@ -599,6 +618,48 @@ export function emitExternrefDestructureGuard(ctx: CodegenContext, fctx: Functio
     fctx.body.push({ op: "call", funcIdx: undefIdx });
     fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: buildDestructureNullThrow(ctx, fctx), else: [] });
   }
+}
+
+/**
+ * (#2568) Derive the WasmGC struct type a destructuring object binding pattern
+ * resolves to, as a `ref`-typed compile hint for the pattern's default object
+ * literal. Mirrors the struct-type derivation in `destructureParamObject` below
+ * so an outer param default materializes in the SAME shape the destructuring
+ * `ref.test`/`ref.cast` expects (otherwise the default boxes its nested fields
+ * to externref → a `{ field: externref }` struct that fails the `ref.test`, drops
+ * to the `__extern_get` else-branch, and reads 0). Returns `undefined` when no
+ * resolvable struct exists (rest pattern, missing fields, primitive) — the
+ * caller then keeps the externref hint. Shared by the class-method
+ * (class-bodies.ts) and plain-function (function-body.ts) param-default sites.
+ */
+export function structHintForBindingPattern(
+  ctx: CodegenContext,
+  pattern: ts.ObjectBindingPattern,
+): ValType | undefined {
+  if (pattern.elements.some((e) => ts.isBindingElement(e) && !!e.dotDotDotToken)) return undefined;
+  const tsType = ctx.checker.getTypeAtLocation(pattern);
+  if (!tsType) return undefined;
+  ensureStructForType(ctx, tsType);
+  const typeName = ctx.anonTypeMap.get(tsType) ?? tsType.getSymbol()?.name ?? tsType.aliasSymbol?.name;
+  const structTypeIdx = typeName ? ctx.structMap.get(typeName) : undefined;
+  if (structTypeIdx === undefined) return undefined;
+  // Only hint the struct when every named pattern property is declared on it —
+  // otherwise the destructuring itself abandons the struct fast path and a
+  // struct hint would just mismatch.
+  const structName = ctx.typeIdxToStructName.get(structTypeIdx);
+  const fields = structName ? ctx.structFields.get(structName) : undefined;
+  if (!fields) return undefined;
+  for (const element of pattern.elements) {
+    if (!ts.isBindingElement(element) || element.dotDotDotToken) continue;
+    const pn = element.propertyName ?? element.name;
+    let propText: string | undefined;
+    if (ts.isIdentifier(pn)) propText = pn.text;
+    else if (ts.isStringLiteral(pn)) propText = pn.text;
+    else if (ts.isNumericLiteral(pn)) propText = pn.text;
+    if (propText === undefined) continue;
+    if (!fields.some((f) => f.name === propText)) return undefined;
+  }
+  return { kind: "ref", typeIdx: structTypeIdx };
 }
 
 /**

--- a/src/codegen/function-body.ts
+++ b/src/codegen/function-body.ts
@@ -18,6 +18,7 @@ import {
   destructureParamArray,
   destructureParamObject,
   isNullOrUndefinedLiteral,
+  structHintForBindingPattern,
 } from "./destructuring-params.js";
 import {
   cacheStringLiterals,
@@ -860,9 +861,18 @@ export function compileFunctionBody(ctx: CodegenContext, decl: ts.FunctionDeclar
       if (isArrayPatternExternref) {
         (ctx as unknown as { _arrayLiteralForceVec?: boolean })._arrayLiteralForceVec = true;
       }
+      // (#2568) Mirror the class-method param-default fix: compile an object
+      // binding pattern's default literal against the pattern's STRUCT type (not
+      // the externref param type) so it materializes in the shape the
+      // destructuring `ref.test`/`ref.cast` expects, instead of boxing the nested
+      // fields to externref. See structHintForBindingPattern.
+      const objectPatternStructHint =
+        ts.isObjectBindingPattern(param.name) && paramType.kind === "externref"
+          ? structHintForBindingPattern(ctx, param.name)
+          : undefined;
       let defaultResultType: ValType | null;
       try {
-        defaultResultType = compileExpression(ctx, fctx, param.initializer, paramType);
+        defaultResultType = compileExpression(ctx, fctx, param.initializer, objectPatternStructHint ?? paramType);
       } finally {
         if (isArrayPatternExternref) {
           (ctx as unknown as { _arrayLiteralForceVec?: boolean })._arrayLiteralForceVec = prevForceVec;

--- a/tests/issue-2568-standalone-nested-dstr-default.test.ts
+++ b/tests/issue-2568-standalone-nested-dstr-default.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+
+/**
+ * #2568 — two-level nested destructuring-param default returns 0 in standalone.
+ *
+ * `method({ w: { x, y, z } = {…} } = { w: {…} })` reads sentinels (0) in
+ * standalone mode when EITHER default fires, while host mode is correct. Two
+ * struct-representation mismatches caused it:
+ *   - OUTER default: the in-method default object literal materialized as a
+ *     struct whose nested `w` field was boxed to externref, NOT matching the
+ *     shape the destructuring `ref.test`/`ref.cast` derives from the pattern's
+ *     type — the fast struct path's `ref.test` failed → bindings read 0.
+ *   - INNER default: in the externref destructuring path the nested default
+ *     object was a closed struct, but the bindings are read back through
+ *     `__extern_get`, which only indexes a `$Object` → bindings read 0.
+ *
+ * Fix: materialize the OUTER default as the binding-pattern's struct type, and
+ * the INNER (externref-path) default as a `$Object`. Host mode is unchanged.
+ */
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", skipSemanticDiagnostics: true, target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "binary must validate").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+const M = `class C { method({ w: { x, y, z } = { x: 4, y: 5, z: 6 } } = { w: { x: 1, y: 2, z: 3 } }): number { return x * 100 + y * 10 + z; } }`;
+
+describe("#2568 — standalone two-level nested destructuring-param default", () => {
+  it("OUTER default fires (no arg) → inner fields read the outer default object", async () => {
+    expect(await runStandalone(`${M} export function test(): number { return new C().method(); }`)).toBe(123);
+  });
+
+  it("INNER default fires ({ w: undefined }) → inner pattern default object is read", async () => {
+    expect(
+      await runStandalone(`${M} export function test(): number { return new C().method({ w: undefined } as any); }`),
+    ).toBe(456);
+  });
+
+  it("explicit value overrides both defaults", async () => {
+    expect(
+      await runStandalone(
+        `${M} export function test(): number { return new C().method({ w: { x: 1, y: 2, z: 3 } }); }`,
+      ),
+    ).toBe(123);
+  });
+
+  it("single-level object param default is unaffected", async () => {
+    expect(
+      await runStandalone(
+        `class C { method({ x }: { x: number } = { x: 7 }): number { return x; } } export function test(): number { return new C().method(); }`,
+      ),
+    ).toBe(7);
+  });
+
+  it("returns the last field (z) from the outer default object", async () => {
+    expect(
+      await runStandalone(
+        `class C { method({ w: { x, y, z } = { x: 4, y: 5, z: 6 } } = { w: { x: 1, y: 2, z: 9 } }): number { return z; } } export function test(): number { return new C().method(); }`,
+      ),
+    ).toBe(9);
+  });
+
+  it("plain function (not a method) two-level default also works", async () => {
+    expect(
+      await runStandalone(
+        `function f({ w: { x } = { x: 4 } } = { w: { x: 1 } }): number { return x; } export function test(): number { return f(); }`,
+      ),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

`method({ w: { x, y, z } = {…} } = { w: {…} })` returned **0** in standalone mode whenever either default fired (host mode is correct). Root cause: two struct-representation mismatches between how the default object is *materialized* and how the destructuring *reads* it — a #1712-family canonical-struct-representation bug, scoped to the param-default sites.

## Root cause (WAT-confirmed)

- **OUTER default**: the in-method/in-function default object literal was compiled against the **externref** param type, which boxes the nested `w` field to externref → builds a struct `{ w: externref }`. But the destructuring `ref.test`/`ref.cast` derives `{ w: (ref null $inner) }` from the pattern's TS type. Mismatch → `ref.test` fails → falls to the `__extern_get` else-branch → bindings read 0. (The *provided-value* call site already builds the correct direct-ref shape, which is why provided values work.)
- **INNER default**: in the externref destructuring path the nested default object was a closed struct, but the bindings are read back through `__extern_get`, which only indexes a `$Object` → bindings read 0.

## Fix

1. New exported helper `structHintForBindingPattern` (destructuring-params.ts) derives the binding-pattern's WasmGC struct type (mirroring the destructuring's own derivation). The outer param-default literal is compiled against that struct type instead of externref, at **both** the class-method (`class-bodies.ts`) and plain-function (`function-body.ts`) sites. `extern.convert_any` to the externref param preserves struct identity so the later `ref.test` passes.
2. The inner (externref-path) default object literal is materialized as a `$Object` via `compileObjectLiteralAsExternref` (destructuring-params.ts), mirroring the existing `literals.ts:272` pattern, so `__extern_get` can read its fields.

Host mode is uniform-JS-object and unaffected.

## Verification

Standalone: outer→123, inner→456, provided→123, single-level→7, last-field→9, plain-function→1. New test `tests/issue-2568-standalone-nested-dstr-default.test.ts` (6 cases). Existing `#2545`/`#2158`/`#1372`/`fn-param-dstr` suites pass; `check-test262-hard-errors.mjs` → OK.

Also files the array-for-in residual found during #2572 as **#2575** (Backlog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)