### PR TITLE
fix(#2515): S1 — Object.create(o, descs) standalone via native __obj_define_from_desc

### DIFF
--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -5247,13 +5247,27 @@ function compileCallExpression(
           const objLocal = allocLocal(fctx, `__ocreate_obj_${fctx.locals.length}`, { kind: "externref" });
           fctx.body.push({ op: "local.set", index: objLocal });
 
-          const dpDescIdx = ensureLateImport(
-            ctx,
-            "__defineProperty_desc",
-            [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }],
-            [{ kind: "externref" }],
-          );
-          flushLateImportShifts(ctx, fctx);
+          // (#2515 S1) Per-property descriptor apply. In `--target standalone`
+          // there is no JS host, so the `__defineProperty_desc` host import is
+          // refused (#1472 Phase B) — route instead to the Wasm-native
+          // `__obj_define_from_desc(obj, key, descObj)` helper, the SAME native
+          // `Object.defineProperty` standalone uses (object-ops.ts). It performs
+          // ToPropertyDescriptor over the descriptor `$Object` and dispatches to
+          // the native `__defineProperty_value`/`__defineProperty_accessor`
+          // store. Host/gc/wasi keep the precise `__defineProperty_desc` import.
+          let dpDescIdx: number | undefined;
+          if (ctx.standalone) {
+            ensureObjectRuntime(ctx);
+            dpDescIdx = ctx.funcMap.get("__obj_define_from_desc");
+          } else {
+            dpDescIdx = ensureLateImport(
+              ctx,
+              "__defineProperty_desc",
+              [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }],
+              [{ kind: "externref" }],
+            );
+            flushLateImportShifts(ctx, fctx);
+          }
 
           for (const prop of descsLiteral.properties) {
             if (!ts.isPropertyAssignment(prop)) continue;

--- a/tests/issue-2515.test.ts
+++ b/tests/issue-2515.test.ts
@@ -145,6 +145,41 @@ describe("#2515 S0 — standalone late-import global-index-shift emit bug", () =
     // No `string_constants::*` global imports — standalone materializes inline.
     expect(hostImports.some((l) => l.startsWith("string_constants::"))).toBe(false);
   });
+
+  // ── S1: Object.create(o, descs) generic descriptor apply ──────────────────
+
+  it("Object.create(proto, descriptorMapLiteral) compiles standalone (no __defineProperty_desc refusal)", async () => {
+    // The `Object.create(o, { x: descObj })` path emitted the refused
+    // `env::__defineProperty_desc` host import in standalone (#1472 Phase B),
+    // a hard compile error. S0 unblocked routing it to the native
+    // `__obj_define_from_desc` (the same native `Object.defineProperty` uses).
+    const r = await compile(
+      `export function test(): number {
+         const o = Object.create(null, { x: { value: 7 }, y: { value: 4 } });
+         return (o as any).x;
+       }`,
+      { fileName: "test.ts", target: "standalone" },
+    );
+    expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+    // No leaked `env::__defineProperty_desc` host import.
+    const hostImports = r.imports.map((i) => `${i.module}::${i.name}`);
+    expect(hostImports.some((l) => l === "env::__defineProperty_desc")).toBe(false);
+    // Value descriptor is applied + readable (single-property read).
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as { test?: () => number }).test?.()).toBe(7);
+  });
+
+  it("Object.create with an identifier descriptor value compiles + applies the value", async () => {
+    const res = await runStandalone(`
+      export function test(): number {
+        const dv: any = { value: 11, enumerable: true };
+        const o = Object.create(null, { x: dv });
+        return (o as any).x;
+      }
+    `);
+    expect(res.success, res.errors).toBe(true);
+    expect(res.value).toBe(11);
+  });
 });
 
 describe("#2515 S0 — host (GC) mode unchanged", () => {


### PR DESCRIPTION
## #2515 S1 — generic descriptor apply for `Object.create(o, descs)`

S0 (PR #1848, merged) unblocked S1. The `Object.create(proto, descriptorLiteral)`
per-property apply path (`calls.ts`) called
`ensureLateImport(ctx, "__defineProperty_desc", …)`, which under `--target
standalone` is a refused host import (#1472 Phase B) — a hard compile error for
the whole `built-ins/Object/create/15.2.3.5-*` cluster.

### Fix
In standalone, route each property's descriptor through the existing Wasm-native
`__obj_define_from_desc(obj, key, descObj)` — the **same** native that
`Object.defineProperty` already uses (`object-ops.ts`). It runs
ToPropertyDescriptor over the descriptor `$Object` and dispatches to
`__defineProperty_value`/`__defineProperty_accessor`. **No new runtime helper
needed** — the spec's `__defineProperty_desc` registration is unnecessary
because `__obj_define_from_desc` already exists. Host/gc/wasi keep the precise
`__defineProperty_desc` import path unchanged.

### Result (sample of 180 built-ins/Object/{create,defineProperty,defineProperties})
- `__defineProperty_desc` refusals: **26 → 0**; compiled **150 → 176**.
- Value descriptors apply + read back correctly (single-property).
- **Out of S1 scope (pre-existing, net-positive vs the CE):** descriptor flag
  semantics (enumerable/writable/configurable) and the combined multi-property
  read are standalone gaps shared with `Object.defineProperties` (S2 / #2542
  read-side) — *not* regressed here. The spec explicitly scopes the precise
  attribute semantics to S2.

### Validation
- Host (`gc`) mode unchanged (`Object.create(null, {x:{value:7}}).x === 7`).
- `tsc` clean; `check:test262-hard-errors` OK (0, no growth).
- `tests/issue-2515.test.ts` — 12 cases green (2 new for S1).
- `issue-1472` shows **zero new failures** vs `main` (its 10 failures pre-exist);
  `issue-1629*` / `issue-2042` descriptor suites all pass.

Builds on / co-locates with the merged S0 slices (#1848 + #1850 toString sites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)