### PR TITLE
fix(#2042 S4): ValidateAndApplyPropertyDescriptor redefine semantics (§10.1.6.3)

### DIFF
--- a/plan/issues/2042-standalone-defineproperty-descriptor-semantics.md
+++ b/plan/issues/2042-standalone-defineproperty-descriptor-semantics.md
@@ -4,7 +4,7 @@ title: "standalone: Object.defineProperty/defineProperties residual — __obj_in
 status: in-progress
 sprint: 64
 created: 2026-06-10
-updated: 2026-06-17
+updated: 2026-06-21
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -290,3 +290,97 @@ edit `object-runtime.ts` (the `OBJECT_RUNTIME_HELPER_NAMES` set +
 `__obj_ordered_all`) and appends to the helper-names set. The two regions are
 disjoint except the append-only set; whichever PR merges second does the small
 `object-runtime.ts` merge resolution (same author, so no cross-agent handoff).
+
+## S4 — ValidateAndApplyPropertyDescriptor (2026-06-21, sdev-reflect)
+
+PROBE-VERIFIED on main HEAD 075d90ee5. Two prior blockers had cleared since the
+issue was last touched, narrowing S4's real scope:
+
+1. **#2043 (late-import index-shift class) is now DONE**, which unblocked the
+   write-side `__defineProperty_desc` the S3 note had deferred — runtime
+   descriptor objects, `Object.create(proto, descs)`, widened-struct define and
+   dynamic-object define all now work on main. So the "write-side descriptor
+   native" is effectively landed; it is NOT redone here.
+2. **CompletePropertyDescriptor defaults (§6.2.6.4) were already correct** — a
+   fresh data desc with omitted attributes already inserts with
+   writable/enumerable/configurable = false (the host flag encoding's
+   unspecified-attr bits already yield 0). Pinned with a regression test, not
+   changed.
+
+The real remaining gap was **ValidateAndApplyPropertyDescriptor (§10.1.6.3)**:
+the native `__defineProperty_value` inserted the `$PropEntry` unconditionally, so
+every invalid (re)definition SILENTLY SUCCEEDED instead of throwing a TypeError.
+
+**Fix** (`src/codegen/object-runtime.ts`, `__defineProperty_value`): a preflight,
+emitted after the receiver/flags are resolved and before the table insert, that
+`__obj_find`s the existing entry and enforces §10.1.6.3 step order, throwing a
+catchable TypeError (the same `emitWasiErrorConstructor("TypeError")` +
+`ensureExnTag` + `throw` pattern `__defineProperties` already uses) on:
+- current undefined + object non-extensible (`OBJ_FLAG_NONEXTENSIBLE`) → step 2;
+- current non-configurable (`FLAG_CONFIGURABLE` clear) → step 4:
+  - desc specifies `configurable: true`,
+  - desc specifies an `enumerable` differing from current,
+  - current is an accessor (data↔accessor conversion — this is the data path),
+  - current non-writable (`FLAG_WRITABLE` clear): desc requests `writable: true`,
+    OR desc supplies a value that is not SameValue with the current value.
+The value-change check uses the native `__object_is` (SameValue §7.2.10), so an
+identical re-define is correctly a no-op (not a throw). To reference `__object_is`
+from `__defineProperty_value`, the `__object_is` registration block was moved
+ahead of the define helpers in `ensureObjectRuntime` (it is `ctx.standalone`-gated
+and depends only on the union/string helpers resolved at the top of the pass — no
+dependency on the define helpers — so the move is behaviour-preserving;
+`Object.is` re-verified working after the move).
+
+The "specified vs value" distinction uses the host flags f64 bits (3/4/5 =
+writable/enumerable/configurable specified, 7 = hasValue) that the call site
+already encodes. Host/gc mode is byte-identical (the preflight lives inside the
+standalone-native `__defineProperty_value`; host uses the JS import).
+
+`Reflect.defineProperty` is still refused standalone (#2046 S5 deferred), so the
+throw cannot break Reflect's return-`false`-on-invalid contract yet; when #2046 S5
+routes Reflect to this native it must catch the throw and return false (already
+noted in #2046's file).
+
+Tests: `tests/issue-2042-s4.test.ts` (11 — non-config redefine throws, config
+redefine OK, non-writable value-change throws, identical re-define OK (SameValue),
+config-flip throws, enum-flip throws, non-extensible-add throws, fresh define OK,
+default-false attributes, explicit attributes preserved, configurable+non-writable
+redefine OK). 34/34 across issue-2042{,-s3,-s4}; define/descriptor suites 58/58;
+native-strings unaffected. tsc + prettier clean.
+
+### Documented finding (NOT fixed here — overlaps #2187, deferred per tech-lead)
+
+A SEPARATE dot-vs-bracket **dual-storage** bug on EMPTY `const o: any = {}` LOCALS:
+`o.a = 7; o['a']` returns 0, and `Object.defineProperty(o, '<literalKey>', …)`
+twice on such a local hits a residual `global index out of range -1`
+("#2043-class") binary-emit error. Reduced repro:
+```ts
+const o: any = {};
+o.a = 7;
+return o['a'];           // → 0 (should be 7)
+// and:
+const o2: any = {};
+Object.defineProperty(o2, 'x', { value: 1, configurable: false });
+Object.defineProperty(o2, 'x', { value: 2 });   // → binary emit error
+```
+Root cause: dot-assignment / literal-key define on an empty object-literal local
+routes through the widened-struct / compiled-property *sidecar* fast path, which
+is OUT OF SYNC with the `$Object` hash runtime that bracket-read, `in`,
+`Object.keys`, and `getOwnPropertyDescriptor` consult. It does NOT reproduce on a
+dynamic receiver (`function mk(): any { return {}; }`) or on an object that
+already has a field (`{ a: 1 }`) — only the empty-literal-local + widened-struct
+path. This is orthogonal to the runtime-helper ValidateAndApply semantics in this
+slice.
+
+Two pieces of it are carved out:
+- The **`global index out of range -1` emit error** on a double literal-key
+  redefine + the **bare-string→TypeError** at the `compileObjectDefineProperty`
+  call site is **task #21** (`object-ops.ts`, separate PR — landed in parallel by
+  another agent; do not duplicate here).
+- The deeper **dot-vs-bracket sidecar/`$Object` reconciliation** (`o.a=7; o['a']`
+  → 0) overlaps the `$Object` value-rep substrate sdev-strdispatch is editing for
+  **#2187 (task #19)**; per tech-lead it is recorded here for a clean follow-up
+  issue after #2187 lands, NOT fixed concurrently.
+
+Issue stays `in-progress` for the #2187-overlapping dual-storage follow-up; the S4
+runtime-helper redefinition semantics (this slice, task #20) are done.

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -3723,6 +3723,164 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     );
   }
 
+  // ── __object_is(externref a, externref b) -> i32 (#2042 S3 — Object.is) ────
+  //
+  // SameValue (§7.2.10) over two boxed externrefs. Tag-dispatched like the
+  // union-helper `===` lowering, but with the SameValue numeric rule:
+  // NaN is SameValue NaN, and +0 is NOT SameValue -0. Comparing the f64 bit
+  // patterns (`i64.reinterpret_f64` + `i64.eq`) gives exactly that — equal NaN
+  // bit patterns compare equal, and +0 (0x0…) vs -0 (0x8000…) compare unequal.
+  // boolean → unbox i32; bigint → i64; both-null → equal; else ref identity.
+  // standalone-only (host mode owns `__object_is` via its JS import).
+  if (ctx.standalone) {
+    addUnionImportsViaRegistry(ctx);
+    const typeofNumIdx = ctx.funcMap.get("__typeof_number")!;
+    const typeofBoolIdx = ctx.funcMap.get("__typeof_boolean")!;
+    const typeofBigIdx = ctx.funcMap.get("__typeof_bigint")!;
+    const unboxNumIdx = ctx.funcMap.get("__unbox_number")!;
+    const unboxBoolIdx = ctx.funcMap.get("__unbox_boolean")!;
+    const toBigIdx = ctx.funcMap.get("__to_bigint")!;
+    const EQ_HEAP = -19; // WasmGC `eq` abstract heap type
+
+    // params: a=0, b=1 ; locals: aa=2 (anyref), ba=3 (anyref)
+    const bothTag = (tagIdx: number): Instr[] => [
+      { op: "local.get", index: 0 },
+      { op: "call", funcIdx: tagIdx } as Instr,
+      { op: "local.get", index: 1 },
+      { op: "call", funcIdx: tagIdx } as Instr,
+      { op: "i32.and" },
+    ];
+    // Reference identity over the WasmGC `eq` heap (the anyref temps are already
+    // materialised in locals 2/3 by `identityArm`'s preamble below).
+    const refIdentityArm: Instr[] = [
+      { op: "local.get", index: 2 },
+      { op: "ref.test", typeIdx: EQ_HEAP } as Instr,
+      { op: "local.get", index: 3 },
+      { op: "ref.test", typeIdx: EQ_HEAP } as Instr,
+      { op: "i32.and" },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: [
+          { op: "local.get", index: 2 },
+          { op: "ref.cast", typeIdx: EQ_HEAP } as Instr,
+          { op: "local.get", index: 3 },
+          { op: "ref.cast", typeIdx: EQ_HEAP } as Instr,
+          { op: "ref.eq" },
+        ],
+        else: [{ op: "i32.const", value: 0 }],
+      } as Instr,
+    ];
+    // String SameValue = value equality (flatten both, __str_equals); else ref
+    // identity. `__str_flatten`/`__str_equals` are resolved at the top of this
+    // same `ensureObjectRuntime` pass (object-runtime helpers already call them,
+    // e.g. __obj_hash/__obj_find), so the call indices are regime-consistent.
+    const stringOrIdentityArm: Instr[] =
+      strFlattenIdx !== undefined && strEqualsIdx !== undefined && anyStrTypeIdx >= 0
+        ? [
+            { op: "local.get", index: 2 },
+            { op: "ref.test", typeIdx: anyStrTypeIdx } as Instr,
+            { op: "local.get", index: 3 },
+            { op: "ref.test", typeIdx: anyStrTypeIdx } as Instr,
+            { op: "i32.and" },
+            {
+              op: "if",
+              blockType: { kind: "val", type: { kind: "i32" } },
+              then: [
+                { op: "local.get", index: 2 },
+                { op: "ref.cast", typeIdx: anyStrTypeIdx } as Instr,
+                { op: "call", funcIdx: strFlattenIdx } as Instr,
+                { op: "local.get", index: 3 },
+                { op: "ref.cast", typeIdx: anyStrTypeIdx } as Instr,
+                { op: "call", funcIdx: strFlattenIdx } as Instr,
+                { op: "call", funcIdx: strEqualsIdx } as Instr,
+              ],
+              else: refIdentityArm,
+            } as Instr,
+          ]
+        : refIdentityArm;
+    const identityArm: Instr[] = [
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" } as Instr,
+      { op: "local.set", index: 2 },
+      { op: "local.get", index: 1 },
+      { op: "any.convert_extern" } as Instr,
+      { op: "local.set", index: 3 },
+      ...stringOrIdentityArm,
+    ];
+    const bigintArm = (elseArm: Instr[]): Instr[] => [
+      ...bothTag(typeofBigIdx),
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: [
+          { op: "local.get", index: 0 },
+          { op: "call", funcIdx: toBigIdx } as Instr,
+          { op: "local.get", index: 1 },
+          { op: "call", funcIdx: toBigIdx } as Instr,
+          { op: "i64.eq" },
+        ],
+        else: elseArm,
+      } as Instr,
+    ];
+    const boolArm = (elseArm: Instr[]): Instr[] => [
+      ...bothTag(typeofBoolIdx),
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: [
+          { op: "local.get", index: 0 },
+          { op: "call", funcIdx: unboxBoolIdx } as Instr,
+          { op: "local.get", index: 1 },
+          { op: "call", funcIdx: unboxBoolIdx } as Instr,
+          { op: "i32.eq" },
+        ],
+        else: elseArm,
+      } as Instr,
+    ];
+    const numberArm = (elseArm: Instr[]): Instr[] => [
+      ...bothTag(typeofNumIdx),
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: [
+          // SameValue numbers: compare f64 bit patterns (NaN==NaN, +0!=-0).
+          { op: "local.get", index: 0 },
+          { op: "call", funcIdx: unboxNumIdx } as Instr,
+          { op: "i64.reinterpret_f64" } as Instr,
+          { op: "local.get", index: 1 },
+          { op: "call", funcIdx: unboxNumIdx } as Instr,
+          { op: "i64.reinterpret_f64" } as Instr,
+          { op: "i64.eq" },
+        ],
+        else: elseArm,
+      } as Instr,
+    ];
+    const nullArm = (rest: Instr[]): Instr[] => [
+      { op: "local.get", index: 0 },
+      { op: "ref.is_null" },
+      { op: "local.get", index: 1 },
+      { op: "ref.is_null" },
+      { op: "i32.and" },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: [{ op: "i32.const", value: 1 }],
+        else: rest,
+      } as Instr,
+    ];
+    registerNative(
+      "__object_is",
+      [{ kind: "externref" }, { kind: "externref" }],
+      [{ kind: "i32" }],
+      [
+        { name: "aa", type: { kind: "anyref" } },
+        { name: "ba", type: { kind: "anyref" } },
+      ],
+      nullArm(numberArm(boolArm(bigintArm(identityArm)))),
+    );
+  }
+
   // ── __defineProperty_value (#1629 S6 — native data-descriptor define) ─────
   //
   // `Object.defineProperty(obj, key, { value, writable?, enumerable?,
@@ -3755,8 +3913,181 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
   //
   // params: 0=obj 1=key 2=value 3=flagsF64
   // locals: 4=o(ref null $Object) 5=any(anyref) 6=cap 7=load 8=nflags(i32) 9=hf(i32)
+  //         10=e(ref null $PropEntry) 11=efl(i32)  — #2042 S4 ValidateAndApply
   {
     const NATIVE_ATTR_MASK = FLAG_WRITABLE | FLAG_ENUMERABLE | FLAG_CONFIGURABLE; // 0x07
+
+    // #2042 S4 — ValidateAndApplyPropertyDescriptor (§10.1.6.3) preflight for the
+    // DATA-descriptor define. The host flags f64 carries, beyond the value bits
+    // 0/1/2, "specified" bits 3/4/5 and a hasValue bit 7 (see encoding comment
+    // above), so we can tell which attributes the descriptor actually mentions —
+    // exactly what the spec's "Desc has a [[X]] field" conditions need. We throw a
+    // catchable TypeError (same exn-tag pattern as __defineProperties) instead of
+    // silently inserting when a (re)definition is invalid. Defaults
+    // (CompletePropertyDescriptor, §6.2.6.4) are already correct on insert.
+    addUnionImportsViaRegistry(ctx);
+    emitWasiErrorConstructor(ctx, "TypeError", 1);
+    const s4TypeErrorCtorIdx = ctx.funcMap.get("__new_TypeError")!;
+    const s4ExnTagIdx = ensureExnTag(ctx);
+    const s4ObjectIsIdx = ctx.funcMap.get("__object_is")!;
+    const HOST_WRITABLE_SPECIFIED = 1 << 3;
+    const HOST_ENUMERABLE_SPECIFIED = 1 << 4;
+    const HOST_CONFIGURABLE_SPECIFIED = 1 << 5;
+    const HOST_HAS_VALUE = 1 << 7;
+    const s4Throw = (message: string): Instr[] => {
+      addStringConstantGlobal(ctx, message);
+      return [
+        ...stringConstantExternrefInstrs(ctx, message),
+        { op: "call", funcIdx: s4TypeErrorCtorIdx },
+        { op: "throw", tagIdx: s4ExnTagIdx } as Instr,
+      ];
+    };
+    // `(hf & valueBit) != 0` as an i32 0/1.
+    const hfBit = (bit: number): Instr[] => [
+      { op: "local.get", index: 9 },
+      { op: "i32.const", value: bit },
+      { op: "i32.and" },
+      { op: "i32.const", value: 0 },
+      { op: "i32.ne" },
+    ];
+    // `(efl & flagBit) != 0` as an i32 0/1 (existing entry's flag word, local 12).
+    const eflBit = (bit: number): Instr[] => [
+      { op: "local.get", index: 12 },
+      { op: "i32.const", value: bit },
+      { op: "i32.and" },
+      { op: "i32.const", value: 0 },
+      { op: "i32.ne" },
+    ];
+    // The preflight body, emitted after `o` (local 4) and `hf` (local 9) are set,
+    // before the grow/insert. §10.1.6.3 in spec order.
+    const s4Preflight: Instr[] = [
+      // e = __obj_find(o, key)  (local 11)
+      { op: "local.get", index: 4 },
+      { op: "ref.as_non_null" },
+      { op: "local.get", index: 1 },
+      { op: "call", funcIdx: objFindIdx },
+      { op: "local.tee", index: 11 },
+      { op: "ref.is_null" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        // current is undefined (new property): §10.1.6.3 step 2 — reject if the
+        // object is non-extensible.
+        then: [
+          { op: "local.get", index: 4 },
+          { op: "ref.as_non_null" },
+          { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 4 },
+          { op: "i32.const", value: OBJ_FLAG_NONEXTENSIBLE },
+          { op: "i32.and" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: s4Throw("TypeError: Cannot define property, object is not extensible"),
+          } as Instr,
+        ],
+        // current exists: §10.1.6.3 step 4 — if current is non-configurable, gate
+        // the forbidden transitions.
+        else: [
+          // efl = e.flags  (local 12)
+          { op: "local.get", index: 11 },
+          { op: "ref.as_non_null" },
+          { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 2 },
+          { op: "local.set", index: 12 },
+          // if (efl & FLAG_CONFIGURABLE) == 0  → current is non-configurable
+          ...eflBit(FLAG_CONFIGURABLE),
+          { op: "i32.eqz" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              // 4.a: Desc specifies configurable:true → reject.
+              ...hfBit(HOST_CONFIGURABLE_SPECIFIED),
+              ...hfBit(1 << 2), // configurable value bit
+              { op: "i32.and" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: s4Throw(
+                  "TypeError: Cannot redefine property: configurable attribute of a non-configurable property",
+                ),
+              } as Instr,
+              // 4.b: Desc specifies enumerable that differs from current → reject.
+              ...hfBit(HOST_ENUMERABLE_SPECIFIED),
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  ...hfBit(1 << 1), // desc enumerable value
+                  ...eflBit(FLAG_ENUMERABLE), // current enumerable
+                  { op: "i32.ne" },
+                  {
+                    op: "if",
+                    blockType: { kind: "empty" },
+                    then: s4Throw(
+                      "TypeError: Cannot redefine property: enumerable attribute of a non-configurable property",
+                    ),
+                  } as Instr,
+                ],
+              } as Instr,
+              // 4.c: data↔accessor conversion. This is the DATA define path; if the
+              // current entry is an accessor, converting it to data is forbidden.
+              ...eflBit(FLAG_ACCESSOR),
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: s4Throw(
+                  "TypeError: Cannot redefine property: cannot convert a non-configurable accessor to a data property",
+                ),
+              } as Instr,
+              // 4.d: both data, current non-writable (FLAG_WRITABLE clear) → reject
+              // a writable:true request OR a value change (SameValue).
+              ...eflBit(FLAG_WRITABLE),
+              { op: "i32.eqz" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  // writable false→true
+                  ...hfBit(HOST_WRITABLE_SPECIFIED),
+                  ...hfBit(1 << 0), // desc writable value
+                  { op: "i32.and" },
+                  {
+                    op: "if",
+                    blockType: { kind: "empty" },
+                    then: s4Throw(
+                      "TypeError: Cannot redefine property: writable attribute of a non-configurable, non-writable property",
+                    ),
+                  } as Instr,
+                  // value change: Desc has a value (hasValue) AND
+                  // !SameValue(descValue, e.value) → reject.
+                  ...hfBit(HOST_HAS_VALUE),
+                  {
+                    op: "if",
+                    blockType: { kind: "empty" },
+                    then: [
+                      // __object_is(descValue (param 2), e.value)
+                      { op: "local.get", index: 2 },
+                      { op: "local.get", index: 11 },
+                      { op: "ref.as_non_null" },
+                      { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 1 },
+                      { op: "extern.convert_any" } as Instr,
+                      { op: "call", funcIdx: s4ObjectIsIdx },
+                      { op: "i32.eqz" },
+                      {
+                        op: "if",
+                        blockType: { kind: "empty" },
+                        then: s4Throw("TypeError: Cannot assign to read only property of a non-configurable property"),
+                      } as Instr,
+                    ],
+                  } as Instr,
+                ],
+              } as Instr,
+            ],
+          } as Instr,
+        ],
+      } as Instr,
+    ];
+
     const body: Instr[] = [
       // any = any.convert_extern(obj) ; if !$Object → return obj (lenient no-op,
       // matches the host import returning O unchanged)
@@ -3786,6 +4117,9 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
       { op: "i32.const", value: NATIVE_ATTR_MASK },
       { op: "i32.and" },
       { op: "local.set", index: 8 },
+      // #2042 S4 — ValidateAndApplyPropertyDescriptor preflight (throws on an
+      // invalid (re)definition before any table mutation).
+      ...s4Preflight,
       // load = o.count + o.tombstones ; cap = o.props.len ; grow at LF 0.7
       { op: "local.get", index: 4 },
       { op: "ref.as_non_null" },
@@ -3850,6 +4184,8 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
         { name: "nflags", type: { kind: "i32" } },
         { name: "hf", type: { kind: "i32" } },
         { name: "seq", type: { kind: "i32" } },
+        { name: "e", type: entryRefNull }, // #2042 S4 — existing entry (local 11)
+        { name: "efl", type: { kind: "i32" } }, // #2042 S4 — existing flags (local 12)
       ],
       body,
     );
@@ -5121,164 +5457,6 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
   // its OBJECT_RUNTIME_HELPER_NAMES entry land as a follow-up). The read-side
   // reflection natives above (__getOwnPropertyNames / __getOwnPropertySymbols /
   // __object_getOwnPropertyDescriptors) are the shipped S3 slice.
-
-  // ── __object_is(externref a, externref b) -> i32 (#2042 S3 — Object.is) ────
-  //
-  // SameValue (§7.2.10) over two boxed externrefs. Tag-dispatched like the
-  // union-helper `===` lowering, but with the SameValue numeric rule:
-  // NaN is SameValue NaN, and +0 is NOT SameValue -0. Comparing the f64 bit
-  // patterns (`i64.reinterpret_f64` + `i64.eq`) gives exactly that — equal NaN
-  // bit patterns compare equal, and +0 (0x0…) vs -0 (0x8000…) compare unequal.
-  // boolean → unbox i32; bigint → i64; both-null → equal; else ref identity.
-  // standalone-only (host mode owns `__object_is` via its JS import).
-  if (ctx.standalone) {
-    addUnionImportsViaRegistry(ctx);
-    const typeofNumIdx = ctx.funcMap.get("__typeof_number")!;
-    const typeofBoolIdx = ctx.funcMap.get("__typeof_boolean")!;
-    const typeofBigIdx = ctx.funcMap.get("__typeof_bigint")!;
-    const unboxNumIdx = ctx.funcMap.get("__unbox_number")!;
-    const unboxBoolIdx = ctx.funcMap.get("__unbox_boolean")!;
-    const toBigIdx = ctx.funcMap.get("__to_bigint")!;
-    const EQ_HEAP = -19; // WasmGC `eq` abstract heap type
-
-    // params: a=0, b=1 ; locals: aa=2 (anyref), ba=3 (anyref)
-    const bothTag = (tagIdx: number): Instr[] => [
-      { op: "local.get", index: 0 },
-      { op: "call", funcIdx: tagIdx } as Instr,
-      { op: "local.get", index: 1 },
-      { op: "call", funcIdx: tagIdx } as Instr,
-      { op: "i32.and" },
-    ];
-    // Reference identity over the WasmGC `eq` heap (the anyref temps are already
-    // materialised in locals 2/3 by `identityArm`'s preamble below).
-    const refIdentityArm: Instr[] = [
-      { op: "local.get", index: 2 },
-      { op: "ref.test", typeIdx: EQ_HEAP } as Instr,
-      { op: "local.get", index: 3 },
-      { op: "ref.test", typeIdx: EQ_HEAP } as Instr,
-      { op: "i32.and" },
-      {
-        op: "if",
-        blockType: { kind: "val", type: { kind: "i32" } },
-        then: [
-          { op: "local.get", index: 2 },
-          { op: "ref.cast", typeIdx: EQ_HEAP } as Instr,
-          { op: "local.get", index: 3 },
-          { op: "ref.cast", typeIdx: EQ_HEAP } as Instr,
-          { op: "ref.eq" },
-        ],
-        else: [{ op: "i32.const", value: 0 }],
-      } as Instr,
-    ];
-    // String SameValue = value equality (flatten both, __str_equals); else ref
-    // identity. `__str_flatten`/`__str_equals` are resolved at the top of this
-    // same `ensureObjectRuntime` pass (object-runtime helpers already call them,
-    // e.g. __obj_hash/__obj_find), so the call indices are regime-consistent.
-    const stringOrIdentityArm: Instr[] =
-      strFlattenIdx !== undefined && strEqualsIdx !== undefined && anyStrTypeIdx >= 0
-        ? [
-            { op: "local.get", index: 2 },
-            { op: "ref.test", typeIdx: anyStrTypeIdx } as Instr,
-            { op: "local.get", index: 3 },
-            { op: "ref.test", typeIdx: anyStrTypeIdx } as Instr,
-            { op: "i32.and" },
-            {
-              op: "if",
-              blockType: { kind: "val", type: { kind: "i32" } },
-              then: [
-                { op: "local.get", index: 2 },
-                { op: "ref.cast", typeIdx: anyStrTypeIdx } as Instr,
-                { op: "call", funcIdx: strFlattenIdx } as Instr,
-                { op: "local.get", index: 3 },
-                { op: "ref.cast", typeIdx: anyStrTypeIdx } as Instr,
-                { op: "call", funcIdx: strFlattenIdx } as Instr,
-                { op: "call", funcIdx: strEqualsIdx } as Instr,
-              ],
-              else: refIdentityArm,
-            } as Instr,
-          ]
-        : refIdentityArm;
-    const identityArm: Instr[] = [
-      { op: "local.get", index: 0 },
-      { op: "any.convert_extern" } as Instr,
-      { op: "local.set", index: 2 },
-      { op: "local.get", index: 1 },
-      { op: "any.convert_extern" } as Instr,
-      { op: "local.set", index: 3 },
-      ...stringOrIdentityArm,
-    ];
-    const bigintArm = (elseArm: Instr[]): Instr[] => [
-      ...bothTag(typeofBigIdx),
-      {
-        op: "if",
-        blockType: { kind: "val", type: { kind: "i32" } },
-        then: [
-          { op: "local.get", index: 0 },
-          { op: "call", funcIdx: toBigIdx } as Instr,
-          { op: "local.get", index: 1 },
-          { op: "call", funcIdx: toBigIdx } as Instr,
-          { op: "i64.eq" },
-        ],
-        else: elseArm,
-      } as Instr,
-    ];
-    const boolArm = (elseArm: Instr[]): Instr[] => [
-      ...bothTag(typeofBoolIdx),
-      {
-        op: "if",
-        blockType: { kind: "val", type: { kind: "i32" } },
-        then: [
-          { op: "local.get", index: 0 },
-          { op: "call", funcIdx: unboxBoolIdx } as Instr,
-          { op: "local.get", index: 1 },
-          { op: "call", funcIdx: unboxBoolIdx } as Instr,
-          { op: "i32.eq" },
-        ],
-        else: elseArm,
-      } as Instr,
-    ];
-    const numberArm = (elseArm: Instr[]): Instr[] => [
-      ...bothTag(typeofNumIdx),
-      {
-        op: "if",
-        blockType: { kind: "val", type: { kind: "i32" } },
-        then: [
-          // SameValue numbers: compare f64 bit patterns (NaN==NaN, +0!=-0).
-          { op: "local.get", index: 0 },
-          { op: "call", funcIdx: unboxNumIdx } as Instr,
-          { op: "i64.reinterpret_f64" } as Instr,
-          { op: "local.get", index: 1 },
-          { op: "call", funcIdx: unboxNumIdx } as Instr,
-          { op: "i64.reinterpret_f64" } as Instr,
-          { op: "i64.eq" },
-        ],
-        else: elseArm,
-      } as Instr,
-    ];
-    const nullArm = (rest: Instr[]): Instr[] => [
-      { op: "local.get", index: 0 },
-      { op: "ref.is_null" },
-      { op: "local.get", index: 1 },
-      { op: "ref.is_null" },
-      { op: "i32.and" },
-      {
-        op: "if",
-        blockType: { kind: "val", type: { kind: "i32" } },
-        then: [{ op: "i32.const", value: 1 }],
-        else: rest,
-      } as Instr,
-    ];
-    registerNative(
-      "__object_is",
-      [{ kind: "externref" }, { kind: "externref" }],
-      [{ kind: "i32" }],
-      [
-        { name: "aa", type: { kind: "anyref" } },
-        { name: "ba", type: { kind: "anyref" } },
-      ],
-      nullArm(numberArm(boolArm(bigintArm(identityArm)))),
-    );
-  }
 
   // ── Object integrity predicates (#1472 Phase B Blocker A Half 1, PR #1074) ─
   //

--- a/tests/issue-2042-s4.test.ts
+++ b/tests/issue-2042-s4.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2042 S4 — ValidateAndApplyPropertyDescriptor (§10.1.6.3) for the standalone
+// native data-descriptor define (`__defineProperty_value`).
+//
+// Before S4 the native define inserted the `$PropEntry` unconditionally, so every
+// invalid (re)definition silently SUCCEEDED instead of throwing a TypeError:
+// redefining a non-configurable property, changing the value of a non-writable
+// property, flipping configurable/enumerable, or adding a property to a
+// non-extensible object. S4 adds a preflight that throws a catchable TypeError on
+// each forbidden transition (spec §10.1.6.3 step order), before any table write.
+// CompletePropertyDescriptor defaults (§6.2.6.4 — omitted attributes default to
+// false on a fresh property) were already correct on insert and are pinned here.
+//
+// Receivers are produced via a helper fn (`mk()`) so they are genuinely dynamic
+// `$Object` values — this avoids the separate dot-vs-bracket dual-storage path on
+// empty `const o: any = {}` locals (a distinct, documented #2042 finding deferred
+// behind the #2187 substrate work), keeping these assertions on the native
+// `__defineProperty_value` path under test.
+async function runStandalone(body: string): Promise<unknown> {
+  const r = await compile(body, { fileName: "test.ts", target: "standalone" });
+  if (!r.success) {
+    throw new Error(`Compile failed:\n${r.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+const MK = "function mk(): any { return {}; }";
+
+describe("#2042 S4 — ValidateAndApplyPropertyDescriptor (redefinition rules)", () => {
+  it("redefining a non-configurable property throws a TypeError", async () => {
+    expect(
+      await runStandalone(`${MK}
+        export function test(): number {
+          const o: any = mk();
+          Object.defineProperty(o, "x", { value: 1, configurable: false });
+          try { Object.defineProperty(o, "x", { value: 2 }); return 0; } catch (e) { return 1; }
+        }`),
+    ).toBe(1);
+  });
+
+  it("redefining a configurable property succeeds and updates the value", async () => {
+    expect(
+      await runStandalone(`${MK}
+        export function test(): number {
+          const o: any = mk();
+          Object.defineProperty(o, "x", { value: 1, configurable: true });
+          Object.defineProperty(o, "x", { value: 2 });
+          const d: any = Object.getOwnPropertyDescriptor(o, "x");
+          return d.value as number;
+        }`),
+    ).toBe(2);
+  });
+
+  it("changing the value of a non-writable, non-configurable property throws", async () => {
+    expect(
+      await runStandalone(`${MK}
+        export function test(): number {
+          const o: any = mk();
+          Object.defineProperty(o, "x", { value: 1, writable: false, configurable: false });
+          try { Object.defineProperty(o, "x", { value: 2 }); return 0; } catch (e) { return 1; }
+        }`),
+    ).toBe(1);
+  });
+
+  it("re-asserting the SAME value of a non-writable property is allowed (SameValue, no throw)", async () => {
+    expect(
+      await runStandalone(`${MK}
+        export function test(): number {
+          const o: any = mk();
+          Object.defineProperty(o, "x", { value: 1, writable: false, enumerable: false, configurable: false });
+          try {
+            Object.defineProperty(o, "x", { value: 1, writable: false, enumerable: false, configurable: false });
+            return 1;
+          } catch (e) { return 0; }
+        }`),
+    ).toBe(1);
+  });
+
+  it("flipping configurable false→true on a non-configurable property throws", async () => {
+    expect(
+      await runStandalone(`${MK}
+        export function test(): number {
+          const o: any = mk();
+          Object.defineProperty(o, "x", { value: 1, configurable: false });
+          try { Object.defineProperty(o, "x", { value: 1, configurable: true }); return 0; } catch (e) { return 1; }
+        }`),
+    ).toBe(1);
+  });
+
+  it("flipping enumerable on a non-configurable property throws", async () => {
+    expect(
+      await runStandalone(`${MK}
+        export function test(): number {
+          const o: any = mk();
+          Object.defineProperty(o, "x", { value: 1, enumerable: false, configurable: false });
+          try { Object.defineProperty(o, "x", { value: 1, enumerable: true }); return 0; } catch (e) { return 1; }
+        }`),
+    ).toBe(1);
+  });
+
+  it("adding a property to a non-extensible object throws", async () => {
+    expect(
+      await runStandalone(`${MK}
+        export function test(): number {
+          const o: any = mk();
+          Object.preventExtensions(o);
+          try { Object.defineProperty(o, "x", { value: 1 }); return 0; } catch (e) { return 1; }
+        }`),
+    ).toBe(1);
+  });
+
+  it("a first define on a fresh object still succeeds and stores the value", async () => {
+    expect(
+      await runStandalone(`${MK}
+        export function test(): number {
+          const o: any = mk();
+          Object.defineProperty(o, "x", { value: 42 });
+          return o.x as number;
+        }`),
+    ).toBe(42);
+  });
+
+  it("CompletePropertyDescriptor: omitted attributes on a fresh data desc default to false", async () => {
+    expect(
+      await runStandalone(`${MK}
+        export function test(): number {
+          const o: any = mk();
+          Object.defineProperty(o, "x", { value: 1 });
+          const d: any = Object.getOwnPropertyDescriptor(o, "x");
+          const w = d.writable ? 1 : 0;
+          const e = d.enumerable ? 2 : 0;
+          const c = d.configurable ? 4 : 0;
+          return w + e + c; // expect 0 — all default false
+        }`),
+    ).toBe(0);
+  });
+
+  it("explicitly-specified attributes on a fresh data desc are preserved", async () => {
+    expect(
+      await runStandalone(`${MK}
+        export function test(): number {
+          const o: any = mk();
+          Object.defineProperty(o, "x", { value: 1, writable: true, enumerable: true, configurable: true });
+          const d: any = Object.getOwnPropertyDescriptor(o, "x");
+          const w = d.writable ? 1 : 0;
+          const e = d.enumerable ? 2 : 0;
+          const c = d.configurable ? 4 : 0;
+          return w + e + c; // expect 7 — all true
+        }`),
+    ).toBe(7);
+  });
+
+  it("a configurable property may be redefined even when currently non-writable", async () => {
+    // configurable:true means ValidateAndApply permits any change, including a
+    // value change on a non-writable property (§10.1.6.3 — the non-writable
+    // restrictions only bind when the property is also non-configurable).
+    expect(
+      await runStandalone(`${MK}
+        export function test(): number {
+          const o: any = mk();
+          Object.defineProperty(o, "x", { value: 1, writable: false, configurable: true });
+          Object.defineProperty(o, "x", { value: 2 });
+          const d: any = Object.getOwnPropertyDescriptor(o, "x");
+          return d.value as number;
+        }`),
+    ).toBe(2);
+  });
+});


### PR DESCRIPTION
## #2042 S4 — ValidateAndApplyPropertyDescriptor (redefinition rules)

The standalone native data-descriptor define (`__defineProperty_value`) inserted
the `$PropEntry` unconditionally, so every **invalid (re)definition silently
SUCCEEDED** instead of throwing a TypeError. This adds the §10.1.6.3
ValidateAndApply preflight.

### Fix
A preflight in `__defineProperty_value` (`src/codegen/object-runtime.ts`),
emitted after the receiver/flags resolve and before the table insert, that
`__obj_find`s the existing entry and throws a **catchable TypeError** (same
`emitWasiErrorConstructor("TypeError")` + `ensureExnTag` + `throw` pattern
`__defineProperties` uses) on:
- current undefined + object non-extensible (`OBJ_FLAG_NONEXTENSIBLE`) — step 2;
- current **non-configurable** (`FLAG_CONFIGURABLE` clear) — step 4:
  - desc specifies `configurable: true`,
  - desc specifies an `enumerable` differing from current,
  - data↔accessor conversion (current is accessor on this data path),
  - current **non-writable**: desc requests `writable: true`, OR supplies a value
    that is not SameValue with the current value.

The value-change check uses the native `__object_is` (SameValue §7.2.10), so an
identical re-define is a no-op (not a throw). To reference `__object_is` from
`__defineProperty_value`, its registration block was **moved ahead of the define
helpers** in `ensureObjectRuntime` (standalone-gated, depends only on the
union/string helpers resolved at the top of the pass — behaviour-preserving;
`Object.is` re-verified working after the move).

`CompletePropertyDescriptor` defaults (§6.2.6.4) were already correct on insert —
pinned, not changed. **Host/gc mode is byte-identical** (the preflight lives in
the standalone-native helper; host uses the JS import). `Reflect.defineProperty`
is still refused standalone (#2046 S5), so the throw can't break its
return-`false`-on-invalid contract yet.

### Scope split (collision-resolved with task #21)
This slice is the **`object-runtime.ts` runtime-helper layer ONLY**. The
`object-ops.ts` call-site fix (literal-key redefine emit error +
bare-string→TypeError) is **task #21**'s separate PR. The deeper dot-vs-bracket
**dual-storage** bug (`o.a=7; o['a']`→0) overlaps **#2187** and is
documented-not-fixed per tech-lead (see the issue file).

### Tests
- `tests/issue-2042-s4.test.ts` (11): non-config redefine throws, config redefine
  OK, non-writable value-change throws, identical re-define OK (SameValue),
  config-flip throws, enum-flip throws, non-extensible-add throws, fresh define OK,
  default-false attributes, explicit attributes preserved, configurable+non-writable
  redefine OK.
- 34/34 across `issue-2042{,-s3,-s4}`; define/descriptor suites 58/58.
- `tsc --noEmit` + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)