### PR TITLE
docs(#983d,#2573): record dual-path revert + retry guidance; re-file #2573

### DIFF
--- a/plan/issues/2573-missing-property-read-returns-null-not-undefined-plain-object.md
+++ b/plan/issues/2573-missing-property-read-returns-null-not-undefined-plain-object.md
@@ -1,0 +1,66 @@
+---
+id: 2573
+title: "Reading a missing property on a plain `{}` object returns null, not undefined"
+status: ready
+created: 2026-06-21
+priority: medium
+feasibility: medium
+goal: test262-conformance
+parent: 983d
+test262_fail: 8
+---
+# #2573 — Missing-property read on a plain object yields `null` not `undefined`
+
+## Problem
+
+Reading an own property that does not exist on a plain object literal
+(`var obj = {}; obj.length`) returns JS `null` (`typeof === "object"`) where the
+spec requires `undefined` (§10.1.8 OrdinaryGet → returns `undefined` for a
+missing property).
+
+```js
+var obj = {};
+obj.length;   // expected: undefined ; actual: null
+```
+
+## How it surfaced (#983d residual)
+
+After #983d landed the dual-path dispatch for `obj.<field>()` host-method calls
+(`var o = {}; o.pop = Array.prototype.pop; o.pop()` now actually runs), the
+generic-Array-method-on-plain-object test262 cluster went 0 → 11/19. The
+remaining 8 fail at a **later** assertion — `obj.length === undefined` — because
+the missing-`length` read returns `null`:
+
+```
+S15.4.4.5_A2_T1.js  #2: ... obj.join(); obj.length === undefined.  Actual: null
+S15.4.4.7_A2_T1.js  #4: ... obj.push(...); ...
+S15.4.4.8_A2_T{1,2,3}.js, S15.4.4.13_A{2_T1,3_T2}.js, S15.4.4.7_A4_T3.js
+```
+
+Probe (`var obj={}; var b=obj.length; ... b===null, typeof==="object"`) confirms
+the read is `null`, independent of any method call — it is a **property-read**
+bug, not a method-dispatch or write-back bug.
+
+## Root cause (to confirm)
+
+`obj.length` on a `{}` struct lowers to a `struct.get` against a struct shape
+that has no `length` field (or reads field 0 of the wrong shape), and the
+missing-field path coerces to `ref.null.extern` (→ JS `null`) instead of the
+host `undefined`. The fix is to make the missing-own-property read on a
+plain-object struct yield `undefined` (e.g. `__get_undefined` / the
+externref-undefined representation), not a null externref. Audit the
+property-access codegen for plain-object structs (`src/codegen/property-access.ts`
+/ the member-read path in `expressions`) and the `__sget_`/`__extern_get`
+missing-field return.
+
+## Acceptance
+
+- `var obj = {}; obj.missing === undefined` (typeof `"undefined"`).
+- The 8 residual `…/S15.4.4.*` generic-method-on-plain-object fails flip to pass.
+- No regression in property reads that legitimately return `null`.
+
+## Notes
+
+Carved from #983d by sd-4 on 2026-06-21. Orthogonal to the dual-path dispatch
+fix that #983d delivered (the method now runs correctly; this is the missing
+sibling property read returning the wrong nullish value).

--- a/plan/issues/983d-live-mirror-writeback-via-sset-struct-setters.md
+++ b/plan/issues/983d-live-mirror-writeback-via-sset-struct-setters.md
@@ -84,3 +84,39 @@ that Wasm subsequently re-reads.
   proxy trap + boundary coercion, and the indexed-store path for Arrays.
 - Overlaps the descriptor/struct-target-writeback design in #1630/#1631 —
   coordinate so both share one struct-setter export mechanism rather than two.
+
+## 2026-06-21 sd-4 — root cause revised, attempt REVERTED (net-negative), retry guidance
+
+**Framing was stale.** This is NOT a missing-`__sset_` host write-back build:
+the `__sset_<field>` setters already exist and `_safeSet` already wires them.
+The real bug is a **codegen dispatch gap**: a call `obj.method(args)` where
+`method` is a **host function value** stored in `obj`
+(`var o = {}; o.pop = Array.prototype.pop; o.pop()`) falls past every
+static/struct-method handler and hits the **graceful-null fallback** in
+`compileCallExpression`, which compiles the callee property-access, **drops**
+the method, and pushes `ref.null.extern` — so the call is never made
+(`o.pop()` yields `null` not `undefined`, no mutation).
+
+**Attempt (PR #1844) reverted + closed.** The dual-path fix — route such calls
+to `__extern_method_call(receiver, method, args)` with the live-mirror proxy
+before the graceful-null fallback — fixed the 19-file generic-method-on-
+plain-object cluster locally (0 → 11/19) but was **net −200 / 323 regressions
+on the full merge_group test262 gate**. The graceful-null `undefined`-return is
+**load-bearing for far more call shapes** than the targeted cluster; the
+syntactic gate (any unresolved `obj.method()`) was far too broad.
+
+**Retry requirements (MANDATORY before any re-attempt):**
+1. **Gate MUCH tighter** — route to `__extern_method_call` ONLY when the callee
+   field is *provably a host function value* (e.g. the receiver is statically an
+   object/struct whose `<method>` is a known externref field assigned a host
+   function), NOT every unresolved property-access call. The broad
+   "fell-through-to-fallback" trigger caused the −200.
+2. **Validate via the FULL gate** — `JS2WASM_LOCAL_CI=1 ./scripts/local-ci.sh`
+   (full local test262, ~68 min) OR accepted-into-the-merge_group-as-validator.
+   A scoped sweep / N-file sample CANNOT validate a dispatch/call-path change
+   (standing team rule, 2026-06-21). Confirm net ≥ 0, ratio < 10%, no bucket
+   > 50 before enqueue.
+
+Residual carved to **#2573** (reading a missing property on a plain `{}` object
+returns `null` not `undefined` — the `obj.length === undefined` assertions in
+the longer cluster variants), an orthogonal property-read bug.


### PR DESCRIPTION
Docs-only. Records the #983d revert (PR #1844 was -200/323 net on the full merge_group gate) with the revised root cause (codegen dispatch gap, not host write-back) and MANDATORY retry requirements (gate to provably-host-function callees only; validate via the full local-ci gate, never a scoped sweep). Re-files #2573 (missing-property read on a plain object returns null not undefined) which was lost when PR #1844 closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)