### PR TITLE
docs(#2568): cross-ref the #1712 canonical-struct-representation family

### DIFF
--- a/plan/issues/2568-standalone-nested-dstr-param-default-object.md
+++ b/plan/issues/2568-standalone-nested-dstr-param-default-object.md
@@ -30,13 +30,14 @@ is correct. The identical source returns `0` in **standalone** mode (`target:
 ```ts
 class C {
   method({ w: { x, y, z } = { x: 4, y: 5, z: 6 } } = { w: { x: 1, y: 2, z: 3 } }): number {
-    return x * 100 + y * 10 + z;   // host: 123  standalone: 0
+    return x * 100 + y * 10 + z; // host: 123  standalone: 0
   }
 }
-new C().method();   // outer default fires
+new C().method(); // outer default fires
 ```
 
 Both branches diverge in standalone:
+
 - outer default fires → `0` (expect 123)
 - `{ w: undefined }` → inner pattern default fires → `0` (expect 456)
 
@@ -45,8 +46,12 @@ Both branches diverge in standalone:
 A **single-level** standalone object param default works:
 
 ```ts
-class C { method({ x }: { x: number } = { x: 7 }): number { return x; } }
-new C().method();   // standalone: 7  ✓
+class C {
+  method({ x }: { x: number } = { x: 7 }): number {
+    return x;
+  }
+}
+new C().method(); // standalone: 7  ✓
 ```
 
 So the gap is specific to the **two-level nested** object default in standalone
@@ -70,3 +75,14 @@ representation).
 Found while closing #2545 (sd-1, 2026-06-21). #2545's regression test is
 deliberately host-scoped so it stays green; this issue owns the standalone lane.
 Senior-dev / standalone-object-representation focus.
+
+**Cross-ref — scoped instance of the #1712 canonical-struct-representation
+family.** This fix and #1712 (sd-acorn) are the _same family, different sites_:
+this one is the **build site** (a param-default object literal must be
+_materialized_ in the representation its destructuring reader expects — the
+binding-pattern struct for the typed/`ref.test` fast path, or a `$Object` for
+the externref/`__extern_get` path); #1712 is the general **dynamic read-path**
+canonical-representation unification. The narrow fix here lands a real
+standalone win without waiting on the hard general fix. If sd-acorn's #1712
+read-path unification later subsumes the per-site materialization choices made
+here, this issue's logic can fold into it — tracked via this cross-ref.


### PR DESCRIPTION
## Summary

Per tech-lead direction: add an explicit cross-ref in #2568's issue noting it's a **scoped instance of the #1712 canonical-struct-representation family** — same family, different sites:

- **#2568** (this, merged in #1852) = the **build site**: a param-default object literal must be *materialized* in the representation its destructuring reader expects (binding-pattern struct for the typed/`ref.test` fast path; `$Object` for the externref/`__extern_get` path).
- **#1712** (sd-acorn) = the general **dynamic read-path** canonical-representation unification.

If sd-acorn's #1712 read-path fix later subsumes the per-site materialization choices made in #2568, this cross-ref tracks the relationship.

## Broad-sweep validation (post-merge, per tech-lead)

Confirmed the merged #2568 fix has the intended narrow blast radius — re-ran a broad object-binding-pattern param-default sweep on current main:
- typed-struct fast path **byte-stable** (typed single / typed provided unchanged);
- all untyped object-pattern defaults correct standalone (outer→123, inner→456, single→7, multi, plain-function);
- non-object (number) and array-pattern defaults unaffected;
- `check-test262-hard-errors.mjs` → OK.

(#2568 also already cleared the full merge_group gate — 8 equiv shards + quality + test262 regression — when #1852 merged.)

No code change — doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)