### PR TITLE
docs(#2571): architect spec — native method-generator lowering plan

### DIFF
--- a/plan/issues/2571-standalone-native-method-generators.md
+++ b/plan/issues/2571-standalone-native-method-generators.md
@@ -12,10 +12,14 @@ task_type: bugfix
 area: codegen, runtime
 language_feature: generators, classes, object-literals
 goal: standalone-mode
-related: [2040, 1665, 2170, 2171, 2203, 680]
+related: [2040, 1665, 2170, 2171, 2203, 680, 1983]
 test262_bucket: standalone-method-generator-hostimport-leak
 test262_count: 250
 es_edition: es2015
+spec_status: ready
+spec_author: sd-5
+spec_date: 2026-06-21
+spec_note: "Implementation Plan written (sd-5). Key insight: `this` is just a leading param — the native state machine already persists+rehydrates params, so threading `this` as a synthetic leading param + admitting MethodDeclaration in the candidate gate + routing the class/object-literal emit through the existing factory does it; the .next()/.return()/.throw() dispatch is already representation-agnostic. A+B+C land as one PR. Broad blast radius (standalone-only) → full gen-method sweep before enqueue."
 origin: "Carved from #2040 (sd-5 reproduction, 2026-06-21). Distinct from #2040's cluster-A rest-identity codegen bug (sd-3): this is a separate instantiation bug — class/object-literal METHOD generators have no native lowering, so in a no-JS-host target they emit env.__gen_* imports that validate but cannot be satisfied at instantiate time. Affects ~250/500 generator/class files sampled."
 ---
 
@@ -28,8 +32,14 @@ object-literal generator method** compiles to a module that **validates** but
 **cannot instantiate**:
 
 ```ts
-class C { *m() { yield 42; } }
-export function run(): number { return new C().m().next().value === 42 ? 1 : 0; }
+class C {
+  *m() {
+    yield 42;
+  }
+}
+export function run(): number {
+  return new C().m().next().value === 42 ? 1 : 0;
+}
 ```
 
 ```
@@ -77,13 +87,13 @@ unrunnable-on-standalone purely from this leak.
 
 1. **Receiver/`this`** — the native state struct (`generators-native.ts`) has
    no slot for `this` or for captured class-scope bindings. The same gap that
-   makes capturing *nested* generators fall to the host path (#2203) applies to
+   makes capturing _nested_ generators fall to the host path (#2203) applies to
    method generators, which always have an implicit `this` capture.
 2. **Static vs instance** — instance methods carry a `this` param at index 0
    (see `class-bodies.ts` `isStatic` handling); static methods don't.
 3. **Laziness** — the buffer model is **eager** (runs the whole body at
    creation, buffers all yields). A mere "buffer into a WasmGC vec instead of a
-   host JS array" port would fix *instantiation* but still fail the spec
+   host JS array" port would fix _instantiation_ but still fail the spec
    laziness rows (`assert.sameValue(executed, false)` until first `.next()`) —
    roughly the cluster-B "~140 must-be-lazy" rows #2040 flagged. The correct
    fix is the **lazy native state machine** extended to a method receiver, not a
@@ -102,6 +112,204 @@ unrunnable-on-standalone purely from this leak.
    keeping the host-buffer path only for the JS-host target.
 4. Update `sourceNeedsGeneratorHostImports` to NOT force `needsHost` for a
    method generator that the (extended) native path can handle.
+
+## Implementation Plan
+
+### Root cause
+
+The native generator state machine (`src/codegen/generators-native.ts`,
+#1665/#2170/#2171) is wired only for **named `function*` declarations**:
+`isNativeGeneratorCandidate` (:795) requires `decl.name` and is typed
+`ts.FunctionDeclaration`; `sourceNeedsGeneratorHostImports` (:911) routes
+**every** `MethodDeclaration` with an asterisk straight to the eager-buffer
+host path. So class / object-literal method generators always emit
+`env.__gen_*` and can't instantiate standalone.
+
+### Key enabling insight — `this` is just a leading parameter
+
+The native machinery **already** persists parameters in the state struct and
+rehydrates them as named locals in the resume function:
+
+- The state struct (`registerNativeGenerator` :986-998) appends one immutable
+  `param_<name>` field per parameter after the 4-word header
+  `[state, sent, mode, abrupt]` (`PARAM_FIELD_OFFSET = 4`).
+- The factory (`compileNativeGeneratorFunction` :1646-1648) reads each wasm
+  param (`local.get i`) into its struct slot.
+- The resume function (:1594-1600) copies each `param_<name>` field back into a
+  **local named `info.paramNames[i]`**.
+- A `this`-reference compiles via `fctx.localMap.get("this")`
+  (`expressions.ts:856-857`).
+
+Therefore, if `this` is modelled as a synthetic **leading param named `"this"`**
+(receiver ref type) for an instance method, every `this.field` read inside the
+generator body resolves automatically — **no new state-struct field kind, no
+new `this`-plumbing**. Static methods have no receiver, so no synthetic param.
+
+The `.next()` / `.return()` / `.throw()` dispatch
+(`compileDirectNativeGeneratorMethod` :1702) operates purely on the state
+struct and is **already representation-agnostic** — it needs **no change**.
+The entire gap is on the **factory (object-construction) side**.
+
+### Work Item A: admit method generators in the candidate gate (~15 lines)
+
+**Patterns addressed**: all `gen-meth-*` (class instance/static, object-literal method).
+**Risk**: Low — additive; gated on `noJsHostTarget`, so JS-host mode is byte-identical.
+**Priority**: 1st (prerequisite for B/C).
+
+#### Changes
+
+**File: `src/codegen/generators-native.ts`**
+
+- `isNativeGeneratorCandidate` (:795) — widen the param type from
+  `ts.FunctionDeclaration` to `ts.FunctionDeclaration | ts.MethodDeclaration`.
+  Drop the `!decl.name` rejection for the method case (a method always has a
+  name; an anonymous object-literal method via computed/string name is out of
+  scope — bail when `decl.name` is a `ComputedPropertyName`). Keep the existing
+  async / rest-param / non-identifier-param / declare rejections (note: a method
+  body that references `arguments` should bail for now — see Edge cases).
+- `generatorElemValType` / `statementContainsYield` / `statementContainsReturn`
+  already stop recursion at `ts.isMethodDeclaration` (:150, :191) so a nested
+  inner method's yields don't leak into the outer plan — unchanged.
+
+### Work Item B: thread `this` as a leading param in the state model (~25 lines)
+
+**Patterns addressed**: instance method generators that read `this`.
+**Risk**: Medium — touches the param-field layout; static methods and free
+functions must stay byte-identical (no synthetic param prepended for them).
+**Priority**: 2nd.
+
+#### Changes
+
+**File: `src/codegen/generators-native.ts`**
+
+- `registerNativeGenerator` (:958) — when `decl` is a **non-static instance**
+  `MethodDeclaration`, prepend a synthetic entry to the param model BEFORE the
+  existing `param_*` loop (:992): `paramNames = ["this", ...userParamNames]`,
+  `paramTypes = [receiverType, ...userParamTypes]`. The receiver `ValType` is
+  the enclosing class's struct ref (the caller already computes it —
+  `class-bodies.ts` `params[0].type` for instance methods); pass it into
+  `registerNativeGenerator` (extend its `paramTypes` arg, OR add a
+  `receiverType?: ValType` param). The existing field loop then mints
+  `param_this` as field `PARAM_FIELD_OFFSET + 0` automatically, and the resume
+  function (:1594) rehydrates a `this` local automatically.
+- `compileNativeGeneratorFunction` (the factory, :1646) — the `local.get i`
+  loop must cover the synthetic `this`. For an instance method the wasm param 0
+  IS `this` and user params are 1..n (matches `class-bodies.ts` `isStatic ? pi
+: pi+1`), so iterate `local.get 0..paramTypes.length-1` UNCHANGED — it already
+  reads param 0 first. Verify the factory's param count equals
+  `info.paramTypes.length` (now includes `this`).
+- Static method: NO synthetic param. wasm params are 0..n-1 (no `this`); the
+  free-function code path already handles this shape verbatim.
+
+#### Edge cases
+
+- **Captured class lexical scope** (a generator method closing over a binding
+  from an enclosing function, not `this`/fields) — `generatorCapturesOuterScope`
+  (#2203, :825) already detects this and forces the host path. Keep that guard:
+  a capturing method generator still bails to host (documented follow-up), so
+  Work Item B covers only `this` + own-params, not arbitrary closure capture.
+- **`arguments` in a method generator** — the eager-buffer path builds an
+  `arguments` vec (`class-bodies.ts:2041`); the native resume function has no
+  such setup. Bail to host when `bodyUsesArguments(member.body)` (cheap check
+  the class emit already computes) until a follow-up.
+- **`super.*` in a method generator** — out of scope; bail (rare in `gen-meth-*`).
+
+### Work Item C: route the class/object-literal emit through the factory (~20 lines)
+
+**Patterns addressed**: makes `new C().m()` / `obj.m()` return the native state struct.
+**Risk**: Medium — the dispatch site; must preserve the host path for JS-host.
+**Priority**: 3rd.
+
+#### Changes
+
+**File: `src/codegen/class-bodies.ts`**
+
+- The generator-method emit (:2048-2080) currently unconditionally builds the
+  eager buffer. Add a guard at the top: when
+  `noJsHostTarget(ctx) && isNativeGeneratorCandidate(ctx, member) && !isAsyncMethod`,
+  register via `registerNativeGenerator(ctx, member, <methodFuncKey>,
+paramTypesIncludingThis)` and emit the method body via
+  `compileNativeGeneratorFunction(ctx, fctx, member, info)` (returns the state
+  struct `ref`), then `return` (skip the buffer block). The method's wasm result
+  type becomes `(ref $GenState_*)` instead of `externref` — mirror the
+  free-function return-type selection already done at
+  `declarations.ts:2493-2494` / `:2984-2985`
+  (`results = nativeGenerator ? [{kind:"ref", typeIdx: stateTypeIdx}] : [{kind:"externref"}]`).
+  Apply the SAME ternary to the method's signature where the class method's
+  result `ValType` is decided.
+- **Object-literal method generators** (`obj = { *m(){…} }`) — the analogous
+  emit lives in `closures.ts` (object-literal method lowering). Apply the same
+  guard there. (If the object-literal method path shares a helper with
+  `class-bodies.ts`, gate once; otherwise mirror.)
+
+**File: `src/codegen/generators-native.ts`**
+
+- `sourceNeedsGeneratorHostImports` (:911) — replace the unconditional
+  `if (ts.isMethodDeclaration(node) && node.asteriskToken && node.body) { needsHost = true }`
+  with: `needsHost = true` ONLY when the method is **not** a native candidate
+  (`!isNativeGeneratorCandidate(ctx, node)`) **or** it captures outer scope
+  (`generatorCapturesOuterScope(ctx, node)`) **or** uses `arguments`. A
+  native-capable method generator no longer forces the host imports — exactly
+  the free-function-declaration branch's logic (:903), generalized to methods.
+
+#### Dispatch — `new C().m().next()`
+
+No change. `new C().m()` produces the state struct (Work Item C); the
+`.next()` / `.return()` / `.throw()` call resolves through
+`compileDirectNativeGeneratorMethod` (:1702), which already reads/writes the
+state struct generically. The receiver-type check there
+(`receiverType.kind === "ref_null"` → `ref.as_non_null`, :1712) already handles
+the state ref.
+
+### Implementer notes (exports / call-graph)
+
+- `isNativeGeneratorCandidate`, `registerNativeGenerator`,
+  `compileNativeGeneratorFunction` are already **exported** from
+  `generators-native.ts` — callable from `class-bodies.ts` / `closures.ts`.
+- `noJsHostTarget` is **module-private** (:109). Either export it, or use the
+  inline `ctx.standalone || ctx.wasi` (class-bodies.ts already uses that form).
+- `registerNativeGenerator(ctx, decl, functionName, paramTypes)` takes a
+  `functionName` (used to mint `__GenState_<name>` + the resume func key and to
+  cache in `ctx.nativeGenerators`). For a method use a **collision-free** key —
+  reuse `classMemberFuncKey` (class-bodies already imports it, #1983) so two
+  classes with a `*m()` don't clash. For the synthetic `this` param, the
+  simplest signature change is to have `registerNativeGenerator` prepend `"this"`
+  - the receiver type when `ts.isMethodDeclaration(decl) && !isStatic`; pass
+    `isStatic` + `receiverType` through (or pre-build the `paramTypes`/param-name
+    arrays at the call site and pass them in, keeping `registerNativeGenerator`'s
+    signature stable — preferred, fewer touch points).
+
+### Sequencing & risk control
+
+- Land **A+B+C as one PR** (they're interdependent: the candidate gate, the
+  `this`-param model, and the emit/return-type all must move together or the
+  method emits a `(ref $GenState)` the dispatch can't see / leaks imports).
+- Keep every guard gated on `noJsHostTarget(ctx)` so **JS-host mode is
+  byte-identical** (the eager-buffer path is untouched there).
+- This is broad-blast-radius (every method generator changes lowering in
+  standalone) → after the narrow fix, run the **full** gen-method test262
+  cluster + a BROAD standalone sweep + `check-test262-hard-errors.mjs`; confirm
+  net ≥ 0, no new `wasm_compile`, 0 regressions BEFORE enqueue (heed the
+  #1837/#1844/#1838 scoped-sweep-miss lesson). Verify free-function and static
+  method generators stay byte-identical (no synthetic `this` param leaks in).
+
+### Tests
+
+- `class C { *m() { yield 42; } }` + `new C().m().next().value === 42` —
+  standalone: **zero `env.__gen_*` imports**, validates + instantiates + runs.
+- Instance method reading `this`: `class C { x = 7; *m() { yield this.x; } }` →
+  first `.next().value === 7`.
+- Static: `class C { static *m() { yield 1; yield 2; } }` → `1` then `2`.
+- Object-literal: `const o = { *m() { yield 9; } }; o.m().next().value === 9`.
+- Laziness: `let ran = 0; class C { *m() { ran = 1; yield 1; } }` — `const it =
+new C().m();` leaves `ran === 0` until the first `it.next()`.
+- test262: `language/statements/class/gen-method-*` and
+  `language/expressions/object/gen-meth-*` rows flip from host-import-leak
+  (validate-can't-instantiate) to pass standalone.
+- Negative / still-host (must keep working, not crash): capturing method
+  generator, `arguments`-using method generator, async-gen method — all bail to
+  the host path under JS-host and refuse-cleanly (not invalid Wasm) under
+  standalone.
 
 ## Acceptance criteria
 


### PR DESCRIPTION
## Summary

Writes the `## Implementation Plan` for **#2571** (standalone class/object-literal method generators leak `env.__gen_*` host imports — no native lowering, ~250/500 generator files can't instantiate standalone). I'm the issue author (found it via the leak probe carved from #2040), so I wrote the spec.

## Key enabling insight

`this` is just a leading parameter. The native generator state machine (`generators-native.ts`, #1665/#2170/#2171) **already** persists params in the state struct and rehydrates them as named locals in the resume function, and a `this`-reference resolves via `fctx.localMap.get("this")`. So:
- thread `this` as a synthetic leading param (receiver ref type) for instance methods → `this.field` reads resolve automatically, no new state-struct field kind;
- admit `MethodDeclaration` in `isNativeGeneratorCandidate`;
- route the class/object-literal emit through the existing `compileNativeGeneratorFunction` factory.

The `.next()`/`.return()`/`.throw()` dispatch (`compileDirectNativeGeneratorMethod`) is **already representation-agnostic** and needs no change — the entire gap is on the factory side.

## Plan (A+B+C, one PR)

- **A** — candidate gate accepts `MethodDeclaration` (asterisk, non-async).
- **B** — thread `this` as a leading param; static = no synthetic param; bail to host on capture (#2203) / `arguments` / `super`.
- **C** — route the `class-bodies.ts` + `closures.ts` emit through the factory; un-force the host imports in `sourceNeedsGeneratorHostImports`.

Exact functions/lines, edge cases, exports (`noJsHostTarget` is module-private — export or inline), the collision-free method key (`classMemberFuncKey`, #1983), and a **broad-sweep-before-enqueue** gate (heeding the #1837/#1844/#1838 scoped-sweep-miss lesson) are all documented. `spec_status: ready`.

Doc-only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)