### PR TITLE
docs(#2515): keystone-done + residual disposition; file #2578 multi-prop read-typing follow-up

### DIFF
--- a/plan/issues/2515-standalone-open-object-completion.md
+++ b/plan/issues/2515-standalone-open-object-completion.md
@@ -508,6 +508,43 @@ still falls through to `throwTypeError` for some wrapper/hint combinations.
 - `src/codegen/property-access.ts` (locate the `Object.prototype.toString.call` refusal) — S3
 - `tests/issue-2515.test.ts` (new) — per-slice run-tests
 
+## Status & residual disposition (sd-6, 2026-06-21)
+
+The **keystone is DONE** — the standalone-blocking emit CE and the create
+refusal are cleared. Merged:
+- **S0** — PR #1848 (sentinel-safe string producers: descriptor TypeError-throw
+  messages, obj-rest excluded-keys, null/undefined concat/template; killed
+  `global index out of range — -1`) + PR #1850 (calls.ts toString-fallback +
+  builtin-name dispatch guards). S0 residual 91 → 20.
+- **S1** — PR #1853 (`Object.create(o, descs)` routed to the existing native
+  `__obj_define_from_desc` instead of the refused `__defineProperty_desc` host
+  import; create-descriptor refusals 26 → 0, no new runtime helper needed).
+- **S3** — already shipped by **#2501** (`Object.prototype.toString.call → [object
+  X]`, verified correct host + standalone). **No S0 binary.ts change was needed**
+  — the `validateFuncRefs` validator was already always-on and already covered
+  globals; the bug was purely producers baking the `-1` string-constant sentinel.
+
+**Residual re-routed** (reproduce-first showed it is NOT a single #2515
+substrate — the pieces belong to other, already-active lanes):
+- **Descriptor flag-storage** (enumerable/writable/configurable lost via
+  create/defineProperties) **+ `getOwnPropertyDescriptor` read-back trap** →
+  **#2042** (object-runtime descriptor define/read semantics; #1854 just reworked
+  the same `__defineProperty_value` helper — same-file lane, do not race it).
+- **Multi-property combined dynamic read** (`const a=o.x; const b=o.y; a+b`→0 but
+  explicit `:number`→7; writes + single reads are correct) → **#2578** (read-side
+  type-inference, #2542 family). Filed separately.
+- **`Reflect.defineProperty` / `Reflect.construct`** → S4 tail: `defineProperty`
+  needs the descriptor reaching the native as an open `$Object` (a closed-struct
+  `{value:5}` makes the native throw "descriptor not an object"; same reification
+  the #2042 lane owns); `construct` needs the **#2158** construct ABI.
+  `Reflect.getOwnPropertyDescriptor` already shipped (#2046 S5).
+- **S5** boxed-wrapper ToPrimitive → **#1910** (coordinate, file overlap).
+
+The 20 remaining S0-residual `global.get -1` rows are the **built-in
+prototype-graph** read cluster (`SuppressedError.prototype`,
+`DisposableStack`/`AsyncDisposableStack` constructor checks, `Set.prototype.<setop>`
+subclass-receiver dispatch) — the **#2193/#2158/#49** epic, out of scope here.
+
 ## Cross-links
 
 - #1472 (parent — open-object runtime core + landed slices)

--- a/plan/issues/2578-standalone-dynamic-property-multi-read-typing.md
+++ b/plan/issues/2578-standalone-dynamic-property-multi-read-typing.md
@@ -1,0 +1,82 @@
+---
+id: 2578
+title: "standalone dynamic property multi-read mangles inferred-typed values (writes fine, combined read → 0)"
+status: ready
+sprint: Backlog
+created: 2026-06-21
+priority: medium
+feasibility: medium
+task_type: bugfix
+area: codegen
+language_feature: objects, property access, type inference
+goal: host-independence
+related: [2542, 2515]
+---
+
+# #2578 — standalone dynamic-property multi-read mangles inferred-typed values
+
+## Problem
+
+Under `--target standalone`, reading two dynamic (`any`-typed) properties off an
+open object and combining them in an inferred-typed expression yields `0`, even
+though each property reads correctly in isolation. The descriptor **writes** are
+correct — this is a **read-side type-inference** bug, in the #2542 dynamic
+property read/write family (not the #2515 descriptor machinery, and not #2042
+descriptor semantics).
+
+Surfaced while draining #2515 S1 (`Object.create(o, descs)`), but it reproduces
+on any open-object dynamic read, so it is filed separately.
+
+## Reproduction (standalone)
+
+```ts
+// each property reads correctly in isolation:
+Object.create(null, { x: { value: 3 }, y: { value: 4 } }) // o.x === 3 ✓, o.y === 4 ✓
+
+// combined read into INFERRED-typed consts → 0 (WRONG, want 7):
+export function test(): number {
+  const o = Object.create(null, { x: { value: 3 }, y: { value: 4 } });
+  const a = (o as any).x;   // inferred (any/number?)
+  const b = (o as any).y;
+  return a + b;             // → 0  (BUG)
+}
+
+// the SAME code with EXPLICIT `: number` annotations → 7 (CORRECT):
+export function test(): number {
+  const o = Object.create(null, { x: { value: 3 }, y: { value: 4 } });
+  const a: number = (o as any).x;
+  const b: number = (o as any).y;
+  return a + b;             // → 7  ✓
+}
+```
+
+So:
+- `return (o as any).x;` alone → 3 ✓
+- `return (o as any).y;` alone → 4 ✓
+- `const a=(o as any).x; const b=(o as any).y; return a+b;` (inferred) → **0** ✗
+- same with `const a: number` / `const b: number` → **7** ✓
+
+The explicit-annotation workaround pins it to **inferred-type lowering of a
+dynamic `__extern_get` read** — the inferred local likely lands as the wrong
+ValType (externref/boxed) so the `+` coerces both to a 0-ish scalar, or the two
+reads alias the same temp. Writes and single reads are unaffected.
+
+## Investigation pointers
+
+- `src/codegen/property-access.ts` dynamic-read path (`__extern_get` → result
+  ValType for an `any`/externref-typed binding).
+- How an inferred `const a = <externref dynamic read>` chooses the local
+  ValType vs an explicitly-`: number`-annotated one (the divergence point).
+- Check for temp-local aliasing across two consecutive dynamic reads.
+
+## Acceptance criteria
+
+- [ ] The inferred-typed combined read returns 7 (matches the annotated form and
+      host/gc mode).
+- [ ] Single-property reads and descriptor writes remain correct (no regression).
+- [ ] `--target gc` unchanged.
+
+## Cross-links
+
+- #2542 (standalone dynamic property read/write by computed key — same family)
+- #2515 (surfaced here during S1; descriptor writes are correct, this is read-side)


### PR DESCRIPTION
Docs-only. Records the #2515 outcome and tracks the residual so it isn't lost, and files the #2578 read-typing follow-up.

## #2515 — keystone done
S0 (PRs #1848 + #1850) + S1 (#1853) merged; S3 already shipped by #2501; Reflect.getOwnPropertyDescriptor by #2046 S5. Adds a "Status & residual disposition" section routing the tail to its real lanes:
- descriptor flag-storage + getOwnPropertyDescriptor read-back trap → **#2042** (object-runtime descriptor semantics, actively reworked by #1854 — do not race);
- multi-property combined dynamic read typing → new **#2578** (#2542 family);
- Reflect.defineProperty (descriptor reification, #2042 lane) / construct (**#2158** ABI);
- S5 boxed-wrapper ToPrimitive → **#1910**;
- the 20 residual `global.get -1` rows → built-in prototype-graph epic **#2193/#2158/#49**.

## New issue #2578
`standalone dynamic property multi-read mangles inferred-typed values` — `const a=o.x; const b=o.y; a+b → 0`, but `:number`-annotated → 7. Writes + single reads correct; read-side type-inference (#2542 family). `--allocate`d id, not hand-picked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)