### PR TITLE
fix(#2579): standalone boxed tag-5 string equality → native __str_equals

### DIFF
--- a/plan/issues/2579-standalone-any-strict-eq-tag5-string-content.md
+++ b/plan/issues/2579-standalone-any-strict-eq-tag5-string-content.md
@@ -1,0 +1,91 @@
+---
+id: 2579
+title: "standalone: __any_strict_eq / __any_eq tag-5 string arm returns always-false (boxed string === and Array.prototype.indexOf/includes.call on string array-likes)"
+status: done
+sprint: 64
+created: 2026-06-21
+updated: 2026-06-21
+completed: 2026-06-21
+assignee: sdev-strdispatch
+priority: low
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: strings
+goal: standalone-mode
+related: [2036, 1461, 1360, 296]
+origin: "2026-06-21 — pinpointed by sdev-reflect while closing #2036 array-search"
+---
+
+# #2579 — `__any_strict_eq` / `__any_eq` tag-5 string arm is always-false in standalone
+
+## Problem
+
+The `$AnyValue`-boxed equality helpers `__any_strict_eq` (`===`) and `__any_eq`
+(`==`) compare same-tag string operands (tag 5) by content via the
+`wasm:js-string` `equals` builtin. In standalone/WASI there is no
+`wasm:js-string` host, so `strEqualsIdx = ctx.jsStringImports.get("equals") ?? -1`
+is `-1`, and the tag-5 arm emitted `i32.const 0` (**always false**) — two equal
+strings boxed in `$AnyValue` never matched.
+
+The headline standalone repro (still failed on `origin/main` `93e53919f`):
+
+```ts
+const al: any = { 0: "x", 1: "y", length: 2 };
+Array.prototype.indexOf.call(al, "y"); // -1   expected 1
+Array.prototype.includes.call(al, "y"); // false expected true
+```
+
+`Array.prototype.{indexOf,lastIndexOf,includes}.call(arrayLike, str)` routes
+through `compileArrayLikePrototypeSearch` → `__extern_strict_eq` /
+`__extern_same_value_zero` (composed from `__any_from_extern` + `__any_strict_eq`),
+so the always-false tag-5 arm made every string-element search miss.
+
+## Root cause
+
+`any-helpers.ts` — the tag-5 (string) arm in both `__any_strict_eq` and
+`__any_eq`: `then: strEqualsIdx >= 0 ? [...wasm:js-string equals...] : [i32.const 0]`.
+Standalone takes the `i32.const 0` stub. The `$AnyValue` field 4 (externval)
+holds the native string as `extern.convert_any($AnyString)`, so the value is
+recoverable — only the comparison was stubbed out.
+
+## Fix
+
+Route the standalone tag-5 arm to the native `__str_equals` (the same helper
+`binary-ops.ts` uses for a static string `===`), recovering each operand from
+field 4: `any.convert_extern` → `ref.test $AnyString` guard → `ref.cast` →
+`__str_flatten` (cons-string safe) → `__str_equals`. Applied to BOTH helpers
+(`==` on same-type strings is content equality too, §7.2.15 → §7.2.16). The
+`ref.test` guard keeps a non-string-rep field-4 carrier on `0` rather than
+trapping. Host/gc mode keeps the `wasm:js-string equals` path unchanged. Two new
+anyref temp locals (`seA`/`seB`) per helper.
+
+## Acceptance criteria
+
+- `Array.prototype.indexOf.call({0:"x",1:"y",length:2}, "y")` → 1;
+  `…includes.call(…, "y")` → true.
+- cons-string element (`"x"+"y"` vs `"xy"`) matches; different-length strings
+  early-out correctly; a miss returns -1/false.
+- No regression: numeric/null array-like `.call` search unchanged; static string
+  `===` unchanged; host/gc mode unchanged.
+
+## Out of scope (verified, pre-existing on main — separate gaps)
+
+- Plain `const a:any=[...]; a.indexOf("y")` (NOT the `.call` form) still returns
+  0 — it routes through `__extern_method_call`, whose non-`$Object` ($Vec) brand
+  arm is the #1888 "Slice 4" deferral (returns undefined), and never reaches
+  `__any_strict_eq`. Separate, larger gap.
+- Boolean-element array-like `.call` search (`includes.call([true,false],
+false)`) returns 0 on main too (search-value boolean boxing, tag-4) — unrelated
+  to the string arm.
+- The #2036 S6 "refuse loud" + #1360 null-field array-like tests fail identically
+  on main (pre-existing, independent).
+
+## Implementation (sdev-strdispatch, 2026-06-21)
+
+`src/codegen/any-helpers.ts` only: capture `__str_equals`/`__str_flatten`
+indices in the standalone native-string block; replace the tag-5 `i32.const 0`
+stub in `__any_strict_eq` and `__any_eq` with the guarded native comparison; add
+`seA`/`seB` anyref locals to both helpers. Tests:
+`tests/issue-2579.test.ts`.

--- a/src/codegen/any-helpers.ts
+++ b/src/codegen/any-helpers.ts
@@ -533,12 +533,26 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
   let externToStringIdx = -1;
   let anyToStringIdx = -1;
   let strConcatIdx = -1;
+  // (#2036/#2575) Native string content-equality for the tag-5 strict-eq arm.
+  // Standalone/WASI has no `wasm:js-string` host (strEqualsIdx === -1), so the
+  // tag-5 arm of `__any_strict_eq` previously emitted `i32.const 0`
+  // (always-false): two equal strings boxed in `$AnyValue` (e.g. `any`-array
+  // elements compared by indexOf/includes via __any_from_extern + __any_strict_eq,
+  // or a boxed `===`) never matched. Route to the same `__str_equals` (content
+  // compare, with `__str_flatten` for cons-strings) that binary-ops uses for a
+  // static `===`. Field 4 (externval) holds the native string as
+  // `extern.convert_any($AnyString)`, so recover it via any.convert_extern + a
+  // `ref.test $AnyString` guard. Host/gc mode keeps the wasm:js-string path.
+  let strEqualsNativeIdx = -1;
+  let strFlattenIdx = -1;
   if ((ctx.standalone === true || ctx.wasi === true) && ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
     ensureNativeStringHelpers(ctx);
     ensureObjectRuntime(ctx); // registers native __extern_toString + __to_primitive
     anyToStringIdx = ensureAnyToStringHelper(ctx); // (anyref AnyValue) → ref $AnyString, tag-dispatched
     externToStringIdx = ctx.funcMap.get("__extern_toString") ?? -1;
     strConcatIdx = ctx.nativeStrHelpers.get("__str_concat") ?? -1;
+    strEqualsNativeIdx = ctx.nativeStrHelpers.get("__str_equals") ?? -1;
+    strFlattenIdx = ctx.nativeStrHelpers.get("__str_flatten") ?? -1;
   }
   // True when the standalone concat arm can be built (all pieces present).
   const anyAddCanConcat = anyToStringIdx >= 0 && externToStringIdx >= 0 && strConcatIdx >= 0 && ctx.anyStrTypeIdx >= 0;
@@ -1441,15 +1455,59 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
                                 op: "if",
                                 blockType: { kind: "val", type: { kind: "i32" } },
                                 then:
-                                  strEqualsIdx >= 0
+                                  // (#2036/#2575) Standalone/WASI: route tag-5
+                                  // string equality to the native `__str_equals`
+                                  // (content compare) on the field-4 externval,
+                                  // recovered to `$AnyString` and flattened — the
+                                  // same helper binary-ops uses for a static `===`.
+                                  // ref.test-guarded so a non-string-rep field-4
+                                  // carrier falls to 0 rather than trapping. Host/gc
+                                  // mode keeps the wasm:js-string `equals`; the
+                                  // legacy standalone `i32.const 0` (always-false)
+                                  // stub is gone (it made boxed string === / `any`
+                                  // array indexOf/includes always miss — #2036).
+                                  strEqualsNativeIdx >= 0 && strFlattenIdx >= 0 && ctx.anyStrTypeIdx >= 0
                                     ? [
+                                        // seA = any.convert_extern(a.externval)
                                         { op: "local.get", index: 0 },
                                         { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 4 },
+                                        { op: "any.convert_extern" },
+                                        { op: "local.set", index: 4 },
+                                        // seB = any.convert_extern(b.externval)
                                         { op: "local.get", index: 1 },
                                         { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 4 },
-                                        { op: "call", funcIdx: strEqualsIdx },
+                                        { op: "any.convert_extern" },
+                                        { op: "local.set", index: 5 },
+                                        // both $AnyString? (defensive guard)
+                                        { op: "local.get", index: 4 },
+                                        { op: "ref.test", typeIdx: ctx.anyStrTypeIdx },
+                                        { op: "local.get", index: 5 },
+                                        { op: "ref.test", typeIdx: ctx.anyStrTypeIdx },
+                                        { op: "i32.and" },
+                                        {
+                                          op: "if",
+                                          blockType: { kind: "val", type: { kind: "i32" } },
+                                          then: [
+                                            { op: "local.get", index: 4 },
+                                            { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx },
+                                            { op: "call", funcIdx: strFlattenIdx },
+                                            { op: "local.get", index: 5 },
+                                            { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx },
+                                            { op: "call", funcIdx: strFlattenIdx },
+                                            { op: "call", funcIdx: strEqualsNativeIdx },
+                                          ],
+                                          else: [{ op: "i32.const", value: 0 }],
+                                        },
                                       ]
-                                    : [{ op: "i32.const", value: 0 }],
+                                    : strEqualsIdx >= 0
+                                      ? [
+                                          { op: "local.get", index: 0 },
+                                          { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 4 },
+                                          { op: "local.get", index: 1 },
+                                          { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 4 },
+                                          { op: "call", funcIdx: strEqualsIdx },
+                                        ]
+                                      : [{ op: "i32.const", value: 0 }],
                                 else: [
                                   // null/undefined (tag < 2): both same tag → equal
                                   { op: "local.get", index: 2 },
@@ -1473,6 +1531,9 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
     [
       { name: "tagA", type: { kind: "i32" } },
       { name: "tagB", type: { kind: "i32" } },
+      // (#2036/#2575) anyref temps for the native tag-5 string-equality arm.
+      { name: "seA", type: { kind: "anyref" } },
+      { name: "seB", type: { kind: "anyref" } },
     ],
   );
 
@@ -1613,15 +1674,59 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
                                 op: "if",
                                 blockType: { kind: "val", type: { kind: "i32" } },
                                 then:
-                                  strEqualsIdx >= 0
+                                  // (#2036/#2575) Standalone/WASI: route tag-5
+                                  // string equality to the native `__str_equals`
+                                  // (content compare) on the field-4 externval,
+                                  // recovered to `$AnyString` and flattened — the
+                                  // same helper binary-ops uses for a static `===`.
+                                  // ref.test-guarded so a non-string-rep field-4
+                                  // carrier falls to 0 rather than trapping. Host/gc
+                                  // mode keeps the wasm:js-string `equals`; the
+                                  // legacy standalone `i32.const 0` (always-false)
+                                  // stub is gone (it made boxed string === / `any`
+                                  // array indexOf/includes always miss — #2036).
+                                  strEqualsNativeIdx >= 0 && strFlattenIdx >= 0 && ctx.anyStrTypeIdx >= 0
                                     ? [
+                                        // seA = any.convert_extern(a.externval)
                                         { op: "local.get", index: 0 },
                                         { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 4 },
+                                        { op: "any.convert_extern" },
+                                        { op: "local.set", index: 4 },
+                                        // seB = any.convert_extern(b.externval)
                                         { op: "local.get", index: 1 },
                                         { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 4 },
-                                        { op: "call", funcIdx: strEqualsIdx },
+                                        { op: "any.convert_extern" },
+                                        { op: "local.set", index: 5 },
+                                        // both $AnyString? (defensive guard)
+                                        { op: "local.get", index: 4 },
+                                        { op: "ref.test", typeIdx: ctx.anyStrTypeIdx },
+                                        { op: "local.get", index: 5 },
+                                        { op: "ref.test", typeIdx: ctx.anyStrTypeIdx },
+                                        { op: "i32.and" },
+                                        {
+                                          op: "if",
+                                          blockType: { kind: "val", type: { kind: "i32" } },
+                                          then: [
+                                            { op: "local.get", index: 4 },
+                                            { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx },
+                                            { op: "call", funcIdx: strFlattenIdx },
+                                            { op: "local.get", index: 5 },
+                                            { op: "ref.cast", typeIdx: ctx.anyStrTypeIdx },
+                                            { op: "call", funcIdx: strFlattenIdx },
+                                            { op: "call", funcIdx: strEqualsNativeIdx },
+                                          ],
+                                          else: [{ op: "i32.const", value: 0 }],
+                                        },
                                       ]
-                                    : [{ op: "i32.const", value: 0 }],
+                                    : strEqualsIdx >= 0
+                                      ? [
+                                          { op: "local.get", index: 0 },
+                                          { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 4 },
+                                          { op: "local.get", index: 1 },
+                                          { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 4 },
+                                          { op: "call", funcIdx: strEqualsIdx },
+                                        ]
+                                      : [{ op: "i32.const", value: 0 }],
                                 else: [
                                   // null/undefined (tag < 2): both same tag → equal
                                   { op: "local.get", index: 2 },
@@ -1645,6 +1750,9 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
     [
       { name: "tagA", type: { kind: "i32" } },
       { name: "tagB", type: { kind: "i32" } },
+      // (#2036/#2575) anyref temps for the native tag-5 string-equality arm.
+      { name: "seA", type: { kind: "anyref" } },
+      { name: "seB", type: { kind: "anyref" } },
     ],
   );
 

--- a/tests/issue-2579.test.ts
+++ b/tests/issue-2579.test.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2579 — `__any_strict_eq` / `__any_eq` tag-5 (string) arm was always-false in
+ * standalone. The `$AnyValue`-boxed equality helpers compared same-tag string
+ * operands via the `wasm:js-string` `equals` builtin, which is absent in
+ * standalone (`strEqualsIdx === -1`), so the arm emitted `i32.const 0`. The fix
+ * routes the standalone arm to the native `__str_equals` (with `__str_flatten`
+ * for cons-strings) on the field-4 externval recovered to `$AnyString`.
+ *
+ * Surfaces via `Array.prototype.{indexOf,lastIndexOf,includes}.call(arrayLike,
+ * str)`, which composes `__any_from_extern` + `__any_strict_eq` /
+ * `__any_eq`-derived `__extern_strict_eq` / `__extern_same_value_zero`.
+ */
+
+async function runStandalone(source: string): Promise<number> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module must validate").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as Record<string, () => number>).test();
+}
+
+describe("#2579 — boxed tag-5 string equality routes to native __str_equals (standalone)", () => {
+  it("Array.prototype.indexOf.call over a string array-like finds the match", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const al:any={0:"x",1:"y",length:2}; return Array.prototype.indexOf.call(al, "y"); }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("Array.prototype.includes.call over a string array-like returns true", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const al:any={0:"x",1:"y",length:2}; return Array.prototype.includes.call(al, "y")?1:0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("Array.prototype.lastIndexOf.call over a string array-like finds the last match", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const al:any={0:"y",1:"x",2:"y",length:3}; return Array.prototype.lastIndexOf.call(al, "y"); }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("cons-string element (concat) compares by content", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const al:any={0:"ab",1:("x"+"y"),length:2}; return Array.prototype.indexOf.call(al, "xy"); }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("different-length strings do not spuriously match (len early-out)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const al:any={0:"abc",1:"de",length:2}; return Array.prototype.indexOf.call(al, "de"); }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("a miss returns -1 / false", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const al:any={0:"x",1:"y",length:2}; return Array.prototype.indexOf.call(al, "z"); }`,
+      ),
+    ).toBe(-1);
+  });
+
+  // ── Non-regression guards ────────────────────────────────────────────────
+
+  it("numeric array-like .call search is unaffected", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const al:any={0:10,1:20,length:2}; return Array.prototype.indexOf.call(al, 20); }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("static string === is unchanged", async () => {
+    expect(await runStandalone(`export function test(): number { const a="hi"; return a==="hi"?1:0; }`)).toBe(1);
+    expect(await runStandalone(`export function test(): number { const a="hi"; return a==="bye"?1:0; }`)).toBe(0);
+  });
+});


### PR DESCRIPTION
## #2579 — `__any_strict_eq` / `__any_eq` tag-5 string arm always-false in standalone

The `$AnyValue`-boxed equality helpers compared same-tag string operands (tag 5) via the `wasm:js-string` `equals` builtin, which is **absent in standalone** (`strEqualsIdx === -1`), so the arm emitted `i32.const 0` — two equal boxed strings never matched.

Surfaced via `Array.prototype.{indexOf,lastIndexOf,includes}.call(stringArrayLike, str)`, which composes `__any_from_extern` + `__any_strict_eq` / `__any_eq`:

```ts
const al: any = { 0: "x", 1: "y", length: 2 };
Array.prototype.indexOf.call(al, "y");    // -1   → 1
Array.prototype.includes.call(al, "y");   // false → true
```

### Fix (`any-helpers.ts` only)
Route the standalone tag-5 arm to the native `__str_equals` (the same helper `binary-ops.ts` uses for a static string `===`): recover each operand from field 4 (`externval`) via `any.convert_extern`, a `ref.test $AnyString` guard, `ref.cast`, `__str_flatten` (cons-string safe), then `__str_equals`. Applied to **both** `__any_strict_eq` (`===`) and `__any_eq` (`==`). The guard keeps a non-string field-4 carrier on `0` rather than trapping. Host/gc mode keeps the `wasm:js-string` path. Two new anyref temps per helper.

### Non-regression
Numeric/null array-like `.call` search unchanged; static string `===` unchanged; host/gc unchanged. The pre-existing #2036 S6 "refuse loud" and #1360 null-field failures are **identical on `main`** (verified) — untouched by this fix.

### Out of scope (pre-existing on `main`, separate gaps)
- Plain `const a:any=[...]; a.indexOf("y")` (NOT the `.call` form) → 0: routes through `__extern_method_call`'s non-`$Object` `$Vec` brand arm (#1888 "Slice 4" deferral), never reaches this helper.
- Boolean-element array-like `.call` search returns 0 on main too (tag-4 search-value boxing).

Tests: `tests/issue-2579.test.ts` (8 cases: indexOf/includes/lastIndexOf, cons-string, len early-out, miss, non-regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)