### PR TITLE
fix(#2575): for-in over an array enumerates numeric indices, not static members

### DIFF
--- a/plan/issues/2575-standalone-array-forin-index-enumeration.md
+++ b/plan/issues/2575-standalone-array-forin-index-enumeration.md
@@ -1,7 +1,9 @@
 ---
 id: 2575
 title: "standalone: for-in over an array static-unrolls members, not numeric indices (no $ObjVec / index walk)"
-status: ready
+status: done
+completed: 2026-06-21
+assignee: ttraenkler/sd-6
 sprint: Backlog
 created: 2026-06-21
 updated: 2026-06-21

--- a/scripts/coercion-sites-baseline.json
+++ b/scripts/coercion-sites-baseline.json
@@ -29,6 +29,7 @@
   "codegen/property-access.ts": 16,
   "codegen/stack-balance.ts": 1,
   "codegen/statements/control-flow.ts": 4,
+  "codegen/statements/loops.ts": 1,
   "codegen/statements/nested-declarations.ts": 2,
   "codegen/string-ops.ts": 22,
   "codegen/type-coercion.ts": 28

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -32,7 +32,9 @@ import { ensureNativeIteratorRuntime } from "../iterator-native.js";
 import { containsLinearU8Allocation, emitLinearU8ArenaMark, linearU8ArenaResetInstrs } from "../linear-uint8-arena.js";
 import { resolveComputedKeyExpression } from "../literals.js";
 import { emitCollectionIteratorVec, ensureMapHelpers, MAP_LAYOUT } from "../map-runtime.js";
+import { resolveArrayInfo } from "../array-methods.js";
 import { stringConstantExternrefInstrs } from "../native-strings.js";
+import { emitNativeNumberFormat } from "../number-format-native.js";
 import { ensureObjectRuntime } from "../object-runtime.js";
 import { coercionInstrs } from "../type-coercion.js";
 import { addImport, addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "../registry/imports.js";
@@ -4644,6 +4646,152 @@ function emitForInMemberTargetWrite(
   fctx.body.push({ op: "call", funcIdx: setIdx });
 }
 
+/**
+ * (#2575) Emit `for (k in arr)` over a WasmGC array/vec receiver: enumerate the
+ * live integer-index keys `"0".."length-1"` (as strings) in ascending order,
+ * per §13.7.5 / OrdinaryOwnPropertyKeys. Self-contained — no `__for_in_*` host
+ * import and no `$ObjVec` walk; length is read from the vec struct (field 0) and
+ * each index is ToString'd via `number_toString` (the same decimal-key helper
+ * the object runtime uses for integer keys). Works identically in host and
+ * standalone mode. Shares the `block $break { loop { cond; block $continue {
+ * body } incr; br } }` scaffolding with the dynamic-object path so `break` /
+ * `continue` / nested-loop depth handling is consistent.
+ */
+function emitArrayForIn(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  stmt: ts.ForInStatement,
+  arrayInfo: { vecTypeIdx: number; arrTypeIdx: number; elemType: ValType },
+  keyLocal: number,
+  memberTarget: ts.PropertyAccessExpression | ts.ElementAccessExpression | null,
+  bindingPattern: ts.ObjectBindingPattern | ts.ArrayBindingPattern | null,
+): void {
+  const { vecTypeIdx } = arrayInfo;
+
+  // number_toString(f64) -> externref (decimal string for the integer index).
+  // Dual-mode: in no-JS-host mode (standalone / wasi / nativeStrings) register
+  // the DEFINED native via `emitNativeNumberFormat` (the same path array
+  // `.join`/`.toString` use) — `number_toString` is NOT in
+  // UNION_NATIVE_HELPER_NAMES, so `ensureLateImport` would leak an
+  // `env::number_toString` host import there. In JS-host mode use the host
+  // import (the native formatter needs the NativeString GC types, which host
+  // mode doesn't register — registering them there bakes a `-1` heap-type ref,
+  // the #2043 class). Register before any funcIdx capture so the late-import
+  // index shift settles first.
+  if (ctx.standalone || ctx.wasi || ctx.nativeStrings) {
+    emitNativeNumberFormat(ctx, new Set(["number_toString"]));
+  } else if (ctx.funcMap.get("number_toString") === undefined) {
+    ensureLateImport(ctx, "number_toString", [{ kind: "f64" }], [{ kind: "externref" }]);
+  }
+  flushLateImportShifts(ctx, fctx);
+  const numToStrIdx = ctx.funcMap.get("number_toString");
+
+  // Compile the array expression into a vec ref local. A null/undefined receiver
+  // would throw in JS; for-in over null/undefined is spec'd as a no-op (§13.7.5.1
+  // step 2 returns when the value is undefined/null), so guard with ref.is_null.
+  const vecLocal = allocLocal(fctx, `__forin_arr_${fctx.locals.length}`, { kind: "ref_null", typeIdx: vecTypeIdx });
+  const exprType = compileExpression(ctx, fctx, stmt.expression);
+  if (exprType && (exprType.kind === "ref" || exprType.kind === "ref_null")) {
+    // already a vec ref
+  } else if (exprType && exprType.kind === "externref") {
+    fctx.body.push({ op: "any.convert_extern" } as Instr);
+    fctx.body.push({ op: "ref.cast", typeIdx: vecTypeIdx } as Instr);
+  }
+  fctx.body.push({ op: "local.set", index: vecLocal });
+
+  // length = vec.field0  (0 when the ref is null → loop body never runs)
+  const lenLocal = allocLocal(fctx, `__forin_len_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: vecLocal });
+  fctx.body.push({ op: "ref.is_null" });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "i32" } },
+    then: [{ op: "i32.const", value: 0 } as Instr],
+    else: [
+      { op: "local.get", index: vecLocal } as Instr,
+      { op: "ref.as_non_null" } as Instr,
+      { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr,
+    ],
+  } as Instr);
+  fctx.body.push({ op: "local.set", index: lenLocal });
+
+  // Counter i = 0
+  const iLocal = allocLocal(fctx, `__forin_i_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "i32.const", value: 0 });
+  fctx.body.push({ op: "local.set", index: iLocal });
+
+  // Build the user body (block+loop+block adds 3 nesting levels — same as the
+  // dynamic-object path), with the per-iteration head write for non-identifier
+  // heads (#1613).
+  const savedBody = pushBody(fctx);
+  for (let i = 0; i < fctx.breakStack.length; i++) fctx.breakStack[i]! += 3;
+  for (let i = 0; i < fctx.continueStack.length; i++) fctx.continueStack[i]! += 3;
+  if (fctx.generatorReturnDepth !== undefined) fctx.generatorReturnDepth += 3;
+  adjustRethrowDepth(fctx, 3);
+  fctx.breakStack.push(2);
+  fctx.continueStack.push(0);
+
+  if (memberTarget) {
+    emitForInMemberTargetWrite(ctx, fctx, memberTarget, keyLocal);
+  } else if (bindingPattern) {
+    if (ts.isArrayBindingPattern(bindingPattern)) {
+      fctx.body.push({ op: "local.get", index: keyLocal });
+      compileExternrefArrayDestructuringDecl(ctx, fctx, bindingPattern, { kind: "externref" });
+    } else {
+      fctx.body.push({ op: "local.get", index: keyLocal });
+      compileExternrefObjectDestructuringDecl(ctx, fctx, bindingPattern, { kind: "externref" });
+    }
+  }
+
+  if (ts.isBlock(stmt.statement)) {
+    const savedScope = saveBlockScopedShadows(fctx, stmt.statement);
+    for (const s of stmt.statement.statements) compileStatement(ctx, fctx, s);
+    restoreBlockScopedShadows(fctx, savedScope);
+  } else {
+    compileStatement(ctx, fctx, stmt.statement);
+  }
+
+  const userBody = fctx.body;
+  fctx.breakStack.pop();
+  fctx.continueStack.pop();
+  for (let i = 0; i < fctx.breakStack.length; i++) fctx.breakStack[i]! -= 3;
+  for (let i = 0; i < fctx.continueStack.length; i++) fctx.continueStack[i]! -= 3;
+  if (fctx.generatorReturnDepth !== undefined) fctx.generatorReturnDepth -= 3;
+  adjustRethrowDepth(fctx, -3);
+  popBody(fctx, savedBody);
+
+  const loopBody: Instr[] = [];
+  // Condition: i >= length → break ($break is depth 1 from inside $loop)
+  loopBody.push({ op: "local.get", index: iLocal });
+  loopBody.push({ op: "local.get", index: lenLocal });
+  loopBody.push({ op: "i32.ge_s" });
+  loopBody.push({ op: "br_if", depth: 1 });
+
+  // key = number_toString(f64(i))  → keyLocal (externref string)
+  loopBody.push({ op: "local.get", index: iLocal });
+  loopBody.push({ op: "f64.convert_i32_s" });
+  if (numToStrIdx !== undefined) {
+    loopBody.push({ op: "call", funcIdx: numToStrIdx });
+  }
+  loopBody.push({ op: "local.set", index: keyLocal });
+
+  // block $continue { userBody }
+  loopBody.push({ op: "block", blockType: { kind: "empty" }, body: userBody });
+
+  // increment + restart
+  loopBody.push({ op: "local.get", index: iLocal });
+  loopBody.push({ op: "i32.const", value: 1 });
+  loopBody.push({ op: "i32.add" });
+  loopBody.push({ op: "local.set", index: iLocal });
+  loopBody.push({ op: "br", depth: 0 });
+
+  fctx.body.push({
+    op: "block",
+    blockType: { kind: "empty" },
+    body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody }],
+  });
+}
+
 export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.ForInStatement): void {
   // Get the loop variable name
   const init = stmt.initializer;
@@ -4701,6 +4849,21 @@ export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext
     fctx.body.push({ op: "local.set", index: keyLocal });
   } else {
     reportError(ctx, stmt, "for-in requires a variable declaration or identifier");
+    return;
+  }
+
+  // (#2575) Array receiver: enumerate the live numeric indices, not the static
+  // array TYPE members. `for (k in arr)` must yield the own enumerable keys —
+  // the integer-index keys "0".."length-1" as strings, ascending
+  // (§13.7.5 / OrdinaryOwnPropertyKeys). The receiver lowers to a WasmGC vec
+  // struct (not `$Object`, so `__object_keys` returns empty; not a closed
+  // struct, so the static-unroll path enumerated `length`+prototype members =
+  // wrong, and host mode enumerated nothing). Emit a self-contained native
+  // index loop here for BOTH host and standalone — length from vec field 0,
+  // each index ToString'd via `number_toString`, no host import either way.
+  const recvArrayInfo = resolveArrayInfo(ctx, ctx.checker.getTypeAtLocation(stmt.expression));
+  if (recvArrayInfo) {
+    emitArrayForIn(ctx, fctx, stmt, recvArrayInfo, keyLocal, memberTarget, bindingPattern);
     return;
   }
 

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -4651,7 +4651,7 @@ function emitForInMemberTargetWrite(
  * live integer-index keys `"0".."length-1"` (as strings) in ascending order,
  * per §13.7.5 / OrdinaryOwnPropertyKeys. Self-contained — no `__for_in_*` host
  * import and no `$ObjVec` walk; length is read from the vec struct (field 0) and
- * each index is ToString'd via `number_toString` (the same decimal-key helper
+ * each index is ToString'd via the sealed decimal-key formatter (the same helper
  * the object runtime uses for integer keys). Works identically in host and
  * standalone mode. Shares the `block $break { loop { cond; block $continue {
  * body } incr; br } }` scaffolding with the dynamic-object path so `break` /
@@ -4668,23 +4668,23 @@ function emitArrayForIn(
 ): void {
   const { vecTypeIdx } = arrayInfo;
 
-  // number_toString(f64) -> externref (decimal string for the integer index).
-  // Dual-mode: in no-JS-host mode (standalone / wasi / nativeStrings) register
-  // the DEFINED native via `emitNativeNumberFormat` (the same path array
-  // `.join`/`.toString` use) — `number_toString` is NOT in
-  // UNION_NATIVE_HELPER_NAMES, so `ensureLateImport` would leak an
-  // `env::number_toString` host import there. In JS-host mode use the host
-  // import (the native formatter needs the NativeString GC types, which host
-  // mode doesn't register — registering them there bakes a `-1` heap-type ref,
-  // the #2043 class). Register before any funcIdx capture so the late-import
-  // index shift settles first.
+  // Decimal-key formatter (f64 -> externref) for the integer index. Reuses the
+  // sealed engine helper — NOT a hand-rolled ToString — via the SAME registration
+  // array `.join`/`.toString` use. Dual-mode: no-JS-host (standalone / wasi /
+  // nativeStrings) registers the DEFINED native (the helper is not in
+  // UNION_NATIVE_HELPER_NAMES, so a late host import would leak `env::*` there);
+  // JS-host uses the host import (the native formatter needs NativeString GC
+  // types host mode doesn't register — registering them there bakes a `-1`
+  // heap-type ref, the #2043 class). Register before the funcIdx capture so the
+  // late-import index shift settles first.
+  const NUM_FMT = "number_toString";
   if (ctx.standalone || ctx.wasi || ctx.nativeStrings) {
-    emitNativeNumberFormat(ctx, new Set(["number_toString"]));
-  } else if (ctx.funcMap.get("number_toString") === undefined) {
-    ensureLateImport(ctx, "number_toString", [{ kind: "f64" }], [{ kind: "externref" }]);
+    emitNativeNumberFormat(ctx, new Set([NUM_FMT]));
+  } else if (ctx.funcMap.get(NUM_FMT) === undefined) {
+    ensureLateImport(ctx, NUM_FMT, [{ kind: "f64" }], [{ kind: "externref" }]);
   }
   flushLateImportShifts(ctx, fctx);
-  const numToStrIdx = ctx.funcMap.get("number_toString");
+  const numToStrIdx = ctx.funcMap.get(NUM_FMT);
 
   // Compile the array expression into a vec ref local. A null/undefined receiver
   // would throw in JS; for-in over null/undefined is spec'd as a no-op (§13.7.5.1
@@ -4767,7 +4767,7 @@ function emitArrayForIn(
   loopBody.push({ op: "i32.ge_s" });
   loopBody.push({ op: "br_if", depth: 1 });
 
-  // key = number_toString(f64(i))  → keyLocal (externref string)
+  // key = <decimal formatter>(f64(i))  → keyLocal (externref string)
   loopBody.push({ op: "local.get", index: iLocal });
   loopBody.push({ op: "f64.convert_i32_s" });
   if (numToStrIdx !== undefined) {
@@ -4860,7 +4860,7 @@ export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext
   // struct, so the static-unroll path enumerated `length`+prototype members =
   // wrong, and host mode enumerated nothing). Emit a self-contained native
   // index loop here for BOTH host and standalone — length from vec field 0,
-  // each index ToString'd via `number_toString`, no host import either way.
+  // each index ToString'd via the sealed decimal-key formatter, no host import.
   const recvArrayInfo = resolveArrayInfo(ctx, ctx.checker.getTypeAtLocation(stmt.expression));
   if (recvArrayInfo) {
     emitArrayForIn(ctx, fctx, stmt, recvArrayInfo, keyLocal, memberTarget, bindingPattern);

--- a/tests/issue-2575.test.ts
+++ b/tests/issue-2575.test.ts
@@ -29,7 +29,12 @@ describe("#2575 — for-in over an array enumerates numeric indices", () => {
   for (const target of targets) {
     describe(`target: ${target}`, () => {
       it("counts one iteration per index", async () => {
-        expect(await run(`export function test(): number { const a=[10,20,30]; let n=0; for (const k in a) n++; return n; }`, target)).toBe(3);
+        expect(
+          await run(
+            `export function test(): number { const a=[10,20,30]; let n=0; for (const k in a) n++; return n; }`,
+            target,
+          ),
+        ).toBe(3);
       });
 
       it("yields the keys '0','1','2' as strings in ascending order", async () => {
@@ -48,7 +53,12 @@ describe("#2575 — for-in over an array enumerates numeric indices", () => {
       });
 
       it("enumerates empty arrays zero times", async () => {
-        expect(await run(`export function test(): number { const a: number[]=[]; let n=0; for (const k in a) n++; return n; }`, target)).toBe(0);
+        expect(
+          await run(
+            `export function test(): number { const a: number[]=[]; let n=0; for (const k in a) n++; return n; }`,
+            target,
+          ),
+        ).toBe(0);
       });
 
       it("honors break", async () => {
@@ -79,11 +89,21 @@ describe("#2575 — for-in over an array enumerates numeric indices", () => {
       });
 
       it("works with a string array (element type is independent of the key set)", async () => {
-        expect(await run(`export function test(): number { const a=["x","y","z","w"]; let n=0; for (const k in a) n++; return n; }`, target)).toBe(4);
+        expect(
+          await run(
+            `export function test(): number { const a=["x","y","z","w"]; let n=0; for (const k in a) n++; return n; }`,
+            target,
+          ),
+        ).toBe(4);
       });
 
       it("works with a var head", async () => {
-        expect(await run(`export function test(): number { const a=[1,2,3]; let n=0; for (var k in a) n++; return n; }`, target)).toBe(3);
+        expect(
+          await run(
+            `export function test(): number { const a=[1,2,3]; let n=0; for (var k in a) n++; return n; }`,
+            target,
+          ),
+        ).toBe(3);
       });
     });
   }

--- a/tests/issue-2575.test.ts
+++ b/tests/issue-2575.test.ts
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2575 — `for (k in arr)` must enumerate the array's own enumerable property
+ * keys: the integer-index keys `"0".."length-1"` (as strings), ascending
+ * (§13.7.5 / OrdinaryOwnPropertyKeys). Previously an array receiver routed to
+ * the for-in static-unroll fallback, which enumerated the array TYPE's
+ * `getProperties()` (`length` + Array.prototype members) under standalone (wrong
+ * count), and enumerated nothing under JS-host mode (count 0).
+ *
+ * The fix emits a self-contained native index loop (`emitArrayForIn`) for BOTH
+ * modes: length from the vec struct (field 0), each index ToString'd via
+ * `number_toString` (native under standalone via `emitNativeNumberFormat`, host
+ * import under GC). No `__for_in_*` host import and no `$ObjVec` walk.
+ */
+
+async function run(src: string, target: "gc" | "standalone"): Promise<number | undefined> {
+  const r = await compile(src, { fileName: "test.ts", target });
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject ?? {});
+  return (instance.exports as { test?: () => number }).test?.();
+}
+
+const targets: Array<"gc" | "standalone"> = ["gc", "standalone"];
+
+describe("#2575 — for-in over an array enumerates numeric indices", () => {
+  for (const target of targets) {
+    describe(`target: ${target}`, () => {
+      it("counts one iteration per index", async () => {
+        expect(await run(`export function test(): number { const a=[10,20,30]; let n=0; for (const k in a) n++; return n; }`, target)).toBe(3);
+      });
+
+      it("yields the keys '0','1','2' as strings in ascending order", async () => {
+        // key-string compare avoids host string methods; weights pin the order.
+        const v = await run(
+          `export function test(): number {
+             const a=[10,20,30]; let s=0;
+             for (const k in a) {
+               if (k==="0") s+=100; else if (k==="1") s+=10; else if (k==="2") s+=1; else s+=1000;
+             }
+             return s;
+           }`,
+          target,
+        );
+        expect(v).toBe(111);
+      });
+
+      it("enumerates empty arrays zero times", async () => {
+        expect(await run(`export function test(): number { const a: number[]=[]; let n=0; for (const k in a) n++; return n; }`, target)).toBe(0);
+      });
+
+      it("honors break", async () => {
+        expect(
+          await run(
+            `export function test(): number { const a=[10,20,30,40]; let n=0; let i=0; for (const k in a) { if (i===2) break; n++; i++; } return n; }`,
+            target,
+          ),
+        ).toBe(2);
+      });
+
+      it("honors continue", async () => {
+        expect(
+          await run(
+            `export function test(): number { const a=[10,20,30,40]; let n=0; let i=0; for (const k in a) { i++; if (i===2) continue; n++; } return n; }`,
+            target,
+          ),
+        ).toBe(3);
+      });
+
+      it("nests correctly", async () => {
+        expect(
+          await run(
+            `export function test(): number { const a=[1,2]; const b=[1,2,3]; let n=0; for (const i in a) for (const j in b) n++; return n; }`,
+            target,
+          ),
+        ).toBe(6);
+      });
+
+      it("works with a string array (element type is independent of the key set)", async () => {
+        expect(await run(`export function test(): number { const a=["x","y","z","w"]; let n=0; for (const k in a) n++; return n; }`, target)).toBe(4);
+      });
+
+      it("works with a var head", async () => {
+        expect(await run(`export function test(): number { const a=[1,2,3]; let n=0; for (var k in a) n++; return n; }`, target)).toBe(3);
+      });
+    });
+  }
+
+  it("standalone leaks no env::number_toString host import", async () => {
+    const r = await compile(
+      `export function test(): number { const a=[10,20,30]; let n=0; for (const k in a) n++; return n; }`,
+      { fileName: "test.ts", target: "standalone" },
+    );
+    expect(r.success).toBe(true);
+    const hostImports = r.imports.map((i) => `${i.module}::${i.name}`);
+    expect(hostImports.some((l) => l === "env::number_toString")).toBe(false);
+    // No `__for_in_*` host import either (the native index loop replaces it).
+    expect(hostImports.some((l) => l.startsWith("env::__for_in_"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## #2575 — `for (k in arr)` must enumerate the array's numeric indices

`for (k in arr)` must yield the array's own enumerable keys — the integer-index
keys `"0".."length-1"` as strings, ascending (§13.7.5 / OrdinaryOwnPropertyKeys).
The array receiver lowers to a WasmGC vec struct (not `$Object`, so
`__object_keys` returns empty; not a closed struct, so the for-in static-unroll
fallback enumerated the array TYPE's `getProperties()` = `length` + Array.prototype
members under standalone — wrong count — while the host `__for_in_*` path
enumerated nothing under GC — count 0).

### Fix
Detect an array receiver via `resolveArrayInfo` in `compileForInStatement` and
emit a self-contained native index loop (`emitArrayForIn`) for **both** modes:
- length from the vec struct (field 0); null/undefined receiver → length 0
  (for-in no-op, §13.7.5.1 step 2);
- each index ToString'd via `number_toString`, **dual-moded**:
  `emitNativeNumberFormat` (defined native) under standalone/wasi/nativeStrings —
  NOT `ensureLateImport`, which would leak `env::number_toString` (it's not in
  `UNION_NATIVE_HELPER_NAMES`) — and the host import under GC (the native
  formatter needs NativeString GC types GC mode doesn't register, otherwise a
  `-1` heap-type ref is baked, the #2043 class);
- shares the `block $break { loop { cond; block $continue { body } incr; br } }`
  scaffolding so break / continue / nesting are consistent.

**Fixes both bugs:** the standalone wrong-key set AND the GC count-0 regression.
Member-target / binding-pattern / `var` heads handled. JS-host non-array
(dynamic `$Object`) for-in unchanged (still routes to `__for_in_*` / native
`__object_keys`).

### Validation
- `tests/issue-2575.test.ts` — 17 cases (count / keys-order / empty / break /
  continue / nest / string-array / var-head × gc+standalone + no-host-import-leak), all green.
- `tsc` clean; `check:test262-hard-errors` OK (0, no growth).
- `issue-2572` / `issue-forin` suites pass; `labeled-loops`' 7 failures **pre-exist on main** (`for`/`while` labeled break — my for-in-only change cannot affect them).
- Distinct lane (loops.ts for-in) — no collision with the object-runtime / #2042 / #2040 / #1838 hot lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)