### PR TITLE
plan(s64): close sprint 64 — carry 39 to s65, record results

### DIFF
--- a/plan/issues/1042-async-await-state-machine-lowering.md
+++ b/plan/issues/1042-async-await-state-machine-lowering.md
@@ -8,7 +8,7 @@ priority: high
 feasibility: hard
 reasoning_effort: max
 goal: async-model
-sprint: 64
+sprint: 65
 parent: 1032
 depends_on: [680]
 required_by: [1058, 1766, 1774]

--- a/plan/issues/1344-spec-gap-generator-prototype-receiver-checks.md
+++ b/plan/issues/1344-spec-gap-generator-prototype-receiver-checks.md
@@ -12,7 +12,7 @@ task_type: bugfix
 area: codegen
 language_feature: generators
 goal: spec-completeness
-sprint: 64
+sprint: 65
 parent: 1328
 depends_on: [1665]
 ---

--- a/plan/issues/1355-spec-backlog-proxy-pure-wasm.md
+++ b/plan/issues/1355-spec-backlog-proxy-pure-wasm.md
@@ -12,7 +12,7 @@ task_type: feature
 area: runtime, codegen
 language_feature: proxy
 goal: spec-completeness
-sprint: 64
+sprint: 65
 parent: 1334
 depends_on: [1100]
 note: "2026-06-15: elevated to TOP priority by stakeholder (Proxy/Promise/async-to-100% epic). Remaining 10 traps + invariant checks to drive Proxy past host-fallback toward 100% (standalone). Follows #1100 Phase 1. Needs architect spec."

--- a/plan/issues/1373b-ir-async-cps-lowering.md
+++ b/plan/issues/1373b-ir-async-cps-lowering.md
@@ -11,7 +11,7 @@ task_type: feature
 area: ir, codegen
 language_feature: async
 goal: ir-full-coverage
-sprint: 64
+sprint: 65
 depends_on: [1326c]
 note: "Verified 2026-05-21: src/codegen/async-scheduler.ts exists; src/codegen/async-cps.ts does NOT exist yet (still pending #1042 introducing it). async-cluster-architect-spec.md exists. Unblocked 2026-06-16 (se1): sole dependency #1326c flipped done — Phase 1C microtask queue + chained .then landed on main."
 ---

--- a/plan/issues/1528-non-constructor-typeerror-promise-and-species.md
+++ b/plan/issues/1528-non-constructor-typeerror-promise-and-species.md
@@ -10,7 +10,7 @@ reasoning_effort: medium
 task_type: bugfix
 area: codegen
 language_feature: promise, species, constructor-invariants
-sprint: 64
+sprint: 65
 es_edition: ES2015+
 test262_category: built-ins/Promise, language/function-code
 test262_count: 79

--- a/plan/issues/1899-reconcile-finalize-funcidx-authority-contract.md
+++ b/plan/issues/1899-reconcile-finalize-funcidx-authority-contract.md
@@ -3,7 +3,7 @@ id: 1899
 title: "finalize funcIdx-authority contract: reconcile↔dead-elim native-string helper sibling-call mismatch (late-shift class recurrence-proofing)"
 status: ready
 updated: 2026-06-12
-sprint: 64
+sprint: 65
 created: 2026-06-05
 priority: medium
 feasibility: hard

--- a/plan/issues/1916-symbolic-function-references-codegen.md
+++ b/plan/issues/1916-symbolic-function-references-codegen.md
@@ -3,7 +3,7 @@ id: 1916
 title: "Symbolic function references in WasmGC codegen — retire the late-import index-shift machinery"
 status: blocked
 blocked_by: [2167]
-sprint: 64
+sprint: 65
 model: fable
 created: 2026-06-10
 updated: 2026-06-12

--- a/plan/issues/1917-single-coercion-engine.md
+++ b/plan/issues/1917-single-coercion-engine.md
@@ -2,7 +2,7 @@
 id: 1917
 title: "One coercion engine — four divergent coercion matrices disagree about lossiness"
 status: in-progress
-sprint: 64
+sprint: 65
 model: opus
 created: 2026-06-10
 updated: 2026-06-17

--- a/plan/issues/1919-transactional-speculative-compile.md
+++ b/plan/issues/1919-transactional-speculative-compile.md
@@ -2,7 +2,7 @@
 id: 1919
 title: "Transactional speculative-compile API — 23 probe/rollback sites leak locals, imports, and types"
 status: ready
-sprint: 64
+sprint: 65
 created: 2026-06-10
 updated: 2026-06-12
 priority: medium

--- a/plan/issues/1926-remove-valtype-typeidx-from-irtype.md
+++ b/plan/issues/1926-remove-valtype-typeidx-from-irtype.md
@@ -2,7 +2,7 @@
 id: 1926
 title: "Remove backend ValType/typeIdx from IrType — unions and boxing must be backend-symbolic"
 status: ready
-sprint: 64
+sprint: 65
 created: 2026-06-10
 updated: 2026-06-12
 priority: medium

--- a/plan/issues/1927-single-pipeline-driver.md
+++ b/plan/issues/1927-single-pipeline-driver.md
@@ -2,7 +2,7 @@
 id: 1927
 title: "One front-end pipeline driver — compileSourceSync/compileMultiSource/compileFilesSource are divergent clones"
 status: ready
-sprint: 64
+sprint: 65
 created: 2026-06-10
 updated: 2026-06-12
 priority: high

--- a/plan/issues/1930-typeoracle-type-query-boundary.md
+++ b/plan/issues/1930-typeoracle-type-query-boundary.md
@@ -3,7 +3,7 @@ id: 1930
 title: "TypeOracle — one type-query boundary between the TS checker and codegen (unblocks TS7, kills suppression heuristics)"
 status: blocked
 blocked_by: [2167]
-sprint: 64
+sprint: 65
 model: fable
 created: 2026-06-10
 updated: 2026-06-12

--- a/plan/issues/1985-stale-proof-index-cells.md
+++ b/plan/issues/1985-stale-proof-index-cells.md
@@ -3,7 +3,7 @@ id: 1985
 title: "stale-proof index cells: shift-walker-updated { idx } handles for captured func indices (#2043 Option 2b, incremental)"
 status: blocked
 blocked_by: [2167]
-sprint: 64
+sprint: 65
 created: 2026-06-10
 updated: 2026-06-12
 priority: medium

--- a/plan/issues/2013-json-parse-reviver-ignored.md
+++ b/plan/issues/2013-json-parse-reviver-ignored.md
@@ -3,7 +3,7 @@ id: 2013
 title: "JSON.parse reviver argument silently ignored (parse arm compiles only arguments[0]; host import drops it)"
 status: blocked
 blocked_on: [23]
-sprint: 64
+sprint: 65
 created: 2026-06-10
 updated: 2026-06-14
 priority: medium

--- a/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
+++ b/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
@@ -2,7 +2,7 @@
 id: 2029
 title: "standalone: `Binary emit error: u32 out of range: -1` on builtin subclassing, disposal protocol, Object.create, Iterator.prototype (497 tests)"
 status: in-progress
-sprint: 64
+sprint: 65
 created: 2026-06-10
 updated: 2026-06-17
 priority: critical

--- a/plan/issues/2044-bigint-i64-brand-valtype-decision.md
+++ b/plan/issues/2044-bigint-i64-brand-valtype-decision.md
@@ -3,7 +3,7 @@ id: 2044
 title: "architect decision: BigInt value representation — i64-bigint-brand ValType vs TS-type-driven boxing (gates #1644 slices, implicated in #2039 i64 ABI bucket)"
 status: blocked
 blocked_by: [2167]
-sprint: 64
+sprint: 65
 created: 2026-06-10
 updated: 2026-06-12
 priority: high

--- a/plan/issues/2045-linear-uint8-soundness-holes.md
+++ b/plan/issues/2045-linear-uint8-soundness-holes.md
@@ -2,7 +2,7 @@
 id: 2045
 title: "linear Uint8Array (WASI): silent-corruption holes — name-keyed buffer registry, no bounds checks — plus escape-analysis demotion gaps (#1886 follow-up)"
 status: in-progress
-sprint: 64
+sprint: 65
 created: 2026-06-10
 updated: 2026-06-17
 priority: critical

--- a/plan/issues/2083-per-module-host-glue-export-suite-size.md
+++ b/plan/issues/2083-per-module-host-glue-export-suite-size.md
@@ -2,7 +2,7 @@
 id: 2083
 title: "per-module exported host-glue suite (__call_fn_*, __sget_*, __vec_*) dominates small-binary size and is unstrippable by wasm-opt"
 status: ready
-sprint: 64
+sprint: 65
 created: 2026-06-11
 updated: 2026-06-12
 priority: medium

--- a/plan/issues/2106-valuerep-p3-undefined-observability.md
+++ b/plan/issues/2106-valuerep-p3-undefined-observability.md
@@ -3,7 +3,7 @@ id: 2106
 title: "value-rep P3: undefined observability — UNDEF_F64 sentinel, union-collapse reversal (flagged), standalone $undefined singleton"
 status: in-progress
 assignee: ttraenkler/sdev7
-sprint: 64
+sprint: 65
 created: 2026-06-11
 updated: 2026-06-18
 priority: high

--- a/plan/issues/2134-ir-effect-model-ordered-emission.md
+++ b/plan/issues/2134-ir-effect-model-ordered-emission.md
@@ -3,7 +3,7 @@ id: 2134
 title: "IR effect model: classify instruction kinds, enforce program-order emission for effectful ops"
 status: blocked
 blocked_by: [2167]
-sprint: 64
+sprint: 65
 created: 2026-06-12
 updated: 2026-06-12
 priority: high

--- a/plan/issues/2135-ir-capability-predicate-single-source.md
+++ b/plan/issues/2135-ir-capability-predicate-single-source.md
@@ -3,7 +3,7 @@ id: 2135
 title: "Single IR capability predicate shared by selector and builder (retire select.ts/from-ast.ts drift)"
 status: blocked
 blocked_by: [2167]
-sprint: 64
+sprint: 65
 created: 2026-06-12
 updated: 2026-06-12
 priority: high

--- a/plan/issues/2138-ir-first-compile-once-inversion.md
+++ b/plan/issues/2138-ir-first-compile-once-inversion.md
@@ -3,7 +3,7 @@ id: 2138
 title: "IR-first compile-once inversion: selector decides before compileDeclarations (flag-gated investigation)"
 status: blocked
 blocked_by: [2167]
-sprint: 64
+sprint: 65
 created: 2026-06-12
 updated: 2026-06-12
 priority: high

--- a/plan/issues/2140-fixbranchtype-coerce-or-throw.md
+++ b/plan/issues/2140-fixbranchtype-coerce-or-throw.md
@@ -3,7 +3,7 @@ id: 2140
 title: "stack-balance fixBranchType: coerce-where-possible, throw on impossible (split of #1858-C1)"
 status: blocked
 blocked_by: [2167]
-sprint: 64
+sprint: 65
 created: 2026-06-12
 updated: 2026-06-12
 priority: critical

--- a/plan/issues/2141-tag5-abi-untangle-honest-boxing.md
+++ b/plan/issues/2141-tag5-abi-untangle-honest-boxing.md
@@ -3,7 +3,7 @@ id: 2141
 title: "Retire the tag-5 box-the-externref ABI: make consumers tag-agnostic, then allow honest generic boxing"
 status: blocked
 blocked_by: [2167]
-sprint: 64
+sprint: 65
 created: 2026-06-12
 updated: 2026-06-12
 priority: high

--- a/plan/issues/2146-retire-shared-ts-registration-indirection.md
+++ b/plan/issues/2146-retire-shared-ts-registration-indirection.md
@@ -2,7 +2,7 @@
 id: 2146
 title: "Retire the registration-indirection layer in codegen/shared.ts"
 status: ready
-sprint: 64
+sprint: 65
 created: 2026-06-12
 updated: 2026-06-12
 priority: medium

--- a/plan/issues/2151-standalone-any-receiver-method-dispatch.md
+++ b/plan/issues/2151-standalone-any-receiver-method-dispatch.md
@@ -2,7 +2,7 @@
 id: 2151
 title: "standalone: any-receiver method dispatch — o.method() on a closed object-literal struct doesn't invoke"
 status: in-progress
-sprint: 64
+sprint: 65
 created: 2026-06-14
 updated: 2026-06-17
 priority: high

--- a/plan/issues/2158-standalone-class-prototype-descriptor-residual.md
+++ b/plan/issues/2158-standalone-class-prototype-descriptor-residual.md
@@ -3,7 +3,7 @@ id: 2158
 title: "Standalone class/prototype/private-name/descriptor conformance residual (~1,388 tests)"
 status: in-progress
 assignee: ttraenkler/cs-2158
-sprint: 64
+sprint: 65
 created: 2026-06-15
 updated: 2026-06-18
 priority: high

--- a/plan/issues/2159-standalone-typedarray-dataview-buffer-residual.md
+++ b/plan/issues/2159-standalone-typedarray-dataview-buffer-residual.md
@@ -2,7 +2,7 @@
 id: 2159
 title: "Standalone TypedArray/DataView/ArrayBuffer conformance residual (~1,308 tests)"
 status: in-progress
-sprint: 64
+sprint: 65
 created: 2026-06-15
 updated: 2026-06-18
 priority: high

--- a/plan/issues/2160-standalone-string-number-coercion-residual.md
+++ b/plan/issues/2160-standalone-string-number-coercion-residual.md
@@ -3,7 +3,7 @@ id: 2160
 title: "Standalone String/Number method & coercion conformance residual (~635 tests)"
 status: ready
 assignee: ttraenkler/cs-2160
-sprint: 64
+sprint: 65
 created: 2026-06-15
 updated: 2026-06-18
 priority: high

--- a/plan/issues/2161-standalone-regexp-engine-residual.md
+++ b/plan/issues/2161-standalone-regexp-engine-residual.md
@@ -3,7 +3,7 @@ id: 2161
 title: "Standalone RegExp engine conformance residual (~579 tests)"
 status: in-progress
 assignee: ttraenkler/sd1
-sprint: 64
+sprint: 65
 created: 2026-06-15
 updated: 2026-06-19
 priority: high

--- a/plan/issues/2162-standalone-map-set-weak-collections-residual.md
+++ b/plan/issues/2162-standalone-map-set-weak-collections-residual.md
@@ -2,7 +2,7 @@
 id: 2162
 title: "Standalone Map/Set/WeakMap/WeakSet conformance residual (~532 tests)"
 status: in-progress
-sprint: 64
+sprint: 65
 created: 2026-06-15
 updated: 2026-06-18
 priority: high

--- a/plan/issues/2167-fable-model-disabled-blocks-frontier-work.md
+++ b/plan/issues/2167-fable-model-disabled-blocks-frontier-work.md
@@ -2,7 +2,7 @@
 id: 2167
 title: "Fable model disabled — frontier-reasoning work blocked"
 status: in-progress
-sprint: 64
+sprint: 65
 created: 2026-06-15
 updated: 2026-06-15
 priority: high

--- a/plan/issues/2173-standalone-generator-general-iterable-yield-star.md
+++ b/plan/issues/2173-standalone-generator-general-iterable-yield-star.md
@@ -3,7 +3,7 @@ id: 2173
 title: "standalone: yield* over a general iterable (array / custom {next()}) in native generators (SF-3 slice-2 of #2157)"
 status: blocked
 blocked_by: [2106]
-sprint: 64
+sprint: 65
 created: 2026-06-16
 updated: 2026-06-16
 priority: medium

--- a/plan/issues/2175-standalone-builtin-prototype-readers.md
+++ b/plan/issues/2175-standalone-builtin-prototype-readers.md
@@ -3,7 +3,7 @@ id: 2175
 title: "architect spec: standalone builtin-prototype object representation + native-method-closure dispatch"
 status: in-progress
 assignee: ttraenkler/se-2175
-sprint: 64
+sprint: 65
 created: 2026-06-16
 updated: 2026-06-17
 priority: high

--- a/plan/issues/2181-define-builtin-representation-scaffold.md
+++ b/plan/issues/2181-define-builtin-representation-scaffold.md
@@ -2,7 +2,7 @@
 id: 2181
 title: "defineBuiltin(name, {elementKinds, lower}) scaffold — unify per-representation element-load/ToString/null handling"
 status: ready
-sprint: 64
+sprint: 65
 created: 2026-06-16
 updated: 2026-06-17
 priority: medium

--- a/plan/issues/2523-enqueue-app-token.md
+++ b/plan/issues/2523-enqueue-app-token.md
@@ -8,7 +8,7 @@ reasoning_effort: medium
 task_type: ci
 area: ci
 goal: dev-velocity
-sprint: 64
+sprint: 65
 related: [2519, 2517]
 ---
 

--- a/plan/issues/2524-process-io-node-io-shim.md
+++ b/plan/issues/2524-process-io-node-io-shim.md
@@ -8,7 +8,7 @@ priority: high
 feasibility: hard
 reasoning_effort: max
 goal: modularization
-sprint: 64
+sprint: 65
 assignee: senior-developer
 ---
 # #2524 -- Phase 1: process IO via linkable `js2wasm:node-io` shim

--- a/plan/issues/2527-core-wasm-linking-host-shims-and-runtime.md
+++ b/plan/issues/2527-core-wasm-linking-host-shims-and-runtime.md
@@ -2,7 +2,7 @@
 id: 2527
 title: "Core-wasm module linking (shared store + canonical rec-group) for host-API shims and the shared runtime — CHOSEN approach"
 status: ready
-sprint: 64
+sprint: 65
 created: 2026-06-20
 updated: 2026-06-20
 priority: medium

--- a/plan/issues/742-extract-and-refactor-compilecallexpression-3.md
+++ b/plan/issues/742-extract-and-refactor-compilecallexpression-3.md
@@ -8,7 +8,7 @@ updated: 2026-06-17
 priority: medium
 feasibility: medium
 goal: maintainability
-sprint: 64
+sprint: 65
 depends_on: [688]
 files:
   src/codegen/expressions.ts:

--- a/plan/issues/promise-async-capability-residual.md
+++ b/plan/issues/promise-async-capability-residual.md
@@ -2,7 +2,7 @@
 id: promise-async-capability-residual
 title: "Promise residual: NewPromiseCapability(C) for custom constructors + resolver-element-function object semantics (~163 fails)"
 status: ready
-sprint: 64
+sprint: 65
 created: 2026-06-17
 updated: 2026-06-18
 priority: medium

--- a/plan/issues/sprints/61.md
+++ b/plan/issues/sprints/61.md
@@ -303,6 +303,7 @@ _Generated from issue files. Update issue `status`, then rerun `node scripts/syn
 | #2131 | JS-host Object.keys/for-in enumeration ignores the integer-keys-ascending-first ordering rule | medium | done |
 | #2132 | method call on a null receiver is an uncatchable wasm trap instead of a catchable TypeError | high | done |
 | #2133 | test262 regression-gate staleness warning reads frozen committed baseline_sha (reports '8h old, commit 3903ea6') | high | done |
+| #2503b | standalone any-vs-typed-string == mis-coerces string operand to NaN (operand-order asymmetry) | high | done |
 | #6407 | Array.prototype.<m>.call(receiver, cb) never reads elements of a compiled $Vec / open-object receiver | high | done |
 
 ### Won't Fix

--- a/plan/issues/sprints/63.md
+++ b/plan/issues/sprints/63.md
@@ -224,6 +224,8 @@ _Generated from issue files. Update issue `status`, then rerun `node scripts/syn
 | #2184 | linear backend: &&/\|\| yield 0/1 constants instead of operand values (needs result-type unification) | medium | done |
 | #2189 | standalone: array .length reads 0 through the externref boundary (latent $Array introspection gap) | high | done |
 | #2190 | standalone: array element indexing (arr as any)[i] returns null/0 through the externref boundary | high | done |
+| #2190a | standalone: homogeneous string sub-array of any[] traps on e[0][0] ($AnyString[]-in-any[] read-back layer) | medium | done |
+| #2190c | standalone: heterogeneous inner tuple of any[] drops off-kind element ([[\"a\",7]] / [[7,\"ab\"]] traps on read-back) | medium | done |
 | #2192 | standalone: caught Error .message/.name read inline (=== literal, .length) returns null/empty; works only via a typed local | high | done |
 
 <!-- GENERATED_ISSUE_TABLES_END -->

--- a/plan/issues/sprints/64.md
+++ b/plan/issues/sprints/64.md
@@ -1,6 +1,14 @@
 ---
 sprint: 64
-status: active
+status: done
+completed: 2026-06-21
+wrap_checklist:
+  results_recorded: true
+  test262_verified: true
+  issues_carried: true
+  worktrees_cleaned: false
+  branches_cleaned: false
+  end_tag_pushed: false
 ---
 
 # Sprint 64 — standalone conformance residuals (autonomous drive)
@@ -67,79 +75,134 @@ Max-effort cores (senior-dev when residual pool thins):
 
 _Generated from issue files. Update issue `status`, then rerun `node scripts/sync-sprint-issue-tables.mjs`._
 
-### Blocked
-
-| Issue | Title | Priority | Status |
-|---|---|---|---|
-| #1916 | Symbolic function references in WasmGC codegen — retire the late-import index-shift machinery | high | blocked |
-| #1930 | TypeOracle — one type-query boundary between the TS checker and codegen (unblocks TS7, kills suppression heuristics) | high | blocked |
-| #1985 | stale-proof index cells: shift-walker-updated { idx } handles for captured func indices (#2043 Option 2b, incremental) | medium | blocked |
-| #2013 | JSON.parse reviver argument silently ignored (parse arm compiles only arguments[0]; host import drops it) | medium | blocked |
-| #2044 | architect decision: BigInt value representation — i64-bigint-brand ValType vs TS-type-driven boxing (gates #1644 slices, implicated in #2039 i64 ABI bucket) | high | blocked |
-| #2134 | IR effect model: classify instruction kinds, enforce program-order emission for effectful ops | high | blocked |
-| #2135 | Single IR capability predicate shared by selector and builder (retire select.ts/from-ast.ts drift) | high | blocked |
-| #2138 | IR-first compile-once inversion: selector decides before compileDeclarations (flag-gated investigation) | high | blocked |
-| #2140 | stack-balance fixBranchType: coerce-where-possible, throw on impossible (split of #1858-C1) | critical | blocked |
-| #2141 | Retire the tag-5 box-the-externref ABI: make consumers tag-agnostic, then allow honest generic boxing | high | blocked |
-| #2173 | standalone: yield* over a general iterable (array / custom {next()}) in native generators (SF-3 slice-2 of #2157) | medium | blocked |
-
 ### Ready
 
 | Issue | Title | Priority | Status |
 |---|---|---|---|
-| #1344 | spec gap: Generator/AsyncIterator prototype receiver TypeErrors + return/throw (52 + 12 test262 fails) | medium | ready |
-| #1373b | IR async Phase C: CPS lowering for await + async-return + async-throw | top | ready |
-| #1899 | finalize funcIdx-authority contract: reconcile↔dead-elim native-string helper sibling-call mismatch (late-shift class recurrence-proofing) | medium | ready |
-| #1919 | Transactional speculative-compile API — 23 probe/rollback sites leak locals, imports, and types | medium | ready |
-| #1926 | Remove backend ValType/typeIdx from IrType — unions and boxing must be backend-symbolic | medium | ready |
-| #1927 | One front-end pipeline driver — compileSourceSync/compileMultiSource/compileFilesSource are divergent clones | high | ready |
+| #820 | Nullish TypeError / null-pointer / illegal-cast umbrella (6,993 FAIL) | critical | ready |
+| #983d | Live-mirror write-back: host mutations to a WasmGC struct's proxy sidecar never reach the struct field (~11 Array.prototype.*.call fails) | medium | ready |
 | #2001 | sparse arrays: holes materialize as element-type defaults and HOFs visit them — [1,,3].forEach runs 3×, b[5]=9 join shows zeros | medium | ready |
-| #2083 | per-module exported host-glue suite (__call_fn_*, __sget_*, __vec_*) dominates small-binary size and is unstrippable by wasm-opt | medium | ready |
-| #2087 | capture-machinery unification: object-literal accessors must use the canonical boxedCaptures ref-cell path | high | ready |
-| #2146 | Retire the registration-indirection layer in codegen/shared.ts | medium | ready |
-| #2160 | Standalone String/Number method & coercion conformance residual (~635 tests) | high | ready |
-| #2181 | defineBuiltin(name, {elementKinds, lower}) scaffold — unify per-representation element-load/ToString/null handling | medium | ready |
-| #2201 | Logical-assignment NamedEvaluation — `x ??=/\|\|=/&&= fn` must set fn.name to \"x\" (~9 test262 fails) | medium | ready |
-| #2202 | arguments.length wrong for trailing-comma + spread call args in generator / class-method bodies (~30 test262 fails) | medium | ready |
-| #2203 | Array destructuring with elisions + defaults binds wrong elements (host) / emits invalid funcidx (standalone) (~54 standalone CE + host fails) | high | ready |
+| #2040 | standalone: generator/destructuring runtime-semantics residual — rest-pattern iterator consumption, lazy defaults, private elements (~1,750 tests) | critical | ready |
+| #2541 | standalone: Object.fromEntries / o.propertyIsEnumerable / Object.is refuse with a dynamic-shape CE | low | ready |
+| #2552 | Annex B B.3.3 Phase 2 rework — TDZ-var outer-binding allocation perturbs hot-path codegen (-1180 test262 regression) | medium | ready |
 
 ### In Progress
 
 | Issue | Title | Priority | Status |
 |---|---|---|---|
-| #742 | Extract and refactor compileCallExpression (3,350 lines) | medium | in-progress |
-| #1042 | async/await state-machine lowering (AwaitExpression is currently a no-op) | high | in-progress |
-| #1355 | spec backlog: Proxy implementation beyond JS-host fallback (235 test262 fails) | top | in-progress |
 | #1712 | acceptance: compiled acorn parses a representative .js with AST structurally equal to node-acorn | high | in-progress |
-| #1917 | One coercion engine — four divergent coercion matrices disagree about lossiness | high | in-progress |
-| #2029 | standalone: `Binary emit error: u32 out of range: -1` on builtin subclassing, disposal protocol, Object.create, Iterator.prototype (497 tests) | critical | in-progress |
-| #2045 | linear Uint8Array (WASI): silent-corruption holes — name-keyed buffer registry, no bounds checks — plus escape-analysis demotion gaps (#1886 follow-up) | critical | in-progress |
-| #2106 | value-rep P3: undefined observability — UNDEF_F64 sentinel, union-collapse reversal (flagged), standalone $undefined singleton | high | in-progress |
-| #2151 | standalone: any-receiver method dispatch — o.method() on a closed object-literal struct doesn't invoke | high | in-progress |
-| #2158 | Standalone class/prototype/private-name/descriptor conformance residual (~1,388 tests) | high | in-progress |
-| #2159 | Standalone TypedArray/DataView/ArrayBuffer conformance residual (~1,308 tests) | high | in-progress |
-| #2161 | Standalone RegExp engine conformance residual (~579 tests) | high | in-progress |
-| #2162 | Standalone Map/Set/WeakMap/WeakSet conformance residual (~532 tests) | high | in-progress |
-| #2167 | Fable model disabled — frontier-reasoning work blocked | high | in-progress |
+| #2036 | standalone: Array.prototype generics over array-like receivers emit invalid Wasm / null-deref / wrong results instead of refusing loud (~500+ tests) | high | in-progress |
+| #2042 | standalone: Object.defineProperty/defineProperties residual — __obj_insert illegal cast + descriptor semantics over $Object (~340 tests) | high | in-progress |
+| #2046 | standalone Reflect: receiver arg silently dropped, deleteProperty ignores freeze/configurable, no ToPropertyKey (#1905 follow-up) | high | in-progress |
 | #2200 | Annex B B.3.3 block-level function declaration hoisting — outer binding created/initialized incorrectly (~186 test262 fails) | high | in-progress |
+| #2515 | host-independence: complete the standalone Wasm-native open-object/property runtime (residual of #1472) | high | in-progress |
+
+### In Review
+
+| Issue | Title | Priority | Status |
+|---|---|---|---|
+| #2553 | variable-spread dynamic-new: new K(...someVar) where the spread source is a runtime array value | medium | in-review |
 
 ### Done
 
 | Issue | Title | Priority | Status |
 |---|---|---|---|
 | #1538 | Wasm-native JSON.parse and JSON.stringify (standalone, no host) | medium | done |
+| #1887 | async-generator yield* emits invalid Wasm (array.set in __closure) — 325 default-lane CE | high | done |
 | #1938 | Linear backend: number[] stores i32 elements ([1.5] → [1]) and element-assignment evaluates RHS twice | high | done |
 | #2009 | structurally identical struct types share field names at the host boundary — Object.assign/spread/JSON.stringify mislabel keys, spread override order broken | high | done |
 | #2162a | Standalone array-spread consumer of a native Set ([...set] / Set.values()/keys()) | medium | done |
 | #2162b | Standalone array-spread of a pair-producing array iterator ([...arr.entries()]) | medium | done |
 | #2169b | Standalone Array.from(<native array iterator>) — __iterator driver struct.new index desync (invalid struct index) | medium | done |
 | #2169c | Standalone host-free Array.from(iterable) — drain via native __iterator instead of __array_from host import | medium | done |
+| #2186 | standalone: post-delete struct read returns stale value — steer delete-touched object literals to $Object | medium | done |
+| #2187 | standalone: string methods on an any-typed local with a native-string ValType take the generic externref path (v.length → 0) | low | done |
 | #2199 | Standalone DataView accessor bounds validation — get/set must throw RangeError, not trap OOB | medium | done |
 | #2199b | Standalone DataView setter operation order — ToNumber(value) before the bounds RangeError | medium | done |
+| #2201 | Logical-assignment NamedEvaluation — `x ??=/\|\|=/&&= fn` must set fn.name to \"x\" (~9 test262 fails) | medium | done |
+| #2202 | arguments.length wrong for trailing-comma + spread call args in generator / class-method bodies (~30 test262 fails) | medium | done |
+| #2203 | Array destructuring with elisions + defaults binds wrong elements (host) / emits invalid funcidx (standalone) (~54 standalone CE + host fails) | high | done |
+| #2358 | Standalone native __to_primitive can't reduce typed (nominal) object structs through the externref boundary | high | done |
 | #2371 | standalone-native single dynamic-descriptor Object.defineProperty (__obj_define_from_desc) | medium | done |
 | #2379 | Uint8ClampedArray methods mis-dispatch to host extern-class imports (invalid Wasm host / Uint8ClampedArray_* leak standalone) | medium | done |
 | #2500 | Wasm-native decodeURI / encodeURI / decodeURIComponent / encodeURIComponent (percent-encoding, ~133 test262) | medium | done |
+| #2501 | Object.prototype.toString [object X] builtin tag — Array/Function/Date missing (host) + standalone CE (~151 test262) | medium | done |
 | #2502 | Array.prototype.sort on an externref-element array emits invalid Wasm (__isort_externref f64.gt on externref) — 28 test262 | medium | done |
+| #2503 | standalone ToPrimitive residual (successor to #1910): 2,835 `Cannot convert object to primitive value` on ==/+/array-literal/destructuring receivers | critical | done |
+| #2517 | reliable queue-unstick trigger — fire on CI/Test262 completion, not just the throttled */15 cron | high | done |
+| #2518 | standalone Array.from(Set) emits invalid Wasm (struct.new arity) — Set struct mis-read as a __vec by structural resolveArrayInfo | medium | done |
+| #2519 | reduce redundant CI workflow runs (debounce idempotent sweeps + heavy test262 merge_group-only) | high | done |
+| #2520 | Ambient global-function host-import warning flood under --target wasi (collapse to a --verbose summary) | medium | done |
+| #2522 | dev branch base: origin/main + merge-before-enqueue, predecessor-stacking for known deps | medium | done |
+| #2526 | Native Messaging example host writes each frame's length prefix and body as SEPARATE fd_writes → streaming receivers misalign (64 MiB test fails where ComponentizeJS works) | high | done |
+| #2531 | Atomic, collision-proof issue-ID allocation + PR-time uniqueness gate | high | done |
+| #2542 | standalone: dynamic property read/write by a runtime string key (o[k]) returns default — needs native key enumeration + dynamic [[Get]]/[[Set]] | high | done |
+| #2543 | CLI run-hint recommends `-W all-proposals=y`, which enables stack-switching and makes wasmtime exit at module load | high | done |
+| #2544 | nested destructuring-param default object emits struct.new one operand short of the field-unified type — invalid Wasm (24 test262) | medium | done |
+| #2545 | nested destructuring-param default: outer-default object fires → inner fields read 0/undefined instead of the default object's values | medium | done |
+| #2547 | Auto-park PRs that fail required CI in the merge_group | high | done |
+| #2549 | Author-trust gate for auto-enqueue: never auto-merge external PRs | high | done |
+| #2550 | Author-trust gate must allow the maintainer's fork — auto-enqueue locked out ALL fork PRs | high | done |
+| #2554 | IR path drops tail calls on top-level recursive functions → deep-recursion stack overflow (regression vs legacy) | high | done |
+| #2560 | Auto-enqueue: append trailing green PRs while a head forms (don't skip the whole sweep) | high | done |
+| #2563 | Private-field/getter brand-check read on a closed-over module global emits invalid wasm (global-index desync) | high | done |
+| #2564 | Private-field nested-class follow-ups: polymorphic method-return blockType (invalid wasm) + read-before-own-slot TypeError gap | medium | done |
+| #2565 | nested destructuring-param default object emits struct.new one operand short of the $shape-bearing type — invalid Wasm (24 test262) | medium | done |
+| #2568 | standalone: nested destructuring-param default OBJECT yields 0 — two-level `{ w: {x,y,z} = {…} } = { w: {…} }` reads sentinels in standalone mode | medium | done |
+| #2572 | standalone: statement-form for-in over a dynamic object leaks env.__for_in_* host imports (no native $ObjVec walk) | high | done |
 | #6408 | standalone object-literal data/method property keys emit `global.get -1` sentinel → binary emit error (~17 tests; subcluster of a 155-test #51-family residual) | high | done |
 
 <!-- GENERATED_ISSUE_TABLES_END -->
+
+## Sprint 64 Results (closed 2026-06-21)
+
+**Theme:** autonomous drive, standalone-conformance residuals first; architecture
+epics deferred (carried to s65).
+
+**Outcome:** ~44/97 issues done at close; **39 open issues carried to s65**
+(architecture epics + substrate-residuals with no in-flight PR). test262
+conformance **72.7% → 73.0%** (~31,467 / 43,135 standard tests) over the sprint.
+
+### Keystone landings (value-rep substrate)
+- **#2187 / #2576** — any-receiver native-string dispatch gate: `.length` /
+  string-methods on `any`-typed locals with a native-string ValType now route to
+  the native fast-path (was → `__extern_get` → 0 standalone). Architect-spec'd
+  (#2187), layered on top of the narrow sd-3 fix. The keystone value-rep unblock.
+- **#2579** — `__any_strict_eq` / `__any_eq` tag-5 string arm → `__str_equals`
+  (was `i32.const 0` standalone). Lands `.call`-form array-like string search.
+- **#2042 S4** — `ValidateAndApplyPropertyDescriptor` (§10.1.6.3): runtime-helper
+  preflight (#1854) + call-site real-`TypeError`-instance throw (#1858).
+- **#2046** Reflect.getOwnPropertyDescriptor native; **#2036** native-string array
+  search by content (`__str_equals`, not `ref.eq`); **#2541** propertyIsEnumerable
+  native; **#2203** capturing-generator funcidx desync; **#2202** spread
+  `arguments`; **#2554** IR tail-call regression; **#2552** Annex B Phase-2
+  (closes #2200); **#1633** Array.of standalone; **#2160** toLocaleString /
+  String.raw standalone; **#2515** Object.create descriptors; and more via the
+  parallel workforce.
+
+### Carried to s65 (architecture epics + substrate, need architect specs)
+async #1042/#1373b · Proxy #1355 · IR-first refactors #1916/#1926/#1927/#1930/
+#2134/#2135/#2138 · funcidx #1899/#1985 · self-host #1712-family · single
+coercion engine #1917 · #2167 · and standalone substrate residuals #2029/#2045/
+#2106/#2151/#2158/#2159/#2160/#2161/#2162/#2175 (value-rep / construct / proto).
+
+### New s65 substrate findings (from completion triage)
+- **#1888 Slice 4** — `__extern_method_call` missing `$Vec`/string/Map/Set brand
+  arm → plain `(a:any).indexOf(x)` returns 0 (the bigger any-typed array-dispatch
+  unblock; sdev-strdispatch has context).
+- **dot-vs-bracket dual-storage** — `o.a=7` on empty `any` → `o['a']`=0 (write
+  slot bracket-read can't see).
+- **proto identity** — `getPrototypeOf(Object.create(p)) === p` → false standalone.
+- **`Object.prototype.toLocaleString`** — needs per-type dispatch (§20.1.3.5),
+  not a blind toString alias.
+
+### Process notes
+- Fork `ttraenkler/js2` main ran far behind upstream `loopdive/js2` (1185+
+  commits) — caused stale-base DIRTY PRs, id-allocator collisions, and
+  "already-done-upstream" mis-dispatch. Fork fast-forwarded to upstream twice;
+  durable fix (recurring sync / branch-from-upstream) is open for s65.
+
+### Wrap-up remaining
+- [ ] Clean merged worktrees · [ ] prune merged branches · [ ] push `sprint/64`
+  tag once the queue fully drains and the merged-PR poller reconciles final
+  statuses.

--- a/plan/issues/sprints/65.md
+++ b/plan/issues/sprints/65.md
@@ -1,0 +1,95 @@
+---
+sprint: 65
+status: active
+---
+
+# Sprint 65 — architecture epics + value-rep substrate (architect-led)
+
+> Carried from s64 (closed 2026-06-21). The standalone-conformance quick-win pool
+> drained in s64; s65 pivots to the **architect-led** substrate and epic work.
+
+## Carried from s64 (39 issues)
+
+**Value-rep / object-model substrate (highest leverage — unblocks clusters):**
+- #1888 Slice 4 — `$Vec`/string/Map/Set brand arm in `__extern_method_call`
+  (plain `(a:any).indexOf` etc.)
+- dot-vs-bracket dual-storage; proto-identity through `Object.create`;
+  `Object.prototype.toLocaleString` per-type dispatch (new s64 findings — need issues)
+- #2029 #2045 #2106 #2151 #2158 #2159 #2160 #2161 #2162 #2175 (standalone residual tails)
+
+**Architecture epics (need architect `## Implementation Plan` first):**
+- Async: #1042 (state machine) · #1373b (IR CPS)
+- Proxy: #1355 (pure-Wasm traps)
+- IR-first refactors: #1916 #1926 #1927 #1930 #2134 #2135 #2138
+- Funcidx/pipeline: #1899 #1985
+- Self-host: #1712-family · single coercion engine #1917 · #2167
+
+**Other carried:** #1344 #1528 #1919 #2013 #2044 #2083 #2140 #2141 #2146 #2167
+#2173 #2181 #2523 #2524 #2527 #742
+
+## Notes
+- Spec-first: route every epic + hard substrate issue through an architect spec
+  before dev dispatch.
+- Durable fork-sync (recurring origin→upstream FF, or branch-from-upstream) to
+  stop the staleness that bit s64.
+
+<!-- GENERATED_ISSUE_TABLES_START -->
+## Issue Tables
+
+_Generated from issue files. Update issue `status`, then rerun `node scripts/sync-sprint-issue-tables.mjs`._
+
+### Blocked
+
+| Issue | Title | Priority | Status |
+|---|---|---|---|
+| #1916 | Symbolic function references in WasmGC codegen — retire the late-import index-shift machinery | high | blocked |
+| #1930 | TypeOracle — one type-query boundary between the TS checker and codegen (unblocks TS7, kills suppression heuristics) | high | blocked |
+| #1985 | stale-proof index cells: shift-walker-updated { idx } handles for captured func indices (#2043 Option 2b, incremental) | medium | blocked |
+| #2013 | JSON.parse reviver argument silently ignored (parse arm compiles only arguments[0]; host import drops it) | medium | blocked |
+| #2044 | architect decision: BigInt value representation — i64-bigint-brand ValType vs TS-type-driven boxing (gates #1644 slices, implicated in #2039 i64 ABI bucket) | high | blocked |
+| #2134 | IR effect model: classify instruction kinds, enforce program-order emission for effectful ops | high | blocked |
+| #2135 | Single IR capability predicate shared by selector and builder (retire select.ts/from-ast.ts drift) | high | blocked |
+| #2138 | IR-first compile-once inversion: selector decides before compileDeclarations (flag-gated investigation) | high | blocked |
+| #2140 | stack-balance fixBranchType: coerce-where-possible, throw on impossible (split of #1858-C1) | critical | blocked |
+| #2141 | Retire the tag-5 box-the-externref ABI: make consumers tag-agnostic, then allow honest generic boxing | high | blocked |
+| #2173 | standalone: yield* over a general iterable (array / custom {next()}) in native generators (SF-3 slice-2 of #2157) | medium | blocked |
+
+### Ready
+
+| Issue | Title | Priority | Status |
+|---|---|---|---|
+| #1344 | spec gap: Generator/AsyncIterator prototype receiver TypeErrors + return/throw (52 + 12 test262 fails) | medium | ready |
+| #1373b | IR async Phase C: CPS lowering for await + async-return + async-throw | top | ready |
+| #1528 | spec gap: non-constructor TypeError — Promise.all / allSettled species and executor paths | medium | ready |
+| #1899 | finalize funcIdx-authority contract: reconcile↔dead-elim native-string helper sibling-call mismatch (late-shift class recurrence-proofing) | medium | ready |
+| #1919 | Transactional speculative-compile API — 23 probe/rollback sites leak locals, imports, and types | medium | ready |
+| #1926 | Remove backend ValType/typeIdx from IrType — unions and boxing must be backend-symbolic | medium | ready |
+| #1927 | One front-end pipeline driver — compileSourceSync/compileMultiSource/compileFilesSource are divergent clones | high | ready |
+| #2083 | per-module exported host-glue suite (__call_fn_*, __sget_*, __vec_*) dominates small-binary size and is unstrippable by wasm-opt | medium | ready |
+| #2146 | Retire the registration-indirection layer in codegen/shared.ts | medium | ready |
+| #2160 | Standalone String/Number method & coercion conformance residual (~635 tests) | high | ready |
+| #2181 | defineBuiltin(name, {elementKinds, lower}) scaffold — unify per-representation element-load/ToString/null handling | medium | ready |
+| #2527 | Core-wasm module linking (shared store + canonical rec-group) for host-API shims and the shared runtime — CHOSEN approach | medium | ready |
+
+### In Progress
+
+| Issue | Title | Priority | Status |
+|---|---|---|---|
+| #742 | Extract and refactor compileCallExpression (3,350 lines) | medium | in-progress |
+| #1042 | async/await state-machine lowering (AwaitExpression is currently a no-op) | high | in-progress |
+| #1355 | spec backlog: Proxy implementation beyond JS-host fallback (235 test262 fails) | top | in-progress |
+| #1917 | One coercion engine — four divergent coercion matrices disagree about lossiness | high | in-progress |
+| #2029 | standalone: `Binary emit error: u32 out of range: -1` on builtin subclassing, disposal protocol, Object.create, Iterator.prototype (497 tests) | critical | in-progress |
+| #2045 | linear Uint8Array (WASI): silent-corruption holes — name-keyed buffer registry, no bounds checks — plus escape-analysis demotion gaps (#1886 follow-up) | critical | in-progress |
+| #2106 | value-rep P3: undefined observability — UNDEF_F64 sentinel, union-collapse reversal (flagged), standalone $undefined singleton | high | in-progress |
+| #2151 | standalone: any-receiver method dispatch — o.method() on a closed object-literal struct doesn't invoke | high | in-progress |
+| #2158 | Standalone class/prototype/private-name/descriptor conformance residual (~1,388 tests) | high | in-progress |
+| #2159 | Standalone TypedArray/DataView/ArrayBuffer conformance residual (~1,308 tests) | high | in-progress |
+| #2161 | Standalone RegExp engine conformance residual (~579 tests) | high | in-progress |
+| #2162 | Standalone Map/Set/WeakMap/WeakSet conformance residual (~532 tests) | high | in-progress |
+| #2167 | Fable model disabled — frontier-reasoning work blocked | high | in-progress |
+| #2175 | architect spec: standalone builtin-prototype object representation + native-method-closure dispatch | high | in-progress |
+| #2523 | enqueue/unstick must use a GitHub App token, not GITHUB_TOKEN (merge-queue wedge fix) | high | in-progress |
+| #2524 | Phase 1: process IO via linkable js2wasm:node-io shim (--node-io-shim) | high | in-progress |
+
+<!-- GENERATED_ISSUE_TABLES_END -->


### PR DESCRIPTION
Closes sprint 64 (standalone-conformance autonomous drive). Outcome ~44/97 done; test262 72.7% → 73.0%. Keystone value-rep substrate landed (#2187/#2576, #2579, #2042 S4, #2046, #2036, #2541, #2203, #2202, #2554, #2552→#2200, #1633, #2160, #2515). This PR (planning only, no src): carries the 39 genuinely-open issues (epics + substrate-residuals with no in-flight PR) sprint:64→65; scaffolds sprints/65.md; records results + wrap_checklist in sprints/64.md (status: done); files 4 new s65 substrate findings (#1888 Slice 4 $Vec dispatch, dot-vs-bracket dual-storage, Object.create proto-identity, toLocaleString per-type dispatch). Issues with merged/open/queued PRs were excluded so they reconcile to done naturally. sprint/64 tag + cleanup deferred until the queue drains. 🤖 Generated with [Claude Code](https://claude.com/claude-code)