### PR TITLE
fix(#2573): plain-object .length is undefined (fail-safe static gate)

### DIFF
--- a/plan/issues/2573-missing-property-read-returns-null-not-undefined-plain-object.md
+++ b/plan/issues/2573-missing-property-read-returns-null-not-undefined-plain-object.md
@@ -1,7 +1,9 @@
 ---
 id: 2573
 title: "Reading a missing property on a plain `{}` object returns null, not undefined"
-status: ready
+status: done
+completed: 2026-06-21
+assignee: ttraenkler/sd-6
 created: 2026-06-21
 priority: medium
 feasibility: medium
@@ -41,17 +43,70 @@ Probe (`var obj={}; var b=obj.length; ... b===null, typeof==="object"`) confirms
 the read is `null`, independent of any method call — it is a **property-read**
 bug, not a method-dispatch or write-back bug.
 
-## Root cause (to confirm)
+## Root cause (CONFIRMED — sd-6, 2026-06-21)
 
-`obj.length` on a `{}` struct lowers to a `struct.get` against a struct shape
-that has no `length` field (or reads field 0 of the wrong shape), and the
-missing-field path coerces to `ref.null.extern` (→ JS `null`) instead of the
-host `undefined`. The fix is to make the missing-own-property read on a
-plain-object struct yield `undefined` (e.g. `__get_undefined` / the
-externref-undefined representation), not a null externref. Audit the
-property-access codegen for plain-object structs (`src/codegen/property-access.ts`
-/ the member-read path in `expressions`) and the `__sget_`/`__extern_get`
-missing-field return.
+It is **`length`-specific**, not a generic missing-property bug. A plain missing
+key (`obj.missing`) already correctly returns `undefined` (routed through the
+generic any-typed `__extern_get` reroute). `obj.length` is the exception:
+
+- `property-access.ts` (~L1967) explicitly **EXCLUDES `length`** (alongside
+  `constructor`/`__proto__`/`prototype`/`name`) from the any-typed
+  `__extern_get` reroute — *"Reserved accessors have dedicated lowerings (array
+  length…) — never reroute them."*
+- So `.length` is handed to the dedicated array-length lowering, which returns a
+  **numeric** ValType (`i32`/`f64`). For a real array/string/arguments that's
+  correct (vec struct field 0). For a **plain `{}` object** it returns the
+  **number `0`** (standalone: a static `f64/i32 0`, no import; gc: still numeric)
+  — so `obj.length === undefined` is *always false* (it's the number 0, not the
+  externref `undefined`). (Measured: `typeof obj.length === "number"`, value 0 —
+  NOT `null` as the original triage guessed.)
+
+**Fix direction:** route `.length` to the normal property read (`__extern_get` →
+`undefined`-if-absent, externref result) ONLY when the receiver statically
+resolves to a **plain object** (`any`/object-literal with NO `length` member, NO
+array/string/function/arguments/typedarray signature). Real array-likes keep the
+vec-field-0 lowering untouched. The gate must be NARROW — `.length` is read on
+arrays/strings/arguments/typedarrays/bound-fns everywhere, so a too-broad gate
+regresses `array.length`. Validate via the full gate (merge_group / local-ci)
+before enqueue — this is a shared-path, broad-reach change.
+
+## Implementation attempt + SUBSTRATE verdict (sd-6, 2026-06-21)
+
+Implemented the narrow STATIC gate (`isPlainObjectWithoutLength` in
+`property-access.ts`, a `.length` arm before the Function/vec arms):
+`.length` → `undefined` (via `emitUndefined`) when `objType` is a CONCRETE
+Object type (NOT `any`/`unknown`) with no own/inherited `length` member, no
+numeric index signature, no call/construct signature.
+
+- **Correct + regression-free for STATICALLY-TYPED plain objects:**
+  `const obj = {}; obj.length === undefined` ✓ (gc + standalone);
+  `array`/`string`/`function`/`any[]` `.length` arithmetic all unchanged
+  (`a.length*2===6`, `"abc".length===3`, `f.length===2`); `issue-2187` (9/9) +
+  `issue-2576` (12/12) `.length` suites pass.
+
+- **BUT moves 0 test262 rows** — the real `S15.4.4.*_A2` cluster stays 0/12. The
+  tests are `var obj = {}` with dynamic `obj.join = Array.prototype.join;
+  obj.length` → the receiver is **`any` / dynamically-mutated**, not a
+  statically-typed plain object. The classifier deliberately EXCLUDES `any`
+  (can't tell plain-object from array there; arrays dominate — excluding `any` is
+  exactly what keeps `any[].length` arithmetic safe), so it structurally cannot
+  catch the real cluster.
+
+**SUBSTRATE conclusion.** The real cluster needs `any`/dynamic-receiver `.length`
+to do a **runtime property-presence** check (`ref.test $Object` →
+`__extern_get("length")` returning undefined-if-absent; else the numeric length),
+which forces `.length` on `any` receivers to return a **uniform externref** (the
+numeric array length boxed too). That is a return-type change on the hot
+`any[].length` path (used in `for (;i<a.length;)` loops + arithmetic everywhere)
+— a value-rep / representation decision, NOT a quick point-fix. The real tests
+additionally route through the generic-array-method-on-plain-object machinery
+(#983d reverted territory) and a standalone ToPrimitive throw, so a correct
+`.length` alone would not flip them.
+
+**Status: substrate-blocked** for the test262 cluster. The narrow static fix is
+correct user-code-level value but banks 0 conformance; whether to land it
+standalone is a tech-lead call (held, not pushed). Re-route the dynamic-receiver
+`.length` substrate to the value-rep / senior-dev lane (coordinate #983d retry).
 
 ## Acceptance
 
@@ -64,3 +119,12 @@ missing-field return.
 Carved from #983d by sd-4 on 2026-06-21. Orthogonal to the dual-path dispatch
 fix that #983d delivered (the method now runs correctly; this is the missing
 sibling property read returning the wrong nullish value).
+
+**DONE (narrow static slice).** The fail-safe static gate
+(`isPlainObjectWithoutLength`) lands the statically-typed plain-object case
+(`const obj = {}; obj.length === undefined`), with the hot `any[].length`
+arithmetic path untouched. The remaining `any`/dynamically-mutated-receiver
+case (the test262 `S15.4.4.*_A2` cluster — `var obj = {}; obj.length`) needs a
+runtime property-presence check + a uniform-externref `.length` representation,
+which is substrate — split out as **#2580** (coordinate the value-rep lane +
+#983d retry, task #20).

--- a/plan/issues/2580-dynamic-receiver-length-undefined-substrate.md
+++ b/plan/issues/2580-dynamic-receiver-length-undefined-substrate.md
@@ -1,0 +1,82 @@
+---
+id: 2580
+title: "`.length` on an any/dynamically-mutated receiver returns numeric 0, not undefined (runtime property-presence)"
+status: ready
+sprint: Backlog
+created: 2026-06-21
+priority: medium
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: codegen, runtime, value-rep
+language_feature: property access, length, dynamic objects
+goal: test262-conformance
+related: [2573, 983d]
+---
+
+# #2580 — `.length` on an `any`/dynamic receiver → runtime property-presence (substrate)
+
+## Problem
+
+`.length` on an **`any`-typed / dynamically-mutated** receiver returns numeric
+`0` where the value is actually a plain object whose `length` is an absent
+property (→ `undefined`, §10.1.8 OrdinaryGet). #2573 fixed the
+**statically-typed** plain-object case with a fail-safe static gate
+(`isPlainObjectWithoutLength` in `property-access.ts`), but that gate
+deliberately EXCLUDES `any`/`unknown` — at that static type a plain object and an
+array are indistinguishable, and arrays dominate, so the numeric vec-field-0 /
+`__extern_length` lowering is kept (excluding `any` is exactly what keeps
+`any[].length` arithmetic safe).
+
+The test262 `built-ins/Array/prototype/S15.4.4.*_A2_T*` cluster (the #983d
+generic-Array-method-on-plain-object residual, 8 fails) is precisely the excluded
+case:
+
+```js
+var obj = {};
+obj.join = Array.prototype.join;
+if (obj.length !== undefined) throw ...;   // obj is `any`; obj.length === 0, fails
+```
+
+## Why this is substrate, not a point-fix
+
+Making `any`/dynamic-receiver `.length` correct requires a **runtime**
+property-presence check at the read site: `ref.test $Object` → if it's a plain
+`$Object`, `__extern_get(obj, "length")` (returns `undefined` when absent);
+else (array / $ObjVec / string) read the numeric length. To express *both*
+outcomes from one expression, `.length` on an `any` receiver must return a
+**uniform externref** (the numeric array length **boxed** too). That is a
+return-type change on the hot `any[].length` path — `for (;i<a.length;)` loops
+and `a.length`-arithmetic are everywhere — so it carries broad regression risk
+and is a value-representation decision (coordinate
+[[project_standalone_any_string_value_read_substrate]] / the value-rep lane).
+
+It also interacts with the #983d generic-array-method-on-plain-object machinery
+(task #20, reverted as net-negative) and a standalone ToPrimitive throw, so a
+correct `.length` alone would not flip the whole cluster.
+
+## Fix direction (substrate)
+
+- Decide the representation: either (a) `.length` on `any` returns a uniform
+  boxed externref (numeric arrays boxed; plain objects `__extern_get`-undefined),
+  validated against `any[].length` arithmetic across the full gate; OR (b)
+  represent `var obj = {}` (dynamically mutated) as a dynamic `$Object` so the
+  existing `$Object`-aware `.length` path applies.
+- Validate via the FULL gate (merge_group / local-ci) — broad-reach, not a
+  scoped sweep (the `.length` path is read everywhere).
+- Coordinate with #983d retry (task #20) for the generic-method cluster.
+
+## Acceptance
+
+- `var obj = {}; obj.length === undefined` (the `any`-receiver case) — typeof
+  `"undefined"`.
+- `S15.4.4.*_A2_T*` length-assertions flip to pass (with the #983d method-dispatch
+  piece).
+- ZERO regression in `any[].length` / array / string / arguments / typedarray /
+  bound-fn `.length` arithmetic across the full gate.
+
+## Cross-links
+
+- #2573 (the statically-typed plain-object slice — landed the fail-safe static gate)
+- #983d (generic Array method on plain object — task #20, reverted; the cluster needs both)
+- value-rep / `project_standalone_any_string_value_read_substrate`

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -1937,6 +1937,35 @@ function emitGuardedNativeStringLength(
 }
 
 /**
+ * (#2573) Is `tsType` a genuine PLAIN object whose `.length` is an absent
+ * property (→ `undefined` per §10.1.8 OrdinaryGet), as opposed to an array /
+ * string / arguments / function / typed-array whose `.length` is a real numeric
+ * member?
+ *
+ * Deliberately CONSERVATIVE so it never reclassifies an array-like (whose
+ * `.length` must stay the numeric vec-field-0 / `__extern_length` lowering):
+ *   - `any` / `unknown` are EXCLUDED — at that static type we cannot tell a
+ *     plain object from an array, and arrays dominate; keep the numeric path.
+ *   - must be an Object type (TypeFlags.Object) — primitives/unions/`any` out.
+ *   - must have NO own/inherited `length` member (a real Array/String/arguments
+ *     /TypedArray/bound-fn type declares one),
+ *   - NO numeric index signature (array-likes / tuples carry one),
+ *   - NO call or construct signature (a function's `.length` is its arity).
+ *
+ * `var obj = {}` widens to an object-literal type (symbol `__object`) that
+ * satisfies all four → its `.length` is `undefined`.
+ */
+function isPlainObjectWithoutLength(ctx: CodegenContext, tsType: ts.Type): boolean {
+  if ((tsType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0) return false;
+  if ((tsType.flags & ts.TypeFlags.Object) === 0) return false;
+  if (tsType.getProperty?.("length") !== undefined) return false;
+  if (ctx.checker.getIndexInfoOfType?.(tsType, ts.IndexKind.Number) !== undefined) return false;
+  if ((tsType.getCallSignatures?.().length ?? 0) > 0) return false;
+  if ((tsType.getConstructSignatures?.().length ?? 0) > 0) return false;
+  return true;
+}
+
+/**
  * (#2179) When the module uses `delete <member>` (JS-host mode only), route an
  * `any`/`unknown`-typed property READ through the tombstone-aware `__extern_get`
  * host helper instead of the inline `ref.test`+`struct.get` fast-path. Returns
@@ -3253,6 +3282,32 @@ export function compilePropertyAccess(
     }
     fctx.body.push({ op: "struct.get", typeIdx: ctx.anyStrTypeIdx, fieldIdx: 0 });
     return { kind: "i32" };
+  }
+
+  // (#2573) `.length` on a PLAIN object → `undefined`, not numeric 0.
+  // §10.1.8 OrdinaryGet: a missing own property reads `undefined`. `length` is
+  // a "reserved accessor" handed to the array-length lowering below, which
+  // returns numeric 0 (vec field 0 / `__extern_length`) — correct for a real
+  // array/string/arguments, but WRONG for a plain `{}` object where `length` is
+  // just an absent property (`({}).length === undefined`). This broke the
+  // generic-Array-method-on-plain-object cluster (test262 S15.4.4.* —
+  // `var obj = {}; obj.length === undefined`), the #983d residual.
+  //
+  // NARROW, static gate so the common (and arithmetic-sensitive) array path is
+  // untouched: only fires when the receiver's TS type is a concrete OBJECT type
+  // (NOT `any`/`unknown` — those keep the runtime `__extern_length` path, where
+  // arrays dominate) that has NO own/inherited `length` member, NO numeric index
+  // signature, and NO call/construct signature — i.e. a genuine plain object
+  // (`var obj = {}` widens to symbol `__object`). A real array/string/function
+  // type carries a `length` member (or a call sig) and is excluded.
+  if (propName === "length" && isPlainObjectWithoutLength(ctx, objType)) {
+    // Evaluate the receiver for its side effects, drop it, push `undefined`.
+    const recv = compileExpression(ctx, fctx, expr.expression);
+    if (recv !== null && recv !== undefined) {
+      fctx.body.push({ op: "drop" } as Instr);
+    }
+    emitUndefined(ctx, fctx);
+    return { kind: "externref" };
   }
 
   // Handle Function.length — return the number of formal parameters

--- a/tests/issue-2573.test.ts
+++ b/tests/issue-2573.test.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2573 — `.length` on a PLAIN object is an absent property → `undefined`
+ * (§10.1.8 OrdinaryGet), not numeric 0.
+ *
+ * `length` is a "reserved accessor" handed to the array-length lowering, which
+ * returns numeric 0 (vec field 0 / `__extern_length`) — correct for a real
+ * array / string / arguments / function, but WRONG for a plain `{}` where
+ * `length` is just a missing property (`({}).length === undefined`).
+ *
+ * The fix is a FAIL-SAFE static gate (`isPlainObjectWithoutLength`): it diverts
+ * `.length` to `undefined` ONLY when the receiver's TS type is a concrete object
+ * type (NOT `any`/`unknown`) with no own/inherited `length` member, no numeric
+ * index signature, and no call/construct signature. An ambiguous `any` receiver
+ * KEEPS the existing numeric vec-field-0 lowering (arrays dominate there), so
+ * `array.length` arithmetic is never touched. The dynamic-`any`-receiver cluster
+ * (`var obj = {}` mutated at runtime) is a separate substrate follow-up — this
+ * fix is the safe, narrow user-code-level correctness slice.
+ */
+
+async function run(src: string, target: "gc" | "standalone"): Promise<number | undefined> {
+  const r = await compile(src, { fileName: "test.ts", target });
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject ?? {});
+  return (instance.exports as { test?: () => number }).test?.();
+}
+
+const targets: Array<"gc" | "standalone"> = ["gc", "standalone"];
+
+describe("#2573 — .length on a plain object is undefined", () => {
+  for (const target of targets) {
+    describe(`target: ${target}`, () => {
+      it("`const obj = {}; obj.length` is undefined", async () => {
+        expect(
+          await run(
+            `export function test(): number { const obj = {}; const L: any = obj.length; return L === undefined ? 1 : 2; }`,
+            target,
+          ),
+        ).toBe(1);
+      });
+
+      it("a plain object with other props still has undefined .length", async () => {
+        expect(
+          await run(
+            `export function test(): number { const o = { x: 5, y: 6 }; const L: any = o.length; return L === undefined ? 1 : 2; }`,
+            target,
+          ),
+        ).toBe(1);
+      });
+
+      it("typeof plain-object .length is 'undefined'", async () => {
+        // Compare via === undefined (typeof over the native-string boundary is a
+        // separate path); the point is the value is the undefined externref.
+        expect(
+          await run(`export function test(): number { const o = {}; return o.length === undefined ? 1 : 2; }`, target),
+        ).toBe(1);
+      });
+    });
+  }
+});
+
+describe("#2573 — array-like .length stays numeric (fail-safe gate, no regression)", () => {
+  for (const target of targets) {
+    describe(`target: ${target}`, () => {
+      const arrayLike: Array<[string, string, number]> = [
+        ["array literal", `const a = [1,2,3]; return a.length;`, 3],
+        ["array arithmetic", `const a = [1,2,3,4]; return a.length * 10;`, 40],
+        ["array as loop bound", `const a = [1,2,3,4,5]; let s=0; for (let i=0;i<a.length;i++) s++; return s;`, 5],
+        ["any-typed array", `const a: any = [1,2]; return a.length;`, 2],
+        ["string", `const s = "hello"; return s.length;`, 5],
+        ["string arithmetic", `const s = "abcd"; return s.length + 1;`, 5],
+        ["function arity", `return fn3.length;`, 3],
+        ["typed array", `const a = new Uint8Array(4); return a.length;`, 4],
+        ["empty array", `const a: number[] = []; return a.length;`, 0],
+        ["array after push", `const a = [1,2]; a.push(3); return a.length;`, 3],
+      ];
+      for (const [name, body, want] of arrayLike) {
+        it(name, async () => {
+          const prelude = body.includes("fn3")
+            ? `function fn3(a: number, b: number, c: number): number { return a; }\n`
+            : "";
+          expect(await run(`${prelude}export function test(): number { ${body} }`, target)).toBe(want);
+        });
+      }
+    });
+  }
+});


### PR DESCRIPTION
## #2573 — `.length` on a plain object is `undefined`, not numeric 0

`.length` is a "reserved accessor" handed to the array-length lowering, which
returns numeric **0** (vec field 0 / `__extern_length`). Correct for a real
array / string / arguments / function, but WRONG for a plain `{}` object where
`length` is an absent property — `({}).length === undefined` (§10.1.8
OrdinaryGet). The #983d generic-Array-method-on-plain-object residual.

### Fail-safe static gate
New `isPlainObjectWithoutLength` (`property-access.ts`), a `.length` arm before
the Function/vec arms: divert `.length` → `undefined` **only on POSITIVE
certainty** that the receiver's TS type is a concrete object type (**NOT**
`any`/`unknown`) with no own/inherited `length` member, no numeric index
signature, and no call/construct signature. An ambiguous `any` receiver **keeps**
the existing numeric vec-field-0 lowering (arrays dominate there) — divert on
certainty, never on "not provably array", so **`any[].length` arithmetic is never
touched**. Safe-partial ≫ regress `array.length` (lead-directed).

### Validation (exhaustive array-like pre-check, box-free, both gc + standalone)
array literal / arithmetic / loop-bound, `any[]`, string, string-arith, function
arity, typed array, empty array, post-push — **all unchanged**. Plain-object
cases (`const obj = {}; obj.length === undefined`) now correct in gc + standalone.
- `tests/issue-2573.test.ts` — 26 cases green.
- `tsc` + `prettier` + `#2108 coercion-drift` + `hard-error` gates all clean locally.

### Scope note — substrate split to #2580
The `any`/dynamically-mutated-receiver case (the test262 `S15.4.4.*_A2` cluster —
`var obj = {}; obj.length`) needs a **runtime** property-presence check + a
uniform-externref `.length` representation = substrate (a return-type change on
the hot `any[].length` path). Split out as **#2580** (value-rep lane + #983d
retry, task #20). So this PR banks the **user-code plain-object correctness with
zero array regression**; the test262 cluster is the #2580 follow-up. (Filed via
`--allocate`, not hand-picked.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)