### PR TITLE
fix(#2569): evaluate computed key in destructuring pattern (side effect + throw)

### DIFF
--- a/plan/issues/2569-computed-key-dstr-pattern-not-evaluated.md
+++ b/plan/issues/2569-computed-key-dstr-pattern-not-evaluated.md
@@ -1,7 +1,9 @@
 ---
 id: 2569
 title: "Computed property key in a destructuring pattern is not evaluated (no side effect / throw)"
-status: ready
+status: done
+completed: 2026-06-21
+assignee: ttraenkler/sd-6
 created: 2026-06-21
 priority: medium
 feasibility: medium

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -62,6 +62,28 @@ import {
  * the zero-initialized local (the original bug: a `ComputedPropertyName` has
  * no `.text`, so `fields.findIndex` returned -1 and the binding was skipped).
  */
+/**
+ * (#2569) Evaluate a destructuring ComputedPropertyName expression for its SIDE
+ * EFFECT (and throw propagation), discarding the resulting key. §13.15.5.3
+ * BindingInitialization / 13.2.5.5 → "Evaluation of ComputedPropertyName" runs
+ * the expression as part of destructuring, so `{ [thrower()]: x }` must run
+ * `thrower()` (and propagate its throw) even when the static fast-path can't map
+ * the runtime key to a struct field. Compiles the key expression and drops
+ * whatever it leaves on the stack (the value type is irrelevant — we only need
+ * the effect); a `null`/`VOID_RESULT` producer leaves nothing to drop.
+ */
+function emitComputedKeyForEffect(ctx: CodegenContext, fctx: FunctionContext, keyExpr: ts.Expression): void {
+  const t = compileExpression(ctx, fctx, keyExpr);
+  // Drop only when the expression left a concrete value on the stack. A `null`
+  // result (no value) or a `VOID_RESULT` sentinel (a void-typed expression, e.g.
+  // a call to a `void` function) pushes nothing droppable — `t` is then not a
+  // `{ kind }`-bearing ValType, so this guard skips the drop and avoids a stack
+  // underflow.
+  if (t !== null && t !== undefined && typeof t === "object" && "kind" in t) {
+    fctx.body.push({ op: "drop" } as Instr);
+  }
+}
+
 function resolveStaticPropKey(ctx: CodegenContext, element: ts.BindingElement): string | undefined {
   const pn = element.propertyName ?? element.name;
   if (ts.isIdentifier(pn)) return pn.text;
@@ -423,6 +445,16 @@ export function destructureParamObjectExternref(
       propNameText = propNameNode.text;
     } else if (ts.isNumericLiteral(propNameNode)) {
       propNameText = propNameNode.text;
+    } else if (ts.isComputedPropertyName(propNameNode)) {
+      // (#2569) A non-constant computed key (`{ [thrower()]: x }`) has no static
+      // text to map to a property read, but §13.15.5.3 requires the key
+      // expression to be EVALUATED during destructuring (side effect + throw
+      // propagation). Run it for its effect and drop the result before skipping
+      // the field bind. A constant computed key would have folded above (via
+      // resolveStaticPropKey upstream); this externref path only sees the
+      // unresolved runtime case.
+      emitComputedKeyForEffect(ctx, fctx, propNameNode.expression);
+      continue;
     }
     if (!propNameText) continue;
 
@@ -894,16 +926,18 @@ export function destructureParamObject(
     // zero-initialized local. Unresolvable computed keys fail loudly below.
     const propKey = resolveStaticPropKey(ctx, element);
     if (propKey === undefined && element.propertyName && ts.isComputedPropertyName(element.propertyName)) {
-      // #2032 + #2031-revival regression fix: a computed key that does NOT fold
-      // to a compile-time constant (e.g. `{ [thrower()]: x }`, where the key is
-      // a runtime call) must NOT hard-error — that regressed 7 test262 cases
-      // (for/for-await-of `obj-ptrn-prop-eval-err`) which compiled+ran on main.
-      // Fall back to the pre-#2032 behaviour: skip this binding element (the
-      // local was pre-allocated by `ensureBindingLocals`). The static
-      // fast-path simply can't map a runtime key to a struct field index; the
-      // generic/runtime destructuring path handles the key-evaluation order
-      // (and its abrupt completion) as before. Only the constant-computed-key
-      // improvement from #2032 stays active above.
+      // #2569 — a computed key that does NOT fold to a compile-time constant
+      // (e.g. `{ [thrower()]: x }`, a runtime call) cannot be mapped to a struct
+      // field index on this static fast path, so the binding is skipped (the
+      // local was pre-allocated by `ensureBindingLocals`). BUT §13.15.5.3
+      // requires the ComputedPropertyName expression to be EVALUATED as part of
+      // the destructuring — for its side effect and, critically, so a throwing
+      // key propagates (`assert.throws(... { [thrower()]: x } ...)`). The
+      // pre-#2032 `continue` dropped the key expression entirely, so the poison
+      // never fired and the side effect never ran. Compile the key expression
+      // for its effect (ToPropertyKey ordering is observable via the throw), then
+      // drop its value, before skipping the field bind.
+      emitComputedKeyForEffect(ctx, fctx, element.propertyName.expression);
       continue;
     }
     if (!ts.isIdentifier(element.name)) {

--- a/tests/issue-2569.test.ts
+++ b/tests/issue-2569.test.ts
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2569 — a computed property key in a destructuring pattern (`{ [expr()]: x }`)
+ * must EVALUATE `expr()` as part of the destructuring (ES2024 §13.15.5.3 →
+ * Evaluation of ComputedPropertyName), exactly once, in source order. If
+ * `expr()` throws, the destructuring throws.
+ *
+ * The static fast-path resolves each property by its constant name and, for a
+ * non-foldable runtime computed key, skipped the binding element WITHOUT
+ * compiling the key expression — so the side effect never ran and a throwing
+ * key never propagated (the 4 `…-dflt-obj-ptrn-prop-eval-err` async-gen fails).
+ * The fix compiles the key expression for its effect (and drops the value)
+ * before skipping the field bind, in both the typed-struct and externref
+ * (`destructureParamObject` / `destructureParamObjectExternref`) paths.
+ */
+
+async function run(src: string, target: "gc" | "standalone"): Promise<number | undefined> {
+  const r = await compile(src, { fileName: "test.ts", target });
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject ?? {});
+  return (instance.exports as { test?: () => number }).test?.();
+}
+
+const targets: Array<"gc" | "standalone"> = ["gc", "standalone"];
+
+describe("#2569 — computed key in a destructuring pattern is evaluated", () => {
+  for (const target of targets) {
+    describe(`target: ${target}`, () => {
+      it("runs the computed-key side effect (any/externref receiver)", async () => {
+        expect(
+          await run(
+            `let ran = 0;
+             function k(): string { ran++; return "x"; }
+             export function test(): number {
+               const obj: any = { x: 5 };
+               const { [k()]: v } = obj;
+               return ran;
+             }`,
+            target,
+          ),
+        ).toBe(1);
+      });
+
+      it("runs the computed-key side effect (typed-struct receiver)", async () => {
+        expect(
+          await run(
+            `let ran = 0;
+             function k(): string { ran++; return "x"; }
+             export function test(): number {
+               const obj = { x: 5, y: 6 };
+               const { [k()]: v } = obj;
+               return ran;
+             }`,
+            target,
+          ),
+        ).toBe(1);
+      });
+
+      it("runs the computed-key side effect exactly once", async () => {
+        expect(
+          await run(
+            `let n = 0;
+             function k(): string { n++; return "a"; }
+             export function test(): number {
+               const obj: any = { a: 1 };
+               const { [k()]: v } = obj;
+               return n;
+             }`,
+            target,
+          ),
+        ).toBe(1);
+      });
+
+      it("propagates a throwing computed key", async () => {
+        expect(
+          await run(
+            `function thrower(): string { throw new Error("boom"); }
+             export function test(): number {
+               const obj: any = {};
+               try {
+                 const { [thrower()]: v } = obj;
+                 return 0;
+               } catch (e) {
+                 return 1;
+               }
+             }`,
+            target,
+          ),
+        ).toBe(1);
+      });
+
+      it("still binds the field for a constant computed key", async () => {
+        // A foldable computed key (`["x"]`) keeps the existing static fast-path:
+        // both the side-effect evaluation AND the field bind must work.
+        expect(
+          await run(
+            `export function test(): number {
+               const obj = { x: 7, y: 9 };
+               const { ["x"]: v } = obj;
+               return v;
+             }`,
+            target,
+          ),
+        ).toBe(7);
+      });
+    });
+  }
+});


### PR DESCRIPTION
## #2569 — computed key in a destructuring pattern must be evaluated

A computed property key in a destructuring pattern (`{ [expr()]: x }`) must
**evaluate `expr()`** as part of the destructuring (ES2024 §13.15.5.3 →
Evaluation of ComputedPropertyName), exactly once in source order; if `expr()`
throws, the destructuring throws.

The static fast-path (`destructuring-params.ts`) resolves each property by its
constant name; for a **non-foldable runtime computed key** (e.g. `[thrower()]`)
it skipped the binding element **without compiling the key expression** — so the
side effect never ran and a throwing key never propagated.

```js
function thrower() { throw new Test262Error(); }
class C { async *method({ [thrower()]: x } = {}) {} }
assert.throws(Test262Error, () => C.prototype.method());  // saw NO throw
```

### Fix
Compile the computed-key expression **for its effect** (and drop the value)
before skipping the field bind, in **both** the typed-struct
(`destructureParamObject`) and externref (`destructureParamObjectExternref`)
paths. New `emitComputedKeyForEffect` helper drops only when the expression left
a concrete value (a `null`/`VOID_RESULT` producer leaves nothing). Constant
computed keys keep the existing static fast-path (field bind preserved).

### Validation
- Moves the test262 `…-dflt-obj-ptrn-prop-eval-err` cluster **20/20** (the 4
  issue-cited async-gen cases + 16 siblings sharing the gap).
- `tests/issue-2569.test.ts` — 10 cases (side-effect runs once / throws
  propagate / typed-struct + externref / constant-key still binds), green in
  gc + standalone.
- `tsc` + `prettier` + `#2108 coercion-drift` + `hard-error` gates all clean.
- `issue-2545` / `2568` / `2169` + class/fn-param dstr suites pass (32/32, no
  regression). The 6 `helpers.js` test failures pre-exist on `main` (missing
  `tests/helpers.js` infra file, unrelated).

Distinct lane (destructuring-eval-ordering) — no collision with the
object-property / value-rep substrate. #2574 (sd-3) merged, so no live conflict
on `destructuring-params.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)