### PR TITLE
fix(#2001 S2): sparse-array HOF visit-skip on the dense vec

### DIFF
--- a/plan/issues/2001-sparse-holes-materialize-defaults.md
+++ b/plan/issues/2001-sparse-holes-materialize-defaults.md
@@ -308,6 +308,45 @@ destructuring / all HOFs / at / pop / slice, typed no-regression + deterministic
 bytes). Gates green: tsc, prettier, biome lint, `check-test262-hard-errors` (0,
 no growth), `check:ir-fallbacks` (no increase).
 
+### S2 landed (2026-06-21, sd-1838)
+
+**Done.** HOF visit-SKIP semantics on the dense WasmGC vec, the headline fix
+(`*-ary-forEach-15.4.4.18-2-9` family + the `does-not-visit-deleted/absent`
+suite). Two reusable gate helpers in `src/codegen/array-holes.ts`:
+
+- `holeSkipGate(ctx, data, i, arrTy, work, onHole?)` — wraps a branch-free
+  per-iteration `work` in `if ($Hole) onHole else work`; used by
+  `forEach`/`filter`/`map`. For `map`, `onHole` writes `$Hole` into the result
+  slot (and the result vec is forced to externref-element so it can hold the
+  sentinel) → a source hole yields a **result hole** (`[1,,3].map(x=>x*10)` →
+  `"10,,30"`).
+- `holeContinueGate(ctx, data, i, arrTy, onHole?, reverse?)` — for loop bodies
+  whose `work` contains its OWN `br` into the loop/block (`some`/`every`
+  early-exit `br 2`, `indexOf`/`lastIndexOf` match-break, `reduce`/`reduceRight`
+  fold). Emits the hole test at the SAME control depth and, on a hole, does
+  `i±1; br 1` (continue) directly — so the present-index work that follows is
+  UNGUARDED and its branch depths are unchanged (avoids the depth-off-by-one
+  hazard of nesting the work in an extra `if`). `reverse` flips `i++`→`i--` for
+  reduceRight / lastIndexOf.
+
+Per-method: `forEach`/`some`/`every` skip (callback not called, scan continues);
+`map` skips + result-hole; `filter` omits; `indexOf`/`lastIndexOf` skip (a hole
+never matches — supersedes S1's hole→undefined read-map for these two);
+`reduce`/`reduceRight` skip the fold AND seek the first/last **present** element
+for the no-initial-value seed (empty/all-holes ⇒ TypeError). `includes` is
+UNCHANGED (uses Get → `[,].includes(undefined) === true`, keeps S1's read-map),
+and `find`/`findIndex`/`findLast`/`findLastIndex` are UNCHANGED (Get semantics —
+they VISIT a hole observing `undefined`, not HasProperty-skip). All gated on
+`ctx.usesArrayHoles && elemType.kind === "externref"` → typed `number[]`
+(f64/i32) kernels are byte-identical (no `ref.test`).
+
+Tests: `tests/issue-2001-s2-hof-skip.test.ts` (21 cases — forEach/map/filter
+visit-skip, some/every skip-not-undefined, indexOf/lastIndexOf skip vs
+includes/find Get, reduce/reduceRight skip+seed-seek+empty-throw, typed
+no-regression + deterministic bytes + standalone). The S1 read-boundary HOF
+assertions in `issue-2001-s1-hole-literal.test.ts` were updated from S1's interim
+"visit-as-undefined" to S2's spec-correct visit-skip.
+
 #### S2 — HOF visit-skip on the dense vec (forEach/map/filter/some/every/reduce/indexOf). **[depends on S1]**
 
 The headline fix. The `$Object`-backed array-like path already has the

--- a/src/codegen/array-holes.ts
+++ b/src/codegen/array-holes.ts
@@ -117,9 +117,17 @@ export function ensureHoleType(ctx: CodegenContext): number {
  * Stack: `[] → [externref]`.
  */
 export function emitHoleSentinel(ctx: CodegenContext, fctx: FunctionContext): void {
+  for (const instr of holeSentinelInstrs(ctx)) fctx.body.push(instr);
+}
+
+/**
+ * Detached-`Instr[]` form of {@link emitHoleSentinel} — pushes the `$Hole`
+ * sentinel as an `externref` for splicing into a loop body (e.g. the `map`
+ * result-hole write in S2). Stack: `[] → [externref]`.
+ */
+export function holeSentinelInstrs(ctx: CodegenContext): Instr[] {
   const globalIdx = ensureHoleType(ctx);
-  fctx.body.push({ op: "global.get", index: globalIdx } as Instr);
-  fctx.body.push({ op: "extern.convert_any" } as Instr);
+  return [{ op: "global.get", index: globalIdx } as Instr, { op: "extern.convert_any" } as Instr];
 }
 
 /**
@@ -187,4 +195,108 @@ export function holeTestInstrs(ctx: CodegenContext): Instr[] {
   ensureHoleType(ctx);
   const holeTypeIdx = ctx.holeTypeIdx;
   return [{ op: "any.convert_extern" } as Instr, { op: "ref.test", typeIdx: holeTypeIdx } as Instr];
+}
+
+/**
+ * (#2001 S2) HOF visit-SKIP gate. Wraps a per-iteration `work` instruction list
+ * so it runs ONLY when the element at `data[i]` is NOT the `$Hole` sentinel; a
+ * hole index runs `onHole` instead (default: nothing). This is the §23.1.3.*
+ * "HasProperty(O, ‹k›) is false ⇒ skip" semantics that the S1 read-mapping
+ * (which only made a *visited* hole read as `undefined`) could not provide.
+ *
+ * Emits, given the loop's `data` array local + index local `i`:
+ *   data[i]; ref.test (ref $Hole)
+ *   if (i32)            ;; element IS a hole
+ *     then: onHole      ;; skipped — callback NOT called (forEach/map/etc.)
+ *     else: work        ;; present — the normal per-iteration body
+ *
+ * The caller still appends its `loopIncrement` AFTER this gate (unconditional),
+ * so a skipped hole falls through to `i++`/`br 0` and the scan continues
+ * (`some`/`find` keep scanning; `indexOf` never matches a hole; `every` does not
+ * falsify). For `map`, `onHole` writes `$Hole` into the result slot so the
+ * result preserves the hole at the same index.
+ *
+ * Gating is the CALLER's responsibility: only call this when
+ * `ctx.usesArrayHoles && elemType.kind === "externref"`. Typed (f64/i32/…) vecs
+ * never reach here, so their loop bodies are byte-identical (no `ref.test`).
+ * `getOp` is the loop's element read op (`array.get` for externref).
+ */
+export function holeSkipGate(
+  ctx: CodegenContext,
+  dataLocal: number,
+  idxLocal: number,
+  arrTypeIdx: number,
+  work: Instr[],
+  onHole: Instr[] = [],
+): Instr[] {
+  ensureHoleType(ctx);
+  const typeIdx = ctx.holeTypeIdx;
+  return [
+    { op: "local.get", index: dataLocal } as Instr,
+    { op: "local.get", index: idxLocal } as Instr,
+    { op: "array.get", typeIdx: arrTypeIdx } as Instr,
+    { op: "any.convert_extern" } as Instr,
+    { op: "ref.test", typeIdx } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: onHole,
+      else: work,
+    } as Instr,
+  ];
+}
+
+/**
+ * (#2001 S2) "Skip-and-continue" hole gate — the variant for loop bodies whose
+ * `work` contains its OWN branches into the loop/block (`some`/`every` early-exit
+ * `br depth: 2`, `indexOf` break, etc.). Wrapping such work inside the
+ * `holeSkipGate` `if`/`else` would nest it one control-frame deeper and silently
+ * off-by-one every `br` depth inside it (the §array-methods.ts depth hazard).
+ *
+ * Instead, this emits — at the SAME control depth as the rest of the loop body —
+ * a hole test that, on a hole, runs `onHole` then `i++; br 0` (continue the loop)
+ * directly, so the caller's `work` follows UNGUARDED at its original depth:
+ *
+ *   data[i]; ref.test (ref $Hole)
+ *   if (hole) { onHole; i++; br 0 }   ;; continue — skip the rest of this iter
+ *   …work… (runs only for a present index; its own `br`s keep their depths)
+ *
+ * The caller emits this as the FIRST thing after `loopExitCheck` and still
+ * appends its normal `loopIncrement` at the end (reached only by present
+ * indices). `idxLocal`/`dataLocal`/`arrTypeIdx` identify the slot; `onHole` is
+ * spliced before the continue (e.g. nothing for some/every/indexOf).
+ */
+export function holeContinueGate(
+  ctx: CodegenContext,
+  dataLocal: number,
+  idxLocal: number,
+  arrTypeIdx: number,
+  onHole: Instr[] = [],
+  reverse = false,
+): Instr[] {
+  ensureHoleType(ctx);
+  const typeIdx = ctx.holeTypeIdx;
+  return [
+    { op: "local.get", index: dataLocal } as Instr,
+    { op: "local.get", index: idxLocal } as Instr,
+    { op: "array.get", typeIdx: arrTypeIdx } as Instr,
+    { op: "any.convert_extern" } as Instr,
+    { op: "ref.test", typeIdx } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        ...onHole,
+        // step the index (i++ forward, i-- for a reverse loop like reduceRight /
+        // lastIndexOf), then continue. We are inside the gate's own `if`
+        // (depth 0), so the enclosing `loop` is at depth 1 — `br 1` re-enters the
+        // loop, skipping the present-index work that follows the gate.
+        { op: "local.get", index: idxLocal } as Instr,
+        { op: "i32.const", value: 1 } as Instr,
+        { op: reverse ? "i32.sub" : "i32.add" } as Instr,
+        { op: "local.set", index: idxLocal } as Instr,
+        { op: "br", depth: 1 } as Instr,
+      ],
+    } as Instr,
+  ];
 }

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -11,7 +11,14 @@ import { isBooleanType, isStringType } from "../checker/type-mapper.js";
 import type { Instr, ValType } from "../ir/types.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal, allocTempLocal, getLocalType } from "./context/locals.js";
-import { emitHoleToUndefined, holeTestInstrs, holeToUndefinedInstrs } from "./array-holes.js"; // (#2001 S1)
+import {
+  emitHoleToUndefined,
+  holeContinueGate,
+  holeSentinelInstrs,
+  holeSkipGate,
+  holeTestInstrs,
+  holeToUndefinedInstrs,
+} from "./array-holes.js"; // (#2001 S1/S2)
 import type { ClosureInfo, CodegenContext, FunctionContext } from "./context/types.js";
 import { addArrayIteratorImports, addStringImports, addUnionImports, resolveWasmType } from "./index.js";
 import { addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "./registry/imports.js";
@@ -3861,17 +3868,13 @@ function compileArrayIndexOf(
   }
   fctx.body.push({ op: "local.set", index: resTmp });
 
-  // (#2001 S1) An `any[]` hole reads `$Hole`; map it to `undefined` before the
-  // strict-eq so `indexOf(undefined)` matches the hole index (an absent index
-  // reads as undefined via Get). Pre-ensure `__get_undefined` while we own
-  // `fctx.body` so the detached `holeToUndefinedInstrs` flush can't shift the
-  // already-captured `__host_eq` funcIdx.
-  let holeMap: Instr[] = [];
-  if (ctx.usesArrayHoles && elemType.kind === "externref") {
-    ensureGetUndefined(ctx);
-    flushLateImportShifts(ctx, fctx);
-    holeMap = holeToUndefinedInstrs(ctx, fctx);
-  }
+  // (#2001 S2) indexOf SKIPS holes — a hole is never a match (§23.1.3.14 uses
+  // HasProperty, not Get, so `[,].indexOf(undefined) === -1`, UNLIKE `includes`
+  // which uses Get). This supersedes S1's hole→undefined read-map for indexOf
+  // (which wrongly made `indexOf(undefined)` match a hole). Skip via the
+  // continue-gate so the present-index strict-eq + match-break depths are intact.
+  const iofSkip =
+    ctx.usesArrayHoles && elemType.kind === "externref" ? holeContinueGate(ctx, dataTmp, iTmp, arrTypeIdx) : [];
 
   const loopBody: Instr[] = [
     { op: "local.get", index: iTmp },
@@ -3879,10 +3882,11 @@ function compileArrayIndexOf(
     { op: "i32.ge_s" },
     { op: "br_if", depth: 1 },
 
+    ...iofSkip,
+
     { op: "local.get", index: dataTmp },
     { op: "local.get", index: iTmp },
     { op: getOp, typeIdx: arrTypeIdx } as Instr,
-    ...holeMap,
     { op: "local.get", index: valTmp },
     ...eqInstrs,
     {
@@ -6329,9 +6333,10 @@ function compileArrayFilter(
     "truthy",
   );
 
-  const loopBody: Instr[] = [
-    ...loopExitCheck(loop),
-
+  // (#2001 S2) filter does NOT call the callback for a hole, and a hole
+  // contributes nothing to the result (§23.1.3.7). Wrap the elem-read + call +
+  // append work so a hole skips straight to the increment (no `onHole`).
+  const fltWork: Instr[] = [
     // elem = data[i]
     { op: "local.get", index: loop.dataTmp } as Instr,
     { op: "local.get", index: loop.iTmp } as Instr,
@@ -6355,9 +6360,13 @@ function compileArrayFilter(
         { op: "local.set", index: resLen } as Instr,
       ],
     } as Instr,
-
-    ...loopIncrement(loop),
   ];
+  const fltGated =
+    ctx.usesArrayHoles && elemType.kind === "externref"
+      ? holeSkipGate(ctx, loop.dataTmp, loop.iTmp, arrTypeIdx, fltWork)
+      : fltWork;
+
+  const loopBody: Instr[] = [...loopExitCheck(loop), ...fltGated, ...loopIncrement(loop)];
 
   emitArrayLoop(fctx, loopBody);
 
@@ -6415,6 +6424,21 @@ function compileArrayMap(
     mapVecTypeIdx = getOrRegisterVecType(ctx, mapResultElemType.kind, mapResultElemType);
   }
 
+  // (#2001 S2) map preserves a source hole as a RESULT hole at the same index
+  // (§23.1.3.18 step 6.c skips the callback when HasProperty is false, leaving
+  // the result index absent). To store `$Hole` at the skipped index the RESULT
+  // vec must be externref-element. When the source is a hole-bearing `any[]`
+  // (externref) and the callback would otherwise map to a typed numeric result,
+  // force the result element to externref so the hole is representable (the
+  // present-index callback results box via the coercion below). Hole-free or
+  // typed sources are unaffected — result type stays as inferred.
+  const mapSkipHoles = ctx.usesArrayHoles && elemType.kind === "externref";
+  if (mapSkipHoles && mapResultElemType.kind !== "externref") {
+    mapResultElemType = { kind: "externref" };
+    mapArrTypeIdx = getOrRegisterArrayType(ctx, "externref", mapResultElemType);
+    mapVecTypeIdx = getOrRegisterVecType(ctx, "externref", mapResultElemType);
+  }
+
   const loop = setupArrayLoop(ctx, fctx, propAccess, vecTypeIdx, arrTypeIdx, elemType, "map");
 
   const resData = allocLocal(fctx, `__arr_map_rd_${fctx.locals.length}`, { kind: "ref_null", typeIdx: mapArrTypeIdx });
@@ -6450,17 +6474,27 @@ function compileArrayMap(
     ];
   }
 
-  const loopBody: Instr[] = [
-    ...loopExitCheck(loop),
-
+  const mapWork: Instr[] = [
     // resData[i] = cb(data[i])
     { op: "local.get", index: resData } as Instr,
     { op: "local.get", index: loop.iTmp } as Instr,
     ...callInstrs,
     { op: "array.set", typeIdx: mapArrTypeIdx } as Instr,
-
-    ...loopIncrement(loop),
   ];
+  // (#2001 S2) For a hole index, do NOT call the callback; write `$Hole` into the
+  // result slot so the result preserves the hole (result vec was forced to
+  // externref above, so it can hold the sentinel).
+  const mapOnHole: Instr[] = mapSkipHoles
+    ? [
+        { op: "local.get", index: resData } as Instr,
+        { op: "local.get", index: loop.iTmp } as Instr,
+        ...holeSentinelInstrs(ctx),
+        { op: "array.set", typeIdx: mapArrTypeIdx } as Instr,
+      ]
+    : [];
+  const mapGated = mapSkipHoles ? holeSkipGate(ctx, loop.dataTmp, loop.iTmp, arrTypeIdx, mapWork, mapOnHole) : mapWork;
+
+  const loopBody: Instr[] = [...loopExitCheck(loop), ...mapGated, ...loopIncrement(loop)];
 
   emitArrayLoop(fctx, loopBody);
 
@@ -6528,14 +6562,66 @@ function compileArrayReduce(
 
   const loop = setupArrayLoop(ctx, fctx, propAccess, vecTypeIdx, arrTypeIdx, elemType, "red");
   const accTmp = allocLocal(fctx, `__arr_red_acc_${fctx.locals.length}`, accType);
+  // (#2001 S2) reduce skips holes for BOTH the no-initial seed seek and the fold
+  // (§23.1.3.21 — uses HasProperty). Gate on externref element.
+  const redSkipHoles = ctx.usesArrayHoles && elemType.kind === "externref";
+  const redGetOp = elemType.kind === "i8" ? "array.get_u" : elemType.kind === "i16" ? "array.get_s" : "array.get";
 
   // Compile initial value or use arr[0] as default
   if (callExpr.arguments.length >= 2) {
     compileExpression(ctx, fctx, callExpr.arguments[1]!, accType);
     fctx.body.push({ op: "local.set", index: accTmp });
     // i already = 0 from setupArrayLoop
+  } else if (redSkipHoles) {
+    // (#2001 S2) No initial value on a hole-bearing `any[]`: the seed is the
+    // FIRST PRESENT element (per spec the initial-accumulator seek advances past
+    // absent indices), and the fold starts at the index AFTER it. Empty OR
+    // all-holes ⇒ TypeError "Reduce of empty array with no initial value".
+    // Forward-scan: while (i < len && data[i] is $Hole) i++; if (i>=len) throw;
+    // acc = data[i]; i++.
+    fctx.body.push({
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            // if (i >= len) break → all holes / empty
+            { op: "local.get", index: loop.iTmp } as Instr,
+            { op: "local.get", index: loop.lenTmp } as Instr,
+            { op: "i32.ge_s" } as Instr,
+            { op: "br_if", depth: 1 } as Instr,
+            // if (data[i] is NOT a hole) break → found the seed
+            ...holeContinueGate(ctx, loop.dataTmp, loop.iTmp, arrTypeIdx),
+            // present element at i: break out of the seek loop
+            { op: "br", depth: 1 } as Instr,
+          ],
+        } as Instr,
+      ],
+    } as Instr);
+    // if (i >= len) throw — empty or all-holes
+    fctx.body.push({ op: "local.get", index: loop.iTmp });
+    fctx.body.push({ op: "local.get", index: loop.lenTmp });
+    fctx.body.push({ op: "i32.ge_s" });
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "empty" },
+      then: throwStringInstrs(ctx, "TypeError: Reduce of empty array with no initial value"),
+    } as Instr);
+    // acc = data[i]  (i points at the first present element)
+    fctx.body.push({ op: "local.get", index: loop.dataTmp });
+    fctx.body.push({ op: "local.get", index: loop.iTmp });
+    fctx.body.push({ op: redGetOp, typeIdx: arrTypeIdx });
+    coercionInstrs(ctx, elemType, accType, fctx).forEach((i) => fctx.body.push(i));
+    fctx.body.push({ op: "local.set", index: accTmp });
+    // i = i + 1  (fold starts after the seed)
+    fctx.body.push({ op: "local.get", index: loop.iTmp });
+    fctx.body.push({ op: "i32.const", value: 1 });
+    fctx.body.push({ op: "i32.add" });
+    fctx.body.push({ op: "local.set", index: loop.iTmp });
   } else {
-    // No initial value: throw TypeError on empty array, else acc = data[0], start from i = 1
+    // No initial value (no holes): throw TypeError on empty array, else acc = data[0], start from i = 1
     fctx.body.push({ op: "local.get", index: loop.lenTmp });
     fctx.body.push({ op: "i32.eqz" });
     fctx.body.push({
@@ -6545,13 +6631,7 @@ function compileArrayReduce(
     } as Instr);
     fctx.body.push({ op: "local.get", index: loop.dataTmp });
     fctx.body.push({ op: "i32.const", value: 0 });
-    fctx.body.push({
-      op: elemType.kind === "i8" ? "array.get_u" : elemType.kind === "i16" ? "array.get_s" : "array.get",
-      typeIdx: arrTypeIdx,
-    });
-    // (#2001 S1) If data[0] is a `$Hole` (the no-initial-value seed), map it to
-    // `undefined` before it becomes the accumulator.
-    if (ctx.usesArrayHoles && elemType.kind === "externref") emitHoleToUndefined(ctx, fctx);
+    fctx.body.push({ op: redGetOp, typeIdx: arrTypeIdx });
     // Coerce the seed element to the accumulator type (e.g. element externref
     // string → accumulator externref, or i32 element → f64 accumulator).
     coercionInstrs(ctx, elemType, accType, fctx).forEach((i) => fctx.body.push(i));
@@ -6577,8 +6657,9 @@ function compileArrayReduce(
             { op: "local.get", index: loop.dataTmp } as Instr,
             { op: "local.get", index: loop.iTmp } as Instr,
             { op: loop.getOp, typeIdx: arrTypeIdx } as Instr,
-            // (#2001 S1) A `$Hole` element reaches the reducer as `undefined`.
-            ...(ctx.usesArrayHoles && elemType.kind === "externref" ? holeToUndefinedInstrs(ctx, fctx) : []),
+            // (#2001 S2) The element at this index is guaranteed present — the
+            // fold loop's continue-gate already skipped any hole index — so the
+            // reducer never receives a hole (no S1 hole→undefined map needed here).
             ...elemCoerce,
           ]
         : []),
@@ -6631,7 +6712,10 @@ function compileArrayReduce(
     ];
   }
 
-  const loopBody: Instr[] = [...loopExitCheck(loop), ...callInstrs, ...loopIncrement(loop)];
+  // (#2001 S2) Skip hole indices in the fold (the reducer is never invoked for an
+  // absent index). Continue-gate keeps the present-index `callInstrs` at depth 0.
+  const redFoldSkip = redSkipHoles ? holeContinueGate(ctx, loop.dataTmp, loop.iTmp, arrTypeIdx) : [];
+  const loopBody: Instr[] = [...loopExitCheck(loop), ...redFoldSkip, ...callInstrs, ...loopIncrement(loop)];
 
   emitArrayLoop(fctx, loopBody);
 
@@ -6683,6 +6767,8 @@ function compileArrayReduceRight(
 
   const getOp = elemType.kind === "i8" ? "array.get_u" : elemType.kind === "i16" ? "array.get_s" : "array.get";
   const accTmp = allocLocal(fctx, `__arr_rr_acc_${fctx.locals.length}`, accType);
+  // (#2001 S2) reduceRight skips holes (HasProperty) for the seed-seek and fold.
+  const rrSkipHoles = ctx.usesArrayHoles && elemType.kind === "externref";
 
   // Compile initial value or use arr[length-1] as default
   if (callExpr.arguments.length >= 2) {
@@ -6693,8 +6779,57 @@ function compileArrayReduceRight(
     fctx.body.push({ op: "i32.const", value: 1 });
     fctx.body.push({ op: "i32.sub" });
     fctx.body.push({ op: "local.set", index: iTmp });
+  } else if (rrSkipHoles) {
+    // (#2001 S2) No initial value on a hole-bearing `any[]`: the seed is the LAST
+    // PRESENT element (the reduceRight initial-accumulator seek walks DOWN past
+    // absent indices), fold starts at the index below it. Empty / all-holes ⇒
+    // TypeError. Backward-scan from length-1: while (i>=0 && data[i] is hole) i--;
+    // if (i<0) throw; acc = data[i]; i--.
+    fctx.body.push({ op: "local.get", index: lenTmp });
+    fctx.body.push({ op: "i32.const", value: 1 });
+    fctx.body.push({ op: "i32.sub" });
+    fctx.body.push({ op: "local.set", index: iTmp });
+    fctx.body.push({
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            // if (i < 0) break → empty / all holes
+            { op: "local.get", index: iTmp } as Instr,
+            { op: "i32.const", value: 0 } as Instr,
+            { op: "i32.lt_s" } as Instr,
+            { op: "br_if", depth: 1 } as Instr,
+            // if (data[i] is a hole) i--; continue; else break (found seed)
+            ...holeContinueGate(ctx, dataTmp, iTmp, arrTypeIdx, [], /*reverse*/ true),
+            { op: "br", depth: 1 } as Instr,
+          ],
+        } as Instr,
+      ],
+    } as Instr);
+    // if (i < 0) throw
+    fctx.body.push({ op: "local.get", index: iTmp });
+    fctx.body.push({ op: "i32.const", value: 0 });
+    fctx.body.push({ op: "i32.lt_s" });
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "empty" },
+      then: throwStringInstrs(ctx, "TypeError: Reduce of empty array with no initial value"),
+    } as Instr);
+    // acc = data[i]; i--
+    fctx.body.push({ op: "local.get", index: dataTmp });
+    fctx.body.push({ op: "local.get", index: iTmp });
+    fctx.body.push({ op: getOp, typeIdx: arrTypeIdx });
+    coercionInstrs(ctx, elemType, accType, fctx).forEach((i) => fctx.body.push(i));
+    fctx.body.push({ op: "local.set", index: accTmp });
+    fctx.body.push({ op: "local.get", index: iTmp });
+    fctx.body.push({ op: "i32.const", value: 1 });
+    fctx.body.push({ op: "i32.sub" });
+    fctx.body.push({ op: "local.set", index: iTmp });
   } else {
-    // No initial value: throw TypeError on empty array, else acc = data[length-1], start from length - 2
+    // No initial value (no holes): throw TypeError on empty array, else acc = data[length-1], start from length - 2
     fctx.body.push({ op: "local.get", index: lenTmp });
     fctx.body.push({ op: "i32.eqz" });
     fctx.body.push({
@@ -6707,8 +6842,6 @@ function compileArrayReduceRight(
     fctx.body.push({ op: "i32.const", value: 1 });
     fctx.body.push({ op: "i32.sub" });
     fctx.body.push({ op: getOp, typeIdx: arrTypeIdx });
-    // (#2001 S1) data[length-1] seed may be a `$Hole` → bind `undefined`.
-    if (ctx.usesArrayHoles && elemType.kind === "externref") emitHoleToUndefined(ctx, fctx);
     // Coerce the seed element to the accumulator type (e.g. element externref
     // string → accumulator externref, or i32 element → f64 accumulator).
     coercionInstrs(ctx, elemType, accType, fctx).forEach((i) => fctx.body.push(i));
@@ -6751,8 +6884,8 @@ function compileArrayReduceRight(
             { op: "local.get", index: dataTmp } as Instr,
             { op: "local.get", index: iTmp } as Instr,
             { op: getOp, typeIdx: arrTypeIdx } as Instr,
-            // (#2001 S1) A `$Hole` element reaches the reducer as `undefined`.
-            ...(ctx.usesArrayHoles && elemType.kind === "externref" ? holeToUndefinedInstrs(ctx, fctx) : []),
+            // (#2001 S2) The fold's reverse continue-gate already skipped any hole
+            // index, so the element here is always present (no S1 map needed).
             ...elemCoerce,
           ]
         : []),
@@ -6803,6 +6936,8 @@ function compileArrayReduceRight(
     ];
   }
 
+  // (#2001 S2) Skip hole indices in the reverse fold (reducer never sees a hole).
+  const rrFoldSkip = rrSkipHoles ? holeContinueGate(ctx, dataTmp, iTmp, arrTypeIdx, [], /*reverse*/ true) : [];
   // Loop: while (i >= 0) { acc = cb(acc, data[i], i, arr); i--; }
   const loopBody: Instr[] = [
     // Exit check: if (i < 0) break
@@ -6810,6 +6945,7 @@ function compileArrayReduceRight(
     { op: "i32.const", value: 0 } as Instr,
     { op: "i32.lt_s" } as Instr,
     { op: "br_if", depth: 1 } as Instr,
+    ...rrFoldSkip,
     // Callback
     ...callInstrs,
     // i--
@@ -6848,20 +6984,28 @@ function compileArrayForEach(
   if (!setup) return null;
 
   const loop = setupArrayLoop(ctx, fctx, propAccess, vecTypeIdx, arrTypeIdx, elemType, "fe");
+  // (#2001 S2) forEach does NOT call the callback for a hole index (§23.1.3.15
+  // step 6.c: skip when HasProperty is false). Wrap the call+drop work so a hole
+  // falls straight through to `loopIncrement`. Gated on externref element.
+  const skipHoles = ctx.usesArrayHoles && elemType.kind === "externref";
 
   if (setup.closureInfo) {
     const callInstrs = buildClosureCallInstrs(ctx, fctx, setup, elemType, vecTypeIdx, arrTypeIdx, loop, {
       kind: "inline",
     });
     const dropInstrs: Instr[] = setup.closureInfo.returnType ? [{ op: "drop" } as Instr] : [];
+    const work = [...callInstrs, ...dropInstrs];
+    const gated = skipHoles ? holeSkipGate(ctx, loop.dataTmp, loop.iTmp, arrTypeIdx, work) : work;
 
-    const loopBody: Instr[] = [...loopExitCheck(loop), ...callInstrs, ...dropInstrs, ...loopIncrement(loop)];
+    const loopBody: Instr[] = [...loopExitCheck(loop), ...gated, ...loopIncrement(loop)];
 
     emitArrayLoop(fctx, loopBody);
   } else {
     const callInstrs = buildBridgeCallInstrs(ctx, setup, elemType, arrTypeIdx, loop, { kind: "inline" });
+    const work = [...callInstrs, { op: "drop" } as Instr];
+    const gated = skipHoles ? holeSkipGate(ctx, loop.dataTmp, loop.iTmp, arrTypeIdx, work) : work;
 
-    const loopBody: Instr[] = [...loopExitCheck(loop), ...callInstrs, { op: "drop" } as Instr, ...loopIncrement(loop)];
+    const loopBody: Instr[] = [...loopExitCheck(loop), ...gated, ...loopIncrement(loop)];
 
     emitArrayLoop(fctx, loopBody);
   }
@@ -7275,8 +7419,17 @@ function compileArraySome(
   fctx.body.push({ op: "i32.const", value: 0 });
   fctx.body.push({ op: "local.set", index: resTmp });
 
+  // (#2001 S2) some does NOT call the callback for a hole (§23.1.3.6); a hole is
+  // skipped, NOT observed as `undefined`, and the scan continues. Use the
+  // continue-gate so the early-exit `br depth: 2` inside the work keeps its depth.
+  const someSkip =
+    ctx.usesArrayHoles && elemType.kind === "externref"
+      ? holeContinueGate(ctx, loop.dataTmp, loop.iTmp, arrTypeIdx)
+      : [];
+
   const loopBody: Instr[] = [
     ...loopExitCheck(loop),
+    ...someSkip,
 
     ...callAndCheck,
     {
@@ -7337,8 +7490,17 @@ function compileArrayEvery(
   fctx.body.push({ op: "i32.const", value: 1 });
   fctx.body.push({ op: "local.set", index: resTmp });
 
+  // (#2001 S2) every does NOT call the callback for a hole (§23.1.3.5) and a hole
+  // does NOT falsify the result — it is simply skipped. Continue-gate keeps the
+  // early-exit `br depth: 2` depth intact.
+  const evrSkip =
+    ctx.usesArrayHoles && elemType.kind === "externref"
+      ? holeContinueGate(ctx, loop.dataTmp, loop.iTmp, arrTypeIdx)
+      : [];
+
   const loopBody: Instr[] = [
     ...loopExitCheck(loop),
+    ...evrSkip,
 
     ...callAndCheck,
     {
@@ -8497,15 +8659,13 @@ function compileArrayLastIndexOf(
   }
   fctx.body.push({ op: "local.set", index: liofResTmp });
 
-  // (#2001 S1) Map a `$Hole` element to `undefined` before the strict-eq so
-  // `lastIndexOf(undefined)` matches a hole index. Pre-ensure `__get_undefined`
-  // so the detached mapping flush can't shift the captured `__host_eq` funcIdx.
-  let liofHoleMap: Instr[] = [];
-  if (ctx.usesArrayHoles && elemType.kind === "externref") {
-    ensureGetUndefined(ctx);
-    flushLateImportShifts(ctx, fctx);
-    liofHoleMap = holeToUndefinedInstrs(ctx, fctx);
-  }
+  // (#2001 S2) lastIndexOf SKIPS holes — a hole never matches (§23.1.3.17 uses
+  // HasProperty), so `[,].lastIndexOf(undefined) === -1`. Supersedes S1's
+  // hole→undefined read-map. Reverse continue-gate keeps the match-break depth.
+  const liofSkip =
+    ctx.usesArrayHoles && elemType.kind === "externref"
+      ? holeContinueGate(ctx, dataTmp, iTmp, arrTypeIdx, [], /*reverse*/ true)
+      : [];
 
   // Loop: while (i >= 0) { if data[i] == val, store i and break; i--; }
   const loopBody: Instr[] = [
@@ -8515,11 +8675,12 @@ function compileArrayLastIndexOf(
     { op: "i32.lt_s" },
     { op: "br_if", depth: 1 },
 
+    ...liofSkip,
+
     // if (data[i] == val) store result and break
     { op: "local.get", index: dataTmp },
     { op: "local.get", index: iTmp },
     { op: getOp, typeIdx: arrTypeIdx } as Instr,
-    ...liofHoleMap,
     { op: "local.get", index: valTmp },
     ...liofEqInstrs,
     {

--- a/tests/issue-2001-s1-hole-literal.test.ts
+++ b/tests/issue-2001-s1-hole-literal.test.ts
@@ -156,13 +156,18 @@ describe("#2001 S1 — sparse-array literal holes ($Hole sentinel, any[] only)",
   });
 
   describe("read-boundary invariant — a hole never leaks the sentinel to a value reader", () => {
-    // S1 does NOT yet skip holes in HOFs (that is S2) — forEach/map/etc still
-    // VISIT the hole — but the visited value MUST be `undefined`, never the
-    // `$Hole` sentinel struct. These lock in the no-regression contract: before
-    // S1 a hole was stored as `undefined`, so every reader saw `undefined`;
-    // after S1 it is stored as `$Hole`, so every value reader must map it back.
+    // The §ToObject/Get readers (for-of, destructuring, find, at, pop, includes)
+    // VISIT a hole observing `undefined` — never the `$Hole` sentinel struct. The
+    // HasProperty readers (forEach/map/filter/some/every/indexOf/lastIndexOf/
+    // reduce) SKIP a hole entirely (S2, #2001). Both invariants are checked here;
+    // in neither case may the raw sentinel leak to user code.
+    //
+    // NOTE (#2001 S2): the HOF assertions below were written for S1's interim
+    // "visit-as-undefined" behaviour and have been updated to S2's spec-correct
+    // visit-SKIP — the dedicated S2 acceptance suite is in
+    // `tests/issue-2001-s2-hof-skip.test.ts`.
 
-    it("for-of yields undefined at a hole", async () => {
+    it("for-of yields undefined at a hole (Get)", async () => {
       expect(
         await run(
           `export function run(): string { const a: any[] = [1, , 3]; let r = ""; for (const x of a) { r += typeof x + ","; } return r; }`,
@@ -170,72 +175,74 @@ describe("#2001 S1 — sparse-array literal holes ($Hole sentinel, any[] only)",
       ).toBe("number,undefined,number,");
     });
 
-    it("array destructuring binds undefined at a hole", async () => {
+    it("array destructuring binds undefined at a hole (Get)", async () => {
       expect(
         await run(`export function run(): string { const a: any[] = [1, , 3]; const [p, q, r] = a; return typeof q; }`),
       ).toBe("undefined");
     });
 
-    it("forEach callback receives undefined (visited, not the sentinel)", async () => {
+    it("forEach SKIPS a hole — the callback is not invoked for it (S2)", async () => {
       expect(
         await run(
           `export function run(): string { const a: any[] = [1, , 3]; let r = ""; a.forEach((x) => { r += typeof x; }); return r; }`,
         ),
-      ).toBe("numberundefinednumber");
+      ).toBe("numbernumber");
     });
 
-    it("map produces undefined at a hole's index in S1", async () => {
+    it("map preserves a result hole at the skipped index (S2)", async () => {
+      // The hole index is skipped (callback not called) and the result slot is a
+      // hole, so join renders it "": [number, <hole>, number] → "number,,number".
       expect(
         await run(
-          `export function run(): string { const a: any[] = [1, , 3]; return a.map((x) => typeof x).join(","); }`,
+          `export function run(): string { const a: any[] = [1, , 3]; return a.map((x: any) => typeof x).join(","); }`,
         ),
-      ).toBe("number,undefined,number");
+      ).toBe("number,,number");
     });
 
-    it("filter callback sees undefined", async () => {
+    it("filter omits a hole — the callback never sees it (S2)", async () => {
       expect(
         await run(
-          `export function run(): number { const a: any[] = [1, , 3]; return a.filter((x) => x === undefined).length; }`,
-        ),
-      ).toBe(1);
-    });
-
-    it("some/every observe undefined at a hole", async () => {
-      expect(
-        await run(
-          `export function run(): boolean { const a: any[] = [1, , 3]; return a.some((x) => x === undefined); }`,
-        ),
-      ).toBe(1);
-      expect(
-        await run(
-          `export function run(): boolean { const a: any[] = [1, , 3]; return a.every((x) => x !== undefined); }`,
+          `export function run(): number { const a: any[] = [1, , 3]; return a.filter((x: any) => x === undefined).length; }`,
         ),
       ).toBe(0);
     });
 
-    it("find returns the undefined element for a matching hole", async () => {
+    it("some/every SKIP a hole — not observed as undefined (S2)", async () => {
       expect(
         await run(
-          `export function run(): string { const a: any[] = [1, , 3]; return typeof a.find((x) => x === undefined); }`,
+          `export function run(): boolean { const a: any[] = [1, , 3]; return a.some((x: any) => x === undefined); }`,
+        ),
+      ).toBe(0);
+      expect(
+        await run(
+          `export function run(): boolean { const a: any[] = [1, , 3]; return a.every((x: any) => x !== undefined); }`,
+        ),
+      ).toBe(1);
+    });
+
+    it("find VISITS a hole observing undefined (Get, NOT HasProperty)", async () => {
+      expect(
+        await run(
+          `export function run(): string { const a: any[] = [1, , 3]; return typeof a.find((x: any) => x === undefined); }`,
         ),
       ).toBe("undefined");
     });
 
-    it("indexOf/includes treat a hole as undefined (Get semantics)", async () => {
+    it("indexOf SKIPS a hole (HasProperty → -1); includes treats it as undefined (Get → true)", async () => {
       expect(
         await run(`export function run(): number { const a: any[] = [1, , 3]; return a.indexOf(undefined); }`),
-      ).toBe(1);
+      ).toBe(-1);
       expect(
         await run(`export function run(): boolean { const a: any[] = [1, , 3]; return a.includes(undefined); }`),
       ).toBe(1);
     });
 
-    it("reduce folds the hole as undefined", async () => {
+    it("reduce SKIPS a hole in the fold (S2)", async () => {
       expect(
         await run(
-          `export function run(): string { const a: any[] = [1, , 3]; return a.reduce((acc, x) => acc + "," + typeof x, "s"); }`,
+          `export function run(): string { const a: any[] = [1, , 3]; return a.reduce((acc: any, x: any) => acc + "," + typeof x, "s"); }`,
         ),
-      ).toBe("s,number,undefined,number");
+      ).toBe("s,number,number");
     });
 
     it("at() of a hole is undefined", async () => {

--- a/tests/issue-2001-s2-hof-skip.test.ts
+++ b/tests/issue-2001-s2-hof-skip.test.ts
@@ -1,0 +1,252 @@
+// (#2001 S2) Sparse-array HOF visit-SKIP on the dense WasmGC vec.
+//
+// S1 introduced the `$Hole` sentinel and a universal `$Hole → undefined`
+// value-read mapping, so a *visited* hole reads as `undefined`. S2 adds the
+// genuine §23.1.3.* visit semantics that the read-mapping alone cannot give:
+//   • forEach/some/every/reduce/reduceRight/indexOf/lastIndexOf SKIP a hole —
+//     the callback is NOT invoked and the hole never matches an `indexOf` /
+//     contributes to a `reduce` fold.
+//   • map produces a RESULT hole at the hole index (callback not called; the
+//     result slot is `$Hole`, so it renders as "" in join), preserving sparsity.
+//   • filter omits holes (a hole contributes nothing).
+//   • includes does NOT skip (it uses Get, so `[,].includes(undefined) === true`)
+//     — verified to remain S1's hole→undefined read behaviour.
+//   • find/findIndex/findLast/findLastIndex use Get (not HasProperty), so they
+//     VISIT a hole observing `undefined` — left to S1's read-map (NOT skipped).
+//
+// Scope: ONLY `any[]` / untyped externref-element vecs. A typed `number[]`
+// kernel (f64 element) is byte-identical — the skip gate is element-typed
+// (`externref` only), never a `ref.test` on an f64/i32 vec.
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(source: string, fn = "run"): Promise<unknown> {
+  const result = await compile(source);
+  expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(result.binary), "module must be valid Wasm").toBe(true);
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>)[fn]();
+}
+
+// Standalone harness — `$Hole` is pure WasmGC, so the skip gate works engine-
+// native with no host import; assert via numbers / `.length` to avoid decoding
+// native strings.
+async function runStandalone(source: string, fn = "run"): Promise<number> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as Record<string, () => number>)[fn]();
+}
+
+describe("#2001 S2 — sparse-array HOF visit-skip (any[] only)", () => {
+  describe("forEach / map / filter — the headline visit-skip", () => {
+    it("forEach does NOT visit a hole (count 2, not 3)", async () => {
+      expect(
+        await run(
+          `export function run(): number { const a: any[] = [1, , 3]; let c = 0; a.forEach(() => { c++; }); return c; }`,
+        ),
+      ).toBe(2);
+    });
+
+    it("map skips the callback at a hole and preserves a result hole", async () => {
+      // Visit count is 2 (callback not called on the hole) and the result hole
+      // renders as "" in join: [10, <hole>, 30] → "10,,30".
+      expect(
+        await run(
+          `export function run(): number { const a: any[] = [1, , 3]; let c = 0; a.map((x: any) => { c++; return x; }); return c; }`,
+        ),
+      ).toBe(2);
+      expect(
+        await run(
+          `export function run(): string { const a: any[] = [1, , 3]; return a.map((x: any) => (x as number) * 10).join(","); }`,
+        ),
+      ).toBe("10,,30");
+    });
+
+    it("filter omits holes (a hole contributes nothing)", async () => {
+      expect(
+        await run(`export function run(): number { const a: any[] = [1, , 3]; return a.filter(() => true).length; }`),
+      ).toBe(2);
+    });
+  });
+
+  describe("some / every — hole skipped, not observed as undefined", () => {
+    it("some does NOT see a hole as undefined", async () => {
+      expect(
+        await run(
+          `export function run(): boolean { const a: any[] = [1, , 3]; return a.some((x: any) => x === undefined); }`,
+        ),
+      ).toBe(0);
+      // …but an EXPLICIT undefined element IS seen.
+      expect(
+        await run(
+          `export function run(): boolean { const a: any[] = [1, undefined, 3]; return a.some((x: any) => x === undefined); }`,
+        ),
+      ).toBe(1);
+    });
+
+    it("every is not falsified by a hole (hole skipped)", async () => {
+      expect(
+        await run(
+          `export function run(): boolean { const a: any[] = [2, , 4]; return a.every((x: any) => (x as number) % 2 === 0); }`,
+        ),
+      ).toBe(1);
+    });
+  });
+
+  describe("indexOf / lastIndexOf / includes — Get vs HasProperty", () => {
+    it("indexOf(undefined) does NOT match a hole (HasProperty) → -1", async () => {
+      expect(
+        await run(`export function run(): number { const a: any[] = [1, , 3]; return a.indexOf(undefined); }`),
+      ).toBe(-1);
+    });
+
+    it("lastIndexOf(undefined) does NOT match a hole → -1, but a present value still matches", async () => {
+      expect(
+        await run(`export function run(): number { const a: any[] = [1, , 3]; return a.lastIndexOf(undefined); }`),
+      ).toBe(-1);
+      expect(await run(`export function run(): number { const a: any[] = [3, , 3]; return a.lastIndexOf(3); }`)).toBe(
+        2,
+      );
+    });
+
+    it("includes(undefined) DOES match a hole (Get) → true — NOT skipped", async () => {
+      expect(
+        await run(`export function run(): boolean { const a: any[] = [1, , 3]; return a.includes(undefined); }`),
+      ).toBe(1);
+    });
+  });
+
+  describe("reduce / reduceRight — holes skipped for seed-seek and fold", () => {
+    it("reduce skips holes in the fold", async () => {
+      expect(
+        await run(
+          `export function run(): number { const a: any[] = [5, , , 2]; return a.reduce((x: any, y: any) => (x as number) + (y as number)) as number; }`,
+        ),
+      ).toBe(7);
+    });
+
+    it("reduce no-initial-value seeks the first PRESENT element", async () => {
+      expect(
+        await run(
+          `export function run(): number { const a: any[] = [, 5, 2]; return a.reduce((x: any, y: any) => (x as number) + (y as number)) as number; }`,
+        ),
+      ).toBe(7);
+    });
+
+    it("reduce with an initial value skips holes", async () => {
+      expect(
+        await run(
+          `export function run(): number { const a: any[] = [1, , 3]; return a.reduce((x: any, y: any) => (x as number) + (y as number), 100) as number; }`,
+        ),
+      ).toBe(104);
+    });
+
+    it("reduce on an all-holes array (no initial value) throws TypeError", async () => {
+      expect(
+        await run(
+          `export function run(): string { const a: any[] = [, ,]; try { a.reduce((x: any, y: any) => x); return "no-throw"; } catch (e) { return "threw"; } }`,
+        ),
+      ).toBe("threw");
+    });
+
+    it("reduceRight skips holes and seeks the last PRESENT element for the seed", async () => {
+      expect(
+        await run(
+          `export function run(): number { const a: any[] = [5, , , 2]; return a.reduceRight((x: any, y: any) => (x as number) + (y as number)) as number; }`,
+        ),
+      ).toBe(7);
+      expect(
+        await run(
+          `export function run(): number { const a: any[] = [1, , 3]; return a.reduceRight((x: any, y: any) => (x as number) + (y as number), 100) as number; }`,
+        ),
+      ).toBe(104);
+    });
+  });
+
+  describe("find / findIndex — Get semantics: a hole IS visited as undefined (NOT skipped)", () => {
+    it("find observes undefined at a hole (Get, not HasProperty)", async () => {
+      // §23.1.3.8 uses Get, so the callback DOES run on a hole with `undefined`.
+      expect(
+        await run(
+          `export function run(): boolean { const a: any[] = [1, , 3]; return a.find((x: any) => x === undefined) === undefined ? false : true; }`,
+        ),
+      ).toBe(0); // find returns the (undefined) hole value → the ternary yields false
+      expect(
+        await run(
+          `export function run(): number { const a: any[] = [1, , 3]; let c = 0; a.find((x: any) => { c++; return false; }); return c; }`,
+        ),
+      ).toBe(3); // find VISITS all 3 indices including the hole
+    });
+  });
+
+  describe("typed no-regression guard — the dense numeric kernel is untouched", () => {
+    it("a dense number[] forEach kernel still sums (no hole machinery on f64)", async () => {
+      expect(
+        await run(
+          `export function run(): number { const a = [1, 2, 3, 4]; let s = 0; a.forEach((x) => { s += x; }); return s; }`,
+        ),
+      ).toBe(10);
+    });
+
+    it("a dense number[] reduce / map / indexOf are unchanged", async () => {
+      expect(
+        await run(`export function run(): number { const a = [1, 2, 3, 4]; return a.reduce((x, y) => x + y); }`),
+      ).toBe(10);
+      expect(
+        await run(`export function run(): string { const a = [1, 2, 3]; return a.map((x) => x * 2).join(","); }`),
+      ).toBe("2,4,6");
+      expect(await run(`export function run(): number { const a = [10, 20, 30]; return a.indexOf(20); }`)).toBe(1);
+    });
+
+    it("a dense any[] (no holes) is unaffected even though usesArrayHoles is module-wide", async () => {
+      // The module has a hole literal so usesArrayHoles is set, but this dense
+      // any[] still forEach-counts every element.
+      expect(
+        await run(
+          `const h: any[] = [1, , 3]; export function run(): number { const a: any[] = [1, 2, 3]; let c = 0; a.forEach(() => { c++; }); return c; }`,
+        ),
+      ).toBe(3);
+    });
+
+    it("the compiled binary is deterministic (reproducible bytes)", async () => {
+      const src = `export function run(): number { const a: any[] = [1, , 3]; let c = 0; a.forEach(() => { c++; }); return c; }`;
+      const a = (await compile(src)).binary;
+      const b = (await compile(src)).binary;
+      expect(Buffer.from(a).equals(Buffer.from(b))).toBe(true);
+    });
+  });
+
+  describe("standalone (pure Wasm — $Hole skip is engine-native, no host import)", () => {
+    it("forEach visit-skip standalone (count 2)", async () => {
+      expect(
+        await runStandalone(
+          `export function run(): number { const a: any[] = [1, , 3]; let c = 0; a.forEach(() => { c++; }); return c; }`,
+        ),
+      ).toBe(2);
+    });
+
+    it("map skips the callback at a hole standalone (visit count 2)", async () => {
+      // join needs native-string concat (a separate standalone gap), so assert the
+      // skip via a visit counter rather than the rendered result.
+      expect(
+        await runStandalone(
+          `export function run(): number { const a: any[] = [1, , 3]; let c = 0; a.map((x: any) => { c++; return x; }); return c; }`,
+        ),
+      ).toBe(2);
+    });
+
+    it("reduce skip standalone ([5,,,2] sum 7)", async () => {
+      expect(
+        await runStandalone(
+          `export function run(): number { const a: any[] = [5, , , 2]; return a.reduce((x: any, y: any) => (x as number) + (y as number)) as number; }`,
+        ),
+      ).toBe(7);
+    });
+  });
+});


### PR DESCRIPTION
The headline #2001 slice (builds on S1 / PR #1838, now merged).

## What S2 does
S1 made a *visited* hole read as `undefined`; S2 adds the §23.1.3.* visit-SKIP
semantics the read-map alone cannot give — the callback is NOT invoked for a
hole, and a hole never matches `indexOf` / contributes to a `reduce` fold.

Two reusable gate helpers in `src/codegen/array-holes.ts` (both gated on
`usesArrayHoles && elemType.kind === "externref"` → typed `number[]`/`boolean[]`
kernels byte-identical, no `ref.test`):
- **`holeSkipGate`** — wraps branch-free per-iteration `work` in `if($Hole) onHole
  else work`. `forEach`/`filter`/`map`. For `map`, `onHole` writes `$Hole` into the
  result slot (result vec forced to externref-element) so a source hole → a
  **result hole** (`[1,,3].map(x=>x*10)` → `"10,,30"`).
- **`holeContinueGate`** — for work that branches into the loop (`some`/`every`
  early-exit `br 2`, `indexOf`/`lastIndexOf` match-break, `reduce`/`reduceRight`
  fold): tests the hole at the SAME control depth and on a hole does `i±1; br 1`
  (continue), leaving the present-index work unguarded so its `br` depths are
  unchanged (avoids the depth-off-by-one of nesting work in an extra `if`).
  `reverse` flips `i++`→`i--` for reduceRight / lastIndexOf.

## Per-method
- `forEach`/`some`/`every` skip (callback not called, scan continues)
- `map` skips + result-hole; `filter` omits
- `indexOf`/`lastIndexOf` skip — a hole never matches (supersedes S1's
  hole→undefined read-map for these two)
- `reduce`/`reduceRight` skip the fold AND seek the first/last **present** element
  for the no-initial-value seed (empty/all-holes ⇒ TypeError)
- `includes` UNCHANGED (Get → `[,].includes(undefined) === true`)
- `find`/`findIndex`/`findLast`/`findLastIndex` UNCHANGED (Get — visit a hole as
  `undefined`, not HasProperty-skip)

## Validation
- `tests/issue-2001-s2-hof-skip.test.ts` (21 cases — host + standalone)
- `tests/issue-2001-s1-hole-literal.test.ts` updated from S1's interim
  visit-as-undefined to S2 visit-skip; 36 cases
- array-methods (22), array-prototype-methods (13), functional-array-methods (24)
  all green; typecheck clean; typed-kernel byte-identity + deterministic-bytes
  guards
- Broad-impact (shared array-HOF loop driver): the merge_group full-Test262 gate
  is the authoritative validator (per memory `project_broad_impact_validate_full_ci`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA