### PR TITLE
fix(#2571): native class generator methods in no-JS-host targets

### DIFF
--- a/plan/issues/2571-standalone-native-method-generators.md
+++ b/plan/issues/2571-standalone-native-method-generators.md
@@ -1,10 +1,13 @@
 ---
 id: 2571
 title: "standalone: class/object-literal method generators leak env.__gen_* host imports — no native lowering (validate-but-can't-instantiate)"
-status: ready
+status: done
 sprint: Backlog
 created: 2026-06-21
 updated: 2026-06-21
+completed: 2026-06-21
+assignee: sd-2
+residual: "object-literal method generators ({ *m(){} }) keep the host path — deferred follow-up (closures.ts lifted-closure path needs native wiring); class/static/instance method generators are native."
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -323,3 +326,51 @@ new C().m();` leaves `ran === 0` until the first `it.next()`.
 - The standalone `env.__gen_*` leak count over the gen-method test262 subset
   drops to ~0; host mode unchanged (no regression).
 - No new host imports introduced for the standalone path.
+
+## Resolution (2026-06-21, sd-2) — CLASS method generators native; object-literal deferred
+
+Implemented Work Items A+B+C from the sd-5 spec for **class** (instance +
+static) generator methods. Object-literal method generators (`{ *m(){} }`) are
+deferred to a follow-up — they lower through the `closures.ts` lifted-closure
+path, which is not yet wired to the native state machine; they keep the host
+path cleanly (valid module, host imports) — NO regression.
+
+### Changes
+
+- **`src/codegen/generators-native.ts`**
+  - `isNativeGeneratorCandidate` widened to `GeneratorDecl =
+    FunctionDeclaration | MethodDeclaration` (the single source of truth). For a
+    method it bails (→ host) when: computed/string name, NOT a class method
+    (object-literal deferred), reads `arguments`, uses `super.*`, or CAPTURES an
+    enclosing binding (#2203 — the native state struct has no capture slot).
+  - `registerNativeGenerator` gains a `synthesizedThis` flag: when set (instance
+    method) it prepends `"this"` to `paramNames`, aligned with the caller's
+    `paramTypes = [receiverType, ...userParams]`, so the state struct mints a
+    `param_this` field that the resume function rehydrates as a `this` local —
+    `this.x` reads resolve via the existing `localMap.get("this")`.
+  - `compileNativeGeneratorFunction` factory reads `info.paramTypes.length`
+    wasm params (NOT `decl.parameters.length`) so the synthetic `this` (wasm
+    param 0) is read into `param_this`.
+  - `sourceNeedsGeneratorHostImports` no longer force-routes a native-capable
+    class method generator to the host path.
+- **`src/codegen/class-bodies.ts`** — the collection pass registers the native
+  generator (under `classMemberFuncKey`, `synthesizedThis = !isStatic`) when
+  `(standalone||wasi) && !async && candidate`, and sets the method's wasm result
+  type to the `$GenState_*` struct ref (mirrors `declarations.ts:2499`). The
+  fctx returnType + the emit block route through `compileNativeGeneratorFunction`
+  for the native case; the eager-buffer host block is the `else`.
+- **`src/codegen/context/types.ts`** — `NativeGeneratorInfo.decl` widened;
+  added `synthesizedThis?`.
+
+All guards are `standalone||wasi`-gated → **JS-host (gc) mode byte-identical**.
+
+### Verified
+
+`tests/issue-2571-native-method-generators.test.ts` (10): instance/static/this/
+this+param/multi-yield/done/lazy native (zero `__gen_*` imports, correct
+values); free `function*` unregressed; capturing + object-literal bail to host
+(valid Wasm). tsc + prettier + hard-error gate + IR-fallback gate clean.
+Runnable generator/class test files unregressed (the 17 `class-methods.test.ts`
+failures are the pre-existing gc-mode `string_constants` harness limitation —
+identical on pristine main). Broad-impact → merge_group is the authoritative
+full-standalone-shard validator.

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -25,6 +25,11 @@ import { emitThrowReferenceError, getFuncParamTypes } from "./expressions/helper
 import { pushDefaultValue } from "./type-coercion.js";
 import { bodyUsesArguments } from "./helpers/body-uses-arguments.js";
 import {
+  compileNativeGeneratorFunction,
+  isNativeGeneratorCandidate,
+  registerNativeGenerator,
+} from "./generators-native.js"; // (#2571) native method-generator lowering
+import {
   cacheStringLiterals,
   extractConstantDefault,
   hasAbstractModifier,
@@ -910,8 +915,28 @@ export function collectClassDeclaration(
       const sig = ctx.checker.getSignatureFromDeclaration(member);
       let methodResults: ValType[] = [];
       if (isGeneratorMethod) {
-        // Generator methods return externref (JS Generator object)
-        methodResults = [{ kind: "externref" }];
+        // (#2571) In a no-JS-host target, a native-capable generator method
+        // returns its `$GenState_*` struct (the lazy native state machine),
+        // NOT the eager-buffer `externref` Generator object. Register it here —
+        // during the collection pass — so the state-struct type exists and the
+        // method's wasm signature carries the right result type (mirrors the
+        // free-function path in declarations.ts:2499). `methodParams` already
+        // includes the leading `this` ref for instance methods; mark
+        // `synthesizedThis` so `param_this` is minted. The actual factory emit
+        // is routed below (the generator-method emit block). JS-host mode keeps
+        // the externref Generator object (eager-buffer path) — byte-identical.
+        const noJsHost = ctx.standalone || ctx.wasi;
+        let nativeGen = null;
+        if (noJsHost && !isAsyncMethod && isNativeGeneratorCandidate(ctx, member)) {
+          nativeGen = registerNativeGenerator(
+            ctx,
+            member,
+            classMemberFuncKey(ctx, fullName),
+            methodParams,
+            /* synthesizedThis */ !isStatic,
+          );
+        }
+        methodResults = nativeGen ? [{ kind: "ref", typeIdx: nativeGen.stateTypeIdx }] : [{ kind: "externref" }];
       } else if (sig) {
         let retType = ctx.checker.getReturnTypeOfSignature(sig);
         if (isAsyncMethod) {
@@ -1891,13 +1916,23 @@ function compileClassBodiesInner(
       const isGeneratorMethod = member.asteriskToken !== undefined;
       const isAsyncMethod = member.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword) ?? false;
 
+      // (#2571) A native-lowered generator method returns its `$GenState_*`
+      // struct ref (registered in the collection pass under the same
+      // classMemberFuncKey); its fctx returnType must match that wasm result
+      // type, not the eager-buffer `externref`. JS-host (no native registration)
+      // keeps `externref`.
+      const nativeGenInfo = isGeneratorMethod ? ctx.nativeGenerators.get(classMemberFuncKey(ctx, fullName)) : undefined;
+      const genMethodReturnType: ValType = nativeGenInfo
+        ? { kind: "ref", typeIdx: nativeGenInfo.stateTypeIdx }
+        : { kind: "externref" };
+
       const fctx: FunctionContext = {
         name: fullName,
         params,
         locals: [],
         localMap: new Map(),
         returnType: isGeneratorMethod
-          ? { kind: "externref" }
+          ? genMethodReturnType
           : retType && !isVoidType(retType)
             ? resolveWasmType(ctx, retType)
             : null,
@@ -2045,7 +2080,14 @@ function compileClassBodiesInner(
         emitArgumentsObject(ctx, fctx, methodParamTypes, paramOffset, true);
       }
 
-      if (isGeneratorMethod && member.body) {
+      if (isGeneratorMethod && member.body && nativeGenInfo) {
+        // (#2571) Native lazy generator method: emit the state-struct factory
+        // (pushes the `$GenState_*` ref) instead of the eager host buffer. The
+        // resume function + `.next()/.return()/.throw()` dispatch are already
+        // representation-agnostic. No host imports, instantiates standalone.
+        compileNativeGeneratorFunction(ctx, fctx, member, nativeGenInfo);
+        fctx.body.push({ op: "return" });
+      } else if (isGeneratorMethod && member.body) {
         // Generator method: eagerly evaluate body, collect yields into a buffer,
         // then wrap with __create_generator to return a Generator-like object.
         // Body is wrapped in try/catch to defer thrown exceptions to first next() (#928).

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -181,8 +181,23 @@ export interface ClosureInfo {
 export interface NativeGeneratorInfo {
   /** Source-level generator function name. */
   functionName: string;
-  /** Original declaration; used to emit the resume function lazily. */
-  decl: ts.FunctionDeclaration;
+  /**
+   * Original declaration; used to emit the resume function lazily. (#2571) A
+   * class / object-literal generator method is a `ts.MethodDeclaration`; it
+   * shares `.body` / `.parameters` / `.asteriskToken` with FunctionDeclaration,
+   * and the native lowering treats an instance method's `this` as a synthetic
+   * leading param (see `registerNativeGenerator`).
+   */
+  decl: ts.FunctionDeclaration | ts.MethodDeclaration;
+  /**
+   * (#2571) When `decl` is a non-static instance generator METHOD, the receiver
+   * is threaded as a synthetic leading param named `"this"` (state field
+   * `param_this`). `synthesizedThis` records that the param model has one extra
+   * leading entry beyond `decl.parameters` so the factory reads `local.get 0`
+   * (the `this` wasm param) into `param_this`. Free functions / static methods
+   * leave this `false` (no synthetic param) — byte-identical to pre-#2571.
+   */
+  synthesizedThis?: boolean;
   /** Per-generator state struct type index. */
   stateTypeIdx: number;
   /** Shared IteratorResult-like struct type index. */

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -36,6 +36,7 @@ import { nativeStringType } from "./native-strings.js";
 import { emitBrandCheckTypeError } from "./native-proto.js";
 import { addFuncType } from "./registry/types.js";
 import { coerceType, compileExpression, compileStatement, valTypesMatch } from "./shared.js";
+import { bodyUsesArguments } from "./helpers/body-uses-arguments.js";
 
 const STATE_FIELD = 0;
 const SENT_FIELD = 1;
@@ -138,7 +139,7 @@ function isStringYieldExpression(ctx: CodegenContext, expr: ts.Expression | unde
  * (not descending into nested functions). Returns `{kind:"f64"}` when there are
  * no yields (degenerate; the plan rejects zero-yield generators separately).
  */
-function generatorElemValType(ctx: CodegenContext, decl: ts.FunctionDeclaration): ValType | null {
+function generatorElemValType(ctx: CodegenContext, decl: GeneratorDecl): ValType | null {
   let sawNumeric = false;
   let sawString = false;
   let unsupported = false;
@@ -237,7 +238,7 @@ function nodeContainsYield(root: ts.Node): boolean {
  * `null` when any shape is outside the supported subset, so callers fall back
  * to the host path (or the scoped diagnostic in standalone).
  */
-function buildNativeGeneratorPlan(ctx: CodegenContext, decl: ts.FunctionDeclaration): NativeGeneratorPlan | null {
+function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): NativeGeneratorPlan | null {
   if (!decl.body) return null;
 
   // (#2171) Decide the uniform yield element type up-front. Numeric → f64 (the
@@ -792,15 +793,87 @@ function thenBody(stmt: ts.Statement): readonly ts.Statement[] {
   return [stmt];
 }
 
-export function isNativeGeneratorCandidate(ctx: CodegenContext, decl: ts.FunctionDeclaration): boolean {
+/**
+ * (#2571) True when a method body references `super.*` (a `SuperKeyword` that is
+ * not just a nested function's own `super`). The native generator resume
+ * function has no `super`-binding setup, so a `super`-using method generator
+ * bails to the eager-buffer host path. Stops at nested non-arrow functions
+ * (their `super` is their own concern); arrow functions inherit the method's
+ * `super`, so it does NOT stop at them.
+ */
+function methodBodyUsesSuper(body: ts.Node): boolean {
+  let found = false;
+  function visit(node: ts.Node): void {
+    if (found) return;
+    if (node.kind === ts.SyntaxKind.SuperKeyword) {
+      found = true;
+      return;
+    }
+    // Nested non-arrow function-likes rebind `super` — their `super` is their
+    // own; do not descend (arrow functions keep the enclosing `super`).
+    if (
+      ts.isFunctionDeclaration(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isMethodDeclaration(node) ||
+      ts.isConstructorDeclaration(node) ||
+      ts.isGetAccessorDeclaration(node) ||
+      ts.isSetAccessorDeclaration(node)
+    ) {
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+  ts.forEachChild(body, visit);
+  return found;
+}
+
+/**
+ * (#2571) A native-generator candidate is either a named `function*`
+ * declaration or a class / object-literal generator METHOD. Both expose
+ * `.body` / `.parameters` / `.asteriskToken` / `.name`, so the plan builder and
+ * the state model treat them uniformly; the only method-specific handling is the
+ * synthetic `this` leading param (threaded in `registerNativeGenerator`).
+ */
+export type GeneratorDecl = ts.FunctionDeclaration | ts.MethodDeclaration;
+
+export function isNativeGeneratorCandidate(ctx: CodegenContext, decl: GeneratorDecl): boolean {
   if (!noJsHostTarget(ctx)) return false;
   if (!decl.name || !decl.body || !decl.asteriskToken) return false;
+  // (#2571) An object-literal method with a computed/string name
+  // (`{ [k]*(){} }`, `{ "m"*(){} }`) is out of scope — only an identifier-named
+  // method threads cleanly through the funcMap key. A FunctionDeclaration name
+  // is always an Identifier.
+  if (ts.isMethodDeclaration(decl) && !ts.isIdentifier(decl.name)) return false;
+  // (#2571) Only CLASS method generators are routed through the native factory
+  // in this slice (class-bodies.ts). An OBJECT-LITERAL method generator
+  // (`{ *m(){} }`) is lowered via the closures.ts lifted-closure path, which is
+  // NOT yet wired to the native state machine — so it must keep forcing the host
+  // path. Bailing here (the single candidate gate consumed by both
+  // `registerNativeGenerator` AND `sourceNeedsGeneratorHostImports`) keeps the
+  // host imports registered for it, avoiding an undefined-funcidx invalid module.
+  // Object-literal method generators are the documented follow-up.
+  if (ts.isMethodDeclaration(decl) && !ts.isClassLike(decl.parent)) return false;
   const modifiers = ts.canHaveModifiers(decl) ? ts.getModifiers(decl) : undefined;
   if (modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword || m.kind === ts.SyntaxKind.DeclareKeyword)) {
     return false;
   }
   for (const param of decl.parameters) {
     if (param.dotDotDotToken || !ts.isIdentifier(param.name)) return false;
+  }
+  // (#2571) A method generator that reads `arguments`, uses `super.*`, or
+  // CAPTURES an enclosing-function binding (#2203) has no native state-machine
+  // support: the eager-buffer path builds the arguments vec / closure, while the
+  // native state struct has slots only for `this` + own params, not captures.
+  // Bail to the host path so it stays correct (host) / refuses cleanly
+  // (standalone) rather than reading a garbage slot. This keeps the candidate
+  // gate the SINGLE source of truth — `registerNativeGenerator` (class-bodies)
+  // and `sourceNeedsGeneratorHostImports` both consult it and agree.
+  if (
+    ts.isMethodDeclaration(decl) &&
+    decl.body &&
+    (bodyUsesArguments(decl.body) || methodBodyUsesSuper(decl.body) || generatorCapturesOuterScope(ctx, decl))
+  ) {
+    return false;
   }
   const plan = buildNativeGeneratorPlan(ctx, decl);
   return plan !== null && plan.states.some((s) => s.terminator.kind === "yield" || s.terminator.kind === "yield-star");
@@ -822,7 +895,7 @@ export function isNativeGeneratorCandidate(ctx: CodegenContext, decl: ts.Functio
  * non-capturing nested generator stays native and is NOT flagged, so it does not
  * gain unused host-import dependencies.
  */
-function generatorCapturesOuterScope(ctx: CodegenContext, decl: ts.FunctionDeclaration): boolean {
+function generatorCapturesOuterScope(ctx: CodegenContext, decl: GeneratorDecl): boolean {
   if (!decl.body) return false;
   // Only generators nested inside another function-like scope can capture; a
   // top-level generator's free variables are module globals, which the native
@@ -910,7 +983,12 @@ export function sourceNeedsGeneratorHostImports(ctx: CodegenContext, sourceFile:
     }
     if (ts.isMethodDeclaration(node) && node.asteriskToken && node.body) {
       found = true;
-      needsHost = true;
+      // (#2571) A class / object-literal generator METHOD that the native path
+      // can lower (instance/static, identifier params, no capture / arguments /
+      // super) no longer forces the host imports — same logic as the
+      // FunctionDeclaration branch above, generalized to methods. A
+      // non-candidate or capturing method generator still needs the host buffer.
+      if (!isNativeGeneratorCandidate(ctx, node) || generatorCapturesOuterScope(ctx, node)) needsHost = true;
       return;
     }
     ts.forEachChild(node, visit);
@@ -957,9 +1035,16 @@ export function ensureNativeGeneratorResultType(ctx: CodegenContext, elemValType
 
 export function registerNativeGenerator(
   ctx: CodegenContext,
-  decl: ts.FunctionDeclaration,
+  decl: GeneratorDecl,
   functionName: string,
   paramTypes: ValType[],
+  // (#2571) When `decl` is a non-static instance generator METHOD, the caller
+  // passes `paramTypes = [receiverType, ...userParamTypes]` and sets this flag.
+  // We then prepend a `"this"` entry to `paramNames` so the state struct mints a
+  // `param_this` field (rehydrated as a `this` local in the resume function) and
+  // the param/name arrays stay aligned. Free functions / static methods leave
+  // this `false` — byte-identical to pre-#2571.
+  synthesizedThis = false,
 ): NativeGeneratorInfo | null {
   const existing = ctx.nativeGenerators.get(functionName);
   if (existing) return existing;
@@ -982,7 +1067,10 @@ export function registerNativeGenerator(
   if (elemIsString && bodySpillsForGuard.length > 0) return null;
 
   const resultTypeIdx = ensureNativeGeneratorResultType(ctx, elemValType);
-  const paramNames = decl.parameters.map((p) => (ts.isIdentifier(p.name) ? p.name.text : ""));
+  // (#2571) The synthetic `this` (when present) is the FIRST param name, aligned
+  // with the caller's `paramTypes[0] === receiverType`. User params follow.
+  const userParamNames = decl.parameters.map((p) => (ts.isIdentifier(p.name) ? p.name.text : ""));
+  const paramNames = synthesizedThis ? ["this", ...userParamNames] : userParamNames;
   const stateFields: FieldDef[] = [
     { name: "state", type: { kind: "i32" }, mutable: true },
     { name: "sent", type: { kind: "f64" }, mutable: true },
@@ -1037,6 +1125,7 @@ export function registerNativeGenerator(
   const info: NativeGeneratorInfo = {
     functionName,
     decl,
+    synthesizedThis,
     stateTypeIdx,
     resultTypeIdx,
     paramNames,
@@ -1634,7 +1723,7 @@ export function ensureNativeGeneratorResumeFunction(ctx: CodegenContext, info: N
 export function compileNativeGeneratorFunction(
   ctx: CodegenContext,
   fctx: FunctionContext,
-  decl: ts.FunctionDeclaration,
+  decl: GeneratorDecl,
   info: NativeGeneratorInfo,
 ): void {
   ensureNativeGeneratorResumeFunction(ctx, info);
@@ -1643,7 +1732,12 @@ export function compileNativeGeneratorFunction(
   fctx.body.push({ op: "f64.const", value: NaN });
   fctx.body.push({ op: "i32.const", value: 0 });
   fctx.body.push({ op: "f64.const", value: NaN });
-  for (let i = 0; i < decl.parameters.length; i++) {
+  // (#2571) Read every wasm param into its `param_*` state slot. For an instance
+  // method generator the synthetic `this` is wasm param 0 and user params are
+  // 1..n, so iterate `info.paramTypes.length` (which includes the synthetic
+  // `this`), NOT `decl.parameters.length`. For free functions / static methods
+  // the two are equal, so this is byte-identical there.
+  for (let i = 0; i < info.paramTypes.length; i++) {
     fctx.body.push({ op: "local.get", index: i });
   }
   for (let i = 0; i < info.spillNames.length; i++) {

--- a/tests/issue-2571-native-method-generators.test.ts
+++ b/tests/issue-2571-native-method-generators.test.ts
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2571 — native CLASS generator methods in a no-JS-host target.
+ *
+ * Before this slice, a class generator method (`class C { *m(){ yield … } }`)
+ * compiled to a module that VALIDATED but could not INSTANTIATE in standalone /
+ * WASI: it imported the eager-buffer host runtime (`__gen_create_buffer`,
+ * `__create_generator`, `__gen_next`, …), which has no pure-Wasm backing. A free
+ * `function*` was already lowered by the native generator state machine
+ * (#1665/#2170/#2171) with zero imports, but `MethodDeclaration` generators were
+ * force-routed to the host path.
+ *
+ * This slice admits a class instance/static generator method into the native
+ * state machine by threading the receiver `this` as a synthetic leading param
+ * (the state struct already persists + rehydrates params), so a class method
+ * generator lowers to a `$GenState_*` struct with no host imports.
+ *
+ * Asserts, for each shape: ZERO `__gen_*` / `__create_generator*` host imports,
+ * the module instantiates with an EMPTY import object, and the values are
+ * correct. Object-literal method generators + capturing / `arguments` / `super`
+ * method generators are out of scope here and keep the host path (documented
+ * follow-up) — covered by the "still host / unregressed" cases.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const HOST_GEN_RE = /^(__gen_|__create_generator|__create_async_generator)/;
+
+async function compileNoHost(src: string): Promise<{ binary: Uint8Array; genImports: string[] }> {
+  const r = await compile(src, { fileName: "test.ts", target: "wasi" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const genImports = WebAssembly.Module.imports(mod)
+    .filter((i) => HOST_GEN_RE.test(i.name))
+    .map((i) => `${i.module}::${i.name}`);
+  return { binary: r.binary, genImports };
+}
+
+async function runNative(src: string): Promise<number> {
+  const { binary, genImports } = await compileNoHost(src);
+  expect(genImports, "native class method generator must emit NO __gen_* host import").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2571 native class generator methods (no-JS-host target)", () => {
+  it("class instance method generator: new C().m().next().value === 42, no host imports", async () => {
+    const src = `class C { *m() { yield 42; } }
+export function test(): number { return (new C().m().next().value as number); }`;
+    expect(await runNative(src)).toBe(42);
+  });
+
+  it("instance method generator reading this: yields this.x", async () => {
+    const src = `class C { x = 7; *m() { yield this.x; } }
+export function test(): number { return (new C().m().next().value as number); }`;
+    expect(await runNative(src)).toBe(7);
+  });
+
+  it("instance method generator with this AND a user param", async () => {
+    const src = `class C { x = 10; *m(d: number) { yield this.x + d; } }
+export function test(): number { return (new C().m(5).next().value as number); }`;
+    expect(await runNative(src)).toBe(15);
+  });
+
+  it("static method generator: C.m() yields 1 then 2", async () => {
+    const src = `class C { static *m() { yield 1; yield 2; } }
+export function test(): number {
+  const it = C.m();
+  return (it.next().value as number) * 10 + (it.next().value as number);
+}`;
+    expect(await runNative(src)).toBe(12);
+  });
+
+  it("multiple yields stream in order through repeated .next()", async () => {
+    const src = `class C { *m() { yield 1; yield 2; yield 3; } }
+export function test(): number {
+  const it = new C().m();
+  return (it.next().value as number) * 100 + (it.next().value as number) * 10 + (it.next().value as number);
+}`;
+    expect(await runNative(src)).toBe(123);
+  });
+
+  it("done flag is set after the last yield", async () => {
+    const src = `class C { *m() { yield 7; } }
+export function test(): number {
+  const it = new C().m();
+  it.next();
+  return it.next().done ? 1 : 0;
+}`;
+    expect(await runNative(src)).toBe(1);
+  });
+
+  it("lazy: the method-generator body does not run until the first .next()", async () => {
+    const src = `let ran = 0;
+class C { *m() { ran = 1; yield 1; } }
+export function test(): number {
+  const it = new C().m();
+  const before = ran;
+  it.next();
+  return before * 10 + ran;
+}`;
+    // before === 0 (not yet run), after first next ran === 1 → 0*10 + 1 = 1
+    expect(await runNative(src)).toBe(1);
+  });
+
+  it("free function* generator stays native (regression guard)", async () => {
+    const src = `function* g() { yield 9; }
+export function test(): number { return (g().next().value as number); }`;
+    expect(await runNative(src)).toBe(9);
+  });
+
+  it("capturing class method generator BAILS to host cleanly (valid module, no native mis-lower)", async () => {
+    // Reads `cap` captured from the enclosing function — the native state struct
+    // has no capture slot, so it must keep the host path (the module still
+    // compiles to valid Wasm; it just carries the host imports here).
+    const src = `function outer(): number {
+  let cap = 3;
+  class C { *m() { yield cap; } }
+  return (new C().m().next().value as number);
+}
+export function test(): number { return outer(); }`;
+    const { binary, genImports } = await compileNoHost(src);
+    // Host imports ARE present (intentional bail) — assert the module is still
+    // structurally valid (compile succeeded above; just confirm it has the host
+    // generator imports rather than an undefined-funcidx invalid module).
+    expect(genImports.length, "capturing method generator keeps the host path").toBeGreaterThan(0);
+    expect(WebAssembly.validate(binary), "capturing-bail module must still be valid Wasm").toBe(true);
+  });
+
+  it("object-literal method generator keeps the host path (out of scope), still valid Wasm", async () => {
+    const src = `export function test(): number {
+  const o = { *m() { yield 9; } };
+  return (o.m().next().value as number);
+}`;
+    const { binary, genImports } = await compileNoHost(src);
+    expect(genImports.length, "object-literal method generator is the documented follow-up").toBeGreaterThan(0);
+    expect(WebAssembly.validate(binary), "object-literal-bail module must still be valid Wasm").toBe(true);
+  });
+});


### PR DESCRIPTION
## #2571 — native class generator methods (standalone / wasi)

A class generator method (`class C { *m(){ yield … } }`) compiled to a module that **validated but could not instantiate** in standalone/wasi — it imported the eager-buffer host generator runtime (`__gen_create_buffer` / `__create_generator` / `__gen_next` / …), which has no pure-Wasm backing. A free `function*` was already native; `MethodDeclaration` generators were force-routed to the host path.

### Fix — admit CLASS (instance + static) method generators to the native state machine

Key insight (sd-5 spec): `this` is just a leading param. The native state struct already persists + rehydrates params, so an instance method threads its receiver as a synthetic `param_this` field, and `this.x` reads resolve via the existing `localMap("this")`. The `.next()/.return()/.throw()` dispatch is already representation-agnostic.

- **`generators-native.ts`** — widen the candidate gate to `GeneratorDecl = FunctionDeclaration | MethodDeclaration` (single source of truth). A method bails to host on: computed/string name, non-class parent (object-literal deferred), `arguments`, `super.*`, or capture (#2203). `registerNativeGenerator` gains `synthesizedThis`; the factory reads `info.paramTypes.length` params; `sourceNeedsGeneratorHostImports` no longer forces host for a native-capable class method generator.
- **`class-bodies.ts`** — the collection pass registers the native generator (under `classMemberFuncKey`, `synthesizedThis = !isStatic`) and sets the method result type to `$GenState_*`; the emit routes through `compileNativeGeneratorFunction` (host eager-buffer is the `else`).
- **`context/types.ts`** — `NativeGeneratorInfo.decl` widened; add `synthesizedThis`.

All guards `(standalone||wasi)`-gated → **JS-host (gc) byte-identical**.

### Scope

Object-literal method generators (`{ *m(){} }`) are a **deferred follow-up** (closures.ts lifted-closure path). They keep the host path and bail cleanly — valid Wasm, no regression.

### Tests

`tests/issue-2571-native-method-generators.test.ts` (10): instance / static / `this` / `this`+param / multi-yield / done / **lazy** native (zero `__gen_*` imports); free `function*` unregressed; capturing + object-literal bail to host (valid Wasm). tsc + prettier + hard-error + IR-fallback gates clean. Broad-impact → merge_group is the authoritative validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA