### PR TITLE
fix(#2581): native object-literal generator methods in no-JS-host targets

### DIFF
--- a/plan/issues/2581-objlit-method-generators-native.md
+++ b/plan/issues/2581-objlit-method-generators-native.md
@@ -1,7 +1,9 @@
 ---
 id: 2581
 title: "standalone: object-literal method generators ({ *m(){} }) still leak env.__gen_* — native lowering via closures.ts"
-status: ready
+status: done
+assignee: sd-2
+completed: 2026-06-21
 sprint: Backlog
 created: 2026-06-21
 priority: medium
@@ -154,3 +156,50 @@ invalid wasm (the exact hazard #2571 hit + fixed).
 - **Resume**: re-claim with `--force`, start from the `this`-free first slice
   above. Validate broad-impact via the full gen-method cluster + merge_group, NOT
   a scoped sweep.
+
+## Resolution (2026-06-21, sd-2) — native, simpler than first feared
+
+Object-literal method generators now lower natively in standalone/wasi. The
+key enabler: the object-literal method **body func already leads with a `this`
+struct param** (`methodFctxParams[0] = (ref structTypeIdx)`, literals.ts) —
+structurally identical to a class method — so the #2571 synthetic-`this`
+state-struct model transferred directly and the closure trampoline carries the
+`$GenState` ref result through unchanged (the earlier `__current_this`-only
+framing was about the trampoline; the underlying body func has the struct param).
+
+### Changes
+
+- **`generators-native.ts`** — the candidate-gate bail
+  `!ts.isClassLike(decl.parent)` widened to also admit
+  `ts.isObjectLiteralExpression(decl.parent)`. Other MethodDeclaration contexts
+  still bail to host. The gate stays the single source of truth (registration +
+  `sourceNeedsGeneratorHostImports` agree).
+- **`literals.ts`** — at the object-literal method collection site: register the
+  native generator when `(standalone||wasi) && !async && candidate`, keyed by the
+  per-literal func identity (`${fullName}__lit${forkIdx}` when a
+  `literalMethodFuncIdx` fork exists, else `fullName`, so forked sibling literals
+  get distinct `$GenState`s), pass `methodParams` (already leads with `this`) +
+  `synthesizedThis = true`, and set the method result type to the `$GenState_*`
+  ref. The generator-method body emit routes through
+  `compileNativeGeneratorFunction` (host eager-buffer is the `else`). The fctx
+  returnType derives from `methodResults`, so it tracks automatically.
+
+### Bail-outs (host path, valid Wasm, no regression)
+
+Capturing / `arguments` / `super` method generators bail via the existing
+`isNativeGeneratorCandidate` guards. Two **same-name same-shape** object literals
+dedup to one method func (last body wins) — the PRE-EXISTING object-literal method
+dedup, identical for non-generators (verified on clean main: `{m(){return 100}}`
++ `{m(){return 200}}` → both 200). Distinct-named generators each get their own
+state machine (verified 100200).
+
+### Verified
+
+`tests/issue-2581-objlit-method-generators.test.ts` (12): simple/this/this+param/
+multi-yield/done/lazy native (zero `__gen_*` imports); fresh-state per call;
+for-of; distinct-named independence; gen+regular coexistence; capturing bail;
+class+free-fn regression guard. Updated the #2571 objlit test (was asserting the
+now-lifted deferral). tsc + prettier + hard-error + IR-fallback gates clean; 40
+generator/class regression tests pass. JS-host (gc) byte-identical
+(`(standalone||wasi)`-gated). Broad-impact → merge_group is the authoritative
+full-standalone-shard validator.

--- a/plan/issues/2581-objlit-method-generators-native.md
+++ b/plan/issues/2581-objlit-method-generators-native.md
@@ -203,3 +203,24 @@ now-lifted deferral). tsc + prettier + hard-error + IR-fallback gates clean; 40
 generator/class regression tests pass. JS-host (gc) byte-identical
 (`(standalone||wasi)`-gated). Broad-impact → merge_group is the authoritative
 full-standalone-shard validator.
+
+## Merge-queue ejection + fix (2026-06-21, sd-2)
+
+PR #1873 ejected from the merge_group on "test262 standalone shard 54" — a REAL
+regression (branch was 0 commits behind origin/main; not stale-base drift).
+
+Root cause: an object-literal generator method with a **default/optional param**
+(`{ *m(d = 5){ yield d } }`) returned the WRONG value (`o.m()` → 0 instead of 5).
+Object-literal methods are invoked through the closure trampoline
+(`emitObjectMethodAsClosure`), which forwards args but does NOT set the
+`__argc_default` global the param-default check reads — so the native factory read
+the un-defaulted sentinel. The CLASS path is unaffected (class methods are called
+directly, argc set), which is why #2571 didn't hit this.
+
+Fix: `isNativeGeneratorCandidate` bails an object-literal generator method with any
+`param.initializer || param.questionToken` to the host eager-buffer path (which
+applies defaults correctly). A strictly-narrowing bail — it can only reduce what
+goes native, never add a regression. The common no-default object-literal
+generator stays native. Class/free generators with defaults stay native
+(unchanged). Regression tests added (default bails to host; explicit-arg stays
+native). Re-validated via chunk54 standalone diff + merge_group.

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -844,15 +844,19 @@ export function isNativeGeneratorCandidate(ctx: CodegenContext, decl: GeneratorD
   // method threads cleanly through the funcMap key. A FunctionDeclaration name
   // is always an Identifier.
   if (ts.isMethodDeclaration(decl) && !ts.isIdentifier(decl.name)) return false;
-  // (#2571) Only CLASS method generators are routed through the native factory
-  // in this slice (class-bodies.ts). An OBJECT-LITERAL method generator
-  // (`{ *m(){} }`) is lowered via the closures.ts lifted-closure path, which is
-  // NOT yet wired to the native state machine — so it must keep forcing the host
-  // path. Bailing here (the single candidate gate consumed by both
-  // `registerNativeGenerator` AND `sourceNeedsGeneratorHostImports`) keeps the
-  // host imports registered for it, avoiding an undefined-funcidx invalid module.
-  // Object-literal method generators are the documented follow-up.
-  if (ts.isMethodDeclaration(decl) && !ts.isClassLike(decl.parent)) return false;
+  // (#2571/#2581) A method generator is native-routable only when its emit site
+  // is wired to the native factory: CLASS bodies (class-bodies.ts, #2571) and
+  // OBJECT-LITERAL methods (literals.ts, #2581). Both compile the method body as
+  // a func whose param 0 is the receiver `this` (a `ref $struct`), so the
+  // synthetic-`this` state-struct model applies uniformly. Any OTHER
+  // MethodDeclaration context (e.g. a TS interface/type member, or a shape the
+  // emit paths don't cover) keeps the host path — bailing here (the single
+  // candidate gate consumed by both `registerNativeGenerator` AND
+  // `sourceNeedsGeneratorHostImports`) keeps the host imports registered,
+  // avoiding an undefined-funcidx invalid module.
+  if (ts.isMethodDeclaration(decl) && !ts.isClassLike(decl.parent) && !ts.isObjectLiteralExpression(decl.parent)) {
+    return false;
+  }
   const modifiers = ts.canHaveModifiers(decl) ? ts.getModifiers(decl) : undefined;
   if (modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword || m.kind === ts.SyntaxKind.DeclareKeyword)) {
     return false;

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -864,6 +864,19 @@ export function isNativeGeneratorCandidate(ctx: CodegenContext, decl: GeneratorD
   for (const param of decl.parameters) {
     if (param.dotDotDotToken || !ts.isIdentifier(param.name)) return false;
   }
+  // (#2581) An OBJECT-LITERAL generator method with a DEFAULT or OPTIONAL param
+  // must bail to the host path. Object-literal methods are invoked through the
+  // closure trampoline (`emitObjectMethodAsClosure`), which forwards args but
+  // does NOT set the `__argc_default` global the param-default check reads — so
+  // the native factory would read the un-defaulted sentinel and yield the wrong
+  // value (`{ *m(d=5){yield d} }.m()` → 0 instead of 5). Class methods are called
+  // directly (argc set), so they keep defaults native. The eager-buffer host path
+  // applies defaults correctly for the object-literal case, so route there.
+  if (ts.isMethodDeclaration(decl) && ts.isObjectLiteralExpression(decl.parent)) {
+    for (const param of decl.parameters) {
+      if (param.initializer || param.questionToken) return false;
+    }
+  }
   // (#2571) A method generator that reads `arguments`, uses `super.*`, or
   // CAPTURES an enclosing-function binding (#2203) has no native state-machine
   // support: the eager-buffer path builds the arguments vec / closure, while the

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -50,7 +50,13 @@ import {
   resolveWasmType,
 } from "./index.js";
 import { ensureExnTag, nextModuleGlobalIdx } from "./registry/imports.js";
-import { emitNativeGeneratorToVec, nativeGeneratorInfoForForOfSubject } from "./generators-native.js";
+import {
+  compileNativeGeneratorFunction,
+  emitNativeGeneratorToVec,
+  isNativeGeneratorCandidate,
+  nativeGeneratorInfoForForOfSubject,
+  registerNativeGenerator,
+} from "./generators-native.js";
 import { emitCollectionIteratorVec } from "./map-runtime.js";
 import { emitSymbolDescStore } from "./symbol-native.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
@@ -2385,8 +2391,40 @@ export function compileObjectLiteralForStruct(
       if (isAsyncMethod && retType) {
         retType = unwrapPromiseType(retType, ctx.checker);
       }
+      // (#2581) In a no-JS-host target, a native-capable object-literal
+      // generator method returns its `$GenState_*` struct (the lazy native state
+      // machine), NOT the eager-buffer externref Generator object. Register it
+      // here so the state-struct type exists and the method's wasm signature
+      // carries the right result type (mirrors class-bodies.ts #2571 + the
+      // free-function path declarations.ts:2499). `methodParams` already leads
+      // with the receiver `this` (`ref structTypeIdx`), so pass it through with
+      // `synthesizedThis = true` to mint `param_this`. The factory emit is routed
+      // in the generator-method body block below. JS-host mode keeps the
+      // externref Generator object (eager-buffer) — byte-identical.
+      let objMethNativeGen = null;
+      if (
+        isGeneratorMethod &&
+        (ctx.standalone || ctx.wasi) &&
+        !isAsyncMethod &&
+        isNativeGeneratorCandidate(ctx, prop)
+      ) {
+        // (#2581) Key the native generator by the SAME identity the method body
+        // func gets, so sibling object literals that share `fullName` but own a
+        // per-literal funcIdx (different bodies → `literalMethodFuncIdx` fork,
+        // #1557) each register a DISTINCT `$GenState` and `.m()` dispatches to
+        // its own state machine. Without the per-literal key, the idempotent
+        // `registerNativeGenerator` returns the FIRST literal's state for every
+        // sibling, so `b.m()` runs `a`'s body (`{*m(){yield 1}}`,`{*m(){yield 2}}`
+        // both yielded 1). A forked literal's body compiles into
+        // `${fullName}__lit${perLiteralIdx}` (see below); mirror that name here.
+        const perLiteralForkIdx = literalMethodFuncIdx.get(methodName);
+        const genKey = perLiteralForkIdx !== undefined ? `${fullName}__lit${perLiteralForkIdx}` : fullName;
+        objMethNativeGen = registerNativeGenerator(ctx, prop, genKey, methodParams, /* synthesizedThis */ true);
+      }
       const methodResults: ValType[] = isGeneratorMethod
-        ? [{ kind: "externref" }]
+        ? objMethNativeGen
+          ? [{ kind: "ref", typeIdx: objMethNativeGen.stateTypeIdx }]
+          : [{ kind: "externref" }]
         : retType && !isVoidType(retType)
           ? [resolveWasmType(ctx, retType)]
           : [];
@@ -2512,7 +2550,16 @@ export function compileObjectLiteralForStruct(
         ); // paramOffset 1 to skip 'this'
       }
 
-      if (isGeneratorMethod && prop.body) {
+      if (isGeneratorMethod && prop.body && objMethNativeGen) {
+        // (#2581) Native lazy object-literal generator method: emit the
+        // state-struct factory (pushes the `$GenState_*` ref) instead of the
+        // eager host buffer. The method body func's param 0 is the receiver
+        // `this` (`ref structTypeIdx`), threaded as `param_this` (#2571). The
+        // `.next()/.return()/.throw()` dispatch on the returned ref is already
+        // representation-agnostic. No host imports — instantiates standalone.
+        compileNativeGeneratorFunction(ctx, methodFctx, prop, objMethNativeGen);
+        methodFctx.body.push({ op: "return" });
+      } else if (isGeneratorMethod && prop.body) {
         // Generator method: eagerly evaluate body, collect yields into a buffer,
         // then wrap with __create_generator to return a Generator-like object.
         // Body is wrapped in try/catch to defer thrown exceptions to first next() (#928).

--- a/tests/issue-2571-native-method-generators.test.ts
+++ b/tests/issue-2571-native-method-generators.test.ts
@@ -127,13 +127,16 @@ export function test(): number { return outer(); }`;
     expect(WebAssembly.validate(binary), "capturing-bail module must still be valid Wasm").toBe(true);
   });
 
-  it("object-literal method generator keeps the host path (out of scope), still valid Wasm", async () => {
+  it("object-literal method generator now lowers natively (#2581 lifted the #2571 deferral)", async () => {
+    // #2571 originally deferred object-literal method generators to the host
+    // path; #2581 wired the literals.ts emit through the native factory (the
+    // object-literal method body func also leads with a `this` struct param), so
+    // they are native now too. Full coverage lives in
+    // tests/issue-2581-objlit-method-generators.test.ts.
     const src = `export function test(): number {
   const o = { *m() { yield 9; } };
   return (o.m().next().value as number);
 }`;
-    const { binary, genImports } = await compileNoHost(src);
-    expect(genImports.length, "object-literal method generator is the documented follow-up").toBeGreaterThan(0);
-    expect(WebAssembly.validate(binary), "object-literal-bail module must still be valid Wasm").toBe(true);
+    expect(await runNative(src)).toBe(9);
   });
 });

--- a/tests/issue-2581-objlit-method-generators.test.ts
+++ b/tests/issue-2581-objlit-method-generators.test.ts
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2581 — native OBJECT-LITERAL generator methods in a no-JS-host target.
+ *
+ * Follow-up to #2571 (which landed native CLASS generator methods). Before this
+ * slice, an object-literal generator method (`const o = { *m(){ yield … } }`)
+ * still imported the eager-buffer host runtime (`__gen_create_buffer` /
+ * `__create_generator` / …) and could not instantiate standalone — #2571
+ * deferred it because object-literal methods lower through a different
+ * (lifted-closure) emit path.
+ *
+ * The enabling observation: the object-literal method body func ALSO leads with
+ * a `this` struct param (`methodFctxParams[0] = (ref $struct)`, literals.ts), so
+ * the #2571 synthetic-`this` state-struct model applies uniformly. Wiring the
+ * literals.ts generator-method emit through `compileNativeGeneratorFunction`
+ * (and lifting the object-literal arm of the candidate-gate bail) makes them
+ * native — the closure trampoline carries the `$GenState` ref result through.
+ *
+ * Asserts: ZERO `__gen_*` host imports, instantiates with an EMPTY import
+ * object, correct values + laziness. Capturing / `arguments` / `super` object-
+ * literal method generators keep the host bail (valid Wasm, no regression).
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const HOST_GEN_RE = /^(__gen_|__create_generator|__create_async_generator)/;
+
+async function compileNoHost(src: string): Promise<{ binary: Uint8Array; genImports: string[] }> {
+  const r = await compile(src, { fileName: "test.ts", target: "wasi" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const genImports = WebAssembly.Module.imports(mod)
+    .filter((i) => HOST_GEN_RE.test(i.name))
+    .map((i) => `${i.module}::${i.name}`);
+  return { binary: r.binary, genImports };
+}
+
+async function runNative(src: string): Promise<number> {
+  const { binary, genImports } = await compileNoHost(src);
+  expect(genImports, "native object-literal method generator must emit NO __gen_* host import").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2581 native object-literal generator methods (no-JS-host target)", () => {
+  it("simple object-literal method generator: o.m().next().value === 9, no host imports", async () => {
+    const src = `export function test(): number {
+  const o = { *m() { yield 9; } };
+  return (o.m().next().value as number);
+}`;
+    expect(await runNative(src)).toBe(9);
+  });
+
+  it("object-literal method generator reading this: yields this.x", async () => {
+    const src = `export function test(): number {
+  const o = { x: 7, *m() { yield this.x; } };
+  return (o.m().next().value as number);
+}`;
+    expect(await runNative(src)).toBe(7);
+  });
+
+  it("this AND a user param", async () => {
+    const src = `export function test(): number {
+  const o = { x: 10, *m(d: number) { yield this.x + d; } };
+  return (o.m(5).next().value as number);
+}`;
+    expect(await runNative(src)).toBe(15);
+  });
+
+  it("multiple yields stream in order", async () => {
+    const src = `export function test(): number {
+  const o = { *m() { yield 1; yield 2; yield 3; } };
+  const it = o.m();
+  return (it.next().value as number) * 100 + (it.next().value as number) * 10 + (it.next().value as number);
+}`;
+    expect(await runNative(src)).toBe(123);
+  });
+
+  it("done flag after the last yield", async () => {
+    const src = `export function test(): number {
+  const o = { *m() { yield 7; } };
+  const it = o.m();
+  it.next();
+  return it.next().done ? 1 : 0;
+}`;
+    expect(await runNative(src)).toBe(1);
+  });
+
+  it("lazy: the body does not run until the first .next()", async () => {
+    const src = `let ran = 0;
+export function test(): number {
+  const o = { *m() { ran = 1; yield 1; } };
+  const it = o.m();
+  const before = ran;
+  it.next();
+  return before * 10 + ran;
+}`;
+    expect(await runNative(src)).toBe(1);
+  });
+
+  it("each o.m() call produces a FRESH generator state", async () => {
+    const src = `export function test(): number {
+  const o = { *m() { yield 1; yield 2; } };
+  const a = o.m();
+  const b = o.m();
+  a.next();
+  return (a.next().value as number) * 10 + (b.next().value as number);
+}`;
+    // a advanced twice (→2), b advanced once (→1): 2*10 + 1 = 21
+    expect(await runNative(src)).toBe(21);
+  });
+
+  it("for-of drives the object-literal generator", async () => {
+    const src = `export function test(): number {
+  const o = { *m() { yield 1; yield 2; yield 3; } };
+  let s = 0;
+  for (const x of o.m()) s += x;
+  return s;
+}`;
+    expect(await runNative(src)).toBe(6);
+  });
+
+  it("distinct-named object-literal generators each register their own state machine", async () => {
+    // Two object literals with DIFFERENT method names → distinct method funcs +
+    // distinct `$GenState` registrations (a same-NAME same-shape pair would
+    // dedup to one method func — the pre-existing object-literal method dedup,
+    // identical for non-generators — so use distinct names to exercise two
+    // independent native generators).
+    const src = `export function test(): number {
+  const a = { *first() { yield 100; } };
+  const b = { *second() { yield 200; } };
+  return (a.first().next().value as number) * 1000 + (b.second().next().value as number);
+}`;
+    expect(await runNative(src)).toBe(100200);
+  });
+
+  it("a generator method coexists with a regular method on the same object", async () => {
+    const src = `export function test(): number {
+  const o = { v: 5, *gen() { yield this.v; }, plain() { return this.v + 1; } };
+  return (o.gen().next().value as number) * 10 + o.plain();
+}`;
+    expect(await runNative(src)).toBe(56);
+  });
+
+  it("capturing object-literal method generator BAILS to host cleanly (valid module)", async () => {
+    const src = `function outer(): number {
+  let cap = 3;
+  const o = { *m() { yield cap; } };
+  return (o.m().next().value as number);
+}
+export function test(): number { return outer(); }`;
+    const { binary, genImports } = await compileNoHost(src);
+    expect(genImports.length, "capturing objlit method generator keeps the host path").toBeGreaterThan(0);
+    expect(WebAssembly.validate(binary), "capturing-bail module must still be valid Wasm").toBe(true);
+  });
+
+  it("class + free function* generators stay native (regression guard)", async () => {
+    expect(
+      await runNative(`class C { *m() { yield 42; } }
+export function test(): number { return (new C().m().next().value as number); }`),
+    ).toBe(42);
+    expect(
+      await runNative(`function* g() { yield 5; }
+export function test(): number { return (g().next().value as number); }`),
+    ).toBe(5);
+  });
+});

--- a/tests/issue-2581-objlit-method-generators.test.ts
+++ b/tests/issue-2581-objlit-method-generators.test.ts
@@ -142,6 +142,30 @@ export function test(): number {
     expect(await runNative(src)).toBe(56);
   });
 
+  it("default/optional-param object-literal generator method BAILS to host (closure-trampoline argc gap)", async () => {
+    // (#2581 eject fix) Object-literal methods are invoked through the closure
+    // trampoline, which does not set the `__argc_default` global the param-default
+    // check reads — so the native factory would yield the wrong value
+    // (`{ *m(d=5){yield d} }.m()` → 0 instead of 5). These bail to the host path
+    // (valid module, host imports) where defaults apply correctly. A class method
+    // generator with a default stays native (called directly, argc set).
+    const src = `export function test(): number {
+  const o = { *m(d: number = 5) { yield d; } };
+  return (o.m().next().value as number);
+}`;
+    const { binary, genImports } = await compileNoHost(src);
+    expect(genImports.length, "default-param objlit generator must bail to host").toBeGreaterThan(0);
+    expect(WebAssembly.validate(binary), "default-param bail module must be valid Wasm").toBe(true);
+  });
+
+  it("explicit-arg (no default) object-literal generator method stays native", async () => {
+    const src = `export function test(): number {
+  const o = { *m(d: number) { yield d; } };
+  return (o.m(5).next().value as number);
+}`;
+    expect(await runNative(src)).toBe(5);
+  });
+
   it("capturing object-literal method generator BAILS to host cleanly (valid module)", async () => {
     const src = `function outer(): number {
   let cap = 3;


### PR DESCRIPTION
## #2581 — native object-literal generator methods (standalone / wasi)

Follow-up to #2571 (class method generators, landed in PR #1872). An object-literal generator method (`const o = { *m(){ yield … } }`) still imported the eager-buffer host runtime (`__gen_create_buffer` / `__create_generator` / …) and could not instantiate standalone.

### Fix — the body func already has `this` as a struct param

The key enabler: the object-literal method **body func also leads with a `this` struct param** (`methodFctxParams[0] = (ref structTypeIdx)`, literals.ts), structurally identical to a class method. So the #2571 synthetic-`this` state-struct model transferred directly, and the closure trampoline carries the `$GenState` ref result through unchanged. (The earlier `__current_this`-only framing in the issue was about the *trampoline*; the underlying body func has the struct param.)

- **`generators-native.ts`** — widen the candidate-gate bail to also admit `ts.isObjectLiteralExpression(decl.parent)`. Other MethodDeclaration contexts still bail to host. The gate stays the single source of truth (registration + `sourceNeedsGeneratorHostImports` agree).
- **`literals.ts`** — at the object-literal method collection site, register the native generator when `(standalone||wasi) && !async && candidate`, keyed by the per-literal func identity (`${fullName}__lit${forkIdx}` when a `literalMethodFuncIdx` fork exists, else `fullName`, so forked sibling literals get distinct `$GenState`s), pass `methodParams` (already leads with `this`) + `synthesizedThis = true`, set the method result type to the `$GenState_*` ref, and route the body emit through `compileNativeGeneratorFunction` (host eager-buffer is the `else`).

All guards `(standalone||wasi)`-gated → **JS-host (gc) byte-identical**.

### Bail-outs (host path, valid Wasm, no regression)

Capturing / `arguments` / `super` method generators bail via the existing candidate guards. Two **same-name same-shape** object literals dedup to one method func (last body wins) — the pre-existing object-literal method dedup, identical for non-generators. Distinct-named generators each get their own state machine.

### Tests

`tests/issue-2581-objlit-method-generators.test.ts` (12): simple / this / this+param / multi-yield / done / **lazy** native (zero `__gen_*` imports); fresh-state per call; for-of; distinct-named independence; gen+regular coexistence; capturing bail; class+free-fn regression guard. Updated the #2571 objlit test (was asserting the now-lifted deferral). tsc + prettier + hard-error + IR-fallback gates clean; 40 generator/class regression tests pass.

Broad-impact (generator lowering + host-import gating) → the **merge_group** is the authoritative full-standalone-shard validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA