### PR TITLE
fix(#1712): two root causes of the compiled-acorn tokenizer identity loop

### DIFF
--- a/plan/issues/1712-acorn-acceptance-differential-ast.md
+++ b/plan/issues/1712-acorn-acceptance-differential-ast.md
@@ -3,7 +3,7 @@ id: 1712
 title: "acceptance: compiled acorn parses a representative .js with AST structurally equal to node-acorn"
 status: in-progress
 created: 2026-05-29
-updated: 2026-06-11
+updated: 2026-06-21
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -442,3 +442,88 @@ have the same identity/equality defect). Next slice: make all dynamic
 read paths return ONE canonical representation per struct (always raw, or
 always cached proxy) before values re-enter Wasm, and check the strict-
 equality lowering for externref operands unwraps proxies on both sides.
+
+### Identity-loop slice 2026-06-21 (issue-1712-acorn-identity, sd-acorn) — TWO root causes fixed, branch PR pending
+
+The pinned "token-object identity" framing was confirmed empirically AND
+shown to be only HALF the story. Reproduced via a fast cached-binary probe
+(`.tmp/run-acorn.mjs` + a `host_eq` call-counter/watchdog in `host_eq`) and
+bisected to TWO **independent** compiler defects, each narrowed to a minimal
+isolated repro that reproduces the acorn loop. Both fixed on the branch:
+
+**BUG 1 — dynamic-method struct-field write never reaches the WasmGC field
+(`src/runtime.ts` `_safeSet`).** A `this.field = v` inside a method body
+compiled through the host bridge (`__extern_set` / `__extern_set_strict`)
+called `_safeSet(obj, key, val, /*exports*/ undefined, callbackState, …)` —
+i.e. it passed `callbackState`, NOT the `exports` param. But `_safeSet`'s
+`__sset_<key>` struct-field writeback was gated on the `exports` PARAM only,
+so the writeback was SKIPPED and the value landed in the SIDECAR ONLY. A
+later *static* `struct.get` read — the compiled member-access path takes the
+guarded-cast struct branch whenever the receiver ref-tests as the struct type
+(every fnctor-instance method body reading `this.field`) — bypasses the
+sidecar and reads the raw WasmGC field, which still held its **initializer**
+value. So a method write was invisible to a struct-typed read of the same
+field. THIS is the real "two reads disagree" identity defect (not merely
+proxy-vs-raw). Minimal repro: a function-constructor `Box` with proto methods
+`store(v){this.t=v}` / `load(){return this.t}`, then `b.store(T); b.load() ===
+T` returned `false` (`load()` read the stale ctor-init `this.t`). Acorn shape:
+`this.type = types$1.eof` (write) vs `this.type !== types$1.eof` (guard read)
+→ guard never tripped → infinite loop.
+Fix: resolve exports from `callbackState` as a fallback for the `__sset_`
+writeback, AND `_unwrapForHost(val)` before the struct-field store so a
+proxy-wrapped method ARG (host-bridge arg marshaling wraps struct args) is
+stored as the RAW struct, keeping typed `ref.eq` reads identity-correct.
+Also hardened `_hostEqComparableValue` to unwrap `_wrapForHost` proxies (the
+originally-pinned proxy-vs-raw case — real, just not sufficient alone).
+Verified: minimal `methodRoundTrip` 0→1; acorn-shape identity probe
+(module-global TokenType object + fnctor Parser + `this.type` guard loop)
+infinite-loop → terminates correct.
+
+**BUG 2 — `any`-receiver `String.prototype.replace` mis-dispatches to a DOM
+extern class and drops the replacement arg (`src/codegen/expressions/
+calls-closures.ts` `tryExternClassMethodOnAny`).** On an `any`/untyped
+receiver, `value.replace(/re/g, "rep")` was first-matched against the FIRST
+registered extern class with a `replace` method — `CSSStyleSheet.replace(text)`
+(one user arg → the replacement string was emitted then immediately `drop`ped,
+so host `replace` ran with `undefined`: `"a b".replace(/ /, "|")` →
+`"aundefinedb"`), and after the arg-count guard, `DOMTokenList.replace(a,b)`
+(returns boolean → `"^(?:false)$"`). This silently broke acorn's
+`wordsRegexp(words){ return new RegExp("^(?:"+words.replace(/ /g,"|")+")$") }`:
+keyword recognition failed (`this.keywords.test("var")` false), so `readWord`
+finished `var` as token `name` instead of `_var`, every statement
+mis-tokenized, and the tokenizer looped forever (the "every statement parses
+as ExpressionStatement / isLet truthiness" symptom noted above). Confirmed via
+`finishToken` call-counter: `readWord("var")` → `finishToken(name)`.
+Fix: refuse extern-class dispatch for `replace`/`replaceAll` on an `any`
+receiver (mirrors the existing `.slice` ambiguity refusal) + a general guard
+that refuses any candidate whose user-arity is LESS than the call's arg count
+(dropping a real arg is never correct). The call then falls through to the
+generic `__extern_method_call` host path, which forwards ALL args to the real
+`String.prototype.replace`. Verified: `anyReplace`/`wordsRegexp`-shape probes
+and the keyword-classification probes all green.
+
+**Regression check:** no new failures from either fix. Scoped suites run on
+the branch: regex/replace (`issue-1539-*`, 209 pass), `issue-1712-dynamic-
+dispatch`, `issue-1712-ifelse-global-shift`, `issue-2192b-*` all pass. The
+failures observed in `prototype-chain.test.ts` (6), `externref.test.ts` (5,
+`Host_*` missing-import), `string-methods.test.ts` (`./helpers.js` load error),
+and `issue-1712-capture-closure-dispatch.test.ts` (1, `__call_fn_1` arity-0)
+were each verified to fail IDENTICALLY on `origin/main` (revert-test-restore) —
+pre-existing container/test-infra issues, NOT regressions from this branch.
+
+**acorn status after this slice: the tokenizer identity loop is GONE.** acorn
+now executes far past the loop — into module-init `buildUnicodeData` →
+`wordsRegexp(...)`. A THIRD, independent blocker surfaces there (not yet
+fixed): `wordsRegexp(unicodeBinaryPropertiesOfStrings[ecmaVersion])` throws
+`Cannot read properties of null (reading 'replace')` — the receiver is `null`
+where real JS reads `""`. The value comes from a module-level object literal
+with numeric keys (`{ 9: "", 10: "", … }`) read by a dynamic numeric key
+inside a `data[ecmaVersion] = { …: wordsRegexp(obj[k]), … }` assignment-as-
+expression. Minimal probes of `obj[numKey]`, empty-string args, and the
+nested-object-literal shape ALL pass in isolation, so the trigger is more
+specific (likely the module-global-object + assignment-expression + nested
+`wordsRegexp` interaction, or a cross-module-global reference
+`unicodeBinaryPropertiesOfStrings[14] = ecma14BinaryPropertiesOfStrings`).
+This is a fresh investigation — a separate slice from the identity loop this
+branch closes. The #1712 acceptance test (`tests/issue-1712.test.ts`) stays
+`it.skip` until the module-init chain clears.

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -894,6 +894,23 @@ export function tryExternClassMethodOnAny(
   // keep the historical first-match behavior.
   if (methodName === "slice") return null;
 
+  // (#1712) `replace` / `replaceAll` are core String.prototype methods, but
+  // SEVERAL DOM extern classes also declare a `replace` (CSSStyleSheet.replace
+  // takes one arg, DOMTokenList.replace takes two and returns a boolean). When
+  // a RegExp literal or other DOM type elsewhere in the module registers those
+  // extern classes, first-match iteration binds an `any`-typed receiver's
+  // `value.replace(search, replacement)` to one of them — silently dropping or
+  // mis-typing the replacement. The concrete acorn failure: `wordsRegexp(words)
+  // { return new RegExp("^(?:" + words.replace(/ /g, "|") + ")$") }` produced
+  // `^(?:varundefinedreturn…)$` (CSSStyleSheet.replace, replacement dropped) or
+  // `^(?:false)$` (DOMTokenList.replace, boolean result) instead of
+  // `^(?:var|return|…)$`, so keyword recognition failed and the tokenizer
+  // looped forever (#1712 dogfood). On an `any` receiver in untyped JS these
+  // are overwhelmingly String operations; refuse extern-class dispatch and let
+  // the generic `__extern_method_call` host path forward all args to the real
+  // `String.prototype.replace`. Mirrors the `.slice` ambiguity refusal above.
+  if (methodName === "replace" || methodName === "replaceAll") return null;
+
   // (#1283) The dispatch below emits `externref` hints for every arg and
   // assumes the call's params are all-externref. When iterating in
   // insertion order we may otherwise hit an extern class whose method has a
@@ -922,6 +939,26 @@ export function tryExternClassMethodOnAny(
     const sig = info.methods.get(methodName);
     if (!sig) continue;
     if (!isAllExternrefParams(sig)) continue;
+
+    // (#1712) Never bind a candidate that would DROP arguments the call
+    // actually provided. `sig.params` includes `self`, so the method's
+    // user-visible arity is `params.length - 1`; if the call passes MORE
+    // args than that, the loop below silently `drop`s the extras — which is
+    // never the right semantics for a name collision. The concrete failure:
+    // an `any`-typed receiver's `value.replace(/re/g, "rep")` first-matched
+    // `CSSStyleSheet.prototype.replace(text)` (one user arg), so the
+    // replacement string was emitted then immediately dropped and the host
+    // `replace` ran with `undefined` as the replacement (`"a b".replace(/ /,
+    // "|")` → `"aundefinedb"`). This silently broke acorn's
+    // `wordsRegexp(words){ return new RegExp("^(?:"+words.replace(/ /g,"|")+
+    // ")$") }` — keyword recognition failed (`varundefinedreturn…`), so every
+    // identifier mis-tokenized as `name` and the tokenizer looped forever
+    // (#1712 acorn dogfood). Refusing here lets the call fall through to the
+    // generic `__extern_method_call` host dispatch, which forwards ALL args to
+    // the correct `String.prototype.replace`. Mirrors the `.slice` refusal
+    // above (ambiguous String/Array/DOM method names on an `any` receiver).
+    const userArity = sig.params.length - 1;
+    if (expr.arguments.length > userArity) continue;
 
     const importName = `${info.importPrefix}_${methodName}`;
     let funcIdx = ctx.funcMap.get(importName);

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1727,6 +1727,21 @@ function _hostEqComparableValue(v: any): any {
   if (typeof v === "function") {
     return _wasmClosureWrapperTargets.get(v as Function) ?? v;
   }
+  // (#1712) Canonicalize a `_wrapForHost` proxy back to its underlying raw
+  // WasmGC struct before the reference compare. The two dynamic read paths
+  // that feed `===`/`!==` disagree on representation: an instance-field read
+  // (`this.type`) returns the raw struct, while a module-global + property
+  // read (`types$1.eof`) returns the cached host proxy for the SAME struct
+  // (the proxy is identity-stable per struct via `_hostProxyCache`). Without
+  // this unwrap `proxy === rawStruct` is `false` even though both denote one
+  // object — which is exactly why acorn's `parseTopLevel` guard
+  // `this.type !== types$1.eof` never tripped and the tokenizer looped forever.
+  // `_unwrapForHost` maps any host proxy to its unique struct (1:1 via
+  // `_hostProxyReverse`) and passes a non-proxy through unchanged, so two
+  // genuinely distinct structs still compare unequal.
+  if (v != null && typeof v === "object") {
+    return _unwrapForHost(v);
+  }
   return v;
 }
 
@@ -3915,11 +3930,33 @@ function _safeSet(
     // Falls back silently when the export is missing or doesn't match the
     // struct's runtime type — sidecar still carries the value so host-side
     // reads (Object.keys, JSON.stringify, dynamic-key reads) keep working.
-    if (typeof key === "string" && exports) {
-      const setter = exports[`__sset_${key}`];
+    //
+    // (#1712) Resolve exports from `callbackState` when the `exports` param is
+    // absent. The `__extern_set` / `__extern_set_strict` host bindings pass
+    // `callbackState` (not `exports`), so without this fallback the `__sset_`
+    // writeback was skipped and the value landed in the SIDECAR ONLY. A later
+    // *static* `struct.get` read (the compiled member-access path takes the
+    // guarded-cast struct branch whenever the receiver ref-tests as the struct
+    // type — e.g. an fnctor instance method body reading `this.field`) bypasses
+    // the sidecar and reads the raw WasmGC field, which still held its
+    // initializer value. That split made a dynamic-method write (`this.t = v`)
+    // invisible to a struct-typed read of the same field — the identity defect
+    // behind acorn's `this.type = types$1.eof` / `this.type !== types$1.eof`
+    // tokenizer loop (#1712): the write reached only the sidecar while the
+    // guard read the stale struct field, so the guard never tripped.
+    const ssetExports = exports ?? callbackState?.getExports();
+    if (typeof key === "string" && ssetExports) {
+      const setter = ssetExports[`__sset_${key}`];
       if (typeof setter === "function") {
         try {
-          setter(obj, val);
+          // (#1712) Store the RAW WasmGC struct in the field, never a
+          // `_wrapForHost` proxy. A method-call argument that is itself a
+          // struct arrives here proxy-wrapped (host-bridge arg marshaling);
+          // writing the proxy into the `externref` field would make a later
+          // *typed* `ref.eq` read compare unequal to the original struct. The
+          // proxy is a pure host-side view — `_unwrapForHost` recovers the
+          // canonical struct (1:1) and passes a non-proxy through unchanged.
+          setter(obj, _unwrapForHost(val));
         } catch {
           /* not a field of this struct's runtime type */
         }

--- a/tests/issue-1712-tokenizer-identity.test.ts
+++ b/tests/issue-1712-tokenizer-identity.test.ts
@@ -1,0 +1,134 @@
+// #1712 — the two root causes behind compiled acorn's tokenizer identity loop.
+// acorn's `parseTopLevel` guard `this.type !== types$1.eof` never tripped, so
+// the parser looped forever. Bisected to two INDEPENDENT compiler defects, both
+// pinned here with minimal repros that mirror acorn's exact shapes:
+//
+// BUG 1 — dynamic-method struct-field write never reached the WasmGC field.
+//   A `this.field = v` inside a fnctor-instance method body went through the
+//   host bridge (__extern_set_strict → _safeSet), which writes the SIDECAR but
+//   gated the `__sset_<field>` struct-field writeback on the `exports` PARAM —
+//   absent on that path (only `callbackState` is passed). A later STATIC
+//   `struct.get` read (the guarded-cast struct branch the compiler takes when
+//   the receiver ref-tests as the struct type) bypasses the sidecar and reads
+//   the raw field, still holding its initializer. So a method write was
+//   invisible to a struct-typed read — acorn's `this.type = types.eof` (write)
+//   vs `this.type !== types.eof` (guard read) disagreed forever.
+//
+// BUG 2 — `any`-receiver String.prototype.replace mis-dispatched to a DOM
+//   extern class and DROPPED the replacement arg. `value.replace(/re/g, "rep")`
+//   on an untyped receiver first-matched CSSStyleSheet.replace(text) (one arg →
+//   replacement dropped → host ran replace with `undefined`) or
+//   DOMTokenList.replace(a,b) (returns boolean). This broke acorn's
+//   `wordsRegexp(words){ return new RegExp("^(?:"+words.replace(/ /g,"|")+")$") }`
+//   so keyword recognition failed and every token mis-classified as `name`.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+
+async function run(src: string): Promise<any> {
+  const result: any = await compile(src, { fileName: "probe.mjs" });
+  expect(result.success).toBe(true);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  return wrapExports(instance.exports, { signatures: result.exportSignatures });
+}
+
+describe("#1712 — compiled-acorn tokenizer identity loop root causes", () => {
+  it("BUG1: struct value written through a method is read back identical (==)", async () => {
+    // Mirrors acorn's `finishToken(type){ this.type = type }` write +
+    // `parseTopLevel` read of `this.type` compared against `types.eof`.
+    const exp = await run(`
+      // @ts-nocheck
+      var TokenType = function TokenType(label) { this.label = label; };
+      var types = { eof: new TokenType("eof"), name: new TokenType("name") };
+      var Box = function Box() { this.t = types.name; };
+      var bp = Box.prototype;
+      bp.store = function (v) { this.t = v; };
+      bp.load = function () { return this.t; };
+      export function roundTrip() {
+        var b = new Box();
+        b.store(types.eof);
+        return b.load() === types.eof ? 1 : 0; // identity preserved -> 1
+      }
+    `);
+    expect(exp.roundTrip()).toBe(1);
+  });
+
+  it("BUG1: an acorn-shape this.type guard loop TERMINATES (no infinite loop)", async () => {
+    // The whole tokenizer loop shape in miniature: an fnctor Parser whose
+    // prototype methods set/read `this.type` against a module-global token
+    // table. Before the fix this never terminated.
+    const exp = await run(`
+      // @ts-nocheck
+      var TokenType = function TokenType(label) { this.label = label; };
+      var types = { eof: new TokenType("eof"), name: new TokenType("name") };
+      var Parser = function Parser() { this.type = types.name; this.steps = 0; };
+      var pp = Parser.prototype;
+      pp.finishToken = function (type) { this.type = type; };
+      pp.nextToken = function () {
+        if (this.steps >= 1) { return this.finishToken(types.eof); }
+        return this.finishToken(types.name);
+      };
+      pp.run = function () {
+        while (this.type !== types.eof) {
+          this.steps = this.steps + 1;
+          this.nextToken();
+          if (this.steps > 100) { break; } // hard cap so a real bug is visible
+        }
+        return this.steps;
+      };
+      export function main() { return new Parser().run(); }
+    `);
+    // Oracle: loop runs exactly once (step 1 -> nextToken sets eof -> guard trips).
+    expect(exp.main()).toBe(1);
+  });
+
+  it("BUG2: replace(regex, str) on an `any` receiver keeps the replacement arg", async () => {
+    // A RegExp literal elsewhere registers DOM extern classes (CSSStyleSheet /
+    // DOMTokenList) that also declare `replace`; on an `any` receiver the call
+    // must NOT bind to those and drop the replacement.
+    const exp = await run(`
+      // @ts-nocheck
+      function anyReplace(words) { return words.replace(/ /g, "|"); }
+      export function viaAny() { return anyReplace("a b c"); } // expect "a|b|c"
+    `);
+    expect(exp.viaAny()).toBe("a|b|c");
+  });
+
+  it("BUG2: acorn's wordsRegexp builds the correct alternation pattern", async () => {
+    // The exact acorn construction. Before the fix the source came out as
+    // "^(?:varundefinedreturnundefinedif)$" (replacement dropped) or "^(?:false)$".
+    const exp = await run(`
+      // @ts-nocheck
+      function wordsRegexp(words) {
+        return new RegExp("^(?:" + words.replace(/ /g, "|") + ")$");
+      }
+      export function pattern() { return wordsRegexp("var return if").source; }
+    `);
+    expect(exp.pattern()).toBe("^(?:var|return|if)$");
+  });
+
+  it("BUG2: keyword recognition through an instance-field regex works", async () => {
+    // readWord shape: `if (this.keywords.test(word)) type = keywords[word]`.
+    const exp = await run(`
+      // @ts-nocheck
+      function wordsRegexp(words) {
+        return new RegExp("^(?:" + words.replace(/ /g, "|") + ")$");
+      }
+      var TokenType = function TokenType(label) { this.label = label; };
+      var names = { name: new TokenType("name") };
+      var keywords = {};
+      keywords["var"] = new TokenType("var");
+      var Lexer = function Lexer() { this.keywords = wordsRegexp("var return if"); };
+      var lp = Lexer.prototype;
+      lp.classify = function (word) {
+        var type = names.name;
+        if (this.keywords.test(word)) { type = keywords[word]; }
+        return type.label;
+      };
+      export function classifyVar() { return new Lexer().classify("var"); }
+    `);
+    expect(exp.classifyVar()).toBe("var");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the two independent compiler defects behind compiled-acorn's **tokenizer identity loop** (#1712 dogfood). acorn's `parseTopLevel` guard `this.type !== types$1.eof` never tripped, so the parser looped forever. Bisected with a fast cached-binary probe + a `host_eq` call-counter/watchdog down to TWO root causes, each narrowed to a minimal isolated repro that mirrors acorn's exact shapes.

### BUG 1 — dynamic-method struct-field write never reached the WasmGC field (`src/runtime.ts`)
A `this.field = v` inside an fnctor-instance method body routes through the host bridge (`__extern_set_strict` → `_safeSet`), which passes `callbackState` (not the `exports` param). The `__sset_<field>` struct-field writeback was gated on the `exports` param **only**, so the write landed in the **sidecar only**. A later *static* `struct.get` read (the guarded-cast struct branch the compiler takes when the receiver ref-tests as the struct type — every fnctor method body reading `this.field`) bypasses the sidecar and reads the raw field, still holding its **initializer**. So a method write was invisible to a struct-typed read of the same field — acorn's `this.type = types.eof` (write) vs `this.type !== types.eof` (guard read) disagreed forever.

**Fix:** resolve exports from `callbackState` as a fallback for the `__sset_` writeback, and `_unwrapForHost(val)` before the struct store so a proxy-wrapped method ARG is stored as the raw struct (keeps typed `ref.eq` reads identity-correct). Also hardened `_hostEqComparableValue` to unwrap `_wrapForHost` proxies (the originally-pinned proxy-vs-raw case — real, just not sufficient alone).

### BUG 2 — `any`-receiver `String.prototype.replace` mis-dispatched to a DOM extern class, dropping the replacement (`src/codegen/expressions/calls-closures.ts`)
On an `any`/untyped receiver, `value.replace(/re/g, "rep")` first-matched `CSSStyleSheet.replace(text)` (one user arg → replacement emitted then `drop`ped → host ran `replace` with `undefined`: `"a b".replace(/ /,"|")` → `"aundefinedb"`) or `DOMTokenList.replace(a,b)` (returns boolean → `"^(?:false)$"`). This broke acorn's `wordsRegexp(words){ return new RegExp("^(?:"+words.replace(/ /g,"|")+")$") }` — keyword recognition failed, every token mis-classified as `name`, and the tokenizer looped.

**Fix:** in `tryExternClassMethodOnAny`, refuse `replace`/`replaceAll` on an `any` receiver (mirrors the existing `.slice` ambiguity refusal) + refuse any candidate whose user-arity is **less** than the call's arg count (dropping a real arg is never correct). The call falls through to the generic `__extern_method_call` host path, which forwards all args to the real `String.prototype.replace`.

## Validation
- Regression pin: `tests/issue-1712-tokenizer-identity.test.ts` (5 tests) — method-write/read identity roundtrip, an acorn-shape `this.type` guard loop that now terminates, and the `wordsRegexp` / keyword-recognition path.
- **No regressions.** The `prototype-chain`, `externref` (`Host_*` missing-import), `string-methods` (`./helpers.js` load error), and `issue-1712-capture-closure-dispatch` (`__call_fn_1` arity-0) suite failures were each verified to fail **identically on `origin/main`** (revert-test-restore) — pre-existing container/test-infra issues, not regressions from this branch.

## Scope note
The acorn tokenizer identity loop is now **gone**; execution proceeds past it into module-init `buildUnicodeData`, where a **third** independent blocker (a `null` receiver into `wordsRegexp` from a numeric-keyed object read) surfaces — documented in the issue for a follow-up slice. The #1712 acceptance test stays `it.skip` until that chain clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA