### PR TITLE
plan(s65): file 3 substrate issues with specs (#2583/#2584/#2585)

### DIFF
--- a/plan/issues/2583-any-array-method-brand-dispatch.md
+++ b/plan/issues/2583-any-array-method-brand-dispatch.md
@@ -1,0 +1,232 @@
+---
+id: 2583
+title: "standalone: any-typed array method dispatch (indexOf/etc.) returns undefined — $__vec_base brand arm in __extern_method_call"
+status: ready
+sprint: 65
+created: 2026-06-21
+updated: 2026-06-21
+priority: high
+feasibility: hard
+reasoning_effort: high
+model: opus
+task_type: bugfix
+area: codegen, runtime
+language_feature: arrays, method dispatch, any-typed receivers
+goal: host-independence
+related: [1888, 2151, 1461, 2186]
+origin: "2026-06-21 — deferred #1888 Slice-4 brand-arm residual, surfaced by sdev-strdispatch during s64 value-rep keystone work; #1888 itself is done (s61)."
+---
+
+## Problem
+
+Standalone, an array method invoked on a genuinely-`any` receiver returns
+`undefined` (→ `0`/`NaN` in numeric context) instead of running:
+
+```ts
+const a: any = ["x", "y"];
+a.indexOf("y");   // → 0  (expected 1)
+```
+
+Repro confirmed failing on main HEAD (93e53919f), `--target standalone`:
+`a.indexOf("y")` returns `+0`. The same gap affects every non-callback array
+method (`lastIndexOf`, `includes`, `join`, `slice`, `concat`, …) when the
+receiver's static type is `any` so the typed array-method fast path
+(array-methods.ts) is not taken.
+
+### Root cause (WAT-confirmed)
+
+`["x","y"]` typed `any` compiles to a `$__vec_externref` struct (subtyping the
+shared `$__vec_base` supertype) boxed to externref. `a.indexOf("y")` lowers to
+the **closed-method dispatcher** `__call_m_indexOf_1`
+(`src/codegen/closed-method-dispatch.ts`), whose per-struct arms only match
+object-literal structs carrying an `<Struct>_indexOf` method (none exist for a
+plain array). It therefore falls to the **bottom arm**, which forwards to:
+
+```
+__extern_method_call(recv, "indexOf", [args…])
+```
+
+`__extern_method_call` (`src/codegen/object-runtime.ts` ~L5613–5670) handles
+ONLY the open `$Object` brand. Its non-`$Object` `else` arm
+(object-runtime.ts:5660) is:
+
+```ts
+// Non-$Object receiver: brand arms ($Vec/string/Map/Set) are Slice 4;
+// return undefined for now (never invalid Wasm).
+else: [{ op: "ref.null.extern" }],
+```
+
+So a `$__vec_base` array receiver hits `ref.null.extern` → `undefined`. This is
+the explicitly-deferred "#1888 Slice 4" brand-arm residual.
+
+## Implementation Plan
+
+### Approach
+
+Add a `$__vec_base` brand arm to `__extern_method_call` that services the
+non-callback array search/predicate methods by **reusing the existing native
+helpers** the typed array-method path already composes:
+
+- `__extern_length(recv) -> f64` — array length over an externref array
+- `__extern_get_idx(recv, f64) -> externref` — positional element read
+  (already has the `$__vec_base` arm, #2186; returns null out of range)
+- `__extern_strict_eq(a, b) -> i32` — native `===` over two externrefs
+  (`src/codegen/any-helpers.ts:280`, `ensureExternStrictEqHelper`)
+- `__extern_same_value_zero(a, b) -> i32` — native SameValueZero for `includes`
+  (`src/codegen/any-helpers.ts:318`)
+
+This avoids re-deriving search logic and matches the semantics array-methods.ts
+already ships for typed arrays (#1461/#54).
+
+### Scope (Slice 1)
+
+Cover the **argument-taking, callback-free search/predicate methods** that are
+the high-frequency any-array failures and need no closure bridge:
+
+- `indexOf` (§23.1.3.14) — Strict Equality, forward, default fromIndex 0,
+  returns f64 index or -1
+- `lastIndexOf` (§23.1.3.17) — Strict Equality, backward, default fromIndex
+  len-1, returns f64 index or -1
+- `includes` (§23.1.3.13) — SameValueZero, forward, returns boolean
+
+Defer `join`/`slice`/`concat`/`map`/`filter`/`reduce` (callback or
+allocation-producing) to a follow-up slice; note them in a `## Deferred`
+section, do NOT widen Slice 1.
+
+### Changes
+
+**File: `src/codegen/closed-method-dispatch.ts`**
+
+The cleanest insertion point is the dispatcher bottom arm, because the method
+name is statically known there (one dispatcher per method name) and the search
+arm can be specialized per method without a runtime string compare.
+
+- In `fillClosedMethodDispatch` (line ~264), in the **fixed-arity** loop
+  (line ~276), BEFORE building the open-`$Object` fallback `current` (line
+  ~292), check whether `methodName` ∈ {`indexOf`, `lastIndexOf`, `includes`}
+  AND `arity >= 1`. If so, prepend a `$__vec_base` brand arm to `current`:
+
+  ```
+  any = <already set in dispFn.body to local anyLocalIdx>
+  if (ref.test $__vec_base) {
+    v   = ref.cast $__vec_base       ;; the array
+    len = __extern_length(recv)      ;; f64
+    target = local.get 1             ;; the search element (externref arg0)
+    ;; linear scan: i = 0..len-1 (or len-1..0 for lastIndexOf)
+    ;;   eq = (includes ? __extern_same_value_zero : __extern_strict_eq)
+    ;;        (__extern_get_idx(recv, i), target)
+    ;;   if eq → return (includes ? box_boolean(1) : box_number(i))
+    ;; not found → return (includes ? box_boolean(0) : box_number(-1))
+  } else { <existing open-$Object fallback> }
+  ```
+
+  Get `$__vec_base` typeIdx via `getOrRegisterVecBaseType(ctx)` (already
+  imported/used in object-runtime.ts; import it here). Box the f64 result via
+  `__box_number` (already wired through `ci.boxNumIdx`); box the boolean via
+  `__box_boolean` (fetch `ctx.funcMap.get("__box_boolean")`).
+
+- Register the dependencies at **reserve** time, not fill time (the
+  reserve-then-fill #1719 discipline — fill only READS funcMap). In
+  `reserveClosedMethodDispatch` (line ~78), after `ensureObjVecBuilders(ctx)`,
+  when `methodName` is one of the three search methods, also call:
+  - `ensureExternStrictEqHelper(ctx)` (indexOf/lastIndexOf)
+  - `ensureExternSameValueZeroHelper(ctx)` (includes)
+  - ensure `__extern_length` and `__extern_get_idx` are registered
+    (`ensureObjVecBuilders` already pulls `__extern_method_call`; verify it
+    also pulls `__extern_length`/`__extern_get_idx` — if not, add the
+    `ensureLateImport` calls here so the funcIdx is stable before fill).
+  - ensure `__box_boolean` exists (`addUnionImportsViaRegistry(ctx)` if needed,
+    matching the proxy runtime's pattern).
+
+  Import `ensureExternStrictEqHelper` / `ensureExternSameValueZeroHelper` from
+  `./any-helpers.js` and `getOrRegisterVecBaseType` from `./object-runtime.js`
+  (or wherever it is exported — grep confirms object-runtime.ts uses it).
+
+### Wasm IR pattern (indexOf $__vec_base arm)
+
+```wasm
+local.get $any
+ref.test $__vec_base
+(if (result externref)
+  (then
+    ;; len = __extern_length(recv)  (recv is param 0, externref)
+    local.get 0
+    call $__extern_length            ;; f64
+    local.set $len_f64
+    ;; i = 0
+    f64.const 0
+    local.set $i
+    (block $found
+      (loop $scan
+        local.get $i
+        local.get $len_f64
+        f64.ge                       ;; i >= len ?  → exit not-found
+        br_if 1                      ;; break out of block (fall to -1)
+        ;; eq = __extern_strict_eq(__extern_get_idx(recv,i), arg0)
+        local.get 0
+        local.get $i
+        call $__extern_get_idx        ;; externref element
+        local.get 1                   ;; search target (arg0)
+        call $__extern_strict_eq      ;; i32
+        (if
+          (then
+            local.get $i
+            call $__box_number        ;; return externref index
+            return))
+        local.get $i
+        f64.const 1
+        f64.add
+        local.set $i
+        br 0))
+    f64.const -1
+    call $__box_number)              ;; not found → -1
+  (else <existing open-$Object fallback> ))
+```
+
+`lastIndexOf` iterates `i = len-1` down to `0` (decrement, `f64.lt 0` exit).
+`includes` uses `__extern_same_value_zero` and returns `__box_boolean(1)` on
+hit, `__box_boolean(0)` otherwise.
+
+### Edge cases
+
+- **Empty array** → `len = 0`, loop never enters → `indexOf`/`lastIndexOf`
+  return -1, `includes` returns false. Correct.
+- **fromIndex argument** (`indexOf(x, 3)`): Slice 1 dispatches the `arity == 1`
+  dispatcher only. A 2-arg call lands on `__call_m_indexOf_2`, a SEPARATE
+  dispatcher — leave that on the existing fallback for now and note in
+  `## Deferred`. (Do NOT silently ignore arg1.)
+- **NaN search target**: `indexOf(NaN)` must return -1 (Strict Equality,
+  NaN≠NaN — `__extern_strict_eq` already gives this); `includes(NaN)` must
+  return true if present (SameValueZero — `__extern_same_value_zero` gives
+  this). This is exactly why the two helpers are split.
+- **Mixed-type elements** (`[1,"x",true]`): `__extern_get_idx` returns the
+  boxed element; `__extern_strict_eq` recovers tags via `__any_from_extern` and
+  compares with no cross-type coercion. Correct.
+- **`$Object` array-like receiver** (`{0:"x",length:1}` typed any): NOT a
+  `$__vec_base` → falls to the existing open-`$Object` fallback arm unchanged
+  (no regression).
+- **wasi target**: `__extern_get_idx`'s `$Object` array-like delegation arm is
+  standalone-gated (object-runtime.ts), but the `$__vec_base` arm itself is
+  representation-direct. Gate this whole brand arm on `ctx.standalone` to match
+  the surrounding any-method machinery; do not extend to wasi in Slice 1.
+
+### Test plan
+
+Add `tests/issue-2583-any-array-method-brand.test.ts` (standalone harness,
+mirror `tests/issue-2358-array-toprimitive.test.ts`'s `runStandalone`):
+
+- `const a:any=["x","y"]; a.indexOf("y")` → 1
+- `const a:any=["x","y"]; a.indexOf("z")` → -1
+- `const a:any=["x","y","x"]; a.lastIndexOf("x")` → 2
+- `const a:any=[1,2,3]; a.includes(2)` → true
+- `const a:any=[1,2,3]; a.includes(9)` → false
+- `const a:any=[NaN]; a.indexOf(NaN)` → -1 (StrictEq)
+- `const a:any=[NaN]; a.includes(NaN)` → true (SameValueZero)
+- `const a:any=[]; a.indexOf("x")` → -1 (empty)
+- regression: typed `const a:string[]=["x","y"]; a.indexOf("y")` → 1 (still
+  the fast path, unchanged)
+- regression: open-$Object method still dispatches (`const o:any={m(){return 5}};
+  o.m()` → 5)
+
+Scoped local check before PR; CI validates conformance. Expect a positive
+test262 delta in `built-ins/Array/prototype/{indexOf,lastIndexOf,includes}/`.

--- a/plan/issues/2584-dot-vs-bracket-dual-storage.md
+++ b/plan/issues/2584-dot-vs-bracket-dual-storage.md
@@ -1,0 +1,205 @@
+---
+id: 2584
+title: "standalone: dot-assign vs bracket-read dual-storage — widened struct invisible to $Object hash (in/keys/bracket)"
+status: ready
+sprint: 65
+created: 2026-06-21
+updated: 2026-06-21
+priority: high
+feasibility: hard
+reasoning_effort: high
+model: opus
+task_type: bugfix
+area: codegen
+language_feature: object-literals, property model, any-typed receivers
+goal: property-model
+related: [2186, 2372, 2542, 2179]
+origin: "2026-06-21 — surfaced during s64 value-rep keystone work; widened-struct ↔ $Object reconciliation gap."
+---
+
+## Problem
+
+Standalone, an `any`-typed object written via **dot-access** but read via
+**bracket / `in` / Object.keys / getOwnPropertyDescriptor** returns the wrong
+value, because the two sides target different representations of the same
+variable:
+
+```ts
+const o: any = {};
+o.a = 7;
+o["a"];        // → 0   (expected 7)
+"a" in o;      // → false (expected true)
+```
+
+Repro confirmed failing on main HEAD (93e53919f), `--target standalone`.
+
+### The exact asymmetry (measured)
+
+| program                          | result | path                         |
+|----------------------------------|--------|------------------------------|
+| `o.a=7; o.a`                     | 7  ✅  | struct.set → struct.get      |
+| `o["a"]=7; o["a"]`               | 7  ✅  | (bracket-write poisons → $Object) |
+| `o["a"]=7; o.a`                  | 7  ✅  | $Object both sides           |
+| `o.a=7; o["a"]`                  | 0  ❌  | struct.set → __extern_get    |
+| `o.a=7; "a" in o`               | false ❌ | struct.set → $Object `in`   |
+
+The break is NOT "bracket reads are broken." It is: a var written **only via
+dot-access** gets **widened to a closed WasmGC struct**, but the
+`$Object`-hash-runtime consumers (bracket-read, `in`, `Object.keys`,
+`Object.getOwnPropertyDescriptor`, `Object.entries`/`values`) can't see a
+widened struct.
+
+### Root cause (WAT-confirmed)
+
+`const o: any = {}` with later `o.a = 7` triggers the empty-object widening
+pre-pass (`collectEmptyObjectWidening` → `collectPropsFromStatements`,
+`src/codegen/declarations.ts:2008/2128`): it scans the dot-assign, adds `a` as
+a widened property, registers an `__anon_N` struct, and records
+`widenedVarStructMap.set("o", structName)`. So:
+
+- The initializer `{}` lowers via `compileWidenedEmptyObject`
+  (`src/codegen/literals.ts:1499`) → `struct.new <__anon>` (NOT
+  `__new_plain_object`). `$o` is that struct boxed to externref.
+- `o.a = 7` lowers via `compilePropertyAssignment`
+  (`src/codegen/expressions/assignment.ts:2453` — `resolveStructNameForExpr`
+  resolves the widened struct) → `struct.set <__anon> 0`. Write lands in the
+  struct field.
+- `o["a"]` lowers via `compileElementAccessBody`
+  (`src/codegen/property-access.ts:5236`). The receiver `compileExpression(o)`
+  reports **externref** (the var is declared `externref`), so it takes the
+  externref arm (line 5243) → `__extern_get(o, "a")`. `__extern_get`'s
+  `ref.test $Object` does NOT match an `__anon` widened struct → null →
+  `__unbox_number(null)` → 0.
+
+WAT excerpt (`const o:any={}; o.a=7; return o["a"]`):
+```
+f64.const 0 / struct.new 12 / extern.convert_any / local.tee $o   ;; widened struct
+f64.const 7 / struct.set 12 0                                     ;; o.a = 7 → struct
+local.get $o / <build "a"> / call $__extern_get                   ;; o["a"] → $Object miss
+call $__unbox_number                                              ;; null → 0
+```
+
+`in` / `Object.keys` / GOPD all consult the same `$Object` runtime, so they too
+miss the struct.
+
+## Implementation Plan
+
+### Approach — poison widening when a $Object-only consumer is present
+
+The codebase ALREADY has the exact mechanism: `dynamicDescriptorWidenVars`
+(declarations.ts:2042/2188) suppresses widening for a var whose
+`Object.defineProperty` uses a dynamic descriptor, so the var stays a pure
+`$Object` and BOTH write and read route through the native runtime
+consistently. Extend the same poison set to cover the dot-vs-bracket gap.
+
+**Decision: poison (steer to `$Object`), do NOT teach bracket-read to resolve
+the struct field.** Rationale:
+1. `in` / `Object.keys` / `Object.entries` / `getOwnPropertyDescriptor` /
+   `Object.assign` / `for-in` all require the `$Object` hash — there is no
+   struct equivalent for enumeration. Teaching only bracket-read to read the
+   struct would still leave `in`/keys/GOPD broken. One representation (`$Object`)
+   fixes the whole family.
+2. The poison path is proven (#2372) and keeps the receiver consistent across
+   ALL access forms.
+
+### Changes
+
+**File: `src/codegen/declarations.ts`**
+
+Add a new poison set (or reuse `dynamicDescriptorWidenVars` if its name is
+acceptably generalized — prefer a new `objectHashConsumerVars` for clarity) and
+populate it during the same statement scan that drives widening.
+
+- In `collectEmptyObjectWidening` (line ~2008) / a sibling scanner: walk the
+  function body (the same statement tree `collectPropsFromStatements` walks) and
+  mark `varName` poisoned when it appears as the **receiver** of any
+  `$Object`-only operation:
+  - `varName[<expr>]` — an `ElementAccessExpression` whose `.expression` is the
+    var (covers `o["a"]` read AND `o[k]` write — though a bracket-write already
+    routes to `$Object`, marking it is harmless and simplifies the rule).
+  - `<key> in varName` — a `BinaryExpression` with `InKeyword` and `right` =
+    the var.
+  - `Object.keys(varName)`, `Object.entries(varName)`,
+    `Object.values(varName)`, `Object.getOwnPropertyDescriptor(varName, …)`,
+    `Object.getOwnPropertyNames(varName)`, `Object.assign(target, varName)` /
+    `Object.assign(varName, …)`, `for (… in varName)`
+    — `CallExpression` / `ForInStatement` with the var as the relevant arg.
+
+  A focused implementation: add a recursive `markObjectHashConsumers(node,
+  varName, poisonSet)` that walks every descendant expression of the function
+  body and sets the poison flag on the first match. Run it once per widened
+  candidate var alongside `collectPropsFromStatements`.
+
+- At the widening decision point (line ~2042, next to the existing
+  `if (ctx.dynamicDescriptorWidenVars.has(varName)) continue;`), add:
+  ```ts
+  if (ctx.objectHashConsumerVars.has(varName)) continue;
+  ```
+  so the var skips struct registration entirely and stays on the `$Object`
+  representation.
+
+**File: `src/codegen/context/types.ts`** (or wherever `CodegenContext` fields
+live)
+
+- Add `objectHashConsumerVars: Set<string>` and initialize it (mirror
+  `dynamicDescriptorWidenVars`).
+
+### Why this fixes both the read and the write
+
+Once `o` is NOT widened, the empty-`{}` any-context arm
+(literals.ts:944–973) builds it via `__new_plain_object` → a real `$Object`.
+Then `o.a = 7` no longer resolves a struct name (`resolveStructNameForExpr`
+returns undefined) and `compilePropertyAssignment` (assignment.ts:2454) routes
+through `compilePropertyAssignmentExternSet` → `__extern_set(o, "a", box(7))`.
+`o["a"]`, `"a" in o`, `Object.keys(o)` all read the same `$Object` hash →
+consistent.
+
+### Edge cases
+
+- **Var written via dot only, never bracket/in/keys** — NOT poisoned, keeps the
+  struct fast path (byte-identical to main). No regression for the common
+  hot-struct case.
+- **Var used in BOTH dot-write and bracket-read** — poisoned → `$Object`. This
+  is the target fix.
+- **Aliasing** (`const p = o; p["a"]`) — out of scope for Slice 1 (the scanner
+  is name-based, like the existing widening pre-pass). Note in `## Deferred`;
+  the existing widening pre-pass has the same name-based limitation, so this is
+  not a regression.
+- **Numeric bracket index on a dot-written var** (`o.a=7; o[0]`) — `o[0]` is an
+  `ElementAccessExpression` receiver → poisons → `$Object`. Correct (the
+  array-like read then goes through `__extern_get_idx`'s `$Object` arm).
+- **host / wasi modes** — host keeps the struct fast path via the live-mirror
+  Proxy (it reflects struct sidecar reads/writes), so gate the new poison on
+  `ctx.standalone` ONLY (match `dynamicDescriptorWidenVars`'s standalone gate at
+  declarations.ts:2187). wasi is unaffected.
+- **defineProperty interaction** — a var already in `dynamicDescriptorWidenVars`
+  stays poisoned regardless; the two sets are additive.
+
+### Test plan
+
+Add `tests/issue-2584-dual-storage.test.ts` (standalone harness):
+
+- `const o:any={}; o.a=7; return o["a"]` → 7
+- `const o:any={}; o.a=7; return ("a" in o)?1:0` → 1
+- `const o:any={}; o.a=7; o.b=8; const ks=Object.keys(o); return ks.length` → 2
+- `const o:any={}; o.a=7; const d=Object.getOwnPropertyDescriptor(o,"a");
+   return d.value` → 7
+- mixed: `const o:any={}; o.a=7; o["b"]=8; return (o["a"] as number)+(o.b as number)`
+  → 15
+- regression (struct fast path preserved): a dot-only var with NO
+  bracket/in/keys consumer still compiles (assert correct dot-read value;
+  ideally also assert via WAT that it uses struct.new/struct.get, or at minimum
+  that the value round-trips).
+- regression: typed struct var (`const o={a:0}; o.a=7; o.a`) unaffected → 7
+
+Scoped local check before PR; CI validates conformance. Expect positive
+test262 delta across object property-model tests that read via bracket/`in`
+after dot-init.
+
+## Deferred
+
+- Aliased receivers (`const p = o; p[k]`) — name-based scanner limitation,
+  shared with the existing widening pre-pass.
+- A future unification could make a single representation serve both fast struct
+  access and dynamic keys (a struct with an attached overflow `$Object`), but
+  that is a larger property-model redesign; out of scope here.

--- a/plan/issues/2585-proto-identity-object-create.md
+++ b/plan/issues/2585-proto-identity-object-create.md
@@ -1,0 +1,197 @@
+---
+id: 2585
+title: "standalone: getPrototypeOf(Object.create(p)) === p is false — object identity lost in __any_strict_eq tag-5 arm"
+status: ready
+sprint: 65
+created: 2026-06-21
+updated: 2026-06-21
+priority: high
+feasibility: medium
+reasoning_effort: high
+model: opus
+task_type: bugfix
+area: codegen, runtime
+language_feature: prototype chain, strict equality, object identity
+goal: property-model
+related: [1888, 1629, 296, 2104]
+origin: "2026-06-21 — surfaced during s64 value-rep keystone work; proto-identity comparison gap."
+---
+
+## Problem
+
+Standalone, comparing two references to the SAME object for identity returns
+false when both flow through the `any` value-tag boxing:
+
+```ts
+const p: any = { z: 1 };
+const c = Object.create(p);
+Object.getPrototypeOf(c) === p;   // → false  (expected true)
+```
+
+Repro confirmed failing on main HEAD (93e53919f), `--target standalone`:
+returns `+0` (false).
+
+### Root cause (WAT-confirmed)
+
+The object plumbing is correct — the bug is in the `===` comparison.
+
+WAT excerpt (`getPrototypeOf(c) === p`):
+```
+local.get $p / local.tee ... / call $__object_create  ;; c
+call $__getPrototypeOf                                 ;; getPrototypeOf(c)
+call $__any_box_string          ;; LHS boxed as tag 5
+local.get $p
+call $__any_box_string          ;; RHS boxed as tag 5
+call $__any_strict_eq           ;; compares as STRINGS
+```
+
+1. `p` is a real `$Object` (`__new_plain_object` + `__extern_set`).
+2. `Object.create(p)` (`__object_create`, object-runtime.ts:2293) builds a
+   fresh `$Object` with `$proto = ref.cast $Object(p)` — a `ref null $Object`.
+   `__getPrototypeOf(c)` (object-runtime.ts:2264) reads field 0 and
+   `extern.convert_any`s it back. So `getPrototypeOf(c)` IS the same GC
+   reference as `p` — identity is preserved up to here.
+3. The `===` lowers BOTH operands through `__any_box_string`
+   (`src/codegen/value-tags.ts:185` — the generic-externref boxing arm, kept at
+   **tag 5 / STRING** by the #1888 −794 regression note) and then
+   `__any_strict_eq`.
+4. `__any_strict_eq`'s **tag-5 arm** (`src/codegen/any-helpers.ts` ~L1608–1624)
+   compares the two `externval` fields via **`__str_equals`** (string content
+   equality) — never `ref.eq`. Two `$Object` externrefs are not strings, so
+   `strEqualsIdx` (the `wasm:js-string` `equals` host import, -1 in pure
+   standalone) yields the `else: [{ op: "i32.const", value: 0 }]` arm → false.
+
+So two identical objects boxed as tag-5 always compare unequal: object identity
+is silently lost whenever a `$Object` is boxed through the generic-externref
+(tag-5) path.
+
+### Why the top-level `ref.eq` fast path does not save it
+
+`__any_strict_eq` opens with a `ref.eq` on the two **`$AnyValue` struct refs
+themselves** (any-helpers.ts:1488). But the two operands are **distinct freshly
+allocated `$AnyValue` boxes** (one per `__any_box_string` call) — different
+structs, so the struct-level `ref.eq` is false. The identity that matters lives
+in `externval` (field 4), which the tag-5 arm never `ref.eq`-compares.
+
+## Implementation Plan
+
+### Approach
+
+Add a `ref.eq` (object-identity) short-circuit to the **tag-5 arm** of
+`__any_strict_eq`, BEFORE the `__str_equals` content compare. Two identical
+object/string externrefs are `ref.eq`-equal, so this returns true for object
+identity; two distinct strings with equal content are NOT `ref.eq` and fall
+through to `__str_equals` (content equality preserved).
+
+This fixes identity WITHOUT changing the boxing representation — so it does NOT
+risk re-introducing the #1888 −794 baseline regression that the
+"keep tag-5 for generic externref" note guards against.
+
+### Changes
+
+**File: `src/codegen/any-helpers.ts`**
+
+- Function building `__any_strict_eq` (`addHelper("__any_strict_eq", …)`, line
+  ~1481). In the **tag-5 (string)** arm (line ~1608, the
+  `tagA == 5` branch), wrap the existing `__str_equals` body so that it FIRST
+  compares the two externvals by reference:
+
+  Current tag-5 `then`:
+  ```ts
+  then: strEqualsIdx >= 0
+    ? [ get a.externval, get b.externval, call strEqualsIdx ]
+    : [ i32.const 0 ],
+  ```
+
+  New tag-5 `then`:
+  ```ts
+  then: [
+    // Object identity (and string-interning) fast path: if both externvals
+    // are the same GC reference → equal. Recovers object identity for
+    // $Object/$Vec/etc. boxed at tag-5 (value-tags.ts:185).
+    local.get a; struct.get $AnyValue 4;  // a.externval (externref)
+    any.convert_extern;                    // → anyref (eqref-comparable)
+    local.get b; struct.get $AnyValue 4;
+    any.convert_extern;
+    ref.eq;
+    (if (result i32)
+      (then i32.const 1)
+      (else
+        // Distinct refs: fall back to STRING content equality for genuine
+        // strings. Non-string externrefs are not ref.eq and not equal here.
+        strEqualsIdx >= 0
+          ? [ local.get a; struct.get $AnyValue 4;
+              local.get b; struct.get $AnyValue 4;
+              call strEqualsIdx ]
+          : [ i32.const 0 ]))
+  ]
+  ```
+
+  Notes for the implementer:
+  - `externval` is field index 4 of `$AnyValue` (tag=0, i32val=1, f64val=2,
+    refval=3/eqref, externval=4/externref) — confirm against the struct layout
+    where `__any_box_string` writes `local.get 0` into the 5th `struct.new`
+    slot (any-helpers.ts:662).
+  - `ref.eq` requires `eqref`-compatible operands. `externref` is not directly
+    `ref.eq`-able, so `any.convert_extern` each externval to `anyref` first
+    (anyref is a subtype of eqref's hierarchy for GC refs; a host externref
+    converts to an internal ref or stays comparable). Verify the emitter
+    accepts `ref.eq` on the converted operands; if `any.convert_extern` of a
+    host externref is not eqref-comparable, gate the fast path on
+    `ref.test`-ing both as internal GC refs first, OR convert and `ref.eq` —
+    both `$Object` externvals are internalized GC refs (`extern.convert_any`
+    round-trips), so `any.convert_extern` + `ref.eq` is the expected shape
+    (this mirrors the tag-6 arm, which `ref.eq`s the eqref `refval` at
+    any-helpers.ts:1605).
+  - A null externval (defensive): `any.convert_extern(null)` is null; `ref.eq`
+    of two nulls is true — acceptable (two tag-5 boxes of null/undefined
+    externval would be equal, which matches `===`).
+
+### Edge cases
+
+- **Object identity** (`getPrototypeOf(c) === p`) — same `$Object` externref →
+  `ref.eq` true. FIXED.
+- **Two distinct strings, equal content** (`("a"+"") === "a"` boxed via any) —
+  distinct GC string refs, NOT `ref.eq` → fall to `__str_equals` → true.
+  Preserved. (Add a regression test to prove the content path still works.)
+- **Two distinct objects** (`{} === {}` via any) — distinct refs, not
+  `ref.eq`; `__str_equals` on two non-string objects returns 0 (or
+  `strEqualsIdx == -1` → 0) → false. Correct (`{} !== {}`).
+- **string vs object both tag-5** — they are different GC refs; `ref.eq` false;
+  `__str_equals` content compare returns 0/false. Correct (a string is never
+  `===` an object — though note both being tag-5 is itself the #1888
+  representation compromise; this fix does not worsen it).
+- **NaN / number tags** — unaffected; numbers are tags 2/3 and handled by the
+  numeric-class arm above (any-helpers.ts:1510), never reaching the tag-5 arm.
+
+### Regression-risk check
+
+This is additive within the tag-5 arm only. The top-level struct `ref.eq`
+(line 1488), numeric arm, and all other tag arms are untouched. The string
+content path is preserved as the `else` of the new `ref.eq`. The #1888 note
+specifically warns against changing the **boxing** (value-tags.ts:185), which
+this fix does NOT touch — so the −794 baseline risk does not apply. Still,
+because the harness comparator `isSameValue` runs over tag-5 externref `any`
+values, the implementer MUST run the standalone-affecting test262 buckets in CI
+and confirm no net regression before merge (escalate if any bucket regresses).
+
+### Test plan
+
+Add `tests/issue-2585-proto-identity.test.ts` (standalone harness):
+
+- `const p:any={z:1}; const c=Object.create(p);
+   return (Object.getPrototypeOf(c)===p)?1:0` → 1
+- `const p:any={z:1}; const q:any={z:1};
+   return (Object.getPrototypeOf(Object.create(p))===q)?1:0` → 0
+  (different objects, even same shape)
+- object self-identity through any: `const a:any={}; const b:any=a;
+   return (a===b)?1:0` → 1
+- string content equality preserved: `const s:any="a"; const t:any=("a"+"");
+   return (s===t)?1:0` → 1
+- string vs object: `const s:any="x"; const o:any={};
+   return (s===o)?1:0` → 0
+- distinct objects: `return (({} as any)===({} as any))?1:0` → 0
+
+Scoped local check before PR; CI validates conformance. Expect positive
+test262 delta in `built-ins/Object/{create,getPrototypeOf}/` and
+`language/expressions/equality/` object-identity tests.


### PR DESCRIPTION
Architect-specced post-keystone substrate findings (all WAT-confirmed failing on main HEAD). #2583 any-array method brand dispatch ($__vec_base arm — biggest unblock), #2584 dot-vs-bracket dual storage (widening poison), #2585 proto identity (ref.eq short-circuit in __any_strict_eq tag-5). Each has files/functions/line refs + Wasm IR + standalone test plan. All independent, senior-dev-implementable. 🤖 Generated with [Claude Code](https://claude.com/claude-code)