### PR TITLE
fix(#2160): String.prototype method dispatch on a new String() wrapper receiver (standalone)

### DIFF
--- a/plan/issues/2160-standalone-string-number-coercion-residual.md
+++ b/plan/issues/2160-standalone-string-number-coercion-residual.md
@@ -197,3 +197,64 @@ equality, and all four prior #2160 suites (47). tsc + prettier + biome lint +
 coercion-sites + any-box gates clean. (Pre-existing unrelated failures on main:
 issue-929 accessor descriptor, imported-string-constants e2e, bigint-string —
 all fail identically on pristine `origin/main`.)
+
+---
+
+## Slice (2026-06-21, sdev-tails) — String.prototype METHOD dispatch on a wrapper receiver
+
+**Status stays `ready`** — closes the "full String-method dispatch on a wrapper
+receiver" residual the cs-2160 slice above explicitly left open. Re-probed
+against current main (post-keystone #2187/#2576/#2579): nearly the entire common
+String/Number method + coercion surface now passes standalone (charAt/slice/
+toUpperCase/padStart/trim/split/at/codePointAt/normalize/localeCompare/matchAll/
+toFixed/toPrecision/toString(radix)/Number.* on PRIMITIVE strings; wrapper
+`.length`/`[i]`/`.valueOf()`/`.toString()`). The genuinely-open in-lane residual
+was **every String.prototype METHOD on a `new String(x)` WRAPPER receiver**.
+
+**Root cause** (`src/codegen/expressions/calls.ts`, the native-string method
+dispatch at the `isStringType(receiverType)` arm): `isStringType` deliberately
+also matches the String *wrapper* Object type (so primitive-string methods can
+dispatch). A wrapper reaching `compileNativeStringMethodCall` had its receiver
+emitted by `compileExpression(propAccess.expression)` → the wrapper's `$Object`
+externref → `__str_flatten`'s `ref.cast $NativeString` → **runtime trap**
+("illegal cast" / "null pointer dereference") for `charAt`/`slice`/`indexOf`/
+`toUpperCase`/`includes`/… — the whole wrapper-method surface was unusable
+standalone (it worked in host/gc via the dynamic object path).
+
+**Fix (no new hand-rolled coercion — reuses the §7.1.1.1 engine helper):**
+1. In the native-string dispatch (calls.ts), for a `ctx.standalone` String-
+   wrapper receiver (excluding `toString`/`valueOf`, which keep their existing
+   arms), pass `compileNativeStringMethodCall` a **`receiverOverride`** that
+   recovers the wrapped primitive via the EXISTING `__to_primitive(hint
+   "string")` helper (reads the wrapper's FLAG_INTERNAL `[[PrimitiveValue]]`
+   slot first — same helper the cs-2160 valueOf slice uses), then
+   `any.convert_extern` + `ref.cast $AnyString` back to a native string ref.
+2. The five two-string-arg arms (`indexOf`/`lastIndexOf`/`includes`/
+   `startsWith`/`endsWith`) stored the receiver via
+   `compileStringValueToLocal(propAccess.expression, …)`, which **bypassed**
+   `emitReceiver()`/the override. Added a `compileReceiverToLocal` helper
+   (`src/codegen/string-ops.ts`) routing the receiver through `emitReceiver()`
+   so the override applies there too.
+
+The coercion-sites baseline (#2108) for calls.ts is bumped 21→23 for the two
+sanctioned `__to_primitive` references — the SAME engine helper, no new matrix.
+
+**Still open (NOT regressed):** `Number.prototype` method dispatch on a `new
+Number(x)` wrapper receiver (slot is a boxed number; orthogonal extraction),
+WASI wrapper parity (native object-runtime is standalone-only). String
+`.replace(fn)` is the standalone RegExp engine's residual (#2161 lane). The
+inline `Array.from(new Set(...))`-expression → 0 and `[...m.entries()]` Map-
+entries-spread residuals are #2162 `$Vec`-dispatch territory (architect #24
+lane), documented below in the report — not folded here.
+
+**Validation.** `tests/issue-2160-wrapper-strmethod-standalone.test.ts` (2/2,
+22 wrapper-method cases × standalone + gc): charAt/charCodeAt/at/toUpperCase/
+toLowerCase/slice/substring/indexOf(hit+miss)/lastIndexOf/includes/startsWith/
+endsWith/repeat/padStart/trim/concat/split/chained, inline and via a wrapper
+local, each asserting NO `__unbox_string`/`__new_String`/`__extern_*`/
+`wasm:js-string` host-import leak under `target: standalone`; plus a gc-mode
+no-regression guard. Regression suites green: native-strings (110),
+issue-1910-string-wrapper-index/1910-s2/1397 (23), issue-2192b caught-error
+string methods, all prior #2160 suites (37/38 — the 1 pre-existing
+`Number(arr)` failure fails identically on pristine `origin/main`). tsc +
+prettier + biome lint + coercion-sites + any-box + stack-balance gates clean.

--- a/scripts/coercion-sites-baseline.json
+++ b/scripts/coercion-sites-baseline.json
@@ -8,7 +8,7 @@
   "codegen/declarations.ts": 18,
   "codegen/expressions/assignment.ts": 12,
   "codegen/expressions/calls-closures.ts": 2,
-  "codegen/expressions/calls.ts": 21,
+  "codegen/expressions/calls.ts": 23,
   "codegen/expressions/identifiers.ts": 2,
   "codegen/expressions/late-imports.ts": 4,
   "codegen/expressions/logical-ops.ts": 2,

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -8972,6 +8972,40 @@ function compileCallExpression(
 
       // Fast mode: native string method dispatch
       if (ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0) {
+        // (#2160 wrapper-strmethod) A String WRAPPER receiver (`new String(x)`)
+        // reaches here because `isStringType` deliberately also matches the
+        // wrapper Object type (for primitive-string method dispatch — see the
+        // cs-2160 `resolveWasmType` note). But the wrapper lowers to a `$Object`
+        // externref, NOT a native string ref, so the default receiver emitter
+        // (`compileExpression(propAccess.expression)` → `__str_flatten`'s
+        // `ref.cast $NativeString`) traps at runtime with "illegal cast" /
+        // "null pointer" for every String.prototype method (`charAt`, `slice`,
+        // `indexOf`, `toUpperCase`, …). The wrapper `.valueOf()`/`.toString()`
+        // slice (cs-2160) already recovers the internal `[[PrimitiveValue]]` slot
+        // via the native `__to_primitive` engine helper; reuse the SAME helper
+        // here as the receiver so the method dispatches against the wrapped
+        // primitive string. Gated on `ctx.standalone` (the native object-runtime
+        // / `__to_primitive` machinery is standalone-only — WASI keeps the host
+        // object path). No new coercion site: `__to_primitive` is the existing
+        // §7.1.1.1 engine helper.
+        if (ctx.standalone && isStringWrapperType(receiverType) && method !== "toString" && method !== "valueOf") {
+          ensureObjectRuntime(ctx);
+          const toPrimIdx = ctx.funcMap.get("__to_primitive");
+          if (toPrimIdx !== undefined && ctx.anyStrTypeIdx >= 0) {
+            const wrapperReceiverOverride = (): ValType => {
+              // wrapper externref → __to_primitive(hint "string") → externref
+              // (the internal slot IS a native string) → back to `ref $AnyString`.
+              compileExpression(ctx, fctx, propAccess.expression, { kind: "externref" });
+              addStringConstantGlobal(ctx, "string");
+              fctx.body.push(...stringConstantExternrefInstrs(ctx, "string"));
+              fctx.body.push({ op: "call", funcIdx: toPrimIdx });
+              fctx.body.push({ op: "any.convert_extern" } as Instr);
+              fctx.body.push({ op: "ref.cast", typeIdx: ctx.anyStrTypeIdx } as Instr);
+              return { kind: "ref", typeIdx: ctx.anyStrTypeIdx };
+            };
+            return compileNativeStringMethodCall(ctx, fctx, expr, propAccess, method, wrapperReceiverOverride);
+          }
+        }
         return compileNativeStringMethodCall(ctx, fctx, expr, propAccess, method);
       }
 

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -2121,6 +2121,20 @@ export function compileNativeStringMethodCall(
     fctx.body.push({ op: "local.set", index: local });
     return local;
   };
+  // (#2160 wrapper-strmethod) Compile the RECEIVER into a native-string local
+  // honoring `receiverOverride`. The two-string-argument arms (indexOf /
+  // lastIndexOf / includes / startsWith / endsWith) store the receiver in a
+  // local before pushing args, so they cannot use `emitReceiver()` inline; they
+  // previously called `compileStringValueToLocal(propAccess.expression, …)`,
+  // which ignores the override and re-compiles the raw receiver expression — a
+  // trap for a `new String(x)` wrapper (the override extracts its primitive
+  // slot). Route the receiver through `emitReceiver()` so the override applies.
+  const compileReceiverToLocal = (name: string): number => {
+    const local = allocLocal(fctx, `${name}_${fctx.locals.length}`, nativeStringType(ctx));
+    emitReceiver();
+    fctx.body.push({ op: "local.set", index: local });
+    return local;
+  };
   const compileIntegerValueToLocal = (value: ts.Expression | undefined, fallback: number, name: string): number => {
     const local = allocLocal(fctx, `${name}_${fctx.locals.length}`, {
       kind: "i32",
@@ -2353,7 +2367,7 @@ export function compileNativeStringMethodCall(
 
   // indexOf: native helper
   if (method === "indexOf") {
-    const receiverLocal = compileStringValueToLocal(propAccess.expression, "", "__str_indexOf_recv");
+    const receiverLocal = compileReceiverToLocal("__str_indexOf_recv");
     const searchLocal = compileStringValueToLocal(expr.arguments[0], "undefined", "__str_indexOf_search");
     const fromLocal = compileIntegerValueToLocal(expr.arguments[1], 0, "__str_indexOf_from");
     const funcIdx = ctx.nativeStrHelpers.get("__str_indexOf")!;
@@ -2366,7 +2380,7 @@ export function compileNativeStringMethodCall(
 
   // lastIndexOf: native helper
   if (method === "lastIndexOf") {
-    const receiverLocal = compileStringValueToLocal(propAccess.expression, "", "__str_lastIndexOf_recv");
+    const receiverLocal = compileReceiverToLocal("__str_lastIndexOf_recv");
     const searchLocal = compileStringValueToLocal(expr.arguments[0], "undefined", "__str_lastIndexOf_search");
     // §22.1.3.9 step 5: ToIntegerOrInfinity(position) with NaN → +∞, so an
     // explicit `NaN` (or `undefined`) position searches from the end — the same
@@ -2385,7 +2399,7 @@ export function compileNativeStringMethodCall(
 
   // includes: native helper
   if (method === "includes") {
-    const receiverLocal = compileStringValueToLocal(propAccess.expression, "", "__str_includes_recv");
+    const receiverLocal = compileReceiverToLocal("__str_includes_recv");
     const searchLocal = compileStringValueToLocal(expr.arguments[0], "undefined", "__str_includes_search");
     const fromLocal = compileIntegerValueToLocal(expr.arguments[1], 0, "__str_includes_from");
     const funcIdx = ctx.nativeStrHelpers.get("__str_includes")!;
@@ -2398,7 +2412,7 @@ export function compileNativeStringMethodCall(
 
   // startsWith: native helper
   if (method === "startsWith") {
-    const receiverLocal = compileStringValueToLocal(propAccess.expression, "", "__str_startsWith_recv");
+    const receiverLocal = compileReceiverToLocal("__str_startsWith_recv");
     const searchLocal = compileStringValueToLocal(expr.arguments[0], "undefined", "__str_startsWith_search");
     const posLocal = compileIntegerValueToLocal(expr.arguments[1], 0, "__str_startsWith_pos");
     const funcIdx = ctx.nativeStrHelpers.get("__str_startsWith")!;
@@ -2411,7 +2425,7 @@ export function compileNativeStringMethodCall(
 
   // endsWith: native helper
   if (method === "endsWith") {
-    const receiverLocal = compileStringValueToLocal(propAccess.expression, "", "__str_endsWith_recv");
+    const receiverLocal = compileReceiverToLocal("__str_endsWith_recv");
     const searchLocal = compileStringValueToLocal(expr.arguments[0], "undefined", "__str_endsWith_search");
     const endLocal = compileIntegerValueToLocal(expr.arguments[1], 0x7fffffff, "__str_endsWith_end");
     const funcIdx = ctx.nativeStrHelpers.get("__str_endsWith")!;

--- a/tests/issue-2160-wrapper-strmethod-standalone.test.ts
+++ b/tests/issue-2160-wrapper-strmethod-standalone.test.ts
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2160 (wrapper-strmethod slice) — String.prototype METHOD dispatch on a
+ * `new String(x)` WRAPPER receiver, standalone.
+ *
+ * A String wrapper (`new String("abc")`) reaches the native-string method
+ * dispatch in `compileMethodCall` because `isStringType` deliberately also
+ * matches the wrapper Object type (so primitive-string methods can dispatch).
+ * But the wrapper lowers to a `$Object` externref, NOT a native string ref, so
+ * the receiver emitter's `__str_flatten` `ref.cast $NativeString` TRAPPED at
+ * runtime ("illegal cast" / "null pointer dereference") for EVERY
+ * String.prototype method (`charAt`, `slice`, `indexOf`, `toUpperCase`, …) —
+ * making the entire wrapper-method surface unusable standalone. The cs-2160
+ * slice fixed `.length`/`[i]`/`.valueOf()`/`.toString()` on a wrapper but
+ * explicitly left "full String-method dispatch on a wrapper receiver" open.
+ *
+ * Fix (no new coercion site): route the native string method's RECEIVER through
+ * the existing `__to_primitive` engine helper (§7.1.1.1, reads the wrapper's
+ * FLAG_INTERNAL `[[PrimitiveValue]]` slot first), recovering the wrapped native
+ * string ref, then dispatch the method against it. Implemented via
+ * `compileNativeStringMethodCall`'s `receiverOverride` callback; the two-string-
+ * arg arms (indexOf/lastIndexOf/includes/startsWith/endsWith) also route their
+ * receiver through the override (they previously bypassed it). Gated on
+ * `ctx.standalone` — WASI / gc keep their existing object paths.
+ *
+ * Each case returns 1 on the spec-correct result and the standalone module is
+ * instantiated with an EMPTY import object, so any host-import leak (or the old
+ * trap) fails the test.
+ */
+
+// Each body returns 1 iff the wrapper method produced the spec-correct value.
+const CASES: ReadonlyArray<[string, string]> = [
+  ["charAt", `return new String("abc").charAt(1) === "b" ? 1 : 0;`],
+  ["charCodeAt", `return new String("A").charCodeAt(0) === 65 ? 1 : 0;`],
+  ["at negative", `return new String("abc").at(-1) === "c" ? 1 : 0;`],
+  ["toUpperCase", `return new String("ab").toUpperCase() === "AB" ? 1 : 0;`],
+  ["toLowerCase", `return new String("AB").toLowerCase() === "ab" ? 1 : 0;`],
+  ["slice", `return new String("abcd").slice(1, 3) === "bc" ? 1 : 0;`],
+  ["substring", `return new String("abcd").substring(1, 3) === "bc" ? 1 : 0;`],
+  ["indexOf hit", `return new String("abcabc").indexOf("b") === 1 ? 1 : 0;`],
+  ["indexOf miss", `return new String("abc").indexOf("z") === -1 ? 1 : 0;`],
+  ["lastIndexOf", `return new String("abcabc").lastIndexOf("b") === 4 ? 1 : 0;`],
+  ["includes true", `return new String("abc").includes("b") ? 1 : 0;`],
+  ["includes false", `return new String("abc").includes("z") ? 0 : 1;`],
+  ["startsWith", `return new String("hello").startsWith("he") ? 1 : 0;`],
+  ["endsWith", `return new String("hello").endsWith("lo") ? 1 : 0;`],
+  ["repeat", `return new String("ab").repeat(2) === "abab" ? 1 : 0;`],
+  ["padStart", `return new String("5").padStart(3, "0") === "005" ? 1 : 0;`],
+  ["trim", `return new String("  x  ").trim() === "x" ? 1 : 0;`],
+  ["concat", `return new String("a").concat("b") === "ab" ? 1 : 0;`],
+  ["split length", `return new String("a,b,c").split(",").length === 3 ? 1 : 0;`],
+  ["chained", `return new String("Hello World").toUpperCase().slice(0, 5) === "HELLO" ? 1 : 0;`],
+  // via a wrapper local (not only inline) — exercises the bound-local path too.
+  ["local charAt", `const s = new String("xyz"); return s.charAt(2) === "z" ? 1 : 0;`],
+  ["local indexOf", `const s = new String("hello"); return s.indexOf("l") === 2 ? 1 : 0;`],
+];
+
+const fn = (i: number) => `t${i}`;
+const MODULE = CASES.map(([, body], i) => `export function ${fn(i)}(): number { ${body} }`).join("\n");
+
+describe("#2160 String.prototype method dispatch on a wrapper receiver — standalone", () => {
+  it("every String method works on a new String() wrapper (no host-import leak)", async () => {
+    const r = await compile(MODULE, { target: "standalone" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    // No leaked host import for the wrapper method-dispatch path.
+    const labels = r.imports.map((im) => `${im.module}::${im.name}`);
+    for (const re of [/^env::__unbox_string$/, /^env::__new_String$/, /^env::__extern_/, /^wasm:js-string::/]) {
+      expect(
+        labels.filter((l) => re.test(l)),
+        `leaked ${re.source}`,
+      ).toEqual([]);
+    }
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    const ex = instance.exports as Record<string, () => number>;
+    CASES.forEach(([name], i) => {
+      expect(ex[fn(i)]!(), `standalone wrapper ${name}`).toBe(1);
+    });
+  });
+
+  // gc / JS-host mode is untouched (the fix is `ctx.standalone`-gated). This
+  // guard proves the default backend still compiles + runs wrapper methods.
+  it("default (gc / JS-host) mode still compiles wrapper string methods", async () => {
+    const r = await compile(MODULE, {});
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, r.importObject);
+    const ex = instance.exports as Record<string, () => number>;
+    CASES.forEach(([name], i) => {
+      expect(ex[fn(i)]!(), `gc wrapper ${name}`).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes the "full String-method dispatch on a wrapper receiver" residual the cs-2160 slice of #2160 explicitly left open.

Every `String.prototype` method (`charAt`/`slice`/`indexOf`/`toUpperCase`/`includes`/…) on a `new String(x)` **wrapper** receiver trapped at runtime in `--target standalone` ("illegal cast" / "null pointer dereference") — the whole wrapper-method surface was unusable standalone (it worked in host/gc via the dynamic object path).

## Root cause

`isStringType` deliberately also matches the String **wrapper** Object type (so primitive-string methods can dispatch). A wrapper reaching `compileNativeStringMethodCall` had its receiver emitted as the wrapper's `$Object` externref → `__str_flatten`'s `ref.cast $NativeString` → trap. `.length`/`[i]`/`.valueOf()`/`.toString()` were already fixed (cs-2160 slice); the **methods** were not.

## Fix (reuses the §7.1.1.1 engine helper — no new coercion matrix)

1. `src/codegen/expressions/calls.ts` — for a `ctx.standalone` String-wrapper receiver (excluding `toString`/`valueOf`), pass `compileNativeStringMethodCall` a `receiverOverride` that recovers the wrapped primitive via the **existing** `__to_primitive(hint "string")` helper (reads the FLAG_INTERNAL `[[PrimitiveValue]]` slot first), then `any.convert_extern` + `ref.cast $AnyString`.
2. `src/codegen/string-ops.ts` — the five two-string-arg arms (`indexOf`/`lastIndexOf`/`includes`/`startsWith`/`endsWith`) stored the receiver via `compileStringValueToLocal`, which bypassed `emitReceiver()`/the override. New `compileReceiverToLocal` routes them through `emitReceiver()` so the override applies.

coercion-sites baseline (#2108) calls.ts 21→23 — two sanctioned `__to_primitive` references, the same engine helper the cs-2160 valueOf slice uses.

## Scope guards / still open (NOT regressed)

- `Number.prototype` method dispatch on a `new Number(x)` wrapper (boxed-number slot; orthogonal extraction).
- WASI wrapper parity (native object-runtime is standalone-only).
- `String.replace(fn)` is the standalone RegExp engine residual (#2161).
- Inline `Array.from(new Set(...))`-expression / `[...m.entries()]` Map-entries-spread are #2162 `$Vec`-dispatch territory (architect lane) — documented, not folded here.

## Validation

`tests/issue-2160-wrapper-strmethod-standalone.test.ts` (2/2, 22 wrapper-method cases × standalone + gc): all common methods, inline + via a wrapper local, each asserting zero `__unbox_string`/`__new_String`/`__extern_*`/`wasm:js-string` host-import leak under `target: standalone`; plus a gc-mode no-regression guard. gc/host mode untouched (`ctx.standalone`-gated).

Regression suites green: native-strings (110), issue-1910-string-wrapper-index/1910-s2/1397 (23), issue-2192b caught-error string methods, all prior #2160 suites (37/38 — the 1 pre-existing `Number(arr)` failure fails identically on pristine `origin/main`). tsc + prettier + biome lint + coercion-sites + any-box + stack-balance gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)