### PR TITLE
fix(#2582): numeric-key struct read with a runtime key at module-init

### DIFF
--- a/plan/issues/2582-acorn-wordsregexp-null-receiver.md
+++ b/plan/issues/2582-acorn-wordsregexp-null-receiver.md
@@ -1,7 +1,9 @@
 ---
 id: 2582
 title: "compiled-acorn module-init: null receiver into wordsRegexp from a numeric-keyed module-object read"
-status: ready
+status: done
+assignee: sd-acorn
+completed: 2026-06-21
 created: 2026-06-21
 updated: 2026-06-21
 priority: high
@@ -125,3 +127,82 @@ heterogeneous numeric-keyed literal).
   object-literal codegen — validate broadly).
 - This unblocks the next acorn dogfood step; #1712 stays open until the full
   parse + AST-match acceptance is met.
+
+## Resolution (2026-06-21, sd-acorn) — TRUE root cause + fix
+
+The "empty-string value elided" hypothesis above was WRONG. Bisected the real
+trigger to a **6-line repro** and pinned a precise two-part root cause.
+
+### True root cause
+
+A **non-literal numeric key** read on a statically-typed numeric-keyed object
+literal (`{ 9: …, 10: … }`) returns `undefined` when executed in
+**module-init / top-level** code:
+
+```ts
+var props = { 9: "a", 10: "b" };
+var arr = [9, 10];
+var tlPlain = props[9];        // literal key  → "a"   (always worked)
+var tlArr   = props[arr[0]];   // RUNTIME key  → undefined (BUG)
+// the same `props[arr[0]]` read INSIDE a function → "a" (worked)
+```
+
+Mechanism (two compounding defects):
+
+1. **Codegen split** (`src/codegen/property-access.ts`,
+   `compileStructOrExternElementAccess`): a LITERAL/const numeric key lowers to
+   a static `struct.get $type fieldIdx` (exports-independent, works anytime). A
+   NON-literal key (`arr[0]`, a `var` loop counter, an `any` param) yields
+   `fieldName === undefined` and falls to the DYNAMIC path
+   `__extern_get(extern.convert_any(props), __box_number(key))`.
+
+2. **Module-init timing + symbol-ID swallow** (`src/runtime.ts` `_safeGet`):
+   `__extern_get` → `_safeGet(struct, 9)` reads the field via the
+   `exports["__sget_9"]` getter. But the module-init top-level
+   `for (…) buildUnicodeData(list[i])` loop runs inside the Wasm **START
+   function**, BEFORE `__setExports` wires the exports — so `__sget_9` is
+   unavailable, the fast-path is skipped, and `_safeGet` falls into the
+   well-known-symbol-ID branch (`key >= 1 && key <= 15`; key 9 ∈ [1,15]),
+   treats 9 as Symbol-ID 9, finds nothing, and `return undefined`. Confirmed
+   via instrumentation: `[INTENT eget key=9 (number)] objStruct=true
+   sget?=undefined`.
+
+acorn's `wordsRegexp(unicodeBinaryPropertiesOfStrings[ecmaVersion])` (ecmaVersion
+from `list[i]` in the module-level loop) hits exactly this → `undefined` →
+`wordsRegexp(undefined)` → `undefined.replace` → instantiation throws.
+
+### Fix
+
+`src/codegen/property-access.ts`: when the element-access receiver is a struct
+whose fields are **ALL numeric-named externref slots** (a plain numeric-keyed
+object literal) and the key is switch-eligible (number / `any` / `unknown`, but
+NOT statically string-typed), emit a static `struct.get` **key-switch**
+(`if key===N0 then struct.get F0 else if key===N1 … else ref.null.extern`)
+instead of `__extern_get`. This is exports- and host-independent, so it reads
+correctly at module-init AND at runtime — generalising the existing literal-key
+`struct.get` lowering to a runtime numeric key. A statically string-typed key,
+or a mixed-shape struct, falls through to the dynamic `__extern_get` path
+unchanged.
+
+### Validation
+
+- Regression pin `tests/issue-2582-numeric-key-struct-read.test.ts` (3 tests:
+  top-level runtime-key read, module-level loop driving the read does not throw,
+  string-key read still resolves the field). All green.
+- The full extracted acorn unicode-data section (`buildUnicodeData` +
+  numeric-keyed objects + module loop) went throws-on-instantiate → returns 6.
+- **Real compiled acorn now INSTANTIATES** (`instantiated OK; parse=function`) —
+  the `__module_init` `buildUnicodeData` throw is gone. Before this fix,
+  instantiation rejected.
+- No regression: scoped computed-property / element-access / #2542 dynamic-key
+  suites all pass (the `./helpers.js` "Failed Suites" are a pre-existing
+  worktree test-infra gap, not introduced here).
+
+### NEXT acorn blocker (4th, NOT this issue)
+
+With acorn now instantiating, `parse("var x = 1;")` **infinite-loops** again —
+a TIGHT Wasm loop (it never yields to the JS event loop, so a `setTimeout`
+watchdog can't fire; only an OS-level `timeout` kills it). This is forward
+progress (parse is now REACHABLE; before, instantiation itself threw), but a
+fresh, deeper blocker past module-init — a separate slice. Filed as a follow-up;
+#1712 stays open until the full acorn parse + AST-match acceptance is met.

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -5533,6 +5533,89 @@ export function compileElementAccessBody(
           return typeDef.fields[fieldIdx]!.type;
         }
       }
+      // (#2582) Non-literal NUMERIC key on a struct whose fields are
+      // numeric-named (an object literal `{ 9: …, 10: … }` read via
+      // `obj[ecmaVersion]` with a runtime key) → emit a static key-switch of
+      // `struct.get` per numeric field instead of the dynamic `__extern_get`.
+      //
+      // Why this matters: the `__extern_get` path routes through the host
+      // runtime's `_safeGet`, which reads the struct field via the
+      // `__sget_<key>` EXPORT — but module-init top-level code (acorn's
+      // `for (…) buildUnicodeData(list[i])` driving
+      // `unicodeBinaryPropertiesOfStrings[ecmaVersion]`) executes inside the
+      // Wasm START function, BEFORE `__setExports` wires the exports, so
+      // `__sget_9` is unavailable and the read returns `undefined`. Worse,
+      // `_safeGet` then falls into the well-known-symbol-ID branch (key 9 ∈
+      // [1,15]) and swallows it. A `struct.get` key-switch is exports- and
+      // host-independent, so it reads correctly at module-init AND at runtime.
+      // Literal-key reads already lower to a direct `struct.get` above; this
+      // generalises that to a runtime numeric key over the same fields.
+      {
+        const numericFields = typeDef.fields
+          .map((f: { name?: string; type: ValType }, idx: number) => ({ f, idx }))
+          .filter(
+            ({ f }: { f: { name?: string; type: ValType } }) =>
+              f.name !== undefined && /^(?:0|[1-9][0-9]*)$/.test(f.name) && f.type.kind === "externref",
+          );
+        const keyType = ctx.checker.getTypeAtLocation(expr.argumentExpression);
+        // The key is switch-eligible when it is (or could be) a number: a
+        // genuine number/number-literal, OR an `any`/`unknown` key (acorn's
+        // `unicodeBinaryPropertiesOfStrings[ecmaVersion]` — `ecmaVersion` is an
+        // untyped JS param, so it resolves to `any`). A non-number `any` value
+        // coerces to NaN, matches no arm, and yields the missing-key result —
+        // exactly what `__extern_get` would return. A STATICALLY string-typed
+        // key is excluded so `obj["9"]`-style string property reads keep the
+        // dynamic path (string→f64 would mis-coerce to NaN).
+        const NUMERIC_KEY_FLAGS = ts.TypeFlags.Number | ts.TypeFlags.NumberLiteral;
+        const PERMISSIVE_KEY_FLAGS = NUMERIC_KEY_FLAGS | ts.TypeFlags.Any | ts.TypeFlags.Unknown;
+        const keyIsStringy =
+          (keyType.flags & (ts.TypeFlags.String | ts.TypeFlags.StringLiteral)) !== 0 &&
+          (keyType.flags & NUMERIC_KEY_FLAGS) === 0;
+        const keySwitchEligible = (keyType.flags & PERMISSIVE_KEY_FLAGS) !== 0 && !keyIsStringy;
+        // Only take the static key-switch when EVERY field is a numeric-named
+        // externref slot (a plain numeric-keyed object literal). A mixed shape
+        // falls through to the dynamic `__extern_get` path unchanged.
+        if (numericFields.length > 0 && numericFields.length === typeDef.fields.length && keySwitchEligible) {
+          // Receiver struct ref is already on the stack — stash it so each
+          // switch arm can re-read the same field.
+          const recvLocal = allocLocal(fctx, `__numkey_recv_${fctx.locals.length}`, {
+            kind: "ref_null",
+            typeIdx,
+          });
+          fctx.body.push({ op: "local.set", index: recvLocal } as Instr);
+          // Key as f64 (numeric reads box through f64; matches the literal path).
+          compileExpression(ctx, fctx, expr.argumentExpression, { kind: "f64" });
+          const keyLocal = allocLocal(fctx, `__numkey_idx_${fctx.locals.length}`, { kind: "f64" });
+          fctx.body.push({ op: "local.set", index: keyLocal } as Instr);
+          // Build a nested if/else chain from the innermost (default) outward:
+          //   if key==N0 then struct.get F0 else if key==N1 then … else null
+          let chain: Instr[] = [{ op: "ref.null.extern" } as Instr];
+          for (let i = numericFields.length - 1; i >= 0; i--) {
+            const { f, idx } = numericFields[i]!;
+            const fieldNum = Number(f.name);
+            // Field is a numeric-named externref slot (guaranteed by the filter
+            // above), so a bare `struct.get` already yields externref — the
+            // unified result type of a dynamic-key read. No coercion needed.
+            const thenArm: Instr[] = [
+              { op: "local.get", index: recvLocal } as Instr,
+              { op: "struct.get", typeIdx, fieldIdx: idx } as Instr,
+            ];
+            chain = [
+              { op: "local.get", index: keyLocal } as Instr,
+              { op: "f64.const", value: fieldNum } as Instr,
+              { op: "f64.eq" } as Instr,
+              {
+                op: "if",
+                blockType: { kind: "val", type: { kind: "externref" } },
+                then: thenArm,
+                else: chain,
+              } as Instr,
+            ];
+          }
+          for (const instr of chain) fctx.body.push(instr);
+          return { kind: "externref" };
+        }
+      }
       // Non-vec, non-tuple struct: fallback to externref conversion + __extern_get
       // Convert struct ref (already on stack) to externref
       fctx.body.push({ op: "extern.convert_any" });

--- a/tests/issue-2582-numeric-key-struct-read.test.ts
+++ b/tests/issue-2582-numeric-key-struct-read.test.ts
@@ -1,0 +1,92 @@
+// #2582 — a non-literal NUMERIC key read on a statically-typed numeric-keyed
+// object literal returned `undefined` when executed in MODULE-INIT (top-level)
+// code, while the same read worked with a literal key or inside a function.
+//
+// Root cause: `obj[runtimeKey]` on a struct whose fields are numeric-named
+// (`{ 9: …, 10: … }`) lowered to the DYNAMIC `__extern_get` host path (only a
+// literal/const key resolved to a static `struct.get`). `__extern_get` →
+// `_safeGet` reads the field via the `__sget_<key>` EXPORT, but the module-init
+// top-level `for (…) f(list[i])` loop runs inside the Wasm START function,
+// BEFORE `__setExports` wires the exports — so `__sget_9` is unavailable and
+// the read returns undefined (then `_safeGet`'s well-known-symbol-ID branch,
+// key 9 ∈ [1,15], swallowed it). acorn's
+// `wordsRegexp(unicodeBinaryPropertiesOfStrings[ecmaVersion])` in module-init
+// `buildUnicodeData` hit exactly this → `wordsRegexp(undefined)` →
+// `undefined.replace` → instantiation threw (#1712 acorn dogfood, 3rd blocker).
+//
+// Fix: a non-literal numeric key on a struct whose fields are ALL numeric-named
+// externref slots emits a static `struct.get` key-switch (exports-independent),
+// generalising the literal-key path to a runtime key.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+
+async function run(src: string): Promise<any> {
+  const result: any = await compile(src, { fileName: "probe.mjs" });
+  expect(result.success).toBe(true);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  return wrapExports(instance.exports, { signatures: result.exportSignatures });
+}
+
+describe("#2582 — numeric-key struct read with a runtime key at module-init", () => {
+  it("reads numeric-keyed object via a runtime (array-sourced) key at TOP LEVEL", async () => {
+    // The exact failing shape: top-level `props[arr[0]]` and `props[k]` where
+    // `k = arr[0]`. Before the fix these returned undefined; the literal
+    // `props[9]` always worked.
+    const exp = await run(`
+      // @ts-nocheck
+      var props = { 9: "a", 10: "b" };
+      var arr = [9, 10];
+      var tlPlain = props[9];          // literal — always worked
+      var tlArr = props[arr[0]];       // runtime key — was undefined
+      var k = arr[0];
+      var tlVar = props[k];            // runtime var key — was undefined
+      export function probe() {
+        return (tlPlain === "a" ? 1 : 0) + (tlArr === "a" ? 1 : 0) + (tlVar === "a" ? 1 : 0);
+      }
+    `);
+    expect(exp.probe()).toBe(3);
+  });
+
+  it("module-level for-loop driving a numeric-key read does not throw (acorn shape)", async () => {
+    // Mirrors acorn's `for (…) buildUnicodeData(list[i])` →
+    // `wordsRegexp(unicodeBinaryPropertiesOfStrings[ecmaVersion])`. The empty-
+    // string values are the ones that previously read undefined and made
+    // `.replace` throw on a null/undefined receiver during instantiation.
+    const exp = await run(`
+      // @ts-nocheck
+      var regexpCache = {};
+      function wordsRegexp(words) {
+        return regexpCache[words] || (regexpCache[words] = new RegExp("^(?:" + words.replace(/ /g, "|") + ")$"));
+      }
+      var ecma14 = "Basic_Emoji RGI_Emoji";
+      var props = { 9: "", 10: "", 11: "", 12: "", 13: "", 14: ecma14 };
+      var count = 0;
+      function build(ecmaVersion) { var r = wordsRegexp(props[ecmaVersion]); if (r) { count = count + 1; } }
+      // MODULE-LEVEL loop — runs in the start function, before __setExports.
+      for (var i = 0, list = [9, 10, 11, 12, 13, 14]; i < list.length; i += 1) {
+        build(list[i]);
+      }
+      export function probe() { return count; }
+    `);
+    // 6 builds, none threw. (If module-init threw, instantiation would reject
+    // and run() would fail before returning.)
+    expect(exp.probe()).toBe(6);
+  });
+
+  it("a string-typed key still resolves the correct numeric field name", async () => {
+    // The fix must NOT hijack a genuine string-keyed read. `props["9"]` (string)
+    // names field "9" and must read "a" via the existing field-name path.
+    const exp = await run(`
+      // @ts-nocheck
+      var props = { 9: "a", 10: "b" };
+      export function probe() {
+        var sk = "9";
+        return props[sk] === "a" ? 1 : 0;
+      }
+    `);
+    expect(exp.probe()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes compiled-acorn's **3rd dogfood blocker** (#1712): a non-literal NUMERIC key read on a statically-typed numeric-keyed object literal returned `undefined` when executed in **module-init (top-level)** code, while the same read worked with a literal key or inside a function.

acorn's module-init `buildUnicodeData` runs `wordsRegexp(unicodeBinaryPropertiesOfStrings[ecmaVersion])` where `ecmaVersion` comes from a module-level `for (…) f(list[i])` loop — the numeric-key read returned `undefined`, so `wordsRegexp(undefined)` → `undefined.replace` → **instantiation threw**.

Minimal 6-line repro (`props[arr[0]]` at top level → undefined; `props[9]` literal → works; both work inside a function).

## Root cause (two compounding defects)

1. **Codegen split** (`src/codegen/property-access.ts`): a literal/const numeric key lowers to a static `struct.get` (exports-independent), but a NON-literal key (`arr[0]`, a loop var, an `any` param) falls to the dynamic `__extern_get(extern.convert_any(obj), __box_number(key))` path.

2. **Module-init timing + symbol-ID swallow** (`src/runtime.ts` `_safeGet`): `__extern_get` → `_safeGet(struct, 9)` reads the field via `exports["__sget_9"]`, but the module-init top-level loop runs in the Wasm **START function** BEFORE `__setExports` wires the exports, so `__sget_9` is unavailable. `_safeGet` then falls into the well-known-symbol-ID branch (key 9 ∈ [1,15]), treats 9 as Symbol-ID 9, and returns `undefined`. (Confirmed via instrumentation.)

## Fix

`src/codegen/property-access.ts`: when the element-access receiver is a struct whose fields are **ALL numeric-named externref slots** (a plain numeric-keyed object literal) and the key is switch-eligible (number / `any` / `unknown`, but NOT statically string-typed), emit a static `struct.get` **key-switch** instead of `__extern_get`. Exports- and host-independent, so it reads correctly at module-init AND at runtime — generalising the existing literal-key lowering to a runtime numeric key. A statically string-typed key, or a mixed-shape struct, falls through to the dynamic path unchanged. No `runtime.ts` change.

## Validation

- Regression pin `tests/issue-2582-numeric-key-struct-read.test.ts` (3 tests): top-level runtime-key read, module-level loop driving the read does not throw, string-key read still resolves the field. All green.
- The full extracted acorn unicode-data section went throws-on-instantiate → returns 6.
- **Real compiled acorn now INSTANTIATES** (`instantiated OK; parse=function`) — the module-init `buildUnicodeData` throw is gone (before this fix, instantiation rejected).
- No regression: scoped computed-property / element-access / #2542 dynamic-key suites all pass (the `./helpers.js` "Failed Suites" are a pre-existing worktree test-infra gap, not introduced here).

## Scope note

With acorn now instantiating, `parse()` infinite-loops again — a 4th, deeper blocker past module-init (forward progress: parse is now *reachable*). Documented in the issue as a follow-up. #1712 stays open until the full acorn parse + AST-match acceptance is met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA