### PR TITLE
fix(#2586): Array.from(Map) → native entries-pair vec under standalone

### DIFF
--- a/plan/issues/2586-standalone-arrayfrom-map.md
+++ b/plan/issues/2586-standalone-arrayfrom-map.md
@@ -1,0 +1,104 @@
+---
+id: 2586
+title: "Array.from(Map) traps illegal_cast under --target standalone"
+status: done
+sprint: 65
+assignee: ttraenkler/sdev-vrep
+feasibility: hard
+reasoning_effort: max
+completed: 2026-06-21
+goals: [standalone]
+---
+
+## Problem
+
+Under `--target standalone` (pure-Wasm, no JS host), `Array.from(map)` traps at
+runtime with `RuntimeError: illegal cast`:
+
+```ts
+const m = new Map<string, string>();
+m.set("k", "v");
+const a = Array.from(m); // a should be [["k", "v"]]
+a[0][0]; // → illegal cast (even a.length traps)
+```
+
+Discovered while re-probing the s65 post-keystone object-value read-back cluster
+(task #25). Of the cluster targets, `Object.values` / `Object.entries` /
+`Object.keys` / `Array.from(Set)` / `catch (e).message` **already pass** in true
+`--target standalone` post-keystone (#2187/#2576/#2579). Only two were genuinely
+still broken: this `Array.from(Map)`, and `Object.assign({}, …)` with an **empty
+object-literal target** — the latter is the dot-vs-bracket dual-storage substrate
+owned by #2584 (task #28) and was escalated, not fixed here.
+
+## Root cause
+
+A Map's default iterator is its `entries()` (§24.1.3.12 → §24.1.5.3), so
+`Array.from(map)` must yield one `[key, value]` pair per live entry.
+
+`Array.from` codegen (`src/codegen/expressions/calls.ts`, the `Array.from`
+intercept) already routes `Array.from(Set)` through the native
+`emitCollectionIteratorVec` driver, but explicitly left **Map** to fall through
+to the generic native `__iterator` drain (`#2169c`). That generic drain is built
+**VEC-ONLY** under noJsHost (`src/codegen/iterator-native.ts` — "a non-vec
+subject hard-casts → illegal cast"): it does `ref.cast $Vec` on its subject. A
+Map lowers to a `ref $Map` struct (field 0 is NOT a `$length`), so the cast
+traps.
+
+## Fix
+
+Route `Array.from(Map)` through the **same** `emitCollectionIteratorVec` driver
+the `[...set]` / `.values()` / `.entries()` paths use, in `"entries"` mode. That
+mode materializes a canonical externref `$Vec` whose slots are 2-element
+`$ObjVec` `[key, value]` pairs — exactly the host `__array_from` contract, with
+**zero host imports**.
+
+The materialized result is handed back as a **plain externref** (via
+`coerceType(..., externref)`), NOT the raw `ref $Vec`. The consumer then reads it
+through the dynamic `__extern_get_idx` / `__extern_length` arm
+(`a[i][0]` / `[k, v]` destructure). Returning the raw `ref $Vec` instead makes a
+`const a: [K,V][]` binding run the typed tuple-vec materialization, which cannot
+bridge an `$ObjVec` pair into a type-resolved tuple struct → invalid `struct.new`
+("expected (ref null 6), found if of type f64").
+
+One-line change in `compileCallExpression`'s `Array.from` block; no new helpers.
+
+### Why gated to `ctx.standalone` (not `noJsHost` / `nativeStrings`)
+
+The `entries`-mode `$ObjVec` pair materialization tickles a **pre-existing**
+substrate limitation that the stricter targets surface but this slice does not
+own — both reproduce on `main` for `[...m.entries()]` independently of this
+change:
+
+- **nativeStrings-WITH-JS-host** → a late-registered object-runtime funcidx
+  (`__defineProperty_value`) desyncs (function-index-out-of-range at emit). Also
+  breaks `[...m.entries()]` there.
+- **`--target wasi`** (strict-no-host) → the same desync, **plus** a
+  `global_Array` declared-global request that the host-import allowlist rejects.
+
+Under `--target standalone` the path lowers to a **zero-import, fully-native**
+module (verified: `WebAssembly.Module.imports(binary).length === 0`), so the fix
+ships there. The `entries`-mode late-registration desync + `global_Array`
+interaction is escalated as the entries-mode substrate follow-up (relates to the
+#2583/#2584 `$Vec`-dispatch substrate work).
+
+## Test Results
+
+`tests/issue-2586-standalone-arrayfrom-map.test.ts` — 8 tests, all green:
+
+- length / string-key+string-value / string-key+number-value / multi-entry
+  order / number-key+number-value pairs read back; each emits **0 imports**.
+- regression guards: `Array.from(Set)`, `Array.from(array)`, `Array.from(string)`
+  remain native + host-free.
+
+Existing suites re-run green: `issue-1103a-standalone-map`,
+`issue-1470-string-iteration-standalone`, `issue-2162b-array-entries-spread`,
+`issue-2157-iterator-generator-residual`.
+
+## Out of scope / escalated
+
+- `Object.assign({}, {a:"x"})` empty-target string/number value read-back → dual
+  storage substrate, #2584 (task #28). Confirmed: even `Object.keys(t).length`
+  returns 0 for the assign result; `{...{a:"x"}}` spread works (builds a real
+  `$Object`), so only `Object.assign` into an empty `{}` is affected.
+- `Array.from(Map)` under `--target wasi` / nativeStrings-with-JS-host → blocked
+  on the entries-mode late-registration desync above.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -4582,6 +4582,49 @@ function compileCallExpression(
         // Driver declined (e.g. a real JS Set arriving as externref) — fall
         // through to the paths below.
       }
+      // (#2586) Array.from(Map) — host-free native. A Map's default iterator
+      // is its `entries()` (§24.1.3.12 → §24.1.5.3), so `Array.from(map)`
+      // yields one `[key, value]` pair per live entry. The generic native
+      // `__iterator` drain below is built VEC-ONLY under noJsHost and hard-casts
+      // its subject to a `$Vec` (iterator-native.ts:293) → `illegal cast` on the
+      // `ref $Map` struct. Route through the SAME `emitCollectionIteratorVec`
+      // driver as Set above, in `"entries"` mode: it materializes a canonical
+      // externref `$Vec` whose slots are 2-element `$ObjVec` `[key, value]`
+      // pairs, so the consumer's `a[i][0]`/`a[i][1]` read back through the
+      // native `__extern_get_idx`/`__extern_length` arm — exactly Array.from's
+      // result. (WeakMap is not iterable; WeakSet/Map-with-mapFn keep the
+      // existing routing.)
+      //
+      // Gated to `ctx.standalone` (the `--target standalone` pure-Wasm target),
+      // NOT plain `nativeStrings` nor WASI. The entries-mode `$ObjVec` pair
+      // materialization tickles a PRE-EXISTING substrate limitation that the
+      // stricter targets surface but this slice does not own:
+      //   - nativeStrings-WITH-JS-host → a late-registered object-runtime funcidx
+      //     (`__defineProperty_value`) desyncs (also breaks `[...m.entries()]`
+      //     there);
+      //   - `--target wasi` (strict-no-host) → the same desync PLUS a
+      //     `global_Array` declared-global request that the allowlist rejects.
+      // Both reproduce on `main` for `[...m.entries()]` independently of this
+      // change, so they are escalated as the entries-mode substrate follow-up
+      // rather than half-fixed here. Under `--target standalone` the path lowers
+      // to a zero-import, fully-native module (verified), so ship that.
+      if (!hasMapFn && ctx.standalone && ctx.nativeStrings && argSymName === "Map") {
+        const matType = emitCollectionIteratorVec(ctx, fctx, expr.arguments[0]!, "entries", /* isSet */ false);
+        if (matType != null && matType !== VOID_RESULT && (matType.kind === "ref" || matType.kind === "ref_null")) {
+          // The materialized vec carries 2-element `$ObjVec` `[key, value]` pairs
+          // as its slots, NOT type-resolved tuple structs. Hand it back as a
+          // plain externref so the consumer reads it through the dynamic
+          // `__extern_get_idx`/`__extern_length` arm (`a[i][0]`/`[k, v]`
+          // destructuring) — exactly the host `__array_from` contract. Returning
+          // the raw `ref $Vec` instead would make a `const a: [K,V][]` binding
+          // run the typed tuple-vec materialization, which can't bridge an
+          // `$ObjVec` pair into a tuple struct (→ invalid `struct.new`).
+          coerceType(ctx, fctx, matType, { kind: "externref" });
+          return { kind: "externref" };
+        }
+        // Driver declined (e.g. a real JS Map arriving as externref) — fall
+        // through to the paths below.
+      }
       // Reject the known non-array builtin collections from the structural
       // array-copy fast path so a Set the driver above declined, or a
       // Map/WeakSet/WeakMap, cannot be mis-read as a `__vec` (the struct.new

--- a/tests/issue-2586-standalone-arrayfrom-map.test.ts
+++ b/tests/issue-2586-standalone-arrayfrom-map.test.ts
@@ -1,0 +1,142 @@
+// #2586 — Array.from(Map) under --target standalone (pure-Wasm, host-free).
+//
+// A Map's default iterator is its `entries()` (§24.1.3.12 → §24.1.5.3), so
+// `Array.from(map)` materializes one `[key, value]` pair per live entry.
+//
+// Before this fix, `Array.from(map)` under standalone fell through to the
+// generic native `__iterator` drain, which is built VEC-ONLY and hard-casts
+// its subject to a `$Vec` (iterator-native.ts) → `illegal cast` trap on the
+// `ref $Map` struct. The fix routes Map through the SAME
+// `emitCollectionIteratorVec` driver the `[...set]` / `.values()` paths use,
+// in `"entries"` mode: it materializes a canonical externref `$Vec` whose slots
+// are 2-element `$ObjVec` `[key, value]` pairs, handed back as a plain externref
+// so the consumer reads it through the dynamic `__extern_get_idx`/`__extern_length`
+// arm — exactly the host `__array_from` contract, with ZERO host imports.
+//
+// Each test compiles with `target: "standalone"`, asserts the module carries
+// zero imports (fully native), and returns the expected value.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/** Compile `source` with `--target standalone`, run `test()`, return its value + import count. */
+async function runStandalone(source: string): Promise<{ value: unknown; imports: number; valid: boolean }> {
+  const result = await compile(source, { fileName: "test.ts", target: "standalone" });
+  if (!result.success) {
+    throw new Error(`compile failed: ${result.errors?.[0]?.message ?? "unknown error"}`);
+  }
+  const valid = WebAssembly.validate(result.binary);
+  const module = await WebAssembly.compile(result.binary);
+  const imports = WebAssembly.Module.imports(module).length;
+  const imp = (result as unknown as { importObject?: WebAssembly.Imports }).importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, imp);
+  (imp as unknown as { __setExports?: (e: unknown) => void }).__setExports?.(instance.exports);
+  const value = (instance.exports as { test: () => unknown }).test();
+  return { value, imports, valid };
+}
+
+describe("#2586 Array.from(Map) standalone (host-free)", () => {
+  it("length reflects entry count — host-import-free", async () => {
+    const { value, imports, valid } = await runStandalone(
+      `export function test(): number {
+         const m = new Map<string, string>();
+         m.set("k", "v");
+         const a = Array.from(m);
+         return a.length;
+       }`,
+    );
+    expect(valid).toBe(true);
+    expect(imports).toBe(0);
+    expect(value).toBe(1);
+  });
+
+  it("string key + string value pair reads back", async () => {
+    const { value, imports } = await runStandalone(
+      `export function test(): boolean {
+         const m = new Map<string, string>();
+         m.set("k", "v");
+         const a = Array.from(m);
+         return a[0][0] === "k" && a[0][1] === "v";
+       }`,
+    );
+    expect(imports).toBe(0);
+    expect(value).toBe(1); // boolean true → i32 1
+  });
+
+  it("string key + number value pair reads back", async () => {
+    const { value, imports } = await runStandalone(
+      `export function test(): boolean {
+         const m = new Map<string, number>();
+         m.set("k", 5);
+         const a = Array.from(m);
+         return a[0][0] === "k" && a[0][1] === 5;
+       }`,
+    );
+    expect(imports).toBe(0);
+    expect(value).toBe(1);
+  });
+
+  it("multiple entries preserve insertion order", async () => {
+    const { value, imports } = await runStandalone(
+      `export function test(): boolean {
+         const m = new Map<string, string>();
+         m.set("a", "1");
+         m.set("b", "2");
+         const a = Array.from(m);
+         return a.length === 2 && a[0][0] === "a" && a[1][0] === "b" && a[1][1] === "2";
+       }`,
+    );
+    expect(imports).toBe(0);
+    expect(value).toBe(1);
+  });
+
+  it("number keys and values", async () => {
+    const { value, imports } = await runStandalone(
+      `export function test(): number {
+         const m = new Map<number, number>();
+         m.set(1, 10);
+         m.set(2, 20);
+         const a = Array.from(m);
+         return a[0][0] * 100 + a[1][1]; // 1*100 + 20 = 120
+       }`,
+    );
+    expect(imports).toBe(0);
+    expect(value).toBe(120);
+  });
+
+  // Regression guards — sibling Array.from paths must keep working host-free.
+  it("regression: Array.from(Set) still native", async () => {
+    const { value, imports } = await runStandalone(
+      `export function test(): boolean {
+         const s = new Set(["x", "y"]);
+         const a = Array.from(s);
+         return a[0] === "x" && a[1] === "y";
+       }`,
+    );
+    expect(imports).toBe(0);
+    expect(value).toBe(1);
+  });
+
+  it("regression: Array.from(array) copy still native", async () => {
+    const { value, imports } = await runStandalone(
+      `export function test(): boolean {
+         const src = [1, 2, 3];
+         const a = Array.from(src);
+         return a.length === 3 && a[2] === 3;
+       }`,
+    );
+    expect(imports).toBe(0);
+    expect(value).toBe(1);
+  });
+
+  it("regression: Array.from(string) char split still native", async () => {
+    const { value, imports } = await runStandalone(
+      `export function test(): boolean {
+         const a = Array.from("hi");
+         return a.length === 2 && a[0] === "h";
+       }`,
+    );
+    expect(imports).toBe(0);
+    expect(value).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

`Array.from(map)` traps `RuntimeError: illegal cast` under `--target standalone`:

```ts
const m = new Map<string, string>();
m.set("k", "v");
const a = Array.from(m);   // should be [["k","v"]]
a[0][0];                    // → illegal cast (even a.length traps)
```

A Map lowers to a `ref $Map` struct (field 0 is NOT a `$length`), but the generic
native `__iterator` drain (#2169c) is built **VEC-ONLY** under noJsHost and
hard-casts its subject to `$Vec` → trap.

## Fix

Route `Array.from(Map)` through the same `emitCollectionIteratorVec` driver as
`Array.from(Set)`, in `"entries"` mode: it materializes a canonical externref
`$Vec` of 2-element `$ObjVec` `[key, value]` pairs (§24.1.3.12 → §24.1.5.3),
handed back as a plain externref so the consumer reads it via the dynamic
`__extern_get_idx`/`__extern_length` arm. **Zero host imports.** One-line change
in the `Array.from` intercept; no new helpers.

Gated to `ctx.standalone` (the pure-Wasm target). The entries-mode `$ObjVec`
materialization tickles a **pre-existing** late-registration desync
(`__defineProperty_value` funcidx) plus a `global_Array` declared-global request
under `--target wasi` / nativeStrings-with-JS-host — both reproduce on `main` for
`[...m.entries()]` independently of this change, and are escalated as the
entries-mode substrate follow-up.

## Tests

`tests/issue-2586-standalone-arrayfrom-map.test.ts` — 8 tests, all green: length,
string/number key+value pairs, multi-entry order, all emitting **0 imports**;
plus regression guards for `Array.from(Set/array/string)`. Existing suites re-run
green (`issue-1103a-standalone-map`, `issue-1470-string-iteration-standalone`,
`issue-2162b-array-entries-spread`, `issue-2157-iterator-generator-residual`).
`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)