### PR TITLE
fix(infra): live-frontmatter statusline + auto-FF fork from upstream

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -275,14 +275,14 @@ if [ -z "$in_worktree" ] && [ "$branch" = "main" ]; then
   sprint_n=""
   sprint_done=0
   sprint_total=0
-  sprints_json="/workspace/website/dashboard/data/sprints.json"
-  if [ -f "$sprints_json" ]; then
-    # Read from pre-built sprints.json (deduplicated, wont-fix counted as done)
-    sprint_data=$(jq -r '
-      [ .[] | select(.sprintNumber != null and .isClosed == false and .isPlanning == false) ]
-      | sort_by(.sprintNumber) | last
-      | "\(.sprintNumber) \(.completedIssueIds | length) \(.issueIds | length)"
-    ' "$sprints_json" 2>/dev/null)
+  # LIVE-FIRST: statusline-sprint.mjs scans the working-tree plan/issues/*.md
+  # frontmatter (always current) and only falls back to the sprints.json cache
+  # internally when the flat scan finds nothing. Reading the cache here FIRST is
+  # what made the statusline go stale — sprints.json only rebuilds on
+  # push-to-main, so it reported a closed sprint for days.
+  sprint_mjs="/workspace/scripts/statusline-sprint.mjs"
+  if [ -f "$sprint_mjs" ] && command -v node >/dev/null 2>&1; then
+    sprint_data=$(node "$sprint_mjs" --porcelain 2>/dev/null)
     if [ -n "$sprint_data" ]; then
       sprint_n=$(echo "$sprint_data" | awk '{print $1}')
       sprint_done=$(echo "$sprint_data" | awk '{print $2}')
@@ -290,14 +290,15 @@ if [ -z "$in_worktree" ] && [ "$branch" = "main" ]; then
     fi
   fi
   if [ -z "$sprint_n" ]; then
-    # Fallback when sprints.json is absent: delegate to statusline-sprint.mjs,
-    # which scans the flat plan/issues/*.md tree by `sprint:`/`status:`
-    # frontmatter (#1616). The previous shell fallback scanned per-sprint
-    # DIRECTORIES, which broke after the #576 flatten (issues are now flat
-    # files; sprint docs are sprints/<N>.md). --porcelain emits "N done total".
-    sprint_mjs="/workspace/scripts/statusline-sprint.mjs"
-    if [ -f "$sprint_mjs" ] && command -v node >/dev/null 2>&1; then
-      sprint_data=$(node "$sprint_mjs" --porcelain 2>/dev/null)
+    # Fallback only when node/the script is unavailable: read the (possibly
+    # stale) pre-built cache directly (deduplicated, wont-fix counted as done).
+    sprints_json="/workspace/website/dashboard/data/sprints.json"
+    if [ -f "$sprints_json" ]; then
+      sprint_data=$(jq -r '
+        [ .[] | select(.sprintNumber != null and .isClosed == false and .isPlanning == false) ]
+        | sort_by(.sprintNumber) | last
+        | "\(.sprintNumber) \(.completedIssueIds | length) \(.issueIds | length)"
+      ' "$sprints_json" 2>/dev/null)
       if [ -n "$sprint_data" ]; then
         sprint_n=$(echo "$sprint_data" | awk '{print $1}')
         sprint_done=$(echo "$sprint_data" | awk '{print $2}')

--- a/scripts/statusline-sprint.mjs
+++ b/scripts/statusline-sprint.mjs
@@ -100,9 +100,21 @@ function interpolateColor(pct) {
   return [Math.round(r * 220), Math.round(g * 200), Math.round(b * 20)];
 }
 
-const jsonData = fromJson();
-const sprint = jsonData ? jsonData.sprint : currentSprint();
-const { done, total } = jsonData ?? sprintProgress(sprint);
+// LIVE-FIRST: read the current working-tree frontmatter (flatTree) so the
+// statusline always reflects reality. The sprints.json cache only rebuilds on
+// push-to-main, so preferring it made the statusline go silently stale (it
+// reported a closed sprint for days). Fall back to the cache only when the flat
+// scan finds no numbered sprint at all (e.g. a partial checkout).
+const flatSprint = currentSprint();
+let sprint, done, total;
+if (flatSprint) {
+  sprint = flatSprint;
+  ({ done, total } = sprintProgress(sprint));
+} else {
+  const jsonData = fromJson();
+  sprint = jsonData ? jsonData.sprint : 0;
+  ({ done, total } = jsonData ?? { done: 0, total: 0 });
+}
 const pct = total === 0 ? 0 : done / total;
 const pctInt = Math.round(pct * 100);
 

--- a/scripts/sync-workspace-main.sh
+++ b/scripts/sync-workspace-main.sh
@@ -28,6 +28,28 @@ say() { echo "[sync-workspace-main] $*"; }
 
 [ -d "$WS/.git" ] || { say "no git repo at $WS — skipping"; exit 0; }
 
+# Keep the FORK's main synced with upstream (clean fast-forward ONLY). Agents
+# branch from origin/main and the statusline reads /workspace, so when the fork
+# (origin = ttraenkler/js2) lags upstream (loopdive/js2 — where PRs actually
+# merge) everything downstream silently rots: stale-base PRs go DIRTY, the
+# id-allocator collides, the statusline shows an old sprint. This advances
+# origin/main to upstream/main ONLY when origin is a strict ANCESTOR of upstream
+# (a real fast-forward) — never a force/rewrite (public main is append-only),
+# and a no-op when already current or when origin has its own commits.
+if git -C "$WS" remote get-url upstream >/dev/null 2>&1 \
+   && git -C "$WS" fetch upstream main --quiet 2>/dev/null; then
+  o=$(git -C "$WS" rev-parse origin/main 2>/dev/null)
+  u=$(git -C "$WS" rev-parse upstream/main 2>/dev/null)
+  if [ -n "$o" ] && [ -n "$u" ] && [ "$o" != "$u" ] \
+     && git -C "$WS" merge-base --is-ancestor "$o" "$u" 2>/dev/null; then
+    if git -C "$WS" push origin "$u:refs/heads/main" --quiet 2>/dev/null; then
+      say "synced fork origin/main -> upstream/main ($(echo "$u" | cut -c1-9))"
+    else
+      say "WARNING: upstream->origin/main fast-forward push failed (perms/protection?)"
+    fi
+  fi
+fi
+
 git -C "$WS" fetch origin main --quiet 2>/dev/null || { say "fetch failed — skipping"; exit 0; }
 
 local_sha=$(git -C "$WS" rev-parse --short HEAD 2>/dev/null)


### PR DESCRIPTION
Two durable staleness fixes. **(1) Statusline:** was reading the committed `sprints.json` cache (rebuilt only on push-to-main) → went stale for days. Now `statusline-sprint.mjs` is live-first (scans working-tree frontmatter, cache only as fallback) and `statusline-command.sh` calls it first. **(2) Fork sync:** `sync-workspace-main.sh` (run on SessionStart+Stop hooks) now FF-syncs `origin/main` from `upstream/main` first — clean fast-forward ONLY (never force/rewrite, no-op when current) — so the fork stops drifting behind loopdive/js2 (the root cause of stale-base DIRTY PRs, id-allocator collisions, and the stale statusline). Verified: porcelain now reports live s65 3/43 vs cache s64 30/80; live run FF'd origin/main to 0-behind-upstream. 🤖 Generated with [Claude Code](https://claude.com/claude-code)