### PR TITLE
chore(memory): commit pending s65 agent-memory (unblocks /workspace sync)

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -55,7 +55,7 @@
 - [feedback_ignore_unreliable_autodispatch.md](feedback_ignore_unreliable_autodispatch.md) — SUPERSEDED 2026-05-23 by native auto-dispatch switch. Devs now trust auto-dispatch; only verify live state (is it merged/owned?) before claiming. Ignoring auto-dispatch wholesale is break-glass only.
 - [feedback_sendmessage_discipline.md](feedback_sendmessage_discipline.md) — SendMessage = blockers/decisions/completions only; status/idle/ack → TaskUpdate or silence
 - [feedback_dev_silence_protocol.md](feedback_dev_silence_protocol.md) — No idle_notification messages ever; devs silent during CI-wait; TL keeps queue full, devs escalate only
-- [feedback_idle_notification_silence.md](feedback_idle_notification_silence.md) — Don't respond to idle notifications unless CI landed or work to assign; silence breaks the ping loop
+- [feedback_idle_notification_silence.md](feedback_idle_notification_silence.md) — An idle ping is a STATE signal: resolve it (TaskList task w/owner / shutdown / recognize stale), never just stay silent — "silence breaks the loop" is false (pings are timer-driven)
 - [feedback_no_ci_wait.md](feedback_no_ci_wait.md) — Dev agents open PR then immediately move on; CI monitoring = tech lead's job via auto-merge monitor
 - [feedback_no_keep_pane.md](feedback_no_keep_pane.md) — Never tell agents "do NOT kill your pane" — always terminate after PR; wait for a slot to open instead
 - [feedback_agent_self_termination.md](feedback_agent_self_termination.md) — Architects idle after finishing instead of self-terminating; added Termination section to architect.md; always include kill-pane in spawn prompts
@@ -64,6 +64,7 @@
 - [feedback_dispatch_status.md](feedback_dispatch_status.md) — Update issue status to in-progress when dispatching an agent
 - [feedback_dedicated_pr_shepherd.md](feedback_dedicated_pr_shepherd.md) — Always staff a dedicated PR-queue shepherd as a standing team role; don't hand-shepherd the merge queue ad-hoc (it strands/wedges when the lead is busy)
 - [feedback_auto_ff_workspace_main.md](feedback_auto_ff_workspace_main.md) — Auto-ff /workspace main to origin/main whenever origin is ahead (Stop+SessionStart hook in .claude/settings.json); stale /workspace gave a wrong 14/67 sprint count
+- [feedback_slice_claim_collision_check_assignments_log.md](feedback_slice_claim_collision_check_assignments_log.md) — Slice-granular (id:slice) claims can double-dispatch; check issue-assignments log for sole ownership + watch for foreign edits in your worktree before committing
 
 ### Issue management
 - [feedback_issue_completion.md](feedback_issue_completion.md) — Completion procedure: move, frontmatter, summary, log, unblock
@@ -163,9 +164,12 @@ Most project context lives in `/workspace/CLAUDE.md`.
 - [reference_2193_call_ref_funcref_not_wrapper.md](reference_2193_call_ref_funcref_not_wrapper.md) — #2193 PR-B call_ref `expected (ref funcType) found (ref wrapStruct)` was a missing struct.get-field-0 funcref extraction, NOT a type-renumber off-by-one
 - [reference_2372_dynamic_descriptor_struct_widening.md](reference_2372_dynamic_descriptor_struct_widening.md) — reference 2372 dynamic descriptor struct widening
 - [reference_2375_typedarray_valueread_postsubstrate_verdict.md](reference_2375_typedarray_valueread_postsubstrate_verdict.md) — reference 2375 typedarray valueread postsubstrate verdict
+- [reference_2042_s4_callsite_vs_2515_redefine_throw.md](reference_2042_s4_callsite_vs_2515_redefine_throw.md) — #2042 S4 = TWO disjoint redefine paths (native $Object runtime / typed-struct call-site); #2515 fixed the call-site -1-global emit but left a bare-string throw → S4 call-site net contribution is bare-string→TypeError-instance via emitThrowTypeError body-swap
 - [reference_2379_new_array_n_arraymethod_invalid_cast.md](reference_2379_new_array_n_arraymethod_invalid_cast.md) — reference 2379 new array n arraymethod invalid cast
 - [reference_2379_new_array_n_boxed_any_elem_rep.md](reference_2379_new_array_n_boxed_any_elem_rep.md) — #2379: standalone `new Array(N)` builds a boxed-any element array (type 1) while `[a,b,c]` builds a typed numeric element array (type 3) — sort/join stringify then ref.casts a boxed-any element to $AnyString = invalid Wasm; representation-scale, NOT a cast-site guard
 - [reference_2524_node_io_shim_memory_ownership.md](reference_2524_node_io_shim_memory_ownership.md) — reference 2524 node io shim memory ownership
+- [reference_2583_any_strict_eq_tag5_host_only.md](reference_2583_any_strict_eq_tag5_host_only.md) — #2583: standalone __any_strict_eq/__any_eq tag-5 string compare was host-only (wasm:js-string equals → const 0); native __str_flatten+__str_equals fallback. Plus any.indexOf routing intercept by the guarded-string else-arm. Touches same tag-5 field-4 arm as parked #2585.
+- [reference_2040_tag5_field4_three_way_classifier.md](reference_2040_tag5_field4_three_way_classifier.md) — #2040/#2585: tag-5 field-4 overloaded (string/$BoxedNumber/object); fix = 3-way classifier INSIDE the both-tags-5 arm of __any_eq/__any_strict_eq, numeric branch gated on nativeBoxNumberTypeIdx>=0 ONLY (not nativeStrings). NOT the rejected cross-tag-arm broadening. Stacks on #1883.
 - [reference_baseline_gates_need_postmerge_autorefresh.md](reference_baseline_gates_need_postmerge_autorefresh.md) — Every prescriptive baseline gate must self-refresh post-merge in promote-baseline or it wedges all PRs via drift
 - [reference_fork_origin_behind_upstream.md](reference_fork_origin_behind_upstream.md) — The fork origin/main is ~1185+ commits behind upstream/main — branch dev work from upstream/main, not origin/main, or PRs land DIRTY
 - [reference_gh_remove_label_rest_not_pr_edit.md](reference_gh_remove_label_rest_not_pr_edit.md) — gh pr edit --remove-label/--add-label silently no-ops (projectCards deprecation aborts the mutation); use the REST API to change PR/issue labels

--- a/.claude/memory/feedback_dev_silence_protocol.md
+++ b/.claude/memory/feedback_dev_silence_protocol.md
@@ -26,4 +26,12 @@ The old "no idle messages ever" rule was designed to stop ping-loops while agent
 
 **How to apply:** One-liner progress updates at key moments (reproduced → fixed → PR open). No multi-paragraph status reports. No pings when literally nothing changed.
 
-**Tech lead behavior:** Acknowledge milestone pings with a brief reply so agents know they're heard. Ignore only empty-status pings with no new information.
+**Tech lead behavior (corrected 2026-06-21, s64):** Acknowledge milestone
+pings briefly. But an **idle ping is a STATE signal, not noise to ignore** —
+"silence breaks the loop" is false (pings are timer-driven by the agent's idle
+state, not replies; they keep coming regardless of whether you answer). Always
+**resolve the state**: stale/crossing-in-flight → ignore; idle + work →
+TaskList task with `owner` pinned (agents are TaskList-driven, not
+SendMessage-driven); idle + no work → `shutdown_request`. Going quiet at an
+idle agent just lets it loop and burn a slot. Full rule:
+[[feedback_idle_notification_silence]].

--- a/.claude/memory/feedback_idle_notification_silence.md
+++ b/.claude/memory/feedback_idle_notification_silence.md
@@ -1,13 +1,44 @@
 ---
 name: idle_notification_silence
-description: Ignore idle_notification pings, but do respond to brief milestone pings from active agents
-type: feedback
-originSessionId: 0ffbd21c-b73d-429a-a76d-4fb742ea9794
+description: "An idle ping is a STATE signal — resolve it (TaskList task / shutdown / recognize stale), never just stay silent"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 54c1df0f-04d4-4026-b675-77fe695fb95c
 ---
-Agents now terminate after opening a PR, so the old CI-wait ping-loop problem is gone.
 
-**Ignore:** `{"type":"idle_notification",...}` messages — still discarded, agents should never send these.
+**Corrected 2026-06-21 (s64).** The old rule said "ignore idle_notification
+pings; silence breaks the ping loop." That mechanism is **false**: idle pings
+are **timer-driven by the agent's own idle state**, not replies to the lead —
+so staying silent never breaks the loop. Observed all s64: agents
+(carla/anita/bruno/sdev-reflect) kept pinging at intervals regardless of
+whether the lead answered. The only things that stop the pings are **giving
+the agent work or shutting it down**. Taken literally, "silence" silently
+degrades into "don't *act* on idle agents" → idle agents burn slots and keep
+pinging.
 
-**Respond briefly to:** one-line milestone pings from active agents ("reproduced", "fix done", "PR #N open"). A quick acknowledgment ("got it, keep going") keeps the agent unblocked without creating a loop.
+**An idle ping is a STATE CHECK. Always resolve the state — never just go
+quiet:**
+- **Stale / crossing-in-flight** (ping about a task you already reassigned) →
+  ignore. This is the only correct "silence."
+- **Genuinely idle + work exists** → create/refresh a **TaskList task with
+  `owner` pinned**. NOT SendMessage, NOT silence. Agents are **TaskList-driven,
+  not SendMessage-driven** (s64: SendMessage assignments were repeatedly
+  ignored or misread — sdev-reflect read a #2036 assignment as a #2046
+  re-confirm). See [[feedback_dispatch_against_upstream_not_stale_fork]].
+- **Genuinely idle + no work** → `shutdown_request` immediately (drained agents
+  burn pane/RAM slots and block new spawns; re-spawn when work appears).
+- **Repeated identical idle pings after you've assigned work** → the agent may
+  be **wedged** (pinging but not acting); re-issue via TaskList, or recognize
+  it can't ack and let the lead-session end clear it.
 
-**How to apply:** Milestone pings = respond once with a brief ack. Idle/CI-polling pings = ignore. The distinction: milestone pings carry new information (state change); idle pings carry no new information.
+**Why:** the goal is less *chatter*, not less *action*. Over-suppression in
+S51 left agents silent after catastrophic CI; under-action in s64 left agents
+idle-looping. Both are the same mistake — treating "don't reply" as the rule
+instead of "resolve the state."
+
+**Keep (the genuinely useful part):** don't send chatty "ack/thanks" replies,
+and don't treat a single status ping as a summons. Milestone pings carrying new
+info (reproduced / fixed / PR open / ESCALATE) still warrant a one-line
+response or action. Related: [[feedback_dev_silence_protocol]],
+[[feedback_sendmessage_discipline]].

--- a/.claude/memory/feedback_slice_claim_collision_check_assignments_log.md
+++ b/.claude/memory/feedback_slice_claim_collision_check_assignments_log.md
@@ -1,0 +1,36 @@
+---
+name: feedback_slice_claim_collision_check_assignments_log
+description: "Slice-granular claims (id:slice) can double-dispatch; verify sole ownership in the issue-assignments log before committing, and watch for foreign edits in your worktree"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 54c1df0f-04d4-4026-b675-77fe695fb95c
+---
+
+On 2026-06-21, #2042:s4-validate-apply was claimed by BOTH sdev-reflect and
+sdev-validate (issue-assignments log showed two `claim #2042:s4-validate-apply`
+commits, mine then theirs). The other agent was editing MY worktree LIVE —
+`src/codegen/object-ops.ts` + `src/emit/binary.ts` appeared modified mid-session
+and a debug block reverted itself between two of my `git status` checks. The
+claim lock did not prevent the second claim (slice-granular `id:slice` keys may
+not lock the same way bare `id` does), and worktree isolation did not prevent the
+other agent writing into my path.
+
+**Why:** slice-suffixed claims (`2042:s4-validate-apply`) and a shared worktree
+path let two agents land on the same work concurrently — the #1 cause of
+merge-queue dups and clobbered commits.
+
+**How to apply:**
+- Before `git add`/commit, run `git status` and treat ANY tracked file you did
+  NOT edit (foreign mtimes, debug instrumentation) as a collision signal — do not
+  stage or commit it as your own.
+- Verify sole ownership: `git log origin/issue-assignments` for your slice key;
+  if another agent's claim is newer, STOP and escalate to the tech lead rather
+  than racing to enqueue.
+- Keep your edits to a disjoint file set from any concurrent agent (here:
+  `object-runtime.ts` runtime-helper layer vs `object-ops.ts` call-site layer) so
+  the two slices can ship as separate small PRs without clobbering.
+- Re-claim with `--force` only when you OWN the resume; never to override a live
+  peer. See [[feedback_no_shared_worktree_assignment]],
+  [[feedback_no_duplicate_issue_dispatch]],
+  [[feedback_shared_worktree_clobber_check_claim_first]].

--- a/.claude/memory/reference_2040_tag5_field4_three_way_classifier.md
+++ b/.claude/memory/reference_2040_tag5_field4_three_way_classifier.md
@@ -1,0 +1,49 @@
+---
+name: reference_2040_tag5_field4_three_way_classifier
+description: "#2040/#2585 tag-5 field-4 is overloaded (string/$BoxedNumber/object); fix = 3-way classifier INSIDE the both-tags-5 arm of __any_eq/__any_strict_eq, numeric branch gated on nativeBoxNumberTypeIdx>=0 only. Stacks on #1883's tag5StringEqThen."
+metadata: 
+  node_type: memory
+  type: reference
+  originSessionId: 54c1df0f-04d4-4026-b675-77fe695fb95c
+---
+
+#2040 (numeric eq) + #2585 (proto identity): the tag-5 (string) `$AnyValue`
+box's field-4 `externval` is OVERLOADED — under tag 5 it holds a genuine string
+($AnyString/$NativeString/cons/host), a `$BoxedNumber` (the #1888 −794
+"box-the-externref" contract for numbers passing through externref), OR an
+object/proto ref. The tag-5 arm of BOTH `__any_eq` and `__any_strict_eq` ran
+string-eq unconditionally on the two field-4 externrefs → with #2583's native
+`tag5StringEqThen()` arm, `ref.cast $AnyString` TRAPS ("illegal cast") on a
+boxed-number/object; pre-#2583 it returned a wrong `0`.
+
+FIX (PR #1888, branch issue-2040-tag5-classifier, stacks on #1883):
+`tag5FieldEqDecision()` — a 3-way classifier INSIDE the both-tags-5 arm (shared
+by both eq helpers):
+1. EITHER field-4 `ref.test $BoxedNumber` → `__any_to_f64` both + `f64.eq`
+   (`23===23.0` true; `NaN===NaN` stays FALSE because f64.eq is self-false →
+   −788 preserved). Gate ONLY on `ctx.nativeBoxNumberTypeIdx >= 0` (ALWAYS true
+   in standalone/wasi — union imports register `$__box_number_struct` before the
+   eq helpers build), NEVER on `nativeStrings` (that mis-gate killed sd-3's
+   attempt — degenerated to const 0 before the numeric branch).
+2. BOTH `ref.test anyStrTypeIdx` → `tag5StringEqThen()` (content-eq, #2583).
+3. BOTH `ref.test (ref eq, -19)` → `ref.eq` (#2585 proto-identity).
+4. else → conservative `tag5StringEqThen()`.
+Also harden `__any_eq`'s cross-tag String⇄Number sub-read (`tag5ToNumber()`):
+boxed-number field-4 → `__any_to_f64`, genuine string → `__str_to_number`.
+
+CRITICAL distinction: this is NOT the rejected "numeric-class-gate broadening"
+(the 14-regression / 0-improvement verdict recorded in 2040.md) — that admitted
+tag-5 into the CROSS-TAG `{2,3}` arm and mis-classified tag-5-vs-tag-2. The
+classifier touches ONLY the both-tags-5 arm, so it cannot cause that. arch-tag5
+EMPIRICALLY confirmed `nativeBoxNumberTypeIdx >= 0` in pure standalone — sd-3's
+"−1" premise (which had motivated a full distinct-boxed-number-tag rep overhaul)
+was FALSE; no representation change needed, consumer-side only.
+
+Pre-existing-and-unrelated standalone failures on the #1883 base (verified by
+reverting any-helpers.ts — identical fail counts): `issue-1888-any-extern-
+roundtrip` (open-any dispatch bridge returns NaN, 5), `issue-1888.test` 2-4-arg
+closure (1), `issue-2081` wasi loose-eq (#2043 late-import shift, 10),
+`logical-conditional-identity` void→NaN (3). NOT eq-classifier regressions.
+
+Builds on [[reference_2583_any_strict_eq_tag5_host_only]]. MUST be full-baseline
+(merge_group) gated — risk is the −788/−794 contracts.

--- a/.claude/memory/reference_2042_s4_callsite_vs_2515_redefine_throw.md
+++ b/.claude/memory/reference_2042_s4_callsite_vs_2515_redefine_throw.md
@@ -1,0 +1,39 @@
+---
+name: reference_2042_s4_callsite_vs_2515_redefine_throw
+metadata: 
+  node_type: memory
+  type: reference
+  originSessionId: 54c1df0f-04d4-4026-b675-77fe695fb95c
+---
+
+#2042 "ValidateAndApplyPropertyDescriptor" splits across TWO disjoint code paths
+in standalone — easy to conflate:
+
+- **Native `$Object` runtime** (`object-runtime.ts` `__defineProperty_value`): the
+  path for a DYNAMIC receiver (`function mk(): any { return {}; }`). sdev-reflect's
+  #2042 S4 (PR #20) added the §10.1.6.3 preflight + catchable TypeError here.
+- **Typed-struct call-site** (`object-ops.ts` `compileObjectDefineProperty`, the
+  `needsValueCompare` branch ~L1684): the path an EMPTY `const o: any = {}` literal
+  takes (lowers to an open typed struct → struct.set, NOT the native). This is task
+  #21 (#2042 S4 call-site, sdev-validate PR #1858).
+
+The call-site `needsValueCompare` branch had its own redefine-throw bug, triggered
+by **two value-defines on the SAME key in one function** under nativeStrings:
+`const o:any={}; defineProperty(o,"x",{value:5}); defineProperty(o,"x",{value:6})`.
+It emitted `global.get <ctx.stringGlobalMap.get(msg)>` → `-1` sentinel under
+nativeStrings → `global index out of range — -1` (#2043 class), AND threw a bare
+string (so `assert.throws(TypeError,…)` never matched).
+
+**#2515 S0 (already merged) took the emit-error HALF** — it replaced `global.get -1`
+with `stringConstantExternrefInstrs` (sentinel-safe inline `$NativeString`). But it
+STILL threw a bare string. So the remaining #2042-S4-callsite contribution is just
+the bare-string→TypeError-instance wrapping: route through `emitThrowTypeError`
+(body-swap pattern, mirrors `buildTemporalThrowInstrs`) — it keeps #2515's
+sentinel-safety AND wraps in `__new_TypeError` for a real catchable instance.
+
+Out of scope (deliberately): `getOwnPropertyDescriptor` readback returns `undefined`
+for a RUNTIME-stored key on an empty `const o:any={}` literal (even a plain `o.x=5`
+assign) — that's the #2187 dot-vs-bracket dual-storage / value-rep substrate
+([[project_toprimitive_nominal_struct_gap]] neighbour), owned by sdev-strdispatch.
+CompletePropertyDescriptor attribute-default false-encoding was ALREADY correct in
+`computeRuntimeFlags` (object-ops.ts) — omitted attr → value bit 0 → false.

--- a/.claude/memory/reference_2583_any_strict_eq_tag5_host_only.md
+++ b/.claude/memory/reference_2583_any_strict_eq_tag5_host_only.md
@@ -1,0 +1,44 @@
+---
+name: reference_2583_any_strict_eq_tag5_host_only
+description: "#2583 — standalone __any_strict_eq/__any_eq tag-5 string compare was host-only (wasm:js-string equals) → const 0; native __str_flatten+__str_equals fallback. Plus any.indexOf routing intercept by guarded-string else-arm."
+metadata: 
+  node_type: memory
+  type: reference
+  originSessionId: 54c1df0f-04d4-4026-b675-77fe695fb95c
+---
+
+#2583 standalone any-array `indexOf`/`lastIndexOf`/`includes` had TWO root
+causes (WAT-confirmed; the spec's assumed `__extern_method_call` path was dead):
+
+1. **Routing intercept.** For an `any` receiver + a STRING_METHODS name,
+   `compileMethodCall` (calls.ts ~L8926) fires `compileGuardedNativeStringMethodCall`
+   (string-ops.ts) FIRST — a runtime `ref.test $AnyString` guard whose non-string
+   **else**-arm returned a benign `0`/`NaN`. The array case never reached the
+   closed-method dispatcher `__call_m_<m>_<arity>`. Fix: route that else-arm to the
+   dispatcher for the 3 methods (arity≥1, standalone/wasi) and unbox the boxed
+   result back to the string-arm's result kind.
+
+2. **Substrate bug (broader than #2583).** `__any_strict_eq` AND `__any_eq`'s
+   **tag-5 (string)** content-compare arm used the HOST `wasm:js-string equals`
+   import (`strEqualsIdx = ctx.jsStringImports.get("equals")`). Standalone/wasi
+   has NO host string import → `strEqualsIdx === -1` → arm collapsed to
+   `i32.const 0`. So two EQUAL boxed strings compared UNEQUAL whenever `===`/`==`
+   routed through `__any_strict_eq`/`__any_eq` (boxed-string operands: array
+   elements via `__extern_strict_eq`, object property values, etc.). Bare-identifier
+   `a === b` worked because it uses the *static* `===` lowering with native
+   `__str_equals` — a different path. Fix: `tag5StringEqThen()` in any-helpers.ts
+   prefers the host import (gc/host unchanged) else falls back to native: recover
+   each operand's tag-5 `externval` (fieldIdx 4) via `extern.convert_any` +
+   `ref.cast $AnyString`, `__str_flatten` → `$NativeString`, then native
+   `__str_equals`. Shared by both helpers.
+
+The `$__vec_base` brand arm itself (closed-method-dispatch.ts `fillClosedMethodDispatch`,
+deps reserved at reserve time #1719) uses `__extern_strict_eq` (indexOf/lastIndexOf)
+vs `__extern_same_value_zero` (includes) → correct NaN: indexOf(NaN)=-1,
+includes(NaN)=true.
+
+This touches the SAME tag-5 field-4 arm as parked #2585 (proto-identity ref.eq) —
+#2583 added content-eq only, no ref.eq short-circuit. See [[reference_1629b_boxed_primitive_typeof_eq_layers]].
+Pre-existing unrelated wasi loose-eq failure: `tests/issue-2081.test.ts`
+`__defineProperty_value` late-import shift (#2043 class) — fails identically on
+clean main, not a #2583 regression. PR #1883.


### PR DESCRIPTION
Preserves uncommitted `.claude/memory` edits that had accumulated in /workspace (MEMORY.md index + s65 reference_* files written by dev agents this session: tag-5 classifier, #2583 host-only eq, #2042-S4-vs-#2515, slice-claim collision). These were perpetually blocking the /workspace main fast-forward (they diverged from upstream MEMORY.md, so `merge --ff-only` refused). Committing them frees the sync. 🤖 Generated with [Claude Code](https://claude.com/claude-code)