### PR TITLE
fix(statusline): live sprint + standalone pass-rate sources; harden /workspace sync

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -275,34 +275,20 @@ if [ -z "$in_worktree" ] && [ "$branch" = "main" ]; then
   sprint_n=""
   sprint_done=0
   sprint_total=0
-  sprints_json="/workspace/website/dashboard/data/sprints.json"
-  if [ -f "$sprints_json" ]; then
-    # Read from pre-built sprints.json (deduplicated, wont-fix counted as done)
-    sprint_data=$(jq -r '
-      [ .[] | select(.sprintNumber != null and .isClosed == false and .isPlanning == false) ]
-      | sort_by(.sprintNumber) | last
-      | "\(.sprintNumber) \(.completedIssueIds | length) \(.issueIds | length)"
-    ' "$sprints_json" 2>/dev/null)
+  # LIVE sprint progress: statusline-sprint.mjs recomputes on every render by
+  # scanning the flat plan/issues tree + the sprints/<N>.md `status: active`
+  # marker, so the badge tracks the synced working copy and never freezes on a
+  # stale committed sprints.json (that file is rebuilt only by
+  # `npm run dashboard`/deploys, NOT on PR merge — it was the freeze root cause).
+  # sprints.json remains the mjs's own internal last-resort fallback.
+  # --porcelain emits "N done total".
+  sprint_mjs="/workspace/scripts/statusline-sprint.mjs"
+  if [ -f "$sprint_mjs" ] && command -v node >/dev/null 2>&1; then
+    sprint_data=$(node "$sprint_mjs" --porcelain 2>/dev/null)
     if [ -n "$sprint_data" ]; then
       sprint_n=$(echo "$sprint_data" | awk '{print $1}')
       sprint_done=$(echo "$sprint_data" | awk '{print $2}')
       sprint_total=$(echo "$sprint_data" | awk '{print $3}')
-    fi
-  fi
-  if [ -z "$sprint_n" ]; then
-    # Fallback when sprints.json is absent: delegate to statusline-sprint.mjs,
-    # which scans the flat plan/issues/*.md tree by `sprint:`/`status:`
-    # frontmatter (#1616). The previous shell fallback scanned per-sprint
-    # DIRECTORIES, which broke after the #576 flatten (issues are now flat
-    # files; sprint docs are sprints/<N>.md). --porcelain emits "N done total".
-    sprint_mjs="/workspace/scripts/statusline-sprint.mjs"
-    if [ -f "$sprint_mjs" ] && command -v node >/dev/null 2>&1; then
-      sprint_data=$(node "$sprint_mjs" --porcelain 2>/dev/null)
-      if [ -n "$sprint_data" ]; then
-        sprint_n=$(echo "$sprint_data" | awk '{print $1}')
-        sprint_done=$(echo "$sprint_data" | awk '{print $2}')
-        sprint_total=$(echo "$sprint_data" | awk '{print $3}')
-      fi
     fi
   fi
   if [ -n "$sprint_n" ] && [ "$sprint_total" -gt 0 ]; then
@@ -408,13 +394,19 @@ elif [ -f "$report" ]; then
     # excluded, matching the host bar's denominator.
     sa_bar=""
     sa_pass=""; sa_total=""
-    if [ -f "$standalone_report" ]; then
-      sa_pass=$(jq -r '.summary.pass // 0' "$standalone_report" 2>/dev/null)
-      sa_total=$(jq -r '.summary.total // 1' "$standalone_report" 2>/dev/null)
-    elif [ -f "$standalone_highwater" ]; then
-      # high-water official_* fields = standalone pass/total WITHOUT proposals
+    # Prefer the committed high-water mark (official_* fields = standalone
+    # pass/total WITHOUT proposals): the promote-baseline CI job refreshes it on
+    # every push to main, so it tracks the latest js2wasm-baselines numbers. The
+    # local test262-standalone-report.json is an UNtracked dev-run artifact that
+    # goes stale (a 5-day-old 47% shadowed the fresh 52.6% high-water mark), so
+    # use it ONLY when it is genuinely newer than the high-water file.
+    if [ -f "$standalone_highwater" ]; then
       sa_pass=$(jq -r '.official_pass // empty' "$standalone_highwater" 2>/dev/null)
       sa_total=$(jq -r '.official_total // empty' "$standalone_highwater" 2>/dev/null)
+    fi
+    if [ -f "$standalone_report" ] && [ "$standalone_report" -nt "$standalone_highwater" ]; then
+      sa_pass=$(jq -r '.summary.pass // 0' "$standalone_report" 2>/dev/null)
+      sa_total=$(jq -r '.summary.total // 1' "$standalone_report" 2>/dev/null)
     fi
     if [ -n "$sa_total" ] && [ "$sa_total" -gt 0 ] 2>/dev/null; then
       sa_pct=$(awk "BEGIN {printf \"%.1f\", $sa_pass * 100 / $sa_total}")

--- a/scripts/statusline-sprint.mjs
+++ b/scripts/statusline-sprint.mjs
@@ -1,9 +1,14 @@
 #!/usr/bin/env node
 // Sprint progress statusline for Claude Code.
-// Prefers dashboard/data/sprints.json (accurate deduplicated view) when available.
-// Falls back to scanning the flat plan/issues/*.md tree, reading the `sprint:`
-// and `status:` frontmatter fields (#1616 — sprint membership is frontmatter,
-// not directory).
+// LIVE source of truth: scans the flat plan/issues/*.md tree (the synced
+// working copy), reading `sprint:`/`status:` frontmatter (#1616 — sprint
+// membership is frontmatter, not directory) and the sprints/<N>.md doc
+// `status: active` marker to pick the current sprint. This recomputes on
+// every render, so the badge never freezes. The committed
+// dashboard/data/sprints.json is only a LAST-RESORT fallback: it is rebuilt
+// solely by `npm run dashboard`/deploys (NOT on PR merge), so it goes stale
+// between rebuilds — which is exactly what used to freeze the badge on an
+// old sprint.
 // Emits a colored badge: "sprint N  NN%"
 
 import { readdirSync, readFileSync, existsSync } from "node:fs";
@@ -12,7 +17,36 @@ import { fileURLToPath } from "node:url";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const ISSUES_DIR = join(ROOT, "plan", "issues");
+const SPRINTS_DIR = join(ISSUES_DIR, "sprints");
 const SPRINTS_JSON = join(ROOT, "website", "dashboard", "data", "sprints.json");
+
+// The current sprint = the highest-numbered sprints/<N>.md whose doc carries
+// `status: active`. Authoritative over "highest sprint number that has issues"
+// because it won't jump ahead when a single future-sprint issue is groomed in.
+function activeSprintFromDocs() {
+  let names = [];
+  try {
+    names = readdirSync(SPRINTS_DIR);
+  } catch {
+    return null;
+  }
+  let best = null;
+  for (const f of names) {
+    const m = f.match(/^(\d+)\.md$/);
+    if (!m) continue;
+    let content;
+    try {
+      content = readFileSync(join(SPRINTS_DIR, f), "utf8");
+    } catch {
+      continue;
+    }
+    if (/^status:\s*active\b/m.test(content)) {
+      const n = Number(m[1]);
+      if (best === null || n > best) best = n;
+    }
+  }
+  return best;
+}
 
 function fromJson() {
   if (!existsSync(SPRINTS_JSON)) return null;
@@ -100,9 +134,16 @@ function interpolateColor(pct) {
   return [Math.round(r * 220), Math.round(g * 200), Math.round(b * 20)];
 }
 
-const jsonData = fromJson();
-const sprint = jsonData ? jsonData.sprint : currentSprint();
-const { done, total } = jsonData ?? sprintProgress(sprint);
+// LIVE-first: active sprint from the sprints/<N>.md `status: active` marker,
+// else the highest sprint number with issues; progress counted from the flat
+// issue tree. The committed sprints.json is consulted only if the live scan
+// finds nothing (e.g. the issues dir is unavailable).
+let sprint = activeSprintFromDocs() ?? currentSprint();
+let { done, total } = sprintProgress(sprint);
+if (total === 0) {
+  const jsonData = fromJson();
+  if (jsonData) ({ sprint, done, total } = jsonData);
+}
 const pct = total === 0 ? 0 : done / total;
 const pctInt = Math.round(pct * 100);
 

--- a/scripts/sync-workspace-main.sh
+++ b/scripts/sync-workspace-main.sh
@@ -39,17 +39,18 @@ if [ "$cur_branch" != "main" ]; then
   say "checkout is on '$cur_branch', not main — skipping (won't switch branches)"; exit 0
 fi
 
-# Refuse to touch a dirty tree — surface, don't discard. EXCEPTION: ignore
-# changes under .claude/memory/ (see header) so the hook isn't permanently
-# blocked by live team-memory writes.
-if ! git -C "$WS" diff --quiet -- . ':(exclude).claude/memory' 2>/dev/null \
-   || ! git -C "$WS" diff --cached --quiet -- . ':(exclude).claude/memory' 2>/dev/null; then
-  say "WARNING: $WS has uncommitted changes outside .claude/memory/ — NOT syncing (commit/clean it, then rerun)."
-  exit 0
-fi
-
+# Fast-forward. `git merge --ff-only` is SAFE on a dirty tree: it preserves
+# uncommitted changes to unrelated files and refuses (non-zero) ONLY when an
+# incoming commit would overwrite a locally-modified file — so it never
+# discards local work. This is deliberately more robust than pre-refusing on
+# any dirt: the old pre-check left /workspace rotting behind main whenever the
+# tree carried incidental uncommitted changes (a regenerated artifact, a stray
+# edit) outside .claude/memory — the very drift this hook exists to prevent.
 if git -C "$WS" merge --ff-only origin/main >/dev/null 2>&1; then
   say "fast-forwarded $local_sha -> $main_sha"
+elif ! git -C "$WS" diff --quiet -- . ':(exclude).claude/memory' 2>/dev/null \
+   || ! git -C "$WS" diff --cached --quiet -- . ':(exclude).claude/memory' 2>/dev/null; then
+  say "WARNING: cannot ff — $WS has uncommitted changes that conflict with incoming main. Commit/stash them, then rerun."
 else
   say "WARNING: cannot fast-forward (diverged?) — left at $local_sha. Resolve manually."
 fi


### PR DESCRIPTION
Statusline froze on stale committed artifacts; this makes its dynamic segments compute from live/CI-refreshed sources.

**Sprint bar** read `website/dashboard/data/sprints.json`, rebuilt only by `build-data.js` on deploys (NOT on PR merge) — it stuck on `s64` after s65 opened. `statusline-sprint.mjs` now computes LIVE from the flat `plan/issues` tree + the `sprints/<N>.md` `status: active` marker; `statusline-command.sh` calls it as the primary source (sprints.json demoted to last-resort fallback). ~250ms/render (2,225 files), well within the 30s refresh.

**Standalone pass-rate** preferred `test262-standalone-report.json` — an UNtracked local dev-run artifact — over the CI-refreshed high-water mark, shadowing the fresh 52.6% with a 5-day-old 47%. Now prefers the committed high-water mark, falling back to the local report only when genuinely newer.

**Sync** (`sync-workspace-main.sh`) stopped pre-refusing on incidental dirt outside `.claude/memory`: it now attempts the ff (`git --ff-only` is safe on a dirty tree — preserves unrelated uncommitted changes, refuses only on real conflict) and warns precisely, so /workspace stays synced.

Verified live: statusline renders `s65 3/43  73.4% t262  52.6% sa` (was frozen `s64 30/80 ... 47.0% sa`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)