### PR TITLE
refactor(#2146): harden codegen DI registration; retire one slot

### DIFF
--- a/plan/issues/2146-retire-shared-ts-registration-indirection.md
+++ b/plan/issues/2146-retire-shared-ts-registration-indirection.md
@@ -1,10 +1,12 @@
 ---
 id: 2146
 title: "Retire the registration-indirection layer in codegen/shared.ts"
-status: ready
+status: done
 sprint: 65
 created: 2026-06-12
-updated: 2026-06-12
+updated: 2026-06-21
+completed: 2026-06-21
+assignee: senior-dev-shared
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -42,3 +44,65 @@ churn twice.
 ## Notes
 
 Routine dev, S-size, sprint 63 (sequenced behind #1916's spec).
+
+## Resolution (2026-06-21, senior-dev)
+
+This issue's acceptance criterion is binary: **zero `register*` DI slots, OR
+absorb the residual into #1916 with a pointer.** Empirical analysis (below)
+showed full-zero is infeasible without the module-graph restructuring that
+#1916 owns, so this PR takes **both** available branches: it retires the one
+slot that can be removed safely *today*, fixes the actual reported defect (the
+runtime trap), and points the residual at #1916.
+
+### Why "zero slots" is not a standalone refactor
+
+The `register*` slots are not gratuitous — `shared.ts` is the deliberate
+**acyclic sink** that every codegen module may import. I built a static
+import-graph prober (throwaway) and tested, for each delegate, whether
+converting its consumers to a direct import of the impl module would introduce
+an ESM cycle. **Almost every conversion cycles** (e.g. `coerceType`,
+`compileExpression`, `ensureLateImport`, `materializeStructAsObject`,
+`ensureBindingLocals`, `hoistFunctionDeclarations`, `compileSuperPropertyAccess`
+all re-form a cycle through `literals.ts`/`type-coercion.ts`/`property-access.ts`/
+`statements.ts`). In ESM a cycle means a binding is *transiently `undefined`* —
+a strictly **worse** trap than the current explicit throw. The two impls that
+live in `index.ts` (`addUnionImports`, `addStringImports`) genuinely cannot be
+direct-imported because `index.ts` imports the would-be consumers
+(`late-imports.ts`, `any-helpers.ts`) — an irreducible cycle given today's
+layout. Retiring those requires extracting the recursion hubs / the
+`addImport`+index-shift machinery into leaf modules, which **is exactly
+#1916's** scope. #1916 is currently `blocked` (`blocked_by: [2167]`).
+
+### What this PR did
+
+1. **Retired one slot fully, zero cycle risk** — `resolveEnclosingClassName`
+   (+ `registerResolveEnclosingClassName`) had a self-contained body that reads
+   only `fctx`, so it now lives *directly* in `shared.ts`. The delegate, the
+   registrar import in `new-super.ts`, and the module-scope `register…()` call
+   are gone. Consumers already imported it from `shared.ts`; no consumer import
+   changed. DI slots: 21 → 20.
+
+2. **Fixed the actual reported defect — the runtime trap.** The remaining 18
+   throwing stubs no longer throw a bare `"X not yet registered"` deep inside
+   codegen; each now names the module that owns its registration. A new
+   `assertCodegenRegistrationsComplete()` runs **once at compile entry**
+   (`compiler.ts::compileSourceSync`, the single production chokepoint that
+   statically pulls every registrar) and fails fast listing *every* unwired
+   delegate + its owning module. An obscure mid-codegen
+   `undefined-is-not-a-function`-class error is now an actionable load-order
+   diagnostic at the front door. Verified: a normal compile passes the
+   assertion and runs; importing `index.ts` in isolation (which does not pull
+   `expressions.ts`/`new-super.ts`) fails with the precise 5-delegate
+   diagnostic. Regression test:
+   `tests/issue-2146-registration-hardening.test.ts`.
+
+### Residual → #1916 (pointer, per acceptance criterion branch 2)
+
+The remaining 20 `register*` slots cannot be removed without the symbolic-ref
++ module-graph restructuring tracked by **#1916** (and its prerequisite
+#2167). When #1916 lands `FuncHandle`-based late imports and lifts
+`addUnionImports`/`addStringImports`/the recursion hubs out of `index.ts` into
+leaf modules, the cycles dissolve and the slots can be replaced by direct
+imports. The fail-fast guard added here is forward-compatible: it simply
+becomes dead (and removable) once the slots are gone. **#1916 owns the residual
+of #2146.**

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -92,7 +92,7 @@ export {
   emitNullCheckThrow,
   isProvablyNonNull,
 } from "./property-access.js";
-export { getCol, getLine, valTypesMatch, VOID_RESULT } from "./shared.js";
+export { getCol, getLine, resolveEnclosingClassName, valTypesMatch, VOID_RESULT } from "./shared.js";
 export {
   compileNativeStringLiteral,
   compileNativeStringMethodCall,
@@ -143,7 +143,6 @@ export {
   compileNewExpression,
   compileSuperElementAccess,
   compileSuperPropertyAccess,
-  resolveEnclosingClassName,
 } from "./expressions/new-super.js";
 export { compileMemberIncDec, compilePostfixUnary, compilePrefixUnary } from "./expressions/unary.js";
 

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -47,7 +47,7 @@ import {
   compileStatement,
   registerCompileSuperElementAccess,
   registerCompileSuperPropertyAccess,
-  registerResolveEnclosingClassName,
+  resolveEnclosingClassName,
 } from "../shared.js";
 import { maybeSetArgcForKnownCall } from "../statements/nested-declarations.js";
 import { compileStringLiteral } from "../string-ops.js";
@@ -69,12 +69,7 @@ import {
 import { localGlobalIdx } from "../registry/imports.js";
 import { ensureLateImport, flushLateImportShifts } from "./late-imports.js";
 
-function resolveEnclosingClassName(fctx: FunctionContext): string | undefined {
-  if (fctx.enclosingClassName) return fctx.enclosingClassName;
-  const underscoreIdx = fctx.name.indexOf("_");
-  if (underscoreIdx > 0) return fctx.name.substring(0, underscoreIdx);
-  return undefined;
-}
+// #2146: resolveEnclosingClassName now lives in shared.ts (imported above).
 
 function valTypeMatches(a: ValType, b: ValType): boolean {
   if (a.kind !== b.kind) return false;
@@ -4652,16 +4647,9 @@ function emitTypedArrayFromByteBuffer(
   return true;
 }
 
-export {
-  compileClassExpression,
-  compileNewExpression,
-  compileSuperElementMethodCall,
-  compileSuperMethodCall,
-  resolveEnclosingClassName,
-};
+export { compileClassExpression, compileNewExpression, compileSuperElementMethodCall, compileSuperMethodCall };
 
-// Register the resolveEnclosingClassName delegate so closures.ts (and others)
-// can call it via shared.ts without creating an import cycle.
-registerResolveEnclosingClassName(resolveEnclosingClassName);
+// #2146: resolveEnclosingClassName is now defined in shared.ts directly (no DI
+// slot), so there is no longer a delegate to register here.
 registerCompileSuperPropertyAccess(compileSuperPropertyAccess);
 registerCompileSuperElementAccess(compileSuperElementAccess);

--- a/src/codegen/shared.ts
+++ b/src/codegen/shared.ts
@@ -105,6 +105,85 @@ export function getCol(node: ts.Node): number {
 // ── Late-bound delegates ──────────────────────────────────────────────
 // Each delegate starts as a throwing stub and is replaced by the real
 // implementation when the owning module is loaded.
+//
+// #2146 — these function-pointer slots are a deliberate cycle-breaker (this
+// module is the acyclic sink that every codegen module may import), but their
+// initialization order used to be a *runtime trap*: a stub threw a bare
+// "X not yet registered" only when first *called*, deep inside codegen, with no
+// hint of which registrar module failed to load. Two changes harden that:
+//   1. each stub's throw now names the module that owns its registration, and
+//   2. `assertCodegenRegistrationsComplete()` (called once at compile entry)
+//      fails fast and lists every still-unwired delegate, turning an obscure
+//      mid-codegen error into an actionable load-order diagnostic.
+// Full removal of the slots is tracked by #1916 (symbolic func refs +
+// module-graph restructuring); see that issue for the residual plan.
+
+/** Names of delegates that have been wired by their owning module. */
+const _registeredDelegates = new Set<string>();
+
+/**
+ * Required delegate → the codegen module whose module-scope `register*` call
+ * wires it. Kept in sync with the `register*` functions below; used to produce
+ * an actionable diagnostic when a delegate is invoked (or asserted) before its
+ * owning module has been imported. Only delegates with a *throwing* stub are
+ * listed — slots with a safe default (`materializeStructAsObject` → false,
+ * `addStringImports` → no-op) are intentionally optional and omitted.
+ */
+const REQUIRED_DELEGATE_OWNERS: Readonly<Record<string, string>> = {
+  compileExpression: "expressions.ts",
+  compileArrowAsClosure: "closures.ts",
+  emitBoundsCheckedArrayGet: "array-methods.ts",
+  coerceType: "type-coercion.ts",
+  ensureLateImport: "expressions/late-imports.ts (registered by expressions.ts)",
+  flushLateImportShifts: "expressions/late-imports.ts (registered by expressions.ts)",
+  ensureAnyHelpers: "any-helpers.ts",
+  addUnionImports: "index.ts",
+  resolveComputedKeyExpression: "literals.ts",
+  compileStatement: "statements.ts",
+  ensureBindingLocals: "statements/destructuring.ts",
+  hoistFunctionDeclarations: "statements/nested-declarations.ts",
+  emitNestedBindingDefault: "statements/destructuring.ts",
+  emitDefaultValueCheck: "statements/destructuring.ts",
+  emitArgumentsObject: "statements/nested-declarations.ts",
+  compileStringLiteral: "string-ops.ts",
+  compileSuperPropertyAccess: "expressions/new-super.ts",
+  compileSuperElementAccess: "expressions/new-super.ts",
+};
+
+function markRegistered(name: string): void {
+  _registeredDelegates.add(name);
+}
+
+/**
+ * Build the "X not yet registered" message for a delegate stub, naming the
+ * module that should have wired it (#2146).
+ */
+function unregisteredDelegateError(name: string): Error {
+  const owner = REQUIRED_DELEGATE_OWNERS[name];
+  const where = owner ? ` — its owning module (${owner}) was not imported before this call` : "";
+  return new Error(`codegen delegate "${name}" not yet registered${where}`);
+}
+
+/**
+ * Fail fast at compile entry if any required codegen delegate is still its
+ * throwing stub (#2146). Without this, a missing registration surfaces only
+ * deep inside codegen — as an obscure "X not yet registered" — when (and if)
+ * the relevant feature happens to be exercised by the input program.
+ *
+ * Call this once per top-level codegen entry (`generateModule` /
+ * `generateMultiModule`). It is O(slots) and has no effect in the normal path
+ * where `src/compiler.ts` eagerly imports the registrar modules.
+ */
+export function assertCodegenRegistrationsComplete(): void {
+  const missing = Object.keys(REQUIRED_DELEGATE_OWNERS).filter((name) => !_registeredDelegates.has(name));
+  if (missing.length === 0) return;
+  const detail = missing.map((name) => `  - ${name} (owner: ${REQUIRED_DELEGATE_OWNERS[name]})`).join("\n");
+  throw new Error(
+    `codegen registration incomplete: ${missing.length} delegate(s) were never wired.\n` +
+      `This means a registrar module was not imported before codegen ran ` +
+      `(see src/compiler.ts and src/codegen/shared.ts #2146).\n${detail}`,
+  );
+}
 
 type CompileExpressionFn = (
   ctx: CodegenContext,
@@ -114,11 +193,12 @@ type CompileExpressionFn = (
 ) => ValType | null;
 
 let _compileExpression: CompileExpressionFn = () => {
-  throw new Error("compileExpression not yet registered");
+  throw unregisteredDelegateError("compileExpression");
 };
 
 export function registerCompileExpression(fn: CompileExpressionFn): void {
   _compileExpression = fn;
+  markRegistered("compileExpression");
 }
 
 export function compileExpression(
@@ -139,11 +219,12 @@ type CompileArrowAsClosureFn = (
 ) => ValType | null;
 
 let _compileArrowAsClosure: CompileArrowAsClosureFn = () => {
-  throw new Error("compileArrowAsClosure not yet registered");
+  throw unregisteredDelegateError("compileArrowAsClosure");
 };
 
 export function registerCompileArrowAsClosure(fn: CompileArrowAsClosureFn): void {
   _compileArrowAsClosure = fn;
+  markRegistered("compileArrowAsClosure");
 }
 
 export function compileArrowAsClosure(
@@ -165,11 +246,12 @@ type EmitBoundsCheckedArrayGetFn = (
 ) => void;
 
 let _emitBoundsCheckedArrayGet: EmitBoundsCheckedArrayGetFn = () => {
-  throw new Error("emitBoundsCheckedArrayGet not yet registered");
+  throw unregisteredDelegateError("emitBoundsCheckedArrayGet");
 };
 
 export function registerEmitBoundsCheckedArrayGet(fn: EmitBoundsCheckedArrayGetFn): void {
   _emitBoundsCheckedArrayGet = fn;
+  markRegistered("emitBoundsCheckedArrayGet");
 }
 
 export function emitBoundsCheckedArrayGet(
@@ -183,17 +265,21 @@ export function emitBoundsCheckedArrayGet(
 }
 
 // ── resolveEnclosingClassName ─────────────────────────────────────────
+// #2146: this helper has NO module dependencies (it reads only `fctx`), so it
+// lives directly in `shared.ts` (the acyclic sink) instead of behind a DI
+// slot. Consumers already import it from here; the previous delegate +
+// `registerResolveEnclosingClassName` indirection has been retired.
 
-type ResolveEnclosingClassNameFn = (fctx: FunctionContext) => string | undefined;
-
-let _resolveEnclosingClassName: ResolveEnclosingClassNameFn = () => undefined;
-
-export function registerResolveEnclosingClassName(fn: ResolveEnclosingClassNameFn): void {
-  _resolveEnclosingClassName = fn;
-}
-
+/**
+ * Best-effort name of the class lexically enclosing `fctx`. Prefers the
+ * explicit `enclosingClassName` carried on the context; otherwise falls back to
+ * the `${Class}_${method}` naming convention baked into compiled method names.
+ */
 export function resolveEnclosingClassName(fctx: FunctionContext): string | undefined {
-  return _resolveEnclosingClassName(fctx);
+  if (fctx.enclosingClassName) return fctx.enclosingClassName;
+  const underscoreIdx = fctx.name.indexOf("_");
+  if (underscoreIdx > 0) return fctx.name.substring(0, underscoreIdx);
+  return undefined;
 }
 
 // ── coerceType ────────────────────────────────────────────────────────
@@ -207,11 +293,12 @@ type CoerceTypeFn = (
 ) => void;
 
 let _coerceType: CoerceTypeFn = () => {
-  throw new Error("coerceType not yet registered");
+  throw unregisteredDelegateError("coerceType");
 };
 
 export function registerCoerceType(fn: CoerceTypeFn): void {
   _coerceType = fn;
+  markRegistered("coerceType");
 }
 
 export function coerceType(
@@ -241,6 +328,7 @@ let _materializeStructAsObject: MaterializeStructAsObjectFn = () => false;
 
 export function registerMaterializeStructAsObject(fn: MaterializeStructAsObjectFn): void {
   _materializeStructAsObject = fn;
+  markRegistered("materializeStructAsObject");
 }
 
 export function materializeStructAsObject(ctx: CodegenContext, fctx: FunctionContext, structTypeIdx: number): boolean {
@@ -259,19 +347,21 @@ type EnsureLateImportFn = (
 type FlushLateImportShiftsFn = (ctx: CodegenContext, fctx: FunctionContext | null) => void;
 
 let _ensureLateImport: EnsureLateImportFn = () => {
-  throw new Error("ensureLateImport not yet registered");
+  throw unregisteredDelegateError("ensureLateImport");
 };
 
 let _flushLateImportShifts: FlushLateImportShiftsFn = () => {
-  throw new Error("flushLateImportShifts not yet registered");
+  throw unregisteredDelegateError("flushLateImportShifts");
 };
 
 export function registerEnsureLateImport(fn: EnsureLateImportFn): void {
   _ensureLateImport = fn;
+  markRegistered("ensureLateImport");
 }
 
 export function registerFlushLateImportShifts(fn: FlushLateImportShiftsFn): void {
   _flushLateImportShifts = fn;
+  markRegistered("flushLateImportShifts");
 }
 
 export function ensureLateImport(
@@ -307,11 +397,12 @@ export function isAnyValue(type: ValType, ctx: CodegenContext): boolean {
 type EnsureAnyHelpersFn = (ctx: CodegenContext) => void;
 
 let _ensureAnyHelpers: EnsureAnyHelpersFn = () => {
-  throw new Error("ensureAnyHelpers not yet registered");
+  throw unregisteredDelegateError("ensureAnyHelpers");
 };
 
 export function registerEnsureAnyHelpers(fn: EnsureAnyHelpersFn): void {
   _ensureAnyHelpers = fn;
+  markRegistered("ensureAnyHelpers");
 }
 
 // ── addUnionImports (lazy binding to avoid index.ts ↔ late-imports.ts cycle) ──
@@ -323,11 +414,12 @@ export function registerEnsureAnyHelpers(fn: EnsureAnyHelpersFn): void {
 type AddUnionImportsFn = (ctx: CodegenContext) => void;
 
 let _addUnionImports: AddUnionImportsFn = () => {
-  throw new Error("addUnionImports not yet registered");
+  throw unregisteredDelegateError("addUnionImports");
 };
 
 export function registerAddUnionImports(fn: AddUnionImportsFn): void {
   _addUnionImports = fn;
+  markRegistered("addUnionImports");
 }
 
 export function addUnionImportsViaRegistry(ctx: CodegenContext): void {
@@ -343,11 +435,12 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
 type ResolveComputedKeyExpressionFn = (ctx: CodegenContext, expr: ts.Expression) => string | undefined;
 
 let _resolveComputedKeyExpression: ResolveComputedKeyExpressionFn = () => {
-  throw new Error("resolveComputedKeyExpression not yet registered");
+  throw unregisteredDelegateError("resolveComputedKeyExpression");
 };
 
 export function registerResolveComputedKeyExpression(fn: ResolveComputedKeyExpressionFn): void {
   _resolveComputedKeyExpression = fn;
+  markRegistered("resolveComputedKeyExpression");
 }
 
 export function resolveComputedKeyExpression(ctx: CodegenContext, expr: ts.Expression): string | undefined {
@@ -359,11 +452,12 @@ export function resolveComputedKeyExpression(ctx: CodegenContext, expr: ts.Expre
 type CompileStatementFn = (ctx: CodegenContext, fctx: FunctionContext, stmt: ts.Statement) => void;
 
 let _compileStatement: CompileStatementFn = () => {
-  throw new Error("compileStatement not yet registered");
+  throw unregisteredDelegateError("compileStatement");
 };
 
 export function registerCompileStatement(fn: CompileStatementFn): void {
   _compileStatement = fn;
+  markRegistered("compileStatement");
 }
 
 export function compileStatement(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.Statement): void {
@@ -375,11 +469,12 @@ export function compileStatement(ctx: CodegenContext, fctx: FunctionContext, stm
 type EnsureBindingLocalsFn = (ctx: CodegenContext, fctx: FunctionContext, pattern: ts.BindingPattern) => void;
 
 let _ensureBindingLocals: EnsureBindingLocalsFn = () => {
-  throw new Error("ensureBindingLocals not yet registered");
+  throw unregisteredDelegateError("ensureBindingLocals");
 };
 
 export function registerEnsureBindingLocals(fn: EnsureBindingLocalsFn): void {
   _ensureBindingLocals = fn;
+  markRegistered("ensureBindingLocals");
 }
 
 export function ensureBindingLocals(ctx: CodegenContext, fctx: FunctionContext, pattern: ts.BindingPattern): void {
@@ -395,11 +490,12 @@ type HoistFunctionDeclarationsFn = (
 ) => void;
 
 let _hoistFunctionDeclarations: HoistFunctionDeclarationsFn = () => {
-  throw new Error("hoistFunctionDeclarations not yet registered");
+  throw unregisteredDelegateError("hoistFunctionDeclarations");
 };
 
 export function registerHoistFunctionDeclarations(fn: HoistFunctionDeclarationsFn): void {
   _hoistFunctionDeclarations = fn;
+  markRegistered("hoistFunctionDeclarations");
 }
 
 export function hoistFunctionDeclarations(
@@ -421,11 +517,12 @@ type EmitNestedBindingDefaultFn = (
 ) => void;
 
 let _emitNestedBindingDefault: EmitNestedBindingDefaultFn = () => {
-  throw new Error("emitNestedBindingDefault not yet registered");
+  throw unregisteredDelegateError("emitNestedBindingDefault");
 };
 
 export function registerEmitNestedBindingDefault(fn: EmitNestedBindingDefaultFn): void {
   _emitNestedBindingDefault = fn;
+  markRegistered("emitNestedBindingDefault");
 }
 
 export function emitNestedBindingDefault(
@@ -451,11 +548,12 @@ type EmitDefaultValueCheckFn = (
 ) => void;
 
 let _emitDefaultValueCheck: EmitDefaultValueCheckFn = () => {
-  throw new Error("emitDefaultValueCheck not yet registered");
+  throw unregisteredDelegateError("emitDefaultValueCheck");
 };
 
 export function registerEmitDefaultValueCheck(fn: EmitDefaultValueCheckFn): void {
   _emitDefaultValueCheck = fn;
+  markRegistered("emitDefaultValueCheck");
 }
 
 export function emitDefaultValueCheck(
@@ -481,11 +579,12 @@ type EmitArgumentsObjectFn = (
 ) => void;
 
 let _emitArgumentsObject: EmitArgumentsObjectFn = () => {
-  throw new Error("emitArgumentsObject not yet registered");
+  throw unregisteredDelegateError("emitArgumentsObject");
 };
 
 export function registerEmitArgumentsObject(fn: EmitArgumentsObjectFn): void {
   _emitArgumentsObject = fn;
+  markRegistered("emitArgumentsObject");
 }
 
 /**
@@ -513,11 +612,12 @@ type CompileStringLiteralFn = (
 ) => ValType | null;
 
 let _compileStringLiteral: CompileStringLiteralFn = () => {
-  throw new Error("compileStringLiteral not yet registered");
+  throw unregisteredDelegateError("compileStringLiteral");
 };
 
 export function registerCompileStringLiteral(fn: CompileStringLiteralFn): void {
   _compileStringLiteral = fn;
+  markRegistered("compileStringLiteral");
 }
 
 export function compileStringLiteral(
@@ -539,11 +639,12 @@ type CompileSuperPropertyAccessFn = (
 ) => ValType | null;
 
 let _compileSuperPropertyAccess: CompileSuperPropertyAccessFn = () => {
-  throw new Error("compileSuperPropertyAccess not yet registered");
+  throw unregisteredDelegateError("compileSuperPropertyAccess");
 };
 
 export function registerCompileSuperPropertyAccess(fn: CompileSuperPropertyAccessFn): void {
   _compileSuperPropertyAccess = fn;
+  markRegistered("compileSuperPropertyAccess");
 }
 
 export function compileSuperPropertyAccess(
@@ -564,11 +665,12 @@ type CompileSuperElementAccessFn = (
 ) => ValType | null;
 
 let _compileSuperElementAccess: CompileSuperElementAccessFn = () => {
-  throw new Error("compileSuperElementAccess not yet registered");
+  throw unregisteredDelegateError("compileSuperElementAccess");
 };
 
 export function registerCompileSuperElementAccess(fn: CompileSuperElementAccessFn): void {
   _compileSuperElementAccess = fn;
+  markRegistered("compileSuperElementAccess");
 }
 
 export function compileSuperElementAccess(
@@ -597,6 +699,7 @@ let _addStringImports: AddStringImportsFn = () => {
 
 export function registerAddStringImports(fn: AddStringImportsFn): void {
   _addStringImports = fn;
+  markRegistered("addStringImports");
 }
 
 export function addStringImportsDelegate(ctx: CodegenContext): void {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -11,6 +11,7 @@ import { getNullablePrimitiveInfo } from "./checker/type-mapper.js";
 import { generateLinearModule, generateLinearMultiModule } from "./codegen-linear/index.js";
 import { resetCompileDepth } from "./codegen/expressions.js";
 import { generateModule, generateMultiModule } from "./codegen/index.js";
+import { assertCodegenRegistrationsComplete } from "./codegen/shared.js";
 import { isFatalCodegenDiagnostic } from "./codegen/context/errors.js";
 import type { WasmModule } from "./ir/types.js";
 import {
@@ -522,6 +523,14 @@ export function compileSourceSync(
   // Without this, the depth accumulates across compilations in the same process
   // (e.g., test262 worker pool), causing false "depth exceeded" errors.
   resetCompileDepth();
+
+  // #2146 — fail fast (with the offending module named) if any codegen delegate
+  // was never wired, instead of throwing an obscure "X not yet registered" deep
+  // inside codegen only when the relevant feature is exercised. This entry pulls
+  // in every registrar module statically (via the codegen imports above), so the
+  // assertion always passes on the production path; it only fires if a future
+  // refactor breaks the registrar-import chain.
+  assertCodegenRegistrationsComplete();
 
   const errors: CompileError[] = [];
   const emitWatOutput = options.emitWat !== false;

--- a/tests/issue-2146-registration-hardening.test.ts
+++ b/tests/issue-2146-registration-hardening.test.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2146 — the codegen DI registration slots in src/codegen/shared.ts used to
+// turn initialization order into a *runtime trap*: a stub threw a bare
+// "X not yet registered" only when first invoked, deep inside codegen, with no
+// hint of which registrar module failed to load. This test pins the two
+// hardening behaviours that replaced that trap:
+//   1. `assertCodegenRegistrationsComplete()` is a no-op on the production path
+//      (compiler.ts pulls every registrar module statically), and
+//   2. `resolveEnclosingClassName`, which moved out of the DI layer and into
+//      shared.ts directly (slot fully retired), still behaves identically.
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { assertCodegenRegistrationsComplete, resolveEnclosingClassName } from "../src/codegen/shared.js";
+import type { FunctionContext } from "../src/codegen/context/types.js";
+
+describe("#2146 codegen registration hardening", () => {
+  it("a real compile passes the registration assertion and runs", async () => {
+    const result = await compile(`
+      class Box { v: number = 0; get(): number { return this.v; } }
+      export function run(): number { const b = new Box(); b.v = 41; return b.get() + 1; }
+    `);
+    expect(result.errors ?? []).toHaveLength(0);
+    expect(result.binary).toBeInstanceOf(Uint8Array);
+
+    const { instance } = await WebAssembly.instantiate(result.binary, result.importObject ?? {});
+    expect((instance.exports as { run: () => number }).run()).toBe(42);
+  });
+
+  it("assertCodegenRegistrationsComplete is a no-op once the registrar chain is loaded", () => {
+    // Importing ../src/index.js (compiler.ts) above pulls every registrar
+    // module statically, so the assertion must not throw.
+    expect(() => assertCodegenRegistrationsComplete()).not.toThrow();
+  });
+
+  it("resolveEnclosingClassName (now defined directly in shared.ts) is behaviour-preserving", () => {
+    const ctx = (over: Partial<FunctionContext>) => over as FunctionContext;
+    // explicit enclosingClassName wins
+    expect(resolveEnclosingClassName(ctx({ name: "anything", enclosingClassName: "Baz" }))).toBe("Baz");
+    // falls back to the `${Class}_${method}` compiled-name convention
+    expect(resolveEnclosingClassName(ctx({ name: "Foo_bar" }))).toBe("Foo");
+    // no underscore, no explicit name → undefined
+    expect(resolveEnclosingClassName(ctx({ name: "noUnderscore" }))).toBeUndefined();
+    // leading underscore is not a class separator (underscoreIdx must be > 0)
+    expect(resolveEnclosingClassName(ctx({ name: "_leading" }))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## #2146 — retire the registration-indirection layer in codegen/shared.ts

The function-pointer `register*` slots in `src/codegen/shared.ts` are a deliberate **acyclic-sink cycle-breaker** (every codegen module may import `shared.ts`), but their initialization order was a *runtime trap*: a stub threw a bare `"X not yet registered"` only when first **called**, deep inside codegen, with no hint which registrar module failed to load.

### Why "zero slots" is not a standalone refactor

The acceptance criterion is binary — zero `register*` slots **OR** absorb the residual into #1916 with a pointer. I built a static import-graph probe and tested, per delegate, whether converting consumers to a direct import of the impl module introduces an ESM cycle. **Almost every conversion cycles** (through `literals.ts`/`type-coercion.ts`/`property-access.ts`/`statements.ts`); in ESM a cycle means a transiently-`undefined` binding — a strictly **worse** trap than the current explicit throw. The two impls in `index.ts` (`addUnionImports`/`addStringImports`) are irreducible because `index.ts` imports their would-be consumers. Full removal needs the symbolic-ref + module-graph restructuring that **#1916 owns** (currently `blocked_by: [2167]`).

So this PR takes **both** available branches of the criterion.

### What changed

1. **Retired one slot, zero cycle risk** — `resolveEnclosingClassName` reads only `fctx`, so it now lives *directly* in `shared.ts`. Delegate + `registerResolveEnclosingClassName` + the module-scope `register…()` call are deleted; no consumer import changed. DI slots: **21 → 20**.

2. **Fixed the actual reported defect (the runtime trap)** — the 18 throwing stubs now name their owning module, and a new `assertCodegenRegistrationsComplete()` runs **once at the compile chokepoint** (`compiler.ts::compileSourceSync`, proven to statically pull every registrar) and fails fast listing *every* unwired delegate + its owning module. An obscure mid-codegen error is now an actionable load-order diagnostic at the front door.

### Residual → #1916

The remaining 20 slots are absorbed into **#1916** with a pointer in the issue file. The guard added here is forward-compatible — it becomes dead/removable once #1916 deletes the slots.

### Files
- `src/codegen/shared.ts` — move `resolveEnclosingClassName` in; add registration registry, self-identifying stub errors, `assertCodegenRegistrationsComplete()`
- `src/codegen/expressions/new-super.ts` — drop local def + registrar; import from shared
- `src/codegen/expressions.ts` — route the re-export through shared
- `src/compiler.ts` — call the assertion at compile entry
- `tests/issue-2146-registration-hardening.test.ts` — regression test
- `plan/issues/2146-…md` — resolution + #1916 residual pointer

### Validation
Scoped (confidence only): `tsc`, `biome lint`, `prettier --check`, coercion-sites gate, and **99 equivalence/super/class/closure/generator tests** green. Negative path verified: importing `index.ts` in isolation fails fast with the precise 5-delegate diagnostic.

⚠️ **Broad-impact shared codegen helper** — a scoped/sampled sweep cannot validate it. The **merge_group full Test262 run is the authoritative gate**; please do not rely on the scoped checks for conformance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA