### PR TITLE
refactor(#1926): make IrType union/boxed backend-symbolic (IrType members)

### DIFF
--- a/plan/issues/1926-remove-valtype-typeidx-from-irtype.md
+++ b/plan/issues/1926-remove-valtype-typeidx-from-irtype.md
@@ -1,10 +1,12 @@
 ---
 id: 1926
 title: "Remove backend ValType/typeIdx from IrType — unions and boxing must be backend-symbolic"
-status: ready
+status: done
 sprint: 65
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-21
+completed: 2026-06-21
+assignee: sendev-1926
 priority: medium
 feasibility: medium
 reasoning_effort: high
@@ -56,3 +58,105 @@ symbolic-ref premise that makes the IR backend-agnostic:
 
 Compiler quality review 2026-06. Related: #1851 (legalization boundary),
 #1852 (per-backend value representation), #1714.
+
+## Implementation notes (sendev-1926, 2026-06-21)
+
+### What changed
+
+`IrType` (`src/ir/nodes.ts`):
+- `union.members: readonly ValType[]` → `readonly IrType[]`.
+- `boxed.inner: ValType` → `IrType`.
+- `irTypeEquals` now recurses through members/inner via `irTypeEquals`
+  (not `valTypeEquals`), so a `boxed`-of-symbolic-kind or
+  `union`-of-symbolic-kind composes structurally.
+
+`ValType` is **no longer reachable through the IrType type system except via
+the explicit `{ kind: "val", val }` wrapper** — which is, by design, the
+documented "single concrete Wasm value type" escape hatch (`irVal`). The
+smuggling vector the issue targets (an arbitrary `ref { typeIdx }` riding
+inside a union member or a box inner, where `irTypeEquals` compared raw
+indices) is closed: any concrete reference now sits behind a `val` wrapper
+that callers must build deliberately, and union/box compose over IrTypes.
+
+### Why this shape (root-cause-driven, not a symptom patch)
+
+The crux is the **resolver boundary**. The backend resolver
+(`resolveUnion`/`resolveBoxed`/`resolveRefCell` in `lower.ts` /
+`integration.ts`) delegates to the legacy WasmGC registries
+(`UnionStructRegistry`, `getOrRegisterRefCellType`) which are *keyed on
+backend `ValType`* — that's the shared-identity contract that makes IR and
+legacy ref cells / unions resolve to the **same** WasmGC struct (byte-for-byte
+output parity). So the resolver methods **keep their `ValType` signatures**;
+the migration unwraps `IrType → ValType` (`asVal`) at the resolver call sites
+via a single `memberValType(t, funcName)` helper in `lower.ts` that asserts
+`val`-kind (a non-`val` union/box member is a selector bug — fail loud, matching
+the existing "resolver cannot lower …" throws). This keeps the *type system*
+backend-symbolic while leaving the *backend identity contract* untouched —
+which is exactly what guarantees byte-identical WasmGC output.
+
+V1 constraints make the unwrap total in practice: tagged unions admit only
+scalar (`f64`/`i32`) members (`passes/tagged-unions.ts`), and ref cells only
+box primitives (`from-ast.ts` `must be a primitive` gate). So every member /
+inner reaching the resolver is a `val`-kind IrType today; the migration just
+removes the *type-level permission* to smuggle a `ref { typeIdx }`.
+
+### Downstream effects considered
+
+- **Stack balance / return types / index shifting**: none. The change is
+  purely in the *type representation* of union members / box inner. Lowering
+  emits the identical `struct.new` / `struct.get` / `i32.const tag` / `i32.eq`
+  sequences against the same resolver-returned typeIdx. No funcidx / typeidx
+  ordering changes.
+- **Producers** (`builder.ts emitRefCellNew`, the three `from-ast.ts` capture
+  sites) wrap their scalar `ValType` with `irVal(...)`. `emitRefCellGet`'s
+  `inner` param became `IrType` (passed straight through as the SSA result
+  type; for a V1 primitive cell that's `{kind:"val",val:scalar}`, byte-identical).
+- **Lattice (`propagate.ts`)**: `lowerTypeToIrType`'s union case builds
+  `{kind:"val",val:...}` members. The separate `LatticeType` union (a different
+  type system) is intentionally NOT touched — aligning the two is the stated
+  follow-up (proposed approach #4), out of scope here.
+- **Type-key / debug-describe functions** (`monomorphize.ts irTypeKey`,
+  `from-ast`/`integration` `irTypeKey`/`describeIrType`, `lower.ts`
+  `describeIrTypeShallow`, `tagged-unions.ts memberList`) now recurse through
+  the IrType members. These keys are pass-internal (dedup/specialization) or
+  error-message-only; they never affect emitted bytes. Equal types still
+  produce equal keys.
+- **No `IrTypeRef` introduced** (proposed approach #2): the existing symbolic
+  kinds (`string`/`object`/`closure`/`class`/`extern`) already cover every
+  concrete-reference need pre-lowering, and V1 union/box only carry scalars, so
+  an interned `IrTypeRef` shape key wasn't needed to satisfy the criteria.
+  Reserve it for when a union/box must carry a *reference* member.
+
+### Validation
+
+- `tsc --noEmit`: 0 errors across the whole codebase.
+- `prettier --check` on all touched files: clean.
+- `check:ir-fallbacks` gate: **no IR demotions** vs. baseline — confirms the IR
+  adoption set is unchanged, i.e. behaviour-identical codegen on the playground
+  corpus (the #1713 byte-parity method's gate).
+- IR unit/integration suites the container can instantiate: green — including
+  the **full `issue-1169c` refcell/closure-capture suite (31/31)**, which
+  exercises `refcell.new`/`get`/`set`, mutable-capture closure-write, and
+  transitive deref through a sibling's refcell. This is the load-bearing
+  behavioral proof for the `boxed` migration.
+- New JSON round-trip test (acceptance criterion 1) in
+  `ir-frontend-widening.test.ts`: a `union`/`boxed`/nested-`boxed(union)`
+  IrType survives `JSON.parse(JSON.stringify(...))` identically.
+- `git grep typeIdx src/ir/nodes.ts`: the only non-comment hit is in
+  `valTypeEquals`, reached **only** from the `val`-kind arm (a single concrete
+  ValType — the intended wrapper), never from union/boxed.
+- **Pre-existing baseline failures** (NOT from this change, verified against a
+  pristine `origin/main` worktree): a set of closure/IR-end-to-end tests
+  `LinkError` on `__unbox_number`/`__get_undefined`/etc. "requires a callable"
+  — a container test-harness import-stub gap that fails identically on
+  unmodified main.
+
+**BROAD-IMPACT note for the merger**: this is an IR-layer change touching
+codegen lowering. A scoped/sampled test262 sweep does NOT validate it
+(regressions land outside the sample). The authoritative gate is the
+`merge_group` full-Test262 run. Local scoped checks above are for confidence
+only; do not infer conformance from them.
+
+### Follow-up unlocked (not in this PR)
+- Align `propagate.ts`'s `LatticeType` with `IrType` (proposed approach #4).
+- Introduce `IrTypeRef` if/when a union/box needs to carry a reference member.

--- a/src/ir/builder.ts
+++ b/src/ir/builder.ts
@@ -444,11 +444,13 @@ export class IrFunctionBuilder {
 
   /**
    * Wrap a primitive value in a fresh ref cell. The SSA def's type is
-   * `{ kind: "boxed", inner }`.
+   * `{ kind: "boxed", inner }`. #1926 — the `boxed` IrType carries an IrType
+   * `inner`, so the ValType arg is wrapped with `irVal` here; the resolver
+   * unwraps it back to the ValType at lowering time.
    */
   emitRefCellNew(value: IrValueId, inner: ValType): IrValueId {
     const result = this.allocator.fresh();
-    const resultType: IrType = { kind: "boxed", inner };
+    const resultType: IrType = { kind: "boxed", inner: irVal(inner) };
     this.valueTypes.set(result, resultType);
     const alloc = this.allocId("refcell", resultType);
     this.pushInstr({
@@ -462,13 +464,16 @@ export class IrFunctionBuilder {
   }
 
   /**
-   * Read the inner value out of a ref cell. The SSA def's type is
-   * `irVal(inner)` — caller passes the same `inner` they used for
-   * `emitRefCellNew`.
+   * Read the inner value out of a ref cell. The SSA def's type is the cell's
+   * `inner` IrType. #1926 — `inner` is now the `boxed` IrType's `inner`
+   * field (an IrType), passed straight through as the result type. Callers
+   * pass the same `inner` they used for the matching `boxed` cell (for V1
+   * primitive cells this is `irVal(scalar)`, so the result type is
+   * `{ kind: "val", val: scalar }` exactly as before).
    */
-  emitRefCellGet(cell: IrValueId, inner: ValType): IrValueId {
+  emitRefCellGet(cell: IrValueId, inner: IrType): IrValueId {
     const result = this.allocator.fresh();
-    const resultType: IrType = { kind: "val", val: inner };
+    const resultType: IrType = inner;
     this.valueTypes.set(result, resultType);
     this.pushInstr({
       kind: "refcell.get",

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -1203,8 +1203,9 @@ function describeIrType(t: IrType): string {
   }
   if (t.kind === "class") return `class<${t.shape.className}>`;
   if (t.kind === "extern") return `extern<${t.className}>`;
-  if (t.kind === "union") return `union<${t.members.map((m) => m.kind).join(",")}>`;
-  return `boxed<${t.inner.kind}>`;
+  // #1926 — union members / boxed inner are IrTypes; recurse.
+  if (t.kind === "union") return `union<${t.members.map(describeIrType).join(",")}>`;
+  return `boxed<${describeIrType(t.inner)}>`;
 }
 
 /**
@@ -2174,7 +2175,8 @@ function lowerNestedFuncCall(
           throw new Error(`ir/from-ast: mutable nested capture "${cap.name}" must be a primitive (${cx.funcName})`);
         }
         const cell = cx.builder.emitRefCellNew(live.value, innerVal);
-        cx.scope.set(cap.name, { kind: "local", value: cell, type: { kind: "boxed", inner: innerVal } });
+        // #1926 — boxed.inner is an IrType; wrap the scalar ValType with irVal.
+        cx.scope.set(cap.name, { kind: "local", value: cell, type: { kind: "boxed", inner: irVal(innerVal) } });
         args.push(cell);
       } else {
         throw new Error(`ir/from-ast: nested mutable capture "${cap.name}" not in scope (${cx.funcName})`);
@@ -4241,7 +4243,8 @@ function lowerClosureExpression(expr: ts.ArrowFunction | ts.FunctionExpression, 
       if (!innerVal) {
         throw new Error(`ir/from-ast: mutable closure capture "${cap.name}" must be a primitive (${cx.funcName})`);
       }
-      const fieldType: IrType = { kind: "boxed", inner: innerVal };
+      // #1926 — boxed.inner is an IrType; wrap the scalar ValType with irVal.
+      const fieldType: IrType = { kind: "boxed", inner: irVal(innerVal) };
       captureFieldTypes.push(fieldType);
       const live = cx.scope.get(cap.name);
       if (live?.kind === "local" && live.type.kind === "boxed") {
@@ -4332,7 +4335,8 @@ function liftNestedFunction(
   // Prepend capture params before the user's params.
   for (const cap of captures) {
     const innerVal = asVal(cap.type);
-    const paramType: IrType = cap.mutable && innerVal ? { kind: "boxed", inner: innerVal } : cap.type;
+    // #1926 — boxed.inner is an IrType; wrap the scalar ValType with irVal.
+    const paramType: IrType = cap.mutable && innerVal ? { kind: "boxed", inner: irVal(innerVal) } : cap.type;
     const v = builder.addParam(cap.name, paramType);
     scope.set(cap.name, { kind: "local", value: v, type: paramType });
   }
@@ -4535,9 +4539,10 @@ function analyseCaptures(
       );
     }
     // If the local is already a refcell (a sibling closure boxed it),
-    // the capture's logical type is the inner ValType — we deref on
-    // read in `lowerClosureExpression`.
-    const logicalType: IrType = binding.type.kind === "boxed" ? irVal(binding.type.inner) : binding.type;
+    // the capture's logical type is the inner IrType — we deref on
+    // read in `lowerClosureExpression`. #1926 — boxed.inner is already an
+    // IrType, so use it directly (no irVal re-wrap).
+    const logicalType: IrType = binding.type.kind === "boxed" ? binding.type.inner : binding.type;
     const isMutable = written.has(name) || outerWrites.has(name);
     captures.push({
       name,

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -1541,8 +1541,9 @@ function irTypeKey(t: IrType): string {
   if (t.kind === "class") return `class:${t.shape.className}`;
   // Slice 10 (#1169i): extern is keyed solely on className.
   if (t.kind === "extern") return `extern:${t.className}`;
-  if (t.kind === "union") return `union<${t.members.map((m) => m.kind).join(",")}>`;
-  return `boxed<${t.inner.kind}>`;
+  // #1926 — union members / boxed inner are IrTypes; recurse.
+  if (t.kind === "union") return `union<${t.members.map(irTypeKey).join(",")}>`;
+  return `boxed<${irTypeKey(t.inner)}>`;
 }
 
 /**

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -1035,10 +1035,12 @@ export function lowerIrFunctionBody<S>(
         if (!valueType) {
           throw new Error(`ir/lower: box value must be a val-kind IrType (${func.name})`);
         }
-        const union = resolver.resolveUnion?.(instr.toType.members);
+        // #1926 — unwrap each member IrType to its backend ValType.
+        const members = instr.toType.members.map((m) => memberValType(m, func.name));
+        const union = resolver.resolveUnion?.(members);
         if (!union) {
           throw new Error(
-            `ir/lower: resolver cannot lower union<${instr.toType.members.map((m) => m.kind).join(",")}> (${func.name})`,
+            `ir/lower: resolver cannot lower union<${members.map((m) => m.kind).join(",")}> (${func.name})`,
           );
         }
         const tag = union.tagFor(valueType);
@@ -1058,10 +1060,12 @@ export function lowerIrFunctionBody<S>(
         if (valueIrType.kind !== "union") {
           throw new Error(`ir/lower: unbox value must be a union IrType, got ${valueIrType.kind} (${func.name})`);
         }
-        const union = resolver.resolveUnion?.(valueIrType.members);
+        // #1926 — unwrap each member IrType to its backend ValType.
+        const unboxMembers = valueIrType.members.map((m) => memberValType(m, func.name));
+        const union = resolver.resolveUnion?.(unboxMembers);
         if (!union) {
           throw new Error(
-            `ir/lower: resolver cannot lower union<${valueIrType.members.map((m) => m.kind).join(",")}> (${func.name})`,
+            `ir/lower: resolver cannot lower union<${unboxMembers.map((m) => m.kind).join(",")}> (${func.name})`,
           );
         }
         emitValue(instr.value, out);
@@ -1078,10 +1082,12 @@ export function lowerIrFunctionBody<S>(
         if (valueIrType.kind !== "union") {
           throw new Error(`ir/lower: tag.test value must be a union IrType, got ${valueIrType.kind} (${func.name})`);
         }
-        const union = resolver.resolveUnion?.(valueIrType.members);
+        // #1926 — unwrap each member IrType to its backend ValType.
+        const tagTestMembers = valueIrType.members.map((m) => memberValType(m, func.name));
+        const union = resolver.resolveUnion?.(tagTestMembers);
         if (!union) {
           throw new Error(
-            `ir/lower: resolver cannot lower union<${valueIrType.members.map((m) => m.kind).join(",")}> (${func.name})`,
+            `ir/lower: resolver cannot lower union<${tagTestMembers.map((m) => m.kind).join(",")}> (${func.name})`,
           );
         }
         const tag = union.tagFor(instr.tag);
@@ -1265,9 +1271,11 @@ export function lowerIrFunctionBody<S>(
         if (cellT.kind !== "boxed") {
           throw new Error(`ir/lower: refcell.get cell must be boxed, got ${cellT.kind} (${func.name})`);
         }
-        const cell = resolver.resolveRefCell?.(cellT.inner);
+        // #1926 — unwrap the inner IrType to its backend ValType.
+        const getInner = memberValType(cellT.inner, func.name);
+        const cell = resolver.resolveRefCell?.(getInner);
         if (!cell) {
-          throw new Error(`ir/lower: resolver cannot lower refcell<${cellT.inner.kind}> (${func.name})`);
+          throw new Error(`ir/lower: resolver cannot lower refcell<${getInner.kind}> (${func.name})`);
         }
         emitValue(instr.cell, out);
         emitter.pushRaw(out, {
@@ -1282,9 +1290,11 @@ export function lowerIrFunctionBody<S>(
         if (cellT.kind !== "boxed") {
           throw new Error(`ir/lower: refcell.set cell must be boxed, got ${cellT.kind} (${func.name})`);
         }
-        const cell = resolver.resolveRefCell?.(cellT.inner);
+        // #1926 — unwrap the inner IrType to its backend ValType.
+        const setInner = memberValType(cellT.inner, func.name);
+        const cell = resolver.resolveRefCell?.(setInner);
         if (!cell) {
-          throw new Error(`ir/lower: resolver cannot lower refcell<${cellT.inner.kind}> (${func.name})`);
+          throw new Error(`ir/lower: resolver cannot lower refcell<${setInner.kind}> (${func.name})`);
         }
         emitValue(instr.cell, out);
         emitValue(instr.value, out);
@@ -2805,6 +2815,25 @@ function collectTerminatorUses(block: IrBlock): readonly IrValueId[] {
  * to that struct. Throws if the resolver cannot lower the type — callers must
  * reject such IR before reaching this function.
  */
+/**
+ * #1926 — unwrap a `union` member / `boxed`-`refcell` inner IrType to the
+ * concrete backend ValType the legacy union / ref-cell registries key on.
+ *
+ * V1 unions admit only scalar (`f64`/`i32`) members and ref cells only box
+ * primitives, so every member / inner here is a `val`-kind IrType. We assert
+ * that explicitly: a non-`val` member means an upstream pass admitted a
+ * symbolic kind into a union/box the backend registries can't key on, which
+ * is a selector bug — failing loud here is correct (and matches the existing
+ * "resolver cannot lower …" throws).
+ */
+function memberValType(t: IrType, funcName: string): ValType {
+  const v = asVal(t);
+  if (!v) {
+    throw new Error(`ir/lower: union/boxed member must be a val-kind IrType, got ${t.kind} (${funcName})`);
+  }
+  return v;
+}
+
 export function lowerIrTypeToValType(t: IrType, resolver: IrLowerResolver, funcName: string): ValType {
   if (t.kind === "val") return t.val;
   if (t.kind === "string") {
@@ -2857,24 +2886,29 @@ export function lowerIrTypeToValType(t: IrType, resolver: IrLowerResolver, funcN
     return { kind: "externref" };
   }
   if (t.kind === "union") {
-    const union = resolver.resolveUnion?.(t.members);
+    // #1926 — unwrap each member IrType to its backend ValType for the
+    // legacy union registry.
+    const members = t.members.map((m) => memberValType(m, funcName));
+    const union = resolver.resolveUnion?.(members);
     if (!union) {
-      throw new Error(`ir/lower: resolver cannot lower union<${t.members.map((m) => m.kind).join(",")}> (${funcName})`);
+      throw new Error(`ir/lower: resolver cannot lower union<${members.map((m) => m.kind).join(",")}> (${funcName})`);
     }
     return { kind: "ref", typeIdx: union.typeIdx };
   }
   // boxed (refcell)
   // Slice 3 (#1169c): the resolver delegates to the legacy ref-cell
   // registry so legacy and IR ref cells share one WasmGC struct.
+  // #1926 — unwrap the inner IrType to its backend ValType.
+  const innerVal = memberValType(t.inner, funcName);
   if (resolver.resolveRefCell) {
-    const cell = resolver.resolveRefCell(t.inner);
+    const cell = resolver.resolveRefCell(innerVal);
     if (cell) {
       return { kind: "ref", typeIdx: cell.typeIdx };
     }
   }
-  const box = resolver.resolveBoxed?.(t.inner);
+  const box = resolver.resolveBoxed?.(innerVal);
   if (!box) {
-    throw new Error(`ir/lower: resolver cannot lower boxed<${t.inner.kind}> (${funcName})`);
+    throw new Error(`ir/lower: resolver cannot lower boxed<${innerVal.kind}> (${funcName})`);
   }
   return { kind: "ref", typeIdx: box.typeIdx };
 }
@@ -2899,8 +2933,9 @@ function describeIrTypeShallow(t: IrType): string {
   }
   if (t.kind === "class") return `class<${t.shape.className}>`;
   if (t.kind === "extern") return `extern<${t.className}>`;
-  if (t.kind === "union") return `union<${t.members.map((m) => m.kind).join(",")}>`;
-  return `boxed<${t.inner.kind}>`;
+  // #1926 — union members / boxed inner are IrTypes; recurse.
+  if (t.kind === "union") return `union<${t.members.map(describeIrTypeShallow).join(",")}>`;
+  return `boxed<${describeIrTypeShallow(t.inner)}>`;
 }
 
 /**

--- a/src/ir/nodes.ts
+++ b/src/ir/nodes.ts
@@ -57,20 +57,31 @@ export type IrSymRef = IrFuncRef | IrGlobalRef | IrTypeRef;
 //   { kind: "val",   val: ValType }      A single concrete Wasm value type —
 //                                        the 1:1 wrapper around a backend
 //                                        ValType (i32, f64, externref, …).
-//   { kind: "union", members: ValType[] } A tagged union of ValTypes, lowered
+//   { kind: "union", members: IrType[] }  A tagged union of IrTypes, lowered
 //                                        to a canonical WasmGC struct with a
 //                                        `$tag: i32` discriminator + one or
 //                                        more `$val` fields. V1 scope:
-//                                        homogeneous-width members only
-//                                        (e.g. `f64|bool`, `f64|null`).
-//                                        Members containing `externref` /
-//                                        `ref` / `funcref` fall back to
-//                                        `dynamic` upstream.
-//   { kind: "boxed", inner: ValType }    A heap-allocated single-field box
+//                                        homogeneous-width SCALAR members only
+//                                        (e.g. `f64|i32`). Members are
+//                                        themselves IrTypes (#1926) so a union
+//                                        composes with the symbolic
+//                                        string/object/etc. kinds without
+//                                        baking a backend ValType (and its
+//                                        module-relative typeIdx) into the IR
+//                                        type system. The backend resolver
+//                                        unwraps each member's underlying
+//                                        ValType at lowering time. Members
+//                                        containing `externref` / `ref` /
+//                                        `funcref` fall back to `dynamic`
+//                                        upstream.
+//   { kind: "boxed", inner: IrType }     A heap-allocated single-field box
 //                                        (`struct (field $val inner)`) —
 //                                        lets the middle-end materialise
 //                                        scalars on the heap when a
 //                                        downstream pass needs a reference.
+//                                        The `inner` is an IrType (#1926); the
+//                                        backend resolver unwraps it to a
+//                                        concrete ValType at lowering time.
 //
 // Every IrType use-site that would have passed a raw `ValType` now either
 //   (a) wraps with `irVal(v)` to produce `{ kind: "val", val: v }`, or
@@ -81,9 +92,13 @@ export type IrSymRef = IrFuncRef | IrGlobalRef | IrTypeRef;
 //   { kind: "val",   val }     → `val` (unchanged).
 //   { kind: "union", members } → ref to the canonical `$union_<members>`
 //                                struct (registered once per module via
-//                                `passes/tagged-union-types.ts`).
+//                                `passes/tagged-union-types.ts`). Each member
+//                                IrType is unwrapped to its ValType
+//                                (`asVal`) at the resolver boundary.
 //   { kind: "boxed", inner }   → ref to a single-field struct with the
-//                                inner ValType as its `$val`.
+//                                inner IrType's ValType as its `$val`
+//                                (unwrapped via `asVal` at the resolver
+//                                boundary).
 
 /**
  * A canonical object shape — a sorted list of named fields with their IR
@@ -208,12 +223,19 @@ export type IrType =
   // without a TS-checker round trip. See `src/ir/from-ast.ts`'s
   // `lowerExternMethodCall` and the `extern.*` IR instr kinds.
   | { readonly kind: "extern"; readonly className: string }
-  | { readonly kind: "union"; readonly members: readonly ValType[] }
+  // #1926 — union members are IrTypes, not raw ValTypes. V1 still only
+  // admits scalar (`f64`/`i32`) members upstream (see
+  // `passes/tagged-unions.ts`), but typing them as IrType keeps the IR
+  // backend-symbolic (no module-relative `ref { typeIdx }` reachable
+  // through the type system) and lets the resolver unwrap each member's
+  // ValType at lowering time.
+  | { readonly kind: "union"; readonly members: readonly IrType[] }
   // Slice 3 (#1169c) repurposes `boxed` as the ref-cell type for mutable
-  // captures. The inner ValType is the cell's stored type; the resolver
-  // delegates to `getOrRegisterRefCellType` so legacy and IR ref cells
-  // share the same WasmGC struct.
-  | { readonly kind: "boxed"; readonly inner: ValType };
+  // captures. The inner IrType is the cell's stored type (#1926 — an IrType,
+  // not a raw ValType); the resolver unwraps it to a ValType and delegates
+  // to `getOrRegisterRefCellType` so legacy and IR ref cells share the same
+  // WasmGC struct.
+  | { readonly kind: "boxed"; readonly inner: IrType };
 
 /** Wrap a plain ValType as an IrType — the common path for Phase 1/2 callers. */
 export function irVal(v: ValType): IrType {
@@ -264,11 +286,13 @@ export function irTypeEquals(a: IrType, b: IrType): boolean {
     return aSigned === bSigned;
   }
   if (a.kind === "string" && b.kind === "string") return true;
-  if (a.kind === "boxed" && b.kind === "boxed") return valTypeEquals(a.inner, b.inner);
+  // #1926 — `inner`/`members` are IrTypes now, so recurse via irTypeEquals
+  // (a boxed-of-string or union-of-symbolic-kind compares structurally).
+  if (a.kind === "boxed" && b.kind === "boxed") return irTypeEquals(a.inner, b.inner);
   if (a.kind === "union" && b.kind === "union") {
     if (a.members.length !== b.members.length) return false;
     for (let i = 0; i < a.members.length; i++) {
-      if (!valTypeEquals(a.members[i]!, b.members[i]!)) return false;
+      if (!irTypeEquals(a.members[i]!, b.members[i]!)) return false;
     }
     return true;
   }

--- a/src/ir/passes/monomorphize.ts
+++ b/src/ir/passes/monomorphize.ts
@@ -434,11 +434,12 @@ function irTypeKey(t: IrType): string {
   if (t.kind === "class") return `cls:${t.shape.className}`;
   // Slice 10 (#1169i): extern is keyed solely on className.
   if (t.kind === "extern") return `ext:${t.className}`;
+  // #1926 — union members / boxed inner are IrTypes; recurse via irTypeKey.
   if (t.kind === "union") {
-    const parts = [...t.members].map(valTypeKey).sort();
+    const parts = [...t.members].map(irTypeKey).sort();
     return `u:${parts.join("|")}`;
   }
-  return `b:${valTypeKey(t.inner)}`;
+  return `b:${irTypeKey(t.inner)}`;
 }
 
 function valTypeKey(v: ValType): string {

--- a/src/ir/passes/tagged-unions.ts
+++ b/src/ir/passes/tagged-unions.ts
@@ -57,8 +57,7 @@
 // with an unsupported union (e.g. `union<f64, externref>`) can surface the
 // error via this pass's `errors` output instead of crashing in lower.ts.
 
-import type { IrFunction, IrInstr, IrModule, IrType } from "../nodes.js";
-import type { ValType } from "../types.js";
+import { type IrFunction, type IrInstr, type IrModule, type IrType, asVal } from "../nodes.js";
 
 export interface TaggedUnionsError {
   readonly func: string;
@@ -162,12 +161,17 @@ function isRegistrySupported(t: Extract<IrType, { kind: "union" }>): boolean {
   return true;
 }
 
-function isScalarMember(m: ValType): boolean {
-  return m.kind === "f64" || m.kind === "i32";
+function isScalarMember(m: IrType): boolean {
+  // #1926 — union members are IrTypes; only a `val`-kind scalar is supported.
+  // Any non-`val` (symbolic string/object/etc.) member makes the union
+  // unsupported by the V1 tagged-union registry, exactly as before.
+  const v = asVal(m);
+  return v?.kind === "f64" || v?.kind === "i32";
 }
 
 function memberList(t: Extract<IrType, { kind: "union" }>): string {
-  return t.members.map((m) => m.kind).join(",");
+  // #1926 — describe each member IrType; a `val`-kind shows its ValType kind.
+  return t.members.map((m) => asVal(m)?.kind ?? m.kind).join(",");
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ir/propagate.ts
+++ b/src/ir/propagate.ts
@@ -1189,10 +1189,12 @@ export function lowerTypeToIrType(t: LatticeType): import("./nodes.js").IrType |
       return { kind: "object", shape: { fields } };
     }
     case "union": {
-      const members: import("./types.js").ValType[] = [];
+      // #1926 — union members are IrTypes now; wrap each scalar ValType in a
+      // `val`-kind IrType. V1 still admits only f64/i32 scalar members.
+      const members: import("./nodes.js").IrType[] = [];
       for (const m of t.members) {
-        if (m.kind === "f64") members.push({ kind: "f64" });
-        else if (m.kind === "bool") members.push({ kind: "i32" });
+        if (m.kind === "f64") members.push({ kind: "val", val: { kind: "f64" } });
+        else if (m.kind === "bool") members.push({ kind: "val", val: { kind: "i32" } });
         // string/object members not supported in V1 tagged unions.
         // #1126 Stage 1 — i32/u32 atoms also fall through to `return null`
         // here. They should never reach this case in practice: the lattice

--- a/src/ir/verify.ts
+++ b/src/ir/verify.ts
@@ -398,7 +398,8 @@ function verifyBlock(
           const operandT = operandValType(func, block, instr.value, localDefs);
           if (operandT && !unionContains(instr.toType.members, operandT)) {
             errors.push({
-              message: `box operand type ${operandT.kind} is not a member of union<${instr.toType.members.map((m) => m.kind).join(",")}>`,
+              // #1926 — members are IrTypes; describe each member's ValType kind.
+              message: `box operand type ${operandT.kind} is not a member of union<${instr.toType.members.map((m) => asVal(m)?.kind ?? m.kind).join(",")}>`,
               func: func.name,
               block: block.id as number,
             });
@@ -416,7 +417,8 @@ function verifyBlock(
           });
         } else if (operandIr && !unionContains(operandIr.members, instr.tag)) {
           errors.push({
-            message: `${instr.kind} tag ${instr.tag.kind} is not a member of union<${operandIr.members.map((m) => m.kind).join(",")}>`,
+            // #1926 — members are IrTypes; describe each member's ValType kind.
+            message: `${instr.kind} tag ${instr.tag.kind} is not a member of union<${operandIr.members.map((m) => asVal(m)?.kind ?? m.kind).join(",")}>`,
             func: func.name,
             block: block.id as number,
           });
@@ -670,8 +672,13 @@ function operandValType(
   return null;
 }
 
-function unionContains(members: readonly ValType[], target: ValType): boolean {
-  for (const m of members) {
+// #1926 — `members` are IrTypes now; unwrap each `val`-kind member to its
+// ValType and compare against the (scalar) `target` ValType. A non-`val`
+// member can never match a scalar target, so it's skipped.
+function unionContains(members: readonly IrType[], target: ValType): boolean {
+  for (const irMember of members) {
+    const m = asVal(irMember);
+    if (!m) continue;
     if (m.kind !== target.kind) continue;
     if (m.kind === "ref" || m.kind === "ref_null") {
       if ((m as { typeIdx: number }).typeIdx !== (target as { typeIdx: number }).typeIdx) continue;

--- a/tests/ir-frontend-widening.test.ts
+++ b/tests/ir-frontend-widening.test.ts
@@ -49,9 +49,10 @@ describe("#1168 — IrType discriminated union", () => {
   });
 
   it("asVal returns null for non-val IrType", () => {
-    const u: IrType = { kind: "union", members: [{ kind: "f64" }, { kind: "i32" }] };
+    // #1926 — union members / boxed inner are IrTypes (wrapped via irVal).
+    const u: IrType = { kind: "union", members: [irVal({ kind: "f64" }), irVal({ kind: "i32" })] };
     expect(asVal(u)).toBeNull();
-    const b: IrType = { kind: "boxed", inner: { kind: "f64" } };
+    const b: IrType = { kind: "boxed", inner: irVal({ kind: "f64" }) };
     expect(asVal(b)).toBeNull();
   });
 
@@ -61,15 +62,37 @@ describe("#1168 — IrType discriminated union", () => {
     const c = irVal({ kind: "i32" });
     expect(irTypeEquals(a, b)).toBe(true);
     expect(irTypeEquals(a, c)).toBe(false);
-    const u1: IrType = { kind: "union", members: [{ kind: "f64" }, { kind: "i32" }] };
-    const u2: IrType = { kind: "union", members: [{ kind: "f64" }, { kind: "i32" }] };
-    const u3: IrType = { kind: "union", members: [{ kind: "f64" }] };
+    // #1926 — union members / boxed inner are IrTypes (wrapped via irVal).
+    const u1: IrType = { kind: "union", members: [irVal({ kind: "f64" }), irVal({ kind: "i32" })] };
+    const u2: IrType = { kind: "union", members: [irVal({ kind: "f64" }), irVal({ kind: "i32" })] };
+    const u3: IrType = { kind: "union", members: [irVal({ kind: "f64" })] };
     expect(irTypeEquals(u1, u2)).toBe(true);
     expect(irTypeEquals(u1, u3)).toBe(false);
     expect(irTypeEquals(a, u1)).toBe(false);
-    const x: IrType = { kind: "boxed", inner: { kind: "f64" } };
-    const y: IrType = { kind: "boxed", inner: { kind: "f64" } };
+    const x: IrType = { kind: "boxed", inner: irVal({ kind: "f64" }) };
+    const y: IrType = { kind: "boxed", inner: irVal({ kind: "f64" }) };
     expect(irTypeEquals(x, y)).toBe(true);
+  });
+
+  // #1926 acceptance criterion 1 — IrType is JSON-serializable and survives a
+  // round-trip. With union/boxed members carrying backend-symbolic IrTypes
+  // (no module-relative `ref { typeIdx }` reachable through the type system),
+  // a union/boxed type can be serialized and reconstructed identically. This
+  // is what unblocks IR caching / cross-backend reuse.
+  it("union/boxed IrTypes JSON round-trip (criterion 1)", () => {
+    const types: IrType[] = [
+      irVal({ kind: "f64" }),
+      { kind: "string" },
+      { kind: "union", members: [irVal({ kind: "f64" }), irVal({ kind: "i32" })] },
+      { kind: "boxed", inner: irVal({ kind: "i32" }) },
+      // Nested: a union-of-symbolic-member composes structurally now.
+      { kind: "boxed", inner: { kind: "union", members: [irVal({ kind: "f64" }), irVal({ kind: "i32" })] } },
+    ];
+    for (const t of types) {
+      const round = JSON.parse(JSON.stringify(t)) as IrType;
+      expect(round).toEqual(t);
+      expect(irTypeEquals(round, t)).toBe(true);
+    }
   });
 });
 
@@ -154,7 +177,8 @@ describe("#1168 — lowerTypeToIrType for unions", () => {
     const ir = lowerTypeToIrType(t);
     expect(ir).not.toBeNull();
     if (ir && ir.kind === "union") {
-      const kinds = ir.members.map((m) => m.kind).sort();
+      // #1926 — members are IrTypes now; unwrap each to its ValType kind.
+      const kinds = ir.members.map((m) => asVal(m)?.kind).sort();
       expect(kinds).toEqual(["f64", "i32"]);
     } else {
       throw new Error(`expected union, got ${ir?.kind}`);
@@ -280,8 +304,9 @@ describe("#1168 — tag.test lowering (criterion 4)", () => {
 
   it("tag.test emits struct.get $tag; i32.const <N>; i32.eq", () => {
     const unionType: IrType = {
+      // #1926 — union members are IrTypes (wrapped via irVal).
       kind: "union",
-      members: [{ kind: "f64" }, { kind: "i32" }],
+      members: [irVal({ kind: "f64" }), irVal({ kind: "i32" })],
     };
     // Handwire an IrFunction: the entry block has a raw.wasm producing a
     // union-typed value (stub), followed by a tag.test.

--- a/tests/ir/phase3c.test.ts
+++ b/tests/ir/phase3c.test.ts
@@ -364,7 +364,8 @@ describe("#1167c — taggedUnions (unit)", () => {
     // We run taggedUnions (no-op in V1), then lower with a registry-backed
     // resolver, then inspect the emitted Wasm ops for `struct.get`/`i32.eq`
     // and the absence of any `call` to an externref boxing helper.
-    const unionType = { kind: "union" as const, members: [{ kind: "f64" }, { kind: "i32" }] as const };
+    // #1926 — union members are IrTypes (wrapped via irVal).
+    const unionType = { kind: "union" as const, members: [irVal({ kind: "f64" }), irVal({ kind: "i32" })] };
     const paramId = asValueId(0);
     const testResult = asValueId(1);
     const fn: IrFunction = {
@@ -430,9 +431,11 @@ describe("#1167c — taggedUnions (unit)", () => {
   it("flags an unsupported union (externref member) as a pass error", () => {
     // union<f64, externref> is out of V1 scope — taggedUnions should report
     // it via runTaggedUnions.errors (non-fatal; pass still returns the module).
+    // #1926 — union members are IrTypes (wrapped via irVal). externref is
+    // not a V1-supported scalar member, so this union is still flagged.
     const unionType = {
       kind: "union" as const,
-      members: [{ kind: "f64" }, { kind: "externref" }] as const,
+      members: [irVal({ kind: "f64" }), irVal({ kind: "externref" })],
     };
     const paramId = asValueId(0);
     const testResult = asValueId(1);

--- a/tests/issue-1238.test.ts
+++ b/tests/issue-1238.test.ts
@@ -292,7 +292,14 @@ describe("#1238 — resolveMethodDispatchTarget", () => {
   });
 
   it("returns null for IrType.union", () => {
-    const t: IrType = { kind: "union", members: [{ kind: "f64" }, { kind: "i32" }] };
+    // #1926 — union members are IrTypes (val-kind wrappers).
+    const t: IrType = {
+      kind: "union",
+      members: [
+        { kind: "val", val: { kind: "f64" } },
+        { kind: "val", val: { kind: "i32" } },
+      ],
+    };
     expect(resolveMethodDispatchTarget(t)).toBeNull();
   });
 });


### PR DESCRIPTION
## #1926 — Remove backend ValType/typeIdx from IrType (unions & boxing backend-symbolic)

Removes backend-`ValType` reachability from the `IrType` type system so the IR stops smuggling module-relative concrete indices that the symbolic-ref design exists to eliminate.

### Change
- `union.members: ValType[]` → `IrType[]`
- `boxed.inner: ValType` → `IrType`
- `irTypeEquals` recurses via `irTypeEquals` (not `valTypeEquals`) for members/inner, so a union/box composes structurally over the symbolic `string`/`object`/`closure`/`class`/`extern` kinds.

### Approach (root-cause-driven, byte-parity preserving)
The backend resolver (`resolveUnion`/`resolveBoxed`/`resolveRefCell`) **keeps its `ValType` signatures** — it delegates to the legacy WasmGC registries keyed on `ValType`, the shared-identity contract that makes IR and legacy ref cells / unions resolve to the *same* WasmGC struct (byte-identical output). The `IrType → ValType` unwrap happens at the resolver call sites via one `memberValType()` helper in `lower.ts` that asserts `val`-kind (a non-`val` union/box member is a selector bug → fail loud, matching the existing "resolver cannot lower …" throws). This keeps the *type system* backend-symbolic while leaving the *backend identity contract* untouched.

V1 constraints make the unwrap total: tagged unions admit only scalar `f64`/`i32` members, ref cells only box primitives. So every member/inner reaching the resolver is `val`-kind today; the migration just removes the *type-level permission* to carry a `ref { typeIdx }`.

The separate `propagate.ts` `LatticeType` union is intentionally **not** touched (stated follow-up #4). No `IrTypeRef` introduced (proposed approach #2) — V1 union/box only carry scalars, so it isn't needed yet.

### Files
- `src/ir/{nodes,builder,from-ast,lower,integration,propagate,verify}.ts`, `src/ir/passes/{tagged-unions,monomorphize}.ts` — type change + resolver-boundary unwrap + recursive type-key/describe helpers.
- `tests/ir-frontend-widening.test.ts` (+ JSON round-trip acceptance test), `tests/ir/phase3c.test.ts`, `tests/issue-1238.test.ts` — IrType construction sites updated to `irVal(...)`-wrapped members.

### Validation (local, confidence-only)
- `tsc --noEmit`: 0 errors. `prettier --check`: clean. `check:ir-fallbacks`: **no IR demotions** vs baseline (byte-parity proxy on the playground corpus).
- Full `issue-1169c` refcell/closure-capture suite green (31/31) — load-bearing behavioral proof for the `boxed` migration (refcell.new/get/set, mutable-capture closure-write, transitive sibling-refcell deref).
- New JSON round-trip test passes (acceptance criterion 1).
- `git grep typeIdx src/ir/nodes.ts`: only non-comment hit is in `valTypeEquals`, reached **only** from the `val`-kind arm (the intended single-ValType wrapper), never from union/boxed.

### ⚠️ BROAD-IMPACT — merger please note
This is an IR-layer change touching codegen lowering. A scoped/sampled test262 sweep does **not** validate it (regressions land outside the sample). The **authoritative gate is the `merge_group` full-Test262 run**. The local checks above are for confidence only.

(Pre-existing baseline failures unrelated to this change — a set of closure/IR-e2e tests `LinkError` on `__unbox_number`/`__get_undefined` "requires a callable" — fail identically on unmodified `origin/main` in this container; verified against a pristine worktree.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA