### PR TITLE
refactor(#1919): transactional speculative-compile API — stop probe rollbacks leaking imports/locals/errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,15 @@ jobs:
       - name: AnyValue box-site gate (#2104)
         run: pnpm run check:any-box-sites
 
+      - name: Speculative-rollback gate (#1919)
+        # Fails when a raw `fctx.body.length = <savedLen>` rollback appears under
+        # src/codegen/ outside the transactional helper
+        # (src/codegen/context/speculative.ts). A bare body truncation restores
+        # only the body and leaks the locals / late imports / errors the probe
+        # allocated (the #1919 / #1916 phantom-import heisenbug). Route the probe
+        # through snapshotSpeculative/rollbackSpeculative instead.
+        run: pnpm run check:speculative-rollback
+
       - name: Coercion-site drift gate (#2108)
         # Fails when the JS-semantic coercion vocabulary (ToString/ToNumber/
         # ToPrimitive/equality/ToBoolean) is hand-rolled at a NEW site outside

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "census:async": "node scripts/async-call-census.mjs",
     "check:codegen-fallbacks": "npx tsx scripts/check-codegen-fallbacks.ts",
     "check:any-box-sites": "node scripts/check-any-box-sites.mjs",
+    "check:speculative-rollback": "node scripts/check-speculative-rollback-sites.mjs",
     "check:coercion-sites": "node scripts/check-coercion-sites.mjs",
     "check:test262-hard-errors": "node scripts/check-test262-hard-errors.mjs",
     "check:issue-spec-coverage": "node scripts/check-issue-spec-coverage.mjs",

--- a/plan/issues/1919-transactional-speculative-compile.md
+++ b/plan/issues/1919-transactional-speculative-compile.md
@@ -1,10 +1,12 @@
 ---
 id: 1919
 title: "Transactional speculative-compile API — 23 probe/rollback sites leak locals, imports, and types"
-status: ready
+status: done
 sprint: 65
 created: 2026-06-10
-updated: 2026-06-12
+updated: 2026-06-21
+completed: 2026-06-21
+assignee: sendev-spec-compile
 priority: medium
 feasibility: medium
 reasoning_effort: high
@@ -53,3 +55,82 @@ of the module (interacts with #1916).
 ## Source
 
 Compiler quality review 2026-06. Related: #1847 (snapshotLocals), #1916.
+
+## Implementation notes (sendev-spec-compile, 2026-06-21)
+
+**New module: `src/codegen/context/speculative.ts`.** Exposes
+`snapshotSpeculative` / `rollbackSpeculative`, plus two ergonomic wrappers:
+`probeCompiledType(ctx, fctx, fn)` (always rolls back — the dominant
+"compile-only-to-read-the-type" probe) and `withSpeculativeCompile(ctx, fctx,
+fn)` (commit-or-rollback for "try-lower; keep iff the shape matched" sites).
+
+**Why snapshot-and-unwind, NOT the spec's "defer ensureLateImport" idea.** The
+proposed-approach §1 (queue-and-flush late imports) is infeasible: the probe's
+own `compileExpression` *uses* the funcIdx `ensureLateImport` returns — it bakes
+a real `call funcIdx` into the body it emits. Deferring registration would make
+the probe emit an invalid index. The probe discards that body anyway; only the
+*registration side effect* leaks. So the correct design mirrors #1847's
+snapshot/restore: capture the mutable state, let the probe run normally, then
+unwind exactly what changed.
+
+**What the snapshot captures (all O(1) except the #1847 locals key-set):**
+`fctx.body.length`, the locals snapshot (#1847), `ctx.errors.length`,
+`ctx.mod.imports.length`, `numImportFuncs`/`numImportGlobals`, and the
+`pendingLateImportShift` reference. Notably it does **not** copy `funcMap` —
+rollback derives the names to delete straight off the popped import descriptors
+(`ensureLateImport` only appends a name that was absent from funcMap at snapshot
+time, by its own early-return contract), so the snapshot stays cheap enough to
+wrap the hot `compileExpression` path.
+
+**Two non-obvious correctness hazards I had to handle (both caught by tests):**
+
+1. **Import GLOBALS must NOT be popped.** Registering a JS-host string-constant
+   global runs `fixupModuleGlobalIndices`, which *already shifts every
+   `global.get` in committed bodies*. Naively decrementing `numImportGlobals`
+   would leave those shifted indices out of range ("global index out of range —
+   N"). Func-import indices are positional *among funcs* and independent of where
+   globals sit in `mod.imports`, so rollback pops only the func-import entries and
+   keeps the globals (idempotent/content-addressed — reused by the re-compile or
+   inert). This broke `functional-array-methods` chaining tests until fixed.
+
+2. **A mid-probe FLUSH makes the func-import pop unsafe.** Some emit helpers call
+   `flushLateImportShifts` eagerly; if a probe flushed, committed func bodies were
+   already shifted UP and the shift walker is forward-only (no cheap inverse).
+   Rollback detects this (`pendingLateImportShift === null` while func imports were
+   added) and *keeps* the imports registered — exactly the pre-#1919 behaviour
+   (consistent, just a phantom import), never corrupting indices. The common
+   no-flush probe still cleans up fully. So #1919 is strictly ≥ the old behaviour.
+
+Registered Wasm **types** are deliberately left in place: type registration is
+idempotent/content-addressed and type indices are never shifted by later import
+additions (truncating could desync an earlier still-referenced struct — see
+`project_type_index_shift_and_deadelim`). A probe-registered type is reused by
+the re-compile or pruned by dead-type elimination.
+
+**Migrated sites (≈20 across 6 files):** `array-methods.ts` (`inferExpressionWasmType`
++ the slow-path receiver probe), `property-access.ts` (`.length` fallback probe),
+`string-builder.ts` (presize-bound try-lower), `expressions/calls.ts` (the two
+`Array.from` try-lowers), `statements/loops.ts` (all for-of receiver/iterable
+probes + the array-shape error exits; the unused `compileForOfIterator` snapshot
+was dead and removed), `statements/destructuring.ts` (object/array/string
+destructuring value-rollback exits), and the `compileExpression` wrapper
+(`expressions.ts`) error-recovery exits.
+
+**Drift gate:** `scripts/check-speculative-rollback-sites.mjs` (wired into the CI
+`quality` job as `check:speculative-rollback`) fails on any new raw
+`*.body.length = …` assignment under `src/codegen/` outside the helper. The one
+legitimate non-probe truncation (a detached `arm` buffer clear in
+`property-access.ts`) carries the inline `not-a-probe-rollback (#1919)` opt-out.
+
+**Tests:** `tests/issue-1919-speculative-compile.test.ts` — unit contract
+(import/local/error/latch unwind; re-register-after-rollback contiguity;
+commit-vs-rollback; throw-then-rollback-and-rethrow; the flush-keeps-import
+safety case) + two end-to-end compiles whose probe paths used to risk leaking.
+
+**Validation:** broad-impact change (shared codegen machinery) — a scoped sweep
+is not authoritative. Scoped confidence checks: tsc clean, prettier clean, biome
+lint (no new errors), all quality sub-gates green (stack-balance, codegen-
+fallbacks, any-box, coercion, the new speculative-rollback gate), and 96
+equivalence tests + the affected unit suites (array-methods, for-of,
+destructuring, string-builder, #1847) all pass. The merge_group full-Test262 run
+is the authoritative conformance gate.

--- a/scripts/check-speculative-rollback-sites.mjs
+++ b/scripts/check-speculative-rollback-sites.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * #1919 — speculative-compile rollback drift gate.
+ *
+ * The probe-compile-and-rollback idiom must go through the transactional helper
+ * in `src/codegen/context/speculative.ts` (`snapshotSpeculative` /
+ * `rollbackSpeculative` / `withSpeculativeCompile` / `probeCompiledType`). A raw
+ * `fctx.body.length = <savedLen>` rollback restores ONLY the body and leaks the
+ * locals / late imports / errors the probe allocated — the heisenbug class #1919
+ * closed.
+ *
+ * This gate fails when a NEW raw `*.body.length = …` ASSIGNMENT appears under
+ * `src/codegen/` outside the sanctioned home, so the idiom can't creep back in.
+ * It deliberately ignores:
+ *   - `===` / `!==` / `==` / `<` / `>` comparisons of `.body.length` (those read
+ *     the length to detect whether emission happened; they are not rollbacks);
+ *   - the helper itself (`context/speculative.ts`);
+ *   - any line carrying the inline marker `not-a-probe-rollback (#1919)` — used
+ *     for the few legitimate detached-buffer truncations (e.g. clearing a
+ *     manually-swapped `arm` buffer in property-access.ts).
+ *
+ * Usage:
+ *   node scripts/check-speculative-rollback-sites.mjs            # fail on any hit
+ *   node scripts/check-speculative-rollback-sites.mjs --list     # list + exit 0
+ */
+import { readFileSync, readdirSync, statSync } from "fs";
+import { join } from "path";
+
+const CODEGEN_DIR = new URL("../src/codegen", import.meta.url).pathname;
+
+// The transactional helper is the ONE place a body truncation is sanctioned.
+const SANCTIONED_REL = new Set(["context/speculative.ts"]);
+
+// Inline opt-out marker for the rare non-probe detached-buffer truncation.
+const OPT_OUT = "not-a-probe-rollback (#1919)";
+
+// Match an ASSIGNMENT to `<x>.body.length` — `=` NOT immediately followed by `=`
+// (so `===`/`==` are excluded) and NOT preceded by a comparison operator.
+const ASSIGN_RE = /\.body\.length\s*=(?!=)/;
+
+function walk(dir, acc) {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const st = statSync(full);
+    if (st.isDirectory()) walk(full, acc);
+    else if (name.endsWith(".ts") && !name.endsWith(".test.ts")) acc.push(full);
+  }
+  return acc;
+}
+
+const files = walk(CODEGEN_DIR, []);
+const hits = [];
+for (const file of files) {
+  const rel = file.slice(CODEGEN_DIR.length + 1);
+  if (SANCTIONED_REL.has(rel)) continue;
+  const lines = readFileSync(file, "utf-8").split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!ASSIGN_RE.test(line)) continue;
+    if (line.includes(OPT_OUT)) continue;
+    hits.push(`  src/codegen/${rel}:${i + 1}: ${line.trim()}`);
+  }
+}
+
+const list = process.argv.includes("--list");
+if (list) {
+  console.log(hits.length ? hits.join("\n") : "(no raw body.length rollback sites)");
+  process.exit(0);
+}
+
+if (hits.length > 0) {
+  console.error("speculative-rollback gate FAILED — raw `.body.length =` rollback(s) outside the helper:\n");
+  console.error(hits.join("\n"));
+  console.error(
+    "\nRoute speculative compiles through src/codegen/context/speculative.ts " +
+      "(snapshotSpeculative/rollbackSpeculative/withSpeculativeCompile/probeCompiledType) so the " +
+      "rollback undoes locals + late imports + errors, not just the body (#1919). If this is a " +
+      "detached-buffer truncation (not a probe), annotate the line with `// not-a-probe-rollback (#1919)`.",
+  );
+  process.exit(1);
+}
+
+console.log("speculative-rollback gate: OK (no raw body.length rollbacks outside the helper).");

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -11,6 +11,7 @@ import { isBooleanType, isStringType } from "../checker/type-mapper.js";
 import type { Instr, ValType } from "../ir/types.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal, allocTempLocal, getLocalType } from "./context/locals.js";
+import { probeCompiledType } from "./context/speculative.js";
 import { emitHoleToUndefined, holeTestInstrs, holeToUndefinedInstrs } from "./array-holes.js"; // (#2001 S1)
 import type { ClosureInfo, CodegenContext, FunctionContext } from "./context/types.js";
 import { addArrayIteratorImports, addStringImports, addUnionImports, resolveWasmType } from "./index.js";
@@ -518,9 +519,9 @@ function inferExpressionWasmType(
   }
 
   if (!allowProbe) return undefined;
-  const savedLen = fctx.body.length;
-  const probeResult = compileExpression(ctx, fctx, expr);
-  fctx.body.length = savedLen;
+  // #1919 — transactional probe: compile only to read the produced ValType, then
+  // roll back the body AND any locals / late imports / errors the compile leaked.
+  const probeResult = probeCompiledType(ctx, fctx, () => compileExpression(ctx, fctx, expr));
   return probeResult ?? undefined;
 }
 
@@ -2787,10 +2788,10 @@ export function compileArrayMethodCall(
     // Slow path: probe-compile the receiver to determine its actual type.
     // Compiles the expression, captures the result type, then rolls back.
     if (!actualType || actualType.kind === "externref" || actualType.kind === "f64" || actualType.kind === "i32") {
-      const savedLen = fctx.body.length;
-      const probeResult = compileExpression(ctx, fctx, receiverExpr);
-      // Roll back — the method function will re-compile the receiver
-      fctx.body.length = savedLen;
+      // #1919 — transactional probe: the method function re-compiles the
+      // receiver below, so discard the body plus any locals / late imports /
+      // errors this probe leaks.
+      const probeResult = probeCompiledType(ctx, fctx, () => compileExpression(ctx, fctx, receiverExpr));
       if (
         probeResult &&
         (probeResult.kind === "ref" || probeResult.kind === "ref_null") &&

--- a/src/codegen/context/speculative.ts
+++ b/src/codegen/context/speculative.ts
@@ -1,0 +1,240 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1919 — transactional speculative compilation.
+ *
+ * The "probe-compile-and-rollback" idiom — speculatively `compileExpression`,
+ * inspect the produced ValType, then truncate `fctx.body.length` to undo —
+ * appears at ~20 call sites across the backend. Truncating only `fctx.body`
+ * restores the emitted instructions but leaks every OTHER mutation the probe
+ * made: locals allocated during the probe (#1847 began fixing this with
+ * `snapshotLocals`/`restoreLocals`, but only `loops.ts` adopted it), late
+ * imports registered via `ensureLateImport`, and error diagnostics pushed onto
+ * `ctx.errors`.
+ *
+ * A leaked late import is the worst of these: `ensureLateImport` appends to
+ * `ctx.mod.imports`, bumps `ctx.numImportFuncs`, writes `ctx.funcMap`, and arms
+ * `ctx.pendingLateImportShift`. A probe that registers an import then rolls back
+ * the body leaves a PHANTOM import in the module — and the next real
+ * `flushLateImportShifts` shifts every already-emitted function index by the
+ * phantom count, a module-wide heisenbug (the #1919 / #1916 interaction).
+ *
+ * This module captures a transactional snapshot of all that mutable state and
+ * provides an exact unwind. The snapshot is cheap (a few integers plus a Set of
+ * the funcMap names present at snapshot time) so probes stay fast.
+ *
+ * Invariant the unwind relies on: a speculative region NEVER flushes a late
+ * import shift (`flushLateImportShifts`). A probe always rolls back, so flushing
+ * mid-probe would corrupt the very bodies the probe is about to discard —
+ * well-behaved probes register-but-defer, exactly the deferred-shift design of
+ * `ensureLateImport`. The snapshot records `pendingLateImportShift` and restores
+ * it on rollback, so a probe that armed the pending shift (without flushing) is
+ * fully undone.
+ */
+import type { CodegenContext, FunctionContext } from "./types.js";
+import { type LocalsSnapshot, snapshotLocals, restoreLocals } from "./locals.js";
+
+/**
+ * A transactional snapshot of the codegen state a speculative compile can
+ * mutate. Capture with {@link snapshotSpeculative}; undo with
+ * {@link rollbackSpeculative}. Discard (no-op) to commit.
+ *
+ * The snapshot is O(1): every field is an integer read or a reference copy
+ * (`snapshotLocals` copies the localMap key set, but locals are typically tiny;
+ * crucially the funcMap is NOT copied — rollback derives the names to delete
+ * from the popped import descriptors, which each carry their `name`). This keeps
+ * the helper cheap enough to wrap even the hot `compileExpression` path.
+ */
+export interface SpeculativeSnapshot {
+  /** `fctx.body.length` at snapshot time — the rollback truncation target. */
+  readonly bodyLen: number;
+  /** Locals / localMap / temp-free-list snapshot (#1847). */
+  readonly locals: LocalsSnapshot;
+  /** `ctx.errors.length` — diagnostics pushed during the probe are discarded. */
+  readonly errorsLen: number;
+  /** `ctx.mod.imports.length` — imports appended during the probe are popped. */
+  readonly importsLen: number;
+  /** `ctx.numImportFuncs` — restored so the func index space is rewound. */
+  readonly numImportFuncs: number;
+  /** `ctx.numImportGlobals` — restored if the probe added an import global. */
+  readonly numImportGlobals: number;
+  /**
+   * `ctx.pendingLateImportShift` reference at snapshot time. A probe that armed
+   * the deferred shift (called `ensureLateImport` while `pendingLateImportShift`
+   * was null) is rewound by restoring this exact reference (usually `null`).
+   */
+  readonly pendingLateImportShift: CodegenContext["pendingLateImportShift"];
+  /** `mod.types.length` — see {@link rollbackSpeculative} for why this is advisory. */
+  readonly typesLen: number;
+}
+
+/**
+ * Capture a transactional snapshot of all state a speculative compile may
+ * mutate. O(localMap.size) for the locals key-set copy; everything else is a
+ * handful of integer / reference reads (no funcMap copy — see
+ * {@link rollbackSpeculative}).
+ */
+export function snapshotSpeculative(ctx: CodegenContext, fctx: FunctionContext): SpeculativeSnapshot {
+  return {
+    bodyLen: fctx.body.length,
+    locals: snapshotLocals(fctx),
+    errorsLen: ctx.errors.length,
+    importsLen: ctx.mod.imports.length,
+    numImportFuncs: ctx.numImportFuncs,
+    numImportGlobals: ctx.numImportGlobals,
+    pendingLateImportShift: ctx.pendingLateImportShift,
+    typesLen: ctx.mod.types.length,
+  };
+}
+
+/**
+ * Undo every mutation made since {@link snapshotSpeculative} produced `snap`.
+ *
+ * - Truncate `fctx.body` to the snapshot length (the classic rollback).
+ * - Restore locals / localMap / temp-free-list (#1847 `restoreLocals`).
+ * - Drop diagnostics pushed during the probe (`ctx.errors`).
+ * - Pop late imports registered during the probe off `ctx.mod.imports`, rewind
+ *   `numImportFuncs` / `numImportGlobals`, delete their `funcMap` entries, and
+ *   restore the deferred-shift latch. This is the leak the #1919 helper exists
+ *   to close: because the probe never flushed the shift (the documented
+ *   invariant), the appended imports never shifted any already-emitted index, so
+ *   popping them and resetting the counters returns the import space exactly to
+ *   the pre-probe state with no body re-walk required.
+ *
+ * Registered Wasm TYPES (`ctx.mod.types` / `funcTypeCache` / struct maps) are
+ * deliberately NOT truncated. Type registration is content-addressed and
+ * idempotent (`addFuncType` dedups by signature; `getOrRegisterVecType` &c. cache
+ * by element kind), and type indices — unlike function indices — are never
+ * shifted by later import additions. A type registered during a rolled-back
+ * probe is therefore inert: it is either reused verbatim by the committed
+ * re-compile or pruned by dead-type elimination if truly unreferenced. Truncating
+ * it would risk desyncing a struct type registered earlier and still referenced
+ * (see `project_type_index_shift_and_deadelim`). `typesLen` is kept on the
+ * snapshot only for diagnostics / a future tightening, not acted on here.
+ */
+export function rollbackSpeculative(ctx: CodegenContext, fctx: FunctionContext, snap: SpeculativeSnapshot): void {
+  // 1. Body — the original rollback.
+  if (fctx.body.length > snap.bodyLen) {
+    fctx.body.length = snap.bodyLen;
+  }
+  // 2. Locals (#1847).
+  restoreLocals(fctx, snap.locals);
+  // 3. Diagnostics pushed during the probe.
+  if (ctx.errors.length > snap.errorsLen) {
+    ctx.errors.length = snap.errorsLen;
+  }
+  // 4. Late FUNC imports registered during the probe. Pop them, rewind
+  //    `numImportFuncs`, drop their funcMap names, and restore the deferred-shift
+  //    latch. Guard on growth so a probe that added nothing (the common case) is
+  //    a pure no-op.
+  //
+  //    The funcMap names to delete are read straight off the popped descriptors:
+  //    `ensureLateImport` only reaches `addImport` (the only appender) AFTER a
+  //    `funcMap.get(name) !== undefined` early-return, so every func import
+  //    appended during the probe carries a NAME that was absent from funcMap at
+  //    snapshot time. Deleting exactly those names restores funcMap precisely.
+  //
+  //    Import GLOBALS (JS-host string constants registered via
+  //    `addStringConstantGlobal`) are deliberately NOT popped. They are
+  //    content-addressed and idempotent (`stringGlobalMap.has(value)` early-
+  //    returns), so a constant registered during a rolled-back probe is reused
+  //    verbatim by the committed re-compile or stays an inert unused global.
+  //    Crucially, registering an import global runs `fixupModuleGlobalIndices`,
+  //    which already SHIFTED every `global.get` in already-committed bodies; the
+  //    naive `numImportGlobals--` here would NOT un-shift those, leaving them
+  //    out of range ("global index out of range"). Func-import indices are
+  //    positional among funcs and independent of where globals sit in
+  //    `ctx.mod.imports`, so removing only the func entries (keeping the global
+  //    entries, hence the global shift, intact) is index-correct for both spaces.
+  //
+  //    SAFETY — only pop when the probe's func imports are still UNFLUSHED.
+  //    `ensureLateImport` defers the index shift (arms `pendingLateImportShift`)
+  //    so a probe that merely registered imports left committed func bodies
+  //    untouched — popping is exact. But some emit helpers `flushLateImportShifts`
+  //    eagerly; if the probe flushed, every committed func index was already
+  //    shifted UP by the probe's imports and there is no cheap inverse (the
+  //    shift walker is forward-only). A flush is detectable: it consumes the
+  //    pending batch, so `pendingLateImportShift === null` while func imports
+  //    were added. In that rare case we KEEP the imports registered — exactly the
+  //    pre-#1919 behaviour (consistent, just a phantom import), never corrupting
+  //    indices. The common no-flush probe still cleans up fully.
+  if (ctx.mod.imports.length > snap.importsLen) {
+    const addedFuncImports = ctx.numImportFuncs > snap.numImportFuncs;
+    const probeFlushed = addedFuncImports && ctx.pendingLateImportShift === null;
+    if (!probeFlushed) {
+      const kept = ctx.mod.imports.slice(0, snap.importsLen);
+      for (let i = snap.importsLen; i < ctx.mod.imports.length; i++) {
+        const imp = ctx.mod.imports[i]!;
+        if (imp.desc.kind === "func") {
+          // Probe func imports all carry the highest func indices (registered in
+          // order at/above snap.numImportFuncs), so removing the whole run leaves
+          // every committed func index unchanged.
+          ctx.funcMap.delete(imp.name);
+        } else {
+          // Preserve import globals (and any non-func import) — see above.
+          kept.push(imp);
+        }
+      }
+      ctx.mod.imports = kept;
+      ctx.numImportFuncs = snap.numImportFuncs;
+      // `numImportGlobals` is intentionally left as-is: kept globals retain their
+      // indices and the shift they triggered stays consistent.
+      // Restore the deferred-shift latch. If the probe armed it (snapshot was
+      // null, probe set it), this returns it to null so the next real
+      // flushLateImportShifts computes its delta from a clean base.
+      ctx.pendingLateImportShift = snap.pendingLateImportShift;
+    }
+  }
+}
+
+/**
+ * Run `fn` as a speculative compile. `fn` returns a result and decides whether
+ * to keep ({@link SpeculativeOutcome.commit} `true`) or discard the emitted
+ * state. On `commit: false` (or if `fn` throws) the entire transaction is rolled
+ * back via {@link rollbackSpeculative} and `value` is still returned to the
+ * caller (so a probe can inspect the produced type after rollback).
+ *
+ * Use this for "try to lower; keep the body iff the shape matched" sites. For
+ * the pure "what ValType does this compile to, then always discard" probe use
+ * {@link probeCompiledType}, which is a thin wrapper that always rolls back.
+ */
+export interface SpeculativeOutcome<T> {
+  commit: boolean;
+  value: T;
+}
+
+export function withSpeculativeCompile<T>(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  fn: () => SpeculativeOutcome<T>,
+): T {
+  const snap = snapshotSpeculative(ctx, fctx);
+  let outcome: SpeculativeOutcome<T>;
+  try {
+    outcome = fn();
+  } catch (e) {
+    rollbackSpeculative(ctx, fctx, snap);
+    throw e;
+  }
+  if (!outcome.commit) {
+    rollbackSpeculative(ctx, fctx, snap);
+  }
+  return outcome.value;
+}
+
+/**
+ * The dominant probe shape: compile `fn` purely to learn the ValType it
+ * produces, then ALWAYS roll back every side effect (body, locals, imports,
+ * errors). Returns whatever `fn` returns (typically the probed `ValType | null`).
+ *
+ * This replaces the raw `const savedLen = fctx.body.length; … ;
+ * fctx.body.length = savedLen;` idiom — which restored only the body — with a
+ * full transactional rollback.
+ */
+export function probeCompiledType<T>(ctx: CodegenContext, fctx: FunctionContext, fn: () => T): T {
+  const snap = snapshotSpeculative(ctx, fctx);
+  try {
+    return fn();
+  } finally {
+    rollbackSpeculative(ctx, fctx, snap);
+  }
+}

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -25,6 +25,7 @@ import {
 } from "./async-scheduler.js";
 import { reportError, reportErrorNoNode } from "./context/errors.js";
 import { allocTempLocal, getLocalType, releaseTempLocal } from "./context/locals.js";
+import { snapshotSpeculative, rollbackSpeculative } from "./context/speculative.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import type { InnerResult } from "./shared.js";
 import {
@@ -600,12 +601,18 @@ function compileExpressionBody(
     }
   }
 
-  const bodyLenBefore = fctx.body.length;
+  // #1919 — transactional wrapper around the inner compile. The snapshot is O(1)
+  // and the two rollback exits below (a thrown inner compile; an inner that
+  // produced no usable value) discard the partial body AND any locals / late
+  // imports / errors it leaked, then emit a clean fallback value. The successful
+  // path simply drops the snapshot, so legitimately-registered imports persist.
+  const snap = snapshotSpeculative(ctx, fctx);
+  const bodyLenBefore = snap.bodyLen;
   let result: InnerResult;
   try {
     result = compileExpressionInner(ctx, fctx, expr, expectedType);
   } catch (e) {
-    fctx.body.length = bodyLenBefore;
+    rollbackSpeculative(ctx, fctx, snap);
     const msg = e instanceof Error ? e.message : String(e);
     reportErrorNoNode(ctx, `Internal error compiling expression: ${msg}`);
     const fallbackType = expectedType ?? { kind: "f64" as const };
@@ -700,7 +707,9 @@ function compileExpressionBody(
     return result;
   }
 
-  fctx.body.length = bodyLenBefore;
+  // Inner compile produced no usable value — roll back its partial emission
+  // (#1919: body + locals + late imports + errors) and emit a default instead.
+  rollbackSpeculative(ctx, fctx, snap);
   let wasmType: ValType;
   if (expectedType) {
     wasmType = expectedType;

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -43,6 +43,7 @@ import {
 import { popBody, pushBody } from "../context/bodies.js";
 import { reportError } from "../context/errors.js";
 import { allocLocal, allocTempLocal, getLocalType, releaseTempLocal } from "../context/locals.js";
+import { snapshotSpeculative, rollbackSpeculative } from "../context/speculative.js";
 import type { ClosureInfo, CodegenContext, FunctionContext } from "../context/types.js";
 import {
   addFuncType,
@@ -4578,7 +4579,10 @@ function compileCallExpression(
       // under --target standalone. Tentatively compile and only commit when
       // the argument genuinely lowers to a native string ref (#1610 pattern).
       if (!hasMapFn && ctx.nativeStrings && ctx.anyStrTypeIdx >= 0 && isStringType(argTsType)) {
-        const bodyLenBefore = fctx.body.length;
+        // #1919 — transactional try-lower: keep the compiled arg when it lowers
+        // to a native string; otherwise roll back the body AND any locals / late
+        // imports / errors so the fallback paths below start clean.
+        const snap = snapshotSpeculative(ctx, fctx);
         const t = compileExpression(ctx, fctx, expr.arguments[0]!);
         if (
           t &&
@@ -4593,7 +4597,7 @@ function compileCallExpression(
           return { kind: "ref", typeIdx: nstrVecTypeIdx };
         }
         // Didn't lower as a native string — roll back and use the paths below.
-        fctx.body.length = bodyLenBefore;
+        rollbackSpeculative(ctx, fctx, snap);
       }
       // (#2169) Array.from(g()) over a Wasm-native generator without a mapFn.
       // The argument lowers to the generator state struct, NOT a __vec — the
@@ -4604,7 +4608,10 @@ function compileCallExpression(
       // lowers to a native-generator subject (mirrors the #1470 native-string
       // probe above).
       if (!hasMapFn) {
-        const bodyLenBefore = fctx.body.length;
+        // #1919 — transactional try-lower: keep the compiled arg when it lowers
+        // to a native-generator subject; otherwise roll back the body AND any
+        // locals / late imports / errors so the fallback paths below start clean.
+        const snap = snapshotSpeculative(ctx, fctx);
         const t = compileExpression(ctx, fctx, expr.arguments[0]!);
         const genInfo = t ? nativeGeneratorInfoForForOfSubject(ctx, t) : undefined;
         if (genInfo) {
@@ -4614,7 +4621,7 @@ function compileCallExpression(
           return { kind: "ref", typeIdx: genVecTypeIdx };
         }
         // Not a native generator — roll back and use the paths below.
-        fctx.body.length = bodyLenBefore;
+        rollbackSpeculative(ctx, fctx, snap);
       }
       // (#42 follow-up) Array.from(Set) — standalone native. A Set lowers to a
       // `ref $Map` whose field layout is NOT a `__vec` (field 0 is not a length,

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -22,6 +22,7 @@ import { classMemberFuncKey } from "./class-member-keys.js"; // (#1983) collisio
 import { popBody, pushBody } from "./context/bodies.js";
 import { reportError, reportErrorNoNode } from "./context/errors.js";
 import { allocLocal, allocTempLocal, getLocalType, releaseTempLocal } from "./context/locals.js";
+import { snapshotSpeculative, rollbackSpeculative } from "./context/speculative.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { emitCachedMethodClosureAccess, emitFuncRefAsClosure, getOrCreateFuncRefWrapperTypes } from "./closures.js";
 import { emitLazyClassObjectGet, emitLazyProtoGet, findExternInfoForMember } from "./expressions/extern.js";
@@ -2141,8 +2142,9 @@ function tryEmitConstructorViaTag(
       fctx.body.push({ op: "local.set", index: resLocal } as Instr);
     } else {
       // No singleton emitted (shouldn't happen — classObjectGlobals has it):
-      // leave resLocal null.
-      fctx.body.length = 0;
+      // leave resLocal null. This clears the DETACHED `arm` buffer (fctx.body is
+      // `arm` here via the manual swap above), not a speculative-compile probe.
+      fctx.body.length = 0; // not-a-probe-rollback (#1919): detached arm buffer
     }
     fctx.body = savedBody;
     if (arm.length === 0) continue;
@@ -3640,7 +3642,10 @@ export function compilePropertyAccess(
     // Fallback: compile the expression and check the actual wasm return type
     // This handles cases like strings.raw.length where TS doesn't know the type
     {
-      const savedLen = fctx.body.length;
+      // #1919 — transactional try-lower: keep the compiled receiver + struct.get
+      // when it lowers to a length-prefixed vec; otherwise roll back the body AND
+      // any locals / late imports / errors the compile leaked.
+      const snap = snapshotSpeculative(ctx, fctx);
       const exprType = compileExpression(ctx, fctx, expr.expression);
       if (
         exprType &&
@@ -3656,7 +3661,7 @@ export function compilePropertyAccess(
         }
       }
       // Undo the compiled expression if it didn't match
-      fctx.body.length = savedLen;
+      rollbackSpeculative(ctx, fctx, snap);
     }
     // #1472 Phase B Blocker B Slice 2 — standalone `.length` on an `any`/unknown
     // receiver. None of the vec fast-paths matched, so the receiver is an opaque

--- a/src/codegen/statements/destructuring.ts
+++ b/src/codegen/statements/destructuring.ts
@@ -7,6 +7,7 @@ import { ts } from "../../ts-api.js";
 import type { Instr, ValType } from "../../ir/types.js";
 import { reportError } from "../context/errors.js";
 import { allocLocal, getLocalType } from "../context/locals.js";
+import { snapshotSpeculative, rollbackSpeculative, type SpeculativeSnapshot } from "../context/speculative.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { ensureLateImport, flushLateImportShifts, shiftLateImportIndices } from "../expressions/late-imports.js";
 import {
@@ -685,8 +686,10 @@ export function compileObjectDestructuring(
     ensureLetConstBindingPatternTdzFlags(ctx, fctx, pattern);
   }
 
-  // Save body length so we can rollback if struct lookup fails
-  const bodyLenBefore = fctx.body.length;
+  // #1919 — snapshot the speculative state so a failed struct lookup rolls back
+  // the compiled initializer value AND any locals / late imports / errors it
+  // leaked, not just the body length.
+  const snap = snapshotSpeculative(ctx, fctx);
 
   // Compile the initializer — result is a struct ref on the stack
   const resultType = compileExpression(ctx, fctx, decl.initializer);
@@ -755,7 +758,7 @@ export function compileObjectDestructuring(
         compileExternrefObjectDestructuringDecl(ctx, fctx, pattern, { kind: "externref" });
         return;
       }
-      fctx.body.length = bodyLenBefore; // rollback — value would leak on stack
+      rollbackSpeculative(ctx, fctx, snap); // value would otherwise leak on stack
       ensureBindingLocals(ctx, fctx, pattern);
       reportError(ctx, decl, "Cannot destructure: unknown type");
       return;
@@ -770,7 +773,7 @@ export function compileObjectDestructuring(
         compileExternrefObjectDestructuringDecl(ctx, fctx, pattern, { kind: "externref" });
         return;
       }
-      fctx.body.length = bodyLenBefore; // rollback — value would leak on stack
+      rollbackSpeculative(ctx, fctx, snap); // value would otherwise leak on stack
       ensureBindingLocals(ctx, fctx, pattern);
       reportError(ctx, decl, `Cannot destructure: not a known struct type: ${typeName}`);
       return;
@@ -796,7 +799,7 @@ export function compileObjectDestructuring(
       compileExternrefObjectDestructuringDecl(ctx, fctx, pattern, { kind: "externref" });
       return;
     }
-    fctx.body.length = bodyLenBefore;
+    rollbackSpeculative(ctx, fctx, snap);
     ensureBindingLocals(ctx, fctx, pattern);
     reportError(ctx, decl, "Cannot destructure: rest element on non-ref typed value");
     return;
@@ -986,7 +989,9 @@ export function compileArrayDestructuring(
     ensureLetConstBindingPatternTdzFlags(ctx, fctx, pattern);
   }
 
-  const bodyLenBefore = fctx.body.length;
+  // #1919 — snapshot so a non-array initializer rolls back its compiled value
+  // plus any locals / late imports / errors, not just the body length.
+  const snap = snapshotSpeculative(ctx, fctx);
 
   // When the pattern has rest elements, force vec mode for the initializer so
   // array literals produce a full vec (not a truncated tuple matching the binding pattern type)
@@ -1015,7 +1020,7 @@ export function compileArrayDestructuring(
         return;
       }
     }
-    fctx.body.length = bodyLenBefore;
+    rollbackSpeculative(ctx, fctx, snap);
     ensureBindingLocals(ctx, fctx, pattern);
     reportError(ctx, decl, "Cannot destructure: not an array type");
     return;
@@ -1180,7 +1185,7 @@ export function compileArrayDestructuring(
 
   // String destructuring: use __str_charAt to extract individual characters
   if (isStringStruct) {
-    compileStringDestructuring(ctx, fctx, pattern, resultType, bodyLenBefore);
+    compileStringDestructuring(ctx, fctx, pattern, resultType, snap);
     return;
   }
 
@@ -1214,13 +1219,13 @@ function compileStringDestructuring(
   fctx: FunctionContext,
   pattern: ts.ArrayBindingPattern,
   resultType: ValType,
-  bodyLenBefore: number,
+  snap: SpeculativeSnapshot,
 ): void {
   // Ensure __str_charAt is available
   ensureNativeStringHelpers(ctx);
   const charAtIdx = ctx.nativeStrHelpers.get("__str_charAt");
   if (charAtIdx === undefined) {
-    fctx.body.length = bodyLenBefore;
+    rollbackSpeculative(ctx, fctx, snap);
     ensureBindingLocals(ctx, fctx, pattern);
     reportError(ctx, pattern, "Cannot destructure string: __str_charAt helper not available");
     return;

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -8,7 +8,8 @@ import { forEachChild, ts } from "../../ts-api.js";
 import { collectReferencedIdentifiers } from "../closures.js";
 import { popBody, pushBody } from "../context/bodies.js";
 import { reportError, reportErrorNoNode } from "../context/errors.js";
-import { allocLocal, getLocalType, restoreLocals, snapshotLocals } from "../context/locals.js";
+import { allocLocal, getLocalType } from "../context/locals.js";
+import { snapshotSpeculative, rollbackSpeculative } from "../context/speculative.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import { emitExternrefDestructureGuard } from "../destructuring-params.js";
 import {
@@ -2479,11 +2480,10 @@ function compileForOfNativeCollection(
   // Confirm the receiver genuinely lowers to the native `$Map` struct (a Map/Set
   // typed value can still be a host externref in JS-host mode) without leaving
   // code behind.
-  const bodyLenBefore = fctx.body.length;
-  const localsSnap = snapshotLocals(fctx);
+  // #1919 — transactional probe: discard body + locals + late imports + errors.
+  const snap = snapshotSpeculative(ctx, fctx);
   const recvType = compileExpression(ctx, fctx, receiver);
-  fctx.body.length = bodyLenBefore;
-  restoreLocals(fctx, localsSnap);
+  rollbackSpeculative(ctx, fctx, snap);
   if (!recvType || (recvType.kind !== "ref" && recvType.kind !== "ref_null")) return false;
   if (recvType.typeIdx !== ctx.mapTypeIdx) return false;
 
@@ -2554,11 +2554,10 @@ function compileForOfNativeMapEntries(
 
   // Confirm the receiver genuinely lowers to the native `$Map` struct without
   // leaving code behind (same probe as compileForOfNativeCollection).
-  const probeBody = fctx.body.length;
-  const probeLocals = snapshotLocals(fctx);
+  // #1919 — transactional probe: discard body + locals + late imports + errors.
+  const probeSnap = snapshotSpeculative(ctx, fctx);
   const recvProbe = compileExpression(ctx, fctx, receiver);
-  fctx.body.length = probeBody;
-  restoreLocals(fctx, probeLocals);
+  rollbackSpeculative(ctx, fctx, probeSnap);
   if (!recvProbe || (recvProbe.kind !== "ref" && recvProbe.kind !== "ref_null")) return false;
   if (recvProbe.typeIdx !== ctx.mapTypeIdx) return false;
 
@@ -2719,11 +2718,10 @@ function arrayIteratorReceiverForForOf(
   if (method !== "values" && method !== "keys" && method !== "entries") return undefined;
 
   // Confirm the receiver lowers to a vec struct without leaving any code behind.
-  const bodyLenBefore = fctx.body.length;
-  const localsSnap = snapshotLocals(fctx); // #1847
+  // #1919 — transactional probe: discard body + locals + late imports + errors.
+  const snap = snapshotSpeculative(ctx, fctx);
   const recvType = compileExpression(ctx, fctx, callee.expression);
-  fctx.body.length = bodyLenBefore;
-  restoreLocals(fctx, localsSnap); // #1847 — also drops stale localMap entries
+  rollbackSpeculative(ctx, fctx, snap);
   if (!recvType || (recvType.kind !== "ref" && recvType.kind !== "ref_null")) return undefined;
   if (getArrTypeIdxFromVec(ctx, recvType.typeIdx) < 0) return undefined;
   return { receiver: callee.expression, method };
@@ -2764,11 +2762,12 @@ function compileForOfString(ctx: CodegenContext, fctx: FunctionContext, stmt: ts
 
   const strType = nativeStringType(ctx);
 
-  // Compile the iterable expression (string ref)
-  const bodyLenBefore = fctx.body.length;
+  // Compile the iterable expression (string ref).
+  // #1919 — snapshot so a failed compile rolls back body + locals + imports.
+  const strSnap = snapshotSpeculative(ctx, fctx);
   const compiledType = compileExpression(ctx, fctx, stmt.expression);
   if (!compiledType) {
-    fctx.body.length = bodyLenBefore;
+    rollbackSpeculative(ctx, fctx, strSnap);
     reportError(ctx, stmt, "for-of: failed to compile string expression");
     return;
   }
@@ -3005,9 +3004,10 @@ function compileForOfArrayTentative(
   iterableOverride?: ts.Expression,
 ): boolean {
   const iterableExpr = iterableOverride ?? stmt.expression;
-  // Tentatively compile just the expression to discover its Wasm type
-  const bodyLenBefore = fctx.body.length;
-  const localsSnap = snapshotLocals(fctx); // #1847
+  // Tentatively compile just the expression to discover its Wasm type.
+  // #1919 — transactional probe: every exit re-compiles (vec path) or defers to
+  // the iterator path, so always discard body + locals + late imports + errors.
+  const snap = snapshotSpeculative(ctx, fctx);
   const exprType = compileExpression(ctx, fctx, iterableExpr);
 
   // Check if it compiled to a ref to a vec struct (not just any struct —
@@ -3018,16 +3018,14 @@ function compileForOfArrayTentative(
     if (typeDef && typeDef.kind === "struct" && getArrTypeIdxFromVec(ctx, exprType.typeIdx) >= 0) {
       // Confirmed vec struct — undo the tentative compilation and use the
       // full array path (which compiles the expression again with proper setup)
-      fctx.body.length = bodyLenBefore;
-      restoreLocals(fctx, localsSnap); // #1847
+      rollbackSpeculative(ctx, fctx, snap);
       compileForOfArray(ctx, fctx, stmt, iterableOverride);
       return true;
     }
   }
 
   // Not a vec struct — undo tentative compilation, let caller use iterator path
-  fctx.body.length = bodyLenBefore;
-  restoreLocals(fctx, localsSnap); // #1847
+  rollbackSpeculative(ctx, fctx, snap);
   return false;
 }
 
@@ -3059,10 +3057,12 @@ function compileForOfArray(
   // inner receiver of a `.values()` call (#681) when present. When `preVec` is
   // supplied the caller already materialized the vec into a local (#2162 native
   // Map/Set for-of), so skip the expression compile.
-  const bodyLenBefore = fctx.body.length;
+  // #1919 — snapshot so a non-array receiver rolls back body + locals + imports
+  // before reporting. With `preVec` no compile happens, so rollback is a no-op.
+  const snap = snapshotSpeculative(ctx, fctx);
   const vecType = preVec ? preVec.vecType : compileExpression(ctx, fctx, iterableOverride ?? stmt.expression);
   if (!vecType || (vecType.kind !== "ref" && vecType.kind !== "ref_null")) {
-    fctx.body.length = bodyLenBefore;
+    rollbackSpeculative(ctx, fctx, snap);
     reportError(ctx, stmt, "for-of requires an array expression");
     return;
   }
@@ -3071,7 +3071,7 @@ function compileForOfArray(
   const vecTypeIdx = vecType.typeIdx;
   const vecDef = ctx.mod.types[vecTypeIdx];
   if (!vecDef || vecDef.kind !== "struct") {
-    fctx.body.length = bodyLenBefore;
+    rollbackSpeculative(ctx, fctx, snap);
     reportError(ctx, stmt, "for-of requires an array type");
     return;
   }
@@ -3079,7 +3079,7 @@ function compileForOfArray(
   const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
   const arrDef = ctx.mod.types[arrTypeIdx];
   if (!arrDef || arrDef.kind !== "array") {
-    fctx.body.length = bodyLenBefore;
+    rollbackSpeculative(ctx, fctx, snap);
     reportError(ctx, stmt, "for-of requires an array type");
     return;
   }
@@ -3405,11 +3405,10 @@ function compileForOfArrayEntries(
   }
 
   // Resolve the element (value) Wasm type from the receiver's vec/arr type.
-  const probeBody = fctx.body.length;
-  const probeLocals = snapshotLocals(fctx);
+  // #1919 — transactional probe: discard body + locals + late imports + errors.
+  const probeSnap = snapshotSpeculative(ctx, fctx);
   const recvType = compileExpression(ctx, fctx, receiver);
-  fctx.body.length = probeBody;
-  restoreLocals(fctx, probeLocals);
+  rollbackSpeculative(ctx, fctx, probeSnap);
   if (!recvType || (recvType.kind !== "ref" && recvType.kind !== "ref_null")) {
     if (!compileForOfArrayTentative(ctx, fctx, stmt)) compileForOfIterator(ctx, fctx, stmt);
     return;
@@ -3490,10 +3489,11 @@ function emitArrayKeysEntriesLoop(
   receiver: ts.Expression,
   bindIteration: (lenLocal: number, iLocal: number, dataLocal: number, arrTypeIdx: number) => void,
 ): void {
-  const bodyLenBefore = fctx.body.length;
+  // #1919 — snapshot so a non-array receiver rolls back body + locals + imports.
+  const snap = snapshotSpeculative(ctx, fctx);
   const vecType = compileExpression(ctx, fctx, receiver);
   if (!vecType || (vecType.kind !== "ref" && vecType.kind !== "ref_null")) {
-    fctx.body.length = bodyLenBefore;
+    rollbackSpeculative(ctx, fctx, snap);
     reportError(ctx, stmt, "for-of requires an array expression");
     return;
   }
@@ -3501,7 +3501,7 @@ function emitArrayKeysEntriesLoop(
   const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
   const arrDef = ctx.mod.types[arrTypeIdx];
   if (!arrDef || arrDef.kind !== "array") {
-    fctx.body.length = bodyLenBefore;
+    rollbackSpeculative(ctx, fctx, snap);
     reportError(ctx, stmt, "for-of requires an array type");
     return;
   }
@@ -4224,9 +4224,9 @@ function findStructFieldsByTypeIdx(
  *     br loop
  */
 function compileForOfIterator(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.ForOfStatement): void {
-  // Compile the iterable expression
-  const bodyLenBefore = fctx.body.length;
-  const localsSnap = snapshotLocals(fctx); // #1847
+  // Compile the iterable expression. (#1919) Unlike the tentative probes above,
+  // every path here KEEPS the compiled iterable on the stack — it is consumed by
+  // the chosen iteration loop — so there is no rollback and no snapshot to take.
   const iterableType = compileExpression(ctx, fctx, stmt.expression);
   if (!iterableType) {
     reportError(ctx, stmt, "for-of: failed to compile iterable expression");

--- a/src/codegen/string-builder.ts
+++ b/src/codegen/string-builder.ts
@@ -31,6 +31,7 @@ import { ts, forEachChild } from "../ts-api.js";
 import type { Instr, ValType } from "../ir/types.js";
 import { collectReferencedIdentifiers } from "./closures.js";
 import { allocLocal } from "./context/locals.js";
+import { snapshotSpeculative, rollbackSpeculative } from "./context/speculative.js";
 import { compileExpression } from "./shared.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 
@@ -762,13 +763,15 @@ function emitPresizedBufferAlloc(
   capLocalIdx: number,
   strDataTypeIdx: number,
 ): boolean {
-  // Snapshot the body so we can roll back if the bound compile fails.
-  const savedLen = fctx.body.length;
+  // #1919 — snapshot the full speculative state so a failed bound-compile rolls
+  // back not just the body but also any locals / late imports / errors it leaked
+  // (the caller falls back to the doubling buffer, which re-emits independently).
+  const snap = snapshotSpeculative(ctx, fctx);
   // Compile the bound expression, requesting an i32 (loop counters/bounds are
   // typically i32 or f64). compileExpression returns the produced ValType.
   const boundType = compileExpression(ctx, fctx, presize.boundExpr, { kind: "i32" });
   if (boundType === null) {
-    fctx.body.length = savedLen;
+    rollbackSpeculative(ctx, fctx, snap);
     return false;
   }
   if (boundType.kind === "f64") {
@@ -777,7 +780,7 @@ function emitPresizedBufferAlloc(
     fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
   } else if (boundType.kind !== "i32") {
     // Unexpected type — roll back, keep the doubling buffer.
-    fctx.body.length = savedLen;
+    rollbackSpeculative(ctx, fctx, snap);
     return false;
   }
   // Stash bound in a temp so we can reference it three times for the clamp.

--- a/tests/issue-1919-speculative-compile.test.ts
+++ b/tests/issue-1919-speculative-compile.test.ts
@@ -1,0 +1,216 @@
+// #1919 — transactional speculative-compile API.
+//
+// The probe-compile-and-rollback idiom (compile an expression to inspect its
+// type, then truncate `fctx.body.length` to undo) leaked locals, late imports,
+// and errors on rollback — restoring only the body. A late import leaked by a
+// rolled-back probe is the worst: it stays in `mod.imports` and shifts every
+// later function index (#1916 interaction). These tests pin the helper's
+// contract (`snapshotSpeculative`/`rollbackSpeculative`) directly, plus an
+// end-to-end compile whose probe path used to leak.
+import { describe, expect, it } from "vitest";
+import ts from "typescript";
+import { compile } from "../src/index.js";
+import { createEmptyModule } from "../src/ir/types.js";
+import { createCodegenContext } from "../src/codegen/index.js";
+import { allocLocal } from "../src/codegen/context/locals.js";
+import { ensureLateImport, flushLateImportShifts } from "../src/codegen/expressions/late-imports.js";
+import {
+  snapshotSpeculative,
+  rollbackSpeculative,
+  withSpeculativeCompile,
+  probeCompiledType,
+} from "../src/codegen/context/speculative.js";
+import type { CodegenContext, FunctionContext } from "../src/codegen/context/types.js";
+
+function makeFctx(): FunctionContext {
+  return {
+    name: "test",
+    params: [],
+    locals: [],
+    localMap: new Map<string, number>(),
+    returnType: null,
+    body: [],
+    blockDepth: 0,
+    breakStack: [],
+    continueStack: [],
+    labelMap: new Map(),
+    savedBodies: [],
+  } as unknown as FunctionContext;
+}
+
+function makeCtx(): CodegenContext {
+  const mod = createEmptyModule();
+  // createCodegenContext only needs the checker object to exist for these paths.
+  return createCodegenContext(mod, {} as unknown as ts.TypeChecker);
+}
+
+describe("#1919 — rollbackSpeculative unwinds body + locals + late imports + errors", () => {
+  it("pops a late import registered during the rolled-back region", () => {
+    const ctx = makeCtx();
+    const fctx = makeFctx();
+
+    // A pre-existing import — must survive rollback untouched. Flush its pending
+    // shift so the snapshot starts from a clean (null) deferred-shift latch,
+    // isolating the probe's effect on `pendingLateImportShift`.
+    ensureLateImport(ctx, "__pre_existing", [{ kind: "i32" }], [{ kind: "i32" }]);
+    ctx.pendingLateImportShift = null; // pretend the pre-existing shift was flushed
+    const importsBefore = ctx.mod.imports.length;
+    const numImportFuncsBefore = ctx.numImportFuncs;
+
+    const snap = snapshotSpeculative(ctx, fctx);
+    expect(snap.pendingLateImportShift).toBeNull();
+
+    // Probe registers a NEW late import + emits a body instr + a local + an error.
+    const phantomIdx = ensureLateImport(ctx, "__phantom_probe", [{ kind: "f64" }], [{ kind: "externref" }]);
+    expect(phantomIdx).toBeDefined();
+    expect(ctx.funcMap.has("__phantom_probe")).toBe(true);
+    expect(ctx.mod.imports.length).toBe(importsBefore + 1);
+    expect(ctx.numImportFuncs).toBe(numImportFuncsBefore + 1);
+    fctx.body.push({ op: "call", funcIdx: phantomIdx! });
+    allocLocal(fctx, "__probe_local", { kind: "i32" });
+    ctx.errors.push({ message: "probe diagnostic", line: 0, column: 0, severity: "error" });
+
+    rollbackSpeculative(ctx, fctx, snap);
+
+    // The phantom import is gone — funcMap, mod.imports, and numImportFuncs all
+    // back to the snapshot, so no later function index would be shifted by it.
+    expect(ctx.funcMap.has("__phantom_probe")).toBe(false);
+    expect(ctx.mod.imports.length).toBe(importsBefore);
+    expect(ctx.numImportFuncs).toBe(numImportFuncsBefore);
+    // The pre-existing import is untouched.
+    expect(ctx.funcMap.has("__pre_existing")).toBe(true);
+    // Body, locals, errors all restored.
+    expect(fctx.body.length).toBe(0);
+    expect(fctx.localMap.has("__probe_local")).toBe(false);
+    expect(ctx.errors.length).toBe(0);
+    // The deferred-shift latch is back to its pre-probe value (null) so the next
+    // real flush computes its delta from a clean base.
+    expect(ctx.pendingLateImportShift).toBeNull();
+  });
+
+  it("re-registering the same import name after rollback gets a fresh, contiguous index", () => {
+    const ctx = makeCtx();
+    const fctx = makeFctx();
+    const snap = snapshotSpeculative(ctx, fctx);
+    const probeIdx = ensureLateImport(ctx, "__box_x", [{ kind: "f64" }], [{ kind: "externref" }]);
+    rollbackSpeculative(ctx, fctx, snap);
+    // After rollback the name is free again; re-registering yields the same slot
+    // it would have had if the probe never ran (no phantom gap in the index space).
+    const committedIdx = ensureLateImport(ctx, "__box_x", [{ kind: "f64" }], [{ kind: "externref" }]);
+    expect(committedIdx).toBe(probeIdx);
+    expect(ctx.numImportFuncs).toBe(1);
+    expect(ctx.mod.imports.length).toBe(1);
+  });
+
+  it("withSpeculativeCompile keeps state on commit, discards it on rollback", () => {
+    const ctx = makeCtx();
+    const fctx = makeFctx();
+
+    // commit: true keeps the registered import.
+    const kept = withSpeculativeCompile(ctx, fctx, () => {
+      const idx = ensureLateImport(ctx, "__kept", [], [{ kind: "i32" }]);
+      return { commit: true, value: idx };
+    });
+    expect(kept).toBeDefined();
+    expect(ctx.funcMap.has("__kept")).toBe(true);
+
+    // commit: false discards it.
+    const discarded = withSpeculativeCompile(ctx, fctx, () => {
+      const idx = ensureLateImport(ctx, "__discarded", [], [{ kind: "i32" }]);
+      return { commit: false, value: idx };
+    });
+    expect(discarded).toBeDefined(); // value still returned for inspection
+    expect(ctx.funcMap.has("__discarded")).toBe(false);
+  });
+
+  it("withSpeculativeCompile rolls back when fn throws, then re-throws", () => {
+    const ctx = makeCtx();
+    const fctx = makeFctx();
+    const importsBefore = ctx.mod.imports.length;
+    expect(() =>
+      withSpeculativeCompile(ctx, fctx, () => {
+        ensureLateImport(ctx, "__throws", [], [{ kind: "i32" }]);
+        throw new Error("boom");
+      }),
+    ).toThrow("boom");
+    // The import registered before the throw is unwound.
+    expect(ctx.funcMap.has("__throws")).toBe(false);
+    expect(ctx.mod.imports.length).toBe(importsBefore);
+  });
+
+  it("keeps the import (no corruption) when the probe FLUSHED its shift mid-region", () => {
+    // If a probe eagerly flushes (some emit helpers do), committed func bodies
+    // were already shifted UP and there is no cheap inverse. Rollback must then
+    // KEEP the import registered (pre-#1919 behaviour) rather than pop the count
+    // and leave indices desynced. Simulate a flush after the import is added.
+    const ctx = makeCtx();
+    const fctx = makeFctx();
+    const importsBefore = ctx.mod.imports.length;
+    const snap = snapshotSpeculative(ctx, fctx);
+    ensureLateImport(ctx, "__flushed_probe", [], [{ kind: "i32" }]);
+    flushLateImportShifts(ctx, fctx); // probe flushed → pendingLateImportShift = null
+    expect(ctx.pendingLateImportShift).toBeNull();
+    rollbackSpeculative(ctx, fctx, snap);
+    // The import is KEPT (popping it would desync the already-shifted indices).
+    expect(ctx.funcMap.has("__flushed_probe")).toBe(true);
+    expect(ctx.mod.imports.length).toBe(importsBefore + 1);
+    // Body + locals + errors are still rolled back (those are always safe).
+    expect(fctx.body.length).toBe(0);
+  });
+
+  it("probeCompiledType always rolls back and returns the probe's value", () => {
+    const ctx = makeCtx();
+    const fctx = makeFctx();
+    const importsBefore = ctx.mod.imports.length;
+    const result = probeCompiledType(ctx, fctx, () => {
+      ensureLateImport(ctx, "__probe_only", [], [{ kind: "i32" }]);
+      fctx.body.push({ op: "i32.const", value: 7 });
+      return { kind: "i32" as const };
+    });
+    expect(result).toEqual({ kind: "i32" });
+    // Always rolled back, regardless of return value.
+    expect(ctx.funcMap.has("__probe_only")).toBe(false);
+    expect(ctx.mod.imports.length).toBe(importsBefore);
+    expect(fctx.body.length).toBe(0);
+  });
+});
+
+describe("#1919 — end-to-end: a probe path that registers an import does not leak it", () => {
+  it("Array.from(<string>) over a non-native-string arg compiles to a valid module", async () => {
+    // The Array.from native-string probe (calls.ts) tentatively compiles the arg
+    // and rolls back when it is not a native string. If the rolled-back probe
+    // leaked a late import, every later function index would shift and the module
+    // would fail Wasm validation. A clean compile + instantiate proves no leak.
+    const src = `
+      export function test(): number {
+        const a = Array.from([1, 2, 3]);
+        const b = Array.from("xy");
+        return a.length + b.length;
+      }
+    `;
+    const r = await compile(src, { fileName: "t.ts" });
+    expect(r.success).toBe(true);
+    const importObject = (r as { importObject?: WebAssembly.Imports }).importObject ?? {};
+    const { instance } = await WebAssembly.instantiate(r.binary, importObject);
+    expect((instance.exports.test as () => number)()).toBe(5);
+  });
+
+  it("consecutive array method probes + for-of over the same array stay valid", async () => {
+    // Exercises the array-method receiver probe (array-methods.ts) and the
+    // tentative for-of path back-to-back; a leaked probe import would desync
+    // indices between the two and fail validation.
+    const src = `
+      export function test(): number {
+        const arr: number[] = [4, 5, 6];
+        let total = arr.reduce((acc, x) => acc + x, 0);
+        for (const v of arr) { total += v; }
+        return total;
+      }
+    `;
+    const r = await compile(src, { fileName: "t.ts" });
+    expect(r.success).toBe(true);
+    const importObject = (r as { importObject?: WebAssembly.Imports }).importObject ?? {};
+    const { instance } = await WebAssembly.instantiate(r.binary, importObject);
+    expect((instance.exports.test as () => number)()).toBe(30);
+  });
+});


### PR DESCRIPTION
## #1919 — transactional speculative-compile API

The probe-compile-and-rollback idiom (speculatively `compileExpression` to read
its produced `ValType`, then truncate `fctx.body.length` to undo) appeared at
~20 sites and restored **only the body** — leaking the locals, late imports, and
error diagnostics the probe allocated. A leaked late import is the worst: it
stays in `mod.imports` and shifts every later function index on the next
`flushLateImportShifts` (the #1919/#1916 phantom-import heisenbug).

### Approach
New `src/codegen/context/speculative.ts`:
- `snapshotSpeculative` / `rollbackSpeculative` — O(1) capture + exact unwind of
  body + locals (#1847) + errors + late **func** imports + the deferred-shift latch.
- `probeCompiledType(ctx, fctx, fn)` — always rolls back (the dominant "compile-only-to-read-the-type" probe).
- `withSpeculativeCompile(ctx, fctx, fn)` — commit-or-rollback try-lower sites.

Two non-obvious correctness guards (both test-covered):
1. **Import GLOBALS are kept**, not popped — registering a string-constant global
   runs `fixupModuleGlobalIndices`, which already shifted committed `global.get`
   indices and has no cheap inverse. Func-import indices are positional among
   funcs and independent of globals, so only func entries are popped.
2. **A probe that FLUSHED mid-region keeps its imports** — committed func bodies
   were already shifted and the shift walker is forward-only. Detected via
   `pendingLateImportShift === null` while func imports grew. This makes #1919
   strictly ≥ the pre-existing behaviour.

Registered Wasm **types** are intentionally left in place (idempotent /
content-addressed; type indices are never shifted by import additions).

### Migrated sites
Every raw `body.length =` rollback under `src/codegen/`: `array-methods.ts`,
`property-access.ts`, `string-builder.ts`, `expressions/calls.ts` (both
`Array.from` try-lowers), `statements/loops.ts` (all for-of probes + array-shape
error exits; one dead snapshot removed), `statements/destructuring.ts`, and the
`compileExpression` error-recovery wrapper.

### Drift gate
`scripts/check-speculative-rollback-sites.mjs` (wired into the CI `quality` job
as `check:speculative-rollback`) fails on any new raw `*.body.length = …`
assignment outside the helper. The single legitimate detached-buffer truncation
carries the inline `not-a-probe-rollback (#1919)` opt-out.

### Acceptance criteria
- [x] Zero raw `body.length =` rollbacks outside the helper (enforced by the new gate).
- [x] Late imports registered during a rolled-back probe do not appear in the module (unit regression test).
- [ ] Equivalence + test262 CI green (this PR — broad-impact, merge_group full-Test262 is authoritative).

### Validation
**Broad-impact** (shared codegen machinery) — a scoped sweep is not authoritative;
the merge_group full-Test262 run is the conformance gate. Scoped confidence:
tsc clean · prettier clean · biome lint (no new errors) · all quality sub-gates
green (stack-balance, codegen-fallbacks, any-box, coercion, the new gate) · 96
equivalence tests + the affected unit suites (array-methods, for-of,
destructuring, string-builder, #1847) + `tests/issue-1919-speculative-compile.test.ts`
(8 cases) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA