### PR TITLE
docs(#2161): slice standalone RegExp residual into 4 dev-tractable sub-issues

### DIFF
--- a/plan/issues/2161-standalone-regexp-engine-residual.md
+++ b/plan/issues/2161-standalone-regexp-engine-residual.md
@@ -400,3 +400,46 @@ sticky (`/y/` + `lastIndex`) **all PASS host-import-free**. So the high-frequenc
 RegExp surface is already correct standalone — **no quick dev win remains here**;
 the open residual is the documented feature/representation tail above (v-flag
 `\q{}`, dynamic ctor patterns, `any`-typed receivers). Not claimed.
+
+## Umbrella sub-issue slicing (2026-06-22, architect)
+
+Re-bucketed the **full standalone-vs-host gap** (host baseline `2026-06-20`,
+standalone baseline `2026-06-19`, both from `loopdive/js2wasm-baselines`):
+**747 RegExp tests pass host / fail standalone** (478 `compile_error` + 269
+`fail`). Re-probed every distinctive feature against **current upstream/main**
+(`--target standalone`, empty importObject) to find the **concrete, bounded,
+substrate-independent** wins. Sliced into 4 dispatch-ready dev issues:
+
+| # | slice | root cause (verified on main) | est. rows | feasibility |
+|---|---|---|---:|---|
+| **#2588** | named-groups result object `m.groups` + `$<name>` substitution | match-vec struct has no `groups` field; reader maps any non-`index` prop to `input`; `$<` is a literal stub. Numbered captures + `\k<name>` already work; only the result-object exposure + `$<name>` are missing. | ~40-50 | medium |
+| **#2589** | `d`-flag match `.indices` array | match-vec struct has no `indices` field; `m.indices` read leaks `env::__extern_get`. The `caps` i32 array already holds every start/end pair — just unmaterialised. | ~15-22 | medium |
+| **#2590** | `RegExp.escape(str)` static method (ES2025) | entirely unimplemented; leaks `env::__get_builtin` and fails to instantiate. Pure native string transform, no engine. | ~20-29 | medium |
+| **#2591** | `v`-flag `\q{…}` string disjunction | set ops `&&`/`--` already work; `\q{}` **traps at runtime** ("illegal cast") — the unicode.ts refusal guard is bypassed for some forms, lowering a malformed multi-char-in-class node. Implement (desugar to alternation) or complete the refusal. | ~25-39 | medium |
+
+**Sub-total ≈ 100-140 standalone rows** across the 4 slices. Each has ONE
+concrete root cause, is independently implementable (~1-2 days), and is pure
+regex-engine / result-shape work — **no value-rep / substrate dependency**.
+
+### Residual NOT covered by the 4 slices (left under #2161)
+
+- **`RegExp.prototype` reflection (~126)** — gated on **#2158**'s standalone
+  builtin-prototype-object representation (every `RegExp.prototype.test`/`.flags`/
+  descriptor form chains off the `RegExp.prototype` OBJECT read that has no native
+  handler). NOT a bounded point-fix; do not slice here. Documented above
+  (2026-06-16 sdev5 + refinement).
+- **Dynamic / `any`-typed receivers (bucket c, ~50+)** — `function f(re: RegExp)`
+  / `re.test` on an externref receiver returns wrong results because the native
+  engine takes a statically-typed `$NativeRegExp`. Needs the runtime-externref
+  regex-receiver generalisation (`emitRegexExecArrayCall`). A larger architectural
+  slice; not in this batch.
+- **Dynamic constructor patterns/flags** (`new RegExp("a"+"b","g")` runtime-traps
+  "illegal cast"; ~64) — engine feature + dynamic-pattern lowering.
+- **`String.prototype.split`/`replace`/`search` `.call()` + ToString-coercion +
+  symbol-protocol dynamic forms** — overlaps the bucket-c dynamic-receiver work.
+- The static `@@match/@@matchAll/@@search/@@replace/@@split` protocol forms and
+  `matchAll`, `toString`, `String(re)`/`` `${re}` `` coercion are **already
+  landed** (slices above); not re-sliced.
+
+**#2161 stays open** as the umbrella tracker for the reflection (#2158-gated) and
+dynamic-receiver residuals once #2588-#2591 land.

--- a/plan/issues/2588-standalone-regexp-named-groups-result-object.md
+++ b/plan/issues/2588-standalone-regexp-named-groups-result-object.md
@@ -1,0 +1,140 @@
+---
+id: 2588
+title: "Standalone RegExp named-groups result object (`m.groups`) + `$<name>` substitution"
+status: ready
+sprint: 65
+priority: high
+feasibility: medium
+parent: 2161
+area: regexp
+goal: standalone-mode
+language_feature: regexp
+task_type: conformance
+created: 2026-06-22
+---
+
+# Standalone RegExp named-groups result object (`m.groups`) + `$<name>` substitution
+
+Slice of umbrella #2161. **Substrate-independent** (regex engine + match-result
+struct shape, not value-rep).
+
+## Problem
+
+In `--target standalone`, named capture groups `(?<name>…)` parse and the
+**numbered** capture and **`\k<name>` backreference** both work, but the named
+groups are **never exposed on the match-result object** and **`$<name>`
+replacement substitution is dropped**:
+
+| form | standalone result | spec (§22.2.7.2 step 28, §22.1.3.x) |
+|---|---|---|
+| `/(?<yr>\d{4})/.exec("2026").groups` | falsy / not an object | `{ yr: "2026" }` |
+| `m.groups.yr` | unreachable (groups falsy) | `"2026"` |
+| `"2026-06".replace(/(?<y>\d{4})-(?<m>\d{2})/, "$<m>/$<y>")` | `undefined` (drops) | `"06/2026"` |
+
+Verified on current main (`--target standalone`, empty importObject): the `.groups`
+read returns falsy and `$<name>` expansion yields wrong output. The `native-regex.ts`
+substitution code even has the literal comment "`$<` (no named groups in the standalone
+backend) → literal" (line ~3055), confirming the gap is intentional-stub, not a bug
+in otherwise-correct code.
+
+## Root cause
+
+1. **Match-result shape** — `ensureRegexMatchVecType` (`native-regex.ts:1690`) builds
+   the `$__regexp_match_vec` struct with only `index` (field 2) and `input` (field 3).
+   There is **no `groups` field**, so `__regex_capture_array` (`native-regex.ts:1738`)
+   never populates a named-groups object.
+2. **Property dispatch** — the match-result property reader in
+   `regexp-standalone.ts` (the match-result-prop branch, ~line 2240) handles only
+   `index` explicitly and treats **every other property name as `input`** (line 2246
+   falls through). `m.groups` therefore reads the `input` string, not a groups object.
+3. **`$<name>` substitution** — the `__regex_get_substitution` emitter (#1913,
+   `native-regex.ts` ~3000-3060) handles `$&`, `` $` ``, `$'`, `$n` but treats `$<` as
+   a literal because it has no name→capture-index mapping at substitution time.
+
+The parser already produces everything needed: `parsePattern` returns
+`{ root, numCaptures, groupNames }` (`regex/parse.ts:829`) where
+`groupNames: Map<string, number>` maps each name to its 1-based capture index.
+This map is available wherever `compilePattern` is called
+(`regexp-standalone.ts:418`) — it just isn't threaded into the result-shape or
+substitution emitters.
+
+## Implementation Plan
+
+### Approach — compile the groups object statically from `groupNames`
+
+The named-group set is **statically known** at compile time (the pattern is a
+literal / backend-created RegExp). So the `groups` object can be a **fixed-shape
+struct** whose fields are the named-group capture slots, built per-exec from the
+same `caps` array `__regex_capture_array` already consumes. No dynamic key
+machinery is needed.
+
+**File: `src/codegen/native-regex.ts`**
+
+1. `ensureRegexMatchVecType` (line ~1690): add a 5th field
+   `groups (ref null any)` (mutable false) to the `$__regexp_match_vec` struct.
+   For a pattern with no named groups it stays `null` (spec: `groups` is
+   `undefined` when there are no named captures — represent as a null ref that the
+   standalone `undefined` reader already maps). Export a
+   `MATCH_VEC_FIELD_GROUPS = 4` constant next to `MATCH_VEC_FIELD_INDEX/INPUT`.
+2. `__regex_capture_array` builds the `[0]+captures` vec from `caps`. Add an
+   **optional groups-builder parameter**: the call site that knows `groupNames`
+   passes the name→index list. For each `(name, idx)` the helper reads
+   `result[idx]` (already a native-string-or-null) and stores it into a
+   groups object field. Two viable representations — **prefer (b)**:
+   - (a) a per-pattern generated struct `$__regex_groups_<hash>` with one field
+     per name; the property reader (`m.groups.yr`) does a `struct.get`.
+   - (b) **reuse the existing open `$Object` / native-object literal path** the
+     standalone backend already builds for object literals — emit a small object
+     with the named string fields, so `m.groups.yr` flows through the existing
+     standalone object property read. This avoids inventing a new dispatch and is
+     the lower-risk lowering. Follow the object-literal construction in
+     `object-ops.ts` / the standalone object literal path.
+3. `__regex_get_substitution` (~line 3000-3060): thread the `groupNames` map in,
+   and handle `$<name>` — look up `name → idx`, emit the same capture-slot read
+   used for `$n` (read `result[idx]`, empty string if unmatched/out-of-range).
+   Unknown `$<bad>` stays literal per Annex B when no named groups exist; throws/
+   is literal per spec otherwise (match the host `String.prototype.replace`
+   §22.1.3.x — confirm against the fetched spec text before coding).
+
+**File: `src/codegen/regexp-standalone.ts`**
+
+4. Match-result property reader (~line 2240): before the `input` fallthrough, add
+   a `propName === "groups"` case that reads `MATCH_VEC_FIELD_GROUPS` (returns the
+   object ref, or the standalone `undefined` for a null/no-named-groups pattern).
+5. Thread `groupNames` from `compilePattern` (line 418) into the capture-array /
+   match-vec construction calls (the exec, match, matchAll, and @@match cores all
+   route through `__regex_capture_array`). Since `groupNames` is per-pattern and
+   the pattern is static at these sites, pass it as a compile-time argument
+   (NOT a runtime value).
+
+### Edge cases
+- Pattern with **no** named groups → `m.groups` is `undefined` (null ref); existing
+  numbered-capture behaviour unchanged.
+- **Unmatched** named group → its field is `undefined` (null native-string), matching
+  the `caps` slot being `-1/-1`.
+- **Duplicate named groups** (ES2025 `(?<n>a)|(?<n>b)`, `named-groups/duplicate-*`):
+  the matched alternative's value wins; the parser's `groupNames` must map the name
+  to whichever group participated. If duplicate-name support is not yet in the
+  parser, **narrow-refuse duplicate-name patterns** (don't silently mis-populate) and
+  leave them for a follow-up — note it in the issue.
+- `matchAll` / `@@match` results: they reuse `__regex_capture_array`, so `.groups`
+  on each iterated match comes for free once (2) lands.
+
+### Representative failing test262 paths
+- `test/built-ins/RegExp/named-groups/groups-object.js`
+- `test/built-ins/RegExp/named-groups/unicode-property-names.js`
+- `test/built-ins/RegExp/named-groups/string-replace-get.js` (`$<name>`)
+- `test/built-ins/RegExp/named-groups/string-replace-unclosed.js`
+- `test/built-ins/RegExp/prototype/Symbol.replace/named-groups.js`
+- `test/built-ins/RegExp/named-groups/groups-properties.js`
+
+### Estimated rows recovered
+~40-50 (named-groups dir 28 + the named-group cases inside Symbol.replace /
+String.replace / exec buckets). Duplicate-named-groups (ES2025) may need the
+follow-up refusal carve-out.
+
+### Test gate (standalone, empty importObject, no env/`__extern_*` leak)
+- `/(?<yr>\d{4})/.exec("2026").groups.yr === "2026"`
+- `"2026-06".replace(/(?<y>\d{4})-(?<m>\d{2})/, "$<m>/$<y>") === "06/2026"`
+- pattern with no named groups: `m.groups === undefined`
+- unmatched named group via alternation → field `undefined`

--- a/plan/issues/2589-standalone-regexp-d-flag-match-indices.md
+++ b/plan/issues/2589-standalone-regexp-d-flag-match-indices.md
@@ -1,0 +1,119 @@
+---
+id: 2589
+title: "Standalone RegExp `d` flag — match `.indices` array (RegExpBuiltinExec step 28-29)"
+status: ready
+sprint: 65
+priority: medium
+feasibility: medium
+parent: 2161
+area: regexp
+goal: standalone-mode
+language_feature: regexp
+task_type: conformance
+created: 2026-06-22
+---
+
+# Standalone RegExp `d` flag — match `.indices` array
+
+Slice of umbrella #2161. **Substrate-independent** (regex engine + match-result
+struct shape).
+
+## Problem
+
+The `d` (hasIndices) flag (§22.2.7.2 RegExpBuiltinExec steps 28-29 / MakeMatchIndicesIndexPairArray)
+makes `exec`/`match` return a match object carrying an extra **`indices`** array:
+`indices[0]` is `[startOfMatch, endOfMatch]`, `indices[n]` is `[start, end]` for
+capture group `n` (or `undefined` when unmatched), and `indices.groups` mirrors the
+named-group start/end pairs.
+
+In `--target standalone` this is entirely missing:
+
+| form | standalone result | spec |
+|---|---|---|
+| `/a/d.flags`, `re.hasIndices` | `"d"`, `true` ✓ (flag bit already works) | — |
+| `/(a)(b)/d.exec("xab").indices` | reads `.input` (wrong) **and leaks `env::__extern_get`** | `[[1,3],[1,2],[2,3]]` |
+
+Verified on current main: `/(a)/d.exec("xa").indices[0][0]` makes the binary leak
+`env::__extern_get` (an unsatisfiable host import in standalone) — the `.indices`
+read falls through to the generic externref-object index path because the match-vec
+struct has no `indices` field.
+
+## Root cause
+
+Same shape gap as #2588 (named-groups), different field:
+
+1. `ensureRegexMatchVecType` (`native-regex.ts:1690`) has no `indices` field — only
+   `index` (field 2) and `input` (field 3).
+2. The match-result property reader (`regexp-standalone.ts` ~line 2240) maps every
+   non-`index` property to `input`; `m.indices` has no handler, so a downstream
+   `m.indices[0][0]` index-access routes through the dynamic externref reader
+   (`__extern_get`) instead of a native struct read.
+3. The `caps` i32 array that `__regex_capture_array` already consumes **already holds
+   every start/end pair** (`caps[2*i]`, `caps[2*i+1]`) — the raw data for `.indices`
+   is present; it's just never materialised into a result array.
+
+## Implementation Plan
+
+### Approach — materialise `indices` from the existing `caps` pairs, gated on the `d` flag
+
+The `caps` i32 array is the exact source data. `.indices` is a vec-of-(2-element
+number-pairs), where each pair is itself a 2-element array `[start, end]` or
+`undefined` for an unmatched slot.
+
+**File: `src/codegen/native-regex.ts`**
+
+1. `ensureRegexMatchVecType` (line ~1690): add a 6th field
+   `indices (ref null any)` (mutable false), `null` when the `d` flag is absent.
+   Export `MATCH_VEC_FIELD_INDICES`. (Coordinate field ordering with #2588 if both
+   land together — pick a stable order: `index, input, groups, indices`.)
+2. New helper `ensureRegexIndicesArray(ctx)` — analogous to `__regex_capture_array`
+   but builds the **pairs array**: for each group slot `i` in `[0, nGroups)`, read
+   `caps[2*i]` / `caps[2*i+1]`; if both `>= 0` push a 2-element number vec
+   `[start, end]`, else push the `undefined` (null) sentinel. Build it from the
+   same `nGroups`/`caps` the capture-array helper already has. Returns a vec-of-vecs
+   (`__vec_ref_<numberVec>` or the open `$Vec`/`$Object` array path — reuse whatever
+   native array representation `String.prototype.split`/`match` already returns so
+   the downstream `m.indices[0][0]` index reads stay native, NO `__extern_get`).
+3. Only emit the indices array when the **compile-time-known flag bits include `d`**
+   (the flags are static at every backend exec/match site). When `d` is absent the
+   field stays `null`.
+
+**File: `src/codegen/regexp-standalone.ts`**
+
+4. Match-result property reader (~line 2240): add a `propName === "indices"` case
+   that reads `MATCH_VEC_FIELD_INDICES` and returns the native array ref type (so
+   `m.indices[i]` and `m.indices[i][j]` are native index reads, not `__extern_get`).
+   When the receiver's flags lack `d`, the field is `null` → standalone `undefined`.
+5. At the exec/match/matchAll cores, when the static flags include `d`, also call
+   `ensureRegexIndicesArray` and store the result into the new field; otherwise
+   store `null`.
+
+### Edge cases
+- `d` flag absent → `.indices` is `undefined` (null field); zero overhead, existing
+  paths unchanged.
+- Unmatched capture group → `indices[n]` is `undefined` (null), NOT `[undefined,undefined]`.
+- Named groups + `d`: `indices.groups` (§ MakeMatchIndicesIndexPairArray) is a
+  follow-on that depends on #2588's groups-object machinery — if #2588 hasn't landed,
+  **narrow-refuse `indices.groups`** (return `undefined` is acceptable as a first
+  slice; note it) rather than mis-populate.
+- Unicode (`u`/`v`) indices are code-point offsets — reuse the same offset arithmetic
+  the engine already uses for `.index`; do NOT introduce a second offset convention.
+
+### Representative failing test262 paths
+- `test/built-ins/RegExp/match-indices/indices-array.js`
+- `test/built-ins/RegExp/match-indices/indices-array-element.js`
+- `test/built-ins/RegExp/match-indices/indices-array-matched.js`
+- `test/built-ins/RegExp/match-indices/indices-array-unmatched.js`
+- `test/built-ins/RegExp/match-indices/indices-array-properties.js`
+- `test/built-ins/RegExp/prototype/hasIndices/this-val-regexp.js`
+
+### Estimated rows recovered
+~15-22 (match-indices dir 9 + the `hasIndices`/`d`-flag cases in
+`RegExp/prototype/*` and `String/prototype/*` that read `.indices`). The
+`indices.groups` cases may defer to a #2588 follow-up.
+
+### Test gate (standalone, empty importObject, no env/`__extern_*` leak)
+- `/(a)(b)/d.exec("xab").indices[0][0] === 1` and `[0][1] === 3`
+- `indices[1]` === `[1,2]`, `indices[2]` === `[2,3]`
+- unmatched group → `indices[n] === undefined`
+- pattern without `d` → `m.indices === undefined`

--- a/plan/issues/2590-standalone-regexp-escape-static-method.md
+++ b/plan/issues/2590-standalone-regexp-escape-static-method.md
@@ -1,0 +1,125 @@
+---
+id: 2590
+title: "Standalone `RegExp.escape(str)` static method (ES2025 §22.2.5.x)"
+status: ready
+sprint: 65
+priority: medium
+feasibility: medium
+parent: 2161
+area: regexp
+goal: standalone-mode
+language_feature: regexp
+task_type: conformance
+created: 2026-06-22
+---
+
+# Standalone `RegExp.escape(str)` static method (ES2025)
+
+Slice of umbrella #2161. **Substrate-independent** — pure string transform, no
+regex engine and no value-rep involvement.
+
+## Problem
+
+`RegExp.escape` is the new ES2025 static method (Stage 4) that returns a string
+with all regex-syntax-significant characters escaped so it can be safely embedded
+in a pattern. It is **entirely unimplemented** in this compiler — in
+`--target standalone` it leaks `env::__get_builtin` (the dynamic-builtin host
+import) and the binary fails to instantiate.
+
+Verified on current main: `RegExp.escape("a.b")` compiles but leaks
+`env::__get_builtin`, so no standalone binary runs. The whole `RegExp/escape/`
+test262 dir (14 in the standalone gap, all `compile_error`) plus the AnnexB
+`RegExp-*-escape` cases fail.
+
+## Spec (ES2025 §22.2.5 "RegExp.escape ( S )" / EncodeForRegExpEscape)
+
+`RegExp.escape(S)`:
+1. If `S` is not a String → **TypeError**.
+2. Let `escaped` be the empty String, `cpList` the code points of `S`.
+3. For the **first** code point: if it is an ASCII **decimal digit or ASCII letter**
+   (`[0-9A-Za-z]`), escape it as `\xHH` (so the result never starts with a char that
+   could combine into a quantifier/identifier). Otherwise process normally.
+4. For every code point `c`:
+   - If `c` is one of the **syntax characters** `^ $ \ . * + ? ( ) [ ] { } |` or
+     the **solidus** `/` → prepend `\` (i.e. `\c`).
+   - Else if `c` is a **white space / control / line terminator** in the
+     "other punctuators to escape" set (`\t \n \v \f \r`, and the
+     `ControlEscape`/whitespace set per the spec table) → escape as the canonical
+     `\t`/`\n`/`\v`/`\f`/`\r`, or `\xHH` / `\uHHHH` / `\u{…}` for the rest.
+   - Else → the code point unescaped.
+
+**Fetch the exact spec text** (tc39.es/ecma262 RegExp.escape + EncodeForRegExpEscape)
+and the test262 `escaped-*` files before coding — the per-character escape table
+(which chars get `\xHH` vs `\uHHHH` vs a named escape) is precise and the tests
+check it byte-for-byte. Implement from the fetched table, NOT from memory.
+
+## Implementation Plan
+
+### Approach — a native string-transform helper, dispatched as a static method
+
+This is a deterministic char-by-char rewrite over a native string; no regex engine.
+
+**File: `src/codegen/native-regex.ts`** (or a small new `regexp-escape.ts` —
+keep it near the other native-string regex helpers)
+
+1. New native helper `ensureRegexEscape(ctx)` → emits
+   `__regex_escape(s: ref $AnyString) -> ref $AnyString`. Loop over the input
+   string's code units / code points (reuse the same iteration the engine's
+   `__str_*` helpers use — `charCodeAt`/code-point decode, see the existing
+   `__regex_*` helpers for the surrogate-pair handling), building the output with
+   `__str_concat` over per-character pieces (mirror `__regex_get_substitution`'s
+   O(1)-piece concat construction, `native-regex.ts:2724`). Use `__str_from_char` /
+   the existing single-char native-string constructors for the escape sequences.
+   - First-char `[0-9A-Za-z]` → `\xHH`.
+   - Syntax chars + `/` → `\` + char.
+   - Control/whitespace set → canonical named escape or `\xHH`/`\uHHHH`/`\u{…}`.
+   - Everything else → the char unescaped.
+   Precompute the escape mapping at **compile time** in TS (a lookup the emitted
+   loop branches on) so the Wasm stays a tight switch.
+
+**File: `src/codegen/expressions/calls.ts`**
+
+2. Add a `RegExp.escape(s)` dispatch next to the existing static-method handlers
+   (`Number.isNaN` ~line 4287, `Object.is` ~line 5931, `Array.isArray` ~line 4400).
+   Gate on `ctx.standalone` + the callee being the `RegExp` builtin ctor identifier
+   and `name === "escape"`. Compile arg0 to a native string and emit the
+   `__regex_escape` call; return `nativeStringType(ctx)`. **Before** the
+   `__get_builtin` refusal/fallthrough so it never leaks the host import.
+   - Host mode is untouched (it can keep the `__get_builtin`/host path or also
+     route to the native helper — prefer routing both modes to the native helper
+     so behaviour is identical; confirm the host path doesn't already exist).
+
+### Edge cases
+- Non-string argument → TypeError (per spec step 1). In standalone, follow the
+  same throw lowering the other RegExp methods use for a type error; a TS-typed
+  `string` param makes this a compile-time guarantee for typed call sites — only
+  `any`-typed args need the runtime throw (those may narrow-refuse for the slice).
+- **Empty string** → empty string.
+- **First-character** special-casing (`\xHH` for a leading ASCII alnum) is easy to
+  miss — the spec escapes the leading alnum even though mid-string alnums are left
+  bare. The `escaped-*-simple.js` tests check exactly this.
+- **Astral / surrogate pairs** (`escaped-surrogates.js`,
+  `escaped-utf16encodecodepoint.js`) — escape per code point, emitting `\u{…}` /
+  surrogate `\uHHHH\uHHHH` per the spec's UTF-16 encoding rule. Reuse the engine's
+  existing surrogate-decode; do NOT invent a second decoder.
+
+### Representative failing test262 paths
+- `test/built-ins/RegExp/escape/escaped-syntax-characters-simple.js`
+- `test/built-ins/RegExp/escape/escaped-syntax-characters-mixed.js`
+- `test/built-ins/RegExp/escape/escaped-control-characters.js`
+- `test/built-ins/RegExp/escape/escaped-solidus-character-simple.js`
+- `test/built-ins/RegExp/escape/escaped-surrogates.js`
+- `test/built-ins/RegExp/escape/escaped-utf16encodecodepoint.js`
+- `test/built-ins/RegExp/escape/escaped-lineterminator.js`
+
+### Estimated rows recovered
+~20-29 (escape dir 14 in the standalone gap + AnnexB `RegExp-*-escape` cases +
+the `RegExp/escape/cross-realm`/`escaped-*` variants that currently CE on
+`__get_builtin`).
+
+### Test gate (standalone, empty importObject, no env/`__get_builtin` leak)
+- `RegExp.escape("a.b") === "\\x61\\.b"` (leading alnum → `\xHH`, `.` → `\.`)
+- `RegExp.escape("(x)") === "\\(x\\)"`
+- `RegExp.escape("\t") === "\\t"`
+- `RegExp.escape("") === ""`
+- host-JS parity check across the test262 `escaped-*` inputs

--- a/plan/issues/2591-standalone-regexp-v-flag-q-string-disjunction.md
+++ b/plan/issues/2591-standalone-regexp-v-flag-q-string-disjunction.md
@@ -1,0 +1,144 @@
+---
+id: 2591
+title: "Standalone RegExp `v`-flag `\\q{…}` string disjunction — implement (or complete the refusal)"
+status: ready
+sprint: 65
+priority: medium
+feasibility: medium
+parent: 2161
+area: regexp
+goal: standalone-mode
+language_feature: regexp
+task_type: conformance
+created: 2026-06-22
+---
+
+# Standalone RegExp `v`-flag `\q{…}` string disjunction
+
+Slice of umbrella #2161. **Substrate-independent** — pure regex-engine
+parse/compile work.
+
+## Problem
+
+The `unicodeSets` (`v`-flag) test262 dir is the largest single compile-error
+bucket in the standalone RegExp gap (~39 entries). After a re-probe on current
+main, the set-operation features actually **work correctly**:
+
+| v-flag form | standalone result |
+|---|---|
+| `/[[a-z]&&[aeiou]]/v.test("e")` (intersection) | ✓ correct |
+| `/[[a-z]--[aeiou]]/v.test("z")` (subtraction) | ✓ correct |
+| `/\p{Basic_Emoji}/v` (property of strings, non-string member) | ✓ correct |
+| `/[\q{abc\|xyz}]/v.test("xyz")` (**string disjunction**) | **TRAPS at runtime: "illegal cast"** |
+
+So the residual is concentrated in **one feature: `\q{…}` string disjunction**
+(v-mode, §22.2.1 ClassStringDisjunction) — a class element that matches a
+**multi-code-point string** rather than a single code point, e.g. `[\q{abc|d}]`
+matches the 3-char sequence `"abc"` or the single char `"d"`.
+
+## Root cause
+
+`enumerateClassRanges` (`regex/unicode.ts:91-93`) **does** have a guard:
+
+```ts
+if (source.includes("\\q{")) {
+  throw new RegexUnsupportedError("\\q{…} string disjunction — matches strings, not code points");
+}
+```
+
+But the guard is **incomplete / bypassed for some forms**: the probe shows
+`/[\q{abc|xyz}]/v` **compiles** and then traps at runtime with "illegal cast",
+meaning a malformed class node reaches the bytecode VM instead of the refusal
+firing. The v-mode nested-class extraction (`extractClassSource`,
+`parse.ts:230`, which nests on `[`) and the `\q{`-containing operand do not
+always route through the single `enumerateClassRanges` guard before being lowered
+by `cpRangesToNode` — so the engine emits a CLASS node for an element that should
+match a multi-unit string, and the result is a malformed/illegal-cast binary at
+runtime.
+
+This is the worst-of-both-worlds state: neither a clean refusal (a
+`RegexUnsupportedError` → host fallback / honest compile_error) **nor** a correct
+implementation. It must become one or the other.
+
+## Implementation Plan
+
+Two honest options. **Prefer (A) — implement it** (recovers the rows); fall back
+to (B) only if the multi-char-in-class lowering proves too large for the slice.
+
+### Option A — implement `\q{…}` by desugaring to alternation (preferred)
+
+`\q{s1|s2|…}` inside a v-mode class is, semantically, an **alternation of the
+literal strings** `s1|s2|…` (each `si` a possibly-multi-code-point literal),
+unioned with any other class elements. The engine **already supports alternation
+of literal strings outside classes** (the normal `(?:abc|d)` path through
+`parseAlternation`). So the lowering is: parse the `\q{…}` body into its `|`-split
+literal strings, build a `ReNode` alternation of literal-sequence nodes, and union
+it with the rest of the class.
+
+**File: `src/codegen/regex/parse.ts`**
+- In the class-source handling (around `uEnum` / `extractClassSource`,
+  lines ~200-250), detect a `\q{…}` element BEFORE handing the source to
+  `enumerateClassRanges`. Split the class into:
+  - the **single-code-point** part (ranges/escapes/props) → existing
+    `enumerateClassRanges` → `cpRangesToNode` path, and
+  - the **`\q{…}` string-disjunction** part → a new desugaring.
+- The combined class node becomes an **alternation**: `(?: <q-strings> | <cp-class> )`
+  consuming a variable number of units. Longest-match / leftmost-alternative
+  ordering must follow the spec (ClassStringDisjunction tries each operand;
+  the overall class is an alternation — order the multi-char strings to match
+  spec semantics; verify against the test262 expectations, NOT memory).
+
+**File: `src/codegen/regex/unicode.ts`**
+- Add an exported helper `parseStringDisjunction(qBody: string): string[]` that
+  splits `\q{a|bc|}` on top-level `|` (respecting `\|` escapes) into the literal
+  string operands (the empty operand matches the empty string).
+- The `enumerateClassRanges` `\q{` guard (line 91) is then only hit for the
+  residual code-point part (which no longer contains `\q{`); keep it as the
+  catch-all for any `\q{` that slips through, so a parse miss is a loud refusal,
+  never a silent illegal-cast.
+
+**File: `src/codegen/regex/compile.ts`**
+- The desugared alternation of literal strings compiles through the existing
+  alternation + literal-sequence bytecode (no new VM op needed — a literal
+  multi-char string is a sequence of CHAR ops, already supported). Confirm the
+  empty-string operand (`\q{|a}`) compiles to a zero-width arm.
+
+### Option B — complete the refusal (fallback if A is too big)
+
+If the in-class multi-char alternation lowering is out of slice scope:
+- Make the `\q{}` refusal **total**: route EVERY `\q{`-containing class through a
+  single guard so it always throws `RegexUnsupportedError` (→ honest
+  compile_error / host fallback in JS-host mode), and **fix the bypass** so no
+  malformed node ever reaches the VM (no more runtime "illegal cast").
+- This recovers 0 rows but removes the silent-wrong/trap state. Only do (B) if (A)
+  is infeasible in the slice; note the residual.
+
+### Edge cases
+- `\q{}` (empty body) and `\q{|a}` (empty operand) → match the empty string.
+- `\q{a|bc}` mixed with ranges in the same class: `[\q{ab}c-e]` → alternation of
+  `"ab"` and the class `[c-e]`.
+- Escaped `\|` and `\}` inside the body must NOT split / close the disjunction.
+- Case-insensitive (`vi`) string disjunction — fold each operand; reuse the
+  engine's existing `i`-mode folding for the literal chars.
+- Nested set ops containing `\q{}` (`[[\q{ab}]&&[…]]`) — string operands in an
+  **intersection/subtraction** are an ES edge (a string can only survive `&&`
+  if the other operand also contains it). If this proves intricate,
+  **narrow-refuse `\q{}` inside `&&`/`--`** (loud, not silent) and implement only
+  top-level/union `\q{}` for the slice; note the carve-out.
+
+### Representative failing test262 paths
+- `test/built-ins/RegExp/unicodeSets/generated/string-literal-*.js`
+- `test/built-ins/RegExp/unicodeSets/generated/character-class-escape-*.js`
+- (the `\q{…}` cases within the `unicodeSets/generated/` set)
+- `test/built-ins/RegExp/match-indices/...` (the `v`-flag indices variants overlap)
+
+### Estimated rows recovered
+~25-39 for Option A (the `\q{}` subset of `unicodeSets`). Option B recovers 0 but
+removes the trap/silent-wrong state — only if A is infeasible.
+
+### Test gate (standalone, empty importObject, no env/`__extern_*` leak)
+- `/[\q{abc|xyz}]/v.test("xyz") === true`
+- `/[\q{abc}]/v.test("a") === false`
+- `"zzabc".match(/[\q{abc}]/v)[0] === "abc"`
+- `/[\q{ab}c-e]/v.test("d") === true` (mixed with a range)
+- empty operand `/[\q{|a}]/v.test("") === true`


### PR DESCRIPTION
Slices the #2161 standalone RegExp conformance umbrella into 4 independently-implementable, substrate-independent dev issues so devs can land focused wins.

## Method
Re-bucketed the **full standalone-vs-host gap** (host baseline 2026-06-20, standalone 2026-06-19) — **747 RegExp tests pass host / fail standalone** (478 compile_error + 269 fail) — and re-probed every distinctive feature against **current upstream/main** (`--target standalone`, empty importObject) to find the concrete, bounded, engine-only wins.

## New sub-issues

| # | slice | root cause (verified on main) | est. rows | feasibility |
|---|---|---|---:|---|
| #2588 | named-groups result object `m.groups` + `$<name>` substitution | match-vec struct has no `groups` field; reader maps any non-`index` prop to `input`; `$<` is a literal stub | ~40-50 | medium |
| #2589 | `d`-flag match `.indices` array | no `indices` field; `m.indices` read leaks `env::__extern_get`; `caps` pairs already present | ~15-22 | medium |
| #2590 | `RegExp.escape(str)` (ES2025) | entirely unimplemented; leaks `env::__get_builtin`. Pure string transform | ~20-29 | medium |
| #2591 | `v`-flag `\q{…}` string disjunction | set ops already work; `\q{}` **traps at runtime** (refusal guard bypassed) | ~25-39 | medium |

**~100-140 standalone rows total.** Each has ONE concrete root cause, a test gate, and exact files/functions to touch in the Implementation Plan.

## Residual left under #2161 (documented, not sliced)
- RegExp.prototype reflection (~126) — gated on #2158's standalone prototype-object representation
- dynamic / `any`-typed receivers (~50+) — needs runtime-externref regex-receiver generalisation
- dynamic ctor patterns/flags (~64) — engine + dynamic-pattern lowering

Docs-only; no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA