### PR TITLE
docs(#2159): slice standalone TypedArray/DataView residual into 6 sub-issues

### DIFF
--- a/plan/issues/2159-standalone-typedarray-dataview-buffer-residual.md
+++ b/plan/issues/2159-standalone-typedarray-dataview-buffer-residual.md
@@ -279,3 +279,57 @@ read, `TypedArray.fill`, `DataView(buf, off, len).byteLength`, `subarray`,
   invalid packed valType).
 Both are in #2159's lane (owner ttraenkler/sdev-json3, live claim) — flagged here
 for that owner, not claimed by triage.
+
+---
+
+## Sprint-65 slicing (2026-06-22, architect) — verified residuals → 6 sub-issues
+
+Re-probed the standalone TypedArray/DataView/ArrayBuffer surface against current
+upstream/main (compile + instantiate + run, `.tmp/` battery). The original
+compile-error class (525+ `(none)`-leak CEs) is **largely fixed** by the prior
+slices — most byte/short element ops, DataView get/set Int/Float, `fill`, `set`,
+`subarray`, `copyWithin`, `slice`, iterators (`values`/`entries`/for-of/spread)
+all compile AND run correctly standalone now. The remaining residual is a mix of
+a few CEs, host-import leaks, and **runtime value-fidelity** gaps (which compile
+clean but fail test262 assertions). Sliced into 6 dev-tractable sub-issues:
+
+| # | title | rows | feasibility |
+|---|---|---|---|
+| **#2592** | TypedArray.of / TypedArray.from static factories (CE `__get_builtin`) | ~40-90 | medium |
+| **#2593** | Integer element-width wrapping (ToInt8/ToUint16/Uint8Clamp) + signed read | ~120-220 | hard |
+| **#2594** | Host-import leaks: `ArrayBuffer.isView`, BigInt64Array ctor, DataView BigInt accessors | ~30-70 | medium |
+| **#2595** | `BYTES_PER_ELEMENT` (static CE + instance returns 0) | ~15-40 | easy |
+| **#2596** | `.buffer` accessor — `illegal cast` at runtime | ~20-50 | hard |
+| **#2597** | `@@toStringTag` — `Object.prototype.toString.call(ta)` returns `[object Object]` | ~15-35 | easy |
+
+**Verified-good standalone (NOT sliced — already correct):** byte/short element
+read+write, `fill`, `set` (with offset), `copyWithin`, `slice`, `subarray`,
+DataView get/set Int8/Uint8/Int16/Uint16/Uint32/Int32/Float32/Float64 + LE,
+DataView OOB→RangeError, `DataView(buf,off,len).byteLength`, `byteLength`/
+`byteOffset` interception, iterators (`values`/`entries`/for-of/spread),
+`map`/`filter`/`reduce`/`forEach`/`find`/`some`/`every`, `indexOf` on byte views,
+`Uint8Array` element wrapping (correct via packed i8 storage).
+
+**Dispatch overlap notes:**
+- #2592 + #2593 both touch `calls.ts`/`new-super.ts` element-init paths —
+  sequence #2592 first (additive arm) then #2593 (changes storage selection),
+  or give both to one dev to avoid a `[CONFLICT]`.
+- #2595 + #2596 + #2597 are largely property-access.ts (#2595/#2596 in the
+  typed-array property block, disjoint `propName` arms; #2597 in `calls.ts`
+  `resolveObjectToStringTag`). Land-order independent.
+- #2593 is the biggest win and the hardest (element-representation level, but
+  bounded — confined to storage selection + packed read/write + a clamp helper;
+  does NOT touch the value-rep substrate #2580).
+
+**Residual NOT covered by these 6 slices (tracked, deferred):**
+- True write-through byte-aliasing between an f64 view and its `.buffer` (needs
+  the unified byte-storage rep; pairs with #2593's packed migration — #2596
+  delivers non-trapping `.buffer` + correct byteLength/identity first).
+- `subarray`/`slice` `.buffer` identity is partly gated on the #2357 subview rep.
+- `TypedArray.from(string | Set | Map | arbitrary iterator)` — only array-like /
+  vec sources are in #2592; iterator sources stay on the existing host path.
+- Atomics (132 in the original gap) — a separate concern (SharedArrayBuffer +
+  atomic ops), not a TypedArray-element slice; out of this umbrella's 6 slices.
+- Detached-buffer semantics beyond the DataView bounds case (#2199, done) —
+  `ArrayBuffer.transfer`/`resize` detach + post-detach TypedArray traps are a
+  separate ArrayBuffer-lifecycle concern, not sliced here.

--- a/plan/issues/2592-standalone-typedarray-static-factories.md
+++ b/plan/issues/2592-standalone-typedarray-static-factories.md
@@ -1,0 +1,143 @@
+---
+id: 2592
+title: "Standalone TypedArray.of / TypedArray.from static factories — CE __get_builtin"
+status: ready
+sprint: 65
+created: 2026-06-22
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: conformance
+area: standalone
+language_feature: typed-arrays
+goal: standalone-mode
+parent: 2159
+depends_on: []
+---
+
+# Standalone TypedArray.of / TypedArray.from static factories
+
+## Problem
+
+In `--target standalone`, the typed-array static factory methods are a hard
+compile error:
+
+```ts
+Uint8Array.of(1, 2, 3)        // CE: '__get_builtin' (dynamic-shape …) not supported in --target standalone
+Int32Array.of(10, 20)         // CE
+Uint8Array.from([4, 5, 6])    // CE
+Int32Array.from([1,2,3], x=>x*2)  // CE
+Float64Array.from([1.5, 2.5])     // CE
+```
+
+Verified on current upstream/main (`--target standalone`). The receiver
+identifier is `Int32Array` / `Uint8Array` / … so it never reaches the
+`Array.of` / `Array.from` native lowerings (those are keyed on the literal
+identifier `Array`). The call falls through to the generic member-call path,
+which lowers `TypedArray.of`/`from` as a dynamic-shape `__get_builtin` —
+explicitly rejected standalone (#1472 Phase B).
+
+This is the **`built-ins/TypedArrayConstructors` (321)** bucket's dominant
+standalone compile-error class from the #2159 evidence.
+
+## Root cause
+
+`src/codegen/expressions/calls.ts`:
+- `Array.of` already has a complete standalone-native lowering at **line ~4848**
+  (`#1633`): it builds an f64 (or typed) vec directly with `array.new_fixed` +
+  `struct.new`, no host import. `Array.from(arr)` (no mapFn) has a native
+  copy/iterate path at **line ~4558**.
+- Both are gated on `propAccess.expression.text === "Array"`. A
+  `TypedArray.of` / `TypedArray.from` call has
+  `propAccess.expression.text ∈ TYPED_ARRAY_NAMES`, so it misses both arms and
+  falls through to the `__get_builtin` rejection.
+
+## Implementation Plan
+
+### Approach
+Add a TypedArray static-factory arm in `compileCallExpression`
+(`src/codegen/expressions/calls.ts`) **before** the generic member-call /
+`__get_builtin` fallthrough, gated on `noJsHost(ctx)` and
+`ts.isIdentifier(propAccess.expression) && TYPED_ARRAY_NAMES.has(propAccess.expression.text)`.
+
+Reuse the storage-classification helper so the element vec matches the
+constructor's existing `new Int32Array([...])` representation:
+
+- **Element vec type**: call `typedArrayVecStorage(ctx, taName)` (index.ts:178)
+  to get `{ key, type }` — `i8_byte` for standalone `Uint8Array`, `f64` for the
+  rest (matches today's `new TA([...])`). Register via
+  `getOrRegisterVecType(ctx, key, type)` →
+  `getArrTypeIdxFromVec`. **Do not invent a new representation** — the result
+  must be assignment-compatible with a `Uint8Array` / `Int32Array` typed local.
+
+**`TypedArray.of(a, b, c)`** (mirror the `Array.of` native arm at ~4848):
+- No spread → fixed arity. For each arg, `compileExpression(arg, elemWasm)`,
+  coerce to the element type (`f64`, or `i32`→packed `i8` via array.set for
+  `Uint8Array`). Emit `array.new_fixed` of arity N, then `struct.new` the vec
+  `(len=N, data)`. Return the vec ref.
+- Empty-arg case: `array.new_default` length 0 + `struct.new`.
+
+**`TypedArray.from(iterable [, mapFn])`**:
+- **Phase 1 (this slice)**: handle the common test262 shapes —
+  `TypedArray.from(<array-literal | typed/number[] vec>)` and the same with a
+  static arrow `mapFn`. Compile the source to its native vec, read `__vec_len`,
+  loop `i = 0..len`, `__vec_get` each element, apply the mapFn closure inline
+  when present (reuse the inline-closure call pattern already used by
+  `Array.from(arr, mapFn)` / `TypedArray.prototype.map` in array-methods.ts),
+  coerce to the element type, `array.set` into a fresh `array.new_default`-sized
+  destination, then `struct.new`.
+- Length comes from the source vec's field-0 (element count). For an
+  array-literal source, that's statically known.
+- **Out of scope (note, don't implement)**: `from(string)`, `from(Set/Map)`,
+  `from` over an arbitrary `Symbol.iterator` object — those fall through to the
+  existing host/iterator path (already non-standalone-native; tracked
+  separately). Only array-like / vec sources are in this slice.
+
+### Wasm IR sketch (`TypedArray.of`)
+```wasm
+;; Int32Array.of(10, 20)  — elemWasm = f64
+f64.const 10        ;; arg 0 (coerced to f64)
+f64.const 20        ;; arg 1
+array.new_fixed $arr_f64 2
+local.set $data
+i32.const 2         ;; length
+local.get $data
+struct.new $vec_f64
+```
+For `Uint8Array.of`, coerce each arg `f64→i32` (ToUint8 wrap belongs to #2593;
+this slice may leave the bare `i32`→`array.set` packing the low byte, matching
+today's `new Uint8Array([...])` element-write behaviour) and use the `i8_byte`
+vec.
+
+### Edge cases
+- Element type from contextual `Int32Array`/`Float64Array` static name — do NOT
+  re-derive from arg types; the constructor name fixes the element width.
+- `Uint8Array.of()` / `.from([])` → length-0 vec (must not trap).
+- Spread arg in `.of(...xs)` → fall through to the existing path (don't claim it
+  here); a standalone spread is a known gap, orthogonal.
+- A `mapFn` that is not a simple arrow (e.g. a captured closure) — if the
+  inline-closure pattern can't apply, roll back the speculative body
+  (snapshot/rollback pattern already in calls.ts) and fall through.
+
+### Files
+- `src/codegen/expressions/calls.ts` — new TA-static arm (~line 4841 region for
+  `.of`, ~4558 region for `.from`); reuse `typedArrayVecStorage`,
+  `getOrRegisterVecType`, `getArrTypeIdxFromVec`, the array-literal/vec
+  element-loop helpers.
+- No change to `index.ts` storage selection (reuse as-is).
+
+### Representative failing test262 paths
+- `test/built-ins/TypedArrayConstructors/from/*` (mapfn, iterable, length)
+- `test/built-ins/TypedArrayConstructors/of/*` (basic, length, this-is-not-ctor)
+- `test/built-ins/TypedArray/prototype/...` tests that pre-seed via `.of`/`.from`
+
+### Estimated rows
+~40-90 standalone passes (of/from direct tests + the many TypedArray prototype
+tests whose setup uses `TA.of`/`TA.from`).
+
+## Notes
+Substrate-independent (does NOT touch the value-rep substrate #2580). The
+`Array.of`/`Array.from` native arms are the proven template. The integer
+element-width wrapping for `Uint8Array.of(300)` → `44` etc. is **deferred to
+#2593** — this slice only needs the factories to compile + produce the right
+length/order, matching today's `new TA([...])` fidelity.

--- a/plan/issues/2593-standalone-typedarray-integer-element-width-wrapping.md
+++ b/plan/issues/2593-standalone-typedarray-integer-element-width-wrapping.md
@@ -1,0 +1,191 @@
+---
+id: 2593
+title: "Standalone TypedArray integer element-width wrapping (ToInt8/ToUint16/Uint8Clamped) + signed read"
+status: ready
+sprint: 65
+created: 2026-06-22
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: conformance
+area: standalone
+language_feature: typed-arrays
+goal: standalone-mode
+parent: 2159
+depends_on: []
+---
+
+# Standalone TypedArray integer element-width wrapping + signed read
+
+## Problem
+
+Integer typed-array element WRITES do not perform the spec
+`ToInt8`/`ToUint8`/`ToInt16`/`ToUint16`/`ToInt32`/`ToUint32`/`ToUint8Clamp`
+truncation, and the READ does not sign/zero-extend by the view's signedness.
+Verified at runtime (standalone AND host — this is a general representation gap):
+
+| repro | actual | spec |
+|---|---|---|
+| `Int8Array; a[0]=200; a[0]` | `200` | `-56` |
+| `Int16Array; a[0]=40000; a[0]` | `40000` | `-25536` |
+| `Uint16Array; a[0]=-1; a[0]` | `-1` | `65535` |
+| `Uint32Array; a[0]=-1; a[0]` | `-1` | `4294967295` |
+| `Uint8ClampedArray; a[0]=300; a[0]` | `300` | `255` |
+| `Uint8ClampedArray; a[0]=-5; a[0]` | `-5` | `0` |
+| `Uint8ClampedArray; a[0]=1.6; a[0]` | `1.6` | `2` (round-half-to-even) |
+| `Uint8Array; a[0]=300; a[0]` | `44` ✓ | `44` |
+| `Int32Array; a[0]=-1; a[0]` | `-1` ✓ | `-1` |
+
+Only `Uint8Array` is correct today — it is the ONLY view with packed (`i8`)
+storage standalone; every other integer view is f64-backed and stores the full
+double with no width truncation.
+
+This is the dominant **value-fidelity** bucket across `built-ins/TypedArray` and
+`built-ins/TypedArrayConstructors` — element-set/get conformance, `fill`, `set`,
+`of`/`from`, `copyWithin`, ctor-from-array all assert wrapped values.
+
+## Root cause
+
+`src/codegen/index.ts` `typedArrayVecStorage` (line 178) returns packed storage
+**only** for `Uint8Array`:
+
+```ts
+return (ctx.wasi || ctx.standalone) && name === "Uint8Array"
+  ? { key: "i8_byte", type: { kind: "i8" } }
+  : { key: "f64", type: { kind: "f64" } };
+```
+
+All other integer views fall through to `f64`. An f64 store keeps the full
+double; no read-side extend can recover the truncated value. Two coupled fixes
+are required (both element-representation level):
+
+1. **Per-view packed storage** — map the integer views to width-matched packed
+   element types so `array.set` truncates and `array.get_s/_u` sign/zero-extends:
+   `Int8Array`/`Uint8ClampedArray` → `i8`, `Int16Array`/`Uint16Array` → `i16`,
+   `Int32Array`/`Uint32Array` → `i32`. Float views stay `f64`.
+2. **Read signedness from the TS type** — `array.get_s` for `Int8Array`,
+   `array.get_u` for `Uint8Array`/`Uint16Array`/`Uint8ClampedArray`, etc. The
+   current packed read hard-codes `i8→get_u`, `i16→get_s` by *storage* kind,
+   which is wrong for a signed `Int8Array` and an unsigned `Uint16Array`.
+
+## Implementation Plan
+
+### Approach — scoped, NOT a full representation rewrite
+
+The triage warning (#2159) that this is "architect-scope" is about avoiding an
+unbounded marshalling rewrite. The bounded plan: **extend packed storage to all
+integer views, and confine the f64-vec assumptions to the export marshalling
+boundary** (which already classifies non-Uint8 typed arrays as "typed-array" /
+`number[]`-on-return — `classifyTypedArrayType`, index.ts:196). Internally,
+integer views become packed; the marshalling layer keeps treating them like
+`number[]` on the wasm/JS boundary (no new boundary work — those tests assert
+*internal* element values, read back through the same wasm module).
+
+### Changes
+
+**1. `src/codegen/index.ts` — `typedArrayVecStorage` (line 178)**
+Extend the standalone/WASI map (keep host mode on f64 UNLESS the same packed
+path is safe there — verify equivalence tests before widening to host; if risky,
+gate the new packing on `noJsHost(ctx)` and leave a follow-up note for host):
+```
+Int8Array, Uint8ClampedArray       → { key: "i8_byte",  type: { kind: "i8"  } }
+Uint8Array                          → { key: "i8_byte",  type: { kind: "i8"  } }  (unchanged)
+Int16Array, Uint16Array            → { key: "i16_byte", type: { kind: "i16" } }
+Int32Array, Uint32Array            → { key: "i32_byte", type: { kind: "i32" } }
+Float32Array                       → f64 (or i32-as-f32 bits — out of scope; keep f64)
+Float64Array                       → f64
+```
+Add a sibling helper `typedArrayPackedSignedness(name): "s" | "u"` →
+`Int*`/`Uint*`/`Uint8Clamped` ("u").
+
+**2. Element WRITE truncation — `src/codegen/expressions/assignment.ts`
+`compileElementAssignment` (~line 3064, the i8/i16 unpack block)**
+After computing the store value as `i32`, apply width truncation BEFORE
+`array.set`:
+- `i8`/`u8` element: value already wraps via packed `array.set` (storage is
+  i8). Confirm `array.set` into an `i8` element truncates to the low 8 bits —
+  it does. So `Int8Array`/`Int16Array`/`Int32Array` need NO extra masking; the
+  packed `array.set` truncates. **The truncation comes for free from packed
+  storage** for Int*/Uint* of 8/16/32.
+- **Uint8ClampedArray is special** (§ ToUint8Clamp): NOT modulo — it clamps to
+  [0,255] with round-half-to-even. Emit a clamp sequence on the f64 value
+  *before* converting to i32: `if NaN → 0; if <=0 → 0; if >=255 → 255; else
+  round-half-even`. Add a helper `emitToUint8Clamp(fctx)` (model on existing
+  `emitToInt32` in binary-ops.ts). Route Uint8ClampedArray writes through it
+  instead of the plain `i32` truncation.
+- Float64/Float32 unchanged.
+
+**3. Element READ signedness — `src/codegen/property-access.ts`
+`compileElementAccessBody` + `emitBoundsCheckedArrayGet`**
+Where the packed element is read, choose `array.get_s` vs `array.get_u` from
+`typedArrayPackedSignedness(receiverTypeName)` (recover the TA name from the
+receiver's resolved TS type), NOT from the storage kind. Today's hard-coded
+`i8→get_u` / `i16→get_s` must become name-driven. The receiver name is
+available the same way `byteLength` recovers it (property-access.ts ~2280-2330,
+`recvName`).
+
+**4. Coercion sites that already assume f64-vec storage**
+Audit these for the newly-packed views and switch their value temp to `i32`
+(the Slice-1/fill pattern — unpack i8/i16 to i32 in a value position):
+- `compileArrayFill` (array-methods.ts) — already handles i8/i16 unpack; extend
+  the gate to the new i16/i32 byte views.
+- `set`/`copyWithin`/`slice`/`subarray` element copy loops in array-methods.ts —
+  ensure they read/write through `array.get_*`/`array.set` (packed-safe), not an
+  f64 temp.
+- `new TA([...])` element-init loop (new-super.ts) — coerce each literal element
+  to `i32` and let packed `array.set` truncate.
+
+### Wasm IR (Uint8ClampedArray write — the one non-free case)
+```wasm
+;; value on stack as f64; clamp to [0,255], round-half-even, → i32
+;; (helper emitToUint8Clamp)
+```
+
+### Edge cases
+- `Uint8ClampedArray` rounding is round-half-to-**even** (1.5→2, 2.5→2, 0.5→0).
+- `Int32Array`/`Uint32Array`: `array.set` into an `i32` element truncates the
+  i32 store value — but the WRITE value must first be `ToInt32`/`ToUint32` of the
+  f64 (use `emitToInt32`; for Uint32 the same bit pattern, read back via
+  `get_u`).
+- NaN → 0 for all integer views (ToIntegerOrInfinity then modulo; for clamped,
+  NaN→0 explicitly).
+- `.length` / `byteLength` already name-keyed (byteLength map at
+  property-access.ts:2319) — verify the i16/i32 byte sizes line up (they do).
+- Marshalling boundary (`wrapExports`, #1700): integer views still surface as
+  `number[]`-like on the JS boundary; internal element tests don't cross it. Run
+  `tests/issue-2159*.test.ts` + the standalone TypedArray equivalence suite to
+  confirm no boundary regression.
+
+### Files
+- `src/codegen/index.ts` (`typedArrayVecStorage`, new `typedArrayPackedSignedness`)
+- `src/codegen/expressions/assignment.ts` (`compileElementAssignment`, clamp)
+- `src/codegen/property-access.ts` (read signedness; byteLength byte-size check)
+- `src/codegen/binary-ops.ts` (`emitToUint8Clamp` helper)
+- `src/codegen/array-methods.ts` (fill/set/copyWithin/slice value temps)
+- `src/codegen/expressions/new-super.ts` (ctor element-init coercion)
+
+### Representative failing test262 paths
+- `test/built-ins/TypedArray/prototype/fill/fill-values-conversion-operations*`
+- `test/built-ins/TypedArrayConstructors/internals/Set/*` (ToInteger conversion)
+- `test/built-ins/TypedArrayConstructors/ctors/typedarray-arg/*`
+- `test/built-ins/TypedArray/prototype/set/*` (value coercion)
+- `test/built-ins/TypedArrayConstructors/ctors/object-arg/*`
+
+### Estimated rows
+~120-220 standalone passes (every integer-view element-fidelity assertion,
+fill/set value-conversion tests, ctor-from-array coercion tests). Largest single
+bucket in the residual.
+
+## Notes
+- Element-representation level but **bounded**: confined to storage selection +
+  packed read/write + a clamp helper; does NOT touch the value-rep substrate
+  #2580 (no dynamic `$Object` reads). The marshalling boundary already treats
+  non-Uint8 typed arrays as `number[]`, so no new boundary work.
+- **Type-index discipline**: `getOrRegisterVecType` for the new `i16_byte` /
+  `i32_byte` keys must register late+once (per `project_type_index_shift_and_deadelim`)
+  — do NOT push a struct type mid-class-collection.
+- Pairs naturally with #2592 (which produces these vecs) but is independent:
+  #2592 can land with today's f64/i8 fidelity, #2593 upgrades the wrapping.
+  **Dispatch note**: #2592 and #2593 both touch `calls.ts`/`new-super.ts`
+  element-init paths — sequence #2592 first (additive arm), then #2593 (changes
+  storage), or assign both to one dev to avoid a `[CONFLICT]`.

--- a/plan/issues/2594-standalone-typedarray-buffer-host-import-leaks.md
+++ b/plan/issues/2594-standalone-typedarray-buffer-host-import-leaks.md
@@ -1,0 +1,121 @@
+---
+id: 2594
+title: "Standalone TypedArray/ArrayBuffer host-import leaks — isView, BigInt64Array ctor, DataView BigInt accessors"
+status: ready
+sprint: 65
+created: 2026-06-22
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: conformance
+area: standalone
+language_feature: typed-arrays
+goal: standalone-mode
+parent: 2159
+depends_on: []
+---
+
+# Standalone TypedArray/ArrayBuffer host-import leaks
+
+## Problem
+
+Several TypedArray/ArrayBuffer surface ops **compile** in `--target standalone`
+but leak `env.*` host imports, so the resulting module fails to instantiate
+standalone (`WebAssembly.instantiate(): Import #0 "env": module is not an object
+or function`). Verified on upstream/main:
+
+| op | leaked env import |
+|---|---|
+| `ArrayBuffer.isView(x)` | `env.__arraybuffer_isView` |
+| `new BigInt64Array(n)` | `env.BigInt64Array_new` |
+| `new BigUint64Array(n)` | `env.BigUint64Array_new` |
+
+(`DataView.getBigInt64`/`setBigInt64` compile clean on the windowed path but
+should be checked for an env leak on the bare-vec path — see edge cases.)
+
+These break the **entire module** standalone, not just the one expression — any
+test that calls `ArrayBuffer.isView` or constructs a BigInt typed array fails to
+run at all. Part of the `built-ins/ArrayBuffer` (78) and BigInt typed-array
+buckets.
+
+## Root cause
+
+**`ArrayBuffer.isView`** — `src/codegen/expressions/calls.ts` line ~6360 always
+emits `ensureLateImport(ctx, "__arraybuffer_isView", …)` with no standalone
+fallback. But standalone has a native isView check already (used by `delete`,
+`Array.isArray`, etc.): an `any.convert_extern` + `ref.test` over the registered
+typed-array/dataview vec types (the same `vecTypeIdxs` ref.test fan-out used in
+`emitIsArrayTerminal`, property-access.ts ~470). For most test262 calls the
+argument's TS type is statically a TypedArray/DataView (→ const `true`) or a
+non-view (→ const `false`).
+
+**`BigInt64Array_new` / `BigUint64Array_new`** — the BigInt64/Uint64 ctor path
+(new-super.ts) routes to a host import instead of building a native i64-element
+vec. These views need an `i64`-element packed vec (`getOrRegisterVecType("i64", …)`),
+mirroring the integer-view ctor path.
+
+## Implementation Plan
+
+### A. `ArrayBuffer.isView` native standalone (`calls.ts` ~6360)
+Gate on `noJsHost(ctx)`:
+1. **Static-decide when possible**: inspect the argument's TS type via
+   `ctx.checker.getTypeAtLocation(arg)`. If it resolves to a TypedArray /
+   DataView name (`TYPED_ARRAY_NAMES.has(sym.name)` or `DataView`), drop the
+   compiled arg and emit `i32.const 1`. If it resolves to a non-object /
+   non-view primitive, emit `i32.const 0`. (ArrayBuffer itself is NOT a view →
+   `false`.)
+2. **Runtime fallback** (arg type is `any`/union): reuse the
+   `emitIsArrayTerminal`-style `ref.test` fan-out over the registered TA/DataView
+   vec type indices (`any.convert_extern` then `ref.test $vec_*` OR-chained,
+   plus a `ref.test $__dv_window`). Return `i32`. Do NOT call
+   `ensureLateImport(__arraybuffer_isView)` in the noJsHost branch.
+
+### B. `BigInt64Array` / `BigUint64Array` native ctor (`new-super.ts`)
+In the typed-array ctor lowering, add the two BigInt views to the native path:
+- Element storage `i64` (signed/unsigned distinguished on read like #2593).
+- `new BigInt64Array(n)` → `array.new_default` of `n` i64 elements + `struct.new`.
+- `new BigInt64Array([1n, 2n])` → element-init loop, each element an i64.
+- Element get/set go through `array.get`/`array.set` on the i64 vec; element
+  values are bigints (already i64 in the brand-gated bigint representation,
+  per `project_bigint_i64_brand_gate`). Read signedness: `BigInt64Array`→signed
+  i64 (no extend needed, i64 is the value type), `BigUint64Array`→unsigned
+  semantics affect `toString`/compare only.
+- Register the i64 vec type late+once (type-index discipline).
+- **If** the i64-bigint-brand ValType decision (#1349/#1644, architect-gated)
+  is NOT yet resolved enough to safely thread bigint element values, scope this
+  slice to **part A only** (isView) and split the BigInt64Array ctor into a
+  follow-up that depends on that brand decision. Note which applies in the PR.
+
+### Edge cases
+- `ArrayBuffer.isView(undefined)` / `(null)` → `false` (not a trap).
+- `ArrayBuffer.isView(new ArrayBuffer(8))` → `false` (buffer is not a view).
+- `ArrayBuffer.isView(new DataView(buf))` → `true` (include `$__dv_window` and
+  the bare-vec DataView shape in the runtime ref.test set).
+- DataView `getBigInt64`/`setBigInt64` — verify on BOTH the bare-vec and
+  `$__dv_window` recover paths (`recoverDvBacking`, dataview-native.ts) that no
+  env import leaks; if it does on the bare-vec path, route through the native
+  i64 little/big-endian byte reassembly already used for `getFloat64`.
+
+### Files
+- `src/codegen/expressions/calls.ts` (`ArrayBuffer.isView` arm ~6360)
+- `src/codegen/expressions/new-super.ts` (BigInt64Array / BigUint64Array ctor)
+- `src/codegen/property-access.ts` (reuse the `vecTypeIdxs` ref.test fan-out
+  helper for isView runtime fallback; BigInt view byteLength byte-size = 8)
+- `src/codegen/dataview-native.ts` (BigInt accessor leak check, if any)
+
+### Representative failing test262 paths
+- `test/built-ins/ArrayBuffer/isView/*`
+- `test/built-ins/TypedArrayConstructors/ctors/buffer-arg/*` (BigInt64Array)
+- `test/built-ins/TypedArray/prototype/...` BigInt64Array variants
+- `test/built-ins/DataView/prototype/getBigInt64/*`, `setBigInt64/*`
+
+### Estimated rows
+~30-70 standalone passes — isView is a small direct bucket but the env-leak
+**unblocks whole modules** that construct/check views, so the effective row gain
+is larger than the direct isView/BigInt test count.
+
+## Notes
+Substrate-independent for part A (isView). Part B (BigInt64Array) touches the
+bigint i64 brand (`project_bigint_i64_brand_gate`) — split out if the brand
+decision blocks it. The `emitIsArrayTerminal` ref.test fan-out
+(property-access.ts ~470) is the proven template for the native isView check.

--- a/plan/issues/2595-standalone-typedarray-bytes-per-element.md
+++ b/plan/issues/2595-standalone-typedarray-bytes-per-element.md
@@ -1,0 +1,100 @@
+---
+id: 2595
+title: "Standalone TypedArray BYTES_PER_ELEMENT — static CE + instance returns 0"
+status: ready
+sprint: 65
+created: 2026-06-22
+priority: medium
+feasibility: easy
+reasoning_effort: medium
+task_type: conformance
+area: standalone
+language_feature: typed-arrays
+goal: standalone-mode
+parent: 2159
+depends_on: []
+---
+
+# Standalone TypedArray BYTES_PER_ELEMENT
+
+## Problem
+
+Verified on upstream/main (`--target standalone`):
+
+```ts
+Int32Array.BYTES_PER_ELEMENT          // CE: BYTES_PER_ELEMENT built-in static property value read not supported (#1907/#1888 S6-b)
+new Float64Array(2).BYTES_PER_ELEMENT // compiles, but returns 0 at runtime (should be 8)
+```
+
+Both the **static** (`Int32Array.BYTES_PER_ELEMENT`) and **instance**
+(`view.BYTES_PER_ELEMENT`) reads are wrong standalone. The byte sizes are
+statically known per constructor name — this is a constant fold, no runtime
+support needed.
+
+## Root cause
+
+- **Static read** hits `reportUnsupportedStandaloneBuiltinValueRead`
+  (`src/codegen/property-access.ts` line ~495) — the generic standalone
+  builtin-static-value-read rejection. `BYTES_PER_ELEMENT` is never special-cased
+  before that fallthrough.
+- **Instance read** (`view.BYTES_PER_ELEMENT`) is not intercepted in the typed
+  array property block, so it falls through to a default property read on the vec
+  struct → `0`.
+
+The byte-size map **already exists** in property-access.ts as
+`TYPED_ARRAY_BYTES_PER_ELEMENT` (line ~2319, used by `byteLength`).
+
+## Implementation Plan
+
+### Approach — constant fold both reads
+Hoist `TYPED_ARRAY_BYTES_PER_ELEMENT` (or reference it) so both paths can use it.
+
+**1. Static read — `src/codegen/property-access.ts`**
+Before `reportUnsupportedStandaloneBuiltinValueRead` fires for
+`<TypedArrayName>.BYTES_PER_ELEMENT`, add a special case: if the builtin name is
+in `TYPED_ARRAY_BYTES_PER_ELEMENT` and `propName === "BYTES_PER_ELEMENT"`, emit
+the constant (`i32.const` / `f64.const` per `ctx.fast`) and return. Gate behind
+`noJsHost(ctx)` (host mode already works via the host import). This is the static
+property-value-read path — locate where builtin-static reads are dispatched
+(the same function that calls `reportUnsupportedStandaloneBuiltinValueRead`).
+
+**2. Instance read — same file, the typed-array property block (~line 2309,
+alongside `byteOffset`/`byteLength`)**
+Add a `propName === "BYTES_PER_ELEMENT"` arm in the `if (isBuffer || isTypedArr)`
+block: drop the compiled receiver, emit the per-name constant. (ArrayBuffer has
+no `BYTES_PER_ELEMENT`; restrict to `isTypedArr`.)
+
+### Wasm IR
+```wasm
+;; Int32Array.BYTES_PER_ELEMENT  →  (fast) i32.const 4   /  (else) f64.const 4
+;; new Float64Array(2).BYTES_PER_ELEMENT  →  drop receiver; f64.const 8
+```
+
+### Edge cases
+- Per-name values: Int8/Uint8/Uint8Clamped=1, Int16/Uint16=2,
+  Int32/Uint32/Float32=4, Float64=8, BigInt64/BigUint64=8 (add the two BigInt
+  names to the map if not present).
+- Instance form must still evaluate (and drop) the receiver if it has side
+  effects (`getView().BYTES_PER_ELEMENT`) — compile the receiver, then `drop`.
+- `ctx.fast` vs default: return `i32` in fast mode, `f64` otherwise (match the
+  `byteLength`/`byteOffset` arms' return-type convention).
+
+### Files
+- `src/codegen/property-access.ts` (both the static-builtin-read dispatch and
+  the typed-array instance property block ~2309)
+
+### Representative failing test262 paths
+- `test/built-ins/TypedArrayConstructors/BYTES_PER_ELEMENT/*`
+- `test/built-ins/TypedArray/prototype/BYTES_PER_ELEMENT/*`
+- Many ctor tests read `TA.BYTES_PER_ELEMENT` in setup (`length`/`byteLength`
+  derivations) — fixing it unblocks their assertions.
+
+### Estimated rows
+~15-40 standalone passes (direct BYTES_PER_ELEMENT tests + setup unblocks).
+
+## Notes
+Smallest/easiest slice — pure constant fold, byte-size map already present.
+Substrate-independent. Good first-claim or warm-up slice. **Dispatch note**:
+touches the same property-access.ts typed-array block as #2596 (.buffer); the
+two arms are disjoint (different `propName`), so they can land independently but
+a single dev taking both avoids a trivial merge.

--- a/plan/issues/2596-standalone-typedarray-buffer-accessor.md
+++ b/plan/issues/2596-standalone-typedarray-buffer-accessor.md
@@ -1,0 +1,138 @@
+---
+id: 2596
+title: "Standalone TypedArray/DataView .buffer accessor — illegal cast at runtime"
+status: ready
+sprint: 65
+created: 2026-06-22
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: conformance
+area: standalone
+language_feature: typed-arrays
+goal: standalone-mode
+parent: 2159
+depends_on: []
+---
+
+# Standalone TypedArray/DataView .buffer accessor
+
+## Problem
+
+`view.buffer` (and `dataView.buffer`) traps `illegal cast` at runtime in
+`--target standalone`:
+
+```ts
+new Int32Array(4).buffer.byteLength     // RT: illegal cast  (want 16)
+new DataView(new ArrayBuffer(16)).buffer.byteLength  // RT: illegal cast (want 16)
+```
+
+`.buffer` is read by a large swath of TypedArray/DataView tests for byteLength
+derivation and for `view.buffer === otherView.buffer` aliasing identity.
+
+## Root cause
+
+A TypedArray's backing is a **typed** vec — `f64` (most views) or `i8`
+(standalone `Uint8Array`) — NOT the `i32_byte` ArrayBuffer vec. The `.buffer`
+property is currently lowered (or falls through) to a path that `ref.cast`s the
+receiver to the `i32_byte` ArrayBuffer vec type, which fails on the f64/i8 vec
+→ `illegal cast`. There is **no real backing ArrayBuffer object** tracked for a
+view that was constructed as `new Int32Array(n)` (only `new TA(buffer)` starts
+from an actual buffer).
+
+This is the deferred "Slice 2b `.buffer` accessor" from #2159 — the TA backing
+is not an i32_byte buffer, so `.buffer` must synthesize/track one.
+
+## Implementation Plan
+
+### Scope decision — synthesize a byte-view, don't trap
+
+The two dominant test262 uses are (1) `view.buffer.byteLength` and (2) buffer
+**identity/aliasing** (`a.buffer === b.buffer` when `b = a.subarray(...)`, and
+`new TA(view.buffer)` round-trips). Full mutable byte-aliasing between an f64
+view and its `i32_byte` buffer is the hard part; this slice targets a correct,
+non-trapping `.buffer` for the common reads and defers true byte-level aliasing.
+
+### Approach
+
+**Option A (recommended, bounded) — compute `.buffer.byteLength` without
+materializing a buffer when the result is only consumed for byteLength.**
+This is what the byteLength interception already does for the view itself. Add a
+`.buffer` arm that, for `view.buffer.byteLength` chains, folds to
+`view.length * BYTES_PER_ELEMENT` (the byte count) — but this only covers the
+chained-byteLength case, not identity.
+
+**Option B (more complete) — a lazy `$__ta_buffer` wrapper.**
+Track an optional backing-buffer slot on views. Two sub-cases:
+- `new TA(buffer)` / `new DataView(buffer)`: the view already knows its source
+  `i32_byte` buffer — store a reference so `.buffer` returns the *same* object
+  (correct identity). For DataView this is the `$__dv_window.buf` field (already
+  exists) or the bare vec. **Return that directly** — no cast needed; this case
+  is already a real i32_byte buffer.
+- `new TA(n)` (no source buffer): lazily synthesize an `i32_byte` vec of
+  `n * BYTES_PER_ELEMENT` bytes on first `.buffer` access. For a read-only
+  byteLength/`isView`/identity-once use this is correct; true write-through
+  aliasing (mutating the buffer mutates the view) is OUT OF SCOPE — note it.
+
+**Recommendation**: implement **Option B for the `new TA(buffer)` / DataView
+case** (return the real backing buffer — correct identity, no synthesis, no
+trap) and **Option A for the `new TA(n)` case** (fold `.buffer.byteLength`;
+return a fresh i32_byte vec of the right byte length for a bare `.buffer` read so
+`.byteLength` works and it doesn't trap). Document the write-through-aliasing
+limitation. This kills the `illegal cast` and passes the byteLength + identity
+(for buffer-sourced views) tests.
+
+### Changes
+
+**1. `src/codegen/property-access.ts` — `.buffer` arm in the
+`if (isBuffer || isTypedArr || isDataView)` region (~line 2309)**
+- For a DataView receiver: return `$__dv_window.buf` (windowed) or the bare
+  `i32_byte` vec (unwindowed) — both are real ArrayBuffer vecs.
+- For a TypedArray receiver with a tracked source buffer: return the tracked
+  `i32_byte` buffer ref.
+- For a TypedArray receiver with no source buffer: synthesize an `i32_byte` vec
+  with field-0 = `view.length * BYTES_PER_ELEMENT` (compute from the vec's
+  field-0 × byte size; allocate a zero-filled data array of that byte length).
+  Return it as the ArrayBuffer vec ref (externref-coerced as views are).
+- **Never** `ref.cast` the f64/i8 view vec to `i32_byte` — that is the bug.
+
+**2. (if Option B buffer tracking) `src/codegen/expressions/new-super.ts`**
+Thread the source-buffer ref into a view slot when `new TA(buffer)` /
+`new DataView(buffer)` is built, so `.buffer` returns the same object.
+
+### Edge cases
+- `view.buffer.byteLength` chain — the synthesized/returned buffer's field-0 is
+  the byte count, so `.byteLength` reads correctly via the existing buffer
+  byteLength arm.
+- `new Int32Array(someBuffer).buffer === someBuffer` — must hold (identity) for
+  the buffer-sourced case (Option B).
+- `subarray` result `.buffer` identity (`s.buffer === a.buffer`) — depends on
+  the #2357 subview rep; if subview tracks the parent buffer, return it; else
+  note as a residual.
+- Empty view (`new Int32Array(0).buffer.byteLength` → 0) — must not trap.
+
+### Files
+- `src/codegen/property-access.ts` (`.buffer` arm, ~2309)
+- `src/codegen/expressions/new-super.ts` (optional buffer-source tracking)
+- `src/codegen/dataview-native.ts` (DataView `.buffer` recover, reuse
+  `recoverDvBacking`)
+
+### Representative failing test262 paths
+- `test/built-ins/TypedArray/prototype/buffer/*`
+- `test/built-ins/DataView/prototype/buffer/*`
+- `test/built-ins/TypedArrayConstructors/ctors/buffer-arg/*` (identity)
+
+### Estimated rows
+~20-50 standalone passes (direct `.buffer` tests + the many tests that read
+`.buffer.byteLength` in assertions). Identity-dependent tests partly gated on
+#2357 subview rep.
+
+## Notes
+Representation-adjacent (`.buffer` synthesis) but **non-trapping is the floor** —
+even Option A alone (fold byteLength, return a non-cast vec) removes the
+`illegal cast` that blocks every `.buffer`-touching test. Substrate-independent
+(no `$Object` dynamic reads). True write-through byte-aliasing between an f64
+view and its byte buffer is explicitly deferred (would require the unified
+byte-storage rep — pairs with #2593's packed migration). **Dispatch note**:
+shares the property-access.ts typed-array block with #2595 (disjoint `propName`
+arms).

--- a/plan/issues/2597-standalone-typedarray-tostringtag.md
+++ b/plan/issues/2597-standalone-typedarray-tostringtag.md
@@ -1,0 +1,99 @@
+---
+id: 2597
+title: "Standalone TypedArray/DataView/ArrayBuffer @@toStringTag — Object.prototype.toString returns [object Object]"
+status: ready
+sprint: 65
+created: 2026-06-22
+priority: medium
+feasibility: easy
+reasoning_effort: medium
+task_type: conformance
+area: standalone
+language_feature: typed-arrays
+goal: standalone-mode
+parent: 2159
+depends_on: []
+---
+
+# Standalone TypedArray/DataView/ArrayBuffer @@toStringTag
+
+## Problem
+
+`Object.prototype.toString.call(typedArray)` returns the wrong tag standalone:
+
+```ts
+Object.prototype.toString.call(new Int32Array(2))  // standalone → "[object Object]"  (want "[object Int32Array]")
+Object.prototype.toString.call(new DataView(buf))  // → "[object Object]"  (want "[object DataView]")
+Object.prototype.toString.call(new ArrayBuffer(8)) // → "[object Object]"  (want "[object ArrayBuffer]")
+```
+
+Per §23.2.3.38 (%TypedArray%.prototype[@@toStringTag]) the tag is the typed
+array's constructor name; §25.1.5.x / §25.3.4.x give `DataView` / `ArrayBuffer`.
+
+## Root cause
+
+`src/codegen/expressions/calls.ts` `resolveObjectToStringTag` (line 324)
+statically resolves the §20.1.3.6 builtin tag for Array / Date / RegExp / Error /
+Function / primitive wrappers, but has **no arm for TypedArray / DataView /
+ArrayBuffer / SharedArrayBuffer**. Those fall through to the final
+`deferOrStandalone("Object")` (line 433) → standalone emits the generic
+`"Object"` tag.
+
+## Implementation Plan
+
+### Approach — add a builtin-name tag arm
+
+In `resolveObjectToStringTag`, after the `Date`/`RegExp`/`Error`/`Arguments`
+arms (~line 412) and before the callable check, add:
+
+```ts
+// §23.2.3.38 — %TypedArray% @@toStringTag is the constructor name.
+// §25.x — DataView / ArrayBuffer / SharedArrayBuffer.
+if (symName && TYPED_ARRAY_NAMES.has(symName)) return symName;        // "Int32Array", ...
+if (symName === "DataView") return "DataView";
+if (symName === "ArrayBuffer") return "ArrayBuffer";
+if (symName === "SharedArrayBuffer") return "SharedArrayBuffer";
+```
+
+`symName` is already computed (line 395, `nn.getSymbol()?.name`). The caller
+formats `[object <tag>]` from the returned string, so returning the raw
+constructor name is exactly right.
+
+This is correct for **both host and standalone** — the host's
+`Object.prototype.toString` sees the opaque Wasm vec and ALSO mis-tags these as
+`[object Object]` (same opaque-receiver class as Array/Date/RegExp already
+handled here), so returning the static tag is the right fix in both modes, not
+just standalone. Do **not** wrap in `deferOrStandalone` — return the tag
+unconditionally (mirrors the `Array`/`Date`/`RegExp` arms).
+
+### Edge cases
+- `Object.prototype.toString.call(new Int32Array(2).subarray(0,1))` — a subview
+  result still types as `Int32Array`, so it tags correctly.
+- `X.prototype` of a typed array (`Int32Array.prototype`) is filtered earlier
+  (the `.prototype` arm at ~381 → `deferOrStandalone("Object")`) — a typed-array
+  *prototype* object is `[object Object]` per spec (no [[TypedArrayName]] slot),
+  so the existing `.prototype` filter correctly prevents tagging it as the view.
+  Verify the typed-array arm sits AFTER the `.prototype` filter (it does — the
+  filter is at line 381, the new arm at ~412).
+- A `Uint8Array | undefined` union — `getNonNullableType` (line 386) already
+  strips the undefined, so `symName` resolves to `Uint8Array`.
+
+### Files
+- `src/codegen/expressions/calls.ts` (`resolveObjectToStringTag`, ~line 412;
+  `TYPED_ARRAY_NAMES` is in scope in this file).
+
+### Representative failing test262 paths
+- `test/built-ins/TypedArray/prototype/Symbol.toStringTag/*`
+- `test/built-ins/DataView/prototype/Symbol.toStringTag/*`
+- `test/built-ins/ArrayBuffer/prototype/Symbol.toStringTag/*`
+- Plus any test using `assert.sameValue(Object.prototype.toString.call(ta), "[object Int32Array]")`.
+
+### Estimated rows
+~15-35 standalone passes (direct toStringTag tests; also benefits host mode for
+the opaque-receiver TypedArray/DataView/ArrayBuffer case).
+
+## Notes
+Smallest, lowest-risk slice — one static arm in an existing classifier, no new
+runtime, no representation work. Substrate-independent. Benefits host mode too
+(those receivers are opaque to the host `toString` and currently mis-tag).
+Independent of all other slices (different file region from #2595/#2596).


### PR DESCRIPTION
Slices the conformance umbrella **#2159** (standalone TypedArray/DataView/ArrayBuffer residual) into 6 dev-tractable sub-issues, each with a verified root cause and concrete implementation plan.

## Method
Re-probed the standalone surface against current upstream/main (compile + instantiate + run, throwaway `.tmp/` battery). The original 525+ `(none)`-leak compile-error class is **largely fixed** by the prior #2159 slices — most byte/short element ops, DataView get/set Int/Float (incl. LE + OOB→RangeError), `fill`, `set`, `subarray`, `copyWithin`, `slice`, iterators, and the higher-order methods all compile AND run correctly standalone now. The remaining residual is a few CEs, host-import leaks, and **runtime value-fidelity** gaps (compile clean, fail test262 assertions).

## Sub-issues

| # | title | rows | feasibility |
|---|---|---|---|
| #2592 | TypedArray.of / TypedArray.from static factories (CE `__get_builtin`) | ~40-90 | medium |
| #2593 | Integer element-width wrapping (ToInt8/ToUint16/Uint8Clamp) + signed read | ~120-220 | hard |
| #2594 | Host-import leaks: `ArrayBuffer.isView`, BigInt64Array ctor, DataView BigInt | ~30-70 | medium |
| #2595 | `BYTES_PER_ELEMENT` (static CE + instance returns 0) | ~15-40 | easy |
| #2596 | `.buffer` accessor — `illegal cast` at runtime | ~20-50 | hard |
| #2597 | `@@toStringTag` — `Object.prototype.toString` → `[object Object]` | ~15-35 | easy |

#2593 is the biggest win and hardest (element-representation level, but **bounded** — confined to storage selection + packed read/write + a clamp helper; does NOT touch the value-rep substrate #2580).

Docs-only (`plan/issues/*.md`); no source touched. IDs allocated via `claim-issue.mjs --allocate`. #2159 updated with the tracker table, verified-good list, and residual-not-covered notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA