### PR TITLE
docs(#2160): slice standalone String residual into 4 dev-tractable sub-issues

### DIFF
--- a/plan/issues/2160-standalone-string-number-coercion-residual.md
+++ b/plan/issues/2160-standalone-string-number-coercion-residual.md
@@ -311,3 +311,60 @@ clean.
 **Still open (NOT regressed):** `new Number(x)` wrapper CONSTRUCTION under
 `--target wasi` (requests `__new_Number`; standalone-only native object-runtime)
 — a separate substrate residual reproducing on pristine `origin/main`.
+
+---
+
+## Re-measure + residual slicing (2026-06-22, architect) — sprint 65
+
+Re-probed the **host-pass / standalone-fail** gap for `built-ins/String` +
+`built-ins/Number` against current main `0451ee920` (every file run twice:
+host-mode `runTest262File` vs `target: "standalone"`; the host-pass /
+standalone-fail set is the umbrella's definition). Result: **148 gap rows, all in
+`built-ins/String`** — `built-ins/Number` has **no** remaining host/standalone gap
+(the wrapper + native-format slices above closed it). The original "635 / 643 / 159"
+numbers were the 2026-06-15 baseline; the value-rep keystones (#2187/#2576/#2579)
++ the wrapper slices have since closed the bulk.
+
+### Verified root-cause buckets of the 148
+
+| bucket | rows | disposition |
+|---|---:|---|
+| **search-method arg ToString + IsRegExp** (`indexOf/lastIndexOf/includes/startsWith/endsWith/localeCompare`, TYPED receiver, non-string arg → `__str_flatten` null-deref) | ~20–28 | **#2598** (dev) |
+| **concat arg ToString** (variadic + non-string-primitive, TYPED receiver → `__str_concat` null-deref / `undefined`) | ~6–10 | **#2599** (dev) |
+| **index/position ToIntegerOrInfinity** (`at/charAt/charCodeAt/codePointAt/indexOf` position, fractional-string/object arg → wrong index) | ~6–12 | **#2600** (dev) |
+| **fromCodePoint RangeError** (non-integral / out-of-[0,0x10FFFF] → must throw) | ~2–3 | **#2601** (dev) |
+| `match`/`matchAll`/`search` (RegExp-routed) | 15 | → **#2161** standalone RegExp engine |
+| **RequireObjectCoercible `this`** via `.call(null/undef/symbol)` + **boxed/dynamic `this`** (`new Boolean; o.indexOf=…`, `_A1_T2`/`_A4_T*`) | ~25 | → **#2580 M2** (any-typed receiver) |
+| builtin-method-**as-value** (`String.prototype.X.length`, `new X`, `.name`, callback) — `built-in static property value read … not supported` / `__get_builtin` CE | ~8 | → builtin-closure substrate (not method correctness) |
+| object→primitive (`Cannot convert object to primitive value`) for `String()`/concat with a dynamic-object arg/receiver | ~18 | → **#1917** coercion engine (already the engine path) |
+
+### The M2-deferred note (per #2580)
+
+Everything where the **receiver is `any`/dynamic/boxed** is **#2580 M2 territory**
+(any-typed string/number method dispatch + coercion-on-any), NOT a #2160 slice.
+That is: `String.prototype.X.call(null/undefined, …)` (RequireObjectCoercible on a
+dynamic receiver), `new Boolean/Number/String; o.method = String.prototype.X; o.X(…)`
+(boxed-primitive receiver), and any `obj.method()` where `obj: any`. #2580's M1
+canary already proved a bare-externref runtime test cannot disambiguate these
+receivers — they need M2's tag-aware dynamic reader. The four #2598–#2601 slices are
+deliberately gated on a **statically-typed string receiver**, so they are
+substrate-INDEPENDENT and land independently of #2580.
+
+### Slices created (sprint 65)
+
+- **#2598** — search-method arg ToString + IsRegExp guard (largest bucket)
+- **#2599** — concat arg ToString (variadic + non-string)
+- **#2600** — index/position ToIntegerOrInfinity
+- **#2601** — fromCodePoint RangeError
+
+Each: ONE verified root cause, typed receiver (substrate-independent), reuses the
+existing `coerceType` / `__str_to_number` engine (no new #2108 coercion site),
+~1 day, full `## Implementation Plan` in its own file. #2598 + #2599 share the
+"ToString an arbitrary arg before a native string helper" shape — whichever lands
+first factors a small `emitArgAsNativeString` helper the other reuses (independently
+landable either order).
+
+**This umbrella stays `ready`** as the tracker; the actionable substrate-independent
+String work is now the four child slices. The remaining residual is #2161 (RegExp),
+#2580 M2 (dynamic receiver), #1917 (object→primitive), and the builtin-method-as-value
+closure substrate — all tracked elsewhere.

--- a/plan/issues/2598-standalone-string-search-method-arg-tostring.md
+++ b/plan/issues/2598-standalone-string-search-method-arg-tostring.md
@@ -1,0 +1,168 @@
+---
+id: 2598
+title: "Standalone: ToString(searchString) + IsRegExp guard for String search methods (typed receiver)"
+status: ready
+sprint: 65
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: conformance
+area: string-number
+language_feature: string-methods
+goal: standalone-mode
+parent: 2160
+related: [1917, 2108]
+---
+
+# #2598 — Standalone String search-method argument ToString + IsRegExp guard
+
+## Problem
+
+In `--target standalone` (nativeStrings), `String.prototype.{indexOf,lastIndexOf,
+includes,startsWith,endsWith,localeCompare}` on a **statically-typed string
+receiver** with a **non-string argument** traps with `dereferencing a null
+pointer in __str_flatten()` instead of coercing the argument per spec.
+
+The receiver is a typed string literal/expression (NOT `any`/dynamic), so this is
+**substrate-independent** — it is purely the native helper failing to run
+`ToString` / `IsRegExp` on the *argument*. (The `.call(null)` / boxed-`this`
+forms are a separate substrate concern — see "Out of scope" below.)
+
+### Verified repros (host pass / standalone trap, current main `0451ee920`)
+
+| test262 path | shape | spec |
+|---|---|---|
+| `String/prototype/includes/searchstring-is-regexp-throws.js` | `''.includes(/./)` → TypeError | §22.1.3.7 step IsRegExp |
+| `String/prototype/endsWith/searchstring-is-regexp-throws.js` | `''.endsWith(/./)` → TypeError | §22.1.3.6 |
+| `String/prototype/indexOf/S15.5.4.7_A1_T5.js` | `"gnulluna".indexOf(null)` → `1` (`null`→`"null"`) | §22.1.3.8 ToString |
+| `String/prototype/indexOf/S15.5.4.7_A1_T7.js` | `String("undefined").indexOf(undefined)` → `0` | ToString(undefined)=`"undefined"` |
+| `String/prototype/indexOf/searchstring-tostring.js` | object arg with `toString` | ToString(searchString) |
+| `String/prototype/includes/coerced-values-of-position.js` | | ToString(arg) |
+| `String/prototype/endsWith/return-{true,false}-if-*` | typed-receiver value-correctness reached only after arg ToString | |
+| `String/prototype/localeCompare/S15.5.4.9_A1_T1.js` | non-string `that` arg | §22.1.3.10 ToString(that) |
+
+Probe: a host-vs-standalone gap sweep of `built-ins/String` (current main) plus
+direct standalone compile+run confirmed every one of these traps in
+`__str_flatten()` (search arg) — the receiver is a typed string, so the trap is
+in the *argument* path.
+
+## Root cause
+
+`compileNativeStringMethodCall` (`src/codegen/string-ops.ts`) stores each search
+argument via `compileStringValueToLocal` (line ~2114):
+
+```ts
+const compileStringValueToLocal = (value, fallback, name): number => {
+  const local = allocLocal(fctx, ..., nativeStringType(ctx));
+  if (value) {
+    compileExpression(ctx, fctx, value, nativeStringType(ctx));  // <-- no ToString
+  } else {
+    compileStringLiteral(ctx, fctx, fallback);
+  }
+  fctx.body.push({ op: "local.set", index: local });
+  return local;
+};
+```
+
+`compileExpression(value, nativeStringType)` does **not** auto-coerce a non-string
+result (number / null / undefined / RegExp / object) into a `ref $AnyString`. The
+mistyped value is `local.set` and later fed to `__str_indexOf` etc., whose
+`__str_flatten(arg)` casts/derefs it → null-pointer trap. Two spec steps are
+missing:
+
+1. **IsRegExp guard** (`includes`/`startsWith`/`endsWith` only — §22.1.3.{6,7,21}
+   step "If isRegExp is true, throw a **TypeError**"). `indexOf`/`lastIndexOf`/
+   `localeCompare` do **not** have this guard.
+2. **ToString(searchString)** for every search method (and `ToString(that)` for
+   `localeCompare`) — `null`→`"null"`, `undefined`→`"undefined"`, `1`→`"1"`,
+   object→`obj.toString()`.
+
+## Implementation Plan
+
+### Root cause (1 sentence)
+`compileStringValueToLocal` feeds a non-string argument straight to a native helper
+that derefs it as a string; the spec's IsRegExp-throw + ToString-coercion steps are
+absent.
+
+### Changes — `src/codegen/string-ops.ts`
+
+**A. ToString coercion in `compileStringValueToLocal` (line ~2114).**
+- Capture `const argType = compileExpression(ctx, fctx, value)` **without** forcing
+  `nativeStringType` (so we see the real type), then route through the existing
+  string-coercion engine: `coerceType(ctx, fctx, argType, nativeStringType(ctx), value)`.
+  `coerceType` (`type-coercion.ts`) already has f64/i32/boolean/null/undefined →
+  `$AnyString` arms and the standalone `$__any_to_string` object dispatcher — reuse
+  them; do **not** hand-roll a new ToString call site (respect the #2108 coercion-site
+  drift gate — this is the existing engine, not a new matrix).
+- Keep the `else` branch (absent arg → `compileStringLiteral(fallback)`) unchanged.
+
+### Wasm IR pattern (IsRegExp static fold)
+```wasm
+;; ''.includes(/./)  — arg is a RegExp literal
+;; (no receiver/arg emitted — unconditional throw)
+<string-const "TypeError: ...">
+throw $exnTag
+```
+
+**B. IsRegExp TypeError guard for `includes`/`startsWith`/`endsWith` (arms at
+lines ~2401/2416/2429).**
+- Before storing the search arg, emit the IsRegExp check. Two cases:
+  - **Static**: if the first arg is syntactically a RegExp literal (`ts.isRegularExpressionLiteral`)
+    or `new RegExp(...)`, emit an **unconditional** `throw TypeError` (compile-time
+    fold — mirror the static-RangeError fold in the `normalize` arm at line ~2846).
+  - **Dynamic** (arg is `any`/object): emit a runtime `Symbol.match`-presence check.
+    In standalone this is the `__extern_get(arg, "@@match")`/`Symbol.match` slot read;
+    if a simpler bounded form is hard, gate the runtime arm to the static case for
+    this slice and leave the dynamic IsRegExp for a follow-up (the test262 reachable
+    set here is the static RegExp-literal form).
+- Use `emitTypeErrorThrow(ctx, fctx, "TypeError: First argument to String.prototype."
+  + method + " must not be a regular expression")` (helper already used at
+  string-ops.ts ~2076).
+
+### Edge cases
+- `indexOf`/`lastIndexOf`/`localeCompare`: **no** IsRegExp guard — a RegExp arg is
+  ToString'd to its source (`/./` → `"/./"`), not thrown. Only includes/startsWith/
+  endsWith throw.
+- `null` arg → `"null"`; `undefined` (explicit or absent for the *search* arg, which
+  has no default) → `"undefined"`. NOTE: the absent-arg fallback string is currently
+  `"undefined"` — that is correct for these methods.
+- Symbol arg → TypeError "Cannot convert a Symbol value to a string" (already handled
+  by `tryThrowOnBigIntOrSymbolArg` for integer args; ensure the string-arg path
+  throws too — `coerceType` of a symbol should route to the existing symbol-throw).
+- A `bigint` arg → ToString is allowed (its decimal string); verify against
+  `searchstring-tostring-bigint.js`, do not over-throw.
+
+### Out of scope (defer)
+- `String.prototype.X.call(null/undefined, ...)` and boxed-`this`
+  (`new Boolean; o.indexOf = String.prototype.indexOf`) — the receiver is a
+  **dynamic/`any`** value, which is **#2580 M2** (RequireObjectCoercible on an
+  `any` receiver). Tests: `this-is-null-throws`, `this-is-undefined-throws`,
+  `this-value-not-obj-coercible`, `S15.5.4.*_A1_T2` (boxed), `_A4_T*` (object
+  receiver). → #2580 M2.
+- Object-valued args whose `toString` is a class/dynamic object that hits
+  `Cannot convert object to primitive value` route through the **#1917 coercion
+  engine** (the same engine `coerceType` calls); a residual there is an #1917
+  item, not this slice.
+
+### Failing test262 paths (verify flip)
+- `built-ins/String/prototype/includes/searchstring-is-regexp-throws.js`
+- `built-ins/String/prototype/endsWith/searchstring-is-regexp-throws.js`
+- `built-ins/String/prototype/startsWith/searchstring-is-regexp-throws.js`
+- `built-ins/String/prototype/indexOf/S15.5.4.7_A1_T5.js`, `_A1_T7.js`
+- `built-ins/String/prototype/indexOf/searchstring-tostring.js`
+- `built-ins/String/prototype/{includes,endsWith}/coerced-values-of-position.js`
+- `built-ins/String/prototype/{includes,endsWith}/return-abrupt-from-searchstring.js`
+- `built-ins/String/prototype/localeCompare/S15.5.4.9_A1_T1.js`
+- `built-ins/String/prototype/endsWith/return-{true,false}-if-*.js`
+
+### Estimated rows
+~20–28 standalone rows (the substrate-independent subset of the search-method +
+localeCompare gap).
+
+### Validation
+- New `tests/issue-2598-string-search-arg-tostring.test.ts`: each repro ×
+  `{standalone, gc}`, asserting correct value/throw and **no** `__str_flatten`
+  null-deref and **no** new host-import leak under `target: standalone`.
+- gc-mode no-regression guard (host path unchanged).
+- Run `pnpm run check:coercion-sites` — must be unchanged (reuse the engine, no
+  new site).

--- a/plan/issues/2599-standalone-string-concat-arg-tostring.md
+++ b/plan/issues/2599-standalone-string-concat-arg-tostring.md
@@ -1,0 +1,110 @@
+---
+id: 2599
+title: "Standalone: String.prototype.concat variadic + non-string-argument ToString (typed receiver)"
+status: ready
+sprint: 65
+priority: high
+feasibility: easy
+reasoning_effort: medium
+task_type: conformance
+area: string-number
+language_feature: string-methods
+goal: standalone-mode
+parent: 2160
+related: [1917, 2108]
+---
+
+# #2599 — Standalone String.prototype.concat ToString(args)
+
+## Problem
+
+In `--target standalone`, `String.prototype.concat` on a **typed string receiver**
+mishandles its arguments:
+
+| call (typed string receiver) | host | standalone (current main) |
+|---|---|---|
+| `'a'.concat('b','c','d')` | `"abcd"` | **`undefined`** (variadic broken) |
+| `'a'.concat(1)` | `"a1"` | **null-deref trap** in `__str_concat()` |
+| `'a'.concat(true)` | `"atrue"` | trap |
+| `'a'.concat(null)` | `"anull"` | trap |
+
+Direct standalone compile+run (current main `0451ee920`) confirms: variadic
+string args return `undefined`, and any non-string primitive arg traps with
+`dereferencing a null pointer in __str_concat()`.
+
+Receiver is a typed string → **substrate-independent**.
+
+## Root cause
+
+`compileNativeStringMethodCall`, the `method === "concat"` arm (`src/codegen/
+string-ops.ts`, the `if (method === "concat")` block):
+
+```ts
+if (method === "concat") {
+  const concatIdx = ctx.nativeStrHelpers.get("__str_concat")!;
+  emitReceiver();                                  // accumulator on stack
+  if (expr.arguments.length === 0) return nativeStringType(ctx);
+  for (const arg of expr.arguments) {
+    compileExpression(ctx, fctx, arg, nativeStringType(ctx));  // <-- no ToString
+    fctx.body.push({ op: "call", funcIdx: concatIdx });
+  }
+  return nativeStringType(ctx);
+}
+```
+
+`compileExpression(arg, nativeStringType)` does not coerce a number/boolean/null
+arg to a `ref $AnyString`, so `__str_concat(acc, arg)` derefs a non-string ref →
+trap. (The reported "variadic returns undefined" is the same failure surfacing as a
+dropped/poisoned accumulator on the first bad arg; once every arg is properly
+ToString'd, the fold is correct.)
+
+## Implementation Plan
+
+### Root cause (1 sentence)
+The concat arm feeds each argument to `__str_concat` without ToString, so a
+non-string argument null-derefs and a multi-arg fold poisons the accumulator.
+
+### Changes — `src/codegen/string-ops.ts` (concat arm)
+- For each argument, capture its real type and route through the existing string
+  coercion engine before the `__str_concat` call:
+  ```ts
+  const argType = compileExpression(ctx, fctx, arg);            // no forced target
+  coerceType(ctx, fctx, argType, nativeStringType(ctx), arg);   // existing engine
+  fctx.body.push({ op: "call", funcIdx: concatIdx });
+  ```
+  `coerceType` (`type-coercion.ts`) already has the f64/i32/boolean/null/undefined →
+  `$AnyString` arms + standalone `$__any_to_string` dispatcher. Reuse it — **no new
+  coercion site** (respect the #2108 drift gate).
+- This SHARES the exact fix shape with #2598's `compileStringValueToLocal`. If #2598
+  lands first, factor a small `emitArgAsNativeString(ctx, fctx, arg)` helper and call
+  it here too; if this lands first, #2598 reuses it. Either order is fine — keep the
+  two slices independently landable (whoever is second rebases on the helper).
+
+### Edge cases
+- `'a'.concat()` (no args) → receiver unchanged (already handled, keep).
+- `null`→`"null"`, `undefined`→`"undefined"`, `true`→`"true"`, `1`→`"1"`,
+  `1.5`→`"1.5"`, `NaN`→`"NaN"`, `Infinity`→`"Infinity"`.
+- Multi-arg left-to-right fold order must be preserved (eval each arg in order;
+  §22.1.3.4 step "Repeat, while items is not empty").
+- Symbol arg → TypeError; bigint arg → its decimal string (allowed).
+
+### Out of scope (defer)
+- `new Boolean; o.concat = String.prototype.concat; o.concat(...)` and other
+  boxed/dynamic **receiver** forms (`S15.5.4.6_A1_T2`, `_A2`) → the receiver is a
+  boxed primitive / `any` and hits `Cannot convert object to primitive value` →
+  **#2580 M2** (dynamic receiver) / **#1917** (object→primitive). Not this slice.
+
+### Failing test262 paths (verify flip)
+- `built-ins/String/prototype/concat/S15.5.4.6_A1_T5.js` (null/undefined args)
+- `built-ins/String/prototype/concat/S15.5.4.6_A1_T7.js`
+- `built-ins/String/prototype/concat/15.5.4.6-*` variadic forms
+- (`_A1_T2`, `_A2` stay failing — boxed receiver, deferred to M2/#1917)
+
+### Estimated rows
+~6–10 standalone rows (the typed-receiver concat subset).
+
+### Validation
+- New `tests/issue-2599-string-concat-arg-tostring.test.ts`: variadic strings,
+  number/boolean/null/undefined args, fold order, × `{standalone, gc}`; assert
+  no `__str_concat` null-deref and no host-import leak under `target: standalone`.
+- `pnpm run check:coercion-sites` unchanged.

--- a/plan/issues/2600-standalone-string-index-arg-tointeger.md
+++ b/plan/issues/2600-standalone-string-index-arg-tointeger.md
@@ -1,0 +1,129 @@
+---
+id: 2600
+title: "Standalone: ToIntegerOrInfinity for String index/position args (at/charAt/charCodeAt/codePointAt/indexOf)"
+status: ready
+sprint: 65
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: conformance
+area: string-number
+language_feature: string-methods
+goal: standalone-mode
+parent: 2160
+related: [2124]
+---
+
+# #2600 — Standalone String index/position argument ToIntegerOrInfinity
+
+## Problem
+
+In `--target standalone`, the position/index argument of
+`String.prototype.{at,charAt,charCodeAt,codePointAt,indexOf,lastIndexOf}` is not
+run through **ToIntegerOrInfinity** (§7.1.5 = ToNumber then truncate-toward-zero),
+so a non-integer-typed position yields the wrong index on a **typed string
+receiver** (substrate-independent value-correctness, not a trap).
+
+### Verified repros (host pass / standalone wrong-value, current main `0451ee920`)
+
+| call (typed string receiver) | host | standalone |
+|---|---|---|
+| `"aaaa".indexOf("aa", "1.9")` | `1` (ToInteger("1.9")=1) | **`14`** (assertion at L24 of `indexOf/position-tointeger.js`) |
+| `"01".at({valueOf(){return 1}})` | `'1'` | **wrong** (`at/index-argument-tointeger.js`) |
+| `"abc".charAt("1.5")` | `'b'` | wrong |
+| `"abc".charCodeAt("2.9")` | code of `'c'` | wrong |
+
+Probe (direct standalone compile+run) confirmed `indexOf("aa","1.9")` returns `14`
+not `1`, and `s.at({valueOf…})` returns the wrong char.
+
+## Root cause
+
+`compileStringIntegerArg` (`src/codegen/string-ops.ts` line ~2062) lowers the
+position with a plain i32 coercion:
+
+```ts
+function compileStringIntegerArg(ctx, fctx, arg): void {
+  if (tryThrowOnBigIntOrSymbolArg(ctx, fctx, arg)) { ...; return; }
+  const argType = compileExpression(ctx, fctx, arg, { kind: "i32" });   // <-- not ToIntegerOrInfinity
+  ...
+}
+```
+
+`compileExpression(arg, {kind:"i32"})`:
+- for a **string** literal `"1.9"` does not run ToNumber(string)→1.9→trunc→1; it
+  takes a different (wrong) path that yields a large/garbage i32.
+- for an **object** with `valueOf` does not invoke ToPrimitive("number")→ToInteger.
+
+Per spec the index is `ToIntegerOrInfinity(arg)` = `truncate(ToNumber(arg))`, with
+`NaN`→0, `+∞`/`-∞` clamped by the subsequent range check.
+
+## Implementation Plan
+
+### Root cause (1 sentence)
+The string index arg is coerced directly to i32 instead of via
+ToNumber→truncate-toward-zero, so non-integer-typed positions resolve wrong.
+
+### Changes — `src/codegen/string-ops.ts`, `compileStringIntegerArg` (line ~2062)
+- Replace the direct `compileExpression(arg, {kind:"i32"})` with: compile the arg,
+  coerce to **f64** via the existing numeric coercion engine
+  (`coerceType(ctx, fctx, argType, {kind:"f64"}, arg)` — this routes a string
+  through the existing `__str_to_number` engine helper and an object through the
+  ToPrimitive("number") path, both already present for `+str`/`Number(x)`), then
+  apply **ToIntegerOrInfinity**:
+  - `f64` on stack → handle `NaN`→0 (`f64.ne self` test → select 0), then
+    `i32.trunc_sat_f64_s` (truncates toward zero, saturates ±∞ to i32 min/max —
+    the subsequent `<0` / `>=len` range checks clamp correctly).
+- Keep the existing `tryThrowOnBigIntOrSymbolArg` guard (line ~2063) and the i64
+  BigInt-drop/throw branch.
+
+### Wasm IR pattern (ToIntegerOrInfinity)
+```wasm
+;; arg already coerced to f64 in $f
+local.get $f
+local.get $f
+f64.ne            ;; isNaN ? 1 : 0
+if (result i32)
+  i32.const 0     ;; NaN → 0
+else
+  local.get $f
+  i32.trunc_sat_f64_s   ;; trunc toward zero, ±∞ saturates
+end
+```
+
+### Edge cases
+- `"1.9"` → 1; `"-1.5"` → -1 (then range-check → behaves per method); `"abc"` →
+  NaN → 0; `""` → 0; `true`→1, `false`→0, `null`→0, `undefined`→method default.
+- Absent arg keeps the method's existing default sentinel (do not regress #2124:
+  explicit `undefined` ≠ 0 for the methods that special-case it; this helper is only
+  reached for *present* args — the absent path lives in `compileIntegerValueToLocal`,
+  unchanged).
+- `at` accepts negative indices (relative from end) — the truncation must preserve
+  sign; `trunc_sat_f64_s` does. The `at`-specific negative-wrap arithmetic already
+  lives in the `at` arm (line ~2213); this fix only changes how the raw index is
+  produced.
+- `lastIndexOf` NaN-position → +∞ search-from-end sentinel is already special-cased
+  (line ~2390); keep that branch ahead of the generic coercion.
+
+### Out of scope (defer)
+- An **object** position whose `valueOf`/`@@toPrimitive` is a *dynamic/class*
+  object that lands on the `Cannot convert object to primitive value` engine path
+  is shared with **#1917** — if the engine handles a simple-object `{valueOf(){…}}`
+  (it does for `+obj`), `s.at({valueOf})` flips here; a residual class/proxy receiver
+  is an #1917/#2580-M2 item, not this slice.
+
+### Failing test262 paths (verify flip)
+- `built-ins/String/prototype/indexOf/position-tointeger.js`
+- `built-ins/String/prototype/at/index-argument-tointeger.js`
+- `built-ins/String/prototype/at/index-non-numeric-argument-tointeger.js`
+- `built-ins/String/prototype/codePointAt/return-abrupt-from-object-pos-to-integer.js`
+  (the throw-from-valueOf abrupt case — verify the engine propagates the throw)
+
+### Estimated rows
+~6–12 standalone rows.
+
+### Validation
+- New `tests/issue-2600-string-index-tointeger.test.ts`: fractional-string,
+  non-numeric-string, boolean, negative positions across at/charAt/charCodeAt/
+  codePointAt/indexOf × `{standalone, gc}`.
+- gc-mode no-regression guard.
+- `pnpm run check:coercion-sites` unchanged (reuse the f64 engine).

--- a/plan/issues/2601-standalone-fromcodepoint-rangeerror.md
+++ b/plan/issues/2601-standalone-fromcodepoint-rangeerror.md
@@ -1,0 +1,120 @@
+---
+id: 2601
+title: "Standalone: String.fromCodePoint RangeError on non-integral / out-of-range code points"
+status: ready
+sprint: 65
+priority: medium
+feasibility: easy
+reasoning_effort: low
+task_type: conformance
+area: string-number
+language_feature: string-methods
+goal: standalone-mode
+parent: 2160
+related: [2088, 2122]
+---
+
+# #2601 — Standalone String.fromCodePoint RangeError guard
+
+## Problem
+
+`String.fromCodePoint(...codePoints)` (§22.1.2.2) must throw a **RangeError** when
+any argument, after ToNumber, is **not an integral Number** or is **< 0 or >
+0x10FFFF**. The standalone native lowering omits both guards, so
+`String.fromCodePoint(3.14)`, `String.fromCodePoint(-1)`,
+`String.fromCodePoint(0x10FFFF + 1)` silently truncate/wrap instead of throwing.
+
+### Verified repros (host pass / standalone fail, current main `0451ee920`)
+
+| test262 path | shape | expected |
+|---|---|---|
+| `built-ins/String/fromCodePoint/argument-is-not-integer.js` | `String.fromCodePoint(3.14)` | RangeError |
+| `built-ins/String/fromCodePoint/number-is-out-of-range.js` | `String.fromCodePoint(-1)`, `(0x10FFFF+1)` | RangeError |
+
+Probe (host-vs-standalone `built-ins/String` sweep): both fail standalone with
+`returned 2 | assert.throws(RangeError, …)` — the code ran and returned a string
+instead of throwing.
+
+No receiver involved (static method, numeric args) → **substrate-independent**.
+
+## Root cause
+
+The fromCodePoint lowering (`src/codegen/expressions/calls.ts`, the
+`propAccess.name.text === "fromCodePoint"` block at line ~4481) routes through
+`compileFromCharCodeFamily(ctx, fctx, expr, { native: true, helperIdx })`. That
+shared fold (also used by `fromCharCode`, which has **no** such guard by spec)
+emits each code point and concatenates, but never checks §22.1.2.2 step 2b
+("not an integral Number → RangeError") or step 2c ("< 0 or > 0x10FFFF →
+RangeError"). The native `__str_fromCodePoint(cp: i32)` helper
+(`native-strings.ts` line ~4417) takes an i32 — by the time the value is an i32
+the fractional/range information is already lost.
+
+## Implementation Plan
+
+### Root cause (1 sentence)
+The shared fromCharCode/fromCodePoint fold skips fromCodePoint's per-argument
+integral + [0, 0x10FFFF] RangeError checks.
+
+### Changes — `src/codegen/expressions/calls.ts` (`compileFromCharCodeFamily`)
+- Add a `kind: "fromCodePoint"` flag (or reuse the existing native/non-native
+  discriminator) so the fold knows to emit the guard **only** for fromCodePoint
+  (NOT fromCharCode — fromCharCode does ToUint16 with no RangeError).
+- For each argument, compile to **f64** (the spec ToNumber, via the existing numeric
+  coercion — `coerceType(argType, {kind:"f64"})`), then before truncating to the i32
+  code point emit:
+  ```
+  ;; integral check: trunc(cp) != cp  → RangeError
+  local.get $cp_f64
+  local.get $cp_f64
+  f64.trunc
+  f64.ne
+  ;; range check: cp < 0 || cp > 0x10FFFF
+  local.get $cp_f64  f64.const 0      f64.lt
+  local.get $cp_f64  f64.const 1114111 f64.gt
+  i32.or  i32.or
+  if  <throw RangeError "Invalid code point ...">  end
+  ```
+  Also throw on `NaN` (NaN fails the `trunc != self` test → already caught) and on
+  `±Infinity` (caught by the range test).
+- Throw helper: `addStringConstantGlobal` + `ensureExnTag` + `throw` — mirror the
+  static-RangeError fold in `string-ops.ts` `normalize` arm (line ~2846/2848) and
+  `emitTypeErrorThrow`.
+
+### Wasm IR pattern
+See the integral + range block above. Code-point value `1114111` = `0x10FFFF`.
+
+### Edge cases
+- `String.fromCodePoint()` (no args) → `""` (already: the block guards
+  `arguments.length >= 1`; the 0-arg case returns empty — unchanged).
+- Integral floats are OK: `String.fromCodePoint(65)` and `(65.0)` → `"A"` (the
+  `trunc != self` test passes for `65.0`).
+- `0` and `0x10FFFF` are valid (inclusive bounds — use `<0` and `>0x10FFFF`, not
+  `<=`/`>=`).
+- `-0` is integral and in range → valid (`""`-adjacent; ToNumber(-0)=0).
+- A non-numeric arg (string/object) first goes through ToNumber (the f64 coercion);
+  `String.fromCodePoint("65")` → `"A"`. A NaN result (`fromCodePoint("x")`) →
+  RangeError (NaN fails integral test). Keep this consistent with host.
+
+### Out of scope (defer)
+- `String.fromCharCode` / `String.fromCodePoint` accessed **as a value** (`.length`,
+  `.name`, `new String.fromCodePoint`, passed as a callback) → the
+  `built-in static property value read is not supported in --target standalone` /
+  `__get_builtin` CE family. That is the **builtin-method-as-value** substrate
+  concern (a native built-in method closure), NOT this method-correctness fix.
+  Tests: `fromCodePoint/not-a-constructor.js`, `length.js`, `fromCharCode/
+  S15.5.3.2_A2.js`, `_A4.js`. Track under the builtin-closure substrate, not here.
+
+### Failing test262 paths (verify flip)
+- `built-ins/String/fromCodePoint/argument-is-not-integer.js`
+- `built-ins/String/fromCodePoint/number-is-out-of-range.js`
+
+### Estimated rows
+~2–3 standalone rows (small but a clean, bounded native-helper correctness fix).
+
+### Validation
+- New `tests/issue-2601-fromcodepoint-rangeerror.test.ts`: `fromCodePoint(3.14)`,
+  `(-1)`, `(0x10FFFF+1)`, `(NaN)`, `(Infinity)` all throw RangeError;
+  `fromCodePoint(0)`, `(65)`, `(65.0)`, `(0x10FFFF)`, multi-arg valid all return
+  correct strings; × `{standalone, gc}`. Assert `fromCharCode` still does NOT throw
+  on `3.14` (ToUint16, no RangeError) — guard must be fromCodePoint-only.
+- gc-mode no-regression guard.


### PR DESCRIPTION
## Summary

Architect spec-only PR (no source changes). Slices the #2160 umbrella
("Standalone String/Number method & coercion residual") into **4
substrate-independent, dev-tractable sub-issues**.

Re-measured the host-pass / standalone-fail gap for `built-ins/String` +
`built-ins/Number` against current main (`0451ee920`): **148 gap rows, all in
`built-ins/String`** — the `built-ins/Number` gap is already closed by the prior
wrapper + native-format slices. Each bucket's root cause was verified by direct
standalone compile+run (not narrative).

## Slices created

| id | title | est. rows | feasibility |
|----|-------|----------:|-------------|
| #2598 | search-method arg ToString + IsRegExp guard (indexOf/lastIndexOf/includes/startsWith/endsWith/localeCompare) | ~20–28 | medium |
| #2599 | concat variadic + non-string-arg ToString | ~6–10 | easy |
| #2600 | index/position ToIntegerOrInfinity (at/charAt/charCodeAt/codePointAt/indexOf) | ~6–12 | medium |
| #2601 | String.fromCodePoint RangeError (non-integral / out-of-range) | ~2–3 | easy |

All four gate on a **statically-typed string receiver** and reuse the existing
`coerceType` / `__str_to_number` engine (no new #2108 coercion site) — so they
are independent of the value-rep substrate and land independently.

## Deferred (NOT sliced — coordinated, not duplicated)

- **`match`/`matchAll`/`search`** (RegExp-routed, 15 rows) → #2161 standalone RegExp engine
- **`any`/dynamic/boxed receiver** (`String.prototype.X.call(null)`, `new Boolean; o.method=…`, ~25 rows) → **#2580 M2** (any-typed receiver dispatch; M1 canary already proved a bare-externref test cannot disambiguate these)
- **object→primitive** (`Cannot convert object to primitive value`, ~18 rows) → #1917 coercion engine
- **builtin-method-as-value** (`String.prototype.X.length`, `new X`, ~8 rows) → builtin-closure substrate

## Files

- `plan/issues/2598-…` … `2601-…` — new slices, each with a concrete `## Implementation Plan` (exact file:function:line, Wasm IR pattern, edge cases, failing test262 paths, estimated rows, validation)
- `plan/issues/2160-…` — umbrella updated with the re-measure, root-cause bucket table, slice tracker, and the M2-deferred note

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA