### PR TITLE
fix(#2590): standalone RegExp.escape(str) static method (ES2025)

### DIFF
--- a/plan/issues/2590-standalone-regexp-escape-static-method.md
+++ b/plan/issues/2590-standalone-regexp-escape-static-method.md
@@ -1,7 +1,7 @@
 ---
 id: 2590
 title: "Standalone `RegExp.escape(str)` static method (ES2025 §22.2.5.x)"
-status: ready
+status: done
 sprint: 65
 priority: medium
 feasibility: medium
@@ -11,6 +11,8 @@ goal: standalone-mode
 language_feature: regexp
 task_type: conformance
 created: 2026-06-22
+completed: 2026-06-22
+assignee: ttraenkler/agent-regexp-escape
 ---
 
 # Standalone `RegExp.escape(str)` static method (ES2025)
@@ -123,3 +125,51 @@ the `RegExp/escape/cross-realm`/`escaped-*` variants that currently CE on
 - `RegExp.escape("\t") === "\\t"`
 - `RegExp.escape("") === ""`
 - host-JS parity check across the test262 `escaped-*` inputs
+
+## Resolution
+
+Implemented as a pure-Wasm native string transform — no regex engine, no host
+import — so a standalone binary instantiates with an **empty importObject** and
+never leaks `env::__get_builtin`.
+
+- **`src/codegen/native-strings.ts`** — new `__regex_escape(s: ref $AnyString)
+  -> ref $AnyString` helper, registered at the end of `ensureNativeStringHelpers`
+  (same late-import-shift reconciliation domain as its sibling-call targets
+  `__str_concat`/`__str_flatten`). Flattens the input, iterates UTF-16 code
+  units, and builds the output with `__str_concat` over per-character flat
+  pieces (`array.new_fixed` + `struct.new $NativeString`). Implements
+  EncodeForRegExpEscape exactly: first-char `[0-9A-Za-z]` → `\xHH`; syntax chars
+  `^ $ \ . * + ? ( ) [ ] { } |` + solidus `/` → `\c`; ControlEscape `\t \n \v
+  \f \r`; otherPunctuators / WhiteSpace / LineTerminator / lone surrogate →
+  `\xHH` (c ≤ 0xFF) or `\uHHHH`; a valid surrogate **pair** (decoded to a
+  >0xFFFF code point by StringToCodePoints) passes through unescaped — detected
+  *before* the lone-surrogate classification so it never gets double-`\u`-escaped.
+- **`src/codegen/expressions/calls.ts`** — `RegExp.escape(s)` dispatch placed
+  right after the `Math.*` block (before the generic builtin-member /
+  `__get_builtin` fallthrough), gated on `ctx.standalone` + `ctx.nativeStrings`
+  + `isGlobalRegExpIdentifier`. A statically `string`-typed arg compiles to a
+  native string and calls `__regex_escape`; a statically non-string literal
+  throws a catchable `TypeError` (§22.2.5 step 1, via `emitBrandCheckTypeError`);
+  an `any`/`unknown` arg narrow-refuses (falls through).
+
+## Test Results
+
+`tests/issue-2590.test.ts` — **28/28 pass** under `target: "standalone"`,
+asserting byte-for-byte via the same `isSameValue(a: any, b: any)` shape the
+test262 harness uses. Covers every escape category from the test262 `escaped-*`
+files (syntax / control / otherpunctuators / whitespace / lineterminator /
+surrogates / utf16encodecodepoint / initial-char / not-escaped) plus the
+non-string-input `TypeError` path. Each case also asserts **no
+`env::__get_builtin` import leaks** and the module instantiates with `{}`.
+
+Residual (out of scope — not behavior, needs runtime function-object reflection):
+the metadata tests `is-function.js` / `length.js` / `name.js` / `prop-desc.js` /
+`not-a-constructor.js` require `RegExp.escape` to be a reflectable first-class
+function object (`typeof`, `.length`, `verifyProperty`), which standalone
+compile-time dispatch does not expose.
+
+Scoped gates green: `tsc`, `prettier --check`, `check:coercion-sites`,
+`check:ir-fallbacks`, `check:issue-ids`. The 2 pre-existing `arr.entries()`
+failures in `tests/issue-1320-standalone.test.ts` (#2043 late-import shift at
+`__defineProperty_value`) are unrelated — confirmed present on the clean base
+commit before this change.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -95,7 +95,11 @@ import type { InnerResult } from "../shared.js";
 import { coerceType, compileExpression, valTypesMatch, VOID_RESULT } from "../shared.js";
 // (#2193 PR-B) reflective `m.call(thisArg, …)` on a `$NativeProto` member-closure value.
 import { ensureArrayNativeProtoGlue, ensureObjectNativeProtoGlue } from "../array-object-proto.js";
-import { ensureStandaloneNativeMethodClosure, getNativeProtoBuiltinGlue } from "../native-proto.js";
+import {
+  emitBrandCheckTypeError,
+  ensureStandaloneNativeMethodClosure,
+  getNativeProtoBuiltinGlue,
+} from "../native-proto.js";
 import { compileStatement, hoistFunctionDeclarations } from "../statements.js";
 import {
   emitSetExtrasArgv,
@@ -172,6 +176,7 @@ import {
 } from "../generators-native.js";
 import {
   ensureNativeStringExternBridge,
+  ensureNativeStringHelpers,
   ensureStrToCharVecHelper,
   ensureTextEncodingHelpers,
   nativeStringLiteralInstrs,
@@ -4282,6 +4287,43 @@ function compileCallExpression(
       if (mathResult !== undefined) return mathResult;
       // Unknown Math method — fall through to generic call handling
       // (e.g. Array.prototype.every.call(Math, ...) rewritten as Math.every(...))
+    }
+
+    // #2590 — RegExp.escape(s) (ES2025, §22.2.5). A pure string transform that
+    // escapes regex-syntax-significant code points. Standalone-only: routing it
+    // through the native `__regex_escape` helper avoids leaking the dynamic
+    // `env::__get_builtin` host import (which would otherwise refuse / fail to
+    // instantiate). Placed before the generic builtin-member fallthrough.
+    if (
+      ctx.standalone &&
+      ts.isIdentifier(propAccess.expression) &&
+      isGlobalRegExpIdentifier(ctx, propAccess.expression) &&
+      propAccess.name.text === "escape" &&
+      ctx.nativeStrings
+    ) {
+      const arg = expr.arguments[0];
+      const argTsType = arg ? ctx.checker.getTypeAtLocation(arg) : undefined;
+      const argFlags = argTsType?.flags ?? 0;
+      const isStringArg = arg !== undefined && (isStringType(argTsType!) || (argFlags & ts.TypeFlags.StringLike) !== 0);
+      const isUnresolvedArg = (argFlags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
+      if (isStringArg) {
+        ensureNativeStringHelpers(ctx);
+        const escapeIdx = ctx.nativeStrHelpers.get("__regex_escape");
+        if (escapeIdx !== undefined) {
+          compileExpression(ctx, fctx, arg!, nativeStringType(ctx));
+          flushLateImportShifts(ctx, fctx);
+          fctx.body.push({ op: "call", funcIdx: ctx.nativeStrHelpers.get("__regex_escape")! } as Instr);
+          return nativeStringType(ctx);
+        }
+      } else if (arg !== undefined && !isUnresolvedArg) {
+        // §22.2.5 step 1: a statically non-String argument is a TypeError.
+        // (number / object / array / null / undefined literals — the
+        // non-string-inputs.js test exercises exactly these.)
+        emitBrandCheckTypeError(ctx, fctx.body, "RegExp.escape called on a non-string value");
+        fctx.body.push({ op: "unreachable" } as Instr);
+        return nativeStringType(ctx);
+      }
+      // `any`/`unknown` arg → narrow-refuse (fall through to the generic path).
     }
 
     // Handle Number.isNaN(n) and Number.isInteger(n)

--- a/src/codegen/native-strings.ts
+++ b/src/codegen/native-strings.ts
@@ -4502,6 +4502,491 @@ export function ensureNativeStringHelpers(ctx: CodegenContext): void {
       exported: false,
     });
   }
+
+  // --- $__regex_escape(s: ref $AnyString) -> ref $AnyString --- (#2590)
+  // Implements ES2025 RegExp.escape / EncodeForRegExpEscape: a pure string
+  // transform that escapes regex-syntax-significant code points so the result
+  // can be embedded safely in a pattern. No regex engine, no host import.
+  //
+  // Iterates the input's UTF-16 code units. For each code point c:
+  //   - First code point only, if c ∈ [0-9A-Za-z] → "\xHH" (lowercase hex).
+  //   - Syntax chars  ^ $ \ . * + ? ( ) [ ] { } |  and solidus /  → "\c".
+  //   - ControlEscape  \t \n \v \f \r  (U+0009..U+000D)            → "\t" etc.
+  //   - otherPunctuators / WhiteSpace / LineTerminator / lone surrogate:
+  //        c ≤ 0xFF  → "\xHH"          (lowercase hex, 2 digits)
+  //        else      → "\uHHHH"        (lowercase hex, 4 digits, per code unit)
+  //   - Everything else → the code point's UTF-16 code units, unescaped.
+  // A high+low surrogate pair forms a scalar code point > 0xFFFF that falls into
+  // the final "unescaped" branch and is copied through; only *lone* surrogates
+  // hit the \uHHHH branch.
+  {
+    const concatIdx = ctx.nativeStrHelpers.get("__str_concat")!;
+    const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten")!;
+    const typeIdx = addFuncType(ctx, [strRef], [strRef]);
+    const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+    ctx.nativeStrHelpers.set("__regex_escape", funcIdx);
+
+    // params: s(0)
+    // locals: flat(1) ref $NativeString, data(2) ref $__str_data, off(3),
+    //         len(4), i(5), out(6) ref $AnyString, cu(7), cu2(8), n0(9), n1(10)
+    const FLAT = 1,
+      DATA = 2,
+      OFF = 3,
+      LEN = 4,
+      I = 5,
+      OUT = 6,
+      CU = 7,
+      CU2 = 8,
+      N0 = 9,
+      N1 = 10;
+
+    // nibble→ascii hex char (lowercase): d<10 ? d+0x30 : d+0x57
+    const hexNibble = (load: Instr[]): Instr[] => [
+      ...load,
+      { op: "local.tee", index: N0 },
+      { op: "i32.const", value: 10 },
+      { op: "i32.lt_u" },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: [{ op: "local.get", index: N0 }, { op: "i32.const", value: 0x30 }, { op: "i32.add" }],
+        else: [{ op: "local.get", index: N0 }, { op: "i32.const", value: 0x57 }, { op: "i32.add" }],
+      } as Instr,
+    ];
+
+    // Build "\uHHHH" flat $NativeString for code unit CU (6 code units).
+    const uEscape: Instr[] = [
+      { op: "i32.const", value: 6 }, // len
+      { op: "i32.const", value: 0 }, // off
+      { op: "i32.const", value: 0x5c }, // '\'
+      { op: "i32.const", value: 0x75 }, // 'u'
+      ...hexNibble([
+        { op: "local.get", index: CU },
+        { op: "i32.const", value: 12 },
+        { op: "i32.shr_u" },
+        { op: "i32.const", value: 0xf },
+        { op: "i32.and" },
+      ]),
+      ...hexNibble([
+        { op: "local.get", index: CU },
+        { op: "i32.const", value: 8 },
+        { op: "i32.shr_u" },
+        { op: "i32.const", value: 0xf },
+        { op: "i32.and" },
+      ]),
+      ...hexNibble([
+        { op: "local.get", index: CU },
+        { op: "i32.const", value: 4 },
+        { op: "i32.shr_u" },
+        { op: "i32.const", value: 0xf },
+        { op: "i32.and" },
+      ]),
+      ...hexNibble([{ op: "local.get", index: CU }, { op: "i32.const", value: 0xf }, { op: "i32.and" }]),
+      { op: "array.new_fixed", typeIdx: strDataTypeIdx, length: 6 },
+      { op: "struct.new", typeIdx: strTypeIdx },
+    ];
+
+    // Build "\xHH" flat $NativeString for code unit CU (4 code units).
+    const xEscape: Instr[] = [
+      { op: "i32.const", value: 4 }, // len
+      { op: "i32.const", value: 0 }, // off
+      { op: "i32.const", value: 0x5c }, // '\'
+      { op: "i32.const", value: 0x78 }, // 'x'
+      ...hexNibble([
+        { op: "local.get", index: CU },
+        { op: "i32.const", value: 4 },
+        { op: "i32.shr_u" },
+        { op: "i32.const", value: 0xf },
+        { op: "i32.and" },
+      ]),
+      ...hexNibble([{ op: "local.get", index: CU }, { op: "i32.const", value: 0xf }, { op: "i32.and" }]),
+      { op: "array.new_fixed", typeIdx: strDataTypeIdx, length: 4 },
+      { op: "struct.new", typeIdx: strTypeIdx },
+    ];
+
+    // Build "\<char>" (backslash + the code unit itself), 2 code units.
+    const backslashEscape: Instr[] = [
+      { op: "i32.const", value: 2 }, // len
+      { op: "i32.const", value: 0 }, // off
+      { op: "i32.const", value: 0x5c }, // '\'
+      { op: "local.get", index: CU }, // the char
+      { op: "array.new_fixed", typeIdx: strDataTypeIdx, length: 2 },
+      { op: "struct.new", typeIdx: strTypeIdx },
+    ];
+
+    // Build "\<ctrl>" where the named-escape letter is in N1, 2 code units.
+    const namedCtrlEscape: Instr[] = [
+      { op: "i32.const", value: 2 }, // len
+      { op: "i32.const", value: 0 }, // off
+      { op: "i32.const", value: 0x5c }, // '\'
+      { op: "local.get", index: N1 }, // mapped letter t/n/v/f/r
+      { op: "array.new_fixed", typeIdx: strDataTypeIdx, length: 2 },
+      { op: "struct.new", typeIdx: strTypeIdx },
+    ];
+
+    // Build a 1-code-unit flat string from CU (pass-through single).
+    const oneUnit: Instr[] = [
+      { op: "i32.const", value: 1 }, // len
+      { op: "i32.const", value: 0 }, // off
+      { op: "local.get", index: CU },
+      { op: "array.new_fixed", typeIdx: strDataTypeIdx, length: 1 },
+      { op: "struct.new", typeIdx: strTypeIdx },
+    ];
+
+    // Build a 2-code-unit flat string from CU,CU2 (valid surrogate pair).
+    const twoUnit: Instr[] = [
+      { op: "i32.const", value: 2 }, // len
+      { op: "i32.const", value: 0 }, // off
+      { op: "local.get", index: CU },
+      { op: "local.get", index: CU2 },
+      { op: "array.new_fixed", typeIdx: strDataTypeIdx, length: 2 },
+      { op: "struct.new", typeIdx: strTypeIdx },
+    ];
+
+    // out = concat(out, piece); i += adv
+    const emitAppend = (piece: Instr[], adv: number): Instr[] => [
+      { op: "local.get", index: OUT },
+      ...piece,
+      { op: "call", funcIdx: concatIdx },
+      { op: "local.set", index: OUT },
+      { op: "local.get", index: I },
+      { op: "i32.const", value: adv },
+      { op: "i32.add" },
+      { op: "local.set", index: I },
+    ];
+
+    // Is CU a syntax char or solidus? (^ $ \ . * + ? ( ) [ ] { } | /)
+    const isSyntaxChar = (): Instr[] => {
+      const codes = [0x5e, 0x24, 0x5c, 0x2e, 0x2a, 0x2b, 0x3f, 0x28, 0x29, 0x5b, 0x5d, 0x7b, 0x7d, 0x7c, 0x2f];
+      const parts: Instr[] = [];
+      codes.forEach((c, idx) => {
+        parts.push({ op: "local.get", index: CU }, { op: "i32.const", value: c }, { op: "i32.eq" });
+        if (idx > 0) parts.push({ op: "i32.or" });
+      });
+      return parts;
+    };
+
+    // Is CU in the "hex-escape" set? otherPunctuators ∪ WhiteSpace ∪
+    // LineTerminator ∪ lone-surrogate (control 0x09..0x0D handled earlier).
+    // otherPunctuators: , - = < > # & ! % : ; @ ~ ' ` "
+    // WhiteSpace (Zs + special): 0x20 0xA0 0x1680 0x2000..0x200A 0x202F 0x205F 0x3000 0xFEFF
+    // LineTerminator: 0x2028 0x2029  (0x0A/0x0D are control, handled earlier)
+    // lone surrogate: 0xD800..0xDFFF
+    const isHexEscapeChar = (): Instr[] => {
+      const eqs = [
+        0x2c,
+        0x2d,
+        0x3d,
+        0x3c,
+        0x3e,
+        0x23,
+        0x26,
+        0x21,
+        0x25,
+        0x3a,
+        0x3b,
+        0x40,
+        0x7e,
+        0x27,
+        0x60,
+        0x22, // otherPunctuators
+        0x20,
+        0xa0,
+        0x1680,
+        0x202f,
+        0x205f,
+        0x3000,
+        0xfeff, // WhiteSpace singletons
+        0x2028,
+        0x2029, // LineTerminator
+      ];
+      const parts: Instr[] = [];
+      eqs.forEach((c) => {
+        parts.push({ op: "local.get", index: CU }, { op: "i32.const", value: c }, { op: "i32.eq" });
+      });
+      // 0x2000..0x200A range (general punctuation spaces)
+      parts.push(
+        { op: "local.get", index: CU },
+        { op: "i32.const", value: 0x2000 },
+        { op: "i32.ge_u" },
+        { op: "local.get", index: CU },
+        { op: "i32.const", value: 0x200a },
+        { op: "i32.le_u" },
+        { op: "i32.and" },
+      );
+      // 0xD800..0xDFFF lone surrogate range
+      parts.push(
+        { op: "local.get", index: CU },
+        { op: "i32.const", value: 0xd800 },
+        { op: "i32.ge_u" },
+        { op: "local.get", index: CU },
+        { op: "i32.const", value: 0xdfff },
+        { op: "i32.le_u" },
+        { op: "i32.and" },
+      );
+      const total = eqs.length + 2; // singletons + 2 ranges
+      for (let k = 1; k < total; k++) parts.push({ op: "i32.or" });
+      return parts;
+    };
+
+    // Per-iteration body, executed while i < len.
+    // The escape classification cascade (everything except the valid-surrogate-
+    // pair passthrough). `cu` is already loaded. Wrapped in the `else` of the
+    // pair check so a high surrogate forming a valid astral code point never
+    // reaches the lone-surrogate `\uHHHH` branch (StringToCodePoints decodes a
+    // valid pair into one >0xFFFF code point, which is in no escape set).
+    const classifyBody: Instr[] = [
+      // First code point && cu ∈ [0-9A-Za-z] → "\xHH"
+      { op: "local.get", index: I },
+      { op: "i32.eqz" },
+      // digit 0x30..0x39
+      { op: "local.get", index: CU },
+      { op: "i32.const", value: 0x30 },
+      { op: "i32.ge_u" },
+      { op: "local.get", index: CU },
+      { op: "i32.const", value: 0x39 },
+      { op: "i32.le_u" },
+      { op: "i32.and" },
+      // upper 0x41..0x5A
+      { op: "local.get", index: CU },
+      { op: "i32.const", value: 0x41 },
+      { op: "i32.ge_u" },
+      { op: "local.get", index: CU },
+      { op: "i32.const", value: 0x5a },
+      { op: "i32.le_u" },
+      { op: "i32.and" },
+      { op: "i32.or" },
+      // lower 0x61..0x7A
+      { op: "local.get", index: CU },
+      { op: "i32.const", value: 0x61 },
+      { op: "i32.ge_u" },
+      { op: "local.get", index: CU },
+      { op: "i32.const", value: 0x7a },
+      { op: "i32.le_u" },
+      { op: "i32.and" },
+      { op: "i32.or" },
+      { op: "i32.and" }, // && (i==0)
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: emitAppend(xEscape, 1),
+        else: [
+          // Syntax char / solidus → "\c"
+          ...isSyntaxChar(),
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: emitAppend(backslashEscape, 1),
+            else: [
+              // ControlEscape 0x09..0x0D → named \t \n \v \f \r
+              { op: "local.get", index: CU },
+              { op: "i32.const", value: 0x09 },
+              { op: "i32.ge_u" },
+              { op: "local.get", index: CU },
+              { op: "i32.const", value: 0x0d },
+              { op: "i32.le_u" },
+              { op: "i32.and" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  // N1 = letter: 0x09→t 0x0A→n 0x0B→v 0x0C→f 0x0D→r
+                  { op: "local.get", index: CU },
+                  { op: "i32.const", value: 0x09 },
+                  { op: "i32.eq" },
+                  {
+                    op: "if",
+                    blockType: { kind: "val", type: { kind: "i32" } },
+                    then: [{ op: "i32.const", value: 0x74 }], // t
+                    else: [
+                      { op: "local.get", index: CU },
+                      { op: "i32.const", value: 0x0a },
+                      { op: "i32.eq" },
+                      {
+                        op: "if",
+                        blockType: { kind: "val", type: { kind: "i32" } },
+                        then: [{ op: "i32.const", value: 0x6e }], // n
+                        else: [
+                          { op: "local.get", index: CU },
+                          { op: "i32.const", value: 0x0b },
+                          { op: "i32.eq" },
+                          {
+                            op: "if",
+                            blockType: { kind: "val", type: { kind: "i32" } },
+                            then: [{ op: "i32.const", value: 0x76 }], // v
+                            else: [
+                              { op: "local.get", index: CU },
+                              { op: "i32.const", value: 0x0c },
+                              { op: "i32.eq" },
+                              {
+                                op: "if",
+                                blockType: { kind: "val", type: { kind: "i32" } },
+                                then: [{ op: "i32.const", value: 0x66 }], // f
+                                else: [{ op: "i32.const", value: 0x72 }], // r (0x0D)
+                              } as Instr,
+                            ],
+                          } as Instr,
+                        ],
+                      } as Instr,
+                    ],
+                  } as Instr,
+                  { op: "local.set", index: N1 },
+                  ...emitAppend(namedCtrlEscape, 1),
+                ],
+                else: [
+                  // hex-escape set (otherPunctuators/WS/LT/lone surrogate)
+                  ...isHexEscapeChar(),
+                  {
+                    op: "if",
+                    blockType: { kind: "empty" },
+                    then: [
+                      // c ≤ 0xFF → \xHH ; else → \uHHHH
+                      { op: "local.get", index: CU },
+                      { op: "i32.const", value: 0xff },
+                      { op: "i32.le_u" },
+                      {
+                        op: "if",
+                        blockType: { kind: "empty" },
+                        then: emitAppend(xEscape, 1),
+                        else: emitAppend(uEscape, 1),
+                      } as Instr,
+                    ],
+                    // Unescaped single code unit. (Valid surrogate pairs are
+                    // handled by the outer pair check; a lone surrogate matched
+                    // the hex-escape branch above; so here cu is a plain BMP
+                    // scalar or a lone surrogate that already routed to \uHHHH.)
+                    else: emitAppend(oneUnit, 1),
+                  } as Instr,
+                ],
+              } as Instr,
+            ],
+          } as Instr,
+        ],
+      } as Instr,
+    ];
+
+    // isValidPair = cu ∈ [0xD800,0xDBFF] && i+1 < len &&
+    //               data[off+i+1] ∈ [0xDC00,0xDFFF]   (sets CU2 = next unit)
+    const loopBody: Instr[] = [
+      // cu = data[off + i]
+      { op: "local.get", index: DATA },
+      { op: "local.get", index: OFF },
+      { op: "local.get", index: I },
+      { op: "i32.add" },
+      { op: "array.get_u", typeIdx: strDataTypeIdx },
+      { op: "local.set", index: CU },
+      // high surrogate?
+      { op: "local.get", index: CU },
+      { op: "i32.const", value: 0xd800 },
+      { op: "i32.ge_u" },
+      { op: "local.get", index: CU },
+      { op: "i32.const", value: 0xdbff },
+      { op: "i32.le_u" },
+      { op: "i32.and" },
+      // && i+1 < len
+      { op: "local.get", index: I },
+      { op: "i32.const", value: 1 },
+      { op: "i32.add" },
+      { op: "local.get", index: LEN },
+      { op: "i32.lt_u" },
+      { op: "i32.and" },
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: [
+          // cu2 = data[off+i+1]; check it is a low surrogate
+          { op: "local.get", index: DATA },
+          { op: "local.get", index: OFF },
+          { op: "local.get", index: I },
+          { op: "i32.add" },
+          { op: "i32.const", value: 1 },
+          { op: "i32.add" },
+          { op: "array.get_u", typeIdx: strDataTypeIdx },
+          { op: "local.tee", index: CU2 },
+          { op: "i32.const", value: 0xdc00 },
+          { op: "i32.ge_u" },
+          { op: "local.get", index: CU2 },
+          { op: "i32.const", value: 0xdfff },
+          { op: "i32.le_u" },
+          { op: "i32.and" },
+        ],
+        else: [{ op: "i32.const", value: 0 }],
+      } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: emitAppend(twoUnit, 2), // valid astral pair → passthrough
+        else: classifyBody,
+      } as Instr,
+    ];
+
+    const body: Instr[] = [
+      // flat = flatten(s)
+      { op: "local.get", index: 0 },
+      { op: "call", funcIdx: flattenIdx },
+      { op: "local.set", index: FLAT },
+      // data = flat.data ; off = flat.off ; len = flat.len
+      { op: "local.get", index: FLAT },
+      { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 2 },
+      { op: "local.set", index: DATA },
+      { op: "local.get", index: FLAT },
+      { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 1 },
+      { op: "local.set", index: OFF },
+      { op: "local.get", index: FLAT },
+      { op: "struct.get", typeIdx: strTypeIdx, fieldIdx: 0 },
+      { op: "local.set", index: LEN },
+      // out = "" (empty NativeString)
+      { op: "i32.const", value: 0 },
+      { op: "i32.const", value: 0 },
+      { op: "i32.const", value: 0 },
+      { op: "array.new_default", typeIdx: strDataTypeIdx },
+      { op: "struct.new", typeIdx: strTypeIdx },
+      { op: "local.set", index: OUT },
+      // i = 0
+      { op: "i32.const", value: 0 },
+      { op: "local.set", index: I },
+      // while (i < len) { loopBody }
+      {
+        op: "block",
+        blockType: { kind: "empty" },
+        body: [
+          {
+            op: "loop",
+            blockType: { kind: "empty" },
+            body: [
+              { op: "local.get", index: I },
+              { op: "local.get", index: LEN },
+              { op: "i32.ge_u" },
+              { op: "br_if", depth: 1 },
+              ...loopBody,
+              { op: "br", depth: 0 },
+            ],
+          } as Instr,
+        ],
+      } as Instr,
+      // return out
+      { op: "local.get", index: OUT },
+    ];
+
+    ctx.mod.functions.push({
+      name: "__regex_escape",
+      typeIdx,
+      locals: [
+        { name: "flat", type: flatStrRef },
+        { name: "data", type: strDataRef },
+        { name: "off", type: { kind: "i32" } },
+        { name: "len", type: { kind: "i32" } },
+        { name: "i", type: { kind: "i32" } },
+        { name: "out", type: strRef },
+        { name: "cu", type: { kind: "i32" } },
+        { name: "cu2", type: { kind: "i32" } },
+        { name: "n0", type: { kind: "i32" } },
+        { name: "n1", type: { kind: "i32" } },
+      ],
+      body: wrapBodyWithFlatten(body, []),
+      exported: false,
+    });
+  }
 }
 
 /**

--- a/tests/issue-2590.test.ts
+++ b/tests/issue-2590.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.ts";
+
+// #2590 — standalone `RegExp.escape(s)` static method (ES2025 §22.2.5 /
+// EncodeForRegExpEscape). Pure Wasm native string transform — no regex engine,
+// no `env::__get_builtin` host import. Routed through the native `__regex_escape`
+// helper in src/codegen/native-strings.ts, dispatched in
+// src/codegen/expressions/calls.ts next to Number.isNaN / Object.is.
+//
+// We assert via the SAME `isSameValue(a: any, b: any)` shape the test262 harness
+// uses (`assert.sameValue` lowers to it): both args are `any` → compared by the
+// §7.2.15 SameValue value-equality helper, the path the conformance suite hits.
+
+// The harness `isSameValue` compares native strings by value, not reference.
+const HARNESS = `
+function isSameValue(a: any, b: any): number {
+  if (a === b) { return 1; }
+  if (a !== a && b !== b) { return 1; }
+  return 0;
+}
+`;
+
+async function escEquals(inputSrc: string, expectedSrc: string): Promise<{ eq: number; leaked: boolean }> {
+  const src = `${HARNESS}\nexport function test(): number { return isSameValue(RegExp.escape(${inputSrc}), ${expectedSrc}); }`;
+  const r = await compile(src, { target: "standalone", skipSemanticDiagnostics: true } as never);
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  const leaked = r.imports.some((i) => i.name.includes("__get_builtin"));
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const eq = (instance.exports as { test(): number }).test();
+  return { eq, leaked };
+}
+
+// Compile a `RegExp.escape(<non-string-literal>)` call inside a try/catch and
+// return whether it threw at runtime (matches non-string-inputs.js).
+async function escThrows(argSrc: string): Promise<{ threw: number; leaked: boolean }> {
+  const src = `export function test(): number { try { RegExp.escape(${argSrc}); return 0; } catch (e) { return 1; } }`;
+  const r = await compile(src, { target: "standalone", skipSemanticDiagnostics: true } as never);
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  const leaked = r.imports.some((i) => i.name.includes("__get_builtin"));
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const threw = (instance.exports as { test(): number }).test();
+  return { threw, leaked };
+}
+
+describe("#2590 standalone RegExp.escape", () => {
+  // [name, input source, expected escaped source] — input/expected are TS string
+  // literal source, doubly-escaped for the embedded compiler source.
+  const cases: Array<[string, string, string]> = [
+    ["leading alnum + syntax dot", '"a.b"', '"\\\\x61\\\\.b"'],
+    ["parens", '"(x)"', '"\\\\(x\\\\)"'],
+    ["empty string", '""', '""'],
+    [
+      "all syntax characters",
+      '"^$\\\\.*+?()[]{}|"',
+      '"\\\\^\\\\$\\\\\\\\\\\\.\\\\*\\\\+\\\\?\\\\(\\\\)\\\\[\\\\]\\\\{\\\\}\\\\|"',
+    ],
+    ["solidus", '"/"', '"\\\\/"'],
+    ["control escapes", '"\\t\\n\\v\\f\\r"', '"\\\\t\\\\n\\\\v\\\\f\\\\r"'],
+    [
+      "other punctuators",
+      '",-=<>#&!%:;@~\\u0027\\u0060\\""',
+      '"\\\\x2c\\\\x2d\\\\x3d\\\\x3c\\\\x3e\\\\x23\\\\x26\\\\x21\\\\x25\\\\x3a\\\\x3b\\\\x40\\\\x7e\\\\x27\\\\x60\\\\x22"',
+    ],
+    ["initial digit", '"1111"', '"\\\\x31111"'],
+    ["initial ascii letter a", '"aaa"', '"\\\\x61aa"'],
+    ["initial letter j (hex 6a)", '"jjj"', '"\\\\x6ajj"'],
+    ["initial Z + special", '"Z*Z"', '"\\\\x5a\\\\*Z"'],
+    ["mid-string alnum not escaped", '".a1b2c3D4E5F6"', '"\\\\.a1b2c3D4E5F6"'],
+    ["whitespace space", '"\\u0020"', '"\\\\x20"'],
+    ["whitespace nbsp", '"\\u00A0"', '"\\\\xa0"'],
+    ["whitespace ZWNBSP", '"\\uFEFF"', '"\\\\ufeff"'],
+    ["whitespace narrow nbsp", '"\\u202F"', '"\\\\u202f"'],
+    ["whitespace combined", '"\\uFEFF\\u0020\\u00A0\\u202F"', '"\\\\ufeff\\\\x20\\\\xa0\\\\u202f"'],
+    ["line terminator LS", '"\\u2028"', '"\\\\u2028"'],
+    ["line terminator PS", '"\\u2029"', '"\\\\u2029"'],
+    ["lone high surrogate", '"\\uD800"', '"\\\\ud800"'],
+    ["lone low surrogate", '"\\uDFFF"', '"\\\\udfff"'],
+    ["valid astral pair passthrough", '"\\uD83D\\uDE00"', '"\\uD83D\\uDE00"'],
+    ["valid pair D800DC00 passthrough", '"\\uD800\\uDC00"', '"\\uD800\\uDC00"'],
+    ["non-ascii passthrough", '"你好"', '"你好"'],
+    ["greek with space", '"Γειά σου"', '"Γειά\\\\x20σου"'],
+    ["korean with bang", '"안녕!"', '"안녕\\\\x21"'],
+    ["mixed ascii + U+D7FF (non-surrogate)", '".hello\\uD7FFworld"', '"\\\\.hello\\uD7FFworld"'],
+  ];
+
+  for (const [name, inputSrc, expectedSrc] of cases) {
+    it(name, async () => {
+      const { eq, leaked } = await escEquals(inputSrc, expectedSrc);
+      expect(leaked, "must not leak env::__get_builtin").toBe(false);
+      expect(eq).toBe(1);
+    });
+  }
+
+  it("non-string literal argument throws (TypeError, §22.2.5 step 1)", async () => {
+    for (const arg of ["123", "true", "null", "undefined"]) {
+      const { threw, leaked } = await escThrows(arg);
+      expect(leaked, `must not leak env::__get_builtin for ${arg}`).toBe(false);
+      expect(threw, `RegExp.escape(${arg}) must throw`).toBe(1);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements ES2025 `RegExp.escape(str)` (§22.2.5 / EncodeForRegExpEscape) for
`--target standalone` as a **pure-Wasm native string transform** — no regex
engine, no host import. On current main, `RegExp.escape(...)` leaked the dynamic
`env::__get_builtin` host import in standalone, so the binary failed to
instantiate; this routes it to a native helper before the `__get_builtin`
fallthrough so a standalone binary instantiates with an **empty importObject**.

Slice of umbrella #2161 (substrate-independent — pure string transform, no
value-rep / regex-engine involvement).

## Changes

- **`src/codegen/native-strings.ts`** — new `__regex_escape(s: ref $AnyString)
  -> ref $AnyString` helper, registered at the end of `ensureNativeStringHelpers`
  (same late-import-shift reconciliation domain as its `__str_concat` /
  `__str_flatten` call targets). Flattens the input, iterates UTF-16 code units,
  builds output with `__str_concat` over per-character flat pieces
  (`array.new_fixed` + `struct.new $NativeString`). Implements
  EncodeForRegExpEscape exactly:
  - first code point `[0-9A-Za-z]` → `\xHH`;
  - syntax chars `^ $ \ . * + ? ( ) [ ] { } |` + solidus `/` → `\c`;
  - ControlEscape `\t \n \v \f \r`;
  - otherPunctuators / WhiteSpace / LineTerminator / lone surrogate → `\xHH`
    (c ≤ 0xFF) or `\uHHHH`;
  - a **valid surrogate pair** (decoded to a >0xFFFF code point by
    StringToCodePoints) passes through unescaped — detected *before* the
    lone-surrogate classification so it is never double-`\u`-escaped.
- **`src/codegen/expressions/calls.ts`** — `RegExp.escape(s)` dispatch placed
  right after the `Math.*` block (before the generic builtin-member /
  `__get_builtin` fallthrough), gated on `ctx.standalone` + `ctx.nativeStrings`
  + `isGlobalRegExpIdentifier`. A statically `string`-typed arg compiles to a
  native string + calls `__regex_escape`; a statically non-string literal throws
  a catchable `TypeError` (§22.2.5 step 1); an `any`/`unknown` arg narrow-refuses.
- **`tests/issue-2590.test.ts`** — 28 scoped standalone tests.

## Validation

- `tests/issue-2590.test.ts` — **28/28 pass** under `target: "standalone"`,
  byte-for-byte via the test262 `isSameValue(a: any, b: any)` shape. Covers every
  escape category from the test262 `escaped-*` files (syntax / control /
  otherpunctuators / whitespace / lineterminator / surrogates /
  utf16encodecodepoint / initial-char / not-escaped) + the non-string `TypeError`
  path. Each case asserts **no `env::__get_builtin` leak** and instantiation with `{}`.
- Scoped gates green: `tsc`, `prettier --check`, `check:coercion-sites`,
  `check:ir-fallbacks`, `check:issue-ids`.

Estimated test262 rows recovered: ~25 (escape dir behavior tests + AnnexB
`RegExp-*-escape`). Residual (out of scope): the metadata reflection tests
(`is-function`, `length`, `name`, `prop-desc`, `not-a-constructor`) need
`RegExp.escape` as a reflectable runtime function object, which standalone
compile-time dispatch does not expose.

Closes #2590.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA