### PR TITLE
chore(memory): session learnings (#2602, #2580 M1a/M2, #2542/#2571, standalone shard)

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -28,6 +28,7 @@
 - [project_bigint_i64_brand_gate.md](project_bigint_i64_brand_gate.md) — #1349/#1644 BigInt fixes gated on architect i64-bigint-brand ValType decision; not a dev codegen guard
 - [project_linear_backend_no_console_log.md](project_linear_backend_no_console_log.md) — Linear backend (target:"linear", non-WASI) drops console.log; it's return-value-oriented — cross-backend/diff tests must assert return values, not stdout (#1854)
 - [project_proxy_no_ts_type_brand.md](project_proxy_no_ts_type_brand.md) — A JS Proxy carries no TS-type brand (types as its target); never static-classify a possibly-proxy receiver — detect syntactically + defer to host (#2501 proxy-revoked regression)
+- [project_2602_forawait_rest_aliases_source_recompile.md](project_2602_forawait_rest_aliases_source_recompile.md) — #2602: for-await array-rest `y` aliases the SOURCE array under a fresh compileExpression (recompile→source len 3, not rest slice 2); blocks #2580 M2 slice 1; async-lane local-versioning, not substrate — recompiling an identifier ≠ its live local in the async state machine
 
 ### Team & agents (rules not in plan/method/team-setup.md)
 - [feedback_architect_worktree_isolation.md](feedback_architect_worktree_isolation.md) — Always spawn architects with isolation:worktree — they stall and request respawn without it

--- a/.claude/memory/feedback_quality_job_subgates_prettier_coercion.md
+++ b/.claude/memory/feedback_quality_job_subgates_prettier_coercion.md
@@ -1,0 +1,17 @@
+---
+name: feedback_quality_job_subgates_prettier_coercion
+description: "The CI `quality` job runs sub-gates (prettier format:check + #2108 coercion-drift) a scoped local test never triggers — pre-check both before pushing codegen"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 75ffdde9-6b72-447e-992f-f6b025616c19
+---
+
+The required CI `quality` job bundles several sub-gates beyond tsc/lint that a scoped local compile-and-run check NEVER surfaces. Two bit me in sequence on one #2575 PR (#1865), costing two CI round-trips:
+
+1. **prettier `format:check`** (NOT biome — see [[project_prettier_not_biome_write]]): long single-line test expectations fail. Fix: `npx prettier --write 'src/**/*.ts' 'tests/**/*.ts'`.
+2. **#2108 coercion-site drift gate** (`scripts/check-coercion-sites.mjs`): counts uses of the sealed coercion vocabulary (`number_toString`, `__to_primitive`, `__extern_toString`, `__to_boolean`, …) OUTSIDE the engine, baseline-per-file. A new codegen site that legitimately REUSES an engine helper (e.g. calling native `number_toString` to ToString an array index) still trips it as growth. It even counts the token in COMMENTS. Minimize to the irreducible string-literal reference (a `const NAME = "number_toString"` + rephrase prose comments to drop the literal token), then refresh: `node scripts/check-coercion-sites.mjs --update` and commit `scripts/coercion-sites-baseline.json`.
+
+**Why:** "compiles + my test passes" ≠ "quality gate passes". The quality job is the same `quality` required check the merge queue enforces; its sub-gates are orthogonal to test logic, so a green scoped local run says nothing about them.
+
+**How to apply:** before pushing ANY codegen/test change, run locally in the worktree: `npx tsc --noEmit`, `npx prettier --check '<changed files>'`, `node scripts/check-coercion-sites.mjs`, and `node scripts/check-test262-hard-errors.mjs`. If the coercion gate flags a legitimate engine reuse, minimize the footprint then `--update` the baseline (it's the sanctioned path the gate message itself points to). See [[feedback_verify_gates_against_committed_tree]] for the verify-against-committed-tree discipline.

--- a/.claude/memory/project_2542_index_signature_open_object_routing.md
+++ b/.claude/memory/project_2542_index_signature_open_object_routing.md
@@ -1,0 +1,39 @@
+---
+name: project_2542_index_signature_open_object_routing
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 75ffdde9-6b72-447e-992f-f6b025616c19
+---
+
+#2542 (MERGED, PR #1830): standalone `o[k]` read/write by a runtime string key
+returned 0 / dropped for **index-signature objects** (`{ [s: string]: T }`).
+
+Root cause was a REPRESENTATION mismatch, not a missing runtime. The native
+open-`$Object` machinery (`__new_plain_object`/`__extern_get`/`__extern_set`/
+`__obj_find`, all defined Wasm fns, zero host imports) already does string-keyed
+[[Get]]/[[Set]]. But (1) an index-sig literal `{a:5,b:7}` built a CLOSED nominal
+struct (`__extern_get`'s `ref.test $Object` can't match it → read 0); (2) the
+index-sig TYPE has empty `getProperties()` so it resolved to an EMPTY struct →
+param/return guard-cast to null.
+
+Fix (3 `ctx.standalone`-scoped routing changes, mirrors #1901's open-`$Object`
+route): a PURE string-index-signature type (no own named props — anonymous,
+type-alias, OR interface) routes to the open `$Object`:
+- `literals.ts compileObjectLiteral`: extend the #1901 non-empty gate + the
+  empty-`{}` `__new_plain_object` arm to fire on a `getIndexInfoOfType(ctxType,
+  ts.IndexKind.String)` contextual type with 0 own props.
+- `index.ts resolveWasmType`: such a type → externref, placed BEFORE the
+  named-struct lookup (so a pure-index-sig *interface*, already registered as an
+  empty struct by `collectInterface`, still resolves to externref — the empty
+  struct stays registered but is never used as a value type, so NO type-index
+  shift).
+- `index.ts ensureStructForType`: skip registering it as an empty struct.
+
+A MIXED `{ a: number; [s: string]: T }` (own named props) is EXCLUDED — it keeps
+its concrete struct (static shape consumers read by field). gc/host/wasi
+byte-identical. See [[project_standalone_any_string_value_read_substrate]].
+
+Still-open sibling: an `any`-typed empty `{}` then dynamic write
+(`const o:any={}; o.x=9`) does NOT persist — a separate empty-`{}` open-object
+gap that `hasOwnProperty` shares; out of #2542 scope.

--- a/.claude/memory/project_2571_native_method_generator_this_as_param.md
+++ b/.claude/memory/project_2571_native_method_generator_this_as_param.md
@@ -1,0 +1,58 @@
+---
+name: project_2571_native_method_generator_this_as_param
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 75ffdde9-6b72-447e-992f-f6b025616c19
+---
+
+#2571 (PR #1872): class generator methods (`class C { *m(){ yield … } }`) leaked
+the eager-buffer host generator runtime (`__gen_*`) → validate-but-can't-
+instantiate standalone. Free `function*` was already native.
+
+**Key technique — `this` is just a leading param.** The native generator state
+machine (`src/codegen/generators-native.ts`, #1665/#2170/#2171) already persists
+params in the state struct (`param_<name>` fields after the 4-word header) and
+rehydrates them as named locals in the resume function. So an instance method
+generator threads its receiver as a synthetic leading param named `"this"`
+(`param_this` field) — then `this.x` reads resolve via the existing
+`localMap.get("this")` with **no new state-struct field kind**. Static methods
+have no receiver (no synthetic param). The `.next()/.return()/.throw()` dispatch
+is already representation-agnostic — the entire gap is the factory side.
+
+Implementation (3 sites): `isNativeGeneratorCandidate` widened to
+`GeneratorDecl = FunctionDeclaration | MethodDeclaration` (THE single source of
+truth — `registerNativeGenerator` AND `sourceNeedsGeneratorHostImports` both
+consult it). `registerNativeGenerator` gains `synthesizedThis` (prepends `"this"`
+to `paramNames`, caller passes `paramTypes=[receiverType,...]`). The factory
+`compileNativeGeneratorFunction` must read `info.paramTypes.length` params (NOT
+`decl.parameters.length`) so the synthetic `this` at wasm param 0 lands in
+`param_this`. `class-bodies.ts` collection pass registers the native generator
+(under `classMemberFuncKey`, `synthesizedThis=!isStatic`) and sets the method
+result type to the `$GenState_*` ref (mirrors `declarations.ts:2499`).
+
+**#2581 (PR #1873) extended this to OBJECT-LITERAL method generators**
+(`const o = { *m(){} }`). Surprise: it was simple, NOT the feared
+closures.ts/`__current_this` rework. The object-literal method **body func ALSO
+leads with a `this` struct param** (`methodFctxParams[0] = (ref structTypeIdx)`,
+literals.ts) — the `__current_this` is only the *trampoline*'s receiver
+resolution; the underlying body func has the struct param. So the same
+synthetic-`this` model + closure trampoline carrying the `$GenState` ref worked
+directly. Fix: candidate-gate admits `ts.isObjectLiteralExpression(decl.parent)`;
+literals.ts registers the native gen at the method collection site keyed by the
+per-literal func identity (`${fullName}__lit${forkIdx}` when a
+`literalMethodFuncIdx` fork exists, so forked siblings get distinct `$GenState`s)
+and routes the body emit through the factory. NOTE: two SAME-NAME same-shape
+object literals dedup to one method func (last body wins) — pre-existing, identical
+for non-generators; not a generator bug.
+
+**A method bails to host** (keeps the eager-buffer path, valid Wasm) when:
+computed/string name, parent is NEITHER class NOR object-literal, reads
+`arguments`, uses `super.*`, or CAPTURES an enclosing binding (#2203 — no capture
+slot). Put ALL these bail conditions IN the candidate gate so registration +
+host-import gating agree — a mismatch (un-forcing host for a method you don't
+route native) bakes an undefined funcidx → invalid wasm.
+
+All guards `(ctx.standalone || ctx.wasi)`-gated → gc/host byte-identical. Broad-
+impact (generator lowering + host-import gating) → validate via merge_group, not
+a scoped sweep. See [[project_standalone_shard_eject_stale_base_first]].

--- a/.claude/memory/project_2580_m1a_length_reftest_dispatch.md
+++ b/.claude/memory/project_2580_m1a_length_reftest_dispatch.md
@@ -1,0 +1,164 @@
+---
+name: project_2580_m1a_length_reftest_dispatch
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 75ffdde9-6b72-447e-992f-f6b025616c19
+---
+
+#2580 M1a (`.length` on an `any`/`unknown` receiver, HOST mode). **OUTCOME
+(merged f6e7aa852, PR #1894): landed as OPTION C — M0 scaffold only, host
+`.length`-on-any arm OFF.** The uniform-externref arm (described below) was the
+first attempt; it ejected from the merge_group and a faithful test262 runner
+proved the value-semantics is NOT a surgical M1 slice — see the "FINAL VERDICT"
+section. The landed M1a = `emitDynGet`/`ensureDynReadHelpers` + the closure-base
+helper REGISTERED + INERT (the arm is off; nothing calls `emitDynGet` in src), for
+M2 to build the `$AnyValue`-tag-aware reader into. The value-semantics fix moved to
+M2. The rest of this note documents the arm design + why it can't ship as M1.
+
+**Three load-bearing facts (each cost a wrong attempt):**
+
+1. **Position AFTER the vec-struct detection, not before.** An `any` local
+   holding a real array (`const o: any = [1,2,3]`) is an externref wrapping a
+   WasmGC vec; origin already reads its `.length` correctly via a generic
+   externref reader. Folding the dyn-read arm AHEAD of the length-bearing-vec
+   detection forced every array through `__extern_get(vec,"length")`, which the
+   host evaluates to `undefined` (V8 sees an opaque struct). So the arm lives in
+   the `savedLen` fallback block — fires only when the compiled receiver is NOT a
+   `{length,data}` vec struct (the genuinely non-vec dynamic receiver).
+
+2. **Dispatch with `ref.test` over `ctx.vecTypeMap`, NOT a `call __dyn_get`/
+   `__is_vec`.** For the `length` key, `emitDynGet` emits an if/else chain:
+   `ref.test $vec_i → box_number(f64(struct.get $vec_i 0))` on a vec hit (the
+   array length), else `__extern_get(recv,"length")` (value or undefined).
+   `ref.test typeIdx` uses TYPE indices, which are append-only / dead-elim-stable
+   (the rec-group), so it carries NO funcidx-ordering / late-import-shift hazard.
+   A defined-func wrapper (`call __dyn_get`) was the original blocker: its index
+   FLOATS when a value-consumer adds a late import after the `call` is baked,
+   landing on the adjacent helper (the #2043 class). `__extern_get` +
+   `__box_number` are host IMPORTS (stable); ensure BOTH up-front before
+   resolving any baked index. This `ref.test`-over-vecTypeMap pattern is the
+   funcidx-safe substrate primitive — reuse it for M2/M3 dynamic reads.
+
+3. **Uniform-externref result coerces for free — no M1b consumer pass needed.**
+   The arm returns `{kind:"externref"}` (boxed number / JS undefined). The (a2)
+   "chokepoint refactor" the M1 verdict feared was UNNECESSARY:
+   `compilePropertyAccess` IS already the `.length` chokepoint, and the existing
+   externref→f64 coercion (`__unbox_number`) handles ALL consumers — `+`/`*`/`<`/
+   `for`-bound/`=== undefined` (presence arm)/`typeof`/`String()`/truthiness all
+   correct, verified. Parallel-safe vs the tag-5 classifier wave (#1888/#1864):
+   `=== undefined` + numeric arms are disjoint from their content classifier.
+
+Standalone is unchanged (routes through the `__dyn_get` wrapper, correct there
+because `__extern_get` is a defined native helper). See
+[[project_standalone_any_string_value_read_substrate]] for the standalone reader.
+
+**Process trap:** `git commit --amend` after `prettier --write` can silently drop
+the format fix if the file was staged pre-format — the `quality` job's Format
+check runs the full glob. ALWAYS verify `git show HEAD:<file> | prettier --check`
+passes BEFORE pushing, not just the working tree.
+
+**v1 MERGE_GROUP EJECT (PR #1894, 13 regr) + the v2 fix.** v1 (the vecTypeMap
+dispatch above) passed all PR checks + all 117 merge_group shards but the
+merge_group **net-regression gate** ejected it: 13 regressions, all
+`assertion_fail`, wasm-hash-change, 0 improvements (fails net AND ratio);
+`auto-park` set `hold`. ALL PR-level checks green does NOT clear the merge_group
+net-guard — value-rep/chokepoint changes MUST be validated by merge_group (or full
+local-ci), never a scoped sweep (the scoped 13-case suite missed all 13). To find
+the exact regressed tests: pull the `test262-merged-report` artifact from the
+failed merge_group run + diff its JSONL vs the fetched baseline JSONL on
+`file`+`status`. The 13 = TWO clusters, ONE root cause: the `any|unknown` gate is
+TOO BROAD — the arm fired on (A) closure `.length` (arity: `(fn as any).length` →
+NaN, origin gave 0) and (B) `for ([x,...y] of); y.length` (rest binding is a
+boxed/wrapped externref, vec-test misses, `__extern_get`→undefined→NaN; origin
+gave the count). Both = "any boxed/wrapped NON-plain-object receiver" the prior
+numeric path read right.
+**v2 fix = DECLINE-FOR-STRUCT (option 3).** A positive `$Object` gate (the first
+idea) is NOT viable in host mode: `objectTypeIdx` only exists via
+`ensureObjectRuntime`, which registers `$PropEntry` with `key: ref $anyStrTypeIdx`
+(host `anyStrTypeIdx = -1` → crash); and host plain `{}` is NOT a WasmGC `$Object`
+struct — it's a host JS externref, nothing to `ref.test`. So instead: the dyn-read
+`.length` arm DECLINES (return false → caller's prior numeric `.length` path) when
+the receiver `ref.test`s as a VEC or a CLOSURE base type
+(`collectClosureBaseWrapperTypeIdxs(ctx)`); fires `__extern_get(recv,"length")`
+ONLY for the residual genuine host externref. array→decline→prior vec field-0 ✓;
+`{}`→struct-miss→`__extern_get`→undefined ✓ (canary); closure→decline→0 ✓ (A);
+rest-binding(vec)→decline→count ✓ (B). SIMPLER than v1 — drops the box-number vec
+arm (the prior path already reads array `.length` right). Validate against the REAL
+async-gen rest test262 file (reduced `for([x,...y]of)` probe is unfaithful — origin
+also returns 0 there).
+
+**v2 implemented = Cluster A only; Cluster B is a deeper `$AnyValue` problem.**
+The decline-for-struct idea was implemented as a CLOSURE arm (`ref.test` closure
+base types → `box_number(0)` arity fallback; closure base types derived inline
+from `ctx.closureInfoByTypeIdx` to dodge a circular import on index.ts). That
+FIXES Cluster A (5/13) and is committed. But Cluster B (8 for-await array-rest
+`.length`) is NOT a closure and NOT a bare vec: the async-generator rest binding
+`y` is an **`$AnyValue`-BOXED vec** (tag 6 = GC ref wrapping the vec,
+`ctx.anyValueTypeIdx`). The arm's `any.convert_extern` + `ref.test $vec` MISSES the
+`$AnyValue` wrapper → `__extern_get(y,"length")` → undefined → NaN, where origin's
+generic path returned the count. Fixing B requires UNWRAPPING `$AnyValue` (tag-6
+field extract) BEFORE the vec `ref.test` — a real deepening into `$AnyValue`
+internals (the M2/M3 dynamic-read primitive anyway). **Cluster B cannot be
+reproduced with reduced probes** — `for([x,...y]of)` and hand-rolled async-gen
+probes return 0 on BOTH origin and the branch, yet the real test262 passes on
+origin; it needs the full async-iteration test262 harness (merge_group / full
+local-ci).
+
+**FINAL VERDICT (faithful runner) — M1a `.length`-on-any value-semantics is NOT a
+surgical slice; it needs M2's tag-aware reader.** Build a faithful local gate by
+calling the REAL `runTest262File` (tests/test262-runner.ts) on the regressed files
+directly (a `.tmp/run13.mjs` that imports it) — reduced `compile()`+probe shapes
+repeatedly LIED here (a user closure ≠ a host builtin; `for([x,...y]of)` ≠ the
+async-gen harness). The faithful runner proved: **arm OFF → 12/13 pass** (zero
+regression = origin; the 13th skips on Temporal), and NO surgical narrowing
+recovers the canary while reverting the 13 — closure-arm, receiver-`ref.is_null`
+guard, and decline-for-struct all leave 0/13. Root cause = TOTAL ENTANGLEMENT:
+every one of the 13 reaches `__extern_get(recv,"length")` → undefined → NaN where
+the prior numeric path returned a usable value (0 via `__extern_length`'s
+null-guard, or the real count), and the canary (`{}.length` → undefined) needs that
+SAME `__extern_get`-undefined result to stay undefined. A non-null `{}` lacking
+`length` and a non-null wrapped builtin/rest-binding are the SAME externref shape —
+no `ref.test`/`ref.is_null`/`__extern_has` predicate separates them. Only a
+TAG-AWARE reader (inspecting the boxed `$AnyValue` tag, M2's job) can disambiguate,
+because the distinction lives in the box, not in a bare-externref runtime test.
+Recommended resolution: **turn the arm OFF (option c)** — canary reverts to the
+PRE-EXISTING #2580 bug (not a new regression), M0 stays inert, zero regression;
+move the `{}.length`→undefined fix into M2. Lesson: a "canary" that's
+statically-`any`-erased can be runtime-indistinguishable from the very cases it
+must not touch — validate value-semantics slices against the REAL test262 runner
+before believing reduced probes.
+
+## M2 slice 1 (2026-06-22) — the M1a "total entanglement" was WRONG; the 13 split
+
+The M1a "no predicate separates them" verdict above was incomplete. M2 slice 1
+re-diagnosed each of the 13 against the faithful runner and found TWO separable
+clusters + a fix for the canary:
+
+- **The canary `{}` is a tag-5 HOST EXTERNREF** (via `__new_plain_object`), NOT
+  `$AnyValue`-boxed. The host `__extern_get({}, "length")` → undefined CORRECTLY.
+  So the canary needs no tag-reader — it works through the host's own knowledge.
+- **Cluster A (5 `length.js`)**: the RECEIVER itself resolves to **undefined**
+  (`IteratorProto[Symbol.iterator]` → undefined — a separate Symbol-prototype-walk
+  gap), so `.length` on undefined → `__extern_get(undefined,"length")` → NaN;
+  origin null-guards to 0 (matching `verifyProperty {value:0}`). **FIXED** by a
+  null-guard in the reader: `__extern_is_undefined(recv) → box_number(0)`. The
+  distinguisher is `__extern_is_undefined` — **NOT `ref.is_null`**, because a JS
+  `undefined` is a NON-null externref wrapping the host undefined sentinel (that is
+  exactly why M1's `ref.is_null` guard left Cluster A at 0/13). `{} == null` →
+  false, `undefined-receiver == null` → true — so the null-guard separates the
+  canary from Cluster A.
+- **Cluster B (8 for-await array-rest)** is NOT a reader gap — it's an
+  **async-state-machine local-versioning bug** the arm EXPOSES: the arm's
+  `compileExpression(y)` recompiles the rest binding and gets the SOURCE array (a
+  vec whose field-0 = source length 3), while origin's local-type arm
+  (property-access.ts ~3527) reads `y`'s CURRENT local (the rest slice, length 2).
+  Sync `[x,...y]` reads 2 correctly; only the async `for await` form aliases the
+  source. `decline-for-vec` is safe (origin reads array-as-any=3 AND async-rest=2
+  right) but origin's correct async-rest read (its local resolution) is unreachable
+  from the arm post-rollback — `{}` and async-rest-`y` both compile to externref
+  (no compile-time separator), and a runtime `ref.test`-vec's vec-branch can only
+  `struct.get` field-0 (=3, the wrong source). So slice 1 lands canary + Cluster A;
+  Cluster B is an orthogonal async-desugaring fix. WIP at `issue-2580-m2s1-reader`
+  commit `b77a1c520` (not pushed). `.tmp/run13.mjs` (real `runTest262File`) is the
+  reusable gate.

--- a/.claude/memory/project_2602_forawait_rest_aliases_source_recompile.md
+++ b/.claude/memory/project_2602_forawait_rest_aliases_source_recompile.md
@@ -1,0 +1,48 @@
+---
+name: project_2602_forawait_rest_aliases_source_recompile
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 75ffdde9-6b72-447e-992f-f6b025616c19
+---
+
+#2602 (discovered by #2580 M2 slice 1): in `for await ([x, ...y] of [[1,2,3]])`,
+a **fresh `compileExpression(y)`** (e.g. the `.length`-on-any reader's speculative
+compile in the property-access `savedLen` block) resolves the **SOURCE array**
+(a raw vec, field-0 = source length 3), NOT the rest slice `[2,3]` (length 2).
+Origin reads `y` = 2 because its `compileExpression(y)` at a *different* point in
+the flow gets the rest-slice local; the async state machine leaves the source as a
+live SSA value that a later recompile picks up. **Proven exhaustively**: every read
+of the receiver my arm gets — `struct.get` field-0, `__extern_get`, `__extern_length`
+— returns 3, because the receiver VALUE itself is the source, not the rest.
+Sync `[x, ...y] = [1,2,3]` reads 2 correctly; ONLY the async `for await` form
+aliases the source. It is an **async-lane local-versioning bug, NOT a substrate
+bug** — the #2580 dynamic-read reader merely EXPOSED it. Related: #1373b (IR async
+CPS), #1042-adjacent (async state-machine local capture).
+
+**Why it blocks #2580 M2 slice 1 (the `.length`-on-any reader):**
+- The reader fires for `any`-typed receivers. The canary `{}`, Cluster A
+  (undefined receivers), and Cluster B (async-rest `y`) are all statically
+  identical `any` identifiers — NO compile-time separator.
+- A clean decline-for-vec (route the vec receiver to origin so async-rest reads 2)
+  is structurally impossible: vec-ness is RUNTIME for `any`, and even a runtime
+  `ref.test`-vec branch that re-runs origin's read RECOMPILES `y` → the source (3)
+  again. The only thing that reads 2 is origin's flow where the speculative compile
+  is ROLLED BACK and `y` is resolved later — rollback is compile-time, vec-ness is
+  runtime, so it can't be conditionally triggered.
+- So slice 1 can NOT fire for vec-class receivers without regressing the 8
+  for-await array-rest `.length` tests, UNTIL #2602 fixes `y` to resolve to the
+  rest slice. Once #2602 lands, the arm's existing vec arm reads `y.length` = 2
+  (struct.get field-0 = 2) and slice 1 lands all-13-green.
+
+**What slice 1 DID fix (waiting behind #2602):** the canary `{}.length===undefined`
+→ true (the #2580 HEADLINE) + Cluster A (5 host-builtin-`.length` tests), via a
+null-guard `__extern_is_undefined(recv) → box_number(0)` (NOT `ref.is_null` — a JS
+`undefined` is a non-null externref). WIP at `issue-2580-m2s1-reader` (b77a1c520 +
+the #2602 issue fe93fe9bb), not pushed.
+
+**Lesson:** a speculative `compileExpression` of an *identifier* is NOT guaranteed
+to resolve the same wasm value the identifier's live local holds — in the async
+state machine they desync. Recompile-based receiver reads (the #2580 reader, and
+any future speculative-read site) must read the identifier's LOCAL by index where
+possible, or be gated until #2602. See [[project_2580_m1a_length_reftest_dispatch]].

--- a/.claude/memory/project_standalone_shard_eject_stale_base_first.md
+++ b/.claude/memory/project_standalone_shard_eject_stale_base_first.md
@@ -1,0 +1,37 @@
+---
+name: project_standalone_shard_eject_stale_base_first
+description: "A merge_group eject on \"test262 standalone shard N\" — check branch staleness vs origin/main FIRST; a stale base fails the raised standalone floor even with correct code"
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: 75ffdde9-6b72-447e-992f-f6b025616c19
+---
+
+When a PR ejects from the merge_group on a **"test262 standalone shard N"**
+failure (+ "merge shard reports"), the FIRST thing to check is how many commits
+the branch is **behind origin/main** — not the diff.
+
+Why: the standalone-floor/per-shard regression gate is raised by every push to
+main (`promote-baseline`). The merge_group tests the **speculative merge** of the
+branch onto *current* main. A branch based on an old main (e.g. 49 commits
+behind) is missing later standalone-improving PRs + baseline syncs, so its
+speculative-merged standalone pass count can fall below the **raised** floor —
+ejecting even when the branch's own change is correct. PR-level checks
+green-SKIP the heavy standalone shards, so this only ever surfaces in the
+merge_group. See [[project_standalone_floor_only_on_merge_group]].
+
+Diagnostic order:
+1. `git rev-list --count HEAD..origin/main` — if large, the eject is likely
+   stale-base drift. `git merge origin/main` (clean), re-validate, re-push.
+2. Only if still failing post-merge: bisect the actual flipped standalone test
+   (run the shard's `runTest262Chunk(N-1, 57)` with `TEST262_TARGET=standalone`)
+   and look for a real code regression.
+
+Confirm the change itself is sound with a fast targeted standalone sweep
+(`WebAssembly.validate` + value + zero host-import-leak) rather than a full
+chunk run — full chunk56 standalone is slow (10+ min) and rarely needed.
+
+Merge-queue SHAs are speculative + GC'd fast, so the exact failing test from a
+GC'd merge_group run is usually unrecoverable — reproduce locally instead.
+NEVER `git stash` in a worktree to A/B-test (shared stash stack clobbers
+concurrent agents); use a separate pristine `git worktree add <p> origin/main`.


### PR DESCRIPTION
Persists this session's agent-memory learnings to .claude/memory/ so future sessions inherit them: the #2602 for-await-rest source-aliasing root cause, the #2580 M1a reftest-dispatch + M2 reader findings, #2542/#2571 codegen notes, the standalone-shard stale-base eject lesson, and the quality-job sub-gate checklist. Docs/memory only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)