### PR TITLE
docs: lead shepherds open PRs to merge queue; agents enqueue proactively

### DIFF
--- a/.claude/skills/dev-self-merge.md
+++ b/.claude/skills/dev-self-merge.md
@@ -12,6 +12,16 @@ description: Regression self-check for a green PR. Reads CI JSON, applies the ha
 > (enqueue once, then stand down) or **ESCALATE** (to tech lead). After that one
 > enqueue the PR is handed off — the dev does NOT touch the queue again.
 >
+> **Enqueue PROACTIVELY — the moment the three required checks are green.**
+> The required checks are `cheap gate (main-ancestor + lint)`, `merge shard
+> reports`, and `quality`. Enqueue as soon as **those three** pass — do NOT wait
+> for the full equivalence-shard matrix to finish, do NOT wait for a background
+> watcher to "settle everything", and do NOT leave the enqueue to the
+> `auto-enqueue` backstop (it's sparse and only catches strays). Actively
+> enqueuing your own PR the instant it's mergeable is the dev's job; a PR that
+> sits green-but-un-enqueued is a process failure. The tech lead also sweeps +
+> enqueues green PRs every loop (see CLAUDE.md "Tech lead discipline").
+>
 > **Enqueue EXACTLY ONCE — never re-enqueue.** The `auto-enqueue.yml` backstop
 > (App-token bot identity, sweeps green PRs on every CI completion + ~30-min
 > cron) owns ALL re-adds for any PR that strands, drifts, or gets ejected; the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,6 +282,7 @@ End of sprint:
 - Batch doc/plan commits on main AFTER all pending agent merges, not between them (doc commits force agents to re-merge main)
 - Complete post-merge issue cleanup (set `status: done` in sprint dir issue file, update dep graph) after each merge
 - **Tag sprints**: `git tag sprint-N/begin` when starting a sprint, `git tag sprint/N` when it finishes. Sprint stats (duration, commits, issues) are auto-generated from tags during `build:pages`.
+- **ALWAYS shepherd the open PRs to the merge queue every loop — the `auto-enqueue` cron is a BACKSTOP, not the primary.** Sweep `gh pr list -R loopdive/js2wasm --state open` and **one-shot enqueue every CLEAN, non-`hold`, non-draft PR not already in the queue** (GraphQL `enqueuePullRequest`, **user PAT**, NEVER re-enqueue — loop hazard, see `project_merge_queue_requeue_cancels_run`). A green PR must never sit idle waiting for the sparse ~30-min backstop cron — the lead drives it to merged. **Held (`hold` label) or CI-failing / `BEHIND` / `DIRTY` PRs → add a high-priority `[CI-FIX]` task at the TOP of the TaskList** for the next dev to rebase/fix the gate failure (with full PR context) and re-enqueue. Both the lead AND the authoring agent actively enqueue; the backstop only catches strays.
 
 ### Sprint planning (PO + Architect + Tech Lead)
 


### PR DESCRIPTION
Codifies the standing directive that PRs must be actively driven into the merge queue, not left for the backstop.

**CLAUDE.md (Tech lead discipline):** the lead sweeps `gh pr list --state open` every loop and one-shot-enqueues every CLEAN/non-hold/non-draft PR not already queued (user PAT, never re-enqueue). Held/`BEHIND`/`DIRTY` PRs → high-priority `[CI-FIX]` task at the TOP of the TaskList for the next dev to rebase/fix + re-enqueue. The `auto-enqueue` cron is a backstop only.

**dev-self-merge skill:** enqueue PROACTIVELY the moment the 3 required checks (`cheap gate`, `merge shard reports`, `quality`) are green — not after the full equivalence-shard matrix, a watcher, or the backstop. A green-but-un-enqueued PR is a process failure.

(developer/senior-developer agent defs already route enqueue through the dev-self-merge skill, so they inherit this.) Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)