### PR TITLE
fix(#2592): standalone TypedArray.of / TypedArray.from static factories

### DIFF
--- a/plan/issues/2592-standalone-typedarray-static-factories.md
+++ b/plan/issues/2592-standalone-typedarray-static-factories.md
@@ -1,7 +1,9 @@
 ---
 id: 2592
 title: "Standalone TypedArray.of / TypedArray.from static factories — CE __get_builtin"
-status: ready
+status: done
+completed: 2026-06-22
+assignee: ttraenkler/agent-typedarray-2595-2597
 sprint: 65
 created: 2026-06-22
 priority: high
@@ -141,3 +143,30 @@ Substrate-independent (does NOT touch the value-rep substrate #2580). The
 element-width wrapping for `Uint8Array.of(300)` → `44` etc. is **deferred to
 #2593** — this slice only needs the factories to compile + produce the right
 length/order, matching today's `new TA([...])` fidelity.
+
+## Resolution (2026-06-22)
+
+Implemented the TypedArray static-factory arm in
+`src/codegen/expressions/calls.ts`, placed BEFORE the `Array.from`/`Array.of`
+arms, gated on `noJsHost(ctx) && TYPED_ARRAY_NAMES.has(receiver)`. Exported
+`typedArrayVecStorage` from `index.ts` so the element vec representation
+(`i8_byte` for standalone `Uint8Array`, `f64` otherwise) matches `new TA([...])`.
+
+- **`TA.of(...)`** — mirrors the `Array.of` native arm: per-arg coerce to the
+  element store type (`i32` for `i8` packed, else `f64`), `array.new_fixed` +
+  `struct.new`. Empty → `array.new_default` len 0. Spread args fall through.
+- **`TA.from(arrayLike)`** (no mapFn) — element-by-element copy with re-coercion
+  (the source vec's element type may differ from the dest), via a
+  `block{loop{ if i>=len br 1; dst[i]=coerce(src[i]); i++; br 0 }}` built with
+  `pushBody`/`popBody` so the `coerceType` conversion lands inside the loop.
+  Handles f64→i8, i8→i8 (`array.get_u`), empty source.
+
+**Deferred to follow-up (still fall through to existing path):**
+- `TA.from(src, mapFn)` — needs in-loop closure dispatch; standalone still CEs
+  (unchanged from before), gc/host works via the host import.
+- `TA.from(string | Set | arbitrary iterable)` and spread in `.of(...xs)`.
+- Integer element-width wrapping (`Uint8Array.of(300)` → 44) → **#2593**.
+
+Validated: `tests/issue-2592.test.ts` (22 tests, standalone + gc/host);
+`Array.of`/`Array.from` non-regression confirmed. tsc + prettier +
+coercion-sites gates clean.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -62,6 +62,7 @@ import {
   resolveWasmType,
   STRING_METHODS,
   TYPED_ARRAY_NAMES,
+  typedArrayVecStorage,
 } from "../index.js";
 import {
   compileArrayConstructorCall,
@@ -4611,6 +4612,169 @@ function compileCallExpression(
       fctx.body.push({ op: "drop" });
       fctx.body.push({ op: "ref.null.extern" });
       return { kind: "externref" };
+    }
+
+    // (#2592) Standalone-native TypedArray static factories — `TA.of(...)` and
+    // `TA.from(src)`. The receiver identifier is `Int32Array` / `Uint8Array` /
+    // … ∈ TYPED_ARRAY_NAMES, so it never reaches the `Array.of` / `Array.from`
+    // arms below (keyed on `"Array"`) and otherwise falls through to the
+    // dynamic-shape `__get_builtin` path — rejected standalone (#1472 Phase B).
+    // The element vec representation is fixed by the constructor NAME via
+    // `typedArrayVecStorage` (i8_byte for standalone Uint8Array, f64 otherwise),
+    // matching today's `new TA([...])` so the result is assignment-compatible.
+    // Integer element-width wrapping (Uint8Array.of(300) → 44) is deferred to
+    // #2593 — this slice matches `new TA([...])` element fidelity (length/order).
+    if (
+      noJsHost(ctx) &&
+      ts.isIdentifier(propAccess.expression) &&
+      TYPED_ARRAY_NAMES.has(propAccess.expression.text) &&
+      (propAccess.name.text === "of" || propAccess.name.text === "from")
+    ) {
+      const taName = propAccess.expression.text;
+      const factory = propAccess.name.text;
+      const storage = typedArrayVecStorage(ctx, taName);
+      const elemWasm = storage.type; // {kind:"f64"} or {kind:"i8"}
+      const taVecTypeIdx = getOrRegisterVecType(ctx, storage.key, elemWasm);
+      const taArrTypeIdx = getArrTypeIdxFromVec(ctx, taVecTypeIdx);
+      // The store ValType for an i8 packed array is i32 on the operand stack.
+      const storeWasm: ValType = elemWasm.kind === "i8" ? { kind: "i32" } : elemWasm;
+
+      if (taArrTypeIdx >= 0) {
+        // --- TA.of(a, b, c) — every arg is an element (§23.2.2.2). ---
+        if (factory === "of") {
+          const hasSpreadArg = expr.arguments.some((a) => ts.isSpreadElement(a));
+          if (!hasSpreadArg) {
+            if (expr.arguments.length === 0) {
+              fctx.body.push({ op: "i32.const", value: 0 });
+              fctx.body.push({ op: "i32.const", value: 0 });
+              fctx.body.push({ op: "array.new_default", typeIdx: taArrTypeIdx });
+              fctx.body.push({ op: "struct.new", typeIdx: taVecTypeIdx });
+              return { kind: "ref_null", typeIdx: taVecTypeIdx };
+            }
+            for (const arg of expr.arguments) {
+              const at = compileExpression(ctx, fctx, arg, storeWasm);
+              if (at && !valTypesMatch(at, storeWasm)) coerceType(ctx, fctx, at, storeWasm);
+            }
+            fctx.body.push({ op: "array.new_fixed", typeIdx: taArrTypeIdx, length: expr.arguments.length });
+            const ofData = allocLocal(fctx, `__taof_data_${fctx.locals.length}`, {
+              kind: "ref",
+              typeIdx: taArrTypeIdx,
+            });
+            fctx.body.push({ op: "local.set", index: ofData });
+            fctx.body.push({ op: "i32.const", value: expr.arguments.length });
+            fctx.body.push({ op: "local.get", index: ofData });
+            fctx.body.push({ op: "struct.new", typeIdx: taVecTypeIdx });
+            return { kind: "ref_null", typeIdx: taVecTypeIdx };
+          }
+          // Spread arg → known standalone gap (orthogonal); fall through.
+        }
+
+        // --- TA.from(src [, mapFn]) — array-like / vec source (§23.2.2.1). ---
+        // Phase 1: array-like sources (array literal / typed/number[] vec) with
+        // NO mapFn. The source vec's element type may differ from the dest
+        // (e.g. number[] f64 → Int32Array f64, or → Uint8Array i8), so copy
+        // element-by-element with re-coercion rather than a raw array.copy.
+        // mapFn and non-array iterables fall through to the existing path.
+        if (factory === "from" && expr.arguments.length === 1) {
+          const argTsType = ctx.checker.getTypeAtLocation(expr.arguments[0]!);
+          const argWasm = resolveWasmType(ctx, argTsType);
+          if (argWasm.kind === "ref" || argWasm.kind === "ref_null") {
+            const srcInfo = resolveArrayInfo(ctx, argTsType);
+            if (srcInfo) {
+              // #1919 — transactional try-lower; roll back if the source doesn't
+              // genuinely lower to its vec (keeps the fall-through paths clean).
+              const snap = snapshotSpeculative(ctx, fctx);
+              const { vecTypeIdx: srcVecIdx, arrTypeIdx: srcArrIdx, elemType: srcElem } = srcInfo;
+              const srcT = compileExpression(ctx, fctx, expr.arguments[0]!);
+              if (srcT && (srcT.kind === "ref" || srcT.kind === "ref_null")) {
+                const srcVec = allocLocal(fctx, `__tafrom_src_${fctx.locals.length}`, {
+                  kind: "ref_null",
+                  typeIdx: srcVecIdx,
+                });
+                const srcData = allocLocal(fctx, `__tafrom_sdata_${fctx.locals.length}`, {
+                  kind: "ref_null",
+                  typeIdx: srcArrIdx,
+                });
+                const lenTmp = allocLocal(fctx, `__tafrom_len_${fctx.locals.length}`, { kind: "i32" });
+                const dstData = allocLocal(fctx, `__tafrom_ddata_${fctx.locals.length}`, {
+                  kind: "ref",
+                  typeIdx: taArrTypeIdx,
+                });
+                const iTmp = allocLocal(fctx, `__tafrom_i_${fctx.locals.length}`, { kind: "i32" });
+
+                // src vec ref → field0 (len), field1 (data)
+                if (srcT.kind === "ref_null") fctx.body.push({ op: "ref.cast", typeIdx: srcVecIdx } as Instr);
+                fctx.body.push({ op: "local.set", index: srcVec });
+                fctx.body.push({ op: "local.get", index: srcVec });
+                fctx.body.push({ op: "struct.get", typeIdx: srcVecIdx, fieldIdx: 0 });
+                fctx.body.push({ op: "local.set", index: lenTmp });
+                fctx.body.push({ op: "local.get", index: srcVec });
+                fctx.body.push({ op: "struct.get", typeIdx: srcVecIdx, fieldIdx: 1 });
+                fctx.body.push({ op: "local.set", index: srcData });
+                // dst data array of len (default-filled)
+                for (const ins of defaultValueInstrs(elemWasm)) fctx.body.push(ins);
+                fctx.body.push({ op: "local.get", index: lenTmp });
+                fctx.body.push({ op: "array.new", typeIdx: taArrTypeIdx });
+                fctx.body.push({ op: "local.set", index: dstData });
+                // for (i=0; i<len; i++) dst[i] = coerce(src[i]) — canonical
+                // block{loop{ if i>=len br 1; body; i++; br 0 }} form. Build the
+                // loop body via pushBody/popBody so the `coerceType` element
+                // conversion (which emits into `fctx.body`) lands INSIDE the loop
+                // rather than leaking before the block.
+                fctx.body.push({ op: "i32.const", value: 0 });
+                fctx.body.push({ op: "local.set", index: iTmp });
+                const srcElemIsSigned = srcElem.kind === "i8" || srcElem.kind === "i16";
+                const srcElemIsPacked = srcElem.kind === "i8" || srcElem.kind === "i16";
+                const srcStore: ValType = srcElemIsPacked ? { kind: "i32" } : srcElem;
+                const savedLoopBody = pushBody(fctx);
+                // if (i >= len) break
+                fctx.body.push({ op: "local.get", index: iTmp } as Instr);
+                fctx.body.push({ op: "local.get", index: lenTmp } as Instr);
+                fctx.body.push({ op: "i32.ge_s" } as Instr);
+                fctx.body.push({ op: "br_if", depth: 1 } as Instr);
+                // dst[i] = coerce(src[i])
+                fctx.body.push({ op: "local.get", index: dstData } as Instr);
+                fctx.body.push({ op: "local.get", index: iTmp } as Instr);
+                fctx.body.push({ op: "local.get", index: srcData } as Instr);
+                fctx.body.push({ op: "local.get", index: iTmp } as Instr);
+                if (srcElemIsPacked) {
+                  fctx.body.push({
+                    op: srcElemIsSigned ? "array.get_s" : "array.get_u",
+                    typeIdx: srcArrIdx,
+                  } as Instr);
+                } else {
+                  fctx.body.push({ op: "array.get", typeIdx: srcArrIdx } as Instr);
+                }
+                if (!valTypesMatch(srcStore, storeWasm)) coerceType(ctx, fctx, srcStore, storeWasm);
+                fctx.body.push({ op: "array.set", typeIdx: taArrTypeIdx } as Instr);
+                // i++
+                fctx.body.push({ op: "local.get", index: iTmp } as Instr);
+                fctx.body.push({ op: "i32.const", value: 1 } as Instr);
+                fctx.body.push({ op: "i32.add" } as Instr);
+                fctx.body.push({ op: "local.set", index: iTmp } as Instr);
+                // continue
+                fctx.body.push({ op: "br", depth: 0 } as Instr);
+                const loopInner = fctx.body;
+                popBody(fctx, savedLoopBody);
+                fctx.body.push({
+                  op: "block",
+                  blockType: { kind: "empty" },
+                  body: [{ op: "loop", blockType: { kind: "empty" }, body: loopInner } as Instr],
+                } as Instr);
+                // struct.new (len, dstData)
+                fctx.body.push({ op: "local.get", index: lenTmp });
+                fctx.body.push({ op: "local.get", index: dstData });
+                fctx.body.push({ op: "struct.new", typeIdx: taVecTypeIdx });
+                return { kind: "ref", typeIdx: taVecTypeIdx };
+              }
+              rollbackSpeculative(ctx, fctx, snap);
+            }
+          }
+          // Non-array-like / mapFn / iterable source → fall through.
+        }
+      }
+      // taArrTypeIdx unavailable or unhandled shape → fall through to the
+      // existing generic path (host mode handles via host import).
     }
 
     // Handle Array.from(arr) — array copy

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -175,7 +175,7 @@ function typedArrayNameFromTypeNode(node: ts.TypeNode): string | null {
   return TYPED_ARRAY_NAMES.has(node.typeName.text) ? node.typeName.text : null;
 }
 
-function typedArrayVecStorage(ctx: CodegenContext, name: string): { key: string; type: ValType } {
+export function typedArrayVecStorage(ctx: CodegenContext, name: string): { key: string; type: ValType } {
   return (ctx.wasi || ctx.standalone) && name === "Uint8Array"
     ? { key: "i8_byte", type: { kind: "i8" } }
     : { key: "f64", type: { kind: "f64" } };

--- a/tests/issue-2592.test.ts
+++ b/tests/issue-2592.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { instantiateWasm } from "../src/runtime-instantiate.js";
+import type { CompileOptions } from "../src/index.js";
+
+// #2592 — standalone TypedArray.of / TypedArray.from static factories. Both CE'd
+//   with "'__get_builtin' (dynamic-shape …) not supported in --target standalone"
+//   because the receiver identifier (Int32Array / Uint8Array / …) never reached
+//   the Array.of / Array.from native lowerings (keyed on "Array"). Now lowered
+//   natively: build the element vec directly (representation fixed by the
+//   constructor NAME via typedArrayVecStorage — i8_byte for standalone
+//   Uint8Array, f64 otherwise), matching `new TA([...])` fidelity.
+//
+// Scope (Phase 1): `.of(...)` (no spread) and `.from(arrayLike)` (no mapFn).
+// mapFn / spread / non-array iterables fall through to the existing path
+// (mapFn integer-width wrapping → #2593).
+async function run(source: string, opts: CompileOptions = {}): Promise<Record<string, Function>> {
+  const result = await compile(source, opts);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const built = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await instantiateWasm(result.binary, built.env, built.string_constants);
+  built.setExports?.(instance.exports as Record<string, Function>);
+  return instance.exports as Record<string, Function>;
+}
+
+const bothModes = (name: string, source: string, expected: number) => {
+  it(`${name} (standalone)`, async () => {
+    const e = await run(source, { target: "standalone" });
+    expect(e.test!()).toBe(expected);
+  });
+  it(`${name} (gc/host)`, async () => {
+    const e = await run(source);
+    expect(e.test!()).toBe(expected);
+  });
+};
+
+describe("#2592 — TypedArray.of static factory", () => {
+  bothModes(
+    "Int32Array.of(10, 20, 30) → len 3, elements preserved",
+    `export function test(): number {
+       const a = Int32Array.of(10, 20, 30);
+       return a.length * 1000 + a[0] + a[1] + a[2]; // 3060
+     }`,
+    3060,
+  );
+
+  bothModes(
+    "Uint8Array.of(1, 2, 3, 4) → len 4",
+    `export function test(): number {
+       const a = Uint8Array.of(1, 2, 3, 4);
+       return a.length * 100 + a[0] + a[3]; // 405
+     }`,
+    405,
+  );
+
+  bothModes(
+    "Float64Array.of() → empty (len 0, no trap)",
+    `export function test(): number { return Float64Array.of().length; }`,
+    0,
+  );
+
+  bothModes(
+    "Float64Array.of(1.5, 2.5) → fractional values kept",
+    `export function test(): number {
+       const a = Float64Array.of(1.5, 2.5);
+       return a.length * 10 + (a[0] + a[1]); // 24
+     }`,
+    24,
+  );
+});
+
+describe("#2592 — TypedArray.from static factory (array-like, no mapFn)", () => {
+  bothModes(
+    "Int32Array.from([5, 10, 15]) → len 3, elements preserved",
+    `export function test(): number {
+       const a = Int32Array.from([5, 10, 15]);
+       return a.length * 1000 + a[0] + a[1] + a[2]; // 3030
+     }`,
+    3030,
+  );
+
+  bothModes(
+    "Float64Array.from(numberVar) → copies a number[] source",
+    `export function test(): number {
+       const src = [1.0, 2.0, 3.0, 4.0];
+       const a = Float64Array.from(src);
+       return a.length * 100 + a[0] + a[3]; // 405
+     }`,
+    405,
+  );
+
+  bothModes(
+    "Uint8Array.from([7, 8, 9]) → f64 source re-coerced to i8 element",
+    `export function test(): number {
+       const a = Uint8Array.from([7, 8, 9]);
+       return a.length * 100 + a[0] + a[2]; // 316
+     }`,
+    316,
+  );
+
+  bothModes(
+    "Uint8Array.from(Uint8Array) → i8 source copied (array.get_u)",
+    `export function test(): number {
+       const src = Uint8Array.of(100, 50, 25);
+       const a = Uint8Array.from(src);
+       return a.length * 1000 + a[0] + a[1] + a[2]; // 3175
+     }`,
+    3175,
+  );
+
+  bothModes(
+    "Int32Array.from([]) → empty (len 0, no trap)",
+    `export function test(): number { return Int32Array.from([]).length; }`,
+    0,
+  );
+});
+
+describe("#2592 — Array.of / Array.from unaffected (no regression)", () => {
+  bothModes(
+    "Array.of(11, 22, 33) still builds a dense array",
+    `export function test(): number {
+       const a = Array.of(11, 22, 33);
+       return a.length * 100 + a[0] + a[2]; // 344
+     }`,
+    344,
+  );
+
+  bothModes(
+    "Array.from([4, 5, 6]) still copies",
+    `export function test(): number {
+       const a = Array.from([4, 5, 6]);
+       return a.length * 100 + a[0] + a[2]; // 310
+     }`,
+    310,
+  );
+});


### PR DESCRIPTION
## Summary

Standalone TypedArray static factories (`TA.of` / `TA.from`) were a hard CE — sprint 65, parent #2159, the dominant compile-error class in the `built-ins/TypedArrayConstructors` (321) bucket. Adjacent to the just-landed #2595/#2597 (same `calls.ts` / property-access TA region).

### Problem
In `--target standalone`:
```ts
Int32Array.of(10, 20)      // CE: '__get_builtin' (dynamic-shape …) not supported standalone
Uint8Array.from([4, 5, 6]) // CE
```
The receiver identifier (`Int32Array` / `Uint8Array` / … ∈ `TYPED_ARRAY_NAMES`) never reached the `Array.of`/`Array.from` native lowerings (keyed on `"Array"`), so the call fell through to a dynamic-shape `__get_builtin` — rejected standalone (#1472 Phase B).

### Fix
- Export `typedArrayVecStorage` from `index.ts` so the element vec representation (`i8_byte` for standalone `Uint8Array`, `f64` otherwise) **matches `new TA([...])`** — result stays assignment-compatible with a typed local.
- New TypedArray static-factory arm in `compileCallExpression` (`src/codegen/expressions/calls.ts`), placed **before** the `Array.from`/`Array.of` arms, gated on `noJsHost(ctx) && TYPED_ARRAY_NAMES.has(receiver)`:
  - **`TA.of(...)`** — mirrors the proven `Array.of` native arm: per-arg coerce to the element store type (`i32` for `i8` packed, else `f64`), `array.new_fixed` + `struct.new`; empty → `array.new_default` len 0. Spread args fall through.
  - **`TA.from(arrayLike)`** (no mapFn) — element-by-element copy with re-coercion (source vec elem type may differ from dest) via a canonical `block{loop{ if i>=len br 1; dst[i]=coerce(src[i]); i++; br 0 }}`, built with `pushBody`/`popBody` so the `coerceType` conversion lands **inside** the loop. Handles f64→i8, i8→i8 (`array.get_u`), empty source.

### Deferred (fall through to existing path, behaviour unchanged)
- `TA.from(src, mapFn)` — needs in-loop closure dispatch; standalone still CEs (as before), gc/host works via host import.
- `TA.from(string | Set | arbitrary iterable)`, spread in `.of(...xs)`.
- Integer element-width wrapping (`Uint8Array.of(300)` → 44) → **#2593**.

## Files
- `src/codegen/expressions/calls.ts` — TA static-factory arm
- `src/codegen/index.ts` — export `typedArrayVecStorage`
- `tests/issue-2592.test.ts` — 22 tests

## Validation
- `tests/issue-2592.test.ts`: **22 tests pass** (standalone + gc/host) — `.of`/`.from` for Int32/Uint8/Float64, empty, i8→i8 copy, fractional f64; `Array.of`/`Array.from` non-regression confirmed.
- `tsc --noEmit` clean; `prettier --check` clean; `check:coercion-sites` OK.
- No new host imports; standalone purity preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA