### PR TITLE
fix(#2600+#2601): standalone String index ToIntegerOrInfinity + fromCodePoint RangeError

### DIFF
--- a/plan/issues/2600-standalone-string-index-arg-tointeger.md
+++ b/plan/issues/2600-standalone-string-index-arg-tointeger.md
@@ -1,7 +1,9 @@
 ---
 id: 2600
 title: "Standalone: ToIntegerOrInfinity for String index/position args (at/charAt/charCodeAt/codePointAt/indexOf)"
-status: ready
+status: done
+completed: 2026-06-22
+assignee: ttraenkler/agent-af6ff9d85ab8e6fc4
 sprint: 65
 priority: medium
 feasibility: medium
@@ -11,7 +13,7 @@ area: string-number
 language_feature: string-methods
 goal: standalone-mode
 parent: 2160
-related: [2124]
+related: [2124, 2601]
 ---
 
 # #2600 — Standalone String index/position argument ToIntegerOrInfinity
@@ -127,3 +129,38 @@ end
   codePointAt/indexOf × `{standalone, gc}`.
 - gc-mode no-regression guard.
 - `pnpm run check:coercion-sites` unchanged (reuse the f64 engine).
+
+## Resolution (2026-06-22)
+
+Fixed together with #2601 in one branch (`issue-2600-2601-string-index-fromcodepoint`).
+
+**Change** — `src/codegen/string-ops.ts`, `compileStringIntegerArg`:
+- Under `noJsHost(ctx)` (standalone/WASI), the index/position arg is now run
+  through ToIntegerOrInfinity (§7.1.5) instead of a direct i32 coercion:
+  - `i32`-typed arg → unchanged (already integral, in range for the helper).
+  - `i64` (bigint) → existing TypeError throw, unchanged.
+  - else → `coerceType(argType, {kind:"f64"}, "number")` (the existing numeric
+    engine: string → `__str_to_number`, object → ToPrimitive("number")), then
+    ToIntegerOrInfinity: NaN→0 (`f64.ne self` test), else `i32.trunc_sat_f64_s`
+    (truncates toward zero; ±∞ saturates and the method's <0/>=len range checks
+    clamp it).
+- The legacy direct-i32 path is kept for the JS-host `nativeStrings` mode (this
+  slice is standalone). No new #2108 coercion site — `coerceType` reuse only;
+  `check:coercion-sites` baseline unchanged.
+
+Covers at/charAt/charCodeAt/codePointAt/indexOf/lastIndexOf (all route their
+position through `compileStringIntegerArg`).
+
+## Test Results
+
+- `tests/issue-2600-string-index-tointeger.test.ts` — 17/17 pass (standalone +
+  gc-mode regression guards).
+- Standalone micro-repros: `indexOf("aa","1.9")`→1, `charAt("1.5")`→'b',
+  `charCodeAt("2.9")`→'c', `codePointAt("1.5")`→'b', `charCodeAt("abc")`→0
+  (NaN), `charCodeAt(true)`→1, `charAt({valueOf:1})`→'b', `at("1.9")`→'b',
+  `at("-1.5")`→'b' — all correct.
+- Integer-position regression guards green; #2124 explicit-undefined defaults
+  untouched (the absent path lives in `compileIntegerValueToLocal`, unchanged).
+- Related suites green: issue-2122, issue-2088, issue-2124, issue-1105-charcodeat,
+  issue-substring-noarg, issue-2160-substr, issue-1910-string-wrapper-index.
+- tsc + prettier clean; `check:coercion-sites` OK (no change).

--- a/plan/issues/2601-standalone-fromcodepoint-rangeerror.md
+++ b/plan/issues/2601-standalone-fromcodepoint-rangeerror.md
@@ -1,7 +1,9 @@
 ---
 id: 2601
 title: "Standalone: String.fromCodePoint RangeError on non-integral / out-of-range code points"
-status: ready
+status: done
+completed: 2026-06-22
+assignee: ttraenkler/agent-af6ff9d85ab8e6fc4
 sprint: 65
 priority: medium
 feasibility: easy
@@ -11,7 +13,7 @@ area: string-number
 language_feature: string-methods
 goal: standalone-mode
 parent: 2160
-related: [2088, 2122]
+related: [2088, 2122, 2600]
 ---
 
 # #2601 — Standalone String.fromCodePoint RangeError guard
@@ -118,3 +120,34 @@ See the integral + range block above. Code-point value `1114111` = `0x10FFFF`.
   correct strings; × `{standalone, gc}`. Assert `fromCharCode` still does NOT throw
   on `3.14` (ToUint16, no RangeError) — guard must be fromCodePoint-only.
 - gc-mode no-regression guard.
+
+## Resolution (2026-06-22)
+
+Fixed together with #2600 in one branch (`issue-2600-2601-string-index-fromcodepoint`).
+
+**Change** — `src/codegen/expressions/calls.ts`, `compileFromCharCodeFamily`:
+- Added an `isFromCodePoint` flag; the per-argument fold now emits the §22.1.2.2
+  step 2b/2c RangeError guard **only** for fromCodePoint (NOT fromCharCode, which
+  does ToUint16 with no check). Per arg: coerce ToNumber→f64, then
+  `if (trunc(cp) != cp  ||  cp < 0  ||  cp > 0x10FFFF) throw RangeError`
+  (`trunc != self` catches fractional AND NaN; the range test catches ±∞), then
+  trunc to the i32 the native helper wants.
+- Gated on `noJsHost(ctx)` (standalone/WASI): the throw uses the in-module
+  `__new_RangeError` constructor (no host bridge). The JS-host lane keeps its
+  existing host-delegated behaviour — gating it standalone-only also avoids a
+  mid-part-loop late-import index shift that briefly broke the fast-mode
+  multi-arg path (#2122 regression, caught + fixed before commit).
+- No new #2108 coercion site (`coerceType` f64 reuse).
+
+## Test Results
+
+- `tests/issue-2601-fromcodepoint-rangeerror.test.ts` — 17/17 pass.
+- Standalone: `fromCodePoint(3.14|-1|0x10FFFF+1|NaN|Infinity|"x")` and multi-arg
+  `(65, 3.14)` all throw RangeError; `fromCodePoint(0|65|65.0|0x10FFFF|"65")` and
+  `(65,66,67)` return correct strings; `fromCharCode(3.14)` does NOT throw
+  (guard is fromCodePoint-only).
+- Regression: #2122 (incl. native fromCodePoint multi-arg surrogate pairs) and
+  #2088 green; gc-mode fromCodePoint/fromCharCode unchanged.
+- tsc + prettier clean; `check:coercion-sites` OK (no change).
+- Note: `String.fromCodePoint()` (0-arg) is out of this slice — the native block
+  gates on `arguments.length >= 1`, so the 0-arg case is unchanged (pre-existing).

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -152,6 +152,7 @@ import {
   tryCompileStandaloneRegExpToString,
 } from "../regexp-standalone.js";
 import {
+  emitThrowRangeError,
   emitThrowTypeError,
   getFuncParamTypes,
   getWasmFuncReturnType,
@@ -2805,9 +2806,9 @@ function compileFromCharCodeFamily(
   ctx: CodegenContext,
   fctx: FunctionContext,
   expr: ts.CallExpression,
-  opts: { native: boolean; helperIdx: number },
+  opts: { native: boolean; helperIdx: number; isFromCodePoint?: boolean },
 ): ValType | null {
-  const { native, helperIdx } = opts;
+  const { native, helperIdx, isFromCodePoint } = opts;
   const repr = native ? nativeStringRepr(ctx) : hostStringRepr(ctx);
   if (repr === undefined) return null;
 
@@ -2823,8 +2824,49 @@ function compileFromCharCodeFamily(
     fctx.body = buf;
     try {
       const argType = compileExpression(ctx, fctx, expr.arguments[i]!, { kind: "f64" });
+      // #2601 — §22.1.2.2 step 2b/2c: each fromCodePoint code point, after
+      // ToNumber, must be an INTEGRAL Number in [0, 0x10FFFF] else RangeError.
+      // (fromCharCode does ToUint16 with NO such check — fromCodePoint-only.)
+      // Scoped to standalone/WASI (`noJsHost`): the throw uses the in-module
+      // `__new_RangeError` constructor with no host bridge. The JS-host lane
+      // keeps its existing host-delegated behaviour (the slice is standalone).
+      const emitRangeGuard = isFromCodePoint === true && noJsHost(ctx);
+      if (emitRangeGuard) {
+        // Normalise to f64, then test `trunc(cp) != cp` (catches fractional AND
+        // NaN) OR `cp < 0` OR `cp > 0x10FFFF` (±∞ caught by the range test).
+        if (argType && argType.kind === "i32") buf.push({ op: "f64.convert_i32_s" });
+        const cpTmp = allocLocal(fctx, `__fcp_cp_${fctx.locals.length}`, { kind: "f64" });
+        buf.push({ op: "local.tee", index: cpTmp });
+        // integral: trunc(cp) != cp  → also true for NaN
+        buf.push({ op: "local.get", index: cpTmp });
+        buf.push({ op: "f64.trunc" });
+        buf.push({ op: "f64.ne" });
+        // range: cp < 0
+        buf.push({ op: "local.get", index: cpTmp });
+        buf.push({ op: "f64.const", value: 0 });
+        buf.push({ op: "f64.lt" });
+        // range: cp > 0x10FFFF
+        buf.push({ op: "local.get", index: cpTmp });
+        buf.push({ op: "f64.const", value: 0x10ffff });
+        buf.push({ op: "f64.gt" });
+        buf.push({ op: "i32.or" });
+        buf.push({ op: "i32.or" });
+        const throwBuf: Instr[] = [];
+        const savedForThrow = fctx.body;
+        fctx.body = throwBuf;
+        emitThrowRangeError(ctx, fctx, "RangeError: Invalid code point");
+        fctx.body = savedForThrow;
+        buf.push({ op: "if", blockType: { kind: "empty" }, then: throwBuf } as Instr);
+        // Re-push the validated code point for the helper.
+        buf.push({ op: "local.get", index: cpTmp });
+      }
       if (native) {
-        if (argType && argType.kind !== "i32") buf.push({ op: "i32.trunc_sat_f64_s" });
+        if (emitRangeGuard) {
+          // Already f64 in the temp above — trunc to the i32 the native helper wants.
+          buf.push({ op: "i32.trunc_sat_f64_s" });
+        } else if (argType && argType.kind !== "i32") {
+          buf.push({ op: "i32.trunc_sat_f64_s" });
+        }
       } else {
         if (argType && argType.kind === "i32") buf.push({ op: "f64.convert_i32_s" });
       }
@@ -4548,7 +4590,7 @@ function compileCallExpression(
       if (ctx.nativeStrings && ctx.nativeStrTypeIdx >= 0) {
         const helperIdx = ctx.nativeStrHelpers.get("__str_fromCodePoint");
         if (helperIdx !== undefined) {
-          const r = compileFromCharCodeFamily(ctx, fctx, expr, { native: true, helperIdx });
+          const r = compileFromCharCodeFamily(ctx, fctx, expr, { native: true, helperIdx, isFromCodePoint: true });
           if (r !== null) return r;
         }
       }
@@ -4558,7 +4600,11 @@ function compileCallExpression(
         // #2122: variadic — each code point produces a string joined via the
         // js-string `concat` import; register it before the shared fold.
         if (expr.arguments.length > 1) addStringImports(ctx);
-        const r = compileFromCharCodeFamily(ctx, fctx, expr, { native: false, helperIdx: funcIdx });
+        const r = compileFromCharCodeFamily(ctx, fctx, expr, {
+          native: false,
+          helperIdx: funcIdx,
+          isFromCodePoint: true,
+        });
         if (r === null) return r;
         return { kind: "externref" };
       }

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -2066,6 +2066,52 @@ function compileStringIntegerArg(ctx: CodegenContext, fctx: FunctionContext, arg
     fctx.body.push({ op: "i32.const", value: 0 });
     return;
   }
+  // #2600 — the index/position is `ToIntegerOrInfinity(arg)` = truncate-toward-
+  // zero of `ToNumber(arg)` (§7.1.5), NOT a direct i32 coercion. In standalone
+  // a fast i32 coercion of a fractional / non-numeric-typed position
+  // (`"1.9"`, `{valueOf(){…}}`, `true`) resolves to a wrong index. Route the
+  // arg through the existing numeric coercion engine to f64 (string →
+  // `__str_to_number`, object → ToPrimitive("number") — both already present
+  // for `+str` / `Number(x)`), then apply ToIntegerOrInfinity (NaN → 0, then
+  // `i32.trunc_sat_f64_s`, which truncates toward zero and saturates ±∞ to the
+  // i32 bounds — the method's subsequent <0 / >=len range checks clamp it).
+  // No new #2108 coercion site (reuses the engine). The legacy direct-i32 path
+  // is kept for the JS-host nativeStrings mode (these slices are standalone).
+  if (noJsHost(ctx)) {
+    const argType = compileExpression(ctx, fctx, arg);
+    if (!argType) {
+      // void → undefined → ToNumber NaN → ToIntegerOrInfinity 0.
+      fctx.body.push({ op: "i32.const", value: 0 });
+      return;
+    }
+    if (argType.kind === "i64") {
+      // BigInt fell through static detection (e.g. `any` widened to bigint).
+      fctx.body.push({ op: "drop" } as Instr);
+      emitTypeErrorThrow(ctx, fctx, "TypeError: Cannot convert a BigInt value to a number");
+      fctx.body.push({ op: "i32.const", value: 0 });
+      return;
+    }
+    if (argType.kind === "i32") {
+      // Already an integer (boolean / int-typed position) — no ToNumber needed;
+      // an i32 is already integral and within range for the helper.
+      return;
+    }
+    // Coerce ToNumber → f64 via the engine, then ToIntegerOrInfinity.
+    coerceType(ctx, fctx, argType, { kind: "f64" }, "number");
+    const fTmp = allocLocal(fctx, `__strint_f_${fctx.locals.length}`, { kind: "f64" });
+    fctx.body.push({ op: "local.set", index: fTmp });
+    // ToIntegerOrInfinity: NaN → 0, else trunc toward zero (±∞ saturates).
+    fctx.body.push({ op: "local.get", index: fTmp });
+    fctx.body.push({ op: "local.get", index: fTmp });
+    fctx.body.push({ op: "f64.ne" }); // self != self ⇒ NaN
+    fctx.body.push({
+      op: "if",
+      blockType: { kind: "val", type: { kind: "i32" } },
+      then: [{ op: "i32.const", value: 0 }],
+      else: [{ op: "local.get", index: fTmp }, { op: "i32.trunc_sat_f64_s" }],
+    } as Instr);
+    return;
+  }
   const argType = compileExpression(ctx, fctx, arg, { kind: "i32" });
   if (!argType) {
     fctx.body.push({ op: "i32.const", value: 0 });

--- a/tests/issue-2600-string-index-tointeger.test.ts
+++ b/tests/issue-2600-string-index-tointeger.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+
+// #2600 — Standalone String index/position argument ToIntegerOrInfinity (§7.1.5)
+//   for at/charAt/charCodeAt/codePointAt/indexOf/lastIndexOf on a typed string
+//   receiver. The position was coerced directly to i32 instead of via
+//   ToNumber→truncate-toward-zero, so a fractional-string ("1.9"), non-numeric
+//   string ("abc"→NaN→0), boolean, or `{valueOf(){…}}` position resolved wrong.
+//
+//   Fix routes the arg through the existing numeric coercion engine
+//   (`coerceType(..., {kind:"f64"}, "number")` — string → __str_to_number,
+//   object → ToPrimitive("number")), then applies ToIntegerOrInfinity (NaN→0,
+//   else i32.trunc_sat_f64_s). No new #2108 coercion site. Substrate-independent
+//   value correctness (typed receiver).
+//
+// `skipSemanticDiagnostics` mirrors the test262 runner — passing a non-number to
+// a `(pos: number)` method is not a hard TS error there.
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, { target: "standalone", skipSemanticDiagnostics: true } as never);
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+async function runGc(src: string): Promise<unknown> {
+  const r = await compile(src, { skipSemanticDiagnostics: true } as never);
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject ?? {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#2600 standalone String index/position ToIntegerOrInfinity", () => {
+  it("indexOf with fractional-string position ('1.9' → 1)", async () => {
+    expect(await runStandalone(`export function test(): number { return "aaaa".indexOf("aa", "1.9"); }`)).toBe(1);
+  });
+
+  it("charAt('1.5') → trunc to index 1 ('b')", async () => {
+    expect(await runStandalone(`export function test(): number { return "abc".charAt("1.5").charCodeAt(0); }`)).toBe(
+      98,
+    );
+  });
+
+  it("charCodeAt('2.9') → trunc to index 2 ('c' = 99)", async () => {
+    expect(await runStandalone(`export function test(): number { return "abc".charCodeAt("2.9"); }`)).toBe(99);
+  });
+
+  it("codePointAt('1.5') → index 1 ('b' = 98)", async () => {
+    expect(await runStandalone(`export function test(): number { return "abc".codePointAt("1.5"); }`)).toBe(98);
+  });
+
+  it("charCodeAt('abc') → NaN → 0 ('X' = 88)", async () => {
+    expect(await runStandalone(`export function test(): number { return "Xyz".charCodeAt("abc"); }`)).toBe(88);
+  });
+
+  it("charCodeAt(true) → 1 ('y' = 121)", async () => {
+    expect(await runStandalone(`export function test(): number { return "Xyz".charCodeAt(true); }`)).toBe(121);
+  });
+
+  it("charAt({valueOf(){return 1}}) → ToPrimitive('number') → 1 ('b')", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o = { valueOf() { return 1; } }; return "abc".charAt(o).charCodeAt(0); }`,
+      ),
+    ).toBe(98);
+  });
+
+  it("at('1.9') → index 1 ('b')", async () => {
+    expect(await runStandalone(`export function test(): number { return "ab".at("1.9") === "b" ? 1 : 0; }`)).toBe(1);
+  });
+
+  it("at('0.9') → index 0 ('a')", async () => {
+    expect(await runStandalone(`export function test(): number { return "ab".at("0.9") === "a" ? 1 : 0; }`)).toBe(1);
+  });
+
+  it("at('-1.5') → trunc toward zero → -1 (last char 'b')", async () => {
+    expect(await runStandalone(`export function test(): number { return "ab".at("-1.5") === "b" ? 1 : 0; }`)).toBe(1);
+  });
+
+  it("at({valueOf(){return 1}}) → 'b'", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o = { valueOf() { return 1; } }; return "ab".at(o) === "b" ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  // Regression guards — integer positions unchanged.
+  it("charAt(1) integer unchanged", async () => {
+    expect(await runStandalone(`export function test(): number { return "abc".charAt(1).charCodeAt(0); }`)).toBe(98);
+  });
+
+  it("indexOf('a', 2) integer position unchanged", async () => {
+    expect(await runStandalone(`export function test(): number { return "aaaa".indexOf("a", 2); }`)).toBe(2);
+  });
+
+  it("charCodeAt(0) integer unchanged", async () => {
+    expect(await runStandalone(`export function test(): number { return "Xyz".charCodeAt(0); }`)).toBe(88);
+  });
+});
+
+describe("#2600 gc-mode (host path) unchanged", () => {
+  it("gc charAt integer", async () => {
+    expect(await runGc(`export function test(): number { return "abc".charAt(1).charCodeAt(0); }`)).toBe(98);
+  });
+
+  it("gc indexOf integer position", async () => {
+    expect(await runGc(`export function test(): number { return "aaaa".indexOf("a", 2); }`)).toBe(2);
+  });
+
+  it("gc charCodeAt", async () => {
+    expect(await runGc(`export function test(): number { return "Xyz".charCodeAt(0); }`)).toBe(88);
+  });
+});

--- a/tests/issue-2601-fromcodepoint-rangeerror.test.ts
+++ b/tests/issue-2601-fromcodepoint-rangeerror.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+
+// #2601 — Standalone String.fromCodePoint RangeError guard (§22.1.2.2).
+//   Each argument, after ToNumber, must be an INTEGRAL Number in [0, 0x10FFFF]
+//   else RangeError (steps 2b/2c). The native lowering omitted both guards, so
+//   fromCodePoint(3.14) / (-1) / (0x10FFFF+1) / (NaN) / (Infinity) silently
+//   truncated/wrapped instead of throwing.
+//
+//   Fix adds an `isFromCodePoint` flag to compileFromCharCodeFamily that, per
+//   argument, coerces ToNumber→f64 (existing engine) then emits the integral
+//   (trunc(cp) != cp, also catches NaN) + range (cp<0 || cp>0x10FFFF, catches
+//   ±∞) check → emitThrowRangeError. fromCharCode does ToUint16 with NO such
+//   check, so the guard is fromCodePoint-only. Substrate-independent (static
+//   method, numeric args).
+//
+// `skipSemanticDiagnostics` mirrors the test262 runner.
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, { target: "standalone", skipSemanticDiagnostics: true } as never);
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+async function runGc(src: string): Promise<unknown> {
+  const r = await compile(src, { skipSemanticDiagnostics: true } as never);
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject ?? {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#2601 standalone String.fromCodePoint RangeError", () => {
+  it("fromCodePoint(3.14) throws RangeError (non-integral)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { try { String.fromCodePoint(3.14); return 0; } catch(e) { return 1; } }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("fromCodePoint(-1) throws RangeError (< 0)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { try { String.fromCodePoint(-1); return 0; } catch(e) { return 1; } }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("fromCodePoint(0x10FFFF + 1) throws RangeError (> max)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { try { String.fromCodePoint(0x10FFFF + 1); return 0; } catch(e) { return 1; } }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("fromCodePoint(NaN) throws RangeError", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { try { String.fromCodePoint(NaN); return 0; } catch(e) { return 1; } }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("fromCodePoint(Infinity) throws RangeError", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { try { String.fromCodePoint(Infinity); return 0; } catch(e) { return 1; } }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("fromCodePoint('x') → NaN → throws RangeError", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { try { String.fromCodePoint("x"); return 0; } catch(e) { return 1; } }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("multi-arg: a later bad code point throws", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { try { String.fromCodePoint(65, 3.14); return 0; } catch(e) { return 1; } }`,
+      ),
+    ).toBe(1);
+  });
+
+  // Valid code points return correct strings (no over-throw).
+  it("fromCodePoint(65) → 'A'", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return String.fromCodePoint(65).charCodeAt(0); }`),
+    ).toBe(65);
+  });
+
+  it("fromCodePoint(65.0) integral float → 'A'", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return String.fromCodePoint(65.0).charCodeAt(0); }`),
+    ).toBe(65);
+  });
+
+  it("fromCodePoint(0) is valid (inclusive lower bound)", async () => {
+    expect(await runStandalone(`export function test(): number { return String.fromCodePoint(0).length; }`)).toBe(1);
+  });
+
+  it("fromCodePoint(0x10FFFF) is valid (inclusive upper bound, surrogate pair)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return String.fromCodePoint(0x10FFFF).length; }`),
+    ).toBe(2);
+  });
+
+  it("fromCodePoint('65') → ToNumber → 'A'", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return String.fromCodePoint("65").charCodeAt(0); }`),
+    ).toBe(65);
+  });
+
+  it("fromCodePoint(65,66,67) multi-arg valid", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return String.fromCodePoint(65, 66, 67).length; }`),
+    ).toBe(3);
+  });
+
+  // Regression — fromCharCode must NOT throw on a fractional arg (ToUint16).
+  it("fromCharCode(3.14) does NOT throw (guard is fromCodePoint-only)", async () => {
+    expect(await runStandalone(`export function test(): number { return String.fromCharCode(3.14).length; }`)).toBe(1);
+  });
+
+  it("fromCharCode(65) → 'A'", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return String.fromCharCode(65).charCodeAt(0); }`),
+    ).toBe(65);
+  });
+});
+
+describe("#2601 gc-mode (host path) unchanged", () => {
+  it("gc fromCodePoint(65) → 'A'", async () => {
+    expect(await runGc(`export function test(): number { return String.fromCodePoint(65).charCodeAt(0); }`)).toBe(65);
+  });
+
+  it("gc fromCharCode(65) → 'A'", async () => {
+    expect(await runGc(`export function test(): number { return String.fromCharCode(65).charCodeAt(0); }`)).toBe(65);
+  });
+});


### PR DESCRIPTION
## Summary

Two related standalone String correctness slices in the same code region
(`string-ops.ts` / `expressions/calls.ts`), both reusing the existing `coerceType`
f64 engine — **no new #2108 coercion site**.

- **#2600** — the index/position argument of `at` / `charAt` / `charCodeAt` /
  `codePointAt` / `indexOf` / `lastIndexOf` was coerced **directly to i32** instead
  of via **ToIntegerOrInfinity** (§7.1.5 = ToNumber then truncate-toward-zero), so a
  fractional-string (`"1.9"`), non-numeric string (`"abc"`→NaN→0), boolean, or
  `{valueOf(){…}}` position resolved to the wrong index on a typed string receiver.
- **#2601** — `String.fromCodePoint` omitted the §22.1.2.2 step 2b/2c per-argument
  **integral + [0, 0x10FFFF] RangeError** checks, silently truncating/wrapping
  `3.14` / `-1` / `0x10FFFF+1` / `NaN` / `Infinity` instead of throwing.

## Changes

**`src/codegen/string-ops.ts` — `compileStringIntegerArg` (#2600)**
Under `noJsHost`: route the position through `coerceType(argType, {kind:"f64"},
"number")` (string → `__str_to_number`, object → ToPrimitive("number")), then
ToIntegerOrInfinity: `NaN`→0 (`f64.ne self`), else `i32.trunc_sat_f64_s` (truncs
toward zero; ±∞ saturates and the method's range checks clamp). `i32`-typed args
unchanged; `i64`/bigint TypeError unchanged. JS-host `nativeStrings` lane kept
byte-identical.

**`src/codegen/expressions/calls.ts` — `compileFromCharCodeFamily` (#2601)**
New `isFromCodePoint` flag emits, under `noJsHost`, the per-arg guard
`if (trunc(cp) != cp || cp < 0 || cp > 0x10FFFF) throw RangeError` (`trunc != self`
catches fractional AND NaN; range test catches ±∞). `fromCharCode` keeps ToUint16
with **no** check. Gating standalone-only also avoids a mid-part-loop late-import
index shift that would otherwise perturb the JS-host multi-arg path.

## Scope

Typed string receiver / numeric args (substrate-independent). Dynamic/class
`valueOf` objects that hit `Cannot convert object to primitive value` route through
the #1917 engine; `String.fromCodePoint()` (0-arg) is unchanged (pre-existing —
native block gates on `length >= 1`).

## Tests

- `tests/issue-2600-string-index-tointeger.test.ts` — **17/17** (standalone + gc).
- `tests/issue-2601-fromcodepoint-rangeerror.test.ts` — **17/17** (standalone + gc).
- Regression: **#2122** (incl. native fromCodePoint multi-arg surrogate pairs),
  **#2088**, **#2124**, charCodeAt/substring/substr/wrapper-index suites all green.
- tsc + prettier clean; `check:coercion-sites` OK (no change).

Both issues set `status: done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA