### PR TITLE
fix(#2594 Part A): standalone ArrayBuffer.isView host-import leak

### DIFF
--- a/plan/issues/2594-standalone-typedarray-buffer-host-import-leaks.md
+++ b/plan/issues/2594-standalone-typedarray-buffer-host-import-leaks.md
@@ -1,7 +1,9 @@
 ---
 id: 2594
 title: "Standalone TypedArray/ArrayBuffer host-import leaks — isView, BigInt64Array ctor, DataView BigInt accessors"
-status: ready
+status: done
+completed: 2026-06-22
+assignee: ttraenkler/agent-typedarray-2595-2597
 sprint: 65
 created: 2026-06-22
 priority: high
@@ -119,3 +121,37 @@ Substrate-independent for part A (isView). Part B (BigInt64Array) touches the
 bigint i64 brand (`project_bigint_i64_brand_gate`) — split out if the brand
 decision blocks it. The `emitIsArrayTerminal` ref.test fan-out
 (property-access.ts ~470) is the proven template for the native isView check.
+
+## Resolution (2026-06-22) — Part A only; Part B split out
+
+Per the spec's scoping clause, **Part A (`ArrayBuffer.isView`)** is implemented
+here; **Part B (BigInt64Array / BigUint64Array native ctor)** is split to a
+follow-up because it touches the unresolved i64-bigint-brand ValType decision
+(#1349/#1644, `project_bigint_i64_brand_gate`) — landing it now would couple
+this conformance slice to an architect-gated representation choice.
+
+**Part A — `ArrayBuffer.isView` host-free** (`src/codegen/expressions/calls.ts`):
+gated on `noJsHost(ctx)`, the arm no longer emits the leaking
+`__arraybuffer_isView` env import (which broke the WHOLE module at instantiate).
+§25.1.4.1 — isView is true iff the arg has a [[ViewedArrayBuffer]] slot:
+- **Static-decide** on the resolvable arg type: TypedArray name / `DataView`
+  (and `BigInt64Array`/`BigUint64Array`) → `i32.const 1` (drop side-effecting
+  arg); a resolvable non-view (ArrayBuffer, primitive, null/undefined, plain
+  array, class/object) → `i32.const 0`.
+- **Runtime fallback** for `any`/union args: `any.convert_extern` + `ref.test`
+  over the registered `$Vec` carriers OR the `$__dv_window` struct. Documented
+  imprecision: standalone shares the `$Vec` carrier between `number[]` and
+  TypedArrays, so a plain array read through an `any` arg reads as a view — an
+  accepted edge for the rare untyped call; the win is not leaking the host
+  import. Host/gc mode is unchanged (still routes the host import).
+
+Validated: `tests/issue-2594.test.ts` (7 tests) — Int32Array/DataView → true,
+ArrayBuffer/primitive/null → false, `any` fallback, and a whole-module
+instantiate-and-compute proof (the env leak previously broke the entire
+module). tsc + prettier + coercion-sites clean; packed-typedarray and
+dataview-window suites still green.
+
+**Follow-up (Part B):** BigInt64Array / BigUint64Array native ctor (i64-element
+vec) + the DataView `getBigInt64`/`setBigInt64` bare-vec env-leak check —
+blocked on the i64-bigint-brand decision; should be a fresh issue once that
+lands.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -185,7 +185,12 @@ import {
 } from "../native-strings.js";
 import { emitVariadicStringConcat, hostStringRepr, nativeStringRepr } from "../builtin-scaffold.js";
 import { URI_DECODE_MASK, URI_ENCODE_MASK } from "../uri-encoding-native.js";
-import { emitArrayBufferSlice, emitDataViewAccessor, isDataViewAccessor } from "../dataview-native.js";
+import {
+  emitArrayBufferSlice,
+  emitDataViewAccessor,
+  getOrRegisterDvWindowType,
+  isDataViewAccessor,
+} from "../dataview-native.js";
 import {
   getLinearU8Buffer,
   getLinearU8ParamIndicesForCall,
@@ -6413,6 +6418,61 @@ function compileCallExpression(
       propAccess.name.text === "isView" &&
       expr.arguments.length >= 1
     ) {
+      // (#2594) Standalone/no-host: the host `__arraybuffer_isView` import does
+      // not exist — emitting it leaks `env.*` and breaks the WHOLE module at
+      // instantiate. §25.1.4.1 isView is `true` iff the arg has a
+      // [[ViewedArrayBuffer]] slot (any TypedArray or DataView). Decide it
+      // host-free.
+      if (noJsHost(ctx)) {
+        const arg0 = expr.arguments[0]!;
+        const argTs = ctx.checker.getNonNullableType(ctx.checker.getTypeAtLocation(arg0));
+        const argSym = argTs.getSymbol()?.name;
+        const rawTs = ctx.checker.getTypeAtLocation(arg0);
+        const isAnyOrUnknown = (rawTs.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
+        const isView = argSym !== undefined && (TYPED_ARRAY_NAMES.has(argSym) || argSym === "DataView");
+        // A non-view whose static type is resolvable: ArrayBuffer itself, a
+        // primitive, null/undefined, a plain array, a class/object — all `false`.
+        const isResolvableNonView =
+          !isAnyOrUnknown && !isView && argSym !== "BigInt64Array" && argSym !== "BigUint64Array" && !rawTs.isUnion();
+        if (isView || argSym === "BigInt64Array" || argSym === "BigUint64Array") {
+          // Static `true`. Still evaluate the (possibly side-effecting) arg, drop it.
+          const at = compileExpression(ctx, fctx, arg0);
+          if (at !== null) fctx.body.push({ op: "drop" } as Instr);
+          fctx.body.push({ op: "i32.const", value: 1 } as Instr);
+          return { kind: "i32" };
+        }
+        if (isResolvableNonView) {
+          const at = compileExpression(ctx, fctx, arg0);
+          if (at !== null) fctx.body.push({ op: "drop" } as Instr);
+          fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+          return { kind: "i32" };
+        }
+        // Runtime fallback for `any`/union/unresolved receivers: ref.test the
+        // registered vec carriers (TypedArrays lower to a `$Vec`) and the
+        // DataView window struct. NOTE: standalone shares the `$Vec` carrier
+        // between `number[]` and TypedArrays, so a plain array is
+        // indistinguishable here and reads as a view — an accepted imprecision
+        // for the rare `any` arg; the win is NOT leaking the host import (which
+        // breaks the whole module). Most isView call sites are statically typed.
+        const at = compileExpression(ctx, fctx, arg0, { kind: "externref" });
+        if (at && at.kind !== "externref") coerceType(ctx, fctx, at, { kind: "externref" });
+        const dvWinTypeIdx = getOrRegisterDvWindowType(ctx);
+        const vecTypeIdxs = Array.from(new Set(ctx.vecTypeMap.values()));
+        const anyTmp = allocLocal(fctx, `__isview_any_${fctx.locals.length}`, { kind: "anyref" } as ValType);
+        fctx.body.push({ op: "any.convert_extern" } as Instr);
+        fctx.body.push({ op: "local.set", index: anyTmp } as Instr);
+        let emitted = false;
+        for (const vi of vecTypeIdxs) {
+          fctx.body.push({ op: "local.get", index: anyTmp } as Instr);
+          fctx.body.push({ op: "ref.test", typeIdx: vi } as Instr);
+          if (emitted) fctx.body.push({ op: "i32.or" } as Instr);
+          emitted = true;
+        }
+        fctx.body.push({ op: "local.get", index: anyTmp } as Instr);
+        fctx.body.push({ op: "ref.test", typeIdx: dvWinTypeIdx } as Instr);
+        if (emitted) fctx.body.push({ op: "i32.or" } as Instr);
+        return { kind: "i32" };
+      }
       const argType = compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "externref" });
       if (argType && argType.kind !== "externref") coerceType(ctx, fctx, argType, { kind: "externref" });
       const funcIdx = ensureLateImport(ctx, "__arraybuffer_isView", [{ kind: "externref" }], [{ kind: "i32" }]);

--- a/tests/issue-2594.test.ts
+++ b/tests/issue-2594.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { instantiateWasm } from "../src/runtime-instantiate.js";
+import type { CompileOptions } from "../src/index.js";
+
+// #2594 (Part A) — standalone `ArrayBuffer.isView` host-import leak.
+//   On --target standalone the arm always emitted `ensureLateImport(
+//   "__arraybuffer_isView")`, leaking an `env.*` import → the WHOLE module
+//   failed to instantiate ("Import #0 'env': module is not an object or
+//   function"). §25.1.4.1: isView is true iff the arg has a
+//   [[ViewedArrayBuffer]] slot (any TypedArray or DataView). Now decided
+//   host-free: static-decide on the resolvable arg type, with a vec/DataView-
+//   window `ref.test` fallback for `any`/union args.
+//
+//   Part B (BigInt64Array / BigUint64Array native ctor) is split to a follow-up
+//   gated on the i64-bigint-brand decision (#1349/#1644), per the issue spec.
+async function run(source: string, opts: CompileOptions = {}): Promise<Record<string, Function>> {
+  const result = await compile(source, opts);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const built = buildImports(result.imports, undefined, result.stringPool);
+  // instantiateWasm throwing on a leaked `env` import is exactly the bug this
+  // fixes — a clean instantiate standalone is the core assertion.
+  const { instance } = await instantiateWasm(result.binary, built.env, built.string_constants);
+  built.setExports?.(instance.exports as Record<string, Function>);
+  return instance.exports as Record<string, Function>;
+}
+
+describe("#2594 — ArrayBuffer.isView native standalone (no env leak)", () => {
+  it("isView(new Int32Array(4)) === true (standalone)", async () => {
+    const e = await run(`export function test(): boolean { return ArrayBuffer.isView(new Int32Array(4)); }`, {
+      target: "standalone",
+    });
+    expect(Boolean(e.test!())).toBe(true);
+  });
+
+  it("isView(new DataView(buf)) === true (standalone)", async () => {
+    const e = await run(
+      `export function test(): boolean {
+         const buf = new ArrayBuffer(8);
+         return ArrayBuffer.isView(new DataView(buf));
+       }`,
+      { target: "standalone" },
+    );
+    expect(Boolean(e.test!())).toBe(true);
+  });
+
+  it("isView(new ArrayBuffer(8)) === false — a buffer is not a view (standalone)", async () => {
+    const e = await run(`export function test(): boolean { return ArrayBuffer.isView(new ArrayBuffer(8)); }`, {
+      target: "standalone",
+    });
+    expect(Boolean(e.test!())).toBe(false);
+  });
+
+  it("isView(42 as any) === false (standalone runtime fallback)", async () => {
+    const e = await run(`export function test(): boolean { return ArrayBuffer.isView(42 as any); }`, {
+      target: "standalone",
+    });
+    expect(Boolean(e.test!())).toBe(false);
+  });
+
+  it("isView(null as any) === false (standalone)", async () => {
+    const e = await run(`export function test(): boolean { return ArrayBuffer.isView(null as any); }`, {
+      target: "standalone",
+    });
+    expect(Boolean(e.test!())).toBe(false);
+  });
+
+  it("a whole module using isView instantiates + computes standalone", async () => {
+    // The env leak previously broke the ENTIRE module at instantiate; this
+    // exercises the full happy path (view, non-view buffer, DataView).
+    const e = await run(
+      `export function test(): number {
+         const a = new Int32Array(4);
+         const buf = new ArrayBuffer(8);
+         let n = 0;
+         if (ArrayBuffer.isView(a)) n += 1;
+         if (!ArrayBuffer.isView(buf)) n += 10;
+         if (ArrayBuffer.isView(new DataView(buf))) n += 100;
+         return n; // 111
+       }`,
+      { target: "standalone" },
+    );
+    expect(e.test!()).toBe(111);
+  });
+
+  it("isView(ArrayBuffer) / isView(null) also resolve in gc/host (host-recognizable args)", async () => {
+    // gc/host keeps the host import; an opaque Wasm-native TypedArray is NOT a
+    // real JS view to the host, so only host-recognizable non-views are
+    // asserted here (the standalone tests above cover view recognition).
+    const bufE = await run(`export function test(): boolean { return ArrayBuffer.isView(new ArrayBuffer(8)); }`);
+    expect(Boolean(bufE.test!())).toBe(false);
+    const nullE = await run(`export function test(): boolean { return ArrayBuffer.isView(null as any); }`);
+    expect(Boolean(nullE.test!())).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Standalone `ArrayBuffer.isView` leaked an `env.*` host import that broke the **whole module** at instantiate — sprint 65, parent #2159, part of the `built-ins/ArrayBuffer` (78) bucket. Adjacent to the just-landed #2592/#2595/#2597 (same `calls.ts` TA region).

### Problem
```ts
ArrayBuffer.isView(x)  // standalone: emits env.__arraybuffer_isView
                       // → "Import #0 'env': module is not an object or function" at instantiate
```
The arm always emitted `ensureLateImport("__arraybuffer_isView")` with no host-free fallback, so **any** standalone module calling `isView` failed to instantiate at all.

### Fix (Part A — `ArrayBuffer.isView` host-free)
Gated on `noJsHost(ctx)`, decide §25.1.4.1 host-free (isView is true iff the arg has a `[[ViewedArrayBuffer]]` slot — any TypedArray or DataView):
- **Static-decide** on the resolvable arg type: TypedArray name / `DataView` (and `BigInt64Array`/`BigUint64Array`) → `i32.const 1` (still evaluate + drop a side-effecting arg); a resolvable non-view (ArrayBuffer, primitive, null/undefined, plain array, class/object) → `i32.const 0`.
- **Runtime fallback** for `any`/union args: `any.convert_extern` + `ref.test` over the registered `$Vec` carriers OR the `$__dv_window` struct (mirrors `emitArrayIsArrayExternrefPredicate`). Documented imprecision: standalone shares the `$Vec` carrier between `number[]` and TypedArrays, so a plain array via an `any` arg reads as a view — accepted for the rare untyped call; the win is **not leaking the host import**. Host/gc mode is unchanged.

### Part B split out (per the issue spec)
**BigInt64Array / BigUint64Array native i64-element ctor** + the DataView `getBigInt64`/`setBigInt64` bare-vec leak check are deferred to a follow-up: they touch the unresolved i64-bigint-brand ValType decision (#1349/#1644, `project_bigint_i64_brand_gate`). Landing them now would couple this conformance slice to an architect-gated representation choice.

## Files
- `src/codegen/expressions/calls.ts` — `ArrayBuffer.isView` `noJsHost` branch
- `tests/issue-2594.test.ts` — 7 tests

## Validation
- `tests/issue-2594.test.ts`: **7 tests pass** — Int32Array/DataView → true, ArrayBuffer/primitive/null → false, `any` runtime fallback, and a whole-module **instantiate-and-compute** proof (the env leak previously broke the entire module).
- `tsc --noEmit` clean; `prettier --check` clean; `check:coercion-sites` OK; packed-typedarray + dataview-window suites still green.
- No new host imports standalone; host/gc path byte-unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA