### PR TITLE
fix(#1528a): new on arrow-function value throws real TypeError

### DIFF
--- a/plan/issues/1528-non-constructor-typeerror-promise-and-species.md
+++ b/plan/issues/1528-non-constructor-typeerror-promise-and-species.md
@@ -543,3 +543,37 @@ that falls past the static guards.
 ## Frontmatter reconcile (2026-06-12)
 
 Was `in-progress` with no open PR, no active agent, and no Suspended Work section (session died sprints 42-52). Reset to `ready` during the sprint-62 issue review; re-validate against current main before claiming (#2148).
+
+## #1528a-arrow subset landed (2026-06-22)
+
+Landed the **arrow-function-value** subset of the #1528a non-constructor cluster
+— a small, substrate-independent slice that reuses the **existing, tested**
+`__construct` brand-check path (#1732 S1), avoiding the
+`flushLateImportShifts`-mid-function index corruption that forced the PR #608
+revert of the broad `compileDynamicConstruct`.
+
+**Change** — `src/codegen/expressions/new-super.ts`,
+`resolvesToNonConstructableValue` (the #1732 S1 helper): an **arrow-function
+initializer** (`const f = () => 1; new f()`) is now recognised as a provably-
+non-constructable value (§15.3.4 — arrows have no [[Construct]]), so `new f()`
+routes through the `__construct` brand check and throws a real
+`TypeError("… is not a constructor")` instead of slipping into the unknown-ctor
+path and silently not throwing. 8 lines, additive, alongside the existing
+prototype-method / `.bind`/`.call`/`.apply` shapes. No runtime.ts change; no new
+coercion site.
+
+**Tests** — `tests/issue-1528.test.ts` gains a `#1528a — arrow-function value`
+describe (5 cases: arrow value, cast-wrapped arrow, arrow-with-params throw;
+class + function-declaration construct regression guards). 11/11 pass. Full
+constructor/new suite (issue-1732-s1/s2, issue-1519, fn-constructor,
+issue-2026-constructor-identity-any) green — zero regressions.
+
+**Still open (substrate-blocked, #1632b-2):** dynamically **CONSTRUCTING** a
+runtime function VALUE (factory-returned `function C(){}` → `new C()`) — verified
+this needs the closure-construct host bridge (`_wrapCallableForHost`'s construct
+trap) PLUS the `__call_fn_*` arity dispatcher to be reachable for the value, and
+behaves inconsistently depending on `setExports` timing. That is the deeper
+closure-as-dynamic-constructor work, NOT a clean dev slice. The non-constructor
+**throw** cases (arrows, bound functions, prototype methods, call-only callables)
+are the substrate-independent, test262-cluster-dominant part and are now covered.
+Issue stays `ready` for the remaining construct-a-fn-value cluster.

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -149,6 +149,14 @@ function resolvesToNonConstructableValue(ctx: CodegenContext, calleeExpr: ts.Exp
           ? e.expression
           : (e as ts.NonNullExpression).expression;
     }
+    // (#1528a) An arrow function is PROVABLY never a constructor — §15.3.4
+    // arrow functions have no [[Construct]] internal method, so `new (arrow)()`
+    // must throw TypeError (§7.3.15 Construct → §7.2.4 IsConstructor). Through a
+    // local of type `any` (`const f = () => 1; new f()`) no static guard sees
+    // the arrow, so control reaches the unknown-ctor path and wrongly does not
+    // throw; route it through the `__construct` brand check (which throws a real
+    // TypeError) just like the prototype-method / bound-function shapes below.
+    if (ts.isArrowFunction(e)) return true;
     // `<...>.prototype.<method>` — a method pulled off a prototype.
     if (ts.isPropertyAccessExpression(e)) {
       const obj = e.expression;

--- a/tests/issue-1528.test.ts
+++ b/tests/issue-1528.test.ts
@@ -133,3 +133,90 @@ export function test(): number {
     expect(exports.test!()).toBe(1);
   });
 });
+
+// #1528a — `new <arrow-function value>()` must throw a real TypeError.
+// An arrow function has no [[Construct]] (§15.3.4), so `new (arrow)()` is a
+// non-constructor TypeError (§7.3.15 Construct → §7.2.4 IsConstructor). Through
+// a local of type `any` no static guard saw the arrow, so control reached the
+// unknown-constructor path and wrongly did not throw. The fix marks an arrow
+// initializer as a provably-non-constructable value in
+// `resolvesToNonConstructableValue`, routing it through the existing `__construct`
+// brand check (which throws a real TypeError instance), alongside the
+// prototype-method / bound-function shapes (#1732 S1). This is the
+// substrate-independent subset of the #1528a non-constructor cluster; dynamically
+// CONSTRUCTING a runtime function value (vs. throwing) remains a closure-construct
+// substrate follow-up (#1632b-2).
+describe("issue #1528a — new on an arrow-function value throws real TypeError", () => {
+  it("`const f = () => 1; new f()` throws an instance of TypeError", async () => {
+    const source = `
+export function test(): number {
+  const f: any = () => 1;
+  try {
+    new f();
+    return -1;
+  } catch (e: any) {
+    return e instanceof TypeError ? 1 : -2;
+  }
+}
+`;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe(1);
+  });
+
+  it("`const f = (() => 1) as any; new f()` (cast-wrapped) throws TypeError", async () => {
+    const source = `
+export function test(): number {
+  const f = (() => 1) as any;
+  try {
+    new f();
+    return -1;
+  } catch (e: any) {
+    return e instanceof TypeError ? 1 : -2;
+  }
+}
+`;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe(1);
+  });
+
+  it("arrow with params is still a non-constructor", async () => {
+    const source = `
+export function test(): number {
+  const f: any = (a: number, b: number) => a + b;
+  try {
+    new f(1, 2);
+    return -1;
+  } catch (e: any) {
+    return e instanceof TypeError ? 1 : -2;
+  }
+}
+`;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe(1);
+  });
+
+  // Regression guards — real constructors must STILL construct (not throw).
+  it("a user class still constructs (no false TypeError)", async () => {
+    const source = `
+class Box { v = 7; }
+export function test(): number {
+  const o = new Box();
+  return o.v;
+}
+`;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe(7);
+  });
+
+  it("a function declaration still constructs (no false TypeError)", async () => {
+    const source = `
+function C(this: any) { (this as any).x = 3; }
+export function test(): number {
+  const o: any = new C();
+  return o.x;
+}
+`;
+    const exports = await compileToWasm(source);
+    expect(exports.test!()).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

The substrate-independent **arrow-function-value** subset of the #1528a
non-constructor cluster. An arrow function has no `[[Construct]]` (§15.3.4), so
`new (arrow)()` is a non-constructor `TypeError` (§7.3.15 Construct → §7.2.4
IsConstructor). Through a local of type `any` (`const f = () => 1; new f()`) no
static guard saw the arrow, so control reached the unknown-constructor path and
**wrongly did not throw**.

## Change — `src/codegen/expressions/new-super.ts` (8 lines)

`resolvesToNonConstructableValue` (the #1732 S1 helper) now also recognises an
**arrow-function initializer** as a provably-non-constructable value, routing
`new f()` through the existing, tested `__construct` brand check (which throws a
real `TypeError` instance) — alongside the prototype-method / `.bind`/`.call`/
`.apply` shapes it already handled. No `runtime.ts` change, no new coercion site.

## Why this scope (not the full dynamic-construct)

The broad `compileDynamicConstruct` (PR #608) was **reverted** for
`flushLateImportShifts`-mid-function index corruption (#618 pattern). This slice
deliberately reuses the already-tested `__construct` *throw* path and adds no new
mid-function flush. Verified during implementation that dynamically
**CONSTRUCTING** a runtime function value (factory-returned `function C(){}`)
needs the closure-construct host bridge + `__call_fn_*` arity dispatch and behaves
inconsistently with `setExports` timing — that remains the closure-as-dynamic-
constructor substrate follow-up (#1632b-2). The non-constructor **throw** cases
(arrows, bound functions, prototype methods, call-only callables) are the
substrate-independent, test262-cluster-dominant part and are now covered. #1528
stays `ready` for the remaining construct-a-fn-value cluster.

## Tests

`tests/issue-1528.test.ts` gains a `#1528a — arrow-function value` describe:
arrow value, cast-wrapped arrow, arrow-with-params throw; class + function-
declaration **construct** regression guards. **11/11 pass** (6 existing #1528b +
5 new). Full constructor/new suite (issue-1732-s1/s2, issue-1519, fn-constructor,
issue-2026-constructor-identity-any) green — zero regressions. tsc + prettier +
coercion-sites gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA