### PR TITLE
fix(#2604+#2607): standalone Set brand-check — .call dispatch + set-algebra arg validation

### DIFF
--- a/plan/issues/2604-standalone-set-method-brand-check-call.md
+++ b/plan/issues/2604-standalone-set-method-brand-check-call.md
@@ -1,7 +1,9 @@
 ---
 id: 2604
 title: "Standalone Set.prototype.METHOD.call(nonSet) — native dispatch + [[SetData]] brand-check TypeError"
-status: ready
+status: done
+completed: 2026-06-22
+assignee: ttraenkler/agent-af6ff9d85ab8e6fc4
 sprint: 65
 created: 2026-06-22
 priority: high
@@ -145,3 +147,41 @@ call $__set_add
 - Verify host/gc mode unchanged (the pre-check is gated on `ctx.nativeStrings`).
 - Independent of #2580 value-rep substrate (brand-test is a `ref.test`, not a
   dynamic property read).
+
+## Resolution (2026-06-22)
+
+Landed with #2607 in one branch (`issue-2604-2607-set-brand-check`).
+
+**Changes**
+- `src/codegen/set-runtime.ts` — new shared `emitSetBrandCheck(ctx, fctx, recvType)`:
+  normalises the compiled receiver to anyref, `ref.test $Map` (NON-trapping); on a
+  miss throws a *catchable* `TypeError` via `emitThrowTypeError` (NOT `ref.cast`,
+  which traps `illegal cast`), on a hit `ref.cast`s to the validated `(ref $Map)`.
+  Plus `tryCompileSetReflectiveCall` (dispatches `Set.prototype.METHOD.call(recv,…)`
+  / `inst.METHOD.call(recv,…)` for add/has/delete/clear after the brand-check) and
+  the cheap `isSetReflectiveCallShape` predicate.
+- `src/codegen/expressions/calls.ts` — in the `.call`/`.apply` handler, BEFORE the
+  generic #2193 member-closure recovery: when `isSetReflectiveCallShape` matches,
+  `addUnionImports(ctx)` (so the arg-boxing `__box_number` is registered up-front,
+  mirroring the direct path's extern.ts setup — avoids a mid-body index shift) then
+  `tryCompileSetReflectiveCall`. ADDS a Set pre-check; does NOT rewrite the generic
+  path (#2193 reflective tests unchanged).
+
+Gated on `ctx.nativeStrings`; host/gc mode unchanged. Both syntactic shapes
+(`Set.prototype.add.call` and `s.add.call`) are caught. `.apply` and
+forEach/keys/values/entries reflective forms fall through (deferred). The
+Set-vs-Map kind-tag discriminator (`internal-slot-{map,weakset}` sub-rows) is the
+documented stretch — those few rows stay red; the primitive/object/array/null
+bulk flips.
+
+## Test Results
+
+- `tests/issue-2604-set-brand-check.test.ts` — 31/31 pass: add/has/delete ×
+  {"", 0, true, null, undefined, {}, [], Set.prototype} all throw TypeError;
+  clear.call(non-Set) throws; instance form `s.add.call({},1)` throws; valid
+  `Set.prototype.{has,add,delete,clear}.call(realSet,…)` dispatch correctly;
+  direct `s.add`/`s.has` regression guard.
+- Set regression suites green (issue-2162-set-algebra/standalone-set/set-foreach/
+  iterators, issue-42-set-spread; Map foreach/from-array; #2193 reflective — 88
+  tests total). gc-mode Set (direct + reflective + algebra) unchanged.
+- tsc + prettier + coercion-sites gate clean.

--- a/plan/issues/2607-standalone-set-algebra-getsetrecord-arg-validation.md
+++ b/plan/issues/2607-standalone-set-algebra-getsetrecord-arg-validation.md
@@ -1,7 +1,9 @@
 ---
 id: 2607
 title: "Standalone Set set-algebra: GetSetRecord argument validation (TypeError on non-object / non-Set arg)"
-status: ready
+status: done
+completed: 2026-06-22
+assignee: ttraenkler/agent-af6ff9d85ab8e6fc4
 sprint: 65
 created: 2026-06-22
 priority: medium
@@ -129,3 +131,28 @@ call $__set_isSubsetOf
 - Gated on `ctx.nativeStrings`; host/gc unchanged.
 - Conservatively throwing for genuine set-like objects is acceptable (those rows
   are M2-deferred, currently failing anyway — no regression).
+
+## Resolution (2026-06-22)
+
+Landed with #2604 in one branch (`issue-2604-2607-set-brand-check`).
+
+**Change** — `src/codegen/set-algebra.ts`, `tryCompileNativeSetAlgebraCall`:
+replace the bare `castToMap(arg)` (which silently fell through to the host path
+or trap-cast) with the shared `emitSetBrandCheck` from #2604 — `ref.test $Map` →
+catchable `TypeError` on a non-Set argument (GetSetRecord 24.2.1.2 step 1 +
+has/keys-callable steps), else `ref.cast $Map`. Covers both predicate
+(`isSubsetOf`/`isSupersetOf`/`isDisjointFrom`) and set-op (`union`/`intersection`/
+`difference`/`symmetricDifference`) methods.
+
+The genuine set-LIKE-object data path (read `obj.size`/`has`/`keys` off an `any`)
+is **#2580 M2** (dynamic property read) and is conservatively (correctly) rejected
+with a TypeError here — those rows currently fail anyway, so no regression.
+
+## Test Results
+
+- `tests/issue-2607-set-algebra-arg-validation.test.ts` — 27/27 pass: predicates
+  × {1, "", true, [], {}} throw TypeError; set-ops × {1, []} throw; valid
+  `isSubsetOf`/`isDisjointFrom`/`union`/`intersection` with a real Set arg still
+  run the algebra (no over-throw).
+- Reuses the #2604 `emitSetBrandCheck` helper; no new coercion site. tsc +
+  prettier + coercion gate clean; Set/Map regression suites green.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -21,6 +21,7 @@ import {
 import type { Instr, ValType } from "../../ir/types.js";
 import { compileArrayMethodCall, compileArrayPrototypeCall, resolveArrayInfo } from "../array-methods.js";
 import { emitCollectionIteratorVec } from "../map-runtime.js"; // (#42) native Set/Map → vec, shared with spread / Array.from
+import { isSetReflectiveCallShape, tryCompileSetReflectiveCall } from "../set-runtime.js"; // (#2604) Set.prototype.METHOD.call brand-check
 import { classMemberFuncKey } from "../class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
 import { ensureNativeIteratorRuntime } from "../iterator-native.js"; // (#2169c) native Array.from drain
 import { reserveClosedMethodDispatch, reserveClosedMethodDispatchVararg } from "../closed-method-dispatch.js";
@@ -3408,6 +3409,20 @@ function compileCallExpression(
     if (propAccess.name.text === "call" || propAccess.name.text === "apply") {
       const isCall = propAccess.name.text === "call";
       const innerExpr = propAccess.expression;
+
+      // (#2604) Reflective `Set.prototype.METHOD.call(recv, …)` /
+      // `inst.METHOD.call(recv, …)` — brand-check the receiver ([[SetData]]) and
+      // dispatch to the native Set runtime. Runs BEFORE the generic #2193
+      // member-closure recovery (which has no native-Set knowledge), and only
+      // matches a Set data-method closure under nativeStrings, so it ADDS a
+      // Set-specific pre-check without rewriting the generic path. addUnionImports
+      // up-front (mirrors extern.ts's direct-path setup) so the arg-boxing
+      // `__box_number` the dispatch emits is registered without a mid-body shift.
+      if (isSetReflectiveCallShape(ctx, expr)) {
+        addUnionImports(ctx);
+        const setReflResult = tryCompileSetReflectiveCall(ctx, fctx, expr);
+        if (setReflResult !== undefined) return setReflResult;
+      }
 
       // (#2193 PR-B) Reflective `m.call/apply(thisArg, …)` on a value-erased
       // `$NativeProto` member closure (e.g. `const m = Array.prototype.slice`).

--- a/src/codegen/set-algebra.ts
+++ b/src/codegen/set-algebra.ts
@@ -30,7 +30,7 @@ import { addFuncType } from "./registry/types.js";
 import type { InnerResult } from "./shared.js";
 import { compileExpression } from "./shared.js";
 import { ensureMapHelpers } from "./map-runtime.js";
-import { ensureSetHelpers } from "./set-runtime.js";
+import { emitSetBrandCheck, ensureSetHelpers } from "./set-runtime.js";
 
 const TOMBSTONE_BIT = 0x40000000; // mirrors map-runtime.ts
 const M_ENTRIES = 1;
@@ -367,9 +367,18 @@ export function tryCompileNativeSetAlgebraCall(
   // receiver → ref $Map
   const recvType = compileExpression(ctx, fctx, propAccess.expression);
   if (!castToMap(ctx, fctx, recvType)) return undefined;
-  // arg → ref $Map
+  // (#2607) GetSetRecord(arg) argument validation — spec 24.2.1.2 step 1 ("If
+  // obj is not an Object, throw a TypeError") + steps 7-10 (has/keys must be
+  // callable). A non-Set argument (primitive `1`/`""`/`true`/`Symbol()`, or a
+  // plain object / array that is not the `$Map` backing struct) throws a
+  // *catchable* TypeError — NOT a `ref.cast` trap (illegal cast) and NOT a host
+  // fall-through (which silently completes / leaks `env`). Reuses #2604's
+  // `emitSetBrandCheck` (`ref.test $Map` → throw-or-cast), which leaves the
+  // validated `(ref $Map)` on the stack. A genuine set-LIKE object (size/has/
+  // keys on an `any`) is conservatively rejected here — that data path is
+  // #2580 M2 (dynamic property read), currently failing anyway (no regression).
   const argType = compileExpression(ctx, fctx, callExpr.arguments[0]!);
-  if (!castToMap(ctx, fctx, argType)) return undefined;
+  emitSetBrandCheck(ctx, fctx, argType);
 
   fctx.body.push({ op: "call", funcIdx: helperIdx });
   return isSetOp ? ({ kind: "ref", typeIdx: ctx.mapTypeIdx } as ValType) : ({ kind: "i32" } as ValType);

--- a/src/codegen/set-runtime.ts
+++ b/src/codegen/set-runtime.ts
@@ -31,7 +31,9 @@ import type { Instr, ValType } from "../ir/types.js";
  * (`union`/`intersection`/…) are follow-up slices.
  */
 import { ts } from "../ts-api.js";
+import { allocTempLocal, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { emitThrowTypeError } from "./expressions/helpers.js";
 import {
   coerceSetArgToAnyref,
   compileNativeCollectionIterator,
@@ -41,6 +43,10 @@ import {
 import { addFuncType } from "./registry/types.js";
 import type { InnerResult } from "./shared.js";
 import { VOID_RESULT, compileExpression } from "./shared.js";
+
+/** Set.prototype methods whose `[[SetData]]` brand-check + native dispatch this
+ *  module owns (the data + iteration methods; set-algebra lives in set-algebra.ts). */
+const SET_BRAND_METHODS = new Set(["add", "has", "delete", "clear", "forEach", "entries", "keys", "values"]);
 
 /**
  * Emit the `__set_add(m, v) -> ref $Map` helper (idempotent). `Set.add` stores
@@ -93,6 +99,67 @@ function castReceiverToMap(ctx: CodegenContext, fctx: FunctionContext, recvType:
     return false; // wrong struct — not our Set
   }
   return true;
+}
+
+/**
+ * (#2604) `[[SetData]]` brand-check for a reflectively-invoked Set method
+ * receiver (`Set.prototype.METHOD.call(recv, …)` / `inst.METHOD.call(recv, …)`).
+ * Consumes the just-compiled receiver value (`recvType` describes what is on the
+ * stack) and leaves a non-null `(ref $Map)` — the validated backing struct — on
+ * the stack.
+ *
+ * Spec 24.2.3.* step "If S does not have a [[SetData]] internal slot, throw a
+ * TypeError": uses a NON-TRAPPING `ref.test $Map` (0/1, never traps on
+ * null/primitive/wrong-struct) then branches — a miss throws a *catchable*
+ * `TypeError` (NOT `ref.cast`, which would trap `illegal cast`, which test262
+ * `assert.throws(TypeError, …)` does not accept). On a hit the value is
+ * `ref.cast`-ed (safe — the test passed) to `(ref $Map)`.
+ *
+ * NOTE: a real `Map`/`WeakSet` is ALSO `$Map`-backed and passes `ref.test $Map`;
+ * distinguishing Set from Map/Weak by struct alone is not possible without a
+ * kind tag (the `does-not-have-setdata-internal-slot-{map,weakset}.js` sub-rows,
+ * a documented stretch — #2604). The primitive / plain-object / array / null
+ * rows (the bulk) flip here.
+ */
+export function emitSetBrandCheck(ctx: CodegenContext, fctx: FunctionContext, recvType: ValType | null): void {
+  // Normalise the receiver to an anyref so `ref.test`/`ref.cast` apply uniformly
+  // across externref / ref-struct / primitive-typed receivers.
+  if (recvType === null) {
+    // A statically void/never receiver — emit a null anyref so the test misses.
+    fctx.body.push({ op: "ref.null", typeIdx: -1 } as unknown as Instr);
+  } else if (recvType.kind === "externref") {
+    fctx.body.push({ op: "any.convert_extern" } as Instr);
+  } else if (recvType.kind === "i32" || recvType.kind === "f64" || recvType.kind === "i64") {
+    // A primitive scalar receiver (`Set.prototype.add.call(0, …)` etc.) can never
+    // be the backing struct — drop it and throw unconditionally.
+    fctx.body.push({ op: "drop" } as Instr);
+    emitThrowTypeError(ctx, fctx, "TypeError: Method Set.prototype.* called on incompatible receiver");
+    // After the throw the stack is polymorphic; push a null $Map sentinel so the
+    // (unreached) downstream call typechecks.
+    fctx.body.push({ op: "ref.null", typeIdx: ctx.mapTypeIdx } as Instr);
+    return;
+  }
+  // Receiver is now an anyref (or already a ref/eqref subtype) on the stack.
+  const recvTmp = allocTempLocal(fctx, { kind: "anyref" } as ValType);
+  fctx.body.push({ op: "local.tee", index: recvTmp } as Instr);
+  fctx.body.push({ op: "ref.test", typeIdx: ctx.mapTypeIdx } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [],
+    else: [],
+  } as Instr);
+  // Build the throw into the else arm via a temporary body swap so the late-import
+  // shift in emitThrowTypeError patches the right buffer.
+  const ifInstr = fctx.body[fctx.body.length - 1] as unknown as { else: Instr[] };
+  const savedBody = fctx.body;
+  fctx.body = ifInstr.else;
+  emitThrowTypeError(ctx, fctx, "TypeError: Method Set.prototype.* called on incompatible receiver");
+  fctx.body = savedBody;
+  // Hit: cast the saved receiver to the concrete backing struct.
+  fctx.body.push({ op: "local.get", index: recvTmp } as Instr);
+  fctx.body.push({ op: "ref.cast", typeIdx: ctx.mapTypeIdx } as Instr);
+  releaseTempLocal(fctx, recvTmp);
 }
 
 /**
@@ -155,6 +222,128 @@ export function tryCompileNativeSetMethodCall(
       coerceSetArgToAnyref(ctx, fctx, vt);
       fctx.body.push({ op: "call", funcIdx: helperIdx });
       // has/delete → i32 (boolean).
+      return { kind: "i32" } as ValType;
+    }
+    case "clear": {
+      fctx.body.push({ op: "call", funcIdx: helperIdx });
+      return VOID_RESULT;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * (#2604) Is `expr` syntactically `X.METHOD` where METHOD is a Set data method
+ * and X is `Set.prototype` or a statically Set-typed expression? Used to gate the
+ * reflective `.call`/`.apply` brand-check dispatch.
+ */
+function setMethodClosureName(ctx: CodegenContext, closure: ts.Expression): string | undefined {
+  let e: ts.Expression = closure;
+  while (ts.isParenthesizedExpression(e) || ts.isAsExpression(e) || ts.isNonNullExpression(e)) {
+    e = (e as ts.ParenthesizedExpression | ts.AsExpression | ts.NonNullExpression).expression;
+  }
+  if (!ts.isPropertyAccessExpression(e)) return undefined;
+  const method = e.name.text;
+  if (!SET_BRAND_METHODS.has(method)) return undefined;
+  const obj = e.expression;
+  // `Set.prototype.METHOD`
+  if (
+    ts.isPropertyAccessExpression(obj) &&
+    obj.name.text === "prototype" &&
+    ts.isIdentifier(obj.expression) &&
+    obj.expression.text === "Set"
+  ) {
+    return method;
+  }
+  // `<setExpr>.METHOD` where setExpr is statically a Set.
+  try {
+    const t = ctx.checker.getTypeAtLocation(obj);
+    if (t.getSymbol()?.name === "Set") return method;
+  } catch {
+    /* type unavailable */
+  }
+  return undefined;
+}
+
+/**
+ * (#2604) Reflective `Set.prototype.METHOD.call(recv, …)` /
+ * `inst.METHOD.call(recv, …)` dispatch with a `[[SetData]]` brand-check.
+ *
+ * The direct `s.METHOD(v)` shape is handled by {@link tryCompileNativeSetMethodCall}
+ * (gated on the receiver's static `className === "Set"`); the reflective `.call`
+ * shape never reaches it, so neither the native dispatch nor the spec brand-check
+ * (24.2.3.* "If S does not have a [[SetData]] internal slot, throw a TypeError")
+ * fires. This handler recognises the `.call` form, compiles the FIRST `.call`
+ * argument as the receiver, brand-checks it ({@link emitSetBrandCheck} →
+ * catchable TypeError on a non-Set), then routes the remaining args to the same
+ * `__set_add`/`__map_has`/`__map_delete`/`__map_clear` helpers.
+ *
+ * Returns the result `InnerResult` when handled, or `undefined` to fall through.
+ * Scoped to add/has/delete/clear (the bulk of the ~84-row brand-check bucket);
+ * forEach/keys/values/entries reflective forms fall through (rarer). `.apply`
+ * (packed-args) is deferred — only `.call` is intercepted here.
+ */
+/**
+ * (#2604) Cheap syntactic predicate (NO codegen): does `expr` match the
+ * reflective Set data-method `.call` shape this module dispatches? The caller
+ * (calls.ts) uses it to gate an `addUnionImports` BEFORE invoking
+ * {@link tryCompileSetReflectiveCall} — the arg-boxing (`__box_number`) the
+ * dispatch emits must be registered up-front (the direct path relies on
+ * extern.ts doing the same), since adding it mid-body would shift indices.
+ */
+export function isSetReflectiveCallShape(ctx: CodegenContext, expr: ts.CallExpression): boolean {
+  if (!ctx.nativeStrings) return false;
+  if (!ts.isPropertyAccessExpression(expr.expression)) return false;
+  const dispatch = expr.expression;
+  if (dispatch.name.text !== "call") return false;
+  const method = setMethodClosureName(ctx, dispatch.expression);
+  return method === "add" || method === "has" || method === "delete" || method === "clear";
+}
+
+export function tryCompileSetReflectiveCall(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+): InnerResult | undefined {
+  if (!ctx.nativeStrings) return undefined;
+  if (!ts.isPropertyAccessExpression(expr.expression)) return undefined;
+  const dispatch = expr.expression; // `<closure>.call`
+  if (dispatch.name.text !== "call") return undefined; // .apply deferred
+  const method = setMethodClosureName(ctx, dispatch.expression);
+  if (method === undefined) return undefined;
+  // Only the data methods are dispatched here; forEach/iterators fall through.
+  if (method !== "add" && method !== "has" && method !== "delete" && method !== "clear") return undefined;
+
+  ensureSetHelpers(ctx);
+  if (ctx.mapTypeIdx < 0) return undefined;
+  const helperName = method === "add" ? "__set_add" : `__map_${method}`;
+  const helperIdx = ctx.mapHelpers.get(helperName);
+  if (helperIdx === undefined) return undefined;
+
+  const callArgs = expr.arguments;
+  // `Set.prototype.add.call(recv, v)` — arg0 is the receiver, arg1.. are method args.
+  const recvExpr = callArgs.length > 0 ? callArgs[0]! : undefined;
+  const recvType = recvExpr ? compileExpression(ctx, fctx, recvExpr) : null;
+  if (recvExpr === undefined) {
+    // `.call()` with no receiver → `this` is undefined → TypeError.
+    emitThrowTypeError(ctx, fctx, "TypeError: Method Set.prototype.* called on incompatible receiver");
+    fctx.body.push({ op: "ref.null", typeIdx: ctx.mapTypeIdx } as Instr);
+  } else {
+    emitSetBrandCheck(ctx, fctx, recvType); // leaves (ref $Map) on the stack
+  }
+
+  switch (method) {
+    case "add": {
+      const vt = callArgs.length > 1 ? compileExpression(ctx, fctx, callArgs[1]!) : null;
+      coerceSetArgToAnyref(ctx, fctx, vt);
+      fctx.body.push({ op: "call", funcIdx: helperIdx });
+      return { kind: "ref", typeIdx: ctx.mapTypeIdx } as ValType;
+    }
+    case "has":
+    case "delete": {
+      const vt = callArgs.length > 1 ? compileExpression(ctx, fctx, callArgs[1]!) : null;
+      coerceSetArgToAnyref(ctx, fctx, vt);
+      fctx.body.push({ op: "call", funcIdx: helperIdx });
       return { kind: "i32" } as ValType;
     }
     case "clear": {

--- a/tests/issue-2604-set-brand-check.test.ts
+++ b/tests/issue-2604-set-brand-check.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+
+// #2604 — Standalone `Set.prototype.METHOD.call(recv, …)` / `inst.METHOD.call(recv, …)`
+//   native dispatch + `[[SetData]]` brand-check TypeError.
+//
+// The reflective `.call` shape never reached `tryCompileNativeSetMethodCall`
+// (which only fires on a direct `s.add(v)` with a static Set receiver), so it
+// neither routed to the native Set runtime NOR brand-checked the receiver — a
+// non-Set receiver (`""`, `0`, `{}`, `[]`, `null`, `new Map()`, `Set.prototype`)
+// ran to completion instead of throwing the spec TypeError (24.2.3.* "If S does
+// not have a [[SetData]] internal slot, throw a TypeError").
+//
+// Fix: a Set-method `.call` pre-check in calls.ts → `tryCompileSetReflectiveCall`
+// (set-runtime.ts) compiles the first `.call` arg as the receiver, runs the
+// shared `emitSetBrandCheck` (`ref.test $Map` → catchable TypeError on a miss),
+// then dispatches add/has/delete/clear to the native helpers. Gated on
+// nativeStrings; the generic #2193 member-closure path is unchanged.
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, { target: "standalone", skipSemanticDiagnostics: true } as never);
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  const io = r.importObject as WebAssembly.Imports & { __setExports?: (e: Record<string, unknown>) => void };
+  const { instance } = await WebAssembly.instantiate(r.binary, io);
+  io.__setExports?.(instance.exports as Record<string, unknown>);
+  return (instance.exports as { test(): unknown }).test();
+}
+
+// Each method × non-Set receiver → 1 if a TypeError was thrown.
+const throwsFor = (method: string, recv: string, args = "") =>
+  `export function test(): number {
+     try { Set.prototype.${method}.call(${recv} as any${args}); return 0; }
+     catch (e: any) { return e instanceof TypeError ? 1 : 2; }
+   }`;
+
+describe("#2604 Set.prototype.METHOD.call brand-check throws TypeError on non-Set receiver", () => {
+  const methods = ["add", "has", "delete"] as const;
+  const primitives = ['""', "0", "true", "null", "undefined"] as const;
+  for (const m of methods) {
+    for (const p of primitives) {
+      it(`${m}.call(${p}) → TypeError`, async () => {
+        expect(await runStandalone(throwsFor(m, p, ", 1"))).toBe(1);
+      });
+    }
+    it(`${m}.call({}) (plain object) → TypeError`, async () => {
+      expect(await runStandalone(throwsFor(m, "{}", ", 1"))).toBe(1);
+    });
+    it(`${m}.call([]) (array) → TypeError`, async () => {
+      expect(await runStandalone(throwsFor(m, "[]", ", 1"))).toBe(1);
+    });
+    it(`${m}.call(Set.prototype) → TypeError`, async () => {
+      expect(await runStandalone(throwsFor(m, "Set.prototype", ", 1"))).toBe(1);
+    });
+  }
+
+  it("clear.call(non-Set) → TypeError", async () => {
+    expect(await runStandalone(throwsFor("clear", '""'))).toBe(1);
+  });
+
+  it("instance form `s.add.call({}, 1)` → TypeError", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const s = new Set(); try { s.add.call({} as any, 1); return 0; } catch (e: any) { return e instanceof TypeError ? 1 : 2; } }`,
+      ),
+    ).toBe(1);
+  });
+});
+
+describe("#2604 valid Set receiver dispatches to the native runtime", () => {
+  it("Set.prototype.has.call(realSet, v) returns the membership boolean", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const s = new Set([5]); return Set.prototype.has.call(s, 5) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("Set.prototype.add.call(realSet, v) mutates the set (chainable)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const s = new Set(); Set.prototype.add.call(s, 9); return s.has(9) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("Set.prototype.delete.call(realSet, v) removes and returns true", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const s = new Set([5]); const r = Set.prototype.delete.call(s, 5); return r && !s.has(5) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("Set.prototype.clear.call(realSet) empties the set", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const s = new Set([1, 2]); Set.prototype.clear.call(s); return s.size === 0 ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("regression: direct s.add/s.has still works", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const s = new Set(); s.add(7); return s.has(7) ? 1 : 0; }`),
+    ).toBe(1);
+  });
+});

--- a/tests/issue-2607-set-algebra-arg-validation.test.ts
+++ b/tests/issue-2607-set-algebra-arg-validation.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+
+// #2607 — Standalone Set set-algebra GetSetRecord argument validation.
+//
+// The ES2025 set-algebra methods (union/intersection/difference/
+// symmetricDifference/isSubsetOf/isSupersetOf/isDisjointFrom) run
+// GetSetRecord(obj) on their single argument (spec 24.2.1.2): "If obj is not an
+// Object, throw a TypeError" + has/keys must be callable. Standalone silently
+// completed (host fall-through / leak) or trap-cast a non-Set argument instead
+// of throwing the spec TypeError.
+//
+// Fix: `tryCompileNativeSetAlgebraCall` (set-algebra.ts) replaces the bare
+// `castToMap(arg)` with the shared `emitSetBrandCheck` (#2604) — `ref.test $Map`
+// → catchable TypeError on a non-Set, else `ref.cast $Map`. The validation/throw
+// cases flip; the genuine set-LIKE-object data path is #2580 M2 (dynamic read)
+// and conservatively (correctly) throws here for now.
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, { target: "standalone", skipSemanticDiagnostics: true } as never);
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  const io = r.importObject as WebAssembly.Imports & { __setExports?: (e: Record<string, unknown>) => void };
+  const { instance } = await WebAssembly.instantiate(r.binary, io);
+  io.__setExports?.(instance.exports as Record<string, unknown>);
+  return (instance.exports as { test(): unknown }).test();
+}
+
+const throwsFor = (method: string, arg: string) =>
+  `export function test(): number {
+     const s = new Set([1, 2, 3]);
+     try { s.${method}(${arg} as any); return 0; }
+     catch (e: any) { return e instanceof TypeError ? 1 : 2; }
+   }`;
+
+describe("#2607 set-algebra throws TypeError on a non-Set argument", () => {
+  const predicates = ["isSubsetOf", "isSupersetOf", "isDisjointFrom"] as const;
+  const setOps = ["union", "intersection", "difference", "symmetricDifference"] as const;
+  const badArgs = ["1", '""', "true", "[]", "{}"] as const;
+
+  for (const m of predicates) {
+    for (const a of badArgs) {
+      it(`${m}(${a}) → TypeError`, async () => {
+        expect(await runStandalone(throwsFor(m, a))).toBe(1);
+      });
+    }
+  }
+  for (const m of setOps) {
+    it(`${m}(1) (primitive) → TypeError`, async () => {
+      expect(await runStandalone(throwsFor(m, "1"))).toBe(1);
+    });
+    it(`${m}([]) (array) → TypeError`, async () => {
+      expect(await runStandalone(throwsFor(m, "[]"))).toBe(1);
+    });
+  }
+});
+
+describe("#2607 valid Set argument still runs the algebra (no over-throw)", () => {
+  it("isSubsetOf(realSet) → boolean", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a = new Set([1, 2]); const b = new Set([1, 2, 3]); return a.isSubsetOf(b) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("isDisjointFrom(realSet) → boolean", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a = new Set([1]); const b = new Set([2]); return a.isDisjointFrom(b) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("union(realSet) → merged Set size", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a = new Set([1]); const b = new Set([2]); return a.union(b).size; }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("intersection(realSet) → common size", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a = new Set([1, 2, 3]); const b = new Set([2, 3, 4]); return a.intersection(b).size; }`,
+      ),
+    ).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

The two `[[SetData]]` brand-check Set slices of #2162, in one branch (shared
`emitSetBrandCheck` helper).

- **#2604** (~84-row bucket) — `Set.prototype.METHOD.call(recv, …)` /
  `inst.METHOD.call(recv, …)` for `add`/`has`/`delete`/`clear` never reached the
  native Set runtime (which only fires on a *direct* `s.add(v)` with a static Set
  receiver), so a non-Set receiver (`""`, `0`, `true`, `null`, `undefined`, `{}`,
  `[]`, `Set.prototype`) ran to completion instead of throwing the spec TypeError
  (24.2.3.* "If S does not have a [[SetData]] internal slot, throw a TypeError").
- **#2607** — the ES2025 set-algebra methods skipped GetSetRecord arg validation
  (24.2.1.2): a non-Set argument silently completed (host fall-through) or
  trap-cast instead of throwing TypeError.

## Changes

**`src/codegen/set-runtime.ts`** — new shared `emitSetBrandCheck(ctx, fctx, recvType)`:
NON-trapping `ref.test $Map`; on a miss throws a *catchable* `TypeError` (via
`emitThrowTypeError`, NOT `ref.cast` — which traps `illegal cast`, which
`assert.throws(TypeError)` rejects); on a hit `ref.cast`s to the validated
`(ref $Map)`. Plus `tryCompileSetReflectiveCall` (dispatches the `.call` shape
after the brand-check) and the cheap `isSetReflectiveCallShape` predicate.

**`src/codegen/expressions/calls.ts`** — in the `.call`/`.apply` handler, BEFORE
the generic #2193 member-closure recovery: when `isSetReflectiveCallShape` matches,
`addUnionImports(ctx)` (registers the arg-boxing `__box_number` up-front — mirrors
the direct path's extern.ts setup, avoids a mid-body index shift) then dispatch.
ADDS a Set pre-check; does NOT rewrite the generic path (#2193 tests unchanged).

**`src/codegen/set-algebra.ts`** — `tryCompileNativeSetAlgebraCall` replaces the
bare `castToMap(arg)` with `emitSetBrandCheck` so a non-Set argument throws.

## Scope

Both gated on `ctx.nativeStrings`; host/gc mode unchanged. `.apply` and
forEach/keys/values/entries reflective forms fall through (deferred). The
Set-vs-Map kind-tag discriminator (`internal-slot-{map,weakset}` sub-rows) is the
documented #2604 stretch — those few rows stay red. The genuine set-LIKE-object
data path is #2580 M2 (dynamic read), conservatively rejected here (no regression).

## Tests

`tests/issue-2604-set-brand-check.test.ts` (31) + `tests/issue-2607-set-algebra-
arg-validation.test.ts` (27) — **58 pass**. Set/Map/#2193-reflective regression
suites green (88 tests); gc-mode Set (direct + reflective + algebra) unchanged.
tsc + prettier + coercion-sites + dup-id gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA