### PR TITLE
fix(infra): sync-workspace-main disposable-divergence auto-reset (task #75)

### DIFF
--- a/scripts/sync-workspace-main.sh
+++ b/scripts/sync-workspace-main.sh
@@ -9,9 +9,20 @@
 # worktree bases, dashboards) — stays current.
 #
 # SAFE BY DESIGN: only fast-forwards a CLEAN checkout. If /workspace has
-# uncommitted tracked changes or has diverged, it WARNS and exits 0 without
-# touching anything — it never discards local work. (Agents shouldn't be
-# editing /workspace directly anyway; that's what worktrees are for.)
+# uncommitted tracked changes it WARNS and exits 0 without touching anything.
+# (Agents shouldn't be editing /workspace directly anyway; that's what worktrees
+# are for.)
+#
+# DISPOSABLE-DIVERGENCE AUTO-RESET (task #75): when the ff-only fails because
+# local main DIVERGED (has commits origin/main lacks), the script resets to
+# origin/main ONLY when every divergent commit is provably disposable — either
+# already-landed upstream by content (`git cherry` patch-id match) or touching
+# ONLY baseline/benchmark-result JSON, run logs, or live team-memory. If ANY
+# divergent commit carries real work (src/tests/plan/scripts/…), it refuses and
+# surfaces for manual resolution — it never discards real local work. This fixes
+# the recurring stale-/workspace problem where a superseded merge-queue baseline
+# commit or a worktree branch-rename left main diverged and the sync silently
+# gave up (the lead had to `git reset --hard origin/main` ~4×/session).
 #
 # EXCEPTION: changes under .claude/memory/ are ignored by the dirty check.
 # That dir is live team-memory the agents write continuously, so it is almost
@@ -72,7 +83,69 @@ fi
 
 if git -C "$WS" merge --ff-only origin/main >/dev/null 2>&1; then
   say "fast-forwarded $local_sha -> $main_sha"
+  exit 0
+fi
+
+# ── Disposable-divergence auto-reset (task #75) ─────────────────────────────
+# The ff-only above failed: local main has commit(s) that are NOT ancestors of
+# origin/main (it DIVERGED, not merely lagged). This recurs because /workspace
+# main occasionally lands on a commit that origin/main later supersedes — most
+# often a github-actions[bot] baseline-refresh (`benchmarks/results/*`) the merge
+# queue produced, or a worktree branch-rename that left main on a feature-branch
+# tip. Those divergent commits carry NO real un-pushed work, so the safe recovery
+# is `reset --hard origin/main` — but ONLY when EVERY divergent commit is provably
+# disposable. If even one carries real work, refuse and surface (never discard).
+#
+# A divergent commit is DISPOSABLE iff either:
+#   (a) its content already landed on origin/main under a different SHA — i.e.
+#       `git cherry` marks it `-` (squash/rebase-merged; patch-id equivalent); or
+#   (b) it touches ONLY throwaway/auto-generated paths (baseline + benchmark
+#       result JSON, run logs, live team-memory) — never src/tests/plan/etc.
+divergent=$(git -C "$WS" rev-list origin/main..HEAD 2>/dev/null)
+if [ -z "$divergent" ]; then
+  # No divergent commits yet ff-only still failed (e.g. a stray detached/odd
+  # state) — surface rather than guess.
+  say "WARNING: cannot fast-forward but no divergent commits found — left at $local_sha. Resolve manually."
+  exit 0
+fi
+
+# `git cherry` prefixes `-` for commits whose patch-id is already upstream, `+`
+# for genuinely-new ones. Collect the SHAs still marked `+` (not yet landed).
+unlanded=$(git -C "$WS" cherry origin/main HEAD 2>/dev/null | sed -n 's/^+ //p')
+
+# Disposable-path allowlist (anchored): a `+` commit is still disposable if every
+# file it touches matches one of these prefixes. Anything else (src/, tests/,
+# plan/, scripts/, .github/, docs/, …) is real work → refuse.
+is_disposable_paths() {
+  # $1 = commit sha; returns 0 (true) iff ALL changed paths are disposable.
+  files=$(git -C "$WS" diff-tree --no-commit-id --name-only -r "$1" 2>/dev/null)
+  [ -n "$files" ] || return 1 # empty/merge commit — treat as non-disposable (surface)
+  printf '%s\n' "$files" | while IFS= read -r f; do
+    case "$f" in
+      benchmarks/results/* | public/benchmarks/* | website/public/benchmarks/* \
+        | website/benchmarks/* | runs/* | .claude/memory/*) : ;;
+      *) echo "REAL"; break ;;
+    esac
+  done | grep -q REAL && return 1
+  return 0
+}
+
+all_disposable=1
+for sha in $unlanded; do
+  if ! is_disposable_paths "$sha"; then
+    all_disposable=0
+    break
+  fi
+done
+
+if [ "$all_disposable" -eq 1 ]; then
+  ndiv=$(printf '%s\n' "$divergent" | grep -c .)
+  if git -C "$WS" reset --hard origin/main >/dev/null 2>&1; then
+    say "diverged on $ndiv disposable commit(s) (already-landed and/or baseline/benchmark/memory-only) — reset $local_sha -> $main_sha"
+  else
+    say "WARNING: disposable-divergence reset to origin/main FAILED — left at $local_sha. Resolve manually."
+  fi
 else
-  say "WARNING: cannot fast-forward (diverged?) — left at $local_sha. Resolve manually."
+  say "WARNING: cannot fast-forward — local main has divergent commit(s) with REAL work (not baseline/benchmark/memory). Left at $local_sha. Resolve manually."
 fi
 exit 0

--- a/tests/sync-workspace-main.test.ts
+++ b/tests/sync-workspace-main.test.ts
@@ -1,0 +1,157 @@
+import { execSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// Task #75 — `scripts/sync-workspace-main.sh` disposable-divergence auto-reset.
+//
+// /workspace main keeps DIVERGING (not just lagging) from origin/main when a
+// superseded merge-queue baseline commit or a worktree branch-rename leaves it
+// on a non-ancestor commit. The ff-only sync then fails and leaves it stale.
+// The fix: when ff-only fails because of divergence, reset --hard to origin/main
+// ONLY when every divergent commit is provably DISPOSABLE — already-landed
+// upstream by content (`git cherry` patch-id match) OR touching only
+// baseline/benchmark-result JSON / run logs / live team-memory. Real work in any
+// divergent commit → refuse (never discard).
+
+const SCRIPT = join(__dirname, "..", "scripts", "sync-workspace-main.sh");
+
+let root: string;
+let origin: string;
+let ws: string;
+
+function git(cwd: string, args: string): string {
+  return execSync(`git ${args}`, {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "t",
+      GIT_AUTHOR_EMAIL: "t@t.co",
+      GIT_COMMITTER_NAME: "t",
+      GIT_COMMITTER_EMAIL: "t@t.co",
+    },
+  }).trim();
+}
+
+function commit(cwd: string, msg: string): void {
+  git(cwd, "add -A");
+  git(cwd, `commit -q -m ${JSON.stringify(msg)}`);
+}
+
+/** Run the sync script against the workspace clone; return its stdout. */
+function runSync(): string {
+  return execSync(`sh ${JSON.stringify(SCRIPT)} ${JSON.stringify(ws)}`, { encoding: "utf8" }).trim();
+}
+
+function shortHead(cwd: string): string {
+  return git(cwd, "rev-parse --short HEAD");
+}
+
+/** Force origin/main to a fresh "superseding" commit on top of `base`, so the
+ *  workspace's current main becomes a non-ancestor (diverged) of origin/main. */
+function supersedeOrigin(baseRef: string, file: string, content: string, msg: string): void {
+  git(ws, `checkout -q -b __sup ${baseRef}`);
+  writeFileSync(join(ws, file), content);
+  commit(ws, msg);
+  git(ws, "push -qf origin HEAD:main");
+  git(ws, "checkout -q main");
+  git(ws, "branch -qD __sup");
+  git(ws, "fetch -q origin");
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "sync-ws-"));
+  origin = join(root, "origin.git");
+  ws = join(root, "ws");
+  git(root, `init -q --bare ${JSON.stringify(origin)}`);
+  git(root, `clone -q ${JSON.stringify(origin)} ${JSON.stringify(ws)}`);
+  mkdirSync(join(ws, "benchmarks", "results"), { recursive: true });
+  mkdirSync(join(ws, "src"), { recursive: true });
+  writeFileSync(join(ws, "benchmarks/results/test262-current.json"), '{"pass":1}\n');
+  writeFileSync(join(ws, "src/a.ts"), "export const a = 1;\n");
+  commit(ws, "base");
+  git(ws, "branch -M main");
+  git(ws, "push -q origin main");
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("sync-workspace-main.sh", () => {
+  it("fast-forwards a clean checkout that is merely BEHIND origin/main", () => {
+    // origin advances; local stays behind.
+    writeFileSync(join(ws, "src/b.ts"), "export const b = 2;\n");
+    commit(ws, "origin real work");
+    git(ws, "push -q origin main");
+    git(ws, "reset -q --hard HEAD~1");
+    const out = runSync();
+    expect(out).toMatch(/fast-forwarded/);
+    expect(shortHead(ws)).toBe(git(ws, "rev-parse --short origin/main"));
+  });
+
+  it("auto-resets a DISPOSABLE (baseline-only) divergence", () => {
+    git(ws, "reset -q --hard origin/main");
+    writeFileSync(join(ws, "benchmarks/results/test262-current.json"), '{"pass":2}\n');
+    commit(ws, "local baseline refresh");
+    supersedeOrigin("origin/main~0", "src/z.ts", "export const z = 3;\n", "origin superseding work");
+    // local main now has a baseline-only commit origin/main lacks.
+    expect(git(ws, "rev-list origin/main..HEAD").length).toBeGreaterThan(0);
+    const out = runSync();
+    expect(out).toMatch(/disposable commit/);
+    expect(out).toMatch(/reset/);
+    expect(shortHead(ws)).toBe(git(ws, "rev-parse --short origin/main"));
+  });
+
+  it("auto-resets an ALREADY-LANDED divergence (patch-id match), even in src/", () => {
+    git(ws, "reset -q --hard origin/main");
+    writeFileSync(join(ws, "src/dup.ts"), "export const dup = 5;\n");
+    commit(ws, "shared change");
+    // origin gets the same content under a different SHA (squash/rebase-merge).
+    supersedeOrigin("origin/main~0", "src/dup.ts", "export const dup = 5;\n", "shared change (squashed)");
+    // `git cherry` should mark the local commit as already-landed ('-').
+    expect(git(ws, "cherry origin/main HEAD")).toMatch(/^- /);
+    const out = runSync();
+    expect(out).toMatch(/disposable commit/);
+    expect(shortHead(ws)).toBe(git(ws, "rev-parse --short origin/main"));
+  });
+
+  it("REFUSES (no reset) a real-work divergence — preserves local work", () => {
+    git(ws, "reset -q --hard origin/main");
+    writeFileSync(join(ws, "src/realwork.ts"), "export const real = 99;\n");
+    commit(ws, "local REAL work");
+    const localReal = shortHead(ws);
+    supersedeOrigin("origin/main~0", "src/other.ts", "export const o = 4;\n", "origin other work");
+    const out = runSync();
+    expect(out).toMatch(/REAL work/);
+    expect(out).not.toMatch(/reset \w+ ->/);
+    expect(shortHead(ws)).toBe(localReal); // local commit preserved
+  });
+
+  it("REFUSES a MIXED divergence (baseline + real work) — not ALL disposable", () => {
+    git(ws, "reset -q --hard origin/main");
+    writeFileSync(join(ws, "benchmarks/results/test262-current.json"), '{"pass":3}\n');
+    commit(ws, "baseline only");
+    writeFileSync(join(ws, "src/mixed.ts"), "export const m = 7;\n");
+    commit(ws, "real work in mix");
+    const localMix = shortHead(ws);
+    supersedeOrigin("origin/main~0", "src/o2.ts", "export const o = 8;\n", "origin other");
+    const out = runSync();
+    expect(out).toMatch(/REAL work/);
+    expect(shortHead(ws)).toBe(localMix);
+  });
+
+  it("REFUSES when the tree is dirty with a tracked-file change", () => {
+    git(ws, "reset -q --hard origin/main");
+    // Make origin advance so a sync would otherwise be needed.
+    supersedeOrigin("origin/main~0", "src/c.ts", "export const c = 9;\n", "origin advance");
+    git(ws, "reset -q --hard HEAD"); // ensure local diverged from origin
+    writeFileSync(join(ws, "src/a.ts"), "export const a = 999; // dirty\n");
+    const out = runSync();
+    expect(out).toMatch(/uncommitted changes/);
+    // dirty edit untouched.
+    expect(git(ws, "status --porcelain")).toMatch(/src\/a\.ts/);
+  });
+});


### PR DESCRIPTION
## Summary

`/workspace` main keeps **diverging** (not merely lagging) from `origin/main` —
a superseded merge-queue baseline-refresh commit (github-actions[bot], touching
only `benchmarks/results/*`) or a worktree branch-rename leaves local main on a
non-ancestor commit. The ff-only `sync-workspace-main.sh` then fails and leaves
`/workspace` stale (the lead manually `git reset --hard origin/main`-ed it
~4×/session). Serves the standing "main always synced" directive.

## Fix

When the ff-only fails because of divergence, the script now `reset --hard`s to
`origin/main` **only when every divergent commit is provably DISPOSABLE**:
- **(a) already-landed upstream by content** — `git cherry` patch-id match (`-`
  prefix; the squash/rebase-merge case), or
- **(b) touches ONLY throwaway paths** — `benchmarks/results/`, `public/` +
  `website/**` benchmarks results, `runs/`, `.claude/memory/`.

If **any** divergent commit carries real work (`src/`/`tests/`/`plan/`/`scripts/`
/…) — even mixed within a single commit — it **refuses** and surfaces for manual
resolution. It never discards real local work. The pre-existing dirty-tree
refusal is unchanged.

## Validation

`tests/sync-workspace-main.test.ts` — 6 cases driving the real script against
temporary git repos:
- ff-forward when merely behind;
- **reset** on a baseline-only (disposable) divergence;
- **reset** on an already-landed (patch-id-equal) divergence, even in `src/`;
- **refuse** (work preserved) on a real-work divergence;
- **refuse** on a mixed (baseline + real) multi-commit divergence;
- **refuse** on a dirty tree.

Plus a manual check that a single commit mixing a disposable + a real path
refuses. `sh -n` + `bash -n` clean; prettier + tsc clean.

Task #75 (no issue file — pure tooling/infra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA