### PR TITLE
fix(#2593): standalone TypedArray integer element-width wrapping + signed read

### DIFF
--- a/plan/issues/2593-standalone-typedarray-integer-element-width-wrapping.md
+++ b/plan/issues/2593-standalone-typedarray-integer-element-width-wrapping.md
@@ -1,7 +1,9 @@
 ---
 id: 2593
 title: "Standalone TypedArray integer element-width wrapping (ToInt8/ToUint16/Uint8Clamped) + signed read"
-status: ready
+status: done
+assignee: ttraenkler/senior-developer
+completed: 2026-06-22
 sprint: 65
 created: 2026-06-22
 priority: high
@@ -189,3 +191,63 @@ bucket in the residual.
   **Dispatch note**: #2592 and #2593 both touch `calls.ts`/`new-super.ts`
   element-init paths — sequence #2592 first (additive arm), then #2593 (changes
   storage), or assign both to one dev to avoid a `[CONFLICT]`.
+
+## Implementation Notes (2026-06-22, senior-developer)
+
+**Landed (standalone/WASI only; host/gc keeps the f64 lane).**
+
+### Root cause hierarchy
+Three layers had to agree on the SAME packed backing vec for an integer view:
+1. **Allocation** — `new TA(...)`. Before #2593 the count/literal constructors
+   hardcoded `isNativeUint8Array ? i8_byte : f64`, so `new Int32Array(n)`
+   allocated an **f64** vec while the read/`.byteLength` paths cast to
+   `i32_byte`. That mismatch was the *keystone* bug: an inline
+   `new Int32Array(4).byteLength` read field-0 through an `i32_byte` cast that
+   never matched (→ `0`), and an empty `new Int32Array(0)` trapped
+   (`illegal cast`). A *typed local* (`const a: Int32Array = ...`) happened to
+   work only because the binding's declared type coerced the f64 vec to the
+   packed vec at the store — inline expressions have no such coercion point.
+2. **Write** — element store applies the spec coercion (ToInt8/ToUint8/
+   ToInt16/ToUint16/ToInt32/ToUint32, and ToUint8Clamp round-half-to-even).
+3. **Read** — sign/zero extension keyed on the **view name** (signed→`array.get_s`,
+   unsigned→`array.get_u`), since signed/unsigned views share storage.
+
+### What changed
+- **`src/codegen/index.ts`** — `TYPED_ARRAY_PACKED_STORAGE` (Int8/Uint8/
+  Uint8Clamped→i8_byte, Int16/Uint16→i16_byte, Int32/Uint32→i32_byte), gated on
+  `wasi || standalone`; `typedArrayVecStorage` is now the single source of truth.
+  Exported `typedArrayPackedSignedness(name)`. `reserveTypedArraySubviewTypes`
+  reserves i16_byte/i32_byte subview backing. Generic vec accessors
+  (`__vec_get`, `__vec_pop`) read packed bytes with `array.get_u` (plain
+  `array.get` is INVALID on packed i8/i16) and unsigned-convert.
+- **`src/codegen/expressions/new-super.ts`** — BOTH count-ctor handlers now
+  allocate via `typedArrayVecStorage` (the keystone fix), so the constructor's
+  backing vec matches the read/byteLength paths.
+- **`src/codegen/property-access.ts`** — view-name-driven get_s/get_u at the vec
+  and bare-array read sites; Uint32 unsigned read (`f64.convert_i32_u`);
+  `.byteLength` reader uses `typedArrayVecStorage` and a runtime `ref.test`
+  guard before the packed-vec cast (empty/mismatched view → length 0, no trap).
+- **`src/codegen/array-methods.ts`** — `emitBoundsCheckedArrayGet` takes a
+  `signedness` param.
+- **`src/codegen/expressions/assignment.ts`** — write-site truncation; routes
+  Uint8Clamped through `emitToUint8Clamp`, other packed views through
+  `i32.trunc_sat_f64_s` into i32 (unpacked) hint.
+- **`src/codegen/binary-ops.ts`** — `emitToUint8Clamp` (clamp to [0,255] with
+  round-half-to-even).
+
+### Validation
+- New `tests/issue-2593-typedarray-intwidth.test.ts` (18/18) + the #1787
+  forward-looking suite flipped to live guards (9/9). Core typed-array sweep
+  77/77 (issue-2159, ta-fill, atomics, 2595-2597, 1787).
+- The legacy `tests/typed-array-basic.test.ts` / `tests/arraybuffer-dataview.test.ts`
+  failures (instantiate with `{}` and lack the now-mandatory `string_constants`
+  import added by a sibling PR) are PRE-EXISTING on `origin/main` — unrelated to
+  #2593.
+- Quality sub-gates green: tsc, prettier (all changed files), stack-balance,
+  coercion-sites, any-box-sites, codegen-fallbacks, ir-fallbacks, biome (changed
+  files).
+
+### Deliberately out of scope
+Cross-view copy conversion (`new Int32Array(someFloat64Array)`) keeps the
+pre-#2593 saturating `i32.trunc_sat_f64_s` rather than full modulo wrapping —
+that vec-to-vec conversion path is independent of the element write/read core.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -342,6 +342,12 @@ export function emitBoundsCheckedArrayGet(
   elementType: ValType,
   ctx?: CodegenContext,
   useUndefinedSentinel = false,
+  // (#2593) Explicit signedness for a packed i8/i16 element, driven by the
+  // typed-array VIEW name (not the storage kind): `Int8Array`/`Int16Array` read
+  // sign-extending (`get_s`), `Uint8Array`/`Uint8ClampedArray`/`Uint16Array` read
+  // zero-extending (`get_u`). When undefined, fall back to the legacy
+  // storage-kind heuristic (i8→get_u, i16→get_s) for non-typed-array callers.
+  signedness?: "s" | "u",
 ): void {
   // Save index and array ref to locals so we can use them in both branches
   const idxLocal = allocLocal(fctx, `__bounds_idx_${fctx.locals.length}`, { kind: "i32" });
@@ -368,9 +374,21 @@ export function emitBoundsCheckedArrayGet(
   fctx.body.push({ op: "array.len" });
   fctx.body.push({ op: "i32.lt_u" } as Instr);
 
-  // Build the "then" branch: in-bounds -> array.get
+  // Build the "then" branch: in-bounds -> array.get. (#2593) For a packed i8/i16
+  // element, prefer the view-name-driven `signedness` (get_s for signed views,
+  // get_u for unsigned); fall back to the legacy storage-kind heuristic when the
+  // caller did not supply it (i32 packed elements use plain `array.get` — i32 has
+  // no sign-extension distinction; the value IS the full 32 bits).
   const packedLoad =
-    elementType.kind === "i8" ? "array.get_u" : elementType.kind === "i16" ? "array.get_s" : "array.get";
+    elementType.kind === "i8" || elementType.kind === "i16"
+      ? signedness === "s"
+        ? "array.get_s"
+        : signedness === "u"
+          ? "array.get_u"
+          : elementType.kind === "i8"
+            ? "array.get_u"
+            : "array.get_s"
+      : "array.get";
   const valueType: ValType = elementType.kind === "i8" || elementType.kind === "i16" ? { kind: "i32" } : elementType;
 
   const thenInstrs: Instr[] = [

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -3804,6 +3804,109 @@ export function emitToInt32(fctx: FunctionContext): void {
   releaseTempLocal(fctx, tmp);
 }
 
+/**
+ * (#2593) ToUint8Clamp (§7.1.x, the `Uint8ClampedArray` element conversion). Input
+ * f64 on the stack → clamped i32 in [0, 255]. NOT modulo: NaN→0, ≤0→0, ≥255→255,
+ * else round-HALF-TO-EVEN (1.5→2, 2.5→2, 0.5→0). Differs from every other integer
+ * view (which truncate modulo via the packed `array.set`), so `Uint8ClampedArray`
+ * writes route through this helper before the store.
+ */
+export function emitToUint8Clamp(fctx: FunctionContext): void {
+  // x on stack (f64) → clamped i32 in [0,255]. Use DEDICATED locals (no reuse) to
+  // keep the stack types unambiguous. Result is built as an i32 in `out`.
+  const x = allocTempLocal(fctx, { kind: "f64" });
+  const f = allocTempLocal(fctx, { kind: "f64" }); // floor(x)
+  const d = allocTempLocal(fctx, { kind: "f64" }); // x - floor(x)
+  const out = allocTempLocal(fctx, { kind: "i32" });
+  fctx.body.push({ op: "local.set", index: x } as Instr);
+
+  // roundHalfEven(x) → i32 (only evaluated when 0 < x < 255, so trunc is exact):
+  //   f = floor(x); d = x - f;
+  //   d<0.5 → f ; d>0.5 → f+1 ; d==0.5 → (f even ? f : f+1)
+  const roundHalfEven: Instr[] = [
+    { op: "local.get", index: x } as Instr,
+    { op: "f64.floor" } as Instr,
+    { op: "local.set", index: f } as Instr,
+    { op: "local.get", index: x } as Instr,
+    { op: "local.get", index: f } as Instr,
+    { op: "f64.sub" } as Instr,
+    { op: "local.set", index: d } as Instr,
+    // d < 0.5 ?
+    { op: "local.get", index: d } as Instr,
+    { op: "f64.const", value: 0.5 } as Instr,
+    { op: "f64.lt" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "f64" } as ValType },
+      then: [{ op: "local.get", index: f } as Instr],
+      else: [
+        // d > 0.5 ?
+        { op: "local.get", index: d } as Instr,
+        { op: "f64.const", value: 0.5 } as Instr,
+        { op: "f64.gt" } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "f64" } as ValType },
+          then: [
+            { op: "local.get", index: f } as Instr,
+            { op: "f64.const", value: 1 } as Instr,
+            { op: "f64.add" } as Instr,
+          ],
+          else: [
+            // tie (d == 0.5): round to even. f even ⇔ floor(f/2) == f/2.
+            { op: "local.get", index: f } as Instr,
+            { op: "f64.const", value: 0.5 } as Instr,
+            { op: "f64.mul" } as Instr,
+            { op: "local.set", index: d } as Instr, // d := f/2 (reuse d, no longer needed)
+            { op: "local.get", index: d } as Instr,
+            { op: "f64.floor" } as Instr,
+            { op: "local.get", index: d } as Instr,
+            { op: "f64.eq" } as Instr,
+            {
+              op: "if",
+              blockType: { kind: "val", type: { kind: "f64" } as ValType },
+              then: [{ op: "local.get", index: f } as Instr],
+              else: [
+                { op: "local.get", index: f } as Instr,
+                { op: "f64.const", value: 1 } as Instr,
+                { op: "f64.add" } as Instr,
+              ],
+            } as Instr,
+          ],
+        } as Instr,
+      ],
+    } as Instr,
+    { op: "i32.trunc_sat_f64_u" } as Instr,
+    { op: "local.set", index: out } as Instr,
+  ];
+
+  // Clamp: x>=255 → 255 ; x>0 (NaN-false) → round ; else → 0.
+  fctx.body.push({ op: "local.get", index: x } as Instr);
+  fctx.body.push({ op: "f64.const", value: 255 } as Instr);
+  fctx.body.push({ op: "f64.ge" } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [{ op: "i32.const", value: 255 } as Instr, { op: "local.set", index: out } as Instr],
+    else: [
+      { op: "local.get", index: x } as Instr,
+      { op: "f64.const", value: 0 } as Instr,
+      { op: "f64.gt" } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: roundHalfEven,
+        else: [{ op: "i32.const", value: 0 } as Instr, { op: "local.set", index: out } as Instr],
+      } as Instr,
+    ],
+  } as Instr);
+  fctx.body.push({ op: "local.get", index: out } as Instr);
+  releaseTempLocal(fctx, x);
+  releaseTempLocal(fctx, f);
+  releaseTempLocal(fctx, d);
+  releaseTempLocal(fctx, out);
+}
+
 /** Truncate two f64 operands to i32 via ToInt32, apply an i32 bitwise op, convert back to f64 */
 function compileBitwiseBinaryOp(
   fctx: FunctionContext,

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -7,7 +7,7 @@ import { isBooleanType, isExternalDeclaredClass, isStringType } from "../../chec
 import type { FieldDef, Instr, ValType } from "../../ir/types.js";
 import { emitBoundsCheckedArrayGet, resolveArrayInfo } from "../array-methods.js";
 import { tryEmitLinearU8ElementCompound, tryEmitLinearU8ElementSet } from "../linear-uint8-codegen.js";
-import { emitAnyAdd, emitModulo, emitToInt32 } from "../binary-ops.js";
+import { emitAnyAdd, emitModulo, emitToInt32, emitToUint8Clamp } from "../binary-ops.js";
 import { pushBody } from "../context/bodies.js";
 import { reportError } from "../context/errors.js";
 import { reportSilentFallback } from "../fallback-telemetry.js";
@@ -25,6 +25,7 @@ import {
   getArrTypeIdxFromVec,
   localGlobalIdx,
   resolveWasmType,
+  TYPED_ARRAY_NAMES,
 } from "../index.js";
 import { getSubviewArrTypeIdx, isSubviewTypeIdx } from "../registry/types.js"; // (#2357/#47) subview write
 import { buildDestructureNullThrow, patternIteratorStepCount } from "../destructuring-params.js";
@@ -82,6 +83,21 @@ import { compileWithBindingAssignment, findWithBinding } from "../with-scope.js"
  * Throws TypeError if the value in `srcLocal` is null or the JS undefined sentinel.
  * Per spec §14.3.3.1 RequireObjectCoercible / §8.4.2 GetIterator.
  */
+/**
+ * (#2593) Recover the typed-array VIEW NAME of an element-assignment receiver
+ * (`a[i] = v`) from its TS type, so the write site can special-case
+ * `Uint8ClampedArray` (ToUint8Clamp) vs the modulo-truncating integer views.
+ * Returns undefined when the receiver is not a recognised typed-array view.
+ */
+function elementAccessTypedArrayName(ctx: CodegenContext, receiver: ts.Expression): string | undefined {
+  const t = ctx.checker.getTypeAtLocation(receiver);
+  let name = t.getSymbol()?.name ?? t.aliasSymbol?.name;
+  if ((!name || !TYPED_ARRAY_NAMES.has(name)) && ts.isNewExpression(receiver) && ts.isIdentifier(receiver.expression)) {
+    name = receiver.expression.text;
+  }
+  return name && TYPED_ARRAY_NAMES.has(name) ? name : undefined;
+}
+
 function emitExternrefAssignDestructureGuard(ctx: CodegenContext, fctx: FunctionContext, srcLocal: number): void {
   // ref.is_null check (catches JS null when encoded as ref.null.extern).
   // Build a fresh Instr[] for each if-then: sharing a single array across two
@@ -3062,18 +3078,29 @@ function compileElementAssignment(
     // INVALID). `array.set` into the packed element re-truncates the i32 store
     // value to the element width (free ToInt8/ToInt16/ToInt32/ToUint*). Float
     // views keep their f64 element hint.
+    // (#2593) `Uint8ClampedArray` write is NOT modulo — it is ToUint8Clamp
+    // (clamp to [0,255] + round-half-even). Detect the view by name so the value
+    // routes through `emitToUint8Clamp` below instead of the plain i32 truncation.
+    const isUint8Clamped = elementAccessTypedArrayName(ctx, target.expression) === "Uint8ClampedArray";
     const valueHint: ValType =
-      arrDef.element.kind === "i8" || arrDef.element.kind === "i16" ? { kind: "i32" } : arrDef.element;
+      arrDef.element.kind === "i8" || arrDef.element.kind === "i16"
+        ? isUint8Clamped
+          ? { kind: "f64" } // keep f64 for the clamp helper
+          : { kind: "i32" }
+        : arrDef.element;
     const elemValResult = compileExpression(ctx, fctx, value, valueHint);
     if (!elemValResult) {
       reportError(ctx, target, "Failed to compile element value");
       return null;
     }
-    // (#2593) Ensure the store value is i32 for a packed i8/i16 element: if the
-    // value compiled to f64 (a number literal / arithmetic result), truncate to
-    // i32 (ToInt32 modulo semantics) so `array.set` re-packs to the element
-    // width. A value already i32 needs no conversion.
-    if ((arrDef.element.kind === "i8" || arrDef.element.kind === "i16") && elemValResult.kind === "f64") {
+    if (isUint8Clamped) {
+      // ToUint8Clamp: f64 → clamped i32 in [0,255], round-half-even. Ensure the
+      // value is f64 first (a literal/i32 may have compiled to i32).
+      if (elemValResult.kind === "i32") fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
+      emitToUint8Clamp(fctx);
+    } else if ((arrDef.element.kind === "i8" || arrDef.element.kind === "i16") && elemValResult.kind === "f64") {
+      // (#2593) Other packed i8/i16 views: truncate the f64 store value to i32
+      // (ToInt32 modulo); `array.set` re-packs to the element width.
       fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
     }
     // #2159 — `i8`/`i16` are *packed storage* types, valid only inside array

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -3055,11 +3055,26 @@ function compileElementAssignment(
       kind: "i32",
     });
     fctx.body.push({ op: "local.set", index: idxLocal });
-    // Compile value
-    const elemValResult = compileExpression(ctx, fctx, value, arrDef.element);
+    // Compile value. (#2593) Hint the UNPACKED value type (i32 for packed
+    // i8/i16 storage), NOT the packed `i8`/`i16` element type — `i8`/`i16` are
+    // storage-only and have no value-position encoding, so passing them as the
+    // compile hint produced an invalid local/value (the Int16/Uint16 element-write
+    // INVALID). `array.set` into the packed element re-truncates the i32 store
+    // value to the element width (free ToInt8/ToInt16/ToInt32/ToUint*). Float
+    // views keep their f64 element hint.
+    const valueHint: ValType =
+      arrDef.element.kind === "i8" || arrDef.element.kind === "i16" ? { kind: "i32" } : arrDef.element;
+    const elemValResult = compileExpression(ctx, fctx, value, valueHint);
     if (!elemValResult) {
       reportError(ctx, target, "Failed to compile element value");
       return null;
+    }
+    // (#2593) Ensure the store value is i32 for a packed i8/i16 element: if the
+    // value compiled to f64 (a number literal / arithmetic result), truncate to
+    // i32 (ToInt32 modulo semantics) so `array.set` re-packs to the element
+    // width. A value already i32 needs no conversion.
+    if ((arrDef.element.kind === "i8" || arrDef.element.kind === "i16") && elemValResult.kind === "f64") {
+      fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
     }
     // #2159 — `i8`/`i16` are *packed storage* types, valid only inside array
     // elements / struct fields. The value temp holds the unpacked Wasm value

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -23,6 +23,7 @@ import {
   getOrRegisterRefCellType,
   getOrRegisterVecType,
   resolveWasmType,
+  typedArrayVecStorage,
 } from "../index.js";
 import { getOrRegisterDvWindowType } from "../dataview-native.js"; // (#2159/#38) DataView windowing wrapper
 import { emitBoundsCheckedArrayGet } from "../array-methods.js";
@@ -3230,9 +3231,17 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       "Float64Array",
     ]);
     if (TYPED_ARRAY_NAMES.has(expr.expression.text)) {
-      const isNativeUint8Array = noJsHost(ctx) && expr.expression.text === "Uint8Array";
-      const elemWasm: ValType = isNativeUint8Array ? { kind: "i8" } : { kind: "f64" };
-      const elemKey = isNativeUint8Array ? "i8_byte" : "f64";
+      // (#2593) Standalone/WASI packs integer views into i8/i16/i32 storage
+      // (Int8/Uint8/Uint8Clamped→i8_byte, Int16/Uint16→i16_byte,
+      // Int32/Uint32→i32_byte); host/gc and the float views keep f64.
+      // `typedArrayVecStorage` is the single source of truth so the
+      // count-constructor's backing vec matches the read / byteLength paths.
+      // Before #2593 only native Uint8Array packed (everything else f64), which
+      // left `new Int32Array(n)` on an f64 vec while the byteLength reader cast
+      // to i32_byte — a runtime type mismatch (read 0 / illegal cast).
+      const storage = typedArrayVecStorage(ctx, expr.expression.text);
+      const elemWasm: ValType = storage.type;
+      const elemKey = storage.key;
       const vecTypeIdx = getOrRegisterVecType(ctx, elemKey, elemWasm);
       const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
       const args = expr.arguments ?? [];
@@ -4024,9 +4033,12 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       "Float64Array",
     ]);
     if (className && TYPED_ARRAY_CTORS.has(className)) {
-      const isNativeUint8Array = noJsHost(ctx) && className === "Uint8Array";
-      const elemType: ValType = isNativeUint8Array ? { kind: "i8" } : { kind: "f64" };
-      const elemKey = isNativeUint8Array ? "i8_byte" : "f64";
+      // (#2593) packed integer storage standalone/WASI — see the matching
+      // count-ctor handler above. `typedArrayVecStorage` keeps host/gc on f64
+      // and packs Int8/Uint8/Uint8Clamped→i8, Int16/Uint16→i16, Int32/Uint32→i32.
+      const storage = typedArrayVecStorage(ctx, className);
+      const elemType: ValType = storage.type;
+      const elemKey = storage.key;
       const vecTypeIdx = getOrRegisterVecType(ctx, elemKey, elemType);
       const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
       const args = expr.arguments ?? [];

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -175,10 +175,55 @@ function typedArrayNameFromTypeNode(node: ts.TypeNode): string | null {
   return TYPED_ARRAY_NAMES.has(node.typeName.text) ? node.typeName.text : null;
 }
 
+// (#2593) Per-view packed storage for the integer typed arrays under
+// standalone/WASI. A width-matched packed element type makes `array.set` truncate
+// to the view's width (ToInt8/ToUint16/… for free) and `array.get_s`/`get_u`
+// sign/zero-extend on read. Before #2593 only `Uint8Array` was packed (i8); every
+// other integer view fell through to f64, which stored the full double with no
+// width truncation. Float views stay f64. Host/gc mode stays f64 for all but
+// Uint8Array — the JS-host marshalling boundary already classifies non-Uint8
+// typed arrays as `number[]`-on-return; packing host-side risks that boundary and
+// is deferred (#2593 note). The packed map is gated on `ctx.wasi || ctx.standalone`.
+const TYPED_ARRAY_PACKED_STORAGE: Readonly<Record<string, { key: string; type: ValType }>> = {
+  Int8Array: { key: "i8_byte", type: { kind: "i8" } },
+  Uint8Array: { key: "i8_byte", type: { kind: "i8" } },
+  Uint8ClampedArray: { key: "i8_byte", type: { kind: "i8" } },
+  Int16Array: { key: "i16_byte", type: { kind: "i16" } },
+  Uint16Array: { key: "i16_byte", type: { kind: "i16" } },
+  Int32Array: { key: "i32_byte", type: { kind: "i32" } },
+  Uint32Array: { key: "i32_byte", type: { kind: "i32" } },
+};
+
 export function typedArrayVecStorage(ctx: CodegenContext, name: string): { key: string; type: ValType } {
-  return (ctx.wasi || ctx.standalone) && name === "Uint8Array"
-    ? { key: "i8_byte", type: { kind: "i8" } }
-    : { key: "f64", type: { kind: "f64" } };
+  if (ctx.wasi || ctx.standalone) {
+    const packed = TYPED_ARRAY_PACKED_STORAGE[name];
+    if (packed) return packed;
+  }
+  return { key: "f64", type: { kind: "f64" } };
+}
+
+/**
+ * (#2593) The signedness of a packed integer typed-array element, driving the
+ * read opcode: `array.get_s` for signed views (`Int8`/`Int16`/`Int32`),
+ * `array.get_u` for unsigned (`Uint8`/`Uint8Clamped`/`Uint16`/`Uint32`). MUST be
+ * keyed on the TS view NAME, not the storage kind — a signed `Int8Array` and an
+ * unsigned `Uint8Array` share `i8` storage but read with opposite extension.
+ * Returns undefined for non-integer views (Float*, or a non-typed-array name).
+ */
+export function typedArrayPackedSignedness(name: string): "s" | "u" | undefined {
+  switch (name) {
+    case "Int8Array":
+    case "Int16Array":
+    case "Int32Array":
+      return "s";
+    case "Uint8Array":
+    case "Uint8ClampedArray":
+    case "Uint16Array":
+    case "Uint32Array":
+      return "u";
+    default:
+      return undefined;
+  }
 }
 
 /**
@@ -6317,13 +6362,17 @@ export function reserveLinearU8AllocType(ctx: CodegenContext): void {
  * (#2357/#47) Reserve the standalone `$__subview_<elem>` struct types up-front so
  * their indices are deterministic across codegen passes (see the call site in
  * `generateModule`). Covers the element kinds standalone TypedArrays use for their
- * backing arrays: `i8_byte` (Uint8Array) and `f64` (the other typed arrays).
+ * backing arrays: `i8_byte` (Int8/Uint8/Uint8Clamped), `i16_byte`
+ * (Int16/Uint16), `i32_byte` (Int32/Uint32), and `f64` (the float views). (#2593
+ * added the i16/i32 byte views — before that only integer Uint8Array was packed.)
  * `getOrRegisterSubviewType` only forces the backing ARRAY type (uniquely deduped
  * per element kind) — it does NOT register or reorder the vec struct, so plain
  * typed-array resolution is unaffected. Idempotent.
  */
 export function reserveTypedArraySubviewTypes(ctx: CodegenContext): void {
   getOrRegisterSubviewType(ctx, "i8_byte", { kind: "i8" });
+  getOrRegisterSubviewType(ctx, "i16_byte", { kind: "i16" }); // (#2593) Int16/Uint16
+  getOrRegisterSubviewType(ctx, "i32_byte", { kind: "i32" }); // (#2593) Int32/Uint32
   getOrRegisterSubviewType(ctx, "f64", { kind: "f64" });
 }
 

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -4442,8 +4442,12 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
         boxInstrs = [{ op: "call", funcIdx: boxNumIdx } as Instr];
       } else if (elemKey === "i32" && boxNumIdx !== undefined) {
         boxInstrs = [{ op: "f64.convert_i32_s" } as Instr, { op: "call", funcIdx: boxNumIdx } as Instr];
-      } else if ((elemKey === "i32_byte" || elemKey === "i8_byte") && boxNumIdx !== undefined) {
-        // ArrayBuffer/DataView byte elements (i32, unsigned 0-255) — convert unsigned then box
+      } else if ((elemKey === "i32_byte" || elemKey === "i8_byte" || elemKey === "i16_byte") && boxNumIdx !== undefined) {
+        // ArrayBuffer/DataView/typed-array byte elements — convert unsigned then box.
+        // (#2593) i16_byte joins here: the GENERIC dynamic-read path (`__vec_get`,
+        // for an `any`-typed read of a typed-array vec) reads the packed element
+        // zero-extended; the per-VIEW signedness for the typed `a[i]` read site is
+        // handled separately in property-access.ts (typedArrayViewSignedness).
         boxInstrs = [{ op: "f64.convert_i32_u" } as Instr, { op: "call", funcIdx: boxNumIdx } as Instr];
       } else if (elemKey === "i64") {
         // i64 (BigInt) is a value type, not a ref type — extern.convert_any expects anyref.
@@ -4462,7 +4466,13 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
         { op: "ref.cast", typeIdx: vecTypeIdx } as Instr,
         { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 } as Instr,
         { op: "local.get", index: 1 } as Instr, // index
-        { op: elemKey === "i8_byte" ? "array.get_u" : "array.get", typeIdx: arrTypeIdx } as Instr,
+        // (#2593) Packed i8/i16 elements REQUIRE array.get_u/_s (plain array.get
+        // is invalid Wasm on a packed array); read zero-extended in this generic
+        // path. i32_byte/f64 use plain array.get.
+        {
+          op: elemKey === "i8_byte" || elemKey === "i16_byte" ? "array.get_u" : "array.get",
+          typeIdx: arrTypeIdx,
+        } as Instr,
         ...boxInstrs,
         { op: "return" } as Instr,
       ];
@@ -4755,12 +4765,18 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
         { name: `__vpop_vec_${vecTypeIdx}`, type: { kind: "ref_null", typeIdx: vecTypeIdx } },
         { name: `__vpop_len_${vecTypeIdx}`, type: { kind: "i32" } },
       );
+      // (#2593) Packed i8/i16 elements need array.get_u and unsigned→f64; plain
+      // `array.get` is invalid Wasm on a packed array. Generic dynamic path reads
+      // zero-extended (the per-view signedness is at the typed `a[i]` site).
+      const isPackedByte = elemKey === "i8_byte" || elemKey === "i16_byte";
       const boxInstrs: Instr[] =
         elemKey === "externref"
           ? []
           : elemKey === "f64"
             ? [{ op: "call", funcIdx: boxNumIdx2! } as Instr]
-            : [{ op: "f64.convert_i32_s" } as Instr, { op: "call", funcIdx: boxNumIdx2! } as Instr];
+            : isPackedByte
+              ? [{ op: "f64.convert_i32_u" } as Instr, { op: "call", funcIdx: boxNumIdx2! } as Instr]
+              : [{ op: "f64.convert_i32_s" } as Instr, { op: "call", funcIdx: boxNumIdx2! } as Instr];
       const thenBranch: Instr[] = [
         { op: "local.get", index: 1 } as Instr,
         { op: "ref.cast", typeIdx: vecTypeIdx } as Instr,
@@ -4782,7 +4798,7 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
         { op: "local.get", index: lenL } as Instr,
         { op: "i32.const", value: 1 } as Instr,
         { op: "i32.sub" } as Instr,
-        { op: "array.get", typeIdx: arrTypeIdx } as Instr,
+        { op: isPackedByte ? "array.get_u" : "array.get", typeIdx: arrTypeIdx } as Instr,
         ...boxInstrs,
         // vec.length = len - 1 (value stays beneath on the stack)
         { op: "local.get", index: vecL } as Instr,

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -4442,7 +4442,10 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
         boxInstrs = [{ op: "call", funcIdx: boxNumIdx } as Instr];
       } else if (elemKey === "i32" && boxNumIdx !== undefined) {
         boxInstrs = [{ op: "f64.convert_i32_s" } as Instr, { op: "call", funcIdx: boxNumIdx } as Instr];
-      } else if ((elemKey === "i32_byte" || elemKey === "i8_byte" || elemKey === "i16_byte") && boxNumIdx !== undefined) {
+      } else if (
+        (elemKey === "i32_byte" || elemKey === "i8_byte" || elemKey === "i16_byte") &&
+        boxNumIdx !== undefined
+      ) {
         // ArrayBuffer/DataView/typed-array byte elements — convert unsigned then box.
         // (#2593) i16_byte joins here: the GENERIC dynamic-read path (`__vec_get`,
         // for an `any`-typed read of a typed-array vec) reads the packed element

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -36,7 +36,7 @@ import {
 } from "./expressions/helpers.js";
 import { emitUndefined, patchStructNewForAddedField } from "./expressions/late-imports.js";
 import { emitSymbolDescLoad } from "./symbol-native.js";
-import { addUnionImports, resolveWasmType, TYPED_ARRAY_NAMES } from "./index.js";
+import { addUnionImports, resolveWasmType, TYPED_ARRAY_NAMES, typedArrayPackedSignedness } from "./index.js";
 import { tryCompileNativeGeneratorResultProperty } from "./generators-native.js";
 import { tryCompileNativeMapSizeGet } from "./map-runtime.js";
 import { tryCompileNativeSetSizeGet } from "./set-runtime.js";
@@ -344,6 +344,26 @@ const TYPED_ARRAY_BYTES_PER_ELEMENT: Record<string, number> = {
   BigInt64Array: 8,
   BigUint64Array: 8,
 };
+
+/**
+ * (#2593) Recover the packed-element signedness ("s"/"u") of a typed-array
+ * element-access receiver from its TS type. Returns undefined when the receiver
+ * is not a recognised integer typed-array view (callers then fall back to the
+ * legacy storage-kind heuristic). The signedness must come from the VIEW NAME,
+ * not the i8/i16 storage kind, because signed and unsigned views of the same
+ * width share storage but read with opposite sign-extension.
+ */
+function typedArrayViewSignedness(ctx: CodegenContext, receiver: ts.Expression): "s" | "u" | undefined {
+  const t = ctx.checker.getTypeAtLocation(receiver);
+  let name = t.getSymbol()?.name ?? t.aliasSymbol?.name;
+  // `new Int8Array(...)` receiver: recover the constructor name when the type
+  // symbol is missing (e.g. a fresh NewExpression whose type didn't resolve).
+  if ((!name || !TYPED_ARRAY_NAMES.has(name)) && ts.isNewExpression(receiver) && ts.isIdentifier(receiver.expression)) {
+    name = receiver.expression.text;
+  }
+  if (!name || !TYPED_ARRAY_NAMES.has(name)) return undefined;
+  return typedArrayPackedSignedness(name);
+}
 
 /**
  * True when `<builtinName>.<propName>` has a Wasm-native **f64 constant**
@@ -5855,6 +5875,11 @@ export function compileElementAccessBody(
       reportErrorNoNode(ctx, "Element access: vec data is not array");
       return null;
     }
+    // (#2593) Signedness of a packed i8/i16 typed-array element is driven by the
+    // VIEW NAME (Int8/Int16 → sign-extend; Uint8/Uint8Clamped/Uint16 →
+    // zero-extend), NOT the storage kind — a signed Int8Array and an unsigned
+    // Uint8Array share `i8` storage but read with opposite extension.
+    const taSignedness = typedArrayViewSignedness(ctx, expr.expression);
     // Unwrap: struct.get data field, then index into backing array
     fctx.body.push({ op: "struct.get", typeIdx, fieldIdx: 1 }); // get data from vec
     // #1179: hint i32 directly for the index. compileExpression will produce
@@ -5867,15 +5892,24 @@ export function compileElementAccessBody(
     if (isSafeBoundsEliminated(fctx, expr)) {
       // Bounds check elided: loop guard guarantees index < array.length
       const getOp =
-        arrDef.element.kind === "i8" ? "array.get_u" : arrDef.element.kind === "i16" ? "array.get_s" : "array.get";
+        arrDef.element.kind === "i8" || arrDef.element.kind === "i16"
+          ? taSignedness === "s"
+            ? "array.get_s"
+            : taSignedness === "u"
+              ? "array.get_u"
+              : arrDef.element.kind === "i8"
+                ? "array.get_u"
+                : "array.get_s"
+          : "array.get";
       fctx.body.push({ op: getOp, typeIdx: arrTypeIdx } as Instr);
       // (#2001 S1) Even bounds-eliminated externref reads must map a `$Hole`
       // slot back to `undefined` — the loop guard proves in-bounds, not present.
       if (ctx.usesArrayHoles && arrDef.element.kind === "externref") emitHoleToUndefined(ctx, fctx);
     } else {
       // (#2001 S1) Pass `ctx` so the in-bounds `$Hole → undefined` read-boundary
-      // mapping fires for an externref-element (`any[]`) vec.
-      emitBoundsCheckedArrayGet(fctx, arrTypeIdx, arrDef.element, ctx);
+      // mapping fires for an externref-element (`any[]`) vec. (#2593) Thread the
+      // view-name signedness for packed i8/i16 reads.
+      emitBoundsCheckedArrayGet(fctx, arrTypeIdx, arrDef.element, ctx, false, taSignedness);
     }
     return valueType;
   }
@@ -5885,6 +5919,8 @@ export function compileElementAccessBody(
     return null;
   }
 
+  // (#2593) View-name-driven signedness for a packed i8/i16 typed-array element.
+  const taSignednessArr = typedArrayViewSignedness(ctx, expr.expression);
   // Compile index and convert to i32 (#1179: hint i32 directly to skip the
   // f64.convert_i32_s + i32.trunc_sat_f64_s round-trip when the index is
   // already an i32 local or integer literal).
@@ -5895,14 +5931,23 @@ export function compileElementAccessBody(
   if (isSafeBoundsEliminated(fctx, expr)) {
     // Bounds check elided: loop guard guarantees index < array.length
     const getOp =
-      typeDef.element.kind === "i8" ? "array.get_u" : typeDef.element.kind === "i16" ? "array.get_s" : "array.get";
+      typeDef.element.kind === "i8" || typeDef.element.kind === "i16"
+        ? taSignednessArr === "s"
+          ? "array.get_s"
+          : taSignednessArr === "u"
+            ? "array.get_u"
+            : typeDef.element.kind === "i8"
+              ? "array.get_u"
+              : "array.get_s"
+        : "array.get";
     fctx.body.push({ op: getOp, typeIdx } as Instr);
     // (#2001 S1) Map a `$Hole` slot back to `undefined` on bounds-eliminated
     // externref reads too (in-bounds ≠ present).
     if (ctx.usesArrayHoles && typeDef.element.kind === "externref") emitHoleToUndefined(ctx, fctx);
   } else {
     // (#2001 S1) Pass `ctx` for the in-bounds `$Hole → undefined` mapping.
-    emitBoundsCheckedArrayGet(fctx, typeIdx, typeDef.element, ctx);
+    // (#2593) Thread the view-name signedness for packed i8/i16 reads.
+    emitBoundsCheckedArrayGet(fctx, typeIdx, typeDef.element, ctx, false, taSignednessArr);
   }
   return valueType;
 }

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -36,7 +36,13 @@ import {
 } from "./expressions/helpers.js";
 import { emitUndefined, patchStructNewForAddedField } from "./expressions/late-imports.js";
 import { emitSymbolDescLoad } from "./symbol-native.js";
-import { addUnionImports, resolveWasmType, TYPED_ARRAY_NAMES, typedArrayPackedSignedness } from "./index.js";
+import {
+  addUnionImports,
+  resolveWasmType,
+  TYPED_ARRAY_NAMES,
+  typedArrayPackedSignedness,
+  typedArrayVecStorage,
+} from "./index.js";
 import { tryCompileNativeGeneratorResultProperty } from "./generators-native.js";
 import { tryCompileNativeMapSizeGet } from "./map-runtime.js";
 import { tryCompileNativeSetSizeGet } from "./set-runtime.js";
@@ -2377,24 +2383,40 @@ export function compilePropertyAccess(
         // byteLength = field0 * BYTES_PER_ELEMENT. ArrayBuffer's field0 is already
         // a byte count, so its element size is 1.
         const bytesPerElem = isBuffer ? 1 : (TYPED_ARRAY_BYTES_PER_ELEMENT[recvName!] ?? 1);
-        const elemKey = isBuffer ? "i32_byte" : noJsHost(ctx) && recvName === "Uint8Array" ? "i8_byte" : "f64";
-        const elemType: ValType =
-          elemKey === "i8_byte" ? { kind: "i8" } : elemKey === "i32_byte" ? { kind: "i32" } : { kind: "f64" };
+        // (#2593) The vec storage MUST match the receiver's actual backing element
+        // type — `typedArrayVecStorage` now packs all integer views standalone
+        // (i8/i16/i32_byte), not just Uint8Array. Casting an Int32Array (i32_byte)
+        // receiver to an f64 vec read the wrong field-0 → wrong byteLength.
+        const storage = isBuffer
+          ? { key: "i32_byte", type: { kind: "i32" } as ValType }
+          : typedArrayVecStorage(ctx, recvName!);
+        const elemKey = storage.key;
+        const elemType: ValType = storage.type;
         const vecTypeIdx = getOrRegisterVecType(ctx, elemKey, elemType);
-        // Compile the receiver and recover the vec struct ref.
+        // (#2593) An EMPTY `new TA(0)` literal can compile to a different backing
+        // vec type (e.g. an f64/empty vec) than the packed `vecTypeIdx` for the
+        // declared view — an unconditional `ref.cast` then traps (`illegal cast`).
+        // Read field-0 (length) through a runtime `ref.test`: on a packed-vec hit
+        // read its length; on a miss (empty/mismatched backing) the length is 0
+        // (`byteLength` of an empty view is 0 regardless of element width).
         const recvType = compileExpression(ctx, fctx, expr.expression);
         if (recvType?.kind === "externref") {
           fctx.body.push({ op: "any.convert_extern" } as Instr);
-          fctx.body.push({ op: "ref.cast", typeIdx: vecTypeIdx } as Instr);
-        } else if (
-          (recvType?.kind === "ref" || recvType?.kind === "ref_null") &&
-          "typeIdx" in recvType &&
-          recvType.typeIdx !== vecTypeIdx
-        ) {
-          fctx.body.push({ op: "ref.cast", typeIdx: vecTypeIdx } as Instr);
         }
-        // field 0 → i32 (element count or byte count).
-        fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr);
+        const lenTmpBL = allocLocal(fctx, `__bl_len_${fctx.locals.length}`, { kind: "anyref" });
+        fctx.body.push({ op: "local.set", index: lenTmpBL } as Instr);
+        fctx.body.push({ op: "local.get", index: lenTmpBL } as Instr);
+        fctx.body.push({ op: "ref.test", typeIdx: vecTypeIdx } as Instr);
+        fctx.body.push({
+          op: "if",
+          blockType: { kind: "val", type: { kind: "i32" } as ValType },
+          then: [
+            { op: "local.get", index: lenTmpBL } as Instr,
+            { op: "ref.cast", typeIdx: vecTypeIdx } as Instr,
+            { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr,
+          ],
+          else: [{ op: "i32.const", value: 0 } as Instr],
+        } as Instr);
         if (bytesPerElem !== 1) {
           fctx.body.push({ op: "i32.const", value: bytesPerElem } as Instr);
           fctx.body.push({ op: "i32.mul" } as Instr);
@@ -5910,6 +5932,17 @@ export function compileElementAccessBody(
       // mapping fires for an externref-element (`any[]`) vec. (#2593) Thread the
       // view-name signedness for packed i8/i16 reads.
       emitBoundsCheckedArrayGet(fctx, arrTypeIdx, arrDef.element, ctx, false, taSignedness);
+    }
+    // (#2593) `Uint32Array` element read: the i32_byte storage holds the full 32
+    // bits; the value as a JS number is the UNSIGNED interpretation (0..2^32-1).
+    // `array.get` on an i32 array yields a raw i32 whose default i32→f64 coercion
+    // is SIGNED (−1 instead of 4294967295). For an unsigned i32 view convert the
+    // i32 to f64 UNSIGNED here and return f64 so no signed re-coerce follows.
+    // (Int32Array is signed → the default signed coercion is already correct;
+    // i8/i16 already sign/zero-extended into the i32 via array.get_s/_u above.)
+    if (arrDef.element.kind === "i32" && taSignedness === "u") {
+      fctx.body.push({ op: "f64.convert_i32_u" } as Instr);
+      return { kind: "f64" };
     }
     return valueType;
   }

--- a/tests/issue-1787-packed-typedarray-semantics.test.ts
+++ b/tests/issue-1787-packed-typedarray-semantics.test.ts
@@ -49,11 +49,16 @@ describe("#1787 packed Uint8Array integer semantics (live guards)", () => {
   });
 });
 
-describe("#1787 forward-looking packed signed / 16-bit / clamped (it.fails until #1799/#1786)", () => {
+describe("#1787/#2593 packed signed / 16-bit / clamped (now implemented by #2593)", () => {
   // Int8Array packed-signed read: 255 stored in an i8 lane reads back as -1.
   // Not implemented — Int8Array currently lowers to $Vec[f64], so [0] is 255.
-  it.fails("Int8Array([255])[0] === -1 (#1799 packed signed storage)", async () => {
-    expect(await runValue(`export function test(): number { const a = new Int8Array([255]); return a[0]; }`)).toBe(-1);
+  it("Int8Array([255])[0] === -1 (#2593 packed signed storage, standalone)", async () => {
+    // #2593 packs integer views standalone/WASI only; host/gc keeps f64 storage
+    // (the marshalling boundary treats non-Uint8 views as number[]), so the
+    // signed-width wrap is asserted under --target standalone.
+    expect(
+      await runValue(`export function test(): number { const a = new Int8Array([255]); return a[0]; }`, "standalone"),
+    ).toBe(-1);
   });
 
   it("Uint16Array([65535])[0] === 65535 (value-correct today; packed i16 storage tracked by #1799)", async () => {
@@ -66,31 +71,34 @@ describe("#1787 forward-looking packed signed / 16-bit / clamped (it.fails until
     );
   });
 
-  it.fails("Int16Array([65535])[0] === -1 (#1799 packed signed 16-bit)", async () => {
-    expect(await runValue(`export function test(): number { const a = new Int16Array([65535]); return a[0]; }`)).toBe(
-      -1,
-    );
+  it("Int16Array([65535])[0] === -1 (#2593 packed signed 16-bit, standalone)", async () => {
+    expect(
+      await runValue(
+        `export function test(): number { const a = new Int16Array([65535]); return a[0]; }`,
+        "standalone",
+      ),
+    ).toBe(-1);
   });
 
-  it.fails("Uint8ClampedArray clamps negative to 0 (#1799 clamped write coercion)", async () => {
+  it("Uint8ClampedArray clamps negative to 0 (#2593 clamped write coercion)", async () => {
     expect(
       await runValue(`export function test(): number { const a = new Uint8ClampedArray(1); a[0] = -5; return a[0]; }`),
     ).toBe(0);
   });
 
-  it.fails("Uint8ClampedArray clamps >255 to 255 (#1799)", async () => {
+  it("Uint8ClampedArray clamps >255 to 255 (#2593)", async () => {
     expect(
       await runValue(`export function test(): number { const a = new Uint8ClampedArray(1); a[0] = 300; return a[0]; }`),
     ).toBe(255);
   });
 
-  it.fails("Uint8ClampedArray rounds 2.5 → 2 (round-half-to-even, #1799)", async () => {
+  it("Uint8ClampedArray rounds 2.5 → 2 (round-half-to-even, #2593)", async () => {
     expect(
       await runValue(`export function test(): number { const a = new Uint8ClampedArray(1); a[0] = 2.5; return a[0]; }`),
     ).toBe(2);
   });
 
-  it.fails("Uint8ClampedArray rounds 3.5 → 4 (round-half-to-even, #1799)", async () => {
+  it("Uint8ClampedArray rounds 3.5 → 4 (round-half-to-even, #2593)", async () => {
     expect(
       await runValue(`export function test(): number { const a = new Uint8ClampedArray(1); a[0] = 3.5; return a[0]; }`),
     ).toBe(4);

--- a/tests/issue-2593-typedarray-intwidth.test.ts
+++ b/tests/issue-2593-typedarray-intwidth.test.ts
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2593 — TypedArray integer element-width wrapping (standalone / WASI).
+ *
+ * Integer views pack into i8/i16/i32 storage and apply the spec coercion on
+ * write (§7.1.x ToInt8/ToUint8/ToUint8Clamp/ToInt16/ToUint16/ToInt32/ToUint32)
+ * and the view-name-driven sign extension on read (signed → `array.get_s`,
+ * unsigned → `array.get_u`). Host/gc mode keeps the legacy f64 lane (the
+ * marshalling boundary treats non-Uint8 views as `number[]`), so wrapping is
+ * asserted under `--target standalone`.
+ *
+ * The keystone fix is that the COUNT constructor (`new Int32Array(n)`) now
+ * allocates the SAME packed vec the read / `.byteLength` paths expect — before
+ * #2593 it allocated an f64 vec for every non-Uint8 view, so an inline
+ * `new Int32Array(4).byteLength` read field-0 through an i32_byte cast that
+ * never matched (returned 0 / illegal cast).
+ */
+
+async function runStandalone(source: string): Promise<number> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {} as WebAssembly.Imports);
+  return (instance.exports as { run: () => number }).run();
+}
+
+describe("#2593 TypedArray integer element-width wrapping (standalone)", () => {
+  describe("signed wrap on write + signed read", () => {
+    it("Int8Array a[0]=200 → -56 (ToInt8)", async () => {
+      expect(
+        await runStandalone(`export function run(): number { const a = new Int8Array(1); a[0] = 200; return a[0]; }`),
+      ).toBe(-56);
+    });
+
+    it("Int16Array a[0]=40000 → -25536 (ToInt16)", async () => {
+      expect(
+        await runStandalone(
+          `export function run(): number { const a = new Int16Array(1); a[0] = 40000; return a[0]; }`,
+        ),
+      ).toBe(-25536);
+    });
+
+    it("Int32Array a[0]=70000 → 70000 (in range, no wrap)", async () => {
+      expect(
+        await runStandalone(
+          `export function run(): number { const a = new Int32Array(1); a[0] = 70000; return a[0]; }`,
+        ),
+      ).toBe(70000);
+    });
+  });
+
+  describe("unsigned wrap on write + unsigned read", () => {
+    it("Uint8Array a[0]=300 → 44 (ToUint8)", async () => {
+      expect(
+        await runStandalone(`export function run(): number { const a = new Uint8Array(1); a[0] = 300; return a[0]; }`),
+      ).toBe(44);
+    });
+
+    it("Uint16Array a[0]=-1 → 65535 (ToUint16)", async () => {
+      expect(
+        await runStandalone(`export function run(): number { const a = new Uint16Array(1); a[0] = -1; return a[0]; }`),
+      ).toBe(65535);
+    });
+
+    it("Uint32Array a[0]=-1 → 4294967295 (ToUint32, unsigned read)", async () => {
+      expect(
+        await runStandalone(`export function run(): number { const a = new Uint32Array(1); a[0] = -1; return a[0]; }`),
+      ).toBe(4294967295);
+    });
+  });
+
+  describe("Uint8ClampedArray (ToUint8Clamp — clamp + round-half-to-even)", () => {
+    it("clamps 300 → 255", async () => {
+      expect(
+        await runStandalone(
+          `export function run(): number { const a = new Uint8ClampedArray(1); a[0] = 300; return a[0]; }`,
+        ),
+      ).toBe(255);
+    });
+
+    it("clamps -5 → 0", async () => {
+      expect(
+        await runStandalone(
+          `export function run(): number { const a = new Uint8ClampedArray(1); a[0] = -5; return a[0]; }`,
+        ),
+      ).toBe(0);
+    });
+
+    it("rounds 1.6 → 2", async () => {
+      expect(
+        await runStandalone(
+          `export function run(): number { const a = new Uint8ClampedArray(1); a[0] = 1.6; return a[0]; }`,
+        ),
+      ).toBe(2);
+    });
+
+    it("rounds 2.5 → 2 (half-to-even)", async () => {
+      expect(
+        await runStandalone(
+          `export function run(): number { const a = new Uint8ClampedArray(1); a[0] = 2.5; return a[0]; }`,
+        ),
+      ).toBe(2);
+    });
+
+    it("rounds 3.5 → 4 (half-to-even)", async () => {
+      expect(
+        await runStandalone(
+          `export function run(): number { const a = new Uint8ClampedArray(1); a[0] = 3.5; return a[0]; }`,
+        ),
+      ).toBe(4);
+    });
+  });
+
+  describe("count-constructor allocates packed storage — .byteLength keystone", () => {
+    it("inline new Int32Array(4).byteLength === 16", async () => {
+      expect(await runStandalone(`export function run(): number { return new Int32Array(4).byteLength; }`)).toBe(16);
+    });
+
+    it("inline new Int16Array(5).byteLength === 10", async () => {
+      expect(await runStandalone(`export function run(): number { return new Int16Array(5).byteLength; }`)).toBe(10);
+    });
+
+    it("inline empty new Int32Array(0).byteLength === 0 (no illegal cast)", async () => {
+      expect(await runStandalone(`export function run(): number { return new Int32Array(0).byteLength; }`)).toBe(0);
+    });
+
+    it("typed-local count ctor byteLength === 12", async () => {
+      expect(
+        await runStandalone(
+          `export function run(): number { const a: Int32Array = new Int32Array(3); return a.byteLength; }`,
+        ),
+      ).toBe(12);
+    });
+  });
+
+  describe("literal constructor packs + wraps", () => {
+    it("new Int8Array([255])[0] === -1 (signed read)", async () => {
+      expect(
+        await runStandalone(`export function run(): number { const a = new Int8Array([255]); return a[0]; }`),
+      ).toBe(-1);
+    });
+
+    it("new Int32Array([1,2,3])[1] === 2 and .byteLength === 12", async () => {
+      expect(
+        await runStandalone(`export function run(): number { const a = new Int32Array([1,2,3]); return a[1]; }`),
+      ).toBe(2);
+      expect(
+        await runStandalone(
+          `export function run(): number { const a = new Int32Array([1,2,3]); return a.byteLength; }`,
+        ),
+      ).toBe(12);
+    });
+  });
+
+  describe("fill applies width-wrapping", () => {
+    it("Int8Array(3).fill(200) → -56 at each index", async () => {
+      expect(
+        await runStandalone(
+          `export function run(): number { const a = new Int8Array(3); a.fill(200); return a[0] + a[1] + a[2]; }`,
+        ),
+      ).toBe(-168);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Integer typed-array views (`Int8`/`Uint8`/`Uint8Clamped`/`Int16`/`Uint16`/`Int32`/`Uint32`) now pack into width-matched i8/i16/i32 storage under `--target standalone`/`wasi`, apply the spec write coercion (ToInt8/ToUint8/ToInt16/ToUint16/ToInt32/ToUint32 and ToUint8Clamp round-half-to-even), and read back with view-name-driven sign/zero extension (signed → `array.get_s`, unsigned → `array.get_u`). Host/gc mode keeps the legacy f64 lane (the marshalling boundary treats non-Uint8 views as `number[]`).

## Root cause — keystone

Three layers had to agree on the same packed backing vec: **allocation** (`new TA(...)`), **write** truncation, and **read** signedness. The deepest bug was allocation: both count-constructor handlers in `new-super.ts` hardcoded `isNativeUint8Array ? i8_byte : f64`, so `new Int32Array(n)` allocated an **f64** vec while the read/`.byteLength` paths cast to `i32_byte`. An inline `new Int32Array(4).byteLength` read field-0 through an i32_byte cast that never matched (→ `0`), and an empty `new Int32Array(0)` trapped (`illegal cast`). A typed local worked only because the declared type coerced the f64 vec at the store. Fixed by routing both ctor handlers through `typedArrayVecStorage` and guarding the byteLength packed-vec cast with a runtime `ref.test`.

## Validation (standalone)

| repro | result |
|---|---|
| `Int8Array a[0]=200` | -56 |
| `Int16Array a[0]=40000` | -25536 |
| `Uint16Array a[0]=-1` | 65535 |
| `Uint32Array a[0]=-1` | 4294967295 (unsigned read) |
| `Uint8ClampedArray a[0]=300 / -5 / 1.6 / 2.5 / 3.5` | 255 / 0 / 2 / 2 / 4 |
| `new Int32Array(4).byteLength` (inline) | 16 |
| `new Int32Array(0).byteLength` (empty) | 0 (no trap) |
| `new Int8Array([255])[0]` | -1 |
| `new Int8Array(3).fill(200)` | -56 each |

- New `tests/issue-2593-typedarray-intwidth.test.ts` (18/18); `tests/issue-1787-*` forward-looking suite flipped to live guards (9/9). Core typed-array sweep 77/77 (issue-2159, ta-fill, atomics, 2595-2597, 1787).
- Quality sub-gates green: tsc, prettier (all changed files), stack-balance, coercion-sites, any-box-sites, codegen-fallbacks, ir-fallbacks, biome (changed files).

## Out of scope

Cross-view copy conversion (`new Int32Array(someFloat64Array)`) keeps the pre-#2593 saturating `i32.trunc_sat_f64_s` rather than full modulo wrapping — independent of the element write/read core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA