### PR TITLE
docs(#2158): re-measure standalone class gap; slice into #2610 + #2611

### DIFF
--- a/plan/issues/2158-standalone-class-prototype-descriptor-residual.md
+++ b/plan/issues/2158-standalone-class-prototype-descriptor-residual.md
@@ -5,7 +5,8 @@ status: in-progress
 assignee: ttraenkler/cs-2158
 sprint: 65
 created: 2026-06-15
-updated: 2026-06-18
+updated: 2026-06-22
+children: [2610, 2611]
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -18,6 +19,82 @@ depends_on: [2101, 1965]
 ---
 
 # Standalone class/prototype/descriptor conformance residual
+
+## RE-MEASUREMENT (architect, 2026-06-22) — the ~1,388 estimate is stale; the umbrella is largely closed
+
+Per the sprint-65 directive, I re-ran the host-vs-standalone **compile** gap on
+**current `origin/main`** over the umbrella's scope — `test/language/{statements,
+expressions}/class` (incl. `/dstr`, `/elements`) and `test/built-ins/Object/
+{defineProperty,getOwnPropertyDescriptor,defineProperties,getOwnPropertyDescriptors,
+create,freeze,keys,getOwnPropertyNames}` — compiling each wrapped file twice
+(host `gc` vs `target:"standalone"`) and bucketing standalone failures where host
+compiles. (Harness: `.tmp/measure-2158-gap.mts`, using `tests/test262-runner`
+`parseMeta`/`wrapTest`/`shouldSkip`; stratified samples of 350–500 files since the
+full ~11 k×2 scan exceeds the 10-min probe budget.)
+
+**The class-element object model is essentially DONE in standalone.** Directly
+verified (compile host == standalone, both OK) on current main:
+
+- **Private names** — `#field`, `#method()`, `static #s`, `#x in o`, private
+  getter/setter, and the wrong-receiver `o.#x` **brand-check TypeError** path.
+  (#1364/#1680 landed; _no_ independent standalone gap.)
+- **Class elements** — field-init evaluation order (`b = this.a + 1`), computed
+  property names (string and `[Symbol.iterator]` method names), static blocks,
+  `super.m()` static, accessor descriptors via
+  `Object.getOwnPropertyDescriptor(C.prototype, "x")`.
+- **Descriptors on typed receivers** — `Object.defineProperty` /
+  `defineProperties` / `getOwnPropertyDescriptor` / `create` / `freeze` / `keys`
+  directories show **GAP ≈ 0** (the `__defineProperty_value`/`_accessor` native
+  store #1629b and the `__getOwnPropertyDescriptor` native read-back #1888-S5 are
+  in place).
+
+**Measured gap rates** (host-OK files that fail standalone):
+
+| Scope                                               |  sample host-OK | standalone GAP |   rate |
+| --------------------------------------------------- | --------------: | -------------: | -----: |
+| `class` (all, 500-strat)                            |             441 |             19 | ~4.3 % |
+| `class/dstr` (400-strat)                            | 222 (dstr only) |             21 | ~9.5 % |
+| `Object/{defineProperty,defineProperties,create,…}` |            ~180 |             ~1 | ~0.5 % |
+
+The residual is NOT broad class semantics — it concentrates in **three** clean
+buckets, two of which are substrate-independent and sliced below, one of which
+defers:
+
+| Bucket                                                                                                                              |                             share of class gap | disposition                                                          |
+| ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------: | -------------------------------------------------------------------- |
+| **A. `Symbol.<wellKnown>` value-read refusal**                                                                                      |                          ~76 % of `class/dstr` | **→ #2610** (constant-fold; NOT #2175/#2580-gated)                   |
+| **B. `__extern_length` #2043 late-import index-shift** (async-gen-meth dstr defaults)                                               |                          ~24 % of `class/dstr` | **→ #2611** (shift-orphan; substrate-independent)                    |
+| **C. `__get_builtin` on a builtin object** (`Object.getOwnPropertyDescriptor(Date,"UTC")`, `getOwnPropertyDescriptors(globalThis)`) | the `Object/getOwnPropertyDescriptor` residual | **→ #2175** (builtin-object representation — DEFERRED, do not slice) |
+
+### Deferred (do NOT slice under #2158)
+
+- **→ #2175** (standalone builtin-prototype object representation, in-progress):
+  every `__get_builtin` / `<Builtin>.prototype`-as-object / descriptor-on-a-
+  builtin-ctor case. `Object.getOwnPropertyDescriptor(Date, "UTC")` and
+  `getOwnPropertyDescriptors` over the global/builtin objects need the builtin
+  object model; they are gated on #2175 and must not be sliced here.
+- **→ #2580 / #2580-M2** (value-rep substrate — `.length`/descriptor reflection
+  on `any`/dynamically-mutated receivers): any descriptor/own-key read whose
+  receiver arrives as an opaque `externref` with no static brand. Already owned
+  by the value-rep substrate track; out of scope for #2158.
+
+### Sliced (substrate-independent, dev-tractable)
+
+- **#2610** — `Symbol.<wellKnown>` value-read folds to its i32 sentinel instead
+  of refusing. ~3-line fix in `hasNativeBuiltinConstantHandler`
+  (`property-access.ts`). **Est. ~150–250 standalone rows.** feasibility: easy.
+- **#2611** — `__extern_length` #2043 late-import index-shift orphan in
+  async-generator/generator class-method destructuring-param defaults. Native-
+  runtime-body shift bookkeeping in `object-runtime.ts`. **Est. ~60–90 rows.**
+  feasibility: medium. (Overlaps #2610 on iterator-error-path tests — both
+  needed for those to pass at runtime.)
+
+**Conclusion:** #2158 should be re-scoped from a "~1,388-test epic" to "two clean
+residual bugs (#2610, #2611) plus a pointer to #2175/#2580 for the rest." After
+#2610 + #2611 land, re-measure; the expected remaining class/Object standalone
+gap is small and #2175/#2580-bound. The historical 7163-bucket framing below is
+superseded — that count was a broad classifier catch-all dominated by the
+builtin-prototype-value-read gap (#2175), not class-element semantics.
 
 ## Problem
 
@@ -118,27 +195,27 @@ classifier (`scripts/build-test262-report.mjs` matcher order) over
 **exactly (7163)**. The bucket matcher is broad — it scoops any record whose
 path contains `…/class/`, `private`, `computed-property-names`, or whose
 **error text contains `prototype`** — so it is dominated by failures that are
-*not* class-element semantics at all. Verified breakdown of the 7163:
+_not_ class-element semantics at all. Verified breakdown of the 7163:
 
-| Family | Count | Status |
-|--------|------:|--------|
-| **A. `<Builtin>.prototype.<member>` value read CE** (S6-b refusal) | **2846** | compile_error |
-| **B. `Symbol.<wellKnown>` value read CE** (species/hasInstance/…) | **273** | compile_error |
-| C. `<Ctor>.<staticProp>` value read CE (Object.getPrototypeOf, Promise.resolve…) | 14 | compile_error |
-| D. other `not (yet) supported in --target standalone` CE | 573 | compile_error |
-| E. `Object.prototype.toString.call(...)` CE | 70 | compile_error |
-| F. invalid-Wasm-binary CE (validator type-mismatch) | 384 | compile_error |
-| G. CE residual (uncategorized) | 80 | compile_error |
-| H. genuinely-class FAILs (private 232, computed-name 96, class-lang 287) | ~615 | fail |
-| I. ToPrimitive ("Cannot convert object to primitive") | 326 | fail+CE |
-| J. `__str_flatten` null-deref | 105 | fail |
-| K. illegal-cast at runtime | 84 | fail |
-| L. misc fail residual | ~1700 | fail |
+| Family                                                                           |    Count | Status        |
+| -------------------------------------------------------------------------------- | -------: | ------------- |
+| **A. `<Builtin>.prototype.<member>` value read CE** (S6-b refusal)               | **2846** | compile_error |
+| **B. `Symbol.<wellKnown>` value read CE** (species/hasInstance/…)                |  **273** | compile_error |
+| C. `<Ctor>.<staticProp>` value read CE (Object.getPrototypeOf, Promise.resolve…) |       14 | compile_error |
+| D. other `not (yet) supported in --target standalone` CE                         |      573 | compile_error |
+| E. `Object.prototype.toString.call(...)` CE                                      |       70 | compile_error |
+| F. invalid-Wasm-binary CE (validator type-mismatch)                              |      384 | compile_error |
+| G. CE residual (uncategorized)                                                   |       80 | compile_error |
+| H. genuinely-class FAILs (private 232, computed-name 96, class-lang 287)         |     ~615 | fail          |
+| I. ToPrimitive ("Cannot convert object to primitive")                            |      326 | fail+CE       |
+| J. `__str_flatten` null-deref                                                    |      105 | fail          |
+| K. illegal-cast at runtime                                                       |       84 | fail          |
+| L. misc fail residual                                                            |    ~1700 | fail          |
 
 **The single dominating root cause (A, 2846) is the builtin-prototype-method-
 as-value gap, not class semantics.** Reading `Array.prototype.push`,
 `String.prototype.charAt`, `Object.prototype.toString`, `Date.prototype.getTime`,
-etc. as a *value* in `--target standalone` hits the refusal at
+etc. as a _value_ in `--target standalone` hits the refusal at
 `property-access.ts:2234` (`reportUnsupportedStandaloneBuiltinValueRead`).
 
 ### Root cause (Family A/B/C)
@@ -153,6 +230,7 @@ comment: `// S3 (reserved, not yet wired): "%TypedArray%", Int8Array, …`.
 The extension point is a **pure registration**: a builtin that calls
 `registerNativeProtoBuiltin(ctx, glue)` with a `NativeProtoBuiltinGlue`
 (`native-proto.ts:142`) automatically gets, host-free:
+
 - `<Builtin>.prototype` as a value → `emitLazyNativeProtoGet`
   (`property-access.ts:2222`),
 - `<Builtin>.prototype.<member>` value read → `tryCompileStandaloneBuiltinProtoMemberRead`
@@ -193,7 +271,7 @@ Reference: `ensureRegExpNativeProtoGlue` + `emitRegExpProtoMemberBody`
    arm). This is the ONE edit that activates routing for the builtin.
 
 **Reuse existing native bodies.** Each builtin family already has native
-method lowerings used by the *direct-call* path (e.g. `array-methods.ts`,
+method lowerings used by the _direct-call_ path (e.g. `array-methods.ts`,
 `src/codegen/*`). `emitMemberBody` should delegate to those existing emitters
 operating on the recovered struct/value, NOT re-implement them. The new code is
 the brand-recovery wrapper + result boxing, not new method semantics.
@@ -207,6 +285,7 @@ Brands + glue for `Array`, the 11 concrete TypedArray views + `%TypedArray%`,
 existing array/typedarray method emitters in `array-methods.ts` on the recovered
 vec/byte-carrier value. The TypedArray views share one glue parameterized by
 element type. This is the single biggest CE win.
+
 - Files: `native-proto.ts` (brand table), new
   `src/codegen/array-native-proto.ts` (glue + `emitMemberBody`),
   `property-access.ts:449` (`tryEnsureNativeProtoBrand` arms), `array-methods.ts`
@@ -215,7 +294,7 @@ element type. This is the single biggest CE win.
   emitter; box ref results with `extern.convert_any`.
 - CE reduction: **≈1253**.
 - Acceptance: `Int8Array.prototype` / `Array.prototype` `built-in static
-  property value read` CEs clear; `built-ins/Array/prototype` (2047 in bucket)
+property value read` CEs clear; `built-ins/Array/prototype` (2047 in bucket)
   and `built-ins/TypedArray/prototype` (523) compile. Sample sigs
   `…Array.prototype built-in static property value read…` and
   `…Int8Array.prototype…` gone.
@@ -229,11 +308,12 @@ extend the standalone slice), `hasOwnProperty`, `isPrototypeOf`,
 `call`, `apply`, `bind`, `toString`. The `Object.prototype.toString.call(x)`
 form (70 CEs) is the same glue once `Object.prototype.toString` is a real
 closure value.
+
 - Files: `native-proto.ts`, new `src/codegen/object-native-proto.ts`,
   `property-access.ts:449`, reuse `object-ops.ts` / existing toString-tag logic.
 - CE reduction: **≈495**.
 - Acceptance: `Object.prototype` / `Function.prototype` `…static property value
-  read…` CEs clear; `Object.prototype.toString.call(...) is not yet supported`
+read…` CEs clear; `Object.prototype.toString.call(...) is not yet supported`
   CE gone; `built-ins/Object/prototype` (147) + `built-ins/Function/prototype`
   (201) compile.
 
@@ -254,6 +334,7 @@ fires where the i32 result is consumed by a symbol-keyed computed access
 raw `!== undefined` comparison until a symbol-as-externref boxing exists (or box
 the well-known symbol to a stable externref sentinel so both compose — preferred
 if cheap). Decide via the failing sample signatures.
+
 - Files: `property-access.ts` (`hasNativeBuiltinConstantHandler` + the deferral
   gate at `:2214`/`:2238`).
 - CE reduction: **≈273** (minus the `!== undefined` subset, ~30).
@@ -270,12 +351,13 @@ The long tail of Family A: `String.prototype.*` (317), `Date.prototype.*` (283),
 family. Lower priority than 1–2 only because it spans more builtins (more glue
 files) for a comparable total; split into 4a (String/Number/Boolean/BigInt) and
 4b (Date/Error/collections) if a single PR is too large.
+
 - Files: `native-proto.ts`, per-family `*-native-proto.ts` glue,
   `property-access.ts:449`, reuse existing string/number/date/collection
   emitters.
 - CE reduction: **≈960**.
 - Acceptance: the remaining `<Builtin>.prototype built-in static property value
-  read` CEs across String/Number/Boolean/BigInt/Date/Error/Set/Map/Weak*/Promise
+read` CEs across String/Number/Boolean/BigInt/Date/Error/Set/Map/Weak\*/Promise
   clear. After slices 1–4 the entire Family-A+B+E (~3700) CE class is gone.
 
 **Slice 5 — invalid-Wasm-binary + ToPrimitive residual (Family F+I, ≈710).**
@@ -290,6 +372,7 @@ the standalone ToPrimitive/`@@toPrimitive` dispatch over class structs
 (`index.ts:1586`/`:5288` already has the class-`[Symbol.toPrimitive]` dispatch
 scaffold). Re-validate against repros before sizing — some F entries may be
 collateral that slices 1–4 already fix.
+
 - Files: `type-coercion.ts`, `property-access.ts`, `index.ts` (ToPrimitive
   dispatch), per WAT diagnosis.
 - Reduction: **≈710** (re-measure after slices 1–4 land).
@@ -297,7 +380,7 @@ collateral that slices 1–4 already fix.
 
 **Slice 6 — genuinely-class FAILs: private fields/methods + computed property
 names (Family H, ≈615).**
-The *actual* class-element semantics residual: private fields/methods/brand
+The _actual_ class-element semantics residual: private fields/methods/brand
 checks (232 — `built-ins`/`language/.../private`), computed-property-name class
 fields/accessors from `await`/function expressions (96 — the `cpn-class-*`
 sample files), and general class-lang fails (287). These are the only slices
@@ -306,11 +389,12 @@ that touch class codegen proper (`class-bodies.ts`, `index.ts`
 fetched ES spec section (§15.7 class definitions, §15.7.10 private names) before
 implementing — these are not a single mechanism. Lowest impact-per-effort of the
 six; schedule after the CE families are cleared so the FAIL signal is clean.
+
 - Files: `src/codegen/class-bodies.ts`, `src/codegen/index.ts`,
   `src/codegen/literals.ts` (computed key resolution).
 - Reduction: **≈615** (subdivide per cluster; re-measure after slice 5).
 - Acceptance: `cpn-class-expr-*-computed-property-name-from-await/function-
-  expression` sample files pass; private-field/brand-check class tests pass.
+expression` sample files pass; private-field/brand-check class tests pass.
 
 ### Sequencing & risk
 
@@ -335,6 +419,7 @@ six; schedule after the CE families are cleared so the FAIL signal is clean.
   1–4 merge; their counts are downstream of the CE fixes and will shift.
 
 ### Test files to verify (per slice)
+
 - S1: `test/built-ins/Array/prototype/*`, `test/built-ins/TypedArray/prototype/*`,
   `test/built-ins/DataView/prototype/*`, `test/built-ins/ArrayBuffer/prototype/*`
 - S2: `test/built-ins/Object/prototype/*`, `test/built-ins/Function/prototype/*`,
@@ -343,7 +428,7 @@ six; schedule after the CE families are cleared so the FAIL signal is clean.
   `c[Symbol.x]`
 - S4: `test/built-ins/{String,Number,Date,Set,Map,Promise,Error}/prototype/*`
 - S6: `test/language/expressions/class/cpn-class-expr-*-computed-property-name-
-  from-{await,function}-expression.js`, `test/language/.../class/.../private*`
+from-{await,function}-expression.js`, `test/language/.../class/.../private*`
 
 Add standalone equivalence regressions under
 `tests/issue-2158-*-standalone.test.ts` per slice (mirror
@@ -354,6 +439,7 @@ Add standalone equivalence regressions under
 ## Implementation notes — Slice F-1 (2026-06-18, cs-2158): dstr-param default funcIdx-shift invalid-Wasm
 
 ### What
+
 Fixes a concrete Family-F (invalid-Wasm-binary) defect that hit a large slice
 of the class `dstr/` failures (e.g.
 `class/dstr/meth-dflt-obj-ptrn-prop-ary`, `private-meth-dflt-obj-ptrn-prop-ary`,
@@ -369,6 +455,7 @@ pointing at `$__object_seal` (an externref producer) instead of
 `$__extern_is_undefined` (an i32 producer).
 
 ### Root cause — a funcIdx index-shift orphan (addUnionImports/#1109 family)
+
 `destructureParamObject`'s externref **struct-fast-path**
 (`destructuring-params.ts`, the `ref.test structTypeIdx ? then : else` arm)
 detaches the OUTER function body to a then/else branch buffer with a **plain
@@ -392,6 +479,7 @@ moved `__extern_is_undefined` to 116 but the emitted call stayed at 114 (= now
 unreachable from the fctx body chain.
 
 ### Fix
+
 `src/codegen/destructuring-params.ts` — in the struct-fast-path branch, track the
 orphaned outer `savedBody` in `ctx.liveBodies` for the recursion window
 (add before the then/else compile, delete after the `if` is assembled),
@@ -401,6 +489,7 @@ double-delete (keeps the #2182 liveBodies-balance invariant intact). +16 lines,
 no behavior change to the non-orphan paths.
 
 ### Verification
+
 - `tests/issue-2158-dstr-param-default-nested-pattern.test.ts` (8 cases):
   standalone now VALIDATES (`WebAssembly.compile` succeeds — the direct
   regression guard for the orphan) for object-prop→array, class-method,
@@ -415,7 +504,8 @@ no behavior change to the non-orphan paths.
   (they import a non-existent `./helpers.js`) — pre-existing, unrelated.
 
 ### Remaining (still open under this umbrella)
-- **Host-import leak in standalone**: these shapes now compile to *valid* Wasm
+
+- **Host-import leak in standalone**: these shapes now compile to _valid_ Wasm
   but still emit `env::__array_from_iter_n` (+ `env::__get_undefined` via
   `emitBoundsCheckedArrayGetUndef` bypassing `ensureGetUndefined`), which
   standalone cannot satisfy at instantiation. Needs a Wasm-native array-from-iter

--- a/plan/issues/2610-standalone-symbol-wellknown-value-read-refusal.md
+++ b/plan/issues/2610-standalone-symbol-wellknown-value-read-refusal.md
@@ -1,0 +1,183 @@
+---
+id: 2610
+title: "standalone: `Symbol.<wellKnown>` read as a VALUE refuses instead of folding to its i32 sentinel"
+status: ready
+sprint: 65
+created: 2026-06-22
+priority: high
+feasibility: easy
+reasoning_effort: medium
+task_type: bugfix
+area: class
+parent: 2158
+goal: standalone-mode
+language_feature: well-known-symbols, computed-property-keys
+---
+
+# #2610 — standalone `Symbol.<wellKnown>` value-read refuses instead of folding to its i32 sentinel
+
+Slice of umbrella **#2158**. This is the single dominant clean root cause in the
+re-measured #2158 host-vs-standalone gap (sprint-65 architect re-measurement,
+2026-06-22): ~76 % of the `language/{statements,expressions}/class/dstr` gap and
+the top bucket across the whole #2158 scope.
+
+## Problem
+
+In `--target standalone`, reading a well-known symbol **as a value** —
+`Symbol.iterator`, `Symbol.asyncIterator`, `Symbol.hasInstance`,
+`Symbol.toPrimitive`, `Symbol.toStringTag`, … — hard-refuses at compile time
+with:
+
+```
+Codegen error: Symbol.iterator built-in static property value read is not
+supported in --target standalone (#1907 / #1888 S6-b).
+```
+
+even though the compiler **already has** a pure-Wasm constant emitter for exactly
+these reads (it folds `Symbol.<wellKnown>` to its small i32 sentinel id). The
+refusal pre-empts that emitter.
+
+### Verified minimal repro
+
+```ts
+// standalone: ERR (refusal). gc/host: OK.
+const o: any = {};
+o[Symbol.iterator] = function () {
+  return {
+    next() {
+      return { done: true, value: undefined };
+    },
+  };
+};
+```
+
+The trigger is reading `Symbol.iterator` **as a value** (a bare property read /
+computed-key value), NOT calling it. `arr[Symbol.iterator]()` (read-then-call)
+and `class C { [Symbol.iterator]() {} }` (computed method _name_) already work —
+those reach the constant fold by other paths. The failing forms are array-/
+iterator-protocol setup and error-path tests under `class/.../dstr/` (the
+generated `*-iter-*-err`, `*-iter-no-close`, `*-iter-get-err` variants assign or
+read `Symbol.iterator` on a plain object to drive the abrupt-completion path).
+
+## Root cause (verified)
+
+`src/codegen/property-access.ts`:
+
+- The standalone builtin-static-value-read block (line ~3013, inside
+  `if (ctx.standalone && BUILTIN_CTOR_NAMES.has(builtinName) && !isShadowed && !deferToNativeConstant)`)
+  is reached for `builtinName === "Symbol"`, `propName === "iterator"` (etc.)
+  because `Symbol ∈ BUILTIN_CTOR_NAMES`. No static-method closure exists for the
+  pair, so it falls through to `reportUnsupportedStandaloneBuiltinValueRead`
+  (line ~3032) → emits `ref.null.extern` + records the hard error.
+- The escape hatch is `deferToNativeConstant = ctx.standalone &&
+hasNativeBuiltinConstantHandler(builtinName, propName)` (line ~3012). When
+  true, the whole block is skipped and control reaches the **existing**
+  constant emitter at line ~4030:
+
+  ```ts
+  // Handle Symbol.iterator, Symbol.hasInstance, etc. → constant i32
+  if (ts.isIdentifier(expr.expression) && expr.expression.text === "Symbol") {
+    const symId = getWellKnownSymbolId(propName);
+    if (symId !== undefined) {
+      fctx.body.push({ op: "i32.const", value: symId });
+      return { kind: "i32" };
+    }
+  }
+  ```
+
+- **`hasNativeBuiltinConstantHandler` (line ~364) does NOT cover `Symbol`.** It
+  returns true only for `Math` (MATH_CONSTANT_PROPS), `Number`
+  (NUMBER_CONSTANT_PROPS), and `<TypedArray>.BYTES_PER_ELEMENT`. So
+  `deferToNativeConstant` is false for `Symbol.iterator`, the refusal fires, and
+  the downstream constant emitter is never reached.
+
+This is **substrate-independent** — the value is a compile-time i32 constant
+(the well-known-symbol sentinel id, already used by `getWellKnownSymbolId` /
+`WELL_KNOWN_SYMBOLS` at property-access.ts:164/297). It needs **no** builtin-
+prototype object representation, so it is **NOT gated on #2175** and **NOT gated
+on #2580**.
+
+## Implementation Plan
+
+### Change (one function, ~3 lines)
+
+**File: `src/codegen/property-access.ts`**, function `hasNativeBuiltinConstantHandler`
+(line ~364). Add a `Symbol` arm that defers to the existing well-known-symbol
+constant fold:
+
+```ts
+function hasNativeBuiltinConstantHandler(builtinName: string, propName: string): boolean {
+  if (builtinName === "Math") return MATH_CONSTANT_PROPS.has(propName);
+  if (builtinName === "Number") return NUMBER_CONSTANT_PROPS.has(propName);
+  // (#2610) Symbol.<wellKnown> as a VALUE folds to its i32 sentinel id at the
+  // downstream constant emitter (~line 4030, `getWellKnownSymbolId`). Defer the
+  // standalone builtin-static-value-read refusal to it — host-free, no prototype
+  // object needed (NOT #2175-gated). Mirrors the Math/Number constant defers.
+  if (builtinName === "Symbol") return getWellKnownSymbolId(propName) !== undefined;
+  // (#2595) <TypedArrayName>.BYTES_PER_ELEMENT static read → constant emitter.
+  if (propName === "BYTES_PER_ELEMENT") return builtinName in TYPED_ARRAY_BYTES_PER_ELEMENT;
+  return false;
+}
+```
+
+`getWellKnownSymbolId` is already defined in this file (line ~297); no new
+import. The gate is exact: it only defers for prop names that the downstream
+emitter actually folds (`iterator`, `asyncIterator`, `hasInstance`,
+`isConcatSpreadable`, `match`, `matchAll`, `replace`, `search`, `species`,
+`split`, `toPrimitive`, `toStringTag`, `unscopables` — whatever is in
+`WELL_KNOWN_SYMBOLS`). A non-well-known `Symbol.foo` still refuses (correct —
+there is no constant for it).
+
+### Why this is safe
+
+- gc/host mode is unaffected: `deferToNativeConstant` is gated on `ctx.standalone`
+  (the `&&` at line 3012), so host still takes the `__get_builtin` import path,
+  which is observationally identical to the constant for these reads.
+- Shadowing is already handled by the existing `isShadowed` check upstream
+  (`fctx.localMap.has("Symbol")` / boxedCaptures) — a local named `Symbol` never
+  reaches `hasNativeBuiltinConstantHandler`.
+- The result type is `{ kind: "i32" }` (the symbol sentinel), matching every
+  other consumer of `getWellKnownSymbolId` (e.g. computed-key dispatch,
+  `Symbol.iterator !== undefined` comparisons) — no ValType mismatch.
+
+### Edge cases to verify
+
+- `o[Symbol.iterator] = fn` (computed-key WRITE) — the LHS key must fold to the
+  i32 sentinel so the dynamic `__extern_set` keys on it. Confirm the write path
+  reaches the same constant emitter (it routes the computed-key expression
+  through this `compilePropertyAccess`/key-eval path).
+- `Symbol.iterator` passed as a call argument / stored in a `const` — bare value
+  read, must fold.
+- `Symbol.asyncIterator`, `Symbol.toPrimitive`, `Symbol.toStringTag` — same fold.
+- `Symbol.for("x")` / `Symbol("x")` — NOT well-known; unaffected (those are
+  call expressions, different path).
+- Non-well-known `Symbol.foo` — still refuses loud (no regression to silent
+  wrong-codegen).
+
+### Failing test262 paths (sample — host passes, standalone refuses)
+
+- `test/language/statements/class/dstr/async-gen-meth-dflt-ary-init-iter-get-err.js`
+- `test/language/statements/class/dstr/gen-meth-static-ary-ptrn-elem-id-iter-step-err.js`
+- `test/language/expressions/class/dstr/gen-meth-static-ary-init-iter-get-err.js`
+- `test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-iter-step-err.js`
+- `test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-iter-val-err.js`
+- (the full `*-ary-*-iter-*` / `*-iter-no-close` generated families under both
+  `class/dstr` trees)
+
+### Estimated rows
+
+Re-measured: ~76 % of the `class/dstr` host-vs-standalone gap. Stratified
+samples → **~250–320 rows** across `language/{statements,expressions}/class/dstr`
+once execution passes (the compile refusal currently blocks every one). Some of
+these are iterator-error-path tests that also need #2611 (the `__extern_length`
+shift bug) to fully pass at runtime; this slice removes the compile refusal
+(necessary, not always sufficient). Conservative standalone-pass uplift from this
+slice alone: **~150–250 rows**.
+
+### Test to add
+
+`tests/issue-2610-symbol-wellknown-value-read-standalone.test.ts` — assert
+standalone COMPILES (and runs) for: `o[Symbol.iterator] = fn`, a bare
+`const k = Symbol.iterator` value read, `Symbol.asyncIterator` / `toPrimitive` /
+`toStringTag` reads, and a computed-key write keyed by `Symbol.iterator`. Mirror
+`tests/issue-2158-class-identity-standalone.test.ts`.

--- a/plan/issues/2611-standalone-extern-length-late-import-shift-orphan.md
+++ b/plan/issues/2611-standalone-extern-length-late-import-shift-orphan.md
@@ -1,0 +1,193 @@
+---
+id: 2611
+title: "standalone: `__extern_length` invalid-Wasm (#2043 late-import index-shift orphan) in async-gen-method destructuring-param defaults"
+status: ready
+sprint: 65
+created: 2026-06-22
+priority: medium
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: class
+parent: 2158
+goal: standalone-mode
+language_feature: destructuring-params, async-generators, late-imports
+related: [2043, 2567, 1109]
+---
+
+# #2611 — standalone `__extern_length` invalid-Wasm (#2043 late-import index-shift orphan)
+
+Slice of umbrella **#2158**. Second-largest clean root cause in the re-measured
+#2158 host-vs-standalone gap (sprint-65 architect re-measurement, 2026-06-22):
+~24 % of the `class/dstr` gap. This is the **deeper shift orphan** the umbrella's
+"Slice F-1" notes explicitly predicted would surface after the F-1 fix
+("the static-method variant surfaces a second shift orphan").
+
+## Problem
+
+`--target standalone` emits **invalid Wasm** for an **async-generator (or
+generator) class method whose parameter binds a destructuring pattern with a
+default value**, when compiled inside a full-size module (the test262 harness
+preamble supplies the import pressure). The validator rejects the module:
+
+```
+Binary emit error: Codegen error: local index out of range — 4 (valid: [0, 4))
+at function '__extern_length'. This is the late-import index-shift class (#2043):
+a captured index went stale across a deferred flushLateImportShifts/
+addUnionImports/addStringImports shift, or a map lookup failed and baked
+-1/undefined. Re-resolve the index by name AFTER the last shift, or make the
+producer refuse loudly.
+```
+
+The compiler's own diagnostic names the class precisely: **#2043 late-import
+index-shift**.
+
+### Verified repro (needs the full harness preamble)
+
+The minimal `class C { async *m([a,b]=[3,4]) { yield a; } }` compiles fine — the
+bug only manifests once the module is large enough that a late import is added
+_after_ `__extern_length` is registered. Reproduce via the real wrapped test:
+
+```
+test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-id-elision-next-err.js
+test/language/statements/class/dstr/async-gen-meth-static-dflt-obj-ptrn-prop-id-get-value-err.js
+```
+
+(wrap with `tests/test262-runner.ts` `wrapTest`, compile `target:"standalone"`).
+Both reproduce the exact error above on current main.
+
+## Root cause (diagnosis)
+
+`__extern_length` is a **native-built** runtime function (standalone), registered
+in `src/codegen/object-runtime.ts` (the `// ── __extern_length …` block, ~line
+3196, `registerNative("__extern_length", …)`). It declares 4 entries (param 0 +
+locals `any`/`lenF64`/`lenTrunc` = indices 0–3), so "valid [0, 4)" matches — and
+yet the decoded body references index **4**. The body itself only uses indices
+0–3, so this is not a local-count bug in the source array: it is the #2043
+symptom — a later index shift desynced the already-encoded body.
+
+The two prime suspects, both captured at **build time** inside the
+`objLengthArm` IIFE:
+
+```ts
+const externGetIdx2036 = ctx.funcMap.get("__extern_get")!;
+const unboxIdx2036 = ctx.funcMap.get("__unbox_number")!;
+// … { op: "call", funcIdx: externGetIdx2036 } / funcIdx: unboxIdx2036 …
+```
+
+and `getOrRegisterVecBaseType(ctx)` / `objVecTypeIdx`. These funcIdx/typeIdx are
+**baked into `__extern_length`'s body** when it is registered. The
+async-generator + destructuring-param-default lowering then adds a **late import**
+(`__array_from_iter_n` / `__extern_get_idx` / `__extern_length` itself /
+`__get_undefined` — the destructuring-params path is a known late-import adder,
+see #2567 / destructuring-params.ts:421 `shiftLateImportIndices`). That shift
+moves the defined-function indices, but the shift walk does **not** re-resolve
+the indices baked into the already-registered `__extern_length` body (the native
+runtime bodies are registered into `ctx.funcs`, not the per-function
+`fctx.body`/`savedBodies`/`liveBodies` chain that `shiftLateImportIndices`
+walks). The stale baked funcIdx then points at a function with a different
+signature/local-frame, and the validator's frame check reports the mismatch as
+"local index out of range — 4 at \_\_extern_length".
+
+This is the **same family** as #2567 (destructuring-param default-buffer orphan)
+and the umbrella's Slice F-1 (`destructuring-params.ts` outer-body orphan), but
+the orphaned body here is a **native runtime function** (`__extern_length`),
+registered up-front and not on any fctx chain — so the existing
+`liveBodies`/`savedBodies` tracking can't reach it.
+
+## Implementation Plan
+
+### Step 1 — confirm which captured index goes stale (diagnostic)
+
+Instrument the `objLengthArm` / `vecBaseArm` registration in
+`object-runtime.ts` (~3196): log `externGetIdx2036`, `unboxIdx2036`,
+`vecBaseIdx`, `objVecTypeIdx` at capture time, and at module-finalize log the
+final `ctx.funcMap.get("__extern_get")` / `__unbox_number`. If they differ, the
+baked funcIdx is the orphan. (The error's "(#2043)" tag + the
+`flushLateImportShifts` hint already point here.) Repro file:
+`async-gen-meth-dflt-ary-ptrn-rest-id-elision-next-err.js` wrapped.
+
+### Step 2 — fix: re-resolve native-runtime body indices after the last shift
+
+Two viable approaches; pick per how the registration is structured:
+
+**(A) Resolve-by-name late (preferred, matches the error's own advice).**
+Make `__extern_length` (and any sibling native body that bakes a
+`ctx.funcMap.get(...)` funcIdx — `__extern_get_idx`, `__getOwnPropertyDescriptor`,
+the #2042 reflection helpers) defer its `call` funcIdx resolution to **after**
+all late imports are flushed. The cleanest mechanism already in the codebase is
+`ensureLateImport` (which participates in the shift bookkeeping) rather than a
+raw `ctx.funcMap.get(...)` captured into the body array. Where the callee is a
+native runtime func (not an import), register the native body so its
+cross-references are patched by the same finalize pass that shifts imports — i.e.
+add the native runtime bodies' instruction arrays to the set that
+`shiftLateImportIndices` / the module-finalize shift walks (the symmetric fix to
+#2567's `liveBodies` tracking, applied to `ctx.funcs[*].body` for native
+runtime functions).
+
+**(B) Order the registration so no shift can follow.** Ensure
+`__extern_length` and friends are registered (and their callee indices resolved)
+**after** the destructuring-params / async-generator late imports are added, so
+nothing shifts their baked indices. This is more fragile (any future late adder
+re-breaks it) — prefer (A).
+
+Whichever path: the invariant to restore is _every funcIdx/typeIdx baked into a
+native runtime body must be re-resolved (or shift-tracked) across the final
+import shift_, exactly as the per-function fctx bodies already are.
+
+### Step 3 — make the producer refuse loudly if it can't (defense)
+
+Per the error text's last clause: if a native body must bake an index that could
+shift, and approach (A) is not wired for that callee, the registration should
+assert the funcIdx is still valid at finalize (or route through a shift-tracked
+mechanism) rather than emit a body the validator later rejects. This converts a
+future regression of this class from invalid-Wasm into a loud compile error.
+
+### Files
+
+- `src/codegen/object-runtime.ts` — `__extern_length` registration (~3196) and
+  the shared native-runtime-body shift bookkeeping. Check siblings
+  `__extern_get_idx` (~3322) and the #2042 reflection helpers (~5106, ~5358) for
+  the same baked-funcIdx pattern; fix them together if they share the orphan.
+- `src/codegen/expressions/late-imports.ts` — `shiftLateImportIndices` (the walk
+  that must also cover native runtime bodies, if approach (A) extends it).
+- `src/codegen/destructuring-params.ts` — the late-import adder that triggers the
+  shift (no change expected, but it is the trigger; cross-reference #2567 / F-1
+  for the body-orphan tracking pattern to mirror).
+
+### Edge cases
+
+- Generator (non-async) class method with the same default-destructuring param —
+  same trigger; verify it is fixed too (sample shows `gen-meth-*` variants).
+- Static vs instance method (`*-static-dflt-*`) — both reproduce; the fix must
+  cover both (the static variant was the umbrella's predicted "second orphan").
+- Nested patterns (`{x:[y]}=…`, `[[y]]=…`) and rest elements
+  (`*-ptrn-rest-id-*`) — the highest import pressure; include in the test.
+- Must NOT change gc/host output: `objArrayLikeArms`/`objVec` arms are already
+  `ctx.standalone`-gated; the fix is to index bookkeeping, observationally inert
+  for host (host's `__extern_length` is a JS import, not a native body).
+
+### Failing test262 paths (sample)
+
+- `test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-id-elision-next-err.js`
+- `test/language/statements/class/dstr/async-gen-meth-static-dflt-obj-ptrn-prop-id-get-value-err.js`
+- `test/language/expressions/class/dstr/async-gen-meth-dflt-obj-ptrn-prop-obj-value-null.js`
+- `test/language/statements/class/dstr/async-gen-meth-dflt-ary-init-iter-get-err.js`
+- `test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-elem-{ary,obj}-val-null.js`
+
+### Estimated rows
+
+~24 % of the `class/dstr` host-vs-standalone gap. Stratified samples →
+**~60–90 rows** (the async-gen-meth + gen-meth default-destructuring families,
+across both `class/dstr` trees). Several overlap with #2610 (iterator-error-path
+tests need BOTH the Symbol fold AND this shift fix to pass at runtime). Standalone
+invalid-Wasm → valid-Wasm uplift is the direct win; full pass also needs the
+async-generator runtime path to be conformant (mostly landed; see #2174).
+
+### Test to add
+
+`tests/issue-2611-extern-length-shift-async-gen-dstr-standalone.test.ts` —
+compile (`WebAssembly.compile` / validate) the wrapped repro files above under
+`target:"standalone"` and assert NO `local index out of range` / invalid-binary
+error. Mirror `tests/issue-2158-dstr-param-default-nested-pattern.test.ts` (the
+Slice F-1 validate-only regression guard).


### PR DESCRIPTION
## Summary

Re-measured the host-vs-standalone gap for umbrella **#2158** (standalone class/prototype/private-name/descriptor conformance) on current `origin/main`, and sliced the substrate-independent residuals into two dev-tractable issues.

### Re-measurement finding
The original ~1,388 estimate is **stale** — the class-element object model is essentially **done** in standalone. Directly verified (host compile == standalone compile, both OK) on current main: private names (`#field`/`#method`/`static #s`/`#x in o`/private get-set/brand-check TypeError), field-init order, computed names, static blocks, `super` static, and accessor descriptors via `getOwnPropertyDescriptor(C.prototype)`. The descriptor builtins on typed receivers (`defineProperty`/`defineProperties`/`getOwnPropertyDescriptor`/`create`/`freeze`/`keys`) show **GAP ≈ 0**.

Measured class gap **~4.3%** (500-file stratified sample), concentrated in three clean buckets.

### Slices (substrate-independent, NOT #2175/#2580-gated)
- **#2610** — `Symbol.<wellKnown>` read as a VALUE refuses instead of folding to its i32 sentinel. ~3-line fix in `hasNativeBuiltinConstantHandler` (`property-access.ts`). Est. **~150–250 rows**. feasibility: easy.
- **#2611** — `__extern_length` #2043 late-import index-shift orphan in async-generator/generator class-method destructuring-param defaults. Native-runtime-body shift bookkeeping in `object-runtime.ts`. Est. **~60–90 rows**. feasibility: medium.

### Deferred (noted, not sliced)
- **→ #2175** — `__get_builtin` on builtin objects / `<Builtin>.prototype`-as-object / descriptor-on-a-builtin-ctor (`getOwnPropertyDescriptor(Date,"UTC")`).
- **→ #2580** — `.length`/descriptor reflection on `any`/dynamically-mutated receivers (opaque externref, no static brand).

Docs-only: three issue spec files, no source/test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA