### PR TITLE
docs(#1355): re-measure Proxy lane + slice host-mode bugs (#2615-#2618)

### DIFF
--- a/plan/issues/1355-spec-backlog-proxy-pure-wasm.md
+++ b/plan/issues/1355-spec-backlog-proxy-pure-wasm.md
@@ -19,6 +19,94 @@ note: "2026-06-15: elevated to TOP priority by stakeholder (Proxy/Promise/async-
 ---
 # #1355 — Proxy: pure-Wasm implementation
 
+## RE-MEASURE + VERDICT (architect, 2026-06-22, against main d970e19a)
+
+Re-grounded the whole Proxy lane in BOTH modes. The original "235 standalone
+fails / 21.5 %" framing is stale. Current authoritative gc baseline + a probed
+standalone run:
+
+| Category | host (gc) | standalone |
+|----------|-----------|------------|
+| `built-ins/Proxy`   | **115/311 = 37.0 %** | ~35/311 ≈ 11 % (revocable + standalone Reflect.* CEs dominate) |
+| `built-ins/Reflect` | **122/153 = 79.7 %** | ~39/153 ≈ 25 % |
+
+(Proxy/Reflect gc numbers verified against the committed
+`loopdive/js2wasm-baselines` JSONL; my in-process harness matched exactly:
+115/122.)
+
+**Verdict: the tractable lane this sprint is HOST mode, not standalone.** Host
+Proxy sits at 37 % and the failures cluster into a handful of *bounded,
+root-caused* bugs — NOT 235 scattered fails. The biggest is a single codegen
+bug (`new Proxy` result statically typed as its target's struct → every READ
+through the proxy traps), which is the concrete form of the
+`project_proxy_no_ts_type_brand` memory. Standalone pure-Wasm invariant
+enforcement remains a genuine multi-slice epic and stays deferred (see below).
+
+### Host-mode failure buckets (after subtracting deferred)
+
+Deferred / not Proxy bugs: **~48** — `*-realm.js` (need `$262.createRealm`,
+~38) + `*-using-with.js` / `call-with.js` (`with` is on the skip list, ~10).
+Subtracting those, the real, tractable host bugs are:
+
+| Bucket | ~count | Slice |
+|--------|--------|-------|
+| READ through a host proxy traps (`new Proxy` result typed as target struct → `struct.get` on a failed `ref.test` → null trap) | 32+ (folds in much of "OTHER") | **#2615** |
+| Present-but-non-callable trap silently dropped instead of TypeError | 19 | **#2616** |
+| Trap-thrown exceptions + §10.5 invariant TypeErrors swallowed by the boundary `try/catch` | ~40 | **#2617** |
+| apply/construct call path on a host Proxy (illegal cast; construct result ignored) | ~15 | **#2618** |
+
+These overlap (a `get/return-is-abrupt` test needs both #2615 and #2617), so the
+net pass-rate gain is less than the sum, but #2615 alone should move host Proxy
+well off 37 % and unblock acceptance criterion #1
+(`get/return-trap-result.js`). Realistic target after #2615–#2618: host
+`built-ins/Proxy` ≈ 60–70 % (the ≥75 % criterion is plausibly reachable but the
+`-realm` deferrals cap the ceiling at ~85 % until `$262.createRealm` exists).
+
+### Standalone — DEFERRED EPIC (with the staged plan below)
+
+Standalone Proxy at ~11 % is dominated by two infrastructure gaps, NOT trap
+logic:
+1. **`Proxy.revocable` / revoke synthesis is unimplemented standalone** —
+   `Proxy not supported in standalone` / `Proxy.revocable built-in` CEs across
+   the entire `revocable/**` directory (~14 CEs). This was explicitly deferred
+   in #1100 Phase 1.
+2. **Several standalone `Reflect.*` methods aren't wired** — `Reflect.setPrototypeOf`
+   (10 CE), `Reflect.defineProperty` (8), `Reflect.construct` (6),
+   `Reflect.getPrototypeOf` (6), `Reflect.apply`/`isExtensible`/`preventExtensions`
+   each ~5 — these CE before any Proxy trap can run. The standalone `Reflect.*`
+   path bypasses the Proxy dispatch (architect note below already flagged this).
+3. Pure-Wasm §10.5 invariant enforcement (the "Implementation Plan" sections
+   below) needs a standalone descriptor-attribute model (#797/#1460/#1462) and
+   touches ~13 internal-method dispatchers — genuinely multi-slice.
+
+**Staged standalone approach (predecessor-ordered):**
+- **Stage S0 (predecessor, separate issue when scheduled):** standalone
+  `Proxy.revocable` + revoke-closure synthesis (finish #1100's deferred piece).
+  Until this lands every `revocable/**` standalone test CEs.
+- **Stage S1:** wire the missing standalone `Reflect.*` methods
+  (setPrototypeOf/defineProperty/construct/getPrototypeOf/apply/isExtensible/
+  preventExtensions) so they route through the existing `$Proxy` dispatch
+  front-guards instead of CE-ing. This is the biggest standalone CE bucket and
+  is mechanical once the dispatch helpers (already present, Slices A–D) are
+  reused.
+- **Stage S2:** §10.5 invariant enforcement on the standalone dispatchers
+  (needs the descriptor-attribute bits — coordinate #797/#1460/#1462).
+- **Stage S3:** standalone `construct`/`apply` trap dispatch (the last two
+  traps; needs the standalone dynamic-new path).
+
+No standalone slices are manufactured for this sprint — S0/S1 are the next
+worthwhile ones and should be filed once a senior-dev/value-rep slot opens. The
+detailed pre-existing "Implementation Plan" + per-slice (A–D) sections below
+remain the authoritative standalone design for S1–S3.
+
+### Sub-issues filed (sprint 65, host-mode, parent #1355)
+- **#2615** — `new Proxy` result must be storage-typed externref, not the
+  target struct (read-through-proxy trap). *Highest value; land first.*
+- **#2616** — present non-callable trap → TypeError (host bridge).
+- **#2617** — propagate trap-thrown exceptions + §10.5 invariant TypeErrors
+  through the boundary helpers.
+- **#2618** — apply/construct call path on a host Proxy (depends on #2615).
+
 ## Problem
 
 `built-ins/Proxy`: **67 / 311 pass (21.5%) — 235 fails (146 assertion_fail, 53 type_error,

--- a/plan/issues/2615-proxy-host-result-type-externref-read-trap.md
+++ b/plan/issues/2615-proxy-host-result-type-externref-read-trap.md
@@ -1,0 +1,142 @@
+---
+id: 2615
+title: "Proxy (host): a `new Proxy` result typed as its target's struct causes every read through the proxy to trap (~32+ fails)"
+status: ready
+sprint: 65
+created: 2026-06-22
+updated: 2026-06-22
+priority: top
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: proxy
+goal: spec-completeness
+parent: 1355
+related: [2180]
+test262_bucket: proxy-get-read-through-host-proxy
+---
+# #2615 — Proxy (host): `new Proxy` result must be storage-typed `externref`/`any`, not the target's struct type
+
+Slice of #1355. **Host (gc) mode only.** This is the single highest-leverage
+host-mode Proxy bug: it makes *every* property READ through a host Proxy trap at
+runtime, which is why the `built-ins/Proxy/get/**` directory and many
+`*-target-is-proxy` / read-through tests fail. Fixing it unblocks acceptance
+criterion #1 of #1355 (`built-ins/Proxy/get/return-trap-result.js`).
+
+## Re-measured evidence (arch, 2026-06-22, against main d970e19a)
+
+Authoritative gc baseline: `built-ins/Proxy` = **115/311 (37.0 %)**. Isolated
+repro — *all three throw with an empty (`undefined`) message, i.e. a Wasm trap,
+even with NO trap defined*:
+
+```ts
+function test() { const t = { attr: 1 }; const p = new Proxy(t, {}); return p.attr; } // THROWS
+function test() { const t = { attr: 1 }; const p = new Proxy(t, { get: () => 2 }); return p.attr; } // THROWS
+function test() { const t = { attr: 1 }; const p = new Proxy(t, {}); return ("attr" in p); } // OK (returns 1)
+```
+
+`has` works; `get` is fundamentally broken for host proxies.
+
+## Root cause
+
+`new Proxy(target, handler)` codegen (`src/codegen/expressions/new-super.ts`
+~line 2834, host arm) correctly returns `{ kind: "externref" }` and emits
+`call __proxy_create -> externref`. **But the local slot for the variable that
+receives it is typed from the TypeScript checker**, and TS types
+`new Proxy<T>(t, h)` as `T` (the *target's* type) — `ProxyConstructor` returns
+its target type. So `const p = new Proxy(t, {})` declares `p` as the
+object-literal struct type `(ref null 8)`, and the externref result is coerced
+into that struct slot with `any.convert_extern` + `ref.test (ref 8)`. The host
+Proxy externref is **not** a `$Object` struct, so `ref.test` fails → the value
+becomes `ref.null 8` → the subsequent `p.attr` lowers to a **direct
+`struct.get 8 0` on a null/struct local**, which `ref.is_null`-traps.
+
+Observed WAT for `const p = new Proxy(t, {}); return p.attr;`:
+
+```wat
+(local $p (ref null 8))        ;; <-- WRONG: struct-typed, should be externref/any
+...
+call 0                          ;; __proxy_create -> externref
+any.convert_extern
+ref.test (ref 8)               ;; fails for a host Proxy
+(if ... (else ref.null 8))     ;; p := null
+local.tee 1
+ref.is_null
+(if (then global.get 2 throw 0) ;; <-- TypeError trap (empty message)
+    (else struct.get 8 0))      ;; direct field read (never routed via __extern_get)
+```
+
+This is the `project_proxy_no_ts_type_brand` memory in concrete form: **a Proxy
+carries no TS-type brand**, so a local statically classified as the target's
+struct type emits direct (`struct.get`) reads that bypass the `__extern_get`
+boundary helper — the only path that runs the host-Proxy MOP (and the trap).
+
+## Implementation Plan
+
+### Goal
+Any value produced by `new Proxy(...)` must be stored/typed so that reads/writes
+route through the dynamic boundary helpers (`__extern_get` / `__extern_set` /
+`__extern_has` / `__extern_method_call`), NOT through a static `struct.get` /
+`struct.set` on the target's WasmGC struct type. The boundary helpers already
+handle a host Proxy correctly (verified: `has` works because `"k" in p` lowers
+to `__extern_has`).
+
+### Approach — type the receiving slot as `externref`/`any`
+Do **not** trust the TS type for a `new Proxy` initializer. The compiler already
+has a notion of "dynamic/open" storage (the `externref` / open-`$Object` path
+used for `const h: any = {…}`). Route `new Proxy` results into it:
+
+**File: `src/codegen/expressions/new-super.ts`** — the host `new Proxy` arm
+already returns `{ kind: "externref" }`; that is correct. The fix is upstream,
+at the **binding/assignment** site that picks the local's storage type.
+
+**File(s): the variable-declaration / local-slot type resolver** (the code that
+maps a `const`/`let` initializer's declared TS type to a Wasm local ValType —
+grep for where `resolveWasmType` / the TS type of a `VariableDeclaration` chooses
+the local type; likely `src/codegen/statements.ts` declaration handling and/or
+`src/codegen/index.ts` local allocation). Add: **if the initializer expression is
+a `new Proxy(...)` call, force the local's storage ValType to `externref`
+(host) / open `$Object` so member reads/writes lower through the boundary
+helpers.** Mirror the existing `const x: any = …` open-object routing
+(`project_2542_index_signature_open_object_routing` describes the open-`$Object`
+routing machinery — reuse it; do not invent a new path).
+
+### Member-read lowering must honor it
+**File: `src/codegen/property-access.ts`** — confirm that when the receiver's
+storage type is `externref`/`any`, `compilePropertyAccess` already emits
+`__extern_get` (it does for `any`-typed receivers). The fix above is sufficient
+*if* the slot type flips to `externref`; verify no residual static
+`ref.test $Object`-then-`struct.get` fast path fires for an externref-typed
+receiver that happens to alias a struct.
+
+### Edge cases
+- `p` reassigned / passed to a function typed as `T` (the target type): the
+  externref must still survive — coercing an externref Proxy *into* a `(ref 8)`
+  parameter will re-trigger this trap. Where a Proxy externref is passed to a
+  struct-typed param, it must stay externref (the callee should also read via
+  boundary helpers). Scope this slice to the **direct `const p = new Proxy` +
+  read** case (covers the bulk); note cross-function flow as follow-up if any
+  gated test still fails.
+- `delete p.x`, `p.x = v`, `"x" in p`, `for (k in p)` — all must route through
+  the boundary helpers once the slot is externref. `has` already works; verify
+  set/delete now do too.
+- Do NOT regress the fast (non-Proxy) path: a `const o = { a: 1 }` literal MUST
+  keep its closed struct + `struct.get` fast read. Only the `new Proxy`
+  initializer flips the slot type.
+
+### Test-gate (test262, gc mode)
+- `built-ins/Proxy/get/return-trap-result.js` (acceptance #1 of #1355)
+- `built-ins/Proxy/get/return-trap-result-accessor-property.js`
+- `built-ins/Proxy/get/trap-is-undefined.js`,
+  `get/trap-is-undefined-no-property.js`, `get/trap-is-undefined-receiver.js`
+- `built-ins/Proxy/function-prototype.js`
+- the `deleteProperty/trap-is-undefined-*` and `*-target-is-proxy` read-through
+  cases that currently throw an empty-message trap
+- `tests/issue-2615.test.ts` — add a direct equivalence test (`new Proxy(t,{}).attr`,
+  `new Proxy(t,{get}).x`, set/delete through a proxy).
+
+### Risk
+Touches local-slot type resolution — a hot path. Validate the full gc
+equivalence suite; broad-impact (value-rep / read-path), so prefer merge_group /
+local-ci over a scoped sweep (`project_broad_impact_validate_full_ci`).

--- a/plan/issues/2616-proxy-host-non-callable-trap-validation.md
+++ b/plan/issues/2616-proxy-host-non-callable-trap-validation.md
@@ -1,0 +1,114 @@
+---
+id: 2616
+title: "Proxy (host): present-but-non-callable trap is silently dropped instead of throwing TypeError (~19 fails)"
+status: ready
+sprint: 65
+created: 2026-06-22
+updated: 2026-06-22
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: runtime
+language_feature: proxy
+goal: spec-completeness
+parent: 1355
+related: [2180]
+test262_bucket: proxy-trap-not-callable
+---
+# #2616 — Proxy (host): a present non-callable / non-undefined trap must throw TypeError, not be omitted
+
+Slice of #1355. **Host (gc) mode only.** Per §10.5 each internal method does
+`trap = GetMethod(handler, "<trapName>")`, and `GetMethod` (§7.3.10) throws a
+**TypeError** when the property is present but not callable (it only returns
+`undefined` when the value is `undefined`/`null`). Our host bridge instead
+*silently omits* a present-non-callable trap, so the host Proxy falls through to
+the target and the user's `assert.throws(TypeError, …)` never fires.
+
+## Re-measured evidence (arch, 2026-06-22)
+
+19 host fails of the shape `new Proxy(t, { <trap>: <non-callable> })` then an
+operation expecting a TypeError. Examples (all `fail`, returned a value instead
+of throwing):
+`get/trap-is-not-callable.js`, `get/null-handler.js`,
+`apply/trap-is-not-callable.js`, `defineProperty/trap-is-not-callable.js`,
+`deleteProperty/trap-is-not-callable.js`,
+`getOwnPropertyDescriptor/trap-is-not-callable.js`,
+`getPrototypeOf/trap-is-not-callable.js`, `getPrototypeOf/null-handler.js`,
+`has/trap-is-not-callable.js`, `ownKeys/trap-is-not-callable.js`,
+`set/trap-is-not-callable.js`, `setPrototypeOf/trap-is-not-callable.js`,
+`preventExtensions/trap-is-not-callable.js`, `isExtensible/trap-is-not-callable.js`,
+`construct/trap-is-not-callable.js` (and the `null-handler` siblings).
+
+Representative test (`get/trap-is-not-callable.js`):
+```js
+var p = new Proxy({}, { get: {} });
+assert.throws(TypeError, function() { p.attr; });
+```
+
+## Root cause
+
+`_buildProxyBridgeHandler` (`src/runtime.ts` ~line 5070) builds the host bridge
+handler by reading each trap off the user handler struct:
+
+```ts
+const rawTrap = _structFieldRaw(handler, name, exports);
+if (rawTrap == null) continue;                       // undefined/null → omit (CORRECT: §7.3.10 returns undefined)
+const callable = _maybeWrapCallableUnknownArity(rawTrap, callbackState);
+if (typeof callable !== "function") continue;        // <-- BUG: present-but-non-callable is silently omitted
+```
+
+A present non-callable trap (`{}`, `1`, `"x"`, …) hits the second `continue`,
+so the bridge has no `<trap>` method, the host engine uses its default
+(ordinary) behavior, and the spec-mandated TypeError never throws.
+
+Note the §7.3.10 *timing* nuance: GetMethod runs *inside each internal method*,
+so strictly the TypeError is thrown when the trapped operation is invoked, not at
+construction. For the test262 corpus, installing a bridge trap that **throws on
+invocation** reproduces the correct observable behavior (the throw happens when
+`p.attr` runs, which is exactly when the tests check it).
+
+## Implementation Plan
+
+### Change
+**File: `src/runtime.ts`**, `_buildProxyBridgeHandler` (~line 5070).
+Replace the silent-omit second `continue` with: install a bridge trap that
+**throws a TypeError when invoked**, for a present-but-non-callable trap value.
+
+```ts
+const rawTrap = _structFieldRaw(handler, name, exports);
+if (rawTrap == null) continue;                       // undefined/null → genuine absence, omit
+const callable = _maybeWrapCallableUnknownArity(rawTrap, callbackState);
+if (typeof callable !== "function") {
+  // §7.3.10 GetMethod: present but not IsCallable → TypeError when the
+  // owning internal method runs. Install a throwing bridge trap so the host
+  // engine surfaces the TypeError at operation time (matches test262 timing).
+  bridge[name] = () => {
+    throw new TypeError(`'${name}' on proxy: trap is not a function`);
+  };
+  continue;
+}
+```
+
+### Edge cases / correctness
+- Distinguish **absent** (`undefined`/`null` → `rawTrap == null` → omit, host
+  forwards to target — CORRECT) from **present-non-callable** (→ throwing bridge
+  trap). The existing `if (rawTrap == null) continue;` already separates these;
+  only the *second* branch changes.
+- A Wasm-closure trap that `_maybeWrapCallableUnknownArity` *does* wrap into a
+  function stays on the normal path — unchanged.
+- The TypeError must be the *host engine's* (so `e instanceof TypeError` holds in
+  the compiled program via the exception bridge). Throwing a plain `TypeError`
+  inside the bridge trap propagates through the host Proxy MOP and the
+  `lastCaughtException` bridge — same path other host-thrown TypeErrors take.
+- `construct` / `apply` traps: same fix applies (a non-callable `apply`/`construct`
+  must throw when `p(...)` / `new p(...)` runs).
+
+### Test-gate (test262, gc mode)
+All `built-ins/Proxy/*/trap-is-not-callable.js` and `*/null-handler.js`
+(non-`-realm`, non-`-with`) — ~19 tests. Plus `tests/issue-2616.test.ts`
+(`new Proxy(t,{get:{}})` access throws TypeError; absent trap still forwards).
+
+### Risk
+Low — localized to the host bridge builder. No codegen change. Validate gc
+equivalence + the Proxy directory.

--- a/plan/issues/2617-proxy-host-trap-throw-and-invariant-propagation.md
+++ b/plan/issues/2617-proxy-host-trap-throw-and-invariant-propagation.md
@@ -1,0 +1,145 @@
+---
+id: 2617
+title: "Proxy (host): trap-thrown exceptions and §10.5 invariant TypeErrors are swallowed by the boundary try/catch (~40 fails)"
+status: ready
+sprint: 65
+created: 2026-06-22
+updated: 2026-06-22
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: runtime
+language_feature: proxy
+goal: spec-completeness
+parent: 1355
+related: [2180]
+test262_bucket: proxy-trap-abrupt-invariant
+---
+# #2617 — Proxy (host): propagate trap-thrown exceptions and §10.5 invariant TypeErrors through the boundary helpers
+
+Slice of #1355. **Host (gc) mode only.** The boundary helpers
+(`__extern_get` / `__extern_set` / `__extern_has` / `__delete_property` /
+`__getPrototypeOf` / `__getOwnPropertyDescriptor` / …) wrap their host reads in
+a `try/catch` that swallows *all* exceptions except the revoked-proxy one,
+falling through to a struct/undefined path. When the host value is a **user
+Proxy**, the swallowed exception is exactly what the test wants to observe: a
+trap's abrupt completion, or the host engine's §10.5 invariant TypeError. This
+is the largest remaining host-mode bucket after the get-read fix (#2615) and the
+non-callable fix (#2616).
+
+## Re-measured evidence (arch, 2026-06-22)
+
+Isolated repros (host gc):
+```ts
+// trap throws → must propagate; currently returns false (0):
+const p = new Proxy({}, { has: () => { throw new RangeError("x"); } }); ("a" in p); // RETURNS 0 (BUG: should throw RangeError)
+// §10.5.1 invariant: getPrototypeOf trap returning a non-object/non-null → TypeError; currently returns null:
+const p = new Proxy({}, { getPrototypeOf: () => 1 }); Object.getPrototypeOf(p); // RETURNS null (BUG: should throw TypeError)
+// (trap IS invoked — side effects observed — so the issue is purely result/throw propagation)
+```
+
+Affected test262 buckets (gc):
+- **`*/return-is-abrupt*.js`** across get/set/has/deleteProperty/defineProperty/
+  getOwnPropertyDescriptor/getPrototypeOf/setPrototypeOf/ownKeys/isExtensible/
+  preventExtensions/apply/construct — trap throws, must propagate (~15).
+- **`assert.throws(TypeError, …)` §10.5 invariant tests** — e.g.
+  `getPrototypeOf/not-extensible-not-same-proto-throws.js`,
+  `getPrototypeOf/trap-result-neither-object-nor-null-throws-*.js`,
+  `getOwnPropertyDescriptor/resultdesc-is-not-configurable-not-writable-targetdesc-is-writable.js`,
+  `setPrototypeOf/*`, `defineProperty/*-throws.js` (~25).
+
+## Root cause
+
+Each boundary helper looks like (`__extern_get`, `src/runtime.ts` ~6883;
+`__extern_has` ~7132; `__delete_property`, `__getPrototypeOf`,
+`__getOwnPropertyDescriptor` similarly):
+
+```ts
+try {
+  if (Object.getPrototypeOf(obj) !== null && key in Object(obj)) return obj[key];
+} catch (e) {
+  if (_isRevokedProxyError(e)) throw e;   // <-- ONLY revoked-proxy re-thrown
+  /* otherwise fall through to the generic struct path */   // <-- swallows trap throws + invariant TypeErrors
+}
+```
+
+For a **user Proxy** (tracked in `_userProxies`), any exception from the host
+MOP operation is either (a) the user trap's own abrupt completion or (b) the
+host engine's §10.5 invariant TypeError — both spec-observable. The catch
+swallows them and returns a struct/undefined fallthrough, so the user program
+sees a wrong value instead of the throw.
+
+Separately, the §10.5.1 *invariant for getPrototypeOf returning a non-object*
+returns `null` rather than throwing because the boundary's `__getPrototypeOf`
+helper does not let the host engine run the invariant (it reads via a path that
+coerces the bad result to null). See the getProto repro above.
+
+## Implementation Plan
+
+### Core change — re-throw exceptions originating from a user Proxy
+**File: `src/runtime.ts`** — in each boundary helper's `catch (e)`, broaden the
+re-throw: if `obj` (or the receiver) is a tracked **user Proxy**
+(`_userProxies.has(obj)` — already used by #2180), re-throw `e` instead of
+falling through. Keep the existing `_isRevokedProxyError(e)` re-throw for the
+non-user-Proxy path (revoked proxies obtained from elsewhere).
+
+```ts
+} catch (e) {
+  if (_isRevokedProxyError(e) || _userProxies.has(obj)) throw e;
+  /* fall through only for genuine WasmGC struct reads */
+}
+```
+
+Apply to every helper that performs a host MOP read on a value that may be a
+user Proxy: `__extern_get`, `__extern_set` (+ `__extern_set_strict`),
+`__extern_has`, `__delete_property`, `__getPrototypeOf`,
+`__object_setPrototypeOf`, `__getOwnPropertyDescriptor`, `__object_isExtensible`,
+`__object_preventExtensions`, `__object_defineProperty`, `__extern_method_call`
+(the apply/ownKeys read paths), and the `ownKeys`/key-enumeration helper used by
+`Object.keys`/`for-in`/spread. Add a single shared predicate
+`_isUserProxy(obj)` and a `_rethrowIfProxyOrRevoked(e, obj)` helper to keep the
+13 sites consistent (single source of truth, matching the architect's "shared
+predicate module" note in #1355).
+
+### §10.5 invariant surfacing
+For the helpers that today *coerce* a bad trap result to a safe default instead
+of letting the host engine throw (the getPrototypeOf `→ null` repro), make the
+host MOP operation the **last** thing in the `try` so the host engine's own
+invariant check runs and throws, and let the broadened catch re-throw it. Do
+**not** re-implement §10.5 invariants in the runtime for host mode — the host
+engine already enforces them; the bug is purely that we were intercepting before
+the engine could throw. (Standalone invariant enforcement is a *separate*,
+deferred concern under #1355 — see parent.)
+
+### Edge cases
+- A genuine WasmGC-struct read that legitimately throws (e.g. a getter that
+  throws) on a **non-proxy** struct must still fall through to the struct path
+  only when appropriate — gate the broadened re-throw strictly on
+  `_isUserProxy(obj)`, so non-proxy behavior is unchanged.
+- `__extern_set_strict` (ESM strict writes): a Proxy `set` trap returning falsy
+  must throw TypeError in strict context — ensure the broadened re-throw covers
+  the strict helper too.
+- The thrown value must reach the compiled `try/catch` via the existing
+  `lastCaughtException` exception bridge (same path revoked-proxy errors take) so
+  `e instanceof TypeError`/`RangeError` holds in the user program.
+
+### Test-gate (test262, gc mode)
+- All `built-ins/Proxy/*/return-is-abrupt*.js`
+- `getPrototypeOf/trap-result-neither-object-nor-null-throws-boolean.js`,
+  `getPrototypeOf/not-extensible-not-same-proto-throws.js`,
+  `getPrototypeOf/instanceof-target-not-extensible-not-same-proto-throws.js`
+- `getOwnPropertyDescriptor/resultdesc-is-not-configurable-not-writable-targetdesc-is-writable.js`
+- a representative `setPrototypeOf/*` and `defineProperty/*-throws.js`
+- `tests/issue-2617.test.ts` — trap-throws-propagates + getProto-non-object-throws.
+
+### Sequencing
+Best landed **after #2615** (the get-read fix), because several abrupt/invariant
+tests first read through the proxy (which #2615 unblocks) before reaching the
+throw. Not a hard dependency, but the gate set overlaps; coordinate so the two
+PRs don't fight over the same Proxy test files.
+
+### Risk
+Medium — the boundary `catch` is a hot path; the `_isUserProxy` gate keeps the
+non-proxy fast path identical. Validate full gc equivalence (broad-impact:
+boundary helpers).

--- a/plan/issues/2618-proxy-host-apply-construct-call-path.md
+++ b/plan/issues/2618-proxy-host-apply-construct-call-path.md
@@ -1,0 +1,120 @@
+---
+id: 2618
+title: "Proxy (host): calling / constructing a Proxy whose target is callable traps (illegal cast) or ignores the construct trap result (~15 fails)"
+status: ready
+sprint: 65
+created: 2026-06-22
+updated: 2026-06-22
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: proxy
+goal: spec-completeness
+parent: 1355
+related: [2180, 2615]
+test262_bucket: proxy-apply-construct
+---
+# #2618 — Proxy (host): the apply/construct call path on a host Proxy
+
+Slice of #1355. **Host (gc) mode only.** A host Proxy whose target is callable
+is itself callable / constructable. Today `p(...)` traps with an illegal cast,
+and `new p(...)` ignores the `construct` trap's return value.
+
+## Re-measured evidence (arch, 2026-06-22)
+
+```ts
+// apply: callee is a host Proxy of a function → illegal cast trap
+const fn = function () { return 1; };
+const p = new Proxy(fn, { apply: () => 42 });
+p();                       // THROWS (empty msg); test262: "illegal cast in __call_fn_method_3"
+
+// construct: trap result ignored
+class C {}
+const p = new Proxy(C, { construct: () => ({ x: 9 }) });
+const o = new p();  o.x;   // RETURNS 0 (BUG: construct trap returned {x:9}, o.x should be 9)
+```
+
+Affected test262 (gc): `built-ins/Proxy/apply/call-parameters.js`,
+`apply/call-result.js`, `apply/trap-is-null.js`,
+`apply/trap-is-undefined*.js`, `construct/call-parameters*.js`,
+`construct/call-result.js`, `construct/trap-is-*` (~15, excluding the `-realm`
+variants which need `$262.createRealm` — deferred).
+
+## Root cause
+
+1. **apply** — the compiled call site for `p(args)` statically classifies the
+   callee `p` by its TS type (the target function type), so it lowers to the
+   closure/method-call fast path (`__call_fn_method_N`) which `ref.cast`s the
+   callee to a `$Closure` struct. A host-Proxy externref is not a `$Closure`,
+   so the `ref.cast` traps ("illegal cast"). Same `project_proxy_no_ts_type_brand`
+   pattern as #2615, but on the *call* path instead of the *read* path: the
+   callee must be invoked through the dynamic call boundary
+   (`__call_extern` / `__apply` / `__extern_method_call`) so the host runs the
+   Proxy `apply` MOP — not via a static `ref.cast $Closure` + `call_ref`.
+
+2. **construct** — `new p(...)` where `p` is a host Proxy: the `construct` trap
+   fires (or forwards), but the returned object is dropped; `o` ends up as a
+   default-constructed value (`o.x === 0`). The dynamic `new`-on-externref path
+   must take the host MOP `[[Construct]]` result as the new object.
+
+## Implementation Plan
+
+### apply path
+**File: `src/codegen/expressions/calls.ts`** (or wherever `CallExpression` chooses
+between the closure fast path and the dynamic `__call_extern`/`__apply` boundary).
+When the callee value's *storage* type is `externref`/`any` — which #2615 makes
+true for a `new Proxy` local — the call must lower to the dynamic boundary, NOT
+the `ref.cast $Closure` fast path. Confirm the dynamic boundary
+(`__call_extern` / `__apply_closure` / `__extern_method_call`) already routes an
+externref callee through the host (it does for `any`-typed callees); then this
+slice is mostly "make the callee externref-typed and select the dynamic path",
+which **depends on / composes with #2615's slot-type fix**. Add a guard: a
+callee produced by `new Proxy` (or any externref-storage callee) skips the
+`__call_fn_method_N` cast path.
+
+### construct path
+**File: `src/codegen/expressions/new-super.ts`** — the `new <expr>(...)` lowering
+where `<expr>` is not a statically-known class. When the constructor value is an
+externref Proxy, route through the host `[[Construct]]` boundary
+(`__construct_extern` / equivalent) and **use its return value** as the result
+object (§10.5.13 / §9.3.2: if the trap returns an object, that is the result).
+Grep for the existing dynamic-`new` boundary helper; if none exists for
+externref constructors, add `__proxy_construct(target, argArray, newTarget)` that
+calls the host `Reflect.construct(proxy, args, newTarget)` (the host runs the
+construct trap + §10.5.13 invariant). The runtime side mirrors #2180's
+`_hostProxyConstruct` machinery.
+
+### Edge cases
+- `apply` trap absent → forward to target's `[[Call]]` (the proxied function
+  runs) — the dynamic boundary already does this.
+- `construct` trap absent → forward to target's `[[Construct]]`.
+- `construct` trap returning a non-object → §10.5.13 TypeError (host enforces;
+  re-throw via the #2617 boundary-propagation fix — note the cross-slice link).
+- A Proxy of a non-callable target called as `p()` → TypeError "not a function"
+  (host enforces).
+- `new.target` / `newTarget` threading: pass the correct newTarget to
+  `Reflect.construct` so `construct/call-parameters-new-target.js` passes.
+
+### Dependencies / sequencing
+- **Depends on #2615** (the externref slot-type fix) for callee/constructor
+  classification — without it the callee local is struct-typed and the dynamic
+  path is never selected. Land #2615 first; this slice then narrows to "select
+  the dynamic call/construct path for externref callees + thread the construct
+  result".
+- Composes with #2617 for the construct-non-object / apply-not-callable TypeError
+  propagation.
+
+### Test-gate (test262, gc mode)
+- `built-ins/Proxy/apply/call-parameters.js`, `apply/call-result.js`,
+  `apply/trap-is-null.js`, `apply/trap-is-undefined.js`
+- `built-ins/Proxy/construct/call-parameters.js`, `construct/call-result.js`,
+  `construct/call-parameters-new-target.js`, `construct/trap-is-undefined.js`
+- `tests/issue-2618.test.ts` — apply trap returns value; construct trap returns
+  object used as result; absent traps forward.
+
+### Risk
+Hard — touches the call/construct dispatch selection (hot path). Gate the dynamic
+routing strictly on externref-storage callees so non-proxy calls keep the
+fast path. Validate full gc equivalence (broad-impact: call path).


### PR DESCRIPTION
## Architect re-measurement + slicing of the Proxy lane (#1355)

Re-grounded the Proxy/Reflect gap in BOTH host (gc) and `target:standalone`
modes against main `d970e19a`. The original "235 standalone fails / 21.5%"
framing is stale.

### Re-measured (authoritative gc baseline-verified)
| Category | host (gc) | standalone |
|----------|-----------|------------|
| `built-ins/Proxy`   | **115/311 = 37.0%** | ~35/311 ≈ 11% |
| `built-ins/Reflect` | **122/153 = 79.7%** | ~39/153 ≈ 25% |

### Verdict
The tractable lane this sprint is **host mode**. Host Proxy failures cluster into
a few root-caused bugs (not 235 scattered fails); ~48 of the host fails are
deferred (`-realm` needs `$262.createRealm`; `using-with` needs `with`).

### Sub-issues filed (sprint 65, parent #1355)
- **#2615** — `new Proxy` result statically typed as its target's struct → every
  READ through the proxy traps (`struct.get` on a failed `ref.test` → null trap).
  Concrete form of the `project_proxy_no_ts_type_brand` memory. **Highest value;
  unblocks #1355 acceptance #1** (`get/return-trap-result.js`). ~32+ rows.
- **#2616** — present non-callable trap silently dropped instead of TypeError
  (host bridge `_buildProxyBridgeHandler`). ~19 rows.
- **#2617** — trap-thrown exceptions + §10.5 invariant TypeErrors swallowed by
  the boundary `try/catch`; re-throw when the receiver is a tracked user Proxy.
  ~40 rows (overlaps #2615).
- **#2618** — apply/construct call path on a host Proxy (illegal cast; construct
  result ignored). Depends on #2615. ~15 rows.

### Standalone — deferred epic (refined in #1355)
Standalone ~11% is dominated by missing `Proxy.revocable` synthesis (#1100
deferred) and unwired standalone `Reflect.*` methods — both CE before any trap
runs. #1355 now carries a staged S0–S3 plan + predecessor blockers. No standalone
slices manufactured.

Docs-only: issue files. No compiler source changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA