### PR TITLE
fix(#2612): detect async fn-expr bound via var/expr as a thenable call

### DIFF
--- a/plan/issues/2612-async-call-detection-thenable-consumer-via-variable.md
+++ b/plan/issues/2612-async-call-detection-thenable-consumer-via-variable.md
@@ -1,0 +1,78 @@
+---
+id: 2612
+title: "async fn consumed as thenable via variable/expression binding not wrapped in Promise (~18 fails)"
+status: done
+created: 2026-06-22
+updated: 2026-06-22
+completed: 2026-06-22
+priority: high
+feasibility: medium
+task_type: bug
+area: async, codegen
+language_feature: async
+goal: async-model
+sprint: 65
+parent: 1042
+assignee: ttraenkler/async-2612-2613
+note: "Re-measured 2026-06-22 (arch, ASYNC lane). Bounded detection bug, NOT the CPS epic."
+---
+# #2612 — async fn assigned to a variable/expression, consumed via `.then`, isn't Promise-wrapped
+
+## Problem
+
+The async-call-site Promise wrap (`wrapAsyncReturn`) only fires when the call is
+recognised as async by `isAsyncCallExpression` (`src/codegen/expressions.ts`).
+For an async function **expression** bound to a variable in the two-step
+declare-then-assign shape —
+
+```js
+var ref;
+ref = async function ref(x, y = x) { /* ... */ };
+ref(3).then(() => { /* ... */ }).then($DONE, $DONE);
+```
+
+— the call `ref(3)` was not detected as async: `ctx.asyncFunctions` only holds
+async **declarations** / class methods / object-literal methods, and the TS
+signature / call-signature fallbacks miss `ref` because `var ref;` has no
+initializer type that surfaces `Promise<T>` (confirmed: `getCallSignatures()`
+and `getApparentType().getCallSignatures()` both return 0 for this shape).
+Result: `ref(3)` returns the raw unwrapped value; `.then` on it →
+`Cannot read properties of null (reading 'then')`.
+
+## Fix (landed)
+
+`src/codegen/expressions.ts`, `isAsyncCallExpression`:
+1. Added `getApparentType(calleeType)` call-signature `Promise<T>` check (in
+   addition to `getTypeAtLocation`).
+2. Added `symbolBindsAsyncFunction(ctx, sym)` — resolves the identifier callee's
+   symbol and returns `true` when a `VariableDeclaration`/`BindingElement`
+   initializer **or** a later `name = async function …` assignment to that same
+   symbol is an `async` function expression / async arrow (excludes async
+   generators via `asteriskToken`). This catches the `var ref; ref = async
+   function …` two-step exactly. Existing `Promise.`-receiver short-circuits
+   (lines 162-186) left untouched (no double-wrap of native `$Promise`).
+
+## Test Results (re-measured 2026-06-22, JS-host runner)
+
+**10 rows flip fail → pass** (the discrete detection-gap bucket):
+- `expressions/async-function/named-dflt-params-ref-prior.js`,
+  `nameless-dflt-params-ref-prior.js`
+- `expressions/async-function/named-dflt-params-arg-val-undefined.js`,
+  `nameless-dflt-params-arg-val-undefined.js`
+- `expressions/async-function/forbidden-ext/b2/async-func-expr-{named,nameless}-forbidden-ext-indirect-access-{prop-caller,own-prop-caller-get,own-prop-caller-value}.js` (6 files)
+
+**Out of scope (separate bugs, still fail after this fix):**
+- `*-params-trailing-comma-*` (4) — fail on a function-`.length` reflection bug
+  (`ref.length` returns 0 for a trailing-comma anon fn-expr bound to a var), NOT
+  detection. Detection now works (the `.then` chain runs); the residual is the
+  `.length` own-property.
+- `*-dflt-params-arg-val-not-undefined` (2) — pass 6 distinct-typed args
+  (`false`/`''`/`NaN`/`0`/`null`/`obj`) through untyped async-fn-expr params;
+  value-representation issue, not detection.
+
+No regressions: 20 currently-passing async-function decl/expr tests + 47
+Promise/async-arrow tests stay green; tsc + prettier clean.
+
+## Validation
+- `tsc --noEmit` ✓, `prettier --check` ✓
+- Scoped `runTest262File` on the 10 flips + decl-path + Promise regression sweep

--- a/plan/issues/2613-await-thenable-assimilation-and-nonpromise.md
+++ b/plan/issues/2613-await-thenable-assimilation-and-nonpromise.md
@@ -1,0 +1,71 @@
+---
+id: 2613
+title: "await on a thenable/non-Promise: assimilate via host (PromiseResolve) instead of returning the raw object (~15 fails)"
+status: blocked
+created: 2026-06-22
+updated: 2026-06-22
+priority: high
+feasibility: hard
+task_type: bug
+area: async, codegen
+language_feature: async
+goal: async-model
+sprint: 65
+parent: 1042
+depends_on: 1373b
+assignee: ttraenkler/async-2612-2613
+note: "Premise invalidated 2026-06-22: the spec assumed ASYNC_CPS_ENABLED=false (legacy identity-passthrough await). On current main ASYNC_CPS_ENABLED=true — the CPS state machine now OWNS thenable-await lowering, so this is no longer a JS-host point-fix. Re-routed to #1373b."
+---
+# #2613 — `await <thenable>` / `await <non-Promise>` must assimilate, not pass the object through
+
+## Investigation result (2026-06-22, ASYNC lane) — BLOCKED on #1373b
+
+The original spec (written when `ASYNC_CPS_ENABLED = false`) planned a JS-host
+`__await_thenable` import on the **legacy identity-passthrough** await arm
+(`expressions.ts` `ts.isAwaitExpression`). That premise no longer holds:
+
+- **`ASYNC_CPS_ENABLED = true` on current main** (`src/codegen/async-cps.ts:60`).
+- For `const v = await <thenable>` (a user thenable / `any` operand), the await
+  operand is **not statically resolved** → `asyncFnNeedsCps` returns true →
+  `emitAsyncStateMachine` drives the body via `Promise_resolve` →
+  `Promise_then2` → continuation. The legacy `compileExpressionInner` await arm
+  is **never reached** (confirmed by instrumentation: the arm fires only for
+  await shapes `splitBodyAtAwait` rejects, e.g. `return (await x)` in some
+  positions).
+
+So a JS-host `__await_thenable` on the legacy arm is largely inert — CPS
+intercepts the thenable shapes first. A prototype of that import + the await-arm
+route was built and **reverted** (it produced 0 confirmed row flips and added a
+new host import + a touch on the hot await path for no gain).
+
+### True root cause of the residual failures — CPS synchronous-settlement gap
+
+The test262 harness runner calls the exported `test()` **synchronously** and
+reads `ret === 1` immediately (`tests/test262-runner.ts:3223`) with **no
+microtask drain and no `await`**. An `asyncTest(foo)` async body must therefore
+complete — including `await thenable` and the assertion after it — synchronously
+inside `foo()`. The CPS state machine, by design, defers its continuation to a
+later microtask (`Promise_then2`), so the post-await assertion's `__fail` update
+lands **after** `ret` is captured → the test reads a stale pass/fail. That is
+the `await-awaits-thenables` / `await-throws-rejections` / `*-non-promise-*`
+failure mechanism.
+
+Fixing it correctly requires either (a) the CPS lowering to settle a
+synchronously-resolvable awaited value **synchronously** (collapse the
+single-tick `Promise_then2` deferral when the operand settles in-tick), or
+(b) the runner to drain the host microtask queue before reading the result.
+Both are #1373b (IR async Phase C — CPS lowering for await/return/throw)
+territory, not a bounded JS-host dev point-fix. Routing there.
+
+## Failing tests (unchanged from baseline, all still `fail`/`compile_error`)
+`expressions/await/`: `await-awaits-thenables.js`,
+`await-awaits-thenables-that-throw.js`, `await-throws-rejections.js`,
+`await-non-promise-thenable.js`, `await-non-promise.js` (compile_error),
+`await-monkey-patched-promise.js`, `async-await-interleaved.js`,
+`for-await-of-interleaved.js`; `module-code/top-level-await/await-awaits-thenables*.js`;
+`built-ins/Array/fromAsync/*-thenable-awaits-once.js`. ≈ 15 rows.
+
+## Recommendation
+Fold the ~15 rows into #1373b's CPS-await Phase C (synchronous-settlement of an
+in-tick-resolvable awaited value). Do NOT re-attempt as a legacy-arm host
+point-fix while `ASYNC_CPS_ENABLED = true`.

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -219,6 +219,79 @@ function isAsyncCallExpression(ctx: CodegenContext, expr: ts.CallExpression): bo
     if (isPromiseType(callSig.getReturnType())) return true;
   }
 
+  // (#2612) Apparent-type call signatures unwrap the variable to its function
+  // type more reliably than `getTypeAtLocation` for some binding indirections.
+  const apparent = ctx.checker.getApparentType(calleeType);
+  for (const callSig of apparent.getCallSignatures()) {
+    if (isPromiseType(callSig.getReturnType())) return true;
+  }
+
+  // (#2612) An async function EXPRESSION bound to a `var`/`let` and consumed as
+  // a thenable (`ref(3).then(...)`) is never registered in `ctx.asyncFunctions`
+  // (that set only holds async declarations / class methods / object-literal
+  // methods). When the variable has no initializer type that surfaces
+  // `Promise<T>` (the `var ref; ref = async function …` two-step pattern), the
+  // signature/apparent-type fallbacks above all miss it. Resolve the callee's
+  // SYMBOL and inspect its bindings: if the variable's initializer — or the RHS
+  // of a later `ref = …` assignment to that same symbol — is an `async` function
+  // expression / async arrow, the call returns a Promise and must be wrapped.
+  if (ts.isIdentifier(expr.expression)) {
+    const sym = ctx.checker.getSymbolAtLocation(expr.expression);
+    if (sym && symbolBindsAsyncFunction(ctx, sym)) return true;
+  }
+
+  return false;
+}
+
+/** True when `node` is an `async function`/`async () =>` (not a generator). */
+function isAsyncFunctionExpr(node: ts.Node | undefined): node is ts.FunctionExpression | ts.ArrowFunction {
+  if (!node || !(ts.isFunctionExpression(node) || ts.isArrowFunction(node))) return false;
+  // Exclude async generators — they return AsyncGenerator, not a Promise.
+  if ((node as ts.FunctionExpression).asteriskToken) return false;
+  const mods = ts.canHaveModifiers(node) ? ts.getModifiers(node) : undefined;
+  return mods?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword) ?? false;
+}
+
+/**
+ * (#2612) Determine whether a callee symbol is bound to an async function
+ * expression — either as a variable initializer or via a later
+ * `name = async function …` assignment. Catches the two-step
+ * declare-then-assign pattern that `ctx.asyncFunctions` and the TS signature
+ * fallbacks all miss.
+ */
+function symbolBindsAsyncFunction(ctx: CodegenContext, sym: ts.Symbol): boolean {
+  const decls = sym.declarations ?? [];
+  for (const decl of decls) {
+    // `const ref = async function …` / `let ref = async () => …`
+    if (ts.isVariableDeclaration(decl) && isAsyncFunctionExpr(decl.initializer)) return true;
+    // `function ref()` async declaration would already be caught by the
+    // `ctx.asyncFunctions` / modifier check; binding-element / param defaults
+    // with an async initializer:
+    if (ts.isBindingElement(decl) && isAsyncFunctionExpr(decl.initializer)) return true;
+  }
+  // Scan for a later `name = async function …` assignment to this symbol's
+  // identifier in the same source file (the `var ref; ref = async function …`
+  // pattern, where the declaration carries no initializer).
+  for (const decl of decls) {
+    const sf = decl.getSourceFile();
+    let found = false;
+    const visit = (node: ts.Node): void => {
+      if (found) return;
+      if (
+        ts.isBinaryExpression(node) &&
+        node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        ts.isIdentifier(node.left) &&
+        isAsyncFunctionExpr(node.right) &&
+        ctx.checker.getSymbolAtLocation(node.left) === sym
+      ) {
+        found = true;
+        return;
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sf);
+    if (found) return true;
+  }
   return false;
 }
 
@@ -1222,6 +1295,20 @@ function compileExpressionInner(
       );
       return { kind: "externref" };
     }
+    // (#2613) `await <thenable>` / `await <non-Promise>` assimilation is now
+    // owned by the async-CPS state machine (`async-cps.ts`, gate
+    // `ASYNC_CPS_ENABLED = true`): a body whose await operand is not statically
+    // resolved (a user thenable / `any`) is a *real suspension* and is driven
+    // by `emitAsyncStateMachine` (`Promise_resolve` → `Promise_then2` →
+    // continuation), so it never reaches this legacy passthrough arm. The
+    // residual thenable-await test262 failures are therefore a CPS
+    // *synchronous-settlement* gap — the test262 harness calls `test()`
+    // synchronously and reads the result with no microtask drain, while the CPS
+    // continuation settles on a later microtask — which is #1373b's domain, not
+    // a JS-host point-fix. Keep the legacy identity passthrough here for the
+    // await shapes CPS does not claim (statically-resolved operands, bodies
+    // `splitBodyAtAwait` rejects); these are already the resolved value on the
+    // stack.
     return compileExpressionInner(ctx, fctx, expr.expression, expectedType);
   }
 

--- a/tests/issue-2612.test.ts
+++ b/tests/issue-2612.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.ts";
+
+// #2612 — an async function EXPRESSION bound to a `var`/`let` and consumed as a
+// thenable (`ref(3).then(...)`) must be Promise-wrapped. `isAsyncCallExpression`
+// missed the `var ref; ref = async function …` two-step shape because
+// `ctx.asyncFunctions` only holds async DECLARATIONS, and the TS signature /
+// call-signature fallbacks see no `Promise<T>` on the initializer-less `var`
+// binding. Fix: resolve the callee symbol and detect a `VariableDeclaration`
+// initializer OR a later `name = async function …` assignment whose RHS is an
+// async function expression / async arrow → treat the call as async so
+// `wrapAsyncReturn` produces a real Promise the `.then` consumer can chain off.
+
+async function runHost(src: string): Promise<unknown> {
+  const r = await compile(src, { fileName: "t.ts" });
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject);
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#2612 async fn-expr via var/expr binding wrapped in Promise", () => {
+  it("var ref; ref = async function ref(...) — ref(3) is a thenable", async () => {
+    const ret = await runHost(`
+      var callCount = 0;
+      var ref;
+      ref = async function ref(x, y = x) { callCount = callCount + 1; };
+      export function test(): number {
+        const p: any = ref(3);
+        return (p !== null && typeof p.then === "function") ? 1 : 0;
+      }
+    `);
+    expect(ret).toBe(1);
+  });
+
+  it("nameless async function expression bound to a var", async () => {
+    const ret = await runHost(`
+      var callCount = 0;
+      var ref;
+      ref = async function(a) { callCount = callCount + 1; };
+      export function test(): number {
+        const p: any = ref(42);
+        return (p !== null && typeof p.then === "function") ? 1 : 0;
+      }
+    `);
+    expect(ret).toBe(1);
+  });
+
+  it("async arrow bound via const initializer", async () => {
+    const ret = await runHost(`
+      const ref = async (x: number) => x;
+      export function test(): number {
+        const p: any = ref(7);
+        return (p !== null && typeof p.then === "function") ? 1 : 0;
+      }
+    `);
+    expect(ret).toBe(1);
+  });
+
+  it("a non-async function bound to a var is NOT treated as async (no spurious wrap)", async () => {
+    const ret = await runHost(`
+      var plain;
+      plain = function plain(x: number) { return x; };
+      export function test(): number {
+        // A sync fn returns its raw value; the result must NOT be a Promise.
+        const r: any = plain(5);
+        return (typeof r === "number" && r === 5) ? 1 : 0;
+      }
+    `);
+    expect(ret).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2612 — async fn-expr bound via var/expr, consumed as a thenable, isn't Promise-wrapped

`isAsyncCallExpression` missed an async function **expression** bound to a var/let in the two-step `var ref; ref = async function …` shape: `ctx.asyncFunctions` only holds async **declarations** (+ class/object-literal methods), and the TS signature / call-signature fallbacks see no `Promise<T>` on the initializer-less `var` binding (confirmed: `getCallSignatures()` and `getApparentType().getCallSignatures()` both return 0 for this shape). So `ref(3)` returned the raw value and `ref(3).then(...)` hit `Cannot read properties of null (reading 'then')`.

### Fix (`src/codegen/expressions.ts`, `isAsyncCallExpression`)
- Added `getApparentType` call-signature `Promise<T>` check.
- Added `symbolBindsAsyncFunction`: resolve the identifier callee's symbol; return `true` when a `VariableDeclaration`/`BindingElement` initializer **or** a later `name = async function …` assignment to that same symbol is an async function expression / async arrow (async generators excluded via `asteriskToken`). Existing `Promise.`-receiver short-circuits untouched (no double-wrap).

### Test Results (JS-host runner)
**10 rows flip fail → pass**: `expressions/async-function/{named,nameless}-dflt-params-ref-prior`, `{named,nameless}-dflt-params-arg-val-undefined`, and 6 `forbidden-ext/b2/async-func-expr-*-indirect-access-*` files.

Out of scope (separate bugs, still fail): `*-params-trailing-comma-*` (fn-`.length` reflection) and `*-arg-val-not-undefined` (value-rep of distinct-typed args through untyped params).

**No regressions**: 20 currently-passing async-function decl/expr + 47 Promise/async-arrow tests stay green; a no-spurious-wrap negative test (non-async fn bound to a var) included. `tsc --noEmit` ✓, `prettier --check` ✓.

### #2613 (await-thenable assimilation) — BLOCKED on #1373b
The #2613 spec assumed `ASYNC_CPS_ENABLED = false` (legacy identity passthrough). On current main it is **`true`** — the CPS state machine now **owns** thenable-await lowering, so a JS-host `__await_thenable` point-fix is inert (a prototype was built and reverted). The residual failures are a **CPS synchronous-settlement gap**: the test262 runner reads `test()` synchronously with no microtask drain while the CPS continuation settles a tick later. Re-routed to #1373b (issue file set `status: blocked`, documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA