### PR TITLE
fix(#2616): present non-callable Proxy trap must throw TypeError, not be dropped

### DIFF
--- a/plan/issues/2616-proxy-host-non-callable-trap-validation.md
+++ b/plan/issues/2616-proxy-host-non-callable-trap-validation.md
@@ -1,0 +1,82 @@
+---
+id: 2616
+title: "Proxy (host): present-but-non-callable trap is silently dropped instead of throwing TypeError (~19 fails)"
+status: done
+sprint: 65
+created: 2026-06-22
+updated: 2026-06-22
+completed: 2026-06-22
+assignee: ttraenkler/agent-acc861f0e7aea64c8
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: runtime
+language_feature: proxy
+goal: spec-completeness
+parent: 1355
+related: [2180, 2615]
+test262_bucket: proxy-trap-not-callable
+---
+# #2616 — Proxy (host): a present non-callable / non-undefined trap must throw TypeError
+
+Slice of #1355; stacked on #2615 (needs the externref Proxy slot so reads reach
+the bridge). Per §10.5 each internal method does `trap = GetMethod(handler,
+"<trapName>")`; §7.3.10 GetMethod throws a **TypeError** when the property is
+present but not callable (it returns `undefined` only for `undefined`/`null`).
+
+## Two-part root cause (re-grounded against current main, #2615 on branch)
+
+1. **TS-checker hard error (the real blocker, not in the original spec).**
+   `new Proxy({}, { get: {} })` — the test262 source itself — fails TS2322
+   (`Type '{}' is not assignable to type ProxyHandler<T>['get']`) **before
+   codegen**, so the runtime path is never reached. All 14
+   `*/trap-is-not-callable.js` tests were hard compile errors.
+2. **Runtime bridge silently omits** a present-non-callable trap.
+   `_buildProxyBridgeHandler` (`src/runtime.ts`) did
+   `if (typeof callable !== "function") continue;`, so the bridge had no trap,
+   the host engine used ordinary behavior, and the spec TypeError never fired.
+
+## Fix
+
+1. **`src/compiler.ts`** — `isProxyHandlerTrapDiagnostic(diag)`: downgrade a
+   TS2322 raised on a trap value **inside the handler (2nd) argument of a
+   `new Proxy(...)`** so the program compiles (and throws at runtime). Tightly
+   scoped — a non-Proxy 2322 still hard-errors (verified). The downstream
+   2339/2349 ("property/call on the target type") are already non-hard.
+2. **`src/runtime.ts`** — `_buildProxyBridgeHandler`: for a present-but-non-
+   callable trap, install a bridge trap that **throws a host TypeError on
+   invocation**. The throw surfaces at operation time (`p.attr` / `p(...)` /
+   `new p(...)`) and propagates through the Proxy MOP + lastCaughtException
+   bridge so `e instanceof TypeError` holds in the compiled program. Absent
+   (`undefined`/`null`) traps still omit → host forwards to target (correct).
+
+## Test Results (local harness, gc mode)
+
+`trap-is-not-callable.js` + `null-handler.js` corpus (26 files): incremental
+over #2615-only **5 pass / 14 err → 11 pass / 1 err** (+6 pass, −13 compile
+errors). `get/construct/defineProperty/getOwnPropertyDescriptor/isExtensible/
+setPrototypeOf` `trap-is-not-callable` now pass.
+
+Whole `built-ins/Proxy` directory (this branch = #2615 + #2616): **82 → 106
+pass** (+24 over #2615-alone; +28 over pure main), err **166 → 113**. The TS
+suppression unblocked many Proxy tests that contained non-callable trap literals,
+not just the 6 trap-is-not-callable rows. `built-ins/Reflect`: identical
+82/19/52 (no regression).
+
+`tests/issue-2616.test.ts` (5 cases) all pass.
+
+## Scope / deferred residual
+
+`set` / `has` / `deleteProperty` / `getPrototypeOf` / `ownKeys` /
+`preventExtensions` `trap-is-not-callable` still FAIL(2): those operations route
+through `__extern_set` / `__extern_has` / `__delete_property` / etc., which don't
+consult the bridge handler the way the real JS-Proxy get-path does — they need
+the boundary helpers to surface the non-callable TypeError (overlaps #2617). The
+`null-handler.js` cases are revoked-proxy tests (#2617 territory, mis-bucketed in
+the spec). `apply`/`construct` non-callable need the call path (#2618).
+
+## Scoped checks
+
+`tsc --noEmit` clean · `prettier --check` clean · `tests/issue-2616.test.ts` 5/5
+· non-Proxy 2322 still hard-errors (scope guard) · Reflect unchanged.

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -439,10 +439,49 @@ function isGuardedNullablePrimitiveDiagnostic(diag: ts.Diagnostic, checker: ts.T
   return assignable ? assignable.call(checker, nonNullType, targetType) : false;
 }
 
+/**
+ * (#2616) Detect a TS2322 raised on a trap value inside a `new Proxy(target,
+ * handler)` handler object literal — e.g. `new Proxy({}, { get: {} })`, where
+ * `{}` is rejected against `ProxyHandler<T>['get']`'s call signature.
+ *
+ * Per §10.5 / §7.3.10 (GetMethod), a present-but-non-callable trap is NOT a
+ * static error: the program must compile and throw a **TypeError at operation
+ * time** (when `p.attr` / `p(...)` runs). The runtime host bridge
+ * (`_buildProxyBridgeHandler`) installs a throwing trap for exactly this case.
+ * TypeScript's `ProxyHandler<T>` typing is stricter than the spec, so it
+ * hard-errors before codegen and the runtime path is never reached. Downgrade
+ * the 2322 so the program compiles and the runtime TypeError fires.
+ *
+ * Tightly scoped: only a 2322 whose node sits inside the SECOND argument
+ * (handler) of a `new Proxy(...)` NewExpression qualifies. (The downstream
+ * 2339/2349 "property/call on the target type" errors are already non-hard, so
+ * they don't need suppression — they stem from the Proxy-no-brand typing.)
+ */
+function isProxyHandlerTrapDiagnostic(diag: ts.Diagnostic): boolean {
+  if (diag.code !== 2322) return false;
+  const file = diag.file;
+  if (!file || diag.start === undefined) return false;
+  let n = findSmallestNodeAtPosition(file, diag.start);
+  // Walk up to the enclosing `new Proxy(...)` and confirm the node is within
+  // its handler (2nd) argument.
+  while (n) {
+    if (ts.isNewExpression(n) && ts.isIdentifier(n.expression) && n.expression.text === "Proxy") {
+      const handlerArg = n.arguments?.[1];
+      if (handlerArg && diag.start >= handlerArg.getStart(file) && diag.start < handlerArg.getEnd()) {
+        return true;
+      }
+      return false;
+    }
+    n = n.parent;
+  }
+  return false;
+}
+
 function isHardTypeScriptDiagnostic(diag: ts.Diagnostic, checker?: ts.TypeChecker): boolean {
   if (diag.category !== 1 || !HARD_TS_DIAG_CODES.has(diag.code)) return false;
   if (checker && isBindingPatternFalsePositive(diag, checker)) return false;
   if (checker && isGuardedNullablePrimitiveDiagnostic(diag, checker)) return false;
+  if (isProxyHandlerTrapDiagnostic(diag)) return false;
   return true;
 }
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -5073,9 +5073,23 @@ function _buildProxyBridgeHandler(
   const bridge: Record<string, any> = {};
   for (const name of _PROXY_TRAP_NAMES) {
     const rawTrap = _structFieldRaw(handler, name, exports);
-    if (rawTrap == null) continue;
+    if (rawTrap == null) continue; // undefined/null → genuine absence, host forwards to target (§7.3.10)
     const callable = _maybeWrapCallableUnknownArity(rawTrap, callbackState);
-    if (typeof callable !== "function") continue;
+    if (typeof callable !== "function") {
+      // (#2616) §7.3.10 GetMethod: a present-but-non-callable trap value (`{}`,
+      // `1`, `"x"`, …) is NOT absence — it must throw a TypeError when the owning
+      // internal method runs. Previously this was silently omitted, so the host
+      // engine used its default (ordinary) behavior and the spec-mandated
+      // TypeError never fired. Install a bridge trap that throws on invocation;
+      // the throw surfaces at operation time (`p.attr`, `p(...)`, `new p(...)`),
+      // which is exactly when test262 checks for it. The host TypeError
+      // propagates through the Proxy MOP and the lastCaughtException bridge so
+      // `e instanceof TypeError` holds in the compiled program.
+      bridge[name] = () => {
+        throw new TypeError(`'${name}' on proxy: trap is not a function`);
+      };
+      continue;
+    }
     // Forward to the user trap with `this` = the raw handler struct. The
     // closure bridge installs that struct as `__current_this`, so the trap
     // body's `this` is the same value the program sees as `handler` and

--- a/tests/issue-2616.test.ts
+++ b/tests/issue-2616.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { compileAndInstantiate } from "../src/runtime-instantiate.js";
+
+// #2616 — a present-but-non-callable Proxy trap must throw a TypeError at
+// operation time (§10.5 / §7.3.10 GetMethod), not be silently dropped. Two
+// parts: (1) the TS checker must not hard-reject `{ get: {} }` against
+// ProxyHandler<T> (it compiles, then throws at runtime); (2) the host bridge
+// (_buildProxyBridgeHandler) installs a throwing trap for the non-callable value.
+
+async function run(source: string): Promise<unknown> {
+  const exports = await compileAndInstantiate(source);
+  return (exports as { test?: () => unknown }).test?.();
+}
+
+describe("#2616 — present non-callable Proxy trap → TypeError", () => {
+  it("compiles `new Proxy(t, { get: {} })` (TS no longer hard-errors)", async () => {
+    const r = await compile(
+      `export function test(): number { const p = new Proxy({ a: 1 }, { get: {} as any }); return 1; }`,
+      { fileName: "t.ts" },
+    );
+    // The non-callable trap value must not block compilation.
+    expect(r.success).toBe(true);
+  });
+
+  it("get with a non-callable trap throws TypeError on access", async () => {
+    // built-ins/Proxy/get/trap-is-not-callable.js shape.
+    const src = `
+      export function test(): number {
+        const p = new Proxy({ attr: 1 }, { get: {} as any });
+        try {
+          const v = p.attr;
+          return 0; // should not reach — read must throw
+        } catch (e) {
+          return e instanceof TypeError ? 1 : 2;
+        }
+      }
+    `;
+    expect(await run(src)).toBe(1);
+  });
+
+  it("an absent trap still forwards (undefined handler trap is NOT an error)", async () => {
+    // get: undefined → genuine absence → host forwards to target (no throw).
+    const src = `
+      export function test(): number {
+        const p = new Proxy({ attr: 1 }, { get: undefined });
+        try {
+          const v = p.attr; // must NOT throw
+          return typeof v === "number" ? 1 : 0;
+        } catch (e) {
+          return 2;
+        }
+      }
+    `;
+    expect(await run(src)).toBe(1);
+  });
+
+  it("a callable get trap still runs normally (regression guard)", async () => {
+    const src = `
+      export function test(): number {
+        const p = new Proxy({ attr: 1 }, { get: function () { return 9; } });
+        return p.attr; // trap returns 9
+      }
+    `;
+    expect(await run(src)).toBe(9);
+  });
+
+  it("a non-Proxy bad assignment is still a hard TS error (scope guard)", async () => {
+    const r = await compile(`const bad: (x: number) => number = {};`, { fileName: "t.ts" });
+    expect(r.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## #2616 — Proxy (host): a present non-callable trap must throw TypeError

Slice of #1355. **Stacked on #2615 (PR #1932)** — base will auto-retarget to `main` when #1932 lands. Needs #2615's externref Proxy slot so reads reach the bridge.

### Two-part root cause (re-grounded against current main)
Per §10.5 / §7.3.10 (GetMethod), a present-but-non-callable trap must throw a TypeError at operation time; absent (`undefined`/`null`) traps forward to target.
1. **TS-checker hard error (not in the original spec):** `new Proxy({}, { get: {} })` — the test262 source itself — fails TS2322 against `ProxyHandler<T>` **before codegen**, so the runtime path was unreachable. All 14 `trap-is-not-callable.js` tests were hard compile errors.
2. **Runtime bridge silently omitted** a present-non-callable trap (`if (typeof callable !== "function") continue;`).

### Fix
- `src/compiler.ts`: `isProxyHandlerTrapDiagnostic()` downgrades a TS2322 raised on a trap value **inside the handler (2nd) arg of a `new Proxy(...)`** so it compiles and throws at runtime. Tightly scoped — a non-Proxy 2322 still hard-errors (verified). Downstream 2339/2349 are already non-hard.
- `src/runtime.ts`: `_buildProxyBridgeHandler` installs a throwing bridge trap for a present-but-non-callable value; the host TypeError surfaces at operation time and propagates through the Proxy MOP + lastCaughtException bridge.

### Results (local harness, gc mode)
- `trap-is-not-callable` + `null-handler` corpus: incremental over #2615 **5 pass / 14 err → 11 pass / 1 err** (+6 pass, −13 compile errors)
- whole `built-ins/Proxy` (this branch = #2615 + #2616): **82 → 106 pass** (+24 over #2615; +28 over main), err **166 → 113**
- `built-ins/Reflect`: identical 82/19/52 (no regression)

### Residual (deferred)
`set`/`has`/`delete`/`getPrototypeOf`/`ownKeys`/`preventExtensions` non-callable need the non-get boundary helpers to surface the TypeError (#2617); `apply`/`construct` need the call path (#2618). `null-handler.js` are revoked-proxy tests (#2617).

### Validation
`tsc --noEmit` clean · `prettier --check` clean · `tests/issue-2616.test.ts` 5/5 · non-Proxy 2322 still hard-errors (scope guard) · Reflect unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA