### PR TITLE
fix(#2611): flush deferred late-import shift after __get_undefined arity-pad add (standalone async-gen dstr-default invalid Wasm)

### DIFF
--- a/plan/issues/2611-standalone-extern-length-late-import-shift-orphan.md
+++ b/plan/issues/2611-standalone-extern-length-late-import-shift-orphan.md
@@ -1,9 +1,11 @@
 ---
 id: 2611
 title: "standalone: `__extern_length` invalid-Wasm (#2043 late-import index-shift orphan) in async-gen-method destructuring-param defaults"
-status: ready
+status: done
 sprint: 65
 created: 2026-06-22
+completed: 2026-06-22
+assignee: sendev-flatten
 priority: medium
 feasibility: medium
 reasoning_effort: high
@@ -191,3 +193,64 @@ compile (`WebAssembly.compile` / validate) the wrapped repro files above under
 `target:"standalone"` and assert NO `local index out of range` / invalid-binary
 error. Mirror `tests/issue-2158-dstr-param-default-nested-pattern.test.ts` (the
 Slice F-1 validate-only regression guard).
+
+## Resolution (2026-06-22, sendev-flatten)
+
+**Verified root cause — corrects the spec's hypothesis.** The diagnostic names
+the #2043 *funcIdx-call-shift* class, but the actual mechanism is a **name↔body
+desync from an UNFLUSHED deferred late-import shift that leaked past later
+function registrations** — confirmed via instrumented build + emitted-body dump,
+not the spec's `objLengthArm`-captured `externGetIdx2036` theory:
+
+1. The error `local index out of range — 4 at __extern_length` is a body-content
+   corruption, not a call-target shift: the dumped `__extern_length` body was
+   literally `__extern_get_idx`'s body (it used local 4 / `i32.trunc_sat_f64_s` /
+   `array.get` / `ref.null.extern` returns), spliced into the wrong function.
+
+2. `tryEmitInlineDynamicCall` (`src/codegen/expressions/calls.ts`) adds the
+   `__get_undefined` arity-pad late import via `ensureLateImport` — which DEFERS
+   the index shift (records `ctx.pendingLateImportShift`, bumps `numImportFuncs`)
+   — but, unlike every sibling late-import call site, **never flushed it**. The
+   async-generator class method's destructuring-param default is one path that
+   reaches this site (other adders `__array_from_iter_n` are flushed by their
+   own sites; `__get_undefined` here was the leak).
+
+3. The dangling pending shift then leaked past further function registrations.
+   `__module_init` (and any function registered after the import) got funcIdx =
+   post-import `numImportFuncs + arrayPos` — already correct. But the native
+   runtime helpers registered BEFORE the import (`__extern_length`,
+   `__extern_get_idx`, …) had stale-low `funcMap` entries. Instrumentation:
+   `funcMap{EL=127,EGI=128}` while `arraySlot{EL=109→128, EGI=110→129}` and
+   `pendingLateImportShift={importsBefore:18}` — stale-low by exactly the
+   unflushed `added`.
+
+4. At finalize, `fillExternGetIdxVecArms` resolved
+   `mod.functions[funcMap.get("__extern_get_idx") - numImportFuncs] =
+   mod.functions[128-19] = mod.functions[109]` = `__extern_length`, and spliced
+   `__extern_get_idx`'s vec arms into `__extern_length`'s body → invalid Wasm.
+
+**Why flushing at finalize is WRONG (rejected alternative).** The deferred shift
+is HALF-applied by finalize: `startFuncIdx` and post-import funcMap entries are
+already at post-shift values while pre-import native helpers are stale. Running
+the full `shiftLateImportIndices` at finalize re-bumps `startFuncIdx` → `invalid
+start function: non-zero parameter or return count` (verified: startFuncIdx 201
+→ wrongly 202; `__module_init` was already correctly at funcIdx 201). The shift
+must be flushed at the leak source, before any further function is registered.
+
+**Fix (1 line + comment, `src/codegen/expressions/calls.ts`).** After the
+`__get_undefined` add in `tryEmitInlineDynamicCall`, flush immediately:
+`if (undefinedIdx !== undefined) flushLateImportShifts(ctx, fctx);`. This repairs
+ONLY the genuinely-stale pre-import indices (no later function exists yet to be
+over-shifted) and keeps the index space self-consistent through finalize —
+mirroring `emitUndefined`, which already flushes after the same
+`ensureGetUndefined` add. Idempotent no-op when nothing pends.
+
+**Validation.** Repro (3 wrapped test262 files) now emit valid Wasm. New
+regression test `tests/issue-2611-extern-length-shift-async-gen-dstr-standalone.test.ts`
+(7 tests: standalone validate for async-gen/static/gen/array-rest dstr defaults +
+a `startFuncIdx` over-shift guard + host-runtime correctness). Regression-neutral:
+the #820/#2158/#2567/#2512/#2174/#2542/#2029 clusters pass; the equivalence
+async/generator/dstr/call subset passes (141/144 — the 3 tagged-template-cache
+failures + the 14 #820b/#820m failures are PRE-EXISTING on `origin/main`,
+A/B-confirmed, unrelated to this fix). tsc / prettier / biome / coercion-sites
+gates clean.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -2303,6 +2303,28 @@ function tryEmitInlineDynamicCall(
   const undefinedIdx = needsUndefinedPad
     ? ensureLateImport(ctx, "__get_undefined", [], [{ kind: "externref" }])
     : undefined;
+  // (#2611) Flush the deferred late-import shift NOW — every other late-import
+  // call site in this file flushes after the add, but this one historically did
+  // not, leaving `ctx.pendingLateImportShift` dangling. `ensureLateImport`
+  // inserts the import at index `numImportFuncs` and defers the shift; until it
+  // is flushed, the funcMap entries + bodies of functions registered BEFORE the
+  // import stay stale-low while functions registered AFTER (e.g. `__module_init`,
+  // whose funcIdx is recomputed from the post-import `numImportFuncs`) are already
+  // correct. A flush left this late is then HALF-applied: shifting it at finalize
+  // re-bumps the already-correct post-import indices (`startFuncIdx` → invalid
+  // start function), while NOT flushing at all leaves the pre-import native
+  // runtime helpers (`__extern_length`/`__extern_get_idx`/…) stale, so a
+  // finalize reserve-then-fill resolves `funcMap.get(name) - numImportFuncs` to
+  // the WRONG `mod.functions[]` slot and corrupts that body ("local index out of
+  // range … #2043 class"). Flushing immediately — before any further function is
+  // registered — repairs only the genuinely-stale pre-import indices and keeps
+  // the index space self-consistent through the rest of compilation. Idempotent
+  // no-op when nothing is pending. This site (`tryEmitInlineDynamicCall` ->
+  // `__get_undefined` for the arity-pad path) is the one async-generator /
+  // destructuring-param trigger that reaches here, but the flush is correct for
+  // every path. (Mirrors `emitUndefined`, which already flushes after the same
+  // `ensureGetUndefined` add.)
+  if (undefinedIdx !== undefined) flushLateImportShifts(ctx, fctx);
   const pushUndefinedExternref = (body: Instr[]): void => {
     if (undefinedIdx !== undefined) {
       body.push({ op: "call", funcIdx: undefinedIdx } as Instr);

--- a/tests/issue-2611-extern-length-shift-async-gen-dstr-standalone.test.ts
+++ b/tests/issue-2611-extern-length-shift-async-gen-dstr-standalone.test.ts
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2611 (slice of umbrella #2158, Family F — invalid-Wasm-binary, the "deeper
+// shift orphan" predicted by Slice F-1) — `--target standalone` emitted invalid
+// Wasm for an async-generator (or generator) class method whose parameter binds
+// a destructuring pattern with a default value, once the module is large enough
+// to trigger a body-time late import. The validator rejected the module with
+// "local index out of range — N at function '__extern_length'" (the #2043
+// late-import index-shift class).
+//
+// Root cause (NOT a funcIdx-of-a-call shift, despite the #2043 diagnostic): a
+// name↔body desync. `tryEmitInlineDynamicCall` (calls.ts) adds the
+// `__get_undefined` late import for the arity-pad path via `ensureLateImport`,
+// which DEFERS the index shift (records `ctx.pendingLateImportShift`) — but,
+// unlike every sibling late-import call site, it never flushed. The pending
+// shift then leaked past further function registrations: `__module_init`'s
+// `startFuncIdx` and the funcMap entries of functions registered AFTER the
+// import were computed at post-import indices (already correct), while the
+// native runtime helpers registered BEFORE the import (`__extern_length` /
+// `__extern_get_idx` / …) stayed stale-low by the unflushed `added`. At
+// finalize, `fillExternGetIdxVecArms` resolved
+// `mod.functions[funcMap.get("__extern_get_idx") - numImportFuncs]` to the WRONG
+// slot — `__extern_length` (registered one slot earlier) — and spliced
+// `__extern_get_idx`'s vec arms (which use local index 4 + `array.get`) into
+// `__extern_length`'s body (only locals 0–3), so the validator rejected
+// `__extern_length` with "local index out of range — 4".
+//
+// Fix: flush the deferred shift immediately after the `__get_undefined` add in
+// `tryEmitInlineDynamicCall`, before any further function is registered —
+// repairing only the genuinely-stale pre-import indices and keeping the index
+// space self-consistent through finalize (mirrors `emitUndefined`, which already
+// flushes after the same add). Flushing the half-applied shift late instead
+// would re-bump the already-correct `startFuncIdx` ("invalid start function").
+//
+// Spec references:
+// - ECMA-262 §15.5 GeneratorFunction / §27.6 AsyncGenerator definitions
+// - ECMA-262 §10.2.11 FunctionDeclarationInstantiation (default-param firing)
+// - ECMA-262 §8.6.2 BindingInitialization / §13.3.3 destructuring
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { instantiateWithRuntime } from "./equivalence/helpers.js";
+
+/**
+ * The slice's core assertion: shapes that previously emitted invalid Wasm now
+ * produce a VALID module under `--target standalone`. `WebAssembly.compile`
+ * validates the binary, isolating the index-shift fix — a regression of the
+ * orphan re-introduces a `CompileError` ("local index out of range" /
+ * "invalid start function").
+ *
+ * To reach the bug the module must be large enough that a body-time late import
+ * is added AFTER the native runtime helpers are registered. A standalone module
+ * that touches an arity-padded dynamic call (the `__get_undefined` trigger) in
+ * the same compile as the async-generator class-method destructuring-param
+ * default reproduces it without the full test262 harness preamble.
+ */
+async function expectValidatesStandalone(src: string): Promise<void> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  // Throws CompileError if the binary is invalid Wasm (the bug).
+  await WebAssembly.compile(r.binary);
+}
+
+/** Host-mode runtime correctness — the env runtime drives the async generator. */
+async function runHost(src: string): Promise<unknown> {
+  const r = await compile(src);
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const inst = await instantiateWithRuntime(r);
+  return (inst.exports as { test: () => unknown }).test();
+}
+
+describe("#2611 async-gen/gen class-method dstr-param default emits valid standalone Wasm", () => {
+  it("standalone validates: async-generator method, defaulted array dstr param", async () => {
+    await expectValidatesStandalone(
+      `class C {
+         async *m([a, b] = [3, 4]) { yield a; yield b; }
+       }
+       export function test(): number {
+         const c = new C();
+         return 0;
+       }`,
+    );
+  });
+
+  it("standalone validates: static async-generator method, defaulted object dstr param", async () => {
+    await expectValidatesStandalone(
+      `class C {
+         static async *m({ x, y } = { x: 1, y: 2 }) { yield x; yield y; }
+       }
+       export function test(): number { return 0; }`,
+    );
+  });
+
+  it("standalone validates: plain generator method, defaulted nested dstr param", async () => {
+    await expectValidatesStandalone(
+      `class C {
+         *m({ w: [p, q] } = { w: [5, 6] }) { yield p; yield q; }
+       }
+       export function test(): number { return 0; }`,
+    );
+  });
+
+  it("standalone validates: async-generator method + array-rest defaulted param", async () => {
+    await expectValidatesStandalone(
+      `class C {
+         async *m([head, ...rest] = [1, 2, 3]) { yield head; }
+       }
+       export function test(): number { return 0; }`,
+    );
+  });
+
+  // Regression guard for the `startFuncIdx` over-shift that a late (finalize)
+  // flush of the half-applied pending shift would re-introduce: the module init
+  // (`(start)` section) must still point at `__module_init` (a `[] -> []` func).
+  // An over-shift surfaces as "invalid start function: non-zero parameter or
+  // return count". Top-level code forces a real `__module_init`.
+  it("standalone validates: async-gen dstr-default method + top-level init code", async () => {
+    await expectValidatesStandalone(
+      `class C {
+         async *m([a, b] = [3, 4]) { yield a; yield b; }
+       }
+       let sentinel: number = 0;
+       sentinel = sentinel + 1;
+       export function test(): number { return sentinel; }`,
+    );
+  });
+
+  // Host-mode runtime correctness: the destructuring-param-default semantics
+  // must be unchanged by the index-shift fix.
+  it("host runtime: async-gen method default fires when arg omitted → 3,4", async () => {
+    expect(
+      await runHost(
+        `class C { async *m([a, b] = [3, 4]) { yield a; yield b; } }
+         export async function test(): Promise<number> {
+           const g = new C().m();
+           const r1 = await g.next();
+           const r2 = await g.next();
+           return (r1.value as number) * 10 + (r2.value as number);
+         }`,
+      ),
+    ).toBe(34);
+  });
+
+  it("host runtime: async-gen method explicit arg overrides default → 7,8", async () => {
+    expect(
+      await runHost(
+        `class C { async *m([a, b] = [3, 4]) { yield a; yield b; } }
+         export async function test(): Promise<number> {
+           const g = new C().m([7, 8]);
+           const r1 = await g.next();
+           const r2 = await g.next();
+           return (r1.value as number) * 10 + (r2.value as number);
+         }`,
+      ),
+    ).toBe(78);
+  });
+});


### PR DESCRIPTION
## #2611 — standalone async-gen/gen class-method dstr-param-default invalid Wasm

Slice of umbrella #2158 (Family F, the "deeper shift orphan" predicted by Slice F-1).

### Problem
`--target standalone` emitted invalid Wasm — `local index out of range — N at function '__extern_length'` (the #2043 late-import index-shift class) — for an async-generator (or generator) class method whose parameter binds a destructuring pattern with a default value, once the module is large enough to pull in a body-time late import (the test262 harness preamble supplies the pressure).

### Root cause (corrects the issue's funcIdx-call-shift hypothesis)
Verified via instrumented build + emitted-body dump: it is **not** a corrupted `call` target, but a **name↔body desync from an UNFLUSHED deferred late-import shift that leaked past later function registrations**.

- `tryEmitInlineDynamicCall` (`src/codegen/expressions/calls.ts`) adds the `__get_undefined` arity-pad import via `ensureLateImport`, which **defers** the index shift (records `ctx.pendingLateImportShift`, bumps `numImportFuncs`) — but, unlike every sibling late-import call site, **never flushed it**.
- The dangling pending shift then leaked past further function registrations. `__module_init`'s `startFuncIdx` and the `funcMap` entries of functions registered *after* the import were computed at post-import indices (already correct), while the native runtime helpers registered *before* the import (`__extern_length`, `__extern_get_idx`, …) stayed **stale-low**. Instrumentation: `funcMap{EL=127,EGI=128}` while `arraySlot{EL=109→128, EGI=110→129}`, `pendingLateImportShift={importsBefore:18}`.
- At finalize, `fillExternGetIdxVecArms` resolved `mod.functions[funcMap.get("__extern_get_idx") - numImportFuncs] = mod.functions[109]` = `__extern_length` (registered one slot earlier) and spliced `__extern_get_idx`'s vec arms (local index 4 + `array.get`) into `__extern_length`'s body → invalid Wasm.

Flushing the half-applied shift **at finalize is wrong**: it re-bumps the already-correct `startFuncIdx` → `invalid start function: non-zero parameter or return count` (verified). The shift must be flushed at the leak source, before any further function is registered.

### Fix
One line + explanatory comment in `tryEmitInlineDynamicCall`: after the `__get_undefined` add, `if (undefinedIdx !== undefined) flushLateImportShifts(ctx, fctx);`. This repairs only the genuinely-stale pre-import indices (no later function exists yet to over-shift) — mirroring `emitUndefined`, which already flushes after the same `ensureGetUndefined` add. Idempotent no-op when nothing pends.

### Validation
- 3 wrapped test262 repro files (`async-gen-meth-dflt-ary-ptrn-rest-id-elision-next-err`, `async-gen-meth-static-dflt-obj-ptrn-prop-id-get-value-err`, `async-gen-meth-dflt-obj-ptrn-prop-obj-value-null`) now emit valid Wasm.
- New regression test `tests/issue-2611-extern-length-shift-async-gen-dstr-standalone.test.ts` (7 tests: standalone validate for async-gen/static/gen/array-rest dstr defaults + a `startFuncIdx` over-shift guard + host-runtime correctness 3,4 / 7,8).
- Regression-neutral: #820 / #2158 / #2567 / #2512 / #2174 / #2542 / #2029 clusters pass; equivalence async/generator/dstr/call subset passes (141/144 — the 3 tagged-template-cache + 14 #820b/#820m failures are **pre-existing on `main`**, A/B-confirmed).
- tsc / prettier / biome / coercion-sites gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA