### PR TITLE
fix(#1528/#1632b-2): closure-as-dynamic-constructor host bridge

### DIFF
--- a/plan/issues/1528-non-constructor-typeerror-promise-and-species.md
+++ b/plan/issues/1528-non-constructor-typeerror-promise-and-species.md
@@ -1,9 +1,10 @@
 ---
 id: 1528
 title: "spec gap: non-constructor TypeError — Promise.all / allSettled species and executor paths"
-status: ready
+status: in-progress
 created: 2026-05-20
-updated: 2026-06-19
+updated: 2026-06-22
+assignee: ttraenkler/senior-developer
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -577,3 +578,67 @@ closure-as-dynamic-constructor work, NOT a clean dev slice. The non-constructor
 **throw** cases (arrows, bound functions, prototype methods, call-only callables)
 are the substrate-independent, test262-cluster-dominant part and are now covered.
 Issue stays `ready` for the remaining construct-a-fn-value cluster.
+
+## #1632b-2 closure-construct-bridge — implementation plan (2026-06-22, sd, task #56)
+
+**Re-grounded root cause (current main).** `new Ctor(args)` where `Ctor` is a
+factory-returned `function C(){}` value (an `any`/function-typed identifier, not
+a declared class) is mis-classified: codegen routes it to the **extern-class**
+path (`new-super.ts:3999` `externClasses.get(className)`), emitting a
+`<prefix>_new` host call that fails at instantiation with
+`No dependency provided for extern class "Ctor"`. It never reaches a construct
+bridge. (Confirmed via `.tmp/probe-construct.js` → that exact runtime error.)
+
+The existing `__construct` host helper (`runtime.ts:9275`) wraps the callee with
+`_wrapForHost` (NON-callable proxy), so its `IsConstructor` probe FAILS for a
+real constructable closure and it throws "not a constructor" — correct for
+arrows/bound/methods (#1921 routes those here to throw), WRONG for a genuine
+`function C(){}` value.
+
+**Fix (two narrow parts; host-helper, NOT a wasm `__construct_closure` codegen
+export — sidesteps the #608/#794 `flushLateImportShifts`-mid-function index
+corruption entirely):**
+
+1. **runtime.ts** — new host helper `__construct_closure(callee, argsArray)`:
+   when `callee` is a wasm closure, wrap with **`_wrapCallableForHost`** (its
+   construct trap = ECMA-262 §10.2.2 OrdinaryCallEvaluateBody, already present at
+   `runtime.ts:4874`) and `Reflect.construct(callableProxy, args)`. Non-closure
+   structs / non-functions still throw the spec TypeError (keeps ctx-non-ctor).
+   Distinct helper name so the arrow/bound/method NON-constructable throw path
+   (`__construct`) is untouched.
+
+2. **new-super.ts** — a NARROW guard placed BEFORE the extern-class branch
+   (3999): when the `new` callee is an identifier whose value is a **function
+   type that is NOT a declared/extern class** (a runtime function value), and
+   `!noJsHost`, materialize args into a `__js_array_new`/`__js_array_push` JS
+   array and emit a single `__construct_closure(callee, argv)` call. ONE terminal
+   `flushLateImportShifts` after the call (the safe pattern the existing
+   `__construct` site at 3663 uses), never mid-emission. Gate strictly on the
+   function-value shape so no declared-class / intrinsic-ctor / typed-array path
+   is intercepted (those branches precede or are matched by `classSet`/
+   `externClasses` with real dependencies).
+
+**Validation:** broad-impact construct path ⇒ full-gate via merge_group, never a
+scoped sweep. Regression-watch the constructor/new suites (issue-1732-s1/s2,
+issue-1519, fn-constructor, issue-2026-constructor-identity-any, issue-1528) +
+the Promise capability tests (this also resolves #2614's any/invoke-resolve
+illegal-cast — the combinator's NewPromiseCapability(C)→Construct(C, executor)
+goes through the same bridge). Add `tests/issue-1528-closure-construct.test.ts`.
+
+## #1632b-2 closure-construct bridge LANDED (2026-06-22, task #56)
+
+The **ordinary-function-value** construct-a-fn-value cluster is now supported
+JS-host: `const C = makeCtor(); new C(args)` constructs via the new
+`__construct_closure` host helper (`_wrapCallableForHost`'s construct trap runs
+the compiled closure body). New `tests/issue-1528-closure-construct.test.ts`
+(4 pass, 1 skip = the explicit-object-return override follow-up). The 48-test
+constructor/new regression suite stays green; the #1921 non-constructable throw
+cases are untouched (separate `__construct` path). Also unblocks the Promise
+combinator capability path's `any/invoke-resolve` (same bridge).
+
+**Still open (follow-up, out of this slice):** the compiled-CLASS-as-dynamic-ctor
+sub-case — `__fn_tramp_Constructor_*` `illegal cast` (e.g.
+`allSettled/call-resolve-element.js`, `race/resolve-from-same-thenable.js`). That
+is the `__construct_closure` *codegen export* (spec step 4), distinct from the
+host-helper ordinary-function path delivered here. Issue stays `in-progress` for
+that arm; #2614 remains blocked on it.

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -214,7 +214,27 @@ function resolvesToConstructableFunctionValue(ctx: CodegenContext, calleeExpr: t
   // Callable value (a function held in the binding). Construct-signature-bearing
   // values (real class ctors typed through the binding) are left to the static
   // class paths; here we target the ordinary-function-value cluster.
-  return t.getCallSignatures().length > 0;
+  const callSigs = t.getCallSignatures();
+  if (callSigs.length === 0) return false;
+  // Only a PLAIN constructable function gets the closure-construct bridge.
+  // Generator (`function*` / `*m()`), async, and async-generator functions, plus
+  // method/accessor/arrow values, have NO [[Construct]] (§14.4.13 / §15.x): e.g.
+  // `var m = { *m(){} }.m; new m()` MUST throw TypeError, not construct. The
+  // bridge would wrongly construct them. The call signature's DECLARATION (kind +
+  // asterisk/async modifiers) is the authoritative discriminator — a binding's
+  // type otherwise loses the AST. (Regressed
+  // `language/.../method-definition/generator-invoke-ctor.js` before this guard.)
+  for (const sig of callSigs) {
+    const sigDecl = sig.getDeclaration() as ts.SignatureDeclaration | undefined;
+    if (!sigDecl) return false; // unknown shape — don't claim it
+    if ("asteriskToken" in sigDecl && (sigDecl as ts.FunctionLikeDeclaration).asteriskToken) return false; // generator
+    if (ts.canHaveModifiers(sigDecl) && ts.getModifiers(sigDecl)?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword))
+      return false; // async / async-gen
+    // Only an ordinary function declaration / expression is constructable;
+    // method / accessor / arrow / constructor-type signatures are not.
+    if (!ts.isFunctionDeclaration(sigDecl) && !ts.isFunctionExpression(sigDecl)) return false;
+  }
+  return true;
 }
 
 /** Compile super.method(args) — resolve to ParentClass_method and call with this */

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -180,6 +180,43 @@ function resolvesToNonConstructableValue(ctx: CodegenContext, calleeExpr: ts.Exp
   return false;
 }
 
+/**
+ * (#1632b-2 / #1528a residual) Does `new <id>(...)` target a runtime FUNCTION
+ * VALUE held in a binding — `const C = makeCtor(); new C()` — that is provably
+ * CONSTRUCTABLE (an ordinary `function` value, not an arrow / bound / prototype
+ * method, which `resolvesToNonConstructableValue` already routes to the throwing
+ * `__construct` brand check)? Such a callee is mis-classified by the unknown-ctor
+ * path as an `extern_class` host import (fails at instantiation with
+ * "No dependency provided for extern class …"); it must instead route through the
+ * `__construct_closure` host bridge, whose `_wrapCallableForHost` construct trap
+ * runs the compiled closure body (ECMA-262 §10.2.2).
+ *
+ * Gate strictly on the value-binding shape so no declared class, ambient/host
+ * constructor (Test262Error is a top-level `FunctionDeclaration`, kept on the
+ * existing path), or intrinsic ctor is intercepted:
+ *  - callee is a bare identifier whose **value declaration is a
+ *    `VariableDeclaration`** (a function held in a binding, not a hoisted
+ *    function/class declaration);
+ *  - the binding's TS type has **call signatures** (it is callable) and **no
+ *    construct signatures** that would have made a static guard fire;
+ *  - it is NOT a known compiled class and NOT a registered extern class.
+ */
+function resolvesToConstructableFunctionValue(ctx: CodegenContext, calleeExpr: ts.Expression): boolean {
+  if (!ts.isIdentifier(calleeExpr)) return false;
+  if (ctx.classSet.has(calleeExpr.text) || ctx.externClasses.has(calleeExpr.text)) return false;
+  // An arrow / bound / prototype-method value is non-constructable — that is the
+  // throwing path, handled by resolvesToNonConstructableValue. Do not claim it.
+  if (resolvesToNonConstructableValue(ctx, calleeExpr)) return false;
+  const sym = ctx.checker.getSymbolAtLocation(calleeExpr);
+  const decl = sym?.valueDeclaration;
+  if (!decl || !ts.isVariableDeclaration(decl)) return false;
+  const t = ctx.checker.getTypeAtLocation(calleeExpr);
+  // Callable value (a function held in the binding). Construct-signature-bearing
+  // values (real class ctors typed through the binding) are left to the static
+  // class paths; here we target the ordinary-function-value cluster.
+  return t.getCallSignatures().length > 0;
+}
+
 /** Compile super.method(args) — resolve to ParentClass_method and call with this */
 /**
  * (#1614) Dispatch `super.method(args)` where the parent is a builtin extern
@@ -3669,6 +3706,62 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       // fall through to the existing unknown-ctor path below.
       fctx.body.push({ op: "drop" });
       fctx.body.push({ op: "drop" });
+    }
+
+    // (#1632b-2 / #1528a residual) `new C(args)` where `C` is a runtime FUNCTION
+    // VALUE bound in a local (`const C = makeCtor(); new C(42)`) — provably
+    // constructable (ordinary function, not arrow/bound/method). Route through
+    // the `__construct_closure` host bridge: materialize args into a JS array,
+    // then `__construct_closure(callee, argv)` wraps the compiled closure with
+    // `_wrapCallableForHost` (constructible) and `Reflect.construct`s it. Without
+    // this the value is mis-routed to the unknown-ctor extern-class import and
+    // fails at instantiation with "No dependency provided for extern class C".
+    // ONE terminal `flushLateImportShifts` (after the call) — never mid-emission
+    // (the PR #608/#794 index-corruption hazard). JS-host only; standalone keeps
+    // the existing path (a Wasm-native dynamic Construct is a separate effort).
+    if (ts.isIdentifier(s1Callee) && !noJsHost(ctx) && resolvesToConstructableFunctionValue(ctx, s1Callee)) {
+      // Evaluate the callee value to externref.
+      const calleeTy = compileExpression(ctx, fctx, s1Callee, { kind: "externref" });
+      if (calleeTy && calleeTy.kind !== "externref") {
+        coerceType(ctx, fctx, calleeTy, { kind: "externref" });
+      } else if (calleeTy === null) {
+        fctx.body.push({ op: "ref.null.extern" });
+      }
+      const calleeLocal = allocLocal(fctx, `__cc_callee_${fctx.locals.length}`, { kind: "externref" });
+      fctx.body.push({ op: "local.set", index: calleeLocal });
+      // Build a JS array of the args (boxed externref each), in source order.
+      const arrNewIdx = ensureLateImport(ctx, "__js_array_new", [], [{ kind: "externref" }]);
+      const arrPushIdx = ensureLateImport(ctx, "__js_array_push", [{ kind: "externref" }, { kind: "externref" }], []);
+      const ccIdx = ensureLateImport(
+        ctx,
+        "__construct_closure",
+        [{ kind: "externref" }, { kind: "externref" }],
+        [{ kind: "externref" }],
+      );
+      flushLateImportShifts(ctx, fctx);
+      const finalArrNew = ctx.funcMap.get("__js_array_new") ?? arrNewIdx;
+      const finalArrPush = ctx.funcMap.get("__js_array_push") ?? arrPushIdx;
+      const finalCc = ctx.funcMap.get("__construct_closure") ?? ccIdx;
+      if (finalArrNew !== undefined && finalArrPush !== undefined && finalCc !== undefined) {
+        fctx.body.push({ op: "call", funcIdx: finalArrNew });
+        const argvLocal = allocLocal(fctx, `__cc_argv_${fctx.locals.length}`, { kind: "externref" });
+        fctx.body.push({ op: "local.set", index: argvLocal });
+        for (const arg of args) {
+          fctx.body.push({ op: "local.get", index: argvLocal });
+          const aTy = compileExpression(ctx, fctx, arg, { kind: "externref" });
+          if (aTy && aTy.kind !== "externref") {
+            coerceType(ctx, fctx, aTy, { kind: "externref" });
+          } else if (aTy === null) {
+            fctx.body.push({ op: "ref.null.extern" });
+          }
+          fctx.body.push({ op: "call", funcIdx: finalArrPush });
+        }
+        fctx.body.push({ op: "local.get", index: calleeLocal });
+        fctx.body.push({ op: "local.get", index: argvLocal });
+        fctx.body.push({ op: "call", funcIdx: finalCc });
+        return { kind: "externref" };
+      }
+      // Imports unavailable (shouldn't happen in JS-host): fall through.
     }
 
     // new ArrayBuffer(byteLength) — validate non-negative integer length

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -9299,6 +9299,53 @@ assert._isSameValue = isSameValue;
           const wrappedArgs = _isWasmStruct(argsArray) ? _wrapForHost(argsArray, exports) : argsArray;
           return Reflect.construct(wrappedCallee, wrappedArgs ?? []);
         };
+      // (#1632b-2 / #1528a residual) Dynamically CONSTRUCT a runtime function
+      // VALUE — `var C = makeCtor(); new C(args)` where `C` is a factory-returned
+      // `function C(){}` lowered to a WasmGC closure struct. Unlike `__construct`
+      // above (which wraps with the NON-callable `_wrapForHost` and therefore
+      // throws "not a constructor" for any closure — correct for arrows/bound/
+      // methods, wrong for a genuine constructable function), this helper wraps a
+      // closure with `_wrapCallableForHost`, whose `construct` trap runs the
+      // closure body as ECMA-262 §10.2.2 OrdinaryCallEvaluateBody. Non-closure
+      // structs and non-functions still throw the spec TypeError (preserves the
+      // ctx-non-object / ctx-non-ctor cases). Also resolves the Promise-combinator
+      // capability path (#2614): V8's NewPromiseCapability(C) → Construct(C,
+      // «executor») routes a compiled executor through this same bridge.
+      if (name === "__construct_closure")
+        return (callee: any, argsArray: any): any => {
+          const exports = callbackState?.getExports();
+          // A WasmGC closure → the callable wrapper (constructible). A non-closure
+          // struct stays on the non-callable `_wrapForHost`, so the IsConstructor
+          // probe below throws the spec TypeError for a non-constructor value.
+          let wrappedCallee: any = callee;
+          if (_isWasmStruct(callee)) {
+            const isClosureFn = exports?.__is_closure as ((v: any) => number) | undefined;
+            let isClosure = false;
+            if (typeof isClosureFn === "function") {
+              try {
+                isClosure = isClosureFn(callee) === 1;
+              } catch {
+                isClosure = false;
+              }
+            }
+            wrappedCallee = isClosure ? _wrapCallableForHost(callee, callbackState) : _wrapForHost(callee, exports);
+          }
+          let isCtor = false;
+          if (typeof wrappedCallee === "function") {
+            try {
+              Reflect.construct(function () {}, [], wrappedCallee);
+              isCtor = true;
+            } catch {
+              isCtor = false;
+            }
+          }
+          if (!isCtor) {
+            const nm = wrappedCallee && wrappedCallee.name ? wrappedCallee.name : String(wrappedCallee);
+            throw new TypeError(nm + " is not a constructor");
+          }
+          const wrappedArgs = _isWasmStruct(argsArray) ? _wrapForHost(argsArray, exports) : argsArray;
+          return Reflect.construct(wrappedCallee, wrappedArgs ?? []);
+        };
       // Symbol.for(key) — global symbol registry (#965)
       // Symbol.for(key) — §20.4.2.2: stringKey = ? ToString(key). Passing a
       // Symbol makes ToString throw TypeError (not stringify). `Symbol.for`

--- a/tests/issue-1528-closure-construct.test.ts
+++ b/tests/issue-1528-closure-construct.test.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+/**
+ * #1632b-2 / #1528a residual — closure-as-dynamic-constructor host bridge.
+ *
+ * `new C(args)` where `C` is a runtime FUNCTION VALUE held in a binding
+ * (`const C = makeCtor(); new C(42)`) was mis-classified by the unknown-ctor
+ * path as an `extern_class` host import and failed at instantiation with
+ * "No dependency provided for extern class C". It now routes through the
+ * `__construct_closure` host helper, whose `_wrapCallableForHost` construct
+ * trap runs the compiled closure body as ECMA-262 §10.2.2.
+ *
+ * JS-host only (the default compile mode). The non-constructable throw cases
+ * (arrow / bound / prototype method) remain on the throwing `__construct`
+ * brand-check path (#1921) and are covered by issue-1528.test.ts.
+ */
+
+async function runHost(source: string): Promise<unknown> {
+  const r = await compile(source, {});
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports as WebAssembly.Imports);
+  // The closure-construct bridge reads `__is_closure` off the live exports, so the
+  // import object's top-level `setExports` must be wired (mirrors the test262
+  // runner, tests/test262-runner.ts:3196).
+  const setEx = (imports as { setExports?: (e: unknown) => void }).setExports;
+  if (typeof setEx === "function") setEx(instance.exports);
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+describe("#1632b-2 closure-as-dynamic-constructor bridge", () => {
+  it("constructs a factory-returned function value and reads an own field", async () => {
+    expect(
+      await runHost(`
+        function makeCtor() { return function C(x: number) { (this as any).x = x; }; }
+        const Ctor = makeCtor();
+        export function test(): number { const inst: any = new Ctor(42); return inst.x; }
+      `),
+    ).toBe(42);
+  });
+
+  it("constructs with zero arguments", async () => {
+    expect(
+      await runHost(`
+        function makeCtor() { return function C() { (this as any).y = 7; }; }
+        const Ctor = makeCtor();
+        export function test(): number { const inst: any = new Ctor(); return inst.y; }
+      `),
+    ).toBe(7);
+  });
+
+  it("threads multiple arguments in source order", async () => {
+    expect(
+      await runHost(`
+        function makeCtor() { return function C(a: number, b: number) { (this as any).sum = a + b; }; }
+        const Ctor = makeCtor();
+        export function test(): number { const inst: any = new Ctor(3, 4); return inst.sum; }
+      `),
+    ).toBe(7);
+  });
+
+  // The ECMA-262 §10.2.2 "return the body's value if it is an object, else the
+  // fresh receiver" override is implemented in the construct trap, but the
+  // object-literal returned by a *compiled* ctor body does not yet read back
+  // correctly through the host boundary (`inst.a` → NaN): the override object is
+  // a compiled struct whose field read after the construct round-trip needs the
+  // tag-aware dynamic reader. Field-initialising ctors (the dominant #1632b-2
+  // cluster) work; the explicit-object-return override is a follow-up.
+  it.skip("returns the body's object override when the ctor returns an object (follow-up)", async () => {
+    expect(
+      await runHost(`
+        function makeCtor() { return function C(this: any) { (this as any).a = 1; return { a: 99 }; }; }
+        const Ctor = makeCtor();
+        export function test(): number { const inst: any = new Ctor(); return inst.a; }
+      `),
+    ).toBe(99);
+  });
+
+  it("constructs a function value reassigned through an any binding", async () => {
+    expect(
+      await runHost(`
+        let C: any = function C0(v: number) { (this as any).v = v; };
+        export function test(): number { const inst: any = new C(11); return inst.v; }
+      `),
+    ).toBe(11);
+  });
+});

--- a/tests/issue-1528-closure-construct.test.ts
+++ b/tests/issue-1528-closure-construct.test.ts
@@ -87,4 +87,60 @@ describe("#1632b-2 closure-as-dynamic-constructor bridge", () => {
       `),
     ).toBe(11);
   });
+
+  // Regression guard (merge_group eject fix): the bridge gate must NOT CLAIM a
+  // non-constructable function VALUE — generator / async / method values have no
+  // [[Construct]]. The too-broad first cut routed `{ *m(){} }.m` (a generator
+  // method value) through `__construct_closure`, which CONSTRUCTED it and flipped
+  // `language/.../method-definition/generator-invoke-ctor.js` pass→fail. Whether
+  // such a value's `new` *throws* is a separate, pre-existing concern (it does not
+  // throw on baseline either) and is out of this bridge's scope; what this PR
+  // guarantees — and what these guards lock — is that the bridge does not make
+  // them WORSE by routing them to a constructing path. We assert the
+  // construct-closure import is NOT emitted for these shapes.
+  async function constructClosureImportEmitted(source: string): Promise<boolean> {
+    const r = await compile(source, {});
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    return (r.imports ?? []).some((i: { name?: string; intent?: { name?: string } }) => {
+      const n = i.name ?? i.intent?.name;
+      return n === "__construct_closure";
+    });
+  }
+
+  it("does NOT route a generator-method value through the construct bridge", async () => {
+    expect(
+      await constructClosureImportEmitted(`
+        const gen: any = { *m() {} }.m;
+        export function test(): number { const x: any = new gen(); return 0; }
+      `),
+    ).toBe(false);
+  });
+
+  it("does NOT route a generator-function value through the construct bridge", async () => {
+    expect(
+      await constructClosureImportEmitted(`
+        const g: any = function* gen() {};
+        export function test(): number { const x: any = new g(); return 0; }
+      `),
+    ).toBe(false);
+  });
+
+  it("does NOT route an async-function value through the construct bridge", async () => {
+    expect(
+      await constructClosureImportEmitted(`
+        const af: any = async function a() {};
+        export function test(): number { const x: any = new af(); return 0; }
+      `),
+    ).toBe(false);
+  });
+
+  it("DOES route a plain function value through the construct bridge", async () => {
+    expect(
+      await constructClosureImportEmitted(`
+        function mk() { return function C(x: number) { (this as any).x = x; }; }
+        const C = mk();
+        export function test(): number { const i: any = new C(1); return i.x; }
+      `),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

`new C(args)` where `C` is a runtime FUNCTION VALUE held in a binding (`const C = makeCtor(); new C(42)`) was mis-classified by the unknown-ctor path as an `extern_class` host import and failed at instantiation with **"No dependency provided for extern class C"**. It now routes through a new `__construct_closure` host helper, whose `_wrapCallableForHost` construct trap runs the compiled closure body as ECMA-262 §10.2.2 OrdinaryCallEvaluateBody. This is the dominant `#1632b-2` "construct a function value" cluster that blocked #1528a-residual (and the Promise combinator capability path, #2614).

## Root cause

`new <fn-value>` reached the unknown-ctor path (`new-super.ts`) which emits an `extern_class` import for the identifier. The existing `__construct` helper wraps the callee with the **non-callable** `_wrapForHost`, so its IsConstructor probe fails for a real constructable closure (correct for arrows/bound/methods — #1921 routes those there to throw, wrong for `function C(){}`).

## Changes

- **`src/runtime.ts`** — `__construct_closure(callee, argsArray)`: wraps a wasm closure with the **constructible** `_wrapCallableForHost`, probes `IsConstructor`, then `Reflect.construct`. Non-closure structs / non-functions still throw the spec TypeError.
- **`src/codegen/expressions/new-super.ts`** — `resolvesToConstructableFunctionValue` gates the narrow shape (identifier callee, value-declaration is a `VariableDeclaration` with call signatures, not a declared/extern class, not a non-constructable arrow/bound/method); materializes args into a JS array and emits **one** `__construct_closure` call with a **single terminal** `flushLateImportShifts` — never mid-emission (the PR #608/#794 index-corruption hazard). JS-host only.

## Validation

- New `tests/issue-1528-closure-construct.test.ts` — 4 pass (factory-ctor + field read, zero-args, multi-args source order, reassigned-`any` binding); 1 skip (explicit-object-return override — a follow-up needing the tag-aware reader).
- Promise `any/invoke-resolve-…` (regressed by the #2614 attempt) now **passes** through this bridge.
- 48-test constructor/new regression suite green (issue-1528, issue-1732-s1/s2, issue-1519, fn-constructor, issue-2026-constructor-identity-any) — #1921 non-constructable throws untouched.
- Quality sub-gates green: tsc, prettier (all changed files), stack-balance, coercion-sites, any-box-sites, codegen-fallbacks.
- **Broad-impact construct path → authoritative validation via merge_group.**

## Still open (follow-up, out of scope)

The compiled-CLASS-as-dynamic-ctor sub-case (`__fn_tramp_Constructor_*` `illegal cast`, e.g. `allSettled/call-resolve-element.js`) — that is the `__construct_closure` *codegen export* (spec step 4), distinct from the host-helper ordinary-function path here. #1528 stays `in-progress` for that arm; #2614 remains blocked on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA