### PR TITLE
fix(#2617): propagate Proxy trap throws + §10.5 invariant TypeErrors through boundary helpers

### DIFF
--- a/plan/issues/2617-proxy-host-trap-throw-and-invariant-propagation.md
+++ b/plan/issues/2617-proxy-host-trap-throw-and-invariant-propagation.md
@@ -1,10 +1,12 @@
 ---
 id: 2617
 title: "Proxy (host): trap-thrown exceptions and §10.5 invariant TypeErrors are swallowed by the boundary try/catch (~40 fails)"
-status: ready
+status: done
 sprint: 65
 created: 2026-06-22
 updated: 2026-06-22
+completed: 2026-06-22
+assignee: ttraenkler/agent-acc861f0e7aea64c8
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -143,3 +145,31 @@ PRs don't fight over the same Proxy test files.
 Medium — the boundary `catch` is a hot path; the `_isUserProxy` gate keeps the
 non-proxy fast path identical. Validate full gc equivalence (broad-impact:
 boundary helpers).
+
+## Resolution (2026-06-22)
+
+**Runtime (`src/runtime.ts`):** added shared `_isUserProxy(obj)` +
+`_rethrowIfProxyOrRevoked(e, obj)` and applied to the boundary helpers that
+swallowed exceptions: `__extern_get`, `__extern_has`, `_safeSet`
+(`__extern_set`/`__extern_set_strict`), `__getPrototypeOf` (was coercing the
+§10.5.1 invariant TypeError to `null`), `__object_preventExtensions`. Helpers
+that call the native method with no try/catch (getOwnPropertyDescriptor,
+isExtensible, defineProperty_desc, reflect_*) already propagate — left unchanged.
+`__delete_property` re-throws a THROWN trap but maps the always-strict runtime's
+"trap returned falsish" delete-result TypeError to `return 0` (false) — in the
+user program's non-strict context `delete` yields false, not a throw
+(`deleteProperty/return-false-not-strict.js`, `flags:[noStrict]`). Added
+`_isStrictDeleteFalsishError` for that distinction.
+
+**Codegen (`src/codegen/binary-ops.ts`):** the `in` operator constant-folded
+`'k' in p` to the target struct's field membership (the TS type of a `new Proxy`
+var is its TARGET type), so `__extern_has` — and the `has` trap — never ran.
+Fixed by trusting the ACTUAL slot type: when the `in` receiver is an identifier
+slotted `externref`/`anyref` (via #2615), route through `__extern_has`.
+
+**Results (local harness, gc):** whole `built-ins/Proxy` vs current main
+(#2615+#2616): **+17 pass, 0 regressions** (107 → 124). Reflect unchanged
+(82/19/52). Gate set (`return-is-abrupt` + invariant): 12 pass / 1 err.
+`tests/issue-2617.test.ts` (6 cases) all pass; `tsc`/`prettier` clean.
+
+Cumulative Proxy progression: 78 → 83 (#2615) → 107 (#2616) → **124 (#2617)**.

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -539,7 +539,31 @@ export function compileBinaryExpression(
     }
 
     const rightType = ctx.checker.getTypeAtLocation(expr.right);
-    const rightWasm = resolveWasmType(ctx, rightType);
+    let rightWasm = resolveWasmType(ctx, rightType);
+
+    // (#2617) The TS type of a `new Proxy(...)`-bound identifier is its TARGET
+    // type (ProxyConstructor returns T), so `resolveWasmType` yields the target
+    // struct and the static `in` fold below would constant-fold `'k' in p` to
+    // the target's field membership — never calling `__extern_has`, so a `has`
+    // trap (incl. one that throws, #2617) never runs. But #2615 slots that
+    // variable as `externref`. Trust the ACTUAL slot type: if the receiver is an
+    // identifier whose local slot is externref/anyref, treat the RHS as externref
+    // so the `in` routes through `__extern_has` (the host Proxy MOP).
+    if (
+      (rightWasm.kind === "ref" || rightWasm.kind === "ref_null") &&
+      ts.isIdentifier(expr.right) &&
+      fctx.localMap.has(expr.right.text)
+    ) {
+      const idx = fctx.localMap.get(expr.right.text)!;
+      const entry = idx < fctx.params.length ? fctx.params[idx] : fctx.locals[idx - fctx.params.length];
+      const slotType =
+        entry && typeof entry === "object" && "type" in entry
+          ? (entry as { type: ValType }).type
+          : (entry as ValType | undefined);
+      if (slotType?.kind === "externref" || slotType?.kind === "anyref") {
+        rightWasm = slotType;
+      }
+    }
 
     // Get struct field names if available; detect vec (array) types
     let structFieldNames: string[] | null = null;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1675,6 +1675,32 @@ function _toPropertyDescriptorValidate(
 // user proxies keeps them on the host MOP path.
 const _userProxies = new WeakSet<object>();
 
+/**
+ * (#2617) Is `obj` a tracked user Proxy (built from `new Proxy(...)` /
+ * `Proxy.revocable(...)` and registered in `_userProxies`)?
+ */
+function _isUserProxy(obj: any): boolean {
+  return obj != null && typeof obj === "object" && _userProxies.has(obj);
+}
+
+/**
+ * (#2617) Shared re-throw gate for the boundary helpers' `catch (e)`.
+ *
+ * Each boundary helper (`__extern_get` / `__extern_has` / `__delete_property` /
+ * `__getPrototypeOf` / …) wraps its host MOP read in a try/catch that, on
+ * failure, falls through to a generic struct/undefined path. That fallthrough
+ * is correct for a genuine WasmGC struct, but WRONG for a **user Proxy**: an
+ * exception from the host MOP on a user Proxy is exactly what the program must
+ * observe — either the user trap's own abrupt completion, or the host engine's
+ * §10.5 invariant TypeError. Swallowing it returns a wrong value instead of the
+ * throw. So re-throw when the receiver is a user Proxy (or the pre-existing
+ * revoked-proxy case). Return normally (caller falls through) otherwise, so the
+ * non-proxy struct fast path is byte-for-byte unchanged.
+ */
+function _rethrowIfProxyOrRevoked(e: any, obj: any): void {
+  if (_isRevokedProxyError(e) || _isUserProxy(obj)) throw e;
+}
+
 function _isWasmStruct(obj: any): boolean {
   if (obj == null || typeof obj !== "object") return false;
   if (_userProxies.has(obj)) return false;
@@ -4007,9 +4033,13 @@ function _safeSet(
   try {
     obj[key] = val;
   } catch (e) {
-    // #2180 — writing to a revoked proxy throws TypeError; propagate it
-    // instead of silently diverting to the sidecar.
-    if (_isRevokedProxyError(e)) throw e;
+    // #2180/#2617 — writing to a revoked proxy throws TypeError; a tracked user
+    // Proxy's `set` trap may also throw (abrupt completion) or the host engine
+    // may raise the §10.5.9 strict-write invariant TypeError. Propagate both
+    // instead of silently diverting to the sidecar. The gate is strictly
+    // `_isUserProxy(obj)`, so the sloppy-mode struct / frozen-builtin cases
+    // below (Math.E=1, Number.NaN=1) are byte-for-byte unchanged (#2017).
+    _rethrowIfProxyOrRevoked(e, obj);
     // (#2017 regression fix) Do NOT blanket re-throw the engine's TypeError just
     // because this came through `__extern_set_strict`. The bundled runtime is an
     // ES module (executes in strict mode), so `obj[key] = val` throws natively
@@ -4979,6 +5009,23 @@ function _isObjectLike(v: any): boolean {
  */
 function _isRevokedProxyError(e: any): boolean {
   return e instanceof TypeError && typeof e.message === "string" && e.message.includes("proxy that has been revoked");
+}
+
+/**
+ * (#2617) The strict-mode `delete obj[k]` result-coercion TypeError that the
+ * (always-strict) bundled runtime raises when a Proxy `deleteProperty` trap
+ * merely RETURNS FALSE (V8: "'deleteProperty' on proxy: trap returned falsish
+ * for property ..."). This is NOT the trap throwing — in the user program's
+ * non-strict context `delete` must yield `false`, not throw. Detected by message
+ * so it can be mapped to a `return 0` instead of propagated. A trap that *itself*
+ * throws produces a different error (its own value) and is propagated.
+ */
+function _isStrictDeleteFalsishError(e: any): boolean {
+  return (
+    e instanceof TypeError &&
+    typeof e.message === "string" &&
+    (e.message.includes("trap returned falsish") || e.message.includes("Cannot delete property"))
+  );
 }
 
 /**
@@ -6886,9 +6933,10 @@ assert._isSameValue = isSameValue;
             try {
               if (Object.getPrototypeOf(obj) !== null && key in Object(obj)) return obj[key];
             } catch (e) {
-              // #2180 — a revoked-proxy TypeError must propagate, not be
-              // swallowed by the struct-getter fallback below.
-              if (_isRevokedProxyError(e)) throw e;
+              // #2180/#2617 — a revoked-proxy TypeError, OR any exception from a
+              // tracked user Proxy's get trap (abrupt completion), must propagate
+              // — not be swallowed by the struct-getter fallback below.
+              _rethrowIfProxyOrRevoked(e, obj);
               /* otherwise fall through to the generic path */
             }
           }
@@ -7128,8 +7176,10 @@ assert._isSameValue = isSameValue;
           try {
             if (key in obj) return 1;
           } catch (e) {
-            // #2180 — `key in revokedProxy` throws TypeError; propagate it.
-            if (_isRevokedProxyError(e)) throw e;
+            // #2180/#2617 — `key in revokedProxy` throws TypeError; a user
+            // Proxy's `has` trap may also throw (abrupt completion). Propagate
+            // both instead of swallowing into the sidecar fallback.
+            _rethrowIfProxyOrRevoked(e, obj);
             /* opaque struct or non-object obj */
           }
           const sc = _wasmStructProps.get(obj);
@@ -7500,7 +7550,12 @@ assert._isSameValue = isSameValue;
           }
           try {
             return Object.preventExtensions(obj);
-          } catch {
+          } catch (e) {
+            // #2617 — a user Proxy's preventExtensions trap may throw, or the
+            // host engine's §10.5 invariant may throw; propagate for a tracked
+            // user Proxy. Non-proxy objects keep the swallow-and-return-self
+            // behavior (sloppy-mode-tolerant).
+            _rethrowIfProxyOrRevoked(e, obj);
             return obj;
           }
         };
@@ -8393,7 +8448,13 @@ assert._isSameValue = isSameValue;
           if (obj === undefined) throw new TypeError("Cannot convert undefined to object");
           try {
             return Object.getPrototypeOf(obj);
-          } catch {
+          } catch (e) {
+            // #2617 — for a user Proxy, the host engine's §10.5.1 invariant
+            // (getPrototypeOf trap result must be Object|null; trap may also
+            // throw) is exactly what the program must observe. Propagate it
+            // instead of coercing to null. Non-proxy opaque structs keep the
+            // null fallback (their getPrototypeOf is genuinely absent).
+            _rethrowIfProxyOrRevoked(e, obj);
             return null;
           }
         };
@@ -9683,9 +9744,18 @@ assert._isSameValue = isSameValue;
               const k = typeof key === "symbol" ? key : String(key);
               return delete obj[k] ? 1 : 0;
             } catch (e) {
-              // #2180 — deleting from a revoked proxy throws TypeError; propagate it.
+              // #2180 — deleting from a revoked proxy throws TypeError; propagate.
               if (_isRevokedProxyError(e)) throw e;
-              // Non-configurable in strict mode throws TypeError; report failure.
+              // #2617 — a user Proxy's deleteProperty trap that THROWS (abrupt
+              // completion) must propagate. BUT the bundled runtime is strict
+              // (ES module), so `delete obj[k]` ALSO throws a TypeError when the
+              // trap merely RETURNS FALSE ("trap returned falsish") — which in
+              // the user program's NON-strict context must be a plain `false`
+              // (return 0), not a throw (test262 deleteProperty/return-false-not-
+              // strict.js, flags:[noStrict]). Distinguish: re-throw a user-Proxy
+              // exception only when it is NOT the strict-delete result coercion.
+              if (_isUserProxy(obj) && !_isStrictDeleteFalsishError(e)) throw e;
+              // Trap returned false (or non-configurable refusal) → report failure.
               return 0;
             }
           }

--- a/tests/issue-2617.test.ts
+++ b/tests/issue-2617.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { compileAndInstantiate } from "../src/runtime-instantiate.js";
+
+// #2617 — a Proxy trap's abrupt completion (throw) and the host engine's §10.5
+// invariant TypeErrors must PROPAGATE through the boundary helpers, not be
+// swallowed by the try/catch that falls through to the struct/undefined path.
+// Gated strictly on `_isUserProxy(obj)` so the non-proxy fast path is unchanged.
+
+async function run(source: string): Promise<unknown> {
+  const exports = await compileAndInstantiate(source);
+  return (exports as { test?: () => unknown }).test?.();
+}
+
+describe("#2617 — Proxy trap throws + §10.5 invariants propagate", () => {
+  it("a `has` trap that throws propagates (was swallowed → false)", async () => {
+    const src = `
+      export function test(): number {
+        const p = new Proxy({}, { has: function () { throw new RangeError("x"); } });
+        try {
+          const r = ("a" in p);
+          return 0; // must not reach — the throw must propagate
+        } catch (e) {
+          return e instanceof RangeError ? 1 : 2;
+        }
+      }
+    `;
+    expect(await run(src)).toBe(1);
+  });
+
+  it("a getPrototypeOf trap returning a non-object throws TypeError (§10.5.1 invariant)", async () => {
+    const src = `
+      export function test(): number {
+        const p = new Proxy({}, { getPrototypeOf: function () { return 1 as any; } });
+        try {
+          Object.getPrototypeOf(p);
+          return 0; // must not reach — invariant TypeError
+        } catch (e) {
+          return e instanceof TypeError ? 1 : 2;
+        }
+      }
+    `;
+    expect(await run(src)).toBe(1);
+  });
+
+  it("a get trap that throws propagates", async () => {
+    const src = `
+      export function test(): number {
+        const p = new Proxy({ attr: 1 }, { get: function () { throw new Error("g"); } });
+        try {
+          const v = p.attr;
+          return 0;
+        } catch (e) {
+          return 1;
+        }
+      }
+    `;
+    expect(await run(src)).toBe(1);
+  });
+
+  it("a deleteProperty trap that THROWS propagates", async () => {
+    const src = `
+      export function test(): number {
+        const p = new Proxy({}, { deleteProperty: function () { throw new RangeError("d"); } });
+        try {
+          delete (p as any).attr;
+          return 0;
+        } catch (e) {
+          return e instanceof RangeError ? 1 : 2;
+        }
+      }
+    `;
+    expect(await run(src)).toBe(1);
+  });
+
+  it("a deleteProperty trap RETURNING false does NOT throw in non-strict context (returns false)", async () => {
+    // Regression guard: the always-strict runtime's "trap returned falsish"
+    // TypeError must be mapped to a plain `false`, not propagated.
+    const src = `
+      export function test(): number {
+        const p = new Proxy({}, { deleteProperty: function () { return false; } });
+        let threw = 0;
+        let result = 1;
+        try {
+          result = (delete (p as any).attr) ? 1 : 0;
+        } catch (e) {
+          threw = 1;
+        }
+        // must NOT throw, and delete must yield false (0)
+        return threw === 0 && result === 0 ? 1 : 0;
+      }
+    `;
+    expect(await run(src)).toBe(1);
+  });
+
+  it("a non-proxy struct read is unaffected (fast path unchanged)", async () => {
+    const src = `
+      export function test(): number {
+        const o = { a: 3, b: 7 };
+        return o.a * o.b; // direct struct.get, no boundary helper
+      }
+    `;
+    expect(await run(src)).toBe(21);
+  });
+});


### PR DESCRIPTION
## #2617 — Proxy (host): trap throws + §10.5 invariant TypeErrors propagate

Slice of #1355; builds on #2615/#2616 trap infrastructure. The largest remaining host-mode Proxy bucket.

### Root cause
The boundary helpers (`__extern_get`/`__extern_has`/`__extern_set`, `__delete_property`, `__getPrototypeOf`, `__object_preventExtensions`) wrapped their host MOP read in a try/catch that swallowed **all** exceptions except the revoked-proxy one, falling through to a struct/undefined path. For a **user Proxy** that swallows exactly what the program must observe: the trap's abrupt completion, or the host engine's §10.5 invariant TypeError. Separately, `'k' in p` constant-folded to the target struct's field membership (the TS type of a `new Proxy` var is its TARGET type), so `__extern_has` — and the `has` trap — never ran.

### Fix
**Runtime (`src/runtime.ts`):** shared `_isUserProxy(obj)` + `_rethrowIfProxyOrRevoked(e,obj)`: re-throw when the receiver is a tracked user Proxy (or the pre-existing revoked case); otherwise fall through (non-proxy struct fast path byte-for-byte unchanged). Applied to `__extern_get`, `__extern_has`, `_safeSet`, `__getPrototypeOf` (was coercing the §10.5.1 invariant TypeError to `null`), `__object_preventExtensions`. `__delete_property` re-throws a THROWN trap but maps the always-strict runtime's "trap returned falsish" delete-result TypeError to `return 0` — in non-strict user context `delete` yields false, not a throw (`deleteProperty/return-false-not-strict.js`); `_isStrictDeleteFalsishError` makes the distinction. Helpers calling the native method with no try/catch (getOwnPropertyDescriptor, isExtensible, defineProperty_desc, reflect_*) already propagate — unchanged.

**Codegen (`src/codegen/binary-ops.ts`):** the `in` operator now trusts the ACTUAL slot type — when the receiver is an identifier slotted `externref`/`anyref` (via #2615), route through `__extern_has` instead of folding to the target struct's field membership.

### Results (local harness, gc; merge_group is authoritative)
- whole `built-ins/Proxy` vs current main (#2615+#2616): **+17 pass, 0 regressions** (107 → 124)
- gate set (`return-is-abrupt` + invariant): 12 pass / 1 err
- `built-ins/Reflect`: unchanged 82/19/52

Cumulative Proxy: 78 → 83 (#2615) → 107 (#2616) → **124 (#2617)**.

### Validation
`tsc --noEmit` clean · `prettier` clean · `tests/issue-2617.test.ts` 6/6 (incl. the non-strict-delete-returns-false regression guard + non-proxy fast-path guard). Boundary-helper change with blast radius → relying on merge_group for authoritative full validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA