### PR TITLE
fix(#2620): clean-CE refusal for standalone subclass of native collection (Set/Map/WeakMap/WeakSet)

### DIFF
--- a/plan/issues/2620-standalone-extends-set-late-import-desync.md
+++ b/plan/issues/2620-standalone-extends-set-late-import-desync.md
@@ -1,9 +1,11 @@
 ---
 id: 2620
 title: "Standalone `class X extends Set/Map` — synthetic accessor late-import index-shift (-1 global) + host-import leak"
-status: ready
+status: done
 sprint: Backlog
 created: 2026-06-22
+completed: 2026-06-22
+assignee: sendev-flatten
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -13,6 +15,7 @@ language_feature: Set, class
 goal: standalone-mode
 parent: 2162
 depends_on: 2043
+follow_up: 2622
 ---
 
 # #2620 — Standalone subclass-of-native-collection compile errors (split from #2606 Bug B)
@@ -76,3 +79,65 @@ This is **two intertwined defects**, both substrate-deep:
 
 The ~21 instanceof/sameValue-bool rows (#2605) and the ~7 null/undefined element
 rows (#2606 Bug A) are already fixed and merged separately.
+
+## Resolution (2026-06-22, sendev-flatten — clean-CE refusal, native subclass parked to #2622)
+
+Lead-approved scope (path 1): land the SAFE, right-sized fix in the index-shift
+lane now; park the native subclass (the only thing that would *pass* the rows) to
+a substrate follow-up. Confirmed against current main both defects reproduce, and
+that **passing** the 7 `Set/prototype/*/subclass-receiver-methods.js` rows
+requires the full native subclass (the tests assert `union` reads `[[SetData]]`
+directly — `sizeCount/hasCount/keysCount === 0` — plus native spread +
+`instanceof Set`/`!instanceof MySet` discrimination). That is collection-runtime
+substrate (#2162-scale), not an index-shift point-fix → split to **#2622**.
+
+### Root cause (confirmed)
+
+`Set`/`Map`/`WeakMap`/`WeakSet` are in `BUILTIN_PARENTS_HOST_CONSTRUCTIBLE`
+(`builtin-tags.ts`), so `class X extends Set` takes the generic host-constructible
+subclass path: `new X()`/`super()` lower to the HOST `__new_Set` import. Under
+`nativeStrings` (standalone/wasi) there is no JS host:
+
+- **Defect A (host-import leak):** even a bare `class MySet extends Set {}` leaks
+  `env::__new_Set` → `WebAssembly.instantiate` fails ("module is not an object").
+- **Defect B (#2043 index-shift):** the synthetic `<Class>_<method>` accessor
+  (`MySet_size`/`MySet_has`) desyncs across the addUnionImports/
+  flushLateImportShifts reorder → invalid Wasm (`-1` global / a stale call
+  funcIdx — on current main it surfaces as `MySet_has: call[0] expected externref,
+  found local.get (ref null N)`).
+
+The base collections ARE native-served (#1103a/#2162) — base `new Set([...])` is
+intercepted to a `$Map`-backed instance in `new-super.ts` — but that interception
+matches only the literal `Set`/`Map`/… constructor name, never a subclass.
+
+### Fix (this PR)
+
+Refuse a standalone subclass of a native-collection builtin at compile time —
+clean `Codegen error:` (success:false, empty binary), never invalid Wasm, never a
+leaked host import (the #1888 dual-mode invariant: "uncertainty ⇒ fail loud").
+
+- `src/codegen/builtin-tags.ts` — new `NATIVE_COLLECTION_BUILTINS` set +
+  `isNativeCollectionBuiltin(name)`.
+- `src/codegen/class-bodies.ts` — at the heritage-clause chokepoint, BEFORE the
+  externref-backed marking, if `ctx.nativeStrings && parentStructTypeIdx ===
+  undefined && isNativeCollectionBuiltin(parent)`: queue the refusal and `break`
+  (so the host-leak / invalid-Wasm path is never entered). gc/host mode is
+  untouched (the refusal is `nativeStrings`-gated) — the externClass host path
+  still compiles the subclass there.
+
+Both defects become a single clean CE. Zero test262 regression risk: the rows
+already failed (A = instantiate-fail, B = invalid-Wasm), so a graceful CE is
+strictly ≥ the prior state. Validated: `extends Error/TypeError/Uint8Array`
+standalone (#2029) and gc/host `extends Set` are unaffected; #1455's 2 failures
+(`extends WeakRef`, `TypeError instanceof` chain) are PRE-EXISTING on main,
+A/B-confirmed, unrelated (those aren't collection builtins).
+
+Test: `tests/issue-2620-extends-set-standalone-refusal.test.ts`.
+
+### Follow-up
+
+**#2622** — native `extends Set/Map/WeakMap/WeakSet` subclass (native
+`$Map`-backed construction + `[[SetData]]`/`[[MapData]]` direct set-algebra +
+native iteration + `instanceof` discrimination) → the real +7
+subclass-receiver-methods rows. Value-rep / collection-runtime lane (#2162/#2580
+M2).

--- a/plan/issues/2622-native-extends-collection-subclass.md
+++ b/plan/issues/2622-native-extends-collection-subclass.md
@@ -1,0 +1,68 @@
+---
+id: 2622
+title: "Standalone native `class X extends Set/Map/WeakMap/WeakSet` subclass — construction + [[SetData]] algebra + iteration + instanceof"
+status: backlog
+sprint: Backlog
+created: 2026-06-22
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: feature
+area: collections
+language_feature: Set, Map, class
+goal: standalone-mode
+parent: 2162
+depends_on: 2620
+---
+
+# #2622 — Native subclass of a native-collection builtin (standalone)
+
+Substrate follow-up split from **#2620**. #2620 landed the safe index-shift-lane
+fix: a standalone subclass of a native-collection builtin
+(`Set`/`Map`/`WeakMap`/`WeakSet`) is now a **clean compile error** (no
+host-import leak, no invalid Wasm). This issue is the real feature — make such a
+subclass *work* natively so the conformance rows pass.
+
+## Problem
+
+`class MySet extends Set {}` (and Map/WeakMap/WeakSet) under `--target
+standalone`/`wasi` is currently refused (#2620). The base collections are served
+by the WasmGC-native `$Map` runtime (#1103a/#2162), but a *subclass* has no
+native path: the generic host-constructible subclass machinery
+(`BUILTIN_PARENTS_HOST_CONSTRUCTIBLE`) lowers `new`/`super` to the host
+`__new_<Name>` import, which standalone cannot satisfy.
+
+## Acceptance criteria (the rows)
+
+`test/built-ins/Set/prototype/{union,intersection,difference,symmetricDifference,
+isSubsetOf,isSupersetOf,isDisjointFrom}/subclass-receiver-methods.js` (~7 rows).
+Each constructs `class MySet extends Set { size(){…} has(){…} keys(){…} }`,
+`const s1 = new MySet([1,2])`, then e.g. `s1.union(s2)` and asserts:
+
+- `[...combined]` spreads the right elements (native iteration over the result);
+- `combined instanceof Set === true` and `combined instanceof MySet === false`
+  (the result is a base Set, not the subclass);
+- `sizeCount === hasCount === keysCount === 0` — the set-algebra methods read the
+  internal `[[SetData]]` slot directly and MUST NOT call the subclass's
+  overridden `size`/`has`/`keys`.
+
+## Direction
+
+- Route `class X extends Set/Map/WeakMap/WeakSet` under `nativeStrings` to a
+  native `$Map`-backed instance (the way base `new Set([...])` is intercepted in
+  `new-super.ts`), instead of the host-constructible path. The subclass instance
+  needs the `$Map` backing PLUS room for the subclass's own fields (a hybrid
+  struct, or a `$Map`-carrying field on the user struct).
+- `super.size`/`super.has`/`super.add`/`super.keys` in subclass methods → native
+  `__map_*`/`__set_*` helpers (not the host externClass dispatch).
+- Set-algebra methods on the subclass receiver read `[[SetData]]` directly
+  (never the overridden methods — the conformance assertion).
+- `instanceof` discrimination: `combined instanceof Set` true,
+  `instanceof MySet` false (the algebra methods return a base Set).
+- Remove the #2620 refusal (`isNativeCollectionBuiltin` guard in
+  `class-bodies.ts`) once this lands.
+
+## Lane
+
+Value-rep / collection-runtime substrate (#2162 / #2580 M2). Index-shift-sensitive
+and broad-impact — validate via merge_group / full local-ci, not a scoped sweep.

--- a/src/codegen/builtin-tags.ts
+++ b/src/codegen/builtin-tags.ts
@@ -239,3 +239,34 @@ export const BUILTIN_PARENTS_HOST_CONSTRUCTIBLE: ReadonlySet<BuiltinTypeName> = 
 export function isHostConstructibleBuiltin(name: string): boolean {
   return isBuiltinTypeName(name) && BUILTIN_PARENTS_HOST_CONSTRUCTIBLE.has(name as BuiltinTypeName);
 }
+
+/**
+ * (#2620) The native-collection builtins. In `nativeStrings` mode
+ * (`--target standalone`/`wasi`) these are served by the WasmGC-native
+ * Map/Set runtime (map-runtime.ts / set-runtime.ts / weak-collections-runtime.ts,
+ * #1103a/#2162) and are deliberately NOT registered as externClasses — base
+ * `new Set([...])` is intercepted to the native `$Map`-backed instance instead
+ * of leaking a `__new_Set` host import.
+ *
+ * A *subclass* (`class X extends Set {}`), however, still routes through the
+ * generic host-constructible path (these names ARE in
+ * `BUILTIN_PARENTS_HOST_CONSTRUCTIBLE`): under standalone that both leaks the
+ * `__new_<Name>` host import AND desyncs the synthetic `<Class>_<method>`
+ * accessor across the late-import shift (the #2043 index-shift class → invalid
+ * Wasm). A native subclass (native construction + direct `[[SetData]]`
+ * set-algebra + native iteration + `instanceof` discrimination) is the
+ * value-rep/collection-runtime substrate (#2162-scale), tracked separately.
+ * Until then, a standalone subclass of one of these is refused at compile time
+ * (clean CE, never invalid Wasm / never a leaked host import). See the
+ * refusal in class-bodies.ts.
+ */
+export const NATIVE_COLLECTION_BUILTINS: ReadonlySet<string> = new Set<string>(["Set", "Map", "WeakMap", "WeakSet"]);
+
+/**
+ * (#2620) Returns true if `name` is a native-collection builtin
+ * (Set/Map/WeakMap/WeakSet) — used to refuse a standalone subclass of one of
+ * them (see {@link NATIVE_COLLECTION_BUILTINS}).
+ */
+export function isNativeCollectionBuiltin(name: string): boolean {
+  return NATIVE_COLLECTION_BUILTINS.has(name);
+}

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -7,7 +7,7 @@
 import { ts } from "../ts-api.js";
 import { isVoidType, unwrapPromiseType } from "../checker/type-mapper.js";
 import type { FieldDef, Instr, StructTypeDef, ValType } from "../ir/types.js";
-import { isHostConstructibleBuiltin } from "./builtin-tags.js";
+import { isHostConstructibleBuiltin, isNativeCollectionBuiltin } from "./builtin-tags.js";
 import { classMemberFuncKey } from "./class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
 import { getOrAssignClassNewTargetId } from "./new-target.js"; // (#2023)
 import { popBody, pushBody } from "./context/bodies.js";
@@ -542,6 +542,38 @@ export function collectClassDeclaration(
           parentFields = ctx.structFields.get(parentClassName) ?? [];
           // Record parent-child relationship
           ctx.classParentMap.set(className, parentClassName);
+          // (#2620) A subclass of a native-collection builtin (Set/Map/WeakMap/
+          // WeakSet) under nativeStrings (`--target standalone`/`wasi`) cannot
+          // take the host-constructible path below: there is no JS host, so
+          // `super(...)`/`new Sub()` lowering to `__new_<Parent>` would leak an
+          // unsatisfiable `env::__new_Set` import (defect A), and the synthetic
+          // `<Class>_<method>` accessor desyncs across the late-import shift
+          // (defect B — the #2043 invalid-Wasm class, e.g. `MySet_has`/`_size`
+          // baking a `-1` global / a stale call funcIdx). The base collections
+          // ARE served by the WasmGC-native runtime (#1103a/#2162), but a true
+          // native *subclass* (native `$Map`-backed construction + direct
+          // `[[SetData]]` set-algebra + native iteration + `instanceof`
+          // discrimination — the Set/prototype/*/subclass-receiver-methods rows)
+          // is the collection-runtime substrate, tracked separately. Until then,
+          // refuse loudly (clean compile error, never invalid Wasm / never a
+          // leaked host import — the #1888 dual-mode invariant). gc/host mode is
+          // unaffected: the externClass host path handles the subclass there.
+          if (parentStructTypeIdx === undefined && ctx.nativeStrings && isNativeCollectionBuiltin(parentClassName)) {
+            reportError(
+              ctx,
+              decl,
+              `Codegen error: 'class ${className} extends ${parentClassName}' is not yet ` +
+                `supported in --target standalone (#2620). The base ${parentClassName} is served ` +
+                `by the WasmGC-native collection runtime, but a native SUBCLASS (with [[SetData]]/` +
+                `[[MapData]] direct access for the set-algebra methods) is not implemented yet — ` +
+                `routing it through the host path would leak an env::__new_${parentClassName} import ` +
+                `or emit invalid Wasm. Use ${parentClassName} directly, or recompile without ` +
+                `--target standalone.`,
+            );
+            // Skip the externref-backed marking so the host-leak/invalid-Wasm
+            // path is never entered; the queued error fails the compile.
+            break;
+          }
           // (#1366a) Detect built-in parent that is host-constructible (Error
           // family). Such subclasses get an externref-backed instance: the
           // constructor returns externref and `super(...)` lowers to

--- a/tests/issue-2620-extends-set-standalone-refusal.test.ts
+++ b/tests/issue-2620-extends-set-standalone-refusal.test.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2620 (split from #2606 Bug B) — `class X extends Set/Map/WeakMap/WeakSet`
+// under `--target standalone`/`wasi` (nativeStrings) had TWO substrate defects:
+//
+//   A. Host-import leak: even a bare `class MySet extends Set {}` lowered
+//      construction through the host-constructible path (these names are in
+//      BUILTIN_PARENTS_HOST_CONSTRUCTIBLE), leaking an unsatisfiable
+//      `env::__new_Set` import — the module failed to instantiate.
+//   B. Late-import index-shift (#2043 class): the synthetic `<Class>_<method>`
+//      accessor (`MySet_size`/`MySet_has`) desynced across the
+//      addUnionImports/flushLateImportShifts reorder, baking a `-1` global /
+//      a stale call funcIdx → invalid Wasm.
+//
+// The base collections ARE served by the WasmGC-native runtime (#1103a/#2162),
+// but a true native SUBCLASS (native `$Map`-backed construction + direct
+// `[[SetData]]` set-algebra + native iteration + `instanceof` discrimination —
+// the Set/prototype/*/subclass-receiver-methods rows) is the collection-runtime
+// substrate, tracked separately (#2162/#2580-M2 lane). Until that lands, a
+// standalone subclass of one of these is REFUSED at compile time: a clean
+// `Codegen error:` (success:false), never invalid Wasm and never a leaked host
+// import (the #1888 dual-mode invariant — "uncertainty ⇒ fail loud").
+//
+// This guards: (1) the standalone refusal fires (clean CE, no invalid binary,
+// no env import leak); (2) gc/host mode is UNAFFECTED (the externClass host path
+// still compiles the subclass).
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const COLLECTIONS = ["Set", "Map", "WeakMap", "WeakSet"] as const;
+
+/**
+ * Standalone: the subclass must be a CLEAN compile error citing #2620 — never a
+ * leaked `env::__new_*` import, never invalid Wasm.
+ */
+async function expectStandaloneRefusal(parent: string, body: string): Promise<void> {
+  const src = `class Sub extends ${parent}<number> { ${body} }
+    export function test(): number { return 0; }`;
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, `expected a clean refusal, but compile succeeded for extends ${parent}`).toBe(false);
+  const errs = r.errors.filter((e) => e.severity === "error").map((e) => e.message);
+  expect(
+    errs.some((m) => m.includes("#2620")),
+    `expected a #2620 refusal for extends ${parent}, got: ${errs.join(" | ")}`,
+  ).toBe(true);
+  // No env host-import leak survived into the (empty) binary.
+  const env = (r.imports ?? []).filter((i: { module?: string }) => i.module === "env");
+  expect(env.length, `extends ${parent} leaked env imports: ${env.map((i: any) => i.name).join(",")}`).toBe(0);
+}
+
+describe("#2620 standalone subclass-of-native-collection refusal", () => {
+  for (const parent of COLLECTIONS) {
+    it(`standalone refuses bare class extends ${parent} (was: env.__new_${parent} leak)`, async () => {
+      await expectStandaloneRefusal(parent, "");
+    });
+  }
+
+  it("standalone refuses extends Set with size/has/keys overrides (was: #2043 invalid Wasm)", async () => {
+    // The Set/prototype/*/subclass-receiver-methods.js shape that emitted the
+    // `MySet_has`/`MySet_size` late-import index-shift invalid Wasm.
+    await expectStandaloneRefusal(
+      "Set",
+      "size(...rest: any[]): any { return rest.length; } has(...rest: any[]): any { return rest.length; } keys(...rest: any[]): any { return rest.length; }",
+    );
+  });
+
+  it("standalone refusal is a CLEAN compile error — never invalid Wasm, never a host import", async () => {
+    const r = await compile(
+      `class MySet extends Set<number> {}
+       export function test(): number { return 0; }`,
+      { target: "standalone" },
+    );
+    expect(r.success).toBe(false);
+    // binary is empty on a failed compile — there is no poisoned module to validate.
+    expect(r.binary.length).toBe(0);
+  });
+
+  // gc/host mode must be UNAFFECTED — the externClass host path compiles the
+  // subclass there (the refusal is nativeStrings-gated only).
+  it("gc/host mode still compiles a Set subclass (refusal is standalone-only)", async () => {
+    const r = await compile(
+      `class MySet extends Set<number> {}
+       export function test(): number { const s = new MySet([1, 2]); return 0; }`,
+    );
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    // gc/host path may legitimately use the __new_Set host import — that's fine.
+    await WebAssembly.compile(r.binary);
+  });
+});


### PR DESCRIPTION
## #2620 — standalone `class X extends Set/Map/WeakMap/WeakSet`

Split from #2606 Bug B; the #2043-class index-shift defect was routed to the index-shift owner.

### Problem (two intertwined defects, both reproduced on current main)
- **A — host-import leak:** even a bare `class MySet extends Set {}` lowered construction through the host-constructible subclass path (`Set/Map/WeakMap/WeakSet` are in `BUILTIN_PARENTS_HOST_CONSTRUCTIBLE`), leaking an unsatisfiable `env::__new_Set` import → `WebAssembly.instantiate` fails.
- **B — late-import index-shift (#2043 class):** the synthetic `<Class>_<method>` accessor (`MySet_size`/`MySet_has`) desynced across the `addUnionImports`/`flushLateImportShifts` reorder → invalid Wasm (a `-1` global / a stale call funcIdx; surfaces today as `MySet_has: call[0] expected externref, found local.get (ref null N)`).

### Why a point index-shift fix isn't enough
The base collections are WasmGC-native-served (#1103a/#2162), and base `new Set([...])` is intercepted to a `$Map`-backed instance — but that interception matches only the literal constructor name, never a subclass. **Passing** the 7 `Set/prototype/*/subclass-receiver-methods.js` rows requires a true native subclass: the tests assert `union` reads `[[SetData]]` directly (`sizeCount/hasCount/keysCount === 0`), native spread, and `instanceof Set` true / `instanceof MySet` false. That is collection-runtime substrate (#2162-scale), **split to follow-up #2622**.

### Fix (this PR — the safe index-shift-lane fix)
Under `nativeStrings`, refuse a subclass of a native-collection builtin at compile time: a clean `Codegen error:` (success:false, empty binary), never invalid Wasm and never a leaked host import (the #1888 dual-mode invariant — "uncertainty ⇒ fail loud"). Both defects collapse to one graceful CE.

- `src/codegen/builtin-tags.ts` — `NATIVE_COLLECTION_BUILTINS` + `isNativeCollectionBuiltin(name)`.
- `src/codegen/class-bodies.ts` — refuse at the heritage-clause chokepoint, BEFORE the externref-backed marking, then `break` (so the host-leak/invalid-Wasm path is never entered).

### Validation
- **Zero regression risk:** the rows already failed (A = instantiate-fail, B = invalid-Wasm), so a CE is strictly ≥ the prior state.
- New test `tests/issue-2620-extends-set-standalone-refusal.test.ts` (7 tests: all 4 collections refused standalone, the method-override shape refused, refusal is a clean empty-binary CE, and gc/host mode still compiles the subclass).
- `extends Error/TypeError/Uint8Array` standalone (#2029) and gc/host `extends Set` are unaffected (the refusal is `nativeStrings`-gated + collection-only). #1455's 2 failures (`extends WeakRef`, `TypeError instanceof` chain) are PRE-EXISTING on main, A/B-confirmed, unrelated.
- tsc / prettier / biome / coercion-sites gates clean.

### Follow-up
**#2622** — native `extends Set/Map/WeakMap/WeakSet` subclass (native construction + `[[SetData]]` algebra + iteration + instanceof) → the real +7 rows. Value-rep / collection-runtime lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA