### PR TITLE
fix(#1528/#86): route capability-ctor executor-param calls through __call_function

### DIFF
--- a/plan/issues/1528-non-constructor-typeerror-promise-and-species.md
+++ b/plan/issues/1528-non-constructor-typeerror-promise-and-species.md
@@ -642,3 +642,42 @@ sub-case — `__fn_tramp_Constructor_*` `illegal cast` (e.g.
 is the `__construct_closure` *codegen export* (spec step 4), distinct from the
 host-helper ordinary-function path delivered here. Issue stays `in-progress` for
 that arm; #2614 remains blocked on it.
+
+## Class-ctor arm — implemented + measured verdict (2026-06-22, sd-1838, post-#1940-merge)
+
+**The bounded surface fix is done; the headline cluster is a larger follow-up.**
+
+### Done (committed, branch issue-1528-classctor-arm, 0 regressions)
+`calleeIsCapabilityCtorParam` (calls.ts) — syntactic gate: a param whose declaring
+function flows to a `Promise.{all,allSettled,race,any}.call(fn, …)` site. Such a
+param (`executor`) is UNTYPED (`any`, no call signatures) and V8 fills it with a
+HOST function when it does `Construct(Constructor, «executor»)` (via #1940's
+bridge). The no-call-signature fallback `ref.cast`s it to a closure struct →
+`illegal cast in Constructor()`. Fixed by routing the call through the existing
+`__call_function` host helper via an early-return BEFORE the call-sig gate
+(alongside the bound-function path). Min repro passes; +2 peripheral rows
+(`capability-executor-called-twice`, `species-get-error`). JS-host only; the
+narrow gate preserves the #1941 dual-mode guarantee.
+
+### NOT closed (larger follow-up — beyond the param-call surface fix)
+1. **Multi-hop host→wasm callback cast** (`allSettled/call-resolve-element`,
+   `race/resolve-from-same-thenable`): `Constructor` passes its INNER `resolve`
+   (a wasm closure) to the host `executor`; when the host thenable later calls
+   `resolve(value)` BACK, the host→wasm callback path casts and traps. The
+   executor-call fix routes the OUTBOUND call; the INBOUND callback of a
+   wasm-closure-passed-to-host is a separate cast site.
+2. **Species / ctor identity** (all `ctx-ctor` rows): `instance.constructor ===
+   SubPromise` requires the capability's `.constructor`/prototype identity to
+   survive the bridge — a `_wrapCallableForHost` `.prototype`/species concern.
+3. **Observable-resolve identity** (`invoke-resolve` all/race): still asserts
+   `nextValue === current` (the #2614 sandbox-`Promise.resolve` coupling); the
+   observable-resolve change was deliberately NOT stacked here (it couples to
+   #1 and #2).
+
+### Recommendation
+The executor-routing substrate is useful and clean, but the cluster's dominant
+rows need #1 (multi-hop callback cast) + #2 (species identity) + #3
+(observable-resolve), which together are a sprint-scale capability-cluster effort,
+not this arm. Ship the arm small OR fold it into that larger effort. #2614 stays
+blocked on #1/#2/#3; #2618 (Proxy apply/construct) shares the same
+`__fn_tramp_Constructor` dispatch and sequences after.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -1565,6 +1565,75 @@ function calleeIsPromiseExecutorParam(ctx: CodegenContext, expr: ts.Expression):
 }
 
 /**
+ * (#1528 / #56 follow-up — class-ctor arm) Is `expr` an identifier resolving to a
+ * parameter of a function that is used as a Promise-combinator CAPABILITY
+ * CONSTRUCTOR — i.e. the `executor` of a `function Constructor(executor){…}` that
+ * flows to `Promise.{all,allSettled,race,any}.call(Constructor, …)`?
+ *
+ * V8's `NewPromiseCapability(Constructor)` does `Construct(Constructor, «executor»)`
+ * (run via #1632b-2's closure-construct bridge). Inside the compiled body the call
+ * `executor(resolve, reject)` is a call of a function-typed PARAMETER whose value
+ * is a HOST function V8 supplied — NOT a wasm closure struct. The default
+ * closure-struct `ref.cast`/`call_ref` dispatch then `illegal cast`s; such a param
+ * must take the `__call_function` host-callable arm instead. This mirrors the
+ * Promise-executor-param case (#2028) but for the capability-constructor entry.
+ *
+ * Gate is SYNTACTIC and narrow (NOT whole-program escape analysis), to preserve
+ * the #1941 dual-mode guarantee: the param's declaring function must be a
+ * `function` declaration / named function-expression whose identifier appears as
+ * the FIRST argument of a `Promise.<combinator>.call(...)` somewhere in the
+ * source file. Only such functions are entered as capability constructors with
+ * host-supplied params; ordinary callable params never match.
+ */
+function calleeIsCapabilityCtorParam(ctx: CodegenContext, expr: ts.Expression): boolean {
+  if (!ts.isIdentifier(expr)) return false;
+  const sym = ctx.checker.getSymbolAtLocation(expr);
+  const decl = sym?.valueDeclaration;
+  if (!decl || !ts.isParameter(decl)) return false;
+  // The declaring function: a FunctionDeclaration, or a function/arrow expression
+  // bound to a variable (so it has a stable referenceable name).
+  const fn = decl.parent;
+  let fnName: string | undefined;
+  if (ts.isFunctionDeclaration(fn) && fn.name) {
+    fnName = fn.name.text;
+  } else if (
+    (ts.isFunctionExpression(fn) || ts.isArrowFunction(fn)) &&
+    fn.parent &&
+    ts.isVariableDeclaration(fn.parent) &&
+    ts.isIdentifier(fn.parent.name)
+  ) {
+    fnName = fn.parent.name.text;
+  }
+  if (fnName === undefined) return false;
+  // Scan the source file for `Promise.<combinator>.call(<fnName>, …)`.
+  const COMBINATORS = new Set(["all", "allSettled", "race", "any"]);
+  const sf = decl.getSourceFile();
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    // `Promise.<combinator>.call(<id>, …)` — `(Promise.X).call`.
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === "call" &&
+      ts.isPropertyAccessExpression(node.expression.expression) &&
+      ts.isIdentifier(node.expression.expression.expression) &&
+      node.expression.expression.expression.text === "Promise" &&
+      COMBINATORS.has(node.expression.expression.name.text)
+    ) {
+      const firstArg = node.arguments[0];
+      if (firstArg && ts.isIdentifier(firstArg) && firstArg.text === fnName) {
+        found = true;
+        return;
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return found;
+}
+
+/**
  * (#1337) Emit a call to a host bound-function externref via the
  * `__call_function(fn, thisArg, argsArray)` host helper. The bound function
  * already carries [[BoundThis]] and [[BoundArguments]], so `thisArg` is passed
@@ -11313,7 +11382,11 @@ function compileCallExpression(
             // (which traps on the null cast). Narrowly gated to Promise-executor
             // params so the #1941 dual-mode guarantee for ordinary callable
             // params is preserved.
-            (calleeMayBeHostCallable(ctx, expr.expression) || calleeIsPromiseExecutorParam(ctx, expr.expression));
+            (calleeMayBeHostCallable(ctx, expr.expression) ||
+              calleeIsPromiseExecutorParam(ctx, expr.expression) ||
+              // (#1528 / #56 class-ctor arm) `executor` param of a capability
+              // constructor (`Promise.X.call(Constructor, …)`) is host-supplied.
+              calleeIsCapabilityCtorParam(ctx, expr.expression));
 
           let fallbackInstrs: Instr[] | null = null;
           let dispatchOuterBody: Instr[] | null = null;

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -11132,6 +11132,22 @@ function compileCallExpression(
         const hostCall = emitBoundFunctionCall(ctx, fctx, expr);
         if (hostCall !== null) return hostCall;
       }
+      // (#1528 / #56 follow-up — class-ctor arm) `executor(...)` inside a function
+      // used as a Promise-combinator capability constructor
+      // (`Promise.X.call(Constructor, …)` → V8 `Construct(Constructor, «executor»)`
+      // via the #1632b-2 bridge). The `executor` PARAM is an UNTYPED (`any`) value
+      // — no call signatures — so it never reaches the callable-param closure
+      // dispatch below; the no-sig fallback would `ref.cast` it to a closure
+      // struct and trap (`illegal cast in Constructor()`), because V8 supplies a
+      // HOST function there, not a wasm closure. Route it through the same
+      // `__call_function` host helper the bound-function path uses (it packs args
+      // into a JS array and calls `Reflect.apply`). JS-host only; narrow syntactic
+      // gate (the fn flows to a combinator capability-ctor site), so the #1941
+      // dual-mode guarantee for ordinary callable params is preserved.
+      if (isKnownVariable && !ctx.standalone && !noJsHost(ctx) && calleeIsCapabilityCtorParam(ctx, expr.expression)) {
+        const hostCall = emitBoundFunctionCall(ctx, fctx, expr);
+        if (hostCall !== null) return hostCall;
+      }
       if (callSigs && callSigs.length > 0) {
         const sig = callSigs[0]!;
         const sigParamCount = sig.parameters.length;
@@ -11382,11 +11398,12 @@ function compileCallExpression(
             // (which traps on the null cast). Narrowly gated to Promise-executor
             // params so the #1941 dual-mode guarantee for ordinary callable
             // params is preserved.
-            (calleeMayBeHostCallable(ctx, expr.expression) ||
-              calleeIsPromiseExecutorParam(ctx, expr.expression) ||
-              // (#1528 / #56 class-ctor arm) `executor` param of a capability
-              // constructor (`Promise.X.call(Constructor, …)`) is host-supplied.
-              calleeIsCapabilityCtorParam(ctx, expr.expression));
+            (calleeMayBeHostCallable(ctx, expr.expression) || calleeIsPromiseExecutorParam(ctx, expr.expression));
+          // NB: capability-ctor `executor` params (#1528/#56 class-ctor arm) are
+          // UNTYPED (`any`, no call signatures) so they never reach this
+          // callable-param dispatch — they are routed earlier through the
+          // `__call_function` host helper (see the calleeIsCapabilityCtorParam
+          // early-return alongside the bound-function path above).
 
           let fallbackInstrs: Instr[] | null = null;
           let dispatchOuterBody: Instr[] | null = null;

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -1621,7 +1621,15 @@ function calleeIsCapabilityCtorParam(ctx: CodegenContext, expr: ts.Expression): 
       node.expression.expression.expression.text === "Promise" &&
       COMBINATORS.has(node.expression.expression.name.text)
     ) {
-      const firstArg = node.arguments[0];
+      // Unwrap `as`/paren/non-null on the capability arg so
+      // `Promise.X.call(Constructor as any, …)` matches the bare-identifier form.
+      let firstArg = node.arguments[0];
+      while (
+        firstArg &&
+        (ts.isAsExpression(firstArg) || ts.isParenthesizedExpression(firstArg) || ts.isNonNullExpression(firstArg))
+      ) {
+        firstArg = firstArg.expression;
+      }
       if (firstArg && ts.isIdentifier(firstArg) && firstArg.text === fnName) {
         found = true;
         return;

--- a/tests/issue-1528-closure-construct.test.ts
+++ b/tests/issue-1528-closure-construct.test.ts
@@ -143,4 +143,57 @@ describe("#1632b-2 closure-as-dynamic-constructor bridge", () => {
       `),
     ).toBe(true);
   });
+
+  // #86 class-ctor arm: `executor(...)` inside a function used as a Promise
+  // combinator CAPABILITY CONSTRUCTOR (`Promise.X.call(Constructor, …)` → V8
+  // `Construct(Constructor, «executor»)` via the #1940 bridge) is a call of an
+  // UNTYPED (`any`) param that V8 fills with a HOST function. The no-call-sig
+  // fallback would `ref.cast` it to a closure struct and trap
+  // (`illegal cast in Constructor()`); the capability-ctor-param gate routes the
+  // OUTBOUND `executor(...)` call through `__call_function` instead, so the
+  // executor protocol runs. (The gate emits the `__call_function` import for the
+  // executor call — that is what this arm fixes.)
+  //
+  // KNOWN LIMITATION (documented follow-up): when the args passed to the host
+  // `executor` are CAPTURING inner closures (`function resolve(){ calls++; }`),
+  // the host→wasm marshalling of that captured-closure arg still casts (the
+  // multi-hop callback cast in the verdict). A NON-capturing executor arg works;
+  // the capturing case is the larger cluster effort. So we assert the gate WIRES
+  // the call through the host helper (the deliverable), not the end-to-end
+  // capturing-closure run.
+  async function importEmitted(source: string, importName: string): Promise<boolean> {
+    const r = await compile(source, {});
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    return (r.imports ?? []).some((i: { name?: string; intent?: { name?: string } }) => {
+      const n = i.name ?? i.intent?.name;
+      return n === importName;
+    });
+  }
+
+  it("routes the capability-ctor executor call through __call_function", async () => {
+    // Bare `Promise.allSettled.call(Constructor, …)` is the test262 shape the
+    // syntactic gate keys on (V8's NewPromiseCapability runs the executor).
+    expect(
+      await importEmitted(
+        `function Constructor(executor: any) {
+           function resolve(v: any) {}
+           executor(resolve, function () {});
+         }
+         (Constructor as any).resolve = function (v: any) { return v; };
+         const p1: any = { then: function (f: any) { f("x"); } };
+         export function test(): number { Promise.allSettled.call(Constructor as any, [p1]); return 0; }`,
+        "__call_function",
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT route an ordinary callable param (no capability-ctor flow) through __call_function (#1941 dual-mode)", async () => {
+    expect(
+      await importEmitted(
+        `function apply2(cb: any, v: number) { return cb(v); }
+         export function test(): number { return apply2((x: number) => x + 1, 10); }`,
+        "__call_function",
+      ),
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

The #56 follow-up "class-ctor arm" (#1632b-2 capability-constructor case). `executor(...)` inside a function used as a Promise-combinator **capability constructor** (`Promise.{all,allSettled,race,any}.call(Constructor, …)` → V8 `Construct(Constructor, «executor»)` via the #1940 closure-construct bridge) is a call of an **untyped** (`any`, no call signatures) param. V8 fills it with a **host** function, but the no-call-signature fallback `ref.cast`s it to a closure struct and traps (`illegal cast in Constructor()`).

## Fix (narrow, ~30 LoC)

`calleeIsCapabilityCtorParam` (syntactic gate: the param's declaring function flows to a `Promise.<combinator>.call(fn, …)` site, with `as`/paren/non-null unwrap on the capability arg) routes the call through the existing `__call_function` host helper via an early-return alongside the bound-function path — **before** the call-signature gate, since the param is untyped. JS-host only; the narrow gate preserves the #1941 dual-mode guarantee (no host-import leak into pure-closure programs — covered by a regression test).

## Scope (honest)

This closes the **direct executor-call cast** (min repro `Promise.allSettled.call(Constructor,[p]); executor(resolve, reject)` runs) and flips the peripheral capability rows (`capability-executor-called-twice`, `species-get-error`). It does **NOT** fully close the headline cluster (`allSettled/call-resolve-element`, `race/resolve-from-same-thenable`): those need the inner `resolve` **capturing closure** passed to the host executor to survive the host→wasm callback cast (multi-hop), plus ctx-ctor needs species/ctor identity through the bridge — both documented as a larger follow-up in the issue file. #2614/#2618 sequence after.

## Validation

- New tests in `issue-1528-closure-construct.test.ts`: capability-ctor executor call routes through `__call_function`; an ordinary callable param does NOT (#1941 guard). 10 pass, 1 skip.
- `generator-invoke-ctor.js` still throws (the #1940 eject-fix guard, now on this branch).
- 33-test constructor/new/closure-construct suite green; quality sub-gates (stack-balance, coercion-sites, codegen-fallbacks) OK.
- Broad-impact call-dispatch path → authoritative validation via merge_group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA