### PR TITLE
docs(#2623): capability-cluster follow-up issue + re-point #2614

### DIFF
--- a/plan/issues/2614-promise-combinator-constructor-resolve-element-callable.md
+++ b/plan/issues/2614-promise-combinator-constructor-resolve-element-callable.md
@@ -14,7 +14,7 @@ goal: async-model
 sprint: 65
 parent: 1042
 related: [1528, 1368, 1116, 1694]
-blocked_on: [1632b-2, 2615]
+blocked_on: [2623]
 note: "BLOCKED (2026-06-22, sd re-ground + impl attempt). The architect framing was wrong for current main: combinators delegate to native V8 (which already does Get(C,'resolve')). The real fix — route C to the user's realm Promise so a patched resolve is observed — is INSEPARABLE from the closure-as-dynamic-ctor capability bridge: the moment C is the realm Promise, NewPromiseCapability(C)→Construct(C, wasmExecutor) hits the same __fn_tramp_Constructor cross-realm illegal-cast as #2615/#1528a-residual (#1632b-2). Attempted observability fix proven net-NEGATIVE (regressed any/invoke-resolve pass→illegal-cast). Fold into / block behind the capability bridge; do NOT ship a standalone runtime.ts patch."
 ---
 # #2614 — Promise combinators: invoke the constructor's own `resolve` + expose callable resolve/reject element functions
@@ -253,3 +253,24 @@ a standalone runtime.ts patch. The attempted diff is preserved out-of-tree
 (not committed — net-negative). Recommend: re-route #2614 behind #1632b-2 /
 #2615, or hand the combined combinator+capability slice to whoever owns that
 bridge.
+
+## Status update (2026-06-22, post #56+#86 merge)
+
+#56/#1940 (closure-construct bridge) and #86/#1945 (capability-ctor executor-call
+host-routing) BOTH MERGED. #86 banked **+2 rows** for this cluster
+(`capability-executor-called-twice`, `species-get-error`) — the executor-call
+surface is now on main.
+
+The DOMINANT rows remain blocked, re-pointed to the new follow-up **#2623**
+(Promise capability-cluster — multi-hop host→wasm callback cast + species/proto
+identity):
+- `invoke-resolve` (all/race) — observable-resolve identity, coupled to the
+  inbound-callback substrate (proven net-negative alone pre-#1940).
+- `call-resolve-element` / `resolve-from-same-thenable` — the inner CAPTURING
+  `resolve` closure passed to the host executor null-derefs/casts on the inbound
+  callback (the #86 capturing-residual; same root as the await-thenable bucket).
+- `ctx-ctor` (all/allSettled/race/any) — `instance.constructor === SubPromise`
+  species/prototype identity through the bridge.
+
+`blocked_on` updated to `[2623]`. This issue stays `blocked` until #2623 lands
+the inbound-callback substrate.

--- a/plan/issues/2623-promise-capability-cluster-multihop-callback-cast.md
+++ b/plan/issues/2623-promise-capability-cluster-multihop-callback-cast.md
@@ -1,0 +1,82 @@
+---
+id: 2623
+title: "Promise capability-cluster: multi-hop host→wasm resolve-element callback cast + ctx-ctor species/prototype identity through the bridge"
+status: backlog
+created: 2026-06-22
+priority: medium
+feasibility: hard
+reasoning_effort: max
+task_type: feature
+area: codegen, promise, async, capability-bridge
+language_feature: promise, async, proxy
+goal: async-model
+sprint: Backlog
+parent: 1528
+related: [2614, 2618, 1373b, 1042, 86, 56]
+note: "Spun off from #86 (class-ctor arm, merged) + #55 async-bucket scope (PR #1947). The #56/#1940 closure-construct bridge + #86 executor-call host-routing landed the SURFACE of the capability lane; this issue is the DEEPER shared substrate behind three clusters that the surface fixes did NOT close."
+---
+# #2623 — Promise capability-cluster: multi-hop host→wasm callback cast + species identity
+
+## Why this exists (one substrate, three clusters)
+
+#56/#1940 (closure-as-dynamic-ctor bridge) and #86/#1945 (capability-ctor
+`executor(...)` host-routing) both LANDED. They closed the *surface* of the
+capability lane. But a single deeper substrate gap remains, and it is shared by
+**three** distinct test262 clusters — fixing it once should bank all three:
+
+1. **#2614 Promise combinator headline rows** —
+   `allSettled/call-resolve-element.js`, `race/resolve-from-same-thenable.js`:
+   `illegal cast in Constructor()`. The user `Constructor` passes its INNER
+   `resolve` (a wasm closure that closes over outer state) to the host
+   `executor`; when the host thenable later calls `resolve(value)` BACK, the
+   host→wasm callback of that **capturing** closure casts/null-derefs. (#86's
+   arm routes the OUTBOUND `executor(...)` call; this is the INBOUND callback.)
+2. **#86 capturing-inner-resolve residual** — proven in #86: a NON-capturing
+   inner `resolve` works through the arm, a CAPTURING one (`function resolve(){
+   calls++; }`) fails the same way. Same root.
+3. **await-thenable bucket (#55 scope, PR #1947, ~21 rows)** —
+   `await <custom thenable {then(res){res(42)}}>` → `dereferencing a null
+   pointer in __closure_N`. `await V` lowers to `Promise_resolve(V)` +
+   `Promise_then2(p, __make_callback(continuation))`; for a custom thenable,
+   V8's `p.then(resolve,reject)` calls the wasm continuation back as a host→wasm
+   callback — the SAME inbound-callback cast/null-deref.
+
+Common shape: **a wasm closure / continuation is handed to host code (a user
+`executor`, a custom thenable's `.then`, or V8's NewPromiseCapability) and later
+INVOKED BACK by the host**, and that inbound call casts the wasm-closure-struct
+arg or null-derefs its captured environment.
+
+## Scope
+
+1. **Inbound host→wasm callback marshalling** — when a wasm closure flows OUT to
+   host code (as a `.then`/executor arg, a capability resolve/reject element
+   function, an await continuation) and the host calls it back, the inbound call
+   must recover the closure struct + its captured environment correctly (no
+   unconditional `ref.cast` to a closure struct that fails on the marshalled
+   host wrapper; no null-deref of the captured env). The capturing-closure case
+   is the hard part — a non-capturing closure has no env to lose.
+2. **ctx-ctor species / prototype identity** — `all/allSettled/race/any
+   ctx-ctor.js`: `instance.constructor === SubPromise` requires the capability's
+   `.constructor`/prototype identity to survive `_wrapCallableForHost`
+   (a `.prototype`/species concern on the construct-trap wrapper).
+3. **Observable-resolve coupling** (#2614 invoke-resolve all/race) — the
+   sandbox-`Promise.resolve` identity fix proven net-negative ALONE in #2614
+   (it regressed `any/invoke-resolve` pre-#1940); re-test it composed on top of
+   the inbound-callback fix here (the regression was the cross-realm construct,
+   which #1940 + this should make legal).
+
+## Gating / discipline
+
+- Bounded-vs-epic TBD: the inbound-callback marshalling touches the hot
+  closure-call + host-glue path. Likely needs an architect spec first.
+- Broad-impact → validate via merge_group, never a scoped sweep (the #1940/#2615
+  eject pattern: PR-level passes, the floor catches the regression).
+- Keep any gate SYNTACTIC / narrow to avoid the #1941 host-import LinkError into
+  pure-closure programs.
+
+## Expected payoff
+
+#2614 headline rows (call-resolve-element, resolve-from-same-thenable, ctx-ctor,
+invoke-resolve) + #86 capturing-inner-resolve residual + await-thenable (~21) +
+unblocks #2618 (Proxy apply/construct shares the `__fn_tramp_Constructor`
+dispatch). Routed to the #2614/#1528 capability-cluster lane, next-sprint.


### PR DESCRIPTION
## Summary (doc-only)

Per lead directive (after #56/#1940 + #86/#1945 both merged): create the deeper-cluster next-sprint follow-up issue and re-point #2614.

**New issue #2623** — "Promise capability-cluster: multi-hop host→wasm resolve-element callback cast + ctx-ctor species/prototype identity" (`status: backlog`, capability-cluster lane). One inbound host→wasm-callback substrate gap is shared by THREE clusters that the merged surface fixes did NOT close:
1. #2614 headline rows (call-resolve-element, resolve-from-same-thenable, ctx-ctor, invoke-resolve) — inner CAPTURING `resolve` closure null-derefs on the inbound host callback + species/proto identity.
2. #86 capturing-inner-resolve residual (proven: non-capturing works, capturing fails the same way).
3. await-thenable bucket (~21 rows, from #55 scope) — same inbound-callback null-deref of the await continuation.

Fixing the inbound host→wasm-callback marshalling once should bank all three.

**#2614 updated**: `blocked_on: [2623]`, +2 rows banked via #86, dominant rows re-pointed to #2623.

Issue id reserved via `claim-issue.mjs --allocate` (2623). Bounded-vs-epic TBD, architect-spec-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA