### PR TITLE
feat(cli): dedupe repeated node/builtin warnings + auto-emulate on node: import (#2603)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,8 +77,10 @@ Options:
                     js2wasm:node-io (no wasi_snapshot_preview1 for stream IO) and
                     links node-shim.wasm. Off by default (inline fd_* fallback).
   --emulate <env>   Emulate a host runtime's globals so they type-check without
-                    @types/node. Currently: 'node' (ambient process). Off by
-                    default; using process then warns to add this flag (#2603).
+                    @types/node. 'node' = ambient process/etc.; 'none' = off.
+                    Auto-enabled (type-level only) when the source imports a
+                    'node:' builtin (use 'none' to disable that); otherwise off,
+                    and using process warns to add this flag (#2603).
   --no-host-imports Strict dual-mode: reject JS-host 'env' imports not on
                     the allowlist (#1524). Implied by --target wasi.
   --allow-host-imports
@@ -141,7 +143,10 @@ let strictNoHostImports: boolean | undefined;
 // #2524 Phase 1 — process IO via the linkable js2wasm:node-io shim (WASI only).
 let nodeIoShim = false;
 // #2603 — `--emulate node`: opt into Node API emulation (ambient `process` typing).
+// `emulateExplicit` records that the user passed `--emulate`/`--no-emulate`, so a
+// `node:` import won't auto-enable over an explicit choice.
 let emulateNode = false;
+let emulateExplicit = false;
 const defines: Record<string, string> = {};
 
 for (let i = 0; i < args.length; i++) {
@@ -201,14 +206,19 @@ for (let i = 0; i < args.length; i++) {
     // shim (WASI only). Off by default; the inline fd_read/fd_write path stays.
     nodeIoShim = true;
   } else if (arg === "--emulate" || arg.startsWith("--emulate=")) {
-    // #2603 — opt into Node API emulation. Gives the checker an ambient
-    // `process` typing so Node globals type-check without @types/node; without
-    // it, the "Cannot find name 'process'" warning suggests adding this flag.
+    // #2603 — opt into (or out of) Node API emulation. `--emulate node` gives the
+    // checker an ambient `process` typing so Node globals type-check without
+    // @types/node; `--emulate none` opts out (and disables the `node:`-import
+    // auto-enable below). An explicit choice always wins over auto-detection.
     const env = arg.startsWith("--emulate=") ? arg.slice("--emulate=".length) : args[++i];
     if (env === "node") {
       emulateNode = true;
+      emulateExplicit = true;
+    } else if (env === "none") {
+      emulateNode = false;
+      emulateExplicit = true;
     } else {
-      console.error(`Unknown --emulate value: ${env ?? "(missing)"} (expected: node)`);
+      console.error(`Unknown --emulate value: ${env ?? "(missing)"} (expected: node | none)`);
       process.exit(1);
     }
   } else if (arg === "--no-host-imports") {
@@ -285,6 +295,16 @@ if (allocator !== undefined && target !== "linear") {
 
 const absInput = resolve(inputPath);
 const source = readFileSync(absInput, "utf-8");
+
+// #2603 — auto-enable Node API emulation when the source imports a `node:`
+// builtin (e.g. `import { readFile } from "node:fs"` / `require("node:path")`),
+// unless the user made an explicit `--emulate`/`--no-emulate` choice. Emulation
+// is type-level only (ambient Node globals); it never changes emitted wasm.
+if (!emulateExplicit && !emulateNode && /['"]node:[A-Za-z0-9_./-]+['"]/.test(source)) {
+  emulateNode = true;
+  console.error("note: auto-enabled Node API emulation (found a `node:` import). Pass --emulate none to disable.");
+}
+
 const name = basename(absInput, ".ts");
 const dir = outDir ? resolve(outDir) : dirname(absInput);
 
@@ -325,13 +345,21 @@ if (!result.success) {
 // summary by default; --verbose restores the full per-import listing.
 const isAllowlistWarning = (msg: string): boolean => msg.includes("not on the dual-mode allowlist");
 let suppressedAllowlist = 0;
+// #2603 follow-up — collapse identical warning messages to a single line. A Node
+// global / builtin used N times (e.g. `process` without `--emulate node`)
+// otherwise prints N identical "Cannot find name 'X'" warnings. Dedupe by message
+// text (first-seen order preserved), appending a count when it repeated.
+const warnCounts = new Map<string, number>();
 for (const e of result.errors) {
   if (e.severity !== "warning") continue;
   if (!verbose && isAllowlistWarning(e.message)) {
     suppressedAllowlist++;
     continue;
   }
-  console.error(`warning: ${e.message}`);
+  warnCounts.set(e.message, (warnCounts.get(e.message) ?? 0) + 1);
+}
+for (const [msg, count] of warnCounts) {
+  console.error(count > 1 ? `warning: ${msg} (${count}×)` : `warning: ${msg}`);
 }
 if (suppressedAllowlist > 0) {
   console.error(

--- a/tests/issue-2603-warning-dedup-auto-emulate.test.ts
+++ b/tests/issue-2603-warning-dedup-auto-emulate.test.ts
@@ -1,0 +1,56 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// #2603 follow-ups to `--emulate node`:
+//  1. identical Node/builtin "Cannot find name 'X'" warnings collapse to one line.
+//  2. a `node:` import auto-enables Node API emulation (with a note + a disable flag).
+// Driven through the real CLI (cli.ts) since both live in the arg/print layer.
+
+let dir: string;
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), "js2-2603-"));
+});
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function runCli(file: string, src: string, extraArgs: string[] = []): string {
+  const input = join(dir, file);
+  writeFileSync(input, src);
+  // spawnSync gives us stdout AND stderr on both success and failure (warnings
+  // are on stderr, and the compile exits 0 — execFileSync would drop them).
+  const r = spawnSync("npx", ["tsx", "src/cli.ts", input, "--target", "wasi", "-o", dir, ...extraArgs], {
+    encoding: "utf8",
+  });
+  return `${r.stdout ?? ""}${r.stderr ?? ""}`;
+}
+
+const procWarnLines = (out: string) => out.split("\n").filter((l) => l.includes("Cannot find name 'process'"));
+
+describe("#2603 warning dedup + node:-import auto-emulate", () => {
+  it("collapses repeated `process` warnings to a single line with a count", () => {
+    const src = `process.stdout.write("a");\nprocess.stderr.write("b");\nprocess.stdout.write("c");\n`;
+    const out = runCli("dedup.js", src);
+    const lines = procWarnLines(out);
+    expect(lines.length).toBe(1);
+    expect(lines[0]).toMatch(/\(3\D*\)/); // "(3×)" — count of 3, char-agnostic
+    expect(lines[0]).toContain("--emulate node");
+  });
+
+  it("auto-enables Node emulation on a `node:` import (note printed, no process warning)", () => {
+    const src = `import { readFileSync } from "node:fs";\nvoid readFileSync;\nprocess.stdout.write("x");\n`;
+    const out = runCli("auto.js", src);
+    expect(out).toContain("auto-enabled Node API emulation");
+    expect(procWarnLines(out).length).toBe(0);
+  });
+
+  it("--emulate none disables the node:-import auto-enable (process warns again)", () => {
+    const src = `import { readFileSync } from "node:fs";\nvoid readFileSync;\nprocess.stdout.write("x");\n`;
+    const out = runCli("noemu.js", src, ["--emulate", "none"]);
+    expect(out).not.toContain("auto-enabled Node API emulation");
+    expect(procWarnLines(out).length).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
Three follow-ups to `--emulate node` (#2603), all in the CLI arg/print layer (type-level only — emitted wasm unchanged):

1. **Dedupe warnings.** Identical "Cannot find name 'X'" warnings now collapse to a **single line with a `(N×)` count** — a Node global used N times no longer prints N identical warnings.
2. **Auto-emulate on `node:` import.** When the source imports a `node:` builtin (`import … from "node:fs"`, `require("node:path")`, …), Node API emulation auto-enables and prints a one-line `note:` (with how to disable). An explicit `--emulate` choice always wins over auto-detection.
3. **`--emulate none`.** Disables emulation (and the auto-enable). No separate `--no-emulate` flag — one flag, two values (`node | none`).

New CLI integration test (`tests/issue-2603-warning-dedup-auto-emulate.test.ts`, 3 cases) drives the real `cli.ts`: dedup count, auto-enable note + suppressed warning, and `--emulate none` re-warning.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>