### PR TITLE
feat(checker): import-scoped Node emulation typing (#2624)

### DIFF
--- a/plan/issues/2624-import-scoped-node-emulation-typing.md
+++ b/plan/issues/2624-import-scoped-node-emulation-typing.md
@@ -1,0 +1,92 @@
+---
+id: 2624
+title: "Node API emulation typing is import-scoped, not blanket"
+status: done
+sprint: Backlog
+created: 2026-06-22
+updated: 2026-06-22
+completed: 2026-06-22
+priority: medium
+feasibility: medium
+reasoning_effort: max
+task_type: feature
+area: checker
+language_feature: node-host-apis
+goal: standalone-mode
+related: [2603, 2524, 2512, 389]
+---
+
+## Problem
+
+`--emulate node` (#2603) injected a **blanket** ambient `.d.ts`
+(`NODE_ENV_DTS_SOURCE`) that always declared the global `process` whenever
+emulation was on — regardless of what Node surface the program actually used. A
+program that imports only `node:fs` would still get an ambient `process`, and
+there was no per-module typing for `node:<mod>` imports at all.
+
+The agreed per-module design (stakeholder-confirmed, loopdive/js2#389) is that
+Node emulation is **per-imported-module, not blanket**, with the type layer and
+the runtime layer lining up 1:1:
+
+- **Type layer** (this issue): `import … from "node:fs"` injects ONLY `node:fs`
+  types (only the imported members); a bare global `process` (no import — the
+  #389 host) injects ONLY the `process` global. Don't inject the whole Node
+  surface.
+- **Runtime layer** (#2625): one linkable shim PER MODULE, named after the
+  module (`node:process` → `js2wasm:node-process`).
+
+## Fix — build the injected `.d.ts` dynamically, scoped to what the source touches
+
+`src/checker/index.ts`, `analyzeSource`: when `emulateNode` is on, build the
+injected `.d.ts` DYNAMICALLY from the source instead of serving the static
+`NODE_ENV_DTS_SOURCE`.
+
+- `scanNodeEmuUsage(source, scriptKind)` — a cheap single `ts.createSourceFile`
+  parse (no type-checking) that records, for the source:
+  - every `import … from "node:<mod>"` (default / named / namespace) and
+    `require("node:<mod>")`, with the **imported member names**;
+  - whether a **bare global `process`** is referenced (and `node:process` was
+    NOT imported — in which case `process` is the import binding, not the
+    global).
+- `buildNodeEnvDts(usage)` — emits ONLY the touched surface:
+  - bare global `process` → the `NodeJS_Process` interfaces + `declare var process`;
+  - `node:process` import → the interfaces + a `declare module "node:process"`
+    with a default export and named member re-exports (so default / namespace /
+    named imports all resolve under ESNext module mode, no `esModuleInterop`);
+  - other `node:<mod>` imports → a permissive `declare module "node:<mod>"`
+    declaring just the imported member names (`export const <name>: any`) + a
+    default, so they type-check (goal: "type-checks, no TS2307/TS2580", minimal
+    surface);
+  - returns `undefined` when the program touches no Node surface → the checker
+    skips injection entirely (no empty synthetic root).
+- `buildNodeEnvDtsForSource(source, scriptKind?)` is exported so tests can assert
+  the EXACT injected text.
+
+Kept from #2603: the `--emulate node|none` flag, the `node:`-import auto-detect
+(cli.ts), the duplicate-identifier fallback (a user that declares its own
+`process`/module never errors), and the warning-dedup.
+
+**Type-level only** — emitted wasm is byte-identical. The example host
+(`examples/native-messaging/nm_js2wasm.ts`, a bare-`process` #389 host) md5s to
+`428a96eb38121be46a7983bdff883e70` with the default path, with `--emulate node`,
+and after this change — all identical. Codegen lowers `process.*` syntactically
+regardless of the injected declaration.
+
+## Verification
+
+- `tests/issue-2603-warning-dedup-auto-emulate.test.ts` (#2624 block, 7 new
+  cases): a `node:fs`-only program does NOT inject `process`; a bare `process`
+  reference injects ONLY the process global (no module decls); a `node:process`
+  import injects the process module but NOT unrelated `node:*` modules and NOT
+  the ambient global; multiple `node:*` imports each declare only their own
+  members; a no-Node-surface program injects nothing (`undefined`); an
+  end-to-end `analyzeSource` with `node:process` resolves with no TS2307/TS2580;
+  namespace import resolves.
+- Byte-identity: `examples/native-messaging/nm_js2wasm.ts` → wasm md5 unchanged
+  (`428a96eb…`) for default and `--emulate node`.
+
+## Notes
+
+Builds on PR #1950 (`fix-dedupe-node-builtin-warnings`). Mirrors the per-module
+runtime-shim design in #2625 (`js2wasm:node-process`). Pairs with #2512 (node
+host APIs as separate linkable wasm modules) and #2524 (process IO shim).

--- a/src/checker/index.ts
+++ b/src/checker/index.ts
@@ -305,15 +305,25 @@ const ES_EARLY_ERROR_CODES = new Set([
   18050, // A rest element cannot have an initializer
 ]);
 
-// #2603: ambient `process` surface emulated under `--target wasi`. Served as a
-// synthetic root .d.ts (a global script — no import/export — so `process` is an
-// ambient global) ONLY when AnalyzeOptions.wasi is set. Declares the members the
-// node-process-api.ts lowering actually supports, so the checker resolves
-// `process` (no TS2580) without the user installing @types/node. Type-level
-// only — codegen lowers `process.*` syntactically regardless of this file.
+// #2603 / #2624: Node API emulation surface, injected when `--emulate node`
+// (or the `node:`-import auto-detect) is on. Served as a synthetic root .d.ts so
+// the checker resolves the emulated Node globals/modules (no TS2580 / TS2307)
+// without the user installing @types/node. Type-level only — codegen lowers
+// `process.*` and the IO calls syntactically regardless of this file.
+//
+// #2624 makes the injection **import-scoped, not blanket**: the .d.ts is built
+// DYNAMICALLY from the source (see `buildNodeEnvDts`) so it declares ONLY the
+// Node surface the program actually touches. A `node:fs`-only program does NOT
+// get an ambient `process` global; a bare `process` reference does NOT pull in
+// unrelated `node:*` module typings. This keeps the injected surface minimal
+// (goal: "type-checks, no TS2580/TS2307", nothing more) and mirrors the
+// per-module runtime-shim design (one shim per imported module).
 const NODE_ENV_DTS_NAME = "__js2wasm_node_env.d.ts";
-const NODE_ENV_DTS_SOURCE = `
-interface NodeJS_WritableStream {
+
+// The `process` member surface that node-process-api.ts actually lowers. Shared
+// between the bare ambient global (`declare var process`) and a `node:process`
+// default/namespace/named import.
+const PROCESS_INTERFACE_DECLS = `interface NodeJS_WritableStream {
   write(chunk: Uint8Array | ArrayBuffer | string): boolean;
   once(event: string, listener: (...args: any[]) => void): void;
 }
@@ -328,9 +338,170 @@ interface NodeJS_Process {
   readonly stdin: NodeJS_ReadableStream;
   readonly stdout: NodeJS_WritableStream;
   readonly stderr: NodeJS_WritableStream;
+}`;
+
+interface NodeEmuUsage {
+  /** node:<mod> -> set of imported member names ("" sentinel = default/namespace import). */
+  modules: Map<string, Set<string>>;
+  /** A bare global `process` is referenced (NOT via a `node:process` import). */
+  bareProcess: boolean;
 }
-declare var process: NodeJS_Process;
-`;
+
+/**
+ * Scan the source for the Node surface it touches: `import … from "node:<mod>"`
+ * (named / default / namespace), `require("node:<mod>")`, plus a bare global
+ * `process` reference. Cheap — a single `ts.createSourceFile` parse, no
+ * type-checking. The result drives the import-scoped .d.ts in `buildNodeEnvDts`.
+ */
+function scanNodeEmuUsage(source: string, scriptKind: ts.ScriptKind): NodeEmuUsage {
+  const modules = new Map<string, Set<string>>();
+  let importsNodeProcess = false;
+
+  const sf = ts.createSourceFile("__scan__.ts", source, ts.ScriptTarget.Latest, /*setParentNodes*/ true, scriptKind);
+
+  const recordModule = (mod: string, members: Iterable<string>): void => {
+    let set = modules.get(mod);
+    if (!set) {
+      set = new Set<string>();
+      modules.set(mod, set);
+    }
+    for (const m of members) set.add(m);
+  };
+
+  // 1. `import … from "node:<mod>"` (named / default / namespace).
+  // 2. `import "node:<mod>"` (side-effect; record the module, no members).
+  // 3. `require("node:<mod>")` (CommonJS — record the module, members unknown).
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+      const spec = node.moduleSpecifier.text;
+      if (spec.startsWith("node:")) {
+        const members: string[] = [];
+        const clause = node.importClause;
+        if (clause) {
+          // default import: `import fs from "node:fs"`
+          if (clause.name) members.push("");
+          if (clause.namedBindings) {
+            if (ts.isNamespaceImport(clause.namedBindings)) {
+              // `import * as fs from "node:fs"` — namespace; whole module surface.
+              members.push("");
+            } else {
+              // `import { a, b as c } from "node:fs"` — record the LOCAL names.
+              for (const el of clause.namedBindings.elements) members.push(el.name.text);
+            }
+          }
+        }
+        if (spec === "node:process") importsNodeProcess = true;
+        recordModule(spec, members);
+      }
+    } else if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "require" &&
+      node.arguments.length === 1 &&
+      ts.isStringLiteral(node.arguments[0]) &&
+      node.arguments[0].text.startsWith("node:")
+    ) {
+      const spec = node.arguments[0].text;
+      if (spec === "node:process") importsNodeProcess = true;
+      recordModule(spec, [""]);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+
+  // A bare global `process` reference: we approximate "referenced" by a regex on
+  // the source, unless the program imports `node:process` (in which case
+  // `process` is the import binding, not the global). A precise binding analysis
+  // is overkill for a type-level emulation hint, and the dup-identifier fallback
+  // covers any user that declares its own `process`.
+  const bareProcess = !importsNodeProcess && /\bprocess\b/.test(source);
+
+  return { modules, bareProcess };
+}
+
+/**
+ * Build the import-scoped Node emulation `.d.ts` for `source`. Declares ONLY the
+ * surface the program touches:
+ *   - bare global `process` → the `process` interfaces + `declare var process`;
+ *   - `import … from "node:process"` → the `process` interfaces + a typed
+ *     `node:process` module (export-assignment of the process value);
+ *   - other `node:<mod>` imports → a permissive `declare module` declaring just
+ *     the imported member names (`export const <name>: any`) + a default, so
+ *     they type-check.
+ * Returns `undefined` when there's nothing to inject (no Node surface touched),
+ * so the caller can skip injection entirely (no empty synthetic root).
+ */
+function buildNodeEnvDts(usage: NodeEmuUsage): string | undefined {
+  const parts: string[] = [];
+  let processInterfacesEmitted = false;
+
+  const emitProcessInterfaces = (): void => {
+    if (!processInterfacesEmitted) {
+      parts.push(PROCESS_INTERFACE_DECLS);
+      processInterfacesEmitted = true;
+    }
+  };
+
+  // Bare ambient global `process`.
+  if (usage.bareProcess) {
+    emitProcessInterfaces();
+    parts.push(`declare var process: NodeJS_Process;`);
+  }
+
+  // `node:<mod>` modules, each scoped to its imported members.
+  for (const [mod, members] of usage.modules) {
+    if (mod === "node:process") {
+      emitProcessInterfaces();
+      // Default / namespace / named import of the process module. We expose the
+      // `NodeJS_Process` value as BOTH a default export and named re-exports of
+      // its members, so `import process from "node:process"`, `import * as
+      // process`, and `import { stdout } from "node:process"` all resolve under
+      // the checker's ESNext module mode (no `esModuleInterop` needed).
+      const lines: string[] = [`declare module "node:process" {`, `  const process: NodeJS_Process;`];
+      lines.push(`  export default process;`);
+      lines.push(`  export const argv: string[];`);
+      lines.push(`  export const env: Record<string, string | undefined>;`);
+      lines.push(`  export const platform: string;`);
+      lines.push(`  export function exit(code?: number): never;`);
+      lines.push(`  export const stdin: NodeJS_ReadableStream;`);
+      lines.push(`  export const stdout: NodeJS_WritableStream;`);
+      lines.push(`  export const stderr: NodeJS_WritableStream;`);
+      lines.push(`}`);
+      parts.push(lines.join("\n"));
+      continue;
+    }
+    // Other modules: permissive, just enough that the imported names resolve.
+    const named = [...members].filter((m) => m !== "");
+    const hasDefaultOrNs = members.has("");
+    const lines: string[] = [`declare module "${mod}" {`];
+    for (const name of named) lines.push(`  export const ${name}: any;`);
+    if (hasDefaultOrNs || named.length === 0) {
+      // Default/namespace import, or a side-effect/require import: give the whole
+      // module an `any` shape so `import fs from "node:fs"` / `import * as fs`
+      // resolve without enumerating members.
+      lines.push(`  const _default: any;`);
+      lines.push(`  export default _default;`);
+    }
+    lines.push(`}`);
+    parts.push(lines.join("\n"));
+  }
+
+  if (parts.length === 0) return undefined;
+  return parts.join("\n") + "\n";
+}
+
+/**
+ * #2624 — compose `scanNodeEmuUsage` + `buildNodeEnvDts` for a source. Exported
+ * so tests can assert the EXACT import-scoped surface that emulation injects
+ * (e.g. that a `node:fs`-only program does not declare the `process` global).
+ * Returns `undefined` when the program touches no Node surface.
+ */
+export function buildNodeEnvDtsForSource(
+  source: string,
+  scriptKind: ts.ScriptKind = ts.ScriptKind.TS,
+): string | undefined {
+  return buildNodeEnvDts(scanNodeEmuUsage(source, scriptKind));
+}
 
 /** Diagnostic codes for a duplicate `process` declaration (user declared it themselves). */
 const DUP_IDENTIFIER_CODES = new Set([
@@ -368,7 +539,13 @@ export function analyzeSource(source: string, fileName = "input.ts", analyzeOpti
     ...(isJsx ? { jsx: ts.JsxEmit.ReactJSX } : {}),
   };
 
-  const injectNodeEnv = analyzeOptions?.emulateNode === true;
+  // #2624: when emulation is on, build the injected Node `.d.ts` DYNAMICALLY from
+  // the source so it declares only the Node surface the program touches (see
+  // `buildNodeEnvDts`). If the program touches no Node surface, there is nothing
+  // to inject and `injectNodeEnv` stays false (no empty synthetic root).
+  const nodeEnvDtsSource =
+    analyzeOptions?.emulateNode === true ? buildNodeEnvDtsForSource(source, scriptKind) : undefined;
+  const injectNodeEnv = nodeEnvDtsSource !== undefined;
 
   const compilerHost: ts.CompilerHost = {
     getSourceFile(name, languageVersion) {
@@ -376,7 +553,7 @@ export function analyzeSource(source: string, fileName = "input.ts", analyzeOpti
         return ts.createSourceFile(name, source, languageVersion, true, scriptKind);
       }
       if (injectNodeEnv && name === NODE_ENV_DTS_NAME) {
-        return ts.createSourceFile(name, NODE_ENV_DTS_SOURCE, languageVersion, true, ts.ScriptKind.TS);
+        return ts.createSourceFile(name, nodeEnvDtsSource, languageVersion, true, ts.ScriptKind.TS);
       }
       const libSf = getLibSourceFile(name, languageVersion);
       if (libSf) return libSf;
@@ -399,11 +576,11 @@ export function analyzeSource(source: string, fileName = "input.ts", analyzeOpti
     compilerOptions.checkJs = true;
   }
 
-  // Build the program. Under WASI (#2603) add a synthetic ambient `process`
-  // .d.ts as an extra root so the checker resolves the emulated Node globals.
-  // If the user already declares `process`, that injection collides — detect
-  // the duplicate-identifier diagnostic and rebuild without it, so we never
-  // turn a benign warning into a hard error.
+  // Build the program. When Node emulation is on (#2603/#2624) add the
+  // import-scoped synthetic Node `.d.ts` as an extra root so the checker resolves
+  // the emulated Node globals/modules. If the user already declares `process`,
+  // that injection collides — detect the duplicate-identifier diagnostic and
+  // rebuild without it, so we never turn a benign warning into a hard error.
   function buildProgram(withNodeEnv: boolean) {
     const rootNames = withNodeEnv ? [fileName, NODE_ENV_DTS_NAME] : [fileName];
     const prog = ts.createProgram(rootNames, compilerOptions, compilerHost);

--- a/tests/issue-2603-warning-dedup-auto-emulate.test.ts
+++ b/tests/issue-2603-warning-dedup-auto-emulate.test.ts
@@ -2,7 +2,9 @@ import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import ts from "typescript";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { analyzeSource, buildNodeEnvDtsForSource } from "../src/checker/index.js";
 
 // #2603 follow-ups to `--emulate node`:
 //  1. identical Node/builtin "Cannot find name 'X'" warnings collapse to one line.
@@ -52,5 +54,86 @@ describe("#2603 warning dedup + node:-import auto-emulate", () => {
     const out = runCli("noemu.js", src, ["--emulate", "none"]);
     expect(out).not.toContain("auto-enabled Node API emulation");
     expect(procWarnLines(out).length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// #2624 — the injected Node typing is IMPORT-SCOPED, not blanket. The synthetic
+// `.d.ts` declares ONLY the surface the source touches: the `process` global is
+// injected ONLY for a bare `process` reference, and a `node:<mod>` import injects
+// ONLY that module (just its imported member names), never the whole Node surface.
+// Asserted directly against `buildNodeEnvDtsForSource` (the exact injected text).
+describe("#2624 import-scoped Node emulation typing", () => {
+  it("a node:fs-only program does NOT inject the `process` global", () => {
+    const dts = buildNodeEnvDtsForSource(
+      `import { readFileSync } from "node:fs";\nconst f = readFileSync;\nexport const z = 1;\n`,
+    );
+    expect(dts).toBeDefined();
+    // node:fs is declared, scoped to the imported member...
+    expect(dts).toContain('declare module "node:fs"');
+    expect(dts).toContain("export const readFileSync: any;");
+    // ...but the `process` global / interfaces are NOT pulled in.
+    expect(dts).not.toContain("declare var process");
+    expect(dts).not.toContain("NodeJS_Process");
+    expect(dts).not.toContain('declare module "node:process"');
+  });
+
+  it("a bare `process` reference injects ONLY the process global, no unrelated modules", () => {
+    const dts = buildNodeEnvDtsForSource(`process.stdout.write("x");\nprocess.exit(0);\n`);
+    expect(dts).toBeDefined();
+    expect(dts).toContain("declare var process: NodeJS_Process;");
+    expect(dts).toContain("NodeJS_WritableStream");
+    // No module declarations leak in for a program that imports nothing.
+    expect(dts).not.toContain("declare module");
+  });
+
+  it("a node:process import injects the process module but NOT unrelated node:* modules", () => {
+    const dts = buildNodeEnvDtsForSource(`import process from "node:process";\nprocess.exit(0);\n`);
+    expect(dts).toBeDefined();
+    expect(dts).toContain('declare module "node:process"');
+    expect(dts).toContain("export default process;");
+    expect(dts).toContain("NodeJS_Process");
+    // Only node:process — no node:fs / node:path leaked.
+    expect(dts).not.toContain('declare module "node:fs"');
+    expect(dts).not.toContain('declare module "node:path"');
+    // The import binds `process`, so we do NOT also emit the ambient global.
+    expect(dts).not.toContain("declare var process");
+  });
+
+  it("multiple node:* imports each declare only their own imported members", () => {
+    const dts = buildNodeEnvDtsForSource(
+      `import { readFileSync, writeFileSync } from "node:fs";\nimport { join } from "node:path";\nvoid readFileSync; void writeFileSync; void join;\n`,
+    );
+    expect(dts).toBeDefined();
+    expect(dts).toContain('declare module "node:fs"');
+    expect(dts).toContain("export const readFileSync: any;");
+    expect(dts).toContain("export const writeFileSync: any;");
+    expect(dts).toContain('declare module "node:path"');
+    expect(dts).toContain("export const join: any;");
+    // No process surface for a program that never touches process.
+    expect(dts).not.toContain("NodeJS_Process");
+  });
+
+  it("a program that touches NO Node surface injects nothing (undefined)", () => {
+    expect(buildNodeEnvDtsForSource(`export const z: number = 1;\n`)).toBeUndefined();
+  });
+
+  it("end-to-end: node:process import + named member resolve under emulateNode (no TS2307/TS2580)", () => {
+    const ast = analyzeSource(`import { stdout } from "node:process";\nstdout.write("x");\n`, "e2e-proc.ts", {
+      emulateNode: true,
+    });
+    const msgs = ast.diagnostics.map((d) =>
+      typeof d.messageText === "string" ? d.messageText : d.messageText.messageText,
+    );
+    expect(
+      msgs.filter((m) => /Cannot find module|Cannot find name 'process'|Cannot find name 'stdout'/.test(m)),
+    ).toEqual([]);
+  });
+
+  it("scriptKind defaults are sane for a .ts source with a default import", () => {
+    // sanity: namespace import resolves too (the whole-module `any` shape).
+    const dts = buildNodeEnvDtsForSource(`import * as fs from "node:fs";\nvoid fs;\n`, ts.ScriptKind.TS);
+    expect(dts).toBeDefined();
+    expect(dts).toContain('declare module "node:fs"');
+    expect(dts).toContain("export default");
   });
 });


### PR DESCRIPTION
## Problem

`--emulate node` (#2603) injected a **blanket** ambient `.d.ts` that always declared the global `process` whenever emulation was on, regardless of what Node surface the program used. A `node:fs`-only program still got an ambient `process`, and there was no per-module typing for `node:<mod>` imports.

The agreed per-module design (loopdive/js2#389) is that Node emulation is **per-imported-module, not blanket**, with the type and runtime layers lining up 1:1. This PR is the **type layer**.

## Fix

`src/checker/index.ts`, `analyzeSource`: when `emulateNode` is on, build the injected `.d.ts` **dynamically** from the source, scoped to what it touches:

- `scanNodeEmuUsage` — cheap single-parse scan of `node:<mod>` imports (default/named/namespace) + `require("node:<mod>")` and a bare global `process` reference.
- `buildNodeEnvDts` — emits the `process` global **only** for a bare reference; a typed `node:process` module (default + named members) for that import; a permissive `declare module` with just the imported member names for other `node:<mod>`; `undefined` when no Node surface is touched.
- `buildNodeEnvDtsForSource` exported for exact-text assertions.

A `node:fs`-only program no longer gets an ambient `process`; a `node:process` import resolves without pulling in unrelated modules. Kept the #2603 flag, node:-import auto-detect, dup-identifier fallback, and warning dedup.

## Verification

- **Type-level only** — example host `examples/native-messaging/nm_js2wasm.ts` wasm md5 unchanged (`428a96eb38121be46a7983bdff883e70`) for the default path and `--emulate node`.
- `tests/issue-2603-warning-dedup-auto-emulate.test.ts` — 7 new import-scope cases + the existing 3 pass (10 total).

Refs loopdive/js2#389, #2603, #2524, #2512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)