### PR TITLE
test(#2587): regression-lock nested obj-pattern default in static class method

### DIFF
--- a/plan/issues/2587-nested-obj-pattern-default-static-method-stack-overflow.md
+++ b/plan/issues/2587-nested-obj-pattern-default-static-method-stack-overflow.md
@@ -1,9 +1,11 @@
 ---
 id: 2587
 title: "compiler stack-overflow on nested object-pattern-with-default destructuring param in a (static) class method"
-status: ready
-sprint: Backlog
+status: done
+sprint: 65
 created: 2026-06-21
+completed: 2026-06-22
+assignee: ttraenkler/dev-acorn
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -48,9 +50,10 @@ The nested-pattern-with-initializer arm of the parameter-destructuring lowering:
 `src/codegen/destructuring-params.ts:~523-534` — the `__ext_dparam_nested_*`
 recursion (`destructureParamObjectExternref` / `destructureParamArray` recursing
 into the nested pattern) combined with the `element.initializer` default-eval
-+ `ctx.liveBodies` body-swap window. The recursion does not bottom out for a
-nested object pattern that itself carries a default object literal whose fields
-are again bindings — the default-eval re-enters the same nested-pattern compile.
+
+- `ctx.liveBodies` body-swap window. The recursion does not bottom out for a
+  nested object pattern that itself carries a default object literal whose fields
+  are again bindings — the default-eval re-enters the same nested-pattern compile.
 
 ## Suggested approach
 
@@ -70,3 +73,47 @@ are again bindings — the default-eval re-enters the same nested-pattern compil
 - The `class/dstr/*obj-ptrn*-{prop,elem}-*-init*` cluster no longer
   `compile_error`s.
 - No regression in the existing destructuring suites.
+
+## Resolution (2026-06-22, dev-acorn)
+
+**Already fixed on `origin/main`** (HEAD `45ae22b3301`). The stack overflow no
+longer reproduces — neither the minimal `static method({ w: { x, y, z } = {...} })`
+case nor the full double-default test262 shape
+(`{ w: { x, y, z } = { x:4, y:5, z:6 } } = { w: { x:10, z:7 } }`) throws.
+
+The issue was filed 2026-06-21 on then-clean main; the nested
+destructuring-param-default work that landed during sprint 65 resolved it,
+specifically:
+
+- **#2158** (`da9a26cdd05`) — "dstr-param default with nested sub-pattern emits
+  valid Wasm"
+- **#2568** (`2f24ab71b2e`) — "two-level nested destructuring-param default
+  reads 0 — struct-shape match"
+- **#2545** — nested destructuring-param default outer-pattern eval
+
+The nested-pattern descent in `destructureParamObjectExternref`
+(`src/codegen/destructuring-params.ts`) now bottoms out correctly through the
+default-initializer compile + body-swap window.
+
+### Test Results
+
+All six representative test262 files — including
+`meth-static-dflt-obj-ptrn-prop-obj.js` whose body the issue quotes, plus the
+`gen-meth-static-*` and `async-gen-meth-static-*` variants — **compile cleanly**
+(no `compile_error`):
+
+| file                                           | result   |
+| ---------------------------------------------- | -------- |
+| `meth-static-dflt-obj-ptrn-prop-obj`           | COMPILED |
+| `meth-static-obj-ptrn-prop-obj`                | COMPILED |
+| `gen-meth-static-dflt-obj-ptrn-prop-obj`       | COMPILED |
+| `gen-meth-static-obj-ptrn-prop-obj`            | COMPILED |
+| `async-gen-meth-static-dflt-obj-ptrn-prop-obj` | COMPILED |
+| `meth-static-dflt-obj-ptrn-prop-obj-init`      | COMPILED |
+
+Runtime semantics verified (host): outer default applied → `997`; inner default
+on `{ w: undefined }` → `456`; explicit values → `123`. Standalone
+(`nativeStrings`) compiles clean.
+
+Regression-locked by `tests/issue-2587-nested-objpat-default-static-method.test.ts`
+(3 cases: host-compile, standalone-compile, runtime semantics).

--- a/tests/issue-2587-nested-objpat-default-static-method.test.ts
+++ b/tests/issue-2587-nested-objpat-default-static-method.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.ts";
+import { compileAndInstantiate } from "../src/runtime-instantiate.ts";
+
+// #2587 — a static class method whose parameter is a nested object binding
+// pattern with a default initializer (the exact shape of the test262
+// `class/dstr/*obj-ptrn*-init*` family, e.g. `meth-static-dflt-obj-ptrn-prop-obj.js`)
+// used to crash the COMPILER with infinite recursion ("Maximum call stack size
+// exceeded") in the parameter-destructuring lowering. The nested-pattern descent
+// combined with the default-initializer compile did not bottom out.
+//
+// Resolved on main by the nested dstr-param-default work (#2158 valid-Wasm for a
+// nested sub-pattern, #2568 two-level nested default struct-shape match, #2545
+// outer-pattern eval). This test regression-locks the class-method shape so the
+// recursion cannot reappear.
+describe("#2587 nested obj-pattern default in a static class method", () => {
+  it("compiles the double-default shape without a stack overflow (host)", async () => {
+    const src = `class C {
+      static method({ w: { x, y, z } = { x: 4, y: 5, z: 6 } }: any = { w: { x: 10, z: 7 } }): number {
+        return x as number;
+      }
+    }
+    export function test(): number { return C.method() ?? -1; }`;
+    const r = await compile(src, { fileName: "test.ts" });
+    expect(r.success).toBe(true);
+  });
+
+  it("compiles the same shape under standalone (nativeStrings)", async () => {
+    const src = `class C {
+      static method({ w: { x, y, z } = { x: 4, y: 5, z: 6 } }: any = { w: { x: 10, z: 7 } }): number {
+        return x as number;
+      }
+    }
+    export function test(): number { return C.method() ?? -1; }`;
+    const r = await compile(src, { fileName: "test.ts", nativeStrings: true });
+    expect(r.success).toBe(true);
+  });
+
+  it("applies outer and inner defaults with correct runtime semantics", async () => {
+    const src = `class C {
+      static method({ w: { x, y, z } = { x: 4, y: 5, z: 6 } }: any = { w: { x: 10, z: 7 } }): number {
+        return (x ?? -1) * 100 + (y ?? -1) * 10 + (z ?? -1);
+      }
+      static call1(): number { return C.method(); }
+      static call2(): number { return C.method({ w: undefined }); }
+      static call3(): number { return C.method({ w: { x: 1, y: 2, z: 3 } }); }
+    }
+    export function call1(): number { return C.call1(); }
+    export function call2(): number { return C.call2(); }
+    export function call3(): number { return C.call3(); }`;
+    const ex = (await compileAndInstantiate(src)) as {
+      call1(): number;
+      call2(): number;
+      call3(): number;
+    };
+    // No arg: outer default { w: { x: 10, z: 7 } } destructured directly →
+    // x=10, y=undefined, z=7 → 10*100 + (-1)*10 + 7 = 997.
+    expect(ex.call1()).toBe(997);
+    // { w: undefined }: inner `w` is undefined → inner default { x:4, y:5, z:6 } → 456.
+    expect(ex.call2()).toBe(456);
+    // { w: { x:1, y:2, z:3 } }: explicit values → 123.
+    expect(ex.call3()).toBe(123);
+  });
+});


### PR DESCRIPTION
## #2587 — nested obj-pattern-default destructuring param in a static class method

### Finding: already fixed on `origin/main`

The compiler stack-overflow described in #2587 — compiling a static class method
whose parameter is a **nested object binding pattern with a default initializer**:

```ts
class C {
  static method({ w: { x, y, z } = { x: 4, y: 5, z: 6 } } = { w: { x: 10, z: 7 } }) {
    return x;
  }
}
```

**no longer reproduces** on current `origin/main`. The issue was filed 2026-06-21
on then-clean main; the sprint-65 nested destructuring-param-default work resolved
it — specifically #2158 (`da9a26cdd05`, "dstr-param default with nested sub-pattern
emits valid Wasm"), #2568 (`2f24ab71b2e`, "two-level nested default — struct-shape
match"), and #2545 (outer-pattern eval). The nested-pattern descent in
`destructureParamObjectExternref` (`src/codegen/destructuring-params.ts`) now bottoms
out correctly through the default-initializer compile + body-swap window.

### What this PR does

- **Adds `tests/issue-2587-nested-objpat-default-static-method.test.ts`** to
  regression-lock the class-method shape (the recursion cannot reappear):
  - host-compile of the double-default shape (no stack overflow),
  - standalone (`nativeStrings`) compile,
  - runtime semantics — outer default applied → `997`; inner default on
    `{ w: undefined }` → `456`; explicit values → `123`.
- **Marks #2587 `status: done`** with a Resolution + Test Results section.

### Verification

All six representative test262 files compile clean (no `compile_error`), including
`meth-static-dflt-obj-ptrn-prop-obj.js` (whose body the issue quotes) plus the
`gen-meth-static-*` and `async-gen-meth-static-*` variants. New test passes
(3/3); `tsc --noEmit` clean; prettier applied.

Part of the acorn-npm-package dogfood (#58).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA