### PR TITLE
refactor(codegen): rename node-io shim to node-process + unify --link-node-shims flag (#2625)

### DIFF
--- a/examples/native-messaging/NODE-PROCESS-SHIM.md
+++ b/examples/native-messaging/NODE-PROCESS-SHIM.md
@@ -1,16 +1,16 @@
-# `js2wasm:node-io` shim (#2524 Phase 1)
+# `js2wasm:node-process` shim (#2625; originally #2524 Phase 1)
 
-`--node-io-shim` factors the `process` stream IO host-API out of every compiled
+`--link-node-shims` factors the `process` stream IO host-API out of every compiled
 module into a separately-compiled, **linkable** core-wasm shim. Instead of
 inlining the `wasi_snapshot_preview1.fd_read` / `fd_write` glue, a module
-compiled with this flag **imports a stable `js2wasm:node-io` interface** and
-links against `node-shim.wasm`, which implements that interface over WASI.
+compiled with this flag **imports a stable `js2wasm:node-process` interface** and
+links against `node-process.wasm`, which implements that interface over WASI.
 
 This is the modularization mechanism that generalizes: the same interface can be
 backed by a deno shim, a browser shim, or an `fs`/`path` shim — swap the shim,
 keep the user module.
 
-## Interface (`js2wasm:node-io`)
+## Interface (`js2wasm:node-process`)
 
 A byte boundary over a **shared linear memory** — nothing GC-typed crosses the
 link (that is Phase 2, #2514):
@@ -26,7 +26,7 @@ link (that is Phase 2, #2514):
 The **shim owns + exports** the linear memory; the **user module imports** it
 (memory index 0) along with the three IO functions. So:
 
-1. Instantiate `node-shim.wasm` first — it imports only `wasi_snapshot_preview1`.
+1. Instantiate `node-process.wasm` first — it imports only `wasi_snapshot_preview1`.
 2. Instantiate the user module with `{ memory, stdin_read, stdout_write,
    stderr_write }` taken from the shim's exports.
 
@@ -39,22 +39,22 @@ iovec in its own reserved scratch, and issues the syscall.
 Compile the user module:
 
 ```sh
-npx js2wasm examples/native-messaging/nm_js2wasm.ts --target wasi --node-io-shim -o out
+npx js2wasm examples/native-messaging/nm_js2wasm.ts --target wasi --link-node-shims -o out
 ```
 
-The emitted `out/nm_js2wasm.wasm` imports only `js2wasm:node-io` (memory + the
+The emitted `out/nm_js2wasm.wasm` imports only `js2wasm:node-process` (memory + the
 IO functions it uses) and carries **no** `wasi_snapshot_preview1` import for the
 stream-IO path.
 
 (Re)generate the shim:
 
 ```sh
-node scripts/build-node-io-shim.mjs            # writes examples/native-messaging/node-shim.wasm + .wat
+node scripts/build-node-process-shim.mjs            # writes examples/native-messaging/node-process.wasm + .wat
 ```
 
-`node-shim.wasm` is a generated artifact (gitignored); `node-shim.wat` is the
+`node-process.wasm` is a generated artifact (gitignored); `node-process.wat` is the
 committed source. Run the generator once before linking, or call the exported
-`buildNodeIoShim()` to assemble it in-process (the test does this).
+`buildNodeProcessShim()` to assemble it in-process (the test does this).
 
 ## Link + run
 
@@ -63,7 +63,7 @@ committed source. Run the generator once before linking, or call the exported
 ```js
 import { readFileSync } from "node:fs";
 
-const shimBin = readFileSync("examples/native-messaging/node-shim.wasm");
+const shimBin = readFileSync("examples/native-messaging/node-process.wasm");
 const userBin = readFileSync("out/nm_js2wasm.wasm");
 
 // Minimal WASI fd_read/fd_write over the shim-owned memory (or use a real WASI).
@@ -76,7 +76,7 @@ const wasi = {
 const shim = await WebAssembly.instantiate(shimBin, { wasi_snapshot_preview1: wasi });
 mem = shim.instance.exports.memory;
 const user = await WebAssembly.instantiate(userBin, {
-  "js2wasm:node-io": {
+  "js2wasm:node-process": {
     memory:       shim.instance.exports.memory,
     stdin_read:   shim.instance.exports.stdin_read,
     stdout_write: shim.instance.exports.stdout_write,
@@ -90,13 +90,13 @@ user.instance.exports.main();
 
 ```sh
 wasmtime run \
-  --preload js2wasm:node-io=examples/native-messaging/node-shim.wasm \
+  --preload js2wasm:node-process=examples/native-messaging/node-process.wasm \
   --invoke main \
   out/nm_js2wasm.wasm
 ```
 
 `--preload <name>=<file>` registers the shim under the import module name
-`js2wasm:node-io`; wasmtime resolves the user module's imports against it and
+`js2wasm:node-process`; wasmtime resolves the user module's imports against it and
 provides `wasi_snapshot_preview1` to the shim.
 
 ## Scope

--- a/examples/native-messaging/README.md
+++ b/examples/native-messaging/README.md
@@ -242,15 +242,15 @@ the compiled module's linear memory below a 512 MiB cap.
    raw bytes on stdin and produces correctly framed bytes on stdout via
    `process.stdout.write` (a `Uint8Array` prefix + the JSON body).
 
-## Linkable `js2wasm:node-io` shim (`--node-io-shim`, #2524)
+## Linkable `js2wasm:node-process` shim (`--link-node-shims`, #2625)
 
 By default the stdin/stdout glue is inlined as `wasi_snapshot_preview1.fd_read`
-/ `fd_write` in every module. With `--target wasi --node-io-shim`, the module
-instead imports a stable `js2wasm:node-io` interface (plus its linear memory)
-and links against a small, separately-compiled `node-shim.wasm` that implements
+/ `fd_write` in every module. With `--target wasi --link-node-shims`, the module
+instead imports a stable `js2wasm:node-process` interface (plus its linear memory)
+and links against a small, separately-compiled `node-process.wasm` that implements
 that interface over WASI — proving the modular linking pattern that generalizes
 to fs/path and to deno/browser shims. See
-[NODE-IO-SHIM.md](./NODE-IO-SHIM.md) for the interface, the memory-ownership
+[NODE-PROCESS-SHIM.md](./NODE-PROCESS-SHIM.md) for the interface, the memory-ownership
 model, and the Node + wasmtime link steps.
 
 ## Reference hosts in other runtimes

--- a/examples/native-messaging/node-process.wat
+++ b/examples/native-messaging/node-process.wat
@@ -1,5 +1,5 @@
 (module
-  ;; js2wasm:node-io shim — implements the byte-boundary IO interface over WASI.
+  ;; js2wasm:node-process shim — implements the byte-boundary IO interface over WASI.
   (import "wasi_snapshot_preview1" "fd_write"
     (func $fd_write (param i32 i32 i32 i32) (result i32)))
   (import "wasi_snapshot_preview1" "fd_read"

--- a/plan/issues/2625-rename-node-io-to-node-process-shim.md
+++ b/plan/issues/2625-rename-node-io-to-node-process-shim.md
@@ -1,0 +1,76 @@
+---
+id: 2625
+title: "Rename js2wasm:node-io shim to js2wasm:node-process + unify --link-node-shims flag"
+status: done
+sprint: Backlog
+created: 2026-06-22
+updated: 2026-06-22
+completed: 2026-06-22
+priority: medium
+feasibility: medium
+task_type: refactor
+area: codegen
+language_feature: node-host-apis
+goal: standalone-mode
+related: [2603, 2524, 2512, 389, 2624]
+---
+# #2625 — Rename `js2wasm:node-io` → `js2wasm:node-process` + unify `--link-node-shims`
+
+This is the RUNTIME layer of the per-module Node-emulation design
+(stakeholder-confirmed, loopdive/js2#389). PR2 of the two-PR Node-API-emulation
+effort.
+
+## Problem
+
+#2524 Phase 1 introduced a single generic linkable shim named `js2wasm:node-io`,
+gated behind a `--node-io-shim` flag. Two issues:
+
+1. **`node-io` is generic.** The per-module design (loopdive/js2#389) makes Node
+   host APIs **one linkable shim PER MODULE**, named after the module: the
+   `node:process` IO surface becomes `js2wasm:node-process`, with siblings like
+   `js2wasm:node-fs` / `js2wasm:node-path` to follow. A single `node-io`
+   namespace can't express that.
+2. **The flag conflated two orthogonal axes.** `--node-io-shim` mixed "which
+   modules are emulated" (now the job of auto-detect / `--emulate`) with
+   "inline-vs-linked" (the only thing a flag should choose).
+
+## Design
+
+- **Rename the shim module string** `js2wasm:node-io` → `js2wasm:node-process`
+  everywhere it appears as an import-module literal (the four `addImport` calls
+  for memory + stdout_write/stderr_write/stdin_read in `src/codegen/index.ts`),
+  plus the strict-mode dual-mode allowlist entry in
+  `src/codegen/host-import-allowlist.ts` (`ALWAYS_ALLOWED_IMPORT_MODULES`) — the
+  allowlist gate is what drops the import under WASI strict mode if the name
+  drifts, so it MUST track the rename.
+- **Replace `--node-io-shim` with one global `--link-node-shims`**
+  (`CompileOptions.linkNodeShims`, default **false**):
+  - **false** = the current inline `fd_read`/`fd_write` path (self-contained,
+    the #389 default). This path is BYTE-IDENTICAL to before.
+  - **true** = emit the per-module `js2wasm:node-<mod>` imports and expect the
+    shim linked.
+  - `CompileOptions.nodeIoShim` and the `--node-io-shim` CLI arg are removed.
+    The internal codegen gate field `ctx.nodeIoShim` is renamed to
+    `ctx.linkNodeShims`; the internal idx fields (`nodeIoStdoutWriteIdx`, etc.)
+    are kept (cosmetic).
+- **Which per-module shim is emitted is chosen by which modules are emulated,
+  not by this flag** — the flag only chooses inline vs linked.
+- Example artifacts renamed: `node-shim.wat` → `node-process.wat`,
+  `NODE-IO-SHIM.md` → `NODE-PROCESS-SHIM.md`, generator
+  `scripts/build-node-io-shim.mjs` → `scripts/build-node-process-shim.mjs`
+  (export `buildNodeIoShim` → `buildNodeProcessShim`), and the
+  `tests/issue-2524-node-io-shim.test.ts` → `…-node-process-shim.test.ts`.
+
+## Verification
+
+1. `npx tsc --noEmit -p tsconfig.json` → exit 0. ✓
+2. **Byte-identity of the inline default (`--link-node-shims` OFF):**
+   `nm_js2wasm.ts --target wasi` → `md5sum` == **428a96eb38121be46a7983bdff883e70**.
+   This is the hard guarantee that the inline path is untouched. ✓
+3. **Shim path (`--link-node-shims` ON):** the emitted `.wat` contains
+   `js2wasm:node-process` (4 imports) and NO `js2wasm:node-io`. ✓
+4. `npx vitest run tests/issue-2524-node-process-shim.test.ts` → 5/5 pass. ✓
+5. `! grep -rn 'node-io-shim\|nodeIoShim' src/` → the flag name is gone (the
+   internal `nodeIoStdoutWriteIdx`-style idx fields are intentionally kept). ✓
+
+References loopdive/js2#389, #2603 / #2524 / #2512 / #2624.

--- a/scripts/build-node-process-shim.mjs
+++ b/scripts/build-node-process-shim.mjs
@@ -1,14 +1,14 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /**
- * #2524 Phase 1 — build `node-shim.wasm`, the linkable implementation of the
- * `js2wasm:node-io` interface.
+ * #2625 — build `node-process.wasm`, the linkable implementation of the
+ * `js2wasm:node-process` interface.
  *
  * The shim OWNS + exports the linear memory; a user module compiled with
- * `--node-io-shim` IMPORTS that memory (memory index 0) plus the three IO
+ * `--link-node-shims` IMPORTS that memory (memory index 0) plus the three IO
  * functions, so the shim can read/write the user's bytes over the SAME memory
  * with no instantiation cycle (the shim imports only `wasi_snapshot_preview1`).
  *
- * Interface (`js2wasm:node-io`, byte boundary over the shared linear memory):
+ * Interface (`js2wasm:node-process`, byte boundary over the shared linear memory):
  *   stdin_read  (ptr i32, len i32) -> (i32)   // bytes read into mem[ptr..ptr+len)
  *   stdout_write(ptr i32, len i32) -> (i32)   // bytes written from mem[ptr..]
  *   stderr_write(ptr i32, len i32)            // (void)
@@ -25,8 +25,8 @@
  * the shim grows on demand as the user module does, so its exported memory is
  * always large enough for the scratch at the top of the current size.
  *
- * Usage: `node scripts/build-node-io-shim.mjs [outPath]`
- *   default outPath: examples/native-messaging/node-shim.wasm
+ * Usage: `node scripts/build-node-process-shim.mjs [outPath]`
+ *   default outPath: examples/native-messaging/node-process.wasm
  * Also writes the `.wat` source next to the binary for inspection / wasmtime.
  */
 import binaryen from "binaryen";
@@ -45,8 +45,8 @@ const repoRoot = resolve(here, "..");
 const IOVEC = 0; // [0]=buf_ptr [4]=buf_len
 const NCELL = 8; // [8]=nread/nwritten
 
-export const NODE_IO_SHIM_WAT = `(module
-  ;; js2wasm:node-io shim — implements the byte-boundary IO interface over WASI.
+export const NODE_PROCESS_SHIM_WAT = `(module
+  ;; js2wasm:node-process shim — implements the byte-boundary IO interface over WASI.
   (import "wasi_snapshot_preview1" "fd_write"
     (func $fd_write (param i32 i32 i32 i32) (result i32)))
   (import "wasi_snapshot_preview1" "fd_read"
@@ -78,12 +78,12 @@ export const NODE_IO_SHIM_WAT = `(module
     (i32.load (i32.const ${NCELL}))))`;
 
 /** Assemble the shim WAT to a validated wasm binary (Uint8Array). */
-export function buildNodeIoShim() {
-  const m = binaryen.parseText(NODE_IO_SHIM_WAT);
+export function buildNodeProcessShim() {
+  const m = binaryen.parseText(NODE_PROCESS_SHIM_WAT);
   m.setFeatures(binaryen.Features.All);
   if (!m.validate()) {
     m.dispose();
-    throw new Error("node-io shim: binaryen validation failed");
+    throw new Error("node-process shim: binaryen validation failed");
   }
   const bin = m.emitBinary();
   m.dispose();
@@ -94,9 +94,9 @@ export function buildNodeIoShim() {
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   const out = process.argv[2]
     ? resolve(process.argv[2])
-    : resolve(repoRoot, "examples/native-messaging/node-shim.wasm");
-  const bin = buildNodeIoShim();
+    : resolve(repoRoot, "examples/native-messaging/node-process.wasm");
+  const bin = buildNodeProcessShim();
   writeFileSync(out, bin);
-  writeFileSync(out.replace(/\.wasm$/, ".wat"), NODE_IO_SHIM_WAT + "\n");
+  writeFileSync(out.replace(/\.wasm$/, ".wat"), NODE_PROCESS_SHIM_WAT + "\n");
   console.log(`wrote ${out} (${bin.length} B) + .wat source`);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,11 +71,12 @@ Options:
                     is ON by default; this restores the pre-#1950 behaviour.
                     (No-op when binaryen/wasm-opt is unavailable — that path
                     already degrades to a one-line note, never a failure.)
-  --node-io-shim    (WASI, #2524 Phase 1) Route process.std{in,out,err} IO
-                    through the linkable js2wasm:node-io shim: the module imports
-                    stdin_read/stdout_write/stderr_write + its memory from
-                    js2wasm:node-io (no wasi_snapshot_preview1 for stream IO) and
-                    links node-shim.wasm. Off by default (inline fd_* fallback).
+  --link-node-shims (WASI, #2625) Emit the per-module linkable js2wasm:node-<mod>
+                    shims instead of inlining the host APIs. For node:process IO
+                    the module imports stdin_read/stdout_write/stderr_write + its
+                    memory from js2wasm:node-process (no wasi_snapshot_preview1 for
+                    stream IO) and links node-process.wasm. Off by default — the
+                    inline fd_read/fd_write path is self-contained.
   --emulate <env>   Emulate a host runtime's globals so they type-check without
                     @types/node. 'node' = ambient process/etc.; 'none' = off.
                     Auto-enabled (type-level only) when the source imports a
@@ -140,8 +141,9 @@ let utf8Storage = false;
 // default (strict-on under `--target wasi`); `true` / `false` = explicit
 // override from `--no-host-imports` / `--allow-host-imports`.
 let strictNoHostImports: boolean | undefined;
-// #2524 Phase 1 — process IO via the linkable js2wasm:node-io shim (WASI only).
-let nodeIoShim = false;
+// #2625 — emit the per-module linkable js2wasm:node-<mod> shims (WASI only);
+// default false keeps the self-contained inline fd_read/fd_write path.
+let linkNodeShims = false;
 // #2603 — `--emulate node`: opt into Node API emulation (ambient `process` typing).
 // `emulateExplicit` records that the user passed `--emulate`/`--no-emulate`, so a
 // `node:` import won't auto-enable over an explicit choice.
@@ -201,10 +203,11 @@ for (let i = 0; i < args.length; i++) {
     quiet = true;
   } else if (arg === "--utf8-storage") {
     utf8Storage = true;
-  } else if (arg === "--node-io-shim") {
-    // #2524 Phase 1 — route process.std* IO through the linkable js2wasm:node-io
-    // shim (WASI only). Off by default; the inline fd_read/fd_write path stays.
-    nodeIoShim = true;
+  } else if (arg === "--link-node-shims") {
+    // #2625 — emit the per-module linkable js2wasm:node-<mod> shims instead of
+    // inlining the host APIs (WASI only). Off by default; the self-contained
+    // inline fd_read/fd_write path stays.
+    linkNodeShims = true;
   } else if (arg === "--emulate" || arg.startsWith("--emulate=")) {
     // #2603 — opt into (or out of) Node API emulation. `--emulate node` gives the
     // checker an ambient `process` typing so Node globals type-check without
@@ -315,7 +318,7 @@ const result = await compile(source, {
   ...(emitWit ? { wit: witPackageName ? { packageName: witPackageName } : true } : {}),
   ...(allowFs ? { allowFs: true } : {}),
   ...(utf8Storage ? { utf8Storage: true } : {}),
-  ...(nodeIoShim ? { nodeIoShim: true } : {}),
+  ...(linkNodeShims ? { linkNodeShims: true } : {}),
   ...(emulateNode ? { emulateNode: true } : {}),
   fileName: absInput,
   ...(strictNoHostImports !== undefined ? { strictNoHostImports } : {}),

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -217,8 +217,8 @@ export function createCodegenContext(
     nullThisTypeErrorReady: false, // (#2025)
     funcClosureGlobals: new Map(),
     wasi: options?.wasi ?? false,
-    // #2524 Phase 1 — node-io shim only applies under WASI; ignored otherwise.
-    nodeIoShim: !!(options?.wasi && options?.nodeIoShim),
+    // #2625 — the linkable js2wasm:node-<mod> shims only apply under WASI; ignored otherwise.
+    linkNodeShims: !!(options?.wasi && options?.linkNodeShims),
     nodeIoStdoutWriteIdx: -1,
     nodeIoStderrWriteIdx: -1,
     nodeIoStdinReadIdx: -1,

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -67,14 +67,14 @@ export interface CodegenOptions {
   wasi?: boolean;
   /**
    * #2524 Phase 1 — route `process.std{in,out,err}` IO through a separately
-   * compiled, linkable `js2wasm:node-io` shim instead of inlining the
+   * compiled, linkable `js2wasm:node-process` shim instead of inlining the
    * `wasi_snapshot_preview1.fd_read`/`fd_write` glue. When set (WASI only), the
    * user module imports `stdin_read`/`stdout_write`/`stderr_write` plus its
-   * linear memory from `js2wasm:node-io` and carries NO `wasi_snapshot_preview1`
-   * import for the stream IO path; `node-shim.wasm` implements the interface
+   * linear memory from `js2wasm:node-process` and carries NO `wasi_snapshot_preview1`
+   * import for the stream IO path; `node-process.wasm` implements the interface
    * over WASI. Default off — the inline fd_read/fd_write path stays as fallback.
    */
-  nodeIoShim?: boolean;
+  linkNodeShims?: boolean;
   /** Standalone target (#1470): pure WasmGC, no JS host imports and no WASI
    *  runtime. Implies `nativeStrings: true` and refuses to emit any
    *  `wasm:js-string` namespace or `env::__concat_*` / `__extern_toString` /
@@ -1537,16 +1537,16 @@ export interface CodegenContext {
   supportsAsyncIr: boolean;
   /**
    * #2524 Phase 1 — when true (WASI only), `process` stream IO is lowered to
-   * imported `js2wasm:node-io` calls (over a shim-owned, imported linear
-   * memory) instead of inline `fd_read`/`fd_write`. See `nodeIoShim` in
+   * imported `js2wasm:node-process` calls (over a shim-owned, imported linear
+   * memory) instead of inline `fd_read`/`fd_write`. See `linkNodeShims` in
    * `CodegenOptions`.
    */
-  nodeIoShim: boolean;
-  /** #2524: func index of the imported `js2wasm:node-io::stdout_write` (-1 = not registered). */
+  linkNodeShims: boolean;
+  /** #2524: func index of the imported `js2wasm:node-process::stdout_write` (-1 = not registered). */
   nodeIoStdoutWriteIdx: number;
-  /** #2524: func index of the imported `js2wasm:node-io::stderr_write` (-1 = not registered). */
+  /** #2524: func index of the imported `js2wasm:node-process::stderr_write` (-1 = not registered). */
   nodeIoStderrWriteIdx: number;
-  /** #2524: func index of the imported `js2wasm:node-io::stdin_read` (-1 = not registered). */
+  /** #2524: func index of the imported `js2wasm:node-process::stdin_read` (-1 = not registered). */
   nodeIoStdinReadIdx: number;
   /** WASI import indices */
   wasiFdWriteIdx: number;

--- a/src/codegen/host-import-allowlist.ts
+++ b/src/codegen/host-import-allowlist.ts
@@ -37,12 +37,13 @@
 /** Modules other than `env` whose imports are not JS-host bindings and are always allowed. */
 export const ALWAYS_ALLOWED_IMPORT_MODULES: ReadonlySet<string> = new Set([
   "wasi_snapshot_preview1",
-  // #2524 Phase 1 — `js2wasm:node-io` is a canonical linkable Wasm interface
-  // (a separately-compiled shim implements it over WASI), NOT a JS-host
-  // binding. Like `wasi_snapshot_preview1`, it is always allowed under strict
-  // dual-mode: the module that imports it links against `node-shim.wasm` (or
-  // any conforming deno/browser shim), no JS runtime required.
-  "js2wasm:node-io",
+  // #2625 — `js2wasm:node-process` is a canonical linkable Wasm interface
+  // (a separately-compiled per-module shim implements it over WASI), NOT a
+  // JS-host binding. Like `wasi_snapshot_preview1`, it is always allowed under
+  // strict dual-mode: the module that imports it links against
+  // `node-process.wasm` (or any conforming deno/browser shim), no JS runtime
+  // required. Per-module Node shims are named `js2wasm:node-<mod>`.
+  "js2wasm:node-process",
 ]);
 
 export interface HostImportAllowlistEntry {

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -5717,8 +5717,8 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
   // output. We now place the stdin buffer in page 1 (WASI_STDIN_BUF_START) and
   // the write scratch in page 2 (WASI_WRITE_SCRATCH_START), well above any
   // data segment, and reserve 3 pages so both regions always exist.
-  if (ctx.nodeIoShim) {
-    // #2524 Phase 1 — the node-io shim OWNS + exports the linear memory; the
+  if (ctx.linkNodeShims) {
+    // #2524 Phase 1 — the node-process shim OWNS + exports the linear memory; the
     // user module IMPORTS it (memory index 0) so the shim can read/write the
     // user's bytes over the SAME memory with no instantiation cycle (shim
     // imports only wasi_snapshot_preview1; user imports {memory + io fns} from
@@ -5730,16 +5730,16 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
     // sits at memory-index 0 (loads/stores/`memory.size`/`memory.grow` all
     // target it). The import order within the import section does not perturb
     // the func index space — only func imports increment it.
-    addImport(ctx, "js2wasm:node-io", "memory", { kind: "memory", min: 3 });
+    addImport(ctx, "js2wasm:node-process", "memory", { kind: "memory", min: 3 });
     // The three byte-boundary IO functions (over the shared memory):
     //   stdout_write(ptr,len)->i32 · stderr_write(ptr,len) · stdin_read(ptr,len)->i32
     const ioWriteType = addFuncType(ctx, [{ kind: "i32" }, { kind: "i32" }], [{ kind: "i32" }], "$node_io_write");
     const ioWriteVoidType = addFuncType(ctx, [{ kind: "i32" }, { kind: "i32" }], [], "$node_io_write_void");
-    addImport(ctx, "js2wasm:node-io", "stdout_write", { kind: "func", typeIdx: ioWriteType });
+    addImport(ctx, "js2wasm:node-process", "stdout_write", { kind: "func", typeIdx: ioWriteType });
     ctx.nodeIoStdoutWriteIdx = ctx.funcMap.get("stdout_write")!;
-    addImport(ctx, "js2wasm:node-io", "stderr_write", { kind: "func", typeIdx: ioWriteVoidType });
+    addImport(ctx, "js2wasm:node-process", "stderr_write", { kind: "func", typeIdx: ioWriteVoidType });
     ctx.nodeIoStderrWriteIdx = ctx.funcMap.get("stderr_write")!;
-    addImport(ctx, "js2wasm:node-io", "stdin_read", { kind: "func", typeIdx: ioWriteType });
+    addImport(ctx, "js2wasm:node-process", "stdin_read", { kind: "func", typeIdx: ioWriteType });
     ctx.nodeIoStdinReadIdx = ctx.funcMap.get("stdin_read")!;
   } else {
     ctx.mod.memories.push({ min: 3 });
@@ -5899,22 +5899,22 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
 
   // #2524 — remember whether the source needs a stream/console *write* helper
   // (console.log/warn/error, process.std*.write) independent of the syscall
-  // import decision below. Under the node-io shim those helpers still get
-  // emitted, but they call `js2wasm:node-io::std{out,err}_write` instead of
+  // import decision below. Under the node-process shim those helpers still get
+  // emitted, but they call `js2wasm:node-process::std{out,err}_write` instead of
   // `wasi_snapshot_preview1.fd_write`.
   const needsStreamWriteHelper = needsFdWrite;
 
   // writeFileSync also needs fd_write for the actual file data write
   if (needsPathOpen) needsFdWrite = true;
 
-  // #2524 Phase 1 — when the node-io shim is active, the stream/console IO path
+  // #2524 Phase 1 — when the node-process shim is active, the stream/console IO path
   // (process.std*.write, process.stdin.read, console.log/warn/error) is lowered
-  // to `js2wasm:node-io` calls (registered above), so it does NOT pull
+  // to `js2wasm:node-process` calls (registered above), so it does NOT pull
   // wasi_snapshot_preview1.fd_read/fd_write into the user module. Only a file
   // write (writeFileSync → path_open) still needs the real syscalls. Recompute
   // the syscall-import needs accordingly: keep fd_write solely for the file
   // path, and drop fd_read entirely (stdin goes through the shim).
-  if (ctx.nodeIoShim) {
+  if (ctx.linkNodeShims) {
     needsFdWrite = needsPathOpen;
     needsFdRead = false;
   }
@@ -6055,7 +6055,7 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
   // silently shift past, corrupting later lookups (e.g. `__wasi_write_string`
   // referenced by `ensureWasiWriteI32Helper` during user-code compilation).
   // #2524 — the console/stream write helper is emitted whenever the source
-  // writes to stdout/stderr, even when the node-io shim diverts the actual
+  // writes to stdout/stderr, even when the node-process shim diverts the actual
   // syscall (so `needsFdWrite` was recomputed to the file-only need above).
   if (needsFdWrite || needsStreamWriteHelper) {
     ctx.wasiPendingFdWriteHelper = true;
@@ -6198,10 +6198,10 @@ function emitWasiWriteStringHelper(ctx: CodegenContext): void {
   ctx.funcMap.set("__wasi_write_string", funcIdx);
 
   // Parameters: 0=ptr, 1=len
-  // #2524 Phase 1 — under the node-io shim, delegate straight to the imported
-  // `js2wasm:node-io::stdout_write(ptr, len)` (the shim owns the iovec/syscall);
+  // #2524 Phase 1 — under the node-process shim, delegate straight to the imported
+  // `js2wasm:node-process::stdout_write(ptr, len)` (the shim owns the iovec/syscall);
   // no fd_write import exists in the user module.
-  const body: Instr[] = ctx.nodeIoShim
+  const body: Instr[] = ctx.linkNodeShims
     ? [
         { op: "local.get", index: 0 } as Instr,
         { op: "local.get", index: 1 } as Instr,
@@ -6247,9 +6247,9 @@ function emitWasiWriteStringStderrHelper(ctx: CodegenContext): void {
   ctx.funcMap.set("__wasi_write_string_stderr", funcIdx);
 
   // Parameters: 0=ptr, 1=len
-  // #2524 Phase 1 — under the node-io shim, delegate to the imported
-  // `js2wasm:node-io::stderr_write(ptr, len)` (returns void).
-  const body: Instr[] = ctx.nodeIoShim
+  // #2524 Phase 1 — under the node-process shim, delegate to the imported
+  // `js2wasm:node-process::stderr_write(ptr, len)` (returns void).
+  const body: Instr[] = ctx.linkNodeShims
     ? [
         { op: "local.get", index: 0 } as Instr,
         { op: "local.get", index: 1 } as Instr,
@@ -6315,13 +6315,13 @@ const LINEAR_U8_ARENA_START = 256 * 1024;
  * Inline (default) path: build the iovec at memory[0..7] pointing at
  * `srcConst`, call `fd_write(fd, iovs=0, iovs_len=1, nwritten=8)`, drop errno.
  *
- * Shim path (`ctx.nodeIoShim`): call the imported `js2wasm:node-io`
+ * Shim path (`ctx.linkNodeShims`): call the imported `js2wasm:node-process`
  * `stdout_write`/`stderr_write(srcConst, len)` directly — the shim owns the
  * iovec + syscall over the shared memory. `stdout_write` returns bytes-written
  * (dropped); `stderr_write` returns void.
  */
 function emitWasiWriteTail(ctx: CodegenContext, fd: number, srcConst: number, lenLocalIdx: number): Instr[] {
-  if (ctx.nodeIoShim) {
+  if (ctx.linkNodeShims) {
     const useStderr = fd === 2;
     const ioIdx = useStderr ? ctx.nodeIoStderrWriteIdx : ctx.nodeIoStdoutWriteIdx;
     return [
@@ -6519,8 +6519,8 @@ export function ensureWasiWriteAnyStringHelper(ctx: CodegenContext, useStderr: b
   const existing = ctx.funcMap.get(helperName);
   if (existing !== undefined) return existing;
 
-  // #2524 — node-io shim path needs no fd_write idx (see Uint8Array helper).
-  if (!ctx.wasi || (!ctx.nodeIoShim && ctx.wasiFdWriteIdx === undefined) || ctx.nativeStrTypeIdx < 0) return -1;
+  // #2524 — node-process shim path needs no fd_write idx (see Uint8Array helper).
+  if (!ctx.wasi || (!ctx.linkNodeShims && ctx.wasiFdWriteIdx === undefined) || ctx.nativeStrTypeIdx < 0) return -1;
 
   // Make sure the native-string runtime (incl. __str_flatten) is emitted.
   ensureNativeStringHelpers(ctx);
@@ -6842,7 +6842,7 @@ export function ensureWasiWriteAnyStringHelper(ctx: CodegenContext, useStderr: b
     },
 
     // #2524 — write the staged UTF-8 region (`O` bytes) via fd_write or the
-    // node-io shim's stdout/stderr_write.
+    // node-process shim's stdout/stderr_write.
     ...emitWasiWriteTail(ctx, fd, WASI_WRITE_SCRATCH_START, O),
   ];
 
@@ -6888,9 +6888,9 @@ export function ensureWasiWriteUint8ArrayHelper(
   vecTypeIdx: number,
   useStderr: boolean = false,
 ): number {
-  // #2524 — under the node-io shim the write is satisfied by the imported
-  // `js2wasm:node-io` fns (no fd_write idx); otherwise it needs the real fd_write.
-  if (!ctx.wasi || (!ctx.nodeIoShim && ctx.wasiFdWriteIdx === undefined)) return -1;
+  // #2524 — under the node-process shim the write is satisfied by the imported
+  // `js2wasm:node-process` fns (no fd_write idx); otherwise it needs the real fd_write.
+  if (!ctx.wasi || (!ctx.linkNodeShims && ctx.wasiFdWriteIdx === undefined)) return -1;
   const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
   if (arrTypeIdx < 0) return -1;
   const arrDef = ctx.mod.types[arrTypeIdx];
@@ -7005,7 +7005,7 @@ export function ensureWasiWriteUint8ArrayHelper(
       ],
     },
 
-    // #2524 — write the staged scratch region (fd_write inline, or node-io shim)
+    // #2524 — write the staged scratch region (fd_write inline, or node-process shim)
     ...emitWasiWriteTail(ctx, fd, WASI_WRITE_SCRATCH_START, LEN),
   ];
 
@@ -7045,8 +7045,8 @@ export function ensureWasiWriteArrayBufferHelper(
   const existing = ctx.funcMap.get(helperName);
   if (existing !== undefined) return existing;
 
-  // #2524 — node-io shim path needs no fd_write idx (see Uint8Array helper).
-  if (!ctx.wasi || (!ctx.nodeIoShim && ctx.wasiFdWriteIdx === undefined)) return -1;
+  // #2524 — node-process shim path needs no fd_write idx (see Uint8Array helper).
+  if (!ctx.wasi || (!ctx.linkNodeShims && ctx.wasiFdWriteIdx === undefined)) return -1;
   const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
   if (arrTypeIdx < 0) return -1;
 
@@ -7144,7 +7144,7 @@ export function ensureWasiWriteArrayBufferHelper(
       ],
     },
 
-    // #2524 — write the staged scratch region (fd_write inline, or node-io shim)
+    // #2524 — write the staged scratch region (fd_write inline, or node-process shim)
     ...emitWasiWriteTail(ctx, fd, WASI_WRITE_SCRATCH_START, LEN),
   ];
 

--- a/src/codegen/linear-uint8-codegen.ts
+++ b/src/codegen/linear-uint8-codegen.ts
@@ -443,10 +443,10 @@ export function tryEmitLinearU8StdinRead(
   }
   fctx.body.push({ op: "local.set", index: offLocal } as Instr);
 
-  // #2524 Phase 1 — under the node-io shim, hand `(ptr+off, len-off)` to the
+  // #2524 Phase 1 — under the node-process shim, hand `(ptr+off, len-off)` to the
   // imported `stdin_read`; the shim builds the iovec + calls fd_read into the
   // shared memory and returns the byte count.
-  if (ctx.nodeIoShim) {
+  if (ctx.linkNodeShims) {
     fctx.body.push({ op: "local.get", index: buf.ptrLocalIdx } as Instr);
     fctx.body.push({ op: "local.get", index: offLocal } as Instr);
     fctx.body.push({ op: "i32.add" } as Instr);
@@ -501,10 +501,10 @@ export function tryEmitLinearU8StdWrite(
   const buf = getLinearU8Buffer(ctx, fctx, bufArg);
   if (!buf) return false;
 
-  // #2524 Phase 1 — under the node-io shim, the syscall + iovec live in the
+  // #2524 Phase 1 — under the node-process shim, the syscall + iovec live in the
   // shim. The user module just hands `(ptr, len)` to the imported write fn over
   // the shared memory: zero staging copy, no iovec, no nwritten cell.
-  if (ctx.nodeIoShim) {
+  if (ctx.linkNodeShims) {
     const ioIdx = useStderr ? ctx.nodeIoStderrWriteIdx : ctx.nodeIoStdoutWriteIdx;
     fctx.body.push({ op: "local.get", index: buf.ptrLocalIdx } as Instr);
     fctx.body.push({ op: "local.get", index: buf.lenLocalIdx } as Instr);

--- a/src/codegen/node-process-api.ts
+++ b/src/codegen/node-process-api.ts
@@ -55,10 +55,10 @@ export function tryCompileNodeProcessCall(
   // #1886 Slice B: zero-copy `process.std*.write(buf)` for a linear-backed
   // Uint8Array — fd_write reads straight from `ptr` for `len` bytes (no
   // GC→linear staging copy). Only fires for a registered linear-safe buffer.
-  // #2524: under the node-io shim there is no fd_write idx; `tryEmitLinearU8StdWrite`
+  // #2524: under the node-process shim there is no fd_write idx; `tryEmitLinearU8StdWrite`
   // routes to the imported `stdout_write`/`stderr_write` instead (the passed idx
   // is unused on that branch).
-  const writeSinkIdx = ctx.nodeIoShim ? ctx.nodeIoStdoutWriteIdx : ctx.wasiFdWriteIdx;
+  const writeSinkIdx = ctx.linkNodeShims ? ctx.nodeIoStdoutWriteIdx : ctx.wasiFdWriteIdx;
   if (writeSinkIdx !== undefined && writeSinkIdx >= 0) {
     if (tryEmitLinearU8StdWrite(ctx, fctx, argExpr, writeSinkIdx, useStderr)) {
       // Match the GC Uint8Array write path's contract: push `1` (write
@@ -142,9 +142,9 @@ function matchProcessStdStreamWrite(
   fctx: FunctionContext,
   expr: ts.CallExpression,
 ): { useStderr: boolean } | null {
-  // #2524 — under the node-io shim there is no fd_write import; the write sink
-  // is `js2wasm:node-io::stdout_write`/`stderr_write` instead.
-  const haveWriteSink = ctx.nodeIoShim
+  // #2524 — under the node-process shim there is no fd_write import; the write sink
+  // is `js2wasm:node-process::stdout_write`/`stderr_write` instead.
+  const haveWriteSink = ctx.linkNodeShims
     ? ctx.nodeIoStdoutWriteIdx >= 0
     : ctx.wasiFdWriteIdx !== undefined && ctx.wasiFdWriteIdx >= 0;
   if (!ctx.wasi || !haveWriteSink) return null;
@@ -174,9 +174,9 @@ function matchProcessStdStreamDrainOnce(ctx: CodegenContext, fctx: FunctionConte
 }
 
 function matchProcessStdinRead(ctx: CodegenContext, fctx: FunctionContext, expr: ts.CallExpression): boolean {
-  // #2524 — under the node-io shim there is no fd_read import; stdin is read via
-  // `js2wasm:node-io::stdin_read` instead.
-  const haveReadSink = ctx.nodeIoShim
+  // #2524 — under the node-process shim there is no fd_read import; stdin is read via
+  // `js2wasm:node-process::stdin_read` instead.
+  const haveReadSink = ctx.linkNodeShims
     ? ctx.nodeIoStdinReadIdx >= 0
     : ctx.wasiFdReadIdx !== undefined && ctx.wasiFdReadIdx >= 0;
   if (!ctx.wasi || !haveReadSink) return false;
@@ -189,10 +189,10 @@ function matchProcessStdinRead(ctx: CodegenContext, fctx: FunctionContext, expr:
 }
 
 function emitProcessStdinRead(ctx: CodegenContext, fctx: FunctionContext, expr: ts.CallExpression): InnerResult | null {
-  // #2524 — under the node-io shim there is no fd_read import; stdin is read via
-  // `js2wasm:node-io::stdin_read`. `readSinkIdx` is the func index to call
+  // #2524 — under the node-process shim there is no fd_read import; stdin is read via
+  // `js2wasm:node-process::stdin_read`. `readSinkIdx` is the func index to call
   // (fd_read inline, or stdin_read under the shim).
-  const readSinkIdx = ctx.nodeIoShim ? ctx.nodeIoStdinReadIdx : ctx.wasiFdReadIdx;
+  const readSinkIdx = ctx.linkNodeShims ? ctx.nodeIoStdinReadIdx : ctx.wasiFdReadIdx;
   if (readSinkIdx === undefined || readSinkIdx < 0) return null;
 
   // #1886 Slice B: when the buffer arg is a linear-backed Uint8Array, read
@@ -269,7 +269,7 @@ function emitProcessStdinRead(ctx: CodegenContext, fctx: FunctionContext, expr: 
   } as Instr);
 
   const nreadLocal = allocLocal(fctx, `__stdin_nread_${fctx.locals.length}`, { kind: "i32" });
-  if (ctx.nodeIoShim) {
+  if (ctx.linkNodeShims) {
     // #2524 — nread = stdin_read(WASI_STDIN_BUF_START, cap); the shim builds the
     // iovec + calls fd_read into the shared memory and returns the byte count.
     fctx.body.push({ op: "i32.const", value: WASI_STDIN_BUF_START } as Instr);

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -835,7 +835,7 @@ export function compileSourceSync(
         utf8Storage: options.utf8Storage,
         testRuntime: options.testRuntime,
         wasi: options.target === "wasi",
-        nodeIoShim: options.nodeIoShim,
+        linkNodeShims: options.linkNodeShims,
         standalone: options.target === "standalone",
         // (#2119) thread module-strictness inference for the single-source
         // path (test262 + the playground both compile via `compile()` here).
@@ -1189,7 +1189,7 @@ export async function compileMultiSource(
         utf8Storage: options.utf8Storage,
         testRuntime: options.testRuntime,
         wasi: options.target === "wasi",
-        nodeIoShim: options.nodeIoShim,
+        linkNodeShims: options.linkNodeShims,
         strictNoHostImports: options.strictNoHostImports,
         standalone: options.target === "standalone",
         // (#2119) default true (module input is strict → unmapped arguments);
@@ -1503,7 +1503,7 @@ export async function compileFilesSource(entryPath: string, options: CompileOpti
         utf8Storage: options.utf8Storage,
         testRuntime: options.testRuntime,
         wasi: options.target === "wasi",
-        nodeIoShim: options.nodeIoShim,
+        linkNodeShims: options.linkNodeShims,
         strictNoHostImports: options.strictNoHostImports,
         standalone: options.target === "standalone",
         // (#2119) default true (module input is strict → unmapped arguments);

--- a/src/index.ts
+++ b/src/index.ts
@@ -276,16 +276,18 @@ export interface CompileOptions {
    *  Default: false (calls to fs.readFileSync / fs.writeFileSync raise a compile error). */
   allowFs?: boolean;
   /**
-   * #2524 Phase 1 — route `process.std{in,out,err}` IO through a separately
-   * compiled, linkable `js2wasm:node-io` shim instead of inlining the
-   * `wasi_snapshot_preview1.fd_read`/`fd_write` glue. WASI-only (ignored for
-   * other targets). When set, the user module imports `stdin_read`/
-   * `stdout_write`/`stderr_write` plus its linear memory from `js2wasm:node-io`
-   * and carries no `wasi_snapshot_preview1` import for stream IO; link against
-   * `node-shim.wasm` (or `--preload js2wasm:node-io=node-shim.wasm` under
-   * wasmtime). Default off — the inline path stays as fallback.
+   * #2625 — emit the per-module linkable `js2wasm:node-<mod>` shims instead of
+   * inlining the host APIs. WASI-only (ignored for other targets). For
+   * `node:process` stream IO, when set, the user module imports `stdin_read`/
+   * `stdout_write`/`stderr_write` plus its linear memory from
+   * `js2wasm:node-process` and carries no `wasi_snapshot_preview1` import for
+   * stream IO; link against `node-process.wasm` (or
+   * `--preload js2wasm:node-process=node-process.wasm` under wasmtime).
+   * Default off — the self-contained inline `fd_read`/`fd_write` path stays.
+   * Which per-module shim is emitted is decided by which `node:` modules the
+   * program emulates, not by this flag (the flag only chooses inline vs linked).
    */
-  nodeIoShim?: boolean;
+  linkNodeShims?: boolean;
   /**
    * Node API emulation (#2603). Opt-in via `--emulate node`. When set, the
    * checker is given an ambient `process` declaration so Node globals js2wasm

--- a/tests/issue-2524-node-process-shim.test.ts
+++ b/tests/issue-2524-node-process-shim.test.ts
@@ -1,10 +1,10 @@
-// #2524 Phase 1 — process IO via the linkable `js2wasm:node-io` shim.
+// #2524 Phase 1 — process IO via the linkable `js2wasm:node-process` shim.
 //
-// Under `--target wasi` + `nodeIoShim: true`, a module that uses
-// process.std{in,out,err} imports the `js2wasm:node-io` interface
+// Under `--target wasi` + `linkNodeShims: true`, a module that uses
+// process.std{in,out,err} imports the `js2wasm:node-process` interface
 // (stdin_read/stdout_write/stderr_write) plus its linear memory from
-// `js2wasm:node-io`, and carries NO `wasi_snapshot_preview1` import for the
-// stream IO path. A separately compiled `node-shim.wasm` implements that
+// `js2wasm:node-process`, and carries NO `wasi_snapshot_preview1` import for the
+// stream IO path. A separately compiled `node-process.wasm` implements that
 // interface over WASI; the user module links against it (the shim OWNS +
 // exports the shared memory, the user IMPORTS it — no instantiation cycle).
 //
@@ -13,7 +13,7 @@
 
 import { describe, it, expect } from "vitest";
 import { compile } from "../src/index.js";
-import { buildNodeIoShim } from "../scripts/build-node-io-shim.mjs";
+import { buildNodeProcessShim } from "../scripts/build-node-process-shim.mjs";
 
 const DECL = `declare const process: {
   stdin: { read(buf: Uint8Array | ArrayBuffer, offset?: number): number };
@@ -45,13 +45,13 @@ const FRAMED_ECHO = `${DECL}
   }`;
 
 /**
- * Link the node-io shim + the user module and round-trip a fixed stdin payload,
+ * Link the node-process shim + the user module and round-trip a fixed stdin payload,
  * capturing fd=1 bytes. The shim owns the memory; the user module imports it
  * along with the three IO functions. A minimal WASI fd_read/fd_write serves the
  * payload incrementally over the shim-owned memory — exactly like a real host.
  */
 function linkAndRun(userBinary: Uint8Array, stdin: Uint8Array): Uint8Array {
-  const shimBinary = buildNodeIoShim();
+  const shimBinary = buildNodeProcessShim();
   const ref: { mem: WebAssembly.Memory | undefined } = { mem: undefined };
   const memView = () => new DataView(ref.mem!.buffer);
   const captured: number[] = [];
@@ -92,7 +92,7 @@ function linkAndRun(userBinary: Uint8Array, stdin: Uint8Array): Uint8Array {
   });
   ref.mem = shim.exports.memory as WebAssembly.Memory;
   const user = new WebAssembly.Instance(new WebAssembly.Module(userBinary), {
-    "js2wasm:node-io": {
+    "js2wasm:node-process": {
       memory: shim.exports.memory,
       stdout_write: shim.exports.stdout_write,
       stderr_write: shim.exports.stderr_write,
@@ -104,15 +104,15 @@ function linkAndRun(userBinary: Uint8Array, stdin: Uint8Array): Uint8Array {
   return Uint8Array.from(captured);
 }
 
-describe("#2524 Phase 1 — js2wasm:node-io shim", () => {
-  it("user module imports js2wasm:node-io (memory + io fns), no wasi_snapshot_preview1", async () => {
-    const result = await compile(FRAMED_ECHO, { fileName: "x.ts", target: "wasi", nodeIoShim: true });
+describe("#2524 Phase 1 — js2wasm:node-process shim", () => {
+  it("user module imports js2wasm:node-process (memory + io fns), no wasi_snapshot_preview1", async () => {
+    const result = await compile(FRAMED_ECHO, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
     expect(result.success).toBe(true);
     const wat = result.wat ?? "";
-    // Imports the node-io interface: memory + the IO functions it uses.
-    expect(wat).toContain('(import "js2wasm:node-io" "memory" (memory');
-    expect(wat).toContain('(import "js2wasm:node-io" "stdin_read"');
-    expect(wat).toContain('(import "js2wasm:node-io" "stdout_write"');
+    // Imports the node-process interface: memory + the IO functions it uses.
+    expect(wat).toContain('(import "js2wasm:node-process" "memory" (memory');
+    expect(wat).toContain('(import "js2wasm:node-process" "stdin_read"');
+    expect(wat).toContain('(import "js2wasm:node-process" "stdout_write"');
     // NO wasi_snapshot_preview1 import survives for the stream IO path.
     expect(wat).not.toContain("wasi_snapshot_preview1");
     // The user module does NOT declare/own its own memory — it imports it.
@@ -129,11 +129,11 @@ describe("#2524 Phase 1 — js2wasm:node-io shim", () => {
     expect(wat).toContain("fd_write");
     // Inline path declares + exports its own memory.
     expect(wat).toContain('(export "memory"');
-    expect(wat).not.toContain("js2wasm:node-io");
+    expect(wat).not.toContain("js2wasm:node-process");
   });
 
-  it("links node-shim.wasm and round-trips a framed message byte-for-byte", async () => {
-    const result = await compile(FRAMED_ECHO, { fileName: "x.ts", target: "wasi", nodeIoShim: true });
+  it("links node-process.wasm and round-trips a framed message byte-for-byte", async () => {
+    const result = await compile(FRAMED_ECHO, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
     expect(result.success).toBe(true);
     // frame: len=5 (LE) + a body with non-printable / high bytes.
     const frame = Uint8Array.from([0x05, 0x00, 0x00, 0x00, 0x00, 0xff, 0x0a, 0x7f, 0x80]);
@@ -165,7 +165,7 @@ describe("#2524 Phase 1 — js2wasm:node-io shim", () => {
           process.stdout.write(body);
         }
       }`;
-    const result = await compile(src, { fileName: "x.ts", target: "wasi", nodeIoShim: true });
+    const result = await compile(src, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
     expect(result.success).toBe(true);
     // frame1: len=2 "AB"; frame2: len=3 "XYZ"
     const frames = Uint8Array.from([0x02, 0, 0, 0, 0x41, 0x42, 0x03, 0, 0, 0, 0x58, 0x59, 0x5a]);
@@ -173,10 +173,10 @@ describe("#2524 Phase 1 — js2wasm:node-io shim", () => {
     expect(Array.from(out)).toEqual([0x02, 0, 0, 0, 0x41, 0x42, 0x03, 0, 0, 0, 0x58, 0x59, 0x5a]);
   });
 
-  it("nodeIoShim is ignored for non-WASI targets (no node-io import)", async () => {
+  it("linkNodeShims is ignored for non-WASI targets (no node-process import)", async () => {
     const src = `export function add(a: number, b: number): number { return a + b; }`;
-    const result = await compile(src, { fileName: "x.ts", nodeIoShim: true });
+    const result = await compile(src, { fileName: "x.ts", linkNodeShims: true });
     expect(result.success).toBe(true);
-    expect(result.wat ?? "").not.toContain("js2wasm:node-io");
+    expect(result.wat ?? "").not.toContain("js2wasm:node-process");
   });
 });


### PR DESCRIPTION
PR2 of the two-PR Node-API-emulation effort (loopdive/js2#389). Node host APIs become one linkable shim **per module**, named after the module: `node:process` IO → `js2wasm:node-process` (was the generic `js2wasm:node-io` from #2524 Phase 1).

## Problem

- `node-io` is a generic name; the per-module design (#389) names each shim after its module (`js2wasm:node-process`, with `node-fs`/`node-path` to follow).
- The `--node-io-shim` flag conflated "which modules are emulated" (now auto-detect / `--emulate`'s job) with "inline-vs-linked" (the only thing a flag should choose).

## Design

- **Part A** — rename the shim module string `js2wasm:node-io` → `js2wasm:node-process` everywhere it is an import-module literal (the four `addImport` calls for memory + stdout_write/stderr_write/stdin_read in `src/codegen/index.ts`), plus the strict-mode dual-mode allowlist entry in `src/codegen/host-import-allowlist.ts` (`ALWAYS_ALLOWED_IMPORT_MODULES`). The allowlist must track the rename or the imports get dropped under WASI strict mode (and func indices go out of range).
- **Part B** — replace `--node-io-shim` (`CompileOptions.nodeIoShim`) with one global `--link-node-shims` (`CompileOptions.linkNodeShims`, default **false**). `false` = inline `fd_read`/`fd_write` path (self-contained, the #389 default — **byte-identical** to before); `true` = emit the `js2wasm:node-<mod>` imports expecting the linked shim. Internal gate `ctx.nodeIoShim` → `ctx.linkNodeShims`; idx fields (`nodeIoStdoutWriteIdx`, …) kept. Which per-module shim is emitted is chosen by which modules are emulated, not by this flag.
- **Part C** — rename example artifacts: `node-shim.wat` → `node-process.wat`, `NODE-IO-SHIM.md` → `NODE-PROCESS-SHIM.md`, `scripts/build-node-io-shim.mjs` → `build-node-process-shim.mjs` (`buildNodeIoShim` → `buildNodeProcessShim`), and `tests/issue-2524-node-io-shim.test.ts` → `…-node-process-shim.test.ts`.

## Verification

1. `npx tsc --noEmit` → exit 0.
2. **Inline default (`--link-node-shims` OFF) byte-identity:** `nm_js2wasm.ts --target wasi` → md5 == `428a96eb38121be46a7983bdff883e70` (unchanged; the hard guarantee that the inline path is untouched).
3. **Shim path (ON):** emitted `.wat` has 4 `js2wasm:node-process` imports and **0** `js2wasm:node-io`.
4. `npx vitest run tests/issue-2524-node-process-shim.test.ts` → 5/5 pass; `host-import-allowlist-budget` → pass.
5. `! grep -rn 'node-io-shim\|nodeIoShim' src/` → flag name gone (internal idx fields kept).

References loopdive/js2#389, #2603 / #2524 / #2512 / #2624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)