### PR TITLE
docs(#2626): track deferred tag-5 boxed-value equality classifier (numeric+object arms)

### DIFF
--- a/plan/issues/2580-dynamic-receiver-length-undefined-substrate.md
+++ b/plan/issues/2580-dynamic-receiver-length-undefined-substrate.md
@@ -672,3 +672,15 @@ index-shift point-fix. Until that lands, the `arguments.length < 3` refusal in
 `standaloneArrayLikeMethodRefused` (array-methods.ts) stays — it is strictly
 better than the alternatives (working host path > incomplete native arm).
 Tracking task #74 set WONT-FIX on this basis.
+
+## M3/M4 follow-up: tag-5 boxed-VALUE equality (#2626)
+
+The tag-5 boxed-VALUE equality arms (numeric `f64.eq` for two `$BoxedNumber`,
+object `ref.eq` for two boxed eqref objects) are blocked on this same value-rep
+substrate. They shipped in #1888's classifier but EJECTED the merge_group floor
+(−162, class/dstr): the destructuring / generator-iterator lowering relies on the
+legacy always-false tag-5 non-string equality, so making those arms correct
+regresses the dstr cluster. The string arm (guarded #2579/#2583) landed; the
+numeric+object arms are tracked by **#2626** for the M3/M4 substrate, where the
+dstr-iterator-protocol dependency is owned. See
+`plan/issues/2626-tag5-boxed-value-equality-classifier-substrate.md`.

--- a/plan/issues/2585-proto-identity-object-create.md
+++ b/plan/issues/2585-proto-identity-object-create.md
@@ -1,10 +1,10 @@
 ---
 id: 2585
 title: "standalone: getPrototypeOf(Object.create(p)) === p is false — object identity lost in __any_strict_eq tag-5 arm"
-status: ready
+status: blocked
 sprint: 65
 created: 2026-06-21
-updated: 2026-06-21
+updated: 2026-06-22
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -13,9 +13,19 @@ task_type: bugfix
 area: codegen, runtime
 language_feature: prototype chain, strict equality, object identity
 goal: property-model
-related: [1888, 1629, 296, 2104]
+related: [1888, 1629, 296, 2104, 2626, 2580]
+depends_on: [2626]
 origin: "2026-06-21 — surfaced during s64 value-rep keystone work; proto-identity comparison gap."
 ---
+
+> **BLOCKED — folded into #2626 (2026-06-22).** The object-identity `ref.eq` arm
+> of the tag-5 equality classifier shipped in #1888 but EJECTED the merge_group on
+> the standalone-highwater floor (−162, class/dstr cluster): making tag-5 boxed-object
+> `===` reference-correct flips a comparison the destructuring / generator-iterator
+> lowering implicitly relied on. The fix is substrate-blocked and tracked, together
+> with the #2040 numeric arm, by **#2626** behind the value-rep substrate (#2580 M3/M4,
+> #35). Do not re-attempt the standalone proto-identity arm in isolation. See
+> `plan/issues/2626-tag5-boxed-value-equality-classifier-substrate.md`.
 
 ## Problem
 

--- a/plan/issues/2626-tag5-boxed-value-equality-classifier-substrate.md
+++ b/plan/issues/2626-tag5-boxed-value-equality-classifier-substrate.md
@@ -1,0 +1,91 @@
+---
+id: 2626
+title: "tag-5 boxed-VALUE equality classifier (numeric #2040 f64.eq + object #2585 ref.eq) — value-rep substrate (deferred from #1888)"
+status: backlog
+assignee: ""
+sprint: Backlog
+created: 2026-06-22
+priority: medium
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: codegen, runtime, value-rep
+language_feature: equality, ===, boxed numbers, object identity, destructuring defaults
+goal: test262-conformance
+related: [2040, 2585, 2580, 2579, 2583]
+---
+
+# #2626 — tag-5 boxed-VALUE equality classifier (numeric + object arms) — substrate-blocked
+
+## Problem
+
+The standalone `$AnyValue` tag-5 box's `externval` (field 4) is overloaded: under
+tag 5 it can hold a genuine string, a `$BoxedNumber` (the #1888 −794
+"box-the-externref-as-tag-5" contract), or a non-string GC object/closure. The
+tag-5 arm of `__any_eq` / `__any_strict_eq` (`src/codegen/any-helpers.ts`) currently
+routes to the GUARDED native string-content compare (`tag5StringEqThen()`,
+`ref.test $AnyString`-gated, `0` for non-strings) — which LANDED in #1888 and banks
+#2579 boxed-string `===` + #2583 search.
+
+Two equality cases remain WRONG for non-string tag-5 boxes (they fall to the `0`
+fallback today):
+
+1. **Numeric (#2040):** two boxed NUMBERS through `$AnyValue` — `23 === 23.0`,
+   `a !== a` after a numeric op, boxed-number `===` boxed-number — should compare
+   `__any_to_f64(a) == __any_to_f64(b)` (with `f64.eq` preserving `NaN===NaN`
+   false / −788). Today they hit the string fallback → wrong.
+2. **Object identity (#2585):** two boxed eqref OBJECTS —
+   `getPrototypeOf(Object.create(p)) === p`, `o === o` — should compare `ref.eq`
+   (reference identity). Today they hit the string fallback → wrong.
+
+## Why it is substrate-blocked (the #1888 eject)
+
+#1888 first shipped a `tag5FieldEqDecision` 3-way classifier adding exactly these
+two arms (numeric `f64.eq`, object `ref.eq`). It **EJECTED from the merge_group on
+the standalone-highwater floor (#2097): −162 standalone**, all in the
+class / class-dstr / generator-destructuring cluster.
+
+**Root cause (bisected, faithful runner standalone).** Canary
+`language/statements/class/dstr/meth-dflt-ary-ptrn-empty`: the empty
+`ArrayBindingPattern : [ ]` default (`method([] = iter)`) must NOT iterate the
+generator default — `iterations === 0`. With the classifier active it iterates
+(0→2). The destructuring / generator-iterator lowering compares tag-5 boxed VALUES
+through `__any_eq` / `__any_strict_eq` and **implicitly relied on the legacy
+always-false tag-5 non-string equality** (main's `i32.const 0` stub). Making the
+numeric (`f64.eq`) OR object (`ref.eq`) arm return a *correct* (non-zero) answer
+flips a comparison the dstr machinery counted on, corrupting the default-application
+/ iteration-guard decision.
+
+Bisection proof (re-runnable):
+- Restore #1864's `ref.test $AnyString` guard on `tag5StringEqThen` (LANDED in
+  #1888) → dstr canary PASSES, string-eq + search preserved.
+- Re-enable ONLY the classifier (numeric arm with `i32.and` gating AND object arm
+  removed) → dstr canary RE-BREAKS. So **the numeric `f64.eq` arm ALSO regresses
+  dstr**, not only the object `ref.eq` arm — both are blocked by the same
+  dstr-iterator-protocol dependency.
+
+## Scope / approach (architect-spec-first)
+
+This is NOT a point-fix on the eq helper. The dstr / generator-iterator lowering
+must stop depending on the legacy always-false tag-5 non-string equality before the
+numeric/object arms can be turned on. That dependency lives in the value-rep
+substrate — the same uniform-externref / tag-aware-reader work tracked by
+**#2580 M3/M4 (#35)**. Land this only WITH (or after) that substrate, and validate
+via the **merge_group standalone floor** (#2097) — broad-impact value-rep, NEVER a
+scoped sweep (the #1888 eject was missed by a scoped equality A/B because the −162
+is a DIFFERENT cluster; see `project_broad_impact_validate_full_ci`).
+
+Deliverables when unblocked:
+- numeric arm: BOTH field-4 `$BoxedNumber` (`i32.and`) → `__any_to_f64` + `f64.eq`;
+- object arm: BOTH field-4 non-null eqref (`ref.test (ref eq)`) → `ref.eq`;
+- re-enable the 4 `it.skip`ped cases in `tests/issue-2040-tag5-field4-eq.test.ts`
+  (marked `DEFERRED #2580 M2`);
+- merge_group floor must clear net-positive with the dstr cluster GREEN.
+
+## Provenance
+
+Deferred out of the reshaped **#1888** (merged 2026-06-22). The guarded string arm
+(#2579/#2583) landed; this captures the two value-equality arms that ejected. See
+the `## RESHAPE LANDED` + `## Merge_group EJECT + root-cause` sections in
+`plan/issues/2040-standalone-generator-dstr-runtime-semantics.md`, and memory
+`project_2040_tag5_classifier_dstr_default_regression`.


### PR DESCRIPTION
Follow-up bookkeeping after the reshaped #1888 merged (2026-06-22).

#1888 landed the guarded tag-5 string-eq arm (banks #2579 boxed-string === + #2583 search). Its two boxed-VALUE equality arms — #2040 numeric `f64.eq` and #2585 object `ref.eq` — EJECTED the merge_group on the standalone-highwater floor (−162, class/dstr cluster): the destructuring / generator-iterator lowering relies on the legacy always-false tag-5 non-string equality, so making those arms correct regresses that cluster.

This PR captures the deferred work:
- **NEW #2626** — tracks both arms, substrate-blocked behind the value-rep work (#2580 M3/M4, #35), architect-spec-first, with the bisection root-cause + re-enable checklist.
- **#2585** → `status: blocked`, `depends_on: [2626]`, with a folded-into-#2626 note.
- **#2580** → M3/M4 follow-up pointer to #2626.

Docs-only; no source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA