### PR TITLE
fix(#2608): new this(...) in fnctor static method via #56 construct-closure bridge

### DIFF
--- a/plan/issues/2608-acorn-parse-loop-post-instantiate.md
+++ b/plan/issues/2608-acorn-parse-loop-post-instantiate.md
@@ -1,10 +1,11 @@
 ---
 id: 2608
 title: "compiled-acorn parse() infinite-loops in parseTopLevel after instantiation (4th dogfood blocker)"
-status: in-progress
-assignee: sd-acorn
+status: done
+assignee: ttraenkler/dev-acorn
 created: 2026-06-21
-updated: 2026-06-21
+updated: 2026-06-22
+completed: 2026-06-22
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -12,10 +13,10 @@ task_type: fix
 area: codegen, runtime
 language_feature: multi
 goal: self-hosting-dogfood
-sprint: Backlog
+sprint: 65
 model: opus
 depends_on: [1712, 2582]
-related: [1712, 2582]
+related: [1712, 2582, 1940, 1528]
 ---
 
 # #2586 — compiled-acorn `parse()` infinite-loops in `parseTopLevel` (4th blocker)
@@ -91,10 +92,19 @@ The defect is **`new this(...)` inside an fnctor static method**, reproduced in
 ~8 lines (`.tmp/probe-static.ts`):
 
 ```ts
-var Parser = function Parser(a, b) { this.a = a; this.b = b; };
-Parser.simple   = function (x, y) { return y; };           // OK   (static, no `new this`)
-Parser.makeIdent= function (x, y) { return new Parser(x, y); }; // OK (`new Parser`)
-Parser.makeNew  = function (x, y) { return new this(x, y); };   // THROWS "is not a constructor"
+var Parser = function Parser(a, b) {
+  this.a = a;
+  this.b = b;
+};
+Parser.simple = function (x, y) {
+  return y;
+}; // OK   (static, no `new this`)
+Parser.makeIdent = function (x, y) {
+  return new Parser(x, y);
+}; // OK (`new Parser`)
+Parser.makeNew = function (x, y) {
+  return new this(x, y);
+}; // THROWS "is not a constructor"
 ```
 
 - `staticSimple` ✓, `staticNewIdent` (`new Parser(x,y)`) ✓,
@@ -161,3 +171,54 @@ enclosing fnctor ctor, and (b) forward the args in order to `<Class>_new`.
 - No test262 / equivalence regression.
 - #1712 stays open until the full parse + AST-match acceptance is met; this
   issue is the next slice toward it.
+
+## Resolution (2026-06-22, dev-acorn) — BOUNDED via the landed #56 bridge
+
+Fixed by routing `new this(...)` through the **already-landed #56
+`__construct_closure` host bridge** (#1940) — NOT the deep `__construct_fnctor`
+dispatcher substrate. Two parts in `src/codegen/expressions/new-super.ts`:
+
+1. **Exclude a `this` callee from the Pattern-2 throw.** The checker types the
+   `new this(...)` callee as the bare `function`-value (CALL sigs, NO construct
+   sigs), so the `callSigs.length > 0 && constructSigs.length === 0` guard
+   (~L2569) threw `"is not a constructor"` _before_ any `this`-aware arm ran.
+   Added `unwrappedNonId.kind !== ts.SyntaxKind.ThisKeyword` to that condition so
+   a `this` callee falls through.
+
+2. **New `new this(...)` bridge arm** (before the `if (!className)` unknown-ctor
+   block, ~L3683, JS-host only): when the callee is `ThisKeyword` and `className`
+   does not resolve to a registered class/fnctor, evaluate `this` → externref,
+   materialize args via `__js_array_new`/`__js_array_push` (source order), and
+   call `__construct_closure`. One terminal `flushLateImportShifts`. The bridge
+   detects `__is_closure`, wraps with `_wrapCallableForHost` (constructible), and
+   `Reflect.construct`s it. Standalone keeps the existing path.
+
+**Why it works without new substrate:** at runtime `this === Parser` (verified)
+and that value is a WasmGC closure struct — exactly what the #56 bridge already
+constructs. No static fnctor resolution is needed.
+
+### Root cause (corrected)
+
+The earlier analysis attributed the failure to `this` being _rewritten to an
+Identifier_. The actual cause is simpler: the checker resolves `this`'s type
+symbol to **no className** for a `Fn.method = function(){…}` static method, so
+the #1679 ThisKeyword arm (gated on a resolved className) is skipped, AND the
+Pattern-2 not-a-constructor guard fires first. Both are addressed above.
+
+### Test Results
+
+`tests/issue-2608-new-this-fnctor-static.test.ts` (sd-acorn's prior skipped case
+un-skipped + passing, 2/2 green):
+
+- `new this(x, y)` constructs and forwards args in order: `getA→10, getB→20`.
+- **Acorn shape** `Parser.parse = function(input,opts){ return new this(opts,input) }`
+  now preserves `this.input = String(input)`: `inputLen('var x = 1;')=10`,
+  `firstChar('Xyz')=88 ('X')`, `pos=0`. This is the empty-`this.input` root cause
+  that made `parseTopLevel` loop forever — RESOLVED.
+- Plain `new Parser(...)` + non-`new this` statics still work.
+- Standalone (`nativeStrings`) compiles clean (no crash).
+- Constructor/this/closure-construct regression suite (issue-1528, 1679,
+  fn-constructor, 2026-\*, 1742, 1636s1): 59 pass (2 pre-existing infra failures
+  unrelated to this change: a wrong relative import path in
+  `new-non-constructor.test.ts`, a bare-instantiate harness gap in
+  `constructor-arity.test.ts`).

--- a/plan/issues/2608-acorn-parse-loop-post-instantiate.md
+++ b/plan/issues/2608-acorn-parse-loop-post-instantiate.md
@@ -19,7 +19,18 @@ depends_on: [1712, 2582]
 related: [1712, 2582, 1940, 1528]
 ---
 
-# #2586 — compiled-acorn `parse()` infinite-loops in `parseTopLevel` (4th blocker)
+# #2608 — compiled-acorn `parse()` infinite-loops in `parseTopLevel` (4th blocker)
+
+> **Issue reconciliation (2026-06-22).** This blocker was first hand-picked as
+> `#2586`, which collided with the unrelated `2586-standalone-arrayfrom-map.md`
+> on `main` (the #2531 hand-pick race). It was re-allocated to **#2608** —
+> the canonical id for this parse()-loop blocker. The `#2586` _file_
+> (`Array.from(Map) illegal_cast`) is a different, separately-`done` issue.
+> sd-acorn's mechanism diagnosis (the `new this(...)` defect + that the generic
+> `__construct` is typeof-gated and fails closure→Proxy, and #86 callable-params
+> is a different path) correctly scoped exactly what the fix had to handle; the
+> landed fix routes through #56 `__construct_closure` — the bounded path sd-acorn
+> had not tested.
 
 ## Context
 

--- a/plan/issues/2627-ts-this-type-param-lowered-as-runtime-arg.md
+++ b/plan/issues/2627-ts-this-type-param-lowered-as-runtime-arg.md
@@ -1,0 +1,37 @@
+---
+id: 2627
+title: "TS type-only `this` parameter lowered as a runtime arg → argument shift"
+status: backlog
+sprint: Backlog
+created: 2026-06-22
+priority: lowest
+feasibility: medium
+reasoning_effort: low
+task_type: bugfix
+area: codegen
+language_feature: typescript-this-param
+origin: "2026-06-22 dev-acorn — found while probing #2608. NOT an acorn blocker (acorn uses no `this:` annotations) and 0 test262 files exercise it."
+---
+
+# #2627 — TS type-only `this` parameter lowered as a runtime arg
+
+A TypeScript `this` parameter (`function f(this: T, a, b) {}`) is a **type-only**
+pseudo-parameter that must be erased from the runtime ABI. js2wasm currently
+counts it as a real Wasm parameter, so all real arguments shift by one:
+
+```ts
+function add(this: any, a: number, b: number): number {
+  return a + b;
+}
+add(3, 4); // returns 4 (reads `b` where `a` should be) — should be 7
+```
+
+The fix: skip a leading parameter whose name is the `this` keyword everywhere a
+function's `parameters` become Wasm param locals/types (regular functions,
+function-expressions, fnctors). Care needed vs. the real instance-method `this`
+receiver (param 0 for instance methods), which is distinct from the TS
+`this`-annotation pseudo-param.
+
+**Priority: lowest.** Affects **0 test262 files** and **0 acorn source** — a
+pure-TypeScript construct with no conformance/dogfood value. Recorded for
+completeness; defer indefinitely.

--- a/plan/issues/2628-acorn-method-call-on-construct-closure-result.md
+++ b/plan/issues/2628-acorn-method-call-on-construct-closure-result.md
@@ -1,0 +1,104 @@
+---
+id: 2628
+title: "compiled-acorn: method call on a __construct_closure-constructed instance fails (5th dogfood blocker)"
+status: ready
+sprint: Backlog
+created: 2026-06-22
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: fix
+area: codegen, runtime
+language_feature: closures, classes
+goal: self-hosting-dogfood
+origin: "2026-06-22 dev-acorn — surfaced immediately after #2608 (new this construct via #56 bridge) let parse() advance past the empty-this.input loop."
+related: [2608, 1940, 1712]
+depends_on: [2608]
+---
+
+# #2628 — method call on a `__construct_closure`-constructed instance fails (5th acorn blocker)
+
+## Context
+
+#2608 fixed `new this(...)` in an fnctor static method by routing it through the
+landed #56 `__construct_closure` host bridge. That unblocked the empty-`this.input`
+loop — compiled-acorn `parse()` now advances PAST `parseTopLevel`'s empty-input
+loop. The **next** wall, surfaced immediately, is acorn's exact `parse` shape:
+
+```js
+Parser.parse = function (input, options) {
+  return new this(options, input).parse();
+};
+```
+
+The `new this(options, input)` part now works (#2608), but the **`.parse()`
+method call on the constructed instance** does not resolve.
+
+## Symptom (minimal repro)
+
+```ts
+var Parser = function Parser(opts, input) {
+  this.input = String(input);
+};
+Parser.prototype.getLen = function () {
+  return this.input.length;
+};
+
+Parser.parseViaThis = function (input) {
+  var p: any = new this({}, input);
+  return p.getLen();
+}; // THROWS "getLen is not a function"
+Parser.parseViaIdent = function (input) {
+  var p: any = new Parser({}, input);
+  return p.getLen();
+}; // OK → 5
+```
+
+- `viaIdent` (`new Parser(...).getLen()`) → **5** ✓ (identifier-constructed
+  instance: prototype-method dispatch resolves).
+- `viaThis` (`new this(...).getLen()`) → **THROWS `"getLen is not a function"`**.
+
+## Root cause (suspected)
+
+The `__construct_closure` bridge returns a **host-wrapped externref** — the result
+of `Reflect.construct(_wrapCallableForHost(closure), args)`. A subsequent
+prototype-method call (`p.getLen()`) on that value routes through the dynamic
+method-dispatch path, which expects to find the method on the compiled
+`Parser.prototype` / the WasmGC instance struct — but the bridge result is a JS
+wrapper, not the raw `__fnctor_Parser` struct, so the method lookup misses.
+
+By contrast, `new Parser(...)` returns the raw WasmGC struct directly (the
+`<Class>_new` path), and prototype-method dispatch on it resolves through the
+registered `__register_fnctor_instance` / `_fnctorProtoLookup` machinery (#1712).
+
+## Suggested approach
+
+Make the value returned by the `new this(...)` / `__construct_closure` bridge
+arm participate in the SAME prototype-method dispatch as an identifier-constructed
+fnctor instance. Either:
+
+1. Have the bridge return (or have the `new this` arm unwrap to) the raw WasmGC
+   instance struct so the existing fnctor prototype-method dispatch resolves it,
+   or
+2. Register the bridge-constructed instance with `__register_fnctor_instance`
+   (the #1712 closure→prototype link) so a method miss on the host-wrapped value
+   resolves through the closure's vivified `.prototype`.
+
+Option 1 is preferable if the bridge can canonicalize back to the struct (the
+WasmGC GC identity is preserved across the host boundary per
+`project_wasm_linking_core_over_component`). The acceptance is `viaThis() === 5`
+and, end-to-end, compiled-acorn `parse("var x = 1;")` returning a Program AST.
+
+## Acceptance
+
+- `new this(...).method()` resolves the prototype method (repro `viaThis` → 5).
+- Compiled-acorn `parse("var x = 1;")` advances past the `new this(...).parse()`
+  call (next dogfood lap — likely surfaces a 6th blocker; that's expected and
+  recorded, per the #1711 triage discipline).
+- No test262 / equivalence regression.
+
+## Notes
+
+This is **separate** from #2608 (which is purely `new this` constructing with
+correct args — DONE and verified). #2628 is the method-dispatch-on-bridge-result
+follow-on. Sequence after #2608 lands.

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -2563,10 +2563,18 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
     // Pattern 2: TypeScript knows the expression has call sigs but no construct sigs.
     // e.g. `new decodeURIComponent()`, `new Math.abs()`, `new Array.from()`.
     // Resolve on the unwrapped target so a cast doesn't widen it to `any`.
+    //
+    // (#2608) EXCEPT `new this(...)`: inside a function-constructor (fnctor) static
+    // method, the checker types `this` as the bare `function`-value, which has CALL
+    // signatures but NO construct signatures — so this guard would wrongly throw
+    // "is not a constructor". But `this` IS a constructable function-value at runtime
+    // (e.g. acorn's `Parser.parse = function(){ return new this(opts, src) }`, where
+    // `this === Parser`). Let a `this` callee fall through to the `__construct_closure`
+    // bridge arm below (JS-host), which constructs the runtime closure value directly.
     const exprType = ctx.checker.getTypeAtLocation(unwrappedNonId);
     const constructSigs = ctx.checker.getSignaturesOfType(exprType, ts.SignatureKind.Construct);
     const callSigs = ctx.checker.getSignaturesOfType(exprType, ts.SignatureKind.Call);
-    if (callSigs.length > 0 && constructSigs.length === 0) {
+    if (unwrappedNonId.kind !== ts.SyntaxKind.ThisKeyword && callSigs.length > 0 && constructSigs.length === 0) {
       // #1528: real TypeError instance — spec requires `Construct(F)` to throw
       // `TypeError("F is not a constructor")` when F has no [[Construct]].
       emitThrowTypeError(ctx, fctx, "is not a constructor");
@@ -3660,6 +3668,74 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
         }
       }
     }
+  }
+
+  // (#2608) `new this(...)` inside a function-constructor (fnctor) STATIC method
+  // — e.g. acorn's `Parser.parse = function(...) { ... return new this(opts, src) }`.
+  // The #1679 ThisKeyword arm above only fires when the checker resolves `this`'s
+  // type symbol to a known fnctor className. For a `Fn.method = function(){…}`
+  // static method the checker resolves `this` to NO symbol (className undefined),
+  // so that arm is skipped and control reaches the generic dynamic-`new` path
+  // below, which throws "is not a constructor" — the receiver is a wrapped
+  // closure externref with no compiled `<Class>_new`. At runtime, though, `this`
+  // IS correctly bound to the constructor function-value (verified `this === Fn`),
+  // and that value is a WasmGC closure struct. So route it through the landed #56
+  // `__construct_closure` host bridge (same machinery as the `new <localFnValue>()`
+  // identifier arm above): the bridge detects `__is_closure`, wraps the closure
+  // with `_wrapCallableForHost` (constructible), and `Reflect.construct`s it with
+  // the args — no static fnctor resolution needed. JS-host only; standalone keeps
+  // the existing throwing path (a Wasm-native dynamic Construct of `this` is a
+  // separate effort). ONE terminal `flushLateImportShifts` (after the call) —
+  // never mid-emission (the #608/#794 index-corruption hazard).
+  if (
+    expr.expression.kind === ts.SyntaxKind.ThisKeyword &&
+    !noJsHost(ctx) &&
+    (!className || (!ctx.classSet.has(className) && !ctx.funcConstructorMap.has(className)))
+  ) {
+    // Evaluate `this` to an externref value (the bound constructor function-value).
+    const calleeTy = compileExpression(ctx, fctx, expr.expression, { kind: "externref" });
+    if (calleeTy && calleeTy.kind !== "externref") {
+      coerceType(ctx, fctx, calleeTy, { kind: "externref" });
+    } else if (calleeTy === null) {
+      fctx.body.push({ op: "ref.null.extern" });
+    }
+    const calleeLocal = allocLocal(fctx, `__nt_callee_${fctx.locals.length}`, { kind: "externref" });
+    fctx.body.push({ op: "local.set", index: calleeLocal });
+    // Build a JS array of the args (boxed externref each), in source order.
+    const args = expr.arguments ?? [];
+    const arrNewIdx = ensureLateImport(ctx, "__js_array_new", [], [{ kind: "externref" }]);
+    const arrPushIdx = ensureLateImport(ctx, "__js_array_push", [{ kind: "externref" }, { kind: "externref" }], []);
+    const ccIdx = ensureLateImport(
+      ctx,
+      "__construct_closure",
+      [{ kind: "externref" }, { kind: "externref" }],
+      [{ kind: "externref" }],
+    );
+    flushLateImportShifts(ctx, fctx);
+    const finalArrNew = ctx.funcMap.get("__js_array_new") ?? arrNewIdx;
+    const finalArrPush = ctx.funcMap.get("__js_array_push") ?? arrPushIdx;
+    const finalCc = ctx.funcMap.get("__construct_closure") ?? ccIdx;
+    if (finalArrNew !== undefined && finalArrPush !== undefined && finalCc !== undefined) {
+      fctx.body.push({ op: "call", funcIdx: finalArrNew });
+      const argvLocal = allocLocal(fctx, `__nt_argv_${fctx.locals.length}`, { kind: "externref" });
+      fctx.body.push({ op: "local.set", index: argvLocal });
+      for (const arg of args) {
+        fctx.body.push({ op: "local.get", index: argvLocal });
+        const aTy = compileExpression(ctx, fctx, arg, { kind: "externref" });
+        if (aTy && aTy.kind !== "externref") {
+          coerceType(ctx, fctx, aTy, { kind: "externref" });
+        } else if (aTy === null) {
+          fctx.body.push({ op: "ref.null.extern" });
+        }
+        fctx.body.push({ op: "call", funcIdx: finalArrPush });
+      }
+      fctx.body.push({ op: "local.get", index: calleeLocal });
+      fctx.body.push({ op: "local.get", index: argvLocal });
+      fctx.body.push({ op: "call", funcIdx: finalCc });
+      return { kind: "externref" };
+    }
+    // Imports unavailable (shouldn't happen in JS-host): fall through to the
+    // existing unknown-ctor path below.
   }
 
   if (!className) {

--- a/tests/issue-2608-new-this-fnctor-static.test.ts
+++ b/tests/issue-2608-new-this-fnctor-static.test.ts
@@ -8,15 +8,19 @@
 // characters and `parseTopLevel` loops forever.
 //
 // Minimal repro: a static method `Fn.make = function(x,y){ return new this(x,y) }`.
-// `new Fn(x,y)` (by identifier) works; `new this(x,y)` throws
-// "is not a constructor" because by the time it reaches `compileNew`, `this`
-// has been rewritten from `ThisKeyword` to an `Identifier`, so the #1679
-// `new this` arm (new-super.ts) is skipped and the callee drops to the generic
-// dynamic-`new` path on a non-constructible wrapped-closure externref.
+// `new Fn(x,y)` (by identifier) works; `new this(x,y)` used to throw
+// "is not a constructor". Root cause: the checker types the `this` callee as the
+// bare `function`-value (CALL sigs, NO construct sigs) and resolves it to NO
+// className, so (1) the `callSigs>0 && constructSigs===0` Pattern-2 guard threw,
+// and (2) the #1679 ThisKeyword arm — gated on a resolved fnctor className — was
+// skipped. The callee then dropped to the generic dynamic-`new` path on a
+// non-constructible wrapped-closure externref.
 //
-// SKIPPED until the fix lands (see plan/issues/2608-...md for the fix
-// direction: resolve the rewritten-`this` callee to the enclosing fnctor ctor
-// + forward args in order to `<Class>_new`).
+// FIX (#2608): `this` IS a constructable function-value at runtime (`this === Fn`,
+// a WasmGC closure struct), so exclude a `this` callee from the Pattern-2 throw and
+// route `new this(...)` through the landed #56 `__construct_closure` host bridge
+// (JS-host) — the bridge detects `__is_closure`, wraps with `_wrapCallableForHost`,
+// and `Reflect.construct`s it with the args in order.
 import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
 import { wrapExports } from "../src/runtime.js";
@@ -41,7 +45,7 @@ describe("#2586 — `new this(...)` in an fnctor static method", () => {
     expect(exp.probe()).toBe("inp");
   });
 
-  it.skip("`new this(x, y)` in a static method constructs with both args (acorn shape)", async () => {
+  it("`new this(x, y)` in a static method constructs with both args (acorn shape)", async () => {
     const exp = await run(`
       // @ts-nocheck
       var Parser = function Parser(a, b) { this.a = a; this.b = b; };


### PR DESCRIPTION
## #2608 — `new this(...)` in a function-constructor static method (acorn parse() keystone)

The **4th compiled-acorn dogfood blocker**. acorn's parser is a function-constructor whose static `parse` does `return new this(options, input)`:

```js
var Parser = function Parser(opts, input) { this.input = String(input); /* ... */ };
Parser.parse = function(input, opts) { return new this(opts, input); };
```

`new this(...)` threw `"is not a constructor"` (or, in compiled acorn, silently lost the `input` arg so `this.input` came back **EMPTY** → `parseTopLevel` looped forever, tokenizing `var` as an empty-string `name`).

### Root cause

The checker types the `new this(...)` callee as the bare `function`-value (CALL sigs, **no** construct sigs) and resolves it to **no className**, so:
1. the `callSigs.length > 0 && constructSigs.length === 0` **Pattern-2 guard** threw `"is not a constructor"` before any `this`-aware arm ran, and
2. the #1679 ThisKeyword arm — gated on a resolved fnctor className — was skipped.

The callee then dropped to the generic dynamic-`new` path on a non-constructible wrapped-closure externref.

### Fix (bounded — reuses the landed #56/#1940 bridge, no new substrate)

In `src/codegen/expressions/new-super.ts` (JS-host only; standalone path unchanged):

1. **Exclude a `this` callee from the Pattern-2 throw** (`unwrappedNonId.kind !== ts.SyntaxKind.ThisKeyword`).
2. **New `new this(...)` arm** before the unknown-ctor block: `this` IS a constructable function-value at runtime (`this === Parser`, a WasmGC closure struct), so evaluate it → externref, materialize args via `__js_array_new`/`__js_array_push` (source order), and route through the landed #56 `__construct_closure` bridge (detects `__is_closure`, wraps with `_wrapCallableForHost`, `Reflect.construct`s). One terminal `flushLateImportShifts` (the #56/#86 index-discipline).

This is a **different mechanism** than the ones a prior analysis ruled out (#86 callable-params / the typeof-gated generic `__construct`): the closure-struct receiver goes straight through `__construct_closure`'s `__is_closure` detection.

### Verification

- **Acorn shape** `Parser.parse = function(input,opts){ return new this(opts,input) }` now preserves `this.input = String(input)`: `inputLen('var x = 1;')=10`, `firstChar('Xyz')=88 ('X')`, `pos=0` — the empty-`this.input` root cause is RESOLVED.
- sd-acorn's prior `it.skip`'d test un-skipped + passing (`tests/issue-2608-new-this-fnctor-static.test.ts`, 2/2 green).
- Plain `new Parser(...)` + non-`new this` statics unaffected.
- Standalone (`nativeStrings`) compiles clean.
- Constructor/this/closure-construct regression suite (issue-1528, 1679, fn-constructor, 2026-*, 1742, 1636s1): 59 pass (2 pre-existing infra failures unrelated to this change).
- `tsc --noEmit` clean.

Side-finding #2627 filed (TS `this:any` param-shift, backlog/lowest — 0 test262/0 acorn).

### Validation note

Construct-dispatch is broad-impact — the **merge_group floor** is the authoritative arbiter (it caught the prior over-broad construct changes #1940/#2615/#1888). On eject I fix-forward once (narrow the gate, #1940 playbook); never re-enqueue.

Part of the acorn-npm-package dogfood (#58).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA