### PR TITLE
fix(#2106): standalone strict ===/!== over type-erased nullish any

### DIFF
--- a/plan/issues/2106-valuerep-p3-undefined-observability.md
+++ b/plan/issues/2106-valuerep-p3-undefined-observability.md
@@ -2,10 +2,10 @@
 id: 2106
 title: "value-rep P3: undefined observability — UNDEF_F64 sentinel, union-collapse reversal (flagged), standalone $undefined singleton"
 status: in-progress
-assignee: ttraenkler/sdev7
+assignee: ttraenkler/sdev-async
 sprint: 65
 created: 2026-06-11
-updated: 2026-06-18
+updated: 2026-06-23
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -332,3 +332,57 @@ measured test262 run, as the plan already says). Reverted the attempt cleanly
 (no code landed). Next agent: investigate why `__unbox_number(__box_number(x))`
 null-derefs in the find-HIT consuming context before re-widening — that
 box-protocol fix is the real prerequisite, not the find emit site itself.
+
+## Slice S1a — standalone strict `===`/`!==` over type-erased nullish (sdev-async, 2026-06-23)
+
+A **bounded, host-free** sub-slice harvested ahead of the full S1 `$undefined`
+singleton, fixing a concrete observability bug that the test262 `isSameValue`
+harness hits constantly.
+
+### Bug (WAT-confirmed, standalone)
+Two `any`-typed operands that both read back as `ref.null extern` compared with
+strict `===` returned **`false`** for `undefined === undefined` AND
+`null === null`:
+- `const a: any[] = [undefined, undefined]; a[0] === a[1]` → `false` (want `true`)
+- `const a: any[] = [null, null]; a[0] === a[1]` → `false` (want `true`)
+- (and the `!==` duals returned `true`)
+
+### Root cause
+`binary-ops.ts` `noJsHost` externref-equality cascade (the `#1776` isSameValue
+path): the **LOOSE** branch already had a both-nullish guard (`#2081`), but the
+**STRICT** branch went straight into the number→boolean→bigint→eqref-identity
+cascade. Two `ref.null extern` operands are none of number/boolean/bigint, so
+they reached the identity arm, where `any.convert_extern(null)` fails
+`ref.test $eq` and the arm returns `0`. There was **no "both nullish → equal"
+arm for strict**. (Note: the standalone `__any_strict_eq` helper DOES have a
+correct `tag < 2` nullish arm — but this inline externref cascade does not route
+through it; it's a separate, hand-rolled comparison.)
+
+### Fix (1 site, gated `noJsHost`, host mode byte-identical)
+Refactored the loose-only nullish guard into a shared `bothNullishGuard(inner)`
+helper applied to **both** modes: `(lNull || rNull) ? (lNull && rNull) : <core
+cascade>`. For strict this makes the same-nullish pairs equal while
+`nullish vs non-nullish` stays `false` (e.g. `undefined === 5` → false). The
+loose path is unchanged in behaviour (it always wrapped in the identical guard).
+
+### KNOWN BOUNDARY (deferred to the full S1 singleton)
+A **fully type-erased** `null === undefined` now returns `true` (want `false`):
+both operands are the identical `ref.null extern` bit pattern, so no inline test
+can split them. Splitting them requires the tag-1 `$undefined` singleton (S1)
+so undefined carries a distinct representation. The **type-aware** path (operands
+with a statically-known null/undefined type) is unaffected and still keeps
+`null === undefined` false — `tests/issue-1021-null-vs-undefined.test.ts` stays
+green. This is a strict net improvement over the prior state where *all*
+nullish strict-eq through erased `any` was `false`.
+
+### Validation
+- New: `tests/issue-2106-standalone-nullish-strict-eq.test.ts` (6 cases, all
+  host-free / zero `env` imports).
+- No regression locally: `tests/equivalence/{strict-equality-edge-cases,
+  loose-equality,equality-mixed-types,typeof-comparison,comparison-coercion,
+  null-narrowing,struct-null-comparison}.test.ts` (50), `issue-1776` (6),
+  `issue-1021-null-vs-undefined` (5), `issue-1127-samevalue`, `issue-2029` (3).
+- Full test262 blast radius (incl. the erased `null===undefined` edge) is
+  measured in `merge_group` per the value-rep broad-impact protocol.
+
+S1/S3/S4 remain open — this issue stays `in-progress`.

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -2500,31 +2500,48 @@ export function compileBinaryExpression(
           ],
         } as Instr,
       ];
-      // For loose equality, wrap the core cascade in the nullish guard
-      // (§7.2.15 steps 2-3): both nullish ⇒ true; nullish-vs-non-nullish ⇒ false.
-      const eqInstrs: Instr[] = looseNullish
-        ? [
+      // (#2106) Nullish guard — shared by both equality modes, just with
+      // different "exactly one side nullish" answers:
+      //   - LOOSE (§7.2.15 steps 2-3): both nullish ⇒ true; one nullish ⇒ false
+      //     (`null == 0` is false, never coerces against a nullish).
+      //   - STRICT (§7.2.16 step 2 / §7.2.10 SameValue on the nullish types):
+      //     both nullish ⇒ true; one nullish ⇒ false. Two erased `any` operands
+      //     that are both `ref.null extern` (e.g. the test262 `isSameValue`
+      //     harness comparing `undefined`/`null` results read back out of an
+      //     `any` carrier) otherwise fell all the way through the numeric/
+      //     boolean/bigint cascade to the eqref-identity arm, where
+      //     `any.convert_extern(null)` fails `ref.test $eq` and returns 0 — so
+      //     `undefined === undefined` and `null === null` were both WRONG
+      //     (`false`). Both modes therefore short-circuit identically: the only
+      //     mode-specific behaviour is the (rare, fully type-erased)
+      //     `null === undefined` pair, which stays indistinguishable until the
+      //     tag-1 `$undefined` singleton (this issue's S1) gives undefined a
+      //     distinct representation — both operands are the same `ref.null extern`
+      //     bit pattern here, so no inline test can split them. Fixing the
+      //     dominant same-nullish cases is a strict net improvement over the
+      //     previous "all nullish strict-eq is false".
+      const bothNullishGuard = (inner: Instr[]): Instr[] => [
+        { op: "local.get", index: lTmp },
+        { op: "ref.is_null" } as Instr,
+        { op: "local.get", index: rTmp },
+        { op: "ref.is_null" } as Instr,
+        // (lNull || rNull): if EITHER is nullish, the result is whether BOTH
+        // are nullish (true) or not (false) — never coerce against a nullish.
+        { op: "i32.or" } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "i32" } },
+          then: [
             { op: "local.get", index: lTmp },
             { op: "ref.is_null" } as Instr,
             { op: "local.get", index: rTmp },
             { op: "ref.is_null" } as Instr,
-            // (lNull || rNull): if EITHER is nullish, the result is whether BOTH
-            // are nullish (true) or not (false) — never coerce against a nullish.
-            { op: "i32.or" } as Instr,
-            {
-              op: "if",
-              blockType: { kind: "val", type: { kind: "i32" } },
-              then: [
-                { op: "local.get", index: lTmp },
-                { op: "ref.is_null" } as Instr,
-                { op: "local.get", index: rTmp },
-                { op: "ref.is_null" } as Instr,
-                { op: "i32.and" } as Instr,
-              ],
-              else: coreEqInstrs,
-            } as Instr,
-          ]
-        : coreEqInstrs;
+            { op: "i32.and" } as Instr,
+          ],
+          else: inner,
+        } as Instr,
+      ];
+      const eqInstrs: Instr[] = bothNullishGuard(coreEqInstrs);
       for (const ins of eqInstrs) fctx.body.push(ins);
       if (isNeqOp) fctx.body.push({ op: "i32.eqz" });
       releaseTempLocal(fctx, rTmp);

--- a/tests/issue-2106-standalone-nullish-strict-eq.test.ts
+++ b/tests/issue-2106-standalone-nullish-strict-eq.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2106 (value-rep P3, undefined observability) — standalone strict `===` /
+ * `!==` over two fully type-erased `any` nullish operands.
+ *
+ * Root cause (binary-ops.ts, the `noJsHost` externref-equality cascade): two
+ * `any`-typed operands that both read back as `ref.null extern` (e.g. the
+ * test262 `isSameValue` harness comparing `undefined`/`null` values pulled out
+ * of an `any` carrier) fell through the number/boolean/bigint cascade to the
+ * eqref-identity arm, where `any.convert_extern(null)` fails `ref.test $eq` and
+ * returns 0. So `undefined === undefined` and `null === null` were both WRONG
+ * (`false`) in standalone mode. The LOOSE path already had a both-nullish guard
+ * (#2081); the STRICT path did not. This shares that guard across both modes.
+ *
+ * All cases run under `--target standalone` and assert ZERO `env` host imports
+ * (the comparison stays pure-Wasm).
+ *
+ * KNOWN BOUNDARY: a fully type-erased `null === undefined` now returns `true`
+ * (both operands are the identical `ref.null extern` bit pattern, so no inline
+ * test can split them). Distinguishing the two requires the tag-1 `$undefined`
+ * singleton (this issue's S1 slice). The type-AWARE path (operands with a
+ * statically-known null/undefined type) still keeps `null === undefined` false
+ * — see tests/issue-1021-null-vs-undefined.test.ts which stays green.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runBool(source: string): Promise<unknown> {
+  const result = await compile(source, { fileName: "test.ts", target: "standalone" });
+  expect(result.success, result.success ? "" : `compile error: ${result.errors?.[0]?.message}`).toBe(true);
+  // Host-free: the equality cascade must not leak an env import.
+  const envImports = result.imports.filter((i) => i.module === "env");
+  expect(envImports).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return Boolean((instance.exports as { test: () => unknown }).test());
+}
+
+describe("#2106 — standalone strict equality over type-erased nullish `any`", () => {
+  it("undefined === undefined is true (read back out of an any[] carrier)", async () => {
+    // The `i = a.length - 2` index defeats the compiler's literal const-fold,
+    // forcing a genuine runtime externref-vs-externref comparison.
+    expect(
+      await runBool(
+        `export function test(): boolean { const a: any[] = [undefined, undefined]; const i = a.length - 2; return a[i] === a[i + 1]; }`,
+      ),
+    ).toBe(true);
+  });
+
+  it("null === null is true (read back out of an any[] carrier)", async () => {
+    expect(
+      await runBool(
+        `export function test(): boolean { const a: any[] = [null, null]; const i = a.length - 2; return a[i] === a[i + 1]; }`,
+      ),
+    ).toBe(true);
+  });
+
+  it("undefined !== undefined is false", async () => {
+    expect(
+      await runBool(
+        `export function test(): boolean { const a: any[] = [undefined, undefined]; const i = a.length - 2; return a[i] !== a[i + 1]; }`,
+      ),
+    ).toBe(false);
+  });
+
+  it("nullish !== non-nullish stays true (undefined === number is false)", async () => {
+    expect(
+      await runBool(
+        `export function test(): boolean { const a: any[] = [undefined, 5]; const i = a.length - 2; return a[i] === a[i + 1]; }`,
+      ),
+    ).toBe(false);
+  });
+
+  it("non-nullish identity is unaffected (5 === 5 through any stays true)", async () => {
+    expect(
+      await runBool(
+        `export function test(): boolean { const a: any[] = [5, 5]; const i = a.length - 2; return a[i] === a[i + 1]; }`,
+      ),
+    ).toBe(true);
+  });
+
+  it("loose `null == undefined` stays true (both-nullish, unchanged)", async () => {
+    expect(
+      await runBool(
+        `export function test(): boolean { const a: any[] = [null, undefined]; const i = a.length - 2; return a[i] == a[i + 1]; }`,
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a standalone-mode strict-equality observability bug (part of #2106's value-rep P3 work): `undefined === undefined` and `null === null` over two fully type-erased `any` operands returned **`false`** in standalone/WASI mode.

This is the exact shape the test262 `isSameValue` harness hits constantly (`isSameValue(a: any, b: any)` compiles both params to `externref`).

## Root cause

`binary-ops.ts` — the `noJsHost` externref-equality cascade (the #1776 isSameValue path). The **LOOSE** `==` branch already had a both-nullish guard (#2081), but the **STRICT** `===` branch went straight into the number → boolean → bigint → eqref-identity cascade. Two `ref.null extern` operands are none of number/boolean/bigint, so they reached the identity arm where `any.convert_extern(null)` fails `ref.test $eq` → returns `0`. There was **no "both nullish → equal" arm for strict**.

## Fix

Refactor the loose-only nullish guard into a shared `bothNullishGuard(inner)` applied to **both** modes:
`(lNull || rNull) ? (lNull && rNull) : <core cascade>`.

- Gated on `noJsHost` (standalone/wasi); **host mode byte-identical**.
- Loose behaviour unchanged (it always wrapped in the identical guard).
- `nullish vs non-nullish` stays `false` (`undefined === 5` → false).

## Known boundary (deferred to the tag-1 `$undefined` singleton, S1)

A **fully type-erased** `null === undefined` now returns `true` (want `false`): both operands are the identical `ref.null extern` bit pattern, so no inline test can split them. Distinguishing them requires the tag-1 `$undefined` singleton (this issue's S1 slice). The **type-aware** path (statically-known null/undefined types) is unaffected and still keeps `null === undefined` false — `tests/issue-1021-null-vs-undefined.test.ts` stays green. This is a strict net improvement over the prior state where *all* nullish strict-eq through erased `any` was `false`.

## Validation

- New: `tests/issue-2106-standalone-nullish-strict-eq.test.ts` (6 cases, host-free / zero `env` imports).
- No local regression: `tests/equivalence/{strict-equality-edge-cases,loose-equality,equality-mixed-types,typeof-comparison,comparison-coercion,null-narrowing,struct-null-comparison}` (50), `issue-1776` (6), `issue-1021-null-vs-undefined` (5), `issue-1127-samevalue`, `issue-2029` (3).
- Full test262 blast radius (incl. the erased `null===undefined` edge) measured in `merge_group` per the value-rep broad-impact protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)