### PR TITLE
refactor(#1917): single coercion engine — emitToNumber Step 2 (behavior-neutral)

### DIFF
--- a/plan/issues/1917-single-coercion-engine.md
+++ b/plan/issues/1917-single-coercion-engine.md
@@ -88,7 +88,36 @@ Sequencing: Step 0 (ValType table) is dependency-safe now; Steps 1+ land
 AFTER the type-aware boxing P0 (#2072/#2080) so the engine consumes
 correct tags. Drift gate: #2108.
 
-## Implementation — Step 1 in progress (sendev-coercion, 2026-06-22; user un-parked)
+## Implementation — Step 2 in progress (sendev-coercion, 2026-06-23)
+
+Branch `issue-1917-emit-tonumber`, predecessor-stacked on the Step-1 branch
+(`emitToNumber` extends the same `coercion-engine.ts`; PR merges after Step 1).
+
+**New `emitToNumber(ctx, fctx, valType)`** in `coercion-engine.ts` — the
+consolidated ToNumber cascade (void→NaN, i64→f64, externref→`__unbox_number`
+js-host / `coerceType(f64,"number")` standalone, object-ref→`coerceType(f64,
+"number")`, i32→f64, f64 no-op). Externref arm gated on `ctx.standalone`
+EXACTLY (not `noJsHost`) to match the migrated `Number(x)` site byte-for-byte
+under `--target wasi`.
+
+**Migrated:** the `Number(x)` lowering (`calls.ts` ~:10674) — its post-pre-check
+cascade now calls `emitToNumber`. The `#2160` array pre-check, the Symbol-throw,
+and the native-string-ref→`__str_to_number` typeIdx-keyed pre-check stay in the
+caller (each is a *source* special-case that must run before / dispatches on
+facts the engine doesn't carry).
+
+**DEFERRED to a follow-up increment (NOT a missed copy — different ToNumber
+policy; folding would REGRESS):** the unary `+`/`-`/`~` arms (`unary.ts`) use
+`coerceType(f64)` with the **default** hint for externref/ref operands, whereas
+`Number(x)` uses the `"number"` hint / `__unbox_number`. Unifying them neutrally
+needs `emitToNumber` to take an explicit `hint` AND careful tracing of
+`coerceType(externref→f64)` no-hint vs `__unbox_number` equivalence — a separate
+neutrality analysis, deferred rather than risked.
+
+**#2108 ratcheted DOWN:** `calls.ts` 27→26 (the `Number(x)` `__unbox_number` use
+now lives in the sanctioned engine). No unsanctioned growth.
+
+## Implementation — Step 1 (sendev-coercion, 2026-06-22; user un-parked) — PR #1960
 
 Branch `issue-1917-emit-tostring`. Phased behavior-neutral consolidation per the
 user override (deduplicate the coercion code; equality last/isolated). All Step

--- a/scripts/coercion-sites-baseline.json
+++ b/scripts/coercion-sites-baseline.json
@@ -8,7 +8,7 @@
   "codegen/declarations.ts": 19,
   "codegen/expressions/assignment.ts": 12,
   "codegen/expressions/calls-closures.ts": 2,
-  "codegen/expressions/calls.ts": 27,
+  "codegen/expressions/calls.ts": 26,
   "codegen/expressions/identifiers.ts": 2,
   "codegen/expressions/late-imports.ts": 4,
   "codegen/expressions/logical-ops.ts": 2,

--- a/src/codegen/coercion-engine.ts
+++ b/src/codegen/coercion-engine.ts
@@ -36,7 +36,7 @@ import type { ValType } from "../ir/types.js";
 import { ts } from "../ts-api.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { noJsHost } from "./expressions/helpers.js";
-import { nativeStringType } from "./index.js";
+import { addUnionImports, nativeStringType } from "./index.js";
 import { ensureAnyToStringHelper } from "./native-strings.js";
 import { compileExpression, compileStringLiteral, ensureLateImport, flushLateImportShifts } from "./shared.js";
 import { coerceType, tryStructToString } from "./type-coercion.js";
@@ -234,6 +234,81 @@ export function compileAndEmitToString(
 ): ValType {
   const valType = compileExpression(ctx, fctx, operand);
   return emitToString(ctx, fctx, valType, tsType, hint);
+}
+
+/**
+ * Emit `ToNumber(operand)` (→ f64) for an operand ALREADY compiled to the top of
+ * the value stack with ValType `valType`. The consolidation of the `Number(x)`
+ * matrix (N2) and the unary `+`/`-`/`~` coercion arms (N1):
+ *
+ *   i64 (BigInt)         → f64.convert_i64_s
+ *   externref            → __unbox_number (js-host) | coerceType(f64,"number") (standalone)
+ *   ref/ref_null         → coerceType(f64,"number")  (object @@toPrimitive("number")/valueOf)
+ *   i32 (number/bool)    → f64.convert_i32_s
+ *   f64                  → no-op
+ *
+ * Returns the ValType left on the stack (`{kind:"f64"}` for every coercing arm;
+ * the original `valType` for the already-f64 no-op).
+ *
+ * NOTE — what stays in the caller (NOT folded here, because each is a *source*
+ * special-case that must run BEFORE the operand is on the stack as a plain
+ * value, or is policy that differs per caller):
+ *   - ToNumber(Symbol) throws TypeError (§7.1.4) — guarded before operand eval.
+ *   - the #2160 `Number(arr)` array→ToString→StringToNumber pre-check.
+ *   - the native-string-ref (`$AnyString`/`$NativeString`) → `__str_to_number`
+ *     (§7.1.4.1) arm — it dispatches on the ref's *typeIdx* (string-struct vs a
+ *     generic object struct), which the caller already resolves; a generic ref
+ *     falls to `coerceType(f64,"number")` here.
+ * The caller handles those, then calls `emitToNumber` for the remaining cascade.
+ */
+export function emitToNumber(ctx: CodegenContext, fctx: FunctionContext, valType: ValType | null): ValType {
+  if (!valType) {
+    // void result in a number context → NaN (ToNumber(undefined) = NaN).
+    fctx.body.push({ op: "f64.const", value: Number.NaN });
+    return { kind: "f64" };
+  }
+
+  // BigInt → number.
+  if (valType.kind === "i64") {
+    fctx.body.push({ op: "f64.convert_i64_s" });
+    return { kind: "f64" };
+  }
+
+  // externref → number. js-host calls `Number(v)` via `__unbox_number`
+  // (ToNumber semantics: Number(null)=0, Number("")=0, Number("0x1F")=31 — NOT
+  // parseFloat). `--target standalone` has no host import, so coerceType does the
+  // ToPrimitive("number") walk in pure Wasm. NOTE: gated on `ctx.standalone`
+  // EXACTLY (not `noJsHost`) to match the migrated `Number(x)` site byte-for-byte
+  // — under `--target wasi` (wasi && !standalone) the original took the
+  // `__unbox_number` host path, and this preserves that (any WASI-specific
+  // correction is a separate, non-neutral change).
+  if (valType.kind === "externref") {
+    if (ctx.standalone) {
+      coerceType(ctx, fctx, valType, { kind: "f64" }, "number");
+      return { kind: "f64" };
+    }
+    addUnionImports(ctx);
+    const unboxIdx = ctx.funcMap.get("__unbox_number");
+    if (unboxIdx !== undefined) {
+      fctx.body.push({ op: "call", funcIdx: unboxIdx });
+    }
+    return { kind: "f64" };
+  }
+
+  // Object/struct ref → number via @@toPrimitive("number")/valueOf.
+  if (valType.kind === "ref" || valType.kind === "ref_null") {
+    coerceType(ctx, fctx, valType, { kind: "f64" }, "number");
+    return { kind: "f64" };
+  }
+
+  // i32 (number or boolean) → f64.
+  if (valType.kind === "i32") {
+    fctx.body.push({ op: "f64.convert_i32_s" });
+    return { kind: "f64" };
+  }
+
+  // Already f64 — no-op.
+  return valType;
 }
 
 /**

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -94,6 +94,7 @@ import {
   receiverMayBeNativeStringAtRuntime,
   typeErrorThrowInstrs,
 } from "../property-access.js";
+import { emitToNumber } from "../coercion-engine.js";
 import type { InnerResult } from "../shared.js";
 import { coerceType, compileExpression, valTypesMatch, VOID_RESULT } from "../shared.js";
 // (#2193 PR-B) reflective `m.call(thisArg, …)` on a `$NativeProto` member-closure value.
@@ -10672,31 +10673,12 @@ function compileCallExpression(
       }
 
       const argType = compileExpression(ctx, fctx, expr.arguments[0]!);
-      if (argType?.kind === "i64") {
-        // BigInt → number: f64.convert_i64_s
-        fctx.body.push({ op: "f64.convert_i64_s" });
-        return { kind: "f64" };
-      }
-      if (argType?.kind === "externref") {
-        if (ctx.standalone) {
-          coerceType(ctx, fctx, argType, { kind: "f64" }, "number");
-          return { kind: "f64" };
-        }
-        // Number(x) uses ToNumber semantics — __unbox_number calls Number(v) in JS.
-        // parseFloat is wrong here: Number(null)=0 but parseFloat(null)=NaN,
-        // Number("")=0 but parseFloat("")=NaN, Number("0x1F")=31 but parseFloat gives 0.
-        addUnionImports(ctx);
-        const unboxIdx = ctx.funcMap.get("__unbox_number");
-        if (unboxIdx !== undefined) {
-          fctx.body.push({ op: "call", funcIdx: unboxIdx });
-          return { kind: "f64" };
-        }
-      }
+      // Native-string ref (WasmGC AnyString/NativeString) → §7.1.4.1
+      // StringToNumber. The generic ToNumber engine (coerceType "number") has no
+      // string-struct case and silently yields 0 in standalone (#1688), so this
+      // typeIdx-keyed string-ref pre-check stays in the caller and routes to the
+      // pure-Wasm __str_to_number BEFORE the engine's generic object-ref arm.
       if (argType?.kind === "ref" || argType?.kind === "ref_null") {
-        // Native-string ref (WasmGC AnyString/NativeString) → §7.1.4.1
-        // StringToNumber. The generic struct ToPrimitive path below has no
-        // string case and silently yields 0 in standalone (#1688), so detect
-        // the string struct type and route to the pure-Wasm __str_to_number.
         const refTypeIdx = (argType as { typeIdx?: number }).typeIdx;
         if (
           ctx.nativeStrings &&
@@ -10706,17 +10688,15 @@ function compileCallExpression(
           // Emitted upfront during the parseNeeded finalize (declarations.ts)
           // when `Number` is referenced under native strings, so no mid-body
           // function registration (which would shift func indices) happens here.
-          // Routes through the shared `emitStrRefToNumber` (single
-          // `__str_to_number` call site for this block); the ref needs
+          // Single `__str_to_number` call site for this block; the ref needs
           // `extern.convert_any` first (alreadyExternref = false).
           if (emitStrRefToNumber(false)) return { kind: "f64" };
         }
-        // Object → number: coerce via @@toPrimitive("number") or valueOf
-        coerceType(ctx, fctx, argType, { kind: "f64" }, "number");
-        return { kind: "f64" };
       }
-      // Already numeric — no-op
-      return argType;
+      // #1917 — the remaining ToNumber cascade (i64→f64, externref→__unbox_number
+      // host / coerceType("number") standalone, object ref→coerceType("number"),
+      // i32→f64, f64 no-op) is now the single coercion engine.
+      return emitToNumber(ctx, fctx, argType);
     }
 
     // BigInt(x) — §21.2.1.1 constructor. (#1644 Slice A+B) The result is


### PR DESCRIPTION
## Summary

**#1917 Step 2 — ToNumber.** Second step of the phased, behavior-neutral coercion dedup. **Stacked on Step 1 (PR #1960)** — this branch includes Step 1's commits; it should merge AFTER #1960.

Adds `emitToNumber(ctx, fctx, valType)` to `coercion-engine.ts` — the consolidated ToNumber cascade:
- void → NaN
- i64 (BigInt) → `f64.convert_i64_s`
- externref → `__unbox_number` (js-host) | `coerceType(f64,"number")` (standalone)
- object ref → `coerceType(f64,"number")`
- i32 → `f64.convert_i32_s`
- f64 → no-op

The externref arm is gated on `ctx.standalone` **exactly** (not `noJsHost`) to match the migrated `Number(x)` site byte-for-byte under `--target wasi`.

## Migrated
- The `Number(x)` lowering (`calls.ts`) — its post-pre-check cascade now calls `emitToNumber`. Kept in the caller (each is a source special-case the engine can't carry): the #2160 `Number(arr)` array pre-check, the Symbol-throw, the native-string-ref → `__str_to_number` typeIdx-keyed pre-check.

## Deferred to a follow-up increment (NOT a missed copy — different policy, folding would REGRESS)
- The unary `+`/`-`/`~` arms use `coerceType(f64)` with the **default** hint for externref/ref, whereas `Number(x)` uses `"number"`/`__unbox_number`. Unifying them neutrally needs an explicit hint param + careful `coerceType`-vs-`__unbox_number` equivalence tracing — a separate neutrality analysis.

## #2108 drift gate
Ratcheted **DOWN**: `calls.ts` 27 → 26. No unsanctioned growth.

## Validation
- `tsc --noEmit` clean; prettier clean; `check:coercion-sites` OK.
- `Number(arr)` suite: 13/13 substantive cases pass. The 1 `bareEmptyNoCrash` failure (`Number([])` bare `never[]` literal) reproduces **identically on the Step-1 base worktree** (verified) — pre-existing, not a regression.

⚠️ **Do not enqueue before #1960 lands** (predecessor dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)