### PR TITLE
fix(#2631): node:fs fd-based readSync/writeSync via a per-module shim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,5 @@ test262-diff-branch-merged/
 test262-diff-main-merged/
 test262-diff-regressions-report/
 examples/native-messaging/node-shim.wasm
+examples/native-messaging/node-process.wasm
+examples/native-messaging/node-fs.wasm

--- a/examples/native-messaging/NODE-FS-SHIM.md
+++ b/examples/native-messaging/NODE-FS-SHIM.md
@@ -1,0 +1,136 @@
+# `node:fs` shim (#2631)
+
+The Native Messaging host needs **synchronous** byte IO over stdin/stdout/stderr.
+The faithful Node primitives for that are `fs.readSync(fd, …)` / `fs.writeSync(fd,
+…)` from `node:fs` — fd-based (integer fd 0/1/2), **not** path-based, mapping 1:1
+to WASI `fd_read` / `fd_write` with **no filesystem**. (The earlier example used
+`process.stdin.read(buffer, offset)`, which matches **no** real Node API:
+`process.stdin` is an async Duplex stream with no synchronous buffer-filling
+`read` — loopdive/js2#389. `fs.readSync`/`fs.writeSync` are also what Javy uses:
+`Javy.IO.readSync`.)
+
+`--link-node-shims` keeps the syscall implementation **out of codegen**: the
+compiler only wires `import { readSync, writeSync } from "node:fs"` to imports of
+a stable **`node:fs`** interface. The module declares **what** host API it needs
+(`node:fs`), not **how** it's satisfied — that is a link-time concern. The same
+module can be linked against:
+
+- **`node-fs.wasm`** (built from [`node-fs.wat`](./node-fs.wat)), which maps the
+  interface to WASI `fd_read`/`fd_write`,
+- a **native WASI host** that provides `node:fs` directly, or
+- the **real `node:fs` module** under a JS host (where `import { readSync,
+  writeSync } from "node:fs"` resolves to the actual Node implementation, so the
+  same source runs **unmodified** under `node`).
+
+Naming the import `node:fs` (not `js2wasm:node-fs`) keeps the shim implementation
+out of the module's declared dependency — the module just says "I need `node:fs`".
+
+## Interface (`node:fs`)
+
+A byte boundary over a **shared linear memory** — nothing GC-typed crosses the
+link. The js2wasm pointer ABI passes `(fd, ptr, len)`; the compiler bridges its
+GC/linear `Uint8Array` buffer to `(ptr, len)`:
+
+| Function | Signature | Meaning |
+|----------|-----------|---------|
+| `readSync`  | `(fd i32, ptr i32, len i32) -> i32` | bytes read from `fd` into `mem[ptr..ptr+len)` |
+| `writeSync` | `(fd i32, ptr i32, len i32) -> i32` | bytes written from `mem[ptr..ptr+len)` to `fd` |
+
+Only the fd-based synchronous primitives are supported. **Path-based** `fs`
+functions (`readFileSync(path)`, …) need a filesystem (`path_open` / preopens)
+and are rejected under `--target wasi`.
+
+## Memory ownership — no instantiation cycle
+
+For a node:fs-only host (no `process`/`console` IO), the **shim owns + exports**
+the linear memory; the **user module imports** it (memory index 0) along with
+`readSync`/`writeSync`. So:
+
+1. Instantiate `node-fs.wasm` first — it imports only `wasi_snapshot_preview1`.
+2. Instantiate the user module with `{ memory, readSync, writeSync }` taken from
+   the shim's exports.
+
+There is no cycle (the shim never imports anything from the user module). The
+shim reads/writes the user's bytes over the *same* memory, builds the WASI iovec
+in its own reserved scratch, and issues the syscall.
+
+(If a module uses **both** `process`/`console` IO and `node:fs`, the
+`node-process` shim owns the memory and node-fs links against the same bytes —
+the memory is byte-identical, min 3 pages, same layout.)
+
+## Build
+
+Compile the user module:
+
+```sh
+npx js2wasm examples/native-messaging/nm_js2wasm.ts --target wasi --link-node-shims -o out
+```
+
+The emitted `out/nm_js2wasm.wasm` imports only `node:fs` (memory + `readSync` +
+`writeSync`) and carries **no** `wasi_snapshot_preview1` import for the IO path.
+
+(Re)generate the shim:
+
+```sh
+node scripts/build-node-fs-shim.mjs                 # writes examples/native-messaging/node-fs.wasm + .wat
+```
+
+`node-fs.wasm` is a generated artifact (gitignored); `node-fs.wat` is the
+committed source. Run the generator once before linking, or call the exported
+`buildNodeFsShim()` to assemble it in-process (the test does this).
+
+## Link + run
+
+### Node (instantiate shim, pass its exports as the user's imports)
+
+```js
+import { readFileSync } from "node:fs";
+
+const shimBin = readFileSync("examples/native-messaging/node-fs.wasm");
+const userBin = readFileSync("out/nm_js2wasm.wasm");
+
+// Minimal WASI fd_read/fd_write over the shim-owned memory (or use a real WASI).
+let mem = null;
+const wasi = {
+  fd_write(fd, iovs, n, nwritten) { /* read iovec from mem, write to fd */ },
+  fd_read(fd, iovs, n, nread)     { /* read from fd into mem at iovec ptr */ },
+};
+
+const shim = await WebAssembly.instantiate(shimBin, { wasi_snapshot_preview1: wasi });
+mem = shim.instance.exports.memory;
+const user = await WebAssembly.instantiate(userBin, {
+  "node:fs": {
+    memory:    shim.instance.exports.memory,
+    readSync:  shim.instance.exports.readSync,
+    writeSync: shim.instance.exports.writeSync,
+  },
+});
+user.instance.exports.main(); // or _start (the top-level main() call)
+```
+
+### Under real `node` (no shim — the import resolves to real `node:fs`)
+
+Because the source imports `{ readSync, writeSync } from "node:fs"` and calls
+them with the real Node argument shapes (`readSync(fd, buffer, { offset, length
+})` / `writeSync(fd, buffer, offset)`), the **same `.ts` file** runs directly
+under `node` (e.g. via `tsx`), where `node:fs` is the real module — no shim, no
+recompile.
+
+### wasmtime (`--preload`)
+
+```sh
+wasmtime run \
+  --preload node:fs=examples/native-messaging/node-fs.wasm \
+  --invoke main \
+  out/nm_js2wasm.wasm
+```
+
+`--preload <name>=<file>` registers the shim under the import module name
+`node:fs`; wasmtime resolves the user module's imports against it and provides
+`wasi_snapshot_preview1` to the shim.
+
+## Scope
+
+The fd-based `readSync`/`writeSync` (no path) are supported now; the ABI can be
+extended to more of `node:fs` later. Path-based `fs` (filesystem) stays gated
+behind `--allow-fs` for JS-host targets and is rejected in standalone WASI.

--- a/examples/native-messaging/README.md
+++ b/examples/native-messaging/README.md
@@ -29,19 +29,29 @@ little-endian length prefix plus the JSON body — to stdout (fd=1) with no
 trailing newline. The two stdout gaps that previously blocked this are closed
 (#1618, #1651).
 
-| Capability                                            | Status | Detail                                                                                                                                                                                                                      |
-| ----------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Read framed message from stdin                        | works  | `process.stdin.read(buf, offset?)` does a binary, incremental fd=0 read into the caller's buffer, returning the byte count (#1653); read-until loops assemble each frame without blocking on speculative continuation reads |
-| Decode the 4-byte LE length prefix                    | works  | byte math on the first 4 bytes of the read header buffer                                                                                                                                                                    |
-| Route debug to stderr (fd=2)                          | works  | `console.error` / `console.warn` (#1493) — keeps the stdout protocol stream clean                                                                                                                                           |
-| Print a **string literal** to stdout                  | works  | `console.log("…")` emits UTF-8 + `\n` (#1480)                                                                                                                                                                               |
-| Print a **runtime/computed string** to stdout         | works  | `console.log(x)` / `process.stdout.write(x)` of a variable, concatenation, or template literal emit the actual content (#1618)                                                                                              |
-| Write a **string** to stdout with no newline          | works  | `process.stdout.write(str)` → `fd_write(1, …)`, no `\n` (#1651)                                                                                                                                                             |
-| Emit the **binary 4-byte LE length prefix** on stdout | works  | `process.stdout.write(new Uint8Array([…]))` writes raw bytes (incl. NUL) verbatim to fd=1 (#1651)                                                                                                                           |
+As of **#2631** the host uses the **real Node fd-based synchronous primitives**
+`fs.readSync(fd, …)` / `fs.writeSync(fd, …)` from `node:fs` instead of the
+js2wasm-specific `process.stdin.read(buf, offset)` shape — which matched **no**
+real Node API (`process.stdin` is an async Duplex stream with no synchronous
+buffer-filling `read`; loopdive/js2#389). The same source now (a) compiles via
+js2wasm to standalone WASI **and** (b) runs **unmodified** under real `node`.
+Compile with `--target wasi --link-node-shims`; the `node:fs` import is bound at
+link time by [`node-fs.wat`](./node-fs.wat) (which maps `readSync`/`writeSync` to
+WASI `fd_read`/`fd_write`). See [`NODE-FS-SHIM.md`](./NODE-FS-SHIM.md).
 
-The response is framed with `process.stdout.write` — a `Uint8Array` for each
-binary length prefix, then the body bytes — mirroring the Node.js host API used
-by the reference hosts (`nm_assemblyscript.ts`, `nm_javy.js`, `nm_qjs_wasi.js`).
+| Capability                                            | Status | Detail                                                                                                                                                                                                            |
+| ----------------------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Read framed message from stdin                        | works  | `readSync(0, buf, { offset, length })` does a binary, incremental fd=0 read into the caller's buffer, returning the byte count (#2631); `length` is the remaining-to-target count so a read never over-reads into the next message |
+| Decode the 4-byte LE length prefix                    | works  | byte math on the first 4 bytes of the read header buffer                                                                                                                                                                    |
+| Route debug to stderr (fd=2)                          | works  | `writeSync(2, bytes, …)` — keeps the stdout protocol stream clean (#2631)                                                                                                                                                   |
+| Write raw bytes to stdout with no newline             | works  | `writeSync(1, bytes, off)` → `fd_write(1, …)`, partial-write loop drains the whole buffer, no `\n` (#2631)                                                                                                                  |
+| Emit the **binary 4-byte LE length prefix** on stdout | works  | the length prefix + body live in ONE buffer written with a single `writeSync` (atomic framing, #2526)                                                                                                                       |
+
+The response is framed with `writeSync(1, …)` — the 4-byte LE length prefix and
+the body bytes in one `Uint8Array`, written atomically — mirroring the Node.js
+host API used by the reference hosts (`nm_assemblyscript.ts`, `nm_javy.js`,
+`nm_qjs_wasi.js`). `fs.readSync`/`fs.writeSync` are also what Javy uses
+(`Javy.IO.readSync`).
 Request bodies larger than 1 MiB can be streamed into the host as successive
 <=1 MiB Native Messaging frames, and each frame is echoed independently. It is
 a drop-in host for byte-exact request/response framing; the only
@@ -58,12 +68,12 @@ guest271314 uses across runtimes:
 
 - **`readMessageLength()` / `readFrameBody()`** — read the 4-byte
   little-endian length header, then exactly that many body bytes via
-  `process.stdin.read` read-until loops (a `readExact` helper handles short
-  reads). Bodies up to 1 MiB stay raw **`Uint8Array`** values and round-trip
-  byte-exactly (#389, #1753).
-- **`sendMessage(message)`** — frames a `Uint8Array` body: writes the 4-byte LE
-  length prefix, then the body bytes, to stdout with no trailing newline. Bodies
-  up to 1 MiB are echoed byte-for-byte.
+  `readSync(0, buf, { offset, length })` read-until loops (a `readExact` helper
+  handles short reads). Bodies up to 1 MiB stay raw **`Uint8Array`** values and
+  round-trip byte-exactly (#389, #1753, #2631).
+- **`emitRun()` / `writeAll()`** — frame a `Uint8Array` body: the 4-byte LE
+  length prefix + body live in ONE buffer written with a single `writeSync(1, …)`
+  (atomic, no trailing newline). Bodies up to 1 MiB are echoed byte-for-byte.
 - **`sendLargeStringChunks(declaredLen)`** — handles the large single-frame
   JSON string stress shape by reading the string body incrementally and writing
   each chunk as its own valid JSON string Native Messaging response frame.
@@ -88,15 +98,20 @@ From the repo root (works immediately after `pnpm install`, no build step):
 
 ```bash
 mkdir -p examples/native-messaging/out
-npx tsx src/cli.ts examples/native-messaging/nm_js2wasm.ts --target wasi -o examples/native-messaging/out
+npx tsx src/cli.ts examples/native-messaging/nm_js2wasm.ts --target wasi --link-node-shims -o examples/native-messaging/out
 ```
 
 (Once the package is built — `pnpm run build` — or installed from npm, you can
-use the `js2wasm` bin directly: `npx js2wasm nm_js2wasm.ts --target wasi -o out`.)
+use the `js2wasm` bin directly: `npx js2wasm nm_js2wasm.ts --target wasi --link-node-shims -o out`.)
 
-This produces `out/nm_js2wasm.wasm`. The module imports only from
-`wasi_snapshot_preview1` (`fd_read`, `fd_write`) — no `env.*` imports — so it
-runs on any standards-compliant WASI preview1 runtime.
+This produces `out/nm_js2wasm.wasm`. The module imports its IO interface from
+`node:fs` (`readSync`, `writeSync`) plus the shared linear `memory` — bound at
+link time by [`node-fs.wat`](./node-fs.wat), which maps them to
+`wasi_snapshot_preview1` `fd_read`/`fd_write`. So the module declares **what**
+host API it needs (`node:fs`), not how it's satisfied: link it against
+`node-fs.wasm` (built from `node-fs.wat`), a native WASI host, or the real
+`node:fs` module under a JS host. See [`NODE-FS-SHIM.md`](./NODE-FS-SHIM.md) for
+the link step.
 
 > The `-o` flag is an **output directory**, not a filename. js2wasm names the
 > output after the input basename (`nm_js2wasm.wasm`).

--- a/examples/native-messaging/nm_js2wasm.ts
+++ b/examples/native-messaging/nm_js2wasm.ts
@@ -1,10 +1,24 @@
 // Native Messaging host, compiled to standalone WASI by js2wasm.
 //
-//   npx js2wasm examples/native-messaging/nm_js2wasm.ts --target wasi -o out
+//   npx js2wasm examples/native-messaging/nm_js2wasm.ts --target wasi --link-node-shims -o out
 //
-// Native Messaging protocol frames each message as a 4-byte
-// little-endian length prefix followed by a UTF-8 **JSON** body, exchanged over
-// the host process's stdin (fd=0) and stdout (fd=1). See:
+// This source uses REAL Node fd-based synchronous IO — `fs.readSync(fd, …)` /
+// `fs.writeSync(fd, …)` from `node:fs` — so the SAME file (a) compiles via
+// js2wasm to standalone WASI AND (b) runs UNMODIFIED under real `node`. The
+// earlier version used `process.stdin.read(buffer, offset)`, which matches NO
+// real Node API: `process.stdin` is an async Duplex stream with no synchronous
+// buffer-filling `read`. `fs.readSync` / `fs.writeSync` are the faithful
+// synchronous primitives (this is also what Javy uses: `Javy.IO.readSync`).
+// See loopdive/js2#389.
+//
+// `readSync(0,…)` / `writeSync(1,…)` / `writeSync(2,…)` are fd-based (integer fd
+// 0=stdin, 1=stdout, 2=stderr), NOT path-based — no filesystem involved. Under
+// js2wasm they lower to imported `node:fs` shim calls (`node-fs.wat`, which maps
+// them to WASI fd_read / fd_write); under real node they call the real fs.
+//
+// Native Messaging protocol frames each message as a 4-byte little-endian length
+// prefix followed by a UTF-8 **JSON** body, exchanged over the host process's
+// stdin (fd=0) and stdout (fd=1). See:
 //   https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging
 //
 // Two hard browser constraints drive the response shape:
@@ -29,53 +43,65 @@
 // can never pull bytes past the current message into the next one.
 //
 // js2wasm support today:
-//   - stdin  : process.stdin.read(buf, offset?) does one binary, incremental
-//              fd=0 read into the caller's typed buffer at `offset`, returning
-//              the byte count (#1653). A read-until loop assembles exactly N.
-//   - stdout : process.stdout.write(bytes|str) writes raw bytes to fd=1 with NO
-//              trailing newline (#1651).
-//   - stderr : process.stderr.write writes to fd=2, off the protocol stream.
+//   - stdin  : readSync(0, buf, { offset, length }) does one binary, incremental
+//              fd=0 read into the caller's typed buffer, returning the byte count
+//              (#2631). A read-until loop assembles exactly N. `length` is always
+//              passed as the remaining-to-target count so a read can never pull
+//              bytes past the current message into the next.
+//   - stdout : writeSync(1, bytes, off) writes raw bytes to fd=1 with NO trailing
+//              newline; the partial-write loop drains the whole buffer (#2631).
+//   - stderr : writeSync(2, bytes, …) writes to fd=2, off the protocol stream.
 
-declare const process: {
-  stdin: { read(buf: Uint8Array | ArrayBuffer, offset?: number): number };
-  stdout: { write(chunk: Uint8Array | ArrayBuffer | string): void };
-  stderr: { write(chunk: Uint8Array | string): void };
-};
+import { readSync, writeSync } from "node:fs";
 
 // Largest body browser Native Messaging implementation accepts in one host->extension message, and the size of
 // the single scratch buffer the whole stream flows through.
 const FRAME_CHUNK = 1024 * 1024;
-const MAX_RUN = FRAME_CHUNK - 2; // leave room for the framing `[` and `]`
+const MAX_RUN = FRAME_CHUNK - 2; // leave room for the framing `[` and `]` (or the two `"`)
 const COMMA = 44; // ,
 const OPEN_BRACKET = 91; // [
 const CLOSE_BRACKET = 93; // ]
+const DQUOTE = 34; // "
 
 // Read exactly `n` bytes into buf[0..n). Over-read-safe only when buf.length
 // === n (the read can't exceed the buffer; caller guarantees the stream has at
-// least `n` bytes left for this message).
+// least `n` bytes left for this message). `length` is the remaining-to-target
+// count, so a single read never pulls bytes past `n`.
 /** @param {Uint8Array} buf @param {number} n @returns {boolean} */
 function readExact(buf: Uint8Array, n: number): boolean {
   let got = 0;
   while (got < n) {
-    const r = process.stdin.read(buf, got);
+    const r = readSync(0, buf, { offset: got, length: n - got });
     if (r <= 0) return false; // EOF or error
     got = got + r;
   }
   return true;
 }
 
-// Read exactly `n` bytes into buf[start..start+n). Over-read-safe only when
-// (buf.length - start) === n, so a single read can never pull bytes past `n`
-// (and thus never into the next message).
+// Read exactly `n` bytes into buf[start..start+n). Over-read-safe: `length` is
+// always `n - got`, so a single read can never pull bytes past `start+n` (and
+// thus never into the next message).
 /** @param {Uint8Array} buf @param {number} start @param {number} n @returns {boolean} */
 function readAt(buf: Uint8Array, start: number, n: number): boolean {
   let got = 0;
   while (got < n) {
-    const r = process.stdin.read(buf, start + got);
+    const r = readSync(0, buf, { offset: start + got, length: n - got });
     if (r <= 0) return false;
     got = got + r;
   }
   return true;
+}
+
+// Write the whole buffer to stdout (fd=1), looping on partial writes. The
+// offset form writes from `out[n..]`; `writeSync` returns the byte count.
+/** @param {Uint8Array} out */
+function writeAll(out: Uint8Array): void {
+  let n = 0;
+  while (n < out.length) {
+    const w = writeSync(1, out, n);
+    if (w <= 0) return; // error; nothing more we can do on this frame
+    n = n + w;
+  }
 }
 
 // Decode the little-endian uint32 length browser wrote as the first 4 bytes.
@@ -85,10 +111,24 @@ function decodeLength(header: Uint8Array): number {
 }
 
 // Debug telemetry to stderr (fd=2) so it never pollutes the stdout protocol
-// stream. The frame is the 4-byte prefix plus the declared body.
+// stream. Encode the message to bytes and writeSync(2, …). The reporter noted
+// stderr was the one part that didn't work in his hand-port — this makes it work.
 /** @param {number} declaredLen */
 function logFrameBodyRead(declaredLen: number): void {
-  process.stderr.write(`[host] received ${4 + declaredLen} chars, declared body length ${declaredLen}\n`);
+  const msg = `[host] received ${4 + declaredLen} chars, declared body length ${declaredLen}\n`;
+  // Encode the ASCII/UTF-8 message to bytes (the telemetry is ASCII-only).
+  const bytes = new Uint8Array(msg.length);
+  let i = 0;
+  while (i < msg.length) {
+    bytes[i] = msg.charCodeAt(i);
+    i = i + 1;
+  }
+  let n = 0;
+  while (n < bytes.length) {
+    const w = writeSync(2, bytes, n);
+    if (w <= 0) return;
+    n = n + w;
+  }
 }
 
 // Emit one frame: `[` + src[start..start+runLen) + `]`, built whole with an
@@ -96,10 +136,10 @@ function logFrameBodyRead(declaredLen: number): void {
 /** @param {Uint8Array} src @param {number} start @param {number} runLen */
 function emitRun(src: Uint8Array, start: number, runLen: number): void {
   // #2526: build the 4-byte LE length prefix + `[run]` body in ONE buffer and
-  // write it with a SINGLE process.stdout.write (one fd_write). Writing the
-  // prefix and body as separate writes lets a streaming receiver misalign on
-  // pipe-chunk boundaries — loopdive/js2#389 (ComponentizeJS works because it
-  // frames atomically; we did not).
+  // write it with a SINGLE writeAll (one fd_write). Writing the prefix and body
+  // as separate writes lets a streaming receiver misalign on pipe-chunk
+  // boundaries — loopdive/js2#389 (ComponentizeJS works because it frames
+  // atomically; we did not).
   const bodyLen = runLen + 2; // `[` + run + `]`
   const out = new Uint8Array(4 + bodyLen);
   out[0] = bodyLen & 0xff;
@@ -113,7 +153,49 @@ function emitRun(src: Uint8Array, start: number, runLen: number): void {
     k = k + 1;
   }
   out[4 + runLen + 1] = CLOSE_BRACKET;
-  process.stdout.write(out);
+  writeAll(out);
+}
+
+// Emit one JSON-STRING frame: `"` + src[start..start+runLen) + `"`, built whole
+// and written atomically. Used to re-chunk a single >1 MiB JSON string body
+// (`"aaaa…"`) into a sequence of valid <=1 MiB JSON string frames. The receiver
+// concatenates the interiors to reproduce the original string. (The element loop
+// must not split a `\`-escape across frames; for the reported workload the body
+// is plain printable characters, so a fixed MAX_RUN split is valid.)
+/** @param {Uint8Array} src @param {number} start @param {number} runLen */
+function emitStringRun(src: Uint8Array, start: number, runLen: number): void {
+  const bodyLen = runLen + 2; // `"` + run + `"`
+  const out = new Uint8Array(4 + bodyLen);
+  out[0] = bodyLen & 0xff;
+  out[1] = (bodyLen >> 8) & 0xff;
+  out[2] = (bodyLen >> 16) & 0xff;
+  out[3] = (bodyLen >> 24) & 0xff;
+  out[4] = DQUOTE;
+  let k = 0;
+  while (k < runLen) {
+    out[5 + k] = src[start + k];
+    k = k + 1;
+  }
+  out[4 + runLen + 1] = DQUOTE;
+  writeAll(out);
+}
+
+// Stream a single large JSON string body `"chars…"` into valid <=1 MiB `"run"`
+// frames. The leading `"` has already been consumed; `interiorRemaining` counts
+// the interior characters (declaredLen - 2), and the trailing `"` is read last.
+// Returns false on EOF mid-frame. A fixed MAX_RUN split keeps each frame within
+// the cap (no comma boundaries to honor, unlike the array path).
+/** @param {Uint8Array} buf @param {number} interiorRemaining @returns {boolean} */
+function streamLargeString(buf: Uint8Array, interiorRemaining: number): boolean {
+  let remaining = interiorRemaining;
+  while (remaining > 0) {
+    let runLen = MAX_RUN;
+    if (remaining < runLen) runLen = remaining;
+    if (!readAt(buf, 0, runLen)) return false;
+    emitStringRun(buf, 0, runLen);
+    remaining = remaining - runLen;
+  }
+  return true;
 }
 
 export function main(): void {
@@ -132,21 +214,32 @@ export function main(): void {
 
     if (declaredLen <= FRAME_CHUNK) {
       // Already a single valid JSON message within the cap — echo verbatim.
-      // #2526: prefix + body in ONE buffer, ONE process.stdout.write (one
-      // fd_write). Read the body straight into the buffer at offset 4.
+      // #2526: prefix + body in ONE buffer, ONE writeAll (one fd_write). Read
+      // the body straight into the buffer at offset 4.
       const out = new Uint8Array(4 + declaredLen);
       out[0] = declaredLen & 0xff;
       out[1] = (declaredLen >> 8) & 0xff;
       out[2] = (declaredLen >> 16) & 0xff;
       out[3] = (declaredLen >> 24) & 0xff;
       if (!readAt(out, 4, declaredLen)) break;
-      process.stdout.write(out);
+      writeAll(out);
+      continue;
+    }
+
+    // Large body > 1 MiB. Peek the first byte to pick the re-chunk shape:
+    //   `"` → a single large JSON string  → `"run"` frames (streamLargeString);
+    //   `[` → a large JSON array          → `[run]` frames (below).
+    if (!readExact(one, 1)) break; // the opening `"` or `[`
+    if (one[0] === DQUOTE) {
+      // Large JSON string: interior = declaredLen - 2 (excludes the two `"`).
+      if (!streamLargeString(buf, declaredLen - 2)) break; // EOF mid-frame
+      if (!readExact(one, 1)) break; // the trailing `"`
       continue;
     }
 
     // Large JSON array `[elem,...,elem]`: stream the interior, emitting valid
-    // `[run]` frames. Consume the leading `[`; the trailing `]` is read last.
-    if (!readExact(one, 1)) break; // the `[`
+    // `[run]` frames. The leading `[` is already consumed; the trailing `]` is
+    // read last.
     let interiorRemaining = declaredLen - 2; // interior bytes (excludes `[` and `]`)
     let fill = 0; // carry bytes held at buf[0..fill) (a partial element, no comma)
     let truncated = false;
@@ -222,3 +315,9 @@ export function main(): void {
     if (!readExact(one, 1)) break; // the trailing `]`
   }
 }
+
+// Invoke the entry point. js2wasm compiles a top-level call into the module's
+// `_start`, and under real `node` this runs the host loop directly. (The
+// reporter noted the earlier bundled output never called main — this makes the
+// entry explicit.)
+main();

--- a/examples/native-messaging/node-fs.wat
+++ b/examples/native-messaging/node-fs.wat
@@ -1,0 +1,43 @@
+(module
+  ;; A provider of the `node:fs` import interface (fd-based readSync / writeSync)
+  ;; implemented over WASI fd_read / fd_write. (#2631)
+  ;;
+  ;; The user module declares `import { readSync, writeSync } from "node:fs"`,
+  ;; which lowers to wasm imports `(import "node:fs" "readSync" …)` /
+  ;; `(import "node:fs" "writeSync" …)`. The module declares WHAT host API it
+  ;; needs (`node:fs`), not HOW it's satisfied — this `.wat` is ONE provider of
+  ;; that interface; a native WASI host or the real `node:fs` module (under a JS
+  ;; host) are others. The shim therefore EXPORTS `readSync` / `writeSync` so the
+  ;; linker binds module=`node:fs`, name=`readSync`.
+  ;;
+  ;; These are the faithful *synchronous* Node primitives the Native Messaging
+  ;; host needs: `fs.readSync(fd, buf, …)` / `fs.writeSync(fd, buf, …)` are
+  ;; fd-based (integer fd 0/1/2), NOT path-based — they map 1:1 to fd_read /
+  ;; fd_write with no path_open, no preopens, NO filesystem. (Only the
+  ;; path-based `fs` family — readFileSync(path) — needs a filesystem.)
+  (import "wasi_snapshot_preview1" "fd_write"
+    (func $fd_write (param i32 i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_read"
+    (func $fd_read (param i32 i32 i32 i32) (result i32)))
+
+  ;; The shim owns + exports the shared linear memory (mirrors node-process.wat).
+  ;; min 3 pages matches the user module's reservation; grows on demand.
+  (memory (export "memory") 3)
+
+  ;; writeSync(fd, ptr, len) -> bytes written. Builds an iovec at [0] pointing
+  ;; at the CALLER's bytes (same memory) and issues fd_write to `fd`. The js2wasm
+  ;; pointer ABI passes (fd, ptr, len); the JS-host real `node:fs.writeSync`
+  ;; takes (fd, buffer, …) — the compiler bridges its GC buffer to (ptr, len).
+  (func (export "writeSync") (param $fd i32) (param $ptr i32) (param $len i32) (result i32)
+    (i32.store (i32.const 0) (local.get $ptr))
+    (i32.store (i32.const 4) (local.get $len))
+    (drop (call $fd_write (local.get $fd) (i32.const 0) (i32.const 1) (i32.const 8)))
+    (i32.load (i32.const 8)))
+
+  ;; readSync(fd, ptr, len) -> bytes read. iovec points at the caller's
+  ;; destination; issues fd_read from `fd`.
+  (func (export "readSync") (param $fd i32) (param $ptr i32) (param $len i32) (result i32)
+    (i32.store (i32.const 0) (local.get $ptr))
+    (i32.store (i32.const 4) (local.get $len))
+    (drop (call $fd_read (local.get $fd) (i32.const 0) (i32.const 1) (i32.const 8)))
+    (i32.load (i32.const 8))))

--- a/examples/native-messaging/smoke-test.sh
+++ b/examples/native-messaging/smoke-test.sh
@@ -20,13 +20,18 @@ trap 'rm -rf "$OUT_DIR"' EXIT
 
 echo "== Compiling examples/native-messaging/nm_js2wasm.ts --target wasi =="
 CLI="$OUT_DIR/js2wasm-cli.mjs"
+# #2631 — the host now uses node:fs readSync/writeSync via the linkable `node:fs`
+# shim, so compile with --link-node-shims and build node-fs.wasm to preload.
+SHIM="$OUT_DIR/node-fs.wasm"
 (
   cd "$REPO_ROOT"
   node scripts/build-standalone-cli.mjs --outfile "$CLI"
-  node "$CLI" examples/native-messaging/nm_js2wasm.ts --target wasi -o "$OUT_DIR" --quiet
+  node "$CLI" examples/native-messaging/nm_js2wasm.ts --target wasi --link-node-shims -o "$OUT_DIR" --quiet
+  node scripts/build-node-fs-shim.mjs "$SHIM"
 )
 WASM="$OUT_DIR/nm_js2wasm.wasm"
 [ -f "$WASM" ] || { echo "FAIL: $WASM was not produced" >&2; exit 1; }
+[ -f "$SHIM" ] || { echo "FAIL: $SHIM was not produced" >&2; exit 1; }
 
 # Framed input: 4-byte LE length prefix (0x0d = 13) + the 13-byte body.
 # Total stdin = 17 bytes → the host's stderr should report
@@ -42,8 +47,11 @@ STDOUT_FILE="$OUT_DIR/stdout.bin"
 STDERR_FILE="$OUT_DIR/stderr.txt"
 
 echo "== Running under wasmtime ($(wasmtime --version)) =="
+# `--preload node:fs=<file>` registers the shim under the import module name
+# `node:fs`; wasmtime resolves the user module's imports against it and provides
+# wasi_snapshot_preview1 to the shim (#2631).
 # shellcheck disable=SC2086
-printf "$FRAME" | wasmtime $WASMTIME_FLAGS "$WASM" >"$STDOUT_FILE" 2>"$STDERR_FILE"
+printf "$FRAME" | wasmtime $WASMTIME_FLAGS --preload "node:fs=$SHIM" "$WASM" >"$STDOUT_FILE" 2>"$STDERR_FILE"
 
 # ---- Expected stdout frame -------------------------------------------------
 # Strict echo: the response body is the received body verbatim, byte-for-byte.

--- a/plan/issues/2631-node-fs-fd-shim-readsync-writesync.md
+++ b/plan/issues/2631-node-fs-fd-shim-readsync-writesync.md
@@ -1,0 +1,107 @@
+---
+id: 2631
+title: "node:fs fd-based readSync/writeSync via a per-module shim (Native Messaging example)"
+status: done
+sprint: Backlog
+assignee: ttraenkler/agent-a0c9d00fc32018cde
+completed: 2026-06-23
+feasibility: medium
+depends_on: [2524, 2625]
+---
+
+# node:fs fd-based readSync/writeSync via a per-module `node:fs` shim
+
+## Problem (loopdive/js2#389)
+
+The Native Messaging host example `examples/native-messaging/nm_js2wasm.ts` used
+the js2wasm-specific `process.stdin.read(buffer, offset)` /
+`process.stdout.write` / `process.stderr.write` shapes. The reporter
+(guest271314) correctly noted that **`process.stdin.read(buffer, offset)` matches
+NO real Node API**: Node's `process.stdin` is an async Duplex stream with no
+synchronous buffer-filling `read`. The faithful synchronous Node primitives are
+`fs.readSync(fd, …)` / `fs.writeSync(fd, …)` (fd-based, integer fd 0/1/2 — NOT
+path-based; this is also what Javy uses: `Javy.IO.readSync`). Because the source
+used a non-Node shape, it could not run unmodified under real `node`, and the
+reporter's hand-port of the stderr telemetry path didn't work.
+
+## Acceptance criteria
+
+- [x] The example imports `{ readSync, writeSync } from "node:fs"` and drops the
+      `process` global entirely; the SAME source compiles to standalone WASI via
+      js2wasm AND runs UNMODIFIED under real `node`.
+- [x] `node:fs` is a **per-module shim** (`node-fs.wat`), mirroring
+      `js2wasm:node-process` (#2524/#2625) — codegen only wires
+      `import { readSync, writeSync } from "node:fs"` → calls to imported
+      `node:fs` shim functions; the syscall sequence lives in the `.wat` shim, NOT
+      in codegen.
+- [x] The wasm import MODULE name is `node:fs` (the declared interface), member
+      names are the real Node members `readSync`/`writeSync` — the shim
+      implementation name never leaks into the module's declared dependency.
+- [x] `readSync(0,…)`/`writeSync(1,…)`/`writeSync(2,…)` are recognized ONLY with an
+      fd argument; they map 1:1 to WASI `fd_read`/`fd_write` (no path_open, no
+      preopens, NO filesystem). Path-based `readFileSync(path)` is rejected under
+      `--target wasi`.
+- [x] Over-read safety preserved: `length` is passed as the remaining-to-target
+      count, so a read can never pull bytes past the current message.
+- [x] stderr telemetry (`writeSync(2, …)`) works.
+- [x] `main()` is invoked (top-level `main();` → compiled `_start`; importable
+      under node).
+- [x] Tests assert the emitted `node:fs` imports (and no direct
+      `wasi_snapshot_preview1` fd_read/fd_write for that path), a byte-for-byte
+      round-trip linking `node-fs.wasm`, fd=2 routing, over-read safety, and the
+      path-based rejection. The `wasmtime` smoke test passes under a real runtime.
+
+## Implementation summary
+
+- **`examples/native-messaging/node-fs.wat`** — new linkable shim exporting
+  `readSync(fd,ptr,len)->i32` / `writeSync(fd,ptr,len)->i32` over WASI
+  `fd_read`/`fd_write`; owns+exports the shared linear memory (mirrors
+  `node-process.wat`). **`scripts/build-node-fs-shim.mjs`** assembles it in-process
+  (binaryen), mirroring `build-node-process-shim.mjs`.
+- **Codegen** (`src/codegen/index.ts`, `src/codegen/node-process-api.ts`,
+  `src/codegen/context/{types,create-context}.ts`,
+  `src/codegen/expressions/calls.ts`): when `--target wasi --link-node-shims` and
+  the program imports `readSync`/`writeSync` from `node:fs`, register imports
+  against module `"node:fs"` (members `readSync`/`writeSync`, pointer ABI
+  `(fd,ptr,len)->i32`) + the shared memory; lower the calls to those imports via
+  `tryCompileNodeFsCall` (GC-Uint8Array copy path + linear-backed zero-copy path;
+  positional and `{offset,length}` options forms; `length` defaults to
+  `buf.length - offset`). Memory ownership: a node:fs-only program (no
+  process/console IO) has the node-fs shim own the memory; otherwise node-process
+  owns it and node-fs links against the same bytes.
+- **Path-based fs rejected under WASI**: `PATH_BASED_FS_FNS` (readFileSync, …)
+  produce a structured compile error under `--target wasi` (no filesystem).
+- **#1886 linear analysis** (`src/codegen/linear-uint8-analysis.ts`):
+  `ioBufferArgIndex` now recognizes `readSync(fd,buf,…)`/`writeSync(fd,buf,…)` as
+  byte-I/O buffer sinks (buffer at arg 1), keeping buffers linear-safe so the
+  Slice-C signature rewrite of element-only helpers stays consistent.
+- **Checker** (`src/checker/index.ts`): `node:fs` gets fd-based `readSync`/
+  `writeSync` signatures (positional + options form) in the synthetic `.d.ts`;
+  other node:fs members stay permissive `any`.
+- **host-import-allowlist**: `node:fs` added to `ALWAYS_ALLOWED_IMPORT_MODULES`
+  (a linkable interface, not a JS-host binding).
+- **Example + docs**: `nm_js2wasm.ts` rewritten to `node:fs`; `README.md` updated;
+  new `NODE-FS-SHIM.md`; `smoke-test.sh` builds + preloads `node-fs.wasm`.
+
+## Test Results
+
+- `tests/issue-2631-node-fs-fd-shim.test.ts` — 6/6 pass (import shape, round-trip,
+  over-read safety, fd=2 routing, path-based rejection, non-WASI no-op).
+- `tests/issue-1886*.test.ts` — pass (updated for the new example shape).
+- `tests/issue-2524-node-process-shim.test.ts` — pass (unaffected).
+- `tests/issue-2526-atomic-frame-writes.test.ts` — pass (atomic framing preserved;
+  updated to link the node-fs shim).
+- `examples/native-messaging/smoke-test.sh` — PASS under real wasmtime 44
+  (byte-exact frame + clean stderr).
+- The example runs unmodified under real `node` (tsx): byte-exact stdout frame +
+  clean stderr telemetry.
+
+## Design note for follow-up
+
+The narrow `readSync(fd,ptr,len)->i32` ABI keeps the **fd** parameter (the
+tech-lead message's `(ptr,len)` restatement dropped it) because fd is essential:
+`writeSync(2, …)` must route stderr telemetry to fd 2, distinct from stdout fd 1
+— the whole point of #389's stderr gap. The ABI can be widened to more of
+`node:fs` later. Separately, the landed `js2wasm:node-process` shim should be
+renamed `node:process` for naming consistency (tech-lead will file separately;
+NOT touched here).

--- a/scripts/build-node-fs-shim.mjs
+++ b/scripts/build-node-fs-shim.mjs
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2631 — build `node-fs.wasm`, a linkable provider of the `node:fs` import
+ * interface (the fd-based synchronous primitives `readSync` / `writeSync`).
+ *
+ * The user module declares `import { readSync, writeSync } from "node:fs"`,
+ * which js2wasm lowers to wasm imports `(import "node:fs" "readSync" …)` /
+ * `(import "node:fs" "writeSync" …)`. The module declares WHAT host API it needs
+ * (`node:fs`), not HOW it's satisfied; this shim is ONE provider of that
+ * interface (over WASI fd_read / fd_write). A native WASI host or the real
+ * `node:fs` module (under a JS host) are other providers.
+ *
+ * The shim OWNS + exports the linear memory; a user module compiled with
+ * `--link-node-shims` that uses ONLY node:fs (no process/console IO) IMPORTS
+ * that memory (memory index 0) plus the two IO functions, so the shim can
+ * read/write the user's bytes over the SAME memory with no instantiation cycle
+ * (the shim imports only `wasi_snapshot_preview1`).
+ *
+ * Interface (`node:fs`, js2wasm pointer ABI over the shared linear memory):
+ *   readSync (fd i32, ptr i32, len i32) -> (i32)   // bytes read into mem[ptr..ptr+len)
+ *   writeSync(fd i32, ptr i32, len i32) -> (i32)   // bytes written from mem[ptr..]
+ *
+ * These are fd-based (integer fd 0/1/2), NOT path-based — they map 1:1 to
+ * fd_read / fd_write with no path_open, no preopens, NO filesystem. (Only the
+ * path-based `fs` family — readFileSync(path) — needs a filesystem.)
+ *
+ * `min: 3` matches the user module's reserved memory (`registerWasiImports`);
+ * the shim grows on demand as the user module does.
+ *
+ * Usage: `node scripts/build-node-fs-shim.mjs [outPath]`
+ *   default outPath: examples/native-messaging/node-fs.wasm
+ * Also writes the `.wat` source next to the binary for inspection / wasmtime.
+ */
+import binaryen from "binaryen";
+import { writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..");
+
+// iovec (8 bytes) + nread/nwritten cell (4 bytes) scratch at memory[0..11].
+const IOVEC = 0; // [0]=buf_ptr [4]=buf_len
+const NCELL = 8; // [8]=nread/nwritten
+
+export const NODE_FS_SHIM_WAT = `(module
+  ;; A provider of the \`node:fs\` import interface (fd-based readSync / writeSync)
+  ;; implemented over WASI fd_read / fd_write. (#2631)
+  (import "wasi_snapshot_preview1" "fd_write"
+    (func $fd_write (param i32 i32 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "fd_read"
+    (func $fd_read (param i32 i32 i32 i32) (result i32)))
+
+  ;; The shim owns + exports the shared linear memory. min 3 pages matches the
+  ;; user module's reservation; grows on demand.
+  (memory (export "memory") 3)
+
+  ;; writeSync(fd, ptr, len) -> bytes written. Builds an iovec at [${IOVEC}]
+  ;; pointing at the CALLER's bytes (same memory) and issues fd_write to \`fd\`.
+  (func (export "writeSync") (param $fd i32) (param $ptr i32) (param $len i32) (result i32)
+    (i32.store (i32.const ${IOVEC}) (local.get $ptr))
+    (i32.store (i32.const ${IOVEC + 4}) (local.get $len))
+    (drop (call $fd_write (local.get $fd) (i32.const ${IOVEC}) (i32.const 1) (i32.const ${NCELL})))
+    (i32.load (i32.const ${NCELL})))
+
+  ;; readSync(fd, ptr, len) -> bytes read. iovec points at the caller's
+  ;; destination; issues fd_read from \`fd\`.
+  (func (export "readSync") (param $fd i32) (param $ptr i32) (param $len i32) (result i32)
+    (i32.store (i32.const ${IOVEC}) (local.get $ptr))
+    (i32.store (i32.const ${IOVEC + 4}) (local.get $len))
+    (drop (call $fd_read (local.get $fd) (i32.const ${IOVEC}) (i32.const 1) (i32.const ${NCELL})))
+    (i32.load (i32.const ${NCELL}))))`;
+
+/** Assemble the shim WAT to a validated wasm binary (Uint8Array). */
+export function buildNodeFsShim() {
+  const m = binaryen.parseText(NODE_FS_SHIM_WAT);
+  m.setFeatures(binaryen.Features.All);
+  if (!m.validate()) {
+    m.dispose();
+    throw new Error("node-fs shim: binaryen validation failed");
+  }
+  const bin = m.emitBinary();
+  m.dispose();
+  return bin;
+}
+
+// CLI entry — only runs when invoked directly (not on import).
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const out = process.argv[2] ? resolve(process.argv[2]) : resolve(repoRoot, "examples/native-messaging/node-fs.wasm");
+  const bin = buildNodeFsShim();
+  writeFileSync(out, bin);
+  writeFileSync(out.replace(/\.wasm$/, ".wat"), NODE_FS_SHIM_WAT + "\n");
+  console.log(`wrote ${out} (${bin.length} B) + .wat source`);
+}

--- a/src/checker/index.ts
+++ b/src/checker/index.ts
@@ -470,6 +470,54 @@ function buildNodeEnvDts(usage: NodeEmuUsage): string | undefined {
       parts.push(lines.join("\n"));
       continue;
     }
+    // #2631 — `node:fs`: give the fd-based synchronous primitives that the
+    // compiler lowers (readSync / writeSync) faithful Node signatures so they
+    // type-check precisely (both the positional and the options form), while any
+    // other imported member stays permissive `any`. The real Node signatures:
+    //   readSync(fd, buffer, offset, length, position): number          (positional)
+    //   readSync(fd, buffer, opts: {offset?,length?,position?}): number  (options)
+    //   writeSync(fd, buffer, offset?, length?, position?): number       (positional)
+    if (mod === "node:fs") {
+      const named = [...members].filter((m) => m !== "");
+      const hasDefaultOrNs = members.has("");
+      const lines: string[] = [`declare module "node:fs" {`];
+      lines.push(
+        `  interface NodeJS_FsReadSyncOptions { offset?: number; length?: number; position?: number | null; }`,
+      );
+      // Use `export const` with a callable *type* (not bodiless `export function`
+      // overload declarations) so the typing is valid even when the importing
+      // file is checked as `.js` (allowJs) — bodiless function declarations there
+      // trip TS error 8017 "Signature declarations can only be used in TypeScript
+      // files" at the import site (#2631 / #1768 transpiled-host case).
+      for (const name of named) {
+        if (name === "readSync") {
+          // A SINGLE call signature (not an overload) so the typing is valid even
+          // under allowJs/.js checking — an imported const with MULTIPLE call
+          // signatures trips TS 8017 at the import site (#1768 transpiled host).
+          // The 3rd param is `offset` (positional) OR the options object, which
+          // covers both real-Node forms the compiler lowers; trailing
+          // length/position are optional.
+          lines.push(
+            `  export const readSync: (fd: number, buffer: Uint8Array, offsetOrOptions?: number | NodeJS_FsReadSyncOptions, length?: number, position?: number | null) => number;`,
+          );
+        } else if (name === "writeSync") {
+          lines.push(
+            `  export const writeSync: (fd: number, buffer: Uint8Array, offset?: number, length?: number, position?: number | null) => number;`,
+          );
+        } else {
+          // Any other node:fs member stays permissive (path-based fs is gated /
+          // rejected in codegen, but should still type-check).
+          lines.push(`  export const ${name}: any;`);
+        }
+      }
+      if (hasDefaultOrNs || named.length === 0) {
+        lines.push(`  const _default: any;`);
+        lines.push(`  export default _default;`);
+      }
+      lines.push(`}`);
+      parts.push(lines.join("\n"));
+      continue;
+    }
     // Other modules: permissive, just enough that the imported names resolve.
     const named = [...members].filter((m) => m !== "");
     const hasDefaultOrNs = members.has("");

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -222,6 +222,8 @@ export function createCodegenContext(
     nodeIoStdoutWriteIdx: -1,
     nodeIoStderrWriteIdx: -1,
     nodeIoStdinReadIdx: -1,
+    nodeFsReadSyncIdx: -1,
+    nodeFsWriteSyncIdx: -1,
     standalone: options?.standalone ?? false,
     // #682 — native standalone RegExp engine hook. Standalone mode enables the
     // reduced literal-substring backend; broader QuickJS libregexp ABI linking

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1549,6 +1549,10 @@ export interface CodegenContext {
   nodeIoStderrWriteIdx: number;
   /** #2524: func index of the imported `js2wasm:node-process::stdin_read` (-1 = not registered). */
   nodeIoStdinReadIdx: number;
+  /** #2631: func index of the imported `js2wasm:node-fs::read_sync` (fd,ptr,len)->i32 (-1 = not registered). */
+  nodeFsReadSyncIdx: number;
+  /** #2631: func index of the imported `js2wasm:node-fs::write_sync` (fd,ptr,len)->i32 (-1 = not registered). */
+  nodeFsWriteSyncIdx: number;
   /** WASI import indices */
   wasiFdWriteIdx: number;
   wasiFdReadIdx?: number;

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -117,7 +117,7 @@ import {
   compileStringLiteral,
   emitBoolToString,
 } from "../string-ops.js";
-import { tryCompileNodeProcessCall } from "../node-process-api.js";
+import { tryCompileNodeFsCall, tryCompileNodeProcessCall } from "../node-process-api.js";
 import { isSupportedBuiltinStaticProperty, resolveBuiltinNamespaceValueName } from "../builtin-static-globals.js";
 import {
   defaultValueInstrs,
@@ -253,6 +253,32 @@ const BUILTIN_CLASS_NAMES = new Set([
   "Float64Array",
   "BigInt64Array",
   "BigUint64Array",
+]);
+
+/**
+ * (#2631) Path-based node:fs functions that require a filesystem (path_open /
+ * preopens). Distinct from the fd-based synchronous primitives readSync /
+ * writeSync (no path). Under --target wasi these are rejected — standalone WASI
+ * has no filesystem. `writeFileSync` is intentionally excluded: it has a
+ * dedicated WASI lowering above (`__wasi_write_file_sync`).
+ */
+const PATH_BASED_FS_FNS = new Set([
+  "readFileSync",
+  "readFile",
+  "writeFile",
+  "appendFileSync",
+  "appendFile",
+  "openSync",
+  "open",
+  "unlinkSync",
+  "unlink",
+  "mkdirSync",
+  "mkdir",
+  "readdirSync",
+  "readdir",
+  "statSync",
+  "stat",
+  "existsSync",
 ]);
 
 /**
@@ -3082,6 +3108,10 @@ function compileCallExpression(
   // call-expression compiler does not accumulate host API special cases.
   const nodeProcessCall = tryCompileNodeProcessCall(ctx, fctx, expr);
   if (nodeProcessCall !== undefined) return nodeProcessCall;
+
+  // #2631 — node:fs fd-based readSync/writeSync → `node:fs` shim calls.
+  const nodeFsCall = tryCompileNodeFsCall(ctx, fctx, expr);
+  if (nodeFsCall !== undefined) return nodeFsCall;
 
   // RegExp(pattern, flags) called without `new`. Extracted to calls-guards.ts (#742).
   {
@@ -10494,6 +10524,40 @@ function compileCallExpression(
       fctx.body.push({ op: "call", funcIdx: writeFileSyncIdx });
       return VOID_RESULT;
     }
+  }
+
+  // #2631 — path-based node:fs functions (readFileSync, readFile, …) are NOT
+  // the fd-based readSync/writeSync handled by the node:fs shim: they need a
+  // filesystem (path_open / preopens). They are gated behind --allow-fs and are
+  // rejected outright under --target wasi (standalone has no filesystem). The
+  // fd-based readSync/writeSync (no path) were already lowered above via
+  // tryCompileNodeFsCall, so anything reaching here named like a path-based fs
+  // reader is unsupported in WASI.
+  if (
+    ctx.wasi &&
+    ts.isIdentifier(expr.expression) &&
+    ctx.wasiNodeFsFuncs.has(expr.expression.text) &&
+    PATH_BASED_FS_FNS.has(expr.expression.text)
+  ) {
+    const fnName = expr.expression.text;
+    const { line, character } = expr.getSourceFile().getLineAndCharacterOfPosition(expr.getStart());
+    ctx.errors.push({
+      message:
+        `'node:fs' path-based call to '${fnName}' is not available under --target wasi (#2631): ` +
+        `standalone WASI has no filesystem (no path_open / preopens). Only the fd-based synchronous ` +
+        `primitives readSync(fd, …) / writeSync(fd, …) are supported (they map to fd_read / fd_write ` +
+        `via the node:fs shim). For host file access, target a JS host with --allow-fs instead.`,
+      line: line + 1,
+      column: character + 1,
+      severity: "error",
+    });
+    // Drop args, emit a safe placeholder so codegen can continue.
+    for (const arg of expr.arguments) {
+      const t = compileExpression(ctx, fctx, arg);
+      if (t) fctx.body.push({ op: "drop" });
+    }
+    fctx.body.push({ op: "ref.null.extern" } as Instr);
+    return { kind: "externref" };
   }
 
   // Handle global isNaN(n) / isFinite(n) / parseInt / parseFloat — inline wasm

--- a/src/codegen/host-import-allowlist.ts
+++ b/src/codegen/host-import-allowlist.ts
@@ -44,6 +44,13 @@ export const ALWAYS_ALLOWED_IMPORT_MODULES: ReadonlySet<string> = new Set([
   // `node-process.wasm` (or any conforming deno/browser shim), no JS runtime
   // required. Per-module Node shims are named `js2wasm:node-<mod>`.
   "js2wasm:node-process",
+  // #2631 — `node:fs` fd-based readSync/writeSync. The module declares WHAT host
+  // API it needs (`node:fs`), not HOW it's satisfied: the import is bound at
+  // LINK time by our `node-fs.wat` shim (over WASI fd_read/fd_write), a native
+  // WASI host, or the real `node:fs` module under a JS host. Like
+  // `wasi_snapshot_preview1`, it is a linkable interface, not a JS-host binding,
+  // so it is always allowed under strict dual-mode.
+  "node:fs",
 ]);
 
 export interface HostImportAllowlistEntry {

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1066,7 +1066,17 @@ export function generateModule(
       // (never escape the GC heap) so they can be backed by linear memory with
       // zero-copy fd_read/fd_write. Side-effect free; codegen consumers are
       // additive (empty result ⇒ emitted module identical to today).
-      ctx.linearUint8 = analyzeLinearUint8(ast.checker, ast.sourceFile);
+      // #2631 — pass the node:fs readSync/writeSync binding names from the
+      // ORIGINAL source (import preprocessing has already stripped the `node:fs`
+      // import from `ast.sourceFile`, so the analysis can't rediscover them).
+      // `ctx.wasiNodeFsFuncs` records the local names of node:fs imports; the
+      // byte-IO sink recognition only fires for these, so it's byte-neutral for
+      // every program that doesn't import them.
+      const nodeFsSyncNames = new Set<string>();
+      for (const name of ctx.wasiNodeFsFuncs) {
+        if (name === "readSync" || name === "writeSync") nodeFsSyncNames.add(name);
+      }
+      ctx.linearUint8 = analyzeLinearUint8(ast.checker, ast.sourceFile, nodeFsSyncNames);
       // #1886 Slice B: reserve the `__lin_u8_alloc` bump-allocator's
       // `(i32)->(i32)` func TYPE eagerly, here — BEFORE any WasmGC struct/array
       // type or native-string helper is registered. This keeps the shared

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -5705,6 +5705,42 @@ function collectConsoleImports(ctx: CodegenContext, sourceFile: ts.SourceFile): 
   }
 }
 
+/**
+ * #2631 — does the source use process/console stream IO that the node-process
+ * shim backs (process.std{in,out,err}.*, console.log/warn/error)? Drives the
+ * node-shim memory-ownership decision in `registerWasiImports`: when a program
+ * uses ONLY node:fs (`readSync`/`writeSync`) and no process/console IO, the
+ * node-fs shim owns the shared linear memory instead of node-process. Cheap
+ * syntactic scan — codegen lowers the calls regardless; this only picks the
+ * memory provider.
+ */
+function sourceUsesNodeProcessOrConsoleIo(sourceFile: ts.SourceFile): boolean {
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    if (ts.isPropertyAccessExpression(node)) {
+      // console.log/warn/error
+      if (
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "console" &&
+        (node.name.text === "log" || node.name.text === "warn" || node.name.text === "error")
+      ) {
+        found = true;
+        return;
+      }
+      // process.<anything> — exit/env/stdin/stdout/stderr/argv/platform are all
+      // node-process-backed; any process member reference means node-process is live.
+      if (ts.isIdentifier(node.expression) && node.expression.text === "process") {
+        found = true;
+        return;
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return found;
+}
+
 /** Register WASI imports: fd_write, proc_exit, path_open, fd_close, linear memory, bump pointer global */
 function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): void {
   // Add linear memory for string data + iovec structs.
@@ -5719,29 +5755,69 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
   // the write scratch in page 2 (WASI_WRITE_SCRATCH_START), well above any
   // data segment, and reserve 3 pages so both regions always exist.
   if (ctx.linkNodeShims) {
-    // #2524 Phase 1 — the node-process shim OWNS + exports the linear memory; the
-    // user module IMPORTS it (memory index 0) so the shim can read/write the
-    // user's bytes over the SAME memory with no instantiation cycle (shim
-    // imports only wasi_snapshot_preview1; user imports {memory + io fns} from
-    // the already-instantiated shim). The user module therefore declares NO
-    // memory and exports none. `min: 3` mirrors the inline path's reservation
-    // (page 0 scratch/data, page 1 stdin buffer, page 2 write scratch); the
-    // shim's exported memory must be at least this large (its source declares
-    // the same min). Imports MUST precede the func imports below so the memory
-    // sits at memory-index 0 (loads/stores/`memory.size`/`memory.grow` all
-    // target it). The import order within the import section does not perturb
-    // the func index space — only func imports increment it.
-    addImport(ctx, "js2wasm:node-process", "memory", { kind: "memory", min: 3 });
-    // The three byte-boundary IO functions (over the shared memory):
-    //   stdout_write(ptr,len)->i32 · stderr_write(ptr,len) · stdin_read(ptr,len)->i32
-    const ioWriteType = addFuncType(ctx, [{ kind: "i32" }, { kind: "i32" }], [{ kind: "i32" }], "$node_io_write");
-    const ioWriteVoidType = addFuncType(ctx, [{ kind: "i32" }, { kind: "i32" }], [], "$node_io_write_void");
-    addImport(ctx, "js2wasm:node-process", "stdout_write", { kind: "func", typeIdx: ioWriteType });
-    ctx.nodeIoStdoutWriteIdx = ctx.funcMap.get("stdout_write")!;
-    addImport(ctx, "js2wasm:node-process", "stderr_write", { kind: "func", typeIdx: ioWriteVoidType });
-    ctx.nodeIoStderrWriteIdx = ctx.funcMap.get("stderr_write")!;
-    addImport(ctx, "js2wasm:node-process", "stdin_read", { kind: "func", typeIdx: ioWriteType });
-    ctx.nodeIoStdinReadIdx = ctx.funcMap.get("stdin_read")!;
+    // #2631 — the per-module shims (`js2wasm:node-process`, `js2wasm:node-fs`)
+    // each conceptually own+export the shared linear memory, but only ONE module
+    // may provide memory index 0. We pick a single memory OWNER and the other
+    // shim's funcs operate over that same imported memory:
+    //   - if the program uses process/console stream IO → node-process owns the
+    //     memory (unchanged from #2524) and node-fs (if also used) is func-only,
+    //     importing nothing else (it reads/writes the shared memory by ptr).
+    //   - else if the program uses node:fs readSync/writeSync but NOT process IO →
+    //     node-fs owns the memory (the native-messaging example's shape: it drops
+    //     `process` entirely and uses only `node:fs`).
+    // Both shims' memories are byte-identical (min 3, same layout), so whichever
+    // owns it the other links against the same bytes. The owner must precede the
+    // func imports so its memory sits at memory-index 0.
+    const usesNodeFsFdShim = ctx.wasiNodeFsFuncs.has("readSync") || ctx.wasiNodeFsFuncs.has("writeSync");
+    const usesNodeProcessIo = sourceUsesNodeProcessOrConsoleIo(sourceFile);
+    const nodeFsOwnsMemory = usesNodeFsFdShim && !usesNodeProcessIo;
+    const memoryOwnerModule = nodeFsOwnsMemory ? "node:fs" : "js2wasm:node-process";
+
+    // #2524 Phase 1 — the shim OWNS + exports the linear memory; the user module
+    // IMPORTS it (memory index 0) so the shim can read/write the user's bytes
+    // over the SAME memory with no instantiation cycle (shim imports only
+    // wasi_snapshot_preview1; user imports {memory + io fns} from the
+    // already-instantiated shim). The user module declares NO memory and exports
+    // none. `min: 3` mirrors the inline path's reservation (page 0 scratch/data,
+    // page 1 stdin buffer, page 2 write scratch). Imports MUST precede the func
+    // imports below so the memory sits at memory-index 0 (loads/stores/
+    // `memory.size`/`memory.grow` all target it). Import order within the import
+    // section does not perturb the func index space — only func imports increment it.
+    addImport(ctx, memoryOwnerModule, "memory", { kind: "memory", min: 3 });
+
+    // node-process IO funcs (process.std*/console) — registered only when the
+    // program actually uses process/console stream IO, so a node:fs-only program
+    // (the example) does NOT pull in unused node-process imports.
+    if (usesNodeProcessIo) {
+      // The three byte-boundary IO functions (over the shared memory):
+      //   stdout_write(ptr,len)->i32 · stderr_write(ptr,len) · stdin_read(ptr,len)->i32
+      const ioWriteType = addFuncType(ctx, [{ kind: "i32" }, { kind: "i32" }], [{ kind: "i32" }], "$node_io_write");
+      const ioWriteVoidType = addFuncType(ctx, [{ kind: "i32" }, { kind: "i32" }], [], "$node_io_write_void");
+      addImport(ctx, "js2wasm:node-process", "stdout_write", { kind: "func", typeIdx: ioWriteType });
+      ctx.nodeIoStdoutWriteIdx = ctx.funcMap.get("stdout_write")!;
+      addImport(ctx, "js2wasm:node-process", "stderr_write", { kind: "func", typeIdx: ioWriteVoidType });
+      ctx.nodeIoStderrWriteIdx = ctx.funcMap.get("stderr_write")!;
+      addImport(ctx, "js2wasm:node-process", "stdin_read", { kind: "func", typeIdx: ioWriteType });
+      ctx.nodeIoStdinReadIdx = ctx.funcMap.get("stdin_read")!;
+    }
+
+    // #2631 — node:fs fd-based IO funcs: readSync(fd,ptr,len)->i32 /
+    // writeSync(fd,ptr,len)->i32 over the shared memory. The user module imports
+    // module `"node:fs"` (declaring WHAT it needs, not the shim that provides
+    // it); the `node-fs.wat` shim is one provider. Registered only when the
+    // program imports readSync/writeSync from node:fs.
+    if (usesNodeFsFdShim) {
+      const fsIoType = addFuncType(
+        ctx,
+        [{ kind: "i32" }, { kind: "i32" }, { kind: "i32" }],
+        [{ kind: "i32" }],
+        "$node_fs_io",
+      );
+      addImport(ctx, "node:fs", "readSync", { kind: "func", typeIdx: fsIoType });
+      ctx.nodeFsReadSyncIdx = ctx.funcMap.get("readSync")!;
+      addImport(ctx, "node:fs", "writeSync", { kind: "func", typeIdx: fsIoType });
+      ctx.nodeFsWriteSyncIdx = ctx.funcMap.get("writeSync")!;
+    }
   } else {
     ctx.mod.memories.push({ min: 3 });
     // WASI requires the memory to be exported as "memory"
@@ -6297,7 +6373,7 @@ function emitWasiWriteStringStderrHelper(ctx: CodegenContext): void {
  * `registerWasiImports` reserves 3 pages so both always exist.
  */
 export const WASI_STDIN_BUF_START = 64 * 1024;
-const WASI_WRITE_SCRATCH_START = 128 * 1024;
+export const WASI_WRITE_SCRATCH_START = 128 * 1024;
 
 /**
  * #1886 Slice B — start of the linear-backed `Uint8Array` arena (page 4,
@@ -12460,6 +12536,19 @@ function registerNodeBuiltinImports(ctx: CodegenContext, builtins: NodeBuiltinIm
       // preprocessing leaves a type-level `process` binding in the AST and
       // node-process-api.ts lowers supported stream calls directly to WASI.
       if (builtin.moduleName === "process") continue;
+      // #2631 — `node:fs` is likewise a compile-time API surface under
+      // --link-node-shims when the program uses the fd-based synchronous
+      // primitives readSync / writeSync: those are stripped by import
+      // preprocessing and lowered to imported `node:fs` shim calls by
+      // node-process-api.ts (tryCompileNodeFsCall). Path-based fs usage is
+      // rejected at the call site (see PATH_BASED_FS_FNS in calls.ts), not here.
+      if (
+        builtin.moduleName === "fs" &&
+        ctx.linkNodeShims &&
+        (ctx.wasiNodeFsFuncs.has("readSync") || ctx.wasiNodeFsFuncs.has("writeSync"))
+      ) {
+        continue;
+      }
       ctx.errors.push({
         message: `Node builtin module '${builtin.moduleName}' is not available in WASI target. Use compile-time syscall path for node:fs (#1035).`,
         line: 1,

--- a/src/codegen/linear-uint8-analysis.ts
+++ b/src/codegen/linear-uint8-analysis.ts
@@ -103,14 +103,29 @@ function isNewUint8Array(expr: ts.Node): expr is ts.NewExpression {
 }
 
 /**
- * Recognise `process.std{in.read,out.write,err.write}(buf, …)` and return the
- * argument index that carries the buffer (0 for both), or `-1` if this is not a
- * std-stream I/O call. We only match the global `process` shape the WASI
- * lowering supports (`node-process-api.ts`); a local `process` shadow makes
- * this not match (the conservative path).
+ * Recognise a byte-I/O intrinsic call that takes a `Uint8Array` buffer and
+ * return the argument index that carries the buffer, or `-1` if this is not one.
+ *
+ * Two shapes are recognised (both lowered by `node-process-api.ts`):
+ *   - `process.std{in.read,out.write,err.write}(buf, …)` — buffer at arg 0. We
+ *     only match the global `process` shape the WASI lowering supports; a local
+ *     `process` shadow makes this not match (the conservative path).
+ *   - #2631: `readSync(fd, buf, …)` / `writeSync(fd, buf, …)` (the node:fs
+ *     fd-based primitives) — buffer at arg 1. Like `process.std*`, these are
+ *     non-escaping byte-I/O sinks: the buffer's bytes are read/written in place
+ *     (the lowering reads them straight from the GC/linear array), so a buffer
+ *     flowing into them stays linear-safe. (Recognising readSync/writeSync as a
+ *     buffer SINK here keeps the #1886 analysis consistent: without it, a buffer
+ *     passed to readSync/writeSync would be treated as escaping, demoting the
+ *     whole helper chain to non-linear and breaking the Slice-C signature
+ *     rewrite of element-only helpers like `decodeLength`/`emitRun`.)
  */
 function ioBufferArgIndex(call: ts.CallExpression): number {
   const callee = call.expression;
+  // node:fs fd-based readSync(fd, buf, …) / writeSync(fd, buf, …): buffer at 1.
+  if (ts.isIdentifier(callee) && (callee.text === "readSync" || callee.text === "writeSync")) {
+    return call.arguments.length >= 2 ? 1 : -1;
+  }
   if (!ts.isPropertyAccessExpression(callee)) return -1;
   const method = callee.name.text;
   const stream = callee.expression;

--- a/src/codegen/linear-uint8-analysis.ts
+++ b/src/codegen/linear-uint8-analysis.ts
@@ -112,19 +112,31 @@ function isNewUint8Array(expr: ts.Node): expr is ts.NewExpression {
  *     `process` shadow makes this not match (the conservative path).
  *   - #2631: `readSync(fd, buf, …)` / `writeSync(fd, buf, …)` (the node:fs
  *     fd-based primitives) — buffer at arg 1. Like `process.std*`, these are
- *     non-escaping byte-I/O sinks: the buffer's bytes are read/written in place
- *     (the lowering reads them straight from the GC/linear array), so a buffer
- *     flowing into them stays linear-safe. (Recognising readSync/writeSync as a
- *     buffer SINK here keeps the #1886 analysis consistent: without it, a buffer
- *     passed to readSync/writeSync would be treated as escaping, demoting the
- *     whole helper chain to non-linear and breaking the Slice-C signature
- *     rewrite of element-only helpers like `decodeLength`/`emitRun`.)
+ *     non-escaping byte-I/O sinks. **BUT** `readSync`/`writeSync` are plain
+ *     identifiers that collide with ordinary user/test code (e.g. a test262
+ *     harness helper named `writeSync`), so we ONLY treat them as sinks when the
+ *     program actually imported them from `node:fs` (the `nodeFsBindings` set,
+ *     scoped to the binding SYMBOL so a local shadow can't masquerade). Without
+ *     this gate the recognition rewrites codegen for unrelated Uint8Array
+ *     programs — a wasm-byte regression caught in the #2631 merge_group
+ *     (17 TypedArray/byte-IO assertion_fail). Keeping the gate makes the change
+ *     byte-neutral for every program that does NOT import node:fs readSync/writeSync.
  */
-function ioBufferArgIndex(call: ts.CallExpression): number {
+function ioBufferArgIndex(call: ts.CallExpression, nodeFsBindings: Set<string>): number {
   const callee = call.expression;
-  // node:fs fd-based readSync(fd, buf, …) / writeSync(fd, buf, …): buffer at 1.
-  if (ts.isIdentifier(callee) && (callee.text === "readSync" || callee.text === "writeSync")) {
-    return call.arguments.length >= 2 ? 1 : -1;
+  // node:fs fd-based readSync(fd, buf, …) / writeSync(fd, buf, …): buffer at 1 —
+  // ONLY when the callee is a LOCAL BINDING NAME imported from node:fs (the
+  // `nodeFsBindings` set is empty unless the program imports readSync/writeSync
+  // from node:fs, so this is a no-op — byte-neutral — for unrelated programs).
+  // Name-based (not symbol-based) so it stays robust when the `node:fs` module
+  // doesn't resolve (e.g. the #1886 unit-test program built with `noLib: true`).
+  if (
+    nodeFsBindings.size > 0 &&
+    ts.isIdentifier(callee) &&
+    nodeFsBindings.has(callee.text) &&
+    call.arguments.length >= 2
+  ) {
+    return 1;
   }
   if (!ts.isPropertyAccessExpression(callee)) return -1;
   const method = callee.name.text;
@@ -136,6 +148,43 @@ function ioBufferArgIndex(call: ts.CallExpression): number {
   if (streamName === "stdin" && method === "read") return 0;
   if ((streamName === "stdout" || streamName === "stderr") && method === "write") return 0;
   return -1;
+}
+
+/**
+ * #2631 — collect the LOCAL BINDING NAMES of `readSync`/`writeSync` imported
+ * from `node:fs` (named imports, honoring an `as` alias — the local name is what
+ * appears at the call site). Returns an EMPTY set for any program that doesn't
+ * import them, so the byte-IO sink recognition is a no-op (byte-identical to
+ * origin/main) for unrelated Uint8Array programs. Name-based rather than
+ * symbol-based so it works even when the `node:fs` module type doesn't resolve
+ * (e.g. a unit-test program built with `noLib: true`); the per-call shadow guard
+ * in the lowering (`fctx.localMap.has`) still protects against a local override.
+ */
+function collectNodeFsSyncBindings(sourceFile: ts.SourceFile): Set<string> {
+  const out = new Set<string>();
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteral(node.moduleSpecifier) &&
+      (node.moduleSpecifier.text === "node:fs" || node.moduleSpecifier.text === "fs")
+    ) {
+      const named = node.importClause?.namedBindings;
+      if (named && ts.isNamedImports(named)) {
+        for (const el of named.elements) {
+          // `propertyName` is the imported name (readSync/writeSync); `name` is
+          // the LOCAL binding (possibly aliased). Gate on the imported name,
+          // record the local name (used at the call site).
+          const importedName = (el.propertyName ?? el.name).text;
+          if (importedName === "readSync" || importedName === "writeSync") {
+            out.add(el.name.text);
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return out;
 }
 
 /**
@@ -176,7 +225,22 @@ function resolveDirectCallee(
  *     is currently demoted. Repeat until no demotions occur in a full pass.
  *  4. Freeze: the survivors are the linear-safe set.
  */
-export function analyzeLinearUint8(checker: ts.TypeChecker, sourceFile: ts.SourceFile): LinearUint8Result {
+export function analyzeLinearUint8(
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+  nodeFsSyncNames?: ReadonlySet<string>,
+): LinearUint8Result {
+  // #2631 — the LOCAL NAMES of node:fs readSync/writeSync imports (empty unless
+  // the program imports them). Gates the byte-IO sink recognition so it stays a
+  // no-op (byte-neutral) for unrelated Uint8Array programs.
+  //
+  // The real compile path strips the `node:fs` import BEFORE this analysis runs
+  // (import preprocessing), so the import declaration is gone from `sourceFile`.
+  // The caller therefore passes the names detected from the ORIGINAL source
+  // (`ctx.wasiNodeFsFuncs`, via `detectNodeFsImports`). When that's not supplied
+  // (e.g. the #1886 unit tests, which analyze the raw source with the import
+  // intact), fall back to scanning the AST.
+  const nodeFsBindings = nodeFsSyncNames ? new Set(nodeFsSyncNames) : collectNodeFsSyncBindings(sourceFile);
   // candidate bindings (locals + params), seeded safe; demote on disqualifying use.
   const safe = new Set<ts.Symbol>();
   // Symbols introduced by a `new Uint8Array(...)` LOCAL init (not parameters).
@@ -244,7 +308,7 @@ export function analyzeLinearUint8(checker: ts.TypeChecker, sourceFile: ts.Sourc
       if (ts.isIdentifier(node)) {
         const sym = checker.getSymbolAtLocation(node);
         if (sym && safe.has(sym) && !isBindingSite(node)) {
-          if (!isAllowedUse(checker, node, safe, fnDecls, fnParamSyms)) {
+          if (!isAllowedUse(checker, node, safe, fnDecls, fnParamSyms, nodeFsBindings)) {
             safe.delete(sym);
             changed = true;
           }
@@ -276,7 +340,7 @@ export function analyzeLinearUint8(checker: ts.TypeChecker, sourceFile: ts.Sourc
   const localOnly = new Set<ts.Symbol>(newLocalSyms);
   const dropParamThreaded = (node: ts.Node): void => {
     if (ts.isCallExpression(node)) {
-      const ioIdx = ioBufferArgIndex(node);
+      const ioIdx = ioBufferArgIndex(node, nodeFsBindings);
       node.arguments.forEach((arg, argIdx) => {
         if (!ts.isIdentifier(arg)) return;
         const sym = checker.getSymbolAtLocation(arg);
@@ -381,6 +445,7 @@ function isAllowedUse(
   safe: Set<ts.Symbol>,
   fnDecls: Map<ts.Symbol, FnDecl>,
   fnParamSyms: Map<ts.Symbol, (ts.Symbol | undefined)[]>,
+  nodeFsBindings: Set<string>,
 ): boolean {
   const p = id.parent;
 
@@ -397,8 +462,8 @@ function isAllowedUse(
   if (ts.isCallExpression(p) && p.expression !== id) {
     const argIdx = p.arguments.indexOf(id);
     if (argIdx < 0) return false; // appears in callee position somehow → unsafe
-    // process.std*.{read,write}(buf …)
-    const ioIdx = ioBufferArgIndex(p);
+    // process.std*.{read,write}(buf …) / node:fs readSync/writeSync(fd, buf …)
+    const ioIdx = ioBufferArgIndex(p, nodeFsBindings);
     if (ioIdx === argIdx) return true;
     // direct user call → corresponding param must be currently linear-safe.
     const resolved = resolveDirectCallee(checker, p);
@@ -412,7 +477,7 @@ function isAllowedUse(
   // Parenthesised buffer: `(b)[i]`, `(b).length` — unwrap one paren level.
   if (ts.isParenthesizedExpression(p)) {
     // Re-classify the paren as if it were the buffer reference.
-    return isAllowedUse(checker, p as unknown as ts.Identifier, safe, fnDecls, fnParamSyms);
+    return isAllowedUse(checker, p as unknown as ts.Identifier, safe, fnDecls, fnParamSyms, nodeFsBindings);
   }
 
   // Everything else is a potential escape:

--- a/src/codegen/node-process-api.ts
+++ b/src/codegen/node-process-api.ts
@@ -21,10 +21,11 @@ import {
   getArrTypeIdxFromVec,
   getOrRegisterVecType,
   WASI_STDIN_BUF_START,
+  WASI_WRITE_SCRATCH_START,
 } from "./index.js";
 import type { InnerResult } from "./shared.js";
 import { compileExpression, VOID_RESULT } from "./shared.js";
-import { tryEmitLinearU8StdinRead, tryEmitLinearU8StdWrite } from "./linear-uint8-codegen.js";
+import { getLinearU8Buffer, tryEmitLinearU8StdinRead, tryEmitLinearU8StdWrite } from "./linear-uint8-codegen.js";
 
 export function tryCompileNodeProcessCall(
   ctx: CodegenContext,
@@ -332,4 +333,393 @@ function emitProcessStdinRead(ctx: CodegenContext, fctx: FunctionContext, expr: 
   fctx.body.push({ op: "local.get", index: nreadLocal } as Instr);
   fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
   return { kind: "f64" };
+}
+
+// ---------------------------------------------------------------------------
+// #2631 — node:fs fd-based readSync / writeSync via the `js2wasm:node-fs` shim.
+//
+// `readSync(fd, buf, …)` / `writeSync(fd, buf, …)` are the faithful synchronous
+// Node primitives the Native Messaging host needs (process.stdin is an async
+// Duplex with no synchronous buffer-filling read — loopdive/js2#389). They are
+// fd-based (integer fd 0/1/2), NOT path-based: they map 1:1 to fd_read/fd_write
+// with NO filesystem. The path-based `fs` family (readFileSync(path)) stays on
+// the --allow-fs path and is rejected in standalone WASI.
+//
+// The compiler's only job is to recognize the imported `readSync`/`writeSync`
+// bindings and call the registered `js2wasm:node-fs` shim funcs with (fd, ptr,
+// len) — the syscall lives in node-fs.wat, not in codegen.
+// ---------------------------------------------------------------------------
+
+/**
+ * Recognize + lower an imported node:fs `readSync(fd, buf, …)` /
+ * `writeSync(fd, buf, …)` call. Returns the result (a byte count, f64), or
+ * `undefined` when this isn't a node-fs fd-based call we handle (the generic
+ * compiler then proceeds — path-based fs is handled / rejected elsewhere).
+ */
+export function tryCompileNodeFsCall(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+): InnerResult | undefined {
+  if (!ctx.wasi || !ctx.linkNodeShims) return undefined;
+  if (expr.questionDotToken) return undefined;
+  if (!ts.isIdentifier(expr.expression)) return undefined;
+  const callee = expr.expression.text;
+  if (callee !== "readSync" && callee !== "writeSync") return undefined;
+  // Only treat it as the fd-based node:fs primitive when it was imported from
+  // node:fs (detected pre-preprocessing) and is not shadowed by a local.
+  if (!ctx.wasiNodeFsFuncs.has(callee)) return undefined;
+  if (fctx.localMap.has(callee) || (fctx.boxedCaptures?.has(callee) ?? false)) return undefined;
+  // fd-based form requires at least (fd, buffer). A bare/path-based call is not ours.
+  if (expr.arguments.length < 2) return undefined;
+  const shimIdx = callee === "readSync" ? ctx.nodeFsReadSyncIdx : ctx.nodeFsWriteSyncIdx;
+  if (shimIdx < 0) return undefined;
+
+  return callee === "readSync"
+    ? emitNodeFsReadSync(ctx, fctx, expr, shimIdx)
+    : emitNodeFsWriteSync(ctx, fctx, expr, shimIdx);
+}
+
+/**
+ * Extract the optional `offset` / `length` arguments shared by readSync and
+ * writeSync. Supports both the positional form
+ * `(fd, buf, offset?, length?, position?)` and the options form
+ * `(fd, buf, { offset?, length?, position? })`. Emits two i32 locals
+ * (offset, length); `length` defaults to `buf.length - offset` when absent, so
+ * over-read/over-write past the buffer is impossible by construction.
+ *
+ * `bufLenLocal` is an i32 local already holding the buffer's element length.
+ */
+function emitNodeFsOffsetLength(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  bufLenLocal: number,
+): { offLocal: number; lenLocal: number } {
+  const offLocal = allocLocal(fctx, `__nodefs_off_${fctx.locals.length}`, { kind: "i32" });
+  const lenLocal = allocLocal(fctx, `__nodefs_len_${fctx.locals.length}`, { kind: "i32" });
+
+  const arg2 = expr.arguments[2];
+  const optionsObj = arg2 && ts.isObjectLiteralExpression(arg2) ? arg2 : undefined;
+
+  // ---- offset ----
+  let offsetExpr: ts.Expression | undefined;
+  if (optionsObj) {
+    offsetExpr = findObjectProp(optionsObj, "offset");
+  } else {
+    offsetExpr = arg2;
+  }
+  if (offsetExpr) {
+    compileExpression(ctx, fctx, offsetExpr, { kind: "f64" });
+    fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  } else {
+    fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  }
+  fctx.body.push({ op: "local.set", index: offLocal } as Instr);
+
+  // ---- length ----  (default: buf.length - offset)
+  let lengthExpr: ts.Expression | undefined;
+  if (optionsObj) {
+    lengthExpr = findObjectProp(optionsObj, "length");
+  } else {
+    lengthExpr = expr.arguments[3];
+  }
+  if (lengthExpr) {
+    compileExpression(ctx, fctx, lengthExpr, { kind: "f64" });
+    fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  } else {
+    fctx.body.push({ op: "local.get", index: bufLenLocal } as Instr);
+    fctx.body.push({ op: "local.get", index: offLocal } as Instr);
+    fctx.body.push({ op: "i32.sub" } as Instr);
+  }
+  fctx.body.push({ op: "local.set", index: lenLocal } as Instr);
+
+  return { offLocal, lenLocal };
+}
+
+/** Find a non-shorthand object-literal property initializer by name, or undefined. */
+function findObjectProp(obj: ts.ObjectLiteralExpression, name: string): ts.Expression | undefined {
+  for (const prop of obj.properties) {
+    if (
+      ts.isPropertyAssignment(prop) &&
+      ((ts.isIdentifier(prop.name) && prop.name.text === name) ||
+        (ts.isStringLiteral(prop.name) && prop.name.text === name))
+    ) {
+      return prop.initializer;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the GC `$Vec`-backed Uint8Array argument into its (vecTypeIdx,
+ * arrTypeIdx) and emit code that leaves nothing on the stack but stores the vec
+ * ref + the underlying i8 array ref + the element length into fresh i32/ref
+ * locals. Returns those locals, or `null` if the arg isn't a GC Uint8Array.
+ */
+function emitNodeFsResolveGcU8(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  bufExpr: ts.Expression,
+): { arrLocal: number; arrTypeIdx: number; lenLocal: number } | null {
+  const bufType = compileExpression(ctx, fctx, bufExpr);
+  if (!bufType || (bufType.kind !== "ref" && bufType.kind !== "ref_null") || !("typeIdx" in bufType)) {
+    if (bufType) fctx.body.push({ op: "drop" } as Instr);
+    return null;
+  }
+  const vecTypeIdx = bufType.typeIdx;
+  const vecDef = ctx.mod.types[vecTypeIdx];
+  if (!vecDef || vecDef.kind !== "struct" || vecDef.fields.length < 2) {
+    fctx.body.push({ op: "drop" } as Instr);
+    return null;
+  }
+  const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+  if (arrTypeIdx < 0) {
+    fctx.body.push({ op: "drop" } as Instr);
+    return null;
+  }
+  if (bufType.kind === "ref_null") fctx.body.push({ op: "ref.as_non_null" } as Instr);
+
+  const vecLocal = allocLocal(fctx, `__nodefs_vec_${fctx.locals.length}`, { kind: "ref", typeIdx: vecTypeIdx });
+  fctx.body.push({ op: "local.set", index: vecLocal } as Instr);
+  // element length = vec.length (field 0)
+  const lenLocal = allocLocal(fctx, `__nodefs_buflen_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: vecLocal } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr);
+  fctx.body.push({ op: "local.set", index: lenLocal } as Instr);
+  // backing i8 array = vec.data (field 1)
+  const arrLocal = allocLocal(fctx, `__nodefs_arr_${fctx.locals.length}`, { kind: "ref", typeIdx: arrTypeIdx });
+  fctx.body.push({ op: "local.get", index: vecLocal } as Instr);
+  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 } as Instr);
+  fctx.body.push({ op: "local.set", index: arrLocal } as Instr);
+
+  return { arrLocal, arrTypeIdx, lenLocal };
+}
+
+/** Emit `fd` (arg0) truncated to i32 into a fresh local; returns the local. */
+function emitNodeFsFd(ctx: CodegenContext, fctx: FunctionContext, fdExpr: ts.Expression): number {
+  const fdLocal = allocLocal(fctx, `__nodefs_fd_${fctx.locals.length}`, { kind: "i32" });
+  compileExpression(ctx, fctx, fdExpr, { kind: "f64" });
+  fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+  fctx.body.push({ op: "local.set", index: fdLocal } as Instr);
+  return fdLocal;
+}
+
+/**
+ * `readSync(fd, buf, offset?, length?, position?)` /
+ * `readSync(fd, buf, { offset?, length?, position? })` → read up to `length`
+ * bytes from `fd` into `buf[offset .. offset+length)`; return the byte count.
+ *
+ * Lowering: call the shim `read_sync(fd, WASI_STDIN_BUF_START, length)` into the
+ * shared linear scratch, then copy the returned bytes into the GC array at
+ * `offset`. (Linear-backed buffers read straight into `ptr+offset`, zero-copy.)
+ */
+function emitNodeFsReadSync(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  shimIdx: number,
+): InnerResult {
+  const fdLocal = emitNodeFsFd(ctx, fctx, expr.arguments[0]!);
+
+  // Zero-copy fast path: linear-backed Uint8Array reads straight into ptr+off.
+  const linBuf = getLinearU8Buffer(ctx, fctx, expr.arguments[1]!);
+  if (linBuf) {
+    const { offLocal, lenLocal } = emitNodeFsOffsetLength(ctx, fctx, expr, linBuf.lenLocalIdx);
+    fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
+    fctx.body.push({ op: "local.get", index: linBuf.ptrLocalIdx } as Instr);
+    fctx.body.push({ op: "local.get", index: offLocal } as Instr);
+    fctx.body.push({ op: "i32.add" } as Instr);
+    fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+    fctx.body.push({ op: "call", funcIdx: shimIdx } as Instr);
+    fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
+    return { kind: "f64" };
+  }
+
+  const gc = emitNodeFsResolveGcU8(ctx, fctx, expr.arguments[1]!);
+  if (!gc) {
+    // Not a recognizable buffer — emit 0 (no bytes read) so codegen continues.
+    fctx.body.push({ op: "f64.const", value: 0 } as Instr);
+    return { kind: "f64" };
+  }
+  const { offLocal, lenLocal } = emitNodeFsOffsetLength(ctx, fctx, expr, gc.lenLocal);
+
+  // Grow memory if the scratch read region (WASI_STDIN_BUF_START + length) would
+  // exceed current pages. Mirrors emitProcessStdinRead.
+  ensureScratchPages(fctx, WASI_STDIN_BUF_START, lenLocal);
+
+  // nread = read_sync(fd, WASI_STDIN_BUF_START, length)
+  const nreadLocal = allocLocal(fctx, `__nodefs_nread_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
+  fctx.body.push({ op: "i32.const", value: WASI_STDIN_BUF_START } as Instr);
+  fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+  fctx.body.push({ op: "call", funcIdx: shimIdx } as Instr);
+  fctx.body.push({ op: "local.set", index: nreadLocal } as Instr);
+
+  // Copy buf_dest[off + j] = scratch[j] for j in [0, nread).
+  emitScratchToArrayCopy(fctx, gc.arrTypeIdx, gc.arrLocal, offLocal, WASI_STDIN_BUF_START, nreadLocal);
+
+  fctx.body.push({ op: "local.get", index: nreadLocal } as Instr);
+  fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
+  return { kind: "f64" };
+}
+
+/**
+ * `writeSync(fd, buf, offset?, length?, position?)` → write
+ * `buf[offset .. offset+length)` to `fd`; return the byte count.
+ *
+ * Lowering: copy the GC array slice into the shared linear scratch, then call
+ * the shim `write_sync(fd, WASI_WRITE_SCRATCH_START, length)`. (Linear-backed
+ * buffers write straight from `ptr+offset`, zero-copy.)
+ */
+function emitNodeFsWriteSync(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  shimIdx: number,
+): InnerResult {
+  const fdLocal = emitNodeFsFd(ctx, fctx, expr.arguments[0]!);
+
+  // Zero-copy fast path: linear-backed Uint8Array writes straight from ptr+off.
+  const linBuf = getLinearU8Buffer(ctx, fctx, expr.arguments[1]!);
+  if (linBuf) {
+    const { offLocal, lenLocal } = emitNodeFsOffsetLength(ctx, fctx, expr, linBuf.lenLocalIdx);
+    fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
+    fctx.body.push({ op: "local.get", index: linBuf.ptrLocalIdx } as Instr);
+    fctx.body.push({ op: "local.get", index: offLocal } as Instr);
+    fctx.body.push({ op: "i32.add" } as Instr);
+    fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+    fctx.body.push({ op: "call", funcIdx: shimIdx } as Instr);
+    fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
+    return { kind: "f64" };
+  }
+
+  const gc = emitNodeFsResolveGcU8(ctx, fctx, expr.arguments[1]!);
+  if (!gc) {
+    fctx.body.push({ op: "f64.const", value: 0 } as Instr);
+    return { kind: "f64" };
+  }
+  const { offLocal, lenLocal } = emitNodeFsOffsetLength(ctx, fctx, expr, gc.lenLocal);
+
+  // Grow memory if the write scratch region would exceed current pages.
+  ensureScratchPages(fctx, WASI_WRITE_SCRATCH_START, lenLocal);
+
+  // Copy scratch[j] = buf[off + j] for j in [0, length).
+  emitArrayToScratchCopy(fctx, gc.arrTypeIdx, gc.arrLocal, offLocal, WASI_WRITE_SCRATCH_START, lenLocal);
+
+  // nwritten = write_sync(fd, WASI_WRITE_SCRATCH_START, length)
+  fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
+  fctx.body.push({ op: "i32.const", value: WASI_WRITE_SCRATCH_START } as Instr);
+  fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+  fctx.body.push({ op: "call", funcIdx: shimIdx } as Instr);
+  fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
+  return { kind: "f64" };
+}
+
+/** Grow linear memory so [scratchStart, scratchStart + lenLocal) is addressable. */
+function ensureScratchPages(fctx: FunctionContext, scratchStart: number, lenLocal: number): void {
+  const needPagesLocal = allocLocal(fctx, `__nodefs_pages_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "i32.const", value: scratchStart } as Instr);
+  fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+  fctx.body.push({ op: "i32.add" } as Instr);
+  fctx.body.push({ op: "i32.const", value: 65535 } as Instr);
+  fctx.body.push({ op: "i32.add" } as Instr);
+  fctx.body.push({ op: "i32.const", value: 16 } as Instr);
+  fctx.body.push({ op: "i32.shr_u" } as Instr);
+  fctx.body.push({ op: "local.set", index: needPagesLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: needPagesLocal } as Instr);
+  fctx.body.push({ op: "memory.size" } as Instr);
+  fctx.body.push({ op: "i32.gt_u" } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [
+      { op: "local.get", index: needPagesLocal } as Instr,
+      { op: "memory.size" } as Instr,
+      { op: "i32.sub" } as Instr,
+      { op: "memory.grow" } as Instr,
+      { op: "drop" } as Instr,
+    ],
+  } as Instr);
+}
+
+/** for j in [0, countLocal): dest[off + j] = scratch[scratchStart + j] (i8 array). */
+function emitScratchToArrayCopy(
+  fctx: FunctionContext,
+  arrTypeIdx: number,
+  arrLocal: number,
+  offLocal: number,
+  scratchStart: number,
+  countLocal: number,
+): void {
+  const jLocal = allocLocal(fctx, `__nodefs_j_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "local.set", index: jLocal } as Instr);
+  const loopBody: Instr[] = [
+    { op: "local.get", index: jLocal } as Instr,
+    { op: "local.get", index: countLocal } as Instr,
+    { op: "i32.ge_s" } as Instr,
+    { op: "br_if", depth: 1 } as Instr,
+    { op: "local.get", index: arrLocal } as Instr,
+    { op: "local.get", index: offLocal } as Instr,
+    { op: "local.get", index: jLocal } as Instr,
+    { op: "i32.add" } as Instr,
+    // value = scratch[scratchStart + j]
+    { op: "i32.const", value: scratchStart } as Instr,
+    { op: "local.get", index: jLocal } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "i32.load8_u", align: 0, offset: 0 } as Instr,
+    { op: "array.set", typeIdx: arrTypeIdx } as Instr,
+    { op: "local.get", index: jLocal } as Instr,
+    { op: "i32.const", value: 1 } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "local.set", index: jLocal } as Instr,
+    { op: "br", depth: 0 } as Instr,
+  ];
+  fctx.body.push({
+    op: "block",
+    blockType: { kind: "empty" },
+    body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr],
+  } as Instr);
+}
+
+/** for j in [0, countLocal): scratch[scratchStart + j] = src[off + j] (i8 array). */
+function emitArrayToScratchCopy(
+  fctx: FunctionContext,
+  arrTypeIdx: number,
+  arrLocal: number,
+  offLocal: number,
+  scratchStart: number,
+  countLocal: number,
+): void {
+  const jLocal = allocLocal(fctx, `__nodefs_wj_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "local.set", index: jLocal } as Instr);
+  const loopBody: Instr[] = [
+    { op: "local.get", index: jLocal } as Instr,
+    { op: "local.get", index: countLocal } as Instr,
+    { op: "i32.ge_s" } as Instr,
+    { op: "br_if", depth: 1 } as Instr,
+    // addr = scratchStart + j
+    { op: "i32.const", value: scratchStart } as Instr,
+    { op: "local.get", index: jLocal } as Instr,
+    { op: "i32.add" } as Instr,
+    // value = src[off + j]  (array.get_u on i8 array)
+    { op: "local.get", index: arrLocal } as Instr,
+    { op: "local.get", index: offLocal } as Instr,
+    { op: "local.get", index: jLocal } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "array.get_u", typeIdx: arrTypeIdx } as Instr,
+    { op: "i32.store8", align: 0, offset: 0 } as Instr,
+    { op: "local.get", index: jLocal } as Instr,
+    { op: "i32.const", value: 1 } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "local.set", index: jLocal } as Instr,
+    { op: "br", depth: 0 } as Instr,
+  ];
+  fctx.body.push({
+    op: "block",
+    blockType: { kind: "empty" },
+    body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr],
+  } as Instr);
 }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1074,18 +1074,21 @@ export function compileSourceSync(
     1100, // "Invalid use of 'X' in strict mode" — sloppy-mode JS allows eval/arguments (#331)
     1121, // "Octal literals are not allowed in strict mode" — valid sloppy-mode JS
     1489, // "Decimals with leading zeros are not allowed" — valid sloppy-mode JS octal literals
+    // #2631/#1768 — "Signature declarations can only be used in TypeScript files."
+    // Fires under checkJs at the import site when a `.js` file imports a value
+    // whose synthetic `.d.ts` typing is a callable/overloaded declaration (e.g.
+    // `import { readSync, writeSync } from "node:fs"` resolving to the node-emu
+    // typings). Benign for codegen — the import resolves and lowers regardless.
+    // Scoped to this exact code so it does NOT relax the gate for genuine
+    // strict-mode SyntaxErrors (e.g. duplicate params), which the eval shim
+    // (src/runtime-eval.ts) relies on `compileSourceSync(...).success === false`
+    // to surface as a thrown SyntaxError (the 17 strict-eval test262 cases).
+    8017,
   ]);
-  // When allowJs is set, don't bail on TS diagnostics — JS packages with JSDoc
-  // annotations (and `.js` files importing overloaded typed declarations from
-  // `node:*`, e.g. node:fs readSync/writeSync — TS8017 "signature-in-JS" at the
-  // import site, #2631/#1768) produce false-positive errors; codegen handles it.
-  // This mirrors the multi-source path's `!options.allowJs` gate below.
-  const hasSyntaxErrors =
-    !options.allowJs &&
-    ast.syntacticDiagnostics.some(
-      (d) => d.category === 1 && d.file === ast.sourceFile && !TOLERATED_SYNTAX_CODES.has(d.code),
-    );
-  const hasHardTypeErrors = !options.allowJs && ast.diagnostics.some((d) => isHardTypeScriptDiagnostic(d, ast.checker));
+  const hasSyntaxErrors = ast.syntacticDiagnostics.some(
+    (d) => d.category === 1 && d.file === ast.sourceFile && !TOLERATED_SYNTAX_CODES.has(d.code),
+  );
+  const hasHardTypeErrors = ast.diagnostics.some((d) => isHardTypeScriptDiagnostic(d, ast.checker));
 
   if ((hasSyntaxErrors || hasHardTypeErrors) && errors.length > 0) {
     return failResult(errors);

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1075,10 +1075,17 @@ export function compileSourceSync(
     1121, // "Octal literals are not allowed in strict mode" — valid sloppy-mode JS
     1489, // "Decimals with leading zeros are not allowed" — valid sloppy-mode JS octal literals
   ]);
-  const hasSyntaxErrors = ast.syntacticDiagnostics.some(
-    (d) => d.category === 1 && d.file === ast.sourceFile && !TOLERATED_SYNTAX_CODES.has(d.code),
-  );
-  const hasHardTypeErrors = ast.diagnostics.some((d) => isHardTypeScriptDiagnostic(d, ast.checker));
+  // When allowJs is set, don't bail on TS diagnostics — JS packages with JSDoc
+  // annotations (and `.js` files importing overloaded typed declarations from
+  // `node:*`, e.g. node:fs readSync/writeSync — TS8017 "signature-in-JS" at the
+  // import site, #2631/#1768) produce false-positive errors; codegen handles it.
+  // This mirrors the multi-source path's `!options.allowJs` gate below.
+  const hasSyntaxErrors =
+    !options.allowJs &&
+    ast.syntacticDiagnostics.some(
+      (d) => d.category === 1 && d.file === ast.sourceFile && !TOLERATED_SYNTAX_CODES.has(d.code),
+    );
+  const hasHardTypeErrors = !options.allowJs && ast.diagnostics.some((d) => isHardTypeScriptDiagnostic(d, ast.checker));
 
   if ((hasSyntaxErrors || hasHardTypeErrors) && errors.length > 0) {
     return failResult(errors);

--- a/tests/issue-1530.test.ts
+++ b/tests/issue-1530.test.ts
@@ -17,6 +17,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { compile } from "../src/index.js";
+import { buildNodeFsShim } from "../scripts/build-node-fs-shim.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const hostPath = join(here, "..", "examples", "native-messaging", "nm_js2wasm.ts");
@@ -24,25 +25,32 @@ const hostPath = join(here, "..", "examples", "native-messaging", "nm_js2wasm.ts
 describe("#1530 Native Messaging host example", () => {
   it("compiles examples/native-messaging/nm_js2wasm.ts under --target wasi", async () => {
     const src = readFileSync(hostPath, "utf-8");
-    const result = await compile(src, { fileName: "nm_js2wasm.ts", target: "wasi" });
+    const result = await compile(src, { fileName: "nm_js2wasm.ts", target: "wasi", linkNodeShims: true });
     expect(result.success).toBe(true);
     expect(result.binary.length).toBeGreaterThan(0);
   });
 
-  it("imports stdin (fd_read) and stdout (fd_write) WASI syscalls, no env imports", async () => {
+  it("imports the node:fs interface (readSync/writeSync + memory), no direct WASI fd_* or env imports", async () => {
+    // #2631 — the example now uses node:fs fd-based readSync/writeSync via the
+    // linkable node:fs shim, so it imports module "node:fs" (the declared
+    // interface) and NOT wasi_snapshot_preview1 fd_read/fd_write directly. The
+    // shim (node-fs.wat) maps node:fs → WASI; the user module stays host-agnostic.
     const src = readFileSync(hostPath, "utf-8");
-    const result = await compile(src, { fileName: "nm_js2wasm.ts", target: "wasi" });
+    const result = await compile(src, { fileName: "nm_js2wasm.ts", target: "wasi", linkNodeShims: true });
     expect(result.success).toBe(true);
-    expect(result.wat).toContain("wasi_snapshot_preview1");
-    expect(result.wat).toContain("fd_read"); // process.stdin.read()
-    expect(result.wat).toContain("fd_write"); // console.log / console.error
-    // Standalone: no JS host env.* imports leak in.
+    expect(result.wat).toContain('(import "node:fs" "readSync"'); // fs.readSync(0, …)
+    expect(result.wat).toContain('(import "node:fs" "writeSync"'); // fs.writeSync(1|2, …)
+    expect(result.wat).toContain('(import "node:fs" "memory"'); // shared linear memory
+    // The shim implementation name must NOT leak into the declared dependency.
+    expect(result.wat).not.toContain("js2wasm:node-fs");
+    // No direct WASI syscall import for the IO path, and no JS host env.* imports.
+    expect(result.wat).not.toContain("wasi_snapshot_preview1");
     expect(result.wat).not.toContain('(import "env"');
   });
 
   it("produces a binary that WebAssembly accepts", async () => {
     const src = readFileSync(hostPath, "utf-8");
-    const result = await compile(src, { fileName: "nm_js2wasm.ts", target: "wasi" });
+    const result = await compile(src, { fileName: "nm_js2wasm.ts", target: "wasi", linkNodeShims: true });
     expect(result.success).toBe(true);
     // Throws on an invalid module; passing means the structure/types are sound.
     expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
@@ -59,7 +67,11 @@ describe("#1530 Native Messaging host example", () => {
 describe("#1618/#1651 framed stdin→stdout round-trip", () => {
   // Minimal raw-byte WASI shim: fd_read drains a preloaded stdin buffer, fd_write
   // appends the exact bytes to an ordered capture list keyed by fd.
-  function runWasiRaw(binary: Uint8Array, stdin: Uint8Array): Uint8Array {
+  // #2631 — `linkShim` links the node-fs shim for example binaries (which import
+  // node:fs readSync/writeSync over a shim-owned memory). Self-contained sources
+  // that still use the inline process.std* path own their own memory (linkShim
+  // false).
+  function runWasiRaw(binary: Uint8Array, stdin: Uint8Array, linkShim = false): Uint8Array {
     // Boxed so the WASI closures can read it after the instance is created.
     const ref: { mem: WebAssembly.Memory | undefined } = { mem: undefined };
     const memView = () => new DataView(ref.mem!.buffer);
@@ -103,11 +115,27 @@ describe("#1618/#1651 framed stdin→stdout round-trip", () => {
         return 0;
       },
     };
-    const inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
-      wasi_snapshot_preview1: wasi,
-      env: {},
-    });
-    ref.mem = inst.exports.memory as WebAssembly.Memory;
+    let inst: WebAssembly.Instance;
+    if (linkShim) {
+      const shim = new WebAssembly.Instance(new WebAssembly.Module(buildNodeFsShim()), {
+        wasi_snapshot_preview1: wasi,
+      });
+      ref.mem = shim.exports.memory as WebAssembly.Memory;
+      inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+        "node:fs": {
+          memory: shim.exports.memory,
+          readSync: shim.exports.readSync,
+          writeSync: shim.exports.writeSync,
+        },
+        env: {},
+      });
+    } else {
+      inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+        wasi_snapshot_preview1: wasi,
+        env: {},
+      });
+      ref.mem = inst.exports.memory as WebAssembly.Memory;
+    }
     (inst.exports.main as () => void)();
     // Reassemble the fd=1 (stdout) byte stream in write order.
     const fd1 = writes.filter(([fd]) => fd === 1).flatMap(([, b]) => Array.from(b));
@@ -173,12 +201,12 @@ export function main(): void {
 
   it("compiles the shipped example and round-trips it byte-exactly", async () => {
     const src = readFileSync(hostPath, "utf-8");
-    const result = await compile(src, { fileName: "nm_js2wasm.ts", target: "wasi" });
+    const result = await compile(src, { fileName: "nm_js2wasm.ts", target: "wasi", linkNodeShims: true });
     expect(result.success).toBe(true);
 
     // The shipped host echoes the received body verbatim (byte-for-byte, no
     // wrapper), so the response body equals the input body exactly.
-    const out = runWasiRaw(result.binary, frame('{"cmd":"ping"}'));
+    const out = runWasiRaw(result.binary, frame('{"cmd":"ping"}'), true);
     const expectedBody = '{"cmd":"ping"}';
     expect(new DataView(out.buffer, out.byteOffset).getUint32(0, true)).toBe(expectedBody.length);
     expect(new TextDecoder().decode(out.subarray(4))).toBe(expectedBody);
@@ -199,7 +227,7 @@ export function main(): void {
   // assert the response is the exact same 1 MiB body with the right prefix.
   it("echoes a 1 MiB framed body byte-exactly (#389 large-message regression)", async () => {
     const src = readFileSync(hostPath, "utf-8");
-    const result = await compile(src, { fileName: "nm_js2wasm.ts", target: "wasi" });
+    const result = await compile(src, { fileName: "nm_js2wasm.ts", target: "wasi", linkNodeShims: true });
     expect(result.success).toBe(true);
 
     const SIZE = 1024 * 1024; // 1 MiB
@@ -209,7 +237,7 @@ export function main(): void {
     new DataView(input.buffer).setUint32(0, SIZE, true);
     input.set(body, 4);
 
-    const out = runWasiRaw(result.binary, input);
+    const out = runWasiRaw(result.binary, input, true);
     // 4-byte LE prefix declares the full 1 MiB length…
     expect(new DataView(out.buffer, out.byteOffset).getUint32(0, true)).toBe(SIZE);
     // …and the body is the exact same bytes, with no truncation/null-fill.
@@ -238,7 +266,7 @@ export function main(): void {
   // exceeds the 1 MiB cap, and the flattened elements equal the inputs in order.
   it("re-chunks large JSON arrays into valid <=1 MiB JSON frames across one session (#389)", async () => {
     const src = readFileSync(hostPath, "utf-8");
-    const result = await compile(src, { fileName: "nm_js2wasm.ts", target: "wasi" });
+    const result = await compile(src, { fileName: "nm_js2wasm.ts", target: "wasi", linkNodeShims: true });
     expect(result.success).toBe(true);
 
     const CHUNK = 1024 * 1024;
@@ -263,7 +291,7 @@ export function main(): void {
       off += p.length;
     }
 
-    const out = runWasiRaw(result.binary, stdin);
+    const out = runWasiRaw(result.binary, stdin, true);
 
     // Parse every response frame as JSON; flatten elements in arrival order.
     const view = new DataView(out.buffer, out.byteOffset);

--- a/tests/issue-1753.test.ts
+++ b/tests/issue-1753.test.ts
@@ -11,6 +11,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { compile } from "../src/index.js";
+import { buildNodeFsShim } from "../scripts/build-node-fs-shim.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const hostPath = join(here, "..", "examples", "native-messaging", "nm_js2wasm.ts");
@@ -23,7 +24,7 @@ async function compileHost(): Promise<Uint8Array> {
   if (!hostBinary) {
     hostBinary = (async () => {
       const src = readFileSync(hostPath, "utf-8");
-      const result = await compile(src, { fileName: "nm_js2wasm.ts", target: "wasi" });
+      const result = await compile(src, { fileName: "nm_js2wasm.ts", target: "wasi", linkNodeShims: true });
       expect(result.success, result.success ? "" : result.errors.map((e) => e.message).join("\n")).toBe(true);
       expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
       return result.binary;
@@ -173,11 +174,21 @@ function runHostWithPatternInput(binary: Uint8Array, totalBodyBytes: number): Ho
     },
   };
 
-  const inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+  // #2631 — the host uses node:fs readSync/writeSync via the node:fs shim.
+  // Instantiate the shim first (it owns the memory + makes the WASI fd_* calls),
+  // then the user module importing {memory, readSync, writeSync} from the shim.
+  const shim = new WebAssembly.Instance(new WebAssembly.Module(buildNodeFsShim()), {
     wasi_snapshot_preview1: wasi,
+  });
+  ref.mem = shim.exports.memory as WebAssembly.Memory;
+  const inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+    "node:fs": {
+      memory: shim.exports.memory,
+      readSync: shim.exports.readSync,
+      writeSync: shim.exports.writeSync,
+    },
     env: {},
   });
-  ref.mem = inst.exports.memory as WebAssembly.Memory;
   (inst.exports.main as () => void)();
 
   return {

--- a/tests/issue-1767.test.ts
+++ b/tests/issue-1767.test.ts
@@ -11,6 +11,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { compile } from "../src/index.js";
+import { buildNodeFsShim } from "../scripts/build-node-fs-shim.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const hostPath = join(here, "..", "examples", "native-messaging", "nm_js2wasm.ts");
@@ -28,7 +29,7 @@ async function compileHost(): Promise<Uint8Array> {
   if (!hostBinary) {
     hostBinary = (async () => {
       const src = readFileSync(hostPath, "utf-8");
-      const result = await compile(src, { fileName: "nm_js2wasm.ts", target: "wasi" });
+      const result = await compile(src, { fileName: "nm_js2wasm.ts", target: "wasi", linkNodeShims: true });
       expect(result.success, result.success ? "" : result.errors.map((e) => e.message).join("\n")).toBe(true);
       expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
       return result.binary;
@@ -79,11 +80,20 @@ function runWasiRaw(binary: Uint8Array, stdin: Uint8Array): Uint8Array {
       return 0;
     },
   };
-  const inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+  // #2631 — node:fs shim: instantiate it first (owns memory + WASI fd_*), then
+  // the user module importing {memory, readSync, writeSync} from the shim.
+  const shim = new WebAssembly.Instance(new WebAssembly.Module(buildNodeFsShim()), {
     wasi_snapshot_preview1: wasi,
+  });
+  ref.mem = shim.exports.memory as WebAssembly.Memory;
+  const inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+    "node:fs": {
+      memory: shim.exports.memory,
+      readSync: shim.exports.readSync,
+      writeSync: shim.exports.writeSync,
+    },
     env: {},
   });
-  ref.mem = inst.exports.memory as WebAssembly.Memory;
   (inst.exports.main as () => void)();
 
   const fd1 = writes.filter(([fd]) => fd === 1).map(([, bytes]) => bytes);
@@ -354,11 +364,20 @@ function runHostWithLargeStringInput(binary: Uint8Array, contentBytes: number): 
     },
   };
 
-  const inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+  // #2631 — node:fs shim: instantiate it first (owns memory + WASI fd_*), then
+  // the user module importing {memory, readSync, writeSync} from the shim.
+  const shim = new WebAssembly.Instance(new WebAssembly.Module(buildNodeFsShim()), {
     wasi_snapshot_preview1: wasi,
+  });
+  ref.mem = shim.exports.memory as WebAssembly.Memory;
+  const inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+    "node:fs": {
+      memory: shim.exports.memory,
+      readSync: shim.exports.readSync,
+      writeSync: shim.exports.writeSync,
+    },
     env: {},
   });
-  ref.mem = inst.exports.memory as WebAssembly.Memory;
   (inst.exports.main as () => void)();
 
   return {
@@ -494,11 +513,20 @@ function runHostWithNullArrayInput(binary: Uint8Array, elements: number): NullAr
     },
   };
 
-  const inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+  // #2631 — node:fs shim: instantiate it first (owns memory + WASI fd_*), then
+  // the user module importing {memory, readSync, writeSync} from the shim.
+  const shim = new WebAssembly.Instance(new WebAssembly.Module(buildNodeFsShim()), {
     wasi_snapshot_preview1: wasi,
+  });
+  ref.mem = shim.exports.memory as WebAssembly.Memory;
+  const inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+    "node:fs": {
+      memory: shim.exports.memory,
+      readSync: shim.exports.readSync,
+      writeSync: shim.exports.writeSync,
+    },
     env: {},
   });
-  ref.mem = inst.exports.memory as WebAssembly.Memory;
   (inst.exports.main as () => void)();
 
   return {

--- a/tests/issue-1768.test.ts
+++ b/tests/issue-1768.test.ts
@@ -16,12 +16,13 @@ import { compile } from "../src/index.js";
 const here = dirname(fileURLToPath(import.meta.url));
 const hostPath = join(here, "..", "examples", "native-messaging", "nm_js2wasm.ts");
 
-async function compileWasiJs(source: string) {
+async function compileWasiJs(source: string, linkNodeShims = false) {
   return await compile(source, {
     fileName: "nm_js2wasm.js",
     allowJs: true,
     target: "wasi",
     optimize: 0,
+    ...(linkNodeShims ? { linkNodeShims: true } : {}),
   });
 }
 
@@ -73,7 +74,9 @@ describe("#1768 allowJs Native Messaging sendMessage validates under --target wa
       },
     }).outputText;
 
-    const result = await compileWasiJs(source);
+    // #2631 — the example now imports node:fs readSync/writeSync, lowered via the
+    // node:fs shim under --link-node-shims (the transpiled JS keeps the import).
+    const result = await compileWasiJs(source, /* linkNodeShims */ true);
     expect(result.success, result.success ? "" : result.errors.map((e) => e.message).join("\n")).toBe(true);
     expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
     expect(result.wat).not.toContain('(import "env"');

--- a/tests/issue-1886.test.ts
+++ b/tests/issue-1886.test.ts
@@ -263,16 +263,22 @@ describe("#1886 linear-safe Uint8Array analysis", () => {
   });
 
   it("classifies every buffer in the native-messaging host as linear-safe", () => {
+    // #2631 — the example now uses node:fs fd-based readSync/writeSync (the
+    // faithful synchronous Node primitives) instead of process.std*.{read,write}.
+    // The #1886 analysis recognises readSync(fd, buf, …)/writeSync(fd, buf, …) as
+    // byte-I/O buffer sinks (ioBufferArgIndex), so every buffer stays linear-safe.
     const nmPath = resolve(here, "../examples/native-messaging/nm_js2wasm.ts");
     const src = readFileSync(nmPath, "utf-8");
     const { safeNames, linearParamFns } = analyze(src);
-    // Buffers declared in main + the per-frame temporaries.
-    for (const name of ["header", "one", "buf", "small", "tmp", "frame", "src"]) {
+    // Buffers declared in main + the per-frame temporaries + the write buffer
+    // (`out`) and the stderr-telemetry byte buffer (`bytes`).
+    for (const name of ["header", "one", "buf", "tmp", "out", "src", "bytes"]) {
       expect(safeNames.has(name), `expected '${name}' linear-safe`).toBe(true);
     }
     // Helper params that carry buffers must be linear-rewritten.
     expect(linearParamFns.get("readExact")).toContain(0);
     expect(linearParamFns.get("readAt")).toContain(0);
+    expect(linearParamFns.get("writeAll")).toContain(0);
     expect(linearParamFns.get("decodeLength")).toContain(0);
     expect(linearParamFns.get("emitRun")).toContain(0);
   });
@@ -388,14 +394,19 @@ describe("#1886 Slice B intraprocedural eligibility (localOnlyBindings)", () => 
   });
 
   it("the native-messaging host: per-frame temporaries are Slice-B-eligible, the threaded read window is not", () => {
+    // #2631 — with node:fs readSync/writeSync, `bytes` (the stderr-telemetry
+    // buffer in `logFrameBodyRead`) is built + written entirely within one
+    // function and only flows into writeSync (an I/O sink), so it is Slice-B
+    // (local-only) eligible.
     const nmPath = resolve(here, "../examples/native-messaging/nm_js2wasm.ts");
     const src = readFileSync(nmPath, "utf-8");
     const { localOnlyNames } = analyze(src);
-    // `frame` (emitRun) and the `writeLength` 4-byte literal are local-only.
-    expect(localOnlyNames.has("frame")).toBe(true);
-    // `buf`/`header`/`one`/`small`/`tmp` flow through readExact/readAt user
-    // params → param-threaded → deferred to Slice C, not linear-backed now.
-    for (const name of ["buf", "header", "one", "small", "tmp", "src"]) {
+    // `bytes` (logFrameBodyRead) is local-only — never threaded into a user fn.
+    expect(localOnlyNames.has("bytes")).toBe(true);
+    // `buf`/`header`/`one`/`tmp`/`out`/`src` flow through readExact/readAt/
+    // writeAll/emitRun user params → param-threaded → deferred to Slice C, not
+    // linear-backed now.
+    for (const name of ["buf", "header", "one", "tmp", "out", "src"]) {
       expect(localOnlyNames.has(name), `expected '${name}' deferred (param-threaded)`).toBe(false);
     }
   });

--- a/tests/issue-2521-native-messaging-rechunk.test.ts
+++ b/tests/issue-2521-native-messaging-rechunk.test.ts
@@ -19,6 +19,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { compile } from "../src/index.js";
+import { buildNodeFsShim } from "../scripts/build-node-fs-shim.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const hostPath = join(here, "..", "examples", "native-messaging", "nm_js2wasm.ts");
@@ -69,11 +70,20 @@ function runWasiRaw(binary: Uint8Array, stdin: Uint8Array): Uint8Array {
       return 0;
     },
   };
-  const inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+  // #2631 — node:fs shim: instantiate it first (owns memory + WASI fd_*), then
+  // the user module importing {memory, readSync, writeSync} from the shim.
+  const shim = new WebAssembly.Instance(new WebAssembly.Module(buildNodeFsShim()), {
     wasi_snapshot_preview1: wasi,
+  });
+  ref.mem = shim.exports.memory as WebAssembly.Memory;
+  const inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+    "node:fs": {
+      memory: shim.exports.memory,
+      readSync: shim.exports.readSync,
+      writeSync: shim.exports.writeSync,
+    },
     env: {},
   });
-  ref.mem = inst.exports.memory as WebAssembly.Memory;
   (inst.exports.main as () => void)();
   const fd1 = writes.filter(([fd]) => fd === 1).flatMap(([, b]) => Array.from(b));
   return Uint8Array.from(fd1);
@@ -115,14 +125,22 @@ function parseFrames(bytes: Uint8Array): string[] {
 
 describe("#2521 Native Messaging host — >1 MiB re-chunking + multi-message sequence", () => {
   it("echoes a <=1 MiB message verbatim in a single frame", async () => {
-    const result = await compile(readFileSync(hostPath, "utf-8"), { fileName: "nm_js2wasm.ts", target: "wasi" });
+    const result = await compile(readFileSync(hostPath, "utf-8"), {
+      fileName: "nm_js2wasm.ts",
+      target: "wasi",
+      linkNodeShims: true,
+    });
     expect(result.success).toBe(true);
     const frames = parseFrames(runWasiRaw(result.binary, frame(JSON.stringify([1, 2, 3]))));
     expect(frames).toEqual(["[1,2,3]"]);
   });
 
   it("re-chunks a >1 MiB array into multiple <=1 MiB JSON-array frames that reassemble to the original", async () => {
-    const result = await compile(readFileSync(hostPath, "utf-8"), { fileName: "nm_js2wasm.ts", target: "wasi" });
+    const result = await compile(readFileSync(hostPath, "utf-8"), {
+      fileName: "nm_js2wasm.ts",
+      target: "wasi",
+      linkNodeShims: true,
+    });
     expect(result.success).toBe(true);
     const N = 209715 * 2; // ~2 MiB JSON body — strictly above the 1 MiB cap
     const big = Array(N); // sparse → JSON renders as [null, null, …]
@@ -143,7 +161,11 @@ describe("#2521 Native Messaging host — >1 MiB re-chunking + multi-message seq
   });
 
   it("processes the reporter's multi-message sequence (big then small) with no desync", async () => {
-    const result = await compile(readFileSync(hostPath, "utf-8"), { fileName: "nm_js2wasm.ts", target: "wasi" });
+    const result = await compile(readFileSync(hostPath, "utf-8"), {
+      fileName: "nm_js2wasm.ts",
+      target: "wasi",
+      linkNodeShims: true,
+    });
     expect(result.success).toBe(true);
     const N = 209715 * 2; // ~2 MiB
     const big = Array(N);

--- a/tests/issue-2526-atomic-frame-writes.test.ts
+++ b/tests/issue-2526-atomic-frame-writes.test.ts
@@ -9,6 +9,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { compile } from "../src/index.js";
+import { buildNodeFsShim } from "../scripts/build-node-fs-shim.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const hostPath = join(here, "..", "examples", "native-messaging", "nm_js2wasm.ts");
@@ -62,8 +63,23 @@ function runCaptureWrites(binary: Uint8Array, stdin: Uint8Array): { sizes: numbe
       return 0;
     },
   };
-  const inst = new WebAssembly.Instance(new WebAssembly.Module(binary), { wasi_snapshot_preview1: wasi, env: {} });
-  ref.mem = inst.exports.memory as WebAssembly.Memory;
+  // #2631 — the example now uses node:fs readSync/writeSync via the node:fs
+  // shim (--link-node-shims). Instantiate the shim FIRST (it owns the memory and
+  // makes the fd_read/fd_write WASI calls), then the user module importing
+  // {memory, readSync, writeSync} from the shim. fd=1 writes are still issued by
+  // the shim's writeSync over the shared memory, so the size capture is unchanged.
+  const shim = new WebAssembly.Instance(new WebAssembly.Module(buildNodeFsShim()), {
+    wasi_snapshot_preview1: wasi,
+  });
+  ref.mem = shim.exports.memory as WebAssembly.Memory;
+  const inst = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+    "node:fs": {
+      memory: shim.exports.memory,
+      readSync: shim.exports.readSync,
+      writeSync: shim.exports.writeSync,
+    },
+    env: {},
+  });
   (inst.exports.main as () => void)();
   const out = Uint8Array.from(chunks.flatMap((c) => Array.from(c)));
   return { sizes, out };
@@ -79,7 +95,11 @@ function frame(jsonBody: string): Uint8Array {
 
 describe("#2526 Native Messaging host — atomic frame writes", () => {
   it("writes a small (<=1 MiB) message as one fd_write (no bare 4-byte length write)", async () => {
-    const r = await compile(readFileSync(hostPath, "utf-8"), { fileName: "nm_js2wasm.ts", target: "wasi" });
+    const r = await compile(readFileSync(hostPath, "utf-8"), {
+      fileName: "nm_js2wasm.ts",
+      target: "wasi",
+      linkNodeShims: true,
+    });
     expect(r.success).toBe(true);
     const { sizes } = runCaptureWrites(r.binary, frame(JSON.stringify([1, 2, 3])));
     expect(sizes).not.toContain(4); // no standalone length-prefix write
@@ -88,7 +108,11 @@ describe("#2526 Native Messaging host — atomic frame writes", () => {
   });
 
   it("writes each re-chunked frame of a >1 MiB message atomically (writes == frames, none is 4 bytes)", async () => {
-    const r = await compile(readFileSync(hostPath, "utf-8"), { fileName: "nm_js2wasm.ts", target: "wasi" });
+    const r = await compile(readFileSync(hostPath, "utf-8"), {
+      fileName: "nm_js2wasm.ts",
+      target: "wasi",
+      linkNodeShims: true,
+    });
     expect(r.success).toBe(true);
     const N = 209715 * 2; // ~2 MiB → multiple re-chunked frames
     const body = JSON.stringify(Array(N));

--- a/tests/issue-2631-node-fs-fd-shim.test.ts
+++ b/tests/issue-2631-node-fs-fd-shim.test.ts
@@ -1,0 +1,216 @@
+// #2631 — node:fs fd-based readSync / writeSync via the linkable `node:fs` shim.
+//
+// loopdive/js2#389: the Native Messaging example used
+// `process.stdin.read(buffer, offset)`, which matches NO real Node API
+// (process.stdin is an async Duplex stream with no synchronous buffer-filling
+// read). The faithful synchronous primitives are `fs.readSync(fd, …)` /
+// `fs.writeSync(fd, …)` — fd-based (integer fd 0/1/2), NOT path-based, mapping
+// 1:1 to WASI fd_read / fd_write with no filesystem.
+//
+// Under `--target wasi` + `linkNodeShims: true`, a module that imports
+// `{ readSync, writeSync } from "node:fs"` emits wasm imports against module
+// `"node:fs"` (the declared interface, not the shim that satisfies it) and
+// carries NO direct `wasi_snapshot_preview1` fd_read/fd_write import for that
+// path. A separately compiled `node-fs.wasm` (or a native WASI host, or the real
+// `node:fs` under a JS host) provides that interface at link time.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildNodeFsShim } from "../scripts/build-node-fs-shim.mjs";
+
+/**
+ * Link the node-fs shim + the user module and round-trip a fixed stdin payload,
+ * capturing fd=1 (stdout) and fd=2 (stderr) bytes. The shim owns the memory; the
+ * user module imports it along with readSync/writeSync. A minimal WASI
+ * fd_read/fd_write serves the payload incrementally over the shim-owned memory.
+ */
+function linkAndRun(userBinary: Uint8Array, stdin: Uint8Array): { stdout: Uint8Array; stderr: Uint8Array } {
+  const shimBinary = buildNodeFsShim();
+  const ref: { mem: WebAssembly.Memory | undefined } = { mem: undefined };
+  const memView = () => new DataView(ref.mem!.buffer);
+  const out1: number[] = [];
+  const out2: number[] = [];
+  let pos = 0;
+  const wasi = {
+    fd_read(fd: number, iovs: number, iovsLen: number, nread: number): number {
+      // fd is the integer passed through from readSync(fd, …); fd=0 = stdin.
+      const view = memView();
+      let total = 0;
+      for (let i = 0; i < iovsLen; i++) {
+        const ptr = view.getUint32(iovs + i * 8, true);
+        const len = view.getUint32(iovs + i * 8 + 4, true);
+        const n = Math.min(len, stdin.length - pos);
+        new Uint8Array(ref.mem!.buffer, ptr, n).set(stdin.subarray(pos, pos + n));
+        pos += n;
+        total += n;
+        if (n < len) break;
+      }
+      view.setUint32(nread, total, true);
+      return 0;
+    },
+    fd_write(wfd: number, iovs: number, iovsLen: number, nwritten: number): number {
+      const view = memView();
+      let total = 0;
+      for (let i = 0; i < iovsLen; i++) {
+        const ptr = view.getUint32(iovs + i * 8, true);
+        const len = view.getUint32(iovs + i * 8 + 4, true);
+        const bytes = new Uint8Array(ref.mem!.buffer, ptr, len);
+        if (wfd === 1) for (const b of bytes) out1.push(b);
+        else if (wfd === 2) for (const b of bytes) out2.push(b);
+        total += len;
+      }
+      view.setUint32(nwritten, total, true);
+      return 0;
+    },
+  };
+  // Instantiate the shim FIRST (imports only wasi_snapshot_preview1), then the
+  // user with {memory + readSync/writeSync} from the shim — no instantiation cycle.
+  const shim = new WebAssembly.Instance(new WebAssembly.Module(shimBinary), {
+    wasi_snapshot_preview1: wasi,
+  });
+  ref.mem = shim.exports.memory as WebAssembly.Memory;
+  const user = new WebAssembly.Instance(new WebAssembly.Module(userBinary), {
+    "node:fs": {
+      memory: shim.exports.memory,
+      readSync: shim.exports.readSync,
+      writeSync: shim.exports.writeSync,
+    },
+    env: {},
+  });
+  (user.exports.main as () => void)();
+  return { stdout: Uint8Array.from(out1), stderr: Uint8Array.from(out2) };
+}
+
+// A framed-echo host: read a 4-byte LE length prefix + body off fd 0, echo both
+// back to fd 1, exactly mirroring the example's small-frame fast path. Uses the
+// options form for readSync and the offset form for writeSync.
+const FRAMED_ECHO = `
+import { readSync, writeSync } from "node:fs";
+function readExact(buf: Uint8Array, n: number): boolean {
+  let got = 0;
+  while (got < n) {
+    const r = readSync(0, buf, { offset: got, length: n - got });
+    if (r <= 0) return false;
+    got = got + r;
+  }
+  return true;
+}
+function writeAll(out: Uint8Array): void {
+  let n = 0;
+  while (n < out.length) {
+    const w = writeSync(1, out, n);
+    if (w <= 0) return;
+    n = n + w;
+  }
+}
+export function main(): void {
+  const header = new Uint8Array(4);
+  if (!readExact(header, 4)) return;
+  const len = header[0] + header[1] * 256 + header[2] * 65536 + header[3] * 16777216;
+  const body = new Uint8Array(len);
+  if (!readExact(body, len)) return;
+  writeAll(header);
+  writeAll(body);
+}
+`;
+
+describe("#2631 — node:fs fd-based readSync/writeSync shim", () => {
+  it("emits node:fs imports (memory + readSync/writeSync), no direct wasi fd_read/fd_write", async () => {
+    const result = await compile(FRAMED_ECHO, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
+    expect(result.success).toBe(true);
+    const wat = result.wat ?? "";
+    // Imports the node:fs interface: memory + the IO functions it uses.
+    expect(wat).toContain('(import "node:fs" "memory" (memory');
+    expect(wat).toContain('(import "node:fs" "readSync"');
+    expect(wat).toContain('(import "node:fs" "writeSync"');
+    // The shim implementation name must NOT leak into the module's declared deps.
+    expect(wat).not.toContain("js2wasm:node-fs");
+    // NO direct wasi_snapshot_preview1 fd_read/fd_write import survives for this path.
+    expect(wat).not.toContain("wasi_snapshot_preview1");
+    // The user module does NOT declare/own its own memory — it imports it.
+    expect(wat).not.toContain('(export "memory"');
+    expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
+  });
+
+  it("links node-fs.wasm and round-trips a framed message byte-for-byte", async () => {
+    const result = await compile(FRAMED_ECHO, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
+    expect(result.success).toBe(true);
+    // frame: len=5 (LE) + a body with non-printable / high bytes.
+    const frame = Uint8Array.from([0x05, 0x00, 0x00, 0x00, 0x00, 0xff, 0x0a, 0x7f, 0x80]);
+    const { stdout } = linkAndRun(result.binary, frame);
+    expect(Array.from(stdout)).toEqual([0x05, 0x00, 0x00, 0x00, 0x00, 0xff, 0x0a, 0x7f, 0x80]);
+  });
+
+  it("readSync respects the options `length` so it never over-reads past the target", async () => {
+    // A buffer larger than the available stdin: readSync(0, buf, {offset, length})
+    // with length = remaining-to-target must stop at the target, not fill the buffer.
+    const src = `
+import { readSync, writeSync } from "node:fs";
+export function main(): void {
+  const buf = new Uint8Array(8); // capacity 8
+  // Only read 3 bytes even though the buffer holds 8 — length caps the read.
+  let got = 0;
+  while (got < 3) {
+    const r = readSync(0, buf, { offset: got, length: 3 - got });
+    if (r <= 0) break;
+    got = got + r;
+  }
+  const out = new Uint8Array(got);
+  let i = 0;
+  while (i < got) { out[i] = buf[i]; i = i + 1; }
+  let n = 0;
+  while (n < out.length) { const w = writeSync(1, out, n); if (w <= 0) break; n = n + w; }
+}
+`;
+    const result = await compile(src, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
+    expect(result.success).toBe(true);
+    // stdin has 5 bytes available, but we only ever request 3.
+    const stdin = Uint8Array.from([0x41, 0x42, 0x43, 0x44, 0x45]);
+    const { stdout } = linkAndRun(result.binary, stdin);
+    expect(Array.from(stdout)).toEqual([0x41, 0x42, 0x43]);
+  });
+
+  it("writeSync(2, …) routes telemetry to fd=2 (stderr), off the stdout stream", async () => {
+    const src = `
+import { readSync, writeSync } from "node:fs";
+export function main(): void {
+  const a = new Uint8Array(2);
+  a[0] = 0x68; a[1] = 0x69; // "hi"
+  let n = 0;
+  while (n < a.length) { const w = writeSync(2, a, n); if (w <= 0) break; n = n + w; }
+  const b = new Uint8Array(2);
+  b[0] = 0x6f; b[1] = 0x6b; // "ok"
+  let m = 0;
+  while (m < b.length) { const w = writeSync(1, b, m); if (w <= 0) break; m = m + w; }
+}
+`;
+    const result = await compile(src, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
+    expect(result.success).toBe(true);
+    const { stdout, stderr } = linkAndRun(result.binary, new Uint8Array(0));
+    expect(Array.from(stdout)).toEqual([0x6f, 0x6b]); // "ok" only on fd=1
+    expect(Array.from(stderr)).toEqual([0x68, 0x69]); // "hi" only on fd=2
+  });
+
+  it("path-based readFileSync(path) is rejected under --target wasi (no filesystem)", async () => {
+    const src = `
+import { readFileSync } from "node:fs";
+export function main(): string {
+  return readFileSync("/etc/hostname", "utf-8");
+}
+`;
+    const result = await compile(src, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
+    expect(result.success).toBe(false);
+    const msgs = (result.errors ?? []).map((e) => e.message).join("\n");
+    expect(msgs).toMatch(/readFileSync/);
+    expect(msgs).toMatch(/not available under --target wasi|no filesystem|#2631/);
+  });
+
+  it("linkNodeShims is ignored for non-WASI targets (no node:fs shim import)", async () => {
+    const src = `
+import { readSync, writeSync } from "node:fs";
+export function noop(): void {}
+`;
+    const result = await compile(src, { fileName: "x.ts", linkNodeShims: true });
+    // Non-WASI: the node:fs fd-shim path does not apply.
+    expect(result.wat ?? "").not.toContain('(import "node:fs" "readSync"');
+  });
+});


### PR DESCRIPTION
## Summary

Switches the Native Messaging host example from the js2wasm-specific `process.stdin.read(buf, offset)` / `process.stdout.write` shapes to **real Node fd-based `fs.readSync(fd, …)` / `fs.writeSync(fd, …)`** from `node:fs`, so the **same source** (a) compiles via js2wasm to standalone WASI **and** (b) runs **unmodified** under real `node`.

Fixes loopdive/js2#389: the reporter correctly noted `process.stdin.read(buffer, offset)` matches **no** real Node API (`process.stdin` is an async Duplex stream with no synchronous buffer-filling `read`). `fs.readSync`/`fs.writeSync` are the faithful synchronous primitives — fd-based (integer fd 0/1/2, no path, no filesystem), mapping 1:1 to WASI `fd_read`/`fd_write`. This is also what Javy uses (`Javy.IO.readSync`).

## Design

`node:fs` is a **per-module shim** (`examples/native-messaging/node-fs.wat`, `scripts/build-node-fs-shim.mjs`), mirroring `js2wasm:node-process` (#2524/#2625). Codegen only wires `import { readSync, writeSync } from "node:fs"` to calls of imported shim functions; the syscall sequence lives in the `.wat` shim, **not** in codegen.

The wasm import **module is `node:fs`** (the declared interface) with the real Node member names `readSync`/`writeSync` — the shim implementation name never leaks into the module's declared dependency. Whether the import is satisfied by `node-fs.wat`, a native WASI host, or the real `node:fs` under a JS host is a link-time concern.

**ABI note:** the narrow ABI keeps the `fd` parameter — `readSync(fd, ptr, len) -> i32` / `writeSync(fd, ptr, len) -> i32`. Dropping `fd` would break stderr telemetry routing (`writeSync(2, …)` must go to fd 2, distinct from stdout fd 1 — exactly the #389 stderr gap). The ABI can be widened to more of `node:fs` later.

## Changes

- **codegen** (`index.ts`, `node-process-api.ts`, `context/{types,create-context}.ts`, `expressions/calls.ts`): register `node:fs` imports + shared memory under `--link-node-shims`; lower the calls via `tryCompileNodeFsCall` (GC-`Uint8Array` copy path + linear-backed zero-copy; positional and `{offset,length}` options forms; `length` defaults to `buf.length - offset` for over-read safety). Memory owner: node-fs for a node:fs-only program, else node-process.
- **path-based fs** (`readFileSync`, …) rejected under `--target wasi` (no filesystem).
- **#1886 analysis** (`linear-uint8-analysis.ts`): recognize `readSync`/`writeSync` as byte-IO buffer sinks so buffers stay linear-safe (keeps the Slice-C helper-signature rewrite consistent).
- **checker** (`checker/index.ts`): `node:fs` `readSync`/`writeSync` get fd-based signatures (single call signature, const form so allowJs/.js stays valid).
- **compiler** (`compiler.ts`): skip the syntax/hard-type gate under `allowJs` in the single-source path (mirrors the multi-source path) — TS8017 at a `node:` import is benign.
- **host-import-allowlist**: `node:fs` is a linkable interface (always allowed).
- **example + docs**: `nm_js2wasm.ts` rewritten to `node:fs` (+ a large-JSON-string re-chunk branch that also fixes a pre-existing #1767 large-string gap); `README.md`, new `NODE-FS-SHIM.md`, `smoke-test.sh` (preloads `node-fs.wasm`).

## Validation

- `tests/issue-2631-node-fs-fd-shim.test.ts` — 6/6: import shape, byte-exact round-trip linking `node-fs.wasm`, over-read safety, fd=2 routing, path-based rejection, non-WASI no-op.
- `examples/native-messaging/smoke-test.sh` — **PASS under real wasmtime 44** (byte-exact frame + clean stderr).
- The example runs **unmodified under real `node`** (verified via tsx): byte-exact stdout frame + clean stderr telemetry.
- Updated 6 example-referencing tests to link the shim (#1530/#1753/#1767/#1768/#2521/#2526); #1886 tests updated for the new example shape. Equivalence shards + linear/c-abi tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)