### PR TITLE
chore(s65): reconcile issue frontmatter against current main

### DIFF
--- a/plan/issues/1528-non-constructor-typeerror-promise-and-species.md
+++ b/plan/issues/1528-non-constructor-typeerror-promise-and-species.md
@@ -1,11 +1,12 @@
 ---
 id: 1528
 title: "spec gap: non-constructor TypeError — Promise.all / allSettled species and executor paths"
-status: blocked
+status: done
+completed: 2026-06-23
 created: 2026-05-20
-updated: 2026-06-22
+updated: 2026-06-23
 assignee: ttraenkler/dev-promise
-blocked_on: capability-bridge (#2614) — multi-hop host→wasm callback cast + Reflect.construct-with-newTarget ctor identity
+reconcile_note: "DONE 2026-06-23 — every non-constructor-TypeError arm of THIS issue is merged (#1921 arrow-noctor, #1940 closure-construct-bridge, #1945 classctor-arm, #1957 re-ground). Remaining isConstructor failures are NOT this issue's shape: 4 → capability bridge (#2614/#2623), 3 → unimplemented Promise methods (Promise.try / .finally / allKeyed) for PO to re-bucket."
 priority: medium
 feasibility: medium
 reasoning_effort: medium

--- a/plan/issues/2013-json-parse-reviver-ignored.md
+++ b/plan/issues/2013-json-parse-reviver-ignored.md
@@ -1,11 +1,12 @@
 ---
 id: 2013
 title: "JSON.parse reviver argument silently ignored (parse arm compiles only arguments[0]; host import drops it)"
-status: blocked
-blocked_on: [23]
+status: done
+completed: 2026-06-23
 sprint: 65
 created: 2026-06-10
-updated: 2026-06-14
+updated: 2026-06-23
+reconcile_note: "DONE 2026-06-23 — headline reviver-transform fix landed on main via PR #1454 (§25.5.1 InternalizeJSONProperty; _internalizeJSONProperty/_invokeJsonCallable runtime present). The old `blocked_on: [23]` was a bad reference (issue #23 = bitwise-operators, unrelated/done) and is removed. Narrow residual only: Object.defineProperty(this,…) inside a reviver (~-4 test262) — file as a separate follow-up if revisited."
 priority: medium
 feasibility: medium
 reasoning_effort: medium

--- a/plan/issues/2151-standalone-any-receiver-method-dispatch.md
+++ b/plan/issues/2151-standalone-any-receiver-method-dispatch.md
@@ -1,10 +1,12 @@
 ---
 id: 2151
 title: "standalone: any-receiver method dispatch — o.method() on a closed object-literal struct doesn't invoke"
-status: in-progress
+status: done
+completed: 2026-06-23
 sprint: 65
 created: 2026-06-14
-updated: 2026-06-17
+updated: 2026-06-23
+reconcile_note: "DONE 2026-06-23 — Slices 1-5 all merged (0-arg → N-ary → static-spread → dynamic-spread PR#1766 → mixed-spread PR#1814). The standalone any-receiver dispatch path is closed. Remaining edges belong to OTHER lanes: --target wasi array-like arms (broader WASI change) and ref/string-typed any-receiver params (#2580 M2 coercion-on-any). No standalone dev slice remains under this issue."
 priority: high
 feasibility: hard
 reasoning_effort: max

--- a/plan/issues/2158-standalone-class-prototype-descriptor-residual.md
+++ b/plan/issues/2158-standalone-class-prototype-descriptor-residual.md
@@ -1,11 +1,13 @@
 ---
 id: 2158
 title: "Standalone class/prototype/private-name/descriptor conformance residual (~1,388 tests)"
-status: in-progress
+status: done
+completed: 2026-06-23
 assignee: ttraenkler/cs-2158
 sprint: 65
 created: 2026-06-15
-updated: 2026-06-22
+updated: 2026-06-23
+reconcile_note: "DRAINED 2026-06-23 — both sliced sub-issues merged (#2610 PR#1935, #2611 #1936); architect re-measure (2026-06-22) found the class object-model umbrella largely closed standalone. Residual is substrate-deferred (#2175 builtin-prototype, #2580 value-rep-on-any)."
 children: [2610, 2611]
 priority: high
 feasibility: hard

--- a/plan/issues/2159-standalone-typedarray-dataview-buffer-residual.md
+++ b/plan/issues/2159-standalone-typedarray-dataview-buffer-residual.md
@@ -1,10 +1,12 @@
 ---
 id: 2159
 title: "Standalone TypedArray/DataView/ArrayBuffer conformance residual (~1,308 tests)"
-status: in-progress
+status: done
+completed: 2026-06-23
 sprint: 65
 created: 2026-06-15
 updated: 2026-06-23
+reconcile_note: "DRAINED 2026-06-23 — all 6 sliced sub-issues merged (#2592 PR#1915, #2593 #1928, #2594 #1917, #2595/#2597 #1912, #2596 #1920). Remaining residual is substrate-deferred (#2175 builtin-prototype readers, #2580/#2104 value-rep, #2622 native-collection subclass)."
 priority: high
 feasibility: medium
 reasoning_effort: high

--- a/plan/issues/2161-standalone-regexp-engine-residual.md
+++ b/plan/issues/2161-standalone-regexp-engine-residual.md
@@ -1,11 +1,13 @@
 ---
 id: 2161
 title: "Standalone RegExp engine conformance residual (~579 tests)"
-status: in-progress
+status: blocked
 assignee: ttraenkler/sd1
 sprint: 65
 created: 2026-06-15
-updated: 2026-06-19
+updated: 2026-06-23
+blocked_on: [2175]
+reconcile_note: "RECONCILED 2026-06-23 — all 4 sliced sub-issues merged (#2588/#2589 PR#1914, #2590 #1908, #2591 #1907). Remaining residual = RegExp.prototype reflection (gated on the #2175 builtin-prototype-readers substrate) + dynamic/any-typed regex receivers. No substrate-independent dev slice left; umbrella tracker blocked on #2175."
 priority: high
 feasibility: hard
 reasoning_effort: high

--- a/plan/issues/2162-standalone-map-set-weak-collections-residual.md
+++ b/plan/issues/2162-standalone-map-set-weak-collections-residual.md
@@ -1,10 +1,12 @@
 ---
 id: 2162
 title: "Standalone Map/Set/WeakMap/WeakSet conformance residual (~532 tests)"
-status: in-progress
+status: done
+completed: 2026-06-23
 sprint: 65
 created: 2026-06-15
 updated: 2026-06-23
+reconcile_note: "DRAINED 2026-06-23 — all 4 Set sub-issues merged (#2604/#2607 PR#1926, #2605/#2606 #1937); Map/WeakMap/WeakSet proven zero-gap. Residual is substrate-deferred (#2580/#2104 value-rep, #1472/#2158 reflection, #2622 collection-subclass)."
 priority: high
 feasibility: medium
 reasoning_effort: medium

--- a/plan/issues/2523-enqueue-app-token.md
+++ b/plan/issues/2523-enqueue-app-token.md
@@ -1,7 +1,8 @@
 ---
 id: 2523
 title: "enqueue/unstick must use a GitHub App token, not GITHUB_TOKEN (merge-queue wedge fix)"
-status: in-progress
+status: done
+completed: 2026-06-23
 priority: high
 feasibility: medium
 reasoning_effort: medium

--- a/plan/issues/2524-process-io-node-io-shim.md
+++ b/plan/issues/2524-process-io-node-io-shim.md
@@ -1,9 +1,10 @@
 ---
 id: 2524
 title: "Phase 1: process IO via linkable js2wasm:node-io shim (--node-io-shim)"
-status: in-progress
+status: done
+completed: 2026-06-23
 created: 2026-06-19
-updated: 2026-06-20
+updated: 2026-06-23
 priority: high
 feasibility: hard
 reasoning_effort: max

--- a/plan/issues/2618-proxy-host-apply-construct-call-path.md
+++ b/plan/issues/2618-proxy-host-apply-construct-call-path.md
@@ -1,10 +1,12 @@
 ---
 id: 2618
 title: "Proxy (host): calling / constructing a Proxy whose target is callable traps (illegal cast) or ignores the construct trap result (~15 fails)"
-status: ready
+status: blocked
 sprint: 65
 created: 2026-06-22
-updated: 2026-06-22
+updated: 2026-06-23
+blocked_on: [56]
+reconcile_note: "DEFERRED 2026-06-23 — per #1944 investigation the prototype was net-negative (+4/-1 hard PASS→ERR). Depends on #2615 (landed) AND blocked on sd-1838's #56 call/construct-dispatch rework (the __fn_tramp_Constructor cross-realm path). Defer until #56 lands; not staffing-ready."
 priority: medium
 feasibility: hard
 reasoning_effort: high


### PR DESCRIPTION
Reconciles the badly-stale s65 issue frontmatter against merged work on `origin/main` (9c0b178a1). Docs-only — `plan/issues/*.md` frontmatter only, no source/test impact.

## DONE (fix merged / all arms landed)
- **#2523** enqueue-app-token — PR #1790 merged
- **#2524** process-io node-io shim Phase 1 — PR #1791 merged
- **#2013** JSON.parse reviver headline — PR #1454; removed bad `blocked_on: [23]` (issue 23 = bitwise, unrelated). Narrow `defineProperty(this,…)`-in-reviver residual noted.
- **#1528** non-constructor TypeError — all arms merged (#1921/#1940/#1945/#1957); residual re-bucketed to #2614/#2623 + unimpl methods
- **#2151** standalone any-receiver dispatch — slices 1-5 merged (#1766/#1814)

## DRAINED (all sliced sub-issues merged → done)
- **#2159** TypedArray/DataView (6 subs merged)
- **#2162** Map/Set/Weak (4 subs merged)
- **#2158** class/prototype (#2610/#2611 merged)

## RETARGETED blockers
- **#2161** RegExp residual → `blocked` on #2175 substrate (4 subs drained)
- **#2618** Proxy apply/construct → `blocked` on #56 (prototype was net-negative)

## Verified-accurate, left unchanged
IR cluster (#1916/#1930/#1985/#2044/#2134/#2135/#2138/#2140/#2141) correctly stays `blocked_on: [2167]` — #2167 is external/infra (Fable model gone); #1927 landing satisfied the *pipeline* prerequisite but does not unblock dispatch. Async epics (#1042/#1373b/#2613/#2614 → #2623), #2585 → #2626, #2106-S1 (suspended), #1344 (suspended) all verified accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)