### PR TITLE
fix(website): re-enable standalone test262 pass-rate toggle

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1622,12 +1622,10 @@
                  baseline. Off by default so the headline number reflects
                  shipped ECMAScript only. -->
             <div class="feat-filter conformance-scope-toggle">
-              <!-- JS-host switch retained for later re-enable; disabled while standalone regression is fixed.
               <label class="feat-toggle">
                 <input type="checkbox" id="host-support-toggle" checked />
                 <span>JS host</span>
               </label>
-              -->
               <label class="feat-toggle">
                 <input type="checkbox" id="strict-only-toggle" />
                 <span>Strict mode</span>
@@ -3883,9 +3881,8 @@ console.log(instance.exports.run()); // &rarr; 55</pre
                   <strong>not</strong>
                   cover Web APIs, Node.js or other host behavior, or whether an arbitrary real-world npm package runs
                   unchanged. A high pass rate is necessary but not sufficient for &ldquo;runs real JavaScript.&rdquo;
-                  Second, the public website figures are currently pinned to the JS-host path; standalone
-                  (no-JS-host) figures are hidden until the current regression is fixed. Check the per-feature report
-                  before relying on anything specific.
+                  Second, the standalone (no-JS-host) path is less complete than the JS-host path. Check the per-feature
+                  report before relying on anything specific.
                 </p>
               </div>
             </details>
@@ -4581,7 +4578,7 @@ console.log(instance.exports.run()); // &rarr; 55</pre
       // Feature table toggles
       (function () {
         const strictToggle = document.getElementById("strict-only-toggle");
-        // const hostToggle = document.getElementById("host-support-toggle");
+        const hostToggle = document.getElementById("host-support-toggle");
         const tables = document.querySelector(".feat-tables");
         if (tables) {
           const hostRows = Array.from(document.querySelectorAll(".feat-row")).filter((row) =>
@@ -4597,24 +4594,21 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           });
           const sync = () => {
             if (strictToggle) tables.classList.toggle("strict-only", strictToggle.checked);
-            // if (hostToggle) tables.classList.toggle("host-off", !hostToggle.checked);
-            // const hostEnabled = hostToggle ? hostToggle.checked : true;
+            if (hostToggle) tables.classList.toggle("host-off", !hostToggle.checked);
+            const hostEnabled = hostToggle ? hostToggle.checked : true;
             hostRows.forEach((row) => {
               const badge = row.querySelector(".feat-badge");
               if (!(badge instanceof HTMLElement)) return;
               const origClass = badge.dataset.origClass || "";
               const origText = badge.dataset.origText || "";
               badge.className = "feat-badge";
-              // JS-host switch branch retained for later re-enable:
-              // if (hostEnabled) {
-              //   if (origClass) badge.classList.add(...origClass.split(/\s+/).filter(Boolean));
-              //   badge.textContent = origText;
-              // } else {
-              //   badge.classList.add("none");
-              //   badge.textContent = "×";
-              // }
-              if (origClass) badge.classList.add(...origClass.split(/\s+/).filter(Boolean));
-              badge.textContent = origText;
+              if (hostEnabled) {
+                if (origClass) badge.classList.add(...origClass.split(/\s+/).filter(Boolean));
+                badge.textContent = origText;
+              } else {
+                badge.classList.add("none");
+                badge.textContent = "×";
+              }
             });
             if (typeof window.updateEditionPassBars === "function") {
               window.updateEditionPassBars();
@@ -4625,7 +4619,7 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           };
           sync();
           strictToggle?.addEventListener("change", sync);
-          // hostToggle?.addEventListener("change", sync);
+          hostToggle?.addEventListener("change", sync);
         }
       })();
 
@@ -4878,11 +4872,15 @@ console.log(instance.exports.run()); // &rarr; 55</pre
         const donutSlot = document.getElementById("conformance-donut-slot");
         const editionTimeline = document.getElementById("conformance-edition-timeline");
         const strictToggle = document.getElementById("strict-only-toggle");
-        // const hostToggle = document.getElementById("host-support-toggle");
+        const hostToggle = document.getElementById("host-support-toggle");
         const rateEl = document.getElementById("compat-pass-rate");
         const rateLabelEl = document.getElementById("compat-pass-rate-label");
         if (!donutSlot || !(editionTimeline instanceof HTMLElement)) return;
 
+        const STANDALONE_TEST262_REPORT_URLS = [
+          "https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-standalone-current.json",
+          "./benchmarks/results/test262-standalone-report.json",
+        ];
         const donutStyle = "--t262-bg: var(--bg, #060a14)";
         const renderDonut = (summary, captionMain = "ECMAScript", captionSub = "conformance") => {
           const pass = Number(summary?.pass ?? 0);
@@ -4904,6 +4902,19 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           donut.setAttribute("caption-sub", captionSub);
           donut.setAttribute("style", donutStyle);
           updateHeadlineStat({ pass, fail, ce, skip, total }, captionMain, captionSub);
+        };
+        const renderUnavailable = (captionMain, captionSub, detail) => {
+          donutSlot.innerHTML = `
+            <div class="conformance-unavailable" role="status" aria-live="polite">
+              <div>
+                <div class="conformance-unavailable-value">Unavailable</div>
+                <div class="conformance-unavailable-title">${captionMain}</div>
+                <div class="conformance-unavailable-title">${captionSub}</div>
+                <div class="conformance-unavailable-copy">${detail}</div>
+              </div>
+            </div>
+          `;
+          updateHeadlineUnavailable(captionMain, captionSub, detail);
         };
         const normalizeSummary = (summary, fallback = {}) => {
           const pass = Number(summary?.pass ?? fallback.pass ?? 0);
@@ -4929,6 +4940,21 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           rateEl.textContent = `${pct}%`;
           rateLabelEl.textContent = `${captionMain} ${captionSub}: ${pass.toLocaleString()} / ${total.toLocaleString()} test262 tests passing`;
         };
+        const updateHeadlineUnavailable = (captionMain, captionSub, detail) => {
+          if (!rateEl || !rateLabelEl) return;
+          window.__conformanceHeadlineHydrated = true;
+          rateEl.textContent = "Unavailable";
+          rateLabelEl.textContent = `${captionMain} ${captionSub}: ${detail}`;
+        };
+        const hasUsableSummary = (summary) => {
+          const pass = Number(summary?.pass ?? 0);
+          const total = Number(summary?.total ?? 0);
+          return Number.isFinite(pass) && Number.isFinite(total) && total > 0;
+        };
+        const summaryHasStaleResults = (summary) => {
+          const stale = Number(summary?.stale ?? 0);
+          return Number.isFinite(stale) && stale > 0;
+        };
         const statusRatio = (filtered, base, key) => {
           const baseValue = Number(base?.[key] ?? 0);
           if (baseValue <= 0) return 1;
@@ -4941,148 +4967,112 @@ console.log(instance.exports.run()); // &rarr; 55</pre
           const skip = Math.round(summary.skip * ratios.skip);
           return { pass, fail, ce, skip, total: pass + fail + ce + skip };
         };
-        /*
-         * Disabled JS-host switch path retained for later re-enable after the
-         * standalone regression is fixed.
-         *
-         * const STANDALONE_TEST262_REPORT_URLS = [
-         *   "https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-standalone-current.json",
-         *   "./benchmarks/results/test262-standalone-report.json",
-         * ];
-         * const renderUnavailable = (captionMain, captionSub, detail) => {
-         *   donutSlot.innerHTML = `
-         *     <div class="conformance-unavailable" role="status" aria-live="polite">
-         *       <div>
-         *         <div class="conformance-unavailable-value">Unavailable</div>
-         *         <div class="conformance-unavailable-title">${captionMain}</div>
-         *         <div class="conformance-unavailable-title">${captionSub}</div>
-         *         <div class="conformance-unavailable-copy">${detail}</div>
-         *       </div>
-         *     </div>
-         *   `;
-         *   updateHeadlineUnavailable(captionMain, captionSub, detail);
-         * };
-         * const updateHeadlineUnavailable = (captionMain, captionSub, detail) => {
-         *   if (!rateEl || !rateLabelEl) return;
-         *   window.__conformanceHeadlineHydrated = true;
-         *   rateEl.textContent = "Unavailable";
-         *   rateLabelEl.textContent = `${captionMain} ${captionSub}: ${detail}`;
-         * };
-         * const hasUsableSummary = (summary) => {
-         *   const pass = Number(summary?.pass ?? 0);
-         *   const total = Number(summary?.total ?? 0);
-         *   return Number.isFinite(pass) && Number.isFinite(total) && total > 0;
-         * };
-         * const summaryHasStaleResults = (summary) => {
-         *   const stale = Number(summary?.stale ?? 0);
-         *   return Number.isFinite(stale) && stale > 0;
-         * };
-         * const fetchJson = async (url) => {
-         *   const resp = await fetch(url);
-         *   if (!resp.ok) throw new Error(`unavailable: ${url}`);
-         *   return resp.json();
-         * };
-         * const standalonePayloadFromHostReport = (report) => {
-         *   if (report?.standalone?.summary || report?.standalone?.official_summary) {
-         *     return report.standalone;
-         *   }
-         *   if (report?.standalone_summary || report?.standalone_full_summary || report?.standalone_strict_summary) {
-         *     return {
-         *       summary: report.standalone_summary,
-         *       official_summary: report.standalone_summary,
-         *       full_summary: report.standalone_full_summary,
-         *       strict_summary: report.standalone_strict_summary,
-         *       edition_summaries: report.standalone_edition_summaries,
-         *     };
-         *   }
-         *   return null;
-         * };
-         * const loadStandaloneReport = async (hostReport) => {
-         *   const embedded = standalonePayloadFromHostReport(hostReport);
-         *   if (embedded && hasUsableSummary(embedded.summary ?? embedded.official_summary)) {
-         *     return { report: embedded, source: "test262-current.json" };
-         *   }
-         *   for (const url of STANDALONE_TEST262_REPORT_URLS) {
-         *     try {
-         *       const report = await fetchJson(url);
-         *       if (hasUsableSummary(report?.summary ?? report?.official_summary)) {
-         *         return { report, source: url };
-         *       }
-         *     } catch {
-         *       // Try the next configured source.
-         *     }
-         *   }
-         *   return null;
-         * };
-         * const getNamedSummary = (report, names) => {
-         *   for (const name of names) {
-         *     if (hasUsableSummary(report?.[name])) return report[name];
-         *   }
-         *   return null;
-         * };
-         * const getStandaloneEditionSummary = (report, scope, strictOnly) => {
-         *   const editionMaps = [
-         *     strictOnly ? report?.strict_edition_summaries : null,
-         *     strictOnly ? report?.standalone_strict_edition_summaries : null,
-         *     report?.edition_summaries,
-         *     report?.standalone_edition_summaries,
-         *   ].filter(Boolean);
-         *   for (const map of editionMaps) {
-         *     const candidate = map?.[scope] ?? map?.[normalizeEditionLabel(scope)];
-         *     if (hasUsableSummary(candidate)) return candidate;
-         *   }
-         *
-         *   const editionRows = [
-         *     strictOnly ? report?.strict_editions : null,
-         *     strictOnly ? report?.standalone_strict_editions : null,
-         *     report?.editions,
-         *     report?.standalone_editions,
-         *   ].filter(Array.isArray);
-         *   for (const rows of editionRows) {
-         *     const candidate = rows.find((row) => {
-         *       const label = String(row?.edition ?? row?.rawEdition ?? row?.label ?? "");
-         *       return label === scope || normalizeEditionLabel(label) === normalizeEditionLabel(scope);
-         *     });
-         *     if (hasUsableSummary(candidate)) return candidate;
-         *   }
-         *   return null;
-         * };
-         * const getStandaloneSummary = (standaloneData, scope, strictOnly) => {
-         *   if (!standaloneData?.report) {
-         *     return {
-         *       summary: null,
-         *       reason: "No standalone test262 baseline has been published for this build.",
-         *     };
-         *   }
-         *   const report = standaloneData.report;
-         *   let summary = null;
-         *   if (scope === "overall") {
-         *     summary = strictOnly
-         *       ? getNamedSummary(report, ["strict_summary", "standalone_strict_summary"])
-         *       : getNamedSummary(report, ["summary", "official_summary", "standalone_summary"]);
-         *   } else if (scope === "overall+proposal") {
-         *     summary = strictOnly
-         *       ? getNamedSummary(report, ["strict_full_summary", "standalone_strict_full_summary"])
-         *       : getNamedSummary(report, ["full_summary", "standalone_full_summary"]);
-         *   } else {
-         *     summary = getStandaloneEditionSummary(report, scope, strictOnly);
-         *   }
-         *
-         *   if (!hasUsableSummary(summary)) {
-         *     return {
-         *       summary: null,
-         *       reason: `Standalone test262 data is not available for ${strictOnly ? "strict " : ""}${scope} scope yet.`,
-         *     };
-         *   }
-         *   if (summaryHasStaleResults(summary)) {
-         *     return {
-         *       summary: null,
-         *       reason: `Standalone test262 data is stale for ${strictOnly ? "strict " : ""}${scope} scope.`,
-         *     };
-         *   }
-         *   return { summary: normalizeSummary(summary), reason: "", source: standaloneData.source };
-         * };
-         */
+        const fetchJson = async (url) => {
+          const resp = await fetch(url);
+          if (!resp.ok) throw new Error(`unavailable: ${url}`);
+          return resp.json();
+        };
+        const standalonePayloadFromHostReport = (report) => {
+          if (report?.standalone?.summary || report?.standalone?.official_summary) {
+            return report.standalone;
+          }
+          if (report?.standalone_summary || report?.standalone_full_summary || report?.standalone_strict_summary) {
+            return {
+              summary: report.standalone_summary,
+              official_summary: report.standalone_summary,
+              full_summary: report.standalone_full_summary,
+              strict_summary: report.standalone_strict_summary,
+              edition_summaries: report.standalone_edition_summaries,
+            };
+          }
+          return null;
+        };
+        const loadStandaloneReport = async (hostReport) => {
+          const embedded = standalonePayloadFromHostReport(hostReport);
+          if (embedded && hasUsableSummary(embedded.summary ?? embedded.official_summary)) {
+            return { report: embedded, source: "test262-current.json" };
+          }
+          for (const url of STANDALONE_TEST262_REPORT_URLS) {
+            try {
+              const report = await fetchJson(url);
+              if (hasUsableSummary(report?.summary ?? report?.official_summary)) {
+                return { report, source: url };
+              }
+            } catch {
+              // Try the next configured source.
+            }
+          }
+          return null;
+        };
+        const getNamedSummary = (report, names) => {
+          for (const name of names) {
+            if (hasUsableSummary(report?.[name])) return report[name];
+          }
+          return null;
+        };
+        const getStandaloneEditionSummary = (report, scope, strictOnly) => {
+          const editionMaps = [
+            strictOnly ? report?.strict_edition_summaries : null,
+            strictOnly ? report?.standalone_strict_edition_summaries : null,
+            report?.edition_summaries,
+            report?.standalone_edition_summaries,
+          ].filter(Boolean);
+          for (const map of editionMaps) {
+            const candidate = map?.[scope] ?? map?.[normalizeEditionLabel(scope)];
+            if (hasUsableSummary(candidate)) return candidate;
+          }
+
+          const editionRows = [
+            strictOnly ? report?.strict_editions : null,
+            strictOnly ? report?.standalone_strict_editions : null,
+            report?.editions,
+            report?.standalone_editions,
+          ].filter(Array.isArray);
+          for (const rows of editionRows) {
+            const candidate = rows.find((row) => {
+              const label = String(row?.edition ?? row?.rawEdition ?? row?.label ?? "");
+              return label === scope || normalizeEditionLabel(label) === normalizeEditionLabel(scope);
+            });
+            if (hasUsableSummary(candidate)) return candidate;
+          }
+          return null;
+        };
+        const getStandaloneSummary = (standaloneData, scope, strictOnly) => {
+          if (!standaloneData?.report) {
+            return {
+              summary: null,
+              reason: "No standalone test262 baseline has been published for this build.",
+            };
+          }
+          const report = standaloneData.report;
+          let summary = null;
+          if (scope === "overall") {
+            summary = strictOnly
+              ? getNamedSummary(report, ["strict_summary", "standalone_strict_summary"])
+              : getNamedSummary(report, ["summary", "official_summary", "standalone_summary"]);
+          } else if (scope === "overall+proposal") {
+            summary = strictOnly
+              ? getNamedSummary(report, ["strict_full_summary", "standalone_strict_full_summary"])
+              : getNamedSummary(report, ["full_summary", "standalone_full_summary"]);
+          } else {
+            summary = getStandaloneEditionSummary(report, scope, strictOnly);
+          }
+
+          if (!hasUsableSummary(summary)) {
+            return {
+              summary: null,
+              reason: `Standalone test262 data is not available for ${strictOnly ? "strict " : ""}${scope} scope yet.`,
+            };
+          }
+          if (summaryHasStaleResults(summary)) {
+            return {
+              summary: null,
+              reason: `Standalone test262 data is stale for ${strictOnly ? "strict " : ""}${scope} scope.`,
+            };
+          }
+          return { summary: normalizeSummary(summary), reason: "", source: standaloneData.source };
+        };
+
         try {
           const reportResp = await fetch("https://raw.githubusercontent.com/loopdive/js2wasm-baselines/main/test262-current.json");
           if (!reportResp.ok) throw new Error("conformance data unavailable");
@@ -5109,24 +5099,23 @@ console.log(instance.exports.run()); // &rarr; 55</pre
             withProposal.ce !== overall.ce ||
             withProposal.skip !== overall.skip ||
             withProposal.total !== overall.total;
-          // const standaloneData = await loadStandaloneReport(report);
+          const standaloneData = await loadStandaloneReport(report);
 
           let lastDetail = null;
           const conformanceOptions = () => {
             const strictOnly = strictToggle ? strictToggle.checked : false;
-            // const hostEnabled = hostToggle ? hostToggle.checked : true;
+            const hostEnabled = hostToggle ? hostToggle.checked : true;
             return {
               strictOnly,
-              // hostEnabled,
-              // captionSub:
-              //   strictOnly && !hostEnabled
-              //     ? "strict standalone conformance"
-              //     : strictOnly
-              //       ? "strict conformance"
-              //       : hostEnabled
-              //         ? "conformance"
-              //         : "standalone conformance",
-              captionSub: strictOnly ? "strict conformance" : "conformance",
+              hostEnabled,
+              captionSub:
+                strictOnly && !hostEnabled
+                  ? "strict standalone conformance"
+                  : strictOnly
+                    ? "strict conformance"
+                    : hostEnabled
+                      ? "conformance"
+                      : "standalone conformance",
             };
           };
           const applyConformanceOptions = (summary, { exactStrictSummary = null } = {}) => {
@@ -5142,17 +5131,17 @@ console.log(instance.exports.run()); // &rarr; 55</pre
             return { summary: next, options };
           };
           const renderSelectedConformance = (scope, hostSummary, captionMain, { exactStrictSummary = null } = {}) => {
-            // const options = conformanceOptions();
-            // if (!options.hostEnabled) {
-            //   const standalone = getStandaloneSummary(standaloneData, scope, options.strictOnly);
-            //   if (!standalone.summary) {
-            //     renderUnavailable(captionMain, options.captionSub, standalone.reason);
-            //     return;
-            //   }
-            //   renderDonut(standalone.summary, captionMain, options.captionSub);
-            //   return;
-            // }
-            const { summary, options } = applyConformanceOptions(hostSummary, { exactStrictSummary });
+            const options = conformanceOptions();
+            if (!options.hostEnabled) {
+              const standalone = getStandaloneSummary(standaloneData, scope, options.strictOnly);
+              if (!standalone.summary) {
+                renderUnavailable(captionMain, options.captionSub, standalone.reason);
+                return;
+              }
+              renderDonut(standalone.summary, captionMain, options.captionSub);
+              return;
+            }
+            const { summary } = applyConformanceOptions(hostSummary, { exactStrictSummary });
             renderDonut(summary, captionMain, options.captionSub);
           };
           const applyScopeFromDetail = (detail) => {
@@ -5184,7 +5173,7 @@ console.log(instance.exports.run()); // &rarr; 55</pre
             if (lastDetail) applyScopeFromDetail(lastDetail);
           };
           strictToggle?.addEventListener("change", window.updateConformanceDonut);
-          // hostToggle?.addEventListener("change", window.updateConformanceDonut);
+          hostToggle?.addEventListener("change", window.updateConformanceDonut);
 
           editionTimeline.addEventListener("edition-change", (event) => {
             applyScopeFromDetail(event.detail);
@@ -5312,22 +5301,13 @@ console.log(instance.exports.run()); // &rarr; 55</pre
 
       (function hydrateEditionPassBars() {
         const strictToggle = document.getElementById("strict-only-toggle");
-        // const hostToggle = document.getElementById("host-support-toggle");
+        const hostToggle = document.getElementById("host-support-toggle");
 
-        // Host-aware scoring retained for later re-enable:
-        // const scoreRow = (row, hostEnabled) => {
-        //   const badge = row.querySelector(".feat-badge");
-        //   const usesHost = !!row.querySelector(".feat-host");
-        //   if (!badge) return 0;
-        //   if (usesHost && !hostEnabled) return 0;
-        //   if (badge.classList.contains("full")) return 1;
-        //   if (badge.classList.contains("partial")) return 0.5;
-        //   return 0;
-        // };
-
-        const scoreRow = (row) => {
+        const scoreRow = (row, hostEnabled) => {
           const badge = row.querySelector(".feat-badge");
+          const usesHost = !!row.querySelector(".feat-host");
           if (!badge) return 0;
+          if (usesHost && !hostEnabled) return 0;
           if (badge.classList.contains("full")) return 1;
           if (badge.classList.contains("partial")) return 0.5;
           return 0;
@@ -5366,7 +5346,7 @@ console.log(instance.exports.run()); // &rarr; 55</pre
 
         const renderHeuristicEditionPassBars = () => {
           const strictOnly = strictToggle ? strictToggle.checked : false;
-          // const hostEnabled = hostToggle ? hostToggle.checked : true;
+          const hostEnabled = hostToggle ? hostToggle.checked : true;
 
           document.querySelectorAll(".feat-section").forEach((section) => {
             const header = ensureEditionLabel(section)?.el;
@@ -5379,8 +5359,7 @@ console.log(instance.exports.run()); // &rarr; 55</pre
             });
 
             const total = rows.length;
-            // const score = rows.reduce((sum, row) => sum + scoreRow(row, hostEnabled), 0);
-            const score = rows.reduce((sum, row) => sum + scoreRow(row), 0);
+            const score = rows.reduce((sum, row) => sum + scoreRow(row, hostEnabled), 0);
             const pct = total > 0 ? Math.round((score / total) * 100) : 0;
             const fill = bar.querySelector(".feat-edition-passbar-fill");
             const text = bar.querySelector(".feat-edition-passbar-text");


### PR DESCRIPTION
## What

Re-enables the **JS host / standalone** conformance pass-rate toggle on the landing page. The toggle (and its feature-table host rows, donut/headline summary, and host-aware edition scoring) was disabled in `eaec0d1f3` while a standalone regression was being investigated; the public figures have been pinned to the JS-host path since.

## Why now

The standalone test262 path is healthy again. The published baseline (`loopdive/js2wasm-baselines/test262-standalone-current.json`) reports **23,772 / 43,136 passing, stale:0**, so the toggle shows real, current standalone numbers rather than "Unavailable".

## How

Reverse-applies **only** the conformance-toggle hunks of `eaec0d1f3`:
- the `#host-support-toggle` checkbox markup
- the feature-table host-row show/hide logic
- the donut/headline standalone summary fetch + render (`STANDALONE_TEST262_REPORT_URLS`, `getStandaloneSummary`, `renderUnavailable`, …)
- the host-aware edition scoring branch

The Wasmtime/WASI **benchmark** sections are left untouched — those were already restored separately in `28b069e6`. Restored code is byte-identical to the pre-disable working version (`23cc596b6`, #1778).

## Validation

- All 3 inline `<script>` blocks parse cleanly (vm.Script syntax check).
- No leftover disable markers; benchmark-loader region unchanged vs `origin/main`.
- Standalone data sources confirmed reachable & fresh (remote primary + committed local fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)