### PR TITLE
feat(#2632): WASI async runtime Phase 1 — event-loop reactor (timers + microtasks)

### DIFF
--- a/plan/issues/2632-wasi-async-runtime-event-loop.md
+++ b/plan/issues/2632-wasi-async-runtime-event-loop.md
@@ -1,7 +1,8 @@
 ---
 id: 2632
 title: WASI async runtime — event-loop reactor (process.stdin Readable, timers, promise-driven I/O)
-status: ready
+status: in-progress
+assignee: ttraenkler/senior-dev-2632
 sprint: Backlog
 goal: wasi-async-runtime
 feasibility: hard
@@ -9,6 +10,13 @@ kind: goal
 created: 2026-06-23
 refs: [389, 2631, 1326, 1326c, 1484, 1653, 2524]
 ---
+
+> **PHASED ISSUE — Phase 1 has LANDED; Phases 2-4 remain (status stays
+> `in-progress`).** Phase 1 (scheduler + timers + microtasks) is implemented and
+> merged; the event-loop reactor now drives `setTimeout`/`setInterval`/
+> `clearTimeout`/`clearInterval`/`queueMicrotask` under `--target wasi`. The
+> fd-readiness reactor (Phase 2), the `process.stdin` Readable stream (Phase 3),
+> and the Preview-2 backend (Phase 4) are still open — do NOT close this issue.
 
 # WASI async runtime — event-loop reactor
 
@@ -136,23 +144,75 @@ loop, not building from scratch.
 
 ## Acceptance criteria (phased)
 
-### Phase 1 — scheduler + timers + microtasks (smallest viable first slice)
-- [ ] A **run-loop driver** function (`__run_event_loop`) replaces the one-shot
+### Phase 1 — scheduler + timers + microtasks (smallest viable first slice) ✅ LANDED
+- [x] A **run-loop driver** function (`__run_event_loop`) replaces the one-shot
       `__drain_microtasks` call in the WASI `_start` wrapper. It loops:
       drain microtasks → if any timer is due, fire it → if timers remain pending,
       `poll_oneoff` on the nearest deadline → repeat → exit when no pending handles.
-- [ ] `setTimeout(cb, ms)` / `setInterval(cb, ms)` / `clearTimeout`/`clearInterval`
-      compile under `--target wasi` (remove them from `WASI_REJECTED_TIMER_GLOBALS`)
-      and are driven by the loop via a **timer heap**, not a blocking sleep.
-- [ ] `queueMicrotask(cb)` compiles under WASI and enqueues onto the existing
+- [x] `setTimeout(cb, ms)` / `setInterval(cb, ms)` / `clearTimeout`/`clearInterval`
+      compile under `--target wasi` (removed from `WASI_REJECTED_TIMER_GLOBALS`)
+      and are driven by the loop via a **timer table**, not a blocking sleep.
+- [x] `queueMicrotask(cb)` compiles under WASI and enqueues onto the existing
       microtask queue.
-- [ ] Ordering: all microtasks drain **before** the first due timer fires; timers fire
+- [x] Ordering: all microtasks drain **before** the first due timer fires; timers fire
       in non-decreasing deadline order; a `setTimeout(…, 0)` fires after sync code and
-      after pending microtasks.
-- [ ] Existing #1326/#1326c Promise tests still pass; existing `wasi-timers.test.ts`
-      (the #1484 diagnostic) is updated from "rejects" to "compiles + runs".
-- [ ] New `tests/issue-2632-wasi-event-loop.test.ts` covering timer ordering,
-      microtask-before-timer, and nested `setTimeout` scheduling.
+      after pending microtasks. (Verified under real wasmtime.)
+- [x] Existing #1326/#1326c Promise tests still pass; `wasi-timers.test.ts`
+      (the #1484 diagnostic) updated from "rejects" to "compiles + runs".
+- [x] New `tests/issue-2632-event-loop.test.ts` covering timer ordering,
+      microtask-before-timer, nested `setTimeout`, interval+clearInterval, and
+      clearTimeout — each compiled `--target wasi` and run under wasmtime.
+
+**Scope boundary hit — top-level `await`**: left rejected/unlowered as the spec
+predicted. The CPS machine lowers `await` only inside `async function` bodies;
+module-suspending top-level await would need module-init itself lowered to a
+state machine. Phase 1 does not need it (top level schedules work synchronously
+and returns; the loop then runs), and it is in the test262 skip set. Untouched.
+
+#### Phase 1 implementation notes (WHY, for Phase 2+ maintainers)
+- **Timer table, not a binary min-heap.** The spec sketched a binary heap; I used
+  **parallel WasmGC arrays** (`deadlines:i64`, `callbacks:funcref`,
+  `captures:externref`, `intervals:i64`, `cancelled:i32`) with an O(n) linear scan
+  for the earliest live deadline (`__timer_peek_deadline`) and a single-pass
+  `__timer_fire_due`. Timer counts are tiny, so O(n)/tick is irrelevant, and a
+  linear scan is far less bug-prone than a hand-rolled WasmGC heap. Ids are stable
+  slot indices (no compaction on grow), so `clearTimeout(id)`/`clearInterval(id)`
+  keep working across a grow; cancellation is a lazy `cancelled[id]=1` flag.
+- **The reactor is byte-neutral for non-timer programs.** `__run_event_loop` is only
+  registered when the source references a timer/microtask global (`needsTimerHeap`);
+  otherwise `_start` keeps the exact `getDrainFuncIdxForWasiStart` one-shot-drain (or
+  empty) body. Verified: a `console.log`, a `for`-loop, a `Promise.resolve().then`,
+  and a plain function program all produce **byte-identical** Wasm (same SHA256 +
+  length) vs the branch base. The run loop with zero timers is also behaviourally a
+  strict superset of the one-shot drain (drains once, peeks empty → exits).
+- **Index discipline (`project_type_index_shift_and_deadelim`).** The timer heap
+  (struct/array types, globals, and the 7 helper funcs `__timer_grow/add/cancel/
+  peek_deadline/fire_due`, `__rl_now_ns`, `__run_event_loop`) is registered in the
+  **deferred-helper phase** (`emitDeferredWasiHelpers`, after `__wasi_sleep_ms` +
+  `clock_time_get`, BEFORE user bodies compile) so the `__timer_add`/`__timer_cancel`
+  func indices baked into call sites are final. The per-callback wrapper
+  (`__timer_cb_N`) is append-only during body compile (safe). The timer callback
+  reuses the microtask queue's uniform `$__mt_func_type` `(externref,externref)->
+  externref` signature, so a timer callback and a microtask continuation are
+  `call_ref`-compatible; the closure struct itself is stored as the `captures`
+  externref and re-cast in the wrapper.
+- **`now` = CLOCK_MONOTONIC.** `__rl_now_ns` calls `clock_time_get(1, …)` into linear
+  scratch[48..55] and recombines the LE u64 from two i32 loads (the binary emitter
+  has no `i64.load`). The blocking wait reuses the existing #1484 single-clock
+  `__wasi_sleep_ms` (relative-ms `poll_oneoff`); Phase 2 swaps this for a
+  multi-subscription `poll_oneoff` (fd0 + clock).
+- **The #1501 timer host-import shim is suppressed under WASI.** `preprocessImports`
+  injects a `function setTimeout(cb,ms){ return __timer_set_timeout(cb,ms); }` stub
+  into the user source for the **JS-host** path. Under `--target wasi` that stub (a)
+  pulls in an unresolvable host import and (b) makes `setTimeout` resolve to a
+  user-file declaration, which *defeated the reactor lowering* (the call inlined the
+  no-op stub). The fix threads `{ wasi }` into `preprocessImports` and skips the shim
+  entirely for WASI. The call-site + detection guards additionally honour a *genuine*
+  user `function setTimeout` shadow (decls not all in `.d.ts`) so a real shadow keeps
+  its own semantics.
+- **`setImmediate` stays rejected.** Its Node "check phase" ordering (after I/O poll,
+  distinct from a 0ms timer) is a later-phase concern; only `setImmediate` remains in
+  `WASI_REJECTED_TIMER_GLOBALS`.
 
 ### Phase 2 — poll_oneoff reactor + non-blocking fds
 - [ ] Set fd 0 non-blocking via `fd_fdstat_set_flags` at loop start.

--- a/src/codegen/async-scheduler.ts
+++ b/src/codegen/async-scheduler.ts
@@ -92,6 +92,42 @@ export interface AsyncSchedulerState {
   thenWrapperCounter: number;
   /** Whether `__drain_microtasks` has been added to the module's exports. */
   drainExported: boolean;
+
+  // ── #2632 Phase 1 — timer heap + run-loop reactor ──────────────────────
+  /** `$__arr_timer_func` funcref-array typeIdx (timer callback storage). -1 until registered. */
+  timerFuncArrTypeIdx: number;
+  /** `$__arr_i64` i64-array typeIdx (timer deadlines + interval periods). -1 until registered. */
+  timerI64ArrTypeIdx: number;
+  /** `$__arr_i32` i32-array typeIdx (timer cancelled flags). -1 until registered. */
+  timerI32ArrTypeIdx: number;
+  /** Wasm global: count of live timer slots (high-water; cancelled lazily). -1 until registered. */
+  timerCountGlobalIdx: number;
+  /** Wasm global: current capacity of the timer arrays. -1 until registered. */
+  timerCapGlobalIdx: number;
+  /** Wasm global: deadlines i64 array (ref.null until first add). -1 until registered. */
+  timerDeadlinesGlobalIdx: number;
+  /** Wasm global: callbacks funcref array. -1 until registered. */
+  timerCallbacksGlobalIdx: number;
+  /** Wasm global: captures externref array. -1 until registered. */
+  timerCapturesGlobalIdx: number;
+  /** Wasm global: interval periods i64 array (0 = one-shot). -1 until registered. */
+  timerIntervalsGlobalIdx: number;
+  /** Wasm global: cancelled i32 flags array. -1 until registered. */
+  timerCancelledGlobalIdx: number;
+  /** Func idx of `__timer_add(deadlineNs i64, cb funcref, cap externref, intervalNs i64) -> i32`. -1 until registered. */
+  timerAddFuncIdx: number;
+  /** Func idx of `__timer_cancel(id i32)`. -1 until registered. */
+  timerCancelFuncIdx: number;
+  /** Func idx of `__timer_peek_deadline() -> i64` (i64 max when none pending). -1 until registered. */
+  timerPeekDeadlineFuncIdx: number;
+  /** Func idx of `__timer_fire_due(nowNs i64)` — fires all due timers, re-arms intervals. -1 until registered. */
+  timerFireDueFuncIdx: number;
+  /** Func idx of `__run_event_loop()` — the reactor driver. -1 until registered. */
+  runLoopFuncIdx: number;
+  /** Func idx of the monotonic-now reader `__rl_now_ns() -> i64` (CLOCK_MONOTONIC). -1 until registered. */
+  runLoopNowFuncIdx: number;
+  /** Whether the timer heap was ever registered (drives run-loop emission + _start wiring). */
+  timerHeapRegistered: boolean;
 }
 
 function getOrInitState(ctx: CodegenContextWithScheduler): AsyncSchedulerState {
@@ -118,6 +154,23 @@ function getOrInitState(ctx: CodegenContextWithScheduler): AsyncSchedulerState {
       identityRejectWrapperFuncIdx: -1,
       thenWrapperCounter: 0,
       drainExported: false,
+      timerFuncArrTypeIdx: -1,
+      timerI64ArrTypeIdx: -1,
+      timerI32ArrTypeIdx: -1,
+      timerCountGlobalIdx: -1,
+      timerCapGlobalIdx: -1,
+      timerDeadlinesGlobalIdx: -1,
+      timerCallbacksGlobalIdx: -1,
+      timerCapturesGlobalIdx: -1,
+      timerIntervalsGlobalIdx: -1,
+      timerCancelledGlobalIdx: -1,
+      timerAddFuncIdx: -1,
+      timerCancelFuncIdx: -1,
+      timerPeekDeadlineFuncIdx: -1,
+      timerFireDueFuncIdx: -1,
+      runLoopFuncIdx: -1,
+      runLoopNowFuncIdx: -1,
+      timerHeapRegistered: false,
     };
   }
   return ctx.asyncScheduler;
@@ -1067,6 +1120,958 @@ export function getDrainFuncIdxForWasiStart(ctx: CodegenContext): number | null 
   const state = (ctx as CodegenContextWithScheduler).asyncScheduler;
   if (!state || state.drainFuncIdx === -1) return null;
   return state.drainFuncIdx;
+}
+
+// ── #2632 Phase 1 — timer heap + run-loop reactor ────────────────────────
+//
+// The reactor composes the EXISTING substrate into a single-threaded
+// cooperative event loop for the `--target wasi` WasmGC+linear path:
+//
+//   - the #1326 microtask queue (`__drain_microtasks`),
+//   - a timer table (parallel WasmGC arrays keyed by deadline-ns), and
+//   - the #1484 single-clock `poll_oneoff` sleep (`__wasi_sleep_ms`),
+//   - CLOCK_MONOTONIC via `clock_time_get`,
+//
+// into `__run_event_loop`, which replaces the one-shot `__drain_microtasks`
+// call in the WASI `_start` wrapper. When the timer table is empty the loop
+// drains microtasks once and exits — byte-effect-equivalent to the old
+// one-shot drain (the run loop is a strict superset of the drain).
+//
+// Timer table model (no binary heap — a linear scan finds the earliest live
+// deadline; timer counts are tiny so O(n) per tick is fine and far less
+// error-prone than a hand-rolled WasmGC binary heap):
+//   deadlines[i]  : i64  absolute fire time in monotonic ns
+//   callbacks[i]  : funcref ($__mt_func_type: (caps externref, val externref) -> externref)
+//   captures[i]   : externref  closure captures passed to the callback
+//   intervals[i]  : i64  re-arm period in ns (0 = one-shot setTimeout)
+//   cancelled[i]  : i32  1 = cancelled (lazy delete)
+// `count` is the high-water slot count; a cancelled / fired one-shot slot is
+// marked by setting cancelled[i]=1 (fired one-shots) so the scan skips it.
+
+const TIMER_QUEUE_INITIAL_SLOTS = 64;
+// Run-loop scratch offsets (inside the reserved 0..1023 bump zone, between the
+// clock-helpers' 16..31 region and `__wasi_sleep_ms`'s 64..147 region).
+const RL_NOW_OUT_OFFSET = 48; // i64 monotonic-now out-ptr for clock_time_get
+
+/**
+ * #2632 — Idempotently register the timer table (types, globals, helpers) and
+ * the run-loop driver. MUST be called in the deferred-helper phase (after
+ * `__wasi_sleep_ms` + `clock_time_get` are registered, before user bodies
+ * compile) so the `__timer_add` / `__timer_cancel` func indices referenced at
+ * timer call sites are final. Depends on `ensureMicrotaskQueue` (the loop
+ * drains microtasks each tick).
+ */
+export function ensureTimerHeap(ctx: CodegenContext): void {
+  const state = getOrInitState(ctx as CodegenContextWithScheduler);
+  if (state.timerHeapRegistered) return;
+
+  // The run loop drains microtasks — guarantee the queue exists first so its
+  // func indices (drain/enqueue) are stable below.
+  ensureMicrotaskQueue(ctx);
+
+  // The microtask queue already registered $__mt_func_type — reuse it as the
+  // uniform timer-callback signature so a timer callback and a microtask
+  // continuation are call_ref-compatible.
+  const mtFuncTypeIdx = state.microtaskFuncTypeIdx;
+
+  // ── 1. Types ──────────────────────────────────────────────────────────
+  // funcref array for callbacks (own typeIdx — funcref arrays are not keyed by
+  // getOrRegisterArrayType, mirroring the microtask queue's $__arr_mt_func).
+  const funcArrIdx = ctx.mod.types.length;
+  ctx.mod.types.push({
+    kind: "array",
+    name: "__arr_timer_func",
+    element: { kind: "funcref" } as ValType,
+    mutable: true,
+  } as unknown as import("../ir/types.js").ArrayTypeDef);
+  state.timerFuncArrTypeIdx = funcArrIdx;
+
+  const i64ArrIdx = getOrRegisterArrayType(ctx, "i64", { kind: "i64" });
+  state.timerI64ArrTypeIdx = i64ArrIdx;
+  const i32ArrIdx = getOrRegisterArrayType(ctx, "i32", { kind: "i32" });
+  state.timerI32ArrTypeIdx = i32ArrIdx;
+  const externArrIdx = getOrRegisterMicrotaskQueueType(ctx); // $__arr_externref
+
+  // ── 2. Globals ────────────────────────────────────────────────────────
+  const baseGlobalIdx = ctx.numImportGlobals + ctx.mod.globals.length;
+  state.timerCountGlobalIdx = baseGlobalIdx;
+  ctx.mod.globals.push({
+    name: "__timer_count",
+    type: { kind: "i32" },
+    mutable: true,
+    init: [{ op: "i32.const", value: 0 }],
+  });
+  state.timerCapGlobalIdx = baseGlobalIdx + 1;
+  ctx.mod.globals.push({
+    name: "__timer_cap",
+    type: { kind: "i32" },
+    mutable: true,
+    init: [{ op: "i32.const", value: 0 }],
+  });
+  state.timerDeadlinesGlobalIdx = baseGlobalIdx + 2;
+  ctx.mod.globals.push({
+    name: "__timer_deadlines",
+    type: { kind: "ref_null", typeIdx: i64ArrIdx },
+    mutable: true,
+    init: [{ op: "ref.null", typeIdx: i64ArrIdx } as Instr],
+  });
+  state.timerCallbacksGlobalIdx = baseGlobalIdx + 3;
+  ctx.mod.globals.push({
+    name: "__timer_callbacks",
+    type: { kind: "ref_null", typeIdx: funcArrIdx },
+    mutable: true,
+    init: [{ op: "ref.null", typeIdx: funcArrIdx } as Instr],
+  });
+  state.timerCapturesGlobalIdx = baseGlobalIdx + 4;
+  ctx.mod.globals.push({
+    name: "__timer_captures",
+    type: { kind: "ref_null", typeIdx: externArrIdx },
+    mutable: true,
+    init: [{ op: "ref.null", typeIdx: externArrIdx } as Instr],
+  });
+  state.timerIntervalsGlobalIdx = baseGlobalIdx + 5;
+  ctx.mod.globals.push({
+    name: "__timer_intervals",
+    type: { kind: "ref_null", typeIdx: i64ArrIdx },
+    mutable: true,
+    init: [{ op: "ref.null", typeIdx: i64ArrIdx } as Instr],
+  });
+  state.timerCancelledGlobalIdx = baseGlobalIdx + 6;
+  ctx.mod.globals.push({
+    name: "__timer_cancelled",
+    type: { kind: "ref_null", typeIdx: i32ArrIdx },
+    mutable: true,
+    init: [{ op: "ref.null", typeIdx: i32ArrIdx } as Instr],
+  });
+
+  // ── 3. Helper functions (push order = funcIdx order) ──────────────────
+  // grow → add → cancel → peek → fire_due → now → run_loop.
+  const baseFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+
+  const growIdx = baseFuncIdx;
+  ctx.mod.functions.push({
+    name: "__timer_grow",
+    typeIdx: addFuncType(ctx, [{ kind: "i32" }], [], "$__timer_grow_type"),
+    locals: buildTimerGrowLocals(state),
+    body: buildTimerGrowBody(state, funcArrIdx, i64ArrIdx, i32ArrIdx, externArrIdx),
+    exported: false,
+  });
+  ctx.funcMap.set("__timer_grow", growIdx);
+
+  state.timerAddFuncIdx = baseFuncIdx + 1;
+  ctx.mod.functions.push({
+    name: "__timer_add",
+    typeIdx: addFuncType(
+      ctx,
+      [{ kind: "i64" }, { kind: "funcref" } as ValType, { kind: "externref" }, { kind: "i64" }],
+      [{ kind: "i32" }],
+      "$__timer_add_type",
+    ),
+    locals: [],
+    body: buildTimerAddBody(state, growIdx, funcArrIdx, i64ArrIdx, i32ArrIdx, externArrIdx),
+    exported: false,
+  });
+  ctx.funcMap.set("__timer_add", state.timerAddFuncIdx);
+
+  state.timerCancelFuncIdx = baseFuncIdx + 2;
+  ctx.mod.functions.push({
+    name: "__timer_cancel",
+    typeIdx: addFuncType(ctx, [{ kind: "i32" }], [], "$__timer_cancel_type"),
+    locals: [],
+    body: buildTimerCancelBody(state, i32ArrIdx),
+    exported: false,
+  });
+  ctx.funcMap.set("__timer_cancel", state.timerCancelFuncIdx);
+
+  state.timerPeekDeadlineFuncIdx = baseFuncIdx + 3;
+  ctx.mod.functions.push({
+    name: "__timer_peek_deadline",
+    typeIdx: addFuncType(ctx, [], [{ kind: "i64" }], "$__timer_peek_type"),
+    locals: buildTimerPeekLocals(),
+    body: buildTimerPeekBody(state, i64ArrIdx, i32ArrIdx),
+    exported: false,
+  });
+  ctx.funcMap.set("__timer_peek_deadline", state.timerPeekDeadlineFuncIdx);
+
+  state.timerFireDueFuncIdx = baseFuncIdx + 4;
+  ctx.mod.functions.push({
+    name: "__timer_fire_due",
+    typeIdx: addFuncType(ctx, [{ kind: "i64" }], [], "$__timer_fire_type"),
+    locals: buildTimerFireLocals(state, mtFuncTypeIdx),
+    body: buildTimerFireBody(state, mtFuncTypeIdx, funcArrIdx, i64ArrIdx, i32ArrIdx, externArrIdx),
+    exported: false,
+  });
+  ctx.funcMap.set("__timer_fire_due", state.timerFireDueFuncIdx);
+
+  // Monotonic-now reader. clock_time_get(CLOCK_MONOTONIC=1, precision, out) →
+  // i64 ns recombined from two i32 loads (the binary emitter has no i64.load).
+  const clockIdx = ctx.wasiClockTimeGetIdx;
+  state.runLoopNowFuncIdx = baseFuncIdx + 5;
+  ctx.mod.functions.push({
+    name: "__rl_now_ns",
+    typeIdx: addFuncType(ctx, [], [{ kind: "i64" }], "$__rl_now_type"),
+    locals: [],
+    body: buildRunLoopNowBody(clockIdx),
+    exported: false,
+  });
+  ctx.funcMap.set("__rl_now_ns", state.runLoopNowFuncIdx);
+
+  // The run loop references __wasi_sleep_ms by funcIdx; it was registered
+  // earlier in the deferred-helper phase (needsPollOneoff). Resolve now.
+  const sleepMsIdx = ctx.funcMap.get("__wasi_sleep_ms");
+  state.runLoopFuncIdx = baseFuncIdx + 6;
+  ctx.mod.functions.push({
+    name: "__run_event_loop",
+    typeIdx: addFuncType(ctx, [], [], "$__run_event_loop_type"),
+    locals: buildRunLoopLocals(),
+    body: buildRunLoopBody(state, sleepMsIdx),
+    exported: false,
+  });
+  ctx.funcMap.set("__run_event_loop", state.runLoopFuncIdx);
+
+  state.timerHeapRegistered = true;
+}
+
+function buildTimerGrowLocals(_state: AsyncSchedulerState): import("../ir/types.js").LocalDef[] {
+  // Param 0: $newCap (i32).
+  return [
+    { name: "$oldDeadlines", type: { kind: "ref_null", typeIdx: _state.timerI64ArrTypeIdx } },
+    { name: "$oldCallbacks", type: { kind: "ref_null", typeIdx: _state.timerFuncArrTypeIdx } },
+    { name: "$oldCaptures", type: { kind: "ref_null", typeIdx: _state.microtaskArgsArrTypeIdx } },
+    { name: "$oldIntervals", type: { kind: "ref_null", typeIdx: _state.timerI64ArrTypeIdx } },
+    { name: "$oldCancelled", type: { kind: "ref_null", typeIdx: _state.timerI32ArrTypeIdx } },
+    { name: "$count", type: { kind: "i32" } },
+    { name: "$i", type: { kind: "i32" } },
+  ];
+}
+
+function buildTimerGrowBody(
+  state: AsyncSchedulerState,
+  funcArrIdx: number,
+  i64ArrIdx: number,
+  i32ArrIdx: number,
+  externArrIdx: number,
+): Instr[] {
+  const newCap = 0;
+  const oldDl = 1;
+  const oldCb = 2;
+  const oldCap = 3;
+  const oldIv = 4;
+  const oldCn = 5;
+  const count = 6;
+  const i = 7;
+
+  return [
+    // Snapshot old arrays + count.
+    { op: "global.get", index: state.timerDeadlinesGlobalIdx } as Instr,
+    { op: "local.set", index: oldDl },
+    { op: "global.get", index: state.timerCallbacksGlobalIdx } as Instr,
+    { op: "local.set", index: oldCb },
+    { op: "global.get", index: state.timerCapturesGlobalIdx } as Instr,
+    { op: "local.set", index: oldCap },
+    { op: "global.get", index: state.timerIntervalsGlobalIdx } as Instr,
+    { op: "local.set", index: oldIv },
+    { op: "global.get", index: state.timerCancelledGlobalIdx } as Instr,
+    { op: "local.set", index: oldCn },
+    { op: "global.get", index: state.timerCountGlobalIdx } as Instr,
+    { op: "local.set", index: count },
+
+    // Allocate new arrays of $newCap (default-initialised).
+    { op: "i64.const", value: 0n },
+    { op: "local.get", index: newCap },
+    { op: "array.new", typeIdx: i64ArrIdx },
+    { op: "global.set", index: state.timerDeadlinesGlobalIdx } as Instr,
+
+    { op: "ref.null.func" } as Instr,
+    { op: "local.get", index: newCap },
+    { op: "array.new", typeIdx: funcArrIdx },
+    { op: "global.set", index: state.timerCallbacksGlobalIdx } as Instr,
+
+    { op: "ref.null.extern" },
+    { op: "local.get", index: newCap },
+    { op: "array.new", typeIdx: externArrIdx },
+    { op: "global.set", index: state.timerCapturesGlobalIdx } as Instr,
+
+    { op: "i64.const", value: 0n },
+    { op: "local.get", index: newCap },
+    { op: "array.new", typeIdx: i64ArrIdx },
+    { op: "global.set", index: state.timerIntervalsGlobalIdx } as Instr,
+
+    { op: "i32.const", value: 0 },
+    { op: "local.get", index: newCap },
+    { op: "array.new", typeIdx: i32ArrIdx },
+    { op: "global.set", index: state.timerCancelledGlobalIdx } as Instr,
+
+    // If oldDeadlines null → nothing to copy; set cap and return.
+    { op: "local.get", index: oldDl },
+    { op: "ref.is_null" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" } as any,
+      then: [
+        { op: "local.get", index: newCap },
+        { op: "global.set", index: state.timerCapGlobalIdx } as Instr,
+        { op: "return" } as Instr,
+      ],
+    },
+
+    // Copy [0, count) into the fresh arrays (compaction not needed — ids stay
+    // stable so live clearTimeout(id) keeps working).
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: i },
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: i },
+            { op: "local.get", index: count },
+            { op: "i32.eq" } as Instr,
+            { op: "br_if", depth: 1 },
+
+            // deadlines[i] = old
+            { op: "global.get", index: state.timerDeadlinesGlobalIdx } as Instr,
+            { op: "ref.as_non_null" } as Instr,
+            { op: "local.get", index: i },
+            { op: "local.get", index: oldDl },
+            { op: "ref.as_non_null" } as Instr,
+            { op: "local.get", index: i },
+            { op: "array.get", typeIdx: i64ArrIdx },
+            { op: "array.set", typeIdx: i64ArrIdx },
+
+            // callbacks[i] = old
+            { op: "global.get", index: state.timerCallbacksGlobalIdx } as Instr,
+            { op: "ref.as_non_null" } as Instr,
+            { op: "local.get", index: i },
+            { op: "local.get", index: oldCb },
+            { op: "ref.as_non_null" } as Instr,
+            { op: "local.get", index: i },
+            { op: "array.get", typeIdx: funcArrIdx },
+            { op: "array.set", typeIdx: funcArrIdx },
+
+            // captures[i] = old
+            { op: "global.get", index: state.timerCapturesGlobalIdx } as Instr,
+            { op: "ref.as_non_null" } as Instr,
+            { op: "local.get", index: i },
+            { op: "local.get", index: oldCap },
+            { op: "ref.as_non_null" } as Instr,
+            { op: "local.get", index: i },
+            { op: "array.get", typeIdx: externArrIdx },
+            { op: "array.set", typeIdx: externArrIdx },
+
+            // intervals[i] = old
+            { op: "global.get", index: state.timerIntervalsGlobalIdx } as Instr,
+            { op: "ref.as_non_null" } as Instr,
+            { op: "local.get", index: i },
+            { op: "local.get", index: oldIv },
+            { op: "ref.as_non_null" } as Instr,
+            { op: "local.get", index: i },
+            { op: "array.get", typeIdx: i64ArrIdx },
+            { op: "array.set", typeIdx: i64ArrIdx },
+
+            // cancelled[i] = old
+            { op: "global.get", index: state.timerCancelledGlobalIdx } as Instr,
+            { op: "ref.as_non_null" } as Instr,
+            { op: "local.get", index: i },
+            { op: "local.get", index: oldCn },
+            { op: "ref.as_non_null" } as Instr,
+            { op: "local.get", index: i },
+            { op: "array.get", typeIdx: i32ArrIdx },
+            { op: "array.set", typeIdx: i32ArrIdx },
+
+            { op: "local.get", index: i },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" } as Instr,
+            { op: "local.set", index: i },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+
+    { op: "local.get", index: newCap },
+    { op: "global.set", index: state.timerCapGlobalIdx } as Instr,
+  ];
+}
+
+function buildTimerAddBody(
+  state: AsyncSchedulerState,
+  growIdx: number,
+  funcArrIdx: number,
+  i64ArrIdx: number,
+  _i32ArrIdx: number,
+  externArrIdx: number,
+): Instr[] {
+  // Params: 0=deadlineNs(i64) 1=cb(funcref) 2=cap(externref) 3=intervalNs(i64)
+  const deadline = 0;
+  const cb = 1;
+  const cap = 2;
+  const interval = 3;
+
+  return [
+    // Lazy first-allocate when callbacks global is null.
+    { op: "global.get", index: state.timerCallbacksGlobalIdx } as Instr,
+    { op: "ref.is_null" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" } as any,
+      then: [
+        { op: "i32.const", value: TIMER_QUEUE_INITIAL_SLOTS },
+        { op: "call", funcIdx: growIdx },
+      ],
+    },
+    // If count == cap, double.
+    { op: "global.get", index: state.timerCountGlobalIdx } as Instr,
+    { op: "global.get", index: state.timerCapGlobalIdx } as Instr,
+    { op: "i32.eq" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" } as any,
+      then: [
+        { op: "global.get", index: state.timerCapGlobalIdx } as Instr,
+        { op: "i32.const", value: 1 },
+        { op: "i32.shl" } as Instr,
+        { op: "call", funcIdx: growIdx },
+      ],
+    },
+
+    // slot = count; write fields.
+    { op: "global.get", index: state.timerDeadlinesGlobalIdx } as Instr,
+    { op: "ref.as_non_null" } as Instr,
+    { op: "global.get", index: state.timerCountGlobalIdx } as Instr,
+    { op: "local.get", index: deadline },
+    { op: "array.set", typeIdx: i64ArrIdx },
+
+    { op: "global.get", index: state.timerCallbacksGlobalIdx } as Instr,
+    { op: "ref.as_non_null" } as Instr,
+    { op: "global.get", index: state.timerCountGlobalIdx } as Instr,
+    { op: "local.get", index: cb },
+    { op: "array.set", typeIdx: funcArrIdx },
+
+    { op: "global.get", index: state.timerCapturesGlobalIdx } as Instr,
+    { op: "ref.as_non_null" } as Instr,
+    { op: "global.get", index: state.timerCountGlobalIdx } as Instr,
+    { op: "local.get", index: cap },
+    { op: "array.set", typeIdx: externArrIdx },
+
+    { op: "global.get", index: state.timerIntervalsGlobalIdx } as Instr,
+    { op: "ref.as_non_null" } as Instr,
+    { op: "global.get", index: state.timerCountGlobalIdx } as Instr,
+    { op: "local.get", index: interval },
+    { op: "array.set", typeIdx: i64ArrIdx },
+
+    // cancelled[slot] is already 0 from array.new default.
+
+    // id = count; count++; return id.
+    { op: "global.get", index: state.timerCountGlobalIdx } as Instr,
+    { op: "global.get", index: state.timerCountGlobalIdx } as Instr,
+    { op: "i32.const", value: 1 },
+    { op: "i32.add" } as Instr,
+    { op: "global.set", index: state.timerCountGlobalIdx } as Instr,
+    // (id left on stack as result)
+  ];
+}
+
+function buildTimerCancelBody(state: AsyncSchedulerState, i32ArrIdx: number): Instr[] {
+  // Param 0 = id (i32). Lazy delete: bounds-check then set cancelled[id]=1.
+  const id = 0;
+  return [
+    { op: "global.get", index: state.timerCancelledGlobalIdx } as Instr,
+    { op: "ref.is_null" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" } as any,
+      then: [{ op: "return" } as Instr],
+    },
+    // if id < 0 || id >= count: return
+    { op: "local.get", index: id },
+    { op: "i32.const", value: 0 },
+    { op: "i32.lt_s" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" } as any,
+      then: [{ op: "return" } as Instr],
+    },
+    { op: "local.get", index: id },
+    { op: "global.get", index: state.timerCountGlobalIdx } as Instr,
+    { op: "i32.ge_s" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" } as any,
+      then: [{ op: "return" } as Instr],
+    },
+    { op: "global.get", index: state.timerCancelledGlobalIdx } as Instr,
+    { op: "ref.as_non_null" } as Instr,
+    { op: "local.get", index: id },
+    { op: "i32.const", value: 1 },
+    { op: "array.set", typeIdx: i32ArrIdx },
+  ];
+}
+
+function buildTimerPeekLocals(): import("../ir/types.js").LocalDef[] {
+  return [
+    { name: "$i", type: { kind: "i32" } },
+    { name: "$best", type: { kind: "i64" } },
+    { name: "$d", type: { kind: "i64" } },
+  ];
+}
+
+const I64_MAX = 0x7fffffffffffffffn;
+
+function buildTimerPeekBody(state: AsyncSchedulerState, i64ArrIdx: number, i32ArrIdx: number): Instr[] {
+  // Linear scan of live (non-cancelled) timers; return the minimum deadline,
+  // or i64 max when none. The run loop compares against i64 max to detect "no
+  // pending timers".
+  const i = 0;
+  const best = 1;
+  const d = 2;
+  return [
+    { op: "i64.const", value: I64_MAX },
+    { op: "local.set", index: best },
+    { op: "global.get", index: state.timerCallbacksGlobalIdx } as Instr,
+    { op: "ref.is_null" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" } as any,
+      then: [{ op: "local.get", index: best }, { op: "return" } as Instr],
+    },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: i },
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: i },
+            { op: "global.get", index: state.timerCountGlobalIdx } as Instr,
+            { op: "i32.ge_s" } as Instr,
+            { op: "br_if", depth: 1 },
+
+            // skip if cancelled[i] != 0
+            { op: "global.get", index: state.timerCancelledGlobalIdx } as Instr,
+            { op: "ref.as_non_null" } as Instr,
+            { op: "local.get", index: i },
+            { op: "array.get", typeIdx: i32ArrIdx },
+            { op: "i32.eqz" } as Instr,
+            {
+              op: "if",
+              blockType: { kind: "empty" } as any,
+              then: [
+                // d = deadlines[i]
+                { op: "global.get", index: state.timerDeadlinesGlobalIdx } as Instr,
+                { op: "ref.as_non_null" } as Instr,
+                { op: "local.get", index: i },
+                { op: "array.get", typeIdx: i64ArrIdx },
+                { op: "local.set", index: d },
+                // if d < best: best = d
+                { op: "local.get", index: d },
+                { op: "local.get", index: best },
+                { op: "i64.lt_s" } as Instr,
+                {
+                  op: "if",
+                  blockType: { kind: "empty" } as any,
+                  then: [
+                    { op: "local.get", index: d },
+                    { op: "local.set", index: best },
+                  ],
+                },
+              ],
+            },
+
+            { op: "local.get", index: i },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" } as Instr,
+            { op: "local.set", index: i },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+    { op: "local.get", index: best },
+  ];
+}
+
+function buildTimerFireLocals(state: AsyncSchedulerState, _mtFuncTypeIdx: number): import("../ir/types.js").LocalDef[] {
+  return [
+    { name: "$i", type: { kind: "i32" } },
+    { name: "$fn", type: { kind: "funcref" } as ValType },
+    { name: "$cap", type: { kind: "externref" } },
+    { name: "$iv", type: { kind: "i64" } },
+    { name: "$dl", type: { kind: "i64" } },
+  ];
+}
+
+function buildTimerFireBody(
+  state: AsyncSchedulerState,
+  mtFuncTypeIdx: number,
+  funcArrIdx: number,
+  i64ArrIdx: number,
+  i32ArrIdx: number,
+  externArrIdx: number,
+): Instr[] {
+  // Param 0 = nowNs (i64). Single pass over [0,count): every live timer whose
+  // deadline <= now fires once. A one-shot is then marked cancelled; an
+  // interval is re-armed (deadline += period) so it can fire again on a later
+  // tick. Re-arming in place keeps the id stable for clearInterval.
+  //
+  // A callback that schedules a NEW timer appends past `count`; we snapshot
+  // count at entry implicitly by reading the global each iteration but only
+  // process indices < the count observed at loop test — newly added timers
+  // (index >= old count) are picked up by the next run-loop tick, matching
+  // Node (a timer scheduled inside a timer callback runs on a later turn).
+  const nowNs = 0;
+  const i = 1;
+  const fn = 2;
+  const cap = 3;
+  const iv = 4;
+  const dl = 5;
+
+  return [
+    { op: "global.get", index: state.timerCallbacksGlobalIdx } as Instr,
+    { op: "ref.is_null" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" } as any,
+      then: [{ op: "return" } as Instr],
+    },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: i },
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            { op: "local.get", index: i },
+            { op: "global.get", index: state.timerCountGlobalIdx } as Instr,
+            { op: "i32.ge_s" } as Instr,
+            { op: "br_if", depth: 1 },
+
+            // live = cancelled[i] == 0
+            { op: "global.get", index: state.timerCancelledGlobalIdx } as Instr,
+            { op: "ref.as_non_null" } as Instr,
+            { op: "local.get", index: i },
+            { op: "array.get", typeIdx: i32ArrIdx },
+            { op: "i32.eqz" } as Instr,
+            {
+              op: "if",
+              blockType: { kind: "empty" } as any,
+              then: [
+                // dl = deadlines[i]
+                { op: "global.get", index: state.timerDeadlinesGlobalIdx } as Instr,
+                { op: "ref.as_non_null" } as Instr,
+                { op: "local.get", index: i },
+                { op: "array.get", typeIdx: i64ArrIdx },
+                { op: "local.set", index: dl },
+                // due = dl <= now
+                { op: "local.get", index: dl },
+                { op: "local.get", index: nowNs },
+                { op: "i64.le_s" } as Instr,
+                {
+                  op: "if",
+                  blockType: { kind: "empty" } as any,
+                  then: [
+                    // iv = intervals[i]
+                    { op: "global.get", index: state.timerIntervalsGlobalIdx } as Instr,
+                    { op: "ref.as_non_null" } as Instr,
+                    { op: "local.get", index: i },
+                    { op: "array.get", typeIdx: i64ArrIdx },
+                    { op: "local.set", index: iv },
+
+                    // Re-arm or retire BEFORE invoking, so a callback that
+                    // calls clearInterval(id) on itself still cancels the next
+                    // fire (it sets cancelled[i]=1 over our re-arm here).
+                    { op: "local.get", index: iv },
+                    { op: "i64.const", value: 0n },
+                    { op: "i64.gt_s" } as Instr,
+                    {
+                      op: "if",
+                      blockType: { kind: "empty" } as any,
+                      then: [
+                        // interval: deadlines[i] = dl + iv (re-arm relative to
+                        // the scheduled deadline so cadence doesn't drift).
+                        { op: "global.get", index: state.timerDeadlinesGlobalIdx } as Instr,
+                        { op: "ref.as_non_null" } as Instr,
+                        { op: "local.get", index: i },
+                        { op: "local.get", index: dl },
+                        { op: "local.get", index: iv },
+                        { op: "i64.add" } as Instr,
+                        { op: "array.set", typeIdx: i64ArrIdx },
+                      ],
+                      else: [
+                        // one-shot: mark cancelled so it never fires again.
+                        { op: "global.get", index: state.timerCancelledGlobalIdx } as Instr,
+                        { op: "ref.as_non_null" } as Instr,
+                        { op: "local.get", index: i },
+                        { op: "i32.const", value: 1 },
+                        { op: "array.set", typeIdx: i32ArrIdx },
+                      ],
+                    },
+
+                    // Load callback + captures.
+                    { op: "global.get", index: state.timerCallbacksGlobalIdx } as Instr,
+                    { op: "ref.as_non_null" } as Instr,
+                    { op: "local.get", index: i },
+                    { op: "array.get", typeIdx: funcArrIdx },
+                    { op: "local.set", index: fn },
+                    { op: "global.get", index: state.timerCapturesGlobalIdx } as Instr,
+                    { op: "ref.as_non_null" } as Instr,
+                    { op: "local.get", index: i },
+                    { op: "array.get", typeIdx: externArrIdx },
+                    { op: "local.set", index: cap },
+
+                    // Invoke fn(cap, null) via call_ref (uniform $__mt_func_type).
+                    { op: "local.get", index: cap },
+                    { op: "ref.null.extern" },
+                    { op: "local.get", index: fn },
+                    { op: "ref.cast", typeIdx: mtFuncTypeIdx },
+                    { op: "call_ref", typeIdx: mtFuncTypeIdx },
+                    { op: "drop" },
+                  ],
+                },
+              ],
+            },
+
+            { op: "local.get", index: i },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" } as Instr,
+            { op: "local.set", index: i },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+  ];
+}
+
+function buildRunLoopNowBody(clockIdx: number | undefined): Instr[] {
+  // clock_time_get(CLOCK_MONOTONIC=1, precision=1us, out=RL_NOW_OUT_OFFSET) then
+  // recombine the LE u64 from two i32 loads (binary emitter lacks i64.load).
+  if (clockIdx === undefined || clockIdx < 0) {
+    // Safety: no clock import → return 0 (timers all appear immediately due).
+    return [{ op: "i64.const", value: 0n }];
+  }
+  return [
+    { op: "i32.const", value: 1 } as Instr, // CLOCK_MONOTONIC
+    { op: "i64.const", value: 1000n }, // precision 1us
+    { op: "i32.const", value: RL_NOW_OUT_OFFSET } as Instr,
+    { op: "call", funcIdx: clockIdx } as Instr,
+    { op: "drop" } as Instr,
+    // hi << 32 | lo
+    { op: "i32.const", value: RL_NOW_OUT_OFFSET + 4 } as Instr,
+    { op: "i32.load", align: 2, offset: 0 } as Instr,
+    { op: "i64.extend_i32_u" } as Instr,
+    { op: "i64.const", value: 32n },
+    { op: "i64.shl" } as Instr,
+    { op: "i32.const", value: RL_NOW_OUT_OFFSET } as Instr,
+    { op: "i32.load", align: 2, offset: 0 } as Instr,
+    { op: "i64.extend_i32_u" } as Instr,
+    { op: "i64.or" } as Instr,
+  ];
+}
+
+function buildRunLoopLocals(): import("../ir/types.js").LocalDef[] {
+  return [
+    { name: "$now", type: { kind: "i64" } },
+    { name: "$next", type: { kind: "i64" } },
+    { name: "$waitMs", type: { kind: "i64" } },
+  ];
+}
+
+function buildRunLoopBody(state: AsyncSchedulerState, sleepMsIdx: number | undefined): Instr[] {
+  const now = 0;
+  const next = 1;
+  const waitMs = 2;
+
+  // Each tick:
+  //   drain microtasks → now = clock → fire due timers (which may enqueue more
+  //   microtasks / timers) → drain again → next = peek_deadline.
+  //   if next == i64_max: no pending timers → exit.
+  //   else: waitMs = ceil((next-now)/1e6); if waitMs > 0 sleep that long; loop.
+  // The post-fire drain settles any Promise reactions a timer callback queued
+  // before we decide whether to block, so a `setTimeout(()=>p.then(...))`
+  // chain runs its microtasks promptly.
+  const tickBody: Instr[] = [
+    { op: "call", funcIdx: state.drainFuncIdx },
+    { op: "call", funcIdx: state.runLoopNowFuncIdx },
+    { op: "local.set", index: now },
+    { op: "local.get", index: now },
+    { op: "call", funcIdx: state.timerFireDueFuncIdx },
+    { op: "call", funcIdx: state.drainFuncIdx },
+
+    // next = peek
+    { op: "call", funcIdx: state.timerPeekDeadlineFuncIdx },
+    { op: "local.set", index: next },
+
+    // if next == I64_MAX → no pending handles → break out of the loop.
+    { op: "local.get", index: next },
+    { op: "i64.const", value: I64_MAX },
+    { op: "i64.eq" } as Instr,
+    { op: "br_if", depth: 1 },
+
+    // waitMs = (next - now) / 1e6 ; clamp negative to 0.
+    { op: "local.get", index: next },
+    { op: "call", funcIdx: state.runLoopNowFuncIdx },
+    { op: "i64.sub" } as Instr,
+    { op: "local.set", index: waitMs },
+    { op: "local.get", index: waitMs },
+    { op: "i64.const", value: 0n },
+    { op: "i64.gt_s" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" } as any,
+      then:
+        sleepMsIdx === undefined
+          ? []
+          : [
+              // ms = (ns + 999_999) / 1_000_000 (round up so we never wake early)
+              { op: "local.get", index: waitMs },
+              { op: "i64.const", value: 999999n },
+              { op: "i64.add" } as Instr,
+              { op: "i64.const", value: 1000000n },
+              { op: "i64.div_s" } as Instr,
+              { op: "i32.wrap_i64" } as Instr,
+              { op: "call", funcIdx: sleepMsIdx } as Instr,
+            ],
+    },
+    // continue looping.
+    { op: "br", depth: 0 },
+  ];
+
+  return [
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: tickBody,
+        },
+      ],
+    },
+  ];
+}
+
+/**
+ * #2632 — Emit a `setTimeout`/`setInterval` registration at a call site.
+ * Pushes the timer id (i32) onto the caller stack. `cbFuncRefInstrs` push the
+ * uniform `$__mt_func_type` funcref; `capInstrs` push the closure-captures
+ * externref; `deadlineInstrs` push the absolute deadline (i64 ns);
+ * `intervalInstrs` push the re-arm period (i64 ns, 0 = one-shot).
+ */
+export function emitTimerAdd(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  deadlineInstrs: Instr[],
+  cbFuncRefInstrs: Instr[],
+  capInstrs: Instr[],
+  intervalInstrs: Instr[],
+): void {
+  const state = (ctx as CodegenContextWithScheduler).asyncScheduler;
+  if (!state || state.timerAddFuncIdx === -1) {
+    throw new Error("emitTimerAdd called before ensureTimerHeap registered __timer_add");
+  }
+  for (const i of deadlineInstrs) fctx.body.push(i);
+  for (const i of cbFuncRefInstrs) fctx.body.push(i);
+  for (const i of capInstrs) fctx.body.push(i);
+  for (const i of intervalInstrs) fctx.body.push(i);
+  fctx.body.push({ op: "call", funcIdx: state.timerAddFuncIdx });
+}
+
+/** #2632 — Emit a `clearTimeout`/`clearInterval` at a call site. Consumes the
+ *  id already pushed by `idInstrs`. */
+export function emitTimerCancel(ctx: CodegenContext, fctx: FunctionContext, idInstrs: Instr[]): void {
+  const state = (ctx as CodegenContextWithScheduler).asyncScheduler;
+  if (!state || state.timerCancelFuncIdx === -1) {
+    throw new Error("emitTimerCancel called before ensureTimerHeap registered __timer_cancel");
+  }
+  for (const i of idInstrs) fctx.body.push(i);
+  fctx.body.push({ op: "call", funcIdx: state.timerCancelFuncIdx });
+}
+
+/** #2632 — The monotonic-now reader func idx (`__rl_now_ns() -> i64`), or -1.
+ *  Timer call sites read it to compute `deadlineNs = now + ms*1e6`. */
+export function getRunLoopNowFuncIdx(ctx: CodegenContext): number {
+  const state = (ctx as CodegenContextWithScheduler).asyncScheduler;
+  return state ? state.runLoopNowFuncIdx : -1;
+}
+
+/**
+ * #2632 — Synthesise a uniform `$__mt_func_type` timer-callback wrapper for a
+ * user closure. The timer table stores the closure struct itself as the
+ * `captures` externref; this wrapper (param 0 = caps externref = the closure
+ * struct, param 1 = value externref = unused/null) decodes the struct and
+ * invokes the closure via `call_ref` with default args for every parameter
+ * (a timer callback receives no arguments in Node — extra `setTimeout` args
+ * are out of Phase-1 scope). Returns the wrapper func idx.
+ *
+ * Mirrors the `.then` wrapper shape (closure call_ref = `[self, ...args,
+ * typed_funcref]`) but without promise settlement.
+ */
+export function emitTimerCallbackWrapper(ctx: CodegenContext, info: ClosureInfo): number {
+  ensureTimerHeap(ctx);
+  const state = getOrInitState(ctx as CodegenContextWithScheduler);
+  const wrapperId = state.thenWrapperCounter++;
+  const wrapperName = `__timer_cb_${wrapperId}`;
+  const callbackLocal = 2; // decoded closure struct
+  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+
+  const locals: LocalDef[] = [{ name: "$callback", type: { kind: "ref", typeIdx: info.structTypeIdx } }];
+  const body: Instr[] = [
+    // caps (param 0) is the closure struct, lifted to externref. Decode it.
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: info.structTypeIdx },
+    { op: "local.set", index: callbackLocal },
+
+    // call_ref shape: [closure_self, ...default_args, typed_funcref]
+    { op: "local.get", index: callbackLocal },
+  ];
+  for (let i = 0; i < info.paramTypes.length; i++) {
+    pushDefaultForType(body, info.paramTypes[i]!);
+  }
+  body.push(
+    { op: "local.get", index: callbackLocal },
+    { op: "struct.get", typeIdx: info.structTypeIdx, fieldIdx: 0 } as Instr,
+    { op: "ref.cast", typeIdx: info.funcTypeIdx } as Instr,
+    { op: "call_ref", typeIdx: info.funcTypeIdx },
+  );
+  // Discard the closure's return value; coerce to externref result of the
+  // wrapper (the run loop drops it). For a non-externref/void return, pop it
+  // and push a null externref so the function signature ($__mt_func_type:
+  // -> externref) is satisfied.
+  coerceStackValueToExternref(ctx, body, info.returnType);
+
+  ctx.mod.functions.push({
+    name: wrapperName,
+    typeIdx: state.microtaskFuncTypeIdx,
+    locals,
+    body,
+    exported: false,
+  });
+  ctx.funcMap.set(wrapperName, funcIdx);
+  return funcIdx;
+}
+
+/**
+ * #2632 — Run-loop hook for WASI `_start`. Returns the funcIdx of
+ * `__run_event_loop` when the timer heap was registered (the loop supersedes
+ * the one-shot drain — it drains microtasks itself), else `null` so the caller
+ * falls back to the bare drain.
+ */
+export function getRunLoopFuncIdxForWasiStart(ctx: CodegenContext): number | null {
+  const state = (ctx as CodegenContextWithScheduler).asyncScheduler;
+  if (!state || !state.timerHeapRegistered || state.runLoopFuncIdx === -1) return null;
+  return state.runLoopFuncIdx;
 }
 
 /**

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1575,6 +1575,8 @@ export interface CodegenContext {
   wasiClockHelpersPending?: boolean;
   /** (#1484) Pending flag — emit `__wasi_sleep_ms` after lib-globals scan. */
   wasiPendingSleepMsHelper?: boolean;
+  /** (#2632) Pending flag — register timer heap + run-loop reactor after lib-globals scan. */
+  wasiPendingTimerHeap?: boolean;
   /** Set of node:fs functions used in this compilation unit (both WASI and JS-host fs paths). */
   wasiNodeFsFuncs: Set<string>;
   /**

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -28,9 +28,15 @@ import { reserveClosedMethodDispatch, reserveClosedMethodDispatchVararg } from "
 import { emitNativeDateParse } from "../date-parse-native.js"; // (#2164) pure-Wasm Date.parse / new Date(str)
 import { ensureObjVecBuilders, ensureObjectRuntime } from "../object-runtime.js";
 import {
+  emitMicrotaskEnqueue,
   emitStandalonePromiseReject,
   emitStandalonePromiseResolve,
   emitStandalonePromiseThen,
+  emitTimerAdd,
+  emitTimerCallbackWrapper,
+  emitTimerCancel,
+  ensureTimerHeap,
+  getRunLoopNowFuncIdx,
   isStandalonePromiseActive,
   type StandalonePromiseThenCallback,
 } from "../async-scheduler.js";
@@ -3044,6 +3050,154 @@ function emitJsonReplacerAllowList(
   fctx.body.push({ op: "local.get", index: allowLocal } as Instr);
 }
 
+/**
+ * #2632 Phase 1 — lower `setTimeout` / `setInterval` / `clearTimeout` /
+ * `clearInterval` / `queueMicrotask` onto the WASI timer-heap + run-loop
+ * reactor. Returns `undefined` when this is not a WASI timer call (so the
+ * generic dispatcher continues), or an `InnerResult` when handled.
+ *
+ * Only bare-identifier callees fire (a member call like `obj.setTimeout(...)`
+ * is a user method, never the global). The timer heap was registered in the
+ * deferred-helper phase (`ensureTimerHeap`), so `__timer_add` / `__timer_cancel`
+ * func indices are already final.
+ */
+function tryWasiTimerCall(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+): InnerResult | undefined {
+  if (!ctx.wasi) return undefined;
+  if (!ts.isIdentifier(expr.expression)) return undefined;
+  const name = expr.expression.text;
+  if (
+    name !== "setTimeout" &&
+    name !== "setInterval" &&
+    name !== "clearTimeout" &&
+    name !== "clearInterval" &&
+    name !== "queueMicrotask"
+  ) {
+    return undefined;
+  }
+  // Guard against a user-defined local/function shadowing the global name. The
+  // global timer functions are declared ONLY in lib .d.ts files; a user shadow
+  // has at least one declaration in a real (.ts) source file. (`setTimeout` &c
+  // are also registered as inlinable lib stubs in ctx.funcMap, so a funcMap
+  // membership check would false-positive — use the symbol's declarations.)
+  {
+    const sym = ctx.checker.getSymbolAtLocation(expr.expression);
+    const decls = sym?.declarations;
+    if (decls && decls.length > 0 && !decls.every((d) => d.getSourceFile().isDeclarationFile)) {
+      return undefined; // user-defined shadow → not the global timer
+    }
+  }
+
+  // Ensure the timer heap exists. It is normally registered eagerly in the
+  // deferred-helper phase; this call is idempotent and a safety net.
+  ensureTimerHeap(ctx);
+
+  // ── clearTimeout(id) / clearInterval(id) ──────────────────────────────
+  if (name === "clearTimeout" || name === "clearInterval") {
+    if (expr.arguments.length < 1) return VOID_RESULT;
+    // id is a JS number (f64). Convert to the i32 slot id.
+    const saved = pushBody(fctx);
+    compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "f64" });
+    const idInstrs = fctx.body;
+    popBody(fctx, saved);
+    idInstrs.push({ op: "i32.trunc_sat_f64_s" } as Instr);
+    emitTimerCancel(ctx, fctx, idInstrs);
+    return VOID_RESULT;
+  }
+
+  // ── setTimeout / setInterval / queueMicrotask: compile the callback ──
+  const cbArg = expr.arguments[0];
+  if (cbArg === undefined) return VOID_RESULT;
+
+  // Compile the callback into its own buffer, yielding a closure struct pushed
+  // as externref + its ClosureInfo (mirrors compileStandalonePromiseThenCallback).
+  let capInstrs: Instr[];
+  let closureInfo: ClosureInfo | undefined;
+  {
+    const saved = pushBody(fctx);
+    try {
+      const type =
+        ts.isArrowFunction(cbArg) || ts.isFunctionExpression(cbArg)
+          ? compileArrowAsClosure(ctx, fctx, cbArg)
+          : compileExpression(ctx, fctx, cbArg);
+      if (type && (type.kind === "ref" || type.kind === "ref_null")) {
+        closureInfo = ctx.closureInfoByTypeIdx.get(type.typeIdx);
+      }
+      if (!closureInfo && ts.isIdentifier(cbArg)) {
+        closureInfo = ctx.closureMap.get(cbArg.text);
+      }
+      if (closureInfo && type && type.kind !== "externref") {
+        coerceType(ctx, fctx, type, { kind: "externref" });
+      }
+    } finally {
+      capInstrs = fctx.body;
+      popBody(fctx, saved);
+    }
+  }
+  if (!closureInfo) {
+    // Not a recognised closure (e.g. a string-bodied setTimeout, unsupported).
+    // Bail to the generic path, which will reject/handle it.
+    return undefined;
+  }
+
+  const wrapperFuncIdx = emitTimerCallbackWrapper(ctx, closureInfo);
+
+  // ── queueMicrotask(cb) — enqueue directly onto the microtask queue ────
+  if (name === "queueMicrotask") {
+    emitMicrotaskEnqueue(
+      ctx,
+      fctx,
+      [{ op: "ref.func", funcIdx: wrapperFuncIdx } as Instr],
+      capInstrs, // captures externref = the closure struct
+      [{ op: "ref.null.extern" } as Instr], // value = undefined
+    );
+    return VOID_RESULT;
+  }
+
+  // ── setTimeout(cb, ms) / setInterval(cb, ms) ──────────────────────────
+  // delayNs = max(0, ms) * 1e6 ; deadlineNs = now + delayNs.
+  const nowIdx = getRunLoopNowFuncIdx(ctx);
+  const delayNsLocal = allocLocal(fctx, `__timer_delay_${fctx.locals.length}`, { kind: "i64" });
+
+  // Compute delayNs into a local: trunc(ms) clamped to >= 0, times 1e6.
+  if (expr.arguments.length >= 2) {
+    compileExpression(ctx, fctx, expr.arguments[1]!, { kind: "f64" });
+  } else {
+    fctx.body.push({ op: "f64.const", value: 0 });
+  }
+  // Clamp negative / NaN ms to 0 (Node treats ms<=0 or NaN as 0).
+  fctx.body.push({ op: "f64.const", value: 0 });
+  fctx.body.push({ op: "f64.max" } as Instr);
+  fctx.body.push({ op: "i64.trunc_sat_f64_s" } as Instr);
+  fctx.body.push({ op: "i64.const", value: 1000000n });
+  fctx.body.push({ op: "i64.mul" } as Instr);
+  fctx.body.push({ op: "local.set", index: delayNsLocal });
+
+  const deadlineInstrs: Instr[] = [
+    { op: "call", funcIdx: nowIdx } as Instr,
+    { op: "local.get", index: delayNsLocal } as Instr,
+    { op: "i64.add" } as Instr,
+  ];
+  // interval period: setInterval re-arms with delayNs; setTimeout = 0 (one-shot).
+  const intervalInstrs: Instr[] =
+    name === "setInterval" ? [{ op: "local.get", index: delayNsLocal } as Instr] : [{ op: "i64.const", value: 0n }];
+
+  emitTimerAdd(
+    ctx,
+    fctx,
+    deadlineInstrs,
+    [{ op: "ref.func", funcIdx: wrapperFuncIdx } as Instr],
+    capInstrs, // captures externref = the closure struct
+    intervalInstrs,
+  );
+  // __timer_add returns the i32 id; setTimeout/setInterval return a JS number.
+  fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
+  return { kind: "f64" };
+}
+
 function compileCallExpression(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -3075,6 +3229,15 @@ function compileCallExpression(
   // the matching `__jsx_runtime_*` host import. Extracted to calls-guards.ts (#742).
   {
     const r = tryJsxRuntimeCall(ctx, fctx, expr);
+    if (r !== undefined) return r;
+  }
+
+  // #2632 Phase 1 — WASI event-loop timers / microtasks. setTimeout/setInterval/
+  // clearTimeout/clearInterval/queueMicrotask lower onto the timer heap + run-loop
+  // reactor (async-scheduler.ts). Only fires under --target wasi; everything else
+  // falls through to the JS-host import path unchanged.
+  {
+    const r = tryWasiTimerCall(ctx, fctx, expr);
     if (r !== undefined) return r;
   }
 

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -77,7 +77,12 @@ import {
   getOrRegisterTemplateVecType,
   getOrRegisterVecType,
 } from "./registry/types.js";
-import { exportDrainMicrotasksIfRegistered, getDrainFuncIdxForWasiStart } from "./async-scheduler.js";
+import {
+  ensureTimerHeap,
+  exportDrainMicrotasksIfRegistered,
+  getDrainFuncIdxForWasiStart,
+  getRunLoopFuncIdxForWasiStart,
+} from "./async-scheduler.js";
 import { flushLateImportShifts, registerAddStringImports, registerAddUnionImports } from "./shared.js";
 import { stackBalance, getFixupEvents, summarizeFixups, strictBalanceDiagnostics } from "./stack-balance.js";
 import { emitNativeParseNumber } from "./parse-number-native.js";
@@ -2079,13 +2084,21 @@ function addWasiStartExport(ctx: CodegenContext): void {
     const startFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
     const body: Instr[] = [{ op: "call", funcIdx: targetIdx }];
 
-    // #1326c Phase 1C-A — auto-drain the microtask queue after the entry
-    // function returns. Only emits the call when the async scheduler
-    // actually registered the queue helpers; otherwise leaves the body
-    // unchanged (no perf cost for modules that never schedule microtasks).
-    const drainFuncIdx = getDrainFuncIdxForWasiStart(ctx);
-    if (drainFuncIdx !== null) {
-      body.push({ op: "call", funcIdx: drainFuncIdx });
+    // #2632 Phase 1 — drive the event-loop reactor after the entry function
+    // returns. When the timer heap was registered, `__run_event_loop`
+    // SUPERSEDES the one-shot drain: it drains microtasks AND fires timers in a
+    // loop until no pending handles remain (and it calls `__drain_microtasks`
+    // itself, so we must NOT also emit the bare drain). When no timer heap was
+    // registered, fall back to the #1326c one-shot drain — byte-identical to
+    // the prior behaviour for every program that uses no timers.
+    const runLoopFuncIdx = getRunLoopFuncIdxForWasiStart(ctx);
+    if (runLoopFuncIdx !== null) {
+      body.push({ op: "call", funcIdx: runLoopFuncIdx });
+    } else {
+      const drainFuncIdx = getDrainFuncIdxForWasiStart(ctx);
+      if (drainFuncIdx !== null) {
+        body.push({ op: "call", funcIdx: drainFuncIdx });
+      }
     }
 
     ctx.mod.functions.push({
@@ -5786,6 +5799,11 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
   // the helper here keeps the infrastructure in place for the follow-up that
   // lowers timer calls to synchronous sleeps via the async scheduler.
   let needsPollOneoff = false;
+  // #2632 Phase 1 — source references a timer / microtask scheduler global
+  // (setTimeout/setInterval/clearTimeout/clearInterval/queueMicrotask). Drives
+  // ensureTimerHeap + the run-loop reactor in emitDeferredWasiHelpers, and the
+  // `getRunLoopFuncIdxForWasiStart` wiring in addWasiStartExport.
+  let needsTimerHeap = false;
   // #1482: process.env.X access — register environ_get / environ_sizes_get +
   // the JS-polyfill fast-path host import.
   let needsEnviron = false;
@@ -5860,10 +5878,35 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
     // #1484 — track setTimeout/setInterval/setImmediate to drive poll_oneoff
     // helper emission. Only bare-identifier call positions count (member-name
     // positions like `obj.setTimeout` are skipped).
+    // #2632 Phase 1 — setTimeout/setInterval/clearTimeout/clearInterval are now
+    // LOWERED onto the timer heap + run-loop reactor (no longer rejected). They
+    // require poll_oneoff (the blocking sleep), clock_time_get (monotonic now),
+    // and the timer heap. queueMicrotask needs only the microtask queue, which
+    // the reactor also drives, so it sets needsTimerHeap to wire the run loop.
     if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
       const callee = node.expression.text;
-      if (callee === "setTimeout" || callee === "setInterval" || callee === "setImmediate") {
+      // A user function/local shadowing the global keeps its own semantics —
+      // the reactor must NOT register/lower for it. The global timer names are
+      // declared ONLY in lib .d.ts files; a user shadow has a declaration in a
+      // real (.ts) source file. (Mirrors the call-site guard in calls.ts.)
+      const isGlobalShadowed = (() => {
+        const sym = ctx.checker.getSymbolAtLocation(node.expression);
+        const decls = sym?.declarations;
+        return !!decls && decls.length > 0 && !decls.every((d) => d.getSourceFile().isDeclarationFile);
+      })();
+      if (!isGlobalShadowed && (callee === "setTimeout" || callee === "setInterval" || callee === "setImmediate")) {
         needsPollOneoff = true;
+      }
+      if (!isGlobalShadowed && (callee === "setTimeout" || callee === "setInterval")) {
+        needsPollOneoff = true;
+        needsClockTimeGet = true;
+        needsTimerHeap = true;
+      }
+      if (
+        !isGlobalShadowed &&
+        (callee === "clearTimeout" || callee === "clearInterval" || callee === "queueMicrotask")
+      ) {
+        needsTimerHeap = true;
       }
     }
     // #1482: detect `process.env.X` (PropertyAccessExpression nested two deep)
@@ -6073,6 +6116,13 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
   if (needsPollOneoff) {
     ctx.wasiPendingSleepMsHelper = true;
   }
+  // #2632 Phase 1 — defer timer-heap + run-loop registration to
+  // emitDeferredWasiHelpers (after __wasi_sleep_ms + clock_time_get are
+  // registered, before user bodies compile), so __timer_add / __timer_cancel
+  // func indices referenced at timer call sites are final.
+  if (needsTimerHeap) {
+    ctx.wasiPendingTimerHeap = true;
+  }
 }
 
 /**
@@ -6103,6 +6153,14 @@ export function emitDeferredWasiHelpers(ctx: CodegenContext): void {
   // async scheduler to call this for setTimeout/await sleep().
   if (ctx.wasiPendingSleepMsHelper && !ctx.funcMap.has("__wasi_sleep_ms")) {
     emitWasiSleepMsHelper(ctx);
+  }
+
+  // #2632 Phase 1 — register the timer heap + run-loop reactor. MUST run after
+  // __wasi_sleep_ms (the run loop calls it) and clock_time_get registration
+  // (for __rl_now_ns), and BEFORE user bodies compile so the __timer_add /
+  // __timer_cancel func indices baked into timer call sites are final.
+  if (ctx.wasiPendingTimerHeap && !ctx.funcMap.has("__run_event_loop")) {
+    ensureTimerHeap(ctx);
   }
 }
 
@@ -12652,7 +12710,12 @@ function checkWasiDomUsage(ctx: CodegenContext, sourceFile: ts.SourceFile): void
  * NOTE: `requestAnimationFrame` / `cancelAnimationFrame` are already covered
  * by DOM_ONLY_GLOBALS above, so they are not duplicated here.
  */
-const WASI_REJECTED_TIMER_GLOBALS = new Set(["setTimeout", "setInterval", "setImmediate", "queueMicrotask"]);
+// #2632 Phase 1 — setTimeout/setInterval/clearTimeout/clearInterval and
+// queueMicrotask are now LOWERED onto the timer-heap + run-loop reactor under
+// --target wasi (see ensureTimerHeap / emitTimerAdd). Only `setImmediate`
+// remains rejected: its Node "check phase" ordering (after I/O poll, distinct
+// from a 0ms timer) is a later-phase concern not modelled by the Phase-1 loop.
+const WASI_REJECTED_TIMER_GLOBALS = new Set(["setImmediate"]);
 
 /**
  * In WASI mode, scan source for timer / event-loop globals (setTimeout etc.)

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -958,7 +958,7 @@ export function compileSourceSync(
   // it contributes an identity map and is omitted from the composition.
   const cjsRewritten2 = rewriteEvalSuperCall(cjsRewritten);
   const wasiNodeFsFuncs = detectNodeFsImports(cjsRewritten);
-  const preprocessed = preprocessImports(cjsRewritten2);
+  const preprocessed = preprocessImports(cjsRewritten2, { wasi: options.target === "wasi" });
   const processedSource = preprocessed.source;
   // Composed map: processedSource → original source. Pipeline output order is
   // define → cjs → (eval/super, identity) → imports, so compose outermost-first.

--- a/src/import-resolver.ts
+++ b/src/import-resolver.ts
@@ -256,7 +256,7 @@ function buildTimerShim(used: Set<string>, definedNames: Set<string>): string {
   return `// #1501 timer host-import shim (auto-injected)\n${lines.join("\n")}\n`;
 }
 
-export function preprocessImports(source: string): PreprocessResult {
+export function preprocessImports(source: string, opts?: { wasi?: boolean }): PreprocessResult {
   const sf = ts.createSourceFile("__preprocess__.ts", source, ts.ScriptTarget.Latest, true);
 
   // #1501 — detect bare-identifier calls to timer globals BEFORE the early
@@ -264,7 +264,15 @@ export function preprocessImports(source: string): PreprocessResult {
   // without any `import` statements still gets the shim. (The
   // `definedNames` reachable at this point includes the same scan used
   // below for the existing import resolution path.)
-  const timerCalls = detectTimerCallSites(sf);
+  //
+  // #2632 Phase 1 — under `--target wasi` the timer shim is SUPPRESSED: the
+  // standalone event-loop reactor lowers setTimeout/setInterval/clearTimeout/
+  // clearInterval natively (no `__timer_set_*` host import, no injected
+  // `function setTimeout` stub). Injecting the stub here would (a) pull in an
+  // unresolvable host import and (b) make `setTimeout` resolve to a user-file
+  // declaration, defeating the codegen reactor lowering (the call would inline
+  // the no-op stub instead). So skip it entirely for WASI.
+  const timerCalls = opts?.wasi ? new Set<string>() : detectTimerCallSites(sf);
 
   // Step 1: Find all imports
   const nsImports = new Map<string, { start: number; end: number; moduleSpec: string }>();

--- a/tests/issue-1326c.test.ts
+++ b/tests/issue-1326c.test.ts
@@ -58,8 +58,14 @@ describe("#1326c Phase 1C-A — microtask queue + drain export", () => {
     expect(typeof scheduler.emitStandalonePromiseResolve).toBe("function");
     expect(typeof scheduler.emitStandalonePromiseReject).toBe("function");
     expect(typeof scheduler.emitStandalonePromiseThen).toBe("function");
-    // emitStandalonePromiseThen still throws in 1C-A (Phase 1C-B fills it in).
-    expect(() => scheduler.emitStandalonePromiseThen({} as any, {} as any, [], [])).toThrow(/Phase 1C-B/);
+    // Phase 1C-B has landed: emitStandalonePromiseThen is fully implemented (the
+    // standalone microtask queue + Promise.then path). It is no longer a stub
+    // that throws "Phase 1C-B". (#2632 corrects this stale 1C-A assertion — the
+    // function's real behaviour is exercised by the #1326 Phase 1C-B suite.)
+    expect(typeof scheduler.emitStandalonePromiseThen).toBe("function");
+    // #2632 also adds the timer-heap + run-loop reactor surface.
+    expect(typeof scheduler.ensureTimerHeap).toBe("function");
+    expect(typeof scheduler.getRunLoopFuncIdxForWasiStart).toBe("function");
   });
 
   it("microtask queue helpers self-register lazily on first emitDrainMicrotasks", async () => {

--- a/tests/issue-2632-event-loop.test.ts
+++ b/tests/issue-2632-event-loop.test.ts
@@ -1,0 +1,232 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2632 Phase 1 — WASI async runtime (event-loop reactor): scheduler + timers
+ * + microtasks.
+ *
+ * Under `--target wasi` the compiler now lowers `setTimeout` / `setInterval` /
+ * `clearTimeout` / `clearInterval` / `queueMicrotask` onto a standalone
+ * timer-heap + run-loop reactor (`src/codegen/async-scheduler.ts`), replacing
+ * the one-shot `__drain_microtasks` call in the WASI `_start` wrapper with
+ * `__run_event_loop`. The loop drains microtasks, fires due timers from a
+ * deadline-ordered timer table, blocks until the nearest deadline via the
+ * existing single-clock `poll_oneoff` sleep, and exits when no pending handles
+ * remain.
+ *
+ * These cases compile each program under `--target wasi`, run the produced
+ * module under real wasmtime, and assert the observed stdout ORDERING matches
+ * Node's event-loop semantics:
+ *   - all synchronous top-level code runs first,
+ *   - then the microtask queue drains,
+ *   - then timers fire in non-decreasing deadline order,
+ *   - a `setTimeout(…, 0)` fires after sync code AND after pending microtasks,
+ *   - a timer scheduled inside a timer callback runs on a later turn,
+ *   - `setInterval` re-arms until `clearInterval`.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// wasmtime feature flags required for the WasmGC + exception-handling binaries
+// js2wasm emits (structs/arrays + the exception tag).
+const WASMTIME_FLAGS = ["-W", "gc=y,function-references=y,exceptions=y"];
+
+/** Resolve a usable `wasmtime` binary, or null when none is on PATH. */
+function findWasmtime(): string | null {
+  for (const cand of ["wasmtime", "/usr/local/bin/wasmtime"]) {
+    try {
+      execFileSync(cand, ["--version"], { stdio: "ignore" });
+      return cand;
+    } catch {
+      /* try next */
+    }
+  }
+  return null;
+}
+
+const wasmtimeBin = findWasmtime();
+
+let tmpDir: string;
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "issue-2632-"));
+});
+afterAll(() => {
+  if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+});
+
+/** Compile `src` under --target wasi, run under wasmtime, return stdout lines. */
+async function runWasi(src: string, name: string): Promise<string[]> {
+  const r = await compile(src, { fileName: `${name}.ts`, target: "wasi", skipSemanticDiagnostics: true });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const path = join(tmpDir, `${name}.wasm`);
+  writeFileSync(path, r.binary!);
+  const out = execFileSync(wasmtimeBin!, [...WASMTIME_FLAGS, path], { encoding: "utf-8" });
+  return out.split("\n").filter((l) => l.length > 0);
+}
+
+describe.skipIf(!wasmtimeBin)("#2632 Phase 1 — WASI event-loop reactor (timers + microtasks)", () => {
+  it("setTimeout fires after synchronous code", async () => {
+    const lines = await runWasi(
+      `
+      console.log("sync1");
+      setTimeout(() => { console.log("timeout"); }, 10);
+      console.log("sync2");
+      `,
+      "after-sync",
+    );
+    expect(lines).toEqual(["sync1", "sync2", "timeout"]);
+  });
+
+  it("queueMicrotask runs before a 0ms macrotask, after sync code", async () => {
+    const lines = await runWasi(
+      `
+      console.log("sync1");
+      setTimeout(() => { console.log("timeout0"); }, 0);
+      queueMicrotask(() => { console.log("micro"); });
+      console.log("sync2");
+      `,
+      "micro-before-timer",
+    );
+    // Node order: sync1, sync2 (sync), micro (microtask), timeout0 (macrotask).
+    expect(lines).toEqual(["sync1", "sync2", "micro", "timeout0"]);
+  });
+
+  it("timers fire in non-decreasing deadline order regardless of registration order", async () => {
+    const lines = await runWasi(
+      `
+      setTimeout(() => { console.log("t50"); }, 50);
+      setTimeout(() => { console.log("t10"); }, 10);
+      setTimeout(() => { console.log("t30"); }, 30);
+      `,
+      "deadline-order",
+    );
+    expect(lines).toEqual(["t10", "t30", "t50"]);
+  });
+
+  it("a timer scheduled inside a timer callback runs on a later turn (nested)", async () => {
+    const lines = await runWasi(
+      `
+      setTimeout(() => {
+        console.log("outer");
+        setTimeout(() => { console.log("inner"); }, 5);
+      }, 5);
+      `,
+      "nested",
+    );
+    expect(lines).toEqual(["outer", "inner"]);
+  });
+
+  it("setInterval re-arms until clearInterval bounds it by a counter", async () => {
+    const lines = await runWasi(
+      `
+      let n = 0;
+      let id = setInterval(() => {
+        n = n + 1;
+        console.log("tick" + n);
+        if (n >= 3) { clearInterval(id); }
+      }, 5);
+      `,
+      "interval-bounded",
+    );
+    expect(lines).toEqual(["tick1", "tick2", "tick3"]);
+  });
+
+  it("clearTimeout before the deadline cancels a pending timer", async () => {
+    const lines = await runWasi(
+      `
+      let id = setTimeout(() => { console.log("should-not-fire"); }, 30);
+      setTimeout(() => { console.log("fired"); }, 5);
+      clearTimeout(id);
+      `,
+      "clear-timeout",
+    );
+    expect(lines).toEqual(["fired"]);
+  });
+
+  it("microtasks chained off a timer callback drain before the next timer", async () => {
+    const lines = await runWasi(
+      `
+      setTimeout(() => {
+        console.log("t1");
+        queueMicrotask(() => { console.log("t1-micro"); });
+      }, 5);
+      setTimeout(() => { console.log("t2"); }, 20);
+      `,
+      "timer-then-micro",
+    );
+    // t1 fires, queues a microtask that must drain before t2's later deadline.
+    expect(lines).toEqual(["t1", "t1-micro", "t2"]);
+  });
+});
+
+describe("#2632 Phase 1 — compile-time wiring (no wasmtime needed)", () => {
+  it("setTimeout under --target wasi compiles (no longer rejected) and emits the run loop", async () => {
+    const r = await compile(`setTimeout(() => { console.log("x"); }, 1);`, {
+      target: "wasi",
+      skipSemanticDiagnostics: true,
+    });
+    expect(r.success, r.success ? "" : r.errors?.[0]?.message).toBe(true);
+    const wat = r.wat!;
+    expect(wat).toContain("$__run_event_loop");
+    expect(wat).toContain("$__timer_add");
+    // _start drives the run loop (which itself drains microtasks). The WAT
+    // prints `call <idx>` (numeric), so resolve the run-loop func idx by its
+    // textual position and assert _start's first body `call` targets it.
+    const numImportFuncs = (wat.match(/\(import [^\n]*\(func /g) || []).length;
+    let idx = numImportFuncs;
+    let runLoopIdx = -1;
+    for (const line of wat.split("\n")) {
+      const dm = line.match(/^ {2}\(func (\$[A-Za-z0-9_$]+)/);
+      if (dm) {
+        if (dm[1] === "$__run_event_loop") {
+          runLoopIdx = idx;
+          break;
+        }
+        idx++;
+      }
+    }
+    expect(runLoopIdx).toBeGreaterThanOrEqual(0);
+    const startBody = wat.match(/\(func \$_start[\s\S]*?\n {2}\)/)?.[0] ?? "";
+    expect(startBody).toContain(`call ${runLoopIdx}`);
+  });
+
+  it("queueMicrotask under --target wasi compiles and enqueues onto the microtask queue", async () => {
+    const r = await compile(`queueMicrotask(() => { console.log("m"); });`, {
+      target: "wasi",
+      skipSemanticDiagnostics: true,
+    });
+    expect(r.success, r.success ? "" : r.errors?.[0]?.message).toBe(true);
+    expect(r.wat!).toContain("$__microtask_enqueue");
+  });
+
+  it("a program with NO timers/microtasks does NOT register the timer heap (byte-neutral path)", async () => {
+    const r = await compile(`console.log("plain");`, { target: "wasi", skipSemanticDiagnostics: true });
+    expect(r.success).toBe(true);
+    expect(r.wat!).not.toContain("$__run_event_loop");
+    expect(r.wat!).not.toContain("$__timer_add");
+  });
+
+  it("setImmediate remains rejected under --target wasi (out of Phase-1 scope)", async () => {
+    const r = await compile(`setImmediate(() => {});`, { target: "wasi", skipSemanticDiagnostics: true });
+    expect(r.success).toBe(false);
+    const msg = r.errors.map((e) => e.message).join("\n");
+    expect(msg).toMatch(/setImmediate/);
+  });
+
+  it("a user-defined setTimeout shadow is NOT intercepted by the reactor lowering", async () => {
+    // A genuine user function named setTimeout must keep its own semantics.
+    const r = await compile(
+      `
+      function setTimeout(_cb: any, _ms: number): number { return 42; }
+      const h = setTimeout(() => {}, 10);
+      console.log(h);
+      `,
+      { target: "wasi", skipSemanticDiagnostics: true },
+    );
+    expect(r.success, r.success ? "" : r.errors?.[0]?.message).toBe(true);
+    // No reactor lowering for the user shadow.
+    expect(r.wat!).not.toContain("$__timer_add");
+  });
+});

--- a/tests/wasi-timers.test.ts
+++ b/tests/wasi-timers.test.ts
@@ -1,39 +1,34 @@
 // #1484 — WASI timer diagnostic + poll_oneoff helper.
 //
-// Under `--target wasi`, setTimeout/setInterval/setImmediate/queueMicrotask
-// must produce a compile-time diagnostic (not a silent runtime hang from a
-// missing `env::setTimeout` import). The compiler also registers
-// `wasi_snapshot_preview1::poll_oneoff` and emits a `__wasi_sleep_ms` helper
-// (gated on timer references) so a follow-up issue can lower timer call
-// sites to synchronous sleeps via the async scheduler. The poll_oneoff
-// polyfill in runtime.ts is the JS-side counterpart used by vitest.
+// #2632 Phase 1 UPDATE: under `--target wasi`, setTimeout/setInterval/
+// clearTimeout/clearInterval/queueMicrotask are now LOWERED onto the standalone
+// event-loop reactor (timer heap + run loop driven by poll_oneoff /
+// clock_time_get) — they COMPILE and RUN rather than being rejected. The
+// `__wasi_sleep_ms` helper this diagnostic introduced (#1484) is the blocking
+// sleep the reactor uses. Only `setImmediate` remains rejected (its Node
+// check-phase ordering is a later-phase concern). End-to-end timer ordering is
+// covered by `tests/issue-2632-event-loop.test.ts` (run under wasmtime).
 import { describe, it, expect } from "vitest";
 import { compile } from "../src/index.js";
 import { buildWasiPolyfill } from "../src/runtime.js";
 
-describe("WASI timers (#1484) — compile-time diagnostic", () => {
-  it("rejects setTimeout under --target wasi with a clear diagnostic", async () => {
+describe("WASI timers (#1484 → #2632 Phase 1) — now lowered, not rejected", () => {
+  it("setTimeout under --target wasi compiles and emits the run loop", async () => {
     const src = `setTimeout(() => { console.log("late"); }, 100);`;
-    const result = await compile(src, { target: "wasi" });
-    expect(result.success).toBe(false);
-    expect(result.errors.length).toBeGreaterThan(0);
-    const msg = result.errors.map((e) => e.message).join("\n");
-    expect(msg).toMatch(/setTimeout/);
-    expect(msg).toMatch(/wasi/i);
-    // Must surface as a `Codegen error:` so compiler.ts short-circuits and
-    // never emits an unresolvable `env::setTimeout` import.
-    expect(msg).toMatch(/Codegen error:/);
+    const result = await compile(src, { target: "wasi", skipSemanticDiagnostics: true });
+    expect(result.success, result.success ? "" : result.errors?.[0]?.message).toBe(true);
+    expect(result.wat!).toContain("$__run_event_loop");
+    expect(result.wat!).toContain("$__timer_add");
   });
 
-  it("rejects setInterval under --target wasi", async () => {
+  it("setInterval under --target wasi compiles", async () => {
     const src = `setInterval(() => {}, 50);`;
-    const result = await compile(src, { target: "wasi" });
-    expect(result.success).toBe(false);
-    const msg = result.errors.map((e) => e.message).join("\n");
-    expect(msg).toMatch(/setInterval/);
+    const result = await compile(src, { target: "wasi", skipSemanticDiagnostics: true });
+    expect(result.success, result.success ? "" : result.errors?.[0]?.message).toBe(true);
+    expect(result.wat!).toContain("$__timer_add");
   });
 
-  it("rejects setImmediate under --target wasi", async () => {
+  it("setImmediate under --target wasi remains rejected (out of Phase-1 scope)", async () => {
     const src = `setImmediate(() => {});`;
     const result = await compile(src, { target: "wasi" });
     expect(result.success).toBe(false);
@@ -41,12 +36,11 @@ describe("WASI timers (#1484) — compile-time diagnostic", () => {
     expect(msg).toMatch(/setImmediate/);
   });
 
-  it("rejects queueMicrotask under --target wasi", async () => {
+  it("queueMicrotask under --target wasi compiles and enqueues onto the microtask queue", async () => {
     const src = `queueMicrotask(() => {});`;
-    const result = await compile(src, { target: "wasi" });
-    expect(result.success).toBe(false);
-    const msg = result.errors.map((e) => e.message).join("\n");
-    expect(msg).toMatch(/queueMicrotask/);
+    const result = await compile(src, { target: "wasi", skipSemanticDiagnostics: true });
+    expect(result.success, result.success ? "" : result.errors?.[0]?.message).toBe(true);
+    expect(result.wat!).toContain("$__microtask_enqueue");
   });
 
   it("does NOT reject when setTimeout appears as a member name (e.g. obj.setTimeout)", async () => {


### PR DESCRIPTION
## #2632 Phase 1 — WASI async runtime: scheduler + timers + microtasks

Implements **Phase 1** of the WASI event-loop reactor goal (#2632). Composes the
existing async substrate into a single-threaded cooperative event loop under
`--target wasi`. **This is a phased goal — Phase 1 only; the issue stays
`in-progress`** (Phases 2 fd-readiness reactor, 3 `process.stdin` Readable, 4
Preview-2 remain).

### What landed
- **`__run_event_loop`** replaces the one-shot `__drain_microtasks` call in the
  WASI `_start` wrapper: drain microtasks → fire due timers (deadline-ordered) →
  block until the nearest deadline via the existing #1484 single-clock
  `poll_oneoff` sleep → repeat → exit when no pending handles remain.
- **`setTimeout` / `setInterval` / `clearTimeout` / `clearInterval` /
  `queueMicrotask`** now lower onto the reactor under WASI (removed from
  `WASI_REJECTED_TIMER_GLOBALS`; only `setImmediate` stays rejected — its
  check-phase ordering is a later phase).
- **Timer table** = parallel WasmGC arrays (`deadlines/callbacks/captures/
  intervals/cancelled`), O(n) linear scan for the earliest live deadline, stable
  slot ids (so `clearTimeout`/`clearInterval` survive a grow), lazy-delete
  cancellation, intervals re-arm relative to the scheduled deadline.
- Timer callbacks reuse the microtask `$__mt_func_type` signature (`call_ref`
  compatible); the closure struct is stored as the captures externref.
- **#1501 JS-host timer shim suppressed under WASI** — it injected a user-file
  `function setTimeout` stub that pulled an unresolvable host import and defeated
  the reactor lowering. Genuine user shadows (`.ts` decls) keep their semantics.

### Byte-neutrality (broad-impact gate)
`__run_event_loop` is only registered when a timer/microtask global is
referenced. For programs with **no** timers/microtasks, `_start` keeps the exact
prior one-shot-drain body. Verified **SHA256-identical** Wasm vs the branch base
for `console.log`, a `for`-loop, `Promise.resolve().then`, and a plain function.

### Index discipline
Timer heap (types/globals + 7 helpers) registered in the deferred-helper phase
(after `__wasi_sleep_ms` + `clock_time_get`, before user bodies) so
`__timer_add`/`__timer_cancel` funcidx baked at call sites are final
(`project_type_index_shift_and_deadelim`).

### Scope boundary hit — top-level `await`
Left unlowered, as the architect spec predicted: the CPS machine lowers `await`
only inside `async function` bodies; module-suspending top-level await needs
module-init itself lowered to a state machine. Phase 1 does not need it (top
level schedules synchronously and returns; the loop then runs) and it is a
test262 skip filter.

### Tests
- `tests/issue-2632-event-loop.test.ts` — compile `--target wasi` + run under
  **real wasmtime**: setTimeout-after-sync, microtask-before-0ms-timer, deadline
  order, nested setTimeout, interval+clearInterval, clearTimeout, timer→microtask
  drain. Plus compile-time wiring + byte-neutral-path assertions.
- `tests/wasi-timers.test.ts` (#1484) flipped from "rejects" to "compiles+runs".
- `tests/issue-1326c.test.ts` — corrected a stale 1C-A throw-assertion (1C-B has
  long landed; pre-existing failure, fixed here as touched-file hygiene).

✓ `tsc --noEmit` clean · scoped tests green · IR-fallback gate OK (no deltas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)