### PR TITLE
fix(#2623): single-box nested capture of an already-boxed outer var (Slice A)

### DIFF
--- a/plan/issues/2623-promise-capability-cluster-multihop-callback-cast.md
+++ b/plan/issues/2623-promise-capability-cluster-multihop-callback-cast.md
@@ -498,3 +498,92 @@ conformance payoff.
 - The branch `issue-2623b-construct-identity` is reverted to clean (no codegen
   shipped). **Row delta: 0.** Slice C (#2618 Proxy apply/construct) is independent
   and not yet verified — recommend the same verify-first treatment before claiming.
+
+---
+
+## Slice 2623-A — SHIPPED — box-depth lowering (senior-dev sendev-2623a, 2026-06-24)
+
+**Verdict: the box-depth double-box IS a real, fixable codegen bug — and the
+prior A re-grounding's blocker ("collapsing the box regresses #1312 async
+recursion") was a MIS-ATTRIBUTION. Shipped a clean, bounded fix; zero scoped
+regressions.**
+
+### Corrected root cause (binaryen-decoded on current main)
+The double-box is a missing `alreadyBoxed` disambiguation in the
+**FunctionDeclaration** capture path (`src/codegen/statements/nested-declarations.ts`),
+which the **arrow** path already has (`src/codegen/closures.ts:1681 / 1728-1748 /
+2457-2476`). Concretely, for the capability shape
+(`Promise.allSettled.call(Constructor, [thenable])`, `Constructor` materialized
+as a host-routed closure VALUE):
+- `callCount` is boxed once into `$__ref_cell_f64` and threaded as a leading
+  `(ref null $cell_f64)` param of `Constructor`.
+- The nested `function resolve(){ callCount++ }` re-captures `callCount`. In
+  `nested-declarations.ts` the mutable-capture param TYPE was computed as
+  `getOrRegisterRefCellType(ctx, c.type)` where `c.type` was ALREADY the
+  `$cell_f64` → it produced `$__ref_cell_ref_N (struct (mut (ref null
+  $cell_f64)))` — a **cell-of-cell** (single positional decode:
+  `resolve.cap0 = (ref null 26)` vs `Constructor.cap0 = (ref null 24)`).
+- **Two breakages from that one depth mismatch:** (1) the construction site
+  (`emitFuncRefAsClosure`) pushed the existing single `$cell_f64` into a closure
+  field typed as the double cell → the `struct.new` field-coerce in
+  `src/codegen/stack-balance.ts:1870` inserted an UNGUARDED `ref.cast $cell_f64
+  → $cell_of_cell` → **`illegal cast in Constructor()`**. (2) the lifted
+  `resolve` body derefed once (`struct.get $cell_of_cell`) and got the inner
+  `$cell` (a ref) where it expected the f64 → `callCount += 1` read garbage
+  (decoded body literally computed `f64.const 0 + 1` and dropped it) → callCount
+  never incremented.
+
+### Canonical box-depth verdict
+**Capture by the existing single `$cell`; do NOT re-box at the nested-capture
+boundary.** When the captured name is already in the outer scope's
+`boxedCaptures`, the outer slot IS the canonical cell — thread it through. This
+is exactly the arrow path's `alreadyBoxed` rule, now ported to the
+FunctionDeclaration path. Both producer (closure field type, via the lifted fn's
+param type) and consumer (lifted body `struct.get/set`, registered at the cell's
+INNER value depth) now agree at depth 1.
+
+### Fix (one file, `src/codegen/statements/nested-declarations.ts`)
+1. capture record gains `alreadyBoxed` (= `fctx.boxedCaptures?.has(name)`) +
+   `boxedValType` (the outer cell's inner value type).
+2. `valueCaptureParamTypes`: `if (c.mutable && c.alreadyBoxed) return c.type;`
+   (the existing cell) instead of re-wrapping.
+3. `boxedCaptures` registration: when `alreadyBoxed`, register the EXISTING
+   cell's typeidx + its inner valType so the body derefs exactly once.
+   `emitFuncRefAsClosure` already pushes the existing cell when
+   `boxedCaptures.has(name)` — no change needed there.
+
+### Why the prior "regresses #1312 async" was wrong
+The `#1312` "async inner recursion via param with mutable ref-cell capture" test
+is **ALREADY NaN on clean `origin/main`**, independent of any box change. Its
+async `next` is **single-boxed** already (`cap0 = $__ref_cell_f64`) and my fix
+does not touch it. The NaN is a SEPARATE bug: the async helper `call(fn){ return
+await fn() }`'s await-of-closure dispatch only handles the VOID wrapper arm; for
+an **f64-returning** callback it does `call_ref; drop; ref.null extern` — it
+**discards the callback's return value** → the recursion's accumulated value is
+lost → NaN. That is an `await`-callback-result-drop bug in the await/call-of-
+closure dispatch, NOT box depth. (File forward as a separate async-lane issue.)
+
+### Results
+- `tests/issue-2623-capture-box-depth.test.ts` (new): asserts no
+  `__ref_cell_ref_*` cell-of-cell + `resolve.cap0 == Constructor.cap0` on the
+  real `allSettled/call-resolve-element.js` fixture. PASS with fix, FAIL on
+  baseline (both assertions flip).
+- The two headline rows (`allSettled/call-resolve-element`,
+  `race/resolve-from-same-thenable`) **no longer trap `illegal cast in
+  Constructor()`** — they advance to a DOWNSTREAM **test-harness shim gap**
+  (`Promise resolve or reject function is not callable` = `Test262Error.thrower`
+  / `promiseHelper.js` not shimmed in `tests/test262-runner.ts`). The substrate
+  is fixed; the row flips additionally require those runner shims (separable
+  follow-up, NOT codegen — documented in the prior A re-grounding, lines
+  410-414).
+- Scoped sweep: 9 capture/closure/async failures (#585 ×4, #1712, #1312-async,
+  …) are ALL identical on clean baseline = **zero regressions**. (The
+  `helpers.js` file-load errors in 4 unrelated suites are a pre-existing infra
+  gap on main — `tests/helpers.ts` is not on `origin/main`.)
+- Broad-impact (hot closure-capture path) → **merge_group floor authoritative**
+  (#2097), per `project_broad_impact_validate_full_ci`.
+
+### Follow-ups (NOT in this PR)
+- `await`-callback-result-drop (the real #1312-async NaN) — async-lane.
+- `Test262Error.thrower` + `promiseHelper.js` runner shims — to actually flip the
+  two headline rows green once on top of this substrate fix.

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -258,6 +258,22 @@ export function compileNestedFunctionDeclaration(
     hasTdzFlag: boolean;
     /** Outer-fctx flag local index (i32 flag OR boxed ref-cell ref). */
     tdzFlagIdx?: number;
+    /**
+     * #2623 Slice A: the captured local is ALREADY a ref cell in the outer
+     * scope (registered in `fctx.boxedCaptures`) — e.g. an outer fn that is
+     * itself materialized as a closure VALUE threads a mutable capture as a
+     * boxed `$cell` param, and a nested fn re-captures the SAME name. The
+     * outer slot IS the canonical cell; re-boxing it here produced a
+     * `$cell-of-cell` whose deref depth desynced the construction-site cast
+     * (illegal cast in Constructor()) AND the lifted body's struct.get/set
+     * (read garbage → callCount never increments). Mirrors the arrow path's
+     * `alreadyBoxed` handling (closures.ts:1681/1728-1748/2457-2476). When
+     * set, thread the existing cell through instead of wrapping again.
+     */
+    alreadyBoxed: boolean;
+    /** Inner value type of the outer cell (when alreadyBoxed) — the depth the
+     * lifted body's struct.get/set should produce/consume. */
+    boxedValType?: ValType;
   }[] = [];
   for (const name of referencedNames) {
     if (ownLocals.has(name)) continue;
@@ -322,7 +338,23 @@ export function compileNestedFunctionDeclaration(
     // the destructure-assign path to be box-aware. Both are out of scope
     // for this PR; the test is marked `.todo` until that follow-up lands.
     const isMutable = writtenInBody.has(name);
-    captures.push({ name, type, localIdx, mutable: isMutable, hasTdzFlag, tdzFlagIdx });
+    // #2623 Slice A: detect a capture whose outer slot is already the canonical
+    // ref cell (the outer scope boxed it). For such a name `type` above is the
+    // cell ref type, so the generic mutable-capture path would re-box to a
+    // cell-of-cell. Remember the outer cell's inner value type so the lifted
+    // body derefs to the right depth.
+    const outerBoxedEntry = fctx.boxedCaptures?.get(name);
+    const alreadyBoxed = !!outerBoxedEntry;
+    captures.push({
+      name,
+      type,
+      localIdx,
+      mutable: isMutable,
+      hasTdzFlag,
+      tdzFlagIdx,
+      alreadyBoxed,
+      boxedValType: outerBoxedEntry?.valType,
+    });
   }
 
   // (#2172 / SF-1 of #2157) Wasm-native lowering for a NESTED `function*` in
@@ -578,6 +610,14 @@ export function compileNestedFunctionDeclaration(
     // For mutable captures, use ref cell types so writes propagate back
     const valueCaptureParamTypes: ValType[] = captures.map((c) => {
       if (c.mutable) {
+        // #2623 Slice A: when the outer slot is ALREADY the canonical cell,
+        // thread it through unchanged (single box) rather than wrapping again
+        // into a cell-of-cell — the construction site (emitFuncRefAsClosure)
+        // pushes the existing cell when `boxedCaptures.has(name)`, and the
+        // lifted body's struct.get/set must match that single depth.
+        if (c.alreadyBoxed) {
+          return c.type;
+        }
         const refCellTypeIdx = getOrRegisterRefCellType(ctx, c.type);
         return { kind: "ref" as const, typeIdx: refCellTypeIdx };
       }
@@ -636,6 +676,20 @@ export function compileNestedFunctionDeclaration(
     // scope, so the body code dereferences through the ref cell.
     for (const cap of captures) {
       if (cap.mutable) {
+        // #2623 Slice A: when the outer slot is already the canonical cell, the
+        // param carries that cell type directly (see valueCaptureParamTypes
+        // above). Register the EXISTING cell's typeidx + its inner value type so
+        // the lifted body's struct.get/set deref exactly once to the value
+        // (matching the single-box param), not twice through a cell-of-cell.
+        if (cap.alreadyBoxed && (cap.type.kind === "ref" || cap.type.kind === "ref_null")) {
+          const refCellTypeIdx = (cap.type as { typeIdx: number }).typeIdx;
+          if (!liftedFctx.boxedCaptures) liftedFctx.boxedCaptures = new Map();
+          liftedFctx.boxedCaptures.set(cap.name, {
+            refCellTypeIdx,
+            valType: cap.boxedValType ?? { kind: "f64" },
+          });
+          continue;
+        }
         const refCellTypeIdx = getOrRegisterRefCellType(ctx, cap.type);
         if (!liftedFctx.boxedCaptures) liftedFctx.boxedCaptures = new Map();
         liftedFctx.boxedCaptures.set(cap.name, { refCellTypeIdx, valType: cap.type });

--- a/tests/issue-2623-capture-box-depth.test.ts
+++ b/tests/issue-2623-capture-box-depth.test.ts
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2623 Slice A — async/capability closure outbound-capture box-depth lowering.
+//
+// Root cause (verified, binaryen-decoded): when an outer function is itself
+// materialized as a closure VALUE and threads a mutable capture as a boxed
+// `$cell` leading param (e.g. the Promise capability `Constructor(executor)`
+// whose module-level `callCount` is boxed), a NESTED function declaration that
+// re-captures the SAME name was DOUBLE-BOXED. `nested-declarations.ts` typed the
+// nested mutable capture as `getOrRegisterRefCellType(ctx, c.type)` where
+// `c.type` was ALREADY the `$cell` — producing a `$cell-of-cell`
+// (`__ref_cell_ref_*` whose value field is itself a `(ref null $cell)`).
+//
+// That deref-depth mismatch (#1205/#1312 hazard) broke two sites:
+//   1. The construction site (emitFuncRefAsClosure) pushed the existing single
+//      `$cell` into a closure field typed as the double cell — the struct.new
+//      field-coerce in stack-balance.ts inserted an UNGUARDED `ref.cast`
+//      `$cell -> $cell-of-cell` that trapped: "illegal cast in Constructor()".
+//   2. The lifted body derefed once (`struct.get $cell-of-cell`) and got the
+//      INNER `$cell` (a ref) where it expected the f64 value, so the mutation
+//      `callCount += 1` read/wrote garbage and never incremented.
+//
+// Fix: mirror the ARROW path's existing `alreadyBoxed` disambiguation
+// (closures.ts:1681/1728-1748/2457-2476) in the FunctionDeclaration path. When
+// the captured name is already registered in the outer scope's `boxedCaptures`,
+// thread the existing `$cell` through unchanged (single box) and register the
+// lifted body's read/write at the cell's inner value depth.
+//
+// This test asserts the STRUCTURAL invariant directly (the generated module
+// must not contain a ref-cell-of-ref-cell for the capability shape) because it
+// is deterministic and does not depend on the test262 harness shims
+// (`Test262Error.thrower` / `promiseHelper.js`) that gate the full row flips.
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { parseMeta, wrapTest } from "./test262-runner.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const TEST262_FILE = resolve(HERE, "../test262/test/built-ins/Promise/allSettled/call-resolve-element.js");
+
+/**
+ * Compile the EXACT test262 source that triggers the double-box (through the
+ * runner's wrap, matching the conformance path). The full capability shape —
+ * `Promise.allSettled.call(Constructor, [thenable])` with a `Constructor`
+ * whose nested `resolve` captures the module-level `var callCount` — is what
+ * boxes `callCount` into a `$cell` threaded as a `Constructor` param and then
+ * re-captured by `resolve`. A reduced synthetic shape does NOT exercise the
+ * host-routed boxing, so we use the real fixture.
+ */
+function compileCapabilityFixture() {
+  const src = readFileSync(TEST262_FILE, "utf-8");
+  const meta = parseMeta(src);
+  const wrapped = wrapTest(src, meta);
+  const wsrc = typeof wrapped === "string" ? wrapped : (wrapped as { source: string }).source;
+  return compile(wsrc, { fileName: "call-resolve-element.ts" });
+}
+
+/**
+ * The compiler names a ref-cell that boxes the value type `T` as
+ * `__ref_cell_<key>`. A SINGLE box of an f64 capture is `__ref_cell_f64`; a
+ * DOUBLE box (cell-of-cell) is `__ref_cell_ref_<n>` — the key is derived from a
+ * `ref` value type, i.e. the cell wraps another ref-cell. That `__ref_cell_ref_`
+ * marker is the precise signature of the #2623 double-box regression: it is
+ * generated ONLY when a mutable capture's value type is itself already a ref
+ * cell. Its presence is the bug; its absence is the fix.
+ */
+function hasCellOfCell(wat: string): boolean {
+  return /\(type \$__ref_cell_ref_\d+\s/.test(wat);
+}
+
+describe("#2623 Slice A — nested-capture box depth (no double-box)", () => {
+  it("the capability fixture's nested capture is single-boxed (no cell-of-cell)", async () => {
+    const r = await compileCapabilityFixture();
+    expect(r.success).toBe(true);
+    // The module must be structurally valid (no ungual cast trap baked in).
+    expect(() => new WebAssembly.Module(r.binary)).not.toThrow();
+    // Box-depth invariant: the `__ref_cell_ref_*` cell-of-cell marker must be
+    // ABSENT. On the pre-fix baseline this fixture emits
+    // `(type $__ref_cell_ref_N (struct (field $value (mut (ref null <f64-cell>)))))`.
+    expect(hasCellOfCell(r.wat)).toBe(false);
+  });
+
+  it("Constructor and its nested resolve capture callCount at the SAME depth", async () => {
+    const r = await compileCapabilityFixture();
+    expect(r.success).toBe(true);
+    const lines = r.wat.split("\n");
+    const ctor = lines.find((l) => /\(type \$__fn_cap_Constructor_\d+_struct/.test(l));
+    const resolveCap = lines.find((l) => /\(type \$__fn_cap_resolve_\d+_struct/.test(l));
+    expect(ctor).toBeDefined();
+    expect(resolveCap).toBeDefined();
+    // Both closures box `callCount` — the cap0 field type index must match
+    // (single shared `$__ref_cell_f64`). Pre-fix, resolve's cap0 pointed at the
+    // cell-of-cell while Constructor's pointed at the f64 cell.
+    const ctorCap0 = ctor!.match(/cap0 \(ref null (\d+)\)/)?.[1];
+    const resolveCap0 = resolveCap!.match(/cap0 \(ref null (\d+)\)/)?.[1];
+    expect(ctorCap0).toBeDefined();
+    expect(resolveCap0).toBeDefined();
+    expect(resolveCap0).toBe(ctorCap0);
+  });
+});


### PR DESCRIPTION
## #2623 Slice A — async/capability closure outbound-capture box-depth lowering

Keystone slice of the #2623 promise capability-cluster. Fixes the **double-box** that traps `illegal cast in Constructor()` on `allSettled/call-resolve-element` and `race/resolve-from-same-thenable`.

### Root cause (binaryen-decoded)
When an outer function is materialized as a closure VALUE and threads a mutable capture as a boxed `$cell` leading param (the Promise capability `Constructor(executor)` whose module-level `callCount` is boxed), a NESTED `function resolve(){ callCount++ }` that re-captures the SAME name was **double-boxed**: `nested-declarations.ts` computed the nested mutable-capture type as `getOrRegisterRefCellType(ctx, c.type)` where `c.type` was ALREADY the `$cell` → a `$cell-of-cell` (`__ref_cell_ref_*`).

That deref-depth mismatch broke two sites:
1. **construction site** — `emitFuncRefAsClosure` pushed the existing single `$cell` into a closure field typed as the double cell, so the `struct.new` field-coerce in `stack-balance.ts:1870` inserted an **ungual `ref.cast $cell → $cell-of-cell`** that trapped (`illegal cast in Constructor()`).
2. **lifted body** — `resolve` derefed once and got the inner `$cell` (a ref) where it expected the f64 value → `callCount += 1` read garbage and never incremented.

### Fix (one file)
Port the **arrow path's existing `alreadyBoxed` disambiguation** (`closures.ts:1681 / 1728-1748 / 2457-2476`) to the FunctionDeclaration path in `src/codegen/statements/nested-declarations.ts`. When the captured name is already in the outer scope's `boxedCaptures`, thread the existing `$cell` through unchanged (single box) and register the body's read/write at the cell's inner value depth. Producer (closure field type) and consumer (body `struct.get/set`) now agree at depth 1. `emitFuncRefAsClosure` already pushes the existing cell when `boxedCaptures.has(name)` — no change needed there.

### Box-depth verdict
**Capture by the existing single `$cell`; do NOT re-box at the nested-capture boundary.**

### Validation
- `tests/issue-2623-capture-box-depth.test.ts` (new): on the real `allSettled/call-resolve-element.js` fixture, asserts NO `__ref_cell_ref_*` cell-of-cell and `resolve.cap0 == Constructor.cap0`. PASS with fix; **both assertions FAIL on clean baseline**.
- The two headline rows no longer trap `illegal cast in Constructor()` — they advance to a downstream **test-harness shim gap** (`Test262Error.thrower` / `promiseHelper.js` unshimmed in the runner), which is separable (not codegen).
- **Zero scoped regressions**: the 9 capture/closure/async failures (#585 ×4, #1712, #1312-async, …) are identical on clean `origin/main`.

### On the prior A re-grounding's "blocker"
The prior session deferred Slice A claiming a box collapse "regresses #1312 async recursion". That was a **mis-attribution**: the `#1312` async-inner-recursion test is **already NaN on clean main** from a SEPARATE bug — the async helper `call(fn){ return await fn() }`'s await-of-closure dispatch handles only the VOID wrapper arm; for an **f64-returning** callback it does `call_ref; drop; ref.null extern`, discarding the return value. That async `next` is already single-boxed and is untouched by this fix. Filed forward as an async-lane follow-up.

### Broad-impact discipline
Touches the hot closure-capture path → **merge_group floor authoritative** (#2097), per `project_broad_impact_validate_full_ci`. No ABI/value-rep change; no dispatcher rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA