### PR TITLE
feat(#1772): node:fs ABI (Phase 0) + edge.js dual-provider proof (Phase 1)

### DIFF
--- a/docs/architecture/node-fs-abi.md
+++ b/docs/architecture/node-fs-abi.md
@@ -1,0 +1,134 @@
+# `node:fs` host-import ABI (one contract, swappable providers)
+
+> Status: **pinned** (2026-06-23, #1772 Phase 0). Anchor members `readSync` /
+> `writeSync`. Companion to `plan/issues/1772-edgejs-node-wasi-shim-spike.md`
+> (`## Phase 0 — ABI`) and the landed shim work in #2631.
+
+## Why this exists
+
+Node-shaped host APIs (`fs.readSync`, `process.stdout.write`, …) must **not**
+accrete as ad-hoc special cases in the generic compiler. The clean model
+(`feedback_node_apis_via_per_module_shim_not_builtin`):
+
+1. a program *imports* a node module surface
+   (`import { readSync } from "node:fs"`),
+2. the compiler emits a **wasm import** declaring the dependency by the **real
+   module + member name** (`(import "node:fs" "readSync" …)`), import-scoped to
+   only the members actually used,
+3. that import is satisfied at **link time** by any provider honoring one fixed
+   ABI. The module declares **what** host API it needs, never **how** it is
+   satisfied.
+
+This document pins that fixed ABI for the fd-based synchronous `node:fs` core so
+that every provider — a pure-WASI `.wat` shim, a JS `edge.js` adapter delegating
+to real `node:fs`, or a WASI polyfill — is interchangeable **by construction**.
+
+## The pointer-ABI (anchor members)
+
+Import module name: **`"node:fs"`**. Member names are the **real Node names**.
+Each member is a flat numeric function over the module's shared linear memory —
+nothing GC-typed crosses the link.
+
+| Member      | Wasm import signature               | Semantics |
+|-------------|-------------------------------------|-----------|
+| `readSync`  | `(fd i32, ptr i32, len i32) -> i32` | Read up to `len` bytes from descriptor `fd` into `mem[ptr, ptr+len)`. Returns the count actually read; `0` means EOF. **MUST NOT** write past `ptr+len`. |
+| `writeSync` | `(fd i32, ptr i32, len i32) -> i32` | Write `mem[ptr, ptr+len)` to descriptor `fd`. Returns the count actually written. A short write is legal (callers loop until drained). |
+
+### `fd` is load-bearing
+
+`fd` is an integer descriptor: `0`=stdin, `1`=stdout, `2`=stderr. A provider
+**must** route by it. In particular `writeSync(2, …)` writes telemetry/diagnostics
+to **stderr**, off the stdout protocol stream — a provider that collapses all
+writes onto stdout is **non-conforming** and corrupts framed protocols (e.g.
+Chrome Native Messaging).
+
+### fd-based, not path-based
+
+These members are fd-based and **filesystem-free**: no `path_open`, no preopens,
+no filesystem. Path-based `node:fs` (`readFileSync(path)`, `open`, …) is a
+**different capability tier** that needs a filesystem (`--allow-fs`/preopens) and
+is **rejected** under `--target wasi`. Keeping the fd core filesystem-free is what
+makes it portable across all three host classes today.
+
+## Two contracts, one bridge
+
+There are two distinct surfaces, and the compiler bridges between them:
+
+- **Source-level (Node-shaped) contract** — what the `.ts` author writes:
+  `readSync(0, buf, { offset, length })`, `writeSync(1, buf, offset)`. These are
+  the *real* Node signatures, so the **same source file runs unmodified under
+  real `node`** (where `node:fs` is the real module).
+- **Wasm-link (pointer) contract** — what crosses the module boundary:
+  `(fd, ptr, len) -> i32` over shared memory, as tabled above.
+
+The compiler lowers the GC/linear `Uint8Array` argument to a `(ptr, len)` pair
+over the shared memory and emits the import call. On the native-Node path, the
+**`edge.js` adapter** performs the inverse: it receives `(fd, ptr, len)`, wraps
+the byte range as a `Buffer`/`Uint8Array` view, and calls the real
+`fs.readSync(fd, buf, 0, len, null)` / `fs.writeSync(fd, buf)`.
+
+## Memory-ownership / linking model
+
+### Today — shim-owned exported memory
+
+Mirrors `examples/native-messaging/node-fs.wat`:
+
+1. The **provider owns + exports** the linear memory:
+   `(memory (export "memory") 3)` (min 3 pages; grows on demand).
+2. The **user module imports** memory index 0 from `"node:fs"` plus the IO
+   functions it uses. It declares **no** memory of its own.
+3. **No instantiation cycle.** Instantiate the provider first (it imports only
+   its own backing — `wasi_snapshot_preview1` for the `.wat` shim; *nothing* for
+   `edge.js`), then instantiate the user module with `{ memory, readSync,
+   writeSync }` taken from the provider's exports.
+4. The provider reads/writes the user's bytes over the **same** memory. The
+   `.wat` shim builds its WASI iovec in reserved scratch at `mem[0, 12)` and
+   issues the syscall; `edge.js` reads/writes the `[ptr, ptr+len)` range directly
+   from JS (no scratch needed).
+
+If a module uses **both** `node:process`/`console` IO **and** `node:fs`, the
+`node-process` shim owns the memory and `node-fs` links the same bytes —
+byte-identical layout, same min 3 pages.
+
+### Durable form — #2527 core-wasm linking
+
+Shim-owned-memory is a stop-gap that works on any plain
+`WebAssembly.instantiate`. The durable form is WebAssembly core-module/component
+linking (#2527): user module + provider linked with an explicitly shared memory,
+so neither side hard-codes "who owns memory". **The pointer-ABI per member is
+unchanged by that migration** — only the memory-binding mechanism changes.
+
+## Provider contract table
+
+One compiled binary, three host classes, one ABI. Compatibility holds **by
+construction iff every provider honors the pointer-ABI above.**
+
+| Host class | Provider | How it satisfies `readSync(fd, ptr, len) -> i32` |
+|---|---|---|
+| **Pure WASI** (wasmtime, no JS) | `node-fs.wat` / `.wasm` shim (#2631) | WASI `fd_read` / `fd_write` over the shim-owned memory (iovec in `mem[0,12)`). |
+| **Native Node** (JS, no WASI) | **`edge.js`** | reads/writes `mem[ptr, ptr+len)` from JS; calls real `fs.readSync(fd, buf, 0, len, null)` / `fs.writeSync(fd, buf)`; returns the count. |
+| **JS + WASI** (browser / Node-WASI) | `edge.js` over a WASI polyfill | delegates to a `fd_read`/`fd_write` polyfill or platform fd APIs over the same memory. |
+
+## Wrinkles that decide real compatibility
+
+1. **Calling-convention impedance.** Real `fs.readSync(fd, buffer, offset,
+   length, position)` ≠ the wasm `readSync(fd, ptr, len)`. So native Node is
+   **never a direct provider** — it always needs `edge.js` to translate
+   pointer-ABI ↔ Buffer-ABI over the exported memory.
+2. **Type surface ≫ runtime surface.** `@types/node` types thousands of members;
+   only the subset with a shim/adapter is *linkable*. Type extraction (#1772
+   Phase 2) must gate against a **capability map** (`@types/node` member →
+   provider fn → host classes that can provide it) so a program either links or
+   gets a precise "no provider" error — never a silent link failure.
+3. **Async ≠ sync.** Sync fd APIs port trivially. Node's async surface
+   (`process.stdin` Readable, `fs.promises`) needs the event loop (#2632); the
+   contract can stay identical but the pure-WASI provider drives `poll_oneoff`
+   while `edge.js` borrows the JS host's loop. **Out of scope here** (Phase 3).
+
+## Verdict on the JS-provider substrate
+
+`edge.js` is a **thin, dependency-free adapter** (≈ two closures over the
+instance's exported memory), not a framework. It is the right substrate precisely
+because it is thin: the only job is the pointer-ABI ↔ Buffer-ABI translation in
+wrinkle #1, which is irreducible. A heavier substrate would add nothing the ABI
+doesn't already pin. See #1772 Phase 1 for the byte-identical dual-provider proof.

--- a/examples/native-messaging/edge.js
+++ b/examples/native-messaging/edge.js
@@ -1,0 +1,118 @@
+// edge.js — a JS provider for the `node:fs` host-import interface (#1772 Phase 1).
+//
+// A js2wasm module compiled with `--target wasi --link-node-shims` imports its
+// fd-based synchronous IO from `node:fs`:
+//
+//   (import "node:fs" "memory"    (memory …))
+//   (import "node:fs" "readSync"  (func (param i32 i32 i32) (result i32)))
+//   (import "node:fs" "writeSync" (func (param i32 i32 i32) (result i32)))
+//
+// The module declares WHAT host API it needs (`node:fs`), never HOW it is
+// satisfied. Under wasmtime that interface is provided by the pure-WASI
+// `node-fs.wat` shim (which maps it to `fd_read`/`fd_write`). Under native Node
+// THIS adapter provides it by delegating to the REAL `node:fs` module over the
+// module's exported linear memory.
+//
+// The canonical per-member pointer-ABI (see docs/architecture/node-fs-abi.md):
+//
+//   readSync(fd, ptr, len) -> i32   read up to len bytes from fd into mem[ptr,ptr+len)
+//   writeSync(fd, ptr, len) -> i32  write mem[ptr,ptr+len) to fd
+//
+// `fd` is load-bearing: 0=stdin, 1=stdout, 2=stderr (writeSync(2,…) → stderr).
+// This is fd-based, filesystem-free — no path_open, no preopens.
+//
+// Calling-convention impedance: real `fs.readSync(fd, buffer, offset, length,
+// position)` ≠ the wasm `readSync(fd, ptr, len)`. So native Node is NEVER a
+// direct provider — this adapter translates pointer-ABI ↔ Buffer-ABI over the
+// shared memory. That irreducible translation is edge.js's entire job.
+
+import * as fs from "node:fs";
+
+/**
+ * Build a `node:fs` import object backed by the real Node `fs` module.
+ *
+ * Memory-ownership model (mirrors node-fs.wat): the PROVIDER owns + exports the
+ * linear memory; the user module imports memory index 0 from `node:fs`. So
+ * edge.js creates the `WebAssembly.Memory` and hands it to the user module
+ * alongside `readSync`/`writeSync`. There is no instantiation cycle — edge.js
+ * imports nothing from the user module.
+ *
+ * @param {object} [opts]
+ * @param {number} [opts.initialPages=3] initial memory size in 64KiB pages
+ *   (min 3 matches the user module's reservation; mirrors node-fs.wat).
+ * @param {number} [opts.maximumPages] optional max pages.
+ * @param {typeof import("node:fs")} [opts.fsImpl] override the fs backend
+ *   (defaults to the real `node:fs`); used by tests / JS+WASI polyfills.
+ * @returns {{ memory: WebAssembly.Memory, importObject: { "node:fs": object } }}
+ */
+export function createNodeFsProvider(opts = {}) {
+  const { initialPages = 3, maximumPages, fsImpl = fs } = opts;
+  const memory = new WebAssembly.Memory(
+    maximumPages != null ? { initial: initialPages, maximum: maximumPages } : { initial: initialPages },
+  );
+
+  // readSync(fd, ptr, len): fill mem[ptr,ptr+len) from fd. Real Node:
+  //   fs.readSync(fd, buffer, offset, length, position)
+  // position=null reads sequentially from the fd's cursor (works for pipes,
+  // ttys, and files alike). We read into a scratch Buffer then copy into wasm
+  // memory, because fs.readSync wants a Node Buffer, and a Buffer view onto the
+  // wasm ArrayBuffer can be invalidated by a memory.grow between calls.
+  const readSync = (fd, ptr, len) => {
+    if (len <= 0) return 0;
+    const scratch = Buffer.allocUnsafe(len);
+    let n;
+    try {
+      n = fsImpl.readSync(fd, scratch, 0, len, null);
+    } catch (e) {
+      // EOF on some platforms surfaces as an error; treat EOF/EAGAIN as 0.
+      if (e && (e.code === "EOF" || e.code === "EAGAIN")) return 0;
+      throw e;
+    }
+    if (n > 0) {
+      new Uint8Array(memory.buffer, ptr, n).set(scratch.subarray(0, n));
+    }
+    return n;
+  };
+
+  // writeSync(fd, ptr, len): write mem[ptr,ptr+len) to fd. Real Node:
+  //   fs.writeSync(fd, buffer, offset, length, position)
+  // We copy the wasm byte range into a standalone Buffer first (so a concurrent
+  // memory.grow can't detach the view mid-syscall), then write it. Returns the
+  // count written; a short write is legal and the caller loops.
+  const writeSync = (fd, ptr, len) => {
+    if (len <= 0) return 0;
+    const bytes = Buffer.from(new Uint8Array(memory.buffer, ptr, len)); // copy
+    return fsImpl.writeSync(fd, bytes, 0, len, null);
+  };
+
+  return {
+    memory,
+    importObject: { "node:fs": { memory, readSync, writeSync } },
+  };
+}
+
+/**
+ * Instantiate a js2wasm `node:fs`-importing module with edge.js as the provider
+ * and run its entry point. The module imports `node:fs` (memory + readSync +
+ * writeSync); edge.js owns the memory and delegates IO to real `node:fs`.
+ *
+ * @param {BufferSource} userBinary the compiled user wasm (imports node:fs).
+ * @param {object} [opts] forwarded to createNodeFsProvider, plus:
+ * @param {string} [opts.entry="main"] exported entry to invoke (falls back to
+ *   `_start`).
+ * @returns {Promise<{ instance: WebAssembly.Instance, memory: WebAssembly.Memory }>}
+ */
+export async function runWithEdge(userBinary, opts = {}) {
+  const { entry = "main", ...providerOpts } = opts;
+  const { memory, importObject } = createNodeFsProvider(providerOpts);
+  const { instance } = await WebAssembly.instantiate(userBinary, {
+    ...importObject,
+    env: {},
+  });
+  const run = instance.exports[entry] ?? instance.exports._start;
+  if (typeof run !== "function") {
+    throw new Error(`edge.js: user module exports no \`${entry}\` or \`_start\``);
+  }
+  run();
+  return { instance, memory };
+}

--- a/examples/native-messaging/run-edge.mjs
+++ b/examples/native-messaging/run-edge.mjs
@@ -1,0 +1,22 @@
+// run-edge.mjs — run a js2wasm `node:fs`-importing module under native Node via
+// the edge.js provider, with REAL fds 0/1/2 (#1772 Phase 1).
+//
+// Usage:  node run-edge.mjs <user.wasm>
+//
+// edge.js delegates `node:fs` readSync/writeSync to the REAL `node:fs` module,
+// so this process's actual stdin (fd 0) / stdout (fd 1) / stderr (fd 2) carry
+// the bytes. Pipe a framed Native Messaging message into stdin and the framed
+// echo comes back on stdout — exactly as under wasmtime + the node-fs.wat shim,
+// from the SAME compiled binary. This is the native-Node arm of the
+// same-binary dual-provider compatibility proof.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { runWithEdge } from "./edge.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const wasmPath = process.argv[2] ? resolve(process.argv[2]) : resolve(here, "out", "nm_js2wasm.wasm");
+
+const userBinary = readFileSync(wasmPath);
+await runWithEdge(userBinary, { entry: "main" });

--- a/plan/issues/1772-edgejs-node-wasi-shim-spike.md
+++ b/plan/issues/1772-edgejs-node-wasi-shim-spike.md
@@ -138,3 +138,80 @@ honors the same pointer-ABI per member.** The synchronous fd core (`readSync`/
   `fs.promises`) — gated on the event loop (#2632).
 - Path-based `node:fs` (`readFileSync(path)`, `open`) — needs a filesystem
   (`--allow-fs`/preopens); a separate capability tier from the fd-based core.
+
+---
+
+## Phase 0 — ABI (PINNED 2026-06-23)
+
+> Companion doc: [`docs/architecture/node-fs-abi.md`](../../docs/architecture/node-fs-abi.md).
+> This section is the normative pin; the doc expands the rationale.
+
+### Canonical per-member pointer-ABI (anchor members)
+
+The wasm import module is `"node:fs"` (real Node member names). Each member is a
+flat `(i32, …) -> i32` function over the module's **exported linear memory** —
+nothing GC-typed crosses the link:
+
+| Member      | Wasm import signature                     | Contract |
+|-------------|-------------------------------------------|----------|
+| `readSync`  | `(fd i32, ptr i32, len i32) -> i32`       | Read up to `len` bytes from descriptor `fd` into `mem[ptr, ptr+len)`. Returns the count actually read (`0` = EOF). MUST NOT write past `ptr+len`. |
+| `writeSync` | `(fd i32, ptr i32, len i32) -> i32`       | Write `mem[ptr, ptr+len)` to descriptor `fd`. Returns the count actually written (a short write is legal — callers loop). |
+
+`fd` is **load-bearing**: `0`=stdin, `1`=stdout, `2`=stderr. `writeSync(2, …)`
+routes telemetry to stderr, off the stdout protocol stream — a provider MUST
+honor the integer fd, never collapse all writes to stdout.
+
+This is the **single** ABI every provider implements. It is fd-based and
+filesystem-free (no `path_open`, no preopens). Path-based `node:fs`
+(`readFileSync(path)`) is a *different* capability tier (needs `--allow-fs`) and
+is rejected under `--target wasi`.
+
+**Caller ↔ ABI bridge.** Source code calls the *Node-shaped* signatures
+(`readSync(0, buf, { offset, length })`, `writeSync(1, buf, offset)`); the
+compiler bridges the GC/linear `Uint8Array` to the flat `(fd, ptr, len)` over the
+shared memory. So the **same `.ts`** runs unmodified under real `node` (where
+`node:fs` is the real module) *and* compiles to a wasm module whose imports honor
+the pointer-ABI above. The pointer-ABI is the wasm-link contract; the Node-shaped
+signature is the source-level contract. `edge.js` is exactly the adapter that
+reconciles the two on the native-Node path.
+
+### Memory-ownership / linking model
+
+**Today — shim-owned exported memory** (mirrors `examples/native-messaging/node-fs.wat`):
+
+1. The **provider owns and exports** the linear memory (`(memory (export "memory") 3)`).
+2. The **user module imports** memory index 0 from `"node:fs"` along with
+   `readSync`/`writeSync`. It declares NO memory of its own.
+3. No instantiation cycle: instantiate the provider first (it imports only its
+   own backing — `wasi_snapshot_preview1` for the `.wat` shim, or nothing for
+   `edge.js`), then instantiate the user module with `{ memory, readSync,
+   writeSync }` taken from the provider's exports.
+4. The provider reads/writes the user's bytes over the **same** memory. The
+   `.wat` shim builds its WASI iovec in reserved scratch at `mem[0, 12)`; `edge.js`
+   reads/writes the byte range directly from JS — no scratch needed.
+
+   (If a module uses **both** `node:process`/`console` IO and `node:fs`, the
+   `node-process` shim owns the memory and `node-fs` links the same bytes —
+   byte-identical layout, min 3 pages.)
+
+**Durable form — #2527 core-wasm linking.** The shim-owned-memory convention is
+a stop-gap that works on any plain `WebAssembly.instantiate`. The durable form is
+WebAssembly core-module linking (#2527): the user module and provider are linked
+as components/core modules with an explicitly shared memory, so neither side
+hard-codes "who owns memory". The pointer-ABI per member is unchanged by that
+migration — only the memory-binding mechanism changes.
+
+### Contract table — one binary, three providers
+
+The user's `nm_js2wasm.wasm` is **agnostic** to the provider. Compatibility holds
+**by construction** iff every provider honors the pointer-ABI above:
+
+| Host class | Provider | Satisfies `node:fs::readSync(fd, ptr, len) -> i32` by |
+|---|---|---|
+| **Pure WASI** (wasmtime, no JS) | `node-fs.wat`/`.wasm` shim (#2631) | WASI `fd_read`/`fd_write` over the shim-owned linear memory (iovec in `mem[0,12)`). |
+| **Native Node** (JS, no WASI) | **`edge.js` adapter** (Phase 1) | reads/writes `mem[ptr, ptr+len)` from JS, calls real `fs.readSync(fd, Buffer, 0, len, null)` / `fs.writeSync(fd, Buffer)`, copies bytes back, returns the count. |
+| **JS + WASI** (browser / Node-WASI) | `edge.js` over a WASI polyfill | delegates to a WASI `fd_read`/`fd_write` polyfill or platform fd APIs over the same memory. |
+
+The Phase-1 proof: the **same compiled binary** runs under (1) wasmtime via the
+`.wat` shim and (2) native Node via `edge.js`, with byte-identical output for the
+same stdin frames.

--- a/plan/issues/1772-edgejs-node-wasi-shim-spike.md
+++ b/plan/issues/1772-edgejs-node-wasi-shim-spike.md
@@ -1,9 +1,10 @@
 ---
 id: 1772
 title: "Node API imports from @types/node, satisfied by one ABI across pure-WASI shim / edge.js→node / JS+WASI hosts (anchor: node:fs readSync/writeSync)"
-status: ready
+status: in-progress
 created: 2026-06-01
-updated: 2026-06-23
+updated: 2026-06-24
+assignee: ttraenkler/agent-a9512a06
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -13,7 +14,7 @@ language_feature: node-api-compat
 goal: platform
 sprint: Backlog
 es_edition: n/a
-related: [389, 1575, 1766, 2527, 2528, 2624, 2625, 2631, 2632, 2083, 2181]
+related: [389, 1575, 1766, 2527, 2528, 2624, 2625, 2631, 2632, 2083, 2181, 2634, 2635]
 origin: "Follow-up from PR #1010 review direction; regrounded 2026-06-23 against the landed node:fs/node:process shim work"
 ---
 # #1772 — Node API imports from @types/node, one ABI, swappable host providers
@@ -215,3 +216,54 @@ The user's `nm_js2wasm.wasm` is **agnostic** to the provider. Compatibility hold
 The Phase-1 proof: the **same compiled binary** runs under (1) wasmtime via the
 `.wat` shim and (2) native Node via `edge.js`, with byte-identical output for the
 same stdin frames.
+
+---
+
+## Phase 1 — edge.js provider + compatibility proof (DONE 2026-06-24)
+
+**Result: the same-binary dual-provider proof works byte-identically.** ✓
+
+Deliverables (on `main` via this issue's PR):
+
+- `examples/native-messaging/edge.js` — a dependency-free native-Node provider of
+  the `node:fs` import interface. `createNodeFsProvider()` owns + exports the
+  linear memory (mirrors `node-fs.wat`) and implements `readSync(fd, ptr, len)` /
+  `writeSync(fd, ptr, len)` by translating the pointer-ABI ↔ Node Buffer-ABI over
+  that memory, delegating to the **real `node:fs`** (`fs.readSync(fd, buf, 0,
+  len, null)` / `fs.writeSync(fd, buf, 0, len, null)`). `runWithEdge()`
+  instantiates a compiled module with edge.js as the `node:fs` provider and runs
+  it.
+- `examples/native-messaging/run-edge.mjs` — runs a compiled module under edge.js
+  with **real fds** 0/1/2 (so real `node:fs` syscalls carry the bytes).
+- `tests/issue-1772-edge-dual-provider.test.ts` — the proof. It compiles **one**
+  `node:fs`-importing wasm binary and runs it under **both** providers:
+  - (a) **pure-WASI**: `node-fs.wat` shim under wasmtime
+    (`-W gc=y,function-references=y,tail-call=y,exceptions=y --preload
+    node:fs=<shim> --invoke main`);
+  - (b) **native Node**: `edge.js` → real `node:fs` over real fds (child process).
+  Both echo a framed message containing non-printable / high bytes
+  (`[0x05,0,0,0, 0x00,0xff,0x0a,0x7f,0x80]`) **byte-for-byte identically** — a
+  UTF-8-collapsing provider would diverge on `0x00`/`0xff`/`0x80`. Test green.
+
+**Verdict on the JS-provider substrate (acceptance item).** `edge.js` is the
+right substrate, and it is a **thin, dependency-free adapter** (two closures over
+the instance's exported memory), **not** a framework. The only irreducible job is
+the pointer-ABI ↔ Buffer-ABI translation (calling-convention impedance wrinkle):
+real `fs.readSync(fd, buffer, offset, length, position)` ≠ wasm `readSync(fd,
+ptr, len)`, so native Node is never a *direct* provider — it always needs this
+adapter. A heavier "edge.js framework" would add nothing the pinned ABI doesn't
+already specify. One implementation detail worth recording: edge.js copies the
+wasm byte range into a standalone `Buffer` before each syscall (rather than
+passing a `Uint8Array` view onto `memory.buffer` directly), because a
+`memory.grow` between calls can detach a cached view — copying keeps the adapter
+correct across growth.
+
+### Phase status
+
+- **Phase 0 — ABI**: ✅ done (pinned above + `docs/architecture/node-fs-abi.md`).
+- **Phase 1 — edge.js + proof**: ✅ done (byte-identical dual-provider proof).
+- **Phase 2 — `@types/node` → capability map**: ⏭️ split out to **#2634**.
+- **Phase 3 — async members**: ⏭️ split out to **#2635** (blocked on #2632).
+
+Issue stays `in-progress` because Phase 2 (#2634) remains. Phases 0+1 acceptance
+criteria are met.

--- a/plan/issues/2634-node-types-capability-map-extraction.md
+++ b/plan/issues/2634-node-types-capability-map-extraction.md
@@ -1,0 +1,56 @@
+---
+id: 2634
+title: "@types/node → capability-map extraction for node:fs (Phase 2 of #1772)"
+status: ready
+created: 2026-06-24
+updated: 2026-06-24
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: feature
+area: host-interop
+language_feature: node-api-compat
+goal: platform
+sprint: Backlog
+es_edition: n/a
+related: [1772, 2624, 2625, 2631, 2528, 2083, 2181, 2527]
+origin: "Phase 2 split out of #1772 once Phase 0 (ABI) + Phase 1 (edge.js dual-provider proof) landed"
+---
+# #2634 — @types/node → capability-map extraction (node:fs)
+
+Phase 2 of #1772. Phases 0 (the `node:fs` pointer-ABI, `docs/architecture/node-fs-abi.md`)
+and 1 (the `edge.js` provider + same-binary dual-provider proof,
+`examples/native-messaging/edge.js`, `tests/issue-1772-edge-dual-provider.test.ts`)
+are done. This issue replaces the hand-written minimal typings with extraction
+from `@types/node`, gated by a capability map.
+
+## Problem
+
+The compiler today recognizes a hand-written minimal set of `node:fs` members
+(`buildNodeEnvDts` / `scanNodeEmuUsage`, #2624). The type surface of
+`@types/node` is thousands of members, but only the subset with a runtime
+provider (a `.wat` shim, an `edge.js` adapter, or a WASI mapping) is *linkable*.
+
+Without a capability gate, a program type-checks against the full `@types/node`
+surface then fails to **link** with an opaque error when it calls a member no
+provider satisfies.
+
+## Scope
+
+- Drive the importable surface + types from `@types/node` (compose with #2528
+  `--platform node`), replacing/extending the hand-written `buildNodeEnvDts`.
+- Gate against a **capability map**: `@types/node` member → provider fn → host
+  classes that can provide it. Only runtime-satisfiable members type-check clean.
+- An **unsatisfiable** member (typed in `@types/node`, no provider) must produce
+  a precise, deliberate compile error ("no provider for `node:fs.openSync` under
+  `--target wasi`"), never a silent link failure.
+- Anchor members: `node:fs` `readSync`/`writeSync` (already linkable per the
+  Phase 0 ABI). Extend the map structure so adding `node:process`/`node:os`
+  members later is a data change, not a code change.
+
+## Acceptance
+
+- A working `@types/node` → capability-map extraction for the anchor `node:fs`
+  members, with the deliberate-error path for unsatisfiable members.
+- Follow-up issues filed for further surfaces (process/os/path tiers).
+- This is #1772 Phase 2; #2635 covers Phase 3 (async members, gated on #2632).

--- a/plan/issues/2635-node-async-members-event-loop.md
+++ b/plan/issues/2635-node-async-members-event-loop.md
@@ -1,0 +1,53 @@
+---
+id: 2635
+title: "Async node:fs / process.stdin members over the event loop (Phase 3 of #1772)"
+status: blocked
+created: 2026-06-24
+updated: 2026-06-24
+priority: low
+feasibility: hard
+reasoning_effort: high
+task_type: feature
+area: host-interop
+language_feature: node-api-compat
+goal: platform
+sprint: Backlog
+es_edition: n/a
+depends_on: [2632]
+related: [1772, 2631, 2632, 2634]
+origin: "Phase 3 split out of #1772; gated on the WASI async event loop (#2632)"
+---
+# #2635 — async Node members over the event loop (Phase 3)
+
+Phase 3 of #1772. The fd-based synchronous `node:fs` core (`readSync`/`writeSync`)
+is portable across all three host classes today (Phase 0 ABI + Phase 1 proof,
+both landed). The **async** Node surface is not, and is gated on the event loop.
+
+## Problem
+
+Node's async surface — `process.stdin` as a `Readable`, `fs.promises.*`,
+EventEmitter-driven IO — has no synchronous fd primitive to lower to. The
+`node:fs` pointer-ABI (`docs/architecture/node-fs-abi.md`) can stay identical in
+shape, but each provider must drive a loop:
+
+- the pure-WASI provider drives `poll_oneoff` over the shim;
+- `edge.js` borrows the JS host's event loop.
+
+Both require a real async runtime, which is #2632 (WASI async event-loop reactor).
+
+## Scope (deferred until #2632 lands)
+
+- Extend the `node:fs` interface (and `node:process`) with the async members,
+  keeping the per-member ABI contract from Phase 0.
+- Pure-WASI provider: drive `poll_oneoff`; `edge.js`: delegate to the JS loop.
+- Same-binary dual-provider proof extended to an async member.
+
+## Acceptance
+
+- Blocked on #2632. When unblocked: one async `node:fs`/`process.stdin` member
+  runs under both providers from the same compiled binary, with a test.
+
+## Out of scope
+
+- Path-based `node:fs` (`readFileSync(path)`, `open`) — separate capability tier
+  needing a filesystem (`--allow-fs`/preopens), not async-gated.

--- a/tests/issue-1772-edge-dual-provider.test.ts
+++ b/tests/issue-1772-edge-dual-provider.test.ts
@@ -1,0 +1,128 @@
+// #1772 Phase 1 — same-binary dual-provider compatibility proof.
+//
+// One compiled `node:fs`-importing wasm binary runs under TWO providers:
+//   (a) the pure-WASI `node-fs.wat` shim under wasmtime, and
+//   (b) the `edge.js` adapter under native Node (delegating to real `node:fs`),
+// and produces BYTE-IDENTICAL output for the same stdin frames. This is the
+// concrete proof that the `node:fs` host-import ABI (docs/architecture/
+// node-fs-abi.md, #1772 Phase 0) is provider-agnostic by construction.
+//
+// The wasm binary is compiled ONCE here; both arms consume the same bytes.
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildNodeFsShim } from "../scripts/build-node-fs-shim.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = resolve(HERE, "..");
+const EDGE_RUNNER = join(REPO, "examples", "native-messaging", "run-edge.mjs");
+
+// A framed-echo host: read a 4-byte LE length prefix + body off fd 0, echo both
+// back to fd 1. Uses the Node-shaped readSync(options) / writeSync(offset)
+// signatures so the SAME source also runs unmodified under real `node`.
+const FRAMED_ECHO = `
+import { readSync, writeSync } from "node:fs";
+function readExact(buf: Uint8Array, n: number): boolean {
+  let got = 0;
+  while (got < n) {
+    const r = readSync(0, buf, { offset: got, length: n - got });
+    if (r <= 0) return false;
+    got = got + r;
+  }
+  return true;
+}
+function writeAll(out: Uint8Array): void {
+  let n = 0;
+  while (n < out.length) {
+    const w = writeSync(1, out, n);
+    if (w <= 0) return;
+    n = n + w;
+  }
+}
+export function main(): void {
+  const header = new Uint8Array(4);
+  if (!readExact(header, 4)) return;
+  const len = header[0] + header[1] * 256 + header[2] * 65536 + header[3] * 16777216;
+  const body = new Uint8Array(len);
+  if (!readExact(body, len)) return;
+  writeAll(header);
+  writeAll(body);
+}
+`;
+
+// A frame with non-printable / high bytes, so a UTF-8-collapsing provider would
+// diverge: len=5 (LE) + body [0x00, 0xff, 0x0a, 0x7f, 0x80].
+const FRAME = Uint8Array.from([0x05, 0x00, 0x00, 0x00, 0x00, 0xff, 0x0a, 0x7f, 0x80]);
+const EXPECTED = Array.from(FRAME); // strict echo: header + body verbatim
+
+function hasWasmtime(): boolean {
+  try {
+    execFileSync("wasmtime", ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("#1772 — node:fs same-binary dual-provider compatibility", () => {
+  let tmp: string;
+  let userBinary: Uint8Array;
+
+  beforeAll(async () => {
+    const result = await compile(FRAMED_ECHO, {
+      fileName: "nm.ts",
+      target: "wasi",
+      linkNodeShims: true,
+    });
+    expect(result.success, JSON.stringify(result.errors)).toBe(true);
+    userBinary = result.binary;
+    tmp = mkdtempSync(join(tmpdir(), "edge-dual-"));
+  });
+
+  afterAll(() => {
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+  });
+
+  // Provider (b): edge.js under native Node, delegating to real node:fs over
+  // real fds. Spawn run-edge.mjs as a child so fd 0/1 are real pipes; feed FRAME
+  // on stdin and capture the framed echo on stdout.
+  it("provider (b): edge.js under native Node echoes the frame byte-for-byte", () => {
+    const wasmPath = join(tmp, "nm_edge.wasm");
+    writeFileSync(wasmPath, userBinary);
+    const stdout = execFileSync(process.execPath, [EDGE_RUNNER, wasmPath], {
+      input: Buffer.from(FRAME),
+      maxBuffer: 4 * 1024 * 1024,
+    });
+    expect(Array.from(stdout)).toEqual(EXPECTED);
+  });
+
+  // Provider (a): node-fs.wat shim under wasmtime, from the SAME binary.
+  it.runIf(hasWasmtime())(
+    "provider (a): node-fs.wat under wasmtime echoes the same bytes; both providers agree",
+    () => {
+      const wasmPath = join(tmp, "nm_wasi.wasm");
+      const shimPath = join(tmp, "node-fs.wasm");
+      writeFileSync(wasmPath, userBinary);
+      writeFileSync(shimPath, buildNodeFsShim());
+
+      const wasmtimeOut = execFileSync(
+        "wasmtime",
+        ["run", "--preload", `node:fs=${shimPath}`, "--invoke", "main", wasmPath],
+        { input: Buffer.from(FRAME), maxBuffer: 4 * 1024 * 1024 },
+      );
+
+      const edgeOut = execFileSync(process.execPath, [EDGE_RUNNER, wasmPath], {
+        input: Buffer.from(FRAME),
+        maxBuffer: 4 * 1024 * 1024,
+      });
+
+      // The core claim: identical output from the SAME binary under both providers.
+      expect(Array.from(wasmtimeOut)).toEqual(EXPECTED);
+      expect(Array.from(edgeOut)).toEqual(Array.from(wasmtimeOut));
+    },
+  );
+});

--- a/tests/issue-1772-edge-dual-provider.test.ts
+++ b/tests/issue-1772-edge-dual-provider.test.ts
@@ -109,9 +109,21 @@ describe("#1772 — node:fs same-binary dual-provider compatibility", () => {
       writeFileSync(wasmPath, userBinary);
       writeFileSync(shimPath, buildNodeFsShim());
 
+      // js2wasm emits a WasmGC module, so enable the GC/function-references/
+      // tail-call/exceptions proposals (mirrors examples/native-messaging/
+      // smoke-test.sh's WASMTIME_FLAGS).
       const wasmtimeOut = execFileSync(
         "wasmtime",
-        ["run", "--preload", `node:fs=${shimPath}`, "--invoke", "main", wasmPath],
+        [
+          "run",
+          "-W",
+          "gc=y,function-references=y,tail-call=y,exceptions=y",
+          "--preload",
+          `node:fs=${shimPath}`,
+          "--invoke",
+          "main",
+          wasmPath,
+        ],
         { input: Buffer.from(FRAME), maxBuffer: 4 * 1024 * 1024 },
       );
 


### PR DESCRIPTION
## #1772 Phases 0 + 1 — Node API imports, one ABI, swappable host providers

Anchor surface: **node:fs readSync/writeSync** (fd-based, filesystem-free), building on #2631.

### Phase 0 — pin the ABI
- `docs/architecture/node-fs-abi.md` + issue `## Phase 0` section pin the canonical per-member **pointer-ABI**: `readSync(fd,ptr,len)->i32` / `writeSync(fd,ptr,len)->i32` over the module's exported linear memory. `fd` is load-bearing (`writeSync(2,…)` → stderr).
- Memory-ownership/linking model: shim-owned exported memory today (mirrors `node-fs.wat`); #2527 core-wasm linking as the durable form.
- Contract table: same binary, three providers (pure-WASI `.wat` / edge.js→node / JS+WASI).

### Phase 1 — edge.js provider + compatibility proof (the deliverable)
- `examples/native-messaging/edge.js` — native-Node provider of the `node:fs` interface, delegating readSync/writeSync to **real `node:fs`** over the module's exported memory (pointer-ABI ↔ Buffer-ABI translation). `run-edge.mjs` runs a compiled module with real fds.
- **The proof** (`tests/issue-1772-edge-dual-provider.test.ts`): the **same compiled `nm_js2wasm` wasm binary** runs under **(a)** wasmtime via `node-fs.wat` and **(b)** native Node via `edge.js`, and produces **byte-identical** output for the same stdin frames — including non-printable/high bytes (`0x00 0xff 0x0a 0x7f 0x80`) that a UTF-8-collapsing provider would corrupt. ✅ green.

### Verdict
edge.js is the right JS-provider substrate — a **thin, dependency-free adapter** (two closures over exported memory), not a framework. The pointer-ABI ↔ Buffer-ABI translation is its only irreducible job (real `fs.readSync(fd,buffer,offset,length,position)` ≠ wasm `readSync(fd,ptr,len)`, so native Node is never a *direct* provider).

### Phasing
- Phase 0 ✅, Phase 1 ✅. Issue stays **in-progress** for Phase 2.
- Phase 2 (@types/node → capability map) split to **#2634**; Phase 3 (async members) to **#2635** (blocked on #2632).

### Validation
- `tests/issue-1772-edge-dual-provider.test.ts` (2 tests) + `tests/issue-2631-node-fs-fd-shim.test.ts` (6) green; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)