### PR TITLE
fix(#2618): Proxy START-timing + callable-target wrap (slice 1, pure runtime)

### DIFF
--- a/plan/issues/2618-proxy-host-apply-construct-call-path.md
+++ b/plan/issues/2618-proxy-host-apply-construct-call-path.md
@@ -1,12 +1,13 @@
 ---
 id: 2618
 title: "Proxy (host): calling / constructing a Proxy whose target is callable traps (illegal cast) or ignores the construct trap result (~15 fails)"
-status: blocked
+status: in-progress
+assignee: ttraenkler/sd-2618
 sprint: 65
 created: 2026-06-22
-updated: 2026-06-23
+updated: 2026-06-24
 blocked_on: [56]
-reconcile_note: "DEFERRED 2026-06-23 — per #1944 investigation the prototype was net-negative (+4/-1 hard PASS→ERR). Depends on #2615 (landed) AND blocked on sd-1838's #56 call/construct-dispatch rework (the __fn_tramp_Constructor cross-realm path). Defer until #56 lands; not staffing-ready."
+reconcile_note: "SLICE 1 LANDING 2026-06-24 (sd-2618): pure-runtime START-timing + callable-target [[ProxyTarget]] wrap. Verified per-process (faithful test262 wrap): +1 gc row (apply/call-parameters fail→pass), zero local regressions. REMAINING (deferred, deep #56 dispatch substrate): externref-callee CALL dispatch (multi-arg p.call(a,b) → illegal cast, tryEmitInlineDynamicCall) + dynamic-new construct-result routing (new p() → 'is not a constructor', tryEmitDynamicNew). See '## Slice 1 (sd-2618, 2026-06-24)'."
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -167,3 +168,92 @@ rework lands (the capability bridge), then the apply+construct routing becomes
 result". Coordinate with sd-1838 before editing shared trampoline/call-dispatch.
 The runtime target-wrap (change 1) can land independently if useful. Branch was
 restored to pristine `origin/main`; no PR opened.
+
+---
+
+## Slice 1 (sd-2618, 2026-06-24) — START-timing + callable-target wrap (pure runtime)
+
+**Verify-first re-grounding against current `origin/main` (faithful per-PROCESS
+test262 wrap: `parseMeta` + `wrapTest` + `compileSource` + `buildImports` +
+`setExports`, one node process per file — NOT in-process `runTest262File`
+loops).** Reconfirmed all three sd-2623 prerequisites per-process; two of the
+three framings have MOVED since the 2026-06-22 spec.
+
+### Re-grounding evidence (current main, faithful runner)
+
+| Probe | Prior framing | ACTUAL on current main (per-process) |
+|---|---|---|
+| **START-timing** (top-level `new Proxy(...)`) | "null-derefs at `_hostProxyConstruct`" | **REAL but no crash** — the eager bridge builds with `getExports()` undefined, so EVERY trap is mis-resolved and the host falls back to its default internal methods. A genuine module-top-level `new Proxy({a:1},{get:()=>99}).x` returned the **target's** value (effectively `0`/dropped), NOT `99`. **Verified flip with fix: 99.** BUT — see below — **test262's harness never triggers it.** |
+| START-timing's test262 reach | (assumed it blocks the rows) | **test262 `wrapTest` injects `var p = new Proxy(...)` INSIDE the synthetic `export function test()` body** (proxy at wrapped-line 46, `function test` at line 38). So in the harness EVERY proxy is built post-`setExports`; START-timing **flips 0 test262 rows**. It is a latent correctness fix for genuine module-scope proxies only. |
+| `apply/call-parameters.js` | `illegal cast in __call_fn_method_3` | `FAIL: call is not a function` (proxy of a wasm-closure target is not host-callable). **Fixed by the callable-target wrap → PASS (+1 row).** |
+| `apply/call-result.js` & most apply rows | illegal cast | still `FAIL illegal cast` — the externref-callee **CALL dispatch** (`p.call(...)`) casts in codegen; NOT fixed by this slice. |
+| `construct/call-result.js`, `construct/call-parameters*.js` | trap result dropped | `FAIL: … is not a constructor` / `No dependency provided for extern class "P"` — the **dynamic-new** path (`tryEmitDynamicNew`) doesn't route an externref Proxy ctor through host `[[Construct]]`; NOT fixed by this slice. |
+
+### What this slice changes (PURE RUNTIME — `src/runtime.ts` only; NO codegen)
+
+1. **START-timing lazy bridge** (`_buildProxyBridgeHandler` → `_buildLazyProxyBridgeHandler`
+   + `_proxyForwardDefault`): when `getExports()` is undefined at construct time
+   (a module-top-level `new Proxy`), defer trap resolution to first invocation
+   (post-`setExports`, when the program actually calls through the proxy). The
+   eager branch (exports present) is byte-for-byte unchanged. Absent-trap →
+   forward to the target default (§7.3.10); non-callable trap → TypeError
+   (§7.3.10 GetMethod); callable trap → forward with `this` = raw handler.
+2. **Callable-target [[ProxyTarget]] wrap** (`_proxyTargetFor` in
+   `_hostProxyConstruct` / `_hostProxyConstructRevocable`): a Proxy whose target
+   is a wasm closure must be host-callable (V8 derives [[Call]]/[[Construct]]
+   from [[ProxyTarget]]; a raw struct is not callable). Use the target's
+   `_maybeWrapCallableUnknownArity` JS wrapper as [[ProxyTarget]]; the bridge
+   substitutes the **raw struct** back as the apply/construct trap's `target`
+   arg (`_wrapPlainHandlerForRawTarget` for plain-JS handlers; `rawTarget` arg
+   threaded through both eager + lazy WasmGC-handler paths) so
+   `assert.sameValue(t, target)` holds (`apply/call-parameters.js`).
+
+### Verified result (per-process faithful runner, gc mode)
+- `built-ins/Proxy/{apply,construct}` non-realm matrix (29 files): **baseline 14
+  PASS → fix 15 PASS, exactly +1** (`apply/call-parameters.js` fail→pass), **zero
+  regressions** (byte-for-byte identical on all other rows).
+- `get`/`has`/`set`/`defineProperty`/`getPrototypeOf`/`ownKeys`/`deleteProperty`
+  `call-parameters` rows: identical baseline↔fix (they already pass; the
+  identity wrap doesn't disturb them).
+- vitest proxy/reflect/closure suites (`issue-2615/2616/2180/1466`,
+  `proxy-passthrough`, `struct-proxy-wrappers`, `issue-1312`,
+  `issue-1712-capture-closure-dispatch`): the 8 fails are **PRE-EXISTING on
+  pristine `origin/main`** (verified by reverting `runtime.ts` and re-running) —
+  no new regressions from this slice.
+- `tests/issue-2618.test.ts` (6 cases, green): top-level get/has/set/apply traps
+  fire; top-level==inner no-trap parity; apply-result via `p.call()`.
+
+### Broad-impact note (validation gate)
+The target-wrap changes `[[ProxyTarget]]` for **every** callable-target proxy
+(not just test262 ones) — affects `proxy===target` probes, `_userProxies`
+reverse-mapping, `typeof`/`instanceof`. Per `project_broad_impact_validate_full_ci`
+the **merge_group floor (#2097) is authoritative**; this PR is full-gate via
+merge_group, not a scoped sweep.
+
+### REMAINING work — prerequisite ordering (deferred, the deep #56 dispatch zone)
+
+The two remaining failure classes are **codegen call/construct dispatch**, NOT
+runtime — exactly the `#56` substrate sd-2623 flagged. They are a separate
+slice and MUST NOT be forced half-built into this PR (the #1888-class floor-eject
+hazard):
+
+1. **Slice 2618-apply-dispatch** — `p.call(a, b)` / `p(args)` for an
+   externref-Proxy callee still casts (`illegal cast`). Locus
+   `src/codegen/expressions/calls.ts` `tryEmitInlineDynamicCall` (the closure-
+   struct dispatch chain whose default `else` is `ref.null.extern`; route an
+   externref-Proxy callee through `__call_function`/host apply). Confirmed
+   fragile: no-arg `p.call()` works (host apply MOP), but multi-arg
+   `p.call(a,b)` → illegal cast — the dispatch is only partially functional
+   without this. **This is the broad-impact dispatch change; full-CI before
+   landing.**
+2. **Slice 2618-construct** — `new p()` for an externref-Proxy ctor fails (`is
+   not a constructor` / `No dependency provided for extern class`). Locus
+   `src/codegen/expressions/new-super.ts` `tryEmitDynamicNew` — route through host
+   `[[Construct]]`/`Reflect.construct` and USE the trap result as the new object
+   (§10.5.13). The runtime callable-target wrap (this slice) already makes the
+   Proxy host-constructable, so slice 2618-construct narrows to the codegen
+   routing + threading the construct-trap result + `new.target`.
+
+Ordering: **this slice (runtime, foundational) FIRST** → then 2618-apply-dispatch
+and 2618-construct (each its own PR, each merge_group-floor-validated). Neither
+touches the value-rep substrate (#2580) or the `__call_fn_N` funcref loop body.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -5046,13 +5046,23 @@ function _hostProxyConstruct(
   if (!_isObjectLike(handler)) {
     throw new TypeError(`Cannot create ${ctor} with a non-object as handler`);
   }
-  const bridgeHandler = _buildProxyBridgeHandler(handler, callbackState);
-  // Use the raw target as [[ProxyTarget]] so `t === target` holds in traps and
-  // `proxy`-vs-`target` identity probes resolve. WasmGC structs are valid
-  // exotic targets for the host engine; the bridge handler routes every MOP
-  // operation through the user trap (or, when a trap is absent, the host's
-  // default which reads the struct via the same boundary helpers).
-  const proxy = new Proxy(target, bridgeHandler);
+  // (#2618) A Proxy whose target is CALLABLE is itself callable / constructable
+  // (§10.5.12 / §10.5.13). The host engine derives the proxy's [[Call]] /
+  // [[Construct]] exotic-ness from its [[ProxyTarget]] — but a raw wasm-closure
+  // struct is NOT callable to V8, so `new Proxy(rawClosure, h)()` fails the host
+  // IsCallable check ("... is not a function" / "call is not a function"). When
+  // the user's target is a wasm closure, use its JS-callable wrapper as the
+  // [[ProxyTarget]] so the proxy gains [[Call]]/[[Construct]] and host-side
+  // `p(...)` / `p.call(...)` dispatch correctly. The bridge handler substitutes
+  // the RAW struct back as the `target` argument of the apply/construct traps
+  // (see `rawTarget` in `_buildProxyBridgeHandler`) so the user-observable trap
+  // `target` is identity-equal to the value the program passed to `new Proxy`
+  // (`assert.sameValue(t, target)` in apply/construct/call-parameters.js). A
+  // non-callable target keeps the raw struct as before (identity-preserving, no
+  // behavior change).
+  const { proxyTarget, rawTarget } = _proxyTargetFor(target, callbackState);
+  const bridgeHandler = _buildProxyBridgeHandler(handler, callbackState, rawTarget);
+  const proxy = new Proxy(proxyTarget, bridgeHandler);
   _userProxies.add(proxy);
   return proxy;
 }
@@ -5069,10 +5079,36 @@ function _hostProxyConstructRevocable(
   if (!_isObjectLike(handler)) {
     throw new TypeError("Cannot create proxy with a non-object as handler");
   }
-  const bridgeHandler = _buildProxyBridgeHandler(handler, callbackState);
-  const rv = Proxy.revocable(target, bridgeHandler);
+  // (#2618) Mirror `_hostProxyConstruct`: a callable target makes the revocable
+  // proxy callable/constructable; use its JS wrapper as [[ProxyTarget]] and
+  // restore the raw struct in the apply/construct traps.
+  const { proxyTarget, rawTarget } = _proxyTargetFor(target, callbackState);
+  const bridgeHandler = _buildProxyBridgeHandler(handler, callbackState, rawTarget);
+  const rv = Proxy.revocable(proxyTarget, bridgeHandler);
   if (rv && typeof rv.proxy === "object" && rv.proxy !== null) _userProxies.add(rv.proxy);
   return rv;
+}
+
+/**
+ * (#2618) Decide the host [[ProxyTarget]] for a user `new Proxy(target, …)`.
+ * If `target` is a wasm-closure struct, V8 cannot treat it as callable, so a
+ * proxy built on it is not callable/constructable host-side. Wrap it into a
+ * JS-callable function and use THAT as [[ProxyTarget]] (gives the proxy
+ * [[Call]]/[[Construct]]); return `rawTarget` = the original struct so the
+ * apply/construct trap bridge can substitute it back for target identity. For a
+ * non-callable target (or when exports aren't wired yet so the wrap can't be
+ * built), keep the raw target unchanged and signal "no substitution"
+ * (`rawTarget === undefined`).
+ */
+function _proxyTargetFor(
+  target: any,
+  callbackState: { getExports: () => Record<string, Function> | undefined } | undefined,
+): { proxyTarget: any; rawTarget: any } {
+  const callable = _maybeWrapCallableUnknownArity(target, callbackState);
+  if (typeof callable === "function" && callable !== target) {
+    return { proxyTarget: callable, rawTarget: target };
+  }
+  return { proxyTarget: target, rawTarget: undefined };
 }
 
 /**
@@ -5111,12 +5147,54 @@ function _structFieldRaw(obj: any, name: string, exports: Record<string, Functio
 function _buildProxyBridgeHandler(
   handler: any,
   callbackState: { getExports: () => Record<string, Function> | undefined } | undefined,
+  // (#2618) When the proxy's [[ProxyTarget]] is a substituted JS-callable
+  // WRAPPER (because the user's target was a wasm closure V8 can't treat as
+  // callable), the engine passes that wrapper as `args[0]` to the
+  // `apply`/`construct` traps. `rawTarget` is the original struct the user
+  // passed to `new Proxy`; the apply/construct bridge substitutes it back so
+  // `assert.sameValue(trapTarget, target)` holds. `undefined` ⇒ no substitution
+  // (non-callable target, identity-preserving — the prior behavior).
+  rawTarget?: any,
 ): any {
   // Plain JS handler (created host-side, not a WasmGC struct) already exposes
-  // its traps directly — use it verbatim so identity/`this` are untouched.
-  if (!_isWasmStruct(handler)) return handler;
+  // its traps directly. BUT if the [[ProxyTarget]] is a substituted callable
+  // wrapper, even a plain-JS handler's apply/construct trap would observe the
+  // wrapper as `target` — so wrap just those two traps to restore the raw
+  // target. With no substitution this returns the handler verbatim (identity /
+  // `this` untouched, exactly as before).
+  if (!_isWasmStruct(handler)) {
+    return rawTarget === undefined ? handler : _wrapPlainHandlerForRawTarget(handler, rawTarget);
+  }
 
   const exports = callbackState?.getExports();
+
+  // (#2618) START-timing: a TOP-LEVEL `new Proxy(target, handler)` — the
+  // dominant test262 shape (`var p = new Proxy(...)` at module scope; every
+  // non-realm `built-ins/Proxy/{apply,construct}/*` file does this) — runs
+  // inside the wasm module's START function, BEFORE `setExports` wires
+  // `__is_closure` and the `__sget_*` field getters. With `exports` still
+  // undefined we can neither (a) read each trap field off the WasmGC handler
+  // struct (`__sget_<name>` unavailable, so `_structFieldRaw` falls through to a
+  // sidecar miss) nor (b) classify a found field as a wasm closure
+  // (`__is_closure` unavailable → `_maybeWrapCallableUnknownArity` returns the
+  // raw struct). The previous eager build therefore lost EVERY user trap on a
+  // top-level proxy: the host fell back to its default internal methods (so
+  // `p.x` / `p()` / `new p()` silently returned the WRONG value — verified:
+  // top-level `new Proxy({a:1},{get:()=>99}).x` returned the target's value,
+  // not 99). The program only INVOKES the proxy later, from an exported
+  // function, by which time exports ARE wired — so deferring trap resolution
+  // to invocation time recovers correct behaviour.
+  //
+  // Fix: when exports are not yet available, build a lazy bridge whose traps
+  // resolve the underlying user trap on first invocation through the
+  // now-wired exports. Fully self-contained — no global proxy registry, no
+  // setExports replay. The common case (exports present at construct time, i.e.
+  // a proxy built inside an exported function) is unchanged: the eager branch
+  // below is byte-for-byte the prior logic.
+  if (!exports) {
+    return _buildLazyProxyBridgeHandler(handler, callbackState, rawTarget);
+  }
+
   const bridge: Record<string, any> = {};
   for (const name of _PROXY_TRAP_NAMES) {
     const rawTrap = _structFieldRaw(handler, name, exports);
@@ -5142,11 +5220,128 @@ function _buildProxyBridgeHandler(
     // body's `this` is the same value the program sees as `handler` and
     // `assert.sameValue(this, handler)` passes. Spec-correct args (raw target,
     // property key, receiver = our user Proxy) flow through unchanged.
+    //
+    // (#2618) For the `apply`/`construct` traps, when the [[ProxyTarget]] is a
+    // substituted callable wrapper, V8 passes that wrapper as args[0]; restore
+    // the raw struct so the trap's `target` parameter is identity-equal to the
+    // value the program passed to `new Proxy` (apply/construct/call-parameters).
+    const substituteTarget = rawTarget !== undefined && (name === "apply" || name === "construct");
     bridge[name] = function (this: any, ...args: any[]): any {
+      if (substituteTarget && args.length > 0) args[0] = rawTarget;
       return (callable as Function).apply(handler, args);
     };
   }
   return bridge;
+}
+
+/**
+ * (#2618) Wrap a plain-JS handler so its `apply`/`construct` traps see the raw
+ * wasm-struct target instead of the substituted callable wrapper installed as
+ * [[ProxyTarget]]. Every other trap is copied through unchanged so identity /
+ * `this` are preserved.
+ */
+function _wrapPlainHandlerForRawTarget(handler: any, rawTarget: any): any {
+  const wrapped: Record<string, any> = {};
+  for (const k of Reflect.ownKeys(handler)) wrapped[k as string] = (handler as any)[k];
+  for (const tn of ["apply", "construct"] as const) {
+    const userTrap = (handler as any)[tn];
+    if (typeof userTrap === "function") {
+      wrapped[tn] = function (this: any, _t: any, ...rest: any[]): any {
+        return userTrap.call(this, rawTarget, ...rest);
+      };
+    }
+  }
+  return wrapped;
+}
+
+/**
+ * (#2618) START-timing bridge for a WasmGC-struct handler built BEFORE
+ * `setExports` (a top-level `new Proxy(...)`). Trap fields can't be read or
+ * classified at construct time, so install a thunk for EVERY MOP name; each
+ * thunk resolves the underlying user trap lazily on first invocation — by which
+ * point the program is running an exported function and exports are wired.
+ *
+ * Lazy semantics deliberately mirror the eager builder so behaviour is
+ * identical whether the proxy was built before or after `setExports`:
+ *  - field absent (undefined/null) at resolve time → forward to the target's
+ *    DEFAULT internal method (§7.3.10 missing trap), exactly as omitting the
+ *    bridge key would have made the host do.
+ *  - field present but non-callable → TypeError (§7.3.10 GetMethod), same text
+ *    as the eager throwing stub.
+ *  - field a callable closure → forward to it with `this` = the raw handler
+ *    struct (identity-preserving), same as the eager path.
+ */
+function _buildLazyProxyBridgeHandler(
+  handler: any,
+  callbackState: { getExports: () => Record<string, Function> | undefined } | undefined,
+  rawTarget?: any,
+): any {
+  const bridge: Record<string, any> = {};
+  for (const name of _PROXY_TRAP_NAMES) {
+    const substituteTarget = rawTarget !== undefined && (name === "apply" || name === "construct");
+    bridge[name] = function (this: any, ...args: any[]): any {
+      const lateExports = callbackState?.getExports();
+      const rawTrap = _structFieldRaw(handler, name, lateExports);
+      if (rawTrap == null) {
+        // Trap genuinely absent → forward to the target's default internal
+        // method. `args[0]` is the [[ProxyTarget]] (the callable WRAPPER when a
+        // wasm-closure target was substituted) — forward through it unchanged so
+        // a default apply/construct lands on a host-callable value.
+        return _proxyForwardDefault(name, args);
+      }
+      // (#2618) restore the raw target for apply/construct (see eager path) only
+      // when actually invoking the user trap, so the trap's `target` parameter
+      // is identity-equal to what the program passed to `new Proxy`.
+      if (substituteTarget && args.length > 0) args[0] = rawTarget;
+      const callable = _maybeWrapCallableUnknownArity(rawTrap, callbackState);
+      if (typeof callable !== "function") {
+        throw new TypeError(`'${name}' on proxy: trap is not a function`);
+      }
+      return (callable as Function).apply(handler, args);
+    };
+  }
+  return bridge;
+}
+
+/**
+ * (#2618) Forward a Proxy MOP to the target's DEFAULT internal method, used by
+ * the lazy bridge when a trap turns out to be absent at resolve time. The host
+ * passes the bridge trap the spec-mandated argument list whose first element is
+ * always the [[ProxyTarget]]; mapping each trap name to the corresponding
+ * Reflect.* default reproduces "missing trap ⇒ ordinary behaviour" (§7.3.10).
+ */
+function _proxyForwardDefault(name: string, args: any[]): any {
+  const target = args[0];
+  switch (name) {
+    case "get":
+      return Reflect.get(target, args[1], args[2] ?? target);
+    case "set":
+      return Reflect.set(target, args[1], args[2], args[3] ?? target);
+    case "has":
+      return Reflect.has(target, args[1]);
+    case "deleteProperty":
+      return Reflect.deleteProperty(target, args[1]);
+    case "defineProperty":
+      return Reflect.defineProperty(target, args[1], args[2]);
+    case "getOwnPropertyDescriptor":
+      return Reflect.getOwnPropertyDescriptor(target, args[1]);
+    case "ownKeys":
+      return Reflect.ownKeys(target);
+    case "getPrototypeOf":
+      return Reflect.getPrototypeOf(target);
+    case "setPrototypeOf":
+      return Reflect.setPrototypeOf(target, args[1]);
+    case "isExtensible":
+      return Reflect.isExtensible(target);
+    case "preventExtensions":
+      return Reflect.preventExtensions(target);
+    case "apply":
+      return Reflect.apply(target, args[1], args[2] ?? []);
+    case "construct":
+      return Reflect.construct(target, args[1] ?? [], args[2] ?? target);
+    default:
+      return undefined;
+  }
 }
 
 // ── #1234 — sparse-aware Array.prototype fast paths ─────────────────────────

--- a/tests/issue-2618.test.ts
+++ b/tests/issue-2618.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { compileAndInstantiate } from "../src/runtime-instantiate.js";
+
+// #2618 — Proxy (host) apply/construct call path, slice 1: START-timing + the
+// callable-target [[ProxyTarget]] wrap.
+//
+// Two verified faults on current main (gc / JS-host mode):
+//
+//  (A) START-timing — a TOP-LEVEL `new Proxy(target, handler)` runs inside the
+//      wasm module START function, BEFORE `setExports` wires `__is_closure` /
+//      the `__sget_*` field getters. The eager bridge could neither read nor
+//      classify the WasmGC-struct handler's trap fields, so EVERY user trap was
+//      lost: the host fell back to its default internal methods and `p.x` /
+//      `p has` / `p set` silently returned the wrong value (the proxy was built
+//      at module scope but invoked later, post-`setExports`, from an exported
+//      function). Fixed by deferring trap resolution to first invocation when
+//      exports aren't yet wired (`_buildLazyProxyBridgeHandler`).
+//
+//  (B) callable-target — a Proxy whose target is a wasm closure was not
+//      host-callable (V8 derives [[Call]] from [[ProxyTarget]]; a raw struct is
+//      not callable), so `p(...)` / `p.call(...)` threw "call is not a
+//      function". Fixed by using the target's JS-callable wrapper as
+//      [[ProxyTarget]] and restoring the raw struct as the apply/construct
+//      trap's `target` argument (so `assert.sameValue(t, target)` still holds).
+//
+// The dynamic-`new`-on-externref-Proxy construct-result routing (codegen
+// `tryEmitDynamicNew`) and the externref-callee call dispatch are a deeper,
+// separate slice — see the issue file's prerequisite ordering.
+
+async function run(source: string): Promise<unknown> {
+  const exports = await compileAndInstantiate(source);
+  return (exports as { test?: () => unknown }).test?.();
+}
+
+describe("#2618 — Proxy START-timing + callable-target wrap", () => {
+  // ── (A) START-timing: a top-level proxy's traps must fire ──────────────────
+
+  it("top-level proxy get trap fires (was dropped: returned target value)", async () => {
+    // The proxy is built at MODULE SCOPE (before setExports) but read from the
+    // exported function (after setExports). Before the fix this returned the
+    // target's own value, not the trap result.
+    const src = `
+      const p: any = new Proxy({ a: 1 }, { get: function () { return 99; } });
+      export function test(): number { return p.x; }
+    `;
+    expect(await run(src)).toBe(99);
+  });
+
+  it("top-level proxy has trap fires", async () => {
+    const src = `
+      const p: any = new Proxy({ a: 1 }, { has: function () { return true; } });
+      export function test(): number { return ("zzz" in p) ? 1 : 0; }
+    `;
+    expect(await run(src)).toBe(1);
+  });
+
+  it("top-level proxy set trap fires", async () => {
+    const src = `
+      let captured = 0;
+      const p: any = new Proxy({ a: 1 }, {
+        set: function (t: any, k: any, v: any) { captured = v; return true; },
+      });
+      export function test(): number { p.a = 42; return captured; }
+    `;
+    expect(await run(src)).toBe(42);
+  });
+
+  it("top-level proxy apply trap fires and returns its result", async () => {
+    // `built-ins/Proxy/apply/call-result.js` shape: top-level proxy of a
+    // function, apply trap returns a value, invoked via the wrapped function.
+    const src = `
+      const result = { v: 7 };
+      const p: any = new Proxy(function () { return -1; }, {
+        apply: function (t: any, c: any, args: any) { return result; },
+      });
+      export function test(): number { return p.call().v; }
+    `;
+    expect(await run(src)).toBe(7);
+  });
+
+  it("top-level proxy with NO trap behaves like an inner-built one (regression guard)", async () => {
+    // No-trap read-through of a closed-struct target is a separate, deferred
+    // concern (#2615); the guard here is only that top-level and inner proxies
+    // behave IDENTICALLY — the START-timing fix must not diverge them.
+    const inner = await run(`
+      export function test(): number {
+        const p: any = new Proxy({ a: 5 }, {});
+        return p.a;
+      }
+    `);
+    const top = await run(`
+      const p: any = new Proxy({ a: 5 }, {});
+      export function test(): number { return p.a; }
+    `);
+    expect(top).toBe(inner);
+  });
+
+  // ── (B) callable-target wrap: the proxy of a function is host-callable ──────
+  //
+  // NOTE: the full externref-callee CALL dispatch (`p.call(a, b)` with args, the
+  // dynamic `__call_function` routing in codegen `tryEmitInlineDynamicCall`) is
+  // a deeper, separate slice — see the issue file's prerequisite ordering. This
+  // slice only makes the proxy host-callable (so the host `apply` MOP runs) and
+  // restores target identity, which is what `apply/call-parameters.js` (a test262
+  // row flipped fail→pass by this slice) needs.
+
+  it("apply trap on a function-targeted proxy returns its result via p.call()", async () => {
+    // No-arg `p.call()` routes through the host apply MOP; the trap result is
+    // returned. (Multi-arg externref-callee dispatch is the deferred slice.)
+    const src = `
+      const result = { v: 11 };
+      const p: any = new Proxy(function () { return -1; }, {
+        apply: function (t: any, c: any, args: any) { return result; },
+      });
+      export function test(): number { return p.call().v; }
+    `;
+    expect(await run(src)).toBe(11);
+  });
+});


### PR DESCRIPTION
## Summary

Slice 1 of the host-Proxy apply/construct call path (#2618, = #2623 Slice C). **Pure runtime** (`src/runtime.ts` only — NO codegen dispatch changes), two cohesive fixes:

1. **START-timing lazy bridge.** A top-level `new Proxy(target, handler)` runs in the wasm START function *before* `setExports` wires `__is_closure` / `__sget_*`, so the eager bridge mis-resolved every trap (the host fell back to its default internal methods — a top-level proxy's `get`/`has`/`set`/`apply` traps silently never fired). When exports aren't yet wired at construct time, defer trap resolution to first invocation (post-`setExports`, when the program actually calls through the proxy). The eager path (exports present) is byte-for-byte unchanged.

2. **Callable-target `[[ProxyTarget]]` wrap.** A Proxy whose target is a wasm closure was not host-callable (V8 derives `[[Call]]`/`[[Construct]]` from `[[ProxyTarget]]`; a raw struct is not callable → `call is not a function`). Use the target's JS-callable wrapper as `[[ProxyTarget]]` and restore the raw struct as the apply/construct trap's `target` argument so `assert.sameValue(t, target)` holds.

## Verification (verify-first, per-process)

Faithful per-PROCESS test262 wrap (`parseMeta`+`wrapTest`+`compileSource`+`buildImports`+`setExports`, one node process/file — not in-process loops), gc mode:

- `built-ins/Proxy/{apply,construct}` non-realm matrix (29 files): **baseline 14 PASS → 15 PASS, exactly +1** (`apply/call-parameters.js` fail→pass), **zero regressions** (all other rows byte-identical).
- `get`/`has`/`set`/`defineProperty`/`getPrototypeOf`/`ownKeys`/`deleteProperty` rows: identical baseline↔fix.
- vitest proxy/reflect/closure suites: the 8 fails are **pre-existing on `origin/main`** (verified by reverting `runtime.ts`); no new regressions.
- `tests/issue-2618.test.ts` (6 cases): top-level get/has/set/apply traps fire; top-level==inner no-trap parity; apply-result via `p.call()`.

## Scope / remaining work

This refines sd-2623's "inert at module-START" verdict: test262's harness builds the proxy *inside* `test()` (post-`setExports`), so the callable-target wrap fires → the +1 row. **Remaining** (deferred, deep #56 dispatch substrate, each its own merge_group-validated PR): externref-callee CALL dispatch (multi-arg `p.call(a,b)` still illegal-casts; `tryEmitInlineDynamicCall`) + dynamic-new construct-result routing (`new p()` → 'is not a constructor'; `tryEmitDynamicNew`). Ordering in the issue file.

## Risk

Broad-impact (changes `[[ProxyTarget]]` for all callable-target proxies) → full-gate via **merge_group floor (#2097)**, not a scoped sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)