### PR TITLE
refactor(#1917): emitStrictEq/emitLooseEq — equality dispatch into coercion engine (slice E3)

### DIFF
--- a/plan/issues/1917-single-coercion-engine.md
+++ b/plan/issues/1917-single-coercion-engine.md
@@ -2,10 +2,11 @@
 id: 1917
 title: "One coercion engine — four divergent coercion matrices disagree about lossiness"
 status: in-progress
+assignee: ttraenkler/sendev-eq
 sprint: 65
 model: opus
 created: 2026-06-10
-updated: 2026-06-17
+updated: 2026-06-24
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -173,6 +174,78 @@ re-enqueue #1960. The pre-existing `String(x)`-returns-bare-f64 →
 `any.convert_extern` bug in the `String()` / native-concat path is a SEPARATE
 real issue (reproduces on `c4ef3fac2`) worth its own ticket — but it is NOT
 introduced by #1917 Step 1.
+
+## Implementation — Equality finale, slice E3 (any/any) (sendev-eq, 2026-06-24)
+
+Branch `issue-1917-emit-eq` (this PR). The LAST step of the dedup series, phased:
+**E3 (any/any) first** as the cleanest byte-neutral wrapper; E5/E6
+(tag-5-sensitive externref typed-side boxing) deferred to a separate isolated PR
+with extra standalone scrutiny vs the frozen #1888 −794 contract; the deferred
+behaviour fixes #1986/#1987/#2081 stay separate (they are classifier-side, not
+dispatch-side).
+
+**New `emitStrictEq(ctx, fctx, expr, negate)` / `emitLooseEq(ctx, fctx, expr,
+negate)`** in `coercion-engine.ts` — the **dispatch layer** for `any`-operand
+equality. They select the helper (`__any_strict_eq` for `===`/`!==`; `__any_eq`
+for `==`/`!=`), marshal both operands into the boxed `(ref null $AnyValue)` shape
+via the shared `emitAnyEqOperands` helper (the verbatim #1211 boxing sequence),
+emit the `call`, and apply the `!=`/`!==` `i32.eqz` negation. They return
+`{ kind: "i32" }`, or `null` (helper unavailable / operand failed) so the caller
+falls back exactly as before.
+
+**WRAPPER, not a re-derivation (the load-bearing invariant).** The hard part —
+the §7.2.15 tag-5 field-4 3-way classifier (`tag5StringEqThen`: genuine-string
+content-eq → `__str_equals`; `$BoxedNumber` → `__any_to_f64`+`f64.eq`; both-eqref
+objects → `ref.eq`; else conservative content-eq, the unified #2040/#2585 spec) —
+lives ENTIRELY in the `__any_eq`/`__any_strict_eq` helper *bodies*
+(`any-helpers.ts`). The engine never copies that logic; it only chooses the
+helper and boxes the operands. Folding a second classifier copy here would
+reproduce the #2585/#2040 disease this issue exists to prevent.
+
+**Migrated:** the four equality arms of `compileAnyBinaryDispatch`
+(`binary-ops.ts`, the `compileAnyBinaryDispatch` tail) now early-return into
+`emitLooseEq`/`emitStrictEq`; the `__any_eq`/`__any_strict_eq` rows are removed
+from the helper-name switch (a comment marks why they never reach it). The
+non-equality arms (`+`/`-`/`*`/`/`/`%`/`<`/`>`/`<=`/`>=`) are untouched.
+
+**Byte-neutral by construction:** the extraction reproduces the SAME helper
+selection, the SAME operand-boxing sequence (`compileExpression` → `isAnyValue`
+guard → `coerceType(ref_null $AnyValue)`), and the SAME `i32.eqz` negation —
+verified identical to the prior in-worktree implementation and gated by both-lane
+(host + standalone) Wasm-byte-SHA diff over equality programs + `playground/
+examples/` vs a fresh detached `origin/main` worktree (0 status changes required).
+
+**Deferred (NOT in this slice):** E5/E6 typed-side externref boxing (tag-5
+sensitive — needs the static-class routing + extra standalone scrutiny); the
+behaviour fixes #1986 (`null===0`), #1987 (`0===-0`), #2081 (SA `'1'==1`) — those
+are classifier/widening changes, intentionally separate from this neutral
+extraction.
+
+**Validation (sendev-eq, 2026-06-24):**
+- **Byte-SHA neutrality (authoritative):** `.tmp/eq-neutrality.mjs` compiled 7
+  programs (`==`/`===`/`!=`/`!==` on several operand shapes + arithmetic +
+  relational controls) on BOTH the gc (host) and standalone lanes and SHA-256'd
+  `result.binary`, then diffed against a fresh detached `origin/main` worktree:
+  **0 byte differences across all 14 (program × lane) outputs.** This is a
+  structural proof the extraction is byte-for-byte identical — it does not depend
+  on the test262 harness.
+- **Behaviour guard:** new `tests/issue-1917-emit-eq.test.ts` — 12 cases (6 per
+  lane) via the real `compile` + `WebAssembly.instantiate`; all pass. Pins each
+  lane's established equality behaviour (incl. the pre-existing standalone
+  `3 === 3.0 → false` numeric-tag gap, verified identical on `origin/main`).
+- **tsc clean, prettier clean.** Removed a now-dead `!=`/`!==` negation block in
+  `compileAnyBinaryDispatch` that tsc correctly flagged as unreachable once the
+  equality ops early-return into the engine (the prior in-worktree draft of this
+  slice had left it in and would not have typechecked).
+- **#2108 ratcheted DOWN:** `binary-ops.ts` 38 → 34 (the four equality arms
+  migrated into the sanctioned engine); baseline committed. No unsanctioned
+  growth.
+- **Caveat — local faithful test262 disregarded:** a direct `runTest262File`
+  probe failed its KNOWN-PASS control (`charAt/S15.5.4.4_A1_T1`) on clean
+  `origin/main` on both lanes — the standard broken-local-harness signature
+  (`feedback_verify_local_repro_against_known_good_control`). Its status readings
+  are therefore non-authoritative and disregarded; the byte-SHA diff above is the
+  neutrality gate, and the CI sharded test262 (faithful) is the conformance gate.
 
 ## Implementation — Step 3 in progress (sendev-coercion, 2026-06-23)
 

--- a/scripts/coercion-sites-baseline.json
+++ b/scripts/coercion-sites-baseline.json
@@ -3,7 +3,7 @@
   "codegen/array-object-proto.ts": 1,
   "codegen/array-to-primitive.ts": 5,
   "codegen/async-scheduler.ts": 3,
-  "codegen/binary-ops.ts": 38,
+  "codegen/binary-ops.ts": 34,
   "codegen/closed-method-dispatch.ts": 1,
   "codegen/declarations.ts": 19,
   "codegen/expressions/assignment.ts": 12,

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -43,6 +43,7 @@ import type { InnerResult } from "./shared.js";
 import { coerceType, compileExpression, ensureAnyHelpers, flushLateImportShifts } from "./shared.js";
 import { isLogicalAssignNamedEvalNameRead, resolveStructNameForExpr } from "./property-access.js";
 import { compileStringBinaryOp } from "./string-ops.js";
+import { emitLooseEq, emitStrictEq } from "./coercion-engine.js";
 import { compileInstanceOf, compileTypeofComparison } from "./typeof-delete.js";
 
 // ── Binary operations ─────────────────────────────────────────────────
@@ -2973,6 +2974,26 @@ function compileAnyBinaryDispatch(
   expr: ts.BinaryExpression,
   op: ts.SyntaxKind,
 ): InnerResult {
+  // (#1917 Step E3) Equality (`==`/`===`/`!=`/`!==`) is the dispatch layer the
+  // coercion engine owns: `emitStrictEq`/`emitLooseEq` select the helper, box
+  // both operands, emit the call, and negate for `!=`/`!==`. This is a
+  // byte-neutral extraction of the four equality arms below — same helper, same
+  // operand boxing, same `i32.eqz` negation — so the engine becomes the single
+  // home for equality dispatch while the tag-5 classifier stays in the
+  // `__any_eq`/`__any_strict_eq` helper bodies (any-helpers.ts).
+  switch (op) {
+    case ts.SyntaxKind.EqualsEqualsToken:
+      return emitLooseEq(ctx, fctx, expr, /*negate*/ false);
+    case ts.SyntaxKind.ExclamationEqualsToken:
+      return emitLooseEq(ctx, fctx, expr, /*negate*/ true);
+    case ts.SyntaxKind.EqualsEqualsEqualsToken:
+      return emitStrictEq(ctx, fctx, expr, /*negate*/ false);
+    case ts.SyntaxKind.ExclamationEqualsEqualsToken:
+      return emitStrictEq(ctx, fctx, expr, /*negate*/ true);
+    default:
+      break;
+  }
+
   // Map operator to helper name and result type
   let helperName: string | null = null;
   let resultIsI32 = false; // true for comparison/equality operators
@@ -2993,22 +3014,9 @@ function compileAnyBinaryDispatch(
     case ts.SyntaxKind.PercentToken:
       helperName = "__any_mod";
       break;
-    case ts.SyntaxKind.EqualsEqualsToken:
-      helperName = "__any_eq";
-      resultIsI32 = true;
-      break;
-    case ts.SyntaxKind.EqualsEqualsEqualsToken:
-      helperName = "__any_strict_eq";
-      resultIsI32 = true;
-      break;
-    case ts.SyntaxKind.ExclamationEqualsToken:
-      helperName = "__any_eq";
-      resultIsI32 = true;
-      break;
-    case ts.SyntaxKind.ExclamationEqualsEqualsToken:
-      helperName = "__any_strict_eq";
-      resultIsI32 = true;
-      break;
+    // NOTE: `==`/`===`/`!=`/`!==` are handled above by emitLooseEq/emitStrictEq
+    // (the coercion engine owns equality dispatch, #1917 Step E3) and never reach
+    // this switch.
     case ts.SyntaxKind.LessThanToken:
       helperName = "__any_lt";
       resultIsI32 = true;
@@ -3054,10 +3062,10 @@ function compileAnyBinaryDispatch(
 
   fctx.body.push({ op: "call", funcIdx });
 
-  // For != / !==, negate the __any_eq result
-  if (op === ts.SyntaxKind.ExclamationEqualsToken || op === ts.SyntaxKind.ExclamationEqualsEqualsToken) {
-    fctx.body.push({ op: "i32.eqz" });
-  }
+  // NOTE: the `!=` / `!==` negation that used to live here is now applied by
+  // `emitLooseEq`/`emitStrictEq` (the equality ops return early above and never
+  // reach this point — #1917 Step E3). The remaining ops here are arithmetic /
+  // relational, which need no negation.
 
   if (resultIsI32) {
     return { kind: "i32" };

--- a/src/codegen/coercion-engine.ts
+++ b/src/codegen/coercion-engine.ts
@@ -411,6 +411,91 @@ export function emitToBoolean(ctx: CodegenContext, valType: ValType | null, sink
 }
 
 /**
+ * Compile both operands of an `any`-typed equality expression, boxing each side
+ * that did not naturally produce a `$AnyValue` to `(ref null $AnyValue)` — the
+ * shared parameter shape of the `__any_eq` / `__any_strict_eq` helpers. Returns
+ * `false` (no instructions appended) if either operand fails to compile, so the
+ * caller can fall back exactly as it did before.
+ *
+ * This is the operand-marshalling half of the §7.2.13/§7.2.15 equality dispatch,
+ * lifted verbatim from `compileAnyBinaryDispatch` (binary-ops.ts) — same
+ * `compileExpression` → `isAnyValue` guard → `coerceType(ref_null $AnyValue)`
+ * sequence (#1211), so the emitted bytes are identical.
+ */
+function emitAnyEqOperands(ctx: CodegenContext, fctx: FunctionContext, expr: ts.BinaryExpression): boolean {
+  const anyValueTarget: ValType = { kind: "ref_null", typeIdx: ctx.anyValueTypeIdx };
+  const leftType = compileExpression(ctx, fctx, expr.left);
+  if (!leftType) return false;
+  if (!isAnyValue(leftType, ctx)) {
+    coerceType(ctx, fctx, leftType, anyValueTarget);
+  }
+  const rightType = compileExpression(ctx, fctx, expr.right);
+  if (!rightType) return false;
+  if (!isAnyValue(rightType, ctx)) {
+    coerceType(ctx, fctx, rightType, anyValueTarget);
+  }
+  return true;
+}
+
+/**
+ * #1917 Step E3 — `emitStrictEq` / `emitLooseEq`: the **dispatch layer** for
+ * `any`-operand equality. These decide WHICH helper to call (`__any_strict_eq`
+ * for `===`/`!==`; `__any_eq` for `==`/`!=`), marshal both operands into the
+ * boxed `$AnyValue` shape, emit the `call`, and apply the `!=`/`!==` negation.
+ *
+ * They are a WRAPPER, not a re-derivation: the tag-5 field-4 3-way classifier
+ * (boxed-number vs proto-identity vs content equality, #2040/#2585 — the
+ * `tag5StringEqThen` machinery) lives in the `__any_eq`/`__any_strict_eq` helper
+ * *bodies* in any-helpers.ts. The engine never copies that logic; it only
+ * selects the helper and boxes the operands. This is a byte-neutral extraction
+ * of the equality arms of `compileAnyBinaryDispatch`.
+ *
+ * @param negate when true, the loose/strict-equal result is i32.eqz'd (the
+ *   `!=` / `!==` half). The helper itself always computes `==`/`===`.
+ * @returns the i32 result ValType, or `null` if the helper is unavailable or an
+ *   operand failed to compile (caller falls back).
+ */
+export function emitStrictEq(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.BinaryExpression,
+  negate: boolean,
+): ValType | null {
+  return emitAnyEquality(ctx, fctx, expr, "__any_strict_eq", negate);
+}
+
+export function emitLooseEq(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.BinaryExpression,
+  negate: boolean,
+): ValType | null {
+  return emitAnyEquality(ctx, fctx, expr, "__any_eq", negate);
+}
+
+function emitAnyEquality(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.BinaryExpression,
+  helperName: "__any_eq" | "__any_strict_eq",
+  negate: boolean,
+): ValType | null {
+  ensureAnyHelpers(ctx);
+  const funcIdx = ctx.funcMap.get(helperName);
+  if (funcIdx === undefined) return null;
+
+  if (!emitAnyEqOperands(ctx, fctx, expr)) return null;
+
+  fctx.body.push({ op: "call", funcIdx });
+
+  if (negate) {
+    fctx.body.push({ op: "i32.eqz" });
+  }
+
+  return { kind: "i32" };
+}
+
+/**
  * Emit a string literal in the active mode. `compileStringLiteral` is already
  * mode-agnostic (a native `$AnyString` constant in native/standalone mode, an
  * externref string-constant in js-host mode) — exactly what every migrated

--- a/tests/issue-1917-emit-eq.test.ts
+++ b/tests/issue-1917-emit-eq.test.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1917 equality finale, slice E3 (any/any) — `emitStrictEq` / `emitLooseEq`.
+ *
+ * The four `any`-operand equality arms (`==`/`===`/`!=`/`!==`) of
+ * `compileAnyBinaryDispatch` were extracted into `emitLooseEq`/`emitStrictEq`
+ * (coercion-engine.ts) — the dispatch layer that selects the `__any_eq` /
+ * `__any_strict_eq` keystone helper (which owns the tag-5 classifier), boxes the
+ * operands, and applies the `!=`/`!==` negation. This is a byte-neutral
+ * extraction; these end-to-end cases regression-guard the OBSERVABLE equality
+ * behaviour on both the JS-host (gc) and standalone lanes.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function run(src: string, standalone: boolean): Promise<unknown> {
+  const r = await compile(src, standalone ? { fileName: "t.ts", target: "standalone" } : { fileName: "t.ts" });
+  expect(r.success, r.success ? "" : `CE: ${r.errors?.[0]?.message}`).toBe(true);
+  const importObj = standalone ? {} : (r.importObject ?? {});
+  const { instance } = await WebAssembly.instantiate(r.binary, importObj as WebAssembly.Imports);
+  return (instance.exports as { test(): unknown }).test();
+}
+
+// `==` performs JS loose-equality coercion: 1 == "1" is true.
+const looseEq = `function eq(a: any, b: any): boolean { return a == b; }
+export function test(): number { return eq(1, "1") ? 1 : 0; }`;
+
+// `===` is strict: 1 === 1 true, 1 === "1" false.
+const strictEqSame = `function eq(a: any, b: any): boolean { return a === b; }
+export function test(): number { return eq(1, 1) ? 1 : 0; }`;
+const strictEqDiff = `function eq(a: any, b: any): boolean { return a === b; }
+export function test(): number { return eq(1, "1") ? 1 : 0; }`;
+
+// `!=` / `!==` are the negated arms.
+const looseNeq = `function ne(a: any, b: any): boolean { return a != b; }
+export function test(): number { return ne(1, 2) ? 1 : 0; }`;
+const strictNeq = `function ne(a: any, b: any): boolean { return a !== b; }
+export function test(): number { return ne(1, "1") ? 1 : 0; }`;
+
+// A combined program exercising all four operators on several operand shapes.
+const combined = `function f(a: any, b: any): number {
+  let n = 0;
+  if (a == b) n += 1;
+  if (a === b) n += 2;
+  if (a != b) n += 4;
+  if (a !== b) n += 8;
+  return n;
+}
+export function test(): number {
+  return f(3, 3.0) + f("x", "x") + f(1, 2);
+}`;
+
+// The combined program's RESULT differs by lane because of a PRE-EXISTING (not
+// E3-introduced) standalone classifier gap, verified byte-identical on
+// origin/main: on the JS-host lane `3 === 3.0` is true (== true(1), === true(2)
+// → 3), but the standalone numeric-tag classifier reports `3 === 3.0` FALSE (==
+// true(1), != true(4), !== true(8) → 13) — a known deferred-fix item
+// (#1987/#2040 family). E3 is a byte-neutral dispatch extraction, so each lane's
+// established value is pinned here as a regression guard, NOT "corrected".
+//   host:       f(3,3.0)=3  + f("x","x")=3 + f(1,2)=12 = 18
+//   standalone: f(3,3.0)=13 + f("x","x")=3 + f(1,2)=12 = 28
+const combinedExpected = { host: 18, standalone: 28 } as const;
+
+describe("#1917 E3 — emitStrictEq / emitLooseEq (any/any equality dispatch)", () => {
+  for (const standalone of [false, true]) {
+    const lane = standalone ? "standalone" : "host";
+    it(`== coerces (1 == "1" true) [${lane}]`, async () => expect(await run(looseEq, standalone)).toBe(1));
+    it(`=== same-type true (1 === 1) [${lane}]`, async () => expect(await run(strictEqSame, standalone)).toBe(1));
+    it(`=== cross-type false (1 === "1") [${lane}]`, async () => expect(await run(strictEqDiff, standalone)).toBe(0));
+    it(`!= true (1 != 2) [${lane}]`, async () => expect(await run(looseNeq, standalone)).toBe(1));
+    it(`!== true (1 !== "1") [${lane}]`, async () => expect(await run(strictNeq, standalone)).toBe(1));
+    it(`combined ==/===/!=/!== [${lane}]`, async () =>
+      expect(await run(combined, standalone)).toBe(combinedExpected[lane]));
+  }
+});


### PR DESCRIPTION
## #1917 equality finale — slice E3 (any/any)

The high-value LAST step of the coercion-engine dedup series (Steps 0-3 —
emitToString/Number/Boolean — already merged via #1960/#1962/#1963). Phased: this
PR lands the **cleanest byte-neutral wrapper first** (E3, any/any); the tag-5-
sensitive externref slices (E5/E6) and the behaviour fixes (#1986/#1987/#2081)
are deferred to separate isolated PRs.

### What changed

The four `any`-operand equality arms (`==`/`===`/`!=`/`!==`) of
`compileAnyBinaryDispatch` (`binary-ops.ts`) now early-return into **new
`emitStrictEq` / `emitLooseEq`** in `coercion-engine.ts` — the dispatch layer
that:
- selects the keystone helper (`__any_strict_eq` for `===`/`!==`, `__any_eq` for
  `==`/`!=`),
- marshals both operands into the boxed `(ref null $AnyValue)` shape (the verbatim
  #1211 boxing sequence),
- emits the `call`, and applies the `!=`/`!==` `i32.eqz` negation.

**WRAPPER, not a re-derivation.** The hard part — the §7.2.15 tag-5 field-4
3-way classifier (`tag5StringEqThen`, the unified #2040/#2585 spec) — stays
ENTIRELY in the `__any_eq`/`__any_strict_eq` helper *bodies* (`any-helpers.ts`).
The engine never copies it; it only chooses the helper and boxes the operands.

### Neutrality / validation

- **Byte-SHA neutrality (authoritative):** compiled 7 programs (`==`/`===`/`!=`/
  `!==` on several operand shapes + arithmetic + relational controls) on BOTH the
  gc (host) and standalone lanes, SHA-256'd `result.binary`, diffed vs a fresh
  detached `origin/main` worktree — **0 byte differences across all 14
  (program × lane) outputs.**
- **Behaviour guard:** new `tests/issue-1917-emit-eq.test.ts` — 12 cases (6/lane)
  via real `compile` + `WebAssembly.instantiate`; all pass. Pins each lane's
  established equality behaviour (incl. the pre-existing standalone
  `3 === 3.0 → false` numeric-tag gap, verified identical on `origin/main`).
- Removed a now-dead `!=`/`!==` negation block that tsc correctly flagged as
  unreachable once the equality ops early-return into the engine.
- **#2108 ratcheted DOWN:** `binary-ops.ts` 38 → 34.
- tsc clean, prettier clean, `check:coercion-sites` OK.

### Deferred (NOT in this PR)

E5/E6 typed-side externref boxing (tag-5 sensitive — needs static-class routing +
extra standalone scrutiny vs the frozen #1888 −794 contract); the behaviour fixes
#1986 / #1987 / #2081 (classifier/widening changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)