### PR TITLE
refactor(#1917): emitAnyEqFromExternTemps — standalone externref loose-eq tail into coercion engine (slice E6)

### DIFF
--- a/plan/issues/1917-single-coercion-engine.md
+++ b/plan/issues/1917-single-coercion-engine.md
@@ -175,6 +175,59 @@ re-enqueue #1960. The pre-existing `String(x)`-returns-bare-f64 →
 real issue (reproduces on `c4ef3fac2`) worth its own ticket — but it is NOT
 introduced by #1917 Step 1.
 
+## Implementation — Equality finale, slice E6 (standalone externref loose-eq tail) (sendev-eq, 2026-06-24)
+
+Branch `issue-1917-emit-eq-e5e6`, branched from `upstream/main` (which carries the
+merged E3, #1989). The follow-up slice to E3 — the tag-5-sensitive externref
+dispatch we deferred — scoped to **pure code-motion** (the behaviour fixes
+#1986/#1987/#2081 remain separate).
+
+**What E5/E6 actually is, on current main.** After E3 migrated the four any/any
+arms of `compileAnyBinaryDispatch`, there was exactly **ONE** remaining direct
+call to a keystone equality helper (`__any_eq`/`__any_strict_eq`) left anywhere in
+`binary-ops.ts`: the **standalone externref-vs-externref loose-eq tail**
+(`compileStringBinaryOp`, the `noJsHost` arm of the not-eqref-identical branch).
+It boxes two opaque `any` externrefs to `$AnyValue` via `__any_from_extern` (tag5
+string / tag3 number / tag4 bool / tag1 null) and calls `__any_eq` — the §7.2.15
+native IsLooselyEqual (#2081). That is the tag-5-sensitive dispatch; the strict
+externref path goes through `__host_eq` + numeric-unbox (NOT the keystone), and
+its routing-to-`__any_strict_eq` is the deferred #1986 behaviour change.
+
+**New `emitAnyEqFromExternTemps(ctx, tmpLeft, tmpRight, negate): Instr[] | null`**
+in `coercion-engine.ts` — returns the `__any_from_extern`×2 → `__any_eq` →
+optional `i32.eqz` instruction SEQUENCE (the caller builds an `Instr[]` for an
+`if`-arm, not a live emit), or `null` when the helpers are unavailable so the
+caller falls through to its `__host_loose_eq` import exactly as before. WRAPPER,
+not a re-derivation: the tag-5 classifier stays in `__any_eq`'s body
+(`any-helpers.ts`). With this, the coercion engine now owns **every** keystone
+equality-helper invocation; `binary-ops.ts` no longer references `__any_eq`
+directly (its `ensureAnyFromExternHelper` import is dropped).
+
+**Byte-neutral (authoritative gate):** `.tmp/e6-neutrality.mjs` compiled 5 programs
+exercising the standalone externref loose-eq path (`"1"==1`, `!=`, mixed any/any,
+plus a strict-eq control and an object-identity control) on BOTH the gc (host) and
+standalone lanes, SHA-256'd `result.binary`, and diffed against a fresh detached
+`upstream/main` (E3-inclusive) worktree: **0 byte differences across all 10
+(program × lane) outputs** — including the `standalone` cases E6 actually rewrites.
+
+**Behaviour guard:** new `tests/issue-1917-emit-eq-e6.test.ts` — 6 cases (3/lane),
+all pass. `"1" == 1 → true`, `"1" != 1 → false`, same-identity object `==` →
+true, on both lanes.
+
+**Pre-existing failure confirmed NOT introduced by E6:** `issue-2081.test.ts`'s
+`null == undefined → true` (standalone) fails IDENTICALLY on the E3-only
+`upstream/main` control — it is the deferred standalone nullish-coercion gap
+(#2081's full behaviour fix), not a code-motion regression. Consistent with the 0
+byte-SHA diff.
+
+**#2108 ratcheted DOWN:** `binary-ops.ts` 34 → 33 (the last keystone `__any_eq`
+call moved into the sanctioned engine). tsc clean, prettier clean.
+
+**Still deferred (separate PRs):** the strict-externref routing-to-`__any_strict_eq`
+(#1986 `null===0`), `0===-0` numeric-merge (#1987), and the standalone
+nullish/full-coercion widening (#2081) — these are classifier/gate-logic
+*behaviour* changes, not dispatch motion.
+
 ## Implementation — Equality finale, slice E3 (any/any) (sendev-eq, 2026-06-24)
 
 Branch `issue-1917-emit-eq` (this PR). The LAST step of the dedup series, phased:

--- a/scripts/coercion-sites-baseline.json
+++ b/scripts/coercion-sites-baseline.json
@@ -3,7 +3,7 @@
   "codegen/array-object-proto.ts": 1,
   "codegen/array-to-primitive.ts": 5,
   "codegen/async-scheduler.ts": 3,
-  "codegen/binary-ops.ts": 34,
+  "codegen/binary-ops.ts": 33,
   "codegen/closed-method-dispatch.ts": 1,
   "codegen/declarations.ts": 19,
   "codegen/expressions/assignment.ts": 12,

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -15,7 +15,7 @@ import {
   isWrapperObjectType,
 } from "../checker/type-mapper.js";
 import type { Instr, ValType } from "../ir/types.js";
-import { ensureAnyFromExternHelper, isAnyValue } from "./any-helpers.js";
+import { isAnyValue } from "./any-helpers.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
@@ -43,7 +43,7 @@ import type { InnerResult } from "./shared.js";
 import { coerceType, compileExpression, ensureAnyHelpers, flushLateImportShifts } from "./shared.js";
 import { isLogicalAssignNamedEvalNameRead, resolveStructNameForExpr } from "./property-access.js";
 import { compileStringBinaryOp } from "./string-ops.js";
-import { emitLooseEq, emitStrictEq } from "./coercion-engine.js";
+import { emitAnyEqFromExternTemps, emitLooseEq, emitStrictEq } from "./coercion-engine.js";
 import { compileInstanceOf, compileTypeofComparison } from "./typeof-delete.js";
 
 // ── Binary operations ─────────────────────────────────────────────────
@@ -2851,23 +2851,17 @@ export function compileBinaryExpression(
             // (incl. the String⇄Number arm added in this PR) implement the spec
             // coercion natively. Host mode keeps `__host_loose_eq` (JS `==`),
             // unchanged.
+            // (#1917 E6) The standalone native IsLooselyEqual tail — box both
+            // externrefs to `$AnyValue` and call the keystone `__any_eq` — is the
+            // same tag-5-sensitive dispatch the coercion engine owns for E3, so it
+            // lives in `emitAnyEqFromExternTemps`. `null` ⇒ helpers unavailable
+            // (should not happen) → fall through to the host import below.
             const noJsHost = ctx.standalone === true || ctx.wasi === true;
             if (noJsHost) {
-              ensureAnyHelpers(ctx);
-              const fromExternIdx = ensureAnyFromExternHelper(ctx);
-              const anyEqIdx = ctx.funcMap.get("__any_eq");
-              if (fromExternIdx !== undefined && anyEqIdx !== undefined) {
-                return [
-                  { op: "local.get", index: tmpLeft },
-                  { op: "call", funcIdx: fromExternIdx } as Instr,
-                  { op: "local.get", index: tmpRight },
-                  { op: "call", funcIdx: fromExternIdx } as Instr,
-                  { op: "call", funcIdx: anyEqIdx } as Instr,
-                  ...(isNeqOp ? [{ op: "i32.eqz" } as Instr] : []),
-                ] as Instr[];
+              const nativeLooseEq = emitAnyEqFromExternTemps(ctx, tmpLeft, tmpRight, isNeqOp);
+              if (nativeLooseEq !== null) {
+                return nativeLooseEq;
               }
-              // Helpers unavailable (should not happen) — fall through to the
-              // host import below rather than emit nothing.
             }
             // Loose equality: __host_loose_eq (JS ==) handles all coercion
             // rules including null==undefined per §7.2.15. The result is

--- a/src/codegen/coercion-engine.ts
+++ b/src/codegen/coercion-engine.ts
@@ -37,6 +37,7 @@ import { ts } from "../ts-api.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { noJsHost } from "./expressions/helpers.js";
 import { addUnionImports, nativeStringType } from "./index.js";
+import { ensureAnyFromExternHelper } from "./any-helpers.js";
 import { ensureAnyToStringHelper } from "./native-strings.js";
 import {
   compileExpression,
@@ -493,6 +494,48 @@ function emitAnyEquality(
   }
 
   return { kind: "i32" };
+}
+
+/**
+ * #1917 equality finale, slice E6 — the standalone externref-vs-externref
+ * loose-equality tail.
+ *
+ * For two opaque `any` externref operands that were NOT eqref-identical, the
+ * standalone/WASI lane (no JS host) routes through the NATIVE §7.2.15
+ * IsLooselyEqual instead of the unsatisfiable `__host_loose_eq` import (#2081):
+ * box both externrefs to `$AnyValue` via `__any_from_extern` (tag5 string / tag3
+ * number / tag4 bool / tag1 null) and call the keystone `__any_eq` helper (whose
+ * tag-5 field-4 classifier owns the String⇄Number / proto-identity arms). This
+ * is the SAME tag-5-sensitive boxing E3 does for the any/any case, just sourced
+ * from two pre-computed externref temps instead of freshly-compiled operands.
+ *
+ * Returns the instruction SEQUENCE (this caller builds an `Instr[]` for an
+ * `if`-arm, it does not emit live), or `null` when the helpers are unavailable so
+ * the caller can fall through to its host-import path exactly as before. WRAPPER,
+ * not a re-derivation: the classifier stays in `__any_eq`'s body (any-helpers.ts).
+ *
+ * @param tmpLeft  local index holding the left externref operand.
+ * @param tmpRight local index holding the right externref operand.
+ * @param negate   append `i32.eqz` for the `!=` form.
+ */
+export function emitAnyEqFromExternTemps(
+  ctx: CodegenContext,
+  tmpLeft: number,
+  tmpRight: number,
+  negate: boolean,
+): Instr[] | null {
+  ensureAnyHelpers(ctx);
+  const fromExternIdx = ensureAnyFromExternHelper(ctx);
+  const anyEqIdx = ctx.funcMap.get("__any_eq");
+  if (fromExternIdx === undefined || anyEqIdx === undefined) return null;
+  return [
+    { op: "local.get", index: tmpLeft },
+    { op: "call", funcIdx: fromExternIdx },
+    { op: "local.get", index: tmpRight },
+    { op: "call", funcIdx: fromExternIdx },
+    { op: "call", funcIdx: anyEqIdx },
+    ...(negate ? [{ op: "i32.eqz" } as Instr] : []),
+  ];
 }
 
 /**

--- a/tests/issue-1917-emit-eq-e6.test.ts
+++ b/tests/issue-1917-emit-eq-e6.test.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #1917 equality finale, slice E6 — `emitAnyEqFromExternTemps`.
+ *
+ * The standalone externref-vs-externref loose-equality tail (two opaque `any`
+ * operands that are not eqref-identical) boxes both externrefs to `$AnyValue` via
+ * `__any_from_extern` and calls the keystone `__any_eq` helper (the native
+ * §7.2.15 IsLooselyEqual, #2081). That construction — the LAST direct keystone
+ * `__any_eq` call left in binary-ops.ts after E3 — moved into the coercion engine
+ * as `emitAnyEqFromExternTemps`. This is a byte-neutral code-motion; these cases
+ * regression-guard the OBSERVABLE standalone behaviour (and that the host lane is
+ * unchanged).
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function run(src: string, standalone: boolean): Promise<unknown> {
+  const r = await compile(src, standalone ? { fileName: "t.ts", target: "standalone" } : { fileName: "t.ts" });
+  expect(r.success, r.success ? "" : `CE: ${r.errors?.[0]?.message}`).toBe(true);
+  const importObj = standalone ? {} : (r.importObject ?? {});
+  const { instance } = await WebAssembly.instantiate(r.binary, importObj as WebAssembly.Imports);
+  return (instance.exports as { test(): unknown }).test();
+}
+
+// Two opaque `any` externrefs, string vs number — the native String<->Number
+// loose-eq arm (#2081). On BOTH lanes `"1" == 1` is true.
+const strNumLoose = `function f(a: any, b: any): boolean { return a == b; }
+export function test(): number { const s: any = "1"; const n: any = 1; return f(s, n) ? 1 : 0; }`;
+
+// `!=` form exercises the negation (i32.eqz) tail.
+const strNumNeq = `function f(a: any, b: any): boolean { return a != b; }
+export function test(): number { const s: any = "1"; const n: any = 1; return f(s, n) ? 1 : 0; }`;
+
+// Two `any` objects with the SAME identity — the eqref-identity arm (not the
+// extern tail), so loose-eq is true.
+const objIdentity = `function f(a: any, b: any): boolean { return a == b; }
+export function test(): number { const o: any = {}; const p: any = o; return f(o, p) ? 1 : 0; }`;
+
+describe("#1917 E6 — emitAnyEqFromExternTemps (standalone externref loose-eq tail)", () => {
+  for (const standalone of [false, true]) {
+    const lane = standalone ? "standalone" : "host";
+    it(`"1" == 1 is true [${lane}]`, async () => expect(await run(strNumLoose, standalone)).toBe(1));
+    it(`"1" != 1 is false [${lane}]`, async () => expect(await run(strNumNeq, standalone)).toBe(0));
+    it(`same-identity object == is true [${lane}]`, async () => expect(await run(objIdentity, standalone)).toBe(1));
+  }
+});


### PR DESCRIPTION
## #1917 equality finale — slice E6 (standalone externref loose-eq tail)

Follow-up to the merged E3 (#1989). The tag-5-sensitive externref dispatch we
deferred, scoped to **pure code-motion** (behaviour fixes #1986/#1987/#2081 stay
separate).

### What this is

After E3 migrated the four any/any arms of `compileAnyBinaryDispatch`, exactly
**ONE** direct keystone `__any_eq`/`__any_strict_eq` call remained anywhere in
`binary-ops.ts`: the **standalone externref-vs-externref loose-eq tail**
(`compileStringBinaryOp`, the `noJsHost` arm of the not-eqref-identical branch).
It boxes two opaque `any` externrefs to `$AnyValue` via `__any_from_extern` (tag5
string / tag3 number / tag4 bool / tag1 null) and calls `__any_eq` — the native
§7.2.15 IsLooselyEqual (#2081). That is the tag-5-sensitive dispatch.

**New `emitAnyEqFromExternTemps(ctx, tmpLeft, tmpRight, negate): Instr[] | null`**
in `coercion-engine.ts` returns the `__any_from_extern`×2 → `__any_eq` → optional
`i32.eqz` sequence (the caller builds an `Instr[]` for an `if`-arm), or `null`
when the helpers are unavailable so the caller falls through to its
`__host_loose_eq` import exactly as before. With this, the coercion engine owns
**every** keystone equality-helper invocation; `binary-ops.ts` no longer
references `__any_eq` directly (its `ensureAnyFromExternHelper` import is dropped).

**WRAPPER, not a re-derivation:** the tag-5 field-4 classifier stays entirely in
`__any_eq`'s body (`any-helpers.ts`).

### Neutrality / validation

- **Byte-SHA neutrality (authoritative):** 5 programs exercising the standalone
  externref loose-eq path (`"1"==1`, `!=`, mixed any/any, + strict-eq and
  object-identity controls) compiled on BOTH lanes, SHA-256'd `result.binary`,
  diffed vs a fresh detached `upstream/main` (E3-inclusive) worktree — **0 byte
  differences across all 10 (program × lane) outputs**, including the `standalone`
  cases E6 rewrites.
- **Behaviour guard:** new `tests/issue-1917-emit-eq-e6.test.ts` — 6 cases
  (3/lane), all pass.
- **Pre-existing failure confirmed NOT from E6:** `issue-2081.test.ts`'s
  `null == undefined → true` (standalone) fails IDENTICALLY on the E3-only
  `upstream/main` control — the deferred #2081 nullish-coercion gap, not a
  code-motion regression. Consistent with the 0 byte-SHA diff.
- **#2108 ratcheted DOWN:** `binary-ops.ts` 34 → 33.
- tsc clean, prettier clean, `check:coercion-sites` OK.

### Still deferred (separate PRs)

Strict-externref routing-to-`__any_strict_eq` (#1986 `null===0`), `0===-0`
numeric-merge (#1987), standalone nullish/full-coercion widening (#2081) — those
are classifier/gate-logic behaviour changes, not dispatch motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)