### PR TITLE
chore(plan): retrofit node-API-compat cluster into sprint 65

### DIFF
--- a/plan/issues/1772-edgejs-node-wasi-shim-spike.md
+++ b/plan/issues/1772-edgejs-node-wasi-shim-spike.md
@@ -12,7 +12,7 @@ task_type: research
 area: host-interop
 language_feature: node-api-compat
 goal: platform
-sprint: Backlog
+sprint: 65
 es_edition: n/a
 related: [389, 1575, 1766, 2527, 2528, 2624, 2625, 2631, 2632, 2083, 2181, 2634, 2635]
 origin: "Follow-up from PR #1010 review direction; regrounded 2026-06-23 against the landed node:fs/node:process shim work"

--- a/plan/issues/2624-import-scoped-node-emulation-typing.md
+++ b/plan/issues/2624-import-scoped-node-emulation-typing.md
@@ -2,7 +2,7 @@
 id: 2624
 title: "Node API emulation typing is import-scoped, not blanket"
 status: done
-sprint: Backlog
+sprint: 65
 created: 2026-06-22
 updated: 2026-06-22
 completed: 2026-06-22

--- a/plan/issues/2625-rename-node-io-to-node-process-shim.md
+++ b/plan/issues/2625-rename-node-io-to-node-process-shim.md
@@ -2,7 +2,7 @@
 id: 2625
 title: "Rename js2wasm:node-io shim to js2wasm:node-process + unify --link-node-shims flag"
 status: done
-sprint: Backlog
+sprint: 65
 created: 2026-06-22
 updated: 2026-06-22
 completed: 2026-06-22

--- a/plan/issues/2631-node-fs-fd-shim-readsync-writesync.md
+++ b/plan/issues/2631-node-fs-fd-shim-readsync-writesync.md
@@ -2,7 +2,7 @@
 id: 2631
 title: "node:fs fd-based readSync/writeSync via a per-module shim (Native Messaging example)"
 status: done
-sprint: Backlog
+sprint: 65
 assignee: ttraenkler/agent-a0c9d00fc32018cde
 completed: 2026-06-23
 feasibility: medium

--- a/plan/issues/2632-wasi-async-runtime-event-loop.md
+++ b/plan/issues/2632-wasi-async-runtime-event-loop.md
@@ -3,7 +3,7 @@ id: 2632
 title: WASI async runtime — event-loop reactor (process.stdin Readable, timers, promise-driven I/O)
 status: in-progress
 assignee: ttraenkler/senior-dev-2632
-sprint: Backlog
+sprint: 65
 goal: wasi-async-runtime
 feasibility: hard
 kind: goal

--- a/plan/issues/2633-process-io-to-node-fs.md
+++ b/plan/issues/2633-process-io-to-node-fs.md
@@ -2,7 +2,7 @@
 id: 2633
 title: "Migrate synchronous std-IO off the hallucinated process.std* surface onto node:fs readSync/writeSync"
 status: done
-sprint: Backlog
+sprint: 65
 assignee: ttraenkler/agent-a0c10078166a3b3a5
 completed: 2026-06-24
 depends_on: [2631, 1968]

--- a/plan/issues/2634-node-types-capability-map-extraction.md
+++ b/plan/issues/2634-node-types-capability-map-extraction.md
@@ -13,7 +13,7 @@ task_type: feature
 area: host-interop
 language_feature: node-api-compat
 goal: platform
-sprint: Backlog
+sprint: 65
 es_edition: n/a
 related: [1772, 2624, 2625, 2631, 2528, 2083, 2181, 2527]
 origin: "Phase 2 split out of #1772 once Phase 0 (ABI) + Phase 1 (edge.js dual-provider proof) landed"

--- a/plan/issues/2635-node-async-members-event-loop.md
+++ b/plan/issues/2635-node-async-members-event-loop.md
@@ -11,7 +11,7 @@ task_type: feature
 area: host-interop
 language_feature: node-api-compat
 goal: platform
-sprint: Backlog
+sprint: 65
 es_edition: n/a
 depends_on: [2632]
 related: [1772, 2631, 2632, 2634]


### PR DESCRIPTION
Assigns the node:fs / WASI-async / `@types/node` issues to **sprint 65** (frontmatter `sprint:` is the authoritative source of sprint membership, #1616). They were planned and landed during the sprint-65 window — driven by the loopdive/js2#389 reporter thread — but were filed as `sprint: Backlog`.

Set `sprint: 65` on all eight:
- #2631 node:fs fd-shim (readSync/writeSync) — done
- #2632 WASI async runtime / event-loop reactor — in-progress (Phases 1+2 landed)
- #2633 process IO → node:fs migration — done
- #2634 real @types/node typings + capability map — done
- #2635 async members (process.stdin Readable) — blocked on #2632 Ph3
- #1772 edge.js dual-provider — in-progress
- #2624 import-scoped node typing — done
- #2625 node-io→node-process rename — done

Frontmatter-only (no content changes). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)