### PR TITLE
chore(#1760): mark warm in-process benchmark lane done (impl already on main)

### DIFF
--- a/plan/issues/1760-wasm-warm-benchmark-inprocess-repeated-measure.md
+++ b/plan/issues/1760-wasm-warm-benchmark-inprocess-repeated-measure.md
@@ -1,16 +1,17 @@
 ---
 id: 1760
 title: "wasm warm-runtime benchmark lane: in-process repeated-measure (current cold−baseline subtraction is noise-dominated)"
-status: ready
+status: done
 created: 2026-05-31
-updated: 2026-05-31
+updated: 2026-06-24
+completed: 2026-06-24
+sprint: 65
 priority: medium
 feasibility: medium
 reasoning_effort: medium
 task_type: bugfix
 area: benchmarks
 goal: platform
-sprint: Backlog
 related: [1580, 1746]
 origin: surfaced while refreshing the #1746 i32-hashpath warm benchmark on #990 — the published warm number could not move because the metric's run-to-run noise exceeded the effect size
 ---
@@ -117,3 +118,18 @@ drop.
       (+ `website/public/...` copy) on **current main's** compiler with the
       new methodology.
 - [x] Stability proof recorded above (6 identical-binary samples).
+
+## Resolution (2026-06-24)
+
+Status-only correction. The implementation already landed on `main` in commit
+`7a9ba70e6` ("fix(#1760): in-process warm lane for wasm-host benchmark") — the
+warm lane (`WARM_DRIVER_SOURCE`, `timeWasmtimeWarmIter`, `--invoke warm`,
+warm-variant compile + precompile) is present in
+`scripts/generate-wasmtime-hot-runtime.mjs`, and
+`benchmarks/results/wasm-host-wasmtime-hot-runtime.json` carries the
+re-baselined `warm` scenario with `wasmStdUs` provenance. Subsequent commits
+(`e92460a68`, `e2c0aff99`) built further on it (rust host for the cold lanes).
+All three Deliverables are satisfied on `main`; only the frontmatter `status`
+was stale (`ready` → `done`). This warm in-process repeated-measure lane is the
+measurement gate that unblocks the string-hash perf work (#1762 / #2621): warm
+per-call deltas are now resolvable (string-hash spread down from ~2.3× to ~4%).


### PR DESCRIPTION
## Summary

Status-only correction for **#1760** (wasm warm-runtime in-process repeated-measure benchmark lane).

While regrounding the string-hash perf work, I found that #1760's implementation **already landed on `main`** in commit `7a9ba70e6` ("fix(#1760): in-process warm lane for wasm-host benchmark"). Only the issue frontmatter was stale (`status: ready`, `sprint: Backlog`), which made the carried slate mis-advertise it as available work.

## What's already on main (verified)

- `scripts/generate-wasmtime-hot-runtime.mjs` — `WARM_DRIVER_SOURCE`, `timeWasmtimeWarmIter`, `--invoke warm`, warm-variant compile + precompile (cold lane untouched). 9 warm-lane symbol references, all tagged `#1760`.
- `benchmarks/results/wasm-host-wasmtime-hot-runtime.json` — re-baselined with the `warm` scenario + `wasmStdUs` provenance.
- Subsequent commits `e92460a68`, `e2c0aff99` built further on it (rust host for the cold lanes).

All three Deliverables in the issue are satisfied on `main`.

## Change in this PR

Frontmatter-only: `status: ready` → `done`, `sprint: Backlog` → `65`, add `completed:` and a `## Resolution` note pointing at the landing commit. No code change.

## Why it matters

This warm in-process repeated-measure lane is the **measurement gate** that unblocks the string-hash perf work — #1762 (linear-memory string backing) and #2621. Per-call warm deltas are now resolvable (string-hash run-to-run spread down from ~2.3× to ~4%), so those issues can demonstrate honest, reproducible drops rather than publishing noise.

Closes #1760.

🤖 Generated with [Claude Code](https://claude.com/claude-code)