### PR TITLE
fix(#2640): array-like generic-method callback receiver arg null-deref

### DIFF
--- a/plan/issues/2640-arraylike-call-receiver-arg-length-nullderef.md
+++ b/plan/issues/2640-arraylike-call-receiver-arg-length-nullderef.md
@@ -1,0 +1,131 @@
+---
+id: 2640
+title: "Array.prototype.X.call(arrayLike, cb): callback's receiver-arg .length/[i] null-derefs (typed-vec param vs dynamic externref receiver)"
+status: done
+assignee: ttraenkler/sdev-bce
+sprint: 65
+created: 2026-06-24
+completed: 2026-06-24
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: arrays, closures, array-like dispatch
+goal: test262-conformance
+related: [2580, 983d]
+---
+
+# #2640 — `Array.prototype.X.call(arrayLike, cb)` callback receiver-arg `.length`/`[i]` null-deref
+
+## Problem (bisected, faithful `runTest262File`, host mode)
+
+When a generic `Array.prototype.X.call(arrayLike, cb)` over a **dynamic
+(non-vec) array-like receiver** invokes its callback, it passes the receiver
+back as the callback's array argument (`cb`'s 3rd arg for `forEach`/`map`/…, 4th
+for `reduce`/`reduceRight`). Inside the callback, reading `obj.length` or
+`obj[i]` on that argument **dereferences a null pointer**:
+
+```js
+var got = -1;
+Array.prototype.forEach.call({ 0: 5, 1: 6, length: 2 },
+  function (v, i, obj) { got = obj.length; });   // → "dereferencing a null pointer in __closure_0"
+```
+
+Bisection (forEach native arm, cross-method): the callback's **value arg**
+(1st) and **index arg** (2nd) read fine; only the **receiver/array arg** traps.
+`obj` outside a callback (`o.length === 2`) reads correctly via the M2.1
+`.length`-on-any reader — so the trap is specific to the receiver re-passed into
+the closure.
+
+### Root cause (from the emitted WAT)
+
+The callback's array parameter is inferred by TypeScript as the array type
+(`T[]`) from `Array.prototype.forEach`'s callback signature, so codegen lowers
+it to a typed WasmGC vec ref:
+
+```wat
+(type $__fn_wrap_1_type (func (param (ref null 23) externref f64 (ref null 2))))
+;;                                          v: extern  i: f64  obj: (ref null $__vec_base)
+```
+
+But the actual receiver passed by the dispatch loop is a **dynamic externref**
+(an `extern.convert_any`-wrapped `$__anon_0` object-literal struct), which is
+**not** a subtype of `$__vec_base`. So the call-site coercion (`externref` →
+vec ref) `ref.test`s the receiver, fails, and pushes **`ref.null`** as the
+`obj` argument:
+
+```wat
+local.get 1            ;; receiver externref ($__anon_0-wrapped)
+any.convert_extern
+ref.test (ref 2)       ;; is it $__vec_base?  NO
+(if (result (ref null 2)) (then …) (else ref.null 2))   ;; ← pushes NULL
+```
+
+Then inside the closure, `obj.length` lowers to `struct.get $__vec_base 0` on
+**null** → trap. (For an inline arrow whose `obj` param happens to stay
+`externref`, the read instead routes through the M2.1 dynamic reader and is
+correct — which is why the bug only surfaces when TS gives the param a concrete
+vec type, e.g. inside the test262 wrapper's full-signature context.)
+
+## Fix (gated, value-rep-safe)
+
+`compileArrayLikePrototypeCall` is entered **only** for a non-vec array-like
+receiver — real `__vec_`/`__arr_` receivers bail out upstream (lines ~700-712).
+So the typed `arr.forEach(cb)` hot path **never** enters this function. The fix
+forces any callback parameter that TS inferred as a typed vec/array
+(`__vec_*`/`__arr_*`/`$__vec_base`) to `externref` for the callback compiled on
+this path, so `obj.length`/`obj[i]` lower through the tag-aware dynamic reader:
+
+1. **`ctx.forceExternrefCallbackParams`** (`src/codegen/context/types.ts`) — a
+   transient flag.
+2. **`compileArrowAsClosure`** (`src/codegen/closures.ts`) — when the flag is
+   set, widen any param whose resolved ValType `isVecOrArrayRefType` to
+   `externref` (value=externref and index=f64 are untouched).
+3. **`compileArrayLikePrototypeCall`** (`src/codegen/array-methods.ts` ~849) —
+   set the flag around the callback compile, restore it after (nested closures
+   outside this path keep their typed params). The dispatch loop already coerces
+   the receiver `externref → paramTypes[N]`; with the param now `externref`
+   that coercion is a no-op and the receiver is passed directly.
+
+This is gated on the non-vec array-like path, so the byte image of any program
+that does not dispatch a generic array-like `.call(cb)` is unchanged.
+
+## Acceptance
+
+- `Array.prototype.forEach.call({0:5,1:6,length:2}, (v,i,obj)=>got=obj.length)`
+  → `got === 2` (no trap). Same for `obj[i]`, and across
+  forEach/map/some/every/find/findIndex/filter/indexOf/lastIndexOf.
+- ZERO regression on the typed `arr.forEach(cb)` / `arr.map(cb)` hot path
+  (it never enters this code path) — verified `[1,2,3].map(x=>x*2)` = 12.
+- Net-positive on the inline-callback array-like cluster, validated via the
+  full merge_group gate (value-rep / call-path touch → full-gate, not a scoped
+  sweep, per `project_broad_impact_validate_full_ci`).
+
+## Measured impact (local faithful `runTest262File` vs committed baseline)
+
+Scan of 217 inline-callback array-like `.call` tests under
+`built-ins/Array/prototype/*`: **+64 gains (baseline≠pass → pass), 0 losses**
+(no baseline-pass row regressed). Typed-array / normal-HOF controls unchanged.
+
+## Out of scope (separate follow-ups, NOT this slice)
+
+- **Named `function callbackfn(...)` + `reduce` boolean accumulator** — the
+  chartered corpus target `reduce/15.4.4.21-2-1` (a *named* fn whose body returns
+  a boolean `obj.length === 2`) fails for a DIFFERENT reason: the reduce arm
+  boxes an i32-boolean callback result via `f64.convert_i32_s` + `__box_number`
+  → a *number* accumulator, losing boolean identity (`typeof result` becomes
+  `"number"`, and the harness sees `2`). That needs the closure's TS boolean
+  return type carried in `ClosureInfo` + a boolean boxing path — a closure-
+  metadata change, not the receiver-arg fix. Tracked for a follow-up.
+- **`.call(primitive)` reading inherited `Boolean.prototype`/`Number.prototype`
+  indices** (`map/15.4.4.19-1-3`, `forEach/15.4.4.18-1-5`) — primitive
+  ToObject + prototype-chain inherited read = the #2580 M3 `[[Prototype]]`-link
+  substrate (deferred / architect-spec'd).
+
+## Files changed
+
+- `src/codegen/context/types.ts` — `forceExternrefCallbackParams` flag
+- `src/codegen/closures.ts` — `isVecOrArrayRefType` + gated param widening
+- `src/codegen/array-methods.ts` — set/restore the flag around the callback compile
+- `tests/issue-2640-arraylike-call-receiver-arg.test.ts` — regression suite

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -845,11 +845,24 @@ export function compileArrayLikePrototypeCall(
   fctx.body.push({ op: "i32.trunc_sat_f64_s" });
   fctx.body.push({ op: "local.set", index: lenTmp });
 
-  // Compile callback to closure
+  // Compile callback to closure.
+  // (#2640) This is the generic `Array.prototype.X.call(arrayLike, cb)` path
+  // over a DYNAMIC (non-vec) array-like receiver — the loop passes that
+  // receiver to the callback's array parameter (`cb`'s 3rd/4th arg) as an
+  // `externref`. TS infers that param as `T[]` → a typed vec ref, so without
+  // widening the dispatch below passes `ref.null` (the receiver fails the vec
+  // `ref.test`) and the callback's `obj.length`/`obj[i]` lowers to a
+  // `struct.get` on null → "dereferencing a null pointer". Force the
+  // callback's vec/array params to externref so those reads route through the
+  // tag-aware dynamic reader. Restore the prior flag afterward (nested
+  // closures outside this path must keep their typed params).
+  const savedForceExternrefCbParams = ctx.forceExternrefCallbackParams;
+  ctx.forceExternrefCallbackParams = true;
   const cbResult =
     ts.isArrowFunction(cbArg) || ts.isFunctionExpression(cbArg)
       ? compileArrowAsClosure(ctx, fctx, cbArg)
       : compileExpression(ctx, fctx, cbArg);
+  ctx.forceExternrefCallbackParams = savedForceExternrefCbParams;
   if (!cbResult || (cbResult.kind !== "ref" && cbResult.kind !== "ref_null")) return undefined;
   const closureTypeIdx = (cbResult as { typeIdx: number }).typeIdx;
   const closureInfo = ctx.closureInfoByTypeIdx.get(closureTypeIdx);

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -1124,6 +1124,22 @@ function isArrayLikeReceiverType(recvType: ts.Type, ctx: CodegenContext): boolea
   return false;
 }
 
+/**
+ * (#2640) True when `wt` is a (nullable) ref to a typed WasmGC vec/array
+ * struct (`__vec_*`/`__arr_*`/`$__vec_base`). Used to widen array-like
+ * generic-method callback params to externref (see
+ * `ctx.forceExternrefCallbackParams`). Mirrors the `__vec_`/`__arr_`
+ * receiver-bail detection in `compileArrayLikePrototypeCall`.
+ */
+function isVecOrArrayRefType(ctx: CodegenContext, wt: ValType): boolean {
+  if (wt.kind !== "ref" && wt.kind !== "ref_null") return false;
+  const typeIdx = (wt as { typeIdx: number }).typeIdx;
+  const typeDef = ctx.mod.types[typeIdx];
+  const name = typeDef && "name" in typeDef ? (typeDef as { name?: string }).name : undefined;
+  if (!name) return false;
+  return name.startsWith("__vec_") || name.startsWith("__arr_") || name === "__vec_base";
+}
+
 /** Check if an arrow/function expression is used as a callback argument to a call
  *  that targets a HOST import (not a user-defined function). User-defined functions
  *  should receive closures via the GC struct path, not the __make_callback host path. */
@@ -1417,6 +1433,19 @@ export function compileArrowAsClosure(
     //     pattern parameter.
     const hasBindingPattern = ts.isArrayBindingPattern(p.name) || ts.isObjectBindingPattern(p.name);
     if (hasBindingPattern && wasmType.kind !== "externref") {
+      wasmType = { kind: "externref" };
+    }
+    // (#2640) Array-like generic-method dispatch widens a callback parameter
+    // that TS inferred as a typed vec/array (`T[]` → `__vec_*`/`__arr_*`/
+    // `$__vec_base`) to `externref`. The receiver passed to such a callback by
+    // `compileArrayLikePrototypeCall` is a DYNAMIC (non-vec) array-like
+    // externref, not a typed vec; if the param stays a vec ref the dispatch
+    // loop must pass `ref.null` (the receiver fails the vec `ref.test`) and the
+    // callback's `obj.length`/`obj[i]` lowers to `struct.get` on null → a null
+    // deref. Widening to externref routes those reads through the tag-aware
+    // dynamic reader. Gated on the flag, set ONLY for the non-vec array-like
+    // path (typed `arr.forEach(cb)` never enters that path).
+    if (ctx.forceExternrefCallbackParams && isVecOrArrayRefType(ctx, wasmType)) {
       wasmType = { kind: "externref" };
     }
     arrowParams.push(wasmType);

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -949,6 +949,24 @@ export interface CodegenContext {
   }[];
   /** Counter for generated closure types/functions */
   closureCounter: number;
+  /**
+   * (#2640) When set, `compileArrowAsClosure` widens any callback parameter
+   * whose resolved type is a typed WasmGC vec/array (`__vec_*`/`__arr_*`/
+   * `$__vec_base`) to `externref`. Set transiently by
+   * `compileArrayLikePrototypeCall` around the callback compile: that path
+   * dispatches a generic `Array.prototype.X.call(arrayLike, cb)` over a
+   * DYNAMIC (non-vec) array-like receiver, and passes that receiver to the
+   * callback's array parameter as an `externref`. Without the widening,
+   * TypeScript infers the callback's array param as `T[]` → a typed vec ref,
+   * so the dispatch loop must pass `ref.null` (the receiver fails the vec
+   * `ref.test`) and the callback's `obj.length`/`obj[i]` lowers to a
+   * `struct.get` on null → "dereferencing a null pointer". Widening to
+   * externref routes those reads through the tag-aware dynamic reader.
+   * This path is ONLY entered for non-vec array-like receivers (real
+   * `__vec_`/`__arr_` receivers bail out of `compileArrayLikePrototypeCall`
+   * upstream), so the typed `arr.forEach(cb)` hot path is never touched.
+   */
+  forceExternrefCallbackParams?: boolean;
   /** Map from local variable name → closure metadata (for call_ref dispatch) */
   closureMap: Map<string, ClosureInfo>;
   /** Map from closure struct type index → closure metadata (for anonymous closures) */

--- a/tests/issue-2640-arraylike-call-receiver-arg.test.ts
+++ b/tests/issue-2640-arraylike-call-receiver-arg.test.ts
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// (#2640) `Array.prototype.X.call(arrayLike, cb)` over a DYNAMIC (non-vec)
+// array-like receiver passes that receiver back as the callback's array
+// argument. TypeScript infers that parameter as the array type (`T[]`) from the
+// method's callback signature, so codegen lowered it to a typed WasmGC vec ref.
+// The actual receiver is a dynamic externref (not a vec), so the dispatch loop
+// pushed `ref.null` for the argument and the callback's `obj.length` / `obj[i]`
+// lowered to `struct.get $__vec_base 0` on null → "dereferencing a null pointer".
+//
+// Fix (gated on `ctx.forceExternrefCallbackParams`, set ONLY for this non-vec
+// array-like path — real `__vec_`/`__arr_` receivers bail out upstream so the
+// typed `arr.forEach(cb)` hot path is untouched): widen vec/array callback
+// params to externref so `obj.length`/`obj[i]` route through the tag-aware
+// dynamic reader.
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(source: string): Promise<unknown> {
+  const result = await compile(source);
+  if (!result.success) {
+    throw new Error("compile error: " + result.errors.map((e) => e.message).join("; "));
+  }
+  if (!WebAssembly.validate(result.binary)) throw new Error("invalid wasm");
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as { setExports?: (e: WebAssembly.Exports) => void }).setExports?.(instance.exports);
+  return (instance.exports as { run: () => unknown }).run();
+}
+
+describe("#2640 array-like generic-method callback receiver argument", () => {
+  it("forEach.call(arrayLike): cb reads obj.length (was: null deref)", async () => {
+    expect(
+      await run(
+        `export function run() {
+           let got = -1;
+           Array.prototype.forEach.call({ 0: 5, 1: 6, length: 2 },
+             function (v, i, obj) { got = obj.length; });
+           return got;
+         }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("forEach.call(arrayLike): cb reads obj[i] (was: null deref)", async () => {
+    expect(
+      await run(
+        `export function run() {
+           let got = -1;
+           Array.prototype.forEach.call({ 0: 5, 1: 6, length: 2 },
+             function (v, i, obj) { got = obj[0]; });
+           return got;
+         }`,
+      ),
+    ).toBe(5);
+  });
+
+  it("forEach.call(arrayLike): value and index args still correct", async () => {
+    expect(
+      await run(
+        `export function run() {
+           let sum = 0;
+           let lastIdx = -1;
+           Array.prototype.forEach.call({ 0: 5, 1: 6, length: 2 },
+             function (v, i, obj) { sum += v; lastIdx = i; });
+           return sum * 10 + lastIdx;
+         }`,
+      ),
+    ).toBe(111); // sum=11, lastIdx=1 → 110 + 1
+  });
+
+  it("map.call(arrayLike): cb reads obj.length", async () => {
+    expect(
+      await run(
+        `export function run() {
+           const r = Array.prototype.map.call({ 0: 1, 1: 2, 2: 3, length: 3 },
+             function (v, i, obj) { return v + obj.length; });
+           return r[0] + r[1] + r[2];
+         }`,
+      ),
+    ).toBe(15); // (1+3)+(2+3)+(3+3) = 4+5+6
+  });
+
+  it("some.call(arrayLike): cb reads obj[i] against value", async () => {
+    expect(
+      await run(
+        `export function run() {
+           const ok = Array.prototype.some.call({ 0: 7, 1: 8, length: 2 },
+             function (v, i, obj) { return obj[i] === 8; });
+           return ok ? 1 : 0;
+         }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("every.call(arrayLike): cb reads obj.length each iteration", async () => {
+    expect(
+      await run(
+        `export function run() {
+           const ok = Array.prototype.every.call({ 0: 1, 1: 2, length: 2 },
+             function (v, i, obj) { return obj.length === 2; });
+           return ok ? 1 : 0;
+         }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("filter.call(arrayLike): cb reads obj[i]", async () => {
+    expect(
+      await run(
+        `export function run() {
+           const r = Array.prototype.filter.call({ 0: 10, 1: 20, 2: 30, length: 3 },
+             function (v, i, obj) { return obj[i] >= 20; });
+           return r.length * 100 + r[0];
+         }`,
+      ),
+    ).toBe(220); // [20,30] → length 2, r[0] 20
+  });
+
+  it("typed array hot path is untouched: [1,2,3].map(x=>x*2)", async () => {
+    expect(
+      await run(
+        `export function run() {
+           const a = [1, 2, 3];
+           const b = a.map(function (x) { return x * 2; });
+           return b[0] + b[1] + b[2];
+         }`,
+      ),
+    ).toBe(12);
+  });
+
+  it("typed array forEach callback can still read its array arg", async () => {
+    // Regression guard: the typed `arr.forEach(cb)` path never enters
+    // compileArrayLikePrototypeCall, so the param widening must not change it.
+    expect(
+      await run(
+        `export function run() {
+           const a = [4, 5, 6];
+           let total = 0;
+           a.forEach(function (v, i, arr) { total += v + arr.length; });
+           return total;
+         }`,
+      ),
+    ).toBe(24); // (4+5+6) + 3*3 = 15 + 9
+  });
+});


### PR DESCRIPTION
## Problem

`Array.prototype.X.call(arrayLike, cb)` over a **dynamic (non-vec) array-like receiver** passes the receiver back as the callback's array argument. Reading `obj.length` / `obj[i]` on that argument inside the callback **dereferences a null pointer**:

```js
Array.prototype.forEach.call({ 0: 5, 1: 6, length: 2 },
  (v, i, obj) => { got = obj.length; });   // → "dereferencing a null pointer in __closure_0"
```

**Root cause (from the emitted WAT):** TypeScript infers the callback's array param as the array type (`T[]`) from the method's callback signature, so codegen lowers it to a typed WasmGC vec ref (`(ref null $__vec_base)`). The actual receiver passed by the dispatch loop is a dynamic externref (an `extern.convert_any`-wrapped object-literal struct), which is **not** a subtype of `$__vec_base`. So the call-site coercion `ref.test`s the receiver, fails, and pushes **`ref.null`** for the argument. Inside the closure, `obj.length` lowers to `struct.get $__vec_base 0` on null → trap.

## Fix (gated, value-rep-safe)

`compileArrayLikePrototypeCall` is entered **only** for non-vec array-like receivers — real `__vec_`/`__arr_` receivers bail out upstream, so the typed `arr.forEach(cb)` hot path **never** enters this function. The fix sets a transient `ctx.forceExternrefCallbackParams` flag around the callback compile; `compileArrowAsClosure` then widens any param whose resolved type is a typed vec/array (`isVecOrArrayRefType`) to `externref`, so `obj.length`/`obj[i]` route through the tag-aware dynamic reader. The dispatch loop already coerces the receiver to the param type; with the param now `externref` that coercion is a no-op and the receiver passes directly. **Byte-identical** for any program that does not dispatch a generic array-like `.call(cb)`.

## Validation

- Local faithful `runTest262File` vs committed baseline: **+64 gains / 0 losses** across 217 inline-callback array-like `.call` tests.
- New suite `tests/issue-2640-arraylike-call-receiver-arg.test.ts` (9 cases incl. typed-path regression guards) green; sibling array-like suites (31) + array-methods (22) green; `tsc`/`prettier` clean.
- **Value-rep / call-path touch → authoritative validation is the full merge_group gate** (per `project_broad_impact_validate_full_ci`), not a scoped sweep.

## Out of scope (separate follow-ups)

- Named-`function` + `reduce` boolean-accumulator boxing (`reduce/15.4.4.21-2-1` — the reduce arm boxes an i32-boolean callback result as a number, losing boolean identity). Closure-metadata change, not the receiver-arg fix.
- `.call(primitive)` reading inherited `Boolean.prototype`/`Number.prototype` indices = #2580 M3 `[[Prototype]]`-link substrate (deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)