### PR TITLE
fix(codegen): #2641 allocate Wasm local for let/const shadowing a module global

### DIFF
--- a/plan/issues/2641-native-string-finalize-shift-wasi-class-method.md
+++ b/plan/issues/2641-native-string-finalize-shift-wasi-class-method.md
@@ -1,0 +1,296 @@
+---
+id: 2641
+title: "Native-string finalize-shift emits invalid Wasm for a class method using __str_concat/__str_fromCharCode under --target wasi (with deferred WASI helpers)"
+status: done
+completed: 2026-06-24
+created: 2026-06-24
+updated: 2026-06-24
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: native-strings
+goal: standalone
+sprint: 65
+related: [2632, 1677, 1903, 2039, 2563, 1690]
+origin: "Surfaced by #2632 Phase 3 (process.stdin Readable): a string/Buffer-chunk Readable class blocks on this; CONFIRMED pre-existing on origin/main with zero Phase-3 code."
+---
+# #2641 — native-string finalize-shift × deferred WASI helpers × class-method body → invalid Wasm
+
+## Problem
+
+A class whose **method** builds a native string via the native-string helpers
+(`__str_concat` / `__str_fromCharCode`) and stores the result into a field of a
+**class-struct-typed** local/field, compiled with **`--target wasi`** (which
+registers the deferred WASI helper set — timer min-heap / reactor / stdin
+drain via `emitDeferredWasiHelpers`), emits **invalid Wasm**:
+
+```
+global.set expected (ref null <class struct>), found call of (ref null <string-tree>)
+```
+
+i.e. a `global.set` (or field/local set) targeting a class-struct ref type
+receives a value typed as the native-string tree type — a type mismatch baked
+into the emitted module. The identical class using `number[]` chunks instead of
+string chunks compiles to **valid** Wasm, isolating the fault to the
+native-string path, not the class/method machinery itself.
+
+## CONFIRMED pre-existing (not introduced by #2632 Phase 3)
+
+Reproduced on **clean `origin/main` with ZERO Phase-3 code** — a timer-driven,
+Phase-2-only program. So this is a latent codegen bug that the #2632 Phase-3
+faithful `process.stdin` library (string/Buffer chunks) is the first consumer to
+trip. Phase 3 stopped here rather than auto-injecting a string-based prelude that
+would emit invalid Wasm for many user programs.
+
+## Suspected root cause (for architect confirmation)
+
+> **ARCHITECT NOTE (2026-06-24): the suspicion below is REFUTED.** It is not a
+> finalize-shift / deferred-WASI-helper index desync, and not WASI-specific. The
+> real cause is a lexical-shadowing bug (a function-local that collides with a
+> same-named module variable is never given a Wasm local). See
+> `## Implementation Plan`. The original text is kept for history.
+
+The native-string **finalize-shift** family — `reconcileNativeStrFinalizeShift`
+and relatives (#1677 / #1903 / #2039 / #2563) — rewrites/repoints indices when
+native-string helpers are materialized late. Interaction with
+`emitDeferredWasiHelpers` (which itself registers late helpers/types for the
+timer-heap + reactor under `--target wasi`) appears to desync a type index or a
+helper return-type so that a `*.set` against a class-struct ref ends up fed by a
+string-tree-typed producer. This is the compiler's most fragile index-shift
+area; a localized band-aid carries high regression risk — needs a root-cause,
+not a patch.
+
+## Acceptance
+
+- A minimal repro in `.tmp/` (string-field class method → invalid Wasm) plus a
+  valid control, with the exact validator error. **(done — see artifacts below)**
+- Root cause identified. **(done — variable-scope collision, see plan)**
+- Fix emits valid Wasm for the class method (+ constructor + generator method)
+  with **zero test262 regression** (verify IN BATCH + `runTest262File`, per
+  #1968 — isolated byte-diff is a false negative here).
+- Unblocks #2632 Phase 3's faithful string/Buffer `process.stdin` `Readable`
+  library (auto-injected prelude + `read([size])`).
+
+## Out of scope
+
+- The #2632 Phase-3 **substrate** (reactor↔stream wiring + intrinsics + byte
+  `Readable`) — that is byte-neutral / zero-regression and lands independently.
+- Async/event-loop semantics (already covered by #2632 P1/P2).
+
+---
+
+## Implementation Plan
+
+### TL;DR — the suspected cause is REFUTED; the real bug is a variable-scope collision
+
+This is **NOT** a native-string finalize-shift / `emitDeferredWasiHelpers` index
+desync. The finalize-shift machinery is innocent. The deferred-WASI-helper set
+is **not** the trigger. The real root cause is a **lexical-shadowing bug**: a
+function-local `let`/`const` whose name matches a **module-level variable** is
+never allocated a Wasm local, so every read/write of it falls through to the
+**module global** of the same name. Under native strings the type mismatch
+(string-tree value → class-struct global) surfaces as invalid Wasm; with
+matching types it **silently corrupts the module variable** (a latent
+miscompilation — see "Wider impact").
+
+It reproduces on **every target** (`wasi`, `standalone`, AND default `gc`/JS-host
+— so it is target-independent), and is fully independent of WASI deferred
+helpers, timers, and the reactor.
+
+### Root cause (verified by IR inspection + binary disassembly)
+
+For the minimal repro (a class method's local `let s = ""` building a string via
+`s += String.fromCharCode(b)`, with a module-level `const s = get()` typed as the
+class struct), the emitted `R_build` contains:
+
+```wat
+;; s += ... lowered AGAINST the module global __mod_s (type ref null $R), not a local:
+(global.set $__mod_s              ;; declared (mut (ref null $R))  ← class struct
+  (call $__str_concat ...))       ;; returns ref $AnyString        ← string tree
+```
+
+→ `global.set expected (ref null <R>), found call of (ref null <AnyString>)`.
+
+Instrumentation of `compileNativeStringCompoundAssignment` confirmed: in
+`R_build`, `fctx.localMap` = `[this, __tmp_0, b]` — **`s` is absent**. The `+=`
+site therefore resolves `s` to `ctx.moduleGlobals.get("s")` (the module global).
+Both maps key `s`; precedence is "local first", but the local was never created,
+so the module global wins.
+
+Two independent defects together cause `s` to never get a local:
+
+1. **`src/codegen/index.ts` — `walkStmtForLetConst` (~line 13600).**
+   The let/const hoister skips allocating a local for any name that collides with
+   a module global:
+   ```ts
+   if (fctx.localMap.has(name)) continue;
+   if (ctx.moduleGlobals.has(name)) continue;   // ← BUG: suppresses lexical shadowing
+   ```
+   This `continue` has no rationale comment and predates #1690b (which fixed the
+   *store-site* shadowing in `compileVariableStatement` but RELIES on the hoister
+   having pre-allocated the shadowing local — a contract this line breaks). The
+   hoister runs only for real function bodies (via `function-body.ts`
+   `hoistLetConstWithTdz`), never for `__module_init`, so this skip serves no
+   legitimate purpose — top-level `let s` becomes the module global through a
+   different path regardless.
+
+2. **`src/codegen/class-bodies.ts` — class method / constructor / generator-method
+   body compilation does NOT hoist at all.** The non-generator instance/static
+   method path (`} else if (member.body) { for (const stmt of member.body.statements) compileStatement(...) }`,
+   ~line 2178), the constructor path (`for (const stmt of ctor.body.statements)`,
+   ~line 1779 — and the duplicate at ~635), and the generator-method path
+   (~line 2144) all compile statements **without** calling
+   `hoistVarDeclarations` / `hoistLetConstWithTdz` first. Free functions DO
+   (`function-body.ts` ~lines 1052-1053 / 1122-1125). So in a class method a
+   `let s` is created lazily by `compileVariableStatement`, whose #1690b
+   `hasLocalShadow = fctx.localMap.has(name)` check is `false` (no hoist ran),
+   so the decl-init stores into the **module global** and never mints a local.
+
+Both must be fixed: defect (2) is why **class methods/constructors** trip it
+(the #2641 symptom); defect (1) is why **free functions** silently alias a
+same-named module variable. Fixing only one is insufficient — verified: with the
+method-hoist added but line 13600 left in place, the hoist itself skips `s`
+(because `moduleGlobals.has("s")`), and the invalid Wasm persists.
+
+### Wider impact (this is a correctness bug, not just an invalid-Wasm bug)
+
+With **matching** types the bug produces no validation error but **silently
+corrupts** the module variable. Verified repro (default `gc` target):
+```ts
+function f(): number { let s = 0; s = 41; s = s + 1; return s; }
+let s = 100;
+// f() returns 42 (correct), but module `s` is clobbered to 42 (should stay 100)
+```
+Before fix: module `s` prints `42`. After fix: prints `100`. So the fix closes a
+real miscompilation, not only the WASI/native-string invalid-Wasm manifestation.
+
+### Changes
+
+**File: `src/codegen/index.ts`** — function `walkStmtForLetConst` (~line 13600)
+- **Remove** the `if (ctx.moduleGlobals.has(name)) continue;` line so a
+  function-body let/const always gets its own local (proper lexical shadowing).
+- Keep the preceding `if (fctx.localMap.has(name)) continue;` (idempotency).
+- Invariant to preserve: this walker is invoked ONLY for real function bodies
+  (free functions via `function-body.ts`, and — after the change below — class
+  methods/ctors). `__module_init` does **not** run it, so top-level `let`/`const`
+  remain module globals. Confirm with the top-level negative control below.
+
+**File: `src/codegen/class-bodies.ts`** — add the missing hoist to every method /
+constructor body-statement loop, mirroring `function-body.ts`:
+- Import `hoistVarDeclarations, hoistLetConstWithTdz` from `./index.js`.
+- **Non-generator instance/static method** path (`} else if (member.body) {`,
+  ~line 2178): before the `for (const stmt of member.body.statements)` loop, call
+  `hoistVarDeclarations(ctx, fctx, member.body.statements)` then
+  `hoistLetConstWithTdz(ctx, fctx, member.body.statements)`.
+- **Constructor** path (~line 1779; check the ~635 site too): hoist
+  `ctor.body.statements` once before its statement loop. NOTE: the ctor loop also
+  handles `super(...)` inlining — hoist BEFORE the loop, do not perturb the
+  super-call handling.
+- **Generator-method** path (~line 2144): hoist `member.body.statements` before
+  the yield-collection statement loop (it already pushes a body via
+  `pushBody`/`popBody`; hoist into the same `fctx` before the loop, matching the
+  free-function generator path in `function-body.ts` ~1052).
+- **#1210 string-builder parity (recommended, not strictly required for
+  correctness):** free functions also run `detectStringBuilders` →
+  `fctx.pendingStringBuilders` before hoisting (function-body.ts ~1104-1108) so
+  `let s=""; loop s+=…` uses the in-place buffer fast path. Without it, class
+  methods still emit CORRECT (now-local) code via the generic `__str_concat`
+  path — just without the builder optimization. Add the detector call for parity
+  if low-risk; otherwise file a follow-up. Gate it exactly as function-body.ts
+  does: `if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0)`.
+
+No change needed in `compileVariableStatement` (variables.ts) — its #1690b
+`hasLocalShadow` store-into-local logic already does the right thing **once the
+local exists** (it does, after the two changes above). No change needed in the
+read path (`compileIdentifier`) or the `+=` paths — they already check
+`localMap` before `moduleGlobals`.
+
+### Wasm IR pattern (after fix)
+
+```wat
+(local $s (ref null $AnyString))      ;; minted by the hoist
+;; s += ...
+(local.get $s)
+(call $__str_concat ... )
+(local.tee $s)                         ;; writes the LOCAL, not the module global
+```
+
+### Edge cases to cover in tests
+- Class **method** local shadowing a module var typed as a class struct (the
+  #2641 invalid-Wasm case). Targets: wasi, standalone, gc — all must be VALID.
+- Class **constructor** local shadowing (verified to reproduce: `R_init`).
+- **Generator method** local shadowing (covered by adding the hoist there).
+- **Static method** local shadowing.
+- **Matching-type** silent-aliasing case (free function `let s` vs module `let s`
+  both `number`) — assert the module var is NOT clobbered (correctness, not just
+  validity).
+- **Negative control**: module-level `let a; let b; a = a + b;` with NO function
+  shadowing — module globals must still read/write correctly (top-level path
+  unaffected). Verified after the index.ts change.
+- **TDZ**: a shadowing `let`/`const` accessed before its decl inside the method
+  must still throw ReferenceError (the hoist sets up TDZ flags — verify the
+  added `hoistLetConstWithTdz` call preserves this, same as free functions).
+- Nested blocks / loops inside the method (the hoister already recurses through
+  blocks/if/loops/try — see `walkStmtForLetConst` recursion).
+
+### Verification (MANDATORY — per #1968, isolated byte-diff is a FALSE NEGATIVE here)
+- This touches the shared per-process hoist/scope path; validate **IN BATCH** and
+  via `runTest262File`, not single-file byte-diff (memory
+  `project_1917_coercion_engine_byte_diff_gate`).
+- Run the full equivalence suite + a representative test262 batch covering
+  classes, methods, constructors, generators, and let/const scoping. Watch the
+  `dev-self-merge` bucket analysis for any class/scope path regressions.
+- Expected **net-positive or byte-neutral**: programs with no
+  function-local↔module-global name collision are unaffected (the hoister still
+  skips already-present names; the only behavioral delta is when a real collision
+  exists, where it now does the spec-correct thing). Confirm no broad byte-diff
+  on collision-free programs.
+
+### Repro artifacts (architect-distilled, in `.tmp/` of the diagnosis worktree
+`/workspace/.claude/worktrees/agent-aa962886b10e2f6e4/.tmp/`)
+- `min2641.ts` — minimal class-method string×struct invalid-Wasm repro (+ the
+  `_renamed`/`_numvar` controls).
+- `ctorbug.ts` — constructor variant (`R_init` invalid Wasm).
+- `corrupt.ts` — matching-type silent-aliasing correctness repro.
+- `freefn.ts` — free-function manifestation (valid-but-aliasing).
+- The oversized `lib-min.ts` (the #2632 Phase-3 string `Readable`) reduces to
+  `min2641.ts`; both go INVALID→VALID with the two-part fix.
+
+### Validated fix (architect prototype — confirmed, then reverted)
+Applying BOTH changes was prototyped and confirmed:
+`min2641.ts` → VALID on wasi/standalone/gc; `lib-min.ts` → VALID;
+`corrupt.ts` module `s` → correctly `100`; top-level `let a/b` → correct.
+Sampled class test files (`class-method-struct-new`, `abstract-classes`, etc.)
+showed **identical** pass/fail counts with and without the change (the few
+failures there are pre-existing environment harness issues — same on clean
+`origin/main`), i.e. no regression introduced.
+
+## Test Results (implementation, 2026-06-24)
+
+Both parts of the fix landed:
+- `src/codegen/index.ts` `walkStmtForLetConst`: removed the
+  `moduleGlobals.has(name) continue` skip (defect 1).
+- `src/codegen/class-bodies.ts`: added `hoistVarDeclarations` +
+  `hoistLetConstWithTdz` (+ the `#1210` `detectStringBuilders` parity gate,
+  `if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0)`) before the
+  **constructor**, **non-generator method**, **generator-method**, **getter**,
+  and **setter** body loops (defect 2). The ctor field-collection scan at ~635
+  is field-discovery only — left untouched.
+
+New `tests/issue-2641.test.ts` (10 cases, all pass): class method / ctor /
+generator method / static method shadowing → VALID (wasi + gc); free-function
+and class-method matching-type silent-aliasing → module var NOT clobbered;
+two negative controls (top-level `let a/b`; collision-free local); TDZ
+shadowing read-before-decl throws (caught → -1, does not fall through to the
+module global).
+
+Repro confirmed on clean `origin/main`: `min2641.ts` (method) + `ctorbug.ts`
+(ctor) INVALID `global.set`; after fix all → VALID. Batch validation per #1968:
+the class/generator/scope batch and the `tdz-reference-error` /
+`class-*` suites show **identical** pass/fail counts vs clean `origin/main`
+(the failures there are pre-existing harness import-object issues —
+`string_constants` / `__unbox_number` — not codegen). `issue-1690b` var-shadow
+suite (8/8) and the IR fallback gate (all deltas 0) stay green. Net: +10
+passing tests, 0 new failures.

--- a/src/codegen/class-bodies.ts
+++ b/src/codegen/class-bodies.ts
@@ -34,8 +34,12 @@ import {
   extractConstantDefault,
   hasAbstractModifier,
   hasStaticModifier,
+  hoistLetConstWithTdz, // (#2641) lexical shadowing in class method/ctor/generator bodies
+  hoistVarDeclarations, // (#2641)
   resolveWasmType,
 } from "./index.js";
+import { detectStringBuilders } from "./string-builder.js"; // (#2641/#1210) string-builder fast-path parity in class methods
+import type { StringBuilderPresizeInfo } from "./string-builder.js";
 import { emitUndefined } from "./expressions/late-imports.js";
 import { addStringConstantGlobal, ensureExnTag, nextModuleGlobalIdx } from "./registry/imports.js";
 import { emitWasiErrorConstructor, getOrRegisterErrorStructType, isWasiErrorName } from "./registry/error-types.js";
@@ -1776,6 +1780,21 @@ function compileClassBodiesInner(
         "Must call super constructor in derived class before accessing 'this' or returning from derived constructor",
       );
     } else if (ctor?.body) {
+      // (#2641) Hoist var + let/const declarations BEFORE the body loop, just
+      // like free functions (function-body.ts). Without this, a constructor-local
+      // `let`/`const` that shadows a same-named module variable never gets a Wasm
+      // local and falls through to the module global (invalid Wasm with native
+      // strings, silent miscompilation otherwise). Hoisting BEFORE the loop leaves
+      // the super-call inlining below undisturbed. The #1210 string-builder
+      // detector runs first so the hoist skips builder bindings (parity gate).
+      if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
+        const presize = new Map<ts.VariableDeclaration, StringBuilderPresizeInfo>();
+        const builders = detectStringBuilders(ctx, ctor.body, presize);
+        if (builders.size > 0) fctx.pendingStringBuilders = builders;
+        if (presize.size > 0) fctx.stringBuilderPresize = presize;
+      }
+      hoistVarDeclarations(ctx, fctx, ctor.body.statements);
+      hoistLetConstWithTdz(ctx, fctx, ctor.body.statements);
       for (const stmt of ctor.body.statements) {
         // Handle super(args) calls: inline parent constructor field initialization
         if (
@@ -2141,6 +2160,19 @@ function compileClassBodiesInner(
         for (let i = 0; i < fctx.breakStack.length; i++) fctx.breakStack[i]!++;
         for (let i = 0; i < fctx.continueStack.length; i++) fctx.continueStack[i]!++;
 
+        // (#2641) Hoist var + let/const so a generator-method-local that shadows
+        // a same-named module variable gets its own Wasm local (mirrors the
+        // free-function generator path in function-body.ts). Hoist into the
+        // same fctx, inside the pushBody scope, before the body loop.
+        if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
+          const presize = new Map<ts.VariableDeclaration, StringBuilderPresizeInfo>();
+          const builders = detectStringBuilders(ctx, member.body, presize);
+          if (builders.size > 0) fctx.pendingStringBuilders = builders;
+          if (presize.size > 0) fctx.stringBuilderPresize = presize;
+        }
+        hoistVarDeclarations(ctx, fctx, member.body.statements);
+        hoistLetConstWithTdz(ctx, fctx, member.body.statements);
+
         for (const stmt of member.body.statements) {
           compileStatement(ctx, fctx, stmt);
         }
@@ -2176,6 +2208,19 @@ function compileClassBodiesInner(
         fctx.body.push({ op: "local.get", index: pendingThrowLocal });
         fctx.body.push({ op: "call", funcIdx: createGenIdx });
       } else if (member.body) {
+        // (#2641) Hoist var + let/const BEFORE the body loop so a method-local
+        // `let`/`const` shadowing a same-named module variable gets its own Wasm
+        // local rather than aliasing the module global (the #2641 invalid-Wasm
+        // symptom under native strings; a silent miscompilation otherwise).
+        // Mirrors free functions in function-body.ts.
+        if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
+          const presize = new Map<ts.VariableDeclaration, StringBuilderPresizeInfo>();
+          const builders = detectStringBuilders(ctx, member.body, presize);
+          if (builders.size > 0) fctx.pendingStringBuilders = builders;
+          if (presize.size > 0) fctx.stringBuilderPresize = presize;
+        }
+        hoistVarDeclarations(ctx, fctx, member.body.statements);
+        hoistLetConstWithTdz(ctx, fctx, member.body.statements);
         for (const stmt of member.body.statements) {
           compileStatement(ctx, fctx, stmt);
         }
@@ -2270,6 +2315,16 @@ function compileClassBodiesInner(
       ctx.currentFunc = fctx;
 
       if (member.body) {
+        // (#2641) Hoist so a getter-body local shadowing a module variable gets
+        // its own Wasm local (same vulnerability as method/ctor bodies).
+        if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
+          const presize = new Map<ts.VariableDeclaration, StringBuilderPresizeInfo>();
+          const builders = detectStringBuilders(ctx, member.body, presize);
+          if (builders.size > 0) fctx.pendingStringBuilders = builders;
+          if (presize.size > 0) fctx.stringBuilderPresize = presize;
+        }
+        hoistVarDeclarations(ctx, fctx, member.body.statements);
+        hoistLetConstWithTdz(ctx, fctx, member.body.statements);
         for (const stmt of member.body.statements) {
           compileStatement(ctx, fctx, stmt);
         }
@@ -2414,6 +2469,16 @@ function compileClassBodiesInner(
       }
 
       if (member.body) {
+        // (#2641) Hoist so a setter-body local shadowing a module variable gets
+        // its own Wasm local (same vulnerability as method/ctor bodies).
+        if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0) {
+          const presize = new Map<ts.VariableDeclaration, StringBuilderPresizeInfo>();
+          const builders = detectStringBuilders(ctx, member.body, presize);
+          if (builders.size > 0) fctx.pendingStringBuilders = builders;
+          if (presize.size > 0) fctx.stringBuilderPresize = presize;
+        }
+        hoistVarDeclarations(ctx, fctx, member.body.statements);
+        hoistLetConstWithTdz(ctx, fctx, member.body.statements);
         for (const stmt of member.body.statements) {
           compileStatement(ctx, fctx, stmt);
         }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -13597,7 +13597,16 @@ function walkStmtForLetConst(ctx: CodegenContext, fctx: FunctionContext, stmt: t
       if (ts.isIdentifier(decl.name)) {
         const name = decl.name.text;
         if (fctx.localMap.has(name)) continue;
-        if (ctx.moduleGlobals.has(name)) continue;
+        // #2641: do NOT skip names that collide with a module global. A
+        // function-body let/const that shadows a same-named module variable
+        // MUST get its own Wasm local (proper lexical shadowing). Previously
+        // this `continue` suppressed the shadow, so every read/write of the
+        // local fell through to the module global of the same name — invalid
+        // Wasm with mismatched types (string-tree value → class-struct global,
+        // the #2641 symptom) and a silent miscompilation (module var clobbered)
+        // with matching types. This walker runs ONLY for real function bodies
+        // (free functions and, after #2641, class methods/ctors); __module_init
+        // does NOT run it, so top-level let/const still become module globals.
         const varType = ctx.checker.getTypeAtLocation(decl);
         // #1120: pre-allocate as i32 if collectI32CoercedLocals tagged this
         // local — keeps the hoisted slot in sync with what compileVariableStatement

--- a/tests/issue-2641.test.ts
+++ b/tests/issue-2641.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Issue #2641 — function/class-method/ctor/generator-method local `let`/`const`
+ * that shadows a same-named MODULE-level variable was never allocated a Wasm
+ * local, so every read/write fell through to the module global of the same name.
+ *
+ * Two defects together (see plan/issues/2641-*.md):
+ *  1. `walkStmtForLetConst` (src/codegen/index.ts) skipped allocating a local
+ *     for any name colliding with a module global (`moduleGlobals.has(name)`).
+ *  2. class-bodies.ts method / constructor / generator-method / accessor bodies
+ *     never ran the hoist passes at all.
+ *
+ * Symptom with native strings + class-struct types: a `global.set` against the
+ * module-struct global is fed a native-string-tree value → INVALID Wasm. With
+ * matching types: the module variable is silently clobbered (a miscompilation).
+ *
+ * These are validity + correctness tests; the shared per-process hoist/scope
+ * path means batch/test262 validation is also required (done in CI), but the
+ * targeted cases below pin the exact behaviors.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+import { compileToWasm } from "./equivalence/helpers.ts";
+
+/** Compile to a binary and assert WebAssembly accepts it, for a given target. */
+async function expectValid(source: string, target?: "wasi"): Promise<void> {
+  const opts: Record<string, unknown> = {};
+  if (target) opts.target = target;
+  const r = await compile(source, opts as never);
+  expect(r.binary && r.binary.length > 0).toBe(true);
+  // WebAssembly.compile surfaces the precise validation error (validate() only
+  // returns a boolean). The #2641 bug produced a global.set type mismatch here.
+  await expect(WebAssembly.compile(r.binary)).resolves.toBeDefined();
+}
+
+describe("#2641 lexical shadowing of module variables in function/class bodies", () => {
+  // ── Validity: native-string × class-struct shadowing must emit VALID Wasm ──
+
+  it("class METHOD: local string `s` shadowing a module var typed as a class struct → VALID (wasi)", async () => {
+    const src = `
+class R {
+  buf: string = "";
+  build(n: number): void {
+    let s = "";
+    let i = 0;
+    while (i < n) { s += String.fromCharCode(65 + i); i = i + 1; }
+    this.buf = s;
+  }
+}
+let g: R | null = null;
+function get(): R { if (g === null) g = new R(); return g; }
+const s = get();
+s.build(3);
+`;
+    await expectValid(src, "wasi");
+    await expectValid(src); // default gc/JS-host target — also affected
+  });
+
+  it("class CONSTRUCTOR: local string `s` shadowing a module struct var → VALID (wasi + gc)", async () => {
+    const src = `
+class R {
+  buf: string = "";
+  constructor(n: number) {
+    let s = "";
+    let i = 0;
+    while (i < n) { s += String.fromCharCode(65 + i); i = i + 1; }
+    this.buf = s;
+  }
+}
+let g: R | null = null;
+function get(): R { if (g === null) g = new R(2); return g; }
+const s = get();
+`;
+    await expectValid(src, "wasi");
+    await expectValid(src);
+  });
+
+  it("GENERATOR method: local string `s` shadowing a module struct var → VALID (gc)", async () => {
+    // The bug reproduced on the default gc/JS-host target too; assert validity
+    // there. (Under --target wasi, String.fromCharCode trips a pre-existing,
+    // unrelated `global_String` allowlist limitation — not #2641.)
+    const src = `
+class R {
+  *build(n: number): Generator<string> {
+    let s = "";
+    let i = 0;
+    while (i < n) { s += String.fromCharCode(65 + i); yield s; i = i + 1; }
+  }
+}
+let g: R | null = null;
+function get(): R { if (g === null) g = new R(); return g; }
+const s = get();
+`;
+    await expectValid(src);
+  });
+
+  it("GENERATOR method: numeric local shadowing a module struct var → VALID (wasi + gc)", async () => {
+    // String-free variant so it also holds under --target wasi.
+    const src = `
+class R {
+  *build(n: number): Generator<number> {
+    let s = 0;
+    let i = 0;
+    while (i < n) { s = s + i; yield s; i = i + 1; }
+  }
+}
+let g: R | null = null;
+function get(): R { if (g === null) g = new R(); return g; }
+const s = get();
+`;
+    await expectValid(src, "wasi");
+    await expectValid(src);
+  });
+
+  it("STATIC method: local string `s` shadowing a module struct var → VALID (wasi)", async () => {
+    const src = `
+class R {
+  static build(n: number): string {
+    let s = "";
+    let i = 0;
+    while (i < n) { s += String.fromCharCode(65 + i); i = i + 1; }
+    return s;
+  }
+}
+let g: R | null = null;
+function get(): R { if (g === null) g = new R(); return g; }
+const s = get();
+const out = R.build(2);
+`;
+    await expectValid(src, "wasi");
+  });
+
+  // ── Correctness: matching-type silent aliasing must NOT clobber the module var ──
+
+  it("free function: local `let s` shadowing a module `let s` does NOT clobber the module var", async () => {
+    const src = `
+function f(): number { let s = 0; s = 41; s = s + 1; return s; }
+let s = 100;
+export function test(): number {
+  const r = f();        // f() returns 42 via its OWN local s
+  return r * 1000 + s;  // module s must remain 100  →  42100
+}
+`;
+    const exports = await compileToWasm(src);
+    // Before the fix, the free-function local aliased the module global, so the
+    // module `s` was clobbered to 42 → result 42042. After the fix: 42100.
+    expect((exports as { test(): number }).test()).toBe(42100);
+  });
+
+  it("class method: local `let s` shadowing a module `let s` does NOT clobber the module var", async () => {
+    const src = `
+let s = 100;
+class C {
+  run(): number { let s = 0; s = 7; return s; }
+}
+export function test(): number {
+  const c = new C();
+  const r = c.run();    // 7, via the method's own local
+  return r * 1000 + s;  // module s must remain 100  →  7100
+}
+`;
+    const exports = await compileToWasm(src);
+    expect((exports as { test(): number }).test()).toBe(7100);
+  });
+
+  // ── Negative control: NO shadowing — module globals must read/write normally ──
+
+  it("negative control: module-level `let a; let b` with no function shadow still works", async () => {
+    const src = `
+let a = 5;
+let b = 7;
+export function test(): number {
+  a = a + b;   // 12
+  b = a - b;   // 5
+  return a * 100 + b;  // 1205
+}
+`;
+    const exports = await compileToWasm(src);
+    expect((exports as { test(): number }).test()).toBe(1205);
+  });
+
+  it("negative control: function local with NO module collision still works", async () => {
+    const src = `
+export function test(): number {
+  let local = 0;
+  for (let i = 0; i < 5; i = i + 1) { local = local + i; }
+  return local;  // 0+1+2+3+4 = 10
+}
+`;
+    const exports = await compileToWasm(src);
+    expect((exports as { test(): number }).test()).toBe(10);
+  });
+
+  // ── TDZ: a shadowing let accessed before its decl still throws ReferenceError ──
+
+  it("TDZ: method-local `let s` shadowing a module var, read before decl, throws ReferenceError", async () => {
+    const src = `
+let s = 100;
+class C {
+  run(): number {
+    // Access the LOCAL s before its declaration — TDZ must throw, and must
+    // NOT silently fall through to the module global (which the bug allowed).
+    const before = (s as number);
+    let s = 5;
+    return s + before;
+  }
+}
+export function test(): number {
+  const c = new C();
+  try { return c.run(); } catch (e) { return -1; }
+}
+`;
+    const exports = await compileToWasm(src);
+    // TDZ access throws → caught → -1 (NOT 105 which would mean it read the module global).
+    expect((exports as { test(): number }).test()).toBe(-1);
+  });
+});


### PR DESCRIPTION
## #2641 — lexical-shadowing bug: function/class-method local `let`/`const` colliding with a module variable was never given a Wasm local

A function/class-method/ctor/generator-method local `let`/`const` whose name matched a **module-level** variable was never allocated a Wasm local, so every read/write fell through to the **module global** of the same name.

- With native strings × class-struct types → **invalid Wasm**: `global.set` against a class-struct global fed a string-tree value (`global.set expected (ref null <R>), found call of (ref null <AnyString>)`). This is the #2641 symptom (surfaced by #2632 Phase 3's string `process.stdin` Readable).
- With matching types → **silent miscompilation**: the module variable is clobbered.

Target-independent (reproduced on wasi, standalone, and default gc/JS-host).

## Fix (both parts required — verified each insufficient alone)

1. **`src/codegen/index.ts` `walkStmtForLetConst`** — removed the `if (ctx.moduleGlobals.has(name)) continue;` skip so a function-body let/const always gets its own local (proper lexical shadowing). The walker runs only for real function bodies; `__module_init` does not run it, so top-level let/const stay module globals.
2. **`src/codegen/class-bodies.ts`** — added `hoistVarDeclarations` + `hoistLetConstWithTdz` (+ the #1210 `detectStringBuilders` parity gate, `if (ctx.nativeStrings && ctx.anyStrTypeIdx >= 0)`) before the **constructor**, **non-generator method**, **generator-method**, **getter**, and **setter** body loops, mirroring `function-body.ts`. Class bodies previously never hoisted, so a method-local was minted lazily and aliased the module global. The ctor field-collection scan (~635) is field-discovery only and left untouched; the ctor hoist runs *before* the super-call inlining loop so super handling is undisturbed.

## Tests / validation (per #1968 — batch, not isolated byte-diff)

- New `tests/issue-2641.test.ts` (10 cases, all green): class method / ctor / generator method / static method shadowing → **VALID** (wasi + gc); free-function and class-method matching-type silent-aliasing → module var **NOT** clobbered; two negative controls (top-level `let a/b`; collision-free local); TDZ shadowing read-before-decl still throws (caught → -1, does not fall through to the module global).
- Repro confirmed on clean `origin/main`: `min2641.ts` (method) + `ctorbug.ts` (ctor) INVALID; after fix → VALID.
- **Batch validation**: class/generator/scope equivalence batch, `tdz-reference-error`, and `class-*` suites show **identical** pass/fail counts vs clean `origin/main` (the failures there are pre-existing harness import-object issues — `string_constants` / `__unbox_number` — not codegen). `issue-1690b` var-shadow suite 8/8 green. IR-fallback gate: all deltas 0. Lint + typecheck clean. Net: **+10 passing tests, 0 new failures**.

Unblocks #2632 Phase 3's faithful string/Buffer `process.stdin` Readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)