### PR TITLE
fix(host-interop): #2639 lower node:fs writeSync(fd, str | DataView)

### DIFF
--- a/plan/issues/2639-node-fs-writesync-string-and-dataview-codegen.md
+++ b/plan/issues/2639-node-fs-writesync-string-and-dataview-codegen.md
@@ -1,0 +1,104 @@
+---
+id: 2639
+title: "node:fs writeSync(fd, str | DataView) codegen — make the #2634 surface compilable"
+status: done
+created: 2026-06-24
+updated: 2026-06-24
+completed: 2026-06-24
+assignee: ttraenkler/dev-2639
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: bug
+area: host-interop
+language_feature: node-api-compat
+goal: platform
+sprint: 65
+es_edition: n/a
+related: [2631, 2633, 2634, 1772, 2624]
+---
+
+# node:fs writeSync(fd, str | DataView) codegen
+
+## Problem
+
+The #2634 capability map (`src/checker/node-capability-map.ts`,
+`FS_WRITE_SYNC_DECLS`) declares TWO faithful `writeSync` overloads, mirroring
+`@types/node`:
+
+1. `writeSync(fd, buffer: __NodeFsArrayBufferView, offset?, length?, position?): number`
+2. `writeSync(fd, str: string, position?, encoding?): number`
+
+…and `__NodeFsArrayBufferView` includes `DataView`. So all of these
+**type-check**. But the codegen arm (`src/codegen/node-fs-api.ts`,
+`emitNodeFsWriteSync` + `emitNodeFsResolveGcU8`) only lowered the
+Uint8Array / ArrayBuffer GC-`$Vec` case. As a result, on current main under
+`--target wasi --link-node-shims`:
+
+- `writeSync(1, "hello")` compiled to a **valid** module but wrote **ZERO
+  bytes** — the GC-`$Vec` resolver returned `null` for a string arg, and the
+  codegen emitted an `f64.const 0` byte count and silently dropped the value.
+- `writeSync(1, new DataView(buf))` did the same — a `DataView` is part of
+  `__NodeFsArrayBufferView` but is not a GC `$Vec` the resolver recognized.
+
+Confirmed by linking the `node-fs` shim and capturing fd 1: both forms produced
+an empty stream. The typings promise a surface the compiler couldn't honour.
+
+## Approach
+
+Stay import-scoped + provider-agnostic — the module still just declares
+`import "node:fs" "writeSync"`; this is purely the codegen arm mapping a
+string / DataView arg onto the pinned `writeSync(fd, ptr, len)` ABI
+(`docs/architecture/node-fs-abi.md`). No new host import, no Node semantics
+inlined.
+
+- **String arm** (`writeSync(fd, str, position?, encoding?)`): encode the JS
+  string to UTF-8 and write to the **runtime** `fd` via the shim. Reuses the
+  exact WTF-16 → UTF-8 encoder that `process.std*.write(string)` already uses —
+  factored out of `ensureWasiWriteAnyStringHelper` into a shared
+  `buildWasiStringEncodeToScratch` (byte-identical, proven via a binary diff of
+  the `process.std*.write` path), with a new fd-parameterized
+  `ensureWasiWriteAnyStringFdHelper(s, fd) -> bytesWritten`. `encoding?` defaults
+  to utf8 (the only byte form the native-string lowering produces); an explicit
+  non-utf8 string-literal encoding is a clear **compile error**, not a silent
+  mis-encode. `position?` is ignored for the fd-streaming case, exactly as the
+  buffer overload ignores it for fd 0/1/2.
+- **DataView arm**: resolve the DataView's backing `i32_byte` array + base
+  byteOffset + byteLength to a `(ptr, len)` over the write scratch, mirroring the
+  DataView accessors' `recoverDvBacking` (handles both the bare offset-0 view and
+  the `$__dv_window` byteOffset/byteLength wrapper), then write that range. New
+  exported helper `emitDataViewToWriteScratch` in `dataview-native.ts`.
+
+## Acceptance
+
+- [x] `writeSync(1, "hi\n")` + `writeSync(2, "err\n")` compile and emit the
+      bytes to the right fd under `--target wasi` (linked node-fs shim),
+      end-to-end.
+- [x] Non-ASCII strings (multi-byte + astral `\u{1F600}`) and a runtime (rope)
+      string encode as correct UTF-8 (byte count = UTF-8 length).
+- [x] Explicit `"utf8"` / `"utf-8"` encoding accepted; an explicit non-utf8
+      encoding (e.g. `"hex"`) is rejected with a clear diagnostic.
+- [x] `writeSync(1, new DataView(buf))` writes the full backing range; a
+      `new DataView(buf, byteOffset, byteLength)` windowed view writes only that
+      range.
+- [x] Existing Uint8Array / ArrayBuffer `writeSync` + `process.std*.write` paths
+      unchanged (the `process.std*.write(string)` binary is byte-identical to
+      main).
+- [x] New wasmtime-style test over the linked shim for the string + DataView
+      forms (`tests/issue-2639-node-fs-writesync-string-dataview.test.ts`, 8
+      cases); tsc + biome lint clean.
+- [x] Validated in batch (#1968): node-fs / wasi / dataview suites green (37
+      pre-existing + 8 new), and a `runTest262File` DataView/String-concat
+      control batch unchanged (the one pre-existing String.concat `this`-coercion
+      fail and the pre-existing `process.argv` `it.fails` are unrelated to this
+      change).
+
+## Files
+
+- `src/codegen/node-fs-api.ts` — string + DataView arms in `emitNodeFsWriteSync`
+  (`emitNodeFsWriteSyncString`, `emitNodeFsWriteSyncDataView`).
+- `src/codegen/index.ts` — extracted `buildWasiStringEncodeToScratch` (shared
+  encoder) + new `ensureWasiWriteAnyStringFdHelper`.
+- `src/codegen/dataview-native.ts` — exported `emitDataViewToWriteScratch`
+  (reuses the existing private `recoverDvBacking`).
+- `tests/issue-2639-node-fs-writesync-string-dataview.test.ts` — new tests.

--- a/src/codegen/dataview-native.ts
+++ b/src/codegen/dataview-native.ts
@@ -891,3 +891,99 @@ function emitWriteBytes(
     else: storeAll(false),
   });
 }
+
+/**
+ * (#2639) Stage a native DataView's bytes into the linear write scratch so
+ * `node:fs` `writeSync(fd, dv)` can hand the shim a (ptr, len) pair.
+ *
+ * The DataView arg (an externref / GC ref already produced by compiling the
+ * argument expression — its `recvType` passed in) is resolved via
+ * {@link recoverDvBacking} to its i32_byte backing array + base byte offset +
+ * view byte length, mirroring exactly what the DataView accessors use. Then it
+ * copies `viewLen` bytes from `arr[base + j]` (masked to a byte) into
+ * `scratch[scratchStart + j]`. The DataView's backing array is `i32_byte` (one
+ * i32 per byte, 0..255), so each element is `& 0xff`-ed before the byte store.
+ *
+ * Returns the i32 local holding the view byte length (the count to write), or
+ * `-1` when the receiver isn't a resolvable DataView/ArrayBuffer view. The
+ * receiver value must already be on the stack (its `recvType` is consumed here).
+ * Memory is assumed already grown for `[scratchStart, scratchStart+viewLen)` —
+ * the caller grows it (it must, since the length is only known at runtime).
+ */
+export function emitDataViewToWriteScratch(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  recvType: ValType | null,
+  scratchStart: number,
+): number {
+  const { vecTypeIdx, arrTypeIdx } = i32ByteVec(ctx);
+  if (arrTypeIdx < 0) return -1;
+
+  const arrLocal = allocLocal(fctx, `__dvw_arr_${fctx.locals.length}`, { kind: "ref", typeIdx: arrTypeIdx });
+  const baseLocal = allocLocal(fctx, `__dvw_base_${fctx.locals.length}`, { kind: "i32" });
+  const lenLocal = allocLocal(fctx, `__dvw_len_${fctx.locals.length}`, { kind: "i32" });
+  if (!recoverDvBacking(ctx, fctx, recvType, arrLocal, baseLocal, vecTypeIdx, arrTypeIdx, lenLocal)) {
+    return -1;
+  }
+
+  // Grow linear memory so [scratchStart, scratchStart + len) is addressable.
+  const needPagesLocal = allocLocal(fctx, `__dvw_pages_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "i32.const", value: scratchStart } as Instr);
+  fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+  fctx.body.push({ op: "i32.add" } as Instr);
+  fctx.body.push({ op: "i32.const", value: 65535 } as Instr);
+  fctx.body.push({ op: "i32.add" } as Instr);
+  fctx.body.push({ op: "i32.const", value: 16 } as Instr);
+  fctx.body.push({ op: "i32.shr_u" } as Instr);
+  fctx.body.push({ op: "local.set", index: needPagesLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: needPagesLocal } as Instr);
+  fctx.body.push({ op: "memory.size" } as Instr);
+  fctx.body.push({ op: "i32.gt_u" } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [
+      { op: "local.get", index: needPagesLocal } as Instr,
+      { op: "memory.size" } as Instr,
+      { op: "i32.sub" } as Instr,
+      { op: "memory.grow" } as Instr,
+      { op: "drop" } as Instr,
+    ],
+  } as Instr);
+
+  // for j in [0, len): scratch[scratchStart + j] = arr[base + j] & 0xff
+  const jLocal = allocLocal(fctx, `__dvw_j_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "local.set", index: jLocal } as Instr);
+  const loopBody: Instr[] = [
+    { op: "local.get", index: jLocal } as Instr,
+    { op: "local.get", index: lenLocal } as Instr,
+    { op: "i32.ge_s" } as Instr,
+    { op: "br_if", depth: 1 } as Instr,
+    // addr = scratchStart + j
+    { op: "i32.const", value: scratchStart } as Instr,
+    { op: "local.get", index: jLocal } as Instr,
+    { op: "i32.add" } as Instr,
+    // value = arr[base + j] & 0xff
+    { op: "local.get", index: arrLocal } as Instr,
+    { op: "local.get", index: baseLocal } as Instr,
+    { op: "local.get", index: jLocal } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "array.get", typeIdx: arrTypeIdx } as Instr,
+    { op: "i32.const", value: 0xff } as Instr,
+    { op: "i32.and" } as Instr,
+    { op: "i32.store8", align: 0, offset: 0 } as Instr,
+    { op: "local.get", index: jLocal } as Instr,
+    { op: "i32.const", value: 1 } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "local.set", index: jLocal } as Instr,
+    { op: "br", depth: 0 } as Instr,
+  ];
+  fctx.body.push({
+    op: "block",
+    blockType: { kind: "empty" },
+    body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr],
+  } as Instr);
+
+  return lenLocal;
+}

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -6706,71 +6706,79 @@ export function ensureLinearU8AllocHelper(ctx: CodegenContext): number {
 }
 
 /**
- * #1618: Ensure __wasi_write_any_string(s: ref NativeString) -> void exists and
- * return its function index (lazy, emitted during expression compilation).
- *
- * Writes a *runtime* string (variable, concatenation, template span) to fd=1
- * (stdout) or fd=2 (stderr). Previously these refs fell through to the
- * `[object]` placeholder in emitWasiValueToStdout, corrupting the stream.
- *
- * Strategy: flatten any AnyString (FlatString / ConsString / Utf8String) to a
- * NativeString via the existing __str_flatten helper, then encode the WTF-16
- * code units as UTF-8 bytes directly into linear memory before issuing
- * fd_write. This keeps WASI string output on the pure-Wasm path (#1470) without
- * routing through the JS-host `__str_to_mem` / `TextEncoder` bridge.
- *
- * Param 0 is typed `ref NativeString` so callers can hand us a value compiled
- * as `{ kind: "ref", typeIdx: ctx.nativeStrTypeIdx }` directly; __str_flatten
- * accepts the NativeString supertype (AnyString) and returns the flat form.
+ * Local-index layout for the shared WTF-16 → UTF-8 encoder. `S` is the AnyString
+ * param's index; the ten work-locals (`FLAT`..`LO`) are laid out contiguously
+ * starting at `base`. In Wasm, params occupy the low indices then declared
+ * locals follow, so a helper with N params declares its work-locals starting at
+ * index N. The fixed-fd writer has one param (s=0) ⇒ base 1; the runtime-fd
+ * writer has two params (s=0, fd=1) ⇒ base 2 (#2639).
  */
-export function ensureWasiWriteAnyStringHelper(ctx: CodegenContext, useStderr: boolean = false): number {
-  const helperName = useStderr ? "__wasi_write_any_string_stderr" : "__wasi_write_any_string";
-  const existing = ctx.funcMap.get(helperName);
-  if (existing !== undefined) return existing;
+interface WasiStrEncodeLayout {
+  S: number;
+  FLAT: number;
+  LEN: number;
+  OFF: number;
+  DATA: number;
+  I: number;
+  O: number;
+  NEED_PAGES: number;
+  CU: number;
+  CP: number;
+  LO: number;
+}
 
-  // #2524 — node-process shim path needs no fd_write idx (see Uint8Array helper).
-  if (!ctx.wasi || (!ctx.linkNodeShims && ctx.wasiFdWriteIdx === undefined) || ctx.nativeStrTypeIdx < 0) return -1;
+/** Build the encoder local layout: AnyString param `s` at 0, work-locals at `base..base+9`. */
+function wasiStrEncodeLayout(base: number): WasiStrEncodeLayout {
+  return {
+    S: 0,
+    FLAT: base + 0,
+    LEN: base + 1,
+    OFF: base + 2,
+    DATA: base + 3,
+    I: base + 4,
+    O: base + 5,
+    NEED_PAGES: base + 6,
+    CU: base + 7,
+    CP: base + 8,
+    LO: base + 9,
+  };
+}
 
-  // Make sure the native-string runtime (incl. __str_flatten) is emitted.
-  ensureNativeStringHelpers(ctx);
-  // __str_flatten via funcMap (shift-maintained), not nativeStrHelpers (which can
-  // be stale-low after late imports). See the registration in
-  // ensureNativeStringHelpers. (#1618)
-  const flattenIdx = ctx.funcMap.get("__str_flatten");
-  if (flattenIdx === undefined) return -1;
+/** The (named, ordered) work-local declarations matching {@link wasiStrEncodeLayout}. */
+function wasiStrEncodeLocalDecls(strTypeIdx: number, strDataTypeIdx: number) {
+  return [
+    { name: "flat", type: { kind: "ref" as const, typeIdx: strTypeIdx } },
+    { name: "len", type: { kind: "i32" as const } },
+    { name: "off", type: { kind: "i32" as const } },
+    { name: "data", type: { kind: "ref" as const, typeIdx: strDataTypeIdx } },
+    { name: "i", type: { kind: "i32" as const } },
+    { name: "o", type: { kind: "i32" as const } },
+    { name: "needPages", type: { kind: "i32" as const } },
+    { name: "cu", type: { kind: "i32" as const } },
+    { name: "cp", type: { kind: "i32" as const } },
+    { name: "lo", type: { kind: "i32" as const } },
+  ];
+}
 
-  const fd = useStderr ? 2 : 1;
-  const strTypeIdx = ctx.nativeStrTypeIdx;
-  const strDataTypeIdx = ctx.nativeStrDataTypeIdx;
-  // #1723: the param MUST be the AnyString supertype, NOT the concrete
-  // NativeString. A runtime concat / template span can be a ConsString (rope),
-  // and the caller hands us whatever the expression produced. If the param were
-  // typed NativeString, the call site would have to `ref.cast` the argument down
-  // to NativeString first — which TRAPS ("illegal cast") for a ConsString. By
-  // accepting AnyString here, both NativeString and ConsString pass without any
-  // downcast, and `__str_flatten` (which takes AnyString and collapses ropes)
-  // does the flattening internally. The original NativeString param + call-site
-  // downcast is exactly what made `writeMessage` trap on a multi-segment
-  // response in the Native Messaging host (#1723).
-  const anyStrTypeIdx = ctx.anyStrTypeIdx >= 0 ? ctx.anyStrTypeIdx : strTypeIdx;
-
-  // param: s(0); locals: flat(1), len(2), off(3), data(4), i(5), o(6),
-  // needPages(7), cu(8), cp(9), lo(10)
-  const S = 0;
-  const FLAT = 1;
-  const LEN = 2;
-  const OFF = 3;
-  const DATA = 4;
-  const I = 5;
-  const O = 6;
-  const NEED_PAGES = 7;
-  const CU = 8;
-  const CP = 9;
-  const LO = 10;
-
-  const funcTypeIdx = addFuncType(ctx, [{ kind: "ref", typeIdx: anyStrTypeIdx }], []);
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
-  ctx.funcMap.set(helperName, funcIdx);
+/**
+ * Build the WTF-16 → UTF-8 encode-to-linear-scratch instruction sequence shared
+ * by every WASI write-string helper. Flattens the AnyString param (local `S`)
+ * via `__str_flatten`, grows linear memory for the worst-case 3 bytes/code-unit
+ * staging region, then encodes the code points into
+ * `[WASI_WRITE_SCRATCH_START .. WASI_WRITE_SCRATCH_START + O)`. On return the
+ * output-cursor local `O` holds the exact UTF-8 byte count; the caller appends
+ * its own write tail (fixed-fd fd_write, or runtime-fd node:fs writeSync). No
+ * value is left on the stack. (#2639 factored this out of
+ * {@link ensureWasiWriteAnyStringHelper} byte-for-byte so existing fd 1/2 output
+ * is unchanged.)
+ */
+function buildWasiStringEncodeToScratch(
+  flattenIdx: number,
+  strTypeIdx: number,
+  strDataTypeIdx: number,
+  layout: WasiStrEncodeLayout,
+): Instr[] {
+  const { FLAT, LEN, OFF, DATA, I, O, NEED_PAGES, CU, CP, LO, S } = layout;
 
   const storeByte = (offsetFromO: number, value: Instr[]): Instr[] => [
     { op: "i32.const", value: WASI_WRITE_SCRATCH_START } as Instr,
@@ -6897,7 +6905,7 @@ export function ensureWasiWriteAnyStringHelper(ctx: CodegenContext, useStderr: b
     } as Instr,
   ];
 
-  const body: Instr[] = [
+  return [
     // flat = __str_flatten(s)
     { op: "local.get", index: S } as Instr,
     { op: "call", funcIdx: flattenIdx } as Instr,
@@ -6909,14 +6917,8 @@ export function ensureWasiWriteAnyStringHelper(ctx: CodegenContext, useStderr: b
     { op: "local.set", index: LEN } as Instr,
 
     // #1723/#1470: grow linear memory if the staging buffer could overflow.
-    // UTF-8/WTF-8 needs at most 3 bytes per UTF-16 code unit: BMP scalars and
-    // lone surrogates are 1..3 bytes, while a surrogate pair is 4 bytes across
-    // two code units. The final fd_write length is the actual output cursor O.
-    //
+    // UTF-8/WTF-8 needs at most 3 bytes per UTF-16 code unit.
     //   neededPages = ceil((WASI_WRITE_SCRATCH_START + len*3) / 65536)
-    //
-    // ceil(x / 65536) == (x + 65535) >> 16. We `i32.shr_u` so a large length
-    // near 2^31 still computes a non-negative page count.
     { op: "i32.const", value: WASI_WRITE_SCRATCH_START } as Instr,
     { op: "local.get", index: LEN } as Instr,
     { op: "i32.const", value: 3 } as Instr,
@@ -6927,7 +6929,6 @@ export function ensureWasiWriteAnyStringHelper(ctx: CodegenContext, useStderr: b
     { op: "i32.const", value: 16 } as Instr,
     { op: "i32.shr_u" } as Instr,
     { op: "local.set", index: NEED_PAGES } as Instr,
-    // if (needPages > memory.size) memory.grow(needPages - memory.size)
     { op: "local.get", index: NEED_PAGES } as Instr,
     { op: "memory.size" } as Instr,
     { op: "i32.gt_u" } as Instr,
@@ -6988,8 +6989,7 @@ export function ensureWasiWriteAnyStringHelper(ctx: CodegenContext, useStderr: b
             { op: "i32.add" } as Instr,
             { op: "local.set", index: I } as Instr,
 
-            // If cu is a high surrogate and the next code unit is a low
-            // surrogate, combine them into one scalar and consume the low unit.
+            // Combine a high+low surrogate pair into one scalar.
             { op: "local.get", index: CU } as Instr,
             { op: "i32.const", value: 0xd800 } as Instr,
             { op: "i32.ge_u" } as Instr,
@@ -7049,27 +7049,132 @@ export function ensureWasiWriteAnyStringHelper(ctx: CodegenContext, useStderr: b
         },
       ],
     },
+  ];
+}
 
+/**
+ * #1618: Ensure __wasi_write_any_string(s: ref NativeString) -> void exists and
+ * return its function index (lazy, emitted during expression compilation).
+ *
+ * Writes a *runtime* string (variable, concatenation, template span) to fd=1
+ * (stdout) or fd=2 (stderr). Previously these refs fell through to the
+ * `[object]` placeholder in emitWasiValueToStdout, corrupting the stream.
+ *
+ * Strategy: flatten any AnyString (FlatString / ConsString / Utf8String) to a
+ * NativeString via the existing __str_flatten helper, then encode the WTF-16
+ * code units as UTF-8 bytes directly into linear memory before issuing
+ * fd_write. This keeps WASI string output on the pure-Wasm path (#1470) without
+ * routing through the JS-host `__str_to_mem` / `TextEncoder` bridge.
+ *
+ * Param 0 is typed `ref NativeString` so callers can hand us a value compiled
+ * as `{ kind: "ref", typeIdx: ctx.nativeStrTypeIdx }` directly; __str_flatten
+ * accepts the NativeString supertype (AnyString) and returns the flat form.
+ */
+export function ensureWasiWriteAnyStringHelper(ctx: CodegenContext, useStderr: boolean = false): number {
+  const helperName = useStderr ? "__wasi_write_any_string_stderr" : "__wasi_write_any_string";
+  const existing = ctx.funcMap.get(helperName);
+  if (existing !== undefined) return existing;
+
+  // #2524 — node-process shim path needs no fd_write idx (see Uint8Array helper).
+  if (!ctx.wasi || (!ctx.linkNodeShims && ctx.wasiFdWriteIdx === undefined) || ctx.nativeStrTypeIdx < 0) return -1;
+
+  // Make sure the native-string runtime (incl. __str_flatten) is emitted.
+  ensureNativeStringHelpers(ctx);
+  // __str_flatten via funcMap (shift-maintained), not nativeStrHelpers (which can
+  // be stale-low after late imports). See the registration in
+  // ensureNativeStringHelpers. (#1618)
+  const flattenIdx = ctx.funcMap.get("__str_flatten");
+  if (flattenIdx === undefined) return -1;
+
+  const fd = useStderr ? 2 : 1;
+  const strTypeIdx = ctx.nativeStrTypeIdx;
+  const strDataTypeIdx = ctx.nativeStrDataTypeIdx;
+  // #1723: the param MUST be the AnyString supertype, NOT the concrete
+  // NativeString. A runtime concat / template span can be a ConsString (rope),
+  // and the caller hands us whatever the expression produced. If the param were
+  // typed NativeString, the call site would have to `ref.cast` the argument down
+  // to NativeString first — which TRAPS ("illegal cast") for a ConsString. By
+  // accepting AnyString here, both NativeString and ConsString pass without any
+  // downcast, and `__str_flatten` (which takes AnyString and collapses ropes)
+  // does the flattening internally. The original NativeString param + call-site
+  // downcast is exactly what made `writeMessage` trap on a multi-segment
+  // response in the Native Messaging host (#1723).
+  const anyStrTypeIdx = ctx.anyStrTypeIdx >= 0 ? ctx.anyStrTypeIdx : strTypeIdx;
+
+  // One param (s=0) ⇒ work-locals start at index 1.
+  const layout = wasiStrEncodeLayout(1);
+  const funcTypeIdx = addFuncType(ctx, [{ kind: "ref", typeIdx: anyStrTypeIdx }], []);
+  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  ctx.funcMap.set(helperName, funcIdx);
+
+  const body: Instr[] = [
+    ...buildWasiStringEncodeToScratch(flattenIdx, strTypeIdx, strDataTypeIdx, layout),
     // #2524/#2633 — write the staged UTF-8 region (`O` bytes) via fd_write or
-    // the node:fs shim's writeSync(fd, …).
-    ...emitWasiWriteTail(ctx, fd, WASI_WRITE_SCRATCH_START, O),
+    // the node:fs shim's writeSync(fd, …). Result (bytes-written) is dropped.
+    ...emitWasiWriteTail(ctx, fd, WASI_WRITE_SCRATCH_START, layout.O),
   ];
 
   ctx.mod.functions.push({
     name: helperName,
     typeIdx: funcTypeIdx,
-    locals: [
-      { name: "flat", type: { kind: "ref", typeIdx: strTypeIdx } },
-      { name: "len", type: { kind: "i32" } },
-      { name: "off", type: { kind: "i32" } },
-      { name: "data", type: { kind: "ref", typeIdx: strDataTypeIdx } },
-      { name: "i", type: { kind: "i32" } },
-      { name: "o", type: { kind: "i32" } },
-      { name: "needPages", type: { kind: "i32" } },
-      { name: "cu", type: { kind: "i32" } },
-      { name: "cp", type: { kind: "i32" } },
-      { name: "lo", type: { kind: "i32" } },
-    ],
+    locals: wasiStrEncodeLocalDecls(strTypeIdx, strDataTypeIdx),
+    body,
+    exported: false,
+  });
+
+  return funcIdx;
+}
+
+/**
+ * #2639: Ensure `__wasi_write_any_string_fd(s: ref AnyString, fd: i32) -> i32`
+ * exists and return its function index (lazy). Encodes the string to UTF-8 in
+ * the shared linear scratch (the same encoder as the fixed-fd writer) and writes
+ * it to the *runtime* fd via the imported `node:fs` `writeSync(fd, ptr, len)`
+ * shim, returning the byte count `writeSync` reports. This backs the STRING
+ * overload of `node:fs` `writeSync(fd, str, position?, encoding?)`, where the fd
+ * is an arbitrary integer (not just stdout/stderr). It is gated to the
+ * `linkNodeShims` path — the only path on which `writeSync(fd, …)` lowers — so
+ * no inline `fd_write` tail is needed here.
+ */
+export function ensureWasiWriteAnyStringFdHelper(ctx: CodegenContext): number {
+  const helperName = "__wasi_write_any_string_fd";
+  const existing = ctx.funcMap.get(helperName);
+  if (existing !== undefined) return existing;
+
+  // Runtime-fd writes only exist on the node:fs shim path.
+  if (!ctx.wasi || !ctx.linkNodeShims || ctx.nodeFsWriteSyncIdx < 0 || ctx.nativeStrTypeIdx < 0) return -1;
+
+  ensureNativeStringHelpers(ctx);
+  const flattenIdx = ctx.funcMap.get("__str_flatten");
+  if (flattenIdx === undefined) return -1;
+
+  const strTypeIdx = ctx.nativeStrTypeIdx;
+  const strDataTypeIdx = ctx.nativeStrDataTypeIdx;
+  const anyStrTypeIdx = ctx.anyStrTypeIdx >= 0 ? ctx.anyStrTypeIdx : strTypeIdx;
+
+  // Two params: s(0), fd(1). The ten encoder work-locals therefore start at
+  // index 2; the byte cursor `O` holds the encoded length after the encoder runs.
+  const FD = 1;
+  const layout = wasiStrEncodeLayout(2);
+
+  const funcTypeIdx = addFuncType(ctx, [{ kind: "ref", typeIdx: anyStrTypeIdx }, { kind: "i32" }], [{ kind: "i32" }]);
+  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  ctx.funcMap.set(helperName, funcIdx);
+
+  const body: Instr[] = [
+    ...buildWasiStringEncodeToScratch(flattenIdx, strTypeIdx, strDataTypeIdx, layout),
+    // return writeSync(fd, WASI_WRITE_SCRATCH_START, O)  — bytes written.
+    { op: "local.get", index: FD } as Instr,
+    { op: "i32.const", value: WASI_WRITE_SCRATCH_START } as Instr,
+    { op: "local.get", index: layout.O } as Instr,
+    { op: "call", funcIdx: ctx.nodeFsWriteSyncIdx } as Instr,
+  ];
+
+  ctx.mod.functions.push({
+    name: helperName,
+    typeIdx: funcTypeIdx,
+    // Work-locals follow the two params (s, fd); no extra local for fd.
+    locals: wasiStrEncodeLocalDecls(strTypeIdx, strDataTypeIdx),
     body,
     exported: false,
   });

--- a/src/codegen/node-fs-api.ts
+++ b/src/codegen/node-fs-api.ts
@@ -14,9 +14,11 @@ import type { Instr, ValType } from "../ir/types.js";
 import { ts } from "../ts-api.js";
 import { allocLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { emitDataViewToWriteScratch } from "./dataview-native.js";
 import { noJsHost } from "./expressions/helpers.js";
 import { flushLateImportShifts } from "./expressions/late-imports.js";
 import {
+  ensureWasiWriteAnyStringFdHelper,
   ensureWasiWriteAnyStringHelper,
   ensureWasiWriteArrayBufferHelper,
   ensureWasiWriteUint8ArrayHelper,
@@ -454,6 +456,27 @@ function emitNodeFsWriteSync(
   expr: ts.CallExpression,
   shimIdx: number,
 ): InnerResult {
+  const arg1 = expr.arguments[1]!;
+  const arg1Type = ctx.checker.getTypeAtLocation(arg1);
+
+  // #2639 — STRING overload: writeSync(fd, str, position?, encoding?). The fd is
+  // a runtime arg (not just 1/2), so encode the string to UTF-8 and write via the
+  // runtime-fd string helper, which returns the bytes written. `encoding?` (arg3)
+  // defaults to utf8; an explicit non-UTF-8 encoding is a clear compile error
+  // rather than a silent mis-encode. `position?` (arg2) is ignored for the fd
+  // streaming case, exactly as the buffer overload ignores it for fd 0/1/2.
+  if (isStringType(arg1Type)) {
+    return emitNodeFsWriteSyncString(ctx, fctx, expr);
+  }
+
+  // #2639 — DataView arg: resolve its i32_byte backing + byteOffset/byteLength to
+  // a (ptr, len) over the write scratch, then write via the shim. DataView is
+  // part of __NodeFsArrayBufferView but isn't a GC $Vec the offset/length path
+  // recognizes, so handle it explicitly before the generic resolution.
+  if (arg1Type.getSymbol?.()?.name === "DataView") {
+    return emitNodeFsWriteSyncDataView(ctx, fctx, expr, shimIdx);
+  }
+
   const fdLocal = emitNodeFsFd(ctx, fctx, expr.arguments[0]!);
 
   // Zero-copy fast path: linear-backed Uint8Array writes straight from ptr+off.
@@ -484,6 +507,106 @@ function emitNodeFsWriteSync(
   emitArrayToScratchCopy(fctx, gc.arrTypeIdx, gc.arrLocal, offLocal, WASI_WRITE_SCRATCH_START, lenLocal);
 
   // nwritten = write_sync(fd, WASI_WRITE_SCRATCH_START, length)
+  fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
+  fctx.body.push({ op: "i32.const", value: WASI_WRITE_SCRATCH_START } as Instr);
+  fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+  fctx.body.push({ op: "call", funcIdx: shimIdx } as Instr);
+  fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
+  return { kind: "f64" };
+}
+
+/**
+ * The `node:fs` `writeSync(fd, str, position?, encoding?)` STRING overload's
+ * supported encodings. We materialize the string as UTF-8 bytes (the WasmGC
+ * native-string lowering's only byte form), so only the utf8 aliases are
+ * faithful; any other listed `BufferEncoding` would silently mis-encode, so we
+ * reject it at compile time with a clear pointer.
+ */
+const WRITESYNC_UTF8_ENCODINGS = new Set(["utf8", "utf-8"]);
+
+/**
+ * #2639 — lower the STRING overload `writeSync(fd, str, position?, encoding?)`:
+ * encode `str` to UTF-8 and write to the runtime `fd` via the shim, returning the
+ * byte count (f64). `encoding?` defaults to utf8; an explicit non-utf8 literal is
+ * a compile error. `position?` is ignored for the fd streaming case (matching the
+ * buffer overload). Returns `VOID_RESULT` (after pushing a diagnostic) on an
+ * unsupported encoding or when the native-string runtime is unavailable.
+ */
+function emitNodeFsWriteSyncString(ctx: CodegenContext, fctx: FunctionContext, expr: ts.CallExpression): InnerResult {
+  // Reject an explicit non-utf8 string-literal encoding (arg index 3).
+  const encArg = expr.arguments[3];
+  if (encArg && ts.isStringLiteralLike(encArg) && !WRITESYNC_UTF8_ENCODINGS.has(encArg.text.toLowerCase())) {
+    ctx.errors.push({
+      message:
+        `node:fs writeSync(fd, str, position?, encoding) only supports the utf8 encoding under ` +
+        `--target wasi (got "${encArg.text}"). Encode the string yourself and pass the bytes as a ` +
+        `Uint8Array/DataView if you need another encoding.`,
+      line: 1,
+      column: 1,
+      severity: "error",
+    });
+    return VOID_RESULT;
+  }
+
+  // fd (arg0) → i32 local.
+  const fdLocal = emitNodeFsFd(ctx, fctx, expr.arguments[0]!);
+
+  // Compile the string arg to a native-string ref, then call the runtime-fd
+  // string writer: __wasi_write_any_string_fd(str, fd) -> bytesWritten (i32).
+  const compiled = compileExpression(ctx, fctx, expr.arguments[1]!);
+  flushLateImportShifts(ctx, fctx);
+  const writeStrFdIdx = ensureWasiWriteAnyStringFdHelper(ctx);
+  if (compiled && ctx.nativeStrTypeIdx >= 0 && writeStrFdIdx >= 0) {
+    if (compiled.kind === "ref_null") {
+      fctx.body.push({ op: "ref.as_non_null" } as Instr);
+    }
+    // Stash the string ref, push (str, fd), call, convert byte count to f64.
+    const strLocal = allocLocal(fctx, `__nodefs_wstr_${fctx.locals.length}`, {
+      kind: "ref",
+      typeIdx: ctx.nativeStrTypeIdx,
+    });
+    fctx.body.push({ op: "local.set", index: strLocal } as Instr);
+    fctx.body.push({ op: "local.get", index: strLocal } as Instr);
+    fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
+    fctx.body.push({ op: "call", funcIdx: writeStrFdIdx } as Instr);
+    fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
+    return { kind: "f64" };
+  }
+
+  // Native-string runtime unavailable — drop the compiled string and report 0.
+  if (compiled) fctx.body.push({ op: "drop" } as Instr);
+  fctx.body.push({ op: "f64.const", value: 0 } as Instr);
+  return { kind: "f64" };
+}
+
+/**
+ * #2639 — lower `writeSync(fd, dataView, …)`: stage the DataView's bytes (its
+ * backing i32_byte array windowed by byteOffset/byteLength) into the write
+ * scratch, then `writeSync(fd, scratch, viewLen)`. Returns the byte count (f64);
+ * on an unresolvable backing it drops the operands and reports 0.
+ */
+function emitNodeFsWriteSyncDataView(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  shimIdx: number,
+): InnerResult {
+  const fdLocal = emitNodeFsFd(ctx, fctx, expr.arguments[0]!);
+
+  // Compile the DataView arg; emitDataViewToWriteScratch consumes the value on
+  // the stack, recovers its (backing, base, byteLength), grows memory, and copies
+  // the bytes into the scratch — returning the byte-length local.
+  const recvType = compileExpression(ctx, fctx, expr.arguments[1]!);
+  flushLateImportShifts(ctx, fctx);
+  const lenLocal = emitDataViewToWriteScratch(ctx, fctx, recvType, WASI_WRITE_SCRATCH_START);
+  if (lenLocal < 0) {
+    // Couldn't resolve the DataView backing — drop the operand and report 0.
+    if (recvType) fctx.body.push({ op: "drop" } as Instr);
+    fctx.body.push({ op: "f64.const", value: 0 } as Instr);
+    return { kind: "f64" };
+  }
+
+  // nwritten = write_sync(fd, WASI_WRITE_SCRATCH_START, viewLen)
   fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
   fctx.body.push({ op: "i32.const", value: WASI_WRITE_SCRATCH_START } as Instr);
   fctx.body.push({ op: "local.get", index: lenLocal } as Instr);

--- a/tests/issue-2639-node-fs-writesync-string-dataview.test.ts
+++ b/tests/issue-2639-node-fs-writesync-string-dataview.test.ts
@@ -1,0 +1,199 @@
+// #2639 — node:fs writeSync(fd, str | DataView) codegen.
+//
+// The #2634 capability map declares TWO writeSync overloads — a buffer form and
+// a STRING form (writeSync(fd, str, position?, encoding?)) — plus DataView is
+// part of __NodeFsArrayBufferView. But only the Uint8Array/ArrayBuffer buffer
+// arm was lowered: a string or DataView arg type-checked, compiled, and then
+// wrote ZERO bytes (the GC-$Vec resolver returned null and the codegen emitted a
+// `0` byte count). This closes that gap:
+//   - string  → encode to UTF-8 (same WTF-16→UTF-8 encoder process.std*.write
+//               uses) and write to the runtime fd via the node:fs writeSync shim.
+//   - DataView → resolve its i32_byte backing + byteOffset/byteLength to a
+//               (ptr, len) over the write scratch, then write that range.
+// utf8 is the default and only supported string encoding under --target wasi;
+// an explicit non-utf8 encoding is a clear compile error.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildNodeFsShim } from "../scripts/build-node-fs-shim.mjs";
+
+/** Link the node-fs shim + the user module, run main(), capture fd 1 / fd 2. */
+function linkAndRun(userBinary: Uint8Array): { stdout: Uint8Array; stderr: Uint8Array } {
+  const shimBinary = buildNodeFsShim();
+  const ref: { mem: WebAssembly.Memory | undefined } = { mem: undefined };
+  const memView = () => new DataView(ref.mem!.buffer);
+  const out1: number[] = [];
+  const out2: number[] = [];
+  const wasi = {
+    fd_read(): number {
+      return 0;
+    },
+    fd_write(wfd: number, iovs: number, iovsLen: number, nwritten: number): number {
+      const view = memView();
+      let total = 0;
+      for (let i = 0; i < iovsLen; i++) {
+        const ptr = view.getUint32(iovs + i * 8, true);
+        const len = view.getUint32(iovs + i * 8 + 4, true);
+        const bytes = new Uint8Array(ref.mem!.buffer, ptr, len);
+        if (wfd === 1) for (const b of bytes) out1.push(b);
+        else if (wfd === 2) for (const b of bytes) out2.push(b);
+        total += len;
+      }
+      view.setUint32(nwritten, total, true);
+      return 0;
+    },
+  };
+  const shim = new WebAssembly.Instance(new WebAssembly.Module(shimBinary), {
+    wasi_snapshot_preview1: wasi,
+  });
+  ref.mem = shim.exports.memory as WebAssembly.Memory;
+  const user = new WebAssembly.Instance(new WebAssembly.Module(userBinary), {
+    "node:fs": {
+      memory: shim.exports.memory,
+      readSync: shim.exports.readSync,
+      writeSync: shim.exports.writeSync,
+    },
+    env: {},
+  });
+  (user.exports.main as () => void)();
+  return { stdout: Uint8Array.from(out1), stderr: Uint8Array.from(out2) };
+}
+
+async function compileWasi(src: string) {
+  return compile(src, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
+}
+
+describe("#2639 — node:fs writeSync string + DataView codegen", () => {
+  it("writeSync(1, str) / writeSync(2, str) emit the UTF-8 bytes to the right fd", async () => {
+    const src = `
+import { writeSync } from "node:fs";
+export function main(): void {
+  writeSync(1, "hi\\n");
+  writeSync(2, "err\\n");
+}
+`;
+    const result = await compileWasi(src);
+    expect(result.success).toBe(true);
+    const { stdout, stderr } = linkAndRun(result.binary);
+    expect(Buffer.from(stdout).toString("utf8")).toBe("hi\n");
+    expect(Buffer.from(stderr).toString("utf8")).toBe("err\n");
+  });
+
+  it("encodes non-ASCII strings (multi-byte + astral) as UTF-8", async () => {
+    const src = `
+import { writeSync } from "node:fs";
+export function main(): void {
+  writeSync(1, "héllo→\\u{1F600}");
+}
+`;
+    const result = await compileWasi(src);
+    expect(result.success).toBe(true);
+    const { stdout } = linkAndRun(result.binary);
+    const expected = "héllo→😀";
+    expect(Buffer.from(stdout).toString("utf8")).toBe(expected);
+    // Byte count equals UTF-8 length, not UTF-16 code-unit count.
+    expect(stdout.length).toBe(Buffer.byteLength(expected, "utf8"));
+  });
+
+  it("handles a runtime (rope) string, not just a literal", async () => {
+    const src = `
+import { writeSync } from "node:fs";
+export function main(): void {
+  const a = "ab";
+  const b = "cd";
+  writeSync(1, a + b + "\\n");
+}
+`;
+    const result = await compileWasi(src);
+    expect(result.success).toBe(true);
+    const { stdout } = linkAndRun(result.binary);
+    expect(Buffer.from(stdout).toString("utf8")).toBe("abcd\n");
+  });
+
+  it("accepts an explicit utf8 encoding arg (position?, encoding?)", async () => {
+    const src = `
+import { writeSync } from "node:fs";
+export function main(): void {
+  writeSync(1, "ok", null, "utf8");
+  writeSync(1, "!", null, "utf-8");
+}
+`;
+    const result = await compileWasi(src);
+    expect(result.success).toBe(true);
+    const { stdout } = linkAndRun(result.binary);
+    expect(Buffer.from(stdout).toString("utf8")).toBe("ok!");
+  });
+
+  it("rejects an explicit non-utf8 encoding with a clear diagnostic", async () => {
+    const src = `
+import { writeSync } from "node:fs";
+export function main(): void {
+  writeSync(1, "x", null, "hex");
+}
+`;
+    const result = await compileWasi(src);
+    expect(result.success).toBe(false);
+    const msgs = (result.errors ?? []).map((e) => e.message).join("\n");
+    expect(msgs).toMatch(/utf8/);
+    expect(msgs).toMatch(/hex/);
+  });
+
+  it("writeSync(1, dataView) writes the full backing range", async () => {
+    const src = `
+import { writeSync } from "node:fs";
+export function main(): void {
+  const b = new ArrayBuffer(3);
+  const dv = new DataView(b);
+  dv.setUint8(0, 0x61); // 'a'
+  dv.setUint8(1, 0x62); // 'b'
+  dv.setUint8(2, 0x63); // 'c'
+  writeSync(1, dv);
+}
+`;
+    const result = await compileWasi(src);
+    expect(result.success).toBe(true);
+    const { stdout } = linkAndRun(result.binary);
+    expect(Buffer.from(stdout).toString("utf8")).toBe("abc");
+  });
+
+  it("honours a windowed DataView's byteOffset/byteLength (writes only that range)", async () => {
+    const src = `
+import { writeSync } from "node:fs";
+export function main(): void {
+  const b = new ArrayBuffer(5);
+  const full = new DataView(b);
+  full.setUint8(0, 0x41); // 'A'
+  full.setUint8(1, 0x42); // 'B'
+  full.setUint8(2, 0x43); // 'C'
+  full.setUint8(3, 0x44); // 'D'
+  full.setUint8(4, 0x45); // 'E'
+  const win = new DataView(b, 1, 3); // bytes 1..3 → "BCD"
+  writeSync(1, win);
+}
+`;
+    const result = await compileWasi(src);
+    expect(result.success).toBe(true);
+    const { stdout } = linkAndRun(result.binary);
+    expect(Buffer.from(stdout).toString("utf8")).toBe("BCD");
+  });
+
+  it("does not regress the Uint8Array buffer overload", async () => {
+    const src = `
+import { writeSync } from "node:fs";
+export function main(): void {
+  const u = new Uint8Array(2);
+  u[0] = 0x68; // 'h'
+  u[1] = 0x69; // 'i'
+  let n = 0;
+  while (n < u.length) {
+    const w = writeSync(1, u, n);
+    if (w <= 0) break;
+    n = n + w;
+  }
+}
+`;
+    const result = await compileWasi(src);
+    expect(result.success).toBe(true);
+    const { stdout } = linkAndRun(result.binary);
+    expect(Buffer.from(stdout).toString("utf8")).toBe("hi");
+  });
+});


### PR DESCRIPTION
Closes #2639.

## Problem
The #2634 capability map declares a STRING `writeSync` overload
(`writeSync(fd, str, position?, encoding?)`) and includes `DataView` in
`__NodeFsArrayBufferView`, but `src/codegen/node-fs-api.ts` only lowered the
Uint8Array/ArrayBuffer GC-`$Vec` arm. So under `--target wasi --link-node-shims`:

- `writeSync(1, "hello")` type-checked, compiled to a **valid** module, and wrote
  **ZERO bytes** (the GC-`$Vec` resolver returned `null`, codegen emitted an
  `f64.const 0` count and dropped the value).
- `writeSync(1, new DataView(buf))` did the same.

Confirmed by linking the `node-fs` shim and capturing fd 1 — both produced an
empty stream. The #2634 typings promised a surface the compiler couldn't honour.

## Fix
Import-scoped + provider-agnostic — still just `import "node:fs" "writeSync"`;
this is only the codegen arm mapping a string/DataView arg onto the pinned
`writeSync(fd, ptr, len)` ABI (`docs/architecture/node-fs-abi.md`). No new host
import.

- **String arm**: encode to UTF-8 and write to the **runtime** fd via the shim.
  Factored the existing WTF-16→UTF-8 encoder out of
  `ensureWasiWriteAnyStringHelper` into a shared `buildWasiStringEncodeToScratch`
  (+ new fd-parameterized `ensureWasiWriteAnyStringFdHelper`). `utf8` default;
  explicit non-utf8 encoding is a clear compile error. `position?` ignored for
  the fd-streaming case (matching the buffer overload). The `process.std*.write`
  binary is **byte-identical** to main (verified by diff).
- **DataView arm**: resolve the i32_byte backing + byteOffset/byteLength via
  `recoverDvBacking` (new exported `emitDataViewToWriteScratch`) and write that
  range — honours windowed `new DataView(buf, off, len)` views.

## Validation
- 8 new tests over the linked node-fs shim
  (`tests/issue-2639-node-fs-writesync-string-dataview.test.ts`): literal /
  Unicode / rope strings, explicit utf8, non-utf8 rejection, full + windowed
  DataView, Uint8Array no-regress.
- 37 pre-existing node-fs / wasi / dataview tests green; `runTest262File`
  DataView/String-concat control batch unchanged; tsc + biome lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)