### PR TITLE
docs(arch): #1772/#2635 capstone implementation plans

### DIFF
--- a/plan/issues/1772-edgejs-node-wasi-shim-spike.md
+++ b/plan/issues/1772-edgejs-node-wasi-shim-spike.md
@@ -267,3 +267,162 @@ correct across growth.
 
 Issue stays `in-progress` because Phase 2 (#2634) remains. Phases 0+1 acceptance
 criteria are met.
+
+---
+
+## Implementation Plan (Phase 2 completion — the generalization)
+
+> Scoping pass 2026-06-24 (architect), regrounded against current `main`.
+> **What is already landed is larger than the issue text implies.** Phase 0 (ABI
+> doc), Phase 1 (edge.js dual-provider proof + `tests/issue-1772-edge-dual-provider.test.ts`),
+> and the **#2634 capability-map *data + type surface*** are all on `main`. The
+> remaining Phase-2 work is narrow and concentrated in **one missing wire** plus
+> two small extensions. This plan specs ONLY that residual.
+
+### Root cause / what is actually missing
+
+`src/checker/node-capability-map.ts` (#2634) already provides: the
+`NODE_CAPABILITY_MAP` registry, faithful overloaded `.d.ts` for `readSync`/
+`writeSync`, the `FS_PATH_BASED_MEMBERS` list, and three query functions —
+`getModuleCapability`, `isKnownMember`, **`isMemberSatisfiable(module, member,
+target)`**. `src/checker/index.ts::buildNodeEnvDts` already consumes
+`buildModuleDecls` to emit the import-scoped surface (#2624).
+
+**The gap:** `isMemberSatisfiable` is dead code. Verified on `main` — nothing
+under `src/codegen/` imports it (`grep -rn isMemberSatisfiable src/codegen/` is
+empty). So a path-based member (`readFileSync(path)`) under `--target wasi` does
+**not** produce the promised *precise* "no provider under --target wasi" compile
+error; it falls through `node-fs-api.ts`'s `tryCompileNodeFsCall` (which only
+matches `readSync`/`writeSync`, returns `undefined` for the rest) onto the
+generic host-import path and becomes a silent link-time failure / dropped
+import. The capability map's central promise — "type-checks clean, but
+unsatisfiable members error at compile time, not at link" — is **unrealized at
+codegen**. Closing that is the bulk of Phase 2.
+
+### Slice P2-a — wire the deliberate "no provider" codegen gate (the core gap)
+
+**File: `src/codegen/node-fs-api.ts`** — `tryCompileNodeFsCall` (line ~237).
+- It currently early-returns `undefined` for any callee that is not
+  `readSync`/`writeSync`. Add, BEFORE that early return, a capability check for
+  imported `node:fs` members that the program actually bound:
+  - Import `getModuleCapability` + `isKnownMember` + `isMemberSatisfiable` from
+    `../checker/node-capability-map.js`.
+  - Build the `CapabilityTarget` from codegen context: `{ wasi: ctx.wasi,
+    allowFs: ctx.allowFs ?? false }`. (Confirm/add an `allowFs` field on
+    `CodegenContext` in `src/codegen/context/types.ts` — there is an
+    `--allow-fs` notion referenced in comments but no plumbed flag yet. **For
+    this slice, hardcode `allowFs: false`** so the gate produces the correct
+    standalone-WASI error and stays atomic; the flag plumbing lands later
+    (P2-a.0) without touching the gate.)
+  - If `isKnownMember("node:fs", callee)` and
+    `isMemberSatisfiable("node:fs", callee, target) === false`, push a precise
+    error to `ctx.errors` (follow the exact shape already used at line ~46 and
+    ~539 in this file) with message text:
+    `` `node:fs.${callee}` needs a filesystem provider, unavailable under `--target wasi`. Pass `--allow-fs` for the JS-host filesystem provider, or use the fd-based `readSync`/`writeSync(fd, …)` for standalone WASI (no path_open/preopens). `` Then return a handled sentinel (a `VOID_RESULT`-style f64 0 / the file's existing "consumed" return) so the generic path does not also fire.
+- **Edge case:** only gate members the program *imported from `node:fs`* — do not
+  gate a same-named user function. `tryCompileNodeFsCall` already keys off the
+  imported binding; reuse that binding set so a local `function readFileSync(){}`
+  is untouched.
+- **Edge case:** `readSync`/`writeSync` stay satisfiable under `--target wasi`
+  (`providersFor` returns `["wasi-fd"]`) — the gate is a no-op for them, the
+  existing lowering proceeds unchanged.
+- **Edge case:** non-WASI target — under a JS host, path-based members resolve
+  through the real `node:fs`; do not gate when `!ctx.wasi` (the
+  `tryCompileNodeFsCall` body already early-returns on `!ctx.wasi`, so the gate
+  must sit AFTER that guard but BEFORE the `readSync`/`writeSync` match).
+
+**P2-a.0 (deferred prerequisite, tiny):** thread `--allow-fs` → `compile()` opts
+→ `ctx.allowFs`, swapping the hardcoded `false`. Independent follow-up; does not
+block P2-a.
+
+- **Role:** developer. **PR-able alone.** Test:
+  `tests/issue-1772-no-provider-gate.test.ts` — compile a program importing
+  `readFileSync` from `node:fs` under `--target wasi`, assert `r.success ===
+  false` and the error names the member + `--allow-fs`. Assert a
+  `readSync`/`writeSync` program still compiles green and a non-WASI compile of
+  the same `readFileSync` program is NOT gated.
+
+### Slice P2-b — extend the capability map beyond the fd anchor (the "mechanism", not new surface)
+
+**File: `src/checker/node-capability-map.ts`** — add a second capability-mapped
+module to *prove the data-not-code extension mechanism* the #2634 design header
+promises ("adding `node:process`/`node:os` members later is a new entry in
+`NODE_CAPABILITY_MAP`, not a code change").
+- Add the **already-lowered** `process.stdout.write` / `process.stderr.write`
+  surface as *satisfiability entries* so P2-a's gate can reason about them. These
+  lower today via `node-fs-api.ts::tryCompileProcessStdoutWrite` to
+  `writeSync(1|2, …)`; gate `providersFor: (t) => (t.wasi ? ["wasi-fd"] :
+  ["js-host-fs"])`.
+- **Important boundary:** `node:process` is *partially* handled today by the
+  bespoke `PROCESS_INTERFACE_DECLS` branch in `buildNodeEnvDts` (line ~454). Do
+  **NOT** rip that out in this slice — the two must not double-declare
+  `stdout`/`stderr`. Keep `node:process` decl emission on the existing bespoke
+  branch; add ONLY the capability *satisfiability* metadata (not new decls) so
+  the map's query functions cover the process std-IO members. A full migration of
+  `node:process` decls into the map is a separate follow-up.
+- **Verdict to record in code (acceptance item — hand-authored vs literal
+  `@types/node`):** *Keep the hand-authored faithful mirror.* Write this into the
+  map's header comment. Reasoning: (1) the checker uses an in-memory lib host and
+  deliberately does NOT load `node_modules/@types/node` (the support-decls
+  comment says so), so literal sourcing means shipping/parsing the full
+  `@types/node` graph (`NodeJS.*`, `Buffer`, stream types, thousands of members)
+  at checker-init — heavy, and ~99% un-linkable. (2) The gate's whole point is
+  that the *type surface must equal the runtime surface*; literal `@types/node`
+  is the opposite (type ≫ runtime). (3) The mirror is already verified faithful
+  against `node_modules/@types/node/fs.d.ts` per member (the #2634 comments cite
+  the exact source files). **So literal-sourcing is rejected; the design is
+  hand-authored-per-member-with-a-cited-source-of-truth.** The "extraction from
+  `@types/node`" language in the original Phase-2 scope is satisfied by *faithful
+  mirroring with a cited source*, not by runtime parsing.
+
+- **Role:** developer. **PR-able alone** (the map entry is independent of P2-a;
+  only a cross-cutting test that exercises the gate on a process member needs
+  P2-a). Test: `tests/issue-1772-capability-map-extend.test.ts` — assert
+  `isMemberSatisfiable("node:process", "stdout"/"write", {wasi:true,allowFs:false})`
+  is truthy and a fabricated unsatisfiable member is falsy; assert
+  `buildNodeEnvDtsForSource` for a `process.stdout.write` program is byte-neutral
+  for a non-process program.
+
+### Slice P2-c — compose with #2528 `--platform node|web` (ambient surface)
+
+**Files: `src/codegen/index.ts`** (the `LIB_GLOBALS`/`DOM_ONLY_GLOBALS` sets
+referenced by #2528) and `src/checker/index.ts` (the `emulateNode` gate at
+line ~573 that decides whether to inject `buildNodeEnvDtsForSource`).
+- #2528 is `status: backlog` and is the **ambient-global** axis; #1772 Phase 2 is
+  the **importable `node:<mod>`** axis. They compose at exactly one decision
+  point: today `buildNodeEnvDts` injection is gated on
+  `analyzeOptions?.emulateNode === true`. When #2528 lands `--platform node`,
+  that flag SHOULD imply `emulateNode = true` (the node platform auto-provides
+  both the ambient `process` global AND the capability-mapped `node:<mod>` import
+  surface). Under `--platform web`, the `node:<mod>` import surface stays
+  available (an explicit `import` is explicit intent) but the bare ambient
+  `process` global is NOT auto-declared.
+- **This slice is a written composition note + the one-line
+  `emulateNode ||= (platform === "node")` wire**, gated on #2528 landing first.
+  **Mark P2-c `depends_on: 2528`; do not dispatch until #2528 is in progress.**
+  If #2528 is not scheduled, P2-c reduces to a paragraph in
+  `docs/architecture/node-fs-abi.md` recording the intended composition and is
+  **deferrable**.
+- **Role:** developer (trivial wire) once #2528 lands; **architect/PO note**
+  meanwhile.
+
+### Verdict on edge.js as the JS-provider substrate (acceptance item — confirmed)
+
+Already recorded in the Phase-1 section above and **confirmed by this scoping
+pass**: edge.js is the right substrate and is a thin, dependency-free adapter
+(two closures over exported memory), NOT a framework. Phase 2 does not change
+that verdict — the capability map decides *what is linkable*; edge.js is *one
+provider* satisfying the fd-based tier on the native-Node host. The async
+extension of edge.js is specced in **#2635** (a genuinely larger surface).
+
+### Phase 2 decomposition summary
+
+| Slice | What | Role | Depends on | PR-able alone |
+|-------|------|------|-----------|---------------|
+| **P2-a** | Wire `isMemberSatisfiable` → precise "no provider" codegen error in `tryCompileNodeFsCall`; hardcode `allowFs:false` | developer | — | yes |
+| **P2-b** | Add `node:process` std-IO satisfiability entries (mechanism proof) + record the hand-authored-mirror verdict in code | developer | — (P2-a only for the cross-test) | yes |
+| **P2-c** | Compose with #2528 `--platform node` (`emulateNode ||= platform==="node"`) | developer | **#2528** | no (gated) |
+
+P2-a is the only true "completes the acceptance" slice; P2-b proves the
+extension mechanism + lands the written verdict; P2-c is deferrable until #2528.
+**Suggested order: P2-a → P2-b (parallel-safe); P2-c last/deferred.**

--- a/plan/issues/2635-node-async-members-event-loop.md
+++ b/plan/issues/2635-node-async-members-event-loop.md
@@ -51,3 +51,194 @@ Both require a real async runtime, which is #2632 (WASI async event-loop reactor
 
 - Path-based `node:fs` (`readFileSync(path)`, `open`) — separate capability tier
   needing a filesystem (`--allow-fs`/preopens), not async-gated.
+
+---
+
+## Implementation Plan (Phase 3 — async dual-provider proof)
+
+> Scoping pass 2026-06-24 (architect), regrounded against current `main`.
+> **The remaining gap is much smaller than the issue text implies.** #2632
+> already landed the ENTIRE WASI side of async `process.stdin`: the fd0-readiness
+> reactor (`src/codegen/async-scheduler.ts` — `buildRunLoopBodyWithFdReactor`,
+> `__rl_stdin_drain`, `poll_oneoff` multi-subscription), the reactor-tick reader
+> hook, the four `__wasiStdin*` intrinsics, AND a faithful `process.stdin`
+> Readable source-prelude (`src/process-stdin-prelude.ts`, #2632 Phase 3 +
+> finalize-shift fix #2641). The WASI provider arm of the dual-provider proof
+> ALREADY WORKS end-to-end (`tests/issue-2632-phase3-stdin-readable.test.ts`
+> proves it under both the JS polyfill and real wasmtime with piped stdin).
+> **So the true #2635 gap is exactly ONE thing: the edge.js (native-Node) arm of
+> the same-binary async proof.** Everything else is in place.
+
+### The central architectural fact (what makes this non-trivial)
+
+Verified in `src/codegen/async-scheduler.ts` + `src/codegen/index.ts`:
+
+- The `process.stdin` reactor is **WASI-internal**, not a `node:fs`-style
+  swappable import. `__run_event_loop` is wired into `_start`
+  (`getRunLoopFuncIdxForWasiStart` → `index.ts` line ~2115) and drives
+  `poll_oneoff` / `fd_read` / `fd_fdstat_set_flags` / `clock_time_get` **directly
+  as `wasi_snapshot_preview1` imports**. There is **no exported per-tick API** and
+  **no `node:fs`-member ABI** for the async path — unlike the sync `readSync`/
+  `writeSync` (which ARE `node:fs` imports edge.js can satisfy as closures).
+- Consequence: edge.js **cannot** provide the async reactor by implementing two
+  `node:fs` closures the way Phase 1 did. The reactor's `poll_oneoff`-blocking
+  loop runs to EOF *inside* `_start`. The provider seam for the async path is
+  therefore **the `wasi_snapshot_preview1` import surface**, not `node:fs`.
+- There already exists exactly such a JS provider of that surface:
+  **`buildWasiPolyfill()` in `src/runtime.ts`** — it implements `fd_read`,
+  `poll_oneoff`, `fd_fdstat_set_flags`, `clock_time_get`, `fd_write`, with
+  `setStdin(bytes)` + `setMemory(mem)`. The #2632 polyfill `poll_oneoff` already
+  reports fd0-readable when buffered stdin remains and CLOCK otherwise. **This is
+  the substrate the edge.js async arm builds on.**
+
+### The provider-ABI contract for the async arm
+
+The async path keeps the **same compiled binary** and the **same Node-shaped
+source** (`process.stdin.on('data'|'end')` / `.read()`), but the link contract is
+the `wasi_snapshot_preview1` surface rather than `node:fs`:
+
+| Host class | Provider | Satisfies the async `process.stdin` reactor by |
+|---|---|---|
+| **Pure WASI** (wasmtime) | the host kernel | real `poll_oneoff`/`fd_read` on fd0 over the module's own memory — **already proven** (#2632 wasmtime arm). |
+| **Native Node** (JS) | **edge.js async** | provide `wasi_snapshot_preview1` = a `buildWasiPolyfill()`-style shim whose `fd_read`/`poll_oneoff` are fed by Node's REAL `process.stdin` `'data'`/`'end'` events (the JS host's event loop), over the module's exported memory. |
+
+The byte-ABI is unchanged from `docs/architecture/node-fs-abi.md` in spirit
+(fd-based, pointer over shared memory); only the *named import surface* differs
+(`wasi_snapshot_preview1.*` vs `node:fs.*`). Record this distinction in the ABI
+doc as the "async tier".
+
+### The smallest async member to prove it on
+
+**`process.stdin` Readable line-count / echo**, exactly mirroring the #2632
+Phase-3 program (`s.on('data', …)` + `s.on('end', …)`). It is the natural choice
+because the whole substrate already exists for it and the WASI arm is already
+green. The proof program is a *byte-chunk* echo/count (the string-chunk prelude
+is also available post-#2641, but the byte-chunk form is the lowest-risk shared
+program for a byte-identical assertion). **Do not** add `fs.promises` or timers
+to the proof — keep it to the one stdin member.
+
+### Slice decomposition
+
+#### Slice P3-a — edge.js async provider (`createNodeStdinWasiProvider`)
+
+**File: `examples/native-messaging/edge.js`** (extend; do NOT fork a new file —
+keep one adapter module).
+- Add `export function createNodeStdinWasiProvider(opts)` returning
+  `{ memory, importObject, run }` where `importObject` has a
+  `wasi_snapshot_preview1` key. Implement it by **reusing the runtime polyfill
+  shape**. Cleanest path: a tiny `examples/.../edge-wasi.mjs` helper that imports
+  `buildWasiPolyfill` from the built `dist/` runtime, so the async arm tracks the
+  canonical polyfill semantics rather than drifting. If the example must stay
+  zero-dep (the Phase-1 precedent), inline the minimal subset: `fd_read(fd0)`,
+  `poll_oneoff`, `fd_fdstat_set_flags`, `clock_time_get`, `fd_write`. **Record the
+  dependency choice in a comment** (mirror the Phase-1 "thin adapter, irreducible
+  job" note). **Recommend reusing `buildWasiPolyfill`** to avoid semantic drift.
+- **The async wiring (the load-bearing part):** unlike the polyfill's
+  `setStdin(preloadedBytes)` (synchronous, all-bytes-up-front), edge.js must feed
+  Node's **real** `process.stdin` incrementally:
+  - subscribe `process.stdin.on('data', chunk => stdinQueue.push(chunk))` and
+    `process.stdin.on('end', () => { stdinEof = true })`;
+  - the provider's `fd_read(0, …)` drains from `stdinQueue` into wasm memory at
+    the iovec base, returns the count; returns 0 + signals EOF only when
+    `stdinEof && queue empty` (mirroring `__rl_stdin_drain`'s 0-byte-read = EOF
+    contract);
+  - the provider's `poll_oneoff` resolves fd0-readable when `stdinQueue` is
+    non-empty OR `stdinEof`, else honors the CLOCK subscription's timeout.
+  - **The impedance:** the wasm reactor's `_start` is a *synchronous*
+    `poll_oneoff`-blocking loop, but Node's stdin is *async* (data arrives on
+    future loop ticks). So edge.js **cannot** just call
+    `instance.exports._start()` and let it block — that deadlocks waiting for data
+    that only arrives when the JS loop is free. **Resolution (the dev MUST pick
+    one):**
+    1. **Asyncify** the `_start` blocking points (wasm-opt `--asyncify`) so
+       `poll_oneoff` suspends the wasm stack, returns to Node, and resumes on the
+       next `'data'`. Heaviest; most faithful to "borrow the JS loop".
+    2. **Pre-drain to EOF then run once** — `await` Node's `process.stdin` to
+       `'end'` collecting all bytes into the queue, THEN call `_start()` so every
+       `poll_oneoff` finds data/EOF immediately and never truly blocks. This is
+       exactly what `buildWasiPolyfill().setStdin()` + `_start()` does today (the
+       proven #2632 polyfill path). **Recommend mechanism 2 for the FIRST proof**
+       — reuses the proven path verbatim, borrows Node's loop for the collection
+       phase, byte-identical to wasmtime. Mechanism 1 (true incremental borrow) is
+       follow-up `P3-d`.
+- **Role:** **senior-developer** (the sync/async impedance + the
+  asyncify-vs-predrain decision is the architecturally load-bearing call). **PR-able
+  alone** (adds an export + helper; no compiler-core change).
+
+#### Slice P3-b — `run-edge-stdin.mjs` (the native-Node async runner)
+
+**File: `examples/native-messaging/run-edge-stdin.mjs`** (new) — mirrors
+`run-edge.mjs` but for the async stdin member. Reads the compiled stdin-echo
+wasm, wires `createNodeStdinWasiProvider` against the process's REAL fd0, runs
+`_start`, lets stdout carry the echo/count. The native-Node arm counterpart to
+the wasmtime invocation.
+- **Role:** developer. **Depends on P3-a.** Can land in the same PR as P3-a or
+  immediately after.
+
+#### Slice P3-c — the same-binary async dual-provider proof test
+
+**File: `tests/issue-2635-async-dual-provider.test.ts`** (new) — the #2635
+acceptance. Mirror the SHAPE of `tests/issue-1772-edge-dual-provider.test.ts`
+(Phase-1 sync proof) extended to the async member:
+- Compile **ONE** wasm binary from a `process.stdin` Readable echo/line-count
+  program (`--target wasi`, so the #2632 prelude + reactor wire in
+  automatically).
+- Run it under **both** providers with the same stdin frames (use bytes that
+  catch a UTF-8-collapsing provider: include `0x00`, `0xff`, `0x80`, `0x0a`):
+  - (a) **pure-WASI**: real `wasmtime` with piped stdin (the proven #2632 arm) —
+    `skipIf(!wasmtime)`;
+  - (b) **native Node**: `createNodeStdinWasiProvider` (P3-a), via a child
+    process running `run-edge-stdin.mjs` with the bytes piped to its real stdin
+    (so Node's real event loop carries them — the "borrows the JS host's loop"
+    requirement, not the synchronous in-process polyfill).
+- Assert **byte-identical** output from both arms.
+- **Role:** developer. **Depends on P3-a + P3-b.** PR-able alone after them.
+
+#### Slice P3-d (follow-up, deferred) — true incremental loop-borrow via asyncify
+
+Mechanism 1 above: feed stdin *incrementally* across real JS loop ticks (not
+pre-drained), proving the reactor genuinely *borrows* Node's event loop rather
+than collecting-then-running. Needs asyncify on the `poll_oneoff` suspend points.
+**Out of scope for the first acceptance.** Note: the pre-drain mechanism already
+uses Node's loop for the collection phase, so it arguably satisfies the
+acceptance wording; P3-d is a fidelity upgrade, not a correctness gap. File as a
+follow-up only if pre-drain is deemed insufficient. **Role:** senior-developer.
+
+### Edge cases (all arms)
+
+- **EOF semantics must match** across providers: a 0-byte `fd_read` at a readable
+  fd0 = EOF (drops the subscription); EAGAIN (errno 6) = "no data this tick"
+  WITHOUT EOF. edge.js's `fd_read`/`poll_oneoff` must reproduce this exactly or
+  the Readable's `'end'` fires at the wrong time and the byte-identical assertion
+  fails. (See `buildStdinDrainBody` in `async-scheduler.ts` for the canonical
+  contract.)
+- **Empty stdin** → both arms emit only the EOF/`'end'` output, no data.
+- **`memory.grow` during the run** — edge.js must re-read `memory.buffer` per
+  `fd_read` (a cached `Uint8Array` view detaches on grow), exactly as the Phase-1
+  `createNodeFsProvider` already copies per-call.
+- **Non-blocking flag** — the reactor calls `fd_fdstat_set_flags(0,
+  FDFLAG_NONBLOCK=0x4)` once; edge.js's shim may treat it as a no-op (its
+  `fd_read` is already non-blocking against the JS queue), matching the polyfill.
+
+### Test shape (acceptance)
+
+`tests/issue-2635-async-dual-provider.test.ts` green: one compiled
+`process.stdin`-echo binary, byte-identical output under wasmtime AND under
+edge.js→real-Node-fd0, for stdin frames containing high/null bytes. The WASI arm
+reuses the proven #2632 path; only the edge.js async arm is new.
+
+### Decomposition summary
+
+| Slice | What | Role | Depends on | PR-able alone |
+|-------|------|------|-----------|---------------|
+| **P3-a** | edge.js async provider `createNodeStdinWasiProvider` (wasi_snapshot_preview1 shim fed by real Node stdin; pre-drain mechanism) | **senior-developer** | #2632 (landed) | yes |
+| **P3-b** | `run-edge-stdin.mjs` native-Node async runner | developer | P3-a | with/after P3-a |
+| **P3-c** | `tests/issue-2635-async-dual-provider.test.ts` same-binary byte-identical proof | developer | P3-a, P3-b | yes (after) |
+| **P3-d** | (deferred) true incremental loop-borrow via asyncify | senior-developer | P3-c | yes (follow-up) |
+
+**Suggested order: P3-a (senior-dev, the impedance decision) → P3-b + P3-c
+(developer) → P3-d deferred.** P3-a is the only architecturally load-bearing
+slice; the rest are mechanical given P3-a's provider.
+
+> **Unblock note:** `depends_on: [2632]` is SATISFIED (#2632 landed). This issue
+> is `ready` to dispatch starting with P3-a.


### PR DESCRIPTION
Scoping pass for the node-API capstone — adds dev-dispatchable `## Implementation Plan` sections to **#1772** (Phase 2 generalization) and **#2635** (Phase 3 async dual-provider). Doc-only; no compiler source touched.

## Regrounded against current main — both gaps are smaller than the issue text implies

**#1772 Phase 2:** Phase 0 (ABI doc), Phase 1 (edge.js dual-provider proof), and the #2634 capability-map *data + type surface* are all landed. The one real residual is that `isMemberSatisfiable` is **dead code** — nothing under `src/codegen/` imports it, so the promised precise "no provider under --target wasi" error never fires (path-based fs falls silently onto the generic host-import path). Slices: **P2-a** wires the gate into `tryCompileNodeFsCall`; **P2-b** adds a `node:process` satisfiability entry to prove the data-not-code extension mechanism + records the *hand-authored-mirror-vs-literal-@types/node* verdict (mirror wins); **P2-c** composes with #2528 `--platform node` (gated on #2528).

**#2635 Phase 3:** #2632 already landed the **entire WASI side** — reactor (`buildRunLoopBodyWithFdReactor`, `__rl_stdin_drain`, multi-sub `poll_oneoff`), the `__wasiStdin*` intrinsics, and the `process.stdin` Readable prelude. The WASI arm of the dual-provider proof is **already green** (`tests/issue-2632-phase3-stdin-readable.test.ts`). The only gap is the **edge.js native-Node async arm**. Key architectural finding: the async reactor is **WASI-internal** (driven from `_start`, no per-tick export, no `node:fs`-member ABI), so the provider seam is `wasi_snapshot_preview1`, not `node:fs` — a `buildWasiPolyfill`-shaped shim fed by Node's real `process.stdin`. Slices: **P3-a** (senior-dev — the sync/async impedance + asyncify-vs-pre-drain decision), **P3-b** runner, **P3-c** byte-identical proof, **P3-d** deferred asyncify.

`depends_on: [2632]` on #2635 is **satisfied** — the issue is `ready` to dispatch starting at P3-a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)