### PR TITLE
feat(host-interop): #2635 — async node:stdin dual-provider proof (edge.js + wasmtime)

### DIFF
--- a/examples/native-messaging/edge.js
+++ b/examples/native-messaging/edge.js
@@ -116,3 +116,246 @@ export async function runWithEdge(userBinary, opts = {}) {
   run();
   return { instance, memory };
 }
+
+// ───────────────────────────────────────────────────────────────────────────
+// #2635 Phase 3 — async `process.stdin` provider (the ASYNC tier).
+//
+// The synchronous `node:fs` tier above (Phase 1) satisfies fd-based readSync/
+// writeSync as two closures. Node's ASYNC surface — `process.stdin` as a
+// `Readable` — has no synchronous fd primitive to lower to; instead a js2wasm
+// module compiled `--target wasi` that touches `process.stdin` wires the #2632
+// async event-loop reactor into its `_start`, which drives `poll_oneoff` /
+// `fd_read` / `fd_fdstat_set_flags` / `clock_time_get` / `fd_write` DIRECTLY as
+// `wasi_snapshot_preview1` imports (the reactor is WASI-internal, NOT a
+// swappable `node:fs` member). So the provider seam for the async path is the
+// `wasi_snapshot_preview1` import surface — not `node:fs`.
+//
+//   Host class          Provider          Satisfies the stdin reactor by
+//   ──────────────────  ────────────────  ─────────────────────────────────────
+//   Pure WASI (wasmtime) the host kernel   real poll_oneoff/fd_read on fd0 over
+//                                          the module's own exported memory.
+//   Native Node (JS)     edge.js (below)   a wasi_snapshot_preview1 shim whose
+//                                          fd_read/poll_oneoff are fed by Node's
+//                                          REAL process.stdin 'data'/'end'
+//                                          events — the JS host's event loop.
+//
+// The byte-ABI is unchanged in spirit from docs/architecture/node-fs-abi.md
+// (fd-based, pointer over shared memory); only the named import surface differs.
+//
+// Dependency choice (mirrors the Phase-1 "thin adapter, irreducible job" note):
+// this stays a ZERO-DEPENDENCY example (only `node:` imports), so the minimal
+// wasi_snapshot_preview1 subset is inlined here rather than imported from the
+// built `dist/` runtime. The semantics deliberately MIRROR `buildWasiPolyfill`
+// in `src/runtime.ts` (the canonical #2632 polyfill): fd0-readable iff bytes
+// remain or EOF, 0-byte fd_read == EOF, fd_fdstat_set_flags no-op, raw-byte
+// fd_write. Keeping it inlined makes this a genuinely INDEPENDENT provider that
+// must AGREE byte-for-byte with both wasmtime AND the in-tree polyfill — a
+// stronger proof than re-exporting the polyfill verbatim. If the semantics ever
+// drift, prefer reusing buildWasiPolyfill via a small edge-wasi.mjs helper.
+//
+// The sync/async impedance: the wasm reactor's `_start` is a SYNCHRONOUS
+// poll_oneoff-blocking loop, but Node's stdin is ASYNC (data arrives on future
+// loop ticks). We therefore CANNOT call `_start()` and let poll_oneoff block —
+// that deadlocks waiting for data that only arrives when the JS loop is free.
+// MECHANISM 2 (pre-drain, used here): `await` Node's real `process.stdin` to
+// 'end', collecting all bytes into the queue (this phase genuinely borrows the
+// JS event loop), THEN call `_start()` so every poll_oneoff finds data/EOF
+// immediately and never truly blocks — exactly the proven `setStdin(bytes)` +
+// `_start()` path #2632 validated against wasmtime.
+//   ┌─ P3-d SEAM ─────────────────────────────────────────────────────────────┐
+//   │ Mechanism 1 (true incremental loop-borrow) would asyncify `_start`'s     │
+//   │ poll_oneoff suspend points so the wasm stack yields back to Node between │
+//   │ 'data' events and resumes incrementally. That is the deferred follow-up  │
+//   │ #2635/P3-d; the pre-drain below is the first-acceptance mechanism.       │
+//   └──────────────────────────────────────────────────────────────────────────┘
+
+const __WASI_ERRNO_SUCCESS = 0;
+
+/**
+ * Build a `wasi_snapshot_preview1` import object whose fd0 (stdin) is fed by a
+ * caller-supplied byte source, satisfying the #2632 async `process.stdin`
+ * reactor. Returns `{ importObject, run }`; the module OWNS + EXPORTS its own
+ * memory (pure `--target wasi`), so the provider binds memory lazily from
+ * `instance.exports.memory` after instantiation.
+ *
+ * @param {object} [opts]
+ * @param {() => Promise<Buffer[]>} [opts.collectStdin] async producer of all
+ *   stdin chunks (pre-drained to EOF). Defaults to draining the process's REAL
+ *   `process.stdin` to 'end' — i.e. borrowing Node's event loop. Override in
+ *   tests to inject a fixed byte sequence without touching the real fd0.
+ * @returns {{ importObject: { wasi_snapshot_preview1: object }, run: (binary: BufferSource, entry?: string) => Promise<{ instance: WebAssembly.Instance, memory: WebAssembly.Memory }> }}
+ */
+export function createNodeStdinWasiProvider(opts = {}) {
+  const collectStdin = opts.collectStdin ?? drainProcessStdin;
+
+  let memory; // bound after instantiation (module exports its own memory)
+  /** @type {Buffer[]} */
+  const queue = []; // pre-drained stdin chunks
+  let qHead = 0; // index of the current chunk in `queue`
+  let qPos = 0; // byte offset within queue[qHead]
+
+  // Total unread bytes left across the queue (drives fd0 readiness + EOF).
+  const remaining = () => {
+    let n = -qPos;
+    for (let i = qHead; i < queue.length; i++) n += queue[i].length;
+    return n < 0 ? 0 : n;
+  };
+
+  // fd_read(fd0, iovs…): drain `queue` into wasm memory at each iovec base;
+  // return the byte count. A 0-byte read == EOF (queue empty), mirroring
+  // `__rl_stdin_drain`'s contract. Re-reads `memory.buffer` per call so a
+  // memory.grow between calls can't leave us writing into a detached view.
+  const fd_read = (fd, iovs, iovs_len, nread) => {
+    if (!memory) return -1;
+    const view = new DataView(memory.buffer);
+    let total = 0;
+    if (fd === 0) {
+      for (let i = 0; i < iovs_len; i++) {
+        const ptr = view.getUint32(iovs + i * 8, true);
+        const len = view.getUint32(iovs + i * 8 + 4, true);
+        if (len === 0) continue;
+        let written = 0;
+        while (written < len && qHead < queue.length) {
+          const chunk = queue[qHead];
+          if (qPos >= chunk.length) {
+            qHead++;
+            qPos = 0;
+            continue;
+          }
+          const take = Math.min(len - written, chunk.length - qPos);
+          new Uint8Array(memory.buffer, ptr + written, take).set(chunk.subarray(qPos, qPos + take));
+          qPos += take;
+          written += take;
+          total += take;
+        }
+        if (written < len) break; // drained — partial fill ends this read
+      }
+    }
+    view.setUint32(nread, total, true);
+    return __WASI_ERRNO_SUCCESS;
+  };
+
+  // fd_write(fd, iovs…): write the RAW bytes verbatim to the real fd1/fd2.
+  // Must be raw (NOT line-buffered through console.log) so the output is
+  // byte-identical to wasmtime's native fd_write from the SAME binary.
+  const fd_write = (fd, iovs, iovs_len, nwritten) => {
+    if (!memory) return -1;
+    const view = new DataView(memory.buffer);
+    const sink = fd === 2 ? process.stderr : process.stdout;
+    let total = 0;
+    for (let i = 0; i < iovs_len; i++) {
+      const ptr = view.getUint32(iovs + i * 8, true);
+      const len = view.getUint32(iovs + i * 8 + 4, true);
+      if (len > 0) sink.write(Buffer.from(new Uint8Array(memory.buffer, ptr, len))); // copy, then write
+      total += len;
+    }
+    view.setUint32(nwritten, total, true);
+    return __WASI_ERRNO_SUCCESS;
+  };
+
+  // poll_oneoff: report fd0 FD_READ as fired when bytes remain (pre-drained, so
+  // it's "remaining || EOF"); else fire the CLOCK subscription (timeout elapses
+  // instantly — there is never anything to truly wait for after pre-drain). If
+  // fd0 is subscribed with no clock and no bytes, fire fd0 anyway so the
+  // reactor's 0-byte (EOF) read ends the subscription instead of hanging.
+  // Mirrors buildWasiPolyfill().poll_oneoff exactly.
+  const poll_oneoff = (in_ptr, out_ptr, nsubs, nevents_out) => {
+    if (!memory) return -1;
+    const view = new DataView(memory.buffer);
+    const subs = [];
+    for (let s = 0; s < nsubs; s++) {
+      const off = in_ptr + s * 48;
+      const userdata = view.getBigUint64(off, true);
+      const tag = view.getUint8(off + 8); // 0=CLOCK, 1=FD_READ
+      const fd = tag === 1 ? view.getUint32(off + 16, true) : -1;
+      subs.push({ type: tag, fd, userdata });
+    }
+    const fd0Readable = remaining() > 0;
+    const fd0Sub = subs.find((x) => x.type === 1 && x.fd === 0);
+    const clockSub = subs.find((x) => x.type === 0);
+    const fired = [];
+    if (fd0Sub && fd0Readable) fired.push(fd0Sub);
+    else if (clockSub) fired.push(clockSub);
+    else if (fd0Sub) fired.push(fd0Sub);
+    else if (subs.length > 0) fired.push(subs[0]);
+    let n = 0;
+    for (const ev of fired) {
+      const eoff = out_ptr + n * 32;
+      for (let i = 0; i < 32; i++) view.setUint8(eoff + i, 0);
+      view.setBigUint64(eoff, ev.userdata, true);
+      view.setUint16(eoff + 8, 0, true); // errno = success
+      view.setUint8(eoff + 10, ev.type); // 0=CLOCK, 1=FD_READ
+      n++;
+    }
+    view.setUint32(nevents_out, n, true);
+    return __WASI_ERRNO_SUCCESS;
+  };
+
+  // The reactor calls this once to set fd0 non-blocking; our fd_read is already
+  // non-blocking against the JS queue, so it's a no-op ack (matches the polyfill).
+  const fd_fdstat_set_flags = () => __WASI_ERRNO_SUCCESS;
+
+  const monotonicStartNs = process.hrtime.bigint();
+  const clock_time_get = (clockid, _precision, out_ptr) => {
+    if (!memory) return 28; // EINVAL
+    let nowNs = clockid === 1 ? process.hrtime.bigint() - monotonicStartNs : BigInt(Date.now()) * 1_000_000n;
+    if (nowNs < 0n) nowNs = 0n;
+    new DataView(memory.buffer).setBigUint64(out_ptr, nowNs, true);
+    return __WASI_ERRNO_SUCCESS;
+  };
+
+  const proc_exit = (code) => {
+    if (code) process.exitCode = code;
+  };
+
+  const wasi = {
+    fd_read,
+    fd_write,
+    poll_oneoff,
+    fd_fdstat_set_flags,
+    clock_time_get,
+    proc_exit,
+  };
+
+  const importObject = { wasi_snapshot_preview1: wasi };
+
+  /**
+   * Pre-drain stdin (mechanism 2), instantiate, bind the module's exported
+   * memory, then run its `_start` (default). poll_oneoff thereafter finds
+   * data/EOF immediately.
+   */
+  async function run(binary, entry = "_start") {
+    const chunks = await collectStdin();
+    for (const c of chunks) queue.push(c);
+    const { instance } = await WebAssembly.instantiate(binary, { ...importObject, env: {} });
+    memory = instance.exports.memory;
+    if (!(memory instanceof WebAssembly.Memory)) {
+      throw new Error("edge.js: stdin-WASI module must EXPORT its own `memory` (compile with --target wasi).");
+    }
+    const start = instance.exports[entry] ?? instance.exports._start;
+    if (typeof start !== "function") {
+      throw new Error(`edge.js: user module exports no \`${entry}\` or \`_start\``);
+    }
+    start();
+    return { instance, memory };
+  }
+
+  return { importObject, run };
+}
+
+/**
+ * Drain the process's REAL `process.stdin` to EOF, collecting every chunk. This
+ * is where edge.js borrows Node's event loop: the 'data'/'end' events fire as
+ * JS loop work, so the bytes piped to this process's fd0 are gathered before
+ * the wasm reactor runs. Resolves with the collected chunks.
+ * @returns {Promise<Buffer[]>}
+ */
+function drainProcessStdin() {
+  return new Promise((resolve, reject) => {
+    /** @type {Buffer[]} */
+    const chunks = [];
+    process.stdin.on("data", (c) => chunks.push(Buffer.isBuffer(c) ? c : Buffer.from(c)));
+    process.stdin.on("end", () => resolve(chunks));
+    process.stdin.on("error", (e) => reject(e));
+  });
+}

--- a/examples/native-messaging/run-edge-stdin.mjs
+++ b/examples/native-messaging/run-edge-stdin.mjs
@@ -1,0 +1,31 @@
+// run-edge-stdin.mjs — run a js2wasm `process.stdin`-reactor module under native
+// Node via the edge.js async provider, with the REAL fd 0/1/2 (#2635 Phase 3).
+//
+// Usage:  node run-edge-stdin.mjs <user.wasm>
+//
+// The user module is compiled `--target wasi` from a program that touches
+// `process.stdin` (a Readable). That wires the #2632 async event-loop reactor
+// into `_start`, which drives `poll_oneoff` / `fd_read` / `fd_write` DIRECTLY as
+// `wasi_snapshot_preview1` imports over the module's OWN exported memory.
+//
+// `createNodeStdinWasiProvider` (in edge.js) provides that `wasi_snapshot_preview1`
+// surface, fed by Node's REAL `process.stdin` 'data'/'end' events (mechanism 2:
+// pre-drain to EOF, then run `_start`). So this process's actual stdin (fd 0)
+// carries the bytes and its stdout (fd 1) carries the output — exactly as under
+// wasmtime's native WASI, from the SAME compiled binary. This is the native-Node
+// arm of the same-binary async dual-provider compatibility proof (#2635).
+//
+// Pipe input into stdin and the program's output (echo / line-count / …) comes
+// back on stdout, byte-identical to `wasmtime run <user.wasm>`.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { createNodeStdinWasiProvider } from "./edge.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const wasmPath = process.argv[2] ? resolve(process.argv[2]) : resolve(here, "out", "stdin_js2wasm.wasm");
+
+const userBinary = readFileSync(wasmPath);
+const provider = createNodeStdinWasiProvider();
+await provider.run(userBinary);

--- a/plan/issues/2635-node-async-members-event-loop.md
+++ b/plan/issues/2635-node-async-members-event-loop.md
@@ -1,7 +1,9 @@
 ---
 id: 2635
 title: "Async node:fs / process.stdin members over the event loop (Phase 3 of #1772)"
-status: ready
+status: done
+assignee: sdev-2635
+completed: 2026-06-24
 created: 2026-06-24
 updated: 2026-06-24
 priority: low
@@ -51,3 +53,84 @@ Both require a real async runtime, which is #2632 (WASI async event-loop reactor
 
 - Path-based `node:fs` (`readFileSync(path)`, `open`) — separate capability tier
   needing a filesystem (`--allow-fs`/preopens), not async-gated.
+
+## Implementation notes (P3-a + P3-b + P3-c — 2026-06-24, sdev-2635)
+
+Landed slices P3-a + P3-b + P3-c in one PR. **P3-d (asyncify incremental
+loop-borrow) is the remaining deferred fidelity follow-up** — not done here.
+
+### What was actually the gap (regrounded against current main)
+#2632 already shipped the ENTIRE WASI side of async `process.stdin`: the
+fd0-readiness reactor (`async-scheduler.ts`: `buildRunLoopBodyWithFdReactor`,
+`__rl_stdin_drain`, multi-subscription `poll_oneoff`), the four `__wasiStdin*`
+reactor intrinsics, and a faithful byte-chunk `Readable` substrate
+(`tests/issue-2632-phase3-stdin-readable.test.ts` proves the WASI arm under both
+the JS polyfill and real wasmtime). So the true #2635 gap was exactly ONE thing:
+the **edge.js (native-Node) arm** of the same-binary async proof.
+
+### The load-bearing architectural fact (why the seam is `wasi_snapshot_preview1`, not `node:fs`)
+The async `process.stdin` reactor is **WASI-internal**: `__run_event_loop` is
+wired into `_start` and drives `poll_oneoff`/`fd_read`/`fd_fdstat_set_flags`/
+`clock_time_get`/`fd_write` **directly as `wasi_snapshot_preview1` imports**.
+There is no exported per-tick API and no `node:fs`-member ABI for the async path
+(unlike the synchronous `readSync`/`writeSync`, which ARE `node:fs` closures
+edge.js can satisfy — Phase 1). So the provider seam for the async path is the
+`wasi_snapshot_preview1` import surface. edge.js's `createNodeStdinWasiProvider`
+provides exactly that surface, fed by Node's real `process.stdin` events.
+
+### The sync/async impedance + the decision I owned
+The wasm reactor's `_start` is a **synchronous** `poll_oneoff`-blocking loop;
+Node's stdin is **async**. Calling `_start()` and letting `poll_oneoff` block
+deadlocks (data only arrives when the JS loop is free). I used **MECHANISM 2
+(pre-drain)**: `await` Node's real `process.stdin` to `'end'`, collecting all
+chunks (this genuinely borrows Node's event loop for the collection phase), THEN
+run `_start()` so every `poll_oneoff` finds data/EOF immediately and never truly
+blocks. This is the proven `setStdin(bytes)` + `_start()` path #2632 validated
+byte-identically against wasmtime. **Mechanism 1** (true incremental
+asyncify-suspend loop-borrow) is the deferred **P3-d**; the `P3-d SEAM` comment
+in `edge.js` marks where it would slot in.
+
+### Crucial codegen constraint discovered (memory ownership)
+The async proof program must be **pure `--target wasi`** (owns + EXPORTS its own
+`memory`), NOT `--link-node-shims`. A first attempt mixed `node:fs` writeSync
+(imported memory, Phase-1 model) with the native WASI reactor; under wasmtime it
+failed with **"missing required memory export"** — wasmtime's native
+`wasi_snapshot_preview1.fd_read`/`clock_time_get` require the COMMAND module to
+export `memory`, but a `node:fs`-importing module imports memory from the shim
+and exports none. The pure-wasi program (memory self-owned + exported) is what
+both wasmtime and edge.js bind. edge.js binds it lazily from
+`instance.exports.memory` after instantiation.
+
+### Provider semantics (mirror `buildWasiPolyfill` exactly, byte-for-byte)
+- `fd_read(0)`: drain the pre-collected queue into the iovec base, return count;
+  0-byte read == EOF (queue empty) — `__rl_stdin_drain`'s contract.
+- `poll_oneoff`: fd0 FD_READ fires when bytes remain (else CLOCK; else fd0 anyway
+  so the reactor's EOF read ends the subscription rather than hanging).
+- `fd_fdstat_set_flags`: no-op ack (fd_read already non-blocking vs the queue).
+- `fd_write`: writes RAW bytes to the real fd1/fd2 (NOT line-buffered through
+  console.log) — required for byte-identity with wasmtime's native fd_write.
+- Re-reads `memory.buffer` per `fd_read`/`fd_write` so a `memory.grow` between
+  calls can't leave a detached view (matches Phase-1 `createNodeFsProvider`).
+
+### Dependency choice
+Kept the example **zero-dependency** (only `node:` imports), inlining the minimal
+`wasi_snapshot_preview1` subset rather than importing `buildWasiPolyfill` from the
+built `dist/` runtime (Phase-1 "thin adapter" precedent). This makes the edge.js
+arm a genuinely INDEPENDENT provider that must AGREE byte-for-byte with both
+wasmtime AND the in-tree polyfill — a stronger proof than re-exporting the
+polyfill verbatim. Recorded in an `edge.js` comment; if semantics ever drift,
+prefer reusing `buildWasiPolyfill` via a small `edge-wasi.mjs` helper.
+
+### Files
+- `examples/native-messaging/edge.js` — added `createNodeStdinWasiProvider`
+  (the async provider) + `drainProcessStdin` helper (P3-a).
+- `examples/native-messaging/run-edge-stdin.mjs` — native-Node async runner (P3-b).
+- `tests/issue-2635-async-dual-provider.test.ts` — same-binary byte-identical
+  proof: one compiled `process.stdin` line-count + byte-echo binary, byte-identical
+  output under wasmtime AND edge.js, across frames incl. `0x00/0xff/0x80/0x0a` (P3-c).
+
+### Validation
+No compiler-core change (example + test + runtime-mirroring helper only). New test
+green under both arms; `tests/issue-1772-*` + `tests/issue-2632-phase3-*` green
+(no regression); tsc + biome lint/format clean. This closes Phase 3 of #1772;
+#1772 itself stays in-progress for P2-c.

--- a/tests/issue-2635-async-dual-provider.test.ts
+++ b/tests/issue-2635-async-dual-provider.test.ts
@@ -34,12 +34,7 @@ import { compile } from "../src/index.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO = resolve(HERE, "..");
-const EDGE_STDIN_RUNNER = join(
-  REPO,
-  "examples",
-  "native-messaging",
-  "run-edge-stdin.mjs",
-);
+const EDGE_STDIN_RUNNER = join(REPO, "examples", "native-messaging", "run-edge-stdin.mjs");
 
 // js2wasm emits a WasmGC module; enable the GC/function-references/exceptions
 // proposals (mirrors the #2632 Phase-3 wasmtime arm flags).
@@ -99,10 +94,7 @@ async function compileStdin(src: string): Promise<Uint8Array> {
     target: "wasi",
     skipSemanticDiagnostics: true,
   });
-  expect(
-    r.success,
-    r.success ? "" : `compile error: ${r.errors?.[0]?.message}`,
-  ).toBe(true);
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
   return r.binary!;
 }
 
@@ -142,10 +134,7 @@ describe("#2635 — process.stdin same-binary async dual-provider compatibility"
   it("provider (b): edge.js async provider line-counts off real Node stdin", () => {
     const wasmPath = join(tmp, "lc_edge.wasm");
     writeFileSync(wasmPath, lineCountBin);
-    const out = runEdge(
-      wasmPath,
-      Buffer.from("Hello\nWorld\nThird line no newline"),
-    );
+    const out = runEdge(wasmPath, Buffer.from("Hello\nWorld\nThird line no newline"));
     expect(out.toString("utf-8")).toBe("lines=2 bytes=33\n");
   });
 
@@ -157,46 +146,37 @@ describe("#2635 — process.stdin same-binary async dual-provider compatibility"
   });
 
   // The #2635 acceptance: SAME binary, BOTH providers, byte-identical output.
-  describe.skipIf(!wasmtimeBin)(
-    "same-binary byte-identical proof (wasmtime vs edge.js)",
-    () => {
-      // Frames containing high/null bytes so a UTF-8-collapsing provider on the
-      // fd_read path would diverge: 0x00, 0xff, 0x80, 0x0a embedded.
-      const FRAMES: Array<{ name: string; input: Uint8Array }> = [
-        { name: "ascii lines", input: Buffer.from("alpha\nbeta\ngamma\n") },
-        { name: "no trailing newline", input: Buffer.from("one\ntwo\nthree") },
-        {
-          name: "high/null bytes",
-          input: Uint8Array.from([0x00, 0xff, 0x80, 0x0a, 0x41, 0x0a, 0x7f]),
-        },
-        { name: "empty", input: new Uint8Array(0) },
-      ];
+  describe.skipIf(!wasmtimeBin)("same-binary byte-identical proof (wasmtime vs edge.js)", () => {
+    // Frames containing high/null bytes so a UTF-8-collapsing provider on the
+    // fd_read path would diverge: 0x00, 0xff, 0x80, 0x0a embedded.
+    const FRAMES: Array<{ name: string; input: Uint8Array }> = [
+      { name: "ascii lines", input: Buffer.from("alpha\nbeta\ngamma\n") },
+      { name: "no trailing newline", input: Buffer.from("one\ntwo\nthree") },
+      {
+        name: "high/null bytes",
+        input: Uint8Array.from([0x00, 0xff, 0x80, 0x0a, 0x41, 0x0a, 0x7f]),
+      },
+      { name: "empty", input: new Uint8Array(0) },
+    ];
 
-      it("line-count: both providers agree byte-for-byte on every frame", () => {
-        const wasmPath = join(tmp, "lc_dual.wasm");
-        writeFileSync(wasmPath, lineCountBin);
-        for (const { name, input } of FRAMES) {
-          const wt = runWasmtime(wasmPath, input);
-          const edge = runEdge(wasmPath, input);
-          expect(
-            Array.from(edge),
-            `line-count edge≠wasmtime for "${name}"`,
-          ).toEqual(Array.from(wt));
-        }
-      });
+    it("line-count: both providers agree byte-for-byte on every frame", () => {
+      const wasmPath = join(tmp, "lc_dual.wasm");
+      writeFileSync(wasmPath, lineCountBin);
+      for (const { name, input } of FRAMES) {
+        const wt = runWasmtime(wasmPath, input);
+        const edge = runEdge(wasmPath, input);
+        expect(Array.from(edge), `line-count edge≠wasmtime for "${name}"`).toEqual(Array.from(wt));
+      }
+    });
 
-      it("byte-echo: both providers agree byte-for-byte on every frame (incl. high/null bytes)", () => {
-        const wasmPath = join(tmp, "echo_dual.wasm");
-        writeFileSync(wasmPath, byteEchoBin);
-        for (const { name, input } of FRAMES) {
-          const wt = runWasmtime(wasmPath, input);
-          const edge = runEdge(wasmPath, input);
-          expect(
-            Array.from(edge),
-            `byte-echo edge≠wasmtime for "${name}"`,
-          ).toEqual(Array.from(wt));
-        }
-      });
-    },
-  );
+    it("byte-echo: both providers agree byte-for-byte on every frame (incl. high/null bytes)", () => {
+      const wasmPath = join(tmp, "echo_dual.wasm");
+      writeFileSync(wasmPath, byteEchoBin);
+      for (const { name, input } of FRAMES) {
+        const wt = runWasmtime(wasmPath, input);
+        const edge = runEdge(wasmPath, input);
+        expect(Array.from(edge), `byte-echo edge≠wasmtime for "${name}"`).toEqual(Array.from(wt));
+      }
+    });
+  });
 });

--- a/tests/issue-2635-async-dual-provider.test.ts
+++ b/tests/issue-2635-async-dual-provider.test.ts
@@ -1,0 +1,202 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2635 Phase 3 — same-binary ASYNC dual-provider compatibility proof.
+//
+// The Phase-1 proof (tests/issue-1772-edge-dual-provider.test.ts) showed one
+// compiled `node:fs`-importing binary runs byte-identically under the pure-WASI
+// `node-fs.wat` shim (wasmtime) AND the edge.js `node:fs` adapter (native Node).
+// That is the SYNCHRONOUS tier.
+//
+// This is the ASYNC tier: one compiled `process.stdin` Readable program
+// (`--target wasi`, so the #2632 async event-loop reactor + the four
+// `__wasiStdin*` reactor intrinsics wire in automatically) runs byte-identically
+// under TWO providers of the `wasi_snapshot_preview1` surface:
+//   (a) pure WASI — real `wasmtime` driving native `poll_oneoff`/`fd_read` on
+//       fd0 over the module's own exported memory (the proven #2632 arm), and
+//   (b) native Node — `createNodeStdinWasiProvider` (edge.js), whose
+//       fd_read/poll_oneoff are fed by Node's REAL `process.stdin` 'data'/'end'
+//       events (the JS host's event loop), run via `run-edge-stdin.mjs` as a
+//       child process with the bytes piped to its real fd0.
+// Both arms consume the SAME binary and must produce BYTE-IDENTICAL output.
+//
+// Unlike the synchronous `node:fs` tier, the async provider seam is the
+// `wasi_snapshot_preview1` import surface (the reactor is WASI-internal, NOT a
+// swappable `node:fs` member). The edge.js arm uses MECHANISM 2 (pre-drain to
+// EOF, then run `_start`) — the proven `setStdin(bytes)` + `_start()` path. The
+// true incremental loop-borrow via asyncify is the deferred follow-up (P3-d).
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = resolve(HERE, "..");
+const EDGE_STDIN_RUNNER = join(
+  REPO,
+  "examples",
+  "native-messaging",
+  "run-edge-stdin.mjs",
+);
+
+// js2wasm emits a WasmGC module; enable the GC/function-references/exceptions
+// proposals (mirrors the #2632 Phase-3 wasmtime arm flags).
+const WASMTIME_FLAGS = ["run", "-W", "gc=y,function-references=y,exceptions=y"];
+
+// ── Program 1: line-count. Reads every stdin byte via the reactor substrate,
+// counts newlines + total bytes, prints a single ASCII summary at EOF. Pure
+// `--target wasi` (owns + exports its memory; no node:fs). Deterministic and
+// byte-clean — the count is sensitive to the raw 0x0a bytes flowing through
+// fd_read on both arms.
+const LINE_COUNT = `
+declare function __wasiStdinReadByte(): number;
+declare function __wasiStdinEof(): boolean;
+declare function __wasiStdinSetReader(cb: () => void): void;
+let lines = 0;
+let bytes = 0;
+let ended = false;
+__wasiStdinSetReader(() => {
+  let b = __wasiStdinReadByte();
+  while (b >= 0) { bytes = bytes + 1; if (b === 10) { lines = lines + 1; } b = __wasiStdinReadByte(); }
+  if (__wasiStdinEof() && !ended) { ended = true; console.log("lines=" + lines + " bytes=" + bytes); }
+});
+`;
+
+// ── Program 2: byte-echo. Reads every stdin byte via the reactor substrate and
+// writes each back via process.stdout.write (lowers to fd_write). Exercises the
+// FULL byte range through fd_read on both arms — including the bytes that catch a
+// UTF-8-collapsing provider (0x00, 0xff, 0x80, 0x0a). Both arms apply the SAME
+// String.fromCharCode → UTF-8 transformation (it is the same binary), so the
+// outputs stay byte-identical; the proof is provider-agreement, not raw fidelity.
+const BYTE_ECHO = `
+declare function __wasiStdinReadByte(): number;
+declare function __wasiStdinEof(): boolean;
+declare function __wasiStdinSetReader(cb: () => void): void;
+__wasiStdinSetReader(() => {
+  let b = __wasiStdinReadByte();
+  while (b >= 0) { process.stdout.write(String.fromCharCode(b)); b = __wasiStdinReadByte(); }
+});
+`;
+
+function findWasmtime(): string | null {
+  for (const cand of ["wasmtime", "/usr/local/bin/wasmtime"]) {
+    try {
+      execFileSync(cand, ["--version"], { stdio: "ignore" });
+      return cand;
+    } catch {
+      /* try next */
+    }
+  }
+  return null;
+}
+const wasmtimeBin = findWasmtime();
+
+async function compileStdin(src: string): Promise<Uint8Array> {
+  const r = await compile(src, {
+    fileName: "stdin.ts",
+    target: "wasi",
+    skipSemanticDiagnostics: true,
+  });
+  expect(
+    r.success,
+    r.success ? "" : `compile error: ${r.errors?.[0]?.message}`,
+  ).toBe(true);
+  return r.binary!;
+}
+
+/** Arm (a): pure-WASI under wasmtime, bytes piped to fd0. Raw output bytes. */
+function runWasmtime(wasmPath: string, input: Uint8Array): Buffer {
+  return execFileSync(wasmtimeBin!, [...WASMTIME_FLAGS, wasmPath], {
+    input: Buffer.from(input),
+    maxBuffer: 4 * 1024 * 1024,
+  });
+}
+
+/** Arm (b): native Node via edge.js, bytes piped to the runner's real fd0. */
+function runEdge(wasmPath: string, input: Uint8Array): Buffer {
+  return execFileSync(process.execPath, [EDGE_STDIN_RUNNER, wasmPath], {
+    input: Buffer.from(input),
+    maxBuffer: 4 * 1024 * 1024,
+  });
+}
+
+describe("#2635 — process.stdin same-binary async dual-provider compatibility", () => {
+  let tmp: string;
+  let lineCountBin: Uint8Array;
+  let byteEchoBin: Uint8Array;
+
+  beforeAll(async () => {
+    lineCountBin = await compileStdin(LINE_COUNT);
+    byteEchoBin = await compileStdin(BYTE_ECHO);
+    tmp = mkdtempSync(join(tmpdir(), "edge-async-dual-"));
+  });
+
+  afterAll(() => {
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+  });
+
+  // Arm (b) alone: the edge.js async provider drives the same binary off real
+  // fd0 and produces the expected line-count. (Always runs — no wasmtime needed.)
+  it("provider (b): edge.js async provider line-counts off real Node stdin", () => {
+    const wasmPath = join(tmp, "lc_edge.wasm");
+    writeFileSync(wasmPath, lineCountBin);
+    const out = runEdge(
+      wasmPath,
+      Buffer.from("Hello\nWorld\nThird line no newline"),
+    );
+    expect(out.toString("utf-8")).toBe("lines=2 bytes=33\n");
+  });
+
+  it("provider (b): edge.js async provider on empty stdin emits only the EOF summary", () => {
+    const wasmPath = join(tmp, "lc_edge_empty.wasm");
+    writeFileSync(wasmPath, lineCountBin);
+    const out = runEdge(wasmPath, new Uint8Array(0));
+    expect(out.toString("utf-8")).toBe("lines=0 bytes=0\n");
+  });
+
+  // The #2635 acceptance: SAME binary, BOTH providers, byte-identical output.
+  describe.skipIf(!wasmtimeBin)(
+    "same-binary byte-identical proof (wasmtime vs edge.js)",
+    () => {
+      // Frames containing high/null bytes so a UTF-8-collapsing provider on the
+      // fd_read path would diverge: 0x00, 0xff, 0x80, 0x0a embedded.
+      const FRAMES: Array<{ name: string; input: Uint8Array }> = [
+        { name: "ascii lines", input: Buffer.from("alpha\nbeta\ngamma\n") },
+        { name: "no trailing newline", input: Buffer.from("one\ntwo\nthree") },
+        {
+          name: "high/null bytes",
+          input: Uint8Array.from([0x00, 0xff, 0x80, 0x0a, 0x41, 0x0a, 0x7f]),
+        },
+        { name: "empty", input: new Uint8Array(0) },
+      ];
+
+      it("line-count: both providers agree byte-for-byte on every frame", () => {
+        const wasmPath = join(tmp, "lc_dual.wasm");
+        writeFileSync(wasmPath, lineCountBin);
+        for (const { name, input } of FRAMES) {
+          const wt = runWasmtime(wasmPath, input);
+          const edge = runEdge(wasmPath, input);
+          expect(
+            Array.from(edge),
+            `line-count edge≠wasmtime for "${name}"`,
+          ).toEqual(Array.from(wt));
+        }
+      });
+
+      it("byte-echo: both providers agree byte-for-byte on every frame (incl. high/null bytes)", () => {
+        const wasmPath = join(tmp, "echo_dual.wasm");
+        writeFileSync(wasmPath, byteEchoBin);
+        for (const { name, input } of FRAMES) {
+          const wt = runWasmtime(wasmPath, input);
+          const edge = runEdge(wasmPath, input);
+          expect(
+            Array.from(edge),
+            `byte-echo edge≠wasmtime for "${name}"`,
+          ).toEqual(Array.from(wt));
+        }
+      });
+    },
+  );
+});


### PR DESCRIPTION
## #2635 — async `process.stdin` same-binary dual-provider proof (Phase 3 of #1772)

Proves the SAME compiled `process.stdin` wasm binary runs **byte-identically** under BOTH providers of the `wasi_snapshot_preview1` surface:
- **(a) pure WASI** — real `wasmtime` driving native `poll_oneoff`/`fd_read` on fd0 over the module's own exported memory (the proven #2632 reactor arm).
- **(b) native Node** — `createNodeStdinWasiProvider` (edge.js), whose `fd_read`/`poll_oneoff` are fed by Node's **real** `process.stdin` `'data'`/`'end'` events (the JS host's event loop), run via `run-edge-stdin.mjs` as a child process with bytes piped to its real fd0.

Slices **P3-a + P3-b + P3-c** in one PR. **P3-d (asyncify incremental loop-borrow) is the remaining deferred fidelity follow-up** — not in this PR.

### The architectural fact
The async `process.stdin` reactor is **WASI-internal**: `__run_event_loop` is wired into `_start` and drives `poll_oneoff`/`fd_read`/`fd_fdstat_set_flags`/`clock_time_get`/`fd_write` **directly as `wasi_snapshot_preview1` imports**. There is no per-tick API and no `node:fs`-member ABI for the async path (unlike the synchronous Phase-1 `readSync`/`writeSync`). So the async provider seam is the `wasi_snapshot_preview1` import surface — `createNodeStdinWasiProvider` provides exactly that.

### Impedance + decision (the load-bearing call)
The reactor's `_start` is a **synchronous** `poll_oneoff`-blocking loop; Node's stdin is **async**. Calling `_start()` and letting `poll_oneoff` block deadlocks. Used **MECHANISM 2 (pre-drain)**: `await` Node's real `process.stdin` to `'end'`, collect all bytes (genuinely borrows Node's loop for the collection phase), then run `_start()` so every `poll_oneoff` finds data/EOF immediately — the proven `setStdin(bytes)` + `_start()` path #2632 validated against wasmtime. The `P3-d SEAM` comment in `edge.js` marks where mechanism 1 (true incremental asyncify-suspend) would slot in.

### Constraint discovered (memory ownership)
The proof program must be **pure `--target wasi`** (owns + EXPORTS its memory), NOT `--link-node-shims`: wasmtime's native `fd_read`/`clock_time_get` require the command module to export `memory`, but a `node:fs`-importing module imports memory from the shim and exports none → `missing required memory export`. edge.js binds memory lazily from `instance.exports.memory` after instantiation.

### Files
- `examples/native-messaging/edge.js` — `createNodeStdinWasiProvider` + `drainProcessStdin` (P3-a). Zero-dependency inlined `wasi_snapshot_preview1` subset mirroring `buildWasiPolyfill` semantics exactly (fd0-readable iff bytes remain/EOF; 0-byte read == EOF; `fd_fdstat_set_flags` no-op; **raw-byte** `fd_write`). Inlined (not re-exported from `dist/`) so the arm is a genuinely independent provider that must agree byte-for-byte with both wasmtime AND the polyfill.
- `examples/native-messaging/run-edge-stdin.mjs` — native-Node async runner (P3-b).
- `tests/issue-2635-async-dual-provider.test.ts` — same-binary byte-identical proof: one compiled `process.stdin` line-count + byte-echo binary, byte-identical output under wasmtime AND edge.js, across frames incl. `0x00/0xff/0x80/0x0a` (P3-c).

### Validation (per #1968)
- **No compiler-core change** — example + test + a runtime-mirroring helper only; the compiler is byte-untouched.
- New dual-provider test green under BOTH arms (4 tests; byte-identical proof skips only if wasmtime absent).
- `tests/issue-1772-edge-dual-provider` + `tests/issue-2632-phase3-stdin-readable` green — no regression.
- `tsc --noEmit` exit 0; biome lint/format clean.

Closes **Phase 3 of #1772** (#2635 `status: done`). #1772 itself stays in-progress for P2-c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)