### PR TITLE
fix(#2644): standalone Array.prototype.at index ToIntegerOrInfinity

### DIFF
--- a/plan/issues/2644-standalone-array-at-index-tointeger.md
+++ b/plan/issues/2644-standalone-array-at-index-tointeger.md
@@ -1,0 +1,96 @@
+---
+id: 2644
+title: "Standalone: ToIntegerOrInfinity for Array.prototype.at index arg"
+status: done
+completed: 2026-06-24
+assignee: ttraenkler/agent-abc4cbcc1c297d4bd
+sprint: 65
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: conformance
+area: array-number
+language_feature: array-methods
+goal: standalone-mode
+parent: 2160
+related: [2600, 2124]
+---
+
+# #2644 — Standalone Array.prototype.at index argument ToIntegerOrInfinity
+
+## Problem
+
+In `--target standalone`, the index argument of `Array.prototype.at` was coerced
+**directly to i32** instead of through **ToIntegerOrInfinity** (§23.1.3.1 step 2 =
+§7.1.5 = ToNumber then truncate-toward-zero). So a non-integer-typed index on a
+**typed array receiver** resolved to the wrong slot — a substrate-independent
+value-correctness bug (not a trap).
+
+This is the **Array analog** of the already-fixed String-method bug #2600
+(`compileStringIntegerArg`).
+
+### Verified repro (host pass / standalone wrong-value, main `4c0582635c`)
+
+| call (typed `number[]` receiver, `a=[10,11,12,13]`) | host | standalone (before) |
+|---|---|---|
+| `a.at("1")` | `11` (ToInteger("1")=1) | **`10`** (index 0) |
+| `a.at("2")` | `12` | **`10`** |
+| `a.at("-1")` | `13` | wrong |
+
+Per-process probe (direct standalone compile+run) confirmed `a.at("1")` → 10.
+`a.at(true)` / `a.at(false)` / numeric literals already worked (they reach an
+i32/f64 path); only the **string / object** index fell through to 0.
+
+The matching test262 row `built-ins/Array/prototype/at/index-non-numeric-argument-tointeger.js`
+was host-pass / standalone-fail (failed at assertion #9, `a.at("1")`).
+
+## Root cause
+
+`compileArrayAt` (`src/codegen/array-methods.ts` ~line 3805) requested the index
+with a direct `{ kind: "i32" }` hint:
+
+```ts
+const argType = compileExpression(ctx, fctx, callExpr.arguments[0]!, { kind: "i32" });
+if (argType && argType.kind === "f64") fctx.body.push({ op: "i32.trunc_sat_f64_s" });
+```
+
+In standalone, `compileExpression(stringLiteral, {kind:"i32"})` does not run
+ToNumber(string)→truncate; it falls through to 0. (Host has a JS import path that
+coerces correctly.)
+
+## Fix
+
+`src/codegen/array-methods.ts`, `compileArrayAt` — under `noJsHost(ctx)` the index
+is now run through ToIntegerOrInfinity, mirroring #2600:
+
+- `i32`-typed arg → unchanged (already integral, in range).
+- `i64` (bigint) → TypeError via `emitThrowString` (§7.1.4).
+- else → `coerceType(argType, {kind:"f64"}, "number")` (the existing numeric
+  engine: string → `__str_to_number`, object → ToPrimitive("number")), then
+  ToIntegerOrInfinity: NaN→0 (`f64.ne self` test), else `i32.trunc_sat_f64_s`
+  (truncates toward zero; ±∞ saturates and the following negative-wrap +
+  bounds-check clamp it).
+
+The legacy direct-i32 path is kept for the JS-host mode. **No new #2108 coercion
+site** — `coerceType` reuse only; `check:coercion-sites` baseline unchanged. The
+negative-index wrap and bounds-check logic in `compileArrayAt` are downstream of
+the produced `idxTmp` and untouched.
+
+## Test Results
+
+- `tests/issue-2644-array-at-index-tointeger.test.ts` — 14/14 pass (standalone +
+  gc-mode regression guards): `at("1")`→11, `at("2")`→12, `at("1.9")`→11,
+  `at("")`→10, `at("abc")`→10 (NaN→0), `at("-1")`→13, `at("-2.5")`→12,
+  `at(true)`→11, `at(false)`→10, numeric `at(2)`/`at(-1)`/`at(1.9)` unchanged,
+  gc-mode `at("1")`/`at(2)` guards green.
+- test262 `built-ins/Array/prototype/at/index-non-numeric-argument-tointeger.js`
+  flips standalone fail→pass; host still pass.
+- Full `Array/prototype/at` dir (13 host-passing files): 0 standalone gaps after
+  the fix (was 1).
+- tsc, lint, prettier, `check:coercion-sites`, `check:stack-balance`,
+  `check:any-box-sites`, `check:codegen-fallbacks`, `check:speculative-rollback`
+  all green. native-arrays.test.ts pre-existing failures (15, TS semantic
+  diagnostics) confirmed identical with/without this change.
+
+### Estimated rows
+~1 standalone row (`index-non-numeric-argument-tointeger.js`).

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -3802,10 +3802,51 @@ function compileArrayAt(
   fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 });
   fctx.body.push({ op: "local.set", index: lenTmp });
 
-  // Compile index argument
-  const argType = compileExpression(ctx, fctx, callExpr.arguments[0]!, { kind: "i32" });
-  if (argType && argType.kind === "f64") {
-    fctx.body.push({ op: "i32.trunc_sat_f64_s" });
+  // Compile index argument. §23.1.3.1 Array.prototype.at step 2:
+  // relativeIndex = ToIntegerOrInfinity(index) = truncate-toward-zero of
+  // ToNumber(index) (§7.1.5), NOT a direct i32 coercion. In standalone a fast
+  // i32 coercion of a non-integer-typed index (a numeric *string* like `"1"`,
+  // a `{valueOf(){…}}` object) resolves to the wrong slot — `a.at("1")` landed
+  // on index 0 instead of 1 (#2644, the Array analog of the String-method fix
+  // #2600). Route the arg through the existing numeric coercion engine to f64
+  // (string → `__str_to_number`, object → ToPrimitive("number") — both already
+  // present for `+x` / `Number(x)`), then apply ToIntegerOrInfinity: NaN → 0,
+  // else `i32.trunc_sat_f64_s` (truncates toward zero; ±∞ saturates and the
+  // following <0 wrap + bounds check clamp it). No new #2108 coercion site —
+  // `coerceType` reuse only. The legacy direct-i32 path is kept for the JS-host
+  // mode (which coerces strings via a host import).
+  if (noJsHost(ctx)) {
+    const argType = compileExpression(ctx, fctx, callExpr.arguments[0]!);
+    if (!argType) {
+      // void → undefined → ToNumber NaN → ToIntegerOrInfinity 0.
+      fctx.body.push({ op: "i32.const", value: 0 });
+    } else if (argType.kind === "i32") {
+      // Already an integer (boolean / int-typed index) — in range, no ToNumber.
+    } else if (argType.kind === "i64") {
+      // BigInt index → TypeError per ToNumber (§7.1.4).
+      fctx.body.push({ op: "drop" } as Instr);
+      emitThrowString(ctx, fctx, "TypeError: Cannot convert a BigInt value to a number");
+      fctx.body.push({ op: "i32.const", value: 0 });
+    } else {
+      // Coerce ToNumber → f64 via the engine, then ToIntegerOrInfinity.
+      coerceType(ctx, fctx, argType, { kind: "f64" }, "number");
+      const fTmp = allocLocal(fctx, `__arr_at_f_${fctx.locals.length}`, { kind: "f64" });
+      fctx.body.push({ op: "local.set", index: fTmp });
+      fctx.body.push({ op: "local.get", index: fTmp });
+      fctx.body.push({ op: "local.get", index: fTmp });
+      fctx.body.push({ op: "f64.ne" }); // self != self ⇒ NaN
+      fctx.body.push({
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: [{ op: "i32.const", value: 0 }],
+        else: [{ op: "local.get", index: fTmp }, { op: "i32.trunc_sat_f64_s" }],
+      } as Instr);
+    }
+  } else {
+    const argType = compileExpression(ctx, fctx, callExpr.arguments[0]!, { kind: "i32" });
+    if (argType && argType.kind === "f64") {
+      fctx.body.push({ op: "i32.trunc_sat_f64_s" });
+    }
   }
   fctx.body.push({ op: "local.set", index: idxTmp });
 

--- a/tests/issue-2644-array-at-index-tointeger.test.ts
+++ b/tests/issue-2644-array-at-index-tointeger.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+
+// #2644 — Standalone Array.prototype.at index argument ToIntegerOrInfinity
+//   (§23.1.3.1 step 2 = §7.1.5: truncate-toward-zero of ToNumber(index)), the
+//   Array analog of the String-method fix #2600. The index was coerced directly
+//   to i32 instead of via ToNumber→truncate, so a non-integer-typed index on a
+//   typed array receiver resolved to the wrong slot: `[10,11,12,13].at("1")`
+//   returned 10 (index 0) instead of 11 (index 1) in --target standalone.
+//
+//   Fix (src/codegen/array-methods.ts, compileArrayAt): under noJsHost route the
+//   arg through the existing numeric coercion engine (coerceType(...,{kind:"f64"},
+//   "number") — string → __str_to_number, object → ToPrimitive("number")), then
+//   ToIntegerOrInfinity (NaN→0, else i32.trunc_sat_f64_s). No new #2108 coercion
+//   site. The JS-host path (which coerces via host imports) is unchanged.
+//
+//   `skipSemanticDiagnostics` mirrors the test262 runner — passing a non-number
+//   to a `(index: number)` method is not a hard TS error there.
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, { target: "standalone", skipSemanticDiagnostics: true } as never);
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+async function runGc(src: string): Promise<unknown> {
+  const r = await compile(src, { skipSemanticDiagnostics: true } as never);
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject ?? {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#2644 standalone Array.prototype.at index ToIntegerOrInfinity", () => {
+  // The headline bug: a numeric *string* index must ToInteger-coerce.
+  it("at('1') → index 1 (was index 0 in standalone)", async () => {
+    expect(await runStandalone(`export function test(): number { const a=[10,11,12,13]; return a.at("1"); }`)).toBe(11);
+  });
+
+  it("at('2') → index 2", async () => {
+    expect(await runStandalone(`export function test(): number { const a=[10,11,12,13]; return a.at("2"); }`)).toBe(12);
+  });
+
+  it("at('1.9') → trunc toward zero → index 1", async () => {
+    expect(await runStandalone(`export function test(): number { const a=[10,11,12,13]; return a.at("1.9"); }`)).toBe(
+      11,
+    );
+  });
+
+  it("at('') → 0 (empty string ToNumber = 0)", async () => {
+    expect(await runStandalone(`export function test(): number { const a=[10,11,12,13]; return a.at(""); }`)).toBe(10);
+  });
+
+  it("at('abc') → NaN → ToIntegerOrInfinity 0", async () => {
+    expect(await runStandalone(`export function test(): number { const a=[10,11,12,13]; return a.at("abc"); }`)).toBe(
+      10,
+    );
+  });
+
+  it("at('-1') → negative index wraps from end → last element", async () => {
+    expect(await runStandalone(`export function test(): number { const a=[10,11,12,13]; return a.at("-1"); }`)).toBe(
+      13,
+    );
+  });
+
+  it("at('-2.5') → trunc to -2 → second from end", async () => {
+    expect(await runStandalone(`export function test(): number { const a=[10,11,12,13]; return a.at("-2.5"); }`)).toBe(
+      12,
+    );
+  });
+
+  // Boolean / null already worked but must keep working through the new path.
+  it("at(true) → 1", async () => {
+    expect(await runStandalone(`export function test(): number { const a=[10,11,12,13]; return a.at(true); }`)).toBe(
+      11,
+    );
+  });
+
+  it("at(false) → 0", async () => {
+    expect(await runStandalone(`export function test(): number { const a=[10,11,12,13]; return a.at(false); }`)).toBe(
+      10,
+    );
+  });
+
+  // Plain integer / float numeric indices — regression guards.
+  it("at(2) → index 2 (numeric literal unchanged)", async () => {
+    expect(await runStandalone(`export function test(): number { const a=[10,11,12,13]; return a.at(2); }`)).toBe(12);
+  });
+
+  it("at(-1) → last element (numeric negative unchanged)", async () => {
+    expect(await runStandalone(`export function test(): number { const a=[10,11,12,13]; return a.at(-1); }`)).toBe(13);
+  });
+
+  it("at(1.9) → trunc to 1 (numeric fractional)", async () => {
+    expect(await runStandalone(`export function test(): number { const a=[10,11,12,13]; return a.at(1.9); }`)).toBe(11);
+  });
+
+  // gc/host mode must remain correct (the JS-host path is untouched).
+  it("gc-mode at('1') → 1 (host path regression guard)", async () => {
+    expect(await runGc(`export function test(): number { const a=[10,11,12,13]; return a.at("1"); }`)).toBe(11);
+  });
+
+  it("gc-mode at(2) → 2 (host path regression guard)", async () => {
+    expect(await runGc(`export function test(): number { const a=[10,11,12,13]; return a.at(2); }`)).toBe(12);
+  });
+});


### PR DESCRIPTION
## Problem

In `--target standalone`, `Array.prototype.at` coerced its index argument
**directly to i32** instead of through **ToIntegerOrInfinity** (§23.1.3.1 step 2
= §7.1.5 = ToNumber then truncate-toward-zero). A non-integer-typed index on a
typed array receiver landed on the wrong slot:

| call (`a=[10,11,12,13]`) | host | standalone (before) |
|---|---|---|
| `a.at("1")` | `11` | **`10`** (index 0) |
| `a.at("-1")` | `13` | wrong |

This is the **Array analog** of the String-method fix #2600.

## Fix

`src/codegen/array-methods.ts`, `compileArrayAt` — under `noJsHost(ctx)` the
index is run through ToIntegerOrInfinity:
- `i32`-typed arg → unchanged (already integral).
- `i64` (bigint) → TypeError (§7.1.4).
- else → `coerceType(argType, {kind:"f64"}, "number")` (existing numeric engine:
  string → `__str_to_number`, object → ToPrimitive("number")), then NaN→0, else
  `i32.trunc_sat_f64_s`.

The negative-index wrap + bounds check downstream of the produced index are
untouched. JS-host path kept. **No new #2108 coercion site** — `coerceType`
reuse only; `check:coercion-sites` baseline unchanged.

## Validation

- `tests/issue-2644-array-at-index-tointeger.test.ts` — 14/14 (standalone +
  gc-mode regression guards).
- test262 `built-ins/Array/prototype/at/index-non-numeric-argument-tointeger.js`
  flips standalone fail→pass (per-process); host still pass. Full
  `Array/prototype/at` dir: 0 standalone gaps after fix (was 1).
- tsc, lint, prettier, `check:coercion-sites`, `check:stack-balance`,
  `check:any-box-sites`, `check:codegen-fallbacks`, `check:speculative-rollback`,
  `check:issue-ids:against-main` all green. native-arrays.test.ts pre-existing
  failures (TS semantic diagnostics) confirmed identical with/without this change.

Closes #2644.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA