### PR TITLE
feat(host-interop): #1772 Phase 2 — no-provider gate + capability-map extension

### DIFF
--- a/plan/issues/1772-edgejs-node-wasi-shim-spike.md
+++ b/plan/issues/1772-edgejs-node-wasi-shim-spike.md
@@ -4,7 +4,7 @@ title: "Node API imports from @types/node, satisfied by one ABI across pure-WASI
 status: in-progress
 created: 2026-06-01
 updated: 2026-06-24
-assignee: ttraenkler/agent-a9512a06
+assignee: ttraenkler/dev-1772-p2
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -267,3 +267,49 @@ correct across growth.
 
 Issue stays `in-progress` because Phase 2 (#2634) remains. Phases 0+1 acceptance
 criteria are met.
+
+---
+
+## Phase 2 progress — slices P2-a + P2-b LANDED (2026-06-24)
+
+Architect scoping (PR #2011, `## Implementation Plan`) split the residual Phase-2
+work into P2-a (wire the gate), P2-b (extend the map + record the verdict), and
+P2-c (compose with #2528, gated). This PR lands **P2-a + P2-b**.
+
+- **P2-a — no-provider codegen gate (DONE).** `src/codegen/node-fs-api.ts`
+  `tryCompileNodeFsCall` now consults the capability map: a `node:fs` member the
+  program imported, known to the map, and **unsatisfiable** under the active
+  target (`isMemberSatisfiable("node:fs", member, { wasi: ctx.wasi, allowFs:
+  false }) === false`) pushes a precise error naming the member + `--allow-fs`,
+  and returns the `VOID_RESULT` "consumed" sentinel so the generic host-import
+  path does not also fire. The gate sits AFTER the `!ctx.wasi` guard but BEFORE
+  the `!ctx.linkNodeShims` short-circuit, so it fires under `--target wasi`
+  regardless of `--link-node-shims`, and is a no-op for the satisfiable fd-based
+  `readSync`/`writeSync`. It keys off `ctx.wasiNodeFsFuncs` (the node:fs import
+  set) so a same-named local function is never gated. This wires up what was
+  **dead code** (`isMemberSatisfiable` had no codegen consumer) and makes the
+  map the source of truth; the legacy hardcoded `PATH_BASED_FS_FNS` gate in
+  `calls.ts` (byte-identical member set) is now a harmless backstop the map gate
+  pre-empts. `allowFs` is hardcoded `false` this PR — the `--allow-fs` plumbing
+  is the tiny deferred follow-up **P2-a.0**.
+  Test: `tests/issue-1772-no-provider-gate.test.ts`.
+
+- **P2-b — capability-map extension + verdict (DONE).**
+  `src/checker/node-capability-map.ts` gains a `node:process` entry with std-IO
+  satisfiability metadata (`write`/`stdout`/`stderr`, `providersFor: t.wasi ?
+  ["wasi-fd"] : ["js-host-fs"]`) — **metadata only, empty decls**. The
+  `node:process` type surface stays owned by the bespoke `PROCESS_INTERFACE_DECLS`
+  branch in `buildNodeEnvDts` (which `continue`s before `buildModuleDecls`), so no
+  double-declaration; the map entry just lets the query functions reason about
+  the std-IO members (proving the #2634 "data-not-code extension" promise). The
+  **hand-authored-mirror verdict is recorded in the map header**: literal
+  `@types/node` sourcing is REJECTED (in-memory lib host doesn't load
+  `@types/node`; the gate needs type-surface == runtime-surface, the opposite of
+  `@types/node`; the mirror is per-member faithful with a cited source).
+  Test: `tests/issue-1772-capability-map-extend.test.ts`.
+
+- **P2-c — deferred (gated on #2528).** Compose with `--platform node|web`
+  (`emulateNode ||= platform === "node"`). Not dispatched until #2528 lands.
+- **Phase 3 (#2635)** — async members; out of scope here.
+
+**#1772 stays `in-progress`** — P2-c (gated on #2528) and Phase 3 (#2635) remain.

--- a/src/checker/node-capability-map.ts
+++ b/src/checker/node-capability-map.ts
@@ -247,8 +247,7 @@ function buildFsCapability(): NodeModuleCapability {
 // `buildModuleDecls` — so this map entry can NOT double-declare `stdout`/`stderr`.
 // A full migration of the `node:process` decls into the map is a separate
 // follow-up; this slice adds only the satisfiability metadata.
-const PROCESS_STDIO_PROVIDERS = (t: CapabilityTarget): NodeProvider[] =>
-  t.wasi ? ["wasi-fd"] : ["js-host-fs"];
+const PROCESS_STDIO_PROVIDERS = (t: CapabilityTarget): NodeProvider[] => (t.wasi ? ["wasi-fd"] : ["js-host-fs"]);
 
 function buildProcessCapability(): NodeModuleCapability {
   const members = new Map<string, NodeMemberCapability>();
@@ -277,9 +276,7 @@ const NODE_CAPABILITY_MAP = new Map<string, NodeModuleCapability>([
 ]);
 
 /** Look up the capability entry for a `node:<mod>` specifier, if mapped. */
-export function getModuleCapability(
-  module: string,
-): NodeModuleCapability | undefined {
+export function getModuleCapability(module: string): NodeModuleCapability | undefined {
   return NODE_CAPABILITY_MAP.get(module);
 }
 
@@ -294,11 +291,7 @@ export function isKnownMember(module: string, member: string): boolean {
  * deliberate-error case). Returns `undefined` for an unknown member (caller
  * decides — usually permissive).
  */
-export function isMemberSatisfiable(
-  module: string,
-  member: string,
-  target: CapabilityTarget,
-): boolean | undefined {
+export function isMemberSatisfiable(module: string, member: string, target: CapabilityTarget): boolean | undefined {
   const cap = NODE_CAPABILITY_MAP.get(module)?.members.get(member);
   if (!cap) return undefined;
   return cap.providersFor(target).length > 0;
@@ -312,10 +305,7 @@ export function isMemberSatisfiable(
  * `undefined` if the module is not in the capability map (caller falls back to
  * the permissive generic module shape).
  */
-export function buildModuleDecls(
-  module: string,
-  imported: Iterable<string>,
-): string[] | undefined {
+export function buildModuleDecls(module: string, imported: Iterable<string>): string[] | undefined {
   const cap = NODE_CAPABILITY_MAP.get(module);
   if (!cap) return undefined;
   const lines: string[] = [cap.supportDecls];

--- a/src/checker/node-capability-map.ts
+++ b/src/checker/node-capability-map.ts
@@ -27,6 +27,22 @@
 //      `.d.ts`-typed synthetic source where overloads ARE legal; the user's
 //      import site only *references* the names, so TS8017 never fires there.
 //      See `buildNodeEnvDts` in `src/checker/index.ts`.
+//
+// VERDICT — hand-authored faithful mirror vs literal `@types/node` sourcing
+// (#1772 Phase 2 acceptance item). **Literal `@types/node` sourcing is REJECTED;
+// the design is hand-authored-per-member-with-a-cited-source-of-truth.** Reasons:
+//   1. The checker uses an in-memory lib host and deliberately does NOT load
+//      `node_modules/@types/node` (see the support-decls comment below). Literal
+//      sourcing would mean parsing the full `@types/node` graph (`NodeJS.*`,
+//      `Buffer`, the stream/event types, thousands of members) at checker-init —
+//      heavy, and ~99% of that surface is un-linkable (no runtime provider).
+//   2. The gate's entire purpose is that the **type surface == the runtime
+//      surface**; literal `@types/node` is the exact opposite (type ≫ runtime),
+//      which is what produces the silent link failures this map exists to prevent.
+//   3. The mirror is already verified faithful PER MEMBER against
+//      `node_modules/@types/node/fs.d.ts` (cited in the #2634 review comments).
+//   So "extraction from @types/node" in the original Phase-2 scope is satisfied by
+//   *faithful mirroring with a cited source*, not by runtime parsing of the graph.
 
 /**
  * A provider that can satisfy a member at link time. Informational today
@@ -213,14 +229,57 @@ function buildFsCapability(): NodeModuleCapability {
 }
 
 // ---------------------------------------------------------------------------
-// Registry — one entry per supported `node:<mod>`. Extend here (data) to add
-// `node:process` / `node:os` members later, NOT in the checker code.
+// node:process — std-IO satisfiability (metadata ONLY, NOT new decls)
 // ---------------------------------------------------------------------------
 
-const NODE_CAPABILITY_MAP = new Map<string, NodeModuleCapability>([["node:fs", buildFsCapability()]]);
+// #1772 P2-b — capability *satisfiability* entries for the `process` std-IO
+// surface, proving the #2634 "data-not-code extension" promise (adding a module
+// is a new map entry, not a checker code change). These members already LOWER
+// today via `src/codegen/node-fs-api.ts` (`process.stdout`/`stderr.write` →
+// `node:fs::writeSync(1|2, …)`); this entry just lets the map's query functions
+// (`isKnownMember` / `isMemberSatisfiable`) reason about them so P2-a's gate has
+// a uniform view of `node:<mod>` satisfiability.
+//
+// IMPORTANT — these are METADATA ONLY (empty `decls`). The `node:process` *type
+// surface* is still emitted by the bespoke `PROCESS_INTERFACE_DECLS` /
+// `declare module "node:process"` branch in `buildNodeEnvDts`
+// (`src/checker/index.ts` ~L454), which `continue`s BEFORE reaching
+// `buildModuleDecls` — so this map entry can NOT double-declare `stdout`/`stderr`.
+// A full migration of the `node:process` decls into the map is a separate
+// follow-up; this slice adds only the satisfiability metadata.
+const PROCESS_STDIO_PROVIDERS = (t: CapabilityTarget): NodeProvider[] =>
+  t.wasi ? ["wasi-fd"] : ["js-host-fs"];
+
+function buildProcessCapability(): NodeModuleCapability {
+  const members = new Map<string, NodeMemberCapability>();
+  // The actual call member (`process.stdout.write(...)` / `process.stderr.write`)
+  // plus the two stream handles it dispatches through. All lower to the fd-based
+  // `writeSync` sink, so all share the std-IO provider set. `decls: ""` keeps the
+  // type surface owned by the bespoke `node:process` branch (no double-declare).
+  for (const name of ["write", "stdout", "stderr"]) {
+    members.set(name, {
+      name,
+      decls: "",
+      providersFor: PROCESS_STDIO_PROVIDERS,
+    });
+  }
+  return { module: "node:process", supportDecls: "", members };
+}
+
+// ---------------------------------------------------------------------------
+// Registry — one entry per supported `node:<mod>`. Extend here (data) to add
+// `node:os` members later, NOT in the checker code.
+// ---------------------------------------------------------------------------
+
+const NODE_CAPABILITY_MAP = new Map<string, NodeModuleCapability>([
+  ["node:fs", buildFsCapability()],
+  ["node:process", buildProcessCapability()],
+]);
 
 /** Look up the capability entry for a `node:<mod>` specifier, if mapped. */
-export function getModuleCapability(module: string): NodeModuleCapability | undefined {
+export function getModuleCapability(
+  module: string,
+): NodeModuleCapability | undefined {
   return NODE_CAPABILITY_MAP.get(module);
 }
 
@@ -235,7 +294,11 @@ export function isKnownMember(module: string, member: string): boolean {
  * deliberate-error case). Returns `undefined` for an unknown member (caller
  * decides — usually permissive).
  */
-export function isMemberSatisfiable(module: string, member: string, target: CapabilityTarget): boolean | undefined {
+export function isMemberSatisfiable(
+  module: string,
+  member: string,
+  target: CapabilityTarget,
+): boolean | undefined {
   const cap = NODE_CAPABILITY_MAP.get(module)?.members.get(member);
   if (!cap) return undefined;
   return cap.providersFor(target).length > 0;
@@ -249,7 +312,10 @@ export function isMemberSatisfiable(module: string, member: string, target: Capa
  * `undefined` if the module is not in the capability map (caller falls back to
  * the permissive generic module shape).
  */
-export function buildModuleDecls(module: string, imported: Iterable<string>): string[] | undefined {
+export function buildModuleDecls(
+  module: string,
+  imported: Iterable<string>,
+): string[] | undefined {
   const cap = NODE_CAPABILITY_MAP.get(module);
   if (!cap) return undefined;
   const lines: string[] = [cap.supportDecls];

--- a/src/codegen/node-fs-api.ts
+++ b/src/codegen/node-fs-api.ts
@@ -9,10 +9,7 @@
  * `node:fs` shim). It also rejects the hallucinated `process.stdin.read(buf,
  * offset)` with a clear pointer to `node:fs` `readSync`.
  */
-import {
-  isKnownMember,
-  isMemberSatisfiable,
-} from "../checker/node-capability-map.js";
+import { isKnownMember, isMemberSatisfiable } from "../checker/node-capability-map.js";
 import { isStringType } from "../checker/type-mapper.js";
 import type { Instr, ValType } from "../ir/types.js";
 import { ts } from "../ts-api.js";
@@ -33,10 +30,7 @@ import {
 } from "./index.js";
 import type { InnerResult } from "./shared.js";
 import { compileExpression, VOID_RESULT } from "./shared.js";
-import {
-  getLinearU8Buffer,
-  tryEmitLinearU8StdWrite,
-} from "./linear-uint8-codegen.js";
+import { getLinearU8Buffer, tryEmitLinearU8StdWrite } from "./linear-uint8-codegen.js";
 
 export function tryCompileNodeProcessCall(
   ctx: CodegenContext,
@@ -85,9 +79,7 @@ export function tryCompileNodeProcessCall(
   // #2633: under the node shims there is no fd_write idx; `tryEmitLinearU8StdWrite`
   // routes to the imported `node:fs` `writeSync(fd, ptr, len)` instead (the passed
   // idx is unused on that branch).
-  const writeSinkIdx = ctx.linkNodeShims
-    ? ctx.nodeFsWriteSyncIdx
-    : ctx.wasiFdWriteIdx;
+  const writeSinkIdx = ctx.linkNodeShims ? ctx.nodeFsWriteSyncIdx : ctx.wasiFdWriteIdx;
   if (writeSinkIdx !== undefined && writeSinkIdx >= 0) {
     if (tryEmitLinearU8StdWrite(ctx, fctx, argExpr, writeSinkIdx, fd)) {
       // Match the GC Uint8Array write path's contract: push `1` (write
@@ -118,20 +110,11 @@ export function tryCompileNodeProcessCall(
   }
 
   const argSymName = argTsType.getSymbol?.()?.name;
-  const isArrayBufferArg =
-    argSymName === "ArrayBuffer" || argSymName === "SharedArrayBuffer";
+  const isArrayBufferArg = argSymName === "ArrayBuffer" || argSymName === "SharedArrayBuffer";
   const elemKey: "i8_byte" | "i32_byte" | "f64" =
-    noJsHost(ctx) && argSymName === "Uint8Array"
-      ? "i8_byte"
-      : isArrayBufferArg
-        ? "i32_byte"
-        : "f64";
+    noJsHost(ctx) && argSymName === "Uint8Array" ? "i8_byte" : isArrayBufferArg ? "i32_byte" : "f64";
   const elemType: ValType =
-    elemKey === "i8_byte"
-      ? { kind: "i8" }
-      : elemKey === "i32_byte"
-        ? { kind: "i32" }
-        : { kind: "f64" };
+    elemKey === "i8_byte" ? { kind: "i8" } : elemKey === "i32_byte" ? { kind: "i32" } : { kind: "f64" };
   const vecTypeIdx = getOrRegisterVecType(ctx, elemKey, elemType);
   const argType = compileExpression(ctx, fctx, argExpr);
   flushLateImportShifts(ctx, fctx);
@@ -143,11 +126,7 @@ export function tryCompileNodeProcessCall(
       } else {
         fctx.body.push({ op: "ref.as_non_null" } as Instr);
       }
-    } else if (
-      argType.kind === "ref" &&
-      "typeIdx" in argType &&
-      argType.typeIdx !== vecTypeIdx
-    ) {
+    } else if (argType.kind === "ref" && "typeIdx" in argType && argType.typeIdx !== vecTypeIdx) {
       fctx.body.push({ op: "ref.cast", typeIdx: vecTypeIdx } as Instr);
     }
   }
@@ -164,10 +143,7 @@ export function tryCompileNodeProcessCall(
   return VOID_RESULT;
 }
 
-function isUnshadowedProcessIdentifier(
-  fctx: FunctionContext,
-  expr: ts.Expression,
-): boolean {
+function isUnshadowedProcessIdentifier(fctx: FunctionContext, expr: ts.Expression): boolean {
   return (
     ts.isIdentifier(expr) &&
     expr.text === "process" &&
@@ -195,39 +171,25 @@ function matchProcessStdStreamWrite(
   if (!ctx.wasi || !haveWriteSink) return null;
   if (expr.questionDotToken || expr.arguments.length !== 1) return null;
   const writeAccess = expr.expression;
-  if (
-    !ts.isPropertyAccessExpression(writeAccess) ||
-    writeAccess.name.text !== "write"
-  )
-    return null;
+  if (!ts.isPropertyAccessExpression(writeAccess) || writeAccess.name.text !== "write") return null;
   const streamAccess = writeAccess.expression;
   if (!ts.isPropertyAccessExpression(streamAccess)) return null;
   const streamName = streamAccess.name.text;
   if (streamName !== "stdout" && streamName !== "stderr") return null;
-  if (!isUnshadowedProcessIdentifier(fctx, streamAccess.expression))
-    return null;
+  if (!isUnshadowedProcessIdentifier(fctx, streamAccess.expression)) return null;
   return { useStderr: streamName === "stderr" };
 }
 
-function matchProcessStdStreamDrainOnce(
-  ctx: CodegenContext,
-  fctx: FunctionContext,
-  expr: ts.CallExpression,
-): boolean {
+function matchProcessStdStreamDrainOnce(ctx: CodegenContext, fctx: FunctionContext, expr: ts.CallExpression): boolean {
   if (!ctx.wasi) return false;
   if (expr.questionDotToken || expr.arguments.length !== 2) return false;
   const onceAccess = expr.expression;
-  if (
-    !ts.isPropertyAccessExpression(onceAccess) ||
-    onceAccess.name.text !== "once"
-  )
-    return false;
+  if (!ts.isPropertyAccessExpression(onceAccess) || onceAccess.name.text !== "once") return false;
   const streamAccess = onceAccess.expression;
   if (!ts.isPropertyAccessExpression(streamAccess)) return false;
   const streamName = streamAccess.name.text;
   if (streamName !== "stdout" && streamName !== "stderr") return false;
-  if (!isUnshadowedProcessIdentifier(fctx, streamAccess.expression))
-    return false;
+  if (!isUnshadowedProcessIdentifier(fctx, streamAccess.expression)) return false;
   const eventArg = expr.arguments[0]!;
   return ts.isStringLiteralLike(eventArg) && eventArg.text === "drain";
 }
@@ -240,23 +202,12 @@ function matchProcessStdStreamDrainOnce(
  * (any local/captured `process` shadow is left alone). Non-WASI targets keep the
  * generic call path (it resolves through the JS host).
  */
-function matchProcessStdinRead(
-  fctx: FunctionContext,
-  expr: ts.CallExpression,
-): boolean {
+function matchProcessStdinRead(fctx: FunctionContext, expr: ts.CallExpression): boolean {
   if (expr.questionDotToken) return false;
   const readAccess = expr.expression;
-  if (
-    !ts.isPropertyAccessExpression(readAccess) ||
-    readAccess.name.text !== "read"
-  )
-    return false;
+  if (!ts.isPropertyAccessExpression(readAccess) || readAccess.name.text !== "read") return false;
   const streamAccess = readAccess.expression;
-  if (
-    !ts.isPropertyAccessExpression(streamAccess) ||
-    streamAccess.name.text !== "stdin"
-  )
-    return false;
+  if (!ts.isPropertyAccessExpression(streamAccess) || streamAccess.name.text !== "stdin") return false;
   return isUnshadowedProcessIdentifier(fctx, streamAccess.expression);
 }
 
@@ -306,9 +257,7 @@ export function tryCompileNodeFsCall(
     // are not shadowed by a local binding — a local `function readFileSync(){}`
     // must NOT be gated. `ctx.wasiNodeFsFuncs` is the set of node:fs imports.
     const importedFromNodeFs =
-      ctx.wasiNodeFsFuncs.has(member) &&
-      !fctx.localMap.has(member) &&
-      !(fctx.boxedCaptures?.has(member) ?? false);
+      ctx.wasiNodeFsFuncs.has(member) && !fctx.localMap.has(member) && !(fctx.boxedCaptures?.has(member) ?? false);
     if (importedFromNodeFs && isKnownMember("node:fs", member)) {
       const target = { wasi: ctx.wasi, allowFs: false };
       if (isMemberSatisfiable("node:fs", member, target) === false) {
@@ -336,12 +285,10 @@ export function tryCompileNodeFsCall(
   // Only treat it as the fd-based node:fs primitive when it was imported from
   // node:fs (detected pre-preprocessing) and is not shadowed by a local.
   if (!ctx.wasiNodeFsFuncs.has(callee)) return undefined;
-  if (fctx.localMap.has(callee) || (fctx.boxedCaptures?.has(callee) ?? false))
-    return undefined;
+  if (fctx.localMap.has(callee) || (fctx.boxedCaptures?.has(callee) ?? false)) return undefined;
   // fd-based form requires at least (fd, buffer). A bare/path-based call is not ours.
   if (expr.arguments.length < 2) return undefined;
-  const shimIdx =
-    callee === "readSync" ? ctx.nodeFsReadSyncIdx : ctx.nodeFsWriteSyncIdx;
+  const shimIdx = callee === "readSync" ? ctx.nodeFsReadSyncIdx : ctx.nodeFsWriteSyncIdx;
   if (shimIdx < 0) return undefined;
 
   return callee === "readSync"
@@ -373,8 +320,7 @@ function emitNodeFsOffsetLength(
   });
 
   const arg2 = expr.arguments[2];
-  const optionsObj =
-    arg2 && ts.isObjectLiteralExpression(arg2) ? arg2 : undefined;
+  const optionsObj = arg2 && ts.isObjectLiteralExpression(arg2) ? arg2 : undefined;
 
   // ---- offset ----
   let offsetExpr: ts.Expression | undefined;
@@ -412,10 +358,7 @@ function emitNodeFsOffsetLength(
 }
 
 /** Find a non-shorthand object-literal property initializer by name, or undefined. */
-function findObjectProp(
-  obj: ts.ObjectLiteralExpression,
-  name: string,
-): ts.Expression | undefined {
+function findObjectProp(obj: ts.ObjectLiteralExpression, name: string): ts.Expression | undefined {
   for (const prop of obj.properties) {
     if (
       ts.isPropertyAssignment(prop) &&
@@ -440,11 +383,7 @@ function emitNodeFsResolveGcU8(
   bufExpr: ts.Expression,
 ): { arrLocal: number; arrTypeIdx: number; lenLocal: number } | null {
   const bufType = compileExpression(ctx, fctx, bufExpr);
-  if (
-    !bufType ||
-    (bufType.kind !== "ref" && bufType.kind !== "ref_null") ||
-    !("typeIdx" in bufType)
-  ) {
+  if (!bufType || (bufType.kind !== "ref" && bufType.kind !== "ref_null") || !("typeIdx" in bufType)) {
     if (bufType) fctx.body.push({ op: "drop" } as Instr);
     return null;
   }
@@ -459,8 +398,7 @@ function emitNodeFsResolveGcU8(
     fctx.body.push({ op: "drop" } as Instr);
     return null;
   }
-  if (bufType.kind === "ref_null")
-    fctx.body.push({ op: "ref.as_non_null" } as Instr);
+  if (bufType.kind === "ref_null") fctx.body.push({ op: "ref.as_non_null" } as Instr);
 
   const vecLocal = allocLocal(fctx, `__nodefs_vec_${fctx.locals.length}`, {
     kind: "ref",
@@ -495,11 +433,7 @@ function emitNodeFsResolveGcU8(
 }
 
 /** Emit `fd` (arg0) truncated to i32 into a fresh local; returns the local. */
-function emitNodeFsFd(
-  ctx: CodegenContext,
-  fctx: FunctionContext,
-  fdExpr: ts.Expression,
-): number {
+function emitNodeFsFd(ctx: CodegenContext, fctx: FunctionContext, fdExpr: ts.Expression): number {
   const fdLocal = allocLocal(fctx, `__nodefs_fd_${fctx.locals.length}`, {
     kind: "i32",
   });
@@ -529,12 +463,7 @@ function emitNodeFsReadSync(
   // Zero-copy fast path: linear-backed Uint8Array reads straight into ptr+off.
   const linBuf = getLinearU8Buffer(ctx, fctx, expr.arguments[1]!);
   if (linBuf) {
-    const { offLocal, lenLocal } = emitNodeFsOffsetLength(
-      ctx,
-      fctx,
-      expr,
-      linBuf.lenLocalIdx,
-    );
+    const { offLocal, lenLocal } = emitNodeFsOffsetLength(ctx, fctx, expr, linBuf.lenLocalIdx);
     fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
     fctx.body.push({ op: "local.get", index: linBuf.ptrLocalIdx } as Instr);
     fctx.body.push({ op: "local.get", index: offLocal } as Instr);
@@ -551,12 +480,7 @@ function emitNodeFsReadSync(
     fctx.body.push({ op: "f64.const", value: 0 } as Instr);
     return { kind: "f64" };
   }
-  const { offLocal, lenLocal } = emitNodeFsOffsetLength(
-    ctx,
-    fctx,
-    expr,
-    gc.lenLocal,
-  );
+  const { offLocal, lenLocal } = emitNodeFsOffsetLength(ctx, fctx, expr, gc.lenLocal);
 
   // Grow memory if the scratch read region (WASI_STDIN_BUF_START + length) would
   // exceed current pages.
@@ -573,14 +497,7 @@ function emitNodeFsReadSync(
   fctx.body.push({ op: "local.set", index: nreadLocal } as Instr);
 
   // Copy buf_dest[off + j] = scratch[j] for j in [0, nread).
-  emitScratchToArrayCopy(
-    fctx,
-    gc.arrTypeIdx,
-    gc.arrLocal,
-    offLocal,
-    WASI_STDIN_BUF_START,
-    nreadLocal,
-  );
+  emitScratchToArrayCopy(fctx, gc.arrTypeIdx, gc.arrLocal, offLocal, WASI_STDIN_BUF_START, nreadLocal);
 
   fctx.body.push({ op: "local.get", index: nreadLocal } as Instr);
   fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
@@ -627,12 +544,7 @@ function emitNodeFsWriteSync(
   // Zero-copy fast path: linear-backed Uint8Array writes straight from ptr+off.
   const linBuf = getLinearU8Buffer(ctx, fctx, expr.arguments[1]!);
   if (linBuf) {
-    const { offLocal, lenLocal } = emitNodeFsOffsetLength(
-      ctx,
-      fctx,
-      expr,
-      linBuf.lenLocalIdx,
-    );
+    const { offLocal, lenLocal } = emitNodeFsOffsetLength(ctx, fctx, expr, linBuf.lenLocalIdx);
     fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
     fctx.body.push({ op: "local.get", index: linBuf.ptrLocalIdx } as Instr);
     fctx.body.push({ op: "local.get", index: offLocal } as Instr);
@@ -648,25 +560,13 @@ function emitNodeFsWriteSync(
     fctx.body.push({ op: "f64.const", value: 0 } as Instr);
     return { kind: "f64" };
   }
-  const { offLocal, lenLocal } = emitNodeFsOffsetLength(
-    ctx,
-    fctx,
-    expr,
-    gc.lenLocal,
-  );
+  const { offLocal, lenLocal } = emitNodeFsOffsetLength(ctx, fctx, expr, gc.lenLocal);
 
   // Grow memory if the write scratch region would exceed current pages.
   ensureScratchPages(fctx, WASI_WRITE_SCRATCH_START, lenLocal);
 
   // Copy scratch[j] = buf[off + j] for j in [0, length).
-  emitArrayToScratchCopy(
-    fctx,
-    gc.arrTypeIdx,
-    gc.arrLocal,
-    offLocal,
-    WASI_WRITE_SCRATCH_START,
-    lenLocal,
-  );
+  emitArrayToScratchCopy(fctx, gc.arrTypeIdx, gc.arrLocal, offLocal, WASI_WRITE_SCRATCH_START, lenLocal);
 
   // nwritten = write_sync(fd, WASI_WRITE_SCRATCH_START, length)
   fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
@@ -694,18 +594,10 @@ const WRITESYNC_UTF8_ENCODINGS = new Set(["utf8", "utf-8"]);
  * buffer overload). Returns `VOID_RESULT` (after pushing a diagnostic) on an
  * unsupported encoding or when the native-string runtime is unavailable.
  */
-function emitNodeFsWriteSyncString(
-  ctx: CodegenContext,
-  fctx: FunctionContext,
-  expr: ts.CallExpression,
-): InnerResult {
+function emitNodeFsWriteSyncString(ctx: CodegenContext, fctx: FunctionContext, expr: ts.CallExpression): InnerResult {
   // Reject an explicit non-utf8 string-literal encoding (arg index 3).
   const encArg = expr.arguments[3];
-  if (
-    encArg &&
-    ts.isStringLiteralLike(encArg) &&
-    !WRITESYNC_UTF8_ENCODINGS.has(encArg.text.toLowerCase())
-  ) {
+  if (encArg && ts.isStringLiteralLike(encArg) && !WRITESYNC_UTF8_ENCODINGS.has(encArg.text.toLowerCase())) {
     ctx.errors.push({
       message:
         `node:fs writeSync(fd, str, position?, encoding) only supports the utf8 encoding under ` +
@@ -768,12 +660,7 @@ function emitNodeFsWriteSyncDataView(
   // the bytes into the scratch — returning the byte-length local.
   const recvType = compileExpression(ctx, fctx, expr.arguments[1]!);
   flushLateImportShifts(ctx, fctx);
-  const lenLocal = emitDataViewToWriteScratch(
-    ctx,
-    fctx,
-    recvType,
-    WASI_WRITE_SCRATCH_START,
-  );
+  const lenLocal = emitDataViewToWriteScratch(ctx, fctx, recvType, WASI_WRITE_SCRATCH_START);
   if (lenLocal < 0) {
     // Couldn't resolve the DataView backing — drop the operand and report 0.
     if (recvType) fctx.body.push({ op: "drop" } as Instr);
@@ -791,16 +678,8 @@ function emitNodeFsWriteSyncDataView(
 }
 
 /** Grow linear memory so [scratchStart, scratchStart + lenLocal) is addressable. */
-function ensureScratchPages(
-  fctx: FunctionContext,
-  scratchStart: number,
-  lenLocal: number,
-): void {
-  const needPagesLocal = allocLocal(
-    fctx,
-    `__nodefs_pages_${fctx.locals.length}`,
-    { kind: "i32" },
-  );
+function ensureScratchPages(fctx: FunctionContext, scratchStart: number, lenLocal: number): void {
+  const needPagesLocal = allocLocal(fctx, `__nodefs_pages_${fctx.locals.length}`, { kind: "i32" });
   fctx.body.push({ op: "i32.const", value: scratchStart } as Instr);
   fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
   fctx.body.push({ op: "i32.add" } as Instr);
@@ -863,9 +742,7 @@ function emitScratchToArrayCopy(
   fctx.body.push({
     op: "block",
     blockType: { kind: "empty" },
-    body: [
-      { op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr,
-    ],
+    body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr],
   } as Instr);
 }
 
@@ -908,8 +785,6 @@ function emitArrayToScratchCopy(
   fctx.body.push({
     op: "block",
     blockType: { kind: "empty" },
-    body: [
-      { op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr,
-    ],
+    body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr],
   } as Instr);
 }

--- a/src/codegen/node-fs-api.ts
+++ b/src/codegen/node-fs-api.ts
@@ -9,6 +9,10 @@
  * `node:fs` shim). It also rejects the hallucinated `process.stdin.read(buf,
  * offset)` with a clear pointer to `node:fs` `readSync`.
  */
+import {
+  isKnownMember,
+  isMemberSatisfiable,
+} from "../checker/node-capability-map.js";
 import { isStringType } from "../checker/type-mapper.js";
 import type { Instr, ValType } from "../ir/types.js";
 import { ts } from "../ts-api.js";
@@ -29,7 +33,10 @@ import {
 } from "./index.js";
 import type { InnerResult } from "./shared.js";
 import { compileExpression, VOID_RESULT } from "./shared.js";
-import { getLinearU8Buffer, tryEmitLinearU8StdWrite } from "./linear-uint8-codegen.js";
+import {
+  getLinearU8Buffer,
+  tryEmitLinearU8StdWrite,
+} from "./linear-uint8-codegen.js";
 
 export function tryCompileNodeProcessCall(
   ctx: CodegenContext,
@@ -78,7 +85,9 @@ export function tryCompileNodeProcessCall(
   // #2633: under the node shims there is no fd_write idx; `tryEmitLinearU8StdWrite`
   // routes to the imported `node:fs` `writeSync(fd, ptr, len)` instead (the passed
   // idx is unused on that branch).
-  const writeSinkIdx = ctx.linkNodeShims ? ctx.nodeFsWriteSyncIdx : ctx.wasiFdWriteIdx;
+  const writeSinkIdx = ctx.linkNodeShims
+    ? ctx.nodeFsWriteSyncIdx
+    : ctx.wasiFdWriteIdx;
   if (writeSinkIdx !== undefined && writeSinkIdx >= 0) {
     if (tryEmitLinearU8StdWrite(ctx, fctx, argExpr, writeSinkIdx, fd)) {
       // Match the GC Uint8Array write path's contract: push `1` (write
@@ -109,11 +118,20 @@ export function tryCompileNodeProcessCall(
   }
 
   const argSymName = argTsType.getSymbol?.()?.name;
-  const isArrayBufferArg = argSymName === "ArrayBuffer" || argSymName === "SharedArrayBuffer";
+  const isArrayBufferArg =
+    argSymName === "ArrayBuffer" || argSymName === "SharedArrayBuffer";
   const elemKey: "i8_byte" | "i32_byte" | "f64" =
-    noJsHost(ctx) && argSymName === "Uint8Array" ? "i8_byte" : isArrayBufferArg ? "i32_byte" : "f64";
+    noJsHost(ctx) && argSymName === "Uint8Array"
+      ? "i8_byte"
+      : isArrayBufferArg
+        ? "i32_byte"
+        : "f64";
   const elemType: ValType =
-    elemKey === "i8_byte" ? { kind: "i8" } : elemKey === "i32_byte" ? { kind: "i32" } : { kind: "f64" };
+    elemKey === "i8_byte"
+      ? { kind: "i8" }
+      : elemKey === "i32_byte"
+        ? { kind: "i32" }
+        : { kind: "f64" };
   const vecTypeIdx = getOrRegisterVecType(ctx, elemKey, elemType);
   const argType = compileExpression(ctx, fctx, argExpr);
   flushLateImportShifts(ctx, fctx);
@@ -125,7 +143,11 @@ export function tryCompileNodeProcessCall(
       } else {
         fctx.body.push({ op: "ref.as_non_null" } as Instr);
       }
-    } else if (argType.kind === "ref" && "typeIdx" in argType && argType.typeIdx !== vecTypeIdx) {
+    } else if (
+      argType.kind === "ref" &&
+      "typeIdx" in argType &&
+      argType.typeIdx !== vecTypeIdx
+    ) {
       fctx.body.push({ op: "ref.cast", typeIdx: vecTypeIdx } as Instr);
     }
   }
@@ -142,7 +164,10 @@ export function tryCompileNodeProcessCall(
   return VOID_RESULT;
 }
 
-function isUnshadowedProcessIdentifier(fctx: FunctionContext, expr: ts.Expression): boolean {
+function isUnshadowedProcessIdentifier(
+  fctx: FunctionContext,
+  expr: ts.Expression,
+): boolean {
   return (
     ts.isIdentifier(expr) &&
     expr.text === "process" &&
@@ -170,25 +195,39 @@ function matchProcessStdStreamWrite(
   if (!ctx.wasi || !haveWriteSink) return null;
   if (expr.questionDotToken || expr.arguments.length !== 1) return null;
   const writeAccess = expr.expression;
-  if (!ts.isPropertyAccessExpression(writeAccess) || writeAccess.name.text !== "write") return null;
+  if (
+    !ts.isPropertyAccessExpression(writeAccess) ||
+    writeAccess.name.text !== "write"
+  )
+    return null;
   const streamAccess = writeAccess.expression;
   if (!ts.isPropertyAccessExpression(streamAccess)) return null;
   const streamName = streamAccess.name.text;
   if (streamName !== "stdout" && streamName !== "stderr") return null;
-  if (!isUnshadowedProcessIdentifier(fctx, streamAccess.expression)) return null;
+  if (!isUnshadowedProcessIdentifier(fctx, streamAccess.expression))
+    return null;
   return { useStderr: streamName === "stderr" };
 }
 
-function matchProcessStdStreamDrainOnce(ctx: CodegenContext, fctx: FunctionContext, expr: ts.CallExpression): boolean {
+function matchProcessStdStreamDrainOnce(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+): boolean {
   if (!ctx.wasi) return false;
   if (expr.questionDotToken || expr.arguments.length !== 2) return false;
   const onceAccess = expr.expression;
-  if (!ts.isPropertyAccessExpression(onceAccess) || onceAccess.name.text !== "once") return false;
+  if (
+    !ts.isPropertyAccessExpression(onceAccess) ||
+    onceAccess.name.text !== "once"
+  )
+    return false;
   const streamAccess = onceAccess.expression;
   if (!ts.isPropertyAccessExpression(streamAccess)) return false;
   const streamName = streamAccess.name.text;
   if (streamName !== "stdout" && streamName !== "stderr") return false;
-  if (!isUnshadowedProcessIdentifier(fctx, streamAccess.expression)) return false;
+  if (!isUnshadowedProcessIdentifier(fctx, streamAccess.expression))
+    return false;
   const eventArg = expr.arguments[0]!;
   return ts.isStringLiteralLike(eventArg) && eventArg.text === "drain";
 }
@@ -201,12 +240,23 @@ function matchProcessStdStreamDrainOnce(ctx: CodegenContext, fctx: FunctionConte
  * (any local/captured `process` shadow is left alone). Non-WASI targets keep the
  * generic call path (it resolves through the JS host).
  */
-function matchProcessStdinRead(fctx: FunctionContext, expr: ts.CallExpression): boolean {
+function matchProcessStdinRead(
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+): boolean {
   if (expr.questionDotToken) return false;
   const readAccess = expr.expression;
-  if (!ts.isPropertyAccessExpression(readAccess) || readAccess.name.text !== "read") return false;
+  if (
+    !ts.isPropertyAccessExpression(readAccess) ||
+    readAccess.name.text !== "read"
+  )
+    return false;
   const streamAccess = readAccess.expression;
-  if (!ts.isPropertyAccessExpression(streamAccess) || streamAccess.name.text !== "stdin") return false;
+  if (
+    !ts.isPropertyAccessExpression(streamAccess) ||
+    streamAccess.name.text !== "stdin"
+  )
+    return false;
   return isUnshadowedProcessIdentifier(fctx, streamAccess.expression);
 }
 
@@ -239,7 +289,46 @@ export function tryCompileNodeFsCall(
   fctx: FunctionContext,
   expr: ts.CallExpression,
 ): InnerResult | undefined {
-  if (!ctx.wasi || !ctx.linkNodeShims) return undefined;
+  // The "no provider" gate (#1772 P2-a) fires under `--target wasi` regardless of
+  // `--link-node-shims`, so it must sit AFTER the `!ctx.wasi` guard but BEFORE the
+  // combined `!ctx.linkNodeShims` short-circuit and the readSync/writeSync match.
+  if (!ctx.wasi) return undefined;
+
+  // #1772 P2-a — deliberate "no provider" compile error. A `node:fs` member that
+  // the program imported, is known to the capability map, but is NOT satisfiable
+  // under the active target (e.g. path-based `readFileSync` under standalone WASI
+  // with no `--allow-fs`), must error here at compile time rather than fall
+  // through to a silent link-time failure. The fd-based `readSync`/`writeSync`
+  // stay satisfiable (providersFor → ["wasi-fd"]) so this is a no-op for them.
+  if (ts.isIdentifier(expr.expression) && !expr.questionDotToken) {
+    const member = expr.expression.text;
+    // Only gate members the program actually imported from `node:fs`, and that
+    // are not shadowed by a local binding — a local `function readFileSync(){}`
+    // must NOT be gated. `ctx.wasiNodeFsFuncs` is the set of node:fs imports.
+    const importedFromNodeFs =
+      ctx.wasiNodeFsFuncs.has(member) &&
+      !fctx.localMap.has(member) &&
+      !(fctx.boxedCaptures?.has(member) ?? false);
+    if (importedFromNodeFs && isKnownMember("node:fs", member)) {
+      const target = { wasi: ctx.wasi, allowFs: false };
+      if (isMemberSatisfiable("node:fs", member, target) === false) {
+        ctx.errors.push({
+          message:
+            `\`node:fs.${member}\` needs a filesystem provider, unavailable under \`--target wasi\`. ` +
+            "Pass `--allow-fs` for the JS-host filesystem provider, or use the fd-based " +
+            "`readSync`/`writeSync(fd, …)` for standalone WASI (no path_open/preopens).",
+          line: 1,
+          column: 1,
+          severity: "error",
+        });
+        // Consumed: return the file's "handled" sentinel so the generic
+        // host-import path does not also fire on this call.
+        return VOID_RESULT;
+      }
+    }
+  }
+
+  if (!ctx.linkNodeShims) return undefined;
   if (expr.questionDotToken) return undefined;
   if (!ts.isIdentifier(expr.expression)) return undefined;
   const callee = expr.expression.text;
@@ -247,10 +336,12 @@ export function tryCompileNodeFsCall(
   // Only treat it as the fd-based node:fs primitive when it was imported from
   // node:fs (detected pre-preprocessing) and is not shadowed by a local.
   if (!ctx.wasiNodeFsFuncs.has(callee)) return undefined;
-  if (fctx.localMap.has(callee) || (fctx.boxedCaptures?.has(callee) ?? false)) return undefined;
+  if (fctx.localMap.has(callee) || (fctx.boxedCaptures?.has(callee) ?? false))
+    return undefined;
   // fd-based form requires at least (fd, buffer). A bare/path-based call is not ours.
   if (expr.arguments.length < 2) return undefined;
-  const shimIdx = callee === "readSync" ? ctx.nodeFsReadSyncIdx : ctx.nodeFsWriteSyncIdx;
+  const shimIdx =
+    callee === "readSync" ? ctx.nodeFsReadSyncIdx : ctx.nodeFsWriteSyncIdx;
   if (shimIdx < 0) return undefined;
 
   return callee === "readSync"
@@ -274,11 +365,16 @@ function emitNodeFsOffsetLength(
   expr: ts.CallExpression,
   bufLenLocal: number,
 ): { offLocal: number; lenLocal: number } {
-  const offLocal = allocLocal(fctx, `__nodefs_off_${fctx.locals.length}`, { kind: "i32" });
-  const lenLocal = allocLocal(fctx, `__nodefs_len_${fctx.locals.length}`, { kind: "i32" });
+  const offLocal = allocLocal(fctx, `__nodefs_off_${fctx.locals.length}`, {
+    kind: "i32",
+  });
+  const lenLocal = allocLocal(fctx, `__nodefs_len_${fctx.locals.length}`, {
+    kind: "i32",
+  });
 
   const arg2 = expr.arguments[2];
-  const optionsObj = arg2 && ts.isObjectLiteralExpression(arg2) ? arg2 : undefined;
+  const optionsObj =
+    arg2 && ts.isObjectLiteralExpression(arg2) ? arg2 : undefined;
 
   // ---- offset ----
   let offsetExpr: ts.Expression | undefined;
@@ -316,7 +412,10 @@ function emitNodeFsOffsetLength(
 }
 
 /** Find a non-shorthand object-literal property initializer by name, or undefined. */
-function findObjectProp(obj: ts.ObjectLiteralExpression, name: string): ts.Expression | undefined {
+function findObjectProp(
+  obj: ts.ObjectLiteralExpression,
+  name: string,
+): ts.Expression | undefined {
   for (const prop of obj.properties) {
     if (
       ts.isPropertyAssignment(prop) &&
@@ -341,7 +440,11 @@ function emitNodeFsResolveGcU8(
   bufExpr: ts.Expression,
 ): { arrLocal: number; arrTypeIdx: number; lenLocal: number } | null {
   const bufType = compileExpression(ctx, fctx, bufExpr);
-  if (!bufType || (bufType.kind !== "ref" && bufType.kind !== "ref_null") || !("typeIdx" in bufType)) {
+  if (
+    !bufType ||
+    (bufType.kind !== "ref" && bufType.kind !== "ref_null") ||
+    !("typeIdx" in bufType)
+  ) {
     if (bufType) fctx.body.push({ op: "drop" } as Instr);
     return null;
   }
@@ -356,27 +459,50 @@ function emitNodeFsResolveGcU8(
     fctx.body.push({ op: "drop" } as Instr);
     return null;
   }
-  if (bufType.kind === "ref_null") fctx.body.push({ op: "ref.as_non_null" } as Instr);
+  if (bufType.kind === "ref_null")
+    fctx.body.push({ op: "ref.as_non_null" } as Instr);
 
-  const vecLocal = allocLocal(fctx, `__nodefs_vec_${fctx.locals.length}`, { kind: "ref", typeIdx: vecTypeIdx });
+  const vecLocal = allocLocal(fctx, `__nodefs_vec_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: vecTypeIdx,
+  });
   fctx.body.push({ op: "local.set", index: vecLocal } as Instr);
   // element length = vec.length (field 0)
-  const lenLocal = allocLocal(fctx, `__nodefs_buflen_${fctx.locals.length}`, { kind: "i32" });
+  const lenLocal = allocLocal(fctx, `__nodefs_buflen_${fctx.locals.length}`, {
+    kind: "i32",
+  });
   fctx.body.push({ op: "local.get", index: vecLocal } as Instr);
-  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 } as Instr);
+  fctx.body.push({
+    op: "struct.get",
+    typeIdx: vecTypeIdx,
+    fieldIdx: 0,
+  } as Instr);
   fctx.body.push({ op: "local.set", index: lenLocal } as Instr);
   // backing i8 array = vec.data (field 1)
-  const arrLocal = allocLocal(fctx, `__nodefs_arr_${fctx.locals.length}`, { kind: "ref", typeIdx: arrTypeIdx });
+  const arrLocal = allocLocal(fctx, `__nodefs_arr_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: arrTypeIdx,
+  });
   fctx.body.push({ op: "local.get", index: vecLocal } as Instr);
-  fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 } as Instr);
+  fctx.body.push({
+    op: "struct.get",
+    typeIdx: vecTypeIdx,
+    fieldIdx: 1,
+  } as Instr);
   fctx.body.push({ op: "local.set", index: arrLocal } as Instr);
 
   return { arrLocal, arrTypeIdx, lenLocal };
 }
 
 /** Emit `fd` (arg0) truncated to i32 into a fresh local; returns the local. */
-function emitNodeFsFd(ctx: CodegenContext, fctx: FunctionContext, fdExpr: ts.Expression): number {
-  const fdLocal = allocLocal(fctx, `__nodefs_fd_${fctx.locals.length}`, { kind: "i32" });
+function emitNodeFsFd(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  fdExpr: ts.Expression,
+): number {
+  const fdLocal = allocLocal(fctx, `__nodefs_fd_${fctx.locals.length}`, {
+    kind: "i32",
+  });
   compileExpression(ctx, fctx, fdExpr, { kind: "f64" });
   fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
   fctx.body.push({ op: "local.set", index: fdLocal } as Instr);
@@ -403,7 +529,12 @@ function emitNodeFsReadSync(
   // Zero-copy fast path: linear-backed Uint8Array reads straight into ptr+off.
   const linBuf = getLinearU8Buffer(ctx, fctx, expr.arguments[1]!);
   if (linBuf) {
-    const { offLocal, lenLocal } = emitNodeFsOffsetLength(ctx, fctx, expr, linBuf.lenLocalIdx);
+    const { offLocal, lenLocal } = emitNodeFsOffsetLength(
+      ctx,
+      fctx,
+      expr,
+      linBuf.lenLocalIdx,
+    );
     fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
     fctx.body.push({ op: "local.get", index: linBuf.ptrLocalIdx } as Instr);
     fctx.body.push({ op: "local.get", index: offLocal } as Instr);
@@ -420,14 +551,21 @@ function emitNodeFsReadSync(
     fctx.body.push({ op: "f64.const", value: 0 } as Instr);
     return { kind: "f64" };
   }
-  const { offLocal, lenLocal } = emitNodeFsOffsetLength(ctx, fctx, expr, gc.lenLocal);
+  const { offLocal, lenLocal } = emitNodeFsOffsetLength(
+    ctx,
+    fctx,
+    expr,
+    gc.lenLocal,
+  );
 
   // Grow memory if the scratch read region (WASI_STDIN_BUF_START + length) would
   // exceed current pages.
   ensureScratchPages(fctx, WASI_STDIN_BUF_START, lenLocal);
 
   // nread = read_sync(fd, WASI_STDIN_BUF_START, length)
-  const nreadLocal = allocLocal(fctx, `__nodefs_nread_${fctx.locals.length}`, { kind: "i32" });
+  const nreadLocal = allocLocal(fctx, `__nodefs_nread_${fctx.locals.length}`, {
+    kind: "i32",
+  });
   fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
   fctx.body.push({ op: "i32.const", value: WASI_STDIN_BUF_START } as Instr);
   fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
@@ -435,7 +573,14 @@ function emitNodeFsReadSync(
   fctx.body.push({ op: "local.set", index: nreadLocal } as Instr);
 
   // Copy buf_dest[off + j] = scratch[j] for j in [0, nread).
-  emitScratchToArrayCopy(fctx, gc.arrTypeIdx, gc.arrLocal, offLocal, WASI_STDIN_BUF_START, nreadLocal);
+  emitScratchToArrayCopy(
+    fctx,
+    gc.arrTypeIdx,
+    gc.arrLocal,
+    offLocal,
+    WASI_STDIN_BUF_START,
+    nreadLocal,
+  );
 
   fctx.body.push({ op: "local.get", index: nreadLocal } as Instr);
   fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
@@ -482,7 +627,12 @@ function emitNodeFsWriteSync(
   // Zero-copy fast path: linear-backed Uint8Array writes straight from ptr+off.
   const linBuf = getLinearU8Buffer(ctx, fctx, expr.arguments[1]!);
   if (linBuf) {
-    const { offLocal, lenLocal } = emitNodeFsOffsetLength(ctx, fctx, expr, linBuf.lenLocalIdx);
+    const { offLocal, lenLocal } = emitNodeFsOffsetLength(
+      ctx,
+      fctx,
+      expr,
+      linBuf.lenLocalIdx,
+    );
     fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
     fctx.body.push({ op: "local.get", index: linBuf.ptrLocalIdx } as Instr);
     fctx.body.push({ op: "local.get", index: offLocal } as Instr);
@@ -498,13 +648,25 @@ function emitNodeFsWriteSync(
     fctx.body.push({ op: "f64.const", value: 0 } as Instr);
     return { kind: "f64" };
   }
-  const { offLocal, lenLocal } = emitNodeFsOffsetLength(ctx, fctx, expr, gc.lenLocal);
+  const { offLocal, lenLocal } = emitNodeFsOffsetLength(
+    ctx,
+    fctx,
+    expr,
+    gc.lenLocal,
+  );
 
   // Grow memory if the write scratch region would exceed current pages.
   ensureScratchPages(fctx, WASI_WRITE_SCRATCH_START, lenLocal);
 
   // Copy scratch[j] = buf[off + j] for j in [0, length).
-  emitArrayToScratchCopy(fctx, gc.arrTypeIdx, gc.arrLocal, offLocal, WASI_WRITE_SCRATCH_START, lenLocal);
+  emitArrayToScratchCopy(
+    fctx,
+    gc.arrTypeIdx,
+    gc.arrLocal,
+    offLocal,
+    WASI_WRITE_SCRATCH_START,
+    lenLocal,
+  );
 
   // nwritten = write_sync(fd, WASI_WRITE_SCRATCH_START, length)
   fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
@@ -532,10 +694,18 @@ const WRITESYNC_UTF8_ENCODINGS = new Set(["utf8", "utf-8"]);
  * buffer overload). Returns `VOID_RESULT` (after pushing a diagnostic) on an
  * unsupported encoding or when the native-string runtime is unavailable.
  */
-function emitNodeFsWriteSyncString(ctx: CodegenContext, fctx: FunctionContext, expr: ts.CallExpression): InnerResult {
+function emitNodeFsWriteSyncString(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+): InnerResult {
   // Reject an explicit non-utf8 string-literal encoding (arg index 3).
   const encArg = expr.arguments[3];
-  if (encArg && ts.isStringLiteralLike(encArg) && !WRITESYNC_UTF8_ENCODINGS.has(encArg.text.toLowerCase())) {
+  if (
+    encArg &&
+    ts.isStringLiteralLike(encArg) &&
+    !WRITESYNC_UTF8_ENCODINGS.has(encArg.text.toLowerCase())
+  ) {
     ctx.errors.push({
       message:
         `node:fs writeSync(fd, str, position?, encoding) only supports the utf8 encoding under ` +
@@ -598,7 +768,12 @@ function emitNodeFsWriteSyncDataView(
   // the bytes into the scratch — returning the byte-length local.
   const recvType = compileExpression(ctx, fctx, expr.arguments[1]!);
   flushLateImportShifts(ctx, fctx);
-  const lenLocal = emitDataViewToWriteScratch(ctx, fctx, recvType, WASI_WRITE_SCRATCH_START);
+  const lenLocal = emitDataViewToWriteScratch(
+    ctx,
+    fctx,
+    recvType,
+    WASI_WRITE_SCRATCH_START,
+  );
   if (lenLocal < 0) {
     // Couldn't resolve the DataView backing — drop the operand and report 0.
     if (recvType) fctx.body.push({ op: "drop" } as Instr);
@@ -616,8 +791,16 @@ function emitNodeFsWriteSyncDataView(
 }
 
 /** Grow linear memory so [scratchStart, scratchStart + lenLocal) is addressable. */
-function ensureScratchPages(fctx: FunctionContext, scratchStart: number, lenLocal: number): void {
-  const needPagesLocal = allocLocal(fctx, `__nodefs_pages_${fctx.locals.length}`, { kind: "i32" });
+function ensureScratchPages(
+  fctx: FunctionContext,
+  scratchStart: number,
+  lenLocal: number,
+): void {
+  const needPagesLocal = allocLocal(
+    fctx,
+    `__nodefs_pages_${fctx.locals.length}`,
+    { kind: "i32" },
+  );
   fctx.body.push({ op: "i32.const", value: scratchStart } as Instr);
   fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
   fctx.body.push({ op: "i32.add" } as Instr);
@@ -651,7 +834,9 @@ function emitScratchToArrayCopy(
   scratchStart: number,
   countLocal: number,
 ): void {
-  const jLocal = allocLocal(fctx, `__nodefs_j_${fctx.locals.length}`, { kind: "i32" });
+  const jLocal = allocLocal(fctx, `__nodefs_j_${fctx.locals.length}`, {
+    kind: "i32",
+  });
   fctx.body.push({ op: "i32.const", value: 0 } as Instr);
   fctx.body.push({ op: "local.set", index: jLocal } as Instr);
   const loopBody: Instr[] = [
@@ -678,7 +863,9 @@ function emitScratchToArrayCopy(
   fctx.body.push({
     op: "block",
     blockType: { kind: "empty" },
-    body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr],
+    body: [
+      { op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr,
+    ],
   } as Instr);
 }
 
@@ -691,7 +878,9 @@ function emitArrayToScratchCopy(
   scratchStart: number,
   countLocal: number,
 ): void {
-  const jLocal = allocLocal(fctx, `__nodefs_wj_${fctx.locals.length}`, { kind: "i32" });
+  const jLocal = allocLocal(fctx, `__nodefs_wj_${fctx.locals.length}`, {
+    kind: "i32",
+  });
   fctx.body.push({ op: "i32.const", value: 0 } as Instr);
   fctx.body.push({ op: "local.set", index: jLocal } as Instr);
   const loopBody: Instr[] = [
@@ -719,6 +908,8 @@ function emitArrayToScratchCopy(
   fctx.body.push({
     op: "block",
     blockType: { kind: "empty" },
-    body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr],
+    body: [
+      { op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr,
+    ],
   } as Instr);
 }

--- a/tests/issue-1772-capability-map-extend.test.ts
+++ b/tests/issue-1772-capability-map-extend.test.ts
@@ -1,0 +1,86 @@
+// #1772 Phase 2 / Slice P2-b — extend the capability map beyond the fd anchor.
+//
+// Proves the #2634 "data-not-code" extension promise: adding `node:process`
+// std-IO members is a new entry in `NODE_CAPABILITY_MAP`, not a checker code
+// change. The entries are METADATA ONLY (empty decls) — the `node:process` type
+// surface stays owned by the bespoke `PROCESS_INTERFACE_DECLS` branch in
+// `buildNodeEnvDts`, which `continue`s before reaching `buildModuleDecls`, so the
+// map entry can NOT double-declare `stdout`/`stderr`.
+//
+// This test asserts:
+//   1. `isMemberSatisfiable("node:process", "write", …)` is truthy (std-IO lowers
+//      to the fd-based `writeSync` sink under both wasi and JS-host targets).
+//   2. A fabricated unsatisfiable member is falsy / unknown.
+//   3. Adding the `node:process` map entry is byte-neutral for the injected dts of
+//      a NON-process program (the entry only affects programs touching node:process).
+import { describe, expect, it } from "vitest";
+import {
+  isKnownMember,
+  isMemberSatisfiable,
+} from "../src/checker/node-capability-map.js";
+import { buildNodeEnvDtsForSource } from "../src/checker/index.js";
+
+describe("#1772 P2-b — node:process std-IO capability entries", () => {
+  it("process.stdout/stderr write is satisfiable under standalone WASI", () => {
+    const wasi = { wasi: true, allowFs: false };
+    expect(isMemberSatisfiable("node:process", "write", wasi)).toBe(true);
+    expect(isMemberSatisfiable("node:process", "stdout", wasi)).toBe(true);
+    expect(isMemberSatisfiable("node:process", "stderr", wasi)).toBe(true);
+  });
+
+  it("process std-IO is satisfiable under a JS host too (js-host-fs provider)", () => {
+    const host = { wasi: false, allowFs: false };
+    expect(isMemberSatisfiable("node:process", "write", host)).toBe(true);
+    expect(isMemberSatisfiable("node:process", "stdout", host)).toBe(true);
+  });
+
+  it("the process std-IO members are known to the map", () => {
+    expect(isKnownMember("node:process", "write")).toBe(true);
+    expect(isKnownMember("node:process", "stdout")).toBe(true);
+    expect(isKnownMember("node:process", "stderr")).toBe(true);
+  });
+
+  it("a fabricated unsatisfiable member is undefined (unknown), not satisfiable", () => {
+    const wasi = { wasi: true, allowFs: false };
+    // An unmapped member returns `undefined` (caller decides — usually permissive),
+    // and is certainly not `true`.
+    expect(
+      isMemberSatisfiable("node:process", "__nope_no_such_member__", wasi),
+    ).toBe(undefined);
+    expect(
+      isMemberSatisfiable("node:process", "__nope_no_such_member__", wasi),
+    ).not.toBe(true);
+    expect(isKnownMember("node:process", "__nope_no_such_member__")).toBe(
+      false,
+    );
+  });
+
+  it("the node:process map entry is byte-neutral for a non-process program's injected dts", () => {
+    // A program that touches NO node:process surface must get the SAME injected
+    // dts whether or not the map carries node:process entries — i.e. the entry
+    // only matters for programs that actually import/use node:process.
+    const fsOnly = `
+import { readSync } from "node:fs";
+export function main(): void {
+  const buf = new Uint8Array(4);
+  readSync(0, buf, { offset: 0, length: 4 });
+}
+`;
+    const dts = buildNodeEnvDtsForSource(fsOnly, /* scriptKind */ undefined);
+    // The node:fs surface is present; the node:process module is NOT injected for
+    // a program that never touches it (the entry is satisfiability metadata, not
+    // an unconditional decl).
+    expect(dts).toBeDefined();
+    expect(dts ?? "").not.toMatch(/declare module "node:process"/);
+
+    // A program that DOES use process.stdout still emits the bespoke node:process
+    // module (unchanged by the metadata-only map entry).
+    const procSrc = `
+export function main(): void {
+  process.stdout.write("hi");
+}
+`;
+    const procDts = buildNodeEnvDtsForSource(procSrc, undefined);
+    expect(procDts ?? "").toMatch(/process|NodeJS_Process/);
+  });
+});

--- a/tests/issue-1772-capability-map-extend.test.ts
+++ b/tests/issue-1772-capability-map-extend.test.ts
@@ -14,10 +14,7 @@
 //   3. Adding the `node:process` map entry is byte-neutral for the injected dts of
 //      a NON-process program (the entry only affects programs touching node:process).
 import { describe, expect, it } from "vitest";
-import {
-  isKnownMember,
-  isMemberSatisfiable,
-} from "../src/checker/node-capability-map.js";
+import { isKnownMember, isMemberSatisfiable } from "../src/checker/node-capability-map.js";
 import { buildNodeEnvDtsForSource } from "../src/checker/index.js";
 
 describe("#1772 P2-b — node:process std-IO capability entries", () => {
@@ -44,15 +41,9 @@ describe("#1772 P2-b — node:process std-IO capability entries", () => {
     const wasi = { wasi: true, allowFs: false };
     // An unmapped member returns `undefined` (caller decides — usually permissive),
     // and is certainly not `true`.
-    expect(
-      isMemberSatisfiable("node:process", "__nope_no_such_member__", wasi),
-    ).toBe(undefined);
-    expect(
-      isMemberSatisfiable("node:process", "__nope_no_such_member__", wasi),
-    ).not.toBe(true);
-    expect(isKnownMember("node:process", "__nope_no_such_member__")).toBe(
-      false,
-    );
+    expect(isMemberSatisfiable("node:process", "__nope_no_such_member__", wasi)).toBe(undefined);
+    expect(isMemberSatisfiable("node:process", "__nope_no_such_member__", wasi)).not.toBe(true);
+    expect(isKnownMember("node:process", "__nope_no_such_member__")).toBe(false);
   });
 
   it("the node:process map entry is byte-neutral for a non-process program's injected dts", () => {

--- a/tests/issue-1772-no-provider-gate.test.ts
+++ b/tests/issue-1772-no-provider-gate.test.ts
@@ -1,0 +1,112 @@
+// #1772 Phase 2 / Slice P2-a — wire the "no provider" codegen gate.
+//
+// `src/checker/node-capability-map.ts` (#2634) provides `isMemberSatisfiable`,
+// but until this slice it was DEAD CODE — nothing in `src/codegen/` consulted it,
+// so a path-based `node:fs` member (`readFileSync(path)`) under `--target wasi`
+// produced only the generic #1035 error / a silent link failure, not the precise
+// "no provider, pass --allow-fs" guidance the capability map promises.
+//
+// This test asserts the gate (now wired into `tryCompileNodeFsCall`):
+//   1. A `--target wasi` program importing a path-based member (`readFileSync`)
+//      from `node:fs` fails to compile, and the error names the member + `--allow-fs`.
+//   2. A `readSync`/`writeSync` program (fd-based, satisfiable) still compiles green.
+//   3. A NON-wasi compile of the same `readFileSync` program is NOT gated
+//      (path-based members resolve through the real `node:fs` under a JS host).
+//   4. A same-named LOCAL function (`function readFileSync(){}`) — not imported
+//      from `node:fs` — is NOT gated.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+describe("#1772 P2-a — node:fs no-provider codegen gate", () => {
+  it("rejects a path-based node:fs member under --target wasi with a precise error", async () => {
+    const src = `
+import { readFileSync } from "node:fs";
+export function main(): void {
+  const data = readFileSync("/etc/hostname");
+}
+`;
+    const result = await compile(src, {
+      fileName: "x.ts",
+      target: "wasi",
+      linkNodeShims: true,
+    });
+    expect(result.success).toBe(false);
+    const msgs = (result.errors ?? []).map((e) => e.message).join("\n");
+    // Names the member …
+    expect(msgs).toMatch(/readFileSync/);
+    // … and points at the actionable `--allow-fs` escape hatch.
+    expect(msgs).toMatch(/--allow-fs/);
+    // … and is target-precise.
+    expect(msgs).toMatch(/--target wasi/);
+  });
+
+  it("the gate also fires WITHOUT --link-node-shims (it keys off --target wasi)", async () => {
+    const src = `
+import { readFileSync } from "node:fs";
+export function main(): void {
+  const data = readFileSync("/etc/hostname");
+}
+`;
+    // No linkNodeShims: the gate must still fire (it sits after the !ctx.wasi
+    // guard but before the !ctx.linkNodeShims short-circuit).
+    const result = await compile(src, { fileName: "x.ts", target: "wasi" });
+    expect(result.success).toBe(false);
+    const msgs = (result.errors ?? []).map((e) => e.message).join("\n");
+    expect(msgs).toMatch(/readFileSync/);
+    expect(msgs).toMatch(/--allow-fs/);
+  });
+
+  it("a satisfiable fd-based program (readSync/writeSync) still compiles green under --target wasi", async () => {
+    const src = `
+import { readSync, writeSync } from "node:fs";
+export function main(): void {
+  const buf = new Uint8Array(4);
+  const r = readSync(0, buf, { offset: 0, length: 4 });
+  let n = 0;
+  while (n < r) { const w = writeSync(1, buf, n); if (w <= 0) break; n = n + w; }
+}
+`;
+    const result = await compile(src, {
+      fileName: "x.ts",
+      target: "wasi",
+      linkNodeShims: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("a NON-wasi compile of the same readFileSync program is NOT gated", async () => {
+    const src = `
+import { readFileSync } from "node:fs";
+export function main(): void {
+  const data = readFileSync("/etc/hostname");
+}
+`;
+    // Under a JS host (no --target wasi), the gate must be a no-op — path-based
+    // members resolve through the real `node:fs`. Whatever the outcome, the
+    // capability-map "no provider under --target wasi" error must NOT appear.
+    const result = await compile(src, { fileName: "x.ts" });
+    const msgs = (result.errors ?? []).map((e) => e.message).join("\n");
+    expect(msgs).not.toMatch(
+      /needs a filesystem provider, unavailable under `--target wasi`/,
+    );
+  });
+
+  it("a same-named LOCAL function (not imported from node:fs) is NOT gated", async () => {
+    const src = `
+function readFileSync(p: string): number { return p.length; }
+export function main(): number {
+  return readFileSync("/etc/hostname");
+}
+`;
+    const result = await compile(src, {
+      fileName: "x.ts",
+      target: "wasi",
+      linkNodeShims: true,
+    });
+    // The local function is unrelated to node:fs; the gate keys off the
+    // node:fs import set, so it must not fire here.
+    const msgs = (result.errors ?? []).map((e) => e.message).join("\n");
+    expect(msgs).not.toMatch(/needs a filesystem provider/);
+    expect(result.success).toBe(true);
+  });
+});

--- a/tests/issue-1772-no-provider-gate.test.ts
+++ b/tests/issue-1772-no-provider-gate.test.ts
@@ -86,9 +86,7 @@ export function main(): void {
     // capability-map "no provider under --target wasi" error must NOT appear.
     const result = await compile(src, { fileName: "x.ts" });
     const msgs = (result.errors ?? []).map((e) => e.message).join("\n");
-    expect(msgs).not.toMatch(
-      /needs a filesystem provider, unavailable under `--target wasi`/,
-    );
+    expect(msgs).not.toMatch(/needs a filesystem provider, unavailable under `--target wasi`/);
   });
 
   it("a same-named LOCAL function (not imported from node:fs) is NOT gated", async () => {

--- a/tests/issue-2631-node-fs-fd-shim.test.ts
+++ b/tests/issue-2631-node-fs-fd-shim.test.ts
@@ -201,7 +201,10 @@ export function main(): string {
     expect(result.success).toBe(false);
     const msgs = (result.errors ?? []).map((e) => e.message).join("\n");
     expect(msgs).toMatch(/readFileSync/);
-    expect(msgs).toMatch(/not available under --target wasi|no filesystem|#2631/);
+    // #1772 P2-a — the capability-map-driven gate in `tryCompileNodeFsCall` now
+    // owns this rejection (it consumes the call before the legacy
+    // `PATH_BASED_FS_FNS` gate in calls.ts), so the message is the map gate's text.
+    expect(msgs).toMatch(/(un)?available under `?--target wasi`?|no filesystem|filesystem provider|#2631/);
   });
 
   it("linkNodeShims is ignored for non-WASI targets (no node:fs shim import)", async () => {

--- a/tests/issue-2634-node-capability-map.test.ts
+++ b/tests/issue-2634-node-capability-map.test.ts
@@ -130,7 +130,10 @@ export function main(): void {
     const msgs = (result.errors ?? []).map((e) => e.message).join("\n");
     // Precise, deliberate — names the member and the target, not an opaque crash.
     expect(msgs).toMatch(/openSync/);
-    expect(msgs).toMatch(/not available under --target wasi|no filesystem|#2631/);
+    // #1772 P2-a — the capability-map-driven gate in `tryCompileNodeFsCall` now
+    // owns this rejection (it consumes the call before the legacy
+    // `PATH_BASED_FS_FNS` gate), so the message is the map gate's precise text.
+    expect(msgs).toMatch(/(un)?available under `?--target wasi`?|no filesystem|filesystem provider|#2631/);
   });
 
   // ── allowJs / TS8017: faithful OVERLOADS must not trip the transpiled host ─


### PR DESCRIPTION
## #1772 Phase 2 — slices P2-a + P2-b (one PR)

Architect-scoped (PR #2011 `## Implementation Plan`). Lands P2-a + P2-b; **#1772 stays `in-progress`** (P2-c gated on #2528, Phase 3 = #2635).

### P2-a — wire the "no provider" codegen gate (the core gap)
`isMemberSatisfiable` (#2634) was **dead code** — no `src/codegen/` consumer — so a path-based `node:fs` member under `--target wasi` got only the generic #1035 error, not the precise capability-map guidance.

`tryCompileNodeFsCall` (`src/codegen/node-fs-api.ts`) now consults the map: a `node:fs` member the program imported, known to the map, and **unsatisfiable** under `{ wasi: ctx.wasi, allowFs: false }` pushes a precise error naming the member + `--allow-fs`, then returns the `VOID_RESULT` "consumed" sentinel so the generic host-import path doesn't also fire. The gate sits **after** the `!ctx.wasi` guard but **before** the `!ctx.linkNodeShims` short-circuit (fires under `--target wasi` regardless of `--link-node-shims`), is a no-op for satisfiable fd-based `readSync`/`writeSync`, and keys off `ctx.wasiNodeFsFuncs` so a same-named local function is never gated. The legacy `PATH_BASED_FS_FNS` gate in `calls.ts` (byte-identical member set) is now a backstop the map gate pre-empts. `allowFs` hardcoded `false` (the `--allow-fs` plumbing is the deferred P2-a.0).

### P2-b — extend the capability map + record the verdict
Adds a `node:process` std-IO entry (`write`/`stdout`/`stderr`) as satisfiability **metadata only** (empty decls) — the `node:process` type surface stays owned by the bespoke `PROCESS_INTERFACE_DECLS` branch in `buildNodeEnvDts` (which `continue`s before `buildModuleDecls`, so **no double-declaration**). This proves the #2634 data-not-code extension promise. The **hand-authored-mirror verdict is recorded in the map header**: literal `@types/node` sourcing is REJECTED (in-memory lib host; gate needs type-surface == runtime-surface; mirror is per-member faithful with a cited source).

### Tests
- `tests/issue-1772-no-provider-gate.test.ts` — gate fires for path-based members under `--target wasi` (with and without `--link-node-shims`), names member + `--allow-fs`; satisfiable fd program compiles green; non-wasi compile NOT gated; same-named local function NOT gated.
- `tests/issue-1772-capability-map-extend.test.ts` — `node:process` std-IO satisfiability truthy, fabricated member falsy/unknown, byte-neutral dts for non-process program.
- Updated the #2631/#2634 path-based regex assertions to the map gate's message text (the map gate now owns that rejection).

### Validation
`npx tsc --noEmit` clean; biome lint/format clean on changed files; the node-fs / process / wasi regression set (issue-2631/2633/2634/2639/1618-1651/1766/1886/2603/wasi-target/edge-dual-provider) all green (65 tests). Gate is a no-op for every program not importing an unsatisfiable `node:fs` member (byte-neutral there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)