### PR TITLE
docs(plan): file deferred node-API capstone follow-ups (#2645/#2646/#2647) as backlog

### DIFF
--- a/plan/issues/2645-compose-capability-gate-with-platform-node-web.md
+++ b/plan/issues/2645-compose-capability-gate-with-platform-node-web.md
@@ -1,0 +1,65 @@
+---
+id: 2645
+title: "Compose the node:<mod> capability gate (#1772 P2) with --platform node|web (#2528) — ambient surface ⊕ importable surface"
+status: backlog
+created: 2026-06-24
+updated: 2026-06-24
+priority: low
+feasibility: medium
+reasoning_effort: medium
+task_type: feature
+area: host-interop
+language_feature: node-api-compat
+goal: platform
+sprint: Backlog
+es_edition: n/a
+depends_on: [2528]
+related: [1772, 2528, 2624, 2634]
+origin: "Slice P2-c of the #1772 Phase 2 capstone (arch-capstone scoping, 2026-06-24). Deliberately deferred from PR #2014 because it is gated on #2528 (--platform), which is itself backlog."
+---
+# #2645 — compose the capability gate with `--platform node|web` (P2-c)
+
+## Problem
+
+There are two orthogonal axes of "what host surface does this program target":
+
+- the **ambient-global** axis — #2528 (`--platform node|web`): which globals
+  (`window.stop`, DOM lib vs node lib) are in scope. Currently the compiler loads
+  `lib.dom.d.ts` unconditionally.
+- the **importable `node:<mod>`** axis — #1772 Phase 2 (landed in PR #2014): the
+  capability gate (`isMemberSatisfiable` wired into `tryCompileNodeFsCall`) that
+  errors precisely when an imported `node:fs`/`node:process` member has no
+  provider under the chosen target.
+
+These two compose at exactly one decision point. Today they are independent:
+`buildNodeEnvDtsForSource` injection is gated by `emulateNode` in
+`src/checker/index.ts` (~L573), and the ambient `LIB_GLOBALS`/`DOM_ONLY_GLOBALS`
+sets in `src/codegen/index.ts` are #2528's territory. A `--platform node` program
+should (a) drop the DOM ambient surface and (b) imply the node-emulation
+injection path, while `--platform web` should do the opposite.
+
+## Scope (deferred until #2528 lands)
+
+- Wire `--platform` into the single `emulateNode` decision:
+  `emulateNode ||= platform === "node"` (and the converse for the ambient lib
+  selection), so the capability gate and the ambient global surface agree on one
+  target model.
+- Define precedence when `--platform` and `--target wasi` disagree (e.g.
+  `--platform web --target wasi`): document the resolution.
+- Keep the #1772 capability gate's per-member `providersFor` gating as the
+  authority for importable members; `--platform` only sets the ambient default.
+
+## Acceptance
+
+- A `--platform node` program type-checks with the node ambient surface + node
+  emulation injection, and a `--platform web` program excludes node globals.
+- The #1772 capability gate composes (no double-gating, no contradiction) with
+  the chosen platform.
+- Validate IN BATCH + `runTest262File` (per #1968) — byte-neutral for programs
+  not setting `--platform`.
+
+## Out of scope
+
+- #2528 itself (the `--platform` flag + ambient lib scoping) — that is the
+  prerequisite this composes with.
+- The importable `node:<mod>` capability map (landed: #2634, #1772 P2-a/P2-b).

--- a/plan/issues/2646-edgejs-asyncify-incremental-stdin-loop-borrow.md
+++ b/plan/issues/2646-edgejs-asyncify-incremental-stdin-loop-borrow.md
@@ -1,0 +1,60 @@
+---
+id: 2646
+title: "edge.js async stdin: true incremental loop-borrow via asyncify (P3-d) — suspend poll_oneoff instead of pre-draining to EOF"
+status: backlog
+created: 2026-06-24
+updated: 2026-06-24
+priority: low
+feasibility: hard
+reasoning_effort: high
+task_type: feature
+area: host-interop
+language_feature: node-api-compat
+goal: platform
+sprint: Backlog
+es_edition: n/a
+depends_on: [2635]
+related: [2635, 2632, 1772]
+origin: "Slice P3-d of the #2635 async dual-provider proof (arch-capstone scoping, 2026-06-24). A `P3-d SEAM` marker comment was left in examples/native-messaging/edge.js where this slots in. Deferred as a fidelity follow-up — the basic proof (#2635, PR #2012) used mechanism 2."
+---
+# #2646 — edge.js incremental loop-borrow via asyncify (P3-d)
+
+## Problem
+
+The #2635 dual-provider proof (PR #2012) showed the SAME `process.stdin` wasm
+binary runs byte-identically under wasmtime (native WASI `poll_oneoff`) AND
+edge.js (native Node). But it used **mechanism 2 (pre-drain)**: edge.js `await`s
+Node's `process.stdin` to `'end'`, collecting ALL bytes, THEN calls `_start()` so
+every `poll_oneoff` finds data/EOF immediately and never truly blocks.
+
+This is correct for batch input but is NOT a *true* incremental loop-borrow: an
+interactive/streaming program (one that should react to each line as it arrives,
+or never sees EOF) cannot be driven by pre-draining. The wasm reactor's `_start`
+is a synchronous `poll_oneoff`-blocking loop, while Node's stdin is async — so to
+borrow Node's loop incrementally, the wasm stack must be able to *suspend* at
+`poll_oneoff` and resume on the next `'data'` tick.
+
+## Scope
+
+- Apply **asyncify** (`wasm-opt --asyncify`) to the reactor's blocking points so
+  `poll_oneoff` suspends the wasm stack, returns control to Node, and resumes on
+  the next `process.stdin` `'data'`/`'end'` event.
+- Extend `createNodeStdinWasiProvider` in `examples/native-messaging/edge.js`
+  (the `P3-d SEAM` marker) to drive the asyncify unwind/rewind around the async
+  stdin queue, replacing the pre-drain.
+- Prove an *interactive/streaming* program (reacts per-chunk, no up-front EOF)
+  runs under edge.js with the same observable behavior as wasmtime.
+
+## Acceptance
+
+- An interactive `process.stdin` program (e.g. echo-per-line that flushes before
+  EOF) runs under edge.js via incremental asyncify loop-borrow, observably
+  matching the wasmtime arm, WITHOUT pre-draining to EOF first.
+- The existing mechanism-2 batch proof (#2635) still passes (no regression).
+- Document the binary-size / perf cost of asyncify and gate it behind an opt-in
+  so non-interactive builds keep the cheaper pre-drain path.
+
+## Out of scope
+
+- The batch dual-provider proof (#2635, landed).
+- The WASI/wasmtime arm (already incremental via native `poll_oneoff`).

--- a/plan/issues/2647-plumb-allow-fs-into-no-provider-gate.md
+++ b/plan/issues/2647-plumb-allow-fs-into-no-provider-gate.md
@@ -1,0 +1,54 @@
+---
+id: 2647
+title: "Plumb --allow-fs into the node:fs no-provider capability gate (P2-a.0) — unhardcode allowFs:false"
+status: backlog
+created: 2026-06-24
+updated: 2026-06-24
+priority: low
+feasibility: low
+reasoning_effort: low
+task_type: feature
+area: host-interop
+language_feature: node-api-compat
+goal: platform
+sprint: Backlog
+es_edition: n/a
+related: [1772, 2634]
+origin: "Slice P2-a.0 of the #1772 Phase 2 capstone (arch-capstone scoping, 2026-06-24). PR #2014 landed the no-provider gate with allowFs hardcoded false to keep the slice atomic; this threads the real flag."
+---
+# #2647 — plumb `--allow-fs` into the no-provider gate (P2-a.0)
+
+## Problem
+
+The #1772 Phase 2 no-provider gate (PR #2014, in
+`src/codegen/node-fs-api.ts::tryCompileNodeFsCall`) calls
+`isMemberSatisfiable("node:fs", member, { wasi: ctx.wasi, allowFs: false })` with
+**`allowFs` hardcoded `false`**. So a path-based `node:fs` member
+(`readFileSync(path)`, `openSync`, …) always errors under `--target wasi`, even
+when a JS-host filesystem provider (or a WASI filesystem with preopens) IS
+available. The capability map already models `allowFs` in `providersFor`; only
+the flag plumbing is missing.
+
+## Scope (small, isolated)
+
+- Thread an `--allow-fs` CLI flag → `compile()` options → `ctx.allowFs`
+  (`src/codegen/context/types.ts` `CodegenContext`), defaulting to `false`.
+- Replace the hardcoded `false` in the gate with `ctx.allowFs`.
+- When `--allow-fs` is set under a JS host, path-based `node:fs` members resolve
+  through the real `node:fs` (or the host filesystem provider) instead of erroring.
+- Document the standalone-WASI story: `--allow-fs` under `--target wasi` requires
+  a WASI filesystem (`path_open`/preopens); without it the precise error stands.
+
+## Acceptance
+
+- `--allow-fs` makes a `readFileSync(path)` program compile (no "no provider"
+  error) under the JS-host filesystem provider; without it the precise #1772
+  error still fires.
+- fd-based `readSync`/`writeSync` unchanged (always satisfiable).
+- Test toggling the flag; validate IN BATCH + `runTest262File` (per #1968),
+  byte-neutral when the flag is unset.
+
+## Out of scope
+
+- A full WASI filesystem backend (preopens) — that is a separate, larger tier.
+- The capability gate itself (#1772 P2-a, landed).


### PR DESCRIPTION
Files the three intentionally-deferred slices from the #1772/#2635 node-API capstone as backlog issues, tracked off the parent plans:

- **#2645 (P2-c)** — compose the `node:<mod>` capability gate (#1772 Phase 2) with `--platform node|web` (#2528). `depends_on: [2528]`.
- **#2646 (P3-d)** — edge.js true incremental loop-borrow via asyncify (suspend `poll_oneoff` instead of pre-draining to EOF). The `P3-d SEAM` marker is in `examples/native-messaging/edge.js`.
- **#2647 (P2-a.0)** — plumb `--allow-fs` into the no-provider gate (unhardcode `allowFs:false` from #1772 PR #2014).

#1772 remains `in-progress` as the parent tracking these. Docs-only (3 new backlog issue files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)