### PR TITLE
fix(#2648): standalone TypedArray.{indexOf,lastIndexOf,includes} packed i8/i16 element + signedness

### DIFF
--- a/plan/issues/2648-standalone-typedarray-search-packed-elem.md
+++ b/plan/issues/2648-standalone-typedarray-search-packed-elem.md
@@ -1,0 +1,100 @@
+---
+id: 2648
+title: "Standalone: TypedArray.{indexOf,lastIndexOf,includes} packed i8/i16 element CE + signedness"
+status: done
+completed: 2026-06-24
+assignee: ttraenkler/agent-abc4cbcc1c297d4bd
+sprint: 65
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: conformance
+area: typedarray
+language_feature: typedarray-methods
+goal: standalone-mode
+parent: 2159
+related: [2159, 2593, 2644]
+---
+
+# #2648 — TypedArray search methods on packed i8/i16 elements (standalone CE + signedness)
+
+## Problem
+
+In `--target standalone`, `TypedArray.prototype.{indexOf,lastIndexOf,includes}`
+on a **sub-32-bit** typed array (Int8/Uint8/Uint8Clamped/Int16/Uint16 — packed
+`i8`/`i16` element storage) was a **hard compile error**:
+
+```
+Binary emit error: packed storage type "i8" is not valid in a value position
+(only struct fields / array elements) — a packed type leaked into a
+param/result/local/global
+```
+
+The IR front-end first logs a benign `[IR-FALLBACK] unknown class "Int8Array"`
+and demotes to legacy codegen; the legacy `compileArray{IndexOf,LastIndexOf,
+Includes}` then allocated the **search-value local** with the raw packed
+`elemType` (i8/i16), which is only valid as a struct field / array element. This
+is the same class of bug #2159 fixed for `.fill()`.
+
+### Verified repros (host pass / standalone CE, main `06e1e04d68`)
+
+| call | host | standalone (before) |
+|---|---|---|
+| `new Int8Array([10,11,12]).indexOf(12)` | `2` | **CE** (packed i8 in local) |
+| `new Uint16Array([…]).includes(x)` | … | **CE** |
+| `new Int16Array([…]).lastIndexOf(x)` | … | **CE** |
+
+32-bit+ views (Int32/Uint32/Float32/Float64) already compiled (i32/f64 are
+non-packed value types).
+
+A **second, latent** bug surfaced once compilation was unblocked: the element
+load used the legacy storage-kind signedness heuristic (i8→`get_u`,
+i16→`get_s`), which is wrong for half the views — `Int8Array([-1]).indexOf(-1)`
+read `255` (unsigned) and `Uint16Array([40000]).indexOf(40000)` read `-25536`
+(signed), neither matching.
+
+## Fix (`src/codegen/array-methods.ts`)
+
+1. **Packed element in value position** — added `unpackedElemType()` (i8/i16 →
+   i32, else identity) and used it for the search-value local + the search-arg
+   `compileExpression` target type in all three functions. Mirrors the #2159
+   `.fill()` fix; the element is loaded widened to i32 (`array.get_s/_u`) and
+   compared as i32, so the value local must be i32, not the packed storage type.
+2. **View-name signedness** — added `typedArraySearchSignedness()` (recovers
+   `"s"/"u"` from the receiver's VIEW NAME via the existing
+   `typedArrayPackedSignedness`, mirroring #2593's `typedArrayViewSignedness`)
+   and `elemGetOp()` (drives `array.get_s` for Int8/Int16, `array.get_u` for
+   Uint8/Uint8Clamped/Uint16; plain `array.get` for i32/f64/ref). The three
+   functions now load the element with the correct, view-driven sign-extension.
+
+No new #2108 coercion site — the search-arg coercion already routes through the
+engine (`compileExpression(arg, valType)`); `check:coercion-sites` baseline
+unchanged. 32-bit+ views, NaN SameValueZero (`includes`), `indexOf(NaN)→-1`
+strict-eq, and plain `number[]`/externref arrays are untouched.
+
+## Test Results
+
+- `tests/issue-2648-typedarray-search-packed-elem.test.ts` — 30/30 pass
+  (standalone + gc-mode regression guards): all 5 packed views × 3 methods
+  compile + match; signed-negative (Int8/Int16) and unsigned-high
+  (Uint8/Uint16) values match with correct sign-extension; not-found → -1/0;
+  Int32 / Float64-NaN-SameValueZero / Float64-indexOf-NaN / plain-array
+  regression guards green.
+- Direct compile probes confirm `Int8Array([10,11,12]).indexOf(12)`: CE → 2;
+  `Int8Array([-1]).indexOf(-1)`: -1 → 1; `Uint16Array([40000]).indexOf(40000)`:
+  -1 → 1.
+- tsc, lint, prettier, `check:coercion-sites`, `check:stack-balance`,
+  `check:any-box-sites`, `check:codegen-fallbacks`, `check:speculative-rollback`
+  all green.
+
+## Notes on test262-row attribution
+
+The fix removes a genuine standalone compile error and is correct for any
+standalone program calling these methods on byte/short typed arrays. However,
+most `built-ins/TypedArray/prototype/{indexOf,lastIndexOf,includes}` test262
+rows are additionally gated on the **#1907/#1888 S6-b** substrate (the
+`testWithTypedArrayConstructors` harness reads `Int8Array` /
+`Int8Array.prototype.indexOf` as a *value*, which standalone refuses), so the
+direct test262-row flip from this change alone is small — the value is the CE
+removal + correctness for direct typed-array call sites. Lifting the per-row
+gate is the separate #1907 substrate work.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -14,7 +14,13 @@ import { allocLocal, allocTempLocal, getLocalType } from "./context/locals.js";
 import { probeCompiledType } from "./context/speculative.js";
 import { emitHoleToUndefined, holeTestInstrs, holeToUndefinedInstrs } from "./array-holes.js"; // (#2001 S1)
 import type { ClosureInfo, CodegenContext, FunctionContext } from "./context/types.js";
-import { addArrayIteratorImports, addStringImports, addUnionImports, resolveWasmType } from "./index.js";
+import {
+  addArrayIteratorImports,
+  addStringImports,
+  addUnionImports,
+  resolveWasmType,
+  typedArrayPackedSignedness,
+} from "./index.js";
 import { addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "./registry/imports.js";
 import { emitToBoolean } from "./coercion-engine.js";
 import { compileStringLiteral } from "./shared.js";
@@ -136,6 +142,51 @@ function throwStringInstrs(ctx: CodegenContext, message: string): Instr[] {
   addStringConstantGlobal(ctx, message);
   const tagIdx = ensureExnTag(ctx);
   return [...stringConstantExternrefInstrs(ctx, message), { op: "throw", tagIdx } as Instr];
+}
+
+/**
+ * Value-position type for a (possibly packed) array element. A packed `i8`/`i16`
+ * storage type is only valid as a struct field / array element — it MUST NOT
+ * appear in a param/result/local/global position (the binary emitter rejects it
+ * with "packed storage type … is not valid in a value position"). A packed
+ * element loaded via `array.get_s`/`array.get_u` is already widened to `i32`, so
+ * a search-value local / comparison operand for the sub-32-bit typed arrays
+ * (Int8/Uint8/Int16/Uint16) must use `i32`, not the raw packed `elemType`
+ * (#2648 — `Int8Array.prototype.{indexOf,lastIndexOf,includes}` standalone CE).
+ */
+function unpackedElemType(elemType: ValType): ValType {
+  return elemType.kind === "i8" || elemType.kind === "i16" ? { kind: "i32" } : elemType;
+}
+
+/**
+ * (#2648, mirrors #2593) Recover the packed-element load signedness ("s"/"u") of
+ * a typed-array search-method receiver from its VIEW NAME — `Int8Array`/
+ * `Int16Array` read sign-extending (`array.get_s`), `Uint8Array`/
+ * `Uint8ClampedArray`/`Uint16Array` read zero-extending (`array.get_u`). Signed
+ * and unsigned views share the same i8/i16 storage but read with opposite
+ * sign-extension, so `indexOf`/`lastIndexOf`/`includes` MUST drive the element
+ * load off the view name, not the storage kind. Returns undefined for a
+ * non-integer-view receiver (caller falls back to the storage-kind heuristic).
+ */
+function typedArraySearchSignedness(ctx: CodegenContext, receiver: ts.Expression): "s" | "u" | undefined {
+  const t = ctx.checker.getTypeAtLocation(receiver);
+  let name = t.getSymbol()?.name ?? t.aliasSymbol?.name;
+  if (!name && ts.isNewExpression(receiver) && ts.isIdentifier(receiver.expression)) {
+    name = receiver.expression.text;
+  }
+  return name ? typedArrayPackedSignedness(name) : undefined;
+}
+
+/** Pick the element-load op for a (possibly packed) typed-array element, driven
+ *  by the view-name signedness when available, else the legacy storage-kind
+ *  heuristic (i8→get_u, i16→get_s). i32/f64/ref elements use plain `array.get`. */
+function elemGetOp(elemType: ValType, signedness: "s" | "u" | undefined): "array.get" | "array.get_s" | "array.get_u" {
+  if (elemType.kind === "i8" || elemType.kind === "i16") {
+    if (signedness === "s") return "array.get_s";
+    if (signedness === "u") return "array.get_u";
+    return elemType.kind === "i8" ? "array.get_u" : "array.get_s";
+  }
+  return "array.get";
 }
 
 /**
@@ -3897,7 +3948,10 @@ function compileArrayIndexOf(
   const dataTmp = allocLocal(fctx, `__arr_iof_data_${fctx.locals.length}`, { kind: "ref_null", typeIdx: arrTypeIdx });
   const iTmp = allocLocal(fctx, `__arr_iof_i_${fctx.locals.length}`, { kind: "i32" });
   const lenTmp = allocLocal(fctx, `__arr_iof_len_${fctx.locals.length}`, { kind: "i32" });
-  const valTmp = allocLocal(fctx, `__arr_iof_val_${fctx.locals.length}`, elemType);
+  // Packed i8/i16 elements load (and compare) as i32 — never store the raw
+  // packed type in a local (#2648).
+  const valType = unpackedElemType(elemType);
+  const valTmp = allocLocal(fctx, `__arr_iof_val_${fctx.locals.length}`, valType);
 
   // Compile receiver -> vec ref
   compileExpression(ctx, fctx, propAccess.expression);
@@ -3952,7 +4006,10 @@ function compileArrayIndexOf(
   }
   fctx.body.push({ op: "local.set", index: iTmp });
 
-  const getOp = elemType.kind === "i8" ? "array.get_u" : elemType.kind === "i16" ? "array.get_s" : "array.get";
+  // (#2648) Drive the packed i8/i16 load off the VIEW NAME signedness so a
+  // signed Int8/Int16 value (`Int8Array([-1]).indexOf(-1)`) and an unsigned
+  // high Uint16 value (`Uint16Array([40000]).indexOf(40000)`) both match.
+  const getOp = elemGetOp(elemType, typedArraySearchSignedness(ctx, propAccess.expression));
 
   // For externref elements, use __host_eq (JS Strict Equality, §7.2.16) so
   // object identity, cross-type (e.g. `[false].indexOf(0)`), and string
@@ -4078,7 +4135,10 @@ function compileArrayIncludes(
   const dataTmp = allocLocal(fctx, `__arr_inc_data_${fctx.locals.length}`, { kind: "ref_null", typeIdx: arrTypeIdx });
   const iTmp = allocLocal(fctx, `__arr_inc_i_${fctx.locals.length}`, { kind: "i32" });
   const lenTmp = allocLocal(fctx, `__arr_inc_len_${fctx.locals.length}`, { kind: "i32" });
-  const valTmp = allocLocal(fctx, `__arr_inc_val_${fctx.locals.length}`, elemType);
+  // Packed i8/i16 elements load (and compare) as i32 — never store the raw
+  // packed type in a local (#2648).
+  const valType = unpackedElemType(elemType);
+  const valTmp = allocLocal(fctx, `__arr_inc_val_${fctx.locals.length}`, valType);
 
   // Compile receiver -> vec ref
   compileExpression(ctx, fctx, propAccess.expression);
@@ -4094,7 +4154,7 @@ function compileArrayIncludes(
   fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 });
   fctx.body.push({ op: "local.set", index: dataTmp });
 
-  compileExpression(ctx, fctx, callExpr.arguments[0]!, elemType);
+  compileExpression(ctx, fctx, callExpr.arguments[0]!, valType);
   fctx.body.push({ op: "local.set", index: valTmp });
 
   // fromIndex (optional 2nd arg, default 0)
@@ -4133,7 +4193,8 @@ function compileArrayIncludes(
   }
   fctx.body.push({ op: "local.set", index: iTmp });
 
-  const getOp = elemType.kind === "i8" ? "array.get_u" : elemType.kind === "i16" ? "array.get_s" : "array.get";
+  // (#2648) View-name-driven signedness for the packed i8/i16 element load.
+  const getOp = elemGetOp(elemType, typedArraySearchSignedness(ctx, propAccess.expression));
 
   // SameValueZero comparison for includes:
   // - For f64: a === b OR (isNaN(a) AND isNaN(b))
@@ -8482,7 +8543,10 @@ function compileArrayLastIndexOf(
   const vecTmp = allocLocal(fctx, `__arr_liof_vec_${fctx.locals.length}`, { kind: "ref_null", typeIdx: vecTypeIdx });
   const dataTmp = allocLocal(fctx, `__arr_liof_data_${fctx.locals.length}`, { kind: "ref_null", typeIdx: arrTypeIdx });
   const iTmp = allocLocal(fctx, `__arr_liof_i_${fctx.locals.length}`, { kind: "i32" });
-  const valTmp = allocLocal(fctx, `__arr_liof_val_${fctx.locals.length}`, elemType);
+  // Packed i8/i16 elements load (and compare) as i32 — never store the raw
+  // packed type in a local (#2648).
+  const valType = unpackedElemType(elemType);
+  const valTmp = allocLocal(fctx, `__arr_liof_val_${fctx.locals.length}`, valType);
 
   // Compile receiver -> vec ref
   compileExpression(ctx, fctx, propAccess.expression);
@@ -8547,10 +8611,11 @@ function compileArrayLastIndexOf(
   fctx.body.push({ op: "local.set", index: dataTmp });
 
   // Compile search value
-  compileExpression(ctx, fctx, callExpr.arguments[0]!, elemType);
+  compileExpression(ctx, fctx, callExpr.arguments[0]!, valType);
   fctx.body.push({ op: "local.set", index: valTmp });
 
-  const getOp = elemType.kind === "i8" ? "array.get_u" : elemType.kind === "i16" ? "array.get_s" : "array.get";
+  // (#2648) View-name-driven signedness for the packed i8/i16 element load.
+  const getOp = elemGetOp(elemType, typedArraySearchSignedness(ctx, propAccess.expression));
 
   // For externref elements, use __host_eq (JS Strict Equality, §7.2.16) so
   // object identity, cross-type, and string comparisons follow spec. The

--- a/tests/issue-2648-typedarray-search-packed-elem.test.ts
+++ b/tests/issue-2648-typedarray-search-packed-elem.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+
+// #2648 — Standalone TypedArray.prototype.{indexOf,lastIndexOf,includes} on a
+//   sub-32-bit (packed i8/i16) typed array was a hard COMPILE ERROR:
+//     "packed storage type 'i8' is not valid in a value position"
+//   The search-value local was allocated with the raw packed element type
+//   (i8/i16), which is only valid as a struct field / array element — never in
+//   a param/result/local/global. (Mirrors the #2159 fix for .fill().)
+//
+//   Fix (src/codegen/array-methods.ts): hold the search value in the UNPACKED
+//   i32 (unpackedElemType), and drive the element load off the VIEW-NAME
+//   signedness (Int8/Int16 → array.get_s; Uint8/Uint8Clamped/Uint16 →
+//   array.get_u; mirrors #2593) so signed negatives and unsigned-high values
+//   both match. 32-bit+ views (Int32/Uint32/Float32/Float64) and plain arrays
+//   are unchanged.
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, { target: "standalone", skipSemanticDiagnostics: true } as never);
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): unknown }).test();
+}
+async function runGc(src: string): Promise<unknown> {
+  const r = await compile(src, { skipSemanticDiagnostics: true } as never);
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject ?? {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+const VIEWS = ["Int8Array", "Uint8Array", "Uint8ClampedArray", "Int16Array", "Uint16Array"];
+
+describe("#2648 standalone TypedArray search on packed i8/i16 elements", () => {
+  // The headline: these were a hard compile error for every packed view.
+  for (const V of VIEWS) {
+    it(`${V} indexOf positive value compiles + matches`, async () => {
+      expect(
+        await runStandalone(
+          `export function test(): number { const a=new ${V}([10,11,12,13]); return a.indexOf(12); }`,
+        ),
+      ).toBe(2);
+    });
+    it(`${V} includes positive value`, async () => {
+      expect(
+        await runStandalone(
+          `export function test(): number { const a=new ${V}([10,11,12,13]); return a.includes(11)?1:0; }`,
+        ),
+      ).toBe(1);
+    });
+    it(`${V} lastIndexOf positive value`, async () => {
+      expect(
+        await runStandalone(
+          `export function test(): number { const a=new ${V}([10,11,11,13]); return a.lastIndexOf(11); }`,
+        ),
+      ).toBe(2);
+    });
+  }
+
+  // Signedness — signed views must match negatives (array.get_s).
+  it("Int8Array indexOf(-1) (signed load)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a=new Int8Array([10,-1,12]); return a.indexOf(-1); }`,
+      ),
+    ).toBe(1);
+  });
+  it("Int8Array includes(-1)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a=new Int8Array([10,-1,12]); return a.includes(-1)?1:0; }`,
+      ),
+    ).toBe(1);
+  });
+  it("Int8Array lastIndexOf(-1)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a=new Int8Array([10,-1,-1]); return a.lastIndexOf(-1); }`,
+      ),
+    ).toBe(2);
+  });
+  it("Int16Array indexOf(-5) (signed load)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a=new Int16Array([10,-5,12]); return a.indexOf(-5); }`,
+      ),
+    ).toBe(1);
+  });
+
+  // Signedness — unsigned views must match high values (array.get_u).
+  it("Uint8Array indexOf(200) (unsigned load)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a=new Uint8Array([10,200,12]); return a.indexOf(200); }`,
+      ),
+    ).toBe(1);
+  });
+  it("Uint8Array includes(255)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a=new Uint8Array([10,255,12]); return a.includes(255)?1:0; }`,
+      ),
+    ).toBe(1);
+  });
+  it("Uint16Array indexOf(40000) (unsigned load)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a=new Uint16Array([10,40000,12]); return a.indexOf(40000); }`,
+      ),
+    ).toBe(1);
+  });
+
+  // Not-found.
+  it("Int8Array indexOf miss → -1", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a=new Int8Array([10,11,12]); return a.indexOf(99); }`,
+      ),
+    ).toBe(-1);
+  });
+  it("Uint8Array includes miss → 0", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a=new Uint8Array([10,11,12]); return a.includes(99)?1:0; }`,
+      ),
+    ).toBe(0);
+  });
+
+  // Regression guards: 32-bit+ views, NaN SameValueZero, plain arrays unchanged.
+  it("Int32Array indexOf unchanged", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a=new Int32Array([10,11,12]); return a.indexOf(12); }`,
+      ),
+    ).toBe(2);
+  });
+  it("Float64Array includes(NaN) SameValueZero", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a=new Float64Array([1,NaN,3]); return a.includes(NaN)?1:0; }`,
+      ),
+    ).toBe(1);
+  });
+  it("Float64Array indexOf(NaN) → -1 (strict eq)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a=new Float64Array([1,NaN,3]); return a.indexOf(NaN); }`,
+      ),
+    ).toBe(-1);
+  });
+  it("plain number[] indexOf unchanged", async () => {
+    expect(await runStandalone(`export function test(): number { const a=[10,11,12]; return a.indexOf(12); }`)).toBe(2);
+  });
+
+  // gc/host mode regression guards.
+  it("gc-mode Int8Array indexOf(-1)", async () => {
+    expect(
+      await runGc(`export function test(): number { const a=new Int8Array([10,-1,12]); return a.indexOf(-1); }`),
+    ).toBe(1);
+  });
+  it("gc-mode Uint16Array indexOf(40000)", async () => {
+    expect(
+      await runGc(
+        `export function test(): number { const a=new Uint16Array([10,40000,12]); return a.indexOf(40000); }`,
+      ),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

In `--target standalone`, `TypedArray.prototype.{indexOf,lastIndexOf,includes}`
on a sub-32-bit typed array (Int8/Uint8/Uint8Clamped/Int16/Uint16 — packed
`i8`/`i16` element storage) was a **hard compile error**:

```
Binary emit error: packed storage type "i8" is not valid in a value position
```

The legacy codegen allocated the search-value local with the raw packed
`elemType` (valid only as a struct field / array element). Same class as the
#2159 `.fill()` fix.

A second latent bug surfaced once compilation was unblocked: the element load
used the storage-kind signedness heuristic (i8→`get_u`, i16→`get_s`), wrong for
half the views — `Int8Array([-1]).indexOf(-1)` read 255, `Uint16Array([40000])
.indexOf(40000)` read -25536, neither matching.

## Fix (`src/codegen/array-methods.ts`)

- `unpackedElemType()`: hold the search value in i32 (i8/i16 widen on load), used
  for the value local + search-arg compile target in all three functions.
- `typedArraySearchSignedness()` + `elemGetOp()`: drive the element load off the
  VIEW NAME (Int8/Int16 → `array.get_s`; Uint8/Uint8Clamped/Uint16 →
  `array.get_u`), mirroring #2593's `typedArrayViewSignedness`, so
  signed-negative and unsigned-high values both match.

No new #2108 coercion site (search-arg coercion already routes through the
engine). 32-bit+ views, NaN SameValueZero (`includes`), `indexOf(NaN)→-1`, and
plain `number[]`/externref arrays untouched.

## Validation

- `tests/issue-2648-typedarray-search-packed-elem.test.ts` — 30/30 (standalone +
  gc-mode regression guards).
- Direct compile probes: `Int8Array([10,11,12]).indexOf(12)` CE → 2;
  `Int8Array([-1]).indexOf(-1)` -1 → 1; `Uint16Array([40000]).indexOf(40000)`
  -1 → 1.
- tsc, lint, prettier, `check:coercion-sites`, `check:stack-balance`,
  `check:any-box-sites`, `check:codegen-fallbacks`, `check:speculative-rollback`,
  `check:issue-ids:against-main` all green.

## Note on test262-row attribution

The fix removes a genuine standalone CE and is correct for any standalone program
calling these methods on byte/short typed arrays. Most
`built-ins/TypedArray/prototype/{indexOf,lastIndexOf,includes}` test262 rows are
additionally gated on the **#1907/#1888 S6-b** substrate (the
`testWithTypedArrayConstructors` harness reads the constructor/prototype method
as a *value*, which standalone refuses), so the direct test262-row flip from this
change alone is small — the value is the CE removal + call-site correctness.

Closes #2648.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA