### PR TITLE
docs(#2649,#2650): record deferred standalone TypedArray.subarray + String.at bugs

### DIFF
--- a/plan/issues/2649-standalone-typedarray-subarray-empty.md
+++ b/plan/issues/2649-standalone-typedarray-subarray-empty.md
@@ -1,0 +1,56 @@
+---
+id: 2649
+title: "Standalone: TypedArray.prototype.subarray returns an empty view (.length === 0)"
+status: ready
+sprint: Backlog
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: conformance
+area: typedarray
+language_feature: typedarray-methods
+goal: standalone-mode
+related: [2648, 1907]
+---
+
+# #2649 — Standalone TypedArray.prototype.subarray returns an empty view
+
+## Problem
+
+In `--target standalone`, `TypedArray.prototype.subarray(begin?, end?)` returns a
+view whose **`.length` reads as 0** regardless of `begin`/`end` — even for the
+no-arg / full-range form. The element data itself is reachable (indexed access on
+the result returns the right values), so the bug is specifically in the
+**length field** of the returned subarray view, not its backing data.
+
+### Verified repros (host pass / standalone wrong-value, main `06e1e04d68`)
+
+| call (`a = new Int8Array([10,11,12,13])`) | host | standalone |
+|---|---|---|
+| `a.subarray(1).length` | `3` | **`0`** |
+| `a.subarray(0,2).length` | `2` | **`0`** |
+| `a.subarray().length` | `4` | **`0`** |
+| `a.subarray(1)[0]` | `11` | `11` (data OK) |
+
+So `subarray()` builds the result view but its length field is left at 0.
+
+## Root cause (to confirm)
+
+`compileTypedArraySubarray` (`src/codegen/array-methods.ts`, ~line 3145 dispatch)
+appears to construct the result vec/view struct with a zero (or unset) length
+field instead of `clamp(end) − clamp(begin)`. Verify whether it shares a backing
+array with a separate length, and whether the length write is missing or
+mis-clamped. (Bug is value-correctness, not a trap or CE.)
+
+## Notes on test262-row yield
+
+Most `built-ins/TypedArray/prototype/subarray` test262 rows additionally go
+through the `testWithTypedArrayConstructors` harness (constructor-as-value →
+#1907/#1888 S6-b substrate), so the direct row flip may be limited; the value is
+standalone correctness for direct `ta.subarray(...)` call sites. Surfaced while
+surveying for the #2648 fix.
+
+## Suggested validation
+- New `tests/issue-2649-*`: `subarray(b)`, `subarray(b,e)`, `subarray()`,
+  negative begin/end, across packed (Int8/Uint16) and 32-bit (Int32/Float64)
+  views × standalone + gc; assert `.length` and element values; gc-mode guard.

--- a/plan/issues/2650-standalone-string-at-nullable-result-member-read.md
+++ b/plan/issues/2650-standalone-string-at-nullable-result-member-read.md
@@ -1,0 +1,58 @@
+---
+id: 2650
+title: "Standalone: member-read on String.prototype.at result returns empty (.length/.charCodeAt)"
+status: ready
+sprint: Backlog
+priority: low
+feasibility: medium
+reasoning_effort: medium
+task_type: conformance
+area: string
+language_feature: string-methods
+goal: standalone-mode
+related: [2600, 2644]
+---
+
+# #2650 — Standalone member-read on a String.prototype.at result returns empty
+
+## Problem
+
+In `--target standalone`, `String.prototype.at(i)` **returns the correct value**
+(string equality and `=== undefined` for OOB both work), but a **member read on
+the result** — `.length`, `.charCodeAt(0)`, chained methods — reads as if the
+string were empty.
+
+### Verified repros (host pass / standalone wrong-value, main `06e1e04d68`)
+
+| expr | host | standalone |
+|---|---|---|
+| `"abcd".at(2) === "c"` | `true` | `true` (value OK) |
+| `"abcd".at(-1) === "d"` | `true` | `true` |
+| `"abcd".at(9) === undefined` | `true` | `true` |
+| `const c = "abcd".at(2); c.length` | `1` | **`0`** |
+| `"abcd".at(2).charCodeAt(0)` | `99` | **`0`** |
+
+Compare: `"abcd".charAt(2).charCodeAt(0)` → `99` in standalone (charAt works).
+
+## Root cause (to confirm)
+
+`String.prototype.at` returns `nativeStringTypeNullable` (a **nullable** AnyString
+ref, because an out-of-range index yields `undefined`). The downstream member-read
+(`.length` / `.charCodeAt`) on a nullable-typed AnyString ref appears to mishandle
+the nullable wrapper — likely flattening/length-reading a path that does not
+account for the nullable cast, producing 0. `charAt` works because it returns a
+non-nullable native string. See `compileNativeStringMethodCall` `method === "at"`
+(`src/codegen/string-ops.ts` ~2287) returning `nativeStringTypeNullable`, and the
+member-read/length lowering for a nullable AnyString receiver.
+
+## Notes on test262-row yield
+
+The `built-ins/String/prototype/at` test262 rows already PASS standalone — they
+assert via `assert.sameValue(s.at(i), "x")` (string equality), which works; they
+do **not** chain a member read on the result. So this bug currently flips **no**
+test262 row; it is recorded as a correctness gap for direct member-read call
+sites (surfaced while surveying for the #2644/#2648 work). Low priority.
+
+## Suggested validation
+- New `tests/issue-2650-*`: `s.at(i).length`, `s.at(i).charCodeAt(0)`, chained
+  `s.at(i).toUpperCase()`, OOB `s.at(99)?.length` × standalone + gc; gc-mode guard.


### PR DESCRIPTION
Records two standalone correctness bugs surfaced while surveying the
`.at`/index-method family for #2644/#2648. Both deferred (low/no direct
test262-row yield) — these are issue-doc files only, no code change.

- **#2649** — `TypedArray.prototype.subarray` returns an empty view
  (`.length === 0`) in standalone even for the full-range form; element data is
  reachable, so the length field of the result view is left unset/zero.
- **#2650** — member-read on a `String.prototype.at` result returns empty
  (`s.at(2).length` → 0); the nullable AnyString result mishandles a downstream
  member read. The value itself is correct (string equality + OOB undefined
  work), so the `String.prototype.at` test262 rows already pass and this flips
  no row today.

Each has verified repros, suspected root cause, and a validation sketch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA