### PR TITLE
fix(#2637 B1): unwrap executor at super(builtin Promise) host shim

### DIFF
--- a/plan/issues/2637-promise-subclass-executor-body-protocol.md
+++ b/plan/issues/2637-promise-subclass-executor-body-protocol.md
@@ -1,7 +1,8 @@
 ---
 id: 2637
 title: "Promise capability executor-body protocol: __promise_subclass_ctor ↔ <Sub>_new ↔ NewPromiseCapability re-architecture"
-status: ready
+status: in-progress
+assignee: sdev-definebuiltin
 created: 2026-06-24
 priority: medium
 feasibility: hard
@@ -145,7 +146,40 @@ To run the user body under `NewPromiseCapability(C)`, three interdependent piece
 
 ## Implementation Plan (architect spec — B1 → B2 sequencing)
 
-### Phase B1 — executor unwrap at `super(<builtin Promise>)` (prerequisite)
+### Phase B1 — executor unwrap at `super(<builtin Promise>)` — ✅ LANDED (sdev-definebuiltin, 2026-06-24)
+
+**Implemented** the spec's PREFERRED pure-runtime approach (host-shim unwrap, no
+funcidx shift, no codegen change). The locus is the generic extern-class `new`
+host handler in `src/runtime.ts` (the `intent.action === "new"` arm, the closure
+`return (...args) => { … new Ctor(...args) }` that backs `__new_Promise` /
+`__new_<Builtin>`). It returns `new Ctor(...args)` with the executor forwarded
+verbatim; for `intent.className === "Promise"` the first arg now passes through
+`_maybeWrapCallable(args[0], 2, callbackState)` first — exactly the unwrap the
+`Promise_new` shim already applies (`new Promise(_maybeWrapCallable(executor, 2,
+callbackState))`).
+
+- **Repro confirmed on clean main first**: the B1 unit test fails on unfixed
+  runtime (throws at the `new Ctor(...args)` line — "Promise resolver
+  [object Object] is not a function"), passes with the unwrap. So the fix is
+  load-bearing, not vacuous.
+- **Behavior-neutral elsewhere**: `_maybeWrapCallable` is a no-op for raw
+  functions (edge case a) and for null/undefined; the unwrap is gated on the
+  `Promise` parent only (edge case b — `extends Array` etc. unchanged); the
+  host-only `new` handler never runs under standalone (edge case c, #1941).
+- **Tests**: `tests/issue-2637-b1-executor-unwrap.test.ts` (4 cases: direct
+  `new SubPromise(executor)` runs the body + callCount=1; executor actually
+  invoked; `extends Array` regression; plain `new Promise(fn)` regression).
+- **No-regression sweep** (#2623 identity / #1366a/b / #1977 / #1981 /
+  #28-promise-executor / promise-combinators): all green EXCEPT 2 PRE-EXISTING
+  failures in `promise-combinators.test.ts` (`Promise.race`/`Promise.allSettled`
+  "undefined is not iterable" at `runtime.ts:10444`) — verified identical on
+  clean origin/main, unrelated to B1.
+- **0 test262 rows flip on B1 alone** (as the spec predicted — the ctx-ctor rows
+  go through the combinator / NewPromiseCapability path, addressed by B2). B1 is
+  the prerequisite for B2; the issue stays OPEN for B2.
+
+Original spec direction (retained for B2 reference):
+
 - **Locus**: the extern-class `super(builtin)` construction lowering (the path
   that emits `__new_Promise(executor)` inside `$<Sub>_new`). Find it via the
   `classBuiltinParentMap` consumers in `src/codegen/class-bodies.ts`

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -6637,7 +6637,26 @@ function resolveImport(
           intent.className === "Number";
         const argCoercionHint: "number" | "string" | "default" =
           intent.className === "Number" ? "number" : intent.className === "Date" ? "default" : "string";
+        // (#2637 B1) The Promise constructor consumes its first argument as an
+        // executor callback (`new Promise((resolve, reject) => …)`). For a
+        // `class Sub extends Promise { constructor(a) { super(a); … } }`, the
+        // user constructor body forwards the executor to this `__new_Promise`
+        // host import as a BOXED wasm closure (an opaque struct, not a raw JS
+        // function). V8's `Promise` ctor then throws "Promise resolver
+        // [object Object] is not a function". Unwrap the executor to a
+        // host-callable here, mirroring the `Promise_new` host shim
+        // (`new Promise(_maybeWrapCallable(executor, 2, callbackState))`).
+        // `_maybeWrapCallable` is a no-op for a value already a raw function
+        // (edge case a) and for null/undefined, so genuine `new Promise(fn)` and
+        // the no-arg `super()` form are unaffected; only the `Promise` parent is
+        // touched (edge case b: `extends Array/Map/...` unchanged); the
+        // host-only construction path leaves standalone untouched (edge case c,
+        // #1941).
+        const isPromiseExecutorCtor = intent.className === "Promise";
         return (...args: any[]) => {
+          if (isPromiseExecutorCtor && args.length > 0) {
+            args[0] = _maybeWrapCallable(args[0], 2, callbackState);
+          }
           if (!isWrapperCtor) {
             let len = args.length;
             while (len > 0 && args[len - 1] == null) len--;

--- a/tests/issue-2637-b1-executor-unwrap.test.ts
+++ b/tests/issue-2637-b1-executor-unwrap.test.ts
@@ -1,0 +1,106 @@
+// #2637 Phase B1 — executor unwrap at `super(<builtin Promise>)`.
+//
+// A `class SubPromise extends Promise { constructor(a) { super(a); … } }` lowers
+// the `super(a)` call to `__self = __new_Promise(a)` (class-bodies.ts builtin-
+// parent branch). The executor `a` arrives at the `__new_Promise` host import as
+// a BOXED wasm closure (an opaque struct, not a raw JS function), so V8's real
+// `Promise` constructor throws "Promise resolver [object Object] is not a
+// function" and the user constructor body never runs.
+//
+// B1 (src/runtime.ts, the generic extern-class `new` host handler backing
+// `__new_Promise`) unwraps the first argument to a host-callable via
+// `_maybeWrapCallable(args[0], 2, callbackState)` when the builtin parent is
+// `Promise` — mirroring the `Promise_new` host shim. This is a pure-runtime
+// change (no funcidx shift, no codegen change). 0 test262 rows flip on B1 alone
+// (every ctx-ctor row goes through the combinator / NewPromiseCapability path,
+// addressed by B2); B1 is gated on this unit test + a no-regression sweep.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function instantiate(src: string): Promise<WebAssembly.Exports> {
+  const r = await compile(src);
+  if (!r.success) throw new Error("compile failed: " + JSON.stringify(r.errors));
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const m = await WebAssembly.instantiate(r.binary, imports);
+  const setExports = (imports as unknown as { setExports?: (e: WebAssembly.Exports) => void }).setExports;
+  if (typeof setExports === "function") setExports(m.instance.exports);
+  return m.instance.exports;
+}
+
+describe("#2637 B1 — executor unwrap at super(builtin Promise)", () => {
+  it("direct `new SubPromise(executor)` runs the user constructor body (callCount=1, no throw)", async () => {
+    // The whole point: the user body forwards the executor through super(a) →
+    // __new_Promise(a); B1 unwraps it so V8's Promise ctor accepts it and the
+    // side effects (callCount += 1) run. Before B1 this threw "Promise resolver
+    // [object Object] is not a function".
+    const ex = await instantiate(`
+      let callCount = 0;
+      class SubPromise extends Promise<number> {
+        constructor(executor: any) {
+          super(executor);
+          callCount += 1;
+        }
+      }
+      export function test(): number {
+        const p: any = new SubPromise((resolve: any, _reject: any) => { resolve(1); });
+        // Returns 1 only when the body ran (callCount) and an instance was built.
+        return callCount === 1 && p != null ? 1 : 0;
+      }
+    `);
+    expect((ex.test as () => number)()).toBe(1);
+  });
+
+  it("the executor passed to super() is the user's executor (it is actually invoked)", async () => {
+    // The host Promise built from the (unwrapped) executor must INVOKE it — i.e.
+    // the resolve/reject machinery reaches the user's arrow body. We observe this
+    // via a side-effecting flag the executor sets when called.
+    const ex = await instantiate(`
+      let executorRan = 0;
+      class SubPromise extends Promise<number> {
+        constructor(executor: any) {
+          super(executor);
+        }
+      }
+      export function test(): number {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const _p: any = new SubPromise((resolve: any, _reject: any) => {
+          executorRan = 1;
+          resolve(1);
+        });
+        return executorRan;
+      }
+    `);
+    expect((ex.test as () => number)()).toBe(1);
+  });
+
+  it("regression: a non-Promise builtin subclass (extends Array) is unchanged", async () => {
+    // Edge case (b): the unwrap is gated on the Promise parent only. A
+    // `class extends Array` super(arg) must still forward its arg verbatim.
+    const ex = await instantiate(`
+      class SubArr extends Array<number> {
+        constructor() {
+          super(3);
+        }
+      }
+      export function test(): number {
+        const a: any = new SubArr();
+        return a.length === 3 ? 1 : 0;
+      }
+    `);
+    expect((ex.test as () => number)()).toBe(1);
+  });
+
+  it("regression: a plain `new Promise(fn)` (no subclass) still resolves", async () => {
+    // Edge case (a): a raw-function executor must pass through _maybeWrapCallable
+    // unchanged. This path does not even touch the extern-class new handler, but
+    // we assert it stays green as a guard against any host-shim coupling.
+    const ex = await instantiate(`
+      export async function main(): Promise<number> {
+        const p = new Promise<number>((resolve) => { resolve(7); });
+        return await p;
+      }
+    `);
+    expect(await (ex.main as () => Promise<number>)()).toBe(7);
+  });
+});


### PR DESCRIPTION
## #2637 Phase B1 — executor unwrap at `super(<builtin Promise>)`

First slice of the Promise capability executor-body protocol (#2637, architect spec by sendev-2623a). **Pure-runtime**, no funcidx shift, no codegen change.

### Problem
`class SubPromise extends Promise { constructor(a) { super(a); … } }` lowers `super(a)` to `__self = __new_Promise(a)`. The executor `a` reaches the `__new_Promise` host import as a **boxed wasm closure** (an opaque struct, not a raw JS function), so V8's real `Promise` constructor throws `Promise resolver [object Object] is not a function` and the user constructor body never runs on a direct `new SubPromise(executor)`.

### Fix
In the generic extern-class `new` host handler that backs `__new_Promise` (`src/runtime.ts`), unwrap the first arg via `_maybeWrapCallable(args[0], 2, callbackState)` when `intent.className === "Promise"` — mirroring the `Promise_new` host shim.

- `_maybeWrapCallable` is a no-op for raw functions and for null/undefined → genuine `new Promise(fn)` and the no-arg `super()` form unaffected (edge case a).
- Gated on the `Promise` parent only → `extends Array/Map/...` unchanged (edge case b).
- The host-only `new` handler never runs under standalone (edge case c, #1941).

### Validation
- `tests/issue-2637-b1-executor-unwrap.test.ts` — 4 cases (direct `new SubPromise(executor)` runs body + callCount=1; executor actually invoked; `extends Array` regression; plain `new Promise(fn)` regression). **Repro confirmed failing on clean main before the fix.**
- No-regression sweep (#2623 identity / #1366a/b / #1977 / #1981 / #28-promise-executor / promise-combinators) all green **except 2 PRE-EXISTING `promise-combinators` failures** verified identical on clean origin/main (unrelated to B1).
- **0 test262 rows flip on B1 alone** (the ctx-ctor rows go through the combinator / NewPromiseCapability path — that's B2, which depends on B1). Broad-impact (touches `__new_Promise`) → **merge_group floor authoritative**.

### Scope
B1 only. #2637 stays **OPEN** for B2 (ctor-closure registration + run-on-host-`this`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)