### PR TITLE
fix(#2046): standalone Reflect.defineProperty → native applier

### DIFF
--- a/plan/issues/2046-standalone-reflect-spec-gaps.md
+++ b/plan/issues/2046-standalone-reflect-spec-gaps.md
@@ -4,7 +4,7 @@ title: "standalone Reflect: receiver arg silently dropped, deleteProperty ignore
 status: in-progress
 sprint: 64
 created: 2026-06-10
-updated: 2026-06-21
+updated: 2026-06-25
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -239,3 +239,60 @@ numeric-key coercion, non-object→TypeError, and the PR-D numeric-key get pin.
 - **PR-C (real receiver plumbing)** — senior/deferred, coordinates with #1888
   Slice 5 accessor invocation; the explicit-receiver get/set refusal stays correct
   meanwhile.
+
+## defineProperty slice landed — route to native applier (2026-06-25)
+
+PROBE-VERIFIED against current main HEAD (064b27657) before any change:
+`Reflect.defineProperty(o, "x", {value:42,…})` refused with
+"Codegen error: Reflect.defineProperty not supported in standalone mode
+(#1472 Phase C)".
+
+**The #2043 blocker recorded above was STALE.** The write-side native
+`__obj_define_from_desc` (#1629b) has backed standalone `Object.defineProperty`
+since that PR and is registered by `ensureObjectRuntime` / reachable end-to-end —
+no new native was needed.
+
+**Change** (`src/codegen/expressions/calls.ts`, inside the `if (ctx.standalone)`
+Reflect dispatch block; `src/codegen/object-ops.ts`): replaced the
+`Reflect.defineProperty` refusal with a route through the SAME standalone
+runtime-descriptor applier `Object.defineProperty` uses —
+`emitDefinePropertyDescRuntime` (now exported). Reusing it (rather than calling
+`__obj_define_from_desc` directly) is essential: it performs the **#2372
+descriptor-struct reify**, so an INLINE object-literal descriptor
+(`{ value: 42, … }`, which the TS checker types as a closed WasmGC struct) is
+reified into a `$Object` before the native's internal `ref.test $Object` runs —
+otherwise the native raises a spurious §10.1.6 TypeError. §28.1.3:
+- step 1 (non-object target → TypeError) — enforced with the shared
+  `emitNonObjectArgGuard` (now exported), which fires for a statically primitive /
+  null / undefined target (the test262 non-object subtests use bare primitive
+  literals). A runtime-`any` primitive still slips through — an accepted
+  imprecision shared with standalone `Object.defineProperty`.
+- step 2 (ToPropertyKey) — handled inside the native via `__to_property_key`
+  (#2042 S1); numeric keys coerce.
+- step 3 (ToPropertyDescriptor errors) — the native already throws a catchable
+  TypeError for malformed descriptors.
+- step 4 (boolean result) — the applier returns the obj (always truthy); we drop
+  it and return i32 `true`.
+
+**Known limitation** (shared with standalone `Object.defineProperty`): a rejected
+redefine of an existing non-configurable property silently no-ops in the native
+rather than surfacing failure, so the Reflect path returns `true` where spec
+wants `false`. Faithful handling needs a failure channel in
+`__defineProperty_value`; out of this slice.
+
+New tests in `tests/issue-2046.test.ts` (28/28 green): data descriptor apply,
+boolean-true return, numeric-key coercion, accessor descriptor, pre-built
+(dynamic) descriptor, enumerable:false hidden from for-in, primitive-target and
+null-target TypeError. `tests/issue-1905.test.ts` updated — `defineProperty`
+removed from the "still refuses" list (now supported), all green.
+
+Pre-existing unrelated failures (byte-identical to origin/main, untouched here):
+`tests/object-define-property.test.ts` fails to load (missing `./helpers.js`
+import); `tests/equivalence/reflect-api.test.ts` "Reflect.construct creates a new
+instance" fails identically on clean main (host-mode construct gap).
+
+**Still refused (out of this PR, issue stays `in-progress`):**
+- **`Reflect.construct`** (152 rows, the big one) — gated on standalone construct
+  machinery (coordinate with #2158).
+- **PR-C (real receiver plumbing)** — senior/deferred (#1888 Slice 5).
+- `getPrototypeOf` / `setPrototypeOf` / `apply` standalone arms.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -95,6 +95,8 @@ import {
   compileObjectDefineProperty,
   compileObjectKeysOrValues,
   compilePropertyIntrospection,
+  emitDefinePropertyDescRuntime,
+  emitNonObjectArgGuard,
 } from "../object-ops.js";
 import {
   emitArrayIsArrayExternrefPredicate,
@@ -7374,6 +7376,70 @@ function compileCallExpression(
             return { kind: "externref" };
           }
           return fallbackReturn(0, "extern-null");
+        }
+
+        if (reflectMethod === "defineProperty" && expr.arguments.length >= 3) {
+          // (#2046) Route Reflect.defineProperty(target, key, desc) through the
+          // SAME standalone runtime-descriptor applier that backs
+          // Object.defineProperty — `emitDefinePropertyDescRuntime`
+          // (object-ops.ts). Reusing it (rather than hand-rolling a
+          // `__obj_define_from_desc` call here) is essential because that helper
+          // performs the **#2372 descriptor struct reify**: an INLINE descriptor
+          // object literal (`{ value: 42, … }`) is typed by the TS checker as a
+          // closed WasmGC struct, which the native `__obj_define_from_desc`'s
+          // internal `ref.test $Object` rejects as "not an object" → spurious
+          // §10.1.6 TypeError. The helper reifies that struct into a fresh
+          // `$Object` first, so inline-literal descriptors work. The issue file
+          // recorded this arm as blocked on a write-side native (#2043); that
+          // blocker is STALE — the native is registered by ensureObjectRuntime
+          // and reachable end-to-end (it has backed Object.defineProperty since
+          // #1629b).
+          //
+          // §28.1.3 Reflect.defineProperty(target, propertyKey, attributes):
+          //   step 1: target not an Object → throw a TypeError. The native
+          //     applier silently no-ops on a non-$Object target (matching the
+          //     pre-existing standalone Object.defineProperty gap), so enforce
+          //     the §28.1.3 step-1 throw HERE with the shared
+          //     `emitNonObjectArgGuard` — it fires for a statically primitive /
+          //     null / undefined target (the test262 non-object subtests use
+          //     bare primitive literals). A runtime-`any` primitive still slips
+          //     through, an accepted imprecision shared with Object.defineProperty.
+          //   step 2: key = ? ToPropertyKey(propertyKey) — handled inside the
+          //     native via __to_property_key (#2042 S1), so numeric keys coerce.
+          //   step 3: desc = ? ToPropertyDescriptor(attributes) — a malformed
+          //     descriptor (data+accessor conflict, non-callable get/set) throws
+          //     a catchable TypeError, which the native already raises (these
+          //     originate in ToPropertyDescriptor, BEFORE [[DefineOwnProperty]],
+          //     so they throw for Reflect too).
+          //   step 4: return the boolean [[DefineOwnProperty]] result. The native
+          //     returns the obj (always truthy) and has no failure channel, so we
+          //     drop it and return i32 `true`.
+          //
+          // KNOWN LIMITATION (shared with standalone Object.defineProperty): a
+          // *rejected* redefine of an existing non-configurable property silently
+          // no-ops in the native rather than surfacing failure, so we cannot
+          // return the spec's `false` for that case — it returns `true`. Faithful
+          // handling needs a failure channel in __defineProperty_value and is out
+          // of this slice; converting the common refusal→working path is the win.
+          const objArg = expr.arguments[0];
+          const keyArg = expr.arguments[1];
+          const descArg = expr.arguments[2];
+          if (objArg !== undefined && keyArg !== undefined && descArg !== undefined) {
+            // §28.1.3 step 1: statically-non-object target → throw TypeError.
+            if (emitNonObjectArgGuard(ctx, fctx, objArg, "Reflect.defineProperty")) {
+              fctx.body.push({ op: "i32.const", value: 0 }); // unreachable after throw
+              return { kind: "i32" };
+            }
+            // `undefinedFields` is the host-only ToPropertyDescriptor presence
+            // sidecar — unused on the standalone path, so pass empty.
+            const r = emitDefinePropertyDescRuntime(ctx, fctx, objArg, keyArg, descArg, []);
+            if (r !== null) {
+              fctx.body.push({ op: "drop" }); // applier returns the obj; Reflect wants a boolean
+              fctx.body.push({ op: "i32.const", value: 1 }); // success → true
+              return { kind: "i32" };
+            }
+          }
+          return fallbackReturn(0, "i32-false");
         }
         // Boolean-returning methods need an i32 on the stack; the rest return
         // externref. Pick the fallback shape per method so the surrounding

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -323,7 +323,7 @@ function emitDescriptorStructReify(
   fctx.body.push({ op: "local.get", index: objLocal });
 }
 
-function emitDefinePropertyDescRuntime(
+export function emitDefinePropertyDescRuntime(
   ctx: CodegenContext,
   fctx: FunctionContext,
   objArg: ts.Expression,
@@ -563,7 +563,7 @@ function maybeEmitVecLengthGrowth(
  *
  * Per ES spec (19.1.2.4 step 1): "If Type(O) is not Object, throw a TypeError."
  */
-function emitNonObjectArgGuard(
+export function emitNonObjectArgGuard(
   ctx: CodegenContext,
   fctx: FunctionContext,
   argExpr: ts.Expression,

--- a/tests/issue-1905.test.ts
+++ b/tests/issue-1905.test.ts
@@ -69,8 +69,11 @@ describe("#1905 standalone native Reflect object subset", () => {
   });
 
   it("unsupported standalone Reflect methods still refuse without __reflect_* imports", async () => {
+    // NOTE: defineProperty is no longer in this list — #2046 routes it to the
+    // native __obj_define_from_desc applier (the same path backing standalone
+    // Object.defineProperty). getOwnPropertyDescriptor was likewise removed by
+    // the #2046 S5 slice.
     const cases: ReadonlyArray<[string, string]> = [
-      ["defineProperty", `export function f(o: any): boolean { return Reflect.defineProperty(o, "k", {}); }`],
       ["getPrototypeOf", `export function f(o: any): any { return Reflect.getPrototypeOf(o); }`],
       ["apply", `export function f(fn: any, t: any, a: any): any { return Reflect.apply(fn, t, a); }`],
       ["construct", `export function f(c: any, a: any): any { return Reflect.construct(c, a); }`],

--- a/tests/issue-2046.test.ts
+++ b/tests/issue-2046.test.ts
@@ -220,4 +220,87 @@ describe("#2046 standalone Reflect spec gaps", () => {
       }`),
     ).toBe(42);
   });
+
+  // ── #2046 defineProperty slice: route to the native __obj_define_from_desc ──
+  // applier (the SAME path backing standalone Object.defineProperty, incl. the
+  // #2372 descriptor-struct reify so INLINE object-literal descriptors work).
+  it("Reflect.defineProperty applies a data descriptor (inline literal) and reads back", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const o: any = {};
+        Reflect.defineProperty(o, "x", { value: 42, writable: true, enumerable: true, configurable: true });
+        return o.x === 42 ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("Reflect.defineProperty returns the boolean true on success", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const o: any = {};
+        return Reflect.defineProperty(o, "y", { value: 7 }) === true ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("Reflect.defineProperty coerces a numeric key via ToPropertyKey", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const o: any = {};
+        Reflect.defineProperty(o, 1, { value: 99, writable: true, enumerable: true, configurable: true });
+        return o["1"] === 99 ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("Reflect.defineProperty applies an accessor descriptor (get runs on read)", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const o: any = {};
+        Reflect.defineProperty(o, "g", { get() { return 13; }, enumerable: true, configurable: true });
+        return o.g === 13 ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("Reflect.defineProperty accepts a pre-built (dynamic) descriptor object", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const o: any = { a: 1 };
+        const d: any = { value: 5, writable: true, enumerable: true, configurable: true };
+        Reflect.defineProperty(o, "z", d);
+        return o.z === 5 ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("Reflect.defineProperty honors enumerable:false (key hidden from for-in)", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const o: any = {};
+        Reflect.defineProperty(o, "h", { value: 1, enumerable: false });
+        let count = 0;
+        for (const k in o) count++;
+        return count === 0 ? 1 : 0;
+      }`),
+    ).toBe(1);
+  });
+
+  it("Reflect.defineProperty on a primitive target throws a catchable TypeError (§28.1.3 step 1)", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        try { Reflect.defineProperty(5, "x", { value: 1 }); return 0; }
+        catch (e) { return 1; }
+      }`),
+    ).toBe(1);
+  });
+
+  it("Reflect.defineProperty on a null target throws a catchable TypeError", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        try { Reflect.defineProperty(null, "x", { value: 1 }); return 0; }
+        catch (e) { return 1; }
+      }`),
+    ).toBe(1);
+  });
 });


### PR DESCRIPTION
## #2046 — standalone Reflect.defineProperty (defineProperty slice)

Routes standalone `Reflect.defineProperty(target, key, desc)` through the same
runtime-descriptor applier that backs `Object.defineProperty`
(`emitDefinePropertyDescRuntime`, now exported), instead of refusing it
(#1472 Phase C).

### Reground (vs origin/main 064b27657)
The issue's other gaps already landed: get/set/has/deleteProperty (#1453),
ownKeys + getOwnPropertyDescriptor (S5 #1842), numeric-key get (#2042 S1). The
recorded **#2043 blocker for defineProperty was STALE** — the write-side native
`__obj_define_from_desc` (#1629b) has backed standalone `Object.defineProperty`
since that PR and is reachable end-to-end. No new native was needed.

### Why reuse the applier (not call the native directly)
The applier performs the **#2372 descriptor-struct reify**: an INLINE
object-literal descriptor (`{ value: 42, … }`) is typed by the TS checker as a
closed WasmGC struct, which the native's internal `ref.test $Object` rejects as
"not an object" → spurious §10.1.6 TypeError. The applier reifies it into a
`$Object` first, so inline-literal descriptors work.

### §28.1.3 conformance
- step 1 (non-object target → TypeError) — via the shared
  `emitNonObjectArgGuard` (now exported); fires for a statically primitive /
  null / undefined target. A runtime-`any` primitive still slips through — an
  accepted imprecision shared with standalone `Object.defineProperty`.
- step 2 (ToPropertyKey) — via `__to_property_key` (#2042 S1); numeric keys coerce.
- step 3 (ToPropertyDescriptor errors) — native already throws catchable TypeError.
- step 4 (boolean) — applier returns the obj; we drop and return `true`.

**Known limitation** (shared with standalone `Object.defineProperty`): a rejected
redefine of an existing non-configurable property silently no-ops, so the Reflect
path returns `true` where spec wants `false`. Needs a failure channel in
`__defineProperty_value`; out of this slice.

### Tests
- `tests/issue-2046.test.ts` 28/28 — data/accessor/numeric-key/pre-built
  descriptor, enumerable:false hidden from for-in, primitive + null target
  TypeError.
- `tests/issue-1905.test.ts` updated — `defineProperty` removed from the "still
  refuses" list.
- Pre-existing unrelated failures confirmed byte-identical to main: broken
  `tests/object-define-property.test.ts` (`./helpers.js` import), host-mode
  `Reflect.construct` equivalence test.

Issue stays `in-progress` — `Reflect.construct` (#2158-gated), real-receiver
plumbing (PR-C, senior/deferred), and getPrototypeOf/setPrototypeOf/apply remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)