### PR TITLE
docs(#1907): route S6-b residual to active s65 owner #2175 (harvest follow-up)

### DIFF
--- a/plan/issues/1907-standalone-builtin-static-method-value-reads.md
+++ b/plan/issues/1907-standalone-builtin-static-method-value-reads.md
@@ -188,6 +188,18 @@ in --target standalone (#1888 / #1907 S6-b)` signatures): `Int8Array.prototype`
 is the **incomplete per-builtin whitelist** — still the clearest standalone-mode
 lever for the next push.
 
+**Active owner of this residual = #2175** (in-progress, sprint 65 — architect
+spec "standalone builtin-prototype object representation + native-method-closure
+dispatch"). #1907 landed only the *starter* slice (`Array.isArray`/`Object.keys`/
+`getOwnPropertyDescriptor` + the closure mechanism, PR #1292); #2175 generalizes
+`ensureStandaloneBuiltinStaticMethodClosure` into a brand-keyed factory covering
+the full `Int8Array/%TypedArray%/ArrayBuffer/DataView/RegExp.prototype`
+object-read + dynamic-receiver dispatch behind this bucket (constructor-as-value
+tier is the #2651 follow-up below). **#1907 stays `done` (starter-slice scope
+met, not regressed); do not reopen** — the residual is tracked and scheduled
+under #2175, and reopening would split ownership of one bucket across two issues.
+Runtime-side coercion counterpart: the ToPrimitive bucket under #1917.
+
 > **Follow-up #2651 (s66, 2026-06-24): the TypedArray *constructor*-as-value
 > tier.** Verified (per-process WAT probe, `main` `c2847896d8`) that the bulk of
 > standalone `built-ins/TypedArray/prototype/*` rows are gated not on the method


### PR DESCRIPTION
Re-lands a one-paragraph note that was dropped from the 2026-06-24 harvest PR (#2001). During that PR's commit `--amend`, a blocked PreToolUse hook swallowed the `git add` for #1907, so the amend committed only the previously-staged set — the "#2175 active owner / do-not-reopen" paragraph never landed (#2503 and #1917 notes did).

This adds it to #1907:
- Names **#2175** (in-progress, sprint 65) as the active owner of the 1,631-record #1888/#1907 S6-b builtin-prototype-read residual.
- Records that **#1907 stays `done`** (starter-slice scope met, PR #1292) — **do not reopen**, since that would split one bucket's ownership across two issues.
- Cross-links the runtime-side ToPrimitive counterpart (#1917).

Docs-only. `check:issues` integrity+link gate green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)