### PR TITLE
fix(#2652): standalone parseInt/parseFloat ToString of primitive args

### DIFF
--- a/plan/issues/2652-standalone-parseint-tostring-primitive.md
+++ b/plan/issues/2652-standalone-parseint-tostring-primitive.md
@@ -1,0 +1,103 @@
+---
+id: 2652
+title: "Standalone: parseInt/parseFloat must ToString a non-string primitive arg"
+status: done
+completed: 2026-06-25
+assignee: ttraenkler/agent-a2bb2065788d7244b
+sprint: 66
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: conformance
+area: number-parse
+language_feature: global-functions
+goal: standalone-mode
+parent: 2160
+related: [2600, 2644, 2648]
+---
+
+# #2652 — Standalone parseInt/parseFloat ToString of primitive arguments
+
+## Problem
+
+In `--target standalone` (and `--target wasi`), `parseInt(x)` / `parseFloat(x)`
+crashed with **`illegal cast in parseInt()`** whenever the argument `x` was a
+**non-string primitive** — a boolean, a number, `undefined`, or `null`. Per
+§19.2.5 step 1 / §19.2.4 step 1 the argument must first be run through
+`ToString`, then parsed:
+
+- `parseInt(true)` → `ToString(true)="true"` → no digits → `NaN`
+- `parseInt(-1)`   → `ToString(-1)="-1"`     → `-1`
+- `parseInt(undefined)` / `parseInt(null)` → `"undefined"` / `"null"` → `NaN`
+
+### Verified host-pass / standalone-fail (per-process, main `669600612e6`)
+
+| call (arg's own static type) | host | standalone (before) |
+|---|---|---|
+| `parseInt(true)` (boolean) | `NaN` | **illegal cast** (trap) |
+| `parseInt(-1)` (number) | `-1` | **illegal cast** (trap) |
+| `parseInt(undefined)` | `NaN` | **illegal cast** (trap) |
+| `parseFloat(true)` | `NaN` | **illegal cast** (trap) |
+| `parseFloat(undefined)` | `NaN` | **illegal cast** (trap) |
+
+A string arg (`parseInt("42")`, `parseInt("0x10")`) already worked.
+
+Test262 rows landed (host-pass / standalone-fail → pass):
+`built-ins/parseInt/S15.1.2.2_A1_T1` (boolean), `…_A1_T2` (number),
+`…_A1_T3` (undefined/null); `built-ins/parseFloat/S15.1.2.3_A1_T1` (boolean),
+`…_A1_T3` (undefined/null). **5 rows.**
+
+## Root cause
+
+The native `parseInt` / `parseFloat` helpers (`src/codegen/parse-number-native.ts`)
+have signature `(externref, f64) -> f64` and start by doing
+`local.get 0; any.convert_extern; ref.cast $AnyString` — i.e. they assume the
+externref argument already wraps a native string. In JS-host mode the `env`
+import does `String(arg)` itself, so a boxed boolean/number is fine. In
+standalone/WASI the call site (`src/codegen/expressions/calls.ts`, global
+`parseInt`/`parseFloat` arm) boxed a non-string primitive as
+boolean (`__box_boolean`) / number (`__box_number`) / a raw ref, which then
+failed the internal `ref.cast $AnyString` ("illegal cast").
+
+## Fix
+
+Two narrow, `noJsHost`-gated edits (host mode byte-for-byte unchanged):
+
+1. **`src/codegen/expressions/calls.ts`** (global parseInt/parseFloat arm): under
+   `ctx.standalone || ctx.wasi`, when the argument is a scalar (i32/f64/i64),
+   void, or a statically-`null`/`undefined`/`void`-typed externref, run it
+   through the existing native ToString engine `emitToString(...)` (the SAME
+   helper the `+`/template sites use: boolean→"true"/"false", numeric→
+   `number_toString`, null/undefined→literal) and hand the resulting native
+   string ref to the helper as an externref (`extern.convert_any` via
+   `coerceType`). A real string arg and a dynamic `any` wrapper object keep the
+   existing passthrough (the wrapper-object cases — Boolean/Number/String object
+   receivers, `…_A1_T4/T5/T6`, `…_A4/A5` — are the deferred wrapper substrate,
+   out of scope here).
+
+2. **`src/codegen/declarations.ts`** (parse import pre-scan): pre-register the
+   engine helpers/literals lowering will need so no late module-function shift
+   is forced mid-body — numeric arg → `number_toString`; boolean → "true"/"false";
+   undefined/void → "undefined"; null → "null".
+
+**Coercion engine reuse only** — `emitToString` / `coerceType`, no new
+hand-rolled ToString matrix. The `#2108 check:coercion-sites` baseline ticks
+`declarations.ts` 19→20 for the 13th instance of the already-sanctioned
+`primitiveNeeded.add("number_toString")` pre-registration pattern (refreshed).
+
+## Deferred (out of scope, noted for follow-up)
+
+- **`parseFloat(".01e+2")` string-exponent bug** — `built-ins/parseFloat/
+  S15.1.2.3_A1_T2` still fails in standalone, but on the **string-parsing** path
+  (`parseFloat(".01e+2")` returns the wrong value), a PRE-EXISTING native
+  parseFloat leading-dot-mantissa-with-positive-exponent bug independent of this
+  change. `parseFloat("1e2")` / `parseFloat(".5e1")` work.
+- Wrapper-object args (`new Boolean(true)`, `new Number(-1)`, `new String("-1")`,
+  and the `valueOf`/`toString` object cases A4/A5) — the deferred
+  builtin-wrapper-as-value / object→primitive substrate (#2160 / #2580 M2).
+
+## Test Results
+
+`tests/issue-2652.test.ts` — host + standalone + wasi all green. Per-process
+test262 re-scan of the parseInt/parseFloat lane (109 files): gaps 21 → 16
+(net **+5 rows**, 0 regressions).

--- a/scripts/coercion-sites-baseline.json
+++ b/scripts/coercion-sites-baseline.json
@@ -6,7 +6,7 @@
   "codegen/binary-ops.ts": 33,
   "codegen/class-to-primitive.ts": 1,
   "codegen/closed-method-dispatch.ts": 1,
-  "codegen/declarations.ts": 19,
+  "codegen/declarations.ts": 20,
   "codegen/expressions/assignment.ts": 12,
   "codegen/expressions/calls-closures.ts": 2,
   "codegen/expressions/calls.ts": 26,

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -538,6 +538,31 @@ export function unifiedVisitNode(ctx: CodegenContext, state: UnifiedCollectorSta
     }
     if (name === "parseInt" || name === "parseFloat") {
       state.parseNeeded.add(name);
+      // (#2652) In standalone / WASI the native parse helpers take a string ref;
+      // a NON-string primitive arg (`parseInt(true)` / `parseInt(-1)`) must be
+      // run through ToString at the call site (emitToString) BEFORE the call.
+      // Pre-register the helpers/literals that lowering needs so no late
+      // module-function shift is forced mid-body:
+      //   numeric arg  → `number_toString`
+      //   boolean arg  → "true"/"false" string literals (emitBoolToString)
+      //   void arg     → "undefined" literal
+      if ((ctx.standalone || ctx.wasi) && node.arguments.length >= 1) {
+        const arg0 = node.arguments[0]!;
+        const arg0Type = ctx.checker.getTypeAtLocation(arg0);
+        const isStr = isStringType(arg0Type);
+        if (!isStr) {
+          if (isBooleanType(arg0Type)) {
+            state.stringLiterals.add("true");
+            state.stringLiterals.add("false");
+          } else if (isNumberType(arg0Type)) {
+            state.primitiveNeeded.add("number_toString");
+          } else if (arg0Type.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void)) {
+            state.stringLiterals.add("undefined");
+          } else if (arg0Type.flags & ts.TypeFlags.Null) {
+            state.stringLiterals.add("null");
+          }
+        }
+      }
     }
     if (
       name === "decodeURI" ||

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -106,7 +106,7 @@ import {
   receiverMayBeNativeStringAtRuntime,
   typeErrorThrowInstrs,
 } from "../property-access.js";
-import { emitToNumber } from "../coercion-engine.js";
+import { emitToNumber, emitToString } from "../coercion-engine.js";
 import type { InnerResult } from "../shared.js";
 import { coerceType, compileExpression, valTypesMatch, VOID_RESULT } from "../shared.js";
 // (#2193 PR-B) reflective `m.call(thisArg, …)` on a `$NativeProto` member-closure value.
@@ -10920,9 +10920,43 @@ function compileCallExpression(
       const importFuncIdx = ctx.funcMap.get(funcName);
       if (importFuncIdx !== undefined) {
         const arg0 = expr.arguments[0]!;
+        // (#2652) §19.2.5 step 1 / §19.2.4 step 1: ToString(argument) BEFORE
+        // parsing. In standalone / WASI the native `parseInt` / `parseFloat`
+        // helpers take a string ref and immediately do `any.convert_extern;
+        // ref.cast $AnyString` on it — a NON-string primitive argument
+        // (`parseInt(true)`, `parseInt(-1)`) boxed as boolean/number tripped
+        // that cast ("illegal cast in parseInt()"). The JS-host imports do the
+        // `String(arg)` themselves, so host mode keeps its existing boxing path
+        // byte-for-byte. Here we run the SAME native ToString engine the `+` /
+        // template sites use (`emitToString`: boolean → "true"/"false", numeric
+        // → `number_toString`, void → "undefined") and hand the resulting
+        // native string ref to the helper as an externref. Only scalar
+        // (i32/f64/i64), void, and statically-`null`/`undefined` args take this
+        // path; a real string (externref / native ref) keeps the existing
+        // passthrough, and a dynamic externref wrapper object is left to the
+        // (separate, deferred) wrapper substrate.
+        const nativeParse = ctx.standalone || ctx.wasi;
+        const arg0TsType = ctx.checker.getTypeAtLocation(arg0);
         const arg0Type = compileExpression(ctx, fctx, arg0);
-        // Coerce to externref, preserving boolean identity (not boxing as number)
-        if (arg0Type && arg0Type.kind !== "externref") {
+        // A statically-typed `null`/`undefined`/`void` arg lowers to an externref
+        // but its ToString is the literal "null"/"undefined" — emitToString's
+        // externref arm handles it (it drops the ref and pushes the literal).
+        const isStaticNullish =
+          arg0Type?.kind === "externref" &&
+          !isStringType(arg0TsType) &&
+          (arg0TsType.flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined | ts.TypeFlags.Void)) !== 0 &&
+          (arg0TsType.flags & ts.TypeFlags.Any) === 0;
+        const isScalarArg = !arg0Type || arg0Type.kind === "i32" || arg0Type.kind === "f64" || arg0Type.kind === "i64";
+        if (nativeParse && (isScalarArg || isStaticNullish)) {
+          const strType = emitToString(ctx, fctx, arg0Type, arg0TsType, "string");
+          // emitToString returns a native `ref $AnyString` (native modes) — the
+          // helper wants an externref, so convert via `extern.convert_any`.
+          if (strType.kind !== "externref") {
+            coerceType(ctx, fctx, strType, { kind: "externref" });
+          }
+        } else if (arg0Type && arg0Type.kind !== "externref") {
+          // Host mode (or a native-string ref) — preserve the original boxing,
+          // which keeps boolean identity so the host `String(true)` → "true".
           if (
             arg0Type.kind === "i32" &&
             (arg0.kind === ts.SyntaxKind.TrueKeyword || arg0.kind === ts.SyntaxKind.FalseKeyword)

--- a/tests/issue-2652.test.ts
+++ b/tests/issue-2652.test.ts
@@ -1,0 +1,73 @@
+// #2652 — Standalone: parseInt / parseFloat must apply ToString to a non-string
+// primitive argument (§19.2.5 step 1 / §19.2.4 step 1) BEFORE parsing.
+//
+// In standalone / WASI the native `parseInt` / `parseFloat` helpers take a
+// string ref and immediately `any.convert_extern; ref.cast $AnyString` it. A
+// non-string primitive argument (`parseInt(true)`, `parseInt(-1)`,
+// `parseInt(undefined)`, `parseInt(null)`) was boxed as boolean/number/ref and
+// tripped that cast ("illegal cast in parseInt()"). The fix runs the argument
+// through the native ToString engine (`emitToString`) at the call site so the
+// helper receives a real string ref. Host mode is unchanged (the JS import does
+// `String(arg)` itself).
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(src: string, target?: "standalone" | "wasi"): Promise<unknown> {
+  const opts: Record<string, unknown> = { fileName: "test.ts" };
+  if (target) opts.target = target;
+  const r = await compile(src, opts);
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  const imports = buildImports(r.imports, undefined, r.stringPool, {});
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  return (instance.exports.test as () => unknown)();
+}
+
+// Each case returns a packed bitmask; the test passes iff every bit is set.
+//
+// The argument's OWN static type is what drives the ToString routing (the
+// compiler reads `getTypeAtLocation(arg0)`), exactly as in test262 where the
+// args are bare primitives. `parseInt`/`parseFloat` are redeclared with an
+// `any` parameter so TS does not coerce the arg node's type to `string` (which
+// would defeat the type-based routing — and is itself a type error in real TS,
+// but test262 runs the source loosely / with skipSemanticDiagnostics).
+const SRC = `
+declare function parseInt(s: any, radix?: number): number;
+declare function parseFloat(s: any): number;
+export function test(): number {
+  let r = 0;
+  // boolean primitive → ToString → "true"/"false" → NaN
+  if (Number.isNaN(parseInt(true))) r += 1;
+  if (Number.isNaN(parseInt(false))) r += 2;
+  // number primitive → ToString → "-1" / "255"
+  if (parseInt(-1) === parseInt("-1")) r += 4;
+  if (parseInt(255) === 255) r += 8;
+  // undefined / null → ToString → "undefined" / "null" → NaN
+  if (Number.isNaN(parseInt(undefined))) r += 16;
+  if (Number.isNaN(parseInt(null))) r += 32;
+  // parseFloat parity
+  if (Number.isNaN(parseFloat(true))) r += 64;
+  if (parseFloat(1.5) === 1.5) r += 128;
+  if (Number.isNaN(parseFloat(undefined))) r += 256;
+  // string args still parse correctly (no regression)
+  if (parseInt("0x10") === 16) r += 512;
+  if (parseFloat("3.14") === 3.14) r += 1024;
+  return r;
+}`;
+
+const ALL = 1 + 2 + 4 + 8 + 16 + 32 + 64 + 128 + 256 + 512 + 1024;
+
+describe("#2652 parseInt/parseFloat ToString of primitive args", () => {
+  it("host mode: all cases pass", async () => {
+    expect(await run(SRC)).toBe(ALL);
+  });
+
+  it("standalone mode: all cases pass (was: illegal cast)", async () => {
+    expect(await run(SRC, "standalone")).toBe(ALL);
+  });
+
+  it("wasi mode: all cases pass", async () => {
+    expect(await run(SRC, "wasi")).toBe(ALL);
+  });
+});


### PR DESCRIPTION
## Problem

In `--target standalone` / `--target wasi`, `parseInt(x)` / `parseFloat(x)` crashed with **`illegal cast in parseInt()`** when `x` was a **non-string primitive** — boolean, number, `undefined`, or `null`. Per §19.2.5 step 1 / §19.2.4 step 1 the argument must first be run through `ToString`, then parsed.

Verified host-pass / standalone-fail on main `669600612e6`:
| call | host | standalone (before) |
|---|---|---|
| `parseInt(true)` | `NaN` | illegal cast (trap) |
| `parseInt(-1)` | `-1` | illegal cast (trap) |
| `parseInt(undefined)` / `parseInt(null)` | `NaN` | illegal cast (trap) |
| `parseFloat(true)` / `parseFloat(undefined)` | `NaN` | illegal cast (trap) |

A string arg (`parseInt("42")`, `parseInt("0x10")`) already worked.

## Root cause

The native `parseInt`/`parseFloat` helpers (`parse-number-native.ts`, sig `(externref, f64) -> f64`) start by `local.get 0; any.convert_extern; ref.cast $AnyString` — they assume the externref already wraps a native string. In JS-host mode the `env` import does `String(arg)` itself; in standalone/wasi the call site boxed a non-string primitive as boolean/number/ref, which then failed the internal `ref.cast $AnyString`.

## Fix (noJsHost-gated; host mode byte-for-byte unchanged)

- **`calls.ts`** (global parseInt/parseFloat arm): under `ctx.standalone || ctx.wasi`, route a scalar (i32/f64/i64), void, or statically-`null`/`undefined` externref arg through the existing native ToString engine `emitToString(...)` (boolean→"true"/"false", numeric→`number_toString`, null/undefined→literal) and hand the native string ref to the helper as an externref. Real-string and dynamic-`any`-wrapper args keep the existing passthrough (wrapper-object cases are the deferred #2160/#2580-M2 substrate).
- **`declarations.ts`** (parse import pre-scan): pre-register the engine helpers/literals lowering needs so no late module-function shift is forced mid-body.

**Coercion-engine reuse only** (`emitToString`/`coerceType`) — no new hand-rolled ToString matrix. The #2108 `check:coercion-sites` baseline ticks `declarations.ts` 19→20 for the 13th instance of the already-sanctioned `number_toString` pre-registration pattern (refreshed).

## Results

- Lands **5 test262 rows**: `parseInt/S15.1.2.2_A1_T1` (boolean), `…_A1_T2` (number), `…_A1_T3` (undefined/null); `parseFloat/S15.1.2.3_A1_T1` (boolean), `…_A1_T3` (undefined/null).
- Per-process re-scan of the parseInt/parseFloat lane (109 files): gaps **21 → 16** (net +5, 0 regressions).
- `tests/issue-2652.test.ts` — host + standalone + wasi all green; existing parse/number suite (31 tests) green.
- Full local quality chain green: lint, typecheck, ir-fallbacks, stack-balance, codegen-fallbacks, any-box-sites, speculative-rollback, coercion-sites, issues, issue-ids:against-main.

### Deferred (out of scope, noted in issue)
- `parseFloat(".01e+2")` string-exponent value bug (pre-existing native-parse bug, not this change).
- Wrapper-object args (`new Boolean/Number/String(...)`, valueOf/toString objects) — the deferred builtin-wrapper-as-value / object→primitive substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQU9VNednk2RVEaLLy2fJA