### PR TITLE
feat(host-interop): #2647 plumb --allow-fs into no-provider gate

### DIFF
--- a/plan/issues/2647-plumb-allow-fs-into-no-provider-gate.md
+++ b/plan/issues/2647-plumb-allow-fs-into-no-provider-gate.md
@@ -1,9 +1,10 @@
 ---
 id: 2647
 title: "Plumb --allow-fs into the node:fs no-provider capability gate (P2-a.0) — unhardcode allowFs:false"
-status: backlog
+status: done
 created: 2026-06-24
 updated: 2026-06-24
+completed: 2026-06-24
 priority: low
 feasibility: low
 reasoning_effort: low
@@ -52,3 +53,20 @@ the flag plumbing is missing.
 
 - A full WASI filesystem backend (preopens) — that is a separate, larger tier.
 - The capability gate itself (#1772 P2-a, landed).
+
+## Resolution (2026-06-24)
+
+The `--allow-fs` flag was already fully plumbed CLI → `compile()` options →
+`ctx.allowFs` (declared on `CodegenContext` in
+`src/codegen/context/types.ts`, set in
+`src/codegen/context/create-context.ts`). The only missing piece was the
+hardcoded `false` in the gate. Single-line change in
+`src/codegen/node-fs-api.ts::tryCompileNodeFsCall`:
+`{ wasi: ctx.wasi, allowFs: false }` → `{ wasi: ctx.wasi, allowFs: ctx.allowFs }`.
+
+With `--allow-fs` the capability map's `providersFor` yields `["js-host-fs"]`
+for path-based members → satisfiable → the #1772 gate is a no-op. Without it
+the precise "no provider under --target wasi" error still fires. fd-based
+`readSync`/`writeSync` are satisfiable regardless. Coverage in
+`tests/issue-2647.test.ts` (flag toggled both ways, byte-neutral for a non-fs
+program when unset).

--- a/src/codegen/node-fs-api.ts
+++ b/src/codegen/node-fs-api.ts
@@ -259,7 +259,14 @@ export function tryCompileNodeFsCall(
     const importedFromNodeFs =
       ctx.wasiNodeFsFuncs.has(member) && !fctx.localMap.has(member) && !(fctx.boxedCaptures?.has(member) ?? false);
     if (importedFromNodeFs && isKnownMember("node:fs", member)) {
-      const target = { wasi: ctx.wasi, allowFs: false };
+      // #2647 — thread the real `--allow-fs` flag (was hardcoded `false` in the
+      // atomic #1772 P2-a slice, PR #2014). With `--allow-fs` under a JS host, a
+      // path-based `node:fs` member (`readFileSync(path)`) resolves through the
+      // `js-host-fs` provider and becomes satisfiable; without it the precise
+      // "no provider under --target wasi" error still fires. fd-based
+      // `readSync`/`writeSync` are satisfiable regardless (providersFor →
+      // ["wasi-fd"]), so this is a no-op for them.
+      const target = { wasi: ctx.wasi, allowFs: ctx.allowFs };
       if (isMemberSatisfiable("node:fs", member, target) === false) {
         ctx.errors.push({
           message:

--- a/tests/issue-2647.test.ts
+++ b/tests/issue-2647.test.ts
@@ -1,0 +1,103 @@
+// #2647 (P2-a.0) — plumb `--allow-fs` into the #1772 no-provider capability gate.
+//
+// PR #2014 landed the #1772 P2-a "no provider" gate in
+// `src/codegen/node-fs-api.ts::tryCompileNodeFsCall` with `allowFs` HARDCODED
+// `false` to keep the slice atomic. So even when the JS-host filesystem provider
+// is available, a path-based `node:fs` member (`readFileSync(path)`) under
+// `--target wasi` always errored.
+//
+// This slice threads the real `--allow-fs` flag (already plumbed CLI → opts →
+// `ctx.allowFs`) into the gate's capability query:
+//   - WITH `allowFs: true`, the capability map's `providersFor` yields
+//     `["js-host-fs"]`, so a path-based member is satisfiable → the gate is a
+//     no-op (compiles green).
+//   - WITHOUT it, the precise #1772 "no provider under --target wasi" error still
+//     fires.
+//   - fd-based `readSync`/`writeSync` are satisfiable regardless of the flag.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const NO_PROVIDER_RE = /needs a filesystem provider, unavailable under `--target wasi`/;
+
+const readFileSyncSrc = `
+import { readFileSync } from "node:fs";
+export function main(): void {
+  const data = readFileSync("/etc/hostname");
+}
+`;
+
+describe("#2647 — plumb --allow-fs into the node:fs no-provider gate", () => {
+  it("WITHOUT --allow-fs, the #1772 no-provider error still fires under --target wasi", async () => {
+    const result = await compile(readFileSyncSrc, {
+      fileName: "x.ts",
+      target: "wasi",
+      linkNodeShims: true,
+    });
+    expect(result.success).toBe(false);
+    const msgs = (result.errors ?? []).map((e) => e.message).join("\n");
+    expect(msgs).toMatch(NO_PROVIDER_RE);
+    expect(msgs).toMatch(/readFileSync/);
+    expect(msgs).toMatch(/--allow-fs/);
+  });
+
+  it("WITH --allow-fs (allowFs: true), a path-based readFileSync(path) is satisfiable — no no-provider error", async () => {
+    const result = await compile(readFileSyncSrc, {
+      fileName: "x.ts",
+      target: "wasi",
+      linkNodeShims: true,
+      allowFs: true,
+    });
+    // The capability map resolves the path-based member through the `js-host-fs`
+    // provider, so the gate is a no-op — the precise #1772 error must NOT appear.
+    const msgs = (result.errors ?? []).map((e) => e.message).join("\n");
+    expect(msgs).not.toMatch(NO_PROVIDER_RE);
+  });
+
+  it("the flag toggles the gate WITHOUT --link-node-shims too (gate keys off --target wasi)", async () => {
+    // allowFs off → error fires.
+    const off = await compile(readFileSyncSrc, { fileName: "x.ts", target: "wasi" });
+    const offMsgs = (off.errors ?? []).map((e) => e.message).join("\n");
+    expect(offMsgs).toMatch(NO_PROVIDER_RE);
+
+    // allowFs on → gate is a no-op.
+    const on = await compile(readFileSyncSrc, { fileName: "x.ts", target: "wasi", allowFs: true });
+    const onMsgs = (on.errors ?? []).map((e) => e.message).join("\n");
+    expect(onMsgs).not.toMatch(NO_PROVIDER_RE);
+  });
+
+  it("fd-based readSync/writeSync compile green regardless of --allow-fs", async () => {
+    const src = `
+import { readSync, writeSync } from "node:fs";
+export function main(): void {
+  const buf = new Uint8Array(4);
+  const r = readSync(0, buf, { offset: 0, length: 4 });
+  let n = 0;
+  while (n < r) { const w = writeSync(1, buf, n); if (w <= 0) break; n = n + w; }
+}
+`;
+    for (const allowFs of [false, true]) {
+      const result = await compile(src, {
+        fileName: "x.ts",
+        target: "wasi",
+        linkNodeShims: true,
+        allowFs,
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("is byte-neutral for a non-fs program when --allow-fs is toggled", async () => {
+    // A program that never touches node:fs must compile to identical bytes with
+    // and without --allow-fs — the flag only gates the node:fs path-based members.
+    const src = `
+export function add(a: number, b: number): number {
+  return a + b;
+}
+`;
+    const off = await compile(src, { fileName: "x.ts", target: "wasi" });
+    const on = await compile(src, { fileName: "x.ts", target: "wasi", allowFs: true });
+    expect(off.success).toBe(true);
+    expect(on.success).toBe(true);
+    expect(Buffer.from(on.binary!)).toEqual(Buffer.from(off.binary!));
+  });
+});


### PR DESCRIPTION
## #2647 (P2-a.0) — plumb `--allow-fs` into the node:fs no-provider capability gate

The #1772 Phase 2 no-provider gate (PR #2014, in
`src/codegen/node-fs-api.ts::tryCompileNodeFsCall`) called
`isMemberSatisfiable("node:fs", member, { wasi: ctx.wasi, allowFs: false })`
with **`allowFs` hardcoded `false`** to keep that slice atomic. So a path-based
`node:fs` member (`readFileSync(path)`) under `--target wasi` always errored —
even when the JS-host filesystem provider was available.

### Change

The `--allow-fs` flag was already fully plumbed CLI → `compile()` options →
`ctx.allowFs` (`CodegenContext` field in `src/codegen/context/types.ts`, set in
`create-context.ts`). The only missing piece was the gate's hardcoded `false`:

```diff
-      const target = { wasi: ctx.wasi, allowFs: false };
+      const target = { wasi: ctx.wasi, allowFs: ctx.allowFs };
```

With `--allow-fs`, the capability map's `providersFor` yields `["js-host-fs"]`
for path-based members → satisfiable → the gate is a no-op (compiles green).
Without it, the precise #1772 "no provider under `--target wasi`" error still
fires. fd-based `readSync`/`writeSync` are satisfiable regardless (providersFor
→ `["wasi-fd"]`), so this is a no-op for them.

### Validation

`tests/issue-2647.test.ts` (5 cases):
- WITHOUT `--allow-fs`: the #1772 no-provider error still fires (names member + `--allow-fs` + `--target wasi`).
- WITH `allowFs: true`: path-based `readFileSync(path)` is satisfiable — no no-provider error.
- Flag toggles the gate WITHOUT `--link-node-shims` too.
- fd-based `readSync`/`writeSync` compile green regardless of the flag.
- **Byte-neutral** for a non-fs program when the flag is toggled.

tsc clean, biome lint clean, prettier-formatted.

Sets #2647 `status: done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)