### PR TITLE
docs(plan): #2646 blocked on binaryen asyncify-GC gap + file reactor single-tick follow-up

### DIFF
--- a/plan/issues/2646-edgejs-asyncify-incremental-stdin-loop-borrow.md
+++ b/plan/issues/2646-edgejs-asyncify-incremental-stdin-loop-borrow.md
@@ -1,9 +1,9 @@
 ---
 id: 2646
 title: "edge.js async stdin: true incremental loop-borrow via asyncify (P3-d) — suspend poll_oneoff instead of pre-draining to EOF"
-status: backlog
+status: blocked
 created: 2026-06-24
-updated: 2026-06-24
+updated: 2026-06-25
 priority: low
 feasibility: hard
 reasoning_effort: high
@@ -13,10 +13,11 @@ language_feature: node-api-compat
 goal: platform
 sprint: Backlog
 es_edition: n/a
-depends_on: [2635]
-related: [2635, 2632, 1772]
+depends_on: [2653]
+related: [2635, 2632, 1772, 2653]
 origin: "Slice P3-d of the #2635 async dual-provider proof (arch-capstone scoping, 2026-06-24). A `P3-d SEAM` marker comment was left in examples/native-messaging/edge.js where this slots in. Deferred as a fidelity follow-up — the basic proof (#2635, PR #2012) used mechanism 2."
 ---
+
 # #2646 — edge.js incremental loop-borrow via asyncify (P3-d)
 
 ## Problem
@@ -27,11 +28,11 @@ edge.js (native Node). But it used **mechanism 2 (pre-drain)**: edge.js `await`s
 Node's `process.stdin` to `'end'`, collecting ALL bytes, THEN calls `_start()` so
 every `poll_oneoff` finds data/EOF immediately and never truly blocks.
 
-This is correct for batch input but is NOT a *true* incremental loop-borrow: an
+This is correct for batch input but is NOT a _true_ incremental loop-borrow: an
 interactive/streaming program (one that should react to each line as it arrives,
 or never sees EOF) cannot be driven by pre-draining. The wasm reactor's `_start`
 is a synchronous `poll_oneoff`-blocking loop, while Node's stdin is async — so to
-borrow Node's loop incrementally, the wasm stack must be able to *suspend* at
+borrow Node's loop incrementally, the wasm stack must be able to _suspend_ at
 `poll_oneoff` and resume on the next `'data'` tick.
 
 ## Scope
@@ -42,7 +43,7 @@ borrow Node's loop incrementally, the wasm stack must be able to *suspend* at
 - Extend `createNodeStdinWasiProvider` in `examples/native-messaging/edge.js`
   (the `P3-d SEAM` marker) to drive the asyncify unwind/rewind around the async
   stdin queue, replacing the pre-drain.
-- Prove an *interactive/streaming* program (reacts per-chunk, no up-front EOF)
+- Prove an _interactive/streaming_ program (reacts per-chunk, no up-front EOF)
   runs under edge.js with the same observable behavior as wasmtime.
 
 ## Acceptance
@@ -58,3 +59,80 @@ borrow Node's loop incrementally, the wasm stack must be able to *suspend* at
 
 - The batch dual-provider proof (#2635, landed).
 - The WASI/wasmtime arm (already incremental via native `poll_oneoff`).
+
+## Investigation (2026-06-24)
+
+**Status → `blocked`.** The asyncify mechanism this issue is scoped around is
+**not viable on our WasmGC reactor binary** with any available Binaryen. The
+architecture is otherwise sound (single suspend point, wasmtime + wasm-opt
+present, asyncify works fine on plain non-GC modules), so this is parked behind
+a Binaryen capability, not closed.
+
+### Root cause — Binaryen asyncify fake-call-global name collision on GC refs
+
+`wasm-opt --asyncify` aborts on the compiled `--target wasi` `process.stdin`
+reactor binary with a **fatal** error during its own pre-scan, before emitting
+anything:
+
+```
+Fatal: Module::addGlobal: asyncify_fake_call_global_(ref null $struct.0) already exists
+```
+
+Why: asyncify creates one "fake-call global" per **function type that returns a
+GC reference** (used to model indirect/`call_ref` returns across a suspend), but
+it **names that global solely by the result type's _printed_ name**. Our
+string/closure helper ABI exports **10+ distinct function types that all return
+`(ref null $1)`** — e.g. the `__str_*` helpers and the closure-dispatch
+trampolines (types `$25 $34 $35 $40 $42 $43 $57 $59` in the binary's type
+section, all `… (result (ref null $1))`). The first such type creates the
+global; the second collides on the identical generated name → `addGlobal`
+aborts. The globals are created in asyncify's analysis phase **before** any
+list/scope filter is consulted, so no pass-arg can avoid them.
+
+### Exhaustively ruled out (none work)
+
+- **Every Binaryen version available**: 123, 125 (current dep), and 130 (latest)
+  — all abort with the identical fatal.
+- **Both optimizer backends** that `src/optimize.ts` uses: the `wasm-opt` CLI
+  _and_ the in-process `binaryen` JS-module API (`mod.runPasses(["asyncify"])`)
+  — identical fatal in each.
+- **Every asyncify scoping pass-arg**:
+  `--pass-arg=asyncify-imports@wasi_snapshot_preview1.poll_oneoff` (scope to the
+  single real suspend point),
+  `--pass-arg=asyncify-onlylist@_start,__run_event_loop,__rl_poll_fd0_or_clock`
+  (the entire direct call path), and `--pass-arg=asyncify-ignore-indirect` — none
+  help, because the colliding globals are created before the filter applies.
+- **DCE the colliding helpers first**: they are part of the module's **exported
+  public ABI** (`__sget_*`, `__vec_*`, `__call_fn_*`, `__str_*` — 20 exports), so
+  `--remove-unused-module-elements` keeps them; and `-O2` (which might prune more)
+  independently aborts on this WasmGC module with a separate
+  `Assertion failed: canMakeZero(type)` (`makeZero`) — the same class of
+  WasmGC-immaturity our optimize pipeline already validates-and-falls-back around.
+
+The single blocking suspend point is confirmed: `_start` → `__run_event_loop`
+(`buildRunLoopBodyWithFdReactor`, `src/codegen/async-scheduler.ts`) →
+`__rl_poll_fd0_or_clock` → imported `poll_oneoff`. Asyncify around exactly that
+import is the clean classic shape; it is blocked **only** by the GC-ref global
+naming bug, not by anything in our reactor design.
+
+> Note: the upstream Binaryen limitation is documented **here, in our own issue,
+> only.** No external Binaryen issue was filed (that needs explicit user
+> consent we do not have). The #2635 batch pre-drain proof was re-run on this
+> branch and still passes 4/4 — the shipped mechanism-2 path is unaffected.
+
+### Two unblock paths
+
+1. **Upstream Binaryen fix** — asyncify should dedup the fake-call global **by
+   the function type itself, not by the result type's printed name** (reusing the
+   one global already created for that result type). When a Binaryen release
+   carries this fix, re-attempt the scoped (`asyncify-imports@…poll_oneoff`) build
+   and resume the original P3-d plan unchanged.
+2. **Non-asyncify reactor single-tick refactor (#2653)** — refactor the #2632
+   reactor codegen (`src/codegen/async-scheduler.ts buildRunLoopBodyWithFdReactor`)
+   to expose a re-entrant **single-tick** export ("process available bytes, return
+   if it would block") that `edge.js` drives per `process.stdin` `'data'` event.
+   This reaches true interactive streaming **without** asyncify and is therefore
+   independent of the Binaryen bug. Tracked as #2653 (`depends_on`).
+
+Either path unblocks this issue; pre-drain (#2635) remains the correct shipped
+mechanism for batch input in the meantime.

--- a/plan/issues/2653-reactor-single-tick-reentrant-export.md
+++ b/plan/issues/2653-reactor-single-tick-reentrant-export.md
@@ -1,0 +1,108 @@
+---
+id: 2653
+title: "reactor single-tick re-entrant export — non-asyncify interactive streaming stdin (drive the #2632 loop per process.stdin 'data')"
+status: backlog
+created: 2026-06-25
+updated: 2026-06-25
+priority: low
+feasibility: hard
+reasoning_effort: high
+task_type: feature
+area: codegen
+language_feature: node-api-compat
+goal: platform
+sprint: Backlog
+es_edition: n/a
+related: [2646, 2632, 2635]
+origin: "Spun off from #2646's investigation (2026-06-24): wasm-opt --asyncify cannot transform our WasmGC reactor binary (Binaryen fake-call-global GC-ref name collision, all of binaryen 123/125/130, both backends). This is the non-asyncify path to the same goal — true incremental loop-borrow — that does NOT depend on the Binaryen bug."
+---
+
+# #2653 — reactor single-tick re-entrant export (non-asyncify interactive streaming stdin)
+
+## Problem
+
+The #2632 async event-loop reactor lowers a `--target wasi` `process.stdin`
+program's `_start` into a **synchronous** run loop
+(`buildRunLoopBodyWithFdReactor` in `src/codegen/async-scheduler.ts`) that blocks
+at a single suspend point — `__rl_poll_fd0_or_clock` → the imported
+`poll_oneoff` — and runs to completion in one call. Under wasmtime that is fine
+(native `poll_oneoff` genuinely blocks on fd0). Under native Node (`edge.js`,
+`createNodeStdinWasiProvider`) it cannot block, because the bytes only arrive on
+future JS event-loop ticks. The shipped batch mechanism is **pre-drain** (#2635,
+landed): collect ALL stdin to EOF first, then call `_start()` so every
+`poll_oneoff` finds data/EOF immediately. That is correct for batch but is NOT a
+_true_ incremental loop-borrow — an interactive/streaming program (reacts
+per-line, flushes before EOF, or never sees EOF) cannot be driven by pre-draining.
+
+The asyncify approach (#2646) — instrument the wasm so `_start` suspends at
+`poll_oneoff` and resumes on the next `'data'` tick — is **blocked**: `wasm-opt
+--asyncify` aborts on our WasmGC reactor binary with a Binaryen fake-call-global
+GC-ref name collision (`asyncify_fake_call_global_(ref null $struct.0) already
+exists`), reproduced on binaryen 123/125/130 and on both the CLI and in-process
+backends, with no scoping pass-arg able to avoid it. See #2646's
+`## Investigation (2026-06-24)` for the full root cause.
+
+## Scope
+
+Provide a **non-asyncify** path to interactive streaming stdin by making the
+reactor run loop **re-entrant**: instead of one blocking `_start` that loops on
+`poll_oneoff` to completion, expose a **single-tick** entry point that the host
+drives once per `process.stdin` `'data'`/`'end'` event.
+
+- Refactor `buildRunLoopBodyWithFdReactor` (`src/codegen/async-scheduler.ts`) so
+  the loop body can be invoked as **one tick**: drain whatever bytes are
+  currently available, run the registered reader/pump + due timers + microtasks,
+  and **return a status** ("more work pending" vs "done") instead of blocking on
+  `poll_oneoff` when fd0 would block. The tick must NOT call the blocking
+  `poll_oneoff` itself — readiness is decided by the host, which only invokes the
+  tick when fd0 is readable or a timer is due.
+- Expose this as an export (e.g. `__reactor_tick() -> i32`, returning whether the
+  reactor still has live subscriptions/timers) alongside the existing `_start`,
+  preserving the reactor's internal state (buffers, timer table, microtask queue,
+  fd0-active flag) across calls. The WasmGC reactor state already lives in module
+  globals, so re-entrancy is a matter of splitting the loop, not adding a stack
+  machine.
+- Drive it from `edge.js` (`createNodeStdinWasiProvider`, the `P3-d SEAM`): on
+  each `process.stdin` `'data'` chunk, enqueue the bytes and call
+  `__reactor_tick()`; on `'end'`, mark EOF and tick until the reactor reports
+  no pending work. This replaces pre-drain for the interactive path while
+  keeping pre-drain available for batch.
+- Preserve byte-for-byte agreement with the wasmtime arm: the SAME program, fed
+  the SAME bytes incrementally, must produce the SAME output as
+  `wasmtime run <user.wasm>` (which uses the blocking `_start`). The reactor's
+  per-tick semantics must be a faithful decomposition of the blocking loop.
+
+## Acceptance
+
+- An interactive `process.stdin` program (e.g. echo-per-line that flushes a
+  result on each newline, before EOF) runs under `edge.js` via the single-tick
+  re-entrant export, reacting per-chunk **without** pre-draining to EOF first,
+  and produces output observably matching the wasmtime arm.
+- The existing mechanism-2 batch proof (#2635) still passes (no regression);
+  pre-drain remains available for batch input.
+- `_start` (the blocking, run-to-completion entry) is unchanged for the
+  wasmtime/standalone path — the single-tick export is additive.
+
+## Out of scope
+
+- The asyncify approach (#2646) — this is the independent, Binaryen-bug-free
+  alternative. If a future Binaryen fixes the GC-ref fake-call-global collision,
+  #2646's scoped-asyncify path becomes viable again; the two are alternatives.
+- The batch dual-provider proof (#2635, landed) — pre-drain stays the shipped
+  correct mechanism for batch input.
+- The WASI/wasmtime arm — already incremental via native blocking `poll_oneoff`.
+
+## Notes
+
+- Single suspend point confirmed: `_start` → `__run_event_loop`
+  (`buildRunLoopBodyWithFdReactor`) → `__rl_poll_fd0_or_clock` → imported
+  `poll_oneoff` (`src/codegen/async-scheduler.ts`). The refactor splits the
+  `loop`/`block` tick body so one iteration can run host-driven, replacing the
+  internal blocking poll with a host-decided readiness gate.
+- All reactor state (stdin buffer, timer table, microtask queue, fd0-active
+  flag) is already in module globals, so re-entrancy needs no asyncify-style
+  stack save/restore — this is precisely why it sidesteps the Binaryen bug.
+- Provider seam: `examples/native-messaging/edge.js` `createNodeStdinWasiProvider`
+  and its `run-edge-stdin.mjs` runner; tests in
+  `tests/issue-2635-async-dual-provider.test.ts` are the dual-provider harness to
+  extend.


### PR DESCRIPTION
Docs-only bookkeeping for #2646 (edge.js incremental asyncify stdin loop-borrow).

## Why
Senior-dev feasibility investigation found `wasm-opt --asyncify` cannot transform our `--target wasi` WasmGC reactor binary — a real **Binaryen capability gap**, not a wiring miss:

```
Fatal: Module::addGlobal: asyncify_fake_call_global_(ref null $struct.0) already exists
```

Asyncify names its per-type fake-call globals **solely by the GC result-type's printed name**, and our string/closure helper ABI exports **10+ distinct function types all returning `(ref null $1)`** (`__str_*`, closure-dispatch trampolines). The 2nd collides → fatal, fired in asyncify's pre-scan **before** any onlylist/removelist/imports filter, so no scoping pass-arg avoids it.

Ruled out exhaustively: binaryen **123 / 125 (current) / 130 (latest)**; both the `wasm-opt` CLI **and** the in-process `binaryen` JS-module backend; all asyncify scoping pass-args; DCE-first (helpers are exported ABI; `-O2` separately hits a `makeZero` GC assertion). Full root cause + matrix is in #2646's `## Investigation` section.

The #2635 batch pre-drain proof was re-run and still passes 4/4 — the shipped mechanism is unaffected.

## Changes (docs/plan only)
- **`plan/issues/2646-…md`**: `status: blocked`; new `## Investigation (2026-06-24)` with the conclusive root cause and the two unblock paths (an upstream Binaryen fix; or #2653); `depends_on: [2653]`. Upstream Binaryen limitation documented **in our issue only** — no external Binaryen issue filed (needs explicit user consent we don't have).
- **`plan/issues/2653-…md`** (new, id from `claim-issue.mjs --allocate`): the **non-asyncify** path — refactor the #2632 reactor (`buildRunLoopBodyWithFdReactor`) to expose a re-entrant **single-tick** export that edge.js drives per `process.stdin` `'data'` event, reaching interactive streaming independent of the Binaryen bug.

Pre-drain (#2635) remains the shipped correct mechanism for batch input; this is purely the interactive-streaming follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)