### PR TITLE
feat(wasi): #2655 direct WASI P1 fd_read/fd_write for node:fs readSync/writeSync (no shim)

### DIFF
--- a/examples/native-messaging/nm_js2wasm.ts
+++ b/examples/native-messaging/nm_js2wasm.ts
@@ -1,20 +1,30 @@
 // Native Messaging host, compiled to standalone WASI by js2wasm.
 //
-//   npx js2wasm examples/native-messaging/nm_js2wasm.ts --target wasi --link-node-shims -o out
+//   npx js2wasm examples/native-messaging/nm_js2wasm.ts --target wasi -o out
+//
+// `--target wasi` ALONE (no `--link-node-shims`) emits a SELF-CONTAINED WASI
+// Preview-1 command module: it imports ONLY `wasi_snapshot_preview1` (fd_read /
+// fd_write), owns + exports its own `memory`, and runs directly under a WASI
+// host such as wasmtime — no node:fs shim, no Node runtime (#2655). This is the
+// loopdive/js2#389 reporter's exact use case: a host that runs under a WASI host,
+// explicitly "not chasing Node.js".
 //
 // This source uses REAL Node fd-based synchronous IO — `fs.readSync(fd, …)` /
-// `fs.writeSync(fd, …)` from `node:fs` — so the SAME file (a) compiles via
-// js2wasm to standalone WASI AND (b) runs UNMODIFIED under real `node`. The
-// earlier version used `process.stdin.read(buffer, offset)`, which matches NO
-// real Node API: `process.stdin` is an async Duplex stream with no synchronous
-// buffer-filling `read`. `fs.readSync` / `fs.writeSync` are the faithful
-// synchronous primitives (this is also what Javy uses: `Javy.IO.readSync`).
-// See loopdive/js2#389.
+// `fs.writeSync(fd, …)` from `node:fs` — so the SAME file ALSO runs UNMODIFIED
+// under real `node`. The earlier version used `process.stdin.read(buffer,
+// offset)`, which matches NO real Node API: `process.stdin` is an async Duplex
+// stream with no synchronous buffer-filling `read`. `fs.readSync` /
+// `fs.writeSync` are the faithful synchronous primitives (this is also what Javy
+// uses: `Javy.IO.readSync`).
 //
-// `readSync(0,…)` / `writeSync(1,…)` / `writeSync(2,…)` are fd-based (integer fd
-// 0=stdin, 1=stdout, 2=stderr), NOT path-based — no filesystem involved. Under
-// js2wasm they lower to imported `node:fs` shim calls (`node-fs.wat`, which maps
-// them to WASI fd_read / fd_write); under real node they call the real fs.
+//   npx js2wasm examples/native-messaging/nm_js2wasm.ts --target wasi --link-node-shims -o out
+//
+// is the VARIANT that lowers the same calls to imported `node:fs` shim calls
+// (`node-fs.wat`, which maps them to WASI fd_read / fd_write) — useful when the
+// same binary should link against an external `node:fs` provider rather than
+// owning the syscalls itself. Either way `readSync(0,…)` / `writeSync(1,…)` /
+// `writeSync(2,…)` are fd-based (integer fd 0=stdin, 1=stdout, 2=stderr), NOT
+// path-based — no filesystem involved; under real node they call the real fs.
 //
 // Native Messaging protocol frames each message as a 4-byte little-endian length
 // prefix followed by a UTF-8 **JSON** body, exchanged over the host process's

--- a/plan/issues/2655-direct-wasi-p1-readsync-writesync.md
+++ b/plan/issues/2655-direct-wasi-p1-readsync-writesync.md
@@ -1,0 +1,107 @@
+---
+id: 2655
+title: Direct WASI Preview-1 fd_read/fd_write for node:fs readSync/writeSync (no shim)
+status: done
+completed: 2026-06-25
+assignee: ttraenkler/sendev-wasi
+area: host-interop
+language_feature: node-api-compat
+goal: platform
+related: [389, 2631, 2633, 2632, 2639]
+feasibility: medium
+sprint: Backlog
+---
+
+# Direct WASI P1 fd_read/fd_write for node:fs readSync/writeSync (no shim)
+
+## Problem
+
+A stdio program that uses `node:fs` fd-based `readSync(0, …)` / `writeSync(1, …)`
+currently can only reach WASI by way of the imported `node:fs` shim
+(`--link-node-shims`). `src/codegen/node-fs-api.ts` `tryCompileNodeFsCall` has a
+blanket `if (!ctx.linkNodeShims) return undefined;` so fd-based readSync/writeSync
+ONLY lower via the shim. There is no direct
+`wasi_snapshot_preview1.fd_read`/`fd_write` lowering.
+
+This blocks the loopdive/js2 **#389** reporter's use case: a Native Messaging host
+that runs directly under a WASI host (wasmtime), explicitly "not chasing Node.js".
+They want a **self-contained WASI P1 command module** that imports ONLY
+`wasi_snapshot_preview1` — no node:fs shim, no Node runtime.
+
+Note: the WRITE side already has precedent — `process.stdout/stderr.write` lowers
+directly to `fd_write` when shims are off (the `ensureWasiWrite*Helper` family
+routes through `emitWasiWriteTail`, which branches on `ctx.linkNodeShims`). The
+READ side is the genuinely new work.
+
+## Approach
+
+Generalize `emitNodeFsReadSync`/`emitNodeFsWriteSync` to take the target funcidx +
+a "direct vs shim" mode. In `tryCompileNodeFsCall`, under `ctx.wasi`, lower
+fd-based readSync/writeSync via EITHER:
+- the shim (`ctx.linkNodeShims`: existing `nodeFsReadSyncIdx`/`nodeFsWriteSyncIdx`,
+  signature `(fd,ptr,len) -> i32`), OR
+- the direct WASI path (`!ctx.linkNodeShims`: `ctx.wasiFdReadIdx`/`ctx.wasiFdWriteIdx`,
+  the 4-arg `(fd, iovs, iovs_len, out) -> errno` syscalls).
+
+**readSync direct path** — blocking, NO reactor/poll_oneoff (the native-messaging
+host uses synchronous readSync, not the async stdin reactor): set up an iovec
+`{ base = bufPtr+offset, len = length }` + an `nread` out-slot in a fixed page-0
+linear-memory scratch (`WASI_READSYNC_IOV_OFFSET` / `WASI_READSYNC_NREAD_OFFSET`,
+chosen above the reactor's 160–336 region and below the 1024 string-data base so it
+collides with neither the write scratch nor the reactor). For a linear-backed
+Uint8Array the iovec base points straight at `ptr+offset` (zero-copy). For a GC
+Uint8Array read into the page-1 `WASI_STDIN_BUF_START` scratch then copy out
+(reusing `emitScratchToArrayCopy`). Call `fd_read(fd, iov, 1, nread)`, load nread,
+return as f64 (matching the shim path's `(fd,ptr,len) -> bytesRead` contract).
+
+**writeSync direct path** — route the buffer/string/DataView arms through the
+existing `ensureWasiWrite*Helper` + `ctx.wasiFdWriteIdx` machinery (the same
+`process.std*.write` uses), instead of the shim funcidx. Because `emitWasiWriteTail`
+already branches on `ctx.linkNodeShims`, the GC/linear/string/DataView helpers
+already emit `fd_write` directly when shims are off — so the writeSync direct path
+mostly needs the funcidx selection (`wasiFdWriteIdx` vs `nodeFsWriteSyncIdx`) and to
+keep its `(fd,ptr,len)` calls in the linear/zero-copy arm correct.
+
+**Import wiring** — `needsFdRead` is currently only set by the hallucinated
+`process.stdin.read(...)` shape or the stdin reactor; it is NOT set by a direct
+`import { readSync } from "node:fs"`. Add: when `usesReadSync && !ctx.linkNodeShims`
+under `--target wasi`, register `fd_read`. (`fd_write` is already registered for any
+stream write.)
+
+**Memory ownership** — a standalone `--target wasi` command module already owns +
+exports its `memory` (non-shim branch: `ctx.mod.memories.push({min:3})` +
+`exports.push({name:"memory"})`). The direct iovec/nread scratch lives in page 0 and
+the read data in page 1 (`WASI_STDIN_BUF_START`), both within the reserved 3 pages,
+so a pure synchronous readSync/writeSync program (no reactor) lays out + exports
+memory correctly with no extra plumbing.
+
+**Keep `--link-node-shims`** — unchanged; that path is the "same file also runs
+unmodified under real node via node:fs" story. The direct path is the additional
+pure-WASI-P1 mode.
+
+## Acceptance
+
+- A readSync/writeSync framed echo (and the native-messaging host) compiles under
+  `--target wasi` with NO `--link-node-shims`; the emitted module imports ONLY
+  `wasi_snapshot_preview1` (no `node:fs` import in the wasm), exports its own
+  `memory`, and runs correctly under wasmtime — reads a 4-byte LE length prefix +
+  body from fd 0, writes a framed response to fd 1, byte-correct. Gated on
+  `findWasmtime()`.
+- The `--link-node-shims` path is unchanged (node:fs shim imports, runs under node).
+- Validated in batch + `runTest262File` (node-fs-api.ts is shared codegen — must be
+  byte-neutral for non-node:fs programs). tsc + lint + prettier clean.
+
+## Implementation notes (WHY)
+
+- The direct readSync iovec scratch deliberately uses dedicated page-0 offsets
+  (`WASI_READSYNC_IOV_OFFSET`/`_NREAD_OFFSET`) rather than the async reactor's
+  `RL_FDREAD_IOV_OFFSET` (324) — a program could in principle use BOTH synchronous
+  readSync AND the async reactor, so the two iovec scratches must not alias.
+- readSync direct is a PLAIN BLOCKING `fd_read` — NOT the reactor's non-blocking
+  `fd_read` + `poll_oneoff`. The synchronous `readSync` contract is "block until at
+  least one byte or EOF", which is exactly wasmtime's default (blocking) fd 0
+  behavior. We deliberately do NOT set `FDFLAG_NONBLOCK`, so this path pulls in only
+  `fd_read` — no `fd_fdstat_set_flags`, no `poll_oneoff`, no timer heap.
+- A read error (errno != 0) yields 0 bytes (the read loops in user code treat
+  `r <= 0` as EOF/stop), matching the shim's behavior and the Node contract closely
+  enough for the streaming use case.

--- a/plan/issues/2655-direct-wasi-p1-readsync-writesync.md
+++ b/plan/issues/2655-direct-wasi-p1-readsync-writesync.md
@@ -105,3 +105,19 @@ pure-WASI-P1 mode.
 - A read error (errno != 0) yields 0 bytes (the read loops in user code treat
   `r <= 0` as EOF/stop), matching the shim's behavior and the Node contract closely
   enough for the streaming use case.
+
+## Test Results
+
+`tests/issue-2655-direct-wasi-readsync-writesync.test.ts` — 6/6 pass:
+- direct compile imports ONLY `wasi_snapshot_preview1` fd_read/fd_write, no
+  `node:fs`, exports its own `memory`, no reactor machinery; module validates.
+- `--link-node-shims` still emits the node:fs shim imports (dual mode preserved).
+- wasmtime-gated: framed echo byte-for-byte incl. high/null bytes (0x00/0xff/0x80);
+  readSync `length` cap; string + DataView writeSync overloads — all byte-correct.
+
+Shim path (#2631/#2633/#2639) + broader WASI suites unchanged. A sample of
+unrelated test262 files still `pass` (node-fs-api.ts is shared codegen, byte-neutral
+for non-node:fs programs). tsc + biome + prettier clean. Pre-existing unrelated
+failure: `issue-1655` subarray "illegal cast" reproduces on clean main (not this PR).
+
+PR: loopdive/js2#2037.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -6082,6 +6082,18 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
     // (not the node-process shim's stdin_read). Keep the inline fd_read import
     // when the reactor is active; otherwise stdin flows through the shim.
     needsFdRead = needsStdinReactor;
+  } else {
+    // #2655 — DIRECT WASI Preview-1 path: a standalone `--target wasi` module
+    // (no `--link-node-shims`) that imports `readSync`/`writeSync` from node:fs
+    // lowers fd-based `readSync(fd, buf, …)` / `writeSync(fd, buf, …)` straight to
+    // `wasi_snapshot_preview1.fd_read` / `fd_write` (a plain BLOCKING read — NOT
+    // the async reactor's non-blocking fd_read + poll_oneoff). `needsFdRead` is
+    // otherwise only set by the hallucinated `process.stdin.read(...)` shape or
+    // the stdin reactor; `needsFdWrite` only by console.log/process.std*.write —
+    // so a bare `import { readSync, writeSync }` would have no syscall import to
+    // call. Pull in the syscalls the imported bindings actually need.
+    if (ctx.wasiNodeFsFuncs.has("readSync")) needsFdRead = true;
+    if (ctx.wasiNodeFsFuncs.has("writeSync")) needsFdWrite = true;
   }
 
   // fd_write(fd: i32, iovs: i32, iovs_len: i32, nwritten: i32) -> i32
@@ -6508,6 +6520,23 @@ function emitWasiWriteStringStderrHelper(ctx: CodegenContext): void {
  */
 export const WASI_STDIN_BUF_START = 64 * 1024;
 export const WASI_WRITE_SCRATCH_START = 128 * 1024;
+
+/**
+ * #2655 — DIRECT `readSync` iovec + nread scratch (page 0). The blocking
+ * `wasi_snapshot_preview1.fd_read(fd, iovs, iovs_len, nread)` syscall needs a
+ * `{ base, len }` iovec (8 bytes) and a `nread` out-slot (4 bytes) in linear
+ * memory. These deliberately use DEDICATED page-0 offsets — NOT the async
+ * reactor's `RL_FDREAD_IOV_OFFSET` (324) / `RL_FDREAD_NREAD_OFFSET` (332) — so a
+ * program that uses BOTH synchronous `readSync` AND the async stdin reactor
+ * never has its two iovec scratches alias. They sit above the reactor's
+ * 160–336 poll/iovec region and below the 1024 string-literal data base, so
+ * they collide with neither the iovec write scratch (0–24), the reactor, nor any
+ * string-literal segment. The read DATA lands in the page-1 stdin buffer
+ * (`WASI_STDIN_BUF_START`) for the GC-array copy path, or straight into the
+ * caller's `ptr+offset` for the linear-backed zero-copy path.
+ */
+export const WASI_READSYNC_IOV_OFFSET = 340;
+export const WASI_READSYNC_NREAD_OFFSET = 348;
 
 /**
  * #1886 Slice B — start of the linear-backed `Uint8Array` arena (page 4,
@@ -7129,20 +7158,23 @@ export function ensureWasiWriteAnyStringHelper(ctx: CodegenContext, useStderr: b
  * #2639: Ensure `__wasi_write_any_string_fd(s: ref AnyString, fd: i32) -> i32`
  * exists and return its function index (lazy). Encodes the string to UTF-8 in
  * the shared linear scratch (the same encoder as the fixed-fd writer) and writes
- * it to the *runtime* fd via the imported `node:fs` `writeSync(fd, ptr, len)`
- * shim, returning the byte count `writeSync` reports. This backs the STRING
- * overload of `node:fs` `writeSync(fd, str, position?, encoding?)`, where the fd
- * is an arbitrary integer (not just stdout/stderr). It is gated to the
- * `linkNodeShims` path — the only path on which `writeSync(fd, …)` lowers — so
- * no inline `fd_write` tail is needed here.
+ * it to the *runtime* fd. This backs the STRING overload of `node:fs`
+ * `writeSync(fd, str, position?, encoding?)`, where the fd is an arbitrary
+ * integer (not just stdout/stderr). Two modes (#2655):
+ *   - shim (`--link-node-shims`): `writeSync(fd, ptr, len)` returns the byte count.
+ *   - direct (standalone `--target wasi`): build a `{ base=ptr, len }` iovec at
+ *     memory[0..7], call `fd_write(fd, iovs=0, 1, nwritten=8)`, load nwritten.
  */
 export function ensureWasiWriteAnyStringFdHelper(ctx: CodegenContext): number {
   const helperName = "__wasi_write_any_string_fd";
   const existing = ctx.funcMap.get(helperName);
   if (existing !== undefined) return existing;
 
-  // Runtime-fd writes only exist on the node:fs shim path.
-  if (!ctx.wasi || !ctx.linkNodeShims || ctx.nodeFsWriteSyncIdx < 0 || ctx.nativeStrTypeIdx < 0) return -1;
+  // Runtime-fd writes need either the node:fs shim funcidx (shim path) or the
+  // wasi_snapshot_preview1.fd_write import (direct path).
+  const directWrite = !ctx.linkNodeShims;
+  if (!ctx.wasi || ctx.nativeStrTypeIdx < 0) return -1;
+  if (directWrite ? ctx.wasiFdWriteIdx === undefined : ctx.nodeFsWriteSyncIdx < 0) return -1;
 
   ensureNativeStringHelpers(ctx);
   const flattenIdx = ctx.funcMap.get("__str_flatten");
@@ -7163,11 +7195,37 @@ export function ensureWasiWriteAnyStringFdHelper(ctx: CodegenContext): number {
 
   const body: Instr[] = [
     ...buildWasiStringEncodeToScratch(flattenIdx, strTypeIdx, strDataTypeIdx, layout),
-    // return writeSync(fd, WASI_WRITE_SCRATCH_START, O)  — bytes written.
-    { op: "local.get", index: FD } as Instr,
-    { op: "i32.const", value: WASI_WRITE_SCRATCH_START } as Instr,
-    { op: "local.get", index: layout.O } as Instr,
-    { op: "call", funcIdx: ctx.nodeFsWriteSyncIdx } as Instr,
+    // return bytes-written for write(fd, WASI_WRITE_SCRATCH_START, O).
+    ...(directWrite
+      ? [
+          // iovec.base = scratch at memory[0]; iovec.len = O at memory[4].
+          { op: "i32.const", value: 0 } as Instr,
+          { op: "i32.const", value: WASI_WRITE_SCRATCH_START } as Instr,
+          { op: "i32.store", align: 2, offset: 0 } as Instr,
+          { op: "i32.const", value: 4 } as Instr,
+          { op: "local.get", index: layout.O } as Instr,
+          { op: "i32.store", align: 2, offset: 0 } as Instr,
+          // errno = fd_write(fd, iovs=0, iovs_len=1, nwritten=8)
+          { op: "local.get", index: FD } as Instr,
+          { op: "i32.const", value: 0 } as Instr,
+          { op: "i32.const", value: 1 } as Instr,
+          { op: "i32.const", value: 8 } as Instr,
+          { op: "call", funcIdx: ctx.wasiFdWriteIdx } as Instr,
+          // errno != 0 → 0 bytes; else load nwritten at memory[8].
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "i32" } },
+            then: [{ op: "i32.const", value: 0 } as Instr],
+            else: [{ op: "i32.const", value: 8 } as Instr, { op: "i32.load", align: 2, offset: 0 } as Instr],
+          } as Instr,
+        ]
+      : [
+          // writeSync(fd, WASI_WRITE_SCRATCH_START, O) — bytes written.
+          { op: "local.get", index: FD } as Instr,
+          { op: "i32.const", value: WASI_WRITE_SCRATCH_START } as Instr,
+          { op: "local.get", index: layout.O } as Instr,
+          { op: "call", funcIdx: ctx.nodeFsWriteSyncIdx } as Instr,
+        ]),
   ];
 
   ctx.mod.functions.push({
@@ -12773,15 +12831,17 @@ function registerNodeBuiltinImports(ctx: CodegenContext, builtins: NodeBuiltinIm
       // preprocessing leaves a type-level `process` binding in the AST and
       // node-fs-api.ts lowers supported stream calls directly to WASI.
       if (builtin.moduleName === "process") continue;
-      // #2631 — `node:fs` is likewise a compile-time API surface under
-      // --link-node-shims when the program uses the fd-based synchronous
-      // primitives readSync / writeSync: those are stripped by import
-      // preprocessing and lowered to imported `node:fs` shim calls by
-      // node-fs-api.ts (tryCompileNodeFsCall). Path-based fs usage is
-      // rejected at the call site (see PATH_BASED_FS_FNS in calls.ts), not here.
+      // #2631/#2655 — `node:fs` is likewise a compile-time API surface when the
+      // program uses the fd-based synchronous primitives readSync / writeSync:
+      // those are stripped by import preprocessing and lowered by node-fs-api.ts
+      // (tryCompileNodeFsCall) to EITHER imported `node:fs` shim calls
+      // (--link-node-shims) OR direct `wasi_snapshot_preview1.fd_read`/`fd_write`
+      // syscalls (standalone --target wasi, #2655). Either way the `fs` builtin
+      // import itself is consumed at compile time and must not error here.
+      // Path-based fs usage is rejected at the call site (PATH_BASED_FS_FNS in
+      // calls.ts) / by the no-provider gate in tryCompileNodeFsCall, not here.
       if (
         builtin.moduleName === "fs" &&
-        ctx.linkNodeShims &&
         (ctx.wasiNodeFsFuncs.has("readSync") || ctx.wasiNodeFsFuncs.has("writeSync"))
       ) {
         continue;

--- a/src/codegen/node-fs-api.ts
+++ b/src/codegen/node-fs-api.ts
@@ -25,6 +25,8 @@ import {
   ensureWasiWriteUint8ArrayHelper,
   getArrTypeIdxFromVec,
   getOrRegisterVecType,
+  WASI_READSYNC_IOV_OFFSET,
+  WASI_READSYNC_NREAD_OFFSET,
   WASI_STDIN_BUF_START,
   WASI_WRITE_SCRATCH_START,
 } from "./index.js";
@@ -284,7 +286,12 @@ export function tryCompileNodeFsCall(
     }
   }
 
-  if (!ctx.linkNodeShims) return undefined;
+  // #2655 — fd-based readSync/writeSync lower via EITHER the `node:fs` shim
+  // (`--link-node-shims`: the imported `(fd,ptr,len) -> i32` shim funcs) OR the
+  // DIRECT WASI Preview-1 path (`!ctx.linkNodeShims`: the
+  // `wasi_snapshot_preview1.fd_read`/`fd_write` syscalls). The direct path makes
+  // a standalone stdio program a self-contained WASI P1 command module importing
+  // ONLY `wasi_snapshot_preview1` — no shim, no Node runtime (loopdive/js2#389).
   if (expr.questionDotToken) return undefined;
   if (!ts.isIdentifier(expr.expression)) return undefined;
   const callee = expr.expression.text;
@@ -295,12 +302,123 @@ export function tryCompileNodeFsCall(
   if (fctx.localMap.has(callee) || (fctx.boxedCaptures?.has(callee) ?? false)) return undefined;
   // fd-based form requires at least (fd, buffer). A bare/path-based call is not ours.
   if (expr.arguments.length < 2) return undefined;
+
+  // Pick the sink + mode. Shim: the imported `(fd,ptr,len)->i32` func. Direct:
+  // the WASI syscall funcidx (a no-op `-1` if it somehow wasn't registered).
+  const direct = !ctx.linkNodeShims;
+  if (direct) {
+    const syscallIdx = callee === "readSync" ? ctx.wasiFdReadIdx : ctx.wasiFdWriteIdx;
+    if (syscallIdx === undefined || syscallIdx < 0) return undefined;
+    return callee === "readSync"
+      ? emitNodeFsReadSync(ctx, fctx, expr, syscallIdx, true)
+      : emitNodeFsWriteSync(ctx, fctx, expr, syscallIdx, true);
+  }
   const shimIdx = callee === "readSync" ? ctx.nodeFsReadSyncIdx : ctx.nodeFsWriteSyncIdx;
   if (shimIdx < 0) return undefined;
-
   return callee === "readSync"
-    ? emitNodeFsReadSync(ctx, fctx, expr, shimIdx)
-    : emitNodeFsWriteSync(ctx, fctx, expr, shimIdx);
+    ? emitNodeFsReadSync(ctx, fctx, expr, shimIdx, false)
+    : emitNodeFsWriteSync(ctx, fctx, expr, shimIdx, false);
+}
+
+/**
+ * #2655 — emit the per-`fd` "read `len` bytes from `fd` into linear `ptrLocal`,
+ * leaving the byte count on the stack as i32". Two modes:
+ *   - shim (`direct=false`): `read_sync(fd, ptr, len)` — the imported shim owns
+ *     the iovec + syscall over the shared memory; it returns the byte count.
+ *   - direct (`direct=true`): build a `{ base=ptr, len }` iovec at
+ *     `WASI_READSYNC_IOV_OFFSET`, call the BLOCKING
+ *     `fd_read(fd, iovs, 1, nread=WASI_READSYNC_NREAD_OFFSET)`, then load nread.
+ *     An errno != 0 yields 0 bytes (read loops treat `r <= 0` as EOF/stop).
+ *
+ * `ptrLocal`/`lenLocal` are i32 locals already holding the destination linear
+ * pointer and the requested length; `fdLocal` holds the fd.
+ */
+function emitFdReadRuntime(
+  fctx: FunctionContext,
+  fdLocal: number,
+  ptrLocal: number,
+  lenLocal: number,
+  sinkIdx: number,
+  direct: boolean,
+): void {
+  if (!direct) {
+    fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
+    fctx.body.push({ op: "local.get", index: ptrLocal } as Instr);
+    fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+    fctx.body.push({ op: "call", funcIdx: sinkIdx } as Instr);
+    return;
+  }
+  // Build the iovec { base=ptr, len } at WASI_READSYNC_IOV_OFFSET.
+  fctx.body.push({ op: "i32.const", value: WASI_READSYNC_IOV_OFFSET } as Instr);
+  fctx.body.push({ op: "local.get", index: ptrLocal } as Instr);
+  fctx.body.push({ op: "i32.store", align: 2, offset: 0 } as Instr);
+  fctx.body.push({ op: "i32.const", value: WASI_READSYNC_IOV_OFFSET + 4 } as Instr);
+  fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+  fctx.body.push({ op: "i32.store", align: 2, offset: 0 } as Instr);
+  // errno = fd_read(fd, iovs=IOV, iovs_len=1, nread=NREAD)
+  fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
+  fctx.body.push({ op: "i32.const", value: WASI_READSYNC_IOV_OFFSET } as Instr);
+  fctx.body.push({ op: "i32.const", value: 1 } as Instr);
+  fctx.body.push({ op: "i32.const", value: WASI_READSYNC_NREAD_OFFSET } as Instr);
+  fctx.body.push({ op: "call", funcIdx: sinkIdx } as Instr);
+  // errno on the stack: if non-zero, push 0 bytes; else load nread.
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "i32" } },
+    then: [{ op: "i32.const", value: 0 } as Instr],
+    else: [
+      { op: "i32.const", value: WASI_READSYNC_NREAD_OFFSET } as Instr,
+      { op: "i32.load", align: 2, offset: 0 } as Instr,
+    ],
+  } as Instr);
+}
+
+/**
+ * #2655 — emit the per-`fd` "write `len` bytes from linear `ptrLocal` to `fd`,
+ * leaving the byte count on the stack as i32". Two modes:
+ *   - shim (`direct=false`): `write_sync(fd, ptr, len)` returns the byte count.
+ *   - direct (`direct=true`): build a `{ base=ptr, len }` iovec at memory[0..7],
+ *     call `fd_write(fd, iovs=0, 1, nwritten=8)`, then load nwritten. An
+ *     errno != 0 yields 0 bytes (write loops treat `w <= 0` as stop). The
+ *     memory[0..11] iovec/nwritten scratch matches `emitWasiWriteTail`; a single
+ *     writeSync call never interleaves with another write over it.
+ */
+function emitFdWriteRuntime(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  fdLocal: number,
+  ptrLocal: number,
+  lenLocal: number,
+  sinkIdx: number,
+  direct: boolean,
+): void {
+  if (!direct) {
+    fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
+    fctx.body.push({ op: "local.get", index: ptrLocal } as Instr);
+    fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+    fctx.body.push({ op: "call", funcIdx: sinkIdx } as Instr);
+    return;
+  }
+  // iovec.base = ptr at memory[0]; iovec.len = len at memory[4].
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "local.get", index: ptrLocal } as Instr);
+  fctx.body.push({ op: "i32.store", align: 2, offset: 0 } as Instr);
+  fctx.body.push({ op: "i32.const", value: 4 } as Instr);
+  fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+  fctx.body.push({ op: "i32.store", align: 2, offset: 0 } as Instr);
+  // errno = fd_write(fd, iovs=0, iovs_len=1, nwritten=8)
+  fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "i32.const", value: 1 } as Instr);
+  fctx.body.push({ op: "i32.const", value: 8 } as Instr);
+  fctx.body.push({ op: "call", funcIdx: sinkIdx } as Instr);
+  // errno on the stack: non-zero → 0 bytes; else load nwritten at memory[8].
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "i32" } },
+    then: [{ op: "i32.const", value: 0 } as Instr],
+    else: [{ op: "i32.const", value: 8 } as Instr, { op: "i32.load", align: 2, offset: 0 } as Instr],
+  } as Instr);
 }
 
 /**
@@ -463,7 +581,8 @@ function emitNodeFsReadSync(
   ctx: CodegenContext,
   fctx: FunctionContext,
   expr: ts.CallExpression,
-  shimIdx: number,
+  sinkIdx: number,
+  direct: boolean,
 ): InnerResult {
   const fdLocal = emitNodeFsFd(ctx, fctx, expr.arguments[0]!);
 
@@ -471,12 +590,13 @@ function emitNodeFsReadSync(
   const linBuf = getLinearU8Buffer(ctx, fctx, expr.arguments[1]!);
   if (linBuf) {
     const { offLocal, lenLocal } = emitNodeFsOffsetLength(ctx, fctx, expr, linBuf.lenLocalIdx);
-    fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
+    // dst = ptr + off
+    const dstLocal = allocLocal(fctx, `__nodefs_rdst_${fctx.locals.length}`, { kind: "i32" });
     fctx.body.push({ op: "local.get", index: linBuf.ptrLocalIdx } as Instr);
     fctx.body.push({ op: "local.get", index: offLocal } as Instr);
     fctx.body.push({ op: "i32.add" } as Instr);
-    fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
-    fctx.body.push({ op: "call", funcIdx: shimIdx } as Instr);
+    fctx.body.push({ op: "local.set", index: dstLocal } as Instr);
+    emitFdReadRuntime(fctx, fdLocal, dstLocal, lenLocal, sinkIdx, direct);
     fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
     return { kind: "f64" };
   }
@@ -493,14 +613,14 @@ function emitNodeFsReadSync(
   // exceed current pages.
   ensureScratchPages(fctx, WASI_STDIN_BUF_START, lenLocal);
 
-  // nread = read_sync(fd, WASI_STDIN_BUF_START, length)
+  // nread = read(fd, WASI_STDIN_BUF_START, length)  [shim call or direct fd_read]
+  const scratchPtrLocal = allocLocal(fctx, `__nodefs_rscratch_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "i32.const", value: WASI_STDIN_BUF_START } as Instr);
+  fctx.body.push({ op: "local.set", index: scratchPtrLocal } as Instr);
   const nreadLocal = allocLocal(fctx, `__nodefs_nread_${fctx.locals.length}`, {
     kind: "i32",
   });
-  fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
-  fctx.body.push({ op: "i32.const", value: WASI_STDIN_BUF_START } as Instr);
-  fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
-  fctx.body.push({ op: "call", funcIdx: shimIdx } as Instr);
+  emitFdReadRuntime(fctx, fdLocal, scratchPtrLocal, lenLocal, sinkIdx, direct);
   fctx.body.push({ op: "local.set", index: nreadLocal } as Instr);
 
   // Copy buf_dest[off + j] = scratch[j] for j in [0, nread).
@@ -523,7 +643,8 @@ function emitNodeFsWriteSync(
   ctx: CodegenContext,
   fctx: FunctionContext,
   expr: ts.CallExpression,
-  shimIdx: number,
+  sinkIdx: number,
+  direct: boolean,
 ): InnerResult {
   const arg1 = expr.arguments[1]!;
   const arg1Type = ctx.checker.getTypeAtLocation(arg1);
@@ -539,11 +660,11 @@ function emitNodeFsWriteSync(
   }
 
   // #2639 — DataView arg: resolve its i32_byte backing + byteOffset/byteLength to
-  // a (ptr, len) over the write scratch, then write via the shim. DataView is
-  // part of __NodeFsArrayBufferView but isn't a GC $Vec the offset/length path
+  // a (ptr, len) over the write scratch, then write. DataView is part of
+  // __NodeFsArrayBufferView but isn't a GC $Vec the offset/length path
   // recognizes, so handle it explicitly before the generic resolution.
   if (arg1Type.getSymbol?.()?.name === "DataView") {
-    return emitNodeFsWriteSyncDataView(ctx, fctx, expr, shimIdx);
+    return emitNodeFsWriteSyncDataView(ctx, fctx, expr, sinkIdx, direct);
   }
 
   const fdLocal = emitNodeFsFd(ctx, fctx, expr.arguments[0]!);
@@ -552,12 +673,13 @@ function emitNodeFsWriteSync(
   const linBuf = getLinearU8Buffer(ctx, fctx, expr.arguments[1]!);
   if (linBuf) {
     const { offLocal, lenLocal } = emitNodeFsOffsetLength(ctx, fctx, expr, linBuf.lenLocalIdx);
-    fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
+    // src = ptr + off
+    const srcLocal = allocLocal(fctx, `__nodefs_wsrc_${fctx.locals.length}`, { kind: "i32" });
     fctx.body.push({ op: "local.get", index: linBuf.ptrLocalIdx } as Instr);
     fctx.body.push({ op: "local.get", index: offLocal } as Instr);
     fctx.body.push({ op: "i32.add" } as Instr);
-    fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
-    fctx.body.push({ op: "call", funcIdx: shimIdx } as Instr);
+    fctx.body.push({ op: "local.set", index: srcLocal } as Instr);
+    emitFdWriteRuntime(ctx, fctx, fdLocal, srcLocal, lenLocal, sinkIdx, direct);
     fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
     return { kind: "f64" };
   }
@@ -575,11 +697,11 @@ function emitNodeFsWriteSync(
   // Copy scratch[j] = buf[off + j] for j in [0, length).
   emitArrayToScratchCopy(fctx, gc.arrTypeIdx, gc.arrLocal, offLocal, WASI_WRITE_SCRATCH_START, lenLocal);
 
-  // nwritten = write_sync(fd, WASI_WRITE_SCRATCH_START, length)
-  fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
+  // nwritten = write(fd, WASI_WRITE_SCRATCH_START, length)  [shim or direct]
+  const scratchPtrLocal = allocLocal(fctx, `__nodefs_wscratch_${fctx.locals.length}`, { kind: "i32" });
   fctx.body.push({ op: "i32.const", value: WASI_WRITE_SCRATCH_START } as Instr);
-  fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
-  fctx.body.push({ op: "call", funcIdx: shimIdx } as Instr);
+  fctx.body.push({ op: "local.set", index: scratchPtrLocal } as Instr);
+  emitFdWriteRuntime(ctx, fctx, fdLocal, scratchPtrLocal, lenLocal, sinkIdx, direct);
   fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
   return { kind: "f64" };
 }
@@ -658,7 +780,8 @@ function emitNodeFsWriteSyncDataView(
   ctx: CodegenContext,
   fctx: FunctionContext,
   expr: ts.CallExpression,
-  shimIdx: number,
+  sinkIdx: number,
+  direct: boolean,
 ): InnerResult {
   const fdLocal = emitNodeFsFd(ctx, fctx, expr.arguments[0]!);
 
@@ -675,11 +798,11 @@ function emitNodeFsWriteSyncDataView(
     return { kind: "f64" };
   }
 
-  // nwritten = write_sync(fd, WASI_WRITE_SCRATCH_START, viewLen)
-  fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
+  // nwritten = write(fd, WASI_WRITE_SCRATCH_START, viewLen)  [shim or direct]
+  const scratchPtrLocal = allocLocal(fctx, `__nodefs_dvscratch_${fctx.locals.length}`, { kind: "i32" });
   fctx.body.push({ op: "i32.const", value: WASI_WRITE_SCRATCH_START } as Instr);
-  fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
-  fctx.body.push({ op: "call", funcIdx: shimIdx } as Instr);
+  fctx.body.push({ op: "local.set", index: scratchPtrLocal } as Instr);
+  emitFdWriteRuntime(ctx, fctx, fdLocal, scratchPtrLocal, lenLocal, sinkIdx, direct);
   fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
   return { kind: "f64" };
 }

--- a/tests/issue-2655-direct-wasi-readsync-writesync.test.ts
+++ b/tests/issue-2655-direct-wasi-readsync-writesync.test.ts
@@ -1,0 +1,177 @@
+// #2655 — DIRECT WASI Preview-1 fd_read/fd_write for node:fs readSync/writeSync.
+//
+// loopdive/js2#389: the Native Messaging host reporter runs directly under a
+// WASI host (wasmtime) and is explicitly "not chasing Node.js". They want a
+// SELF-CONTAINED WASI P1 command module that imports ONLY
+// `wasi_snapshot_preview1` — no node:fs shim (`--link-node-shims`), no Node
+// runtime. #2631/#2633 gave the shim path; this adds the direct path: fd-based
+// `readSync(0, …)` / `writeSync(1, …)` lower straight to
+// `wasi_snapshot_preview1.fd_read` / `fd_write` (a plain BLOCKING read — NOT the
+// async reactor's non-blocking fd_read + poll_oneoff), and the command module
+// owns + exports its own `memory`.
+//
+// The `--link-node-shims` path (the "same file also runs unmodified under real
+// node via node:fs" story) is unchanged — covered by issue-2631-node-fs-fd-shim.
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const WASMTIME_FLAGS = ["run", "-W", "gc=y,function-references=y,exceptions=y"];
+
+function findWasmtime(): string | null {
+  for (const cand of ["wasmtime", "/usr/local/bin/wasmtime"]) {
+    try {
+      execFileSync(cand, ["--version"], { stdio: "ignore" });
+      return cand;
+    } catch {
+      /* try next */
+    }
+  }
+  return null;
+}
+const wasmtimeBin = findWasmtime();
+
+// A framed-echo host: read a 4-byte LE length prefix + body off fd 0, echo both
+// back to fd 1 (mirrors the example's small-frame fast path + the #2631 shim
+// test). `export function main` with NO top-level call: `_start` wraps the
+// exported main, so it runs exactly once under wasmtime.
+const FRAMED_ECHO = `
+import { readSync, writeSync } from "node:fs";
+function readExact(buf: Uint8Array, n: number): boolean {
+  let got = 0;
+  while (got < n) {
+    const r = readSync(0, buf, { offset: got, length: n - got });
+    if (r <= 0) return false;
+    got = got + r;
+  }
+  return true;
+}
+function writeAll(out: Uint8Array): void {
+  let n = 0;
+  while (n < out.length) {
+    const w = writeSync(1, out, n);
+    if (w <= 0) return;
+    n = n + w;
+  }
+}
+export function main(): void {
+  const header = new Uint8Array(4);
+  if (!readExact(header, 4)) return;
+  const len = header[0] + header[1] * 256 + header[2] * 65536 + header[3] * 16777216;
+  const body = new Uint8Array(len);
+  if (!readExact(body, len)) return;
+  writeAll(header);
+  writeAll(body);
+}
+`;
+
+describe("#2655 — direct WASI P1 readSync/writeSync (no shim)", () => {
+  it("emits ONLY wasi_snapshot_preview1 fd_read/fd_write, no node:fs import, owns memory", async () => {
+    const result = await compile(FRAMED_ECHO, { fileName: "x.ts", target: "wasi" });
+    expect(result.success, result.success ? "" : result.errors?.[0]?.message).toBe(true);
+    const wat = result.wat ?? "";
+    // Direct WASI syscalls — no node:fs interface import.
+    expect(wat).toContain('(import "wasi_snapshot_preview1" "fd_read"');
+    expect(wat).toContain('(import "wasi_snapshot_preview1" "fd_write"');
+    expect(wat).not.toContain('(import "node:fs"');
+    expect(wat).not.toContain("node:fs");
+    // A standalone command module OWNS + exports its own memory.
+    expect(wat).toContain('(export "memory"');
+    // No reactor machinery: blocking readSync pulls in fd_read alone, not
+    // poll_oneoff / fd_fdstat_set_flags / the timer scheduler.
+    expect(wat).not.toContain("poll_oneoff");
+    expect(wat).not.toContain("fd_fdstat_set_flags");
+    expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
+  });
+
+  // Sanity: the SAME source still compiles under --link-node-shims to the shim
+  // imports (the node-runtime variant), proving the dual mode coexists.
+  it("--link-node-shims still emits the node:fs shim imports (dual mode preserved)", async () => {
+    const result = await compile(FRAMED_ECHO, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
+    expect(result.success).toBe(true);
+    const wat = result.wat ?? "";
+    expect(wat).toContain('(import "node:fs" "readSync"');
+    expect(wat).toContain('(import "node:fs" "writeSync"');
+    expect(wat).not.toContain("wasi_snapshot_preview1");
+  });
+
+  describe.skipIf(!wasmtimeBin)("runs under wasmtime (pure WASI P1)", () => {
+    let tmp: string;
+    beforeAll(() => {
+      tmp = mkdtempSync(join(tmpdir(), "wt-2655-"));
+    });
+    afterAll(() => {
+      if (tmp) rmSync(tmp, { recursive: true, force: true });
+    });
+
+    function run(binary: Uint8Array, name: string, input: Buffer): Buffer {
+      const p = join(tmp, `${name}.wasm`);
+      writeFileSync(p, binary);
+      return execFileSync(wasmtimeBin!, [...WASMTIME_FLAGS, p], { input, maxBuffer: 4 * 1024 * 1024 });
+    }
+
+    it("framed echo round-trips a message byte-for-byte (incl. high/null bytes)", async () => {
+      const result = await compile(FRAMED_ECHO, { fileName: "x.ts", target: "wasi" });
+      expect(result.success).toBe(true);
+      // frame: len=5 (LE) + 5 body bytes with non-printable / high bytes.
+      const frame = Buffer.from([0x05, 0x00, 0x00, 0x00, 0x00, 0xff, 0x0a, 0x7f, 0x80]);
+      const out = run(result.binary!, "echo", frame);
+      expect(Array.from(out)).toEqual([0x05, 0x00, 0x00, 0x00, 0x00, 0xff, 0x0a, 0x7f, 0x80]);
+    });
+
+    it("readSync options `length` caps the read so it never over-reads past the target", async () => {
+      const src = `
+import { readSync, writeSync } from "node:fs";
+export function main(): void {
+  const buf = new Uint8Array(8); // capacity 8
+  let got = 0;
+  while (got < 3) {
+    const r = readSync(0, buf, { offset: got, length: 3 - got });
+    if (r <= 0) break;
+    got = got + r;
+  }
+  const out = new Uint8Array(got);
+  let i = 0;
+  while (i < got) { out[i] = buf[i]; i = i + 1; }
+  let n = 0;
+  while (n < out.length) { const w = writeSync(1, out, n); if (w <= 0) break; n = n + w; }
+}
+`;
+      const result = await compile(src, { fileName: "x.ts", target: "wasi" });
+      expect(result.success).toBe(true);
+      // stdin has 5 bytes available, but we only ever request 3.
+      const out = run(result.binary!, "cap", Buffer.from([0x41, 0x42, 0x43, 0x44, 0x45]));
+      expect(Array.from(out)).toEqual([0x41, 0x42, 0x43]);
+    });
+
+    it("writeSync STRING overload writes UTF-8 bytes to the runtime fd", async () => {
+      const src = `
+import { writeSync } from "node:fs";
+export function main(): void { writeSync(1, "héllo\\n"); }
+`;
+      const result = await compile(src, { fileName: "x.ts", target: "wasi" });
+      expect(result.success).toBe(true);
+      const out = run(result.binary!, "str", Buffer.alloc(0));
+      expect(out.toString("utf-8")).toBe("héllo\n");
+    });
+
+    it("writeSync DataView overload writes the view's bytes to the runtime fd", async () => {
+      const src = `
+import { writeSync } from "node:fs";
+export function main(): void {
+  const ab = new ArrayBuffer(3);
+  const dv = new DataView(ab);
+  dv.setUint8(0, 65); dv.setUint8(1, 66); dv.setUint8(2, 67);
+  writeSync(1, dv);
+}
+`;
+      const result = await compile(src, { fileName: "x.ts", target: "wasi" });
+      expect(result.success).toBe(true);
+      const out = run(result.binary!, "dv", Buffer.alloc(0));
+      expect(out.toString("utf-8")).toBe("ABC");
+    });
+  });
+});


### PR DESCRIPTION
## Problem

A standalone `--target wasi` stdio program that uses `node:fs` fd-based `readSync(0, …)` / `writeSync(1, …)` could only reach WASI via the imported `node:fs` shim (`--link-node-shims`). `node-fs-api.ts` `tryCompileNodeFsCall` had a blanket `if (!ctx.linkNodeShims) return undefined;` — there was no direct `wasi_snapshot_preview1.fd_read`/`fd_write` lowering. This blocked loopdive/js2#389: a Native Messaging host that runs directly under a WASI host (wasmtime), explicitly "not chasing Node.js" — it wants a self-contained WASI P1 command module importing ONLY `wasi_snapshot_preview1`.

## Change

Adds the DIRECT path while keeping the shim path intact (dual mode):

- **node-fs-api.ts**: `tryCompileNodeFsCall` dispatches fd-based readSync/writeSync through EITHER the `node:fs` shim (`--link-node-shims`) OR the direct WASI syscalls (`!linkNodeShims`). `emitNodeFsReadSync`/`emitNodeFsWriteSync` take the sink funcidx + a `direct` flag; new `emitFdReadRuntime`/`emitFdWriteRuntime` emit a **blocking** `fd_read`/`fd_write` over a dedicated page-0 iovec scratch (`WASI_READSYNC_IOV_OFFSET`/`_NREAD_OFFSET` = 340/348, deliberately distinct from the async reactor's 324/332 so the two iovec scratches never alias). readSync is a plain blocking read — NOT the reactor's non-blocking `fd_read` + `poll_oneoff`, so it pulls in `fd_read` alone (no `fd_fdstat_set_flags`, no timer heap).
- **index.ts**: register `fd_read`/`fd_write` for a bare `import { readSync, writeSync } from "node:fs"` under standalone WASI; generalize `ensureWasiWriteAnyStringFdHelper` (the `writeSync(fd, str)` overload) to emit a runtime-fd `fd_write` on the direct path; let the `node:fs` builtin gate consume the import in direct mode too.
- **example**: `examples/native-messaging/nm_js2wasm.ts` header now documents `--target wasi` ALONE as the self-contained WASI P1 compile (imports only `wasi_snapshot_preview1`); `--link-node-shims` remains the node-linkable variant. Source unchanged (`import { readSync, writeSync } from "node:fs"`).

## Validation

`tests/issue-2655-direct-wasi-readsync-writesync.test.ts` — 6 tests:
- direct compile imports ONLY `wasi_snapshot_preview1` fd_read/fd_write, no `node:fs`, exports its own `memory`, no reactor machinery; module validates (always-on);
- `--link-node-shims` still emits the node:fs shim imports (dual mode preserved);
- wasmtime-gated (`findWasmtime()`): framed echo round-trips a message byte-for-byte incl. high/null bytes (0x00/0xff/0x80); readSync `length` cap; string + DataView writeSync overloads.

Shim path (#2631/#2633/#2639) + broader WASI suites unchanged; a sample of unrelated test262 files still `pass` (node-fs-api.ts is shared codegen — byte-neutral for non-node:fs programs). tsc + biome + prettier clean.

Closes #2655. Fulfils loopdive/js2#389 reporter's pure-WASI use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)