### PR TITLE
feat(wasi): #2657 raw wasi_snapshot_preview1 fd_read/fd_write import + nm_wasi.ts variant

### DIFF
--- a/examples/native-messaging/nm_wasi.ts
+++ b/examples/native-messaging/nm_wasi.ts
@@ -1,0 +1,158 @@
+// Native Messaging host, compiled to standalone WASI by js2wasm — the RAW
+// `wasi_snapshot_preview1` variant.
+//
+//   npx js2wasm examples/native-messaging/nm_wasi.ts --target wasi -o out
+//
+// This is the MOST honest pure-WASI-Preview-1 expression of the host: it imports
+// `fd_read` / `fd_write` DIRECTLY from `wasi_snapshot_preview1` — the real WASI
+// P1 core module a runtime such as wasmtime satisfies — with NO `node:fs` surface
+// at all (loopdive/js2#389, the reporter is "not chasing Node.js"). The emitted
+// module imports ONLY `wasi_snapshot_preview1`, owns + exports its own `memory`,
+// and runs directly under wasmtime.
+//
+// Contrast with the sibling `nm_js2wasm.ts`, which uses `node:fs`
+// `readSync`/`writeSync(fd, …)` — faithful Node fd-based IO that ALSO runs
+// UNMODIFIED under real `node`. This file does NOT run under Node (it speaks raw
+// WASI syscalls over linear memory); it is the pure-WASI counterpart.
+//
+// The raw WASI ABI: `fd_read`/`fd_write` take an **iovec** array in linear memory
+// and a result-count pointer. We own linear memory and lay the iovec out
+// ourselves with js2wasm's inline linear-memory accessors `store32`/`load32`/
+// `store8`/`load8` (no GC roundtrip). Those accessors are NOT WASI host functions
+// — no host provides a `store32` syscall — so they are imported from a distinct
+// js2wasm INTRINSIC namespace, `"wasm:memory"` (they lower to inline
+// `i32.store`/`i32.load`/… over the module's own memory). Only `fd_read`/
+// `fd_write` come from `"wasi_snapshot_preview1"`, the real WASI core module, so
+// the emitted module's ONLY import is `wasi_snapshot_preview1`.
+//
+//   fd_read (fd, iovs, iovs_len, nread)    -> errno   reads into iovs[0].{buf,len}
+//   fd_write(fd, iovs, iovs_len, nwritten) -> errno   writes from iovs[0].{buf,len}
+//
+// Native Messaging protocol: each message is a 4-byte little-endian length prefix
+// followed by a UTF-8 JSON body, exchanged over fd 0 (stdin) / fd 1 (stdout). See
+//   https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging
+//
+// This raw variant echoes a framed message verbatim: it reads the 4-byte LE
+// length prefix, then the body, then writes the prefix + body straight back —
+// byte-for-byte, including high and null bytes (a frame is an opaque byte run to
+// the syscall layer). It streams through a single fixed linear-memory window, so
+// resident memory stays flat regardless of message size. (The 64-MiB re-chunking
+// the `node:fs` variant does for the browser 1-MiB cap is orthogonal to the raw
+// syscall layer and omitted here to keep the pure-WASI example focused on the
+// fd_read/fd_write ABI.)
+
+import { fd_read, fd_write } from "wasi_snapshot_preview1";
+import { store32, load32, store8, load8 } from "wasm:memory";
+
+// js2wasm native i32 annotation — emits i32 locals + i32 arithmetic. The raw WASI
+// pointers and lengths are all linear-memory i32 offsets.
+type i32 = number;
+
+// ---- linear-memory scratch layout (the module owns + exports `memory`) --------
+// The default WASI memory is 3 pages (192 KiB). We reserve a small fixed control
+// region at the base and stream the body through a window well clear of it.
+const IOV: i32 = 0; // iovec[0] = { buf: i32 @0, buf_len: i32 @4 } (8 bytes)
+const RESULT: i32 = 8; // nread / nwritten result slot (4 bytes)
+const DATA: i32 = 64; // body window base (page-aligned headroom over the control region)
+const WINDOW: i32 = 64 * 1024; // 64 KiB streaming window (fits in the 3-page default)
+
+// Set iovec[0] = { buf, len } and zero the result slot, ready for one fd_read /
+// fd_write of a single contiguous run.
+function setIovec(buf: i32, len: i32): void {
+  store32(IOV, buf);
+  store32(IOV + 4, len);
+  store32(RESULT, 0);
+}
+
+// Read up to `len` bytes from `fd` into linear memory at `buf`. Returns the byte
+// count, or 0 on EOF / error (errno != 0). One raw `fd_read` over a 1-iovec list.
+function readSome(fd: i32, buf: i32, len: i32): i32 {
+  setIovec(buf, len);
+  const errno: i32 = fd_read(fd, IOV, 1, RESULT);
+  if (errno !== 0) return 0;
+  return load32(RESULT);
+}
+
+// Read EXACTLY `n` bytes from `fd` into `buf`, looping over short reads. Returns
+// false on EOF / error before `n` bytes arrive.
+function readExact(fd: i32, buf: i32, n: i32): boolean {
+  let got: i32 = 0;
+  while (got < n) {
+    const r: i32 = readSome(fd, buf + got, n - got);
+    if (r <= 0) return false; // EOF or error
+    got = got + r;
+  }
+  return true;
+}
+
+// Write EXACTLY `n` bytes from `buf` to `fd`, looping over partial writes. Returns
+// false on error before `n` bytes are written.
+function writeExact(fd: i32, buf: i32, n: i32): boolean {
+  let put: i32 = 0;
+  while (put < n) {
+    setIovec(buf + put, n - put);
+    const errno: i32 = fd_write(fd, IOV, 1, RESULT);
+    if (errno !== 0) return false;
+    const w: i32 = load32(RESULT);
+    if (w <= 0) return false;
+    put = put + w;
+  }
+  return true;
+}
+
+// Decode the little-endian uint32 the browser wrote as the first 4 bytes.
+function decodeLength(p: i32): i32 {
+  return load8(p) + load8(p + 1) * 256 + load8(p + 2) * 65536 + load8(p + 3) * 16777216;
+}
+
+// Re-encode `len` as a 4-byte LE prefix at `p` (so we write the frame back whole).
+function encodeLength(p: i32, len: i32): void {
+  store8(p, len & 0xff);
+  store8(p + 1, (len >> 8) & 0xff);
+  store8(p + 2, (len >> 16) & 0xff);
+  store8(p + 3, (len >> 24) & 0xff);
+}
+
+export function main(): void {
+  // Long-lived port loop: read framed messages off stdin (fd 0) and echo each one
+  // back on stdout (fd 1) until EOF. The 4-byte prefix lives at DATA[0..4); the
+  // body streams through DATA[4..4+window). A frame larger than the window is
+  // echoed in window-sized runs (the receiver concatenates the raw bytes, so the
+  // framing prefix + body are byte-identical to the input).
+  const bodyBase: i32 = DATA + 4; // body bytes follow the 4-byte prefix slot
+  const cap: i32 = WINDOW - 4; // bytes of body that fit after the prefix
+
+  while (true) {
+    // 4-byte LE length prefix. EOF (or a zero-length frame) = clean shutdown.
+    if (!readExact(0, DATA, 4)) break;
+    const declaredLen: i32 = decodeLength(DATA);
+    if (declaredLen === 0) break;
+
+    // Write the prefix back first (built whole from the decoded length).
+    encodeLength(DATA, declaredLen);
+    if (!writeExact(1, DATA, 4)) break;
+
+    // Stream the body through the fixed window: read a run into the body window,
+    // write it straight back, repeat until the whole declared body is echoed.
+    let remaining: i32 = declaredLen;
+    let truncated: boolean = false;
+    while (remaining > 0) {
+      let run: i32 = cap;
+      if (remaining < run) run = remaining;
+      if (!readExact(0, bodyBase, run)) {
+        truncated = true;
+        break;
+      }
+      if (!writeExact(1, bodyBase, run)) {
+        truncated = true;
+        break;
+      }
+      remaining = remaining - run;
+    }
+    if (truncated) break; // EOF mid-frame → stop
+  }
+}
+
+// Invoke the entry point. js2wasm compiles a top-level call into the module's
+// `_start`, which wasmtime runs.
+main();

--- a/plan/issues/2657-raw-wasi-p1-fd-import-variant.md
+++ b/plan/issues/2657-raw-wasi-p1-fd-import-variant.md
@@ -1,0 +1,102 @@
+---
+id: 2657
+title: "Raw wasi_snapshot_preview1 fd_read/fd_write import + nm_wasi.ts variant"
+status: done
+completed: 2026-06-25
+assignee: ttraenkler/sendev-rawwasi
+area: host-interop
+language_feature: wasi
+goal: platform
+related: [389, 2655, 2631]
+feasibility: medium
+sprint: Backlog
+---
+
+## Problem
+
+loopdive/js2#389's reporter wants the _most honest pure-WASI-P1_ expression of a
+native-messaging host: **no `node:fs` surface at all**, importing `fd_read` /
+`fd_write` DIRECTLY from `wasi_snapshot_preview1` — the real WASI Preview-1 core
+module a runtime like wasmtime satisfies. The existing `nm_js2wasm.ts` variant
+(#2631/#2655) uses `node:fs` `readSync`/`writeSync`, which is faithful but still
+Node-shaped; this issue adds the raw-syscall variant alongside it.
+
+### Root cause (why it doesn't work on main today)
+
+`import { fd_write } from "wasi_snapshot_preview1"` is stripped by
+`preprocessImports` and replaced with `declare function fd_write(...): any`. Under
+`--target wasi` the resulting bare call binds to nothing (no host target, strict
+mode), and the call is silently dead-code-eliminated — no `fd_write` import is
+emitted. So the raw-WASI import path is simply unimplemented.
+
+## Design
+
+Mirror the existing `wasiNodeFsFuncs` mechanism (#2631) but as a **raw
+passthrough** — the user already supplies the four i32 linear-memory offsets, so
+codegen just binds the identifier to the WASI import func and emits a direct
+`call`. No buffer/scratch management (that's the `node:fs` shim's job).
+
+1. **`compiler.ts`** — `detectRawWasiImports(source)` (pre-preprocessing, like
+   `detectNodeFsImports`) collects the local names imported from
+   `"wasi_snapshot_preview1"` (→ `wasiRawImports`) AND from the intrinsic module
+   `"wasm:memory"` (→ `wasiMemAccessors`). Both threaded through
+   `buildCodegenOptions` → `CodegenContext` (single-source only, same constraint
+   as `wasiNodeFsFuncs`; multi-source stays `undefined`). The preprocessor strips
+   both imports to bare `declare function` stubs, so no ambient `.d.ts` injection
+   was needed — the call sites resolve to typed-`any` stubs and codegen compiles
+   the args under an i32 hint.
+2. **`index.ts` `registerWasiImports`** — when `ctx.wasiRawImports` has
+   `fd_read`/`fd_write`, force `needsFdRead`/`needsFdWrite` so the **existing**
+   #2037 `addImport` → `ctx.wasiFdReadIdx`/`wasiFdWriteIdx` registration fires.
+   No duplicate imports — the user binding routes to the same import func index.
+3. **`raw-wasi-api.ts`** (new) — `tryCompileRawWasiCall`: an unshadowed
+   `fd_read`/`fd_write` bound from `wasi_snapshot_preview1` → a direct `call` of
+   the WASI import (4 i32 args, returns i32 errno); an unshadowed
+   `store32`/`load32`/`store8`/`load8` bound from `wasm:memory` → a single inline
+   memory op. Wired into `calls.ts` just before `tryCompileNodeFsCall`.
+
+See **Implementation notes (final)** below for the honest two-surface naming
+decision and why no allowlist/leak-scan change was needed.
+
+## Implementation notes (final)
+
+### Two honestly-separated source surfaces (naming decision)
+
+`fd_read`/`fd_write` ARE real `wasi_snapshot_preview1` Preview-1 functions, so
+they're imported from `"wasi_snapshot_preview1"` and bound 1:1 to the WASI import
+func. The example also needs to lay out the iovec `{buf, buf_len}` + result slot
+in linear memory, which required a raw linear-memory store/load surface js2wasm
+didn't expose (DataView/ArrayBuffer are GC-backed, not linear). Those accessors
+(`store32`/`load32`/`store8`/`load8`) are NOT WASI host functions — no host
+provides a `wasi_snapshot_preview1.store32` — so surfacing them under the WASI
+module name would mislabel compiler intrinsics as host syscalls (the
+`feedback_node_apis_via_per_module_shim_not_builtin` anti-pattern). They are
+imported from a distinct js2wasm INTRINSIC namespace, **`"wasm:memory"`** (mirrors
+`wasm:js-string`), and lower to a single inline WASM memory op — NO import is
+emitted. So the emitted module's ONLY import module is `wasi_snapshot_preview1`.
+The module-name constant is `WASM_MEMORY_INTRINSIC_MODULE` in `src/compiler.ts`.
+
+### Memory access lowering
+
+| source (`wasm:memory`) | inline op     |
+| ---------------------- | ------------- |
+| `store32(addr, v)`     | `i32.store`   |
+| `load32(addr)`         | `i32.load`    |
+| `store8(addr, v)`      | `i32.store8`  |
+| `load8(addr)`          | `i32.load8_u` |
+
+All gated on `ctx.wasiMemAccessors` (the fd path on `ctx.wasiRawImports`), so the
+whole feature is byte-neutral for any program importing neither module.
+
+### Why no allowlist / leak-scan change
+
+`wasi_snapshot_preview1` is already in `ALWAYS_ALLOWED_IMPORT_MODULES`, and the
+`wasm:memory` accessors emit no import at all, so neither the strict-mode
+allowlist nor the post-link leak scan needed touching.
+
+## Test Results
+
+`tests/issue-2657-raw-wasi-fd-import.test.ts` — all green incl. a REAL wasmtime
+byte-correct framed echo (high/null bytes) and a 150 KiB multi-window body.
+Imports asserted to be ONLY `{wasi_snapshot_preview1}`; accessors verified inline
+(not imports). `nm_js2wasm.ts` (node:fs variant) confirmed still compiling.

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -238,6 +238,8 @@ export function createCodegenContext(
     wasiEnvironGetIdx: -1,
     wasiEnvGetStrIdx: -1,
     wasiNodeFsFuncs: options?.wasiNodeFsFuncs ?? new Set(),
+    wasiRawImports: options?.wasiRawImports ?? new Set(),
+    wasiMemAccessors: options?.wasiMemAccessors ?? new Set(),
     allowFs: options?.allowFs ?? false,
     strictNoHostImports,
     tdzGlobals: new Map(),

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -101,6 +101,17 @@ export interface CodegenOptions {
   /** Set of function names imported from node:fs (detected pre-preprocessing).
    *  Used by both the WASI fs syscall path (#1035) and the JS-host fs imports (#1491). */
   wasiNodeFsFuncs?: Set<string>;
+  /** (#2657) Set of LOCAL names imported from `"wasi_snapshot_preview1"`
+   *  (detected pre-preprocessing). The raw-WASI fd_read/fd_write passthrough
+   *  binds these identifiers directly to the WASI import funcs — the most honest
+   *  pure-WASI-P1 expression, no `node:fs` surface (loopdive/js2#389). */
+  wasiRawImports?: Set<string>;
+  /** (#2657) Set of LOCAL names imported from `"wasm:memory"` — js2wasm's inline
+   *  linear-memory access intrinsics (`store32`/`load32`/`store8`/`load8`). These
+   *  lower to a single WASM memory op (NOT imports); they let a raw-WASI module
+   *  lay out its iovec + result slot without a GC roundtrip. Honestly namespaced
+   *  away from `wasi_snapshot_preview1` (no host provides them). */
+  wasiMemAccessors?: Set<string>;
   /** Allow `node:fs` JS-host imports for non-WASI targets (#1491). Default: false. */
   allowFs?: boolean;
   /**
@@ -1613,6 +1624,14 @@ export interface CodegenContext {
   wasiPendingStdinReactor?: boolean;
   /** Set of node:fs functions used in this compilation unit (both WASI and JS-host fs paths). */
   wasiNodeFsFuncs: Set<string>;
+  /** (#2657) Local names imported from `"wasi_snapshot_preview1"` — the raw-WASI
+   *  fd_read/fd_write passthrough bindings (loopdive/js2#389). Empty for any
+   *  program that does not import the raw WASI module. */
+  wasiRawImports: Set<string>;
+  /** (#2657) Local names imported from `"wasm:memory"` — js2wasm's inline
+   *  linear-memory access intrinsics (`store32`/`load32`/`store8`/`load8`). Empty
+   *  for any program that does not import the intrinsic module. */
+  wasiMemAccessors: Set<string>;
   /**
    * #1886 — Linear-safe `Uint8Array` analysis result. Populated (WASI/standalone
    * only) by `analyzeLinearUint8` as a pre-pass; `undefined` otherwise. Symbols

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -130,6 +130,7 @@ import {
   emitBoolToString,
 } from "../string-ops.js";
 import { tryCompileNodeFsCall, tryCompileNodeProcessCall } from "../node-fs-api.js";
+import { tryCompileRawWasiCall } from "../raw-wasi-api.js";
 import { resolvePromiseSubclassName, tryEmitPromiseSubclassReceiver } from "./promise-subclass.js";
 import { isSupportedBuiltinStaticProperty, resolveBuiltinNamespaceValueName } from "../builtin-static-globals.js";
 import {
@@ -3359,6 +3360,12 @@ function compileCallExpression(
   // call-expression compiler does not accumulate host API special cases.
   const nodeProcessCall = tryCompileNodeProcessCall(ctx, fctx, expr);
   if (nodeProcessCall !== undefined) return nodeProcessCall;
+
+  // #2657 — raw `wasi_snapshot_preview1` fd_read/fd_write → direct WASI import
+  // call (the most honest pure-WASI-P1 path; no node:fs surface). Sits before the
+  // node:fs path; byte-neutral unless the source imports the raw WASI module.
+  const rawWasiCall = tryCompileRawWasiCall(ctx, fctx, expr);
+  if (rawWasiCall !== undefined) return rawWasiCall;
 
   // #2631 — node:fs fd-based readSync/writeSync → `node:fs` shim calls.
   const nodeFsCall = tryCompileNodeFsCall(ctx, fctx, expr);

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -6096,6 +6096,16 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
     if (ctx.wasiNodeFsFuncs.has("writeSync")) needsFdWrite = true;
   }
 
+  // #2657 — RAW `wasi_snapshot_preview1` fd_read/fd_write import. When the source
+  // imports the syscall by name (`import { fd_read, fd_write } from
+  // "wasi_snapshot_preview1"`), the binding maps 1:1 to the import func, so the
+  // import MUST be registered regardless of the shim/direct branch above (the
+  // user wrote the syscall call explicitly). Routes the user binding to the same
+  // `ctx.wasiFdReadIdx`/`wasiFdWriteIdx` — no duplicate import. This sits after
+  // the linkNodeShims recompute so a raw `fd_read` import is never dropped.
+  if (ctx.wasiRawImports.has("fd_read")) needsFdRead = true;
+  if (ctx.wasiRawImports.has("fd_write")) needsFdWrite = true;
+
   // fd_write(fd: i32, iovs: i32, iovs_len: i32, nwritten: i32) -> i32
   if (needsFdWrite) {
     const fdWriteType = addFuncType(

--- a/src/codegen/raw-wasi-api.ts
+++ b/src/codegen/raw-wasi-api.ts
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2657 — RAW `wasi_snapshot_preview1` fd_read / fd_write passthrough + the
+ * minimal linear-memory accessors a raw-WASI module needs.
+ *
+ * The MOST honest pure-WASI-Preview-1 expression of fd-based I/O. Two recognizer
+ * families on two HONESTLY-SEPARATED source-import surfaces (so the source never
+ * mislabels a compiler intrinsic as a WASI host function), each gated on its own
+ * context set so both are byte-neutral for any program that doesn't import them:
+ *
+ *  1. `fd_read` / `fd_write`, imported from `"wasi_snapshot_preview1"` (the REAL
+ *     WASI Preview-1 core module) → a DIRECT `call` of the registered WASI
+ *     import. The user supplies the four raw i32 arguments (an iovec pointer,
+ *     iovec count, and a result-count pointer) exactly as the WASI ABI specifies;
+ *     the program owns linear memory and lays out the iovec itself. The import is
+ *     registered in `registerWasiImports` (index.ts), which routes the binding to
+ *     the SAME `ctx.wasiFdReadIdx` / `ctx.wasiFdWriteIdx` import the #2037
+ *     direct-fd infra already wires — no duplicate import. (Gated on
+ *     `ctx.wasiRawImports`.)
+ *
+ *       import { fd_read, fd_write } from "wasi_snapshot_preview1";
+ *       fd_read (fd, iovs, iovs_len, nread)    -> i32 (errno)
+ *       fd_write(fd, iovs, iovs_len, nwritten) -> i32 (errno)
+ *
+ *  2. `store32` / `load32` / `store8` / `load8`, imported from `"wasm:memory"` (a
+ *     js2wasm INTRINSIC namespace, mirroring `wasm:js-string`) → INLINE WASM
+ *     memory ops (`i32.store` / `i32.load` / `i32.store8` / `i32.load8_u`). These
+ *     are NOT imports — no host provides a `wasm:memory.store32`; they lower to a
+ *     single memory instruction over the module's own exported `memory`, the
+ *     linear-memory access surface that lets a raw-WASI module lay out its iovec
+ *     `{buf, buf_len}` + nread/nwritten slot and move bytes without a GC
+ *     roundtrip. Raw linear-memory access is inherent to the WASM target with no
+ *     Node/Web equivalent, so it is honestly namespaced AWAY from the WASI host
+ *     surface. (Gated on `ctx.wasiMemAccessors`.)
+ *
+ *       import { store32, load32, store8, load8 } from "wasm:memory";
+ *       store32(addr, value) -> void   (i32.store,   4-byte LE)
+ *       load32 (addr)        -> i32     (i32.load,    4-byte LE)
+ *       store8 (addr, value) -> void   (i32.store8,  low byte)
+ *       load8  (addr)        -> i32     (i32.load8_u, zero-extended)
+ *
+ * No `node:fs` surface at all (loopdive/js2#389).
+ */
+import type { Instr } from "../ir/types.js";
+import { ts } from "../ts-api.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { flushLateImportShifts } from "./expressions/late-imports.js";
+import type { InnerResult } from "./shared.js";
+import { coerceType, compileExpression, VOID_RESULT } from "./shared.js";
+
+/** The raw WASI Preview-1 fd functions, recognized by import name → a `call`. */
+const RAW_WASI_FD_FUNCS = new Set(["fd_read", "fd_write"]);
+
+/** The inline linear-memory accessors, recognized by name → a single memory op. */
+const RAW_WASI_MEM_ACCESSORS = new Set(["store32", "load32", "store8", "load8"]);
+
+/**
+ * Compile one call argument as i32. Native i32-annotated args land here
+ * directly; an f64-typed arg is coerced. Used for both the fd-syscall args and
+ * the memory-accessor address/value.
+ */
+function emitI32Arg(ctx: CodegenContext, fctx: FunctionContext, argExpr: ts.Expression): void {
+  const argType = compileExpression(ctx, fctx, argExpr, { kind: "i32" });
+  flushLateImportShifts(ctx, fctx);
+  if (argType) coerceType(ctx, fctx, argType, { kind: "i32" });
+}
+
+/**
+ * Recognize + lower a call to a raw `wasi_snapshot_preview1` binding —
+ * `fd_read`/`fd_write` (→ a direct WASI import call) or one of the inline
+ * linear-memory accessors `store32`/`load32`/`store8`/`load8` (→ a single memory
+ * instruction). Returns the result, or `undefined` when this isn't a raw-WASI
+ * call we handle (the generic compiler then proceeds). Byte-neutral for any
+ * program that doesn't import the raw module — `ctx.wasiRawImports` is empty, so
+ * the early returns fire immediately.
+ */
+export function tryCompileRawWasiCall(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+): InnerResult | undefined {
+  if (!ctx.wasi) return undefined;
+  if (ctx.wasiRawImports.size === 0 && ctx.wasiMemAccessors.size === 0) return undefined;
+  if (expr.questionDotToken) return undefined;
+  if (!ts.isIdentifier(expr.expression)) return undefined;
+  const callee = expr.expression.text;
+
+  // `fd_read`/`fd_write` are intercepted only when imported from
+  // `wasi_snapshot_preview1`; the inline accessors only when imported from
+  // `wasm:memory`. The two surfaces are tracked separately, so a name that
+  // matches the family but came from the WRONG module is left to the generic
+  // path. Also skip any local shadow — a `function fd_read(){}` /
+  // `function load8(){}` must NOT be intercepted.
+  const isFdFunc = RAW_WASI_FD_FUNCS.has(callee) && ctx.wasiRawImports.has(callee);
+  const isMemAccessor = RAW_WASI_MEM_ACCESSORS.has(callee) && ctx.wasiMemAccessors.has(callee);
+  if (!isFdFunc && !isMemAccessor) return undefined;
+  if (fctx.localMap.has(callee) || (fctx.boxedCaptures?.has(callee) ?? false)) return undefined;
+
+  if (isFdFunc) {
+    const importIdx = callee === "fd_read" ? ctx.wasiFdReadIdx : ctx.wasiFdWriteIdx;
+    // Registered up-front in registerWasiImports when the raw binding is present.
+    // If it somehow wasn't (defensive), bail to the generic path.
+    if (importIdx === undefined || importIdx < 0) return undefined;
+    // Raw WASI fd_read/fd_write take exactly four i32 args. A wrong-arity call is
+    // not the raw syscall shape — defer to the generic path.
+    if (expr.arguments.length !== 4) return undefined;
+    for (const argExpr of expr.arguments) emitI32Arg(ctx, fctx, argExpr);
+    fctx.body.push({ op: "call", funcIdx: importIdx } as Instr);
+    // The WASI call leaves the errno (i32) on the stack.
+    return { kind: "i32" };
+  }
+
+  // Inline linear-memory accessor.
+  return emitMemAccessor(ctx, fctx, expr, callee);
+}
+
+/**
+ * Lower a `store32`/`load32`/`store8`/`load8` call to a single WASM memory
+ * instruction over the module's own exported `memory`. Stores return
+ * `VOID_RESULT` (nothing on the stack); loads return an i32.
+ */
+function emitMemAccessor(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.CallExpression,
+  callee: string,
+): InnerResult | undefined {
+  const isStore = callee === "store32" || callee === "store8";
+  // store(addr, value): 2 args; load(addr): 1 arg. Wrong arity → generic path.
+  if (isStore) {
+    if (expr.arguments.length !== 2) return undefined;
+    emitI32Arg(ctx, fctx, expr.arguments[0]!); // addr
+    emitI32Arg(ctx, fctx, expr.arguments[1]!); // value
+    fctx.body.push(
+      callee === "store32"
+        ? ({ op: "i32.store", align: 0, offset: 0 } as Instr)
+        : ({ op: "i32.store8", align: 0, offset: 0 } as Instr),
+    );
+    return VOID_RESULT;
+  }
+
+  if (expr.arguments.length !== 1) return undefined;
+  emitI32Arg(ctx, fctx, expr.arguments[0]!); // addr
+  fctx.body.push(
+    callee === "load32"
+      ? ({ op: "i32.load", align: 0, offset: 0 } as Instr)
+      : ({ op: "i32.load8_u", align: 0, offset: 0 } as Instr),
+  );
+  return { kind: "i32" };
+}

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -511,6 +511,54 @@ function detectNodeFsImports(source: string): Set<string> {
   return result;
 }
 
+/**
+ * #2657 — the source-import module string for js2wasm's raw linear-memory access
+ * intrinsics (`store32`/`load32`/`store8`/`load8`). These are NOT WASI host
+ * functions — they lower to inline `i32.store`/`i32.load`/`i32.store8`/
+ * `i32.load8_u` ops over the module's own exported `memory`. They are honestly
+ * named under a `wasm:` intrinsic namespace (mirroring `wasm:js-string`) so the
+ * source never mislabels a compiler intrinsic as a WASI host import: only
+ * `fd_read`/`fd_write` come from `"wasi_snapshot_preview1"`, the real WASI core
+ * module. (No host provides a `wasi_snapshot_preview1.store32`.)
+ */
+export const WASM_MEMORY_INTRINSIC_MODULE = "wasm:memory";
+
+/**
+ * #2657 — detect the LOCAL names of the raw-WASI source imports BEFORE import
+ * preprocessing strips them (preprocessing rewrites them to bare `declare
+ * function` stubs, losing the module origin). Two honestly-separated surfaces:
+ *
+ *  - `rawWasi`: named imports from `"wasi_snapshot_preview1"` — the real WASI
+ *    Preview-1 fd syscalls (`fd_read`/`fd_write`). The most honest pure-WASI-P1
+ *    path for fd-based IO, with no `node:fs` surface (loopdive/js2#389). These
+ *    bind directly to the WASI import funcs.
+ *  - `memAccessors`: named imports from `"wasm:memory"` — js2wasm's inline
+ *    linear-memory access intrinsics (`store32`/`load32`/`store8`/`load8`). These
+ *    are NOT imports; they lower to a single WASM memory op.
+ *
+ * The returned LOCAL names (honoring `as` aliases) drive `tryCompileRawWasiCall`.
+ * Both sets are empty for any program that doesn't import the respective module,
+ * so the rest of the compiler is unaffected.
+ */
+function detectRawWasiImports(source: string): { rawWasi: Set<string>; memAccessors: Set<string> } {
+  const rawWasi = new Set<string>();
+  const memAccessors = new Set<string>();
+  const sf = ts.createSourceFile("__detect_raw_wasi__.ts", source, ts.ScriptTarget.Latest, true);
+  for (const stmt of sf.statements) {
+    if (!ts.isImportDeclaration(stmt) || !stmt.moduleSpecifier || !ts.isStringLiteral(stmt.moduleSpecifier)) continue;
+    const mod = stmt.moduleSpecifier.text;
+    const target =
+      mod === "wasi_snapshot_preview1" ? rawWasi : mod === WASM_MEMORY_INTRINSIC_MODULE ? memAccessors : undefined;
+    if (!target) continue;
+    const clause = stmt.importClause;
+    if (clause?.namedBindings && ts.isNamedImports(clause.namedBindings)) {
+      // `el.name` is the LOCAL binding (after any `as` alias) the call sites use.
+      for (const el of clause.namedBindings.elements) target.add(el.name.text);
+    }
+  }
+  return { rawWasi, memAccessors };
+}
+
 /** The canonical empty failure result. #1927 — replaces the inline copies. */
 function failResult(errors: CompileError[]): CompileResult {
   return {
@@ -573,6 +621,8 @@ function buildCodegenOptions(
   prep?: {
     nodeBuiltins?: import("./import-resolver.js").NodeBuiltinImport[];
     wasiNodeFsFuncs?: Set<string>;
+    wasiRawImports?: Set<string>;
+    wasiMemAccessors?: Set<string>;
     jsxRuntime?: import("./import-resolver.js").JsxRuntimeImport;
   },
 ): CodegenOptions {
@@ -601,6 +651,8 @@ function buildCodegenOptions(
     // separate change (tracked alongside #2138).
     nodeBuiltins: prep?.nodeBuiltins,
     wasiNodeFsFuncs: prep?.wasiNodeFsFuncs,
+    wasiRawImports: prep?.wasiRawImports,
+    wasiMemAccessors: prep?.wasiMemAccessors,
     allowFs: options.allowFs ?? false,
     jsxRuntime: prep?.jsxRuntime,
   };
@@ -973,6 +1025,11 @@ export function compileSourceSync(
   // it contributes an identity map and is omitted from the composition.
   const cjsRewritten2 = rewriteEvalSuperCall(cjsRewritten);
   const wasiNodeFsFuncs = detectNodeFsImports(cjsRewritten);
+  // #2657 — raw `wasi_snapshot_preview1` fd_read/fd_write imports + the
+  // `wasm:memory` inline linear-memory accessors (detected pre-preprocessing,
+  // like node:fs above). Both empty for every program that doesn't import the
+  // respective module, so it's byte-neutral elsewhere.
+  const { rawWasi: wasiRawImports, memAccessors: wasiMemAccessors } = detectRawWasiImports(cjsRewritten);
   const preprocessed = preprocessImports(cjsRewritten2, { wasi: options.target === "wasi" });
   const processedSource = preprocessed.source;
   // Composed map: processedSource → original source. Pipeline output order is
@@ -1141,6 +1198,8 @@ export function compileSourceSync(
     codegenOptions: buildCodegenOptions(options, emitSourceMap, {
       nodeBuiltins: preprocessed.nodeBuiltins,
       wasiNodeFsFuncs,
+      wasiRawImports,
+      wasiMemAccessors,
       jsxRuntime: preprocessed.jsxRuntime,
     }),
     sourcesContent,

--- a/tests/issue-2657-raw-wasi-fd-import.test.ts
+++ b/tests/issue-2657-raw-wasi-fd-import.test.ts
@@ -1,0 +1,310 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2657 — RAW `wasi_snapshot_preview1` fd_read/fd_write import variant.
+ *
+ * The most honest pure-WASI-Preview-1 expression of fd-based IO: the source
+ * imports the syscalls directly —
+ *
+ *   import { fd_read, fd_write } from "wasi_snapshot_preview1";
+ *   import { store32, load32, store8, load8 } from "wasm:memory";
+ *
+ * — the fd calls bind 1:1 to the WASI import (fd_read/fd_write); the `wasm:memory`
+ * accessors lower to a single inline linear-memory op (store32/load32/store8/
+ * load8) and emit NO import (no host provides them). There is NO `node:fs`
+ * surface: the emitted module imports ONLY `wasi_snapshot_preview1`, owns +
+ * exports `memory`, and runs under wasmtime (loopdive/js2#389).
+ *
+ * These cases pin:
+ *   1. a raw fd echo compiles, imports ONLY `wasi_snapshot_preview1` (fd_read +
+ *      fd_write, no node:fs / no env), owns+exports `memory`, and round-trips a
+ *      framed message byte-correctly (incl. high + null bytes) under a fd shim;
+ *   2. `store32/load32/store8/load8` lower inline (NOT as imports);
+ *   3. the full `examples/native-messaging/nm_wasi.ts` host echoes a framed
+ *      Native-Messaging message byte-correctly under REAL wasmtime (gated on
+ *      `findWasmtime()`), incl. a multi-window body;
+ *   4. the existing `node:fs` example (`nm_js2wasm.ts`) still compiles unchanged.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// wasmtime feature flags for the WasmGC + exception-handling binaries js2wasm
+// emits (structs/arrays + the exception tag).
+const WASMTIME_FLAGS = ["-W", "gc=y,function-references=y,exceptions=y"];
+
+/** Resolve a usable `wasmtime` binary, or null when none is on PATH. */
+function findWasmtime(): string | null {
+  for (const cand of ["wasmtime", "/usr/local/bin/wasmtime"]) {
+    try {
+      execFileSync(cand, ["--version"], { stdio: "ignore" });
+      return cand;
+    } catch {
+      /* try next */
+    }
+  }
+  return null;
+}
+
+const wasmtimeBin = findWasmtime();
+
+let tmpDir: string;
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "issue-2657-"));
+});
+afterAll(() => {
+  if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function compileWasi(src: string, name: string): Promise<Uint8Array> {
+  const r = await compile(src, { fileName: `${name}.ts`, target: "wasi", skipSemanticDiagnostics: true });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  return r.binary!;
+}
+
+/** Extract the (module,name) pairs of every import in a compiled WAT. */
+function importModules(wat: string): Set<string> {
+  const mods = new Set<string>();
+  for (const line of wat.split("\n")) {
+    const m = line.match(/\(import\s+"([^"]+)"/);
+    if (m) mods.add(m[1]!);
+  }
+  return mods;
+}
+
+/**
+ * Run a compiled raw-WASI module under an in-process fd_read/fd_write shim over
+ * the module's exported `memory`, feeding `stdinBytes` to fd 0 and capturing fd 1
+ * output as raw bytes. Mirrors the wasmtime fd ABI: iovec list + result slot.
+ */
+async function runWithFdShim(binary: Uint8Array, stdinBytes: Uint8Array): Promise<Uint8Array> {
+  let inPos = 0;
+  const out: number[] = [];
+  const ref: { mem?: WebAssembly.Memory } = {};
+  const dv = (): DataView => new DataView(ref.mem!.buffer);
+  const wasi = {
+    fd_read(_fd: number, iovs: number, iovsLen: number, nread: number): number {
+      const v = dv();
+      const mem = new Uint8Array(ref.mem!.buffer);
+      let total = 0;
+      for (let i = 0; i < iovsLen; i++) {
+        const buf = v.getUint32(iovs + i * 8, true);
+        const len = v.getUint32(iovs + i * 8 + 4, true);
+        const n = Math.min(len, stdinBytes.length - inPos);
+        for (let j = 0; j < n; j++) mem[buf + j] = stdinBytes[inPos + j]!;
+        inPos += n;
+        total += n;
+      }
+      v.setUint32(nread, total, true);
+      return 0;
+    },
+    fd_write(_fd: number, iovs: number, iovsLen: number, nwritten: number): number {
+      const v = dv();
+      const mem = new Uint8Array(ref.mem!.buffer);
+      let total = 0;
+      for (let i = 0; i < iovsLen; i++) {
+        const buf = v.getUint32(iovs + i * 8, true);
+        const len = v.getUint32(iovs + i * 8 + 4, true);
+        for (let j = 0; j < len; j++) out.push(mem[buf + j]!);
+        total += len;
+      }
+      v.setUint32(nwritten, total, true);
+      return 0;
+    },
+    proc_exit(): void {},
+    random_get(): number {
+      return 0;
+    },
+    clock_time_get(): number {
+      return 0;
+    },
+  };
+  const { instance } = await WebAssembly.instantiate(binary, {
+    wasi_snapshot_preview1: wasi as unknown as WebAssembly.ModuleImports,
+    env: {},
+  });
+  ref.mem = instance.exports.memory as WebAssembly.Memory;
+  const start = (instance.exports._start ?? instance.exports.main) as () => void;
+  start();
+  return Uint8Array.from(out);
+}
+
+/** Frame a body as a 4-byte LE length prefix + the body bytes (Native Messaging). */
+function frame(body: Uint8Array): Uint8Array {
+  const out = new Uint8Array(4 + body.length);
+  const n = body.length;
+  out[0] = n & 0xff;
+  out[1] = (n >> 8) & 0xff;
+  out[2] = (n >> 16) & 0xff;
+  out[3] = (n >> 24) & 0xff;
+  out.set(body, 4);
+  return out;
+}
+
+/** A minimal raw-fd echo: read a framed message and write it back verbatim. */
+const RAW_ECHO_SRC = `
+import { fd_read, fd_write } from "wasi_snapshot_preview1";
+import { store32, load32, store8, load8 } from "wasm:memory";
+type i32 = number;
+const IOV: i32 = 0;
+const RESULT: i32 = 8;
+const DATA: i32 = 64;
+function setIovec(buf: i32, len: i32): void {
+  store32(IOV, buf);
+  store32(IOV + 4, len);
+  store32(RESULT, 0);
+}
+function readExact(buf: i32, n: i32): boolean {
+  let got: i32 = 0;
+  while (got < n) {
+    setIovec(buf + got, n - got);
+    const errno: i32 = fd_read(0, IOV, 1, RESULT);
+    if (errno !== 0) return false;
+    const r: i32 = load32(RESULT);
+    if (r <= 0) return false;
+    got = got + r;
+  }
+  return true;
+}
+function writeExact(buf: i32, n: i32): boolean {
+  let put: i32 = 0;
+  while (put < n) {
+    setIovec(buf + put, n - put);
+    const errno: i32 = fd_write(1, IOV, 1, RESULT);
+    if (errno !== 0) return false;
+    const w: i32 = load32(RESULT);
+    if (w <= 0) return false;
+    put = put + w;
+  }
+  return true;
+}
+export function main(): void {
+  if (!readExact(DATA, 4)) return;
+  const len: i32 = load8(DATA) + load8(DATA + 1) * 256 + load8(DATA + 2) * 65536 + load8(DATA + 3) * 16777216;
+  if (len === 0) return;
+  if (!writeExact(DATA, 4)) return;
+  if (!readExact(DATA + 4, len)) return;
+  writeExact(DATA + 4, len);
+}
+main();
+`;
+
+describe("#2657 raw wasi_snapshot_preview1 fd import — compile + imports", () => {
+  it("imports ONLY wasi_snapshot_preview1 (fd_read + fd_write), owns+exports memory", async () => {
+    const r = await compile(RAW_ECHO_SRC, { fileName: "echo.ts", target: "wasi", skipSemanticDiagnostics: true });
+    expect(r.success, r.success ? "" : r.errors?.[0]?.message).toBe(true);
+    const wat = r.wat!;
+    // The ONLY import module is the raw WASI core module — no node:fs, no env.
+    expect(importModules(wat)).toEqual(new Set(["wasi_snapshot_preview1"]));
+    expect(wat).toContain('(import "wasi_snapshot_preview1" "fd_read"');
+    expect(wat).toContain('(import "wasi_snapshot_preview1" "fd_write"');
+    expect(wat).not.toContain("node:fs");
+    // Owns + exports its own linear memory.
+    expect(wat).toContain('(export "memory"');
+    expect(WebAssembly.validate(r.binary!)).toBe(true);
+  });
+
+  it("store32/load32/store8/load8 lower INLINE (not as imports)", async () => {
+    const r = await compile(RAW_ECHO_SRC, { fileName: "echo.ts", target: "wasi", skipSemanticDiagnostics: true });
+    const wat = r.wat!;
+    // The accessors must NOT appear as imports — they are inline memory ops.
+    expect(wat).not.toContain('"store32"');
+    expect(wat).not.toContain('"load32"');
+    expect(wat).not.toContain('"store8"');
+    expect(wat).not.toContain('"load8"');
+    // The inline memory ops are present.
+    expect(wat).toContain("i32.store");
+    expect(wat).toContain("i32.load");
+  });
+
+  it("a program that does NOT import the raw module is byte-neutral (no fd import forced)", async () => {
+    const r = await compile(`export function add(a: number, b: number): number { return a + b; }`, {
+      fileName: "plain.ts",
+      target: "wasi",
+      skipSemanticDiagnostics: true,
+    });
+    expect(r.success).toBe(true);
+    expect(r.wat!).not.toContain('"fd_read"');
+    expect(r.wat!).not.toContain('"fd_write"');
+  });
+});
+
+describe("#2657 raw fd echo — round-trip under a fd shim", () => {
+  it("echoes a framed message byte-for-byte (incl. high + null bytes)", async () => {
+    const binary = await compileWasi(RAW_ECHO_SRC, "echo");
+    // Body with high bytes (0xff, 0x80) and a null byte — the raw syscall layer
+    // is byte-opaque, so the frame must come back unchanged.
+    const body = Uint8Array.from([0x7b, 0x00, 0xff, 0x41, 0x80, 0x7d]); // { \0 \xff A \x80 }
+    const input = frame(body);
+    const out = await runWithFdShim(binary, input);
+    expect(Array.from(out)).toEqual(Array.from(input));
+  });
+
+  it("echoes an empty payload (zero-length frame is a clean shutdown)", async () => {
+    const binary = await compileWasi(RAW_ECHO_SRC, "echo");
+    const input = frame(new Uint8Array(0)); // declaredLen 0 → main returns before any write
+    const out = await runWithFdShim(binary, input);
+    expect(out.length).toBe(0);
+  });
+});
+
+describe("#2657 nm_wasi.ts example — real Native-Messaging host", () => {
+  const examplePath = join(__dirname, "..", "examples", "native-messaging", "nm_wasi.ts");
+
+  it("compiles under --target wasi importing ONLY wasi_snapshot_preview1", async () => {
+    const src = readFileSync(examplePath, "utf-8");
+    const r = await compile(src, { fileName: "nm_wasi.ts", target: "wasi", skipSemanticDiagnostics: true });
+    expect(r.success, r.success ? "" : r.errors?.[0]?.message).toBe(true);
+    expect(importModules(r.wat!)).toEqual(new Set(["wasi_snapshot_preview1"]));
+    expect(r.wat!).not.toContain("node:fs");
+    expect(r.wat!).toContain('(export "memory"');
+    expect(WebAssembly.validate(r.binary!)).toBe(true);
+  });
+
+  it("echoes a small framed JSON message byte-correctly under a fd shim", async () => {
+    const src = readFileSync(examplePath, "utf-8");
+    const binary = await compileWasi(src, "nm_wasi");
+    const body = new TextEncoder().encode('["hello",null,42]');
+    const input = frame(body);
+    const out = await runWithFdShim(binary, input);
+    expect(Array.from(out)).toEqual(Array.from(input));
+  });
+
+  it("echoes a multi-window body (> 64 KiB streams through the fixed window)", async () => {
+    const src = readFileSync(examplePath, "utf-8");
+    const binary = await compileWasi(src, "nm_wasi");
+    // 150 KiB body with a deterministic byte pattern incl. nulls + high bytes.
+    const n = 150 * 1024;
+    const body = new Uint8Array(n);
+    for (let i = 0; i < n; i++) body[i] = (i * 31 + (i >> 7)) & 0xff;
+    const input = frame(body);
+    const out = await runWithFdShim(binary, input);
+    expect(out.length).toBe(input.length);
+    expect(Array.from(out)).toEqual(Array.from(input));
+  });
+
+  it.runIf(wasmtimeBin)("runs under REAL wasmtime: byte-correct framed echo", async () => {
+    const src = readFileSync(examplePath, "utf-8");
+    const binary = await compileWasi(src, "nm_wasi_wasmtime");
+    const path = join(tmpDir, "nm_wasi.wasm");
+    writeFileSync(path, binary);
+    const body = Uint8Array.from([0x5b, 0x00, 0xff, 0x80, 0x41, 0x5d]); // [ \0 \xff \x80 A ]
+    const input = frame(body);
+    const out = execFileSync(wasmtimeBin!, [...WASMTIME_FLAGS, path], { input: Buffer.from(input) });
+    expect(Array.from(out)).toEqual(Array.from(input));
+  });
+});
+
+describe("#2657 — node:fs variant unchanged", () => {
+  it("the existing nm_js2wasm.ts example still compiles under --target wasi", async () => {
+    const src = readFileSync(join(__dirname, "..", "examples", "native-messaging", "nm_js2wasm.ts"), "utf-8");
+    const r = await compile(src, { fileName: "nm_js2wasm.ts", target: "wasi", skipSemanticDiagnostics: true });
+    expect(r.success, r.success ? "" : r.errors?.[0]?.message).toBe(true);
+    // The node:fs variant declares WHAT it needs as `node:fs`; it must NOT have
+    // grown a raw `wasi_snapshot_preview1` direct import path by accident.
+    expect(r.wat!).toContain("fd_read");
+    expect(r.wat!).toContain("fd_write");
+  });
+});


### PR DESCRIPTION
## #2657 — raw `wasi_snapshot_preview1` fd_read/fd_write import variant

The most honest pure-WASI-Preview-1 expression of fd-based IO for the
Native-Messaging host (loopdive/js2#389, the reporter is "not chasing Node.js"):
bind `import { fd_read, fd_write } from "wasi_snapshot_preview1"` directly to the
real WASI P1 syscall imports — **no `node:fs` surface at all**. A raw call
`fd_write(fd, iovs, iovsLen, nwrittenPtr)` compiles to a direct `call` of the
import (4 i32 args → i32 errno), reusing #2037's `ctx.wasiFdReadIdx`/`wasiFdWriteIdx`
(no duplicate import).

### Two honestly-separated source surfaces (naming)
A raw module must also lay out the iovec `{buf, buf_len}` + result slot in linear
memory, which js2wasm didn't expose (DataView/ArrayBuffer are GC-backed, not
linear). This adds four **inline** linear-memory accessors — `store32`/`load32`/
`store8`/`load8` → `i32.store`/`i32.load`/`i32.store8`/`i32.load8_u`. These are
**not** WASI host functions (no host provides a `wasi_snapshot_preview1.store32`),
so surfacing them under the WASI module name would mislabel compiler intrinsics as
host syscalls. They are imported from a distinct js2wasm **intrinsic** namespace
**`"wasm:memory"`** (mirrors `wasm:js-string`) and emit **NO import**. So the
emitted module's ONLY import module is `wasi_snapshot_preview1`; it owns + exports
`memory`.

### Files
- `src/compiler.ts` — `detectRawWasiImports` (both modules) → `wasiRawImports` /
  `wasiMemAccessors`, threaded via `buildCodegenOptions` → `CodegenContext`.
- `src/codegen/index.ts` `registerWasiImports` — force the fd import on a raw binding.
- `src/codegen/raw-wasi-api.ts` (new) — `tryCompileRawWasiCall` (fd call vs inline mem op).
- `src/codegen/expressions/calls.ts` — dispatch before `tryCompileNodeFsCall`.
- `examples/native-messaging/nm_wasi.ts` (new) — raw echo host alongside `nm_js2wasm.ts`.
- `tests/issue-2657-raw-wasi-fd-import.test.ts` (new).

### Validation
- 10/10 in the new test file incl. a **REAL wasmtime** byte-correct framed echo
  (high/null bytes) + a 150 KiB multi-window body; imports asserted to be ONLY
  `{wasi_snapshot_preview1}`; accessors verified inline (not imports).
- `node:fs` example (`nm_js2wasm.ts`) + #2655 direct path + shim path unchanged.
- tsc clean; WASI + host-import-allowlist suites green. Byte-neutral for programs
  importing neither module (gated on the two ctx sets).

Closes #2657.

🤖 Generated with [Claude Code](https://claude.com/claude-code)