### PR TITLE
fix(#2161): standalone native RegExp for const-foldable new RegExp() patterns

### DIFF
--- a/plan/issues/2161-standalone-regexp-engine-residual.md
+++ b/plan/issues/2161-standalone-regexp-engine-residual.md
@@ -445,3 +445,54 @@ regex-engine / result-shape work — **no value-rep / substrate dependency**.
 
 **#2161 stays open** as the umbrella tracker for the reflection (#2158-gated) and
 dynamic-receiver residuals once #2588-#2591 land.
+
+## Slice 9 (2026-06-25, sdev-async-sm) — const-foldable `new RegExp(...)` patterns
+
+**Landed.** Regrounded against current main (HEAD `7f66cc33e`, after #2588-#2591 +
+#2637 all merged): probed every residual RegExp bucket in `--target standalone`
+(empty importObject). The 4 architect slices are done; the dominant remaining
+buckets are #2175-gated reflection and the dynamic/`any`-typed receiver
+architecture — neither bounded. The **one genuinely bounded, substrate-independent
+win left** was the dynamic-constructor-pattern bucket, *narrowed to its
+compile-time-constant subset*.
+
+**Root cause (pinned):** `compileStandaloneRegExpConstructor`
+(`regexp-standalone.ts`) recovered the pattern via the narrow `staticStringValue`,
+which only accepts a bare string literal. Patterns that ARE compile-time-constant
+and CAN be compiled to native bytecode were rejected → lowered to a placeholder
+that **runtime-traps** (the documented "dynamic ctor patterns illegal-cast"):
+  - `new RegExp("a" + "b")` — string-literal concatenation,
+  - `const p = "ab"; new RegExp(p)` — `const`-bound literal,
+  - `new RegExp(/ab/g)` / `new RegExp(/ab/, "i")` — §22.2.3.1 copy-constructor.
+
+**Fix** (`regexp-standalone.ts`, +112 LoC, zero new host imports, zero substrate
+dep): new `staticConstStringValue` (recursively folds string literals, `const`-
+bound identifiers, and `a + b` concatenation; refuses template substitutions,
+numeric coercions, `let`/`var`/reassigned bindings) + `staticRegExpLiteralCopy`
+(the §22.2.3.1 copy form: flags arg OVERRIDES the literal's flags, omitted/
+`undefined` INHERITS them). Both `compileStandaloneRegExpConstructor` and
+`staticRegExpPatternFlags` (the receiver-recovery helper used by downstream
+`re.test`/`re.exec`/etc.) now route these const-foldable forms to the existing
+native `compileStandaloneRegExpPattern`. A genuinely-dynamic pattern (function
+param, `let`, reassigned) still resolves to `null` and keeps the prior dynamic
+behaviour — behaviour-preserving for every existing static form.
+
+**Validation.** New `tests/issue-2161-regex-const-ctor.test.ts` (9 cases: concat,
+const-bound, chained const+concat, copy-ctor inherit/override flags, downstream
+`re.test`, two no-regression controls, and a guard that a dynamic param is NOT
+mis-folded). All standalone, empty importObject, zero host-import leak. The
+pre-existing standalone-regex suites are unchanged by this slice (the handful of
+already-red "expects refusal" cases in `issue-1474`/`issue-1539` predate this
+slice — earlier slices (#1912) turned those static-invalid refusals into a
+runtime `throw`; not in this slice's scope and not in the CI equivalence gate).
+
+**Future architect-spec items (NOT this window — bounded budget call):**
+- **Dynamic / `any`-typed regex receivers** (`function f(re: RegExp){re.test(s)}`
+  returns wrong / `re.exec` → "Cannot convert object to primitive value"; truly-
+  runtime `new RegExp(runtimeString)` runtime-traps): needs a **runtime regex
+  compiler in wasm** (parse + compile-to-bytecode at runtime) and/or the
+  runtime-externref regex-receiver generalisation of `emitRegexExecArrayCall`.
+  Larger architectural slice — file as its own architect-spec issue.
+- **`RegExp.prototype` reflection (~126)** — still gated on **#2175** (in-progress;
+  standalone builtin-prototype-object representation). Both are the next-sprint
+  pickups for the #2161 umbrella.

--- a/plan/issues/2161-standalone-regexp-engine-residual.md
+++ b/plan/issues/2161-standalone-regexp-engine-residual.md
@@ -5,9 +5,9 @@ status: blocked
 assignee: ttraenkler/sd1
 sprint: 66
 created: 2026-06-15
-updated: 2026-06-24
+updated: 2026-06-25
 blocked_on: [2175]
-reconcile_note: "RECONCILED 2026-06-23 — all 4 sliced sub-issues merged (#2588/#2589 PR#1914, #2590 #1908, #2591 #1907). Remaining residual = RegExp.prototype reflection (gated on the #2175 builtin-prototype-readers substrate) + dynamic/any-typed regex receivers. No substrate-independent dev slice left; umbrella tracker blocked on #2175."
+reconcile_note: "RECONCILED 2026-06-23 — all 4 sliced sub-issues merged (#2588/#2589 PR#1914, #2590 #1908, #2591 #1907). 2026-06-25 (sdev-async-sm): Slice 9 landed one MORE bounded substrate-independent win the prior reconcile missed — const-foldable new RegExp() patterns (concat / const-bound literal / §22.2.3.1 regex-literal copy-ctor) now compile to the native engine instead of runtime-trapping (see Slice 9). Remaining residual = RegExp.prototype reflection (gated on #2175) + dynamic/any-typed receivers + truly-runtime ctor patterns (need a runtime regex compiler — future architect-spec, NOT bounded). Umbrella stays blocked on #2175 for the reflection bucket."
 priority: high
 feasibility: hard
 reasoning_effort: high

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -347,6 +347,89 @@ function staticStringValue(ctx: CodegenContext, expr: ts.Expression): string | n
   return null;
 }
 
+/**
+ * #2161 — recover a **compile-time-constant** string from a `new RegExp(...)`
+ * pattern / flags argument that `staticStringValue` is too narrow to fold.
+ *
+ * Returns the folded string, `undefined` for a statically-`undefined` operand
+ * (so the caller can apply the spec default), or `null` when the operand is not
+ * a constant we can resolve at compile time (genuinely dynamic — the caller
+ * keeps the existing refusal, which lowers to a runtime path).
+ *
+ * Folds, recursively:
+ *   - string literals / no-substitution templates (same as `staticStringValue`),
+ *   - `const`-bound identifiers initialised to a foldable constant,
+ *   - `a + b` string concatenation where both sides fold to strings, and
+ *   - parenthesised / `as` / `!` wrappers (via `stripStaticWrapper`).
+ *
+ * It intentionally does NOT fold template literals with substitutions, numeric
+ * coercions, or `let`/`var` / reassigned bindings — those stay dynamic. Bounded
+ * + behaviour-preserving: a pattern this resolves was already statically known,
+ * so routing it to the native engine cannot change a previously-correct result
+ * (the only prior behaviour for these forms was a runtime trap).
+ */
+function staticConstStringValue(
+  ctx: CodegenContext,
+  expr: ts.Expression,
+  seen: Set<ts.Node> = new Set(),
+): string | null | undefined {
+  const cur = stripStaticWrapper(expr);
+
+  // Direct literal / undefined — defer to the narrow helper first.
+  const direct = staticStringValue(ctx, cur);
+  if (direct !== null) return direct;
+
+  // `a + b` — fold when both operands fold to strings.
+  if (ts.isBinaryExpression(cur) && cur.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+    const left = staticConstStringValue(ctx, cur.left, seen);
+    if (typeof left !== "string") return null;
+    const right = staticConstStringValue(ctx, cur.right, seen);
+    if (typeof right !== "string") return null;
+    return left + right;
+  }
+
+  // `const`-bound identifier → follow its initialiser once.
+  if (ts.isIdentifier(cur)) {
+    const sym = ctx.checker.getSymbolAtLocation(cur);
+    const decl = sym?.valueDeclaration;
+    if (!decl || !ts.isVariableDeclaration(decl) || !decl.initializer) return null;
+    const list = decl.parent;
+    if (!ts.isVariableDeclarationList(list) || (list.flags & ts.NodeFlags.Const) === 0) return null;
+    if (seen.has(decl.initializer)) return null;
+    seen.add(decl.initializer);
+    return staticConstStringValue(ctx, decl.initializer, seen);
+  }
+
+  return null;
+}
+
+/**
+ * #2161 — recover pattern + flags from a regex-literal first argument to
+ * `new RegExp(/…/f [, flags])` (the §22.2.3.1 copy-constructor form). When the
+ * second `flags` argument is provided it OVERRIDES the literal's own flags
+ * (step 4.b/7); when omitted (or statically `undefined`) the literal's flags
+ * are inherited (step 4.a). `flagsArg` must itself fold to a constant (or be
+ * absent/undefined); a dynamic flags argument returns `null` (stays refused).
+ */
+function staticRegExpLiteralCopy(
+  ctx: CodegenContext,
+  patternArg: ts.Expression,
+  flagsArg: ts.Expression | undefined,
+): StaticRegExpPatternFlags | null {
+  const unwrapped = stripStaticWrapper(patternArg);
+  if (unwrapped.kind !== ts.SyntaxKind.RegularExpressionLiteral) return null;
+  const text = (unwrapped as ts.RegularExpressionLiteral).text;
+  const lastSlash = text.lastIndexOf("/");
+  const litPattern = lastSlash >= 0 ? text.slice(1, lastSlash) : text;
+  const litFlags = lastSlash >= 0 ? text.slice(lastSlash + 1) : "";
+
+  if (flagsArg === undefined) return { pattern: litPattern, flags: litFlags };
+  const overrideFlags = staticConstStringValue(ctx, flagsArg);
+  if (overrideFlags === null) return null; // dynamic flags → stay refused
+  // `undefined` flags argument inherits the literal's flags (§22.2.3.1 step 4.a).
+  return { pattern: litPattern, flags: overrideFlags ?? litFlags };
+}
+
 interface StaticRegExpPatternFlags {
   pattern: string;
   flags: string;
@@ -372,8 +455,16 @@ function staticRegExpPatternFlags(ctx: CodegenContext, expr: ts.Expression): Sta
     if (!ts.isIdentifier(callee) || !isGlobalRegExpIdentifier(ctx, callee)) return null;
     const patternArg = unwrapped.arguments?.[0];
     const flagsArg = unwrapped.arguments?.[1];
-    const pattern = patternArg === undefined ? "" : staticStringValue(ctx, patternArg);
-    const flags = flagsArg === undefined ? "" : staticStringValue(ctx, flagsArg);
+    // #2161 — a regex-literal first arg is the §22.2.3.1 copy form.
+    if (patternArg !== undefined) {
+      const copy = staticRegExpLiteralCopy(ctx, patternArg, flagsArg);
+      if (copy !== null) return copy;
+    }
+    // #2161 — fold compile-time-constant pattern/flags (concat, const-bound)
+    // so a `const re = new RegExp("a"+"b","g")` binding is recognised as a
+    // backend-created receiver for downstream `re.test`/`re.exec`/etc.
+    const pattern = patternArg === undefined ? "" : staticConstStringValue(ctx, patternArg);
+    const flags = flagsArg === undefined ? "" : staticConstStringValue(ctx, flagsArg);
     if (pattern === null || flags === null) return null;
     return { pattern: pattern ?? "", flags: flags ?? "" };
   }
@@ -691,13 +782,30 @@ export function compileStandaloneRegExpConstructor(
   const patternArg = args[0];
   const flagsArg = args[1];
 
-  const pattern = patternArg === undefined ? "" : staticStringValue(ctx, patternArg);
+  // #2161 — §22.2.3.1 copy-constructor: `new RegExp(/…/f [, flags])`. The first
+  // argument is a regex literal; the pattern (and inherited-or-overridden flags)
+  // are statically known, so route to the native engine instead of refusing.
+  if (patternArg !== undefined) {
+    const copy = staticRegExpLiteralCopy(ctx, patternArg, flagsArg);
+    if (copy !== null) {
+      const syntaxMsg = hostRegExpSyntaxErrorMessage(copy.pattern, copy.flags);
+      if (syntaxMsg !== null && hasStandaloneRegExpEngine(ctx)) {
+        return emitThrowRegExpSyntaxError(ctx, fctx, syntaxMsg);
+      }
+      return compileStandaloneRegExpPattern(ctx, fctx, copy.pattern, copy.flags, node);
+    }
+  }
+
+  // #2161 — fold compile-time-constant patterns/flags (string-literal concat,
+  // `const`-bound literals) that `staticStringValue` alone is too narrow for;
+  // genuinely dynamic operands still resolve to `null` and keep the refusal.
+  const pattern = patternArg === undefined ? "" : staticConstStringValue(ctx, patternArg);
   if (pattern === null) {
     reportStandaloneRegExpUnsupported(ctx, patternArg, "dynamic constructor patterns");
     return null;
   }
 
-  const flags = flagsArg === undefined ? "" : staticStringValue(ctx, flagsArg);
+  const flags = flagsArg === undefined ? "" : staticConstStringValue(ctx, flagsArg);
   if (flags === null) {
     reportStandaloneRegExpUnsupported(ctx, flagsArg, "dynamic constructor flags");
     return null;

--- a/tests/issue-2161-regex-const-ctor.test.ts
+++ b/tests/issue-2161-regex-const-ctor.test.ts
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2161 — standalone `new RegExp(...)` with a **compile-time-constant** pattern.
+ *
+ * The standalone native RegExp engine compiles a pattern to bytecode at COMPILE
+ * time, so `new RegExp(<dynamicPattern>)` (a genuinely runtime string) must
+ * refuse / route to the dynamic path. But the constructor's static-pattern
+ * recovery used a helper (`staticStringValue`) that only accepted a bare string
+ * literal — so patterns that ARE compile-time-constant and CAN be lowered to the
+ * native engine were rejected and lowered to a placeholder that **runtime-trapped**:
+ *
+ *   - `new RegExp("a" + "b")`        — string-literal concatenation,
+ *   - `const p = "ab"; new RegExp(p)` — `const`-bound literal,
+ *   - `new RegExp(/ab/g)` / `new RegExp(/ab/, "i")` — §22.2.3.1 copy-constructor.
+ *
+ * This slice folds those constants (`staticConstStringValue`) and handles the
+ * regex-literal copy form (`staticRegExpLiteralCopy`), routing them to the
+ * existing native `compileStandaloneRegExpPattern`. Zero new host imports, zero
+ * substrate dependency, behaviour-preserving for every existing static form. A
+ * genuinely-dynamic pattern (function param, `let`, reassigned binding) is NOT
+ * folded and keeps the prior dynamic behaviour.
+ *
+ * Spec: ECMA-262 §22.2.3.1 RegExp(pattern, flags) — when pattern is a RegExp,
+ * inherit `[[OriginalFlags]]` if flags is `undefined`, else use flags.
+ *
+ * Still open under #2161 (NOT this slice): `RegExp.prototype` reflection
+ * (#2175-gated builtin-prototype-object substrate) and dynamic/`any`-typed
+ * regex receivers + truly-runtime constructor patterns (need a runtime regex
+ * compiler / runtime-externref receiver generalisation — future architect spec).
+ */
+async function runStandalone(src: string): Promise<{ leaks: string[]; main: () => unknown }> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const leaks = r.imports.map((i) => `${i.module}::${i.name}`).filter((l) => !l.startsWith("wasm:js-string::"));
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return { leaks, main: instance.exports.main as () => unknown };
+}
+
+describe("#2161 const-foldable new RegExp() patterns (standalone)", () => {
+  it("string-literal concatenation pattern compiles natively", async () => {
+    const { leaks, main } = await runStandalone(
+      `export function main(): number { const re = new RegExp("a" + "b", "g"); return "abab".match(re)!.length; }`,
+    );
+    expect(leaks).toEqual([]);
+    expect(main()).toBe(2);
+  });
+
+  it("const-bound literal pattern compiles natively", async () => {
+    const { leaks, main } = await runStandalone(
+      `export function main(): number { const p = "ab"; const re = new RegExp(p, "g"); return "abab".match(re)!.length; }`,
+    );
+    expect(leaks).toEqual([]);
+    expect(main()).toBe(2);
+  });
+
+  it("const-bound + concat (chained fold) pattern compiles natively", async () => {
+    const { leaks, main } = await runStandalone(
+      `export function main(): number { const a = "a"; const re = new RegExp(a + "b", "g"); return "abab".match(re)!.length; }`,
+    );
+    expect(leaks).toEqual([]);
+    expect(main()).toBe(2);
+  });
+
+  it("regex-literal copy-constructor inherits the literal's flags", async () => {
+    const { leaks, main } = await runStandalone(
+      `export function main(): number { const re = new RegExp(/ab/g); return "abab".match(re)!.length; }`,
+    );
+    expect(leaks).toEqual([]);
+    expect(main()).toBe(2);
+  });
+
+  it("regex-literal copy-constructor overrides flags when provided (§22.2.3.1)", async () => {
+    const { leaks, main } = await runStandalone(
+      `export function main(): number { const re = new RegExp(/AB/, "gi"); return "abAB".match(re)!.length; }`,
+    );
+    expect(leaks).toEqual([]);
+    expect(main()).toBe(2);
+  });
+
+  it("const-folded ctor binding flows to a downstream re.test", async () => {
+    const { leaks, main } = await runStandalone(
+      `export function main(): number { const re = new RegExp("a" + "b"); return re.test("xabx") ? 7 : 3; }`,
+    );
+    expect(leaks).toEqual([]);
+    expect(main()).toBe(7);
+  });
+
+  it("control: static string-literal pattern still works (no regression)", async () => {
+    const { leaks, main } = await runStandalone(
+      `export function main(): number { const re = new RegExp("ab", "g"); return "abab".match(re)!.length; }`,
+    );
+    expect(leaks).toEqual([]);
+    expect(main()).toBe(2);
+  });
+
+  it("regex literal (no ctor) still works (no regression)", async () => {
+    const { leaks, main } = await runStandalone(
+      `export function main(): number { return "abab".match(/ab/g)!.length; }`,
+    );
+    expect(leaks).toEqual([]);
+    expect(main()).toBe(2);
+  });
+
+  it("genuinely-dynamic param pattern is NOT mis-folded as a constant", async () => {
+    // A function-param pattern is NOT a compile-time constant: the const-fold
+    // must NOT accept it (which would silently run the native engine on an
+    // empty/garbage pattern and return the wrong count). Its behaviour stays
+    // exactly as before this slice — the documented dynamic-constructor path,
+    // which compiles but runtime-traps (it needs a runtime regex compiler,
+    // tracked under #2161 as a future architect-spec item). The invariant this
+    // slice must preserve: it must NOT silently return the correct native count
+    // of 2, because that would prove a dynamic pattern was mis-folded.
+    const r = await compile(
+      `function mk(p: string): RegExp { return new RegExp(p, "g"); } export function main(): number { return "abab".match(mk("ab"))!.length; }`,
+      { target: "standalone" },
+    );
+    if (!r.success) return; // refusal is an acceptable outcome
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    let result: unknown = "TRAP";
+    try {
+      result = (instance.exports.main as () => unknown)();
+    } catch {
+      result = "TRAP"; // dynamic pattern traps at runtime — not mis-folded
+    }
+    expect(result).not.toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Closes a bounded, substrate-independent slice of the **#2161** standalone-RegExp umbrella: `new RegExp(...)` with a **compile-time-constant** pattern now compiles to the native engine instead of runtime-trapping.

The standalone native RegExp engine compiles a pattern to bytecode at **compile time**. The constructor's static-pattern recovery used the narrow `staticStringValue` (bare string literal only), so patterns that ARE compile-time-constant — and CAN be lowered to native bytecode — were rejected and lowered to a placeholder that **runtime-trapped** (the documented "dynamic ctor patterns illegal-cast" bucket):

- `new RegExp("a" + "b")` — string-literal concatenation
- `const p = "ab"; new RegExp(p)` — `const`-bound literal
- `new RegExp(/ab/g)` / `new RegExp(/ab/, "i")` — §22.2.3.1 copy-constructor

## Change

`src/codegen/regexp-standalone.ts` (+112 LoC, **zero new host imports, zero substrate dependency**):
- `staticConstStringValue` — recursively folds string literals, `const`-bound identifiers, and `a + b` concatenation. Refuses template substitutions, numeric coercion, and `let`/`var`/reassigned bindings (those stay dynamic).
- `staticRegExpLiteralCopy` — the §22.2.3.1 copy form: a provided `flags` arg **overrides** the literal's flags; omitted/`undefined` **inherits** them.
- Routes these const-foldable forms — in both `compileStandaloneRegExpConstructor` and the `staticRegExpPatternFlags` receiver-recovery helper (so downstream `re.test`/`re.exec` on a const-folded binding also work) — to the existing native `compileStandaloneRegExpPattern`.

A genuinely-dynamic pattern (function param, `let`, reassigned) still resolves to `null` and keeps the prior dynamic behaviour — **behaviour-preserving for every existing static form**.

## Spec
ECMA-262 §22.2.3.1 RegExp(pattern, flags) — RegExp-valued pattern inherits `[[OriginalFlags]]` when flags is `undefined`, else uses flags.

## Tests
`tests/issue-2161-regex-const-ctor.test.ts` — 9 standalone cases (concat, const-bound, chained const+concat, copy-ctor inherit/override flags, downstream `re.test`, two no-regression controls, and a guard that a dynamic param is **not** mis-folded). All standalone, empty importObject, zero host-import leak.

## Scope / out of scope
Broad-impact (codegen) → validated by the **merge_group** floor (no scoped sweep). Genuinely-dynamic / `any`-typed receivers + truly-runtime ctor patterns need a runtime regex compiler — recorded in the issue as a **future architect-spec item**, not this slice. `RegExp.prototype` reflection stays gated on #2175. Umbrella #2161 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)