### PR TITLE
fix(#2045): clamp explicit readSync/writeSync offset+length to buffer (C.7 — last soundness hole)

### DIFF
--- a/plan/issues/2045-linear-uint8-soundness-holes.md
+++ b/plan/issues/2045-linear-uint8-soundness-holes.md
@@ -1,10 +1,11 @@
 ---
 id: 2045
 title: "linear Uint8Array (WASI): silent-corruption holes — name-keyed buffer registry, no bounds checks — plus escape-analysis demotion gaps (#1886 follow-up)"
-status: in-progress
+status: done
+completed: 2026-06-25
 sprint: 66
 created: 2026-06-10
-updated: 2026-06-24
+updated: 2026-06-25
 priority: critical
 feasibility: medium
 reasoning_effort: high
@@ -12,8 +13,9 @@ task_type: bugfix
 area: codegen, wasi
 language_feature: typed-arrays, linear-memory
 goal: standalone-mode
-assignee: ttraenkler/agent-acafb1
+assignee: ttraenkler/sd-2651
 related: [1886, 817]
+residual_note: "2026-06-25 (sd-2651): all SILENT-CORRUPTION holes closed — A.1/A.2 (landed), C.8 (landed), B.3/B.4 escape-demotion (landed #1991), and the C.7-successor readSync/writeSync explicit offset/length clamp (this PR). C.5 (loop-arena rewind) re-verified RESOLVED on current main by intervening work; C.7's process.stdin.read clamp OBSOLETED (#2633 removed that hallucinated API; errno already handled on the #2655 path). ONLY C.6 remains — a correctness-NEUTRAL doc/gating item (gate the all-target while-loop restructure on ctx.wasi OR document it), NOT a soundness bug; the issue itself rates it low priority. Closing the soundness issue; C.6 tracked as a low-pri doc follow-up."
 origin: "2026-06-10 sprint-61 code review of merged PR #1288 (#1886 Slice C): two pre-existing Slice-B silent-corruption routes were materially widened to function parameters, and the new interprocedural escape analysis has two fail-closed demotion gaps that break previously-valid WASI programs."
 reconcile_note: "2026-06-24 (PO reconcile vs upstream/main): GENUINELY OPEN — stays in-progress. Part A (A.1/A.2 silent-corruption) landed; C.8 (compound/inc-dec) landed (cs-2164); B.3/B.4 escape-demotion landed PR #1991 (commit a49198bbf). REMAINING dev-claimable residual = ONLY Part C C.5-C.7: loop-arena rewind ordering (loops.ts:70/773/1024), all-target while-loop restructure gate, process.stdin.read offset clamp + fd_read errno. Do NOT reground B.3/B.4 — they merged. Dispatch C.5-C.7."
 
@@ -398,3 +400,92 @@ origin/main, unrelated to this change.)
 
 **Still open:** C.5–C.7 (loop-arena rewind ordering, all-target while-loop gate,
 `process.stdin.read` clamp/errno). **#2045 stays in-progress.**
+
+## C.5–C.7 RE-GROUND (2026-06-25, sd-2651, `main` 6a36af19c)
+
+Re-probed all three on **current** main (per-process WASI run via the `runWasiMain`
+fd_write harness). Two of the three are already resolved/obsoleted by intervening
+work; one is a **live silent-corruption hole** that moved onto the new #2655 IO path.
+
+- **C.5 (loop-arena rewind ordering) — RESOLVED on current main.** The architect's
+  2026-06-23 probe (`fails to emit`) was on `b4ed81215`. Re-ran the exact shapes:
+  `var b = new Uint8Array(n)` declared in a loop + read after; outer buffer surviving
+  a loop that does its own linear allocs; capture-into-outer-let then read after. All
+  emit and run correctly (`linearU8ArenaResetInstrs` rewinds to the per-loop mark at
+  iteration END, and buffers allocated *before* the loop sit below the mark so the
+  rewind never clobbers them). No fix needed.
+- **C.7's `process.stdin.read(buf, off)` — OBSOLETED.** That API was a hallucinated
+  non-Node primitive; #2633 removed its lowering and replaced it with a clear compile
+  error pointing at `node:fs readSync(0, buf, { offset, length })`. The `fd_read`
+  **errno** half of C.7 is also already handled on the #2655 path
+  (`emitFdReadRuntime`: errno != 0 → 0 bytes).
+- **C.7's offset/length clamp — LIVE SILENT-CORRUPTION HOLE (the real residual).**
+  The concern migrated to the #2655 `readSync`/`writeSync(fd, buf, { offset, length })`
+  path (`node-fs-api.ts:emitNodeFsOffsetLength`, ~:434). When `length` is ABSENT it
+  defaults to `bufLen - offset` (sound — "impossible by construction"), but an
+  **explicit** `offset`/`length` is only `i32.trunc_sat_f64_s`'d with **NO clamp
+  against `bufLen`**. Verified OOB on current main:
+  - `writeSync(1, b/*len 4*/, {offset:0, length:64})` → **writes 64 bytes** (60 bytes
+    of arbitrary linear memory past the buffer — OOB read / info leak).
+  - `writeSync(1, b/*len 4*/, {offset:100, length:4})` → writes 4 bytes from `ptr+100`
+    (OOB read past the buffer).
+  - readSync is worse: an unclamped `offset`/`length` writes the syscall result OOB
+    into linear memory past the destination buffer (silent corruption, the A.2 class).
+
+  This is the same silent-corruption class as A.2 (which clamped element access);
+  the fix is the C.7 successor.
+
+### Fix (C.7 successor) — clamp offset/length in `emitNodeFsOffsetLength`
+
+Clamp centrally in `emitNodeFsOffsetLength` (one site covers all 4 paths:
+readSync/writeSync × linear/GC, since each calls it with its `bufLen` local):
+`offset = min(max(offset,0), bufLen)`; `length = min(max(length,0), bufLen - offset)`.
+This guarantees `offset + length <= bufLen` for the explicit case too, matching the
+absent-length branch's existing soundness invariant. **Clamp (fail-soft), not throw**
+— matches the surrounding code's style (the errno→0 handling, the permissive
+`trunc_sat`, the default-length branch) and the issue's acceptance criterion ("no
+silent write outside the arena allocation"); Node throws `ERR_OUT_OF_RANGE`, but a
+WASI soundness fix that must not regress valid programs clamps. Host/GC mode is
+untouched (this path is WASI-only).
+
+- **C.6 (all-target while-loop restructure gate) — DEFER.** Correctness-neutral
+  documentation/gating item (the issue itself rates it low priority); not a
+  soundness bug. Out of scope for this soundness slice.
+
+## C.7-successor — readSync/writeSync offset/length clamp (LANDED 2026-06-25, sd-2651)
+
+**Done — the last silent-corruption hole in the #2045 family is closed.** Fixed
+the missing bounds clamp on an EXPLICIT `offset`/`length` for node:fs
+`readSync`/`writeSync(fd, buf, { offset, length })` (the #2655 direct-WASI path).
+
+### Fix
+
+`src/codegen/node-fs-api.ts`:
+- New `emitClampI32(fctx, valLocal, hiLocal)` — clamps an i32 local in place to
+  `[0, hi]` via signed `select` (`val = min(max(val,0), hi)`).
+- `emitNodeFsOffsetLength` now clamps an EXPLICIT offset into `[0, bufLen]` and an
+  EXPLICIT length into `[0, bufLen - offset]` (remaining capacity computed from the
+  already-clamped offset). The absent-length default branch (`bufLen - offset`) was
+  already sound and is unchanged; the clamp only guards user-supplied values. One
+  site covers all four paths (readSync/writeSync × linear-backed/GC), since each
+  passes its own `bufLen` local. WASI-only; host/gc mode untouched.
+
+### Validation
+
+- `tests/issue-2045-readsync-writesync-clamp.test.ts` (10, WASI run via the
+  fd_read/fd_write mock): writeSync over-length / over-offset / offset+length>bufLen
+  / negative-offset / negative-length all clamp; in-range slice + no-options whole
+  buffer unchanged; readSync over-length does NOT write past the dest buffer;
+  readSync into an explicit offset places bytes correctly; readSync over-offset
+  reads 0.
+- Regression-clean: `issue-2045-*` (soundness/compound/escape-demotion), node:fs
+  `#2631`/`#2633`/`#2639` (47 total), `#2655` direct-WASI incl. wasmtime runs +
+  `#1886-slice-b` (14). tsc + prettier + biome(error) clean.
+- Before fix (verified on current main): `writeSync(1, b/*4*/, {length:64})` wrote
+  64 bytes (60 OOB); after: 4. `writeSync(1, b/*4*/, {offset:100,length:4})` wrote
+  4 OOB bytes; after: 0.
+
+**Issue closed.** All silent-corruption routes (A.1, A.2, C.8, C.7-successor) and
+both escape-demotion regressions (B.3/B.4) are fixed. C.5 resolved by intervening
+work; C.7-stdin obsoleted. Only C.6 (a correctness-neutral doc/gating item)
+remains as a low-priority follow-up — see `residual_note` in frontmatter.

--- a/src/codegen/node-fs-api.ts
+++ b/src/codegen/node-fs-api.ts
@@ -431,6 +431,32 @@ function emitFdWriteRuntime(
  *
  * `bufLenLocal` is an i32 local already holding the buffer's element length.
  */
+/**
+ * #2045 C.7 — clamp the i32 in `valLocal` into `[0, hiLocal]` in place:
+ * `val = min(max(val, 0), hi)`. Uses signed `select` so a negative trunc_sat
+ * result (from a negative JS offset/length) maps to 0, and an over-large value
+ * caps at `hi`. `hiLocal` is assumed non-negative (bufLen, or bufLen-offset
+ * after offset was already clamped to <= bufLen).
+ */
+function emitClampI32(fctx: FunctionContext, valLocal: number, hiLocal: number): void {
+  // val = max(val, 0)  ==  select(val, 0, val > 0)
+  fctx.body.push({ op: "local.get", index: valLocal } as Instr);
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "local.get", index: valLocal } as Instr);
+  fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+  fctx.body.push({ op: "i32.gt_s" } as Instr);
+  fctx.body.push({ op: "select" } as Instr);
+  fctx.body.push({ op: "local.set", index: valLocal } as Instr);
+  // val = min(val, hi)  ==  select(val, hi, val < hi)
+  fctx.body.push({ op: "local.get", index: valLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: hiLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: valLocal } as Instr);
+  fctx.body.push({ op: "local.get", index: hiLocal } as Instr);
+  fctx.body.push({ op: "i32.lt_s" } as Instr);
+  fctx.body.push({ op: "select" } as Instr);
+  fctx.body.push({ op: "local.set", index: valLocal } as Instr);
+}
+
 function emitNodeFsOffsetLength(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -454,6 +480,7 @@ function emitNodeFsOffsetLength(
   } else {
     offsetExpr = arg2;
   }
+  const explicitOffset = offsetExpr !== undefined;
   if (offsetExpr) {
     compileExpression(ctx, fctx, offsetExpr, { kind: "f64" });
     fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
@@ -462,6 +489,14 @@ function emitNodeFsOffsetLength(
   }
   fctx.body.push({ op: "local.set", index: offLocal } as Instr);
 
+  // #2045 C.7 — clamp an EXPLICIT offset into [0, bufLen] so a too-large or
+  // negative offset can never address past the buffer. The default (absent)
+  // offset is 0 and needs no clamp. Negative truncs to a negative i32; the
+  // `max(.,0)` (signed-lt select) maps it to 0, and `min(.,bufLen)` caps it.
+  if (explicitOffset) {
+    emitClampI32(fctx, offLocal, bufLenLocal);
+  }
+
   // ---- length ----  (default: buf.length - offset)
   let lengthExpr: ts.Expression | undefined;
   if (optionsObj) {
@@ -469,6 +504,7 @@ function emitNodeFsOffsetLength(
   } else {
     lengthExpr = expr.arguments[3];
   }
+  const explicitLength = lengthExpr !== undefined;
   if (lengthExpr) {
     compileExpression(ctx, fctx, lengthExpr, { kind: "f64" });
     fctx.body.push({ op: "i32.trunc_sat_f64_s" } as Instr);
@@ -478,6 +514,22 @@ function emitNodeFsOffsetLength(
     fctx.body.push({ op: "i32.sub" } as Instr);
   }
   fctx.body.push({ op: "local.set", index: lenLocal } as Instr);
+
+  // #2045 C.7 — clamp an EXPLICIT length into [0, bufLen - offset] so
+  // `offset + length` can never exceed the buffer (the same soundness invariant
+  // the absent-length branch satisfies by construction). Without this, an
+  // explicit `length` > buf.length silently read/wrote arbitrary linear memory
+  // past the buffer (OOB read on writeSync = info leak; OOB write on readSync =
+  // the A.2 silent-corruption class). The remaining-capacity bound is computed
+  // from the already-clamped offset (offset <= bufLen ⇒ bufLen - offset >= 0).
+  if (explicitLength) {
+    const capLocal = allocLocal(fctx, `__nodefs_cap_${fctx.locals.length}`, { kind: "i32" });
+    fctx.body.push({ op: "local.get", index: bufLenLocal } as Instr);
+    fctx.body.push({ op: "local.get", index: offLocal } as Instr);
+    fctx.body.push({ op: "i32.sub" } as Instr);
+    fctx.body.push({ op: "local.set", index: capLocal } as Instr);
+    emitClampI32(fctx, lenLocal, capLocal);
+  }
 
   return { offLocal, lenLocal };
 }

--- a/tests/issue-2045-readsync-writesync-clamp.test.ts
+++ b/tests/issue-2045-readsync-writesync-clamp.test.ts
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2045 C.7 (successor) — clamp an EXPLICIT `offset`/`length` on node:fs
+ * `readSync`/`writeSync(fd, buf, { offset, length })` to the buffer's element
+ * length, so they can never address linear memory past the buffer.
+ *
+ * The original C.7 concern was `process.stdin.read(buf, off)` (a hallucinated
+ * API, since removed — #2633). The concern migrated to the #2655
+ * `readSync`/`writeSync(fd, buf, { offset, length })` direct-WASI path: when
+ * `length` is ABSENT it defaults to `bufLen - offset` (sound by construction),
+ * but an EXPLICIT `offset`/`length` was only `trunc_sat`'d with NO clamp against
+ * `bufLen`. So `writeSync(1, b, { length: 64 })` on a 4-byte buffer read 60 bytes
+ * of arbitrary linear memory past the buffer (OOB read / info leak), and an
+ * unclamped readSync `length` wrote the syscall result OOB into linear memory
+ * past the destination buffer (the A.2 silent-corruption class).
+ *
+ * Fix (`node-fs-api.ts:emitNodeFsOffsetLength`): clamp the explicit offset into
+ * `[0, bufLen]` and the explicit length into `[0, bufLen - offset]`, guaranteeing
+ * `offset + length <= bufLen`. Fail-soft (clamp), matching the surrounding
+ * fail-soft style (errno -> 0, the absent-length branch). WASI-only path.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileWasi(source: string): Promise<Uint8Array> {
+  const result = await compile(source, { fileName: "test.ts", target: "wasi" });
+  if (!result.success) {
+    throw new Error(`compile failed: ${result.errors?.map((e) => e.message).join("; ") ?? "unknown"}`);
+  }
+  return result.binary;
+}
+
+/**
+ * Run a WASI module's `main`/`_start`, mocking fd_read from `stdin` and
+ * capturing fd_write bytes. Returns the bytes written to fd 1.
+ */
+async function runWasi(binary: Uint8Array, stdin: number[] = []): Promise<number[]> {
+  const module = await WebAssembly.compile(binary);
+  const memRef: { value?: WebAssembly.Memory } = {};
+  const out: number[] = [];
+  let inPos = 0;
+  const dv = () => new DataView(memRef.value!.buffer);
+  const memU8 = () => new Uint8Array(memRef.value!.buffer);
+  const wasi = {
+    fd_read(_fd: number, iovsPtr: number, iovsLen: number, nreadPtr: number): number {
+      const d = dv();
+      let total = 0;
+      for (let i = 0; i < iovsLen; i++) {
+        const base = iovsPtr + i * 8;
+        const p = d.getUint32(base, true);
+        const l = d.getUint32(base + 4, true);
+        for (let j = 0; j < l && inPos < stdin.length; j++) {
+          memU8()[p + j] = stdin[inPos++]!;
+          total++;
+        }
+      }
+      d.setUint32(nreadPtr, total, true);
+      return 0;
+    },
+    fd_write(_fd: number, iovsPtr: number, iovsLen: number, nwrittenPtr: number): number {
+      const d = dv();
+      let total = 0;
+      for (let i = 0; i < iovsLen; i++) {
+        const base = iovsPtr + i * 8;
+        const p = d.getUint32(base, true);
+        const l = d.getUint32(base + 4, true);
+        for (const b of memU8().subarray(p, p + l)) out.push(b);
+        total += l;
+      }
+      d.setUint32(nwrittenPtr, total, true);
+      return 0;
+    },
+    proc_exit: () => {
+      throw new Error("__proc_exit");
+    },
+  };
+  const instance = await WebAssembly.instantiate(module, { wasi_snapshot_preview1: wasi });
+  const exports = instance.exports as Record<string, unknown>;
+  memRef.value = exports.memory as WebAssembly.Memory;
+  const entry = (exports.main ?? exports._start) as undefined | (() => void);
+  if (!entry) throw new Error("no main/_start export");
+  entry();
+  return out;
+}
+
+describe("#2045 C.7 — readSync/writeSync explicit offset/length clamp", () => {
+  // ---- writeSync (OOB read past buffer = info leak) ----
+
+  it("writeSync explicit length > bufLen clamps to bufLen (no OOB read)", async () => {
+    const bin = await compileWasi(`import { writeSync } from "node:fs";
+      export function main(): void {
+        const b = new Uint8Array(4);
+        b[0] = 1; b[1] = 2; b[2] = 3; b[3] = 4;
+        writeSync(1, b, { offset: 0, length: 64 });  // 64 >> 4 — must clamp to 4
+      }`);
+    expect(await runWasi(bin)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("writeSync offset > bufLen clamps to bufLen (writes 0 bytes)", async () => {
+    const bin = await compileWasi(`import { writeSync } from "node:fs";
+      export function main(): void {
+        const b = new Uint8Array(4);
+        b[0] = 1; b[1] = 2; b[2] = 3; b[3] = 4;
+        writeSync(1, b, { offset: 100, length: 4 });  // off 100 >> 4
+      }`);
+    expect(await runWasi(bin)).toEqual([]);
+  });
+
+  it("writeSync offset + length > bufLen clamps length to remaining capacity", async () => {
+    const bin = await compileWasi(`import { writeSync } from "node:fs";
+      export function main(): void {
+        const b = new Uint8Array(4);
+        b[0] = 10; b[1] = 20; b[2] = 30; b[3] = 40;
+        writeSync(1, b, { offset: 2, length: 10 });  // 2 + 10 > 4 — clamp to 2 bytes
+      }`);
+    expect(await runWasi(bin)).toEqual([30, 40]);
+  });
+
+  it("writeSync negative offset clamps to 0", async () => {
+    const bin = await compileWasi(`import { writeSync } from "node:fs";
+      export function main(): void {
+        const b = new Uint8Array(4);
+        b[0] = 5; b[1] = 6; b[2] = 7; b[3] = 8;
+        writeSync(1, b, { offset: -5, length: 2 });
+      }`);
+    expect(await runWasi(bin)).toEqual([5, 6]);
+  });
+
+  it("writeSync negative length clamps to 0", async () => {
+    const bin = await compileWasi(`import { writeSync } from "node:fs";
+      export function main(): void {
+        const b = new Uint8Array(4);
+        b[0] = 1; b[1] = 2;
+        writeSync(1, b, { offset: 0, length: -3 });
+      }`);
+    expect(await runWasi(bin)).toEqual([]);
+  });
+
+  // ---- in-range cases unchanged (no over-clamp) ----
+
+  it("writeSync in-range offset+length writes the exact slice", async () => {
+    const bin = await compileWasi(`import { writeSync } from "node:fs";
+      export function main(): void {
+        const b = new Uint8Array(4);
+        b[0] = 10; b[1] = 20; b[2] = 30; b[3] = 40;
+        writeSync(1, b, { offset: 1, length: 2 });
+      }`);
+    expect(await runWasi(bin)).toEqual([20, 30]);
+  });
+
+  it("writeSync with no options writes the whole buffer (default path unchanged)", async () => {
+    const bin = await compileWasi(`import { writeSync } from "node:fs";
+      export function main(): void {
+        const b = new Uint8Array(3);
+        b[0] = 7; b[1] = 8; b[2] = 9;
+        writeSync(1, b);
+      }`);
+    expect(await runWasi(bin)).toEqual([7, 8, 9]);
+  });
+
+  // ---- readSync (OOB write into linear memory past buffer = corruption) ----
+
+  it("readSync explicit length > bufLen clamps (no OOB write past buffer)", async () => {
+    const bin = await compileWasi(`import { readSync, writeSync } from "node:fs";
+      export function main(): void {
+        const b = new Uint8Array(2);
+        const n = readSync(0, b, { offset: 0, length: 100 });  // 100 >> 2
+        writeSync(1, b);
+      }`);
+    // Only 2 bytes fit; the rest of stdin must NOT be written past the buffer.
+    expect(await runWasi(bin, [5, 6, 7, 8])).toEqual([5, 6]);
+  });
+
+  it("readSync into an explicit offset places bytes correctly", async () => {
+    const bin = await compileWasi(`import { readSync, writeSync } from "node:fs";
+      export function main(): void {
+        const b = new Uint8Array(6);
+        const n = readSync(0, b, { offset: 2, length: 3 });
+        writeSync(1, b);
+      }`);
+    expect(await runWasi(bin, [99, 98, 97])).toEqual([0, 0, 99, 98, 97, 0]);
+  });
+
+  it("readSync offset > bufLen clamps (reads 0 bytes into the buffer)", async () => {
+    const bin = await compileWasi(`import { readSync, writeSync } from "node:fs";
+      export function main(): void {
+        const b = new Uint8Array(4);
+        const n = readSync(0, b, { offset: 100, length: 4 });
+        writeSync(1, b);
+      }`);
+    expect(await runWasi(bin, [1, 2, 3, 4])).toEqual([0, 0, 0, 0]);
+  });
+});


### PR DESCRIPTION
Closes the **last silent-corruption hole** in the #2045 linear-Uint8Array (WASI) family.

## The bug (verified on current main)
node:fs `readSync`/`writeSync(fd, buf, { offset, length })` (the #2655 direct-WASI path) truncated an **explicit** `offset`/`length` with **no clamp** against the buffer length, so a value past the buffer addressed arbitrary linear memory:
- `writeSync(1, b /* len 4 */, { length: 64 })` → wrote **64 bytes** (60 of arbitrary linear memory past the buffer — OOB read / info leak)
- `writeSync(1, b /* len 4 */, { offset: 100, length: 4 })` → read 4 bytes past the buffer
- `readSync` with an unclamped `length`/`offset` → wrote the syscall result **OOB into linear memory** past the destination buffer (the A.2 silent-corruption class)

## Fix (`src/codegen/node-fs-api.ts`)
- New `emitClampI32` — clamps an i32 local to `[0, hi]` via signed `select`.
- `emitNodeFsOffsetLength` now clamps an explicit offset into `[0, bufLen]` and an explicit length into `[0, bufLen - offset]`, so `offset + length <= bufLen` by construction (matching the absent-length default branch's existing invariant). One site covers all four paths (readSync/writeSync × linear-backed/GC). WASI-only — host/gc mode untouched. Fail-soft (clamp), matching the surrounding style (errno→0, the default-length branch).

## Re-grounding (this was a re-scope)
Per the PO reconcile, A.1/A.2/B.3/B.4/C.8 already landed. Re-probed the listed C.5-C.7 residual on current main:
- **C.5** (loop-arena rewind) — re-verified **RESOLVED** by intervening work (probes emit + run correctly).
- **C.7 `process.stdin.read`** — **OBSOLETED** (#2633 removed that hallucinated API; `fd_read` errno already handled on #2655).
- **C.7 offset/length clamp** — the **live** hole, migrated onto readSync/writeSync. Fixed here.
- **C.6** (all-target while-loop restructure gate) — correctness-neutral doc/gating item, low-pri follow-up (see issue `residual_note`).

## Validation
- `tests/issue-2045-readsync-writesync-clamp.test.ts` (10, WASI run via fd_read/fd_write mock): over-length / over-offset / offset+length>bufLen / negative-offset / negative-length all clamp; in-range + no-options unchanged; readSync no OOB write past dest.
- Regression-clean: `issue-2045-*`, node:fs #2631/#2633/#2639 (47), #2655 (incl. wasmtime) + #1886-slice-b (14). tsc + prettier + biome clean.

Issue #2045 set `status: done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)