### PR TITLE
fix(#2580 M3 B-protoextend): inherited Object.prototype index read in generic array-method loop

### DIFF
--- a/plan/issues/2580-dynamic-receiver-length-undefined-substrate.md
+++ b/plan/issues/2580-dynamic-receiver-length-undefined-substrate.md
@@ -2,7 +2,7 @@
 id: 2580
 title: "`.length` on an any/dynamically-mutated receiver returns numeric 0, not undefined (runtime property-presence)"
 status: in-progress
-assignee: ttraenkler/sd-value-rep-m3-bacc
+assignee: ttraenkler/sd-2580
 sprint: 66
 created: 2026-06-21
 priority: medium
@@ -1940,3 +1940,94 @@ highest-density, zero-regression increment of the 181-file lever. Authoritative
 gate = merge_group standalone floor (#2097) + the test262 net-regression gate;
 stop-the-line on any eject. Files changed: `src/codegen/object-ops.ts`,
 `src/runtime.ts`, `tests/issue-2580-m3-bacc-defineproperty-accessor.test.ts`.
+
+---
+
+# M3 — B-protoextend LANDED: inherited `Object.prototype[idx]` index read in the generic array-method loop (host) (2026-06-25, sd-2580, max-reasoning)
+
+> Verify-first, per-process (`runTest262File`, fresh process per file — the
+> in-process / parallel-scan trap avoided) + a runtime trace of the actual
+> `__extern_has_idx`/`__extern_get_idx` calls on CURRENT main. The architect
+> decision (route inherited reads through the ONE shared `%Object.prototype%`
+> walk, option ii-a, NOT a per-receiver `$proto` field) is honoured.
+
+## Confirmed mechanism (runtime-traced, host mode)
+
+The canonical `b-i-8` shape `Object.prototype[0]=true; Object.prototype[1]=false;
+Object.prototype[2]="true"; Array.prototype.indexOf.call({length:3}, true)` must
+return `0` — `obj[0]` walks the receiver's `[[Prototype]]` chain to
+`%Object.prototype%` and finds the inherited data property. On main it **fails**.
+A trace of the index-loop helpers showed exactly why:
+
+```
+[has_idx] idx=0 isWasm=true (idx in obj)=false ObjProtoHas=true
+[has_idx] idx=1 isWasm=true (idx in obj)=false ObjProtoHas=true
+[has_idx] idx=2 isWasm=true (idx in obj)=false ObjProtoHas=true
+```
+
+- The array-like plain-object receiver `{length:3}` is an **opaque WasmGC
+  struct** whose runtime `[[Prototype]]` is `null` — it does NOT inherit from the
+  host `Object.prototype`, so `(idx in obj) === false`.
+- `Object.prototype[i] = v` **DOES land on the real host `Object.prototype`**
+  (member-assignment lowers to a host write) — `idx in Object.prototype === true`.
+- The own-only `obj[i]` / sidecar lookups in `__extern_get_idx` /
+  `__extern_has_idx` never consulted that inherited slot → the generic-method
+  loop skipped every index → `indexOf`/`forEach`/`some`/… saw nothing.
+
+This is distinct from B-acc (OWN accessor descriptors via the `_wasmStructProps`
+sidecar) — B-protoextend is the **inherited-data-on-`Object.prototype`** subset.
+
+## The fix (2 runtime sites + 1 shared helper, host-scoped, hot-path byte-identical)
+
+`src/runtime.ts`: a module-level `_protoIndexHas(idx)` / `_protoIndexGet(idx)`
+pair that consults `%Object.prototype%[idx]` (canonical non-negative integer
+indices only), wired as the **FINAL fallback** in both `__extern_get_idx`
+(`Get`, §7.3.2) and `__extern_has_idx` (`HasProperty`, §7.3.12 — presence is
+value-independent, so an inherited slot holding `undefined` is still visited).
+
+Reached **only after** own struct fields + sidecar + own accessor descriptors all
+miss, so a real array / `$Vec` / any receiver carrying its own index is resolved
+earlier and never enters the arm — the hot path is byte-identical. Consults only
+`%Object.prototype%` (the single chain every object value shares); `Array.prototype[i]=v`
+inherited on REAL arrays already resolves through the native array path (verified
+passing on main), and no reachable test262 case sets `Array.prototype[i]` then
+calls a generic method on a *plain-object* receiver (that would be spec-incorrect).
+
+## Measured impact (per-process, single-process — the reliable signal)
+
+Cluster = 34 files writing `Object.prototype[<idx>]` across
+indexOf/lastIndexOf/every/some/forEach/map/filter/reduce/reduceRight + an 8-file
+hot-path own-data/real-array guard sample (42 total). Baseline `origin/main` vs
+branch, **one fresh process per file**:
+
+- **`indexOf/15.4.4.14-9-b-i-8`: fail → pass**
+- **`lastIndexOf/15.4.4.15-8-b-i-8`: fail → pass**
+- **0 regressions** in the hot-path / own-data / real-array sample (the two
+  `pass→compile_error` deltas a `-P 6` PARALLEL scan reported were **runner-trap
+  artifacts** — re-run single-process, both PASS on baseline AND branch; the
+  parallel `tsx` processes collide on the shared disk-compile-cache).
+
+The reachable confirmed flip this slice banks is the `b-i-8` inherited-data pair
+(+2). Several sibling `b-i-N` rows remain `fail`/`compile_error` for SEPARATE
+mechanisms surfaced during the scan (next laps, not this fix):
+- `lastIndexOf.call(arrayLike)` / various `.call` arms have a pre-existing codegen
+  `compile_error` (`Cannot create property 'declaredType' on boolean`) independent
+  of the proto walk — a method-support gap.
+- own-accessor-overrides-inherited on a *real array* (`b-i-11`) is B-acc
+  real-array territory.
+
+The authoritative conformance gate is the **merge_group standalone floor (#2097)
++ the test262 net-regression gate** (broad-reach, full-gate per
+`project_broad_impact_validate_full_ci`), which validates the whole `__extern_*_idx`
+blast radius — this PR rides it. New vitest:
+`tests/issue-2580-m3-protoextend.test.ts` (5 host cases: inherited indexOf /
+forEach / some, own-index-shadows-inherited, hot-path own-data unaffected) green.
+
+## What this lap does NOT touch
+
+- **B-fnctor (the `new F()` `$proto` lap, LAST + hardest, escape-analysis-gated)**
+  is explicitly out of scope — no fnctor / `new F()` / `.prototype=` code changed,
+  so this lap carries **no #1888-floor eject risk** (the B-fnctor hazard). Files
+  changed: `src/runtime.ts`, `tests/issue-2580-m3-protoextend.test.ts`.
+
+Issue stays `in-progress` (B-fnctor remains).

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1448,6 +1448,56 @@ const _OBJECT_PROTO_KEYS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * (#2580 M3 B-protoextend) Inherited indexed property lookup via the
+ * `Object.prototype` chain.
+ *
+ * A generic Array method invoked on an array-like *plain object* receiver
+ * (`Array.prototype.indexOf.call({length:3}, v)`) reads `obj[i]` per §7.3.2
+ * `Get`, which walks the receiver's `[[Prototype]]` chain. A plain object's
+ * chain terminates at `%Object.prototype%`, so a test that writes
+ * `Object.prototype[0] = true` makes `({length:3})[0]` resolve to `true`
+ * (the `built-ins/Array/prototype/<m>/<m>-9-b-i-N` "element to be retrieved
+ * is inherited data property on an Array-like object" cluster).
+ *
+ * In this compiler an array-like plain-object receiver is an *opaque WasmGC
+ * struct* whose runtime `[[Prototype]]` is `null` — it does NOT inherit from
+ * the host `Object.prototype`, so the own-only `obj[i]` / sidecar lookups in
+ * `__extern_get_idx`/`__extern_has_idx` miss the inherited index and the
+ * generic-method loop skips it (verified per-process: `(idx in obj)=false`
+ * while `idx in Object.prototype === true`). `Object.prototype[i] = v` DOES
+ * land on the real host `Object.prototype` (member-assignment lowers to a
+ * host write), so consulting it here reads exactly what the test wrote.
+ *
+ * Scope: this is the FINAL fallback, reached only after own struct fields,
+ * the sidecar, and accessor descriptors are exhausted — so a real array, a
+ * `$Vec`, or any receiver carrying its own index never enters this arm (its
+ * own element is found earlier). Real-array receivers with an
+ * `Array.prototype[i]=v` inherited element already resolve through the native
+ * array path (verified passing), so this arm intentionally consults only
+ * `%Object.prototype%`, the single chain every object value shares — matching
+ * the architect decision to route inherited reads through the ONE shared
+ * `Object.prototype` walk rather than a per-receiver prototype field.
+ *
+ * `_protoIndexHas` answers `[[HasProperty]]` (§7.3.12 — presence is
+ * value-independent, so an inherited slot holding `undefined` is still
+ * present); `_protoIndexGet` runs `[[Get]]` (invokes an inherited accessor via
+ * native `[]`). Only canonical non-negative integer indices participate
+ * (negative / fractional keys are not array element indices).
+ */
+function _protoIndexHas(idx: number): boolean {
+  if (!Number.isInteger(idx) || idx < 0) return false;
+  // `idx in Object.prototype` walks Object.prototype's own keys; a user write
+  // `Object.prototype[i] = v` (own data prop) or `defineProperty` (accessor)
+  // both register here. `Object.create(null)`-style holes never match.
+  return idx in (Object.prototype as Record<number, unknown>);
+}
+
+function _protoIndexGet(idx: number): unknown {
+  if (!Number.isInteger(idx) || idx < 0) return undefined;
+  return (Object.prototype as Record<number, unknown>)[idx];
+}
+
+/**
  * DataView subview metadata (#1064).
  *
  * The compiler emits `new DataView(buffer, byteOffset, byteLength)` as the raw
@@ -7340,6 +7390,13 @@ assert._isSameValue = isSameValue;
           const exports = callbackState?.getExports();
           const getter = exports?.[`__sget_${strKey}`];
           if (typeof getter === "function") return getter(obj);
+          // (#2580 M3 B-protoextend) Inherited indexed data/accessor on the
+          // Object.prototype chain. Reached only after own fields + sidecar +
+          // own accessor descriptors miss — so a real array / $Vec / receiver
+          // with its own element never gets here. `Get` (§7.3.2) walks the
+          // proto chain; an array-like plain-object receiver inherits
+          // `Object.prototype[i]` written by the test (`Object.prototype[0]=v`).
+          if (_protoIndexHas(idx)) return _protoIndexGet(idx);
           return undefined;
         };
       // __extern_has_idx: HasProperty(O, ToString(idx)) for array-like callback
@@ -7404,6 +7461,13 @@ assert._isSameValue = isSameValue;
               /* getter not defined for this struct variant — fall through */
             }
           }
+          // (#2580 M3 B-protoextend) Inherited index on the Object.prototype
+          // chain. HasProperty (§7.3.12) walks `[[Prototype]]`; an array-like
+          // plain-object receiver inherits `Object.prototype[i]`. Presence is
+          // value-independent, so this also visits an inherited slot holding
+          // `undefined`. Reached only after every own / sidecar / accessor
+          // probe misses, so it cannot mask an own hole.
+          if (_protoIndexHas(idx)) return 1;
           return 0;
         };
       // __extern_has(obj, key) → i32. Runtime fallback for `key in obj` when

--- a/tests/issue-2580-m3-protoextend.test.ts
+++ b/tests/issue-2580-m3-protoextend.test.ts
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2580 M3 B-protoextend — inherited indexed data/accessor on the
+// `Object.prototype` chain, read by the generic `Array.prototype.X.call(arrayLike, …)`
+// cluster (host/gc mode).
+//
+// Root cause (verified per-process + runtime trace, host mode):
+//   A generic Array method invoked on an array-like *plain object* receiver
+//   (`Array.prototype.indexOf.call({length:3}, v)`) reads `obj[i]` via §7.3.2
+//   `Get`, which walks the receiver's `[[Prototype]]` chain to `%Object.prototype%`.
+//   A test that does `Object.prototype[0] = true` makes `({length:3})[0]` resolve
+//   to `true`. In this compiler an array-like plain-object receiver is an OPAQUE
+//   WasmGC struct whose runtime `[[Prototype]]` is `null`, so the own-only
+//   `obj[i]` / sidecar lookups in `__extern_get_idx` / `__extern_has_idx` missed
+//   the inherited index — the generic-method loop skipped it. The trace showed
+//   `(idx in obj) === false` while `idx in Object.prototype === true`:
+//   `Object.prototype[i] = v` lands on the REAL host `Object.prototype`, but the
+//   struct receiver never consulted it.
+//
+// Fix: as the FINAL fallback in `__extern_get_idx` / `__extern_has_idx` (after own
+// struct fields, the sidecar and own accessor descriptors miss), consult
+// `%Object.prototype%[idx]` — the single `[[Prototype]]` chain every object value
+// shares (matching the architect decision to route inherited reads through the ONE
+// shared `Object.prototype` walk, not a per-receiver prototype field). A real
+// array / `$Vec` / any receiver carrying its own element is resolved earlier and
+// never enters this arm, so the hot path is unchanged.
+//
+// SCOPE: inherited DATA properties on `Object.prototype` for an array-like
+// plain-object receiver — the `built-ins/Array/prototype/<m>/<m>-9-b-i-N`
+// "inherited data property on an Array-like object" subset. `Array.prototype[i]=v`
+// inherited on REAL arrays already resolves through the native array path; the
+// fnctor `.prototype=` lap (B-fnctor) and getter-bodies that close over outer
+// scope are separate, later sub-mechanisms. Host/gc mode.
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runHost(source: string): Promise<unknown> {
+  const result = await compile(source);
+  if (!result.success) throw new Error("compile error: " + result.errors.map((e) => e.message).join("; "));
+  if (!WebAssembly.validate(result.binary)) throw new Error("invalid wasm");
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as { setExports?: (e: WebAssembly.Exports) => void }).setExports?.(instance.exports);
+  return (instance.exports as { run: () => unknown }).run();
+}
+
+describe("#2580 B-protoextend — inherited Object.prototype index read (host)", () => {
+  // The canonical b-i-8 shape: `indexOf.call({length:3}, v)` finds `v` at the
+  // index where `Object.prototype[i] = v` placed it (inherited data property).
+  it("indexOf.call(arrayLike) reads an inherited Object.prototype index", async () => {
+    const src = `export function run(): number {
+      (Object.prototype as any)[0] = true;
+      (Object.prototype as any)[1] = false;
+      (Object.prototype as any)[2] = "true";
+      const r0 = Array.prototype.indexOf.call({ length: 3 } as any, true);
+      const r1 = Array.prototype.indexOf.call({ length: 3 } as any, false);
+      const r2 = Array.prototype.indexOf.call({ length: 3 } as any, "true");
+      delete (Object.prototype as any)[0];
+      delete (Object.prototype as any)[1];
+      delete (Object.prototype as any)[2];
+      return r0 * 100 + r1 * 10 + r2;
+    }`;
+    // r0=0, r1=1, r2=2  →  0*100 + 1*10 + 2 = 12
+    expect(await runHost(src)).toBe(12);
+  });
+
+  // forEach visits inherited indices (HasProperty walks the proto chain) and the
+  // callback sees the inherited value.
+  it("forEach.call(arrayLike) visits inherited Object.prototype indices", async () => {
+    const src = `export function run(): string {
+      (Object.prototype as any)[0] = "a";
+      (Object.prototype as any)[1] = "b";
+      let log = "";
+      Array.prototype.forEach.call({ length: 2 } as any, function (v: any, i: any): void {
+        log = log + i + ":" + v + ";";
+      });
+      delete (Object.prototype as any)[0];
+      delete (Object.prototype as any)[1];
+      return log;
+    }`;
+    expect(await runHost(src)).toBe("0:a;1:b;");
+  });
+
+  // `some` honours an inherited element value.
+  it("some.call(arrayLike) honours an inherited Object.prototype element", async () => {
+    const src = `export function run(): boolean {
+      (Object.prototype as any)[2] = 42;
+      const r = Array.prototype.some.call({ length: 3 } as any, function (v: any): boolean {
+        return v === 42;
+      });
+      delete (Object.prototype as any)[2];
+      return r;
+    }`;
+    expect(await runHost(src)).toBeTruthy();
+  });
+
+  // An OWN index shadows the inherited one (the proto fallback must NOT mask an
+  // own element — it is reached only after own lookups miss).
+  it("an own index shadows the inherited Object.prototype index", async () => {
+    const src = `export function run(): number {
+      (Object.prototype as any)[0] = 111;
+      const r = Array.prototype.indexOf.call({ length: 1, 0: 222 } as any, 222);
+      const miss = Array.prototype.indexOf.call({ length: 1, 0: 222 } as any, 111);
+      delete (Object.prototype as any)[0];
+      // 222 is the own element at index 0; 111 (inherited) is shadowed → not found.
+      return r * 10 + (miss + 1);
+    }`;
+    // r=0 (222 found at own index 0), miss=-1 (111 shadowed) → 0*10 + 0 = 0
+    expect(await runHost(src)).toBe(0);
+  });
+
+  // Hot-path guard: a plain array-like own-data receiver with NO proto write is
+  // unaffected (the fallback never fires because own indices resolve first).
+  it("array-like own-data receiver is unaffected by the proto fallback", async () => {
+    const src = `export function run(): number {
+      return Array.prototype.indexOf.call({ length: 3, 0: 7, 1: 8, 2: 9 } as any, 8);
+    }`;
+    expect(await runHost(src)).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2580 M3 — B-protoextend lap (value-rep spine)

`Array.prototype.X.call(arrayLike, …)` on an array-like **plain-object** receiver reads `obj[i]` via `Get` (§7.3.2), which walks the receiver's `[[Prototype]]` chain to `%Object.prototype%`. A test that does `Object.prototype[0]=true` then `indexOf.call({length:3}, true)` must return `0`.

### Confirmed mechanism (runtime-traced, per-process, host mode)
The array-like plain-object receiver is an **opaque WasmGC struct** whose runtime `[[Prototype]]` is `null` — it does NOT inherit from the host `Object.prototype`. Trace on current main:
```
[has_idx] idx=0 isWasm=true (idx in obj)=false ObjProtoHas=true
```
`Object.prototype[i]=v` **does** land on the real host `Object.prototype`, but the own-only `obj[i]`/sidecar lookups in `__extern_get_idx`/`__extern_has_idx` never consulted it → the generic-method loop skipped every inherited index.

### Fix (2 runtime sites + 1 shared helper, host-scoped, hot-path byte-identical)
`_protoIndexHas`/`_protoIndexGet` consult `%Object.prototype%[idx]` as the **FINAL fallback** in `__extern_get_idx` (`Get`) and `__extern_has_idx` (`HasProperty` — value-independent). Reached only after own fields + sidecar + own accessor descriptors miss, so a real array / `$Vec` / own-index receiver is resolved earlier and the hot path is unchanged. Routes inherited reads through the **ONE shared `Object.prototype` walk** (architect decision ii-a), not a per-receiver `$proto` field — **no fnctor/`new F()`/`.prototype=` code touched, so no #1888-floor eject risk** (that is the separate B-fnctor lap).

### Measured (per-process, single-process — the reliable signal)
- `indexOf/15.4.4.14-9-b-i-8`: **fail → pass**
- `lastIndexOf/15.4.4.15-8-b-i-8`: **fail → pass**
- **0 regressions** across the 34-file `Object.prototype[idx]` cluster + 8-file hot-path/own-data/real-array guard sample (the two `pass→compile_error` a parallel scan reported were runner-trap artifacts — single-process they PASS on both baseline and branch).
- vitest: new `tests/issue-2580-m3-protoextend.test.ts` (5 host cases) + sibling `array-methods`/`functional-array-methods`/B-acc (55) all green; `tsc` clean.

Authoritative gate = merge_group standalone floor (#2097) + the test262 net-regression gate (broad-reach validation of the whole `__extern_*_idx` blast radius).

Files: `src/runtime.ts`, `tests/issue-2580-m3-protoextend.test.ts`. Issue #2580 stays `in-progress` (B-fnctor lap remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)