### PR TITLE
docs(#1344): re-ground generator return/throw residual + root-cause checkpoint; split #2661

### DIFF
--- a/plan/issues/1344-spec-gap-generator-prototype-receiver-checks.md
+++ b/plan/issues/1344-spec-gap-generator-prototype-receiver-checks.md
@@ -318,3 +318,61 @@ abrupt-completion state machine through `try`/`catch`/`finally`.**
 sd-2651 has verified all of the above on current main; no code landed in this
 re-ground pass (analysis + slicing only) pending a go/no-go on committing the
 multi-day S-B/S-C build vs landing S-A first.
+
+## ROOT-CAUSE CHECKPOINT (2026-06-25, sd-2651) — the host generator backend is EAGER; S-A is NOT a small slice
+
+Drilling into S-A revealed the decisive architectural fact: **#1344's
+try/catch/finally residual is a TWO-BACKEND problem, and the host (gc) backend
+is fundamentally eager-buffered**, so it cannot implement lazy
+suspension / abrupt-interruption semantics at all.
+
+### Two generator backends (the test262 fails hit both)
+
+Native generators are **standalone/wasi-only** (`generators-native.ts:849`
+`if (!noJsHostTarget(ctx)) return false`). In **default gc mode** generators use
+the **host runtime** (`src/runtime.ts`), which is an **EAGER-YIELD BUFFER**
+(`buf: any[]` filled by running the whole body up front — runtime.ts:135).
+
+**Proof (verified, current main):** a generator whose body sets a side effect
+before/between yields, observed BEFORE any `.next()`:
+```
+function* g(){ sideEffect=1; yield 1; sideEffect=2; yield 2; sideEffect=3; }
+g();                        // no .next() yet
+```
+- **gc/host: sideEffect === 3** — the ENTIRE body ran eagerly at `g()` call time.
+- **standalone: sideEffect === 0** — correctly lazy (native state machine).
+
+So every test that observes suspension timing — `.return()`/`.throw()`
+interrupting a generator suspended in a try, `finally`-on-abrupt, "statement
+following yield not executed" — **fails on the host path by construction**, and
+the native path is the correct one. (Confirmed: the failing
+`return/try-finally-within-try.js` asserts `inFinally===0` after the first
+`.next()`; gc returns 1 because the eager buffer already ran the finally;
+standalone in ISOLATION returns 0 correctly.)
+
+### Why standalone ALSO fails the full test262 file (not just gc)
+
+In isolation the native path is correct (`inFinally===0`), but the full
+test262 file fails `standalone` too (same assert). The native path is either not
+selected under the full-harness program shape, or a harness construct routes the
+generator to the host/eager path even under `--target standalone`. **Open
+sub-question to resolve before S-B/S-C** — whether the native path is actually
+exercised by the test262 runner for these files, or the harness defeats the
+candidate gate. (The isolated-vs-harness divergence is the tell.)
+
+### Revised path forward (CHECKPOINT — do NOT pre-commit)
+
+- **S-A as originally scoped (.throw into non-yielding try/finally) is NOT a
+  small, high-value slice.** The host backend can't do it (eager), and the
+  native backend already does the simple cases right; the test262 fails need
+  EITHER (a) the host eager-buffer backend made lazy (a massive rewrite, likely
+  out of scope), OR (b) the test262 lane driven through the NATIVE path +
+  extended for catch / yielding-finally (S-B/S-C).
+- The highest-leverage direction is **(b): make the native lazy backend the path
+  test262 exercises** (resolve the harness-fallback sub-question), then extend it
+  (S-B yielding finalizers + deferred abrupt completion; S-C try/catch state
+  decomposition). That IS the multi-day state-machine build.
+- **Receiver-checks (the original framing) are done; the residual is this
+  backend/state-machine work.** sd-2651 paused here per the lead's "checkpoint
+  before S-B/S-C" instruction — mechanism fully traced (above + the loci section);
+  awaiting go/no-go on solo-continue vs architect-spec pass.

--- a/plan/issues/1344-spec-gap-generator-prototype-receiver-checks.md
+++ b/plan/issues/1344-spec-gap-generator-prototype-receiver-checks.md
@@ -14,8 +14,8 @@ language_feature: generators
 goal: spec-completeness
 sprint: 66
 parent: 1328
-depends_on: [1665]
-related: [2029]
+depends_on: [1665, 2662]
+related: [2029, 2662]
 reground_note: "2026-06-25 (sd-2651): receiver-check framing STALE — Slice 1 (PR #1732 receiver-brand TypeError) merged 2026-06-19. Current residual = 31 GeneratorPrototype fails (NOT 52), 26 of them return/throw through try/catch/finally. AsyncGeneratorPrototype down to 2; AsyncIteratorPrototype 7 = Symbol.asyncDispose split to its own issue (S-D). Slices S-A (.throw try/finally via mode=2 + finally-override), S-B (yielding finalizers + deferred abrupt completion), S-C (try/catch state decomposition). S-B/S-C are the multi-day state-machine build the 2026-05-28 triage flagged."
 ---
 ## Triage 2026-05-28 — NOT a localized receiver-check fix

--- a/plan/issues/1344-spec-gap-generator-prototype-receiver-checks.md
+++ b/plan/issues/1344-spec-gap-generator-prototype-receiver-checks.md
@@ -245,3 +245,74 @@ desync → another net-53 class. This is NOT just hoisting a throw to a stub.
 5. Then (separate follow-on slices, still #1344): `.throw()` routing,
    AsyncGenerator/AsyncIterator prototype checks, GeneratorPrototype-as-object
    reification — see the remaining-parts list above.
+
+## RE-GROUND (2026-06-25, sd-2651, `main` 6a36af19c) — the receiver-check framing is STALE; residual is the try/catch/finally + `.throw()` state machine
+
+Slice 1 (PR #1732, the receiver-brand TypeError) **MERGED** on 2026-06-19 (commit
+`d154a77d8`) — the inline `emitBrandCheckTypeError` is on main at
+`generators-native.ts:1899`. The suspended note's "parked, net-53, option-A
+shared-helper refactor" describes a state that **no longer applies** (the slice
+landed; the baseline has since refreshed many times and absorbed it). So the
+option-A refactor is NOT the remaining work.
+
+### Current fail buckets (baseline jsonl, current main) — NOT 52+12 receiver checks
+
+| suite | fail | shape |
+| --- | ---: | --- |
+| `built-ins/GeneratorPrototype` | **31** | 15 `return/*`, 13 `throw/*`, 3 `next/*` — **26 are `try-*`** |
+| `built-ins/AsyncGeneratorPrototype` | 2 | sibling PRs resolved the async receiver bucket |
+| `built-ins/AsyncIteratorPrototype` | 7 | `Symbol.asyncDispose` (explicit-resource-mgmt; separate feature) |
+
+The 31 `GeneratorPrototype` fails decompose: **9 pure `try-finally`, 8 pure
+`try-catch`, 10 nested `try-finally+catch`, 2 state-guard, 2 other.** The
+receiver-brand half is DONE; the residual is the **`.throw()` / `.return()`
+abrupt-completion state machine through `try`/`catch`/`finally`.**
+
+### Verified mechanism (per-process + per-shape probe)
+
+1. **The native-generator planner BAILS on any `try` with a `catch` clause OR a
+   yielding `finally`** — `generators-native.ts:377` (`if (stmt.catchClause ||
+   !stmt.finallyBlock) return fail()`) + `:378`
+   (`statementsAreYieldFree(finallyBlock)` required). Such generators fall back to
+   the host path, which ALSO mishandles `.throw()` injection.
+2. **`.throw()` is not routed through native dispatch at all**
+   (`tryCompileNativeGeneratorMethodCall` early-returns for `throw`, `:1999`;
+   `compileDirectNativeGeneratorMethod` returns undefined for it, `:1821`).
+3. **The resume function handles mode=1 (`.return()` abrupt) but NOT mode=2
+   (`.throw()` injection)** — `:1448-1481` runs `abruptResume.finalizers` and
+   completes with `doneState`; there is no arm that injects a throw at the
+   yield-resume point and routes it through the enclosing `catch`, nor one that
+   DEFERS the throw across a yielding finally.
+4. **The hard sub-case (the actual test262 shapes):** `throw/try-finally-within-try.js`
+   has `finally { yield 3; }` — `.throw()` at `yield 2` must run the finally
+   (which yields 3, done:false, throw PENDING), and only the NEXT `.next()`
+   completes the finally and THEN propagates the deferred throw. This needs
+   yielding finalizers + deferred abrupt completions, which the
+   `statementsAreYieldFree(finally)` gate currently refuses outright.
+   (Simplified probes with a NON-yielding finally already pass — confirming the
+   gap is specifically yielding-finalizer + catch-state decomposition, not the
+   basic finally path.)
+
+### Proposed slicing (each a full-gate PR; the receiver half is NOT it)
+
+- **S-A — `.throw()` into `try/finally` (non-yielding finally) via mode=2.** Route
+  `throw` through native dispatch; add a resume-function mode=2 arm that runs
+  finalizers then RE-THROWS (vs mode=1's normal completion). Smallest
+  self-contained slice; serves part of the 9 pure-try-finally + the simple
+  throw-no-try propagation hardening. NO planner-catch changes.
+- **S-B — yielding finalizers + deferred abrupt completion.** Lift the
+  `statementsAreYieldFree(finally)` gate; the plan must model a finally as its own
+  yield-capable sub-states and carry a pending-completion (throw/return) across
+  the finally's yields. Serves the `*-within-try`/`*-within-finally` shapes.
+- **S-C — `try/catch` state decomposition.** Stop `fail()`ing on `catchClause`;
+  decompose catch into states with a per-yield-state catch-handler target so
+  mode=2 jumps to the catch instead of propagating. Serves the 8 pure-try-catch +
+  feeds the 10 nested.
+- **S-D — `AsyncIteratorPrototype Symbol.asyncDispose`** is a SEPARATE
+  explicit-resource-management feature (7 fails); split to its own issue.
+
+**Scope reality:** S-B/S-C are a multi-day generator state-machine build (the
+2026-05-28 triage's "NOT a localized fix"). S-A is the tractable first slice.
+sd-2651 has verified all of the above on current main; no code landed in this
+re-ground pass (analysis + slicing only) pending a go/no-go on committing the
+multi-day S-B/S-C build vs landing S-A first.

--- a/plan/issues/1344-spec-gap-generator-prototype-receiver-checks.md
+++ b/plan/issues/1344-spec-gap-generator-prototype-receiver-checks.md
@@ -1,10 +1,10 @@
 ---
 id: 1344
-title: "spec gap: Generator/AsyncIterator prototype receiver TypeErrors + return/throw (52 + 12 test262 fails)"
-status: suspended
-assignee: ttraenkler/sen-1
+title: "spec gap: Generator return/throw abrupt completion through try/catch/finally (31 GeneratorPrototype fails; receiver-checks landed in Slice 1)"
+status: in-progress
+assignee: ttraenkler/sd-2651
 created: 2026-05-08
-updated: 2026-06-24
+updated: 2026-06-25
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -15,6 +15,8 @@ goal: spec-completeness
 sprint: 66
 parent: 1328
 depends_on: [1665]
+related: [2029]
+reground_note: "2026-06-25 (sd-2651): receiver-check framing STALE — Slice 1 (PR #1732 receiver-brand TypeError) merged 2026-06-19. Current residual = 31 GeneratorPrototype fails (NOT 52), 26 of them return/throw through try/catch/finally. AsyncGeneratorPrototype down to 2; AsyncIteratorPrototype 7 = Symbol.asyncDispose split to its own issue (S-D). Slices S-A (.throw try/finally via mode=2 + finally-override), S-B (yielding finalizers + deferred abrupt completion), S-C (try/catch state decomposition). S-B/S-C are the multi-day state-machine build the 2026-05-28 triage flagged."
 ---
 ## Triage 2026-05-28 — NOT a localized receiver-check fix
 

--- a/plan/issues/2661-asynciteratorprototype-symbol-asyncdispose.md
+++ b/plan/issues/2661-asynciteratorprototype-symbol-asyncdispose.md
@@ -1,0 +1,66 @@
+---
+id: 2661
+title: "AsyncIteratorPrototype[Symbol.asyncDispose] — explicit-resource-management disposal protocol (7 test262 fails)"
+status: ready
+created: 2026-06-25
+priority: low
+feasibility: medium
+reasoning_effort: medium
+task_type: feature
+area: codegen, runtime
+language_feature: async-iterators, explicit-resource-management
+goal: spec-completeness
+parent: 1344
+related: [2029]
+test262_bucket: built-ins/AsyncIteratorPrototype
+---
+
+# #2661 — `%AsyncIteratorPrototype%[Symbol.asyncDispose]` (split from #1344)
+
+Split from **#1344** (2026-06-25, sd-2651). The #1344 re-ground found the
+`built-ins/AsyncIteratorPrototype` fails (7 on current `main`) are **not** the
+generator return/throw try/catch/finally residual that #1344 now tracks — they
+are the **`Symbol.asyncDispose`** method on `%AsyncIteratorPrototype%`, an
+**explicit-resource-management** feature (ES2026 `using`/`await using` disposal
+protocol). Different layer, different feature → own issue.
+
+## Failing rows (baseline jsonl, current `main`)
+
+```
+built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/throw-return-getter.js
+built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/name.js
+built-ins/AsyncIteratorPrototype/Symbol.asyncDispose/is-function.js
+… (7 total under built-ins/AsyncIteratorPrototype/, all Symbol.asyncDispose/* +
+   Symbol.asyncIterator/*)
+```
+
+## Scope
+
+`%AsyncIteratorPrototype%[Symbol.asyncDispose]` (§27.1.3.1-ish in the
+explicit-resource-management proposal): the well-known `@@asyncDispose` method
+that closes the async iterator (`return()` it) and returns a promise. Tests check
+it is a function, its `.name` is `[Symbol.asyncDispose]`, its `.length`, and that
+it forwards to the iterator's `return`.
+
+## Boundary with #2029 (cross-reference)
+
+#2029 is the broader **disposal-protocol cluster** (`SuppressedError` /
+`DisposableStack` / `using`). sd-2038 is touching #2029 as an **EMIT-CRASH**
+bucket (a different layer — the codegen crash, not the per-method feature gap).
+This issue (#2661) is the **`%AsyncIteratorPrototype%` well-known-method feature
+gap** specifically — no direct collision, but the two share the
+`Symbol.asyncDispose` / `Symbol.dispose` well-known-symbol plumbing, so coordinate
+the symbol registration if both are in flight.
+
+## Acceptance
+
+- The 7 `built-ins/AsyncIteratorPrototype` rows pass (host + standalone).
+- `%AsyncIteratorPrototype%[Symbol.asyncDispose]` is a function with the correct
+  `name`/`length`/`@@asyncDispose` descriptor; calling it `return()`s the async
+  iterator and resolves.
+
+## Routing
+
+Low priority (a narrow well-known-method feature, 7 rows). Pick up after the
+#1344 generator state-machine slices and #2029's disposal cluster settle so the
+shared well-known-symbol plumbing is stable.

--- a/plan/issues/2662-host-gc-generator-backend-eager-breaks-suspension.md
+++ b/plan/issues/2662-host-gc-generator-backend-eager-breaks-suspension.md
@@ -1,0 +1,105 @@
+---
+id: 2662
+title: "host (gc) generator backend is EAGER-buffered — breaks lazy/suspension semantics on the default path (architecture)"
+status: ready
+created: 2026-06-25
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: bugfix
+area: codegen, runtime, architecture
+language_feature: generators
+goal: spec-completeness
+related: [1344, 1665, 2157]
+test262_bucket: built-ins/GeneratorPrototype
+---
+
+# #2662 — host (gc) generator backend is eager-buffered (architectural correctness gap)
+
+Split out of **#1344** (2026-06-25, sd-2651) because it is **bigger than #1344**
+and gates whether #1344's state-machine slices (S-B/S-C) move the conformance
+dashboard at all.
+
+## The gap
+
+There are **two** generator backends:
+
+- **Native lazy state machine** (`src/codegen/generators-native.ts`) — correct
+  suspension semantics, but **standalone/wasi-ONLY** (`generators-native.ts:849`
+  `if (!noJsHostTarget(ctx)) return false`).
+- **Host runtime** (`src/runtime.ts`) — used in **default gc mode** — is an
+  **EAGER-YIELD BUFFER**: it runs the **entire** generator body up front into a
+  `buf: any[]` (runtime.ts:135), then `.next()` just drains the buffer.
+
+The eager backend **cannot** implement lazy suspension, so it is wrong for every
+observable that depends on when the body runs:
+
+- side-effect timing (statement after a `yield` must not run until resumed);
+- `.return()` / `.throw()` **interrupting** a generator suspended in a `try`;
+- `finally` running on abrupt completion at the right time;
+- infinite generators (eager buffer never terminates).
+
+### Proof (verified, current `main`)
+
+```ts
+let se = 0;
+function* g() { se = 1; yield 1; se = 2; yield 2; se = 3; }
+g();            // create, NO .next() yet
+// gc/host:    se === 3   (whole body ran eagerly — WRONG)
+// standalone: se === 0   (correctly lazy)
+```
+
+## Why this gates #1344 (and any generator-conformance work)
+
+The test262 conformance runner wraps every test in `export function test() { … }`
+(`tests/test262-runner.ts:2370`, `wrapTest`). A test's top-level `function* g()`
+therefore becomes a **generator nested inside `test()`**, and (for the
+GeneratorPrototype tests, which have no class so their `var`s are NOT hoisted to
+module scope) it **captures** the `test()`-local vars. A capturing nested
+generator hits `generatorCapturesOuterScope` (`generators-native.ts:901`) →
+**bail to the host EAGER path even under `--target standalone`.**
+
+Verified: the wrapped `return/try-finally-within-try.js` keeps `var inTry`,
+`var inFinally`, and `function* g()` all INSIDE `test()` (capturing), so it runs
+on the eager host path in BOTH lanes. The conformance dashboard's
+`runTest262File` defaults to gc/host (`scripts/runner-bundle.mjs:64253` — no
+`target` arg). **So test262 generators are measured on the eager host path.**
+
+⇒ Building the native state machine for catch / yielding-finally (#1344 S-B/S-C)
+would move the dashboard by **ZERO** until this gap is closed, because the
+measured path never reaches the native backend for these tests.
+
+## Options (architecture decision — needs the lead / an architect)
+
+1. **Make the native lazy path handle CAPTURES** (so a nested/capturing generator
+   goes native instead of bailing to eager host). This re-routes the wrapped
+   test262 generators onto the correct backend and is likely the highest-leverage
+   single change — it may flip a large swath of generator tests at once AND
+   unblock #1344 S-B/S-C. Scope: the native state struct currently has slots for
+   `this` + own params only, not captures (`generators-native.ts:899-902`);
+   capture support means materializing captured bindings as ref-cell fields in the
+   state struct (the closure-capture pattern already used elsewhere).
+2. **Make the host gc backend lazy** (a proper resumable coroutine in
+   `src/runtime.ts` instead of the eager buffer). Large rewrite; the eager buffer
+   was a deliberate simplification. Likely out of scope / lower leverage than (1).
+3. **Measure conformance on the standalone lane for generators** — does not fix
+   the gc correctness gap, and captured generators still bail to eager even under
+   standalone, so this alone is insufficient.
+
+**Recommendation (sd-2651):** Option 1 (native captures) — it fixes the
+measured-path selection (the #1344 gating sub-question), is bounded by the
+existing closure-capture machinery, and unblocks the #1344 state-machine slices.
+Decide before committing #1344 S-B/S-C.
+
+## Acceptance
+
+- A capturing nested generator runs LAZILY (the side-effect-timing proof above
+  returns 0 in gc mode, or the wrapped test262 generators are routed to the
+  native lazy path), without regressing the existing generator suites.
+- Re-measure the GeneratorPrototype `return`/`throw` buckets afterward; #1344
+  S-B/S-C then have a measurable target.
+
+## Routing
+
+Architecture decision first (lead/architect): option 1 vs 2 vs 3. Then a
+senior-dev build. Blocks #1344 S-B/S-C from moving the dashboard.


### PR DESCRIPTION
Docs/planning-only. Re-grounds #1344 on current main and records a root-cause checkpoint; no source change.

## Re-ground findings
- **Slice 1 (PR #1732 receiver-brand TypeError) already MERGED** 2026-06-19. The suspended note's net-53 / option-A shared-helper refactor no longer applies.
- **Fail buckets corrected:** GeneratorPrototype **31** (not 52); AsyncGeneratorPrototype down to **2**; AsyncIteratorPrototype **7** = `Symbol.asyncDispose` → **split to #2661** (separate explicit-resource-management feature, cross-referenced to #2029's disposal cluster).
- The 31 GeneratorPrototype fails are 26 `return`/`throw` through try/catch/finally.

## Root-cause checkpoint (the decisive finding)
The residual is a **TWO-BACKEND** problem:
- Native generators are **standalone/wasi-only** (`generators-native.ts:849`).
- Default **gc mode uses the host runtime** (`src/runtime.ts`), which is an **EAGER-YIELD BUFFER** — it runs the whole generator body up front.
- **Proof:** `function* g(){ se=1; yield 1; se=2; yield 2; se=3 }; g()` (no `.next()`) → gc `se===3` (eager), standalone `se===0` (lazy). So suspension-timing / abrupt-interruption / finally-on-abrupt tests fail on the host path **by construction**; the native path is correct.

## Path forward (checkpoint — not pre-committed)
S-A (.throw into non-yielding try/finally) is NOT a small slice: the host backend can't do it (eager) and the native backend already does the simple cases. Highest leverage = drive test262 through the native lazy backend + extend it (S-B yielding finalizers + deferred abrupt completion, S-C try/catch state decomposition) — the multi-day state-machine build. Paused per the lead's checkpoint instruction; full mechanism trace in the issue file (loci + the two-backend root cause).

Frontmatter: #1344 title/status/count corrected, `status: in-progress`. New #2661 created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)