### PR TITLE
docs(#2662): durable architecture writeup — generator-backend epic (Option ii) + sd-2651 context note

### DIFF
--- a/plan/agent-context/sd-2651.md
+++ b/plan/agent-context/sd-2651.md
@@ -1,0 +1,79 @@
+# sd-2651 — session context (2026-06-25)
+
+Senior developer (Opus). Session theme: **verify-first discipline** — re-grounding
+stale issue framings against current `main`, PoC-before-build, and slicing hard
+issues. 4 stale-framing corrections + 2 decisive PoCs, each saving days of
+misdirected build.
+
+## Laps done this session (all merged unless noted)
+
+| Issue | Outcome | PR | State |
+| --- | --- | --- | --- |
+| **#2045** linear Uint8Array soundness | Re-grounded (A.1/A.2/B.3/B.4/C.8 already landed; C.5 resolved; C.7-stdin obsoleted). Fixed the live hole: `readSync`/`writeSync(fd,buf,{offset,length})` didn't clamp explicit offset/length → OOB linear-mem read/write. Clamp in `emitNodeFsOffsetLength` (`src/codegen/node-fs-api.ts`). 10 WASI tests + 61 regression clean. | #2048 | **MERGED**, `status: done` |
+| **#2651** TypedArray builtin-ctor value | Verified D2/M1 already landed (PR #2043). Re-measured: real lever is M3 (`%TypedArray%` intrinsic, ~130 rows). Lead parked M3 behind #2580 M3 (predecessor-stack). | #2047 | **MERGED**, `status: blocked` on 2580 |
+| **#1344** generator return/throw try/catch/finally | Re-grounded + root-caused + PoC. See "Generator epic" below. Build PARKED behind #2662. | #2050 | **MERGED** (docs), `status: in-progress` |
+| **#2661** AsyncIteratorPrototype[Symbol.asyncDispose] | Split out of #1344 (separate explicit-resource-mgmt feature, 7 fails). | (in #2050) | `status: ready` |
+| **#2662** host gc generator backend is eager (architecture) | New issue + durable architecture writeup. See below. | #2050 + #<arch-writeup PR> | created; writeup PR open/merging |
+
+## Generator-backend epic (#2662) — RESUME POINTER for the build
+
+**This is the durable spec: read `plan/issues/2662-host-gc-generator-backend-eager-breaks-suspension.md` "ARCHITECTURE WRITEUP" section.** It is complete — a
+future session builds directly from it.
+
+**The problem (verified):** two generator backends. Native lazy state machine
+(`src/codegen/generators-native.ts`) is **standalone/wasi-only**; default **gc
+mode uses the host runtime** (`src/runtime.ts`) which is an **EAGER-YIELD BUFFER**
+(runs the whole body up front → cannot do lazy suspension / abrupt-interruption /
+finally-on-abrupt). test262 generators are measured on the eager gc path
+(`wrapTest` wraps each test in `export function test()` → top-level `function* g`
+becomes nested+capturing → `generatorCapturesOuterScope` bails → eager host, even
+under `--target standalone`). So #1344's S-B/S-C state-machine work would move the
+dashboard by ZERO until this is fixed.
+
+**Decision (lead): Option (ii)** — native-struct→JS-callable boundary wrapper +
+in-module-only native selection + capture-materialization. (Option (i) only moves
+the standalone report + leaves gc broken; (iii) host-lazy rewrite is two engines.)
+
+**PoC verdict (env-gated probe, REVERTED — not committed):** flipping
+`noJsHostTarget` to allow gc routes simple gens to native (lazy works), BUT (a)
+capturing gens still bail, (b) THE BLOCKER: native returns an opaque Wasm state
+struct, not a JS-callable object → escaping gens break (`gen.next is not a
+function`, 5 unit-test failures). So native is correct for **in-module** use
+(conformance), wrong for **JS-escaping** use without a boundary wrapper.
+
+**Build order (3 levers, in #2662):** JS-boundary wrapper (prereq, high) → Lever A
+capture-materialization (high, ref-cell fields in the state struct) → re-measure
+GeneratorPrototype buckets → unblock #1344 S-B/S-C. Lever B (runner-hoist in
+`wrapTest`) is a low-cost conformance-signal accelerator only, NOT a substitute.
+
+**Build is DEFERRED** (multi-session epic) — prioritize against s66 work with the
+spec in hand. **#1344 stays parked behind #2662** (`#1344 depends_on [1665, 2662]`).
+
+## #1344 specifics (parked behind #2662)
+
+Receiver-checks (the original "52+12" framing) landed in Slice 1 (PR #1732,
+already merged). Current residual = 31 GeneratorPrototype `return`/`throw`
+through try/catch/finally. Slices documented in the #1344 file:
+- S-A `.throw` into try/finally via resume mode=2 (NOT a small slice — host eager
+  can't do it, native already does simple cases).
+- S-B yielding finalizers + deferred abrupt completion (lift the
+  `statementsAreYieldFree(finally)` gate at `generators-native.ts:~378`).
+- S-C try/catch state decomposition (stop `fail()` on `catchClause` at `:~377`).
+All gated on #2662 (the measured path must reach the native backend first).
+
+## Working notes
+
+- Cross-dev claim lock: `node scripts/claim-issue.mjs <id> ttraenkler/sd-2651
+  --branch <b>` (exit 0 own / 3 taken / 4 done). `--complete`/`--release` on done/suspend.
+- Baseline jsonl cache: the shared `/workspace/.test262-cache` symlink can be
+  read-only from a worktree; replace with a real dir + `node
+  scripts/fetch-baseline-jsonl.mjs` for a writable local copy.
+- Measurement instrument: per-process 3-bucket scan (`.tmp/measure-one.mjs`,
+  one fresh process per file) is the faithful path (avoids the #2580 in-process
+  runner artifact).
+- Merge protocol: enqueue ONCE via GraphQL `enqueuePullRequest` (user PAT), never
+  re-enqueue; auto-enqueue backstop owns re-adds.
+
+## Claims at session end
+- #2045 `--complete`, #2651 `released`, #1344 held `in-progress` (parked, mine to
+  resume when #2662 build is prioritized).

--- a/plan/issues/2662-host-gc-generator-backend-eager-breaks-suspension.md
+++ b/plan/issues/2662-host-gc-generator-backend-eager-breaks-suspension.md
@@ -86,10 +86,12 @@ measured path never reaches the native backend for these tests.
    the gc correctness gap, and captured generators still bail to eager even under
    standalone, so this alone is insufficient.
 
-**Recommendation (sd-2651):** Option 1 (native captures) — it fixes the
-measured-path selection (the #1344 gating sub-question), is bounded by the
-existing closure-capture machinery, and unblocks the #1344 state-machine slices.
-Decide before committing #1344 S-B/S-C.
+**DECISION (lead, 2026-06-25): Option (ii)** — native-struct→JS-callable boundary
+wrapper + in-module-only native selection + capture-materialization. The PoC
+revealed the JS-host boundary blocker that makes a plain "Option 1" insufficient
+on its own (a captured generator can still escape to JS). See the full
+**ARCHITECTURE WRITEUP** section below for the verdict, the option (i)/(ii)/(iii)
+reasoning, and the 3-lever cost model. Build DEFERRED (multi-session epic).
 
 ## Acceptance
 
@@ -103,3 +105,105 @@ Decide before committing #1344 S-B/S-C.
 
 Architecture decision first (lead/architect): option 1 vs 2 vs 3. Then a
 senior-dev build. Blocks #1344 S-B/S-C from moving the dashboard.
+
+---
+
+# ARCHITECTURE WRITEUP (2026-06-25, sd-2651) — DECISION + PoC verdict + cost model
+
+> This section is the durable spec a future session builds from. The build is
+> **DEFERRED** (multi-session epic); the design is settled here. **DECISION
+> (lead): Option (ii)** — native-struct→JS-callable boundary wrapper +
+> in-module-only native selection + capture-materialization. Reasoning below.
+
+## PoC verdict (env-gated probe `JS2WASM_POC_GC_NATIVE_GEN`, reverted — no commit)
+
+Flipping `noJsHostTarget` (`generators-native.ts:110`) to also return true for gc
+routed gc-mode generators to the native lazy backend. Three findings, in order of
+how they reshape the design:
+
+1. **Routing gc→native is trivial to ENABLE and works for the simple case.** A
+   non-capturing top-level generator in gc mode became lazy
+   (`function* g(){ se=1; yield 1; … }; g()` → `se===0`, was `3` eager) and
+   emitted the native resume function (`__gen_resume_`). So the gate is the only
+   thing standing between gc and the native path *for the simple shape*.
+
+2. **Capturing generators still bail** (`generatorCapturesOuterScope`,
+   `generators-native.ts:~901`) → eager host. The wrapped test262 shape (a
+   `function* g()` nested in `export function test()` capturing the test-locals)
+   needs capture-materialization (Lever A) OR runner-side hoist (Lever B) to reach
+   native at all.
+
+3. **THE BLOCKER — routing gc→native breaks the JS-HOST BOUNDARY.** The native
+   path returns an **opaque Wasm state struct**, not a JS-callable generator
+   object. Existing gc generator unit tests fail with **`gen.next is not a
+   function`** (5 failures across `generators`/`generator-methods`/
+   `generator-nested`/`for-of-generator`) the moment a native generator is handed
+   **back to JS** (`const gen = exports.count(); gen.next()`). The native `.next`/
+   `.return`/`.throw` are reached only via **in-module dispatch** (the
+   `tryCompileNativeGeneratorMethodCall` path), never as JS methods on the struct.
+
+### The decisive distinction (drives the whole design)
+
+- **In-module generator use** (the wrapped test262 `test()` calls `it.next()`
+  *inside* Wasm; standalone programs) → native lazy backend is CORRECT and is what
+  we want everywhere.
+- **JS-escaping generator use** (a gc program returns a generator to a JS caller,
+  or host-side `for…of` drives it) → needs a **JS-callable object**, which today
+  only the eager host runtime provides.
+
+A global gc→native flip is therefore WRONG: it silently breaks every escaping
+generator. Native must be selected only when the generator provably stays
+in-module, **or** the native struct must be wrapped in a JS-callable object at the
+Wasm↔JS boundary.
+
+## Why Option (ii), not (i) or (iii) (lead decision)
+
+- **(i) Keep gc eager; measure generators on the standalone+native lane.** Only
+  moves the STANDALONE report, not the headline gc dashboard; leaves real gc-mode
+  generators broken; and introduces a measurement-integrity wrinkle (generators
+  scored on a different lane than the rest of the dashboard). Rejected.
+- **(iii) Make the host gc runtime lazy** (resumable coroutine in `src/runtime.ts`
+  instead of the eager `buf`). A large rewrite duplicating the state-machine the
+  native backend already has. Rejected (lower leverage; two lazy engines).
+- **(ii) native-struct→JS-callable wrapper + in-module-only native selection +
+  capture-materialization.** Fixes the gc correctness gap broadly (escaping AND
+  in-module), moves the headline dashboard, and reuses the one correct lazy engine
+  (native). **CHOSEN.** Multi-session epic; build deferred, design captured here.
+
+## 3-lever cost model (build order for the epic)
+
+| Lever | What | Cost | Notes / prerequisite |
+| --- | --- | --- | --- |
+| **JS-boundary wrapper** (PREREQUISITE) | Wrap the native state struct in a JS-callable object exposing `.next/.return/.throw/[Symbol.iterator]` that forward into the in-module native dispatch helpers; emit it at the Wasm↔JS boundary when a native generator value escapes to JS (return value, export, host `for…of`). Equivalently/additionally: an **in-module-only native selection** gate so a generator that never escapes JS takes native, while an escaping one either gets the wrapper or stays host. | **High (architectural)** | The genuinely new design piece. Decides escape analysis (which generators escape to JS) + the externref wrapper object shape. Reuses `tryCompileNativeGeneratorMethodCall` dispatch as the wrapper's forwarding target. Without it, gc→native breaks escaping generators (PoC finding 3). |
+| **Lever A — capture-materialization** | Make `generatorCapturesOuterScope` NOT bail; materialize captured bindings as **ref-cell fields** (`struct (field $value (mut T))`) in the native state struct, shared with the enclosing scope's locals (the existing closure-capture pattern). Thread the ref-cells into the generator factory call; read/write through them in the resume function. | **High (multi-day)** | Bounded by the existing closure-capture machinery, but touches the state-struct layout (`registerNativeGenerator` ~:1094-1135), the factory call, and the resume emitter. Required because the wrapped test262 generators all capture. Needs the boundary wrapper first (a captured generator can still escape). |
+| **Lever B — runner-side hoist** | In `tests/test262-runner.ts` `wrapTest`, hoist a test's top-level `function* g` + the `var`s it references to **module scope** (outside `export function test()`), so it is not captured → with gc→native it goes native. | **Low** | CHEAPER but: (a) still needs the gc→native routing + boundary-wrapper decision; (b) changes WHAT is measured — must preserve test semantics (hoist order, TDZ); (c) only helps the conformance lane, not real gc-mode generator correctness. A measurement convenience, NOT a substitute for Levers A + wrapper. Use only to *accelerate dashboard signal* once the core lands. |
+
+**Build order:** JS-boundary wrapper (+ in-module-only selection) → Lever A
+(captures) → re-measure GeneratorPrototype buckets → unblock #1344 S-B/S-C
+(yielding finalizers, try/catch state decomposition). Lever B optionally bolted on
+to speed the conformance signal, with semantics-preservation review.
+
+## Loci (current `main`, for the builder)
+
+- `src/codegen/generators-native.ts:110` `noJsHostTarget` — the gc/standalone gate.
+- `:~839` `isNativeGeneratorCandidate` (gates on `noJsHostTarget`) +
+  `:~901` `generatorCapturesOuterScope` (the capture bail — Lever A).
+- `:~1094-1135` `registerNativeGenerator` state-struct field layout (add capture
+  ref-cell fields here).
+- `:~1448-1481` resume-function mode handling (mode 1 = `.return` abrupt;
+  #1344 S-B adds mode 2 = `.throw` + deferred-throw-through-yielding-finally).
+- `tryCompileNativeGeneratorMethodCall` (`:~1992`) — the in-module dispatch the
+  JS-boundary wrapper must forward into.
+- Call-site double-gates that also block gc→native:
+  `declarations.ts:~848`, `class-bodies.ts:~1073`, `literals.ts:~2409`,
+  `nested-declarations.ts:~377` (each `(ctx.standalone || ctx.wasi) && …`).
+- `src/runtime.ts:~135` — the eager host generator `buf` (option (iii)'s target;
+  NOT chosen, listed for completeness).
+- `tests/test262-runner.ts:~2370` `wrapTest` — wraps every test in
+  `export function test()` (the capture source); Lever B edits here.
+
+## Status
+
+Design settled (Option ii). Build DEFERRED — multi-session epic, to be prioritized
+against s66 work with this spec in hand. **#1344 stays parked behind this epic**
+(`#1344 depends_on [1665, 2662]`).


### PR DESCRIPTION
Docs/planning-only. No source change.

## #2662 architecture writeup (the spec a future session builds from)
Consolidates the generator-backend epic:
- **PoC verdict** (env-gated probe, reverted): gc→native routing is trivial to enable and works for simple generators, BUT (a) capturing generators still bail, (b) THE BLOCKER — native returns an opaque Wasm state struct, not a JS-callable object, so generators that escape to JS break (`gen.next is not a function`, 5 unit-test failures). Native is correct for in-module use (conformance), wrong for JS-escaping use without a boundary wrapper.
- **Decision (lead): Option (ii)** — native-struct→JS-callable boundary wrapper + in-module-only native selection + capture-materialization. (Rejected (i) standalone-only / leaves gc broken; (iii) host-lazy rewrite / two engines.)
- **3-lever cost model + build order:** JS-boundary wrapper (prereq, high) → Lever A capture-materialization (high) → re-measure → unblock #1344 S-B/S-C; Lever B runner-hoist (low, conformance-signal accelerator only). Loci table included.
- Build **DEFERRED** (multi-session epic); #1344 stays parked behind it.

## sd-2651 context note
`plan/agent-context/sd-2651.md` — session laps (#2045 merged, #2651 parked, #1344 parked, #2661 split) + the #2662 build resume-pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)