### PR TITLE
fix(#2029): route SuppressedError + ERM-ctor builtin reads off the global.get -1 sentinel

### DIFF
--- a/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
+++ b/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
@@ -508,3 +508,48 @@ test262 floor for full conformance (per `project_broad_impact_validate_full_ci`)
 **Remaining (separate PRs, this issue stays `in-progress`):** the `global index
 -1` sentinel cluster (17) and the `function index` funcIdx-shift cluster (8), plus
 1 stray `for-of/iterator-next-reference` local-index from a different producer.
+
+## LANDED slice (2026-06-25, sd-2038) — global-index `-1` sentinel cluster (14 off the emit-crash)
+
+Two distinct producers in the global-index `-1` sentinel sub-bucket, both the
+documented `-1` string-global-sentinel class (a string constant un-materialized
+standalone records `-1` in `stringGlobalMap`; a raw `global.get` of it crashes
+the encoder):
+
+1. **`SuppressedError.prototype.<member>`** — `SuppressedError` was missing from
+   `BUILTIN_CTOR_NAMES` (`property-access.ts`), so the read fell through both the
+   standalone native-proto path and the host `__get_builtin` fallback into a
+   generic member path that pushed a raw `global.get <stringGlobalMap.get>`.
+   **Fix:** list `SuppressedError` in `BUILTIN_CTOR_NAMES` — identical to the
+   DisposableStack/AsyncDisposableStack precedent already there. Routes the read
+   to the dual-mode handler (clean located refusal standalone, `__get_builtin`
+   under gc/host). Flips the 7 `built-ins/SuppressedError/prototype/*` rows off
+   the emit-crash (now clean CE).
+
+2. **ERM ctors read as bare VALUES** (`Object.getPrototypeOf(SuppressedError)`,
+   `isConstructor(DisposableStack)` — `proto.js` / `is-a-constructor.js` for all
+   three ERM ctors, 6 rows) — `identifiers.ts` had a HOST-ONLY fast path for
+   `DisposableStack`/`AsyncDisposableStack`/`SuppressedError`-as-value that called
+   `__get_globalThis` + `__extern_get` and pushed the ctor-name key via the `-1`
+   string-global sentinel → `global.get -1`. It was NOT standalone-gated, so it
+   both baked the bad index AND leaked two host imports an empty import object
+   can't satisfy. **Fix:** gate the fast path to gc/host (`!standalone && !wasi`);
+   standalone falls through to the clean path. (This is why the already-listed
+   DisposableStack pair STILL had a `proto`/`is-a-constructor` residual — listing
+   in `BUILTIN_CTOR_NAMES` covers `.prototype.*` but not the bare-value path.)
+
+**Row-delta:** the 37-file runner re-probe (post-#2052 baseline 26 still-crashing)
+→ **12 still-crashing**: 14 flipped off the emit-crash, 1 now PASSES outright.
+gc/host mode unchanged (the value fast-path still fires in gc; verified
+`Object.getPrototypeOf(SuppressedError)` compiles gc). Files:
+`src/codegen/property-access.ts` (+SuppressedError in BUILTIN_CTOR_NAMES),
+`src/codegen/expressions/identifiers.ts` (host-gate the ERM-ctor value fast-path).
+Test: `tests/issue-2029-suppressederror-builtin-global-sentinel.test.ts` (6/6).
+Existing #2029 suites green (23/23). Broad emit-path change → merge_group floor.
+
+**Remaining global-index (3, separate/deferred producers):** `String.prototype.
+replaceAll/searchValue-replacer-RegExp-*` (2, regexp-replacer string key) and
+`language/expressions/property-accessors/S11.2.1_A3_T2.js` (1, getter/setter
+accessor). Plus the `function index` funcIdx-shift cluster (8: TypedArray/Array
+`toLocaleString`, annexB RegExp, optional-chaining async) and 1 stray
+`for-of/iterator-next-reference` local-index — the next PR(s).

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -816,7 +816,20 @@ function compileIdentifier(ctx: CodegenContext, fctx: FunctionContext, id: ts.Id
   // native constructor object (with its prototype + accessor descriptors) is
   // visible. Scope strictly to these host-delegated ERM globals and only when
   // the name is not shadowed by a local/captured binding.
+  //
+  // (#2029) HOST-ONLY: this whole fast path uses the `__get_globalThis` /
+  // `__extern_get` host imports (absent in no-JS-host targets) AND pushes the
+  // ctor-name string key via a string-constant global — which under
+  // standalone/nativeStrings is the `-1` sentinel, baking `global.get -1`
+  // ("global index out of range — -1") at serialize time. It also leaks two
+  // host imports that an empty import object can't satisfy. The reflective
+  // `Object.getPrototypeOf(SuppressedError)` / `isConstructor(DisposableStack)`
+  // shapes (built-ins/{SuppressedError,DisposableStack,AsyncDisposableStack}/
+  // {proto,is-a-constructor}.js) hit this. Gate to gc/host; standalone falls
+  // through to the clean located refusal (the #1888 dual-mode invariant).
   if (
+    !ctx.standalone &&
+    !ctx.wasi &&
     (name === "DisposableStack" || name === "AsyncDisposableStack" || name === "SuppressedError") &&
     !fctx.localMap.has(name) &&
     !(fctx.boxedCaptures?.has(name) ?? false) &&

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -165,6 +165,15 @@ const BUILTIN_CTOR_NAMES = new Set([
   // standalone).
   "DisposableStack",
   "AsyncDisposableStack",
+  // (#2029) `SuppressedError` (ES2025 error aggregation) — same class as the
+  // DisposableStack pair above: not listed here, a `SuppressedError.prototype.*`
+  // read fell through both the standalone native-proto path and the host
+  // `__get_builtin` fallback into a generic member path that emitted
+  // `global.get -1` (the -1 string-global sentinel) → `global index out of
+  // range — -1` encoder crash standalone (whole file lost; 9 test262 rows under
+  // built-ins/SuppressedError/*). Listing it routes the read to the dual-mode
+  // handler (loud located refusal standalone, `__get_builtin` under gc/host).
+  "SuppressedError",
 ]);
 
 // Well-known Symbol IDs (inlined from literals.ts to avoid circular deps)

--- a/tests/issue-2029-suppressederror-builtin-global-sentinel.test.ts
+++ b/tests/issue-2029-suppressederror-builtin-global-sentinel.test.ts
@@ -1,0 +1,85 @@
+// #2029 (global-index `-1` sentinel sub-bucket) — `SuppressedError` and the two
+// Disposable-stack ERM constructors, read as VALUES or via `.prototype.*` under
+// `--target standalone`, must NOT emit `global.get -1` ("global index out of
+// range — -1") at serialize time. Two distinct producers, both rooted in the
+// `-1` string-global sentinel that standalone/nativeStrings records for an
+// un-materialized string constant:
+//
+//  1. `SuppressedError.prototype.<member>` fell through both the standalone
+//     native-proto path and the host `__get_builtin` fallback into a generic
+//     member path that pushed a raw `global.get <stringGlobalMap.get>` — fixed
+//     by listing `SuppressedError` in `BUILTIN_CTOR_NAMES` (property-access.ts),
+//     routing it to the dual-mode handler (clean located refusal standalone,
+//     `__get_builtin` under gc/host) — same as the DisposableStack pair (#2029).
+//  2. The ERM ctors read as bare VALUES (`Object.getPrototypeOf(SuppressedError)`,
+//     `isConstructor(DisposableStack)`) took a HOST-ONLY fast path
+//     (`__get_globalThis` + `__extern_get`, identifiers.ts) that both leaked two
+//     host imports AND pushed the ctor-name key via the `-1` string-global
+//     sentinel — fixed by gating that fast path to gc/host (`!standalone &&
+//     !wasi`); standalone falls through to the clean path.
+//
+// Acceptance: NO `index out of range` / `Binary emit error` for these shapes
+// standalone (the whole-file-lost encoder crash); gc/host mode unchanged.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileStandalone(src: string) {
+  return (await compile(src, { target: "standalone" })) as any;
+}
+
+function noEmitCrash(r: any): void {
+  // The defining failure of this bucket is the encoder RangeError, surfaced as a
+  // compile error whose message contains "index out of range" / "Binary emit
+  // error". A clean located refusal (reportError) is acceptable — it is NOT an
+  // emit crash. So we assert specifically that no emit-crash message is present.
+  const msgs: string[] = (r.errors ?? []).map((e: any) => e.message);
+  expect(msgs.some((m) => /index out of range|Binary emit error/.test(m))).toBe(false);
+}
+
+describe("#2029 — SuppressedError / ERM-ctor builtin global-index `-1` sentinel (standalone emit)", () => {
+  it("`SuppressedError.prototype.name` no longer emits global.get -1 (clean refusal, not crash)", async () => {
+    const r = await compileStandalone(
+      `export function test(): number { const n: any = SuppressedError.prototype.name; return n === "SuppressedError" ? 1 : 0; }`,
+    );
+    noEmitCrash(r);
+  });
+
+  it("`Object.getPrototypeOf(SuppressedError)` compiles standalone (was: global.get -1)", async () => {
+    const r = await compileStandalone(
+      `export function test(): number { const p: any = Object.getPrototypeOf(SuppressedError); return p ? 1 : 0; }`,
+    );
+    expect(r.success).toBe(true);
+    noEmitCrash(r);
+  });
+
+  it("`Object.getPrototypeOf(DisposableStack)` compiles standalone (already-listed ctor, bare-value path)", async () => {
+    const r = await compileStandalone(
+      `export function test(): number { const p: any = Object.getPrototypeOf(DisposableStack); return p ? 1 : 0; }`,
+    );
+    expect(r.success).toBe(true);
+    noEmitCrash(r);
+  });
+
+  it("`Object.getPrototypeOf(AsyncDisposableStack)` compiles standalone", async () => {
+    const r = await compileStandalone(
+      `export function test(): number { const p: any = Object.getPrototypeOf(AsyncDisposableStack); return p ? 1 : 0; }`,
+    );
+    expect(r.success).toBe(true);
+    noEmitCrash(r);
+  });
+
+  it("`new SuppressedError()` still compiles standalone (unaffected by the value-path gate)", async () => {
+    const r = await compileStandalone(
+      `export function test(): number { const e: any = new SuppressedError(); return e ? 1 : 0; }`,
+    );
+    expect(r.success).toBe(true);
+    noEmitCrash(r);
+  });
+
+  it("gc/host mode unaffected — `Object.getPrototypeOf(SuppressedError)` still compiles", async () => {
+    const r = (await compile(
+      `export function test(): number { const p: any = Object.getPrototypeOf(SuppressedError); return p ? 1 : 0; }`,
+    )) as any;
+    expect(r.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Producers (global-index `-1` sentinel sub-bucket of #2029)

Two distinct producers, both the documented `-1` string-global-sentinel class (a
string constant un-materialized standalone records `-1` in `stringGlobalMap`; a
raw `global.get` of it crashes the encoder, losing the whole file):

1. **`SuppressedError.prototype.<member>`** — `SuppressedError` was missing from
   `BUILTIN_CTOR_NAMES` (property-access.ts), so the read fell through both the
   standalone native-proto path and the host `__get_builtin` fallback into a
   generic member path that pushed a raw `global.get <stringGlobalMap.get>`.
   **Fix:** list it alongside the `DisposableStack`/`AsyncDisposableStack`
   precedent already there → dual-mode handler (clean located refusal standalone,
   `__get_builtin` under gc/host). Flips the 7 `built-ins/SuppressedError/prototype/*`
   rows off the emit-crash.

2. **ERM ctors read as bare VALUES** (`Object.getPrototypeOf(SuppressedError)`,
   `isConstructor(DisposableStack)` — `proto.js` / `is-a-constructor.js` for all
   three ERM ctors) — identifiers.ts had a HOST-ONLY fast path for these three
   ctors-as-values (`__get_globalThis` + `__extern_get`) that pushed the ctor-name
   key via the `-1` sentinel AND leaked two host imports an empty import object
   can't satisfy. It was **not** standalone-gated. **Fix:** gate to gc/host
   (`!standalone && !wasi`); standalone falls through to the clean path. (This is
   why the already-listed DisposableStack pair still had a `proto`/`is-a-constructor`
   residual — `BUILTIN_CTOR_NAMES` covers `.prototype.*` but not the bare-value path.)

## Row-delta

37-file standalone runner re-probe, post-#2052 baseline 26 still-crashing →
**12 still-crashing**: **14 flipped off the emit-crash, 1 now PASSES outright**.

## Validation

- New test `tests/issue-2029-suppressederror-builtin-global-sentinel.test.ts` (6/6).
- Existing #2029 suites green (23/23) — no regression.
- gc/host mode unchanged (the value fast-path still fires in gc; verified
  `Object.getPrototypeOf(SuppressedError)` compiles gc).
- tsc + prettier + biome clean.
- Broad emit-path change → relying on the merge_group test262 floor for conformance.

## Remaining (#2029, separate follow-up PRs)

`String.prototype.replaceAll` regexp-replacer (2) + a getter/setter property-accessor
(1) — other global-index producers; the `function index` funcIdx-shift cluster (8:
TypedArray/Array `toLocaleString`, annexB RegExp, optional-chaining async) is the
next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)