### PR TITLE
docs(#2663): architect spec for with-statement Tier 2 dynamic-scope fallback

### DIFF
--- a/plan/issues/2663-with-statement-tier2-dynamic-scope.md
+++ b/plan/issues/2663-with-statement-tier2-dynamic-scope.md
@@ -1,0 +1,497 @@
+---
+id: 2663
+title: "feat: `with` statement Tier 2 — dynamic-scope fallback (de-skip the 294 test262 WithStatement tests; landing page shows unsupported)"
+status: ready
+created: 2026-06-25
+updated: 2026-06-25
+priority: medium
+feasibility: hard
+reasoning_effort: max
+task_type: feature
+area: codegen, ir
+language_feature: with
+goal: spec-completeness
+depends_on: [1387, 2580]
+needs_arch_spec: false
+sprint: 66
+---
+
+# #2663 — `with` statement Tier 2: dynamic-scope fallback
+
+## Why this exists (landing-page "not supported")
+
+The landing-page feature report (`website/public/benchmarks/feature-report.html`)
+derives each feature's status from **test262 category pass/total counts**. The
+`with` category is overwhelmingly failing, so `with` shows as **not supported**
+— even though **Tier 1 already shipped** (#1387, sprint 61, PR #1272).
+
+## Current state
+
+- **Tier 1 (DONE, #1387):** `src/codegen/with-scope.ts` `compileWithStatement`
+  handles `with(target){…}` *only when* the target lowers to a WasmGC struct
+  with a **statically closed shape** (literal keys resolvable at compile time).
+  Bare identifiers in the block that match a known struct field are routed to
+  that field; otherwise `reportWithStatementDiagnostic` fires and the statement
+  is unsupported.
+- **Tier 2 (THIS ISSUE, deferred at #1387):** the **dynamic-scope** case — a
+  bare identifier inside `with(obj){}` may resolve to a *runtime* property of
+  `obj` whose shape is not statically known. This is the bulk of the **294**
+  test262 `WithStatement` tests and the reason the feature reads unsupported.
+  #1387's feasibility note: Tier 2 "is hard and overlaps the
+  object-representation ceiling."
+
+## Scope
+
+1. **Architect spec first (`needs_arch_spec`)** — the dynamic-scope compilation
+   strategy: how a bare identifier in a `with` block does a runtime
+   property-presence check on the `with` object before falling back to the outer
+   lexical binding (the ECMAScript `with` scope-chain semantics, §14.11 +
+   §9.1.1.2 Object Environment Records / HasBinding with `[[Unscopables]]`).
+   Likely an externref/`__extern_has`/`__extern_get` runtime-resolution path
+   gated behind the dynamic object representation — coordinate with the
+   value-rep substrate (#2580) and the any-typed read substrate.
+2. **Implement** the dynamic fallback for non-statically-closed `with` targets.
+3. **`@@unscopables`** handling (HasBinding consults `Symbol.unscopables`).
+4. **De-skip** the test262 `with` category once the dynamic path lands; confirm
+   the landing-page feature report flips.
+
+## Notes
+
+- `with` is forbidden in strict mode / ES modules / TS strict — the test262
+  coverage is the non-strict sloppy-mode corpus. Confirm the runner exercises
+  these (they are currently skip-listed).
+- Reuses the Tier-1 static fast path: only fall through to the dynamic path when
+  the target shape is not statically closed.
+- Tier 2 depends on the dynamic any-typed object read substrate; sequence it
+  behind / alongside the #2580 value-rep work rather than as a standalone hack.
+
+---
+
+## Implementation Plan
+
+> Verified against current `main` (post-#2054 merge, HEAD `152a9a05f` + origin/main).
+> All file:line references are to that tree. The #2580 dynamic-read substrate
+> (`src/codegen/dyn-read.ts`) and the `__extern_get`/`__extern_has` runtime
+> helpers (`src/runtime.ts`) were traced directly, not from issue text.
+
+### Root cause
+
+Tier 1 (`compileWithStatement`, `src/codegen/with-scope.ts:106`) only admits a
+`with` target it can **prove** is a closed object literal
+(`proveObjectLiteralWithTarget`, line 223). Any other target —
+`with (someVariable)`, `with (fn())`, a spread/accessor/method literal, an
+`@@unscopables`-bearing literal, or a literal whose body references inherited
+`Object.prototype` keys — hits `reportWithStatementDiagnostic` (line 215) and the
+statement is rejected at compile time. The 174 sloppy-mode `noStrict`
+`WithStatement` tests (of 181 in `test262/test/language/statements/with/`; the
+other 6 are `onlyStrict` *negative syntax* tests + 16 negative cases) all use
+`with (variableOrExpression)`, so they all fall into the rejected path. Tier 1
+also has no runtime HasBinding: it routes a name to a struct field purely by
+static shape, so there is no place to consult `@@unscopables` or to *fall back*
+to the outer lexical binding when the property is absent at runtime.
+
+Tier 2 adds the **dynamic scope-chain semantics**: at each bare-identifier read /
+write inside a non-closed `with`, emit a runtime `HasBinding(N)` test on the
+`with` object (own+proto+`@@unscopables` filter, ECMA-262 §9.1.1.2.1) and branch:
+present ⇒ `Get`/`Set` the property; absent ⇒ the name's prior (outer) lowering.
+
+### The substrate to consume (do NOT build a parallel hack)
+
+**`src/codegen/dyn-read.ts` is the #2580 value-rep dynamic-read substrate.** Tier 2
+consumes it directly:
+
+- `emitDynGet(ctx, fctx, keyName)` (`dyn-read.ts:195`) — receiver externref on
+  the stack ⇒ pushes the key + a property `Get`, leaving the value externref (or
+  `undefined`). HOST mode inlines `__extern_get` (a stable JS host *import*);
+  STANDALONE routes through the defined `__dyn_get` wrapper
+  (`dyn-read.ts:124`), which delegates to the native `__extern_get` object
+  runtime (prototype-chain walk). This is the `Get` half of HasBinding+Get.
+- `__dyn_has(recv, key) -> i32` (`dyn-read.ts:163`) and the host
+  `__extern_has(obj, key) -> i32` runtime helper (`src/runtime.ts:7480`) — the
+  `HasProperty` half (own + proto chain; `__extern_has` already includes
+  `_OBJECT_PROTO_KEYS` inherited members per §7.3.12).
+
+**Critical substrate gap Tier 2 must close (HasBinding ≠ non-null Get):**
+`__dyn_has` (dyn-read.ts:163) is the M0/M1 *approximation* `present ⇔ __extern_get
+!== null` — it conflates "present with value `undefined`" vs "absent" (see its own
+NOTE at dyn-read.ts:159-162). For `with`, this is **wrong**: a property present
+with value `undefined` must still **shadow** the outer binding (HasBinding is
+value-independent, §7.3.12). The host `__extern_has` (runtime.ts:7480) is the
+*correct* value-independent HasProperty (it does `key in obj`, sidecar-aware), so
+the read/write site must gate on **`__extern_has`**, not on `__dyn_has`'s non-null
+proxy. Slice 1 below wires `__extern_has` as the gate; `__dyn_get`/`emitDynGet`
+remains the value fetch.
+
+There is no separate "any-string value-read substrate" call needed here — the
+`with` receiver is a whole object/externref, and `emitDynGet`'s STANDALONE arm
+already routes through the native-string-aware `__extern_get`. Tier 2 adds **no
+new host import** beyond `__extern_has` (already registered) and the
+`@@unscopables` symbol-keyed read (below, reuses the existing well-known-symbol
+plumbing).
+
+### Strategy: dynamic `with` scope entry + per-name runtime resolution
+
+**1. Widen the `withScopes` stack entry to carry a dynamic kind.**
+
+`src/codegen/context/types.ts:405` — the `withScopes` entry today is
+`{ localIdx, structTypeIdx, fields, blockedNames }` (static-only). Add a
+discriminated `kind`:
+
+```ts
+withScopes?: ({
+  kind: "static";                      // existing Tier-1 entry (unchanged shape)
+  localIdx: number; structTypeIdx: number; fields: FieldDef[]; blockedNames: Set<string>;
+} | {
+  kind: "dynamic";                     // Tier-2: target is an arbitrary externref
+  localIdx: number;                    // local holding the with-object as externref
+  blockedNames: Set<string>;           // body-declared names (var/fn/catch) — never routed
+})[];
+```
+
+Default existing construction sites to `kind: "static"` (the one push at
+`with-scope.ts:160`).
+
+**2. New entry path in `compileWithStatement` (`with-scope.ts:106`).**
+
+Keep Tier 1 as the fast path. Restructure:
+
+```
+const proof = proveObjectLiteralWithTarget(fctx, stmt.expression);
+if (proof.ok && !containsNestedFunctionBoundary(stmt.statement)) {
+  ... existing Tier-1 closed-shape lowering (unchanged) ...
+  return;
+}
+// Tier 2 fallback:
+compileDynamicWithStatement(ctx, fctx, stmt);
+```
+
+`compileDynamicWithStatement` (new function, same file):
+- Compile `stmt.expression` to a value; coerce to `externref` via `coerceType`
+  (the receiver may be a struct ref, a boxed any, a host object — externref is
+  the uniform receiver the substrate expects). ECMA-262 §14.11.7 step 1-3:
+  evaluate, `GetValue`, `ToObject` — `ToObject(undefined|null)` throws TypeError.
+  Emit a null/undefined guard: `__extern_is_undefined(recv) || ref.is_null(recv)`
+  ⇒ throw TypeError (reuse `emitThrowString` / the no-JS-host TypeError path used
+  elsewhere; `__extern_is_undefined` is already a known late import, used at
+  dyn-read.ts:254). `ToObject` of a primitive (number/string/boolean) is a
+  wrapper object — for the corpus this is rare; box via the existing any-box path
+  or, minimally, treat primitives as having no own enumerable bindings (Slice 4).
+- `local.set` into a fresh externref local (`allocLocal`, like with-scope.ts:129).
+- `blockedNames = collectBodyDeclaredNames(stmt.statement)` (reuse line 321) —
+  names lexically declared in the body are NOT object-environment bindings.
+- Push `{ kind: "dynamic", localIdx, blockedNames }` onto `fctx.withScopes`,
+  `compileStatement(ctx, fctx, stmt.statement)`, pop in `finally` (mirror
+  lines 161-166).
+- **Nested-function boundary:** Tier 1 rejects bodies containing a nested
+  function/class (`containsNestedFunctionBoundary`, line 112) because the closure
+  cannot statically capture the with-binding. For Tier 2, a nested function that
+  references a with-routed name needs the object environment captured at runtime
+  — out of scope for the first landing. **Keep the boundary rejection for the
+  dynamic path too** (route to `reportWithStatementDiagnostic` when the body has a
+  function/class boundary). This still de-skips the large majority of the corpus
+  (the boundary cases are a minority; the canary `12.10-0-1.js` captures `foo`
+  via an *outer* `var f` that reads `foo` from the function scope, NOT from
+  inside the with — that body has no nested boundary, so it passes).
+
+**3. Per-name READ resolution — `findWithBinding` + `emitWithBindingGet`.**
+
+`findWithBinding` (`with-scope.ts:51`) currently returns a *static* binding or
+`null`. Extend it to also report a **dynamic** scope hit:
+
+```ts
+type WithResolution =
+  | { kind: "static"; binding: WithBinding }
+  | { kind: "dynamic"; scope: DynamicWithScope }   // innermost dynamic scope not shadowing `name`
+  | null;
+```
+
+Walk innermost-first (as today). For a `static` scope, the existing field-match
+logic applies. For a `dynamic` scope: if `name` is in `blockedNames`, skip
+(shadowed by a body-local decl); otherwise return `{ kind: "dynamic", scope }`.
+Do **not** stop the walk for `OBJECT_PROTO_KEYS` in the dynamic case (the runtime
+HasBinding handles proto members).
+
+At the call site (`src/codegen/expressions/identifiers.ts:486`):
+
+```ts
+const res = resolveWithBinding(fctx, name);
+if (res?.kind === "static") return emitWithBindingGet(fctx, res.binding);
+if (res?.kind === "dynamic") return emitDynamicWithGet(ctx, fctx, res.scope, name, /*fallback*/ () => <normal id lowering>);
+```
+
+`emitDynamicWithGet` emits the **HasBinding-gated select**, ECMA-262
+§9.1.1.2.5 (GetBindingValue) + §9.1.1.2.1 (HasBinding):
+
+```wasm
+;; recv = with-object externref (local.get scope.localIdx)
+;; if (HasBinding(recv, "name")) result = Get(recv, "name") else result = <outer lowering>
+local.get $with_recv
+<emit @@unscopables-aware HasBinding for "name">   ;; -> i32  (see step 5)
+if (result externref)
+  local.get $with_recv
+  emitDynGet(ctx, fctx, "name")        ;; Get -> externref value
+else
+  <fallback: the name's prior lowering>  ;; local.get / global / func / ReferenceError
+end
+```
+
+Because the two arms must have the SAME Wasm result type and the fallback may be
+an i32/f64/struct-ref local while `Get` yields externref, **normalize both arms
+to `externref`**: in the `then` arm `emitDynGet` already yields externref; in the
+`else` arm, compile the fallback and `coerceType(resultType, externref)`. The
+`compileIdentifier` return type for a dynamic-with read is therefore
+`{ kind: "externref" }`. (This matches how `any`-typed reads already surface as
+externref — consumers box/unbox as needed via the existing coercion path.)
+
+**Late-import / funcidx hazard (read the #2580 note at dyn-read.ts:212-239).**
+`emitDynGet` (host) inlines the *import* `__extern_get` (shift-safe). The
+`__extern_has` gate is likewise a host import — register it via `ensureLateImport`
++ `flushLateImportShifts` BEFORE baking its `call`, exactly as `dyn-read.ts:240`
+does for `__extern_get`. Do NOT bake `call __dyn_has` (a *defined* function whose
+index floats). Build the whole `if/else` with `pushBody`/`popBody` (the branch
+arms are separate `Instr[]` — never alias one array into both arms; see
+`reference_shared_instr_object_dce_double_remap`).
+
+**4. Per-name WRITE resolution — assignment + compound + inc/dec.**
+
+`src/codegen/expressions/assignment.ts:155` already calls `findWithBinding`. Route
+a dynamic hit to a new `compileDynamicWithAssignment`:
+
+```wasm
+;; if HasBinding(recv,"name")  Set(recv,"name", rhs)   else  <outer assign>
+local.get $with_recv
+<HasBinding "name">
+if
+  local.get $with_recv ; push key ; push rhs(externref) ; call __extern_set(_strict)
+else
+  <fallback assignment lowering for "name">
+end
+```
+
+- Use `__extern_set` (sloppy) — `with` is sloppy-only, so the silent-on-failure
+  semantics are correct; `__extern_set_strict` (runtime.ts:7289) is NOT needed
+  here. (`src/runtime.ts:7273`.)
+- The assignment expression's value is the RHS — evaluate RHS once into a temp,
+  use it in both arms, leave it on the stack as the result.
+- **Compound assignment (`x += 1`) and inc/dec (`x++`)** also route through the
+  with object: these read-modify-write. `src/codegen/expressions/unary-updates.ts`
+  (touched by #2656 in this merge) and the compound path in `assignment.ts` must
+  consult `resolveWithBinding` for the LHS identifier and, on a dynamic hit, emit
+  HasBinding-gated read-then-write. **Slice this separately** (Slice 3) — plain
+  read + plain assignment (Slices 1-2) already de-skip a large fraction; `unscopables-inc-dec.js` and compound cases need Slice 3.
+
+**5. `@@unscopables` filter — the HasBinding predicate (§9.1.1.2.1).**
+
+HasBinding(N) for an object environment record with `withEnvironment=true`:
+1. `found = HasProperty(bindings, N)` — the `__extern_has` gate above.
+2. If `found` is false ⇒ return false.
+3. `unscopables = Get(bindings, @@unscopables)`.
+4. If `Type(unscopables)` is Object: `blocked = ToBoolean(Get(unscopables, N))`;
+   if `blocked` ⇒ return false.
+5. return true.
+
+Implement `emitWithHasBinding(ctx, fctx, recvLocal, name) -> i32`:
+
+```wasm
+local.get $recv
+ensureLateImport __extern_has ; push "name" ; call __extern_has   ;; (1)
+if (result i32)
+  ;; (3) us = Get(recv, @@unscopables)   — symbol-keyed read
+  local.get $recv
+  <emit Get(recv, @@unscopables)>            ;; externref; see below
+  local.tee $us
+  ;; (4) if Type(us) is Object: blocked = ToBoolean(Get(us, "name"))
+  <is-object(us)?>          ;; non-null && typeof object (host: __extern_is_object or ref.test)
+  if (result i32)
+    local.get $us
+    emitDynGet "name"       ;; Get(us, "name") -> externref
+    <ToBoolean(externref)>  ;; host: __extern_truthy / __to_boolean; standalone: existing truthiness helper
+    i32.eqz                 ;; blocked ⇒ NOT a binding ⇒ has=0
+  else
+    i32.const 1             ;; us not an object ⇒ binding present
+  end
+else
+  i32.const 0              ;; not even own/proto present
+end
+```
+
+- **`@@unscopables` symbol-keyed Get:** reuse the existing well-known-symbol
+  plumbing — `Symbol.unscopables` maps to wasm key `"@@unscopables"` / symbol ID
+  `11` (`src/runtime.ts:3600`, `:3751`; `src/codegen/literals.ts:1319`;
+  `src/codegen/property-access.ts:182`). `__extern_get(recv, <Symbol.unscopables>)`
+  resolves it on the host; for the symbol key, route through the existing
+  symbol-id `__extern_get_idx`/well-known-symbol path (`runtime.ts:7355`) — i.e.
+  `Get(recv, @@unscopables)` is `__extern_get_idx(recv, 11)` (or the named
+  `"@@unscopables"` string the runtime already aliases). Confirm against
+  `binding-blocked-by-unscopables.js` (true-coercing values block) and
+  `unscopables-*` tests.
+- **`ToBoolean(externref)`** and **is-object** already exist as truthiness/typeof
+  helpers in the codebase (used by `if`/`&&` lowering and `typeof`); reuse them —
+  do not hand-roll. Grep `__extern_truthy` / the existing `coerceToBool` /
+  `typeof`-object path.
+- **Cost guard:** `Get(@@unscopables)` is only evaluated when HasProperty is true
+  (rare per-name), so the common "absent ⇒ fall to lexical" path is one
+  `__extern_has` call. No per-name unscopables read on the miss path.
+
+### The test262 runner blocker (MUST be fixed for acceptance)
+
+**Verified:** the runner wraps every test body inside `export function test()` in
+a `.ts` module (`tests/test262-runner.ts:2356`, `:2373`), which is **strict
+mode**. TypeScript's parser rejects `with` there:
+
+```
+$ npx tsc --noEmit --strict   (body inside export function)
+error TS1101: 'with' statements are not allowed in strict mode.
+error TS2410: The 'with' statement is not supported...
+```
+
+So **no amount of Tier-2 codegen makes these tests pass until the runner stops
+wrapping sloppy `with` tests in a strict module.** The codegen frontend
+(`ts.createSourceFile` for compilation) tolerates `with` via TS error-recovery
+(it still yields a `WithStatement` node — that is how Tier 1 is reachable today),
+but the runner's strict-module wrapper is the hard gate.
+
+**Runner change (Slice 5):** for a test classified `strict: "no"`
+(`classifyStrictMode`, `tests/test262-runner.ts:189` — already computes this from
+`noStrict` + `SLOPPY_MODE_PATHS`), wrap the body in a **non-strict script
+context** rather than `export function test()`. Options, simplest first:
+- (a) Emit the body at top level of a **non-module** script (no `export`, no
+  implicit strict) and expose the result via a sentinel global the harness reads
+  — but the compiler's source is `.ts` (module). Cleaner:
+- (b) Keep `export function test()` but ensure the function body is **not**
+  strict. A function is strict iff the module is strict iff it contains an
+  `export`/`import` or `"use strict"`. Since the wrapper file inherently has
+  `export function test`, the file is a module ⇒ strict ⇒ `with` is rejected.
+  Therefore the sloppy-`with` wrapper must drop the `export` and run as a
+  **script** (the runner already has the TLA branch as precedent for an alternate
+  wrapper shape at `:2350`). Provide a script-mode wrapper that defines a global
+  `__test()` and have the harness call it.
+
+Implementation detail to settle in Slice 5: the compiler's entry
+(`src/resolve.ts:40`, `module: ESNext`) compiles a single source. A sloppy-mode
+wrapper must be a **script** (no top-level `import`/`export`) so neither TS nor
+the emitted Wasm forces strict. Confirm `with` survives codegen in script mode
+(it should — `createSourceFile` recovery already yields the node). This is the
+single highest-leverage step: it is what actually flips the 174 tests from
+`compile_error` (TS1101) to running, where the Tier-2 codegen is then exercised.
+
+### Interaction with Tier 1 (keep the fast path)
+
+- `compileWithStatement` tries `proveObjectLiteralWithTarget` first; only a
+  **failed** proof (or a body-boundary rejection that the dynamic path also
+  can't handle) falls to `compileDynamicWithStatement`. A proven closed literal
+  with a boundary-free body still takes the zero-overhead static struct path.
+- `findWithBinding`/`resolveWithBinding` walks innermost-first across a **mixed**
+  stack (a static `with` nested inside a dynamic one, or vice versa) — each scope
+  resolves by its own `kind`. A static field hit short-circuits (no runtime
+  HasBinding); a dynamic scope emits the gated select.
+- `typeof` on a with-routed name (`src/codegen/typeof-delete.ts:895`, `:1041`):
+  the static arm returns the field's static `typeof` string. For a dynamic hit,
+  `typeof name` must be HasBinding-gated too: present ⇒ `typeof Get(recv,"name")`
+  (runtime `__extern_typeof`), absent ⇒ the prior `typeof` lowering (which for an
+  undeclared name yields `"undefined"` without throwing — §13.5.1.1). Slice 3.
+
+### Nested `with`, var hoisting, and the canary
+
+- **Nested `with`:** handled by the innermost-first stack walk; each level emits
+  its own HasBinding gate, so a name absent on the inner object falls to the
+  next-outer with (then to lexical). No special casing.
+- **`var` inside `with` hoists to the function scope** (canary `12.10-0-1.js`):
+  `var foo` declared inside `with(o)` creates a *function-scope* var, and the
+  assignment `foo = "..."` inside the with writes through the object env IF `o`
+  has `foo`, else the var. `collectBodyDeclaredNames` already collects `var`
+  names into `blockedNames` — but per §, a `var`-declared name is still resolved
+  against the object environment at *runtime* (the var binding exists in the
+  function env, the object env is consulted first). For the canary, `o` is empty
+  so `foo` resolves to the hoisted var. **Decision:** do NOT blanket-block `var`
+  names — `blockedNames` should hold only *lexical* (`let`/`const`/class/catch)
+  and inner-function names (true shadows). `var`/function-scope names must still
+  pass through the HasBinding gate (present-on-object ⇒ object wins). Adjust
+  `collectBodyDeclaredNames` usage accordingly for the dynamic path (it currently
+  lumps `var` in). Verify with `12.10-0-1.js` (empty `o` ⇒ falls to var ⇒ `f()`
+  returns the hoisted value) and a sibling test where `o` *has* the name.
+
+### Slice breakdown (land incrementally)
+
+- **Slice 0 — runner de-strict (CAN LAND FIRST, independently):** script-mode
+  wrapper for `strict: "no"` tests in `tests/test262-runner.ts` so sloppy `with`
+  tests reach codegen instead of failing TS1101. This alone moves the 174 tests
+  from `compile_error` to `fail`/`pass` and lets every later slice be measured.
+  Acceptance: the `with` category count in the test262 report stops being
+  ~all-`compile_error`.
+- **Slice 1 — dynamic READ:** widen `withScopes` (`context/types.ts:405`),
+  `compileDynamicWithStatement`, `resolveWithBinding`, `emitDynamicWithGet`
+  (HasBinding via `__extern_has` + `Get` via `emitDynGet`), null/undefined-receiver
+  TypeError guard. No `@@unscopables` yet (treat HasProperty as HasBinding).
+  Lands the bulk of the read-only corpus.
+- **Slice 2 — dynamic WRITE:** `compileDynamicWithAssignment` (plain `=`) via
+  `__extern_set`; RHS-once-into-temp; result = RHS.
+- **Slice 3 — compound/inc-dec + `typeof`/`delete`:** `+=`, `++`/`--`
+  (`unary-updates.ts`, `assignment.ts` compound path), `typeof`
+  (`typeof-delete.ts:895/1041`), `delete name`. HasBinding-gated read-modify-write.
+- **Slice 4 — `@@unscopables`:** `emitWithHasBinding` full §9.1.1.2.1 with the
+  symbol-keyed `Get(recv,@@unscopables)` + `ToBoolean(Get(unscopables,N))` block.
+  Covers `binding-blocked-by-unscopables.js`, `unscopables-*` tests. Also handle
+  `ToObject(primitive)` wrapper-object receivers if any corpus test needs it.
+- **Slice 5 — landing-page flip + de-skip confirmation:** confirm no remaining
+  blanket skip for the `with` category in `shouldSkip`
+  (`tests/test262-runner.ts:324`; today there is no `with`-specific skip — the
+  blocker is the strict wrapper, fixed in Slice 0). Re-run the `with` category,
+  refresh the baseline, confirm `website/public/benchmarks/feature-report.html`
+  flips `with` to supported.
+
+Each slice is byte-identical for non-`with` modules (the dynamic path is only
+reached from `compileDynamicWithStatement`, and `resolveWithBinding` early-returns
+when `fctx.withScopes` is empty/static — same gating discipline as Tier 1).
+
+### Wasm IR pattern (dynamic with read, host mode)
+
+```wasm
+;; x  inside  with (o) { ... }   — o is an arbitrary externref in $with_o
+local.get $with_o
+;; --- HasBinding "x" (no-unscopables form, Slice 1) ---
+(string.const "x")                 ;; key externref
+call $__extern_has                 ;; -> i32  (own+proto, value-independent)
+(if (result externref)
+  (then
+    local.get $with_o
+    (string.const "x")
+    call $__extern_get)            ;; Get -> value externref  (via emitDynGet)
+  (else
+    ;; fallback: x's prior lowering, coerced to externref
+    <outer x>  (coerce externref)))
+```
+
+### Test files to verify
+
+- `test262/test/language/statements/with/12.10-0-1.js` — `var` in `with` visible
+  outside; empty object ⇒ falls to hoisted var (the canary).
+- `test262/test/language/statements/with/binding-blocked-by-unscopables.js` —
+  true-coercing `@@unscopables[N]` blocks the object binding (Slice 4).
+- `test262/test/language/statements/with/unscopables-inc-dec.js` — compound on a
+  blocked name (Slice 3 + 4).
+- `test262/test/language/statements/with/get-binding-value-call-with-proxy-env.js`
+  / `set-mutable-binding-idref-with-proxy-env.js` — Proxy-backed env (proxy is
+  deferred per project policy; expect skip/fail, not a target).
+- The 174 `noStrict` files under `.../with/` collectively — the acceptance signal
+  is the category count flip after Slice 0 unblocks compilation.
+
+### Acceptance signal
+
+1. Slice 0 merged ⇒ `with` category in the test262 report stops being
+   all-`compile_error` (tests now run).
+2. Slices 1-4 merged ⇒ `with` category pass count rises toward the 174
+   sloppy-mode tests (Proxy/nested-function-capture cases excepted).
+3. Baseline refreshed ⇒ `website/public/benchmarks/feature-report.html` flips
+   `with` from **not supported** to supported.
+
+### Dependencies
+
+- **#2580** (value-rep dynamic-read substrate, `src/codegen/dyn-read.ts`) —
+  Tier 2 consumes `emitDynGet`/`__dyn_get`/`__extern_get`/`__extern_has`. M1 (the
+  `emitDynGet` call site) must be on `main` first; the host-mode `__extern_get`
+  inline + `__extern_has` import are already present. Sequence Slice 1 after the
+  #2580 M1 landing (already in-tree per `dyn-read.ts`). The HasBinding
+  value-independence fix (use `__extern_has`, not `__dyn_has`'s non-null proxy) is
+  Tier 2's own change, not a #2580 dependency.
+- **#1387** (Tier 1) — extended, not replaced.


### PR DESCRIPTION
Architect implementation spec for #2663 — `with` statement Tier 2 (dynamic-scope fallback). Docs-only (one issue file).

## What this settles
- **Dynamic-scope strategy**: per-name runtime `HasBinding` (§9.1.1.2.1) gate on the with-object via the **value-independent** `__extern_has` (NOT `__dyn_has`'s non-null proxy — a property present with value `undefined` must still shadow the lexical binding), then `Get`/`Set` via the #2580 dyn-read substrate (`emitDynGet`/`__extern_get`/`__extern_set`), with the fallback arm emitting the name's prior (outer) lowering coerced to externref.
- **Tier-1 fast path preserved**: `compileWithStatement` still tries `proveObjectLiteralWithTarget` first; only a failed proof falls to the new `compileDynamicWithStatement`. Mixed static/dynamic `withScopes` stack resolves innermost-first by `kind`.
- **#2580 coordination**: consumes `src/codegen/dyn-read.ts` (`emitDynGet`, `__dyn_get`, `__extern_get`/`__extern_has`) — no parallel hack, no new host import. Calls out the late-import/funcidx hazard (inline the `__extern_get`/`__extern_has` *imports*, never bake `call __dyn_has`).
- **`@@unscopables`** full §9.1.1.2.1 predicate (symbol-keyed `Get` via the existing well-known-symbol id 11 plumbing + `ToBoolean(Get(unscopables,N))` block).
- **Writes, compound/inc-dec, nested with, var-hoist canary** all specced.
- **Runner blocker found + verified**: the test262 runner wraps bodies in `export function test()` (strict module) ⇒ TS1101 rejects `with`. **Slice 0** de-stricts `strict:"no"` tests (script-mode wrapper) — the single highest-leverage step; without it no Tier-2 codegen is reachable.
- **Slice breakdown 0-5** + landing-page `feature-report.html` flip as the acceptance signal.

Frontmatter: `depends_on: [1387, 2580]`, `needs_arch_spec: false`, `status: ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)