### PR TITLE
feat(#2663): with Tier-2 dynamic-scope READ — Slice 1 (ref #1472)

### DIFF
--- a/plan/issues/2663-with-statement-tier2-dynamic-scope.md
+++ b/plan/issues/2663-with-statement-tier2-dynamic-scope.md
@@ -333,47 +333,29 @@ end
   (rare per-name), so the common "absent ⇒ fall to lexical" path is one
   `__extern_has` call. No per-name unscopables read on the miss path.
 
-### The test262 runner blocker (MUST be fixed for acceptance)
+### The test262 runner is NOT a blocker (Slice 0 premise REFUTED — audited 2026-06-25, dev-2046)
 
-**Verified:** the runner wraps every test body inside `export function test()` in
-a `.ts` module (`tests/test262-runner.ts:2356`, `:2373`), which is **strict
-mode**. TypeScript's parser rejects `with` there:
+**CORRECTION.** This section originally claimed the runner's
+`export function test()` strict-module wrapper is the hard gate (TS1101 rejects
+`with`), making "runner de-strict" (Slice 0) the prerequisite. **That premise is
+wrong.** The runner ALREADY passes `skipSemanticDiagnostics: true` on EVERY path
+(`scripts/compiler-fork-worker.mjs:40,67`, `tests/test262-shared.ts:608`, the
+in-process runner), and `skipSemanticDiagnostics: true` **already suppresses
+TS1101** for `with` (verified: `export function test(){ …; with(o){…} }` +
+skipSemanticDiagnostics reaches codegen — no TS1101).
 
-```
-$ npx tsc --noEmit --strict   (body inside export function)
-error TS1101: 'with' statements are not allowed in strict mode.
-error TS2410: The 'with' statement is not supported...
-```
+**Audit (37 noStrict `with` tests through the actual `wrapTest` + the runner's
+exact compile opts, current main):** TS1101-blocked = **0**; codegen-#1387 = 30;
+already-compiling = 7. **Zero** `with` tests are blocked by the strict wrapper.
+The real gate is the **codegen #1387 rejection** (the dynamic-`with` path this
+issue implements), NOT the runner.
 
-So **no amount of Tier-2 codegen makes these tests pass until the runner stops
-wrapping sloppy `with` tests in a strict module.** The codegen frontend
-(`ts.createSourceFile` for compilation) tolerates `with` via TS error-recovery
-(it still yields a `WithStatement` node — that is how Tier 1 is reachable today),
-but the runner's strict-module wrapper is the hard gate.
-
-**Runner change (Slice 5):** for a test classified `strict: "no"`
-(`classifyStrictMode`, `tests/test262-runner.ts:189` — already computes this from
-`noStrict` + `SLOPPY_MODE_PATHS`), wrap the body in a **non-strict script
-context** rather than `export function test()`. Options, simplest first:
-- (a) Emit the body at top level of a **non-module** script (no `export`, no
-  implicit strict) and expose the result via a sentinel global the harness reads
-  — but the compiler's source is `.ts` (module). Cleaner:
-- (b) Keep `export function test()` but ensure the function body is **not**
-  strict. A function is strict iff the module is strict iff it contains an
-  `export`/`import` or `"use strict"`. Since the wrapper file inherently has
-  `export function test`, the file is a module ⇒ strict ⇒ `with` is rejected.
-  Therefore the sloppy-`with` wrapper must drop the `export` and run as a
-  **script** (the runner already has the TLA branch as precedent for an alternate
-  wrapper shape at `:2350`). Provide a script-mode wrapper that defines a global
-  `__test()` and have the harness call it.
-
-Implementation detail to settle in Slice 5: the compiler's entry
-(`src/resolve.ts:40`, `module: ESNext`) compiles a single source. A sloppy-mode
-wrapper must be a **script** (no top-level `import`/`export`) so neither TS nor
-the emitted Wasm forces strict. Confirm `with` survives codegen in script mode
-(it should — `createSourceFile` recovery already yields the node). This is the
-single highest-leverage step: it is what actually flips the 174 tests from
-`compile_error` (TS1101) to running, where the Tier-2 codegen is then exercised.
+**⇒ Slice 0 (runner de-strict) is MOOT and was dropped** — implementing it would
+move 0 tests (they'd still hit codegen #1387). The codegen frontend
+(`ts.createSourceFile`) already yields a `WithStatement` node and
+`skipSemanticDiagnostics` lets it through; **Tier-2 codegen (Slices 1-4) is what
+actually makes the tests run/pass.** No runner change is needed for the `with`
+corpus.
 
 ### Interaction with Tier 1 (keep the fast path)
 
@@ -413,17 +395,22 @@ single highest-leverage step: it is what actually flips the 174 tests from
 
 ### Slice breakdown (land incrementally)
 
-- **Slice 0 — runner de-strict (CAN LAND FIRST, independently):** script-mode
-  wrapper for `strict: "no"` tests in `tests/test262-runner.ts` so sloppy `with`
-  tests reach codegen instead of failing TS1101. This alone moves the 174 tests
-  from `compile_error` to `fail`/`pass` and lets every later slice be measured.
-  Acceptance: the `with` category count in the test262 report stops being
-  ~all-`compile_error`.
-- **Slice 1 — dynamic READ:** widen `withScopes` (`context/types.ts:405`),
+- **Slice 0 — runner de-strict: ~~CAN LAND FIRST~~ DROPPED (moot).** The premise
+  (TS1101 strict wrapper blocks `with`) is refuted — `skipSemanticDiagnostics`
+  already de-stricts the TS frontend (0/37 `with` tests TS1101-blocked; audit
+  above). No runner change needed; the codegen path (Slices 1-4) is the gate.
+- **Slice 1 — dynamic READ: ✅ DONE (PR, 2026-06-25).** Widened `withScopes`
+  (`context/types.ts`, discriminated `kind:"static"|"dynamic"`),
   `compileDynamicWithStatement`, `resolveWithBinding`, `emitDynamicWithGet`
-  (HasBinding via `__extern_has` + `Get` via `emitDynGet`), null/undefined-receiver
-  TypeError guard. No `@@unscopables` yet (treat HasProperty as HasBinding).
-  Lands the bulk of the read-only corpus.
+  (HasBinding via value-independent `__extern_has` + `Get` via `emitDynGet`),
+  null/undefined-receiver TypeError guard (`__extern_is_undefined`),
+  innermost-first cascade through nested/mixed `with` scopes, lexical-shadow via
+  `blockedNames`. No `@@unscopables` yet (HasProperty treated as HasBinding).
+  **Measured row-delta (174 noStrict `with` tests, in-process runner): pass
+  3→16 (+13), compile_error 162→51 (−111 now reach codegen/run). Zero
+  regression to non-`with` modules; Tier-1 static path byte-unchanged.** The
+  +91 runtime_error are WRITE-dependent tests (Slice 2) now reaching execution
+  (previously compile_error) — progress toward measurability, not a regression.
 - **Slice 2 — dynamic WRITE:** `compileDynamicWithAssignment` (plain `=`) via
   `__extern_set`; RHS-once-into-temp; result = RHS.
 - **Slice 3 — compound/inc-dec + `typeof`/`delete`:** `+=`, `++`/`--`

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -402,12 +402,27 @@ export interface FunctionContext {
    * this stack innermost-first and rewrites proven own-property bindings to
    * direct struct field access.
    */
-  withScopes?: {
-    localIdx: number;
-    structTypeIdx: number;
-    fields: FieldDef[];
-    blockedNames: Set<string>;
-  }[];
+  withScopes?: (
+    | {
+        // (#1387) Tier-1 static entry: a closed object-literal target compiled
+        // into a local; bare names matching a field route to direct struct
+        // get/set.
+        kind: "static";
+        localIdx: number;
+        structTypeIdx: number;
+        fields: FieldDef[];
+        blockedNames: Set<string>;
+      }
+    | {
+        // (#2663 Slice 1) Tier-2 dynamic entry: the `with` target is an
+        // arbitrary externref. Bare names are resolved at runtime via a
+        // HasBinding gate (`__extern_has`) + `Get` (`emitDynGet`), falling back
+        // to the outer lexical lowering when absent.
+        kind: "dynamic";
+        localIdx: number;
+        blockedNames: Set<string>;
+      }
+  )[];
   /** Map from let/const local variable name → local index of its i32 TDZ flag (0 = uninitialized) */
   tdzFlagLocals?: Map<string, number>;
   /**

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -37,7 +37,7 @@ import { getOrRegisterErrorStructType, isWasiErrorName } from "../registry/error
 import { allocLocal } from "../context/locals.js";
 import { reportSilentFallback } from "../fallback-telemetry.js";
 import { emitThrowReferenceError, noJsHost } from "./helpers.js";
-import { emitWithBindingGet, findWithBinding } from "../with-scope.js";
+import { emitDynamicWithGet, emitWithBindingGet, resolveWithBinding } from "../with-scope.js";
 import { emitBuiltinNamespaceObject, isSupportedBuiltinNamespace } from "../builtin-static-globals.js";
 import { tryEmitPromiseSubclassValue } from "./promise-subclass.js";
 
@@ -483,10 +483,39 @@ export function emitStaticTdzThrow(ctx: CodegenContext, fctx: FunctionContext, n
 function compileIdentifier(ctx: CodegenContext, fctx: FunctionContext, id: ts.Identifier): ValType | null {
   const name = id.text;
 
-  const withBinding = findWithBinding(fctx, name);
-  if (withBinding) {
-    return emitWithBindingGet(fctx, withBinding);
+  // (#1387 / #2663) `with` scope resolution, innermost-first.
+  const withRes = resolveWithBinding(fctx, name);
+  if (withRes?.kind === "static") {
+    return emitWithBindingGet(fctx, withRes.binding);
   }
+  if (withRes?.kind === "dynamic") {
+    // (#2663 Slice 1) HasBinding-gated runtime read. The HasBinding-miss fallback
+    // must re-resolve against the OUTER scopes (a name absent on the inner `with`
+    // object cascades to the next-outer `with`, then to the lexical binding —
+    // §nested-with). Temporarily truncate `withScopes` to exclude the matched
+    // scope (and anything inner to it), re-run full identifier resolution for the
+    // else arm, then restore the stack.
+    const scopes = fctx.withScopes!;
+    const matchedIdx = scopes.lastIndexOf(withRes.scope);
+    return emitDynamicWithGet(ctx, fctx, withRes.scope, name, () => {
+      const saved = fctx.withScopes;
+      fctx.withScopes = scopes.slice(0, matchedIdx);
+      try {
+        return compileIdentifier(ctx, fctx, id);
+      } finally {
+        fctx.withScopes = saved;
+      }
+    });
+  }
+
+  return compileIdentifierCore(ctx, fctx, id);
+}
+
+/** The non-`with` identifier lowering (locals, globals, funcs, builders,
+ *  ReferenceError). Split out so the Tier-2 dynamic `with` path can invoke it as
+ *  the HasBinding-miss fallback (#2663 Slice 1). */
+function compileIdentifierCore(ctx: CodegenContext, fctx: FunctionContext, id: ts.Identifier): ValType | null {
+  const name = id.text;
 
   // #1210: string-builder bindings are stored as a (buf, len, cap, mat)
   // tuple of synthetic locals. The binding name is intentionally NOT in

--- a/src/codegen/with-scope.ts
+++ b/src/codegen/with-scope.ts
@@ -9,13 +9,19 @@
  * get/set. Unproven targets keep the #1387 diagnostic gate.
  */
 import { ts, forEachChild } from "../ts-api.js";
-import type { FieldDef, ValType } from "../ir/types.js";
+import type { FieldDef, Instr, ValType } from "../ir/types.js";
 import { reportError } from "./context/errors.js";
+import { pushBody, popBody } from "./context/bodies.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { ensureComputedPropertyFields, compileObjectLiteralForStruct } from "./literals.js";
 import { ensureStructForType, resolveWasmType } from "./index.js";
 import { resolveStructName } from "./property-access.js";
+import { emitDynGet } from "./dyn-read.js";
+import { addStringConstantGlobal } from "./registry/imports.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
+import { ensureLateImport, flushLateImportShifts } from "./expressions/late-imports.js";
+import { emitThrowTypeError } from "./expressions/helpers.js";
 import { compileExpression, compileStatement, coerceType, valTypesMatch } from "./shared.js";
 
 const OBJECT_PROTOTYPE_KEYS = new Set([
@@ -33,8 +39,11 @@ const OBJECT_PROTOTYPE_KEYS = new Set([
   "valueOf",
 ]);
 
+/** A static (#1387 Tier-1) `with` scope entry. */
+export type StaticWithScope = Extract<NonNullable<FunctionContext["withScopes"]>[number], { kind: "static" }>;
+
 export interface WithBinding {
-  scope: NonNullable<FunctionContext["withScopes"]>[number];
+  scope: StaticWithScope;
   field: FieldDef;
   fieldIdx: number;
 }
@@ -48,16 +57,50 @@ interface WithTargetProof {
   integrity: WithTargetIntegrity;
 }
 
+/** A dynamic (#2663 Tier-2) `with` scope: arbitrary externref target resolved at
+ *  runtime via HasBinding + Get. */
+export type DynamicWithScope = Extract<NonNullable<FunctionContext["withScopes"]>[number], { kind: "dynamic" }>;
+
+/** Result of resolving a bare identifier against the `with` scope stack. */
+export type WithResolution =
+  | { kind: "static"; binding: WithBinding }
+  | { kind: "dynamic"; scope: DynamicWithScope }
+  | null;
+
 export function findWithBinding(fctx: FunctionContext, name: string): WithBinding | null {
+  const res = resolveWithBinding(fctx, name);
+  return res?.kind === "static" ? res.binding : null;
+}
+
+/**
+ * (#2663 Slice 1) Resolve a bare identifier against the `with` scope stack,
+ * innermost-first, across a MIXED static/dynamic stack.
+ *
+ * - A `static` scope hit returns the proven struct field binding (Tier-1
+ *   zero-overhead path) — short-circuits the walk.
+ * - A `dynamic` scope hit returns the scope for a runtime HasBinding-gated
+ *   select (the absent case falls through to the next-outer scope / lexical at
+ *   runtime, but statically we resolve to the innermost non-shadowing dynamic
+ *   scope and let codegen emit the gate + fallback).
+ * - `blockedNames` (body-declared lexical/inner-function names) shadow a scope
+ *   for that name — skip it.
+ */
+export function resolveWithBinding(fctx: FunctionContext, name: string): WithResolution {
   const scopes = fctx.withScopes;
   if (!scopes || scopes.length === 0) return null;
 
   for (let i = scopes.length - 1; i >= 0; i--) {
     const scope = scopes[i]!;
     if (scope.blockedNames.has(name)) continue;
+    if (scope.kind === "dynamic") {
+      // Runtime HasBinding decides presence; resolve to this dynamic scope and
+      // let codegen emit the gated select (present ⇒ object, absent ⇒ outer).
+      return { kind: "dynamic", scope };
+    }
+    // static scope
     const fieldIdx = scope.fields.findIndex((f) => f.name === name);
     if (fieldIdx >= 0) {
-      return { scope, field: scope.fields[fieldIdx]!, fieldIdx };
+      return { kind: "static", binding: { scope, field: scope.fields[fieldIdx]!, fieldIdx } };
     }
     if (OBJECT_PROTOTYPE_KEYS.has(name)) {
       return null;
@@ -105,22 +148,23 @@ export function compileWithBindingAssignment(
 
 export function compileWithStatement(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.WithStatement): void {
   const proof = proveObjectLiteralWithTarget(fctx, stmt.expression);
-  if (!proof.ok) {
-    reportWithStatementDiagnostic(ctx, stmt, proof.reason);
-    return;
-  }
-  if (containsNestedFunctionBoundary(stmt.statement)) {
-    reportWithStatementDiagnostic(
-      ctx,
-      stmt,
-      "body contains a nested function or class that could capture the object environment",
-    );
+  // (#2663 Slice 1) Tier-1 (static closed-shape) is the zero-overhead fast path;
+  // any non-proven target — `with(variable)`, `with(fn())`, etc. — falls to the
+  // Tier-2 dynamic-scope path (runtime HasBinding + Get) instead of being
+  // rejected at compile time.
+  if (!proof.ok || containsNestedFunctionBoundary(stmt.statement)) {
+    compileDynamicWithStatement(ctx, fctx, stmt);
     return;
   }
 
   const targetType = compileClosedObjectLiteralTarget(ctx, fctx, proof.expr);
   if (!targetType || (targetType.kind !== "ref" && targetType.kind !== "ref_null")) {
     if (targetType) fctx.body.push({ op: "drop" });
+    // Degenerate: proof said closed-literal but lowering didn't yield a struct.
+    // The target was already (partially) compiled here, so re-routing to the
+    // dynamic path would double-evaluate it — keep the diagnostic for this rare
+    // internal case. (The common non-proven targets never reach here; they took
+    // the Tier-2 path above before any target compilation.)
     reportWithStatementDiagnostic(ctx, stmt, "target did not lower to a WasmGC struct with a closed shape");
     return;
   }
@@ -157,13 +201,156 @@ export function compileWithStatement(ctx: CodegenContext, fctx: FunctionContext,
     }
   }
   const scopeFields = proof.integrity === "frozen" ? fields.map((field) => ({ ...field, mutable: false })) : fields;
-  const scope = { localIdx, structTypeIdx, fields: scopeFields, blockedNames };
+  const scope = { kind: "static" as const, localIdx, structTypeIdx, fields: scopeFields, blockedNames };
   (fctx.withScopes ??= []).push(scope);
   try {
     compileStatement(ctx, fctx, stmt.statement);
   } finally {
     fctx.withScopes?.pop();
   }
+}
+
+/**
+ * (#2663 Slice 1) Tier-2 dynamic `with` lowering. The target is an arbitrary
+ * value (variable / call / non-closed literal). ECMA-262 §14.11.7: evaluate the
+ * target, `GetValue`, `ToObject` (throws TypeError on null/undefined), and run
+ * the body with an Object Environment Record on the scope chain. Bare-identifier
+ * reads inside the body are resolved at runtime via `emitDynamicWithGet`
+ * (HasBinding gate + Get, falling back to the outer lowering when absent).
+ *
+ * Scope of THIS slice (READ only): writes/compound/inc-dec/`typeof`/`delete`
+ * (Slices 2-3) still take their non-with lowering — they don't consult the
+ * dynamic scope yet. `@@unscopables` (Slice 4) is not consulted; HasProperty is
+ * treated as HasBinding. A body containing a nested function/class boundary is
+ * rejected (the closure can't capture the object environment at runtime yet),
+ * matching the Tier-1 boundary refusal.
+ */
+function compileDynamicWithStatement(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.WithStatement): void {
+  if (containsNestedFunctionBoundary(stmt.statement)) {
+    reportWithStatementDiagnostic(
+      ctx,
+      stmt,
+      "body contains a nested function or class that could capture the object environment (Tier-2 dynamic with: deferred)",
+    );
+    return;
+  }
+
+  // §14.11.7 step 1-3: evaluate the target and coerce to a uniform externref
+  // receiver (struct ref / boxed any / host object all normalize to externref).
+  const targetType = compileExpression(ctx, fctx, stmt.expression, { kind: "externref" });
+  if (!targetType) {
+    reportWithStatementDiagnostic(ctx, stmt, "dynamic with target did not compile");
+    return;
+  }
+  if (targetType.kind !== "externref") {
+    coerceType(ctx, fctx, targetType, { kind: "externref" });
+  }
+  const localIdx = allocLocal(fctx, `__with_dyn_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: localIdx });
+
+  // §14.11.7: ToObject(undefined|null) throws TypeError. A JS `undefined`/`null`
+  // is a NON-null externref wrapping the host sentinel, so `ref.is_null` alone is
+  // insufficient — use `__extern_is_undefined` (host) which matches `v == null`.
+  // Guard: if (__extern_is_undefined(recv)) throw TypeError.
+  const isUndefIdx = ensureLateImport(ctx, "__extern_is_undefined", [{ kind: "externref" }], [{ kind: "i32" }]);
+  flushLateImportShifts(ctx, fctx);
+  if (isUndefIdx !== undefined) {
+    fctx.body.push({ op: "local.get", index: localIdx });
+    fctx.body.push({ op: "call", funcIdx: isUndefIdx } as Instr);
+    const savedGuard = pushBody(fctx);
+    emitThrowTypeError(ctx, fctx, "Cannot convert undefined or null to object");
+    const throwArm = fctx.body;
+    popBody(fctx, savedGuard);
+    fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: throwArm } as Instr);
+  }
+
+  // Body-declared LEXICAL names (let/const/class/catch) and inner-function names
+  // genuinely shadow the object environment. `var`/function-scope names do NOT
+  // (§: a var hoists to the function env but the object env is still consulted
+  // first at runtime) — but `collectBodyDeclaredNames` lumps `var` in. For the
+  // READ slice the conservative effect of blocking a var name is that it reads
+  // the outer var directly instead of HasBinding-gating — which is correct ONLY
+  // when the object lacks the name. The canary 12.10-0-1.js has an EMPTY object,
+  // so a blocked `foo` still resolves to the hoisted var (the expected result).
+  // A precise var/object precedence is refined in a later slice; Slice 1 uses
+  // the declared-name set as-is to stay conservative and byte-safe.
+  const blockedNames = collectBodyDeclaredNames(stmt.statement);
+
+  (fctx.withScopes ??= []).push({ kind: "dynamic", localIdx, blockedNames });
+  try {
+    compileStatement(ctx, fctx, stmt.statement);
+  } finally {
+    fctx.withScopes?.pop();
+  }
+}
+
+/**
+ * (#2663 Slice 1) Emit the HasBinding-gated READ select for a bare identifier
+ * that resolved to a dynamic `with` scope (§9.1.1.2.1 HasBinding +
+ * §9.1.1.2.5 GetBindingValue):
+ *
+ *   if (HasBinding(recv, name)) result = Get(recv, name) else result = <outer>
+ *
+ * Both arms normalize to `externref` (the `Get` half yields externref; the outer
+ * fallback is coerced). `emitFallback` emits the name's normal (non-with)
+ * lowering into the current body and returns its ValType (or null on error).
+ *
+ * Slice 1 treats HasProperty as HasBinding (no `@@unscopables` — Slice 4). The
+ * gate uses the value-INDEPENDENT host `__extern_has` (NOT `__dyn_has`'s
+ * non-null proxy): a property present with value `undefined` MUST still shadow
+ * the outer binding (§7.3.12).
+ */
+export function emitDynamicWithGet(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  scope: DynamicWithScope,
+  name: string,
+  emitFallback: () => ValType | null,
+): ValType {
+  // HasBinding gate: __extern_has(recv, "name") -> i32 (own+proto, value-indep).
+  addStringConstantGlobal(ctx, name);
+  const hasIdx = ensureLateImport(
+    ctx,
+    "__extern_has",
+    [{ kind: "externref" }, { kind: "externref" }],
+    [{ kind: "i32" }],
+  );
+  flushLateImportShifts(ctx, fctx);
+
+  // THEN arm: Get(recv, name) -> externref (via the #2580 substrate emitDynGet).
+  const savedThen = pushBody(fctx);
+  fctx.body.push({ op: "local.get", index: scope.localIdx });
+  emitDynGet(ctx, fctx, name);
+  const thenArm = fctx.body;
+  popBody(fctx, savedThen);
+
+  // ELSE arm: the name's normal (outer) lowering, normalized to externref.
+  const savedElse = pushBody(fctx);
+  const fbType = emitFallback();
+  if (fbType && fbType.kind !== "externref") {
+    coerceType(ctx, fctx, fbType, { kind: "externref" });
+  }
+  const elseArm = fctx.body;
+  popBody(fctx, savedElse);
+
+  if (hasIdx === undefined) {
+    // Could not register the gate — fall back to the plain outer lowering
+    // (already captured in elseArm); splice it inline so we don't lose it.
+    fctx.body.push(...elseArm);
+    return { kind: "externref" };
+  }
+
+  fctx.body.push({ op: "local.get", index: scope.localIdx });
+  // Build the key externref + __extern_has call as the condition.
+  for (const instr of stringConstantExternrefInstrs(ctx, name)) fctx.body.push(instr);
+  fctx.body.push({ op: "call", funcIdx: hasIdx } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "externref" } as ValType },
+    then: thenArm,
+    else: elseArm,
+  } as Instr);
+  return { kind: "externref" };
 }
 
 function compileClosedObjectLiteralTarget(

--- a/tests/issue-2663.test.ts
+++ b/tests/issue-2663.test.ts
@@ -1,0 +1,91 @@
+// #2663 Slice 1 — `with` statement Tier 2: dynamic-scope READ.
+//
+// Tier 1 (#1387) only handles `with(target)` when `target` is a statically
+// closed object literal. Tier 2 adds the dynamic case — `with(variable)`,
+// `with(fn())`, etc. — where a bare identifier inside the block is resolved at
+// runtime: HasBinding (value-independent `__extern_has`, own+proto) gates a
+// `Get` (`emitDynGet`, the #2580 substrate); absent ⇒ fall through to the outer
+// (next `with`, then lexical) binding. §14.11 / §9.1.1.2.
+//
+// Slice 1 is READ-only: writes/compound/inc-dec/typeof/delete and @@unscopables
+// are later slices. A body with a nested function/class boundary is still
+// rejected (the closure can't capture the object environment yet).
+//
+// These tests compile with `inferModuleStrictArguments: false` + the runner's
+// `skipSemanticDiagnostics: true` — `with` is sloppy-only, and the TS frontend
+// already de-stricts it under skipSemanticDiagnostics (see the #2663 Slice-0
+// audit: 0 with-tests are TS1101-blocked; the real gate was codegen, fixed here).
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+
+async function run(body: string): Promise<any> {
+  const src = `export function test(): any { ${body} }`;
+  const result: any = await compile(src, {
+    fileName: "test.ts",
+    skipSemanticDiagnostics: true,
+    inferModuleStrictArguments: false,
+  } as any);
+  expect(result.binary?.length).toBeGreaterThan(0);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  return wrapExports(instance.exports, { signatures: result.exportSignatures });
+}
+
+describe("#2663 Slice 1 — dynamic with READ", () => {
+  it("reads a present property off a non-literal `with` target (variable)", async () => {
+    const exp = await run(`var o = { x: 42 }; var r; with (o) { r = x; } return r;`);
+    expect(exp.test()).toBe(42);
+  });
+
+  it("falls through to the outer lexical binding when the property is absent", async () => {
+    const exp = await run(`var x = 7; var o = { y: 1 }; var r; with (o) { r = x; } return r;`);
+    expect(exp.test()).toBe(7);
+  });
+
+  it("nested with: a name absent on the inner object cascades to the outer with", async () => {
+    const exp = await run(`var a = { p: 1 }; var b = { q: 2 }; var r; with (a) { with (b) { r = p; } } return r;`);
+    expect(exp.test()).toBe(1);
+  });
+
+  it("nested with: inner object shadows the outer for a shared name", async () => {
+    const exp = await run(`var a = { v: 1 }; var b = { v: 2 }; var r; with (a) { with (b) { r = v; } } return r;`);
+    expect(exp.test()).toBe(2);
+  });
+
+  it("a body-declared lexical (let) shadows the with object's property", async () => {
+    const exp = await run(`var o = { x: 99 }; var r; with (o) { let x = 5; r = x; } return r;`);
+    expect(exp.test()).toBe(5);
+  });
+
+  it("the `with` target is computed by a call expression", async () => {
+    const exp = await run(`function mk() { return { z: 11 }; } var r; with (mk()) { r = z; } return r;`);
+    expect(exp.test()).toBe(11);
+  });
+
+  it("absent on object, absent in scope → cascades to a true outer global read", async () => {
+    const exp = await run(
+      `var g = 3; function inner() { var o = { nope: 0 }; var r; with (o) { r = g; } return r; } return inner();`,
+    );
+    expect(exp.test()).toBe(3);
+  });
+
+  it("Tier-1 static closed-literal `with` read still works (no regression)", async () => {
+    const exp = await run(`var r; with ({ a: 5 }) { r = a; } return r;`);
+    expect(exp.test()).toBe(5);
+  });
+
+  it("Tier-1 static closed-literal `with` write still works (no regression)", async () => {
+    const exp = await run(`var o2; with ({ a: 0 }) { a = 9; o2 = a; } return o2;`);
+    expect(exp.test()).toBe(9);
+  });
+
+  it("ToObject(undefined) throws a TypeError (§14.11.7)", async () => {
+    const exp = await run(
+      `var u; var threw = 0; try { with (u) { var z = 1; } } catch (e) { threw = 1; } return threw;`,
+    );
+    // u is undefined → entering the with must throw; caught → threw === 1.
+    expect(exp.test()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

`with` statement **Tier 2, Slice 1 — dynamic-scope READ**. Tier 1 (#1387) only handled `with(target)` when `target` is a statically closed object literal; everything else (`with(variable)`, `with(fn())`, …) hit the #1387 codegen refusal (the `#1472`-deferred dynamic fallback). This slice implements the dynamic scope-chain **read**: a bare identifier inside a non-closed `with` is resolved at runtime via a **value-independent HasBinding** gate (`__extern_has`, own+proto) + **Get** (`emitDynGet`, the #2580 dyn-read substrate); absent ⇒ cascade to the next-outer `with`, then to the lexical binding (§9.1.1.2 / §14.11).

## Reconciliation: #2663 vs #1472 vs the Slice-0 premise

- **#1472 is DONE** (host-independence for object/property ops, PR #1047) and does **not** cover `with`. The #1387 error's "Dynamic fallback deferred to #1472" is a **stale** reference — the dynamic-`with` work is tracked here under **#2663** (no silent duplicate; #2663 = canonical).
- **Slice 0 (runner de-strict) DROPPED as moot.** The spec's premise (the runner's strict `export function test()` wrapper TS1101-blocks `with`) is **refuted**: `skipSemanticDiagnostics: true` (already on every runner path) suppresses TS1101. Audit: **0 / 37** noStrict `with` tests are strict-wrapper-blocked; the real gate is codegen #1387, fixed here. Spec corrected in this PR.

## Changes

- `context/types.ts` — widen `withScopes` to a discriminated `kind: "static" | "dynamic"` union.
- `with-scope.ts` — `resolveWithBinding` (mixed-stack innermost-first walk), `compileDynamicWithStatement` (target→externref, ToObject TypeError guard on null/undefined via `__extern_is_undefined`, push dynamic scope), `emitDynamicWithGet` (HasBinding-gated select; both arms normalized to externref; `pushBody`/`popBody` separate arms — no shared `Instr` aliasing). `compileWithStatement` now falls to the dynamic path instead of rejecting non-closed targets.
- `identifiers.ts` — split `compileIdentifierCore` out; the dynamic-with read runs the outer lowering as the HasBinding-**miss** fallback with the matched scope (and inner) temporarily truncated so **nested `with` cascades** correctly.

## Scope (Slice 1 = READ only)

WRITE (Slice 2), compound/inc-dec/`typeof`/`delete` (Slice 3), `@@unscopables` (Slice 4) are follow-ups. Nested-function-boundary bodies are still rejected (the closure can't capture the object environment yet). `@@unscopables` not consulted (HasProperty treated as HasBinding).

## Row-delta (174 noStrict `with` tests, in-process runner)

| bucket | baseline (origin/main) | Slice 1 | Δ |
|---|---|---|---|
| **pass** | 3 | **16** | **+13** |
| fail | 8 | 15 | +7 |
| compile_error | 162 | 51 | **−111** (now reach codegen) |
| runtime_error | 1 | 92 | +91 (WRITE-dependent, Slice 2; previously compile_error) |

Net **+13 passing**; 111 unblocked from `compile_error` to measurable. Tier-1 static path byte-unchanged; non-`with` modules unaffected (`resolveWithBinding` early-returns on empty `withScopes`).

## Tests

`tests/issue-2663.test.ts` — 10/10: present-prop read, absent→outer, nested cascade, inner-shadows-outer, lexical-shadow, call-expression target, outer-global cascade, ToObject(undefined) TypeError, + 2 Tier-1 no-regression cases.

## Risk

Touches the shared `compileIdentifier` (refactored to `compileIdentifierCore`) — validated via the **full merge_group floor**, not a scoped sweep. Adjacent suites green (#1712 tokenizer-identity, #2659, generators).

Refs #1472. Implements #2663 Slice 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)