### PR TITLE
feat(#2663): with Tier-2 dynamic delete + var/object precedence — Slice 3 (ref #1472)

### DIFF
--- a/plan/issues/2663-with-statement-tier2-dynamic-scope.md
+++ b/plan/issues/2663-with-statement-tier2-dynamic-scope.md
@@ -425,9 +425,38 @@ corpus.
   — `var foo` inside `with` visible via an outer closure; needs the var/object
   precedence refinement noted above) plus `typeof`/`delete`/`@@unscopables`
   (Slices 3-4). Zero regression to non-`with` modules.
-- **Slice 3 — compound/inc-dec + `typeof`/`delete`:** `+=`, `++`/`--`
-  (`unary-updates.ts`, `assignment.ts` compound path), `typeof`
-  (`typeof-delete.ts:895/1041`), `delete name`. HasBinding-gated read-modify-write.
+- **Slice 3 — `delete name` + var/object precedence: ✅ DONE (PR, 2026-06-25).**
+  Data-driven scope: a feature classification of the 89 remaining
+  runtime_errors found **delete = 45** (the biggest bucket), closure-capture =
+  35, and typeof/compound/inc-dec ≈ 0 in this corpus — so Slice 3 targets
+  `delete` (and folds in the var-precedence refinement); typeof/compound/inc-dec
+  are deferred as near-nil-yield here.
+  - `emitDynamicWithDelete` (`with-scope.ts`): HasBinding-gated
+    `__delete_property(recv,name)` else cascade to the outer delete / bare-var
+    `false`; wired at the `delete identifier` site (`typeof-delete.ts`).
+  - **var/object precedence:** `blockedNames` for a dynamic scope is now
+    LEXICAL-only (`collectBodyLexicalNames` — `let`/`const`/class/catch +
+    inner-fn), EXCLUDING `var`. §: a `var` inside `with` hoists to the function
+    env but the Object Environment Record is consulted FIRST, so a `var foo` name
+    must still pass the HasBinding gate (object wins if owned). So
+    `var foo; with({foo}){ foo=… }` now writes the OBJECT; `let` still shadows.
+  - **Row-delta: pass 20→23 (+3), runtime_error 89→86.** The delete RETURN value
+    is now spec-correct; the bulk of the 45 delete tests ALSO check `in`/re-read
+    after delete, which hits a **delete-on-struct-slot observability gap** (the
+    with object is a typed WasmGC struct; `__delete_property` clears the host
+    sidecar but `in`/re-read reads the struct slot — the #2659-family struct-slot
+    vs sidecar asymmetry, for delete). Closing that needs a struct-slot-aware
+    delete on an externref receiver — deferred (see below).
+- **DEFERRED — closure-capture class (~35 tests) + delete-on-struct
+  observability:** the var-decl-initializer-in-`with` + **outer-closure capture**
+  of a function-scope var (canary `12.10-0-1/7/8`) is the remaining big bucket;
+  it touches the closure-capture machinery and is substantially harder — its own
+  sub-slice / possibly senior-dev. The delete struct-slot observability is the
+  #2659-family asymmetry for delete. Both are flagged to the lead, NOT bundled.
+- **Slice 4 — `@@unscopables`:** `emitWithHasBinding` full §9.1.1.2.1 with the
+  symbol-keyed `Get(recv,@@unscopables)` + `ToBoolean(Get(unscopables,N))` block.
+  Covers `binding-blocked-by-unscopables.js`, `unscopables-*` tests. Also handle
+  `ToObject(primitive)` wrapper-object receivers if any corpus test needs it.
 - **Slice 4 — `@@unscopables`:** `emitWithHasBinding` full §9.1.1.2.1 with the
   symbol-keyed `Get(recv,@@unscopables)` + `ToBoolean(Get(unscopables,N))` block.
   Covers `binding-blocked-by-unscopables.js`, `unscopables-*` tests. Also handle

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -18,7 +18,7 @@ import { addFuncType } from "./registry/types.js";
 import type { InnerResult } from "./shared.js";
 import { compileExpression, ensureAnyHelpers, isAnyValue } from "./shared.js";
 import { compileStringLiteral } from "./string-ops.js";
-import { findWithBinding } from "./with-scope.js";
+import { emitDynamicWithDelete, findWithBinding, resolveWithBinding } from "./with-scope.js";
 
 // ── Delete expression ─────────────────────────────────────────────────
 
@@ -85,6 +85,34 @@ export function compileDeleteExpression(
   }
 
   if (ts.isIdentifier(inner)) {
+    // (#2663 Slice 3) `delete name` inside a dynamic `with`: if the with-object
+    // has the binding ⇒ delete the object property (configurability-aware
+    // result); else ⇒ cascade to the next-outer with, then to the bare-variable
+    // case (variables are not deletable ⇒ false). §13.5.1.2 / §8.5.2.
+    const ident = inner;
+    const emitOuterDelete = (): void => {
+      const res = resolveWithBinding(fctx, ident.text);
+      if (res?.kind === "dynamic") {
+        const scopes = fctx.withScopes!;
+        const matchedIdx = scopes.lastIndexOf(res.scope);
+        emitDynamicWithDelete(ctx, fctx, res.scope, ident.text, () => {
+          const saved = fctx.withScopes;
+          fctx.withScopes = scopes.slice(0, matchedIdx);
+          try {
+            emitOuterDelete();
+          } finally {
+            fctx.withScopes = saved;
+          }
+        });
+        return;
+      }
+      // A static with-bound name or a plain variable: not deletable ⇒ false.
+      fctx.body.push({ op: "i32.const", value: 0 });
+    };
+    if (resolveWithBinding(fctx, ident.text)?.kind === "dynamic") {
+      emitOuterDelete();
+      return { kind: "i32" };
+    }
     // Variables are not deletable — return false
     fctx.body.push({ op: "i32.const", value: 0 });
     return { kind: "i32" };

--- a/src/codegen/with-scope.ts
+++ b/src/codegen/with-scope.ts
@@ -264,17 +264,15 @@ function compileDynamicWithStatement(ctx: CodegenContext, fctx: FunctionContext,
     fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: throwArm } as Instr);
   }
 
-  // Body-declared LEXICAL names (let/const/class/catch) and inner-function names
-  // genuinely shadow the object environment. `var`/function-scope names do NOT
-  // (§: a var hoists to the function env but the object env is still consulted
-  // first at runtime) — but `collectBodyDeclaredNames` lumps `var` in. For the
-  // READ slice the conservative effect of blocking a var name is that it reads
-  // the outer var directly instead of HasBinding-gating — which is correct ONLY
-  // when the object lacks the name. The canary 12.10-0-1.js has an EMPTY object,
-  // so a blocked `foo` still resolves to the hoisted var (the expected result).
-  // A precise var/object precedence is refined in a later slice; Slice 1 uses
-  // the declared-name set as-is to stay conservative and byte-safe.
-  const blockedNames = collectBodyDeclaredNames(stmt.statement);
+  // Only body-declared LEXICAL names (let/const/class/catch) + inner-function
+  // names genuinely shadow the object environment. `var`/function-scope names do
+  // NOT — a `var` inside `with` hoists to the function env, but the object env is
+  // consulted FIRST at runtime, so a `var foo` must still pass the HasBinding
+  // gate (object wins if it owns `foo`; else the hoisted var). Using the lexical
+  // set (not the full declared set) is what makes `with({foo:..}){ var foo=.. }`
+  // write the OBJECT, while keeping the empty-object canary correct (gate misses
+  // ⇒ falls to the hoisted var). (#2663 Slice 2 var-precedence refinement.)
+  const blockedNames = collectBodyLexicalNames(stmt.statement);
 
   (fctx.withScopes ??= []).push({ kind: "dynamic", localIdx, blockedNames });
   try {
@@ -419,6 +417,70 @@ export function emitDynamicWithSet(
     then: thenArm,
     else: elseArm,
   } as Instr);
+}
+
+/**
+ * (#2663 Slice 3) Emit `delete name` where `name` resolved to a dynamic `with`
+ * scope, leaving an i32 result on the stack (§13.5.1.2 / §8.5.2 DeleteBinding):
+ *
+ *   if (HasBinding(recv, name)) result = __delete_property(recv, name)
+ *   else result = <outer delete>   // a bare variable is not deletable ⇒ 0,
+ *                                  // unless an outer with also binds it (cascade)
+ *
+ * `emitOuterDelete()` emits the next-outer `delete name` result as i32 (another
+ * dynamic-with gate, or the plain "variables not deletable" `i32.const 0`).
+ */
+export function emitDynamicWithDelete(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  scope: DynamicWithScope,
+  name: string,
+  emitOuterDelete: () => void,
+): ValType {
+  addStringConstantGlobal(ctx, name);
+  const hasIdx = ensureLateImport(
+    ctx,
+    "__extern_has",
+    [{ kind: "externref" }, { kind: "externref" }],
+    [{ kind: "i32" }],
+  );
+  const delIdx = ensureLateImport(
+    ctx,
+    "__delete_property",
+    [{ kind: "externref" }, { kind: "externref" }],
+    [{ kind: "i32" }],
+  );
+  flushLateImportShifts(ctx, fctx);
+
+  // ELSE arm: the next-outer delete (cascade) → i32.
+  const savedElse = pushBody(fctx);
+  emitOuterDelete();
+  const elseArm = fctx.body;
+  popBody(fctx, savedElse);
+
+  if (hasIdx === undefined || delIdx === undefined) {
+    fctx.body.push(...elseArm);
+    return { kind: "i32" };
+  }
+
+  // THEN arm: __delete_property(recv, name) → i32 (configurability-aware result).
+  const savedThen = pushBody(fctx);
+  fctx.body.push({ op: "local.get", index: scope.localIdx });
+  for (const instr of stringConstantExternrefInstrs(ctx, name)) fctx.body.push(instr);
+  fctx.body.push({ op: "call", funcIdx: delIdx } as Instr);
+  const thenArm = fctx.body;
+  popBody(fctx, savedThen);
+
+  fctx.body.push({ op: "local.get", index: scope.localIdx });
+  for (const instr of stringConstantExternrefInstrs(ctx, name)) fctx.body.push(instr);
+  fctx.body.push({ op: "call", funcIdx: hasIdx } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "i32" } },
+    then: thenArm,
+    else: elseArm,
+  } as Instr);
+  return { kind: "i32" };
 }
 
 function compileClosedObjectLiteralTarget(
@@ -580,6 +642,47 @@ function collectBodyDeclaredNames(stmt: ts.Statement): Set<string> {
     if (ts.isVariableDeclaration(node)) {
       collectBindingNames(node.name, names);
       return;
+    }
+    if (ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node)) {
+      if (node.name) names.add(node.name.text);
+      return;
+    }
+    if (ts.isCatchClause(node) && node.variableDeclaration) {
+      collectBindingNames(node.variableDeclaration.name, names);
+    }
+    forEachChild(node, walk);
+  };
+  walk(stmt);
+  return names;
+}
+
+/** True if a VariableDeclaration is `let`/`const` (block-scoped), not `var`. */
+function isLexicalVarDecl(node: ts.VariableDeclaration): boolean {
+  const list = node.parent;
+  if (list && ts.isVariableDeclarationList(list)) {
+    // NodeFlags.Let (0x1) | NodeFlags.Const (0x2) — `var` has neither.
+    return (list.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const)) !== 0;
+  }
+  return false;
+}
+
+/**
+ * (#2663 Slice 2 var-precedence) Names that GENUINELY shadow a dynamic `with`
+ * object binding: lexical declarations (`let`/`const`/class/catch) and
+ * inner-function declarations. `var`-declared (function-scoped) names are
+ * deliberately EXCLUDED — per §, a `var` inside `with` hoists to the function
+ * environment but the object environment is consulted FIRST at runtime, so a
+ * `var foo` name must still pass through the HasBinding gate (object wins if the
+ * with-object owns `foo`; otherwise it resolves to the hoisted var). Used as the
+ * dynamic scope's `blockedNames` so the gate is not bypassed for `var` names.
+ */
+function collectBodyLexicalNames(stmt: ts.Statement): Set<string> {
+  const names = new Set<string>();
+  const walk = (node: ts.Node): void => {
+    if (node !== stmt && isFunctionOrClassBoundary(node)) return;
+    if (ts.isVariableDeclaration(node)) {
+      if (isLexicalVarDecl(node)) collectBindingNames(node.name, names);
+      return; // `var` declarations are NOT blocked (object env consulted first)
     }
     if (ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node)) {
       if (node.name) names.add(node.name.text);

--- a/tests/issue-2663.test.ts
+++ b/tests/issue-2663.test.ts
@@ -127,3 +127,42 @@ describe("#2663 Slice 2 — dynamic with WRITE", () => {
     expect(exp.test()).toBe(19);
   });
 });
+
+describe("#2663 Slice 3 — dynamic with DELETE + var/object precedence", () => {
+  it("`delete name` on a present configurable with-binding returns true", async () => {
+    const exp = await run(`var o = { x: 1 }; var r; with (o) { r = delete x; } return r ? 1 : 0;`);
+    expect(exp.test()).toBe(1);
+  });
+
+  it("`delete name` for an absent name returns false (bare variable not deletable)", async () => {
+    const exp = await run(`var x = 1; var o = { y: 0 }; var r; with (o) { r = delete x; } return r ? 1 : 0;`);
+    expect(exp.test()).toBe(0);
+  });
+
+  it("`delete name` cascades the HasBinding gate to the outer with object", async () => {
+    // p is on the outer `a`, absent on inner `b` → inner gate misses, outer hits
+    // → delete a.p returns true.
+    const exp = await run(
+      `var a = { p: 1 }; var b = { q: 2 }; var r; with (a) { with (b) { r = delete p; } } return r ? 1 : 0;`,
+    );
+    expect(exp.test()).toBe(1);
+  });
+
+  // var/object precedence (lexical-only blockedNames, §9.1.x Object Environment
+  // Record precedence): a `var`-declared name does NOT shadow the with object —
+  // a plain assignment routes to the object when it owns the name.
+  it("a `var`-bound name + plain assign in with writes the OBJECT when it owns the name", async () => {
+    const exp = await run(`var foo; var o = { foo: "obj" }; with (o) { foo = "hi"; } return o.foo;`);
+    expect(exp.test()).toBe("hi");
+  });
+
+  it("a `let` inside with DOES shadow the with object (lexical binding wins)", async () => {
+    const exp = await run(`var o = { x: "obj" }; var r; with (o) { let x = "lex"; r = x; } return r;`);
+    expect(exp.test()).toBe("lex");
+  });
+
+  it("a `var`-bound name absent on the object falls through to the variable", async () => {
+    const exp = await run(`var foo; var o = { y: 0 }; with (o) { foo = "hi"; } return foo;`);
+    expect(exp.test()).toBe("hi");
+  });
+});


### PR DESCRIPTION
## Summary

`with` statement **Tier 2, Slice 3 — `delete name` over a dynamic with-binding + var/object precedence**, stacked on Slice 2 (#2061). 

**Data-driven scope:** classifying the 89 remaining with-corpus runtime_errors gave **delete = 45** (biggest), closure-capture = 35, typeof/compound/inc-dec ≈ 0 in this corpus. So Slice 3 targets `delete` and folds in the var/object-precedence refinement; typeof/compound/inc-dec are deferred (near-nil yield here).

> **Stacked on #2061 (Slice 2).** Until #2061 merges, this PR's diff includes the Slice-2 commit too; it resolves to just the Slice-3 delta once #2061 lands. Enqueue after #2061.

## Changes

- `with-scope.ts` `emitDynamicWithDelete` — HasBinding-gated `__delete_property(recv, name)` else cascade to the outer delete / bare-variable `false` (§13.5.1.2 / §8.5.2 DeleteBinding). Same recursive nested-with cascade as read/write.
- `typeof-delete.ts` — the `delete identifier` site routes a dynamic-with hit through `emitDynamicWithDelete`.
- **var/object precedence:** a dynamic with scope's `blockedNames` is now LEXICAL-only (`collectBodyLexicalNames`: `let`/`const`/class/catch + inner-fn), **excluding `var`**. Per the Object Environment Record precedence (§9.1.x), a `var` inside `with` hoists to the function env but the object env is consulted FIRST, so a var-bound name must still pass the HasBinding gate (object wins if it owns the name). Now `var foo; with({foo}){ foo=… }` writes the **object**; `let` still shadows.

## Row-delta (174 noStrict `with` tests)

| bucket | Slice 2 | **Slice 3** | Δ |
|---|---|---|---|
| **pass** | 20 | **23** | **+3** |
| runtime_error | 89 | 86 | −3 |

The delete **return value** is now spec-correct. The bulk of the 45 delete tests ALSO check `in`/re-read after delete, which hits a **delete-on-struct-slot observability gap** (the with object is a typed WasmGC struct; `__delete_property` clears the host sidecar but `in`/re-read reads the struct slot — the #2659-family struct-slot vs sidecar asymmetry, for delete). Closing that needs a struct-slot-aware delete on an externref receiver — **deferred** (flagged to the lead alongside the 35-test closure-capture class, NOT bundled here).

## Tests

`tests/issue-2663.test.ts` — **22/22** (read + write + delete + var/object precedence). Pre-existing `delete-operator.test.ts` (missing `tests/helpers.js` harness file) and `issue-2130` (1 failure identical on clean main) are **not** regressions. Adjacent #2659 green.

## Risk

Touches the shared `delete` identifier path — validated via the **full merge_group floor**.

Refs #1472. Implements #2663 Slice 3 (Slices 1-2 = #2059 merged / #2061 in queue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)