### PR TITLE
fix(#2029): keep object-runtime helpers when a nested-fn hoist fails (standalone funcIdx crash)

### DIFF
--- a/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
+++ b/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
@@ -6,7 +6,7 @@ sprint: 66
 created: 2026-06-10
 updated: 2026-06-25
 priority: critical
-assignee: ttraenkler/sd-2038
+assignee: ttraenkler/sd-2029fn
 feasibility: medium
 reasoning_effort: high
 model: opus
@@ -553,3 +553,92 @@ replaceAll/searchValue-replacer-RegExp-*` (2, regexp-replacer string key) and
 accessor). Plus the `function index` funcIdx-shift cluster (8: TypedArray/Array
 `toLocaleString`, annexB RegExp, optional-chaining async) and 1 stray
 `for-of/iterator-next-reference` local-index — the next PR(s).
+
+## LANDED slice (2026-06-25, sd-2029fn) — function-index cluster (failed-nested-hoist strands object-runtime helpers)
+
+**Root cause — NOT dead-elimination (sd-2038's hypothesis was disproved by the
+per-process trace).** The characterized repro
+(`built-ins/Array/prototype/toLocaleString/user-provided-tolocalestring-grow.js`,
+`call 136` into a 129-func module at `__call_m_resize_1`) was traced emit-time:
+
+- At `fillClosedMethodDispatch`, `funcMap.get("__extern_method_call")` returned
+  **136 while the local table held only 132 funcs** — i.e. the funcMap entry was
+  ALREADY stale at fill time (delta exactly = the 4 dead imports? no — the delta
+  was the count of object-runtime helpers truncated below; see trace). The helper
+  named `__extern_method_call` had `actualTablePos = -1` — it was **not in
+  `mod.functions` at all** (along with `__apply_closure`, `__object_seal/freeze`,
+  and all 16 `__proxy_*` dispatchers — 30 orphaned funcMap entries pointing past
+  the table).
+- The orphan source: **`hoistFunctionDeclarations`** (`nested-declarations.ts`).
+  The test's `listToString` nested `function` declaration FAILS to hoist (its body
+  hits `__extern_toLocaleString`, standalone-unsupported → `reportError`). During
+  that failed compile it had pulled in the **entire object runtime** as a side
+  effect (86 funcs registered in `mod.functions` AND `funcMap`, plus
+  `objectRuntimeTypes` / a late import). The rollback did
+  `ctx.mod.functions.length = funcsBefore` — truncating those 86 helpers out of
+  the table — **but left their `funcMap` entries and the `objectRuntimeTypes` /
+  `ensureProxyRuntime` (`funcMap.has`) guards intact.** A later real
+  `rab.resize(...)` any-receiver call reserved `__call_m_resize_1`; its
+  `ensureObjVecBuilders` → `ensureObjectRuntime` found `objectRuntimeTypes` SET,
+  SKIPPED re-registration, and `fillClosedMethodDispatch` baked the stale funcIdx
+  (136) past the shrunken table → the encoder's "function index out of range".
+
+This is a NEW instance of `project_type_index_shift_and_deadelim`'s sibling for
+the **local function table**: `src/codegen/context/speculative.ts` (#1919) makes
+expression probes transactional over imports/funcMap, but the older
+nested-function-hoist rollback truncated `mod.functions` WITHOUT the matching
+side-table unwind.
+
+**Fix (`src/codegen/statements/nested-declarations.ts`, the failed-hoist
+rollback): do NOT truncate `ctx.mod.functions`.** The side-effect helpers are
+valid, content-addressed, idempotent, and potentially needed by later code —
+removing them is the over-reach. Instead keep every pushed func and neutralise
+ONLY the failed user function's own entry to a valid `unreachable` stub (local
+funcs are never dead-eliminated, so a leftover MUST be valid Wasm, not an empty /
+broken body), dropping its funcMap name so `compileStatement` re-compiles it at
+its real textual position (the pre-existing `hoistFailedFuncs` re-attempt). funcMap
+and the table stay in lockstep — no dispatcher can bake a stale index.
+
+**Why not "complete the truncation" (purge funcMap + reset `objectRuntimeTypes`
+→ re-register)?** Tried and REJECTED: the object runtime's own dependencies
+(`number_toString`, native-string helpers, union boxes) have separate
+registration latches that would ALSO need resetting in dependency order — a
+re-register-after-purge crashed a probe with `function index out of range —
+undefined at __to_property_key` (a purged dep baked as `undefined`). Keeping the
+helpers (no truncation) sidesteps the entire cascading-latch problem.
+
+**Downstream-effect audit:** the change is in the mode-agnostic hoist, but the
+truncation only ever stranded the standalone-only object-runtime/closed-method
+helpers (gc/host never reserves a dispatcher), so the stale-index crash was
+standalone-only and the fix is too. No stack-balance / return-type / index-shift
+fallout: the only behavioural delta is "a failed-hoist leftover func is an
+`unreachable` stub instead of being spliced out", and that func is unreferenced
+(dead) — `reservedEntry.body = []` (invalid for non-void returns) is now
+`[unreachable]` (strictly safer).
+
+**Row-delta (paired scan, my branch vs pristine, identical on the 3 touched
+files):** `built-ins/{Array,TypedArray}/prototype/toLocaleString` — **5 →
+0** `function index out of range` emit-crashes (now reach a downstream
+`__closure_5` instantiate type-mismatch / `Cannot convert object to primitive` —
+SEPARATE bugs, not emit crashes). optional-chaining: 0 funcidx crashes on both
+(`member-expression-async-this` PASSES; others runtime-fail, not emit-crash). No
+regression anywhere (annexB unchanged; see residual).
+
+**Validation:** new `tests/issue-2029-nested-hoist-funcidx-standalone.test.ts`
+(3/3) — proven to FAIL on pristine (2 standalone cases emit-crash) and PASS on
+this branch, plus a gc-mode no-regression control. tsc clean. Hoist/closure/2029
+suites: 59/59 tests pass (matches pristine; the cross-suite "failed file"
+collection noise is identical on pristine). #2151 / #2015 / #2038 / generator /
+standalone-coercion batch green. Broad emit-path change → relying on the
+merge_group test262 floor for full conformance
+(`project_broad_impact_validate_full_ci`).
+
+**Remaining function-index (separate producer, NOT this fix, PRE-EXISTING — out
+of traced scope):** `annexB/built-ins/RegExp/RegExp-{control-escape-russian-letter,
+invalid-control-escape-character-class}.js` (2) crash with `function index out of
+range — undefined at <generator fn>` — a `function* …()` native-generator funcMap
+lookup baking `undefined`, confirmed IDENTICAL on pristine (neither fixed nor
+regressed here). A distinct funcMap-returns-undefined producer in the
+generator-native lowering; route as its own slice. Plus the global-index
+regexp-replacer (2) + property-accessor (1) and the for-of/iterator-next
+local-index (1) residuals already noted above.

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -1280,18 +1280,51 @@ export function hoistFunctionDeclarations(
       if (!ctx.funcMap.has(funcName) || reservedEntry) {
         // Save state so we can roll back if compilation fails
         const errorsBefore = ctx.errors.length;
-        const funcsBefore = ctx.mod.functions.length;
 
         compileNestedFunctionDeclaration(ctx, fctx, stmt, reservedEntry ? { reuseReservedEntry: reservedEntry } : {});
 
         // If new errors were added during hoisting, roll back
         if (ctx.errors.length > errorsBefore) {
           ctx.errors.length = errorsBefore;
-          ctx.mod.functions.length = funcsBefore;
+          // (#2029 function-index cluster) DO NOT truncate `ctx.mod.functions`
+          // back to `funcsBefore`. The failed nested compile pushed its OWN
+          // partially-built funcs AND — as a SIDE EFFECT — module-level runtime
+          // helpers it pulled in (`ensureObjectRuntime` registers
+          // `__extern_method_call` / `__apply_closure` / the `__proxy_*`
+          // dispatchers + their string/number/union dependencies;
+          // `ensureObjVecBuilders` / iterator-native / array-to-primitive
+          // likewise). Those helpers are recorded in `ctx.funcMap` (and gate
+          // `objectRuntimeTypes` / `ensureProxyRuntime`'s `funcMap.has(...)`),
+          // and they are perfectly VALID — content-addressed, idempotent, and
+          // potentially needed by later real code. A blanket
+          // `mod.functions.length = funcsBefore` removed them from the table while
+          // leaving their funcMap entries (and the registration latches) intact,
+          // so a later call site that re-needed the runtime found the guards
+          // already satisfied, SKIPPED re-registration, and baked the now-stale
+          // funcIdx into a dispatcher body (`fillClosedMethodDispatch` →
+          // `call 136` into a 129-func module → "function index out of range").
+          // Re-registering after a purge is fragile too: the runtime's own deps
+          // (`number_toString`, native-string helpers, union boxes) have separate
+          // latches that would also need resetting, in dependency order.
+          //
+          // Instead, keep every pushed func and neutralise ONLY the failed user
+          // function's own entry to a valid stub. The helpers stay in the table at
+          // their registered indices (funcMap consistent); the failed function
+          // becomes an unreferenced dead stub (locals are never DCE'd, so it must
+          // be a VALID body — `unreachable` satisfies any result type). Dropping
+          // its funcMap name lets `compileStatement` re-compile it at its real
+          // textual position (where captures are in scope), exactly as the
+          // pre-existing `hoistFailedFuncs` re-attempt intends.
+          const failedIdx = ctx.funcMap.get(funcName);
+          const failedEntry = failedIdx !== undefined ? ctx.mod.functions[failedIdx - ctx.numImportFuncs] : undefined;
           if (reservedEntry) {
             reservedEntry.locals = [];
-            reservedEntry.body = [];
+            reservedEntry.body = [{ op: "unreachable" } as Instr];
           } else {
+            if (failedEntry) {
+              failedEntry.locals = [];
+              failedEntry.body = [{ op: "unreachable" } as Instr];
+            }
             ctx.funcMap.delete(funcName);
             ctx.nestedFuncCaptures.delete(funcName);
             ctx.funcOptionalParams.delete(funcName);

--- a/tests/issue-2029-nested-hoist-funcidx-standalone.test.ts
+++ b/tests/issue-2029-nested-hoist-funcidx-standalone.test.ts
@@ -1,0 +1,113 @@
+// #2029 (function-index sub-bucket) — a FAILED nested-function hoist must not
+// strand the module-level runtime helpers it pulled in as a side effect, or a
+// later any-receiver method dispatch bakes a stale funcIdx → the
+// "function index out of range" emit crash.
+//
+// Root cause (traced on the `built-ins/Array/prototype/toLocaleString/
+// user-provided-tolocalestring-grow.js` repro, `call 136` into a 129-func
+// module): under `--target standalone`, the function-hoist pre-pass compiles a
+// nested `function` declaration. When that body contains a standalone-unsupported
+// op (e.g. `[].toLocaleString()` → `__extern_toLocaleString` reportError) AND has
+// already pulled in the object runtime (`ensureObjectRuntime` registers
+// `__extern_method_call` / `__apply_closure` / the `__proxy_*` dispatchers + their
+// string/number/union deps), the hoist rolled back by truncating
+// `ctx.mod.functions` back to its pre-compile length — removing those VALID,
+// content-addressed helpers from the table while leaving their `ctx.funcMap`
+// entries (and the `objectRuntimeTypes` / `ensureProxyRuntime` `funcMap.has`
+// guards) intact. A later any-receiver method call (`o.resize(n)` → the reserved
+// `__call_m_resize_1` closed-struct dispatcher) then found the guards already
+// satisfied, SKIPPED re-registering the runtime, and `fillClosedMethodDispatch`
+// baked the now-stale helper funcIdx (136) past the shrunken table.
+//
+// Fix (`nested-declarations.ts`): on a failed hoist, DO NOT truncate
+// `ctx.mod.functions`. Keep every pushed func (the side-effect helpers are valid
+// and possibly needed later) and neutralise ONLY the failed user function's own
+// entry to a valid `unreachable` stub, dropping its funcMap name so
+// `compileStatement` re-compiles it at its real textual position. funcMap and the
+// table stay in lockstep, so no dispatcher bakes a stale index.
+//
+// Acceptance: the shapes below COMPILE standalone with no "function index out of
+// range" / "Binary emit error"; gc/host mode is unaffected.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileStandalone(src: string) {
+  return (await compile(src, { target: "standalone", skipSemanticDiagnostics: true })) as any;
+}
+
+function noEmitCrash(r: any): void {
+  // The defining failure of this sub-bucket is the encoder RangeError surfaced as
+  // a compile error whose message contains "index out of range" / "Binary emit
+  // error". A clean located refusal (reportError) is acceptable — NOT an emit
+  // crash. Assert specifically that no emit-crash message is present.
+  const msgs: string[] = (r.errors ?? []).map((e: any) => e.message);
+  expect(msgs.some((m) => /index out of range|Binary emit error/.test(m))).toBe(false);
+}
+
+describe("#2029 — failed nested-hoist must not strand object-runtime helpers (standalone funcIdx)", () => {
+  it("nested fn whose hoist fails (object-runtime side effect) + any-receiver method dispatch compiles", async () => {
+    // `inner` pulls in the object runtime via `['',''].toLocaleString()` (a
+    // standalone-unsupported op → its hoist fails and rolls back). The later
+    // any-receiver `o.resize(2)` reserves the `__call_m_resize_1` dispatcher whose
+    // fill must resolve against the still-registered object-runtime helpers.
+    const r = await compileStandalone(
+      `export function test(): number {
+         function inner(list: any): string {
+           const comma = ['', ''].toLocaleString();
+           return list[0] + comma;
+         }
+         const o: any = { resize(n: number) { return n + 1; } };
+         const r = o.resize(2) as number;
+         if (r < 0) { inner([1]); }
+         return r;
+       }`,
+    );
+    // Pre-fix: `Binary emit error: ... function index out of range — 136`.
+    noEmitCrash(r);
+    expect(r.success).toBe(true);
+  });
+
+  it("the test262 toLocaleString grow shape compiles standalone (was: `call 136` emit crash)", async () => {
+    // Mirrors `built-ins/Array/prototype/toLocaleString/
+    // user-provided-tolocalestring-grow.js` — a `listToString` helper (array
+    // toLocaleString inside) whose hoist fails, alongside `rab.resize(...)` (the
+    // any-receiver method call that reserves `__call_m_resize_1`).
+    const r = await compileStandalone(
+      `export function test(): number {
+         function listToString(list: any): string {
+           const comma = ['', ''].toLocaleString();
+           const len = list.length;
+           let result = '';
+           for (let i = 0; i < len - 1; i++) { result += list[i] + comma; }
+           if (len > 0) { result += list[len - 1]; }
+           return result;
+         }
+         const rab: any = { resize(n: number) { return n; } };
+         rab.resize(6);
+         if (rab.resize(0) < 0) { listToString([0, 0]); }
+         return 1;
+       }`,
+    );
+    noEmitCrash(r);
+    expect(r.success).toBe(true);
+  });
+
+  it("gc/host mode is unaffected (no regression) — same shape compiles", async () => {
+    // The fix path is reached in every mode (the truncation lived in the
+    // mode-agnostic hoist), but the object-runtime helpers + closed-method
+    // dispatcher are standalone-only, so gc/host never hit the stale-index crash.
+    // Assert the shape still compiles cleanly in the default (gc/host) target.
+    const r = (await compile(
+      `export function test(): number {
+         function inner(list: any): string { return ('' + list[0]); }
+         const o: any = { resize(n: number) { return n + 1; } };
+         const r = o.resize(2) as number;
+         if (r < 0) { inner([1]); }
+         return r;
+       }`,
+      { skipSemanticDiagnostics: true },
+    )) as any;
+    noEmitCrash(r);
+    expect(r.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## #2029 — function-index sub-bucket (standalone emit crash)

Fixes the characterized `function index out of range — 136` standalone emit crash
(`built-ins/{Array,TypedArray}/prototype/toLocaleString/user-provided-tolocalestring-*`,
`__call_m_resize_1` baking `call 136` into a 129-func module).

### Root cause (traced per-process — NOT dead-elimination)

A FAILED nested-`function`-declaration hoist (`hoistFunctionDeclarations`,
`nested-declarations.ts`) rolled back by truncating `ctx.mod.functions` back to
its pre-compile length. The failed body (`listToString`, which hits the
standalone-unsupported `[].toLocaleString()` → `reportError`) had pulled in the
**entire object runtime** as a side effect (`__extern_method_call` /
`__apply_closure` / the `__proxy_*` dispatchers + their string/number/union
deps). The bare truncation removed those VALID helpers from the table while
leaving their `funcMap` entries — and the `objectRuntimeTypes` /
`ensureProxyRuntime` (`funcMap.has`) guards — intact. A later any-receiver
`rab.resize(...)` reserved `__call_m_resize_1`; `ensureObjectRuntime` found the
guard satisfied, SKIPPED re-registration, and `fillClosedMethodDispatch` baked
the now-stale funcIdx (136) past the shrunken table.

A new instance of `project_type_index_shift_and_deadelim`'s sibling for the
**local function table** — the #1919 `speculative.ts` transaction covers
expression probes, but this older hoist rollback truncated `mod.functions`
without the matching side-table unwind.

### Fix

On a failed hoist, do **not** truncate `ctx.mod.functions`. Keep every pushed
func (the side-effect helpers are valid/idempotent/possibly-needed) and
neutralise only the failed user function's own entry to a valid `unreachable`
stub (local funcs are never dead-eliminated, so a leftover must be valid Wasm),
dropping its funcMap name so `compileStatement` re-compiles it at its real
textual position. funcMap and the table stay in lockstep → no stale-index bake.
Standalone-only in effect (the stranded helpers + dispatcher are standalone-only);
gc/host untouched. Surgical: one file, 36/−3.

(Rejected the "purge funcMap + reset `objectRuntimeTypes` → re-register"
alternative — the runtime's own deps have separate latches that would need
resetting in dependency order; a re-register-after-purge crashed with
`function index out of range — undefined at __to_property_key`.)

### Row-delta (paired scan, my branch vs pristine)

- `built-ins/{Array,TypedArray}/prototype/toLocaleString`: **5 → 0** function-index
  emit-crashes (now reach a downstream `__closure_5` instantiate type-mismatch /
  `Cannot convert object to primitive` — SEPARATE bugs, not emit crashes).
- optional-chaining: 0 funcidx crashes on both (`member-expression-async-this`
  PASSES).
- No regressions (annexB RegExp generator funcidx producer is separate +
  pre-existing — identical on pristine).

### Validation

- New `tests/issue-2029-nested-hoist-funcidx-standalone.test.ts` (3/3) — **proven
  to FAIL on pristine** (2 standalone cases emit-crash) and PASS here, + gc-mode
  no-regression control.
- Hoist/closure/#2029 suites: 59/59 tests pass (matches pristine). #2151 / #2015 /
  #2038 / generator / standalone-coercion batch green.
- tsc clean, biome lint clean (error level), prettier clean, speculative-rollback
  gate clean.
- Broad emit-path change → relying on the merge_group test262 floor for full
  conformance.

### Residual (separate producers, NOT this PR)

- annexB RegExp `function* …()` generator funcidx-`undefined` (2) — distinct
  native-generator producer, pre-existing.
- global-index regexp-replacer (2) + property-accessor (1); for-of/iterator-next
  local-index (1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)