### PR TITLE
test(#2674): worker-thread watchdog probe harness + localize the acorn 9th wall

### DIFF
--- a/plan/issues/2674-acorn-parse-9th-wall-past-tokenizer.md
+++ b/plan/issues/2674-acorn-parse-9th-wall-past-tokenizer.md
@@ -1,0 +1,163 @@
+---
+id: 2674
+title: "acorn parse() 9th wall PAST tokenization (after #2664 type-write fix) — parseTopLevel/parseStatement array-push loop"
+status: in-progress
+assignee: ttraenkler/sd-2038
+sprint: 66
+created: 2026-06-25
+updated: 2026-06-25
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: unknown
+goal: acorn-dogfood
+related: [1712, 2664, 2659, 2656, 2655, 2608, 2582]
+depends_on: [2664]
+origin: "Surfaced by sd-2038 fixing #2664 (PR #2064): the 8th-wall type-write asymmetry (finishToken's this.type= leaking to the sidecar) is FIXED via the deferred-fill __set_member_<name> dispatcher (WAT-proven 44→90 complete chain, instance type 90 now hits the slot). But full parse(\"var x = 1;\") STILL does not return — it blocks SYNCHRONOUSLY at a NEW, distinct wall PAST tokenization."
+---
+
+# #2674 — acorn `parse()` 9th wall past tokenization
+
+## Context (the acorn dogfood chain, layer by layer toward the AST)
+
+Prior dogfood blockers cleared: #1712 b1-3, #2582, #2608, #2655/#2659
+(member-write struct-slot), #2656 (`++this.field` write-drop), #2664 (the 8th
+wall — `this.type =` write leaking to the sidecar via a compile-order-frozen
+single-candidate dispatch; fixed by the deferred-fill `__set_member_<name>`
+dispatcher in PR #2064).
+
+## What we know (verify-first, sd-2038)
+
+- The #2664 **type-write asymmetry is FIXED** (must re-confirm on NEW main once
+  #2064 merges): WAT-proven `$__set_member_type` now carries the COMPLETE
+  candidate chain (`ref.test 44 → struct.set 44 11` else `ref.test 90 → struct.set
+  90 11` else 165/204/230…), called from 19 sites; the Parser instance is type 90,
+  so the write now hits the slot. Reduced repro round-trips.
+- BUT full `parse("var x = 1;")` STILL does not return. The wasm `parse` call
+  **blocks the JS event loop SYNCHRONOUSLY** (a `setInterval` watchdog never
+  fired), so the non-termination is in a TIGHT in-Wasm loop PAST tokenization
+  (the type-write fix moved the wall deeper — the tokenizer now produces `semi`
+  etc.). This is NOT the #2664 type-write and NOT a regression.
+
+## Blocker 0 — PROBE HARNESS LIMITATION (solve first)
+
+The in-Wasm-method runtime probe is currently blocked:
+- `wrapExports` (src/runtime.ts:12902) marshals a struct RETURN to a plain JS
+  object of FIELD values — it does NOT bind the struct's prototype METHODS as
+  callable. So `tokenizer("1;").nextToken()` fails (`nextToken is not a
+  function`): the returned Parser exposes `pos`/`type`/`value`… fields but no
+  callable methods (methods are in-Wasm dynamic dispatch, not struct fields).
+- The top-level `parse` EXPORT is directly callable (the harness uses it), but it
+  blocks synchronously, so a same-thread watchdog can't bound it or snapshot a
+  mid-hang host-call signature.
+
+**Fix the harness first (durable, helps all future acorn-chain localization):**
+- (a) Run the wasm `parse`/method call in a **Worker thread** with a watchdog
+  that terminates the worker after N ms — bounds the synchronous loop AND lets a
+  host-import call-counter snapshot the loop signature before kill; OR
+- (b) Extend `wrapExports` / the dogfood harness to expose CALLABLE in-Wasm
+  methods on a returned struct (a method-dispatch bridge over `__call_fn_method_N`
+  / the closed-method dispatcher), so `tokenizer(src).nextToken()` /
+  `.getToken()` drive the in-Wasm tokenizer step-by-step.
+
+Bank whichever lands as a reusable dogfood-probe utility.
+
+## Localization plan (after #2064 merges — re-probe on NEW main, verify-first)
+
+1. Confirm the #2664 type-write fix is in (sibling PRs move the path).
+2. With the harness fix, drive the tokenizer to EOF on `"var x = 1;"` and confirm
+   `this.type` now reaches `eof` (the #2664 symptom was `num`/`semi` frozen).
+3. If tokenization completes, the 9th wall is in the PARSER (parseTopLevel /
+   parseStatement / parseVarStatement / eat / expect / next). Use the #2656/#2664
+   method: incremental `stepN` count probes + piece-isolation + WAT decode of the
+   pinned function under a watchdog.
+4. Candidate suspects (do NOT assume — verify): a `this.next()`/`eat`/`expect`
+   not consuming a token (read/write-asymmetry on a DIFFERENT field —
+   `this.start`/`this.end`/`this.lastTokEnd`/`this.lastTokStart` — possibly the
+   SAME dual-struct-type or sidecar class #2664 fixed for `this.type`, now needed
+   for another field); a token-type singleton `===` identity at a deeper switch;
+   or the eof-token guard never tripping at true end-of-input.
+
+## Read-side latent note (from #2664, not yet needed)
+
+The member-READ multi-struct dispatch (`findAlternateStructsForField` inline at
+property-access.ts:1400/1678/4872) has the SAME compile-order enumeration as the
+write had pre-#2664. Reads happen to compile late enough today, but if a deeper
+wall turns out to be an early-frozen READ candidate set, apply the same
+deferred-fill treatment (a `__get_member_<name>` dispatcher mirroring #2664's
+`__set_member_<name>`).
+
+## Acceptance
+
+- Localize (verify-first, watchdog-bounded) the exact construct where
+  compiled-acorn `parse("var x = 1;")` now fails to terminate, with a reduced
+  repro where practical.
+- Fix it (or carve a precise sub-issue if it splits further).
+- Compiled-acorn `parse("var x = 1;")` returns a `Program` AST → the #1712
+  differential-AST gate becomes runnable on the first fixture.
+- Full merge_group / test262 (any codegen change here is broad-impact).
+
+## BLOCKER-0 RESOLVED (2026-06-25, sd-2038) — worker-thread watchdog probe harness landed
+
+Built the reusable dogfood probe harness (the BLOCKER-0 the same-thread watchdog
+could not solve):
+- `tests/dogfood/probe-worker.mjs` — compiles + instantiates + runs an acorn
+  entry point INSIDE a worker thread (the parent can terminate it on a hang; a
+  synchronous Wasm loop blocks the event loop so setTimeout can't). It wraps every
+  host import with a **SharedArrayBuffer**-backed call counter — the import
+  closures run DURING the in-Wasm loop, so even though the worker's own JS timers
+  are starved, the PARENT reads the live SAB counts and reports the loop's
+  host-call signature before terminating.
+- `tests/dogfood/probe-driver.mjs` — parent: spawns the worker (propagating the
+  tsx loader flags from `process.execArgv` so the worker can import the .ts
+  compiler), arms the watchdog only for the RUN phase (not the ~100s compile), and
+  on a hang prints the top host-call signature. Reusable `probe({source, call,
+  args, watchdogMs})` export + a CLI that drives the PINNED acorn entry.
+  Usage: `npx tsx tests/dogfood/probe-driver.mjs 'var x = 1;' parse 20000`.
+
+Validated: a trivial `export function parse(s){…}` returns `{status:"ok", result:
+{type:"Program", bodyLen:0}}`; acorn `parse("var x = 1;")` returns
+`{status:"hang", signature:[…]}` with the loop fingerprint.
+
+## 9th WALL LOCALIZED (2026-06-25, sd-2038) — parseTopLevel/parseStatement array-push loop
+
+Ran the harness against **merged-main WITH the #2664 type-write fix** (confirmed
+`fillMemberSetDispatch` present). `parse("var x = 1;")` STILL hangs (the #2664 fix
+moved the wall deeper, as expected — NOT a regression). The host-call signature
+over the bounded hang window:
+
+| host import | calls (~) |
+|---|---:|
+| `__js_array_push` | 166,229 |
+| `__js_array_new` | 124,671 |
+| `__extern_method_call` | 124,650 |
+| `__box_number` | 62,403 |
+| `__register_fnctor_instance` | 20,857 |
+| `__host_compare` | 20,812 |
+| `__box_boolean` | 20,802 |
+
+**Reading:** a tight loop that, each iteration, calls a method via
+`__extern_method_call` (124k) which `__js_array_new` + `__js_array_push`es (166k)
+and boxes numbers (62k) — i.e. the parser is **re-running a statement-parse that
+appends to an array forever without consuming input**. In acorn's
+`parseTopLevel`, `while (this.type !== eof) { node.body.push(this.parseStatement(…)) }`
+appends to `body`; if `parseStatement` (→ `parseVarStatement` → `expect`/`eat` →
+`this.next()`) fails to advance the token, the loop appends forever — matching the
+`__js_array_push`-dominated signature. (`__extern_method_call` 124k ≈ the
+any-receiver method dispatch for `this.parseX()` / `this.next()`; `__box_number`
+the numeric field math.)
+
+**Next (re-localize on merged-main, verify-first):** narrow within the parser —
+incremental probes on `parseTopLevel` / `parseStatement` / `parseVarStatement` /
+`eat` / `expect` / `next`. Prime suspect (do NOT assume — verify with the same
+WAT + harness method that cracked #2664): a `this.next()` / `eat` / `expect` whose
+field WRITE (e.g. `this.start`/`this.end`/`this.lastTokStart`/`this.lastTokEnd`)
+does NOT advance — possibly the SAME dual-struct-type / sidecar class #2664 fixed
+for `this.type`, now needed for another Parser field, OR a token-type `===`
+identity at a deeper switch that never matches so `next()` is never called. The
+#2664 `__set_member_<name>` dispatcher already covers ALL field writes generically,
+so if it IS another field-write asymmetry it may already be fixed by #2664 for that
+field too — re-probe to see WHICH field's read/write now diverges (or whether it's
+a token-identity / control-flow loop instead).

--- a/plan/issues/2674-acorn-parse-9th-wall-past-tokenizer.md
+++ b/plan/issues/2674-acorn-parse-9th-wall-past-tokenizer.md
@@ -161,3 +161,29 @@ identity at a deeper switch that never matches so `next()` is never called. The
 so if it IS another field-write asymmetry it may already be fixed by #2664 for that
 field too — re-probe to see WHICH field's read/write now diverges (or whether it's
 a token-identity / control-flow loop instead).
+
+## BISECT NARROWED (2026-06-25, sd-2038) — empty input PARSES; wall is in statement-parse
+
+Decisive datapoint via the harness on merged-main (with #2664): **`parse("")`
+returns `{type:"Program", bodyLen:0}` in 19ms** — a valid, EMPTY Program AST. So
+the full entry chain WORKS for empty input: `Parser.parse` → `new this(...).parse()`
+→ `parseTopLevel` correctly sees `this.type === eof` immediately and returns the
+Program. (This also means the harness end-to-end is sound and the AST marshalling
+works — the #1712 differential gate is RUNNABLE the moment a non-empty statement
+parses.)
+
+Therefore the 9th wall is **specifically in the statement-parse path**
+(`parseStatement` / `parseVarStatement` and the `next`/`eat`/`expect` it drives),
+NOT in `parseTopLevel`'s loop/eof-guard or the entry machinery — those are proven
+working by the empty-input pass. For `var x = 1;` the parser enters
+`parseStatement`, fails to consume the `var` token (the `__js_array_push` 166k
+loop = `parseTopLevel` re-appending a never-advancing statement), and spins.
+
+**Next probe (verify-first):** bisect statement shapes — `parse(";")` (empty
+statement, exercises `parseStatement`'s `semi` case → `this.next()`), `parse("1")`
+(bare expression-statement), `parse("1;")` — to pin whether `next()`/`eat()` after
+the FIRST token advances. Then WAT-decode `parseStatement`/`next` and check the
+specific field read/write (`this.start`/`this.end`/`this.lastTokStart`/
+`this.lastTokEnd`) or the token-type `switch` dispatch, the same way #2664's
+`this.type` was cracked. (A single-compile multi-input probe variant of the
+harness would avoid the per-input recompile — a worthwhile harness follow-up.)

--- a/tests/dogfood/probe-driver.mjs
+++ b/tests/dogfood/probe-driver.mjs
@@ -1,0 +1,104 @@
+// Dogfood probe DRIVER (#2674) — parent side of the worker-thread watchdog probe.
+//
+// Runs a compiled-acorn entry point (`parse` by default) in probe-worker.mjs and:
+//   - on success, prints the returned AST summary + timing;
+//   - on a HANG (synchronous in-Wasm infinite loop), terminates the worker after
+//     the watchdog budget and prints the live host-call SIGNATURE read from the
+//     SharedArrayBuffer (which host import the loop is hammering — the localization
+//     fingerprint the same-thread watchdog could never capture).
+//
+// Usage (via tsx so the worker can import the TS compiler):
+//   node --import tsx tests/dogfood/probe-driver.mjs '<source>' [callName] [watchdogMs]
+// or set PROBE_SRC / PROBE_CALL / PROBE_WATCHDOG_MS / PROBE_ARGS_JSON env vars.
+import { Worker } from "node:worker_threads";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+export async function probe({ source, fileName, call = "parse", args = [], watchdogMs = 15000, sabSlots = 512 }) {
+  const sab = new SharedArrayBuffer(sabSlots * 4);
+  const counts = new Int32Array(sab);
+  let keys = [];
+  // Propagate the parent's tsx loader flags (`--require …/preflight.cjs`,
+  // `--import …/loader.mjs`) so the worker can import the .ts compiler. The
+  // driver runs under `npx tsx`, whose loader paths live in process.execArgv;
+  // forward only the tsx-loader flags (drop --eval/script args).
+  const tsxArgv = [];
+  for (let i = 0; i < process.execArgv.length; i++) {
+    const a = process.execArgv[i];
+    if ((a === "--require" || a === "--import") && /tsx\//.test(process.execArgv[i + 1] ?? "")) {
+      tsxArgv.push(a, process.execArgv[i + 1]);
+      i++;
+    }
+  }
+  const worker = new Worker(join(HERE, "probe-worker.mjs"), {
+    workerData: { source, fileName, call, args, sab },
+    execArgv: tsxArgv,
+  });
+
+  const topSignature = () =>
+    [...counts]
+      .map((c, i) => [keys[i] ?? `slot${i}`, c])
+      .filter(([, c]) => c > 0)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 12);
+
+  return await new Promise((resolve) => {
+    let compiled = false;
+    let watchdog = null;
+    const armWatchdog = () => {
+      watchdog = setTimeout(() => {
+        const sig = topSignature();
+        worker.terminate();
+        resolve({ status: "hang", watchdogMs, signature: sig });
+      }, watchdogMs);
+      watchdog.unref?.();
+    };
+    worker.on("message", (m) => {
+      if (m.kind === "keys") keys = m.keys;
+      else if (m.kind === "compiled") {
+        compiled = true;
+        armWatchdog(); // start the watchdog only for the RUN phase, not compile
+      } else if (m.kind === "done") {
+        if (watchdog) clearTimeout(watchdog);
+        worker.terminate();
+        resolve({ status: "ok", ms: m.ms, result: m.result, signature: topSignature() });
+      } else if (m.kind === "error") {
+        if (watchdog) clearTimeout(watchdog);
+        worker.terminate();
+        resolve({ status: "error", phase: m.phase, message: m.message, signature: topSignature() });
+      }
+    });
+    worker.on("error", (e) => {
+      if (watchdog) clearTimeout(watchdog);
+      resolve({ status: "error", phase: "worker", message: String(e?.message ?? e), signature: topSignature() });
+    });
+    worker.on("exit", (code) => {
+      if (!compiled) resolve({ status: "error", phase: "worker-exit", message: `exit ${code} before compile` });
+    });
+  });
+}
+
+// CLI entry — drives the PINNED acorn entry module (the dogfood subject) and
+// parses the given input under the watchdog.
+//   node --import tsx tests/dogfood/probe-driver.mjs '<jsInput>' [call] [watchdogMs]
+//   e.g. node --import tsx tests/dogfood/probe-driver.mjs 'var x = 1;' parse 15000
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const input = process.argv[2] ?? process.env.PROBE_INPUT ?? "var x = 1;";
+  const call = process.argv[3] ?? process.env.PROBE_CALL ?? "parse";
+  const watchdogMs = Number(process.argv[4] ?? process.env.PROBE_WATCHDOG_MS ?? 15000);
+  const { readFileSync } = await import("node:fs");
+  const { setupAcorn } = await import("./setup-acorn.mjs");
+  const { entryModulePath } = setupAcorn();
+  const acornSource = readFileSync(entryModulePath, "utf-8");
+  console.error(`[probe] compiling acorn + running ${call}(${JSON.stringify(input)}) with ${watchdogMs}ms watchdog…`);
+  const res = await probe({
+    source: acornSource,
+    fileName: "acorn.mjs",
+    call,
+    args: [input, { ecmaVersion: 2020 }],
+    watchdogMs,
+  });
+  console.log(JSON.stringify(res, null, 2));
+}

--- a/tests/dogfood/probe-worker.mjs
+++ b/tests/dogfood/probe-worker.mjs
@@ -1,0 +1,96 @@
+// Dogfood probe WORKER (#2674) — compiles + runs a compiled-acorn entry point in
+// an ISOLATED worker thread so the parent can terminate it when the in-Wasm call
+// hangs. A synchronous Wasm infinite loop blocks the event loop, so a same-thread
+// setTimeout watchdog can NEVER fire (the reason the #2664 / 9th-wall hang could
+// not be bounded or signature-sampled before).
+//
+// Host-call signature via SharedArrayBuffer: every host import is wrapped to
+// increment a per-import counter in a SAB. The import closures run DURING the
+// in-Wasm loop (each loop iteration that calls a host import bumps a counter), so
+// even though the worker's own JS timers are STARVED by the synchronous call, the
+// PARENT thread reads the live SAB counts and — on a hang — terminates the worker
+// and reports the top counters. That signature (which import is hammered, e.g.
+// `__extern_get("type")` vs `__extern_set`) localizes the wall, bounded, the same
+// way the #2656/#2664 host-call-count probes did.
+//
+// Protocol (workerData):
+//   { source, fileName, call, args, sab }  — sab = SharedArrayBuffer (Int32Array)
+// Worker posts:
+//   { kind: "keys", keys: string[] }       — SAB slot i ↔ keys[i] (host import name)
+//   { kind: "compiled", ms }
+//   { kind: "done", ms, result }
+//   { kind: "error", phase, message }
+// The parent (probe-driver.mjs) spawns this worker with the tsx loader flags in
+// execArgv, so static .ts imports resolve.
+import { parentPort, workerData } from "node:worker_threads";
+import { compile } from "../../src/index.ts";
+import { wrapExports } from "../../src/runtime.ts";
+
+process.on("unhandledRejection", () => {});
+
+async function main() {
+  const { source, fileName, call, args, sab } = workerData;
+  const counts = new Int32Array(sab);
+  const t0 = Date.now();
+  const r = await compile(source, { fileName: fileName ?? "probe.mjs" });
+  if (!r.success) {
+    parentPort.postMessage({
+      kind: "error",
+      phase: "compile",
+      message: (r.errors ?? [])
+        .map((e) => e.message)
+        .slice(0, 5)
+        .join(" | "),
+    });
+    return;
+  }
+  parentPort.postMessage({ kind: "compiled", ms: Date.now() - t0 });
+
+  // Wrap every host import with a SAB-backed counter BEFORE instantiation.
+  const io = r.importObject ?? {};
+  const keys = [];
+  for (const ns of Object.keys(io)) {
+    const mod = io[ns];
+    if (!mod || typeof mod !== "object") continue;
+    for (const fn of Object.keys(mod)) {
+      const orig = mod[fn];
+      if (typeof orig !== "function") continue;
+      const slot = keys.length;
+      if (slot >= counts.length) continue; // SAB full — skip extras
+      keys.push(`${ns}.${fn}`);
+      mod[fn] = function instrumented(...a) {
+        Atomics.add(counts, slot, 1);
+        return orig.apply(this, a);
+      };
+    }
+  }
+  parentPort.postMessage({ kind: "keys", keys });
+
+  let instance;
+  try {
+    ({ instance } = await WebAssembly.instantiate(r.binary, io));
+    io.__setExports?.(instance.exports);
+  } catch (e) {
+    parentPort.postMessage({ kind: "error", phase: "instantiate", message: String(e?.message ?? e) });
+    return;
+  }
+  const exp = wrapExports(instance.exports, { signatures: r.exportSignatures });
+
+  const callName = call ?? "parse";
+  const fn = exp[callName];
+  if (typeof fn !== "function") {
+    parentPort.postMessage({ kind: "error", phase: "run", message: `export '${callName}' is not callable` });
+    return;
+  }
+  const tCall = Date.now();
+  const result = fn(...(args ?? [])); // BLOCKS here on a hang; parent terminates us.
+  const summary =
+    result && typeof result === "object"
+      ? { type: result.type, bodyLen: Array.isArray(result.body) ? result.body.length : undefined }
+      : result;
+  parentPort.postMessage({ kind: "done", ms: Date.now() - tCall, result: summary });
+}
+
+main().catch((e) => {
+  parentPort.postMessage({ kind: "error", phase: "run", message: String(e?.message ?? e), stack: e?.stack });
+});


### PR DESCRIPTION
## What

Reusable dogfood **probe harness** that bounds and fingerprints a synchronous
in-Wasm hang — the BLOCKER-0 that prevented localizing the acorn `parse()` hang —
plus the resulting **localization** of the 9th acorn dogfood wall (recorded in the
#2674 issue).

Docs / test-infra only — **no compiler source change.**

## Why the harness was needed

A synchronous Wasm infinite loop blocks the JS event loop, so a same-thread
`setTimeout` watchdog can NEVER fire (it couldn't bound the hang or sample a
mid-hang signature). And `wrapExports` marshals a struct return to a fields-only
object (no callable methods), so `tokenizer().nextToken()` can't drive the
tokenizer from JS.

## Harness

- `tests/dogfood/probe-worker.mjs` — compiles + instantiates + runs an acorn entry
  in a **worker thread** the parent can terminate on a hang. Wraps every host
  import with a **SharedArrayBuffer**-backed call counter; the import closures run
  DURING the in-Wasm loop, so the PARENT reads the live SAB counts and reports the
  loop's host-call signature even though the worker's own timers are starved.
- `tests/dogfood/probe-driver.mjs` — parent: spawns the worker (propagating the
  tsx loader flags so it can import the .ts compiler), arms the watchdog only for
  the RUN phase (not the ~100s compile), prints the top host-call signature on a
  hang. Reusable `probe({source, call, args, watchdogMs})` export + a CLI driving
  the pinned acorn entry: `npx tsx tests/dogfood/probe-driver.mjs 'var x = 1;' parse 20000`.

Validated: a trivial `export function parse(s){…}` → `{status:"ok", result:
{type:"Program", bodyLen:0}}`; acorn `parse("var x = 1;")` → `{status:"hang",
signature:[…]}`.

## 9th-wall localization (run on merged-main WITH the #2664 fix)

`parse("var x = 1;")` STILL hangs (the #2664 type-write fix moved the wall deeper
— NOT a regression). Signature: `__js_array_push` 166k / `__js_array_new` 124k /
`__extern_method_call` 124k / `__box_number` 62k — a tight loop re-running a
statement-parse that appends to an array forever without consuming input
(`parseTopLevel`'s `while(this.type!==eof){ body.push(parseStatement()) }` where
`next`/`eat`/`expect` never advances the token). Next-step suspects + plan recorded
in `plan/issues/2674-...md`; localization continues on #2674.

🤖 Generated with [Claude Code](https://claude.com/claude-code)