### PR TITLE
fix(#2667): mapped-arguments non-configurable/non-writable + delete semantics

### DIFF
--- a/plan/issues/2667-es3-mapped-arguments-nonconfigurable-delete-residual.md
+++ b/plan/issues/2667-es3-mapped-arguments-nonconfigurable-delete-residual.md
@@ -1,9 +1,11 @@
 ---
 id: 2667
 title: "≤ES3: mapped arguments object — non-configurable/non-writable property + [[Delete]] semantics (residual of #1511)"
-status: ready
+status: done
+assignee: ttraenkler/dev-es3
 created: 2026-06-25
 updated: 2026-06-25
+completed: 2026-06-25
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -13,7 +15,7 @@ es_edition: 0
 language_feature: arguments-object
 goal: spec-completeness
 depends_on: []
-related: [1511]
+related: [1511, 2676]
 sprint: 66
 ---
 # #2667 — ≤ES3 mapped-arguments non-configurable/non-writable + delete residual
@@ -77,3 +79,47 @@ argumentsAndDelete(1);
 
 - Builds on #1511. The fix is in the mapped-arguments exotic-object [[Delete]] /
   [[DefineOwnProperty]] implementation (configurability check before unmap).
+
+## Resolution (2026-06-25)
+
+The WasmGC-vec-backed mapped `arguments` object never modelled the
+configurability/writability of its own index properties — `delete arguments[i]`
+returned `true` even for a non-configurable index, and
+`Object.defineProperty(arguments,"i",{value})` routed to the runtime
+`Object.defineProperty` on the vec (which carries no matching sidecar
+descriptor) and threw `Cannot redefine property: 0`.
+
+Fixed by tracking per-index attribute state **at compile time** in
+`fctx.mappedArgsInfo`, mirroring the existing `unmappedIndices` link-break set
+(§10.4.4):
+
+- `nonConfigurableIndices` — `delete arguments[i]` on such an index emits the
+  spec `false` (OrdinaryDelete) without severing the param map
+  (`src/codegen/typeof-delete.ts`).
+- `nonWritableIndices` — `arguments[i] = x` on such an index is dropped
+  (`src/codegen/expressions/assignment.ts`); also severs the param map.
+- A pure-data `{value}` define on a still-configurable-or-writable mapped index
+  is handled inline (`emitMappedArgValueDefine` in `src/codegen/object-ops.ts`):
+  writes the vec slot and, when still mapped, the linked formal param. Truly
+  frozen (non-configurable AND non-writable) slots fall through to the runtime
+  for the spec TypeError.
+
+These are populated by the statically-resolvable
+`Object.defineProperty(arguments, "<literal>", {literal desc})` shape and read
+live during body codegen (codegen order matters), exactly like `unmappedIndices`.
+
+## Test Results (real test262 runner, `language/arguments-object/mapped`)
+
+8 of the 12 listed cases now pass:
+`mapped-arguments-nonconfigurable-delete-1..4`,
+`mapped-arguments-nonconfigurable-3`,
+`mapped-arguments-nonwritable-nonconfigurable-3` / `-4`,
+`mapped-arguments-nonconfigurable-nonwritable-5`.
+Category: 34 pass / 9 fail (was 26 pass). Covered by `tests/issue-2667.test.ts`.
+
+**Carved out → #2676**: `mapped-arguments-nonconfigurable-strict-delete-1..4`
+(4 tests). These do `var args = arguments; (function(){ "use strict"; delete
+args[0]; })` — an *aliased* delete inside a *nested strict* function that must
+throw a TypeError on a non-configurable index. That needs cross-function alias
+tracking plus strict-mode delete-throws, a distinct and larger sub-problem than
+the static per-index attribute path landed here.

--- a/plan/issues/2676-es3-mapped-arguments-strict-delete-aliased-throw.md
+++ b/plan/issues/2676-es3-mapped-arguments-strict-delete-aliased-throw.md
@@ -1,0 +1,77 @@
+---
+id: 2676
+title: "≤ES3: mapped arguments — strict-mode aliased `delete args[i]` must throw TypeError on a non-configurable index (residual of #2667)"
+status: ready
+created: 2026-06-25
+updated: 2026-06-25
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: bug
+area: codegen
+es_edition: 0
+language_feature: arguments-object
+goal: spec-completeness
+depends_on: []
+related: [2667, 1511]
+sprint: Backlog
+---
+# #2676 — ≤ES3 mapped-arguments strict aliased delete throws (residual of #2667)
+
+## Edition / impact
+
+- **Edition:** ≤ES3 (sloppy mapped `arguments`, but the delete site is strict).
+- **Fail count:** **4** `language/arguments-object/mapped/*` tests.
+- Residual carved out of #2667 (which fixed the 8 non-strict cases). Part of the
+  ≤ES3 full-coverage goal.
+
+## Problem
+
+```
+language/arguments-object/mapped/mapped-arguments-nonconfigurable-strict-delete-1.js .. -4.js
+```
+
+Representative:
+```js
+function argumentsAndStrictDelete(a) {
+  Object.defineProperty(arguments, "0", { configurable: false });
+  var args = arguments;                                  // (1) alias
+  assert.throws(TypeError, function() {                  // (3) nested fn
+    "use strict";                                        // (2) strict context
+    delete args[0];                                      //     must THROW
+  });
+  assert.sameValue(a, 1);
+  assert.sameValue(arguments[0], 1);
+}
+argumentsAndStrictDelete(1);
+```
+
+In **strict** mode, `delete` of a non-configurable own property throws a
+TypeError (§13.5.1.2 / OrdinaryDelete with `Throw = true`). Currently the
+compiled `delete args[0]` returns normally (the test then fails the
+`assert.throws`).
+
+Three things make this harder than the #2667 static path:
+
+1. **Aliasing** — the receiver is `args` (a `var` initialized to `arguments`),
+   not the literal `arguments` identifier #2667's tracking keys on.
+2. **Strict context** — the delete is inside a nested non-arrow function with
+   its own strict prologue, so `args` is a closure capture and the strict bit
+   lives on the inner function, not the outer mapped one.
+3. **Conditional throw** — must emit a runtime TypeError only when the target
+   index is non-configurable.
+
+## Acceptance criteria
+
+- All 4 `mapped-arguments-nonconfigurable-strict-delete-*` tests pass.
+- No regression in the #2667 non-strict mapped cases or the rest of
+  `language/arguments-object/mapped`.
+
+## Notes
+
+- The #2667 fix tracks per-index `nonConfigurableIndices` in `mappedArgsInfo` at
+  compile time. A solution here likely needs either (a) alias-resolution from
+  `args` back to the captured `arguments` vec + the outer function's
+  `mappedArgsInfo`, or (b) a runtime descriptor on the arguments object so a
+  strict `delete` consults real configurability and throws. Option (b) overlaps
+  with the broader arguments-object descriptor-fidelity gap (#2668).

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -537,6 +537,27 @@ export interface FunctionContext {
      * during body codegen — order matters, since the emitters read it live.
      */
     unmappedIndices?: Set<number>;
+    /**
+     * Argument indices made non-configurable via a statically-resolvable
+     * `Object.defineProperty(arguments, "<i>", { configurable: false })`
+     * (#2667). Per ECMA-262 §10.4.4.5 + OrdinaryDelete, `delete arguments[i]`
+     * on a non-configurable index must return `false` and leave the property
+     * (and its param mapping) intact. The delete emitter consults this set so
+     * the statically-known case reports the spec-correct result without a
+     * runtime descriptor-sidecar round-trip. Populated lazily during body
+     * codegen; read live, so codegen order matters.
+     */
+    nonConfigurableIndices?: Set<number>;
+    /**
+     * Argument indices made non-writable via a statically-resolvable
+     * `Object.defineProperty(arguments, "<i>", { writable: false })` (#2667).
+     * Per ECMA-262 §10.4.4.2, a non-writable data property rejects later
+     * `arguments[i] = x` writes (and the write-back into the param). The
+     * element-assignment emitter consults this set to drop such writes.
+     * (Setting `writable:false` also severs the param↔arguments map, so the
+     * index is additionally added to `unmappedIndices`.)
+     */
+    nonWritableIndices?: Set<number>;
   };
   /**
    * #1210: bindings detected as `let s = ""; for (...) s += <expr>` builders

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -2850,6 +2850,26 @@ function compileElementAssignment(
   const linU8Set = tryEmitLinearU8ElementSet(ctx, fctx, target, value);
   if (linU8Set !== null) return linU8Set;
 
+  // (#2667) Non-writable mapped arguments index: `arguments[i] = x` on a slot
+  // made non-writable by `Object.defineProperty(arguments,"<i>",{writable:false})`
+  // is dropped (§10.4.4 — OrdinarySet on a non-writable data property fails;
+  // sloppy mode does not throw). Detect the statically-resolvable literal-index
+  // case and emit a write-free no-op: evaluate the RHS for side effects and
+  // leave its value as the assignment-expression result.
+  if (
+    fctx.mappedArgsInfo?.nonWritableIndices &&
+    ts.isIdentifier(target.expression) &&
+    target.expression.text === "arguments"
+  ) {
+    const idxArg = target.argumentExpression;
+    const idxText = ts.isNumericLiteral(idxArg) ? idxArg.text : ts.isStringLiteral(idxArg) ? idxArg.text : undefined;
+    const argIndex = idxText !== undefined ? Number(idxText) : NaN;
+    if (Number.isInteger(argIndex) && fctx.mappedArgsInfo.nonWritableIndices.has(argIndex)) {
+      const valResult = compileExpression(ctx, fctx, value);
+      return valResult;
+    }
+  }
+
   // Handle ClassName[key] = value for static setter accessors and static properties (#848)
   if (ts.isIdentifier(target.expression)) {
     const objName = target.expression.text;

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -18,6 +18,7 @@ import { reportError } from "./context/errors.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { emitThrowTypeError } from "./expressions/helpers.js";
+import { emitMappedArgReverseSync } from "./expressions/logical-ops.js";
 import { resolveStructName } from "./expressions/misc.js";
 import { addUnionImports, cacheStringLiterals, getOrRegisterTupleType, resolveWasmType } from "./index.js";
 import { ensureObjectRuntime } from "./object-runtime.js";
@@ -948,28 +949,15 @@ function emitMappedArgValueDefine(
     ],
   });
 
-  // Param sync — only when the index is still mapped (§10.4.4.2: a data
-  // descriptor with a value, on a still-mapped slot, Set()s the binding).
-  if (!info.unmappedIndices?.has(argIndex)) {
-    const paramType = info.paramTypes[argIndex]!;
-    const paramIdx = argIndex + info.paramOffset;
-    const convert: Instr[] = [{ op: "local.get", index: valLocal } as Instr];
-    if (paramType.kind === "f64") {
-      const unboxIdx = ctx.funcMap.get("__unbox_number");
-      if (unboxIdx !== undefined) convert.push({ op: "call", funcIdx: unboxIdx });
-    } else if (paramType.kind === "i32") {
-      const unboxIdx = ctx.funcMap.get("__unbox_number");
-      if (unboxIdx !== undefined) convert.push({ op: "call", funcIdx: unboxIdx });
-      convert.push({ op: "i32.trunc_sat_f64_s" });
-    } else if (paramType.kind === "ref" || paramType.kind === "ref_null") {
-      convert.push({ op: "any.convert_extern" });
-      if (paramType.kind === "ref") {
-        convert.push({ op: "ref.cast", typeIdx: (paramType as { typeIdx: number }).typeIdx });
-      }
-    }
-    fctx.body.push(...convert);
-    fctx.body.push({ op: "local.set", index: paramIdx });
-  }
+  // Param sync — reuse the canonical mapped-args reverse-sync emitter, which
+  // already skips severed (`unmappedIndices`) slots (§10.4.4.2) and owns the
+  // single value-coercion vocabulary (§7.1.x), so this site stays out of the
+  // per-file coercion-site budget (#2108). It matches on a runtime index, so
+  // pin a constant-index local to argIndex.
+  const idxLocal = allocLocal(fctx, `__mappedarg_idx_${fctx.locals.length}`, { kind: "i32" });
+  fctx.body.push({ op: "i32.const", value: argIndex });
+  fctx.body.push({ op: "local.set", index: idxLocal });
+  emitMappedArgReverseSync(ctx, fctx, idxLocal, valLocal);
 
   // Result of Object.defineProperty is the object — push arguments as externref.
   fctx.body.push({ op: "local.get", index: info.argsLocalIdx });

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -903,6 +903,80 @@ export function emitDefinePropertyFlagCheck(
   fctx.body.push({ op: "call", funcIdx: setIdx });
 }
 
+// ── Mapped-arguments value redefine (#2667) ──────────────────────────────
+
+/**
+ * Emit `Object.defineProperty(arguments, "<i>", { value: V })` for a mapped
+ * arguments index, per ECMA-262 §10.4.4.2. The WasmGC-vec-backed arguments
+ * object carries no sidecar descriptor for its indices, so routing this through
+ * the runtime `Object.defineProperty` throws ("Cannot redefine property"). The
+ * spec-correct behaviour for a still-mapped index is to update the arguments
+ * slot AND the linked formal parameter; if the link was already severed
+ * (`unmappedIndices`), only the slot is written. Leaves the arguments object
+ * (externref) on the stack as the call result.
+ */
+function emitMappedArgValueDefine(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  info: NonNullable<FunctionContext["mappedArgsInfo"]>,
+  argIndex: number,
+  valueExpr: ts.Expression,
+): ValType {
+  // Compile the value as externref (boxing numbers/refs) for storage in the
+  // externref-backed arguments vec.
+  const valType = compileExpression(ctx, fctx, valueExpr, { kind: "externref" });
+  if (valType && valType.kind !== "externref") {
+    coerceType(ctx, fctx, valType, { kind: "externref" });
+  }
+  const valLocal = allocLocal(fctx, `__mappedarg_val_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: valLocal });
+
+  // arguments vec slot write: vec.data[argIndex] = val (null-guarded). The slot
+  // exists since argIndex < paramCount, so no grow is needed.
+  fctx.body.push({ op: "local.get", index: info.argsLocalIdx });
+  fctx.body.push({ op: "ref.is_null" });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [] as Instr[],
+    else: [
+      { op: "local.get", index: info.argsLocalIdx } as Instr,
+      { op: "struct.get", typeIdx: info.vecTypeIdx, fieldIdx: 1 } as Instr,
+      { op: "i32.const", value: argIndex } as Instr,
+      { op: "local.get", index: valLocal } as Instr,
+      { op: "array.set", typeIdx: info.arrTypeIdx } as Instr,
+    ],
+  });
+
+  // Param sync — only when the index is still mapped (§10.4.4.2: a data
+  // descriptor with a value, on a still-mapped slot, Set()s the binding).
+  if (!info.unmappedIndices?.has(argIndex)) {
+    const paramType = info.paramTypes[argIndex]!;
+    const paramIdx = argIndex + info.paramOffset;
+    const convert: Instr[] = [{ op: "local.get", index: valLocal } as Instr];
+    if (paramType.kind === "f64") {
+      const unboxIdx = ctx.funcMap.get("__unbox_number");
+      if (unboxIdx !== undefined) convert.push({ op: "call", funcIdx: unboxIdx });
+    } else if (paramType.kind === "i32") {
+      const unboxIdx = ctx.funcMap.get("__unbox_number");
+      if (unboxIdx !== undefined) convert.push({ op: "call", funcIdx: unboxIdx });
+      convert.push({ op: "i32.trunc_sat_f64_s" });
+    } else if (paramType.kind === "ref" || paramType.kind === "ref_null") {
+      convert.push({ op: "any.convert_extern" });
+      if (paramType.kind === "ref") {
+        convert.push({ op: "ref.cast", typeIdx: (paramType as { typeIdx: number }).typeIdx });
+      }
+    }
+    fctx.body.push(...convert);
+    fctx.body.push({ op: "local.set", index: paramIdx });
+  }
+
+  // Result of Object.defineProperty is the object — push arguments as externref.
+  fctx.body.push({ op: "local.get", index: info.argsLocalIdx });
+  fctx.body.push({ op: "extern.convert_any" } as Instr);
+  return { kind: "externref" };
+}
+
 // ── Object.defineProperty ─────────────────────────────────────────────
 
 /**
@@ -1183,11 +1257,53 @@ export function compileObjectDefineProperty(
     const idxKey = propName ?? (ts.isNumericLiteral(propArg) ? propArg.text : undefined);
     const argIndex = idxKey !== undefined ? Number(idxKey) : NaN;
     if (Number.isInteger(argIndex) && argIndex >= 0 && argIndex < fctx.mappedArgsInfo.paramCount) {
+      const info = fctx.mappedArgsInfo;
       const isAccessor =
         getNode !== undefined || setNode !== undefined || getExpr !== undefined || setExpr !== undefined;
       const breaksLink = isAccessor || descWritable === false;
       if (breaksLink) {
-        (fctx.mappedArgsInfo.unmappedIndices ??= new Set<number>()).add(argIndex);
+        (info.unmappedIndices ??= new Set<number>()).add(argIndex);
+      }
+      // (#2667) Track non-configurable / non-writable attribute state so the
+      // delete + element-write emitters can apply §10.4.4 semantics for the
+      // statically-resolvable case (literal index on the `arguments`
+      // identifier). `configurable:false` makes `delete arguments[i]` return
+      // false (OrdinaryDelete) without severing the map; `writable:false`
+      // freezes the value (writes dropped) and severs the map.
+      if (descConfigurable === false) {
+        (info.nonConfigurableIndices ??= new Set<number>()).add(argIndex);
+      }
+      if (descWritable === false) {
+        (info.nonWritableIndices ??= new Set<number>()).add(argIndex);
+      }
+
+      // (#2667) A pure data-descriptor define carrying a literal `value`, for a
+      // mapped arguments index, writes the arguments slot and — when the slot is
+      // still mapped — the linked formal parameter (§10.4.4.2 +
+      // OrdinaryDefineOwnProperty). Routing it through the runtime
+      // `Object.defineProperty` on the WasmGC-vec-backed arguments object trips
+      // `_validatePropertyDescriptor` ("Cannot redefine property") because the
+      // vec carries no matching sidecar descriptor. Handle it inline.
+      //
+      // A value change is permitted whenever the property is still configurable
+      // (configurable ⇒ any redefinition is allowed) OR still writable. It is
+      // forbidden only once the slot is BOTH non-configurable AND non-writable
+      // (truly frozen) — that case is left to the runtime so it reports the
+      // spec-mandated TypeError. `nonWritableIndices` severs the param map (set
+      // above + via `unmappedIndices`), so the helper writes only the slot.
+      const isFrozen =
+        (info.nonConfigurableIndices?.has(argIndex) ?? false) &&
+        (info.nonWritableIndices?.has(argIndex) ?? false) &&
+        descWritable !== true; // re-enabling writable un-freezes
+      const isPureDataValueDefine =
+        !isAccessor &&
+        valueExpr !== undefined &&
+        getExpr === undefined &&
+        setExpr === undefined &&
+        descWritable !== false && // writable:false freezes — handled by the drop path below
+        !isFrozen;
+      if (isPureDataValueDefine) {
+        return emitMappedArgValueDefine(ctx, fctx, info, argIndex, valueExpr!);
       }
     }
   }

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -107,6 +107,16 @@ export function compileDeleteExpression(
     const idxText = ts.isNumericLiteral(idxArg) ? idxArg.text : ts.isStringLiteral(idxArg) ? idxArg.text : undefined;
     const argIndex = idxText !== undefined ? Number(idxText) : NaN;
     if (Number.isInteger(argIndex) && argIndex >= 0 && argIndex < fctx.mappedArgsInfo.paramCount) {
+      // (#2667) §10.4.4.5 + OrdinaryDelete: deleting a non-configurable mapped
+      // index FAILS — `delete arguments[i]` returns `false`, the property and
+      // its param mapping stay intact. Only a *successful* delete severs the
+      // map. Detect the statically-known non-configurable case (set earlier in
+      // this body by `Object.defineProperty(arguments,"<i>",{configurable:false})`)
+      // and emit the spec-correct `false` without touching `unmappedIndices`.
+      if (fctx.mappedArgsInfo.nonConfigurableIndices?.has(argIndex)) {
+        fctx.body.push({ op: "i32.const", value: 0 });
+        return { kind: "i32" };
+      }
       (fctx.mappedArgsInfo.unmappedIndices ??= new Set<number>()).add(argIndex);
     }
   }

--- a/tests/issue-2667.test.ts
+++ b/tests/issue-2667.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports as buildRuntimeImports } from "../src/runtime.js";
+import { buildImports } from "./equivalence/helpers.js";
+
+// #2667 — ≤ES3 mapped-arguments non-configurable / non-writable property
+// attributes + [[Delete]] semantics (ECMA-262 §10.4.4). Residual of #1511.
+//
+// These cases require *mapped* (sloppy-mode) arguments, where index properties
+// stay linked to the formal parameters. The test262 harness compiles such
+// `noStrict` script tests with `inferModuleStrictArguments: false` so the
+// synthetic `export function test()` wrapper does not force module-strict (which
+// would unmap arguments). We mirror that here — `compileToWasm` defaults to
+// module-strict, which would make these functions strict/unmapped.
+async function compileSloppyToWasm(source: string) {
+  const result = await compile(source, { inferModuleStrictArguments: false });
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const manualImports = buildImports(result);
+  let setExportsFn: ((exports: Record<string, Function>) => void) | undefined;
+  if (result.imports && result.imports.length > 0) {
+    const runtimeResult = buildRuntimeImports(result.imports, undefined, result.stringPool);
+    setExportsFn = runtimeResult.setExports;
+    manualImports.env = { ...(manualImports.env as Record<string, Function>), ...runtimeResult.env };
+    if (runtimeResult.string_constants) manualImports.string_constants = runtimeResult.string_constants;
+  }
+  const { instance } = await WebAssembly.instantiate(result.binary, manualImports);
+  if (setExportsFn) setExportsFn(instance.exports as Record<string, Function>);
+  return instance.exports as Record<string, Function>;
+}
+
+describe("#2667 mapped arguments non-configurable / delete", () => {
+  // mapped-arguments-nonconfigurable-delete-1.js
+  it("delete on a non-configurable mapped index returns false, value unchanged", async () => {
+    const exports = await compileSloppyToWasm(`
+      function fn(a: any): any {
+        Object.defineProperty(arguments, "0", { configurable: false });
+        const r = delete arguments[0];
+        return (r ? 1000 : 0) + (a as number) * 10 + (arguments[0] as number);
+      }
+      export function test(): any { return fn(1); }
+    `);
+    // r === false (0), a === 1, arguments[0] === 1  =>  0 + 10 + 1 = 11
+    expect((exports as any).test()).toBe(11);
+  });
+
+  // mapped-arguments-nonconfigurable-delete-2.js (SetMutableBinding tail)
+  it("failed delete leaves the mapping live (param write reflects)", async () => {
+    const exports = await compileSloppyToWasm(`
+      function fn(a: any): any {
+        Object.defineProperty(arguments, "0", { configurable: false });
+        const r = delete arguments[0];
+        a = 2;
+        return (r ? 1000 : 0) + (arguments[0] as number);
+      }
+      export function test(): any { return fn(1); }
+    `);
+    // r === false (0); mapping live so arguments[0] tracks a===2 => 2
+    expect((exports as any).test()).toBe(2);
+  });
+
+  // mapped-arguments-nonconfigurable-delete-4.js (Set tail)
+  it("failed delete leaves the mapping live (arguments write reflects)", async () => {
+    const exports = await compileSloppyToWasm(`
+      function fn(a: any): any {
+        Object.defineProperty(arguments, "0", { configurable: false });
+        const r = delete arguments[0];
+        arguments[0] = 2;
+        return (r ? 1000 : 0) + (a as number);
+      }
+      export function test(): any { return fn(1); }
+    `);
+    // r === false (0); mapping live so a tracks arguments[0]===2 => 2
+    expect((exports as any).test()).toBe(2);
+  });
+
+  // mapped-arguments-nonconfigurable-3.js / -delete-3.js value-redefine tail
+  it("redefining value of a non-configurable mapped index updates param + arguments", async () => {
+    const exports = await compileSloppyToWasm(`
+      function fn(a: any): any {
+        Object.defineProperty(arguments, "0", { configurable: false });
+        Object.defineProperty(arguments, "0", { value: 2 });
+        return (a as number) * 10 + (arguments[0] as number);
+      }
+      export function test(): any { return fn(1); }
+    `);
+    // a === 2, arguments[0] === 2 => 22
+    expect((exports as any).test()).toBe(22);
+  });
+
+  // mapped-arguments-nonwritable-nonconfigurable-3.js
+  it("writable:false drops later arguments writes and severs the map", async () => {
+    const exports = await compileSloppyToWasm(`
+      function fn(a: any): any {
+        Object.defineProperty(arguments, "0", { writable: false });
+        arguments[0] = 2;            // ignored: non-writable
+        Object.defineProperty(arguments, "0", { configurable: false });
+        a = 3;                        // map severed by writable:false; no reflect
+        return (a as number) * 10 + (arguments[0] as number);
+      }
+      export function test(): any { return fn(1); }
+    `);
+    // a === 3, arguments[0] === 1 => 31
+    expect((exports as any).test()).toBe(31);
+  });
+
+  // mapped-arguments-nonconfigurable-nonwritable-5.js
+  it("nonconfigurable then value-redefine then nonwritable severs map", async () => {
+    const exports = await compileSloppyToWasm(`
+      function fn(a: any): any {
+        Object.defineProperty(arguments, "0", { configurable: false });
+        Object.defineProperty(arguments, "0", { value: 2 });
+        Object.defineProperty(arguments, "0", { writable: false });
+        a = 3;                        // map severed by writable:false
+        return (a as number) * 10 + (arguments[0] as number);
+      }
+      export function test(): any { return fn(1); }
+    `);
+    // a === 3, arguments[0] === 2 => 32
+    expect((exports as any).test()).toBe(32);
+  });
+
+  // mapped-arguments-nonwritable-nonconfigurable-4.js — writable:false (still
+  // configurable) then a value redefine to a DIFFERENT value is permitted
+  // because the slot is still configurable; the map is already severed.
+  it("value redefine after writable:false (still configurable) updates only arguments", async () => {
+    const exports = await compileSloppyToWasm(`
+      function fn(a: any): any {
+        Object.defineProperty(arguments, "0", { writable: false });
+        Object.defineProperty(arguments, "0", { value: 2 });
+        Object.defineProperty(arguments, "0", { configurable: false });
+        a = 3;                        // map severed; no reflect into arguments
+        return (a as number) * 10 + (arguments[0] as number);
+      }
+      export function test(): any { return fn(1); }
+    `);
+    // a === 3, arguments[0] === 2 => 32
+    expect((exports as any).test()).toBe(32);
+  });
+
+  // Regression guard: a plain mapped function still round-trips both directions.
+  it("does not disturb the normal mapped link", async () => {
+    const fwd = await compileSloppyToWasm(`
+      function fn(a: any): any { a = 5; return arguments[0]; }
+      export function test(): any { return fn(1); }
+    `);
+    expect((fwd as any).test()).toBe(5);
+    const rev = await compileSloppyToWasm(`
+      function fn(a: any): any { arguments[0] = 7; return a; }
+      export function test(): any { return fn(1); }
+    `);
+    expect((rev as any).test()).toBe(7);
+  });
+});


### PR DESCRIPTION
## #2667 — ≤ES3 mapped-arguments non-configurable / non-writable property attributes + delete

Residual of #1511. The WasmGC-vec-backed mapped (sloppy-mode) `arguments` object never modelled the configurability/writability of its own index properties, so:
- `delete arguments[i]` returned `true` even for a non-configurable index (spec: `false`, OrdinaryDelete), and wrongly severed the param map;
- `Object.defineProperty(arguments,"i",{value})` routed to the runtime `Object.defineProperty` on the vec (no matching sidecar descriptor) and threw `Cannot redefine property: 0`;
- `arguments[i] = x` on a non-writable index still wrote the slot.

### Fix
Track per-index attribute state **at compile time** in `fctx.mappedArgsInfo`, mirroring the existing `unmappedIndices` link-break mechanism (ECMA-262 §10.4.4):
- `nonConfigurableIndices` → `delete arguments[i]` emits the spec `false` without severing the map (`typeof-delete.ts`).
- `nonWritableIndices` → `arguments[i] = x` is dropped (`assignment.ts`); also severs the param map.
- A pure-data `{value}` define on a still-configurable-or-writable mapped index is handled inline (`emitMappedArgValueDefine` in `object-ops.ts`): writes the vec slot and, when still mapped, the linked formal param. Truly frozen (non-configurable AND non-writable) slots fall through to the runtime for the spec TypeError.

Populated from the statically-resolvable `Object.defineProperty(arguments, "<literal>", {literal desc})` shape, read live during body codegen (same design as `unmappedIndices`).

### Results (real test262 runner, `language/arguments-object/mapped`)
**8 of the 12** listed cases now pass — `nonconfigurable-delete-1..4`, `nonconfigurable-3`, `nonwritable-nonconfigurable-3`/`-4`, `nonconfigurable-nonwritable-5`. Category 26 → 34 pass. No regressions in the category.

The 4 `nonconfigurable-strict-delete-*` cases (aliased `delete args[0]` inside a nested strict fn → must throw TypeError; needs cross-function alias tracking + strict delete-throws) are carved out as follow-up **#2676**.

Covered by `tests/issue-2667.test.ts` (8 cases, mirrors the test262 bodies, compiled with `inferModuleStrictArguments: false` to keep `arguments` mapped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)