### PR TITLE
fix(#2674): collect ALL chained this-assignment targets as fnctor struct fields

### DIFF
--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -934,27 +934,48 @@ function compileNewFunctionDeclaration(
 
   // 1. Analyze the function body for `this.prop = value` assignments
   const fields: FieldDef[] = [];
+  // Record one `this.<field>` slot from an assignment whose LHS is `this.<field>`.
+  // `valueExpr` is the value being assigned to THAT field (for type inference) —
+  // for a chained `this.a = this.b = expr`, the value flowing into `this.a` is the
+  // whole `this.b = expr` sub-assignment (whose result type === expr's type).
+  function recordThisField(lhs: ts.PropertyAccessExpression, valueExpr: ts.Expression): void {
+    const fieldName = lhs.name.text;
+    if (fields.some((f) => f.name === fieldName)) return;
+    // Prefer the RHS type — when `this` is `any`, the LHS type is also `any`
+    // (externref), but the RHS has concrete type info (e.g., number → f64).
+    const lhsType = ctx.checker.getTypeAtLocation(lhs);
+    const rhsType = ctx.checker.getTypeAtLocation(valueExpr);
+    const lhsWasm = resolveWasmType(ctx, lhsType);
+    const rhsWasm = resolveWasmType(ctx, rhsType);
+    const fieldType = lhsWasm.kind === "externref" ? rhsWasm : lhsWasm;
+    fields.push({ name: fieldName, type: fieldType, mutable: true });
+  }
+  // Walk an assignment EXPRESSION, collecting EVERY `this.<field>` LHS in a
+  // (possibly CHAINED) assignment. acorn's Parser ctor uses chained assignments
+  // heavily — `this.start = this.end = this.pos`,
+  // `this.lastTokEndLoc = this.lastTokStartLoc = null`,
+  // `this.yieldPos = this.awaitPos = this.awaitIdentPos = 0` — so the inner
+  // targets (`end`, `lastTokStartLoc`, `awaitPos`, `awaitIdentPos`, …) MUST be
+  // collected too. Missing them gave `$__fnctor_Parser` a SHORTER field set than
+  // the fields the parser later READS (`base.end`, `this.lastTokEnd`), so reads
+  // resolved to the wrong slot / fell through to `__extern_get` → `undefined` and
+  // `parseSubscripts`/expression-parse looped forever (the 9th acorn wall, #2674).
+  function collectAssignmentChain(expr: ts.Expression): void {
+    if (
+      ts.isBinaryExpression(expr) &&
+      expr.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isPropertyAccessExpression(expr.left) &&
+      expr.left.expression.kind === ts.SyntaxKind.ThisKeyword
+    ) {
+      recordThisField(expr.left, expr.right);
+      // The RHS may itself be `this.<field> = …` (chained) — recurse to collect it.
+      collectAssignmentChain(expr.right);
+    }
+  }
   function collectThisAssignments(stmts: ts.NodeArray<ts.Statement> | readonly ts.Statement[]): void {
     for (const stmt of stmts) {
-      if (
-        ts.isExpressionStatement(stmt) &&
-        ts.isBinaryExpression(stmt.expression) &&
-        stmt.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
-        ts.isPropertyAccessExpression(stmt.expression.left) &&
-        stmt.expression.left.expression.kind === ts.SyntaxKind.ThisKeyword
-      ) {
-        const fieldName = stmt.expression.left.name.text;
-        if (!fields.some((f) => f.name === fieldName)) {
-          // Prefer the RHS type — when `this` is `any`, the LHS type is also `any`
-          // (externref), but the RHS has concrete type info (e.g., number → f64).
-          const lhsType = ctx.checker.getTypeAtLocation(stmt.expression.left);
-          const rhsType = ctx.checker.getTypeAtLocation(stmt.expression.right);
-          const lhsWasm = resolveWasmType(ctx, lhsType);
-          const rhsWasm = resolveWasmType(ctx, rhsType);
-          // Use RHS type if LHS resolved to externref (i.e., `any`)
-          const fieldType = lhsWasm.kind === "externref" ? rhsWasm : lhsWasm;
-          fields.push({ name: fieldName, type: fieldType, mutable: true });
-        }
+      if (ts.isExpressionStatement(stmt) && ts.isBinaryExpression(stmt.expression)) {
+        collectAssignmentChain(stmt.expression);
       }
       // Recurse into if/else blocks
       if (ts.isIfStatement(stmt)) {

--- a/tests/issue-2674-chained-this-assignment-fnctor-fields.test.ts
+++ b/tests/issue-2674-chained-this-assignment-fnctor-fields.test.ts
@@ -1,0 +1,92 @@
+// #2674 — a function-constructor (fnctor) whose body uses CHAINED `this`
+// assignments (`this.a = this.b = this.c = expr`) must register a struct field
+// for EVERY chained target, not just the outermost LHS.
+//
+// Root cause: `compileNewFunctionDeclaration`'s `collectThisAssignments`
+// (new-super.ts) matched only a statement-level `this.<field> = <value>` and
+// treated the RHS as an opaque value — so for `this.start = this.end = this.pos`
+// it recorded `start` but dropped `end` (the inner `this.end = this.pos` was the
+// "value"). acorn's Parser ctor leans on chained assignments heavily
+// (`this.start = this.end = this.pos`, `this.startLoc = this.endLoc = …`,
+// `this.lastTokStart = this.lastTokEnd = …`, `this.yieldPos = this.awaitPos =
+// this.awaitIdentPos = 0`), so `$__fnctor_Parser` ended up MISSING end/endLoc/
+// lastTokEnd/lastTokStartLoc/awaitPos/awaitIdentPos. The parser then READ those
+// absent fields (`base.end`, `this.lastTokEnd`) → fell through to the
+// `__extern_get` sidecar → `undefined` → expression-parse loops never terminated
+// (a contributor to the acorn 9th dogfood wall).
+//
+// Fix: `collectAssignmentChain` walks the full `=` chain, recording every
+// `this.<field>` LHS. This is a GENERAL fnctor/ctor correctness fix (any chained
+// this-assignment), not acorn-specific.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+
+async function run(src: string): Promise<{ exp: any; wat: string }> {
+  const r: any = await compile(src, { fileName: "probe.ts" });
+  expect(r.success).toBe(true);
+  const io: any = r.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(r.binary, io);
+  io.__setExports?.(instance.exports);
+  return { exp: wrapExports(instance.exports, { signatures: r.exportSignatures }), wat: r.wat as string };
+}
+
+describe("#2674 — chained `this` assignment fnctor field collection", () => {
+  it("`this.a = this.b = this.c = 5` registers ALL three fields and reads them back", async () => {
+    const { exp } = await run(`
+      // @ts-nocheck
+      var P = function P() { this.a = this.b = this.c = 5; this.x = this.y = 0; };
+      var pp = P.prototype;
+      pp.sum = function () { return this.a + this.b + this.c + this.x + this.y; };
+      export function probe() { var p = new P(); return p.sum(); }
+    `);
+    // a+b+c+x+y = 5+5+5+0+0 = 15 (pre-fix dropped b/c/y → wrong sum / undefined reads)
+    expect(exp.probe()).toBe(15);
+  });
+
+  it("the chained inner targets are real struct fields (not sidecar-only)", async () => {
+    const { wat } = await run(`
+      // @ts-nocheck
+      var P = function P() { this.start = this.end = 7; };
+      var pp = P.prototype;
+      pp.readEnd = function () { return this.end; };
+      export function probe() { var p = new P(); return p.readEnd(); }
+    `);
+    // Both `start` and `end` must appear as fields on the $__fnctor_P struct.
+    expect(/\$__fnctor_P\b/.test(wat)).toBe(true);
+    expect(/field \$start\b/.test(wat)).toBe(true);
+    expect(/field \$end\b/.test(wat)).toBe(true);
+  });
+
+  it("the inner chained target reads back the assigned value (not undefined)", async () => {
+    const { exp } = await run(`
+      // @ts-nocheck
+      var P = function P() { this.start = this.end = 7; };
+      var pp = P.prototype;
+      pp.readEnd = function () { return this.end; };
+      export function probe() { var p = new P(); return p.readEnd(); }
+    `);
+    expect(exp.probe()).toBe(7);
+  });
+
+  it("acorn-faithful 3-deep chain + null/number mix", async () => {
+    const { exp } = await run(`
+      // @ts-nocheck
+      var P = function P() {
+        this.lastTokEndLoc = this.lastTokStartLoc = null;
+        this.yieldPos = this.awaitPos = this.awaitIdentPos = 0;
+        this.n = 0;
+      };
+      var pp = P.prototype;
+      pp.go = function () {
+        // read every chained inner target — must NOT be undefined
+        if (this.lastTokStartLoc === null) this.n = this.n + 1;
+        if (this.awaitPos === 0) this.n = this.n + 1;
+        if (this.awaitIdentPos === 0) this.n = this.n + 1;
+        return this.n;
+      };
+      export function probe() { var p = new P(); return p.go(); }
+    `);
+    expect(exp.probe()).toBe(3);
+  });
+});


### PR DESCRIPTION
## Bug

`compileNewFunctionDeclaration`'s `collectThisAssignments` (new-super.ts)
recorded only the OUTERMOST LHS of a constructor `this`-assignment and treated
the RHS as an opaque value. For a CHAINED assignment `this.start = this.end =
this.pos` it recorded `start` but **dropped `end`** (the inner `this.end =
this.pos` was the "value").

acorn's Parser ctor leans on chained assignments heavily:
```js
this.start = this.end = this.pos;
this.startLoc = this.endLoc = this.curPosition();
this.lastTokEndLoc = this.lastTokStartLoc = null;
this.lastTokStart = this.lastTokEnd = this.pos;
this.yieldPos = this.awaitPos = this.awaitIdentPos = 0;
```
so `$__fnctor_Parser` ended up MISSING `end`/`endLoc`/`lastTokEnd`/
`lastTokStartLoc`/`awaitPos`/`awaitIdentPos` — fields the parser later READS
(`base.end`, `this.lastTokEnd`). A read of an absent slot falls through to the
`__extern_get` sidecar → `undefined`.

## Fix

`collectAssignmentChain` walks the full `=` chain, recording every `this.<field>`
LHS (outer + all chained inner targets), inferring each field's type from the
value flowing into it. General fnctor/ctor correctness fix (any chained
this-assignment) — not acorn-specific; expect net-positive struct-emission
movement beyond acorn (like #2664).

## Verification

- WAT: `$__fnctor_Parser` now carries the full 35-field set (end/endLoc/lastTokEnd/
  awaitPos/… present).
- New test `tests/issue-2674-chained-this-assignment-fnctor-fields.test.ts` (4/4):
  `this.a=this.b=this.c=5` → reads back 15; `this.start=this.end=7` → `end` reads
  7; a 3-deep null/number chain reads every inner target.
- tsc + prettier + biome(error) + coercion-sites gate clean.
- Broad-impact fnctor-ctor field-collection change → **full merge_group floor**.

## Scope note

This is a necessary correctness fix but does NOT by itself crack the acorn 9th
wall — `parse("x")`/`parse("1")` still hang. The remaining cause (confirmed) is
the read-side compile-order candidate freeze: parser methods compiled before
`$__fnctor_Parser` registered emit `ref.test 44 → struct.get 44 N` with no
type-90 arm → `__extern_get` → `undefined` on the type-90 instance. That is the
read-side counterpart of #2664's write-side freeze; the fix is a symmetric
`__get_member_<name>` deferred-fill, tracked as the next #2674 step (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)