### PR TITLE
fix(#2671): add Date.prototype.getYear (Annex B §B.2.4)

### DIFF
--- a/plan/issues/2671-es6-builtin-spec-residuals-date-regexp-promise-json-super.md
+++ b/plan/issues/2671-es6-builtin-spec-residuals-date-regexp-promise-json-super.md
@@ -43,6 +43,20 @@ built-ins/Date/prototype/setSeconds/arg-ms-to-number.js
 annexB/built-ins/Date/prototype/getYear/not-a-constructor.js
 ```
 
+**Progress (dev-2046, 2026-06-25):**
+- ✅ **`getYear` (Annex B §B.2.4)** — was MISSING entirely (returned
+  undefined/null; `setYear` existed but not the getter). Added to `DATE_METHODS`
+  / `DATE_PROTO_METHODS` + a `getFullYear()-1900` codegen arm (NaN-guarded).
+  `annexB/.../getYear/` test262: 6/7 pass (the 1 fail is `not-a-constructor.js`,
+  the general #930-family "method is not a constructor" gap shared by ALL Date
+  methods — not getYear-specific). `tests/issue-2671-getyear.test.ts` 6/6.
+- 📋 **`Date.parse` / `new Date(str)` NaN in HOST mode** — carved to **#2678**.
+  The native parser (`__date_parse`, #2164) works but is gated standalone/WASI-
+  only; host wiring needs js-string-externref support (dual-mode change), too big
+  to fold into the `getYear` quick win.
+- ⏳ Remaining Date: `set*` ToNumber-coercion side-effect ordering,
+  `proto-from-ctor-realm-*`, not-a-constructor (#930-family).
+
 ### RegExp (95)
 `Symbol.split` / `Symbol.match` / `Symbol.replace` / `Symbol.search` protocol
 edge cases: `lastIndex` get/coerce errors, species constructor validation,

--- a/plan/issues/2678-date-parse-host-mode-js-string.md
+++ b/plan/issues/2678-date-parse-host-mode-js-string.md
@@ -1,0 +1,76 @@
+---
+id: 2678
+title: "Date.parse / new Date(str) are NaN stubs in HOST mode — native parser is standalone/WASI-only (needs js-string externref support)"
+status: ready
+created: 2026-06-25
+priority: medium
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen, runtime
+es_edition: multi
+language_feature: date, strings, dual-mode
+goal: spec-completeness
+related: [2164, 2671]
+sprint: 66
+---
+
+# #2678 — `Date.parse` / `new Date(str)` are NaN stubs in host mode
+
+Carved from #2671 (ES2015 Date residuals). The native string-date parser
+(`__date_parse`, #2164) exists and **works** — but only on the **standalone /
+WASI** targets. In **JS-host mode** (the test262 runner default) `Date.parse(str)`
+and `new Date(str)` are still **NaN stubs**.
+
+## Evidence (current main)
+
+- `Date.parse("2000-01-01T00:00:00.000Z")` →
+  - **standalone:** `946684800000` ✅ (native `__date_parse` works)
+  - **host (default):** `NaN` ❌
+- `new Date("1970-01-01T00:00:00.000Z").getTime()` → host: `NaN`.
+
+## Root cause
+
+`src/codegen/expressions/calls.ts:8443-8451` (`Date.parse`) and the matching
+`new Date(str)` arm in `src/codegen/expressions/new-super.ts:~3084` **gate the
+native parser to `ctx.standalone || ctx.wasi`** and emit a `f64.const NaN` stub
+otherwise. Two reasons it was gated off for host:
+
+1. **Late-import index-shift (#2043):** wiring `__date_parse` lazily mid-body in
+   host mode trips the "heap type index out of range" class. The fix the comment
+   itself suggests: register `__date_parse` **up-front** (like `parseInt` /
+   `collectParseImports` in `index.ts`) via a source scan, so its funcidx is
+   stable before the body compiles.
+2. **String representation mismatch (the real dual-mode work):**
+   `emitNativeDateParse` (`date-parse-native.ts:53`) calls
+   `ensureNativeStringHelpers` + `__str_flatten` and scans a WasmGC **i16**
+   `$NativeString`. In host mode strings are **`wasm:js-string` externrefs**, not
+   native i16 arrays — the parser has no i16 buffer to scan. So host wiring needs
+   EITHER (a) convert the js-string externref to a native string first (a
+   host→native string bridge, then reuse the existing parser), OR (b) a
+   js-string char-access parse path (charCodeAt via the wasm:js-string import).
+
+## Fix direction
+
+1. Up-front register `__date_parse` for host mode (source scan for `Date.parse(…)`
+   / `new Date(<string-typed>)`), mirroring `collectParseImports`.
+2. Bridge the js-string receiver into the native parser — simplest: a host
+   `__js_string_to_native` (or reuse an existing js-string→NativeString helper)
+   so `__date_parse` gets the i16 buffer it expects; then drop the
+   `standalone||wasi` gate at calls.ts:8443 / new-super.ts.
+3. Keep standalone path byte-identical (it already flattens native strings).
+
+## Acceptance
+
+- Host-mode `Date.parse("2000-01-01T00:00:00.000Z")` === 946684800000 and the
+  ISO/RFC2822 forms the standalone parser already handles.
+- `new Date(str).getTime()` matches in host mode.
+- Standalone/WASI unchanged. No late-import-shift validation error (#2043).
+- The `built-ins/Date/parse` + `Date(str)`-construction test262 cluster flips
+  toward pass in the (host-mode) runner.
+
+## Notes
+
+- This is the bigger of the two #2671 Date gaps; `getYear` (Annex B §B.2.4, the
+  other gap) was a quick win done separately under #2671.
+- Dual-mode rule: host-mode wiring must not disturb the standalone native path.

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -104,6 +104,7 @@ const DATE_PROTO_METHODS = [
   "getDate",
   "getDay",
   "getFullYear",
+  "getYear", // (#2671) Annex B §B.2.4 legacy getter
   "getHours",
   "getMilliseconds",
   "getMinutes",
@@ -419,6 +420,7 @@ const PROTO_METHOD_LENGTH: Readonly<Record<string, number>> = {
   getDate: 0,
   getDay: 0,
   getFullYear: 0,
+  getYear: 0, // (#2671) Annex B §B.2.4 legacy getter (0-arity)
   getHours: 0,
   getMilliseconds: 0,
   getMinutes: 0,

--- a/src/codegen/expressions/builtins.ts
+++ b/src/codegen/expressions/builtins.ts
@@ -1392,6 +1392,7 @@ function compileDateMethodCall(
     "setFullYear",
     "setUTCFullYear",
     "setYear",
+    "getYear", // (#2671) Annex B §B.2.4 legacy getter
     "getTimezoneOffset",
     "getUTCFullYear",
     "getUTCMonth",
@@ -2316,6 +2317,23 @@ function compileDateMethodCall(
       emitPackedYear(fctx.body, tmp); // floor(packed/10000)
       releaseTempLocal(fctx, tmp);
       fctx.body.push({ op: "f64.convert_i64_s" } as Instr);
+    });
+  }
+
+  // (#2671) Annex B §B.2.4 `Date.prototype.getYear()` — legacy `getFullYear() -
+  // 1900`. Like getFullYear but with the −1900 offset; NaN-guarded the same way.
+  // (`setYear` already exists in the set-path below; this is the missing getter.)
+  if (methodName === "getYear") {
+    return wrapWithInvalidDateGuard(() => {
+      emitDaysToCivil(); // packed on stack
+      const tmp = allocTempLocal(fctx, { kind: "i64" });
+      emitPackedYear(fctx.body, tmp); // floor(packed/10000) → full year (i64)
+      releaseTempLocal(fctx, tmp);
+      fctx.body.push(
+        { op: "i64.const", value: 1900n } as Instr,
+        { op: "i64.sub" } as Instr, // year - 1900
+        { op: "f64.convert_i64_s" } as Instr,
+      );
     });
   }
 

--- a/tests/issue-2671-getyear.test.ts
+++ b/tests/issue-2671-getyear.test.ts
@@ -1,0 +1,51 @@
+// #2671 (ES2015 Date residual) — Annex B §B.2.4 `Date.prototype.getYear()`.
+//
+// `getYear` (legacy, `getFullYear() - 1900`) was MISSING from the Date method
+// dispatch (DATE_METHODS / DATE_PROTO_METHODS) and codegen, so `d.getYear()`
+// returned undefined/null. `setYear` already existed; this adds the matching
+// getter. NaN-guarded like the other getters.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+
+async function run(body: string): Promise<any> {
+  const src = `export function test(): any { ${body} }`;
+  const result: any = await compile(src, { fileName: "test.ts", skipSemanticDiagnostics: true } as any);
+  expect(result.binary?.length).toBeGreaterThan(0);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  return wrapExports(instance.exports, { signatures: result.exportSignatures });
+}
+
+describe("#2671 — Date.prototype.getYear (Annex B §B.2.4)", () => {
+  it("getYear() of the epoch is 70 (1970 - 1900)", async () => {
+    const exp = await run(`return new Date(0).getYear();`);
+    expect(exp.test()).toBe(70);
+  });
+
+  it("getYear() is getFullYear() - 1900", async () => {
+    const exp = await run(`return new Date(Date.UTC(2000, 0, 1)).getYear();`);
+    expect(exp.test()).toBe(100);
+  });
+
+  it("getYear() is negative for years before 1900", async () => {
+    const exp = await run(`return new Date(Date.UTC(1899, 0, 1)).getYear();`);
+    expect(exp.test()).toBe(-1);
+  });
+
+  it("getYear() of an invalid Date is NaN", async () => {
+    const exp = await run(`var y = new Date(NaN).getYear(); return (y !== y) ? 1 : 0;`);
+    expect(exp.test()).toBe(1); // NaN !== NaN
+  });
+
+  it("setYear then getYear round-trips (Annex B legacy pair)", async () => {
+    const exp = await run(`var d = new Date(0); d.setYear(98); return d.getYear();`);
+    expect(exp.test()).toBe(98);
+  });
+
+  it("getFullYear still works (no regression to the canonical getter)", async () => {
+    const exp = await run(`return new Date(0).getFullYear();`);
+    expect(exp.test()).toBe(1970);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the legacy **`Date.prototype.getYear()`** (Annex B §B.2.4) — it was MISSING entirely from the Date method dispatch and codegen, so `d.getYear()` returned undefined/null. `setYear` already existed; this adds the matching getter. (One slice of the #2671 ES2015 Date residual cluster.)

`getYear()` ≡ `getFullYear() - 1900`, NaN-guarded for invalid dates.

## Changes

- `src/codegen/expressions/builtins.ts` — `getYear` codegen arm (`emitDaysToCivil` → packed year → `-1900` → f64), wrapped in `wrapWithInvalidDateGuard` like the other getters; added to `DATE_METHODS`.
- `src/codegen/array-object-proto.ts` — `getYear` added to `DATE_PROTO_METHODS` + the 0-arity map (host-free value-read + spec `.length === 0`).

## Verification

- test262 `annexB/built-ins/Date/prototype/getYear`: **6/7 pass** (was 0). The 1 fail (`not-a-constructor.js`) is the general #930-family "method is not a constructor" gap shared by **all** Date methods — not getYear-specific.
- `tests/issue-2671-getyear.test.ts` — **6/6**: epoch→70, 2000→100, 1899→-1, NaN-date→NaN, setYear/getYear round-trip, getFullYear control unchanged.

## Carved follow-up (#2678)

`Date.parse` / `new Date(str)` are NaN stubs in **host mode** (the native parser `__date_parse` #2164 works but is gated standalone/WASI-only; host wiring needs js-string-externref support — a dual-mode change, too big to fold into this getYear quick win). Tracked as #2678.

Implements one slice of #2671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)