### PR TITLE
docs(#2674): handoff — acorn 9th-wall two landed fixes + pinned typeof residual; track #2677

### DIFF
--- a/plan/issues/2674-acorn-parse-9th-wall-past-tokenizer.md
+++ b/plan/issues/2674-acorn-parse-9th-wall-past-tokenizer.md
@@ -187,3 +187,62 @@ specific field read/write (`this.start`/`this.end`/`this.lastTokStart`/
 `this.lastTokEnd`) or the token-type `switch` dispatch, the same way #2664's
 `this.type` was cracked. (A single-compile multi-input probe variant of the
 harness would avoid the per-input recompile — a worthwhile harness follow-up.)
+
+## HANDOFF (2026-06-25, sd-2038) — two landed fixes; residual typeof-led loop pinned
+
+Worked the 9th wall to TWO distinct, landed root causes; both are NECESSARY but
+NEITHER is SUFFICIENT alone. `parse("")` and `parse(";")` return a valid empty
+Program AST; `parse("x")`/`parse("1")` (any expression statement) STILL hang on a
+RESIDUAL cause. NOT yet the #1712 AST milestone — `parse()` does not return for a
+non-empty statement.
+
+### Probe harness (landed, #2069) — use this to continue
+- `npx tsx tests/dogfood/probe-driver.mjs '<input>' parse <watchdogMs>` — single
+  input, prints `{status: ok|hang, signature, result}`. Worker-thread watchdog +
+  SharedArrayBuffer host-call counter (the in-Wasm loop is synchronous and starves
+  same-thread timers; the SAB lets the parent read the live host-call signature
+  before terminating).
+- `bisect({source, call, inputs, perInputWatchdogMs})` (export in probe-driver) —
+  ONE compile, N inputs in one worker, per-input watchdog, first-hang wins. Use
+  for fast statement-shape bisects (`["", ";", "x", "1", "1;", "var x = 1;"]`).
+- For the EXACT field/key under a hang: wrap `io.env.__extern_get` with a
+  key-histogram + a call CAP that throws (see `.tmp/keys-probe2.mjs` pattern) —
+  names the property being hammered.
+
+### Fix 1 (LANDED, #2072 / tracked #2677) — chained this-assignment field collection
+`compileNewFunctionDeclaration.collectThisAssignments` (new-super.ts) only
+recorded the OUTERMOST LHS of a ctor `this`-assignment, dropping inner chained
+targets (`this.start = this.end = this.pos` → `end` lost). `$__fnctor_Parser` was
+missing end/endLoc/lastTokEnd/lastTokStartLoc/awaitPos/awaitIdentPos. Fixed via
+`collectAssignmentChain` (walks the full `=` chain). The struct now has the full
+35-field set.
+
+### Fix 2 (LANDED, #2075) — read-side __get_member_<name> deferred-fill dispatcher
+The member-READ multi-struct dispatch (`findAlternateStructsForField` chain at
+property-access.ts:1386/1684/4896) was frozen inline at compile time, like #2664's
+write side. A reader compiled before `$__fnctor_Parser` registered only tested the
+earlier struct type → `__extern_get` → `undefined` on the real instance.
+`src/codegen/member-get-dispatch.ts` (`__get_member_<name>(recv)->externref`,
+filled at finalize with the complete candidate set) now backs each read site's
+terminal. Frozen single-candidate read sites in compiled-acorn: **9 → 1**.
+
+### RESIDUAL (still open) — typeof-led loop, NOT a struct-slot read
+After both fixes, `parse("x")` still hangs. The signature SHIFTED from
+`__extern_get`-led to **`__typeof_number`-led**:
+`__typeof_number ≈115k, __extern_get ≈118k, __get_undefined ≈98k, __host_eq` present.
+`__typeof_number` is compiler-emitted (NOT acorn source `typeof`) — for a value
+type-tag check. Hypothesis (VERIFY, don't assume — one hypothesis was already
+disproven this session): a `typeof x === "..."` / ToNumber-or-ToPrimitive value
+classification in a loop (candidate: `parseExprOp` operator-precedence
+`this.type.binop` read + comparison, or a boxed-value `===`/`!==` that never
+satisfies the loop-break), OR the 1 remaining frozen read. It is NO LONGER the
+struct-read freeze (that's fixed). 
+
+### Next step (fresh agent, on merged #2072+#2075)
+1. Re-bisect `["x","1","1;"]` on merged main (confirm still hangs + fresh signature).
+2. Capture the dominant `__typeof_number` / `__host_eq` CALL-SITE: instrument those
+   host imports (key/arg histogram, CAP-throw) OR add a per-closure hit counter to
+   find the hot function, then WAT-decode it.
+3. Likely loci: `parseExprOp` (`this.type.binop` precedence loop), `parseMaybeUnary`
+   postfix `while`, or a token-type `===` identity (the #2656-noted switch-on-
+   externref class) that never matches so `next()` is never called.

--- a/plan/issues/2677-fnctor-ctor-chained-this-assignment-drops-fields.md
+++ b/plan/issues/2677-fnctor-ctor-chained-this-assignment-drops-fields.md
@@ -1,0 +1,63 @@
+---
+id: 2677
+title: "fnctor/class ctor chained this-assignment drops non-outermost fields (this.a = this.b = expr → b missing from struct)"
+status: done
+assignee: ttraenkler/sd-2038
+completed: 2026-06-25
+sprint: 66
+created: 2026-06-25
+updated: 2026-06-25
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: classes, constructors
+goal: correctness
+related: [2674, 2664]
+origin: "Discovered while tracing the acorn 9th wall (#2674): compileNewFunctionDeclaration's collectThisAssignments only recorded the OUTERMOST LHS of a constructor this-assignment, dropping inner chained targets. A GENERAL bug (any chained ctor this-assignment), carved out of #2674 as its own tracked correctness win. Fixed in PR #2072 (commit titled fix(#2674) — discovery context)."
+---
+
+# #2677 — fnctor/class ctor chained `this`-assignment drops non-outermost fields
+
+## Problem
+
+A function-constructor (fnctor) `var P = function(){ … }` whose body uses a
+CHAINED `this`-assignment — `this.a = this.b = this.c = expr` — only registered a
+WasmGC struct field for the **outermost** LHS (`a`). The inner targets (`b`, `c`)
+were dropped: `compileNewFunctionDeclaration`'s `collectThisAssignments`
+(`src/codegen/expressions/new-super.ts`) matched a statement-level
+`this.<field> = <value>` and treated the entire RHS (`this.b = this.c = expr`) as
+an opaque "value", never recursing into it.
+
+Result: the fnctor struct is missing the inner-target fields. A later READ of one
+(`p.b`) falls through to the `__extern_get` sidecar → `undefined`, or the WRITE
+lands in the sidecar instead of the slot — read/write divergence and silent
+wrong values.
+
+Surfaced concretely by acorn's Parser ctor (`this.start = this.end = this.pos`,
+`this.startLoc = this.endLoc = …`, `this.lastTokStart = this.lastTokEnd = …`,
+`this.yieldPos = this.awaitPos = this.awaitIdentPos = 0`), which left
+`$__fnctor_Parser` missing `end`/`endLoc`/`lastTokEnd`/`lastTokStartLoc`/
+`awaitPos`/`awaitIdentPos`. General bug, not acorn-specific.
+
+## Fix (LANDED — PR #2072)
+
+`collectAssignmentChain` walks the full `=` chain, recording every `this.<field>`
+LHS (outer + all chained inner targets), inferring each field's type from the
+value flowing into it.
+
+## Verification
+
+`tests/issue-2674-chained-this-assignment-fnctor-fields.test.ts` (4/4):
+`this.a=this.b=this.c=5` reads back 15; `this.start=this.end=7` → `end` reads 7;
+a 3-deep null/number chain reads every inner target. WAT shows `$__fnctor_Parser`
+with the full field set. tsc + prettier + biome + coercion-sites gate clean.
+Broad-impact (struct field-collection) → validated via the merge_group floor.
+
+## Note
+
+This fix is NECESSARY but NOT SUFFICIENT for the acorn 9th wall (#2674) — the
+remaining cause there is the read-side dispatch compile-order candidate freeze
+(symmetric to #2664's write side), fixed separately by a `__get_member_<name>`
+deferred-fill under #2674.


### PR DESCRIPTION
Docs-only. Finalizes the #2674 handoff for a fresh agent to continue the acorn
9th-wall residual, and tracks the general chained-ctor field-drop bug as #2677.

## #2674 handoff
- Two LANDED root-cause fixes recorded: chained `this`-assignment field collection
  (#2072) and read-side `__get_member` deferred-fill (#2075). Both necessary,
  neither sufficient; frozen acorn read sites 9 → 1.
- RESIDUAL pinned: `parse("x")` still hangs with a `__typeof_number`-led signature
  (~115k typeof / 118k extern_get / 98k get_undefined) — a DISTINCT loop, no
  longer the struct-read freeze. Hypothesis (typeof/value-tag or `===` in
  `parseExprOp`) + next-step bisect/WAT plan + probe-harness invocation recorded.
- `parse("")`/`parse(";")` DO return a valid empty Program AST (entry chain works).

## #2677 (new)
General correctness bug carved from the #2674 discovery: fnctor/class ctor chained
`this`-assignment (`this.a = this.b = expr`) dropped non-outermost struct fields.
`status: done` — fixed in #2072.

🤖 Generated with [Claude Code](https://claude.com/claude-code)