### PR TITLE
feat(#2663): with Tier-2 @@unscopables HasBinding (Slice 4, host-mode)

### DIFF
--- a/plan/issues/2663-with-statement-tier2-dynamic-scope.md
+++ b/plan/issues/2663-with-statement-tier2-dynamic-scope.md
@@ -1,7 +1,8 @@
 ---
 id: 2663
 title: "feat: `with` statement Tier 2 — dynamic-scope fallback (de-skip the 294 test262 WithStatement tests; landing page shows unsupported)"
-status: ready
+status: in-progress
+assignee: ttraenkler/dev-conformance
 created: 2026-06-25
 updated: 2026-06-25
 priority: medium
@@ -467,14 +468,39 @@ corpus.
   it touches the closure-capture machinery and is substantially harder — its own
   sub-slice / possibly senior-dev. The delete struct-slot observability is the
   #2659-family asymmetry for delete. Both are flagged to the lead, NOT bundled.
-- **Slice 4 — `@@unscopables`:** `emitWithHasBinding` full §9.1.1.2.1 with the
-  symbol-keyed `Get(recv,@@unscopables)` + `ToBoolean(Get(unscopables,N))` block.
-  Covers `binding-blocked-by-unscopables.js`, `unscopables-*` tests. Also handle
-  `ToObject(primitive)` wrapper-object receivers if any corpus test needs it.
-- **Slice 4 — `@@unscopables`:** `emitWithHasBinding` full §9.1.1.2.1 with the
-  symbol-keyed `Get(recv,@@unscopables)` + `ToBoolean(Get(unscopables,N))` block.
-  Covers `binding-blocked-by-unscopables.js`, `unscopables-*` tests. Also handle
-  `ToObject(primitive)` wrapper-object receivers if any corpus test needs it.
+- **Slice 4 — `@@unscopables` HasBinding: ✅ DONE (host-mode, PR 2026-06-25).**
+  Implemented as a single HOST helper `__with_has_binding(obj, key) -> i32`
+  (`src/runtime.ts`, in `resolveImport` `case "builtin"`) applying the full
+  §9.1.1.2.1 predicate: value-independent HasProperty (reuses `__extern_has`)
+  THEN the @@unscopables filter — `unsc = __extern_get(obj, Symbol.unscopables)`
+  (sidecar-aware, so a WasmGC-struct receiver resolves identically to a host
+  object); if `Type(unsc)` is Object and `ToBoolean(__extern_get(unsc, key))` is
+  true, the name is unscopable ⇒ NOT a binding. The three with-gates (READ /
+  WRITE-capture / DELETE resolution in `with-scope.ts`) route through
+  `withHasBindingImport(ctx)` — `__with_has_binding` in host mode,
+  `__extern_has` under `--target standalone` (where the dynamic-`with` path is
+  already refused by the #1472 gate, so the new host import is NEVER emitted in a
+  no-JS-host build — byte-identical standalone, no allowlist growth). Guarded by
+  `tests/issue-2663-unscopables.test.ts` (11 cases: blocking true/truthy, not
+  blocking false/empty/non-object, sibling-name unaffected, getter-not-invoked
+  for absent props, blocked read+write fall to outer, nested cascade, Slice-1
+  no-regression).
+  - **Measured:** the non-mutating blocking/not-blocking cases are now
+    spec-correct in host mode; ZERO regression to non-`with` modules.
+  - **NOT yet flipped — corpus needs the #2580 object-representation ceiling:**
+    `binding-blocked-by-unscopables.js` mutates `env[Symbol.unscopables].x` across
+    heterogeneous types (`true → 'string' → 86 → {} → Symbol`); the
+    `{ x: true }` literal lowers to a typed struct whose numeric `x` field cannot
+    hold those later values (writing `'string'`/`{}`/`Symbol` coerces to 0 → the
+    assertion-2+ rows still fail). `unscopables-inc-dec.js` needs a literal
+    `get [Symbol.unscopables]()` accessor. Both are the dynamic any-typed object
+    representation (#2580), NOT the HasBinding logic — which is landed and
+    isolated here so the representation work immediately flips the corpus. The
+    `binding-not-blocked-*` / `unscopables-not-referenced-for-undef` tests already
+    pass on `main` (HasProperty gives the same answer when unblocked), so the
+    measurable test262 delta of this slice alone is small; its value is banking
+    the correct, prerequisite HasBinding semantics. **DEFERRED to senior-dev /
+    #2580 alongside the closure-capture class.**
 - **Slice 5 — landing-page flip + de-skip confirmation:** confirm no remaining
   blanket skip for the `with` category in `shouldSkip`
   (`tests/test262-runner.ts:324`; today there is no `with`-specific skip — the

--- a/src/codegen/with-scope.ts
+++ b/src/codegen/with-scope.ts
@@ -39,6 +39,22 @@ const OBJECT_PROTOTYPE_KEYS = new Set([
   "valueOf",
 ]);
 
+/**
+ * (#2663 Slice 4) The HasBinding gate import for the dynamic `with` object
+ * environment record. HOST mode uses `__with_has_binding`, which applies the
+ * full ECMAScript §9.1.1.2.1 predicate: value-independent HasProperty filtered
+ * by the receiver's @@unscopables blocklist (a `with`-routed name shadows the
+ * outer binding only when HasBinding is true). Under `--target standalone`
+ * there is no JS host, and the dynamic-`with` path already emits `__extern_has`
+ * — which the #1472 standalone gate REFUSES (dynamic `with` is host-only). We
+ * keep that exact name in standalone so the refusal is byte-identical to Slices
+ * 1-3; `__with_has_binding` is NOT `__extern_*`-prefixed and so would NOT be
+ * refused, which must never leak into a no-JS-host build.
+ */
+function withHasBindingImport(ctx: CodegenContext): string {
+  return ctx.standalone ? "__extern_has" : "__with_has_binding";
+}
+
 /** A static (#1387 Tier-1) `with` scope entry. */
 export type StaticWithScope = Extract<NonNullable<FunctionContext["withScopes"]>[number], { kind: "static" }>;
 
@@ -309,7 +325,7 @@ export function emitDynamicWithGet(
   addStringConstantGlobal(ctx, name);
   const hasIdx = ensureLateImport(
     ctx,
-    "__extern_has",
+    withHasBindingImport(ctx),
     [{ kind: "externref" }, { kind: "externref" }],
     [{ kind: "i32" }],
   );
@@ -385,7 +401,7 @@ export function emitCaptureWithHasBinding(
   addStringConstantGlobal(ctx, name);
   const hasIdx = ensureLateImport(
     ctx,
-    "__extern_has",
+    withHasBindingImport(ctx),
     [{ kind: "externref" }, { kind: "externref" }],
     [{ kind: "i32" }],
   );
@@ -480,7 +496,7 @@ export function emitDynamicWithDelete(
   addStringConstantGlobal(ctx, name);
   const hasIdx = ensureLateImport(
     ctx,
-    "__extern_has",
+    withHasBindingImport(ctx),
     [{ kind: "externref" }, { kind: "externref" }],
     [{ kind: "i32" }],
   );

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -7557,6 +7557,70 @@ assert._isSameValue = isSameValue;
           }
           return 0;
         };
+      // (#2663 Slice 4) __with_has_binding(obj, key) -> i32. The ECMAScript
+      // Object Environment Record HasBinding (§9.1.1.2.1) used by the `with`
+      // statement: value-independent HasProperty, THEN filtered by the
+      // receiver's @@unscopables blocklist. A bare name inside `with (obj) {}`
+      // shadows the outer binding only when HasBinding is true.
+      //   1. found = HasProperty(obj, N)                (= __extern_has)
+      //   2. if not found -> 0
+      //   3. unscopables = Get(obj, @@unscopables)
+      //   4. if Type(unscopables) is Object and ToBoolean(Get(unscopables, N))
+      //        -> 0   (the @@unscopables entry hides the binding)
+      //   5. -> 1
+      // Host-mode only: the standalone with-gate emits `__extern_has` (refused
+      // under --target standalone, like Slices 1-3), so this import is never
+      // requested in a no-JS-host build.
+      if (name === "__with_has_binding") {
+        // Reuse the value-independent HasProperty (`__extern_has`) and the
+        // sidecar-aware reader (`__extern_get`, the `extern_get` intent) so a
+        // WasmGC-struct `with` receiver whose @@unscopables / properties live in
+        // the host sidecar resolve identically to a plain host object.
+        const hasProp = resolveImport(
+          { type: "builtin", name: "__extern_has" } as ImportIntent,
+          deps,
+          callbackState,
+          globalSandbox,
+          instanceState,
+        ) as (o: any, k: any) => number;
+        const getProp = resolveImport(
+          { type: "extern_get" } as ImportIntent,
+          deps,
+          callbackState,
+          globalSandbox,
+          instanceState,
+        ) as (o: any, k: any) => any;
+        const toBool = resolveImport(
+          { type: "builtin", name: "__to_boolean" } as ImportIntent,
+          deps,
+          callbackState,
+          globalSandbox,
+          instanceState,
+        ) as (v: any) => number;
+        return (obj: any, key: any): number => {
+          // (1)+(2) value-independent HasProperty.
+          if (!hasProp(obj, key)) return 0;
+          // (3) unscopables = Get(obj, @@unscopables). A throw (opaque struct
+          // with no sidecar entry) ⇒ no blocklist.
+          let unsc: any;
+          try {
+            unsc = getProp(obj, Symbol.unscopables);
+          } catch {
+            unsc = undefined;
+          }
+          // (4) If Type(unscopables) is Object: blocked = ToBoolean(Get(unsc, N)).
+          if (unsc !== null && (typeof unsc === "object" || typeof unsc === "function")) {
+            let blocked: any;
+            try {
+              blocked = getProp(unsc, key);
+            } catch {
+              blocked = undefined;
+            }
+            if (toBool(blocked)) return 0; // @@unscopables hides the binding.
+          }
+          return 1; // (5)
+        };
+      }
       if (name === "__extern_toString")
         return (v: any) => {
           if (v == null) return String(v);

--- a/tests/issue-2663-unscopables.test.ts
+++ b/tests/issue-2663-unscopables.test.ts
@@ -1,0 +1,113 @@
+// #2663 Slice 4 — `with` statement Tier 2: @@unscopables-aware HasBinding.
+//
+// Slices 1-3 gated every dynamic-`with` name resolution on the value-independent
+// HasProperty (`__extern_has`), treating "present on the object" as HasBinding.
+// That is incomplete: ECMA-262 §9.1.1.2.1 HasBinding for a `with` Object
+// Environment Record filters a present property through the receiver's
+// @@unscopables blocklist — a name whose `@@unscopables[name]` ToBoolean-coerces
+// to true does NOT shadow the outer binding.
+//
+// Slice 4 routes the three HOST-mode with-gates (read / write / delete
+// resolution) through the new `__with_has_binding` host helper, which applies
+// the full predicate: HasProperty THEN the @@unscopables filter. Standalone is
+// unchanged (the dynamic-`with` path is host-only — `__extern_has` is refused
+// under --target standalone, #1472).
+//
+// NOTE: the test262 `binding-blocked-by-unscopables.js` mutates
+// `env[Symbol.unscopables].x` across heterogeneous types (true → 'string' → 86 →
+// {} → Symbol); the `{ x: true }` literal lowers to a typed struct whose numeric
+// `x` field cannot hold those later values (the object-representation ceiling,
+// #2580). The HasBinding LOGIC below is correct and isolated; flipping that
+// specific corpus file additionally needs the dynamic any-typed representation.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+
+async function run(body: string): Promise<any> {
+  const src = `export function test(): any { ${body} }`;
+  const result: any = await compile(src, {
+    fileName: "test.ts",
+    skipSemanticDiagnostics: true,
+    inferModuleStrictArguments: false,
+  } as any);
+  expect(result.binary?.length).toBeGreaterThan(0);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  return wrapExports(instance.exports, { signatures: result.exportSignatures });
+}
+
+describe("#2663 Slice 4 — with @@unscopables HasBinding", () => {
+  it("a true-valued @@unscopables entry blocks the object binding (read falls to outer)", async () => {
+    const exp = await run(
+      `var x = 0; var env = { x: 1 }; env[Symbol.unscopables] = { x: true }; var r; with (env) { r = x; } return r;`,
+    );
+    expect(exp.test()).toBe(0);
+  });
+
+  it("a truthy non-boolean @@unscopables entry (number) also blocks the binding", async () => {
+    const exp = await run(
+      `var x = 0; var env = { x: 1 }; env[Symbol.unscopables] = { x: 86 }; var r; with (env) { r = x; } return r;`,
+    );
+    expect(exp.test()).toBe(0);
+  });
+
+  it("a false-valued @@unscopables entry does NOT block (object property wins)", async () => {
+    const exp = await run(
+      `var x = 0; var env = { x: 1 }; env[Symbol.unscopables] = { x: false }; var r; with (env) { r = x; } return r;`,
+    );
+    expect(exp.test()).toBe(1);
+  });
+
+  it("an empty @@unscopables object does not block any name", async () => {
+    const exp = await run(
+      `var x = 0; var env = { x: 1 }; env[Symbol.unscopables] = {}; var r; with (env) { r = x; } return r;`,
+    );
+    expect(exp.test()).toBe(1);
+  });
+
+  it("a non-object @@unscopables (string) is ignored — own property wins", async () => {
+    const exp = await run(
+      `var marker = 0; var env = { y: 7 }; env[Symbol.unscopables] = ''; var r; with (env) { r = y; } return r;`,
+    );
+    expect(exp.test()).toBe(7);
+  });
+
+  it("@@unscopables only blocks the named property, not siblings", async () => {
+    const exp = await run(
+      `var y = 0; var env = { x: 1, y: 2 }; env[Symbol.unscopables] = { x: true }; var r; with (env) { r = y; } return r;`,
+    );
+    expect(exp.test()).toBe(2);
+  });
+
+  it("@@unscopables is not consulted when the property is absent (getter not invoked)", async () => {
+    const exp = await run(
+      `var x = 0; var env = {}; var cc = 0; Object.defineProperty(env, Symbol.unscopables, { get: function () { cc += 1; } }); with (env) { x; } return cc;`,
+    );
+    expect(exp.test()).toBe(0);
+  });
+
+  it("a blocked WRITE falls through to the outer binding", async () => {
+    const exp = await run(
+      `var x = 0; var env = { x: 1 }; env[Symbol.unscopables] = { x: true }; with (env) { x = 9; } return x;`,
+    );
+    expect(exp.test()).toBe(9);
+  });
+
+  it("an unblocked WRITE still targets the object property (no regression)", async () => {
+    const exp = await run(`var env = { x: 1 }; with (env) { x = 9; } return env.x;`);
+    expect(exp.test()).toBe(9);
+  });
+
+  it("nested with: a blocked name on the inner object cascades to the outer with", async () => {
+    const exp = await run(
+      `var a = { v: 1 }; var b = { v: 2 }; b[Symbol.unscopables] = { v: true }; var r; with (a) { with (b) { r = v; } } return r;`,
+    );
+    expect(exp.test()).toBe(1);
+  });
+
+  it("Slice 1 dynamic read (no @@unscopables) still works — no regression", async () => {
+    const exp = await run(`var o = { x: 42 }; var r; with (o) { r = x; } return r;`);
+    expect(exp.test()).toBe(42);
+  });
+});


### PR DESCRIPTION
## #2663 Slice 4 — `with` Tier-2 @@unscopables-aware HasBinding (host-mode)

Slices 1-3 gated every dynamic-`with` name resolution on value-independent HasProperty (`__extern_has`), treating "present on the object" as HasBinding. ECMA-262 §9.1.1.2.1 additionally filters a present property through the receiver's `@@unscopables` blocklist.

### Change
- New HOST helper `__with_has_binding(obj, key) -> i32` (`src/runtime.ts`, `resolveImport` `case "builtin"`): full §9.1.1.2.1 — HasProperty (reuses `__extern_has`) **then** the @@unscopables filter via `__extern_get(obj, Symbol.unscopables)` (sidecar-aware, so a WasmGC-struct receiver resolves like a host object) + `ToBoolean(__extern_get(unsc, key))`.
- The three with-gates (read / write-capture / delete resolution in `with-scope.ts`) pick the gate import via `withHasBindingImport(ctx)`: `__with_has_binding` in host mode, `__extern_has` under `--target standalone` (where the dynamic-`with` path is already refused by the #1472 gate, so the new host import is **never emitted** in a no-JS-host build → standalone byte-identical, no strict-allowlist growth).

### Tests
`tests/issue-2663-unscopables.test.ts` (11 cases): truthy-blocks, falsy/empty/non-object don't block, sibling name unaffected, getter-not-invoked for absent props, blocked read+write fall to outer, nested cascade, Slice-1 no-regression. Existing `tests/issue-2663.test.ts` (23) still green.

### Scope / measured
Non-mutating blocking/not-blocking cases are now spec-correct in host mode; **zero regression** to non-`with` modules. The `binding-blocked-by-unscopables.js` / `unscopables-inc-dec.js` corpus flip additionally needs the **#2580 object-representation ceiling** (heterogeneous `env[Symbol.unscopables].x` mutation across `true→'string'→86→{}→Symbol` — the typed-struct field can't hold them — plus a literal `get [Symbol.unscopables]()`). The HasBinding logic is landed and isolated here so that representation work immediately flips the corpus. The deferred closure-capture class + representation work stay open for senior-dev.

Refs #2663 (Slice 4), depends_on #2580 for the corpus flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)