### PR TITLE
fix(#2668 Slice B): preserve own-property accessor get/set identity

### DIFF
--- a/plan/issues/2668-es5-object-defineproperty-descriptor-fidelity-residual.md
+++ b/plan/issues/2668-es5-object-defineproperty-descriptor-fidelity-residual.md
@@ -2,7 +2,7 @@
 id: 2668
 title: "ES5: Object.defineProperty/defineProperties descriptor fidelity residual (~788 fails — largest ES5 cluster)"
 status: in-progress
-assignee: ttraenkler/sd-2668a
+assignee: ttraenkler/sd-2668b
 created: 2026-06-25
 updated: 2026-06-25
 priority: high
@@ -172,6 +172,81 @@ parts of the first cut, both removed:
   recovered (isolated runs). `tsc --noEmit` clean.
 - Conformance: net-positive, **0 regressions** — re-validated via the
   `merge_group` floor (core define/read path is broad-impact).
+
+## Slice B — landed (sd-2668b, host mode)
+
+**Status:** Slice B merged; issue stays open for Slice C (array-`length`
+exotic) and D (cleanup). Slice B targets **own-property accessor descriptor
+identity**: `Object.getOwnPropertyDescriptor(o, k).get/.set` returning the same
+function the user passed, and redefine-preserves-the-other-half.
+
+### Verify-first finding — the real bug is accessor re-synthesis, not read-back
+
+The box was quiet, so the per-file signal sd-2668a couldn't get earlier was
+reliable here (fresh single-process `runTest262File`, not the in-process batch).
+Repro (host/JS): `Object.defineProperty(o, "p", { get: getter, set: setter });
+Object.getOwnPropertyDescriptor(o, "p").get === getter` → **false** on main, even
+though `o.p` invokes the getter correctly.
+
+Root cause is in **codegen**, not the runtime read-back. For an
+*identifier-reference* accessor half (`{ get: fnRef }`), the
+`emitExternDefinePropertyNoValue` getExpr/setExpr branches
+(`src/codegen/object-ops.ts`) resolved `fnRef` back to its function
+*declaration* (`resolveExprToFuncNode`) and **re-synthesized a FRESH closure**
+via `emitAccessorFn`. That fresh closure is a different object than the value the
+user holds, so the descriptor's get/set never matched `=== fnRef`. (The runtime
+already memoizes the `_wrapWasmClosure` invocation bridge per source closure and
+`_hostEqComparableValue` unwraps it on `===`, so once the *stored* value derives
+from the user's actual closure, identity round-trips for free.)
+
+### The fix (one change, host mode)
+
+`emitAccessorRefValue` (`src/codegen/object-ops.ts`): in **host mode**, compile
+the `get`/`set` reference expression *directly* to push the user's actual
+function value (function-reference identity is stable in this compiler), instead
+of re-synthesizing from the declaration. Standalone keeps `emitAccessorFn`
+(host-free closure the native accessor arms dispatch through) — byte-identical
+standalone output. Invocation is unaffected (the runtime bridge dispatches via
+`__call_fn_method_0/1`, which also threads the receiver as `this` — a strict
+improvement over the captureless re-synthesized fn).
+
+### Discarded approach — runtime GOPD unwrap (documented to save the next dev)
+
+An earlier cut ALSO unwrapped the accessor bridge back to the raw closure at the
+`__getOwnPropertyDescriptor(s)` boundary. It produced the same +33 on the
+accessor batch but was **reverted** — it returns the raw WasmGC closure, which
+is `typeof "object"` (violates "accessor get is a function") and is **not
+dynamically invocable** (`desc.get()` → `NaN` in TS mode; broke the existing
+`issue-1629` "preserves referenced getter identity" vitest). The codegen-only
+fix avoids this entirely: the descriptor keeps the invocable JS-function bridge,
+and identity is recovered by the existing `__host_eq` unwrap.
+
+### Scope / two comparison regimes (why some shapes still differ)
+
+- **Regime 1 — `any === any` (the test262 regime).** test262's harness is
+  untyped JS, so `desc.get === origGetter` lowers to the JS-host `__host_eq`
+  path, which unwraps the bridge → identity matches. **This is what Slice B
+  fixes.**
+- **Regime 2 — statically function-typed `fnRef === any GOPD result`.** Lowers
+  to WasmGC `ref.eq` across two representations (a closure-ref vs the host bridge
+  externref) and does not match. This is a deeper representation-canonicalization
+  gap (out of Slice B scope) — the Slice B vitest cases use `any`-typed function
+  values to reflect the regime that is actually fixed.
+- Proto-inherited accessor attribute reads remain deferred to **#2680**.
+- Inline-method (`get(){}`) `this`-binding capture (`issue-929` "accessor
+  descriptor" case) fails on base too — pre-existing, untouched, separate.
+
+### Test results
+
+- New: 4 `#2668 Slice B` cases in `tests/issue-2668.test.ts` (get/set identity
+  round-trip + typeof, redefine-preserves-other-half, invocable-after-define,
+  data-value identity no-regression guard). Full file green (12 cases).
+- Per-file accessor batch (734 `defineProperty`/`defineProperties`/
+  `getOwnPropertyDescriptor` files touching get/set, fresh single-process):
+  **+33 pass (342→375), 0 regressions** (pass→fail).
+- Regression: `issue-1460/1629*/1364a/1364b/2017/2580-m3-bacc/2042-s3` +
+  `accessor-side-effects` green (119 passed; the lone fail is the pre-existing
+  `issue-929` inline-capture case, fails on base). `tsc --noEmit` clean.
 
 ---
 

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -2445,6 +2445,49 @@ function emitAccessorFn(
 }
 
 /**
+ * (#2668 Slice B) Emit the externref operand for an *identifier-reference*
+ * accessor half (`{ get: fnRef }` / `{ set: fnRef }`) so the value stored in the
+ * descriptor preserves the user's ORIGINAL function identity.
+ *
+ * The legacy path resolved `fnRef` back to its function *declaration* and
+ * re-synthesized a FRESH closure via {@link emitAccessorFn}. That fresh closure
+ * is a different object than the value the user holds, so
+ * `Object.getOwnPropertyDescriptor(o, k).get === fnRef` failed (the largest
+ * remaining accessor-descriptor bucket) — even though the getter *worked*.
+ *
+ * Instead, compile the reference expression directly to push the user's actual
+ * function value (a stable closure — function-reference identity is preserved
+ * across multiple references in this compiler). The runtime
+ * `__defineProperty_accessor` wraps it for native invocation, and
+ * `_hostEqComparableValue` unwraps that wrapper back to this same closure on the
+ * `===`/`!==` compare — so identity round-trips. Invocation is unaffected: the
+ * wrapper dispatches through `__call_fn_method_0/1`, threading the receiver as
+ * `this` (a strict improvement over the captureless re-synthesized fn).
+ *
+ * Host mode only. Under `ctx.standalone` the descriptor stores a host-free
+ * closure that the native accessor arms dispatch through, so keep the existing
+ * {@link emitAccessorFn} path there (byte-identical standalone output).
+ *
+ * Returns `true` when a value was pushed; `false` when the caller should push
+ * `ref.null.extern`.
+ */
+function emitAccessorRefValue(ctx: CodegenContext, fctx: FunctionContext, expr: ts.Expression): boolean {
+  if (ctx.standalone) {
+    const funcNode = resolveExprToFuncNode(ctx, expr);
+    if (!funcNode) return false;
+    return emitAccessorFn(ctx, fctx, funcNode as unknown as ts.FunctionExpression);
+  }
+  const t = compileExpression(ctx, fctx, expr, { kind: "externref" });
+  if (!t) return false;
+  if (t.kind === "ref" || t.kind === "ref_null") {
+    fctx.body.push({ op: "extern.convert_any" } as Instr);
+  } else if (t.kind !== "externref") {
+    coerceType(ctx, fctx, t, { kind: "externref" });
+  }
+  return true;
+}
+
+/**
  * Emit __defineProperty_value(obj, prop, null, flags) for descriptors without a value property.
  * For externref objects, this delegates to the JS host which can handle flag-only descriptors.
  * For struct-typed objects, this is a no-op (struct fields are always writable).
@@ -2596,14 +2639,9 @@ function emitExternDefinePropertyNoValue(
         if (!emitAccessorFn(ctx, fctx, getNode as unknown as ts.FunctionExpression))
           fctx.body.push({ op: "ref.null.extern" });
       } else if (getExpr) {
-        // get: identifierRef — resolve to function declaration and compile
-        const getFuncNode = resolveExprToFuncNode(ctx, getExpr);
-        if (getFuncNode) {
-          if (!emitAccessorFn(ctx, fctx, getFuncNode as unknown as ts.FunctionExpression))
-            fctx.body.push({ op: "ref.null.extern" });
-        } else {
-          fctx.body.push({ op: "ref.null.extern" });
-        }
+        // get: identifierRef — compile the reference directly (host) so the
+        // descriptor preserves the user's original function identity (#2668 B).
+        if (!emitAccessorRefValue(ctx, fctx, getExpr)) fctx.body.push({ op: "ref.null.extern" });
       } else {
         fctx.body.push({ op: "ref.null.extern" });
       }
@@ -2614,14 +2652,9 @@ function emitExternDefinePropertyNoValue(
         if (!emitAccessorFn(ctx, fctx, setNode as unknown as ts.FunctionExpression))
           fctx.body.push({ op: "ref.null.extern" });
       } else if (setExpr) {
-        // set: identifierRef — resolve to function declaration and compile
-        const setFuncNode = resolveExprToFuncNode(ctx, setExpr);
-        if (setFuncNode) {
-          if (!emitAccessorFn(ctx, fctx, setFuncNode as unknown as ts.FunctionExpression))
-            fctx.body.push({ op: "ref.null.extern" });
-        } else {
-          fctx.body.push({ op: "ref.null.extern" });
-        }
+        // set: identifierRef — compile the reference directly (host) so the
+        // descriptor preserves the user's original function identity (#2668 B).
+        if (!emitAccessorRefValue(ctx, fctx, setExpr)) fctx.body.push({ op: "ref.null.extern" });
       } else {
         fctx.body.push({ op: "ref.null.extern" });
       }

--- a/tests/issue-2668.test.ts
+++ b/tests/issue-2668.test.ts
@@ -174,3 +174,100 @@ describe("#2668 Slice A — no regression on existing fast paths", () => {
     ).toBe(1);
   });
 });
+
+// #2668 Slice B — own-property ACCESSOR descriptor identity (host mode).
+//
+// Root cause: `Object.defineProperty(o, k, { get: fnRef })` (an identifier-
+// reference accessor half) re-synthesized a FRESH closure from `fnRef`'s
+// *declaration* (`resolveExprToFuncNode` + `emitAccessorFn`) instead of using
+// the value `fnRef` already denotes. The descriptor therefore stored a getter
+// that was a DIFFERENT object than the one the user holds, so
+// `Object.getOwnPropertyDescriptor(o, k).get === fnRef` failed (the largest
+// residual accessor-descriptor bucket) even though the getter *worked*. Host
+// mode now compiles the reference expression directly (`emitAccessorRefValue`);
+// the runtime's `_wrapWasmClosure` bridge memoizes per source closure and
+// `_hostEqComparableValue` unwraps it on `===`, so identity round-trips while
+// the descriptor's get/set stay invocable JS functions.
+//
+// NOTE: these mirror the test262 regime where descriptor function values are
+// `any`-typed (the harness is untyped JS) — `desc.get === fnRef` lowers to the
+// JS-host `__host_eq` path. A *statically function-typed* `fnRef` compared
+// against an `any` GOPD result lowers to WasmGC `ref.eq` across two
+// representations (closure-ref vs the host bridge externref) and is a separate,
+// deeper representation-canonicalization gap, out of this slice's scope.
+// Proto-inherited accessor attribute reads remain deferred to #2680.
+describe("#2668 Slice B — own-property accessor descriptor identity", () => {
+  it("get/set identity round-trips through getOwnPropertyDescriptor", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          const obj: any = {};
+          const getter: any = function () { return 1; };
+          const setter: any = function (v: any) {};
+          Object.defineProperty(obj, "prop", { get: getter, set: setter, enumerable: true, configurable: true });
+          const d: any = Object.getOwnPropertyDescriptor(obj, "prop");
+          if (d.get !== getter) return 10;
+          if (d.set !== setter) return 11;
+          if (typeof d.get !== "function") return 12;
+          if (d.enumerable !== true) return 13;
+          if (d.configurable !== true) return 14;
+          return 1;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("redefining one half preserves the other (get redefined, set kept)", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          const obj: any = {};
+          const getter: any = function () { return 1; };
+          const setter: any = function (v: any) {};
+          Object.defineProperty(obj, "prop", { get: getter, set: setter, configurable: true });
+          const getter2: any = function () { return 2; };
+          Object.defineProperty(obj, "prop", { get: getter2 });
+          const d: any = Object.getOwnPropertyDescriptor(obj, "prop");
+          if (d.get !== getter2) return 20;
+          if (d.set !== setter) return 21;
+          return 1;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("accessor getter stays invocable and identity-preserving after define", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          const obj: any = {};
+          const getter: any = function () { return 42; };
+          Object.defineProperty(obj, "p", { get: getter, configurable: true });
+          if (obj.p !== 42) return 30;
+          const d: any = Object.getOwnPropertyDescriptor(obj, "p");
+          if (d.get !== getter) return 31;
+          if (d.get() !== 42) return 32;
+          return 1;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("data-property function value identity is NOT regressed (Slice A guard)", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          const obj: any = {};
+          const f: any = function () { return 1; };
+          obj.f = f;
+          if (obj.f !== f) return 40;
+          Object.defineProperty(obj, "g", { value: f });
+          if (obj.g !== f) return 41;
+          const d: any = Object.getOwnPropertyDescriptor(obj, "g");
+          if (d.value !== f) return 42;
+          return 1;
+        }
+      `),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2668 Slice B — own-property accessor descriptor identity (host mode)

`Object.defineProperty(o, k, { get: fnRef })` re-synthesized a **fresh closure**
from `fnRef`'s declaration (`resolveExprToFuncNode` + `emitAccessorFn`) instead
of using the value `fnRef` already denotes. So the descriptor stored a getter
that was a different object than the one the user holds, and
`Object.getOwnPropertyDescriptor(o, k).get === fnRef` failed — the largest
residual accessor-descriptor bucket — even though `o.p` invoked the getter fine.

### Fix (one codegen change, host mode)

`emitAccessorRefValue` (`src/codegen/object-ops.ts`): host mode now compiles the
`get`/`set` identifier-reference expression **directly**, so the descriptor
stores a value derived from the user's actual closure. The runtime's
`_wrapWasmClosure` bridge memoizes per source closure and `_hostEqComparableValue`
unwraps it on `===`, so identity round-trips while get/set stay invocable JS
functions. Standalone keeps the host-free `emitAccessorFn` path (byte-identical).

A runtime "unwrap at the GOPD boundary" alternative was tried and **discarded**:
it returned the raw WasmGC closure (`typeof "object"`, not invocable — `desc.get()`
→ `NaN`), breaking the existing `issue-1629` getter-identity vitest. The
codegen-only fix avoids that.

### Validation

- Per-file accessor batch (734 `defineProperty`/`defineProperties`/
  `getOwnPropertyDescriptor` files touching get/set, fresh single-process):
  **+33 pass (342 → 375), 0 regressions** (pass→fail).
- `tsc --noEmit` clean. `issue-1460/1629*/1364a/1364b/2017/2580-m3-bacc/2042-s3`
  + `accessor-side-effects` green (119 passed; lone fail is the pre-existing
  `issue-929` inline-capture case, fails on base too).
- 4 new `#2668 Slice B` cases in `tests/issue-2668.test.ts`.

### Scope

Own-property accessor identity + redefine-preserves-other-half, host mode, in
the test262 `any === any` (`__host_eq`) regime. Proto-inherited accessor
attribute reads → **#2680**. Statically-function-typed `===` (`ref.eq` regime),
array-`length` exotic (Slice C), and standalone descriptor fidelity (#2580) are
out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)