### PR TITLE
fix(#2675): obj[keyExpr]++/-- on object elements does a real read-modify-write

### DIFF
--- a/plan/issues/2675-incdec-computed-object-key-struct-slot.md
+++ b/plan/issues/2675-incdec-computed-object-key-struct-slot.md
@@ -1,7 +1,9 @@
 ---
 id: 2675
 title: "++/-- on a computed object key (obj[keyExpr]++) is broken: NaN/no-update + double ToPropertyKey — #2659-family struct-slot vs sidecar"
-status: ready
+status: done
+completed: 2026-06-26
+assignee: ttraenkler/dev-conformance
 created: 2026-06-25
 priority: medium
 feasibility: medium
@@ -86,3 +88,23 @@ Once the #2659 read/write asymmetry is fully resolved (connects to the acorn
   currently file-private) when implementing here.
 - Depends on / overlaps #2659 (member write struct.set dispatch) and #2674
   (acorn read-side struct dispatch).
+
+
+## Resolution (2026-06-26)
+
+Fixed in `src/codegen/expressions/unary-updates.ts`: the externref (any-typed)
+element arm of `compileMemberIncDec` no longer NaN-drops the write. New helper
+`emitExternrefElementIncDec` does a real read-modify-write mirroring the working
+compound path `o[k] += 1` (`compileElementCompoundAssignment`): `__extern_get` →
+`__unbox_number` → f64, ±1, `__box_number`, write-back via the #2659 symmetric
+`struct.set` dispatch for a STATIC string-literal key (slot-consistent, with
+`__extern_set` terminal fallback) or `__extern_set` for a DYNAMIC key. The key's
+ToPropertyKey fires ONCE (§7.1.19) via the now-exported `emitToPropertyKeyOnce`
+(re-exported from `assignment.ts`), and §13.4 prefix(new)/postfix(old) return
+semantics are honoured. The wasm-null base RequireObjectCoercible TypeError is
+preserved (shift-safe, #1720).
+
+Guarded by `tests/issue-2675.test.ts` (15 cases): variable/literal/`{toString}`
+keys update the slot, postfix returns old + prefix returns new, decrement,
+ToPropertyKey-once, ToNumber coercion, nested `o[a][b]++`, and regression guards
+for `o[k] += 1` / `arr[i]++` / `o.prop++`.

--- a/scripts/coercion-sites-baseline.json
+++ b/scripts/coercion-sites-baseline.json
@@ -14,7 +14,7 @@
   "codegen/expressions/late-imports.ts": 4,
   "codegen/expressions/logical-ops.ts": 2,
   "codegen/expressions/new-super.ts": 2,
-  "codegen/expressions/unary-updates.ts": 2,
+  "codegen/expressions/unary-updates.ts": 3,
   "codegen/expressions.ts": 1,
   "codegen/fixups.ts": 1,
   "codegen/function-body.ts": 1,

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -5977,7 +5977,7 @@ function compilePropertyCompoundAssignmentExternref(
  * Symbol-preserving). STANDALONE: the native `__to_property_key` helper
  * (object-runtime.ts) — ensure the object runtime so it is emitted.
  */
-function emitToPropertyKeyOnce(ctx: CodegenContext, fctx: FunctionContext): void {
+export function emitToPropertyKeyOnce(ctx: CodegenContext, fctx: FunctionContext): void {
   if (ctx.standalone) {
     ensureObjectRuntime(ctx);
     flushLateImportShifts(ctx, fctx);

--- a/src/codegen/expressions/unary-updates.ts
+++ b/src/codegen/expressions/unary-updates.ts
@@ -33,6 +33,7 @@ import { compileStringLiteral } from "../string-ops.js";
 import { defaultValueInstrs } from "../type-coercion.js";
 import { emitThrowString, emitThrowTypeError, getFuncParamTypes } from "./helpers.js";
 import { ensureLateImport, flushLateImportShifts } from "./late-imports.js";
+import { emitToPropertyKeyOnce } from "./assignment.js";
 import { emitMappedArgParamSync } from "./logical-ops.js";
 import { resolveStructName } from "./misc.js";
 
@@ -289,6 +290,113 @@ function emitExternrefMemberIncDec(
   }
 
   // Return new (prefix) or old (postfix). §13.4 UpdateExpression semantics.
+  fctx.body.push({ op: "local.get", index: mode === "postfix" ? oldTmp : newTmp });
+  return { kind: "f64" };
+}
+
+/**
+ * (#2675) Object element `obj[keyExpr]++` / `--obj[keyExpr]` on an externref
+ * (any-typed) receiver — a real read-modify-write instead of the historical
+ * NaN-drop. Mirrors the working compound path `compileElementCompoundAssignment`
+ * (assignment.ts; #2666 fixed it for ToPropertyKey-once) but with ±1 and §13.4
+ * UpdateExpression old/new return semantics:
+ *
+ *   read  __extern_get(base, key) -> __unbox_number -> f64 (= old)
+ *   new = old ±1
+ *   write back: a STATIC string-literal key routes through the symmetric
+ *     struct.set dispatch (#2659 `emitAlternateStructSetDispatch`) so a typed
+ *     WasmGC-struct receiver hits the same slot the member READ uses, with
+ *     `__extern_set` as the terminal sidecar fallback; a DYNAMIC key writes via
+ *     `__extern_set` (the same path `o[k] += 1` uses).
+ *
+ * The key's ToPropertyKey (§7.1.19) fires ONCE for a side-effecting `{toString}`
+ * key. `baseLocal` already holds the receiver externref. Prefix returns the NEW
+ * value, postfix the OLD. f64 numeric semantics (matching `o[k] += 1`).
+ */
+function emitExternrefElementIncDec(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  baseLocal: number,
+  keyExpr: ts.Expression,
+  f64Op: "f64.add" | "f64.sub",
+  mode: "prefix" | "postfix",
+): ValType | null {
+  // §13.3.3: base already evaluated; evaluate the key expression (side effects),
+  // then ToPropertyKey ONCE (reference formation, before the null-base check).
+  const keyResult = compileExpression(ctx, fctx, keyExpr, { kind: "externref" });
+  if (!keyResult) return null;
+  emitToPropertyKeyOnce(ctx, fctx);
+  const keyLocal = allocLocal(fctx, `__incdec_ekey_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: keyLocal });
+
+  // RequireObjectCoercible: a wasm-null base throws TypeError before the update.
+  // (Shift-safe: emit the throw into the real body so emitThrowTypeError's
+  // late-import bookkeeping patches prior instrs, then splice into the if-then —
+  // #1720.)
+  fctx.body.push({ op: "local.get", index: baseLocal });
+  fctx.body.push({ op: "ref.is_null" });
+  const throwStart = fctx.body.length;
+  emitThrowTypeError(ctx, fctx, "TypeError: Cannot read properties of null (update target)");
+  const thenBody = fctx.body.splice(throwStart);
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: thenBody });
+
+  // Read current: __extern_get(base, key) -> externref (slot-consistent via _safeGet).
+  fctx.body.push({ op: "local.get", index: baseLocal });
+  fctx.body.push({ op: "local.get", index: keyLocal });
+  const getIdx = ensureLateImport(
+    ctx,
+    "__extern_get",
+    [{ kind: "externref" }, { kind: "externref" }],
+    [{ kind: "externref" }],
+  );
+  flushLateImportShifts(ctx, fctx);
+  if (getIdx !== undefined) fctx.body.push({ op: "call", funcIdx: getIdx });
+
+  // Unbox -> f64 (ToNumber on the current value).
+  addUnionImports(ctx);
+  const unboxIdx = ctx.funcMap.get("__unbox_number");
+  if (unboxIdx !== undefined) fctx.body.push({ op: "call", funcIdx: unboxIdx });
+
+  // Save OLD (postfix return).
+  const oldTmp = allocLocal(fctx, `__incdec_eeold_${fctx.locals.length}`, { kind: "f64" });
+  fctx.body.push({ op: "local.tee", index: oldTmp });
+
+  // NEW = old ±1.
+  fctx.body.push({ op: "f64.const", value: 1 });
+  fctx.body.push({ op: f64Op });
+  const newTmp = allocLocal(fctx, `__incdec_eenew_${fctx.locals.length}`, { kind: "f64" });
+  fctx.body.push({ op: "local.set", index: newTmp });
+
+  // Box NEW for the write-back.
+  fctx.body.push({ op: "local.get", index: newTmp });
+  const boxIdx = ctx.funcMap.get("__box_number");
+  if (boxIdx !== undefined) fctx.body.push({ op: "call", funcIdx: boxIdx });
+  const boxedLocal = allocLocal(fctx, `__incdec_eeboxed_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: boxedLocal });
+
+  // Write back. Static string-literal key → symmetric struct.set dispatch (#2659)
+  // for slot-consistency (terminal __extern_set fallback inside); dynamic key →
+  // __extern_set (same path as `o[k] += 1`).
+  const setIdx = ensureLateImport(
+    ctx,
+    "__extern_set",
+    [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }],
+    [],
+  );
+  flushLateImportShifts(ctx, fctx);
+  const litName = ts.isStringLiteral(keyExpr) ? keyExpr.text : undefined;
+  let dispatched = false;
+  if (litName !== undefined) {
+    dispatched = emitAlternateStructSetDispatch(ctx, fctx, baseLocal, boxedLocal, litName, /*strict*/ false);
+  }
+  if (!dispatched) {
+    fctx.body.push({ op: "local.get", index: baseLocal });
+    fctx.body.push({ op: "local.get", index: keyLocal });
+    fctx.body.push({ op: "local.get", index: boxedLocal });
+    if (setIdx !== undefined) fctx.body.push({ op: "call", funcIdx: setIdx });
+  }
+
+  // Return NEW (prefix) / OLD (postfix). §13.4.
   fctx.body.push({ op: "local.get", index: mode === "postfix" ? oldTmp : newTmp });
   return { kind: "f64" };
 }
@@ -585,30 +693,14 @@ function compileMemberIncDec(
     // which is observable *before* ToPropertyKey would call the key's
     // `toString`. A non-null externref base still falls through to NaN.
     if (objResult.kind === "externref") {
+      // (#2675) Object element `obj[keyExpr]++` / `--` on an any-typed (externref)
+      // receiver: a real read-modify-write instead of the historical NaN-drop.
+      // The key's ToPropertyKey-once, the null-base RequireObjectCoercible
+      // TypeError, and the slot-consistent write-back are handled in the shared
+      // helper (mirrors the working compound path `o[key] += 1`).
       const elemBaseTmp = allocLocal(fctx, `__incdec_ebase_${fctx.locals.length}`, objResult);
       fctx.body.push({ op: "local.set", index: elemBaseTmp });
-      // Evaluate the property-key expression for its side effects, then discard
-      // its value (ToPropertyKey itself is skipped — GetValue throws first when
-      // the base is null/undefined).
-      const keyResult = compileExpression(ctx, fctx, operand.argumentExpression);
-      if (keyResult) fctx.body.push({ op: "drop" });
-      // RequireObjectCoercible: null base -> TypeError before the update step.
-      fctx.body.push({ op: "local.get", index: elemBaseTmp });
-      fctx.body.push({ op: "ref.is_null" });
-      // Emit the TypeError throw into the REAL body first so emitThrowTypeError's
-      // late-import-shift bookkeeping (ensureLateImport + flushLateImportShifts)
-      // patches the already-emitted instructions correctly, then splice the
-      // freshly-appended throw instrs out into the `if` then-body. Building the
-      // throw against a detached body would skip the shift on prior instrs and
-      // emit an index-corrupt module (#1720).
-      const throwStart = fctx.body.length;
-      emitThrowTypeError(ctx, fctx, "TypeError: Cannot read properties of null (update target)");
-      const thenBody = fctx.body.splice(throwStart);
-      fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: thenBody });
-      // Non-null externref base: incrementing a dynamic property yields NaN.
-      reportSilentFallback(ctx, "const-fallback", "unary-updates:incdec-dynamic-property-externref", operand);
-      fctx.body.push({ op: "f64.const", value: NaN });
-      return { kind: "f64" };
+      return emitExternrefElementIncDec(ctx, fctx, elemBaseTmp, operand.argumentExpression, f64Op, mode);
     }
 
     if (objResult.kind !== "ref" && objResult.kind !== "ref_null") {

--- a/tests/issue-2675.test.ts
+++ b/tests/issue-2675.test.ts
@@ -1,0 +1,108 @@
+// #2675 — `obj[keyExpr]++` / `--obj[keyExpr]` on an object element.
+//
+// Carved from #2666 (which fixed the compound-assignment half). The prefix/
+// postfix ++/-- half on a computed/dynamic OBJECT key (`o:any`/externref base)
+// hit the externref element arm in `compileMemberIncDec`, which dropped the
+// write and returned NaN — so `o[k]++` left `o.x` unchanged and returned the
+// wrong value. The fix routes the externref element arm through a real
+// read-modify-write (`emitExternrefElementIncDec`) mirroring the working
+// compound path `o[k] += 1`: read via __extern_get, unbox, ±1, box, write back
+// via the #2659 symmetric struct.set dispatch (static literal key) or
+// __extern_set (dynamic key), with ToPropertyKey fired ONCE (§7.1.19) and §13.4
+// prefix(new)/postfix(old) return semantics.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+
+async function run(body: string): Promise<any> {
+  const src = `export function test(): any { ${body} }`;
+  const result: any = await compile(src, { fileName: "test.ts", skipSemanticDiagnostics: true } as any);
+  expect(result.binary?.length).toBeGreaterThan(0);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  return wrapExports(instance.exports, { signatures: result.exportSignatures });
+}
+
+describe("#2675 — obj[key]++ / --obj[key] on object elements", () => {
+  it("postfix ++ with a variable key updates the slot", async () => {
+    const exp = await run(`var o: any = { x: 5 }; var k = "x"; o[k]++; return o.x;`);
+    expect(exp.test()).toBe(6);
+  });
+
+  it("postfix ++ with a string-literal key updates the slot", async () => {
+    const exp = await run(`var o: any = { x: 5 }; o["x"]++; return o.x;`);
+    expect(exp.test()).toBe(6);
+  });
+
+  it("prefix ++ updates the slot", async () => {
+    const exp = await run(`var o: any = { x: 5 }; var k = "x"; ++o[k]; return o.x;`);
+    expect(exp.test()).toBe(6);
+  });
+
+  it("postfix ++ returns the OLD value (§13.4)", async () => {
+    const exp = await run(`var o: any = { x: 5 }; var k = "x"; var r = o[k]++; return r;`);
+    expect(exp.test()).toBe(5);
+  });
+
+  it("prefix ++ returns the NEW value (§13.4)", async () => {
+    const exp = await run(`var o: any = { x: 5 }; var k = "x"; var r = ++o[k]; return r;`);
+    expect(exp.test()).toBe(6);
+  });
+
+  it("postfix -- decrements and returns the old value", async () => {
+    const exp = await run(`var o: any = { x: 5 }; var k = "x"; var r = o[k]--; return r === 5 && o.x === 4 ? 1 : 0;`);
+    expect(exp.test()).toBe(1);
+  });
+
+  it("prefix -- decrements the slot", async () => {
+    const exp = await run(`var o: any = { x: 5 }; var k = "x"; --o[k]; return o.x;`);
+    expect(exp.test()).toBe(4);
+  });
+
+  it("a side-effecting {toString} key has ToPropertyKey fire exactly once", async () => {
+    const exp = await run(
+      `var n = 0; var key: any = { toString() { n++; return "x"; } }; var o: any = { x: 5 }; o[key]++; return n;`,
+    );
+    expect(exp.test()).toBe(1);
+  });
+
+  it("a {toString} key updates the resolved property", async () => {
+    const exp = await run(
+      `var key: any = { toString() { return "x"; } }; var o: any = { x: 5 }; o[key]++; return o.x;`,
+    );
+    expect(exp.test()).toBe(6);
+  });
+
+  it("a string-valued property is ToNumber-coerced before ±1", async () => {
+    const exp = await run(`var o: any = { x: "5" }; var k = "x"; o[k]++; return o.x;`);
+    expect(exp.test()).toBe(6);
+  });
+
+  it("repeated ++ accumulate", async () => {
+    const exp = await run(`var o: any = { x: 5 }; var k = "x"; o[k]++; o[k]++; return o.x;`);
+    expect(exp.test()).toBe(7);
+  });
+
+  it("nested obj[a][b]++ updates the inner slot", async () => {
+    const exp = await run(
+      `var o: any = { inner: { x: 5 } }; var a = "inner"; var b = "x"; o[a][b]++; return o.inner.x;`,
+    );
+    expect(exp.test()).toBe(6);
+  });
+
+  it("compound element assignment still works (no regression)", async () => {
+    const exp = await run(`var o: any = { x: 5 }; var k = "x"; o[k] += 10; return o.x;`);
+    expect(exp.test()).toBe(15);
+  });
+
+  it("array element arr[i]++ still works (no regression)", async () => {
+    const exp = await run(`var a = [5]; var i = 0; a[i]++; return a[i];`);
+    expect(exp.test()).toBe(6);
+  });
+
+  it("member name o.prop++ still works (no regression)", async () => {
+    const exp = await run(`var o: any = { x: 5 }; o.x++; return o.x;`);
+    expect(exp.test()).toBe(6);
+  });
+});


### PR DESCRIPTION
## #2675 — `obj[keyExpr]++` / `--obj[keyExpr]` on object elements

Carved from #2666 (which fixed the compound-assignment half). The prefix/postfix `++`/`--` half on a computed/dynamic **object** key (`o: any`/externref base) hit the externref element arm in `compileMemberIncDec`, which **dropped the write and returned NaN** — so `o[k]++` left `o.x` unchanged and returned the wrong value.

### Fix
New helper `emitExternrefElementIncDec` (`src/codegen/expressions/unary-updates.ts`) does a real read-modify-write mirroring the **already-working** compound path `o[k] += 1` (`compileElementCompoundAssignment`):
- `__extern_get(base, key)` → `__unbox_number` → f64 (= old), ±1, `__box_number`;
- write back via the **#2659 symmetric `struct.set` dispatch** for a STATIC string-literal key (slot-consistent, with `__extern_set` terminal fallback), or `__extern_set` for a DYNAMIC key;
- key's **ToPropertyKey fires ONCE** (§7.1.19) via the now-exported `emitToPropertyKeyOnce`;
- §13.4 **prefix(new) / postfix(old)** return semantics; wasm-null base RequireObjectCoercible TypeError preserved (#1720).

### Tests
`tests/issue-2675.test.ts` (15): variable / string-literal / `{toString}` keys update the slot; postfix returns old + prefix returns new; decrement; ToPropertyKey-once; ToNumber coercion; nested `o[a][b]++`; regression guards for `o[k] += 1`, `arr[i]++`, `o.prop++`.

Gates green locally: typecheck, lint, prettier, codegen silent-fallback (#2089, reduced one site), AnyValue box-site (#2104). Should flip the `prefix/postfix-(in|de)crement/*_A6_T2.js` test262 cluster toward pass.

Refs #2675; related #2666 #2659 #2674.

🤖 Generated with [Claude Code](https://claude.com/claude-code)