### PR TITLE
docs(#1762): architect spec — linear-memory string backing (LinearString)

### DIFF
--- a/plan/issues/1762-linear-memory-string-backing-build-hash-hot-path.md
+++ b/plan/issues/1762-linear-memory-string-backing-build-hash-hot-path.md
@@ -2,9 +2,10 @@
 id: 1762
 title: "perf(strings): linear-memory string backing for the build/hash hot path — drop the WasmGC (array i16) GC barrier"
 status: ready
-needs_arch_spec: true
+needs_arch_spec: false
 created: 2026-05-31
-updated: 2026-06-24
+updated: 2026-06-26
+arch_spec_landed: "2026-06-26 (sd-typedarray): ## Implementation Plan settles representation (LinearString GC descriptor + linear char data), boundary, alloc/lifetime, host interop. Unblocks dev Slice 0 (measure-first)."
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -99,6 +100,185 @@ interop story with the JS-host string path.
 - Result-parity regression tests across both string backends and representative
   inputs; zero test262 regressions.
 - Refresh the committed benchmark JSON and keep the #1580 staleness gate green.
+
+## Implementation Plan (architect spec, 2026-06-26, sd-typedarray)
+
+> Verified against current `main` (6d1b24089581). All file:line anchors below
+> were re-checked on this tree — they drift, re-grep before coding.
+
+### Ground truth — the current native-string representation (`registry/types.ts:307` `registerNativeStringTypes`)
+
+| type | idx field | layout | role |
+| --- | --- | --- | --- |
+| `__str_data` | `ctx.nativeStrDataTypeIdx` | `(array (mut i16))` | the WTF-16 char backing array |
+| `AnyString` | `ctx.anyStrTypeIdx` | `struct { len:i32 }` (super=-1) | **universal string handle** — every helper signature is `ref $AnyString` |
+| `NativeString` (flat) | `ctx.nativeStrTypeIdx` | `struct { len:i32, off:i32, data: ref $__str_data }` (super=AnyString) | flat leaf; `off` enables O(1) substring views |
+| `ConsString` (rope) | `ctx.consStrTypeIdx` | `struct { len:i32, left: ref $AnyString, right: ref $AnyString }` (super=AnyString) | O(1) concat node |
+
+- **Build hot path** (`a + b`, `native-strings.ts:1363` `__str_concat`): `len ≥ 64`
+  → `struct.new $ConsString(len, a, b)` (rope; 2 ref fields = GC alloc + write
+  barriers). `len < 64` → flatten both + copy into a fresh `__str_data` via
+  `array.set` (the per-store **GC write barrier** the #1746 differential measured).
+  Rope→flat happens in `__str_copy_tree` (`native-strings.ts:285`), an `array.set`
+  loop over the leaves.
+- **Hash/read hot path** (`charCodeAt(i)` in a loop): the receiver is flattened
+  (`__str_flatten`) to a `NativeString`, then each read is
+  `array.get $__str_data (data, off+i)` — **GC read barrier** + the three
+  un-hoistable opaque-ref **struct-field reloads** (`len`/`off`/`data`) per
+  iteration (Cranelift can't prove the `ref` loop-invariant). This is the floor
+  #1746 identified.
+
+### Where linear memory exists today (the gate)
+
+- **No linear memory in default WasmGC mode** — `WasmModule.memories` starts `[]`
+  (`src/ir/types.ts:467`); the ONLY `mod.memories.push()` is WASI-gated
+  (`index.ts:5973`, `min:3` pages, exported `"memory"`). Reserved low region:
+  `memory[0..7]` iovec, `memory[8..11]` nwritten (`index.ts:6563`).
+- **The linear backend** (`src/codegen-linear/`) already has the allocator we
+  reuse the *design* of: `__heap_ptr` global (`HEAP_START=1024`), `__malloc(size)`
+  8-byte-aligned bump + on-demand `memory.grow` (`codegen-linear/runtime.ts:52-164`),
+  and a linear string layout `[hdr 8B][len u32][utf8…]` (`runtime.ts:1071`).
+- **⇒ Representation gate:** the linear-memory string backing is enabled only when
+  a linear memory is present — **`ctx.wasi` today** (WASI auto-enables
+  `nativeStrings`; matches the issue's `--target wasi --nativeStrings` scope).
+  Default-browser WasmGC keeps `NativeString`/`ConsString` unchanged (no memory to
+  point into). A future `--target standalone` memory would widen the gate; out of
+  scope here.
+
+### D1 — Representation: a new `LinearString` subtype of `$AnyString`; char data in linear memory, descriptor stays GC
+
+Add a 4th string type, registered **up-front and append-only** in
+`registerNativeStringTypes` (so its type index never shifts — the
+`project_type_index_shift_and_deadelim` discipline; the new type goes LAST so the
+existing `anyStr`/`nativeStr`/`consStr` indices are unchanged):
+
+```
+LinearString  struct { len:i32, ptr:i32, off:i32 }   (super = AnyString)
+```
+
+- `ptr` = **byte offset into the WASI linear memory** of the WTF-16 char data
+  (`len` i16 code units at `ptr + off*2 ..`); `off` preserves the substring-view
+  semantics `NativeString.off` has.
+- The **descriptor is a GC struct** (so a `LinearString` IS a `ref $AnyString` and
+  flows through every existing consumer unchanged as the universal handle), but the
+  **char bytes live in linear memory** — so hot reads/writes touch raw memory with
+  **no GC barrier** and a **transparent i32 base pointer** Cranelift can hoist.
+- This is exactly V8's sequential-string model (small GC-traced header + pointer
+  to an off-heap backing store) — the ceiling the issue targets, reached without
+  abandoning the `ref $AnyString` invariant.
+
+**Why a GC descriptor, not a pure i32 handle:** every string helper signature is
+`ref $AnyString` (`native-strings.ts:228`); a pure-i32 handle would force a
+representation flag through hundreds of call sites and break `ref.test`-based
+dispatch. Keeping the descriptor GC-managed confines the change to (a) the type
+table, (b) the create sites, (c) the hot read/build fast paths, and (d) a single
+new arm in the universal consumers.
+
+### D2 — The WasmGC↔linear boundary (create / read / build / escape)
+
+- **Create** (WASI only): (i) a string **literal** materialized in WASI mode
+  bump-allocates `len*2` bytes, stores the i16 units with `i32.store16`, and
+  `struct.new $LinearString(len, ptr, 0)` instead of the current
+  `array.new_fixed`+`NativeString` (`native-strings.ts:362`
+  `compileNativeStringLiteral`); (ii) the **flatten** sink and the **builder**
+  (D4) produce `LinearString` directly.
+- **Read fast path** (the hash-loop win): `charCodeAt`/index/`[i]` on a value
+  statically known (or `ref.test`-proven) to be `LinearString` lowers to
+  `i32.load16_u (memBase + (ptr + (off+i)*2))` — base pointer loaded **once**,
+  hoistable; no `array.get`, no struct-field reload. Add this arm at the
+  `charCodeAt` lowering (`binary-ops.ts:1578` region + the string-method path) and
+  in `__str_flatten` (a `LinearString` input flattens to itself, O(1)).
+- **Build fast path** (the build-loop win): see D4.
+- **Escape / universal consumers** — `__str_flatten` (`native-strings.ts`),
+  `__str_concat` (`:1363`), `__str_eq`/compare, `__str_copy_tree` (`:285`), and any
+  `struct.get $NativeString data` site must gain a **`ref.test $LinearString`
+  arm**. Because WASI has **no JS host**, the only "escape" is to these in-module
+  helpers — there is NO `wasm:js-string`/externref conversion to design (that is
+  the non-`nativeStrings` host backend, which never creates a `LinearString`). A
+  `LinearString` reaching a helper that genuinely needs an `(array i16)` (rare —
+  e.g. a path not yet given a linear arm) converts via a one-shot
+  `__str_lin_to_flat` (copy `len` i16 from memory into a fresh `__str_data`) —
+  **refuse-loud / convert, never read the wrong field**. Inventory of `struct.get`
+  sites keyed on `nativeStrTypeIdx` data/off must be enumerated in Slice 1 (grep
+  `struct.get .* nativeStrTypeIdx`) and each given a `ref.test` dispatch or routed
+  through the shared accessor.
+
+### D3 — Allocation / lifetime (bump now, arena later)
+
+- Reuse the WASI memory. Add a `__str_heap_ptr` bump global initialized **past the
+  reserved iovec/nwritten scratch** (`memory[0..11]`) — e.g. start at a page
+  boundary (`65536`) to keep fd_write scratch and the string heap disjoint; grow
+  via `memory.grow` on exhaustion (mirror `codegen-linear/runtime.ts:83-142`
+  `__malloc`, 2-byte alignment is enough for i16 data).
+- **GC interaction / lifetime tradeoff (the honest cost):** char bytes are **not
+  GC-traced**; the bump allocator **never frees**, so a collected `LinearString`
+  descriptor leaves its char bytes resident. For the hot path (build a big string,
+  hash it, drop it) and for benchmark/short-lived WASI programs the leak is bounded
+  by total string bytes and is dwarfed by the per-iteration barrier win. **Slice 1
+  ships bump-only and documents this.** A follow-on (separate issue) adds a
+  string-arena reset at statement/region boundaries or a size-classed freelist;
+  pure-Wasm has no finalization hook to tie char-data lifetime to the GC descriptor,
+  so the arena/region approach (not refcounting) is the right long-term answer.
+- **Builder presize couples to #1761:** the build loop bump-allocates ONE buffer
+  sized from the presized capacity (#1761) and appends in place with `i32.store16`
+  (no per-append alloc, no per-store GC write barrier) → one allocation per built
+  string, not per append. This is where the "60,000 barriered stores → 0" win lands.
+
+### D4 — Slicing (each a full-gate PR; measure on #1760 before widening)
+
+- **Slice 0 (measure-first, no land):** prototype the `LinearString` read arm for
+  `charCodeAt` only; run the #1760 warm bench (`scripts/generate-wasmtime-hot-runtime.mjs`,
+  the `warm(__n)` string-hash program) and a native re-diff (per #1746) to CONFIRM
+  the GC read barrier + 3 struct reloads are gone and the warm hash-loop drop
+  exceeds combined std. Go/no-go gate before committing the type-table change.
+- **Slice 1 (read path):** register `LinearString` (append-only); create it for
+  string literals + the flatten sink under `ctx.wasi`; `charCodeAt`/index fast
+  path; `ref.test` arms in `__str_flatten`/`__str_eq` + the enumerated `struct.get`
+  consumers; `__str_lin_to_flat` escape. **Acceptance:** hash-loop warm drop on
+  #1760; full result-parity (length/index/charCodeAt/compare/concat/substring/
+  for-of) vs the WasmGC backend across representative inputs; zero test262
+  regressions (WASI + default both green — default is byte-unchanged since the new
+  type is unreachable without a memory).
+- **Slice 2 (build path):** presized linear builder (`i32.store16` appends) for the
+  `s += c` and `Array.prototype.join` hot paths (couple to #1761); `__str_concat`
+  short-string arm builds a `LinearString`. **Acceptance:** build-loop warm drop;
+  native re-diff shows the `array.set` write barrier gone; parity + zero regressions.
+- **Slice 3 (consolidation):** rope-flatten sink emits `LinearString`; sweep
+  remaining `struct.get $NativeString` consumers; refresh committed benchmark JSON;
+  keep the #1580 30 ms staleness gate honest (no gaming).
+
+### Risks / guards
+
+- **R1 — type-index shift.** Register `LinearString` LAST in
+  `registerNativeStringTypes` (append-only) so `anyStr`/`nativeStr`/`consStr`
+  indices are byte-identical; default-mode binaries must be **byte-unchanged**
+  (the type is registered but unreachable without a memory — verify with a
+  host-mode WAT identity guard on a string program).
+- **R2 — missed consumer reads the wrong field.** A `LinearString` whose `ptr` is
+  mis-read as a `ref $__str_data` is a hard trap. Gate EVERY `data`-field read
+  behind `ref.test $LinearString` first, OR route all char access through one
+  shared `emitStrCharAt(ctx, …)` accessor that branches on the subtype. Enumerate
+  the `struct.get …nativeStrTypeIdx` sites in Slice 1; none may read `data`/`off`
+  without the dispatch.
+- **R3 — fd_write scratch collision.** The string heap must start past
+  `memory[0..11]`; pick a page boundary and assert disjointness.
+- **R4 — dual-mode parity (the #679/#682 invariant).** A `LinearString` must be
+  **observably identical** to a `NativeString` for every op that can reach it.
+  Slice 1's parity suite runs the SAME programs through both backends and diffs
+  results (length, index, charCodeAt, ===, <, concat, substring, escape-to-host).
+  No behaviour change; perf-only.
+- **R5 — leak/lifetime.** Documented bump-only tradeoff (D3); ship behind the WASI
+  gate, carve the arena/freelist follow-on as a separate issue, do not block Slice 1
+  on it.
+
+### Dispatch readiness
+
+This settles the representation (`LinearString` GC descriptor + linear char data),
+the boundary (create/read/build/escape with `ref.test` dispatch; no host-string
+interop needed under WASI), allocation/lifetime (bump-now/arena-later), and the
+JS-host interop story (untouched — gated to the no-host WASI lane). Slice 0
+(measure-first) is the recommended dev entry; it de-risks the whole feature before
+the type-table change lands. Dev task #3 (the prototype) can proceed from Slice 0.
 
 ## Notes
 


### PR DESCRIPTION
Settles the `needs_arch_spec` deliverable for #1762 (the strategic linear-memory string-backing perf substrate) so dev Slice 0 can proceed. **Spec only — no code.**

## What this settles (the `## Implementation Plan` in the issue file)
- **Representation**: a new `LinearString` subtype of `$AnyString` — a GC-managed descriptor `{ len, ptr, off }` with WTF-16 char data in WASI linear memory (V8 sequential-string model). Preserves the universal `ref $AnyString` handle so every existing consumer flows through unchanged.
- **Boundary**: create (literals + flatten/builder sink), read fast path (`i32.load16_u` — no GC read barrier, no opaque-ref `len`/`off`/`data` reloads), build fast path (`i32.store16` appends — no GC write barrier), escape via `ref.test $LinearString` arms in the universal consumers. No `wasm:js-string` interop needed — WASI has no JS host.
- **Allocation/lifetime**: reuse a WASI bump heap past the fd_write scratch; bump-now, arena/freelist follow-on (documented leak tradeoff).
- **Gate**: `ctx.wasi` only (linear memory present); default WasmGC byte-unchanged (new type registered append-only, unreachable without a memory).
- **Slicing**: Slice 0 *measure-first* (charCodeAt read arm + #1760 warm bench + #1746 native re-diff) as the go/no-go gate, then read / build / consolidation slices.

Verified all file:line anchors against current `main` (string struct layout `registry/types.ts:307`, `__str_concat` `native-strings.ts:1363`, WASI memory `index.ts:5973`, linear allocator `codegen-linear/runtime.ts`).

`needs_arch_spec: true → false`. Unblocks dev task #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)