### PR TITLE
docs(#1642): re-scope for-of IteratorClose to the residual 8 + verified root-cause

### DIFF
--- a/plan/issues/1642-spec-gap-for-of-iterator-close-on-throw.md
+++ b/plan/issues/1642-spec-gap-for-of-iterator-close-on-throw.md
@@ -1,12 +1,14 @@
 ---
 id: 1642
-title: "spec gap: for-of doesn't IteratorClose on body throw (portion of 389 fails)"
-status: ready
+title: "spec gap: for-of IteratorClose — RE-SCOPED to the residual 8 (return-method representation + generator-close)"
+status: in-progress
+assignee: ttraenkler/dev-conformance
 created: 2026-05-08
-updated: 2026-06-19
-priority: high
-feasibility: medium
-reasoning_effort: medium
+updated: 2026-06-26
+priority: medium
+feasibility: hard
+reasoning_effort: high
+needs_arch_spec: true
 task_type: bugfix
 area: codegen
 language_feature: iteration
@@ -14,6 +16,63 @@ goal: spec-completeness
 sprint: 66
 renumbered_from: 1348
 parent: 1328
+---
+
+## RE-SCOPE + VERIFIED FINDINGS (2026-06-26, dev-conformance)
+
+**The broad "389 fails / 48%->75%" framing is OBSOLETE.** Core IteratorClose
+landed since this issue was filed (2026-05-08). Verified on current `main`
+(re-grounded, not from issue text):
+
+- **Core close works**: close-on-throw, break, labeled-break, return-from-fn;
+  continue and normal completion correctly do NOT close. Both surviving
+  acceptance test262 files PASS via a faithful sta+assert harness:
+  `iterator-close-via-break.js`, `iterator-close-via-return.js`.
+- **Authoritative baseline** (`test262-current.jsonl`), for-of close cluster:
+  **7 pass / 8 fail.** The residual 8:
+  - 4 x `generator-close-via-{break,continue,return,throw}.js`
+  - 4 x `iterator-close-{non-throw-get-method-abrupt, non-throw-get-method-is-null,
+    return-emulates-undefined-throws-when-called, throw-get-method-abrupt}.js`
+
+### Root cause (this is why it needs an arch spec)
+
+The host `__iterator_return` (`src/runtime.ts:11143`) is itself spec-correct
+(GetMethod + IteratorClose: reads `iter.return` so a getter fires; null/undefined
+-> no-op; non-callable -> TypeError; abrupt propagates). The for-of close *call
+sites* are also wired (host-delegated path: break post-loop `loops.ts:4859`,
+throw try/catch_all `:4825`; struct path `:4436`). **The gap is that the user
+iterator's `return` method never reaches `__iterator_return` as a callable:**
+
+- An object-literal iterator `{ next(){}, return(){} }` (and a generator) lowers
+  to a **WasmGC struct**. At close time `__iterator_return` does
+  `iter.return ?? _sidecarGet(iter,"return") ?? __sget_return(iter)` -- but for
+  these structs the `return` **method field is not reachable** via `__sget_return`
+  (no such getter / methods are not readable data fields), so `ret` stays
+  undefined and close is a silent no-op. Minimal repro (closed=0, want 1):
+  `var iterable:any={}; iterable[Symbol.iterator]=function(){ return { next(){}, return(){ closed=1; } }; }; for (const _ of iterable) break;`
+  -- yet a **named** iterable-is-iterator literal
+  (`var it={[Symbol.iterator](){return this;}, next, return}`) DOES close (its
+  struct gets the field getter). So the bug is **iterator-object method-field
+  representation / `__sget_return` reachability**, not the close protocol.
+- `get return()` (accessor) cases additionally need the read to fire the getter
+  exactly once at close -- couples to the dynamic accessor read path.
+- **Generator-close** is a separate mechanism (the for-of must call the
+  generator's `.return()` so its `finally` runs); `function*` iterators do not
+  expose a struct `_return` the close path finds.
+- **Standalone**: `__iterator_return` native (`iterator-native.ts:213`) is a
+  **no-op stub** -- standalone close is entirely unimplemented (dual-mode gap).
+
+### Why arch spec (flagged to lead)
+
+The fix spans (a) iterator-object method-field representation + `__sget_return`
+emission, (b) accessor-`return` read semantics, (c) generator `.return()`
+integration with for-of close, (d) a real standalone-native `__iterator_return`,
+across the hot `loops.ts` close path + the iterator runtime, dual-mode. This
+overlaps the dynamic-object/method-representation ceiling (#2580 family).
+Recommend an architect `## Implementation Plan` (or senior-dev) before codegen.
+Slicing suggestion: (1) host-mode return-method reachability for the 4
+iterator-close edges first; (2) generator-close; (3) standalone-native.
+
 ---
 # #1348 — for-of / for-await-of: IteratorClose on abrupt completion
 

--- a/plan/issues/1642-spec-gap-for-of-iterator-close-on-throw.md
+++ b/plan/issues/1642-spec-gap-for-of-iterator-close-on-throw.md
@@ -102,62 +102,116 @@ A large portion of the assertion_fail failures (estimated ~150 of 304) check tha
 4. `language/statements/for-await-of/iterator-close-throw-error.js` passes.
 5. Pass-rate for `language/statements/for-of` rises from 48% to ≥75%.
 
-## Files to modify
+## Implementation Plan (2026-06-26 — re-scoped residual, dev-conformance trace)
 
-- `src/codegen/statements.ts` — `compileForOfStatement`, `compileForAwaitOfStatement`
-- `src/codegen/expressions.ts` — exception-region setup around for-of body
+> Supersedes the pre-#851 `try_table` sketch (now obsolete: core IteratorClose
+> shipped in #851/#1348 — see the historical notes below). This plan targets the
+> **residual 8** only. DO NOT implement as a single PR — slice as below; the
+> accessor/method-representation half overlaps the #2580 method-rep ceiling and
+> is senior-dev work.
 
-## Implementation Plan
+### Mechanism: the missing `__call_return` dispatcher (+ value-read for GetMethod)
 
-### Root cause
+`__iterator_next` reaches a struct iterator's `next` via the per-struct method
+dispatcher **`__call_next`**, emitted by `emitMethodDispatch("next","__call_next")`
+in `emitIteratorMethodExport` (`src/codegen/index.ts:2939-3035`): for each
+registered struct it emits `ref.test $StructN -> ref.cast -> call $StructN_next`,
+externref result, and registers the export in `ctx.funcMap`. There is
+`__call_@@iterator` + `__call_next` but **NO `__call_return`** — so the host
+`__iterator_return` (`src/runtime.ts:11143`) can only try `iter.return` (opaque on
+a struct -> undefined), `_sidecarGet(iter,"return")`, and `__sget_return(iter)` (a
+DATA-field getter; `return` is a METHOD/accessor, no such getter is emitted) -> the
+close silently no-ops. A NAMED iterable-is-iterator literal closes only when its
+struct happens to expose the field getter; an anonymous `{ next, return }` returned
+from `[Symbol.iterator]()` does not.
 
-The for-of body is currently emitted as a plain Wasm loop without a try/catch around it.
-When the body throws, control flows directly out of the loop — the iterator's `.return()` is
-never called. Spec requires the loop to be wrapped in a try-catch that catches any abrupt
-completion, calls `IteratorClose`, then re-raises.
+**Spec §7.4.6 IteratorClose + GetMethod (§7.3.10):** close must (1) `GetMethod(iter,
+"return")` — a value READ that fires an accessor `get return()` getter, (2) if the
+result is `undefined`/`null` return (no-op, no throw), (3) if not callable throw
+TypeError, (4) else Call it (binding `this=iter`), and on a throw outer-completion
+SUPPRESS any error from steps 1/3/4 (the existing nested try/catch_all at
+`loops.ts:4822` already models step-6 suppression). So the primitive needed is a
+value-producing **`GetMethod(iter,"return")`**, not just a method dispatch-call.
 
-### Approach
+### Slice 1 — host return-method reachability (the 4 `iterator-close-*` edges) [LAND FIRST]
 
-```wasm
-;; Pseudocode for compileForOfStatement
-local.set $iter
-loop $body
-  ;; Call iter.next()
-  local.get $iter
-  call $__iterator_next
-  ...
-  ;; Bind binding to value
-  ;; ─── BEGIN body try block ───
-  try_table $loop_close
-    <body>
-    br $body
-  end
-  ;; ─── END body — handler ───
-  ;; Body threw or break/return — call IteratorClose
-  local.get $iter
-  call $__iterator_close
-  rethrow $exn
-end loop
-```
+Files: `src/codegen/index.ts` (dispatcher), `src/runtime.ts` (host close).
 
-For `break`/`continue` to outer label and `return`, intercept the same way: emit a
-finally-style cleanup that runs IteratorClose before the actual jump.
+1. **Add a value-read driver `__get_return(iter) -> externref`** that yields the
+   iterator's `return` AS A VALUE (firing an accessor getter, or returning the bound
+   method closure for a plain `return(){}`), or `ref.null.extern` when absent. This
+   is the method-as-value half — model it on the existing accessor-get driver
+   `reserveAccessorGetDriver` (`src/codegen/accessor-driver.ts:72`) and the
+   `emitMethodDispatch` per-struct `ref.test/cast` shape. For a plain method `return`,
+   "get as value" must produce a callable closure bound to the struct (the
+   representation gap that overlaps #2580 — object-literal method fields are
+   currently dispatch-callable but not value-gettable as closures). If a clean
+   value-get for plain methods is not yet available, Slice 1 may add
+   `__call_return` (direct dispatch-call) for the plain-method path and use
+   `__get_return` only for the accessor path — but the GetMethod null/callable test
+   MUST run on the read result either way (do not blind-call).
+2. **Wire `__iterator_return`** (`runtime.ts:11143`): replace the
+   `iter.return ?? _sidecarGet ?? __sget_return` chain's struct arm with
+   `exports.__get_return?.(iter)` to obtain the value (fires the accessor), then apply
+   the existing GetMethod logic already present in that function (null/undefined ->
+   no-op; non-callable -> TypeError; callable -> call + result-object check). The
+   getter-side-effect (`returnGets++`), the null-skip, the abrupt-on-read propagation,
+   and step-6 suppression then all fall out of the host JS.
+   - `non-throw-get-method-is-null`: getter fires (returnGets=1) -> null -> no-op. PASS.
+   - `non-throw-get-method-abrupt`: getter read throws -> propagates (break path). PASS.
+   - `throw-get-method-abrupt`: getter read throws under a throw-completion -> suppressed
+     by the existing `:4822` nested try/catch_all -> original throw wins. PASS.
+   - `return-emulates-undefined-throws-when-called`: callable-but-throws-on-call -> the
+     call throws and propagates (break path) / is suppressed (throw path). PASS.
 
-For for-await-of: the IteratorClose must be `await`-ed; this requires inserting a yield-suspend
-point in the cleanup path.
+### Slice 2 — generator-close (the 4 `generator-close-via-*`)
 
-### Edge cases
+A `function*` used as a for-of iterator must, on abrupt completion, run the
+generator's `.return()` so its `finally` executes. Generators compile to a resume
+function + `.next()/.return()/.throw()` dispatch (`src/codegen/class-bodies.ts:2253`);
+they do NOT expose a struct `${name}_return` the close path finds. Slice 2 routes
+the for-of close to the generator's `.return()` — either by emitting a
+`${genStruct}_return` that the Slice-1 `__call_return`/`__get_return` dispatcher
+picks up, or by special-casing a generator receiver in `__iterator_return` to invoke
+the generator resume-return entry. Verify `finallyCount`/`startedCount` per the
+`generator-close-via-{break,continue,return,throw}.js` assertions.
 
-- Iterator without `.return()` — IteratorClose is a no-op.
-- `.return()` itself throws → re-raise the new error (replacing the original per spec
-  §7.4.6 IteratorClose step 6).
-- `break` to a label that's still inside the loop body — no close needed.
+### Slice 3 — standalone-native `__iterator_return` (§7.4.6)
 
-### Test262 sample
+The standalone native `__iterator_return` (`src/codegen/iterator-native.ts:213`) is a
+**no-op stub**. Implement the §7.4.6 sequence over the `$IterRec`/`$Object` runtime:
+native GetMethod(rec.userIter, "return") (own+proto, accessor-aware via the native
+object runtime), null-skip, callable-test (TypeError), call, result-object check,
+step-6 suppression. Gate behind the dual-mode contract (host import vs native) like
+the rest of the iterator runtime. Validate via the standalone floor (merge_group).
 
-- `test262/test/language/statements/for-of/iterator-close-throw-error.js`
-- `test262/test/language/statements/for-of/iterator-close-via-break.js`
-- `test262/test/language/statements/for-await-of/iterator-close-throw-error.js`
+### #2580 overlap (flagged)
+
+Slice 1's "method/accessor as a gettable value" is the same dynamic method-field
+representation gap tracked in the #2580 family (object-literal methods are
+dispatch-callable but not uniformly value-readable as bound closures). Coordinate the
+`__get_return` value-read with the #2580 substrate rather than building a parallel
+one-off; if #2580 lands a general method-as-value read first, Slice 1 consumes it.
+
+### Edge cases / invariants
+
+- Byte-identical for modules with no for-of-over-iterator (`emitMethodDispatch`
+  `entries.length===0` -> no dispatcher emitted).
+- Normal completion (`done=true`) and `continue` MUST NOT close (current behavior —
+  keep the `doneFlag` gate, `loops.ts:4854`).
+- Accessor `return` getter fires EXACTLY ONCE per close (one GetMethod read).
+- Both for-of paths (struct `loops.ts:4316` and host-delegated `:4476`) must reach the
+  new primitive; the struct path currently gates close on `returnMethodIdx!==undefined`
+  (`:4436`) and must also consult `__call_return`/`__get_return`.
+
+### Test262 acceptance (residual 8)
+
+`language/statements/for-of/`: `generator-close-via-{break,continue,return,throw}.js`,
+`iterator-close-non-throw-get-method-abrupt.js`,
+`iterator-close-non-throw-get-method-is-null.js`,
+`iterator-close-return-emulates-undefined-throws-when-called.js`,
+`iterator-close-throw-get-method-abrupt.js`. (Baseline today: for-of close cluster
+7 pass / 8 fail; Slice 1 targets the 4 `iterator-close-*`, Slice 2 the 4 generators.)
 
 ## Implementation notes (dev-1389, 2026-05-08)
 


### PR DESCRIPTION
## #1642 re-scope (planning artifact only)

Verify-first finding: the for-of IteratorClose core landed since #1642 was filed (2026-05-08). The broad **"389 fails / 48%→75%"** framing is **obsolete**.

**Verified on current main** (re-grounded, not from issue text):
- Core close works: throw / break / labeled-break / return-from-fn close; continue + normal completion correctly do NOT close. Both surviving acceptance test262 files PASS via a faithful sta+assert harness (`iterator-close-via-break.js`, `iterator-close-via-return.js`).
- Authoritative baseline (`test262-current.jsonl`) for-of close cluster: **7 pass / 8 fail.**

**Residual 8** = 4 × `generator-close-via-*` + 4 × `iterator-close-{get-method-abrupt/is-null, return-emulates-undefined-throws, throw-get-method-abrupt}`.

**Root cause** (full detail in the issue file): the host `__iterator_return` (runtime.ts:11143) is spec-correct, and the close call sites are wired — but an object-literal/generator iterator lowers to a **WasmGC struct whose `return` method isn't reachable at close** via `__sget_return`, so close is a silent no-op. Accessor-`return` needs lazy getter read; generator-close is a separate mechanism; standalone `__iterator_return` is a **no-op stub**. Spans iterator method-field representation + the iterator runtime, dual-mode → **needs an arch spec** (set `needs_arch_spec`, `feasibility: hard`, `reasoning_effort: high`).

This PR only updates the #1642 issue file (re-scope + root-cause groundwork) so the architect/senior-dev who takes the codegen restructure has a complete head start. No source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)