### PR TITLE
feat(wasi): #2658 B0 spike — P3 async stream<u8> echo runs under wasmtime 44 + nm_wasi_p3 comparison instance

### DIFF
--- a/examples/native-messaging/nm_wasi_p3.ts
+++ b/examples/native-messaging/nm_wasi_p3.ts
@@ -1,0 +1,99 @@
+// Native Messaging host, expressed against the **WASI Preview 3 (0.3)** async
+// `stream<u8>` surface — the P3 comparison instance for #2658.
+//
+// ┌─ STATUS: SOURCE-REFERENCE ────────────────────────────────────────────────┐
+// │ This file COMPILES ONCE THE js2wasm P3 ASYNC PRODUCER LANDS — see #2658     │
+// │ slices B2–B4 (the component-model-producer epic, deferred / gated on        │
+// │ #2525). js2wasm cannot yet emit a P3 component (async-lifted `run`,          │
+// │ `stream<u8>`/`future<T>` canonical-ABI lowering, `component-type` section).  │
+// │ The B0 spike PROVES the runtime target works: the runnable P3 async proof    │
+// │ is the hand-authored `p3-b0-spike/run-async.wat` + `run-p3-b0.sh`, and the   │
+// │ stream-echo binary shape this file mirrors is `p3-b0-spike/stream-echo.wat`. │
+// │ This is NOT a js2wasm-compiled P3 binary — none exists yet; do not treat it  │
+// │ as runnable. It is the intended SOURCE of the P3 arm of the comparison.      │
+// └────────────────────────────────────────────────────────────────────────────┘
+//
+// Contrast the siblings:
+//   * `nm_wasi.ts`    — WASI **Preview 1**: hand-marshals iovecs through linear
+//                       memory in an explicit `fd_read`/`fd_write` loop. Runs
+//                       today under wasmtime via `--target wasi`.
+//   * `nm_js2wasm.ts` — `node:fs` `readSync`/`writeSync(fd, …)`; runs under Node.
+//   * `nm_wasi_p3.ts` — WASI **Preview 3**: the host drives the byte copy over a
+//                       native `stream<u8>`; the guest just plumbs the stream and
+//                       awaits. The async-lifted entry suspends/resumes via the
+//                       component-model scheduler (the substrate #2646 wants —
+//                       interactive incremental stdin with no asyncify, no
+//                       pre-drain).
+//
+// Native Messaging protocol: each message is a 4-byte little-endian length prefix
+// followed by a UTF-8 JSON body, exchanged over stdin/stdout. In P3, stdin and
+// stdout are `stream<u8>` ends rather than fd 0 / fd 1. The simplest faithful
+// echo is a whole-stream hand-off: take stdin's readable stream and hand it to
+// stdout's writer; the host pumps every byte (prefix + body, opaque) straight
+// through. We await the write future so the task stays alive until the host has
+// drained the stream — resident memory stays flat regardless of message size.
+//
+// The P3 stdio surface mirrors wasi:cli@0.3.0-rc-2026-03-15 (the exact world id
+// wasmtime 44 hosts):
+//   stdin.read-via-stream:  () -> [stream<u8>, future<result<_, error-code>>]
+//   stdout.write-via-stream: (stream<u8>) -> future<result<_, error-code>>
+//   run: async () -> result
+
+// ---- ambient P3 component-model surface (provided by the P3 producer) ---------
+// These mirror the WASI 0.3 canonical-ABI handle types. Until the js2wasm P3
+// backend lands they are reference declarations describing the imports the
+// emitted component will bind to.
+
+/** A component-model `stream<u8>` readable/writable end (an opaque handle). */
+declare type StreamU8 = { readonly __brand: "stream<u8>" };
+
+/** error-code from wasi:cli/types@0.3.0-rc. */
+declare type WasiErrorCode = "io" | "illegal-byte-sequence" | "pipe";
+
+/** A component-model `future<result<_, error-code>>` (an opaque handle). */
+declare type WriteFuture = { readonly __brand: "future<result>" };
+
+// The P3 backend binds these to the component imports
+// `wasi:cli/stdin@0.3.0-rc-2026-03-15#read-via-stream` and
+// `wasi:cli/stdout@0.3.0-rc-2026-03-15#write-via-stream` (see wit/cli.wit in the
+// p3-b0-spike directory). They are ambient here so this source-reference
+// type-checks standalone — the component-import binding is the producer's job.
+
+/** stdin.read-via-stream: () -> [stream<u8>, future<result<_, error-code>>]. */
+declare function readViaStream(): [StreamU8, WriteFuture];
+
+/** stdout.write-via-stream: (stream<u8>) -> future<result<_, error-code>>. */
+declare function writeViaStream(data: StreamU8): WriteFuture;
+
+// ---- the P3 echo --------------------------------------------------------------
+// `run` is the async-lifted `wasi:cli/run@0.3.0-rc-2026-03-15` command export.
+// The whole-stream hand-off: read stdin's stream, give it to stdout, await the
+// host pump. No 4-byte-prefix bookkeeping is needed at the syscall layer — a
+// Native Messaging frame is an opaque byte run, and the host copies it through
+// the stream byte-for-byte (prefix + body, including high/null bytes), so the
+// receiver reconstructs framing from the raw bytes exactly as in `nm_wasi.ts`.
+
+export async function run(): Promise<void> {
+  // Obtain the stdin readable stream. The paired read-future is left to the host
+  // (dropping the stream's readable end resolves it to success on clean EOF).
+  const [stdinStream] = readViaStream();
+
+  // Hand the same readable stream straight to stdout — the host pumps stdin
+  // bytes to stdout with no per-message guest copy.
+  const writeDone: WriteFuture = writeViaStream(stdinStream);
+
+  // Await the write future: the async-lifted `run` suspends here and is resumed
+  // by the component-model scheduler when the host has drained the whole stream
+  // (EOF) or hit an error. This is the suspend/resume point that gives #2646
+  // interactive streaming "for free" — the host, not asyncify, drives it.
+  await awaitFuture(writeDone);
+}
+
+/** Await a component-model `future<result>`. Under the P3 backend this lowers to
+ *  `future.read` + the task suspending on the host scheduler (see the canonical
+ *  await loop hand-authored in `p3-b0-spike/stream-echo.wat`). */
+declare function awaitFuture(future: WriteFuture): Promise<void>;
+
+// Invoke the async entry point. js2wasm's P3 backend lifts this top-level call
+// into the component's async `wasi:cli/run@0.3.0-rc-2026-03-15` `run` export.
+void run();

--- a/examples/native-messaging/p3-b0-spike/.gitignore
+++ b/examples/native-messaging/p3-b0-spike/.gitignore
@@ -1,0 +1,3 @@
+# Build artifacts produced by run-p3-b0.sh (regenerated on demand).
+*.wasm
+.stream-echo.err

--- a/examples/native-messaging/p3-b0-spike/README.md
+++ b/examples/native-messaging/p3-b0-spike/README.md
@@ -1,0 +1,57 @@
+# #2658 B0 spike — native WASI Preview 3 (0.3) async, de-risked
+
+This directory is the **runnable output of the #2658 Slice B0 spike** — the
+de-risking probe for "target WASI Preview 3". It is **not** the js2wasm P3
+producer (that is the deferred B2–B4 epic, gated on #2525). It proves the P3
+async _runtime target_ works on this box and pins the exact binary shape a
+js2wasm P3 producer must emit. Full write-up: `plan/issues/2658-wasi-preview3-target.md`
+→ "B0 Spike Findings".
+
+## Files
+
+| File              | What it is                                                                                                                              | State                                                                                                                      |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `run-async.wat`   | Minimal P3 component exporting `wasi:cli/run@0.3.0-rc-2026-03-15` as an **async**-lifted `run` (async lift + callback + `task.return`). | ✅ **Runs** under wasmtime 44.                                                                                             |
+| `stream-echo.wat` | The P3 `stream<u8>` stdin→stdout echo, authored against the authoritative WIT (host-driven stream hand-off).                            | ⚠️ Parses with jco; **blocked at wasmtime decode** by the `future<T>` encoding skew. Serves as the binary-shape reference. |
+| `wit/cli.wit`     | Authoritative `wasi:cli@0.3.0-rc-2026-03-15` stdio interfaces (trimmed from wasmtime v44).                                              | reference                                                                                                                  |
+| `run-p3-b0.sh`    | Build + run both artifacts; shows #1 running and #2 hitting the documented gap.                                                         | —                                                                                                                          |
+
+```bash
+bash examples/native-messaging/p3-b0-spike/run-p3-b0.sh
+```
+
+## What the spike established
+
+- **wasmtime 44 hosts WASI `0.3.0-rc-2026-03-15`** (NOT final `0.3.0`) via
+  `-S p3=y`, with `-W component-model-async{,-builtins,-stackful}=y` enabling the
+  async canonical ABI and the `task.*`/`waitable-set.*`/`stream.*`/`future.*`
+  built-ins.
+- **The async-command half of the ABI runs here** — async lift, callback, and
+  `task.return` are functional (`run-async.wat`). So a _synchronous_ P3 `run`
+  producer (B2) is unblocked.
+- **The `stream`/`future` half is blocked by a toolchain encoding skew, not a
+  feature flag.** Any component using a `future<T>` type fails to _decode_ in
+  wasmtime 44 ("instance not valid to be used as import"), in import or export
+  position, under every async flag combination. Bisected: bare `stream<u8>` and
+  `tuple<stream<u8>, u32>` decode fine; adding a `future<…>` member breaks it.
+  The bundled wasm-tools (jco 1.16.1) _encodes_ `future` in a layout wasmtime
+  44's decoder rejects — a component-model-async type-encoding version skew.
+- **Named prerequisite for B3:** build the P3 producer against a wasm-tools whose
+  `future`/`stream` encoding matches wasmtime 44, and validate with `wasmtime`
+  directly (not only `jco parse`, which masked the skew).
+
+## The P3 echo shape (why P3 is the clean substrate for #2646)
+
+P3 stdio is a host-driven stream hand-off:
+
+```
+run():
+  let (s, _read_fut) = stdin.read-via-stream();   // s: stream<u8>
+  let write_fut      = stdout.write-via-stream(s); // host pumps s -> stdout
+  await write_fut;                                  // suspend/resume via host scheduler
+```
+
+The host drives the stdin→stdout copy and the async-lifted `run` suspends at the
+await — exactly the incremental loop-borrow #2646 needs, with no asyncify and no
+pre-drain. Contrast `../nm_wasi.ts` (P1), which hand-marshals iovecs through
+linear memory in an explicit `fd_read`/`fd_write` loop.

--- a/examples/native-messaging/p3-b0-spike/run-async.wat
+++ b/examples/native-messaging/p3-b0-spike/run-async.wat
@@ -1,0 +1,39 @@
+;; #2658 B0 spike — minimal native WASI Preview 3 (0.3) ASYNC command component.
+;;
+;; This is the RUNNABLE P3 proof: a hand-authored component that exports
+;; `wasi:cli/run@0.3.0-rc-2026-03-15` as an ASYNC-lifted `run`, exercising the
+;; component-model async canonical ABI (async lift + callback + `task.return`).
+;; It does NOT touch streams — it proves the P3 async *runtime target* works on
+;; this box before the stream/future producer machinery (the deferred B2/B3
+;; epic) is built. See ./README.md and ../../../plan/issues/2658-*.md.
+;;
+;; Build + run (see run-p3-b0.sh):
+;;   jco parse run-async.wat -o run-async.wasm
+;;   wasmtime run -W component-model-async=y -S p3=y run-async.wasm   # -> exit 0
+;;
+;; The world id is the EXACT version wasmtime 44 hosts: 0.3.0-rc-2026-03-15
+;; (NOT the final 0.3.0). `run: async func() -> result`.
+(component
+  ;; The async-lifted core `run`:
+  ;;   * calls `task.return` with the result (`ok` = discriminant 0), then
+  ;;   * returns the async status code 0 = EXIT (task complete, no waiting).
+  ;; `cb` is the callback the host scheduler would resume on a wait event; here
+  ;; the task completes synchronously so it is never invoked.
+  (core module $m
+    (import "" "task-return" (func $tr (param i32)))
+    (func (export "run") (result i32)
+      (call $tr (i32.const 0))   ;; task.return(ok)
+      (i32.const 0))             ;; async status: 0 = EXIT (done)
+    (func (export "cb") (param i32 i32 i32) (result i32) (i32.const 0)))
+
+  ;; `task.return` for `result` (unit ok/err) takes the discriminant as one i32.
+  (core func $tr (canon task.return (result (result))))
+  (core instance $i
+    (instantiate $m (with "" (instance (export "task-return" (func $tr))))))
+  (alias core export $i "cb" (core func $cb))
+
+  ;; Async lift WITH a callback. (memory is unnecessary for the unit result.)
+  (func $run (result (result))
+    (canon lift (core func $i "run") async (callback $cb)))
+  (instance $runinst (export "run" (func $run)))
+  (export "wasi:cli/run@0.3.0-rc-2026-03-15" (instance $runinst)))

--- a/examples/native-messaging/p3-b0-spike/run-p3-b0.sh
+++ b/examples/native-messaging/p3-b0-spike/run-p3-b0.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# #2658 B0 spike — build + run the native WASI Preview 3 (0.3) demonstrations.
+#
+# Two artifacts:
+#   1. run-async.wat   — minimal P3 ASYNC command (RUNS under wasmtime 44).
+#   2. stream-echo.wat — P3 stream<u8> stdin->stdout echo (parses; gated at the
+#                        wasmtime decode step by the future<T> encoding skew —
+#                        see README.md / plan/issues/2658-*.md "B0 Spike Findings").
+#
+# Prereqs on this box: wasmtime 44, and jco (bundled via componentize-js — this
+# script resolves it the same way scripts/wasi-p2-component.mjs does).
+#
+# Usage:  bash examples/native-messaging/p3-b0-spike/run-p3-b0.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE/../../.." && pwd)"
+
+# Resolve the vendored jco CLI (no standalone wasm-tools on this box).
+JCO="$(node -e "import('file://$REPO/scripts/wasi-p2-component.mjs').then(m=>{const j=m.resolveJco();if(!j){process.exit(3)}process.stdout.write(j.cli)})")"
+if [ -z "${JCO:-}" ]; then
+  echo "FATAL: could not resolve @bytecodealliance/jco — run 'pnpm install'." >&2
+  exit 3
+fi
+
+ASYNC_FLAGS="-W component-model-async=y -W component-model-async-builtins=y -W component-model-async-stackful=y"
+
+echo "== 1. minimal P3 async command (run-async.wat) =="
+node "$JCO" parse "$HERE/run-async.wat" -o "$HERE/run-async.wasm" || { echo "parse FAILED"; exit 1; }
+echo "   parsed -> run-async.wasm"
+# shellcheck disable=SC2086
+if printf 'x' | wasmtime run -W component-model-async=y -S p3=y "$HERE/run-async.wasm"; then
+  echo "   ✅ RAN under wasmtime 44 (exit 0) — P3 async canonical ABI works here."
+else
+  echo "   ❌ did not run (unexpected — was proven 2026-06-26)."
+fi
+
+echo
+echo "== 2. P3 stream<u8> echo (stream-echo.wat) =="
+if node "$JCO" parse "$HERE/stream-echo.wat" -o "$HERE/stream-echo.wasm" 2>/dev/null; then
+  echo "   parsed with jco -> stream-echo.wasm (wasm-tools accepts the future<T> encoding)"
+else
+  echo "   ❌ jco parse failed (unexpected)."
+fi
+echo "   attempting to run under wasmtime 44 (expected: future<T> decode gap)..."
+# shellcheck disable=SC2086
+if printf 'hello P3\n' | wasmtime run $ASYNC_FLAGS -S p3=y "$HERE/stream-echo.wasm" 2>"$HERE/.stream-echo.err"; then
+  echo "   ✅ stream echo RAN — the future<T> encoding skew has been resolved!"
+else
+  echo "   ⚠️  blocked at wasmtime decode (the documented B3 prerequisite):"
+  sed 's/^/      /' "$HERE/.stream-echo.err" | head -4
+  rm -f "$HERE/.stream-echo.err"
+fi

--- a/examples/native-messaging/p3-b0-spike/stream-echo.wat
+++ b/examples/native-messaging/p3-b0-spike/stream-echo.wat
@@ -1,0 +1,105 @@
+;; #2658 B0 spike — native WASI Preview 3 (0.3) async stream<u8> stdin->stdout ECHO.
+;;
+;; Authored against the AUTHORITATIVE wasi:cli@0.3.0-rc-2026-03-15 stdio WIT
+;; (fetched from wasmtime v44.0.0 crates/wasi/src/p3/wit/deps/cli.wit):
+;;
+;;   stdin.read-via-stream:  func() -> tuple<stream<u8>, future<result<_, error-code>>>
+;;   stdout.write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>
+;;   run: async func() -> result
+;;
+;; The P3 echo is a host-driven stream HAND-OFF: read-via-stream() yields the
+;; stdin readable stream; hand that same stream to write-via-stream(); the HOST
+;; pumps stdin->stdout; the guest awaits the returned future<result>. The guest
+;; barely touches the bytes (contrast nm_wasi.ts, which hand-marshals iovecs).
+;;
+;; STATUS — parses with `jco parse`, but does NOT yet run under wasmtime 44:
+;;   wasmtime rejects the `future<T>`-typed import at DECODE time:
+;;     "failed to parse WebAssembly module / instance not valid to be used as import"
+;;   under EVERY component-model-async feature-flag combination.
+;;   Bisected: bare `stream<u8>` and `tuple<stream<u8>, u32>` decode fine; adding
+;;   a `future<...>` member breaks the decode. Root cause = a component-model-async
+;;   `future`/`stream` TYPE-ENCODING skew between jco 1.16.1's bundled wasm-tools
+;;   (encodes it) and wasmtime 44's decoder (rejects it) — NOT a feature flag and
+;;   NOT a js2wasm issue. Closing this skew (newer wasm-tools / encoding that
+;;   matches wasmtime 44) is the named prerequisite for B3. See ./README.md and
+;;   ../../../plan/issues/2658-*.md "B0 Spike Findings".
+;;
+;; This file is therefore the BINARY-SHAPE REFERENCE for the js2wasm P3 producer
+;; (B2/B3), paired with the runnable run-async.wat for the proven async-command
+;; half of the ABI.
+(component
+  (type $ec (enum "io" "illegal-byte-sequence" "pipe"))
+  (type $rd-ret (tuple (stream u8) (future (result (error $ec)))))
+  (type $wr-ret (future (result (error $ec))))
+
+  (import "wasi:cli/stdin@0.3.0-rc-2026-03-15" (instance $stdin
+    (export "read-via-stream" (func $rvs (result $rd-ret)))))
+  (import "wasi:cli/stdout@0.3.0-rc-2026-03-15" (instance $stdout
+    (export "write-via-stream" (func $wvs (param "data" (stream u8)) (result $wr-ret)))))
+  (alias export $stdin "read-via-stream" (func $read-hl))
+  (alias export $stdout "write-via-stream" (func $write-hl))
+
+  ;; libc: memory + bump cabi_realloc, instantiated FIRST to break the
+  ;; lower/lift memory cycle (no shim/fixup table needed — the memory does not
+  ;; live in the instance that imports the lowered host funcs).
+  (core module $libc
+    (memory (export "memory") 1)
+    (global $bump (mut i32) (i32.const 1024))
+    (func (export "realloc") (param i32 i32 i32 i32) (result i32)
+      (local $p i32)
+      (local.set $p (global.get $bump))
+      (global.set $bump (i32.add (global.get $bump) (local.get 3)))
+      (local.get $p)))
+  (core instance $libci (instantiate $libc))
+  (alias core export $libci "memory" (core memory $mem))
+  (alias core export $libci "realloc" (core func $realloc))
+
+  ;; Lowered host imports (return-area / handles in libc memory).
+  (core func $read-low  (canon lower (func $read-hl)  (memory $mem) (realloc $realloc)))
+  (core func $write-low (canon lower (func $write-hl) (memory $mem) (realloc $realloc)))
+  ;; Async built-ins to await the host-side write pump.
+  (core func $task-return (canon task.return (result (result))))
+  (core func $ws-new (canon waitable-set.new))
+  (core func $ws-wait (canon waitable-set.wait (memory $mem)))
+  (core func $w-join (canon waitable.join))
+  (core func $fread (canon future.read $wr-ret (memory $mem)))
+
+  (core module $main
+    (import "libc" "memory" (memory 1))
+    (import "h" "read" (func $read (param i32)))             ;; -> retptr [stream@0, future@4]
+    (import "h" "write" (func $write (param i32) (result i32))) ;; stream handle -> future handle
+    (import "h" "task-return" (func $tr (param i32)))
+    (import "h" "ws-new" (func $wsnew (result i32)))
+    (import "h" "ws-wait" (func $wswait (param i32 i32) (result i32)))
+    (import "h" "w-join" (func $wjoin (param i32 i32)))
+    (import "h" "fread" (func $fr (param i32 i32) (result i32)))
+    (func (export "run")
+      (local $s i32) (local $wfut i32) (local $ws i32) (local $st i32)
+      (call $read (i32.const 0))                  ;; read-via-stream() -> [s, rfut]
+      (local.set $s (i32.load (i32.const 0)))      ;; stdin readable stream handle
+      (local.set $wfut (call $write (local.get $s))) ;; hand it to stdout; future<result>
+      (local.set $ws (call $wsnew))
+      (call $wjoin (local.get $wfut) (local.get $ws))
+      (local.set $st (call $fr (local.get $wfut) (i32.const 16))) ;; drive completion
+      (block $done
+        (br_if $done (i32.eqz (i32.and (local.get $st) (i32.const 0xf)))) ;; already complete
+        (drop (call $wswait (local.get $ws) (i32.const 8))))             ;; else block until done
+      (call $tr (i32.const 0))))   ;; task.return(ok)
+
+  (core instance $maini (instantiate $main
+    (with "libc" (instance $libci))
+    (with "h" (instance
+      (export "read" (func $read-low))
+      (export "write" (func $write-low))
+      (export "task-return" (func $task-return))
+      (export "ws-new" (func $ws-new))
+      (export "ws-wait" (func $ws-wait))
+      (export "w-join" (func $w-join))
+      (export "fread" (func $fread))))))
+
+  ;; Async lift WITHOUT a callback (stackful) — the core run() blocks on
+  ;; waitable-set.wait while the host pumps the stream.
+  (func $run-lifted (result (result))
+    (canon lift (core func $maini "run") async (memory $mem)))
+  (instance $ri (export "run" (func $run-lifted)))
+  (export "wasi:cli/run@0.3.0-rc-2026-03-15" (instance $ri)))

--- a/examples/native-messaging/p3-b0-spike/wit/cli.wit
+++ b/examples/native-messaging/p3-b0-spike/wit/cli.wit
@@ -1,0 +1,34 @@
+// #2658 B0 spike — authoritative WASI Preview 3 stdio interfaces.
+//
+// Trimmed from wasmtime v44.0.0 crates/wasi/src/p3/wit/deps/cli.wit to just the
+// types/run/stdin/stdout interfaces the echo needs (the upstream `command`
+// world additionally pulls wasi:clocks/filesystem/sockets/random). The package
+// version string is EXACTLY the world id wasmtime 44 hosts.
+package wasi:cli@0.3.0-rc-2026-03-15;
+
+interface types {
+  enum error-code {
+    io,
+    illegal-byte-sequence,
+    pipe,
+  }
+}
+
+interface run {
+  // The command entrypoint — ASYNC in P3 (suspends/resumes via the host
+  // scheduler, the substrate #2646 interactive streaming wants).
+  run: async func() -> result;
+}
+
+interface stdin {
+  use types.{error-code};
+  // Returns the stdin readable stream PLUS a future signalling read completion.
+  read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
+}
+
+interface stdout {
+  use types.{error-code};
+  // Hand the host a readable stream; the host drains it to stdout. The returned
+  // future resolves when the whole stream has been written (or errors).
+  write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
+}

--- a/plan/issues/2658-wasi-preview3-target.md
+++ b/plan/issues/2658-wasi-preview3-target.md
@@ -1,9 +1,10 @@
 ---
 id: 2658
 title: "WASI Preview 3 (0.3) target — scope: adapter-interop tops out at P2, native-P3 is a component-model epic"
-status: ready
+status: in-progress
+assignee: ttraenkler/sdev-p3-b0
 created: 2026-06-25
-updated: 2026-06-25
+updated: 2026-06-26
 priority: low
 feasibility: hard
 reasoning_effort: high
@@ -213,3 +214,155 @@ developer)**
 - The #2525 component-model substrate itself (prerequisite, tracked separately).
 - Reviving the #2646 asyncify approach (superseded by Path 2 Slice B3 long-term;
   remains the P1-host fallback).
+
+## B0 Spike Findings (2026-06-26, executed)
+
+Slice **B0** was executed — the de-risking spike for Path 2 (NOT the producer
+itself). Goal: prove a minimal native P3 async component runs on this box, and
+pin the exact binary shape js2wasm must emit for B2/B3. Artifacts live under
+`examples/native-messaging/p3-b0-spike/` (hand-authored WAT + run script) and the
+`nm_wasi_p3.ts` source-reference comparison instance. **Headline: the P3 async
+runtime target is real and runnable here; the producer toolchain on this box has
+a precise `future<T>` encoding gap that B2/B3 must close.**
+
+### Toolchain probed (this box, 2026-06-26)
+
+| Tool     | Version                                                                                     | Relevant capability                                                                                                                                                                                                                |
+| -------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| wasmtime | **44.0.0** (`af382d7d9`, 2026-04-20)                                                        | Hosts WASI **`0.3.0-rc-2026-03-15`** worlds. `-S p3=y` enables WASIp3 host APIs; `-W component-model-async{,-builtins,-stackful}=y` enable async lifting/lowering + the `task.*`/`waitable-set.*`/`stream.*`/`future.*` built-ins. |
+| jco      | **1.16.1** (pnpm dir `@bytecodealliance+jco@1.17.6`; vendored via `componentize-js@0.19.3`) | `jco parse`/`embed`/`new`/`print` wrap a **bundled** wasm-tools (`obj/wasm-tools.core.wasm`). No standalone `wasm-tools`/`cargo`/`rustc` on the box. `componentize` (StarlingMonkey) emits **P2 only**.                            |
+
+The world id wasmtime 44 actually hosts is **`0.3.0-rc-2026-03-15`**, NOT the
+final `0.3.0`. A producer MUST emit that exact package version string or
+wasmtime rejects the world (`no exported instance named wasi:cli/run@…`).
+
+### Authoritative P3 stdio WIT (fetched from `wasmtime` v44.0.0,
+
+`crates/wasi/src/p3/wit/deps/cli.wit`)
+
+```wit
+package wasi:cli@0.3.0-rc-2026-03-15;
+
+interface types { enum error-code { io, illegal-byte-sequence, pipe } }
+
+interface run {                       // the command entrypoint
+  run: async func() -> result;        // <-- ASYNC-lifted export
+}
+
+interface stdin {
+  use types.{error-code};
+  read-via-stream: func() -> tuple<stream<u8>, future<result<_, error-code>>>;
+}
+
+interface stdout {
+  use types.{error-code};
+  write-via-stream: func(data: stream<u8>) -> future<result<_, error-code>>;
+}
+```
+
+So the **elegant P3 echo** is a stream hand-off: `read-via-stream()` yields the
+stdin `stream<u8>`; pass that same readable end to `write-via-stream(data)`; the
+host pumps stdin→stdout; the guest awaits the returned `future<result>`. The
+guest barely touches the bytes — the host drives the copy. (Contrast the P1
+`nm_wasi.ts`, which hand-marshals iovecs through linear memory in a
+`fd_read`/`fd_write` loop.)
+
+### ✅ What RUNS here (de-risked)
+
+1. **A genuine P3 async command runs under wasmtime 44.** A hand-authored
+   component that exports `wasi:cli/run@0.3.0-rc-2026-03-15` with an
+   **async-lifted** `run` — `(canon lift (core func) async (callback $cb))`,
+   the core `run` calling `(canon task.return (result (result)))` then returning
+   the `EXIT` code `0` — runs cleanly:
+   `wasmtime run -W component-model-async=y -S p3=y run-async.wasm` → rc 0.
+   This proves the **async canonical ABI** (async lift + callback + `task.return`)
+   is fully functional on this box. This is the runnable B0 proof
+   (`p3-b0-spike/run-async.wat` + `run-p3-b0.sh`).
+2. **`stream<u8>` types encode and decode fine.** A component importing a
+   function returning bare `stream<u8>` — or `tuple<stream<u8>, u32>` — decodes
+   and reaches the linker stage (not a parse error).
+3. **The lower/lift memory cycle has a clean break.** Put `memory` + a bump
+   `cabi_realloc` in a small **libc** core module instantiated _first_; alias its
+   memory/realloc; `canon lower` the host imports and `canon lift` the `run`
+   export against that memory; instantiate `$main` with `(with "libc" (instance
+$libc))` + the lowered-import instance. No shim/fixup indirection table is
+   needed because the memory does not live in the instance that imports the
+   lowered funcs. (`wasm-tools component new` would instead auto-generate the
+   shim+fixup table idiom — verified by inspecting a real adapted P2 component.)
+
+### ❌ The precise blocker for the FULL stream echo (`future<T>` encoding skew)
+
+A component that uses a **`future<T>`** type — in EITHER an imported-instance
+function signature (e.g. `stdin.read-via-stream`'s
+`tuple<stream<u8>, future<result<_, error-code>>>`) or an export — **fails to
+DECODE in wasmtime 44**, under every async feature-flag combination
+(`component-model-async`, `-async-builtins`, `-async-stackful`,
+`-error-context`, `-gc`):
+
+```
+Error: failed to parse WebAssembly module
+Caused by: instance not valid to be used as import (at offset 0x…)
+```
+
+Bisected precisely: bare `stream<u8>` ✅ decodes, `tuple<stream<u8>, u32>` ✅
+decodes, but adding a `future<…>` member ❌ breaks the **decode**. Since the
+entire P3 stdio surface returns `future<result<_, error-code>>`, a fully-running
+stdin→stdout stream echo **cannot be produced with the on-box toolchain
+combination** (jco 1.16.1's bundled wasm-tools + wasmtime 44).
+
+**Root cause = component-model-async TYPE-ENCODING version skew**, not a missing
+feature flag and not a js2wasm issue: the `future`/`stream` canonical type
+encoding evolved between the wasm-tools snapshot jco 1.16.1 vendors (late-2025
+era) and wasmtime 44 (2026-04). wasm-tools _parses + encodes_ the `future`-typed
+component; wasmtime's decoder _rejects_ that encoding. The `stream-echo.wat`
+artifact is authored to the correct authoritative WIT and **parses with jco**,
+but is gated at the wasmtime decode step by exactly this skew (documented inline
+in the file + reproduced by `run-p3-b0.sh`).
+
+### Binary-shape spec js2wasm's P3 producer (B2/B3) must emit
+
+A native P3 component for `wasi:cli/run@0.3.0-rc-2026-03-15` consists of:
+
+1. **`component-type` custom section** describing the world — package version
+   string **`0.3.0-rc-2026-03-15`** exactly; `run` typed `async func() -> result`.
+2. **Async-lifted `run` export**: `(canon lift (core func $run) async (callback
+$cb) (memory $mem) (realloc $realloc))`. The core `run` implements the async
+   protocol — returns the packed status code (`EXIT`/`WAIT`/`YIELD`/`POLL` in the
+   low 4 bits, waitable-set index in the high bits) and calls `(canon
+task.return (result (result)))` to deliver its result; `$cb` is the callback
+   resumed by the host scheduler. (For the simpler model, lift `async` _without_
+   a callback and use blocking `waitable-set.wait` under
+   `-W component-model-async-stackful`.)
+3. **`cabi_realloc`** (a real bump/allocator) + an owned, exported `memory`.
+4. **`stream<u8>` / `future<result<_, error-code>>` lowering** of the stdio
+   imports via `(canon lower (func …) (memory $mem) (realloc $realloc))`, plus
+   the async built-ins `(canon stream.read/​stream.write/​future.read/​
+waitable-set.new/​waitable-set.wait/​waitable.join/​subtask.drop …)` to drive
+   and await the host-side stream pump. read-via-stream returns the
+   `tuple<stream, future>` via a return-area pointer (the tuple exceeds 1 flat
+   result); write-via-stream takes the stream handle (flat i32) and returns the
+   future handle.
+5. **resource/handle tables** for the `stream`/`future` handles (i32 indices
+   into the component's per-instance tables).
+6. **The lower/lift memory-cycle break** (libc-first or shim+fixup, both work).
+
+**Gate output for B1+:** B2/B3 must be built against a wasm-tools whose
+`future`/`stream` encoding matches **wasmtime 44**'s decoder (upgrade jco's
+bundled wasm-tools, vendor a matching standalone `wasm-tools`, or have the native
+producer emit the type encoding wasmtime 44 expects and validate with `wasmtime`
+directly — NOT only `jco parse`, which is what masked the skew). The
+async-command half of the ABI (lift/callback/`task.return`) is already proven to
+run, so B2 (sync `run` producer) is unblocked by this finding; only the
+`stream`/`future` half (B3) carries the encoding-skew dependency.
+
+### B0 verdict
+
+- **B0 acceptance met:** a runnable minimal P3 async component demonstrated under
+  wasmtime 44 (`run-async.wat`), the binary-shape spec written (above), the
+  `nm_wasi_p3.ts` comparison instance produced (source-reference, honestly
+  labeled — the js2wasm P3 producer is the deferred B2–B4 epic).
+- **Sizing unchanged:** B0 did NOT prove the epic is cheaper than scoped. The
+  async-command runtime works, but the `future`/`stream` producer half now
+  carries a _concrete, named_ prerequisite (toolchain encoding-skew resolution)
+  on top of the component-model-producer work. Path 2 (B2–B4) stays **deferred /
+  gated on #2525**. Issue remains **`in-progress`** (B0 done; B2–B4 deferred).


### PR DESCRIPTION
## #2658 Slice B0 — native WASI Preview 3 (0.3) de-risking spike

Executes the **B0 spike** from the #2658 scope (NOT the producer epic B2–B4, which stays deferred / gated on #2525).

### Outcome: RUNS (async command) + precise blocker (stream/future)

- **wasmtime 44 hosts WASI `0.3.0-rc-2026-03-15`** (NOT final `0.3.0`) via `-S p3=y`; `-W component-model-async{,-builtins,-stackful}` enable the async ABI + built-ins.
- ✅ **PROVEN runnable:** a genuine P3 async `wasi:cli/run@0.3.0-rc` command (async lift + callback + `task.return`) runs under wasmtime 44 — the async canonical ABI works on this box. So a *synchronous* P3 `run` producer (B2) is unblocked.
- ❌ **Blocker for the full stream echo:** any `future<T>`-typed import/export **fails to DECODE** in wasmtime 44 (`instance not valid to be used as import`), under every async feature-flag combination. Bisected precisely: bare `stream<u8>` and `tuple<stream<u8>, u32>` decode fine; adding a `future<…>` member breaks the decode. Root cause = a **component-model-async `future`/`stream` type-encoding skew** between jco 1.16.1's bundled wasm-tools (encodes it) and wasmtime 44's decoder (rejects it) — NOT a feature flag, NOT a js2wasm issue. This is the named prerequisite for B3.
- Authoritative `wasi:cli@0.3.0-rc` stdio WIT + the full binary-shape spec js2wasm's P3 producer must emit are written into the issue's `## B0 Spike Findings`.

### Deliverables

- `plan/issues/2658-wasi-preview3-target.md` — `## B0 Spike Findings` spec (toolchain probe, authoritative WIT, what runs, the precise `future` blocker, binary-shape requirements, gate output for B1+). Issue set `in-progress`.
- `examples/native-messaging/p3-b0-spike/`
  - `run-async.wat` — minimal P3 async command, **runs under wasmtime 44** (the runnable proof).
  - `stream-echo.wat` — P3 `stream<u8>` stdin→stdout echo (host-driven stream hand-off), authored to the authoritative WIT; **parses with jco, gated at the wasmtime decode** by the `future<T>` skew. Binary-shape reference.
  - `wit/cli.wit` — authoritative trimmed P3 stdio WIT.
  - `run-p3-b0.sh` — builds + runs both; shows #1 running and #2 hitting the documented gap.
  - `README.md` (new subdir file) — spike explainer.
- `examples/native-messaging/nm_wasi_p3.ts` — the P3 comparison instance, **SOURCE-REFERENCE** (honestly labeled: compiles once the js2wasm P3 async producer lands — B2–B4; the B0 spike proves the runtime target works). tsc/prettier clean. NOT a faked compiled binary.

### Scope guard

Does **NOT** touch `examples/native-messaging/README.md` or `tests/native-messaging-comparison.test.ts` (another agent owns them; the harness gates the P3 row gracefully). No compiler `src/` changes — B0 is a spike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)