### PR TITLE
fix(#2678): Date.parse / new Date(str) in HOST mode (dual-mode host fast-path)

### DIFF
--- a/plan/issues/2678-date-parse-host-mode-js-string.md
+++ b/plan/issues/2678-date-parse-host-mode-js-string.md
@@ -1,7 +1,9 @@
 ---
 id: 2678
 title: "Date.parse / new Date(str) are NaN stubs in HOST mode — native parser is standalone/WASI-only (needs js-string externref support)"
-status: ready
+status: done
+completed: 2026-06-26
+assignee: ttraenkler/dev-conformance
 created: 2026-06-25
 priority: medium
 feasibility: medium
@@ -74,3 +76,25 @@ otherwise. Two reasons it was gated off for host:
 - This is the bigger of the two #2671 Date gaps; `getYear` (Annex B §B.2.4, the
   other gap) was a quick win done separately under #2671.
 - Dual-mode rule: host-mode wiring must not disturb the standalone native path.
+
+
+## Resolution (2026-06-26)
+
+Fixed via a dual-mode HOST fast-path. `Date.parse(...)` and `new Date(<string>)`
+in host mode now delegate to the JS `Date.parse` through a new host import
+`__date_parse_host(externref) -> f64` (runtime.ts), registered **up-front** by a
+new `collectDateParseHostImports` scan in `declarations.ts` (state flag
+`dateParseHostNeeded`, scan + finalize) so the funcidx is stable and the #2043
+late-import shift the gate comment cited is avoided. The two call sites
+(`calls.ts` Date.parse, `new-super.ts` new Date(str)) gained a host branch ahead
+of the old NaN stub. Host strings are real `wasm:js-string` externrefs and the JS
+`Date.parse` is more format-complete than the native ISO parser.
+
+**Standalone/WASI unchanged** — the scan only sets the flag in host mode, so the
+native `__date_parse` (#2164) stays the only path there; verified no
+`__date_parse_host` import leaks into a `target: standalone`/`wasi` module. The
+host-only import is not in the strict allowlist (no #1524 budget growth).
+
+Guarded by `tests/issue-2678.test.ts` (9 cases: ISO + date-only parse, variable
+arg, invalid→NaN, no-arg→NaN, new Date(str), numeric construction unaffected,
+Invalid Date). The issue-2164 standalone Date suite stays green.

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -96,6 +96,10 @@ interface UnifiedCollectorState {
   mathNeedsToUint32: boolean;
   // -- collectParseImports --
   parseNeeded: Set<string>;
+  // (#2678) HOST-mode `Date.parse(...)` / `new Date(<string>)` → host import
+  // `__date_parse_host` (delegates to JS Date.parse). Registered up-front to
+  // avoid the #2043 late-import shift; standalone/WASI use the native parser.
+  dateParseHostNeeded: boolean;
   // -- collectURIImports --
   uriNeeded: Set<string>;
   // -- collectStringStaticImports --
@@ -194,6 +198,7 @@ export function createUnifiedCollectorState(sourceFile: ts.SourceFile): UnifiedC
     mathNeeded: new Set(),
     mathNeedsToUint32: false,
     parseNeeded: new Set(),
+    dateParseHostNeeded: false,
     uriNeeded: new Set(),
     needsFromCharCode: false,
     needsFromCodePoint: false,
@@ -520,6 +525,39 @@ export function unifiedVisitNode(ctx: CodegenContext, state: UnifiedCollectorSta
       node.operatorToken.kind === ts.SyntaxKind.AsteriskAsteriskEqualsToken)
   ) {
     state.mathNeeded.add("pow");
+  }
+
+  // ── collectDateParseHostImports (#2678) ──
+  // HOST mode only — standalone/WASI use the native `__date_parse` emitted at
+  // the call site. `Date.parse(...)` (member call) and `new Date(<string>)`
+  // both delegate to the host JS `Date.parse` via `__date_parse_host`.
+  if (!ctx.standalone && !ctx.wasi) {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      ts.isIdentifier(node.expression.expression) &&
+      node.expression.expression.text === "Date" &&
+      node.expression.name.text === "parse" &&
+      node.arguments.length >= 1
+    ) {
+      state.dateParseHostNeeded = true;
+    }
+    if (
+      ts.isNewExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "Date" &&
+      node.arguments &&
+      node.arguments.length === 1
+    ) {
+      try {
+        const argType = ctx.checker.getTypeAtLocation(node.arguments[0]!);
+        if (argType.flags & ts.TypeFlags.StringLike || isStringType(argType)) {
+          state.dateParseHostNeeded = true;
+        }
+      } catch {
+        // type resolution may fail — skip (a runtime ToString path still applies)
+      }
+    }
   }
 
   // ── collectParseImports ──
@@ -1266,6 +1304,16 @@ export function finalizeUnifiedCollector(ctx: CodegenContext, state: UnifiedColl
     if (parseNative.size > 0) {
       emitNativeParseNumber(ctx, parseNative);
     }
+  }
+
+  // ── collectDateParseHostImports finalize (#2678) ──
+  // HOST mode: register `__date_parse_host(externref) -> f64` up-front so the
+  // call sites (Date.parse / new Date(<string>)) get a stable funcidx without a
+  // mid-body late-import shift (#2043). Standalone/WASI never reach here (the
+  // scan only sets the flag for host mode); they keep the native `__date_parse`.
+  if (state.dateParseHostNeeded && !ctx.standalone && !ctx.wasi && !ctx.funcMap.has("__date_parse_host")) {
+    const typeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "f64" }]);
+    addImport(ctx, "env", "__date_parse_host", { kind: "func", typeIdx });
   }
 
   // ── collectURIImports finalize ──

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -8441,7 +8441,29 @@ function compileCallExpression(
       // can register __date_parse up-front (like parseInt in index.ts) to extend
       // native parsing to host mode.
       if (method === "parse") {
-        if (expr.arguments.length === 0 || !(ctx.standalone || ctx.wasi)) {
+        // Date.parse() with no args → NaN (§21.4.3.2 — ToString(undefined)).
+        if (expr.arguments.length === 0) {
+          fctx.body.push({ op: "f64.const", value: NaN } as Instr);
+          return { kind: "f64" };
+        }
+        // (#2678) HOST mode: delegate to the JS `Date.parse` host import
+        // (`__date_parse_host`, registered up-front by collectDateParseHostImports
+        // so no mid-body late-import shift / #2043). Host strings are real
+        // wasm:js-string externrefs and JS Date.parse is more format-complete than
+        // the native ISO parser. Falls back to the prior NaN stub only if the
+        // up-front scan somehow missed registering the import.
+        if (!ctx.standalone && !ctx.wasi) {
+          const hostIdx = ctx.funcMap.get("__date_parse_host");
+          if (hostIdx !== undefined) {
+            const argType = compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "externref" });
+            if (argType && argType.kind !== "externref") coerceType(ctx, fctx, argType, { kind: "externref" });
+            for (let i = 1; i < expr.arguments.length; i++) {
+              const t = compileExpression(ctx, fctx, expr.arguments[i]!);
+              if (t) fctx.body.push({ op: "drop" } as Instr);
+            }
+            fctx.body.push({ op: "call", funcIdx: hostIdx } as Instr);
+            return { kind: "f64" };
+          }
           for (const arg of expr.arguments) {
             const t = compileExpression(ctx, fctx, arg);
             if (t) fctx.body.push({ op: "drop" } as Instr);
@@ -8449,7 +8471,7 @@ function compileCallExpression(
           fctx.body.push({ op: "f64.const", value: NaN } as Instr);
           return { kind: "f64" };
         }
-        // Register the native parser, then push the (sole) argument as externref.
+        // Standalone / WASI: pure-Wasm native parser (#2164).
         emitNativeDateParse(ctx);
         const dateParseIdx = ctx.funcMap.get("__date_parse")!;
         const argType = compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "externref" });

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -3112,6 +3112,18 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
         if (argType && argType.kind !== "externref") coerceType(ctx, fctx, argType, { kind: "externref" });
         flushLateImportShifts(ctx, fctx);
         fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__date_parse")! } as Instr);
+      } else if (
+        !ctx.standalone &&
+        !ctx.wasi &&
+        isStringTypedArg(ctx, args[0]!) &&
+        ctx.funcMap.has("__date_parse_host")
+      ) {
+        // (#2678) HOST mode: a String arg is parsed as if by Date.parse
+        // (§21.4.2.1) — delegate to the JS `Date.parse` host import (registered
+        // up-front by collectDateParseHostImports, no #2043 late-import shift).
+        const argType = compileExpression(ctx, fctx, args[0]!, { kind: "externref" });
+        if (argType && argType.kind !== "externref") coerceType(ctx, fctx, argType, { kind: "externref" });
+        fctx.body.push({ op: "call", funcIdx: ctx.funcMap.get("__date_parse_host")! } as Instr);
       } else {
         compileExpression(ctx, fctx, args[0]!, { kind: "f64" });
       }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -6985,6 +6985,12 @@ function resolveImport(
       //      string → StringToBigInt (SyntaxError on malformed numeric string);
       //      Symbol → TypeError.
       // Returns the bigint as a wasm i64 (JS-BigInt-integration).
+      // (#2678) Date.parse / new Date(<string>) in HOST mode. Host strings are
+      // real `wasm:js-string` externrefs, so the JS `Date.parse` runs directly
+      // (and is more format-complete than the native ISO parser). Registered
+      // up-front by collectDateParseHostImports (declarations.ts) so its funcidx
+      // is stable. Returns f64 ms (NaN on an unparseable string).
+      if (name === "__date_parse_host") return (s: any): number => Date.parse(s);
       if (name === "__bigint_ctor") {
         return (v: any): bigint => {
           // ToPrimitive(value, number). WasmGC structs / proxies need our

--- a/tests/issue-2678.test.ts
+++ b/tests/issue-2678.test.ts
@@ -1,0 +1,69 @@
+// #2678 — Date.parse / new Date(str) in HOST mode.
+//
+// The native string-date parser (#2164) works on standalone/WASI but was gated
+// OFF for host mode (calls.ts / new-super.ts emitted a NaN stub) because wiring
+// the helper lazily mid-body tripped the #2043 late-import shift. Host strings
+// are real wasm:js-string externrefs, so this routes Date.parse / new Date(str)
+// through a host import (`__date_parse_host`) delegating to JS Date.parse —
+// registered UP-FRONT (collectDateParseHostImports) so the funcidx is stable.
+// Standalone/WASI keep the native parser (verified: no host-import leak).
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+
+async function run(body: string): Promise<any> {
+  const src = `export function test(): any { ${body} }`;
+  const result: any = await compile(src, { fileName: "test.ts" } as any);
+  expect(result.binary?.length).toBeGreaterThan(0);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  return wrapExports(instance.exports, { signatures: result.exportSignatures });
+}
+
+describe("#2678 — Date.parse / new Date(str) in host mode", () => {
+  it("Date.parse of an ISO 8601 string returns the epoch ms", async () => {
+    const exp = await run(`return Date.parse("2000-01-01T00:00:00.000Z");`);
+    expect(exp.test()).toBe(946684800000);
+  });
+
+  it("new Date(isoString).getTime() returns the epoch ms", async () => {
+    const exp = await run(`return new Date("1970-01-01T00:00:00.000Z").getTime();`);
+    expect(exp.test()).toBe(0);
+  });
+
+  it("Date.parse of a later ISO date", async () => {
+    const exp = await run(`return Date.parse("2020-06-15T12:00:00.000Z");`);
+    expect(exp.test()).toBe(1592222400000);
+  });
+
+  it("Date.parse of an unparseable string returns NaN", async () => {
+    const exp = await run(`var r = Date.parse("not a date"); return r !== r ? 1 : 0;`);
+    expect(exp.test()).toBe(1);
+  });
+
+  it("Date.parse() with no argument returns NaN", async () => {
+    const exp = await run(`var r = Date.parse(); return r !== r ? 1 : 0;`);
+    expect(exp.test()).toBe(1);
+  });
+
+  it("Date.parse reads through a variable", async () => {
+    const exp = await run(`var s = "2000-01-01T00:00:00.000Z"; return Date.parse(s);`);
+    expect(exp.test()).toBe(946684800000);
+  });
+
+  it("new Date(ms) numeric construction is unaffected", async () => {
+    const exp = await run(`return new Date(1000).getTime();`);
+    expect(exp.test()).toBe(1000);
+  });
+
+  it("Date.parse of a date-only string (host JS Date.parse format coverage)", async () => {
+    const exp = await run(`return Date.parse("2000-01-01");`);
+    expect(exp.test()).toBe(946684800000);
+  });
+
+  it("new Date(str) of an invalid string yields an Invalid Date (NaN getTime)", async () => {
+    const exp = await run(`var t = new Date("nope").getTime(); return t !== t ? 1 : 0;`);
+    expect(exp.test()).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2678 — `Date.parse` / `new Date(str)` were NaN stubs in HOST mode

The native string-date parser (#2164) works on standalone/WASI but was gated **off** for host mode (`calls.ts:8443` / `new-super.ts` emitted `f64.const NaN`), because wiring the helper lazily mid-body trips the #2043 late-import shift. Verified on main: host `Date.parse("2000-01-01T…Z")` → NaN, `new Date(str).getTime()` → NaN.

### Fix — dual-mode host fast-path
Host strings are real `wasm:js-string` externrefs, so delegate to JS `Date.parse` (also more format-complete than the native ISO parser) via a new host import `__date_parse_host(externref) -> f64` (`runtime.ts`), **registered up-front** by a new `collectDateParseHostImports` scan in `declarations.ts` (state flag `dateParseHostNeeded` + scan + finalize) so the funcidx is stable (no #2043 shift). The two call sites gained a host branch ahead of the old NaN stub.

### Dual-mode invariants (verified)
- **Standalone/WASI unchanged** — the scan only flags host mode, so the native `__date_parse` stays the only path there. Confirmed **no `__date_parse_host` import leaks** into a `target: standalone`/`wasi` module (instantiates with empty imports).
- Host-only import → **no #1524 strict-allowlist growth** (host-import budget + gate tests green).

### Tests
`tests/issue-2678.test.ts` (9): ISO + date-only parse, variable arg, invalid→NaN, no-arg→NaN, `new Date(str)`, numeric construction unaffected, Invalid Date. The issue-2164 standalone Date suite stays green; lint/prettier/coercion-site/silent-fallback/host-import gates all clean locally.

Carved from #2671 (ES2015 Date residuals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)