### PR TITLE
docs(#2669): verify-first diagnosis — dstr binding codegen correct; root cause is closure-capture box lazy-init

### DIFF
--- a/plan/issues/2669-es6-destructuring-correctness-residual-umbrella.md
+++ b/plan/issues/2669-es6-destructuring-correctness-residual-umbrella.md
@@ -89,3 +89,96 @@ language/statements/class/dstr/private-meth-ary-ptrn-elem-ary-elision-init.js
 Keep #1642, #2566, #1556 as the concrete sub-issues; this umbrella tracks the
 aggregate and the remaining un-issued tail (binding patterns, object-method
 params, arrow params).
+
+## Verify-first investigation (sd-dstr, 2026-06-26) — premise correction
+
+Branched off `upstream/main` @ `51134ae24`; fetched baseline jsonl; reproduced
+samples with **fresh single-file processes** (not in-process batch).
+
+### Verified fail count (path-based, `/dstr/` + `destructuring`)
+**1499 non-pass** (not ~696): `fail` 1427, `compile_timeout` 56, `compile_error`
+16. The ~696 in the title was a feature-tag-filtered subset; the path-based count
+is ~2× larger. By pattern kind from the test basename: ARRAY-pattern 1043,
+OBJECT-pattern 208, neither/other 247, mixed-nested 1.
+
+### KEY FINDING — the binding-pattern codegen is already CORRECT
+Minimal fresh-process probes (via `runTest262File` harness, both strict modes):
+
+| probe | result |
+|-------|--------|
+| `let [a=7,b=9]=[undefined,undefined]` (default FIRES) | **pass** |
+| `let [a=7,b=9]=[1,2]` (default SKIP) | **pass** |
+| `var c=0;function k(){c+=1;return 5} let [a=k()]=[undefined]; assert c==1` | **pass** |
+| `let [a,...r]=[1,2,3]` (rest) | **pass** |
+| `let [,a,,b]=[1,2,3,4]` (elision) | **pass** |
+
+So array default-init / rest / elision / value-present / value-skip lowering is
+spec-correct. The umbrella's premise ("default-init / holes / rest binding-pattern
+codegen is broken") is **largely wrong** for the WasmGC host path.
+
+### ROOT CAUSE of the dominant failure cluster — closure-capture box lazy-init
+The standard test262 dstr template declares a **captured counter**:
+`var initCount=0; function counter(){ initCount += 1 }`. `initCount` is captured
+& mutated by a nested function, so it is boxed into a ref cell
+(`$__ref_cell_f64`). The box (`struct.new` + `local.tee __boxed_initCount`) is
+materialized **lazily at the first call site** of `counter`, in
+`src/codegen/expressions/calls.ts` (the `nestedFuncCaptures` mutable-capture
+branch, ~L12359–12383): it does `local.get <outer>; struct.new <refCell>;
+local.tee <box>` and then re-aims `localMap[name]` to the box for **all**
+subsequent reads/writes.
+
+The bug: that `struct.new` is emitted into **whatever body buffer is active**,
+which for a destructuring default is the conditional `then`-branch of the
+`__extern_is_undefined` / sNaN check (`emitDefaultValueCheck`,
+`src/codegen/statements/destructuring.ts`). When the element is present the
+default arm does **not** execute at runtime → the box is never created → it
+stays `ref.null` → every later read of the captured var (incl. the test's final
+`assert.sameValue(initCount, 0)` and even plain value reads) dereferences a null
+ref cell and yields the sNaN→`NaN` sentinel. Test fails.
+
+**This is NOT destructuring-specific.** Confirmed minimal repro with a plain
+conditional, no destructuring at all:
+```ts
+export function test(): number {
+  var c = 0;
+  function k() { c += 1; }
+  if (c > 100) { k(); }   // not-taken branch — only call site to k
+  return c;               // reads through the never-created box → NaN
+}
+// returns NaN, should return 0
+```
+The dstr default-init tests are simply the **largest surface** of a general
+closure ref-cell materialization defect: *a mutable captured variable's box is
+created lazily at the first capturing call site; when that site is a
+conditionally-skipped branch, the box is never created and all reads corrupt.*
+
+### Fix direction (and why it needs care — prior regressions)
+Correct fix: materialize the box **eagerly at the variable's declaration** (or at
+the nested-function-declaration point, which is where `ctx.nestedFuncCaptures` is
+populated — `src/codegen/statements/nested-declarations.ts:764`), unconditionally,
+so `localMap`/`boxedCaptures` re-aim and the box exist before any conditional use;
+the call site then just `local.get`s the existing box. **This is the exact area
+that regressed before** — the in-code comments at calls.ts:12361 document
+#1177 Stage 1 (the `localMap.get ?? outerLocalIdx` attempt) causing **100+
+test262 regressions**, and PR#166 a type-only guard causing **net −25 / 33
+wasm-change regressions**. Hoisting interacts with `var`/function hoisting order
+and per-iteration `for`-let box identity (closures.ts:1699–1705). So this needs
+an architect spec + full `merge_group` validation, not an inline patch.
+
+### Recommendation
+- This is a **distinct, high-value, independent** (NOT substrate-gated) codegen
+  root cause — recommend carving a **dedicated issue** (closure-capture box
+  eager-materialization) via `claim-issue.mjs --allocate`, routed through
+  architect given the #1177/#PR166 regression history. It likely unblocks a
+  large fraction of the 1499 (every dstr test using the captured-counter
+  template, plus general closure correctness).
+- The genuinely destructuring-specific residual buckets remain the existing open
+  sub-issues: **#1642** (for-of IteratorClose on abrupt completion, ~129
+  iterator-protocol sigs), **#2566** (generator-as-source eager-buffer
+  over-consumption — e.g. `let [[,]=g()]=[]` over-runs the generator), **#1556**
+  (param-pattern struct-field type mismatch, ~153 null-deref sigs).
+- Umbrella Slice B ("default-init evaluation + elision/hole iteration") should be
+  **closed as already-correct** for the host path per the probes above; its
+  apparent failures are the closure-box bug.
+
+Repro driver + probes used: `.tmp/runsrc.mts`, `.tmp/runwasm.mts` (gitignored).


### PR DESCRIPTION
## Summary

Verify-first investigation for the #2669 destructuring umbrella. **Docs-only** — records the diagnosis in the issue file; no code change.

## Key findings (full detail in the issue file)

- **Verified fail count: 1499** non-pass `/dstr/` tests (fail 1427, compile_timeout 56, compile_error 16) — ~2× the ~696 estimate (the estimate was a feature-tag subset; this is path-based).
- **The array binding-pattern codegen is already spec-correct.** Five fresh-process minimal probes (default fires, default skip, rest, elision, captured-counter-with-default-firing) all **pass**. The umbrella's premise that default-init/holes/rest binding-pattern lowering is broken is **largely wrong** for the WasmGC host path.
- **Dominant root cause is a GENERAL closure-capture defect, not a destructuring bug.** A mutable captured variable's ref-cell box is materialized *lazily at the first capturing call site* (`src/codegen/expressions/calls.ts` ~L12359, the `nestedFuncCaptures` mutable branch). For a destructuring default that call site is a conditional `then`-branch; when the default does not fire at runtime the box is never created → null ref cell → all later reads of the captured var return the sNaN→`NaN` sentinel. The dstr default-init tests (standard template uses a captured `counter()`) are the largest *surface* of this. Confirmed with a destructuring-free repro:
  ```ts
  export function test(): number {
    var c = 0; function k() { c += 1; }
    if (c > 100) { k(); }   // not-taken; only call site
    return c;               // reads never-created box -> NaN (should be 0)
  }
  ```

## Recommendation
- Carve a **dedicated issue** for closure-capture box **eager-materialization** (at declaration / nested-func-decl point), routed through **architect** — this exact area regressed before (#1177 Stage 1 = 100+ test262 regressions; PR#166 = net −25), so it needs a spec + full `merge_group` validation, not an inline patch.
- Close umbrella **Slice B** (default-init + elision/hole) as already-correct for the host path.
- Keep genuinely dstr-specific residual in the existing sub-issues: **#1642** (IteratorClose), **#2566** (generator over-consume), **#1556** (param struct-field mismatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)