### PR TITLE
fix(#2692): materialize closure-capture ref-cell box eagerly at function-top

### DIFF
--- a/plan/issues/2692-closure-capture-box-eager-materialization.md
+++ b/plan/issues/2692-closure-capture-box-eager-materialization.md
@@ -324,6 +324,35 @@ This touches broad closure codegen and is the exact machinery behind the
 4. Confirm the expected large **improvement** in the `/dstr/` cluster
    (captured-counter template) materializes — that is the value signal.
 
+## Implementation note — first floor attempt regressed, fix applied (sd-dstr, 2026-06-26)
+
+PR #2102's first `merge_group` floor run **regressed -133 net** (189 pass→other,
+56 improvements). Root cause pinned via the merged-report jsonl diff + WAT of a
+failing case (`Reflect/apply/arguments-list-is-not-array-like`):
+
+- The regressions were **all `let`/`const` captures** (the entire for-await-of
+  async-dstr cluster uses `let x`/`let iterCount`; the scattered Promise/module
+  cases likewise). Validation error: `ref.is_null expected reference type, found
+  local.get of type f64`.
+- Mechanism: eager-boxing a `let`/`const` captured var at function-top **races
+  the variable's own block-scoped declaration**. The `let count` decl, compiled
+  later, re-allocates the value slot (block-scope shadow / type reset) and resets
+  `localMap[count]` to a fresh **f64** local — but `boxedCaptures[count]` stays
+  set from the eager pass. The var-decl box-write path (`boxedForInit`) then runs
+  `local.get <fresh f64>; ref.is_null` → invalid Wasm. (`var` decls and params
+  have no such re-declaration, so they were fine — and the captured-counter dstr
+  win, all `var`-based, held: 56 improvements.)
+- **Fix:** `emitEagerCaptureBoxes` now **skips TDZ-flagged (`let`/`const`)
+  captures** (`if (cap.hasTdzFlag) continue;`). Those fall back to the existing
+  lazy call-site boxing (pre-#2692 behaviour — correct for the non-conditional
+  cases that dominate; the conditional-branch `let`-counter residual is a small
+  follow-up, noted in code). `var`/param captures keep eager boxing → the #2669
+  win.
+- **Post-fix local re-verification** (fresh single-file, the exact regressed
+  files): for-await-of cluster + the 6 runnable non-for-await regressions all
+  flip back to pass; new `tests/issue-2692-closure-box-eager.test.ts` 12/12 still
+  green; tsc clean. Re-validated on the full floor before re-enqueue.
+
 ## References (read before implementing)
 
 - `src/codegen/expressions/calls.ts` L12316–12354 — lazy box (current) + narrow

--- a/plan/issues/2692-closure-capture-box-eager-materialization.md
+++ b/plan/issues/2692-closure-capture-box-eager-materialization.md
@@ -1,0 +1,342 @@
+---
+id: 2692
+title: "Closure-capture ref-cell box must be materialized eagerly at declaration, not lazily at first call site"
+status: done
+assignee: sd-dstr
+completed: 2026-06-26
+created: 2026-06-26
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: closures
+goal: correctness
+sprint: 66
+related: [2669, 1177, 1556]
+---
+# #2692 — Closure-capture ref-cell box: eager materialization at declaration
+
+## Problem
+
+A mutable closure-captured variable (a variable written by a nested
+`function` declaration) is wrapped in a ref-cell box (`struct (field $value
+(mut T))`) so writes propagate across the scope boundary. Today that box is
+materialized **lazily, at the FIRST capturing call site** —
+`src/codegen/expressions/calls.ts` ~L12330–12354 (the `nestedFuncCaptures`
+mutable-capture branch). The call site emits:
+
+```wasm
+local.get <outerLocalIdx>          ;; current value of the captured var
+struct.new <refCellTypeIdx>        ;; box it
+local.tee <__boxed_name>           ;; stash the box in a new outer local
+```
+
+and then **mutates compile-time state** that outlives the buffer it emitted
+into: `fctx.localMap.set(name, boxedLocalIdx)` (re-aim every later read/write
+to go through the box) and `fctx.boxedCaptures.set(name, …)`.
+
+### Root cause (the buffer/state split)
+
+The compile-time re-aim (`localMap` / `boxedCaptures`) is **global to the
+function context**, but the runtime box-creation instructions
+(`struct.new` + `local.tee`) are emitted into **whatever body buffer is active
+at that call site**. When the first capturing call site sits inside a
+**conditionally-executed buffer** — a destructuring default's then-branch
+(`emitDefaultValueCheck` / `emitNestedBindingDefault` in
+`src/codegen/statements/destructuring.ts`), or any `if` / ternary / `&&` arm —
+and that branch does **not** run at runtime, the box is never created. The
+`__boxed_name` local stays `ref.null`, yet every later read of the captured
+var was statically re-aimed to `struct.get` on that null box → null deref →
+the read yields the sNaN→`NaN` sentinel. Wrong result.
+
+This is **not destructuring-specific**. Minimal repro, no destructuring at all,
+returns `NaN` instead of `0`:
+
+```ts
+export function test(): number {
+  var c = 0;
+  function k() { c += 1; }   // c is captured-mutable → boxed
+  if (c > 100) { k(); }      // only call site to k, in a not-taken branch
+  return c;                  // statically re-aimed to struct.get on a box
+                             // that was never struct.new'd → NaN
+}
+```
+
+The standard test262 destructuring template
+(`var initCount = 0; function counter(){ initCount += 1 }`, then a default-init
+arm calls `counter()`) is the **largest single surface** of this defect —
+sd-2669 attributes a large fraction of the 1499 `/dstr/` non-passes to it (full
+diagnosis: `plan/issues/2669-…md` → "Verify-first investigation"). The
+destructuring binding/default/rest/elision lowering itself is already correct;
+the failures come from this closure-box bug.
+
+## Acceptance criteria
+
+- The repro above returns `0`.
+- The captured-counter destructuring template
+  (`var initCount=0; function counter(){initCount+=1}; let [a=counter()]=[1];
+  assert.sameValue(initCount,0)`) passes.
+- No net regression in the test262 `merge_group` floor; the closure / TDZ /
+  for-of-destructure clusters in particular must not regress (see
+  Validation — this is the exact machinery that produced 100+ regressions in
+  #1177 Stage 1 and net −25 in PR#166).
+
+## Implementation Plan
+
+### Strategy: materialize the box EAGERLY during function-declaration hoisting
+
+Move the `local.get; struct.new; local.set` box creation out of the call site
+and into the **function-declaration hoisting pass**, where it lands in an
+**unconditional, function-top body buffer**. The call site then only consumes
+the already-existing box (the existing already-boxed branch handles that with
+no `struct.new`).
+
+#### Why hoisting is the correct (and only safe) locus
+
+`hoistFunctionDeclarations` (`src/codegen/statements/nested-declarations.ts`
+L1157) runs at function-body entry, **after** `hoistVarDeclarations` and
+`hoistLetConstWithTdz` (see `src/codegen/function-body.ts` L1122–1128), so:
+
+1. **All capturable slots already exist.** `var`/`let`/`const`/param slots and
+   TDZ flags are allocated before function-decl hoisting, so
+   `cap.outerLocalIdx` is valid and the box's initial `local.get` reads a real
+   slot.
+2. **The active buffer is the function-top `fctx.body`, unconditionally.**
+   Hoisting **recurses into `if` / `try` / loop / `switch` blocks**
+   (nested-declarations.ts L1310–1361) to lift function declarations to
+   function scope, but it does **not** swap `fctx.body` while doing so — there
+   is no `pushBody`/branch buffer in the hoist walk. So a `function k(){…}`
+   that is *textually* inside `if (cond) { … }` still gets its box emitted into
+   the **top-level** function buffer. This is precisely what fixes the bug: the
+   box-creation can never land in a conditionally-skipped buffer again.
+3. **Function-declaration semantics match.** JS hoists function declarations to
+   the top of the enclosing function scope, so a box created at function-top is
+   live before any textual use of the name — exactly the binding the nested
+   function shares.
+
+This is a **declaration-side** mirror of the existing call-site machinery; it
+does **not** widen the *set* of boxed variables (same `mutable && valType &&
+!alreadyBoxed` predicate the call site uses) — it only changes *when* and
+*into which buffer* the box is created.
+
+#### Exact insertion point
+
+In `hoistFunctionDeclarations`
+(`src/codegen/statements/nested-declarations.ts`), inside the per-statement
+loop, **after** the successful `compileNestedFunctionDeclaration(...)` call
+(L1285) and its success check (the `else if (reservedEntry)` arm completes
+around L1304) — i.e. only on the path where `ctx.nestedFuncCaptures.get(
+funcName)` is populated and the hoist did **not** roll back (L1288–1301 deletes
+`nestedFuncCaptures` on failure). Emit there, NOT inside
+`compileNestedFunctionDeclaration` itself, because:
+
+- the rollback path truncates `ctx.mod.functions` and deletes
+  `nestedFuncCaptures` but does **not** rewind `fctx.body`; emitting from
+  inside the compile helper would orphan box-init instructions in `fctx.body`
+  if the body later errored;
+- at the L764 `nestedFuncCaptures.set` site, `ctx.currentFunc` has already been
+  swapped to `liftedFctx` (L736) — emitting there is error-prone.
+
+Pseudocode for the new emit (factor into a helper, e.g.
+`emitEagerCaptureBoxes(ctx, fctx, funcName)`):
+
+```ts
+const caps = ctx.nestedFuncCaptures.get(funcName);
+if (caps) {
+  for (const cap of caps) {
+    if (!cap.mutable || !cap.valType) continue;        // match call-site predicate
+    if (fctx.boxedCaptures?.has(cap.name)) continue;   // dedup: already boxed by a sibling
+    // Don't re-box an outer slot that is itself already the canonical cell
+    // (#2623 alreadyBoxed) — those thread through unchanged.
+    const refCellTypeIdx = getOrRegisterRefCellType(ctx, cap.valType);
+    const boxedLocalIdx = allocLocal(fctx, `__boxed_${cap.name}`, {
+      kind: "ref", typeIdx: refCellTypeIdx,
+    });
+    fctx.body.push({ op: "local.get", index: cap.outerLocalIdx });
+    fctx.body.push({ op: "struct.new", typeIdx: refCellTypeIdx });
+    fctx.body.push({ op: "local.set", index: boxedLocalIdx });   // set, not tee — nothing on stack needed
+    fctx.localMap.set(cap.name, boxedLocalIdx);
+    if (!fctx.boxedCaptures) fctx.boxedCaptures = new Map();
+    fctx.boxedCaptures.set(cap.name, { refCellTypeIdx, valType: cap.valType });
+  }
+}
+```
+
+Notes:
+- Use `local.set` (not `local.tee`) — the eager site does not need the box on
+  the stack (unlike the call site, which needs it as the prepended call arg).
+- The `__boxed_<name>` naming convention is **load-bearing** — the call-site
+  narrow guard (calls.ts L12309–12314) recognizes a deliberately-boxed slot by
+  *both* its ref-cell type **and** the `__boxed_` name prefix. Preserve it.
+- Keep `boxedCaptures` and `localMap` writes **in lockstep** with the
+  `__boxed_` naming — this paired invariant is what makes the call-site guard
+  safe (PR#166 broke it by using a type-only guard).
+
+#### Keep the call site working (re-aim, no re-creation)
+
+No structural change is required at calls.ts L12316–12354. After eager
+boxing, `fctx.boxedCaptures.has(cap.name)` is already true at the call site, so
+control flows into the **already-boxed branch** (L12316–12329): it emits
+`local.get <fctx.localMap.get(cap.name)>` (the eager box) and passes it as the
+prepended ref-cell arg. The `struct.new` branch (L12330–12354) is simply no
+longer reached for eagerly-boxed names. Verify (read-time) that the
+already-boxed branch's `currentLocalIdx = fctx.localMap.get(cap.name) ??
+cap.outerLocalIdx` resolves to the eager box index.
+
+### Why prior attempts regressed, and why this one differs
+
+- **#1177 Stage 1 (PR#125, 100+ regressions; #1245):** changed the call-site
+  *value source* to `localMap.get(name) ?? outerLocalIdx`, i.e. it boxed the
+  *already-re-aimed* slot. That re-sourcing unmasked systematic spec bugs
+  (notably #1258 — `compileForOfAssignDestructuringExternref` writing past the
+  box — and #1259) and depended on "wrong-slot" main behavior some async tests
+  relied on. **This change does not touch the call-site value source** — it
+  boxes `cap.outerLocalIdx` (the canonical declaration slot) once, at
+  function-top, then the call site reads the box. The #1258/#1259 blockers are
+  already **done** (box-aware for-of-assign writes landed), removing the two
+  largest Stage-1 regression clusters.
+- **PR#166 (net −25, 33 wasm-change regressions):** widened the
+  already-boxed detection to a **type-only** guard, so a coincidentally
+  same-ref-cell-typed local was mistaken for a box. **This change keeps the
+  narrow two-signal guard** (`__boxed_` name + matching ref-cell type) and
+  always writes `boxedCaptures` + `localMap` + the `__boxed_` name together, so
+  the guard's invariant holds.
+- **#1205 value force-box (48+ for-await regressions):** force-boxed the
+  *value* whenever a TDZ flag was present — boxing variables the call-site path
+  would not have boxed, and tripping the direct-`local.set` write paths in
+  loops. **This change boxes exactly the call-site predicate set**
+  (`mutable && valType && !alreadyBoxed`), no TDZ-driven widening. It does not
+  change the lifted function signature (mutable captures already take ref-cell
+  params, nested-declarations.ts L611–625), so callee shape is unchanged.
+
+### Required companion audit — non-box-aware write paths
+
+Eager boxing means `boxedCaptures` / `localMap` re-aim is set **earlier** (from
+function-top) than today's lazy first-call-site re-aim. Any outer-scope write
+path that resolves a target via `fctx.localMap.get(name)` and then does a plain
+`emitCoercedLocalSet` **without** checking `fctx.boxedCaptures` will now write
+an `externref`/`f64` into a ref-cell-typed box slot → `externref→ref` coercion
+trap (the exact #1205/#1258 failure mode). The externref and vec for-of-assign
+paths are already box-aware (#1258 / #1510 — loops.ts L1985), but the
+implementer MUST audit and, if needed, make box-aware:
+
+- `compileForOfAssignDestructuring` object-pattern write,
+  `src/codegen/statements/loops.ts` ~L1695–1716 (raw `localMap.get` +
+  `emitCoercedLocalSet`, no `boxedCaptures` check).
+- Any other `localMap.get(name)` + `emitCoercedLocalSet`/`local.set` site that
+  can target a captured-mutable name (grep `emitCoercedLocalSet` in loops.ts /
+  destructuring.ts / assignment.ts). Where the name is in `boxedCaptures`, the
+  write must go through `local.get <box>; <value>; struct.set <refCellTypeIdx>
+  0` instead of a direct slot set.
+
+Pattern to follow: the existing box-aware branch at loops.ts L1985–1995
+(`const boxedCap = fctx.boxedCaptures?.get(name); if (boxedCap) { … struct.set
+… }`).
+
+### Wasm IR pattern (eager box at function-top)
+
+```wasm
+;; emitted once, at function-top, for `var c=0; function k(){c+=1}`
+local.get $c               ;; outer slot current value (hoisted default 0.0)
+struct.new $ref_cell_f64   ;; box
+local.set $__boxed_c       ;; stash box; localMap[c] re-aimed to $__boxed_c
+
+;; later: `c = 0`  (assignment routes through boxedCaptures)
+local.get $__boxed_c
+f64.const 0
+struct.set $ref_cell_f64 0
+
+;; later: `if (c>100) { k() }`  (call-site already-boxed branch)
+local.get $__boxed_c       ;; pass existing box as prepended capture arg
+call $k
+
+;; later: `return c`  (read routes through box)
+local.get $__boxed_c
+struct.get $ref_cell_f64 0
+```
+
+## Edge cases (each needs a targeted probe before the floor run)
+
+1. **Multiple nested functions capturing the same var.** First hoisted decl
+   boxes it; the `boxedCaptures.has(name)` dedup skips the rest. Both call sites
+   pass the same box. (Hoist processes siblings in order.)
+2. **`let`/`const` TDZ capture (box before declaration).** A `function k`
+   hoisted above a later `let c` gets its box at function-top, reading the
+   pre-init slot (garbage). Correctness relies on (a) the TDZ-flag mechanism
+   (#1205) still guarding *reads* before the `let` init throws ReferenceError,
+   and (b) the `let c = …` init routing its store through `boxedCaptures`
+   (struct.set), not a raw slot set. Verify the existing TDZ-flag box plumbing
+   (`tdzFlagLocals` / `boxedTdzFlags`, calls.ts L12379+) is unaffected — the
+   eager *value* box is orthogonal to the i32 *flag* box. Do NOT eager-box the
+   flag.
+3. **Captured function params.** Param slot holds its value at entry, before
+   the function-top box-init runs, so the box captures the entry value and all
+   later param reads/writes route through it — correct closure semantics.
+4. **`for (let i…)` loop variable captured by a closure (per-iteration box).**
+   Function *declarations* are hoisted out of loop blocks to function scope, so
+   this path boxes the **function-scope** binding once — NOT per iteration. The
+   per-iteration box concern (closures.ts L1699–1705, and loops.ts L651–759
+   for-let per-iter boxing) belongs to the **arrow/closure-value** path, which
+   is out of scope here. Confirm the eager nested-decl box does not collide
+   with the loop's own per-iteration `boxedCaptures` save/restore
+   (loops.ts L463–487 / L1010–1016): if a name is already in `boxedCaptures`
+   from the loop machinery, the dedup must skip it (it will — `boxedCaptures.has`).
+5. **`alreadyBoxed` (#2623) capture.** When the outer slot is itself the
+   canonical cell (outer fn materialized as a closure value threading a boxed
+   param), `cap.alreadyBoxed`/outer `boxedCaptures` is set — do NOT re-box
+   (would create a cell-of-cell). The dedup `boxedCaptures.has(name)` covers
+   the outer-boxed case; also skip when the nested-capture entry's
+   `alreadyBoxed` is true.
+6. **Buffer-swap discipline (#2563).** The eager emit pushes directly into
+   `fctx.body` during the hoist walk, where `fctx.body` is the stable
+   function-top buffer (no `pushBody`/`popBody` active). Do NOT introduce a
+   buffer swap here; if any future refactor wraps the hoist emit in a saved
+   buffer, it MUST use `pushBody`/`popBody` (per #2563 brand-check-swap
+   discipline), never a manual `fctx.body =` save/restore.
+7. **Generator / async nested declarations.** These still register
+   `nestedFuncCaptures` for their captures; confirm the eager box for a
+   captured-mutable var used by a nested generator/async fn does not interfere
+   with the generator state-struct / CPS lowering (the box lives in the OUTER
+   fctx, the generator body reads it via the ref-cell param — same as today's
+   lazy box, just earlier).
+8. **Hoist rollback.** If `compileNestedFunctionDeclaration` errors and rolls
+   back (deletes `nestedFuncCaptures`), the eager emit must be skipped — gate it
+   on the success path so no orphan box-init lands in `fctx.body`.
+
+## Validation plan (MANDATORY — high regression risk)
+
+This touches broad closure codegen and is the exact machinery behind the
+#1177/#PR166/#1205 regressions. PR-level scoped checks are **insufficient**.
+
+1. **Targeted probes** (fresh single-file processes, both strict modes) BEFORE
+   any floor run: the repro above; the captured-counter destructuring template;
+   each edge case 1–8.
+2. **Full `merge_group` floor** — broad-impact change; run the standalone floor
+   + full test262 sharded validation, NOT a scoped sweep (per
+   `project_broad_impact_validate_full_ci`).
+3. **Paired baseline-vs-branch per-test diff** — fetch the baseline jsonl
+   (`scripts/fetch-baseline-jsonl.mjs`) and diff branch vs baseline per test
+   path. Inspect every `pass→fail` flip individually; the acceptance bar is
+   **net positive with zero unexplained regression** in the closure / TDZ /
+   `for-of`-destructure / for-await buckets. A single-bucket regression >50 or
+   net <0 is an escalation, not a merge.
+4. Confirm the expected large **improvement** in the `/dstr/` cluster
+   (captured-counter template) materializes — that is the value signal.
+
+## References (read before implementing)
+
+- `src/codegen/expressions/calls.ts` L12316–12354 — lazy box (current) + narrow
+  already-boxed guard.
+- `src/codegen/statements/nested-declarations.ts` L764 (`nestedFuncCaptures.set`),
+  L1157+ (`hoistFunctionDeclarations`, insertion locus), L611–625 (lifted
+  mutable-capture param types), L278–358 (capture detection / `alreadyBoxed`).
+- `src/codegen/function-body.ts` L1122–1128 — hoist ordering (var → let/const →
+  function).
+- `src/codegen/closures.ts` L1699–1707 — per-iteration vs force-box caution
+  (out-of-scope arrow path, but read for the per-iter reasoning).
+- `src/codegen/statements/loops.ts` L1695–1716 (non-box-aware object-pattern
+  write — companion audit), L1985–1995 (#1510 box-aware vec pattern to mirror).
+- `plan/issues/2669-…md` — root-cause diagnosis; `plan/issues/1245-…md`,
+  `1258-…md`, `1259-…md` — prior regression analysis + the now-done box-aware
+  write fixes that unblock this.

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -1596,6 +1596,35 @@ function compileForOfDestructuring(
  *   for ({a, b} of arr) — assigns to already-declared variables
  *   for ([x, y] of arr) — assigns to already-declared variables
  */
+/**
+ * (#2692) Store a for-of-assignment destructuring field value — currently the
+ * single value on top of the stack (type `fieldType`) — into a target that is a
+ * closure-captured-mutable BOX. A plain `local.set` on the box-ref local would
+ * clobber the cell pointer; we must write THROUGH the cell with `struct.set`.
+ * Mirrors the #1510 vec-default / #1258 externref box-aware branches, but covers
+ * the plain (no-default) array/tuple writes that were left box-unaware — newly
+ * reachable now that #2692 boxes captured-mutable vars eagerly at function-top.
+ * Captured-mutable names live in a cell, never a module global, so there is no
+ * global-sync to emit. Consumes exactly one stack value.
+ */
+function emitBoxedForOfAssignStore(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  targetLocal: number,
+  fieldType: ValType,
+  boxedCap: { refCellTypeIdx: number; valType: ValType },
+): void {
+  const valType = boxedCap.valType;
+  const tmpVal = allocLocal(fctx, `__forof_boxset_${fctx.locals.length}`, fieldType);
+  fctx.body.push({ op: "local.set", index: tmpVal });
+  fctx.body.push({ op: "local.get", index: targetLocal });
+  fctx.body.push({ op: "local.get", index: tmpVal });
+  if (!valTypesMatch(fieldType, valType)) {
+    coerceType(ctx, fctx, fieldType, valType);
+  }
+  fctx.body.push({ op: "struct.set", typeIdx: boxedCap.refCellTypeIdx, fieldIdx: 0 } as Instr);
+}
+
 function compileForOfAssignDestructuring(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -1647,10 +1676,17 @@ function compileForOfAssignDestructuring(
         // Property doesn't exist on primitive — use default if provided
         const init = ts.isShorthandPropertyAssignment(prop) ? prop.objectAssignmentInitializer : undefined;
         if (init) {
-          const targetType = getLocalType(fctx, targetLocal);
+          // (#2692) Box-aware: when `targetName` is a captured-mutable var (now
+          // boxed eagerly at function-top), write the default THROUGH the cell.
+          const boxedCapPrim = fctx.boxedCaptures?.get(targetName);
+          const targetType = boxedCapPrim ? boxedCapPrim.valType : getLocalType(fctx, targetLocal);
           const instrs = collectInstrs(fctx, () => {
-            compileExpression(ctx, fctx, init, targetType ?? { kind: "externref" });
-            fctx.body.push({ op: "local.set", index: targetLocal } as Instr);
+            const dfltType = compileExpression(ctx, fctx, init, targetType ?? { kind: "externref" });
+            if (boxedCapPrim) {
+              emitBoxedForOfAssignStore(ctx, fctx, targetLocal, dfltType ?? boxedCapPrim.valType, boxedCapPrim);
+            } else {
+              fctx.body.push({ op: "local.set", index: targetLocal } as Instr);
+            }
           });
           fctx.body.push(...instrs);
         }
@@ -1706,6 +1742,25 @@ function compileForOfAssignDestructuring(
       const fieldEntry2 = fields[fieldIdx];
       if (!fieldEntry2) continue;
       const fieldType = fieldEntry2.type;
+      // (#2692) Box-aware write: when `targetName` is a closure-captured-mutable
+      // var, `targetLocal` is the ref-cell-ref local (now the common case since
+      // #2692 boxes such vars eagerly at function-top). A plain
+      // `emitCoercedLocalSet` would coerce the field value f64/externref → cell
+      // ref (garbage / null deref). Write THROUGH the cell with `struct.set`,
+      // mirroring the #1510 vec box-aware branch below. (Module-global sync is
+      // moot here — captured-mutable names live in a cell, not a global.)
+      const boxedCapObj = fctx.boxedCaptures?.get(targetName);
+      if (boxedCapObj) {
+        const valType = boxedCapObj.valType;
+        fctx.body.push({ op: "local.get", index: targetLocal });
+        fctx.body.push({ op: "local.get", index: elemLocal });
+        fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx });
+        if (!valTypesMatch(fieldType, valType)) {
+          coerceType(ctx, fctx, fieldType, valType);
+        }
+        fctx.body.push({ op: "struct.set", typeIdx: boxedCapObj.refCellTypeIdx, fieldIdx: 0 } as Instr);
+        continue;
+      }
       const targetType = getLocalType(fctx, targetLocal);
       fctx.body.push({ op: "local.get", index: elemLocal });
       fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx });
@@ -1880,13 +1935,35 @@ function compileForOfAssignDestructuring(
           tupleSyncGlobalIdx = globalIdx;
         }
 
-        const targetType = getLocalType(fctx, targetLocal);
+        // (#2692) Box-aware write when the target is a captured-mutable var
+        // (now boxed eagerly at function-top). `targetLocal` is the cell ref —
+        // route through `struct.set`, NOT a plain `local.set` (which would clobber
+        // the cell pointer → null deref). Tuple path: field read by index `i`.
+        const boxedCapTup = fctx.boxedCaptures?.get(targetEl.text);
+        const targetType = boxedCapTup ? boxedCapTup.valType : getLocalType(fctx, targetLocal);
         fctx.body.push({ op: "local.get", index: elemLocal });
         fctx.body.push({
           op: "struct.get",
           typeIdx: innerVecTypeIdx,
           fieldIdx: i,
         });
+
+        if (boxedCapTup) {
+          if (defaultInit) {
+            // Compute value-or-default into a temp of the cell's value type
+            // (emitDefaultValueCheck consumes the field value on the stack and
+            // stores into the temp), then write the temp through the cell.
+            const tmpV = allocLocal(fctx, `__forof_tupdflt_${fctx.locals.length}`, boxedCapTup.valType);
+            emitDefaultValueCheck(ctx, fctx, fieldType, tmpV, defaultInit, boxedCapTup.valType);
+            fctx.body.push({ op: "local.get", index: targetLocal });
+            fctx.body.push({ op: "local.get", index: tmpV });
+            fctx.body.push({ op: "struct.set", typeIdx: boxedCapTup.refCellTypeIdx, fieldIdx: 0 } as Instr);
+          } else {
+            emitBoxedForOfAssignStore(ctx, fctx, targetLocal, fieldType, boxedCapTup);
+          }
+          // captured-mutable lives in a cell, not a global → no global sync.
+          continue;
+        }
 
         if (defaultInit) {
           // Check for undefined and apply default — BEFORE type coercion
@@ -2106,6 +2183,10 @@ function compileForOfAssignDestructuring(
           if (defaultInit) {
             // Check for undefined and apply default — BEFORE type coercion
             emitDefaultValueCheck(ctx, fctx, innerElemType, targetLocal, defaultInit, targetType ?? undefined);
+          } else if (boxedCapVec) {
+            // (#2692) Box-aware plain write (boxed+default already handled and
+            // `continue`d at the #1510 branch above, so here it is no-default).
+            emitBoxedForOfAssignStore(ctx, fctx, targetLocal, innerElemType, boxedCapVec);
           } else {
             if (targetType && !valTypesMatch(innerElemType, targetType)) {
               coerceType(ctx, fctx, innerElemType, targetType);

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -1154,11 +1154,79 @@ function annexBBlockNestedEligible(fnDecl: ts.FunctionDeclaration): ts.Block | n
   return block;
 }
 
+/**
+ * (#2692) Eagerly materialize the ref-cell box for each mutable variable
+ * captured by a successfully-hoisted nested `function` declaration.
+ *
+ * Background: a mutable captured variable (written by a nested function) is
+ * boxed into a `struct (field $value (mut T))` so writes propagate across the
+ * scope boundary. Historically the box was created LAZILY at the FIRST
+ * capturing call site (`calls.ts` `nestedFuncCaptures` mutable branch). The
+ * compile-time re-aim of `fctx.localMap`/`fctx.boxedCaptures` is global to the
+ * function context, but the runtime `struct.new` + `local.set` landed in
+ * whatever body buffer was active at that call site. When the first call site
+ * sat inside a conditionally-executed buffer (a destructuring default's
+ * then-branch, any `if`/ternary/`&&` arm) that did NOT run at runtime, the box
+ * was never created — yet every later read had been statically re-aimed to a
+ * `struct.get` on the still-null box → null deref → sNaN/NaN. (Root cause:
+ * #2669 diagnosis.)
+ *
+ * Fix: create the box here, during function-declaration hoisting, where it
+ * lands in the UNCONDITIONAL function-top `fctx.body`. The call site then takes
+ * its existing already-boxed branch (no `struct.new`) because
+ * `fctx.boxedCaptures.has(name)` is already true.
+ *
+ * This is a declaration-side MIRROR of the call-site machinery — it does NOT
+ * widen the set of boxed variables (same `mutable && valType && !alreadyBoxed`
+ * predicate, deduped via `boxedCaptures.has`), it only changes WHEN and INTO
+ * WHICH buffer the box is created. The `__boxed_<name>` naming convention and
+ * the lockstep `boxedCaptures` + `localMap` writes are load-bearing for the
+ * call-site narrow two-signal guard (calls.ts) — preserve them.
+ */
+function emitEagerCaptureBoxes(ctx: CodegenContext, fctx: FunctionContext, funcName: string): void {
+  const caps = ctx.nestedFuncCaptures.get(funcName);
+  if (!caps) return;
+  for (const cap of caps) {
+    // Match the call-site predicate exactly: only mutable value captures with a
+    // resolved value type are boxed. Immutable captures pass by value.
+    if (!cap.mutable || !cap.valType) continue;
+    // Dedup: a sibling nested fn already boxed this name (multi-capture of the
+    // same var), OR the outer slot is itself the canonical cell (#2623
+    // alreadyBoxed — re-boxing would create a cell-of-cell). `boxedCaptures.has`
+    // covers both: alreadyBoxed ⟺ an outer `boxedCaptures` entry exists.
+    if (fctx.boxedCaptures?.has(cap.name)) continue;
+    const refCellTypeIdx = getOrRegisterRefCellType(ctx, cap.valType);
+    // Mirror the call-site alloc: a NON-null `ref` to the cell, `__boxed_`-named.
+    const boxedLocalIdx = allocLocal(fctx, `__boxed_${cap.name}`, {
+      kind: "ref",
+      typeIdx: refCellTypeIdx,
+    });
+    // Box the canonical declaration slot's current value (the hoisted default —
+    // 0.0 / null — for `var`/`let`; the entry value for a param). All later
+    // writes route through the box via `boxedCaptures`, so the end state matches
+    // the lazy path. `local.set` (not `tee`) — the eager site leaves nothing on
+    // the stack; the call site re-reads the box via its already-boxed branch.
+    fctx.body.push({ op: "local.get", index: cap.outerLocalIdx });
+    fctx.body.push({ op: "struct.new", typeIdx: refCellTypeIdx });
+    fctx.body.push({ op: "local.set", index: boxedLocalIdx });
+    fctx.localMap.set(cap.name, boxedLocalIdx);
+    if (!fctx.boxedCaptures) fctx.boxedCaptures = new Map();
+    fctx.boxedCaptures.set(cap.name, { refCellTypeIdx, valType: cap.valType });
+  }
+}
+
 export function hoistFunctionDeclarations(
   ctx: CodegenContext,
   fctx: FunctionContext,
   stmts: ts.NodeArray<ts.Statement> | ts.Statement[],
+  // (#2692) Internal: accumulates every successfully-hoisted nested-function
+  // name across the recursive walk (into if/loop/try blocks). The TOP-LEVEL
+  // call (where this is undefined) runs the eager-capture-box pass ONCE after
+  // the entire recursion completes — see the rationale at the post-pass below.
+  _eagerBoxFuncNames?: Set<string>,
 ): void {
+  const isTopLevelHoist = _eagerBoxFuncNames === undefined;
+  const eagerBoxFuncNames = _eagerBoxFuncNames ?? new Set<string>();
   // (#2068) Phase 0: reserve a correctly-typed bodyless funcMap slot for every
   // direct-sibling function that captures NO outer local, BEFORE compiling any
   // body. Without this a forward sibling reference
@@ -1332,8 +1400,22 @@ export function hoistFunctionDeclarations(
           // Track failed hoist so compileStatement doesn't re-attempt
           if (!ctx.hoistFailedFuncs) ctx.hoistFailedFuncs = new Set();
           ctx.hoistFailedFuncs.add(funcName);
-        } else if (reservedEntry) {
-          ctx.preRegisteredBodyless?.delete(funcName);
+        } else {
+          if (reservedEntry) {
+            ctx.preRegisteredBodyless?.delete(funcName);
+          }
+          // (#2692) Defer eager-box materialization to the post-recursion pass.
+          // Boxing here (inline) would set `fctx.boxedCaptures` BEFORE a
+          // LATER-hoisted sibling that captures the same var is compiled — that
+          // sibling's capture detection would then see the var as `alreadyBoxed`
+          // (#2623), giving it a different lifted signature (cell threaded
+          // directly) than the earlier sibling (cell wrapped), and the call site
+          // re-derives a cell-of-cell (illegal cast). Collecting now and boxing
+          // once AFTER all nested fns are compiled keeps every sibling's
+          // signature consistent (plain mutable capture), then boxes once.
+          // Success path only — the rollback arm above deletes
+          // `nestedFuncCaptures`, so a failed fn is never collected.
+          eagerBoxFuncNames.add(funcName);
         }
       }
     }
@@ -1342,55 +1424,72 @@ export function hoistFunctionDeclarations(
     // even when inside if-branches, try/catch blocks, etc.
     if (ts.isIfStatement(stmt)) {
       if (ts.isBlock(stmt.thenStatement)) {
-        hoistFunctionDeclarations(ctx, fctx, stmt.thenStatement.statements);
+        hoistFunctionDeclarations(ctx, fctx, stmt.thenStatement.statements, eagerBoxFuncNames);
       }
       if (stmt.elseStatement) {
         if (ts.isBlock(stmt.elseStatement)) {
-          hoistFunctionDeclarations(ctx, fctx, stmt.elseStatement.statements);
+          hoistFunctionDeclarations(ctx, fctx, stmt.elseStatement.statements, eagerBoxFuncNames);
         } else if (ts.isIfStatement(stmt.elseStatement)) {
-          hoistFunctionDeclarations(ctx, fctx, [stmt.elseStatement]);
+          hoistFunctionDeclarations(ctx, fctx, [stmt.elseStatement], eagerBoxFuncNames);
         }
       }
     }
     if (ts.isTryStatement(stmt)) {
-      hoistFunctionDeclarations(ctx, fctx, stmt.tryBlock.statements);
+      hoistFunctionDeclarations(ctx, fctx, stmt.tryBlock.statements, eagerBoxFuncNames);
       if (stmt.catchClause) {
-        hoistFunctionDeclarations(ctx, fctx, stmt.catchClause.block.statements);
+        hoistFunctionDeclarations(ctx, fctx, stmt.catchClause.block.statements, eagerBoxFuncNames);
       }
       if (stmt.finallyBlock) {
-        hoistFunctionDeclarations(ctx, fctx, stmt.finallyBlock.statements);
+        hoistFunctionDeclarations(ctx, fctx, stmt.finallyBlock.statements, eagerBoxFuncNames);
       }
     }
     if (ts.isBlock(stmt)) {
-      hoistFunctionDeclarations(ctx, fctx, stmt.statements);
+      hoistFunctionDeclarations(ctx, fctx, stmt.statements, eagerBoxFuncNames);
     }
     // Recurse into loop bodies — function declarations inside loops are hoisted
     // to the enclosing function scope in JS semantics.
     if (ts.isForStatement(stmt) || ts.isWhileStatement(stmt) || ts.isDoStatement(stmt)) {
       if (ts.isBlock(stmt.statement)) {
-        hoistFunctionDeclarations(ctx, fctx, stmt.statement.statements);
+        hoistFunctionDeclarations(ctx, fctx, stmt.statement.statements, eagerBoxFuncNames);
       } else {
-        hoistFunctionDeclarations(ctx, fctx, [stmt.statement]);
+        hoistFunctionDeclarations(ctx, fctx, [stmt.statement], eagerBoxFuncNames);
       }
     }
     if (ts.isForInStatement(stmt) || ts.isForOfStatement(stmt)) {
       if (ts.isBlock(stmt.statement)) {
-        hoistFunctionDeclarations(ctx, fctx, stmt.statement.statements);
+        hoistFunctionDeclarations(ctx, fctx, stmt.statement.statements, eagerBoxFuncNames);
       } else {
-        hoistFunctionDeclarations(ctx, fctx, [stmt.statement]);
+        hoistFunctionDeclarations(ctx, fctx, [stmt.statement], eagerBoxFuncNames);
       }
     }
     if (ts.isSwitchStatement(stmt)) {
       for (const clause of stmt.caseBlock.clauses) {
-        hoistFunctionDeclarations(ctx, fctx, clause.statements);
+        hoistFunctionDeclarations(ctx, fctx, clause.statements, eagerBoxFuncNames);
       }
     }
     if (ts.isLabeledStatement(stmt)) {
       if (ts.isBlock(stmt.statement)) {
-        hoistFunctionDeclarations(ctx, fctx, stmt.statement.statements);
+        hoistFunctionDeclarations(ctx, fctx, stmt.statement.statements, eagerBoxFuncNames);
       } else {
-        hoistFunctionDeclarations(ctx, fctx, [stmt.statement]);
+        hoistFunctionDeclarations(ctx, fctx, [stmt.statement], eagerBoxFuncNames);
       }
+    }
+  }
+
+  // (#2692) Eager-box pass — runs ONCE, at the TOP-LEVEL call, AFTER the entire
+  // recursive hoist has compiled every nested function (in blocks/loops/try
+  // too). Materializing the ref-cell boxes now — not inline during the walk —
+  // guarantees every nested function that captures a given mutable var was
+  // compiled with the SAME (plain-mutable, not `alreadyBoxed`) lifted signature,
+  // so sibling call sites agree on the capture's cell type (no cell-of-cell).
+  // The box `struct.new`/`local.set` lands in the unconditional function-top
+  // `fctx.body` (hoisting never swaps the body buffer), so the box always exists
+  // before any conditionally-executed capturing call site — the bug #2692 fixes.
+  // `emitEagerCaptureBoxes` dedups via `boxedCaptures.has`, so a var captured by
+  // several siblings is boxed exactly once. Root cause: #2669 diagnosis.
+  if (isTopLevelHoist) {
+    for (const funcName of eagerBoxFuncNames) {
+      emitEagerCaptureBoxes(ctx, fctx, funcName);
     }
   }
 }

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -1190,6 +1190,19 @@ function emitEagerCaptureBoxes(ctx: CodegenContext, fctx: FunctionContext, funcN
     // Match the call-site predicate exactly: only mutable value captures with a
     // resolved value type are boxed. Immutable captures pass by value.
     if (!cap.mutable || !cap.valType) continue;
+    // (#2692) SKIP `let`/`const` (TDZ-flagged) captures. Eager-boxing them at
+    // function-top races their later block-scoped declaration: the `let`/`const`
+    // decl re-allocates the value slot (block-scope shadow / type reset) and
+    // resets `localMap` to a fresh unboxed f64 local, while `boxedCaptures` stays
+    // set → the var-decl box-write path then emits `ref.is_null` / `struct.set`
+    // on that fresh f64 slot → "ref.is_null expected reference, found f64"
+    // invalid Wasm (the entire for-await-of async-dstr regression cluster — all
+    // `let`-based). `var`/param captures have no such re-declaration, so eager
+    // boxing is safe for them, and the captured-counter dstr template (the #2669
+    // win) uses `var`. TDZ (`let`/`const`) captures fall back to the existing
+    // lazy call-site boxing (the pre-#2692 behaviour). Follow-up can extend the
+    // declaration path to be box-aware for the residual let/const-counter case.
+    if (cap.hasTdzFlag) continue;
     // Dedup: a sibling nested fn already boxed this name (multi-capture of the
     // same var), OR the outer slot is itself the canonical cell (#2623
     // alreadyBoxed — re-boxing would create a cell-of-cell). `boxedCaptures.has`

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -962,7 +962,20 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
         const prevElemOverride = ctxAny._i32ElemArrayOverride;
         if (isI32SpecializedArray) ctxAny._i32ElemArrayOverride = true;
         let resultType: ValType | null;
-        const initializerExpectedType = getLocalType(fctx, localIdx) ?? wasmType;
+        // (#2692) If `name` is a closure-captured-mutable boxed BEFORE this
+        // declaration runs — now the common case since #2692 materializes the
+        // ref-cell box eagerly at function-top, but also the #1177 case of a
+        // closure constructed before the decl — then `localIdx` points at the
+        // ref-cell-ref local. The initializer's VALUE type, the type hint, and
+        // the coercion target must all be the box's `valType` (the inner field
+        // type), NOT the box ref type. The box write itself is done by the
+        // `boxedForInit`/`boxedNoInit` `struct.set` paths below; using the box
+        // ref type here would coerce the value f64/externref → ref-cell (garbage
+        // `ref.null; ref.as_non_null` / illegal cast). Computed once, reused.
+        const boxedForInit = fctx.boxedCaptures?.get(name);
+        const initializerExpectedType = boxedForInit
+          ? boxedForInit.valType
+          : (getLocalType(fctx, localIdx) ?? wasmType);
         try {
           resultType = compileExpression(ctx, fctx, decl.initializer, initializerExpectedType);
         } finally {
@@ -985,8 +998,11 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
                 : resultType;
           }
         }
-        // Coerce if the expression produced a type that doesn't match the local
-        const targetType = getLocalType(fctx, localIdx) ?? wasmType;
+        // Coerce if the expression produced a type that doesn't match the local.
+        // (#2692) When boxed, the target is the box's value type — the
+        // `boxedForInit` struct.set path below writes the cell; coercing to the
+        // box ref type here would corrupt the stack.
+        const targetType = boxedForInit ? boxedForInit.valType : (getLocalType(fctx, localIdx) ?? wasmType);
         if (resultType && !valTypesMatch(resultType, targetType)) {
           const bodyLenBeforeCoerce = fctx.body.length;
           coerceType(ctx, fctx, resultType, targetType);
@@ -999,14 +1015,17 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
           }
         }
       }
-      // #1177: If the variable was boxed by a closure constructed BEFORE this
-      // declaration ran (e.g. `function() { f(); }` constructed before
-      // `let x` is reached), `localIdx` already points to a `ref __ref_cell_T`
-      // local and a plain `local.set` would be a type mismatch. Route the
-      // assignment through `struct.set` on the ref cell so post-init mutations
-      // propagate to every closure that captured the same cell.
-      const boxedForInit = fctx.boxedCaptures?.get(name);
-      if (boxedForInit) {
+      // #1177/#2692: If the variable was boxed BEFORE this declaration ran
+      // (a closure constructed earlier, OR #2692 eager function-top boxing),
+      // `localIdx` already points to a `ref __ref_cell_T` local and a plain
+      // `local.set` would be a type mismatch. Route the assignment through
+      // `struct.set` on the ref cell so post-init mutations propagate to every
+      // closure that captured the same cell. (The inner-scope `boxedForInit`
+      // above made the initializer value/coerce box-aware; re-resolve here for
+      // this outer scope.)
+      const boxedForInitStore = fctx.boxedCaptures?.get(name);
+      if (boxedForInitStore) {
+        const boxedForInit = boxedForInitStore;
         // Coerce stack to value type if needed.
         if (!valTypesMatch(stackType, boxedForInit.valType)) {
           coerceType(ctx, fctx, stackType, boxedForInit.valType);

--- a/tests/issue-2692-closure-box-eager.test.ts
+++ b/tests/issue-2692-closure-box-eager.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #2692 — A mutable variable captured (written) by a nested `function`
+// declaration is boxed into a ref cell. Previously the box was materialized
+// LAZILY at the first capturing call site; when that site sat in a
+// conditionally-skipped branch (a destructuring default's then-arm, an `if`,
+// etc.) the box was never created, so every later read of the captured var
+// dereferenced a null cell → NaN/garbage. This fix materializes the box EAGERLY
+// at function-top during function-declaration hoisting. (Root cause: #2669.)
+
+async function run(source: string, fn = "test", args: unknown[] = []): Promise<unknown> {
+  const result = await compile(source, { fileName: "t.ts" });
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as unknown as WebAssembly.Imports);
+  const anyImp = imports as unknown as { setExports?: (e: Record<string, unknown>) => void };
+  if (anyImp.setExports) anyImp.setExports(instance.exports as Record<string, unknown>);
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>)[fn]!(...args);
+}
+
+describe("#2692 — eager closure-capture box materialization", () => {
+  it("captured counter in a NOT-taken branch leaves the var intact (core repro)", async () => {
+    // The only call site to `k` is inside a branch that never runs; `c` must
+    // still read 0, not NaN. This is the destructuring-free minimal repro.
+    expect(
+      await run(`export function test(): number {
+        var c = 0;
+        function k() { c += 1; }
+        if (c > 100) { k(); }
+        return c;
+      }`),
+    ).toBe(0);
+  });
+
+  it("captured counter is NOT incremented when an array-default is skipped", async () => {
+    // Standard test262 dstr template: defaults present-valued, so counter() must
+    // not run and initCount stays 0 (was NaN/garbage before the fix).
+    expect(
+      await run(`export function test(): number {
+        var initCount = 0;
+        function counter(): any { initCount += 1; return 9; }
+        let [a = counter(), b = counter()] = [1, 2];
+        return initCount + (a === 1 ? 0 : 100) + (b === 2 ? 0 : 1000);
+      }`),
+    ).toBe(0);
+  });
+
+  it("captured counter IS incremented when the array-default fires, exactly once each", async () => {
+    expect(
+      await run(`export function test(): number {
+        var initCount = 0;
+        function counter(): any { initCount += 1; return 9; }
+        let [a = counter(), b = counter()] = [undefined, undefined];
+        return initCount + (a === 9 ? 0 : 100) + (b === 9 ? 0 : 1000);
+      }`),
+    ).toBe(2);
+  });
+
+  it("unconditional capturing calls still mutate the shared box", async () => {
+    expect(
+      await run(`export function test(): number {
+        var c = 0;
+        function k() { c += 1; }
+        k(); k(); k();
+        return c;
+      }`),
+    ).toBe(3);
+  });
+
+  it("two nested functions capturing the same var share ONE box (no cell-of-cell)", async () => {
+    expect(
+      await run(`export function test(): number {
+        var c = 0;
+        function inc() { c += 1; }
+        function add2() { c += 2; }
+        inc(); add2(); add2();
+        return c;
+      }`),
+    ).toBe(5);
+  });
+
+  it("let-TDZ capture: read after init sees the post-init value", async () => {
+    expect(
+      await run(`export function test(): number {
+        function k(): number { return c + 1; }
+        let c = 6;
+        return k();
+      }`),
+    ).toBe(7);
+  });
+
+  it("captured function parameter mutated through a nested function", async () => {
+    expect(
+      await run(`function outer(p: number): number {
+        function bump() { p += 1; }
+        bump(); bump();
+        return p;
+      }
+      export function test(): number { return outer(40); }`),
+    ).toBe(42);
+  });
+
+  it("function declared inside a loop captures the function-scope binding once", async () => {
+    expect(
+      await run(`export function test(): number {
+        var c = 0;
+        for (let i = 0; i < 3; i++) { function k() { c += 1; } k(); }
+        return c;
+      }`),
+    ).toBe(3);
+  });
+
+  it("nested generator capturing a mutable var observes the shared box", async () => {
+    expect(
+      await run(`export function test(): number {
+        var c = 0;
+        function* g() { c += 10; yield c; }
+        const it = g();
+        it.next();
+        return c;
+      }`),
+    ).toBe(10);
+  });
+
+  // Companion audit (#2692): for-of-assignment writes to a target that is ALSO
+  // written by a nested function (hence eagerly boxed) must go THROUGH the cell.
+  it("for-of array-assign target also written by a nested fn (box-aware write)", async () => {
+    expect(
+      await run(`export function test(): number {
+        var v = 0;
+        function bump() { v += 100; }
+        for ([v] of [[1], [2], [3]]) {}
+        bump();
+        return v;
+      }`),
+    ).toBe(103);
+  });
+
+  it("for-of object-assign target also written by a nested fn (box-aware write)", async () => {
+    expect(
+      await run(`export function test(): number {
+        var x = 0;
+        function bump() { x += 100; }
+        for ({ x } of [{ x: 7 }, { x: 8 }, { x: 9 }]) {}
+        bump();
+        return x;
+      }`),
+    ).toBe(109);
+  });
+
+  it("for-of object-assign default into a boxed target (box-aware default write)", async () => {
+    expect(
+      await run(`export function test(): number {
+        var x = 0;
+        function bump() { x += 1; }
+        for ({ x = 50 } of [{}]) {}
+        return x;
+      }`),
+    ).toBe(50);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the dominant root cause behind the #2669 destructuring residual (verify-first diagnosis): a **general closure-capture defect**, not a destructuring bug.

A mutable variable captured (written) by a nested `function` declaration is boxed into a ref cell so writes cross the scope boundary. The box was created **lazily at the first capturing call site** — but the compile-time `localMap`/`boxedCaptures` re-aim is global to the function while the runtime `struct.new`+`local.set` landed in whatever body buffer was active there. When that first call site sat in a **conditionally-skipped buffer** (a destructuring default's then-arm, any `if`/ternary/`&&`), the box was never created → every later read deref'd a null cell → `NaN`/garbage.

Destructuring-free minimal repro (returned `NaN`, now `0`):
```ts
export function test(): number {
  var c = 0; function k() { c += 1; }
  if (c > 100) { k(); }   // only call site, not taken
  return c;
}
```
The test262 dstr default-init template (`var initCount=0; function counter(){initCount+=1}`) is the single largest surface.

## Fix

Materialize the box during **function-declaration hoisting** (`hoistFunctionDeclarations`), where it lands in the **unconditional function-top `fctx.body`**, so the box always exists before any conditional capturing call site. The call site then takes its existing already-boxed branch (no `struct.new`).

Two-phase: collect successfully-hoisted fn names across the recursive walk, then box once **after** all nested fns are compiled — so every sibling capturing the same var was compiled with the same plain-mutable (not #2623-`alreadyBoxed`) lifted signature, avoiding a cell-of-cell at sibling call sites. Deduped via `boxedCaptures.has`.

## Anti-regression (this is the #1177/PR#166/#1205 machinery)
- does **not** change the call-site value source (#1177 Stage 1 = 100+ regressions);
- keeps the narrow `__boxed_` name+type two-signal guard (PR#166 = −25);
- boxes exactly the call-site predicate set (`mutable && valType`), no TDZ-driven value force-box (#1205 = 48+ for-await regressions); lifted signature unchanged.

## Companion write-path audit
Eager boxing sets `boxedCaptures` earlier, exposing box-unaware writes. Made the for-of destructuring-**assignment** writes box-aware (`compileForOfAssignDestructuring`: object-pattern, tuple-pattern, vec-plain, primitive-default) — `struct.set` through the cell instead of clobbering the cell ref. Made the var-decl initializer box-aware (coerce to the cell's value type, not the cell ref type).

## Validation
- `tsc` green.
- New `tests/issue-2692-closure-box-eager.test.ts` — 12/12 (core repro, dstr default skip/fire, multi-fn-same-var, let-TDZ, captured param, for-loop, nested generator, 3 companion for-of-assign box-aware writes).
- Local regression suites green: issue-1177 / 1258 / 1259 / 1510 / 2623 / 1528 / 2602 / 329.
- The 585 / 1712 / `./helpers.js` failures seen locally are **pre-existing on clean upstream/main** (verified by running there), not introduced here.
- The real gate is the **full `merge_group` floor + paired baseline jsonl diff** — expecting a large net-positive in the `/dstr/` cluster plus general closure correctness.

Closes #2692. Addresses the bulk of #2669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)