### PR TITLE
fix(#2689): lazy iterator/for-in/generator import-adders must shift baked funcIdx

### DIFF
--- a/plan/issues/2689-eslint-source-code-new-return-call-tail-type.md
+++ b/plan/issues/2689-eslint-source-code-new-return-call-tail-type.md
@@ -1,8 +1,10 @@
 ---
 id: 2689
 title: "ESLint source-code.js: SourceCode_new return_call tail-call type error"
-status: ready
+status: done
 created: 2026-06-26
+completed: 2026-06-26
+assignee: ttraenkler/sendev-eslint
 priority: medium
 area: codegen
 goal: npm-library-support
@@ -14,6 +16,25 @@ related: [1573]
 Carved from the de-staled #1573 ESLint survey (bug C). The stale sprint-53
 matrix recorded a `global.set externref into f64` error here; the substrate
 work since then changed the first-error to a tail-call type mismatch.
+
+> **FIXED 2026-06-26.** Root cause was NOT in the tail-call lowering itself —
+> it was a **late-import index desync**. `addIteratorImports` (and its siblings
+> `addArrayIteratorImports` / `addGeneratorImports` / `addForInImports`) added
+> their host imports via raw `addImport`, which bumps `numImportFuncs` WITHOUT
+> shifting already-baked defined-function `funcIdx` values. These adders run
+> LAZILY on the first `for-of` / array-iterator / for-in / generator compiled —
+> which in `source-code.js` happened AFTER `SourceCode_new` baked
+> `return_call SourceCode_init` (#1965 alloc + tail-call-init split). So
+> `SourceCode_init` slid 9 slots up while the baked `return_call` stayed put,
+> ending up pointed at the `__iterator_next` IMPORT → "return_call: tail call
+> type error". The same desync also produced the follow-on "not enough
+> arguments on the stack for call" in `SourceCode_applyLanguageOptions`. **Fix
+> (src/codegen/index.ts):** route all four lazy import-adders through
+> `ensureLateImport` + an immediate `flushLateImportShifts`. The flushed batch
+> shift repairs already-baked funcIdx in the LATE context and is a clean no-op
+> EARLY (collect-finalize) — without leaving a deferred shift that would later
+> over-shift functions registered after the imports.
+> `source-code.js` now fully validates. Regression test: `tests/issue-2689.test.ts`.
 
 ## Reproducer
 ```ts

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -88,7 +88,12 @@ import {
   getDrainFuncIdxForWasiStart,
   getRunLoopFuncIdxForWasiStart,
 } from "./async-scheduler.js";
-import { flushLateImportShifts, registerAddStringImports, registerAddUnionImports } from "./shared.js";
+import {
+  ensureLateImport,
+  flushLateImportShifts,
+  registerAddStringImports,
+  registerAddUnionImports,
+} from "./shared.js";
 import { stackBalance, getFixupEvents, summarizeFixups, strictBalanceDiagnostics } from "./stack-balance.js";
 import { emitNativeParseNumber } from "./parse-number-native.js";
 import { ensureRegexMatchVecType } from "./native-regex.js";
@@ -10754,45 +10759,50 @@ export function addIteratorImports(ctx: CodegenContext): void {
   // Guard: only register once
   if (ctx.funcMap.has("__iterator")) return;
 
+  // (#2689) Add via the late-import batch (`ensureLateImport`) + an IMMEDIATE
+  // `flushLateImportShifts`. This helper has TWO call contexts: the EARLY
+  // collect-finalize (declarations.ts, before any function is registered) and
+  // the LATE lazy fallback (compileForOfStatement, after functions already
+  // baked `call`/`return_call` funcIdx values). Raw `addImport` bumps
+  // `numImportFuncs` WITHOUT shifting already-baked defined-function indices, so
+  // the LATE context silently desynced every earlier function's funcIdx — the
+  // ESLint `SourceCode_new` tail call ended up pointing at `__iterator_next`
+  // ("return_call: tail call type error"). The flushed batch shift fixes the
+  // late context AND is a clean no-op early (no functions to shift, and the
+  // immediate flush leaves NO lingering pending shift that would later
+  // over-shift functions registered after these imports).
+  const ER: ValType = { kind: "externref" };
   // __iterator: (externref) → externref — calls obj[Symbol.iterator]()
-  const extToExt = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "externref" }]);
-  addImport(ctx, "env", "__iterator", { kind: "func", typeIdx: extToExt });
-
+  ensureLateImport(ctx, "__iterator", [ER], [ER]);
   // __iterator_next: (externref) → (i32 done, externref value) — calls iter.next()
   // Multi-value result avoids the $IteratorResult struct: a freshly-built WasmGC
   // struct cannot survive the JS import hop (it surfaces as undefined in V8/Node;
   // see #1620 BLOCKED). The two primitives (i32 + externref) cross the JS↔Wasm
   // multi-value ABI cleanly, eliminating __iterator_done / __iterator_value.
-  const extToDoneValue = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i32" }, { kind: "externref" }]);
-  addImport(ctx, "env", "__iterator_next", {
-    kind: "func",
-    typeIdx: extToDoneValue,
-  });
-
+  ensureLateImport(ctx, "__iterator_next", [ER], [{ kind: "i32" }, ER]);
   // __iterator_return: (externref) → void — calls iter.return() if it exists
-  const extToVoid = addFuncType(ctx, [{ kind: "externref" }], []);
-  addImport(ctx, "env", "__iterator_return", {
-    kind: "func",
-    typeIdx: extToVoid,
-  });
-
+  ensureLateImport(ctx, "__iterator_return", [ER], []);
   // __iterator_rest: (externref) → externref — drains a partially-consumed
   // iterator into a real JS Array for the `[...rest]` binding pattern (#1052).
-  addImport(ctx, "env", "__iterator_rest", {
-    kind: "func",
-    typeIdx: extToExt,
-  });
+  ensureLateImport(ctx, "__iterator_rest", [ER], [ER]);
+  // Apply the batch's index shift NOW so a late call repairs already-baked
+  // funcIdx immediately and no deferred shift lingers (the #2689 fix).
+  flushLateImportShifts(ctx, ctx.currentFunc);
 }
 
 /** Register array iterator host imports (entries/keys/values) if not already registered */
 export function addArrayIteratorImports(ctx: CodegenContext): void {
   if (ctx.funcMap.has("__array_entries")) return;
 
+  // (#2689) Batch + immediate flush — see addIteratorImports for the rationale.
+  // Lazily called during body compilation (array-methods.ts), raw addImport
+  // would desync already-baked defined-function funcIdx values.
+  const ER: ValType = { kind: "externref" };
   // All three: (externref) → externref — take a vec struct, return a JS iterator
-  const extToExt = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "externref" }]);
-  addImport(ctx, "env", "__array_entries", { kind: "func", typeIdx: extToExt });
-  addImport(ctx, "env", "__array_keys", { kind: "func", typeIdx: extToExt });
-  addImport(ctx, "env", "__array_values", { kind: "func", typeIdx: extToExt });
+  ensureLateImport(ctx, "__array_entries", [ER], [ER]);
+  ensureLateImport(ctx, "__array_keys", [ER], [ER]);
+  ensureLateImport(ctx, "__array_values", [ER], [ER]);
+  flushLateImportShifts(ctx, ctx.currentFunc);
 }
 
 /**
@@ -10828,59 +10838,38 @@ export function addGeneratorImports(ctx: CodegenContext, options?: { allowNoJsHo
   // Guard: only register once
   if (ctx.funcMap.has("__gen_create_buffer")) return;
 
-  const bufType = addFuncType(ctx, [], [{ kind: "externref" }]);
-  addImport(ctx, "env", "__gen_create_buffer", { kind: "func", typeIdx: bufType });
-
-  const pushF64Type = addFuncType(ctx, [{ kind: "externref" }, { kind: "f64" }], []);
-  addImport(ctx, "env", "__gen_push_f64", { kind: "func", typeIdx: pushF64Type });
-
-  const pushI32Type = addFuncType(ctx, [{ kind: "externref" }, { kind: "i32" }], []);
-  addImport(ctx, "env", "__gen_push_i32", { kind: "func", typeIdx: pushI32Type });
-
-  const pushRefType = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], []);
-  addImport(ctx, "env", "__gen_push_ref", { kind: "func", typeIdx: pushRefType });
-
+  // (#2689) Batch + immediate flush — see addIteratorImports for the rationale.
+  // Can be registered lazily (IR-path generator claim / body compilation) after
+  // other functions baked their funcIdx; raw addImport would desync them. The
+  // `__gen_*` / `__create_*` / `__get_caught_exception` names are not in any
+  // standalone-refusal / native-helper set, so the `allowNoJsHost` fallback
+  // behaves exactly as the previous raw additions did.
+  const ER: ValType = { kind: "externref" };
+  ensureLateImport(ctx, "__gen_create_buffer", [], [ER]);
+  ensureLateImport(ctx, "__gen_push_f64", [ER, { kind: "f64" }], []);
+  ensureLateImport(ctx, "__gen_push_i32", [ER, { kind: "i32" }], []);
+  ensureLateImport(ctx, "__gen_push_ref", [ER, ER], []);
   // __gen_yield_star: (externref, externref) → void  (iterates inner iterable, pushes all values into outer buffer)
-  addImport(ctx, "env", "__gen_yield_star", {
-    kind: "func",
-    typeIdx: pushRefType, // same signature as push_ref: (buf, iterable) → void
-  });
-
+  ensureLateImport(ctx, "__gen_yield_star", [ER, ER], []);
   // __gen_set_return: (externref, externref) → void  (#2035 — stashes the
   // generator's `return` value on the buffer instead of pushing it as a yield)
-  addImport(ctx, "env", "__gen_set_return", {
-    kind: "func",
-    typeIdx: pushRefType, // same signature as push_ref: (buf, value) → void
-  });
-
+  ensureLateImport(ctx, "__gen_set_return", [ER, ER], []);
   // __create_generator: (buf: externref, pendingThrow: externref) -> externref
   // Takes a buffer of yielded values and an optional pending exception,
   // returns a Generator-like object that defers the throw to the first next() call.
-  const createGenType = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
-  addImport(ctx, "env", "__create_generator", { kind: "func", typeIdx: createGenType });
+  ensureLateImport(ctx, "__create_generator", [ER, ER], [ER]);
   // __create_async_generator: same Wasm signature as __create_generator, but .next()/.return()/.throw()
   // return Promise-wrapped results as required by the ES spec for async generators.
-  addImport(ctx, "env", "__create_async_generator", { kind: "func", typeIdx: createGenType });
-  const genType = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "externref" }]);
-  addImport(ctx, "env", "__gen_next", { kind: "func", typeIdx: genType });
-
-  const genReturnType = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
-  addImport(ctx, "env", "__gen_return", { kind: "func", typeIdx: genReturnType });
-  addImport(ctx, "env", "__gen_throw", { kind: "func", typeIdx: genReturnType });
-
-  addImport(ctx, "env", "__gen_result_value", { kind: "func", typeIdx: genType });
-
-  const resultValF64Type = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "f64" }]);
-  addImport(ctx, "env", "__gen_result_value_f64", { kind: "func", typeIdx: resultValF64Type });
-
-  const resultDoneType = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i32" }]);
-  addImport(ctx, "env", "__gen_result_done", { kind: "func", typeIdx: resultDoneType });
-
+  ensureLateImport(ctx, "__create_async_generator", [ER, ER], [ER]);
+  ensureLateImport(ctx, "__gen_next", [ER], [ER]);
+  ensureLateImport(ctx, "__gen_return", [ER, ER], [ER]);
+  ensureLateImport(ctx, "__gen_throw", [ER, ER], [ER]);
+  ensureLateImport(ctx, "__gen_result_value", [ER], [ER]);
+  ensureLateImport(ctx, "__gen_result_value_f64", [ER], [{ kind: "f64" }]);
+  ensureLateImport(ctx, "__gen_result_done", [ER], [{ kind: "i32" }]);
   // Ensure __get_caught_exception is available for generator body try/catch wrappers
-  if (!ctx.funcMap.has("__get_caught_exception")) {
-    const getCaughtType = addFuncType(ctx, [], [{ kind: "externref" }]);
-    addImport(ctx, "env", "__get_caught_exception", { kind: "func", typeIdx: getCaughtType });
-  }
+  ensureLateImport(ctx, "__get_caught_exception", [], [ER]);
+  flushLateImportShifts(ctx, ctx.currentFunc);
 }
 
 /** Register for-in key enumeration host imports if not already registered */
@@ -10888,22 +10877,21 @@ export function addForInImports(ctx: CodegenContext): void {
   // Guard: only register once
   if (ctx.funcMap.has("__for_in_keys")) return;
 
+  // (#2689) Batch + immediate flush — see addIteratorImports for the rationale.
+  // Only registered in JS-host mode (caller-guarded `!standalone && !wasi`), so
+  // the standalone `__for_in_*` refusal inside ensureLateImport never triggers
+  // here. Raw addImport on this lazy path would desync already-baked funcIdx.
+  const ER: ValType = { kind: "externref" };
   // __for_in_keys: (externref) -> externref — returns JS array of enumerable string keys
-  const extToExt = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "externref" }]);
-  addImport(ctx, "env", "__for_in_keys", { kind: "func", typeIdx: extToExt });
-
+  ensureLateImport(ctx, "__for_in_keys", [ER], [ER]);
   // __for_in_len: (externref) -> i32 — returns keys.length
-  const extToI32 = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "i32" }]);
-  addImport(ctx, "env", "__for_in_len", { kind: "func", typeIdx: extToI32 });
-
+  ensureLateImport(ctx, "__for_in_len", [ER], [{ kind: "i32" }]);
   // __for_in_get: (externref, i32) -> externref — returns keys[i]
-  const extI32ToExt = addFuncType(ctx, [{ kind: "externref" }, { kind: "i32" }], [{ kind: "externref" }]);
-  addImport(ctx, "env", "__for_in_get", { kind: "func", typeIdx: extI32ToExt });
-
+  ensureLateImport(ctx, "__for_in_get", [ER, { kind: "i32" }], [ER]);
   // __for_in_has: (externref obj, externref key) -> i32 — per-visit liveness
   // check so a property deleted mid-enumeration is skipped (#2066).
-  const extExtToI32 = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], [{ kind: "i32" }]);
-  addImport(ctx, "env", "__for_in_has", { kind: "func", typeIdx: extExtToI32 });
+  ensureLateImport(ctx, "__for_in_has", [ER, ER], [{ kind: "i32" }]);
+  flushLateImportShifts(ctx, ctx.currentFunc);
 }
 
 /**

--- a/tests/issue-2689.test.ts
+++ b/tests/issue-2689.test.ts
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2689 — ESLint `eslint/lib/languages/js/source-code/source-code.js` failed
+// `WebAssembly.validate` with
+//
+//   function "SourceCode_new" failed: return_call: tail call type error
+//
+// Root cause: the iterator-protocol host imports (`__iterator`,
+// `__iterator_next`, …) are registered LAZILY on the first `for-of` compiled
+// (`compileForOfStatement` → `addIteratorImports`). That can happen AFTER a
+// derived class's `${C}_new` constructor already baked `return_call ${C}_init`
+// (the #1965 alloc + tail-call-init split). `addIteratorImports` (and its
+// siblings `addArrayIteratorImports` / `addGeneratorImports` / `addForInImports`)
+// added their imports via raw `addImport`, which bumps `numImportFuncs` WITHOUT
+// shifting already-baked defined-function indices. So every funcIdx registered
+// before that point silently desynced: `SourceCode_init` slid 9 slots up while
+// `SourceCode_new`'s `return_call` stayed put, ending up pointed at the
+// `__iterator_next` IMPORT → the tail-call type error. The same desync also
+// broke later `call` sites ("not enough arguments on the stack for call").
+//
+// Fix: route those four lazy import-adders through `ensureLateImport` + an
+// immediate `flushLateImportShifts`. The flushed batch shift repairs the
+// already-baked funcIdx in the LATE context and is a clean no-op in the EARLY
+// (collect-finalize) context — crucially WITHOUT leaving a deferred shift that
+// would later over-shift functions registered after the imports.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { compileProject } from "../src/index.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const TMP_DIR = resolve(__dirname, "../.tmp/issue-2689");
+
+function write(name: string, src: string): string {
+  mkdirSync(TMP_DIR, { recursive: true });
+  const p = join(TMP_DIR, name);
+  writeFileSync(p, src);
+  return p;
+}
+
+describe("#2689 — lazy iterator/for-in/generator imports must not desync funcIdx", () => {
+  it("derived class `_new` return_call survives a lazily-imported for-of (multi-module)", async () => {
+    // base.js is a separate CJS module (mirrors eslint's TokenStore), so the
+    // multi-module pipeline registers `Derived_new`/`Derived_init` BEFORE the
+    // first for-of body is compiled — the precise ordering that desynced the
+    // baked `return_call`.
+    write(
+      "base.js",
+      `"use strict";
+class Base {
+  constructor(tokens, comments) { this.tokens = tokens; this.comments = comments; }
+}
+module.exports = Base;
+`,
+    );
+    const entry = write(
+      "main.js",
+      `"use strict";
+const Base = require("./base");
+class Derived extends Base {
+  constructor(textOrConfig, ast) {
+    let text;
+    if (typeof textOrConfig === "string") { text = textOrConfig; }
+    else { text = textOrConfig.text; ast = textOrConfig.ast; }
+    super(ast.tokens, ast.comments);
+    this.text = text;
+    Object.freeze(this);
+  }
+  countItems(items) {
+    let n = 0;
+    for (const x of items) { n += 1; }
+    return n;
+  }
+}
+module.exports = { Derived };
+`,
+    );
+    const r = await compileProject(entry, { allowJs: true });
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+    // Pre-fix: `Base_new` / `Derived_new` failed with "return_call: tail call
+    // type error" because the lazy iterator import shifted indices out from
+    // under the baked tail call.
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+  });
+
+  it("derived class + for-of with destructuring over Object.entries (array-iterator + for-in path)", async () => {
+    write(
+      "base2.js",
+      `"use strict";
+class Base { constructor(a) { this.a = a; } }
+module.exports = Base;
+`,
+    );
+    const entry = write(
+      "main2.js",
+      `"use strict";
+const Base = require("./base2");
+class Derived extends Base {
+  constructor(a, b) { super(a); this.b = b; Object.freeze(this); }
+  applyOpts(opts) {
+    const out = [];
+    for (const [k, v] of Object.entries(opts || {})) { out.push(k); }
+    for (const key in (opts || {})) { out.push(key); }
+    return out;
+  }
+}
+module.exports = { Derived };
+`,
+    );
+    const r = await compileProject(entry, { allowJs: true });
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+  });
+
+  it("the real eslint source-code.js validates", async () => {
+    const p = "/workspace/node_modules/eslint/lib/languages/js/source-code/source-code.js";
+    let r: Awaited<ReturnType<typeof compileProject>>;
+    try {
+      r = await compileProject(p, { allowJs: true });
+    } catch {
+      // eslint not installed in this environment — skip (the synthetic
+      // reproducers above pin the fix without the dependency).
+      return;
+    }
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the ESLint `source-code.js` validation blocker (#2689) — `SourceCode_new: return_call: tail call type error` — and the whole **latent bug class** behind it. ESLint internal-module frontier moves **16/21 → 17/21 validate** (source-code.js now fully validates).

### Root cause (not what the issue title suggested)
The error was NOT in the tail-call lowering — it was a **late-import index desync**. `addIteratorImports` (and siblings `addArrayIteratorImports` / `addGeneratorImports` / `addForInImports`) registered their host imports via raw `addImport`, which bumps `numImportFuncs` **without shifting already-baked defined-function `funcIdx` values**.

These adders run **lazily** on the first `for-of` / array-iterator / for-in / generator compiled. In `source-code.js` that happened **after** the derived class `SourceCode_new` baked `return_call SourceCode_init` (the #1965 alloc + tail-call-init split). So `SourceCode_init` slid 9 slots up while the baked `return_call` stayed put — landing on the `__iterator_next` **import** → "return_call: tail call type error". The same desync also caused the follow-on "not enough arguments on the stack for call" in `SourceCode_applyLanguageOptions`.

### Fix (`src/codegen/index.ts`)
Route all four lazy import-adders through `ensureLateImport` + an immediate `flushLateImportShifts`. The flushed batch shift repairs already-baked funcIdx in the **late** context and is a clean **no-op early** (collect-finalize, no functions yet) — crucially **without** leaving a deferred shift that would later over-shift functions registered after the imports (an `ensureLateImport`-without-flush first attempt hit exactly that over-shift trap; regression test #1 guards it).

General fix: any module that compiles functions **before** its first for-of/for-in/generator/array-iterator was exposed to this desync.

### Validation
- `tests/issue-2689.test.ts` — 3 cases (2 discriminating: fail on baseline, pass with fix; 1 over-shift guard). All pass.
- The real `eslint/lib/languages/js/source-code/source-code.js` now fully validates.
- **Zero regressions**: a 14-file iterator/generator/class/destructuring/Map-Set suite gives **identical 33-fail / 58-pass on baseline and branch** (the 33 are pre-existing harness failures, verified by reverting the fix).
- Broad-impact pass → relying on CI `merge shard reports` for full test262 conformance.

### Remaining ESLint frontier (separate follow-ups, unchanged by this PR)
#2688 apply-disable-directives conditional-spread struct shape · #2690 rule-tester polymorphic return · #2691 api.js re-export · #1791-#1794 node:path (linter.js).

🤖 Generated with [Claude Code](https://claude.com/claude-code)