### PR TITLE
feat(#1791): node:path posix shim (pure TS, host + standalone)

### DIFF
--- a/plan/issues/1791-node-path-builtin-impl.md
+++ b/plan/issues/1791-node-path-builtin-impl.md
@@ -1,10 +1,12 @@
 ---
 id: 1791
 title: "node:path — typed host import + standalone TS-port fallback"
-status: ready
+status: done
+assignee: ttraenkler/sd-2668c
+completed: 2026-06-26
 sprint: Backlog
 created: 2026-06-03
-updated: 2026-06-03
+updated: 2026-06-26
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -68,3 +70,67 @@ Tier 0 (smoke test — must pass on **both** JS-host and standalone WASI):
 `tests/issue-1791.test.ts` — compile each Tier 0 snippet and assert the
 returned value, once with default JS-host config and once with
 `--target wasi` (standalone).
+
+## Resolution — landed (sd-2668c, 2026-06-26)
+
+### Chosen approach: ONE pure-TS posix shim, both modes (no host import)
+
+`path` is pure string compute, so a single TS port serves BOTH the JS-host and
+standalone targets — no host import, no standalone trap. The "typed host import"
+half of the title is unnecessary for posix; win32 is deferred. This is simpler
+than the dual host-import-plus-fallback the issue sketched.
+
+**Mechanism** (`src/import-resolver.ts`, `preprocessImports`):
+- A prepended prelude of top-level posix functions `__js2wasm_path_*`
+  (`buildPathShim`) — faithful port of Node `lib/path.js` posix:
+  `normStr`/`normalize`/`join`/`resolve`/`dirname`/`basename`/`extname`/
+  `isAbsolute`/`relative`. Prepended once (alongside the timer shim; combined
+  prepend length feeds the position map).
+- **Named import** (`import { join } from "node:path"`) → forwarding function
+  declarations (`function join(...a){ return __js2wasm_path_join(...a); }`) +
+  `const sep = "/"`. Robust: top-level variadic calls + spread-in-call compile
+  fine.
+- **Default/namespace import** (`import path from "node:path"`) → a `const path =
+  { join(...), …, sep: "/" }` object of FIXED-arity wrapper methods. Variadic
+  dispatch through an object field is currently miscompiled, so `join`/`resolve`
+  wrappers are fixed 8-slot (`a:string=""…`) forwarders to the variadic
+  top-level functions — `join`/`resolve` skip empty args, so padding is inert.
+- `path` is excluded from `nodeBuiltins` (no `__node_path`) when shimmed.
+
+### Scope guards (no regression)
+
+- A **default** import is shimmed only when EVERY `path.<member>` access is in the
+  supported surface (`pathDefaultFullySupported`); otherwise it stays on the
+  legacy opaque `__node_path` host route — so programs using `path.parse` /
+  `path.win32` / etc. (out of Tier-0 scope) do not regress in JS-host mode.
+- Unsupported **named** path exports fall through to the existing generic stub.
+
+### Verify-first dev notes (saved for the next dev)
+
+- **`resolve` WasmGC type-merge bug:** `let path = "/"; path = args[i]` merges a
+  string-constant global (distinct WasmGC type) with an array-element string
+  under `nativeStrings`, producing an invalid `struct.get` (standalone compile
+  error). Fixed by reading only array elements in the loop and prepending the
+  cwd-root via concat (`resolvedPath = "/" + resolvedPath`) instead of a
+  reassigned `let`.
+- Standalone cwd fallback is `/` (no host cwd); win32, `path.posix`/`path.win32`,
+  `parse`/`format` deferred.
+
+### Surface covered (= exactly what ESLint + deps call)
+
+`resolve, sep, join, dirname, relative, isAbsolute, extname, normalize` (grep of
+`node_modules/eslint/lib`) + `basename` (Tier 0). This unblocks linter.js's only
+`node:` import.
+
+### Test results
+
+- `tests/issue-1791.test.ts` — 6 cases, each run in BOTH host and standalone
+  (`--target wasi`), all green. Covers all Tier-0 acceptance snippets (default +
+  named), relative, and join/extname/dirname edge cases.
+- `tests/issue-1575.test.ts` updated (the node:path "gap survey" tests now assert
+  the gap is CLOSED) — 7 green, incl. new guards for the shim binding + the
+  unsupported-member legacy fallback.
+- No regressions in path-importing tests (issue-1400/1043/1081/host-import-
+  allowlist-gate). `tsc --noEmit` clean. (issue-1296 missing-fixture +
+  issue-1492 crypto-fnName failures are PRE-EXISTING on `upstream/main`,
+  unrelated.)

--- a/src/import-resolver.ts
+++ b/src/import-resolver.ts
@@ -76,6 +76,337 @@ const NODE_BUILTIN_FN_TYPED_STUBS: Record<
   },
 };
 
+/**
+ * #1791 — `node:path` posix surface implemented as a pure-TS shim compiled into
+ * the module. `path` is pure string compute (no I/O), so a single TS port serves
+ * BOTH the JS-host and standalone (WASI/browser) targets — no host import, no
+ * standalone trap. This is the highest-leverage Node builtin (blocks ESLint,
+ * prettier, TypeScript). win32 semantics + `path.posix`/`path.win32`/`parse`/
+ * `format` namespaces are deferred (posix-only Tier 0).
+ *
+ * The methods covered are exactly the surface ESLint + its deps call
+ * (resolve/sep/join/dirname/relative/isAbsolute/extname/normalize) plus
+ * `basename` (Tier 0 acceptance).
+ */
+const PATH_SHIM_METHODS = [
+  "join",
+  "resolve",
+  "normalize",
+  "dirname",
+  "basename",
+  "extname",
+  "isAbsolute",
+  "relative",
+] as const;
+/** Recognised data properties on the `path` module object (posix). */
+const PATH_SHIM_PROPS: Record<string, string> = { sep: '"/"', delimiter: '":"' };
+
+/**
+ * The prepended prelude: top-level posix path functions (`__js2wasm_path_*`).
+ * Variadic (`join`/`resolve`) are top-level functions — variadic dispatch
+ * through an object field is currently miscompiled (#1791 dev note), so the
+ * default-import object's methods are FIXED-arity wrappers that forward here
+ * (the wrappers pad unused slots with `""`, which `join`/`resolve` skip).
+ * Faithful port of Node's `lib/path.js` posix subset.
+ */
+function buildPathShim(): string {
+  return `// #1791 node:path posix shim (pure string compute; host + standalone)
+function __js2wasm_path_normStr(path: string, allowAboveRoot: boolean): string {
+  let res = "";
+  let lastSegmentLength = 0;
+  let lastSlash = -1;
+  let dots = 0;
+  let code = 0;
+  for (let i = 0; i <= path.length; i++) {
+    if (i < path.length) code = path.charCodeAt(i);
+    else if (code === 47) break;
+    else code = 47;
+    if (code === 47) {
+      if (lastSlash === i - 1 || dots === 1) {
+        // empty segment or "."
+      } else if (dots === 2) {
+        if (res.length < 2 || lastSegmentLength !== 2 ||
+            res.charCodeAt(res.length - 1) !== 46 ||
+            res.charCodeAt(res.length - 2) !== 46) {
+          if (res.length > 2) {
+            const lsi = res.lastIndexOf("/");
+            if (lsi === -1) { res = ""; lastSegmentLength = 0; }
+            else { res = res.slice(0, lsi); lastSegmentLength = res.length - 1 - res.lastIndexOf("/"); }
+            lastSlash = i; dots = 0; continue;
+          } else if (res.length !== 0) {
+            res = ""; lastSegmentLength = 0; lastSlash = i; dots = 0; continue;
+          }
+        }
+        if (allowAboveRoot) {
+          if (res.length > 0) res = res + "/.."; else res = "..";
+          lastSegmentLength = 2;
+        }
+      } else {
+        if (res.length > 0) res = res + "/" + path.slice(lastSlash + 1, i);
+        else res = path.slice(lastSlash + 1, i);
+        lastSegmentLength = i - lastSlash - 1;
+      }
+      lastSlash = i; dots = 0;
+    } else if (code === 46 && dots !== -1) {
+      dots = dots + 1;
+    } else {
+      dots = -1;
+    }
+  }
+  return res;
+}
+function __js2wasm_path_normalize(path: string): string {
+  if (path.length === 0) return ".";
+  const isAbs = path.charCodeAt(0) === 47;
+  const trail = path.charCodeAt(path.length - 1) === 47;
+  let p = __js2wasm_path_normStr(path, !isAbs);
+  if (p.length === 0) {
+    if (isAbs) return "/";
+    return trail ? "./" : ".";
+  }
+  if (trail) p = p + "/";
+  return isAbs ? "/" + p : p;
+}
+function __js2wasm_path_isAbsolute(path: string): boolean {
+  return path.length > 0 && path.charCodeAt(0) === 47;
+}
+function __js2wasm_path_join(...args: string[]): string {
+  let joined = "";
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.length > 0) {
+      if (joined.length === 0) joined = arg;
+      else joined = joined + "/" + arg;
+    }
+  }
+  if (joined.length === 0) return ".";
+  return __js2wasm_path_normalize(joined);
+}
+function __js2wasm_path_resolve(...args: string[]): string {
+  let resolvedPath = "";
+  let resolvedAbsolute = false;
+  for (let i = args.length - 1; i >= 0; i--) {
+    if (resolvedAbsolute) break;
+    const seg = args[i];
+    if (seg.length === 0) continue;
+    resolvedPath = seg + "/" + resolvedPath;
+    resolvedAbsolute = seg.charCodeAt(0) === 47;
+  }
+  // No absolute segment found → prepend the (standalone) cwd root "/". Keeping
+  // the literal in a concat (not a reassigned \`let\`) avoids a string-constant /
+  // array-element WasmGC type merge under nativeStrings.
+  if (!resolvedAbsolute) {
+    resolvedPath = "/" + resolvedPath;
+    resolvedAbsolute = true;
+  }
+  resolvedPath = __js2wasm_path_normStr(resolvedPath, !resolvedAbsolute);
+  if (resolvedAbsolute) {
+    if (resolvedPath.length > 0) return "/" + resolvedPath;
+    return "/";
+  }
+  if (resolvedPath.length > 0) return resolvedPath;
+  return ".";
+}
+function __js2wasm_path_dirname(path: string): string {
+  if (path.length === 0) return ".";
+  const hasRoot = path.charCodeAt(0) === 47;
+  let end = -1;
+  let matchedSlash = true;
+  for (let i = path.length - 1; i >= 1; i--) {
+    if (path.charCodeAt(i) === 47) {
+      if (!matchedSlash) { end = i; break; }
+    } else {
+      matchedSlash = false;
+    }
+  }
+  if (end === -1) return hasRoot ? "/" : ".";
+  if (hasRoot && end === 1) return "//";
+  return path.slice(0, end);
+}
+function __js2wasm_path_basename(path: string, ext: string = ""): string {
+  let start = 0;
+  let end = -1;
+  let matchedSlash = true;
+  if (ext.length > 0 && ext.length <= path.length) {
+    if (ext === path) return "";
+    let extIdx = ext.length - 1;
+    let firstNonSlashEnd = -1;
+    for (let i = path.length - 1; i >= 0; i--) {
+      const code = path.charCodeAt(i);
+      if (code === 47) {
+        if (!matchedSlash) { start = i + 1; break; }
+      } else {
+        if (firstNonSlashEnd === -1) { matchedSlash = false; firstNonSlashEnd = i + 1; }
+        if (extIdx >= 0) {
+          if (code === ext.charCodeAt(extIdx)) {
+            extIdx = extIdx - 1;
+            if (extIdx === -1) end = i;
+          } else {
+            extIdx = -1;
+            end = firstNonSlashEnd;
+          }
+        }
+      }
+    }
+    if (start === end) end = firstNonSlashEnd;
+    else if (end === -1) end = path.length;
+    return path.slice(start, end);
+  }
+  for (let i = path.length - 1; i >= 0; i--) {
+    if (path.charCodeAt(i) === 47) {
+      if (!matchedSlash) { start = i + 1; break; }
+    } else if (end === -1) {
+      matchedSlash = false;
+      end = i + 1;
+    }
+  }
+  if (end === -1) return "";
+  return path.slice(start, end);
+}
+function __js2wasm_path_extname(path: string): string {
+  let startDot = -1;
+  let startPart = 0;
+  let end = -1;
+  let matchedSlash = true;
+  let preDotState = 0;
+  for (let i = path.length - 1; i >= 0; i--) {
+    const code = path.charCodeAt(i);
+    if (code === 47) {
+      if (!matchedSlash) { startPart = i + 1; break; }
+      continue;
+    }
+    if (end === -1) { matchedSlash = false; end = i + 1; }
+    if (code === 46) {
+      if (startDot === -1) startDot = i;
+      else if (preDotState !== 1) preDotState = 1;
+    } else if (startDot !== -1) {
+      preDotState = -1;
+    }
+  }
+  if (startDot === -1 || end === -1 || preDotState === 0 ||
+      (preDotState === 1 && startDot === end - 1 && startDot === startPart + 1)) {
+    return "";
+  }
+  return path.slice(startDot, end);
+}
+function __js2wasm_path_relative(from: string, to: string): string {
+  if (from === to) return "";
+  const f = __js2wasm_path_resolve(from);
+  const t = __js2wasm_path_resolve(to);
+  if (f === t) return "";
+  const fromStart = 1;
+  const fromEnd = f.length;
+  const fromLen = fromEnd - fromStart;
+  const toStart = 1;
+  const toLen = t.length - toStart;
+  const length = fromLen < toLen ? fromLen : toLen;
+  let lastCommonSep = -1;
+  let i = 0;
+  for (; i < length; i++) {
+    const fromCode = f.charCodeAt(fromStart + i);
+    if (fromCode !== t.charCodeAt(toStart + i)) break;
+    else if (fromCode === 47) lastCommonSep = i;
+  }
+  if (i === length) {
+    if (toLen > length) {
+      if (t.charCodeAt(toStart + i) === 47) return t.slice(toStart + i + 1);
+      if (i === 0) return t.slice(toStart + i);
+    } else if (fromLen > length) {
+      if (f.charCodeAt(fromStart + i) === 47) lastCommonSep = i;
+      else if (i === 0) lastCommonSep = 0;
+    }
+  }
+  let out = "";
+  for (i = fromStart + lastCommonSep + 1; i <= fromEnd; i++) {
+    if (i === fromEnd || f.charCodeAt(i) === 47) {
+      if (out.length === 0) out = ".."; else out = out + "/..";
+    }
+  }
+  return out + t.slice(toStart + lastCommonSep);
+}
+`;
+}
+
+/** Fixed-arity (optional-param) object-method wrapper text for a path method. */
+function pathObjectMethod(name: string): string {
+  // Variadic methods → fixed 8-slot wrappers padded with "" (join/resolve skip
+  // empty args, so padding is semantically inert).
+  if (name === "join" || name === "resolve") {
+    return `  ${name}(a: string = "", b: string = "", c: string = "", d: string = "", e: string = "", f: string = "", g: string = "", h: string = ""): string { return __js2wasm_path_${name}(a, b, c, d, e, f, g, h); }`;
+  }
+  if (name === "basename") {
+    return `  basename(p: string, ext: string = ""): string { return __js2wasm_path_basename(p, ext); }`;
+  }
+  if (name === "isAbsolute") {
+    return `  isAbsolute(p: string): boolean { return __js2wasm_path_isAbsolute(p); }`;
+  }
+  if (name === "relative") {
+    return `  relative(from: string, to: string): string { return __js2wasm_path_relative(from, to); }`;
+  }
+  // single-string-arg methods: normalize / dirname / extname
+  return `  ${name}(p: string): string { return __js2wasm_path_${name}(p); }`;
+}
+
+/** Build the default/namespace `const <local> = { ...methods..., sep: "/" }` object. */
+function buildPathDefaultObject(localName: string): string {
+  const methods = PATH_SHIM_METHODS.map(pathObjectMethod);
+  for (const [prop, val] of Object.entries(PATH_SHIM_PROPS)) {
+    methods.push(`  ${prop}: ${val}`);
+  }
+  return `const ${localName} = {\n${methods.join(",\n")}\n};`;
+}
+
+/**
+ * Forwarding binding for a named import (`import { join } from "node:path"`).
+ * Returns null for an unrecognised name (caller falls through to the generic
+ * stub so unsupported names don't regress).
+ */
+function buildPathNamedBinding(name: string): string | null {
+  if (name === "join" || name === "resolve") {
+    return `function ${name}(...a: string[]): string { return __js2wasm_path_${name}(...a); }`;
+  }
+  if (name === "basename") {
+    return `function basename(p: string, ext: string = ""): string { return __js2wasm_path_basename(p, ext); }`;
+  }
+  if (name === "isAbsolute") {
+    return `function isAbsolute(p: string): boolean { return __js2wasm_path_isAbsolute(p); }`;
+  }
+  if (name === "relative") {
+    return `function relative(from: string, to: string): string { return __js2wasm_path_relative(from, to); }`;
+  }
+  if (name === "normalize" || name === "dirname" || name === "extname") {
+    return `function ${name}(p: string): string { return __js2wasm_path_${name}(p); }`;
+  }
+  if (name in PATH_SHIM_PROPS) {
+    return `const ${name} = ${PATH_SHIM_PROPS[name]};`;
+  }
+  return null;
+}
+
+/**
+ * #1791 — true when every `<local>.<member>` access in the source is within the
+ * shim's supported posix surface. A default `import path from "node:path"` is
+ * only shimmed when fully supported; otherwise it stays on the legacy
+ * `__node_path` host path so programs using `path.parse`/`path.win32`/etc. (out
+ * of Tier 0 scope) don't regress in JS-host mode.
+ */
+function pathDefaultFullySupported(sf: ts.SourceFile, localName: string): boolean {
+  const supported = new Set<string>([...PATH_SHIM_METHODS, ...Object.keys(PATH_SHIM_PROPS)]);
+  let allOk = true;
+  let sawAny = false;
+  const walk = (node: ts.Node): void => {
+    if (ts.isPropertyAccessExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === localName) {
+      sawAny = true;
+      if (!supported.has(node.name.text)) allOk = false;
+    }
+    forEachChild(node, walk);
+  };
+  walk(sf);
+  // If the binding is imported but never accessed via member, shimming is still
+  // safe (the object is inert) — treat as supported.
+  return sawAny ? allOk : true;
+}
+
 /** Returns true if `spec` is a recognized Node.js builtin (with or without `node:` prefix). */
 export function isNodeBuiltin(spec: string): boolean {
   return NODE_BUILTIN_MODULES.has(spec.replace(/^node:/, ""));
@@ -282,8 +613,13 @@ export function preprocessImports(source: string, opts?: { wasi?: boolean }): Pr
     defaultName?: string;
     namedBindings?: string[];
     moduleSpec: string;
+    /** #1791 — when set, emit the pure-TS `node:path` shim instead of a stub. */
+    shimPath?: boolean;
   }[] = [];
   const nodeBuiltins: NodeBuiltinImport[] = [];
+  // #1791 — set when any import binds the node:path shim, so the prelude is
+  // prepended exactly once.
+  let usesPathShim = false;
   // (#1540) Per-source JSX runtime import — we only support one
   // `jsxImportSource` per compile unit (matches the TypeScript model).
   // If multiple JSX runtime imports appear, the last one wins.
@@ -368,14 +704,27 @@ export function preprocessImports(source: string, opts?: { wasi?: boolean }): Pr
       // declare signatures.
       continue;
     }
+    // #1791 — decide whether to bind `node:path` to the pure-TS posix shim
+    // (works in BOTH host + standalone). A NAMED-only path import always shims
+    // (the legacy named-path stub is broken anyway); a DEFAULT import shims only
+    // when every `path.<member>` access is in the supported surface (else keep
+    // legacy host `__node_path`, so `path.parse`/win32 don't regress).
+    let shimPath = false;
+    if (isNodeBuiltin(moduleSpec) && normalizeNodeBuiltin(moduleSpec) === "path") {
+      if (defaultName) shimPath = pathDefaultFullySupported(sf, defaultName);
+      else if (namedBindings.length > 0) shimPath = true;
+    }
     otherImports.push({
       start: stmt.getStart(sf),
       end: stmt.end,
       defaultName,
       namedBindings: namedBindings.length > 0 ? namedBindings : undefined,
       moduleSpec,
+      shimPath,
     });
-    if (isNodeBuiltin(moduleSpec)) {
+    // A shimmed path import must NOT also register the `__node_path` host import
+    // (it would create a conflicting global for the same local name).
+    if (isNodeBuiltin(moduleSpec) && !shimPath) {
       nodeBuiltins.push({
         localName: defaultName || namedBindings[0] || normalizeNodeBuiltin(moduleSpec),
         moduleName: normalizeNodeBuiltin(moduleSpec),
@@ -634,6 +983,37 @@ export function preprocessImports(source: string, opts?: { wasi?: boolean }): Pr
   // Default and named imports → declare stubs
   for (const imp of otherImports) {
     const lines: string[] = [];
+
+    // #1791 — bind `node:path` to the pure-TS posix shim (default object +
+    // named forwarding functions). The shim function prelude itself is
+    // prepended once (see `usesPathShim`).
+    if (imp.shimPath) {
+      if (imp.defaultName && !definedNames.has(imp.defaultName)) {
+        lines.push(buildPathDefaultObject(imp.defaultName));
+        usesPathShim = true;
+      }
+      if (imp.namedBindings) {
+        for (const name of imp.namedBindings) {
+          if (definedNames.has(name)) continue;
+          const binding = buildPathNamedBinding(name);
+          if (binding) {
+            lines.push(binding);
+            usesPathShim = true;
+          } else {
+            // Unsupported named path export (e.g. parse) — fall back to the
+            // generic stub so it doesn't regress.
+            lines.push(`declare const ${name}: any;`);
+          }
+        }
+      }
+      replacements.push({
+        start: imp.start,
+        end: imp.end,
+        text: lines.length > 0 ? lines.join("\n") : `/* node:path shim import removed */`,
+      });
+      continue;
+    }
+
     // #1492 — when a Node builtin is imported by named bindings (e.g.
     // `import { randomBytes, randomUUID } from "node:crypto"`), emit a typed
     // host-import stub for each known function instead of a plain
@@ -729,10 +1109,17 @@ export function preprocessImports(source: string, opts?: { wasi?: boolean }): Pr
     }
   }
 
+  // #1791 — the path-shim function prelude is prepended once, alongside the
+  // timer shim. Both are top-level declarations (hoisted), so the relative
+  // order is irrelevant; the position map only needs the combined prepend
+  // length.
+  const pathShim = usesPathShim ? buildPathShim() : "";
+  const prelude = pathShim + timerShim;
+
   // #1928 — capture the import-stub edits (in INPUT coordinates) for the
   // position map BEFORE the reverse-order apply mutates `result`. The map
   // constructor re-sorts ascending, so the apply order here is irrelevant to it.
-  const positionMap = buildPreprocessPositionMap(replacements, timerShim.length);
+  const positionMap = buildPreprocessPositionMap(replacements, prelude.length);
 
   // Apply replacements in reverse order to preserve positions
   let result = source;
@@ -741,5 +1128,5 @@ export function preprocessImports(source: string, opts?: { wasi?: boolean }): Pr
     result = result.substring(0, r.start) + r.text + result.substring(r.end);
   }
 
-  return { source: timerShim ? timerShim + result : result, nodeBuiltins, jsxRuntime, positionMap };
+  return { source: prelude ? prelude + result : result, nodeBuiltins, jsxRuntime, positionMap };
 }

--- a/tests/issue-1575.test.ts
+++ b/tests/issue-1575.test.ts
@@ -75,27 +75,30 @@ describe("#1575 - Node.js builtin gap survey", () => {
       export const marker = 1;
     `);
 
+    // #1791 — `node:path` is now bound to the pure-TS posix shim (host +
+    // standalone), so it is NOT recorded as an opaque `__node_path` builtin.
+    // The remaining opaque builtins (http, events) are still recorded.
     expect(result.nodeBuiltins).toEqual([
-      { localName: "path", moduleName: "path" },
       { localName: "http", moduleName: "http" },
       { localName: "EventEmitter", moduleName: "events", namedBindings: ["EventEmitter"] },
     ]);
     expect(result.source).not.toContain("import path");
     expect(result.source).not.toContain("import * as http");
     expect(result.source).not.toContain("import { EventEmitter }");
+    // The path shim prelude is injected in place of the opaque import.
+    expect(result.source).toContain("__js2wasm_path_");
   });
 
   it("routes unsupported default builtin imports through opaque __node_<module> imports", async () => {
     const result = await compile(
       `
-        import path from "node:path";
         import http from "node:http";
         import events from "node:events";
 
         export function touch(): any {
           const h = http;
           const e = events;
-          return path.join("a", "b") || h || e;
+          return h || e;
         }
       `,
       { fileName: "issue-1575-default-builtins.ts" },
@@ -107,8 +110,9 @@ describe("#1575 - Node.js builtin gap survey", () => {
       .filter((imp) => imp.intent.type === "node_builtin")
       .map((imp) => [imp.name, imp.intent.moduleName]);
 
+    // #1791 — `node:path` is no longer opaque (it has a real shim); http/events
+    // remain opaque `__node_<module>` host imports.
     expect(moduleImports).toEqual([
-      ["__node_path", "path"],
       ["__node_http", "http"],
       ["__node_events", "events"],
     ]);
@@ -117,6 +121,47 @@ describe("#1575 - Node.js builtin gap survey", () => {
       (imp) => imp.intent.type === "node_builtin_fn" && ["path", "http", "events"].includes(imp.intent.moduleName),
     );
     expect(typedImports).toEqual([]);
+  });
+
+  it("binds node:path (default import) to the pure-TS posix shim, not an opaque import (#1791)", async () => {
+    const result = await compile(
+      `
+        import path from "node:path";
+        export function touch(): string {
+          return path.join("a", "b");
+        }
+      `,
+      { fileName: "issue-1575-path-shim.ts" },
+    );
+
+    expectSuccessfulCompile(result);
+
+    // No opaque __node_path import, and no node_builtin_fn for path.
+    expect(result.imports.some((imp) => imp.intent.type === "node_builtin" && imp.intent.moduleName === "path")).toBe(
+      false,
+    );
+    expect(
+      result.imports.some((imp) => imp.intent.type === "node_builtin_fn" && imp.intent.moduleName === "path"),
+    ).toBe(false);
+  });
+
+  it("keeps node:path on the legacy opaque path when an unsupported member is used (#1791)", async () => {
+    // `path.parse` is out of the posix Tier-0 shim surface, so the default
+    // import must stay on the legacy `__node_path` host route (no regression).
+    const result = await compile(
+      `
+        import path from "node:path";
+        export function touch(): any {
+          return path.parse("/a/b.txt");
+        }
+      `,
+      { fileName: "issue-1575-path-unsupported.ts" },
+    );
+
+    expectSuccessfulCompile(result);
+    expect(result.imports.some((imp) => imp.intent.type === "node_builtin" && imp.intent.moduleName === "path")).toBe(
+      true,
+    );
   });
 
   it("keeps the current typed-function exceptions limited to fs and crypto", async () => {
@@ -160,7 +205,7 @@ describe("#1575 - Node.js builtin gap survey", () => {
     ).toEqual([["__node_fs_readFileSync", "fs", "readFileSync"]]);
   });
 
-  it("documents the unsupported named-import gap for common npm builtins", async () => {
+  it("resolves named node:path imports via the shim; other named builtins remain a gap", async () => {
     const result = await compile(
       `
         import { join } from "node:path";
@@ -175,22 +220,20 @@ describe("#1575 - Node.js builtin gap survey", () => {
 
     expectSuccessfulCompile(result);
 
-    expect(result.imports.find((imp) => imp.name === "join")?.intent).toEqual({ type: "builtin", name: "join" });
+    // #1791 — `join` is now a real shim function, so there is NO `join` import
+    // at all (neither generic-builtin nor node_builtin_fn).
+    expect(result.imports.find((imp) => imp.name === "join")).toBeUndefined();
+    expect(
+      result.imports.some((imp) => imp.intent.type === "node_builtin_fn" && imp.intent.moduleName === "path"),
+    ).toBe(false);
+    expect(result.imports.some((imp) => imp.intent.type === "node_builtin" && imp.intent.moduleName === "path")).toBe(
+      false,
+    );
+
+    // `createHash` is still an unsupported named crypto import → generic stub.
     expect(result.imports.find((imp) => imp.name === "createHash")?.intent).toEqual({
       type: "builtin",
       name: "createHash",
     });
-
-    expect(result.imports.some((imp) => imp.intent.type === "node_builtin" && imp.intent.moduleName === "path")).toBe(
-      false,
-    );
-    expect(
-      result.imports.some(
-        (imp) =>
-          imp.intent.type === "node_builtin_fn" &&
-          ((imp.intent.moduleName === "path" && imp.intent.name === "join") ||
-            (imp.intent.moduleName === "crypto" && imp.intent.name === "createHash")),
-      ),
-    ).toBe(false);
   });
 });

--- a/tests/issue-1791.test.ts
+++ b/tests/issue-1791.test.ts
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #1791 — `node:path` as a pure-TS posix shim compiled into the module.
+//
+// `path` is pure string compute (no I/O), so a single TS port serves BOTH the
+// JS-host and standalone (WASI) targets — no host import, no standalone trap.
+// This is the highest-leverage Node builtin (blocks ESLint/prettier/TS). The
+// covered surface is exactly what ESLint + deps call
+// (resolve/sep/join/dirname/relative/isAbsolute/extname/normalize) plus
+// `basename` (Tier 0). win32 + `path.posix`/`path.win32`/`parse`/`format` are
+// deferred; a default import that uses any of those stays on the legacy host
+// `__node_path` path (no regression).
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { instantiateWithRuntime } from "./equivalence/helpers.js";
+
+/** Compile + instantiate in JS-host (gc) mode; call a numeric `test()`. */
+async function runHost(src: string): Promise<number> {
+  const result = await compile(src, { fileName: "test.ts" });
+  expect(result.success, JSON.stringify(result.errors)).toBe(true);
+  const instance = await instantiateWithRuntime(result);
+  return (instance.exports as Record<string, () => number>).test();
+}
+
+/** Compile + instantiate in standalone (--target wasi) mode; call `test()`. */
+async function runWasi(src: string): Promise<number> {
+  const result = await compile(src, { fileName: "test.ts", target: "wasi" });
+  expect(result.success, JSON.stringify(result.errors)).toBe(true);
+  // Pure-compute test functions don't call I/O, but the module may still import
+  // wasi_snapshot_preview1 entries; supply no-op stubs for any imported name.
+  const noop = () => 0;
+  const stub = new Proxy({}, { get: () => noop });
+  const instance = new WebAssembly.Instance(new WebAssembly.Module(result.binary), {
+    wasi_snapshot_preview1: stub,
+    env: stub,
+  });
+  return (instance.exports.test as () => number)();
+}
+
+/** Run the same snippet in both modes; both must return 1. */
+async function bothModes(src: string): Promise<{ host: number; wasi: number }> {
+  return { host: await runHost(src), wasi: await runWasi(src) };
+}
+
+describe("#1791 node:path posix shim — Tier 0 (default import)", () => {
+  it("covers join/basename/dirname/extname/resolve/sep/isAbsolute/normalize", async () => {
+    const src = `
+      import path from "node:path";
+      export function test(): number {
+        if (path.join("/a", "b", "../c") !== "/a/c") return 10;
+        if (path.basename("/foo/bar.ts", ".ts") !== "bar") return 11;
+        if (path.dirname("/foo/bar.ts") !== "/foo") return 12;
+        if (path.extname("/foo/bar.ts") !== ".ts") return 13;
+        if (path.resolve("/a", "b") !== "/a/b") return 14;
+        if (path.sep !== "/") return 15;
+        if (path.isAbsolute("/x")) {} else { return 16; }
+        if (path.isAbsolute("x")) { return 17; }
+        if (path.normalize("/a/./b/../c") !== "/a/c") return 18;
+        if (path.basename("/foo/bar.ts") !== "bar.ts") return 19;
+        return 1;
+      }
+    `;
+    const { host, wasi } = await bothModes(src);
+    expect(host).toBe(1);
+    expect(wasi).toBe(1);
+  });
+
+  it("relative computes the posix relative path", async () => {
+    const src = `
+      import path from "node:path";
+      export function test(): number {
+        if (path.relative("/a/b/c", "/a/b/d") !== "../d") return 20;
+        if (path.relative("/a/b", "/a/b/c/d") !== "c/d") return 21;
+        return 1;
+      }
+    `;
+    const { host, wasi } = await bothModes(src);
+    expect(host).toBe(1);
+    expect(wasi).toBe(1);
+  });
+});
+
+describe("#1791 node:path posix shim — Tier 0 (named imports)", () => {
+  it("named { join, basename, dirname, extname, resolve, isAbsolute, normalize }", async () => {
+    const src = `
+      import { join, basename, dirname, extname, resolve, isAbsolute, normalize } from "node:path";
+      export function test(): number {
+        if (join("/a", "b", "../c") !== "/a/c") return 30;
+        if (basename("/foo/bar.ts", ".ts") !== "bar") return 31;
+        if (dirname("/foo/bar.ts") !== "/foo") return 32;
+        if (extname("/foo/bar.ts") !== ".ts") return 33;
+        if (resolve("/a", "b") !== "/a/b") return 34;
+        if (isAbsolute("/x")) {} else { return 35; }
+        if (normalize("a/b/../c") !== "a/c") return 36;
+        return 1;
+      }
+    `;
+    const { host, wasi } = await bothModes(src);
+    expect(host).toBe(1);
+    expect(wasi).toBe(1);
+  });
+
+  it("default and named forms agree on the same input", async () => {
+    const src = `
+      import path from "node:path";
+      import { join } from "node:path";
+      export function test(): number {
+        return path.join("/x", "y") === join("/x", "y") ? 1 : 40;
+      }
+    `;
+    const { host, wasi } = await bothModes(src);
+    expect(host).toBe(1);
+    expect(wasi).toBe(1);
+  });
+});
+
+describe("#1791 node:path posix shim — edge cases", () => {
+  it("join collapses '.' and trailing slashes", async () => {
+    const src = `
+      import path from "node:path";
+      export function test(): number {
+        if (path.join("foo", ".", "bar") !== "foo/bar") return 50;
+        if (path.join("/", "foo") !== "/foo") return 51;
+        if (path.join("a", "") !== "a") return 52;
+        return 1;
+      }
+    `;
+    const { host, wasi } = await bothModes(src);
+    expect(host).toBe(1);
+    expect(wasi).toBe(1);
+  });
+
+  it("extname/dirname corner cases", async () => {
+    const src = `
+      import path from "node:path";
+      export function test(): number {
+        if (path.extname("index") !== "") return 60;
+        if (path.extname(".gitignore") !== "") return 61;
+        if (path.extname("a.b.c") !== ".c") return 62;
+        if (path.dirname("foo") !== ".") return 63;
+        if (path.dirname("/foo") !== "/") return 64;
+        return 1;
+      }
+    `;
+    const { host, wasi } = await bothModes(src);
+    expect(host).toBe(1);
+    expect(wasi).toBe(1);
+  });
+});


### PR DESCRIPTION
## #1791 — node:path as a pure-TS posix shim (host + standalone)

`node:path` was the highest-leverage Node builtin gap (blocks ESLint, prettier,
TypeScript per the #1575 matrix): default `path.X` resolved to the opaque
`__node_path` host module (traps in standalone) and named imports
(`import { join }`) fell through to a generic `env` stub. `path` is pure string
compute, so a **single TS port serves BOTH the JS-host and standalone
(WASI/browser) targets** — no host import, no trap.

### Implementation (`src/import-resolver.ts`)
- `buildPathShim()` — prepended prelude of posix `__js2wasm_path_*` functions
  (faithful Node `lib/path.js` posix port: normStr/normalize/join/resolve/
  dirname/basename/extname/isAbsolute/relative).
- **Named import** → forwarding function declarations + `const sep = "/"`.
- **Default/namespace import** → `const path = { …fixed-arity wrappers…, sep:
  "/" }`. Variadic dispatch through an object field is miscompiled, so
  `join`/`resolve` wrappers are fixed 8-slot forwarders to the variadic
  top-level shims (which skip empty args, so padding is inert).
- `path` excluded from `nodeBuiltins` (no `__node_path`) when shimmed.

### Scope guards (no regression)
- A **default** import is shimmed only when every `path.<member>` access is in
  the supported surface (`pathDefaultFullySupported`); else it stays on the
  legacy `__node_path` host route — so `path.parse`/`path.win32`/etc. (deferred)
  don't regress in JS-host mode.
- Unsupported **named** exports fall through to the generic stub.

### Surface covered (= exactly what ESLint + deps call)
`resolve, sep, join, dirname, relative, isAbsolute, extname, normalize` (grep of
`node_modules/eslint/lib`) + `basename` (Tier 0). Unblocks linter.js's only
`node:` import. win32 / `path.posix`/`path.win32` / `parse`/`format` deferred.

### Validation
- `tests/issue-1791.test.ts` — 6 cases, each run in BOTH host and `--target
  wasi` (standalone), all green; covers every Tier-0 acceptance snippet (default
  + named), relative, and join/extname/dirname edge cases.
- `tests/issue-1575.test.ts` updated — the node:path "gap survey" tests now
  assert the gap is CLOSED, plus new shim-binding + unsupported-member legacy
  fallback guards (7 green).
- No regressions in path-importing tests (issue-1400/1043/1081/host-import-
  allowlist-gate). `tsc --noEmit` clean. (issue-1296 missing-fixture +
  issue-1492 crypto-fnName failures are PRE-EXISTING on `main`, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)