### PR TITLE
docs(#2660): acorn #1712 keystone handoff + carve #2694 (Scope.flags wall)

### DIFF
--- a/plan/issues/2660-fnctor-instance-dynamic-use-escape-gate.md
+++ b/plan/issues/2660-fnctor-instance-dynamic-use-escape-gate.md
@@ -515,3 +515,74 @@ S3b re-types the binding local / param / return that an approved struct-typed
 reconstructed `$Object` flows through the dynamic-read + generic-method paths and
 the test262 cluster lands. Held behind S3a's floor result; budget a fix-iterate
 cycle (S2 took one). Issue stays `in-progress`.
+
+## HANDOFF (2026-06-26, sd-2674c) — acorn #1712 endgame needs this keystone; validated READ-half component ready
+
+The acorn dogfood (#1712) endgame converges on THIS issue. After #2085 fixed the
+9th-wall hang, `parse()` returns Programs for empty/numeric statements but the
+remaining walls are all ONE family: an **`any`/`unknown`-typed receiver that at
+runtime IS a known WasmGC struct**, where the dynamic read path
+(`__extern_get` → host proxy / sidecar) diverges in representation from the
+struct-slot write (`#2664`/`#2659` `emitAlternateStructSetDispatch`). Identity
+breaks (`this.type === types$1.X` → false) and read/write desync (numeric-field
+loops).
+
+### Bounded-vs-escape-analysis verdict (cheap TS-checker probe — conclusive)
+`.tmp/checker-probe.mjs` (mirrors the compiler's `createProgram`+allowJs) shows
+the compiler's checker types the local receivers as **`any`**:
+- `var node = this.startNode(...)` → **any** (43/43 samples)
+- `scope.flags` where `scope = this.currentVarScope()` → receiver **any**;
+  `currentVarScope()` / `enterScope()` return types → **any**
+- `this` in the lifted parser methods → the polymorphic `this`-type (no struct)
+
+So receiver-resolution splits in two:
+- **`this` receiver = BOUNDED** — recoverable SYNTACTICALLY from the
+  `Class.prototype.m = function(){}` (or aliased `var pp = Class.prototype; pp.m
+  = …`) assignment. No flow needed. **Already implemented + validated** (below).
+- **local receivers (`node`, `scope`) = NEEDS #2660** — they are bound from
+  METHOD-CALL RETURNS (`this.startNode()`, `this.currentVarScope()`) the checker
+  leaves `any` (the callees are aliased-prototype methods — same root). Recovering
+  `Node`/`Scope` requires inter-procedural return-type + field-element-type
+  inference (follow callee `return new Node()` / `return this.scopeStack[i]`
+  chains). That is the whole-program flow THIS issue builds.
+
+### Per-wall map (all the same family)
+| wall | receiver | resolution |
+|---|---|---|
+| #2681 `this.type` (parseExprAtom switch `unexpected()`) | `this` | BOUNDED — FIXED + validated (read-half below) |
+| #2694 `Scope.flags` (11th wall, tight loop) | `this.currentVarScope()` (local) | needs #2660 flow |
+| #2687 `node.expression` null | `node = this.startNode()` (local) | needs #2660 flow |
+| #2686 binary-expr throw | parseExprOp token compares / node builds | almost certainly same family → needs #2660 |
+
+### Validated READ-half component to REUSE (don't rebuild)
+Branch `issue-2681-acorn-lifted-method-this` @ `c83216fe2` (WIP, NOT PR'd —
+preserved for folding in). It is the symmetric READ counterpart to #2664's
+`emitAlternateStructSetDispatch` WRITE half:
+- `FunctionContext.thisStructName` (context/types.ts) — the struct a lifted
+  method's `this` resolves to.
+- `resolveLiftedMethodThisStruct` (closures.ts) — the SYNTACTIC prototype-alias
+  resolver (set on `liftedFctx`).
+- `tryEmitThisStructMemberRead` (property-access.ts) — guarded
+  `emitExternrefToStructGet` (`ref.test $struct → struct.get → __extern_get`
+  fallback) for `this.<field>`.
+Validated: on compiled acorn, `parse("x")` `__host_eq` dropped **30k → 163** — the
+parseExprAtom switch now matches and the #2681 `unexpected()` throw is gone.
+
+### How the unified substrate should generalize it
+Keep this exact symmetric read+write+**compound** dispatch; only generalize the
+RECEIVER-RESOLUTION step from "syntactic `this`" to "any receiver whose struct
+type #2660's flow proves". I.e. `thisStructName` becomes a general
+`receiverStructName(expr)` backed by the #2660 escape/flow result; the
+read/write/compound emitters are unchanged.
+
+### CRITICAL hazard — symmetry is mandatory
+A READ-only slot fix WITHOUT the matching write+compound caused a **35.9M-iter
+`__extern_get`/box/unbox loop** in `parse("x")` (read=slot, `this.field++`
+write-back=sidecar → desync). The substrate MUST cover **read + write + compound**
+(`recv.field++`, `recv.field op= v`) consistently, or numeric-field loops appear.
+
+### Probes banked (`.tmp/`, single-compile worker+SAB; ~290s/acorn-compile)
+`checker-probe.mjs` (the verdict gate, no Wasm compile), `keyhist2.mjs`
+(`__extern_get` key histogram — named the Scope.flags wall), `this-bind-repro.mjs`
+(small-scale fix verification), `structwalk.mjs`, `diff-probe.mjs` +
+`tests/dogfood/probe-driver.mjs`.

--- a/plan/issues/2686-acorn-binary-expression-throws.md
+++ b/plan/issues/2686-acorn-binary-expression-throws.md
@@ -13,8 +13,8 @@ task_type: bugfix
 area: codegen
 language_feature: unknown
 goal: acorn-dogfood
-related: [1712, 2681, 2674, 2664]
-depends_on: []
+related: [1712, 2681, 2674, 2664, 2660]
+depends_on: [2660]
 origin: "Surfaced re-verifying the acorn dogfood after #2085 fixed the 9th-wall hang (sd-2674c, #2674). With parseExpression() now running, numeric/empty statements parse, but a binary-expression statement THROWS a WebAssembly.Exception — distinct from the #2681 identifier-`unexpected()` wall."
 ---
 

--- a/plan/issues/2687-acorn-expressionstatement-expression-null.md
+++ b/plan/issues/2687-acorn-expressionstatement-expression-null.md
@@ -13,8 +13,8 @@ task_type: bugfix
 area: codegen
 language_feature: unknown
 goal: acorn-dogfood
-related: [1712, 2681, 2674, 2664, 2659]
-depends_on: []
+related: [1712, 2681, 2674, 2664, 2659, 2660]
+depends_on: [2660]
 origin: "Surfaced re-verifying the acorn dogfood after #2085 fixed the 9th-wall hang (sd-2674c, #2674). The numeric/empty statements that DO parse return an ExpressionStatement whose `.expression` is null — the parsed Literal is not attached to the statement node. CONFIRMED a real codegen defect (not a host-marshalling artifact) by a direct struct-walk."
 ---
 

--- a/plan/issues/2694-acorn-scope-flags-loop.md
+++ b/plan/issues/2694-acorn-scope-flags-loop.md
@@ -1,0 +1,74 @@
+---
+id: 2694
+title: "acorn parse() 11th wall — Scope.flags read loop (local-receiver slot/sidecar asymmetry, needs #2660)"
+status: blocked
+assignee: ttraenkler/unassigned
+sprint: 66
+created: 2026-06-26
+updated: 2026-06-26
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: unknown
+goal: acorn-dogfood
+related: [1712, 2681, 2687, 2686, 2660, 2664, 2659]
+depends_on: [2660]
+origin: "Surfaced by sd-2674c's validated #2681 this-read-dispatch: with the parseExprAtom switch now matching (the #2681 unexpected() throw resolved), parse(\"x\") advances PAST the identifier path and hits a tight loop reading Scope.flags ~800k×/cap. Same any-typed-local-receiver slot/sidecar family as #2681/#2687; the receiver is a method-call return the checker types `any`, so resolving it needs the #2660 inter-procedural flow keystone."
+---
+
+# #2694 — acorn `parse()` 11th wall: `Scope.flags` read loop
+
+## Context
+
+After sd-2674c's #2681 `this`-receiver read-dispatch fix (validated: compiled-acorn
+`parse("x")` `__host_eq` 30k→163, the parseExprAtom `switch(this.type)` matches and
+the #2681 `unexpected()` throw is gone), `parse("x")` STILL hangs — now at a
+DEEPER wall reached only because #2681 peeled past the throw.
+
+## Localized (key histogram, sd-2674c)
+
+`.tmp/keyhist2.mjs` (`__extern_get` key histogram, cap-throw, on the #2681-fixed
+base) names the hot field:
+
+```
+__extern_get top keys (parse "x"):
+  flags: 799238      ← the loop
+  keyword/beforeExpr/startsExpr/isLoop/isAssign/postfix/binop: ~77-80  (TokenType)
+  ...
+```
+
+`.flags` = **`Scope.flags`** (`var Scope = function Scope(flags){ this.flags =
+flags; ... }`, a function-constructor like Parser; 16 `scope.flags & SCOPE_*`
+bitops). The loop reads `Scope.flags` ~800k× with `__box_number`/`__unbox_number`
+in lockstep (numeric bitmask).
+
+## Root (same family as #2681/#2687 — needs #2660)
+
+The receiver is `this.currentVarScope()` / `this.scopeStack[i]` — a LOCAL bound
+from a method-call return that the compiler's checker types **`any`** (verified by
+`.tmp/checker-probe.mjs`: `currentVarScope()` return type = `any`). So
+`scope.flags` reads route through the dynamic `__extern_get` (host proxy/sidecar)
+path, which diverges from the struct-slot write → a non-advancing loop.
+
+Unlike #2681's `this` receiver (recoverable SYNTACTICALLY from the prototype-alias
+assignment), resolving `scope`'s `Scope` struct type requires inter-procedural
+return-type flow (follow `currentVarScope` → `scopeStack[last]` → the field's
+element type). That is the **#2660** whole-program escape/flow keystone — hence
+`depends_on: [2660]`, `status: blocked`.
+
+## Fix (via #2660)
+
+Once #2660 resolves local-receiver struct types, route `scope.<field>` (and the
+general `recv.<field>`) reads/writes/compound through the SAME symmetric dispatch
+as #2681's READ half (`tryEmitThisStructMemberRead` → generalized
+`emitExternrefToStructGet`) + #2664's WRITE half. Must cover read + write +
+**compound** (`scope.flags & X`, `scope.flags |= X`) consistently — a read-only
+slot fix without the write/compound match caused a 35.9M-iter loop in the #2681
+investigation.
+
+## Acceptance
+- `parse("x")` / `parse("var x = 1;")` advance past the Scope.flags loop (return
+  or hit the next wall, not spin).
+- Full merge_group / test262 floor (broad value-rep change via #2660).


### PR DESCRIPTION
Doc-only. Hands the acorn #1712 endgame to the #2660 escape/flow keystone for the architect, and carves the next wall.

## What this lands (no source)
- **#2660 handoff section**: the bounded-vs-escape-analysis VERDICT (cheap TS-checker probe — `node = this.startNode()` and `scope = this.currentVarScope()` receivers are checker-`any`, bound from method-call returns → resolving them needs inter-procedural flow = #2660); the per-wall map (#2681 `this`=BOUNDED-fixed; Scope.flags/#2687/#2686 = local-receiver = need #2660); and the **validated #2681 read-half component** (branch `issue-2681-acorn-lifted-method-this` @ `c83216fe2` — `FunctionContext.thisStructName` + `resolveLiftedMethodThisStruct` + `tryEmitThisStructMemberRead`) as the READ counterpart to #2664's WRITE half, to fold into the unified substrate. Notes the read/write/**compound** symmetry hazard (a read-only slot fix caused a 35.9M-iter loop).
- **#2694 (NEW)**: the Scope.flags 11th wall (`status: blocked`, `depends_on: [2660]`).
- **#2687/#2686**: linked `depends_on: [2660]`.

Validated: my #2681 `this`-read-dispatch fixed the parseExprAtom comparison (compiled-acorn `parse("x")` `__host_eq` 30k→163, the #2681 throw gone) — kept as WIP (not merged; alone it doesn't close #1712 and is unvalidated on the floor).

Issue id allocated via `claim-issue --allocate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)