### PR TITLE
docs(#2680): verify-first verdict BROAD — no runtime-reachable proto link for wasmGC descriptors

### DIFF
--- a/plan/issues/2680-runtime-topropertydescriptor-proto-inherited-attrs.md
+++ b/plan/issues/2680-runtime-topropertydescriptor-proto-inherited-attrs.md
@@ -80,3 +80,63 @@ struct) — so the proto-walk MUST use the shape-precise `_getStructFieldNames` 
 sidecar membership at each level, never a `__sget_*` try/catch probe. Validate
 via the full `merge_group` floor — this is the path that auto-parked #2668
 Slice A's first cut. Coordinate the standalone value-rep with #2580.
+
+## Verify-first findings (sd-2668c, 2026-06-26) — VERDICT: BROAD (needs a proto-link representation, not a reader extension)
+
+### The premise (proto chain is walkable) does NOT hold for wasmGC descriptors
+
+Instrumented `__defineProperty_desc` on the real cluster. For the proto-inherited
+pattern (`var proto = {…}; ConstructFun.prototype = proto; var child = new
+ConstructFun(); Object.defineProperty(obj, "property", child)`), the descriptor
+`child` is a **wasmGC struct with an EMPTY own sidecar**, and:
+
+```
+[dp76] objWasm=true descWasm=true descChain= wasm[[]]
+```
+
+`Object.getPrototypeOf(child)` returns **no link to `proto`** — the chain is just
+`child → (null)`. There is **no `_wasmStructProto` sidecar** and no host
+[[Prototype]] edge recording `ConstructFun.prototype = proto` on the instance
+(confirmed: only `_prototypeMethodBridges` exists, which is method-name routing,
+not a value-attribute proto link). So the runtime descriptor reader has **nothing
+to walk** — the proto-carrying ancestor is unreachable at the
+ToPropertyDescriptor boundary.
+
+The acceptance criterion ("`getField`/`hasField` walk the descriptor's prototype
+chain consulting each ancestor's own struct fields + sidecar") cannot be met
+because the prototype chain is not represented at runtime for wasmGC instances.
+This is the object-model substrate work coordinated with #2580 — **route to an
+architect spec** (like #2688), not a bounded reader patch.
+
+### Bounded sub-piece that WOULD be needed first (for the spec)
+
+Codegen must record a **runtime-reachable prototype link** for wasmGC instances
+whose constructor's `.prototype` was user-assigned (`ConstructFun.prototype =
+proto`) and for `Object.create(proto)` when `proto` is a wasmGC struct — e.g. a
+`_wasmStructProto` WeakMap (instance → proto struct), populated at
+`__construct`/`__construct_closure` and `__object_create`. THEN `getField`/
+`hasField` can walk it, consulting each ancestor's own fields + sidecar via
+`_readOwnDescriptor`/`_getStructFieldNames` (the #1629-safe membership test, NOT
+a `__sget_*` probe). The native fast-path (`!_isWasmStruct(obj) &&
+!_isWasmStruct(desc)` → `Object.defineProperty(obj,key,desc)`) must also be gated
+off when the descriptor has any wasmGC ancestor in that chain.
+
+### Actual fail count this unblocks
+
+- Of the **138** `built-ins/Object/defineProperty/15.2.3.6-3-*` family failures,
+  only **~29 are genuinely proto-inherited-descriptor** cases (the #2680 target):
+  `15.2.3.6-3-{31,32,76,77,78,80,81,82,85,129,133,134,135,138,208,209,210,212,
+  213,214,216,217,238,239,240,242,243,244,246}`. The other ~109 are own-level /
+  other sub-features (defineProperties batching, ToPropertyDescriptor edge cases)
+  unrelated to proto-walk.
+- The issue's cited cluster `15.2.3.6-3-23..45` is **mostly already passing** on
+  current main (23,25,28,35,40,45 pass — #2668 Slice A covered them); the stale
+  premise overstated the cluster.
+- Indirect: unblocks re-introducing the #2668 Slice A for-in `enumerable:false`
+  filter + re-widening the dynamic-descriptor route once the proto-link lands.
+
+### Disposition
+
+BROAD → escalated for an architect spec (next-sprint), same as #2688. The
+~29-test ceiling + the substrate dependency (#2580) make a careful spec the right
+path over a risky partial reader patch on the auto-park-prone descriptor surface.


### PR DESCRIPTION
Doc-only PR — persists the verify-first diagnosis for #2680 so an architect spec can build on it. **No code changes.**

## Verdict: BROAD (needs a proto-link representation, not a reader extension)

The issue's premise — extend `ToPropertyDescriptor`'s `getField`/`hasField` to walk the descriptor's prototype chain — **cannot be met**: there is no runtime-reachable prototype chain for wasmGC-struct descriptors.

Instrumented `__defineProperty_desc` on the real cluster. For the proto-inherited pattern (`var proto = {…}; ConstructFun.prototype = proto; var child = new ConstructFun(); Object.defineProperty(obj, "property", child)`):

```
[dp76] objWasm=true descWasm=true descChain= wasm[[]]
```

`child` is a wasmGC struct with an **empty own sidecar**, and `Object.getPrototypeOf(child)` returns **no link to `proto`** (chain is just `child → null`). There is **no `_wasmStructProto` sidecar** recording `ConstructFun.prototype = proto` on the instance. So the reader has nothing to walk — the proto-carrying ancestor is unreachable.

## What the fix actually needs (for the architect spec)
1. A runtime-reachable **prototype link** for wasmGC instances — a `_wasmStructProto` WeakMap (instance → proto struct) populated at `__construct`/`__construct_closure` and `__object_create` (when proto is a wasmGC struct).
2. Then `getField`/`hasField` walk it, consulting each ancestor's own fields + sidecar via `_readOwnDescriptor`/`_getStructFieldNames` (the #1629-safe membership test, never a `__sget_*` probe).
3. Gate off the native fast-path when the descriptor has a wasmGC ancestor.

This is object-model substrate work coordinated with #2580 → architect spec (like #2688).

## Actual fail count this unblocks
- Of **138** `15.2.3.6-3-*` family failures, only **~29 are genuinely proto-inherited** (the #2680 target); ~109 are own-level/other sub-features.
- The cited `15.2.3.6-3-23..45` cluster **mostly already passes** on main (#2668 Slice A covered it) — the premise was stale.
- Indirect: unblocks re-introducing the #2668 Slice A for-in filter + re-widening the dynamic-descriptor route.

Full evidence in the issue file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)