### PR TITLE
feat(#2699): host-glue node:url/module/os destructured function imports

### DIFF
--- a/plan/issues/2699-node-builtin-fn-host-glue-url-module-os.md
+++ b/plan/issues/2699-node-builtin-fn-host-glue-url-module-os.md
@@ -1,0 +1,76 @@
+---
+id: 2699
+title: "node builtins: destructured/named function imports for url/module/os route to host (eslint host-glue)"
+status: done
+completed: 2026-06-26
+assignee: ttraenkler/agent-ae565d4893a5783d7
+created: 2026-06-26
+updated: 2026-06-26
+priority: high
+feasibility: easy
+reasoning_effort: medium
+task_type: feature
+area: host-interop
+language_feature: node-builtins
+goal: npm-library-support
+related: [1791, 1792, 1044, 1491, 1492, 2693]
+---
+# #2699 — node:url / node:module / node:os destructured-import host-glue
+
+## Problem (verify-first findings)
+
+Real-eslint-runs need the Node builtins eslint/lib imports. Verified on current
+`main`:
+
+- The **namespace** form already works in a JS host: `const os = require("node:os");
+  os.platform()` → "linux", `const fs = require("node:fs"); fs.existsSync(p)` →
+  true. The `node_builtin` runtime resolver (`src/runtime.ts:11981`) already does
+  `require(modName)` and member dispatch flows through `__extern_get`. No new
+  runtime shim is needed for the namespace form.
+- The **destructured / named** form was BROKEN: `const { pathToFileURL } =
+  require("node:url")` (eslint's actual form — cli.js, config-loader.js, eslint.js)
+  generated **no host import** — `pathToFileURL` fell through to a generic `env`
+  stub and resolved to `undefined`. eslint imports node builtins destructured:
+  `{ pathToFileURL }`, `{ createRequire }`, `{ isMainThread, threadId }`, etc.
+
+The working mechanism for named/destructured function imports is the existing
+`__nodefn__<module>__<fn>` typed-stub path (`NODE_BUILTIN_FN_TYPED_STUBS` →
+`node_builtin_fn` ImportIntent → `require(module)[fn]` host adapter), already used
+by `node:crypto` (#1491/#1492). The gap was simply that url/module/os had no
+entries (and `node:module` was not even in `NODE_BUILTIN_MODULES`).
+
+## Fix (pure data — runtime route already exists)
+
+`src/import-resolver.ts`:
+- Added `node:module` to `NODE_BUILTIN_MODULES`.
+- Added `NODE_BUILTIN_FN_TYPED_STUBS` entries for the eslint function surface:
+  - `url`: `pathToFileURL`, `fileURLToPath`
+  - `module`: `createRequire`
+  - `os`: `platform`, `release`
+
+## Verified
+
+`const { pathToFileURL, fileURLToPath } = require("node:url")` → routes to
+`__nodefn__url__pathToFileURL` / `__nodefn__url__fileURLToPath`:
+- `pathToFileURL("/tmp/x.js").href` → "file:///tmp/x.js"
+- `fileURLToPath("file:///tmp/x.js")` → "/tmp/x.js"
+- `os.platform()` → "linux", `os.release()` → "6.12.76-linuxkit"
+- `createRequire("/tmp/x.js")` → a function
+
+`tests/issue-2699.test.ts` covers classification + round-trips with the real
+modules injected via `buildImports(..., deps)`.
+
+## Deferred follow-ups
+
+- **`node:fs/promises`** — the `/` in the module name breaks the
+  `__nodefn__<module>__<fn>` identifier scheme (would emit an invalid
+  `__nodefn__fs/promises__readFile` declaration). Needs slash-sanitisation
+  coordinated across the import-manifest classifier + runtime resolver. eslint's
+  `fs/promises` use is in the CLI/config layers, not the Linter.verify hot path.
+- **`node:worker_threads`** — `Worker`/`parentPort`/`isMainThread` are
+  value/class-shaped, not functions, so the function-stub pattern doesn't fit;
+  CLI-only (not eslint/lib), deferred.
+- **`node:url` `URL` class** (a global + class) and **`node:util`
+  styleText/stripVTControlCharacters** — separate shapes/efforts.
+- Standalone (`--target wasi`) host-glue is out of scope (these route to the JS
+  host `require`); dual-mode for these is a follow-up.

--- a/src/import-resolver.ts
+++ b/src/import-resolver.ts
@@ -33,6 +33,7 @@ export const NODE_BUILTIN_MODULES = new Set([
   "fs",
   "crypto",
   "os",
+  "module",
   "child_process",
   "assert",
   "dns",
@@ -73,6 +74,34 @@ const NODE_BUILTIN_FN_TYPED_STUBS: Record<
   crypto: {
     randomBytes: { params: "size: number", returns: "Uint8Array", passthrough: "size" },
     randomUUID: { params: "", returns: "string", passthrough: "" },
+  },
+  // #2699 — the destructured/named `node:url` function surface ESLint + npm libs
+  // import (`const { pathToFileURL } = require("node:url")`). Routes to
+  // `__nodefn__url__*` → `require("node:url")[fn]` (host) via the existing
+  // `node_builtin_fn` adapter. The namespace form (`url.pathToFileURL`) already
+  // worked via the `__node_url` module route; this fixes the destructured form,
+  // which otherwise fell through to a broken generic `env` stub.
+  url: {
+    pathToFileURL: { params: "path: any", returns: "any", passthrough: "path" },
+    fileURLToPath: { params: "url: any", returns: "any", passthrough: "url" },
+  },
+  // #2699 — `node:module` (not previously a recognized builtin). `createRequire`
+  // is used by ESLint's config loader and by many ESM/CJS-interop shims.
+  module: {
+    createRequire: { params: "filename: any", returns: "any", passthrough: "filename" },
+  },
+  // NOTE: `node:fs/promises` is deferred — the `/` in the module name breaks the
+  // `__nodefn__<module>__<fn>` identifier scheme (would emit an invalid
+  // `__nodefn__fs/promises__readFile` declaration). Sanitising the slash needs
+  // coordinated changes in the import-manifest classifier + runtime resolver;
+  // tracked as a follow-up. ESLint's `fs/promises` use is in the CLI/config
+  // layers, not the Linter.verify hot path.
+  // #2699 — `node:os` destructured function surface (`const { platform } =
+  // require("node:os")`). The namespace form (`os.platform()`) already worked
+  // via `__node_os`; this covers the destructured form ESLint's deps use.
+  os: {
+    platform: { params: "", returns: "any", passthrough: "" },
+    release: { params: "", returns: "any", passthrough: "" },
   },
 };
 

--- a/tests/issue-2699.test.ts
+++ b/tests/issue-2699.test.ts
@@ -1,0 +1,97 @@
+// #2699 — destructured/named function imports for node:url / node:module /
+// node:os route to the `__nodefn__<module>__<fn>` host adapter (eslint imports
+// these destructured: `const { pathToFileURL } = require("node:url")`).
+//
+// Before this fix, the destructured form fell through to a generic `env` stub
+// and resolved to `undefined`. The namespace form (`os.platform()`) already
+// worked via the `__node_os` module route; this covers the destructured form.
+import { describe, it, expect } from "vitest";
+import { createRequire } from "node:module";
+import { compile, buildImports } from "../src/index.js";
+
+const require = createRequire(import.meta.url);
+const deps = {
+  url: require("node:url"),
+  module: require("node:module"),
+  os: require("node:os"),
+};
+
+async function run(src: string) {
+  const result = await compile(src, { fileName: "test.ts" });
+  expect(result.success, JSON.stringify(result.errors)).toBe(true);
+  // Pass the stringPool (3rd arg) so string-literal args resolve to JS strings
+  // at the host-import boundary (e.g. `pathToFileURL("/tmp/x.js")`).
+  const imports = buildImports(result.imports, deps, (result as { stringPool?: unknown }).stringPool);
+  const instance = new WebAssembly.Instance(new WebAssembly.Module(result.binary), imports);
+  if (imports.setExports) imports.setExports(instance.exports as Record<string, Function>);
+  return { result, instance };
+}
+
+describe("#2699 — node:url/module/os destructured-import host-glue", () => {
+  it("classifies __nodefn__ imports for destructured node:url/module/os fns", async () => {
+    const src = `
+      const { pathToFileURL, fileURLToPath } = require("node:url");
+      const { createRequire } = require("node:module");
+      const { platform, release } = require("node:os");
+      export function main(): number {
+        return (typeof pathToFileURL) === "function" &&
+               (typeof fileURLToPath) === "function" &&
+               (typeof createRequire) === "function" &&
+               (typeof platform) === "function" &&
+               (typeof release) === "function" ? 1 : 0;
+      }
+    `;
+    const { result, instance } = await run(src);
+    const nodefn = result.imports.filter((i) => i.name.startsWith("__nodefn__")).map((i) => i.name);
+    expect(nodefn).toContain("__nodefn__url__pathToFileURL");
+    expect(nodefn).toContain("__nodefn__url__fileURLToPath");
+    expect(nodefn).toContain("__nodefn__module__createRequire");
+    expect(nodefn).toContain("__nodefn__os__platform");
+    expect(nodefn).toContain("__nodefn__os__release");
+    expect((instance.exports.main as () => number)()).toBe(1);
+  });
+
+  it("url.pathToFileURL / fileURLToPath round-trip via the host adapter", async () => {
+    const src = `
+      const { pathToFileURL, fileURLToPath } = require("node:url");
+      export function ok(): number {
+        const href = pathToFileURL("/tmp/x.js").href;
+        const back = fileURLToPath("file:///tmp/x.js");
+        return (href === "file:///tmp/x.js" && back === "/tmp/x.js") ? 1 : 0;
+      }
+    `;
+    const { instance } = await run(src);
+    expect((instance.exports.ok as () => number)()).toBe(1);
+  });
+
+  it("os.platform / os.release return the host values (non-empty strings)", async () => {
+    const src = `
+      const { platform, release } = require("node:os");
+      export function plen(): number { return platform().length; }
+      export function rlen(): number { return release().length; }
+    `;
+    const { instance } = await run(src);
+    expect((instance.exports.plen as () => number)()).toBeGreaterThan(0);
+    expect((instance.exports.rlen as () => number)()).toBeGreaterThan(0);
+  });
+
+  it("module.createRequire returns a callable", async () => {
+    const src = `
+      const { createRequire } = require("node:module");
+      export function isFn(): number {
+        return (typeof createRequire("/tmp/x.js")) === "function" ? 1 : 0;
+      }
+    `;
+    const { instance } = await run(src);
+    expect((instance.exports.isFn as () => number)()).toBe(1);
+  });
+
+  it("namespace form still works (no regression): os.platform()", async () => {
+    const src = `
+      const os = require("node:os");
+      export function plen(): number { return os.platform().length; }
+    `;
+    const { instance } = await run(src);
+    expect((instance.exports.plen as () => number)()).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## #2699 — node:url / node:module / node:os destructured-import host-glue

Unblocks real-eslint-runs (eslint/lib imports node builtins destructured).

### Verify-first
- The **namespace** form already works in a JS host: `const os = require("node:os"); os.platform()` → "linux" (the `node_builtin` resolver does `require(mod)` + `__extern_get` member dispatch). No new runtime code needed.
- The **destructured** form eslint actually uses (`const { pathToFileURL } = require("node:url")`, also `{ createRequire }`, etc.) was BROKEN — generated no host import, resolved to `undefined`.

### Fix (pure data — runtime route already exists)
Route named/destructured node-builtin **function** imports through the existing `__nodefn__<module>__<fn>` typed-stub path (`node_builtin_fn` ImportIntent → `require(module)[fn]` host adapter — the same mechanism `node:crypto` uses, #1491/#1492):
- add `node:module` to `NODE_BUILTIN_MODULES`
- add `NODE_BUILTIN_FN_TYPED_STUBS` entries: `url.{pathToFileURL,fileURLToPath}`, `module.createRequire`, `os.{platform,release}`

### Verified (host, real modules injected via `buildImports(..., deps, stringPool)`)
`pathToFileURL("/tmp/x.js").href` → `file:///tmp/x.js`; `fileURLToPath` round-trips; `os.platform()`→"linux", `os.release()`→host release; `createRequire(...)`→a function. `tests/issue-2699.test.ts` 5/5 (incl. namespace no-regression).

> Note: the pre-existing #1492 "classifies" test failure (reads `intent.fnName`; the field is `intent.name`) is unrelated — it fails identically on clean upstream.

### Deferred (in the issue)
`node:fs/promises` (the `/` breaks the `__nodefn__` identifier — needs slash-sanitisation across manifest+runtime), `node:worker_threads` (value/class-shaped), `url` `URL` class, `util` styleText. Standalone host-glue out of scope (these route to the JS host `require`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)