### PR TITLE
fix(#2688): ref-element array/vec dedup-key collapse (eslint Linter.verify blocker)

### DIFF
--- a/plan/issues/2688-eslint-apply-disable-conditional-spread-struct-shape.md
+++ b/plan/issues/2688-eslint-apply-disable-conditional-spread-struct-shape.md
@@ -1,7 +1,9 @@
 ---
 id: 2688
 title: "ESLint apply-disable-directives.js: conditional-spread produces two struct shapes for array.set element type"
-status: ready
+status: done
+assignee: ttraenkler/sd-2668c
+completed: 2026-06-26
 created: 2026-06-26
 priority: medium
 area: codegen
@@ -121,3 +123,49 @@ Escalated for an architect spec rather than a risky partial fix on remaining
 budget. The bounded sub-piece (route struct-element `.map` through
 `compileArrayMap` AND make that path reachable for non-typed-vec receivers) is
 the most promising starting point for the spec.
+
+## Resolution (sd-2668c, 2026-06-26) — BOUNDED root cause: ref-element array/vec dedup-key collapse
+
+Earlier verify-first (#2109 doc) found the failing `array.set` is a
+struct-element `.map` typing its result array from the wrong struct. The actual
+ROOT CAUSE turned out to be **bounded**, not the broad shape-unification infra
+first suspected:
+
+**`getOrRegisterArrayType` / `getOrRegisterVecType` cached ref-element arrays/
+vecs under the plain `"ref"` / `"ref_null"` string key, ignoring the struct
+typeIdx.** So the FIRST ref-struct array registered (element struct A) was
+returned for EVERY subsequent ref-element request — `getOrRegisterArrayType(ctx,
+"ref", {ref:B})` returned array-of-A, not array-of-B. A shape-transforming
+`.map` (`Directive[].map(d => ({kind, justification}))`) then stored a struct-B
+`call_ref` result into an array typed for struct-A → `array.set expected (ref
+null A), found call_ref of type (ref null B)` validation failure in
+`applyDirectives` (the `Linter.verify` → `applyDisableDirectives` path).
+
+### Fix (3 localized changes, no new infra)
+
+1. `src/codegen/registry/types.ts` — `getOrRegisterArrayType` /
+   `getOrRegisterVecType` qualify the cache key + type name with the struct
+   typeIdx for `ref`/`ref_null` elements (`ref_<typeIdx>`), matching the
+   existing convention used by symbol-native / native-string vecs. f64 / i32 /
+   externref keys are unchanged (type-index stability preserved). This SPLITS
+   the incorrectly-collapsed ref arrays/vecs into correct distinct types.
+2. `src/codegen/array-methods.ts` — `compileArrayMap` element-type
+   reconciliation is now typeIdx-aware (`valTypesMatch` instead of `.kind`-only),
+   so a callback returning a different ref struct than the receiver element
+   updates the result array element type (and requests the correct
+   `getOrRegisterArrayType(ref, <callbackStruct>)`).
+3. `src/codegen/array-methods.ts` — the `case "map"` gate now includes
+   `ref`/`ref_null` struct-element receivers (mirrors the #1967 `sort` gate
+   widening), so struct-element `.map` is routed through `compileArrayMap` (the
+   callback-return-typed builder) instead of falling through to a generic path.
+
+### Validation
+
+- Repro: `compileProject("node_modules/eslint/lib/linter/apply-disable-directives.js",
+  {allowJs:true})` → `WebAssembly.validate` **true** (was false).
+- New `tests/issue-2688.test.ts` (4 cases): struct→different-struct `.map`,
+  two-distinct-shape maps don't collapse, smaller-struct return, + the eslint
+  integration validate. All green.
+- Regression: `tests/array-methods` + `tests/equivalence/array-*` (71 tests)
+  green; `tsc --noEmit` clean. Full `merge_group` floor + paired jsonl on the PR
+  (broad codegen — type registry).

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -23,7 +23,7 @@ import {
 } from "./index.js";
 import { addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "./registry/imports.js";
 import { emitToBoolean } from "./coercion-engine.js";
-import { compileStringLiteral } from "./shared.js";
+import { compileStringLiteral, valTypesMatch } from "./shared.js";
 import {
   getArrTypeIdxFromVec,
   getOrRegisterArrayType,
@@ -3093,8 +3093,20 @@ export function compileArrayMethodCall(
           : undefined;
       break;
     case "map":
+      // (#2688) Include ref/ref_null struct-element receivers (mirrors the #1967
+      // `sort` gate widening). A `Directive[].map(d => ({…}))` (eslint
+      // apply-disable-directives.js) otherwise fell through to a generic builder
+      // that typed the result array with the RECEIVER element struct instead of
+      // the callback's return struct. `compileArrayMap` derives the result
+      // element type from the callback's actual return (typeIdx-aware as of
+      // #2688), so routing struct-element receivers through it types the result
+      // array correctly.
       result =
-        elemType.kind === "f64" || elemType.kind === "i32" || elemType.kind === "externref"
+        elemType.kind === "f64" ||
+        elemType.kind === "i32" ||
+        elemType.kind === "externref" ||
+        elemType.kind === "ref" ||
+        elemType.kind === "ref_null"
           ? compileArrayMap(ctx, fctx, methodAccess, callExpr, vecTypeIdx, arrTypeIdx, elemType)
           : undefined;
       break;
@@ -6552,7 +6564,13 @@ function compileArrayMap(
     if (cbSig) {
       const retType = ctx.checker.getReturnTypeOfSignature(cbSig);
       const mapped = resolveWasmType(ctx, retType);
-      if (mapped.kind !== elemType.kind) {
+      // (#2688) Compare the FULL ValType (incl. struct typeIdx), not just `.kind`.
+      // A shape-transforming `.map` whose callback returns a DIFFERENT ref struct
+      // than the receiver's element struct is `ref`-vs-`ref` by kind, so the old
+      // `.kind`-only check left the result array typed as the INPUT element struct
+      // while the callback emitted a different struct → `array.set` validation
+      // failure (apply-disable-directives.js, eslint Linter path).
+      if (!valTypesMatch(mapped, elemType)) {
         mapResultElemType = mapped;
         mapArrTypeIdx = getOrRegisterArrayType(ctx, mapResultElemType.kind, mapResultElemType);
         mapVecTypeIdx = getOrRegisterVecType(ctx, mapResultElemType.kind, mapResultElemType);
@@ -6563,8 +6581,11 @@ function compileArrayMap(
   const setup = setupArrayCallback(ctx, fctx, callExpr, "map", "map", undefined, 1);
   if (!setup) return null;
 
-  // Update map result type from closure return type if available
-  if (setup.closureInfo?.returnType && setup.closureInfo.returnType.kind !== mapResultElemType.kind) {
+  // Update map result type from the closure's ACTUAL compiled return type — the
+  // ground truth for what `call_ref` produces. (#2688) typeIdx-aware so a
+  // ref-struct return differing from the current result element struct is honored
+  // (not just a differing kind).
+  if (setup.closureInfo?.returnType && !valTypesMatch(setup.closureInfo.returnType, mapResultElemType)) {
     mapResultElemType = setup.closureInfo.returnType;
     mapArrTypeIdx = getOrRegisterArrayType(ctx, mapResultElemType.kind, mapResultElemType);
     mapVecTypeIdx = getOrRegisterVecType(ctx, mapResultElemType.kind, mapResultElemType);
@@ -6590,7 +6611,7 @@ function compileArrayMap(
       // JS semantics: `undefined → mapped` maps to NaN/null/0 per type. (#1522)
       ...(retType === null
         ? defaultValueInstrs(mapResultElemType)
-        : retType.kind !== mapResultElemType.kind
+        : !valTypesMatch(retType, mapResultElemType)
           ? coercionInstrs(ctx, retType, mapResultElemType, fctx)
           : []),
     ];

--- a/src/codegen/registry/types.ts
+++ b/src/codegen/registry/types.ts
@@ -67,7 +67,20 @@ export function funcTypeEq(t: FuncTypeDef, params: ValType[], results: ValType[]
  * Reuses existing registrations so each element type only gets one array type.
  */
 export function getOrRegisterArrayType(ctx: CodegenContext, elemKind: string, elemTypeOverride?: ValType): number {
-  if (ctx.arrayTypeMap.has(elemKind)) return ctx.arrayTypeMap.get(elemKind)!;
+  // (#2688) Qualify a bare `ref`/`ref_null` elemKind with its struct typeIdx so
+  // DISTINCT ref-struct element types get DISTINCT array types. Caching ref
+  // arrays under the plain `"ref"` key collapsed every ref-element array to the
+  // FIRST-registered element struct — so a shape-transforming `.map` returning a
+  // different struct stored into an array typed for the wrong struct
+  // (`array.set` validation failure, eslint apply-disable-directives.js). Matches
+  // the existing `ref_<typeIdx>` convention (symbol-native / native-string vecs).
+  const cacheKey =
+    (elemKind === "ref" || elemKind === "ref_null") &&
+    elemTypeOverride &&
+    (elemTypeOverride.kind === "ref" || elemTypeOverride.kind === "ref_null")
+      ? `ref_${(elemTypeOverride as { typeIdx: number }).typeIdx}`
+      : elemKind;
+  if (ctx.arrayTypeMap.has(cacheKey)) return ctx.arrayTypeMap.get(cacheKey)!;
   let elemType: ValType =
     elemTypeOverride ??
     (elemKind === "f64" ? { kind: "f64" } : elemKind === "i32" ? { kind: "i32" } : { kind: "externref" });
@@ -77,11 +90,11 @@ export function getOrRegisterArrayType(ctx: CodegenContext, elemKind: string, el
   const idx = ctx.mod.types.length;
   ctx.mod.types.push({
     kind: "array",
-    name: `__arr_${elemKind}`,
+    name: `__arr_${cacheKey}`,
     element: elemType,
     mutable: true,
   } as ArrayTypeDef);
-  ctx.arrayTypeMap.set(elemKind, idx);
+  ctx.arrayTypeMap.set(cacheKey, idx);
   return idx;
 }
 
@@ -125,7 +138,16 @@ export function getOrRegisterVecType(ctx: CodegenContext, elemKind: string, elem
   // calls in `createCodegenContext` set `ctx.suppressVecUsageFlag` so they do
   // NOT count as usage.
   if (!ctx.suppressVecUsageFlag) ctx.usesVecValue = true;
-  const existing = ctx.vecTypeMap.get(elemKind);
+  // (#2688) Qualify a bare `ref`/`ref_null` elemKind with its struct typeIdx (see
+  // getOrRegisterArrayType) so distinct ref-struct vecs are distinct types, not
+  // collapsed onto the first ref struct registered.
+  const cacheKey =
+    (elemKind === "ref" || elemKind === "ref_null") &&
+    elemTypeOverride &&
+    (elemTypeOverride.kind === "ref" || elemTypeOverride.kind === "ref_null")
+      ? `ref_${(elemTypeOverride as { typeIdx: number }).typeIdx}`
+      : elemKind;
+  const existing = ctx.vecTypeMap.get(cacheKey);
   if (existing !== undefined) return existing;
 
   // (#2186) Ensure the shared `$__vec_base` length supertype exists before
@@ -140,7 +162,7 @@ export function getOrRegisterVecType(ctx: CodegenContext, elemKind: string, elem
   const vecIdx = ctx.mod.types.length;
   ctx.mod.types.push({
     kind: "struct",
-    name: `__vec_${elemKind}`,
+    name: `__vec_${cacheKey}`,
     superTypeIdx: vecBaseIdx,
     fields: [
       { name: "length", type: { kind: "i32" }, mutable: true },
@@ -151,9 +173,9 @@ export function getOrRegisterVecType(ctx: CodegenContext, elemKind: string, elem
       },
     ],
   });
-  ctx.vecTypeMap.set(elemKind, vecIdx);
+  ctx.vecTypeMap.set(cacheKey, vecIdx);
 
-  const vecStructName = `__vec_${elemKind}`;
+  const vecStructName = `__vec_${cacheKey}`;
   ctx.structMap.set(vecStructName, vecIdx);
   ctx.typeIdxToStructName.set(vecIdx, vecStructName);
   ctx.structFields.set(vecStructName, [

--- a/tests/issue-2688.test.ts
+++ b/tests/issue-2688.test.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2688 — struct-element `.map` typed its result array from the FIRST-registered
+// ref-element struct, not the callback's return struct.
+//
+// Root cause: `getOrRegisterArrayType`/`getOrRegisterVecType` cached ref-element
+// arrays/vecs under the plain `"ref"` key (ignoring the struct typeIdx), so every
+// distinct ref-struct array collapsed onto the first one registered. A
+// shape-transforming `.map` (`Directive[].map(d => ({kind, justification}))` in
+// eslint's apply-disable-directives.js) then stored a struct-B value into an
+// array typed for struct-A → `array.set expected (ref null A), found call_ref of
+// type (ref null B)` WebAssembly validation failure on the Linter.verify path.
+//
+// Fix: qualify the registry cache key with the struct typeIdx for ref/ref_null
+// elements (the existing `ref_<typeIdx>` convention), and route struct-element
+// `.map` receivers through `compileArrayMap` (gate widening) with typeIdx-aware
+// result-element reconciliation.
+import { describe, it, expect } from "vitest";
+import { compile, compileProject } from "../src/index.js";
+import { instantiateWithRuntime } from "./equivalence/helpers.js";
+
+async function run(src: string, fn = "test"): Promise<unknown> {
+  const result = await compile(src);
+  if (!result.success) {
+    throw new Error("Compile failed: " + result.errors.map((e) => `L${e.line}: ${e.message}`).join("; "));
+  }
+  expect(WebAssembly.validate(result.binary), "binary must validate").toBe(true);
+  const instance = await instantiateWithRuntime(result);
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>)[fn]!();
+}
+
+describe("#2688 — struct-element .map result-array element type", () => {
+  it("a .map over a struct array returning a DIFFERENT struct shape validates + works", async () => {
+    expect(
+      await run(`
+        interface In { a: number; b: number; c: number; }
+        interface Out { x: number; y: number; }
+        export function test(): number {
+          const ins: In[] = [{ a: 1, b: 2, c: 3 }, { a: 4, b: 5, c: 6 }];
+          const outs: Out[] = ins.map((i: In) => ({ x: i.a + i.b, y: i.c }));
+          return outs[0].x + outs[0].y + outs[1].x + outs[1].y; // 3+3 + 9+6 = 21
+        }
+      `),
+    ).toBe(21);
+  });
+
+  it("two distinct struct-shape maps do NOT collapse to one array type", async () => {
+    expect(
+      await run(`
+        interface D { id: number; tag: number; }
+        export function test(): number {
+          const src: D[] = [{ id: 1, tag: 9 }];
+          // first ref-struct array shape
+          const pairs = src.map((d: D) => ({ k: d.id, v: d.tag }));   // {k,v}
+          // second, DIFFERENT ref-struct array shape from the same receiver
+          const singles = src.map((d: D) => ({ only: d.id + d.tag }));// {only}
+          return pairs[0].k + pairs[0].v + singles[0].only;           // 1+9 + 10 = 20
+        }
+      `),
+    ).toBe(20);
+  });
+
+  it("map callback returning a smaller struct than the receiver element", async () => {
+    expect(
+      await run(`
+        interface Big { a: number; b: number; c: number; d: number; }
+        export function test(): number {
+          const xs: Big[] = [{ a: 10, b: 20, c: 30, d: 40 }];
+          const ys = xs.map((x: Big) => ({ sum: x.a + x.b }));  // 2-field from 4-field
+          return ys[0].sum; // 30
+        }
+      `),
+    ).toBe(30);
+  });
+
+  it("eslint apply-disable-directives.js compiles AND validates (Linter.verify path)", async () => {
+    const r = await compileProject("/workspace/node_modules/eslint/lib/linter/apply-disable-directives.js", {
+      allowJs: true,
+    } as Parameters<typeof compileProject>[1]);
+    expect(r.success, JSON.stringify(r.errors?.slice?.(0, 2))).toBe(true);
+    expect(WebAssembly.validate(r.binary), "apply-disable-directives.js binary must validate").toBe(true);
+  });
+});


### PR DESCRIPTION
## #2688 — THE last codegen blocker for real-eslint-runs

`new Linter().verify()` → `applyDisableDirectives` → `applyDirectives` failed `WebAssembly.validate`:
```
function #128 "applyDirectives":
  array.set expected type (ref null A), found call_ref of type (ref null B)
```

### Root cause (bounded — not the broad shape-unification first suspected)
`getOrRegisterArrayType` / `getOrRegisterVecType` cached ref-element arrays/vecs under the plain `"ref"`/`"ref_null"` **string** key, ignoring the struct `typeIdx`. So the FIRST ref-struct array registered (element struct A) was returned for **every** subsequent ref-element request — `getOrRegisterArrayType(ctx, "ref", {ref:B})` returned array-of-A, not array-of-B. A shape-transforming `.map` (`Directive[].map(d => ({kind, justification}))`) then stored a struct-B `call_ref` result into an array typed for struct-A → the `array.set` mismatch.

### Fix (3 localized changes, no new infra)
1. **`src/codegen/registry/types.ts`** — qualify the array/vec cache key + type name with the struct `typeIdx` for `ref`/`ref_null` elements (`ref_<typeIdx>`), matching the existing symbol-native / native-string convention. `f64`/`i32`/`externref` keys unchanged (type-index stability preserved). Splits the incorrectly-collapsed ref arrays/vecs into correct distinct types.
2. **`src/codegen/array-methods.ts`** — `compileArrayMap` element-type reconciliation is now typeIdx-aware (`valTypesMatch`, not `.kind`-only), so a callback returning a different ref struct than the receiver element updates the result array type.
3. **`src/codegen/array-methods.ts`** — the `case "map"` gate includes `ref`/`ref_null` struct-element receivers (mirrors the #1967 `sort` gate widening), routing them through the callback-return-typed `compileArrayMap`.

Watched the type-index-shift / dead-elim-remap hazards (`project_type_index_shift_and_deadelim`, `reference_shared_instr_object_dce_double_remap`): only ref-element keys change (previously collapsed/incorrect); the stable f64/i32/externref pre-registrations are untouched.

### Validation
- `compileProject("node_modules/eslint/lib/linter/apply-disable-directives.js", {allowJs:true})` → `WebAssembly.validate` **true** (was false).
- New `tests/issue-2688.test.ts` (4 cases: struct→different-struct `.map`, two-distinct-shape maps don't collapse, smaller-struct return, + the eslint integration validate) — all green.
- Regression: `tests/array-methods` + `tests/equivalence/array-*` (71 tests) green; `tsc --noEmit` clean.
- Broad codegen (type registry) → full `merge_group` floor + paired jsonl is the authoritative gate.

The instant this lands, sd-eslint runs the real `new Linter().verify()` milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)