### PR TITLE
feat(#2701): node:fs/promises destructured-import host-glue (slash sanitisation)

### DIFF
--- a/plan/issues/2701-fs-promises-nodefn-slash-sanitisation.md
+++ b/plan/issues/2701-fs-promises-nodefn-slash-sanitisation.md
@@ -1,0 +1,69 @@
+---
+id: 2701
+title: "node:fs/promises destructured-import host-glue — sanitise the `/` in the __nodefn__ identifier"
+status: done
+completed: 2026-06-26
+assignee: ttraenkler/agent-ae565d4893a5783d7
+created: 2026-06-26
+updated: 2026-06-26
+priority: high
+feasibility: easy
+reasoning_effort: medium
+task_type: feature
+area: host-interop
+language_feature: node-builtins
+goal: npm-library-support
+related: [2699, 1791, 1491, 1492, 2693]
+depends_on: [2699]
+---
+# #2701 — node:fs/promises destructured-import host-glue (slash sanitisation)
+
+## Problem
+
+Follow-up to #2699. ESLint's CLI/config layers import `node:fs/promises`
+destructured: `const { mkdir, stat, writeFile } = require("node:fs/promises")`
+(cli.js, config-loader.js, eslint.js). The #2699 `__nodefn__<module>__<fn>`
+host-glue route could not be applied because the `/` in `fs/promises` is not a
+valid TypeScript identifier character — the generated declaration
+`__nodefn__fs/promises__readFile` was a syntax error (`'(' expected` at compile).
+
+## Fix
+
+Encode `/` → `$` (a valid identifier char that never appears in a Node
+module/fn name) in the `__nodefn__` host-import name, and decode it back in the
+import-manifest classifier so the runtime resolves the real
+`require("fs/promises")`:
+
+- `src/import-resolver.ts`:
+  - add `node:fs/promises` to `NODE_BUILTIN_MODULES`
+  - add `NODE_BUILTIN_FN_TYPED_STUBS["fs/promises"]` = `{ readFile, writeFile,
+    unlink, stat, mkdir }`
+  - `nodeBuiltinFnTypedStub`: `hostName = \`__nodefn__${moduleName.replace(/\//g,"$")}__${name}\``
+- `src/compiler/import-manifest.ts`: decode the module token `$` → `/` when
+  classifying `__nodefn__` → `node_builtin_fn`.
+
+The runtime `node_builtin_fn` resolver already does `require(moduleName)[fn]`
+and passes the returned Promise through unchanged (verified).
+
+## Verified (host, real `node:fs/promises` via `buildImports(..., deps, stringPool)`)
+
+```
+const { stat, readFile } = require("node:fs/promises");
+await stat("/etc/hostname").isFile()      → 1
+await readFile("/etc/hostname","utf8")    → non-empty string
+```
+Imports emitted: `__nodefn__fs$promises__stat`, `__nodefn__fs$promises__readFile`.
+`tests/issue-2701.test.ts` covers classification (decoded moduleName ===
+`fs/promises`) + the Promise round-trip.
+
+## Notes
+
+- Stacked on #2699 (shares `NODE_BUILTIN_FN_TYPED_STUBS` / `NODE_BUILTIN_MODULES`).
+- The runner must pass `stringPool` as the 3rd arg to `buildImports` for
+  string-literal args (e.g. `readFile("/path")`) to marshal at the host boundary
+  (the #2699 finding).
+- Deferred (next-sprint carve): `node:worker_threads` (value/class-shaped),
+  `url` `URL` class, `util.styleText`/`stripVTControlCharacters`. The namespace
+  form of fs/promises (`const fsp = require("node:fs/promises"); fsp.writeFile`)
+  would hit the same slash in `__node_fs/promises` — a separate module-route
+  sanitisation; eslint's destructured form (covered here) is the common one.

--- a/src/compiler/import-manifest.ts
+++ b/src/compiler/import-manifest.ts
@@ -176,7 +176,11 @@ function classifyImport(name: string, mod: WasmModule): ImportIntent {
     const payload = name.slice("__nodefn__".length);
     const sepIdx = payload.indexOf("__");
     if (sepIdx > 0) {
-      const moduleName = payload.slice(0, sepIdx);
+      // #2701 — decode the `/`→`$` encoding applied to slashed module names
+      // (e.g. `fs$promises` → `fs/promises`) so the runtime resolves the real
+      // `require("fs/promises")`. `$` never appears in a Node module name, so the
+      // decode is unambiguous.
+      const moduleName = payload.slice(0, sepIdx).replace(/\$/g, "/");
       const fnName = payload.slice(sepIdx + 2);
       if (fnName.length > 0) {
         return { type: "node_builtin_fn", moduleName, name: fnName };

--- a/src/import-resolver.ts
+++ b/src/import-resolver.ts
@@ -34,6 +34,7 @@ export const NODE_BUILTIN_MODULES = new Set([
   "crypto",
   "os",
   "module",
+  "fs/promises",
   "child_process",
   "assert",
   "dns",
@@ -90,12 +91,18 @@ const NODE_BUILTIN_FN_TYPED_STUBS: Record<
   module: {
     createRequire: { params: "filename: any", returns: "any", passthrough: "filename" },
   },
-  // NOTE: `node:fs/promises` is deferred — the `/` in the module name breaks the
-  // `__nodefn__<module>__<fn>` identifier scheme (would emit an invalid
-  // `__nodefn__fs/promises__readFile` declaration). Sanitising the slash needs
-  // coordinated changes in the import-manifest classifier + runtime resolver;
-  // tracked as a follow-up. ESLint's `fs/promises` use is in the CLI/config
-  // layers, not the Linter.verify hot path.
+  // #2701 — `node:fs/promises` function surface ESLint's CLI/config layers
+  // import (`const { mkdir, stat, writeFile } = require("node:fs/promises")`).
+  // These return Promises; the host adapter passes the Promise through. The `/`
+  // in the module name is encoded `/`→`$` in the `__nodefn__` host name (see
+  // `nodeBuiltinFnTypedStub`) and decoded back in the import-manifest classifier.
+  "fs/promises": {
+    readFile: { params: "a0: any, a1: any", returns: "any", passthrough: "a0, a1" },
+    writeFile: { params: "a0: any, a1: any, a2: any", returns: "any", passthrough: "a0, a1, a2" },
+    unlink: { params: "a0: any", returns: "any", passthrough: "a0" },
+    stat: { params: "a0: any, a1: any", returns: "any", passthrough: "a0, a1" },
+    mkdir: { params: "a0: any, a1: any", returns: "any", passthrough: "a0, a1" },
+  },
   // #2699 — `node:os` destructured function surface (`const { platform } =
   // require("node:os")`). The namespace form (`os.platform()`) already worked
   // via `__node_os`; this covers the destructured form ESLint's deps use.
@@ -1057,7 +1064,12 @@ export function preprocessImports(source: string, opts?: { wasi?: boolean }): Pr
       if (!isBuiltin) return null;
       const stub = NODE_BUILTIN_FN_TYPED_STUBS[moduleName]?.[name];
       if (!stub) return null;
-      const hostName = `__nodefn__${moduleName}__${name}`;
+      // #2701 — a `/` in the module name (e.g. `fs/promises`) is not a valid TS
+      // identifier char, which would make `__nodefn__fs/promises__readFile` a
+      // syntax error. Encode `/` → `$` (a valid identifier char that never
+      // appears in a Node module/fn name); the import-manifest classifier
+      // decodes `$` → `/` so the runtime resolves `require("fs/promises")`.
+      const hostName = `__nodefn__${moduleName.replace(/\//g, "$")}__${name}`;
       return (
         `declare function ${hostName}(${stub.params}): ${stub.returns};\n` +
         `function ${name}(${stub.params}): ${stub.returns} { return ${hostName}(${stub.passthrough}); }`

--- a/tests/issue-2701.test.ts
+++ b/tests/issue-2701.test.ts
@@ -1,0 +1,69 @@
+// #2701 — node:fs/promises destructured function imports route through the
+// `__nodefn__` host adapter. The `/` in the module name is encoded `/`→`$` in
+// the host-import identifier (`__nodefn__fs$promises__readFile`) and decoded
+// back to `fs/promises` in the import-manifest classifier so the runtime
+// resolves `require("fs/promises")`. Follow-up to #2699.
+import { describe, it, expect } from "vitest";
+import { createRequire } from "node:module";
+import { compile, buildImports } from "../src/index.js";
+
+const require = createRequire(import.meta.url);
+const deps = { "fs/promises": require("node:fs/promises") };
+
+async function run(src: string) {
+  const result = await compile(src, { fileName: "test.ts" });
+  expect(result.success, JSON.stringify(result.errors)).toBe(true);
+  // stringPool (3rd arg) is required for string-literal args to marshal at the
+  // host boundary (e.g. readFile("/path")).
+  const imports = buildImports(result.imports, deps, (result as { stringPool?: unknown }).stringPool);
+  const instance = new WebAssembly.Instance(new WebAssembly.Module(result.binary), imports);
+  if (imports.setExports) imports.setExports(instance.exports as Record<string, Function>);
+  return { result, instance };
+}
+
+describe("#2701 — node:fs/promises destructured-import host-glue", () => {
+  it("encodes the slash in the host name and decodes the module back to fs/promises", async () => {
+    const src = `
+      const { readFile, stat } = require("node:fs/promises");
+      export function ok(): number {
+        return (typeof readFile) === "function" && (typeof stat) === "function" ? 1 : 0;
+      }
+    `;
+    const { result, instance } = await run(src);
+    const nodefn = result.imports.filter((i) => i.name.startsWith("__nodefn__"));
+    // Host-import identifier carries the `$`-encoded module token.
+    expect(nodefn.map((i) => i.name)).toContain("__nodefn__fs$promises__readFile");
+    expect(nodefn.map((i) => i.name)).toContain("__nodefn__fs$promises__stat");
+    // Classifier decodes `$` → `/` so the runtime resolves require("fs/promises").
+    for (const imp of nodefn) {
+      const intent = imp.intent as { type: string; moduleName: string };
+      expect(intent.type).toBe("node_builtin_fn");
+      expect(intent.moduleName).toBe("fs/promises");
+    }
+    expect((instance.exports.ok as () => number)()).toBe(1);
+  });
+
+  it("stat() resolves a real Promise through the host adapter", async () => {
+    const src = `
+      const { stat } = require("node:fs/promises");
+      export async function isf(): Promise<number> {
+        const s = await stat("/etc/hostname");
+        return s.isFile() ? 1 : 0;
+      }
+    `;
+    const { instance } = await run(src);
+    await expect((instance.exports.isf as () => Promise<number>)()).resolves.toBe(1);
+  });
+
+  it("readFile() returns a non-empty string via the host adapter", async () => {
+    const src = `
+      const { readFile } = require("node:fs/promises");
+      export async function rd(): Promise<number> {
+        const b = await readFile("/etc/hostname", "utf8");
+        return (typeof b === "string" && b.length > 0) ? 1 : 0;
+      }
+    `;
+    const { instance } = await run(src);
+    await expect((instance.exports.rd as () => Promise<number>)()).resolves.toBe(1);
+  });
+});


### PR DESCRIPTION
## #2701 — node:fs/promises destructured-import host-glue

Follow-up to #2699 (merged). ESLint's CLI/config layers import `node:fs/promises` destructured: `const { mkdir, stat, writeFile } = require("node:fs/promises")`. The #2699 `__nodefn__<module>__<fn>` route couldn't apply because the `/` in `fs/promises` isn't a valid TS identifier char — `__nodefn__fs/promises__readFile` was a syntax error.

### Fix
Encode `/`→`$` (a valid identifier char that never appears in a Node module/fn name) in the host-import name; decode `$`→`/` in the import-manifest classifier so the runtime resolves the real `require("fs/promises")`:
- `src/import-resolver.ts`: add `node:fs/promises` to `NODE_BUILTIN_MODULES` + `NODE_BUILTIN_FN_TYPED_STUBS` `{readFile,writeFile,unlink,stat,mkdir}`; `hostName = ` + "`" + `__nodefn__${moduleName.replace(/\//g,"$")}__${name}` + "`"
- `src/compiler/import-manifest.ts`: decode the module token `$`→`/` when classifying `node_builtin_fn`.

The runtime `node_builtin_fn` resolver already does `require(mod)[fn]` and passes the returned Promise through unchanged.

### Verified (host, real `node:fs/promises` via `buildImports(..., deps, stringPool)`)
`await stat("/etc/hostname").isFile()` → 1; `await readFile(p,"utf8")` → non-empty string. Imports emitted: `__nodefn__fs$promises__{stat,readFile}`. `tests/issue-2701.test.ts` 3/3; #2699 suite still 5/5.

Deferred (next-sprint carve): `node:worker_threads` (value/class-shaped), `url` `URL` class, `util.styleText`/`stripVTControlCharacters`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)