### PR TITLE
perf(#2682): string read-loop fast path — hoist charCodeAt flatten/descriptor + proof-gated i32 leaf

### DIFF
--- a/plan/issues/2682-string-read-loop-i32-hoist.md
+++ b/plan/issues/2682-string-read-loop-i32-hoist.md
@@ -1,7 +1,8 @@
 ---
 id: 2682
 title: "perf(strings): string read-loop fast path — hoist charCodeAt flatten/descriptor + i32 hash accumulator (the #1762 NO-GO redirect)"
-status: ready
+status: in-progress
+assignee: ttraenkler/sd-strhash
 needs_arch_spec: false
 created: 2026-06-26
 updated: 2026-06-26
@@ -183,3 +184,59 @@ Senior-dev. Spec settled here; implementation is a deliberate, floor-validated
 follow-on slice (recommend the pattern-recognizer FIRST slice in D1–D4's note).
 Measurement instrument: `.tmp/measure.py` + the 3 hand-WAT variants from #1762
 Slice 0 (re-create per the verdict section) for the before/after warm delta.
+
+## Implementation Notes — sd-strhash verify-first grounding (2026-06-26)
+
+**Verdict: CLEAN BOUNDED SLICE.** Scope is *narrower* than the spec's D1–D4
+because grounding the actual codegen on current `main` (commit 93e7aebbc849)
+shows D2 (relational) and D4 (accumulator) are **already done** by existing
+passes. Decoded WAT of `hashStr` (probe `.tmp/probe2.mjs` / `.tmp/probe-native.mjs`):
+
+- **D4 already done.** `collectI32CoercedLocals` (function-body.ts:186) already
+  promotes `h` to an **i32 local** in all modes — `let h=0; h=(h*31+c)|0` is
+  i32-safe because the assignment's top op is `|` (isI32SafeExpr returns true on
+  bitwise without recursing). The spec's "h is f64 today" is stale.
+- **D2 relational partly done.** In `{fast,nativeStrings}` the loop condition
+  `i < s.length` already emits `i32.lt_s` and `h*31` is `i32.mul`. (Non-fast
+  native still routes the condition through f64.lt — a minor residual, out of
+  this slice's critical path.)
+- **The real remaining cost is D1 + D3:**
+  - **D1** — `call $__str_flatten($0)` runs **every iteration** (loop-invariant),
+    plus per-iter `struct.get` of `.len/.off/.data`. This is the dominant
+    1.66–1.8x per Slice-0. Hoist into locals before the loop.
+  - **D3** — charCodeAt reads via the NaN-branch then `f64.convert_i32_u`, and the
+    consumer immediately `i32.trunc_sat_f64_s`-es it back — a pointless f64
+    round-trip. Under the in-bounds proof the NaN branch is dead and the read is a
+    direct i32 `array.get_u`.
+
+**Soundness (R1) is cleanly expressible on current main.** The in-bounds proof
+reuses `detectI32LoopVar` (loops.ts:157 — proves init non-neg literal + strict
+`<`/`>` condition + monotonic `++`/`+=k` step, so `i>=0` always) and a
+string-specific mutation check modeled on `loopBodyMutatesIndexOrArray`
+(loops.ts:237). NOTE: the #1196 helper rejects **all** method calls on the array
+(lines 299–307), so it can't be reused verbatim — strings are immutable, so only
+reassignment of `recv`/`i` and nested closures matter; `recv.charCodeAt(i)` reads
+must be allowed. With `0<=i<len` proven at every body point, dropping BOTH OOB
+checks and emitting a bare `array.get_u(dataL, offL+i)` is byte-identical.
+
+**Implementation loci (verified on main):**
+- `src/codegen/statements/loops.ts` `compileForStatement` (~819–868, the #1196
+  block) — add the canonical-loop recognizer: detect `i < recv.length` (recv
+  string-typed), check the string mutation guard, hoist `__str_flatten` + descriptor
+  reads into fresh locals before the loop, record a per-loop proof on a new
+  `fctx.hoistedCharReads` side-table (scoped save/restore exactly like
+  `safeIndexedArrays`).
+- `src/codegen/context/types.ts` (~377) — add `hoistedCharReads?` field next to
+  `safeIndexedArrays`.
+- `src/codegen/string-ops.ts` `compileNativeStringMethodCall` charCodeAt arm
+  (2230) — when an active proof matches `(recvName, idx===indexName)`, emit the
+  direct hoisted i32 read (no flatten / struct.get / NaN branch), wrap to f64 for
+  the f64-consumption context.
+- `src/codegen/binary-ops.ts` `isI32PureExpr` (1571) + `emitI32PureExpr` (1635) —
+  add a proof-gated charCodeAt **i32 leaf** so the whole `(h*31+c)|0` chain stays
+  i32 (this is what drops the f64 round-trip; the existing path already keeps
+  `h*31` in i32 once `c` is a pure leaf).
+
+Only fires in native-string mode (host/externref strings have no flattenable
+descriptor — charCodeAt is a host call there, untouched). Validated through the
+#2097 merge_group standalone floor.

--- a/plan/issues/2682-string-read-loop-i32-hoist.md
+++ b/plan/issues/2682-string-read-loop-i32-hoist.md
@@ -1,8 +1,9 @@
 ---
 id: 2682
 title: "perf(strings): string read-loop fast path — hoist charCodeAt flatten/descriptor + i32 hash accumulator (the #1762 NO-GO redirect)"
-status: in-progress
+status: done
 assignee: ttraenkler/sd-strhash
+completed: 2026-06-26
 needs_arch_spec: false
 created: 2026-06-26
 updated: 2026-06-26
@@ -240,3 +241,48 @@ checks and emitting a bare `array.get_u(dataL, offL+i)` is byte-identical.
 Only fires in native-string mode (host/externref strings have no flattenable
 descriptor — charCodeAt is a host call there, untouched). Validated through the
 #2097 merge_group standalone floor.
+
+## Implementation — DONE (sd-strhash, 2026-06-26)
+
+Landed the single canonical-loop pattern recognizer (D1 hoist + D3 proof-gated
+i32 leaf; D2/D4 were already done by existing passes). Files:
+
+- `src/codegen/context/types.ts` — `HoistedCharRead` interface + scoped
+  `FunctionContext.hoistedCharReads` side-table (sibling of `safeIndexedArrays`).
+- `src/codegen/statements/loops.ts` — `detectCanonicalCharReadLoop` (the
+  recognizer; emits the once-before-loop `__str_flatten` + `.data`/`.off` hoist),
+  plus guards `isIncreasingStep`, `loopBodyMutatesStringReadInvariants` (string
+  variant of the #1196 helper — allows receiver method calls, but rejects
+  recv/i reassignment, `++`/`--`, **shadowing declarations**, and closures),
+  `bodyHasMatchingCharRead`. Wired into `compileForStatement` with scoped
+  save/restore around the body.
+- `src/codegen/string-ops.ts` — `matchHoistedCharRead` + `emitHoistedCharCodeAtRead`
+  helpers; charCodeAt arm (≈2230) fast-path for the f64-consumption case.
+- `src/codegen/binary-ops.ts` — proof-gated charCodeAt **i32 leaf** in
+  `isI32PureExpr` + `emitI32PureExpr` (keeps the whole `(h*31+c)|0` chain i32).
+
+### Result (decoded WAT of `hashStr`, acceptance met)
+
+`{fast,nativeStrings}` and `{nativeStrings}` both now emit: ONE `call $__str_flatten`
++ `.data`/`.off` hoisted into locals BEFORE the loop, and an inner loop body of
+`i32.add(i32.mul(h,31), array.get_u(dataL, offL+i))` — **no** per-iteration
+flatten, **no** `struct.get` reload, **no** OOB/NaN `if` branch, **no**
+`f64.convert_i32_u` round-trip, **no** `|0` f64 emulation (`4294967296` gone).
+Non-fast `hashStr` dropped from the full f64 ToUint32 emulation to pure i32.
+(Residual: the non-fast loop *condition* `i < s.length` still uses `f64.lt` —
+the optional D2 relational extension, deliberately out of this slice's scope.)
+
+### Validation (verify-first, byte-identity discipline — #2078 class)
+
+- `tests/issue-2682.test.ts` (12 tests, all green): result-parity for the
+  canonical loop (fast + non-fast, incl. empty/unicode/long/ConsString/step-2/
+  multi-read), and NOT-optimised+correct for every non-matching shape
+  (OOB-outside-loop, `charCodeAt(i+1)`, reassigned-recv, mutated-i, shadowed
+  recv, `other.length` bound mismatch).
+- **Byte-identity proof**: decoded WAT of non-matching functions
+  (`oobOutside`, `nonInductionIdx`, `reassignRecv`, `mutateI`) is **identical**
+  between this branch and pristine `origin/main`; only the recognised loop
+  changes (115→90 lines). The pre-existing fast-mode OOB-charCodeAt quirks are
+  unchanged (identical results on baseline). `tsc --noEmit` clean; biome clean.
+  Existing suites (8-file i32/charCodeAt set; 4-file bitwise/string set) show
+  **identical** pass/fail counts vs baseline → zero new failures.

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -42,7 +42,7 @@ import { addStringImports, addUnionImports, resolveNativeTypeAnnotation, resolve
 import type { InnerResult } from "./shared.js";
 import { coerceType, compileExpression, ensureAnyHelpers, flushLateImportShifts } from "./shared.js";
 import { isLogicalAssignNamedEvalNameRead, resolveStructNameForExpr } from "./property-access.js";
-import { compileStringBinaryOp } from "./string-ops.js";
+import { compileStringBinaryOp, emitHoistedCharCodeAtRead, matchHoistedCharRead } from "./string-ops.js";
 import { emitAnyEqFromExternTemps, emitLooseEq, emitStrictEq } from "./coercion-engine.js";
 import { compileInstanceOf, compileTypeofComparison } from "./typeof-delete.js";
 
@@ -1580,6 +1580,15 @@ export function compileBinaryExpression(
     // §7.1.7 ToInt32 maps that NaN to 0 only after the surrounding expression
     // has evaluated. Treating `x.charCodeAt(i)` as a direct i32 leaf inside
     // `(a + x.charCodeAt(i)) | 0` would incorrectly preserve `a` for OOB reads.
+    //
+    // #2682 EXCEPTION: inside a recognised canonical read loop, `recv.charCodeAt(i)`
+    // is PROVEN in-bounds (`0 <= i < len`) so it can never return NaN — it is a
+    // genuine i32 leaf (an unsigned 16-bit code unit). `matchHoistedCharRead`
+    // gates this to exactly that proven receiver+index; every other charCodeAt
+    // stays excluded (falls through to `return false`), preserving #1105.
+    if (ts.isCallExpression(inner) && matchHoistedCharRead(fctx, inner)) {
+      return true;
+    }
     if (ts.isBinaryExpression(inner)) {
       const k = inner.operatorToken.kind;
       // `expr | 0` always produces i32 cleanly when its operand does.
@@ -1642,6 +1651,17 @@ export function compileBinaryExpression(
     if (ts.isNumericLiteral(inner)) {
       fctx.body.push({ op: "i32.const", value: Number(inner.text.replace(/_/g, "")) | 0 });
       return;
+    }
+    // #2682: proven-in-bounds `recv.charCodeAt(i)` — emit the direct i32 read
+    // from the hoisted descriptor (no flatten / struct.get / OOB branch / f64
+    // round-trip). This is what keeps the whole `(h*31 + charCodeAt) | 0` chain
+    // in i32 and drops the f64 |0 emulation. Gated by `matchHoistedCharRead`.
+    if (ts.isCallExpression(inner)) {
+      const hoisted = matchHoistedCharRead(fctx, inner);
+      if (hoisted) {
+        emitHoistedCharCodeAtRead(ctx, fctx, hoisted, inner.arguments[0]!);
+        return;
+      }
     }
     if (ts.isBinaryExpression(inner)) {
       const k = inner.operatorToken.kind;

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -263,6 +263,20 @@ export interface NullGuardFact {
   provesNonNull: boolean;
 }
 
+/**
+ * #2682: a recognised canonical string-read loop. `dataLocal` holds the
+ * (non-null) `ref $__str_data` i16 array of the once-flattened receiver and
+ * `offLocal` its i32 byte offset; `recvName`/`indexName` are the loop-invariant
+ * receiver and the in-bounds-proven induction variable. See
+ * `FunctionContext.hoistedCharReads`.
+ */
+export interface HoistedCharRead {
+  recvName: string;
+  indexName: string;
+  dataLocal: number;
+  offLocal: number;
+}
+
 /** Per-function context. */
 export interface FunctionContext {
   /** Function name */
@@ -375,6 +389,23 @@ export interface FunctionContext {
    * Populated when a for-loop condition guarantees indexVar < arrayVar.length.
    */
   safeIndexedArrays?: Set<string>;
+  /**
+   * #2682: per-loop proofs for the canonical string-read hot loop
+   * `for (let i = 0; i < recv.length; i++) … recv.charCodeAt(i) …`.
+   *
+   * Keyed by the (loop-invariant) string receiver identifier name. When an
+   * entry is present, the loop has been recognised by
+   * `detectCanonicalCharReadLoop` (statements/loops.ts): the receiver was
+   * flattened ONCE before the loop and its `.data`/`.off` descriptor hoisted
+   * into the listed locals, and `i` is PROVEN in-bounds (`0 <= i < len`) at
+   * every body point (init >= 0, strict `<`, monotonic step, `i`/`recv` not
+   * mutated, no capturing closure). `recv.charCodeAt(i)` reads then lower to a
+   * direct i32 `array.get_u(dataLocal, offLocal + i)` with NO per-call flatten,
+   * NO struct.get reload, and NO OOB/NaN branch (the branch is dead under the
+   * proof — byte-identical to the guarded read). Native-string mode only.
+   * Scoped save/restore around the loop body exactly like `safeIndexedArrays`.
+   */
+  hoistedCharReads?: Map<string, HoistedCharRead>;
   /**
    * #1120: Set of let/const locals whose lifecycle is fully constrained
    * to int32 by explicit `| 0` (or other bitwise) coercion. These get

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -10,7 +10,7 @@ import { popBody, pushBody } from "../context/bodies.js";
 import { reportError, reportErrorNoNode } from "../context/errors.js";
 import { allocLocal, getLocalType } from "../context/locals.js";
 import { snapshotSpeculative, rollbackSpeculative } from "../context/speculative.js";
-import type { CodegenContext, FunctionContext } from "../context/types.js";
+import type { CodegenContext, FunctionContext, HoistedCharRead } from "../context/types.js";
 import { emitExternrefDestructureGuard } from "../destructuring-params.js";
 import {
   findUnresolvableInArrayPattern,
@@ -34,7 +34,7 @@ import { containsLinearU8Allocation, emitLinearU8ArenaMark, linearU8ArenaResetIn
 import { resolveComputedKeyExpression } from "../literals.js";
 import { emitCollectionIteratorVec, ensureMapHelpers, MAP_LAYOUT } from "../map-runtime.js";
 import { resolveArrayInfo } from "../array-methods.js";
-import { stringConstantExternrefInstrs } from "../native-strings.js";
+import { flatStringType, stringConstantExternrefInstrs } from "../native-strings.js";
 import { emitNativeNumberFormat } from "../number-format-native.js";
 import { ensureObjectRuntime } from "../object-runtime.js";
 import { coercionInstrs } from "../type-coercion.js";
@@ -327,6 +327,229 @@ function loopBodyMutatesIndexOrArray(body: ts.Statement, indexName: string, arra
 }
 
 /**
+ * #2682: the increment must strictly INCREASE `i` so that, combined with a
+ * non-negative init and the strict `i < recv.length` condition, `0 <= i < len`
+ * holds at every body point. `i++`/`++i` and `i += <positive int literal>`
+ * qualify; `i--`/`i -= k`/`i += <non-positive>` do NOT (would break the proof).
+ * Narrower than `detectI32LoopVar`'s incrementor check, which also accepts the
+ * decreasing forms.
+ */
+function isIncreasingStep(incr: ts.Expression | undefined, name: string): boolean {
+  if (!incr) return false;
+  if (ts.isPostfixUnaryExpression(incr) || ts.isPrefixUnaryExpression(incr)) {
+    return ts.isIdentifier(incr.operand) && incr.operand.text === name && incr.operator === ts.SyntaxKind.PlusPlusToken;
+  }
+  if (ts.isBinaryExpression(incr)) {
+    if (!ts.isIdentifier(incr.left) || incr.left.text !== name) return false;
+    if (incr.operatorToken.kind !== ts.SyntaxKind.PlusEqualsToken) return false;
+    if (!ts.isNumericLiteral(incr.right)) return false;
+    const step = Number(incr.right.text.replace(/_/g, ""));
+    return Number.isInteger(step) && step > 0;
+  }
+  return false;
+}
+
+/**
+ * #2682: string-specific variant of {@link loopBodyMutatesIndexOrArray} for the
+ * canonical read-loop hoist. Returns true if the body could invalidate the
+ * loop-invariance of `recvName` or the in-bounds invariant of `indexName`.
+ *
+ * Strings are IMMUTABLE, so — unlike the #1196 array helper — method calls on
+ * the receiver (notably `recv.charCodeAt(i)`, the whole point) are SAFE and must
+ * NOT disqualify. Only these break the invariants:
+ *   - assignment / compound-assignment / `++`/`--` to `recvName` or `indexName`;
+ *   - a body-local declaration that SHADOWS `recvName` or `indexName` — the
+ *     downstream `recv.charCodeAt(i)` match keys on identifier TEXT, so a shadow
+ *     (`for (…) { let recv = other; … recv.charCodeAt(i) … }`) would wrongly read
+ *     the hoisted OUTER descriptor. Reject any such shadow (sound, conservative);
+ *   - any nested function / arrow / class (could capture and reassign either
+ *     binding via a call we can't statically see — conservative, matches #1196).
+ */
+function loopBodyMutatesStringReadInvariants(body: ts.Statement, indexName: string, recvName: string): boolean {
+  let mutates = false;
+  const declaresShadow = (name: ts.BindingName | undefined): boolean => {
+    if (!name) return false;
+    for (const n of collectPatternBindingNames(name)) {
+      if (n === indexName || n === recvName) return true;
+    }
+    return false;
+  };
+  function isAssignmentOp(kind: ts.SyntaxKind): boolean {
+    return (
+      kind === ts.SyntaxKind.EqualsToken ||
+      kind === ts.SyntaxKind.PlusEqualsToken ||
+      kind === ts.SyntaxKind.MinusEqualsToken ||
+      kind === ts.SyntaxKind.AsteriskEqualsToken ||
+      kind === ts.SyntaxKind.SlashEqualsToken ||
+      kind === ts.SyntaxKind.PercentEqualsToken ||
+      kind === ts.SyntaxKind.AsteriskAsteriskEqualsToken ||
+      kind === ts.SyntaxKind.LessThanLessThanEqualsToken ||
+      kind === ts.SyntaxKind.GreaterThanGreaterThanEqualsToken ||
+      kind === ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken ||
+      kind === ts.SyntaxKind.AmpersandEqualsToken ||
+      kind === ts.SyntaxKind.BarEqualsToken ||
+      kind === ts.SyntaxKind.CaretEqualsToken ||
+      kind === ts.SyntaxKind.QuestionQuestionEqualsToken ||
+      kind === ts.SyntaxKind.AmpersandAmpersandEqualsToken ||
+      kind === ts.SyntaxKind.BarBarEqualsToken
+    );
+  }
+  function visit(node: ts.Node): void {
+    if (mutates) return;
+    if (ts.isBinaryExpression(node) && isAssignmentOp(node.operatorToken.kind)) {
+      const lhs = node.left;
+      if (ts.isIdentifier(lhs) && (lhs.text === indexName || lhs.text === recvName)) {
+        mutates = true;
+        return;
+      }
+    }
+    if (
+      (ts.isPostfixUnaryExpression(node) || ts.isPrefixUnaryExpression(node)) &&
+      (node.operator === ts.SyntaxKind.PlusPlusToken || node.operator === ts.SyntaxKind.MinusMinusToken) &&
+      ts.isIdentifier(node.operand) &&
+      (node.operand.text === indexName || node.operand.text === recvName)
+    ) {
+      mutates = true;
+      return;
+    }
+    // Body-local declaration shadowing recv/i — see the doc comment.
+    if (
+      (ts.isVariableDeclaration(node) || ts.isParameter(node) || ts.isBindingElement(node)) &&
+      declaresShadow(node.name)
+    ) {
+      mutates = true;
+      return;
+    }
+    if (ts.isCatchClause(node) && declaresShadow(node.variableDeclaration?.name)) {
+      mutates = true;
+      return;
+    }
+    if (
+      ts.isFunctionDeclaration(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isArrowFunction(node) ||
+      ts.isClassDeclaration(node) ||
+      ts.isClassExpression(node)
+    ) {
+      mutates = true;
+      return;
+    }
+    forEachChild(node, visit);
+  }
+  visit(body);
+  return mutates;
+}
+
+/**
+ * #2682: true iff the body contains at least one `recvName.charCodeAt(indexName)`
+ * read (exact receiver + induction identifier). Gating the hoist on this keeps
+ * codegen byte-identical for string loops that never read a char by the
+ * induction var, and avoids emitting a dead `__str_flatten` + descriptor hoist.
+ */
+function bodyHasMatchingCharRead(body: ts.Statement, recvName: string, indexName: string): boolean {
+  let found = false;
+  function visit(node: ts.Node): void {
+    if (found) return;
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === "charCodeAt" &&
+      ts.isIdentifier(node.expression.expression) &&
+      node.expression.expression.text === recvName &&
+      node.arguments.length === 1 &&
+      ts.isIdentifier(node.arguments[0]!) &&
+      (node.arguments[0] as ts.Identifier).text === indexName
+    ) {
+      found = true;
+      return;
+    }
+    forEachChild(node, visit);
+  }
+  visit(body);
+  return found;
+}
+
+/**
+ * #2682: recognise the canonical string-read hot loop
+ * `for (let i = <non-neg int>; i < recv.length; i++/+=k) … recv.charCodeAt(i) …`
+ * and, when matched, hoist the loop-invariant `__str_flatten(recv)` + its
+ * `.data`/`.off` descriptor into fresh locals emitted ONCE before the loop.
+ * Returns the in-bounds proof to install on `fctx.hoistedCharReads`, or null
+ * (emitting nothing) on any deviation — refuse-loud, never miscompile.
+ *
+ * Native-string mode only: host/externref strings have no flattenable
+ * descriptor (charCodeAt is a host call there), so the receiver isn't a
+ * `$NativeString` struct and this never fires.
+ *
+ * Soundness of dropping the OOB/NaN branch at the read sites (R1): `init >= 0`
+ * + strict `<` + monotonic increase + `i`/`recv` not mutated in the body (and
+ * no capturing closure) ⇒ `0 <= i < len` at every `recv.charCodeAt(i)`. The
+ * read can never be out of range, so the NaN branch is dead and the direct
+ * `array.get_u` is byte-identical to the guarded read.
+ *
+ * MUST be called while `fctx.body` is the OUTER body (before `pushBody`) so the
+ * hoisted descriptor setup runs exactly once, before the loop.
+ */
+function detectCanonicalCharReadLoop(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  stmt: ts.ForStatement,
+): HoistedCharRead | null {
+  // Native-string mode only.
+  if (!ctx.nativeStrings || ctx.nativeStrTypeIdx < 0 || ctx.nativeStrDataTypeIdx < 0) return null;
+  const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten");
+  if (flattenIdx === undefined) return null;
+
+  // Induction var: reuse detectI32LoopVar (same shape the i32-promotion uses),
+  // then add the strictly-increasing-from-non-negative constraints it lacks.
+  const i32Loop = detectI32LoopVar(stmt);
+  if (!i32Loop) return null;
+  const indexName = i32Loop.name;
+  if (i32Loop.initValue < 0) return null; // i must start >= 0
+  if (!isIncreasingStep(stmt.incrementor, indexName)) return null;
+
+  // Condition must be exactly `i < recv.length` (strict <, index on the left).
+  if (!stmt.condition || !ts.isBinaryExpression(stmt.condition)) return null;
+  const cond = stmt.condition;
+  if (cond.operatorToken.kind !== ts.SyntaxKind.LessThanToken) return null;
+  if (!ts.isIdentifier(cond.left) || cond.left.text !== indexName) return null;
+  if (!ts.isPropertyAccessExpression(cond.right) || cond.right.name.text !== "length") return null;
+  if (!ts.isIdentifier(cond.right.expression)) return null;
+  const recvIdent = cond.right.expression;
+  const recvName = recvIdent.text;
+
+  // recv must be a (native) string — not any/union/array.
+  if (!isStringType(ctx.checker.getTypeAtLocation(recvIdent))) return null;
+
+  // Loop-invariance + induction-in-bounds: no mutation of recv/i, no closures.
+  if (loopBodyMutatesStringReadInvariants(stmt.statement, indexName, recvName)) return null;
+
+  // Only hoist if the body actually reads `recv.charCodeAt(i)` at least once.
+  if (!bodyHasMatchingCharRead(stmt.statement, recvName, indexName)) return null;
+
+  // --- Emit the hoist into the OUTER body (runs once, before the loop) ---
+  ensureNativeStringHelpers(ctx); // idempotent; __str_flatten already present
+  const flatTmp = allocLocal(fctx, `__cca_flat_${fctx.locals.length}`, flatStringType(ctx));
+  const dataLocal = allocLocal(fctx, `__cca_data_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: ctx.nativeStrDataTypeIdx,
+  });
+  const offLocal = allocLocal(fctx, `__cca_off_${fctx.locals.length}`, { kind: "i32" });
+
+  compileExpression(ctx, fctx, recvIdent); // push recv (ref $AnyString)
+  fctx.body.push({ op: "call", funcIdx: ctx.nativeStrHelpers.get("__str_flatten")! });
+  fctx.body.push({ op: "local.set", index: flatTmp });
+  fctx.body.push({ op: "local.get", index: flatTmp });
+  fctx.body.push({ op: "struct.get", typeIdx: ctx.nativeStrTypeIdx, fieldIdx: 2 }); // .data
+  fctx.body.push({ op: "local.set", index: dataLocal });
+  fctx.body.push({ op: "local.get", index: flatTmp });
+  fctx.body.push({ op: "struct.get", typeIdx: ctx.nativeStrTypeIdx, fieldIdx: 1 }); // .off
+  fctx.body.push({ op: "local.set", index: offLocal });
+
+  return { recvName, indexName, dataLocal, offLocal };
+}
+
+/**
  * #1453: Per-iteration fresh binding detection for `for (let X = …; …; …)`.
  *
  * Per ECMA-262 §14.7.4.4 (CreatePerIterationEnvironment), each iteration of
@@ -463,6 +686,9 @@ export function compileForStatement(ctx: CodegenContext, fctx: FunctionContext, 
   // #1453: Save existing boxedCaptures entries that we will overwrite when
   // boxing per-iteration cells. `undefined` means the name had no prior entry.
   let savedForBoxedCaptures: Map<string, { refCellTypeIdx: number; valType: ValType } | undefined> | null = null;
+  // #2682: canonical string-read-loop hoist proof + its scoped save/restore.
+  let charReadProof: HoistedCharRead | null = null;
+  let savedHoistedCharReads: Map<string, HoistedCharRead> | undefined;
   if (
     stmt.initializer &&
     ts.isVariableDeclarationList(stmt.initializer) &&
@@ -783,6 +1009,19 @@ export function compileForStatement(ctx: CodegenContext, fctx: FunctionContext, 
     ? emitLinearU8ArenaMark(ctx, fctx, "__linu8_loop_mark")
     : undefined;
   const arenaReset = linearU8ArenaResetInstrs(ctx, arenaMark);
+
+  // #2682: recognise the canonical string-read hot loop and hoist the
+  // loop-invariant `__str_flatten` + descriptor into locals emitted into the
+  // OUTER body (here — BEFORE pushBody — so they run exactly once before the
+  // loop). The proof is installed on a scoped `fctx.hoistedCharReads` consumed
+  // by the body's `recv.charCodeAt(i)` lowering, then restored after the body.
+  charReadProof = detectCanonicalCharReadLoop(ctx, fctx, stmt);
+  if (charReadProof) {
+    savedHoistedCharReads = fctx.hoistedCharReads;
+    fctx.hoistedCharReads = new Map(fctx.hoistedCharReads ?? []);
+    fctx.hoistedCharReads.set(charReadProof.recvName, charReadProof);
+  }
+
   const savedBody = pushBody(fctx);
 
   // Adjust existing break/continue depths: block+loop+block adds 3 nesting levels
@@ -882,6 +1121,10 @@ export function compileForStatement(ctx: CodegenContext, fctx: FunctionContext, 
 
   // Restore previous safeIndexedArrays (scoped to this loop)
   fctx.safeIndexedArrays = savedSafeIndexed;
+  // #2682: restore the canonical-read proof (scoped to this loop). The hoisted
+  // descriptor locals stay allocated (they're function-wide), but the proof is
+  // only visible to THIS loop's body — the incrementor (`i++`) must NOT see it.
+  if (charReadProof) fctx.hoistedCharReads = savedHoistedCharReads;
 
   // Incrementor (inside $loop, after $continue block)
   // (#1690) Same liveBodies registration as condInstrs above: the incrementor

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -13,7 +13,7 @@ import { compileAndEmitToString, emitToString, registerStringHelperEmitters } fr
 import { popBody, pushBody } from "./context/bodies.js";
 import { reportError } from "./context/errors.js";
 import { allocLocal } from "./context/locals.js";
-import type { ClosureInfo, CodegenContext, FunctionContext } from "./context/types.js";
+import type { ClosureInfo, CodegenContext, FunctionContext, HoistedCharRead } from "./context/types.js";
 import { emitThrowTypeError, getFuncParamTypes, noJsHost } from "./expressions/helpers.js";
 import { addStringImports, flatStringType, nativeStringType, resolveIdentifierType, resolveWasmType } from "./index.js";
 import {
@@ -2151,6 +2151,51 @@ function compileStringIntegerArg(ctx: CodegenContext, fctx: FunctionContext, arg
 }
 
 /**
+ * #2682: if `expr` is `recv.charCodeAt(i)` where `recv` is the loop-invariant
+ * receiver and `i` the in-bounds-proven induction variable of an active
+ * canonical string-read loop, return that loop's hoisted-descriptor proof.
+ * Otherwise return null. Both the i32-pure-leaf path (binary-ops.ts) and the
+ * f64 charCodeAt lowering below consult this. The match is deliberately exact —
+ * the argument must be the SAME induction identifier (not `i+1`, not a literal)
+ * so the dropped OOB branch stays sound.
+ */
+export function matchHoistedCharRead(fctx: FunctionContext, expr: ts.Expression): HoistedCharRead | null {
+  const reads = fctx.hoistedCharReads;
+  if (!reads || reads.size === 0) return null;
+  if (!ts.isCallExpression(expr)) return null;
+  const callee = expr.expression;
+  if (!ts.isPropertyAccessExpression(callee) || callee.name.text !== "charCodeAt") return null;
+  if (!ts.isIdentifier(callee.expression)) return null;
+  const entry = reads.get(callee.expression.text);
+  if (!entry) return null;
+  if (expr.arguments.length !== 1) return null;
+  const arg = expr.arguments[0]!;
+  if (!ts.isIdentifier(arg) || arg.text !== entry.indexName) return null;
+  return entry;
+}
+
+/**
+ * #2682: emit the hoisted-descriptor charCodeAt read, leaving an i32 char code
+ * on the stack. The receiver was flattened once before the loop and `i` is
+ * proven `0 <= i < len`, so this is a bare `array.get_u(dataLocal, offLocal + i)`
+ * — no `__str_flatten`, no `.data`/`.off` struct.get reload, no OOB/NaN branch.
+ * Caller must have matched via {@link matchHoistedCharRead}.
+ */
+export function emitHoistedCharCodeAtRead(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  entry: HoistedCharRead,
+  idxArg: ts.Expression,
+): void {
+  fctx.body.push({ op: "local.get", index: entry.dataLocal });
+  fctx.body.push({ op: "local.get", index: entry.offLocal });
+  // The argument is the proven induction var (an i32 local) — emits `local.get`.
+  compileExpression(ctx, fctx, idxArg, { kind: "i32" });
+  fctx.body.push({ op: "i32.add" });
+  fctx.body.push({ op: "array.get_u", typeIdx: ctx.nativeStrDataTypeIdx });
+}
+
+/**
  * Compile a method call on a native string in fast mode.
  * Handles: charCodeAt (inline), charAt, substring, slice (native helpers),
  * and delegates other methods to host via marshal.
@@ -2228,6 +2273,20 @@ export function compileNativeStringMethodCall(
   // ECMA-262 §22.1.3.3: ToIntegerOrInfinity(pos), then return NaN when
   // the resulting position is outside [0, string length).
   if (method === "charCodeAt") {
+    // #2682 fast path: inside a recognised canonical read loop the receiver was
+    // flattened once and the index is proven in-bounds — read directly from the
+    // hoisted descriptor (no flatten / struct.get / NaN branch). This arm is the
+    // f64-consumption case (the i32-pure chain reads it via emitI32PureExpr in
+    // binary-ops.ts). Result is byte-identical to the guarded read on the
+    // in-bounds path, which is the only path the proof admits.
+    if (!receiverOverride) {
+      const hoisted = matchHoistedCharRead(fctx, expr);
+      if (hoisted) {
+        emitHoistedCharCodeAtRead(ctx, fctx, hoisted, expr.arguments[0]!);
+        fctx.body.push({ op: "f64.convert_i32_u" });
+        return { kind: "f64" };
+      }
+    }
     emitReceiver();
     // Flatten to FlatString (handles ConsString → FlatString)
     const flattenIdx = ctx.nativeStrHelpers.get("__str_flatten")!;

--- a/tests/issue-2682.test.ts
+++ b/tests/issue-2682.test.ts
@@ -1,0 +1,310 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2682 — string read-loop fast path: hoist the loop-invariant `__str_flatten`
+// + `.data`/`.off` descriptor out of the canonical hash loop, and (under the
+// in-bounds proof) lower `recv.charCodeAt(i)` to a direct i32 `array.get_u` so
+// the whole `(h*31 + c) | 0` chain stays in i32 — no per-iteration flatten, no
+// struct.get reload, no OOB/NaN branch, no f64 `|0` emulation.
+//
+// The optimization is GATED on the canonical loop shape + an in-bounds proof
+// (init >= 0, strict `i < recv.length`, monotonic step, `i`/`recv` not mutated,
+// no capturing closure). These tests assert (a) byte-faithful results for the
+// optimized loops, and (b) that every NON-matching shape is left unoptimized and
+// behaviourally unchanged (the #1105 OOB-NaN semantics are preserved).
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+
+const ENV_STUB = {
+  console_log_number: () => {},
+  console_log_string: () => {},
+  console_log_bool: () => {},
+};
+
+interface Built {
+  exports: Record<string, unknown>;
+  toNative: (s: string) => unknown;
+}
+
+async function compileNative(source: string, opts: Record<string, unknown> = {}): Promise<Built> {
+  const r = await compile(source, {
+    nativeStrings: true,
+    testRuntime: true,
+    fileName: "issue-2682.ts",
+    ...opts,
+  });
+  if (!r.success) {
+    const errors = Array.isArray(r.errors) ? r.errors.map((err) => err.message).join("; ") : "no errors array";
+    throw new Error(`compile failed: ${errors}`);
+  }
+  const built = buildImports(r.imports, ENV_STUB, r.stringPool);
+  const { instance } = await instantiateWasm(r.binary, built.env, built.string_constants);
+  const exports = instance.exports as Record<string, unknown>;
+  built.setExports?.(exports as Record<string, Function>);
+  return { exports, toNative: exports.__test_str_from_externref as (s: string) => unknown };
+}
+
+// Just the WAT of the named function (the recogniser only ever touches one fn).
+async function watOf(source: string, fnName: string, opts: Record<string, unknown> = {}): Promise<string> {
+  const r = await compile(source, { nativeStrings: true, emitWat: true, fileName: "issue-2682-wat.ts", ...opts });
+  const lines = (r.wat ?? "").split("\n");
+  const out: string[] = [];
+  let cap = false;
+  for (const l of lines) {
+    if (l.includes(`(func $${fnName} `)) cap = true;
+    if (cap) {
+      out.push(l);
+      if (out.length > 1 && /^\s*\(func /.test(l) && !l.includes(`$${fnName} `)) {
+        out.pop();
+        break;
+      }
+    }
+  }
+  return out.join("\n");
+}
+
+// JS reference for the canonical `(h * 31 + s.charCodeAt(i)) | 0` hash.
+function refHash(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0;
+  return h;
+}
+
+const HASH_SRC = `
+  export function hashStr(s: string): number {
+    let h = 0;
+    for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0;
+    return h;
+  }
+`;
+
+describe("#2682 canonical string read-loop fast path", () => {
+  for (const mode of [
+    { tag: "fast+nativeStrings", opts: { fast: true } },
+    { tag: "nativeStrings", opts: {} },
+  ]) {
+    it(`hash result is byte-faithful (${mode.tag})`, async () => {
+      const { exports, toNative } = await compileNative(HASH_SRC, mode.opts);
+      const hashStr = exports.hashStr as (s: unknown) => number;
+      for (const s of ["", "a", "hello world", "The quick brown fox 0123456789!", "héllo ☃ unicode", "z".repeat(300)]) {
+        expect(hashStr(toNative(s))).toBe(refHash(s));
+      }
+    });
+  }
+
+  it("emits ONE hoisted flatten + a pure-i32 inner loop (no per-iter flatten / NaN branch / f64 round-trip)", async () => {
+    for (const opts of [{ fast: true }, {}]) {
+      const wat = await watOf(HASH_SRC, "hashStr", opts);
+      // recogniser fired: the descriptor was hoisted into dedicated locals.
+      expect(wat).toContain("$__cca_data");
+      expect(wat).toContain("$__cca_off");
+      // exactly one flatten local (single flatten, hoisted before the loop).
+      expect((wat.match(/\$__cca_flat/g) ?? []).length).toBeGreaterThan(0);
+      // the inner read is a direct i32 array.get_u — no f64 round-trip, no |0 emulation.
+      expect(wat).toContain("array.get_u");
+      expect(wat).not.toContain("f64.convert_i32_u");
+      expect(wat).not.toContain("4294967296"); // the f64 ToUint32 (|0) emulation constant
+    }
+  });
+
+  it("a non-negative literal init and `i += 2` step still optimise (and stay correct)", async () => {
+    const src = `
+      export function hashStep(s: string): number {
+        let h = 0;
+        for (let i = 0; i < s.length; i += 2) h = (h * 31 + s.charCodeAt(i)) | 0;
+        return h;
+      }
+    `;
+    const { exports, toNative } = await compileNative(src, { fast: true });
+    const hashStep = exports.hashStep as (s: unknown) => number;
+    const ref = (str: string) => {
+      let h = 0;
+      for (let i = 0; i < str.length; i += 2) h = (h * 31 + str.charCodeAt(i)) | 0;
+      return h;
+    };
+    for (const s of ["abcdefgh", "x", "", "abcdefghijklmnop"]) expect(hashStep(toNative(s))).toBe(ref(s));
+    expect(await watOf(src, "hashStep", { fast: true })).toContain("$__cca_data");
+  });
+
+  it("multiple charCodeAt(i) reads share a single hoist", async () => {
+    const src = `
+      export function h2(s: string): number {
+        let h = 0;
+        for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i) + s.charCodeAt(i)) | 0;
+        return h;
+      }
+    `;
+    const { exports, toNative } = await compileNative(src, { fast: true });
+    const h2 = exports.h2 as (s: unknown) => number;
+    const ref = (str: string) => {
+      let h = 0;
+      for (let i = 0; i < str.length; i++) h = (h * 31 + str.charCodeAt(i) + str.charCodeAt(i)) | 0;
+      return h;
+    };
+    for (const s of ["abcd", "", "hello"]) expect(h2(toNative(s))).toBe(ref(s));
+    const wat = await watOf(src, "h2", { fast: true });
+    expect((wat.match(/\$__cca_flat/g) ?? []).length).toBeGreaterThan(0); // single flatten local
+    expect((wat.match(/array\.get_u/g) ?? []).length).toBe(2); // two reads, both direct
+  });
+});
+
+describe("#2682 soundness — non-matching shapes are left unoptimised and unchanged", () => {
+  // Outside a recognised loop, charCodeAt keeps its OOB-NaN semantics (#1105):
+  // `(a + s.charCodeAt(OOB)) | 0` poisons to 0, NOT to `a`.
+  it("OOB charCodeAt outside a loop still poisons `(a + c) | 0` to 0 (nativeStrings, exact f64)", async () => {
+    const src = `export function oob(): number { const s = "ab"; return (100 + s.charCodeAt(50)) | 0; }`;
+    const { exports } = await compileNative(src); // non-fast: exact spec f64 semantics
+    expect((exports.oob as () => number)()).toBe(0);
+    // and it is NOT optimised (no hoist locals).
+    expect(await watOf(src, "oob")).not.toContain("$__cca_data");
+  });
+
+  it("a non-induction index `charCodeAt(i + 1)` is NOT optimised and stays correct", async () => {
+    const src = `
+      export function nh(s: string): number {
+        let h = 0;
+        for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i + 1)) | 0;
+        return h;
+      }
+    `;
+    const { exports, toNative } = await compileNative(src); // non-fast for exact NaN semantics
+    const nh = exports.nh as (s: unknown) => number;
+    const ref = (str: string) => {
+      let h = 0;
+      for (let i = 0; i < str.length; i++) h = (h * 31 + str.charCodeAt(i + 1)) | 0;
+      return h;
+    };
+    for (const s of ["abc", "abcde", "a"]) expect(nh(toNative(s))).toBe(ref(s));
+    expect(await watOf(src, "nh")).not.toContain("$__cca_data");
+  });
+
+  it("a reassigned receiver inside the loop is NOT optimised and stays correct", async () => {
+    const src = `
+      export function rr(): number {
+        let h = 0;
+        let s = "abcd";
+        for (let i = 0; i < s.length; i++) { h = (h * 31 + s.charCodeAt(i)) | 0; if (i === 1) s = "xy"; }
+        return h;
+      }
+    `;
+    const { exports } = await compileNative(src);
+    const ref = () => {
+      let h = 0;
+      let s = "abcd";
+      for (let i = 0; i < s.length; i++) {
+        h = (h * 31 + s.charCodeAt(i)) | 0;
+        if (i === 1) s = "xy";
+      }
+      return h;
+    };
+    expect((exports.rr as () => number)()).toBe(ref());
+    expect(await watOf(src, "rr")).not.toContain("$__cca_data");
+  });
+
+  it("a body that SHADOWS the receiver name is NOT optimised (text-keyed match stays sound)", async () => {
+    // Inner `s` shadows the loop receiver; `s.charCodeAt(i)` must read the INNER
+    // string, never the hoisted outer descriptor.
+    const src = `
+      export function sh(): number {
+        let h = 0;
+        const s = "abcdef";
+        for (let i = 0; i < s.length; i++) { const s = "ZZ"; h = (h * 31 + s.charCodeAt(i % 2)) | 0; }
+        return h;
+      }
+    `;
+    const { exports } = await compileNative(src);
+    const ref = () => {
+      let h = 0;
+      const s = "abcdef";
+      for (let i = 0; i < s.length; i++) {
+        const s = "ZZ";
+        h = (h * 31 + s.charCodeAt(i % 2)) | 0;
+      }
+      return h;
+    };
+    expect((exports.sh as () => number)()).toBe(ref());
+    expect(await watOf(src, "sh")).not.toContain("$__cca_data");
+  });
+
+  it("a ConsString receiver flattens correctly once-hoisted", async () => {
+    // `a + b` is a ConsString (rope); the hoisted `__str_flatten` must still
+    // produce the correct flat code units.
+    const src = `
+      export function hc(a: string, b: string): number {
+        const s = a + b;
+        let h = 0;
+        for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0;
+        return h;
+      }
+    `;
+    const { exports, toNative } = await compileNative(src, { fast: true });
+    const hc = exports.hc as (a: unknown, b: unknown) => number;
+    const ref = (a: string, b: string) => {
+      const s = a + b;
+      let h = 0;
+      for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0;
+      return h;
+    };
+    for (const [a, b] of [
+      ["foo", "bar"],
+      ["", "x"],
+      ["hello ", "world"],
+    ] as const) {
+      expect(hc(toNative(a), toNative(b))).toBe(ref(a, b));
+    }
+    expect(await watOf(src, "hc", { fast: true })).toContain("$__cca_data");
+  });
+
+  it("a `.length` bound on a DIFFERENT string than the charCodeAt receiver is not mis-optimised", async () => {
+    // Condition bounds `i` by `a.length`, but the read is `b.charCodeAt(i)` — `b`
+    // is NOT proven in-bounds, so it must keep the guarded (NaN) lowering.
+    const src = `
+      export function bm(a: string, b: string): number {
+        let h = 0;
+        for (let i = 0; i < a.length; i++) h = (h * 31 + b.charCodeAt(i)) | 0;
+        return h;
+      }
+    `;
+    const { exports, toNative } = await compileNative(src); // non-fast: exact NaN semantics
+    const bm = exports.bm as (a: unknown, b: unknown) => number;
+    const ref = (a: string, b: string) => {
+      let h = 0;
+      for (let i = 0; i < a.length; i++) h = (h * 31 + b.charCodeAt(i)) | 0;
+      return h;
+    };
+    // a longer than b => b.charCodeAt(i) is OOB on the tail => NaN-poisons to 0.
+    for (const [a, b] of [
+      ["abcdef", "xy"],
+      ["ab", "wxyz"],
+    ] as const) {
+      expect(bm(toNative(a), toNative(b))).toBe(ref(a, b));
+    }
+    // `b` is not the bound receiver, so `b.charCodeAt(i)` stays unoptimised.
+    expect(await watOf(src, "bm")).not.toContain("$__cca_data");
+  });
+
+  it("a body that mutates the induction var is NOT optimised and stays correct", async () => {
+    const src = `
+      export function mi(): number {
+        let h = 0;
+        const s = "abcdef";
+        for (let i = 0; i < s.length; i++) { h = (h * 31 + s.charCodeAt(i)) | 0; i++; }
+        return h;
+      }
+    `;
+    const { exports } = await compileNative(src);
+    const ref = () => {
+      let h = 0;
+      const s = "abcdef";
+      for (let i = 0; i < s.length; i++) {
+        h = (h * 31 + s.charCodeAt(i)) | 0;
+        i++;
+      }
+      return h;
+    };
+    expect((exports.mi as () => number)()).toBe(ref());
+    expect(await watOf(src, "mi")).not.toContain("$__cca_data");
+  });
+});


### PR DESCRIPTION
## #2682 — string read-loop fast path (the #1762 NO-GO redirect)

Recognises the canonical string-hash hot loop
`for (let i=0; i<recv.length; i++) … recv.charCodeAt(i) …` and rewrites it on
the **existing WasmGC string representation** (no dual-backend risk):

- **D1 (hoist):** the loop-invariant `__str_flatten(recv)` + `.data`/`.off`
  descriptor reads are emitted **once before the loop** into locals (kills the
  per-iteration `__str_flatten` call + `struct.get` reloads — the dominant
  1.66–1.8x per #1762 Slice-0).
- **D3 (proof-gated i32 leaf):** under an in-bounds proof (init ≥ 0, strict
  `i < recv.length`, monotonic step, `recv`/`i` not mutated/shadowed, no
  capturing closure), `recv.charCodeAt(i)` lowers to a direct i32 `array.get_u`
  — **no OOB/NaN branch, no f64 round-trip** — so the whole `(h*31 + c) | 0`
  chain stays i32 and the f64 `|0` emulation disappears.

### Verify-first scope narrowing

Decoding the **actual** `hashStr` WAT on `main` showed the spec's D2 (relational
i32) and D4 (i32 accumulator) are **already done** by existing passes
(`collectI32CoercedLocals` makes `h` i32; fast-mode already emits `i32.lt_s` /
`i32.mul`). So the real remaining cost — and this PR — is D1 + D3. (Residual: the
non-fast loop *condition* still uses `f64.lt`, the optional D2 relational
extension, deliberately out of scope.)

### Result (decoded WAT, acceptance met)

Both `{fast,nativeStrings}` and `{nativeStrings}` now emit ONE hoisted flatten +
descriptor before the loop and an inner body of
`i32.add(i32.mul(h,31), array.get_u(dataL, offL+i))` — no per-iter
call/struct.get, no NaN branch, no f64 round-trip, no `|0` emulation.

### Soundness (#1105 / R1 preserved)

`charCodeAt`'s OOB→NaN poisoning is byte-identical **outside** a proven loop — the
i32 leaf fires ONLY under the in-bounds proof (where the read can never be OOB).
The receiver match is by identifier text and is **shadow-guarded**.

### Validation (#2078 string-codegen regression class)

- `tests/issue-2682.test.ts` (12 tests): result-parity for the optimised loop
  (fast + non-fast; empty/unicode/long/**ConsString**/step-2/multi-read) and
  NOT-optimised-but-correct for every non-matching shape (OOB-outside-loop,
  `charCodeAt(i+1)`, reassigned-recv, mutated-i, shadowed recv, `other.length`
  bound mismatch).
- **Byte-identity proof**: decoded WAT of non-matching functions is *identical*
  to pristine `origin/main`; only the recognised loop changes. Existing i32/
  charCodeAt/bitwise/string suites show identical pass/fail counts vs baseline →
  zero new failures. `tsc --noEmit` + biome clean.
- Native-string mode only (host/externref strings untouched). Confirmed through
  the #2097 merge_group standalone floor.

Closes #2682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)