### PR TITLE
fix(#2669): nested-array destructuring default-init codegen (3 defects)

### DIFF
--- a/plan/issues/2566-eager-generator-overconsumes-in-dstr.md
+++ b/plan/issues/2566-eager-generator-overconsumes-in-dstr.md
@@ -74,3 +74,19 @@ assertion (`assert.sameValue(second, 0)`).
 - [ ] `var [[,] = g()] = []` with a capturing `g` ⇒ default runs once, not resumed.
 - [ ] The ~29 capturing-generator `*ary-ptrn*elision*` test262 cases flip from
       fail → pass without regressing the non-capturing (native) generator cases.
+
+## Related residual deferred here (from #2669, 2026-06-26)
+
+#2669 landed the SYNC for-of nested-default codegen (`for (const [[x,y,z]=[4,5,6]]
+of [[]])`) but **deliberately forgoes the nested default when the initializer is a
+CALL expression** (generator `g()`, capturing helper, IIFE) — gated
+`!ts.isCallExpression(initializer)` — and skips it entirely for **for-await-of**.
+Reason: compiling such a default inside the conditionally-skipped default arm
+materialises its capture box only on the not-taken branch and corrupts later reads
+of the captured variable (a #2692 closure-box-lazy interaction), and the generator
+case additionally over-consumes — this issue. The forgone surface is the
+`for-await-of/async-{func,gen}-dstr-…ary-ptrn-elem-ary-elision-{init,iter,empty}`
+cluster (~15 tests) plus the sync `ary-empty-init` IIFE-default cases. They unblock
+once this (#2566) + a fully-general #2692 land; then the `!isCallExpression`
+restriction in `compileForOfDestructuring` (`src/codegen/statements/loops.ts`) can
+be lifted.

--- a/plan/issues/2669-es6-destructuring-correctness-residual-umbrella.md
+++ b/plan/issues/2669-es6-destructuring-correctness-residual-umbrella.md
@@ -220,11 +220,36 @@ NOT an iterator-protocol gap) — all fixed in this slice with guard test
    slot null and the recursive destructure threw "Cannot destructure 'null' or
    'undefined'" (`for (const [[x,y,z]=[4,5,6]] of [[]])`). Fix: apply
    `emitNestedBindingDefault` (with the externref OOB→undefined sentinel) before
-   recursing.
+   recursing — **scoped to the SYNC for-of path AND PURE (non-call) default
+   initializers** (array/object literals, identifiers). See the CI-FIX note below.
 
-**Validation:** 9/9 guard tests; `hardError=0` across 1781 dstr files (no new
-malformed-Wasm); 13/14 curated fresh-process regression sample green (the 1 fail
-is the pre-existing in-bounds-undefined/hole sub-bug below, an unrelated path).
+### CI-FIX (merge_group floor) — scope narrowed (2026-06-26)
+
+The first cut of fix #3 applied the nested default for **all** initializers in
+**both** for-of and for-await. The #2097 merge_group floor (full test262, not the
+scoped sweep) flagged **15 `for-await-of` regressions** (`async-{func,gen}-dstr-…
+ary-ptrn-elem-ary-elision-{init,iter}` + 3 `…ary-empty-init` flake timeouts): a
+**CALL-expression** default (generator `g()`, capturing helper, IIFE) compiled
+inside the conditionally-skipped default arm materialised its capture box **only
+on the not-taken branch**, corrupting later reads of the captured variable
+(#2692 closure-box-lazy territory; the generator case also over-consumes,
+#2566). On clean main fix #3 didn't exist so those defaults were ignored and the
+tests passed by coincidence (the element was present, so the default must not
+fire anyway). Net was +9 but the regression **ratio** (12/24 = 50%) tripped the
+gate. Fix: gate the nested-default application to `!stmt.awaitModifier &&
+!ts.isCallExpression(initializer)`. Pure literal/identifier defaults have no side
+effect or capture box, so they are safe to evaluate conditionally; call-default
+nested cases (and all for-await nested defaults) revert byte-for-byte to the
+pre-fix behaviour and stay tracked under the umbrella tail (#2566 / #2692).
+Result: all 15 for-await regressions cleared, 12 sync improvements retained
+(`ary-elem-init`, `ary-rest-init`, `obj-id-init`, `obj-prop-id-init`),
+`ary-empty-init` (IIFE default) deliberately forgone. Guard
+`tests/issue-2669.test.ts` extended with the capturing-call present-element
+poison signature.
+
+**Validation:** 10/10 guard tests; `hardError=0` across 1781 dstr files (no new
+malformed-Wasm); all 15 floor-regressed `for-await-of` tests verified back to
+PASS via fresh single-file runs; 12 sync improvements re-verified PASS.
 
 **Remaining umbrella tail (NOT this slice):**
 - The 4 still-failing cluster samples are iterator-protocol semantics → **#1642**

--- a/plan/issues/2669-es6-destructuring-correctness-residual-umbrella.md
+++ b/plan/issues/2669-es6-destructuring-correctness-residual-umbrella.md
@@ -1,8 +1,7 @@
 ---
 id: 2669
 title: "ES2015: destructuring correctness residual umbrella (~696 fails — iterator-close, defaults, holes, rest across for-of/assignment/binding/params)"
-status: in-progress
-assignee: ttraenkler/dev-dstr2669
+status: ready
 created: 2026-06-25
 updated: 2026-06-26
 priority: high
@@ -62,13 +61,18 @@ after a close assertion, `Cannot destructure 'null' or 'undefined'`,
 
 ## Failing-test cluster (examples)
 
+> **2026-06-26 re-sweep (current `origin/main`, post-#2692).** 2 of the 6 below
+> now PASS and are struck through; the remaining 4 are all **iterator-protocol
+> semantic gaps** routed to #1642 (IteratorClose) / #2566 (generator
+> over-consumption) — NOT the codegen-default family. See "## Slice landed".
+
 ```
-language/statements/for-of/dstr/array-elem-iter-nrml-close-err.js
-language/statements/for-of/dstr/let-obj-ptrn-prop-id-init-skipped.js
-language/statements/for-of/dstr/const-ary-ptrn-elem-ary-elem-init.js
-language/expressions/assignment/dstr/array-elem-trlg-iter-elision-iter-abpt.js
-language/expressions/object/dstr/meth-ary-ptrn-elem-ary-elision-init.js
-language/statements/class/dstr/private-meth-ary-ptrn-elem-ary-elision-init.js
+language/statements/for-of/dstr/array-elem-iter-nrml-close-err.js            # FAIL — IteratorClose (#1642)
+# PASS (#2692): language/statements/for-of/dstr/let-obj-ptrn-prop-id-init-skipped.js
+# PASS (this slice): language/statements/for-of/dstr/const-ary-ptrn-elem-ary-elem-init.js
+language/expressions/assignment/dstr/array-elem-trlg-iter-elision-iter-abpt.js  # FAIL — trailing-elision over-consumption (#2566)
+language/expressions/object/dstr/meth-ary-ptrn-elem-ary-elision-init.js      # FAIL — generator over-consumption (#2566)
+language/statements/class/dstr/private-meth-ary-ptrn-elem-ary-elision-init.js  # FAIL — generator over-consumption (#2566)
 ```
 
 ## Acceptance criteria
@@ -183,3 +187,58 @@ an architect spec + full `merge_group` validation, not an inline patch.
   apparent failures are the closure-box bug.
 
 Repro driver + probes used: `.tmp/runsrc.mts`, `.tmp/runwasm.mts` (gitignored).
+
+## Slice landed (dev-dstr2669, 2026-06-26) — nested-array-default codegen family
+
+Verify-first re-sweep of the 6-sample cluster on current `origin/main` (post-#2692):
+**2 PASS, 4 FAIL**. The single `let-obj-ptrn-prop-id-init-skipped` was already
+fixed by #2692 (the closure-box surface). The verify-first sweep then root-caused
+the `const-ary-ptrn-elem-ary-elem-init` failure to **three distinct codegen
+defects** in the array-destructuring *default-init* family (NOT the closure box,
+NOT an iterator-protocol gap) — all fixed in this slice with guard test
+`tests/issue-2669.test.ts` (9/9 green):
+
+1. **Malformed Wasm — `extern.convert_any` on an already-externref `array.get`.**
+   A `ref_*` keyed vec (nested arrays/objects, e.g. `number[][]`) lowers its
+   backing store to `(array (mut externref))` — its elements are *already*
+   externref. The element-conversion loop in `destructureParamArray`
+   (`src/codegen/destructuring-params.ts`, `boxToExternref`) and the host-boundary
+   `__vec_get` helper (`src/codegen/index.ts`) keyed off the `"ref_*"` STRING and
+   emitted `extern.convert_any` (operand must be `anyref`) on the externref slot →
+   invalid Wasm, module failed to instantiate (`const [[x,y,z]=[4,5,6]] = []`).
+   Fix: decide boxing from the **real backing-array element kind** — an externref
+   store is a straight pass-through.
+2. **for-of identifier default never fired (externref source).** A for-of element
+   with a default over an externref source was coerced to the (numeric) binding
+   type BEFORE the default check (`src/codegen/statements/loops.ts`), unboxing
+   `undefined` to a plain NaN that never matched the f64 sNaN sentinel the check
+   looks for (`for (const [a=9] of [[]])` kept NaN). Fix: run
+   `emitDefaultValueCheck` on the RAW externref (`__extern_is_undefined`), then
+   coerce the survivor.
+3. **for-of nested-pattern default ignored.** The for-of nested-pattern branch
+   dropped `element.initializer` entirely, so a short/empty source left the nested
+   slot null and the recursive destructure threw "Cannot destructure 'null' or
+   'undefined'" (`for (const [[x,y,z]=[4,5,6]] of [[]])`). Fix: apply
+   `emitNestedBindingDefault` (with the externref OOB→undefined sentinel) before
+   recursing.
+
+**Validation:** 9/9 guard tests; `hardError=0` across 1781 dstr files (no new
+malformed-Wasm); 13/14 curated fresh-process regression sample green (the 1 fail
+is the pre-existing in-bounds-undefined/hole sub-bug below, an unrelated path).
+
+**Remaining umbrella tail (NOT this slice):**
+- The 4 still-failing cluster samples are iterator-protocol semantics → **#1642**
+  (IteratorClose on abrupt completion) and **#2566** (generator / trailing-elision
+  over-consumption). Keep those as the concrete sub-issues.
+- A separate **in-bounds `undefined`/hole** default-init sub-bug remains: a literal
+  `undefined`/elision element of a *typed* nested vec is not carried as a
+  recognizable "undefined" through the default check (`for (let [x=23] of
+  [[undefined]])` / `[[,]]` → `x` stays the value, default never fires;
+  `[a=1,b,c=3] = [..., , undefined]` assignment likewise). Distinct from the three
+  fixes above (those are the externref/OOB and malformed-Wasm paths); the typed
+  in-bounds sentinel-propagation is the next carve.
+- The nested **object**-default (`[{a}={a:1}]`) over an empty/externref source also
+  still mis-binds — same default-init family, follow-up carve.
+
+This slice keeps the umbrella OPEN (status stays `ready`) — it burns down the
+nested-array-default codegen corner, not the iterator-protocol tail.

--- a/plan/issues/2669-es6-destructuring-correctness-residual-umbrella.md
+++ b/plan/issues/2669-es6-destructuring-correctness-residual-umbrella.md
@@ -1,9 +1,10 @@
 ---
 id: 2669
 title: "ES2015: destructuring correctness residual umbrella (~696 fails — iterator-close, defaults, holes, rest across for-of/assignment/binding/params)"
-status: ready
+status: in-progress
+assignee: ttraenkler/dev-dstr2669
 created: 2026-06-25
-updated: 2026-06-25
+updated: 2026-06-26
 priority: high
 feasibility: hard
 reasoning_effort: high

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -265,7 +265,20 @@ function emitBoundsCheckedArrayGetUndef(
   });
 }
 
-function boxToExternref(ctx: CodegenContext, elemKey: string): Instr[] {
+function boxToExternref(ctx: CodegenContext, elemKey: string, srcElemType?: ValType): Instr[] {
+  // (#2669) When the backing array ALREADY stores externref elements, the value
+  // produced by `array.get` is already an externref and needs no conversion.
+  // The vec-type-map key alone is misleading here: a `ref_*` keyed vec (a vec of
+  // nested arrays/objects, e.g. from `number[][]`) lowers its backing store to
+  // `(array (mut externref))` — its elements are boxed to externref — so keying
+  // off the `"ref_*"` string would emit `extern.convert_any`, whose operand must
+  // be an `anyref`, on an externref `array.get`. That is invalid Wasm and made
+  // `const [[x,y,z]=[4,5,6]] = []` (over a `number[][]` source) fail to
+  // instantiate. Decide from the real element kind: an externref store is a
+  // straight pass-through.
+  if (srcElemType && (srcElemType.kind === "externref" || srcElemType.kind === "ref_extern")) {
+    return [];
+  }
   if (elemKey === "externref") {
     // Already externref, just pass through
     return [];
@@ -1262,6 +1275,12 @@ export function destructureParamArray(
         const dataField = vecDef.fields[1];
         if (!dataField || dataField.name !== "data") continue;
         const srcArrTypeIdx = (dataField.type as { typeIdx: number }).typeIdx;
+        // (#2669) The real backing-store element type drives boxing/conversion —
+        // a `ref_*` keyed vec stores its (boxed) elements as externref, so the
+        // string key would mis-trigger `extern.convert_any` on an externref.
+        const srcArrDef = ctx.mod.types[srcArrTypeIdx];
+        const srcElemType: ValType | undefined =
+          srcArrDef && srcArrDef.kind === "array" ? (srcArrDef.element as ValType) : undefined;
 
         const cvtTmp = allocLocal(fctx, `__dparam_src_${key}_${fctx.locals.length}`, {
           kind: "ref_null",
@@ -1310,7 +1329,7 @@ export function destructureParamArray(
                   { op: "local.get", index: idxTmp } as Instr,
                   { op: "array.get", typeIdx: srcArrTypeIdx } as Instr,
                   // Box primitive types before storing as externref
-                  ...boxToExternref(ctx, key),
+                  ...boxToExternref(ctx, key, srcElemType),
                   { op: "array.set", typeIdx: extArrTypeIdx } as Instr,
                   // idx++
                   { op: "local.get", index: idxTmp } as Instr,

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -4570,6 +4570,14 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
       const [elemKey, vecTypeIdx] = vecEntries[i]!;
       const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
       if (arrTypeIdx < 0) continue;
+      // (#2669) The REAL backing-array element kind, not the `elemKey` string,
+      // decides whether the read value needs converting to externref: a `ref_*`
+      // keyed vec stores its (boxed) elements as externref already.
+      const arrElemDef = ctx.mod.types[arrTypeIdx];
+      const arrElemIsExternref =
+        arrElemDef !== undefined &&
+        arrElemDef.kind === "array" &&
+        ((arrElemDef.element as ValType).kind === "externref" || (arrElemDef.element as ValType).kind === "ref_extern");
       // Skip numeric element types if __box_number is not available
       if (
         (elemKey === "f64" || elemKey === "i32" || elemKey === "i32_byte" || elemKey === "i8_byte") &&
@@ -4626,6 +4634,13 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
         } else {
           boxInstrs = [{ op: "drop" } as Instr, { op: "ref.null.extern" } as Instr];
         }
+      } else if (arrElemIsExternref) {
+        // (#2669) A `ref_*` keyed vec (nested arrays/objects, e.g. `number[][]`)
+        // lowers its backing store to `(array (mut externref))` — the elements
+        // are already boxed to externref. `array.get` yields externref, so an
+        // `extern.convert_any` (whose operand MUST be an anyref) is invalid Wasm.
+        // Pass the externref slot through unchanged.
+        boxInstrs = [];
       } else {
         boxInstrs = [{ op: "extern.convert_any" } as Instr];
       }

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -1719,29 +1719,45 @@ function compileForOfDestructuring(
             fieldIdx: 1,
           });
           fctx.body.push({ op: "i32.const", value: i });
-          // (#2669) When the nested element has a default (`[[x,y,z]=[4,5,6]]`),
-          // the OOB else-branch must yield JS `undefined` (not wasm-null) for an
-          // externref source so `emitNestedBindingDefault`'s
-          // `__extern_is_undefined` check fires the initializer. For a typed
-          // (f64/ref) source the existing sentinel/null check already fires.
-          const nestedWantsUndef =
-            element.initializer !== undefined &&
-            (innerElemType.kind === "externref" || innerElemType.kind === "ref_extern");
-          emitBoundsCheckedArrayGet(fctx, innerArrTypeIdx, innerElemType, ctx, nestedWantsUndef);
-          fctx.body.push({ op: "local.set", index: nestedLocal });
           // (#2669) Apply the nested element's default initializer BEFORE recursing
           // into the sub-pattern — otherwise a short/empty source left `nestedLocal`
           // null/undefined and the recursive destructure threw
           // "Cannot destructure 'null' or 'undefined'"
           // (`for (const [[x,y,z]=[4,5,6]] of [[]])`). Mirrors the
           // `destructureParamArray` nested-default path.
-          if (element.initializer) {
+          //
+          // Restricted to (a) the SYNC for-of path and (b) PURE (non-call)
+          // default initializers — array/object literals and identifiers. A
+          // CALL-expression default (IIFE, generator `g()`, capturing helper) is
+          // deferred to the pre-fix behaviour because compiling it inside the
+          // conditionally-skipped default arm materialises its capture box only on
+          // the not-taken branch, corrupting later reads of the captured variable
+          // (#2692 closure-box-lazy territory) — and the generator case also
+          // over-consumes the iterator (#2566). This is exactly what regressed 15
+          // `for-await-of` elision-default tests in the merge_group floor; a pure
+          // literal/identifier default has no side effect or capture box, so it is
+          // safe to evaluate conditionally. Call-expression nested defaults stay
+          // tracked under the umbrella tail (#2566 / #2692).
+          const applyNestedDefault =
+            element.initializer !== undefined && !stmt.awaitModifier && !ts.isCallExpression(element.initializer);
+          if (applyNestedDefault) {
+            // The OOB else-branch must yield JS `undefined` (not wasm-null) for an
+            // externref source so `emitNestedBindingDefault`'s
+            // `__extern_is_undefined` check fires the initializer. For a typed
+            // (f64/ref) source the existing sentinel/null check already fires.
+            const nestedWantsUndef = innerElemType.kind === "externref" || innerElemType.kind === "ref_extern";
+            emitBoundsCheckedArrayGet(fctx, innerArrTypeIdx, innerElemType, ctx, nestedWantsUndef);
+            fctx.body.push({ op: "local.set", index: nestedLocal });
             (ctx as any)._arrayLiteralForceVec = true;
             try {
-              emitNestedBindingDefault(ctx, fctx, nestedLocal, innerElemType, element.initializer);
+              emitNestedBindingDefault(ctx, fctx, nestedLocal, innerElemType, element.initializer!);
             } finally {
               (ctx as any)._arrayLiteralForceVec = false;
             }
+          } else {
+            // Byte-identical to the pre-#2669 extraction (no sentinel, no default).
+            emitBoundsCheckedArrayGet(fctx, innerArrTypeIdx, innerElemType);
+            fctx.body.push({ op: "local.set", index: nestedLocal });
           }
           compileForOfDestructuring(ctx, fctx, element.name, nestedLocal, innerElemType, stmt);
           continue;

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -54,6 +54,7 @@ import {
   compileExternrefObjectDestructuringDecl,
   compileObjectDestructuring,
   emitDefaultValueCheck,
+  emitNestedBindingDefault,
   emitNullGuard,
   ensureAsyncIterator,
   ensureExternIsUndefined,
@@ -1718,8 +1719,30 @@ function compileForOfDestructuring(
             fieldIdx: 1,
           });
           fctx.body.push({ op: "i32.const", value: i });
-          emitBoundsCheckedArrayGet(fctx, innerArrTypeIdx, innerElemType);
+          // (#2669) When the nested element has a default (`[[x,y,z]=[4,5,6]]`),
+          // the OOB else-branch must yield JS `undefined` (not wasm-null) for an
+          // externref source so `emitNestedBindingDefault`'s
+          // `__extern_is_undefined` check fires the initializer. For a typed
+          // (f64/ref) source the existing sentinel/null check already fires.
+          const nestedWantsUndef =
+            element.initializer !== undefined &&
+            (innerElemType.kind === "externref" || innerElemType.kind === "ref_extern");
+          emitBoundsCheckedArrayGet(fctx, innerArrTypeIdx, innerElemType, ctx, nestedWantsUndef);
           fctx.body.push({ op: "local.set", index: nestedLocal });
+          // (#2669) Apply the nested element's default initializer BEFORE recursing
+          // into the sub-pattern — otherwise a short/empty source left `nestedLocal`
+          // null/undefined and the recursive destructure threw
+          // "Cannot destructure 'null' or 'undefined'"
+          // (`for (const [[x,y,z]=[4,5,6]] of [[]])`). Mirrors the
+          // `destructureParamArray` nested-default path.
+          if (element.initializer) {
+            (ctx as any)._arrayLiteralForceVec = true;
+            try {
+              emitNestedBindingDefault(ctx, fctx, nestedLocal, innerElemType, element.initializer);
+            } finally {
+              (ctx as any)._arrayLiteralForceVec = false;
+            }
+          }
           compileForOfDestructuring(ctx, fctx, element.name, nestedLocal, innerElemType, stmt);
           continue;
         }
@@ -1820,14 +1843,24 @@ function compileForOfDestructuring(
           (innerElemType.kind === "externref" || innerElemType.kind === "ref_extern");
         emitBoundsCheckedArrayGet(fctx, innerArrTypeIdx, innerElemType, ctx, wantUndefinedSentinel);
 
-        if (!valTypesMatch(innerElemType, bindingWasmType)) {
-          coerceType(ctx, fctx, innerElemType, bindingWasmType);
-        }
-
-        if (element.initializer) {
-          emitDefaultValueCheck(ctx, fctx, bindingWasmType, localIdx, element.initializer);
+        if (element.initializer && wantUndefinedSentinel) {
+          // (#2669) Externref source element WITH a default: the OOB else-branch
+          // yields JS `undefined`, which is only detectable on the RAW externref
+          // via `__extern_is_undefined`. Coercing to the (numeric) binding type
+          // FIRST would unbox `undefined` to a plain NaN — NOT the f64 sNaN
+          // sentinel the default-check looks for — so the default never fired
+          // (`for (const [a=9] of [[]])` kept NaN). Run the check on the externref
+          // and let emitDefaultValueCheck coerce the surviving value afterwards.
+          emitDefaultValueCheck(ctx, fctx, innerElemType, localIdx, element.initializer, bindingWasmType);
         } else {
-          fctx.body.push({ op: "local.set", index: localIdx });
+          if (!valTypesMatch(innerElemType, bindingWasmType)) {
+            coerceType(ctx, fctx, innerElemType, bindingWasmType);
+          }
+          if (element.initializer) {
+            emitDefaultValueCheck(ctx, fctx, bindingWasmType, localIdx, element.initializer);
+          } else {
+            fctx.body.push({ op: "local.set", index: localIdx });
+          }
         }
       }
     }); // end null guard for for-of array destructuring

--- a/tests/issue-2669.test.ts
+++ b/tests/issue-2669.test.ts
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+/**
+ * #2669 — ES2015 destructuring correctness residual (nested-array default).
+ *
+ * Three distinct codegen defects in the array-destructuring default-init family,
+ * all surfaced by the `dstr` test262 cluster (`*-ary-ptrn-elem-ary-elem-init`,
+ * `for-of/dstr` default-init) and the umbrella's verify-first sweep:
+ *
+ *   - Bug 0 (malformed Wasm): a `ref_*` keyed vec (nested arrays/objects, e.g.
+ *     `number[][]`) lowers its backing store to `(array (mut externref))`, so its
+ *     elements are already externref. The element-conversion loop in
+ *     `destructureParamArray` (and the host-boundary `__vec_get` helper) keyed off
+ *     the `"ref_*"` STRING and emitted `extern.convert_any` — whose operand must be
+ *     an `anyref` — on an externref `array.get`. Invalid Wasm ⇒ the module failed to
+ *     instantiate (`const [[x,y,z]=[4,5,6]] = []`).
+ *   - Bug 1 (for-of identifier default never fired): a for-of element with a
+ *     default over an externref source was coerced to the (numeric) binding type
+ *     BEFORE the default check, unboxing `undefined` to a plain NaN that never
+ *     matched the f64 sNaN sentinel the check looks for (`for (const [a=9] of [[]])`
+ *     kept NaN).
+ *   - Bug 2 (for-of nested default ignored): the for-of nested-pattern branch
+ *     dropped `element.initializer` entirely, so a short/empty source left the
+ *     nested slot null and the recursive destructure threw
+ *     "Cannot destructure 'null' or 'undefined'"
+ *     (`for (const [[x,y,z]=[4,5,6]] of [[]])`).
+ *
+ * The closure-capture-box surface of this umbrella was fixed separately by #2692.
+ */
+
+async function compileAndRun(source: string): Promise<Record<string, Function>> {
+  const result = await compile(source);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as unknown as WebAssembly.Imports);
+  return instance.exports as Record<string, Function>;
+}
+
+describe("#2669 — nested-array destructuring default (Bug 0: malformed Wasm)", () => {
+  it("direct: nested array default fires when outer source is empty", async () => {
+    const e = await compileAndRun(
+      `export function test(): number { const [[x, y, z] = [4, 5, 6]]: number[][] = []; return x + y + z; }`,
+    );
+    expect(e.test!()).toBe(15);
+  });
+
+  it("direct: nested array default, single element", async () => {
+    const e = await compileAndRun(`export function test(): number { const [[x] = [4]]: number[][] = []; return x; }`);
+    expect(e.test!()).toBe(4);
+  });
+
+  it("direct: nested array default SKIPPED when element present", async () => {
+    const e = await compileAndRun(
+      `export function test(): number { const [[x, y, z] = [4, 5, 6]]: number[][] = [[1, 2, 3]]; return x + y + z; }`,
+    );
+    expect(e.test!()).toBe(6);
+  });
+
+  it("direct: nested array NO default, value present (regression guard)", async () => {
+    const e = await compileAndRun(
+      `export function test(): number { const [[x, y, z]]: number[][] = [[1, 2, 3]]; return x + y + z; }`,
+    );
+    expect(e.test!()).toBe(6);
+  });
+});
+
+describe("#2669 — for-of destructuring default (Bug 1: identifier default)", () => {
+  it("for-of simple default fires when iterated element is empty", async () => {
+    const e = await compileAndRun(
+      `export function test(): number { let s = -1; for (const [a = 9] of [[]]) { s = a; } return s; }`,
+    );
+    expect(e.test!()).toBe(9);
+  });
+
+  it("for-of simple default SKIPPED when element present (regression guard)", async () => {
+    const e = await compileAndRun(
+      `export function test(): number { let s = -1; for (const [a = 9] of [[5]]) { s = a; } return s; }`,
+    );
+    expect(e.test!()).toBe(5);
+  });
+});
+
+describe("#2669 — for-of nested destructuring default (Bug 2: nested default ignored)", () => {
+  it("for-of nested array default fires when iterated element is empty", async () => {
+    const e = await compileAndRun(
+      `export function test(): number { let s = 0; for (const [[x, y, z] = [4, 5, 6]] of [[]]) { s = x + y + z; } return s; }`,
+    );
+    expect(e.test!()).toBe(15);
+  });
+
+  it("for-of nested array default, single element", async () => {
+    const e = await compileAndRun(
+      `export function test(): number { let s = -1; for (const [[x] = [4]] of [[]]) { s = x; } return s; }`,
+    );
+    expect(e.test!()).toBe(4);
+  });
+
+  it("for-of nested array NO default, value present (regression guard)", async () => {
+    const e = await compileAndRun(
+      `export function test(): number { let s = 0; for (const [[x, y, z]] of [[[1, 2, 3]]]) { s = x + y + z; } return s; }`,
+    );
+    expect(e.test!()).toBe(6);
+  });
+});

--- a/tests/issue-2669.test.ts
+++ b/tests/issue-2669.test.ts
@@ -106,4 +106,23 @@ describe("#2669 — for-of nested destructuring default (Bug 2: nested default i
     );
     expect(e.test!()).toBe(6);
   });
+
+  // (#2669 CI-FIX) A CALL-expression nested default (capturing helper / generator
+  // / IIFE) is deliberately DEFERRED: compiling it inside the conditionally-skipped
+  // default arm materialised its capture box only on the not-taken branch and
+  // corrupted later reads of the captured variable (#2692 closure-box-lazy
+  // territory; also #2566 generator over-consumption). This regressed 15
+  // `for-await-of` elision-default tests in the merge_group floor. The deferral
+  // keeps the captured variable intact when the element is PRESENT — h() must not
+  // run AND `count` must read its real value (0), not a poisoned NaN.
+  it("for-of nested call-default does not poison a captured var when element present", async () => {
+    const e = await compileAndRun(`export function test(): number {
+      let count = 0;
+      function h(): number[] { count += 1; return [9]; }
+      let s = -1;
+      for (const [[x] = h()] of [[[5]]]) { s = x; }  // element present → x = 5, h() never runs
+      return count * 100 + s;                         // expect 0*100 + 5 = 5
+    }`);
+    expect(e.test!()).toBe(5);
+  });
 });


### PR DESCRIPTION
## #2669 — ES2015 destructuring residual umbrella (verify-first slice)

Verify-first re-sweep of the #2669 dstr cluster on current `origin/main` (post-#2692): **2 of 6 cluster samples now pass** (1 via #2692's closure-box fix, 1 via this slice). Root-caused `const-ary-ptrn-elem-ary-elem-init` to **three distinct codegen defects** in the array-destructuring *default-init* family — none of which is the closure box or an iterator-protocol gap:

1. **Malformed Wasm — `extern.convert_any` on an already-externref `array.get`.** A `ref_*` keyed vec (nested arrays/objects, e.g. `number[][]`) lowers its backing store to `(array (mut externref))` — elements are *already* externref. The element-conversion loop in `destructureParamArray` (`boxToExternref`) and the host-boundary `__vec_get` helper keyed off the `"ref_*"` STRING and emitted `extern.convert_any` (operand must be `anyref`) on the externref slot → invalid module, failed to instantiate (`const [[x,y,z]=[4,5,6]] = []`). Fix: decide boxing from the **real backing-array element kind**.
2. **for-of identifier default never fired (externref source).** Coerced to the numeric binding type before the default check, unboxing `undefined` to a plain NaN that never matched the f64 sNaN sentinel (`for (const [a=9] of [[]])` kept NaN). Fix: check the raw externref via `__extern_is_undefined` first.
3. **for-of nested-pattern default ignored.** The nested branch dropped `element.initializer` entirely → `for (const [[x,y,z]=[4,5,6]] of [[]])` threw "Cannot destructure 'null' or 'undefined'". Fix: apply `emitNestedBindingDefault` before recursing.

## Validation
- `tests/issue-2669.test.ts` — 9/9 green (Bug 0/1/2 + present-value regression guards).
- `hardError=0` across 1781 dstr test262 files (no new malformed Wasm).
- 13/14 curated fresh-process regression sample green; the 1 fail is a pre-existing in-bounds-undefined/hole assignment-dstr case on an unrelated path.

## Scope
Umbrella stays **open** — the 4 still-failing cluster samples are iterator-protocol semantics routed to **#1642** (IteratorClose) and **#2566** (generator / trailing-elision over-consumption). Typed in-bounds-undefined/hole sentinel propagation and nested-object-default are noted as follow-up carves in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)