### PR TITLE
docs(sprint-67): ES3-conformance issue slate (7 new + reactivate #1846)

### DIFF
--- a/plan/issues/1846-minor-typeof-conformance-notes.md
+++ b/plan/issues/1846-minor-typeof-conformance-notes.md
@@ -1,15 +1,15 @@
 ---
 id: 1846
 title: "Minor typeof conformance: i64->'number' in with-bindings; externref->null fallthrough"
-status: backlog
+status: ready
 created: 2026-06-04
-updated: 2026-06-04
+updated: 2026-06-26
 priority: low
 feasibility: low
 task_type: bugfix
 area: codegen
-goal: correctness
-sprint: Backlog
+goal: test262-conformance
+sprint: 67
 ---
 # #1846 — minor `typeof` conformance notes
 
@@ -25,4 +25,15 @@ ECMAScript §13.5.3 typeof table.
 ## Fix
 Add `if (kind==="i64") return "bigint"` before the f64 case; ensure the externref
 branch returns "object" (or routes to runtime) for known non-undefined objects.
+
+## Sprint 67 additions
+
+The following test262 tests are tracked as closeable under this issue (baseline 2026-06-26):
+
+- `test/language/expressions/typeof/symbol.js` — `typeof Object(Symbol())` must return `"object"` (boxed Symbol is an object); we currently return wrong value.
+- `test/language/expressions/typeof/built-in-exotic-objects-no-call.js` — `typeof Math`, `typeof JSON`, `typeof Reflect`, etc. must return `"object"`; assert fails indicating wrong return.
+- `test/language/expressions/typeof/syntax.js` — whitespace (`\t` tab character) before the typeof operand is valid; `eval("var\t...")` path fails, possibly due to whitespace normalization in our parser.
+- `test/language/expressions/typeof/bigint.js` — `typeof 1n` must return `"bigint"` (wasm_compile error: "No dependency provided for extern class BigInt") — **NOTE: blocked on #2044 (BigInt i64-brand ValType architect decision). Do NOT include this test in the closeable count for Sprint 67.** Track separately under #2044/#1644.
+
+Closeable count for Sprint 67: 3 tests (symbol, built-in-exotic-objects-no-call, syntax). `bigint.js` is explicitly deferred.
 

--- a/plan/issues/2702-instanceof-spec-correctness-hasinstance-nonobject-rhs.md
+++ b/plan/issues/2702-instanceof-spec-correctness-hasinstance-nonobject-rhs.md
@@ -1,0 +1,96 @@
+---
+id: 2702
+title: "instanceof spec correctness: non-object RHS TypeError, Symbol.hasInstance protocol, null-deref edge cases"
+status: ready
+sprint: 67
+goal: test262-conformance
+feasibility: medium
+depends_on: []
+priority: medium
+es_edition: ES2015
+language_feature: instanceof
+task_type: bug
+created: 2026-06-26
+updated: 2026-06-26
+---
+# #2702 — instanceof spec correctness: HasInstance, non-object RHS, Symbol.hasInstance
+
+## Problem
+
+The `instanceof` operator has three correctness gaps vs ECMAScript §13.10 InstanceofOperator:
+
+**(a) Non-object / non-callable RHS must throw TypeError.** When the RHS is not an object (`true instanceof true`, `x instanceof Math` where Math is not callable), or when RHS is an object but not callable and has no `Symbol.hasInstance`, the spec mandates a TypeError. We currently produce wrong results or throw the wrong error type.
+
+**(b) `Symbol.hasInstance` well-known method protocol is not implemented.** If the RHS has a callable `@@hasInstance` property, §13.10.2 step 2 requires calling it and returning ToBoolean of the result. We currently ignore `Symbol.hasInstance` entirely, so `symbol-hasinstance-invocation`, `symbol-hasinstance-to-boolean`, `symbol-hasinstance-not-callable`, and `symbol-hasinstance-get-err` all fail.
+
+**(c) null/undefined LHS or prototype-getter edge cases.** `Cannot access property on null or undefined` in `S15.3.5.3_A3_T1/T2`, `S15.3.5.3_A2_T5`, `S11.8.6_A7_T3` indicates a null-deref when walking the prototype chain. `prototype-getter-with-object` / `prototype-getter-with-object-throws` assert that a getter on `Symbol.hasInstance` or `.prototype` is called correctly.
+
+Spec: ECMAScript §13.10 — Relational Operators — Runtime Semantics, InstanceofOperator steps 1–7.
+
+Note: #1325 (a perf optimization using a built-in type-tag registry to avoid the host) is a separate optimization concern, NOT this correctness fix.
+
+## Failing tests (test262 baseline 2026-06-26)
+
+```
+test/language/expressions/instanceof/symbol-hasinstance-not-callable.js
+test/language/expressions/instanceof/S15.3.5.3_A2_T6.js
+test/language/expressions/instanceof/S15.3.5.3_A2_T2.js
+test/language/expressions/instanceof/S11.8.6_A2.4_T1.js
+test/language/expressions/instanceof/S11.8.6_A3.js
+test/language/expressions/instanceof/symbol-hasinstance-get-err.js
+test/language/expressions/instanceof/S11.8.6_A6_T1.js
+test/language/expressions/instanceof/S11.8.6_A6_T2.js
+test/language/expressions/instanceof/S11.8.6_A2.1_T3.js
+test/language/expressions/instanceof/S15.3.5.3_A3_T1.js
+test/language/expressions/instanceof/S15.3.5.3_A2_T5.js
+test/language/expressions/instanceof/prototype-getter-with-object-throws.js
+test/language/expressions/instanceof/S11.8.6_A6_T4.js
+test/language/expressions/instanceof/S11.8.6_A2.4_T4.js
+test/language/expressions/instanceof/primitive-prototype-with-object.js
+test/language/expressions/instanceof/prototype-getter-with-object.js
+test/language/expressions/instanceof/symbol-hasinstance-to-boolean.js
+test/language/expressions/instanceof/S15.3.5.3_A3_T2.js
+test/language/expressions/instanceof/symbol-hasinstance-invocation.js
+test/language/expressions/instanceof/S11.8.6_A7_T3.js
+```
+
+### Sub-groups
+
+**Non-callable / non-object RHS TypeError (~8 tests)**
+- `S11.8.6_A3.js` — `true instanceof true` must throw TypeError
+- `S11.8.6_A6_T1.js`, `S11.8.6_A6_T2.js`, `S11.8.6_A6_T4.js` — `x instanceof Math` must throw TypeError (not callable, no HasInstance)
+- `S15.3.5.3_A2_T2.js`, `S15.3.5.3_A2_T5.js`, `S15.3.5.3_A2_T6.js` — RHS not an object → TypeError
+- `S11.8.6_A2.1_T3.js` — wrong throw type (ReferenceError instead of expected result)
+
+**Symbol.hasInstance protocol (~4 tests)**
+- `symbol-hasinstance-invocation.js` — `@@hasInstance` must be called; `callCount` assert
+- `symbol-hasinstance-to-boolean.js` — result must be ToBoolean of `@@hasInstance` return
+- `symbol-hasinstance-not-callable.js` — non-callable `@@hasInstance` must throw TypeError
+- `symbol-hasinstance-get-err.js` — getter on `@@hasInstance` that throws must propagate
+
+**Null/undefined prototype-chain deref (~5 tests)**
+- `S15.3.5.3_A3_T1.js`, `S15.3.5.3_A3_T2.js`, `S11.8.6_A7_T3.js` — null deref during prototype walk
+- `prototype-getter-with-object.js`, `prototype-getter-with-object-throws.js` — `.prototype` getter invoked correctly
+
+**Other correctness (~3 tests)**
+- `S11.8.6_A2.4_T1.js`, `S11.8.6_A2.4_T4.js` — `(OBJECT = Object, {}) instanceof OBJECT` side-effect ordering
+- `primitive-prototype-with-object.js` — RHS has primitive `.prototype` → TypeError
+
+## Root cause (suspected)
+
+The `instanceof` codegen in `src/codegen/expressions.ts` (BinaryExpression handler for `instanceof`) likely:
+1. Only checks the nominal WasmGC type path and falls through on non-callable RHS without throwing.
+2. Never consults `Symbol.hasInstance` on the RHS — the @@hasInstance lookup is absent.
+3. The prototype walk does not guard against `null` returns from `Object.getPrototypeOf`, causing null-deref traps.
+
+The fix requires implementing the full §13.10.2 InstanceofOperator algorithm: check `Symbol.hasInstance` first; if absent, check OrdinaryHasInstance; in OrdinaryHasInstance check callability and walk the prototype chain with null guards.
+
+## Acceptance criteria
+
+All 20 listed tests flip from fail to pass. No regression in `expressions/instanceof/` (currently-passing tests stay green). Full CI green.
+
+## Notes
+
+- Related: #1325 (optimization, perf — do NOT conflate with this correctness fix).
+- The `S11.8.6_A2.4_T*` side-effect-ordering tests may share a root cause with the null-deref tests (prototype getter called before object check).
+- If `Symbol.hasInstance` implementation requires broader WellKnownSymbol support changes, note them in the PR but keep this issue focused on `instanceof` correctness only.

--- a/plan/issues/2703-delete-reference-semantics-strict-throw-invalid-base.md
+++ b/plan/issues/2703-delete-reference-semantics-strict-throw-invalid-base.md
@@ -1,0 +1,100 @@
+---
+id: 2703
+title: "delete reference semantics: strict-mode TypeError throws, null/undefined base TypeError, super-property ReferenceError"
+status: ready
+sprint: 67
+goal: test262-conformance
+feasibility: medium
+depends_on: []
+priority: medium
+es_edition: ES5
+language_feature: delete
+task_type: bug
+created: 2026-06-26
+updated: 2026-06-26
+---
+# #2703 — delete reference semantics: strict-mode throws, null base, super property
+
+## Problem
+
+The `delete` operator has multiple gaps in its throw-on-error semantics vs ECMAScript §13.5.1:
+
+**(a) Strict mode: deleting a non-configurable property or an unqualified identifier must throw TypeError.** Tests like `11.4.1-4.a-9-s.js`, `11.4.4-4.a-3-s.js`, `11.4.1-4-a-4-s.js`, `delete Math.LN2` (non-configurable) — we return `false` instead of throwing.
+
+**(b) `delete base.x` / `delete base[k]` where base is null or undefined must throw TypeError.** `member-computed-reference-null.js`, `member-identifier-reference-null.js`, `member-computed-reference-undefined.js`, `member-identifier-reference-undefined.js`, `delete-unresolvable-base-object-reference-throws-typeerror.js` all assert a TypeError we currently skip.
+
+**(c) `delete super.prop` must throw ReferenceError.** `super-property.js`, `super-property-method.js`, `super-property-null-base.js`, `super-property-uninitialized-this.js` — deleting a super property is always a ReferenceError per spec §13.5.1 step 5.f.i.
+
+**(d) Sloppy-mode: `delete x` of a `var`/function-level variable returns false; `delete` of a deletable global returns true.** `S11.4.1_A2.2_T1.js` (delete x === true for a deletable global), `S11.4.1_A3.1.js` (delete this.y === false), `S11.4.1_A3.2_T1.js`, `S11.4.1_A3.3_T1.js`, `S11.4.1_A3.3_T6.js`, `11.4.1-3-1.js`, `11.4.1-4.a-1.js`, `11.4.1-4.a-2.js`, `11.4.1-4.a-8.js`, `11.4.1-4.a-17.js`, `S8.12.7_A2_T2.js`.
+
+Spec: ECMAScript §13.5.1 — The `delete` Operator; §7.2.9 OrdinaryDelete; §9.1.10 ordinary [[Delete]].
+
+Note: #124 is `wont-fix` (old/superseded); #1112 (undefined-sentinel happy path for `delete`) is done — this issue targets the throw/edge semantics layered on top of that foundation.
+
+## Failing tests (test262 baseline 2026-06-26)
+
+```
+test/language/expressions/delete/S11.4.1_A3.1.js
+test/language/expressions/delete/11.4.1-4.a-9-s.js
+test/language/expressions/delete/super-property-null-base.js
+test/language/expressions/delete/super-property-method.js
+test/language/expressions/delete/11.4.1-4-a-4-s.js
+test/language/expressions/delete/S11.4.1_A3.2_T1.js
+test/language/expressions/delete/11.4.1-4.a-2.js
+test/language/expressions/delete/member-computed-reference-null.js
+test/language/expressions/delete/member-identifier-reference-undefined.js
+test/language/expressions/delete/11.4.1-4-a-2-s.js
+test/language/expressions/delete/S11.4.1_A3.3_T1.js
+test/language/expressions/delete/11.4.4-4.a-3-s.js
+test/language/expressions/delete/S11.4.1_A2.2_T1.js
+test/language/expressions/delete/member-identifier-reference-null.js
+test/language/expressions/delete/S8.12.7_A2_T2.js
+test/language/expressions/delete/S11.4.1_A3.3_T6.js
+test/language/expressions/delete/11.4.1-4.a-8.js
+test/language/expressions/delete/11.4.1-4.a-3-s.js
+test/language/expressions/delete/delete-unresolvable-base-object-reference-throws-typeerror.js
+test/language/expressions/delete/11.4.1-4.a-17.js
+test/language/expressions/delete/11.4.1-4-a-1-s.js
+test/language/expressions/delete/11.4.1-4.a-8-s.js
+test/language/expressions/delete/11.4.1-3-1.js
+test/language/expressions/delete/11.4.1-5-a-27-s.js
+test/language/expressions/delete/11.4.1-4.a-1.js
+test/language/expressions/delete/super-property.js
+test/language/expressions/delete/member-computed-reference-undefined.js
+test/language/expressions/delete/super-property-uninitialized-this.js
+```
+
+### Sub-groups
+
+**Strict-mode non-configurable property TypeError (~10 tests)**
+- `11.4.1-4.a-9-s.js`, `11.4.1-4-a-4-s.js`, `11.4.1-4-a-2-s.js`, `11.4.1-4.a-3-s.js`, `11.4.1-4-a-1-s.js`, `11.4.1-4.a-8-s.js`, `11.4.4-4.a-3-s.js`, `11.4.1-5-a-27-s.js`
+
+**Null/undefined base TypeError (~4 tests)**
+- `member-computed-reference-null.js`, `member-identifier-reference-null.js`
+- `member-computed-reference-undefined.js`, `member-identifier-reference-undefined.js`
+- `delete-unresolvable-base-object-reference-throws-typeerror.js`
+
+**super property ReferenceError (~4 tests)**
+- `super-property.js`, `super-property-method.js`, `super-property-null-base.js`, `super-property-uninitialized-this.js`
+
+**Sloppy-mode return value semantics (~10 tests)**
+- `S11.4.1_A2.2_T1.js`, `S11.4.1_A3.1.js`, `S11.4.1_A3.2_T1.js`, `S11.4.1_A3.3_T1.js`, `S11.4.1_A3.3_T6.js`
+- `11.4.1-3-1.js`, `11.4.1-4.a-1.js`, `11.4.1-4.a-2.js`, `11.4.1-4.a-8.js`, `11.4.1-4.a-17.js`, `S8.12.7_A2_T2.js`
+
+## Root cause (suspected)
+
+The `delete` codegen in `src/codegen/expressions.ts` (UnaryExpression `delete`) handles the basic "delete configurable own property" case but:
+1. Does not check strict mode before returning `false` for non-configurable deletes — should throw TypeError instead.
+2. Does not guard against null/undefined base before doing a property lookup — null-deref.
+3. Does not reject `super` property delete — needs a compile-time or runtime ReferenceError path.
+4. Sloppy-mode `delete varIdentifier` return value may be wrong (always returning `true`/`false` without checking environment record configurability).
+
+## Acceptance criteria
+
+All 28 listed tests flip from fail to pass. No regression in `expressions/delete/` (currently-passing tests stay green). Full CI green.
+
+## Notes
+
+- Strict-mode detection: the codegen already has access to `ctx.isStrict` or similar — use it to switch behavior at the delete site.
+- Super-property: can be caught at compile time (the AST `delete super.x` node is identifiable) and lowered to an unconditional `throw new ReferenceError(...)`.
+- Sloppy-mode global-delete requires access to the property descriptor of the global object — may need a host import or a __has_own_configurable runtime helper.

--- a/plan/issues/2704-arguments-length-trailing-comma-and-sloppy-binding.md
+++ b/plan/issues/2704-arguments-length-trailing-comma-and-sloppy-binding.md
@@ -1,0 +1,90 @@
+---
+id: 2704
+title: "arguments.length off-by-N with trailing comma in async-gen/static methods; sloppy-mode arguments binding missing"
+status: ready
+sprint: 67
+goal: test262-conformance
+feasibility: medium
+depends_on: []
+priority: high
+es_edition: multi
+language_feature: arguments-object
+task_type: bug
+created: 2026-06-26
+updated: 2026-06-26
+---
+# #2704 — arguments: trailing-comma length bug (async-gen/static), sloppy binding missing
+
+## Problem
+
+Two distinct sub-bugs in `arguments` handling:
+
+**(a) `arguments.length` wrong (off by N) when a call has a trailing comma in async-generator / async-generator static / class-expression async-gen forms.** `#1053` fixed trailing-comma for plain class methods; the fix was not propagated to async-generator methods, static async-generator methods, and class-expression variants. All `*-args-trailing-comma-*` tests for those forms report wrong `arguments.length`.
+
+**(b) Sloppy-mode `arguments` object is missing in some function forms.** `S10.6_A2.js`, `S10.6_A3_T1.js`, `S10.6_A3_T4.js`, `S10.6_A4.js`, `S10.6_A5_T1.js`, `S10.6_A5_T3.js`, `S10.6_A5_T4.js` — these assert the implicit `arguments` binding exists in sloppy-mode functions/constructors; we emit "arguments object doesn't exist" / "arguments doesn't exist", indicating the binding is absent for those function forms.
+
+EXCLUDED from this issue (tracked elsewhere):
+- **Mapped arguments exotic descriptor tests** (`mapped/mapped-arguments-nonconfigurable-strict-delete-*`, `mapped/enumerable-configurable-accessor-descriptor.js`, `mapped/nonconfigurable-descriptors-define-failure.js`, `mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-define-property.js`, `mapped/writable-enumerable-configurable-descriptor.js`) → those belong to **#1726** (mapped arguments exotic §10.4.4, already `ready`).
+- `mapped/Symbol.iterator.js` and `unmapped/Symbol.iterator.js` — "Cannot convert a Symbol value to a number" → separate Symbol iterator bug.
+
+Spec: ECMAScript §10.4.4 CreateMappedArgumentsObject / CreateUnmappedArgumentsObject; trailing-comma parsing §13.3.8 (ArgumentsList grammar).
+
+## Failing tests (test262 baseline 2026-06-26)
+
+### (a) Trailing-comma async-gen / static (~25 tests)
+
+```
+test/language/arguments-object/async-gen-meth-args-trailing-comma-undefined.js
+test/language/arguments-object/async-gen-meth-args-trailing-comma-null.js
+test/language/arguments-object/async-gen-meth-args-trailing-comma-multiple.js
+test/language/arguments-object/async-gen-meth-args-trailing-comma-spread-operator.js
+test/language/arguments-object/async-gen-meth-args-trailing-comma-single-args.js
+test/language/arguments-object/cls-decl-async-gen-meth-args-trailing-comma-spread-operator.js
+test/language/arguments-object/cls-decl-async-gen-meth-static-args-trailing-comma-single-args.js
+test/language/arguments-object/cls-decl-async-gen-meth-args-trailing-comma-null.js
+test/language/arguments-object/cls-decl-async-gen-meth-args-trailing-comma-multiple.js
+test/language/arguments-object/cls-decl-async-gen-meth-static-args-trailing-comma-null.js
+test/language/arguments-object/cls-decl-async-gen-meth-args-trailing-comma-single-args.js
+test/language/arguments-object/cls-decl-async-gen-meth-static-args-trailing-comma-spread-operator.js
+test/language/arguments-object/cls-decl-async-gen-meth-args-trailing-comma-undefined.js
+test/language/arguments-object/cls-decl-async-gen-meth-static-args-trailing-comma-undefined.js
+test/language/arguments-object/cls-decl-async-gen-meth-static-args-trailing-comma-multiple.js
+test/language/arguments-object/cls-expr-async-gen-meth-args-trailing-comma-undefined.js
+test/language/arguments-object/cls-expr-async-gen-meth-args-trailing-comma-single-args.js
+test/language/arguments-object/cls-expr-async-gen-meth-static-args-trailing-comma-multiple.js
+test/language/arguments-object/cls-expr-async-gen-meth-args-trailing-comma-null.js
+test/language/arguments-object/cls-expr-async-gen-meth-args-trailing-comma-spread-operator.js
+test/language/arguments-object/cls-expr-async-gen-meth-args-trailing-comma-multiple.js
+test/language/arguments-object/cls-expr-async-gen-meth-static-args-trailing-comma-null.js
+test/language/arguments-object/cls-expr-async-gen-meth-static-args-trailing-comma-single-args.js
+test/language/arguments-object/cls-expr-async-gen-meth-static-args-trailing-comma-spread-operator.js
+test/language/arguments-object/cls-expr-async-gen-meth-static-args-trailing-comma-undefined.js
+```
+
+### (b) Sloppy-mode arguments binding missing (~7 tests)
+
+```
+test/language/arguments-object/S10.6_A2.js
+test/language/arguments-object/S10.6_A3_T1.js
+test/language/arguments-object/S10.6_A3_T4.js
+test/language/arguments-object/S10.6_A4.js
+test/language/arguments-object/S10.6_A5_T1.js
+test/language/arguments-object/S10.6_A5_T3.js
+test/language/arguments-object/S10.6_A5_T4.js
+```
+
+## Root cause (suspected)
+
+**(a)** The trailing-comma fix from #1053 normalizes argument count in the parser/AST before passing to codegen. That normalization was applied to plain method AST nodes but likely not to `AsyncGenerator*` function kinds or their static variants. The fix should extend the same trailing-comma stripping logic to cover: `AsyncGeneratorMethod`, `AsyncGeneratorDeclaration`, `AsyncGeneratorExpression`, and their static class counterparts.
+
+**(b)** The `arguments` binding creation in `src/codegen/index.ts` (function prologue) is gated on function kind. Sloppy-mode functions should always create an `arguments` binding unless they are arrow functions, but some function kinds (possibly certain generator or constructor variants) are being skipped.
+
+## Acceptance criteria
+
+At least 30 of the 32 listed tests flip from fail to pass (trailing comma: 25, sloppy binding: 7; deduct at most 2 for any that turn out to have a separate dependency). No regression in `arguments-object/` currently-passing tests. Full CI green.
+
+## Notes
+
+- Reference: #1053 (the original plain-method trailing-comma fix) — read that PR diff first to understand the normalization site.
+- Mapped arguments exotic tests → #1726. Do NOT attempt to fix mapped-argument descriptor semantics in this issue.
+- `unmapped/via-params-rest.js` (wasm_compile error) and `10.6-6-3.js`, `10.6-6-4.js` (illegal_cast) are NOT included in the closeable count here; they may require separate investigation.

--- a/plan/issues/2705-for-in-head-lexical-scope-tdz-and-lhs-targets.md
+++ b/plan/issues/2705-for-in-head-lexical-scope-tdz-and-lhs-targets.md
@@ -1,0 +1,92 @@
+---
+id: 2705
+title: "for-in: head let/const TDZ, lexical scope open/close, LHS non-simple targets, var-head visibility"
+status: ready
+sprint: 67
+goal: test262-conformance
+feasibility: hard
+depends_on: []
+priority: high
+es_edition: ES2015
+language_feature: for-in
+task_type: bug
+created: 2026-06-26
+updated: 2026-06-26
+---
+# #2705 — for-in head lexical scope, TDZ, LHS targets, var visibility
+
+## Problem
+
+The `for (... in ...)` statement has multiple scoping and LHS-target gaps vs ECMAScript §14.7.5:
+
+**(a) Per-iteration lexical binding + TDZ.** `for (let x in obj)` and `for (const x in obj)` must create a fresh lexical binding each iteration with a TDZ entry at the top of each iteration body. Accessing `x` before the binding is initialized should throw a ReferenceError. Tests: `head-let-bound-names-fordecl-tdz`, `head-const-bound-names-fordecl-tdz`, `scope-head-lex-open`, `scope-head-lex-close`, `scope-body-lex-open`, `scope-body-lex-close`.
+
+**(b) LHS that is NOT a simple declaration or plain identifier.** `head-lhs-cover` ("for-in requires a variable declaration or identifier" — the LHS is a CoverParenthesizedExpression/ObjectPattern not yet handled), `head-lhs-let` / `identifier-let-allowed-as-lefthandside-expression-not-strict` ("Cannot read properties of undefined (reading 'name')" — the parser/compiler tries to access `.name` on an undefined node when `let` appears as a plain LHS identifier in non-strict mode). `let-identifier-with-newline` (invalid Wasm binary — line-terminator between `for` and `(let` causing a bad parse path).
+
+**(c) `var`-declared head variable not visible in body or after loop.** `S12.6.4_A3.js`, `S12.6.4_A4.js`, `S12.6.4_A4.1.js`, `S12.6.4_A3.1.js` ("__str is not defined" in both the loop body and after the loop) and `scope-head-var-none.js`, `scope-body-var-none.js` (null_deref) — the `var x` in `for (var x in obj)` is not being hoisted into the enclosing function scope properly, or the code-generated iteration variable has the wrong wasm local slot.
+
+Spec: ECMAScript §14.7.5 (The `for-in` Statement), §14.7.5.6 ForIn/OfHeadEvaluation, §14.7.5.7 ForIn/OfBodyEvaluation.
+
+## Failing tests (test262 baseline 2026-06-26)
+
+### (a) let/const TDZ + lexical scope open/close (~6 tests)
+
+```
+test/language/statements/for-in/head-let-bound-names-fordecl-tdz.js
+test/language/statements/for-in/head-const-bound-names-fordecl-tdz.js
+test/language/statements/for-in/scope-head-lex-open.js
+test/language/statements/for-in/scope-head-lex-close.js
+test/language/statements/for-in/scope-body-lex-open.js
+test/language/statements/for-in/scope-body-lex-close.js
+```
+
+### (b) LHS non-simple targets (~3 tests)
+
+```
+test/language/statements/for-in/head-lhs-cover.js
+test/language/statements/for-in/head-lhs-let.js
+test/language/statements/for-in/identifier-let-allowed-as-lefthandside-expression-not-strict.js
+test/language/statements/for-in/let-identifier-with-newline.js
+```
+
+### (c) var-head visibility in body/after (~6 tests)
+
+```
+test/language/statements/for-in/S12.6.4_A3.js
+test/language/statements/for-in/S12.6.4_A4.js
+test/language/statements/for-in/S12.6.4_A4.1.js
+test/language/statements/for-in/S12.6.4_A3.1.js
+test/language/statements/for-in/scope-head-var-none.js
+test/language/statements/for-in/scope-body-var-none.js
+test/language/statements/for-in/head-var-bound-names-in-stmt.js
+```
+
+### Additional related tests in this cluster (~3 tests)
+
+```
+test/language/statements/for-in/nonstrict-initializer.js
+test/annexB/language/statements/for-in/nonstrict-initializer.js
+test/language/statements/for-in/resizable-buffer.js
+```
+
+Note: `cptn-expr-itr.js`, `cptn-decl-abrupt-empty.js`, `cptn-decl-itr.js`, `cptn-expr-abrupt-empty.js` use `eval()` — deferred (eval is skip-filtered).
+
+## Root cause (suspected)
+
+**(a)** The for-in codegen in `src/codegen/statements.ts` (ForInStatement handler) likely emits the loop binding as a single outer let rather than creating a fresh per-iteration scope. The TDZ guard (ref.is_null + throw) is absent. Fix: wrap each iteration body in a new inner scope where the binding is initialized (see `ForIn/OfBodyEvaluation` step 6.c.iii — CreatePerIterationEnvironment equivalent).
+
+**(b)** The parser/codegen has a special case for `let` as a non-reserved word that appears as a plain identifier in LHS position (non-strict mode). The name resolution path calls `.name` on a node that is `undefined` — needs a guard. `head-lhs-cover` requires recognizing destructuring patterns in for-in heads.
+
+**(c)** The `var` binding in `for (var x in obj)` head is not being added to the enclosing function's variable scope during hoisting, so `x` is local to the loop block and not visible outside. The fix is to ensure `var` in a for-in head is declared at function scope.
+
+This is marked `feasibility: hard` because (a) requires per-iteration environment creation which is a structural change to how the for-in loop is lowered, and (b) requires understanding `let`-as-identifier ambiguity in the grammar.
+
+## Acceptance criteria
+
+At least 18 of the 20 closeable listed tests (excluding eval-based and resizable-buffer) flip from fail to pass. No regression in `statements/for-in/` currently-passing tests. Full CI green.
+
+## Notes
+
+- The architect should spec the per-iteration scope mechanism carefully — particularly how the wasm locals for the binding are cloned per iteration without an allocation.
+- See also #2706 (for-in enumeration order — a separate issue on the enumeration algorithm, not scoping).
+- `resizable-buffer.js` ("ctors is not defined") is TypedArray-related and out of scope for this issue.

--- a/plan/issues/2706-for-in-enumeration-order-and-prototype-keys.md
+++ b/plan/issues/2706-for-in-enumeration-order-and-prototype-keys.md
@@ -1,0 +1,61 @@
+---
+id: 2706
+title: "for-in enumeration order: integer-index keys ascending, insertion-order strings, prototype-chain dedup"
+status: ready
+sprint: 67
+goal: test262-conformance
+feasibility: medium
+depends_on: []
+priority: medium
+es_edition: ES5
+language_feature: for-in
+task_type: bug
+created: 2026-06-26
+updated: 2026-06-26
+---
+# #2706 — for-in enumeration order: numeric-first, insertion-order strings, prototype chain
+
+## Problem
+
+The `for-in` statement does not enumerate object keys in the order required by ECMAScript §13.7.5.15 EnumerateObjectProperties:
+
+**(a) Integer-indexed keys must come first in ascending numeric order, then remaining string keys in property-creation (insertion) order.** `order-simple-object.js` creates an object with properties `b`, `a`, `1`, `2` and expects the for-in output to be `["1", "2", "b", "a"]` — integer indices ascending, then strings in insertion order. We currently emit them in a different order.
+
+**(b) Prototype chain keys: inherited enumerable properties must appear after all own properties, with shadowed/already-visited keys skipped.** `order-property-on-prototype.js` and `S12.6.4_A6.js` / `S12.6.4_A6.1.js` check that properties from the prototype appear after own properties and that shadowed ones are not repeated.
+
+**(c) Properties added via `Object.defineProperty` after object creation must appear in the right position.** `order-after-define-property.js` checks that a property added with `defineProperty` (non-numeric, non-creation-order) still follows the integer-index-first rule.
+
+Spec: ECMAScript §13.7.5.15 EnumerateObjectProperties abstract operation — note the spec deliberately leaves ordering partially unspecified for non-integer-index string keys, but test262 validates the most common conforming ordering (integer indices first, then insertion order, then prototype chain).
+
+## Failing tests (test262 baseline 2026-06-26)
+
+```
+test/language/statements/for-in/order-simple-object.js
+test/language/statements/for-in/order-property-on-prototype.js
+test/language/statements/for-in/order-after-define-property.js
+test/language/statements/for-in/S12.6.4_A6.js
+test/language/statements/for-in/S12.6.4_A6.1.js
+```
+
+## Root cause (suspected)
+
+The for-in enumeration in the runtime (likely a host import or the `__for_in_keys` helper) returns property keys in an arbitrary iteration order (probably whatever JS engine order the host's `Object.keys`/`for...in` gives). It may not:
+1. Sort integer-indexed own properties numerically before string own properties.
+2. Walk and deduplicate the prototype chain.
+3. Preserve insertion order for string keys after the numeric sort.
+
+The fix likely requires either:
+- Implementing EnumerateObjectProperties in the Wasm runtime helper (sort integers, preserve insertion, walk proto chain, track seen set), or
+- If using a JS host import, ensuring the host-side `__for_in_keys` helper returns keys in the correct canonical order.
+
+Standalone mode must also implement this without relying on JS engine for-in ordering.
+
+## Acceptance criteria
+
+All 5 listed tests flip from fail to pass. No regression in `statements/for-in/` currently-passing tests. Full CI green.
+
+## Notes
+
+- Keep separate from #2705 (for-in lexical scoping — different code path: enumeration key generation vs head/body scoping).
+- The ordering requirement is "implementation-defined for string keys" per strict spec reading, but test262 validates the de-facto standard: integer-index ascending, then insertion order, then prototype chain without duplicates. Conforming implementations all follow this pattern.
+- If the `__for_in_keys` helper is shared between `for-in` and `for-of` on objects, changes here must not regress `for-of` enumeration.

--- a/plan/issues/2707-operators-unary-nullish-strict-eq-tco.md
+++ b/plan/issues/2707-operators-unary-nullish-strict-eq-tco.md
@@ -1,0 +1,96 @@
+---
+id: 2707
+title: "operators: unary +/-/~/>>> null-deref on null/undefined; strict-equals # edge; TCO in ?:/&&/||"
+status: ready
+sprint: 67
+goal: test262-conformance
+feasibility: medium
+depends_on: []
+priority: medium
+es_edition: ES3
+language_feature: operators
+task_type: bug
+created: 2026-06-26
+updated: 2026-06-26
+---
+# #2707 — operators: unary null-deref on nullish, strict-equals edge, TCO through conditional/logical
+
+## Problem
+
+Three sub-bugs in operator codegen (BigInt and `with`-statement tests are excluded):
+
+**(a) Unary `+` / `-` / `~` / `>>>` on null or undefined operands causes a null pointer dereference instead of coercing via ToNumber.** Per spec: `ToNumber(undefined) = NaN`, `ToNumber(null) = 0`. Tests `S11.4.6_A2.2_T1.js` (+null), `S11.4.7_A2.2_T1.js` (-null), `S11.4.8_A2.2_T1.js` (~null), `S9.6_A3.1_T4.js` (>>>null), `S9.5_A3.1_T4.js` (~undefined) all crash with "dereferencing a null pointer".
+
+**(b) `strict-equals` / `strict-does-not-equals` edge: `false !== #`.** `S11.9.4_A8_T3.js`, `S11.9.4_A8_T2.js`, `S11.9.4_A8_T1.js`, `S11.9.5_A8_T3.js`, `S11.9.5_A8_T2.js`, `S11.9.5_A8_T1.js` — the `#` is a wasm function reference, and `false !== <funcref>` should be `true` (they are of different types) but our strict-equals emits incorrect results for the function-reference vs boolean case.
+
+**(c) Tail-call optimization is not recognized in `?:` / `&&` / `||` tail positions.** `conditional/tco-cond.js`, `conditional/tco-pos.js`, `logical-and/tco-right.js`, `logical-or/tco-right.js` — these set a `callCount` and assert it equals 1 (the function calls itself recursively but TCO should prevent stack growth). The `return_call` opcode is not being emitted for tail calls in the consequent/alternate of `?:` or the RHS of `&&`/`||`.
+
+**Excluded (not in this issue):**
+- BigInt tests (`unsigned-right-shift/bigint.js`, `bitwise-not/bigint.js`, `unary-minus/bigint.js`, etc.) → blocked on #2044 (BigInt i64-brand).
+- `with`-statement-based tests (increment/decrement `scope.x===N` where `scope` is a `with` binding) → deferred/wont-fix.
+- `emulates-undefined` annexB tests (`IsHTMLDDA`) → host-only feature, out of scope.
+- `order-of-evaluation.js` (unsigned-right-shift) and `coalesce-expr-ternary.js` — possibly independent bugs; include only if non-with and non-bigint.
+
+Spec: §7.1.4 ToNumber (null→0, undefined→NaN); §13.11 Strict Equality (===); §14.9.2 Tail Position Calls in ConditionalExpression, LogicalExpression.
+
+## Failing tests (test262 baseline 2026-06-26)
+
+### (a) Unary null-deref on nullish operands (~5 tests)
+
+```
+test/language/expressions/unary-plus/S11.4.6_A2.2_T1.js
+test/language/expressions/unary-minus/S11.4.7_A2.2_T1.js
+test/language/expressions/bitwise-not/S11.4.8_A2.2_T1.js
+test/language/expressions/unsigned-right-shift/S9.6_A3.1_T4.js
+test/language/expressions/bitwise-not/S9.5_A3.1_T4.js
+```
+
+### (b) Strict-equals # edge (~6 tests)
+
+```
+test/language/expressions/strict-equals/S11.9.4_A8_T3.js
+test/language/expressions/strict-equals/S11.9.4_A8_T2.js
+test/language/expressions/strict-equals/S11.9.4_A8_T1.js
+test/language/expressions/strict-does-not-equals/S11.9.5_A8_T3.js
+test/language/expressions/strict-does-not-equals/S11.9.5_A8_T2.js
+test/language/expressions/strict-does-not-equals/S11.9.5_A8_T1.js
+```
+
+### (c) TCO through conditional and logical operators (~4 tests)
+
+```
+test/language/expressions/conditional/tco-cond.js
+test/language/expressions/conditional/tco-pos.js
+test/language/expressions/logical-and/tco-right.js
+test/language/expressions/logical-or/tco-right.js
+```
+
+### Additional non-BigInt, non-with tests to confirm
+
+```
+test/language/expressions/unary-plus/S11.4.6_A3_T5.js
+test/language/expressions/unary-minus/S11.4.7_A3_T5.js
+test/language/expressions/unsigned-right-shift/order-of-evaluation.js
+test/language/expressions/conditional/coalesce-expr-ternary.js
+test/language/expressions/strict-does-not-equals/S11.9.5_A2.4_T2.js
+test/language/expressions/strict-equals/S11.9.4_A2.4_T2.js
+```
+
+## Root cause (suspected)
+
+**(a)** Unary operator codegen (`src/codegen/expressions.ts` UnaryExpression handler for `+`, `-`, `~`) emits a `f64.load` or externref field access on the operand before checking for null/undefined. The fix: coerce the operand first — `ToNumber(null) → f64.const 0`, `ToNumber(undefined) → f64.const NaN` — before applying the unary op. These should be handled in `coerceType` (already handles `null/undefined in f64 context: emit f64.const 0 / f64.const NaN` per CLAUDE.md).
+
+**(b)** The strict-equals fast path probably checks type tags. A function reference (`#` in the test output = wasm funcref) against `false` (boolean) should short-circuit to `false !== false` → `true`. The bug may be that a funcref is misidentified as a falsy non-object.
+
+**(c)** The TCO pass (`src/codegen/peephole.ts` or tail-call detection in `src/codegen/statements.ts`) looks for `ReturnStatement` with a `CallExpression`. In `ConditionalExpression` (`?:`) and `LogicalExpression` (`&&`, `||`), the tail call is inside a sub-expression, not directly under a `ReturnStatement`. The codegen needs to propagate the "is-tail-position" flag into conditional/logical branches.
+
+## Acceptance criteria
+
+At least 15 of the 21 listed non-BigInt, non-with tests flip from fail to pass (5 null-deref + 6 strict-equals + 4 TCO, adjusting for any that turn out to be with-based after inspection). No regression in operator tests. Full CI green.
+
+## Notes
+
+- BigInt operator tests (~8) are explicitly NOT in scope — they depend on #2044.
+- `with`-based increment/decrement tests are wont-fix (the `with` statement is skip-filtered in our test runner).
+- Postfix/prefix `11.3.x-2-3` wasm_compile errors: investigate first — include only if they are non-`with`.
+- The `S11.4.6_A3_T5.js` / `S11.4.7_A3_T5.js` tests (unary on function result) — if they fail for a different reason than null-deref, note separately.

--- a/plan/issues/2708-primitive-literal-escapes-and-putvalue-autobox.md
+++ b/plan/issues/2708-primitive-literal-escapes-and-putvalue-autobox.md
@@ -1,0 +1,101 @@
+---
+id: 2708
+title: "primitive & literal edge cases: legacy string escapes \\8/\\9/octal, regexp \\u atoms, PutValue primitive-base auto-box"
+status: ready
+sprint: 67
+goal: test262-conformance
+feasibility: medium
+depends_on: []
+priority: medium
+es_edition: multi
+language_feature: primitives
+task_type: bug
+created: 2026-06-26
+updated: 2026-06-26
+---
+# #2708 — primitive/literal: legacy escapes, regexp \\u, PutValue primitive-base auto-box
+
+## Problem
+
+Three sub-bugs in primitive and literal handling:
+
+**(a) Legacy string escape sequences `\8`, `\9`, and octal escapes in non-strict mode.** ECMAScript Annex B §12.9.4 / B.1.2: in sloppy (non-strict) mode, `\8` and `\9` are "LegacyNonOctal" escapes that decode as the literal digit character. `\nnn` octal escapes (`\0` through `\7` variants) are also permitted. We currently reject both with `"Escape sequence '\#' is not allowed"` (for `\8`/`\9`) and `"Octal escape sequences are not allowed"` (for legacy octals).
+
+**(b) Regexp literal `\u` atom escapes (non-`u` flag).** Without the `u` flag, `\uXXXX` in a regexp should be treated as a Unicode escape that matches that code point (ES5 compatible). `S7.8.5_A1.1_T1.js` (`/A/` — fails to match `A`), `S7.8.5_A2.1_T1.js` (`/aA/` — fails to match `aA`), `u-surrogate-pairs-atom-escape-decimal.js` (surrogate pair decimal escape in atom position). These compile/execute but produce wrong match results.
+
+**(c) PutValue with a primitive base auto-boxes via ToObject then silently drops the write (no throw in sloppy mode).** Per §13.15.2 PutValue step 6.b: if the base reference has a primitive value, call `ToObject(base)` and then set the property on the transient object — the assignment is a no-op (the transient object is discarded). In strict mode, step 6.a throws a TypeError. Tests `put-value-prop-base-primitive.js`, `put-value-prop-base-primitive-realm.js`, `get-value-prop-base-primitive.js`, `get-value-prop-base-primitive-realm.js`, `S8.6_A2_T2.js`, `S8.6_A3_T2.js`, `S8.6.2_A5_T1.js`–`T4.js`, `8.7.2-3-s.js`, `8.7.2-5-s.js` — these test that reading properties of primitives (auto-boxed via ToObject) works and that writing to them silently succeeds in sloppy mode (or throws in strict).
+
+**Note on deferred tests:** `mongolian-vowel-separator-eval.js` uses `eval()` → deferred. `named-groups/invalid-lone-surrogate-groupname.js` → may require regexp named-group work.
+
+Spec: §12.9.4 (String literals, legacy escapes), §13.15.2 PutValue, §7.1.18 ToObject (auto-boxing).
+
+## Failing tests (test262 baseline 2026-06-26)
+
+### (a) Legacy string escapes (~3 tests)
+
+```
+test/language/literals/string/legacy-non-octal-escape-sequence-8-non-strict.js
+test/language/literals/string/legacy-non-octal-escape-sequence-9-non-strict.js
+test/language/literals/string/legacy-octal-escape-sequence.js
+```
+
+### (b) Regexp \\u atom escapes (~3 tests)
+
+```
+test/language/literals/regexp/S7.8.5_A1.1_T1.js
+test/language/literals/regexp/S7.8.5_A2.1_T1.js
+test/language/literals/regexp/u-surrogate-pairs-atom-escape-decimal.js
+```
+
+### (c) PutValue / GetValue on primitive base (~14 tests)
+
+```
+test/language/types/reference/put-value-prop-base-primitive.js
+test/language/types/reference/put-value-prop-base-primitive-realm.js
+test/language/types/reference/get-value-prop-base-primitive.js
+test/language/types/reference/get-value-prop-base-primitive-realm.js
+test/language/types/object/S8.6_A2_T2.js
+test/language/types/object/S8.6_A3_T2.js
+test/language/types/object/S8.6.2_A5_T1.js
+test/language/types/object/S8.6.2_A5_T2.js
+test/language/types/object/S8.6.2_A5_T3.js
+test/language/types/object/S8.6.2_A5_T4.js
+test/language/types/reference/8.7.2-3-s.js
+test/language/types/reference/8.7.2-5-s.js
+test/language/types/reference/8.7.2-1-s.js
+test/language/types/reference/8.7.2-7-s.js
+test/language/types/reference/8.7.2-3-a-1gs.js
+```
+
+### Additional in cluster (confirm root cause before including)
+
+```
+test/language/types/object/S8.6_A4_T1.js
+test/language/types/object/S8.6.2_A1.js
+test/language/types/object/S8.6.2_A8.js
+test/language/types/reference/S8.7_A5_T1.js
+test/language/types/reference/S8.7_A5_T2.js
+test/language/types/reference/S8.7.2_A3.js
+test/language/types/undefined/S8.1_A5.js
+test/language/types/undefined/S8.1_A2_T2.js
+test/language/literals/numeric/7.8.3-3gs.js
+```
+
+## Root cause (suspected)
+
+**(a)** The TypeScript parser rejects `\8`, `\9` and octal sequences in string literals unconditionally. The fix: when `ctx.isStrict === false`, allow legacy non-octal escapes (`\8`, `\9` → the digit) and octal escapes (`\0nn` → codepoint). The restriction should only be enforced in strict mode.
+
+**(b)** The regexp compiler (`src/codegen/` regexp path) may be treating `\uXXXX` in the absence of the `u` flag differently from a spec-compliant Unicode escape. In non-`u` mode the `\u` atom escape should decode to a single character via `String.fromCharCode`. If we are passing the pattern verbatim to a JS `RegExp` constructor, this may already work; if we are compiling the regexp ourselves, verify the `\u` handling.
+
+**(c)** Member expression assignment (left-hand side) in codegen: when the base is a primitive (string, number, boolean), the spec calls for ToObject boxing. In sloppy mode the transient object is silently discarded; in strict mode a TypeError is thrown. We likely crash with a null-deref or misrouted type cast when attempting to write to a primitive base. The fix: detect primitive base in MemberExpression assignment, create a transient ToObject for the set, then discard in sloppy mode / throw in strict.
+
+## Acceptance criteria
+
+At least 18 of the 32 listed tests flip from fail to pass (3 string escape + 3 regexp + at least 12 of the PutValue/reference tests). No regression in `literals/` or `types/reference/`. Full CI green.
+
+## Notes
+
+- Sub-bugs (a), (b), (c) are independent enough that a dev may tackle them in separate commits within the same PR, or split into sub-PRs if the scope grows.
+- `mongolian-vowel-separator-eval.js` is excluded (eval-deferred).
+- `named-groups/invalid-lone-surrogate-groupname.js` — investigate; if it requires named-group regexp work beyond unicode escapes, exclude from this issue.
+- `S8.6.2_A8.js` ("Prototype of non-extensible object mutated") and `S8.1_A5.js` (stack overflow) may have distinct root causes — confirm before including in the fix count.

--- a/plan/issues/sprints/67.md
+++ b/plan/issues/sprints/67.md
@@ -1,0 +1,67 @@
+---
+sprint: 67
+status: active
+started: 2026-06-26
+---
+# Sprint 67 — ES3 conformance gap closure
+
+## Theme
+
+Sprint 67 targets the remaining ES3 / Core category gaps in the test262 dashboard. The goal is to drive the lower-tier categories — delete, typeof/instanceof, for-in, arguments, operators, primitives — toward green by fixing the specific correctness holes the tech lead has root-caused from the 2026-06-26 baseline (32,115 / 43,135 passing, 74.5%). All 7 new issues plus one reactivated issue are closeable without BigInt, `with`-statement, or eval infrastructure changes.
+
+Current ES3/Core category standings (dashboard, baseline 2026-06-26):
+
+| Category | Pass | Total | % |
+|----------|------|-------|---|
+| Primitive | 615 | 647 | 95.1% |
+| Operators | 893 | 1083 | 82.5% |
+| typeof/instanceof | 34 | 59 | 57.6% |
+| delete | 41 | 69 | 59.4% |
+| comma | 5 | 6 | 83.3% |
+| labeled | 21 | 24 | 87.5% |
+| for-in | 88 | 115 | 76.5% |
+| arguments | 203 | 263 | 77.2% |
+
+## Issue slate
+
+| ID | Title | ~Tests | Feasibility |
+|----|-------|--------|-------------|
+| #2702 | instanceof spec correctness: HasInstance, non-object RHS, Symbol.hasInstance | 20 | medium |
+| #2703 | delete reference semantics: strict-mode TypeError throws, null base, super property | 28 | medium |
+| #2704 | arguments: trailing-comma length bug (async-gen/static), sloppy binding missing | ~32 | medium |
+| #2705 | for-in: head let/const TDZ, lexical scope open/close, LHS targets, var visibility | ~20 | hard |
+| #2706 | for-in enumeration order: integer-index keys ascending, insertion-order, prototype chain | 5 | medium |
+| #2707 | operators: unary null-deref on nullish; strict-equals # edge; TCO in ?:/&&/\|\| | ~21 | medium |
+| #2708 | primitive/literal: legacy escapes \\8/\\9/octal, regexp \\u atoms, PutValue primitive-base | ~20 | medium |
+| #1846 | Minor typeof conformance (reactivated): symbol, built-in-exotic-objects, syntax whitespace | 3 | low |
+
+**Total target: ~149 tests closeable (not counting BigInt, with, or eval-blocked tests).**
+
+Note: #2705 is `feasibility: hard` — the architect must spec the per-iteration scope mechanism before a dev is dispatched. Route to architect first.
+
+## Deferred / blocked (not in this sprint)
+
+**BigInt (~36 operator + typeof fails)**
+- Errors: "No dependency provided for extern class BigInt", "Cannot mix BigInt and other types"
+- Blocked on **#2044** (BigInt i64-brand ValType architect decision); also related: #1644, #1526, #560.
+- Affected test files: `expressions/unsigned-right-shift/bigint.js`, `expressions/bitwise-not/bigint.js`, `expressions/unary-minus/bigint.js`, `expressions/unary-plus/bigint-throws.js`, `expressions/strict-equals/bigint-and-bigint.js`, `expressions/strict-does-not-equals/bigint-and-bigint.js`, `expressions/unsigned-right-shift/bigint-non-primitive.js`, `expressions/typeof/bigint.js`, and others.
+
+**`with` statement (~12 operator/scope fails)**
+- Deferred/wont-fix by design. Strict-mode-only; the `with` statement is noCompile-flagged in our runner. Tests involving `scope.x` where `scope` is a `with` binding are not runnable. Do NOT fix `with`-based test failures.
+
+**`eval()` scattered**
+- Host/deferred. Standalone eval tracked by #1066. Tests using `eval()` (cptn-* for-in completion tests, `mongolian-vowel-separator-eval.js`, etc.) are excluded from sprint counts.
+
+**Mapped `arguments` exotic descriptors**
+- `mapped/mapped-arguments-nonconfigurable-strict-delete-*`, `mapped/enumerable-configurable-accessor-descriptor.js`, `mapped/nonconfigurable-descriptors-define-failure.js`, `mapped/nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-define-property.js`, `mapped/writable-enumerable-configurable-descriptor.js`
+- Tracked by existing **#1726** (mapped arguments exotic §10.4.4, already `ready`).
+
+**Private-field `in` (`#x in obj`, ~3 fails)**
+- ES2022 class field feature; out of ES3 scope. Not targeted this sprint.
+
+## Sprint planning notes
+
+- #2705 (for-in head lexical scope) is marked `hard` — the architect must write an implementation spec before dev dispatch. Per-iteration environment creation is a structural change to for-in lowering.
+- All other issues (#2702–#2704, #2706–#2708, #1846) are medium/low feasibility and can go directly to developer dispatch after architect review of #2705.
+- Issues are independent; no sprint-internal ordering dependencies beyond the architect-first gate on #2705.
+- BigInt tests are explicitly NOT counted in sprint targets — they form a separate blocked cluster under #2044.


### PR DESCRIPTION
## Summary

Sprint 67 ES3-conformance issue slate: 7 new issues + reactivation of #1846 (typeof), covering ~149 closeable test262 failures from the 2026-06-26 baseline (32,115/43,135 passing).

**New issues:**

| ID | Slug | Tests | Feasibility |
|----|------|-------|-------------|
| #2702 | instanceof-spec-correctness-hasinstance-nonobject-rhs | 20 | medium |
| #2703 | delete-reference-semantics-strict-throw-invalid-base | 28 | medium |
| #2704 | arguments-length-trailing-comma-and-sloppy-binding | ~32 | medium |
| #2705 | for-in-head-lexical-scope-tdz-and-lhs-targets | ~20 | **hard** |
| #2706 | for-in-enumeration-order-and-prototype-keys | 5 | medium |
| #2707 | operators-unary-nullish-strict-eq-tco | ~21 | medium |
| #2708 | primitive-literal-escapes-and-putvalue-autobox | ~20 | medium |

**Reactivated:** #1846 (typeof: symbol/built-in-exotic/syntax whitespace, 3 closeable; bigint deferred to #2044)

**Deferred:** BigInt (~36 tests, blocked on #2044), `with` statement (wont-fix), `eval()` (deferred), mapped arguments (#1726), private-field `in` (ES2022).

**Architecture note:** #2705 (for-in lexical scope) is marked `feasibility: hard` — the architect must write an implementation spec before dev dispatch (per-iteration environment creation is a structural change to for-in lowering).

## Files changed

- `plan/issues/sprints/67.md` — new sprint doc
- `plan/issues/2702-*.md` through `plan/issues/2708-*.md` — 7 new issue files
- `plan/issues/1846-minor-typeof-conformance-notes.md` — reactivated for sprint 67

## Test plan

- [ ] No source code changed — CI will pass (only plan/ files)
- [ ] Issue IDs 2702-2708 allocated atomically via `claim-issue.mjs --allocate`
- [ ] Each issue file has required frontmatter: id, title, status, sprint, goal, feasibility, es_edition, language_feature, task_type, created, updated
- [ ] Failing test paths cited from `es3-clusters-s67.txt` (2026-06-26 baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)