### PR TITLE
fix(#1551): nested super(...) arg-eval no longer rolled back out of the try-region

### DIFF
--- a/plan/issues/1551-spec-gap-super-call-argument-evaluation.md
+++ b/plan/issues/1551-spec-gap-super-call-argument-evaluation.md
@@ -1,7 +1,8 @@
 ---
 id: 1551
 title: "spec gap: SuperCall — argument-list evaluation order, spread getter side-effects, uninitialized-this PutValue"
-status: ready
+status: in-progress
+assignee: ttraenkler/sd-super1551
 created: 2026-05-20
 updated: 2026-06-26
 priority: medium

--- a/plan/issues/1551-spec-gap-super-call-argument-evaluation.md
+++ b/plan/issues/1551-spec-gap-super-call-argument-evaluation.md
@@ -1,8 +1,9 @@
 ---
 id: 1551
 title: "spec gap: SuperCall — argument-list evaluation order, spread getter side-effects, uninitialized-this PutValue"
-status: in-progress
+status: done
 assignee: ttraenkler/sd-super1551
+completed: 2026-06-26
 created: 2026-05-20
 updated: 2026-06-26
 priority: medium
@@ -19,7 +20,56 @@ note: "Verified 2026-05-21: compileSuperPropertyAccess at new-super.ts:258, comp
 ---
 # #1551 — `super(...)` / `super[expr]` evaluation order and abrupt-completion handling
 
+## RESOLUTION (2026-06-26, sd-super1551) — actual root cause + fix
+
+**Fixed:** the verified primary sub-case — `super(...)` inside a `try`/control-flow
+region escaping the enclosing try-region (the catch never ran, execution fell
+through past `super(...)`).
+
+**The actual root cause differs from the speculation in VERIFIED FINDINGS below.**
+The try-region nesting was *correct* — the `super(...)` *was* emitted inside the
+`try_table` body. The bug was that the nested-super fallback in
+`compileCallExpression` (`src/codegen/expressions/calls.ts` ~:13024 — reached
+when `super(...)` appears inside control flow, where the `class-bodies.ts` inline
+handler never sees it) **returned `null`** after emitting the super-argument
+evaluation. A `null` inner result is interpreted by the **#1919 speculative
+wrapper** in `compileExpressionBody` (`expressions.ts:782` — "inner compile
+produced no usable value") as a failure, so it called `rollbackSpeculative`,
+which **truncated the just-emitted arg-evaluation instructions** — including the
+throwing super-arg call — and replaced them with a default constant
+(`i32.const 0`). So the exception-raising call was *deleted at compile time*: the
+throw never happened, the catch never fired, and `reached = 1` ran.
+
+Traced by freezing the emitted instr buffer and trapping the in-place mutation:
+`[call, drop]` → `[i32.const 0, drop]` via the speculative rollback +
+`pushDefaultValue`.
+
+**Fix (one line + comment):** the fallback returns `VOID_RESULT` instead of
+`null`. `VOID_RESULT` means "compiled, void result, KEEP the emitted
+instructions" — the speculative wrapper preserves the arg evaluation, so
+ArgumentListEvaluation's side effects and abrupt completion (§13.3.7.1 step 4)
+survive. Net stack effect is unchanged (args evaluated + dropped).
+
+Guard tests in `tests/issue-1551.test.ts` (new `describe` block): super-arg
+throw caught (identity preserved), non-throwing arg side effect persists,
+no-`try` still throws OUT, multi-arg left-to-right + abrupt-at-2nd, super in an
+`if`-branch, super in a nested `try` rethrow. Verified regression-free against
+the scoped class/super suites (identical pass/fail vs origin/main).
+
+**Carved to follow-up #2709** (independent code paths, NOT bundled here):
+spread-getter side-effects (`call-spread-*`), uninitialized-`this` PutValue,
+`GetSuperBase`-before-`ToPropertyKey` ordering, the nested-super `this`-init gap
+(args now evaluate but the parent ctor is still not invoked for nested super),
+and the top-level super-arg global-visibility "secondary quirk" below.
+
+---
+
 ## VERIFIED FINDINGS — abrupt completion root cause (2026-06-26, dev-conformance)
+
+> NOTE: the "Where to fix" hypothesis in this section (super emitted *outside*
+> the try-region) was **disproven** during implementation — see RESOLUTION
+> above. The symptom table is accurate; the mechanism was the speculative-wrapper
+> rollback, not try-region nesting.
 
 Deep-traced sub-case (1) `call-arg-evaluation-err.js` on current `main` (probes,
 not issue text). The bug is **`super(...)` inside a `try` ESCAPES the

--- a/plan/issues/2709-super-spread-uninit-this-and-nested-this-init.md
+++ b/plan/issues/2709-super-spread-uninit-this-and-nested-this-init.md
@@ -1,0 +1,91 @@
+---
+id: 2709
+title: "SuperCall remaining sub-cases: spread-getter side-effects, uninitialized-this PutValue, GetSuperBase ordering, nested-super this-init, top-level super-arg global visibility"
+status: ready
+created: 2026-06-26
+updated: 2026-06-26
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: classes, super, spread
+goal: spec-completeness
+sprint: Backlog
+parent: 1551
+related: [1455, 1456, 1824, 1965]
+---
+# #2709 — SuperCall remaining sub-cases (carved out of #1551)
+
+#1551 was reframed (verified 2026-06-26) around a single concrete root cause —
+`super(...)` **inside a `try`/control-flow region** had its argument evaluation
+*rolled back* by the #1919 speculative wrapper, so a throwing super-arg escaped
+the enclosing try-region. That has been fixed (the nested-super fallback in
+`compileCallExpression` now returns `VOID_RESULT` instead of `null`, so
+`compileExpressionBody` preserves the emitted arg-evaluation instead of
+truncating them). See `tests/issue-1551.test.ts` and the commit on
+`issue-1551-super-try-region`.
+
+This follow-up tracks the remaining super sub-cases that #1551's original spec
+listed but that the abrupt-completion fix does **not** address. They are
+independent code paths.
+
+## Sub-cases
+
+### 1. Spread argument getter side-effects (`call-spread-*`, ~25 test262 rows)
+`super({...o, get c() { executedGetter = true; }})` — the object spread must use
+CopyDataProperties semantics: own-enumerable keys of `o` are read, and the inline
+`get c()` is installed as an accessor descriptor **without being invoked**.
+Verify the spread path used for super arguments matches `compileObjectExpression`
+(the non-super position), reusing `__copy_data_properties`. See #1551 step 4.
+
+### 2. Uninitialized-`this` PutValue (`prop-expr-uninitialized-this-putvalue*`, ~6 rows)
+`class Derived extends Base { constructor() { super[super()] = 0; } }` must throw
+`ReferenceError` (because `this` is uninitialized at the `super[expr]` reference
+resolution) **before** evaluating the inner `super()` or the RHS. Emit the
+uninitialized-`this` guard at the top of `compileSuperProperty` (PutValue
+context) before the index expression is evaluated. See #1551 step 2.
+
+### 3. `GetSuperBase` before `ToPropertyKey` (`prop-expr-getsuperbase-before-*`, 2 rows)
+§13.3.7.3: compute `GetSuperBase()` (≈ `GetPrototypeOf(this)`) **before**
+`ToPropertyKey(propertyNameValue)`. Swap the two emission blocks in
+`compileSuperProperty`. See #1551 step 3.
+
+### 4. Nested-super `this` initialization (the best-effort gap)
+The #1551 fix made nested `super(...)` **evaluate its arguments** (side effects +
+abrupt completion now propagate), but the nested-super fallback still does NOT
+actually invoke the parent constructor / initialize `this`. A non-throwing
+`class C extends Object { constructor() { try { super(x); } catch {} } }` leaves
+`__self` null and returns a null-ish instance. To fully support `super(...)`
+inside control flow, the fallback needs to perform the real parent
+construction (route through the `compileSuperCall` machinery in
+`class-bodies.ts`, which needs `className` / `selfLocal` / `fields` context that
+is not currently threaded into the generic `compileCallExpression`).
+
+### 5. Top-level super-arg global-visibility quirk (the "secondary quirk" from #1551)
+**Needs re-verification.** Reported in #1551: for
+`var calls = 0; function f(){ calls++; return 42; } class C extends P {
+constructor(){ super(f()); } }`, the parent received `42` but the module-global
+`calls` read back `0`. This is the **top-level** super path
+(`compileSuperCall` split-init `${C}_new` → `return_call ${C}_init`), distinct
+from the nested-super fallback fixed in #1551. A WAT dump of `C_init` for that
+shape shows the super-arg call interleaved with the parent-init call in a way
+worth auditing for argument ordering and global write-back. Re-probe on current
+main (the #1551 arg-rollback fix may have shifted behavior) before implementing.
+
+## Acceptance criteria
+- `test/language/expressions/super/call-spread-obj-getter-init.js` passes.
+- `test/language/expressions/super/prop-expr-uninitialized-this-putvalue.js` and
+  `…-increment.js` pass.
+- `test/language/expressions/super/prop-expr-getsuperbase-before-topropertykey-getvalue.js`
+  passes.
+- `expressions/super/` `assertion_fail` count reduces (target ≥ 40 once spread +
+  uninit-this land).
+- Nested `super(...)` in a non-throwing `try` produces a correctly-initialized
+  instance (sub-case 4).
+
+## Files to inspect
+- `src/codegen/expressions/new-super.ts` — `compileSuperProperty`, super-element.
+- `src/codegen/class-bodies.ts` — `compileSuperCall`, split-init constructor.
+- `src/codegen/expressions/calls.ts` — nested-super fallback (~:13024).
+- `src/codegen/expressions/object.ts` — object-spread / CopyDataProperties.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -13029,7 +13029,17 @@ function compileCallExpression(
         fctx.body.push({ op: "drop" });
       }
     }
-    return null;
+    // (#1551) Return VOID_RESULT, NOT null. A `null` return signals "no usable
+    // value" to the #1919 speculative wrapper in compileExpressionBody, which
+    // then calls rollbackSpeculative — TRUNCATING the argument-evaluation
+    // instructions we just emitted (including a throwing super-arg call) and
+    // replacing them with a default constant. That rollback is exactly why the
+    // super-arg throw escaped the enclosing try-region: the exception-raising
+    // call was deleted before it could run, so the user's `catch` never fired
+    // and execution fell through past `super(...)`. VOID_RESULT means "compiled,
+    // void result, KEEP the emitted instructions" — the wrapper preserves the
+    // arg evaluation so ArgumentListEvaluation's abrupt completion propagates.
+    return VOID_RESULT;
   }
 
   // Handle IIFE: (function(...) { ... })(...) — immediately invoked function expression

--- a/tests/issue-1551.test.ts
+++ b/tests/issue-1551.test.ts
@@ -104,3 +104,153 @@ describe("#1551 SuperCall argument evaluation", () => {
     expect(await runReturnNumber(src)).toBe(123);
   });
 });
+
+// ---------------------------------------------------------------------------
+// #1551 — `super(...)` nested inside control flow (try/if/loop) must NOT escape
+// the enclosing try-region.
+//
+// Verified root cause (2026-06-26): the nested-super fallback in
+// compileCallExpression (super inside control flow — the class-bodies inline
+// handler never sees it) returned `null` after emitting the super-argument
+// evaluation. The #1919 speculative wrapper in compileExpressionBody interprets
+// a `null` inner result as "no usable value" and calls rollbackSpeculative,
+// which TRUNCATED the just-emitted arg-evaluation instructions (including a
+// throwing super-arg call) and replaced them with a default constant. So
+// `super(thrower())` inside `try { } catch` never actually threw: the
+// exception-raising call was deleted at compile time, the user's `catch` never
+// ran, and execution fell through past `super(...)`. The fallback now returns
+// VOID_RESULT (preserved by the wrapper) so ArgumentListEvaluation's side
+// effects and abrupt completion survive (§13.3.7.1 step 4).
+// ---------------------------------------------------------------------------
+describe("#1551 super(...) inside try does not escape the try-region", () => {
+  it("super(thrower()) inside try{}catch: the catch runs and past-super is NOT reached", async () => {
+    // 0 PASS (catch ran, identity ok, reached 0); 1 escaped out of new C;
+    // 2 catch never ran (reached set); 3 caught wrong identity
+    const src = `
+      let thrown = 777;
+      let caught = -1;
+      let reached = 0;
+      class C extends Object {
+        constructor() {
+          try {
+            super((() => { throw thrown; })());
+            reached = 1;
+          } catch (e) {
+            caught = e as any;
+          }
+        }
+      }
+      export function test(): number {
+        try { new C(); } catch (e) { return 1; }
+        if (reached === 1) return 2;
+        if (caught !== thrown) return 3;
+        return 0;
+      }
+    `;
+    expect(await runReturnNumber(src)).toBe(0);
+  });
+
+  it("super(thrower()) with a named-function arg inside try: catch runs, exception identity preserved", async () => {
+    const src = `
+      let caught = -1; let reached = 0;
+      function thrower(): number { throw 777; }
+      class C extends Object {
+        constructor() {
+          try { super(thrower()); reached = 1; } catch (e) { caught = e as any; }
+        }
+      }
+      export function test(): number {
+        try { new C(); } catch (e) { return 1; }
+        if (reached === 1) return 2;
+        return caught === 777 ? 0 : 3;
+      }
+    `;
+    expect(await runReturnNumber(src)).toBe(0);
+  });
+
+  it("a NON-throwing super arg inside try is still evaluated (side effect persists)", async () => {
+    const src = `
+      let ran = 0;
+      function f(): number { ran = 1; return 5; }
+      class C extends Object {
+        constructor() { try { super(f()); } catch (e) {} }
+      }
+      export function test(): number { new C(); return ran; }
+    `;
+    expect(await runReturnNumber(src)).toBe(1);
+  });
+
+  it("super(thrower()) with NO surrounding try still throws OUT of new C (no regression)", async () => {
+    // 0 = threw out & reached stayed 0; 1 = no throw; 2 = threw but reached set
+    const src = `
+      let reached = 0;
+      class C extends Object {
+        constructor() { super((() => { throw 9; })()); reached = 1; }
+      }
+      export function test(): number {
+        try { new C(); } catch (e) { return reached === 0 ? 0 : 2; }
+        return 1;
+      }
+    `;
+    expect(await runReturnNumber(src)).toBe(0);
+  });
+
+  it("plain ctor try/catch with no super still catches (baseline, unaffected)", async () => {
+    const src = `
+      let caught = -1;
+      class C {
+        constructor() {
+          try { throw 55; } catch (e) { caught = e as any; }
+        }
+      }
+      export function test(): number { new C(); return caught === 55 ? 0 : 1; }
+    `;
+    expect(await runReturnNumber(src)).toBe(0);
+  });
+
+  it("multi-arg super: left-to-right eval order + abrupt at 2nd arg propagates to catch", async () => {
+    // order accumulates which args ran (a -> 1, bThrow -> 2): want 12; caught want 99
+    const src = `
+      let order = 0; let caught = -1;
+      function a(): number { order = order * 10 + 1; return 1; }
+      function bThrow(): number { order = order * 10 + 2; throw 99; }
+      class C extends Object {
+        constructor() { try { super(a(), bThrow()); } catch (e) { caught = e as any; } }
+      }
+      export function test(): number {
+        new C();
+        return order === 12 && caught === 99 ? 0 : 1;
+      }
+    `;
+    expect(await runReturnNumber(src)).toBe(0);
+  });
+
+  it("super inside an if-branch evaluates its arg (nested non-try control flow)", async () => {
+    const src = `
+      let ran = 0;
+      function g(): number { ran = ran + 1; return 7; }
+      class C extends Object {
+        constructor(b: boolean) { if (b) { super(g()); } else { super(0); } }
+      }
+      export function test(): number { new C(true); return ran; }
+    `;
+    expect(await runReturnNumber(src)).toBe(1);
+  });
+
+  it("super inside a nested try re-thrown to the outer catch", async () => {
+    // inner catch sets 1 + rethrows; outer catch adds 10 => 11
+    const src = `
+      let caught = 0;
+      function t(): number { throw 5; }
+      class C extends Object {
+        constructor() {
+          try {
+            try { super(t()); } catch (e) { caught = 1; throw e; }
+          } catch (e2) { caught = caught + 10; }
+        }
+      }
+      export function test(): number { new C(); return caught; }
+    `;
+    expect(await runReturnNumber(src)).toBe(11);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the verified primary sub-case of #1551: **`super(...)` inside a `try` (or any control flow) escaped the enclosing try-region** — the user's `catch` never ran and execution fell through past `super(...)`.

## Root cause (differs from the pre-impl hypothesis)

The try-region nesting was already correct — the `super(...)` *was* emitted inside the `try_table` body. The real bug: the nested-super fallback in `compileCallExpression` (`src/codegen/expressions/calls.ts` ~:13024, reached when `super(...)` is nested so the `class-bodies.ts` inline handler never sees it) returned **`null`** after emitting the super-argument evaluation.

A `null` inner result is treated by the **#1919 speculative wrapper** in `compileExpressionBody` (`expressions.ts:782`) as "inner compile produced no usable value", so it calls `rollbackSpeculative`, which **truncated the just-emitted arg-evaluation instructions** — including the throwing super-arg call — and replaced them with a default constant. The exception-raising call was deleted at compile time, so the throw never happened.

Traced by freezing the emitted instr buffer and trapping the in-place mutation: `[call, drop]` → `[i32.const 0, drop]` via the speculative rollback + `pushDefaultValue`.

## Fix

One line: the fallback returns `VOID_RESULT` instead of `null`. `VOID_RESULT` means "compiled, void result, KEEP the emitted instructions" — the wrapper preserves the arg evaluation, so ArgumentListEvaluation's side effects and abrupt completion (§13.3.7.1 step 4) survive. Net stack effect is unchanged (args evaluated + dropped).

## Tests

New `describe` block in `tests/issue-1551.test.ts` (12 pass total): super-arg throw caught with identity preserved, non-throwing arg side effect persists, no-`try` still throws OUT (no regression), multi-arg left-to-right + abrupt-at-2nd, super in an `if`-branch, super in a nested `try` rethrow. Verified regression-free vs origin/main on the scoped class/super suites (identical pass/fail; the pre-existing `string_constants` harness failures in `classes.test.ts` etc. are unrelated and present on main).

## Scope / follow-up

Carved the remaining originally-specced sub-cases to **#2709** (independent code paths, deliberately NOT bundled): spread-getter side-effects, uninitialized-`this` PutValue, `GetSuperBase`-before-`ToPropertyKey` ordering, the nested-super `this`-init gap (args now evaluate but the parent ctor is still not invoked for nested super), and the top-level super-arg global-visibility "secondary quirk".

🤖 Generated with [Claude Code](https://claude.com/claude-code)