### PR TITLE
fix(#2671): JSON.stringify wrong-type replacer + circular-structure crash

### DIFF
--- a/plan/issues/2671-es6-builtin-spec-residuals-date-regexp-promise-json-super.md
+++ b/plan/issues/2671-es6-builtin-spec-residuals-date-regexp-promise-json-super.md
@@ -3,7 +3,7 @@ id: 2671
 title: "ES2015 builtin/feature spec residuals: Date, RegExp, Promise, JSON, super (~400 fails — tracking, slice per area)"
 status: ready
 created: 2026-06-25
-updated: 2026-06-25
+updated: 2026-06-26
 priority: medium
 feasibility: medium
 reasoning_effort: high
@@ -116,6 +116,54 @@ feed only JSON.stringify):
 - ⏳ Remaining JSON: `replacer-array-duplicates`/`-undefined`/`-empty` (getter
   side-effect counting + sparse/hole handling), reviver descriptor edges (ties to
   #2668), Proxy/BigInt/circular cases — separate root causes, not in this slice.
+
+**Progress (dev-builtin2671, 2026-06-26): JSON.stringify §25.5.2 host-runtime
+serialization fidelity (wrong-type replacer + circular crash) — SHIPPED.**
+
+Verified-first through the real harness (`runTest262File`, `setExports` wired).
+Two `src/runtime.ts` host-runtime bugs, both rooted in `_wasmToPlain`
+mis-treating a non-vec WasmGC struct as an empty array (`__vec_len`'s not-a-vec
+default is 0, indistinguishable from an empty vec):
+- **Non-array object replacer not ignored** (§25.5.2.1 step 4.b):
+  `JSON.stringify({key:[1]}, {})` produced `"{}"` (the empty `{}` materialised
+  as `[]` → empty PropertyList that filtered every key) instead of the full
+  `'{"key":[1]}'`. Fixed in `_normaliseJsonReplacer` by gating the PropertyList
+  path on the **positive** `__is_vec` discriminator (`ref.test` over all
+  registered vec types); a plain object answers 0 and falls through to "no
+  replacer". Genuine array replacers cross the host boundary as real JS arrays
+  and hit the existing `Array.isArray` branch, so they are unaffected.
+- **Circular structure stack-overflows instead of throwing TypeError**
+  (§25.5.2.5/6 step 1): `var o:any={}; o.prop=o; JSON.stringify(o)` recursed
+  `_wasmToPlain → _structToPlainObject → _wasmToPlain` (via the `__sget_prop`
+  field getter) until a host RangeError "Maximum call stack size exceeded". Added
+  an opt-in, **path-scoped** `seen` set threaded through `_wasmToPlain` /
+  `_structToPlainObject` (added before descending, removed in `finally`, so a DAG
+  with shared-but-acyclic refs still flattens); the JSON fast path passes a fresh
+  set, all non-JSON callers omit it (behaviour unchanged). A self-referential
+  struct now throws the spec TypeError.
+- Guard: `tests/issue-2671-json-replacer.test.ts` extended to 15/15 (8 prior + 7
+  new wrong-type/array-replacer cases). Acyclic/DAG/shared-ref JSON verified
+  byte-identical; `built-ins/JSON/stringify` survey unchanged at 35 pass / 31
+  fail (no regression).
+- ⚠️ **Harness blockers — these correct fixes do NOT flip their test262 files**
+  (recorded so future devs don't re-chase them):
+  - `replacer-wrong-type.js` / `space-wrong-type.js` — `wrapTest`'s
+    `assert_sameValue(..., (true|false))` rewrite regex (test262-runner.ts
+    ~L2000) is not paren-balanced, so `assert.sameValue(JSON.stringify(obj,
+    true), json)` is mis-wrapped as `assert_sameValue_bool` (it greedily matches
+    the *inner* `, true)`). The replacer fix advances `replacer-wrong-type` from
+    failing at assert #1 to assert #8 (the mis-wrapped `true` line). Needs a
+    harness regex fix (tester scope), not a compiler change.
+  - `value-array-circular.js` — uses a **typed** `var direct = []` which routes
+    JSON.stringify through a separate typed-array serialization path (not
+    `_wasmToPlain`); the cycle there does not throw. `value-object-circular.js`
+    needs the nested object-literal getter (`get p3(){…}`) case too (assert #2
+    hits a separate codegen null-deref). Both need typed-path / getter work.
+- ⏳ Remaining JSON value cases (separate, deeper root causes): function values
+  inside arrays/objects render as `[[]]`/`{"key":[]}` instead of `[null]`/`{}`
+  (captureless closures answer `__is_closure`=0, then mis-flatten as `[]`);
+  Symbol values leak as a numeric id; lone-surrogate string escaping; BigInt
+  (gated).
 
 **Other areas — verified NOT independent of the deferred member-dispatch /
 string substrate (do NOT pick these before the proto-read substrate lands):**

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -3071,6 +3071,7 @@ function _wasmStructHasOwn(obj: any, key: any, exports: Record<string, Function>
 function _structToPlainObject(
   obj: any,
   exports: Record<string, Function> | undefined,
+  seen?: Set<any>,
 ): Record<string, any> | undefined {
   const fieldNames = _getStructFieldNames(obj, exports);
   if (!fieldNames) return undefined;
@@ -3079,8 +3080,11 @@ function _structToPlainObject(
     const getter = exports?.[`__sget_${key}`];
     if (typeof getter === "function") {
       let val = getter(obj);
-      // Recursively convert nested WasmGC structs and vecs
-      val = _wasmToPlain(val, exports);
+      // Recursively convert nested WasmGC structs and vecs (threading the
+      // JSON cycle-detection `seen` set, when supplied, so a self-referential
+      // field — `o.prop = o` — raises a TypeError instead of recursing here
+      // until a host stack overflow; #2671).
+      val = _wasmToPlain(val, exports, seen);
       result[key] = val;
     }
   }
@@ -3142,48 +3146,68 @@ function _installErrorCause(inst: any, options: any, exports: Record<string, Fun
  *   - WasmGC vecs     -> JS arrays (via __vec_len / __vec_get)
  *   - primitives / normal JS objects -> returned as-is
  */
-function _wasmToPlain(val: any, exports: Record<string, Function> | undefined): any {
+function _wasmToPlain(val: any, exports: Record<string, Function> | undefined, seen?: Set<any>): any {
   if (val == null || typeof val !== "object") return val;
   if (!_isWasmStruct(val)) return val;
 
-  // Check if this is a named struct (has field names from __struct_field_names).
-  // Named structs are user-defined types — convert to plain objects.
-  // Vec wrappers (arrays) don't have meaningful field names registered.
-  const fieldNames = _getStructFieldNames(val, exports);
-  if (fieldNames) {
-    // It's a named struct — convert to plain object with recursive conversion
-    return _structToPlainObject(val, exports);
+  // (#2671) Cycle detection for the JSON.stringify flatten fast path. When a
+  // `seen` ancestor set is supplied, a struct already on the current
+  // serialization path is a circular reference — §25.5.2.5 / §25.5.2.6 step 1
+  // mandate a TypeError ("Converting circular structure to JSON"); the previous
+  // behaviour recursed (`_wasmToPlain` → `_structToPlainObject` → `_wasmToPlain`
+  // via the field getter) until a host RangeError stack overflow. The set is
+  // PATH-scoped (added before descending, removed in `finally`), so a DAG with
+  // shared-but-acyclic references still flattens correctly. Callers that omit
+  // `seen` (non-JSON consumers) keep the original cycle-unsafe behaviour.
+  if (seen) {
+    if (seen.has(val)) throw new TypeError("Converting circular structure to JSON");
+    seen.add(val);
   }
+  try {
+    // Check if this is a named struct (has field names from __struct_field_names).
+    // Named structs are user-defined types — convert to plain objects.
+    // Vec wrappers (arrays) don't have meaningful field names registered.
+    const fieldNames = _getStructFieldNames(val, exports);
+    if (fieldNames) {
+      // It's a named struct — convert to plain object with recursive conversion
+      return _structToPlainObject(val, exports, seen);
+    }
 
-  // Try vec (array wrapper) conversion — vec structs have {length, data} fields
-  // but are NOT registered in __struct_field_names (they're internal types).
-  if (exports) {
-    const vecLen = exports.__vec_len;
-    const vecGet = exports.__vec_get;
-    if (typeof vecLen === "function" && typeof vecGet === "function") {
-      try {
-        const len = vecLen(val);
-        if (typeof len === "number" && len > 0) {
-          const arr: any[] = [];
-          for (let i = 0; i < len; i++) {
-            arr.push(_wasmToPlain(vecGet(val, i), exports));
+    // Try vec (array wrapper) conversion — vec structs have {length, data} fields
+    // but are NOT registered in __struct_field_names (they're internal types).
+    if (exports) {
+      const vecLen = exports.__vec_len;
+      const vecGet = exports.__vec_get;
+      if (typeof vecLen === "function" && typeof vecGet === "function") {
+        try {
+          const len = vecLen(val);
+          if (typeof len === "number" && len > 0) {
+            const arr: any[] = [];
+            for (let i = 0; i < len; i++) {
+              arr.push(_wasmToPlain(vecGet(val, i), exports, seen));
+            }
+            return arr;
           }
-          return arr;
+          // len === 0 could be an empty array or a non-vec struct with 0 as first field.
+          // Since we already checked field names above (and it wasn't a named struct),
+          // treat len=0 as an empty array if __vec_get doesn't throw.
+          if (len === 0) {
+            return [];
+          }
+        } catch (e) {
+          // Propagate a circular-structure TypeError raised by a deeper element;
+          // only a genuine "not a vec" probe failure should fall through.
+          if (e instanceof TypeError) throw e;
+          // Not a vec — fall through
         }
-        // len === 0 could be an empty array or a non-vec struct with 0 as first field.
-        // Since we already checked field names above (and it wasn't a named struct),
-        // treat len=0 as an empty array if __vec_get doesn't throw.
-        if (len === 0) {
-          return [];
-        }
-      } catch {
-        // Not a vec — fall through
       }
     }
-  }
 
-  // Unknown WasmGC struct — return as-is
-  return val;
+    // Unknown WasmGC struct — return as-is
+    return val;
+  } finally {
+    if (seen) seen.delete(val);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -3220,10 +3244,25 @@ function _normaliseJsonReplacer(
     // Try function bridge first (Wasm closure → JS callable via __call_fn_2).
     const wrapped = exports ? _wrapWasmClosure(replacer, 2, callbackState) : null;
     if (wrapped) return { kind: "fn", fn: wrapped };
-    // Otherwise treat as property-list array if it materialises as one.
-    const asPlain = _wasmToPlain(replacer, exports);
-    if (Array.isArray(asPlain)) {
-      return { kind: "list", keys: _buildJsonPropertyList(asPlain) };
+    // (#2671) §25.5.2.1 step 4.b — only an *array* replacer becomes a
+    // PropertyList; any other object (`JSON.stringify(obj, {})`,
+    // `new String('s')`, …) is silently ignored. `_wasmToPlain` cannot tell an
+    // empty object struct from an empty vec (both report `__vec_len` 0 — the
+    // not-a-vec default), so it mis-materialises `{}` as `[]`, producing an
+    // empty PropertyList that wrongly filters out every key (`{}` → `"{}"`).
+    // Gate the PropertyList path on the *positive* `__is_vec` discriminator
+    // (`ref.test` over all registered vec types); a plain object struct answers
+    // 0 and correctly falls through to `{ kind: "none" }` (no replacer). Genuine
+    // array replacers cross the host boundary as real JS arrays and are handled
+    // by the `Array.isArray(replacer)` branch above, so this branch is reached
+    // only by object structs (and, defensively, any true wasm vec struct, which
+    // `__is_vec` still routes to the PropertyList path).
+    const isVecFn = exports?.__is_vec;
+    if (typeof isVecFn === "function" && isVecFn(replacer) === 1) {
+      const asPlain = _wasmToPlain(replacer, exports);
+      if (Array.isArray(asPlain)) {
+        return { kind: "list", keys: _buildJsonPropertyList(asPlain) };
+      }
     }
   }
   return { kind: "none" };
@@ -7152,7 +7191,10 @@ function resolveImport(
             // flatten path would drop the method before host JSON.stringify
             // sees it.
             if (!_hasReachableToJSON(v, exports, new Set())) {
-              const plain = _wasmToPlain(v, exports);
+              // (#2671) Pass a fresh path-scoped `seen` set so a circular
+              // structure raises a TypeError (§25.5.2.5/6 step 1) instead of a
+              // host stack-overflow RangeError.
+              const plain = _wasmToPlain(v, exports, new Set());
               return JSON.stringify(plain, undefined, sp);
             }
           }

--- a/tests/issue-2671-json-replacer.test.ts
+++ b/tests/issue-2671-json-replacer.test.ts
@@ -68,3 +68,53 @@ describe("#2671 — JSON.stringify array replacer (PropertyList)", () => {
     expect(exp.test()).toBe('{"a":5,"b":7}');
   });
 });
+
+// §25.5.2.1 step 4 — when `Type(replacer)` is Object and `IsCallable(replacer)`
+// is false, only an *array* replacer (`IsArray` true) becomes a PropertyList;
+// EVERY other replacer (a plain object, a String/Number wrapper object, or a
+// non-object primitive) is silently ignored, so the value serializes in full.
+// The regression: a plain object literal `{}` reached the host as a WasmGC
+// struct, and `_wasmToPlain` mis-materialised it as `[]` (an empty vec, because
+// `__vec_len` returns 0 for a non-vec struct), yielding an empty PropertyList
+// that wrongly filtered out every own key — `JSON.stringify(obj, {})` produced
+// `"{}"` instead of the full serialization. (test262
+// built-ins/JSON/stringify/replacer-wrong-type.js.)
+describe("#2671 — JSON.stringify wrong-type replacer is silently ignored", () => {
+  const FULL = '{"key":[1]}';
+
+  it("a plain object replacer `{}` is ignored (regression — was `{}`)", async () => {
+    const exp = await run(`return JSON.stringify({key: [1]}, {} as any);`);
+    expect(exp.test()).toBe(FULL);
+  });
+
+  it("a non-empty plain object replacer is ignored, not treated as a key list", async () => {
+    const exp = await run(`return JSON.stringify({key: [1]}, {key: 0, other: 1} as any);`);
+    expect(exp.test()).toBe(FULL);
+  });
+
+  it("a String wrapper-object replacer is ignored", async () => {
+    const exp = await run(`return JSON.stringify({key: [1]}, new String('str') as any);`);
+    expect(exp.test()).toBe(FULL);
+  });
+
+  it("a Number wrapper-object replacer is ignored", async () => {
+    const exp = await run(`return JSON.stringify({key: [1]}, new Number(6.1) as any);`);
+    expect(exp.test()).toBe(FULL);
+  });
+
+  it("null / primitive replacers are ignored", async () => {
+    expect((await run(`return JSON.stringify({key: [1]}, null as any);`)).test()).toBe(FULL);
+    expect((await run(`return JSON.stringify({key: [1]}, '' as any);`)).test()).toBe(FULL);
+    expect((await run(`return JSON.stringify({key: [1]}, 0 as any);`)).test()).toBe(FULL);
+  });
+
+  it("an empty array replacer still filters everything (genuine PropertyList path)", async () => {
+    const exp = await run(`return JSON.stringify({key: [1]}, [] as any);`);
+    expect(exp.test()).toBe("{}");
+  });
+
+  it("a non-empty array replacer still filters by its keys (no regression)", async () => {
+    const exp = await run(`return JSON.stringify({a: 1, b: 2}, ['b'] as any);`);
+    expect(exp.test()).toBe('{"b":2}');
+  });
+});


### PR DESCRIPTION
## #2671 (ES2015 builtin residuals) — JSON.stringify §25.5.2 host-runtime serialization fidelity

Verified-first against current `origin/main` through the real harness
(`runTest262File`, `setExports` wired). Two `src/runtime.ts` host-runtime bugs in
`JSON.stringify`, both rooted in `_wasmToPlain` mis-treating a non-vec WasmGC
struct as an empty array (`__vec_len`'s not-a-vec default of `0` is
indistinguishable from an empty vec):

### 1. Non-array object replacer not ignored (§25.5.2.1 step 4.b)
`JSON.stringify({key:[1]}, {})` produced `"{}"` instead of `'{"key":[1]}'` — the
empty `{}` struct materialised as `[]`, becoming an empty PropertyList that
filtered out every own key. Fixed in `_normaliseJsonReplacer` by gating the
PropertyList path on the **positive** `__is_vec` discriminator (`ref.test` over
all registered vec types); a plain object answers `0` and falls through to "no
replacer". Genuine array replacers cross the host boundary as real JS arrays
(handled by the existing `Array.isArray` branch) and are unaffected.

### 2. Circular structure crashes instead of throwing TypeError (§25.5.2.5/6 step 1)
`var o:any={}; o.prop=o; JSON.stringify(o)` recursed
`_wasmToPlain → _structToPlainObject → _wasmToPlain` (via the `__sget_prop` field
getter) until a host `RangeError: Maximum call stack size exceeded`. Added an
**opt-in, path-scoped** `seen` set threaded through `_wasmToPlain` /
`_structToPlainObject` (added before descending, removed in `finally`, so a DAG
with shared-but-acyclic refs still flattens). The JSON fast path passes a fresh
set; all non-JSON callers omit it (behaviour unchanged). A self-referential
struct now throws the spec `TypeError`.

## Testing
- `tests/issue-2671-json-replacer.test.ts` extended to **15/15** (8 prior + 7 new
  wrong-type / array-replacer cases).
- Acyclic / DAG / shared-ref JSON verified byte-identical; `built-ins/JSON/stringify`
  survey unchanged at **35 pass / 31 fail** (no regression).
- `tsc --noEmit` clean; biome/prettier clean.
- Standalone JSON path is codegen-native (no host import) — unaffected.

## Scope note
Both fixes are spec-correct and zero-regression, but their headline test262 files
are blocked from flipping by harness/typed-path issues (documented in the issue's
sub-area notes so future devs don't re-chase): `replacer-wrong-type.js` /
`space-wrong-type.js` hit a non-paren-balanced `assert_sameValue(...,(true|false))`
rewrite regex in the test262 runner (tester scope); `value-array-circular.js` uses
a *typed* `[]` that routes through a separate serialization path. Tracking issue
#2671 stays `ready` (umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)