### PR TITLE
docs(#2705,#2707): for-in architect spec + comma/labeled TCO fold

### DIFF
--- a/plan/issues/2705-for-in-head-lexical-scope-tdz-and-lhs-targets.md
+++ b/plan/issues/2705-for-in-head-lexical-scope-tdz-and-lhs-targets.md
@@ -90,3 +90,288 @@ At least 18 of the 20 closeable listed tests (excluding eval-based and resizable
 - The architect should spec the per-iteration scope mechanism carefully — particularly how the wasm locals for the binding are cloned per iteration without an allocation.
 - See also #2706 (for-in enumeration order — a separate issue on the enumeration algorithm, not scoping).
 - `resizable-buffer.js` ("ctors is not defined") is TypedArray-related and out of scope for this issue.
+
+## Implementation Plan
+
+> **Scope correction (read first).** The four `S12.6.4_A3/A3.1/A4/A4.1.js` and
+> `scope-head-var-none.js`/`scope-body-var-none.js` tests in section (c) are
+> **eval-based** — they enumerate via `eval("for(var ind in …)…")` or run
+> `eval('var x=2')` inside the head's computed default. They reach the dynamic
+> `__extern_eval` host import (not the inline path) because
+> `allNodesInlineSupported` in `src/codegen/expressions/eval-inline.ts:179`
+> **bails on `ForInStatement`**, and the host eval cannot see the module's
+> `__str`/`arr`/`x` locals → "__str is not defined". They are therefore NOT
+> closeable by the for-in lowering changes below; they belong to the eval-inline
+> work (Slice D, deferred). The PO's "excluding eval-based" carve-out in the
+> acceptance criteria should be read to cover these six, not just the four
+> `cptn-*` tests. **Realistic closeable set = 11 tests** (Slice A: 5, Slice B: 6).
+
+### Root cause
+
+All for-in lowering lives in **`src/codegen/statements/loops.ts` →
+`compileForInStatement` (line 5389)**. The whole loop uses a **single
+`externref` local `keyLocal`** for the head variable (allocated once, lines
+5400–5447) and writes `keys[i]` into it each iteration (line 5631). There is no
+per-iteration fresh binding, no TDZ environment, and no head/per-iteration env
+split. The user body is compiled with `saveBlockScopedShadows` /
+`restoreBlockScopedShadows` (lines 5596–5604) — a name-shadow save/restore, not
+a fresh declarative environment.
+
+- **(a) let/const TDZ + per-iteration (6 tests).** `keyLocal` is a plain local,
+  always initialized before the body runs (line 5631), and the receiver
+  expression is compiled at line 5531 **with no head binding in scope**. So:
+  - `head-let-bound-names-fordecl-tdz` (`for (let x in { x })`): per
+    §14.7.5.6 ForIn/OfHeadEvaluation step 2, the head's `let x` must be a **TDZ
+    binding in scope while the receiver `{ x }` is evaluated** → reading `x`
+    (shorthand `{x:x}`) must throw ReferenceError. We currently evaluate `{ x }`
+    against the *outer* `x` (no throw) → test fails.
+  - `scope-head-lex-open/close`: a closure created **inside the receiver**
+    (`{ i: probeExpr = function(){ typeof x } }`) must capture the **head TDZ
+    binding** (never initialized) → `typeof x` throws ReferenceError when called
+    later. We capture the outer/loop `x` instead → no throw.
+  - `scope-body-lex-open/close`: closures created in the ForDeclaration defaults
+    (`probeDecl`) and the body (`probeBody`) must capture a **fresh
+    per-iteration binding** initialized to the key (`'i'`). We share one local
+    → wrong capture identity.
+- **(b) non-simple / `let`-identifier LHS (4 tests).** The dispatch at lines
+  5399–5447 does not cover two parse shapes (verified via `ts.createSourceFile`
+  probe):
+  - `head-lhs-cover` (`for ((x) in …)`): the initializer parses as a
+    **`ParenthesizedExpression`** wrapping the identifier — no branch matches →
+    falls to the `else` "for-in requires a variable declaration or identifier"
+    (line 5445).
+  - `head-lhs-let` / `identifier-let-allowed-as-lefthandside-expression-not-strict`
+    (`for (let in obj)`, non-strict): TS parses this as a
+    **`VariableDeclarationList` with `declarations.length === 0`** (the `let`
+    token is consumed as the list keyword; the identifier text is lost). Line
+    5400 does `const decl = init.declarations[0]!` → `decl` is `undefined`, then
+    line 5401 `decl.name` → **"Cannot read properties of undefined (reading
+    'name')"**. Per the grammar's `[lookahead ∉ { let [ }]` restriction, a `let`
+    not followed by `[` is the *identifier* `let`. The second half of
+    `head-lhs-let` (`for ([let][1] in obj)`) parses as an
+    `ElementAccessExpression` and already routes through the `memberTarget`
+    branch (line 5412) — only the `for (let in obj)` half crashes.
+  - `let-identifier-with-newline` (`for (var x in null) let \n x = 1;`): the
+    **receiver is `null`** (`exprKind=NullKeyword`). There is no
+    null/undefined-receiver guard — `compileExpression` pushes a null externref
+    (line 5531) and `__for_in_keys(null)` / the native enumeration path is
+    emitted over it → invalid Wasm / trap. Per §14.7.5.6 step 7, a `null`/`undefined`
+    receiver yields **zero iterations**.
+- **(c) var-head visibility — the ONE non-eval test, `head-var-bound-names-in-stmt`
+  (`for (var x in {…}) { var x; … }`).** `var x` is already hoisted to a
+  function-scope local by `hoistVarDeclarations`
+  (`src/codegen/index.ts:13582–13594`). But the var-decl-list-with-identifier
+  branch at **lines 5407–5411 unconditionally calls
+  `allocLocal(fctx, varName, …)`**, allocating a *fresh* local that **shadows
+  the hoisted slot**. Writes to `keyLocal` never reach the hoisted `x`, so the
+  body's `var x` reference and the post-loop value read the wrong slot. (The
+  bare-identifier branch at lines 5418–5427 already does the right thing — it
+  checks `fctx.localMap.get(varName)` first. The var-decl branch must do the
+  same.)
+
+### Approach
+
+Split along risk. **Slice A** is small, local, and closes 5 tests with no new
+infrastructure. **Slice B** is the hard per-iteration-env + TDZ change and
+should reuse the existing C-style-for-loop machinery rather than invent new.
+
+#### Slice A — LHS dispatch + var reuse + null-receiver guard (5 tests)
+
+All edits in `compileForInStatement` (loops.ts 5389–5447, 5531).
+
+1. **Unwrap parentheses** at the top of the dispatch: before the
+   `isVariableDeclarationList`/`isIdentifier`/member checks, set
+   `let head: ts.Node = init; while (ts.isParenthesizedExpression(head)) head = head.expression;`
+   and dispatch on `head`. A parenthesized identifier `(x)` then routes to the
+   existing bare-identifier branch; a parenthesized member `(a.b)` to the
+   member-target branch. (Closes `head-lhs-cover`.)
+2. **`let`-as-identifier (declCount === 0).** In the `isVariableDeclarationList`
+   branch, **before** dereferencing `declarations[0]`, add:
+   `if (init.declarations.length === 0) { /* "for (let in …)" — the only empty
+   VarDeclList shape; head is the identifier "let" */ varName = "let";
+   keyLocal = fctx.localMap.get("let") ?? allocLocal(fctx, "let", {kind:"externref"}); }`
+   then skip the rest. (`var`/`const` can't produce an empty list — both are
+   reserved as identifiers — so `"let"` is unambiguous.) (Closes `head-lhs-let`,
+   `identifier-let-allowed-…`.)
+3. **`var`-head reuses the hoisted local.** In the var-decl-list-identifier
+   branch (lines 5407–5411), gate on `let`/`const` vs `var`:
+   `const isLexical = !!(init.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const));`
+   For a **`var`** head, mirror the bare-identifier path — reuse
+   `fctx.localMap.get(varName)` if present (the hoisted slot), else `allocLocal`.
+   For **let/const**, keep allocating a fresh block-scoped local (Slice B
+   refines this). (Closes `head-var-bound-names-in-stmt`.)
+4. **Null/undefined receiver guard.** The receiver type is known at compile time
+   for the literal case (`exprKind === NullKeyword`, or
+   `ctx.checker.getTypeAtLocation(stmt.expression)` is `null`/`undefined`/`void`).
+   When statically nullish, **emit nothing for the loop** (skip body codegen
+   entirely — zero iterations) after still running var-hoisting (already done in
+   the pre-pass, so safe to skip here). For the dynamic case where the receiver
+   *may* be null at runtime, wrap the enumeration in a `ref.is_null`
+   guard: `local.tee $obj; ref.is_null; if (then: br to $break)` before
+   `__for_in_keys`. The static skip alone closes `let-identifier-with-newline`
+   (receiver is the `null` literal); add the runtime guard for robustness.
+   **Caveat:** the body of `let-identifier-with-newline` is a lexical
+   declaration (`let x = 1`, dead code) — confirm the static-skip path does not
+   compile the body (so no invalid-Wasm lexical-decl-as-sole-statement is
+   emitted).
+
+#### Slice B — head TDZ env + per-iteration fresh binding for let/const (6 tests)
+
+This implements §14.7.5.6 (head TDZ environment) and §14.7.5.7
+ForIn/OfBodyEvaluation step 6.e (CreatePerIterationEnvironment +
+BindingInstantiation) for the **let/const head** only. Reuse the existing
+ref-cell + TDZ-flag machinery that the **C-style `for (let x = …; …)` loop**
+already uses (same file): `findHeadBindingsCapturedByClosures` (loops.ts:571),
+`getOrRegisterRefCellType` (`registry/types.ts`), `fctx.boxedCaptures`,
+`fctx.tdzFlagLocals`, the per-iteration cell-clone block (loops.ts ~1152–1260),
+and `collectPatternBindingNames` / `emitLocalTdzInit` / `emitTdzInitForBindingPattern`
+(`statements/tdz.ts`).
+
+Sequence inside `compileForInStatement`, gated on
+`isVariableDeclarationList(init) && (init.flags & (Let|Const))`:
+
+1. **Head TDZ environment (before line 5531, the receiver compile).**
+   - Collect the head bound names with `collectPatternBindingNames(decl.name)`.
+   - For each name, allocate a **ref cell** (`getOrRegisterRefCellType(ctx,
+     {kind:"externref"})`), store its `boxedLocal`, register
+     `fctx.boxedCaptures.set(name, {refCellTypeIdx, valType})`, and allocate a
+     **TDZ flag local set to 0 (uninitialized)** via `fctx.tdzFlagLocals`.
+     (Save the prior `boxedCaptures`/`tdzFlagLocals`/`localMap` entries to
+     restore on loop exit — see the `savedForBoxedCaptures` pattern at
+     loops.ts:687, 896–907.)
+   - **Now compile the receiver** (existing line 5531). Any identifier read of
+     the head name inside the receiver routes through the ref cell + TDZ flag,
+     so an uninitialized read emits the TDZ guard (`ref.is_null`/flag check →
+     `throw ReferenceError`) — closing `head-let-bound-names-fordecl-tdz` and the
+     receiver-closure capture in `scope-head-lex-open/close`. A closure built in
+     the receiver captures **this** (never-initialized) cell → `typeof x`
+     throws when later called.
+2. **Per-iteration environment (top of each iteration body, where line 5631
+   currently does the plain `local.set keyLocal`).** Mirror the C-style
+   per-iteration cell-clone at loops.ts ~1152–1170:
+   - Allocate a **fresh ref cell** each iteration (`struct.new $refcell` with a
+     null/placeholder init) and **re-aim `boxedCaptures[name]`** to it, so
+     closures created in the ForDeclaration defaults and the body capture a
+     **distinct per-iteration cell**.
+   - Run **BindingInstantiation**: bind the key into the per-iteration cell. For
+     a plain identifier head, write the key into the cell and flip the TDZ flag
+     to 1 (`emitLocalTdzInit`). For a **binding-pattern head**
+     (`let [x, _ = …]`), reuse the existing externref-destructuring helpers
+     (`compileExternrefArrayDestructuringDecl` /
+     `compileExternrefObjectDestructuringDecl`, already invoked at lines
+     5582–5592) so default initializers run **in the per-iteration env** and
+     `emitTdzInitForBindingPattern` flips the flags. This closes
+     `scope-body-lex-open/close` (probeDecl/probeBody capture the per-iteration
+     cell → return `'i'`).
+   - **Important:** establish the per-iteration env (fresh cell + re-aim) BEFORE
+     running the pattern defaults, so a default that builds a closure
+     (`_ = probeDecl = function(){ return x }`) captures the new cell.
+3. **Restore** the saved `boxedCaptures`/`tdzFlagLocals`/`localMap` entries on
+   loop exit (the `savedForBoxedCaptures` restore at loops.ts:1254–1260 is the
+   template).
+
+> **Reuse-vs-rebuild call.** The cleanest implementation factors the C-style
+> loop's per-iteration cell logic (loops.ts ~858–909 setup, ~1152–1260
+> clone+restore) into a small shared helper
+> (`emitPerIterationLexicalEnv(fctx, headNames, …)`) and calls it from both the
+> C-style loop and for-in. If that refactor looks too broad for one PR,
+> **duplicate the ~40-line cell-clone block** into the for-in path and leave a
+> `// TODO(#2705) de-dup with compileForStatement per-iter env` marker — the
+> functional outcome is identical and lower-risk than a cross-cutting refactor.
+
+#### Slice C — dynamic null-receiver runtime guard (robustness, 0 new tests)
+
+If Slice A only does the *static* nullish skip, add the runtime `ref.is_null →
+br $break` guard for non-literal receivers that may be null at runtime. Optional;
+no listed test requires it but it prevents the same trap class for
+`for (k in maybeNull)`. Can fold into Slice A.
+
+#### Slice D — eval-based var-head (deferred, 6 tests)
+
+`S12.6.4_A3/A3.1/A4/A4.1`, `scope-head-var-none`, `scope-body-var-none`. Closing
+these requires lifting the `ForInStatement` bail in `allNodesInlineSupported`
+(`eval-inline.ts:179`) so `eval("for(var ind in …)…")` inlines and outer locals
+(`__str`, `arr`) resolve. **High risk:** the inlined source is parsed via
+`ts.createSourceFile` with **no checker bindings**, and `compileForInStatement`
+leans on `ctx.checker.getTypeAtLocation(stmt.expression)` (resolveArrayInfo /
+resolveWasmType) which returns error/`any` types for foreign nodes — the
+enumeration-primitive selection would mis-route. Treat as a **separate
+follow-up**, not part of #2705's acceptance.
+
+### Edge cases
+
+- `for (let in obj)` — `"let"` is a *real binding name* in non-strict mode; it
+  must be writable and visible after the loop per `head-lhs-let`'s
+  `assert.sameValue(let, 'key')`. Use the same reuse-or-alloc logic as any other
+  identifier (Slice A step 2), not a throwaway temp.
+- `for ([let][1] in obj)` (member target) — already handled by the
+  `memberTarget` branch + `emitForInMemberTargetWrite`; verify the
+  `Array.prototype[1]` **setter** is invoked (PutValue semantics) so
+  `head-lhs-let`'s second assertion passes. No change expected; add a test probe.
+- Head binding-pattern with defaults (`let [x, _ = f()]`) — defaults must run
+  per iteration in the per-iteration env (Slice B step 2), not once.
+- `continue`/`break` depth bookkeeping (the `+= 3` / `-= 3` adjustments at lines
+  5566–5614) must remain correct if Slice B adds nesting; if the per-iteration
+  cell-clone adds a block, update the depth deltas accordingly.
+- TDZ flag for a head whose name **also** exists as an outer let/const (the
+  `let x = 1; for (let x in {x})` shadow in `head-let-bound-names-fordecl-tdz`) —
+  the head TDZ binding must **shadow** the outer one for the receiver eval; save
+  and restore the outer `localMap`/`boxedCaptures`/`tdzFlagLocals` entry.
+- A `var` head that collides with a body `var` re-declaration
+  (`head-var-bound-names-in-stmt`) — both must resolve to the single hoisted slot
+  (Slice A step 3).
+
+### Wasm / IR patterns
+
+- **Ref cell** for the per-iteration + head bindings:
+  `struct (field $value (mut externref))` via `getOrRegisterRefCellType`. Closure
+  capture reads/writes go through `struct.get`/`struct.set` so every closure that
+  captured the same cell sees the same mutation (existing `boxedCaptures` path).
+- **TDZ guard** (uninitialized read): the existing module/local TDZ pattern —
+  flag local (i32, 0=uninitialized) checked before the value read; on 0 emit
+  `throw ReferenceError`. For the boxed (closure-captured) case the flag itself
+  is boxed (`fctx.boxedTdzFlags`) so the throw fires from inside the closure.
+  `typeof` of a TDZ binding must **also** throw (not yield `"undefined"`) — the
+  `typeof x` in `scope-head-lex-open` relies on this; confirm the `typeof`
+  lowering honors the TDZ flag for boxed head bindings.
+- **Per-iteration fresh cell:** `struct.new $refcell` each iteration then re-aim
+  `boxedCaptures` — copy the C-style template at loops.ts ~1163–1170.
+- **Null-receiver skip:** static case emits no loop; dynamic case
+  `local.tee $obj / ref.is_null / br_if $break`.
+
+### Suggested slicing (dev-sized PRs)
+
+| Slice | Closes | Risk |
+|-------|--------|------|
+| **A** — LHS dispatch (paren unwrap + `let`-identifier declCount===0) + `var`-head local reuse + static null-receiver skip | `head-lhs-cover`, `head-lhs-let`, `identifier-let-allowed-…`, `let-identifier-with-newline`, `head-var-bound-names-in-stmt` (**5**) | Low — local edits in lines 5399–5447, 5531 |
+| **B** — head TDZ env + per-iteration fresh lexical binding for let/const heads | `head-let-bound-names-fordecl-tdz`, `head-const-bound-names-fordecl-tdz`, `scope-head-lex-open`, `scope-head-lex-close`, `scope-body-lex-open`, `scope-body-lex-close` (**6**) | High — reuses C-style per-iter machinery; new head/per-iter env split |
+| **C** — dynamic runtime null-receiver guard | (robustness, 0) | Low — fold into A |
+| **D** — eval-inline `ForInStatement` support | `S12.6.4_A3/A3.1/A4/A4.1`, `scope-head-var-none`, `scope-body-var-none` (**6**) | High, **deferred** — foreign-node type resolution; separate follow-up |
+
+Ship **A first** (independent, 5 tests, fast). **B** can start in parallel but
+should land after A to avoid dispatch-block conflicts in lines 5399–5447.
+Re-target the acceptance criteria to **"≥10 of the 11 Slice A+B tests"** (the
+"18 of 20" figure counted the 6 eval/var-none tests that are not closeable here).
+
+### Risk note
+
+- **#2552 (AnnexB TDZ hotpath).** AnnexB §B.3.5 allows a `var`-redeclaration to
+  cross a `catch` parameter and has special TDZ handling that touches the same
+  `tdzFlagLocals`/`boxedTdzFlags` maps (`src/codegen/statements/nested-declarations.ts`,
+  `expressions/identifiers.ts`). Slice B adds head bindings to those maps — verify
+  the save/restore is symmetric so a for-in inside a `catch` body (or vice-versa)
+  doesn't leak a TDZ flag. Add a regression probe combining a `catch` and a
+  `for (let x in …)`.
+- **#1888 standalone open-any floor.** The standalone/WASI enumeration path
+  (lines 5480–5523, `__object_keys`/`__extern_*`) is governed by the open-any
+  floor; Slice B's per-iteration ref-cell + TDZ machinery is backend-agnostic
+  (operates on `boxedCaptures` before the enumeration primitives are chosen), so
+  it should not move the floor — but run the standalone floor check, since a new
+  `throw ReferenceError` import or ref-cell type can shift func/type indices.
+- **Index-shift / late-import hazards.** A new `throw ReferenceError` path or
+  ref-cell struct type registered late can shift func/type indices — register
+  shared types up-front (per `reference_subview_type_idx_stability`) and prefer
+  name-based repoint over positional.
+- **`continue` depth math.** If Slice B nests the per-iteration cell-clone in a
+  new block, the `breakStack`/`continueStack` `+= 3`/`-= 3` deltas (lines
+  5566–5614) must be updated in lockstep or `continue` lands on the wrong label.

--- a/plan/issues/2707-operators-unary-nullish-strict-eq-tco.md
+++ b/plan/issues/2707-operators-unary-nullish-strict-eq-tco.md
@@ -23,7 +23,7 @@ Three sub-bugs in operator codegen (BigInt and `with`-statement tests are exclud
 
 **(b) `strict-equals` / `strict-does-not-equals` edge: `false !== #`.** `S11.9.4_A8_T3.js`, `S11.9.4_A8_T2.js`, `S11.9.4_A8_T1.js`, `S11.9.5_A8_T3.js`, `S11.9.5_A8_T2.js`, `S11.9.5_A8_T1.js` — the `#` is a wasm function reference, and `false !== <funcref>` should be `true` (they are of different types) but our strict-equals emits incorrect results for the function-reference vs boolean case.
 
-**(c) Tail-call optimization is not recognized in `?:` / `&&` / `||` tail positions.** `conditional/tco-cond.js`, `conditional/tco-pos.js`, `logical-and/tco-right.js`, `logical-or/tco-right.js` — these set a `callCount` and assert it equals 1 (the function calls itself recursively but TCO should prevent stack growth). The `return_call` opcode is not being emitted for tail calls in the consequent/alternate of `?:` or the RHS of `&&`/`||`.
+**(c) Tail-call optimization is not recognized in `?:` / `&&` / `||` / comma / labeled-block tail positions.** `conditional/tco-cond.js`, `conditional/tco-pos.js`, `logical-and/tco-right.js`, `logical-or/tco-right.js`, `comma/tco-final.js`, `labeled/tco.js` — these set a `callCount` and assert it equals 1 (the function calls itself recursively but TCO should prevent stack growth). The `return_call` opcode is not being emitted for tail calls in the consequent/alternate of `?:`, the RHS of `&&`/`||`, the **final operand of a comma expression** (`return 0, f(n-1)`), or a **labeled return** (`test262: return f(n-1)`). All five are the **same tail-call-position recognition gap** — `emitReturnTail` (`src/codegen/statements/control-flow.ts:340`) only rewrites the *last emitted* `call`/`call_ref` to `return_call`, so a call buried inside a conditional/logical/comma sub-expression or a labeled wrapper is never recognized — in additional syntactic contexts.
 
 **Excluded (not in this issue):**
 - BigInt tests (`unsigned-right-shift/bigint.js`, `bitwise-not/bigint.js`, `unary-minus/bigint.js`, etc.) → blocked on #2044 (BigInt i64-brand).
@@ -56,13 +56,15 @@ test/language/expressions/strict-does-not-equals/S11.9.5_A8_T2.js
 test/language/expressions/strict-does-not-equals/S11.9.5_A8_T1.js
 ```
 
-### (c) TCO through conditional and logical operators (~4 tests)
+### (c) TCO through conditional, logical, comma, and labeled tail positions (~6 tests)
 
 ```
 test/language/expressions/conditional/tco-cond.js
 test/language/expressions/conditional/tco-pos.js
 test/language/expressions/logical-and/tco-right.js
 test/language/expressions/logical-or/tco-right.js
+test/language/expressions/comma/tco-final.js
+test/language/statements/labeled/tco.js
 ```
 
 ### Additional non-BigInt, non-with tests to confirm


### PR DESCRIPTION
## Summary

Planning-only PR (two issue files; no source touched).

### #2705 — for-in head lexical scope, TDZ, LHS targets, var visibility
Added a full `## Implementation Plan`:
- **Root cause** per sub-bug, all in `src/codegen/statements/loops.ts → compileForInStatement` (line 5389): one shared `externref` keyLocal, no per-iteration env, no TDZ, no head-env; LHS dispatch (lines 5399–5447) misses `ParenthesizedExpression` and the empty-VarDeclList `for (let in obj)` shape (crashes on `decl.name` of undefined); the var-decl-identifier branch allocates a fresh local instead of reusing the hoisted slot.
- **Scope correction:** the four `S12.6.4_A*` and `scope-*-var-none` tests are eval-based (route through dynamic `__extern_eval` because `allNodesInlineSupported` bails on `ForInStatement`) — NOT closeable by for-in changes; closeable set is **11 tests**.
- **Slicing:** Slice A (LHS dispatch + var-head local reuse + null-receiver guard, **5 tests**, low risk) → Slice B (head TDZ env + per-iteration fresh lexical binding reusing the C-style-for-loop ref-cell/TDZ machinery, **6 tests**, high risk) → Slice C (runtime null guard) → Slice D (eval-inline for-in, **deferred**).
- Edge cases, Wasm/IR patterns, and **#2552 (AnnexB TDZ)** / **#1888 (standalone floor)** / index-shift risk notes.

### #2707 — operators
Broadened the TCO sub-part from `?:/&&/||` to also cover **comma** and **labeled-block** tail positions (same `emitReturnTail` last-instr recognition gap, control-flow.ts:340) and added `comma/tco-final.js` + `labeled/tco.js` to the failing-tests list. Frontmatter untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)