### PR TITLE
fix(#2671): Date set* must not clobber [[DateValue]] re-set during ToNumber

### DIFF
--- a/plan/issues/2671-es6-builtin-spec-residuals-date-regexp-promise-json-super.md
+++ b/plan/issues/2671-es6-builtin-spec-residuals-date-regexp-promise-json-super.md
@@ -57,6 +57,37 @@ annexB/built-ins/Date/prototype/getYear/not-a-constructor.js
 - ⏳ Remaining Date: `set*` ToNumber-coercion side-effect ordering,
   `proto-from-ctor-realm-*`, not-a-constructor (#930-family).
 
+**Progress (dev-builtin2671c, 2026-06-26): `set*` Invalid-Date
+[[DateValue]]-clobber on ToNumber side-effect — SHIPPED (+12 test262).**
+
+Verified-first against the real test262 harness (`runTest262File`, `setExports`
+wired — critical: a `: any` receiver routes through generic host dispatch and
+silently bypasses the typed Date codegen, so the repro/test must let `dt` infer
+as `Date`, matching the plain-JS test262 source).
+
+Root cause in `compileDateMethodCall` (`src/codegen/expressions/builtins.ts`):
+the time-of-day setters (`setSeconds/setMinutes/setHours/setMilliseconds` +UTC)
+and the calendar setters `setDate/setMonth` (+UTC) read `t = [[DateValue]]`
+FIRST, then ToNumber each arg, then — §21.4.4.* step "If t is NaN, return NaN" —
+return WITHOUT writing `[[DateValue]]`. The compiler's invalid-branch wrote the
+Invalid-Date sentinel **unconditionally**, clobbering a `[[DateValue]]` that a
+ToNumber side-effect (`value.valueOf()` calling `this.setTime(0)`) had
+legitimately re-set. Fixed both then-branches to write the sentinel only when
+the receiver was still VALID before the call (`curTs != sentinel`) and an arg
+invalidated it; an already-invalid receiver now returns NaN without touching the
+slot.
+- `setFullYear/setUTCFullYear/setYear` (§21.4.4.21) are exempt — they
+  re-validate an Invalid receiver to `t=+0` and ALWAYS write — and were already
+  correct; their `isSetFullYear` then-branch keeps the unconditional write.
+- Flips 12 `built-ins/Date/prototype/<setter>/date-value-read-before-tonumber-when-date-is-invalid.js`
+  (the 12 non-FullYear setters; FullYear's 2 already passed). 230/232 pass across
+  the touched `set*`/`get*` dirs — the 2 residual setFullYear fails
+  (`15.9.5.40_1.js` not-a-constructor #930-family, `arg-year-to-number.js` valueOf
+  calling-convention) are pre-existing and unrelated.
+- Guard: `tests/issue-2671-date-setter-ordering.test.ts` (41/41).
+- ⏳ Remaining Date: `proto-from-ctor-realm-*`, not-a-constructor (#930-family),
+  `A4` multi-arg ctor `PoisonedValueOf` (object→f64 ToNumber on class instances).
+
 ### RegExp (95)
 `Symbol.split` / `Symbol.match` / `Symbol.replace` / `Symbol.search` protocol
 edge cases: `lastIndex` get/coerce errors, species constructor validation,

--- a/src/codegen/expressions/builtins.ts
+++ b/src/codegen/expressions/builtins.ts
@@ -1652,15 +1652,29 @@ function compileDateMethodCall(
     fctx.body.push({ op: "local.get", index: tempAnyInvalid } as Instr);
     fctx.body.push({ op: "i32.or" } as Instr);
 
-    // then-branch: write sentinel and push NaN.
+    // then-branch: the time-value result is NaN → push NaN. Write the
+    // Invalid-Date sentinel ONLY when the receiver was still VALID before
+    // this call (curTs != sentinel) and an arg coerced to NaN / out-of-range
+    // invalidated it — then §21.4.4.* step "Set dateObject.[[DateValue]] to u"
+    // stores NaN. When the receiver was ALREADY invalid (curTs == sentinel),
+    // the spec's earlier step "If t is NaN, return NaN" returns WITHOUT
+    // touching [[DateValue]]; a ToNumber side-effect during arg coercion (e.g.
+    // `value.valueOf()` calling `this.setTime(0)`) may have legitimately
+    // re-set it, and clobbering it back to the sentinel violates the spec
+    // (test262 date-value-read-before-tonumber-when-date-is-invalid).
     const savedThen = pushBody(fctx);
-    fctx.body.push({ op: "local.get", index: tempRef } as Instr);
+    fctx.body.push({ op: "local.get", index: tempCurTs } as Instr);
     fctx.body.push({ op: "i64.const", value: -9223372036854775808n } as Instr);
+    fctx.body.push({ op: "i64.ne" } as Instr);
     fctx.body.push({
-      op: "struct.set",
-      typeIdx: dateTypeIdx,
-      fieldIdx: 0,
-    });
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: tempRef } as Instr,
+        { op: "i64.const", value: -9223372036854775808n } as Instr,
+        { op: "struct.set", typeIdx: dateTypeIdx, fieldIdx: 0 } as Instr,
+      ],
+    } as unknown as Instr);
     fctx.body.push({ op: "f64.const", value: NaN } as Instr);
     const thenInstrs = fctx.body;
     popBody(fctx, savedThen);
@@ -1912,15 +1926,41 @@ function compileDateMethodCall(
       fctx.body.push({ op: "i32.or" } as Instr);
     }
 
-    // then-branch: invalid → sentinel + NaN.
+    // then-branch: invalid → NaN.
+    // setFullYear / setUTCFullYear / setYear (§21.4.4.21) re-validate an
+    // Invalid receiver (t → +0) and ALWAYS write [[DateValue]] (no early "if t
+    // is NaN return") — the then-branch is reached only when an arg coerced to
+    // NaN/out-of-range, so the sentinel write is unconditional. setDate /
+    // setMonth (+UTC) (§21.4.4.{20,24}) have step "If t is NaN, return NaN"
+    // which returns WITHOUT writing when the receiver was ALREADY invalid
+    // (curTs == sentinel) — a ToNumber side-effect during arg coercion
+    // (`value.valueOf()` calling `this.setTime(0)`) may have legitimately
+    // re-set it. So write the sentinel only when the receiver was still valid
+    // (curTs != sentinel) and an arg invalidated it
+    // (test262 date-value-read-before-tonumber-when-date-is-invalid).
     const savedThen = pushBody(fctx);
-    fctx.body.push({ op: "local.get", index: tempRef } as Instr);
-    fctx.body.push({ op: "i64.const", value: -9223372036854775808n } as Instr);
-    fctx.body.push({
-      op: "struct.set",
-      typeIdx: dateTypeIdx,
-      fieldIdx: 0,
-    });
+    if (isSetFullYear) {
+      fctx.body.push({ op: "local.get", index: tempRef } as Instr);
+      fctx.body.push({ op: "i64.const", value: -9223372036854775808n } as Instr);
+      fctx.body.push({
+        op: "struct.set",
+        typeIdx: dateTypeIdx,
+        fieldIdx: 0,
+      });
+    } else {
+      fctx.body.push({ op: "local.get", index: tempCurTs } as Instr);
+      fctx.body.push({ op: "i64.const", value: -9223372036854775808n } as Instr);
+      fctx.body.push({ op: "i64.ne" } as Instr);
+      fctx.body.push({
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: tempRef } as Instr,
+          { op: "i64.const", value: -9223372036854775808n } as Instr,
+          { op: "struct.set", typeIdx: dateTypeIdx, fieldIdx: 0 } as Instr,
+        ],
+      } as unknown as Instr);
+    }
     fctx.body.push({ op: "f64.const", value: NaN } as Instr);
     const thenInstrs = fctx.body;
     popBody(fctx, savedThen);

--- a/tests/issue-2671-date-setter-ordering.test.ts
+++ b/tests/issue-2671-date-setter-ordering.test.ts
@@ -1,0 +1,123 @@
+// #2671 (ES2015 Date residual) — Date setter [[DateValue]]-clobber on an
+// Invalid-Date receiver.
+//
+// Per ECMA-262 §21.4.4 the time-of-day setters (setSeconds/setMinutes/
+// setHours/setMilliseconds + UTC) and the calendar setters setDate/setMonth
+// (+UTC) read `t = dateObject.[[DateValue]]` FIRST, then run ToNumber on each
+// arg, then — "If t is NaN, return NaN" — return WITHOUT writing [[DateValue]].
+// The compiler's invalid-branch previously wrote the Invalid-Date sentinel
+// unconditionally, which CLOBBERED a [[DateValue]] that a ToNumber side-effect
+// (`value.valueOf()` calling `this.setTime(0)`) had legitimately re-set —
+// flipping 12 test262 `date-value-read-before-tonumber-when-date-is-invalid`
+// files. setFullYear/setUTCFullYear are exempt: §21.4.4.21 re-validates an
+// Invalid receiver to t=+0 and ALWAYS writes [[DateValue]] (step 8).
+//
+// NOTE: the receiver MUST be statically typed `Date` (the test262 source uses
+// `var dt = new Date(NaN)`, which TS infers as Date) so the typed Date-method
+// codegen path (compileDateMethodCall) fires. A `: any` annotation would route
+// through generic host dispatch and not exercise this code.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+
+async function run(body: string): Promise<any> {
+  const src = `export function test(): any { ${body} }`;
+  const result: any = await compile(src, { fileName: "test.ts", skipSemanticDiagnostics: true } as any);
+  expect(result.binary?.length).toBeGreaterThan(0);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  return wrapExports(instance.exports, { signatures: result.exportSignatures });
+}
+
+// A ToNumber side-effect object: calls `dt.setTime(0)` during coercion, then
+// reports 1. Used to prove the setter does NOT clobber [[DateValue]] back to
+// the sentinel after the side-effect ran. `dt` infers as Date (typed path).
+const sideEffect = (call: string) => `
+  var dt = new Date(NaN);
+  var calls = 0;
+  var value = { valueOf: function() { calls++; dt.setTime(0); return 1; } };
+  var result = dt.${call};
+`;
+
+describe("#2671 — Date setter Invalid-Date [[DateValue]] preservation", () => {
+  for (const m of [
+    "setSeconds",
+    "setMinutes",
+    "setHours",
+    "setMilliseconds",
+    "setDate",
+    "setMonth",
+    "setUTCSeconds",
+    "setUTCMinutes",
+    "setUTCHours",
+    "setUTCMilliseconds",
+    "setUTCDate",
+    "setUTCMonth",
+  ]) {
+    it(`${m}: ToNumber runs exactly once on an Invalid-Date receiver`, async () => {
+      const exp = await run(sideEffect(`${m}(value)`) + `return calls;`);
+      expect(exp.test()).toBe(1);
+    });
+
+    it(`${m}: returns NaN on an Invalid-Date receiver`, async () => {
+      const exp = await run(sideEffect(`${m}(value)`) + `return (result !== result) ? 1 : 0;`);
+      expect(exp.test()).toBe(1); // NaN !== NaN
+    });
+
+    it(`${m}: does NOT clobber [[DateValue]] re-set during ToNumber`, async () => {
+      // The valueOf side-effect set the time to 0; the setter must leave it.
+      const exp = await run(sideEffect(`${m}(value)`) + `return dt.getTime();`);
+      expect(exp.test()).toBe(0);
+    });
+  }
+
+  it("valid receiver + NaN arg DOES write the sentinel (date becomes Invalid)", async () => {
+    // Receiver valid, arg coerces to NaN → [[DateValue]] is set to Invalid.
+    const exp = await run(`
+      var d = new Date(2016, 6, 1);
+      var r = d.setSeconds(0, undefined); // ms = ToNumber(undefined) = NaN
+      var t = d.getTime();
+      return ((r !== r) && (t !== t)) ? 1 : 0;
+    `);
+    expect(exp.test()).toBe(1);
+  });
+
+  it("already-invalid receiver + valid arg, no side-effect: stays Invalid", async () => {
+    const exp = await run(`
+      var d = new Date(NaN);
+      var r = d.setSeconds(5);
+      var t = d.getTime();
+      return ((r !== r) && (t !== t)) ? 1 : 0;
+    `);
+    expect(exp.test()).toBe(1);
+  });
+
+  it("setFullYear is exempt: re-validates Invalid receiver to t=+0 and writes", async () => {
+    // valueOf side-effect sets time to 0; setFullYear(1) re-validates and
+    // writes the new value, so the result is finite and getFullYear() === 1.
+    const exp = await run(
+      sideEffect(`setFullYear(value)`) +
+        `return ((result === result) && dt.getTime() === result && dt.getFullYear() === 1) ? 1 : 0;`,
+    );
+    expect(exp.test()).toBe(1);
+  });
+
+  it("setUTCFullYear is exempt: re-validates Invalid receiver and writes", async () => {
+    const exp = await run(
+      sideEffect(`setUTCFullYear(value)`) + `return ((result === result) && dt.getTime() === result) ? 1 : 0;`,
+    );
+    expect(exp.test()).toBe(1);
+  });
+
+  it("normal valid-receiver setters are unaffected", async () => {
+    const exp = await run(`
+      var d = new Date(2016, 0, 1, 0, 0, 0, 0);
+      d.setSeconds(30, 500);
+      d.setDate(15);
+      d.setMonth(5, 20);
+      return (d.getSeconds() === 30 && d.getMilliseconds() === 500 && d.getDate() === 20 && d.getMonth() === 5) ? 1 : 0;
+    `);
+    expect(exp.test()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Issue #2671 — Date sub-area slice

ES2015 Date residual: `set*` ToNumber-coercion side-effect ordering.

### Root cause
In `compileDateMethodCall` (`src/codegen/expressions/builtins.ts`), the
time-of-day setters (`setSeconds`/`setMinutes`/`setHours`/`setMilliseconds`
+UTC) and the calendar setters `setDate`/`setMonth` (+UTC) read
`t = [[DateValue]]` FIRST, then run ToNumber on each arg, then — per ECMA-262
§21.4.4.* step **"If t is NaN, return NaN"** — return WITHOUT writing
`[[DateValue]]`. The compiler's invalid then-branch wrote the Invalid-Date
sentinel **unconditionally**, clobbering a `[[DateValue]]` that a ToNumber
side-effect (`value.valueOf()` calling `this.setTime(0)`) had legitimately
re-set.

### Fix
Both invalid then-branches now write the sentinel **only** when the receiver was
still VALID before the call (`curTs != sentinel`) and an arg invalidated it.
`setFullYear`/`setUTCFullYear`/`setYear` (§21.4.4.21) re-validate an Invalid
receiver to `t=+0` and ALWAYS write, so their `isSetFullYear` then-branch keeps
the unconditional write (unchanged behaviour).

### Validation (verified-first against the real test262 harness)
- Flips **12** `built-ins/Date/prototype/<setter>/date-value-read-before-tonumber-when-date-is-invalid.js`
  (the 12 non-FullYear setters; FullYear's 2 were already passing via re-validation).
- **230/232** pass across the touched `set*`/`get*` dirs. The 2 residual
  setFullYear fails (`15.9.5.40_1.js` not-a-constructor #930-family,
  `arg-year-to-number.js` valueOf calling-convention) are pre-existing and
  unrelated to this change.
- Guard test `tests/issue-2671-date-setter-ordering.test.ts` — 41/41.
- `tsc --noEmit`, prettier, biome all clean.

NOTE: the typed Date codegen path only fires when the receiver infers as `Date`
(as in the plain-JS test262 source); a `: any` annotation routes through generic
host dispatch and bypasses this code — the guard test types `dt` as `Date`
accordingly.

#2671 stays `ready` (umbrella tracking issue); sub-area notes updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)