### PR TITLE
fix(statusline): pre-planned sprint must not hijack the badge; set s67 planned

### DIFF
--- a/plan/issues/sprints/67.md
+++ b/plan/issues/sprints/67.md
@@ -1,7 +1,6 @@
 ---
 sprint: 67
-status: active
-started: 2026-06-26
+status: planned
 ---
 # Sprint 67 — ES3 conformance gap closure
 

--- a/scripts/statusline-sprint.mjs
+++ b/scripts/statusline-sprint.mjs
@@ -68,9 +68,40 @@ function flatTree() {
   return (_flatCache ??= scanFlatTree());
 }
 
+const SPRINTS_DIR = join(ISSUES_DIR, "sprints");
+// A sprint whose doc status is one of these is NOT the current working sprint,
+// even if its issues are already tagged `sprint: N` in frontmatter. This stops a
+// PRE-PLANNED future sprint (issues queued but the sprint not yet started) from
+// hijacking the "current sprint" pick — the bug where pre-creating sprint N+1's
+// issues made the badge jump to N+1 0/X while the team was still on sprint N.
+const INACTIVE_SPRINT_STATUSES = new Set(["planning", "planned", "closed", "done"]);
+function inactiveSprintNumbers() {
+  const out = new Set();
+  let names = [];
+  try {
+    names = readdirSync(SPRINTS_DIR);
+  } catch {
+    return out;
+  }
+  for (const f of names) {
+    const m = f.match(/^(\d+)\.md$/);
+    if (!m) continue;
+    let content;
+    try {
+      content = readFileSync(join(SPRINTS_DIR, f), "utf8");
+    } catch {
+      continue;
+    }
+    const st = content.match(/^status:\s*(\S+)/m)?.[1] ?? "";
+    if (INACTIVE_SPRINT_STATUSES.has(st)) out.add(Number(m[1]));
+  }
+  return out;
+}
+
 function currentSprint() {
   const buckets = flatTree();
-  const nums = [...buckets.keys()].sort((a, b) => b - a);
+  const inactive = inactiveSprintNumbers();
+  const nums = [...buckets.keys()].filter((n) => !inactive.has(n)).sort((a, b) => b - a);
   return nums[0] ?? 0;
 }
 


### PR DESCRIPTION
## Problem
Statusline showed `s67 0/8` while the team was working sprint 66. `scripts/statusline-sprint.mjs` is LIVE-FIRST (reads issue `sprint:` frontmatter) and `currentSprint()` picked the highest sprint **number** regardless of the sprint doc status. Pre-creating sprint 67's issues (#1846, #2702–#2708, all `sprint: 67`) hijacked the badge even though s67 hadn't started.

## Fix
- `currentSprint()` now skips sprints whose doc status is `planning`/`planned`/`closed`/`done`, so a pre-planned future sprint no longer hijacks the badge.
- `plan/issues/sprints/67.md`: `status: active` → `status: planned` (s67 is unstarted — 0/8, all `ready`).

## Verification
- Badge now reads `s66 20/68`. Status-driven: s67→active picks `s67 0/8`; `planned`→`s66 20/68`. JSON fallback unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)