### PR TITLE
docs(sprint-67): reconcile #2705 closeable count (20→11) + sprint total (149→140)

### DIFF
--- a/plan/issues/2705-for-in-head-lexical-scope-tdz-and-lhs-targets.md
+++ b/plan/issues/2705-for-in-head-lexical-scope-tdz-and-lhs-targets.md
@@ -83,7 +83,7 @@ This is marked `feasibility: hard` because (a) requires per-iteration environmen
 
 ## Acceptance criteria
 
-At least 18 of the 20 closeable listed tests (excluding eval-based and resizable-buffer) flip from fail to pass. No regression in `statements/for-in/` currently-passing tests. Full CI green.
+At least 10 of the **11** closeable listed tests flip from fail to pass (Slice A: 5, Slice B: 6). Note: 8 of the originally-listed for-in tests (`S12.6.4_A3/A3.1/A4/A4.1`, `scope-head-var-none`, `scope-body-var-none`, and the `cptn-*` set) route through `__extern_eval` because `allNodesInlineSupported` bails on `ForInStatement` — they are **eval-blocked, not closeable by this issue** (they belong to the eval-inline Slice D, deferred). See the Implementation Plan note below. No regression in `statements/for-in/` currently-passing tests. Full CI green.
 
 ## Notes
 

--- a/plan/issues/sprints/67.md
+++ b/plan/issues/sprints/67.md
@@ -28,13 +28,13 @@ Current ES3/Core category standings (dashboard, baseline 2026-06-26):
 | #2702 | instanceof spec correctness: HasInstance, non-object RHS, Symbol.hasInstance | 20 | medium |
 | #2703 | delete reference semantics: strict-mode TypeError throws, null base, super property | 28 | medium |
 | #2704 | arguments: trailing-comma length bug (async-gen/static), sloppy binding missing | ~32 | medium |
-| #2705 | for-in: head let/const TDZ, lexical scope open/close, LHS targets, var visibility | ~20 | hard |
+| #2705 | for-in: head let/const TDZ, lexical scope open/close, LHS targets, var visibility | ~11 | hard |
 | #2706 | for-in enumeration order: integer-index keys ascending, insertion-order, prototype chain | 5 | medium |
 | #2707 | operators: unary null-deref on nullish; strict-equals # edge; TCO in ?:/&&/\|\| | ~21 | medium |
 | #2708 | primitive/literal: legacy escapes \\8/\\9/octal, regexp \\u atoms, PutValue primitive-base | ~20 | medium |
 | #1846 | Minor typeof conformance (reactivated): symbol, built-in-exotic-objects, syntax whitespace | 3 | low |
 
-**Total target: ~149 tests closeable (not counting BigInt, with, or eval-blocked tests).**
+**Total target: ~140 tests closeable (not counting BigInt, with, or eval-blocked tests).** _(#2705 revised from ~20 to ~11 after the architect found 8 of its for-in tests route through `__extern_eval` — eval-blocked, deferred to Slice D.)_
 
 Note: #2705 is `feasibility: hard` — the architect must spec the per-iteration scope mechanism before a dev is dispatched. Route to architect first.
 


### PR DESCRIPTION
Reconciles the sprint-67 planning counts with the architect's scope finding in PR #2128.

The architect found 8 of #2705's listed for-in tests route through `__extern_eval` (`allNodesInlineSupported` bails on `ForInStatement`) — they are **eval-blocked**, not closeable by for-in lowering changes (deferred to Slice D).

- #2705 acceptance criteria: 'At least 18 of 20' → 'At least 10 of **11**' (Slice A: 5, Slice B: 6), with the eval-blocked carve-out spelled out.
- sprint-67 slate: #2705 ~20 → ~11.
- sprint-67 total target: ~149 → ~140.

Docs-only; no source touched.