### PR TITLE
docs(plan): sprint-66 architecture issues #2710-#2713

### DIFF
--- a/plan/issues/2710-late-bind-module-indices-eliminate-index-shift-class.md
+++ b/plan/issues/2710-late-bind-module-indices-eliminate-index-shift-class.md
@@ -1,0 +1,184 @@
+---
+id: 2710
+title: "Late-bind module indices (func/global/type) to eliminate the late-index-shift bug class"
+status: ready
+sprint: 66
+created: 2026-06-26
+updated: 2026-06-26
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: refactor
+area: codegen
+language_feature: compiler-internals
+goal: backend-agnostic-ir
+related: [1839, 1819, 1851, 1530, 2182]
+---
+# #2710 — Late-bind module indices to eliminate the index-shift bug class
+
+**Source:** 2026-06-26 codebase audit (tech lead). Recurring "bug factory" #1:
+manual function/global/type index shifting. Confirmed instances span the
+2026-06-04 fable review (#1839 string-import shift, #1819 logical-assign global
+index) and the 2026-06-26 audit (stale global index in static-prop assignment;
+optional-direct-call funcIdx not repointed; three drifted shifters).
+
+## Problem — eager index binding
+
+The compiler **binds module indices eagerly**: at instruction-construction time
+it bakes `ctx.funcMap.get(name)` (a *live position* in the function index space)
+directly into the `Instr` as `funcIdx`. Globals and types do the same. A *live
+position* is a value that keeps changing:
+
+- **Late imports** (`addUnionImports`, `addStringImports`, `ensureLateImport`)
+  append before defined functions → every defined-function index shifts by +N.
+- **String-constant / import globals** insert into the global space → every
+  `global.get`/`global.set` index shifts.
+- **Dead-code elimination** *removes* type entries → a full type renumber.
+
+Because the concrete index is already baked into thousands of emitted
+instructions, every such change must be **chased by hand** into all bodies +
+`ctx.currentFunc.body` + `pendingInitBody` + helpers + start func. That sweep is:
+
+1. **Triplicated and drifted** — `shiftLateImportIndices` (late-imports.ts:144),
+   plus two hand-rolled shifters in `index.ts` (`addStringImports`,
+   `addUnionImports`), plus `flushLateImportShifts` exists in **two** forked
+   copies (`shared.ts:376` **and** `late-imports.ts:574`). They have measurably
+   diverged (the #2039 flush guard, the asyncScheduler side-channel shift, the
+   generic-vs-op-allowlist funcIdx test).
+2. **An unwritten invariant applied ad hoc** — the "re-read the index after
+   compiling a sub-expression" rule is correct in some arms and forgotten in
+   adjacent arms of the *same* function (the `?? funcIdx` repoint hacks). Every
+   new emit site is a fresh opportunity to forget it.
+
+The bug class is definitionally: *a concrete index baked into instruction X went
+stale when the index space changed.* As long as instructions hold concrete
+indices, the class is reachable by construction.
+
+## Preconditions that make this tractable (verified on main 2026-06-26)
+
+1. **One serialization chokepoint** — `src/emit/binary.ts` is the *sole* place a
+   `funcIdx`/`globalIdx` becomes bytes (`enc.u32(instr.funcIdx)` at lines
+   950/955/1390). Every reference funnels through there.
+2. **A relocation/symbol model already exists** — `src/emit/object.ts` builds
+   stable symbols + `funcIdxToSymIdx`/`globalIdxToSymIdx` and resolves at emit
+   (`encodeInstrWithReloc`). It is only wired to the latent `.o` linker path; the
+   machinery is in-repo and proven.
+3. **A generic "iterate every index-bearing instruction" pass already exists** —
+   `shiftLateImportIndices` (late-imports.ts:160) keys on
+   `"funcIdx" in instr && typeof instr.funcIdx === "number"`. That is exactly the
+   seam a resolver plugs into.
+
+Scale (construction sites, current main): `op:"call"` ×1892, `op:"ref.func"` ×22,
+`global.get/set` ×409; index-bearing fields referenced: `funcIdx` ×3280,
+`globalIdx` ×198, `typeIdx` ×5988. Mid-compile *positional reads* of a numeric
+module index (the real migration surface): `mod.functions[idx]` ×94,
+`mod.globals[idx]` ×55.
+
+## Recommendation — bind indices *last*, not eagerly
+
+Instructions reference functions/globals/types by a **stable handle**: an opaque
+id minted at registration that is **never renumbered and never reused**. One
+`resolveLayout()` pass runs after all imports/functions/globals/types are
+registered and after DCE; it computes the canonical layout (imports-first,
+post-DCE) and produces `handle → finalIndex` maps. `binary.ts` dereferences
+handle→index as it writes bytes.
+
+**Why this is structurally immune** (not merely better-tested): if no instruction
+ever holds a concrete index — only a handle *defined* to be layout-independent —
+there is nothing a late import can invalidate. "Late additions don't disturb
+emitted code" stops being a discipline every author must remember and becomes
+true *by construction*. The reactive sweep disappears because there was never
+anything to sweep.
+
+### Minimal-churn form (recommended)
+
+Keep the instruction shape `{op:"call", funcIdx}` and **redefine `funcIdx` to
+mean a stable handle**, not a live index. The ~2300 construction sites already
+write `ctx.funcMap.get(name)` — make `funcMap` return a stable handle and they
+are unchanged. Work concentrates at two seams:
+
+- the ~150 mid-compile positional reads (`mod.functions[idx]`,
+  `mod.globals[idx]`) become handle-keyed lookups (some compute
+  `idx - numImportFuncs` relative offsets assuming imports-first — those need
+  care);
+- one `resolveLayout()` + the `binary.ts` dereference.
+
+### Enforcement that makes it a *single safe process*
+
+Brand the handle types:
+
+```ts
+type FuncHandle   = number & { readonly __func:   unique symbol };
+type GlobalHandle = number & { readonly __global: unique symbol };
+type TypeHandle   = number & { readonly __type:   unique symbol };
+```
+
+Any code that uses a handle as a raw array index now **fails to typecheck**.
+TypeScript mechanically enumerates the migration surface and permanently prevents
+reintroducing a positional read. That is the structural guarantee: not "we
+remembered to resolve everywhere," but "the typechecker refuses to compile a
+concrete-index use."
+
+### Bonus: subsumes the type-DCE renumber factory for free
+
+funcIdx shift is monotonic (+N); type DCE is *remove-and-renumber* — a worse
+problem the current shifters don't fully handle (see project memory
+`project_type_index_shift_and_deadelim`). Under late binding both are identical:
+types get handles, `resolveLayout` emits the live-type ordering after DCE,
+instructions referenced handles all along. **One mechanism kills three index-shift
+factories** (functions, globals, types — and tags/tables/elems/data come along).
+
+## What gets deleted (payoff)
+
+- `shiftLateImportIndices` (late-imports.ts:144); both `flushLateImportShifts`
+  copies (shared.ts:376, late-imports.ts:574); the two hand-rolled shifters in
+  `index.ts` (`addStringImports`, `addUnionImports`).
+- `localGlobalIdx`, `fixupModuleGlobalIndices`, `shiftMap` over
+  `funcMap`/`staticProps`/`funcClosureGlobals` (imports.ts:132/153/277).
+- Every `?? funcIdx` "name-based repoint" hack and the `flushLateImportShifts`
+  ordering dependencies in `exceptions.ts` / `context/speculative.ts`.
+- Makes unreachable: audit findings (static-prop stale global; optional-call
+  funcIdx) and #1839 / #1819.
+
+## Migration plan (phased — each step ships green)
+
+1. **Introduce branded handle types**, aliased to `number` — zero runtime change;
+   compile errors now flag every positional read. Brand `funcMap`'s value and
+   `Instr.funcIdx`/`globalIdx`/`typeIdx`.
+2. **Add `resolveLayout()` as an identity map** (handles == current indices) and
+   wire `binary.ts` through it. Pure plumbing, behaviour-identical — proves the
+   path with zero output diff (assert byte-identical emit on the equivalence
+   suite).
+3. **Convert the ~150 positional reads** to handle-keyed lookups, typechecker-
+   guided. Audit the `idx - numImportFuncs` relative-offset sites specifically.
+4. **Mint non-renumbering handles at registration**; `resolveLayout` computes the
+   real permutation. Delete the shifters one at a time, each behind a full CI run
+   (equivalence + test262 + standalone floor).
+5. **Remove** `localGlobalIdx`/`fixupModuleGlobalIndices`/`flush*`/`shift*` and
+   the repoint hacks. Class gone.
+
+## Acceptance criteria
+
+- [ ] Branded `FuncHandle`/`GlobalHandle`/`TypeHandle` exist; using a handle as a
+      raw array index is a compile error.
+- [ ] A single `resolveLayout(mod)` produces `handle → finalIndex` maps; it is the
+      only place module indices are assigned, and runs once after registration +
+      DCE.
+- [ ] `binary.ts` dereferences handles at serialization; no instruction holds a
+      concrete module index before that point.
+- [ ] `shiftLateImportIndices`, both `flushLateImportShifts`, both hand-rolled
+      `index.ts` shifters, `localGlobalIdx`, `fixupModuleGlobalIndices`, and the
+      `?? funcIdx` repoints are deleted.
+- [ ] No behaviour change: equivalence suite byte-identical (steps 1–2),
+      test262 non-regressing, standalone floor green (full CI / merge_group, not
+      a scoped sweep — broad-impact change, see project memory).
+- [ ] Type-DCE renumber routes through the same `resolveLayout` (one mechanism).
+
+## Notes
+
+- Net performance is *better*: one resolve pass replaces N reactive full-body
+  sweeps run today.
+- Coordinates with the (done) #1851 legalization boundary; this is the
+  index-binding analogue of that seam work.
+- Broad-impact, cross-cutting: senior-developer / Opus-tier, max reasoning. Land
+  behind the phased plan; never a single mega-PR.

--- a/plan/issues/2711-standalone-host-differential-parity-ci-gate.md
+++ b/plan/issues/2711-standalone-host-differential-parity-ci-gate.md
@@ -1,0 +1,71 @@
+---
+id: 2711
+title: "Standalone↔host differential parity CI gate over the builtin surface (fail-loud, not trap)"
+status: ready
+sprint: 66
+created: 2026-06-26
+updated: 2026-06-26
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: test-infra
+area: codegen-linear
+language_feature: standalone
+goal: standalone-everything
+related: [1854, 1838, 1662, 1535]
+---
+# #2711 — Standalone↔host differential parity CI gate
+
+**Source:** 2026-06-26 audit. Recurring "bug factory" #4: the standalone /
+linear path systematically lags the JS-host path and **fails by trapping or by
+emitting an unsatisfiable late import** rather than failing loud. test262 runs
+one mode, so these never surface there. Given the product direction is
+**standalone-everything**, this is a release-gating class.
+
+## Problem
+
+Concrete divergences found (all standalone-only, host mode correct):
+
+- `flat`/`flatMap` are host-import-only — `ensureLateImport("__array_flat"/
+  "__array_flatMap")` with no `ctx.standalone` guard and no native arm
+  (`array-methods.ts:8748/8790`) → **module fails to instantiate** in WASI.
+- dedicated `indexOf`/`includes`/`lastIndexOf` on externref-element arrays emit
+  `__host_eq`/`__same_value_zero` with no standalone branch
+  (`array-methods.ts:4034/4262/8648`) → unsatisfiable import.
+- linear backend bitwise operands + Uint8Array stores use trapping
+  `i32.trunc_f64_s` (`codegen-linear/index.ts:3954/3201`) → `NaN|0`, `u8[i]=NaN`
+  **trap** instead of ToInt32/ToUint8 wrap.
+- try/`finally` with an early `return`/`break` inlines past the finally
+  (`codegen-linear/index.ts:741`) → finally silently skipped.
+- standalone `/i` is ASCII-only; `/u`,`/v` match per-code-unit; JSON booleans/null
+  box as numbers (`json-codec-native.ts:1361`); `JSON.parse` accepts malformed
+  number/`\uXXXX` grammar.
+
+#1854 already built a **cross-backend differential harness** (done) but it is not
+wired as a **CI gate over the builtin surface**, so these slip through.
+
+## Recommendation
+
+1. **Promote #1854's harness to a required CI gate** that runs a corpus
+   (start: the builtin-method equivalence cases + a standalone-targeted sweep)
+   through **both** WasmGC/host and linear/standalone and asserts identical
+   observable output (`.status` + value, per project memory on `.status` not
+   `.outcome`). Diverge ⇒ red.
+2. **Make "unsupported in standalone" fail loud, never trap or emit an
+   unsatisfiable import.** A method with no native arm must `reportError` when
+   `ctx.standalone`/`wasi`, the way #1838 made linear `try/catch` refuse loudly.
+   This converts silent miscompiles/instantiation failures into compile errors
+   with a tracked gap.
+3. File the per-method native-arm gaps (flat/flatMap, externref search, regex
+   case-fold/unicode, JSON grammar, linear trunc/​finally) as child issues; this
+   issue owns the **gate + fail-loud policy**, not each method.
+
+## Acceptance criteria
+
+- [ ] Differential harness runs in CI as a required check over the builtin corpus
+      in both modes; a host↔standalone divergence fails the PR.
+- [ ] Standalone compile of a method with no native arm produces a compile error
+      (tracked gap), not a trap or unsatisfiable import.
+- [ ] Linear backend: bitwise/typed-array conversions use `i32.trunc_sat_f64_s`;
+      try/finally early-exit runs the finally (or refuses loudly).
+- [ ] Child issues filed for each enumerated native-arm gap.

--- a/plan/issues/2712-real-bool-valtype-retire-i32-boolean-brand.md
+++ b/plan/issues/2712-real-bool-valtype-retire-i32-boolean-brand.md
@@ -1,0 +1,69 @@
+---
+id: 2712
+title: "Introduce a real bool ValType; retire the optional i32 boolean brand"
+status: ready
+sprint: 66
+created: 2026-06-26
+updated: 2026-06-26
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: refactor
+area: codegen
+language_feature: value-representation
+goal: value-rep-substrate
+related: [1788, 1917, 2580]
+---
+# #2712 — Real bool ValType; retire the optional i32 boolean brand
+
+**Source:** 2026-06-26 audit. Recurring "bug factory" #2: representation
+collision. `{kind:"i32"}` simultaneously means **number**, **boolean**, and
+**char-code**. Booleanness is carried as an *optional* side-channel brand
+(`{kind:"i32", boolean:true}`, `src/checker/type-mapper.ts`) that **every boxing
+site must remember to consult** — and several don't.
+
+## Problem
+
+#1788 (done) added `__box_boolean` and the brand for the dynamic-getter path, but
+the brand is dropped at multiple boxing sites, so a boolean reifies as the
+*number* 1/0:
+
+- `Object.values`/`Object.entries` box a boolean field as `1`/`0`
+  (`object-ops.ts:4000-4003`, `:4059-4063`) → `Object.values({a:true})[0]===true`
+  is false; `typeof` is `"number"`.
+- Map/Set key coercion boxes boolean keys as numbers (`map-runtime.ts:1204-1212`);
+  `__same_value_zero` has no boolean arm → `new Set([true]).has(1)` wrongly true.
+- `__to_property_key` has no boolean arm (`object-runtime.ts:459-502`) → `o[true]`
+  keys `"1"` not `"true"`; a null/undefined computed key hits a non-null
+  `ref.cast $AnyString` and **traps**.
+- `coerceType` i32→externref drops the brand (`type-coercion.ts:1525-1537`) even
+  though the adjacent i64→externref arm honours the analogous `bigint` brand.
+
+Any *new* i32→externref site is a latent boolean-as-number bug. The brand is the
+wrong shape: optionality means correctness depends on memory, not on types.
+
+## Recommendation
+
+Promote boolean to a **first-class ValType** (`{kind:"bool"}`), the way `bigint`
+already has a typed i64 lane. Then:
+
+- boxing dispatches on the ValType (`bool` → `__box_boolean`) — unrepresentable to
+  "forget the brand";
+- `__same_value_zero`, `__to_property_key`, `Object.values/entries`,
+  `coerceType`, and the descriptor reify path each gain a `bool` arm by
+  construction (the type forces the switch to be exhaustive);
+- the i32 lane reverts to meaning *number/char-code* only.
+
+This is value-rep substrate work — coordinate with #1917 (single coercion engine)
+and the #2580 substrate spine so the bool lane lands once, centrally.
+
+## Acceptance criteria
+
+- [ ] A `bool` ValType exists; the checker emits it where it currently emits
+      `{kind:"i32", boolean:true}`.
+- [ ] All boxing/coercion/property-key/SameValueZero sites dispatch on `bool`;
+      the optional `boolean:true` brand is removed.
+- [ ] `Object.values({a:true})[0]===true`, `new Set([true]).has(1)===false`,
+      `o[true]` keys `"true"`, `o[null]` keys `"null"` (no trap) — all in both
+      host and standalone modes.
+- [ ] Equivalence + test262 non-regressing; full-CI / merge_group (broad impact).

--- a/plan/issues/2713-ir-legacy-parity-correctness-twins.md
+++ b/plan/issues/2713-ir-legacy-parity-correctness-twins.md
@@ -1,0 +1,70 @@
+---
+id: 2713
+title: "IR↔legacy parity: IR path re-introduces correctness bugs fixed only on the legacy side"
+status: ready
+sprint: 66
+created: 2026-06-26
+updated: 2026-06-26
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: ir
+language_feature: compiler-internals
+goal: backend-agnostic-ir
+related: [1821, 1981, 1375, 1530, 1927]
+---
+# #2713 — IR↔legacy parity correctness twins
+
+**Source:** 2026-06-26 audit. Recurring "bug factory" #3: the IR front-end
+re-introduces correctness bugs that were fixed **only on the legacy AST→Wasm
+path**, because the IR lowering was never given the fix and there is no test
+forcing parity. The IR verifier checks structure, not semantics, so these are
+*committed* miscompiles, not clean demotes.
+
+## Confirmed instances (current main)
+
+- **`delete o.x` returns constant `true`, performs no deletion** —
+  `ir/from-ast.ts:1393-1405` lowers the operand for side effects then
+  `emitConst({kind:"bool", value:true})`. Legacy twin #1821 is **done**; the IR
+  path is the un-fixed twin. `const o={a:1}; delete o.a; return o.a;` → `1`.
+- **`string === null` folded to a constant** — `ir/from-ast.ts:4148-4196`
+  (`tryFoldNullCompare`) bails for boxed/extern/class/object/closure/ref_null
+  (the #1981 fix) but **not** for a `val{string}` operand, which lowers to a
+  nullable ref. An exported/host-facing fn receiving `null` for a string param
+  sees `s===null` folded to `false`. Same bug class as #1981, left open for the
+  string arm.
+- **`a?.[i]` drops the optional short-circuit** — `ir/from-ast.ts:1908`
+  (`lowerElementAccess`) never reads `questionDotToken`; selector accepts it
+  (`select.ts:1744`). On a null receiver it **traps** instead of yielding
+  `undefined`. (Legacy/property twins handled under #1375/#1981.)
+- **`void <expr>` always materializes `f64 NaN`** — `ir/from-ast.ts:1415-1418`,
+  contradicting its own guard comment; wrong representation of `undefined` in a
+  non-f64 carrier.
+- **rest/default/optional params slip the identifier-only param gate** —
+  `ir/from-ast.ts:300` gates only `!ts.isIdentifier(p.name)`; `...args`, `x=5`,
+  `x?` keep an Identifier name, so their semantics are dropped on closure /
+  nested-func / method param paths (a regression against #1372's intent, which
+  was to reject them to legacy).
+
+## Recommendation
+
+1. **Fix the five instances** — bail the string arm in `tryFoldNullCompare`;
+   route IR `delete` through the real property-delete helper (or refuse to legacy);
+   honour `questionDotToken` in `lowerElementAccess` (short-circuit or clean
+   fallback); make `void` respect its carrier; tighten the param gate to reject
+   rest/default/optional to legacy.
+2. **Add the structural guard** — a parity rule that **every legacy-path
+   correctness fix ships an IR-path test** (or an explicit "IR demotes here"
+   assertion). The #2711 differential harness is the natural home: run the same
+   corpus through IR-on and IR-off and assert identical output. This converts the
+   "fixed on one path only" failure mode into a red test.
+
+## Acceptance criteria
+
+- [ ] All five instances fixed (each a committed correct answer or a clean
+      legacy demote, never a trap or wrong constant).
+- [ ] A differential IR-on vs IR-off check exists over the correctness corpus and
+      is green; the five repros are in it.
+- [ ] test262 non-regressing; the IR-claimed subset of each repro produces the
+      spec result.


### PR DESCRIPTION
Captures the four root-cause "bug factory" items from the 2026-06-26 codebase audit as sprint-66 issues. **Planning docs only — no source changes** (adds 4 files under `plan/issues/`).

| Issue | Factory | What |
|-------|---------|------|
| **#2710** | index-shift | Late-bind module indices (func/global/type) via a single `resolveLayout()` pass at the `binary.ts` serialization chokepoint + branded handle types. Eliminates the late-index-shift bug class and subsumes the type-DCE renumber. Reuses the relocation model already in `src/emit/object.ts`. |
| **#2711** | dual-mode | Promote #1854's cross-backend differential harness to a required CI gate over the builtin surface; make unsupported-in-standalone fail loud instead of trapping / emitting an unsatisfiable import. |
| **#2712** | rep-collision | Real `bool` ValType; retire the optional `{kind:"i32",boolean:true}` brand that several boxing sites drop. |
| **#2713** | IR↔legacy parity | Fix five IR-path twins of legacy-only fixes (delete→true, `string===null` fold, `a?.[i]` trap, `void` NaN, rest/default/optional param gate) + a parity-test guard. |

IDs allocated atomically via `claim-issue.mjs --allocate`. All carry `sprint: 66` frontmatter; the index-shift refactor (#2710) is the flagship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)