### PR TITLE
docs: block #2566 on #2662, reschedule #2106 to s67

### DIFF
--- a/plan/issues/2106-valuerep-p3-undefined-observability.md
+++ b/plan/issues/2106-valuerep-p3-undefined-observability.md
@@ -3,9 +3,9 @@ id: 2106
 title: "value-rep P3: undefined observability — UNDEF_F64 sentinel, union-collapse reversal (flagged), standalone $undefined singleton"
 status: in-progress
 assignee: ttraenkler/sdev-s1fix
-sprint: 66
+sprint: 67
 created: 2026-06-11
-updated: 2026-06-25
+updated: 2026-06-26
 s1_note: "S1 (standalone tag-1 $undefined singleton) NOT COMPLETE — PR #2025 was AUTO-PARKED in merge_group (2026-06-24): standalone high-water floor breached (pass 23729 vs mark 24956), NET −1245 test262 rows (1654 regressed / 409 gained). Root cause (diagnosed by sdev-s1fix 2026-06-25, see '## S1 merge_group regression — diagnosis'): S1.1 flipped the CONSUMER __extern_is_undefined to singleton-only but did NOT flip the matching PRODUCERS (notably __extern_get's missing-key return at object-runtime.ts:856, still ref.null.extern), so destructuring/param defaults stop firing. This is the architect-spec's full ~40-site producer+consumer sweep done as a partial subset — there is NO narrow floor-saving fix. RESOLUTION 2026-06-25: S1.1+S1.2 behavioral flips REVERTED on the branch (kept inert S1.0); PR #2025 re-targets to a floor-neutral revert. S1 to be re-landed as a fully-scoped complete sweep (architect re-spec). REMAINING slices unchanged: S2 (sNaN carve-out), S3 (number|undefined→externref), S4 (union-collapse reversal), typeof-null→object."
 priority: high
 feasibility: hard
@@ -20,6 +20,13 @@ reconcile_note: "2026-06-24 (PO reconcile vs upstream/main): SUSPENDED, not dev-
 ---
 
 # #2106 — T | undefined collapses to bare T
+
+> **2026-06-26 — rescheduled to s67 (upcoming).** PR #1961 (standalone strict-eq
+> over type-erased nullish — the manual rep-block partial) CLOSED as superseded.
+> The standalone `===`/`!==` nullish observability it targeted is delivered by S1
+> (the `$undefined` tag-1 singleton), to be re-landed as the architect-re-spec'd
+> full producer+consumer sweep (a partial S1 subset breaches the standalone floor
+> — see #2025).
 
 ## Problem
 

--- a/plan/issues/2566-eager-generator-overconsumes-in-dstr.md
+++ b/plan/issues/2566-eager-generator-overconsumes-in-dstr.md
@@ -1,10 +1,11 @@
 ---
 id: 2566
 title: "Eager-buffer generator over-consumes in array destructuring (capturing generators yield wrong side-effect counts; trailing elision steps too far)"
-status: ready
+status: blocked
+blocked_by: 2662
 sprint: 66
 created: 2026-06-21
-updated: 2026-06-21
+updated: 2026-06-26
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -19,6 +20,17 @@ origin: "2026-06-21 split out of #2203. #2203 fixed the STANDALONE invalid-Wasm 
 ---
 
 # #2566 — Eager-buffer generator over-consumes in array destructuring
+
+> **BLOCKED on #2662 (verify-first, dev-1556b 2026-06-26).** Re-confirmed the
+> eager over-consume on current `origin/main`: `function* g(){first+=1;yield;second+=1;} let [,]=g();`
+> ⇒ `second=1` (want `0`); two-yield / empty-pattern cases also run the body to
+> completion. Root cause is #2662 — the default gc-mode **host generator backend
+> is eager-buffered** (drains the whole body into `buf:any[]` at call time, then
+> `.next()` just replays the buffer), so destructuring cannot step the iterator
+> once-per-element per §13.3.3.6. There is **no focused dstr-codegen fix** until
+> #2662's lazy/suspendable host backend lands (the native lazy machine is
+> standalone-only and bails on captured outer-scope bindings, which these cases
+> intrinsically have).
 
 ## Problem
 


### PR DESCRIPTION
## Summary

Two planning-frontmatter updates (docs-only, no compiler source):

1. **#2566** (eager generator over-consumes in dstr) → `status: blocked`, `blocked_by: 2662`. Verify-first re-confirmed the eager over-consume on current `main` (`let [,]=g()` runs the generator body to completion). Root cause is **#2662** — the default gc-mode host generator backend is eager-buffered (drains the whole body into `buf[]` at call time). No focused dstr-codegen fix exists until #2662's lazy/suspendable backend lands.

2. **#2106** (value-rep P3 undefined observability) → `sprint: 66` → `sprint: 67` (scheduled for the upcoming sprint). Body note: PR #1961 (the manual rep-block partial for standalone strict-eq over type-erased nullish) closed as superseded — that observability is delivered by S1 (`$undefined` tag-1 singleton), to be re-landed as the architect-re-spec'd full producer+consumer sweep (a partial S1 subset breaches the standalone floor, see #2025).

🤖 Generated with [Claude Code](https://claude.com/claude-code)