### PR TITLE
refactor(#2710): late-bind module indices — slices 0+1 foundation

### DIFF
--- a/plan/issues/2710-late-bind-module-indices-eliminate-index-shift-class.md
+++ b/plan/issues/2710-late-bind-module-indices-eliminate-index-shift-class.md
@@ -1,7 +1,8 @@
 ---
 id: 2710
 title: "Late-bind module indices (func/global/type) to eliminate the late-index-shift bug class"
-status: ready
+status: in-progress
+assignee: ttraenkler/sd-indexshift
 sprint: 67
 created: 2026-06-26
 updated: 2026-06-26
@@ -463,3 +464,62 @@ unreachable by construction.
   every `?? funcIdx` repoint hack, and the `flushLateImportShifts` ordering deps.
 - Makes unreachable: #2078, #2191/#2193, #1839, #1819, and the recurring
   `project_type_index_shift_and_deadelim` factory.
+
+## Progress log
+
+### Slices 0 + 1 — foundation landed (sd-indexshift, 2026-06-26)
+
+**Scope of this PR:** the *safe foundation* only — slice 0 (proof harness) and
+slice 1 (handle vocabulary as transparent aliases). It does **not** add
+`resolveLayout`, wire `binary.ts`, convert positional reads, mint
+non-renumbering handles, or delete any shifter. The umbrella issue therefore
+stays `in-progress`; slices 2–5 are follow-up tasks.
+
+**Slice 0 — `scripts/prove-emit-identity.mjs`.** A sha256 byte-identity oracle:
+compiles the `website/playground/examples` corpus across the `{gc, standalone,
+wasi}` target matrix and records `sha256(emitBinary(mod))` per `(file,target)`.
+`write` mode captures a golden baseline; `check` mode fails (exit 1) on any
+single drift, pinpointing the exact `(file,target)`. The baseline is a hash of
+raw emitted bytes — it legitimately changes on most unrelated PRs — so it is
+written to gitignored `.tmp/` and is **never committed**; this is a developer
+proof tool, not a CI gate. It is the regression oracle for every later slice
+(reproducing the current final layout makes each slice byte-identical, so any
+representation bug shows up as a single sha mismatch — far sharper than test262
+row counts).
+
+**Slice 1 — branded handle types as pure aliases (`src/ir/types.ts`).** Defined
+`FuncHandle` / `GlobalHandle` / `TypeHandle` and pinned them onto the correct,
+*discriminated* `Instr` arms + type defs:
+- `funcIdx: FuncHandle` on `call` / `return_call` / `ref.func`; func-index
+  side-channels in this file (`WasmModule.startFuncIdx`, `declaredFuncRefs`,
+  `Element.funcIndices`).
+- `index: GlobalHandle` on **`global.{get,set}` only** — `local.{get,set,tee}`
+  share the `index` field name but are function-scoped and never shift, so they
+  stay raw `number`. This per-union-member field typing is the load-bearing
+  discrimination: `binary.ts` already switches on `op` at the encode seams, so
+  the global arms can later dereference a handle while the local arms pass
+  through unchanged.
+- `typeIdx: TypeHandle` on every type-bearing arm (`struct.*`, `array.*` incl.
+  `array.copy` `dst/srcTypeIdx`, `ref.cast{,_null}`, `ref.test`, `ref.null`,
+  `call_indirect`, `call_ref`, `return_call_ref`), plus `ValType.ref/ref_null`,
+  `BlockType{kind:"type"}`, `WasmFunction.typeIdx`, `StructTypeDef.superTypeIdx`,
+  `SubTypeDef.superType`, `TagDef.typeIdx`, `ImportDesc.func/tag.typeIdx`.
+- Left as raw `number` (separate index spaces, never the three handle kinds):
+  `tableIdx`, `fieldIdx`, `tagIdx`, and `WasmExport.desc.index` (polymorphic
+  func/table/memory/global/tag).
+
+**Why aliases, not the real `unique symbol` brand, in this slice.** The brand's
+*enforcement* (turning `mod.functions[h]` / `h - numImportFuncs` / `h + delta`
+into compile errors) only becomes safe AFTER the ~150 positional reads are
+converted (slices 3–4) and registration sites mint handles. Flipping the brand
+now would leave the tree red. So slice 1 ships the alias form: zero runtime
+change, fully interchangeable with `number`, `tsc`-clean, and **byte-identical**
+(brands erase). The future flip to
+`number & { readonly __func: unique symbol }` is a one-line change per type in
+`src/ir/types.ts` — the vocabulary and the correct arm placement are already in
+place, so that later slice only has to chase the errors `tsc` then surfaces.
+
+**Proof:** `tsc --noEmit` clean; `prove-emit-identity.mjs check` reports
+`IDENTICAL — all 39 (file,target) emits match baseline` (gc + standalone + wasi).
+Files touched: `scripts/prove-emit-identity.mjs` (new), `src/ir/types.ts`
+(typing only).

--- a/scripts/prove-emit-identity.mjs
+++ b/scripts/prove-emit-identity.mjs
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// scripts/prove-emit-identity.mjs — emitted-Wasm byte-identity oracle (#2710 slice 0).
+//
+// WHY THIS EXISTS
+// ---------------
+// #2710 ("late-bind module indices") is a representation refactor: instructions
+// stop holding live func/global/type *indices* and start holding stable
+// *handles* that a single `resolveLayout()` dereferences to the final index at
+// serialization. The migration's whole safety argument is that it reproduces the
+// CURRENT final layout byte-for-byte — so EVERY slice must emit identical bytes.
+//
+// This harness is that proof. It compiles a fixed corpus across the target
+// matrix and records `sha256(emitBinary(mod))` per `(file, target)`. Run it
+// once to capture a golden baseline, make a refactor edit, then run it in
+// `check` mode: any single sha mismatch pinpoints the exact `(file, target)`
+// that drifted — a far sharper regression signal than test262 row counts.
+//
+// It is a DEVELOPER PROOF TOOL, not a committed CI gate: the baseline is a hash
+// of raw emitted bytes, which legitimately changes on most unrelated PRs, so it
+// is written to a gitignored location (`.tmp/` by default) and never committed.
+//
+// USAGE
+//   npx tsx scripts/prove-emit-identity.mjs               # write baseline (.tmp/emit-identity-baseline.json)
+//   npx tsx scripts/prove-emit-identity.mjs write         # explicit write
+//   npx tsx scripts/prove-emit-identity.mjs check         # compare against baseline; exit 1 on any drift
+//   npx tsx scripts/prove-emit-identity.mjs check --baseline /path/to/file.json
+//   npx tsx scripts/prove-emit-identity.mjs --root <dir>  # add an extra corpus root (repeatable)
+//
+// Typical byte-identity proof (slices 1–4):
+//   npx tsx scripts/prove-emit-identity.mjs        # golden baseline BEFORE the edit
+//   <apply refactor edits>
+//   npx tsx scripts/prove-emit-identity.mjs check  # must print "IDENTICAL" and exit 0
+
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync, mkdirSync } from "node:fs";
+import { join, dirname, resolve, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { compile } from "../src/index.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+
+// The canonical, curated, known-compilable corpus — the same root
+// `check-ir-fallbacks.ts` walks. Extra roots may be added with `--root <dir>`.
+const DEFAULT_CORPUS_ROOTS = [join(REPO_ROOT, "website/playground/examples")];
+
+// The full backend matrix this refactor must keep byte-identical. `gc` is the
+// default WasmGC lowering; `standalone`/`wasi` exercise the late-import +
+// string-constant-global paths that are exactly the index-shift bug surface.
+const TARGETS = /** @type {const} */ (["gc", "standalone", "wasi"]);
+
+const DEFAULT_BASELINE = join(REPO_ROOT, ".tmp/emit-identity-baseline.json");
+
+/** Recursively list `.ts` files (excluding `.d.ts`), sorted for determinism. */
+function listTsFiles(root) {
+  const out = [];
+  if (!existsSync(root)) return out;
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    for (const name of readdirSync(dir).sort()) {
+      const p = join(dir, name);
+      const s = statSync(p);
+      if (s.isDirectory()) stack.push(p);
+      else if (s.isFile() && name.endsWith(".ts") && !name.endsWith(".d.ts")) out.push(p);
+    }
+  }
+  return out.sort();
+}
+
+/**
+ * Compile one `(file, target)` and return a deterministic record. A compile
+ * error (CE) is itself a stable outcome and is recorded (with the first error
+ * line) so a slice that flips CE<->success is also caught as drift.
+ */
+async function probe(filePath, target) {
+  const source = readFileSync(filePath, "utf-8");
+  try {
+    const r = await compile(source, { target });
+    if (!r.success || !r.binary) {
+      return { status: "ce", detail: (r.errors?.[0]?.message ?? "no binary").split("\n")[0].slice(0, 160) };
+    }
+    return {
+      status: "ok",
+      sha256: createHash("sha256").update(r.binary).digest("hex"),
+      bytes: r.binary.length,
+    };
+  } catch (e) {
+    return {
+      status: "throw",
+      detail: String(e?.message ?? e)
+        .split("\n")[0]
+        .slice(0, 160),
+    };
+  }
+}
+
+function recordKey(relPath, target) {
+  return `${relPath}::${target}`;
+}
+
+function summarize(rec) {
+  if (!rec) return "(absent)";
+  if (rec.status === "ok") return `ok  sha=${rec.sha256.slice(0, 12)} bytes=${rec.bytes}`;
+  return `${rec.status.toUpperCase()} ${rec.detail ?? ""}`.trim();
+}
+
+async function buildSnapshot(roots) {
+  const corpus = roots.flatMap(listTsFiles);
+  if (corpus.length === 0) {
+    throw new Error(`empty corpus — no .ts files under: ${roots.join(", ")}`);
+  }
+  /** @type {Record<string, any>} */
+  const records = {};
+  for (const filePath of corpus) {
+    const relPath = relative(REPO_ROOT, filePath);
+    for (const target of TARGETS) {
+      const rec = await probe(filePath, target);
+      records[recordKey(relPath, target)] = rec;
+      process.stdout.write(`  ${recordKey(relPath, target)}  →  ${summarize(rec)}\n`);
+    }
+  }
+  return { generated: new Date().toISOString(), targets: [...TARGETS], records };
+}
+
+function recEq(a, b) {
+  if (!a || !b) return false;
+  if (a.status !== b.status) return false;
+  if (a.status === "ok") return a.sha256 === b.sha256 && a.bytes === b.bytes;
+  return a.detail === b.detail;
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  let mode = "write";
+  let baselinePath = DEFAULT_BASELINE;
+  const extraRoots = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "write" || a === "check") mode = a;
+    else if (a === "--baseline") baselinePath = resolve(argv[++i]);
+    else if (a === "--root") extraRoots.push(resolve(argv[++i]));
+    else throw new Error(`unknown arg: ${a}`);
+  }
+  const roots = [...DEFAULT_CORPUS_ROOTS, ...extraRoots];
+
+  console.log(`[prove-emit-identity] mode=${mode} baseline=${relative(REPO_ROOT, baselinePath)}`);
+  console.log(
+    `[prove-emit-identity] roots=${roots.map((r) => relative(REPO_ROOT, r)).join(", ")} targets=${TARGETS.join(",")}`,
+  );
+  console.log("");
+
+  const snapshot = await buildSnapshot(roots);
+  const n = Object.keys(snapshot.records).length;
+
+  if (mode === "write") {
+    mkdirSync(dirname(baselinePath), { recursive: true });
+    writeFileSync(baselinePath, JSON.stringify(snapshot, null, 2) + "\n");
+    console.log(`\n[prove-emit-identity] wrote ${n} (file,target) hashes → ${relative(REPO_ROOT, baselinePath)}`);
+    return;
+  }
+
+  // check
+  if (!existsSync(baselinePath)) {
+    console.error(`\n[prove-emit-identity] no baseline at ${baselinePath} — run write mode first.`);
+    process.exit(2);
+  }
+  const baseline = JSON.parse(readFileSync(baselinePath, "utf-8"));
+  const base = baseline.records ?? {};
+  const cur = snapshot.records;
+  const allKeys = new Set([...Object.keys(base), ...Object.keys(cur)]);
+  const mismatches = [];
+  for (const k of [...allKeys].sort()) {
+    if (!recEq(base[k], cur[k])) mismatches.push({ key: k, baseline: base[k], current: cur[k] });
+  }
+  if (mismatches.length === 0) {
+    console.log(`\n[prove-emit-identity] IDENTICAL — all ${n} (file,target) emits match baseline. ✓`);
+    return;
+  }
+  console.error(`\n[prove-emit-identity] DRIFT — ${mismatches.length} of ${n} (file,target) emits changed:`);
+  for (const m of mismatches) {
+    console.error(`  ✗ ${m.key}`);
+    console.error(`      baseline: ${summarize(m.baseline)}`);
+    console.error(`      current:  ${summarize(m.current)}`);
+  }
+  process.exit(1);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(2);
+});

--- a/src/ir/types.ts
+++ b/src/ir/types.ts
@@ -1,4 +1,37 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+// ---------------------------------------------------------------------------
+// Stable module-index handles (#2710 — late-bind module indices).
+//
+// `FuncHandle` / `GlobalHandle` / `TypeHandle` name the three module index
+// spaces whose *live positions* shift when late imports / string-constant
+// globals are appended, or DCE removes type/func entries. Instructions and type
+// defs reference functions / globals / types through these named types so that
+// — in a later slice — a single `resolveLayout()` pass becomes the sole place a
+// concrete final index is assigned (at serialization), eliminating the whole
+// class of "a baked index went stale when the index space changed" bugs.
+//
+// SLICE 1 (this change): the three are *transparent aliases* of `number` — zero
+// runtime change, fully interchangeable with `number`, so the tree stays
+// `tsc`-clean AND every emitted byte is identical (proven by
+// `scripts/prove-emit-identity.mjs`). Their only job here is to (a) establish
+// the vocabulary and (b) pin it onto the correct, discriminated union arms.
+// Crucially `GlobalHandle` is applied ONLY to `global.{get,set}`, NOT to
+// `local.{get,set,tee}`: locals are function-scoped and never shift, and
+// `src/emit/binary.ts` already discriminates on `op` at the encode seams, so
+// the global arms can later dereference while the local arms pass through raw.
+//
+// A LATER SLICE promotes these to true branded types, e.g.
+//   `type FuncHandle = number & { readonly __func: unique symbol }`
+// At that point `tsc` mechanically enumerates every remaining positional read
+// (`mod.functions[h]`, `h - numImportFuncs`, `h + delta`) as a compile error —
+// the structural guard that makes the bug class unreachable by construction.
+// Branding now (transparently) keeps that future flip to a one-line change here.
+// ---------------------------------------------------------------------------
+export type FuncHandle = number;
+export type GlobalHandle = number;
+export type TypeHandle = number;
+
 export interface ExternClassMeta {
   importPrefix: string;
   namespacePath: string[];
@@ -34,7 +67,7 @@ export interface WasmModule {
   /** Set of function names that are async (for .d.ts generation) */
   asyncFunctions: Set<string>;
   /** Function indices referenced by ref.func that need declarative element segments */
-  declaredFuncRefs: number[];
+  declaredFuncRefs: FuncHandle[];
   /** Linear memory definitions */
   memories: { min: number; max?: number }[];
   /** Data segments for linear memory (string literals, etc.) */
@@ -42,7 +75,7 @@ export interface WasmModule {
   /** Whether the module has top-level executable statements (module init code) */
   hasTopLevelStatements?: boolean;
   /** Wasm start function index — runs automatically on instantiation (#907) */
-  startFuncIdx?: number;
+  startFuncIdx?: FuncHandle;
   /**
    * Per-export TS-level type annotations (#1700). Surfaced so the JS-host
    * `wrapExports` can faithfully marshal `Uint8Array` (and other TypedArray)
@@ -83,7 +116,7 @@ export interface StructTypeDef {
   name: string;
   fields: FieldDef[];
   /** Type index of the parent struct (for class inheritance sub-typing) */
-  superTypeIdx?: number;
+  superTypeIdx?: TypeHandle;
   /** When true and superTypeIdx is set, emit sub_final instead of sub (leaf types in hierarchy) */
   final?: boolean;
 }
@@ -100,7 +133,7 @@ export interface RecGroupDef {
 export interface SubTypeDef {
   kind: "sub";
   name: string;
-  superType: number | null;
+  superType: TypeHandle | null;
   final: boolean;
   type: StructTypeDef | ArrayTypeDef | FuncTypeDef;
 }
@@ -118,8 +151,8 @@ export type ValType =
   | { kind: "v128" }
   | { kind: "i8" }
   | { kind: "i16" }
-  | { kind: "ref"; typeIdx: number }
-  | { kind: "ref_null"; typeIdx: number }
+  | { kind: "ref"; typeIdx: TypeHandle }
+  | { kind: "ref_null"; typeIdx: TypeHandle }
   | { kind: "funcref" }
   | { kind: "externref" }
   | { kind: "ref_extern" }
@@ -128,7 +161,7 @@ export type ValType =
 
 export interface WasmFunction {
   name: string;
-  typeIdx: number;
+  typeIdx: TypeHandle;
   locals: LocalDef[];
   body: Instr[];
   exported: boolean;
@@ -147,11 +180,14 @@ export interface SourcePos {
 }
 
 type InstrBase =
+  // locals are function-scoped and never shift — they stay raw `number`.
   | { op: "local.get"; index: number }
   | { op: "local.set"; index: number }
   | { op: "local.tee"; index: number }
-  | { op: "global.get"; index: number }
-  | { op: "global.set"; index: number }
+  // globals share the `index` field name with locals but live in the module
+  // index space, so they carry a GlobalHandle (binary.ts discriminates on `op`).
+  | { op: "global.get"; index: GlobalHandle }
+  | { op: "global.set"; index: GlobalHandle }
   | { op: "i32.const"; value: number }
   | { op: "i64.const"; value: bigint }
   | { op: "i64.add" }
@@ -242,39 +278,39 @@ type InstrBase =
   | { op: "br_table" }
   | { op: "return" }
   | { op: "end" }
-  | { op: "call"; funcIdx: number }
-  | { op: "return_call"; funcIdx: number }
-  | { op: "call_indirect"; typeIdx: number; tableIdx: number }
+  | { op: "call"; funcIdx: FuncHandle }
+  | { op: "return_call"; funcIdx: FuncHandle }
+  | { op: "call_indirect"; typeIdx: TypeHandle; tableIdx: number }
   | { op: "drop" }
   | { op: "select" }
   | { op: "unreachable" }
   | { op: "nop" }
-  | { op: "struct.new"; typeIdx: number }
-  | { op: "struct.get"; typeIdx: number; fieldIdx: number }
-  | { op: "struct.set"; typeIdx: number; fieldIdx: number }
-  | { op: "array.new"; typeIdx: number }
-  | { op: "array.new_fixed"; typeIdx: number; length: number }
-  | { op: "array.new_default"; typeIdx: number }
-  | { op: "array.get"; typeIdx: number }
-  | { op: "array.get_s"; typeIdx: number }
-  | { op: "array.get_u"; typeIdx: number }
-  | { op: "array.set"; typeIdx: number }
+  | { op: "struct.new"; typeIdx: TypeHandle }
+  | { op: "struct.get"; typeIdx: TypeHandle; fieldIdx: number }
+  | { op: "struct.set"; typeIdx: TypeHandle; fieldIdx: number }
+  | { op: "array.new"; typeIdx: TypeHandle }
+  | { op: "array.new_fixed"; typeIdx: TypeHandle; length: number }
+  | { op: "array.new_default"; typeIdx: TypeHandle }
+  | { op: "array.get"; typeIdx: TypeHandle }
+  | { op: "array.get_s"; typeIdx: TypeHandle }
+  | { op: "array.get_u"; typeIdx: TypeHandle }
+  | { op: "array.set"; typeIdx: TypeHandle }
   | { op: "array.len" }
-  | { op: "array.copy"; dstTypeIdx: number; srcTypeIdx: number }
-  | { op: "array.fill"; typeIdx: number }
-  | { op: "ref.null"; typeIdx: number }
+  | { op: "array.copy"; dstTypeIdx: TypeHandle; srcTypeIdx: TypeHandle }
+  | { op: "array.fill"; typeIdx: TypeHandle }
+  | { op: "ref.null"; typeIdx: TypeHandle }
   | { op: "ref.null.extern" }
   | { op: "ref.null.eq" }
   | { op: "ref.null.func" }
   | { op: "ref.is_null" }
   | { op: "ref.as_non_null" }
-  | { op: "ref.cast"; typeIdx: number }
-  | { op: "ref.cast_null"; typeIdx: number }
-  | { op: "ref.test"; typeIdx: number }
+  | { op: "ref.cast"; typeIdx: TypeHandle }
+  | { op: "ref.cast_null"; typeIdx: TypeHandle }
+  | { op: "ref.test"; typeIdx: TypeHandle }
   | { op: "ref.eq" }
-  | { op: "ref.func"; funcIdx: number }
-  | { op: "call_ref"; typeIdx: number }
-  | { op: "return_call_ref"; typeIdx: number }
+  | { op: "ref.func"; funcIdx: FuncHandle }
+  | { op: "call_ref"; typeIdx: TypeHandle }
+  | { op: "return_call_ref"; typeIdx: TypeHandle }
   | { op: "memory.size" }
   | { op: "memory.grow" }
   | { op: "try"; blockType: BlockType; body: Instr[]; catches: CatchClause[]; catchAll?: Instr[] }
@@ -402,7 +438,7 @@ type InstrBase =
 
 export type Instr = InstrBase & { sourcePos?: SourcePos };
 
-export type BlockType = { kind: "empty" } | { kind: "val"; type: ValType } | { kind: "type"; typeIdx: number };
+export type BlockType = { kind: "empty" } | { kind: "val"; type: ValType } | { kind: "type"; typeIdx: TypeHandle };
 
 export interface CatchClause {
   tagIdx: number;
@@ -412,7 +448,7 @@ export interface CatchClause {
 export interface TagDef {
   name: string;
   /** Type index of the tag's function signature (params = exception values) */
-  typeIdx: number;
+  typeIdx: TypeHandle;
 }
 
 export interface Import {
@@ -421,11 +457,11 @@ export interface Import {
   desc: ImportDesc;
 }
 export type ImportDesc =
-  | { kind: "func"; typeIdx: number }
+  | { kind: "func"; typeIdx: TypeHandle }
   | { kind: "table"; elementType: string; min: number; max?: number }
   | { kind: "global"; type: ValType; mutable: boolean }
   | { kind: "memory"; min: number; max?: number }
-  | { kind: "tag"; typeIdx: number };
+  | { kind: "tag"; typeIdx: TypeHandle };
 
 export interface WasmExport {
   name: string;
@@ -439,7 +475,7 @@ export interface Table {
 export interface Element {
   tableIdx: number;
   offset: Instr[];
-  funcIndices: number[];
+  funcIndices: FuncHandle[];
 }
 export interface GlobalDef {
   name: string;


### PR DESCRIPTION
Foundational slices of #2710 (late-bind module indices → eliminate the index-shift bug class). **Slices 0 + 1 only** — the safe foundation. No `resolveLayout`, no `binary.ts` wiring, no positional-read conversion, no shifter deletion. The umbrella issue stays `in-progress`; slices 2–5 are follow-ups.

## Slice 0 — `scripts/prove-emit-identity.mjs` (byte-identity oracle)
Compiles the `website/playground/examples` corpus across the `{gc, standalone, wasi}` matrix and records `sha256(emitBinary(mod))` per `(file,target)`.
- `write` mode captures a golden baseline; `check` mode exits 1 on any single drift, pinpointing the exact `(file,target)`.
- Baseline is raw-byte hashes (rot on unrelated PRs) → written to gitignored `.tmp/`, **never committed**. A developer proof tool, not a CI gate.
- It is the regression oracle for every later slice: reproducing the current final layout keeps each slice byte-identical, so a representation bug shows up as one sha mismatch — sharper than test262 row counts.

## Slice 1 — branded handle types as pure aliases (`src/ir/types.ts`)
`FuncHandle` / `GlobalHandle` / `TypeHandle` as **transparent aliases of `number`** (zero runtime change), pinned onto the correct, discriminated `Instr` arms + type defs:
- `funcIdx → FuncHandle` on `call` / `return_call` / `ref.func` (+ `startFuncIdx`, `declaredFuncRefs`, `Element.funcIndices`).
- `index → GlobalHandle` on **`global.{get,set}` only** — `local.{get,set,tee}` share the field name but are function-scoped and never shift, so they stay raw `number`. `binary.ts` already discriminates on `op` at the encode seams, so the global arms can later dereference while locals pass through.
- `typeIdx → TypeHandle` on every type-bearing arm + `ValType.ref/ref_null`, `BlockType`, `WasmFunction`, `Struct/SubTypeDef` supertype, `TagDef`, `ImportDesc`.
- `tableIdx` / `fieldIdx` / `tagIdx` and the polymorphic `WasmExport.desc.index` stay `number` (not one of the three handle spaces).

**Why aliases, not the `unique symbol` brand, here:** the enforcement form (turning `mod.functions[h]` / `h - numImportFuncs` into compile errors) is only safe after the ~150 positional reads are converted (slices 3–4). Flipping the brand now would leave the tree red. The future flip is a one-line change per type in this file — the vocabulary and arm placement are already in place.

## Proof
- `tsc --noEmit` clean.
- `npx tsx scripts/prove-emit-identity.mjs check` → `IDENTICAL — all 39 (file,target) emits match baseline` (gc + standalone + wasi).
- `biome lint scripts` clean; `prettier --check src/ir/types.ts` clean.

Purely additive typing + a proof harness; no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BuD4FvrUx5imJ9GqRgE2JY