### PR TITLE
fix(#2722): nested optional object-field destructuring default now fires

### DIFF
--- a/plan/issues/2722-nested-optional-object-field-default-not-firing.md
+++ b/plan/issues/2722-nested-optional-object-field-default-not-firing.md
@@ -1,7 +1,9 @@
 ---
 id: 2722
 title: "Nested OPTIONAL object-field binding default not firing — externref field + f64 struct-getter can't signal field-absent"
-status: ready
+status: done
+completed: 2026-06-26
+assignee: ttraenkler/sd-accessor
 created: 2026-06-26
 updated: 2026-06-26
 priority: medium
@@ -16,6 +18,38 @@ parent: 1556
 related: [1542, 1543, 1544, 1550, 1556]
 owner_role: senior-developer
 ---
+
+## Test Results (2026-06-26, sd-accessor)
+
+Implemented the architect's Path A — two coordinated edits, no `function-body.ts`
+threading:
+- **Change 1** (`src/codegen/index.ts`, #1589A guard): gate the empty-object
+  widening on the *resolved struct* actually being empty (`ctx.structFields`),
+  not the union's common-property count. The union `{ b? } | undefined`'s
+  `getProperties()` is always `[]`, so the old guard clobbered a populated
+  `ref_null structB` back to externref.
+- **Change 2** (`src/codegen/literals.ts`, `compileObjectLiteral` contextual-type
+  resolution): strip a 2-member `T | undefined` union to `T` before
+  `resolveStructName`, so optional-typed inner literals build as the inner struct.
+
+Results (`tests/issue-2722.test.ts`, 9/9 green; args built in-Wasm + called via
+no-arg exported wrappers since a WasmGC struct param can't be passed from JS):
+- Four core repros: `f()`/`f({})`/`f({a:{}})`/`f({a:{c:1}})` → **3**;
+  `f({a:{b:5}})` → **5** (was 0/0/0/1/5).
+- Controls `g`/`h`/`m` stay 3. Edge cases all correct: 3-level deep (5/5/5/9),
+  mixed optional+required (7/15), optional-no-default (1/2), optional-primitive
+  (9/4), genuinely-empty optional (0/1).
+- Standalone: core repros + controls compile to valid Wasm and run (3/3/3/5,
+  controls 3) — no `$Object`-route regression.
+- Regression basket diffed against `origin/main` @ 4b4549d: identical results —
+  `tests/issue-1542-repro.test.ts` (2) + `tests/null-destructure-param-object.test.ts`
+  (3) carry pre-existing reds on BOTH main and this branch (0 new);
+  `tests/issue-1589a.test.ts` (the modified guard), `tests/issue-2158`,
+  `tests/issue-2545`, `tests/issue-2512`, `tests/issue-2568-standalone`,
+  `tests/issue-1372`, `tests/object-literals.test.ts` all green.
+- `tsc --noEmit` clean; `prettier --check` clean.
+- Broad-impact representation change → real floor validation is the #2097
+  merge_group standalone shard.
 # #2722 — Nested optional object-field destructuring default not firing
 
 **Carved from #1556** (verify-first by dev-1556b, 2026-06-26). #1556's core scope

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -11608,7 +11608,22 @@ export function ensureStructForType(ctx: CodegenContext, tsType: ts.Type): void 
     ) {
       const refTypeIdx = (wasmType as { typeIdx: number }).typeIdx;
       const refStructName = ctx.typeIdxToStructName.get(refTypeIdx);
-      if (refStructName !== "__Date") {
+      // (#2722) `propType.getProperties().length === 0` is a FALSE POSITIVE for an
+      // optional object field `a?: { b? }`: its TS type is the union `{ b? } |
+      // undefined`, and `getProperties()` on a union returns only the *common*
+      // properties — intersected with `undefined`'s empty set that is ALWAYS `[]`.
+      // So the guard would clobber the correct `ref_null structB` (a real,
+      // populated inner struct) back to externref, which forces the value through
+      // the host `__extern_get`/`__sget_b` f64-`0` else-branch and stops the nested
+      // `b = D` default from ever firing. Gate the widening on the *resolved struct*
+      // actually being empty (0 fields), not the union's common-property count. The
+      // resolved struct is already registered by the time we reach here, so its
+      // field list is in `ctx.structFields`. A genuinely-empty `{}` field resolves
+      // to a 0-field struct → still widened (preserves #1589A's HasProperty intent);
+      // an optional `{ b? }` resolves to a 1-field struct → kept as `ref_null`.
+      const resolvedFields = refStructName ? ctx.structFields.get(refStructName) : undefined;
+      const resolvedIsEmpty = !resolvedFields || resolvedFields.length === 0;
+      if (refStructName !== "__Date" && resolvedIsEmpty) {
         wasmType = { kind: "externref" };
       }
     }

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -1098,14 +1098,32 @@ export function compileObjectLiteral(
     return null;
   }
 
-  let typeName = resolveStructName(ctx, contextType);
+  // (#2722) An optional object field's contextual type is the union
+  // `T | undefined` (e.g. `a?: { b? }`). `resolveStructName` can't map a union to
+  // a single struct name, so an inner literal `{}` / `{ c: 1 }` flowing into such
+  // a slot would fall through to the host-externref path and never build as the
+  // inner `structB` — the field then stores `ref.null` and the nested destructure
+  // throws "Cannot destructure 'null' or 'undefined'". Strip a 2-member
+  // `T | undefined` (also null/void) union to `T` before resolving the struct name
+  // (mirrors the resolver's union branch in index.ts). Purely additive to the
+  // struct branch: if the stripped `T` doesn't map to a registered struct (host
+  // class, `any`, empty `{}`), it still falls through to the unchanged
+  // externref/inferred-type path below.
+  let effectiveContextType = contextType;
+  if (contextType.isUnion()) {
+    const nn = contextType.types.filter(
+      (t) => !(t.flags & ts.TypeFlags.Null) && !(t.flags & ts.TypeFlags.Undefined) && !(t.flags & ts.TypeFlags.Void),
+    );
+    if (nn.length === 1 && contextType.types.length === 2) effectiveContextType = nn[0]!;
+  }
+  let typeName = resolveStructName(ctx, effectiveContextType);
   if (!typeName) {
     // Auto-register the struct type for the contextual type
-    ensureStructForType(ctx, contextType);
-    typeName = resolveStructName(ctx, contextType);
+    ensureStructForType(ctx, effectiveContextType);
+    typeName = resolveStructName(ctx, effectiveContextType);
   }
   if (typeName) {
-    ensureComputedPropertyFields(ctx, fctx, expr, contextType);
+    ensureComputedPropertyFields(ctx, fctx, expr, effectiveContextType);
     return compileObjectLiteralForStruct(ctx, fctx, expr, typeName);
   }
 

--- a/tests/issue-2722.test.ts
+++ b/tests/issue-2722.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers";
+import { compile } from "../src/index.js";
+
+/**
+ * #2722 — Nested OPTIONAL object-field destructuring default not firing.
+ *
+ *   function f({ a: { b = 3 } = {} }: { a?: { b?: number } } = {}): number { return b; }
+ *
+ * `a?` is the union `{ b? } | undefined`. The #1589A empty-object widening guard
+ * in `ensureStructForType` used `propType.getProperties().length === 0` to decide
+ * "this field is a genuinely empty `{}`" — but `getProperties()` on a union returns
+ * only the *common* properties, which for `T | undefined` is ALWAYS `[]`. So the
+ * guard clobbered the correct `ref_null structB` back to externref, routing the
+ * value through the host `__extern_get`/`__sget_b` f64-`0` else-branch and stopping
+ * the nested `b = 3` default from ever firing.
+ *
+ * Path A fix — two coordinated edits:
+ *   Change 1 (index.ts): gate the #1589A widening on the RESOLVED struct actually
+ *     being empty (via ctx.structFields), not the union's common-property count.
+ *   Change 2 (literals.ts): strip a 2-member `T | undefined` union to `T` before
+ *     resolveStructName, so optional-typed inner literals build as structs.
+ *
+ * NOTE: a WasmGC struct param cannot be passed directly from JS
+ * (`instance.exports.f({…})` throws a type incompatibility), so every repro builds
+ * its argument inside TS and calls `f` internally through a no-arg exported wrapper.
+ */
+const CORE = `
+function f({ a: { b = 3 } = {} }: { a?: { b?: number } } = {}): number { return b; }
+// controls (all pass pre-fix — the defect is precisely "nested + optional field")
+function g({ a: { b = 3 } }: { a: { b?: number } }): number { return b; }      // required nested
+function h({ b = 3 }: { b?: number } = {}): number { return b; }               // single-level optional
+function m([{ b = 3 } = {}]: Array<{ b?: number }> = []): number { return b; } // array-element nested
+// 3-level deep nested optional
+function f3lvl({ a: { b: { c = 5 } = {} } = {} }: { a?: { b?: { c?: number } } } = {}): number { return c; }
+// mixed optional + required
+function fmix({ a: { b = 3 } = {}, d: { e = 4 } }: { a?: { b?: number }; d: { e?: number } }): number { return b + e; }
+// optional field, no default, no nested pattern (binds ref_null structB)
+function fopt({ a }: { a?: { b?: number } } = {}): number { return a ? 2 : 1; }
+// optional PRIMITIVE field — guard's ref precondition must NOT fire
+function fprim({ a = 9 }: { a?: number } = {}): number { return a; }
+// genuinely-empty optional object — stays externref
+function femptyq({ a }: { a?: {} } = {}): number { return a ? 1 : 0; }
+
+export function f0(): number { return f(); }
+export function f1(): number { return f({}); }
+export function f2(): number { return f({ a: {} }); }
+export function f3(): number { return f({ a: { c: 1 } }); }
+export function f4(): number { return f({ a: { b: 5 } }); }
+export function g0(): number { return g({ a: {} }); }
+export function h0(): number { return h(); }
+export function h1(): number { return h({}); }
+export function m0(): number { return m(); }
+export function m1(): number { return m([{}]); }
+export function d0(): number { return f3lvl(); }
+export function d1(): number { return f3lvl({ a: {} }); }
+export function d2(): number { return f3lvl({ a: { b: {} } }); }
+export function d3(): number { return f3lvl({ a: { b: { c: 9 } } }); }
+export function mix0(): number { return fmix({ d: {} }); }
+export function mix1(): number { return fmix({ a: { b: 7 }, d: { e: 8 } }); }
+export function opt0(): number { return fopt(); }
+export function opt1(): number { return fopt({ a: { b: 7 } }); }
+export function prim0(): number { return fprim(); }
+export function prim1(): number { return fprim({ a: 4 }); }
+export function emptyq0(): number { return femptyq(); }
+export function emptyq1(): number { return femptyq({ a: {} }); }
+`;
+
+describe("#2722 nested optional object-field default (gc/host)", () => {
+  let exp: Record<string, Function>;
+  const call = (n: string) => (exp[n] as Function)();
+
+  it("compiles", async () => {
+    exp = (await compileToWasm(CORE)) as Record<string, Function>;
+    expect(typeof exp.f0).toBe("function");
+  });
+
+  it("four core repros return the spec-correct value (3/3/3/5)", () => {
+    expect(call("f0")).toBe(3); // f()
+    expect(call("f1")).toBe(3); // f({})
+    expect(call("f2")).toBe(3); // f({ a: {} })
+    expect(call("f3")).toBe(3); // f({ a: { c: 1 } }) — excess c dropped, b defaults
+    expect(call("f4")).toBe(5); // f({ a: { b: 5 } }) — inner literal HAS the field
+  });
+
+  it("controls g / h / m stay green", () => {
+    expect(call("g0")).toBe(3); // required nested twin
+    expect(call("h0")).toBe(3); // single-level optional
+    expect(call("h1")).toBe(3);
+    expect(call("m0")).toBe(3); // array-element nested
+    expect(call("m1")).toBe(3);
+  });
+
+  it("3-level-deep nested optional (5/5/5/9)", () => {
+    expect(call("d0")).toBe(5);
+    expect(call("d1")).toBe(5);
+    expect(call("d2")).toBe(5);
+    expect(call("d3")).toBe(9);
+  });
+
+  it("mixed optional + required field", () => {
+    expect(call("mix0")).toBe(7); // 3 + 4
+    expect(call("mix1")).toBe(15); // 7 + 8
+  });
+
+  it("optional field, no default, no nested pattern → undefined when omitted", () => {
+    expect(call("opt0")).toBe(1); // a undefined
+    expect(call("opt1")).toBe(2); // a present
+  });
+
+  it("optional primitive field is untouched by the guard", () => {
+    expect(call("prim0")).toBe(9);
+    expect(call("prim1")).toBe(4);
+  });
+
+  it("genuinely-empty optional object stays externref", () => {
+    expect(call("emptyq0")).toBe(0); // a undefined
+    expect(call("emptyq1")).toBe(1); // a present {}
+  });
+});
+
+describe("#2722 nested optional object-field default (standalone)", () => {
+  it("four core repros + controls compile + run valid under standalone", async () => {
+    const r = await compile(CORE, { target: "standalone" });
+    expect(r.success, r.errors?.map((e) => e.message).join("; ")).toBe(true);
+    expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    const call = (n: string) => (instance.exports[n] as Function)() as number;
+    expect(call("f0")).toBe(3);
+    expect(call("f2")).toBe(3);
+    expect(call("f3")).toBe(3);
+    expect(call("f4")).toBe(5);
+    expect(call("g0")).toBe(3);
+    expect(call("h0")).toBe(3);
+    expect(call("m0")).toBe(3);
+  });
+});


### PR DESCRIPTION
## What

```ts
function f({ a: { b = 3 } = {} }: { a?: { b?: number } } = {}): number { return b; }
```

| Call | Before | After (spec) |
|------|--------|------|
| `f()`              | 0 | **3** |
| `f({ a: {} })`     | 0 | **3** |
| `f({ a: { c: 1 }})`| 1 | **3** |
| `f({ a: { b: 5 }})`| 5 | **5** ✅ |

## Root cause + fix (Path A — two coordinated edits, ~10 LOC, no `function-body.ts` threading)

`a?` is the union `{ b? } | undefined`.

- **Change 1** — `src/codegen/index.ts`, the #1589A empty-object widening guard. It used `propType.getProperties().length === 0` to detect a "genuinely empty `{}`" field, but `getProperties()` on a **union** returns only the *common* properties — intersected with `undefined`'s empty set that is **always `[]`**. So the guard mistook *every* optional object field for an empty `{}` and clobbered the correct `ref_null structB` back to externref, routing the value through the host `__extern_get`/`__sget_b` f64-`0` else-branch so the nested `b = 3` default never fired. Now gated on the **resolved struct actually being empty** (`ctx.structFields`), preserving #1589A's genuinely-empty-`{}` intent (HasProperty / `indexOf.call` unchanged).
- **Change 2** — `src/codegen/literals.ts`, `compileObjectLiteral` contextual-type resolution. Strip a 2-member `T | undefined` union to `T` before `resolveStructName`, so an optional-typed inner literal `{}` / `{c:1}` builds as the inner `structB` (absent fields → sentinel) instead of falling through to a host externref that stores `ref.null` and makes the nested destructure throw *"Cannot destructure null"*. Purely additive to the struct branch — any `T` that maps to externref still falls through unchanged.

No `function-body.ts` / `runtime.ts` / `__sget_*` / destructure-reader changes (the field-type change flows through `ctx.structFields` and the existing struct-read destructure path already handles a nullable-struct field + nested `= {}` default).

## Validation

- `tests/issue-2722.test.ts` — **9/9** (gc + standalone; args built in-Wasm + called via no-arg exported wrappers, since a WasmGC struct param can't be passed from JS): four core repros 3/3/3/5; controls `g`/`h`/`m` green; 3-level deep (5/5/5/9); mixed optional+required (7/15); optional-no-default (1/2); optional-primitive (9/4); genuinely-empty optional (0/1).
- Regression basket diffed against `origin/main` — **0 new failures** (the reds in `issue-1542-repro` (2) + `null-destructure-param-object` (3) are pre-existing on main too). `issue-1589a` (the modified guard), `issue-2158`/`2545`/`2512`/`2568-standalone`, `issue-1372`, `object-literals` all green.
- `tsc --noEmit` clean; `prettier --check` clean.

## Floor

Broad-impact representation change → real validation is the **#2097 merge_group standalone shard**. Change 2 sits *after* the standalone `$Object` diversion, so standalone non-empty literals still route to `$Object` first; the union-strip only affects the closed-struct fallthrough.

Carved from #1556 (its #1543/#1544 cluster + single-level defaults are done); this is the narrow nested-optional residual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BuD4FvrUx5imJ9GqRgE2JY