### PR TITLE
fix(#2704): plumb __argc in multi-funcref indirect call dispatch (arguments.length on aliased method calls)

### DIFF
--- a/plan/issues/2704-arguments-length-trailing-comma-and-sloppy-binding.md
+++ b/plan/issues/2704-arguments-length-trailing-comma-and-sloppy-binding.md
@@ -1,7 +1,8 @@
 ---
 id: 2704
 title: "arguments.length off-by-N with trailing comma in async-gen/static methods; sloppy-mode arguments binding missing"
-status: in-progress
+status: done
+completed: 2026-06-26
 assignee: ttraenkler/dev3
 sprint: 67
 goal: test262-conformance
@@ -89,3 +90,40 @@ At least 30 of the 32 listed tests flip from fail to pass (trailing comma: 25, s
 - Reference: #1053 (the original plain-method trailing-comma fix) — read that PR diff first to understand the normalization site.
 - Mapped arguments exotic tests → #1726. Do NOT attempt to fix mapped-argument descriptor semantics in this issue.
 - `unmapped/via-params-rest.js` (wasm_compile error) and `10.6-6-3.js`, `10.6-6-4.js` (illegal_cast) are NOT included in the closeable count here; they may require separate investigation.
+
+## Resolution (dev3, 2026-06-26)
+
+**Root cause was NOT a trailing-comma parser bug.** TypeScript's parser already
+drops a call's trailing comma, so `ref(42,)` and `ref(42)` produce the same
+AST. The real defect: `arguments.length` / `arguments[i]` were wrong whenever a
+method was invoked through an **aliased / indirect reference** — exactly the
+`var ref = obj.method; ref(42,)` shape every failing test uses — regardless of
+the trailing comma. Verified: the *direct* call `obj.m(42)` already returned the
+correct count; only `ref(42)` (a closure-value call) returned the formal-param
+count (0 for the 0-formal `arguments`-reading methods).
+
+The indirect-callable dispatch in `compileCallExpression`
+(`src/codegen/expressions/calls.ts`) has two arms: a single-funcref-type arm
+that already set the `__argc` / `__extras_argv` globals the callee's `arguments`
+object reads (`buildArgcExtrasSetupFromLocals` + reset), and a **multi-funcref-
+type** arm (taken when several closures of the matched struct shape have
+distinct funcref types) that built each `self + args + funcref` call but **never
+set those globals** — so the boxed call-site args sat unused in locals and the
+callee fell back to its formal-param count. Fix: set `__argc`/`__extras_argv`
+once before the funcref-type dispatch chain (it is pure `ref.test`/`if` with no
+intervening calls and exactly one arm runs) and reset after (save/restore the
+return value), mirroring the single-funcref arm. Spec: ECMAScript §10.4.4
+CreateUnmappedArgumentsObject (`arguments.length` = count of *passed* args).
+
+Closes the **non-spread** (a) forms: `single-args` / `null` / `multiple` /
+`undefined` trailing-comma tests across async-gen-meth, static, and class-expr
+variants (~20 tests). Regression test: `tests/issue-2704.test.ts`.
+
+**Split out to #2725** (separate, deeper changes):
+- **(a)-spread** (~5 tests): spread args (`...arr`) in an *indirect* call need
+  runtime-length argc plumbing; the direct path already handles them.
+- **(b) sloppy-mode arguments-object identity** (~7 `S10.6_*` tests):
+  `arguments.callee` / `arguments.constructor` / `arguments.hasOwnProperty`
+  require the arguments object to carry an `Object.prototype` chain + `callee`
+  slot + own-property semantics — an arguments-object *representation* change,
+  not argc plumbing.

--- a/plan/issues/2704-arguments-length-trailing-comma-and-sloppy-binding.md
+++ b/plan/issues/2704-arguments-length-trailing-comma-and-sloppy-binding.md
@@ -1,7 +1,8 @@
 ---
 id: 2704
 title: "arguments.length off-by-N with trailing comma in async-gen/static methods; sloppy-mode arguments binding missing"
-status: ready
+status: in-progress
+assignee: ttraenkler/dev3
 sprint: 67
 goal: test262-conformance
 feasibility: medium

--- a/plan/issues/2725-arguments-indirect-spread-and-sloppy-object.md
+++ b/plan/issues/2725-arguments-indirect-spread-and-sloppy-object.md
@@ -1,0 +1,83 @@
+---
+id: 2725
+title: "arguments residual: spread args in indirect/aliased calls + sloppy-mode arguments-object identity (.callee/.constructor/hasOwnProperty)"
+status: ready
+sprint: Backlog
+goal: test262-conformance
+feasibility: medium
+depends_on: []
+priority: medium
+es_edition: multi
+language_feature: arguments-object
+task_type: bug
+created: 2026-06-26
+updated: 2026-06-26
+---
+# #2725 — arguments residual: indirect-call spread + sloppy-mode arguments-object identity
+
+Split out from **#2704** (which fixed the dominant case: `arguments.length` /
+`arguments[i]` on *non-spread* aliased / indirect method calls — the
+multi-funcref dispatch path now plumbs `__argc` / `__extras_argv`). Two distinct
+residuals remain, each a separate, deeper change:
+
+## (A) Spread args in an indirect / aliased call (~5 tests)
+
+The **direct** method-call path already handles spread + `arguments.length`
+correctly (`obj.m(42, ...[1], ...arr)` → `arguments.length === 4`). The
+**indirect** path (`var ref = obj.m; ref(42, ...[1], ...arr)`) does NOT: it
+compiles each `expr.arguments[i]` as a plain expression and builds a
+compile-time-fixed extras list, so a `SpreadElement` (especially a runtime array
+`...arr`) is mis-counted — observed `arguments.length === 3` (want 4),
+`arguments[2] === NaN` (want 2).
+
+Fixing this requires the indirect-callable dispatch in
+`compileCallExpression` (`src/codegen/expressions/calls.ts`, the
+`__callable_param` / multi-funcref branch) to expand spread arguments — building
+the args/extras at **runtime** for non-literal spreads and setting `__argc`
+from the runtime length, mirroring the direct path's spread machinery.
+
+Failing test262 (baseline 2026-06-26):
+```
+test/language/arguments-object/async-gen-meth-args-trailing-comma-spread-operator.js
+test/language/arguments-object/cls-decl-async-gen-meth-args-trailing-comma-spread-operator.js
+test/language/arguments-object/cls-decl-async-gen-meth-static-args-trailing-comma-spread-operator.js
+test/language/arguments-object/cls-expr-async-gen-meth-args-trailing-comma-spread-operator.js
+test/language/arguments-object/cls-expr-async-gen-meth-static-args-trailing-comma-spread-operator.js
+```
+
+## (B) Sloppy-mode arguments-object identity (~7 tests)
+
+The current `arguments` object is a simplified vec-backed value; it does not
+expose the real object surface that ES §10.4.4 mandates:
+- `arguments.callee` (the executing function object)
+- `arguments.constructor` / `arguments.constructor.prototype === Object.prototype`
+  (the `[[Prototype]]` is `Object.prototype`)
+- `arguments.hasOwnProperty("length")` (own `length` data property)
+
+These probe the arguments object *as a real Object*, so they need the arguments
+object to carry an Object prototype + a `callee` slot + own-property semantics —
+an arguments-object *representation* change, not the argc plumbing #2704 fixed.
+
+Failing test262 (baseline 2026-06-26):
+```
+test/language/arguments-object/S10.6_A2.js     (arguments.constructor.prototype === Object.prototype)
+test/language/arguments-object/S10.6_A3_T1.js
+test/language/arguments-object/S10.6_A3_T4.js
+test/language/arguments-object/S10.6_A4.js     (arguments.callee === fn)
+test/language/arguments-object/S10.6_A5_T1.js  (arguments.hasOwnProperty("length"))
+test/language/arguments-object/S10.6_A5_T3.js
+test/language/arguments-object/S10.6_A5_T4.js
+```
+
+Related: **#1726** (mapped arguments exotic descriptor semantics, §10.4.4) — (B)
+is the unmapped/identity side, distinct from #1726's mapped-descriptor side.
+
+## Acceptance criteria
+
+- (A) the 5 spread tests above flip to pass (indirect-call spread is counted /
+  exposed in `arguments` identically to the direct path).
+- (B) the 7 `S10.6_*` tests above flip to pass (arguments object exposes
+  `callee`, `Object.prototype` chain, and own `length`).
+- No regression in `arguments-object/` currently-passing tests. Full CI green.
+
+(A) and (B) are independent; either may be sliced separately.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -12187,14 +12187,7 @@ function compileCallExpression(
               fctx.body.push(ins);
             }
             fctx.body.push(...funcDispatch);
-            if (expectedReturn !== null) {
-              const retL = allocLocal(fctx, `__mfd_ret_${fctx.locals.length}`, expectedReturn);
-              fctx.body.push({ op: "local.set", index: retL } as Instr);
-              for (const ins of buildArgcExtrasReset(ctx)) fctx.body.push(ins);
-              fctx.body.push({ op: "local.get", index: retL } as Instr);
-            } else {
-              for (const ins of buildArgcExtrasReset(ctx)) fctx.body.push(ins);
-            }
+            // BISECT: reset disabled
           }
 
           // (#1712) Assemble the host-callable fallback split: the funcref

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -2083,6 +2083,41 @@ function buildArgcExtrasReset(ctx: CodegenContext): Instr[] {
 }
 
 /**
+ * Reset `__argc` to its -1 sentinel and `__extras_argv` to null WITHOUT
+ * lazily creating either global. Unlike {@link buildArgcExtrasReset}, this
+ * never calls `ensureExtrasArgvGlobal` — so it cannot register the
+ * `__extras_argv` vec heap type for the FIRST time mid-function-body.
+ *
+ * Why this matters (#2704 / PR #2149): the multi-funcref dispatch arm builds
+ * its ref.test/ref.cast/call_ref chain (with type indices already resolved)
+ * BEFORE emitting the post-dispatch reset. The preceding setup only registers
+ * `__extras_argv` when the call actually has overflow args; a 0-extras callback
+ * (e.g. the `() => void` thunk passed to `assert.throws`) leaves it
+ * unregistered. Calling `ensureExtrasArgvGlobal` from the reset then becomes
+ * the FIRST registration of that global/type at a point where the surrounding
+ * function body has already been partially emitted — which desynced codegen
+ * and silently miscompiled `new Map/WeakMap/WeakSet(iterable)` inside the
+ * callback so it no longer threw (4-test merge_group regression).
+ *
+ * Resetting `__argc` is always safe (it is an i32 global with no heap type and
+ * is already registered by the preceding setup). `__extras_argv` only needs a
+ * reset when it was actually used / previously registered: if it was never
+ * registered it still holds its null initializer, so there is nothing to leak
+ * (#1511) and skipping the reset is correct.
+ */
+function buildArgcResetNoLazyExtras(ctx: CodegenContext): Instr[] {
+  const argcGlobalIdx = ensureArgcGlobal(ctx);
+  const out: Instr[] = [];
+  if (ctx.extrasArgvGlobalIdx >= 0) {
+    out.push({ op: "ref.null", typeIdx: ctx.extrasArgvVecTypeIdx } as Instr);
+    out.push({ op: "global.set", index: ctx.extrasArgvGlobalIdx } as Instr);
+  }
+  out.push({ op: "i32.const", value: -1 } as Instr);
+  out.push({ op: "global.set", index: argcGlobalIdx } as Instr);
+  return out;
+}
+
+/**
  * Flatten call-site arguments, expanding spread elements on array literals
  * into individual expressions. Returns the flat list of expressions.
  * For spread on non-literal arrays, returns null (cannot flatten at compile time).
@@ -12181,13 +12216,28 @@ function compileCallExpression(
             // async-gen-meth / static-async-gen test262 forms in #2704). The
             // dispatch chain below is pure ref.test/if with no intervening
             // calls and exactly ONE arm runs, so a single set-before /
-            // reset-after is correct. Reset prevents stale extras from leaking
-            // into a subsequent callee that DOES read `arguments` (#1511).
+            // reset-after is correct.
             for (const ins of buildArgcExtrasSetupFromLocals(ctx, fctx, cpParamCnt, cpExtrasLocals)) {
               fctx.body.push(ins);
             }
             fctx.body.push(...funcDispatch);
-            // BISECT: reset disabled
+            // (#2704) Reset __argc to its sentinel after the dispatch so a stale
+            // count can't leak into a subsequent callee that reads `arguments`
+            // (#1511). Use the no-lazy-register variant: the dispatch chain's
+            // type operands are already baked above, and calling
+            // ensureExtrasArgvGlobal here for a 0-extras callback would register
+            // the __extras_argv vec type for the FIRST time mid-body and desync
+            // codegen — that miscompiled `new Map/WeakMap/WeakSet(iterable)`
+            // inside an assert.throws callback so it stopped throwing (the
+            // 4-test merge_group regression that parked PR #2149).
+            if (expectedReturn !== null) {
+              const retL = allocLocal(fctx, `__mfd_ret_${fctx.locals.length}`, expectedReturn);
+              fctx.body.push({ op: "local.set", index: retL } as Instr);
+              for (const ins of buildArgcResetNoLazyExtras(ctx)) fctx.body.push(ins);
+              fctx.body.push({ op: "local.get", index: retL } as Instr);
+            } else {
+              for (const ins of buildArgcResetNoLazyExtras(ctx)) fctx.body.push(ins);
+            }
           }
 
           // (#1712) Assemble the host-callable fallback split: the funcref

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -12170,7 +12170,31 @@ function compileCallExpression(
               ];
             }
 
+            // (#2704) Set __argc / __extras_argv ONCE around the funcref-type
+            // dispatch so the callee's `arguments` object observes the TRUE
+            // call-site arg count. The single-funcref arm above already does
+            // this (via buildArgcExtrasSetupFromLocals); this multi-funcref arm
+            // previously omitted it, so an aliased / indirect method call —
+            // `var ref = obj.m; ref(42)` — left __argc at its -1 sentinel and
+            // the callee fell back to its formal-param count: `arguments.length`
+            // came back 0 for a 0-formal method that reads `arguments` (the
+            // async-gen-meth / static-async-gen test262 forms in #2704). The
+            // dispatch chain below is pure ref.test/if with no intervening
+            // calls and exactly ONE arm runs, so a single set-before /
+            // reset-after is correct. Reset prevents stale extras from leaking
+            // into a subsequent callee that DOES read `arguments` (#1511).
+            for (const ins of buildArgcExtrasSetupFromLocals(ctx, fctx, cpParamCnt, cpExtrasLocals)) {
+              fctx.body.push(ins);
+            }
             fctx.body.push(...funcDispatch);
+            if (expectedReturn !== null) {
+              const retL = allocLocal(fctx, `__mfd_ret_${fctx.locals.length}`, expectedReturn);
+              fctx.body.push({ op: "local.set", index: retL } as Instr);
+              for (const ins of buildArgcExtrasReset(ctx)) fctx.body.push(ins);
+              fctx.body.push({ op: "local.get", index: retL } as Instr);
+            } else {
+              for (const ins of buildArgcExtrasReset(ctx)) fctx.body.push(ins);
+            }
           }
 
           // (#1712) Assemble the host-callable fallback split: the funcref

--- a/tests/issue-2704.test.ts
+++ b/tests/issue-2704.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.ts";
+import { buildImports } from "../src/runtime.ts";
+
+// #2704 — `arguments.length` (and `arguments[i]`) was wrong when a method was
+// called through an *aliased / indirect* reference (`var ref = obj.m; ref(42)`)
+// rather than directly (`obj.m(42)`). The multi-funcref-type indirect dispatch
+// path in compileCallExpression built each `self + args + funcref` call arm but
+// never set the `__argc` / `__extras_argv` globals the callee's `arguments`
+// object reads, so the callee fell back to its formal-param count — yielding 0
+// for the 0-formal methods that read `arguments` (the async-gen-meth /
+// static-async-gen test262 trailing-comma forms). The single-funcref arm
+// already plumbed argc; this brings the multi-funcref arm to parity.
+
+async function run(src: string): Promise<unknown> {
+  const r = await compile(src, { fileName: "test.ts" });
+  if (!r.success) throw new Error("CE: " + r.errors.map((e) => e.message).join(" | "));
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports as WebAssembly.Imports);
+  const exports = instance.exports as Record<string, (...a: unknown[]) => unknown>;
+  if ((imports as { setExports?: (e: unknown) => void }).setExports) {
+    (imports as { setExports: (e: unknown) => void }).setExports(exports);
+  }
+  let ret = exports.test();
+  if (ret && typeof (ret as { then?: unknown }).then === "function") ret = await ret;
+  return ret;
+}
+
+describe("#2704 arguments.length on aliased / indirect method calls", () => {
+  it("aliased async-generator method observes the true call-site arg count", async () => {
+    expect(
+      await run(
+        `let log = -1;
+         var o = { async *m() { log = arguments.length; yield 1; } };
+         export function test(): number { var ref = o.m; ref(42).next(); return log; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("aliased async-generator method counts multiple args", async () => {
+    expect(
+      await run(
+        `let log = -1;
+         var o = { async *m() { log = arguments.length; yield 1; } };
+         export function test(): number { var ref = o.m; ref(42, 99).next(); return log; }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("aliased plain method observes the true call-site arg count", async () => {
+    expect(
+      await run(
+        `let log = -1;
+         var o = { m() { log = arguments.length; } };
+         export function test(): number { var ref = o.m; ref(42); return log; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("aliased sync-generator method observes the true call-site arg count", async () => {
+    expect(
+      await run(
+        `let log = -1;
+         var o = { *m() { log = arguments.length; yield 1; } };
+         export function test(): number { var ref = o.m; ref(42).next(); return log; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("aliased async method observes the true call-site arg count", async () => {
+    expect(
+      await run(
+        `let log = -1;
+         var o = { async m() { log = arguments.length; } };
+         export function test(): number { var ref = o.m; ref(42); return log; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("aliased call exposes arguments[i] values (extras region)", async () => {
+    expect(
+      await run(
+        `let log = -1;
+         var o = { async *m() { log = arguments[1] as number; yield 1; } };
+         export function test(): number { var ref = o.m; ref(42, 99).next(); return log; }`,
+      ),
+    ).toBe(99);
+  });
+
+  it("aliased static async-generator class method observes the arg count", async () => {
+    expect(
+      await run(
+        `let log = -1;
+         class C { static async *m() { log = arguments.length; yield 1; } }
+         export function test(): number { var ref = C.m; ref(42).next(); return log; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("no-arg aliased call yields arguments.length 0 (no stale extras)", async () => {
+    expect(
+      await run(
+        `let log = -1;
+         var o = { async *m() { log = arguments.length; yield 1; } };
+         export function test(): number { var ref = o.m; ref().next(); return log; }`,
+      ),
+    ).toBe(0);
+  });
+
+  it("direct method call is unaffected", async () => {
+    expect(
+      await run(
+        `let log = -1;
+         var o = { async *m() { log = arguments.length; yield 1; } };
+         export function test(): number { o.m(42).next(); return log; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("a sequence of aliased calls does not leak a stale arg count", async () => {
+    // The first call (2 args) must not bleed __argc/__extras into the second
+    // (0 args) — the reset-after in the multi-funcref dispatch guards this.
+    expect(
+      await run(
+        `let calls = 0; let len2 = -1;
+         var o = { async *m() { calls = calls + 1; if (calls === 2) len2 = arguments.length; yield 1; } };
+         export function test(): number {
+           var ref = o.m;
+           ref(1, 2).next();
+           ref().next();
+           return len2;
+         }`,
+      ),
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## #2704 — `arguments.length` on aliased / indirect method calls

### Root cause (not a trailing-comma bug)
TypeScript's parser already drops a call's trailing comma, so `ref(42,)` and
`ref(42)` produce the same AST. The real defect: `arguments.length` /
`arguments[i]` were wrong whenever a method was invoked through an **aliased /
indirect reference** — exactly the `var ref = obj.method; ref(42,)` shape every
failing test262 trailing-comma test uses — regardless of the trailing comma.

The indirect-callable dispatch in `compileCallExpression`
(`src/codegen/expressions/calls.ts`) has two arms. The **single-funcref-type**
arm already set the `__argc` / `__extras_argv` globals that the callee's
`arguments` object reads. The **multi-funcref-type** arm (taken when several
closures of the matched struct shape have distinct funcref types) built each
`self + args + funcref` call but **never set those globals**, so the boxed
call-site args sat unused in locals and the callee fell back to its formal-param
count — `arguments.length === 0` for the 0-formal `async *method() { … }` /
static-async-gen forms that read `arguments`.

### Fix
Set `__argc` / `__extras_argv` once before the funcref-type dispatch chain (pure
`ref.test`/`if` with no intervening calls; exactly one arm runs) and reset after
(save/restore the return value), mirroring the single-funcref arm. Verified the
*direct* call `obj.m(42)` was already correct — only the indirect path was
broken.

Spec: ECMAScript §10.4.4 CreateUnmappedArgumentsObject (`arguments.length` =
count of *passed* args, not formal params).

### Scope
Closes the **non-spread** trailing-comma forms (~20 tests: single-args / null /
multiple / undefined across async-gen-meth, static, cls-decl, cls-expr).

Two residuals split to **#2725** (separate, deeper changes):
- spread args (`...arr`) in an *indirect* call (~5 tests) — needs runtime-length
  argc plumbing; the direct path already handles them.
- sloppy-mode arguments-object identity (`.callee` / `.constructor` /
  `hasOwnProperty`, ~7 `S10.6_*` tests) — needs the arguments object to carry an
  `Object.prototype` chain + `callee` slot + own-property semantics (a
  representation change, not argc plumbing).

### Tests
`tests/issue-2704.test.ts` — 10 cases (aliased async-gen / sync-gen / plain /
async methods, multi-arg counts, `arguments[i]` values, static class method,
no-arg, direct-call-unaffected, stale-leak across a call sequence). All pass.
Regression checks: `issue-1053-arguments-global-staleness`,
`issue-2202-spread-arguments-count`, `issue-2174-async-closure-dynamic-call`
all green (29/29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
