### PR TITLE
fix(#2705): for-in head let/const TDZ + lexical scope, LHS non-simple targets, var-head visibility

### DIFF
--- a/plan/issues/2705-for-in-head-lexical-scope-tdz-and-lhs-targets.md
+++ b/plan/issues/2705-for-in-head-lexical-scope-tdz-and-lhs-targets.md
@@ -2,7 +2,7 @@
 id: 2705
 title: "for-in: head let/const TDZ, lexical scope open/close, LHS non-simple targets, var-head visibility"
 status: done
-assignee: ttraenkler/esch
+assignee: ttraenkler/Esch
 completed: 2026-06-26
 sprint: 67
 goal: test262-conformance
@@ -464,12 +464,27 @@ identifier for-in — the overwhelming common case — are byte-identical.
 
 ### Regression validation (scoped, host mode, fresh process per test)
 
-- 10/11 target tests pass; the eval-routed `S12.6.4_A3/A3.1/A4/A4.1`,
-  `scope-head/body-var-none`, `cptn-*` remain deferred (Slice D / eval-inline)
-  as specced.
-- `language/statements/for-in`: the only fresh-process fails are pre-existing
-  **enumeration-order** cases (`S12.6.4_A6/A6.1`, `order-simple-object`,
-  `order-property-on-prototype`, `order-after-define-property` — #2706) — all
-  confirmed already failing on `origin/main`. No scoping regressions.
-- `language/expressions/typeof`: 11/16 branch == 11/16 baseline.
+Re-run on resume (full for-in suite, both branch HEAD and merge-base `14fa625`
+via a fresh tsx process per test — the test262 worker uses fork isolation, so
+each compile must be isolated to avoid in-process TS-program pollution):
+
+- **`language/statements/for-in` + `annexB/.../for-in` (122 tests): baseline 94
+  PASS → branch 104 PASS = +10, ZERO regressions.** The 10 improvements are
+  exactly the closeable set (Slice A: `head-lhs-cover`, `head-var-bound-names-in-stmt`,
+  `identifier-let-allowed`, `let-identifier-with-newline`; Slice B: the 6
+  TDZ/scope tests). `head-lhs-let` remains FAIL on both branches (the 1 allowed
+  miss — Array.prototype numeric-index setter, out of scope; not a regression).
+- **Broad var/typeof/scope sample (70 tests across
+  `language/statements/{variable,for,let,const}` + `language/expressions/typeof`):
+  baseline 56 PASS == branch 56 PASS, ZERO deltas.** Confirms the broad-reach
+  `variables.ts` var-redecl-no-op and `typeof-delete.ts` boxed-TDZ changes do not
+  regress non-for-in code.
+- Curated equivalence batch (`issue-1896-typeof-closure`, `issue-1128-dstr-tdz`,
+  `issue-2572-standalone-forin`, `issue-2200-annexb-block-fn-hoist`,
+  `for-of-array-destructuring`, `issue-2705`) all green; the 3 failing files in
+  the batch (`ir-let-const-equivalence`, `issue-1690b`, `illegal-cast-closures-585`)
+  fail **identically on the merge-base** — pre-existing stale-import-map harness
+  drift in those test files, not a codegen regression.
+- The eval-routed `S12.6.4_A3/A3.1/A4/A4.1`, `scope-head/body-var-none`, `cptn-*`
+  remain deferred (Slice D / eval-inline) as specced.
 - CI runs full test262 for the authoritative regression check.

--- a/plan/issues/2705-for-in-head-lexical-scope-tdz-and-lhs-targets.md
+++ b/plan/issues/2705-for-in-head-lexical-scope-tdz-and-lhs-targets.md
@@ -1,7 +1,9 @@
 ---
 id: 2705
 title: "for-in: head let/const TDZ, lexical scope open/close, LHS non-simple targets, var-head visibility"
-status: ready
+status: done
+assignee: ttraenkler/esch
+completed: 2026-06-26
 sprint: 67
 goal: test262-conformance
 feasibility: hard
@@ -375,3 +377,99 @@ Re-target the acceptance criteria to **"≥10 of the 11 Slice A+B tests"** (the
 - **`continue` depth math.** If Slice B nests the per-iteration cell-clone in a
   new block, the `breakStack`/`continueStack` `+= 3`/`-= 3` deltas (lines
   5566–5614) must be updated in lockstep or `continue` lands on the wrong label.
+
+## Implementation Notes (esch, 2026-06-26)
+
+**Result: 10 / 11 closeable tests pass** (Slice A: 4, Slice B: 6). The single
+miss is `head-lhs-let.js`, whose second assertion (`for ([let][1] in obj)`)
+requires invoking an `Array.prototype['1']` numeric-index **setter** installed
+via `Object.defineProperty` when assigning past the end of a freshly-built
+array literal `[let]`. js2wasm lowers `[let]` to a WasmGC vec, not a host JS
+array with a live prototype-accessor chain, so a PutValue through the inherited
+numeric setter is a host-array exotic that is out of scope for for-in scoping.
+The IdentifierReference half (`for (let in obj)`) **does** pass; only the
+MemberExpression half is unreachable. This is the 1 allowed miss.
+
+### What changed and WHY (not just what)
+
+The architect's "Slice B = per-iteration ref-cell rebuild" turned out to be
+**more than these tests need** — the existing externref-destructuring path
+(`compileExternrefArrayDestructuringDecl`) already gives per-iteration-correct
+captures for a 1-iteration receiver (confirmed: `scope-body-lex-close`'s
+`probeDecl()`/`probeBody()` already returned `'i'` before any Slice B work).
+The two genuinely-missing mechanisms were the **head TDZ environment** and the
+**post-loop restore**. Implemented as a tightly-scoped change gated on
+`isLexicalHead` (a `let`/`const` head with ≥1 declaration) so `var` and bare
+identifier for-in — the overwhelming common case — are byte-identical.
+
+1. **`src/codegen/statements/loops.ts` — LHS dispatch (Slice A).**
+   - Paren-unwrap (`head = init; while isParenthesizedExpression …`) routes
+     `for ((x) in …)` to the bare-identifier branch (`head-lhs-cover`).
+   - Empty-`declarations` VariableDeclarationList ⇒ the non-strict `let`
+     *identifier* (`for (let in …)`); TS drops the identifier text, so before
+     this the code deref'd `declarations[0].name` on `undefined`
+     (`head-lhs-let`, `identifier-let-allowed`).
+   - `var`-head reuses the hoisted function-scope slot instead of `allocLocal`
+     (a fresh slot shadowed the hoisted one, so writes never reached the body's
+     view of `x`) (`head-var-bound-names-in-stmt`).
+   - Static-nullish receiver (`isStaticNullishReceiver`) ⇒ emit no loop (zero
+     iterations, §14.7.5.6 step 7) — fixes `let-identifier-with-newline` whose
+     `null` receiver previously produced invalid Wasm.
+
+2. **`src/codegen/statements/variables.ts` — `var x;` redeclaration is a
+   runtime no-op (root cause of `head-var-bound-names-in-stmt`).** A no-init
+   `var x;` whose slot was already hoisted re-emitted `__get_undefined → x`,
+   **clobbering** the value the slot held (the enumerated key). Per §14.3.2.1 a
+   bare `var x;` is a no-op; the hoister already initialized the slot to
+   `undefined` at function entry. Now skipped when the var reused a hoisted
+   local (`isVar && existingIdx >= params.length`). This is a general
+   correctness fix, not for-in-specific.
+
+3. **`src/codegen/statements/loops.ts` — head TDZ env + post-loop restore
+   (Slice B).** For a `let`/`const` head: before compiling the receiver, install
+   a TDZ environment for the head's bound names (§14.7.5.6 step 2) — boxed
+   ref-cell + boxed TDZ flag for names captured by a closure (so the closure
+   captures the never-initialized binding by reference), plain local + i32 TDZ
+   flag otherwise; both uninitialized. Compile the receiver (reads of head names
+   now throw / `typeof` throws). Tear the env down (step 4); the per-iteration
+   body binds the names afresh (binding-pattern via the existing destructuring,
+   plain identifier via `keyLocal`). After the loop, restore the saved outer
+   `localMap`/`tdzFlagLocals`/`boxedCaptures`/`boxedTdzFlags`/`constBindings`
+   entries so head names do not leak (`scope-body-lex-close`'s
+   `x === 'outside'`). Scoped to the host enumeration path; array/closed-shape
+   receivers are unchanged. Ref-cell types are fetched via the shared
+   `getOrRegisterRefCellType` (externref + i32 cells already exist, so no late
+   type-index shift).
+
+4. **`src/codegen/typeof-delete.ts` — `typeof x` of a boxed-TDZ binding must
+   throw, not static-fold.** `compileTypeofExpression` folded `typeof x` to a
+   type string via `staticTypeofForType` BEFORE compiling the operand, bypassing
+   the TDZ check. Now, when the operand is an identifier with a boxed TDZ flag
+   (`fctx.boxedTdzFlags`), force the runtime path so `compileExpression` emits
+   the boxed TDZ check (throws when the flag is 0). Narrow gate — only
+   closure-captured TDZ bindings — so ordinary `typeof letVar` is unchanged
+   (verified: `language/expressions/typeof` 11/16 on branch == baseline).
+
+5. **`src/codegen/closures.ts` — receiver closures are a TDZ risk
+   (`closureProvablyAfterLetDecl`).** A closure built inside a `for (let x in
+   RECEIVER)` head's receiver was wrongly deemed "provably after the decl /
+   per-iteration, no TDZ" because the for-in wraps both. Per §14.7.5.6 the
+   receiver is evaluated in the head TDZ env (distinct from the per-iteration
+   env), so such a closure captures a binding that stays in its TDZ forever and
+   its read/`typeof` must throw. Added: when the wrapping loop is for-in/for-of,
+   the closure is in `cur.expression` (receiver) and the decl is the head
+   (`cur.initializer`), return `false` (TDZ risk). Without this the closure
+   never carried the TDZ flag, so `typeof x` could not throw
+   (`scope-head-lex-open/close`, `scope-body-lex-open`).
+
+### Regression validation (scoped, host mode, fresh process per test)
+
+- 10/11 target tests pass; the eval-routed `S12.6.4_A3/A3.1/A4/A4.1`,
+  `scope-head/body-var-none`, `cptn-*` remain deferred (Slice D / eval-inline)
+  as specced.
+- `language/statements/for-in`: the only fresh-process fails are pre-existing
+  **enumeration-order** cases (`S12.6.4_A6/A6.1`, `order-simple-object`,
+  `order-property-on-prototype`, `order-after-define-property` — #2706) — all
+  confirmed already failing on `origin/main`. No scoping regressions.
+- `language/expressions/typeof`: 11/16 branch == 11/16 baseline.
+- CI runs full test262 for the authoritative regression check.

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -1324,6 +1324,17 @@ export function isDeferredCallbackArgument(node: ts.Node, ctx: CodegenContext): 
  * iteration. Force-boxing here would break per-iteration semantics (all
  * closures would share the same Wasm box slot, observing the final value).
  */
+/** (#2705) True if `node` is `ancestor` or a descendant of it. */
+function isNodeDescendantOf(node: ts.Node | undefined, ancestor: ts.Node | undefined): boolean {
+  if (!ancestor) return false;
+  let cur: ts.Node | undefined = node;
+  while (cur) {
+    if (cur === ancestor) return true;
+    cur = cur.parent;
+  }
+  return false;
+}
+
 function closureProvablyAfterLetDecl(
   ctx: CodegenContext,
   arrow: ts.ArrowFunction | ts.FunctionExpression,
@@ -1367,6 +1378,20 @@ function closureProvablyAfterLetDecl(
       let d: ts.Node | undefined = decl;
       while (d) {
         if (d === cur) {
+          // (#2705) Exception: a `for (let/const <head> in/of RECEIVER)` whose
+          // RECEIVER builds a closure capturing the HEAD binding. Per §14.7.5.6
+          // ForIn/OfHeadEvaluation step 2, the receiver is evaluated in a TDZ
+          // environment where the head binding is NOT yet initialized — distinct
+          // from the per-iteration environment. A closure inside the receiver
+          // therefore captures a binding that stays in its TDZ forever, so its
+          // read/`typeof` MUST throw — it is a TDZ risk. Detect: for-in/for-of,
+          // decl is the head (`cur.initializer`), closure is in the receiver
+          // (`cur.expression`).
+          if (ts.isForInStatement(cur) || ts.isForOfStatement(cur)) {
+            if (isNodeDescendantOf(arrow, cur.expression) && isNodeDescendantOf(decl, cur.initializer)) {
+              return false; // head binding is in TDZ while the receiver is evaluated
+            }
+          }
           // Decl is inside (or part of) this loop. The loop wraps both
           // the decl and the closure — per-iteration semantics apply,
           // closure runs after decl in each iteration, no TDZ risk.

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -5435,9 +5435,119 @@ function emitArrayForIn(
   });
 }
 
+/**
+ * (#2705) Is the for-in receiver statically the `null`/`undefined`/`void`
+ * literal? §14.7.5.6 ForIn/OfHeadEvaluation step 7 yields zero iterations for a
+ * nullish receiver. Detect the literal forms syntactically (the checker can
+ * widen the receiver to `any`, so a type-based test is unreliable). Conservative
+ * by design — a runtime-nullish receiver (`for (k in maybeNull)`) is NOT covered
+ * here and would still enumerate; only the statically-provable literal nullish
+ * forms short-circuit.
+ */
+function isStaticNullishReceiver(expr: ts.Expression): boolean {
+  if (expr.kind === ts.SyntaxKind.NullKeyword) return true;
+  if (ts.isIdentifier(expr) && expr.text === "undefined") return true;
+  if (ts.isVoidExpression(expr)) return true;
+  if (ts.isParenthesizedExpression(expr)) return isStaticNullishReceiver(expr.expression);
+  return false;
+}
+
+/**
+ * (#2705) Which of a `for (let/const <head> in …)` head's bound names are
+ * referenced from a nested closure anywhere in the receiver, the ForDeclaration
+ * (binding-pattern default initializers), or the body? Such names must be boxed
+ * into a ref cell so the closure captures the binding by reference — for the
+ * head TDZ environment (a closure built in the receiver captures the
+ * never-initialized binding → `typeof x` throws) and the per-iteration
+ * environment. Mirrors `findHeadBindingsCapturedByClosures` (the C-style-loop
+ * analogue) but walks the for-in's receiver/ForDeclaration/body.
+ */
+function collectForInHeadClosureCaptures(stmt: ts.ForInStatement, headNames: ReadonlySet<string>): Set<string> {
+  const captured = new Set<string>();
+  if (headNames.size === 0) return captured;
+  function visit(node: ts.Node | undefined): void {
+    if (!node) return;
+    if (
+      ts.isArrowFunction(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isFunctionDeclaration(node) ||
+      ts.isMethodDeclaration(node) ||
+      ts.isGetAccessorDeclaration(node) ||
+      ts.isSetAccessorDeclaration(node) ||
+      ts.isClassDeclaration(node) ||
+      ts.isClassExpression(node)
+    ) {
+      const refs = new Set<string>();
+      collectReferencedIdentifiers(node, refs);
+      for (const n of headNames) if (refs.has(n)) captured.add(n);
+      return; // collectReferencedIdentifiers already walked nested closures.
+    }
+    forEachChild(node, visit);
+  }
+  visit(stmt.expression); // receiver (head TDZ scope)
+  visit(stmt.initializer); // ForDeclaration — binding-pattern default initializers
+  visit(stmt.statement); // body
+  return captured;
+}
+
+/**
+ * (#2705) Saved outer-scope binding for a for-in head name, so the head's
+ * lexical environment can be torn down and the outer binding restored after the
+ * loop (no leak — `head-bound` names must not escape per §14.7.5.7).
+ */
+interface ForInHeadSaved {
+  name: string;
+  localMap: number | undefined;
+  tdz: number | undefined;
+  boxed: { refCellTypeIdx: number; valType: ValType } | undefined;
+  boxedTdz: { localIdx: number; refCellTypeIdx: number } | undefined;
+  isConst: boolean;
+}
+
 export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext, stmt: ts.ForInStatement): void {
   // Get the loop variable name
   const init = stmt.initializer;
+  // (#2705) Unwrap a CoverParenthesizedExpression head — `for ((x) in obj)` /
+  // `for ((a.b) in obj)`. The parenthesized form parses as a
+  // ParenthesizedExpression wrapping the real LHS target. A
+  // VariableDeclarationList is never parenthesized, so only the expression
+  // branches dispatch on `head`.
+  let head: ts.Node = init;
+  while (ts.isParenthesizedExpression(head)) head = head.expression;
+  // (#2705) A `let`/`const` head needs a per-iteration lexical environment with
+  // a TDZ binding (§14.7.5.6/.7). A `var` head reuses the function-scope slot
+  // the var-hoister already allocated. The non-strict `for (let in obj)` legacy
+  // form (an *empty* VariableDeclarationList — see below) is an identifier
+  // reference, not a ForDeclaration, so it is NOT treated as lexical.
+  const isLexicalHead =
+    ts.isVariableDeclarationList(init) &&
+    init.declarations.length > 0 &&
+    !!(init.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const));
+
+  // (#2705 Slice B) Snapshot the OUTER binding of each head bound name BEFORE the
+  // dispatch below allocates the head's own local — for a plain-identifier let
+  // head the dispatch does `localMap.set(x, keyLocal)`, overwriting the true
+  // outer slot, so capturing the save afterwards would restore to `keyLocal`
+  // (the leaked head binding) instead of the enclosing scope's `x`. The head
+  // names come straight from the ForDeclaration. Used to install the head TDZ
+  // env around the receiver compile (host path) and to restore the outer
+  // bindings after the loop so head names do not leak (§14.7.5.7).
+  const headNames: string[] = [];
+  const headSaved: ForInHeadSaved[] = [];
+  if (isLexicalHead) {
+    const headDecl = init.declarations[0]!;
+    for (const n of collectPatternBindingNames(headDecl.name)) headNames.push(n);
+    for (const name of headNames) {
+      headSaved.push({
+        name,
+        localMap: fctx.localMap.get(name),
+        tdz: fctx.tdzFlagLocals?.get(name),
+        boxed: fctx.boxedCaptures?.get(name),
+        boxedTdz: fctx.boxedTdzFlags?.get(name),
+        isConst: fctx.constBindings?.has(name) ?? false,
+      });
+    }
+  }
   let varName: string;
   let keyLocal: number;
   // For non-identifier heads (binding pattern / member-expression target) the
@@ -5446,27 +5556,51 @@ export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext
   let bindingPattern: ts.ObjectBindingPattern | ts.ArrayBindingPattern | null = null;
   let memberTarget: ts.PropertyAccessExpression | ts.ElementAccessExpression | null = null;
   if (ts.isVariableDeclarationList(init)) {
-    const decl = init.declarations[0]!;
-    if (!ts.isIdentifier(decl.name)) {
-      // Destructuring binding head: `for (var/let [a] in obj)`. The key is a
-      // string; per spec the binding pattern destructures that string value.
-      bindingPattern = decl.name;
-      varName = `__forin_key_${fctx.locals.length}`;
-      keyLocal = allocLocal(fctx, varName, { kind: "externref" });
+    if (init.declarations.length === 0) {
+      // (#2705) `for (let in obj)` in non-strict mode: TS parses the head as a
+      // VariableDeclarationList with ZERO declarations (the `let` token is
+      // consumed as the list keyword and the identifier text is lost). Per the
+      // grammar's `[lookahead ∉ { let [ }]` restriction, a `let` not followed by
+      // `[` is the *identifier* `let`. `var`/`const` cannot produce an empty
+      // list (both are reserved as identifiers), so the name is unambiguously
+      // "let" — a real, writable binding visible after the loop.
+      varName = "let";
+      const existingLocal = fctx.localMap.get(varName);
+      keyLocal = existingLocal !== undefined ? existingLocal : allocLocal(fctx, varName, { kind: "externref" });
     } else {
-      varName = decl.name.text;
-      // Allocate a local for the loop variable (string / externref)
-      keyLocal = allocLocal(fctx, varName, { kind: "externref" });
+      const decl = init.declarations[0]!;
+      if (!ts.isIdentifier(decl.name)) {
+        // Destructuring binding head: `for (var/let [a] in obj)`. The key is a
+        // string; per spec the binding pattern destructures that string value.
+        bindingPattern = decl.name;
+        varName = `__forin_key_${fctx.locals.length}`;
+        keyLocal = allocLocal(fctx, varName, { kind: "externref" });
+      } else {
+        varName = decl.name.text;
+        if (!isLexicalHead) {
+          // (#2705) `var` head: reuse the function-scope slot the var-hoister
+          // already allocated so the body's `var x` re-declaration and the
+          // post-loop read all resolve to the SAME slot. Allocating a fresh
+          // local here shadowed the hoisted one (writes never reached the body's
+          // view of `x`).
+          const existingLocal = fctx.localMap.get(varName);
+          keyLocal = existingLocal !== undefined ? existingLocal : allocLocal(fctx, varName, { kind: "externref" });
+        } else {
+          // let/const head: fresh block-scoped local (Slice B refines this into
+          // a per-iteration ref cell + TDZ flag).
+          keyLocal = allocLocal(fctx, varName, { kind: "externref" });
+        }
+      }
     }
-  } else if (ts.isPropertyAccessExpression(init) || ts.isElementAccessExpression(init)) {
+  } else if (ts.isPropertyAccessExpression(head) || ts.isElementAccessExpression(head)) {
     // Member-expression target: `for (x.y in obj)` / `for (x[k] in obj)`.
     // Per spec the enumerated key is assigned to the reference each iteration.
-    memberTarget = init;
+    memberTarget = head;
     varName = `__forin_key_${fctx.locals.length}`;
     keyLocal = allocLocal(fctx, varName, { kind: "externref" });
-  } else if (ts.isIdentifier(init)) {
+  } else if (ts.isIdentifier(head)) {
     // Bare identifier: `for (x in obj)` — look up existing local
-    varName = init.text;
+    varName = head.text;
     const existingLocal = fctx.localMap.get(varName);
     if (existingLocal !== undefined) {
       keyLocal = existingLocal;
@@ -5475,12 +5609,12 @@ export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext
       keyLocal = allocLocal(fctx, varName, { kind: "externref" });
     }
   } else if (
-    ts.isBinaryExpression(init) &&
-    init.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
-    ts.isIdentifier(init.left)
+    ts.isBinaryExpression(head) &&
+    head.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+    ts.isIdentifier(head.left)
   ) {
     // Assignment expression: `for (x = defaultVal in obj)` — compile assignment, use the target
-    varName = init.left.text;
+    varName = head.left.text;
     const existingLocal = fctx.localMap.get(varName);
     if (existingLocal !== undefined) {
       keyLocal = existingLocal;
@@ -5488,10 +5622,21 @@ export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext
       keyLocal = allocLocal(fctx, varName, { kind: "externref" });
     }
     // Compile the initializer assignment (default value)
-    compileExpression(ctx, fctx, init.right);
+    compileExpression(ctx, fctx, head.right);
     fctx.body.push({ op: "local.set", index: keyLocal });
   } else {
     reportError(ctx, stmt, "for-in requires a variable declaration or identifier");
+    return;
+  }
+
+  // (#2705) §14.7.5.6 step 7: a `null`/`undefined` receiver yields zero
+  // iterations. When the receiver is statically the `null`/`undefined`/`void`
+  // literal, emit NO loop — the body is never reached (so a body that would
+  // compile to invalid Wasm, e.g. a lexical-decl-only statement after ASI, is
+  // correctly skipped) and the enumeration primitives are never invoked over a
+  // null ref (which trapped / produced invalid Wasm before). `var`-hoisting
+  // already ran in the function pre-pass, so nothing is lost by the early exit.
+  if (isStaticNullishReceiver(stmt.expression)) {
     return;
   }
 
@@ -5577,10 +5722,90 @@ export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext
   const objLocal = allocLocal(fctx, `__forin_obj_${fctx.locals.length}`, {
     kind: "externref",
   });
+
+  // (#2705 Slice B) For a `let`/`const` head, §14.7.5.6 ForIn/OfHeadEvaluation
+  // step 2 puts the head's bound names in a fresh TDZ environment while the
+  // RECEIVER is evaluated — so a read of a head name inside the receiver (direct
+  // `{ x }`, or via a closure built there) throws ReferenceError / `typeof`
+  // throws. We install that TDZ env now, compile the receiver, then tear it down
+  // (step 4) before the per-iteration body binds the names to the key. The outer
+  // binding was snapshot into `headSaved` (BEFORE the dispatch) and is restored
+  // after the loop so the head names do not leak.
+  if (isLexicalHead) {
+    const captured = collectForInHeadClosureCaptures(stmt, new Set(headNames));
+    for (const name of headNames) {
+      if (captured.has(name)) {
+        // Closure-captured head name → box the binding + its TDZ flag so the
+        // closure captures them by reference. The receiver-env cell is NEVER
+        // initialized (TDZ flag stays 0), so a closure built in the receiver
+        // observes a permanent TDZ.
+        const valCellTypeIdx = getOrRegisterRefCellType(ctx, { kind: "externref" });
+        const boxLocal = allocLocal(fctx, `__forin_hbox_${name}_${fctx.locals.length}`, {
+          kind: "ref_null",
+          typeIdx: valCellTypeIdx,
+        });
+        fctx.body.push({ op: "ref.null.extern" } as Instr); // placeholder value
+        fctx.body.push({ op: "struct.new", typeIdx: valCellTypeIdx });
+        fctx.body.push({ op: "local.set", index: boxLocal });
+        const flagCellTypeIdx = getOrRegisterRefCellType(ctx, { kind: "i32" });
+        const flagBoxLocal = allocLocal(fctx, `__forin_hflag_${name}_${fctx.locals.length}`, {
+          kind: "ref_null",
+          typeIdx: flagCellTypeIdx,
+        });
+        fctx.body.push({ op: "i32.const", value: 0 }); // uninitialized
+        fctx.body.push({ op: "struct.new", typeIdx: flagCellTypeIdx });
+        fctx.body.push({ op: "local.set", index: flagBoxLocal });
+        fctx.localMap.set(name, boxLocal);
+        if (!fctx.boxedCaptures) fctx.boxedCaptures = new Map();
+        fctx.boxedCaptures.set(name, { refCellTypeIdx: valCellTypeIdx, valType: { kind: "externref" } });
+        if (!fctx.tdzFlagLocals) fctx.tdzFlagLocals = new Map();
+        fctx.tdzFlagLocals.set(name, flagBoxLocal);
+        if (!fctx.boxedTdzFlags) fctx.boxedTdzFlags = new Map();
+        fctx.boxedTdzFlags.set(name, { localIdx: flagBoxLocal, refCellTypeIdx: flagCellTypeIdx });
+      } else {
+        // Not captured — a plain local + a plain (i32, zero-init = uninitialized)
+        // TDZ flag suffice. The value slot is never read (TDZ throws first).
+        const slot = allocLocal(fctx, `__forin_hbind_${name}_${fctx.locals.length}`, { kind: "externref" });
+        const flagLocal = allocLocal(fctx, `__forin_hflag_${name}_${fctx.locals.length}`, { kind: "i32" });
+        fctx.localMap.set(name, slot);
+        if (!fctx.tdzFlagLocals) fctx.tdzFlagLocals = new Map();
+        fctx.tdzFlagLocals.set(name, flagLocal);
+        fctx.boxedCaptures?.delete(name);
+        fctx.boxedTdzFlags?.delete(name);
+      }
+      fctx.constBindings?.delete(name);
+    }
+  }
+
   const exprType = compileExpression(ctx, fctx, stmt.expression);
   if (exprType && exprType.kind !== "externref") {
     coerceType(ctx, fctx, exprType, { kind: "externref" });
   }
+
+  // (#2705 Slice B) Tear down the head TDZ env (HeadEvaluation step 4). The
+  // per-iteration body now binds the head names afresh: a binding-pattern head
+  // re-allocates them via the destructuring path below; a plain-identifier head
+  // uses `keyLocal` (which receives keys[i] each iteration). Remove the TDZ-env
+  // entries so the body reads resolve to the per-iteration binding, not the
+  // never-initialized receiver-env cell.
+  if (isLexicalHead) {
+    for (const s of headSaved) {
+      fctx.localMap.delete(s.name);
+      fctx.tdzFlagLocals?.delete(s.name);
+      fctx.boxedCaptures?.delete(s.name);
+      fctx.boxedTdzFlags?.delete(s.name);
+      fctx.constBindings?.delete(s.name);
+    }
+    if (bindingPattern === null && memberTarget === null) {
+      // Plain-identifier head: `keyLocal` is the per-iteration binding.
+      fctx.localMap.set(varName, keyLocal);
+      if (init.flags & ts.NodeFlags.Const) {
+        if (!fctx.constBindings) fctx.constBindings = new Set();
+        fctx.constBindings.add(varName);
+      }
+    }
+  }
+
   fctx.body.push({ op: "local.tee", index: objLocal });
   fctx.body.push({ op: "call", funcIdx: keysIdx }); // __for_in_keys(obj) -> keys array
 
@@ -5729,4 +5954,30 @@ export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext
       },
     ],
   });
+
+  // (#2705 Slice B) Restore the outer bindings the head TDZ / per-iteration env
+  // shadowed, so the head names do not leak past the loop (§14.7.5.7 — the
+  // lexical bindings are scoped to the loop). Without this, `let x = 'outside';
+  // for (let x in obj) …; x /* === 'outside' */` would observe the loop's last
+  // binding instead.
+  for (const s of headSaved) {
+    if (s.localMap !== undefined) fctx.localMap.set(s.name, s.localMap);
+    else fctx.localMap.delete(s.name);
+    if (s.tdz !== undefined) {
+      if (!fctx.tdzFlagLocals) fctx.tdzFlagLocals = new Map();
+      fctx.tdzFlagLocals.set(s.name, s.tdz);
+    } else fctx.tdzFlagLocals?.delete(s.name);
+    if (s.boxed !== undefined) {
+      if (!fctx.boxedCaptures) fctx.boxedCaptures = new Map();
+      fctx.boxedCaptures.set(s.name, s.boxed);
+    } else fctx.boxedCaptures?.delete(s.name);
+    if (s.boxedTdz !== undefined) {
+      if (!fctx.boxedTdzFlags) fctx.boxedTdzFlags = new Map();
+      fctx.boxedTdzFlags.set(s.name, s.boxedTdz);
+    } else fctx.boxedTdzFlags?.delete(s.name);
+    if (s.isConst) {
+      if (!fctx.constBindings) fctx.constBindings = new Set();
+      fctx.constBindings.add(s.name);
+    } else fctx.constBindings?.delete(s.name);
+  }
 }

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -1052,34 +1052,46 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
         emitCoercedLocalSet(ctx, fctx, localIdx, stackType);
       }
     } else if (wasmType.kind === "externref") {
-      // No initializer: `let x;` / `var x;` — in JS, uninitialized variables
-      // are `undefined`, not `null`. Emit __get_undefined() so that
-      // `x === undefined` works correctly (#737).
-      emitUndefined(ctx, fctx);
-      // #1177: If a closure captured x BEFORE this declaration ran, `localIdx`
-      // is now the boxed ref-cell ref local. Route the init through
-      // `struct.set` on the ref cell so the closure observes the same value.
-      // Without this, the post-fixup `local.set` becomes an `any.convert_extern;
-      // ref.cast null (ref __ref_cell_T)` that traps at runtime ("illegal cast"),
-      // because JS undefined is not a struct ref.
-      const boxedNoInit = fctx.boxedCaptures?.get(name);
-      if (boxedNoInit) {
-        const tmpVal = allocLocal(fctx, `__box_init_tmp_${fctx.locals.length}`, boxedNoInit.valType);
-        fctx.body.push({ op: "local.set", index: tmpVal });
-        fctx.body.push({ op: "local.get", index: localIdx });
-        fctx.body.push({ op: "ref.is_null" });
-        fctx.body.push({
-          op: "if",
-          blockType: { kind: "empty" },
-          then: [] as Instr[],
-          else: [
-            { op: "local.get", index: localIdx } as Instr,
-            { op: "local.get", index: tmpVal } as Instr,
-            { op: "struct.set", typeIdx: boxedNoInit.refCellTypeIdx, fieldIdx: 0 } as Instr,
-          ],
-        });
-      } else {
-        fctx.body.push({ op: "local.set", index: localIdx });
+      // (#2705) A bare `var x;` redeclaration whose slot was already hoisted to
+      // the function scope (and initialized to `undefined` at function entry by
+      // `hoistVarDecl`) is a runtime NO-OP per ECMA-262 §14.3.2.1 — re-emitting
+      // `__get_undefined` here would CLOBBER any value the variable already
+      // holds. Concretely, `for (var x in obj) { var x; … }` writes the
+      // enumerated key into x's slot, then the body's `var x;` redeclaration
+      // would reset it to undefined. Only emit the undefined-init for a FRESH
+      // slot (the genuine first declaration) or a let/const binding leaving the
+      // TDZ; skip it for a var that reused a hoisted local.
+      const isVarRedeclOfHoistedSlot = isVar && existingIdx !== undefined && existingIdx >= fctx.params.length;
+      if (!isVarRedeclOfHoistedSlot) {
+        // No initializer: `let x;` / `var x;` — in JS, uninitialized variables
+        // are `undefined`, not `null`. Emit __get_undefined() so that
+        // `x === undefined` works correctly (#737).
+        emitUndefined(ctx, fctx);
+        // #1177: If a closure captured x BEFORE this declaration ran, `localIdx`
+        // is now the boxed ref-cell ref local. Route the init through
+        // `struct.set` on the ref cell so the closure observes the same value.
+        // Without this, the post-fixup `local.set` becomes an `any.convert_extern;
+        // ref.cast null (ref __ref_cell_T)` that traps at runtime ("illegal cast"),
+        // because JS undefined is not a struct ref.
+        const boxedNoInit = fctx.boxedCaptures?.get(name);
+        if (boxedNoInit) {
+          const tmpVal = allocLocal(fctx, `__box_init_tmp_${fctx.locals.length}`, boxedNoInit.valType);
+          fctx.body.push({ op: "local.set", index: tmpVal });
+          fctx.body.push({ op: "local.get", index: localIdx });
+          fctx.body.push({ op: "ref.is_null" });
+          fctx.body.push({
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [] as Instr[],
+            else: [
+              { op: "local.get", index: localIdx } as Instr,
+              { op: "local.get", index: tmpVal } as Instr,
+              { op: "struct.set", typeIdx: boxedNoInit.refCellTypeIdx, fieldIdx: 0 } as Instr,
+            ],
+          });
+        } else {
+          fctx.body.push({ op: "local.set", index: localIdx });
+        }
       }
     }
     // Set local TDZ flag to 1 (initialized) if this is a hoisted let/const

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -970,10 +970,35 @@ export function compileTypeofExpression(
 
   const tsType = ctx.checker.getTypeAtLocation(operand);
 
+  // (#2705) `typeof x` where x is a let/const binding boxed for closure capture
+  // (so it carries a boxed TDZ flag) must NOT static-fold to a type string — if
+  // the binding is in its temporal dead zone the read must throw a
+  // ReferenceError (§13.5.3.1 / §14.7.5.6). Force the runtime path so
+  // `compileExpression(operand)` emits the boxed TDZ check. This fires for a
+  // closure built inside a `for (let x in …)` head's receiver that captures the
+  // never-initialized head binding (scope-head/​body-lex-open/close).
+  let forceRuntimeTypeof = false;
+  {
+    let bareTdz: ts.Expression = operand;
+    while (
+      ts.isParenthesizedExpression(bareTdz) ||
+      ts.isAsExpression(bareTdz) ||
+      ts.isTypeAssertionExpression(bareTdz) ||
+      ts.isNonNullExpression(bareTdz)
+    ) {
+      bareTdz = (bareTdz as ts.ParenthesizedExpression | ts.AsExpression).expression;
+    }
+    if (ts.isIdentifier(bareTdz) && fctx.boxedTdzFlags?.has(bareTdz.text)) {
+      forceRuntimeTypeof = true;
+    }
+  }
+
   // Try static resolution first via the shared helper
-  const staticResult = staticTypeofForType(ctx, tsType);
-  if (staticResult !== null) {
-    return compileStringLiteral(ctx, fctx, staticResult);
+  if (!forceRuntimeTypeof) {
+    const staticResult = staticTypeofForType(ctx, tsType);
+    if (staticResult !== null) {
+      return compileStringLiteral(ctx, fctx, staticResult);
+    }
   }
 
   // $AnyValue operand → runtime typeof via __any_typeof, which tag-dispatches

--- a/tests/issue-2705.test.ts
+++ b/tests/issue-2705.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+
+// #2705 — for-in head lexical scope (let/const TDZ during receiver eval +
+// post-loop restore), LHS non-simple targets, var-head visibility.
+//
+// These exercise the scoping/dispatch fixes in `compileForInStatement`
+// (src/codegen/statements/loops.ts), the `var x;` redeclaration no-op
+// (src/codegen/statements/variables.ts), the boxed-TDZ `typeof` runtime path
+// (src/codegen/typeof-delete.ts), and the receiver-closure TDZ classification
+// (src/codegen/closures.ts). Compiled in `--target standalone` so the binary
+// instantiates with NO host imports; results are numeric so no native-string
+// readback is needed.
+async function run(src: string): Promise<unknown> {
+  const r = await compile(src, { target: "standalone", skipSemanticDiagnostics: true } as never);
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#2705 for-in head lexical scope / LHS targets / var visibility", () => {
+  it("var-head: body `var x;` redeclaration does not clobber the enumerated key", async () => {
+    // The body `var x;` is a runtime no-op (§14.3.2.1); it must NOT reset the
+    // loop variable to undefined. Pre-fix it re-emitted __get_undefined.
+    expect(
+      await run(`let r = 0;
+for (var x in { attr: 1 }) { var x; if (x === 'attr') r = 1; }
+export function test(): number { return r; }`),
+    ).toBe(1);
+  });
+
+  it("parenthesized identifier head `for ((x) in obj)` binds the key", async () => {
+    expect(
+      await run(`let r = 0; let x = '';
+for ((x) in { attr: 1 }) { if (x === 'attr') r = 1; }
+export function test(): number { return r; }`),
+    ).toBe(1);
+  });
+
+  it("null receiver yields zero iterations (no invalid Wasm / trap)", async () => {
+    expect(
+      await run(`let r = 5;
+for (var k in (null as any)) { r = 0; }
+export function test(): number { return r; }`),
+    ).toBe(5);
+  });
+
+  it("head `let` binding is in TDZ while the receiver is evaluated (ReferenceError)", async () => {
+    // Reading the head `x` (here via a computed key) inside the receiver must
+    // throw, observing the head TDZ binding, not the outer `let x = 1`.
+    expect(
+      await run(`function f(): number {
+  let x = 1;
+  try { for (let x in ({ [x]: 1 } as any)) {} return 0; } catch (e) { return 1; }
+}
+export function test(): number { return f(); }`),
+    ).toBe(1);
+  });
+
+  it("head `const` binding is in TDZ while the receiver is evaluated (ReferenceError)", async () => {
+    expect(
+      await run(`function f(): number {
+  let x = 1;
+  try { for (const x in ({ [x]: 1 } as any)) {} return 0; } catch (e) { return 1; }
+}
+export function test(): number { return f(); }`),
+    ).toBe(1);
+  });
+
+  it("a closure built in the receiver captures the head binding's TDZ (typeof throws)", async () => {
+    // §14.7.5.6: the receiver's closure captures the never-initialized head
+    // binding; calling it later must throw — `typeof x` must NOT static-fold.
+    expect(
+      await run(`function f(): number {
+  let probe: any;
+  for (let x in ({ ['k']: (probe = function () { typeof x; }) } as any)) {}
+  try { probe(); return 0; } catch (e) { return 1; }
+}
+export function test(): number { return f(); }`),
+    ).toBe(1);
+  });
+
+  it("head let/const binding does not leak past the loop", async () => {
+    // After the loop the outer `x` must read 'outside', not the loop binding.
+    // (`as any` routes through the dynamic enumeration path the fix covers; the
+    // closed-shape standalone static-unroll path is a separate pre-existing
+    // limitation. In host/gc mode — the test262 lane — both paths restore.)
+    expect(
+      await run(`function f(): number {
+  let x = 'outside';
+  for (let x in ({ a: 1 } as any)) {}
+  return x === 'outside' ? 1 : 0;
+}
+export function test(): number { return f(); }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #2705 (10 of 11 closeable tests; the 1 miss is the allowed `head-lhs-let` Array.prototype-setter half).

## What
Implements ECMAScript §14.7.5 for-in head scoping/dispatch gaps:

**Slice A — LHS dispatch + var reuse + null-receiver guard** (`loops.ts`)
- Paren-unwrap routes `for ((x) in …)` to the identifier branch (`head-lhs-cover`).
- Empty-`declarations` VariableDeclarationList ⇒ the non-strict `let` *identifier* (`for (let in …)`); previously deref'd `declarations[0].name` on `undefined` (`head-lhs-let`, `identifier-let-allowed`).
- `var`-head reuses the hoisted function-scope slot instead of allocating a fresh shadowing local (`head-var-bound-names-in-stmt`).
- Static-nullish receiver ⇒ emit no loop (zero iterations, step 7) — fixes `let-identifier-with-newline`.

**Slice B — head TDZ env + post-loop restore** (`loops.ts`)
- For a `let`/`const` head: install a TDZ environment for the head bound names before compiling the receiver (boxed ref-cell + boxed TDZ flag for closure-captured names; plain local + i32 flag otherwise), so receiver reads / `typeof` throw ReferenceError. Tear down (step 4); the per-iteration body binds the names afresh. After the loop, restore saved outer bindings so head names don't leak. Closes `head-let/const-bound-names-fordecl-tdz`, `scope-head/body-lex-open/close`.

**Supporting (narrowly gated)**
- `variables.ts`: a no-init `var x;` that reused a hoisted slot is now a runtime no-op (§14.3.2.1) — it no longer clobbers the slot with `__get_undefined`. The hoister already inits the slot to `undefined` at function entry, so this is a general correctness fix.
- `typeof-delete.ts`: `typeof x` of a boxed-TDZ binding forces the runtime path (no static-fold) so a TDZ read throws.
- `closures.ts`: a closure built in a for-in/for-of receiver capturing the head binding is a TDZ risk (the receiver env is distinct from the per-iteration env).

## Validation (scoped; CI runs full test262)
- **for-in suite (122 tests) vs merge-base: 94 → 104 PASS = +10, ZERO regressions.**
- **Broad var/typeof/scope sample (70 tests): 56 == 56, ZERO deltas** — confirms the broad-reach `variables.ts`/`typeof-delete.ts` changes don't regress non-for-in code.
- `tests/issue-2705.test.ts` (7) + `issue-1896-typeof-closure` + `issue-2572-standalone-forin` + `issue-2200-annexb-block-fn-hoist` + `issue-1128-dstr-tdz` all green post-merge.
- The eval-routed `S12.6.4_A3/A3.1/A4/A4.1`, `scope-head/body-var-none`, `cptn-*` remain deferred (eval-inline Slice D) per the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)