### PR TITLE
docs(#1846): descope typeof-conformance to backlog; split to #2727 + #2728

### DIFF
--- a/plan/issues/1846-minor-typeof-conformance-notes.md
+++ b/plan/issues/1846-minor-typeof-conformance-notes.md
@@ -1,7 +1,7 @@
 ---
 id: 1846
 title: "Minor typeof conformance: i64->'number' in with-bindings; externref->null fallthrough"
-status: ready
+status: backlog
 created: 2026-06-04
 updated: 2026-06-26
 priority: low
@@ -9,9 +9,33 @@ feasibility: low
 task_type: bugfix
 area: codegen
 goal: test262-conformance
-sprint: 67
+sprint: Backlog
+depends_on: []
 ---
 # #1846 — minor `typeof` conformance notes
+
+## DESCOPED → Backlog (2026-06-26)
+
+Investigated the 3 Sprint-67 "closeable" tests against current main. None is a
+clean win; each real sub-gap is split to its own tracked issue, and the original
+one-liner defects yield ~0 test262 movement. Set `status: backlog`.
+
+- **`built-in-exotic-objects-no-call.js`** — ALL `typeof new X()` asserts already
+  pass ("object"); the only failure is assert #1 `typeof this` (top-level
+  sloppy-script `this` must be the global object → "object"). Real semantics gap,
+  **split to #2727** (feasibility: hard — needs script-mode-`this` / global-object
+  design; do NOT attempt as a one-off).
+- **`symbol.js`** — only `typeof Object(Symbol())` fails (returns "symbol"); needs
+  a Symbol-wrapper-object boxing branch in the `Object()` call path. **Split to
+  #2728** (feasibility: medium). Deliberately NOT done here: the `Object()`
+  call-lowering is the busy/broad-coverage path that produced the #2149/#2702
+  merge_group regressions — not worth the risk for a single test.
+- **`syntax.js`** — routes through `eval(...)`; **eval-blocked** (see #1066
+  standalone-eval). Consistent with the sprint's eval carve-out.
+- **`bigint.js`** — blocked on #2044 (BigInt i64-brand ValType decision).
+- **Original one-liner defects** (i64→"bigint" static map; externref→null
+  fallthrough) — correct but near-nil impact (i64 path is `with`-bindings-only;
+  bigint blocked on #2044). Not worth a standalone PR.
 
 ## Defects
 - `src/codegen/typeof-delete.ts:831` (`staticTypeofForWasmType`) maps i64 → "number"

--- a/plan/issues/2727-typeof-toplevel-this-sloppy-script-global.md
+++ b/plan/issues/2727-typeof-toplevel-this-sloppy-script-global.md
@@ -1,0 +1,60 @@
+---
+id: 2727
+title: "Top-level (sloppy script) `this` should be the global object (typeof this === 'object')"
+status: ready
+created: 2026-06-26
+updated: 2026-06-26
+priority: low
+feasibility: hard
+task_type: bugfix
+area: codegen
+goal: test262-conformance
+sprint: Backlog
+depends_on: []
+---
+# #2727 — top-level sloppy-script `this` = global object
+
+Split out of **#1846** (descoped). This is the single remaining failing
+assertion in `test/language/expressions/typeof/built-in-exotic-objects-no-call.js`
+— every `typeof new X()` case already returns `"object"` correctly on current
+main.
+
+## Problem
+
+In a **non-strict (sloppy) script**, the top-level `this` is the global object,
+so `typeof this === "object"`. test262 runs these as scripts, not modules.
+
+Our pipeline wraps each test body into an exported `test()` function. Inside that
+(strict module) function, `this` is `undefined`, so `typeof this` evaluates to
+`"undefined"` instead of `"object"`.
+
+Verified on current main:
+
+```ts
+export function test(): string { return typeof this; }   // → "undefined" (want "object")
+```
+
+## Failing test262 (baseline 2026-06-26)
+
+- `test/language/expressions/typeof/built-in-exotic-objects-no-call.js` — assert
+  #1 `typeof this === "object"` (all other asserts in the file already pass).
+
+## Root cause
+
+We model every compilation unit as a strict module; there is no notion of a
+sloppy-script top-level `this` bound to a global object. The test-harness wrapper
+turns the script body into a strict function whose `this` is `undefined`.
+
+## Possible directions (need design — feasibility: hard)
+
+- **Harness-level**: bind the wrapper's `this` to a global-like object for tests
+  flagged as flat/sloppy scripts (narrow, but a harness hack, not a compiler
+  fix).
+- **Compiler-level**: model a top-level (script-mode) `this` that resolves to a
+  global object value. Broad semantics change — touches `this` resolution and a
+  global-object representation. Should be specced before implementation.
+
+## Notes
+
+Low movement (single assertion). Parked in Backlog until the global-object /
+script-mode-`this` semantics are designed. Do NOT attempt as a one-off.

--- a/plan/issues/2728-object-symbol-wrapper-boxing.md
+++ b/plan/issues/2728-object-symbol-wrapper-boxing.md
@@ -1,0 +1,68 @@
+---
+id: 2728
+title: "Object(Symbol()) should box to a Symbol-wrapper object (typeof → 'object')"
+status: ready
+created: 2026-06-26
+updated: 2026-06-26
+priority: low
+feasibility: medium
+task_type: bugfix
+area: codegen
+goal: test262-conformance
+sprint: Backlog
+depends_on: []
+---
+# #2728 — `Object(Symbol())` → Symbol-wrapper object
+
+Split out of **#1846** (descoped). This is the single remaining failing
+assertion in `test/language/expressions/typeof/symbol.js`; the bare
+`typeof Symbol()` cases already pass.
+
+## Problem
+
+§7.1.18 ToObject (Table 13): `Object(sym)` for a symbol primitive must return a
+**Symbol-wrapper object**, whose `typeof` is `"object"`.
+
+Verified on current main:
+
+```ts
+export function test(): string { return typeof Object(Symbol()); }   // → "symbol" (want "object")
+```
+
+`tryObjectCoercionCall` (`src/codegen/expressions/calls-guards.ts`) boxes
+`Object(x)` for Number / String / Boolean / BigInt, but has **no Symbol branch**,
+so a symbol argument falls through to the identity case (returns the raw symbol →
+`typeof` `"symbol"`).
+
+## Failing test262 (baseline 2026-06-26)
+
+- `test/language/expressions/typeof/symbol.js` — asserts #3/#4
+  `typeof Object(Symbol()) === "object"` / `typeof Object(Symbol("A")) === "object"`.
+
+## Implementation sketch (medium)
+
+1. Add a dedicated `__new_Symbol` host helper that boxes a symbol into a wrapper
+   object via the spec's literal `Object(sym)` — **Symbol is not a constructor**,
+   so the generic `__new_<Ctor>` path (`new Symbol(...)`) throws, exactly like
+   `__new_BigInt` (#1568). It must reuse the per-instance symbol id→Symbol cache
+   that `__box_symbol` uses (`src/runtime.ts`, `instanceState.symbolCache`), so
+   the wrapped symbol preserves identity/description. The runtime already
+   recognises Symbol-wrapper objects (`Symbol.prototype.description` unwraps
+   them — `src/runtime.ts` ~L10115).
+2. Add `else if (isSymbolType(argTsType))` to `tryObjectCoercionCall` mirroring
+   the Number/String/Boolean branches: compile the arg to its i32 symbol id and
+   call `__new_Symbol(i32) -> externref`.
+3. Standalone fallback: identity (no JS host wrapper) — JS-host is the target.
+
+## Risk / why split from #1846
+
+The `Object(x)` call-lowering is a **busy, broad-coverage path** (it produced the
+#2149 / #2702 merge_group regressions). Adding a new branch is lower-risk than
+touching existing arms, but it must be validated against the full
+`Object(...)` / typeof surface, not just symbol.js. Verify-first.
+
+## Notes
+
+Low movement (single test). Parked in Backlog. Links to the Symbol-wrapper
+machinery (`__box_symbol`, `instanceState.symbolCache`, Symbol.prototype
+description unwrap) in `src/runtime.ts`.


### PR DESCRIPTION
Descopes **#1846** (minor typeof conformance) after a verify-first investigation on current main found that none of the 3 Sprint-67 "closeable" tests is a clean win. Splits the two real sub-gaps into their own tracked issues and parks #1846 in the backlog. Doc-only (no compiler changes).

## Findings (current main)
- `built-in-exotic-objects-no-call.js` — every `typeof new X()` assert already passes ("object"); the ONLY failure is assert #1 `typeof this` (top-level sloppy-script `this` must be the global object). Real semantics gap → **#2727** (hard, needs design).
- `symbol.js` — only `typeof Object(Symbol())` fails (returns "symbol"); needs a Symbol-wrapper-object boxing branch in the `Object()` call path → **#2728** (medium). Deliberately NOT done inline: the `Object()` lowering is the busy/broad-coverage path that produced the #2149/#2702 merge_group regressions — bad risk/reward for a single test.
- `syntax.js` — `eval(...)`-routed → eval-blocked (#1066).
- `bigint.js` — blocked on #2044.
- Original i64→"bigint" / externref one-liners — correct but ~0 test262 movement.

## Changes
- New `plan/issues/2727-...md` (sloppy-script top-level `this` = global).
- New `plan/issues/2728-...md` (Object(Symbol) wrapper boxing).
- `plan/issues/1846-...md` → `status: backlog`, documents the descope + links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)