### PR TITLE
fix(#2719): standalone Array indexOf/includes/lastIndexOf on externref elements

### DIFF
--- a/plan/issues/2719-array-externref-search-unsatisfiable-standalone.md
+++ b/plan/issues/2719-array-externref-search-unsatisfiable-standalone.md
@@ -1,10 +1,11 @@
 ---
 id: 2719
 title: "Array indexOf/includes/lastIndexOf on externref elements emit __host_eq/__same_value_zero with no standalone branch"
-status: ready
+status: done
 sprint: 67
 created: 2026-06-26
 updated: 2026-06-26
+completed: 2026-06-26
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -37,6 +38,38 @@ also tracked here.)
 
 ## Acceptance criteria
 
-- [ ] externref-element `indexOf`/`includes`/`lastIndexOf` agree with host in
+- [x] externref-element `indexOf`/`includes`/`lastIndexOf` agree with host in
       standalone OR produce a tracked compile error — never an unsatisfiable
       import.
+
+## Resolution (2026-06-26)
+
+The three dedicated externref-element lowerings (`compileArrayIndexOf`,
+`compileArrayIncludes`, `compileArrayLastIndexOf` in
+`src/codegen/array-methods.ts`) now gate on `ctx.standalone || ctx.wasi`:
+
+- **indexOf / lastIndexOf** → `ensureExternStrictEqHelper` (`__extern_strict_eq`,
+  Strict Equality §7.2.16) instead of the host `__host_eq` import.
+- **includes** → `ensureExternSameValueZeroHelper` (`__extern_same_value_zero`,
+  SameValueZero §7.2.11) instead of the host `__same_value_zero` import.
+
+These are the same pure-Wasm helpers (composed from `__any_from_extern` +
+`__any_strict_eq`) already used by the `.call(...)` form
+(`compileArrayLikePrototypeSearch`), so standalone search emits **zero host
+imports**. Host/gc mode is byte-unchanged (still uses the host imports). The
+funcIdx is re-resolved from `funcMap` by name after `flushLateImportShifts` so a
+late-import shift can't desync the captured index.
+
+Verified (`tests/issue-2719.test.ts`, 14 cases): standalone `indexOf` /
+`includes` / `lastIndexOf` on `any[]` instantiate with empty imports and return
+spec-correct results, including the NaN distinction (`includes(NaN)` → true via
+SameValueZero, `indexOf(NaN)` / `lastIndexOf(NaN)` → -1 via Strict Equality);
+host-mode results match. No new host imports. Pre-existing `#1360`
+`lastIndexOf.call(arr, null)` null-field failures (tracked under #1382) are
+unaffected — they live in the separate `.call` path and fail identically on
+clean main.
+
+**Out of scope (deferred):** the linear backend still has no externref-element
+search lowering (hard compile error there) — the WasmGC standalone gap is what
+parent #2711's parity gate flags; the linear-backend lowering is a separate
+follow-up.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -4031,19 +4031,24 @@ function compileArrayIndexOf(
   // For ref/ref_null elements, use ref.eq for reference identity comparison.
   let eqInstrs: Instr[];
   if (elemType.kind === "externref") {
-    const hostEqIdx = ensureLateImport(
-      ctx,
-      "__host_eq",
-      [{ kind: "externref" }, { kind: "externref" }],
-      [{ kind: "i32" }],
-    );
+    // (#2719) Standalone/WASI have no JS host, so the `__host_eq` import is
+    // unsatisfiable and the module fails to instantiate. Route element Strict
+    // Equality through the pure-Wasm `__extern_strict_eq` helper there (composed
+    // from `__any_from_extern` + `__any_strict_eq`, §7.2.16-equivalent). Host/gc
+    // mode keeps the `__host_eq` host import. Mirrors the standalone arm in
+    // `compileArrayLikePrototypeSearch` (the `.call(...)` form).
+    const nativeCmp = ctx.standalone || ctx.wasi;
+    const cmpIdx = nativeCmp
+      ? ensureExternStrictEqHelper(ctx)
+      : ensureLateImport(ctx, "__host_eq", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "i32" }]);
     flushLateImportShifts(ctx, fctx);
-    const finalHostEqIdx = ctx.funcMap.get("__host_eq") ?? hostEqIdx;
-    if (finalHostEqIdx === undefined) {
-      reportError(ctx, callExpr, "indexOf: failed to bind __host_eq import");
+    const cmpName = nativeCmp ? "__extern_strict_eq" : "__host_eq";
+    const finalCmpIdx = ctx.funcMap.get(cmpName) ?? cmpIdx;
+    if (finalCmpIdx === undefined) {
+      reportError(ctx, callExpr, "indexOf: failed to bind element equality helper");
       return null;
     }
-    eqInstrs = [{ op: "call", funcIdx: finalHostEqIdx } as Instr];
+    eqInstrs = [{ op: "call", funcIdx: finalCmpIdx } as Instr];
   } else if (elemType.kind === "ref" || elemType.kind === "ref_null") {
     // #2036 — native-string elements compare by content (§7.2.16), not identity.
     eqInstrs = nativeStringElementEqInstrs(ctx, fctx, elemType) ?? [{ op: "ref.eq" }];
@@ -4259,16 +4264,18 @@ function compileArrayIncludes(
     // identity, cross-type → false. The wasm:js-string `equals` builtin
     // coerces both operands to strings, mis-matching object/boolean/number
     // elements (#786 — `includes` on an externref vec).
-    const svzIdx = ensureLateImport(
-      ctx,
-      "__same_value_zero",
-      [{ kind: "externref" }, { kind: "externref" }],
-      [{ kind: "i32" }],
-    );
+    // (#2719) Standalone/WASI have no JS host, so the `__same_value_zero` import
+    // is unsatisfiable. Route SameValueZero through the pure-Wasm
+    // `__extern_same_value_zero` helper there; host/gc mode keeps the import.
+    const nativeCmp = ctx.standalone || ctx.wasi;
+    const svzIdx = nativeCmp
+      ? ensureExternSameValueZeroHelper(ctx)
+      : ensureLateImport(ctx, "__same_value_zero", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "i32" }]);
     flushLateImportShifts(ctx, fctx);
-    const finalSvzIdx = ctx.funcMap.get("__same_value_zero") ?? svzIdx;
+    const svzName = nativeCmp ? "__extern_same_value_zero" : "__same_value_zero";
+    const finalSvzIdx = ctx.funcMap.get(svzName) ?? svzIdx;
     if (finalSvzIdx === undefined) {
-      reportError(ctx, callExpr, "includes: failed to bind __same_value_zero import");
+      reportError(ctx, callExpr, "includes: failed to bind SameValueZero helper");
       return null;
     }
     // (#2001 S1) §22.1.3.13 includes uses Get (holes → undefined), so
@@ -8645,19 +8652,21 @@ function compileArrayLastIndexOf(
   // For ref/ref_null elements, use ref.eq for reference identity comparison.
   let liofEqInstrs: Instr[];
   if (elemType.kind === "externref") {
-    const hostEqIdx = ensureLateImport(
-      ctx,
-      "__host_eq",
-      [{ kind: "externref" }, { kind: "externref" }],
-      [{ kind: "i32" }],
-    );
+    // (#2719) Standalone/WASI route element Strict Equality through the pure-Wasm
+    // `__extern_strict_eq` helper instead of the unsatisfiable `__host_eq` import;
+    // host/gc mode keeps the import. Mirrors indexOf / the `.call(...)` form.
+    const nativeCmp = ctx.standalone || ctx.wasi;
+    const cmpIdx = nativeCmp
+      ? ensureExternStrictEqHelper(ctx)
+      : ensureLateImport(ctx, "__host_eq", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "i32" }]);
     flushLateImportShifts(ctx, fctx);
-    const finalHostEqIdx = ctx.funcMap.get("__host_eq") ?? hostEqIdx;
-    if (finalHostEqIdx === undefined) {
-      reportError(ctx, callExpr, "lastIndexOf: failed to bind __host_eq import");
+    const cmpName = nativeCmp ? "__extern_strict_eq" : "__host_eq";
+    const finalCmpIdx = ctx.funcMap.get(cmpName) ?? cmpIdx;
+    if (finalCmpIdx === undefined) {
+      reportError(ctx, callExpr, "lastIndexOf: failed to bind element equality helper");
       return null;
     }
-    liofEqInstrs = [{ op: "call", funcIdx: finalHostEqIdx } as Instr];
+    liofEqInstrs = [{ op: "call", funcIdx: finalCmpIdx } as Instr];
   } else if (elemType.kind === "ref" || elemType.kind === "ref_null") {
     // #2036 — native-string elements compare by content (§7.2.16), not identity.
     liofEqInstrs = nativeStringElementEqInstrs(ctx, fctx, elemType) ?? [{ op: "ref.eq" }];

--- a/tests/issue-2719.test.ts
+++ b/tests/issue-2719.test.ts
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2719 — Array `indexOf` / `includes` / `lastIndexOf` on externref elements.
+ *
+ * The dedicated externref-element lowerings emitted the host imports `__host_eq`
+ * (indexOf/lastIndexOf, Strict Equality §7.2.16) / `__same_value_zero` (includes,
+ * SameValueZero §7.2.11) with no standalone branch, so a `--target standalone`
+ * module referenced an unsatisfiable import and failed to instantiate.
+ *
+ * Fix: in standalone/WASI route element comparison through the pure-Wasm
+ * `__extern_strict_eq` / `__extern_same_value_zero` helpers (composed from
+ * `__any_from_extern` + `__any_strict_eq`). Host/gc mode keeps the host imports
+ * unchanged. Additive — turns an unsatisfiable import into a self-contained
+ * native search; results agree with the spec (incl. the NaN distinction:
+ * `includes(NaN)` true, `indexOf(NaN)` false).
+ */
+
+async function runStandalone(body: string): Promise<{ value: number; hostImports: string[] }> {
+  const src = `export function test(): number { ${body} }`;
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const hostImports = r.imports.map((i) => i.name).filter((n) => n === "__host_eq" || n === "__same_value_zero");
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const value = (instance.exports as { test: () => number }).test();
+  return { value, hostImports };
+}
+
+describe("#2719 — externref-element Array search in standalone (no host imports)", () => {
+  const cases: Array<[string, string, number]> = [
+    ["indexOf hit", `const a: any[] = [1,"y",{}]; return a.indexOf("y");`, 1],
+    ["indexOf miss", `const a: any[] = [1,"y",{}]; return a.indexOf("z");`, -1],
+    ["indexOf number", `const a: any[] = [1,2,3]; return a.indexOf(2);`, 1],
+    ["includes hit", `const a: any[] = [1,"y",{}]; return a.includes("y") ? 1 : 0;`, 1],
+    ["includes miss", `const a: any[] = [1,"y",{}]; return a.includes("z") ? 1 : 0;`, 0],
+    ["lastIndexOf hit", `const a: any[] = ["y",2,"y"]; return a.lastIndexOf("y");`, 2],
+    ["lastIndexOf miss", `const a: any[] = ["y",2,"y"]; return a.lastIndexOf("q");`, -1],
+    // NaN: Strict Equality (indexOf/lastIndexOf) NaN !== NaN; SameValueZero (includes) NaN === NaN.
+    ["includes NaN (SameValueZero)", `const a: any[] = [NaN]; return a.includes(NaN) ? 1 : 0;`, 1],
+    ["indexOf NaN (Strict Equality)", `const a: any[] = [NaN]; return a.indexOf(NaN);`, -1],
+    ["lastIndexOf NaN (Strict Equality)", `const a: any[] = [NaN]; return a.lastIndexOf(NaN);`, -1],
+  ];
+  for (const [label, body, want] of cases) {
+    it(`${label} → ${want}, no __host_eq/__same_value_zero import`, async () => {
+      const { value, hostImports } = await runStandalone(body);
+      expect(value).toBe(want);
+      expect(hostImports).toEqual([]);
+    });
+  }
+});
+
+describe("#2719 — host/gc mode results unchanged", () => {
+  async function runHost(body: string): Promise<number> {
+    const { buildImports } = await import("../src/runtime.js");
+    const r = await compile(`export function test(): number { ${body} }`, { fileName: "t.ts" });
+    expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+    const built = buildImports(r.imports, {}, r.stringPool);
+    const { instance } = await WebAssembly.instantiate(r.binary, built as WebAssembly.Imports);
+    if (built.setExports) built.setExports(instance.exports as Record<string, Function>);
+    return (instance.exports as { test: () => number }).test();
+  }
+  const cases: Array<[string, string, number]> = [
+    ["indexOf hit", `const a: any[] = [1,"y",{}]; return a.indexOf("y");`, 1],
+    ["includes NaN", `const a: any[] = [NaN]; return a.includes(NaN) ? 1 : 0;`, 1],
+    ["indexOf NaN", `const a: any[] = [NaN]; return a.indexOf(NaN);`, -1],
+    ["lastIndexOf hit", `const a: any[] = ["y",2,"y"]; return a.lastIndexOf("y");`, 2],
+  ];
+  for (const [label, body, want] of cases) {
+    it(`${label} → ${want}`, async () => {
+      expect(await runHost(body)).toBe(want);
+    });
+  }
+});


### PR DESCRIPTION
Closes **#2719** (parent #2711 standalone↔host parity).

## Problem
The dedicated externref-element lowerings for `indexOf` / `includes` / `lastIndexOf` emitted the host imports `__host_eq` (Strict Equality §7.2.16) / `__same_value_zero` (SameValueZero §7.2.11) with **no standalone branch**. A `--target standalone` module therefore referenced an unsatisfiable import and failed to instantiate.

## Fix
Gate the three lowerings (`compileArrayIndexOf` / `compileArrayIncludes` / `compileArrayLastIndexOf` in `src/codegen/array-methods.ts`) on `ctx.standalone || ctx.wasi`:
- indexOf / lastIndexOf → `ensureExternStrictEqHelper` (`__extern_strict_eq`)
- includes → `ensureExternSameValueZeroHelper` (`__extern_same_value_zero`)

These pure-Wasm helpers (composed from `__any_from_extern` + `__any_strict_eq`) are exactly what the `.call(...)` form (`compileArrayLikePrototypeSearch`) already uses, so standalone search emits **zero host imports**. Host/gc mode is byte-unchanged. The funcIdx is re-resolved from `funcMap` by name after `flushLateImportShifts` so a late-import shift can't desync it.

## Validation
- `tests/issue-2719.test.ts` (14 cases): standalone `indexOf`/`includes`/`lastIndexOf` on `any[]` instantiate with **empty imports** and return spec-correct results, incl. the NaN distinction (`includes(NaN)` → true via SameValueZero; `indexOf(NaN)` / `lastIndexOf(NaN)` → -1 via Strict Equality). Host-mode results match. No new host imports.
- Existing `issue-786` / `issue-2648` array-search tests pass. The 2 pre-existing `#1360` `lastIndexOf.call(arr, null)` null-field failures (tracked under #1382) are in the separate `.call` path and fail identically on clean main — unaffected.
- `tsc --noEmit` + prettier clean.

## Out of scope (deferred)
The linear backend still has no externref-element search lowering (hard compile error there) — a separate follow-up; this PR closes the WasmGC standalone gap that #2711's parity gate flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)