### PR TITLE
fix(#2715): linear backend ToInt32/ToUint8 wrap instead of trapping trunc

### DIFF
--- a/plan/issues/2715-linear-trapping-trunc-bitwise-typedarray.md
+++ b/plan/issues/2715-linear-trapping-trunc-bitwise-typedarray.md
@@ -1,10 +1,12 @@
 ---
 id: 2715
 title: "Linear backend: trapping i32.trunc_f64_s in bitwise ops + typed-array stores → use trunc_sat / ToInt32 wrap"
-status: ready
+status: done
 sprint: 67
 created: 2026-06-26
 updated: 2026-06-26
+completed: 2026-06-26
+assignee: ttraenkler/dev1
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -14,6 +16,7 @@ language_feature: standalone
 goal: standalone-everything
 parent: 2711
 ---
+
 # #2715 — Linear backend traps on float→int conversion (bitwise / Uint8Array)
 
 **Parent:** #2711 (standalone↔host differential parity gate). **Surfaced by**
@@ -48,7 +51,40 @@ correct because it routes through a different path).
 
 ## Acceptance criteria
 
-- [ ] `(0/0)|0`, `(1/0)|0`, large-magnitude `x|0` agree with host on the linear
-      backend (add to the cross-backend corpus once green).
-- [ ] `u8[i] = NaN` stores `0` on linear, no trap.
-- [ ] No remaining trapping `i32.trunc_f64_s` on the JS-number→int paths.
+- [x] `(0/0)|0`, `(1/0)|0`, large-magnitude `x|0` agree with host on the linear
+      backend (added the `numeric/bitwise-toint32-nan-wrap` cross-backend corpus entry).
+- [x] `u8[i] = NaN` stores `0` on linear, no trap.
+- [x] No remaining trapping `i32.trunc_f64_s` on the JS-number→int paths.
+
+## Resolution (2026-06-26, dev1)
+
+Added a non-trapping `emitToInt32` to the linear backend (`src/codegen-linear/index.ts`)
+mirroring the WasmGC `emitToInt32` (binary-ops.ts): `f64.trunc` → modular
+reduction `x - floor(x/2³²)*2³²` → `i32.trunc_sat_f64_u`. NaN/±∞ map to 0 and
+large magnitudes wrap mod 2³² instead of trapping. A new `compileExprToInt32`
+routes bitwise operands through it.
+
+Sites changed (all the JS-number→int paths):
+
+- unary `~` operand
+- binary bitwise operators (`& | ^ << >> >>>`)
+- bitwise compound assignment (`&= |= ^= <<= >>= >>>=`)
+- `Uint8Array` element store (ToUint8 — `__u8arr_set`'s `i32.store8` keeps the low byte)
+
+The trapping `compileExprToI32` is retained (renamed-in-doc) for **internal**
+integer conversions (array indices, lengths, struct-handle slots) where the
+value is a representable integer and a trap on garbage is acceptable; the 4
+native-`i32`-typed field/handle conversion sites (`index.ts` ~1658/1930/3584/4393)
+are intentionally left on it (native-type semantics, not JS ToInt32).
+
+Verified every case against the JS oracle: `(0/0)|0===0`, `1e20|0===1661992960`,
+`4294967297|0===1`, `-1>>>0===4294967295`, `~(0/0)===-1`, `u8[0]=257→1`,
+`u8[0]=NaN→0`, `u8[0]=-1→255`. Tests: `tests/issue-2715.test.ts` (22) +
+`numeric/bitwise-toint32-nan-wrap` cross-backend corpus entry. Full linear suite
+(18 files / 159 tests) + cross-backend-diff green.
+
+**Discovered + filed #2729**: the WasmGC backend has a _separate_ pre-existing
+bug — `new Uint8Array(n)` element stores skip ToUint8 entirely (`u[0]=257` reads
+257, `u[0]=NaN` reads NaN). That's why a Uint8Array cross-backend corpus entry is
+NOT added here (the backends diverge for an unrelated reason); it's tracked in
+#2729 and the corpus entry should be added once WasmGC is fixed.

--- a/plan/issues/2729-wasmgc-uint8array-store-skips-touint8.md
+++ b/plan/issues/2729-wasmgc-uint8array-store-skips-touint8.md
@@ -1,0 +1,59 @@
+---
+id: 2729
+title: "WasmGC backend: new Uint8Array(n) element store skips ToUint8 (u[0]=257 reads 257, u[0]=NaN reads NaN)"
+status: ready
+sprint: Backlog
+created: 2026-06-26
+priority: medium
+feasibility: medium
+task_type: bug
+area: codegen
+language_feature: typed-arrays
+goal: core-semantics
+related: [2715]
+---
+
+# #2729 — WasmGC Uint8Array element store does not apply ToUint8
+
+## Problem
+
+On the **WasmGC** backend (default `target`), assigning an out-of-range or
+non-integer value to a `Uint8Array` element does not apply the §7.1.x ToUint8
+conversion — the element reads back the raw assigned value instead of the wrapped
+byte:
+
+```ts
+const u = new Uint8Array(1);
+u[0] = 257;
+u[0]; // → 257  (should be 1)
+u[0] = -1;
+u[0]; // → -1   (should be 255)
+u[0] = 0 / 0;
+u[0]; // → NaN  (should be 0)
+```
+
+Surfaced by #2715: the cross-backend differential harness flagged a divergence
+between WasmGC and linear for `new Uint8Array(1); u[0]=NaN; return u[0]` —
+**linear is now correct (0)** after #2715, but WasmGC returns `NaN`.
+
+## Root cause (suspected)
+
+The `new Uint8Array(n)` (no explicit `ArrayBuffer`) element-assignment path on the
+WasmGC backend appears to store/return the raw RHS rather than routing through a
+packed byte store + ToUint8. Contrast: a `Uint8Array` over an explicit
+`ArrayBuffer` (and the `array.set` packed-store path used elsewhere) truncates
+correctly. Verify whether the `new Uint8Array(n)` form lowers to a real packed
+backing store at all.
+
+## Acceptance criteria
+
+- `u[0] = 257` reads back `1`, `u[0] = -1` reads back `255`, `u[0] = NaN`/`±Inf`
+  reads back `0` on the WasmGC backend.
+- Re-add the `numeric/uint8-store-touint8` cross-backend corpus entry (removed in
+  #2715 because of this divergence) so the gate covers it once both backends agree.
+- No regression in existing TypedArray tests.
+
+## Notes
+
+The linear backend's ToUint8 store is already correct (#2715). This issue is the
+WasmGC counterpart only.

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -1474,8 +1474,9 @@ export function compileExpression(ctx: LinearContext, fctx: LinearFuncContext, e
       // Result is i32 (0 or 1), convert back to f64
       fctx.body.push({ op: "f64.convert_i32_s" });
     } else if (expr.operator === ts.SyntaxKind.TildeToken) {
-      // Bitwise NOT: ~x = (x ^ -1)
-      compileExprToI32(ctx, fctx, expr.operand);
+      // Bitwise NOT: ~x = (x ^ -1). ToInt32 the operand (#2715: NaN/∞/large wrap,
+      // never trap) so `~(0/0) === -1`.
+      compileExprToInt32(ctx, fctx, expr.operand);
       fctx.body.push({ op: "i32.const", value: -1 });
       fctx.body.push({ op: "i32.xor" });
       fctx.body.push({ op: "f64.convert_i32_s" });
@@ -2018,9 +2019,9 @@ function compileBinaryExpression(ctx: LinearContext, fctx: LinearFuncContext, ex
     const idx = fctx.localMap.get(expr.left.text);
     if (idx !== undefined) {
       if (isBitwiseCompoundAssignment(op)) {
-        // Bitwise compound: operate in i32, store f64 result
-        compileExprToI32(ctx, fctx, expr.left);
-        compileExprToI32(ctx, fctx, expr.right);
+        // Bitwise compound: operate in i32 (JS ToInt32 operands — #2715), store f64 result
+        compileExprToInt32(ctx, fctx, expr.left);
+        compileExprToInt32(ctx, fctx, expr.right);
         fctx.body.push(bitwiseOp(bitwiseCompoundToOp(op)));
         if (op === ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken) {
           fctx.body.push({ op: "f64.convert_i32_u" });
@@ -2088,10 +2089,11 @@ function compileBinaryExpression(ctx: LinearContext, fctx: LinearFuncContext, ex
     }
   }
 
-  // Bitwise operators: need i32 truncation
+  // Bitwise operators: ToInt32 both operands per JS spec (#2715: NaN/∞/large
+  // wrap mod 2^32, never trap — `(0/0)|0 === 0`).
   if (isBitwiseOp(op)) {
-    compileExprToI32(ctx, fctx, expr.left);
-    compileExprToI32(ctx, fctx, expr.right);
+    compileExprToInt32(ctx, fctx, expr.left);
+    compileExprToInt32(ctx, fctx, expr.right);
     fctx.body.push(bitwiseOp(op));
     // Unsigned right shift converts back with unsigned conversion
     if (op === ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken) {
@@ -3200,7 +3202,9 @@ function compileElementAccessAssignment(
     compileExpression(ctx, fctx, left.expression);
     compileExprToI32(ctx, fctx, left.argumentExpression); // index → i32
     fctx.body.push({ op: "local.get", index: valLocal });
-    fctx.body.push({ op: "i32.trunc_f64_s" }); // byte value
+    // ToUint8 byte value (#2715): ToInt32 then `__u8arr_set`'s i32.store8 keeps the
+    // low byte. NaN/∞ → 0, large values wrap mod 256, never trap.
+    emitToInt32(fctx);
     fctx.body.push({ op: "call", funcIdx: setIdx });
     fctx.body.push({ op: "local.get", index: valLocal }); // assigned value (f64)
   } else {
@@ -3950,12 +3954,58 @@ function compileSetMethodCall(
 /**
  * Compile an expression and convert to i32 if needed.
  * If the expression produces f64, emit i32.trunc_f64_s; if i32, no-op.
+ *
+ * NOTE: this uses the **trapping** `i32.trunc_f64_s` and is for internal
+ * integer conversions (array indices, lengths, handles) where the value is
+ * expected to be a representable integer. JS-number paths that require the
+ * §7.1.6 `ToInt32` / `ToUint8` wrap (bitwise operators, integer typed-array
+ * element stores) must use {@link compileExprToInt32} / {@link emitToInt32}
+ * instead — those wrap mod 2³² and map NaN/±∞ to 0 rather than trapping (#2715).
  */
 function compileExprToI32(ctx: LinearContext, fctx: LinearFuncContext, expr: ts.Expression): void {
   const exprType = inferExprType(ctx, fctx, expr);
   compileExpression(ctx, fctx, expr);
   if (exprType.kind === "f64") {
     fctx.body.push({ op: "i32.trunc_f64_s" });
+  }
+}
+
+/**
+ * #2715 — JS ToInt32 (§7.1.6) for an f64 already on the stack → i32 bit pattern.
+ *
+ * NaN / ±Infinity → 0; finite values truncate toward zero then reduce mod 2³²
+ * (large magnitudes WRAP, not saturate). Mirrors the WasmGC backend's
+ * `emitToInt32` (src/codegen/binary-ops.ts): the non-trapping saturating
+ * conversion removes the `i32.trunc_f64_s` trap on NaN/∞, and the explicit
+ * `x - floor(x / 2³²) * 2³²` reduction supplies the modular wrap that saturation
+ * alone does not. The `_u` saturating conversion then yields the correct 32-bit
+ * pattern (reinterpreted as signed by the consumer).
+ */
+function emitToInt32(fctx: LinearFuncContext): void {
+  const tmp = fctx.params.length + fctx.locals.length;
+  fctx.locals.push({ name: `__toint32_${tmp}`, type: { kind: "f64" } });
+  fctx.body.push({ op: "f64.trunc" }); // truncate toward zero (ToInteger)
+  fctx.body.push({ op: "local.tee", index: tmp });
+  fctx.body.push({ op: "local.get", index: tmp });
+  fctx.body.push({ op: "f64.const", value: 4294967296 }); // 2^32
+  fctx.body.push({ op: "f64.div" });
+  fctx.body.push({ op: "f64.floor" });
+  fctx.body.push({ op: "f64.const", value: 4294967296 });
+  fctx.body.push({ op: "f64.mul" });
+  fctx.body.push({ op: "f64.sub" }); // x - floor(x/2^32)*2^32 ∈ [0, 2^32)
+  fctx.body.push({ op: "i32.trunc_sat_f64_u" }); // bit pattern; NaN/∞ → 0
+}
+
+/**
+ * #2715 — compile an expression and coerce to i32 using JS `ToInt32` semantics
+ * (for bitwise operands). An already-i32 value is left untouched (it is already a
+ * 32-bit integer); an f64 value is run through {@link emitToInt32}.
+ */
+function compileExprToInt32(ctx: LinearContext, fctx: LinearFuncContext, expr: ts.Expression): void {
+  const exprType = inferExprType(ctx, fctx, expr);
+  compileExpression(ctx, fctx, expr);
+  if (exprType.kind === "f64") {
+    emitToInt32(fctx);
   }
 }
 

--- a/tests/cross-backend/corpus.ts
+++ b/tests/cross-backend/corpus.ts
@@ -86,6 +86,40 @@ export const CROSS_BACKEND_CORPUS: readonly CrossBackendProgram[] = [
     ],
   },
   {
+    // #2715 — bitwise ToInt32 (§7.1.6): NaN/±Infinity → 0, large magnitudes wrap
+    // mod 2^32 (never trap). The linear backend used to lower these with the
+    // trapping i32.trunc_f64_s, so `(0/0)|0` trapped instead of returning 0.
+    name: "numeric/bitwise-toint32-nan-wrap",
+    category: "numeric",
+    source: `
+      export function nanOr(): number { return (0 / 0) | 0; }
+      export function infOr(): number { return (1 / 0) | 0; }
+      export function negInfOr(): number { return (-1 / 0) | 0; }
+      export function bigWrap(): number { return 1e20 | 0; }
+      export function plus2to32(): number { return 4294967297 | 0; }
+      export function notNan(): number { return ~(0 / 0); }
+      export function ushrNeg(): number { return (-1 >>> 0) === 4294967295 ? 1 : 0; }
+      export function compoundNan(): number { let x = 5; x |= 0 / 0; return x; }
+    `,
+    calls: [
+      { fn: "nanOr", args: [] },
+      { fn: "infOr", args: [] },
+      { fn: "negInfOr", args: [] },
+      { fn: "bigWrap", args: [] },
+      { fn: "plus2to32", args: [] },
+      { fn: "notNan", args: [] },
+      { fn: "ushrNeg", args: [] },
+      { fn: "compoundNan", args: [] },
+    ],
+  },
+  // NOTE: a Uint8Array ToUint8 store cross-backend entry is deliberately NOT
+  // added here — the WasmGC backend has a separate, pre-existing bug where
+  // `new Uint8Array(1)` element stores skip ToUint8 entirely (`u[0]=257` reads
+  // back 257, `u[0]=NaN` reads back NaN), so the two backends diverge for an
+  // unrelated reason. The linear ToUint8 fix is covered directly against the JS
+  // oracle in tests/issue-2715.test.ts; the WasmGC store bug is tracked
+  // separately (follow-up issue).
+  {
     // Math.trunc is not yet lowered by the linear backend (Unsupported method
     // call: .trunc()). Tracked here so the gap is visible and the flag drops
     // the moment linear gains Math.* support.

--- a/tests/issue-2715.test.ts
+++ b/tests/issue-2715.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2715 — Linear backend lowered bitwise operands and Uint8Array element stores
+// with the TRAPPING `i32.trunc_f64_s`, so JS programs that rely on ToInt32 /
+// ToUint8 of NaN / ±Infinity / out-of-range values trapped ("float
+// unrepresentable in integer range") instead of producing the wrapped value.
+// The fix routes those paths through a non-trapping ToInt32 (trunc_sat + modular
+// reduction), mirroring the WasmGC backend.
+
+async function runLinear(body: string): Promise<number> {
+  const r = await compile(`export function test(): number { ${body} }`, { target: "linear" });
+  if (!r.success) throw new Error("compile failed: " + (r.errors[0]?.message ?? "unknown"));
+  const { instance } = await WebAssembly.instantiate(r.binary);
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#2715 linear backend ToInt32 — bitwise ops do not trap", () => {
+  const cases: Array<[string, number]> = [
+    ["return (0 / 0) | 0;", (0 / 0) | 0],
+    ["return (1 / 0) | 0;", (1 / 0) | 0],
+    ["return (-1 / 0) | 0;", (-1 / 0) | 0],
+    ["return 1e20 | 0;", 1e20 | 0],
+    ["return 4294967297 | 0;", 4294967297 | 0],
+    ["return 2147483648 | 0;", 2147483648 | 0],
+    ["return 3.9 | 0;", 3.9 | 0],
+    ["return -3.9 | 0;", -3.9 | 0],
+    ["return 5 & 3;", 5 & 3],
+    ["return 6 ^ 3;", 6 ^ 3],
+    ["return 1 << 31;", 1 << 31],
+    ["return -2.5 >> 1;", -2.5 >> 1],
+    ["return (-1 >>> 0) === 4294967295 ? 1 : 0;", 1],
+    ["return ~(0 / 0);", ~(0 / 0)],
+    ["return ~3.2;", ~3.2],
+  ];
+  for (const [body, expected] of cases) {
+    it(`${body.trim()} === ${expected}`, async () => {
+      expect(await runLinear(body)).toBe(expected);
+    });
+  }
+});
+
+describe("#2715 linear backend bitwise compound assignment ToInt32", () => {
+  it("x |= NaN keeps x (ToInt32(NaN)=0)", async () => {
+    expect(await runLinear("let x = 5; x |= 0 / 0; return x;")).toBe(5);
+  });
+  it("x &= 255 wraps", async () => {
+    expect(await runLinear("let x = 257; x &= 255; return x;")).toBe(1);
+  });
+  it("x <<= 31 produces INT_MIN", async () => {
+    expect(await runLinear("let x = 1; x <<= 31; return x;")).toBe(1 << 31);
+  });
+});
+
+describe("#2715 linear backend Uint8Array store ToUint8 — no trap", () => {
+  it("u8[0] = NaN stores 0", async () => {
+    expect(await runLinear("const u = new Uint8Array(1); u[0] = 0 / 0; return u[0];")).toBe(0);
+  });
+  it("u8[0] = Infinity stores 0", async () => {
+    expect(await runLinear("const u = new Uint8Array(1); u[0] = 1 / 0; return u[0];")).toBe(0);
+  });
+  it("u8[0] = 257 wraps to 1", async () => {
+    expect(await runLinear("const u = new Uint8Array(1); u[0] = 257; return u[0];")).toBe(1);
+  });
+  it("u8[0] = -1 wraps to 255", async () => {
+    expect(await runLinear("const u = new Uint8Array(1); u[0] = -1; return u[0];")).toBe(255);
+  });
+});


### PR DESCRIPTION
Fixes #2715. Parent: #2711 (standalone↔host parity).

## Problem
The linear backend (`target: "linear"`) lowered bitwise operands and `Uint8Array` element stores with the **trapping** `i32.trunc_f64_s`, so JS programs relying on `ToInt32`/`ToUint8` of NaN / ±Infinity / out-of-range values **trapped** (`float unrepresentable in integer range`) instead of producing the wrapped value. `(0/0)|0` trapped on linear vs `0` on WasmGC/host (surfaced by the cross-backend differential harness).

## Fix
Added a non-trapping `emitToInt32` to `src/codegen-linear/index.ts` mirroring the WasmGC backend (`binary-ops.ts`): `f64.trunc` → modular reduction `x - floor(x / 2³²) * 2³²` → `i32.trunc_sat_f64_u`. NaN/±∞ map to 0; large magnitudes wrap mod 2³² (saturation alone would clamp, not wrap). A new `compileExprToInt32` routes bitwise operands through it.

Sites changed (the JS-number→int paths):
- unary `~`
- binary bitwise (`& | ^ << >> >>>`)
- bitwise compound assignment (`&= |= ^= <<= >>= >>>=`)
- `Uint8Array` element store (ToUint8 — `__u8arr_set`'s `i32.store8` keeps the low byte)

The trapping `compileExprToI32` is **retained** for internal index/length/handle conversions (representable integers — a trap on garbage is acceptable there); the 4 native-`i32`-typed field/handle sites are intentionally left on it.

## Verification (vs JS oracle)
`(0/0)|0===0`, `(1/0)|0===0`, `1e20|0===1661992960`, `4294967297|0===1`, `2147483648|0===-2147483648`, `-1>>>0===4294967295`, `~(0/0)===-1`, `u8[0]=257→1`, `u8[0]=NaN→0`, `u8[0]=-1→255`.

Tests: `tests/issue-2715.test.ts` (22) + `numeric/bitwise-toint32-nan-wrap` cross-backend corpus entry. Full linear suite (18 files / 159 tests) + `cross-backend-diff` green; `tsc` clean.

## Follow-up filed: #2729
En route I discovered a **separate, pre-existing WasmGC bug**: `new Uint8Array(n)` element stores skip ToUint8 entirely (`u[0]=257` reads back 257, `u[0]=NaN` reads back NaN). That's why a Uint8Array cross-backend corpus entry is **not** added here (the backends would diverge for an unrelated reason). Tracked in #2729 (issue file included in this PR); the corpus entry should be added once WasmGC is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)