### PR TITLE
fix(#2717): fail loud for Array flat/flatMap in standalone instead of unsatisfiable import

### DIFF
--- a/plan/issues/2717-array-flat-flatmap-host-import-only-standalone.md
+++ b/plan/issues/2717-array-flat-flatmap-host-import-only-standalone.md
@@ -1,10 +1,11 @@
 ---
 id: 2717
 title: "Array flat/flatMap are host-import-only — no standalone native arm, no ctx.standalone guard"
-status: ready
+status: done
 sprint: 67
 created: 2026-06-26
 updated: 2026-06-26
+completed: 2026-06-26
 priority: high
 feasibility: medium
 reasoning_effort: medium
@@ -39,6 +40,41 @@ because the import is satisfied.
 
 ## Acceptance criteria
 
-- [ ] `flat`/`flatMap` either compile+run in standalone (agree with host on the
+- [x] `flat`/`flatMap` either compile+run in standalone (agree with host on the
       cross-backend corpus) OR produce a tracked compile error — never an
       unsatisfiable late import.
+
+## Resolution (2026-06-26) — fail-loud guard (#2711 policy)
+
+`compileArrayFlat` / `compileArrayFlatMap` (`src/codegen/array-methods.ts`) now
+gate on `ctx.standalone || ctx.wasi` and refuse loudly via `reportError` BEFORE
+`ensureLateImport`, so the unsatisfiable `__array_flat` / `__array_flatMap` host
+import is never registered. Host/gc mode is byte-unchanged.
+
+**Why fail-loud, not a native arm.** Unlike #2719 (where the pure-Wasm
+`__extern_strict_eq` / `__extern_same_value_zero` helpers already existed and the
+fix was a one-line swap), flat/flatMap have NO native machinery. A real native
+arm needs recursive flatten (variable depth + runtime `IsArray` per element +
+dynamic result-array build over heterogeneous WasmGC element types), and flatMap
+additionally needs callback invocation with mixed scalar/array returns — a large,
+busy-`Object()`/array-method-surface change. Per the tech-lead's call and the
+#2711 policy, a marginal single-feature standalone gain is not worth a risky
+partial native flatten on the surface that produced the #2149/#2702 merge_group
+regressions this sprint. The native arm is a tracked follow-up.
+
+**Sticky-error mechanism.** A naïve `reportError(...) + return null` is SILENTLY
+SWALLOWED here: the `a.flat().length` outer access wraps the `a.flat()` compile
+in the #1919 speculative transaction, and `rollbackSpeculative` truncates
+`ctx.errors` on a null inner result, then emits a default — so standalone
+`flat().length` compiled to a silent-wrong `0`. The guard instead returns a
+NON-NULL `externref` (matching the host result) and emits `unreachable`, so the
+speculative wrapper COMMITS, the diagnostic survives, and the compile fails loud
+(mirrors the `RegExp.escape` brand-check refusal at `calls.ts:4831`).
+
+Verified (`tests/issue-2717.test.ts`, 5 cases): standalone `flat()` / `flat(1)` /
+`flatMap()` produce a tracked compile error with zero `__array_flat*` imports;
+host `flat()` → 4, `flatMap()` → 6 unchanged. Existing `flatmap-closure` /
+`issue-1718-flatmap` host tests pass; `tsc` + prettier clean.
+
+**Follow-up (not in scope):** a Wasm-native flat/flatMap arm (and the linear
+backend lowering) to turn the compile-error into compile+run in standalone.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -8751,6 +8751,32 @@ function compileArrayFlat(
   propAccess: ts.PropertyAccessExpression,
   callExpr: ts.CallExpression,
 ): ValType | null {
+  // (#2717) `flat` has no Wasm-native arm — it delegates to the host
+  // `__array_flat` import. Under `--target standalone`/`wasi` there is no JS host
+  // to satisfy that import, so emitting it produces a module that traps at
+  // instantiation. Per the #2711 fail-loud policy, refuse loudly instead of
+  // emitting an unsatisfiable import. A native recursive-flatten arm (depth +
+  // runtime IsArray + dynamic result-build over heterogeneous WasmGC element
+  // types) is a separate, larger follow-up. Host/gc mode is unchanged.
+  if (ctx.standalone || ctx.wasi) {
+    reportError(
+      ctx,
+      callExpr,
+      `Codegen error: Array.prototype.flat() is not yet supported in --target standalone/wasi ` +
+        `(#2717) — there is no Wasm-native flatten arm and emitting the host import __array_flat ` +
+        `would produce a module that traps at instantiation. Recompile without --target ` +
+        `standalone, or avoid flat() in standalone/WASI code.`,
+    );
+    // Return a non-null type (matching the host externref result) + `unreachable`
+    // so the #1919 speculative wrapper COMMITS instead of rolling back: a rolled-
+    // back null would discard the diagnostic (truncate `ctx.errors`) and emit a
+    // silent default, so the standalone build would compile to a wrong value
+    // (e.g. `flat().length === 0`) instead of failing loud. The `unreachable`
+    // keeps the body well-typed; the recorded error fails the compile.
+    fctx.body.push({ op: "unreachable" } as Instr);
+    return { kind: "externref" };
+  }
+
   // __array_flat(receiver: externref, depth: externref) -> externref
   const flatIdx = ensureLateImport(
     ctx,
@@ -8794,6 +8820,27 @@ function compileArrayFlatMap(
   callExpr: ts.CallExpression,
 ): ValType | null {
   if (callExpr.arguments.length < 1) return null; // flatMap requires a callback
+
+  // (#2717) `flatMap` has no Wasm-native arm — it delegates to the host
+  // `__array_flatMap` import, which is unsatisfiable under `--target
+  // standalone`/`wasi` (no JS host) and traps at instantiation. Per the #2711
+  // fail-loud policy, refuse loudly instead of emitting the unsatisfiable import.
+  // A native arm (callback invocation + depth-1 flatten of scalar-or-array
+  // returns) is a separate follow-up. Host/gc mode is unchanged.
+  if (ctx.standalone || ctx.wasi) {
+    reportError(
+      ctx,
+      callExpr,
+      `Codegen error: Array.prototype.flatMap() is not yet supported in --target standalone/wasi ` +
+        `(#2717) — there is no Wasm-native arm and emitting the host import __array_flatMap ` +
+        `would produce a module that traps at instantiation. Recompile without --target ` +
+        `standalone, or avoid flatMap() in standalone/WASI code.`,
+    );
+    // Non-null type + `unreachable` so the #1919 speculative wrapper commits and
+    // the diagnostic is not rolled back into a silent default (see compileArrayFlat).
+    fctx.body.push({ op: "unreachable" } as Instr);
+    return { kind: "externref" };
+  }
 
   // __array_flatMap(receiver: externref, fn: externref, thisArg: externref) -> externref
   const flatMapIdx = ensureLateImport(

--- a/tests/issue-2717.test.ts
+++ b/tests/issue-2717.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2717 — Array.prototype.flat / flatMap have no standalone native arm.
+ *
+ * Both delegate to the host imports `__array_flat` / `__array_flatMap` with no
+ * `ctx.standalone` guard. Under `--target standalone`/`wasi` there is no JS host
+ * to satisfy those imports, so the emitted module FAILS TO INSTANTIATE.
+ *
+ * Per the #2711 fail-loud policy, the standalone/WASI path now refuses LOUDLY
+ * (a tracked compile error) instead of emitting an unsatisfiable import. A full
+ * Wasm-native flatten arm (recursive depth + runtime IsArray + dynamic
+ * result-array build over heterogeneous WasmGC element types; flatMap also needs
+ * callback invocation with mixed scalar/array returns) is a separate, larger
+ * follow-up — the busy `Object()`/array-method surface isn't worth a risky
+ * partial native flatten for a marginal test gain.
+ *
+ * Host/gc mode is byte-unchanged (the guard is gated on standalone||wasi).
+ */
+
+async function compileStandalone(body: string) {
+  return compile(`export function test(): number { ${body} }`, { fileName: "t.ts", target: "standalone" });
+}
+
+describe("#2717 — flat/flatMap refuse loudly in standalone (no unsatisfiable import)", () => {
+  const cases: Array<[string, string, RegExp]> = [
+    [
+      "flat()",
+      `const a: number[][] = [[1,2],[3,4]]; return a.flat().length;`,
+      /flat\(\) is not yet supported in --target standalone/,
+    ],
+    [
+      "flat(depth)",
+      `const a: number[][] = [[1,2],[3,4]]; return a.flat(1).length;`,
+      /flat\(\) is not yet supported in --target standalone/,
+    ],
+    [
+      "flatMap()",
+      `const a: number[] = [1,2,3]; return a.flatMap(x => [x, x*2]).length;`,
+      /flatMap\(\) is not yet supported in --target standalone/,
+    ],
+  ];
+  for (const [label, body, re] of cases) {
+    it(`${label} → tracked compile error, never an unsatisfiable __array_flat* import`, async () => {
+      const r = await compileStandalone(body);
+      expect(r.success).toBe(false);
+      const messages = r.errors.map((e) => e.message).join("\n");
+      expect(messages).toMatch(re);
+      // The guard runs BEFORE ensureLateImport, so the unsatisfiable host import
+      // is never registered.
+      const flatImports = r.imports.map((i) => i.name).filter((n) => n === "__array_flat" || n === "__array_flatMap");
+      expect(flatImports).toEqual([]);
+    });
+  }
+});
+
+describe("#2717 — host/gc mode flat/flatMap unchanged", () => {
+  async function runHost(body: string): Promise<number> {
+    const { buildImports } = await import("../src/runtime.js");
+    const r = await compile(`export function test(): number { ${body} }`, { fileName: "t.ts" });
+    expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+    const built = buildImports(r.imports, {}, r.stringPool);
+    const { instance } = await WebAssembly.instantiate(r.binary, built as WebAssembly.Imports);
+    if (built.setExports) built.setExports(instance.exports as Record<string, Function>);
+    return (instance.exports as { test: () => number }).test();
+  }
+  const cases: Array<[string, string, number]> = [
+    ["flat() flattens one level", `const a: number[][] = [[1,2],[3,4]]; return a.flat().length;`, 4],
+    ["flatMap() maps + flattens", `const a: number[] = [1,2,3]; return a.flatMap(x => [x, x*2]).length;`, 6],
+  ];
+  for (const [label, body, want] of cases) {
+    it(`${label} → ${want}`, async () => {
+      expect(await runHost(body)).toBe(want);
+    });
+  }
+});


### PR DESCRIPTION
Closes **#2717** (parent #2711 standalone↔host parity).

## Problem
`Array.prototype.flat` / `flatMap` delegate to the host imports `__array_flat` / `__array_flatMap` with **no `ctx.standalone` guard**. A `--target standalone`/`wasi` module therefore referenced an unsatisfiable import and failed to instantiate.

## Fix — fail-loud guard (#2711 policy)
Gate `compileArrayFlat` / `compileArrayFlatMap` (`src/codegen/array-methods.ts`) on `ctx.standalone || ctx.wasi` and `reportError` BEFORE `ensureLateImport`, so the host import is never registered. Host/gc mode is byte-unchanged.

**Why fail-loud, not a native arm:** unlike #2719 (a one-line helper swap — the pure-Wasm `__extern_*` helpers already existed), flat/flatMap have no native machinery. A real arm needs recursive flatten (variable depth + runtime IsArray + dynamic result-build over heterogeneous WasmGC element types; flatMap also callback invocation with mixed scalar/array returns) — a large, busy-array-method-surface change. Per the tech-lead's call, a marginal standalone gain isn't worth a risky partial native flatten on the surface behind this sprint's #2149/#2702 merge_group regressions. Native arm is a tracked follow-up.

**Sticky-error mechanism:** a naïve `reportError + return null` is silently swallowed — the `a.flat().length` outer access wraps `a.flat()` in the #1919 speculative transaction, whose `rollbackSpeculative` truncates `ctx.errors` on a null inner result and emits a silent default (standalone `flat().length` compiled to a wrong `0`). The guard returns a NON-NULL `externref` + `unreachable` so the wrapper commits and the diagnostic survives (mirrors the `RegExp.escape` brand-check refusal at `calls.ts:4831`).

## Validation
- `tests/issue-2717.test.ts` (5 cases): standalone `flat()` / `flat(1)` / `flatMap()` produce a tracked compile error with **zero** `__array_flat*` imports; host `flat()` → 4, `flatMap()` → 6 unchanged.
- Existing `flatmap-closure` / `issue-1718-flatmap` host tests pass; `tsc --noEmit` + prettier clean.

## Follow-up (out of scope)
A Wasm-native flat/flatMap arm (+ linear-backend lowering) to turn the compile-error into compile+run in standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)