### PR TITLE
fix(#2716): linear backend runs try/finally on early-exit paths

### DIFF
--- a/plan/issues/2716-linear-try-finally-early-exit-skips-finally.md
+++ b/plan/issues/2716-linear-try-finally-early-exit-skips-finally.md
@@ -1,10 +1,12 @@
 ---
 id: 2716
 title: "Linear backend: try/finally with early return/break inlines past the finally block"
-status: ready
+status: done
 sprint: 67
 created: 2026-06-26
 updated: 2026-06-26
+completed: 2026-06-26
+assignee: ttraenkler/dev1
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -14,6 +16,7 @@ language_feature: standalone
 goal: standalone-everything
 parent: 2711
 ---
+
 # #2716 — Linear try/finally early-exit skips the finally block
 
 **Parent:** #2711 (standalone↔host differential parity gate).
@@ -33,7 +36,7 @@ flag resets), a standalone-only correctness bug.
 - The naive `try{r=1;return r;}finally{r=2;}` case happens to agree across
   backends because the return value is captured before finally runs and finally
   only mutates a local — so the divergence is NOT caught by that shape. A child
-  test must observe a finally side effect that is visible *after* the early
+  test must observe a finally side effect that is visible _after_ the early
   exit (e.g. finally mutates an outer/captured cell that a second call reads, or
   finally itself performs a `return`/`break`).
 - #1838 made the linear `try/catch` path **refuse loudly** rather than
@@ -43,7 +46,44 @@ flag resets), a standalone-only correctness bug.
 
 ## Acceptance criteria
 
-- [ ] finally runs on `return` / `break` / `continue` out of a `try` on the
-      linear backend, OR the compile refuses loudly with a tracked gap.
-- [ ] A cross-backend corpus entry observes the finally side effect and agrees
-      with host.
+- [x] finally runs on `return` / `break` / `continue` out of a `try` on the
+      linear backend (implemented — not just a loud refusal).
+- [x] A cross-backend corpus entry observes the finally side effect and agrees
+      with host (`control/try-finally-early-exit`).
+
+## Resolution (2026-06-26, dev1)
+
+Implemented finally-replay rather than a loud refusal (a refusal would regress
+floor programs that currently fall through; replay only _adds_ the missing
+finally runs). Added `fctx.finallyStack` (`src/codegen-linear/context.ts`,
+`FinallyEntry`): each `try { … } finally { … }` pushes an entry recording the
+break/continue nesting at try-entry, compiles the try body, pops, then runs the
+finally inline for normal fall-through.
+
+The early-exit handlers in `compileStatement` (`src/codegen-linear/index.ts`)
+replay the applicable finally blocks (innermost first) before the jump:
+
+- **`return`** replays every enclosing finally. The return value is stashed in a
+  temp first so a finally that mutates the source global can't clobber the
+  in-flight value (`try { return g+1 } finally { g=99 }` → returns the pre-finally
+  value).
+- **`break` / `continue`** replay only the finallys that sit _between_ the jump
+  and its target loop/switch (`entry.breakDepth/continueDepth === stack.length`),
+  so a `break` of an inner loop _inside_ the try does not prematurely run the
+  try's finally. Replaying inline keeps `blockDepth` balanced, so the `br` depth
+  is unchanged.
+
+`localMap` is snapshotted/restored around each replay so a block-scoped decl in
+the finally doesn't leak its binding.
+
+**Loud refusal kept for one case:** a finally that itself performs a
+`return`/`break`/`continue` needs completion-override semantics the replay model
+doesn't implement → `finallyBlockHasOwnEarlyExit` throws a clear compile error
+(like the try/catch gate, #1838) rather than miscompile.
+
+Verified: early return / break / continue run finally; nested finally replays
+innermost-first; return value preserved across finally; inner-loop break does NOT
+run the try-finally; normal fall-through runs finally exactly once; finally-with-
+own-return refused. Tests: `tests/issue-2716.test.ts` (8) +
+`control/try-finally-early-exit` cross-backend corpus entry. Full linear suite
+(19 files / 167 tests) + cross-backend-diff green; tsc clean.

--- a/src/codegen-linear/context.ts
+++ b/src/codegen-linear/context.ts
@@ -36,6 +36,16 @@ export interface LinearContext {
 /** Collection type tag for tracking variable types */
 export type CollectionKind = "Array" | "Uint8Array" | "ArrayOrUint8Array" | "Map" | "Set";
 
+/** (#2716) A `finally` block pending replay on early-exit paths out of its try. */
+export interface FinallyEntry {
+  /** The `finally` block statements to replay. */
+  block: ts.Block;
+  /** `breakStack.length` at try-entry — used to decide if a `break` replays it. */
+  breakDepth: number;
+  /** `continueStack.length` at try-entry — used to decide if a `continue` replays it. */
+  continueDepth: number;
+}
+
 /** Per-function context for linear-memory codegen */
 export interface LinearFuncContext {
   /** Function name */
@@ -56,6 +66,15 @@ export interface LinearFuncContext {
   breakStack: number[];
   /** Continue label depth stack */
   continueStack: number[];
+  /**
+   * (#2716) Stack of enclosing `try { … } finally { … }` blocks whose `finally`
+   * must run on every completion path out of the try. Normal fall-through runs
+   * the finally inline; `return` / `break` / `continue` replay the applicable
+   * finally blocks before the jump. Each entry records the break/continue
+   * nesting at try-entry so a `break`/`continue` only replays the finallys that
+   * sit BETWEEN it and its target loop/switch.
+   */
+  finallyStack: FinallyEntry[];
   /** Track which locals are collection types (varName → kind) */
   collectionTypes: Map<string, CollectionKind>;
   /** Parameters that are callback/function-typed (param name → call_indirect type index) */

--- a/src/codegen-linear/index.ts
+++ b/src/codegen-linear/index.ts
@@ -3,7 +3,7 @@ import { ts, forEachChild } from "../ts-api.js";
 import type { MultiTypedAST, TypedAST } from "../checker/index.js";
 import type { FuncTypeDef, Instr, ValType, WasmModule } from "../ir/types.js";
 import { createEmptyModule } from "../ir/types.js";
-import type { CollectionKind, LinearContext, LinearFuncContext } from "./context.js";
+import type { CollectionKind, FinallyEntry, LinearContext, LinearFuncContext } from "./context.js";
 import { addLocal } from "./context.js";
 import type { ClassLayout } from "./layout.js";
 import { computeClassLayout } from "./layout.js";
@@ -408,6 +408,7 @@ function compileFunctionMulti(
     blockDepth: 0,
     breakStack: [],
     continueStack: [],
+    finallyStack: [],
     collectionTypes: new Map(),
     callbackParams: new Map(),
   };
@@ -488,6 +489,7 @@ function compileFunction(ctx: LinearContext, decl: ts.FunctionDeclaration): void
     blockDepth: 0,
     breakStack: [],
     continueStack: [],
+    finallyStack: [],
     collectionTypes: new Map(),
     callbackParams: new Map(),
   };
@@ -538,8 +540,97 @@ function compileFunction(ctx: LinearContext, decl: ts.FunctionDeclaration): void
   ctx.currentFunc = null;
 }
 
+/**
+ * (#2716) Does a `finally` block itself perform a `return` / `break` / `continue`
+ * (a completion that would override the pending early-exit being replayed)?
+ *
+ * Such a finally needs the spec's completion-override semantics, which the
+ * simple replay model below does not implement — so we refuse loudly (like the
+ * try/catch gate, #1838) rather than miscompile. The scan does NOT descend into
+ * nested function/class bodies (their early exits belong to a different frame)
+ * but DOES descend into nested loops/switches: a `break`/`continue` whose target
+ * is INSIDE the finally is fine, so we only flag exits not captured by a
+ * breakable/iteration construct within the finally.
+ */
+function finallyBlockHasOwnEarlyExit(block: ts.Block): boolean {
+  let found = false;
+  const visit = (node: ts.Node, inBreakable: boolean, inLoop: boolean): void => {
+    if (found) return;
+    // Don't cross into a new function/class scope — their exits are unrelated.
+    if (
+      ts.isFunctionDeclaration(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isArrowFunction(node) ||
+      ts.isClassDeclaration(node) ||
+      ts.isClassExpression(node) ||
+      ts.isMethodDeclaration(node)
+    ) {
+      return;
+    }
+    if (ts.isReturnStatement(node)) {
+      found = true;
+      return;
+    }
+    if (ts.isBreakStatement(node) && !inBreakable) {
+      found = true;
+      return;
+    }
+    if (ts.isContinueStatement(node) && !inLoop) {
+      found = true;
+      return;
+    }
+    const isLoop =
+      ts.isForStatement(node) ||
+      ts.isForOfStatement(node) ||
+      ts.isForInStatement(node) ||
+      ts.isWhileStatement(node) ||
+      ts.isDoStatement(node);
+    const isBreakable = isLoop || ts.isSwitchStatement(node);
+    ts.forEachChild(node, (child) => visit(child, inBreakable || isBreakable, inLoop || isLoop));
+  };
+  for (const s of block.statements) visit(s, false, false);
+  return found;
+}
+
+/**
+ * (#2716) Replay the given `finally` blocks (already ordered innermost-first)
+ * inline at the current program point, ahead of an early-exit jump. localMap is
+ * snapshotted/restored around each replay so any block-scoped declaration in the
+ * finally does not leak its name binding into the surrounding code (the backing
+ * locals stay allocated; only the name→index map is scoped).
+ */
+function replayFinallyBlocks(ctx: LinearContext, fctx: LinearFuncContext, entries: FinallyEntry[]): void {
+  for (const entry of entries) {
+    const savedMap = new Map(fctx.localMap);
+    for (const s of entry.block.statements) compileStatement(ctx, fctx, s);
+    fctx.localMap = savedMap;
+  }
+}
+
 function compileStatement(ctx: LinearContext, fctx: LinearFuncContext, stmt: ts.Statement): void {
   if (ts.isReturnStatement(stmt)) {
+    // (#2716) Run every enclosing finally before leaving the function. The
+    // return value is already on the stack; the finally blocks are side-effect
+    // statements (a finally with its own early-exit is refused at the try site),
+    // so they don't disturb it. Innermost finally first.
+    if (fctx.finallyStack.length > 0 && stmt.expression) {
+      // Evaluate the return value into a temp, run finallys, then reload it, so a
+      // finally that reads/writes globals can't clobber the in-flight value.
+      const rt = fctx.returnType ?? { kind: "f64" };
+      const tmp = fctx.params.length + fctx.locals.length;
+      fctx.locals.push({ name: `__retval_${tmp}`, type: rt });
+      compileExpression(ctx, fctx, stmt.expression);
+      fctx.body.push({ op: "local.set", index: tmp });
+      replayFinallyBlocks(ctx, fctx, [...fctx.finallyStack].reverse());
+      fctx.body.push({ op: "local.get", index: tmp });
+      fctx.body.push({ op: "return" });
+      return;
+    }
+    if (fctx.finallyStack.length > 0) {
+      replayFinallyBlocks(ctx, fctx, [...fctx.finallyStack].reverse());
+      fctx.body.push({ op: "return" });
+      return;
+    }
     if (stmt.expression) {
       compileExpression(ctx, fctx, stmt.expression);
     }
@@ -738,15 +829,39 @@ function compileStatement(ctx: LinearContext, fctx: LinearFuncContext, stmt: ts.
           "would silently drop the catch handler (#1838). A Wasm-EH try/catch lowering is " +
           "the planned fix; a bare `try { ... }` with only `finally` is supported.",
       );
-    } else {
-      // try { ... } finally { ... } — no handler to lose; inline both blocks.
+    } else if (stmt.finallyBlock) {
+      // try { ... } finally { ... } — no catch to lose. (#2716) The finally must
+      // run on EVERY completion path out of the try, not just fall-through: an
+      // early `return` / `break` / `continue` in the try body used to inline
+      // straight to the exit and SKIP the trailing finally. We register the
+      // finally on fctx.finallyStack so those exits replay it before jumping,
+      // and still emit it inline for the normal fall-through path.
+      if (finallyBlockHasOwnEarlyExit(stmt.finallyBlock)) {
+        // A finally that itself returns/breaks/continues needs completion-
+        // override semantics the replay model doesn't implement — refuse loudly
+        // (like try/catch, #1838) rather than miscompile.
+        throw new Error(
+          "try/finally where the `finally` block itself performs a return/break/continue is not " +
+            "yet supported by the linear/standalone backend (#2716) — it requires completion-override " +
+            "semantics; a `finally` with only side effects is supported.",
+        );
+      }
+      const entry: FinallyEntry = {
+        block: stmt.finallyBlock,
+        breakDepth: fctx.breakStack.length,
+        continueDepth: fctx.continueStack.length,
+      };
+      fctx.finallyStack.push(entry);
       for (const s of stmt.tryBlock.statements) {
         compileStatement(ctx, fctx, s);
       }
-      if (stmt.finallyBlock) {
-        for (const s of stmt.finallyBlock.statements) {
-          compileStatement(ctx, fctx, s);
-        }
+      fctx.finallyStack.pop();
+      // Normal fall-through completion: run finally inline.
+      replayFinallyBlocks(ctx, fctx, [entry]);
+    } else {
+      // Bare `try { ... }` with neither catch nor finally — inline the body.
+      for (const s of stmt.tryBlock.statements) {
+        compileStatement(ctx, fctx, s);
       }
     }
   } else if (ts.isExpressionStatement(stmt)) {
@@ -778,6 +893,19 @@ function compileStatement(ctx: LinearContext, fctx: LinearFuncContext, stmt: ts.
           ...nodeLoc(stmt),
         });
       } else {
+        // (#2716) Replay any finally blocks that sit BETWEEN this break/continue
+        // and its target. A finally is "inside" the target iff it was entered
+        // when the break/continue nesting was already at the current depth (i.e.
+        // inside the innermost loop/switch the jump exits). Innermost first.
+        // Replaying inline keeps blockDepth balanced, so the br depth below is
+        // unchanged.
+        const targetDepth = stack.length;
+        const pending = fctx.finallyStack.filter((e) =>
+          isBreak ? e.breakDepth === targetDepth : e.continueDepth === targetDepth,
+        );
+        if (pending.length > 0) {
+          replayFinallyBlocks(ctx, fctx, [...pending].reverse());
+        }
         fctx.body.push({ op: "br", depth: fctx.blockDepth - stack[stack.length - 1]! - 1 });
       }
     }
@@ -4368,6 +4496,7 @@ function compileClassCtor(
     blockDepth: 0,
     breakStack: [],
     continueStack: [],
+    finallyStack: [],
     collectionTypes: new Map(),
     callbackParams: new Map(),
   };
@@ -4462,6 +4591,7 @@ function compileClassMethod(
     blockDepth: 0,
     breakStack: [],
     continueStack: [],
+    finallyStack: [],
     collectionTypes: new Map(),
     callbackParams: new Map(),
   };
@@ -4530,6 +4660,7 @@ function compileClassGetter(
     blockDepth: 0,
     breakStack: [],
     continueStack: [],
+    finallyStack: [],
     collectionTypes: new Map(),
     callbackParams: new Map(),
   };
@@ -5178,6 +5309,7 @@ function compileArrowFunctionArg(
     blockDepth: 0,
     breakStack: [],
     continueStack: [],
+    finallyStack: [],
     collectionTypes: new Map(),
     callbackParams: new Map(),
   };

--- a/tests/cross-backend/corpus.ts
+++ b/tests/cross-backend/corpus.ts
@@ -182,6 +182,42 @@ export const CROSS_BACKEND_CORPUS: readonly CrossBackendProgram[] = [
       { fn: "logic", args: [1, -1] },
     ],
   },
+  {
+    // #2716 — try/finally must run the finally on early exit. Each function
+    // exposes a finally side effect that is observable AFTER the early return /
+    // break / continue, so a skipped finally would diverge from the WasmGC/host
+    // oracle (the linear backend used to inline past the finally and trap-free
+    // drop it).
+    name: "control/try-finally-early-exit",
+    category: "control",
+    source: `
+      let earlyReturnFlag = 0;
+      function earlyReturn(): number { try { return 1; } finally { earlyReturnFlag = 9; } }
+      export function returnRunsFinally(): number { const r = earlyReturn(); return r * 100 + earlyReturnFlag; }
+
+      export function breakRunsFinally(): number {
+        let fin = 0;
+        for (let i = 0; i < 3; i++) { try { if (i === 0) break; } finally { fin = fin + 1; } }
+        return fin;
+      }
+
+      export function continueRunsFinally(): number {
+        let fin = 0;
+        for (let i = 0; i < 3; i++) { try { continue; } finally { fin = fin + 1; } }
+        return fin;
+      }
+
+      let nestedLog = 0;
+      function nested(): number { try { try { return 1; } finally { nestedLog = nestedLog * 10 + 2; } } finally { nestedLog = nestedLog * 10 + 3; } }
+      export function nestedFinallyOrder(): number { const r = nested(); return r * 1000 + nestedLog; }
+    `,
+    calls: [
+      { fn: "returnRunsFinally", args: [] },
+      { fn: "breakRunsFinally", args: [] },
+      { fn: "continueRunsFinally", args: [] },
+      { fn: "nestedFinallyOrder", args: [] },
+    ],
+  },
 
   // ── strings ──────────────────────────────────────────────────────────────
   {

--- a/tests/issue-2716.test.ts
+++ b/tests/issue-2716.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2716 — The linear backend inlined a `try { … } finally { … }` as
+// try-body-then-finally, so an early `return` / `break` / `continue` in the try
+// jumped past the inlined finally and silently dropped its side effects. The fix
+// replays the finally on every early-exit path (innermost first), and refuses
+// loudly when the finally itself performs a return/break/continue.
+
+async function runLinear(src: string): Promise<number> {
+  const r = await compile(src, { target: "linear" });
+  if (!r.success) throw new Error("compile failed: " + (r.errors[0]?.message ?? "unknown"));
+  const { instance } = await WebAssembly.instantiate(r.binary);
+  return (instance.exports as { test: () => number }).test();
+}
+
+async function compileLinear(src: string) {
+  return compile(src, { target: "linear" });
+}
+
+describe("#2716 linear try/finally runs finally on early exit", () => {
+  it("finally runs on early return (observable side effect)", async () => {
+    expect(
+      await runLinear(`
+      let flag = 0;
+      function f(): number { try { return 1; } finally { flag = 9; } }
+      export function test(): number { const r = f(); return r * 100 + flag; }
+    `),
+    ).toBe(109);
+  });
+
+  it("return value is captured before finally mutates the source global", async () => {
+    expect(
+      await runLinear(`
+      let g = 0;
+      function f(): number { try { return g + 1; } finally { g = 99; } }
+      export function test(): number { const r = f(); return r * 100 + g; }
+    `),
+    ).toBe(199);
+  });
+
+  it("finally runs on break out of the enclosing loop", async () => {
+    expect(
+      await runLinear(`
+      let fin = 0;
+      export function test(): number {
+        for (let i = 0; i < 3; i++) { try { if (i === 0) break; } finally { fin = fin + 1; } }
+        return fin;
+      }
+    `),
+    ).toBe(1);
+  });
+
+  it("finally runs on continue each iteration", async () => {
+    expect(
+      await runLinear(`
+      let fin = 0;
+      export function test(): number {
+        for (let i = 0; i < 3; i++) { try { continue; } finally { fin = fin + 1; } }
+        return fin;
+      }
+    `),
+    ).toBe(3);
+  });
+
+  it("nested try/finally replays innermost-first on return", async () => {
+    expect(
+      await runLinear(`
+      let log = 0;
+      function f(): number { try { try { return 1; } finally { log = log * 10 + 2; } } finally { log = log * 10 + 3; } }
+      export function test(): number { const r = f(); return r * 1000 + log; }
+    `),
+    ).toBe(1023);
+  });
+
+  it("normal fall-through still runs finally exactly once", async () => {
+    expect(
+      await runLinear(`
+      let n = 0;
+      export function test(): number { try { n = n + 1; } finally { n = n + 10; } return n; }
+    `),
+    ).toBe(11);
+  });
+
+  it("a break of an inner loop inside the try does NOT prematurely run the try-finally", async () => {
+    // The inner-loop break exits only the inner loop; the try-finally runs once
+    // at the try's normal completion afterwards.
+    expect(
+      await runLinear(`
+      let fin = 0;
+      export function test(): number {
+        try { for (let i = 0; i < 3; i++) { if (i === 1) break; } } finally { fin = 5; }
+        return fin;
+      }
+    `),
+    ).toBe(5);
+  });
+});
+
+describe("#2716 linear try/finally refuses loudly for finally with its own early exit", () => {
+  it("finally with its own return is rejected (not silently miscompiled)", async () => {
+    const r = await compileLinear(`
+      function f(): number { try { return 1; } finally { return 2; } }
+      export function test(): number { return f(); }
+    `);
+    expect(r.success).toBe(false);
+    expect(r.errors.map((e) => e.message).join("\n")).toMatch(/finally/i);
+  });
+});


### PR DESCRIPTION
Fixes #2716. Parent: #2711 (standalone↔host parity).

## Problem
The linear backend inlined `try { … } finally { … }` as try-body-then-finally, so an early `return` / `break` / `continue` in the try body jumped past the inlined finally and **silently dropped its side effects** — a standalone-only correctness bug (the finally must run on every completion path).

## Fix — finally replay (not a loud refusal)
A loud refusal would regress floor programs that currently fall through; replay only *adds* the missing finally runs, so it can't regress.

- Added `fctx.finallyStack` (`src/codegen-linear/context.ts`, `FinallyEntry`): each `try/finally` pushes an entry recording the break/continue nesting at try-entry, compiles the body, pops, then runs the finally inline for normal fall-through.
- **`return`** replays every enclosing finally — the return value is stashed in a temp first so a finally mutating the source global can't clobber the in-flight value (`try { return g+1 } finally { g=99 }` → returns the pre-finally value).
- **`break` / `continue`** replay only the finallys that sit *between* the jump and its target loop/switch (`entry.breakDepth/continueDepth === stack.length`), so an inner-loop break *inside* the try doesn't prematurely run the try-finally. Inline replay keeps `blockDepth` balanced (br depth unchanged).
- `localMap` snapshot/restore around each replay so a finally's block-scoped decl doesn't leak its binding.

**Loud refusal kept for one case:** a finally that itself performs `return`/`break`/`continue` needs completion-override semantics the replay model doesn't implement → `finallyBlockHasOwnEarlyExit` throws a clear compile error (like the try/catch gate, #1838) rather than miscompile.

## Verification
early return / break / continue run finally; nested finally replays innermost-first; return value preserved across finally; inner-loop break does NOT run the try-finally; normal fall-through runs finally exactly once; finally-with-own-return refused.

Tests: `tests/issue-2716.test.ts` (8) + `control/try-finally-early-exit` cross-backend corpus entry (observes the finally side effect, agrees host↔linear). Full linear suite (19 files / 167 tests) + `cross-backend-diff` green; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)