### PR TITLE
fix(#2734): restore standalone object-identity Array search (regression from #2719)

### DIFF
--- a/plan/issues/2734-standalone-object-identity-eq.md
+++ b/plan/issues/2734-standalone-object-identity-eq.md
@@ -1,0 +1,69 @@
+---
+id: 2734
+title: "Standalone Array indexOf/includes/lastIndexOf lose object identity (regression from #2719)"
+status: done
+sprint: 67
+created: 2026-06-27
+updated: 2026-06-27
+completed: 2026-06-27
+priority: high
+feasibility: medium
+task_type: fix
+area: codegen
+language_feature: standalone
+goal: standalone-everything
+parent: 2711
+related: [2719]
+---
+# #2734 — standalone object-identity search regression (from #2719)
+
+**Follow-up fix for #2719.** Caught in the `merge_group` standalone floor (not at
+PR level), behind a baseline that predated #2719's merge.
+
+## Root cause
+
+#2719 replaced the `__host_eq` / `__same_value_zero` host imports in the
+standalone `indexOf`/`lastIndexOf`/`includes` arms with the native
+`__extern_strict_eq` / `__extern_same_value_zero` helpers
+(`src/codegen/any-helpers.ts`). Those compose `__any_from_extern` +
+`__any_strict_eq` — but **`__any_from_extern` has no Object tag**: it folds an
+object externref into the tag-5 (string) fallback (`fallbackStringAny`), so
+`__any_strict_eq` string-compares two objects and never matches them by
+identity.
+
+Result: standalone `[0, o].indexOf(o)` → -1 (want 1), `includes(o)` → false,
+`lastIndexOf(o)` → -1. Strings/numbers/NaN were correct (#2719's tests only
+covered those — that's the gap that let this through). This regressed the
+`built-ins/Array/prototype/{indexOf,lastIndexOf}/15.4.4.1{4,5}-*` object-element
+cluster (20 standalone tests, signature `fb9900322f32d212`), which wedged the
+merge queue (every PR parked against the pre-#2719 baseline).
+
+## Fix
+
+A `ref.eq` reference-identity fast path at the top of
+`ensureExternStrictEqHelper`: internalise both externrefs (`any.convert_extern`);
+if both are non-null `eq` refs and `ref.eq` (the SAME reference) → `===` → return
+1; otherwise fall through to the existing `__any_strict_eq` primitive comparison.
+`__extern_same_value_zero` (includes) calls `__extern_strict_eq`, so it inherits
+the fix. Never false-positives a primitive (distinct number/string boxes are
+distinct refs → value comparison); `null`/non-eq values fail `ref.test (ref eq)`
+and fall through.
+
+## Acceptance criteria
+
+- [x] Standalone `indexOf`/`lastIndexOf`/`includes` find object/array elements by
+      identity; distinct objects still miss; strings/numbers/NaN unchanged.
+- [x] The 20 regressed `15.4.4.1{4,5}-*` object-element tests pass in standalone.
+- [x] Host/gc mode unaffected (native helpers are standalone-only).
+
+## Validation
+
+- All 20 regressed test262 tests pass in standalone after the fix.
+- `tests/issue-2734.test.ts` (13 cases: object/array identity, distinct-miss,
+  string/number/NaN no-regression, host parity).
+- `tests/issue-2719.test.ts` (string/number/NaN) still 14/14. `tsc` + prettier
+  clean.
+
+Once this lands, its merge_group shows +improvements (passes the floor) → the
+baseline refreshes → the collateral parks on #2157/#2158/#2160 clear with no
+change to them.

--- a/src/codegen/any-helpers.ts
+++ b/src/codegen/any-helpers.ts
@@ -359,14 +359,64 @@ export function ensureExternStrictEqHelper(ctx: CodegenContext): number | undefi
     "__extern_strict_eq",
   );
   const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const EQ_HEAP_TYPE = -19; // WasmGC `eq` abstract heap type
   const body: Instr[] = [
+    // (#2734) Object/reference-identity fast path. `__any_from_extern` has no
+    // dedicated Object tag — it folds an object externref into the tag-5 (string)
+    // fallback, so the `__any_strict_eq` below would string-compare two objects
+    // and never match them by identity (`[o].indexOf(o)` → -1). That regressed
+    // the `built-ins/Array/prototype/{indexOf,lastIndexOf}/...` object-element
+    // cluster (and `includes`, which calls this helper) when #2719 replaced the
+    // `__host_eq` import with this native arm. Internalise both externrefs; if
+    // both are non-null `eq` refs and `ref.eq` (the SAME reference), they are
+    // `===` → return 1. Otherwise fall through to the primitive comparison. This
+    // never false-positives a primitive: distinct number/string boxes are
+    // distinct refs (→ value comparison); only a genuinely identical reference
+    // short-circuits. `null`/non-eq values fail `ref.test (ref eq)` and fall
+    // through (so `null === null` etc. stay handled by `__any_strict_eq`).
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" } as Instr,
+    { op: "local.tee", index: 2 },
+    { op: "ref.test", typeIdx: EQ_HEAP_TYPE } as Instr,
+    { op: "local.get", index: 1 },
+    { op: "any.convert_extern" } as Instr,
+    { op: "local.tee", index: 3 },
+    { op: "ref.test", typeIdx: EQ_HEAP_TYPE } as Instr,
+    { op: "i32.and" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: 2 },
+        { op: "ref.cast", typeIdx: EQ_HEAP_TYPE } as Instr,
+        { op: "local.get", index: 3 },
+        { op: "ref.cast", typeIdx: EQ_HEAP_TYPE } as Instr,
+        { op: "ref.eq" } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [{ op: "i32.const", value: 1 }, { op: "return" } as Instr],
+        },
+      ],
+    },
+    // Primitive comparison (numbers unified via f64.eq, strings by content,
+    // booleans, null/undefined by tag) for everything the fast path didn't match.
     { op: "local.get", index: 0 },
     { op: "call", funcIdx: fromExternIdx },
     { op: "local.get", index: 1 },
     { op: "call", funcIdx: fromExternIdx },
     { op: "call", funcIdx: strictEqIdx },
   ];
-  ctx.mod.functions.push({ name: "__extern_strict_eq", typeIdx, locals: [], body, exported: false });
+  ctx.mod.functions.push({
+    name: "__extern_strict_eq",
+    typeIdx,
+    locals: [
+      { name: "a_any", type: { kind: "anyref" } },
+      { name: "b_any", type: { kind: "anyref" } },
+    ],
+    body,
+    exported: false,
+  });
   ctx.funcMap.set("__extern_strict_eq", funcIdx);
   return funcIdx;
 }

--- a/tests/issue-2734.test.ts
+++ b/tests/issue-2734.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2734 — standalone Array search must find OBJECT elements by identity.
+ *
+ * Regression from #2719: that PR replaced the `__host_eq` / `__same_value_zero`
+ * host imports in the standalone `indexOf`/`lastIndexOf`/`includes` arms with the
+ * native `__extern_strict_eq` / `__extern_same_value_zero` helpers. Those compose
+ * `__any_from_extern` + `__any_strict_eq`, but `__any_from_extern` has NO Object
+ * tag — it folds an object externref into the tag-5 (string) fallback, so
+ * `__any_strict_eq` string-compared two objects and never matched them by
+ * identity. Result: standalone `[0, o].indexOf(o)` returned -1, regressing the
+ * `built-ins/Array/prototype/{indexOf,lastIndexOf}/15.4.4.1{4,5}-*` object-element
+ * cluster (20 tests) — surfaced only in the merge_group standalone floor, behind
+ * a baseline that predated #2719.
+ *
+ * Fix: a `ref.eq` reference-identity fast path in `ensureExternStrictEqHelper`
+ * (inherited by `__extern_same_value_zero`, which calls it). #2719's own tests
+ * only covered string/number/NaN elements — this file closes the object-identity
+ * gap. Host/gc mode is unaffected (the native helpers are standalone-only).
+ */
+
+async function runStandalone(body: string): Promise<number> {
+  const r = await compile(`export function test(): number { ${body} }`, { fileName: "t.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#2734 — standalone Array search finds object elements by identity", () => {
+  const cases: Array<[string, string, number]> = [
+    ["indexOf finds the object", `const o: any = {}; const a: any[] = [0, o, 1]; return a.indexOf(o);`, 1],
+    ["lastIndexOf finds the object", `const o: any = {}; const a: any[] = [o, 1, o]; return a.lastIndexOf(o);`, 2],
+    ["includes finds the object", `const o: any = {}; const a: any[] = [0, o]; return a.includes(o) ? 1 : 0;`, 1],
+    [
+      "indexOf distinct object → -1",
+      `const a: any = {}; const b: any = {}; const arr: any[] = [0, a]; return arr.indexOf(b);`,
+      -1,
+    ],
+    [
+      "includes distinct object → false",
+      `const a: any = {}; const b: any = {}; const arr: any[] = [0, a]; return arr.includes(b) ? 1 : 0;`,
+      0,
+    ],
+    ["array element found by identity", `const o: any = [9]; const a: any[] = [0, o]; return a.indexOf(o);`, 1],
+    // no regression on primitives:
+    ["string element", `const a: any[] = [0, "y"]; return a.indexOf("y");`, 1],
+    ["number element", `const a: any[] = [1, 2, 3]; return a.indexOf(2);`, 1],
+    ["includes NaN (SameValueZero)", `const a: any[] = [NaN]; return a.includes(NaN) ? 1 : 0;`, 1],
+    ["indexOf NaN (Strict Equality)", `const a: any[] = [NaN]; return a.indexOf(NaN);`, -1],
+    ["miss → -1", `const a: any[] = [1, 2, 3]; return a.indexOf(4);`, -1],
+  ];
+  for (const [label, body, want] of cases) {
+    it(`${label} → ${want}`, async () => {
+      expect(await runStandalone(body)).toBe(want);
+    });
+  }
+});
+
+describe("#2734 — host/gc mode unaffected", () => {
+  async function runHost(body: string): Promise<number> {
+    const { buildImports } = await import("../src/runtime.js");
+    const r = await compile(`export function test(): number { ${body} }`, { fileName: "t.ts" });
+    expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+    const built = buildImports(r.imports, {}, r.stringPool);
+    const { instance } = await WebAssembly.instantiate(r.binary, built as WebAssembly.Imports);
+    if (built.setExports) built.setExports(instance.exports as Record<string, Function>);
+    return (instance.exports as { test: () => number }).test();
+  }
+  it("host indexOf finds object by identity", async () => {
+    expect(await runHost(`const o: any = {}; const a: any[] = [0, o]; return a.indexOf(o);`)).toBe(1);
+  });
+  it("host includes finds object by identity", async () => {
+    expect(await runHost(`const o: any = {}; const a: any[] = [0, o]; return a.includes(o) ? 1 : 0;`)).toBe(1);
+  });
+});


### PR DESCRIPTION
**Unblocks the merge queue.** Fixes the real standalone regression #2719 introduced (caught only in the `merge_group` floor, behind a baseline that predated #2719). Once this lands, its merge_group shows +improvements → passes the floor → refreshes the baseline → the collateral parks on #2157/#2158/#2160 clear with no change to them.

## Root cause
#2719 swapped the standalone `indexOf`/`lastIndexOf`/`includes` externref comparison from the `__host_eq` import to the native `__extern_strict_eq` / `__extern_same_value_zero` helpers (`src/codegen/any-helpers.ts`). Those compose `__any_from_extern` + `__any_strict_eq` — but **`__any_from_extern` has no Object tag**: it folds an object externref into the tag-5 (string) fallback, so `__any_strict_eq` string-compares two objects and never matches them by identity. Standalone `[0, o].indexOf(o)` returned **-1** (want 1); this regressed the `built-ins/Array/prototype/{indexOf,lastIndexOf}/15.4.4.1{4,5}-*` object-element cluster (**20 tests**, signature `fb9900322f32d212`). #2719's tests only covered string/number/NaN — that's the gap.

## Fix
A `ref.eq` reference-identity fast path at the top of `ensureExternStrictEqHelper`: internalize both externrefs (`any.convert_extern`); if both are non-null `eq` refs and `ref.eq` (the SAME reference) → `===` → return 1; else fall through to the existing `__any_strict_eq` primitive comparison. `__extern_same_value_zero` (includes) calls `__extern_strict_eq`, so it inherits the fix. Never false-positives a primitive (distinct number/string boxes are distinct refs → value comparison); `null`/non-eq fail `ref.test (ref eq)` and fall through.

## Validation
- All **20** regressed test262 tests pass in standalone after the fix (verified individually).
- `tests/issue-2734.test.ts` — 13 cases: object/array identity, distinct-object miss, string/number/NaN no-regression, host parity.
- `tests/issue-2719.test.ts` (string/number/NaN) still 14/14. `tsc --noEmit` + prettier clean.
- Host/gc mode unaffected (the native helpers are gated on `ctx.standalone||ctx.wasi`).

Follow-up to #2719 · parent #2711.

🤖 Generated with [Claude Code](https://claude.com/claude-code)