### PR TITLE
fix(wasi): #2735 stdin reactor non-EOF termination (process.exit/.destroy/in-band shutdown)

### DIFF
--- a/examples/native-messaging/nm_node_process.ts
+++ b/examples/native-messaging/nm_node_process.ts
@@ -40,6 +40,17 @@
 // The prelude injection that backs `process.stdin` deliberately leaves a
 // user-declared/-imported `process` binding alone, so the faithful global surface
 // is what compiles to the async Readable here.
+//
+// Clean shutdown WITHOUT stdin EOF (#2735): a real Native-Messaging port keeps
+// stdin OPEN for the lifetime of the connection and signals end-of-conversation
+// IN BAND — here, with a zero-length frame (a 4-byte prefix declaring length 0).
+// The fd0 reactor that drives the async `'data'` callbacks only terminates on
+// stdin EOF, so an open-stdin peer would make `_start` block forever. On the
+// shutdown frame we therefore call `process.stdin.destroy()`, which drops the
+// reactor's fd0 subscription so the run loop falls through and the program exits
+// cleanly. (`process.exit(0)` is the alternative — it routes to WASI `proc_exit`
+// after the same subscription drop.) Feeding the host a bounded buffer that hits
+// EOF still exits via the `'end'` path, exactly as before.
 
 // The buffered, not-yet-echoed input. Each char's code is a raw input byte
 // (0–255), so `charCodeAt` recovers the byte and `length` counts bytes.
@@ -63,6 +74,12 @@ function drain(): void {
     const len = decodeLength(buffered);
     if (len === 0) {
       stopped = true; // zero-length frame = clean shutdown
+      // #2735: in-band shutdown. The peer (a long-lived Native-Messaging port)
+      // keeps stdin OPEN — it signals "done" with a zero-length frame rather
+      // than by closing the pipe, so stdin never reaches EOF. `.destroy()`
+      // drops the fd0 reactor subscription so `_start` returns cleanly; without
+      // it the reactor's only exit is stdin EOF and the program HANGS forever.
+      process.stdin.destroy();
       return;
     }
     const frameLen = 4 + len;

--- a/plan/issues/2735-stdin-reactor-nonEOF-termination.md
+++ b/plan/issues/2735-stdin-reactor-nonEOF-termination.md
@@ -1,0 +1,82 @@
+---
+id: 2735
+title: "WASI process.stdin reactor HANGS when stdin stays open — no non-EOF termination trigger (process.exit/.destroy/in-band shutdown)"
+status: done
+created: 2026-06-27
+completed: 2026-06-27
+assignee: ttraenkler/sdev-2735-stdin-exit
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen
+es_edition: n/a
+language_feature: wasi, process.stdin, event-loop
+goal: standalone-wasi
+related: [389, 2632, 2123, 2683]
+sprint: 66
+---
+
+# #2735 — stdin reactor non-EOF termination
+
+## Problem
+
+`nm_node_process.ts --target wasi` HANGS when stdin stays open — the real
+Native-Messaging case, where the peer keeps the port (pipe) OPEN for the
+lifetime of the connection and signals end-of-conversation IN BAND (a
+zero-length frame) rather than by closing the pipe. The program blocks forever
+in `poll_oneoff` (0 CPU — cleanly blocked, NOT a busy-wait), because the #2632
+fd-readiness reactor's ONLY termination trigger is stdin EOF.
+
+This is distinct from `--target node` and from #2646.
+
+## Root cause (verified)
+
+`buildRunLoopBodyWithFdReactor` (`src/codegen/async-scheduler.ts`) exits only when
+`pending = (nextTimer != I64_MAX) | fd0_active` becomes false. `fd0_active`
+(`state.stdinFdActiveGlobalIdx`) was cleared in EXACTLY ONE place — the 0-byte
+`fd_read` (EOF) in `buildStdinDrainBody`. So the program could ONLY terminate via
+stdin EOF. `process.stdin.pause()` (`src/process-stdin-prelude.ts`) just flips a
+`paused` flag; there was no `.destroy()` and `process.exit()`'s WASI lowering
+(`proc_exit`) was not paired with a subscription drop. The example's zero-length
+"clean shutdown" frame set `stopped=true` but never dropped the fd0 subscription,
+so the reactor kept blocking.
+
+Exit-on-EOF was already CORRECT and is untouched; the fix ADDS a non-EOF
+termination trigger.
+
+## Fix
+
+1. **Reactor escape hatch** (`async-scheduler.ts`): new `emitStdinStop()` (backs the
+   `__wasiStdinStop()` intrinsic) clears `__stdin_fd_active` (mirrors the EOF
+   clear), so the next `pending` test falls through and `_start` returns cleanly
+   even though stdin never reached EOF. `isStdinReactorActive()` lets callers gate
+   on the reactor being active. `__wasiStdinStop` added to the
+   `needsStdinReactor` detection list in `codegen/index.ts`; the intrinsic is
+   lowered in `expressions/calls.ts`.
+2. **Wire it** (`process-stdin-prelude.ts`): the library `Readable` gains a faithful
+   `destroy()` → `__wasiStdinStop()` (drops the subscription, emits `'close'`
+   once, suppresses further events; `pause()` alone still keeps stdin subscribed
+   so a data-listening program stays alive — Node parity). The WASI `process.exit`
+   lowering now drops the fd0 subscription (when the reactor is active) BEFORE
+   `proc_exit(code)`; a `process.exit`-only program (no stdin) is NOT forced to
+   wire the reactor.
+3. **Example** (`examples/native-messaging/nm_node_process.ts`): on the zero-length
+   shutdown frame, call `process.stdin.destroy()`; header documents the standalone
+   clean-shutdown-without-EOF path.
+
+## Tests
+
+`tests/issue-2735-stdin-nonEOF-termination.test.ts` (wasmtime-gated runtime cases +
+always-on compile cases): open-stdin + in-band shutdown frame exits cleanly and
+echoes byte-exact; `process.exit()` with stdin held open exits cleanly; EOF cases
+stay green; `nm_node_process.ts` still imports only `wasi_snapshot_preview1`; a
+`process.exit`-only program does not wire the reactor. A control program with no
+escape hatch was verified to hang (the gap the prior suite missed: it only fed
+bounded buffers that close stdin/EOF).
+
+## Validation
+
+- New test (6 cases) green; `native-messaging-comparison`, `issue-2632-phase2/3`,
+  `wasi-stdin`, `issue-1411` suites green.
+- tsc + lint clean; prettier applied.

--- a/src/codegen/async-scheduler.ts
+++ b/src/codegen/async-scheduler.ts
@@ -2675,6 +2675,39 @@ export function emitStdinEof(ctx: CodegenContext, fctx: FunctionContext): void {
 }
 
 /**
+ * #2735 — emit `__wasiStdinStop()` at a call site: a NON-EOF reactor exit
+ * trigger. Drops the fd0 subscription by clearing `__stdin_fd_active` (mirrors
+ * the EOF clear in `buildStdinDrainBody`), so the run loop's next `pending`
+ * test — `(next != I64_MAX) | fd0_active` — falls through and `_start` returns
+ * cleanly EVEN THOUGH stdin never reached EOF. Without this the fd-readiness
+ * reactor's ONLY termination path is stdin EOF, which hangs the real
+ * Native-Messaging case (the peer keeps the pipe open and signals shutdown
+ * in-band). Backs `process.stdin.destroy()` and the `process.exit()` pre-exit
+ * drop. Stack-neutral; a no-op (and safe to call unconditionally) when the
+ * reactor isn't active for this module (the global was never registered).
+ */
+export function emitStdinStop(ctx: CodegenContext, fctx: FunctionContext): void {
+  const state = getOrInitState(ctx as CodegenContextWithScheduler);
+  if (state.stdinFdActiveGlobalIdx < 0) return;
+  fctx.body.push(
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "global.set", index: state.stdinFdActiveGlobalIdx } as Instr,
+  );
+}
+
+/**
+ * #2735 — true when the fd0 stdin reactor is active for this module (the
+ * Phase-2 globals were registered). Lets the WASI `process.exit` lowering
+ * decide whether to drop the fd0 subscription before `proc_exit` WITHOUT
+ * forcing the reactor onto a program that only calls `process.exit` and never
+ * touches stdin.
+ */
+export function isStdinReactorActive(ctx: CodegenContext): boolean {
+  const state = (ctx as CodegenContextWithScheduler).asyncScheduler;
+  return !!state && state.stdinReactor && state.stdinFdActiveGlobalIdx >= 0;
+}
+
+/**
  * #2632 Phase 3 — emit `__wasiStdinSetReader(cb)` at a call site. Stores the
  * pump funcref + its closure captures into the reactor-tick-hook globals, so the
  * run loop invokes `cb(captures, null)` each tick after draining fd0. The

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -36,12 +36,14 @@ import {
   emitStdinEof,
   emitStdinReadByte,
   emitStdinSetReader,
+  emitStdinStop,
   emitTimerAdd,
   emitTimerCallbackWrapper,
   emitTimerCancel,
   ensureTimerHeap,
   getRunLoopNowFuncIdx,
   isStandalonePromiseActive,
+  isStdinReactorActive,
   type StandalonePromiseThenCallback,
 } from "../async-scheduler.js";
 import {
@@ -3183,6 +3185,13 @@ function tryWasiTimerCall(
     // boolean result (i32 0/1)
     return { kind: "i32" };
   }
+  // #2735 — `__wasiStdinStop()` drops the fd0 subscription so the reactor can
+  // terminate WITHOUT stdin EOF (in-band shutdown / `process.stdin.destroy()`).
+  // The library `Readable.destroy()` lowers to this.
+  if (name === "__wasiStdinStop") {
+    emitStdinStop(ctx, fctx);
+    return VOID_RESULT;
+  }
   // #2632 Phase 3 — `__wasiStdinSetReader(cb)` registers the Readable's pump as
   // the reactor-tick hook (run loop call_ref's it each tick after the drain).
   // The callback closure is compiled into a `$__mt_func_type` wrapper + captures
@@ -4773,6 +4782,15 @@ function compileCallExpression(
       propAccess.name.text === "exit" &&
       ctx.wasiProcExitIdx >= 0
     ) {
+      // #2735 — when the fd0 stdin reactor is active, drop its subscription
+      // before `proc_exit` so the intent (terminate now) is explicit and the
+      // run loop cannot out-live the exit. `proc_exit` already tears the whole
+      // instance down, so this is belt-and-suspenders; it is gated on the
+      // reactor being active so a `process.exit`-only program (no stdin) is
+      // NOT forced to wire the reactor.
+      if (isStdinReactorActive(ctx)) {
+        emitStdinStop(ctx, fctx);
+      }
       if (expr.arguments.length >= 1) {
         // #1801: `proc_exit` takes an i32 exit code. Compiling the argument
         // with expected type `{ kind: "i32" }` already delivers an i32 on the

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -6165,7 +6165,8 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
         callee === "__wasiStdinReadByte" ||
         callee === "__wasiStdinAvailable" ||
         callee === "__wasiStdinEof" ||
-        callee === "__wasiStdinSetReader"
+        callee === "__wasiStdinSetReader" ||
+        callee === "__wasiStdinStop"
       ) {
         needsStdinReactor = true;
         needsFdRead = true;

--- a/src/process-stdin-prelude.ts
+++ b/src/process-stdin-prelude.ts
@@ -177,17 +177,20 @@ const STDIN_READABLE_PRELUDE = `declare function __wasiStdinReadByte(): number;
 declare function __wasiStdinAvailable(): number;
 declare function __wasiStdinEof(): boolean;
 declare function __wasiStdinSetReader(cb: () => void): void;
+declare function __wasiStdinStop(): void;
 
 class __Js2wasmReadable {
   private chunk: string = "";
   private dataCbs: ((c: string) => void)[] = [];
   private endCbs: (() => void)[] = [];
   private readableCbs: (() => void)[] = [];
+  private closeCbs: (() => void)[] = [];
   private flowing: boolean = false;
   private paused: boolean = false;
   private ended: boolean = false;
   private armed: boolean = false;
   private eofReadableFired: boolean = false;
+  private destroyed: boolean = false;
 
   private drainBytes(): number {
     let n = 0;
@@ -204,6 +207,9 @@ class __Js2wasmReadable {
   }
 
   private pump(): void {
+    // A destroyed stream emits no further 'readable'/'data'/'end' (Node parity)
+    // and stops draining; the reactor's fd0 subscription was already dropped.
+    if (this.destroyed) { return; }
     const got = this.drainBytes();
     const atEof = __wasiStdinEof();
     // 'readable' fires when new bytes arrived OR when the stream has just reached
@@ -234,12 +240,14 @@ class __Js2wasmReadable {
     if (event === "data") { this.dataCbs.push(cb); this.flowing = true; this.arm(); }
     else if (event === "end") { this.endCbs.push(cb); this.arm(); }
     else if (event === "readable") { this.readableCbs.push(cb); this.arm(); }
+    else if (event === "close") { this.closeCbs.push(cb); }
     return this;
   }
 
   // read([size]): returns a string chunk of up to size chars, or null when fewer
   // than size are buffered and EOF has not been reached (paused-mode semantics).
   read(size?: number): string | null {
+    if (this.destroyed) { return null; }
     // Pull any freshly-ready bytes so a paused .read() sees the latest buffer.
     this.drainBytes();
     const avail = this.chunk.length;
@@ -271,6 +279,22 @@ class __Js2wasmReadable {
     // Flush any bytes withheld while paused immediately (the reactor may already
     // be at EOF and not call the hook again).
     this.pump();
+    return this;
+  }
+
+  // destroy(): tear the stream down NOW. Unlike .pause() (which leaves stdin
+  // subscribed so the process stays alive while data listeners remain), destroy
+  // drops the fd0 reactor subscription via __wasiStdinStop(), so the run loop's
+  // 'pending' test falls through and _start returns cleanly EVEN THOUGH stdin
+  // never reached EOF. This is the in-band / programmatic shutdown escape hatch
+  // (#2735): without it the reactor's only exit is stdin EOF, which hangs when
+  // the peer keeps the pipe open (the real Native-Messaging case). Emits 'close'
+  // once, then suppresses all further events (Node parity).
+  destroy(): __Js2wasmReadable {
+    if (this.destroyed) { return this; }
+    this.destroyed = true;
+    __wasiStdinStop();
+    for (let i = 0; i < this.closeCbs.length; i = i + 1) { this.closeCbs[i](); }
     return this;
   }
 }

--- a/tests/issue-2735-stdin-nonEOF-termination.test.ts
+++ b/tests/issue-2735-stdin-nonEOF-termination.test.ts
@@ -1,0 +1,224 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2735 — the WASI `process.stdin` fd-readiness reactor must have a NON-EOF
+ * termination trigger.
+ *
+ * The #2632 reactor (`async-scheduler.ts buildRunLoopBodyWithFdReactor`) exits
+ * only when its `pending` test — `(nextTimer != I64_MAX) | fd0_active` — becomes
+ * false, and `fd0_active` was cleared in EXACTLY ONE place: the 0-byte `fd_read`
+ * (stdin EOF) in `buildStdinDrainBody`. So the program could ONLY terminate via
+ * stdin EOF. The real Native-Messaging case keeps the pipe OPEN for the lifetime
+ * of the port and signals end-of-conversation IN BAND (a zero-length frame), so
+ * stdin never reaches EOF and `_start` HANGS forever (0 CPU, blocked in
+ * poll_oneoff).
+ *
+ * The fix adds an escape hatch: a `__wasiStdinStop()` intrinsic that clears
+ * `__stdin_fd_active` (mirroring the EOF clear), wired to `process.stdin.destroy()`
+ * and to `process.exit()` (which drops the subscription, then calls WASI
+ * `proc_exit`). The existing `native-messaging-comparison` suite only ever fed
+ * BOUNDED buffers that close stdin (EOF), so it never exercised the open-stdin
+ * path — these cases close that gap by keeping stdin OPEN.
+ *
+ * The runtime cases require REAL wasmtime (the reactor runs in the event loop,
+ * which the in-process fd shim does not drive) and are skipped when it is not on
+ * PATH; the compile-only cases always run.
+ */
+import { execFileSync, spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// wasmtime feature flags for the WasmGC + exception-handling binaries js2wasm
+// emits (structs/arrays + the exception tag).
+const WASMTIME_FLAGS = ["-W", "gc=y,function-references=y,exceptions=y"];
+
+/** Resolve a usable `wasmtime` binary, or null when none is on PATH. */
+function findWasmtime(): string | null {
+  for (const cand of ["wasmtime", "/usr/local/bin/wasmtime"]) {
+    try {
+      execFileSync(cand, ["--version"], { stdio: "ignore" });
+      return cand;
+    } catch {
+      /* try next */
+    }
+  }
+  return null;
+}
+const wasmtimeBin = findWasmtime();
+
+const NM_DIR = join(__dirname, "..", "examples", "native-messaging");
+
+/** Frame a body as a 4-byte LE length prefix + the body bytes (Native Messaging). */
+function frame(body: Uint8Array): Uint8Array {
+  const out = new Uint8Array(4 + body.length);
+  const n = body.length;
+  out[0] = n & 0xff;
+  out[1] = (n >> 8) & 0xff;
+  out[2] = (n >> 16) & 0xff;
+  out[3] = (n >> 24) & 0xff;
+  out.set(body, 4);
+  return out;
+}
+
+/** The (module) name of every import in a compiled WAT. */
+function importModules(wat: string): Set<string> {
+  const mods = new Set<string>();
+  for (const line of wat.split("\n")) {
+    const m = line.match(/\(import\s+"([^"]+)"/);
+    if (m) mods.add(m[1]!);
+  }
+  return mods;
+}
+
+async function compileWasi(src: string, name: string): Promise<Awaited<ReturnType<typeof compile>>> {
+  return compile(src, { fileName: `${name}.ts`, target: "wasi", skipSemanticDiagnostics: true });
+}
+
+interface RunResult {
+  stdout: Uint8Array;
+  exitCode: number | null;
+  timedOut: boolean;
+}
+
+/**
+ * Spawn a compiled WASI module under wasmtime, write `input` to its stdin, and
+ * resolve when it exits (or the timeout fires). When `keepOpen` is true the
+ * parent's stdin pipe is DELIBERATELY left open (never `.end()`-ed) so the child
+ * never sees EOF — the whole point of #2735: the program must terminate via the
+ * in-band escape hatch, not via stdin EOF. `timedOut: true` means it hung (the
+ * pre-fix behavior).
+ */
+function runWasmtimeStdin(
+  binPath: string,
+  input: Uint8Array,
+  opts: { keepOpen: boolean; timeoutMs: number },
+): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const child = spawn(wasmtimeBin!, [...WASMTIME_FLAGS, binPath], {
+      stdio: ["pipe", "pipe", "ignore"], // drop fd 2 diagnostics
+    });
+    const out: number[] = [];
+    child.stdout.on("data", (d: Buffer) => {
+      for (const b of d) out.push(b);
+    });
+    // The child may exit before we finish with its stdin → swallow EPIPE.
+    child.stdin.on("error", () => {});
+    let done = false;
+    const timer = setTimeout(() => {
+      if (done) return;
+      done = true;
+      child.kill("SIGKILL");
+      resolve({ stdout: Uint8Array.from(out), exitCode: null, timedOut: true });
+    }, opts.timeoutMs);
+    child.on("exit", (code) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      resolve({ stdout: Uint8Array.from(out), exitCode: code, timedOut: false });
+    });
+    child.stdin.write(Buffer.from(input));
+    if (!opts.keepOpen) child.stdin.end();
+  });
+}
+
+describe("#2735 — stdin reactor non-EOF termination", () => {
+  let tmpDir: string;
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "issue-2735-"));
+  });
+  afterAll(() => {
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function buildToDisk(src: string, name: string): Promise<string> {
+    const r = await compileWasi(src, name);
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+    expect(WebAssembly.validate(r.binary!), `${name} binary must validate`).toBe(true);
+    const path = join(tmpDir, `${name}.wasm`);
+    writeFileSync(path, r.binary!);
+    return path;
+  }
+
+  const requestBody = new TextEncoder().encode('["hello",null,42]');
+  const requestFrame = frame(requestBody);
+  const shutdownFrame = frame(new Uint8Array(0)); // zero-length = in-band clean shutdown
+
+  // ── Compile-only invariants (always run, no runtime needed) ──────────────
+
+  it("nm_node_process.ts still lowers to a standalone module importing only wasi_snapshot_preview1", async () => {
+    // The destroy() → __wasiStdinStop() lowering must NOT leak an `env.*` host
+    // import (a regression of the #2696 zero-env-leak guarantee).
+    const src = readFileSync(join(NM_DIR, "nm_node_process.ts"), "utf-8");
+    const r = await compileWasi(src, "nm_node_process_imports");
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+    expect(WebAssembly.validate(r.binary!)).toBe(true);
+    expect([...importModules(r.wat!)]).toEqual(["wasi_snapshot_preview1"]);
+    // The reactor IS wired (it uses process.stdin) ...
+    expect(r.wat!.includes("__run_event_loop")).toBe(true);
+  });
+
+  it("a process.exit-only program does NOT force the stdin reactor", async () => {
+    // __wasiStdinStop must only be emitted before proc_exit when the reactor is
+    // already active — a program that never touches stdin stays reactor-free.
+    const r = await compileWasi("process.exit(3);\n", "exit_only");
+    expect(r.success).toBe(true);
+    expect(r.wat!.includes("__run_event_loop"), "no event loop for a stdin-free program").toBe(false);
+    expect(r.wat!.includes("__rl_stdin_drain"), "no stdin reactor for a stdin-free program").toBe(false);
+  });
+
+  // ── Runtime behavior under real wasmtime (the actual hang repro) ──────────
+
+  const maybe = wasmtimeBin ? describe : describe.skip;
+  maybe("under wasmtime (stdin kept OPEN — the real Native-Messaging case)", () => {
+    it(
+      "exits cleanly on an in-band zero-length shutdown frame and echoes the data frame byte-exact",
+      { timeout: 30_000 },
+      async () => {
+        const binPath = await buildToDisk(
+          readFileSync(join(NM_DIR, "nm_node_process.ts"), "utf-8"),
+          "nm_open_shutdown",
+        );
+        const input = new Uint8Array([...requestFrame, ...shutdownFrame]);
+        const res = await runWasmtimeStdin(binPath, input, { keepOpen: true, timeoutMs: 15_000 });
+        // The pre-fix reactor would block forever here (timedOut: true).
+        expect(res.timedOut, "open-stdin program HUNG — no non-EOF termination trigger").toBe(false);
+        expect(res.exitCode).toBe(0);
+        expect(Array.from(res.stdout), "must echo only the data frame, byte-exact").toEqual(Array.from(requestFrame));
+      },
+    );
+
+    it("process.exit() with stdin held open exits cleanly", { timeout: 30_000 }, async () => {
+      // A program whose data callback calls process.exit(0): proc_exit tears the
+      // instance down (after dropping the fd0 subscription) even though stdin is
+      // still open.
+      const binPath = await buildToDisk(
+        `process.stdin.on("data", (chunk: string) => { process.exit(0); });\n`,
+        "exit_open_stdin",
+      );
+      const res = await runWasmtimeStdin(binPath, Uint8Array.of(9), { keepOpen: true, timeoutMs: 15_000 });
+      expect(res.timedOut, "process.exit() did not terminate with stdin open").toBe(false);
+      expect(res.exitCode).toBe(0);
+    });
+  });
+
+  maybe("under wasmtime (stdin CLOSED — EOF path stays green)", () => {
+    it("EOF-closed stdin still echoes the frame and exits", { timeout: 30_000 }, async () => {
+      const binPath = await buildToDisk(readFileSync(join(NM_DIR, "nm_node_process.ts"), "utf-8"), "nm_eof_close");
+      // Same input, but the parent CLOSES stdin → the reactor's existing EOF
+      // trigger fires. This must remain unaffected by the new escape hatch.
+      const input = new Uint8Array([...requestFrame, ...shutdownFrame]);
+      const res = await runWasmtimeStdin(binPath, input, { keepOpen: false, timeoutMs: 15_000 });
+      expect(res.timedOut, "EOF-closed program HUNG").toBe(false);
+      expect(Array.from(res.stdout)).toEqual(Array.from(requestFrame));
+    });
+
+    it("a bounded buffer with no shutdown frame still exits on EOF", { timeout: 30_000 }, async () => {
+      const binPath = await buildToDisk(readFileSync(join(NM_DIR, "nm_node_process.ts"), "utf-8"), "nm_eof_plain");
+      const res = await runWasmtimeStdin(binPath, requestFrame, { keepOpen: false, timeoutMs: 15_000 });
+      expect(res.timedOut).toBe(false);
+      expect(Array.from(res.stdout)).toEqual(Array.from(requestFrame));
+    });
+  });
+});


### PR DESCRIPTION
## #2735 — stdin reactor non-EOF termination

`nm_node_process.ts --target wasi` HANGS when stdin stays OPEN (the real
Native-Messaging case): the peer keeps the pipe open and signals shutdown IN
BAND (a zero-length frame), so stdin never reaches EOF.

### Root cause (verified)
The #2632 fd-readiness reactor (`buildRunLoopBodyWithFdReactor`,
`src/codegen/async-scheduler.ts`) exits only when its `pending` test —
`(nextTimer != I64_MAX) | fd0_active` — goes false, and `fd0_active`
(`stdinFdActiveGlobalIdx`) was cleared in EXACTLY ONE place: the 0-byte
`fd_read` (stdin EOF) in `buildStdinDrainBody`. So a `process.stdin` program
could ONLY terminate via stdin EOF. `pause()` just flips a flag; there was no
`.destroy()`, and WASI `process.exit` → `proc_exit` was not paired with a
subscription drop. The example set `stopped=true` on the shutdown frame but
never dropped the fd0 subscription. (Exit-on-EOF was already correct and is
untouched; this ADDS a non-EOF trigger. 0 CPU — cleanly blocked in
`poll_oneoff`, NOT a busy-wait. Distinct from `--target node` and #2646.)

### Fix
- **`async-scheduler.ts`** — `emitStdinStop()` (backs the `__wasiStdinStop()`
  intrinsic) clears `__stdin_fd_active` (mirrors the EOF clear) so the next
  `pending` test falls through and `_start` returns cleanly even though stdin
  never EOFs; `isStdinReactorActive()` gates callers.
- **`codegen/index.ts`** — `__wasiStdinStop` joins the `needsStdinReactor`
  detection list; **`expressions/calls.ts`** lowers the intrinsic and, in the
  WASI `process.exit` path, drops the fd0 subscription before `proc_exit`
  **only when the reactor is active** (a `process.exit`-only program is NOT
  forced to wire the reactor).
- **`process-stdin-prelude.ts`** — `Readable.destroy()` → `__wasiStdinStop()`
  (drops the subscription, emits `'close'` once, suppresses further events;
  `pause()` alone still keeps stdin subscribed so a data-listening program
  stays alive — Node parity).
- **`examples/native-messaging/nm_node_process.ts`** — call
  `process.stdin.destroy()` on the zero-length shutdown frame; header documents
  the standalone clean-shutdown-without-EOF path.

### Tests — `tests/issue-2735-stdin-nonEOF-termination.test.ts`
Closes the gap the existing suite missed (it only fed BOUNDED buffers that
close stdin/EOF). wasmtime-gated runtime cases keep stdin OPEN:
- open-stdin + in-band zero-length shutdown frame → exits cleanly, byte-exact echo;
- `process.exit()` with stdin held open → clean exit;
- EOF-closed + plain-EOF cases stay green;
- compile-only (always run): `nm_node_process.ts` imports only
  `wasi_snapshot_preview1`; a `process.exit`-only program does NOT wire the reactor.

A no-escape-hatch control program was verified to hang, confirming the test
catches the regression.

### Validation
New suite (6) green; `native-messaging-comparison`, `issue-2632-phase2/3`,
`issue-2632-event-loop`, `wasi-stdin`, `issue-1411`, `deno-stdio`,
`process-io-to-node-fs`, `atomic-frame-writes` green. tsc + biome lint clean;
prettier applied. `async-scheduler.ts` is shared codegen but the changes are
additive and gated (WASI + stdin-reactor only), so non-WASI / non-stdin output
is byte-identical.

Closes #2735.

🤖 Generated with [Claude Code](https://claude.com/claude-code)