### PR TITLE
docs(#2731,#2680): architect implementation specs (substrate phase)

### DIFF
--- a/plan/issues/2680-runtime-topropertydescriptor-proto-inherited-attrs.md
+++ b/plan/issues/2680-runtime-topropertydescriptor-proto-inherited-attrs.md
@@ -140,3 +140,155 @@ off when the descriptor has any wasmGC ancestor in that chain.
 BROAD → escalated for an architect spec (next-sprint), same as #2688. The
 ~29-test ceiling + the substrate dependency (#2580) make a careful spec the right
 path over a risky partial reader patch on the auto-park-prone descriptor surface.
+
+## Implementation Plan (architect, verified on origin/main @ 5a92381, 2026-06-27)
+
+### The verify-first finding (sd-2668c) was WRONG about "no proto link exists" — it MISSED #1712
+
+The sd-2668c finding looked for `Object.getPrototypeOf(child)` returning `proto`
+(a real JS `[[Prototype]]` edge) and, not finding one, concluded a whole new
+`_wasmStructProto` representation must be built. **That conclusion is incorrect.**
+A runtime-reachable instance→prototype link **already exists** in HOST mode
+(`#1712`):
+
+- `_fnctorInstanceCtor: WeakMap<object, object>` (`src/runtime.ts:71`) links each
+  constructed fnctor instance struct → its **constructor closure struct**.
+- It is populated by the `__register_fnctor_instance` host import
+  (`runtime.ts:7669`), emitted in the fnctor ctor PROLOGUE
+  (`src/codegen/expressions/new-super.ts:1267-1287`).
+- `F.prototype = proto` stores `proto` in the **constructor closure's sidecar**
+  under key `"prototype"` (host mode: `__extern_set_strict($ctorClosure,
+  "prototype", proto)` — verified by tracing the repro).
+- `_fnctorProtoLookup(obj, key)` (`runtime.ts:74`) already walks: `ctor =
+  _fnctorInstanceCtor.get(obj)` → `proto = _sidecarGet(ctor, "prototype")` →
+  walk `proto`'s chain.
+
+So the link is real and reachable. There are **two actual gaps** (both verified by
+instrumenting the cited-cluster pattern `var ConstructFun = function(){};
+ConstructFun.prototype = proto; var child = new ConstructFun(); ...`):
+
+**GAP A — the descriptor reader never consults the proto chain.** The
+`getField`/`hasField` closures in `__defineProperty_desc` (`runtime.ts:8798-8826`)
+and `__defineProperties` (`9064-9095`) read a wasmGC-struct descriptor's attribute
+slots **own-level only** (sidecar + `__sget_<f>` + `_getStructFieldNames`). Per
+ES §10.1.6.2 ToPropertyDescriptor → §7.3.12 HasProperty / §7.3.3 Get (both
+proto-inclusive), a descriptor attribute on the descriptor's `[[Prototype]]` must
+be read. They do not call `_fnctorProtoLookup` (or any proto walk).
+
+**GAP B — even the existing proto walk is NOT wasmGC-aware.** `_fnctorProtoLookup`
+(`74-89`) walks each ancestor with **native `Object.getOwnPropertyDescriptor(cur,
+key)`** (line 83). When `proto` is itself a wasmGC struct (the common case: `var
+proto = {}` is a wasmGC struct whose `configurable`/`enumerable`/`value`/`get`
+attribute lives in proto's **sidecar**), `Object.getOwnPropertyDescriptor` on the
+opaque struct returns `undefined` and the inherited attribute is dropped. This is
+why even a DIRECT inherited read `child.configurable` returns `0`/false — verified.
+
+### Verified buggy outputs (host mode, current main)
+
+- `child.configurable` (direct inherited read, module-scope ctor) → `false`
+  (expected `true`).
+- `Object.defineProperty(obj,"property",child)` then
+  `Object.getOwnPropertyDescriptor(obj,"property").configurable` → `false`
+  (expected `true`).
+- Trace confirms BOTH `__extern_set_strict($ctor,"prototype",<proto>)` AND
+  `__register_fnctor_instance(child,$ctor)` fire (link populated), yet
+  `_fnctorProtoLookup` returns `undefined` (it walks `proto` via native
+  `Object.getOwnPropertyDescriptor`, which can't see the wasmGC-struct sidecar).
+
+### Registration-scope precondition (already satisfied for the target cluster)
+
+`__register_fnctor_instance` is emitted ONLY when the ctor closure is a **module
+global** (`ctorGlobalIdx !== undefined`, `new-super.ts:1267-1287`). The cited
+cluster uses top-level `var ConstructFun` (module global) → covered. A
+**function-LOCAL** fnctor ctor is NOT registered → its instances have no link →
+out of scope (a known, acceptable limitation for the ~29-test ceiling). Verified:
+module-scope ctor emits the registration; a `const ConstructFun = function(){}`
+inside a function does not. Do NOT widen the registration gate in this PR.
+
+### Fix — two changes, both in `src/runtime.ts` (no new representation, no codegen change)
+
+#### GAP B — make the proto walk wasmGC-aware (also fixes direct inherited reads)
+
+**`_fnctorProtoLookup` (`runtime.ts:74-89`)**: thread `exports`
+(`callbackState?.getExports()`) in (add a param; callers at `4148` and `4939`
+already have `callbackState`/`exports`). At each `cur` in the walk: if
+`_isWasmStruct(cur)`, read the own descriptor via the existing wasmGC-aware
+`_readOwnDescriptor(cur, key, exports)` (`runtime.ts:4655` — reads sidecar +
+descriptor table + `__sget_<key>` + class methods, the #1629-safe reader);
+else use `Object.getOwnPropertyDescriptor(cur, key)` (plain JS ancestor). Advance
+`cur` via: wasmGC struct → its recorded parent (the ctor-closure sidecar
+`"prototype"` is already the first hop; deeper wasmGC chains via a recorded proto
+link if/when present — for the cluster the chain is depth-1, so the first hop
+suffices). Keep the existing 16-level guard + `Object.prototype` stop (cycle-safe).
+
+#### GAP A — make the descriptor reader consult the proto chain
+
+**`getField`/`hasField` in `__defineProperty_desc` (`runtime.ts:8798-8826`)** and
+the matching pair in `__defineProperties` (`9064-9095`): after the own-level miss
+(sidecar miss + `_getStructFieldNames` miss), walk the descriptor's prototype
+chain via the #1712 link:
+
+- `getField(o,f)`: own-level (unchanged) → on miss, `const d =
+  _fnctorProtoLookup(o, f /*, exports*/)`; if `d` has a getter return
+  `d.get.call(o)`, else return `d?.value`.
+- `hasField(o,f)`: own-level (unchanged) → on miss, return
+  `_fnctorProtoLookup(o, f) !== undefined`.
+
+Both go through `_fnctorProtoLookup`, which (after GAP B) walks ancestor levels
+with the **shape-precise** `_readOwnDescriptor` / `_getStructFieldNames`
+membership — **NEVER** a `__sget_*` try/catch probe (the #1629 hazard: `__sget_*`
+getters are module-global, one per field NAME, and do NOT trap on a struct lacking
+the field, so a probe returns a spurious value for every ubiquitous descriptor name
+`value`/`get`/`set`/`writable` → bogus data⇄accessor conflicts). This guarantee is
+already met because `_readOwnDescriptor` and `_getStructFieldNames` are
+shape-derived, not probe-derived.
+
+#### Gate the native fast-path off when the descriptor has a wasmGC ancestor
+
+`__defineProperty_desc` short-circuits `!_isWasmStruct(obj) && !_isWasmStruct(desc)
+→ Object.defineProperty(obj,key,desc)` (`runtime.ts:8834`). A wasmGC descriptor is
+already excluded (`_isWasmStruct(desc)` true → skips the native path). But a
+**plain JS descriptor whose `[[Prototype]]` is a wasmGC struct** (e.g.
+`Object.create(<wasmStruct>)`) would still take the native path and drop the
+wasmGC-proto attribute. Extend the guard: also skip the native fast-path when the
+descriptor's own proto chain contains any wasmGC struct (walk `Object.getProtoOf`
++ the #1712 link; bounded). For the cited cluster the descriptor is a wasmGC struct
+already, so this is a no-regression hardening for the `Object.create(wasmStruct)`
+neighbour — verify on the floor.
+
+### Why this is small, not a substrate rebuild
+
+The link + a 16-level cycle-safe walk already exist (#1712). The fix is: (1) make
+the walk read wasmGC-struct levels via `_readOwnDescriptor` instead of native
+`Object.getOwnPropertyDescriptor`, and (2) call that walk from the two descriptor
+readers' own-level miss. No new WeakMap, no construct-site codegen, no #2580
+substrate dependency for the host-mode cluster. (The standalone equivalent — where
+descriptors are native `$Object` structs — rides on #2580 separately and is out of
+scope here.)
+
+### Edge cases
+- Accessor descriptor whose `get`/`set` is proto-inherited (e.g. 15.2.3.6-3-31):
+  `getField(o,"get")` walks to proto, `_readOwnDescriptor` returns the accessor
+  pair; `_maybeWrapCallable` (the existing `wrap`, `8830`) makes it invocable.
+- `child` overrides one half on its OWN level (own `set`, inherited `get`): own
+  level wins (checked first); proto walk only fills genuine own-misses. ✓
+- proto-inherited `enumerable:false` honoring (the #2668 Slice A re-introduction):
+  once `getField(child,"enumerable")` reads the proto value accurately, the
+  for-in filter can be re-enabled per the acceptance criteria.
+- Function-local fnctor ctor descriptor → no link → own-level only (status quo,
+  acceptable; not in the cluster).
+- Cycle / deep chain: the existing `guard++ < 16` cap + `Object.prototype` stop
+  prevent runaway.
+
+### Validating tests (test262, the ~29 genuinely proto-inherited cases)
+`built-ins/Object/defineProperty/15.2.3.6-3-{31,32,76,77,78,80,81,82,85,129,133,
+134,135,138,208,209,210,212,213,214,216,217,238,239,240,242,243,244,246}.js`.
+No regression in the own-level `15.2.3.6-3-*` data/accessor family already fixed by
+#2668 Slice A (23,25,28,35,40,45,…). **Validate on the full `merge_group` floor** —
+this is the descriptor surface that auto-parked #2668 Slice A's first cut.
+
+### Coordination
+- Independent of #2731 (different mechanism; #2731 is the delete-tombstone
+  asymmetry, #2680 is the descriptor proto-walk). They can land in either order.
+- Once landed: re-introduce the #2668 Slice A for-in `enumerable:false` filter and
+  re-widen the Slice A dynamic-descriptor route (per this issue's acceptance).

--- a/plan/issues/2731-forin-object-delete-readd-host-tombstone-disconnect.md
+++ b/plan/issues/2731-forin-object-delete-readd-host-tombstone-disconnect.md
@@ -99,3 +99,178 @@ five `for-in` order tests above pass (with #1830 also landed).
 - Split from #2706 (which is now `blocked` on this). #2706's #1830 half is landed
   separately as `fix(#1830)`.
 - Route to **architect** for a spec; overlaps #2580 / #2660 substrate.
+
+## Implementation Plan (architect, verified on origin/main @ 5a92381, 2026-06-27)
+
+### Root cause — RE-VERIFIED, the issue's framing is imprecise
+
+The repro receiver is **NOT** a native `$Object` open-hashmap. It is a
+**shape-inferred NOMINAL anon struct**. There is no
+`src/codegen-linear/object-runtime.ts` (the native open-object `$Object` runtime
+is `src/codegen/object-runtime.ts` and is gated **standalone-only**). Verified by
+compiling repro 1 in host mode:
+
+```
+(type $__anon_0 (struct (field $x (mut f64)) (field $y (mut f64))))
+```
+
+`o.x = 1` / `o.y = 2` are native `struct.set`; `delete o.x` is `__delete_property`
+(host); `for-in` is host `__for_in_keys`/`__for_in_has`. The **real** disconnect
+is an asymmetry the `moduleUsesDelete` pre-scan introduced (#2179):
+
+- When the module contains a member-`delete`, `ctx.moduleUsesDelete` is set
+  (`src/codegen/index.ts:1075`, `sourceContainsDelete` ~303). This routes
+  `any`/`unknown`-receiver property **READS** through the tombstone-aware host
+  `__extern_get` via `tryEmitDeleteAwareDynamicGet`
+  (`src/codegen/property-access.ts:2148`, called at ~2412). **Correct.**
+- But the corresponding **WRITE** path has **no symmetric gate** — `o.x = 9`
+  still takes the native `struct.set` fast-path (the `__set_member_<name>`
+  dispatcher built by `emitAlternateStructSetDispatch`,
+  `src/codegen/property-access.ts:1282`; its native struct.set arm STOPS, it does
+  not fall to the `__extern_set_strict` else-arm). The native write **bypasses
+  `_safeSet`** (`src/runtime.ts:4216`), where the tombstone-clear lives
+  (`runtime.ts:4245-4248`, `tomb.delete(key)`).
+
+So `delete o.x` (host `__delete_property`, `runtime.ts:10606` → sets
+`_wasmStructDeletedKeys` tombstone + clears native field to its sentinel) followed
+by a native `struct.set` re-add leaves the host tombstone **set**. Every
+tombstone-consulting reader then suppresses the re-added key:
+`__extern_get` (`runtime.ts:4118`), `_wasmStructHasOwn` (`3176`),
+`__for_in_has` per-visit liveness (`10806`), `__object_keys/values/entries`
+(`8409/8431/8456`).
+
+**Verified buggy outputs (host mode, current main)** via `compileAndInstantiate`:
+- repro 1 for-in → `"y,"` (expected `"y,x,"`)
+- repro 2 `"a" in o` → `false` (expected `true`)
+- repro 2 `o.a` → `NaN` (expected `9`)
+
+Trace proof: instrumenting the host env helpers shows the re-add `o.a = 9` calls
+**no** host setter (it is native `struct.set`); only `__delete_property(o,"a")`
+then `__extern_get(o,"a") → undefined` fire. Routing the SAME re-add through the
+host (computed key `o[k]=9` → `__extern_set_strict` → `_safeSet`) already returns
+`9` / `true` — proving the fix direction (reconnect the re-add to `_safeSet`).
+
+### Fix — two coordinated parts (HOST mode; standalone is a separate sub-case, below)
+
+#### PART 1 — Codegen: symmetric tombstone-aware WRITE routing (the reconnection)
+
+**File: `src/codegen/property-access.ts`**
+
+Add `tryEmitDeleteAwareDynamicSet`, the mirror of `tryEmitDeleteAwareDynamicGet`
+(~2148). Gate identically: `ctx.moduleUsesDelete && !ctx.standalone`, receiver
+type is `any`/`unknown` (`ts.TypeFlags.Any | ts.TypeFlags.Unknown`), `propName`
+is not a reserved accessor (`length`/`constructor`/`__proto__`/`prototype`/`name`),
+and the access is not method/function-typed. When it fires, **skip** the native
+`emitAlternateStructSetDispatch` struct.set fast-path and emit the receiver +
+boxed value + `ensureLateImport(ctx, "__extern_set_strict", [externref, externref,
+externref?], [])` (use the SAME strict setter the dispatcher's else-arm uses; ESM
+is strict). Call this gate from the property-**assignment** lowering at the point
+where it currently decides to call `emitAlternateStructSetDispatch` (the
+`compileAssignment` property-access arm; the dispatcher's caller). Return a
+handled sentinel so the caller does not also emit the native dispatcher.
+
+Effect: the re-add flows through `_safeSet`, which (today) clears the tombstone
+(`4247`), writes the sidecar (`4357`), and mirrors the native field via
+`__sset_<key>` (`4334-4351`). This alone fixes repro 2 (`o.a===9`, `"a" in o`) and
+makes the key re-appear in for-in — but at its **struct-shape position**, not the
+spec-required insertion-order END. PART 2 fixes the order.
+
+Perf note: this routes ALL `any`-receiver writes in delete-using modules through
+the host (matching the read side, which already does). Delete-free modules are
+unaffected (`moduleUsesDelete` false → byte-identical). Acceptable.
+
+#### PART 2 — Runtime: enumerate a deleted-then-readded field at insertion-order END
+
+The 5 for-in tests require the re-added key LAST, e.g. `order-simple-object`
+expects `['0','1','2','p2','p4','p1']` (deleted+readded `p1` at the end). The
+struct shape is fixed-order, so the re-added field must be enumerated from the
+**sidecar** (insertion-ordered) and excluded from its struct position — but ONLY
+when it was deleted (plain re-assignment of a never-deleted field must keep its
+struct position). Use a persistent marker that only `delete`+re-add sets.
+
+**File: `src/runtime.ts`**
+
+1. Add `const _wasmStructShadowedFields = new WeakMap<object, Set<string>>();`
+   (near `_wasmStructDeletedKeys`, ~571). "Struct-shape fields that were
+   deleted-then-readded, so their live value lives in the sidecar and they must be
+   enumerated from the sidecar (insertion end), not their struct-shape slot."
+
+2. In `_safeSet` (`4216`), at the existing tombstone block (`4245-4248`): capture
+   `const wasTombstoned = !!tomb && tomb.has(k)` BEFORE clearing. If
+   `wasTombstoned` AND `k` is a struct-shape field
+   (`_getStructFieldNames(obj, exports ?? callbackState?.getExports())?.includes(k)`),
+   then `shadowed.add(k)` in `_wasmStructShadowedFields(obj)`. Keep the existing
+   `tomb.delete(k)` clear and the sidecar write — presence/value readers stay
+   correct and UNCHANGED (lower regression risk).
+
+3. In `__for_in_keys` (`runtime.ts:10730-10734`), the struct-shape loop: **skip**
+   any field in `_wasmStructShadowedFields(current)` (so the re-added field is not
+   emitted at its struct slot). The existing sidecar loop (`10736-10748`) then adds
+   it at the end (the sidecar JS object preserves re-insertion order from
+   `_safeSet`'s `_sidecarSet`), and `_orderOwnKeysSpec` (integers-first) + the
+   per-visit `__for_in_has` place it correctly.
+
+Worked trace (design validated against the existing readers):
+`o={x,y}`, `delete o.x` → tomb={x}, sidecar drops x; `o.x=9` → `_safeSet`:
+`wasTombstoned && x∈shape` → shadowed={x}, clear tomb, sidecar re-inserts x at end
+({y,x}). `__for_in_keys`: struct loop emits y (x skipped via shadowed); sidecar
+loop appends x → `[y,x]` → **"y,x,"**. ✓ `order-simple-object`: p1 deleted+readded
+→ shadowed; struct loop skips p1,p3 (p3 tombstoned via `__for_in_has`); sidecar
+appends p1 after p4 → `0,1,2,p2,p4,p1`. ✓
+
+4. **No-regression for Object.keys/values/entries**: `__object_keys/values/entries`
+   (`8398-8469`) currently filter tombstoned struct fields but do **not** merge the
+   sidecar at all. The 5 for-in tests use `__for_in_keys` only, so PART 2 above is
+   sufficient for acceptance. Add the same `_wasmStructShadowedFields` skip in these
+   three filters so a shadowed field is not double-counted, and verify on the
+   `merge_group` floor whether the (pre-existing) sidecar-merge gap in these paths
+   needs a follow-up. Do NOT expand scope here.
+
+### Standalone mode — separate sub-case, scope OUT of this issue
+
+Verified: the repro compiles in `--target standalone` with **zero imports** (pure
+native nominal struct). There is no host tombstone — `delete o.x` only clears the
+field to its sentinel and the native `__delete_property` (object-runtime.ts, for
+`$Object`) is a no-op on a nominal struct (`ref.test $Object` false). So standalone
+has the OPPOSITE profile: delete+re-add "works" (native field holds the value) but
+a delete WITHOUT re-add still enumerates (no tombstone to suppress it, since
+`__struct_field_names` returns the full shape). That is a distinct native-tombstone
+gap — track it under the #2580 substrate / a follow-up, NOT here. Scope #2731's
+acceptance to **host mode** (the verified repro). Note this in the issue's
+"both host and standalone modes" criterion — only host is in scope for this PR.
+
+### Wasm / host patterns
+- PART 1 write routing: `local.get <recvExt>; local.get <valExt(boxed externref)>;
+  call $__extern_set_strict` — exactly the dispatcher's existing strict else-arm
+  (`emitAlternateStructSetDispatch` terminal arm), just taken unconditionally for
+  `any` receivers under `moduleUsesDelete`.
+- No new host import is needed (`__extern_set_strict` already exists; `_safeSet`
+  already clears the tombstone + writes sidecar + mirrors the native field).
+
+### Edge cases
+- Plain re-assign of a never-deleted struct field (`o.y = 5`): `_safeSet`
+  `wasTombstoned` is false → NOT shadowed → stays at struct position. ✓
+- Delete WITHOUT re-add (`delete o.x` only): tomb set, not shadowed, not in
+  sidecar → `__for_in_has` suppresses it (absent). ✓ No change.
+- Sidecar-only dynamic key delete+re-add (`o.dyn=1; delete o.dyn; o.dyn=2`):
+  not a struct-shape field → not shadowed; the existing sidecar re-insert already
+  orders it at the end. ✓ (shadowed-set only matters for struct-shape fields.)
+- `delete o.x; o.x = undefined` (re-add with `undefined`): the value goes to the
+  sidecar as `undefined`; `"x" in o` true (HasProperty is value-independent), `o.x`
+  reads `undefined`, x enumerates at end. ✓
+- Untouched native fields still read through `__extern_get` correctly in
+  delete-modules (verified `o.b → 2`), so routing writes to the sidecar does not
+  desync reads.
+
+### Validating tests (test262)
+- `test/language/statements/for-in/order-simple-object.js` (`['0','1','2','p2','p4','p1']`)
+- `test/language/statements/for-in/order-after-define-property.js`
+- `test/language/statements/for-in/order-property-on-prototype.js`
+- `test/language/statements/for-in/S12.6.4_A6.js`
+- `test/language/statements/for-in/S12.6.4_A6.1.js`
+- All five need BOTH the #1830 integer-key fix (landed) AND this PR.
+- Local equivalence probes (host mode) — must pass after the fix:
+  - repro 1 for-in `"y,x,"`; repro 2 `"a" in o === true`, `o.a === 9`.
+- **Validate on the full `merge_group` floor** (broad host-mode object-model
+  surface): the read-gate sibling (#2179) and the `__object_keys` family are the
+  regression-prone neighbours.


### PR DESCRIPTION
Architect implementation specs for two blocked substrate issues gating the for-in / descriptor-correctness residuals. **Docs-only — `plan/` issue files; no source/test changes.**

## #2731 — delete+re-add tombstone disconnect

Root cause **re-verified on origin/main** (the issue's framing was imprecise):
- The receiver is a **shape-inferred nominal anon struct**, not a `$Object` open-hashmap. There is no `src/codegen-linear/object-runtime.ts`.
- The real defect is a `moduleUsesDelete` read/write **asymmetry**: `any`-receiver READS route through the tombstone-aware host `__extern_get` (`tryEmitDeleteAwareDynamicGet`), but WRITES stay native `struct.set`, bypassing `_safeSet`'s tombstone clear (`runtime.ts:4247`).
- Verified buggy outputs: repro1 for-in `"y,"` (want `"y,x,"`), repro2 `"a" in o` false, `o.a` NaN.

Spec: **PART 1** symmetric tombstone-aware write routing (`tryEmitDeleteAwareDynamicSet` -> `__extern_set_strict`); **PART 2** `_wasmStructShadowedFields` + `__for_in_keys` struct-loop skip so a deleted-then-readded field enumerates at insertion-order **END**. Host-mode scoped; standalone is a separate native-tombstone sub-case.

## #2680 — ToPropertyDescriptor drops proto-inherited attributes

The prior finding (sd-2668c) **missed the existing #1712 `_fnctorInstanceCtor` instance->ctor link** — it concluded a new representation was needed. It is not. Two actual gaps:
- **GAP A**: the descriptor reader `getField`/`hasField` never consult the proto chain.
- **GAP B**: `_fnctorProtoLookup` walks ancestors with native `Object.getOwnPropertyDescriptor`, which can't read a **wasmGC-struct** proto's sidecar attribute.

Spec: route the proto walk through the wasmGC-aware `_readOwnDescriptor` and call it from the two readers' own-level miss. No new representation, no codegen, no #2580 dependency for the host cluster (~29 `15.2.3.6-3-*` tests). #1629-safe.

Both specs flag full `merge_group`-floor validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)