### PR TITLE
fix(#2731): symmetric delete-aware property write routing (delete+re-add re-appears in for-in)

### DIFF
--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -35,6 +35,7 @@ import {
   emitNullGuardedStructGet,
   isProvablyNonNull,
   isSafeBoundsEliminated,
+  tryEmitDeleteAwareDynamicSet,
   typeErrorThrowInstrs,
 } from "../property-access.js";
 import type { InnerResult } from "../shared.js";
@@ -2690,6 +2691,21 @@ function compilePropertyAssignment(
       if (!ctx.fast) fctx.body.push({ op: "f64.convert_i32_s" });
       return ctx.fast ? { kind: "i32" } : { kind: "f64" };
     }
+  }
+
+  // (#2731) Symmetric tombstone-aware WRITE routing. In a `delete`-using module,
+  // any-receiver READS already route through the tombstone-aware host
+  // `__extern_get` (`tryEmitDeleteAwareDynamicGet`); the WRITE must match. Without
+  // this, `o.x = 9` after `delete o.x` takes the native `struct.set` fast-path
+  // below (`resolveStructNameForExpr` resolves the shape-inferred anon struct),
+  // bypassing `_safeSet`'s tombstone-clear — so the re-added key stays suppressed
+  // in `__extern_get` / `__for_in_*` / `__object_keys`. Runs BEFORE the
+  // struct-name resolution so the native struct.set is skipped for `any`
+  // receivers; concrete-typed receivers and reserved/callable props decline.
+  {
+    const dynPropName = ts.isPrivateIdentifier(target.name) ? "__priv_" + target.name.text.slice(1) : target.name.text;
+    const dynSet = tryEmitDeleteAwareDynamicSet(ctx, fctx, target, value, objType, dynPropName);
+    if (dynSet !== undefined) return dynSet;
   }
 
   const typeName = resolveStructNameForExpr(ctx, fctx, target.expression);

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -2198,6 +2198,107 @@ function tryEmitDeleteAwareDynamicGet(
 }
 
 /**
+ * (#2731) Symmetric mirror of `tryEmitDeleteAwareDynamicGet` for the WRITE side.
+ *
+ * In a module that contains a member-`delete`, `ctx.moduleUsesDelete` routes
+ * `any`/`unknown`-receiver property READS through the tombstone-aware host
+ * `__extern_get` (above). The corresponding WRITE had no symmetric gate, so
+ * `o.x = 9` still took the native `struct.set` fast-path
+ * (`emitAlternateStructSetDispatch`), which **bypasses `_safeSet`** — the host
+ * function where the delete-tombstone (`_wasmStructDeletedKeys`) is cleared on
+ * re-assignment (`runtime.ts`). Result: `delete o.x; o.x = 9` left the tombstone
+ * set, so every tombstone-consulting reader (`__extern_get`, `__for_in_has`,
+ * `_wasmStructHasOwn`, `__object_keys`) suppressed the re-added key
+ * (`o.x === undefined`, `"x" in o === false`, for-in dropped `x`).
+ *
+ * This reroutes the `any`-receiver write through the strict host setter
+ * `__extern_set_strict` → `_safeSet`, which clears the tombstone, writes the
+ * sidecar, AND mirrors the native field via `__sset_<key>` — so read/write stay
+ * symmetric. Returns the assignment-result type when handled, else `undefined`
+ * (caller falls through to the native struct-set dispatch). Gated identically to
+ * the read side: `moduleUsesDelete && !standalone`, `any`/`unknown` receiver,
+ * non-reserved-accessor, non-callable property. Delete-free modules are
+ * untouched (`moduleUsesDelete` false → byte-identical).
+ */
+export function tryEmitDeleteAwareDynamicSet(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  target: ts.PropertyAccessExpression,
+  value: ts.Expression,
+  objType: ts.Type,
+  propName: string,
+): ValType | undefined {
+  if (!ctx.moduleUsesDelete || ctx.standalone) return undefined;
+  // The receiver must be a shape-inferred dynamic struct that `delete` can
+  // tombstone: `any`/`unknown` (the read side's case) OR a shape-inferred
+  // ANONYMOUS object/type literal (`var o = { … }` / `(o: { a: T })`). The
+  // actual test262 cases use the latter — a concrete inferred object-literal
+  // type (`SymbolFlags.ObjectLiteral`), NOT `any` — and its native `struct.set`
+  // re-add leaves the delete-tombstone set so for-in's per-visit `__for_in_has`
+  // drops the re-added key. EXCLUDE class instances (`SymbolFlags.Class`),
+  // arrays, and named interfaces — those are not the deleted-then-readded
+  // dynamic-object shape and keep their fast native writes.
+  const isAnyOrUnknown = (objType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
+  const sym = objType.getSymbol();
+  const isAnonObjectLiteral = !!(sym && sym.flags & (ts.SymbolFlags.ObjectLiteral | ts.SymbolFlags.TypeLiteral));
+  if (!isAnyOrUnknown && !isAnonObjectLiteral) return undefined;
+  if (
+    propName === "length" ||
+    propName === "constructor" ||
+    propName === "__proto__" ||
+    propName === "prototype" ||
+    propName === "name"
+  ) {
+    return undefined;
+  }
+  // A method/function-typed write keeps its closure/funcref lowering.
+  const accessType = ctx.checker.getTypeAtLocation(target);
+  if (accessType.getCallSignatures && accessType.getCallSignatures().length > 0) return undefined;
+
+  const setIdx = ensureLateImport(
+    ctx,
+    "__extern_set_strict",
+    [{ kind: "externref" }, { kind: "externref" }, { kind: "externref" }],
+    [],
+  );
+  flushLateImportShifts(ctx, fctx);
+  if (setIdx === undefined) return undefined;
+
+  // Evaluate the receiver (spec order: reference before value), coerce to externref.
+  const objResult = compileExpression(ctx, fctx, target.expression);
+  if (objResult && objResult.kind !== "externref") {
+    coerceType(ctx, fctx, objResult, { kind: "externref" });
+  } else if (!objResult) {
+    fctx.body.push({ op: "ref.null.extern" } as Instr);
+  }
+  const objLocal = allocLocal(fctx, `__daset_obj_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: objLocal });
+
+  // Evaluate the value, coerce/box to externref.
+  const valResult = compileExpression(ctx, fctx, value);
+  if (valResult && valResult.kind !== "externref") {
+    coerceType(ctx, fctx, valResult, { kind: "externref" });
+  } else if (!valResult) {
+    fctx.body.push({ op: "ref.null.extern" } as Instr);
+  }
+  const valLocal = allocLocal(fctx, `__daset_val_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: valLocal });
+
+  // __extern_set_strict(obj, "prop", val) → _safeSet (clears tombstone, writes
+  // sidecar, mirrors __sset_<key>). Bare call — NOT the struct.set dispatcher,
+  // whose native arm is exactly what bypassed _safeSet.
+  fctx.body.push({ op: "local.get", index: objLocal });
+  addStringConstantGlobal(ctx, propName);
+  fctx.body.push(...stringConstantExternrefInstrs(ctx, propName));
+  fctx.body.push({ op: "local.get", index: valLocal });
+  fctx.body.push({ op: "call", funcIdx: setIdx } as Instr);
+
+  // `=` evaluates to the assigned value.
+  fctx.body.push({ op: "local.get", index: valLocal });
+  return { kind: "externref" };
+}
+
+/**
  * (#2026 PR-2) `.constructor` identity on an externref / `any`-typed instance.
  *
  * The static arm (`compileInstanceMember`, gated on `ctx.classSet.has(typeName)`)

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -571,6 +571,19 @@ function _getAsyncGeneratorFunctionPrototype(): any {
 const _wasmStructDeletedKeys = new WeakMap<object, Set<string | symbol>>();
 
 /**
+ * (#2731) Struct-shape fields that were DELETED then RE-ADDED, so their live
+ * value now lives in the sidecar (insertion-ordered) and they must be enumerated
+ * from the sidecar at insertion-order END — NOT from their fixed struct-shape
+ * slot. Set in `_safeSet` when a re-assignment clears a tombstone on a key that
+ * is a struct-shape field; consulted by `__for_in_keys` (and the `__object_*`
+ * key collectors) to skip the struct-slot emission so the sidecar loop supplies
+ * the field at the correct (end) position. A plain re-assignment of a
+ * never-deleted field is NOT marked (it keeps its struct position), and a
+ * dynamic sidecar-only key needs no marker (it already orders via the sidecar).
+ */
+const _wasmStructShadowedFields = new WeakMap<object, Set<string>>();
+
+/**
  * Sidecar property descriptor store for WasmGC structs.
  *
  * Stores property descriptor flags per property on WasmGC structs, enabling
@@ -4244,7 +4257,24 @@ function _safeSet(
   // that bypass the sidecar (A3).
   if (_isWasmStruct(obj)) {
     const tomb = _wasmStructDeletedKeys.get(obj);
-    if (tomb) tomb.delete(typeof key === "symbol" ? key : String(key));
+    const k = typeof key === "symbol" ? key : String(key);
+    // (#2731) Before clearing the tombstone, note whether THIS write is the
+    // re-add of a deleted STRUCT-SHAPE field. If so, mark it shadowed: its live
+    // value now lives in the sidecar (re-inserted below at the end) and it must
+    // enumerate from there, not its fixed struct slot, so the for-in / Object.*
+    // collectors place it at insertion-order END (§ EnumerateObjectProperties).
+    if (typeof k === "string" && !!tomb && tomb.has(k)) {
+      const exportsForShape = exports ?? callbackState?.getExports();
+      if (_getStructFieldNames(obj, exportsForShape)?.includes(k)) {
+        let shadowed = _wasmStructShadowedFields.get(obj);
+        if (!shadowed) {
+          shadowed = new Set<string>();
+          _wasmStructShadowedFields.set(obj, shadowed);
+        }
+        shadowed.add(k);
+      }
+    }
+    if (tomb) tomb.delete(k);
   }
   // (#2706 / #1830) Mirror of the `_safeGet` fix above. A genuine integer-index
   // assignment (`o[5] = 55`) on a WasmGC struct is NOT a well-known-symbol write.
@@ -10729,7 +10759,13 @@ assert._isSameValue = isSameValue;
               // collect this level's keys first, order, then push.
               const levelKeys: string[] = [];
               const fieldNames = _getStructFieldNames(current, exports) ?? [];
+              // (#2731) A deleted-then-re-added struct-shape field is emitted from
+              // the sidecar below (insertion-order END), not its fixed struct
+              // slot. Skip it here so it isn't enumerated twice / at the wrong
+              // position.
+              const shadowedFields = _wasmStructShadowedFields.get(current);
               for (const k of fieldNames) {
+                if (shadowedFields && shadowedFields.has(k)) continue;
                 if (!seen.has(k) && !levelKeys.includes(k)) levelKeys.push(k);
               }
               // Also include enumerable sidecar properties

--- a/tests/issue-2731.test.ts
+++ b/tests/issue-2731.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+import { buildImports } from "../src/runtime.ts";
+
+// #2731 — delete + re-add read/write asymmetry (HOST mode).
+//
+// In a module that uses `delete`, any/anon-object-literal-receiver property
+// READS already route through the tombstone-aware host `__extern_get`, but the
+// matching WRITE took the native `struct.set` fast-path, bypassing `_safeSet`'s
+// tombstone-clear. So `delete o.x; o.x = 9` left `_wasmStructDeletedKeys`'s
+// tombstone set, and every tombstone-consulting reader suppressed the re-added
+// key (`o.x === undefined`, `"x" in o === false`, for-in dropped `x`).
+//
+// Fix: `tryEmitDeleteAwareDynamicSet` reroutes the write through
+// `__extern_set_strict` → `_safeSet` (clears the tombstone, mirrors the native
+// field, re-inserts the sidecar), and `_wasmStructShadowedFields` makes the
+// re-added struct-shape field enumerate at insertion-order END.
+async function runHost(src: string): Promise<unknown> {
+  const r = await compile(src, { fileName: "test.ts", skipSemanticDiagnostics: true } as never);
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  const imp = buildImports(r.imports, undefined, r.stringPool) as Record<string, unknown> & {
+    setExports?: (e: unknown) => void;
+  };
+  const { instance } = await WebAssembly.instantiate(r.binary, imp);
+  if (typeof imp.setExports === "function") imp.setExports(instance.exports);
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#2731 for-in delete+re-add read/write symmetry", () => {
+  it("concrete `var o = {…}`: re-added field enumerates at insertion-order END", async () => {
+    expect(
+      await runHost(`export function test(): string {
+  var o = { a: 1, b: 2, c: 3 };
+  delete o.a; delete o.c; o.a = 9;
+  var s = ""; for (var k in o) s += k + ",";
+  return s;
+}`),
+    ).toBe("b,a,");
+  });
+
+  it("any `o.x` re-add: value + presence + for-in all recover", async () => {
+    expect(
+      await runHost(`export function test(): string {
+  var o: any = { x: 1, y: 2 };
+  delete o.x; o.x = 9;
+  var s = ""; for (var k in o) s += k + ",";
+  return "for=" + s + " val=" + o.x + " in=" + ("x" in o);
+}`),
+    ).toBe("for=y,x, val=9 in=true");
+  });
+
+  it("order-simple-object (test262): integer keys ascending, then insertion order, re-added last", async () => {
+    expect(
+      await runHost(`export function test(): string {
+  var o: any = { p1: 'p1', p2: 'p2', p3: 'p3' };
+  o.p4 = 'p4'; o[2] = '2'; o[0] = '0'; o[1] = '1';
+  delete o.p1; delete o.p3; o.p1 = 'p1';
+  var keys: any[] = []; for (var key in o) { keys.push(key); }
+  return keys.join(',');
+}`),
+    ).toBe("0,1,2,p2,p4,p1");
+  });
+
+  it("plain re-assign of a never-deleted field keeps its struct position (no shadow)", async () => {
+    expect(
+      await runHost(`export function test(): string {
+  var o = { a: 1, b: 2 };
+  o.a = 9; // never deleted — must stay first
+  var s = ""; for (var k in o) s += k + ",";
+  return s;
+}`),
+    ).toBe("a,b,");
+  });
+
+  it("delete WITHOUT re-add still removes the key from for-in", async () => {
+    expect(
+      await runHost(`export function test(): string {
+  var o = { a: 1, b: 2 };
+  delete o.a;
+  var s = ""; for (var k in o) s += k + ",";
+  return s;
+}`),
+    ).toBe("b,");
+  });
+});


### PR DESCRIPTION
Implements the architect's #2731 spec (open #2167): the read/write **asymmetry** behind `delete o.x; o.x = 9` never re-appearing.

## Root cause (verified)
In a `delete`-using module, any/anon-object-receiver property READS route through the tombstone-aware host `__extern_get` (`tryEmitDeleteAwareDynamicGet`), but the matching WRITE took the native `struct.set` fast-path (`emitAlternateStructSetDispatch`), **bypassing `_safeSet`** where the delete-tombstone (`_wasmStructDeletedKeys`) is cleared. So a native re-add left the tombstone set and every tombstone-consulting reader (`__extern_get` / `__for_in_has` / `_wasmStructHasOwn`) suppressed the re-added key.

## Fix — two parts (HOST mode; standalone out of scope per spec)
**PART 1 (codegen).** New `tryEmitDeleteAwareDynamicSet` mirrors the read-side gate — reroutes the write through `__extern_set_strict` → `_safeSet` (clears the tombstone, mirrors the native field via `__sset_<key>`, re-inserts the sidecar). No new host import.

**PART 2 (runtime).** `_wasmStructShadowedFields` marks a deleted-then-re-added struct-shape field so `__for_in_keys` skips its fixed struct slot and the sidecar loop emits it at insertion-order **END** (`order-simple-object` → `0,1,2,p2,p4,p1`).

## Deviation from spec (gate widening) — needs architect awareness
The spec gated on `any`/`unknown` (verified there). But the actual test262 cases use **concrete** `var o = { … }` (shape-inferred object literals, `SymbolFlags.ObjectLiteral`), not `any` — for which value/presence already work natively and only for-in breaks. I widened the gate to `ObjectLiteral | TypeLiteral` (still excluding class instances / arrays / reserved accessors / callables) so the concrete case is covered.

## Scope correction
Of the 5 tests the spec listed, **only `order-simple-object` is a delete/re-add bug** (now PASS). The other 4 are a DIFFERENT bug class — prototype-chain / `defineProperty` for-in enumeration (the original #2706 scope), not delete/re-add:
- `order-property-on-prototype`, `S12.6.4_A6`, `S12.6.4_A6.1` — `setPrototypeOf` / constructor-`prototype` chain not enumerated by for-in.
- `order-after-define-property` — `Object.defineProperty` ordering.

This fix cannot close those; they need a separate prototype/defineProperty-enumeration issue.

## Validation (host mode, same-worktree with/without isolation)
- `statements/for-in` + annexB (122): **104 → 105 (+1 `order-simple-object`), ZERO regressions**
- Broad sweep (150: delete / property-accessors / object / assignment / defineProperty / Object.keys / Object.assign / getOwnPropertyNames / Reflect / for-of / for-in): **90 → 90, ZERO deltas**
- `tests/issue-2731.test.ts` (5) + `tests/issue-1830.test.ts` (3) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)