### PR TITLE
docs(#2739): file for-in prototype/defineProperty enumeration follow-up; re-scope #2706

### DIFF
--- a/plan/issues/2706-for-in-enumeration-order-and-prototype-keys.md
+++ b/plan/issues/2706-for-in-enumeration-order-and-prototype-keys.md
@@ -6,7 +6,7 @@ assignee: ttraenkler/Esch
 sprint: 67
 goal: test262-conformance
 feasibility: medium
-depends_on: [2731]
+depends_on: [2739]
 priority: medium
 es_edition: ES5
 language_feature: for-in
@@ -54,6 +54,21 @@ Standalone mode must also implement this without relying on JS engine for-in ord
 ## Acceptance criteria
 
 All 5 listed tests flip from fail to pass. No regression in `statements/for-in/` currently-passing tests. Full CI green.
+
+## Split status (esch, 2026-06-27) — three independent halves, two landed
+
+This issue's scope decomposed into three independent bug classes; two are landed
+and the remaining blocker is now #2739:
+
+| Half | Tests | Status |
+|------|-------|--------|
+| Integer-index keys ascending (#1830) | (integer-key mis-routing) | **landed** — PR #2160 |
+| Insertion-order + delete/re-add (#2731) | `order-simple-object` | **landed** — PR #2170 |
+| Prototype-chain (`setPrototypeOf`/constructor) + `defineProperty` ordering (**#2739**) | `order-property-on-prototype`, `S12.6.4_A6`, `S12.6.4_A6.1`, `order-after-define-property` | **open** — `depends_on: [2739]` |
+
+So this issue is now blocked solely on **#2739** (prototype/defineProperty for-in
+enumeration). Re-point the acceptance to those 4 prototype/defineProperty tests
+once #2739 lands.
 
 ## Notes
 

--- a/plan/issues/2739-forin-prototype-chain-defineproperty-enumeration.md
+++ b/plan/issues/2739-forin-prototype-chain-defineproperty-enumeration.md
@@ -1,0 +1,98 @@
+---
+id: 2739
+title: "for-in does not enumerate setPrototypeOf / constructor-prototype-chain properties; Object.defineProperty ordering"
+status: ready
+sprint: Backlog
+goal: test262-conformance
+feasibility: hard
+depends_on: []
+priority: high
+es_edition: ES5
+language_feature: for-in
+task_type: bug
+created: 2026-06-27
+updated: 2026-06-27
+---
+# #2739 — for-in prototype-chain + defineProperty enumeration
+
+## Problem
+
+`for-in` over a shape-inferred struct does **not** enumerate properties reached
+through a runtime prototype link, and `Object.defineProperty` perturbs creation
+order. Split out of #2706/#2731 — these are NOT the delete/re-add asymmetry (that
+is #2731, landed via PR #2170); they are a distinct prototype/defineProperty
+enumeration bug class. Verified (host mode, current main):
+
+**(a) `Object.setPrototypeOf` chain not walked.**
+
+```ts
+var proto = { p4: 'p4' };
+var o = { p1: 'p1', p2: 'p2', p3: 'p3' };
+Object.setPrototypeOf(o, proto);
+for (var k in o) …          // yields "p1,p2,p3" — proto's "p4" is MISSING
+                            // (expected ['p1','p2','p3','p4'])
+```
+
+**(b) Constructor-function `prototype` chain not walked, with own-shadows-proto.**
+
+```ts
+function FACTORY(){ this.prop = 1; this.hint = "hinted"; }
+FACTORY.prototype = { feat: 2, hint: "protohint" };
+var __instance = new FACTORY;
+for (key in __instance) …   // must visit own prop/hint AND inherited feat,
+                            // with own hint shadowing proto hint; currently
+                            // throws / drops inherited keys
+```
+
+**(c) `Object.defineProperty` must not reorder creation order.**
+
+```ts
+var obj = {}; obj.a = 1; obj.b = 2;
+Object.defineProperty(obj, "a", { value: 11 });
+for (var k in obj) …        // must stay ["a","b"] (define does not re-create)
+```
+
+Spec: §13.7.5.15 EnumerateObjectProperties — after own keys (OrdinaryOwnPropertyKeys
+order), walk `[[GetPrototypeOf]]` and visit each level's enumerable own keys,
+skipping any already-visited (shadowed) key.
+
+## Failing tests (test262 baseline)
+
+```
+test/language/statements/for-in/order-property-on-prototype.js   (a)
+test/language/statements/for-in/S12.6.4_A6.js                    (b)
+test/language/statements/for-in/S12.6.4_A6.1.js                  (b)
+test/language/statements/for-in/order-after-define-property.js   (c)
+```
+
+## Root cause (suspected) — for the architect
+
+`__for_in_keys` (`src/runtime.ts`) already has a manual prototype-chain walk
+(`Object.getPrototypeOf(current)`), but for a shape-inferred WasmGC struct:
+- `Object.setPrototypeOf(struct, proto)` likely sets a host-side proto link that
+  `Object.getPrototypeOf(struct)` in the walk does NOT observe (the struct's
+  native `[[Prototype]]` is not the user `proto`), so the proto level is never
+  visited.
+- A constructor-function (`function FACTORY(){…}; FACTORY.prototype = {…};
+  new FACTORY`) builds an instance whose prototype is the function's `.prototype`
+  object — the runtime must link the instance to that prototype object so the
+  for-in walk reaches `feat`, with `hint` shadowing.
+- `defineProperty` ordering: `__object_keys`/`__for_in_keys` must treat a
+  `defineProperty` on an EXISTING key as not re-creating it (no reorder).
+
+This needs a coherent prototype-link model for shape-inferred structs +
+`Object.getPrototypeOf` consistency in the for-in walk — architect-scope, and a
+sibling of #2706's remaining "prototype-chain dedup" goal.
+
+## Acceptance criteria
+
+The 4 tests above flip fail→pass. No regression in `statements/for-in/`. Host
+mode (the standalone prototype-link model is a separate sub-case). Full CI green.
+
+## Notes
+
+- Split from #2706 / #2731 (esch, 2026-06-27). #2731 (PR #2170) closed only
+  `order-simple-object` (the delete/re-add half); #1830 (PR #2160) closed the
+  integer-index half. These 4 are the remaining prototype/defineProperty half.
+- Route to **architect** for a prototype-link spec. Overlaps #2706's
+  "prototype-chain dedup" scope and the #2580/#2660 substrate.


### PR DESCRIPTION
Files the follow-up issue **#2739** for the 4 for-in tests that are NOT delete/re-add (split out during #2731 / PR #2170 work), and re-scopes #2706.

## #2739 (new) — for-in prototype-chain + defineProperty enumeration
- `order-property-on-prototype` — `Object.setPrototypeOf(o, proto)` chain not enumerated (for-in yields `p1,p2,p3`, missing proto `p4`).
- `S12.6.4_A6` / `S12.6.4_A6.1` — constructor-function `prototype` chain not enumerated (own shadows proto).
- `order-after-define-property` — `Object.defineProperty` must not reorder creation order.

These are a prototype-link / defineProperty enumeration bug class, distinct from #2731's delete/re-add asymmetry. `feasibility: hard`, routed to architect, links #2706/#2580/#2660.

## #2706 re-scope
`depends_on` retargeted `[2731] → [2739]` — its three halves: integer-index keys (#1830, landed PR #2160), insertion-order + delete/re-add (#2731, PR #2170), and the remaining prototype/defineProperty half (#2739).

Docs-only; does not touch `plan/issues/2731-*.md` (architect owns via #2167).

🤖 Generated with [Claude Code](https://claude.com/claude-code)