### PR TITLE
fix(#2628): method call on a __construct_closure-built instance (new this().m())

### DIFF
--- a/plan/issues/2628-acorn-method-call-on-construct-closure-result.md
+++ b/plan/issues/2628-acorn-method-call-on-construct-closure-result.md
@@ -1,8 +1,10 @@
 ---
 id: 2628
 title: "compiled-acorn: method call on a __construct_closure-constructed instance fails (5th dogfood blocker)"
-status: ready
-sprint: Backlog
+status: done
+sprint: 67
+completed: 2026-06-27
+assignee: ttraenkler/dev-acorn-construct
 created: 2026-06-22
 priority: high
 feasibility: medium
@@ -127,3 +129,57 @@ framing **for the acorn dogfood path**:
 NOT dispatch #2628 as a standalone acorn blocker; the dogfood lap is unblocked,
 and the host-facing identity fix rides #2623-B. Re-probe the next acorn wall
 after #2623-B lands.
+
+## Resolution (dev-acorn-construct, 2026-06-27) — the IN-WASM path WAS broken on current main
+
+The 2026-06-22 re-grounding above is **STALE / refuted by a verify-first probe on
+current `origin/main` (`d52cca0c9`)**. The exact in-wasm chained shape the note
+claimed "returns 5 ✓" actually **throws**:
+
+```
+new this({}, input).getLen()  chained IN-WASM  →  THREW "getLen is not a function"
+new Parser({}, input).getLen() chained IN-WASM  →  5 ✓
+```
+
+So #2628 was a real, live, in-wasm dispatch defect — exactly as the original
+symptom stated. (The intervening sibling PRs must have moved the path since the
+note was written; re-grounding must always re-probe current main, per
+`feedback_reground_spec_against_current_main`.)
+
+### Root cause
+The `__construct_closure` host bridge constructs the instance in the
+`_wrapCallableForHost` **`construct` trap** (`runtime.ts`), which built a **bare
+`self = {}`** — no `[[Prototype]]` link to the constructor closure's vivified
+prototype, and no `_fnctorInstanceCtor` registration. A subsequent `p.m()`
+routes through `__extern_method_call`, where the native `wrappedObj[method]` read
+misses (the bare object has only own data fields) and the only fallback branch
+required `_isWasmStruct(obj)` — false for the plain bridge object — so it threw.
+By contrast `new Parser(...)` returns the raw WasmGC struct via `<Class>_new`,
+whose method dispatch resolves through the registered fnctor machinery (#1712).
+
+### Fix (two edits, `src/runtime.ts`, JS-host glue only)
+1. **`construct` trap**: build the instance with
+   `Object.create(_getOrVivifyFnPrototype(closure))` and register it via
+   `_fnctorInstanceCtor.set(self, closure)` (also link a body-returned distinct
+   object). Mirrors the identifier-constructed instance's prototype link.
+2. **`__extern_method_call`**: when the native method read misses, consult
+   `_fnctorProtoLookup(obj, method)` (works for any registered instance, struct
+   or plain object), wrap the raw-struct method value into a callable, and
+   dispatch with the instance as `this`.
+
+Standalone/`noJsHost` is unaffected — the #2608 `new this` arm and this bridge
+are JS-host-only; the standalone path keeps its existing behavior.
+
+### Test Results (`tests/issue-2628.test.ts`, all pass)
+- `new this({}, "hello").getLen()` (acorn parse shape) → **5** ✓ (was: THREW)
+- `new Parser({}, "hello").getLen()` (no regression) → **5** ✓
+- method calling another prototype method via `this` (`twice → this.getLen()*2`) → **10** ✓
+
+Adjacent regression sweep (all green): issue-1528-closure-construct, issue-1632a,
+issue-2608-new-this-fnctor-static, issue-1712(+dynamic-dispatch),
+issue-2637-b2-ctor-closure-registration, fn-constructor,
+issue-2026-constructor-identity-any, issue-28-promise-executor-invocation,
+issue-2623-promise-subclass-identity, issue-1772-capability-map-extend,
+issue-2660-s2/s3, wrapper-constructors. The 2 `promise-combinators` "with
+resolved values" failures are **pre-existing on `origin/main`** (verified on a
+clean checkout) — `_toIterable(arr)` argument shape, unrelated to this change.

--- a/plan/issues/sprints/67.md
+++ b/plan/issues/sprints/67.md
@@ -90,7 +90,6 @@ _Generated from issue files. Update issue `status`, then rerun `node scripts/syn
 
 | Issue | Title | Priority | Status |
 |---|---|---|---|
-| #1642 | spec gap: for-of IteratorClose — RE-SCOPED to the residual 8 (return-method representation + generator-close) | medium | blocked |
 | #1916 | Symbolic function references in WasmGC codegen — retire the late-import index-shift machinery | high | blocked |
 | #1930 | TypeOracle — one type-query boundary between the TS checker and codegen (unblocks TS7, kills suppression heuristics) | high | blocked |
 | #1985 | stale-proof index cells: shift-walker-updated { idx } handles for captured func indices (#2043 Option 2b, incremental) | medium | blocked |
@@ -110,12 +109,13 @@ _Generated from issue files. Update issue `status`, then rerun `node scripts/syn
 | #2618 | Proxy (host): calling / constructing a Proxy whose target is callable traps (illegal cast) or ignores the construct trap result (~15 fails) | medium | blocked |
 | #2651 | standalone: builtin constructor + prototype as a first-class VALUE (TypedArray ctor-iteration substrate) | high | blocked |
 | #2694 | acorn parse() 11th wall — Scope.flags read loop (local-receiver slot/sidecar asymmetry, needs #2660) | medium | blocked |
+| #2706 | for-in enumeration order: integer-index keys ascending, insertion-order strings, prototype-chain dedup | medium | blocked |
+| #2722 | Nested OPTIONAL object-field binding default not firing — Path A INVALIDATED, needs substrate re-spec | medium | blocked |
 
 ### Ready
 
 | Issue | Title | Priority | Status |
 |---|---|---|---|
-| #1846 | Minor typeof conformance: i64->'number' in with-bindings; externref->null fallthrough | low | ready |
 | #2181 | defineBuiltin(name, {elementKinds, lower}) scaffold — unify per-representation element-load/ToString/null handling | medium | ready |
 | #2669 | ES2015: destructuring correctness residual umbrella (~696 fails — iterator-close, defaults, holes, rest across for-of/assignment/binding/params) | high | ready |
 | #2671 | ES2015 builtin/feature spec residuals: Date, RegExp, Promise, JSON, super (~400 fails — tracking, slice per area) | medium | ready |
@@ -123,22 +123,10 @@ _Generated from issue files. Update issue `status`, then rerun `node scripts/syn
 | #2681 | acorn parse() 10th wall — identifier expression-statement throws (unexpected() on a `name` token) after the #2664 arity-dispatch fix | high | ready |
 | #2686 | acorn parse() — binary-expression statement throws (parse(\"1 + 2 * 3;\") → WebAssembly.Exception) | medium | ready |
 | #2687 | acorn parse() — ExpressionStatement.expression is null (parsed Literal not attached to the statement node) | medium | ready |
-| #2702 | instanceof spec correctness: non-object RHS TypeError, Symbol.hasInstance protocol, null-deref edge cases | medium | ready |
-| #2703 | delete reference semantics: strict-mode TypeError throws, null/undefined base TypeError, super-property ReferenceError | medium | ready |
-| #2704 | arguments.length off-by-N with trailing comma in async-gen/static methods; sloppy-mode arguments binding missing | high | ready |
-| #2705 | for-in: head let/const TDZ, lexical scope open/close, LHS non-simple targets, var-head visibility | high | ready |
-| #2706 | for-in enumeration order: integer-index keys ascending, insertion-order strings, prototype-chain dedup | medium | ready |
 | #2707 | operators: unary +/-/~/>>> null-deref on null/undefined; strict-equals # edge; TCO in ?:/&&/\|\| | medium | ready |
-| #2708 | primitive & literal edge cases: legacy string escapes \\8/\\9/octal, regexp \\u atoms, PutValue primitive-base auto-box | medium | ready |
 | #2712 | Introduce a real bool ValType; retire the optional i32 boolean brand | high | ready |
-| #2715 | Linear backend: trapping i32.trunc_f64_s in bitwise ops + typed-array stores → use trunc_sat / ToInt32 wrap | high | ready |
-| #2716 | Linear backend: try/finally with early return/break inlines past the finally block | medium | ready |
-| #2717 | Array flat/flatMap are host-import-only — no standalone native arm, no ctx.standalone guard | high | ready |
-| #2719 | Array indexOf/includes/lastIndexOf on externref elements emit __host_eq/__same_value_zero with no standalone branch | medium | ready |
 | #2720 | Standalone regex: /i is ASCII-only case-fold; /u and /v match per-code-unit not per-code-point | medium | ready |
-| #2721 | Standalone JSON: booleans/null box as numbers; JSON.parse accepts malformed number/\\uXXXX grammar | medium | ready |
-| #2722 | Nested OPTIONAL object-field binding default not firing — externref field + f64 struct-getter can't signal field-absent | medium | ready |
-| #2724 | Object-literal get/set accessor representation: accessor-bearing literal types mis-register as closed structs (unblocks #1642) | high | ready |
+| #2726 | delete residual: sloppy return-value semantics, hasOwnProperty-after-delete, accessor descriptor configurability, mapped-arguments delete | medium | ready |
 
 ### In Progress
 
@@ -162,5 +150,24 @@ _Generated from issue files. Update issue `status`, then rerun `node scripts/syn
 | #2670 | ES2015: Array.prototype iteration-method semantics residual (~1017 fails — generic array-like receiver, callback/thisArg, holes, length coercion) | high | in-progress |
 | #2674 | acorn parse() 9th wall PAST tokenization (after #2664 type-write fix) — parseTopLevel/parseStatement array-push loop | high | in-progress |
 | #2710 | Late-bind module indices (func/global/type) to eliminate the late-index-shift bug class | high | in-progress |
+
+### Done
+
+| Issue | Title | Priority | Status |
+|---|---|---|---|
+| #1642 | spec gap: for-of IteratorClose — RE-SCOPED to the residual 8 (return-method representation + generator-close) | medium | done |
+| #2628 | compiled-acorn: method call on a __construct_closure-constructed instance fails (5th dogfood blocker) | high | done |
+| #2702 | instanceof spec correctness: non-object RHS TypeError, Symbol.hasInstance protocol, null-deref edge cases | medium | done |
+| #2703 | delete reference semantics: strict-mode TypeError throws, null/undefined base TypeError, super-property ReferenceError | medium | done |
+| #2704 | arguments.length off-by-N with trailing comma in async-gen/static methods; sloppy-mode arguments binding missing | high | done |
+| #2705 | for-in: head let/const TDZ, lexical scope open/close, LHS non-simple targets, var-head visibility | high | done |
+| #2708 | primitive & literal edge cases: legacy string escapes \\8/\\9/octal, regexp \\u atoms, PutValue primitive-base auto-box | medium | done |
+| #2715 | Linear backend: trapping i32.trunc_f64_s in bitwise ops + typed-array stores → use trunc_sat / ToInt32 wrap | high | done |
+| #2716 | Linear backend: try/finally with early return/break inlines past the finally block | medium | done |
+| #2717 | Array flat/flatMap are host-import-only — no standalone native arm, no ctx.standalone guard | high | done |
+| #2719 | Array indexOf/includes/lastIndexOf on externref elements emit __host_eq/__same_value_zero with no standalone branch | medium | done |
+| #2721 | Standalone JSON: JSON.parse accepts malformed number grammar (booleans/null typeof split to #2733) | medium | done |
+| #2724 | Object-literal get/set accessor representation: accessor-bearing literal types mis-register as closed structs (unblocks #1642) | high | done |
+| #2734 | Standalone Array indexOf/includes/lastIndexOf lose object identity (regression from #2719) | high | done |
 
 <!-- GENERATED_ISSUE_TABLES_END -->

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -5316,9 +5316,29 @@ function _wrapCallableForHost(
       if (typeof wrapped !== "function") {
         throw new TypeError("compiled function is not a constructor (no __call_fn_* export)");
       }
-      const self: Record<string, any> = {};
+      // (#2628) Link the fresh instance to the constructor closure's vivified
+      // prototype so a subsequent prototype-method call resolves. Previously the
+      // instance was a bare `{}` with no `[[Prototype]]` and no
+      // `_fnctorInstanceCtor` entry, so `new this(...).m()` (acorn's
+      // `new this(opts,input).parse()`) routed through `__extern_method_call`,
+      // found no `m` on the bare object, and threw "m is not a function" — even
+      // though `new Parser(...).m()` (the raw-struct `<Class>_new` path) works.
+      // `Object.create(proto)` gives native prototype-chain reads; the
+      // `_fnctorInstanceCtor` registration lets `_fnctorProtoLookup` wrap the
+      // raw-struct method values into callables on dispatch (same machinery the
+      // identifier-constructed fnctor instance uses for in-wasm method calls).
+      const ctorProto = _getOrVivifyFnPrototype(closure, callbackState);
+      const self: Record<string, any> =
+        ctorProto != null && typeof ctorProto === "object" ? Object.create(ctorProto) : {};
+      if (_canBeWeakKey(self)) _fnctorInstanceCtor.set(self, closure);
       const r = wrapped.apply(self, args);
-      return r != null && typeof r === "object" ? r : self;
+      const inst = r != null && typeof r === "object" ? r : self;
+      // The body may `return {...}` a different object; link it too so method
+      // dispatch resolves on whichever instance escapes.
+      if (inst !== self && _canBeWeakKey(inst) && !_fnctorInstanceCtor.has(inst)) {
+        _fnctorInstanceCtor.set(inst, closure);
+      }
+      return inst;
     },
     // Property reads / writes / enumeration delegate to the standard
     // `_wrapForHost` proxy so `.prototype`, `.name`, static members, `has`,
@@ -9438,6 +9458,29 @@ assert._isSameValue = isSameValue;
               if (typeof resolved === "function") {
                 const ret = resolved.apply(obj, wrappedArgs);
                 return ret === obj || ret === wrappedObj ? obj : _unwrapForHost(ret);
+              }
+            }
+            // (#2628) Prototype method on a `__construct_closure`-built instance.
+            // The construct trap returns a PLAIN JS object (not a wasm struct)
+            // whose method values live on the constructor closure's vivified
+            // prototype as RAW closure structs (`Parser.prototype.m = fn`), so
+            // the native `wrappedObj[method]` read above yielded a non-callable
+            // raw struct. The trap registered the instance in
+            // `_fnctorInstanceCtor`, so resolve the method through
+            // `_fnctorProtoLookup` (which walks the vivified prototype chain),
+            // wrap it into a callable, and dispatch with the instance as `this`.
+            // This is what makes `new this(...).m()` resolve like the
+            // identifier-constructed `new Parser(...).m()` path does.
+            {
+              const protoDesc = _fnctorProtoLookup(obj, method);
+              if (protoDesc) {
+                const resolved = protoDesc.get
+                  ? protoDesc.get.call(obj)
+                  : _maybeWrapCallableUnknownArity(protoDesc.value, callbackState);
+                if (typeof resolved === "function") {
+                  const ret = resolved.apply(obj, wrappedArgs);
+                  return ret === obj ? obj : _unwrapForHost(ret);
+                }
               }
             }
             // (#1712) Array mutators on WasmGC vec structs. acorn mutates

--- a/tests/issue-2628.test.ts
+++ b/tests/issue-2628.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #2628 — method call on a `__construct_closure`-constructed instance.
+//
+// `new this(...)` inside a function-constructor (fnctor) static method routes
+// through the #56/#2608 `__construct_closure` host bridge, which returns a
+// host-built instance object. Before the fix that object was a bare `{}` with no
+// `[[Prototype]]` link and no `_fnctorInstanceCtor` registration, so a
+// subsequent prototype-method call on it (`new this(...).m()` — acorn's
+// `new this(options, input).parse()` shape) threw "m is not a function", even
+// though the identifier form `new Parser(...).m()` resolved.
+async function run(source: string, fn: string, args: unknown[] = []): Promise<unknown> {
+  const result = await compile(source);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, {}, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as { setExports?: (e: object) => void }).setExports?.(instance.exports as object);
+  return (instance.exports as any)[fn](...args);
+}
+
+const PARSER_SRC = `
+var Parser = function Parser(opts: any, input: any) {
+  this.input = String(input);
+};
+Parser.prototype.getLen = function () {
+  return this.input.length;
+};
+Parser.prototype.twice = function () {
+  return this.getLen() * 2;
+};
+
+Parser.parseViaThis = function (input: any): number {
+  var p: any = new this({}, input);
+  return p.getLen();
+};
+Parser.parseViaIdent = function (input: any): number {
+  var p: any = new Parser({}, input);
+  return p.getLen();
+};
+Parser.chainViaThis = function (input: any): number {
+  var p: any = new this({}, input);
+  return p.twice();
+};
+
+export function viaThis(): number { return Parser.parseViaThis("hello"); }
+export function viaIdent(): number { return Parser.parseViaIdent("hello"); }
+export function chainViaThis(): number { return Parser.chainViaThis("hello"); }
+`;
+
+describe("#2628 — method call on a __construct_closure-constructed instance", () => {
+  it("resolves a prototype method on a `new this(...)`-built instance (acorn parse shape)", async () => {
+    expect(await run(PARSER_SRC, "viaThis")).toBe(5);
+  });
+
+  it("still resolves on an identifier-constructed instance (no regression)", async () => {
+    expect(await run(PARSER_SRC, "viaIdent")).toBe(5);
+  });
+
+  it("resolves a method that itself calls another prototype method via `this`", async () => {
+    expect(await run(PARSER_SRC, "chainViaThis")).toBe(10);
+  });
+});


### PR DESCRIPTION
## #2628 — method call on a `__construct_closure`-built instance (acorn `new this(...).m()`)

`new this(...)` in a function-constructor (fnctor) static method — acorn's
`Parser.parse = function(input, options){ return new this(options, input).parse(); }`
— routes through the #56/#2608 `__construct_closure` host bridge. The bridge's
`_wrapCallableForHost` **construct trap** built a bare `self = {}` with no
`[[Prototype]]` link to the constructor closure's vivified prototype and no
`_fnctorInstanceCtor` registration. A subsequent prototype-method call (`p.m()`)
routes through `__extern_method_call`; the native `wrappedObj[method]` read
misses, the only fallback branch required `_isWasmStruct(obj)` (false for the
plain bridge object), and it threw **"m is not a function"** — while
`new Parser(...).m()` (raw-struct `<Class>_new` path) resolved.

### Verify-first
Probed on current `origin/main` (`d52cca0c9`): the in-wasm chained shape
`new this({}, input).getLen()` **THREW**, while `new Parser({}, input).getLen()`
returned 5. This **refutes the stale 2026-06-22 re-grounding note** in the issue
file (which claimed the in-wasm path already returned 5). #2628 was a real, live
in-wasm dispatch defect.

### Fix (JS-host glue only, `src/runtime.ts`)
1. **construct trap** — build the instance via
   `Object.create(_getOrVivifyFnPrototype(closure))` and register it in
   `_fnctorInstanceCtor` (also link a body-returned distinct object).
2. **`__extern_method_call`** — on a native method miss, consult
   `_fnctorProtoLookup(obj, method)` for any registered instance (struct OR plain
   object), wrap the raw-struct method value into a callable, and dispatch with
   the instance as `this`.

Standalone / `noJsHost` is unaffected — the bridge and the #2608 `new this` arm
are JS-host-only.

### Tests (`tests/issue-2628.test.ts`, all pass)
- `new this({}, "hello").getLen()` (acorn parse shape) → **5** (was: THREW)
- `new Parser({}, "hello").getLen()` (no regression) → **5**
- method calling another prototype method via `this` (`twice → this.getLen()*2`) → **10**

Adjacent regression sweep green (closure-construct, fnctor #1712/#2608/#2637,
fn-constructor, ctor-identity, Promise executor/subclass/capability,
#2660 s2/s3, wrapper-constructors). The 2 `promise-combinators` "with resolved
values" failures are **pre-existing on origin/main** (verified on a clean
checkout) — unrelated `_toIterable(arr)` argument shape.

Closes #2628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)