### PR TITLE
docs(#2739,#2681,#2712,#2732): architect specs + verified verdicts

### DIFF
--- a/plan/issues/2681-acorn-parse-10th-wall-unexpected-on-name.md
+++ b/plan/issues/2681-acorn-parse-10th-wall-unexpected-on-name.md
@@ -142,6 +142,40 @@ ROOT-CAUSE" + "## RESOLVED BY #2085"). Summary:
 Reusable `.tmp` probes (worker-thread + SAB, single-compile) banked under #2674.
 Each full-acorn compile is ~290s on this box — reuse one compile per probe.
 
+## Architect verdict — NOT unblocked by #2731 (esch, 2026-06-27)
+
+**Verdict: #2731 does NOT unblock #2681. Still requires the ranked-#1/#2 substrate
+work — NOT a clean dev fix as-is.**
+
+#2731 (PR #2170) added ONLY the symmetric WRITE routing
+(`tryEmitDeleteAwareDynamicSet`, property-access.ts:2223). The GET path this issue
+pinned — `tryEmitDeleteAwareDynamicGet` (property-access.ts:2148) → plain
+`__extern_get` — is **byte-unchanged**, and #2731 touched neither `__host_eq` /
+`_unwrapForHost` nor the lifted-method `this`-binding.
+
+Verified on current `origin/main` HEAD (f51590644910a, post-#2731) with a minimal
+faithful repro of the mechanism (a fnctor whose `this.<field>` is written in the
+ctor and read in a `pp = F.prototype; pp.m = function(this:any){…}` lifted method,
+`skipSemanticDiagnostics: true` to match the runner):
+- `this.type` written in the ctor reads back as **`undefined`/null** inside the
+  lifted method (`var t = this.type` → null), and `this.type === TT.name` is **`0`**
+  → a `switch(this.type){ case TT.name: … }` falls to `default` (acorn's
+  `unexpected()`). This is the exact host-proxy-vs-struct divergence #2681 names.
+- It reproduces **even without `delete`** in the module, confirming the defect is the
+  lifted-method `this`→struct binding (ranked #1), broader than the delete-aware GET
+  path. #2731's write-symmetry cannot bridge it: the ctor write is `struct.set` on a
+  concretely-typed `this` (NOT rerouted by `tryEmitDeleteAwareDynamicSet`, which gates
+  on an `any`/`unknown` receiver), while the lifted-method read is `__extern_get` on a
+  host proxy that never saw that struct field.
+
+The scale-dependent `name-token === empty-proxy → 1` collision (the full-acorn smoking
+gun) is a *symptom* of the same divergence; minimally it surfaces as a null read. The
+fix set is unchanged from the pinned analysis: **ranked #1** (whole-program
+prototype-alias `pp$N = F.prototype` tracking + lifted-method `this`→`$__fnctor_F`
+binding — the substrate fix), or **ranked #2** (route `tryEmitDeleteAwareDynamicGet`
+through the struct-candidate dispatch first, `__extern_get` terminal). Both are
+architect/senior-dev-scoped; #2731 changes none of the inputs.
+
 ### Carved sibling walls (now their own issues — do NOT bundle into #2681)
 - **#2686 — Binary-expression throw**: `parse("1 + 2 * 3;")` THROWS (separate from
   the identifier path; likely the same token-type-comparison root via parseExprOp).

--- a/plan/issues/2712-real-bool-valtype-retire-i32-boolean-brand.md
+++ b/plan/issues/2712-real-bool-valtype-retire-i32-boolean-brand.md
@@ -67,3 +67,37 @@ and the #2580 substrate spine so the bool lane lands once, centrally.
       `o[true]` keys `"true"`, `o[null]` keys `"null"` (no trap) — all in both
       host and standalone modes.
 - [ ] Equivalence + test262 non-regressing; full-CI / merge_group (broad impact).
+
+## Architect scope-read (esch, 2026-06-27) — needs a fuller spec before dispatch
+
+**Verdict: NOT plain-dev-able. Needs a short architect addendum (a representation
+decision + a switch-site sweep), then senior-dev-able.** The issue body lists the
+5 boxing drop-sites correctly, but the framing "the way `bigint` already has a
+typed i64 lane" understates the blast radius. The current `ValType` union
+(`src/ir/types.ts:146-160`) is:
+```ts
+| { kind: "i32"; boolean?: true }
+| { kind: "i64"; bigint?: boolean }    // bigint is ALSO an optional brand, not a separate kind
+```
+So **`bigint` is NOT a separate `{kind:"bigint"}`** — it is the same optional-brand
+shape this issue wants to retire for booleans. Promoting boolean to a first-class
+`{kind:"bool"}` therefore introduces a *genuinely new kind*, not a mirror of an
+existing one.
+
+The load-bearing design decision the architect must settle first: **a `bool` value
+is physically an `i32` in wasm** (locals, `i32.eqz`/branches, comparisons, struct
+fields all stay i32). So `{kind:"bool"}` must be treated as i32 by every low-level
+site (local allocation, the emitter's `case "i32"`, arithmetic/branch lowering,
+field storage) but as bool by the boxing/coercion/property-key/SameValueZero sites.
+That means a `bool` arm is needed at MANY more `switch (vt.kind)` sites than the 5
+listed — the spec must enumerate the full sweep (emitter encoding, `resolveWasmType`,
+local/global type mapping, `coerceType` both directions, struct field types,
+function param/result types) and define which fall through to the i32 path vs. take
+a distinct bool path. Recommend the architect (or the senior dev, inline) produce
+that switch-site inventory + the physical-rep contract as a `## Implementation Plan`
+before code starts; the 5 drop-sites are the *acceptance* surface, not the *change*
+surface. Already `[SENIOR-DEV]` (task #3) — keep it there; do not hand to a plain dev.
+
+Cross-link: **#2732(b) `true === 1` depends on this** (see #2732 scope-read) — the
+strict-equals type-tag distinction between boolean and number is unrepresentable
+until the bool lane exists.

--- a/plan/issues/2732-operator-toprimitive-strict-equals-boxed-wrapper-traps.md
+++ b/plan/issues/2732-operator-toprimitive-strict-equals-boxed-wrapper-traps.md
@@ -78,3 +78,39 @@ with no regression in operator tests and full CI green.
 - BigInt operator tests remain out of scope (blocked on #2044).
 - `with`-statement increment/decrement tests remain wont-fix (skip-filtered).
 - TCO portion (c) of the parent #2707 is done in PR #2159.
+
+## Architect scope-read (esch, 2026-06-27) — SPLIT (a) from (b); (b) depends on #2712
+
+Re-verified on current `origin/main` HEAD (f51590644910a) via the real
+`runTest262File` runner. **(a) and (b) have DIFFERENT root causes and must NOT be
+dispatched as one task.**
+
+**(a) unary `+`/`-`/`~`/`>>>` on object → REAL, still traps.** All 5 listed tests
+`fail` with **"dereferencing a null pointer in test()"**. (Note: a *simple*
+`+{valueOf(){return 1}}` probe returns 1 — the trap is on the FULL OrdinaryToPrimitive
+fallback chain the tests exercise: `valueOf` returns an object → must fall to
+`toString`; `toString` throws → must propagate; `valueOf`-only / `toString`-only.) The
+unary lowering reads a numeric field off the operand ref before coercing, null-derefing
+on a non-number object. **This is a self-contained ToNumber/ToPrimitive-in-numeric-
+context codegen gap — architect-spec-able and dev-implementable independently of #2712.**
+Spec target: the unary numeric lowering must call ToPrimitive(operand, Number)
+(valueOf→toString, §7.1.1) BEFORE extracting the f64/i32, when the operand is a
+non-primitive ref. This is the higher-value, independently-shippable half.
+
+**(b) strict-equals — NOT a trap; it is the boolean-as-i32 representation collision →
+DEPENDS ON #2712.** The 6 strict-(in)equals tests fail at assertion **#2: `true === 1`**
+(must be `false` per §7.2.16 step 1, Type(boolean) ≠ Type(number)). The compiler
+returns `true` because boolean `true` and number share the i32 `1` representation —
+confirmed directly: `false === 0` evaluates `EQ` (wrong) on current main. The original
+"traps with a WebAssembly.Exception" framing is stale — it now mis-VALUES, not traps.
+**This cannot be fixed cleanly without a value-rep way to distinguish boolean from
+number, which is exactly #2712 (real bool ValType).** Recommend: re-scope (b) as
+blocked-on / folded-into #2712; do NOT dispatch (b) as an independent operator patch
+(a localized strict-eq tag check would re-encode the same brand fragility #2712
+retires). The `new Boolean(...)`/`new Number(...)`/`new String(...)` boxed-wrapper
+cases (#1/#3/#5) are downstream of the same primitive-tag gap.
+
+**Recommended action:** keep (a) in this issue (architect-spec the ToPrimitive unary
+path; dev-able). Move (b) to depend on #2712 (or carve a `#2732b` blocked-on-#2712).
+Acceptance "9 of 11" is not reachable while (b) is blocked — (a) alone is the 5 unary
+tests.

--- a/plan/issues/2739-forin-prototype-chain-defineproperty-enumeration.md
+++ b/plan/issues/2739-forin-prototype-chain-defineproperty-enumeration.md
@@ -96,3 +96,135 @@ mode (the standalone prototype-link model is a separate sub-case). Full CI green
   integer-index half. These 4 are the remaining prototype/defineProperty half.
 - Route to **architect** for a prototype-link spec. Overlaps #2706's
   "prototype-chain dedup" scope and the #2580/#2660 substrate.
+
+## Implementation Plan (architect: esch, 2026-06-27)
+
+**All claims below VERIFIED by compile+run on current `origin/main` HEAD
+(f51590644910a), host/gc mode, via `compile()` + `buildImports`/`instantiateWasm`
+probes and the real `runTest262File` runner.** The three sub-bugs split into
+**two root causes** plus one separate lower-confidence item:
+
+### Root cause
+
+**Shape-inferred and fnctor WasmGC structs have NO host-observable `[[Prototype]]`
+link that `__for_in_keys`' manual walk can follow.** The walk in `__for_in_keys`
+(`src/runtime.ts:10844-10906`) advances with `current = Object.getPrototypeOf(current)`
+(`:10902`). For an opaque WasmGC struct exported to JS, host `Object.getPrototypeOf`
+returns null/the engine default — **never** the user-intended prototype. The link
+is also never *recorded* at the two mutation sites:
+
+- **(a) `Object.setPrototypeOf(o, proto)` is a COMPLETE NO-OP in gc/host mode.**
+  `src/codegen/expressions/calls.ts:5943-5949` compiles both args, `drop`s `proto`,
+  returns `obj`. The comment claims "the host runtime owns proto" but codegen never
+  calls any host `setPrototypeOf` — the link is dropped on the floor. Verified:
+  `Object.setPrototypeOf(o,{p4})` then `for k in o` yields `p1,p2,p3` (no `p4`).
+
+- **(b) `new F()` builds a `$__fnctor_F` struct with no prototype link, and
+  `F.prototype = {...}` is silently dropped in host mode.** `new FACTORY` →
+  `compileNewFunctionDeclaration` (`new-super.ts:1004`) builds a `$__fnctor_FACTORY`
+  struct with fields `prop`,`hint`. Its `__register_fnctor_instance` registration
+  (`new-super.ts:1267-1287`) fires **only when `ctorGlobalIdx` is defined** — i.e.
+  the fnctor has a closure global. A fnctor that is *only* `new`'d (never used as a
+  value) has **no** closure global, so registration never fires (WAT-verified:
+  `__fn_closure_FACTORY` absent, `__register_fnctor_instance` absent). Separately,
+  `FACTORY.prototype = {feat,hint}` routes through `tryCompileFnctorPrototypeAssign`
+  (`assignment.ts:2489-2498`) which is **standalone-only**; in host mode it falls to
+  `__extern_set($closure,"prototype",…)` which (per the in-code comment) "misses
+  `ref.test $Object` and silently drops the write". Net: the `F.prototype` object and
+  the `new F()` instance never rendezvous on a shared identity. Verified: own fields
+  enumerate (`prop1`,`hinthinted` — own `hint` correctly shadows), but inherited
+  `feat` is MISSING from for-in AND `__instance.feat`/`__instance["feat"]` read
+  `undefined` (the instance has no proto link the read path can walk either).
+
+So (a) and (b) are the **same** missing-prototype-link defect at two construction
+sites, both surfacing in the SAME `__for_in_keys` walk.
+
+### Changes
+
+**Part 1a — record the setPrototypeOf link (host mode).**
+- `src/runtime.ts`: add `const _wasmStructProto = new WeakMap<object, any>();`
+  (sibling of `_wasmStructProps`/`_wasmStructDeletedKeys`/`_wasmStructShadowedFields`).
+- `src/runtime.ts`: add a host import `__host_set_struct_proto(obj, proto)` that, when
+  `_isWasmStruct(obj)` and `proto` is object-or-null, performs the §10.1.2.1
+  OrdinarySetPrototypeOf extensibility + cycle checks (mirror the native
+  `__object_setPrototypeOf` logic, object-runtime.ts:2426), then
+  `_wasmStructProto.set(obj, proto)` and returns `obj`. Register its name so
+  `buildImports` wires it.
+- `src/codegen/expressions/calls.ts:5943-5949` (the gc/host arm): instead of
+  `drop`+return, emit `call __host_set_struct_proto(obj, proto)` (ensureLateImport
+  + flushLateImportShifts, same discipline as the standalone arm at :5927-5935).
+  Mirror at **`Reflect.setPrototypeOf`** (calls.ts:7593) and the `o.__proto__ = v`
+  write path (grep `__proto__` in assignment.ts) so all three record the link.
+
+**Part 1b — record the fnctor instance→prototype link (host mode).** Pick ONE:
+- *Preferred (reuse #1712 machinery):* ensure `__register_fnctor_instance` fires for
+  EVERY `new`'d fnctor. At `new-super.ts:1267`, when `ctorGlobalIdx` is undefined,
+  allocate the closure global for `funcName` (the same lazy global `closures.ts:4300`
+  mints) so the registration emits, AND make `F.prototype = {...}` vivify the SAME
+  closure-sidecar prototype object in host mode (extend `tryCompileFnctorPrototypeAssign`
+  / its host fall-through to write `_sidecarSet(closure,"prototype",rhs)` via
+  `_getOrVivifyFnPrototype`). Then `_fnctorInstanceCtor`→`_sidecarGet(ctor,"prototype")`
+  is the link, and the existing read path (`_fnctorProtoLookup`, runtime.ts:74) already
+  resolves inherited reads — closing the `__instance.feat`→undefined half of (b).
+- *Alternative (name-keyed rendezvous):* a host `Map<string,object> _fnctorPrototypeByName`;
+  `F.prototype = {...}` (host) writes it; construction does
+  `_wasmStructProto.set(instance, _fnctorPrototypeByName.get(F))`. Simpler but a second
+  proto-link channel; prefer reusing `_fnctorInstanceCtor` to avoid divergence.
+
+**Part 2 — consult the link in the for-in walk (fixes a + b enumeration).**
+- `src/runtime.ts`: add `_structUserProto(current, exports)` returning, for a wasm
+  struct: (1) `_wasmStructProto.get(current)` if set; else (2) the fnctor prototype
+  via `_fnctorInstanceCtor.get(current)` → `_sidecarGet(ctor,"prototype")`; else (3)
+  `Object.getPrototypeOf(current)`. For a non-struct, return `Object.getPrototypeOf`.
+- `__for_in_keys` (runtime.ts): replace the `current = Object.getPrototypeOf(current)`
+  step at `:10902` with `current = _structUserProto(current, exports)`. The existing
+  `seen` set + `_orderOwnKeysSpec` already give own-before-proto ordering and
+  own-shadows-proto dedup (verified: own `hint` already wins). The proto level may
+  itself be a wasm struct (`{p4}`/`{feat,hint}` compile to structs) — the walk's
+  struct branch (`:10850`) already handles that recursively.
+
+**Part 3 — read-path consistency (already mostly covered).**
+- For (b) the test reads `__instance[key]`; once Part 1b registers the link,
+  `_fnctorProtoLookup` (consulted by `__extern_get` at runtime.ts:4170/4977) resolves
+  inherited reads. ALSO have `_fnctorProtoLookup` (or a shared resolver) consult
+  `_wasmStructProto` so setPrototypeOf-set protos resolve reads too — keeps reads and
+  for-in walking ONE prototype source.
+
+**Part 4 — `__getPrototypeOf` consistency (recommended, not strictly required by the
+4 tests).** Route `__getPrototypeOf` (runtime.ts:9353) through `_structUserProto` for
+wasm structs so `Object.getPrototypeOf(o)` post-setPrototypeOf returns the user proto.
+Guard against regressing existing proto-walk tests (run the `Object/getPrototypeOf`
+and `setPrototypeOf` test262 dirs).
+
+### Edge cases
+- `Object.setPrototypeOf(o, null)` → store null; for-in then enumerates own keys only.
+- Cycle: OrdinarySetPrototypeOf must refuse a cycle (no-op); ALSO add a visited-object
+  guard in the `__for_in_keys` walk (the `_fnctorProtoLookup` uses `guard++ < 16`) so a
+  hand-built cycle can't loop the enumerator.
+- own-shadows-proto: `seen` is populated with own keys BEFORE the proto level — already
+  correct; do not reorder.
+- proto level is a plain JS object vs a wasm struct — both branches already exist.
+- Standalone/WASI is OUT OF SCOPE for these 4 tests (host mode). Standalone already has
+  `$Object.$proto` (calls.ts:5909) + fnctor S3a reconstruction; a separate sub-case.
+- Do NOT regress `for-of` over objects if it shares `__for_in_keys` (it does not today —
+  verify before shipping).
+
+### (c) `order-after-define-property` — SEPARATE, lower-confidence sub-task
+Verified split: assert #1 (plain object: `obj.a=1;obj.b=2;defineProperty(obj,"a",{value})`
+→ `["a","b"]`) **already PASSES** on current main. Only assert #2 (the **array +
+accessor-descriptor** case: `defineProperty(arr,"a",{get,enumerable,configurable})`;
+`arr.b=2`; redefine `a`) fails — AND it fails **only in the full-harness `runTest262File`
+run**; an isolated `compile()` probe of the same array snippet returns the correct
+`["a","b"]` (len=2). This is a full-program-compilation interaction (array vec +
+accessor-descriptor sidecar for-in under the assert.js harness), NOT the
+prototype-link defect. **Treat as its own follow-up**; the dev MUST reproduce via
+`runTest262File(".../order-after-define-property.js")` (it does NOT repro in a bare
+`compile()` probe). Do not block (a)+(b) on it. Recommend the PO file (c) as a separate
+issue if (a)+(b) ship first.
+
+### Test files to verify
+- `statements/for-in/order-property-on-prototype.js` — Part 1a + Part 2 (a)
+- `statements/for-in/S12.6.4_A6.js`, `S12.6.4_A6.1.js` — Part 1b + Part 2 + Part 3 (b)
+- `statements/for-in/order-after-define-property.js` — (c), separate sub-task
+- Regression watch: `statements/for-in/` (esp. `order-simple-object` from #2731),
+  `built-ins/Object/getPrototypeOf`, `built-ins/Object/setPrototypeOf`.


### PR DESCRIPTION
Plan-only docs. Architect specs/verdicts, all VERIFIED by compile+run on current origin/main (host mode) via `compile()` probes and the real `runTest262File` runner.

## #2739 — for-in prototype-chain + defineProperty enumeration (`## Implementation Plan` added)
- **(a)** `Object.setPrototypeOf(o, proto)` is a **complete no-op in gc/host mode** (`calls.ts:5943-5949` drops `proto`); the link is never recorded — for-in misses `p4`.
- **(b)** `new F()` builds a `$__fnctor_F` struct with **no prototype link**, and `F.prototype = {…}` is **silently dropped in host mode** (fnctor has no closure global → `__register_fnctor_instance` never fires). Own fields enumerate; inherited `feat` missing from for-in AND `__instance.feat` reads `undefined`.
- Both surface in the SAME `__for_in_keys` walk. Unified fix: record a host-observable `[[Prototype]]` (`_wasmStructProto` + reuse `_fnctorInstanceCtor`) and consult it in the walk via a `_structUserProto` resolver.
- **(c)** `order-after-define-property`: assert #1 (plain obj) already PASSES; only assert #2 (array+accessor) fails, and only in the full-harness runner — carved as a separate lower-confidence sub-task.

## #2681 — VERDICT: NOT unblocked by #2731
#2731 added only the symmetric WRITE routing. The GET path (`tryEmitDeleteAwareDynamicGet → __extern_get`) and the lifted-method `this`-binding this issue pins are unchanged. Minimal faithful repro on current main (post-#2731) confirms: `this.<field>` written in the ctor reads `null` in a lifted `pp.m = function(this:any){…}` method (reproduces even without `delete`) → `switch(this.type)` falls to `default`. Still needs ranked-#1/#2 substrate work; not a clean dev fix.

## #2712 — scope-read: needs a fuller spec before dispatch
`bigint` is itself an optional brand (not a separate kind), so `{kind:"bool"}` is a genuinely NEW kind. `bool` is physically i32, so it touches far more `switch(vt.kind)` sites than the 5 boxing drops. Keep `[SENIOR-DEV]`; produce a switch-site inventory + physical-rep contract first.

## #2732 — scope-read: SPLIT (a) from (b)
- **(a)** unary `+/-/~/>>>` on object → REAL null-deref trap (full ToPrimitive fallback chain); architect-spec-able + dev-able independently.
- **(b)** strict-eq `true === 1` → the boolean-as-i32 representation collision (`false === 0` evaluates EQ on main); **depends on #2712**. Do not dispatch (b) as an independent operator patch.

No source changes — `plan/issues/` only.