### PR TITLE
fix(#2687): emit __call_fn_method_N up to max closure arity (acorn parseSubscript dispatch)

### DIFF
--- a/plan/issues/2687-acorn-expressionstatement-expression-null.md
+++ b/plan/issues/2687-acorn-expressionstatement-expression-null.md
@@ -1,11 +1,12 @@
 ---
 id: 2687
 title: "acorn parse() — ExpressionStatement.expression is null (parsed Literal not attached to the statement node)"
-status: ready
-assignee: ttraenkler/unassigned
+status: done
+assignee: ttraenkler/dev1
 sprint: 67
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-06-27
+completed: 2026-06-27
 priority: medium
 feasibility: medium
 reasoning_effort: high
@@ -78,3 +79,75 @@ for other fields by the #2664 `__set_member_<name>` dispatcher; re-probe to see 
   Literal{ value: 1 } }` matching node-acorn (the #1712 differential passes for
   literal expression statements).
 - Full merge_group / test262 (codegen-adjacent).
+
+## ROOT CAUSE (pinned, dev1 2026-06-27) — higher-arity prototype-method host dispatch was un-emitted, NOT a dropped write
+
+The suspected-locus hypotheses (dropped `node.expression = expr` write, or a
+read/write representation divergence) were BOTH wrong. A chained per-level
+diagnostic probe (instrument every return in
+`parseExpression → parseMaybeAssign → … → parseExprAtom/parseSubscripts`, surface
+the tags on the statement node, single ~26 s acorn compile) pinned it precisely:
+
+- `parseLiteral` and `parseExprAtom` return a valid `Literal` (`__d_atom=2`), but
+  **`parseExprSubscripts` returns null** (`__d_subs=-1`). So `expr` is already
+  null when `parseExpressionStatement(node, expr)` runs — the write attaches a
+  genuinely-null value (`exprWasNull=1`), it is NOT dropped.
+- Inside `parseSubscripts`, the loop runs twice and **`this.parseSubscript(...)`
+  returns null without its body ever executing** — even a first-line call-counter
+  `this.__d_subCalls` stays `undefined`, while the sibling `this.__d_ps_*` writes
+  (same `pp$5` `this`) DO surface. So `parseSubscript`'s body never ran; the
+  method-call returned null.
+
+`parseSubscript` is an **arity-7** prototype method
+(`base, startPos, startLoc, noCalls, maybeAsyncArrow, optionalChained, forInit`).
+A `this.parseSubscript(...)` on an `any`/externref receiver wraps the lifted
+closure and dispatches it through `__call_fn_method_<N>` (runtime.ts
+`wasmClosureBridge` / `wasmClosureDynamicBridge`). The compiler emitted
+`__call_fn_method_N` only for **N=0..5** (the highest being the #1712 fnctor
+arity-5 bridge). Each dispatcher's membership filter is
+`info.paramTypes.length <= arity`, so the arity-7 closure was **OMITTED** from the
+highest-available `__call_fn_method_5` → the dynamic method call returned null →
+`parseSubscript` returned null → null bubbled up the entire expression chain →
+`ExpressionStatement.expression = null`.
+
+This is the **symmetric companion to #2664**: #2664 fixed a method invoked with
+FEWER args than its declared params (dispatched too LOW); #2687 is a method whose
+DECLARED arity EXCEEDS the highest emitted dispatcher.
+
+Confirmed against the compiled module: `__call_fn_method_N` exports were
+`0..5` only. acorn's prototype-method arity histogram tops out at 8
+(`parsePropertyValue`), with 7 (`parseSubscript`) and 6 present.
+
+## FIX (src/codegen/index.ts, finalize)
+
+After `emitClosureMethodCallExportN(ctx, 5)`, emit one dispatcher per arity up to
+the module's actual max closure arity, capped at 8 (the dynamic bridge's existing
+scan range — `_wrapWasmClosureUnknownArity` iterates `a = 8..0`):
+
+```ts
+let maxClosureArity = 5;
+for (const info of ctx.closureInfoByTypeIdx.values())
+  if (info.paramTypes.length > maxClosureArity) maxClosureArity = info.paramTypes.length;
+for (let n = 6; n <= Math.min(maxClosureArity, 8); n++) emitClosureMethodCallExportN(ctx, n);
+```
+
+`emitClosureMethodCallExportN` no-ops when no closure of arity ≤ N exists, so
+modules whose methods top out at ≤5 are byte-identical. Low-arity closures in a
+module that DOES have arity-6/7/8 methods are unaffected: each closure is still
+dispatched at its OWN arity at the wasm dispatch arm (extra padding args dropped).
+
+## Test Results
+- Compiled pinned acorn: `parse("1")` / `parse("1;")` / `parse("true;")` now
+  return `ExpressionStatement{ expression: Literal{...} }` (was `expression: null`).
+- New `tests/issue-2687.test.ts` (4 tests): arity-6/7/8 prototype methods invoked
+  via `this.m(...)` now RUN (were null); arity-≤5 unaffected. Confirmed genuine
+  regression guard — reverting the fix returns null/0.
+- Method-dispatch family green: #2664, #2674, #1712 (dynamic-dispatch/tokenizer/
+  capture), #1636 (json-stringify/tojson), #2015, #2731, #1382.
+- `tsc --noEmit` clean; prettier clean.
+- NOTE: `tests/issue-1712-capture-closure-dispatch.test.ts` has one PRE-EXISTING
+  failure on clean origin/main (`__call_fn_1 dispatches an arity-0 capturing
+  closure`) — fails identically WITHOUT this change; unrelated to #2687.
+- OUT OF SCOPE (still substrate-blocked, separate read-side root): #2681
+  (`parse("x")` identifier path THROWS) and #2686 (`parse("1 + 2 * 3;")` binary
+  THROWS) — the parseExprAtom `switch (this.type)` host-proxy mis-comparison.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1768,6 +1768,31 @@ export function generateModule(
     // when no arity-5 closure exists.
     emitClosureMethodCallExportN(ctx, 5);
 
+    // (#2687) Arities 6..8 for HIGHER-arity prototype methods. acorn's
+    // `parseSubscript(base, startPos, startLoc, noCalls, maybeAsyncArrow,
+    // optionalChained, forInit)` is arity 7 and `parsePropertyValue` is arity 8;
+    // a `this.parseSubscript(...)` host method-call wraps the closure and
+    // dispatches it through `__call_fn_method_<N>` (runtime.ts wasmClosureBridge /
+    // wasmClosureDynamicBridge). With the highest emitted dispatcher capped at 5,
+    // an arity-7 closure was OMITTED from `__call_fn_method_5` (its filter is
+    // `paramTypes.length <= arity`), so the dynamic method-call returned null and
+    // the body never ran — parseSubscript returned null up the parse chain, leaving
+    // `ExpressionStatement.expression` null (#2687) and breaking the acorn dogfood.
+    // Emit one dispatcher per arity up to the module's actual max closure arity,
+    // capped at 8 — the dynamic bridge's scan range
+    // (`_wrapWasmClosureUnknownArity` iterates `a = 8..0`). Each call no-ops when
+    // no closure of arity ≤ N exists, so modules whose methods top out at ≤5 are
+    // byte-identical. Mirrors the #2664 fix direction (a method's declared arity
+    // EXCEEDING the dispatcher arity — the symmetric case of fewer-args-than-params).
+    {
+      let maxClosureArity = 5;
+      for (const info of ctx.closureInfoByTypeIdx.values()) {
+        if (info.paramTypes.length > maxClosureArity) maxClosureArity = info.paramTypes.length;
+      }
+      const cap = Math.min(maxClosureArity, 8);
+      for (let n = 6; n <= cap; n++) emitClosureMethodCallExportN(ctx, n);
+    }
+
     // (#1719 CPR read-drive) Fill the reserved `__drive_proto_iterator` driver
     // body now that `__call_fn_method_0` is registered. No-op when no read-drive
     // site reserved a driver (brand clear / no Array.prototype @@iterator override).

--- a/tests/issue-2687.test.ts
+++ b/tests/issue-2687.test.ts
@@ -1,0 +1,88 @@
+// #2687 — acorn parse() ExpressionStatement.expression was null because a
+// higher-arity prototype method (acorn's `parseSubscript`, arity 7) could not be
+// dispatched through the host method-call bridge.
+//
+// ROOT CAUSE (pinned, dev probe 2026-06-27): the compiler emitted
+// `__call_fn_method_<N>` dispatchers only for N=0..5 (the highest being the
+// #1712 fnctor arity-5 bridge). A `this.parseSubscript(...)` call on an
+// `any`/externref receiver wraps the lifted prototype closure and dispatches it
+// through `__call_fn_method_<N>` (runtime.ts wasmClosureBridge /
+// wasmClosureDynamicBridge). Each dispatcher's filter is
+// `info.paramTypes.length <= arity`, so an arity-7 closure was OMITTED from the
+// highest-available `__call_fn_method_5` → the dynamic method call returned null
+// and the method body NEVER RAN. parseSubscript therefore returned null up the
+// expression chain (parseExprSubscripts → parseMaybeUnary → … → parseExpression),
+// and `parseExpressionStatement(node, expr)` attached a null `expr`, leaving
+// `ExpressionStatement.expression === null`.
+//
+// FIX: emit `__call_fn_method_<N>` up to the module's actual max closure arity,
+// capped at 8 (the dynamic bridge's scan range). This is the symmetric companion
+// to #2664 (which fixed FEWER-args-than-params); here the method's DECLARED arity
+// EXCEEDED the highest dispatcher.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+
+async function run(src: string): Promise<any> {
+  const result: any = await compile(src, { fileName: "acorn.mjs" });
+  expect(result.success).toBe(true);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  return wrapExports(instance.exports, { signatures: result.exportSignatures });
+}
+
+describe("#2687 — higher-arity prototype-method host dispatch (acorn parseSubscript shape)", () => {
+  it("a 7-param prototype method invoked via this.m(1..7) RUNS (was: null body)", async () => {
+    // Mirrors acorn's `Parser.prototype.parseSubscript(base, startPos, startLoc,
+    // noCalls, maybeAsyncArrow, optionalChained, forInit)` (arity 7) invoked from
+    // another prototype method via `this.parseSubscript(...)`.
+    const exp = await run(`
+      var Parser = function Parser(input) { this.input = String(input); };
+      Parser.prototype.seven = function seven(a, b, c, d, e, f, g) {
+        return a + b + c + d + e + f + g;
+      };
+      Parser.prototype.run = function run() { return this.seven(1, 2, 3, 4, 5, 6, 7); };
+      Parser.parse = function parse(input) { return new this(input).run(); };
+      export function parse(input) { return Parser.parse(input); }
+    `);
+    // Before the fix this returned null (→ 0 / NaN in arithmetic) because the
+    // arity-7 closure was omitted from __call_fn_method_5.
+    expect(exp.parse("x")).toBe(28);
+  });
+
+  it("an 8-param prototype method (acorn parsePropertyValue shape) also runs", async () => {
+    const exp = await run(`
+      var Parser = function Parser(input) { this.input = String(input); };
+      Parser.prototype.eight = function eight(a, b, c, d, e, f, g, h) {
+        return a + b + c + d + e + f + g + h;
+      };
+      Parser.prototype.run = function run() { return this.eight(1, 2, 3, 4, 5, 6, 7, 8); };
+      Parser.parse = function parse(input) { return new this(input).run(); };
+      export function parse(input) { return Parser.parse(input); }
+    `);
+    expect(exp.parse("x")).toBe(36);
+  });
+
+  it("a 6-param prototype method runs (fills the gap between arity-5 bridge and 7/8)", async () => {
+    const exp = await run(`
+      var Parser = function Parser(input) { this.input = String(input); };
+      Parser.prototype.six = function six(a, b, c, d, e, f) { return a + b + c + d + e + f; };
+      Parser.prototype.run = function run() { return this.six(10, 20, 30, 40, 50, 60); };
+      Parser.parse = function parse(input) { return new this(input).run(); };
+      export function parse(input) { return Parser.parse(input); }
+    `);
+    expect(exp.parse("x")).toBe(210);
+  });
+
+  it("low-arity (<=5) prototype-method dispatch is unaffected (regression guard)", async () => {
+    const exp = await run(`
+      var Parser = function Parser(input) { this.input = String(input); };
+      Parser.prototype.two = function two(a, b) { return a * b; };
+      Parser.prototype.run = function run() { return this.two(6, 7); };
+      Parser.parse = function parse(input) { return new this(input).run(); };
+      export function parse(input) { return Parser.parse(input); }
+    `);
+    expect(exp.parse("x")).toBe(42);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2687 — acorn `parse()` returned `ExpressionStatement{ expression: null }` for literal expression statements.

**Root cause (NOT a dropped write, as the issue hypothesized):** a chained per-level diagnostic probe pinned the null origin to `parseSubscript` — an **arity-7** prototype method (`base, startPos, startLoc, noCalls, maybeAsyncArrow, optionalChained, forInit`). A `this.parseSubscript(...)` call on an `any`/externref receiver dispatches the lifted closure through `__call_fn_method_<N>` (runtime.ts `wasmClosureBridge` / `wasmClosureDynamicBridge`). The compiler emitted `__call_fn_method_N` only for **N=0..5**, and each dispatcher's membership filter is `paramTypes.length <= N`, so the arity-7 closure was **omitted** from the highest-available `__call_fn_method_5` → the dynamic call returned null **without running the body** → null bubbled up the whole expression chain (`parseSubscripts → parseExprSubscripts → … → parseExpression`), so `parseExpressionStatement(node, expr)` attached a genuinely-null `expr`.

This is the **symmetric companion to #2664**: #2664 fixed a method dispatched too LOW (fewer args than params); #2687 is a method whose **declared arity EXCEEDS** the highest emitted dispatcher. acorn's prototype-method arity histogram tops out at 8 (`parsePropertyValue`), with 7 (`parseSubscript`) and 6 present.

## Fix (`src/codegen/index.ts`, finalize)

Emit one `__call_fn_method_N` dispatcher per arity up to the module's actual max closure arity, capped at 8 (the dynamic bridge's existing scan range in `_wrapWasmClosureUnknownArity`, which iterates `a = 8..0`). `emitClosureMethodCallExportN` no-ops when no closure of arity ≤ N exists, so modules whose methods top out at ≤5 are byte-identical. Low-arity closures in a module that DOES have arity-6/7/8 methods are unaffected — each closure is dispatched at its own arity at the wasm arm (extra padding dropped).

## Verification

- Compiled pinned acorn: `parse("1")` / `parse("1;")` / `parse("true;")` now return `ExpressionStatement{ expression: Literal{...} }` (was `expression: null`).
- New `tests/issue-2687.test.ts` (4 tests): arity 6/7/8 prototype methods invoked via `this.m(...)` now run; arity ≤5 regression guard. Confirmed a genuine guard — reverting the fix returns null/0.
- Method-dispatch family green: #2664, #2674, #1712 (dynamic-dispatch/tokenizer/capture), #1636, #2015, #2731, #1382.
- `tsc --noEmit` clean; prettier clean.
- **Out of scope (still substrate-blocked, separate read-side root):** #2681 (`parse("x")` THROWS) and #2686 (`parse("1 + 2 * 3;")` THROWS) — the `parseExprAtom switch(this.type)` host-proxy mis-comparison.
- Note: `tests/issue-1712-capture-closure-dispatch.test.ts` has one PRE-EXISTING failure on clean `origin/main`, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)