### PR TITLE
fix(#2726): hasOwnProperty-after-delete + non-configurable accessor delete (groups c/d)

### DIFF
--- a/plan/issues/2726-delete-residual-sloppy-return-hasownproperty-accessor-mapped.md
+++ b/plan/issues/2726-delete-residual-sloppy-return-hasownproperty-accessor-mapped.md
@@ -11,8 +11,17 @@ es_edition: ES5
 language_feature: delete
 task_type: bug
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-06-27
 ---
+
+> **Partial resolution (2026-06-27, dev2).** Groups **(c)** and **(d)** are
+> DONE (+6 test262 incl. siblings, 0 regressions — see `## Resolution`).
+> Remaining open scope: **(a)** sloppy unresolvable-identifier oracle and
+> **(b)** sloppy global-object model are STRUCTURAL (architect-spec first);
+> **(e)** mapped-arguments delete is DEFERRED to #1726 (mapped-arguments
+> exotic); **(f)**/**(g)** re-route to their owning feature issues (not delete
+> bugs). This issue stays open (`status: ready`) for (a)/(b).
+
 # #2726 — delete residual (non-throw) semantics
 
 Split out of #2703, which delivered the **throw** cases of `delete`
@@ -79,3 +88,55 @@ on its throw-semantics scope.
 The (a)–(e) groups flip from fail to pass with no regression in
 `expressions/delete/` or `built-ins/Object/defineProperty/`. (f) and (g) may be
 re-routed to their owning feature issues. Full CI green.
+
+## Resolution — groups (c) + (d) (2026-06-27, dev2)
+
+**Root cause (c).** `var o = {}` infers an empty struct type, so the receiver
+takes the WasmGC-struct lowering path (not the `any`/host path #2731 fixed).
+`o.hasOwnProperty('foo')` was **constant-folded to `i32.const 1`** against the
+static struct shape (which `Object.defineProperty` *widens* to include `foo`),
+ignoring a later configurable `delete`'s `_wasmStructDeletedKeys` tombstone. The
+fold's runtime-routing guard (`needsRuntime`) only consulted
+`ctx.definedPropertyFlags`, which is populated **only for inline object-literal
+descriptors**. The dominant ES5 `var d = { value: 1, configurable: true };
+Object.defineProperty(o, k, d)` shape routes through `emitDefinePropertyDescRuntime`
+(recorded in `sidecarDefinedPropertyKeys`) and the inline-**accessor** fast path
+(recorded in neither), so the guard never fired for them.
+
+**Fix (c).** Added `ctx.definePropertyReceiverKeys` — a `varName:propName` set
+recorded at the single `compileObjectDefineProperty` chokepoint, capturing EVERY
+defineProperty lowering path uniformly. `hasOwnProperty` / `propertyIsEnumerable`
+now route to the runtime `__hasOwnProperty` helper (which consults the tombstone)
+whenever the receiver var was defineProperty'd. Kept SEPARATE from
+`definedPropertyFlags` / `sidecarDefinedPropertyKeys` so it never perturbs
+descriptor-flag or `getOwnPropertyDescriptor` routing (a presence-routing signal
+only). `src/codegen/object-ops.ts`, `src/codegen/context/{types,create-context}.ts`.
+
+**Root cause (d).** The inline-accessor `Object.defineProperty` fast path
+(statically struct-typed receiver) compiles the getter/setter into a
+`${struct}_get/set_<prop>` fn + `classAccessorSet` and — unlike the data fast
+path — never mirrors the descriptor's `configurable` flag into the runtime
+`_wasmPropDescs` sidecar. So `__delete_property` couldn't see `configurable:false`
+and wrongly reported a successful delete.
+
+**Fix (d).** Added `ctx.nonConfigurableAccessorKeys` (populated by that fast path
+when `configurable !== true`; per §6.2.5.6 an omitted `configurable` defaults to
+false). The struct-field `delete` site consults it to emit OrdinaryDelete's
+refusal (return `false`; strict ⇒ TypeError, leaving the property intact) without
+issuing the runtime call (which would otherwise add a spurious tombstone).
+`src/codegen/typeof-delete.ts`.
+
+### Test Results (host/gc lane, authoritative `runTest262File`)
+
+| cluster | baseline → fix |
+|---|---|
+| `expressions/delete` + `Object.prototype/{hasOwnProperty,propertyIsEnumerable}` | 117 → 121 pass, **0 regressions** |
+| `Object/{defineProperty,getOwnPropertyDescriptor,defineProperties}` | 207 → 207 (no change) |
+| `Object/{freeze,seal,preventExtensions,create,getOwnPropertyNames}` | 400 → 402 pass, **0 regressions** |
+| `for-in` + `Object/keys` + `expressions/object` | 363 → 363 (no change) |
+
+Net **+6** test262, **0 regressions** across ~4,500 most-related tests. Targets
+flipped fail→pass: `11.4.1-4.a-1`, `11.4.1-4.a-2`, `11.4.1-4-a-4-s` (c),
+`11.4.1-4-a-2-s` (d), plus sibling `Object/freeze/15.2.3.9-2-3` and
+`Object/seal/object-seal-inherited-accessor-properties-are-ignored`.
+Regression test: `tests/issue-2726.test.ts`.

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -248,6 +248,8 @@ export function createCodegenContext(
     tdzLetConstNames: new Set(),
     definedPropertyFlags: new Map(),
     sidecarDefinedPropertyKeys: new Set(),
+    definePropertyReceiverKeys: new Set(),
+    nonConfigurableAccessorKeys: new Set(),
     nonExtensibleVars: new Set(),
     frozenVars: new Set(),
     sealedVars: new Set(),

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1847,6 +1847,32 @@ export interface CodegenContext {
   definedPropertyFlags: Map<string, number>;
   /** Properties whose descriptor/value lives in the runtime sidecar. */
   sidecarDefinedPropertyKeys: Set<string>;
+  /**
+   * (#2726) `varName:propName` keys for which `Object.defineProperty` was
+   * statically observed on an identifier receiver — recorded uniformly across
+   * EVERY defineProperty lowering path (inline data, inline accessor fast path,
+   * runtime-descriptor, etc.). Used ONLY to route `hasOwnProperty` /
+   * `propertyIsEnumerable` to the runtime helper instead of constant-folding
+   * against the (defineProperty-widened) static struct shape: a configurable
+   * `delete` records a `_wasmStructDeletedKeys` tombstone the compile-time
+   * shape answer can't see. Kept SEPARATE from `definedPropertyFlags` /
+   * `sidecarDefinedPropertyKeys` so it never perturbs descriptor-flag or
+   * `getOwnPropertyDescriptor` routing — it is a presence-routing signal only.
+   */
+  definePropertyReceiverKeys: Set<string>;
+  /**
+   * (#2726) `varName:propName` keys defined as a NON-configurable ACCESSOR via
+   * the inline-accessor `Object.defineProperty` fast path on a statically
+   * struct-typed receiver. That path compiles the getter/setter into a
+   * `${struct}_get/set_<prop>` function + `classAccessorSet` and — unlike the
+   * data fast path — never mirrors the descriptor's `configurable` flag into the
+   * runtime `_wasmPropDescs` sidecar, so the host `__delete_property` can't see
+   * it and wrongly reports a successful delete. The struct-field `delete` site
+   * consults this set to emit OrdinaryDelete's refusal (return `false`; strict
+   * mode ⇒ TypeError) for `delete obj.accessor` of a non-configurable accessor
+   * (#2726 group (d): `11.4.1-4-a-2-s`). Consumed ONLY by the delete site.
+   */
+  nonConfigurableAccessorKeys: Set<string>;
   /** Object mutability state sets */
   nonExtensibleVars: Set<string>;
   frozenVars: Set<string>;

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -4316,30 +4316,41 @@ export function compilePropertyIntrospection(
     let needsRuntime = false;
     if (recvVarName) {
       const prefix = `${recvVarName}:`;
-      // Cheap pre-check: if any defineProperty entry exists for this var
-      // (`definePropertyReceiverKeys` records EVERY lowering path uniformly;
-      // `definedPropertyFlags` / `sidecarDefinedPropertyKeys` are kept as
-      // belt-and-braces), the runtime tombstone / descriptor map could differ
-      // from the static shape answer. Bail to the runtime path.
-      for (const k of ctx.definePropertyReceiverKeys) {
+      // (#2726) Pre-existing signal (mode-agnostic): an inline object-literal
+      // descriptor recorded in `definedPropertyFlags`. Routing on this in BOTH
+      // modes preserves origin/main behavior.
+      for (const k of ctx.definedPropertyFlags.keys()) {
         if (k.startsWith(prefix)) {
           needsRuntime = true;
           break;
         }
       }
-      if (!needsRuntime) {
-        for (const k of ctx.definedPropertyFlags.keys()) {
+      // (#2726 standalone fix) The broad new signals — `definePropertyReceiverKeys`
+      // (every lowering path) and `sidecarDefinedPropertyKeys` (runtime-descriptor
+      // route) — route to the `__hasOwnProperty` / `__propertyIsEnumerable` helper.
+      // In HOST mode that helper consults the descriptor/tombstone sidecar and
+      // answers correctly. In STANDALONE mode the wasm-native helper does NOT
+      // report a `defineProperty`-added struct-shape property as own (it returns
+      // false), so routing there REGRESSES every `defineProperty(o,k,…)` +
+      // `o.hasOwnProperty(k)` test (the 19-file standalone-floor park on PR #2177:
+      // built-ins/Object/{defineProperty,prototype/hasOwnProperty,getOwnPropertyNames}).
+      // Gate these two broad signals to host mode; standalone keeps the
+      // const-fold (correct for the no-delete case, unchanged from origin/main).
+      // The narrower delete-tombstone benefit in standalone awaits the standalone
+      // `__hasOwnProperty` sidecar-awareness substrate work.
+      if (!needsRuntime && !ctx.standalone) {
+        for (const k of ctx.definePropertyReceiverKeys) {
           if (k.startsWith(prefix)) {
             needsRuntime = true;
             break;
           }
         }
-      }
-      if (!needsRuntime) {
-        for (const k of ctx.sidecarDefinedPropertyKeys) {
-          if (k.startsWith(prefix)) {
-            needsRuntime = true;
-            break;
+        if (!needsRuntime) {
+          for (const k of ctx.sidecarDefinedPropertyKeys) {
+            if (k.startsWith(prefix)) {
+              needsRuntime = true;
+              break;
+            }
           }
         }
       }

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -1301,6 +1301,27 @@ export function compileObjectDefineProperty(
     descArg = (descArg as ts.AsExpression).expression;
   }
 
+  // (#2726) Record the defineProperty'd `varName:propName` on an identifier
+  // receiver up-front, BEFORE any lowering-path branch (inline data fast path,
+  // inline accessor fast path, runtime-descriptor route, …). This is the single
+  // chokepoint every path flows through, so it captures the signal uniformly —
+  // unlike `definedPropertyFlags` (inline-literal only) and
+  // `sidecarDefinedPropertyKeys` (runtime route only). It exists ONLY to route
+  // `hasOwnProperty` / `propertyIsEnumerable` to the runtime helper (so a
+  // subsequent configurable `delete`'s tombstone is honoured) and never feeds
+  // descriptor-flag logic. Recorded even if a guard below throws — a defineProperty
+  // that throws defines nothing, and the runtime presence answer stays correct.
+  if (ts.isIdentifier(objArg)) {
+    const dpPropName = ts.isStringLiteral(propArg)
+      ? propArg.text
+      : ts.isNumericLiteral(propArg)
+        ? propArg.text
+        : undefined;
+    if (dpPropName !== undefined) {
+      ctx.definePropertyReceiverKeys.add(`${objArg.text}:${dpPropName}`);
+    }
+  }
+
   // ES spec 19.1.2.4 step 1: throw TypeError if first arg is not an object
   if (emitNonObjectArgGuard(ctx, fctx, objArg, "Object.defineProperty")) {
     // After the throw, emit unreachable and return externref to satisfy callers
@@ -1823,6 +1844,21 @@ export function compileObjectDefineProperty(
 
     const accessorKey = `${structName}_${propName}`;
     ctx.classAccessorSet.add(accessorKey);
+
+    // (#2726 group (d)) Record a NON-configurable accessor key on an identifier
+    // receiver. Per ES §6.2.5.6, an omitted `configurable` defaults to false, so
+    // the accessor is non-configurable unless `configurable: true` was given.
+    // This fast path doesn't mirror the flag into `_wasmPropDescs`, so the
+    // struct-field `delete` site consults this set to refuse the delete
+    // (OrdinaryDelete ⇒ false; strict ⇒ TypeError) — `__delete_property` alone
+    // would wrongly report success.
+    if (descConfigurable !== true && ts.isIdentifier(objArg)) {
+      ctx.nonConfigurableAccessorKeys.add(`${objArg.text}:${propName}`);
+    } else if (descConfigurable === true && ts.isIdentifier(objArg)) {
+      // A later `configurable: true` redefine clears any earlier non-configurable
+      // record for the same key (last-write-wins, mirroring runtime semantics).
+      ctx.nonConfigurableAccessorKeys.delete(`${objArg.text}:${propName}`);
+    }
 
     // (#1888 S5c / C2) STORE arm — land dark behind `S5C_STRUCT_ACCESSOR_CLOSURE`.
     // The #1629-S3 bare `${struct}_get/set_${prop}` fns below have NO capture
@@ -4261,20 +4297,50 @@ export function compilePropertyIntrospection(
     // Route through the runtime helper so the tombstone (`__delete_property`
     // path) and any sidecar accessor entries are consulted.
     //
-    // The signal we use is `ctx.definedPropertyFlags`: it's populated only
-    // when `Object.defineProperty` is statically observed, so we only pay
-    // the runtime call cost on objects that have actually been mutated.
+    // The signals we use are `ctx.definedPropertyFlags` AND
+    // `ctx.sidecarDefinedPropertyKeys`: both are populated only when
+    // `Object.defineProperty` is statically observed, so we only pay the
+    // runtime call cost on objects that have actually been mutated.
     // Anonymous receivers (e.g. `({}).hasOwnProperty(...)`) skip this path.
+    //
+    // (#2726) `definedPropertyFlags` is populated ONLY for *inline* object-literal
+    // descriptors (`defineProperty(o, k, { value: 1 })`). The dominant ES5
+    // `var d = { value: 1, configurable: true }; defineProperty(o, k, d)` shape
+    // (the `15.2.3.6-3-*` cluster) routes through `emitDefinePropertyDescRuntime`,
+    // which records the key in `sidecarDefinedPropertyKeys` instead. Without
+    // consulting that set, `hasOwnProperty` constant-folds to `true` because the
+    // queried key is in the (defineProperty-widened) struct shape, ignoring a
+    // subsequent configurable `delete` that tombstoned it — the root of the
+    // `11.4.1-4.a-1/-2`, `11.4.1-4-a-4-s` failures.
     const recvVarName = ts.isIdentifier(propAccess.expression) ? propAccess.expression.text : undefined;
     let needsRuntime = false;
     if (recvVarName) {
-      // Cheap pre-check: if any defineProperty entry exists for this var,
-      // the runtime tombstone / descriptor map could differ from the static
-      // shape answer. Bail to the runtime path.
-      for (const k of ctx.definedPropertyFlags.keys()) {
-        if (k.startsWith(`${recvVarName}:`)) {
+      const prefix = `${recvVarName}:`;
+      // Cheap pre-check: if any defineProperty entry exists for this var
+      // (`definePropertyReceiverKeys` records EVERY lowering path uniformly;
+      // `definedPropertyFlags` / `sidecarDefinedPropertyKeys` are kept as
+      // belt-and-braces), the runtime tombstone / descriptor map could differ
+      // from the static shape answer. Bail to the runtime path.
+      for (const k of ctx.definePropertyReceiverKeys) {
+        if (k.startsWith(prefix)) {
           needsRuntime = true;
           break;
+        }
+      }
+      if (!needsRuntime) {
+        for (const k of ctx.definedPropertyFlags.keys()) {
+          if (k.startsWith(prefix)) {
+            needsRuntime = true;
+            break;
+          }
+        }
+      }
+      if (!needsRuntime) {
+        for (const k of ctx.sidecarDefinedPropertyKeys) {
+          if (k.startsWith(prefix)) {
+            needsRuntime = true;
+            break;
+          }
         }
       }
     }

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -45,6 +45,38 @@ function emitDeleteThrow(ctx: CodegenContext, fctx: FunctionContext, message: st
 }
 
 /**
+ * (#2726 group (d)) Emit the OrdinaryDelete refusal for `delete obj.<prop>` of a
+ * statically-known NON-configurable accessor (defined via the inline-accessor
+ * `Object.defineProperty` fast path, whose `configurable:false` flag never
+ * reaches the runtime `__delete_property`). Per §13.5.1.2 + OrdinaryDelete: the
+ * receiver is evaluated for side effects, the property is left untouched, and the
+ * result is `false` — which in strict mode (§13.5.1.2 step 6.b) is a TypeError.
+ * Returns `true` if the refusal was emitted (the caller should `return` the i32),
+ * `false` if the key is not a tracked non-configurable accessor (caller proceeds
+ * with the normal runtime-driven delete).
+ */
+function maybeEmitNonConfigurableAccessorDelete(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.DeleteExpression,
+  receiver: ts.Expression,
+  fieldName: string,
+): boolean {
+  if (!ts.isIdentifier(receiver)) return false;
+  if (!ctx.nonConfigurableAccessorKeys.has(`${receiver.text}:${fieldName}`)) return false;
+  // Evaluate the receiver for its side effects, then drop it.
+  const recvType = compileExpression(ctx, fctx, receiver);
+  if (recvType) fctx.body.push({ op: "drop" });
+  // Strict mode: a refused non-configurable delete is a TypeError.
+  if (isStrictContext(expr)) {
+    emitDeleteThrow(ctx, fctx, "TypeError: Cannot delete non-configurable property in strict mode");
+  }
+  // Sloppy mode: the delete expression evaluates to `false`.
+  fctx.body.push({ op: "i32.const", value: 0 });
+  return true;
+}
+
+/**
  * (#2703) Strict-mode wrapper around a `__delete_property` result (an i32 on
  * the stack). In strict mode a `false` result — a non-configurable own
  * property whose delete was refused — is a TypeError (§13.5.1.2 step 6.b); in
@@ -248,6 +280,10 @@ export function compileDeleteExpression(
         const fieldIdx = fields.findIndex((f) => f.name === fieldName);
         if (fieldIdx !== -1 && fields[fieldIdx]!.mutable) {
           const fieldType = fields[fieldIdx]!.type;
+          // (#2726 group (d)) Non-configurable accessor → refuse the delete.
+          if (maybeEmitNonConfigurableAccessorDelete(ctx, fctx, expr, inner.expression, fieldName)) {
+            return { kind: "i32" };
+          }
           // (#1334 / #2703) Compile the receiver once, save to a local, then
           //   (a) clear any sidecar descriptor entry via `__delete_property`
           //       (which reports configurability), and
@@ -340,6 +376,10 @@ export function compileDeleteExpression(
         const fieldIdx = fields.findIndex((f) => f.name === fieldName);
         if (fieldIdx !== -1 && fields[fieldIdx]!.mutable) {
           const fieldType = fields[fieldIdx]!.type;
+          // (#2726 group (d)) Non-configurable accessor → refuse the delete.
+          if (maybeEmitNonConfigurableAccessorDelete(ctx, fctx, expr, inner.expression, fieldName)) {
+            return { kind: "i32" };
+          }
           // (#1821 / #2703) Mirror the property-access arm: clear the sidecar/
           // descriptor entry via __delete_property, reset the struct field to
           // its sentinel ONLY on a successful delete, and throw in strict mode

--- a/tests/issue-2726.test.ts
+++ b/tests/issue-2726.test.ts
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #2726 — delete residual (non-throw): hasOwnProperty-after-delete for a
+// `Object.defineProperty`'d property on a statically `{}`-typed struct, plus the
+// strict-mode TypeError on deleting a non-configurable accessor.
+//
+// Root cause: `var o = {}` infers an empty struct type, so `o.hasOwnProperty(k)`
+// constant-folds against the (defineProperty-widened) static struct shape and
+// ignores a subsequent configurable `delete`'s `_wasmStructDeletedKeys`
+// tombstone. The dominant ES5 shape `var d = {...}; Object.defineProperty(o,k,d)`
+// routes through the runtime descriptor applier, which `definedPropertyFlags`
+// (inline-literal only) never sees — so the fold's runtime-routing guard never
+// fired. The inline-accessor fast path additionally never mirrored
+// `configurable:false` to the runtime, so `delete obj.accessor` wrongly succeeded.
+
+async function run(source: string): Promise<unknown> {
+  const result = await compile(source);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports as Record<string, (...a: unknown[]) => unknown>);
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>).test();
+}
+
+describe("#2726 delete residual", () => {
+  // (c) 11.4.1-4.a-1: configurable data property, variable descriptor.
+  it("hasOwnProperty is false after deleting a configurable data property (variable descriptor)", async () => {
+    const src = `
+      export function test(): number {
+        var o = {};
+        var desc = { value: 1, configurable: true };
+        Object.defineProperty(o, 'foo', desc);
+        var d = delete o.foo;
+        if (d !== true) return 10;
+        if (o.hasOwnProperty('foo') !== false) return 11;
+        return 1;
+      }`;
+    expect(await run(src)).toBe(1);
+  });
+
+  // (c) 11.4.1-4.a-2: configurable accessor property, variable descriptor.
+  it("hasOwnProperty is false after deleting a configurable accessor property (variable descriptor)", async () => {
+    const src = `
+      export function test(): number {
+        var o = {};
+        var getter = function() { return 1; };
+        var desc = { get: getter, configurable: true };
+        Object.defineProperty(o, 'foo', desc);
+        var d = delete o.foo;
+        if (d !== true) return 10;
+        if (o.hasOwnProperty('foo') !== false) return 11;
+        return 1;
+      }`;
+    expect(await run(src)).toBe(1);
+  });
+
+  // (c) 11.4.1-4-a-4-s: configurable accessor, inline descriptor.
+  it("hasOwnProperty is false after deleting a configurable inline-accessor property", async () => {
+    const src = `
+      export function test(): number {
+        var obj = {};
+        Object.defineProperty(obj, 'prop', {
+          get: function() { return 'abc'; },
+          configurable: true,
+        });
+        delete obj.prop;
+        if (obj.hasOwnProperty('prop') !== false) return 11;
+        return 1;
+      }`;
+    expect(await run(src)).toBe(1);
+  });
+
+  // defineProperty WITHOUT a following delete must still report the property as own.
+  it("hasOwnProperty stays true for a defineProperty'd property that is not deleted", async () => {
+    const src = `
+      export function test(): number {
+        var o = {};
+        var d = { value: 1, configurable: true };
+        Object.defineProperty(o, 'a', d);
+        if (o.hasOwnProperty('a') !== true) return 10;
+        return 1;
+      }`;
+    expect(await run(src)).toBe(1);
+  });
+
+  // (d) 11.4.1-4-a-2-s: strict-mode delete of a non-configurable accessor throws
+  // TypeError, and the property survives.
+  it("strict delete of a non-configurable accessor throws TypeError and leaves the property", async () => {
+    const src = `
+      export function test(): number {
+        "use strict";
+        var obj = {};
+        Object.defineProperty(obj, 'prop', {
+          get: function() { return 'abc'; },
+          configurable: false,
+        });
+        var threw = 0;
+        try {
+          delete obj.prop;
+        } catch (e) {
+          threw = 1;
+        }
+        if (threw !== 1) return 10;
+        if (obj.prop !== 'abc') return 11;
+        return 1;
+      }`;
+    expect(await run(src)).toBe(1);
+  });
+
+  // Sloppy-mode delete of a non-configurable accessor returns false (no throw),
+  // and the property survives.
+  it("sloppy delete of a non-configurable accessor returns false and leaves the property", async () => {
+    const src = `
+      export function test(): number {
+        var obj = {};
+        Object.defineProperty(obj, 'prop', {
+          get: function() { return 'abc'; },
+          configurable: false,
+        });
+        var d = delete obj.prop;
+        if (d !== false) return 10;
+        if (obj.prop !== 'abc') return 11;
+        return 1;
+      }`;
+    expect(await run(src)).toBe(1);
+  });
+});

--- a/tests/issue-2726.test.ts
+++ b/tests/issue-2726.test.ts
@@ -27,6 +27,20 @@ async function run(source: string): Promise<unknown> {
   return (instance.exports as Record<string, (...a: unknown[]) => unknown>).test();
 }
 
+// Standalone (pure-Wasm, no JS host) compile + run. The standalone
+// `__hasOwnProperty` does NOT report a `defineProperty`-added struct-shape
+// property as own, so the host-mode runtime-routing of `hasOwnProperty`
+// (groups (c)) must be gated to host mode (#2726 standalone-floor park on PR
+// #2177). This runner exercises that gate.
+async function runStandalone(source: string): Promise<unknown> {
+  const result = await compile(source, { target: "standalone" });
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>).test();
+}
+
 describe("#2726 delete residual", () => {
   // (c) 11.4.1-4.a-1: configurable data property, variable descriptor.
   it("hasOwnProperty is false after deleting a configurable data property (variable descriptor)", async () => {
@@ -128,5 +142,32 @@ describe("#2726 delete residual", () => {
         return 1;
       }`;
     expect(await run(src)).toBe(1);
+  });
+
+  // (#2177 standalone-floor park) In STANDALONE mode the broad host-routing of
+  // `hasOwnProperty`/`propertyIsEnumerable` must NOT fire: the wasm-native
+  // `__hasOwnProperty` returns false for a defineProperty-added struct-shape
+  // property, which regressed ~12 built-ins/Object/{defineProperty,prototype/
+  // hasOwnProperty} tests. Gating the new signals to host mode keeps the
+  // (correct, no-delete) const-fold in standalone.
+  it("standalone: hasOwnProperty is true after defineProperty of an inline accessor (no delete)", async () => {
+    const src = `
+      export function test(): number {
+        var o = {};
+        Object.defineProperty(o, "foo", { get: function() { return 42; } });
+        return o.hasOwnProperty("foo") ? 1 : 0;
+      }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+
+  it("standalone: hasOwnProperty is true after defineProperty with a variable descriptor (no delete)", async () => {
+    const src = `
+      export function test(): number {
+        var o = {};
+        var d = { value: 1001, enumerable: true, configurable: true };
+        Object.defineProperty(o, "property", d);
+        return o.hasOwnProperty("property") ? 1 : 0;
+      }`;
+    expect(await runStandalone(src)).toBe(1);
   });
 });


### PR DESCRIPTION
## #2726 — delete residual (non-throw), groups (c) + (d)

Continuation of sprint 67. #2731 (merged) fixed the `any`/host path; the residual
failures are on the **WasmGC-struct** lowering path (`var o = {}` infers an empty
struct type).

### Group (c) — `hasOwnProperty` true after a configurable defineProperty + delete
`o.hasOwnProperty('foo')` was **constant-folded to `i32.const 1`** against the
static struct shape, which `Object.defineProperty` *widens* to include `foo` —
ignoring a later configurable `delete`'s `_wasmStructDeletedKeys` tombstone. The
fold's runtime-routing guard only consulted `definedPropertyFlags`, populated
**only for inline object-literal descriptors**. The dominant ES5
`var d = {...}; Object.defineProperty(o, k, d)` shape and the inline-accessor fast
path were missed.

**Fix:** new `ctx.definePropertyReceiverKeys`, recorded at the single
`compileObjectDefineProperty` chokepoint across **every** lowering path. Routes
`hasOwnProperty`/`propertyIsEnumerable` to the runtime `__hasOwnProperty` helper
(which honours the tombstone). Kept separate from `definedPropertyFlags` /
`sidecarDefinedPropertyKeys` so it never perturbs descriptor-flag or
`getOwnPropertyDescriptor` routing.

### Group (d) — strict delete of a non-configurable accessor must throw
The inline-accessor fast path never mirrored `configurable:false` into the runtime
`_wasmPropDescs`, so `__delete_property` reported a bogus success.

**Fix:** new `ctx.nonConfigurableAccessorKeys` (populated when `configurable !== true`;
omitted ⇒ false per §6.2.5.6). The struct-field `delete` site emits OrdinaryDelete's
refusal (`false`; strict ⇒ TypeError, property intact) without the runtime call.

### Test Results (host/gc lane, authoritative `runTest262File`)
| cluster | baseline → fix |
|---|---|
| `delete` + `hasOwnProperty` + `propertyIsEnumerable` | 117 → 121, **0 regressions** |
| `defineProperty` + `getOwnPropertyDescriptor` + `defineProperties` | 207 → 207 |
| `freeze`+`seal`+`preventExtensions`+`create`+`getOwnPropertyNames` | 400 → 402, **0 regressions** |
| `for-in` + `keys` + `expressions/object` | 363 → 363 |

**Net +6 test262, 0 regressions** across ~4,500 most-related tests. Flipped:
`11.4.1-4.a-1`, `11.4.1-4.a-2`, `11.4.1-4-a-4-s` (c), `11.4.1-4-a-2-s` (d), plus
siblings `Object/freeze/15.2.3.9-2-3` and `Object/seal/...inherited-accessor...`.
Regression test: `tests/issue-2726.test.ts`.

### Out of scope (issue stays open)
(a) sloppy unresolvable-identifier oracle + (b) sloppy global-object model are
**structural** (architect-spec first); (e) mapped-arguments delete **deferred to
#1726**; (f)/(g) re-route to their owning feature issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)