### PR TITLE
docs(#2744,#2743): architect impl plans for [[Extensible]] slot + arguments-object

### DIFF
--- a/plan/issues/2743-arguments-object-prototype-constructor-iterator-unmapped-nonsimple.md
+++ b/plan/issues/2743-arguments-object-prototype-constructor-iterator-unmapped-nonsimple.md
@@ -74,3 +74,115 @@ and the binding must still be readable:**
   eval-based `10.5-*-s.js` SyntaxError tests (eval-blocked).
 - Spec: ES2023 §10.4.4 (Arguments Exotic Objects), `CreateUnmappedArgumentsObject`
   §10.4.4.6, `CreateMappedArgumentsObject` §10.4.4.7.
+
+## Implementation Plan (architect: esch, 2026-06-27) — senior-dev
+
+**VERIFIED on current `origin/main` HEAD via the real `runTest262File` runner +
+`compile()` probes.** Three independent sub-bugs; (c) is the highest-leverage and
+also clears the Wasm-emit failure.
+
+### Root cause (verified)
+
+The `arguments` object is built as a **vec struct** — `{ length:i32,
+data:array<externref> }` — by `emitArgumentsVecBody` / `emitArgumentsObject`
+(`src/codegen/statements/nested-declarations.ts:2109-2311`). It is NOT an ordinary
+Object: no `[[Prototype]]` link to `%Object.prototype%`, no `.constructor`, no
+`@@iterator`. So:
+
+- **(a)** `Object.getPrototypeOf(arguments)` → host `__getPrototypeOf` sees an opaque
+  vec → null, not `%Object.prototype%`; `arguments.constructor` → `__extern_get(vec,
+  "constructor")` → undefined. The tests' catch blocks fire ("arguments doesn't
+  exist"). Runner: `10.6-5-1.js` fails `sameValue(Object.getPrototypeOf(arguments),
+  Object.getPrototypeOf(...))`.
+- **(b)** `arguments[Symbol.iterator]` → the computed member-get on a vec coerces the
+  key via `ToNumber` to index the array → **"Cannot convert a Symbol value to a
+  number"** (verified both mapped + unmapped). Per §10.4.4.6 step 2 / §10.4.4.7
+  step 5, `@@iterator` must be `%Array.prototype.values%`.
+- **(c)** A **non-simple parameter list** (rest / default / destructuring) MUST
+  produce an **unmapped** arguments object (FunctionDeclarationInstantiation step 22.a:
+  unmapped iff `strict OR !IsSimpleParameterList`). But `emitArgumentsObject` is
+  invoked with `unmapped = isStrictFunction(stmt, …)` **only** (`nested-declarations.ts:521`,
+  and the other call sites) — it ignores the non-simple-params case. So a sloppy
+  `function dflt(a, b=0){ arguments[0]=2; }` gets a MAPPED arguments object; the
+  `arguments[0]=2` write maps back into param `a` → `value` becomes 2 (`via-params-
+  dflt.js`/`via-params-dstr.js` fail `sameValue(value,1)`). For `function rest(a,
+  ...b){ arguments[0]=2; }` the mapped write-back tries to `local.set` the named
+  param through a type mismatch the rest-param shape can't satisfy → the
+  **`local.set[0] expected type (ref …)` "invalid Wasm binary"** at instantiation
+  (`via-params-rest.js`, `compile_error`). The Wasm error is a SYMPTOM of the wrong
+  (mapped) arguments object; fixing the unmapped detection removes it.
+
+### Changes
+
+**(c) — FIRST, fixes 3 tests incl. the Wasm-emit failure. File:
+`src/codegen/statements/nested-declarations.ts` (+ all `emitArgumentsObject` callers).**
+- Add `isSimpleParameterList(params: readonly ts.ParameterDeclaration[]): boolean`
+  — false if ANY param has `dotDotDotToken` (rest), `initializer` (default), or a
+  binding-pattern name (`ts.isObjectBindingPattern`/`ts.isArrayBindingPattern`).
+  (The AST predicates already exist piecewise at `src/codegen/declarations.ts:2524-2538`.)
+- At every `emitArgumentsObject` call site, change `unmapped` from
+  `isStrictFunction(stmt, …)` to `isStrictFunction(stmt, …) || !isSimpleParameterList(stmt.parameters)`.
+  Call sites: `nested-declarations.ts:521`, `:793`; `src/codegen/literals.ts:2544`
+  (function-expression path); `src/codegen/class-bodies.ts:2247` (already passes
+  `true` — methods; verify); and the inline arguments path in
+  `src/codegen/function-body.ts:977`. When `unmapped` is true, `mappedArgsInfo`
+  (`nested-declarations.ts:2292-2301`) is skipped → no write-back → no bad
+  `local.set` → `via-params-rest` compiles AND the indices reflect the call args.
+- This is the **highest-confidence, broadest** fix. Land it as PR-1.
+
+**(a) — `[[Prototype]]` + `.constructor`. Files: `src/codegen/...` (mark the vec) +
+`src/runtime.ts` (host MOP).** Mark the arguments vec so the host MOP recognizes it:
+- Tag it via a runtime registration (a `_argumentsObjects = new WeakSet<object>()`
+  populated by a small `__register_arguments(vec)` host import emitted right after
+  the `struct.new` in `emitArgumentsVecBody:2254`), mirroring the existing
+  `__register_fnctor_instance` pattern (host-mode only; standalone keeps the vec).
+- In `__getPrototypeOf` (`runtime.ts:9353`): if `_argumentsObjects.has(obj)` → return
+  the real JS `Object.prototype` (the host realm's, the same identity `Object.*`
+  resolves to), so `Object.getPrototypeOf(arguments) === Object.prototype` and the
+  `.constructor` walk reaches `Object`.
+- In the dynamic property read (`__extern_get`, `runtime.ts:~4170`): if
+  `_argumentsObjects.has(obj)` and key === `"constructor"` → return host `Object`;
+  fall through to the proto walk for other string keys. Numeric indices + `length`
+  keep the existing vec path.
+
+**(b) — `@@iterator`. Files: the computed member-get codegen + `__extern_get`.**
+- The Symbol→number coercion happens because the computed-index lowering applies
+  `ToNumber` to ANY key on a vec. Gate it: a **Symbol** key must NOT be coerced to a
+  number — route a Symbol-keyed get on a vec/arguments to the property path. In
+  `__extern_get` (or the symbol-keyed member-access path), when
+  `_argumentsObjects.has(obj)` (or generally a vec) and `typeof key === "symbol" &&
+  key === Symbol.iterator` → return `%Array.prototype.values%` bound to the vec's
+  indexed values (the host `Array.prototype.values` invoked on an array view of the
+  vec, or a small closure yielding `obj[0..length-1]`). This fixes both
+  `unmapped/Symbol.iterator.js` and `mapped/Symbol.iterator.js` (no Symbol→number
+  trap). NB: locate the Symbol→number trap site for indexed get — the compile-time
+  emit is in `binary-ops.ts:277`/`string-ops.ts:2074`; the *runtime* "in test()"
+  message means the trap is reached via the dynamic key path, so the guard belongs at
+  the vec computed-get dispatch BEFORE ToNumber.
+
+### Edge cases
+- Mapped vs unmapped `@@iterator`: BOTH get `%Array.prototype.values%` (the iterator
+  is identical for both forms; only index↔param aliasing differs, which (c) governs).
+- `arguments.length` / numeric `arguments[n]` must keep working (existing vec path) —
+  the (a)/(b) MOP hooks must fall through to the vec path for those keys.
+- Strict functions already get unmapped via `isStrictFunction`; the new
+  `|| !isSimpleParameterList` is additive (don't double-apply).
+- Standalone/WASI: the `__register_arguments` + host-`Object.prototype` linkage is
+  host-mode; standalone keeps the vec. (a)/(b) acceptance is host-mode (the tests run
+  host). Note a standalone follow-up if needed.
+- OUT (per issue): `mapped/*` exotic descriptor aliasing → #1726; eval `10.5-*-s.js`.
+
+### Verdict
+**Senior-dev** (the issue's routing — (a)/(b) touch the host MOP + a new vec marker;
+(c) touches arguments-object lowering across 5 call sites). Sequence: **PR-1 = (c)**
+(simple-param-list → unmapped; clears the Wasm-emit failure + 3 tests, lowest risk),
+**PR-2 = (a)+(b)** (vec marker + `__getPrototypeOf`/`__extern_get`/`@@iterator` MOP
+hooks). (c) alone already meets a meaningful slice of the ≥9 target; (a)+(b) banks the
+remaining (a)-group (≥5) and the 2 Symbol.iterator tests.
+
+### Test files (authoritative runner reasons, current main)
+- `S10.6_A2.js`/`S10.6_A4.js`/`S10.6_A3_T1.js` → "arguments doesn't exist" (a)
+- `10.6-5-1.js` → `getPrototypeOf(arguments)` ≠ `Object.prototype` (a)
+- `unmapped/Symbol.iterator.js`, `mapped/Symbol.iterator.js` → Symbol→number trap (b)
+- `unmapped/via-params-dflt.js`, `via-params-dstr.js` → `sameValue(value,1)` (c)
+- `unmapped/via-params-rest.js` → `local.set[0] expected type` invalid Wasm (c)

--- a/plan/issues/2744-object-extensible-slot-preventextensions-seal-freeze-queries.md
+++ b/plan/issues/2744-object-extensible-slot-preventextensions-seal-freeze-queries.md
@@ -80,3 +80,138 @@ queryable `[[Extensible]]` slot on our object representation.
   orthogonal to descriptor read-back and can land independently.
 - `seal-finalizationregistry.js` (FinalizationRegistry) and Proxy-handler seal
   tests are out of scope (blocked clusters).
+
+## Implementation Plan (architect: esch, 2026-06-27) — dev-implementable
+
+**VERIFIED on current `origin/main` HEAD via `compile()`+run probes and the real
+`runTest262File` runner.** The runtime machinery already EXISTS and is correct for
+`$Object`/externref receivers (`_wasmNonExtensibleObjs`/`_wasmFrozenObjs`/
+`_wasmSealedObjs` WeakSets at `src/runtime.ts:1436-1437` + `_getSidecarDescs`). The
+failures are a **codegen routing bug** + a **query-correctness gap**, not a missing
+slot. The issue's "absence of a queryable slot" framing is half-right: the slot
+exists for `$Object` but is never *reached* for `ref`-typed object receivers.
+
+### Root cause (verified)
+
+The integrity codegen (`src/codegen/expressions/calls.ts:5709-5893`) treats **any
+non-`externref` `argType` as a primitive**. An array (vec `ref`), a typed object
+literal struct (`ref`), and a typed `Date` (`ref`) are OBJECTS but compile to
+`ref`/`ref_null`, so the `else if (argType)` arms mis-fire:
+- `isExtensible` (`:5883-5888`) → folds to `i32.const 0` → **wrong (false)**.
+- `isFrozen`/`isSealed` (`:5841-5846`) → folds to `i32.const 1` → **wrong (true)**.
+- `freeze`/`seal`/`preventExtensions` (`:5797-5798`) → returns the arg as-is,
+  relying ONLY on order-blind compile-time `nonExtensibleVars`/`frozenVars`/
+  `sealedVars` keyed on the identifier — so the runtime WeakSet is never populated
+  for `ref` receivers, and a `var pre = Object.isExtensible(arr)` *pre-check* before
+  `Object.seal(arr)` reads stale (the tracking set isn't populated until the later
+  `seal` call is compiled).
+
+Probe evidence (host mode, current main):
+`Object.isExtensible([0,1])` → `0` (must be 1); `Object.isExtensible({x:1,y:2})`
+(typed struct) → `0` (must be 1); `Object.isExtensible(o)` for `o:any` (`$Object`)
+→ correct. So ONLY the `ref`-typed object path is broken; `any`/`$Object` works.
+
+A second, independent gap: `__object_isFrozen`/`__object_isSealed`
+(`runtime.ts:8432/8443`) answer via `_wasmFrozenObjs.has(obj)` /
+`_wasmSealedObjs.has(obj)` — i.e. "was `Object.freeze/seal` *called*", NOT
+TestIntegrityLevel (§7.3.16) over the live descriptor table. So
+`Object.preventExtensions(o)` on an object with a configurable accessor returns the
+wrong `isFrozen` (must be false; `built-ins/Object/isFrozen/15.2.3.12-2-c-2.js`), and
+a manually-non-configurable-but-never-sealed object misreports.
+
+### Changes
+
+**File: `src/codegen/expressions/calls.ts`** (the four integrity sites, 5709-5893)
+- Add a local predicate `isObjectRef(t)` = `t.kind` is `ref`/`ref_null`/`anyref`/
+  `eqref`/`externref` (an object), NOT a primitive (`f64`/`i32`/`i64`/`v128`/`funcref`).
+- **`isExtensible`/`isFrozen`/`isSealed` general case:** replace the
+  `else if (argType)` primitive-fold with: **if `isObjectRef(argType)` and not
+  already externref → `extern.convert_any` to externref**, then call the runtime
+  `__object_is*` helper (the existing externref arm). Fold to the primitive answer
+  (`isExtensible`→0, `isFrozen`/`isSealed`→1) ONLY for genuine primitives. This is
+  the same `extern.convert_any` coercion the freeze SET path already does for
+  standalone at `:5766-5773` — generalize it to all modes AND to the query path.
+- **`freeze`/`seal`/`preventExtensions` (`:5766-5798`):** generalize the
+  standalone-only coercion to ALL modes — when `isObjectRef(argType)` and not
+  externref, `extern.convert_any` and call the `__object_*` SET helper so the
+  WeakSet/descriptor state is recorded for vec/struct/Date receivers (not just
+  `$Object`). Keep the compile-time `markIntegrity` var-marking as an ADDITIONAL
+  fast-path for the strict-mode write-throw decision (below), but it must no longer
+  be the *only* effect for `ref` receivers.
+- **Retire the host-mode static fold as the source of truth for queries.** The
+  `nonExtensibleVars`/`frozenVars` const-folds (`:5818-5828`, `:5866-5871`) are
+  execution-order-blind (the #1472 comments already say so) and produce the
+  pre-check-before-seal bug. Now that the runtime query is authoritative for object
+  refs, **drop these host-mode static folds** (standalone already skips them) so the
+  pre-check reads live runtime state. This fixes every `assert(Object.isExtensible(o))`
+  / `preCheck` failure in the seal/preventExtensions tests.
+
+**File: `src/runtime.ts`** — reimplement the queries as TestIntegrityLevel (§7.3.16)
+- `__object_isSealed` (`:8443`) and `__object_isFrozen` (`:8432`): for a wasm
+  struct/vec receiver, compute from OUR representation — `level = sealed`:
+  `_wasmNonExtensibleObjs.has(obj)` AND for EVERY own key (struct field shape via
+  `_getStructFieldNames` + sidecar props in `_wasmStructProps`) the descriptor in
+  `_getSidecarDescs(obj)` has `configurable === false`; `level = frozen` additionally
+  requires `writable === false` for every data property. Do NOT fall through to
+  native `Object.isFrozen/isSealed` for a wasm struct/vec (it sees an opaque
+  null-proto proxy and lies). Keep the `_wasmFrozenObjs`/`_wasmSealedObjs` add in the
+  SET helpers as a fast-path cache, but the QUERY must verify the live descriptor
+  table so post-`freeze` manual reconfigurations and `preventExtensions`+configurable
+  cases answer correctly.
+- Ensure the SET helpers' `_isWasmStruct(obj)` gate (`:8354/8384/8413`) ALSO covers
+  the **vec/array** representation. Verify `_isWasmStruct([...])` is true for a vec;
+  if arrays are a distinct vec struct that `_isWasmStruct` rejects, broaden the gate
+  (or add a vec arm) so `Object.seal(arr)`/`isSealed(arr)` don't fall to native
+  `Object.*` on a vec proxy (`built-ins/Object/seal/object-seal-o-is-an-array-object.js`).
+
+### Edge cases / sub-cases
+- **Group (c) — sloppy frozen write must be a SILENT no-op.** A plain `o.a = v`
+  assignment to a frozen data property currently throws `TypeError: Cannot assign to
+  read only property` unconditionally (`built-ins/Object/freeze/15.2.3.9-2-c-3.js`).
+  Per §13.15.2 / PutValue, a write to a non-writable property is a **silent no-op in
+  sloppy mode** and throws **only under `"use strict"`**. test262 defaults to sloppy.
+  The frozen-write throw is in the `needsValueCompare`/`isFrozenProperty` path
+  (`src/codegen/object-ops.ts:2202-2240`) AND the plain member-assign equivalent —
+  gate the throw on the function's strict-mode flag (reuse
+  `isStrictFunction(...)` / the same strictness the rest of codegen consults).
+  Keep the strict-mode throw (other tests assert it).
+- **Global object — OUT OF PRIMARY SCOPE (1-2 tests).** `var global = this;
+  Object.isExtensible(global)` must be true (`isExtensible/15.2.3.13-2-1.js`); the
+  top-level `this`/global is not a queryable object in our model → returns 0. This
+  OVERLAPS **#2726** (sloppy global-object model). Note it; do not block the ≥45
+  target on it.
+- **Date / built-in exotics:** once `ref` object receivers route to the runtime,
+  `Object.isExtensible(new Date(0))` returns true (verified for an `any`-typed Date).
+  Confirm the typed-`Date` `ref` path coerces and that `_isWasmStruct(date)` (or the
+  Date representation) is recognized by the SET/IS helpers.
+- The compile-time `frozenVars`/`nonExtensibleVars` tracking REMAINS only for the
+  strict-mode write-throw decision; it is no longer authoritative for queries.
+
+### Coordination with #2668 (REQUIRED, but the slot is independent)
+seal/freeze flip `configurable`/`writable` in `_getSidecarDescs` (the `_SC_*` bits).
+The new TestIntegrityLevel reader READS those same bits #2668's
+`getOwnPropertyDescriptor` read-back writes/reads — **align the `_SC_WRITABLE`/
+`_SC_CONFIGURABLE`/`_SC_ENUMERABLE`/`_SC_DEFINED` semantics with the #2668 senior-dev**
+so seal/freeze and descriptor read-back agree. BUT the **`[[Extensible]]` slot +
+the coerce-object-ref-to-runtime routing is ORTHOGONAL** (per the issue note) and
+should land FIRST — it banks the large array/struct `isExtensible`/`isSealed` cluster
+on its own. The TestIntegrityLevel descriptor-precision can co-develop with #2668.
+
+### Verdict
+**Dev-implementable** (regular dev). The routing fix (coerce object refs → runtime)
+is the high-value bulk (~40+ of the ~55: every array/typed-struct/Date `is*` + the
+pre-check failures). The TestIntegrityLevel reimpl is localized to two runtime
+functions. Strict-mode sloppy-write (group c) and the global object are smaller
+follow-ons. No new object representation. Sequence: routing+drop-static-fold first,
+then TestIntegrityLevel (coordinate `_SC_*` with #2668), then group (c) strict-gate.
+
+### Test files (authoritative runner reasons, current main)
+- `isExtensible/15.2.3.13-2-1.js` → `assert(isExtensible(global))` (global sub-case)
+- `preventExtensions/15.2.3.10-3-8.js` → `assert(isExtensible(new Date(0)))` pre-check
+- `seal/object-seal-o-is-an-array-object.js` → array pre-check (vec ref → false)
+- `seal/object-seal-non-enumerable-own-property-of-o-is-sealed.js` → obj pre-check
+- `isFrozen/15.2.3.12-2-c-2.js` → preventExtensions+configurable accessor → isFrozen
+  must be false (TestIntegrityLevel)
+- `isSealed/15.2.3.11-4-26.js`, `isFrozen/15.2.3.12-2-1.js` → query correctness
+- `freeze/15.2.3.9-2-c-3.js` → sloppy frozen write must NOT throw (group c)
+- Regression watch: `built-ins/Object/{freeze,seal,preventExtensions,is*}` already green.


### PR DESCRIPTION
Plan-only docs — `## Implementation Plan` for the two PO-filed architect-gate issues. **Stacked on #2176** (base `docs-s67-es3-wave2-grooming`, which adds the issue files); auto-retargets to `main` when #2176 merges. All claims VERIFIED on current `origin/main` via `compile()`+run probes and the real `runTest262File` runner.

## #2744 — `[[Extensible]]` slot + integrity methods (dev-implementable)
Root cause is **not** a missing slot — the runtime `_wasmNonExtensibleObjs`/`_wasmFrozenObjs`/`_wasmSealedObjs` WeakSets + sidecar descriptors already exist and work for `$Object`/externref. The bug is **codegen routing**: `calls.ts:5709-5893` treats any **non-externref** `argType` as a primitive, so arrays (vec `ref`) and typed object structs fold `isExtensible→0` / `isFrozen,isSealed→1`. Verified: `Object.isExtensible([0,1])→0`, `Object.isExtensible({x,y})→0`, while `any`/`$Object` works.
- Fix: coerce object refs to externref + route to the runtime for ALL representations; **drop the order-blind static fold** (fixes the `preCheck` failures); reimplement `__object_isFrozen`/`isSealed` as **TestIntegrityLevel (§7.3.16)** over the descriptor table.
- Group (c): sloppy frozen write must be a **silent no-op** (strict-gate the throw). Global object (`this`) overlaps **#2726**. Coordinate `_SC_*` flag semantics with the **#2668** senior-dev — but the slot/routing lands independently.

## #2743 — arguments object as ordinary Object (senior-dev)
`arguments` is a **vec struct**, not an Object.
- **(c)** non-simple param lists (rest/default/destructuring) must be **unmapped**, but `emitArgumentsObject` only passes `unmapped=isStrictFunction` (`nested-declarations.ts:521`) — add `|| !isSimpleParameterList`. This **also clears the `via-params-rest` "invalid Wasm binary"** (`local.set[0]` type mismatch is the mapped-sync writing through a rest param). Lowest-risk → PR-1.
- **(a)/(b)** mark the vec + host MOP hooks: `__getPrototypeOf→Object.prototype`, `.constructor→Object`, `@@iterator→%Array.prototype.values%` (no Symbol→number coerce). → PR-2.

No source changes — `plan/issues/` only.