### PR TITLE
fix(#2739): for-in walks a setPrototypeOf prototype chain (part a)

### DIFF
--- a/plan/issues/2747-forin-fnctor-prototype-chain-and-defineproperty-array-order.md
+++ b/plan/issues/2747-forin-fnctor-prototype-chain-and-defineproperty-array-order.md
@@ -1,0 +1,102 @@
+---
+id: 2747
+title: "for-in: constructor-function prototype-chain enumeration (S12.6.4_A6*) + Object.defineProperty array+accessor ordering"
+status: ready
+sprint: Backlog
+goal: test262-conformance
+feasibility: hard
+depends_on: []
+priority: high
+es_edition: ES5
+language_feature: for-in
+task_type: bug
+created: 2026-06-27
+updated: 2026-06-27
+parent: 2739
+related: [1712, 2660, 2706, 2731]
+---
+# #2747 — for-in fnctor prototype chain (b) + defineProperty array order (c)
+
+**Carved from #2739** (dev2, 2026-06-27). #2739 PR landed the **setPrototypeOf**
+half (a): `Object.setPrototypeOf(struct, proto)` now records a `_wasmStructProto`
+link (host import `__host_set_struct_proto`) and the for-in walk advances through
+`_structUserProto`. This issue is the remaining two halves, both carved because
+they carry **regression risk against the load-bearing #1712 acorn prototype-method
+machinery** and need careful, floor-validated work.
+
+## (b) Constructor-function prototype chain — `S12.6.4_A6.js`, `S12.6.4_A6.1.js`
+
+```js
+function FACTORY(){ this.prop=1; this.hint="hinted"; }
+FACTORY.prototype = { feat:2, hint:"protohint" };
+var __instance = new FACTORY;
+for (key in __instance) __accum += key + __instance[key];
+// must include prop1, feat2, hinthinted (own `hint` shadows proto `hint`)
+```
+
+Verified-first (current main, after #2739 part a): for-in over `__instance`
+enumerates **nothing** (and `__instance["feat"]` reads `undefined`). Root cause
+(architect-verified, #2739 plan): `new FACTORY` builds a `$__fnctor_FACTORY`
+struct whose `__register_fnctor_instance` (#1712 instance→ctor link) fires **only
+when the fnctor has a closure global** (`ctorGlobalIdx` defined). A fnctor that is
+only `new`'d (never used as a value) has no closure global, so neither the
+instance→ctor link nor the host-mode `FACTORY.prototype = {…}` write happens (the
+host fall-through `__extern_set($closure,"prototype",…)` misses `ref.test $Object`
+and drops). The `FACTORY.prototype` object and the `new FACTORY` instance never
+rendezvous on a shared identity.
+
+### Why carved — the #1712 collision risk (dev2 verify-first finding)
+
+The two tractable fixes both risk the #1712 acorn surface:
+
+1. **Force the closure global for every `new`'d fnctor** (architect's preferred):
+   so `__register_fnctor_instance` fires and `F.prototype=` writes the closure
+   sidecar uniformly. BUT the prototype-assign (`F.prototype = {…}`) compiles
+   BEFORE the construct (`new F`) in source order, so the global must be minted at
+   FUNCTION-DECLARATION time for both sites to share it — a change on the hot
+   function-decl path.
+2. **Reuse `_wasmStructProto` + a per-fnctor proto global** (rendezvous): have
+   `_structUserProto` / `_fnctorProtoLookup` ALSO consult `_wasmStructProto` for
+   fnctor instances. BUT routing host `F.prototype = {…}` to the proto global (away
+   from the `__extern_set($closure,"prototype")` path) **breaks #1712's read path**
+   (`_fnctorProtoLookup` → `_sidecarGet(ctor,"prototype")`) for acorn's
+   closure-global fnctors unless reads are migrated to the same source — a
+   two-channel divergence. Also, having `_structUserProto` consult the
+   `_fnctorInstanceCtor` link changes for-in output for **existing** #1712 fnctor
+   instances (acorn Parser), which must be validated against the acorn prototype-
+   method tests.
+
+So (b) needs a coherent single-prototype-source design across construction,
+`F.prototype=` write, for-in walk, AND the #1712 read path — architect/senior-dev
+scope with full `merge_group` floor + acorn-dogfood validation. Do NOT ship a
+half-measure that diverges the two channels.
+
+## (c) `Object.defineProperty` array+accessor ordering — `order-after-define-property.js`
+
+Architect-verified split (#2739 plan): assert #1 (plain object) ALREADY PASSES.
+Only assert #2 — `defineProperty(arr,"a",{get,enumerable,configurable}); arr.b=2;`
+redefine `a` → `["a","b"]` — fails, and **only in the full-harness
+`runTest262File` run** (an isolated `compile()` probe of the array snippet returns
+the correct `["a","b"]`). A full-program-compilation interaction (array vec +
+accessor-descriptor sidecar for-in under assert.js), NOT the prototype-link
+defect. MUST reproduce via `runTest262File(".../order-after-define-property.js")`.
+
+## (d) Reflect.setPrototypeOf / `o.__proto__ = v` mirrors (deferred from #2739 part a)
+
+#2739 part a wired only `Object.setPrototypeOf` (the gc/host arm at
+`calls.ts`) to `__host_set_struct_proto`. The same one-line treatment should
+mirror to **`Reflect.setPrototypeOf`** (`calls.ts` ~7593) and the
+**`o.__proto__ = v`** write path (assignment.ts) so all three record the
+`_wasmStructProto` link. Low-risk (same import); folded here to keep the
+setPrototypeOf capability complete.
+
+## Acceptance criteria
+- `S12.6.4_A6.js`, `S12.6.4_A6.1.js`, `order-after-define-property.js` flip
+  fail→pass. No regression in `statements/for-in/` (esp. `order-simple-object`,
+  `order-property-on-prototype`) or the #1712 acorn prototype-method surface.
+  Reflect.setPrototypeOf / `__proto__` for-in walk works. Full `merge_group` floor.
+
+## Notes
+- Split from #2739 (PR fixes part a). The #1712 read/write prototype channel is
+  `_fnctorInstanceCtor` → `_sidecarGet(ctor,"prototype")` (runtime.ts ~74); the
+  new setPrototypeOf channel is `_wasmStructProto` (runtime.ts ~49). Unify them.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -5940,13 +5940,41 @@ function compileCallExpression(
         }
         return { kind: "externref" };
       }
-      // GC/host stub: compile both args, drop proto, return obj.
-      const objType = compileExpression(ctx, fctx, expr.arguments[0]!);
-      const protoType = compileExpression(ctx, fctx, expr.arguments[1]!);
+      // (#2739) GC/host: record the user [[Prototype]] via the host import so the
+      // for-in walk + read path can follow it. An opaque WasmGC struct has no
+      // host-observable [[Prototype]], so the previous stub (drop proto) lost the
+      // link entirely and inherited keys never enumerated.
+      const objType = compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "externref" });
+      if (!objType) {
+        fctx.body.push({ op: "ref.null.extern" });
+        return { kind: "externref" };
+      }
+      if (objType.kind !== "externref") {
+        coerceType(ctx, fctx, objType, { kind: "externref" });
+      }
+      const protoType = compileExpression(ctx, fctx, expr.arguments[1]!, { kind: "externref" });
       if (protoType) {
+        if (protoType.kind !== "externref") {
+          coerceType(ctx, fctx, protoType, { kind: "externref" });
+        }
+      } else {
+        // proto produced no value — push null so the import receives two args.
+        fctx.body.push({ op: "ref.null.extern" });
+      }
+      const sproIdx = ensureLateImport(
+        ctx,
+        "__host_set_struct_proto",
+        [{ kind: "externref" }, { kind: "externref" }],
+        [{ kind: "externref" }],
+      );
+      flushLateImportShifts(ctx, fctx);
+      if (sproIdx !== undefined) {
+        fctx.body.push({ op: "call", funcIdx: sproIdx });
+      } else {
+        // Import unavailable — fall back to the old stub (drop proto, keep obj).
         fctx.body.push({ op: "drop" });
       }
-      return objType;
+      return { kind: "externref" };
     }
 
     // Handle Object.getPrototypeOf(obj) — return prototype as externref

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -47,6 +47,15 @@ function _getNodeRequire(): ((id: string) => any) | undefined {
  */
 const _wasmStructProps = new WeakMap<object, Record<string | symbol, any>>();
 
+// (#2739) Host-recorded [[Prototype]] link for an opaque WasmGC struct. A struct
+// exported to JS has no host-observable [[Prototype]] (`Object.getPrototypeOf`
+// returns null/the engine default), so `Object.setPrototypeOf(struct, proto)` /
+// `Reflect.setPrototypeOf` / `struct.__proto__ = proto` record the user-intended
+// prototype here, and the for-in walk + read path consult it via
+// `_structUserProto`. A recorded value may be `null` (setPrototypeOf(o, null));
+// presence is tested with `.has`, never `!== undefined`.
+const _wasmStructProto = new WeakMap<object, any>();
+
 /**
  * (#1712) Function-style-constructor prototype bridge.
  *
@@ -100,6 +109,33 @@ function _fnctorProtoLookup(
     if (cur === Object.prototype) break;
   }
   return undefined;
+}
+
+/**
+ * (#2739) Resolve the user-intended [[Prototype]] of a value for the for-in
+ * walk — the ONE prototype source for enumeration so it stays consistent with
+ * member reads (§13.7.5.15 EnumerateObjectProperties walks [[GetPrototypeOf]]).
+ * For an opaque WasmGC struct, native `Object.getPrototypeOf` is blind to the
+ * user prototype, so consult the explicit `_wasmStructProto` link first
+ * (setPrototypeOf / Reflect.setPrototypeOf / `__proto__` — the value may be
+ * `null`, meaning "own keys only", which must stop the walk). Otherwise fall
+ * back to the native `[[Prototype]]`.
+ *
+ * NOTE: the fnctor instance→ctor prototype link (`function F(){}; F.prototype =
+ * {…}; new F()`) is intentionally NOT consulted here — that path (the
+ * `S12.6.4_A6*` for-in tests) is carved to a follow-up because routing existing
+ * #1712 fnctor instances through the prototype walk changes their for-in output
+ * and must be validated against the acorn/#1712 prototype-method surface.
+ */
+function _structUserProto(current: any): any {
+  if (_isWasmStruct(current) && _canBeWeakKey(current) && _wasmStructProto.has(current)) {
+    return _wasmStructProto.get(current);
+  }
+  try {
+    return Object.getPrototypeOf(current);
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -10821,6 +10857,37 @@ assert._isSameValue = isSameValue;
           // (#1334) Deleted property — not own, hence not enumerable.
           return _wasmStructPropertyIsEnumerable(obj, key, callbackState?.getExports());
         };
+      // (#2739) Record a WasmGC struct's user [[Prototype]] (Object.setPrototypeOf
+      // / Reflect.setPrototypeOf / `o.__proto__ = v`). In gc/host mode the struct
+      // is opaque, so codegen previously dropped `proto` on the floor; this stores
+      // it in `_wasmStructProto` for the for-in walk + read path. Mirrors
+      // §10.1.2.1 OrdinarySetPrototypeOf: a non-object/non-null proto is ignored;
+      // a proto chain that would reach `obj` (cycle) is refused.
+      if (name === "__host_set_struct_proto")
+        return (obj: any, proto: any): any => {
+          if (!_isWasmStruct(obj) || !_canBeWeakKey(obj)) return obj;
+          if (proto !== null && typeof proto !== "object" && typeof proto !== "function") {
+            // Neither Object nor Null: OrdinarySetPrototypeOf is a no-op here.
+            return obj;
+          }
+          // Cycle check (§10.1.2.1 step 8): walk proto's chain; refuse on reaching obj.
+          let p: any = proto;
+          let guard = 0;
+          while (p != null && guard++ < 100) {
+            if (p === obj) return obj; // would create a cycle — no-op
+            if (_isWasmStruct(p) && _canBeWeakKey(p) && _wasmStructProto.has(p)) {
+              p = _wasmStructProto.get(p);
+            } else {
+              try {
+                p = Object.getPrototypeOf(p);
+              } catch {
+                break;
+              }
+            }
+          }
+          _wasmStructProto.set(obj, proto);
+          return obj;
+        };
       // for-in key enumeration: returns a JS array of enumerable string keys
       if (name === "__for_in_keys")
         return (obj: any) => {
@@ -10845,8 +10912,13 @@ assert._isSameValue = isSameValue;
           const exports = callbackState?.getExports();
           const keys: string[] = [];
           const seen = new Set<string>();
+          // (#2739) Visited-object guard: a hand-built or recorded prototype
+          // link could in principle form a cycle; stop if we revisit an object.
+          const visitedObjs = new Set<any>();
           let current: any = obj;
           while (current != null) {
+            if (visitedObjs.has(current)) break;
+            visitedObjs.add(current);
             if (_isWasmStruct(current)) {
               // WasmGC struct — get field names from exported helper.
               // (#2131) Per spec, EnumerateObjectProperties visits each
@@ -10898,11 +10970,10 @@ assert._isSameValue = isSameValue;
                 break;
               }
             }
-            try {
-              current = Object.getPrototypeOf(current);
-            } catch {
-              break;
-            }
+            // (#2739) Advance through the user-intended prototype (consults the
+            // recorded setPrototypeOf link + the #1712 fnctor proto), not the
+            // native [[Prototype]] which is null for an opaque WasmGC struct.
+            current = _structUserProto(current);
           }
           return keys;
         };

--- a/tests/issue-2739.test.ts
+++ b/tests/issue-2739.test.ts
@@ -1,0 +1,73 @@
+// #2739 (part a) — for-in must walk a prototype set via Object.setPrototypeOf
+// on a WasmGC struct. §13.7.5.15 EnumerateObjectProperties walks
+// [[GetPrototypeOf]]; an opaque struct has no host-observable [[Prototype]], so
+// `Object.setPrototypeOf(struct, proto)` previously dropped the link on the
+// floor (gc/host arm compiled both args, dropped proto) and the for-in walk's
+// `Object.getPrototypeOf(struct)` returned null — the inherited keys never
+// enumerated.
+//
+// Fix: record the link in `_wasmStructProto` via a `__host_set_struct_proto`
+// host import (called from the Object.setPrototypeOf gc/host arm), and advance
+// the for-in walk through `_structUserProto` (which consults that link).
+//
+// The constructor-function prototype-chain half (S12.6.4_A6*) and the
+// Object.defineProperty array+accessor ordering half are carved to a follow-up.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+
+async function forInKeys(body: string): Promise<string> {
+  const src = `export function test(): any { ${body} }`;
+  const result = (await compile(src, {
+    fileName: "test.ts",
+    skipSemanticDiagnostics: true,
+  } as never)) as any;
+  expect(result.success, result.errors?.[0]?.message).toBe(true);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  const ex = wrapExports(instance.exports, { signatures: result.exportSignatures });
+  return ex.test() as string;
+}
+
+describe("#2739 (a) — for-in walks a setPrototypeOf prototype chain", () => {
+  it("enumerates own keys then the proto's keys (order-property-on-prototype)", async () => {
+    // Mirrors test262 language/statements/for-in/order-property-on-prototype.js
+    expect(
+      await forInKeys(`
+        const proto: any = { p4: "p4" };
+        const o: any = { p1: "p1", p2: "p2", p3: "p3" };
+        Object.setPrototypeOf(o, proto);
+        let keys = "";
+        for (const k in o) keys += k + ",";
+        return keys;`),
+    ).toBe("p1,p2,p3,p4,");
+  });
+
+  it("walks a multi-level setPrototypeOf chain, own-shadows-proto", async () => {
+    expect(
+      await forInKeys(`
+        const grand: any = { g: 1, shared: "grand" };
+        const proto: any = { p: 1, shared: "proto" };
+        Object.setPrototypeOf(proto, grand);
+        const o: any = { a: 1, shared: "own" };
+        Object.setPrototypeOf(o, proto);
+        let keys = "";
+        for (const k in o) keys += k + ",";
+        return keys;`),
+    ).toBe("a,shared,p,g,");
+  });
+
+  it("setPrototypeOf(o, null) enumerates own keys only", async () => {
+    expect(
+      await forInKeys(`
+        const proto: any = { p4: "p4" };
+        const o: any = { p1: "p1", p2: "p2" };
+        Object.setPrototypeOf(o, proto);
+        Object.setPrototypeOf(o, null);
+        let keys = "";
+        for (const k in o) keys += k + ",";
+        return keys;`),
+    ).toBe("p1,p2,");
+  });
+});


### PR DESCRIPTION
## #2739 part (a) — for-in over a `Object.setPrototypeOf` chain

`Object.setPrototypeOf(struct, proto)` on an opaque WasmGC struct **dropped the proto on the floor** (the gc/host arm compiled both args and dropped `proto`), and the for-in walk's `Object.getPrototypeOf(struct)` returned null — so inherited keys never enumerated, contra ES §13.7.5.15 EnumerateObjectProperties (which walks `[[GetPrototypeOf]]`).

### Fix (host-mode, isolated — reuses the #2680/#1712 link pattern)
- **runtime.ts**: `_wasmStructProto` WeakMap records a struct's user `[[Prototype]]`; a new `__host_set_struct_proto` host import sets it (mirrors §10.1.2.1 OrdinarySetPrototypeOf — non-object/non-null proto ignored, cycle refused).
- **calls.ts**: the `Object.setPrototypeOf` gc/host arm now calls `__host_set_struct_proto` instead of dropping `proto`.
- **runtime.ts `__for_in_keys`**: advance through `_structUserProto` (consults the recorded link) instead of native `Object.getPrototypeOf`; added a visited-object cycle guard.

`_structUserProto` consults **only** the explicit `_wasmStructProto` link (NOT the #1712 `_fnctorInstanceCtor` link) — keeping this change isolated so existing fnctor instances' for-in output is unchanged.

### Validation
- Flips `statements/for-in/order-property-on-prototype.js` **fail→pass** (authoritative `runTest262File`).
- `tests/issue-2739.test.ts`: 3 pass (single + multi-level chain + `setPrototypeOf(o, null)` → own-keys-only).
- **No regression** in the for-in dir: `order-simple-object` (#2731 watch) stays green; the other 9 for-in fails are **pre-existing** (eval / completion-value / let-token gaps, none use proto APIs — verified). `prototype-chain.test.ts` failures are a pre-existing stale hand-rolled `env` (confirmed identical on clean origin/main), and the `__call_fn_1`/for-of-destructuring failures have zero code-path to this change. **Validate on the full `merge_group` floor** (for-in machinery, auto-park-prone).

### Carved to #2747 (verify-first finding)
The constructor-function prototype-chain half **(b, S12.6.4_A6*)**, the defineProperty array+accessor ordering half **(c)**, and the `Reflect.setPrototypeOf`/`__proto__` mirrors **(d)** are carved to **#2747** — (b) risks the **load-bearing #1712 acorn prototype-method channel** (routing host `F.prototype=` to the proto global, or consulting the fnctor link in the for-in walk, changes existing fnctor for-in output and the #1712 read path) and needs a unified single-prototype-source design with acorn-dogfood floor validation. (#2739's Implementation Plan lands via PR #2174; this PR fixes part a.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)