### PR TITLE
fix(#2744): route object integrity queries to runtime for all reps + TestIntegrityLevel

### DIFF
--- a/plan/issues/2744-object-extensible-slot-preventextensions-seal-freeze-queries.md
+++ b/plan/issues/2744-object-extensible-slot-preventextensions-seal-freeze-queries.md
@@ -1,7 +1,8 @@
 ---
 id: 2744
 title: "ES5: object [[Extensible]] internal slot — preventExtensions/seal/freeze set it; isExtensible/isSealed/isFrozen read it"
-status: ready
+status: done
+completed: 2026-06-27
 sprint: 67
 created: 2026-06-27
 updated: 2026-06-27
@@ -80,3 +81,33 @@ queryable `[[Extensible]]` slot on our object representation.
   orthogonal to descriptor read-back and can land independently.
 - `seal-finalizationregistry.js` (FinalizationRegistry) and Proxy-handler seal
   tests are out of scope (blocked clusters).
+
+## Test Results (esch, 2026-06-27) — Slice 1: routing + slot + TestIntegrityLevel
+
+Implemented the architect's Slice-1 (routing + `[[Extensible]]` slot, the
+independent unit). Measured on `built-ins/Object/{isExtensible,isFrozen,isSealed,
+preventExtensions,seal,freeze}` (317 tests) via the real `wrapTest`+runner:
+
+- **baseline (origin/main): 252 pass / 65 fail → with fix: 281 pass / 36 fail**
+  = **+29 fixed, ZERO regressions** (verified by fail-set diff).
+
+Changes:
+- `src/codegen/expressions/calls.ts` — the integrity codegen treated any
+  non-`externref` argType as a primitive (folding `isExtensible`→0 /
+  `isFrozen`,`isSealed`→1 for arrays/typed-structs/Date). Now an `isObjectRef`
+  predicate routes EVERY object ref through the runtime via **raw
+  `extern.convert_any`** (NOT `coerceType`, which appends `__make_iterable` and
+  materializes a vec into a *fresh* JS array per call → identity loss). Dropped the
+  order-blind host-mode static fold for the queries (fixes the
+  `isExtensible`-pre-check-before-`seal` failures). Generalized the freeze/seal/
+  preventExtensions SET coercion from standalone-only to ALL modes.
+- `src/runtime.ts` — reimplemented `__object_isFrozen`/`__object_isSealed` as
+  WeakSet fast-path **OR** `_testIntegrityLevel` (§7.3.16) over the live descriptor
+  table (`_getSidecarDescs` + canonical `_ownStructKeys`), so `preventExtensions` +
+  `defineProperty(non-writable/non-config)` (data AND accessor) reports `isFrozen`.
+
+Remaining (deferred follow-ons, #2668-coupled, per the architect's sequencing):
+group (c) sloppy frozen-write strict-gate (the `freeze/15.2.3.9-2-c-*` propertyHelper
+tests trap deeper than the write-throw), the global-object sub-case (overlaps #2726),
+and the `propertyHelper.js`/descriptor-precision cluster. Out of scope: Proxy-handler,
+FinalizationRegistry, `not-a-constructor` harness CEs, resizable-buffer TypedArray.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -5706,6 +5706,19 @@ function compileCallExpression(
       return compileObjectKeysOrValues(ctx, fctx, propAccess.name.text, expr);
     }
 
+    // (#2744) An object operand for the integrity methods can compile to any
+    // reference kind — `externref` ($Object/any), a `ref`/`ref_null` to a typed
+    // object struct or a vec (array / typed Date), `anyref`, or `eqref`. All of
+    // these are OBJECTS; only the scalar kinds (f64/i32/i64/f32/v128/i8/i16/
+    // funcref) are genuine primitives. The integrity SET + query codegen routes
+    // every object ref through the runtime helpers (coercing to externref via
+    // `extern.convert_any` first), and folds to the primitive answer ONLY for
+    // true primitives. Previously any non-`externref` argType was treated as a
+    // primitive, so arrays (vec ref) and typed object structs (ref) mis-folded
+    // `isExtensible`→0 / `isFrozen`,`isSealed`→1 and never reached the runtime.
+    const isObjectRef = (t: ValType): boolean =>
+      t.kind === "ref" || t.kind === "ref_null" || t.kind === "anyref" || t.kind === "eqref" || t.kind === "externref";
+
     // Handle Object.freeze/seal/preventExtensions — compile-away strategy
     if (
       ts.isIdentifier(propAccess.expression) &&
@@ -5752,23 +5765,28 @@ function compileCallExpression(
       let argType = compileExpression(ctx, fctx, expr.arguments[0]!);
       if (!argType) return null;
 
-      // #1472 Phase B Blocker A Half 2 — open-`any` receiver normalization.
-      // The open-object representation is a $Object wrapped to externref, but a
-      // variable reference (`Object.freeze(o)` where `o: any`) can compile to a
-      // ref/ref_null/anyref rather than externref, which would fall through to
-      // the return-arg no-op and never reach the native __object_freeze (the
-      // $flags would never be set). In standalone, coerce a non-externref
-      // ref/anyref receiver to externref first (extern.convert_any) so the
-      // native SET helper fires and the integrity bits actually get written.
-      // JS-host mode is unchanged (it already routes externref args to the host
-      // import; non-externref args there are typed objects with no dynamic
-      // freeze semantics).
-      if (
-        ctx.standalone &&
-        argType.kind !== "externref" &&
-        (argType.kind === "ref" || argType.kind === "ref_null" || argType.kind === "anyref")
-      ) {
-        coerceType(ctx, fctx, argType, { kind: "externref" });
+      // #1472 Phase B Blocker A Half 2 — object-receiver normalization.
+      // The open-object representation is a $Object wrapped to externref, but an
+      // object receiver (`Object.freeze(o)` where `o: any`, a typed object
+      // struct, or an array/vec) can compile to a ref/ref_null/anyref/eqref
+      // rather than externref, which would fall through to the return-arg no-op
+      // and never reach the native __object_freeze (the runtime WeakSet/
+      // descriptor state would never be set, so a later isFrozen/isSealed/
+      // isExtensible query returns the wrong answer). (#2744) Coerce ANY
+      // non-externref object receiver to externref first (extern.convert_any) so
+      // the runtime SET helper fires for arrays/structs/Date in ALL modes, not
+      // just standalone. Use RAW `extern.convert_any` (NOT coerceType): for a vec
+      // (array) receiver, coerceType appends `__make_iterable`, which materializes
+      // a *fresh* JS array per call — so the runtime WeakSet/descriptor state keyed
+      // on that throwaway wrapper would never match a later query's fresh wrapper
+      // (`Object.freeze(arr); Object.isFrozen(arr)` → false). The bare
+      // `extern.convert_any` passes the OPAQUE WasmGC ref, which is
+      // identity-preserving across SET/query coercions of the same object AND is
+      // recognized by `_isWasmStruct`, so arrays track integrity exactly like
+      // plain structs. The compile-time `markIntegrity` var-marking remains as an
+      // additional fast-path for the strict-mode write-throw decision.
+      if (argType.kind !== "externref" && isObjectRef(argType)) {
+        fctx.body.push({ op: "extern.convert_any" });
         argType = { kind: "externref" };
       }
 
@@ -5808,28 +5826,23 @@ function compileCallExpression(
       const method = propAccess.name.text;
       const arg0 = expr.arguments[0]!;
 
-      // Compile-time fast path: identifier known to be frozen/sealed at compile
-      // time. This is execution-order-blind (Object.freeze(o) populates
-      // ctx.frozenVars during codegen, so an *earlier* Object.isFrozen(o) would
-      // wrongly fold to const 1). In standalone mode the Wasm-native
-      // __object_isFrozen/__object_isSealed read the live $Object.flags, so we
-      // skip the static fold and let the runtime answer correctly (#1472
-      // Phase B Blocker A Half 1).
-      if (!ctx.standalone && ts.isIdentifier(arg0)) {
-        const isKnown =
-          (method === "isFrozen" && ctx.frozenVars.has(arg0.text)) ||
-          (method === "isSealed" && ctx.sealedVars.has(arg0.text));
-        if (isKnown) {
-          const argType = compileExpression(ctx, fctx, arg0);
-          if (argType) fctx.body.push({ op: "drop" });
-          fctx.body.push({ op: "i32.const", value: 1 });
-          return { kind: "i32" };
-        }
-      }
-
-      // General case: compile arg and delegate to runtime host import
+      // (#2744) The host-mode static fold (`ctx.frozenVars`/`ctx.sealedVars`
+      // keyed on the identifier) was execution-order-blind — `Object.freeze(o)`
+      // populates those sets during codegen, so an *earlier* `Object.isFrozen(o)`
+      // / `assert(Object.isExtensible(o))` pre-check wrongly folded to the sealed
+      // answer. The runtime `__object_is*` helpers now answer authoritatively for
+      // every object ref (the SET path records WeakSet/descriptor state for
+      // arrays/structs/Date too), so the static fold is dropped here; the
+      // compile-time tracking remains only for the strict-mode write-throw
+      // decision.
       const argType = compileExpression(ctx, fctx, arg0);
-      if (argType?.kind === "externref") {
+      if (argType && isObjectRef(argType)) {
+        // Object receiver ($Object/any externref, typed struct ref, array vec,
+        // Date) → RAW extern.convert_any (identity-preserving, recognized by
+        // _isWasmStruct; NOT coerceType, which would materialize a vec into a
+        // fresh JS array and lose the WeakSet/descriptor identity) and delegate to
+        // the runtime TestIntegrityLevel query.
+        if (argType.kind !== "externref") fctx.body.push({ op: "extern.convert_any" });
         const importName = method === "isFrozen" ? "__object_isFrozen" : "__object_isSealed";
         const hostIdx = ensureLateImport(ctx, importName, [{ kind: "externref" }], [{ kind: "i32" }]);
         flushLateImportShifts(ctx, fctx);
@@ -5838,6 +5851,8 @@ function compileCallExpression(
           return { kind: "i32" };
         }
         fctx.body.push({ op: "drop" });
+        fctx.body.push({ op: "i32.const", value: 0 });
+        return { kind: "i32" };
       } else if (argType) {
         fctx.body.push({ op: "drop" });
         // (#1462) Primitive (f64/i32/i64) is not an Object per ES2015+ §19.1.2.13/14;
@@ -5859,20 +5874,19 @@ function compileCallExpression(
     ) {
       const arg0 = expr.arguments[0]!;
 
-      // Compile-time fast path: identifier known to be non-extensible.
-      // Skipped in standalone (execution-order-blind, same reason as
-      // isFrozen/isSealed above) — the native __object_isExtensible reads the
-      // live $Object.flags instead (#1472 Phase B Blocker A Half 1).
-      if (!ctx.standalone && ts.isIdentifier(arg0) && ctx.nonExtensibleVars.has(arg0.text)) {
-        const argType = compileExpression(ctx, fctx, arg0);
-        if (argType) fctx.body.push({ op: "drop" });
-        fctx.body.push({ op: "i32.const", value: 0 });
-        return { kind: "i32" };
-      }
-
-      // General case: delegate to runtime
+      // (#2744) The host-mode static fold (`ctx.nonExtensibleVars`) was
+      // execution-order-blind (same reason as isFrozen/isSealed above) — a
+      // pre-check `Object.isExtensible(o)` before a later `Object.seal(o)` wrongly
+      // folded to 0. The runtime `__object_isExtensible` now answers
+      // authoritatively for every object ref (the SET path records the WeakSet
+      // for arrays/structs/Date too), so the static fold is dropped here.
       const argType = compileExpression(ctx, fctx, arg0);
-      if (argType?.kind === "externref") {
+      if (argType && isObjectRef(argType)) {
+        // Object receiver → RAW extern.convert_any (identity-preserving,
+        // recognized by _isWasmStruct; NOT coerceType, which would materialize a
+        // vec into a fresh JS array and lose identity) and delegate to the runtime
+        // query.
+        if (argType.kind !== "externref") fctx.body.push({ op: "extern.convert_any" });
         const hostIdx = ensureLateImport(ctx, "__object_isExtensible", [{ kind: "externref" }], [{ kind: "i32" }]);
         flushLateImportShifts(ctx, fctx);
         if (hostIdx !== undefined) {
@@ -5880,6 +5894,8 @@ function compileCallExpression(
           return { kind: "i32" };
         }
         fctx.body.push({ op: "drop" });
+        fctx.body.push({ op: "i32.const", value: 1 });
+        return { kind: "i32" };
       } else if (argType) {
         fctx.body.push({ op: "drop" });
         // (#1462) Primitive (f64/i32/i64) is not an Object per ES2015+ §19.1.2.12;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1611,6 +1611,43 @@ function _getSidecarDescs(obj: object): Map<string | symbol, number> {
 }
 
 /**
+ * (#2744) TestIntegrityLevel (§7.3.16) for a WasmGC struct / vec receiver,
+ * computed over OUR descriptor table (`_getSidecarDescs`) rather than "was
+ * Object.freeze/seal called" (the `_wasmFrozenObjs`/`_wasmSealedObjs` caches).
+ *
+ *   sealed (`frozen=false`): non-extensible AND every own property is
+ *     non-configurable.
+ *   frozen (`frozen=true`): sealed AND every own DATA property is non-writable.
+ *
+ * This answers correctly for objects made non-extensible and then reconfigured
+ * via `Object.defineProperty` (e.g. `preventExtensions(o)` on an object whose
+ * props were defined non-writable+non-configurable → `isFrozen` is true), which
+ * the WeakSet cache cannot. Own keys = static struct fields (`_getStructFieldNames`)
+ * + dynamic sidecar props (`_wasmStructProps`), minus tombstoned (`delete`d) keys.
+ * A property with NO descriptor entry is a default data property
+ * (writable+enumerable+configurable) → not sealed/frozen.
+ */
+function _testIntegrityLevel(obj: any, frozen: boolean, exports: Record<string, Function> | undefined): boolean {
+  // An extensible object can never be sealed or frozen (§7.3.16 step 4).
+  if (!_wasmNonExtensibleObjs.has(obj)) return false;
+  const descs = _getSidecarDescs(obj);
+  // Use the canonical own-key enumeration (skips internal `__get_`/`__set_`
+  // accessor-storage keys, tombstoned `delete`d keys, and includes symbols /
+  // class methods consistently with Object.keys/getOwnPropertyNames).
+  for (const key of _ownStructKeys(obj, exports)) {
+    const flags = descs.get(_normalizeDescKey(key));
+    // No descriptor → default data property (writable+configurable): fails both.
+    if (flags === undefined) return false;
+    // Both sealed and frozen require every own property be non-configurable.
+    if (flags & _SC_CONFIGURABLE) return false;
+    // Frozen additionally requires data properties be non-writable. Accessor
+    // properties (no writable attribute) are exempt from the writable check.
+    if (frozen && !(flags & _SC_ACCESSOR) && flags & _SC_WRITABLE) return false;
+  }
+  return true;
+}
+
+/**
  * Validate a defineProperty call against existing sidecar property descriptor.
  * Implements ES spec 9.1.6.3 ValidateAndApplyPropertyDescriptor for WasmGC structs.
  * Throws TypeError if the redefinition violates non-configurable constraints.
@@ -8473,7 +8510,11 @@ assert._isSameValue = isSameValue;
           // true for them. Test262 covers this under `Object/isFrozen/`.
           if (obj == null) return 1;
           if (typeof obj !== "object" && typeof obj !== "function") return 1;
-          if (_isWasmStruct(obj)) return _wasmFrozenObjs.has(obj) ? 1 : 0;
+          // (#2744) WasmGC struct/vec: WeakSet fast-path (Object.freeze was
+          // called) OR TestIntegrityLevel over the live descriptor table (covers
+          // preventExtensions + defineProperty(non-writable, non-configurable)).
+          if (_isWasmStruct(obj))
+            return _wasmFrozenObjs.has(obj) || _testIntegrityLevel(obj, true, callbackState?.getExports()) ? 1 : 0;
           return Object.isFrozen(obj) ? 1 : 0;
         };
       if (name === "__object_isSealed")
@@ -8481,7 +8522,15 @@ assert._isSameValue = isSameValue;
           // (#1462) ES2015+ §19.1.2.14: if Type(O) is not Object, return true.
           if (obj == null) return 1;
           if (typeof obj !== "object" && typeof obj !== "function") return 1;
-          if (_isWasmStruct(obj)) return _wasmSealedObjs.has(obj) || _wasmFrozenObjs.has(obj) ? 1 : 0;
+          // (#2744) WasmGC struct/vec: WeakSet fast-path (Object.seal/freeze was
+          // called) OR TestIntegrityLevel (non-extensible + all own props
+          // non-configurable) over the live descriptor table.
+          if (_isWasmStruct(obj))
+            return _wasmSealedObjs.has(obj) ||
+              _wasmFrozenObjs.has(obj) ||
+              _testIntegrityLevel(obj, false, callbackState?.getExports())
+              ? 1
+              : 0;
           return Object.isSealed(obj) ? 1 : 0;
         };
       if (name === "__object_isExtensible")

--- a/tests/issue-2744.test.ts
+++ b/tests/issue-2744.test.ts
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2744 — object [[Extensible]] / integrity-level queries route through the
+// runtime for ALL object representations (arrays/vec refs, typed object structs,
+// Date), not just `$Object`/externref. Previously the integrity codegen treated
+// any non-externref argType as a primitive, so `Object.isExtensible(arr)` folded
+// to a static 0 and `Object.isFrozen(struct)`/`isSealed(struct)` to a static 1.
+//
+// Also: the queries are answered by TestIntegrityLevel (§7.3.16) over the live
+// descriptor table, so `preventExtensions` + `defineProperty(non-writable,
+// non-configurable)` correctly reports `isFrozen`.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports as buildRuntimeImports } from "../src/runtime.js";
+
+async function run(source: string): Promise<unknown> {
+  const result = await compile(source, { fileName: "test.ts" });
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  if (!WebAssembly.validate(result.binary)) {
+    throw new Error(`Invalid Wasm binary\nWAT:\n${result.wat}`);
+  }
+  const runtime = buildRuntimeImports(result.imports ?? [], undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, runtime as WebAssembly.Imports);
+  const r = runtime as { setExports?: (e: Record<string, Function>) => void };
+  if (r.setExports) r.setExports(instance.exports as Record<string, Function>);
+  return (instance.exports as Record<string, () => unknown>).test?.();
+}
+
+describe("#2744 [[Extensible]] / integrity queries route for all object reps", () => {
+  it("isExtensible is true for a fresh array (vec ref)", async () => {
+    expect(await run(`export function test(){ const a=[0,1]; return Object.isExtensible(a)?1:0; }`)).toBe(1);
+  });
+
+  it("isExtensible is true for a fresh typed object struct", async () => {
+    expect(await run(`export function test(){ const o={x:1,y:2}; return Object.isExtensible(o)?1:0; }`)).toBe(1);
+  });
+
+  it("isFrozen is false for a fresh array", async () => {
+    expect(await run(`export function test(){ const a:number[]=[]; return Object.isFrozen(a)?1:0; }`)).toBe(0);
+  });
+
+  it("isSealed is false for a fresh struct", async () => {
+    expect(await run(`export function test(){ const o={x:1}; return Object.isSealed(o)?1:0; }`)).toBe(0);
+  });
+
+  it("preventExtensions(array) then isExtensible is false (identity-preserving)", async () => {
+    expect(
+      await run(
+        `export function test(){ const a=[0,1]; Object.preventExtensions(a); return Object.isExtensible(a)?1:0; }`,
+      ),
+    ).toBe(0);
+  });
+
+  it("freeze(array) then isFrozen is true", async () => {
+    expect(await run(`export function test(){ const a=[0,1]; Object.freeze(a); return Object.isFrozen(a)?1:0; }`)).toBe(
+      1,
+    );
+  });
+
+  it("seal(struct) then isSealed is true", async () => {
+    expect(
+      await run(`export function test(){ const o={x:1,y:2}; Object.seal(o); return Object.isSealed(o)?1:0; }`),
+    ).toBe(1);
+  });
+
+  it("isExtensible pre-check before seal is not order-blind", async () => {
+    // The dropped static fold used to read the LATER seal() and fold the
+    // earlier isExtensible to false; now it reads live runtime state.
+    expect(
+      await run(
+        `export function test(){ const a=[0,1]; const pre = Object.isExtensible(a)?1:0; Object.seal(a); return pre; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("TestIntegrityLevel: preventExtensions + non-writable/non-config data prop => isFrozen", async () => {
+    expect(
+      await run(
+        `export function test(){ const o:any={}; Object.defineProperty(o,"foo1",{value:20,writable:false,enumerable:false,configurable:false}); Object.preventExtensions(o); return Object.isFrozen(o)?1:0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("TestIntegrityLevel: preventExtensions + non-config accessor prop => isFrozen", async () => {
+    expect(
+      await run(
+        `export function test(){ const o:any={}; function g(){return 10;} function s(v:any){} Object.defineProperty(o,"foo2",{get:g,set:s,configurable:false}); Object.preventExtensions(o); return Object.isFrozen(o)?1:0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("isFrozen/isSealed/isExtensible on a primitive keep spec answers", async () => {
+    expect(await run(`export function test(){ return (Object.isFrozen(5 as any)?1:0); }`)).toBe(1);
+    expect(await run(`export function test(){ return (Object.isSealed(5 as any)?1:0); }`)).toBe(1);
+    expect(await run(`export function test(){ return (Object.isExtensible(5 as any)?1:0); }`)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the `Object.isExtensible`/`isFrozen`/`isSealed`/`freeze`/`seal`/`preventExtensions` cluster (#2744). The integrity codegen treated any **non-`externref` argType as a primitive**, so arrays (vec `ref`) and typed object structs (`ref`) folded `isExtensible`→0 / `isFrozen`,`isSealed`→1 statically and never reached the runtime — the `[[Extensible]]` slot was unreachable for ref-typed objects. Only `$Object`/`any` (externref) worked.

This is the architect's **Slice 1 (routing + slot)** — the independent unit that banks the array/struct/Date cluster; group(c) and descriptor-precision are deferred follow-ons coordinated with #2668.

## Root cause + fix
- **`src/codegen/expressions/calls.ts`**: add an `isObjectRef` predicate; route every object ref through the runtime helpers via **raw `extern.convert_any`** — NOT `coerceType`, which appends `__make_iterable` and materializes a vec into a *fresh* JS array per call (identity loss → `Object.freeze(arr); Object.isFrozen(arr)` reads false). The bare `extern.convert_any` passes the **opaque WasmGC ref**: identity-preserving across SET/query AND recognized by `_isWasmStruct`, so arrays track integrity exactly like structs. Drop the **order-blind host-mode static fold** for queries (fixes `isExtensible` pre-check before `seal`). Generalize the freeze/seal/preventExtensions SET coercion to all modes.
- **`src/runtime.ts`**: reimplement `__object_isFrozen`/`__object_isSealed` as WeakSet fast-path **OR** `_testIntegrityLevel` (§7.3.16) over the live descriptor table (`_getSidecarDescs` + canonical `_ownStructKeys`, which skips internal `__get_`/`__set_` accessor-storage keys), so `preventExtensions` + `defineProperty(non-writable/non-config)` on data **and** accessor props reports `isFrozen`.

## Validation
Measured on `built-ins/Object/{isExtensible,isFrozen,isSealed,preventExtensions,seal,freeze}` (317 tests) via the real `wrapTest`+runner:

| | pass | fail |
|---|---|---|
| baseline (origin/main) | 252 | 65 |
| **this PR** | **281** | **36** |

**+29 fixed, ZERO regressions** (verified by fail-set diff). `tests/issue-2744.test.ts` (11 cases) green; `tsc` clean; prettier clean. `issue-1387`/`issue-1472` local failures are pre-existing (identical on baseline).

Broad value-rep area — please validate on the **full merge_group floor** (touches seal/freeze/descriptor machinery + #2668's area; auto-park-prone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)