### PR TITLE
chore(release): v0.57.0 — first npm publish + #389 native-messaging fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.1.0",
+  "version": "0.57.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js2wasm",
-  "version": "0.1.0",
+  "version": "0.57.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC (unscoped proxy for @loopdive/js2)",
   "keywords": [
     "webassembly",


### PR DESCRIPTION
Cuts npm release **v0.57.0** of `@loopdive/js2` (and the `js2wasm` proxy) — the **first npm publish** of the package (registry currently 404) — so the loopdive/js2#389 reporter and all npm consumers get the #2123 native-messaging fixes plus everything merged since the old `v0.56.0` tag.

## Why 0.57.0
`v0.57.0` is the next free version above the last public tag `v0.56.0`. The earlier v0.1.0/v0.52.1/v0.65.0 candidates were withdrawn: v0.1.0 collides with a pre-existing upstream tag, and a fresh non-colliding version avoids any destructive tag rewrite. No existing tags are deleted or force-updated.

## What this is
- `node scripts/release.mjs 0.57.0` — bumps BOTH `package.json` (root `@loopdive/js2`) and `packages/js2wasm/package.json` (proxy) to `0.57.0` in lockstep, single `release: v0.57.0` commit + annotated `v0.57.0` tag (held local until merge per `docs/releasing.md`).
- Publishes **current main**: #2123 / #389 native-messaging fixes (nm_wasi / nm_js2wasm / nm_deno + import cleanup) and everything since 0.56.0.

## Flow (per docs/releasing.md)
1. ✅ Lockstep bump committed (this PR) — both package.jsons at `0.57.0`.
2. ⏳ Merge this PR.
3. ⏳ After merge, push the `v0.57.0` tag → fires `publish-npm.yml`; `verify-version` enforces tag == both package.json versions, then publishes to npm (public, first publish of the `@loopdive` scope).
4. ⏳ Verify `npm view @loopdive/js2 version` → `0.57.0`.

Known caveat (not a release blocker): `nm_node_process.ts` still hangs standalone — a separate async-reactor issue under investigation. The other native-messaging fixes ship in this release.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>