### PR TITLE
fix(#2743): unmapped arguments object for non-simple parameter lists (group c)

### DIFF
--- a/plan/issues/2743-arguments-object-prototype-constructor-iterator-unmapped-nonsimple.md
+++ b/plan/issues/2743-arguments-object-prototype-constructor-iterator-unmapped-nonsimple.md
@@ -1,7 +1,8 @@
 ---
 id: 2743
 title: "arguments object as an ordinary Object: [[Prototype]]=Object.prototype, .constructor, Symbol.iterator, and unmapped arguments for non-simple parameter lists"
-status: ready
+status: in-progress
+assignee: ttraenkler/sendev-args
 sprint: 67
 created: 2026-06-27
 updated: 2026-06-27

--- a/plan/issues/2743-arguments-object-prototype-constructor-iterator-unmapped-nonsimple.md
+++ b/plan/issues/2743-arguments-object-prototype-constructor-iterator-unmapped-nonsimple.md
@@ -187,3 +187,70 @@ remaining (a)-group (≥5) and the 2 Symbol.iterator tests.
 - `unmapped/Symbol.iterator.js`, `mapped/Symbol.iterator.js` → Symbol→number trap (b)
 - `unmapped/via-params-dflt.js`, `via-params-dstr.js` → `sameValue(value,1)` (c)
 - `unmapped/via-params-rest.js` → `local.set[0] expected type` invalid Wasm (c)
+
+## Implementation notes — PR-1 = group (c) (sendev-args, 2026-06-27)
+
+**Status: group (c) DELIVERED in PR-1; groups (a)+(b) remain → PR-2.** Issue
+frontmatter stays `in-progress`; PR-2 flips it to `done` once the acceptance
+criteria (≥9 of ~13, incl. the (a)/(b) groups) are met.
+
+### What PR-1 changes (and WHY)
+
+The mapped-vs-unmapped split was driven *only* by `isStrictFunction(...)`, so a
+**sloppy** function with a **non-simple parameter list** (rest / default /
+destructuring) wrongly got a **mapped** arguments object. Spec §10.2.11
+(FunctionDeclarationInstantiation) step 22.a requires unmapped iff
+`strict OR !IsSimpleParameterList`.
+
+- New pure AST predicate `isSimpleParameterList(params)` in
+  `src/codegen/helpers/is-strict-function.ts` (co-located with `isStrictFunction`,
+  already imported by every call site — no new import cycle). False if any param
+  has `dotDotDotToken` (rest), `initializer` (default), or a non-identifier name
+  (object/array binding pattern). A TS `this` param stays simple.
+- ORed `|| !isSimpleParameterList(stmt.parameters)` into the `unmapped` argument
+  at every `emitArgumentsObject` call site:
+  - `statements/nested-declarations.ts:521` and `:793` (function-declaration /
+    closure-lifted paths — the path the failing tests take),
+  - `literals.ts:2544` (object-literal method path),
+  - `class-bodies.ts:2247` already hard-codes `true` (class bodies are strict) —
+    unchanged, verified.
+- `function-body.ts` (the inline top-level path) had its *own* simple-param
+  check that caught rest + destructuring but **missed defaulted params**
+  (`initializer`); replaced the ad-hoc `every(isIdentifier && !rest)` with the
+  shared `isSimpleParameterList`, so defaults are now correctly unmapped there too.
+
+When `unmapped` is true, `emitArgumentsObject` skips installing `mappedArgsInfo`
+(`nested-declarations.ts:2292`), so **no write-back** is emitted. That (1) makes
+`arguments[0]=2` not flow into the named param (fixes `via-params-dflt/dstr`,
+`sameValue(value,1)`), and (2) removes the bad mapped-write `local.set` that the
+rest-param local shape couldn't satisfy — which was the *root cause* of
+`via-params-rest`'s "invalid Wasm binary" `compile_error` (a symptom, not a
+separate Wasm-emit bug).
+
+### Verification (isolated `runTest262File`, this branch)
+- `unmapped/via-params-rest.js` compile_error → **pass**
+- `unmapped/via-params-dflt.js` fail → **pass**
+- `unmapped/via-params-dstr.js` fail → **pass**
+- `unmapped/via-strict.js` **pass** (unchanged guard)
+- `mapped/mapped-arguments-nonconfigurable-1.js` **pass** (mapped/simple unaffected)
+
+### Regression surface (why this is safe)
+The change only flips mapped→unmapped for functions with a **non-simple**
+parameter list. A grep of `language/arguments-object/` confirms **no** mapped/*
+or other in-scope test uses a non-simple param list, so the only suite files the
+change touches are the three (c) tests (now green). Mapped behaviour with a
+non-simple param list is itself spec-wrong, so no conformant *passing* test can
+rely on the prior (buggy) behaviour. Broad-impact validation (full sharded
+test262 + the merge_group standalone floor) runs in CI. Tag-marker for the floor:
+watch for an auto-park after enqueue since this touches arguments-object
+machinery.
+
+Lock-in test: `tests/issue-2743.test.ts` (drives `runTest262File` on the three
+(c) files + the `via-strict` guard).
+
+### Remaining for PR-2 (groups (a)+(b))
+- (a) `[[Prototype]]`=Object.prototype + `.constructor`=Object: host `_argumentsObjects`
+  WeakSet marker registered after the vec `struct.new`, with `__getPrototypeOf` /
+  `__extern_get("constructor")` hooks in `runtime.ts`; standalone keeps the vec.
+- (b) `arguments[Symbol.iterator]` = %Array.prototype.values%: gate the vec
+  computed-get so a Symbol key is not coerced via ToNumber, route @@iterator.

--- a/src/codegen/function-body.ts
+++ b/src/codegen/function-body.ts
@@ -47,7 +47,7 @@ import {
 } from "./statements/nested-declarations.js";
 import { emitThrowReferenceError } from "./expressions/helpers.js";
 import { bodyUsesArguments } from "./helpers/body-uses-arguments.js";
-import { isStrictFunction } from "./helpers/is-strict-function.js";
+import { isStrictFunction, isSimpleParameterList } from "./helpers/is-strict-function.js";
 import { detectStringBuilders, type StringBuilderPresizeInfo } from "./string-builder.js";
 import { collectI32SpecializedArrays } from "./array-element-typing.js";
 import { detectArrayReduceFusion, applyArrayReduceFusion } from "./array-reduce-fusion.js";
@@ -976,13 +976,14 @@ export function compileFunctionBody(ctx: CodegenContext, decl: ts.FunctionDeclar
     const argsLocal = allocLocal(fctx, "arguments", vecRef);
     const arrTmp = allocLocal(fctx, "__args_arr_tmp", { kind: "ref", typeIdx: arrTypeIdx });
 
-    // Check if all params are simple identifiers (not destructuring patterns).
-    // Mapped arguments only applies to simple parameter lists in non-strict mode.
-    // In strict mode the arguments object is *unmapped* (§10.4.4): writes to
-    // `arguments[i]` must not flow back into the named parameter, so skip
-    // mappedArgsInfo entirely and leave the built vec as an independent copy
-    // (#779e).
-    const allSimpleParams = decl.parameters.every((p) => ts.isIdentifier(p.name) && !p.dotDotDotToken);
+    // Mapped arguments only applies to a *simple* parameter list in non-strict
+    // mode. In strict mode the arguments object is *unmapped* (§10.4.4); so is a
+    // non-simple parameter list (rest/default/destructuring — §10.2.11 step
+    // 22.a, #2743): writes to `arguments[i]` must not flow back into the named
+    // parameter, so skip mappedArgsInfo entirely and leave the built vec as an
+    // independent copy (#779e). (`isSimpleParameterList` also rejects defaulted
+    // params, which the prior local `every(isIdentifier && !rest)` check missed.)
+    const allSimpleParams = isSimpleParameterList(decl.parameters);
     const mappedAllowed = allSimpleParams && !isStrictFunction(decl, ctx.inferModuleStrictArguments);
 
     // Set up mapped arguments info for param ↔ arguments sync (#849)

--- a/src/codegen/helpers/is-strict-function.ts
+++ b/src/codegen/helpers/is-strict-function.ts
@@ -103,6 +103,33 @@ export function isStrictFunction(
 }
 
 /**
+ * (#2743) IsSimpleParameterList (ECMA-262 §15.1.3). A FormalParameters list is
+ * "simple" iff every element is a plain `BindingIdentifier` with no default
+ * initializer — i.e. it contains NO rest element, NO defaulted parameter, and
+ * NO destructuring (binding-pattern) parameter.
+ *
+ * This drives the mapped-vs-unmapped `arguments` split in
+ * FunctionDeclarationInstantiation (§10.2.11 step 22.a): the arguments object is
+ * *unmapped* when the function is strict OR its parameter list is non-simple.
+ * A non-simple list must therefore NOT install `mappedArgsInfo`, so a write to
+ * `arguments[i]` does not flow back into the named parameter (and the mapped
+ * write-back's `local.set` — which the rest/default param local shapes can't
+ * satisfy — is never emitted).
+ *
+ * A TypeScript `this` parameter (`function f(this: T, ...)`) is a plain
+ * identifier with no initializer/rest, so it does not make the list non-simple;
+ * it is erased before lowering and the call sites skip it via `paramOffset`.
+ */
+export function isSimpleParameterList(params: readonly ts.ParameterDeclaration[]): boolean {
+  for (const p of params) {
+    if (p.dotDotDotToken) return false; // rest parameter
+    if (p.initializer) return false; // defaulted parameter
+    if (!ts.isIdentifier(p.name)) return false; // object/array binding pattern (destructuring)
+  }
+  return true;
+}
+
+/**
  * (#2119) True iff `sf` is genuine module code — it carries a top-level
  * `import`/`export` (TypeScript sets the internal `externalModuleIndicator`),
  * or its implied node format is ESM. Deliberately ignores `scriptKind`: a

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -37,7 +37,7 @@ import { resolveStructName } from "./expressions/misc.js";
 import { arrayIteratorOverrideGlobalIdx, emitArrayProtoIteratorDrive } from "./expressions/proto-override.js";
 import { ensureObjVecBuilders } from "./object-runtime.js";
 import { bodyUsesArguments } from "./helpers/body-uses-arguments.js";
-import { isStrictFunction } from "./helpers/is-strict-function.js";
+import { isStrictFunction, isSimpleParameterList } from "./helpers/is-strict-function.js";
 import { collectInstrs } from "./statements/shared.js";
 import {
   cacheStringLiterals,
@@ -2541,13 +2541,11 @@ export function compileObjectLiteralForStruct(
       if (prop.body && bodyUsesArguments(prop.body)) {
         const methodParamTypes = methodFctxParams.slice(1).map((p) => p.type); // skip 'this'
         // Object-literal methods inherit the surrounding code's strictness (#779e).
-        emitArgumentsObject(
-          ctx,
-          methodFctx,
-          methodParamTypes,
-          1,
-          isStrictFunction(prop, ctx.inferModuleStrictArguments),
-        ); // paramOffset 1 to skip 'this'
+        // (#2743) Also unmapped when the parameter list is non-simple
+        // (rest/default/destructuring) — §10.2.11 step 22.a.
+        const unmapped =
+          isStrictFunction(prop, ctx.inferModuleStrictArguments) || !isSimpleParameterList(prop.parameters);
+        emitArgumentsObject(ctx, methodFctx, methodParamTypes, 1, unmapped); // paramOffset 1 to skip 'this'
       }
 
       if (isGeneratorMethod && prop.body && objMethNativeGen) {

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -8,7 +8,7 @@ import { ts } from "../../ts-api.js";
 import { isVoidType, unwrapPromiseType } from "../../checker/type-mapper.js";
 import { bodyUsesArguments } from "../helpers/body-uses-arguments.js";
 import { bodyReferencesOwnThis } from "../helpers/body-references-own-this.js";
-import { isStrictFunction } from "../helpers/is-strict-function.js";
+import { isStrictFunction, isSimpleParameterList } from "../helpers/is-strict-function.js";
 import type { Instr, ValType, WasmFunction } from "../../ir/types.js";
 import {
   collectReferencedIdentifiers,
@@ -516,9 +516,14 @@ export function compileNestedFunctionDeclaration(
       }
     }
 
-    // Set up `arguments` object if the function body references it
+    // Set up `arguments` object if the function body references it.
+    // (#2743) Unmapped when strict OR the parameter list is non-simple
+    // (rest/default/destructuring) — §10.2.11 FunctionDeclarationInstantiation
+    // step 22.a.
     if (stmt.body && bodyUsesArguments(stmt.body)) {
-      emitArgumentsObject(ctx, liftedFctx, paramTypes, 0, isStrictFunction(stmt, ctx.inferModuleStrictArguments));
+      const unmapped =
+        isStrictFunction(stmt, ctx.inferModuleStrictArguments) || !isSimpleParameterList(stmt.parameters);
+      emitArgumentsObject(ctx, liftedFctx, paramTypes, 0, unmapped);
     }
 
     if (nativeGenInfo) {
@@ -788,15 +793,13 @@ export function compileNestedFunctionDeclaration(
       }
     }
 
-    // Set up `arguments` object if the function body references it
+    // Set up `arguments` object if the function body references it.
+    // (#2743) Unmapped when strict OR the parameter list is non-simple
+    // (rest/default/destructuring) — §10.2.11 step 22.a.
     if (stmt.body && bodyUsesArguments(stmt.body)) {
-      emitArgumentsObject(
-        ctx,
-        liftedFctx,
-        paramTypes,
-        captures.length,
-        isStrictFunction(stmt, ctx.inferModuleStrictArguments),
-      );
+      const unmapped =
+        isStrictFunction(stmt, ctx.inferModuleStrictArguments) || !isSimpleParameterList(stmt.parameters);
+      emitArgumentsObject(ctx, liftedFctx, paramTypes, captures.length, unmapped);
     }
 
     if (isGenerator) {

--- a/tests/issue-2743.test.ts
+++ b/tests/issue-2743.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { existsSync } from "fs";
+import { runTest262File } from "./test262-runner.js";
+
+/**
+ * #2743 (c) — unmapped `arguments` for a non-simple parameter list.
+ *
+ * Per FunctionDeclarationInstantiation (ECMA-262 §10.2.11 step 22.a), the
+ * arguments object is *unmapped* when the function is strict OR its parameter
+ * list is non-simple (IsSimpleParameterList = false: any rest element,
+ * defaulted parameter, or destructuring binding pattern). Before this fix
+ * `emitArgumentsObject` was invoked with `unmapped = isStrictFunction(...)`
+ * only, so a sloppy function with a non-simple parameter list got a *mapped*
+ * arguments object:
+ *
+ *   - `function dflt(a, b = 0) { arguments[0] = 2; value = a; }` — the mapped
+ *     write-back made `a === 2` (test asserts `value === 1`); likewise for the
+ *     destructuring case `function dstr(a, [b]) { ... }`.
+ *   - `function rest(a, ...b) { arguments[0] = 2; ... }` — the mapped
+ *     write-back emitted a `local.set` the rest-param local shape can't satisfy,
+ *     producing an "invalid Wasm binary" at instantiation (compile_error).
+ *
+ * The fix adds `isSimpleParameterList` and ORs `|| !isSimpleParameterList(...)`
+ * into the `unmapped` decision at every `emitArgumentsObject` call site, so a
+ * non-simple parameter list installs no `mappedArgsInfo` (no write-back, no bad
+ * `local.set`) and the indices reflect the call arguments.
+ *
+ * Out of scope (tracked separately): mapped/* exotic descriptors (#1726),
+ * arguments `[[Prototype]]`/`.constructor`/`@@iterator` ordinary-Object
+ * semantics (#2743 groups (a)/(b), follow-up PR).
+ */
+
+const TEST262 = "/workspace/test262";
+const ROOT = `${TEST262}/test/language/arguments-object`;
+
+// Non-simple parameter lists → unmapped arguments object (the (c) group).
+const unmappedNonSimple = [
+  "unmapped/via-params-rest.js", // rest param; previously compile_error (invalid Wasm)
+  "unmapped/via-params-dflt.js", // default param; previously fail (mapped write-back)
+  "unmapped/via-params-dstr.js", // destructuring param; previously fail
+];
+
+// Guard: pre-existing unmapped/strict behaviour must stay green.
+const stillGreen = ["unmapped/via-strict.js"];
+
+const maybe = existsSync(TEST262) ? describe : describe.skip;
+
+maybe("#2743 (c) unmapped arguments for non-simple parameter lists", () => {
+  for (const rel of [...unmappedNonSimple, ...stillGreen]) {
+    it(rel, async () => {
+      const r = await runTest262File(`${ROOT}/${rel}`, "language");
+      expect(r.status, `reason: ${(r as any).reason ?? (r as any).error ?? ""}`).toBe("pass");
+    });
+  }
+});


### PR DESCRIPTION
## #2743 group (c) — unmapped `arguments` for non-simple parameter lists

PR-1 of 2 for #2743. Delivers **group (c)**; groups (a) (`[[Prototype]]`/`.constructor`) and (b) (`@@iterator`) follow in PR-2. Issue stays `in-progress`.

### Root cause
The mapped-vs-unmapped `arguments` split was driven **only** by `isStrictFunction(...)`. Per FunctionDeclarationInstantiation (ECMA-262 §10.2.11 step 22.a) the object must be **unmapped** when the function is strict **OR** its parameter list is non-simple (rest / default / destructuring). So a *sloppy* function with a non-simple parameter list wrongly got a **mapped** arguments object:

- `function dflt(a, b=0){ arguments[0]=2; value=a; }` — mapped write-back set `value=2` (test asserts `1`); same for the destructuring case.
- `function rest(a, ...b){ arguments[0]=2; }` — the mapped write-back emitted a `local.set` the rest-param local shape can't satisfy → **"invalid Wasm binary"** `compile_error`. That Wasm error was a *symptom* of the wrong (mapped) object, not a separate emit bug.

### Fix
- New pure AST predicate `isSimpleParameterList(params)` in `src/codegen/helpers/is-strict-function.ts` (co-located with `isStrictFunction`, already imported at every call site — no new import cycle).
- ORed `|| !isSimpleParameterList(...)` into the `unmapped` argument at each `emitArgumentsObject` call site: `nested-declarations.ts:521/793`, `literals.ts` (object-literal methods). `class-bodies.ts` already hard-codes `true` (verified). `function-body.ts` inline path replaced its ad-hoc simple-param check (which **missed defaulted params**) with the shared predicate.
- Unmapped ⇒ no `mappedArgsInfo` ⇒ no write-back ⇒ no bad `local.set`.

### Verification (isolated `runTest262File`)
| test | before | after |
|---|---|---|
| `unmapped/via-params-rest.js` | compile_error | **pass** |
| `unmapped/via-params-dflt.js` | fail | **pass** |
| `unmapped/via-params-dstr.js` | fail | **pass** |
| `unmapped/via-strict.js` (guard) | pass | **pass** |
| `mapped/mapped-arguments-nonconfigurable-1.js` | pass | **pass** |

Regression surface: the change only flips mapped→unmapped for non-simple param lists; a grep of `language/arguments-object/` confirms no mapped/* or other in-scope test uses a non-simple param list. Mapped behaviour with a non-simple list is itself spec-wrong, so no conformant passing test relies on the prior behaviour. Full sharded test262 + merge_group standalone floor validate broadly in CI.

Lock-in test: `tests/issue-2743.test.ts`. `tsc` clean, prettier clean.

Closes part of #2743 (group c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)