### PR TITLE
docs(method): #2749 sprint-end creates no vX.Y.Z version tags — release.mjs only

### DIFF
--- a/.claude/skills/sprint-wrap-up.md
+++ b/.claude/skills/sprint-wrap-up.md
@@ -22,6 +22,7 @@ ls /workspace/.claude/worktrees/
 ```
 
 For each worktree:
+
 - Check for uncommitted work: `git -C <wt> diff --stat`
 - Check for unmerged commits: `git -C <wt> log --oneline main..HEAD`
 - If all merged: `git worktree remove --force <wt>`
@@ -66,6 +67,11 @@ git tag sprint/N  # replace N with sprint number
 git push origin sprint/N
 ```
 
+> Sprint-end tags ONLY `sprint/N` — it does **not** tag a version. Never
+> `git tag vX.Y.Z` at sprint end. Version tags are cut exclusively via
+> `node scripts/release.mjs <x.y.z>` (the deliberate, reviewed release flow);
+> see `docs/releasing.md` and loopdive/js2#389.
+
 Then set `end_tag_pushed: true` in the `wrap_checklist` in `plan/issues/sprints/{N}/sprint.md`.
 
 ## Step 6: Carry over unfinished issues to the next sprint
@@ -90,6 +96,7 @@ numbers and the phrase "moved into [sprint-M.md]" (this sets the dashboard's
 
 Sprint docs are **flat files** (#1616): `plan/issues/sprints/{N}.md` (NOT a
 `{N}/sprint.md` directory). Edit `plan/issues/sprints/{N}.md`:
+
 - Fill in final test262 numbers
 - Calculate delta from baseline
 - Note any deferred tasks
@@ -122,6 +129,7 @@ deploy regen.
 ## Step 9: Spawn SM for retrospective
 
 Spawn the scrum-master agent to write `plan/log/retrospectives/sprint-{N}.md`. The SM reads:
+
 - `plan/issues/sprints/{N}.md` — results, deferred tasks
 - `git log sprint-{N}/begin..sprint/{N}` — what landed
 - Previous retro for format reference
@@ -145,6 +153,7 @@ Invoke the harvest-errors skill (or spawn a dedicated harvester agent)
 ```
 
 The harvester:
+
 - Clusters failures in the baseline JSONL by normalized error pattern (run
   `node scripts/fetch-baseline-jsonl.mjs` first to populate
   `.test262-cache/test262-current.jsonl` — the file is no longer
@@ -155,11 +164,12 @@ The harvester:
 
 Commit any newly-filed issues before Step 10.
 
-**Why here and not at sprint kickoff:** after the sprint's merges have landed, the failure distribution has shifted — running harvest at wrap-up captures the *current* gaps, not stale pre-sprint ones. The next sprint's planning session (PO) can then slice the fresh issue list by theme. See memory: `feedback_harvest_at_sprint_end.md`.
+**Why here and not at sprint kickoff:** after the sprint's merges have landed, the failure distribution has shifted — running harvest at wrap-up captures the _current_ gaps, not stale pre-sprint ones. The next sprint's planning session (PO) can then slice the fresh issue list by theme. See memory: `feedback_harvest_at_sprint_end.md`.
 
 ## Step 12: Update session memory
 
 Update `/home/node/.claude/projects/-workspace/memory/project_next_session.md` with:
+
 - Final git hash
 - Test262 numbers
 - What's still open

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 TypeScript-to-WebAssembly compiler using WasmGC.
 
 ## Running Tests
+
 - Run all tests: `npm test` (vitest — may OOM on full suite in constrained envs)
 - Run a specific test file: `npm test -- tests/issue-277.test.ts`
 - Run equivalence tests only: `npm test -- tests/equivalence.test.ts`
@@ -10,22 +11,25 @@ TypeScript-to-WebAssembly compiler using WasmGC.
 - **Local CI on Claude Code on Web** (or any 16GB+ container): `JS2WASM_LOCAL_CI=1 ./scripts/local-ci.sh` — idempotent pnpm install + test262 submodule init, then `pnpm run test:262` with `COMPILER_POOL_SIZE=$(nproc)`. Baseline 2026-05-20 on a 4-core/16GB container: ~68 min wall-clock, ~2.8 GB peak RAM. CI sharded is still faster end-to-end; this is for in-container validation runs. See `plan/issues/1522-race-local-test262-vs-ci.md` for the scoped pre-flight design.
 
 ## Dev scratch
+
 - **All ad-hoc probe / debug / repro files go in `.tmp/`** — gitignored, not picked up by vitest, doesn't pollute `git status`.
 - If you spin up a quick `check-foo.ts`, `debug-bar.mts`, or `probe-*.test.ts` to investigate a bug, write it inside `.tmp/`, not at repo root or under `tests/`.
 - Root-level patterns like `check-*.ts`, `debug-*.ts`, `run-*.ts`, `test-*-debug.ts`, `tests/probe-*.test.ts`, `tests/*-debug*.test.ts` are also gitignored as a safety net, but the convention is `.tmp/`.
 
 ## Working in worktrees
+
 - **All agent work happens in worktrees**, not in `/workspace` directly. The `check-cwd.sh` hook blocks `git commit`/`merge`/`push` from `/workspace` for non-tech-lead users.
 - **Canonical worktree path**: `/workspace/.claude/worktrees/<branch-name>/` — this is enforced by the `check-worktree-path.sh` hook on `git worktree add`. Worktrees outside this root (e.g. `/tmp/worktrees/`) are rejected.
 - **Persistent shell cwd resets between Bash invocations**: every Bash tool call starts from `/workspace` regardless of where the previous one ended. Trailers like `Shell cwd was reset to /workspace` confirm this. The agent must prefix git commands with `cd /workspace/.claude/worktrees/<branch> &&` for them to land on the right branch.
   - Read/Edit/Write tools use absolute paths and are unaffected.
   - The `pre-git-commit.sh` hook injects a "VERIFY BEFORE COMMITTING: pwd=/workspace branch=main" reminder; that's the hook reading the (reset) shell cwd, NOT the actual command's working dir. The reminder is informational — verify by reading the commit's branch in git output (`[issue-1183-string-forof-ir 0527c7c5]`-style line shows the real branch).
 - **Worktree creation**: `git worktree add /workspace/.claude/worktrees/issue-NNN-slug -b issue-NNN-slug origin/main`. Always branch from `origin/main` (post-fetch), never from local `main`.
-- **Branch base — `origin/main`, never the merge-queue tip (#2522)**: for independent work, branch from `origin/main`, then `git merge origin/main` again right before enqueue — that catch-up rebases the work onto future-main but incorporates only PRs that *actually landed*. Do **not** branch from a `gh-readonly-queue/main/pr-N-<sha>` tip or otherwise base work on the queue's *speculative* end-state: queued PRs eject, and a base built on an ejected PR carries phantom commits that force a rebase (forbidden — public main is append-only). **Exception — known dependency (explicit predecessor-stacking)**: when a new task is known to depend on / heavily overlap a specific in-flight PR, branch from *that PR's real branch* (durable, not the ephemeral queue ref) and enqueue only after the predecessor lands; re-merge it if it changes. The inter-PR conflict rate is a queue-*speculation* lever (`max_entries_to_build > 1`, re-raise once runner capacity from #2519 allows), not a dev-branch-base lever.
+- **Branch base — `origin/main`, never the merge-queue tip (#2522)**: for independent work, branch from `origin/main`, then `git merge origin/main` again right before enqueue — that catch-up rebases the work onto future-main but incorporates only PRs that _actually landed_. Do **not** branch from a `gh-readonly-queue/main/pr-N-<sha>` tip or otherwise base work on the queue's _speculative_ end-state: queued PRs eject, and a base built on an ejected PR carries phantom commits that force a rebase (forbidden — public main is append-only). **Exception — known dependency (explicit predecessor-stacking)**: when a new task is known to depend on / heavily overlap a specific in-flight PR, branch from _that PR's real branch_ (durable, not the ephemeral queue ref) and enqueue only after the predecessor lands; re-merge it if it changes. The inter-PR conflict rate is a queue-_speculation_ lever (`max_entries_to_build > 1`, re-raise once runner capacity from #2519 allows), not a dev-branch-base lever.
 - **Push safety**: `.git/config` sets `push.default=current` — `git push` always pushes to the remote branch matching the local branch name, regardless of upstream tracking. This prevents the `git worktree add -b <branch> origin/main` trap where the inherited tracking ref routes pushes to origin/main.
 - **Worktree cleanup after merge**: after a dev self-merges their PR, they remove their own worktree (`git worktree remove /workspace/.claude/worktrees/<branch>`) before claiming the next task. Tech-lead only removes worktrees for suspended or abandoned branches.
 
 ## Architecture Principles
+
 - **Dual-mode: JS host optional** — the compiler supports two modes: JS host mode (uses host imports for performance/completeness) and standalone mode (pure Wasm, no JS runtime). New features should have Wasm-native implementations for standalone mode; JS host imports are acceptable as a fast path when a JS runtime is available. Don't add new host imports without a standalone fallback.
 - This follows the pattern of #679 (dual string backend) and #682 (dual RegExp backend).
 - **Two orthogonal axes in codegen** (see #1527):
@@ -34,6 +38,7 @@ TypeScript-to-WebAssembly compiler using WasmGC.
   - Full discussion: [docs/architecture/codegen-axes.md](docs/architecture/codegen-axes.md). Per-AST-kind adoption status: [plan/log/ir-adoption.md](plan/log/ir-adoption.md).
 
 ## Project Structure
+
 - Codegen: `src/codegen/expressions.ts`, `src/codegen/index.ts`, `src/codegen/statements.ts`, `src/codegen/type-coercion.ts`, `src/codegen/peephole.ts`
 - WIT generator: `src/wit-generator.ts` (TypeScript → WIT interface generation)
 - Optimizer: `src/optimize.ts` (Binaryen wasm-opt integration)
@@ -76,6 +81,7 @@ TypeScript-to-WebAssembly compiler using WasmGC.
   - Legacy milestones in `plan/milestones/` are superseded by goals
 
 ## Key Patterns
+
 - `VOID_RESULT` sentinel in expressions.ts — `InnerResult = ValType | null | typeof VOID_RESULT`
 - Ref cells for mutable closure captures — `struct (field $value (mut T))`
 - FunctionContext must include `labelMap: new Map()` and `isGenerator?: boolean` in all object literals
@@ -87,17 +93,20 @@ TypeScript-to-WebAssembly compiler using WasmGC.
 - `nativeStrings` flag decouples WasmGC string arrays from fast mode (auto-enables for WASI)
 
 ## Type Coercion (now in `src/codegen/type-coercion.ts`)
+
 - ref/ref_null → externref: use `extern.convert_any` (in coerceType)
 - f64 → externref: use `__box_number` import
 - i32 → externref: use `f64.convert_i32_s` + `__box_number`
 - null/undefined in f64 context: emit `f64.const 0` / `f64.const NaN` directly (avoids externref roundtrip)
 
 ## addUnionImports
+
 - Late import addition shifts function indices — `addUnionImports` in index.ts
 - Must also shift `ctx.currentFunc.body` (the current function being compiled)
 - `body: []` in FunctionContext (NOT `body: func.body`) — shared references break savedBody/swap pattern
 
 ## Test262
+
 - test262.test.ts has no assertions — all vitest tests pass; conformance is tracked via report
 - Skip filters: eval, with, Proxy, SharedArrayBuffer, Temporal, WeakRef, FinalizationRegistry, dynamic import(), top-level-await
 - Many previously-skipped features now supported: TypedArray, DataView, ArrayBuffer, delete, async, generators, for-of
@@ -106,11 +115,11 @@ TypeScript-to-WebAssembly compiler using WasmGC.
 
 ### Baseline files (which is authoritative?)
 
-| File | Lives in | Authoritative for | Refreshed by | Validated by |
-|------|----------|-------------------|--------------|--------------|
-| `benchmarks/results/test262-current.json` | main repo (committed, ~kB) | landing-page summary, pass/total badges | `test262-sharded.yml` `promote-baseline` job (every push to main) | (none) |
-| `test262-current.jsonl` (in `loopdive/js2wasm-baselines`) | separate repo | PR regression-gate baseline (fetched fresh per CI run); `dev-self-merge` Step 4 bucket-by-path regression analysis (#1528) | `test262-sharded.yml` `promote-baseline` job (every push to main) | `test262-baseline-validate.yml` spot-checks 50 random `pass` entries on every PR (#1218); fails the PR if any sampled entry no longer passes on main HEAD |
-| `benchmarks/results/playground-benchmark-sidebar.json` | main repo (committed, ~1KB) | landing-page sidebar wasm/js perf chart; `benchmark-refresh.yml` regression diff baseline | `benchmark-refresh.yml` auto-commit step on every push to main (#1216) | (none) |
+| File                                                      | Lives in                    | Authoritative for                                                                                                          | Refreshed by                                                           | Validated by                                                                                                                                              |
+| --------------------------------------------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `benchmarks/results/test262-current.json`                 | main repo (committed, ~kB)  | landing-page summary, pass/total badges                                                                                    | `test262-sharded.yml` `promote-baseline` job (every push to main)      | (none)                                                                                                                                                    |
+| `test262-current.jsonl` (in `loopdive/js2wasm-baselines`) | separate repo               | PR regression-gate baseline (fetched fresh per CI run); `dev-self-merge` Step 4 bucket-by-path regression analysis (#1528) | `test262-sharded.yml` `promote-baseline` job (every push to main)      | `test262-baseline-validate.yml` spot-checks 50 random `pass` entries on every PR (#1218); fails the PR if any sampled entry no longer passes on main HEAD |
+| `benchmarks/results/playground-benchmark-sidebar.json`    | main repo (committed, ~1KB) | landing-page sidebar wasm/js perf chart; `benchmark-refresh.yml` regression diff baseline                                  | `benchmark-refresh.yml` auto-commit step on every push to main (#1216) | (none)                                                                                                                                                    |
 
 **Baseline JSONL is no longer committed to the main repo (#1528).** It lives only in `loopdive/js2wasm-baselines` and is fetched on demand by `scripts/fetch-baseline-jsonl.mjs` to `.test262-cache/test262-current.jsonl` (gitignored). Consumers (validator, `dev-self-merge` bucket analysis, regression triage, sprint wrap-up harvest) either call the helper directly or accept the cache path via fallback. This removes the ~15 MB blob from every clone and retired the dedicated `refresh-committed-baseline.yml` workflow.
 
@@ -132,9 +141,9 @@ reason from a silent legacy fallback to a hard compile error. Per-bucket
 ownership + target dates live in `plan/log/ir-adoption.md`.
 
 | Reason                       | Category   | Reduces with                         |
-|------------------------------|------------|--------------------------------------|
+| ---------------------------- | ---------- | ------------------------------------ |
 | `body-shape-rejected`        | unintended | #1370 (class methods), #1373 (async) |
-| `external-call`              | unintended | #1371 (whitelist Math.* / parseInt)  |
+| `external-call`              | unintended | #1371 (whitelist Math.\* / parseInt) |
 | `call-graph-closure`         | unintended | #1370, #1373                         |
 | `param-shape-rejected`       | unintended | #1372 (destructuring params)         |
 | `param-type-not-resolvable`  | unintended | better TypeMap propagation           |
@@ -161,6 +170,7 @@ bank automatically; use `--verbose` on either mode to print the per-file
 rejection breakdown.
 
 ## CLI Flags
+
 - `--target wasi` — emit WASI imports (fd_write, proc_exit) instead of JS host
 - `--optimize` / `-O` — run Binaryen wasm-opt on compiled binary
 - `--wit` — generate WIT interface file for Component Model
@@ -171,12 +181,14 @@ rejection breakdown.
 See [plan/method/team-setup.md](plan/method/team-setup.md) for full team config, roles, memory budget, communication protocol, and merge lessons. Agent preferences and rules are in `.claude/memory/` (MEMORY.md index).
 
 **Checklists** (read at the right moment, not at spawn time):
+
 - `plan/method/session-start-checklist.md` — tech lead reads at session start
 - `plan/method/pre-commit-checklist.md` — devs read before every git add/commit
 - `plan/method/pre-completion-checklist.md` — devs read before signaling task completion
 - `plan/method/pre-merge-checklist.md` — dev reads before merging to main
 
 **Skills** (on-demand role protocols — any agent can invoke these):
+
 - `/test-and-merge` — full tester pipeline: merge main into branch, equiv tests, ff-only merge
 - `/smoke-test-issue` — validate an issue still reproduces before dispatching
 - `/analyze-regression` — diff two test262 runs to find which tests flipped
@@ -185,11 +197,13 @@ See [plan/method/team-setup.md](plan/method/team-setup.md) for full team config,
 - `/architect-spec` — write implementation spec for a hard issue
 
 Skills replace idle specialist agents. A dev can invoke `/test-and-merge` instead of waiting for a tester. Any agent can invoke `/architect-spec` instead of spawning an architect. Prefer skills over dedicated agents when:
+
 - The task is short (< 5 min of agent time)
 - Only one agent needs the capability at a time
 - RAM is tight
 
 Spawn dedicated agents when:
+
 - Multiple tasks need the same role concurrently (e.g., 3 devs)
 - The role needs sustained back-and-forth with the user (e.g., PO during planning)
 - The role accumulates context that's hard to capture in a skill (e.g., SM during retro discussion)
@@ -205,33 +219,34 @@ Default rule: if the agent's job is "produce one document and exit," it's a suba
 
 **IMPORTANT: Always use team name `"js2wasm"`** — this is the single permanent team. Never create ad-hoc team names (e.g. `"wasi-conflicts"`, `"s52-wave2"`). One team, one task queue, always.
 
-**Key numbers**: 16GB RAM + 16GB swap (container, set in `.devcontainer/devcontainer.json`), **8 cores**. `free -m` may report ~20GB but Docker enforces 16GB hard limit. **CPU is the binding constraint, not RAM** — keep concurrent *active* agents to ~`cores − 2` (≈6 here) so the box stays interactive; the `pre-agent-spawn.sh` load gate enforces this. All agents use `bypassPermissions` mode + worktree isolation. Work driven by `plan/log/dependency-graph.md`.
+**Key numbers**: 16GB RAM + 16GB swap (container, set in `.devcontainer/devcontainer.json`), **8 cores**. `free -m` may report ~20GB but Docker enforces 16GB hard limit. **CPU is the binding constraint, not RAM** — keep concurrent _active_ agents to ~`cores − 2` (≈6 here) so the box stays interactive; the `pre-agent-spawn.sh` load gate enforces this. All agents use `bypassPermissions` mode + worktree isolation. Work driven by `plan/log/dependency-graph.md`.
 
 **RAM monitoring**: Use `free -m` "available" column (not "free"). "free" excludes reclaimable disk cache. Hooks check "available" before allowing agent spawns.
 
-**CPU / concurrency cap (the binding limit)**: The real bottleneck on this box is CPU, not RAM — agents are cheap while idle (waiting on the API) but each *active* one bursts a core during compile/test. With no ceiling, load oversubscribes (it hit 13–16 on 8 cores), which starves sshd and drops interactive SSH sessions. `pre-agent-spawn.sh` therefore hard-blocks a new spawn when the **1-min load average ≥ `cores − 2`** (the `JS2WASM_MAX_LOAD` env var; default leaves ~2 cores for the lead/IDE/sshd/system). It gates on *load*, not a process count, because the harness keeps a warm `claude.exe` pool (`--bg-spare`/`--bg-pty-host`) that makes process-counting a poor proxy for active agents. Raise `JS2WASM_MAX_LOAD` to trade SSH responsiveness for throughput.
+**CPU / concurrency cap (the binding limit)**: The real bottleneck on this box is CPU, not RAM — agents are cheap while idle (waiting on the API) but each _active_ one bursts a core during compile/test. With no ceiling, load oversubscribes (it hit 13–16 on 8 cores), which starves sshd and drops interactive SSH sessions. `pre-agent-spawn.sh` therefore hard-blocks a new spawn when the **1-min load average ≥ `cores − 2`** (the `JS2WASM_MAX_LOAD` env var; default leaves ~2 cores for the lead/IDE/sshd/system). It gates on _load_, not a process count, because the harness keeps a warm `claude.exe` pool (`--bg-spare`/`--bg-pty-host`) that makes process-counting a poor proxy for active agents. Raise `JS2WASM_MAX_LOAD` to trade SSH responsiveness for throughput.
 
 **Memory budget** (measured peaks via `/proc/[pid]/status` VmHWM):
+
 - Fixed: Cursor ~1,400MB + system ~1,200MB + tech lead ~1,400MB = **~4,000MB**
 - Dev agent: ~700MB peak (no local test262)
 - Test262 (CI only): ~4,300MB peak per shard — runs in GitHub Actions, not locally
-- RAM allows ~8 devs (~9.6GB headroom), but **CPU is the tighter limit**: target ~`cores − 2` (≈6) concurrent *active* agents. The `pre-agent-spawn.sh` load gate (see "CPU / concurrency cap" above) enforces it; `free -m` available is still a secondary floor.
+- RAM allows ~8 devs (~9.6GB headroom), but **CPU is the tighter limit**: target ~`cores − 2` (≈6) concurrent _active_ agents. The `pre-agent-spawn.sh` load gate (see "CPU / concurrency cap" above) enforces it; `free -m` available is still a secondary floor.
 
 ### Agent lifecycle — when to spawn, skill, or terminate
 
-| Situation | Action |
-|-----------|--------|
-| Dev needs to test + merge | Invoke `/test-and-merge` skill (no tester agent needed) |
-| Need to validate 1-2 issues | Invoke `/smoke-test-issue` skill |
-| Sprint planning (collaborative, multi-issue) | Spawn PO + Architect agents |
-| Hard issue needs design | Invoke `/architect-spec` skill, or spawn architect if multiple issues |
-| Sprint retro (discussion with user) | Spawn SM agent |
-| Planning agents done, user not talking to them | Write context summary → terminate |
-| Planning agents done, user IS talking to them | Keep alive until user signals done |
-| Dev between tasks | Keep alive — wait for CI, self-merge if green, then claim next task from TaskList |
-| Dev sending idle_notification pings | If TaskList has unowned work: redirect them to it. Otherwise: send `shutdown_request` — that's the correct lifecycle exit, not a punishment. |
-| Dev idle, no tasks available | Send `shutdown_request` immediately. Idle teammates burn pane slots and block new spawns. Re-spawn when work appears. |
-| End of sprint | All agents write context summaries → terminate → run `/sprint-wrap-up` |
+| Situation                                      | Action                                                                                                                                       |
+| ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Dev needs to test + merge                      | Invoke `/test-and-merge` skill (no tester agent needed)                                                                                      |
+| Need to validate 1-2 issues                    | Invoke `/smoke-test-issue` skill                                                                                                             |
+| Sprint planning (collaborative, multi-issue)   | Spawn PO + Architect agents                                                                                                                  |
+| Hard issue needs design                        | Invoke `/architect-spec` skill, or spawn architect if multiple issues                                                                        |
+| Sprint retro (discussion with user)            | Spawn SM agent                                                                                                                               |
+| Planning agents done, user not talking to them | Write context summary → terminate                                                                                                            |
+| Planning agents done, user IS talking to them  | Keep alive until user signals done                                                                                                           |
+| Dev between tasks                              | Keep alive — wait for CI, self-merge if green, then claim next task from TaskList                                                            |
+| Dev sending idle_notification pings            | If TaskList has unowned work: redirect them to it. Otherwise: send `shutdown_request` — that's the correct lifecycle exit, not a punishment. |
+| Dev idle, no tasks available                   | Send `shutdown_request` immediately. Idle teammates burn pane slots and block new spawns. Re-spawn when work appears.                        |
+| End of sprint                                  | All agents write context summaries → terminate → run `/sprint-wrap-up`                                                                       |
 
 ### Roles and interactions
 
@@ -252,39 +267,35 @@ Scrum Master
   ↔ reviews sprint → proposes process changes to PO + tech lead
 ```
 
-| Role | Agent | Owns | Reads from | Writes to |
-|------|-------|------|-----------|-----------|
-| **Product Owner** | `.claude/agents/product-owner.md` | Backlog, issue creation, priorities | test262 results, dependency graph | `plan/issues/`, `plan/log/dependency-graph.md` |
-| **Architect** | `.claude/agents/architect.md` | Implementation specs | Issue files, compiler source | `## Implementation Plan` in issue files |
-| **Tech Lead** | (orchestrator) | Task queue, merges, test runs | Issue files, agent messages | `main` branch, task list |
-| **Developer** | `.claude/agents/developer.md` | Code changes in worktree | Issue file + impl spec, checklists | Source code, test files, issue status |
-| **PR-queue Shepherd** | `.claude/agents/developer.md` (standing teammate) | The merge queue end-to-end | Open PRs, CI/`merge_group` results, park-hold comments | Enqueue mutations, `[CI-FIX]` tasks, escalations |
-| **Scrum Master** | `.claude/agents/scrum-master.md` | Process improvement | Done issues, git history, messages | `plan/retrospectives/`, checklist edits (proposed) |
+| Role                  | Agent                                             | Owns                                | Reads from                                             | Writes to                                          |
+| --------------------- | ------------------------------------------------- | ----------------------------------- | ------------------------------------------------------ | -------------------------------------------------- |
+| **Product Owner**     | `.claude/agents/product-owner.md`                 | Backlog, issue creation, priorities | test262 results, dependency graph                      | `plan/issues/`, `plan/log/dependency-graph.md`     |
+| **Architect**         | `.claude/agents/architect.md`                     | Implementation specs                | Issue files, compiler source                           | `## Implementation Plan` in issue files            |
+| **Tech Lead**         | (orchestrator)                                    | Task queue, merges, test runs       | Issue files, agent messages                            | `main` branch, task list                           |
+| **Developer**         | `.claude/agents/developer.md`                     | Code changes in worktree            | Issue file + impl spec, checklists                     | Source code, test files, issue status              |
+| **PR-queue Shepherd** | `.claude/agents/developer.md` (standing teammate) | The merge queue end-to-end          | Open PRs, CI/`merge_group` results, park-hold comments | Enqueue mutations, `[CI-FIX]` tasks, escalations   |
+| **Scrum Master**      | `.claude/agents/scrum-master.md`                  | Process improvement                 | Done issues, git history, messages                     | `plan/retrospectives/`, checklist edits (proposed) |
 
 **Interaction flow:**
 
 Sprint planning:
+
 1. **PO** validates candidate issues against current main → closes stale ones
 2. **PO** prioritizes remaining issues by value → routes hard ones to architect
 3. **Architect** reads issue + compiler source → writes implementation plan in the issue file
 4. **PO** creates task queue with full context → tech lead dispatches to devs
 
-During sprint:
-5. **Dev** reads issue (with impl plan) → implements → follows checklists → signals completion
-6. **Dev** invokes `/test-and-merge` skill → merges main into branch → equiv tests → if pass: ff-only to main → post-merge cleanup. If fail: fixes on branch.
-7. **PO** accepts/rejects completed work against acceptance criteria
+During sprint: 5. **Dev** reads issue (with impl plan) → implements → follows checklists → signals completion 6. **Dev** invokes `/test-and-merge` skill → merges main into branch → equiv tests → if pass: ff-only to main → post-merge cleanup. If fail: fixes on branch. 7. **PO** accepts/rejects completed work against acceptance criteria
 
-End of sprint:
-8. **Tech lead** runs full test262 → records results
-9. **SM** reviews sprint → proposes process improvements
-10. **PO** grooms backlog for next sprint
+End of sprint: 8. **Tech lead** runs full test262 → records results 9. **SM** reviews sprint → proposes process improvements 10. **PO** grooms backlog for next sprint
 
 **Tech lead discipline:**
+
 - **Populate TaskList** at sprint start from the issues with `sprint: {N}` frontmatter (flat `plan/issues/<id>-<slug>.md`) and immediately whenever new issues are added mid-sprint. Empty queue = agents spin idle.
-- **Reconcile the TaskList against issue-status every loop / session start** — `node scripts/reconcile-tasklist.mjs` (also wired as a SessionStart hook, `--quiet`). It reads the on-disk task stores (`~/.claude/tasks/{<session-uuid>,js2wasm}/*.json`) and reports every non-`completed` task whose **target issue** (first `#NNNN` in the subject) is already `done`/`wont-fix`; apply `TaskUpdate status=completed` for each (or `--apply` for a best-effort direct rewrite of dead-session task files). **Why this exists / root cause of stale tasks:** a task's flip to `completed` is a manual `TaskUpdate` nobody is structurally forced to make — (1) PRs merge *asynchronously* in the queue after the authoring dev has moved on; (2) PO/lead **tracking-tasks** get completed via the *issue file* (`status: done` in the impl PR — the source of truth) with no agent owning the TaskList twin; (3) tasks live in **two stores** (per-session + team `js2wasm`) that don't reconcile each other. So `issue status` (accurate) and `TaskList status` (stale) drift silently. The reconciler derives done-ness from the authoritative issue frontmatter and closes the loop. Devs should also flip their own task to `completed` at **enqueue** time (enqueue ⇒ will-merge), not "after merge" (by then they're gone).
+- **Reconcile the TaskList against issue-status every loop / session start** — `node scripts/reconcile-tasklist.mjs` (also wired as a SessionStart hook, `--quiet`). It reads the on-disk task stores (`~/.claude/tasks/{<session-uuid>,js2wasm}/*.json`) and reports every non-`completed` task whose **target issue** (first `#NNNN` in the subject) is already `done`/`wont-fix`; apply `TaskUpdate status=completed` for each (or `--apply` for a best-effort direct rewrite of dead-session task files). **Why this exists / root cause of stale tasks:** a task's flip to `completed` is a manual `TaskUpdate` nobody is structurally forced to make — (1) PRs merge _asynchronously_ in the queue after the authoring dev has moved on; (2) PO/lead **tracking-tasks** get completed via the _issue file_ (`status: done` in the impl PR — the source of truth) with no agent owning the TaskList twin; (3) tasks live in **two stores** (per-session + team `js2wasm`) that don't reconcile each other. So `issue status` (accurate) and `TaskList status` (stale) drift silently. The reconciler derives done-ness from the authoritative issue frontmatter and closes the loop. Devs should also flip their own task to `completed` at **enqueue** time (enqueue ⇒ will-merge), not "after merge" (by then they're gone).
 - Batch doc/plan commits on main AFTER all pending agent merges, not between them (doc commits force agents to re-merge main)
 - Complete post-merge issue cleanup (set `status: done` in sprint dir issue file, update dep graph) after each merge
-- **Tag sprints**: `git tag sprint-N/begin` when starting a sprint, `git tag sprint/N` when it finishes. Sprint stats (duration, commits, issues) are auto-generated from tags during `build:pages`.
+- **Tag sprints**: `git tag sprint-N/begin` when starting a sprint, `git tag sprint/N` when it finishes. Sprint stats (duration, commits, issues) are auto-generated from tags during `build:pages`. Sprint tagging creates ONLY `sprint/N` (+ `sprint-N/begin`) tags — **never `vX.Y.Z` version tags**. Version tags are cut EXCLUSIVELY via `node scripts/release.mjs <x.y.z>` (lockstep `package.json` bump + reviewed release PR + tag-on-merge), never auto-tagged per sprint (44 legacy bare `v0.*` tags from the old convention caused publish-version drift — loopdive/js2#389).
 - **Prefer the dedicated PR-queue shepherd (below) over hand-shepherding the queue from the lead loop.** Hand-shepherding ad-hoc from the lead loop strands PRs and consumes lead attention; staff a standing shepherd so the lead only steps in on escalations. When no shepherd is staffed, the lead falls back to the sweep below — **ALWAYS shepherd the open PRs to the merge queue every loop, because the `auto-enqueue` cron is a BACKSTOP, not the primary.** Sweep `gh pr list -R loopdive/js2wasm --state open` and **one-shot enqueue every CLEAN, non-`hold`, non-draft PR not already in the queue** (GraphQL `enqueuePullRequest`, **user PAT**, NEVER re-enqueue — loop hazard, see `project_merge_queue_requeue_cancels_run`). A green PR must never sit idle waiting for the sparse ~30-min backstop cron — the shepherd (or lead) drives it to merged. **Held (`hold` label) or CI-failing / `BEHIND` / `DIRTY` PRs → add a high-priority `[CI-FIX]` task at the TOP of the TaskList** for the next dev to rebase/fix the gate failure (with full PR context) and re-enqueue. Both the shepherd/lead AND the authoring agent actively enqueue; the backstop only catches strays.
 
 ### PR-queue shepherd (standing role)
@@ -292,6 +303,7 @@ End of sprint:
 The merge queue needs a **dedicated owner**, not ad-hoc attention from the lead loop. Staff a **standing PR-queue shepherd** — a long-running teammate (team `js2wasm`, `isolation: "worktree"`) whose entire job is to drive open PRs to merged. It is the **primary** enqueuer; the `auto-enqueue.yml` cron remains the **backstop**.
 
 The shepherd owns the queue end-to-end:
+
 - **Sweep** `gh pr list -R loopdive/js2wasm --state open` every loop.
 - **One-shot enqueue** every CLEAN, non-`hold`, non-draft PR not already in the queue, via the GraphQL `enqueuePullRequest` mutation with the **user PAT** (NOT `GITHUB_TOKEN`, which suppresses the `merge_group` event; NOT `gh pr merge --auto`, which silently no-ops on an already-green `CLEAN` PR). Verify the PR appears in the queue. **NEVER re-enqueue** — a single one-shot enqueue per PR; re-enqueue loops cancel in-flight `merge_group` runs (see `project_merge_queue_requeue_cancels_run`).
 - **Monitor `merge_group` results** and handle parks/ejections per the auto-park rules below.
@@ -321,19 +333,21 @@ Sprint planning is a collaborative process, not a solo tech lead activity:
 6. **Tech lead dispatches** — assigns tasks to devs, manages the merge queue
 
 ### Agent work dispatch
+
 - **Tech lead populates TaskList** — devs self-serve from it. No per-task dispatch messages needed.
 - **Owner pins + scope are how the auto-dispatcher is steered.** The native agent-teams auto-dispatcher only auto-offers tasks with **no `owner`**, and it does **not** read role. So the tech lead encodes routing in two places the dispatcher/agents actually honor:
   - **Set `owner` immediately** on any task pinned to a specific agent (e.g. an in-flight `[CONFLICT]` for a named senior-dev, or a one-PR migration). An ownerless `in_progress` task is the #1 mis-route cause — the dispatcher re-offers it. Reconcile (`TaskUpdate status=completed` the moment a PR merges) so stale entries never get re-offered.
   - **Tag role/scope in the subject** so agents can self-gate: `[SENIOR-DEV ONLY]`, `[CONFLICT]` (senior-dev), `arch(...)`/`[ARCH]` (architect), `po:`/`[PO]` (product owner), `[PARKED …]`/`[PAUSE]` (not ready). Plain `fix(...)`/`refactor(...)`/`dev:` = developer-claimable. Agents skip tasks owned by others or tagged outside their lane (see the pre-claim gate in `developer.md`/`senior-developer.md`).
 - **Dev loop**: claim task from TaskList → **branch from latest `origin/main` and push the branch to origin immediately (the moment the task goes in-progress)** → implement → push PR → wait for CI → self-merge if green → mark completed → claim next task.
 - **Pull-main-first + push-on-in-progress (the branch is a live sync point)**: when an agent moves a task to **in-progress** it MUST (1) pull/merge latest `origin/main` into its worktree branch FIRST — never start on a stale base — and (2) **push that branch to origin immediately** (an initial / WIP / grounding commit is fine). Do **not** work local-only for a long window before the first push: an unpushed branch is invisible, so staleness and collisions hide until the PR finally surfaces (e.g. a ~30-min local-only window before the PR appeared). Pushing early makes the branch a **live sync point** other agents can see and rebase against, and makes the assignment concrete. Keep merging `origin/main` as work proceeds. This is additive to — not a replacement for — the merge-before-PR step and the floor/CI discipline below.
-- **Dev self-enqueue ONCE, then stand down (2026-06-20)**: when `.claude/ci-status/pr-<N>.json` has matching SHA, `net_per_test > 0`, ratio <10%, no bucket >50 — the dev **enqueues the PR EXACTLY ONCE** via the GraphQL `enqueuePullRequest` mutation: `PRID=$(gh pr view <N> --json id -q .id); gh api graphql -f query='mutation($id:ID!){enqueuePullRequest(input:{pullRequestId:$id}){clientMutationId}}' -f id="$PRID"`, verifies the PR appears in the queue, marks the task completed, and stands down. Use the **user PAT** for this enqueue — NOT `GITHUB_TOKEN` (which suppresses the `merge_group` event and wedges the queue), and NOT `gh pr merge <N> --auto` (which only arms on a check-state *transition*, so on an already-green `CLEAN` PR it silently no-ops and the PR is never queued — stranded a 9-PR backlog on 2026-05-29; never pass `--merge`/strategy flags either). **NEVER re-enqueue** on drift / ejection / `hold` / CI failure — re-enqueue **loops** were the sole cause of the ~3.5h merge-queue cancellation churn on 2026-06-20 (every re-add rebuilds the merge group and CANCELS the in-flight `merge_group` run; memory `project_merge_queue_requeue_cancels_run`); a single one-shot enqueue does not loop, so it cannot churn. Escalate to tech lead only when criteria fail. `--admin --merge` is reserved for workflow-only / hotfix bypass. See `.claude/skills/dev-self-merge.md`. **Backstop (not primary):** `.github/workflows/auto-enqueue.yml` (`scripts/enqueue-green-prs.mjs`, App-token bot identity) runs on every CI completion + every ~30 min and auto-enqueues any open, non-draft, mergeable PR not already in the queue — it owns ALL re-adds for PRs that strand, drift, or get ejected. The back-off fix #2560 (enqueue trailing PRs while a head forms) makes it a reliable backstop. Its ~30-min cron is too sparse to be the *primary* enqueuer (the "agents never enqueue" experiment left green PRs un-enqueued for long idle stretches), which is why the dev does the one-shot enqueue and the cron only backstops. Manual `node scripts/enqueue-green-prs.mjs` forces a sweep now. Drafts and PRs labelled `hold`/`do-not-merge`/`wip` are never auto-enqueued. **Security:** dev-self-enqueue is for internal/trusted dev agents only — external contributor PRs still go through auto-enqueue's author-trust gate (or a deliberate maintainer enqueue) plus a green `cla-check`.
+- **Dev self-enqueue ONCE, then stand down (2026-06-20)**: when `.claude/ci-status/pr-<N>.json` has matching SHA, `net_per_test > 0`, ratio <10%, no bucket >50 — the dev **enqueues the PR EXACTLY ONCE** via the GraphQL `enqueuePullRequest` mutation: `PRID=$(gh pr view <N> --json id -q .id); gh api graphql -f query='mutation($id:ID!){enqueuePullRequest(input:{pullRequestId:$id}){clientMutationId}}' -f id="$PRID"`, verifies the PR appears in the queue, marks the task completed, and stands down. Use the **user PAT** for this enqueue — NOT `GITHUB_TOKEN` (which suppresses the `merge_group` event and wedges the queue), and NOT `gh pr merge <N> --auto` (which only arms on a check-state _transition_, so on an already-green `CLEAN` PR it silently no-ops and the PR is never queued — stranded a 9-PR backlog on 2026-05-29; never pass `--merge`/strategy flags either). **NEVER re-enqueue** on drift / ejection / `hold` / CI failure — re-enqueue **loops** were the sole cause of the ~3.5h merge-queue cancellation churn on 2026-06-20 (every re-add rebuilds the merge group and CANCELS the in-flight `merge_group` run; memory `project_merge_queue_requeue_cancels_run`); a single one-shot enqueue does not loop, so it cannot churn. Escalate to tech lead only when criteria fail. `--admin --merge` is reserved for workflow-only / hotfix bypass. See `.claude/skills/dev-self-merge.md`. **Backstop (not primary):** `.github/workflows/auto-enqueue.yml` (`scripts/enqueue-green-prs.mjs`, App-token bot identity) runs on every CI completion + every ~30 min and auto-enqueues any open, non-draft, mergeable PR not already in the queue — it owns ALL re-adds for PRs that strand, drift, or get ejected. The back-off fix #2560 (enqueue trailing PRs while a head forms) makes it a reliable backstop. Its ~30-min cron is too sparse to be the _primary_ enqueuer (the "agents never enqueue" experiment left green PRs un-enqueued for long idle stretches), which is why the dev does the one-shot enqueue and the cron only backstops. Manual `node scripts/enqueue-green-prs.mjs` forces a sweep now. Drafts and PRs labelled `hold`/`do-not-merge`/`wip` are never auto-enqueued. **Security:** dev-self-enqueue is for internal/trusted dev agents only — external contributor PRs still go through auto-enqueue's author-trust gate (or a deliberate maintainer enqueue) plus a green `cla-check`.
 - **Tech lead reading ci-status files**: always verify `head_sha` matches current PR HEAD (`gh pr view N --json headRefOid`) before interpreting `net_per_test` or regression counts. A SHA mismatch means CI ran on a stale commit — the numbers are misleading. Also check `baseline_staleness_commits` > 0 as a secondary signal.
 - **Silence vs. pings is the dev health signal.** A dev correctly waiting on CI runs a **background watcher** and goes quiet (see `developer.md` CI-wait protocol) — silence is the healthy state, do NOT poke a silent dev. By contrast, **repeated `idle_notification` pings mean the opposite**: a dev with no background watcher idling in-context, or one wedged (e.g. a tool-param failure loop). Treat a stream of idle pings as an escalation/health signal — redirect to unowned work, send `shutdown_request` if idle, or recognize a wedged agent (it pings but can't ack shutdown; clears on lead-session end). Don't mistake an agent waiting on an already-merged PR for one doing work — reconcile the TaskList (`completed` on merge) so it learns its PR landed.
 - **Devs contact tech lead for**: TaskList empty, blocked >30 min, CI ESCALATE result (immediately — do not wait to be asked), net < 0 result.
 - Dev agents do NOT run full test262 locally — scoped checks only, CI validates conformance.
 
 ### Controlling agents
+
 - **Pause (between tasks)**: create a task with `[PAUSE]` in the subject. Agents stop when they reach it and wait idle.
 - **Pause (immediate)**: send `PAUSE` via SendMessage. Agent stops current work, kills running tests, waits idle. Send `RESUME` to continue.
 - **Suspend**: send `SUSPEND` via SendMessage. Agent commits WIP, writes `## Suspended Work` to the issue file (worktree path, branch, resume steps), then **terminates**. A new agent resumes later from the issue file.
@@ -373,22 +387,28 @@ GitHub branch protection is the hard block.
 11. **Public `main` is append-only — never force-push or rewrite published history** (it breaks every external clone/fork). Fix bad commits forward via revert PRs. See `docs/ci-policy.md`.
 
 ### Issue status lifecycle
+
 The issue frontmatter `status:` field tracks where an issue is, set by whichever agent drives the transition:
+
 - `ready`/`in-progress` → dev starts work (sets `in-progress` when claiming).
-- **Self-merge path (the common case)** — when a dev opens the implementation PR for an issue they will self-merge, the **implementation PR sets `status: done` directly** (with `completed:`), not `in-review`. By the time the merge queue lands the PR, the issue *is* done, and there is no separate observer who can make a post-merge commit. Setting `in-review` here orphans the issue: the dev can't flip it to `done` afterward from `/workspace` once the queue lands the PR. So the impl PR carries the final status. (See #1602/#1603/#1606 — stuck at `in-review` because of exactly this.)
+- **Self-merge path (the common case)** — when a dev opens the implementation PR for an issue they will self-merge, the **implementation PR sets `status: done` directly** (with `completed:`), not `in-review`. By the time the merge queue lands the PR, the issue _is_ done, and there is no separate observer who can make a post-merge commit. Setting `in-review` here orphans the issue: the dev can't flip it to `done` afterward from `/workspace` once the queue lands the PR. So the impl PR carries the final status. (See #1602/#1603/#1606 — stuck at `in-review` because of exactly this.)
 - **`in-review`** — reserved for the **handoff/external case**: the PR author is NOT the merger (e.g. work handed off to another agent, or an external contributor's PR). Set when the PR opens; flipped to `done` by whoever observes the merge.
 - **`done`** — true once the **PR merges**. In the self-merge path it's already set in the impl PR; in the handoff/external case it's set by the merge observer. A merged PR ⇒ `done`. Never leave a merged issue at `in-review`.
 
 ### Issue completion (post-merge)
+
 1. Set `status: done` in the issue file at `plan/issues/<id>-<slug>.md`
 2. Update `plan/log/dependency-graph.md` — remove/strikethrough completed issue
 3. Update `plan/issues/backlog/backlog.md` if the issue was listed there
 
 <!-- AUTO:conformance-start -->
+
 **test262 conformance**: 32,319 / 43,135 (74.9 %)
+
 <!-- AUTO:conformance-end -->
 
 ### Sprint History
+
 - **Sprint 1**: 550 → 1,509 pass (+174%), 167 fail, 5,700 CE. Issues #138-#173.
 - **Sprint 2**: 12 branches, 18 issues (#207-#224). Key: destructuring hoisting (~1200 CE), string comparison, .call(), member increment/decrement, labeled break. Equivalence tests: 86 → 170.
 - **Sprint 3**: 32 issues (#225-#256). Target: 0 runtime failures, ~1,500 CE reduction.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -26,6 +26,13 @@ The fix has two parts:
    publish unless the tag version equals BOTH `package.json` versions. This
    catches both the original drift bug and a forgotten lockstep proxy bump.
 
+**Version tags are release-only.** The 44 legacy `v0.*` tags that caused #389
+came from an old per-sprint / manual version-tagging habit. To prevent a repeat,
+`vX.Y.Z` tags are cut **exclusively** via `node scripts/release.mjs <x.y.z>` (the
+flow below). **Sprint-end must NOT create a version tag** — the sprint protocol
+tags only `sprint/N` (+ `sprint-N/begin`); see `CLAUDE.md` and
+`.claude/skills/sprint-wrap-up.md`. Never `git tag vX.Y.Z` outside this flow.
+
 ## How to cut a release
 
 1. **Bump both packages, commit, and tag — in one step, on a clean tree:**
@@ -86,12 +93,12 @@ The script tags the release commit **on your branch**, and the tag stays valid
 after merge because the merge queue uses a **merge commit** (`mergeMethod = MERGE`,
 confirmed for this repo) — the merge commit keeps your tagged commit reachable in
 `main`'s history. So you push the same `vX.Y.Z` tag after merge and it points at a
-commit that *is* on `main`.
+commit that _is_ on `main`.
 
 > **If the repo ever switches `main` to squash or rebase merges**, the branch
 > commit (and therefore the branch tag) would be rewritten or dropped on merge,
 > leaving the tag dangling off `main`. In that case this flow must change to
-> *tag the merge commit* after it lands (`git tag vX.Y.Z <merge-sha>`) rather
+> _tag the merge commit_ after it lands (`git tag vX.Y.Z <merge-sha>`) rather
 > than tagging on the branch. The `verify-version` guard is the backstop either
 > way: a tag pointing at the wrong commit fails the publish instead of shipping a
 > stale version.

--- a/plan/issues/2749-no-sprint-version-autotag-protocol.md
+++ b/plan/issues/2749-no-sprint-version-autotag-protocol.md
@@ -1,0 +1,49 @@
+---
+id: 2749
+title: Sprint-end creates no vX.Y.Z version tags — release.mjs only
+status: done
+completed: 2026-06-27
+sprint: 67
+assignee: ttraenkler/agent-ace4f48e
+type: docs
+feasibility: easy
+---
+
+# Sprint-end must not auto-create `vX.Y.Z` version tags
+
+## Problem
+
+The repo accumulated 44 legacy `v0.x.0` tags from an old per-sprint / manual
+version-tagging convention (loopdive/js2#389). Those bare lightweight tags never
+touched `package.json`, so `publish-npm.yml` (which publishes whatever `version`
+field `package.json` carries at the tagged commit) kept shipping a stale
+`0.52.0`. That drift is exactly why `scripts/release.mjs` (lockstep
+`package.json` bump) and the `verify-version` gate in `publish-npm.yml` now
+exist.
+
+The team protocol must make explicit that **sprint tagging creates ONLY
+`sprint/N` (+ `sprint-N/begin`) tags and NEVER `vX.Y.Z` version tags**. Version
+tags are cut exclusively via the deliberate `node scripts/release.mjs <x.y.z>`
+release flow (reviewed release PR, lockstep package.json bump, tag-on-merge).
+
+## Verification: no active auto-tagger
+
+Grepped `scripts/`, `.github/workflows/`, `.claude/skills/` (incl.
+`sprint-wrap-up.md`), `package.json`, and `build:pages`/`build-pages*` for any
+code path that auto-cuts a `vX.Y.Z` tag. The **only** `git tag vX.Y.Z` site is
+`scripts/release.mjs` (the deliberate release flow) plus a descriptive comment.
+The active sprint protocol uses `sprint/N` + `sprint-N/begin` only. **No active
+auto-tagger exists** — the change is documentation-only.
+
+## Changes
+
+- `CLAUDE.md` — sprint-tag protocol line: sprint tagging creates only
+  `sprint/N` (+ `sprint-N/begin`), never `vX.Y.Z`; version tags are
+  release-only.
+- `.claude/skills/sprint-wrap-up.md` — `git tag sprint/N` step: explicit note
+  that sprint-end does not tag a version.
+- `docs/releasing.md` — note that version tags are release-only and sprint-end
+  must not create them; reference the #389 legacy-bare-tag cleanup.
+
+Existing legacy `v0.*` tags are public on upstream and are handled separately by
+the release work — not deleted here.


### PR DESCRIPTION
## Summary

Makes the team protocol explicit: **sprint tagging creates ONLY `sprint/N` (+ `sprint-N/begin`) tags — never `vX.Y.Z` version tags.** Version tags are cut exclusively via `node scripts/release.mjs <x.y.z>` (lockstep package.json bump + reviewed release PR + tag-on-merge).

Context: loopdive/js2#389 — the repo accumulated 44 legacy bare `v0.*` tags from an old per-sprint/manual version-tagging convention. Those tags never touched package.json, causing publish-version drift, which is why `release.mjs` + the `verify-version` gate exist.

## Verification: no active auto-tagger
Grepped `scripts/`, `.github/workflows/`, `.claude/skills/` (incl. `sprint-wrap-up.md`), `package.json`, and `build:pages`/`build-pages*`. The only `git tag vX.Y.Z` site is `scripts/release.mjs` (the deliberate release flow). The sprint protocol uses `sprint/N` + `sprint-N/begin` only. **No active auto-tagger exists — this is documentation-only.**

## Changes
- `CLAUDE.md` — sprint-tag protocol line: only `sprint/N` (+ begin), never version tags; release.mjs is the sole version-tag path.
- `.claude/skills/sprint-wrap-up.md` — explicit note at the `git tag sprint/N` step.
- `docs/releasing.md` — version-tags-are-release-only note referencing the #389 cleanup.
- `plan/issues/2749-no-sprint-version-autotag-protocol.md` — issue (status: done).

No existing tags deleted; the legacy `v0.*` tags are handled separately by the release work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)