### PR TITLE
chore(statusline): track origin/main for sprint + test262 numbers

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -39,6 +39,26 @@ else                                           model_color='00;32'
 fi
 branch=$(git -C "${cwd:-$(pwd)}" rev-parse --abbrev-ref HEAD 2>/dev/null)
 issue=$(echo "$branch" | sed -n 's/^issue-\([a-zA-Z0-9]*\).*/\1/p')
+# Base remote: 'upstream' if it exists, else 'origin'. Resolved once at startup.
+_base_remote=$(git -C "${cwd:-$(pwd)}" remote 2>/dev/null | grep -Fx 'upstream' | head -1)
+[ -z "$_base_remote" ] && _base_remote="origin"
+_base_ref="${_base_remote}/main"
+# Throttled background fetch: ensure the base ref stays reasonably fresh
+# without ever blocking the render. If >180s since the last fetch, launch
+# `git fetch` detached in the background (timeout 20s) and update the
+# timestamp. The current render uses whatever objects are already cached.
+_fetch_ts="${HOME}/.cache/js2-statusline/last-fetch"
+_now_s=$(date +%s)
+_do_fetch=1
+if [ -f "$_fetch_ts" ]; then
+  _last=$(cat "$_fetch_ts" 2>/dev/null)
+  [ -n "$_last" ] && [ $(( _now_s - _last )) -lt 180 ] && _do_fetch=0
+fi
+if [ "$_do_fetch" = "1" ]; then
+  mkdir -p "${HOME}/.cache/js2-statusline" 2>/dev/null
+  printf '%s' "$_now_s" > "$_fetch_ts" 2>/dev/null
+  (timeout 20 git -C "${cwd:-$(pwd)}" fetch --quiet "$_base_remote" main 2>/dev/null &) 2>/dev/null
+fi
 display_cwd=$(basename "${cwd:-$(pwd)}")
 printf '\033[01;34m%s\033[00m' "$display_cwd"
 # Model badge — before the ctx bar
@@ -275,11 +295,9 @@ if [ -z "$in_worktree" ] && [ "$branch" = "main" ]; then
   sprint_n=""
   sprint_done=0
   sprint_total=0
-  # LIVE-FIRST: statusline-sprint.mjs scans the working-tree plan/issues/*.md
-  # frontmatter (always current) and only falls back to the sprints.json cache
-  # internally when the flat scan finds nothing. Reading the cache here FIRST is
-  # what made the statusline go stale — sprints.json only rebuilds on
-  # push-to-main, so it reported a closed sprint for days.
+  # statusline-sprint.mjs reads from origin/main via git grep (PRIMARY) so the
+  # sprint numbers always reflect committed truth even when /workspace is stale.
+  # Falls back to the local working-tree scan, then sprints.json, internally.
   sprint_mjs="/workspace/scripts/statusline-sprint.mjs"
   if [ -f "$sprint_mjs" ] && command -v node >/dev/null 2>&1; then
     sprint_data=$(node "$sprint_mjs" --porcelain 2>/dev/null)
@@ -396,8 +414,21 @@ elif [ -n "$vitesting" ]; then
     printf ' \033[00;33m⟳t262:starting\033[00m'
   fi
 elif [ -f "$report" ]; then
-  pass=$(jq -r '.summary.pass // 0' "$report" 2>/dev/null)
-  total=$(jq -r '.summary.total // 1' "$report" 2>/dev/null)
+  # Read host pass/total from the base remote ref (test262-current.json is the
+  # authoritative committed file, refreshed on every push to main). Fall back
+  # to the local file only when the ref read fails (offline / first run).
+  # No timeout: git show on a local ref is a pack-file read — never blocks.
+  _t262_json=$(git -C "${cwd:-$(pwd)}" show "${_base_ref}:benchmarks/results/test262-current.json" 2>/dev/null)
+  if [ -n "$_t262_json" ]; then
+    pass=$(printf '%s' "$_t262_json" | jq -r '.summary.pass // .pass // 0' 2>/dev/null)
+    total=$(printf '%s' "$_t262_json" | jq -r '.summary.total // .total // 1' 2>/dev/null)
+  else
+    # Fallback: local committed file (may be stale when /workspace is behind)
+    _local_t262="/workspace/benchmarks/results/test262-current.json"
+    [ ! -f "$_local_t262" ] && _local_t262="$report"
+    pass=$(jq -r '.summary.pass // .pass // 0' "$_local_t262" 2>/dev/null)
+    total=$(jq -r '.summary.total // .total // 1' "$_local_t262" 2>/dev/null)
+  fi
   pass_pct=$(awk "BEGIN {printf \"%.1f\", $pass * 100 / $total}")
   free_mb=$(free -m | awk '/Mem/{print $7}')
   free_g=$(awk "BEGIN {printf \"%.0f\", $free_mb / 1024}")
@@ -405,20 +436,23 @@ elif [ -f "$report" ]; then
     p_bar=$(pass_bar "$pass_pct" "${pass_pct}% t262")
     f_bar=$(free_bar "$free_g")
     # Standalone (pure-Wasm, no JS host) test262 pass rate, shown right after
-    # the JS-host bar. `.summary` is standard+annexB (43,135) — TC39 proposals
-    # excluded, matching the host bar's denominator.
+    # the JS-host bar. official_pass/official_total = standard+annexB (43,135),
+    # TC39 proposals excluded, matching the host bar's denominator.
     sa_bar=""
     sa_pass=""; sa_total=""
-    # Prefer the committed high-water mark (official_* = standalone pass/total
-    # WITHOUT proposals): the promote-baseline CI job refreshes it on every push
-    # to main, so it tracks the latest js2wasm-baselines numbers. The local
-    # test262-standalone-report.json is an UNtracked dev-run artifact that goes
-    # stale (a 5-day-old 47% shadowed the fresh 52.6% high-water), so use it only
-    # when it is genuinely newer than the high-water file.
-    if [ -f "$standalone_highwater" ]; then
-      sa_pass=$(jq -r '.official_pass // empty' "$standalone_highwater" 2>/dev/null)
-      sa_total=$(jq -r '.official_total // empty' "$standalone_highwater" 2>/dev/null)
+    # Read standalone from the base remote ref (always current).
+    _sa_json=$(git -C "${cwd:-$(pwd)}" show "${_base_ref}:benchmarks/results/test262-standalone-highwater.json" 2>/dev/null)
+    if [ -n "$_sa_json" ]; then
+      sa_pass=$(printf '%s' "$_sa_json" | jq -r '.official_pass // empty' 2>/dev/null)
+      sa_total=$(printf '%s' "$_sa_json" | jq -r '.official_total // empty' 2>/dev/null)
+    else
+      # Fallback to local high-water file
+      if [ -f "$standalone_highwater" ]; then
+        sa_pass=$(jq -r '.official_pass // empty' "$standalone_highwater" 2>/dev/null)
+        sa_total=$(jq -r '.official_total // empty' "$standalone_highwater" 2>/dev/null)
+      fi
     fi
+    # A locally-run standalone report that is genuinely newer takes precedence.
     if [ -f "$standalone_report" ] && [ "$standalone_report" -nt "$standalone_highwater" ]; then
       sa_pass=$(jq -r '.summary.pass // 0' "$standalone_report" 2>/dev/null)
       sa_total=$(jq -r '.summary.total // 1' "$standalone_report" 2>/dev/null)

--- a/scripts/statusline-sprint.mjs
+++ b/scripts/statusline-sprint.mjs
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 // Sprint progress statusline for Claude Code.
-// Prefers dashboard/data/sprints.json (accurate deduplicated view) when available.
-// Falls back to scanning the flat plan/issues/*.md tree, reading the `sprint:`
-// and `status:` frontmatter fields (#1616 — sprint membership is frontmatter,
-// not directory).
+// PRIMARY: reads from the base remote ref (origin/main or upstream/main) via a
+// single batched `git grep` call so the statusline always reflects committed truth
+// even when the local /workspace working tree is behind.
+// FALLBACK: scans the local working-tree plan/issues/*.md frontmatter.
+// LAST RESORT: reads from dashboard/data/sprints.json cache.
 // Emits a colored badge: "sprint N  NN%"
 
+import { spawnSync } from "node:child_process";
 import { readdirSync, readFileSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -13,6 +15,123 @@ import { fileURLToPath } from "node:url";
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const ISSUES_DIR = join(ROOT, "plan", "issues");
 const SPRINTS_JSON = join(ROOT, "website", "dashboard", "data", "sprints.json");
+
+// ── Remote detection ────────────────────────────────────────────────────────
+
+/** Returns 'upstream' if that remote exists in this repo, else 'origin'. */
+function detectBaseRemote() {
+  try {
+    const r = spawnSync("git", ["-C", ROOT, "remote"], {
+      encoding: "utf8",
+      timeout: 3000,
+    });
+    if (r.status === 0) {
+      const remotes = r.stdout.trim().split("\n");
+      if (remotes.includes("upstream")) return "upstream";
+    }
+  } catch {
+    // ignore
+  }
+  return "origin";
+}
+
+// ── Remote ref scan (PRIMARY) ───────────────────────────────────────────────
+
+/**
+ * Reads sprint+status frontmatter for all issue files on <remote>/main via a
+ * single `git grep -E` call (batched — never per-file git show).
+ * Returns { sprint, done, total } or null on failure / unavailability.
+ */
+function sprintFromRemote(remote) {
+  const ref = `${remote}/main`;
+
+  // Single grep for sprint and status lines across all flat issue files.
+  // git grep output format: <ref>:<path>:<matched-line>
+  const grepResult = spawnSync(
+    "git",
+    ["-C", ROOT, "grep", "-E", "^(sprint: [0-9]|status: )", ref, "--", "plan/issues/*.md"],
+    { encoding: "utf8", timeout: 8000, maxBuffer: 16 * 1024 * 1024 },
+  );
+
+  // grep exits 1 when no matches (treat as empty, not failure)
+  if (!grepResult.stdout) return null;
+
+  // Parse output lines: <ref>:<path>:<content>
+  // Split only on the first two colons (paths never contain colons on Linux).
+  const byFile = new Map(); // path -> { sprint?, status? }
+  for (const line of grepResult.stdout.split("\n")) {
+    if (!line) continue;
+    const c1 = line.indexOf(":");
+    if (c1 === -1) continue;
+    const c2 = line.indexOf(":", c1 + 1);
+    if (c2 === -1) continue;
+    const path = line.slice(c1 + 1, c2);
+    const content = line.slice(c2 + 1);
+
+    // Only flat issue files (not plan/issues/sprints/*.md subdirectory)
+    if (path.includes("/sprints/")) continue;
+    // Filename must start with a digit
+    const base = path.slice(path.lastIndexOf("/") + 1);
+    if (!/^\d/.test(base)) continue;
+
+    const file = byFile.get(path) ?? {};
+    // First-wins: frontmatter appears before body text
+    if (file.sprint === undefined) {
+      const m = content.match(/^sprint:\s*(\d+)\s*$/);
+      if (m) file.sprint = Number(m[1]);
+    }
+    if (file.status === undefined) {
+      const m = content.match(/^status:\s*(\S+)/);
+      if (m) file.status = m[1];
+    }
+    byFile.set(path, file);
+  }
+
+  if (byFile.size === 0) return null;
+
+  // Detect inactive sprint numbers from sprint doc files on the remote ref.
+  const sprintDocGrep = spawnSync(
+    "git",
+    ["-C", ROOT, "grep", "-E", "^status: (planning|planned|closed|done)", ref, "--", "plan/issues/sprints/*.md"],
+    { encoding: "utf8", timeout: 4000 },
+  );
+
+  const inactive = new Set();
+  if (sprintDocGrep.stdout) {
+    for (const line of sprintDocGrep.stdout.split("\n")) {
+      if (!line) continue;
+      const c1 = line.indexOf(":");
+      if (c1 === -1) continue;
+      const c2 = line.indexOf(":", c1 + 1);
+      if (c2 === -1) continue;
+      const path = line.slice(c1 + 1, c2);
+      const m = path.match(/\/(\d+)\.md$/);
+      if (m) inactive.add(Number(m[1]));
+    }
+  }
+
+  // Build sprint buckets from the parsed file map.
+  const bySprint = new Map(); // sprintNum -> { total, done }
+  for (const { sprint, status } of byFile.values()) {
+    if (!sprint) continue;
+    const bucket = bySprint.get(sprint) ?? { total: 0, done: 0 };
+    bucket.total++;
+    if (status === "done" || status === "wont-fix") bucket.done++;
+    bySprint.set(sprint, bucket);
+  }
+
+  if (bySprint.size === 0) return null;
+
+  // Current sprint = highest numbered sprint that is not inactive.
+  const nums = [...bySprint.keys()].filter((n) => !inactive.has(n)).sort((a, b) => b - a);
+  const sprintNum = nums[0] ?? 0;
+  if (!sprintNum) return null;
+
+  const { total, done } = bySprint.get(sprintNum);
+  return { sprint: sprintNum, done, total };
+}
+
+// ── Local working-tree fallback ─────────────────────────────────────────────
 
 function fromJson() {
   if (!existsSync(SPRINTS_JSON)) return null;
@@ -69,11 +188,7 @@ function flatTree() {
 }
 
 const SPRINTS_DIR = join(ISSUES_DIR, "sprints");
-// A sprint whose doc status is one of these is NOT the current working sprint,
-// even if its issues are already tagged `sprint: N` in frontmatter. This stops a
-// PRE-PLANNED future sprint (issues queued but the sprint not yet started) from
-// hijacking the "current sprint" pick — the bug where pre-creating sprint N+1's
-// issues made the badge jump to N+1 0/X while the team was still on sprint N.
+// A sprint whose doc status is one of these is NOT the current working sprint.
 const INACTIVE_SPRINT_STATUSES = new Set(["planning", "planned", "closed", "done"]);
 function inactiveSprintNumbers() {
   const out = new Set();
@@ -98,15 +213,46 @@ function inactiveSprintNumbers() {
   return out;
 }
 
-function currentSprint() {
+function currentSprintLocal() {
   const buckets = flatTree();
   const inactive = inactiveSprintNumbers();
   const nums = [...buckets.keys()].filter((n) => !inactive.has(n)).sort((a, b) => b - a);
   return nums[0] ?? 0;
 }
 
-function sprintProgress(n) {
+function sprintProgressLocal(n) {
   return flatTree().get(n) ?? { done: 0, total: 0 };
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+// Priority 1: remote ref (always reflects committed truth regardless of local-tree state)
+const remote = detectBaseRemote();
+let sprintData = sprintFromRemote(remote);
+
+// Priority 2: local working-tree scan (fallback when offline / ref not yet fetched)
+if (!sprintData) {
+  const localSprint = currentSprintLocal();
+  if (localSprint) {
+    sprintData = { sprint: localSprint, ...sprintProgressLocal(localSprint) };
+  }
+}
+
+// Priority 3: pre-built sprints.json cache (last resort)
+if (!sprintData) {
+  sprintData = fromJson();
+}
+
+const sprint = sprintData?.sprint ?? 0;
+const done = sprintData?.done ?? 0;
+const total = sprintData?.total ?? 0;
+const pct = total === 0 ? 0 : done / total;
+
+// --porcelain: emit machine-readable "N done total" for shell callers
+// (.claude/statusline-command.sh renders its own progress bar from these).
+if (process.argv.includes("--porcelain")) {
+  process.stdout.write(`${sprint} ${done} ${total}\n`);
+  process.exit(0);
 }
 
 function interpolateColor(pct) {
@@ -129,31 +275,6 @@ function interpolateColor(pct) {
     b = x;
   }
   return [Math.round(r * 220), Math.round(g * 200), Math.round(b * 20)];
-}
-
-// LIVE-FIRST: read the current working-tree frontmatter (flatTree) so the
-// statusline always reflects reality. The sprints.json cache only rebuilds on
-// push-to-main, so preferring it made the statusline go silently stale (it
-// reported a closed sprint for days). Fall back to the cache only when the flat
-// scan finds no numbered sprint at all (e.g. a partial checkout).
-const flatSprint = currentSprint();
-let sprint, done, total;
-if (flatSprint) {
-  sprint = flatSprint;
-  ({ done, total } = sprintProgress(sprint));
-} else {
-  const jsonData = fromJson();
-  sprint = jsonData ? jsonData.sprint : 0;
-  ({ done, total } = jsonData ?? { done: 0, total: 0 });
-}
-const pct = total === 0 ? 0 : done / total;
-const pctInt = Math.round(pct * 100);
-
-// --porcelain: emit machine-readable "N done total" for shell callers
-// (.claude/statusline-command.sh renders its own progress bar from these).
-if (process.argv.includes("--porcelain")) {
-  process.stdout.write(`${sprint} ${done} ${total}\n`);
-  process.exit(0);
 }
 
 const [r, g, b] = interpolateColor(pct);


### PR DESCRIPTION
## Summary

The statusline was reading sprint and test262 numbers from the local `/workspace` working tree, which is often 100+ commits behind `origin/main` (auto-ff blocked by a dirty tree). This caused stale values like `2/65 s67` and `74.6% t262` when the correct values were `19/75 s67` and `75.0% t262`.

## Changes

**`scripts/statusline-sprint.mjs`** — PRIMARY path now uses a single batched `git grep -E` call against `<remote>/main` to read all `sprint:`/`status:` frontmatter lines in one pass (~80ms for 2460 files). Inactive sprint detection via a second `git grep` on sprint docs. Falls back to local working-tree scan (existing code) when offline, then to `sprints.json`.

**`.claude/statusline-command.sh`**:
- Base remote detection at startup: `upstream` if present, else `origin` (resolves to `origin` on this checkout).
- Throttled background fetch: if >180s since last fetch, kicks off `git fetch --quiet <remote> main &` (detached, timeout 20s) so the ref stays fresh. Never blocks the render.
- Host t262 bar now reads from `<remote>/main:benchmarks/results/test262-current.json` (`.summary.pass`/`.summary.total`) — the authoritative committed file — instead of the stale local `test262-report.json`.
- Standalone sa bar reads from `<remote>/main:benchmarks/results/test262-standalone-highwater.json` (`.official_pass`/`.official_total`) via the same ref path. Falls back to local files when the ref is unavailable.
- `git show` calls are direct (no timeout wrapper) — local pack reads never block on network.

## Verification

Rendered on a `/workspace` 118 commits behind `origin/main`:

```
workspace Sonnet 4.6  10% ctx  19/75 s67  75.0% t262  56.2% sa  15G free
```

Previously showed: `2/65 s67  74.6% t262  56.0% sa` (stale local tree).

Sprint script standalone: `node scripts/statusline-sprint.mjs --porcelain` → `67 19 75` (~170ms, well under 500ms budget).

Offline fallback: a bad/unavailable ref causes `git show`/`git grep` to exit immediately, script falls back silently to local files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)