### PR TITLE
fix(#2746): Object.keys own-key listing — array hasOwnProperty, defineProperty enumerable keys, null/undefined ToObject

### DIFF
--- a/plan/issues/2746-object-keys-getownpropertynames-own-enumerable-arrayindex-nonobject.md
+++ b/plan/issues/2746-object-keys-getownpropertynames-own-enumerable-arrayindex-nonobject.md
@@ -1,7 +1,8 @@
 ---
 id: 2746
 title: "Object.keys / Object.getOwnPropertyNames: own-enumerable key listing, array-exotic index keys, and non-object receiver handling"
-status: ready
+status: in-progress
+assignee: ttraenkler/agent-a4c75e2b30
 sprint: 67
 created: 2026-06-27
 updated: 2026-06-27

--- a/plan/issues/2746-object-keys-getownpropertynames-own-enumerable-arrayindex-nonobject.md
+++ b/plan/issues/2746-object-keys-getownpropertynames-own-enumerable-arrayindex-nonobject.md
@@ -99,12 +99,26 @@ dev-able mechanisms** (none are the enumeration-ORDER substrate #2706/#2739):
    type (mode-agnostic). `getOwnPropertyNames(null/undefined)` already threw.
 
 **Tests fixed (host + standalone verified):** `keys/15.2.3.14-{1-4,1-5,4-1,5-1,
-5-2,3-7}`, `getOwnPropertyNames/15.2.3.4-3-1`. Net **+9** across
-`built-ins/Object/{keys,getOwnPropertyNames,values,entries,
-getOwnPropertyDescriptor,getOwnPropertyDescriptors}` (395→404), with **zero
-regressions** across the entire `built-ins/Object` tree (the earlier
-naive-bounds-check M1 that broke sparse/length-shrink `hasOwnProperty`
-— `defineProperties/15.2.3.7-6-a-{156,161,162}` — was refined away).
+5-2,3-7}`, `getOwnPropertyNames/15.2.3.4-3-1`, `entries|values/exception-not-
+object-coercible`. Net **+9** with **zero regressions** across the full test262
+suite (merge_group re-validation).
+
+**merge_group regression fixes (2026-06-27).** The first cut passed PR-CI but
+the merge_group full-suite found 2 real regressions PR-CI does not run:
+- `defineProperty/15.2.3.6-4-531-6` — `[].hasOwnProperty("0")` after a
+  defineProperty'd index accessor. M1's vec bounds-check returns false (length 0)
+  because the index lives in the runtime sidecar, not the vec data. **Fix:** M1 is
+  now `(vec slot present) OR __hasOwnProperty(arr, key)` — the OR with the
+  host/native helper catches the sidecar index. (Also retired the earlier
+  naive sparse/length-shrink M1 break on `defineProperties/15.2.3.7-6-a-{156,
+  161,162}` by gating M1 to reference-element vecs only.)
+- `keys/15.2.3.14-6-5` — `Object.keys(Date)` vs for-in parity. The M2 superset
+  over-reported plain dynamic-write (`obj.x = …`) sidecar props that for-in does
+  not surface. **Fix:** the M2 superset now adds ONLY defineProperty'd sidecar
+  keys (those with a `_wasmPropDescs` entry), keeping `Object.keys` consistent
+  with for-in. (Trade-off: `keys/15.2.3.14-3-2` — function with a dynamic-write
+  `.x` — reverts to its baseline fail; it needs for-in/keys to BOTH surface
+  dynamic writes, out of scope here.)
 
 **Left for later (substrate-gated, not this issue):** function-dynamic-prop keys
 (`3-2`); sparse-array hole listing (`5-13`, `6-2`); accessor-materialized-as-

--- a/plan/issues/2746-object-keys-getownpropertynames-own-enumerable-arrayindex-nonobject.md
+++ b/plan/issues/2746-object-keys-getownpropertynames-own-enumerable-arrayindex-nonobject.md
@@ -1,7 +1,8 @@
 ---
 id: 2746
 title: "Object.keys / Object.getOwnPropertyNames: own-enumerable key listing, array-exotic index keys, and non-object receiver handling"
-status: in-progress
+status: done
+completed: 2026-06-27
 assignee: ttraenkler/agent-a4c75e2b30
 sprint: 67
 created: 2026-06-27
@@ -68,3 +69,48 @@ coercion / TypeError-on-null-undefined behaviour:**
   `ownKeys`-trap tests (`proxy-*`) are out of scope (Proxy, #1355).
 - Spec: ES2023 §20.1.2.17 `Object.keys`, §20.1.2.16
   `Object.getOwnPropertyNames`, `EnumerableOwnPropertyNames` §7.3.23.
+
+## Implementation / Test Results (2026-06-27)
+
+Verify-first tracing showed the listed fails resolve to **three distinct,
+dev-able mechanisms** (none are the enumeration-ORDER substrate #2706/#2739):
+
+1. **M1 — `arr.hasOwnProperty(index)` on an Array (vec) receiver** returned
+   `false`. `compilePropertyIntrospection` only checked static struct fields; a
+   vec's integer-index slots are exotic, not struct fields. Fix
+   (`src/codegen/object-ops.ts`): for a **reference-element** vec with a static
+   canonical index, emit `index < length && data[index] != null` (the `if`
+   gates the element load so an out-of-range index never traps). Restricted to
+   reference-element vecs because numeric vecs densify holes to `0`/`NaN`
+   (indistinguishable from a real value) and a `defineProperties` length-shrink
+   leaves stale slots — those keep the legacy `false` answer, avoiding the
+   sparse/length-shrink-`hasOwnProperty` regression class. Both modes.
+2. **M2 — `Object.keys` dropped `Object.defineProperty`-added props.** The
+   compile-time struct expansion only sees the literal's declared fields; an
+   added prop lives in the runtime sidecar. Fix: route `Object.keys` for a
+   receiver with an ADDED (non-field) define to the runtime `__object_keys`
+   helper, and make that helper a **superset** of the legacy filter — it now
+   also lists enumerable sidecar (defineProperty/dynamic-write) keys
+   (`src/runtime.ts`). The added-key path only ADDS keys, so the legacy
+   struct-field result cannot regress. Both modes.
+3. **M-C — `Object.keys(null/undefined)` compiled away to `[]`** instead of the
+   `ToObject` `TypeError`. A bare nullish-typed argument hit the empty-literal
+   fast path. Fix: emit the `TypeError` directly for a purely-nullish argument
+   type (mode-agnostic). `getOwnPropertyNames(null/undefined)` already threw.
+
+**Tests fixed (host + standalone verified):** `keys/15.2.3.14-{1-4,1-5,4-1,5-1,
+5-2,3-7}`, `getOwnPropertyNames/15.2.3.4-3-1`. Net **+9** across
+`built-ins/Object/{keys,getOwnPropertyNames,values,entries,
+getOwnPropertyDescriptor,getOwnPropertyDescriptors}` (395→404), with **zero
+regressions** across the entire `built-ins/Object` tree (the earlier
+naive-bounds-check M1 that broke sparse/length-shrink `hasOwnProperty`
+— `defineProperties/15.2.3.7-6-a-{156,161,162}` — was refined away).
+
+**Left for later (substrate-gated, not this issue):** function-dynamic-prop keys
+(`3-2`); sparse-array hole listing (`5-13`, `6-2`); accessor-materialized-as-
+struct-field non-enumerable flag (`2-7`); for-in over the result array (`6-1`,
+`5-12`); `delete array[i]` (`5-a-4`); `getOwnPropertyNames(globalThis)`
+(`gOPN 4-1`); insertion-ORDER tests (#2706/#2739) and Proxy `ownKeys` (#1355).
+The ≥15 acceptance target assumed those substrate cases were in reach; the
+clean dev-able set here is +9 (7 named keys/gOPN + 2 collateral in the
+descriptor dirs).

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -4226,21 +4226,20 @@ export function compilePropertyIntrospection(
   // whose integer-index elements are own (enumerable) data properties — NOT
   // static WasmGC struct fields, so the field-name logic below would wrongly
   // answer `false` for `arr.hasOwnProperty(0)` (e.g. on the result array of
-  // `Object.keys`). Per ES §10.4.2 a canonical in-bounds index is an own
-  // property iff that slot is present (not a hole).
+  // `Object.keys`). The answer is `(index in-bounds and the slot is present) OR
+  // the index was added to the runtime sidecar (e.g. `Object.defineProperty(arr,
+  // "0", …)` on an empty array)` — the OR with the host/native `__hasOwnProperty`
+  // covers the sidecar case the vec data alone can't see.
   //
-  // We only intercept REFERENCE-element vecs (string/object arrays): there a hole
-  // is a distinguishable `ref.null`, so `index < length AND data[index] != null`
-  // is exact. NUMERIC-element vecs densify holes to `0`/`NaN` (indistinguishable
-  // from a real value) AND a `defineProperties` length-shrink leaves stale slots,
+  // We only run the vec bounds branch for REFERENCE-element vecs (string/object
+  // arrays): there a hole is a distinguishable `ref.null`, so `index < length AND
+  // data[index] != null` is exact. NUMERIC-element vecs densify holes to `0`/`NaN`
+  // (indistinguishable) AND a `defineProperties` length-shrink leaves stale slots,
   // so a bounds check there would mis-report holes/shrunk indices as own — those
-  // keep the legacy field-name path (which answers `false`) to avoid regressing
-  // the sparse/length-shrink `hasOwnProperty` tests. The result array of
-  // `Object.keys`/`getOwnPropertyNames` is an externref string vec, so the
-  // affected tests are covered. Only a statically-resolvable canonical index is
-  // handled; everything else (incl. `"length"`, dynamic keys, numeric vecs) falls
-  // through unchanged.
-  if (receiverWasm.kind === "ref" || receiverWasm.kind === "ref_null") {
+  // keep the legacy field-name path. The result array of `Object.keys`/
+  // `getOwnPropertyNames` is an externref string vec, so the targeted tests are
+  // covered. Only a statically-resolvable canonical index is handled.
+  if (propAccess.name.text === "hasOwnProperty" && (receiverWasm.kind === "ref" || receiverWasm.kind === "ref_null")) {
     const vecTypeIdx = (receiverWasm as { typeIdx: number }).typeIdx;
     const vecInfo = getVecInfo(ctx, vecTypeIdx);
     const elemIsRef =
@@ -4260,18 +4259,18 @@ export function compilePropertyIntrospection(
         else if (at.isNumberLiteral()) staticKey = String(at.value);
       }
     }
-    if (elemIsRef && staticKey !== null && _isCanonicalArrayIndexString(staticKey)) {
+    if (elemIsRef && keyArg && staticKey !== null && _isCanonicalArrayIndexString(staticKey)) {
       const dataArrTypeIdx = vecInfo!.arrTypeIdx;
       const idxVal = Number(staticKey);
       const recvLocal = allocLocal(fctx, `__hop_arr_${fctx.locals.length}`, receiverWasm);
+      const presentLocal = allocLocal(fctx, `__hop_present_${fctx.locals.length}`, { kind: "i32" });
       const recv = compileExpression(ctx, fctx, propAccess.expression, receiverWasm);
       if (recv && (recv.kind === "ref" || recv.kind === "ref_null")) {
         fctx.body.push({ op: "ref.as_non_null" } as Instr);
       }
       fctx.body.push({ op: "local.set", index: recvLocal });
-      // own iff (index < length) && (data[index] !== null). The bounds test
-      // gates the element load via an `if` so an out-of-range index never traps
-      // in `array.get`.
+      // present := (index < length) ? (data[index] != null) : 0. The bounds test
+      // gates the element load via an `if` so an out-of-range index never traps.
       fctx.body.push({ op: "local.get", index: recvLocal });
       fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 }); // length
       fctx.body.push({ op: "i32.const", value: idxVal });
@@ -4289,6 +4288,31 @@ export function compilePropertyIntrospection(
         ],
         else: [{ op: "i32.const", value: 0 } as Instr],
       } as Instr);
+      fctx.body.push({ op: "local.set", index: presentLocal });
+      // result := present OR __hasOwnProperty(arr, key) — the latter catches an
+      // index added to the sidecar (e.g. defineProperty on an array index, where
+      // the vec data length is unchanged). __hasOwnProperty exists in both modes.
+      const hopIdx2 = ensureLateImport(
+        ctx,
+        "__hasOwnProperty",
+        [{ kind: "externref" }, { kind: "externref" }],
+        [{ kind: "i32" }],
+      );
+      fctx.body.push({ op: "local.get", index: recvLocal });
+      fctx.body.push({ op: "extern.convert_any" } as Instr);
+      const keyT = compileExpression(ctx, fctx, keyArg, { kind: "externref" });
+      if (keyT && keyT.kind !== "externref") coerceType(ctx, fctx, keyT, { kind: "externref" });
+      flushLateImportShifts(ctx, fctx);
+      if (hopIdx2 !== undefined) {
+        fctx.body.push({ op: "call", funcIdx: hopIdx2 });
+      } else {
+        // No host helper available — drop the args, sidecar contributes nothing.
+        fctx.body.push({ op: "drop" });
+        fctx.body.push({ op: "drop" });
+        fctx.body.push({ op: "i32.const", value: 0 });
+      }
+      fctx.body.push({ op: "local.get", index: presentLocal });
+      fctx.body.push({ op: "i32.or" });
       return { kind: "i32", boolean: true };
     }
     // else fall through to the generic struct-field path (legacy behaviour).

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -3826,6 +3826,26 @@ export function compileObjectKeysOrValues(
   const arg = expr.arguments[0]!;
   const argType = ctx.checker.getTypeAtLocation(arg);
 
+  // (#2746) ES ToObject (§7.1.18): Object.keys/values/entries of `null` or
+  // `undefined` throws a TypeError. A bare nullish-typed argument otherwise
+  // falls into the empty-object-literal fast path below (no own properties to
+  // enumerate) and wrongly compiles away to `[]` instead of throwing. Detect a
+  // purely-nullish argument type and emit the ToObject TypeError directly — this
+  // is mode-agnostic (works in JS-host and standalone) since it never reaches a
+  // host import. `any`/`unknown` keep flowing to the runtime path (which throws
+  // at runtime when the value turns out to be nullish).
+  const NULLISH_FLAGS = ts.TypeFlags.Null | ts.TypeFlags.Undefined | ts.TypeFlags.Void;
+  const isNullishType = (t: ts.Type): boolean =>
+    t.isUnion() ? t.types.every(isNullishType) : (t.flags & NULLISH_FLAGS) !== 0 && (t.flags & ~NULLISH_FLAGS) === 0;
+  if (isNullishType(argType)) {
+    const t = compileExpression(ctx, fctx, arg);
+    if (t) fctx.body.push({ op: "drop" });
+    const which = !argType.isUnion() && argType.flags & ts.TypeFlags.Null ? "null" : "undefined";
+    emitThrowTypeError(ctx, fctx, `Cannot convert ${which} to object`);
+    fctx.body.push({ op: "unreachable" });
+    return { kind: "externref" };
+  }
+
   // Resolve struct name from the argument type
   const structName = resolveStructName(ctx, argType);
   if (!structName) {
@@ -3895,6 +3915,51 @@ export function compileObjectKeysOrValues(
   // by Object.defineProperty calls. shapePropFlags is initialized with defaults after
   // compilation, so it won't reflect defineProperty updates during this pass.
   const argVarName = ts.isIdentifier(arg) ? arg.text : undefined;
+
+  // (#2746) An object that received an `Object.defineProperty` ADDING a property
+  // beyond its static struct shape needs the runtime own-property set: the
+  // compile-time field expansion below can only see the literal's declared
+  // fields. Route `Object.keys` for such a receiver to the runtime
+  // `__object_keys` helper (which reads struct fields + the defineProperty/
+  // dynamic-write sidecar with the correct enumerable filter — #2746 runtime
+  // fix). Gate PRECISELY on a property that is NOT a known struct field
+  // (`definePropertyReceiverKeys` records every `varName:propName` define at a
+  // single chokepoint, independent of the lowering path): a define that only
+  // re-flags an EXISTING field is already handled by the `definedPropertyFlags`
+  // filter below, so it keeps the fast compile-time vec path and does not perturb
+  // the many currently-green define-on-existing-field tests. The `!structName`
+  // branch above proves this helper exists in both host and standalone modes.
+  const fieldNameSetForRoute = new Set(userFields.map((e) => e.field.name));
+  const hasAddedDefineProp =
+    method === "keys" &&
+    argVarName !== undefined &&
+    (() => {
+      const prefix = `${argVarName}:`;
+      for (const k of ctx.definePropertyReceiverKeys) {
+        if (!k.startsWith(prefix)) continue;
+        if (!fieldNameSetForRoute.has(k.slice(prefix.length))) return true;
+      }
+      return false;
+    })();
+  if (hasAddedDefineProp) {
+    const objType = compileExpression(ctx, fctx, arg);
+    if (!objType) return null;
+    if (objType.kind === "ref" || objType.kind === "ref_null") {
+      fctx.body.push({ op: "extern.convert_any" } as Instr);
+    } else if (objType.kind !== "externref") {
+      coerceType(ctx, fctx, objType, { kind: "externref" });
+    }
+    const funcIdx = ensureLateImport(ctx, "__object_keys", [{ kind: "externref" }], [{ kind: "externref" }]);
+    flushLateImportShifts(ctx, fctx);
+    if (funcIdx !== undefined) {
+      fctx.body.push({ op: "call", funcIdx });
+    } else {
+      fctx.body.push({ op: "drop" });
+      fctx.body.push({ op: "ref.null.extern" } as Instr);
+    }
+    return { kind: "externref" };
+  }
+
   const enumUserFields = userFields.filter((e) => {
     if (argVarName) {
       const key = `${argVarName}:${e.field.name}`;
@@ -4155,6 +4220,78 @@ export function compilePropertyIntrospection(
       fctx.body.push({ op: "call", funcIdx: hopIdx });
       return { kind: "i32", boolean: true };
     }
+  }
+
+  // (#2746) Array-exotic own index keys. An Array compiles to a `__vec_*` struct
+  // whose integer-index elements are own (enumerable) data properties — NOT
+  // static WasmGC struct fields, so the field-name logic below would wrongly
+  // answer `false` for `arr.hasOwnProperty(0)` (e.g. on the result array of
+  // `Object.keys`). Per ES §10.4.2 a canonical in-bounds index is an own
+  // property iff that slot is present (not a hole).
+  //
+  // We only intercept REFERENCE-element vecs (string/object arrays): there a hole
+  // is a distinguishable `ref.null`, so `index < length AND data[index] != null`
+  // is exact. NUMERIC-element vecs densify holes to `0`/`NaN` (indistinguishable
+  // from a real value) AND a `defineProperties` length-shrink leaves stale slots,
+  // so a bounds check there would mis-report holes/shrunk indices as own — those
+  // keep the legacy field-name path (which answers `false`) to avoid regressing
+  // the sparse/length-shrink `hasOwnProperty` tests. The result array of
+  // `Object.keys`/`getOwnPropertyNames` is an externref string vec, so the
+  // affected tests are covered. Only a statically-resolvable canonical index is
+  // handled; everything else (incl. `"length"`, dynamic keys, numeric vecs) falls
+  // through unchanged.
+  if (receiverWasm.kind === "ref" || receiverWasm.kind === "ref_null") {
+    const vecTypeIdx = (receiverWasm as { typeIdx: number }).typeIdx;
+    const vecInfo = getVecInfo(ctx, vecTypeIdx);
+    const elemIsRef =
+      vecInfo !== null &&
+      (vecInfo.elemType.kind === "externref" ||
+        vecInfo.elemType.kind === "ref" ||
+        vecInfo.elemType.kind === "ref_null" ||
+        vecInfo.elemType.kind === "anyref" ||
+        vecInfo.elemType.kind === "eqref");
+    const keyArg = expr.arguments[0];
+    let staticKey: string | null = null;
+    if (keyArg) {
+      if (ts.isStringLiteral(keyArg) || ts.isNumericLiteral(keyArg)) staticKey = keyArg.text;
+      else {
+        const at = ctx.checker.getTypeAtLocation(keyArg);
+        if (at.isStringLiteral()) staticKey = at.value;
+        else if (at.isNumberLiteral()) staticKey = String(at.value);
+      }
+    }
+    if (elemIsRef && staticKey !== null && _isCanonicalArrayIndexString(staticKey)) {
+      const dataArrTypeIdx = vecInfo!.arrTypeIdx;
+      const idxVal = Number(staticKey);
+      const recvLocal = allocLocal(fctx, `__hop_arr_${fctx.locals.length}`, receiverWasm);
+      const recv = compileExpression(ctx, fctx, propAccess.expression, receiverWasm);
+      if (recv && (recv.kind === "ref" || recv.kind === "ref_null")) {
+        fctx.body.push({ op: "ref.as_non_null" } as Instr);
+      }
+      fctx.body.push({ op: "local.set", index: recvLocal });
+      // own iff (index < length) && (data[index] !== null). The bounds test
+      // gates the element load via an `if` so an out-of-range index never traps
+      // in `array.get`.
+      fctx.body.push({ op: "local.get", index: recvLocal });
+      fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 }); // length
+      fctx.body.push({ op: "i32.const", value: idxVal });
+      fctx.body.push({ op: "i32.gt_u" }); // length > index  ⇔  index in bounds
+      fctx.body.push({
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: [
+          { op: "local.get", index: recvLocal } as Instr,
+          { op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 } as Instr, // data array
+          { op: "i32.const", value: idxVal } as Instr,
+          { op: "array.get", typeIdx: dataArrTypeIdx } as Instr, // element
+          { op: "ref.is_null" } as Instr,
+          { op: "i32.eqz" } as Instr, // present (non-null) → 1
+        ],
+        else: [{ op: "i32.const", value: 0 } as Instr],
+      } as Instr);
+      return { kind: "i32", boolean: true };
+    }
+    // else fall through to the generic struct-field path (legacy behaviour).
   }
 
   // Build a set of private member names (without '#') from the TS type.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -8566,17 +8566,24 @@ assert._isSameValue = isSameValue;
               // (#2179) Static struct fields — UNCHANGED legacy filter (drop
               // deleted keys + non-enumerable redefinitions).
               if (fieldNames) for (const k of fieldNames) if (isEnumerable(k)) result.push(k);
-              // (#2746) ADD own ENUMERABLE keys that live ONLY in the
-              // defineProperty/dynamic-write sidecar (not part of the static struct
-              // shape) — e.g. `Object.defineProperty(obj, "prop3", {enumerable:true})`
-              // on an object whose literal declared only prop1/prop2. The accessor
-              // bookkeeping keys (`__get_<p>`/`__set_<p>`) are skipped. This only
-              // ADDS keys the old path omitted; it never drops a previously-returned
-              // key, so the legacy struct-field result cannot regress.
-              if (sc) {
+              // (#2746) ADD own ENUMERABLE keys introduced via
+              // `Object.defineProperty` BEYOND the static struct shape — e.g.
+              // `Object.defineProperty(obj, "prop3", {enumerable:true})` on an
+              // object whose literal declared only prop1/prop2. Gate on a
+              // descriptor-table entry (`_wasmPropDescs`): defineProperty records
+              // one, a plain dynamic write (`obj.x = 1`) does NOT. This keeps the
+              // enumeration consistent with the for-in path (which likewise does
+              // not surface plain dynamic-write sidecar props on a struct), so we
+              // don't make `Object.keys` over-report relative to for-in (which
+              // would break tests that compare the two — e.g. keys of a `Date`
+              // with `obj.prop1 = …`). Accessor bookkeeping keys
+              // (`__get_<p>`/`__set_<p>`) are skipped. This only ADDS keys the old
+              // path omitted, so the legacy struct-field result cannot regress.
+              if (sc && descs) {
                 for (const k of Object.getOwnPropertyNames(sc)) {
                   if (k.startsWith("__get_") || k.startsWith("__set_")) continue;
                   if (result.includes(k) || (fieldNames && fieldNames.includes(k))) continue;
+                  if (!descs.has(_normalizeDescKey(k))) continue; // defineProperty'd only
                   if (isEnumerable(k)) result.push(k);
                 }
               }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -8502,19 +8502,36 @@ assert._isSameValue = isSameValue;
           if (_isWasmStruct(obj)) {
             const exports = callbackState?.getExports();
             const fieldNames = _getStructFieldNames(obj, exports);
-            if (fieldNames) {
-              const descs = _wasmPropDescs.get(obj);
-              // (#2179) Drop deleted keys — the static struct shape still carries
-              // the field, but `delete o.k` tombstoned it.
-              const tomb = _wasmStructDeletedKeys.get(obj);
-              return _orderOwnKeysSpec(
-                fieldNames.filter((k) => {
-                  if (tomb && tomb.has(k)) return false;
-                  if (!descs) return true;
-                  const flags = descs.get(k);
-                  return flags === undefined || !!(flags & _SC_ENUMERABLE);
-                }),
-              ); // (#2131)
+            const descs = _wasmPropDescs.get(obj);
+            const tomb = _wasmStructDeletedKeys.get(obj);
+            const sc = _wasmStructProps.get(obj);
+            // Enumerable iff not deleted and (no descriptor entry ⇒ enumerable by
+            // default, else the descriptor's ENUMERABLE flag).
+            const isEnumerable = (k: string): boolean => {
+              if (tomb && tomb.has(k)) return false;
+              const flags = descs?.get(_normalizeDescKey(k));
+              return flags === undefined || !!(flags & _SC_ENUMERABLE);
+            };
+            if (fieldNames || sc) {
+              const result: string[] = [];
+              // (#2179) Static struct fields — UNCHANGED legacy filter (drop
+              // deleted keys + non-enumerable redefinitions).
+              if (fieldNames) for (const k of fieldNames) if (isEnumerable(k)) result.push(k);
+              // (#2746) ADD own ENUMERABLE keys that live ONLY in the
+              // defineProperty/dynamic-write sidecar (not part of the static struct
+              // shape) — e.g. `Object.defineProperty(obj, "prop3", {enumerable:true})`
+              // on an object whose literal declared only prop1/prop2. The accessor
+              // bookkeeping keys (`__get_<p>`/`__set_<p>`) are skipped. This only
+              // ADDS keys the old path omitted; it never drops a previously-returned
+              // key, so the legacy struct-field result cannot regress.
+              if (sc) {
+                for (const k of Object.getOwnPropertyNames(sc)) {
+                  if (k.startsWith("__get_") || k.startsWith("__set_")) continue;
+                  if (result.includes(k) || (fieldNames && fieldNames.includes(k))) continue;
+                  if (isEnumerable(k)) result.push(k);
+                }
+              }
+              return _orderOwnKeysSpec(result); // (#2131)
             }
           }
           return Object.keys(obj);

--- a/tests/issue-2746.test.ts
+++ b/tests/issue-2746.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #2746 — Object.keys / Object.getOwnPropertyNames own-key listing.
+//
+// Three independent, dev-able mechanisms (see the issue file for the full
+// trace). Each case is exercised in JS-host mode AND standalone mode, since the
+// fixes are mode-agnostic.
+//
+//   M1  Array-exotic own index keys: `arr.hasOwnProperty(i)` on a string array
+//       (the result shape of Object.keys) holds for in-bounds indices and is
+//       false out of bounds. Numeric/sparse arrays keep the legacy answer.
+//   M2  Object.keys lists defineProperty-added ENUMERABLE props (and excludes
+//       non-enumerable ones).
+//   M-C Object.keys(null|undefined) throws a TypeError (ToObject, §7.1.18).
+
+async function run(source: string, opts: { standalone?: boolean } = {}): Promise<unknown> {
+  const result: any = await compile(source, { fileName: "test.ts", ...(opts.standalone ? { standalone: true } : {}) });
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e: any) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = result.importObject ?? buildImports(result.imports, {}, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as { __setExports?: (e: object) => void }).__setExports?.(instance.exports as object);
+  return (instance.exports as any).test();
+}
+
+const MODES: Array<{ name: string; standalone?: boolean }> = [
+  { name: "host" },
+  { name: "standalone", standalone: true },
+];
+
+describe("#2746 Object.keys own-key listing", () => {
+  for (const mode of MODES) {
+    describe(mode.name, () => {
+      it("M1: arr.hasOwnProperty(index) holds for in-bounds, false otherwise", async () => {
+        const src = `
+          export function test(): number {
+            const arr = ["a", "b", "c"];
+            if (!arr.hasOwnProperty(0)) return 10;
+            if (!arr.hasOwnProperty(2)) return 12;
+            if (arr.hasOwnProperty(3)) return 13;
+            if (arr.hasOwnProperty(5)) return 14;
+            return 1;
+          }`;
+        expect(await run(src, mode)).toBe(1);
+      });
+
+      it("M1: numeric sparse array hole is NOT an own property", async () => {
+        const src = `
+          export function test(): number {
+            const arr = [0, , 2];
+            // densified numeric vec — legacy 'false' answer preserved
+            return (arr.hasOwnProperty(1) as any) === true ? 20 : 1;
+          }`;
+        expect(await run(src, mode)).toBe(1);
+      });
+
+      it("M2: Object.keys lists enumerable defineProperty-added prop, drops non-enumerable", async () => {
+        const src = `
+          export function test(): number {
+            var obj = { prop1: 1001, prop2: 1002 };
+            Object.defineProperty(obj, "prop3", { value: 1003, enumerable: true, configurable: true });
+            Object.defineProperty(obj, "prop4", { get: function () { return 1003; }, enumerable: false, configurable: true });
+            var arr = Object.keys(obj);
+            return arr.length; // prop1, prop2, prop3 — prop4 excluded
+          }`;
+        expect(await run(src, mode)).toBe(3);
+      });
+
+      it("M-C: Object.keys(null) throws TypeError", async () => {
+        const src = `
+          export function test(): number {
+            try { Object.keys(null); } catch (e) { return e instanceof TypeError ? 1 : 2; }
+            return 0;
+          }`;
+        expect(await run(src, mode)).toBe(1);
+      });
+
+      it("M-C: Object.keys(undefined) throws TypeError", async () => {
+        const src = `
+          export function test(): number {
+            try { Object.keys(undefined); } catch (e) { return e instanceof TypeError ? 1 : 2; }
+            return 0;
+          }`;
+        expect(await run(src, mode)).toBe(1);
+      });
+    });
+  }
+});

--- a/tests/issue-2746.test.ts
+++ b/tests/issue-2746.test.ts
@@ -57,6 +57,37 @@ describe("#2746 Object.keys own-key listing", () => {
         expect(await run(src, mode)).toBe(1);
       });
 
+      it("M1: defineProperty-added array index is an own property (sidecar OR bounds)", async () => {
+        // Regression guard (merge_group): an empty array with a defineProperty'd
+        // index lives in the sidecar, not the vec data — the vec bounds check
+        // alone (length 0) returns false, so the OR with __hasOwnProperty is
+        // required. cf. defineProperty/15.2.3.6-4-531-6.
+        const src = `
+          export function test(): number {
+            var obj: any[] = [];
+            Object.defineProperty(obj, "0", { get: function () { return 7; }, enumerable: true, configurable: true });
+            return obj.hasOwnProperty("0") ? 1 : 0;
+          }`;
+        expect(await run(src, mode)).toBe(1);
+      });
+
+      it("M2: Object.keys does NOT over-report plain dynamic-write sidecar props (for-in parity)", async () => {
+        // Regression guard (merge_group): keys must stay consistent with for-in,
+        // which does not surface plain `obj.x = …` writes on a struct receiver —
+        // only defineProperty'd props are added. cf. keys/15.2.3.14-6-5.
+        const src = `
+          export function test(): number {
+            var obj = new Date(0);
+            (obj as any).p1 = 1;
+            (obj as any).p2 = 2;
+            var forin = 0;
+            for (var p in obj) { if (obj.hasOwnProperty(p)) forin++; }
+            var keys = Object.keys(obj).length;
+            return keys === forin ? 1 : 100 + keys * 10 + forin;
+          }`;
+        expect(await run(src, mode)).toBe(1);
+      });
+
       it("M2: Object.keys lists enumerable defineProperty-added prop, drops non-enumerable", async () => {
         const src = `
           export function test(): number {


### PR DESCRIPTION
## #2746 — Object.keys / Object.getOwnPropertyNames own-key listing

Verify-first tracing resolved the listed fails to **three distinct, dev-able mechanisms** (none are the enumeration-ORDER substrate #2706/#2739). All fixes are mode-agnostic (JS-host **and** standalone verified).

**M1 — `arr.hasOwnProperty(index)` on an Array (vec) receiver returned `false`.** `compilePropertyIntrospection` only checked static struct fields; a vec's integer-index slots are exotic. Fix: for a **reference-element** vec with a static canonical index, emit `index < length && data[index] != null` (an `if` gates the element load so an out-of-range index never traps in `array.get`). Restricted to reference-element vecs — numeric vecs densify holes to `0`/`NaN` and a `defineProperties` length-shrink leaves stale slots, so those keep the legacy `false` answer (avoiding the sparse/length-shrink `hasOwnProperty` regression class).

**M2 — `Object.keys` dropped `Object.defineProperty`-added props.** The compile-time struct expansion only sees the literal's declared fields; an added prop lives in the runtime sidecar. Fix: route `Object.keys` for a receiver with an ADDED (non-field) define to the runtime `__object_keys` helper, made a **superset** of the legacy struct-field filter so it also lists enumerable sidecar keys. Only ADDS keys → legacy struct-field result cannot regress.

**M-C — `Object.keys(null|undefined)` compiled away to `[]`** instead of the `ToObject` `TypeError`. A bare nullish-typed argument hit the empty-literal fast path. Fix: emit the `TypeError` directly for a purely-nullish argument type.

### Results
- **Fixed** (host + standalone): `keys/15.2.3.14-{1-4,1-5,4-1,5-1,5-2,3-7}`, `getOwnPropertyNames/15.2.3.4-3-1`.
- **Net +9** across `built-ins/Object/{keys,getOwnPropertyNames,values,entries,getOwnPropertyDescriptor,getOwnPropertyDescriptors}` (395→404), **zero regressions** across the entire `built-ins/Object` tree (the earlier naive-bounds M1 that broke `defineProperties/15.2.3.7-6-a-{156,161,162}` was refined away).
- `tests/issue-2746.test.ts` — 10 cases (5 × 2 modes), all green. tsc + prettier clean.

### Out of scope (substrate-gated, left for later)
function-dynamic-prop keys (`3-2`); sparse-hole listing (`5-13`, `6-2`); accessor-materialized-as-struct-field non-enum flag (`2-7`); for-in over result array (`6-1`, `5-12`); `delete array[i]` (`5-a-4`); `getOwnPropertyNames(globalThis)`; insertion-ORDER (#2706/#2739) and Proxy `ownKeys` (#1355). The issue's ≥15 target assumed those substrate cases were in reach; the clean dev-able set here is +9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)