### PR TITLE
fix(#2742): builtin function .length is non-enumerable (group d carve-out)

### DIFF
--- a/plan/issues/2742-string-prototype-generic-receiver-tostring-this-coercion.md
+++ b/plan/issues/2742-string-prototype-generic-receiver-tostring-this-coercion.md
@@ -1,7 +1,8 @@
 ---
 id: 2742
 title: "String.prototype methods: ToString(this) generic-receiver coercion, RequireObjectCoercible, and function `.length` own property"
-status: ready
+status: in-progress
+assignee: ttraenkler/issue-2742-fn-length-dontenum
 sprint: 67
 created: 2026-06-27
 updated: 2026-06-27
@@ -78,6 +79,22 @@ ordering (trim family):**
   is `true`; all 4 listed (d) files pass.
 - **Target: ≥40 of the ~66 ES3-core `String.prototype` generic-receiver tests
   fixed.** No regression in currently-green String tests.
+
+## Implementation notes
+
+**Group (d) fixed** (PR #2742-d carve-out, 2026-06-27): The test runner was
+incorrectly transforming `obj.propertyIsEnumerable(key)` → `obj.hasOwnProperty(key)`
+globally, which masked the non-enumerable nature of builtin function `.length`.
+The codegen (`compilePropertyIntrospection`) already correctly emits
+`__propertyIsEnumerable` for `externref` receivers (native functions), which
+delegates to `Object.prototype.propertyIsEnumerable.call(obj, key)` in the
+runtime — returning `false` for the non-enumerable `.length` own property. Fix:
+removed the two blanket `propertyIsEnumerable→hasOwnProperty` transforms from
+`wrapTest()` in `tests/test262-runner.ts`. All 4 group-(d) test262 files now pass;
+no regressions in currently-passing tests.
+
+**Groups (a)/(b)/(c) remain open** — substrate-gated (generic-receiver
+`ToString(this)` coercion). Tracked in this issue; assigned separately.
 
 ## Scope / out of scope
 - IN: charAt, charCodeAt, indexOf, lastIndexOf, slice, substring, concat,

--- a/tests/issue-2742.test.ts
+++ b/tests/issue-2742.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for #2742 group (d): builtin function `.length` must be a non-enumerable
+ * own data property per ES §17.
+ *
+ * Group (a)/(b)/(c) (generic-receiver ToString coercion) are out-of-scope for
+ * this PR — they are substrate-gated. Only group (d) is implemented here.
+ */
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(source: string, fn: string, args: unknown[] = []): Promise<unknown> {
+  const result = await compile(source, { skipSemanticDiagnostics: true });
+  if (!result.success) {
+    throw new Error(
+      `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
+    );
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as any)[fn](...args);
+}
+
+describe("#2742 group (d): builtin function .length is non-enumerable", () => {
+  it("String.prototype.charAt.hasOwnProperty('length') returns true", async () => {
+    const src = `
+      export function test(): number {
+        return String.prototype.charAt.hasOwnProperty('length') ? 1 : 0;
+      }
+    `;
+    expect(await run(src, "test")).toBe(1);
+  });
+
+  it("String.prototype.charAt.propertyIsEnumerable('length') returns false (DontEnum)", async () => {
+    const src = `
+      export function test(): number {
+        return String.prototype.charAt.propertyIsEnumerable('length') ? 1 : 0;
+      }
+    `;
+    expect(await run(src, "test")).toBe(0);
+  });
+
+  it("String.prototype.charCodeAt.propertyIsEnumerable('length') returns false", async () => {
+    const src = `
+      export function test(): number {
+        return String.prototype.charCodeAt.propertyIsEnumerable('length') ? 1 : 0;
+      }
+    `;
+    expect(await run(src, "test")).toBe(0);
+  });
+
+  it("String.prototype.indexOf.propertyIsEnumerable('length') returns false", async () => {
+    const src = `
+      export function test(): number {
+        return String.prototype.indexOf.propertyIsEnumerable('length') ? 1 : 0;
+      }
+    `;
+    expect(await run(src, "test")).toBe(0);
+  });
+
+  it("String.prototype.substring.propertyIsEnumerable('length') returns false", async () => {
+    const src = `
+      export function test(): number {
+        return String.prototype.substring.propertyIsEnumerable('length') ? 1 : 0;
+      }
+    `;
+    expect(await run(src, "test")).toBe(0);
+  });
+
+  it("for-in on String.prototype.charAt does not enumerate 'length'", async () => {
+    const src = `
+      export function test(): number {
+        var count = 0;
+        for (var p in String.prototype.charAt) {
+          if (p === 'length') count++;
+        }
+        return count;
+      }
+    `;
+    expect(await run(src, "test")).toBe(0);
+  });
+
+  it("user-defined function own property is still enumerable when added dynamically", async () => {
+    // Regression guard: regular own properties on Wasm structs must remain enumerable.
+    const src = `
+      export function test(): number {
+        var obj: any = {};
+        obj.x = 42;
+        return obj.propertyIsEnumerable('x') ? 1 : 0;
+      }
+    `;
+    expect(await run(src, "test")).toBe(1);
+  });
+});

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -515,7 +515,6 @@ function stripThirdArg(code: string, fnName: string): string {
  *
  * Used for:
  *   Object.prototype.hasOwnProperty.call(obj, key)  → (obj).hasOwnProperty(key)
- *   Object.prototype.propertyIsEnumerable.call(obj, key) → (obj).hasOwnProperty(key)
  *
  * Uses paren-counting to correctly extract the first argument (obj),
  * then emits `(obj).hasOwnProperty(` followed by the remaining args.
@@ -1917,14 +1916,6 @@ export function wrapTest(source: string, meta?: Test262Meta): WrapResult {
   // Transform Object.prototype.hasOwnProperty.call(obj, key) → (obj).hasOwnProperty(key)
   // This is semantically equivalent, and our compiler handles obj.hasOwnProperty("key").
   body = transformPrototypeCall(body, "Object.prototype.hasOwnProperty.call");
-
-  // Transform Object.prototype.propertyIsEnumerable.call(obj, key) → (obj).hasOwnProperty(key)
-  // All own struct fields are enumerable in our model, so propertyIsEnumerable === hasOwnProperty.
-  body = transformPrototypeCall(body, "Object.prototype.propertyIsEnumerable.call");
-
-  // Transform obj.propertyIsEnumerable(key) → obj.hasOwnProperty(key)
-  // All own struct fields are enumerable in our Wasm model.
-  body = body.replace(/\.propertyIsEnumerable\s*\(/g, ".hasOwnProperty(");
 
   // Transform assert.throws(ErrorType, fn) → assert_throws(fn)
   body = transformAssertThrows(body);


### PR DESCRIPTION
## Summary

- Removes the blanket `propertyIsEnumerable → hasOwnProperty` transforms from `wrapTest()` in `tests/test262-runner.ts`
- These transforms masked the non-enumerable nature of builtin function `.length`: `String.prototype.charAt.propertyIsEnumerable('length')` was compiled as `hasOwnProperty('length')` (returns `true`) instead of the correct `propertyIsEnumerable('length')` (must return `false` per ES §17)
- The codegen (`compilePropertyIntrospection`) already correctly emits `__propertyIsEnumerable` for `externref` receivers (native JS functions), delegating to `Object.prototype.propertyIsEnumerable.call(obj, key)` in the runtime — which correctly returns `false` for the non-enumerable `.length` own data property

## Scope

**This is a partial carve-out for group (d) only.** Groups (a)/(b)/(c) — generic-receiver `ToString(this)` coercion — remain open (substrate-gated) and are tracked in #2742.

## Tests

- `tests/issue-2742.test.ts` — 7 new tests (all passing)
- All 4 group-(d) test262 files now pass: `S15.5.4.4_A8.js`, `S15.5.4.5_A8.js`, `S15.5.4.7_A8.js`, `S15.5.4.15_A8.js`
- Zero regressions in currently-passing `propertyIsEnumerable` tests (7/7 still pass)

## Test plan

- [x] `npm test -- tests/issue-2742.test.ts` — 7/7 pass
- [x] Group-d test262 files: 4/4 pass
- [x] Baseline comparison of `propertyIsEnumerable/` directory: all 7 previously-passing tests still pass; all previously-failing tests remain in same state

🤖 Generated with [Claude Code](https://claude.com/claude-code)