### PR TITLE
chore(sprint): activate sprint 68 slate — 36 issues → sprint: current + add 68.md

### DIFF
--- a/plan/issues/1042-async-await-state-machine-lowering.md
+++ b/plan/issues/1042-async-await-state-machine-lowering.md
@@ -8,7 +8,7 @@ priority: high
 feasibility: hard
 reasoning_effort: max
 goal: async-model
-sprint: 67
+sprint: current
 parent: 1032
 depends_on: [680]
 required_by: [1058, 1766, 1774]

--- a/plan/issues/1712-acorn-acceptance-differential-ast.md
+++ b/plan/issues/1712-acorn-acceptance-differential-ast.md
@@ -11,7 +11,7 @@ task_type: test
 area: test-infrastructure, codegen
 language_feature: multi
 goal: self-hosting-dogfood
-sprint: 67
+sprint: current
 model: opus
 depends_on: [1710, 1711]
 es_edition: multi

--- a/plan/issues/1916-symbolic-function-references-codegen.md
+++ b/plan/issues/1916-symbolic-function-references-codegen.md
@@ -4,7 +4,7 @@ title: "Symbolic function references in WasmGC codegen — retire the late-impor
 status: blocked
 blocked_by: [2167]
 pipeline_unblocked: 1927
-sprint: 67
+sprint: current
 model: fable
 created: 2026-06-10
 updated: 2026-06-24

--- a/plan/issues/1917-single-coercion-engine.md
+++ b/plan/issues/1917-single-coercion-engine.md
@@ -3,7 +3,7 @@ id: 1917
 title: "One coercion engine — four divergent coercion matrices disagree about lossiness"
 status: in-progress
 assignee: ttraenkler/sendev-eq
-sprint: 67
+sprint: current
 model: opus
 created: 2026-06-10
 updated: 2026-06-24

--- a/plan/issues/1930-typeoracle-type-query-boundary.md
+++ b/plan/issues/1930-typeoracle-type-query-boundary.md
@@ -3,7 +3,7 @@ id: 1930
 title: "TypeOracle — one type-query boundary between the TS checker and codegen (unblocks TS7, kills suppression heuristics)"
 status: blocked
 blocked_by: [2167]
-sprint: 67
+sprint: current
 model: fable
 created: 2026-06-10
 updated: 2026-06-24

--- a/plan/issues/1985-stale-proof-index-cells.md
+++ b/plan/issues/1985-stale-proof-index-cells.md
@@ -3,7 +3,7 @@ id: 1985
 title: "stale-proof index cells: shift-walker-updated { idx } handles for captured func indices (#2043 Option 2b, incremental)"
 status: blocked
 blocked_by: [2167]
-sprint: 67
+sprint: current
 created: 2026-06-10
 updated: 2026-06-24
 priority: medium

--- a/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
+++ b/plan/issues/2029-standalone-u32-out-of-range-binary-emit.md
@@ -2,7 +2,7 @@
 id: 2029
 title: "standalone: `Binary emit error: u32 out of range: -1` on builtin subclassing, disposal protocol, Object.create, Iterator.prototype (497 tests)"
 status: in-progress
-sprint: 67
+sprint: current
 created: 2026-06-10
 updated: 2026-06-25
 priority: critical

--- a/plan/issues/2044-bigint-i64-brand-valtype-decision.md
+++ b/plan/issues/2044-bigint-i64-brand-valtype-decision.md
@@ -3,7 +3,7 @@ id: 2044
 title: "architect decision: BigInt value representation — i64-bigint-brand ValType vs TS-type-driven boxing (gates #1644 slices, implicated in #2039 i64 ABI bucket)"
 status: blocked
 blocked_by: [2167]
-sprint: 67
+sprint: current
 created: 2026-06-10
 updated: 2026-06-24
 priority: high

--- a/plan/issues/2106-valuerep-p3-undefined-observability.md
+++ b/plan/issues/2106-valuerep-p3-undefined-observability.md
@@ -3,7 +3,7 @@ id: 2106
 title: "value-rep P3: undefined observability — UNDEF_F64 sentinel, union-collapse reversal (flagged), standalone $undefined singleton"
 status: in-progress
 assignee: ttraenkler/sdev-s1fix
-sprint: 67
+sprint: current
 created: 2026-06-11
 updated: 2026-06-26
 s1_note: "S1 (standalone tag-1 $undefined singleton) NOT COMPLETE — PR #2025 was AUTO-PARKED in merge_group (2026-06-24): standalone high-water floor breached (pass 23729 vs mark 24956), NET −1245 test262 rows (1654 regressed / 409 gained). Root cause (diagnosed by sdev-s1fix 2026-06-25, see '## S1 merge_group regression — diagnosis'): S1.1 flipped the CONSUMER __extern_is_undefined to singleton-only but did NOT flip the matching PRODUCERS (notably __extern_get's missing-key return at object-runtime.ts:856, still ref.null.extern), so destructuring/param defaults stop firing. This is the architect-spec's full ~40-site producer+consumer sweep done as a partial subset — there is NO narrow floor-saving fix. RESOLUTION 2026-06-25: S1.1+S1.2 behavioral flips REVERTED on the branch (kept inert S1.0); PR #2025 re-targets to a floor-neutral revert. S1 to be re-landed as a fully-scoped complete sweep (architect re-spec). REMAINING slices unchanged: S2 (sNaN carve-out), S3 (number|undefined→externref), S4 (union-collapse reversal), typeof-null→object."

--- a/plan/issues/2134-ir-effect-model-ordered-emission.md
+++ b/plan/issues/2134-ir-effect-model-ordered-emission.md
@@ -3,7 +3,7 @@ id: 2134
 title: "IR effect model: classify instruction kinds, enforce program-order emission for effectful ops"
 status: blocked
 blocked_by: [2167]
-sprint: 67
+sprint: current
 created: 2026-06-12
 updated: 2026-06-24
 priority: high

--- a/plan/issues/2138-ir-first-compile-once-inversion.md
+++ b/plan/issues/2138-ir-first-compile-once-inversion.md
@@ -5,7 +5,7 @@ status: blocked
 blocked_by: [2167]
 pipeline_unblocked: 1927
 spec: ready
-sprint: 67
+sprint: current
 created: 2026-06-12
 updated: 2026-06-24
 priority: high

--- a/plan/issues/2161-standalone-regexp-engine-residual.md
+++ b/plan/issues/2161-standalone-regexp-engine-residual.md
@@ -3,7 +3,7 @@ id: 2161
 title: "Standalone RegExp engine conformance residual (~579 tests)"
 status: blocked
 assignee: ttraenkler/sd1
-sprint: 67
+sprint: current
 created: 2026-06-15
 updated: 2026-06-25
 blocked_on: [2175]

--- a/plan/issues/2167-fable-model-disabled-blocks-frontier-work.md
+++ b/plan/issues/2167-fable-model-disabled-blocks-frontier-work.md
@@ -2,7 +2,7 @@
 id: 2167
 title: "Fable model disabled — frontier-reasoning work blocked"
 status: blocked
-sprint: 67
+sprint: current
 created: 2026-06-15
 updated: 2026-06-24
 priority: high

--- a/plan/issues/2173-standalone-generator-general-iterable-yield-star.md
+++ b/plan/issues/2173-standalone-generator-general-iterable-yield-star.md
@@ -3,7 +3,7 @@ id: 2173
 title: "standalone: yield* over a general iterable (array / custom {next()}) in native generators (SF-3 slice-2 of #2157)"
 status: blocked
 blocked_by: [2106]
-sprint: 67
+sprint: current
 created: 2026-06-16
 updated: 2026-06-24
 priority: medium

--- a/plan/issues/2175-standalone-builtin-prototype-readers.md
+++ b/plan/issues/2175-standalone-builtin-prototype-readers.md
@@ -3,7 +3,7 @@ id: 2175
 title: "architect spec: standalone builtin-prototype object representation + native-method-closure dispatch"
 status: in-progress
 assignee: ttraenkler/se-2175
-sprint: 67
+sprint: current
 created: 2026-06-16
 updated: 2026-06-24
 priority: high

--- a/plan/issues/2181-define-builtin-representation-scaffold.md
+++ b/plan/issues/2181-define-builtin-representation-scaffold.md
@@ -2,7 +2,7 @@
 id: 2181
 title: "defineBuiltin(name, {elementKinds, lower}) scaffold — unify per-representation element-load/ToString/null handling"
 status: ready
-sprint: 67
+sprint: current
 created: 2026-06-16
 updated: 2026-06-24
 priority: medium

--- a/plan/issues/2580-dynamic-receiver-length-undefined-substrate.md
+++ b/plan/issues/2580-dynamic-receiver-length-undefined-substrate.md
@@ -3,7 +3,7 @@ id: 2580
 title: "`.length` on an any/dynamically-mutated receiver returns numeric 0, not undefined (runtime property-presence)"
 status: in-progress
 assignee: ttraenkler/sd-2580
-sprint: 67
+sprint: current
 created: 2026-06-21
 priority: medium
 feasibility: hard

--- a/plan/issues/2585-proto-identity-object-create.md
+++ b/plan/issues/2585-proto-identity-object-create.md
@@ -2,7 +2,7 @@
 id: 2585
 title: "standalone: getPrototypeOf(Object.create(p)) === p is false — object identity lost in __any_strict_eq tag-5 arm"
 status: blocked
-sprint: 67
+sprint: current
 created: 2026-06-21
 updated: 2026-06-24
 priority: high

--- a/plan/issues/2613-await-thenable-assimilation-and-nonpromise.md
+++ b/plan/issues/2613-await-thenable-assimilation-and-nonpromise.md
@@ -10,7 +10,7 @@ task_type: bug
 area: async, codegen
 language_feature: async
 goal: async-model
-sprint: 67
+sprint: current
 parent: 1042
 depends_on: 1373b
 assignee: ttraenkler/async-2612-2613

--- a/plan/issues/2614-promise-combinator-constructor-resolve-element-callable.md
+++ b/plan/issues/2614-promise-combinator-constructor-resolve-element-callable.md
@@ -11,7 +11,7 @@ task_type: bug
 area: async, codegen, promise
 language_feature: promise
 goal: async-model
-sprint: 67
+sprint: current
 parent: 1042
 related: [1528, 1368, 1116, 1694]
 blocked_on: [2623]

--- a/plan/issues/2618-proxy-host-apply-construct-call-path.md
+++ b/plan/issues/2618-proxy-host-apply-construct-call-path.md
@@ -3,7 +3,7 @@ id: 2618
 title: "Proxy (host): calling / constructing a Proxy whose target is callable traps (illegal cast) or ignores the construct trap result (~15 fails)"
 status: blocked
 assignee: ttraenkler/sd-2618
-sprint: 67
+sprint: current
 created: 2026-06-22
 updated: 2026-06-24
 reconcile_status_note: "2026-06-24 (PO reconcile vs upstream/main): Slice 1 LANDED (PR #1984, commit 1cc09f72f — pure-runtime START-timing + callable-target wrap, +1 gc row). REMAINING work (externref-callee p.call(a,b) CALL dispatch + dynamic-new construct-result routing) is gated on the deep #56 dispatch substrate (blocked_on:[56] already set). NOT dev-claimable until #56 lands. → blocked (was in-progress)."

--- a/plan/issues/2623-promise-capability-cluster-multihop-callback-cast.md
+++ b/plan/issues/2623-promise-capability-cluster-multihop-callback-cast.md
@@ -11,7 +11,7 @@ task_type: feature
 area: codegen, promise, async, capability-bridge
 language_feature: promise, async, proxy
 goal: async-model
-sprint: Backlog
+sprint: current
 parent: 1528
 related: [2614, 2618, 1373b, 1042, 86, 56]
 note: "Spun off from #86 (class-ctor arm, merged) + #55 async-bucket scope (PR #1947). The #56/#1940 closure-construct bridge + #86 executor-call host-routing landed the SURFACE of the capability lane; this issue is the DEEPER shared substrate behind three clusters that the surface fixes did NOT close."

--- a/plan/issues/2626-tag5-boxed-value-equality-classifier-substrate.md
+++ b/plan/issues/2626-tag5-boxed-value-equality-classifier-substrate.md
@@ -3,7 +3,7 @@ id: 2626
 title: "tag-5 boxed-VALUE equality classifier (numeric #2040 f64.eq + object #2585 ref.eq) — value-rep substrate (deferred from #1888)"
 status: backlog
 assignee: ""
-sprint: Backlog
+sprint: current
 created: 2026-06-22
 priority: medium
 feasibility: hard

--- a/plan/issues/2651-builtin-constructor-prototype-as-value-substrate.md
+++ b/plan/issues/2651-builtin-constructor-prototype-as-value-substrate.md
@@ -6,7 +6,7 @@ blocked_on: 2580
 assignee: ttraenkler/sd-2651
 slices_done: "D2/M1 (PR #2043, commit 7374c34c6)"
 slices_remaining: "M3 (%TypedArray% intrinsic value-dispatch) — predecessor-stack on #2580 M3"
-sprint: 67
+sprint: current
 created: 2026-06-24
 priority: high
 feasibility: hard

--- a/plan/issues/2660-fnctor-instance-dynamic-use-escape-gate.md
+++ b/plan/issues/2660-fnctor-instance-dynamic-use-escape-gate.md
@@ -3,7 +3,7 @@ id: 2660
 title: "Whole-program escape/dynamic-use gate for reconstructing `new F()` instances as `$Object` (value-rep infra)"
 status: in-progress
 assignee: ttraenkler/sd-2674b
-sprint: 67
+sprint: current
 created: 2026-06-25
 priority: medium
 feasibility: hard

--- a/plan/issues/2669-es6-destructuring-correctness-residual-umbrella.md
+++ b/plan/issues/2669-es6-destructuring-correctness-residual-umbrella.md
@@ -13,7 +13,7 @@ es_edition: 2015
 language_feature: destructuring
 goal: spec-completeness
 related: [1642, 2566, 1556, 1454, 2203, 2032, 796]
-sprint: 67
+sprint: current
 ---
 # #2669 — ES2015 destructuring correctness residual umbrella
 

--- a/plan/issues/2671-es6-builtin-spec-residuals-date-regexp-promise-json-super.md
+++ b/plan/issues/2671-es6-builtin-spec-residuals-date-regexp-promise-json-super.md
@@ -13,7 +13,7 @@ es_edition: 2015
 language_feature: builtins, regexp, promise, date, json, super
 goal: spec-completeness
 related: [1343, 1440, 1444, 1439, 1465, 1368, 1551, 1342]
-sprint: 67
+sprint: current
 ---
 # #2671 — ES2015 builtin/feature spec residuals (Date / RegExp / Promise / JSON / super)
 

--- a/plan/issues/2674-acorn-parse-9th-wall-past-tokenizer.md
+++ b/plan/issues/2674-acorn-parse-9th-wall-past-tokenizer.md
@@ -3,7 +3,7 @@ id: 2674
 title: "acorn parse() 9th wall PAST tokenization (after #2664 type-write fix) — parseTopLevel/parseStatement array-push loop"
 status: in-progress
 assignee: ttraenkler/sd-2674c
-sprint: 67
+sprint: current
 created: 2026-06-25
 updated: 2026-06-25
 priority: high

--- a/plan/issues/2681-acorn-parse-10th-wall-unexpected-on-name.md
+++ b/plan/issues/2681-acorn-parse-10th-wall-unexpected-on-name.md
@@ -3,7 +3,7 @@ id: 2681
 title: "acorn parse() 10th wall — identifier expression-statement throws (unexpected() on a `name` token) after the #2664 arity-dispatch fix"
 status: ready
 assignee: ttraenkler/unassigned
-sprint: 67
+sprint: current
 created: 2026-06-26
 updated: 2026-06-26
 priority: high

--- a/plan/issues/2686-acorn-binary-expression-throws.md
+++ b/plan/issues/2686-acorn-binary-expression-throws.md
@@ -3,7 +3,7 @@ id: 2686
 title: "acorn parse() — binary-expression statement throws (parse(\"1 + 2 * 3;\") → WebAssembly.Exception)"
 status: ready
 assignee: ttraenkler/unassigned
-sprint: 67
+sprint: current
 created: 2026-06-26
 updated: 2026-06-26
 priority: medium

--- a/plan/issues/2694-acorn-scope-flags-loop.md
+++ b/plan/issues/2694-acorn-scope-flags-loop.md
@@ -3,7 +3,7 @@ id: 2694
 title: "acorn parse() 11th wall — Scope.flags read loop (local-receiver slot/sidecar asymmetry, needs #2660)"
 status: blocked
 assignee: ttraenkler/unassigned
-sprint: 67
+sprint: current
 created: 2026-06-26
 updated: 2026-06-26
 priority: medium

--- a/plan/issues/2710-late-bind-module-indices-eliminate-index-shift-class.md
+++ b/plan/issues/2710-late-bind-module-indices-eliminate-index-shift-class.md
@@ -3,7 +3,7 @@ id: 2710
 title: "Late-bind module indices (func/global/type) to eliminate the late-index-shift bug class"
 status: in-progress
 assignee: ttraenkler/sd-indexshift
-sprint: 67
+sprint: current
 created: 2026-06-26
 updated: 2026-06-26
 priority: high

--- a/plan/issues/2712-real-bool-valtype-retire-i32-boolean-brand.md
+++ b/plan/issues/2712-real-bool-valtype-retire-i32-boolean-brand.md
@@ -3,7 +3,7 @@ id: 2712
 title: "Introduce a real bool ValType; retire the optional i32 boolean brand"
 status: blocked
 blocked_on: "architect ValType-registration decision — the boolean analog of #2044's BigInt i64-brand decision (see Senior dev note + Architect hand-off below)"
-sprint: 67
+sprint: current
 created: 2026-06-26
 updated: 2026-06-27
 priority: high

--- a/plan/issues/2726-delete-residual-sloppy-return-hasownproperty-accessor-mapped.md
+++ b/plan/issues/2726-delete-residual-sloppy-return-hasownproperty-accessor-mapped.md
@@ -2,7 +2,7 @@
 id: 2726
 title: "delete residual: sloppy return-value semantics, hasOwnProperty-after-delete, accessor descriptor configurability, mapped-arguments delete"
 status: ready
-sprint: 67
+sprint: current
 goal: test262-conformance
 feasibility: medium
 depends_on: []

--- a/plan/issues/2732-operator-toprimitive-strict-equals-boxed-wrapper-traps.md
+++ b/plan/issues/2732-operator-toprimitive-strict-equals-boxed-wrapper-traps.md
@@ -2,7 +2,7 @@
 id: 2732
 title: "operators: unary +/-/~/>>> ToPrimitive(object) trap; strict-equals boxed-wrapper/funcref trap"
 status: blocked
-sprint: 67
+sprint: current
 goal: test262-conformance
 feasibility: hard
 depends_on: [2712]

--- a/plan/issues/742-extract-and-refactor-compilecallexpression-3.md
+++ b/plan/issues/742-extract-and-refactor-compilecallexpression-3.md
@@ -8,7 +8,7 @@ updated: 2026-06-24
 priority: medium
 feasibility: medium
 goal: maintainability
-sprint: 67
+sprint: current
 depends_on: [688]
 files:
   src/codegen/expressions.ts:

--- a/plan/issues/sprints/68.md
+++ b/plan/issues/sprints/68.md
@@ -1,0 +1,203 @@
+---
+sprint: 68
+status: planned
+planned: 2026-06-27
+---
+# Sprint 68 (DRAFT) — value-rep linchpin + acorn unblock, standalone prototype scaffold, IR-retirement safe wins
+
+> **Forward-planned 2026-06-27 while [sprint 67](67.md) is still ACTIVE.** This is
+> a candidate slate, not an activated sprint — no issue frontmatter is reassigned
+> to `sprint: 68` yet. Activation (carry-over reassignment, tagging, queue
+> populate) happens when s67 closes. Baseline at planning time:
+> **32,403 / 43,135 (75.0%)**.
+>
+> Planning inputs: PO agent (standalone+conformance slate validation + fresh
+> failure-pool mining) and architect agent (spine + maintainability + acorn wall
+> sequencing). Both validated every claim against `origin/main @ 2e4d57a`.
+
+## Theme
+
+Three threads chosen by the stakeholder, in dependency order:
+
+1. **Architecture spine + acorn dogfood** — converge on ONE linchpin: land
+   **#2660 PART-2** (the pinned value-rep dispatch). It is simultaneously the
+   value-rep spine's #1 lever and the acorn keystone; landing it flips the
+   `receiverStruct` map ON and unblocks the entire acorn wall chain.
+2. **Standalone** — dispatch devs against the **#2175** builtin-prototype scaffold
+   (gates ~2,800 standalone tests), plus self-contained standalone slices.
+3. **Maintainability / IR retirement** — bank the byte-identical safe wins
+   (#2710 slices, #742) and ratify the first-class-ValType lane (#2712 + #2044).
+
+A parallel **conformance quick-win** lane keeps every dev productive while the
+keystone/spine work proceeds (host-mode, dev-claimable, no substrate gating).
+
+---
+
+## 🔑 The linchpin — #2660 PART-2 (do this FIRST)
+
+**#2660 PART-2** — the unified PINNED read+write+compound dispatch — is **built
+and mechanism-validated** (compiled-acorn `__host_eq` 30k → 163), but its WIP is
+**NOT on origin**: it lives on the **fork** `ttraenkler/js2` branch
+`issue-2681-acorn-lifted-method-this` @ `86cd76321` (per #2660 log line 646).
+PART-1 (inert receiver-resolution flow map) is already on main.
+
+- **Type**: senior-dev LANDING task, **NOT** an architect spec (the design is
+  done). Single #2660 owner, `reasoning_effort: max`, validate through the
+  `merge_group` standalone floor (#2097), stop-the-line on any typed-fnctor eject.
+- **Recover** the WIP from the fork branch; re-base on current `origin/main`.
+- **Land with the 3 already-diagnosed regression fixes (do NOT re-derive)**:
+  - **#2179** — delete-tombstone gate: `resolveReceiverStruct` returns `undefined`
+    for delete-target fields.
+  - **#2656** — scope the pin to genuine lifted-method externref `this`.
+  - **#2659** — sidecar-only `fieldIdx === -1` fall-through.
+- Then flip the `receiverStruct` map **ON** (P2).
+
+**What this single landing unblocks**: #2681 (10th wall, read-half already
+validated), #2687 (ExpressionStatement.null), #2694 (Scope.flags loop), #2686
+(binary-expr) — i.e. the whole acorn wall chain — plus #2651 (TypedArray ctor
+value-dispatch, `blocked_on: 2580`) and it closes the #2580 M3 framing.
+
+---
+
+## Slate
+
+### Thread 1 — Architecture spine + acorn dogfood
+
+| ID | Title | Type | Status entering s68 | Notes |
+|----|-------|------|---------------------|-------|
+| **#2660** | value-rep PART-2 pinned dispatch (the linchpin) | senior-dev land | in-progress (WIP on fork) | **#1 priority.** Recover `86cd76321`, land + #2179/#2656/#2659, flip map ON. |
+| #2681 | acorn 10th wall — identifier `unexpected()` | dev (spine-gated) | ready* | Closes when PART-2 map flips ON. |
+| #2687 | acorn ExpressionStatement.expression null | dev (spine-gated) | ready* (mislabeled — `depends_on: 2660`) | Closes with PART-2. **Fix frontmatter.** |
+| #2694 | acorn 11th wall — Scope.flags loop | dev (spine-gated) | blocked → unblocks w/ PART-2 | Closes with PART-2. |
+| #2686 | acorn binary-expr statement throws | dev (spine-gated) | ready* (mislabeled — `depends_on: 2660`) | P3 after PART-2. **Fix frontmatter.** |
+| #1712 | acorn acceptance differential-AST gate | acceptance | in-progress | Run after walls clear; note a separate `wordsRegexp` null-receiver wall in the tail (orthogonal to #2660). |
+| #1917 | one coercion engine (close out residual matrices) | dev | in-progress | Core series landed; close the residual. |
+
+\* "ready" frontmatter is misleading for the acorn walls — they are spine-gated on #2660 PART-2.
+
+### Thread 2 — Standalone
+
+| ID | Title | Type | Status | Notes |
+|----|-------|------|--------|-------|
+| **#2175** | standalone builtin-prototype object representation + native-method-closure dispatch | architect spec → **dispatch** | in-progress (`max`) | **Highest standalone leverage.** If the spec deliverable is on-branch, dispatch devs immediately — unblocks #2161 (~126 RegExp.prototype), #2158 (~1,388 class desc), #2159 (~1,308 TA reflection). If not complete, escalate to architect. |
+| #2161 | standalone RegExp residual (prototype-reflection bucket ~126) | dev (gated) | blocked-on-#2175 | Activatable once #2175 lands. |
+| #2029 | primitive-wrapper subclass invalid Wasm (~12) | dev | in-progress | Headline `-1` crash already fixed; remaining sub-slice = `Number/Boolean/String` subclass param-type mismatch (`BUILTIN_PARENTS_HOST_CONSTRUCTIBLE` in class-bodies.ts). Reassess scope on merge. |
+| **NEW-a** | standalone String.prototype null-deref on non-string `this` (~47) | dev | propose | `__str_flatten` null-derefs instead of TypeError; add ThisStringValue guard in string-ops.ts. |
+| **NEW-b** | standalone `Object.getOwnPropertyDescriptor(Builtin, method)` refused (~79) | dev | propose | `__get_builtin` standalone refusal; needs a builtin static-method descriptor table. Verify non-overlap with #2175 before dispatch. |
+
+### Thread 3 — Maintainability / IR retirement
+
+| ID | Title | Type | Status | Notes |
+|----|-------|------|--------|-------|
+| **#2710** | late-bind module indices — Slices 2→3→4 | senior-dev | in-progress (Slices 0–1 landed) | **Top maintainability win.** Byte-identical per slice (prove-emit-identity oracle). Kills the #1 bug factory (index-shift). **Subsumes #1916 + #1985 — close both as superseded.** |
+| #742 | extract compileCallExpression (3,350 lines) | dev | in-progress | Continue incremental, WAT-hash-oracle behaviour-preserving. Reliable banked win. |
+| **#2712** | real bool ValType; retire optional i32 boolean brand | dev/senior | ready | Co-design with #2044 as ONE first-class-ValType lane (same anti-pattern: optionality → correctness depends on memory not types). |
+| #2138 | IR-first compile-once inversion — Slice 1 (hoist IR planning above `compileDeclarations`) | dev | blocked-on-#2167 | **Conditional**: only if the lead lifts the #2167 Fable gate for this byte-identical reorder. Highest-leverage IR-*retirement* step; acceptance = `check:ir-fallbacks` zero-delta + corpus byte-diff. The lane's real entry point is #2138 (spec-ready), NOT #2134 (needs design first). |
+
+### Thread 4 — Conformance quick-wins (host-mode, parallel filler, no substrate gating)
+
+| ID | Title | Type | Impact | Feasibility |
+|----|-------|------|--------|-------------|
+| #2671 | ES2015 builtin residuals — remaining Date / super / Promise slices | dev | ~180 | medium (3 independent slices, root-caused in issue) |
+| **NEW-c** | `SetFunctionName` overwrites `class.name` when class has own static `name` (§7.2.11 step 3) | dev | ~134 | medium (one `hasOwnProperty('name')` check in class-bodies.ts) |
+| **NEW-d** | `Set.prototype` set-like methods: GetSetRecord misses `ToNumber(size)` + `has`/`keys` callability (§24.2.1.2) | dev | ~47 | easy (runtime.ts only, no codegen) |
+| **NEW-e** | computed getter/setter key fails to emit `__make_getter_callback` import | dev | ~22 | medium (add `ensureLateImport` on the computed-accessor path) |
+| #2726 | delete residual — merge done (c)+(d) slice; split (a)/(b) | dev + arch | (c)+(d) done | (c)+(d) +6 done, needs merge PR; (a)/(b) = global-object model + unresolvable-id oracle → architect. |
+
+---
+
+## Architect specs to commission BEFORE/EARLY in s68 (the "route to architect first" gate)
+
+Ranked by downstream unblock. These are **design-first** — partial implementation
+has already proven destructive (cite the regressions below).
+
+1. **#2106 S1 — exhaustive `$undefined` singleton producer/consumer site map.**
+   Must enumerate the full ~40-site atomic sweep flipped in ONE PR. Proof it
+   can't be piecemeal: the partial S1.1/S1.2 sweep ejected the merge_group floor
+   by **−1,245** (`__extern_get`'s missing-key return at object-runtime.ts:856 has
+   111 callers and doubles as the `__extern_has` absence signal + proto-walk
+   terminator — must flip in lockstep). Unblocks #2173, standalone nullish
+   observability, core-semantics.
+2. **Async synchronous-consumption contract** (umbrella #1373b/#1042; unblocks
+   #2613 ~15 + #2614 ~45). `ASYNC_CPS_ENABLED = true` already — async lowers
+   through CPS. The wall is undesigned, not a point-fix: decide option-a (CPS
+   settles in-tick-resolvable awaits synchronously) vs option-b (test262 runner
+   drains the host microtask queue before reading `ret`). Larger-than-one-sprint
+   epic — commission the spec in s68, dispatch dev work later.
+3. **BigInt #2044 representation decision.** Makeable NOW — the "gates #1644"
+   premise is **stale** (#1644 landed, PR #1249). **Architect recommendation: a
+   first-class `{kind:"bigint"}` ValType** (not an optional `i64` brand, not
+   call-site boxing) — forces exhaustive dispatch by construction, same shape as
+   #2712's bool ValType; co-design the two as one lane. Deliverable = the
+   `## Implementation Plan` + consultation-site list + re-sized slices.
+
+**NEW-f (architect-first, banks for s69): closure-box eager materialization.**
+The #2669 verify-first found this is the DOMINANT root cause across ~1,000+ host
+failures (dstr/class/generator/for-await-of): the mutable-capture ref-cell
+`struct.new` is emitted at the first call-site (calls.ts ~L12359), so a not-taken
+conditional branch never allocates the box → reads return null → NaN. Fix shape =
+"emit box at nested-function-declaration point," but prior attempts caused 100+
+regressions (#1177 Stage 1, PR #166 net-25) — **mandatory architect spec first**,
+allocate a new id, implement in s69.
+
+---
+
+## Housekeeping (tracking hygiene — apply at s68 activation, or now as a small PR)
+
+- **Close #2674** — resolved-by-#2085; still marked in-progress (stale).
+- **Re-point #2618** `blocked_on: 56 → 2623` — #56 (tuples) is done; the operative
+  blocker is the #2623 inbound arg-marshalling keystone (in-progress). #2623 also
+  gates #2614 — escalate to a fresh spec only if it stalls.
+- **Fix #2686 / #2687 frontmatter** — both say `ready` but carry `depends_on: 2660`
+  (spine-gated, not independently claimable).
+- **Close #1916 + #1985** as superseded by #2710 (same index-shift bug class,
+  Opus-landable vs the old Fable-gated framing).
+
+---
+
+## Deferred / still genuinely blocked (NOT in s68)
+
+- **#2585** (proto identity) — folded into #2626, behind #2580 M3/M4; `ref.eq` arm
+  ejected −162 on the floor. No slice until #2626.
+- **#2173** (yield* general iterable) — blocked on #2106 S1.
+- **#2106 S1.1/S1.2 implementation** — blocked on the architect re-spec above.
+- **#2134** (IR effect model) — needs design before dispatch; not the lane entry.
+- **#2167** (Fable model disabled) — external/infra gate over the IR lane + #1930.
+- **#2181** (defineBuiltin scaffold) — demote to backlog (no impl, senior-dev
+  hard, zero direct test262 count; activate when a concrete cross-lane regression
+  motivates it).
+- **#2732** (operator ToPrimitive/strict-eq traps) — now `blocked`, `depends_on:
+  2712` + substrate. Re-surface when the bool-ValType decision lands.
+- **#1930** (TypeOracle) — keystone needs an architect spec; sprint-64+ scale. A
+  thin 3–4-query facade slice is possible but defer behind the Fable gate.
+
+---
+
+## Sequencing notes
+
+- **Critical path**: #2660 PART-2 (linchpin) → acorn walls cascade (#2681 →
+  #2687/#2694 → #2686) → #1712 differential. Run the spine landing FIRST.
+- **#2175** is the parallel standalone keystone — independent of #2660; dispatch
+  as soon as its spec deliverable is confirmed on-branch.
+- **Keep devs busy**: Thread 4 (quick-wins) + #2029 sub-slice + #2671 slices are
+  all dev-claimable on day 1, no gating. Don't let devs idle while the keystones
+  land.
+- **First-class-ValType lane**: land #2712 (bool) and ratify #2044 (bigint)
+  together — one mechanism, two brands.
+- All broad-impact validation through the `merge_group` standalone floor (#2097) +
+  the per-process sharded runner — never in-process loops. One-shot enqueue,
+  never re-enqueue.
+- **Spec-first WITH trace-first**: for spine/substrate work, the architect
+  documents the *confirmed* mechanism (binaryen WAT evidence); a senior-dev (Opus)
+  owns the trace.
+
+## Capacity (rough)
+
+~6 concurrent active agents (CPU-bound, cores−2). Suggested s68 opening
+allocation:
+- 1 senior-dev → #2660 PART-2 linchpin (recover fork WIP, land + 3 fixes).
+- 1 senior-dev → #2710 Slices 2–4.
+- 1 dev → #2175 dispatch (or escalate) → then #2161 prototype bucket.
+- 1 dev → #2671 remaining slices, then NEW-c (fn-name-class).
+- 1 dev → NEW-d (Set GetSetRecord, easy) → NEW-e (computed accessor) → #2029 sub-slice.
+- 1 architect → #2106 S1 spec, then BigInt #2044 decision, then async contract / NEW-f closure-box.


### PR DESCRIPTION
Activates the sprint 68 planning slate by reassigning every **non-done** issue referenced in `plan/issues/sprints/68.md` to the rolling live-window tag `sprint: current`.

## What changed
- **36 issues → `sprint: current`**: the 34 actionable issues previously tagged `sprint: 67` + the 2 Backlog pull-ins (#2623, #2626).
- **13 done issues left untouched** — they keep their historical sprint tags (#166, #1177, #1249, #1373, #1644, #2085, #2097, #2158, #2159, #2179, #2656, #2687, #2659).
- **Adds `plan/issues/sprints/68.md`** — the sprint 68 planning doc (themes: standalone+acorn dogfood, architecture spine, maintainability/IR-retirement; linchpin #2660 PART-2).

Plan-only change (frontmatter + planning doc) — no source or test files touched.

Once merged, `scripts/sync-current-tasklist.mjs` will pick up the `sprint: current` issues into the live TaskList.

🤖 Generated with [Claude Code](https://claude.com/claude-code)