### PR TITLE
fix(codegen): #2752 inject process.stdin prelude as TS regardless of .js user-file extension

### DIFF
--- a/plan/issues/2752-stdin-prelude-fails-js-parse.md
+++ b/plan/issues/2752-stdin-prelude-fails-js-parse.md
@@ -1,0 +1,89 @@
+---
+id: 2752
+title: transpiled (type-stripped) nm_node_process.js fails to compile — process.stdin TS prelude parsed under .js grammar
+area: codegen
+related: [389, 2632, 2748, 2123]
+feasibility: hard
+status: done
+completed: 2026-06-27
+assignee: ttraenkler/sdev-2752-prelude-js
+sprint: current
+---
+
+## Problem
+
+External reporter (loopdive/js2#389): the `process.stdin` async-stream host
+`examples/native-messaging/nm_node_process.ts` compiles + runs correctly directly
+(`js2wasm nm_node_process.ts --target wasi`), but the reporter's pipeline transpiles
+to JS first (`bun build → .js`, strips TS types) before compiling. The transpiled
+`.js` FAILS TO COMPILE with **46 TS-grammar errors** (`8017`
+signature-declarations-only-in-TS, `8009` `private` modifier, `8010`
+type-annotations). This blocks loopdive/js2#389's reporter pipeline and the v0.57.0
+publish.
+
+## Root cause
+
+`STDIN_READABLE_PRELUDE` in `src/process-stdin-prelude.ts` is raw TypeScript
+(`declare function __wasiStdinReadByte(): number; … private chunk: string;
+read(size?): string | null;`). `injectProcessStdinPrelude()` PREPENDS it to the
+user source; the combined source is then parsed downstream (`src/compiler.ts`)
+under the user file's extension. For a `.js`-named input the loose-JS grammar
+checker hard-rejects the prelude's TS syntax → compile fails before codegen. The
+DIRECT `.ts` path works because its callbacks are typed; the `.js` path was never
+exercised (`nm_deno` injects no prelude, so #2748's `.js` fixes sufficed there).
+
+A SECOND, latent bug surfaced once the `.js` parsed: a type-stripped consumer's
+`.on("data", (chunk) => …)` arrow has an UNTYPED param. With the prelude's `on`
+callback typed `any`, `chunk` lowered as externref; its closure-struct shape
+((externref) => void) then differed from the `((c: string) => void)[]` slot it is
+stored in, and the `emitChunk` call site (`ref.cast` to the (string)=>void closure
+struct) nulled the mismatched value → `null reference` TRAP at runtime. (This is a
+general closure-typing gap, reproducible on plain `.ts`, rooted in the standalone
+any-typed native-string substrate — see `project_standalone_any_string_value_read_substrate`.)
+
+## Fix
+
+Two changes, both scoped to the prelude-injection path (byte-neutral elsewhere):
+
+1. **Parse the prelude-injected unit under the TS grammar** even for a `.js` user
+   file — `forceTsGrammar` option on `analyzeSource` (`src/checker/index.ts`) and
+   the incremental language service (`src/checker/language-service.ts`), threaded
+   from `src/compiler.ts` when `stdinResult.injected`. Flips ONLY the `ScriptKind`
+   (TS vs JS); the `.js`-derived lenient semantics (`strict: false`,
+   `allowJs`/`checkJs`) are left intact, so the user's `.js` code keeps its lenient
+   checking while the prelude's TS syntax is accepted (option 1 from the diagnosis;
+   validated to not regress loose-`.js` user code).
+
+2. **Type the prelude's `.on()` callback as a UNION** `((c: string) => void) | (()
+=> void)` instead of `any` (`src/process-stdin-prelude.ts`). This makes
+   TypeScript contextually type the untyped `chunk` as `string`, so the stripped
+   arrow lowers as a (string)=>void closure that MATCHES the slot — for both typed
+   (.ts) and untyped (.js) callbacks — avoiding the trap WITHOUT weakening the
+   load-bearing `.read(size?): string | null` return type (#2748 bug C). The
+   contextual typing only takes effect because of fix #1. (`any[]` storage and
+   method overloads were both tried and rejected: `any[]` routes through dynamic
+   dispatch which corrupts native-string args; overloads regress the working typed
+   case.)
+
+## Acceptance — MET
+
+- Type-stripped `nm_node_process.js` (esbuild/bun strip) compiles under `--target
+wasi`: imports = `{wasi_snapshot_preview1}` only, no `env::*` leak, valid module.
+- Under wasmtime with stdin held OPEN + the in-band zero-length shutdown frame:
+  echoes byte-exact AND exits cleanly (exit 0) — at small and multi-KiB payloads.
+  EOF-close path also green. The direct `.ts` stays working.
+- Byte-neutral for programs that don't reference `process.stdin` (prelude only
+  injects then; `forceTsGrammar` only set when injected).
+- Regression test: `tests/issue-2752-stdin-prelude-js.test.ts`.
+
+## Implementation notes (why, not just what)
+
+- The TS parser builds type-annotation AST nodes regardless of `ScriptKind`;
+  `.js` mode only ADDS the grammar-error diagnostics (8009/8010/8017). So forcing
+  `ScriptKind.TS` for the prelude-injected unit is sufficient — no AST shape change,
+  just suppression of the JS-only grammar diagnostics. `strictNullChecks` stays
+  `true` regardless, so the prelude's `string | null` types are preserved.
+- The runtime trap is genuinely a SEPARATE, deeper codegen gap (untyped closure →
+  typed closure-array). Fix #2 sidesteps it at the prelude (library) level via
+  contextual typing rather than a broad, risky closure-representation overhaul; the
+  general gap remains for a future issue.

--- a/src/checker/index.ts
+++ b/src/checker/index.ts
@@ -346,6 +346,23 @@ export interface AnalyzeOptions {
    * + the `emulateNode ||= platform ∈ {node,deno}` composition in #2645/#2736.
    */
   platform?: "web" | "node" | "deno";
+  /**
+   * Force TypeScript GRAMMAR for the parse even when the input file is named
+   * `.js`/`.mjs`/`.cjs` (#2752). When the compiler prepends an injected source
+   * prelude that is written in TypeScript — currently the `process.stdin`
+   * Readable prelude (`src/process-stdin-prelude.ts`), which carries the
+   * nullable/union types codegen relies on (`read(size?): string | null`) — the
+   * combined unit must be parsed under the TS grammar, or the loose-JS grammar
+   * checker hard-rejects the prelude's TS syntax with TS8009/8010/8017 ("X can
+   * only be used in TypeScript files") and compilation fails before codegen.
+   * This flag flips ONLY the `ScriptKind` (TS vs JS) for the parse; the
+   * `isJs`-derived semantics (`strict: false`, `allowJs`+`checkJs`) stay
+   * derived from the filename, so the user's `.js` code keeps its lenient
+   * checking while the prelude's TS syntax is accepted and its types stay
+   * load-bearing. Scoped to the prelude-injection path only — byte-neutral for
+   * every program that does not trigger a TS prelude injection.
+   */
+  forceTsGrammar?: boolean;
 }
 
 /**
@@ -669,8 +686,21 @@ export function analyzeSource(source: string, fileName = "input.ts", analyzeOpti
   const ext = fileName.match(/\.(tsx|jsx|ts|js|mjs|cjs)$/)?.[1] ?? "ts";
   const isJsx = ext === "tsx" || ext === "jsx";
   const isJs = ext === "js" || ext === "jsx" || ext === "mjs" || ext === "cjs";
-  const scriptKind =
-    ext === "tsx" ? ts.ScriptKind.TSX : ext === "jsx" ? ts.ScriptKind.JSX : isJs ? ts.ScriptKind.JS : ts.ScriptKind.TS;
+  // #2752 — when a TS source prelude was injected ahead of a `.js`-named user
+  // file, force the TS grammar for the parse so the prelude's TS syntax
+  // (type annotations, `private`, signature declarations) is not rejected with
+  // TS8009/8010/8017. This overrides ONLY the ScriptKind; `isJs` (and thus the
+  // `strict: false` + `allowJs`/`checkJs` semantics below) stay derived from
+  // the filename, so the user's `.js` code keeps its lenient checking.
+  const scriptKind = analyzeOptions?.forceTsGrammar
+    ? ts.ScriptKind.TS
+    : ext === "tsx"
+      ? ts.ScriptKind.TSX
+      : ext === "jsx"
+        ? ts.ScriptKind.JSX
+        : isJs
+          ? ts.ScriptKind.JS
+          : ts.ScriptKind.TS;
   const useAllowJs = isJs || analyzeOptions?.allowJs === true;
 
   const compilerOptions: ts.CompilerOptions = {

--- a/src/checker/language-service.ts
+++ b/src/checker/language-service.ts
@@ -62,8 +62,16 @@ export class IncrementalLanguageService {
     };
   }
 
-  /** Update the source for the next compilation */
-  updateSource(source: string, fileName?: string): void {
+  /**
+   * Update the source for the next compilation.
+   *
+   * #2752 — `forceTsGrammar` forces `ScriptKind.TS` for the parsed SourceFile
+   * even when `fileName` ends in `.js` (otherwise `ts.createSourceFile` infers
+   * `ScriptKind.JS` from the extension and the loose-JS grammar checker rejects
+   * an injected TS prelude with TS8009/8010/8017). Mirrors the
+   * `forceTsGrammar` override in the non-incremental `analyzeSource`.
+   */
+  updateSource(source: string, fileName?: string, forceTsGrammar?: boolean): void {
     this.currentSource = source;
     if (fileName) this.fileName = fileName;
     this.currentSourceFile = ts.createSourceFile(
@@ -71,6 +79,7 @@ export class IncrementalLanguageService {
       this.currentSource,
       this.compilerOptions.target ?? ts.ScriptTarget.ES2022,
       true,
+      forceTsGrammar ? ts.ScriptKind.TS : undefined,
     );
   }
 

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -1087,10 +1087,17 @@ export function compileSourceSync(
   // `--emulate node` it already has via `--target`).
   const effectiveEmulateNode =
     options.emulateNode === true || options.platform === "node" || options.platform === "deno";
+  // #2752 — when the `process.stdin` Readable prelude (or any future TS source
+  // prelude) was injected ahead of a `.js`-named user file, parse the combined
+  // unit under the TS grammar so the prelude's TS syntax (type annotations,
+  // `private`, signature declarations) isn't hard-rejected with TS8009/8010/8017.
+  // ScriptKind-only override; the `.js`-derived semantics (lenient checking)
+  // stay intact. Byte-neutral when no prelude was injected.
+  const forceTsGrammar = stdinResult.injected;
   let ast: TypedAST;
   if (languageService) {
     // Incremental path: reuse cached lib files via the language service
-    languageService.updateSource(processedSource, effectiveFileName);
+    languageService.updateSource(processedSource, effectiveFileName, forceTsGrammar);
     ast = languageService.analyze({
       allowJs: options.allowJs,
       skipSemanticDiagnostics: options.skipSemanticDiagnostics,
@@ -1101,6 +1108,7 @@ export function compileSourceSync(
       allowJs: options.allowJs,
       skipSemanticDiagnostics: options.skipSemanticDiagnostics,
       emulateNode: options.emulateNode,
+      forceTsGrammar,
       ...(options.platform ? { platform: options.platform } : {}),
     });
   }

--- a/src/process-stdin-prelude.ts
+++ b/src/process-stdin-prelude.ts
@@ -236,11 +236,28 @@ class __Js2wasmReadable {
     __wasiStdinSetReader(() => { this.pump(); });
   }
 
-  on(event: string, cb: any): __Js2wasmReadable {
-    if (event === "data") { this.dataCbs.push(cb); this.flowing = true; this.arm(); }
-    else if (event === "end") { this.endCbs.push(cb); this.arm(); }
-    else if (event === "readable") { this.readableCbs.push(cb); this.arm(); }
-    else if (event === "close") { this.closeCbs.push(cb); }
+  // #2752 — the callback parameter is a UNION of the 'data' shape ((c: string)
+  // => void) and the param-less shape (() => void), NOT \`any\`. This is
+  // load-bearing for TYPE-STRIPPED consumers (\`bun build\`/esbuild/tsc → .js):
+  // a stripped \`.on("data", (chunk) => …)\` arrow has an UNTYPED param, and an
+  // \`any\` \`cb\` would give it no contextual type, so \`chunk\` lowers as
+  // externref. Its closure-struct shape ((externref) => void) then differs from
+  // the \`((c: string) => void)[]\` slot it is stored in, and the call site in
+  // \`emitChunk\` (a \`ref.cast\` to the (string)=>void closure struct) nulls the
+  // mismatched value and TRAPS with a null reference. Typing \`cb\` as the union
+  // makes TypeScript CONTEXTUALLY type the untyped \`chunk\` as \`string\` (the
+  // 'data' member of the union), so the arrow lowers as a (string)=>void
+  // closure that matches the slot — for BOTH the typed (direct .ts) and untyped
+  // (transpiled .js) consumer callback. The \`() => void\` end/readable/close
+  // callbacks remain assignable (the param-less union member). This only takes
+  // effect because the injected prelude is now parsed under the TS grammar even
+  // for a \`.js\` user file (the \`forceTsGrammar\` parse fix). The per-event
+  // \`as\` casts narrow the union to the concrete slot element type.
+  on(event: string, cb: ((c: string) => void) | (() => void)): __Js2wasmReadable {
+    if (event === "data") { this.dataCbs.push(cb as (c: string) => void); this.flowing = true; this.arm(); }
+    else if (event === "end") { this.endCbs.push(cb as () => void); this.arm(); }
+    else if (event === "readable") { this.readableCbs.push(cb as () => void); this.arm(); }
+    else if (event === "close") { this.closeCbs.push(cb as () => void); }
     return this;
   }
 

--- a/tests/issue-2752-stdin-prelude-js.test.ts
+++ b/tests/issue-2752-stdin-prelude-js.test.ts
@@ -1,0 +1,266 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2752 — a TYPE-STRIPPED (transpiled `.js`) `process.stdin` program must
+ * compile AND run, not fail with 46 TS-grammar errors.
+ *
+ * The faithful `process.stdin` Readable surface is injected as a source PRELUDE
+ * (`src/process-stdin-prelude.ts`) prepended to the user source. That prelude is
+ * written in TypeScript (`declare function …`, `private chunk: string`,
+ * `read(size?): string | null`). The combined unit is parsed downstream under
+ * the USER file's extension — so for a `.js`-named input (the reporter's
+ * `bun build → .js` pipeline, loopdive/js2#389) the loose-JS grammar checker
+ * hard-rejected the prelude's TS syntax with TS8017/8009/8010 ("… can only be
+ * used in TypeScript files") and compilation failed BEFORE codegen. The direct
+ * `.ts` path always worked (its callbacks are typed); only the transpiled `.js`
+ * path was never exercised.
+ *
+ * Two fixes, both scoped to the prelude-injection path (byte-neutral elsewhere):
+ *
+ *   1. **Parse the prelude-injected unit under the TS grammar** even for a `.js`
+ *      user file (`forceTsGrammar` in `analyzeSource` / the incremental
+ *      language service, threaded from `compiler.ts` when `stdinResult.injected`).
+ *      This flips ONLY the `ScriptKind`; the `.js`-derived lenient semantics
+ *      (`strict: false`, `allowJs`/`checkJs`) are untouched.
+ *
+ *   2. **Type the prelude's `.on()` callback as a UNION** —
+ *      `((c: string) => void) | (() => void)` instead of `any`. A type-stripped
+ *      consumer's `.on("data", (chunk) => …)` arrow has an UNTYPED param; an
+ *      `any` callback would give it no contextual type, so `chunk` lowered as
+ *      externref. Its closure-struct shape then differed from the
+ *      `((c: string) => void)[]` slot it is stored in, and the `emitChunk` call
+ *      site (`ref.cast` to the (string)=>void closure struct) nulled the
+ *      mismatched value and TRAPPED with a null reference. The union makes
+ *      TypeScript contextually type the untyped `chunk` as `string`, so the
+ *      arrow lowers as a (string)=>void closure that matches the slot — for both
+ *      the typed (direct `.ts`) and untyped (transpiled `.js`) callback. This
+ *      contextual typing only takes effect because of fix #1 (the prelude is now
+ *      parsed as TS).
+ *
+ * The runtime gate (the unblocking criterion for loopdive/js2#389 + the v0.57.0
+ * publish): the type-stripped `nm_node_process.js` echoes a framed message
+ * byte-exact AND exits cleanly under wasmtime with stdin held OPEN + the in-band
+ * zero-length shutdown frame (`process.stdin.destroy()`).
+ */
+import { execFileSync, spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as esbuild from "esbuild";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+const WASMTIME_FLAGS = ["-W", "gc=y,function-references=y,exceptions=y"];
+
+function findWasmtime(): string | null {
+  for (const cand of ["wasmtime", "/usr/local/bin/wasmtime"]) {
+    try {
+      execFileSync(cand, ["--version"], { stdio: "ignore" });
+      return cand;
+    } catch {
+      /* try next */
+    }
+  }
+  return null;
+}
+const wasmtimeBin = findWasmtime();
+
+const NM_DIR = join(__dirname, "..", "examples", "native-messaging");
+
+/** Frame a body as a 4-byte LE length prefix + the body bytes (Native Messaging). */
+function frame(body: Uint8Array): Uint8Array {
+  const out = new Uint8Array(4 + body.length);
+  const n = body.length;
+  out[0] = n & 0xff;
+  out[1] = (n >> 8) & 0xff;
+  out[2] = (n >> 16) & 0xff;
+  out[3] = (n >> 24) & 0xff;
+  out.set(body, 4);
+  return out;
+}
+
+/** The (module) name of every import in a compiled WAT. */
+function importModules(wat: string): Set<string> {
+  const mods = new Set<string>();
+  for (const line of wat.split("\n")) {
+    const m = line.match(/\(import\s+"([^"]+)"/);
+    if (m) mods.add(m[1]!);
+  }
+  return mods;
+}
+
+interface RunResult {
+  stdout: Uint8Array;
+  exitCode: number | null;
+  timedOut: boolean;
+}
+
+/**
+ * Spawn a compiled WASI module under wasmtime, write `input` to its stdin, and
+ * resolve when it exits (or the timeout fires). When `keepOpen` is true the
+ * parent's stdin pipe is left OPEN (never `.end()`-ed) so the child never sees
+ * EOF — it must terminate via the in-band zero-length shutdown frame
+ * (`process.stdin.destroy()`), the real Native-Messaging case. `timedOut: true`
+ * means it hung.
+ */
+function runWasmtimeStdin(
+  binPath: string,
+  input: Uint8Array,
+  opts: { keepOpen: boolean; timeoutMs: number },
+): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const child = spawn(wasmtimeBin!, [...WASMTIME_FLAGS, binPath], {
+      stdio: ["pipe", "pipe", "ignore"], // drop fd 2 diagnostics
+    });
+    const out: number[] = [];
+    child.stdout.on("data", (d: Buffer) => {
+      for (const b of d) out.push(b);
+    });
+    child.stdin.on("error", () => {});
+    let done = false;
+    const timer = setTimeout(() => {
+      if (done) return;
+      done = true;
+      child.kill("SIGKILL");
+      resolve({ stdout: Uint8Array.from(out), exitCode: null, timedOut: true });
+    }, opts.timeoutMs);
+    child.on("exit", (code) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      resolve({ stdout: Uint8Array.from(out), exitCode: code, timedOut: false });
+    });
+    child.stdin.write(Buffer.from(input));
+    if (!opts.keepOpen) child.stdin.end();
+  });
+}
+
+// A hand-written TYPE-STRIPPED `process.stdin` echo host — the data callback's
+// param carries NO annotation (`(chunk) =>`), exactly what a transpiler emits.
+// Independent of esbuild's exact output, this is the deterministic backstop.
+const STRIPPED_STDIN_ECHO = `
+let buffered = "";
+let stopped = false;
+function decodeLength(s) {
+  return s.charCodeAt(0) + s.charCodeAt(1) * 256 + s.charCodeAt(2) * 65536 + s.charCodeAt(3) * 16777216;
+}
+function drain() {
+  while (!stopped) {
+    if (buffered.length < 4) return;
+    const len = decodeLength(buffered);
+    if (len === 0) { stopped = true; process.stdin.destroy(); return; }
+    const frameLen = 4 + len;
+    if (buffered.length < frameLen) return;
+    const out = new Uint8Array(frameLen);
+    out[0] = len & 0xff;
+    out[1] = (len >> 8) & 0xff;
+    out[2] = (len >> 16) & 0xff;
+    out[3] = (len >> 24) & 0xff;
+    let i = 0;
+    while (i < len) { out[4 + i] = buffered.charCodeAt(4 + i) & 0xff; i = i + 1; }
+    process.stdout.write(out);
+    buffered = buffered.substring(frameLen);
+  }
+}
+function main() {
+  process.stdin.on("data", (chunk) => { if (stopped) return; buffered = buffered + chunk; drain(); });
+  process.stdin.on("end", () => {});
+}
+main();
+`;
+
+describe("#2752 — type-stripped process.stdin program compiles + runs", () => {
+  // ── Compile-only invariants (always run, no runtime needed) ──────────────
+
+  it("the esbuild-transpiled (type-stripped) nm_node_process.ts compiles to a pure-WASI module", async () => {
+    // The reporter's exact pipeline: strip TS types, then compile the `.js`.
+    const tsSrc = readFileSync(join(NM_DIR, "nm_node_process.ts"), "utf-8");
+    const { code } = await esbuild.transform(tsSrc, { loader: "ts", format: "esm" });
+    expect(code).toContain("process.stdin");
+    expect(code).not.toContain(": string"); // types really are stripped
+    const r = await compile(code, { fileName: "nm_node_process.js", target: "wasi" });
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+    expect(WebAssembly.validate(r.binary!)).toBe(true);
+    // No `env::*` host-import leak; pure WASI P1 — same module shape as the `.ts`.
+    expect([...importModules(r.wat!)]).toEqual(["wasi_snapshot_preview1"]);
+    // The reactor IS wired (the program uses process.stdin).
+    expect(r.wat!.includes("__run_event_loop")).toBe(true);
+  });
+
+  it("a hand-written TYPE-STRIPPED process.stdin echo (.js) compiles to pure WASI", async () => {
+    const r = await compile(STRIPPED_STDIN_ECHO, { fileName: "echo.js", target: "wasi" });
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+    expect(WebAssembly.validate(r.binary!)).toBe(true);
+    expect([...importModules(r.wat!)]).toEqual(["wasi_snapshot_preview1"]);
+  });
+
+  it("is byte-neutral: a `.js` program that never touches process.stdin gets no prelude", async () => {
+    const r = await compile("export function add(a, b) { return a + b; }\n", {
+      fileName: "plain.js",
+      target: "wasi",
+    });
+    expect(r.success).toBe(true);
+    expect(r.wat!.includes("__Js2wasmReadable"), "no Readable prelude for a stdin-free program").toBe(false);
+    expect(r.wat!.includes("__run_event_loop"), "no event loop for a stdin-free program").toBe(false);
+  });
+
+  // ── Runtime behavior under real wasmtime (the gate) ──────────────────────
+
+  const maybe = wasmtimeBin ? describe : describe.skip;
+  maybe("under wasmtime — the type-stripped host echoes byte-exact and exits cleanly", () => {
+    let tmpDir: string;
+    beforeAll(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), "issue-2752-"));
+    });
+    afterAll(() => {
+      if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    async function buildStripped(name: string): Promise<string> {
+      const tsSrc = readFileSync(join(NM_DIR, "nm_node_process.ts"), "utf-8");
+      const { code } = await esbuild.transform(tsSrc, { loader: "ts", format: "esm" });
+      const r = await compile(code, { fileName: "nm_node_process.js", target: "wasi" });
+      expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+      expect(WebAssembly.validate(r.binary!), "binary must validate").toBe(true);
+      const path = join(tmpDir, `${name}.wasm`);
+      writeFileSync(path, r.binary!);
+      return path;
+    }
+
+    const requestFrame = frame(new TextEncoder().encode('["hello",null,42]'));
+    const shutdownFrame = frame(new Uint8Array(0)); // zero-length = in-band clean shutdown
+
+    it(
+      "stdin held OPEN: exits cleanly on the in-band shutdown frame, echoes the data frame byte-exact",
+      { timeout: 30_000 },
+      async () => {
+        const binPath = await buildStripped("nm_open_shutdown");
+        const input = new Uint8Array([...requestFrame, ...shutdownFrame]);
+        const res = await runWasmtimeStdin(binPath, input, { keepOpen: true, timeoutMs: 15_000 });
+        expect(res.timedOut, "type-stripped open-stdin host HUNG").toBe(false);
+        expect(res.exitCode).toBe(0);
+        expect(Array.from(res.stdout), "must echo only the data frame, byte-exact").toEqual(Array.from(requestFrame));
+      },
+    );
+
+    it("stdin held OPEN: round-trips a >window (multi-KiB) body byte-exact", { timeout: 30_000 }, async () => {
+      const binPath = await buildStripped("nm_open_big");
+      const big = new Uint8Array(4096);
+      for (let i = 0; i < big.length; i++) big[i] = (i * 7 + 3) & 0xff;
+      const bigFrame = frame(big);
+      const input = new Uint8Array([...requestFrame, ...bigFrame, ...shutdownFrame]);
+      const expected = new Uint8Array([...requestFrame, ...bigFrame]);
+      const res = await runWasmtimeStdin(binPath, input, { keepOpen: true, timeoutMs: 15_000 });
+      expect(res.timedOut, "type-stripped open-stdin host HUNG on a multi-frame payload").toBe(false);
+      expect(res.exitCode).toBe(0);
+      expect(Array.from(res.stdout)).toEqual(Array.from(expected));
+    });
+
+    it("stdin CLOSED (EOF): still echoes the frame and exits", { timeout: 30_000 }, async () => {
+      const binPath = await buildStripped("nm_eof");
+      const input = new Uint8Array([...requestFrame, ...shutdownFrame]);
+      const res = await runWasmtimeStdin(binPath, input, { keepOpen: false, timeoutMs: 15_000 });
+      expect(res.timedOut, "type-stripped EOF-closed host HUNG").toBe(false);
+      expect(Array.from(res.stdout)).toEqual(Array.from(requestFrame));
+    });
+  });
+});


### PR DESCRIPTION
## Problem (loopdive/js2#389, blocks v0.57.0 publish)

A transpiled (type-stripped) `nm_node_process.js` **fails to compile** with 46 TS-grammar errors (`8017`/`8009`/`8010`). The `process.stdin` Readable prelude (`src/process-stdin-prelude.ts`) is raw TypeScript prepended to the user source, then parsed downstream under the user file's `.js` extension → the loose-JS grammar checker hard-rejects the prelude's TS syntax (`declare function`, `private chunk: string`, `read(size?): string | null`) before codegen. The direct `.ts` path works (its callbacks are typed); the reporter's `bun build → .js` pipeline never worked.

## Fix (two scoped changes, byte-neutral when no prelude is injected)

1. **Parse the prelude-injected unit under the TS grammar** even for a `.js` user file — new `forceTsGrammar` option on `analyzeSource` + the incremental language service, threaded from `compiler.ts` when `stdinResult.injected`. Flips ONLY the `ScriptKind` (TS vs JS); the `.js`-derived lenient semantics (`strict: false`, `allowJs`/`checkJs`) are left intact. `strictNullChecks` stays on, so the prelude's load-bearing `read(size?): string | null` types are preserved (#2748 bug-C class).

2. **Type the prelude's `.on()` callback as a union** `((c: string) => void) | (() => void)` instead of `any`. A type-stripped consumer's `.on("data", (chunk) => …)` arrow is untyped; an `any` callback gave `chunk` no contextual type → it lowered as externref, and its closure-struct shape mismatched the `((c: string) => void)[]` slot → the `emitChunk` call site nulled the `ref.cast` and trapped (`null reference`) at runtime. The union makes TypeScript contextually type `chunk` as `string`, matching the slot for **both** typed (.ts) and untyped (.js) callbacks. Only effective because of fix #1.

(`any[]` storage and method overloads were both tried and rejected — `any[]` routes through dynamic dispatch which corrupts native-string args; overloads regress the working typed case.)

## Gate — MET (the unblocking criterion)

The esbuild/bun **type-stripped** `nm_node_process.js`:
- compiles to a **pure-WASI** module (imports only `wasi_snapshot_preview1`, no `env::*` leak, valid binary);
- under wasmtime with **stdin held OPEN + the in-band zero-length shutdown frame** → **echoes byte-exact AND exits cleanly (exit 0)** — verified at small + multi-KiB payloads, plus the EOF-close path.
- The direct `.ts` stays working. Byte-neutral for programs that never reference `process.stdin`.

## Validation
- New regression test `tests/issue-2752-stdin-prelude-js.test.ts` (6 cases) — green.
- Existing `issue-2735` + `issue-2632-phase3` suites (15 cases) — green.
- `tsc --noEmit`, `biome lint`, `prettier` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)