### PR TITLE
fix(soundness): #2750 S1+S2 — full sound umbrella for .js + externref-array OOB→undefined

### DIFF
--- a/src/checker/index.ts
+++ b/src/checker/index.ts
@@ -676,8 +676,22 @@ export function analyzeSource(source: string, fileName = "input.ts", analyzeOpti
   const compilerOptions: ts.CompilerOptions = {
     target: ts.ScriptTarget.ES2022,
     module: ts.ModuleKind.ESNext,
-    strict: !isJs,
+    // #2750 S1 — single-file `.js` now gets the FULL sound `strict` umbrella,
+    // matching both multi-file blocks (`analyzeMultipleFiles`/`analyzeFiles`,
+    // which set `strict: true` unconditionally). Previously `strict: !isJs`
+    // gave a single-file `.js` ONLY the pinned `strictNullChecks` (#2748 C),
+    // leaving `strictFunctionTypes`/`strictPropertyInitialization`/
+    // `useUnknownInCatchVariables`/… OFF — a latent single-file vs multi-file
+    // inconsistency. Sound flags keep type-directed codegen accurate.
+    strict: true,
+    // `strictNullChecks` is already implied by `strict: true`; kept explicit as
+    // the soundness-critical guard the #2748 C fix established (a `T|null`
+    // collapse changes the Wasm value-representation and folds null/undefined
+    // guards — the #2748 infinite-loop miscompile).
     strictNullChecks: true,
+    // BOUNDARY (#2750 Prong 1): `noImplicitAny` stays OFF for `.js` — rejecting
+    // untyped JS is NOT the goal; the dynamic/`any`/externref path handles it.
+    // This override MUST come after `strict: true` (which would enable it).
     noImplicitAny: false,
     noEmit: true,
     // Enable JSX parsing for .tsx/.jsx files. ReactJSX desugars JSX to

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -6300,7 +6300,13 @@ export function compileElementAccessBody(
       // (#2001 S1) Pass `ctx` so the in-bounds `$Hole → undefined` read-boundary
       // mapping fires for an externref-element (`any[]`) vec. (#2593) Thread the
       // view-name signedness for packed i8/i16 reads.
-      emitBoundsCheckedArrayGet(fctx, arrTypeIdx, arrDef.element, ctx, false, taSignedness);
+      // (#2750 S2) `useUndefinedSentinel=true`: an out-of-bounds read of an
+      // externref-element array (`any[]`/`string[]`) returns JS `undefined`
+      // (`__get_undefined`) instead of `null` (`ref.null.extern`). No-op for
+      // packed `number[]`/`boolean[]` (the sentinel only applies to
+      // externref/ref_extern element kinds; f64/i32 keep their type-default
+      // sentinel — the deferred S5 `noUncheckedIndexedAccess` epic, not this slice).
+      emitBoundsCheckedArrayGet(fctx, arrTypeIdx, arrDef.element, ctx, true, taSignedness);
     }
     // (#2593) `Uint32Array` element read: the i32_byte storage holds the full 32
     // bits; the value as a JS number is the UNSIGNED interpretation (0..2^32-1).
@@ -6349,7 +6355,10 @@ export function compileElementAccessBody(
   } else {
     // (#2001 S1) Pass `ctx` for the in-bounds `$Hole → undefined` mapping.
     // (#2593) Thread the view-name signedness for packed i8/i16 reads.
-    emitBoundsCheckedArrayGet(fctx, typeIdx, typeDef.element, ctx, false, taSignednessArr);
+    // (#2750 S2) `useUndefinedSentinel=true`: out-of-bounds read of an
+    // externref-element array (`any[]`/`string[]`) returns JS `undefined`, not
+    // `null`. No-op for packed `number[]`/`boolean[]` (see the matching site above).
+    emitBoundsCheckedArrayGet(fctx, typeIdx, typeDef.element, ctx, true, taSignednessArr);
   }
   return valueType;
 }

--- a/tests/issue-2750.test.ts
+++ b/tests/issue-2750.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #2750 S2 — out-of-bounds index read on an externref-element array (`any[]`,
+// `string[]`) must return JS `undefined`, not `null`. The element slot of a
+// packed `number[]`/`boolean[]` cannot structurally hold `undefined`, so those
+// keep their type-default sentinel — the full close is the deferred S5
+// `noUncheckedIndexedAccess` epic, NOT this slice.
+async function run(source: string, fn: string, args: unknown[] = []): Promise<unknown> {
+  const result = await compile(source, { fileName: "test.ts" });
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>)[fn](...args);
+}
+
+describe("#2750 S2 — externref-element OOB read returns undefined", () => {
+  it("any[] out-of-bounds === undefined", async () => {
+    const src = `export function test(): boolean { const a: any[] = [1]; return a[9] === undefined; }`;
+    expect(await run(src, "test")).toBe(1); // true
+  });
+
+  it("any[] out-of-bounds !== null", async () => {
+    const src = `export function test(): boolean { const a: any[] = [1]; return a[9] === null; }`;
+    expect(await run(src, "test")).toBe(0); // false — was true (ref.null.extern) before the fix
+  });
+
+  it("string[] out-of-bounds === undefined", async () => {
+    const src = `export function test(): boolean { const a: string[] = ["x"]; return a[9] === undefined; }`;
+    expect(await run(src, "test")).toBe(1); // true
+  });
+
+  it("any[] negative index === undefined", async () => {
+    const src = `export function test(): boolean { const a: any[] = [1, 2]; return a[-1] === undefined; }`;
+    expect(await run(src, "test")).toBe(1); // true
+  });
+
+  it("any[] in-bounds read is unchanged", async () => {
+    const src = `export function test(): number { const a: any[] = [42]; return a[0] as number; }`;
+    expect(await run(src, "test")).toBe(42);
+  });
+
+  // Packed-array OOB is explicitly NOT changed by S2 — it keeps the type-default
+  // sentinel (sNaN for number, 0/false for boolean). The real fix is the deferred
+  // S5 `noUncheckedIndexedAccess` epic. These cases lock in the intentional gap so
+  // a future change to packed reads is a conscious decision, not an accident.
+  it("number[] OOB still returns the type-default sentinel, NOT undefined (deferred S5)", async () => {
+    const src = `export function test(): boolean { const a: number[] = [1]; return a[9] === undefined; }`;
+    expect(await run(src, "test")).toBe(0); // false — packed f64 slot can't hold undefined
+  });
+
+  it("boolean[] OOB still returns the type-default sentinel, NOT undefined (deferred S5)", async () => {
+    const src = `export function test(): boolean { const a: boolean[] = [true]; return a[9] === undefined; }`;
+    expect(await run(src, "test")).toBe(0); // false — packed i32 slot can't hold undefined
+  });
+});


### PR DESCRIPTION
Implements the two cheap, byte-neutral correctness wins from **#2750** (slices **S1 + S2**), consistent with the JS-semantics-first direction (#2751). #2750 stays **in-progress** (S3/S4/S5 remain).

## S1 — full sound umbrella for single-file `.js` (`src/checker/index.ts`)
`analyzeSource` used `strict: !isJs`, so a single-file `.js` got ONLY the pinned `strictNullChecks` (#2748 C) while BOTH multi-file blocks (`analyzeMultipleFiles`/`analyzeFiles`) use `strict: true` unconditionally. This unifies them: `.js` now gets `strict: true` (→ `strictFunctionTypes`, `strictPropertyInitialization`, `useUnknownInCatchVariables`, …) with an explicit `noImplicitAny: false` override (rejecting untyped JS is NOT the goal — the dynamic/externref path handles it). The `strictNullChecks: true` guard is kept explicit + commented (soundness-critical for the #2748 null-collapse miscompile).

## S2 — externref-element array OOB read → `undefined`, not `null` (`src/codegen/property-access.ts`)
Out-of-bounds index read on an externref-element array (`any[]`, `string[]`) returned `null` (`ref.null.extern`) only because the two plain-read call sites passed `useUndefinedSentinel=false`. Flipped to `true` (the #1396 machinery already existed for destructuring callers). Now `any[]`/`string[]` OOB → JS `undefined` (`__get_undefined`). Packed `number[]`/`boolean[]` are untouched — the sentinel only applies to externref/ref_extern element kinds; the full close (packed `T|undefined` rep) is the deferred S5 `noUncheckedIndexedAccess` epic.

## Validation / byte-neutrality evidence
- **S1 byte-neutral on the `.ts` corpus**: test262/equivalence compile via `test.ts` filenames → `isJs=false` → `strict` was ALREADY `true`. The change only affects the `.js` branch. Confirmed `.js` boundary holds: untyped `.js` still compiles (noImplicitAny off), null-guard still works (strictNullChecks on), `.ts` control unchanged.
- **S2 scoped to externref OOB**: `useUndefinedSentinel=true` is a no-op for packed f64/i32 elements (the sentinel path is gated on externref/ref_extern element kind), so `number[]`/`boolean[]` reads are byte-identical.
- **Regression test** `tests/issue-2750.test.ts` (7 cases): `any[]`/`string[]` OOB → undefined, OOB !== null, negative index, in-bounds unchanged; `number[]`/`boolean[]` OOB still sentinel (locks in the deferred S5 gap).
- Existing related suites green: `array-oob-bounds-check`, `issue-2001-s1-hole-literal`, `issue-1105-at-oob`, `array-methods` (66 tests).
- `tsc --noEmit` clean; `biome lint` clean; `prettier --write` applied.

Note: the #2750 issue file ("sound TS settings") lives on open PR #2195, not on main; this PR adds no issue file. (Heads-up: main currently has a *different* `id: 2750`, "Consolidate process docs" — an id-collision with PR #2195 to reconcile.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)