### PR TITLE
fix(ci): publish-npm — drop conflicting pnpm version: 10, use pinned packageManager

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -73,9 +73,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # No `version:` here on purpose — package.json pins pnpm via the
+      # "packageManager" field, and passing both makes pnpm/action-setup@v4
+      # fail with ERR_PNPM_BAD_PM_VERSION (it killed the v0.56.0 and v0.57.0
+      # publish runs). Let action-setup read the pinned version instead.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Problem
`publish-npm.yml` has never successfully published. Both the only-ever runs — v0.56.0 (2026-05-29) and the just-attempted v0.57.0 — died at the `pnpm/action-setup@v4` step with:

```
Error: Multiple versions of pnpm specified:
  - version 10 in the GitHub Action config with the key "version"
  - version pnpm@10.30.2+sha512... in the package.json with the key "packageManager"
Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION
```

`pnpm/action-setup@v4` refuses to run when an explicit `version:` input AND a `package.json` `packageManager` field both specify a pnpm version.

## Fix
Drop the `version: 10` input from the `pnpm/action-setup@v4` step in the publish job. `package.json` already pins `pnpm@10.30.2` via `packageManager`, so the action reads the pinned version from there — the single source of truth. One-line change (plus an explanatory comment).

## Impact
Unblocks the publish pipeline. The `verify-version` gate (tag == both package.json versions) already passed on the v0.57.0 run, so once this lands the publish job can proceed to the actual `npm publish` step. (Separately, the `NPM_TOKEN` repo secret must be provisioned for the publish step to authenticate — tracked outside this PR.)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>