### PR TITLE
build: exclude .d.ts.map from npm package (dead source maps, 456→233 files)

### DIFF
--- a/vite.config.lib.ts
+++ b/vite.config.lib.ts
@@ -15,6 +15,11 @@ export default defineConfig({
       include: ["src/**/*.ts"],
       exclude: ["src/**/*.test.ts"],
       rollupTypes: false,
+      // Don't ship .d.ts.map: the published tarball has no src/, so their
+      // "../src/*.ts" sources are dead references that just double the file
+      // count. tsconfig keeps declarationMap on for in-repo editor
+      // go-to-definition; this overrides it for the published lib build only.
+      compilerOptions: { declarationMap: false },
     }),
   ],
   publicDir: false,


### PR DESCRIPTION
## Problem
The lib build (`vite.config.lib.ts` → `vite-plugin-dts`) emitted a `.d.ts.map` next to every `.d.ts` — **223 files**. But the published tarball ships only `dist/` (per the `files` allowlist), so every map's `"sources":["../src/*.ts"]` points at source that isn't in the package: dead references that **doubled the file count (456 → 233)** for zero consumer value, and exposed the source-tree layout.

## Fix
Scope `declarationMap: false` to `vite-plugin-dts`'s `compilerOptions` (one block). The dev `tsconfig.json` keeps `declarationMap: true` so in-repo editor go-to-definition still works; only the **published** lib build drops the maps.

## Verified (`npm pack --dry-run`)
| | before | after |
|---|---|---|
| total files | 456 | **233** |
| `.d.ts.map` | 223 | **0** |
| `.d.ts` (kept) | 223 | 223 |
| size | 1.4 MB | 1.3 MB |

`dist/index.js`, `dist/cli.js`, `README.md`, `LICENSE`, `CHANGELOG.md` all still present; `@loopdive/js2@0.57.0`.

Pre-first-publish cleanup for the npm release (loopdive/js2#389).