### PR TITLE
refactor(#2181): close as done — scaffold landed via #2088; add cross-lane anchor test

### DIFF
--- a/plan/issues/2181-define-builtin-representation-scaffold.md
+++ b/plan/issues/2181-define-builtin-representation-scaffold.md
@@ -1,10 +1,12 @@
 ---
 id: 2181
 title: "defineBuiltin(name, {elementKinds, lower}) scaffold — unify per-representation element-load/ToString/null handling"
-status: ready
+status: done
 sprint: current
 created: 2026-06-16
-updated: 2026-06-24
+updated: 2026-06-28
+completed: 2026-06-28
+assignee: ttraenkler/agent-a20aa13da21b8d592
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -78,3 +80,49 @@ The entire scope is therefore still open: the `defineBuiltin(name, {elementKinds
 lower})` scaffold, the `join` + `fromCharCode` migration onto it across
 host/native/standalone, and the cross-lane "deliberate bug fails all lanes" guard
 (acceptance-2). Status stays `ready` for senior-dev pickup.
+
+## Resolution (2026-06-28, verify-first)
+
+**Done — already implemented on `main` via #2088, commit `563e2fe2`
+(`refactor(#2088): per-builtin representation scaffold for join + fromCharCode`,
+2026-06-17).** The 2026-06-17 "Remaining work" note above was a misattribution
+analysis of PR #1550 (a test262-runner harness change for #2183) and was written
+without awareness of the _real_ #2088 PR, which landed the scaffold the same day.
+
+The scaffold lives in `src/codegen/builtin-scaffold.ts`:
+
+- `StringRepr` strategy — the minimal per-representation seam (`literal`,
+  `concat`, `resultType`), with concrete `hostStringRepr` (JS-string / externref,
+  `wasm:js-string` `concat`) and `nativeStringRepr` (standalone / `$AnyString`,
+  pure-Wasm `__str_concat`).
+- `emitStringJoinFold` + `allocJoinFoldLocals` — the shared `join` loop owning
+  the separator placement and the empty-array→`""` (not `"null"`, the #1968 bug)
+  fallback **once**. Both `join` lanes route through it:
+  `array-methods.ts` native lane (≈5309) and host lane (≈5558).
+- `emitVariadicStringConcat` — the shared `fromCharCode`/`fromCodePoint` variadic
+  fold. `compileFromCharCodeFamily` (`expressions/calls.ts` ≈3043) serves all
+  four lanes (native helper × host import) from one definition, killing the
+  single-argument-drop (#2122 / #1955) at the source.
+
+Acceptance criteria met:
+
+- **AC1** — `join` + `fromCharCode` are each served by one shared definition of
+  the element-load/ToString/null-handling matrix across host + native lanes (the
+  per-element load is the intentional, genuinely-per-rep `elemToStr` seam; the
+  externref-receiver `__array_join_any` fallback is intentionally excluded — a
+  single host delegation with nothing to drift).
+- **AC2** — a deliberate bug in the shared `emitStringJoinFold` /
+  `emitVariadicStringConcat` regresses every lane at once; covered by the
+  multi-lane suites `tests/issue-2074.test.ts` (join, 3 lanes),
+  `tests/issue-2122.test.ts` (fromCharCode, 4 backends), and
+  `tests/issue-2088.test.ts`.
+
+Verified green on current main (`bf56e30`): 30 tests across
+`issue-2088` + `issue-2074` + `issue-2122`, plus this issue's named anchor
+`tests/issue-2181.test.ts` (cross-lane parity guard).
+
+Closing as `done`. No source change is warranted: the bounded first slice the
+issue prescribed (`join` + `fromCharCode` first, "then repeatable per builtin")
+has landed, and manufacturing a broader `defineBuiltin()` _registration_ registry
+across the fragile scanner sites — beyond what the acceptance criteria require —
+is exactly the speculative blast-radius the issue itself flagged as over the line.

--- a/tests/issue-2181.test.ts
+++ b/tests/issue-2181.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+// #2181 — per-builtin representation scaffold (carried forward from #2088).
+//
+// The scaffold that this issue tracks landed on `main` via #2088
+// (`src/codegen/builtin-scaffold.ts`): a single `StringRepr` strategy plus the
+// shared `emitStringJoinFold` / `allocJoinFoldLocals` (`join`) and
+// `emitVariadicStringConcat` (`fromCharCode` / `fromCodePoint`) primitives.
+// Each builtin lane now supplies only the genuinely per-representation element
+// load; the separator placement, the empty-array→"" fallback (the #1968 bug),
+// and the variadic concat structure are defined exactly once.
+//
+// This file is the named cross-lane anchor for #2181 (acceptance-(2)): it pins
+// BOTH the host JS-string lane and the standalone native-string lane of `join`
+// and `fromCharCode`/`fromCodePoint` to the same observable behaviour. A
+// deliberate bug introduced into the shared lowering regresses at least one
+// assertion in EVERY lane here — the structural guarantee the issue asks for.
+// (The element-load seam stays per-rep by design, and the externref-receiver
+// `__array_join_any` fallback is intentionally NOT routed through the scaffold —
+// a single host delegation with nothing to drift.)
+
+async function host(expr: string): Promise<unknown> {
+  const exports = await compileToWasm(`export function test(): string { return ${expr}; }`);
+  return (exports as { test: () => unknown }).test();
+}
+
+function envImports(imports: ReadonlyArray<{ module: string; name: string }>): string[] {
+  return imports.filter((i) => i.module === "env").map((i) => i.name);
+}
+
+// Compile a standalone (zero-host-import) module and return a numeric probe of
+// the produced string. Returning a number rather than the string keeps the
+// boundary host-free, so this genuinely exercises the native-string lane.
+async function standaloneNum(body: string): Promise<number> {
+  const r = await compile(`export function run(): number { ${body} }`, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const leaked = envImports(r.imports);
+  expect(leaked, `--target standalone leaked env imports: ${leaked.join(", ")}`).toEqual([]);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as Record<string, () => number>).run();
+}
+
+describe("#2181 join — one shared definition across lanes", () => {
+  // ── host JS-string lane (hostStringRepr + emitStringJoinFold) ──
+  it("host: string[] join content", async () => {
+    expect(await host(`["a","b","c"].join("-")`)).toBe("a-b-c");
+  });
+  it("host: number[] join coerces each element (#1998)", async () => {
+    expect(await host(`[1,2,3].join(",")`)).toBe("1,2,3");
+  });
+  it("host: empty array joins to '' not 'null' (#1968)", async () => {
+    expect(await host(`([] as number[]).join(",")`)).toBe("");
+  });
+  it("host: default separator is ','", async () => {
+    expect(await host(`[10,20].join()`)).toBe("10,20");
+  });
+
+  // ── standalone native-string lane (nativeStringRepr + emitStringJoinFold) ──
+  it("standalone: string[] join length + separator content", async () => {
+    // "a-b-c" → length 5; index 1 is the '-' separator (char code 45).
+    expect(await standaloneNum(`const a: string[] = ["a","b","c"]; return a.join("-").length;`)).toBe(5);
+    expect(await standaloneNum(`const a: string[] = ["a","b","c"]; return a.join("-").charCodeAt(1);`)).toBe(45);
+  });
+  it("standalone: number[] join coerces each element", async () => {
+    // "1,2,3" → length 5; index 0 is '1' (49), index 1 is ',' (44).
+    expect(await standaloneNum(`const a: number[] = [1,2,3]; return a.join(",").length;`)).toBe(5);
+    expect(await standaloneNum(`const a: number[] = [1,2,3]; return a.join(",").charCodeAt(1);`)).toBe(44);
+  });
+});
+
+describe("#2181 fromCharCode / fromCodePoint — one shared variadic concat", () => {
+  // ── host lane (hostStringRepr + emitVariadicStringConcat) ──
+  it("host: fromCharCode keeps ALL args (#2122 / #1955)", async () => {
+    expect(await host(`String.fromCharCode(104,105,33)`)).toBe("hi!");
+  });
+  it("host: fromCodePoint keeps ALL args incl. surrogate pair", async () => {
+    expect(await host(`String.fromCodePoint(97, 0x1F600)`)).toBe("a\u{1F600}");
+  });
+
+  // ── standalone native lane (nativeStringRepr + emitVariadicStringConcat) ──
+  it("standalone: fromCharCode keeps all args (length + content)", async () => {
+    // "hi!" → length 3; index 1 is 'i' (105).
+    expect(await standaloneNum(`return String.fromCharCode(104,105,33).length;`)).toBe(3);
+    expect(await standaloneNum(`return String.fromCharCode(104,105,33).charCodeAt(1);`)).toBe(105);
+  });
+  it("standalone: fromCodePoint keeps all args incl. surrogate pair", async () => {
+    // "a" (1 unit) + U+1F600 (2 surrogate units) = 3 UTF-16 units.
+    expect(await standaloneNum(`return String.fromCodePoint(97, 0x1F600).length;`)).toBe(3);
+  });
+});


### PR DESCRIPTION
## #2181 — per-builtin representation scaffold (verify-first closure)

**The scaffold #2181 tracks already landed on `main`** via #2088, commit `563e2fe2` (`src/codegen/builtin-scaffold.ts`, 2026-06-17). The 2026-06-17 "Remaining work" note in the issue was a *misattribution* analysis of PR #1550 (a test262-runner change for #2183), written without awareness of the real #2088 PR.

### What's already on main
- `StringRepr` strategy + `hostStringRepr` / `nativeStringRepr` — the per-representation seam (literal / concat / resultType).
- `emitStringJoinFold` + `allocJoinFoldLocals` — the shared `join` loop (separator placement + empty-array→`""` #1968 fallback) owned **once**. Both `join` lanes route through it (`array-methods.ts`).
- `emitVariadicStringConcat` — the shared `fromCharCode`/`fromCodePoint` fold; `compileFromCharCodeFamily` (`expressions/calls.ts`) serves all 4 lanes from one definition (kills the #2122/#1955 single-arg drop at source).

### Acceptance criteria — met
- **AC1**: `join` + `fromCharCode` each served by one shared definition across host + native lanes (per-element load is the intentional per-rep seam; the externref `__array_join_any` fallback is intentionally excluded — nothing to drift).
- **AC2**: a deliberate bug in the shared lowering regresses all lanes — covered by `tests/issue-2074.test.ts` (join, 3 lanes), `tests/issue-2122.test.ts` (fromCharCode, 4 backends), `tests/issue-2088.test.ts`.

### This PR (no source change, behavior-preserving)
- Flips `status: done` with a `## Resolution` section.
- Adds `tests/issue-2181.test.ts` — the named cross-lane parity anchor (10 tests: host + standalone lanes, content+length probes).

Verified green locally on `bf56e30`: 30 tests (issue-2088/2074/2122) + 10 (issue-2181). No `defineBuiltin()` *registration* registry is built — that broader scanner-site refactor is beyond the AC and is the speculative blast-radius the issue itself flagged as over the line.

Closes #2181.