### PR TITLE
ci(publish-npm): tokenless OIDC trusted publishing for @loopdive/js2

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -85,6 +85,10 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
+      # OIDC trusted publishing requires npm >= 11.5.1; Node 20 ships npm 10.x.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Install deps
         run: pnpm install --frozen-lockfile
 
@@ -94,24 +98,30 @@ jobs:
       - name: Pack @loopdive/js2 (dry-run preview)
         run: npm pack --dry-run
 
+      # Tokenless OIDC trusted publishing — no NODE_AUTH_TOKEN. npm authenticates
+      # to npmjs via the GitHub Actions OIDC token (id-token: write is granted at
+      # the workflow level), using the trusted publisher configured for
+      # @loopdive/js2. Provenance is attested automatically under OIDC.
       - name: Publish @loopdive/js2
         if: github.event_name == 'push' || inputs.dry-run == 'false'
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      # DISABLED: the unscoped js2wasm proxy is unpublished, has no trusted
+      # publisher, and pins @loopdive/js2 at a stale 0.52.0. Re-enable (and add
+      # its own trusted publisher + a dep bump) once you want `npm install
+      # js2wasm` to resolve. See loopdive/js2#389.
       - name: Publish js2wasm proxy
-        if: github.event_name == 'push' || inputs.dry-run == 'false'
+        if: false
         working-directory: packages/js2wasm
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-jsr:
     name: JSR publish (@loopdive/js2)
     runs-on: ubuntu-latest
     needs: publish-npm
-    if: github.event_name == 'push' || inputs.dry-run == 'false'
+    # DISABLED: JSR publishing needs its own OIDC link (jsr.io ↔ this repo) set
+    # up separately. Re-enable once the JSR package + GitHub link are configured.
+    if: false
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
## What
Convert the npm publish of **`@loopdive/js2`** to tokenless **OIDC trusted publishing** (you configured the trusted publisher on npm for `publish-npm.yml`).

- **Drop `NODE_AUTH_TOKEN`/`NPM_TOKEN`** — npm authenticates to npmjs via the GitHub Actions OIDC token (`id-token: write` is already granted workflow-level). No repo secret needed; provenance is attested automatically.
- **Upgrade npm to ≥ 11.5.1** in CI — OIDC trusted publishing requires it, and Node 20 ships npm 10.x.
- **Disable** the unscoped `js2wasm` proxy publish (unpublished, no trusted publisher, stale `@loopdive/js2@0.52.0` dep) and the **JSR** job (needs its own jsr.io↔repo OIDC link) via `if: false` — both clearly commented and re-enableable later.

## Context
`@loopdive/js2@0.57.0` was bootstrap-published manually (npm requires a package to exist before a trusted publisher can be attached). From the **next** release tag, `publish-npm.yml` ships `@loopdive/js2` tokenless with provenance — `node scripts/release.mjs <x.y.z>` → reviewed bump PR → tag → publish.

Per the @loopdive/js2-only decision for loopdive/js2#389.