### PR TITLE
fix(soundness): #2750 S1 — single-file .js gets the full sound strict umbrella (corpus-neutral)

### DIFF
--- a/src/checker/index.ts
+++ b/src/checker/index.ts
@@ -706,8 +706,22 @@ export function analyzeSource(source: string, fileName = "input.ts", analyzeOpti
   const compilerOptions: ts.CompilerOptions = {
     target: ts.ScriptTarget.ES2022,
     module: ts.ModuleKind.ESNext,
-    strict: !isJs,
+    // #2750 S1 — single-file `.js` now gets the FULL sound `strict` umbrella,
+    // matching both multi-file blocks (`analyzeMultipleFiles`/`analyzeFiles` at
+    // :1011/:1103, which set `strict: true` unconditionally). Previously
+    // `strict: !isJs` gave a single-file `.js` ONLY the pinned `strictNullChecks`
+    // (#2748 C), leaving `strictFunctionTypes`/`strictPropertyInitialization`/
+    // `useUnknownInCatchVariables`/… OFF — a latent single-file-vs-multi-file
+    // inconsistency. Sound flags keep type-directed codegen accurate.
+    strict: true,
+    // `strictNullChecks` is already implied by `strict: true`; kept explicit as
+    // the soundness-critical guard the #2748 C fix established (a `T|null`
+    // collapse changes the Wasm value-representation and folds null/undefined
+    // guards — the #2748 infinite-loop miscompile).
     strictNullChecks: true,
+    // BOUNDARY (#2750 Prong 1): `noImplicitAny` stays OFF for `.js` — rejecting
+    // untyped JS is NOT the goal; the dynamic/`any`/externref path handles it.
+    // This override MUST come after `strict: true` (which would enable it).
     noImplicitAny: false,
     noEmit: true,
     // Enable JSX parsing for .tsx/.jsx files. ReactJSX desugars JSX to

--- a/tests/issue-2750-s1.test.ts
+++ b/tests/issue-2750-s1.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #2750 S1 — single-file `.js` now gets the FULL sound `strict` umbrella
+// (`strict: true`), matching both multi-file analysis blocks, instead of only
+// the pinned `strictNullChecks` it got under the old `strict: !isJs`.
+//
+// The risk of `strict: true` for `.js` is that it could start REJECTING
+// previously-compiling untyped JS (e.g. via `noImplicitAny`). S1 keeps
+// `noImplicitAny: false` precisely so untyped `.js` is NOT rejected — the
+// dynamic/`any`/externref path handles it. These tests lock that boundary in:
+// untyped single-file `.js` must still compile and run, and the
+// soundness-critical `strictNullChecks` guard stays active.
+async function runJs(source: string, fn: string, args: unknown[] = []): Promise<unknown> {
+  const result = await compile(source, { fileName: "test.js" });
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>)[fn](...args);
+}
+
+describe("#2750 S1 — single-file .js gets the sound strict umbrella, noImplicitAny stays OFF", () => {
+  it("untyped .js arithmetic still compiles and runs (noImplicitAny OFF under strict:true)", async () => {
+    const src = `export function add(a, b) { return a + b; }`;
+    expect(await runJs(src, "add", [2, 3])).toBe(5);
+  });
+
+  it("untyped .js with an implicit-any local still compiles and runs", async () => {
+    const src = `export function sumTo(n) { let acc = 0; for (let i = 1; i <= n; i++) { acc += i; } return acc; }`;
+    expect(await runJs(src, "sumTo", [4])).toBe(10);
+  });
+
+  it("untyped .js boolean logic still compiles and runs", async () => {
+    const src = `export function pick(flag) { return flag ? 1 : 0; }`;
+    expect(await runJs(src, "pick", [true])).toBe(1);
+    expect(await runJs(src, "pick", [false])).toBe(0);
+  });
+
+  it(".js null comparison guard works (strictNullChecks active under strict:true)", async () => {
+    // `x === null` must stay a real runtime null check, not be folded away — the
+    // #2748 C soundness guard. A typed-any param keeps the dynamic path.
+    const src = `export function isNull(x) { return x === null ? 1 : 0; }`;
+    expect(await runJs(src, "isNull", [null])).toBe(1);
+    expect(await runJs(src, "isNull", [5])).toBe(0);
+  });
+});


### PR DESCRIPTION
Splits **S1** out of the parked S1+S2 umbrella PR #2198 and lands it on its own. S1 is **corpus-byte-neutral** and a clean `.js`-soundness win — banking it now while S2 awaits a direction call.

## What this is (S1 only)
`src/checker/index.ts` — single-file `analyzeSource` now sets `strict: true` for `.js` too (keeping the explicit `noImplicitAny: false` override), matching both multi-file blocks (`analyzeMultipleFiles`/`analyzeFiles`, which already set `strict: true` unconditionally). Previously `strict: !isJs` gave a single-file `.js` ONLY the pinned `strictNullChecks` (#2748 C), leaving the rest of the sound umbrella (`strictFunctionTypes`, `strictPropertyInitialization`, `useUnknownInCatchVariables`, …) OFF — a latent single-file-vs-multi-file inconsistency.

## Why it is corpus-byte-neutral
The test262/equivalence corpus compiles via `test.ts` filenames (`tests/test262-runner.ts` → `fileName: "test.ts"` → `isJs=false`), so `strict` was ALREADY `true` for every corpus compile. S1 only affects **real single-file `.js` input** (npm libs), which the corpus does not exercise. `noImplicitAny` stays OFF so untyped `.js` is not rejected — the dynamic/`any`/externref path handles it.

## What this deliberately does NOT include (S2)
The S2 externref-OOB→`undefined` flip (`useUndefinedSentinel=true` in `src/codegen/property-access.ts`) stays on **#2198**. Diagnosis showed S2 carries a **real, PR-caused** test262 regression — `built-ins/Array/prototype/map/15.4.4.19-8-b-2.js` (generic `Array.prototype.map` on an array-like whose `length`-getter side-effect adds an element mid-iteration; `testResult[2]` returns `2`, want `false`) — i.e. the sentinel flip perturbs a generic array-method path, not just genuine OOB. That is evidence the "patch the holes" shape may be wrong, which is a **direction call** (trust-the-type-and-patch vs JS-semantics-first), tracked separately. S2 is intentionally excluded here.

## Tests / checks
- `tests/issue-2750-s1.test.ts` (4 cases): untyped single-file `.js` still compiles + runs (the `noImplicitAny`-OFF boundary), and the `strictNullChecks` null guard stays active. All pass locally.
- `prettier --check`, `biome lint`, `tsc --noEmit` clean.
- No issue file added (no dup-id risk).

#2750 stays in-progress (S2 on #2198; S3/S4/S5 remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)