### PR TITLE
chore(plan): promote dispatched #1627/#2740/#2745 to sprint:current

### DIFF
--- a/plan/issues/1627-spec-gap-set-methods-set-like-arg.md
+++ b/plan/issues/1627-spec-gap-set-methods-set-like-arg.md
@@ -1,7 +1,7 @@
 ---
 id: 1627
 title: "spec gap: Set methods (union/intersection/etc.) accept any set-like argument (101 test262 fails)"
-status: ready
+status: in-progress
 created: 2026-05-08
 updated: 2026-06-19
 priority: medium
@@ -11,7 +11,7 @@ task_type: bugfix
 area: runtime
 language_feature: set
 goal: spec-completeness
-sprint: Backlog
+sprint: current
 renumbered_from: 1352
 parent: 1328
 ---

--- a/plan/issues/2740-instanceof-residual-noncallable-rhs-evalorder-hasinstance.md
+++ b/plan/issues/2740-instanceof-residual-noncallable-rhs-evalorder-hasinstance.md
@@ -1,8 +1,8 @@
 ---
 id: 2740
 title: "instanceof residual: non-callable RHS TypeError, null/undefined LHS, evaluation-order ReferenceError, Symbol.hasInstance arg count"
-status: ready
-sprint: 67
+status: in-progress
+sprint: current
 created: 2026-06-27
 updated: 2026-06-27
 priority: medium

--- a/plan/issues/2745-function-prototype-bind-partial-application-length-newtarget.md
+++ b/plan/issues/2745-function-prototype-bind-partial-application-length-newtarget.md
@@ -1,8 +1,8 @@
 ---
 id: 2745
 title: "Function.prototype.bind: bound partial-application arguments, bound `.length`/`.name`, construct newTarget forwarding, restricted-property poison"
-status: ready
-sprint: 67
+status: in-progress
+sprint: current
 created: 2026-06-27
 updated: 2026-06-27
 priority: medium


### PR DESCRIPTION
Promote three in-flight dispatched issues to sprint: current + status: in-progress so the live TaskList (synced from sprint:current) reflects work actually in progress and the sync won't re-offer them as claimable. Plan-only, no source changes.

- #1627 Set set-like methods (dev: builtins)
- #2740 instanceof residual (dev: instanceof)
- #2745 Function.prototype.bind (dev: bind)

🤖 Generated with [Claude Code](https://claude.com/claude-code)