### PR TITLE
docs(#2755): decide type-soundness approach — trust-the-type-and-patch vs JS-semantics-first

### DIFF
--- a/plan/issues/2755-evaluate-type-soundness-approach.md
+++ b/plan/issues/2755-evaluate-type-soundness-approach.md
@@ -1,0 +1,154 @@
+---
+id: 2755
+title: "Decide the type-soundness approach: trust-the-type-and-patch vs JS-semantics-first"
+status: ready
+sprint: current
+created: 2026-06-28
+updated: 2026-06-28
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: decision
+area: codegen, checker, type-system
+language_feature: none
+goal: correctness
+owner_role: product-owner
+related: [2698, 2748, 2750, 2754]
+---
+
+# #2755 — Decide the type-soundness approach (direction call)
+
+> **This is a DECISION issue, not an implementation issue.** It exists so the
+> project lead / stakeholder picks ONE of two directions before more code is
+> written under the #2698/#2750/#2754 "soundness" track. The #2750 S2 slice
+> surfaced concrete evidence that the two directions diverge in practice — that
+> evidence is captured below as the deciding data point.
+
+## Background
+
+TS is **deliberately unsound** in several places (array index access, `as`
+casts, covariant arrays, `any`, bivariant method params, …). This compiler
+*lowers TS types to Wasm value representations*, so wherever it **trusts a TS
+type that does not hold at runtime**, it can emit a Wasm binary that computes the
+wrong answer (a miscompile), not merely a type error. #2748 was the canonical
+incident: a `T | null` collapse folded null/undefined guards and produced an
+infinite-loop miscompile; the fix pinned `strictNullChecks`.
+
+The #2698/#2750/#2754 track generalized that point-fix into a policy with two
+prongs:
+
+1. **Prong 1 (type-level):** force the *sound* TS flags ON for both `.ts` and
+   `.js` (e.g. `strict: true`), so the checker hands codegen the most accurate
+   types it can. (This is **#2750 S1**, landed on PR #2205 — corpus-byte-neutral,
+   uncontroversial, and orthogonal to the question below.)
+2. **Prong 2 (codegen-level):** enumerate the remaining unsoundness holes (the
+   ones no flag closes — array OOB, etc.) and **patch each hole in codegen** so
+   the emitted Wasm matches JS runtime semantics. (This is **#2750 S2…S5**.)
+
+**The question this issue decides is about Prong 2's *shape*.**
+
+## The two directions
+
+### Direction A — "trust-the-type-and-patch" (the current #2750 plan)
+
+Keep lowering on the TS type, and close the known unsoundness holes one at a time
+in codegen (S2 = externref-array OOB → `undefined`; S5 = packed `T|undefined`
+representation; etc.). The type stays a **correctness contract**; we audit and
+patch the places where the contract is a lie.
+
+- **Pro:** preserves the type-directed codegen that makes this compiler fast
+  (packed `number[]`, monomorphic struct fields, no boxing) — most of the perf
+  story depends on trusting types.
+- **Pro:** incremental; each hole is a small slice.
+- **Con:** the hole catalog is **open-ended and not obviously enumerable** — you
+  only learn a hole exists when a test regresses. Each patch risks perturbing a
+  shared path (see the data point below).
+- **Con:** "sound flags + patch the holes" gives **no guarantee** of
+  JS-runtime-correctness; it reduces the surface without bounding it.
+
+### Direction B — "JS-semantics-first"
+
+Treat TS types as **optimization hints, never a correctness contract**. Codegen
+defaults to JS-runtime-correct behavior; a type only *unlocks a faster lowering*
+when the compiler can prove (or the mode asserts) the value can't escape the
+type. Where it can't prove it, fall back to the dynamic/`any`/externref path that
+is correct by construction.
+
+- **Pro:** correctness is the **default**, not a property you chase hole-by-hole.
+  No open-ended catalog.
+- **Pro:** matches the dual-mode architecture (the dynamic path already exists).
+- **Con:** large refactor of the type-directed fast paths; risks regressing perf
+  unless the "prove it's safe to specialize" analysis is good.
+- **Con:** the boundary "when is it safe to trust the type as a hint" is itself
+  subtle — moves the hard problem rather than removing it.
+
+## Deciding data point — #2750 S2's blast radius (concrete evidence)
+
+S2 was the *first* Prong-2 hole-patch attempted: flip externref-array
+out-of-bounds reads from `null` to JS `undefined` (`useUndefinedSentinel=true` at
+two `emitBoundsCheckedArrayGet` call sites in `src/codegen/property-access.ts`).
+It looked surgical. In the merge_group it produced:
+
+- **+7 test262 improvements, −1 regression, net +6** — but it tripped the 10%
+  regression-ratio gate (1/7 = 14.3%) and was auto-parked (PR #2198).
+- The single regression is **real and PR-caused** (wasm-hash changed; baseline
+  content-current): `built-ins/Array/prototype/map/15.4.4.19-8-b-2.js` —
+  `Array.prototype.map.call(obj, cb)` on an **array-like whose `length` getter
+  side-effect adds `obj[2]` mid-iteration**; `testResult[2]` now returns `2`,
+  spec wants `false`.
+- Attribution is decisive: the corpus compiles via `test.ts`
+  (`tests/test262-runner.ts` → `isJs=false`), so **S1 is a no-op on the corpus**;
+  both the +7 and the −1 come from **S2 alone**.
+
+**What this tells us:** a "surgical" OOB sentinel flip did **not** stay confined
+to genuine OOB — it perturbed a **generic `Array.prototype.map`-on-array-like**
+path. That is exactly the failure mode Direction A's critics predict: patching
+one hole shifts a shared representation and opens another. A single data point is
+not proof, but it is the strongest available signal that "patch the holes" is
+**leaky in practice**, not just in theory.
+
+## Recommendation (senior-developer)
+
+**Hybrid, sequenced — adopt Direction B as the *default/invariant*, keep
+Direction A's type-directed fast paths as a *proven-safe optimization*:**
+
+1. **Land Prong 1 unconditionally** (#2750 S1, PR #2205) — sound flags are pure
+   upside and direction-independent.
+2. **Adopt the Direction-B *framing* as the correctness invariant:** "a TS type
+   may only change the emitted Wasm when the value provably cannot violate the
+   type at runtime; otherwise lower the JS-correct way." This makes correctness
+   the default and turns every existing fast path into a thing we must *justify*,
+   not assume.
+3. **Re-evaluate each Prong-2 hole-patch (S2…S5) under that invariant** instead
+   of as standalone codegen edits. S2 specifically: don't re-land the
+   sentinel-flip as-is; either (a) make OOB-correctness fall out of the general
+   element-read path (B-style), or (b) prove the flip is byte-identical on every
+   non-OOB read before shipping. The map-on-array-like regression must be green
+   either way.
+4. **Do NOT pursue a full perf-path rewrite up front** — that is the expensive,
+   risky part of B and isn't justified by one data point. Convert paths to
+   "prove-then-specialize" opportunistically, regression-gated.
+
+Rationale: pure-A is open-ended and leaky (the S2 evidence); pure-B is a large
+speculative refactor that risks the perf story this compiler is built on. The
+hybrid keeps A's speed where it's *provably* safe and gets B's
+correctness-by-default everywhere else.
+
+## Decision needed (owner: project lead / PO)
+
+- [ ] Pick: **A**, **B**, or the **hybrid** above (or amend).
+- [ ] Given the pick, set the disposition of the open soundness PRs/issues:
+  - **#2198 (S2 code)** — currently parked with a real regression. Fix-on-branch
+    under the chosen direction, or close/supersede.
+  - **#2195 (spec docs, adds #2754)** — the "sound TS settings" spec. Keep,
+    revise to match the chosen direction, or close.
+  - **#2754 / #2698** — re-scope Prong 2 to the chosen direction.
+
+## Notes
+
+- #2750 S1 (PR #2205) is **independent of this decision** and should land
+  regardless — it only forces already-sound flags and is corpus-byte-neutral.
+- This issue supersedes the inline "evaluate the approach" research charter that
+  PR #2195 tried to add as `2751-evaluate-type-soundness-approach.md` (that id
+  collided with the budget-windowed-sprint issue already on `main`; this is the
+  freshly-allocated id).


### PR DESCRIPTION
Docs-only. Adds **#2755**, a **decision artifact** for the project lead to pick the type-soundness direction before more code lands under the #2698/#2750/#2754 track.

## Why
The #2750 S2 slice surfaced concrete evidence that the two candidate directions diverge in practice. Rather than keep shipping Prong-2 hole-patches and discovering the divergence per-regression, this issue puts the choice in front of the stakeholder with the evidence attached.

## Contents
- **Direction A — trust-the-type-and-patch** (the current #2750 plan): keep lowering on the TS type, close unsoundness holes one at a time in codegen. Pro: preserves the type-directed fast paths the perf story depends on. Con: open-ended, leaky hole catalog.
- **Direction B — JS-semantics-first**: TS types as optimization hints, never a correctness contract; JS-correct by default, specialize only when provably safe. Pro: correctness is the default. Con: large refactor, perf risk.
- **Deciding data point** — #2750 S2's blast radius: a "surgical" externref-OOB sentinel flip produced **net +6** test262 but a **real, PR-caused** regression in a generic `Array.prototype.map`-on-array-like path (`built-ins/Array/prototype/map/15.4.4.19-8-b-2.js`). Evidence that "patch the holes" is leaky in practice.
- **Recommendation** (senior-dev): sequenced hybrid — land Prong-1 sound flags unconditionally (#2750 S1, **PR #2205**, corpus-neutral); adopt B's correctness-by-default invariant; re-evaluate each Prong-2 hole-patch under it; avoid a speculative full perf rewrite.
- **Decision checklist** + disposition for #2198 / #2195 / #2754 / #2698.

Uses a freshly-allocated id (#2755); supersedes the inline charter PR #2195 tried to add as `2751-evaluate-type-soundness-approach.md` (id-collided with the budget-windowed-sprint issue already on main).

No code changes; one issue file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)