### PR TITLE
chore(pnpm): add bun and deno to onlyBuiltDependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 onlyBuiltDependencies:
   - '@biomejs/biome'
+  - bun
+  - deno
   - esbuild


### PR DESCRIPTION
Adds `bun` and `deno` to `onlyBuiltDependencies` in `pnpm-workspace.yaml` (alongside the existing `esbuild`), so pnpm runs their build/install scripts — needed for the bun/deno native-messaging example builds.

Authored locally by @ttraenkler; cherry-picked onto a branch so it lands on `main` via PR (it was a local-only commit not yet on upstream).