### PR TITLE
fix(#1627): Set set-algebra methods accept object-literal set-like args (host GetSetRecord)

### DIFF
--- a/plan/issues/1627-spec-gap-set-methods-set-like-arg.md
+++ b/plan/issues/1627-spec-gap-set-methods-set-like-arg.md
@@ -1,9 +1,11 @@
 ---
 id: 1627
 title: "spec gap: Set methods (union/intersection/etc.) accept any set-like argument (101 test262 fails)"
-status: ready
+status: done
 created: 2026-05-08
-updated: 2026-06-19
+updated: 2026-06-28
+completed: 2026-06-28
+assignee: ttraenkler/agent-a20aa13da21b8d592
 priority: medium
 feasibility: easy
 reasoning_effort: medium
@@ -11,10 +13,11 @@ task_type: bugfix
 area: runtime
 language_feature: set
 goal: spec-completeness
-sprint: Backlog
+sprint: current
 renumbered_from: 1352
 parent: 1328
 ---
+
 # #1352 — Set new methods: accept any set-like (size + has + keys)
 
 ## Problem
@@ -24,6 +27,7 @@ parent: 1328
 
 Spec §24.2.2.x (ES2025 stage 4): the new Set methods must accept any "set-like" object as their
 argument — defined as an object with:
+
 - `size` property (number)
 - `has(key)` method (returns boolean)
 - `keys()` method (returns iterator)
@@ -55,15 +59,15 @@ a structural-typing check via `GetSetRecord`:
 
 ```javascript
 function GetSetRecord(obj) {
-  if (typeof obj !== 'object' || obj === null) throw TypeError;
+  if (typeof obj !== "object" || obj === null) throw TypeError;
   const rawSize = obj.size;
   const numSize = ToNumber(rawSize);
   if (Number.isNaN(numSize)) throw TypeError;
   const intSize = Math.max(0, Math.trunc(numSize));
   const has = obj.has;
-  if (typeof has !== 'function') throw TypeError;
+  if (typeof has !== "function") throw TypeError;
   const keys = obj.keys;
-  if (typeof keys !== 'function') throw TypeError;
+  if (typeof keys !== "function") throw TypeError;
   return { Set: obj, Size: intSize, Has: has, Keys: keys };
 }
 ```
@@ -88,3 +92,73 @@ than `this.size`, iterate the argument; otherwise iterate `this`. This is also a
 ## Frontmatter reconcile (2026-06-12)
 
 Was `in-progress` with no open PR, no active agent, and no Suspended Work section (session died sprints 42-52). Reset to `ready` during the sprint-62 issue review; re-validate against current main before claiming (#2148).
+
+## Resolution (2026-06-28) — GetSetRecord host-bridge adapter
+
+### Verify-first magnitude recheck
+
+The "101 fails" in the title was a 2026-06-19 baseline. On current `main`
+(post-#1352/#2607 `_wrapForHost` bridge), `built-ins/Set` is **328/383 pass, 55
+non-pass** (52 fail + 3 compile_error). ~45 of the 55 are the set-like-arg
+cluster across the 7 set-algebra methods. Still the single biggest `built-ins`
+lever, so the scope was confirmed and taken.
+
+### Root cause (host / JS-host gc lane — the lane test262 conformance runs)
+
+The receiver crosses to the host as a **real JS `Set`**, so native V8's
+`Set.prototype[m]` runs the spec `GetSetRecord(other)` on the WasmGC-struct
+argument. The bridge (`resolveImport`, `runtime.ts`) wrapped that arg with the
+`_wrapForHost` proxy, whose **generic `__call_fn_N` fallback masks EVERY struct
+field as a callable `closureBridge`**. So native GetSetRecord:
+
+- saw a non-callable `has = {}` / `keys = {}` as _callable_ → no §24.2.1.2
+  `IsCallable` `TypeError` (`has-is-callable` / `keys-is-callable`);
+- saw a `size = {valueOf(){…}}` as a _function_, never `ToNumber`-coerced it →
+  the coercion side-effect never fired (`size-is-a-number`).
+
+### Fix (scoped, no global `_wrapForHost` change)
+
+`src/runtime.ts`:
+
+1. Extracted the proxy's field-resolution precedence into a module-level
+   `_resolveHostField(obj, key, exports)` (accessor getter → sidecar →
+   `__sget_` field getter → well-known-symbol sidecar → vivified prototype),
+   **behaviour-preserving** — `_wrapForHost` now calls it and applies its bridge
+   on top exactly as before.
+2. Added `_setLikeRecordForHost(arg, exports, state)`, used **only** by the 7
+   set-algebra methods, which reads each GetSetRecord field RAW and presents it
+   faithfully: a genuine closure (`__is_closure`) stays a callable bridge; a
+   non-closure struct (`{}`, `{valueOf}`) becomes a plain (non-callable)
+   `_wrapForHost` object; primitives/undefined pass through. Native
+   GetSetRecord's spec validation + coercion then fire correctly.
+
+### Result
+
+`built-ins/Set/prototype` set-algebra dirs: **141 → 159 pass (+18), 0
+regressions** (verified via `runTest262File` across all 186 files in the 7 method
+dirs). Overall `built-ins/Set` → **346/383 ≈ 90.3 %**, meeting acceptance
+criterion #4 (≥ 90 %). Acceptance #2 (`intersection/setlike-with-non-callable-keys`)
+and #3 (`difference/setlike-with-throwing-has`) are in the flipped set; #1
+(`union/set-like-arg.js`) does not exist in the vendored test262 (the modern
+suite splits it into the per-method files now covered). Guard:
+`tests/issue-1627.test.ts` (27 tests — 6 happy-path behavioural + 21
+GetSetRecord-validation flips). No regression in host-heavy suites
+(set-algebra / set-foreach / map-foreach / regexp lastIndex+proto-readers /
+loose-eq / spread / dynamic-new-spread).
+
+### Remaining tail (NOT this slice — separate root cause, follow-up)
+
+27 set-like fails remain, all needing host resolution the adapter cannot supply:
+
+- **class-instance set-likes** (`allows-set-like-class`, `set-like-class-order`,
+  `set-like-class-mutation` — 18): the host cannot resolve an anonymous
+  `new class { get size(){…} has(){…} *keys(){…} }` instance's **prototype**
+  getter/methods — `_resolveHostField` returns `undefined` for all three, so
+  GetSetRecord sees `size = undefined` → `NaN` → throws. Needs host
+  prototype-member resolution for anonymous class instances.
+- **`set-like-array`** (7): an array with dynamically-added `size`/`has`/`keys`
+  props — the props don't resolve through the struct/sidecar path used here.
+- **`set-like-iter-return`** (2): the iterator `return()` close protocol on the
+  `keys()` iterator ("`next` is not a function").
+  These should be carved as a follow-up issue; this slice meets the issue's
+  acceptance criteria and is closed `done`.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -4995,6 +4995,138 @@ function _ownStructKeys(obj: any, exports: Record<string, Function> | undefined)
   return _orderOwnKeysSpec(keys); // (#2131) array-index keys first, ascending
 }
 
+/**
+ * Resolve the RAW host-visible value of property `key` on a WasmGC struct,
+ * applying the same precedence the `_wrapForHost` proxy uses (accessor getter →
+ * sidecar → `__sget_` struct-field getter → well-known-symbol sidecar →
+ * vivified prototype) but WITHOUT the proxy `get` trap's closure-bridge
+ * wrapping. `_wrapForHost` calls this and then applies its bridge on top; other
+ * callers (e.g. GetSetRecord, which must distinguish a genuine callable from a
+ * non-callable object — #1627) need the unmasked underlying value. Returns
+ * `undefined` when nothing resolves.
+ */
+function _resolveHostField(obj: any, key: any, exports: Record<string, Function> | undefined): any {
+  // #1336 — accessor properties (Object.defineProperty(obj, k, {get})) must
+  // INVOKE the getter, not return a descriptor. Sidecar stores the descriptor
+  // function under `__get_<k>` (string) or in `_wasmStructAccessors` (symbol).
+  // #1935 — return `_MISS` ONLY when no getter is actually callable; a getter
+  // that runs and returns `undefined` is a genuine HIT that shadows the field.
+  const invokeGetter = (g: any): any => {
+    if (g == null) return _MISS;
+    if (typeof g === "function") return (g as Function).call(obj);
+    if (typeof g === "object" && _isWasmStruct(g) && exports) {
+      const callFn0 = exports["__call_fn_0"];
+      if (typeof callFn0 === "function") return callFn0(g);
+    }
+    return _MISS;
+  };
+  if (typeof key === "string") {
+    const wasmSc = _wasmStructProps.get(obj);
+    const getter = wasmSc?.[`__get_${key}` as string];
+    if (getter !== undefined) {
+      const v = invokeGetter(getter);
+      if (v !== _MISS) return v;
+    }
+  } else if (typeof key === "symbol") {
+    const accessor = _wasmStructAccessors.get(obj)?.get(key);
+    if (accessor?.get !== undefined) {
+      const v = invokeGetter(accessor.get);
+      if (v !== _MISS) return v;
+    }
+  }
+  // Sidecar first (handles both string and symbol keys)
+  const sc = _sidecarGet(obj, key);
+  if (sc !== undefined) return sc;
+  // Wasm struct field getter
+  if (exports && (typeof key === "string" || typeof key === "number")) {
+    const getter = exports[`__sget_${String(key)}`];
+    if (typeof getter === "function") {
+      try {
+        // (#1712) Treat a nullish result as a MISS, not a hit: the
+        // __sget_<name> per-shape dispatcher yields null/undefined when the
+        // receiver's struct shape doesn't carry the field at all.
+        const v = getter(obj);
+        if (v !== undefined && v !== null) return v;
+      } catch {
+        /* not a field of this struct type */
+      }
+    }
+  }
+  // Well-known symbol → @@name sidecar fallback (#1443).
+  if (typeof key === "symbol") {
+    const wasmKey = _symbolToWasm.get(key);
+    if (wasmKey !== undefined) {
+      const v = _sidecarGet(obj, wasmKey);
+      if (v !== undefined) return v;
+    }
+  }
+  // (#1712) fnctor instances: resolve through the constructor's vivified
+  // prototype object. Accessors run with the live-mirror proxy as the receiver.
+  const protoDesc = _fnctorProtoLookup(obj, key, exports);
+  if (protoDesc) {
+    if (process.env.DEBUG_1712)
+      console.error(
+        "[protoHook]",
+        String(key),
+        "valType=",
+        typeof protoDesc.value,
+        "exports?",
+        exports != null,
+        "is_closure?",
+        typeof exports?.__is_closure,
+      );
+    if (protoDesc.get) return protoDesc.get.call(_hostProxyCache.get(obj) ?? obj);
+    return _maybeWrapCallableUnknownArity(protoDesc.value, { getExports: () => exports });
+  }
+  return undefined;
+}
+
+/**
+ * (#1627) Build a clean, GetSetRecord-faithful set-like object from a WasmGC
+ * struct argument to a Set set-algebra method. The default `_wrapForHost` proxy
+ * masks EVERY wasm-struct field value as a callable `closureBridge` (the generic
+ * `__call_fn_N` fallback) — so native V8's GetSetRecord wrongly sees a
+ * non-callable object (`has = {}`) as callable and a `{valueOf}` size object as
+ * a function instead of a coercible object. This adapter reads each of the three
+ * GetSetRecord fields RAW and presents it faithfully:
+ *   - genuine closure  → the working proxy bridge (callable, generator-aware),
+ *   - non-closure wasm struct (`{}`, `{valueOf(){…}}`) → a `_wrapForHost` proxy
+ *     OBJECT (typeof "object", non-callable, exposes valueOf/toString),
+ *   - primitive / undefined → as-is.
+ * Native `Set.prototype[m]` then runs its own spec GetSetRecord on this object,
+ * so the callability throws + size ToNumber coercion happen per spec. Scoped to
+ * the 7 set-algebra methods only — no change to `_wrapForHost`'s own behaviour.
+ */
+function _setLikeRecordForHost(
+  arg: any,
+  exports: Record<string, Function> | undefined,
+  state: { getExports: () => Record<string, Function> | undefined } | undefined,
+): any {
+  const proxy = _wrapForHost(arg, exports);
+  const isClosureFn = exports?.__is_closure as ((v: any) => number) | undefined;
+  const fixField = (key: string): any => {
+    const raw = _resolveHostField(arg, key, exports);
+    if (raw != null && typeof raw === "object" && _isWasmStruct(raw)) {
+      let isClosure = false;
+      if (typeof isClosureFn === "function") {
+        try {
+          isClosure = isClosureFn(raw) === 1;
+        } catch {
+          /* discriminator unavailable — fall through to proxy */
+        }
+      }
+      // A non-closure wasm struct must NOT be presented as a function: expose it
+      // as a plain object so GetSetRecord throws on `has`/`keys` (non-callable)
+      // and coerces `size` via its valueOf/toString.
+      if (!isClosure) return _wrapForHost(raw, exports);
+    }
+    // Genuine closure or primitive/undefined: the existing proxy bridge already
+    // handles these correctly (callable closureBridge / raw value).
+    return proxy[key];
+  };
+  return { size: fixField("size"), has: fixField("has"), keys: fixField("keys") };
+}
+
 function _wrapForHost(obj: any, exports: Record<string, Function> | undefined): any {
   if (obj == null || typeof obj !== "object") return obj;
   if (!_isWasmStruct(obj)) return obj;
@@ -5004,98 +5136,9 @@ function _wrapForHost(obj: any, exports: Record<string, Function> | undefined): 
 
   const target: Record<string | symbol, any> = Object.create(null);
 
-  const safeGetField = (key: any): any => {
-    // #1336 — accessor properties (Object.defineProperty(obj, k, {get})) must
-    // INVOKE the getter, not return a descriptor. Sidecar stores the descriptor
-    // function under `__get_<k>` (string) or in `_wasmStructAccessors` (symbol).
-    // Note: getters defined in a TS object literal compile to a Wasm closure
-    // (typeof === "object"); call those via __call_fn_0 export.
-    // #1935 — return `_MISS` ONLY when no getter is actually callable. When a
-    // getter runs, its result (even `undefined`) is a genuine HIT and is
-    // returned as-is; the caller must distinguish `_MISS` from `undefined` so a
-    // getter that returns `undefined` shadows the underlying field per spec,
-    // instead of silently falling through to the sidecar/struct value.
-    const invokeGetter = (g: any): any => {
-      if (g == null) return _MISS;
-      if (typeof g === "function") return (g as Function).call(obj);
-      if (typeof g === "object" && _isWasmStruct(g) && exports) {
-        const callFn0 = exports["__call_fn_0"];
-        if (typeof callFn0 === "function") return callFn0(g);
-      }
-      return _MISS;
-    };
-    if (typeof key === "string") {
-      const wasmSc = _wasmStructProps.get(obj);
-      const getter = wasmSc?.[`__get_${key}` as string];
-      if (getter !== undefined) {
-        const v = invokeGetter(getter);
-        if (v !== _MISS) return v;
-      }
-    } else if (typeof key === "symbol") {
-      const accessor = _wasmStructAccessors.get(obj)?.get(key);
-      if (accessor?.get !== undefined) {
-        const v = invokeGetter(accessor.get);
-        if (v !== _MISS) return v;
-      }
-    }
-    // Sidecar first (handles both string and symbol keys)
-    const sc = _sidecarGet(obj, key);
-    if (sc !== undefined) return sc;
-    // Wasm struct field getter
-    if (exports && (typeof key === "string" || typeof key === "number")) {
-      const getter = exports[`__sget_${String(key)}`];
-      if (typeof getter === "function") {
-        try {
-          // (#1712) Treat a nullish result as a MISS, not a hit: the
-          // __sget_<name> per-shape dispatcher yields null/undefined when the
-          // receiver's struct shape doesn't carry the field at all (fnctor
-          // ctor-shape instances vs the wider checker shape that generated
-          // the export). Returning it unconditionally short-circuited the
-          // vivified-prototype fallback below and made every prototype
-          // method on a fnctor instance unreachable whenever the checker
-          // shape had synthesized a same-named field.
-          const v = getter(obj);
-          if (v !== undefined && v !== null) return v;
-        } catch {
-          /* not a field of this struct type */
-        }
-      }
-    }
-    // Well-known symbol → @@name sidecar fallback. Object literals like
-    // `{ [Symbol.replace]: fn }` mostly arrive as dynamic property
-    // assignments (`obj[Symbol.replace] = fn`) per ECMA-262 test patterns;
-    // those routes through `_safeSet` which mirrors to the sidecar (#1443).
-    if (typeof key === "symbol") {
-      const wasmKey = _symbolToWasm.get(key);
-      if (wasmKey !== undefined) {
-        const v = _sidecarGet(obj, wasmKey);
-        if (v !== undefined) return v;
-      }
-    }
-    // (#1712) fnctor instances: resolve through the constructor's vivified
-    // prototype object. Accessors run with the live-mirror proxy as the
-    // receiver so getter bodies reading `this.<field>` reach the struct.
-    // Values stored during the module START function were written before
-    // exports existed, so the write-side closure wrap no-op'd — wrap raw
-    // closure structs here, at read time, instead.
-    const protoDesc = _fnctorProtoLookup(obj, key, exports);
-    if (protoDesc) {
-      if (process.env.DEBUG_1712)
-        console.error(
-          "[protoHook]",
-          String(key),
-          "valType=",
-          typeof protoDesc.value,
-          "exports?",
-          exports != null,
-          "is_closure?",
-          typeof exports?.__is_closure,
-        );
-      if (protoDesc.get) return protoDesc.get.call(_hostProxyCache.get(obj) ?? obj);
-      return _maybeWrapCallableUnknownArity(protoDesc.value, { getExports: () => exports });
-    }
-    return undefined;
-  };
+  // (#1627) Resolution precedence lives in the module-level `_resolveHostField`
+  // so callers that need the unmasked raw value (GetSetRecord) can reuse it.
+  const safeGetField = (key: any): any => _resolveHostField(obj, key, exports);
 
   // #1047 — if `obj` was registered as a class prototype, surface only the
   // method names in the allowlist. Otherwise fall back to the struct-field
@@ -7339,7 +7382,15 @@ function resolveImport(
         return (self: any, ...args: any[]) => {
           if (self == null) return undefined;
           const exports = callbackState?.getExports();
-          const wrappedArgs = args.map((a) => (_isWasmStruct(a) ? _wrapForHost(a, exports) : a));
+          // (#1627) A wasm-struct set-like argument is presented through a
+          // GetSetRecord-faithful adapter rather than the raw `_wrapForHost`
+          // proxy: the proxy masks every struct field as a callable, defeating
+          // native GetSetRecord's `has`/`keys` IsCallable throws and `size`
+          // ToNumber coercion. The adapter exposes only size/has/keys, with
+          // non-closure objects kept non-callable so native validation fires.
+          const wrappedArgs = args.map((a) =>
+            _isWasmStruct(a) ? _setLikeRecordForHost(a, exports, callbackState) : a,
+          );
           const fn = self[m] ?? _sidecarGet(self, m);
           if (typeof fn === "function") return fn.call(self, ...wrappedArgs);
           return undefined;

--- a/tests/issue-1627.test.ts
+++ b/tests/issue-1627.test.ts
@@ -7,10 +7,12 @@
 // to bridge wasmGC structs through `_wrapForHost` so their sidecar properties
 // (`size`, `has`, `keys`) are visible to native JS access.
 
+import { existsSync } from "fs";
 import { describe, expect, it } from "vitest";
 
 import { compile } from "../src/index.js";
 import { buildImports } from "../src/runtime.js";
+import { runTest262File } from "./test262-runner.js";
 
 const ENV_STUB = {
   console_log_number: () => {},
@@ -185,4 +187,53 @@ describe("#1627 — Set methods accept set-like arguments", () => {
     `;
     expect(await runTest(src)).toBe(0);
   });
+});
+
+// ── GetSetRecord argument-validation flips (the actual #1627 host-mode fix) ──
+//
+// The receiver crosses to the host as a real JS `Set`, so native V8's
+// `Set.prototype[m]` runs the spec `GetSetRecord(other)` on the WasmGC-struct
+// argument. The historical bridge wrapped the arg with the `_wrapForHost` proxy,
+// whose generic `__call_fn_N` fallback masks EVERY struct field as a callable
+// `closureBridge` — so a non-callable `has = {}` looked callable (no TypeError)
+// and a `{valueOf(){…}}` size looked like a function (never ToNumber-coerced).
+//
+// The scoped `_setLikeRecordForHost` adapter (runtime.ts), used ONLY by the 7
+// set-algebra methods, reads each GetSetRecord field RAW (via the extracted
+// `_resolveHostField`) and presents non-closure structs as plain (non-callable)
+// objects, so native GetSetRecord's `IsCallable(has)`/`IsCallable(keys)` throws
+// and `ToNumber(size)` coercion fire per spec. These test262 files flip
+// fail→pass with the adapter.
+//
+// Out of scope (documented follow-up — separate root cause): class-instance
+// set-likes (`allows-set-like-class`, `set-like-class-{order,mutation}`), the
+// array-with-props case (`set-like-array`), and `set-like-iter-return` — those
+// need the host to resolve anonymous-class-instance prototype members / array
+// dynamic props / iterator `return`, not this adapter.
+const TEST262 = "/workspace/test262";
+const SET_PROTO = `${TEST262}/test/built-ins/Set/prototype`;
+const SET_METHODS = [
+  "union",
+  "intersection",
+  "difference",
+  "symmetricDifference",
+  "isSubsetOf",
+  "isSupersetOf",
+  "isDisjointFrom",
+];
+const VALIDATION_CASES = ["has-is-callable.js", "keys-is-callable.js", "size-is-a-number.js"];
+
+const maybe = existsSync(TEST262) ? describe : describe.skip;
+
+maybe("#1627 — GetSetRecord validation on object-literal set-like args (host mode)", () => {
+  for (const meth of SET_METHODS) {
+    for (const rel of VALIDATION_CASES) {
+      const file = `${SET_PROTO}/${meth}/${rel}`;
+      if (!existsSync(file)) continue; // not every method ships every case
+      it(`${meth}/${rel}`, async () => {
+        const r = await runTest262File(file, "built-ins/Set");
+        expect(r.status, `reason: ${(r as { reason?: string }).reason ?? ""}`).toBe("pass");
+      });
+    }
+  }
 });


### PR DESCRIPTION
## #1627 — Set methods accept any set-like argument (host/JS-host gc lane)

### Verify-first magnitude
The title's "101 fails" was a 2026-06-19 baseline. On current `main` (post-#1352/#2607 `_wrapForHost` bridge), `built-ins/Set` is **328/383 pass, 55 non-pass** — still the single biggest `built-ins` lever, so scope was confirmed.

### Root cause
A Set set-algebra receiver crosses to the host as a **real JS `Set`**, so native V8 runs spec `GetSetRecord(other)` on the WasmGC-struct argument. The bridge wrapped that arg with the `_wrapForHost` proxy, whose generic `__call_fn_N` fallback **masks EVERY struct field as a callable `closureBridge`** — so a non-callable `has = {}` looked callable (no §24.2.1.2 TypeError) and a `size = {valueOf(){…}}` looked like a function (never `ToNumber`-coerced).

### Fix (`src/runtime.ts`, scoped — no global `_wrapForHost` behaviour change)
1. Extract the proxy's field-resolution precedence into module-level `_resolveHostField` (**behaviour-preserving**; `_wrapForHost` now calls it then applies its bridge exactly as before).
2. Add `_setLikeRecordForHost`, used **only** by the 7 set-algebra methods: reads each GetSetRecord field RAW and presents it faithfully — genuine closure → callable bridge; non-closure struct (`{}`, `{valueOf}`) → plain non-callable object; primitive/undefined → as-is. Native GetSetRecord's `IsCallable` throws + `ToNumber(size)` coercion then fire per spec.

### Result
`built-ins/Set/prototype` set-algebra dirs: **141 → 159 pass (+18), 0 regressions** (verified via `runTest262File` across all 186 files in the 7 method dirs). Overall `built-ins/Set` → **346/383 ≈ 90.3%**, meeting acceptance criterion #4 (≥90%). AC #2 (`intersection/setlike-with-non-callable-keys`) and #3 (`difference/setlike-with-throwing-has`) are in the flipped set; AC #1 (`union/set-like-arg.js`) doesn't exist in the vendored test262 (modern suite splits it per-method, all covered).

Guard: `tests/issue-1627.test.ts` — 27 tests (6 happy-path behavioural + 21 GetSetRecord-validation flips). No regression in host-heavy suites (set-algebra / set-foreach / map-foreach / regexp lastIndex+proto-readers / loose-eq / spread / dynamic-new-spread). The 2 pre-existing broken suites (getters-setters missing `string_constants` import; computed-setter-class missing `./helpers.js`) reproduce identically on clean main.

### Remaining tail (documented follow-up — separate root cause, NOT this slice)
27 set-like fails remain: **class-instance set-likes** (18 — host can't resolve anonymous-`class`-instance prototype getter/methods), **`set-like-array`** (7 — array dynamic props), **`set-like-iter-return`** (2 — iterator `return` close protocol).

Closes #1627.