### PR TITLE
docs(#2674): close acorn 9th-wall (resolved by #2085); re-tag #2681/#2686 [ARCH] with sharpened root cause

### DIFF
--- a/plan/issues/2674-acorn-parse-9th-wall-past-tokenizer.md
+++ b/plan/issues/2674-acorn-parse-9th-wall-past-tokenizer.md
@@ -1,11 +1,12 @@
 ---
 id: 2674
 title: "acorn parse() 9th wall PAST tokenization (after #2664 type-write fix) — parseTopLevel/parseStatement array-push loop"
-status: in-progress
+status: done
 assignee: ttraenkler/sd-2674c
 sprint: current
 created: 2026-06-25
-updated: 2026-06-25
+updated: 2026-06-28
+completed: 2026-06-28
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -566,3 +567,22 @@ never matches) is exactly why, post-#2085, the identifier path reaches
 `unexpected()` and THROWS (#2681) instead of matching the `name` case. The 3 ranked
 fix directions + the banked `.tmp` probes apply to #2681. Recommend porting this
 analysis to #2681 and closing #2674 as resolved-by-#2085.
+
+## CLOSED — re-verified on current `origin/main` (2026-06-28, dev-acorn)
+
+Re-ran the dogfood probe against current `origin/main` (HEAD #2201, post-#2731;
+single-compile multi-input worker, `.tmp/verify-driver.mjs`). The 9th-wall HANG is
+gone — nothing blocks the event loop:
+
+| input | result on current main |
+|---|---|
+| `""` / `";"` | Program returned (bodyLen 0 / 1 EmptyStatement) |
+| `"1"` / `"1;"` / `"true;"` | Program returned — ExpressionStatement with a **Literal** `expression` (the #2687 `expression:null` symptom is no longer observed via the host marshalling either) |
+| `"x"` / `"var x = 1;"` / `"foo(bar);"` | THROW (→ #2681) |
+| `"1 + 2 * 3;"` | THROW (→ #2686) |
+
+Acorn now compiles in ~40s (not the ~290s noted earlier this chain). The
+non-termination this issue tracked is **RESOLVED** (by #2085). The remaining
+throws are tracked separately by #2681 (identifier/var path) and #2686 (binary
+path); their root cause is sharpened in those issues (Parser is NOT reconstructed
+as a `__fnctor_Parser` struct on current main — see #2681). Marking `done`.

--- a/plan/issues/2681-acorn-parse-10th-wall-unexpected-on-name.md
+++ b/plan/issues/2681-acorn-parse-10th-wall-unexpected-on-name.md
@@ -1,11 +1,11 @@
 ---
 id: 2681
-title: "acorn parse() 10th wall — identifier expression-statement throws (unexpected() on a `name` token) after the #2664 arity-dispatch fix"
+title: "[ARCH] acorn parse() 10th wall — identifier expression-statement throws (unexpected() on a `name` token); root cause = Parser not reconstructed (new this() in static methods), substrate-scoped"
 status: ready
 assignee: ttraenkler/unassigned
 sprint: current
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-06-28
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -190,3 +190,82 @@ architect/senior-dev-scoped; #2731 changes none of the inputs.
   AST — the #1712 differential needs #2687 fixed too. **TRUE #1712 GAP is larger
   than "just identifiers throw": even literal expression statements return
   `expression: null`.**
+
+## ROOT CAUSE SHARPENED + SUPERSEDED on current `origin/main` (2026-06-28, dev-acorn)
+
+Re-verified against current `origin/main` (HEAD #2201, post-#2731). `parse("x")`,
+`parse("var x = 1;")`, `parse("foo(bar);")` still THROW. The prior analysis (and
+the architect verdict) assumed acorn's `Parser` is a reconstructed
+`$__fnctor_Parser` struct (the "type 90" framing). **That is NO LONGER TRUE on
+current main** — and this changes the fix.
+
+### The decisive structural finding
+Dumped the full acorn WAT (emitWat) on current main and grepped the type section:
+- **There is NO `__fnctor_Parser` struct at all.** The fnctors that ARE
+  reconstructed: `__fnctor_Node`, `__fnctor_Token`, `__fnctor_TokenType`,
+  `__fnctor_Scope`, `__fnctor_Position`, `__fnctor_SourceLocation`,
+  `__fnctor_TokContext`, `__fnctor_RegExpValidationState`,
+  `__fnctor_DestructuringErrors`, `__fnctor_BranchID`. **Parser is the one that is
+  not.**
+- **Why:** acorn instantiates the parser ONLY via `new this(options, input)`
+  inside the STATIC methods `Parser.parse` / `parseExpressionAt` / `tokenizer`
+  (acorn.mjs:672/676/682) — there is **no `new Parser(...)` anywhere**. The fnctor
+  escape-gate (`analyzeFnctorEscapeGate`) classifies a fnctor for reconstruction
+  only at a `new <identifier>()` site; `new this()` has callee `this` →
+  `resolveFnctorSymbol(this)` is `undefined` → Parser is never seen as a
+  reconstruct site → it stays a **dynamic `$Object`**.
+- **Consequence (the actual #2681/#2686 mechanism):** `this.<field>` reads on the
+  parser instance go through the `$Object` / `__extern_get` host path, which
+  returns a value whose identity DIVERGES from the stored `__fnctor_TokenType`
+  struct. So `switch (this.type) { case types$1.<name>: … }` (the case labels
+  `types$1.name` read the raw `__fnctor_TokenType` structs) never matches its
+  discriminant → falls to `default → unexpected()` → THROW (#2681); the operator
+  path throws the same way (#2686).
+
+### Two candidate substrate fixes — both architect-scoped (NOT a dev slice)
+- **(A) escape-gate reconstruct of `new this()` in a static/prototype method.**
+  Teach `analyzeFnctorEscapeGate` to recognize `new this(...)` inside a function
+  assigned to `F.method = function(){…}` (resolve the enclosing method's owner `F`
+  — the same prototype/static-holder analysis used by the alias resolver) as an
+  `F` reconstruct site, so Parser gets a `__fnctor_Parser` struct. Then the read
+  path (below) + the existing write-mirror (`_safeSet`/`__sset_<key>`/#2664) close
+  the loop. **Broad escape-gate change** — reconstruction approval is the #2660
+  substrate, regression risk that needs full `merge_group` CI; it also must handle
+  the 35+ Parser fields and the `Object.defineProperties(Parser.prototype, …)`
+  accessors.
+- **(B) `$Object` dynamic reader preserves native struct-value identity.** Make
+  `__extern_get` / the `$Object` reader return the SAME `__fnctor_*` struct
+  externref that was stored, so `this.type` round-trips the TokenType identity even
+  while Parser stays a `$Object`. This is the foundational value-rep substrate item
+  (cf. `project_s64_value_rep_substrate_next`, "$Object dynamic reader drops native
+  values") and overlaps the value-rep / IR-migration scope — **A-vs-B is an
+  architect call.**
+
+### Banked: #2660 PART-2 read-dispatch wiring (correct, but INERT for Parser here)
+Prototyped (then reverted — NOT shipped) the designed #2660 PART-2 wiring:
+1. `resolveLiftedMethodThisStruct(ctx, arrow)` (in `expressions/fnctor-prototype.ts`)
+   — resolves a function-expression's `this` to `__fnctor_<F>` when it is a
+   `F.prototype.m = fn` / `var pp = F.prototype; pp.m = fn` method (handles the
+   aliased acorn `pp$N` form).
+2. `compileArrowAsClosure` (closures.ts) sets `liftedFctx.thisStructName` from it.
+3. A consumer in `compilePropertyAccess` (property-access.ts, BEFORE
+   `tryEmitDeleteAwareDynamicGet`) routes a resolved-`this` / flow-mapped read
+   through the deferred `__get_member_<name>` dispatcher (#2075) — finalize-time
+   struct-candidate resolution, `__extern_get` fallback.
+
+Verified it ENGAGES at acorn scale (the consumer fired 1704× with
+`thisStruct=__fnctor_Parser`, e.g. `prop=type`), and `__get_member_type` was
+emitted with a ref.test chain over `__fnctor_Node`/`__fnctor_Token`/`__anon_33`.
+But it is **INERT for the parser** precisely because `__fnctor_Parser` is never
+registered (finding above), so the Parser receiver matches none of the dispatcher's
+candidate `ref.test`s and falls back to the broken `__extern_get`. This wiring
+becomes load-bearing the moment fix (A) gives Parser a struct — keep it for the
+implementer of (A). It does NOT close #2681/#2686 on its own.
+
+Reusable probes banked: `.tmp/verify-driver.mjs` + `.tmp/verify-worker.mjs`
+(single-compile multi-input acorn `parse()` driver, worker-thread watchdog — acorn
+compiles in ~40s on this box now). `compile(..., { skipSemanticDiagnostics: true })`
+is required to get past acorn's semantic diagnostics.
+
+**Status: re-tagged `[ARCH]` / substrate-scoped — routed to architect for the
+A-vs-B decision. Not a quick dev slice.**

--- a/plan/issues/2686-acorn-binary-expression-throws.md
+++ b/plan/issues/2686-acorn-binary-expression-throws.md
@@ -1,11 +1,11 @@
 ---
 id: 2686
-title: "acorn parse() — binary-expression statement throws (parse(\"1 + 2 * 3;\") → WebAssembly.Exception)"
+title: "[ARCH] acorn parse() — binary-expression statement throws (parse(\"1 + 2 * 3;\") → WebAssembly.Exception); same root as #2681 (Parser not reconstructed), substrate-scoped"
 status: ready
 assignee: ttraenkler/unassigned
 sprint: current
 created: 2026-06-26
-updated: 2026-06-26
+updated: 2026-06-28
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -59,3 +59,20 @@ single acorn compile ~290s — reuse one compile).
 - Compiled-acorn `parse("1 + 2 * 3;")` returns a BinaryExpression AST matching
   node-acorn.
 - Full merge_group / test262 (codegen-adjacent).
+
+## SAME ROOT AS #2681 — substrate-scoped (2026-06-28, dev-acorn)
+
+Re-verified on current `origin/main` (#2201): `parse("1 + 2 * 3;")` still THROWS.
+Confirmed SAME root cause as #2681 — see #2681's `## ROOT CAUSE SHARPENED +
+SUPERSEDED` section for the full analysis. In short: acorn's `Parser` is NOT
+reconstructed as a `__fnctor_Parser` struct on current main (no such struct exists
+in the acorn WAT), because acorn only ever does `new this(...)` inside the static
+`Parser.parse`/etc — never `new Parser()` — so the fnctor escape-gate never
+classifies it. The parser instance stays a dynamic `$Object`, so `this.type` reads
+via `__extern_get` lose the `__fnctor_TokenType` identity; the operator-precedence
+path's token-type comparisons (`this.type === types$1.<op>` in `parseExprOp`) then
+fail the same way the #2681 identifier switch does → `unexpected()`/throw.
+
+Fix is one of the two substrate paths in #2681 (A: escape-gate reconstruct
+`new this()` sites; B: `$Object` reader struct-value identity) — architect call,
+NOT a quick dev slice. Re-tagged `[ARCH]`. Likely closes together with #2681.


### PR DESCRIPTION
## Summary

Verify-first pass on the acorn `parse()` expression-statement cluster (#2674, #2681, #2686) against current `origin/main`. **Docs/issue-tracking only — no source changes.**

- **#2674 (9th-wall HANG) → `status: done`.** Re-verified on current main: the `parse()` non-termination is gone (resolved by #2085, merged). `parse("")/";"/"1"/"1;"/"true;"` all return a `Program` AST; acorn now compiles in ~40s.
- **#2681 + #2686 → re-tagged `[ARCH]` (substrate-scoped).** Sharpened (and superseded) the prior `$__fnctor_Parser` "type 90" framing.

## #2681/#2686 sharpened root cause

On **current main there is NO `__fnctor_Parser` struct** in the acorn WAT — many other fnctors are reconstructed (`Node`, `Token`, `TokenType`, `Scope`, …) but **Parser is not**, because acorn instantiates it **only** via `new this(options, input)` inside the static `Parser.parse`/`parseExpressionAt`/`tokenizer` (`acorn.mjs:672`), **never `new Parser()`**. The fnctor escape-gate classifies a reconstruct site only at a `new <identifier>()` callee, so Parser stays a dynamic `$Object`. Its `this.<field>` reads then go through `__extern_get`, which loses the stored `__fnctor_TokenType` struct identity → `switch (this.type) { case types$1.<name>: … }` (and `parseExprOp`'s token-type compares) never match → `unexpected()` / throw.

Two candidate substrate fixes, both **architect-scoped** (need full `merge_group` CI, can't be validated by a dev locally):
- **(A)** teach the escape-gate to reconstruct `new this()` inside a static/prototype method as an `F` reconstruct site (Parser gets a struct);
- **(B)** make the `$Object` dynamic reader preserve native struct-value identity (the value-rep / IR-migration substrate item).

A-vs-B is an architect call → routed to architect. I also prototyped (and **reverted — not shipped**) the designed #2660 PART-2 read-dispatch wiring; it's correct and engages at acorn scale (1704×) but is **inert for Parser** because `__fnctor_Parser` is never registered. Full analysis + the banked wiring approach are recorded in the #2681 issue file for the implementer.

## Test plan

Docs-only (3 `plan/issues/*.md` files); no compiler behavior change. Verify-first evidence captured in the issue files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)