### PR TITLE
fix(codegen): #1336 symbol-keyed object literals create real Symbol properties

### DIFF
--- a/plan/issues/1336-spec-gap-object-assign-getter-iteration.md
+++ b/plan/issues/1336-spec-gap-object-assign-getter-iteration.md
@@ -1,9 +1,11 @@
 ---
 id: 1336
 title: "spec gap: Object.assign drops getters / Symbol keys (27 of 38 test262 fails)"
-status: ready
+status: done
+assignee: ttraenkler/sendev-soundness
 created: 2026-05-08
-updated: 2026-06-19
+updated: 2026-06-28
+completed: 2026-06-28
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -11,7 +13,7 @@ task_type: bugfix
 area: codegen, runtime
 language_feature: object
 goal: spec-completeness
-sprint: Backlog
+sprint: current
 parent: 1328
 ---
 # #1336 — Object.assign: getter invocation + Symbol-key copying
@@ -132,3 +134,61 @@ fails without those compiler changes.
 ## Frontmatter reconcile (2026-06-12)
 
 Was `in-progress` with no open PR, no active agent, and no Suspended Work section (session died sprints 42-52). Reset to `ready` during the sprint-62 issue review; re-validate against current main before claiming (#2148).
+
+## Verify-first re-scope + fix (2026-06-28, sendev-soundness)
+
+**Re-probed against current `origin/main` (de24f6c). The issue's 2026-05-08
+framing is partly stale: getter invocation now WORKS.** Probe results before the
+fix:
+
+| case | before | note |
+|------|--------|------|
+| `Object.assign(t, {get a(){return 42}})` → `t.a` | **42 ✓** | getters already invoked (prior `_wrapForHost` work) |
+| getter throw aborts iteration | **✓** | already correct |
+| `Object.defineProperty(o, sym, {value})` → `o[sym]` | **✓** | defineProperty-form symbol keys already work |
+| `const s = {[k]: 7}` (k=Symbol) → `s[k]` | **NaN ✗** | the real remaining gap |
+| `{[k]:7}` → `Object.getOwnPropertySymbols(s).length` | **0 ✗** | key not a real Symbol |
+| `{[k]:7}` → `Object.getOwnPropertyNames(s).length` | **1 ✗** | landed under STRING key |
+| `Object.assign`/spread of `{[k]:7}` | **NaN ✗** | source never had the symbol |
+
+### Root cause (precise)
+
+The gap is **upstream of Object.assign** — a computed **Symbol-keyed object
+LITERAL** drops symbol identity. A user `Symbol()` lowers to a bare **i32**
+counter id (`compileSymbolCall`, literals.ts). The #2126 runtime-computed-key
+WRITE path (`literals.ts` ~:573 data, ~:655 method) compiled the key with
+`compileExpression(ctx, fctx, prop.name.expression)` — **no expected-type
+hint** — then a manual `coerceType(i32 → externref)`, which boxes the id as a
+**NUMBER** (`__box_number`). So `{ [k]: 7 }` did `__extern_set(obj, 100, 7)` →
+the property landed under string key `"100"`. The element-READ path
+(`property-access.ts` → `compileExpression(..., {kind:"externref"})`) DOES box an
+`ESSymbolLike` i32 via `__box_symbol` (expressions.ts:753-762), so write/read
+disagreed → `o[k]` missed it; `getOwnPropertySymbols` saw nothing; `Object.assign`
+and spread (which CopyDataProperties off the real own-symbol set) had nothing to
+copy. Element-WRITE `o[k] = v` already passed the hint and was correct.
+
+### Fix (surgical, ~1 line × 2 sites)
+
+`src/codegen/literals.ts` — pass the `{ kind: "externref" }` expected-type hint to
+`compileExpression` at both #2126 computed-key sites (data property + method), so
+an ESSymbol key boxes via `__box_symbol` (a real JS Symbol), matching the
+read/write paths. Non-symbol runtime keys (number/string) are unaffected — the
+hint boxes those exactly as the prior `coerceType` did.
+
+After the fix all probe cases pass: `s[k]`=7, `getOwnPropertySymbols`=1,
+`getOwnPropertyNames`=0, `Object.assign`/spread copy the symbol, mixed
+string+symbol literals keep both, and controls (getter invoke, plain copy,
+numeric computed key) are unchanged.
+
+### Tests / checks
+- `tests/issue-1336.test.ts` — extended to 8 cases (2 prior + 6 new
+  symbol-literal cases incl. assign/spread/mixed + numeric-key control). All pass.
+- Regression sweep (suites importing the compiler directly): `computed-props`,
+  `issue-computed-props`, `object-literals`, `iterators`,
+  `issue-2029-disposablestack-static-read-standalone`, `issue-2151-spread-literal`
+  — all green. (`object-literal-getters-setters` / `computed-property-class`
+  error on a pre-existing `./helpers.js` module-resolution quirk in this shallow
+  worktree — reproduced with the fix stashed; unrelated to this change.)
+- `prettier`, `biome lint`, `tsc --noEmit` clean.
+- test262 `built-ins/Object/assign` delta confirmed by CI (the symbol-key bucket;
+  getters were already passing). Real test262 conformance is the CI gate.

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -570,7 +570,17 @@ function compileObjectLiteralWithAccessors(
         // pass it to __extern_set as the externref key. The host coerces a
         // non-string key (e.g. a boxed number) per ToPropertyKey.
         fctx.body.push({ op: "local.get", index: objLocal });
-        const keyType = compileExpression(ctx, fctx, prop.name.expression);
+        // (#1336) Pass the `externref` expected-type hint so an ESSymbol-typed
+        // key (a user `Symbol()`, lowered to a bare i32 id) is boxed into a REAL
+        // JS Symbol via `__box_symbol` — matching the element-READ path
+        // (property-access.ts → compileExpression(..., {kind:"externref"}),
+        // expressions.ts:753 ESSymbolLike arm). Without the hint the manual
+        // `coerceType(i32→externref)` below boxed the id as a NUMBER
+        // (`__box_number`), so `{ [k]: v }` landed under string key "<id>" and
+        // symbol identity was lost (getOwnPropertySymbols empty; `o[k]`,
+        // Object.assign, spread all missed it). A non-symbol runtime key
+        // (number/string) is unaffected — the hint boxes those exactly as before.
+        const keyType = compileExpression(ctx, fctx, prop.name.expression, { kind: "externref" });
         if (!keyType) {
           fctx.body.push({ op: "ref.null.extern" });
         } else if (keyType.kind !== "externref") {
@@ -652,7 +662,17 @@ function compileObjectLiteralWithAccessors(
         // (#2126) Runtime computed method key — same as the PropertyAssignment
         // branch: evaluate the key expression and pass it as the externref key.
         fctx.body.push({ op: "local.get", index: objLocal });
-        const keyType = compileExpression(ctx, fctx, prop.name.expression);
+        // (#1336) Pass the `externref` expected-type hint so an ESSymbol-typed
+        // key (a user `Symbol()`, lowered to a bare i32 id) is boxed into a REAL
+        // JS Symbol via `__box_symbol` — matching the element-READ path
+        // (property-access.ts → compileExpression(..., {kind:"externref"}),
+        // expressions.ts:753 ESSymbolLike arm). Without the hint the manual
+        // `coerceType(i32→externref)` below boxed the id as a NUMBER
+        // (`__box_number`), so `{ [k]: v }` landed under string key "<id>" and
+        // symbol identity was lost (getOwnPropertySymbols empty; `o[k]`,
+        // Object.assign, spread all missed it). A non-symbol runtime key
+        // (number/string) is unaffected — the hint boxes those exactly as before.
+        const keyType = compileExpression(ctx, fctx, prop.name.expression, { kind: "externref" });
         if (!keyType) {
           fctx.body.push({ op: "ref.null.extern" });
         } else if (keyType.kind !== "externref") {

--- a/tests/issue-1336.test.ts
+++ b/tests/issue-1336.test.ts
@@ -42,3 +42,58 @@ export function test(): number {
     expect((r as any).test()).toBe(6);
   });
 });
+
+// A computed Symbol-keyed object LITERAL (`{ [k]: v }`) previously dropped symbol
+// identity: the #2126 runtime-computed-key write path compiled the key without
+// an `externref` expected-type hint, so the symbol's i32 id was boxed as a
+// NUMBER (`__box_number`) instead of a real JS Symbol (`__box_symbol`). The
+// property landed under string key "<id>", so `o[k]`, getOwnPropertySymbols,
+// Object.assign and spread all missed it. (`defineProperty`-form symbol keys,
+// covered above, already worked.)
+describe("#1336 Symbol-keyed object LITERAL fidelity", () => {
+  it("reads back a symbol-keyed literal property", async () => {
+    const r = await compileToWasm(
+      `export function test(): number { const k = Symbol("k"); const s: any = { [k]: 7 }; return s[k] as number; }`,
+    );
+    expect((r as any).test()).toBe(7);
+  });
+
+  it("registers the literal key as a real Symbol, not a string", async () => {
+    const r1 = await compileToWasm(
+      `export function test(): number { const k = Symbol("k"); const s: any = { [k]: 7 }; return Object.getOwnPropertySymbols(s).length; }`,
+    );
+    expect((r1 as any).test()).toBe(1);
+    const r2 = await compileToWasm(
+      `export function test(): number { const k = Symbol("k"); const s: any = { [k]: 7 }; return Object.getOwnPropertyNames(s).length; }`,
+    );
+    expect((r2 as any).test()).toBe(0);
+  });
+
+  it("Object.assign copies a symbol-keyed literal property", async () => {
+    const r = await compileToWasm(
+      `export function test(): number { const k = Symbol("k"); const s: any = { [k]: 7 }; const t: any = {}; Object.assign(t, s); return t[k] as number; }`,
+    );
+    expect((r as any).test()).toBe(7);
+  });
+
+  it("object spread copies a symbol-keyed literal property", async () => {
+    const r = await compileToWasm(
+      `export function test(): number { const k = Symbol("k"); const s: any = { [k]: 7 }; const t: any = { ...s }; return t[k] as number; }`,
+    );
+    expect((r as any).test()).toBe(7);
+  });
+
+  it("mixed literal: string field and symbol key both survive", async () => {
+    const r = await compileToWasm(
+      `export function test(): number { const k = Symbol("k"); const s: any = { a: 1, [k]: 7 }; return (s.a as number) + Object.getOwnPropertySymbols(s).length; }`,
+    );
+    expect((r as any).test()).toBe(2);
+  });
+
+  it("CONTROL: numeric runtime computed key unchanged", async () => {
+    const r = await compileToWasm(
+      `export function test(): number { const s: any = { [1 + 1]: 7 }; return s[2] as number; }`,
+    );
+    expect((r as any).test()).toBe(7);
+  });
+});


### PR DESCRIPTION
Closes #1336.

## Verify-first re-scope
Re-probing #1336 against current `main` showed the 2026-05-08 framing is partly stale: **getter invocation already works** (`Object.assign(t, {get a(){return 42}})` → `t.a===42`), getter-throw-aborts works, and `defineProperty`-form Symbol keys work. The concrete remaining gap is **computed Symbol-keyed object LITERALS** (`{ [k]: v }`).

## Root cause
A user `Symbol()` lowers to a bare **i32** counter id (`compileSymbolCall`). The #2126 runtime-computed-key WRITE path in `src/codegen/literals.ts` compiled the key with `compileExpression(...)` (no expected-type hint) then a manual `coerceType(i32 → externref)`, which boxes the id as a **NUMBER** (`__box_number`). So `{ [k]: 7 }` ran `__extern_set(obj, 100, 7)` and the property landed under **string key `"100"`**: `o[k]` read `NaN`, `Object.getOwnPropertySymbols` was empty, and `Object.assign`/spread (which copy off the real own-symbol set) had nothing to copy. The element-**read** path already boxed ESSymbol i32 ids via `__box_symbol` (`expressions.ts:753-762`), so write/read disagreed.

## Fix (surgical)
Pass the `{ kind: "externref" }` expected-type hint to `compileExpression` at both #2126 computed-key sites (data property + method), so an ESSymbol key boxes via `__box_symbol` — a real JS Symbol — matching the read/write paths. Non-symbol runtime keys (number/string) are unaffected (the hint boxes them exactly as the prior `coerceType` did).

## Validation
- `tests/issue-1336.test.ts` extended to **8 cases** (2 prior + 6 new): symbol-literal read-back, `getOwnPropertySymbols`/`getOwnPropertyNames`, `Object.assign`, spread, mixed string+symbol literal, plus controls (getter invoke, plain copy, numeric computed key). All pass.
- Regression sweep (suites importing the compiler directly): `computed-props`, `issue-computed-props`, `object-literals`, `iterators`, `issue-2029-disposablestack-static-read-standalone`, `issue-2151-spread-literal` — all green.
- `prettier --check`, `biome lint`, `tsc --noEmit` clean.
- test262 `built-ins/Object/assign` delta (the Symbol-key bucket) confirmed by the CI regression gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)