### PR TITLE
plan(#2761): carve #1627 set-like-arg residual (class-instance/array/iter-return)

### DIFF
--- a/plan/issues/2761-set-like-arg-residual-class-instance-array-iter-return.md
+++ b/plan/issues/2761-set-like-arg-residual-class-instance-array-iter-return.md
@@ -1,0 +1,95 @@
+---
+id: 2761
+title: "Set set-algebra set-like-arg residual: class-instance set-likes (substrate-gated), set-like-array, iterator-return (27 test262 fails)"
+status: ready
+created: 2026-06-28
+updated: 2026-06-28
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: bug
+area: runtime
+language_feature: set
+goal: spec-completeness
+sprint: Backlog
+related: [1627, 2681, 2686]
+parent: 1627
+---
+
+# #2761 — Set set-algebra set-like-arg residual (carried over from #1627)
+
+## Origin
+
+#1627 fixed the **object-literal** set-like-argument cases for the 7 Set
+set-algebra methods (`union` / `intersection` / `difference` /
+`symmetricDifference` / `isSubsetOf` / `isSupersetOf` / `isDisjointFrom`) by
+adding a GetSetRecord-faithful host adapter (`_setLikeRecordForHost` +
+`_resolveHostField` in `src/runtime.ts`): the host `_wrapForHost` proxy masked
+every WasmGC-struct field as a callable, defeating native V8's
+`GetSetRecord(other)` `IsCallable`/`ToNumber` validation. That landed
+**built-ins/Set 328 → 346 / 383 (≈90.3 %)**.
+
+This issue tracks the **27 remaining** `built-ins/Set/prototype` set-like-arg
+fails, which have three distinct root causes the #1627 adapter cannot supply
+(each verified via `runTest262File` on the host/JS-host gc lane).
+
+## Sub-cause A — class-instance set-likes (18) **[SUBSTRATE-GATED / architect-scoped]**
+
+```
+{union,intersection,difference,symmetricDifference,isSubsetOf,isSupersetOf,isDisjointFrom}/allows-set-like-class.js   (7)
+{union,intersection,difference,symmetricDifference,isSubsetOf,isSupersetOf,isDisjointFrom}/set-like-class-order.js     (7)
+{union,intersection,difference,symmetricDifference}/set-like-class-mutation.js                                        (4)
+```
+
+A set-like built as `new class { get size(){…} has(){…} *keys(){…} }` reaches
+the host as an opaque WasmGC struct whose getter/methods live on the (anonymous
+class) **prototype**. `_resolveHostField` returns `undefined` for all of
+`size`/`has`/`keys` → native GetSetRecord reads `size = undefined` → `NaN` →
+throws TypeError, so a _valid_ set-like is rejected.
+
+**This is the SAME value-rep substrate theme as the acorn cluster #2681 / #2686**
+(`$Object` / dynamic reader loses native struct / prototype identity): the host
+cannot resolve an anonymous-class-instance's prototype members off the opaque
+struct. It should be folded into the value-rep / IR substrate roadmap and is
+**architect-scoped** — do NOT attempt a point fix in the Set adapter; the same
+gap recurs across every host consumer that reads members off a class-instance
+struct. Gate this sub-cause behind the proto-read / value-rep substrate work.
+
+## Sub-cause B — set-like-array (7) **[possibly independently tractable]**
+
+```
+{union,intersection,difference,symmetricDifference,isSubsetOf,isSupersetOf,isDisjointFrom}/set-like-array.js  (7)
+```
+
+`const s2 = [5,6]; s2.size = 3; s2.has = fn; s2.keys = fn;` — an array consumed
+as a set-like, not as an array. The dynamically-added `size`/`has`/`keys` props
+do not resolve through the struct/sidecar path `_resolveHostField` uses for a vec
+backing, so `size` reads as NaN. May be fixable independently of the substrate
+work by routing array dynamic-prop reads through the same sidecar lookup; worth a
+verify-first probe before assuming substrate-gated.
+
+## Sub-cause C — iterator-return (2) **[possibly independently tractable]**
+
+```
+isSupersetOf/set-like-iter-return.js
+isDisjointFrom/set-like-iter-return.js
+```
+
+`string "next" is not a function` — the `keys()` iterator's `return()` close
+protocol (IteratorClose on early exit) isn't bridged for the wasm-returned
+iterator. Likely independent of A/B; relates to the broader IteratorClose theme
+(#1642).
+
+## Acceptance criteria
+
+- Sub-cause B and C verify-first probed; if independently tractable, flip their
+  9 tests fail→pass with no regression in `built-ins/Set`.
+- Sub-cause A folded into the value-rep / proto-read substrate roadmap (tracked,
+  not point-fixed); flips the 18 class-instance fails once that substrate lands.
+- No regression in currently-passing `built-ins/Set` tests (host gc lane).
+
+## Notes
+
+- Guard from #1627: `tests/issue-1627.test.ts` (27 tests). Extend it as B/C land.
+- Host adapter entry points to reuse: `_setLikeRecordForHost` /
+  `_resolveHostField` in `src/runtime.ts` (the 7 set-algebra methods' bridge).


### PR DESCRIPTION
Follow-up to #1627 (merged: object-literal set-like-arg cases fixed, built-ins/Set → ~90.3%). Doc-only: carves the **27 remaining** `built-ins/Set/prototype` set-like-arg fails into one tracked issue with three root causes:

- **A — class-instance set-likes (18)** — SUBSTRATE-GATED / architect-scoped. Host can't resolve an anonymous `new class { get size(){…} … }` instance's **prototype** members off the opaque WasmGC struct → same value-rep substrate theme as the acorn cluster #2681/#2686. Folds into the value-rep / IR roadmap; no point fix.
- **B — set-like-array (7)** — array dynamic props (`s2.size=3; s2.has=fn; s2.keys=fn`) don't resolve through the vec sidecar path. Possibly independently tractable (verify-first probe noted).
- **C — iterator-return (2)** — `keys()` iterator `return()` close protocol unbridged (`"next" is not a function`). Possibly independently tractable (relates to #1642).

Tagged `sprint: Backlog`, `priority: medium`. Reuses the #1627 host adapter entry points (`_setLikeRecordForHost` / `_resolveHostField`). New id reserved via `claim-issue.mjs --allocate` (#2761).