### PR TITLE
fix(#2745): bound-function partial-application args, [[Construct]] args, restricted-property poison

### DIFF
--- a/plan/issues/2745-function-prototype-bind-partial-application-length-newtarget.md
+++ b/plan/issues/2745-function-prototype-bind-partial-application-length-newtarget.md
@@ -1,7 +1,8 @@
 ---
 id: 2745
 title: "Function.prototype.bind: bound partial-application arguments, bound `.length`/`.name`, construct newTarget forwarding, restricted-property poison"
-status: in-progress
+status: done
+completed: 2026-06-28
 assignee: ttraenkler/agent-a3bfd116a51704f18
 sprint: current
 created: 2026-06-27
@@ -67,3 +68,48 @@ args** (`f.bind(o, 1)(2)` should call `f(1, 2)`):
   §10.4.1, `[[Call]]`/`[[Construct]]` of bound functions §10.4.1.1-2.
 - Cross-realm tests (`get-fn-realm*.js`, `proto-from-ctor-realm.js`) depend on
   realm/Reflect infra and are out of scope.
+
+## Test Results (2026-06-28)
+
+`built-ins/Function/prototype/bind` directory: **66 → 85 pass / 100 (+19,
+0 regressions)**.
+
+Root causes fixed:
+- **(a) partial-application + over-arity arguments** — the bound-function
+  wrapper in `__bind_function` (`src/runtime.ts`) used a *fixed-arity*
+  `_wrapWasmClosure(target, lengthHint)` bridge that truncated call-time args to
+  the target's declared formal count, so a target reading `arguments[i]` past
+  its formals never saw the bound/call args. Replaced with a dedicated VARIADIC
+  bridge that dispatches at `max(args.length, realArity)` (plain `__call_fn_n`
+  for `undefined`/`null`/`globalThis` this, `__call_fn_method_n` for a real
+  object receiver). All 7 `15.3.4.5.1-4-*` pass.
+- **dispatcher `__argc` double-count** (`src/codegen/index.ts`) — the
+  `__call_fn_N` `#820l` plumbing set `__argc = arity` (raw dispatcher arity)
+  instead of the clamped-to-formals `closureArity` that `emitArgumentsVecBody`
+  (`totalLen = argc + extrasLen`) and `maybeSetArgcForKnownCall`
+  (`min(actual, paramCount)`) expect, so an over-arity HOF callback reported a
+  *doubled* `arguments.length`. Fixed to `entry.closureArity`, and the same
+  plumbing was ADDED to `emitClosureMethodCallExportN` (method dispatch
+  previously forwarded no extras at all). Now matches V8.
+- **(b) `[[Construct]]`** — `new boundFn(...)` routed through
+  `__construct(callee, NULL)` (the provably-non-constructable throw path) and so
+  constructed with ZERO args. The `resolvesToNonConstructableValue` →
+  `__construct` arm (`src/codegen/expressions/new-super.ts`) now builds and
+  passes the real call args; bound functions construct correctly and newTarget
+  is forwarded by the native bound function. All 7 listed `15.3.4.5.2-4-*` pass.
+- **(d) restricted-property poison** — `bound.arguments = {}` / `bound.caller =
+  {}` were swallowed by `_safeSet`'s sloppy-builtin catch. The strict pre-check
+  now resolves accessor descriptors along the prototype chain (skipping user
+  proxies) and propagates the inherited %ThrowTypeError% poison setter's
+  exception. `BoundFunction_restricted-properties.js` passes.
+
+Deferred (separate concerns, not regressions):
+- **(c) `instance-length-*`** — requires (1) a *configurable* `length` on the
+  host-wrapped wasm function so the test's `Object.defineProperty(foo,"length")`
+  succeeds, and (2) bind reading the target's *runtime* `.length` rather than
+  the compile-time `lengthHint`. Both are property-model changes orthogonal to
+  bind; tracked as follow-up.
+- **`instance-construct-newtarget-self-new`** — `new.target === A` needs
+  new-target identity threaded through the host bound-function bridge; deferred.
+- `15.3.4.5-6-*` (Function.prototype dynamic property inheritance through the
+  bound externref) and the realm tests remain pre-existing/out-of-scope.

--- a/plan/issues/2745-function-prototype-bind-partial-application-length-newtarget.md
+++ b/plan/issues/2745-function-prototype-bind-partial-application-length-newtarget.md
@@ -1,10 +1,11 @@
 ---
 id: 2745
 title: "Function.prototype.bind: bound partial-application arguments, bound `.length`/`.name`, construct newTarget forwarding, restricted-property poison"
-status: ready
-sprint: 67
+status: in-progress
+assignee: ttraenkler/agent-a3bfd116a51704f18
+sprint: current
 created: 2026-06-27
-updated: 2026-06-27
+updated: 2026-06-28
 priority: medium
 feasibility: medium
 reasoning_effort: medium

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -3938,16 +3938,27 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
           : (s1Callee as ts.NonNullExpression).expression;
     }
     if (ts.isIdentifier(s1Callee) && !noJsHost(ctx) && resolvesToNonConstructableValue(ctx, s1Callee)) {
-      // Evaluate `f` to an externref value (the held callee).
+      // Evaluate `f` to an externref value (the held callee), stash in a local.
       const calleeTy = compileExpression(ctx, fctx, s1Callee, { kind: "externref" });
       if (calleeTy && calleeTy.kind !== "externref") {
         coerceType(ctx, fctx, calleeTy, { kind: "externref" });
       } else if (calleeTy === null) {
         fctx.body.push({ op: "ref.null.extern" });
       }
-      // argsArray — null externref (the A7 cases never reach construction; the
-      // TypeError is thrown by the IsConstructor check before args are used).
-      fctx.body.push({ op: "ref.null.extern" });
+      const calleeLocal = allocLocal(fctx, `__ctor_callee_${fctx.locals.length}`, { kind: "externref" });
+      fctx.body.push({ op: "local.set", index: calleeLocal });
+
+      // (#2745 b) Build a JS array of the call-site args. A `.bind()` result is
+      // a constructable bound function when its target is a constructor, and
+      // `new boundFn(...)` must apply the bound + call args (and forward
+      // newTarget). The non-constructable A7 cases (arrow / prototype-method /
+      // `.call`/`.apply` value) still throw at the `__construct` IsConstructor
+      // check — before the args are used — so passing real args is harmless for
+      // them and is the spec-correct evaluation order (args evaluated, then
+      // Construct). The previous null-args path silently constructed bound
+      // functions with ZERO args (test262 `15.3.4.5.2-4-*`).
+      const arrNewIdx = ensureLateImport(ctx, "__js_array_new", [], [{ kind: "externref" }]);
+      const arrPushIdx = ensureLateImport(ctx, "__js_array_push", [{ kind: "externref" }, { kind: "externref" }], []);
       const funcIdx = ensureLateImport(
         ctx,
         "__construct",
@@ -3955,14 +3966,30 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
         [{ kind: "externref" }],
       );
       flushLateImportShifts(ctx, fctx);
-      if (funcIdx !== undefined) {
-        fctx.body.push({ op: "call", funcIdx });
+      const finalArrNew = ctx.funcMap.get("__js_array_new") ?? arrNewIdx;
+      const finalArrPush = ctx.funcMap.get("__js_array_push") ?? arrPushIdx;
+      const finalConstruct = ctx.funcMap.get("__construct") ?? funcIdx;
+      if (finalArrNew !== undefined && finalArrPush !== undefined && finalConstruct !== undefined) {
+        fctx.body.push({ op: "call", funcIdx: finalArrNew });
+        const argvLocal = allocLocal(fctx, `__ctor_argv_${fctx.locals.length}`, { kind: "externref" });
+        fctx.body.push({ op: "local.set", index: argvLocal });
+        for (const arg of args) {
+          fctx.body.push({ op: "local.get", index: argvLocal });
+          const aTy = compileExpression(ctx, fctx, ts.isSpreadElement(arg) ? arg.expression : arg, {
+            kind: "externref",
+          });
+          if (aTy && aTy.kind !== "externref") {
+            coerceType(ctx, fctx, aTy, { kind: "externref" });
+          } else if (aTy === null) {
+            fctx.body.push({ op: "ref.null.extern" });
+          }
+          fctx.body.push({ op: "call", funcIdx: finalArrPush });
+        }
+        fctx.body.push({ op: "local.get", index: calleeLocal });
+        fctx.body.push({ op: "local.get", index: argvLocal });
+        fctx.body.push({ op: "call", funcIdx: finalConstruct });
         return { kind: "externref" };
       }
-      // Import unavailable (shouldn't happen in JS-host): drop callee+args and
-      // fall through to the existing unknown-ctor path below.
-      fctx.body.push({ op: "drop" });
-      fctx.body.push({ op: "drop" });
     }
 
     // (#1632b-2 / #1528a residual) `new C(args)` where `C` is a runtime FUNCTION

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -3520,8 +3520,19 @@ function emitClosureCallExportN(ctx: CodegenContext, arity: number): void {
     // [1..arity]; the closure declares `closureArity ≤ arity` formals. The
     // receive-side (emitArgumentsVecBody) reads __argc + __extras_argv to
     // build `arguments` with all `arity` slots populated.
+    //
+    // (#2745) `__argc` follows the CLAMPED-to-formals convention that
+    // `emitArgumentsVecBody` (`totalLen = argc + extrasLen`),
+    // `maybeSetArgcForKnownCall` (`min(actual, paramCount)`) and the inline
+    // array-method plumbing all use: it is the count of FORMAL params filled
+    // (`closureArity`), NOT the raw dispatcher arity. The overflow args go to
+    // `__extras_argv`, so `arguments.length = argc + extrasLen = arity`. Setting
+    // `__argc = arity` here instead double-counted the extras (e.g. an arity-0
+    // closure called via `__call_fn_3` reported `arguments.length === 6`), which
+    // broke bound-function over-arity forwarding (the bound `[[Call]]` prepends
+    // partial args, so the target sees more args than its declared formals).
     const setupInstrs: Instr[] = [
-      { op: "i32.const", value: arity } as Instr,
+      { op: "i32.const", value: entry.closureArity } as Instr,
       { op: "global.set", index: argcGlobalIdx } as Instr,
     ];
     if (arity > entry.closureArity) {
@@ -3755,6 +3766,16 @@ function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number): void 
   addUnionImports(ctx);
   const boxNumberIdx = ctx.funcMap.get("__box_number");
   const currentThisGlobalIdx = ensureCurrentThisGlobal(ctx);
+  // (#2745) Same #820l argc/extras plumbing as `emitClosureCallExportN`, so a
+  // method-dispatched closure's `arguments` object observes over-arity args
+  // (the receiver-bound bound-function `[[Call]]` / `[[Construct]]` path, and
+  // any `o.m(...extra)` method call). Without this the method dispatch left
+  // `__argc`/`__extras_argv` untouched, so a bound target reading
+  // `arguments[i]` past its formals (e.g. `func.bind(obj)` then `newFunc(1)`)
+  // never saw the extra args.
+  const argcGlobalIdx = ensureArgcGlobal(ctx);
+  const { globalIdx: extrasArgvGlobalIdx, vecTypeIdx: extrasVecTypeIdx } = ensureExtrasArgvGlobal(ctx);
+  const extrasArrTypeIdx = getArrTypeIdxFromVec(ctx, extrasVecTypeIdx);
 
   const params: ValType[] = [];
   for (let i = 0; i < totalParams; i++) params.push({ kind: "externref" });
@@ -3813,7 +3834,30 @@ function emitClosureMethodCallExportN(ctx: CodegenContext, arity: number): void 
       argInstrs.push(...buildArgConversion(i + 2, paramType));
     }
 
+    // (#2745) #820l argc/extras plumbing (clamped-to-formals convention; see
+    // emitClosureCallExportN). User args are at locals [2..arity+1]; formal i is
+    // at local i+2, extras are args[closureArity..arity) at locals
+    // [closureArity+2 .. arity+2).
+    const setupInstrs: Instr[] = [
+      { op: "i32.const", value: entry.closureArity } as Instr,
+      { op: "global.set", index: argcGlobalIdx } as Instr,
+    ];
+    if (arity > entry.closureArity) {
+      const extrasCount = arity - entry.closureArity;
+      setupInstrs.push({ op: "i32.const", value: extrasCount } as Instr);
+      for (let i = entry.closureArity; i < arity; i++) {
+        setupInstrs.push({ op: "local.get", index: i + 2 } as Instr);
+      }
+      setupInstrs.push({ op: "array.new_fixed", typeIdx: extrasArrTypeIdx, length: extrasCount } as Instr);
+      setupInstrs.push({ op: "struct.new", typeIdx: extrasVecTypeIdx } as Instr);
+      setupInstrs.push({ op: "global.set", index: extrasArgvGlobalIdx } as Instr);
+    } else {
+      setupInstrs.push({ op: "ref.null", typeIdx: extrasVecTypeIdx } as Instr);
+      setupInstrs.push({ op: "global.set", index: extrasArgvGlobalIdx } as Instr);
+    }
+
     const callBody: Instr[] = [
+      ...setupInstrs,
       { op: "local.get", index: anyLocal } as Instr,
       { op: "ref.cast", typeIdx: entry.selfTypeIdx } as Instr,
       ...argInstrs,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -4527,15 +4527,46 @@ function _safeSet(
   //     default) must silently no-op, not throw (S8.5_A9, S8.12.4_A1, S8.6.1_A1).
   //     A non-writable data-property write that the engine itself surfaces under
   //     a genuinely-strict caller is still propagated by the catch arm below.
-  if (strict && (typeof key === "string" || typeof key === "symbol")) {
-    const ownDesc = Object.getOwnPropertyDescriptor(obj, key as PropertyKey);
-    if (ownDesc && ownDesc.get && !ownDesc.set) {
-      throw new TypeError(`Cannot set property ${String(key)} of #<Object> which has only a getter`);
+  // (#2745 d) An ACCESSOR property resolved along the prototype chain whose
+  // [[Set]] is present (e.g. the %ThrowTypeError% poison on a bound function's
+  // inherited `caller`/`arguments`, §10.4.1 / §10.2.4) — its setter exception
+  // must propagate, not be swallowed by the catch below. Resolved here so the
+  // write can run and any throw be re-raised.
+  let strictAccessorWrite = false;
+  if (strict && (typeof key === "string" || typeof key === "symbol") && !_isUserProxy(obj)) {
+    // Walk obj + prototype chain for the property descriptor, bailing on any
+    // user Proxy link so we never fire a Proxy MOP trap (#2017 kept the check
+    // own-only for exactly this reason; the explicit proxy guard lets us look
+    // up the chain safely now).
+    let cur: any = obj;
+    let desc: PropertyDescriptor | undefined;
+    while (cur != null && (typeof cur === "object" || typeof cur === "function")) {
+      if (_isUserProxy(cur)) {
+        desc = undefined;
+        break;
+      }
+      const d = Object.getOwnPropertyDescriptor(cur, key as PropertyKey);
+      if (d) {
+        desc = d;
+        break;
+      }
+      cur = Object.getPrototypeOf(cur);
+    }
+    if (desc && (desc.get || desc.set)) {
+      if (!desc.set) {
+        // Getter-only accessor (own or inherited) → strict [[Set]] throws.
+        throw new TypeError(`Cannot set property ${String(key)} of #<Object> which has only a getter`);
+      }
+      // Accessor WITH a setter — invoke it via the write below; propagate throws.
+      strictAccessorWrite = true;
     }
   }
   try {
     obj[key] = val;
   } catch (e) {
+    // (#2745 d) A genuine accessor-setter exception (e.g. the bound-function
+    // poison pill) must reach the user's try/catch — never divert to sidecar.
+    if (strictAccessorWrite) throw e;
     // #2180/#2617 — writing to a revoked proxy throws TypeError; a tracked user
     // Proxy's `set` trap may also throw (abrupt completion) or the host engine
     // may raise the §10.5.9 strict-write invariant TypeError. Propagate both
@@ -10314,72 +10345,95 @@ assert._isSameValue = isSameValue;
       if (name === "__bind_function")
         return (target: any, thisArg: any, argsArray: any, nameHint: any, lengthHint: number): any => {
           let callable: any = target;
-          if (_isWasmStruct(target)) {
-            const arity = typeof lengthHint === "number" && lengthHint >= 0 ? lengthHint : 0;
-            const wrapped = _wrapWasmClosure(target, arity, callbackState);
-            if (wrapped) {
-              callable = wrapped;
-              // Stamp hints onto the wrapper so the bound function inherits
-              // them via the host's own `Function.prototype.bind` (which
-              // computes `name = "bound " + target.name` and copies
-              // `length = max(0, target.length - boundArgs.length)`).
-              try {
-                if (typeof nameHint === "string" && nameHint.length > 0) {
-                  Object.defineProperty(callable, "name", {
-                    value: nameHint,
-                    configurable: true,
-                  });
-                }
-                if (typeof lengthHint === "number" && lengthHint >= 0) {
-                  Object.defineProperty(callable, "length", {
-                    value: lengthHint,
-                    configurable: true,
-                  });
-                }
-              } catch {
-                /* readonly host envs — ignore, bound fn just inherits wrapper defaults */
+          if (_isWasmStruct(target) && callbackState) {
+            // (#2745 a/b) Bridge the Wasm-closure target with a dedicated
+            // VARIADIC wrapper that forwards EVERY effective argument to the
+            // closure with a correct `arguments` object. A bound function's
+            // `[[Call]]` prepends the bound partial args (and `[[Construct]]`
+            // also runs the body), so the wrapper can receive more args than
+            // the target's declared arity — every one must reach the closure's
+            // `arguments`. The old fixed-arity `_wrapWasmClosure(target,
+            // lengthHint)` bridge truncated to `lengthHint` formals, so a target
+            // reading `arguments[i]` past its formals (e.g. `function(){ return
+            // arguments[0]; }`, arity 0) never saw the bound/call args.
+            //
+            // Dispatch rules:
+            //   • `n = max(args.length, realArity)` — high enough that the
+            //     closure (arity ≈ realArity) is matched by the dispatcher AND
+            //     every passed arg is forwarded; clamped to an emitted arity.
+            //   • Receiver-bound (`this` is a real object: an explicit object
+            //     `boundThis`, or the fresh `[[Construct]]` object) →
+            //     `__call_fn_method_n` (threads `this` via `__current_this`).
+            //   • Otherwise (`undefined`/`null`/`globalThis` this) →
+            //     `__call_fn_n` (plain dispatch).
+            //   Both dispatchers now carry the #820l argc/extras plumbing
+            //   (clamped-to-formals `__argc`), so `arguments` is exact.
+            const realArity = typeof lengthHint === "number" && lengthHint >= 0 ? lengthHint : 0;
+            const captured = target;
+            const cbState = callbackState;
+            const boundBridge = function boundWasmTargetBridge(this: any, ...args: any[]): any {
+              const ex = cbState.getExports();
+              if (!ex) {
+                throw new TypeError("Function.prototype.bind: target closure is not callable");
               }
-            } else if (callbackState) {
-              // (#1337) Exports aren't bound yet — this happens for
-              // module-level `const bound = fn.bind(...)`, which runs during
-              // instantiation *before* `setExports`. We can't build the
-              // `__call_fn_<arity>` bridge now, but we can build a JS function
-              // that resolves it lazily at call time (exports are populated by
-              // then) and stamp the spec metadata immediately so deferred
-              // `.name` / `.length` reads are correct. Without this the bound
-              // value degraded to the raw wasm-struct (an object), so
-              // `bound.name` / `bound.length` / `bound()` all failed.
-              const arity2 = typeof lengthHint === "number" && lengthHint >= 0 ? lengthHint : 0;
-              const captured = target;
-              const lazyBridge = function lazyWasmClosureBridge(...args: any[]): any {
-                const ex = callbackState.getExports();
-                const callFn = ex?.[`__call_fn_${arity2}`];
-                if (typeof callFn !== "function") {
-                  throw new TypeError("Function.prototype.bind: target closure is not callable");
-                }
-                const padded: any[] = [];
-                for (let i = 0; i < arity2; i++) padded.push(args[i]);
-                return callFn(captured, ...padded);
-              };
-              callable = lazyBridge;
-              try {
-                if (typeof nameHint === "string" && nameHint.length > 0) {
-                  Object.defineProperty(callable, "name", { value: nameHint, configurable: true });
-                }
-                if (typeof lengthHint === "number" && lengthHint >= 0) {
-                  Object.defineProperty(callable, "length", { value: lengthHint, configurable: true });
-                }
-              } catch {
-                /* readonly host envs — bound fn inherits wrapper defaults */
+              const useMethod = this !== undefined && this !== null && this !== globalThis;
+              const prefix = useMethod ? "__call_fn_method_" : "__call_fn_";
+              // Choose dispatch arity: prefer max(args.length, realArity), clamp
+              // DOWN to an emitted dispatcher; if that drops below realArity,
+              // bump UP to the lowest emitted dispatcher ≥ realArity so the
+              // target closure is still matched.
+              let n = Math.max(args.length, realArity);
+              while (n > 0 && typeof ex[`${prefix}${n}`] !== "function") n--;
+              if (n < realArity) {
+                let up = realArity;
+                while (up <= 12 && typeof ex[`${prefix}${up}`] !== "function") up++;
+                if (typeof ex[`${prefix}${up}`] === "function") n = up;
               }
-            } else {
-              // No callbackState at all (e.g. caller used raw `buildImports`
-              // without setExports support). Degrade gracefully to
-              // identity-bind: return the original target so callers that
-              // only need a non-null function value continue to work.
-              // Pre-#1632a behaviour for this hostless path.
-              return target;
+              let callFn = ex[`${prefix}${n}`];
+              let viaMethod = useMethod;
+              if (typeof callFn !== "function") {
+                // Method dispatcher of this arity missing — fall back to plain.
+                callFn = ex[`__call_fn_${n}`];
+                viaMethod = false;
+              }
+              if (typeof callFn !== "function") {
+                throw new TypeError("Function.prototype.bind: target closure is not callable");
+              }
+              const padded: any[] = [];
+              for (let i = 0; i < n; i++) padded.push(args[i]);
+              if (viaMethod) {
+                const rawThis = this !== null && typeof this === "object" ? _unwrapForHost(this) : this;
+                return callFn(_isWasmStruct(rawThis) ? rawThis : this, captured, ...padded);
+              }
+              return callFn(captured, ...padded);
+            };
+            callable = boundBridge;
+            // Stamp hints onto the wrapper so the bound function inherits
+            // them via the host's own `Function.prototype.bind` (which
+            // computes `name = "bound " + target.name` and copies
+            // `length = max(0, target.length - boundArgs.length)`).
+            try {
+              if (typeof nameHint === "string" && nameHint.length > 0) {
+                Object.defineProperty(callable, "name", {
+                  value: nameHint,
+                  configurable: true,
+                });
+              }
+              if (typeof lengthHint === "number" && lengthHint >= 0) {
+                Object.defineProperty(callable, "length", {
+                  value: lengthHint,
+                  configurable: true,
+                });
+              }
+            } catch {
+              /* readonly host envs — ignore, bound fn just inherits wrapper defaults */
             }
+          } else if (_isWasmStruct(target)) {
+            // No callbackState at all (e.g. caller used raw `buildImports`
+            // without setExports support). Degrade gracefully to identity-bind:
+            // return the original target so callers that only need a non-null
+            // function value continue to work. Pre-#1632a behaviour.
+            return target;
           }
           if (typeof callable !== "function") {
             // Non-callable receiver (typed-struct that isn't a closure, or

--- a/tests/issue-2745.test.ts
+++ b/tests/issue-2745.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #2745 — Function.prototype.bind residual: bound partial-application args,
+// bound [[Construct]] arg concatenation, restricted-property poison, plus the
+// HOF over-arity `arguments.length` correctness the dispatcher fix restores.
+async function run(source: string): Promise<unknown> {
+  const r = await compile(source, { fileName: "test.ts" });
+  if (!r.success) {
+    throw new Error(`Compile failed: ${r.errors.map((e) => `L${e.line}: ${e.message}`).join("; ")}`);
+  }
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports as unknown as WebAssembly.Imports);
+  (imports as { setExports?: (e: Record<string, Function>) => void }).setExports?.(
+    instance.exports as Record<string, Function>,
+  );
+  return (instance.exports as Record<string, () => unknown>).test();
+}
+
+describe("#2745 Function.prototype.bind residual", () => {
+  // ---- (a) bound partial-application arguments + over-arity forwarding ----
+
+  it("bound function forwards call-time args to a 0-formal target's arguments", async () => {
+    expect(
+      await run(`
+        function func() { return arguments[0] === 1; }
+        export function test(): number {
+          var newFunc = Function.prototype.bind.call(func);
+          return newFunc(1) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("bound this + over-arity arguments are all observed", async () => {
+    expect(
+      await run(`
+        var obj = { prop: "abc" };
+        var func = function(x) {
+          return this === obj && x === 1 && arguments[1] === 2 &&
+            arguments[0] === 1 && arguments.length === 2 && this.prop === "abc";
+        };
+        export function test(): number {
+          var newFunc = Function.prototype.bind.call(func, obj);
+          return newFunc(1, 2) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("bound partial args concatenate before call-time args", async () => {
+    expect(
+      await run(`
+        function func() {
+          return arguments.length === 2 && arguments[0] === 1 && arguments[1] === 2;
+        }
+        export function test(): number {
+          var newFunc = Function.prototype.bind.call(func, undefined, 1);
+          return newFunc(2) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  // ---- (b) bound [[Construct]] applies bound + call args ----
+
+  it("new boundFn(...) applies the call-time args and returns the instance", async () => {
+    expect(
+      await run(`
+        var func = function(x, y, z) {
+          var o = {};
+          o.returnValue = x + y + z;
+          o.ok = arguments[0] === "a" && arguments.length === 3;
+          return o;
+        };
+        export function test(): number {
+          var NewFunc = Function.prototype.bind.call(func, {});
+          var inst = new NewFunc("a", "b", "c");
+          return (inst.returnValue === "abc" && inst.ok === true) ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("new boundFn(...) concatenates bound partial args with construct args", async () => {
+    expect(
+      await run(`
+        var func = function(a, b, c) {
+          return new Boolean(a === 1 && b === 2 && c === 3 && arguments.length === 3);
+        };
+        export function test(): number {
+          var NewFunc = Function.prototype.bind.call(func, {}, 1, 2);
+          var inst = new NewFunc(3);
+          return inst.valueOf() === true ? 1 : 0;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  // ---- (d) restricted caller/arguments poison ----
+
+  it("writing bound.arguments throws a catchable TypeError", async () => {
+    expect(
+      await run(`
+        function target() {}
+        export function test(): number {
+          var bound = target.bind(null);
+          var threw = 0;
+          try { (bound as any).arguments = {}; } catch (e) { if (e instanceof TypeError) threw = 1; }
+          return threw;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("reading bound.caller throws a catchable TypeError", async () => {
+    expect(
+      await run(`
+        function target() {}
+        export function test(): number {
+          var bound = target.bind(null);
+          var threw = 0;
+          try { var x = (bound as any).caller; } catch (e) { if (e instanceof TypeError) threw = 1; }
+          return threw;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  // ---- regression guard: HOF over-arity arguments.length must be exact ----
+  // The dispatcher #820l `__argc` convention is now clamped-to-formals, so an
+  // arity-mismatched callback's `arguments.length` matches V8 (was doubled).
+
+  it("forEach callback sees arguments.length === 3 (value,index,array)", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          var seen = 0;
+          [10, 20].forEach(function() { seen = arguments.length; });
+          return seen;
+        }
+      `),
+    ).toBe(3);
+  });
+
+  it("map callback (1 formal) sees arguments.length === 3", async () => {
+    expect(
+      await run(`
+        export function test(): number {
+          var arr = [5].map(function(v: number) { return arguments.length; });
+          return arr[0];
+        }
+      `),
+    ).toBe(3);
+  });
+});


### PR DESCRIPTION
## #2745 — Function.prototype.bind residual

Fixes 3 of the 4 concrete bind bugs (groups **a/b/d**). Net test262
`built-ins/Function/prototype/bind`: **66 → 85 of 100 (+19, 0 regressions** in
the directory).

### Root causes fixed
- **(a) partial-application + over-arity `arguments`** — `__bind_function`
  (`src/runtime.ts`) wrapped the wasm-closure target with a *fixed-arity*
  `_wrapWasmClosure(target, lengthHint)` bridge that truncated call-time args to
  the target's declared formals, so a target reading `arguments[i]` past its
  formals never saw the bound/call args. Replaced with a dedicated **variadic**
  bridge dispatching at `max(args.length, realArity)` (plain `__call_fn_n` for an
  `undefined`/`null`/`globalThis` this, `__call_fn_method_n` for a real object
  receiver / `[[Construct]]`). All 7 `15.3.4.5.1-4-*` pass.
- **dispatcher `__argc` double-count** (`src/codegen/index.ts`) — `__call_fn_N`
  set `__argc = arity` (raw dispatcher arity) instead of the clamped-to-formals
  `closureArity` convention that `emitArgumentsVecBody`
  (`totalLen = argc + extrasLen`) and `maybeSetArgcForKnownCall`
  (`min(actual, paramCount)`) expect, so an over-arity HOF callback reported a
  *doubled* `arguments.length`. Fixed, and the same `#820l` plumbing was **added
  to `emitClosureMethodCallExportN`** (method dispatch forwarded no extras at
  all). Now matches V8 — a latent correctness fix beyond bind.
- **(b) `[[Construct]]`** — `new boundFn(...)` routed through
  `__construct(callee, NULL)` (the provably-non-constructable throw path) and so
  built with **zero args**. The `resolvesToNonConstructableValue -> __construct`
  arm (`src/codegen/expressions/new-super.ts`) now builds and passes the real
  call args; non-constructable A7 cases still throw at the IsConstructor check
  (before args are used). All 7 listed `15.3.4.5.2-4-*` pass.
- **(d) restricted-property poison** — `bound.arguments = {}` / `bound.caller =
  {}` were swallowed by `_safeSet`'s sloppy-builtin catch. The strict pre-check
  now resolves accessor descriptors along the prototype chain (skipping user
  proxies, so no Proxy MOP trap fires) and propagates the inherited
  `%ThrowTypeError%` poison setter's exception.
  `BoundFunction_restricted-properties.js` passes.

### Deferred (separate concerns, not regressions)
- **(c) `instance-length-*`** — needs a *configurable* host-wrapper `length` +
  bind reading the target's *runtime* `.length` (property-model, orthogonal).
- **`instance-construct-newtarget-self-new`** — `new.target === A` identity
  threading through the host bridge.
- `15.3.4.5-6-*` / realm tests remain pre-existing / out-of-scope.

### Validation
- `tests/issue-2745.test.ts` (9 cases: a/b/d + HOF `arguments.length` regression
  guard) — all green.
- Targeted regression check vs clean `origin/main`: `class-methods`,
  `default-params`, `issue-1337-bind-call`, `issue-1528-closure-construct`,
  `functional-array-methods`, etc. — identical pass set (the pre-existing
  `{ env: {} }` / missing-`helpers.js` harness failures are unchanged).
- `tsc --noEmit` + `biome lint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)