### PR TITLE
fix(codegen): clamp vec-rest length in array assignment-destructuring (#2757 partial)

### DIFF
--- a/plan/issues/2757-assign-dstr-rest-hole-wrong-value.md
+++ b/plan/issues/2757-assign-dstr-rest-hole-wrong-value.md
@@ -1,0 +1,113 @@
+---
+id: 2757
+title: "Assignment-destructuring (expressions/assignment): rest element + undefined/hole binds wrong value / 'array too large' trap"
+status: ready
+assignee: ttraenkler/unassigned
+created: 2026-06-28
+updated: 2026-06-28
+priority: high
+feasibility: medium
+reasoning_effort: high
+task_type: bug
+area: codegen
+es_edition: 2015
+language_feature: destructuring
+goal: spec-completeness
+parent: 2669
+related: [2669]
+sprint: current
+---
+# #2757 — assignment-destructuring rest/hole wrong value
+
+Carved from the #2669 destructuring umbrella (sd-dstr-objdefault, 2026-06-28).
+The **assignment** destructuring path (`[a, ...r] = x`, i.e.
+`expressions/assignment/dstr/`) — distinct file/codegen from binding-pattern
+destructuring, so independently shippable in parallel with #2756/#2758.
+
+## Repro (verified on current `origin/main` @ #2201)
+
+```ts
+// TRAP: "requested new array is too large"  (want x === undefined)
+let x: any, r: any;
+[x, ...r] = [];
+```
+test262 (fresh single-file, FAIL):
+```
+language/expressions/assignment/dstr/array-rest-nested-obj-undefined-own.js
+  -> returned 2 | assert #1 at L28: assert.sameValue(x, undefined)
+language/expressions/assignment/dstr/array-rest-nested-obj-undefined-hole.js
+  -> same
+```
+The rest element drained from a short/empty source mis-sizes the new array
+(trap), and a present-but-`undefined` / hole element in assignment destructuring
+binds the underlying value rather than `undefined`.
+
+## Scope
+
+- `expressions/assignment/dstr/` cluster — **149** total non-pass; this slice is
+  the **rest-element + elision/hole value-binding** subset that does NOT involve
+  a generator source (those route to #2566) or a custom iterable (those route to
+  the iterator-protocol tail / #2662). Est net recovery: **~40–60**.
+- The assignment path differs from binding patterns: the targets are arbitrary
+  assignment LHS (member exprs, identifiers), not fresh bindings — confirm the
+  rest-collection and the hole→undefined semantics in the assignment lowering.
+
+## Root-cause pointer
+
+- Assignment-destructuring lowering lives in the expression/assignment codegen
+  (grep `compileArrayAssignmentDestructuring` / array-assignment rest handling in
+  `src/codegen/expressions*`); the rest collection sizes a new array from the
+  remaining iterator/vec length — verify the empty/short-source length math and
+  the OOB→undefined sentinel for non-rest holes.
+
+## Acceptance criteria
+
+- `[x, ...r] = []` ⇒ `x === undefined`, `r` is an empty array (no trap).
+- `array-rest-nested-obj-undefined-own` / `-undefined-hole` flip fail→pass.
+- No regression in passing assignment-destructuring cases.
+- Guard test `tests/issue-2757.test.ts`.
+
+## PARTIAL LANDED — vec-rest length clamp (dev-acorn, 2026-06-28)
+
+Shipped the trap-hardening slice (focused PR `fix(codegen): clamp vec-rest length
+in array assignment-destructuring (#2757 partial)`):
+
+- **`src/codegen/expressions/assignment.ts` (array-rest branch, ~line 1578):** the
+  rest array was sized `src.length - i` (i = rest element's pattern index) and
+  passed straight to `array.new_default`. For a source shorter than the non-rest
+  prefix that count is NEGATIVE; `array.new_default` reads the size UNSIGNED → a
+  ~4-billion-element request → "requested new array is too large" trap. Now floored
+  at 0 (`i32.lt_s` + `if` → 0) so a short/empty source yields an empty rest. Guard:
+  `tests/issue-2757.test.ts` (no-trap + normal-rest-still-collects).
+
+## REMAINING (the actual test262 acceptance — fresh dev, precise map)
+
+Verify-first established that the two named cases are blocked by a DIFFERENT
+defect than the trap, precisely localized in `src/codegen/expressions/assignment.ts`:
+
+1. **THE BLOCKER — `assignment.ts:1556`: the array-rest branch only handles an
+   IDENTIFIER rest target.** `if (ts.isIdentifier(restTarget))` wraps the entire
+   rest build+bind. The named cases use an **object-pattern rest target**
+   (`[...{ 0: x, length }] = vals`), so `restTarget` is an `ObjectLiteralExpression`
+   → the branch is skipped → `x`/`length` are never bound (the `assert.sameValue(x,
+   undefined)` fail). **Fix:** build the rest vec into a TEMP local (the existing
+   build already produces `struct.new typeIdx` — redirect its final `local.set` to a
+   temp), then dispatch on the target kind exactly like the non-rest elements do
+   (lines ~1663-1682): `ts.isObjectLiteralExpression` → `emitObjectDestructureFromLocal`,
+   `ts.isArrayLiteralExpression` → `emitArrayDestructureFromLocal`,
+   property/element access → `emitAssignToTarget`, identifier → the current
+   `local.set restLocalIdx`. Keep the identifier path byte-identical to avoid
+   churning the working cases.
+2. **Secondary — `assignment.ts:1660` "rest on tuples is not supported."** A small
+   literal source like `[1]` compiles to a TUPLE struct (fixed-size), not a vec, so
+   `isVecStruct` is false and the rest path is skipped entirely. The named cases use
+   a VARIABLE source (`vals: any[]` → vec) so they DO hit the vec path; this tuple
+   note is only relevant for literal sources and is a separate, lower-priority tail.
+3. **Also observed (own follow-up if it persists):** an OOB *non-rest* element in
+   the vec path does NOT read `undefined` (`[a, b, ...r] = [1 as any]` left `b`
+   non-undefined). `emitElementGet`/`emitBoundsCheckedArrayGet` should yield
+   `undefined` for an out-of-range index in assignment destructuring.
+
+Validate on the FULL `merge_group` / test262 floor — the `expressions/assignment/dstr`
+cluster is 149 cases and the rest-bind refactor is broad-impact; a dev cannot
+validate it with scoped local checks.

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -1579,7 +1579,22 @@ function compileArrayDestructuringAssignment(
           fctx.body.push({ op: "struct.get", typeIdx, fieldIdx: 0 }); // length
           fctx.body.push({ op: "i32.const", value: i });
           fctx.body.push({ op: "i32.sub" } as Instr);
+          // (#2757) Clamp `length - i` to >= 0. When the source has FEWER
+          // elements than the non-rest prefix (e.g. `[a, ...r] = []` → 0 - 1),
+          // the count is negative; `array.new_default` reads the size as
+          // UNSIGNED → requests a ~4-billion-element array → "requested new
+          // array is too large" trap. A short/empty source must yield an empty
+          // rest array, so floor the count at 0.
           fctx.body.push({ op: "local.tee", index: tmpLen });
+          fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+          fctx.body.push({ op: "i32.lt_s" } as Instr);
+          fctx.body.push({
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [{ op: "i32.const", value: 0 } as Instr, { op: "local.set", index: tmpLen } as Instr],
+            else: [],
+          } as Instr);
+          fctx.body.push({ op: "local.get", index: tmpLen });
 
           fctx.body.push({
             op: "array.new_default",

--- a/tests/issue-2757.test.ts
+++ b/tests/issue-2757.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+// #2757 (partial) — clamp the vec-rest length in array assignment-destructuring.
+//
+// In `[a, b, ...r] = src` the rest array is sized `src.length - i` where `i` is
+// the rest element's index (the count of preceding pattern elements). When the
+// source vec has FEWER elements than that prefix (`src.length < i`), the count is
+// NEGATIVE; `array.new_default` reads the size operand as UNSIGNED → it requests
+// a ~4-billion-element array → "requested new array is too large" trap.
+// `src/codegen/expressions/assignment.ts` now floors the count at 0, so a
+// short/empty source yields an EMPTY rest array instead of trapping.
+//
+// NOTE: this is the partial (trap-hardening) slice of #2757. The remaining work
+// (object-pattern rest target `[...{0:x,length}] = vals`, and the OOB non-rest
+// element → `undefined` value, and tuple-source rest) is tracked in the #2757
+// issue file. These tests pin ONLY the clamp's contract.
+describe("#2757 array assignment-destructuring rest-length clamp", () => {
+  it("does not trap when the vec source is shorter than the non-rest prefix", async () => {
+    const exports = await compileToWasm(`
+      export function test(): number {
+        let src: any[] = [1];
+        let a: any, b: any, r: any;
+        [a, b, ...r] = src;        // prefix(2) > src.length(1): rest count -1 pre-clamp
+        if (a !== 1) return 1;      // the present element still reads
+        if (!Array.isArray(r)) return 2;
+        if (r.length !== 0) return 3; // clamped to an empty rest — no trap
+        return 0;
+      }`);
+    expect((exports as { test: () => number }).test()).toBe(0);
+  });
+
+  it("still collects the tail for a normal rest", async () => {
+    const exports = await compileToWasm(`
+      export function test(): number {
+        let src: any[] = [1, 2, 3];
+        let a: any, r: any;
+        [a, ...r] = src;
+        if (a !== 1) return 1;
+        if (r.length !== 2 || r[0] !== 2 || r[1] !== 3) return 2;
+        return 0;
+      }`);
+    expect((exports as { test: () => number }).test()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Partial (trap-hardening) slice of **#2757**. In `[a, b, ...r] = src` the rest array is sized `src.length - i` (where `i` is the rest element's pattern index = count of preceding elements). When the source vec is **shorter than the non-rest prefix** (`src.length < i`), the count is **negative**; `array.new_default` reads the size operand as **unsigned** → it requests a ~4-billion-element array → **"requested new array is too large" trap**.

This floors the rest count at 0 (`i32.lt_s` + `if` → 0), so a short/empty source yields an **empty rest array** instead of trapping. `src/codegen/expressions/assignment.ts`, array-rest branch.

## What this does NOT do (tracked in #2757, stays `status: ready`)

The two named test262 cases (`array-rest-nested-obj-undefined-own/-hole`) are blocked by a **different** defect — `assignment.ts:1556`, the array-rest branch only handles an **identifier** rest target, so an **object-pattern rest target** (`[...{ 0: x, length }] = vals`) falls through unbound. That refactor (build rest vec into a temp, then `emitObjectDestructure`/`emitArrayDestructure`/`emitAssignToTarget`) touches the 149-case `expressions/assignment/dstr` cluster and needs full-CI validation; it's precisely mapped in the #2757 issue file for a fresh-context dev. This PR is the safe, self-contained trap fix only.

## Test plan

- `tests/issue-2757.test.ts` — no-trap on a short vec source (rest clamps to empty) + normal rest still collects the tail. Both pass locally.
- Full `merge_group` / test262 validates no regression in the assignment-destructuring cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)