### PR TITLE
fix(codegen): #2714 object-spread keys enumerable in non-specific contexts

### DIFF
--- a/plan/issues/2714-object-spread-keys-not-enumerable.md
+++ b/plan/issues/2714-object-spread-keys-not-enumerable.md
@@ -1,15 +1,18 @@
 ---
 id: 2714
 title: "Object spread copies values but the copied keys are not enumerable (Object.keys / spread-then-data drop)"
-status: ready
+status: done
+assignee: ttraenkler/sendev-soundness
 created: 2026-06-26
+updated: 2026-06-28
+completed: 2026-06-28
 priority: medium
 feasibility: medium
 task_type: bugfix
 area: codegen
 language_feature: object-spread, Object.keys
 goal: spec-completeness
-sprint: Backlog
+sprint: current
 parent: 2709
 related: [2709, 1551]
 ---
@@ -71,3 +74,58 @@ shadows the literal's static key list rather than appending to it.
 - `Object.keys({ ...{ a: 2, b: 3 } }).length === 2`.
 - `Object.keys({ ...{ a: 2, b: 3 }, c: 5 }).length === 3`.
 - `test/language/expressions/super/call-spread-obj-getter-init.js` passes.
+
+## Verify-first re-scope + fix (2026-06-28, sendev-soundness)
+
+**Re-probed on current `main` (714b8d1). The behavior shifted since 2026-06-26 —
+the bug is narrower than the original framing, but it now includes a Wasm-validation
+CRASH.** Probe matrix:
+
+| form | result | 
+|------|--------|
+| `const t:any = {...o}; Object.keys(t)` (assigned) | **2 ✓** |
+| `const t:any = {...o}; for(k in t)` / `getOwnPropertyNames(t)` | **2 ✓** |
+| `Object.keys({ ...o })` (var src, DIRECT call-arg) | **0 ✗** |
+| `Object.keys({ ...{a,b} })` (inline src, DIRECT call-arg) | **CRASH ✗** (`struct.new need 2 got 0`) |
+| `Object.keys({ ...{a,b}, c:5 })` | 3 ✓ (already fixed) |
+| `{...o}` value reads (`o.a`) | ✓ |
+
+### Root cause (confirmed)
+
+The failure is **not** generic "spread keys non-enumerable" — every
+**assigned-to-variable / `any`-context** spread literal already routes to the host
+plain-object path and enumerates correctly. The defect is a spread literal used
+**directly in a NON-SPECIFIC contextual type** — most importantly as a direct call
+argument like `Object.keys({...})`, whose contextual type is the **shapeless
+`object` param (zero own properties)**. That context made `compileObjectLiteral`
+take the **struct-spread path** (`compileObjectLiteralForStruct`), which lays out
+fields from the literal's STATIC type only — so spread-copied (dynamic) keys are
+absent from the key list `Object.keys` walks (→ 0), and an inline spread source
+consumed directly underflows the struct-spread assembly's `struct.new` (→ crash).
+
+### Fix (routing)
+
+`src/codegen/literals.ts`, `compileObjectLiteral` — route a spread-containing
+literal to the host plain-object path (`compileObjectLiteralWithAccessors`, which
+copies via `__object_assign` → a real enumerable object) when its contextual type
+does **not** pin a concrete object SHAPE: `any`/`unknown`/`object`, no contextual
+type, OR a shapeless object type with `getProperties().length === 0`. A CONCRETE
+target (`const x: { a: number } = { ...o }`, ≥1 property) keeps the struct path so
+typed consumers still receive a struct. This generalizes the routing that
+assigned/`any`-context spread literals already used to the direct-call-argument
+position.
+
+### Tests / checks
+- `tests/issue-2714.test.ts` — 8 cases (inline-spread `Object.keys` crash repro,
+  var-spread, spread-then-data, data-then-spread, value-read, getOwnPropertyNames,
+  + no-spread and concrete-struct-target controls). All pass.
+- Local regression sweep (suites importing the compiler directly): `object-literals`,
+  `computed-props`, `issue-2151-{spread-literal,mixed-spread,dynamic-spread}`,
+  `issue-2026-dynamic-new-spread` — 51/51 green. (`new-expression-spread`,
+  `sparse-array-spread`, `spread-in-new-expressions`, `object-literal-getters-setters`
+  error on a pre-existing `./helpers.js` resolution quirk in the shallow worktree;
+  validated by CI on a full clone.)
+- `prettier`, `biome lint`, `tsc --noEmit` clean.
+- **Broad-impact** (changes spread-literal routing): the test262 regression gate +
+  standalone-floor (merge_group) are the authoritative validation; the
+  `call-spread-obj-getter-init.js` super row (#2709 sub-case 1) is confirmed by CI.

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -928,6 +928,37 @@ export function compileObjectLiteral(
     return compileObjectLiteralWithAccessors(ctx, fctx, expr);
   }
 
+  // (#2714) A spread-containing literal evaluated in a NON-SPECIFIC contextual
+  // type (`any`/`unknown`/`object`, or no contextual type) must take the host
+  // plain-object path, like the empty-`{}` any-context arm below. The struct
+  // path lays out fields from the literal's STATIC type only, so spread-copied
+  // keys (which are dynamic — CopyDataProperties at runtime) are absent from the
+  // key list `Object.keys` walks; and an INLINE spread source consumed directly
+  // (e.g. `Object.keys({ ...{ a, b } })`, whose contextual type is the `object`
+  // param of `Object.keys`) underflows the struct-spread assembly's `struct.new`.
+  // When a CONCRETE struct type is expected (e.g. `const x: { a: number } =
+  // { ...o }`), keep the struct path so typed consumers still get a struct.
+  // (Assigning to an `any`/untyped variable already worked via the host path;
+  // this generalizes the same routing to the direct-call-argument position.)
+  if (expr.properties.length > 0 && expr.properties.some((p) => ts.isSpreadAssignment(p))) {
+    const spreadCtxType = ctx.checker.getContextualType(expr);
+    // Non-specific = the contextual type does not pin a concrete object SHAPE the
+    // struct path could build/enumerate: `any`/`unknown`/`object`, no contextual
+    // type at all, OR a shapeless object type with zero own properties (e.g. the
+    // `object` param of `Object.keys`, whose contextual type carries no fields).
+    // A CONCRETE target (`const x: { a: number } = { ...o }`) has ≥1 property and
+    // keeps the struct path so typed consumers still receive a struct.
+    const nonSpecificCtx =
+      !spreadCtxType ||
+      (spreadCtxType.flags & ts.TypeFlags.Any) !== 0 ||
+      (spreadCtxType.flags & ts.TypeFlags.Unknown) !== 0 ||
+      (spreadCtxType.flags & ts.TypeFlags.NonPrimitive) !== 0 ||
+      spreadCtxType.getProperties().length === 0;
+    if (nonSpecificCtx) {
+      return compileObjectLiteralWithAccessors(ctx, fctx, expr);
+    }
+  }
+
   // If this empty object literal is the initializer of a variable with widened
   // properties (from pre-pass), register the struct with those extra fields and
   // compile as a struct.new with default values for the widened fields.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -5379,10 +5379,21 @@ function _wrapForHost(obj: any, exports: Record<string, Function> | undefined): 
       }
       const val = safeGetField(key);
       if (protoMethods === undefined && val === undefined && !hasInSidecar && !hasInFields) return undefined;
+      // (#2714) Reflect the sidecar descriptor's stored enumerable flag so a
+      // `defineProperty(o, k, { enumerable: false })` own prop is reported as
+      // non-enumerable through the host proxy. Native consumers that filter by
+      // enumerability — `Object.assign` -> CopyDataProperties, object spread
+      // `{ ...o }` (both lowered via `__object_assign` over a `_wrapForHost`
+      // source) — must SKIP a non-enumerable own key. Hardcoding
+      // `enumerable: true` here leaked non-enumerable sidecar props into spread
+      // results (`spread-obj-skip-non-enumerable`, #2714). Declared struct
+      // fields and class methods carry no sidecar flags entry and stay
+      // enumerable data props, matching their spec semantics.
+      const scFlags = _wasmPropDescs.get(obj)?.get(_normalizeDescKey(key));
       const desc: PropertyDescriptor = {
         value: val,
         writable: true,
-        enumerable: true,
+        enumerable: scFlags === undefined ? true : !!(scFlags & _SC_ENUMERABLE),
         configurable: true,
       };
       // Mirror onto target so V8's Proxy invariant checker is happy

--- a/tests/issue-2714.test.ts
+++ b/tests/issue-2714.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #2714 — an object literal containing a spread, evaluated in a NON-SPECIFIC
+// contextual type (notably as a direct call argument like `Object.keys({...o})`,
+// whose contextual type is the shapeless `object` param), used to take the
+// struct-spread path. That path lays out fields from the literal's STATIC type
+// only, so spread-copied keys (dynamic, CopyDataProperties-at-runtime) were
+// absent from the key list `Object.keys` walks — and an INLINE spread source
+// consumed directly (`Object.keys({ ...{ a, b } })`) underflowed the
+// struct-spread `struct.new` and crashed Wasm validation. The fix routes such
+// literals to the host plain-object path (which copies via __object_assign and
+// produces a real enumerable object), matching what an assigned/`any`-context
+// spread literal already did. A CONCRETE struct target keeps the struct path.
+async function run(source: string, fn = "test"): Promise<unknown> {
+  const result = await compile(source, { fileName: "test.ts" });
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>)[fn]();
+}
+
+describe("#2714 — object-spread keys are enumerable", () => {
+  it("Object.keys of an inline-spread literal (was a struct.new crash)", async () => {
+    expect(await run(`export function test(): number { return Object.keys({ ...{ a: 2, b: 3 } }).length; }`)).toBe(2);
+  });
+
+  it("Object.keys of a var-spread literal (was 0)", async () => {
+    expect(
+      await run(
+        `export function test(): number { const o: any = { a: 2, b: 3 }; return Object.keys({ ...o }).length; }`,
+      ),
+    ).toBe(2);
+  });
+
+  it("Object.keys of spread-then-data", async () => {
+    expect(
+      await run(`export function test(): number { return Object.keys({ ...{ a: 2, b: 3 }, c: 5 }).length; }`),
+    ).toBe(3);
+  });
+
+  it("Object.keys of data-then-spread", async () => {
+    expect(
+      await run(`export function test(): number { return Object.keys({ c: 5, ...{ a: 2, b: 3 } }).length; }`),
+    ).toBe(3);
+  });
+
+  it("spread values are still read correctly", async () => {
+    expect(
+      await run(
+        `export function test(): number { const o: any = { ...{ a: 2, b: 3 } }; return (o.a as number) + (o.b as number); }`,
+      ),
+    ).toBe(5);
+  });
+
+  it("getOwnPropertyNames matches Object.keys for a spread literal", async () => {
+    expect(
+      await run(
+        `export function test(): number { const o: any = { ...{ a: 2, b: 3 } }; return Object.getOwnPropertyNames(o).length; }`,
+      ),
+    ).toBe(2);
+  });
+
+  // ── controls ──
+  it("CONTROL: no-spread literal still enumerates", async () => {
+    expect(await run(`export function test(): number { return Object.keys({ a: 2, b: 3 }).length; }`)).toBe(2);
+  });
+
+  it("CONTROL: spread into a CONCRETE struct target reads back (struct path retained)", async () => {
+    expect(
+      await run(
+        `export function test(): number { const o = { a: 2, b: 3 }; const x: { a: number; b: number } = { ...o }; return x.a + x.b; }`,
+      ),
+    ).toBe(5);
+  });
+});

--- a/tests/issue-2714.test.ts
+++ b/tests/issue-2714.test.ts
@@ -77,4 +77,49 @@ describe("#2714 — object-spread keys are enumerable", () => {
       ),
     ).toBe(5);
   });
+
+  // Regression: the host-path routing (above) lowers `{ ...o }` via
+  // `__object_assign` over a `_wrapForHost` proxy. That proxy's
+  // `getOwnPropertyDescriptor` trap hardcoded `enumerable: true`, so native
+  // `Object.assign`/spread copied a NON-enumerable own source prop. Object
+  // spread must skip non-enumerable own props (ECMA-262 CopyDataProperties).
+  // (spread-obj-skip-non-enumerable, #2714)
+  it("spread SKIPS a non-enumerable own source property", async () => {
+    expect(
+      await run(
+        `export function test(): number {
+          const o: any = {};
+          Object.defineProperty(o, "b", { value: 3, enumerable: false });
+          const r: any = { ...o };
+          return r.hasOwnProperty("b") ? 99 : Object.keys(r).length;
+        }`,
+      ),
+    ).toBe(0);
+  });
+
+  it("Object.assign SKIPS a non-enumerable own source property", async () => {
+    expect(
+      await run(
+        `export function test(): number {
+          const o: any = {};
+          Object.defineProperty(o, "b", { value: 3, enumerable: false });
+          const r: any = Object.assign({}, o);
+          return r.hasOwnProperty("b") ? 99 : Object.keys(r).length;
+        }`,
+      ),
+    ).toBe(0);
+  });
+
+  it("spread STILL copies an enumerable own source property", async () => {
+    expect(
+      await run(
+        `export function test(): number {
+          const o: any = {};
+          Object.defineProperty(o, "a", { value: 7, enumerable: true });
+          const r: any = { ...o };
+          return r.a === 7 && Object.keys(r).length === 1 ? 1 : 99;
+        }`,
+      ),
+    ).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #2714. Also unblocks the #2709 super row `call-spread-obj-getter-init.js`.

## Verify-first re-scope
Re-probing on current `main` showed the bug is narrower than the 2026-06-26 framing — and now includes a **Wasm-validation crash**:

| form | before |
|------|--------|
| `const t:any = {...o}; Object.keys(t)` (assigned) | 2 ✓ (already worked) |
| `Object.keys({ ...o })` (var src, direct call-arg) | **0 ✗** |
| `Object.keys({ ...{a,b} })` (inline src, direct call-arg) | **CRASH** (`struct.new need 2 got 0`) |
| `Object.keys({ ...{a,b}, c:5 })` | 3 ✓ |

Every **assigned-to-variable / `any`-context** spread literal already routed to the host plain-object path and enumerated correctly (for-in, getOwnPropertyNames, Object.keys). Only a spread literal used **directly in a non-specific contextual type** was broken.

## Root cause
A spread literal whose contextual type doesn't pin a concrete object shape — e.g. the shapeless `object` param of `Object.keys` (zero own properties) — took the **struct-spread path** (`compileObjectLiteralForStruct`), which lays out fields from the literal's STATIC type only. So spread-copied (dynamic) keys are absent from the key list `Object.keys` walks (→ 0), and an inline spread source consumed directly underflows the struct-spread `struct.new` (→ crash).

## Fix
`src/codegen/literals.ts`, `compileObjectLiteral` — route a spread-containing literal to the host plain-object path (`compileObjectLiteralWithAccessors`, which copies via `__object_assign` → a real enumerable object) when the contextual type does **not** pin a concrete shape: `any`/`unknown`/`object`, no contextual type, or a shapeless object type with `getProperties().length === 0`. A **concrete** target (`const x: { a: number } = { ...o }`, ≥1 property) keeps the struct path so typed consumers still receive a struct. This generalizes the routing assigned/`any`-context spread literals already used.

## Validation
- `tests/issue-2714.test.ts` (8 cases): inline-spread crash repro, var-spread, spread-then-data, data-then-spread, value-read, getOwnPropertyNames, + no-spread and concrete-struct-target controls. All pass.
- Local sweep of compiler-direct spread/object-literal suites: 51/51 green. `prettier`/`biome`/`tsc` clean.
- **Broad-impact** (changes spread-literal routing): the test262 regression gate + standalone-floor (merge_group) are the authoritative validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)