### PR TITLE
docs(arch): record hybrid type-soundness decision (#2755) + merged IR roadmap

### DIFF
--- a/docs/architecture/hybrid-soundness-ir-roadmap.md
+++ b/docs/architecture/hybrid-soundness-ir-roadmap.md
@@ -332,8 +332,8 @@ as `sprint: current`, `status: ready`.
   linear) axes.
 - [`../../plan/log/ir-adoption.md`](../../plan/log/ir-adoption.md) — per-kind IR
   status & ratchet.
-- [`../../plan/issues/2755-evaluate-type-soundness-approach.md`](../../plan/issues/2755-evaluate-type-soundness-approach.md)
-  — the decision.
+- [`#2755`](../../plan/issues/2755-evaluate-type-soundness-approach.md) — the
+  decision.
 - #1530 — phase out the IR demote-to-warning channel (now: fall to SAFE, not
   legacy-trust).
 - #2681 / #2686 / #1627 / #2740 — the substrate-convergence evidence.

--- a/docs/architecture/hybrid-soundness-ir-roadmap.md
+++ b/docs/architecture/hybrid-soundness-ir-roadmap.md
@@ -1,0 +1,339 @@
+# Hybrid type-soundness × IR-migration roadmap
+
+> **Decision of record.** The project lead chose the **hybrid** type-soundness
+> direction on 2026-06-28 (decision issue
+> [`#2755`](../../plan/issues/2755-evaluate-type-soundness-approach.md)). This
+> document is the merged implementation roadmap for that decision. It is the
+> companion to [`codegen-axes.md`](./codegen-axes.md) (the front-end/back-end
+> axes) and [`../../plan/log/ir-adoption.md`](../../plan/log/ir-adoption.md)
+> (per-AST-kind IR status). Read both first.
+
+## TL;DR
+
+- **Invariant:** *a TS type may only change the emitted Wasm when the value
+  provably cannot violate that type at runtime; otherwise lower the JS-correct
+  way.* Correctness is the default; **specialization must be proven**.
+- The legacy direct AST→Wasm path (`src/codegen/`) **trusts types inline at
+  scattered sites** — that is exactly the old "trust-the-type-and-patch"
+  approach the decision rejects. The typed **IR** (`src/ir/`) is the *single
+  chokepoint* where a "prove-then-specialize" gate belongs. So the soundness
+  finish line and the **#1530 IR-migration** finish line are now the **same
+  line**.
+- We do **not** rewrite the perf paths up front. We (1) land cheap correctness
+  **floor** fixes in legacy now, (2) move the four hybrid-governed kinds onto
+  the IR in a test-gated order, and (3) convert each existing type-directed fast
+  path to a *proven-safe* specialization opportunistically, regression-gated.
+
+---
+
+## (a) The hybrid invariant, precisely
+
+> **Hybrid invariant (HI).** For every value whose Wasm representation or
+> instruction selection is influenced by its TypeScript type `T`, codegen must
+> emit one of:
+>
+> 1. the **SAFE lowering** — the JS-runtime-correct lowering that holds for *any*
+>    runtime value the expression could actually produce (the dynamic /
+>    `any` / externref path, by construction correct), **or**
+> 2. the **FAST lowering** — the `T`-directed specialization (packed array,
+>    monomorphic `struct.get`, unboxed `f64`, …) **guarded by a discharged
+>    safety predicate** `P(T, site)` that proves the runtime value cannot
+>    violate `T` at this site.
+>
+> The SAFE lowering is the **default**. The FAST lowering is an *optimization*
+> that must *justify itself* with `P`. When `P` cannot be discharged, codegen
+> falls to the SAFE lowering — it never silently trusts `T`.
+
+Two corollaries make this operational:
+
+- **Every existing fast path is now a thing we must justify, not assume.** The
+  audit in §(d) attaches a concrete `P` to each one and classifies whether `P`
+  is *already* discharged by existing analysis, easy to discharge, or subtle.
+- **`P` is discharged by a *proof*, not by a flag.** "The user wrote `: number`"
+  is not a proof (TS is unsound: `as`, covariant arrays, `any`, index access,
+  bivariance). A proof is a compiler-checked fact: a counted-loop bound, a
+  fresh-allocation with no widening escape, a `ref.test` runtime guard, a
+  literal index below a known length, etc.
+
+### Redefining the #1530 IR fallback under HI
+
+Today the IR demote-to-warning escape hatch (`src/codegen/index.ts`, the IR
+claim/compile block ~`1372–1595`; historically documented as `889–896`) means:
+*"if the IR path throws, keep the **legacy direct-codegen body**."* Under HI that
+is wrong in one important way — the legacy body is precisely the trust-the-type
+path we are retiring. We therefore **redefine the fallback target**:
+
+> **#1530 finish line (HI form).** When the IR cannot claim or cannot prove a
+> specialization for a hybrid-governed kind, it falls to the **SAFE JS-correct
+> lowering**, never to a legacy trust-the-type lowering. A kind is "done" when
+> (a) its IR rejection buckets are zero **and** (b) the only two outcomes are
+> *FAST-with-discharged-`P`* or *SAFE* — there is no third "claimed-then-silently-
+> fell-back-to-trusting-`T`" state.
+
+Concretely this means the SAFE lowering for each hybrid-governed kind must exist
+**as an IR lowering** (or a shared helper the IR calls), not only as a legacy
+branch. The floor fixes in §(c) build those SAFE lowerings; the IR-adoption
+order in §(b) routes the kinds through them. This is why the two tracks share a
+finish line: you cannot complete #1530 for `ElementAccess` without also making
+`ElementAccess` correctness-by-default, and vice versa.
+
+---
+
+## (b) IR-adoption order for the four hybrid-governed kinds
+
+These four kinds are `mixed` on the IR today and are where type-directed
+lowering bites (per `ir-adoption.md`):
+
+| Kind | IR today | Type-directed lowering at stake |
+|------|----------|--------------------------------|
+| `ElementAccessExpression` | mixed (numeric index / const string key) | `vec.get`/`array.get` (OOB), packed reads |
+| `PropertyAccessExpression` | mixed | monomorphic `struct.get`, union/`any` receivers |
+| `BinaryExpression` | mixed | unboxed `f64`/`i32` arithmetic, `+` string vs number |
+| `ArrayLiteralExpression` | mixed | `vec.new_fixed` packed construction |
+
+**Recommended order — `ElementAccess → ArrayLiteral → Binary → PropertyAccess`:**
+
+1. **`ElementAccessExpression` first.** It is the *sharpest* HI violation and has
+   the *smallest* SAFE-lowering gap:
+   - The IR read (`src/ir/from-ast.ts:1919` `lowerElementAccess` →
+     `emitVecGet` → `vec.get`/`array.get`) **traps on OOB** and *explicitly*
+     defers JS-correct OOB to the selector (see the comment at
+     `from-ast.ts:1952–1960`). That is a pure trust-the-type fast path with **no
+     SAFE fallback at all** — strictly worse than legacy, which at least returns
+     a (wrong) sentinel.
+   - The proof primitive **already exists**: legacy `isSafeBoundsEliminated`
+     (`src/codegen/property-access.ts:5371`) + `fctx.safeIndexedArrays` is a
+     counted-loop in-bounds proof. Porting that proof into the IR is the model
+     for the whole roadmap: *prove in-bounds → keep `vec.get`; else emit a
+     SAFE bounds-checked read returning `undefined`.*
+   - This is also where the **#2198/S2 rework** lands (§(c), floor fix F1) — so
+     ElementAccess gives us the canonical end-to-end example: floor fix in
+     legacy + proof-gated specialization in IR.
+2. **`ArrayLiteralExpression` second.** Smallest blast radius: a literal is a
+   **fresh allocation** with locally-decidable element types (#1804 already does
+   `vec.new_fixed` for fixed-length same-typed literals). The safety predicate
+   ("all elements same static type, literal not later widened to `any`/
+   heterogeneous") is *local* and cheap — a clean second exemplar that the proof
+   need not be a whole-function dataflow.
+3. **`BinaryExpression` third.** Unboxed `f64`/`i32` arithmetic is high-value and
+   mostly safe, but `+` carries the classic unsoundness (string-or-number
+   operand). Doing it after ElementAccess/ArrayLiteral means the proof
+   infrastructure (operand-type proof, `any`/union detection) is already in
+   place.
+4. **`PropertyAccessExpression` last.** Largest surface (object / closure /
+   string / vec / extern receivers; optional `?.`) and the subtlest predicate
+   (monomorphic-receiver proof across unions, subclassing, covariant fields).
+   It benefits most from the proof machinery built by the first three.
+
+**Test gating (every step):**
+- Byte-neutral on the `.ts` test262 corpus is **not** the bar by itself
+  (a correctness fix legitimately changes bytes). The bar is: **no test262
+  regression in the `merge_group` re-validation**, and the targeted
+  correctness cases (e.g. the map-on-array-like case below) flip **green**.
+- The IR ratchet (`pnpm run check:ir-fallbacks`) must not grow any unintended
+  bucket; when a kind reaches *FAST-or-SAFE only*, promote its row in
+  `ir-adoption.md` and zero its bucket in `scripts/ir-fallback-baseline.json`.
+- Each kind keeps a `.ts`/`.js` parity probe (the SAFE lowering must be
+  identical whether the source was typed or untyped).
+
+---
+
+## (c) Correctness FLOOR (legacy, now) vs SPECIALIZATION (IR, proof-gated)
+
+The floor fixes are JS-correctness bugs that can land in legacy `src/codegen/`
+**today**, independently of the IR migration, and that the IR will later reuse as
+its SAFE lowering. The specialization work needs the IR's typed analysis.
+
+### Floor fixes — land in legacy now
+
+| # | Floor fix | Where | Why it is a floor (not a fast path) | Risk |
+|---|-----------|-------|--------------------------------------|------|
+| F1 | **Plain-array OOB read → JS `undefined`** (the #2198/S2 rework) | `src/codegen/property-access.ts:6303,6352` (the two non-bounds-eliminated `compileElementAccessBody` call sites) | OOB currently returns a *type-default sentinel* (sNaN for `number`, `false` for `boolean`, `ref.null.extern`→JS `null` for externref), **never** `undefined`. JS reads OOB as `undefined`. | **Blast radius** — see below |
+| F2 | **`$Hole` → `undefined` on every read boundary** | already present (`emitHoleToUndefined`, `array-methods.ts:481`) — audit for gaps in the typed-element (`number[]`/`boolean[]`) read paths | a hole is "absent", reads as `undefined` per spec | low |
+| F3 | **Document `emitThisReceiverGuardConvert` as the HI exemplar** | `src/codegen/property-access.ts:5405` | it already does a **runtime `ref.test`** instead of trusting the static `this` type — this *is* HI done right; make it the reference pattern | none (doc) |
+
+**F1 is the deciding lesson of S2 and must be done HI-style, NOT as the parked
+sentinel flip.** PR #2198 set `useUndefinedSentinel=true` on the **shared**
+helper `emitBoundsCheckedArrayGet` (`src/codegen/array-methods.ts:386`). That
+helper is called by plain-array reads **and** typed-array reads **and** the
+`$__subview` path (`property-access.ts:6034`) **and** the array-method
+machinery. Flipping it perturbed a generic `Array.prototype.map`-on-array-like
+path (`built-ins/Array/prototype/map/15.4.4.19-8-b-2.js`) — the data point that
+proved "patch the holes" is leaky.
+
+> **F1 HI rework:** make OOB-correctness **fall out of the element-read path
+> itself**, not by toggling the shared low-level helper. Either (a) handle the
+> OOB→`undefined` decision at the `compileElementAccessBody` level for the
+> **dynamic plain-array value read** only — leaving typed-array / subview /
+> array-method internal callers on their own (correct) OOB semantics — or
+> (b) split the OOB-default policy into an explicit parameter the *call site*
+> owns, with plain dynamic reads passing "undefined" and the internal callers
+> passing their existing default. The map-on-array-like case must be **green**.
+> Do **not** re-land the shared-helper sentinel flip.
+
+### Specialization — needs the IR typed analysis (proof-gated)
+
+| # | Specialization | Proof `P` it now requires | Gating analysis |
+|---|----------------|----------------------------|-----------------|
+| S1 | IR `vec.get` keeps `array.get` (no bounds check) | index provably in `[0, length)` | counted-loop proof ported from `safeIndexedArrays`; literal-index-below-known-length |
+| S2 | Packed-`i32` array reads/writes | every write is an i32-safe integer **and** no read needs the f64 NaN/fractional distinction | `collectI32SpecializedArrays` / `isI32SafeExprForArray` (`array-element-typing.ts`) — already approximates `P` |
+| S3 | Monomorphic `struct.get` | receiver provably the nominal struct (not a union arm, not `any`-widened, not a differently-laid-out subclass) | IR receiver-type narrowing; `resolveStructName` + a "no covariant/union escape" check |
+| S4 | Unboxed `f64` number path | value never observed as `any`/boxed without an explicit box | IR escape analysis (`src/ir/analysis/escape.ts:92`) at any/union sinks |
+
+---
+
+## (d) Migration-cost sizing — the type-directed fast-path inventory
+
+> **This is the lead's key open question:** *how big is "prove every fast path
+> is safe"?* Below is the enumeration. Each row gives the fast path, the safety
+> predicate `P` HI now demands, an **easy vs subtle** classification, and a rough
+> effort band (**S** ≤ ~1 dev-day · **M** ~2–4 dev-days · **L** ~1–2 dev-weeks,
+> including the regression-gated rollout).
+
+| # | Type-directed fast path | Anchor | Safety predicate `P` | Class | Effort |
+|---|-------------------------|--------|----------------------|-------|--------|
+| 1 | **IR `vec.get` element read** (traps OOB) | `from-ast.ts:1919/1990` | index ∈ `[0,length)` (counted loop / literal < known len) | **easy** where a counted-loop or literal bound exists; **subtle** for general dynamic indices (needs SAFE fallback) | **M** |
+| 2 | **Legacy bounds-eliminated read** | `property-access.ts:5371,6333` | counted-loop guarantees index < len | **already discharged** — this path *is* HI-compliant; just make the un-proven default JS-correct (F1) and document | **S** |
+| 3 | **Packed-`i32` arrays** | `array-element-typing.ts:44,212` | all writes i32-safe ints; no read needs NaN/fractional/large-magnitude distinction | **subtle** — whole-function flow; misclassification *miscompiles* fractional/`>2³¹` values | **L** |
+| 4 | **Monomorphic `struct.get`/`struct.set`** | `property-access.ts` (`resolveStructName`, `emitNullGuardedStructGet`) | receiver provably that nominal type; no union arm / `any` widening / divergent-layout subclass | **subtle** — covariant fields, union narrowing, subclass layout | **L** |
+| 5 | **Unboxed `f64`/`i32` number locals** (no-box) | numeric local typing across codegen + IR | value never flows to an `any`/externref sink without an explicit box | **easy** for pure-numeric locals; **subtle** at any/union boundaries | **M** |
+| 6 | **`ArrayLiteral` → `vec.new_fixed`** | `from-ast.ts` (#1804) | all elements same static type; literal not later widened to `any`/heterogeneous | **easy** — fresh alloc, local analysis | **S** |
+| 7 | **`Binary` unboxed arithmetic** | IR `lowerBinary` (`from-ast.ts:3787`); legacy `binary-ops.ts` | operands provably `number` (not `any`/union/string-coercible); `+` not string-`+` | **easy** for annotated-number operands; **subtle** for `+` with a possibly-string operand | **M** |
+| 8 | **`this`-receiver typed read** | `property-access.ts:5405` | (runtime `ref.test` guard) | **already discharged** — exemplar of HI; document as the pattern | **S** |
+| 9 | **Typed-array element read** (sentinel semantics) | `property-access.ts:6285–6316`; `array-methods.ts:386` | view length is the bound; OOB → `undefined` per spec | **easy** but entangled with the shared helper (keep separate from F1's plain-array scope) | **S–M** |
+
+### Sizing summary (the answer to the open question)
+
+- **Already HI-compliant (cost ≈ documentation):** rows **2, 8** (proof already
+  discharged), and the runtime-guard pattern generally. *These prove the
+  approach is tractable — the compiler already contains "prove-then-specialize"
+  primitives; HI generalizes them rather than inventing them.*
+- **Easy / local proofs:** rows **6, 9** (fresh-array / view-bounded), plus the
+  in-bounds half of row **1**. Banded **S–M each**.
+- **Medium / boundary proofs:** rows **1 (general), 5, 7** — these need IR escape
+  analysis (`escape.ts`) and `any`/union-sink detection, but the analyses exist.
+  Banded **M each**.
+- **Subtle / whole-function proofs (the real cost):** rows **3 (packed-i32)** and
+  **4 (monomorphic struct)**. These are where a wrong `P` *miscompiles* rather
+  than merely deoptimizes, so they need the strongest proofs and the most
+  regression gating. Banded **L each**.
+
+**Bottom line for the lead:** the migration is **not** a uniform rewrite. Of the
+~9 fast-path families, **~2 are free** (already proof-gated), **~4 are S–M**
+(local or analysis-backed proofs), and **only ~2–3 are L** (packed-i32,
+monomorphic struct, and the substrate work in §(e)). The expensive, risky tail
+is small and isolable, which is exactly why the hybrid (do the cheap floors +
+proof-gate opportunistically) beats a pure-B up-front rewrite. Rough order-of-
+magnitude for the *fast-path* conversion alone: **~2 free + ~4×M + ~2×L ≈ a few
+focused dev-weeks**, spread across the IR-adoption steps in §(b), **not** a
+big-bang. The substrate workstream §(e) is sized separately below.
+
+---
+
+## (e) The `$Object` / dynamic-reader value-identity substrate workstream
+
+A distinct but **convergent** root cause keeps surfacing: the legacy
+`$Object` / dynamic value reader **loses native struct / prototype-value
+identity** when a compiled WasmGC value is read back through the dynamic
+(`externref`/`any`) path. This is a value-**representation** substrate issue, and
+it is the SAFE-path's weak point — the very path HI makes the default. If the
+dynamic reader is lossy, "fall back to the dynamic path" is not actually correct,
+so **this workstream is a prerequisite for HI's SAFE default to be trustworthy**.
+
+**Three independent converging signals (as of 2026-06-28):**
+
+1. **acorn parser walls — #2681 / #2686.** `acorn`'s `parse` 10th-wall
+   ("unexpected on name") and `BinaryExpression` throw both bottom out in the
+   `$Object`/dynamic reader dropping native struct/prototype values.
+2. **builtins #1627 tail — 18 class-instance set-likes.** The Set-method
+   set-like-argument tail is blocked on the same reader losing class-instance
+   identity (`size`/`has`/`keys` read back as not-present).
+3. **`instanceof` #2740 — 2 of 5 failure clusters are value-rep gaps** (verify-
+   first by the instanceof dev; sub-issues being filed substrate/architect-
+   scoped):
+   - **(3a)** cross-realm `Object`/`Function` globals arrive with **sandbox-realm
+     host identity**, so `v instanceof Object` is `false` (and the static fold
+     hides the direct case) — a host-identity gap, same `$Object` theme.
+   - **(3b)** `.prototype` access on a **dynamic `Function`-typed value traps** —
+     a property-access gap on `Function` values, not an `instanceof` bug.
+
+These are the **same substrate**: the dynamic reader's value representation does
+not preserve (i) native struct field/prototype-value identity and (ii) host vs
+compiled-value / cross-realm identity. Patch-the-symptom in any one of the three
+shifts the others (the §(a) blast-radius lesson, again, one layer down).
+
+**Workstream scope (named: `substrate/value-identity`):**
+- **Single root fix:** make the `$Object`/dynamic reader **representation-
+  preserving** — reading a compiled value back as `any`/externref and re-reading
+  it must round-trip native struct identity, prototype-value identity, and host/
+  cross-realm identity. (See the prior substrate analyses in MEMORY:
+  `project_standalone_any_string_value_read_substrate`,
+  `project_s64_value_rep_substrate_next`.)
+- **Validation:** the fix must simultaneously unblock #2681/#2686 (acorn),
+  the #1627 class-instance tail, and the #2740 (3a)/(3b) clusters — *one fix,
+  three corpora green*. If it only fixes one, it is a symptom patch, not the
+  substrate fix.
+- **Sizing:** **L (1–2 dev-weeks)**, and it is **architect-scoped / senior-dev
+  implementation** — it touches the value representation that the SAFE path
+  depends on, so it gates the trustworthiness of HI's default. Treat it as the
+  highest-leverage non-floor item.
+
+### Assessment of #2758 (architect-first flag) — *does it belong here?*
+
+**#2758** (destructuring default-init side-effect on a falsy value, entangled
+with the #1177 / #2692 **closure-box** history) is **a different substrate** from
+the `$Object` value-identity reader. #1177 (TDZ propagation through closure
+captures) and #2692 (closure-capture ref-cell box must be materialized eagerly at
+declaration) are about the **closure-capture ref-cell box** representation, not
+the dynamic value reader.
+
+> **Architect verdict:** #2758 does **not** belong in the
+> `substrate/value-identity` ($Object reader) workstream. It belongs to the
+> **closure-box / ref-cell** lineage (#1177 → #2692). Scope it there, not here.
+> It *is* a substrate issue in the broad sense (a representation contract for
+> ref-cells: a default-init must observe the *current* box value and only
+> side-effect on a genuinely-falsy slot, respecting eager materialization), so it
+> shares the roadmap's "fix the representation, don't patch the symptom"
+> philosophy — but it is a **sibling sub-workstream** (`substrate/closure-box`),
+> tracked under the #2692 follow-ups, not folded into the $Object reader fix.
+> Conflating the two would repeat the exact blast-radius mistake this roadmap
+> exists to avoid.
+
+---
+
+## Sequencing summary & follow-up issues
+
+| Step | Roadmap issue | What | Effort |
+|------|---------------|------|--------|
+| 1 (now, legacy floor) | **R1** | F1 (plain-array OOB→`undefined`, HI-style — the #2198/S2 rework, *not* the shared-helper flip) + F2 audit + F3 doc | M |
+| 2 (first IR step) | **R2** | `ElementAccessExpression` — port the `safeIndexedArrays` in-bounds proof into the IR; `vec.get` only when in-bounds is proven, else the SAFE bounds-checked read (F1 reused as the SAFE lowering) | M |
+| 3 (audit, dispatchable) | **R3** | Migration-cost audit made a living checklist: annotate every §(d) fast path with discharged/undischarged proof status; this is the backlog generator for the M/L items | S |
+| 4 (then, in order) | (follow-ons) | `ArrayLiteral` → `Binary` → `PropertyAccess` (§(b)), each proof-gated, each `merge_group`-regression-gated | M each |
+| 5 (parallel, architect/senior-dev) | (substrate) | `substrate/value-identity` §(e) (acorn #2681/#2686 + #1627 tail + #2740 clusters), and sibling `substrate/closure-box` (#2758 under #2692) — **not** merged into each other | L each |
+
+The concrete R1/R2/R3 issue IDs are recorded in the disposition note of
+[`#2755`](../../plan/issues/2755-evaluate-type-soundness-approach.md) and created
+as `sprint: current`, `status: ready`.
+
+### Disposition of the open soundness PRs/issues (recorded in #2755)
+
+- **PR #2198 (S1+S2 code)** — keep S1 (sound flags, corpus-neutral); **rework
+  S2** as floor fix **F1** under HI (do *not* re-land the shared-helper sentinel
+  flip).
+- **PR #2195 / issue #2754 (sound-TS-settings spec)** — revise to the HI framing:
+  Prong-1 stays; Prong-2 is reframed from "enumerate & patch holes" to "SAFE
+  default + proof-gated specialization" (this doc is the authority).
+- **#2698 (checker track) Prong-2** — re-scoped to HI; the codegen Prong-2 work
+  is now governed by this roadmap, not a standalone hole catalog.
+
+## See also
+
+- [`codegen-axes.md`](./codegen-axes.md) — front-end (IR) vs back-end (WasmGC/
+  linear) axes.
+- [`../../plan/log/ir-adoption.md`](../../plan/log/ir-adoption.md) — per-kind IR
+  status & ratchet.
+- [`../../plan/issues/2755-evaluate-type-soundness-approach.md`](../../plan/issues/2755-evaluate-type-soundness-approach.md)
+  — the decision.
+- #1530 — phase out the IR demote-to-warning channel (now: fall to SAFE, not
+  legacy-trust).
+- #2681 / #2686 / #1627 / #2740 — the substrate-convergence evidence.

--- a/plan/issues/2755-evaluate-type-soundness-approach.md
+++ b/plan/issues/2755-evaluate-type-soundness-approach.md
@@ -1,10 +1,12 @@
 ---
 id: 2755
 title: "Decide the type-soundness approach: trust-the-type-and-patch vs JS-semantics-first"
-status: ready
+status: done
 sprint: current
 created: 2026-06-28
 updated: 2026-06-28
+completed: 2026-06-28
+decision: hybrid
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -134,15 +136,63 @@ speculative refactor that risks the perf story this compiler is built on. The
 hybrid keeps A's speed where it's *provably* safe and gets B's
 correctness-by-default everywhere else.
 
-## Decision needed (owner: project lead / PO)
+## Decision (RECORDED — 2026-06-28, project lead)
 
-- [ ] Pick: **A**, **B**, or the **hybrid** above (or amend).
-- [ ] Given the pick, set the disposition of the open soundness PRs/issues:
-  - **#2198 (S2 code)** — currently parked with a real regression. Fix-on-branch
-    under the chosen direction, or close/supersede.
-  - **#2195 (spec docs, adds #2754)** — the "sound TS settings" spec. Keep,
-    revise to match the chosen direction, or close.
-  - **#2754 / #2698** — re-scope Prong 2 to the chosen direction.
+- [x] **Picked: the HYBRID.** Adopt Direction B as the *default/invariant* and
+  keep Direction A's type-directed fast paths only as a *proven-safe*
+  optimization.
+
+  > **The hybrid invariant (HI):** *"A TS type may only change the emitted Wasm
+  > when the value provably cannot violate it at runtime; otherwise lower the
+  > JS-correct way."* Correctness is the default; **specialization must be
+  > proven**. Keep type-directed fast paths only where provably safe.
+
+  The merged implementation roadmap is
+  [`docs/architecture/hybrid-soundness-ir-roadmap.md`](../../docs/architecture/hybrid-soundness-ir-roadmap.md).
+  It binds this soundness decision to the **#1530 IR-migration** finish line:
+  the legacy direct AST→Wasm path is the "trust-the-type" approach we are
+  retiring; the typed IR (`src/ir/`) is the chokepoint where "prove-then-
+  specialize" belongs, so the IR fallback is redefined as *"fall to the SAFE
+  JS-correct default, never the legacy trust-the-type path."*
+
+- [x] **Dispositions of the open soundness PRs/issues:**
+  - **PR #2198 (S1+S2 code)** — **keep S1** (sound flags, corpus-neutral);
+    **rework S2 under HI**. Do **NOT** re-land the shared-helper
+    `useUndefinedSentinel` flip (it leaked into the generic
+    `Array.prototype.map`-on-array-like path — the deciding data point that
+    "patch-the-holes" is leaky). Instead make OOB-correctness **fall out of the
+    safe default element-read path** at the `compileElementAccessBody` call sites
+    (`property-access.ts:6303,6352`), scoped to the dynamic plain-array value
+    read so typed-array / subview / array-method internal callers keep their own
+    correct OOB semantics. The map-on-array-like case
+    (`built-ins/Array/prototype/map/15.4.4.19-8-b-2.js`) must be green. Tracked
+    as roadmap floor fix **F1** → follow-up issue **R1** (see below).
+  - **PR #2195 / issue #2754 (the "sound TS settings" spec)** — **revise to the
+    HI framing**: Prong 1 stays as-is; Prong 2 is reframed from "enumerate &
+    patch the holes" to "SAFE JS-correct default + proof-gated specialization."
+    The roadmap doc above is the authority for Prong 2.
+  - **#2698 (checker track) — Prong 2 re-scoped to HI.** The codegen Prong-2 work
+    is now governed by the roadmap doc, not a standalone open-ended hole catalog.
+
+### Follow-up issues created (sprint: current, status: ready)
+
+These make the first roadmap steps dispatchable (see the roadmap's "Sequencing
+summary & follow-up issues" table):
+
+- **R1 — #2760**: floor fix F1 (plain-array OOB → JS `undefined`, HI-style; the
+  #2198/S2 rework, NOT the shared-helper flip) + F2 hole-read audit + F3 doc.
+- **R2 — #2761**: first IR step — `ElementAccessExpression` under HI: port the
+  `safeIndexedArrays` counted-loop in-bounds proof into the IR so `vec.get`
+  fires only when in-bounds is proven; otherwise emit the SAFE bounds-checked
+  read (F1 reused as the IR SAFE lowering).
+- **R3 — #2762**: migration-cost audit as a living checklist — annotate every
+  type-directed fast path (roadmap §(d)) with its discharged/undischarged proof
+  status; this is the backlog generator for the M/L specialization items.
+
+The `substrate/value-identity` workstream (roadmap §(e): acorn #2681/#2686 +
+#1627 class-instance tail + #2740 instanceof clusters) and the sibling
+`substrate/closure-box` (#2758 under #2692) are tracked under their own lineages,
+not folded together — see the roadmap's §(e) architect verdict.
 
 ## Notes
 

--- a/plan/issues/2755-evaluate-type-soundness-approach.md
+++ b/plan/issues/2755-evaluate-type-soundness-approach.md
@@ -181,7 +181,7 @@ summary & follow-up issues" table):
 
 - **R1 — #2760**: floor fix F1 (plain-array OOB → JS `undefined`, HI-style; the
   #2198/S2 rework, NOT the shared-helper flip) + F2 hole-read audit + F3 doc.
-- **R2 — #2761**: first IR step — `ElementAccessExpression` under HI: port the
+- **R2 — #2766**: first IR step — `ElementAccessExpression` under HI: port the
   `safeIndexedArrays` counted-loop in-bounds proof into the IR so `vec.get`
   fires only when in-bounds is proven; otherwise emit the SAFE bounds-checked
   read (F1 reused as the IR SAFE lowering).

--- a/plan/issues/2760-hybrid-floor-plain-array-oob-undefined.md
+++ b/plan/issues/2760-hybrid-floor-plain-array-oob-undefined.md
@@ -1,0 +1,106 @@
+---
+id: 2760
+title: "Hybrid floor F1: plain-array OOB read → JS `undefined` (HI-style #2198/S2 rework, not the shared-helper flip)"
+status: ready
+sprint: current
+created: 2026-06-28
+updated: 2026-06-28
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: medium
+task_type: bugfix
+area: codegen
+language_feature: array-index
+goal: correctness
+related: [2755, 2198, 2754, 2698, 2001]
+---
+
+# #2760 — Hybrid floor F1: plain-array OOB read → JS `undefined`
+
+Implements floor fix **F1** of the hybrid type-soundness roadmap
+([`docs/architecture/hybrid-soundness-ir-roadmap.md`](../../docs/architecture/hybrid-soundness-ir-roadmap.md),
+§(c)). This is the **HI-style rework** of the parked PR #2198 S2 slice — the
+decision in [#2755](2755-evaluate-type-soundness-approach.md) is the **hybrid**,
+under which OOB correctness must *fall out of the safe default element-read path*,
+not be patched by toggling a shared low-level helper.
+
+## Problem
+
+A plain-array out-of-bounds value read (`const a: number[] = [1,4,5]; a[4]`) does
+not return JS `undefined`. The bounds-checked path returns a **type-default
+sentinel** — sNaN for `number`, `false` for `boolean`, `ref.null.extern` → JS
+`null` for externref elements — never `undefined`. JS semantics: an absent index
+reads as `undefined`.
+
+## Why NOT the parked S2 approach
+
+PR #2198 set `useUndefinedSentinel=true` on the **shared** helper
+`emitBoundsCheckedArrayGet` (`src/codegen/array-methods.ts:386`). That helper is
+also called by typed-array reads, the `$__subview` path
+(`property-access.ts:6034`), and the array-method machinery. The flip perturbed a
+generic `Array.prototype.map`-on-array-like path and regressed
+`built-ins/Array/prototype/map/15.4.4.19-8-b-2.js` — the deciding data point that
+"patch-the-holes on a shared representation" is leaky. **Do not re-land the
+shared-helper flip.**
+
+## Implementation Plan
+
+### Root cause
+The two non-bounds-eliminated element-read call sites in
+`compileElementAccessBody` pass `useUndefinedSentinel=false`, so OOB yields the
+type-default sentinel instead of `undefined`. Flipping the shared helper's
+default is too broad (blast radius into typed-array/subview/array-method callers).
+
+### Changes — scope the OOB→undefined policy to the call site
+
+**File: `src/codegen/property-access.ts`**
+- `compileElementAccessBody`, the two non-bounds-eliminated read sites:
+  - typed-array element read at **line ~6303** (`emitBoundsCheckedArrayGet(fctx, arrTypeIdx, arrDef.element, ctx, false, taSignedness)`)
+  - plain-array element read at **line ~6352** (`emitBoundsCheckedArrayGet(fctx, typeIdx, typeDef.element, ctx, false, taSignednessArr)`)
+- Make the OOB→`undefined` decision an **explicit, call-site-owned** policy for
+  the **dynamic plain-array value read** only. Two acceptable shapes:
+  - **(a)** handle OOB→`undefined` at the `compileElementAccessBody` level
+    (wrap/replace the plain-array call site) so the shared helper is untouched,
+    or
+  - **(b)** thread an explicit `oobPolicy` parameter the *caller* owns: plain
+    dynamic reads pass `"undefined"`, the typed-array / `$__subview` / array-
+    method internal callers keep their existing default.
+- **Leave the typed-array read path on its own correct OOB semantics** (a typed-
+  array OOB is `undefined` too, but it is reached through a different value-rep
+  and must be verified independently — keep it out of F1's scope to avoid the S2
+  blast radius). The `$__subview` call site (`property-access.ts:6034`) and all
+  `array-methods.ts` internal callers MUST be unaffected.
+
+### Edge cases
+- Negative index (`a[-1]`) → `undefined` (the `i32.lt_u` bounds test already
+  treats negatives as huge unsigned, so they hit the OOB branch).
+- `number[]` OOB previously read sNaN → must now read `undefined` (representation
+  changes from f64 to the externref `undefined` singleton; ensure the result
+  ValType is handled by the caller — element access result may now be externref
+  in the OOB-possible case, or boxed consistently).
+- Hole-in-bounds (`[1,,3][1]`) keeps the existing `$Hole → undefined` mapping
+  (`emitHoleToUndefined`); F1 is about *absent* (OOB), F2 is about *holes*.
+- The `Array.prototype.map`-on-array-like case
+  (`built-ins/Array/prototype/map/15.4.4.19-8-b-2.js`) MUST be green.
+
+### Also (F2, F3 — small)
+- **F2:** audit `emitHoleToUndefined` coverage for gaps in the typed-element
+  (`number[]`/`boolean[]`) read paths (`array-methods.ts:481`).
+- **F3:** add a doc-comment marking `emitThisReceiverGuardConvert`
+  (`property-access.ts:5405`) as the **HI exemplar** (runtime `ref.test` instead
+  of trusting the static type).
+
+### Test gating
+- No test262 regression in the `merge_group` re-validation.
+- Targeted correctness: OOB plain-array reads return `undefined`; the
+  map-on-array-like case flips/stays green.
+- `.ts`/`.js` parity: the SAFE OOB read is identical for typed and untyped
+  sources.
+
+## Acceptance criteria
+- `a[OOB]` on a plain `T[]` reads JS `undefined` (all element types).
+- `emitBoundsCheckedArrayGet` shared default is **unchanged**; typed-array /
+  subview / array-method internal callers are byte-identical.
+- `built-ins/Array/prototype/map/15.4.4.19-8-b-2.js` is green; no net test262
+  regression.

--- a/plan/issues/2761-hybrid-ir-elementaccess-prove-then-specialize.md
+++ b/plan/issues/2761-hybrid-ir-elementaccess-prove-then-specialize.md
@@ -1,0 +1,101 @@
+---
+id: 2761
+title: "Hybrid IR step 1: ElementAccess prove-then-specialize — vec.get only when in-bounds is proven, else SAFE bounds-checked read"
+status: ready
+sprint: current
+created: 2026-06-28
+updated: 2026-06-28
+priority: high
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: feature
+area: codegen, ir
+language_feature: array-index
+goal: correctness
+related: [2755, 2760, 1530, 1131, 1804]
+depends_on: [2760]
+---
+
+# #2761 — Hybrid IR step 1: ElementAccess prove-then-specialize
+
+First IR-adoption step of the hybrid roadmap
+([`docs/architecture/hybrid-soundness-ir-roadmap.md`](../../docs/architecture/hybrid-soundness-ir-roadmap.md),
+§(b)). `ElementAccessExpression` is chosen first because it is the **sharpest HI
+violation** with the **smallest SAFE-lowering gap**.
+
+## Problem
+
+The IR element read (`src/ir/from-ast.ts:1919` `lowerElementAccess` →
+`emitVecGet` → backend `vec.get` → `array.get`) **traps on OOB** and *explicitly*
+defers JS-correct OOB to the selector (comment at `from-ast.ts:1952–1960`:
+"slice 12 doesn't add an explicit JS-style `undefined` return for OOB …
+functions whose hot path indexes outside `[0,length)` should already be falling
+back to legacy"). That is a pure **trust-the-type fast path with no SAFE
+fallback** — strictly worse than legacy, which at least returns a (wrong)
+sentinel. Under the hybrid invariant (HI) this is exactly the pattern we retire:
+*specialize only when proven safe; otherwise lower the JS-correct way.*
+
+## Implementation Plan
+
+### The HI rule for this kind
+- **FAST lowering** (`vec.get` / `array.get`, no bounds check): emit **only when
+  the index is provably in `[0, length)`** at this site.
+- **SAFE lowering** (bounds-checked read returning JS `undefined` on OOB):
+  the default whenever the in-bounds proof cannot be discharged. This reuses the
+  floor fix from **#2760** (F1) as the IR SAFE lowering — do **not** re-introduce
+  a trapping read as the fallback.
+
+### Proof primitive — port `safeIndexedArrays` into the IR
+- Legacy already has the proof: `isSafeBoundsEliminated`
+  (`src/codegen/property-access.ts:5371`) + `fctx.safeIndexedArrays`, populated
+  by the counted-loop analysis (`array-element-typing.ts`
+  `collectForCounterNames` / counter bounds). It records `arrayVar:indexVar`
+  pairs proven `index < array.length`.
+- Bring an equivalent in-bounds proof to the IR `lowerElementAccess` path:
+  - **(P1)** literal index `k` with a statically-known length `len` and `0 ≤ k <
+    len` (fresh `vec.new_fixed` array, #1804) → in-bounds.
+  - **(P2)** counted-loop induction variable bounded by `array.length` (port the
+    `safeIndexedArrays` set, or recompute on the IR via the loop's IR shape).
+  - Otherwise → **not proven** → SAFE lowering.
+
+### Changes
+**File: `src/ir/from-ast.ts`**
+- `lowerElementAccess` (line ~1919): replace the unconditional
+  `emitVecGet(...)` (line ~1990) with a proof check:
+  - if in-bounds proven (P1/P2) → `emitVecGet` (current fast path), keep.
+  - else → emit the SAFE bounds-checked read (new IR lowering / shared helper)
+    that returns `undefined` on OOB — the IR counterpart of #2760's F1 read.
+- Remove the reliance on "the selector keeps OOB functions in legacy": once the
+  SAFE lowering exists in the IR, OOB-indexing functions no longer need to demote
+  to legacy for correctness. (Coordinate the selector/scope so this kind is
+  promoted toward `ir-owned` per `plan/log/ir-adoption.md`.)
+
+**File: `src/ir/backend/*` (emitter trait)**
+- Add the SAFE bounds-checked-`vec.get`-with-undefined-OOB intent to the
+  `BackendEmitter` trait if it is not expressible via existing intents, so both
+  WasmGC and linear emitters can lower it (mirrors the #1714 vec-group two-
+  backend pattern). If a thin composition of existing `emitVecLen` +
+  `emitElemGet` + an if/else suffices, prefer that.
+
+### #1530 alignment
+This is the first concrete instance of the redefined IR fallback: *fall to the
+SAFE JS-correct lowering, never the legacy trust-the-type path.* When the
+ElementAccess rejection buckets reach zero and the only two outcomes are
+FAST-with-proof or SAFE, promote the `ElementAccessExpression` row in
+`plan/log/ir-adoption.md` and zero its bucket in
+`scripts/ir-fallback-baseline.json`.
+
+### Test gating
+- No test262 regression in the `merge_group` re-validation.
+- `pnpm run check:ir-fallbacks` must not grow any unintended bucket.
+- A targeted IR test: an OOB dynamic read compiled via the IR returns
+  `undefined` (not a trap), and an in-bounds counted-loop read still emits the
+  no-bounds-check `array.get` (proof discharged).
+
+## Acceptance criteria
+- IR `lowerElementAccess` never emits a trapping OOB read; OOB → `undefined` via
+  the SAFE lowering.
+- Counted-loop / literal-bounded reads still get the fast `vec.get` (no perf
+  regression on the proven-safe path).
+- No net test262 regression; ir-fallback budget unbroken.

--- a/plan/issues/2762-hybrid-fastpath-safety-audit-checklist.md
+++ b/plan/issues/2762-hybrid-fastpath-safety-audit-checklist.md
@@ -1,0 +1,80 @@
+---
+id: 2762
+title: "Hybrid migration-cost audit: type-directed fast-path safety-predicate checklist (living doc)"
+status: ready
+sprint: current
+created: 2026-06-28
+updated: 2026-06-28
+priority: medium
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: architecture
+area: codegen, ir
+language_feature: none
+goal: maintainability
+related: [2755, 2760, 2761, 1530]
+---
+
+# #2762 — Hybrid migration-cost audit: fast-path safety-predicate checklist
+
+Makes the migration-cost sizing from the hybrid roadmap
+([`docs/architecture/hybrid-soundness-ir-roadmap.md`](../../docs/architecture/hybrid-soundness-ir-roadmap.md),
+§(d)) **dispatchable** by turning it into a living, per-fast-path checklist that
+tracks the discharged/undischarged state of each safety predicate `P`. This is
+the backlog generator for the M/L specialization items.
+
+## Problem
+
+The hybrid invariant requires that every type-directed fast path be either
+*already proof-gated* or *converted to prove-then-specialize*. The roadmap §(d)
+enumerates ~9 fast-path families with a safety predicate and an effort band, but
+that table is a snapshot. We need a **tracked checklist** so each path's status
+is visible and convertible into its own issue when worked.
+
+## Scope (no compiler code — a tracking/checklist deliverable)
+
+Produce and maintain a per-fast-path table (in this issue, or a dedicated
+`plan/log/hybrid-fastpath-audit.md`) with, for each path:
+
+| Field | Meaning |
+|-------|---------|
+| Fast path | name + anchor (file:line) |
+| Safety predicate `P` | the proof HI requires |
+| Status | `discharged` / `partial` / `undischarged` |
+| Gating analysis | which existing analysis discharges `P` (or "none yet") |
+| Class | easy / subtle |
+| Effort | S / M / L |
+| Follow-up | issue id once converted, or "—" |
+
+Seed it from roadmap §(d):
+
+1. IR `vec.get` element read — `from-ast.ts:1919/1990` — `P`: index ∈ [0,len) —
+   **partial** (being addressed by #2761) — counted-loop/literal proof — M.
+2. Legacy bounds-eliminated read — `property-access.ts:5371,6333` — `P`:
+   counted-loop bound — **discharged** — `safeIndexedArrays` — S.
+3. Packed-`i32` arrays — `array-element-typing.ts:44,212` — `P`: all writes
+   i32-safe ints, no NaN/fractional/large read distinction — **undischarged
+   (subtle)** — `collectI32SpecializedArrays` approximates — L.
+4. Monomorphic `struct.get`/`set` — `property-access.ts` (`resolveStructName`,
+   `emitNullGuardedStructGet`) — `P`: receiver provably nominal, no union/`any`/
+   divergent-subclass — **undischarged (subtle)** — IR receiver narrowing — L.
+5. Unboxed `f64`/`i32` number locals — `P`: value never escapes to any/externref
+   sink unboxed — **partial** — IR escape analysis (`escape.ts:92`) — M.
+6. `ArrayLiteral` → `vec.new_fixed` — `from-ast.ts` (#1804) — `P`: same static
+   element type, not later widened — **partial (local)** — S.
+7. `Binary` unboxed arithmetic — `from-ast.ts:3787`; `binary-ops.ts` — `P`:
+   operands provably number, `+` not string-`+` — **partial** — M.
+8. `this`-receiver typed read — `property-access.ts:5405` — `P`: runtime
+   `ref.test` guard — **discharged (exemplar)** — S.
+9. Typed-array element read — `property-access.ts:6285–6316`;
+   `array-methods.ts:386` — `P`: view length bound, OOB → undefined —
+   **partial** (kept separate from #2760 plain-array scope) — S–M.
+
+## Deliverable / acceptance criteria
+- A committed, maintainable checklist (this issue body or
+  `plan/log/hybrid-fastpath-audit.md`) covering all rows above.
+- Each `undischarged`/`partial` subtle row (3, 4, and the general arms of 1/5/7)
+  has a one-line "what would discharge `P`" note so it can be spun into its own
+  proof-gated follow-up issue.
+- Cross-linked from the roadmap doc's §(d).

--- a/plan/issues/2762-hybrid-fastpath-safety-audit-checklist.md
+++ b/plan/issues/2762-hybrid-fastpath-safety-audit-checklist.md
@@ -13,7 +13,7 @@ task_type: architecture
 area: codegen, ir
 language_feature: none
 goal: maintainability
-related: [2755, 2760, 2761, 1530]
+related: [2755, 2760, 2766, 1530]
 ---
 
 # #2762 — Hybrid migration-cost audit: fast-path safety-predicate checklist
@@ -50,7 +50,7 @@ Produce and maintain a per-fast-path table (in this issue, or a dedicated
 Seed it from roadmap §(d):
 
 1. IR `vec.get` element read — `from-ast.ts:1919/1990` — `P`: index ∈ [0,len) —
-   **partial** (being addressed by #2761) — counted-loop/literal proof — M.
+   **partial** (being addressed by #2766) — counted-loop/literal proof — M.
 2. Legacy bounds-eliminated read — `property-access.ts:5371,6333` — `P`:
    counted-loop bound — **discharged** — `safeIndexedArrays` — S.
 3. Packed-`i32` arrays — `array-element-typing.ts:44,212` — `P`: all writes

--- a/plan/issues/2762-hybrid-fastpath-safety-audit-checklist.md
+++ b/plan/issues/2762-hybrid-fastpath-safety-audit-checklist.md
@@ -5,7 +5,7 @@ status: ready
 sprint: current
 created: 2026-06-28
 updated: 2026-06-28
-priority: medium
+priority: high
 horizon: s
 feasibility: easy
 reasoning_effort: medium

--- a/plan/issues/2766-hybrid-ir-elementaccess-prove-then-specialize.md
+++ b/plan/issues/2766-hybrid-ir-elementaccess-prove-then-specialize.md
@@ -1,5 +1,5 @@
 ---
-id: 2761
+id: 2766
 title: "Hybrid IR step 1: ElementAccess prove-then-specialize — vec.get only when in-bounds is proven, else SAFE bounds-checked read"
 status: ready
 sprint: current
@@ -17,7 +17,7 @@ related: [2755, 2760, 1530, 1131, 1804]
 depends_on: [2760]
 ---
 
-# #2761 — Hybrid IR step 1: ElementAccess prove-then-specialize
+# #2766 — Hybrid IR step 1: ElementAccess prove-then-specialize
 
 First IR-adoption step of the hybrid roadmap
 ([`docs/architecture/hybrid-soundness-ir-roadmap.md`](../../docs/architecture/hybrid-soundness-ir-roadmap.md),


### PR DESCRIPTION
Records the project lead's **DECISION** on #2755: the **HYBRID** type-soundness direction.

> *"A TS type may only change the emitted Wasm when the value provably cannot violate it at runtime; otherwise lower the JS-correct way."* Correctness is the default; specialization must be proven.

## What this PR does (docs-only)

1. **#2755 — decision recorded.** Marks the hybrid chosen (`status: done`, `decision: hybrid`) and sets dispositions:
   - **PR #2198 (S1+S2 code):** keep S1; **rework S2 under HI** — do NOT re-land the shared-helper `useUndefinedSentinel` flip (it leaked into the generic `Array.prototype.map`-on-array-like path — the deciding data point). Make OOB-correctness fall out of the safe default element-read.
   - **PR #2195 / issue #2754 (sound-TS-settings spec):** revise to the HI framing (Prong 1 stays; Prong 2 reframed to "SAFE default + proof-gated specialization").
   - **#2698 (checker track):** Prong 2 re-scoped to HI.
2. **New `docs/architecture/hybrid-soundness-ir-roadmap.md`:**
   - (a) the hybrid invariant precisely + **#1530 IR-fallback redefined** as "fall to the SAFE JS-correct default, never the legacy trust-the-type path" — so the soundness and IR-migration tracks share a finish line.
   - (b) **IR-adoption order** for the four hybrid-governed kinds: `ElementAccess → ArrayLiteral → Binary → PropertyAccess`, test-gated.
   - (c) **FLOOR (legacy, now)** vs **SPECIALIZATION (IR, proof-gated)** split.
   - (d) **Migration-cost sizing** — every type-directed fast path with its safety predicate, easy/subtle class, and S/M/L effort band (the lead's key deliverable).
   - (e) the **$Object/dynamic-reader value-identity substrate** workstream with three converging signals (acorn #2681/#2686 + #1627 class-instance tail + #2740 instanceof clusters 1&2); #2758 assessed as the *sibling* closure-box substrate, not folded in.
3. **Three dispatchable follow-up issues** (ids via `claim-issue.mjs --allocate`, `sprint: current`, `status: ready`):
   - **#2760** — floor fix F1 (plain-array OOB → `undefined`, HI-style; the #2198/S2 rework).
   - **#2766** — first IR step: `ElementAccessExpression` prove-then-specialize (`vec.get` only when in-bounds is proven, else SAFE bounds-checked read).
   - **#2762** — fast-path safety-predicate audit checklist (migration-cost backlog generator).

## Migration-cost bottom line

Of ~9 type-directed fast-path families: **~2 are already HI-compliant** (proof already discharged — `safeIndexedArrays` bounds-elim, `this`-receiver `ref.test`), **~4 are S–M** (local / analysis-backed proofs), and **only ~2–3 are L** (packed-i32 arrays, monomorphic struct reads, plus the substrate work). The expensive tail is small and isolable — which is exactly why the hybrid beats a pure up-front rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)