### PR TITLE
docs(#2740): re-scope instanceof residual into umbrella + split #2763/#2764/#2765

### DIFF
--- a/plan/issues/2740-instanceof-residual-noncallable-rhs-evalorder-hasinstance.md
+++ b/plan/issues/2740-instanceof-residual-noncallable-rhs-evalorder-hasinstance.md
@@ -1,76 +1,71 @@
 ---
 id: 2740
-title: "instanceof residual: non-callable RHS TypeError, null/undefined LHS, evaluation-order ReferenceError, Symbol.hasInstance arg count"
-status: in-progress
+title: "[UMBRELLA] instanceof residual after #2702 — 5 deep gaps, split into #2763/#2764/#2765"
+status: ready
 sprint: current
 created: 2026-06-27
-updated: 2026-06-27
+updated: 2026-06-28
 priority: medium
-feasibility: medium
+horizon: s
+feasibility: hard
 reasoning_effort: medium
-task_type: bug
+task_type: planning
 area: codegen
 es_edition: ES3
 language_feature: instanceof
 goal: test262-conformance
 parent: 2702
 depends_on: []
+children: [2763, 2764, 2765]
 ---
-# #2740 — `instanceof` residual after #2702
+# #2740 — `instanceof` residual after #2702 (UMBRELLA — do not implement directly)
 
 `#2702` delivered the core `OrdinaryHasInstance` ordering (step 3 before step 4)
-and the non-object RHS `TypeError`. The current main baseline
-(`benchmarks/results/test262-current.jsonl`, HEAD = the 2026-06-27 baseline
-refresh, 32 commits after the last #2702 fix) still shows **13 residual
-`language/expressions/instanceof` fails** that group into four concrete bugs.
+and the non-object RHS `TypeError`. A verify-first investigation on 2026-06-28
+(local sweep: **28 pass / 15 fail** in `test/language/expressions/instanceof/`)
+found that the residual failures are **NOT instanceof-operator bugs** — the
+operator semantics are correct. They are symptoms of **5 distinct deep feature
+gaps**. The original "4 concrete bugs" framing mis-diagnosed where the failures
+originate (e.g. the "null/undefined LHS" group is actually a `.prototype`
+property-access trap on dynamic `Function(...)` values).
 
-## Failing test262 files (current main)
+This issue is now an **umbrella / tracking** record. Do not implement it
+directly — work the split sub-issues below.
 
-**(a) Non-callable RHS must throw `TypeError` ("Only Function objects implement
-[[HasInstance]]")** — we currently do not throw:
-- `test/language/expressions/instanceof/S11.8.6_A6_T1.js`
-- `test/language/expressions/instanceof/S11.8.6_A6_T4.js`
-- `test/language/expressions/instanceof/S15.3.5.3_A2_T6.js`
-- `test/language/expressions/instanceof/S15.3.5.3_A2_T2.js`
-- `test/language/expressions/instanceof/S11.8.6_A2.4_T1.js`
+## Split
 
-**(b) `null` / `undefined` LHS — our compiler raises an internal null-deref
-("TypeError: Cannot access property on null or undefined") instead of returning
-`false`** per `OrdinaryHasInstance` step 2 (`If Type(O) is not Object, return
-false`):
-- `test/language/expressions/instanceof/S15.3.5.3_A3_T1.js`
-- `test/language/expressions/instanceof/S15.3.5.3_A2_T5.js`
-- `test/language/expressions/instanceof/S11.8.6_A7_T3.js`
+| Sub-issue | Clusters | Routing | Tests |
+|-----------|----------|---------|-------|
+| **#2763** | (1) cross-realm `Object`/`Function` constructor identity in the dynamic instanceof path; (2) `.prototype` access on dynamic `Function(...)`/`new Function` values traps | SUBSTRATE / architect (folds into the value-rep / IR roadmap) | A2.1_T1, A2.4_T1, A2.4_T4, A6_T1, A6_T4 · A2_T6, A2_T2, A3_T1, A2_T5, A7_T1, A7_T3, A3_T2 |
+| **#2764** | (3) `@@hasInstance` handler invoked at unknown-arity → `arguments.length` wrong (host method-bridge) | dispatcher half RESOLVED by #2213; **verified one-line residual** in `_instanceofResult` | symbol-hasinstance-invocation |
+| **#2765** | (4) `Function.prototype` "prototype" getter + WasmGC array prototype chain; (5) undeclared-global read → `ReferenceError` (broad/risky) | hard (cluster 5 may be wont-fix) | prototype-getter-with-object · A2.1_T3 |
 
-**(c) Evaluation order — RHS reference must be evaluated and may throw
-`ReferenceError`; the LHS-then-RHS order and the "joined objects" identity
-checks fail:**
-- `test/language/expressions/instanceof/S11.8.6_A2.1_T3.js` (expects
-  `ReferenceError`, we throw `Test262Error`)
-- `test/language/expressions/instanceof/S11.8.6_A2.4_T4.js`
-- `test/language/expressions/instanceof/S15.3.5.3_A3_T2.js`
+## Root-cause summary (full detail in each sub-issue)
 
-**(d) `Symbol.hasInstance` invocation protocol — the well-known method must be
-called with exactly one argument and its return ToBoolean-coerced:**
-- `test/language/expressions/instanceof/symbol-hasinstance-invocation.js`
-  (`assert.sameValue(args.length, 1)`)
-- `test/language/expressions/instanceof/prototype-getter-with-object.js`
-  (`[]` should be `instanceof Function.prototype` via a prototype getter)
+1. **Cross-realm value-rep (#2763)** — `var O = Object; ({}) instanceof O` is
+   `false` at runtime: `Object`/`Function` arrive in `_instanceofResult` as a
+   *sandbox-realm* native fn (`target !== Object` host identity) and the `{}`
+   LHS arrives as a real host object; the direct form only passes via static
+   fold. `({}) instanceof this` (this = undefined) returns false instead of
+   throwing. Plus an over-eager codegen static-throw for primitive-typed-but-
+   reassignable RHS (`var O=0; (O=Object,…)`).
+2. **`.prototype` on dynamic Function values (#2763)** — `Function(...)`/`new
+   Function` now return real callables (the `runtime.ts` "lowers to undefined"
+   comment is STALE), but reading `.prototype` off one traps "Cannot access
+   property on null or undefined". This is the cluster mis-labeled "null/
+   undefined LHS"; the null-deref is on `FACTORY.prototype`, not in instanceof.
+3. **`@@hasInstance` arity (#2764)** — VERIFIED: #2213 fixed the dispatcher half
+   (`emitClosureMethodCallExportN` now sets `__argc`); the residual is a verified
+   one-liner bridging the handler at arity 1 in `_instanceofResult`.
+4. **`Function.prototype` getter + array proto chain (#2765)** — hard.
+5. **undeclared-global → ReferenceError (#2765)** — broad cross-cutting semantic;
+   may be wont-fix.
 
-## Acceptance criteria
-
-- All 5 files in group (a) pass: a `V instanceof C` where `C` is not callable
-  throws `TypeError`.
-- All 3 files in group (b) pass: `null`/`undefined`/primitive LHS yields `false`
-  (no internal null-deref trap).
-- Group (c): RHS is evaluated as a reference; an unresolvable RHS throws
-  `ReferenceError`; joined-object identity holds. ≥2 of 3 pass.
-- Group (d): `Symbol.hasInstance` is invoked with `argumentsList` length 1 and
-  the result ToBoolean-coerced. Both files pass.
-- **Target: ≥11 of 13 residual instanceof tests fixed.** No regression in the
-  20 instanceof tests already green from #2702.
+## Out of scope
+BigInt-RHS and `with`-bound RHS instanceof tests (blocked clusters, sprint 67
+deferred list).
 
 ## Notes
-- Spec: ES2023 §13.10.2 `InstanceofOperator`, `OrdinaryHasInstance`.
-- BigInt-RHS and `with`-bound RHS instanceof tests are out of scope (blocked
-  clusters, see sprint 67 deferred list).
+- Spec: ES2023 §13.10.2 `InstanceofOperator`, §7.3.20 `OrdinaryHasInstance`.
+- No-regression bar for every sub-issue: the 28 instanceof tests currently green
+  must stay green.

--- a/plan/issues/2763-instanceof-value-rep-realm-and-dynamic-function-prototype.md
+++ b/plan/issues/2763-instanceof-value-rep-realm-and-dynamic-function-prototype.md
@@ -1,0 +1,87 @@
+---
+id: 2763
+title: "[SUBSTRATE][ARCH] instanceof value-rep residual: cross-realm Object/Function identity + .prototype access on dynamic Function values"
+status: ready
+sprint: Backlog
+created: 2026-06-28
+updated: 2026-06-28
+priority: medium
+horizon: l
+feasibility: hard
+reasoning_effort: high
+task_type: investigation
+area: runtime
+language_feature: instanceof
+goal: core-semantics
+parent: 2740
+depends_on: []
+---
+# #2763 — instanceof value-representation residual (cross-realm identity + dynamic-Function `.prototype`)
+
+Architect-scoped split of the #2740 umbrella. These two clusters are NOT
+instanceof-operator bugs — they are value-representation gaps that surface
+through `instanceof` tests. They fold into the value-rep / IR substrate roadmap.
+Verified against current `main` on 2026-06-28 (see #2740 for the full trace).
+
+## Cluster 1 — cross-realm `Object`/`Function` constructor identity (value-rep)
+
+`var O = Object; ({}) instanceof O` returns **false** at runtime (should be
+`true`). The DIRECT `({}) instanceof Object` only passes because it is
+*static-folded* in codegen, masking the gap.
+
+Root cause (traced in `_instanceofResult`, `src/runtime.ts`): when the RHS
+constructor flows through a variable to the dynamic path
+(`__instanceof_check`), the `Object`/`Function` globals arrive as a
+**sandbox-realm** `function Object(){ [native code] }`, so `target === Object`
+(the host-realm intrinsic) is **false**; and the `{}` LHS arrives as a *real
+host object* whose `[[Prototype]]` is host `Object.prototype`, so the native
+`v instanceof target` walks a mismatched prototype chain and yields false. The
+explicit WasmGC-struct Object/Function recognition (`_isWasmStruct(v)` +
+`target === Object`) does not fire because (a) `v` is a real object not a wasm
+struct here, and (b) the realm-split breaks the identity compare.
+
+Affected test262 (failing on main):
+- `language/expressions/instanceof/S11.8.6_A2.1_T1.js` (`var O=Object; ({}) instanceof O === true`)
+- `language/expressions/instanceof/S11.8.6_A2.4_T1.js` (`var O=0; (O=Object,{}) instanceof O` — also hits the over-eager static-throw)
+- `language/expressions/instanceof/S11.8.6_A2.4_T4.js` (`(O=Object,{}) instanceof O`, undeclared O)
+- `language/expressions/instanceof/S11.8.6_A6_T1.js` (`({}) instanceof this`; top-level `this` is `undefined`, dynamic path returns false instead of throwing TypeError)
+- `language/expressions/instanceof/S11.8.6_A6_T4.js` (plain-function `new MyFunct` + `instanceof MyFunct`/`Function`/`Object` + non-callable throw)
+
+Note: there is ALSO an over-eager codegen static-throw — `compileHostInstanceOf`
+in `src/codegen/expressions/identifiers.ts` throws `TypeError` unconditionally
+when the RHS *static type* is exclusively primitive (e.g. `var O = 0`), which is
+unsound for a reassignable binding (`O = Object` at runtime). Narrowing that
+static-throw to literal/keyword-primitive RHS only (routing identifiers to the
+dynamic check) is the codegen half; it must land together with the realm-safe
+runtime recognition or A2.4_T1 flips from a wrong-throw to a wrong-`false`.
+
+## Cluster 2 — `.prototype` access on dynamic `Function(...)` / `new Function` values traps
+
+`Function(...)` and `new Function` DO return real callables now (the
+`src/runtime.ts` comment claiming they "lower to undefined" is **STALE** —
+verified: `typeof Function("return 1") === "function"`). But reading
+`.prototype` off such a value traps with the internal
+`"TypeError: Cannot access property on null or undefined"` — a property-access
+gap on Function-typed dynamic values, not an instanceof bug. This is the cluster
+the original #2740 framing mis-labeled "null/undefined LHS": the null-deref is on
+`FACTORY.prototype`, after `FACTORY = Function(...)`, not in the instanceof.
+
+Affected test262 (failing on main, all blocked on this `.prototype` trap before
+instanceof even runs):
+- `S15.3.5.3_A2_T6.js` (`new Function; FACTORY.prototype="error"` → expect TypeError)
+- `S15.3.5.3_A2_T2.js` (`new Function; FACTORY.prototype=undefined` → expect TypeError)
+- `S15.3.5.3_A3_T1.js` (`Function("…"); FACTORY.prototype.type=1; new FACTORY`)
+- `S15.3.5.3_A2_T5.js` (`Function("…"); FACTORY.prototype.name=…`)
+- `S11.8.6_A7_T1.js` / `S11.8.6_A7_T3.js` (`new Function; .constructor`/`.prototype`)
+- `S15.3.5.3_A3_T2.js` (`Function(); FAKEFACTORY.prototype = Object.prototype`)
+
+## Acceptance criteria
+- `var O = Object; ({}) instanceof O` → `true`; `var F = Function; (function(){}) instanceof F` → `true` (realm-safe constructor identity in the dynamic instanceof path).
+- `({}) instanceof this` (this = undefined) → throws `TypeError`.
+- `.prototype` read/write on a `Function(...)` / `new Function` value no longer traps.
+- No regression in the 28 instanceof tests currently green.
+
+## Notes
+- Spec: ES2023 §13.10.2, §7.3.20.
+- Key sites: `src/runtime.ts` `_instanceofResult` (~2215), `__instanceof_check`/`__instanceof` (~12224); `src/codegen/expressions/identifiers.ts` `compileHostInstanceOf`/`tryStaticInstanceOf`; property-access for `.prototype` on Function values in `src/codegen/property-access.ts`.
+- Architect should decide whether the realm-safe Object/Function recognition belongs in the runtime (`_instanceofResult`) or is subsumed by a broader value-rep change (the harness realm-split may itself need addressing).

--- a/plan/issues/2764-call-fn-method-export-drops-argc-arguments-length.md
+++ b/plan/issues/2764-call-fn-method-export-drops-argc-arguments-length.md
@@ -1,0 +1,77 @@
+---
+id: 2764
+title: "@@hasInstance handler invoked at unknown-arity (arguments.length wrong) — dispatcher half fixed by #2213; one-line residual"
+status: ready
+sprint: Backlog
+created: 2026-06-28
+updated: 2026-06-28
+priority: medium
+horizon: s
+feasibility: easy
+reasoning_effort: medium
+task_type: bugfix
+area: runtime
+language_feature: arguments
+goal: core-semantics
+parent: 2740
+depends_on: []
+related: [2213]
+---
+# #2764 — host method-bridge closure dispatch leaves `arguments` length stale
+
+Split of the #2740 umbrella. A general correctness bug (not instanceof-specific)
+surfaced by the instanceof `Symbol.hasInstance` test.
+
+## ✅ STATUS 2026-06-28: dispatcher half RESOLVED by #2213; residual is a verified one-liner
+
+Originally: a Wasm closure invoked from the host through the **method** dispatch
+bridge (`__call_fn_method_<N>`) built its `arguments` object from a **stale**
+`__argc` global. The non-method bridge (`__call_fn_<N>`,
+`emitClosureCallExportN`) sets `__argc`/`__extras_argv` before its `call_ref`
+(#820l); the method bridge (`emitClosureMethodCallExportN`,
+`src/codegen/index.ts`) did not.
+
+bind's **#2213** (merged to `main`) added the `__argc`/`__extras_argv` setup to
+`emitClosureMethodCallExportN` — exactly the dispatcher gap flagged here.
+Re-verified against current `main` (post-#2213 merge): the method export now
+sets `__argc` correctly.
+
+**Remaining residual — small and VERIFIED.** With #2213 in place,
+`language/expressions/instanceof/symbol-hasinstance-invocation.js` still fails
+(`arguments.length === 4`) ONLY because `_instanceofResult` (`src/runtime.ts`)
+bridges the `@@hasInstance` handler via `_maybeWrapCallableUnknownArity`, which
+dispatches the `this`-bound handler through `__call_fn_method_<maxArity>` (=4);
+`__argc` is then (correctly, post-#2213) set to 4. Per §13.10.2 step 4a the
+handler must be called with **exactly one** argument. Bridging it at known arity
+1 routes it through `__call_fn_method_1` → `__argc === 1`.
+
+Verified fix — in the `@@hasInstance` branch of `_instanceofResult`, replace the
+`_maybeWrapCallableUnknownArity(handler, …)` bridge with a known-arity-1 bridge:
+```ts
+// recover the raw closure (the property read may already have wrapped it) and
+// re-bridge at the spec-mandated arity 1
+const rawHandler = typeof handler === "function" ? (_wasmClosureWrapperTargets.get(handler) ?? handler) : handler;
+const wrappedHandler = _maybeWrapCallable(rawHandler, 1, callbackState);
+const hfn = typeof wrappedHandler === "function" ? wrappedHandler : typeof handler === "function" ? handler : undefined;
+```
+Confirmed locally on current main (cache cleared): with this change
+`symbol-hasinstance-invocation.js` PASSES (`arguments.length === 1`,
+`args[0] === 0`, `thisValue === F`, `callCount === 1`), and the other three
+`symbol-hasinstance-*` tests stay green.
+
+## Acceptance criteria
+- `symbol-hasinstance-invocation.js` passes (`arguments.length === 1`, `args[0] === 0`, `thisValue === F`, `callCount === 1`).
+- No regression in `symbol-hasinstance-not-callable` / `-to-boolean` / `-get-err` (all green) or other closure/arguments tests.
+
+## Notes
+- This is a broad-impact runtime change (the dynamic instanceof path), so land it
+  via its OWN PR with **full test262 CI** validation (`project_broad_impact_validate_full_ci`),
+  not folded into a docs PR.
+- Reproduction-harness gotcha: the test262 runner caches compiled wasm by source
+  SHA + a `compilerHash` that covers `runtime.ts` but NOT `src/index.ts`. When
+  iterating on `index.ts` codegen, clear `.test262-cache/` (or touch
+  `runtime.ts`) or the runner serves stale wasm and your change appears to no-op.
+- Sites: `src/runtime.ts` `_instanceofResult` (~2215, the residual fix);
+  `src/codegen/index.ts` `emitClosureMethodCallExportN` (dispatcher, fixed by
+  #2213) vs `emitClosureCallExportN` (the reference);
+  `src/codegen/statements/nested-declarations.ts` `emitArgumentsVecBody`.

--- a/plan/issues/2765-instanceof-hard-residuals-proto-getter-and-undeclared-ref.md
+++ b/plan/issues/2765-instanceof-hard-residuals-proto-getter-and-undeclared-ref.md
@@ -1,0 +1,63 @@
+---
+id: 2765
+title: "instanceof hard residuals: Function.prototype getter / WasmGC array proto-chain + undeclared-global ReferenceError"
+status: ready
+sprint: Backlog
+created: 2026-06-28
+updated: 2026-06-28
+priority: low
+horizon: l
+feasibility: hard
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: instanceof
+goal: core-semantics
+parent: 2740
+depends_on: []
+---
+# #2765 — instanceof hard residuals (two unrelated deep gaps)
+
+Hard split of the #2740 umbrella — two distinct deep gaps grouped here per
+tech-lead routing. Both surface through instanceof tests but are general
+semantics gaps. Verified on current `main` 2026-06-28.
+
+## Cluster 4 — `Function.prototype` "prototype" getter + WasmGC array prototype chain
+
+`language/expressions/instanceof/prototype-getter-with-object.js`:
+```js
+Object.defineProperty(Function.prototype, "prototype", { get() { return Array.prototype; } });
+var result = [] instanceof Function.prototype;   // expect true
+```
+`Function.prototype` is itself callable; OrdinaryHasInstance must read its
+`prototype` (firing the installed getter → `Array.prototype`), then walk
+`[]`'s prototype chain and find `Array.prototype` → `true`. Requires (a) the
+getter on `Function.prototype.prototype` to fire through the dynamic instanceof
+path, and (b) a WasmGC array (`[]`) to expose a real `[[Prototype]]` chain
+reaching `Array.prototype`. We currently return false. This is a
+prototype-chain / accessor-on-builtin-proto gap.
+
+## Cluster 5 — undeclared-global read should throw `ReferenceError`
+
+`language/expressions/instanceof/S11.8.6_A2.1_T3.js`:
+```js
+({}) instanceof OBJECT;   // OBJECT undeclared → must throw ReferenceError
+```
+We treat an undeclared global read as `undefined`, so the instanceof returns
+`false` instead of throwing `ReferenceError`. This is a **broad, cross-cutting**
+semantic (it affects *every* undeclared identifier read, not just instanceof
+RHS) and is risky to change narrowly — scope carefully. May be wont-fix /
+deferred depending on the cost-benefit of strict undeclared-reference semantics
+in the WasmGC backend.
+
+## Acceptance criteria
+- Cluster 4: `[] instanceof Function.prototype` with a `prototype` getter
+  returning `Array.prototype` → `true`; the getter fires exactly once.
+- Cluster 5: `({}) instanceof <undeclared>` throws `ReferenceError`
+  (or documented wont-fix with rationale if strict undeclared-read semantics are
+  out of scope for the backend).
+- No regression in the 28 instanceof tests currently green.
+
+## Notes
+- These are the two lowest-priority / hardest residuals of #2740; cluster 5 in
+  particular may be deferred. Filed for tracking completeness.


### PR DESCRIPTION
## Summary

Verify-first investigation of #2740 found the residual `instanceof` failures (local sweep: 28 pass / 15 fail) are **NOT instanceof-operator bugs** — #2702 already fixed the operator semantics. They are symptoms of **5 distinct deep feature gaps**. The original "4 concrete bugs" framing mis-diagnosed where the failures originate (notably the "null/undefined LHS" group is actually a `.prototype` property-access trap on dynamic `Function(...)` values).

Re-scopes #2740 as an **umbrella** and splits into:
- **#2763** [SUBSTRATE/ARCH] cross-realm `Object`/`Function` value-rep identity in the dynamic instanceof path + `.prototype` access on dynamic `Function(...)`/`new Function` values traps. Folds into the value-rep/IR roadmap.
- **#2764** `@@hasInstance` arity: bind's #2213 (merged) fixed the dispatcher half (`emitClosureMethodCallExportN` now sets `__argc`); the residual is a **verified one-line fix** in `_instanceofResult` (documented in the issue) — confirmed locally to flip `symbol-hasinstance-invocation.js` with no regression. Land via its own full-CI PR.
- **#2765** hard residuals: `Function.prototype` prototype getter / WasmGC array proto-chain + undeclared-global → `ReferenceError` (may be wont-fix).

## Changes
Docs/plan only — no code. Adds 3 sub-issue files (ids reserved via `claim-issue.mjs --allocate`), rewrites #2740 as the umbrella linking them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS