### PR TITLE
fix(#2764): invoke @@hasInstance handler at spec arity 1

### DIFF
--- a/plan/issues/2764-call-fn-method-export-drops-argc-arguments-length.md
+++ b/plan/issues/2764-call-fn-method-export-drops-argc-arguments-length.md
@@ -1,10 +1,12 @@
 ---
 id: 2764
 title: "@@hasInstance handler invoked at unknown-arity (arguments.length wrong) — dispatcher half fixed by #2213; one-line residual"
-status: ready
-sprint: Backlog
+status: done
+sprint: current
 created: 2026-06-28
 updated: 2026-06-28
+completed: 2026-06-28
+assignee: ttraenkler/agent-a2da3f181c62e4768
 priority: medium
 horizon: s
 feasibility: easy
@@ -75,3 +77,19 @@ Confirmed locally on current main (cache cleared): with this change
   `src/codegen/index.ts` `emitClosureMethodCallExportN` (dispatcher, fixed by
   #2213) vs `emitClosureCallExportN` (the reference);
   `src/codegen/statements/nested-declarations.ts` `emitArgumentsVecBody`.
+
+## Resolution (2026-06-28)
+Applied the documented one-liner in `_instanceofResult` (`src/runtime.ts`):
+recover the raw wasm closure from `_wasmClosureWrapperTargets` and re-bridge the
+`@@hasInstance` handler at the spec-mandated known arity 1 (via
+`_maybeWrapCallable(rawHandler, 1, …)` → `__call_fn_method_1` → `__argc === 1`)
+instead of the unknown-arity max bridge.
+
+Verified on current `main` (cache cleared) via the test262 harness:
+- `symbol-hasinstance-invocation.js`: fail → **pass**
+- `symbol-hasinstance-not-callable.js` / `-to-boolean.js` / `-get-err.js`: stay **pass**
+
+Added `tests/issue-2764.test.ts` (5 `assertEquivalent` cases: `arguments.length
+=== 1`, `args[0] === V`, `this === F` + `callCount === 1`, named-param binding,
+ToBoolean-coercion regression) — all green; `tests/issue-2702.test.ts` (8) stays
+green.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -2253,8 +2253,16 @@ function _instanceofResult(
   const handler = (target as Record<symbol, unknown>)[Symbol.hasInstance];
   if (handler !== undefined && handler !== null && handler !== Function.prototype[Symbol.hasInstance]) {
     // A *custom* @@hasInstance must be callable (GetMethod), else TypeError.
-    const wrappedHandler = _maybeWrapCallableUnknownArity(handler, callbackState);
-    const hfn = typeof wrappedHandler === "function" ? wrappedHandler : handler;
+    // §13.10.2 step 4a mandates the handler be invoked with EXACTLY ONE argument
+    // (V). The property read may already have wrapped the wasm closure at the
+    // method bridge's max arity (=4), which would surface as `arguments.length
+    // === 4` inside the handler. Recover the raw closure and re-bridge at the
+    // known arity 1 so the wasm dispatcher routes via `__call_fn_method_1`
+    // (→ `__argc === 1`) instead of the unknown-arity max bridge (#2764).
+    const rawHandler = typeof handler === "function" ? (_wasmClosureWrapperTargets.get(handler) ?? handler) : handler;
+    const wrappedHandler = _maybeWrapCallable(rawHandler, 1, callbackState);
+    const hfn =
+      typeof wrappedHandler === "function" ? wrappedHandler : typeof handler === "function" ? handler : undefined;
     if (typeof hfn !== "function") return _INSTANCEOF_THROW;
     // step 3: Return ToBoolean(Call(instOfHandler, target, «V»)). `this` is the
     // ORIGINAL target so a WasmGC-struct receiver round-trips to the same ref.

--- a/tests/issue-2764.test.ts
+++ b/tests/issue-2764.test.ts
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2764 — a custom `@@hasInstance` (Symbol.hasInstance) handler must be invoked
+// at the spec-mandated arity of EXACTLY ONE argument (ECMA-262 §13.10.2 step 4a:
+// `Return ToBoolean(Call(instOfHandler, C, «O»))`). The runtime bridge
+// (`_instanceofResult` in src/runtime.ts) previously dispatched the handler
+// through the method bridge at its *max* arity (=4), so `arguments.length` was
+// 4 inside the handler instead of 1. The fix re-bridges the recovered raw
+// closure at known arity 1 (→ `__call_fn_method_1` → `__argc === 1`).
+//
+// Each case is validated by `assertEquivalent`, which runs the compiled wasm AND
+// native JS and asserts they agree — native JS implements the spec, so a match
+// proves the wasm matches the spec.
+import { describe, it } from "vitest";
+import { assertEquivalent } from "./equivalence/helpers.js";
+
+describe("#2764 @@hasInstance handler arity", () => {
+  it("handler sees arguments.length === 1 (not the bridge's max arity)", async () => {
+    await assertEquivalent(
+      `
+      export function test(): number {
+        const F: any = {};
+        let argc = -1;
+        F[Symbol.hasInstance] = function () {
+          argc = arguments.length;
+          return false;
+        };
+        const _ = (0 as any) instanceof F;
+        return argc;
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("handler receives V as its sole argument (args[0] === V)", async () => {
+    await assertEquivalent(
+      `
+      export function test(): number {
+        const F: any = {};
+        let first = -1;
+        F[Symbol.hasInstance] = function () {
+          first = arguments[0];
+          return false;
+        };
+        const _ = (42 as any) instanceof F;
+        return first;
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("handler `this` is the original receiver F and callCount === 1", async () => {
+    await assertEquivalent(
+      `
+      export function test(): number {
+        const F: any = {};
+        let callCount = 0;
+        let thisIsF = 0;
+        F[Symbol.hasInstance] = function () {
+          callCount += 1;
+          thisIsF = (this === F) ? 1 : 0;
+          return false;
+        };
+        const _ = (0 as any) instanceof F;
+        return callCount * 10 + thisIsF;
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("named-parameter handler still binds its one declared param to V", async () => {
+    await assertEquivalent(
+      `
+      export function test(): number {
+        const F: any = {};
+        let seen = -1;
+        let argc = -1;
+        F[Symbol.hasInstance] = function (v: any) {
+          seen = v;
+          argc = arguments.length;
+          return false;
+        };
+        const _ = (7 as any) instanceof F;
+        return seen * 100 + argc;
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("regression: handler result is still ToBoolean-coerced (truthy → true)", async () => {
+    await assertEquivalent(
+      `
+      export function test(): number {
+        const F: any = {};
+        F[Symbol.hasInstance] = function () { return 5; };
+        return ((0 as any) instanceof F) ? 1 : 0;
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});


### PR DESCRIPTION
## #2764 — `@@hasInstance` handler invoked at unknown-arity (drops `arguments.length`)

Split of the #2740 instanceof umbrella. A custom `Symbol.hasInstance` handler
must be invoked with **exactly one** argument (ECMA-262 §13.10.2 step 4a:
`Return ToBoolean(Call(instOfHandler, C, «O»))`). The runtime bridge
`_instanceofResult` (`src/runtime.ts`) dispatched the handler through the method
bridge at its **max** arity (=4), so `arguments.length` was 4 inside the handler
instead of 1.

### Fix (the documented one-liner)
Recover the raw wasm closure from `_wasmClosureWrapperTargets` (the property read
may already have wrapped it) and re-bridge at known arity 1
(`_maybeWrapCallable(rawHandler, 1, …)` → `__call_fn_method_1` → `__argc === 1`)
instead of `_maybeWrapCallableUnknownArity`. The dispatcher half was already
fixed by #2213.

### Verification
- `language/expressions/instanceof/symbol-hasinstance-invocation.js`: **fail → pass**
  (`arguments.length === 1`, `args[0] === 0`, `thisValue === F`, `callCount === 1`)
- `symbol-hasinstance-not-callable` / `-to-boolean` / `-get-err`: stay **pass**
- Added `tests/issue-2764.test.ts` (5 `assertEquivalent` cases); `tests/issue-2702.test.ts` (8) stays green.

Broad-impact runtime change (dynamic instanceof path) → validated via full
test262 CI.

Closes #2764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS