### PR TITLE
fix(#2760): hybrid floor F1 — plain-array primitive OOB read → JS undefined

### DIFF
--- a/plan/issues/2760-hybrid-floor-plain-array-oob-undefined.md
+++ b/plan/issues/2760-hybrid-floor-plain-array-oob-undefined.md
@@ -1,7 +1,9 @@
 ---
 id: 2760
 title: "Hybrid floor F1: plain-array OOB read → JS `undefined` (HI-style #2198/S2 rework, not the shared-helper flip)"
-status: ready
+status: done
+assignee: ttraenkler/senior-dev-2760
+completed: 2026-06-28
 sprint: current
 created: 2026-06-28
 updated: 2026-06-28
@@ -104,3 +106,63 @@ default is too broad (blast radius into typed-array/subview/array-method callers
   subview / array-method internal callers are byte-identical.
 - `built-ins/Array/prototype/map/15.4.4.19-8-b-2.js` is green; no net test262
   regression.
+
+## Implementation notes (senior-dev, 2026-06-28)
+
+**What landed:** OOB→`undefined` for **primitive-element** plain arrays only —
+`number[]` (f64) and `boolean[]` (i32). The unproven (non-bounds-eliminated)
+read widens its SAFE result to a **boxed-or-undefined externref** (box the
+in-bounds element; OOB → `__get_undefined`, or `ref.null.extern` under
+standalone where `undefined ≡ null`); the proven in-bounds read
+(`isSafeBoundsEliminated`, the counted-loop proof) keeps the **unboxed fast
+path**. This is the hybrid invariant in miniature: SAFE-by-default, FAST only
+when proven.
+
+**Where:** a new call-site helper `emitPlainArrayUndefinedOobGet`
+(`src/codegen/property-access.ts`) invoked from the two
+`compileElementAccessBody` plain-array value-read sites (the vec-struct path and
+the raw-array path), gated on `classifyTypedArrayType(...) === "other"` (plain
+array, NOT a typed-array view) and, for the vec-struct path, excluding the
+`$__regexp_match_vec` exotic. The shared `emitBoundsCheckedArrayGet` default is
+**unchanged** — its `$__subview` / typed-array / array-method internal callers
+are byte-identical. This is the HI-style rework the issue asked for, NOT the S2
+shared-helper flip.
+
+**Why externref (`any[]`/`string[]`) OOB→undefined was DEFERRED (the key
+decision):** flipping externref OOB null→undefined regresses the S2 canary
+`built-ins/Array/prototype/map/15.4.4.19-8-b-2.js`. Root cause, traced directly:
+`var testResult = Array.prototype.map.call(obj, cb)` over a plain array-like
+object produces a vec whose runtime **length is 0** (a separate, pre-existing
+map-of-plain-object bug — verified: `(testResult as any).length === 0`), so the
+asserted `testResult[2]` is an **OOB read**. The test passes today only by
+accident: OOB externref → `ref.null.extern` → JS `null`, and the assert
+`testResult[2] === false` coerces `null` to the expected `false`. Returning the
+spec-correct `undefined` removes that accidental coercion (`undefined === false`
+→ false) and the canary fails. Since the hard gate is "no net test262
+regression," externref OOB→undefined is deferred to a follow-up that **first
+fixes the map-of-array-like length bug** (or finds a provenance-based
+discriminator). The behaviour is unchanged for externref arrays (still `null`),
+so `any[]`/`string[]` OOB stays as-is — not a regression, just not yet fixed.
+
+**Also observed (out of scope, noted for follow-up):** `typeof a[OOB]` folds to
+the static element type's string (e.g. `"number"`) at compile time rather than
+`"undefined"` — a separate static-type-trusting `typeof` unsoundness. The
+element *value* is correctly `undefined`; only the `typeof` operator's
+compile-time fold is wrong. Belongs to the same hybrid-soundness family but is a
+distinct site (the `typeof` lowering, not the element read).
+
+**Object-element arrays (`Foo[]`, `ref`/`ref_null` element):** intentionally
+left unchanged. Widening their result to externref would break downstream
+`a[i].field` (loses the struct type → no `struct.get`). Their OOB read keeps the
+typed-null default (which traps on deref ≈ JS TypeError). Correct OOB→undefined
+for object arrays needs the result type to become `Foo | undefined` (externref) —
+that is the IR `prove-then-specialize` work (#2766), not a legacy floor fix.
+
+**Validation:** new `tests/issue-2760.test.ts` (15 cases: primitive OOB→undefined
+host+standalone, in-bounds preserved incl. boolean tag + counted-loop fast path,
+typed-array unchanged, and the map-on-array-like canary guard). Targeted local
+array/destructuring batches + the `tests/equivalence/` suite showed no new
+failures (the only local failures are the pre-existing `tests/helpers.js`
+infra-resolution issue and `fast-arrays > array find` / `array-capacity`, all of
+which fail identically on clean `main`). Broad conformance validated by full CI /
+`merge_group` (test262 regression gate + standalone-floor).

--- a/plan/issues/2760-hybrid-floor-plain-array-oob-undefined.md
+++ b/plan/issues/2760-hybrid-floor-plain-array-oob-undefined.md
@@ -110,13 +110,39 @@ default is too broad (blast radius into typed-array/subview/array-method callers
 ## Implementation notes (senior-dev, 2026-06-28)
 
 **What landed:** OOB→`undefined` for **primitive-element** plain arrays only —
-`number[]` (f64) and `boolean[]` (i32). The unproven (non-bounds-eliminated)
-read widens its SAFE result to a **boxed-or-undefined externref** (box the
-in-bounds element; OOB → `__get_undefined`, or `ref.null.extern` under
-standalone where `undefined ≡ null`); the proven in-bounds read
-(`isSafeBoundsEliminated`, the counted-loop proof) keeps the **unboxed fast
-path**. This is the hybrid invariant in miniature: SAFE-by-default, FAST only
-when proven.
+`number[]` (f64) and `boolean[]` (i32), AND only when the element is read in a
+**non-numeric value context**. The unproven (non-bounds-eliminated) read widens
+its SAFE result to a **boxed-or-undefined externref** (box the in-bounds element;
+OOB → `__get_undefined`, or `ref.null.extern` under standalone where
+`undefined ≡ null`); the proven in-bounds read (`isSafeBoundsEliminated`, the
+counted-loop proof) keeps the **unboxed fast path**. This is the hybrid
+invariant in miniature: SAFE-by-default, FAST only when proven.
+
+**Numeric-hint suppression (the second lesson — Math.\* regression).** The first
+implementation widened *every* unproven primitive read to externref. The
+`equivalence-gate` caught a regression: `Math.pow`/`min`/`max`/`hypot` with array
+element args produced **invalid wasm**. Root cause: a numeric-consuming caller
+like `compileMathCall` captures the host `Math_pow` funcIdx *before* compiling
+its arguments; the externref widening adds a late import *during* arg
+compilation, which shifts that already-captured funcIdx → a stale `call`. Fix:
+**honor the value-context hint** — when the element is read into an `f64`/`i32`
+context, suppress the widening and keep the unboxed read. There `undefined` is
+unobservable anyway (it coerces to `NaN`/`0`, the JS-correct `ToNumber`), and the
+unboxed read adds no imports, so no captured funcIdx shifts. `expectedType` is
+threaded `compileExpressionInner → compileElementAccess →
+compileElementAccessBody`. `=== undefined` / `typeof` / dynamic contexts pass no
+numeric hint, so OOB→`undefined` still fires there. (Generalises the latent
+"caller captures funcIdx before compiling args" fragility into a non-issue for
+this path; the full `merge_group` test262 gate guards any other consumer.)
+
+**Robust imperative boxing.** The helper emits the bounded read
+(`emitBoundsCheckedArrayGet`, OOB→default, never traps) + box (`coerceType`) +
+`undefined` (`emitUndefined`) **imperatively on `fctx.body`** so the late imports
+register through the normal index-shift path; the final `inBounds ? boxed :
+undefined` select-`if` carries only `local.get`. An earlier version that baked
+the box/undefined funcIdxs into detached branch `Instr[]` desynced indices (a
+duplicate `__box_number` import + a wrong arg value) — the same late-import-shift
+hazard, avoided by never baking a funcIdx inside a branch array.
 
 **Where:** a new call-site helper `emitPlainArrayUndefinedOobGet`
 (`src/codegen/property-access.ts`) invoked from the two

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -1255,11 +1255,14 @@ function compileExpressionInner(
   if (ts.isElementAccessExpression(expr)) {
     // (#2128) Same getter-dispatch re-sync as the property-access arm above.
     if (fctx.persistentCallbackWritebacks && fctx.persistentCallbackWritebacks.length > 0) {
-      const readResult = compileElementAccess(ctx, fctx, expr);
+      const readResult = compileElementAccess(ctx, fctx, expr, expectedType);
       fctx.body.push(...fctx.persistentCallbackWritebacks.map((instr) => structuredClone(instr)));
       return readResult;
     }
-    return compileElementAccess(ctx, fctx, expr);
+    // (#2760 F1) Forward the value-context hint so the primitive OOB→undefined
+    // widening is suppressed in a numeric (f64/i32) context (avoids boxing + a
+    // late-import shift under a funcIdx already captured by a numeric caller).
+    return compileElementAccess(ctx, fctx, expr, expectedType);
   }
 
   if (ts.isObjectLiteralExpression(expr)) {

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -34,10 +34,11 @@ import {
   noJsHost,
   resolveDeclaringClassForPrivateName,
 } from "./expressions/helpers.js";
-import { emitUndefined, patchStructNewForAddedField } from "./expressions/late-imports.js";
+import { emitUndefined, ensureGetUndefined, patchStructNewForAddedField } from "./expressions/late-imports.js";
 import { emitSymbolDescLoad } from "./symbol-native.js";
 import {
   addUnionImports,
+  classifyTypedArrayType,
   resolveWasmType,
   TYPED_ARRAY_NAMES,
   typedArrayPackedSignedness,
@@ -5377,6 +5378,97 @@ export function isSafeBoundsEliminated(fctx: FunctionContext, expr: ts.ElementAc
   return fctx.safeIndexedArrays.has(arrayVar + ":" + indexVar);
 }
 
+/**
+ * (#2760 — hybrid type-soundness floor F1) SAFE plain-array OOB read for a
+ * PRIMITIVE element (`f64` `number[]` / `i32` `boolean[]`): push the in-bounds
+ * element **boxed to externref**, or JS `undefined` when the index is out of
+ * bounds. An `f64`/`i32` cannot represent `undefined`, so the JS-correct (SAFE)
+ * lowering of a read whose index is NOT provably in-bounds is the
+ * boxed-or-undefined externref — never the type-default sentinel (sNaN / 0).
+ * Per the hybrid invariant, the unboxed fast path is kept for the *proven*
+ * in-bounds read (`isSafeBoundsEliminated`, the counted-loop proof) at the call
+ * site; only the unproven read pays the box.
+ *
+ * **Call-site-owned policy, NOT a shared-helper flip.** The shared
+ * `emitBoundsCheckedArrayGet` default is deliberately left untouched — its
+ * `$__subview`, typed-array, and array-method internal callers keep their own
+ * OOB semantics. Flipping the shared `useUndefinedSentinel` default was the S2
+ * leak that regressed `Array.prototype.map`-on-array-like (#2198). This helper
+ * is reached only from the two `compileElementAccessBody` plain-array value-read
+ * call sites, gated on a genuine (non-typed-array) array receiver.
+ *
+ * Stack in:  [arrayref(non-null $arr), i32 index]
+ * Stack out: [externref]
+ */
+function emitPlainArrayUndefinedOobGet(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  arrTypeIdx: number,
+  elementType: ValType,
+): void {
+  // Save index + array ref (consumed in both the bounds test and the read arm).
+  const idxLocal = allocLocal(fctx, `__oobu_idx_${fctx.locals.length}`, { kind: "i32" });
+  const arrLocal = allocLocal(fctx, `__oobu_arr_${fctx.locals.length}`, { kind: "ref", typeIdx: arrTypeIdx });
+  fctx.body.push({ op: "local.set", index: idxLocal });
+  fctx.body.push({ op: "local.set", index: arrLocal });
+
+  // Register the late imports both arms need and flush index shifts BEFORE
+  // building the if-block, so the funcIdxs baked into the branch Instr[] are
+  // stable (the emitBoundsCheckedArrayGet late-import discipline). `__box_*` /
+  // `__get_undefined` route through addUnionImports natively under standalone.
+  const undefinedFuncIdx = ensureGetUndefined(ctx); // undefined under standalone (undefined≡null)
+  const isBool = elementType.kind === "i32" && (elementType as { boolean?: boolean }).boolean === true;
+  const boxNumberIdx = !isBool
+    ? ensureLateImport(ctx, "__box_number", [{ kind: "f64" }], [{ kind: "externref" }])
+    : undefined;
+  const boxBoolIdx = isBool
+    ? ensureLateImport(ctx, "__box_boolean", [{ kind: "i32" }], [{ kind: "externref" }])
+    : undefined;
+  flushLateImportShifts(ctx, fctx);
+
+  // Condition: (unsigned) idx < array.len — a negative index wraps to a huge
+  // unsigned value > any length, so it falls into the OOB (undefined) arm too.
+  fctx.body.push({ op: "local.get", index: idxLocal });
+  fctx.body.push({ op: "local.get", index: arrLocal });
+  fctx.body.push({ op: "array.len" });
+  fctx.body.push({ op: "i32.lt_u" } as Instr);
+
+  // then: in-bounds → array.get element, boxed to externref. A boolean i32 MUST
+  // box via __box_boolean (so its runtime tag reads `true`/`false`, not 1/0); a
+  // numeric i32 widens to f64 first, then __box_number.
+  const thenInstrs: Instr[] = [
+    { op: "local.get", index: arrLocal } as Instr,
+    { op: "local.get", index: idxLocal } as Instr,
+    { op: "array.get", typeIdx: arrTypeIdx } as Instr,
+  ];
+  if (isBool) {
+    if (boxBoolIdx !== undefined) thenInstrs.push({ op: "call", funcIdx: boxBoolIdx } as Instr);
+    else thenInstrs.push({ op: "drop" } as Instr, { op: "ref.null.extern" } as Instr);
+  } else if (elementType.kind === "i32") {
+    if (boxNumberIdx !== undefined)
+      thenInstrs.push({ op: "f64.convert_i32_s" } as Instr, { op: "call", funcIdx: boxNumberIdx } as Instr);
+    else thenInstrs.push({ op: "drop" } as Instr, { op: "ref.null.extern" } as Instr);
+  } else {
+    // f64 element
+    if (boxNumberIdx !== undefined) thenInstrs.push({ op: "call", funcIdx: boxNumberIdx } as Instr);
+    else thenInstrs.push({ op: "drop" } as Instr, { op: "ref.null.extern" } as Instr);
+  }
+
+  // else: OOB → JS `undefined` (host import) / `ref.null.extern` under standalone
+  // (where undefined is conflated with null — same convention as emitUndefined).
+  const elseInstrs: Instr[] =
+    undefinedFuncIdx !== undefined
+      ? [{ op: "call", funcIdx: undefinedFuncIdx } as Instr]
+      : [{ op: "ref.null.extern" } as Instr];
+
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val" as const, type: { kind: "externref" } },
+    then: thenInstrs,
+    else: elseInstrs,
+  } as Instr);
+}
+
 // ── Element access ───────────────────────────────────────────────────
 
 /**
@@ -6271,6 +6363,20 @@ export function compileElementAccessBody(
     // zero-extend), NOT the storage kind — a signed Int8Array and an unsigned
     // Uint8Array share `i8` storage but read with opposite extension.
     const taSignedness = typedArrayViewSignedness(ctx, expr.expression);
+    // (#2760 — hybrid floor F1) An OOB read of a genuine PLAIN array reads JS
+    // `undefined`, not the type-default sentinel. The policy applies only to a
+    // real array receiver: NOT a typed-array view (kept on its own OOB semantics
+    // — the S2 blast radius) and NOT the `$__regexp_match_vec` exotic (its
+    // index/input/groups fields are property reads with their own spec
+    // semantics; deferred). This F1 slice widens ONLY the PRIMITIVE element kinds
+    // (`number[]` f64 / `boolean[]` i32) — see the element-kind dispatch below;
+    // object-element (`ref`) arrays keep their typed result, and externref
+    // (`any[]`/`string[]`) OOB→undefined is deferred (it trips the
+    // map-on-array-like canary via a pre-existing length bug).
+    const isRegexMatchVec = typeDef.fields.length >= 4 && typeDef.fields[2]?.name === "index";
+    const oobUndefined =
+      classifyTypedArrayType(ctx.checker.getTypeAtLocation(expr.expression), ctx.checker) === "other" &&
+      !isRegexMatchVec;
     // Unwrap: struct.get data field, then index into backing array
     fctx.body.push({ op: "struct.get", typeIdx, fieldIdx: 1 }); // get data from vec
     // #1179: hint i32 directly for the index. compileExpression will produce
@@ -6296,6 +6402,29 @@ export function compileElementAccessBody(
       // (#2001 S1) Even bounds-eliminated externref reads must map a `$Hole`
       // slot back to `undefined` — the loop guard proves in-bounds, not present.
       if (ctx.usesArrayHoles && arrDef.element.kind === "externref") emitHoleToUndefined(ctx, fctx);
+    } else if (oobUndefined && (arrDef.element.kind === "f64" || arrDef.element.kind === "i32")) {
+      // (#2760 F1) Plain-array OOB → `undefined` for a PRIMITIVE element
+      // (`number[]` f64 / `boolean[]` i32): widen the SAFE result to externref
+      // (box the in-bounds value, OOB → undefined). f64/i32 cannot represent
+      // `undefined`, so the JS-correct lowering of an unproven read is the
+      // boxed-or-undefined externref. Bounds-eliminated reads keep the unboxed
+      // fast path above; only the unproven read pays the box. Call-site-owned
+      // policy — the shared `emitBoundsCheckedArrayGet` default is untouched (its
+      // subview / typed-array / array-method callers are byte-identical; flipping
+      // the shared default was the S2 leak).
+      //
+      // EXTERNREF elements (`any[]`/`string[]`) are intentionally NOT widened to
+      // OOB→undefined here yet: that change trips the canary
+      // `built-ins/Array/prototype/map/15.4.4.19-8-b-2.js`, whose `testResult[2]`
+      // read is an OOB read on a length-0 map-of-array-like result (a separate,
+      // pre-existing map-on-plain-object bug) and passes today only because the
+      // OOB externref default (`null`) coerces to the asserted `false`. Returning
+      // the spec-correct `undefined` exposes that latent bug → a net regression.
+      // Externref OOB→undefined is deferred to a follow-up that first fixes the
+      // map-on-array-like length bug (tracked in the issue file). Externref reads
+      // fall through to the unchanged shared-helper call below.
+      emitPlainArrayUndefinedOobGet(ctx, fctx, arrTypeIdx, arrDef.element);
+      return { kind: "externref" };
     } else {
       // (#2001 S1) Pass `ctx` so the in-bounds `$Hole → undefined` read-boundary
       // mapping fires for an externref-element (`any[]`) vec. (#2593) Thread the
@@ -6323,6 +6452,11 @@ export function compileElementAccessBody(
 
   // (#2593) View-name-driven signedness for a packed i8/i16 typed-array element.
   const taSignednessArr = typedArrayViewSignedness(ctx, expr.expression);
+  // (#2760 F1) Plain-array OOB → JS `undefined` policy (typed-array views keep
+  // their own OOB semantics). A raw array type has no struct fields, so there is
+  // no regex-match-vec exotic to exclude here.
+  const oobUndefinedArr =
+    classifyTypedArrayType(ctx.checker.getTypeAtLocation(expr.expression), ctx.checker) === "other";
   // Compile index and convert to i32 (#1179: hint i32 directly to skip the
   // f64.convert_i32_s + i32.trunc_sat_f64_s round-trip when the index is
   // already an i32 local or integer literal).
@@ -6346,6 +6480,15 @@ export function compileElementAccessBody(
     // (#2001 S1) Map a `$Hole` slot back to `undefined` on bounds-eliminated
     // externref reads too (in-bounds ≠ present).
     if (ctx.usesArrayHoles && typeDef.element.kind === "externref") emitHoleToUndefined(ctx, fctx);
+  } else if (oobUndefinedArr && (typeDef.element.kind === "f64" || typeDef.element.kind === "i32")) {
+    // (#2760 F1) Plain-array OOB → `undefined` for a PRIMITIVE element
+    // (`number[]`/`boolean[]`): widen to a boxed-or-undefined externref.
+    // Bounds-eliminated reads above keep the unboxed fast path. Externref
+    // elements are NOT widened here (see the matching note at the vec-struct call
+    // site — externref OOB→undefined trips the map-on-array-like canary via a
+    // pre-existing length bug; deferred).
+    emitPlainArrayUndefinedOobGet(ctx, fctx, typeIdx, typeDef.element);
+    return { kind: "externref" };
   } else {
     // (#2001 S1) Pass `ctx` for the in-bounds `$Hole → undefined` mapping.
     // (#2593) Thread the view-name signedness for packed i8/i16 reads.

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -34,7 +34,7 @@ import {
   noJsHost,
   resolveDeclaringClassForPrivateName,
 } from "./expressions/helpers.js";
-import { emitUndefined, ensureGetUndefined, patchStructNewForAddedField } from "./expressions/late-imports.js";
+import { emitUndefined, patchStructNewForAddedField } from "./expressions/late-imports.js";
 import { emitSymbolDescLoad } from "./symbol-native.js";
 import {
   addUnionImports,
@@ -5444,66 +5444,50 @@ function emitPlainArrayUndefinedOobGet(
   arrTypeIdx: number,
   elementType: ValType,
 ): void {
-  // Save index + array ref (consumed in both the bounds test and the read arm).
+  // Save index + array ref (consumed by the bounds test AND the bounded read).
   const idxLocal = allocLocal(fctx, `__oobu_idx_${fctx.locals.length}`, { kind: "i32" });
   const arrLocal = allocLocal(fctx, `__oobu_arr_${fctx.locals.length}`, { kind: "ref", typeIdx: arrTypeIdx });
   fctx.body.push({ op: "local.set", index: idxLocal });
   fctx.body.push({ op: "local.set", index: arrLocal });
 
-  // Register the late imports both arms need and flush index shifts BEFORE
-  // building the if-block, so the funcIdxs baked into the branch Instr[] are
-  // stable (the emitBoundsCheckedArrayGet late-import discipline). `__box_*` /
-  // `__get_undefined` route through addUnionImports natively under standalone.
-  const undefinedFuncIdx = ensureGetUndefined(ctx); // undefined under standalone (undefined≡null)
-  const isBool = elementType.kind === "i32" && (elementType as { boolean?: boolean }).boolean === true;
-  const boxNumberIdx = !isBool
-    ? ensureLateImport(ctx, "__box_number", [{ kind: "f64" }], [{ kind: "externref" }])
-    : undefined;
-  const boxBoolIdx = isBool
-    ? ensureLateImport(ctx, "__box_boolean", [{ kind: "i32" }], [{ kind: "externref" }])
-    : undefined;
-  flushLateImportShifts(ctx, fctx);
-
-  // Condition: (unsigned) idx < array.len — a negative index wraps to a huge
+  // (1) inBounds = (unsigned) idx < array.len. A negative index wraps to a huge
   // unsigned value > any length, so it falls into the OOB (undefined) arm too.
+  const inBoundsLocal = allocLocal(fctx, `__oobu_in_${fctx.locals.length}`, { kind: "i32" });
   fctx.body.push({ op: "local.get", index: idxLocal });
   fctx.body.push({ op: "local.get", index: arrLocal });
   fctx.body.push({ op: "array.len" });
   fctx.body.push({ op: "i32.lt_u" } as Instr);
+  fctx.body.push({ op: "local.set", index: inBoundsLocal });
 
-  // then: in-bounds → array.get element, boxed to externref. A boolean i32 MUST
-  // box via __box_boolean (so its runtime tag reads `true`/`false`, not 1/0); a
-  // numeric i32 widens to f64 first, then __box_number.
-  const thenInstrs: Instr[] = [
-    { op: "local.get", index: arrLocal } as Instr,
-    { op: "local.get", index: idxLocal } as Instr,
-    { op: "array.get", typeIdx: arrTypeIdx } as Instr,
-  ];
-  if (isBool) {
-    if (boxBoolIdx !== undefined) thenInstrs.push({ op: "call", funcIdx: boxBoolIdx } as Instr);
-    else thenInstrs.push({ op: "drop" } as Instr, { op: "ref.null.extern" } as Instr);
-  } else if (elementType.kind === "i32") {
-    if (boxNumberIdx !== undefined)
-      thenInstrs.push({ op: "f64.convert_i32_s" } as Instr, { op: "call", funcIdx: boxNumberIdx } as Instr);
-    else thenInstrs.push({ op: "drop" } as Instr, { op: "ref.null.extern" } as Instr);
-  } else {
-    // f64 element
-    if (boxNumberIdx !== undefined) thenInstrs.push({ op: "call", funcIdx: boxNumberIdx } as Instr);
-    else thenInstrs.push({ op: "drop" } as Instr, { op: "ref.null.extern" } as Instr);
-  }
+  // (2) Bounded native read (OOB → type-default, never traps), then box to
+  // externref — emitted IMPERATIVELY on `fctx.body` so the box / undefined
+  // late-imports (`__box_number`/`__box_boolean`/`__get_undefined`) register and
+  // index-shift through the normal path. (An earlier version baked these funcIdxs
+  // into detached branch `Instr[]`, which desynced indices — a duplicate
+  // `__box_number` import and a wrong Math.pow arg value.) The branches of the
+  // final select below carry ONLY `local.get`, so nothing inside them can shift.
+  fctx.body.push({ op: "local.get", index: arrLocal });
+  fctx.body.push({ op: "local.get", index: idxLocal });
+  emitBoundsCheckedArrayGet(fctx, arrTypeIdx, elementType, ctx, false);
+  const nativeValueType: ValType =
+    elementType.kind === "i8" || elementType.kind === "i16" ? { kind: "i32" } : elementType;
+  coerceType(ctx, fctx, nativeValueType, { kind: "externref" });
+  const boxedLocal = allocLocal(fctx, `__oobu_box_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: boxedLocal });
 
-  // else: OOB → JS `undefined` (host import) / `ref.null.extern` under standalone
-  // (where undefined is conflated with null — same convention as emitUndefined).
-  const elseInstrs: Instr[] =
-    undefinedFuncIdx !== undefined
-      ? [{ op: "call", funcIdx: undefinedFuncIdx } as Instr]
-      : [{ op: "ref.null.extern" } as Instr];
+  // (3) `undefined` into a local (host `__get_undefined`, or `ref.null.extern`
+  // under standalone where undefined ≡ null — both via emitUndefined).
+  emitUndefined(ctx, fctx);
+  const undefLocal = allocLocal(fctx, `__oobu_undef_${fctx.locals.length}`, { kind: "externref" });
+  fctx.body.push({ op: "local.set", index: undefLocal });
 
+  // (4) result = inBounds ? boxedValue : undefined. Pure local.get branches.
+  fctx.body.push({ op: "local.get", index: inBoundsLocal });
   fctx.body.push({
     op: "if",
     blockType: { kind: "val" as const, type: { kind: "externref" } },
-    then: thenInstrs,
-    else: elseInstrs,
+    then: [{ op: "local.get", index: boxedLocal } as Instr],
+    else: [{ op: "local.get", index: undefLocal } as Instr],
   } as Instr);
 }
 
@@ -5768,6 +5752,9 @@ export function compileElementAccess(
   ctx: CodegenContext,
   fctx: FunctionContext,
   expr: ts.ElementAccessExpression,
+  // (#2760 F1) value-context hint — forwarded to compileElementAccessBody so the
+  // primitive OOB→undefined widening is suppressed in a numeric (f64/i32) context.
+  expectedType?: ValType,
 ): ValType | null {
   // Optional chaining: a?.[i] (#2050). Short-circuits on a nullish base — the
   // index expression must NOT evaluate and the result must be undefined-
@@ -5992,7 +5979,7 @@ export function compileElementAccess(
     }
     // After the null check (or provably non-null), the value is guaranteed non-null
     const nonNullObjType: ValType = { kind: "ref", typeIdx: (objType as any).typeIdx };
-    return compileElementAccessBody(ctx, fctx, expr, nonNullObjType);
+    return compileElementAccessBody(ctx, fctx, expr, nonNullObjType, expectedType);
   }
 
   // Null-guard for externref: null[x] and undefined[x] throw TypeError (#775)
@@ -6002,7 +5989,7 @@ export function compileElementAccess(
     }
   }
 
-  return compileElementAccessBody(ctx, fctx, expr, objType);
+  return compileElementAccessBody(ctx, fctx, expr, objType, expectedType);
 }
 
 /**
@@ -6043,6 +6030,15 @@ export function compileElementAccessBody(
   fctx: FunctionContext,
   expr: ts.ElementAccessExpression,
   objType: ValType,
+  // (#2760 F1) The value-context hint the caller is reading this element into.
+  // When it is a NUMERIC kind (f64/i32) the primitive OOB→undefined widening is
+  // suppressed: in a numeric context `undefined` is not observable anyway (it
+  // coerces to NaN/0, which is the JS-correct `ToNumber(undefined)`), and — more
+  // importantly — widening would box→externref and add a late import *during*
+  // argument compilation, shifting a funcIdx a numeric-consuming caller may have
+  // already captured (e.g. `Math.pow(a[i], …)` grabs `Math_pow` before compiling
+  // its args). Keeping the unboxed f64/i32 in numeric context avoids that.
+  expectedType?: ValType,
 ): ValType | null {
   // Externref element access: obj[key] → host import __extern_get(obj, externref) → externref
   if (objType.kind === "externref") {
@@ -6412,7 +6408,9 @@ export function compileElementAccessBody(
     // (`any[]`/`string[]`) OOB→undefined is deferred (it trips the
     // map-on-array-like canary via a pre-existing length bug).
     const isRegexMatchVec = typeDef.fields.length >= 4 && typeDef.fields[2]?.name === "index";
+    const numericHint = expectedType?.kind === "f64" || expectedType?.kind === "i32";
     const oobUndefined =
+      !numericHint &&
       classifyTypedArrayType(ctx.checker.getTypeAtLocation(expr.expression), ctx.checker) === "other" &&
       !isRegexMatchVec;
     // Unwrap: struct.get data field, then index into backing array
@@ -6494,6 +6492,7 @@ export function compileElementAccessBody(
   // their own OOB semantics). A raw array type has no struct fields, so there is
   // no regex-match-vec exotic to exclude here.
   const oobUndefinedArr =
+    !(expectedType?.kind === "f64" || expectedType?.kind === "i32") &&
     classifyTypedArrayType(ctx.checker.getTypeAtLocation(expr.expression), ctx.checker) === "other";
   // Compile index and convert to i32 (#1179: hint i32 directly to skip the
   // f64.convert_i32_s + i32.trunc_sat_f64_s round-trip when the index is

--- a/tests/issue-2760.test.ts
+++ b/tests/issue-2760.test.ts
@@ -180,4 +180,38 @@ describe("#2760 F1 — plain-array OOB read → JS `undefined` (primitive elemen
       ).toBe(1);
     });
   });
+
+  describe("numeric-context regression guard — Math.* with array element args", () => {
+    // The first cut widened every unproven primitive read to externref, which
+    // broke `Math.pow`/`max`/`hypot` (the numeric caller captures `Math_pow`'s
+    // funcIdx before compiling args; the widening's late import shifted it →
+    // invalid wasm). The numeric-hint suppression keeps these unboxed.
+    it("Math.pow with array element arg (number[]) is valid and correct", async () => {
+      expect(
+        await run(`export function test(): number { const b: number[] = [2, 7]; return Math.pow(b[0], 3); }`),
+      ).toBe(8);
+    });
+
+    it("Math.pow with new Array() element arg (evolving number[])", async () => {
+      expect(
+        await run(`export function test(): number { var b = new Array(); b[0] = 2; return Math.pow(b[0], 3); }`),
+      ).toBe(8);
+    });
+
+    it("Math.max with two array element args", async () => {
+      expect(
+        await run(`export function test(): number { const a: number[] = [3, 5]; return Math.max(a[0], a[1]); }`),
+      ).toBe(5);
+    });
+
+    it("OOB element in a numeric context coerces to NaN (undefined → ToNumber)", async () => {
+      // In a numeric context `a[OOB]` is unobservable as undefined; it coerces to
+      // NaN, which is the JS-correct `Math.pow(undefined, 3)` result.
+      expect(
+        await run(
+          `export function test(): boolean { const a: number[] = [2]; let i = 9; let v = Math.pow(a[i], 3); return v !== v; }`,
+        ),
+      ).toBe(1);
+    });
+  });
 });

--- a/tests/issue-2760.test.ts
+++ b/tests/issue-2760.test.ts
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2760 — Hybrid type-soundness floor F1: a plain-array out-of-bounds read of a
+// PRIMITIVE element (`number[]` f64 / `boolean[]` i32) returns JS `undefined`
+// (the SAFE default), not the type-default sentinel (sNaN / 0).
+//
+// Scope of this F1 slice (see the issue file for the full rationale):
+//   - PRIMITIVE element arrays (`number[]`, `boolean[]`) → OOB reads `undefined`.
+//   - The unproven (non-bounds-eliminated) read widens to a boxed-or-undefined
+//     externref; the proven in-bounds read keeps the unboxed fast path.
+//   - The OOB→undefined policy is applied at the `compileElementAccessBody` call
+//     sites — the shared `emitBoundsCheckedArrayGet` default is NOT flipped, so
+//     the typed-array / `$__subview` / array-method internal callers keep their
+//     own OOB semantics (flipping the shared default was the S2 leak, #2198).
+//   - EXTERNREF element arrays (`any[]`/`string[]`) OOB→undefined is DEFERRED:
+//     it trips the `Array.prototype.map`-on-array-like canary
+//     (`built-ins/Array/prototype/map/15.4.4.19-8-b-2.js`) via a pre-existing
+//     map-of-plain-object length bug. The canary MUST stay green — guarded below.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// Host-mode harness (buildImports + setExports — the canonical host runtime glue
+// so a newly-imported helper can never be silently masked).
+async function run(source: string, fn = "test"): Promise<unknown> {
+  const result = await compile(source);
+  expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>)[fn]();
+}
+
+// Standalone harness (empty imports `{}` — a leaked host import fails
+// instantiation; the binary must be valid Wasm). Standalone conflates
+// `undefined` with `null`, so `=== undefined` is satisfied by the native
+// `ref.null.extern` OOB sentinel.
+async function runStandalone(source: string, fn = "test"): Promise<number> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as Record<string, () => number>)[fn]() as number;
+}
+
+describe("#2760 F1 — plain-array OOB read → JS `undefined` (primitive elements)", () => {
+  describe("host — number[] OOB reads undefined", () => {
+    it("a[OOB] === undefined (literal index past end)", async () => {
+      expect(
+        await run(`export function test(): boolean { const a: number[] = [1, 4, 5]; return a[4] === undefined; }`),
+      ).toBe(1);
+    });
+
+    it("a[OOB] surfaces to JS as undefined, not sNaN/null", async () => {
+      expect(await run(`export function test(): any { const a: number[] = [1, 4, 5]; return a[4]; }`)).toBe(undefined);
+    });
+
+    it("negative index reads undefined", async () => {
+      expect(
+        await run(`export function test(): boolean { const a: number[] = [1, 4, 5]; return a[-1] === undefined; }`),
+      ).toBe(1);
+    });
+
+    it("dynamic OOB index reads undefined", async () => {
+      expect(
+        await run(
+          `export function test(): boolean { const a: number[] = [1, 4, 5]; let i = 7; return a[i] === undefined; }`,
+        ),
+      ).toBe(1);
+    });
+
+    it("OOB read used in arithmetic is NaN (undefined + 1)", async () => {
+      // `undefined + 1` is NaN in JS; the widened externref unboxes to NaN.
+      expect(
+        await run(
+          `export function test(): boolean { const a: number[] = [1, 4, 5]; let i = 9; let v = a[i] + 1; return v !== v; }`,
+        ),
+      ).toBe(1);
+    });
+  });
+
+  describe("host — boolean[] OOB reads undefined", () => {
+    it("a[OOB] === undefined", async () => {
+      expect(
+        await run(`export function test(): boolean { const a: boolean[] = [true, false]; return a[4] === undefined; }`),
+      ).toBe(1);
+    });
+  });
+
+  describe("host — in-bounds primitive reads are unchanged", () => {
+    it("number[] in-bounds read returns the element", async () => {
+      expect(
+        await run(`export function test(): number { const a: number[] = [1, 4, 5]; let i = 1; return a[i]; }`),
+      ).toBe(4);
+    });
+
+    it("number[] in-bounds read round-trips through arithmetic", async () => {
+      expect(
+        await run(`export function test(): number { const a: number[] = [1, 4, 5]; let i = 1; return a[i] + 10; }`),
+      ).toBe(14);
+    });
+
+    it("boolean[] in-bounds read preserves the boolean tag (=== true)", async () => {
+      expect(
+        await run(
+          `export function test(): boolean { const a: boolean[] = [true, false]; let i = 0; return a[i] === true; }`,
+        ),
+      ).toBe(1);
+    });
+
+    it("counted-loop sum keeps the unboxed fast path", async () => {
+      expect(
+        await run(
+          `export function test(): number { const a: number[] = [1, 2, 3, 4]; let s = 0; for (let i = 0; i < a.length; i++) s += a[i]; return s; }`,
+        ),
+      ).toBe(10);
+    });
+  });
+
+  describe("standalone — primitive OOB reads undefined (undefined≡null), fast path intact", () => {
+    it("number[] OOB === undefined", async () => {
+      expect(
+        await runStandalone(
+          `export function test(): boolean { const a: number[] = [1, 4, 5]; return a[4] === undefined; }`,
+        ),
+      ).toBe(1);
+    });
+
+    it("number[] in-bounds read is preserved", async () => {
+      expect(
+        await runStandalone(
+          `export function test(): number { const a: number[] = [1, 4, 5]; let i = 1; return a[i]; }`,
+        ),
+      ).toBe(4);
+    });
+
+    it("counted-loop sum (bounds-eliminated, no host import) is valid Wasm", async () => {
+      expect(
+        await runStandalone(
+          `export function test(): number { const a: number[] = [1, 2, 3, 4]; let s = 0; for (let i = 0; i < a.length; i++) s += a[i]; return s; }`,
+        ),
+      ).toBe(10);
+    });
+  });
+
+  describe("typed arrays keep their own OOB semantics (unchanged — out of F1 scope)", () => {
+    it("Int32Array OOB is NOT widened to undefined (still the typed default)", async () => {
+      // The shared helper default is untouched, so a typed-array OOB read keeps
+      // its existing semantics. `=== undefined` is therefore false here.
+      expect(
+        await run(
+          `export function test(): boolean { const a = new Int32Array(3); let i = 9; return a[i] === undefined; }`,
+        ),
+      ).toBe(0);
+    });
+  });
+
+  describe("S2 canary — Array.prototype.map on an array-like MUST stay green (#2198)", () => {
+    // The exact shape of test262 built-ins/Array/prototype/map/15.4.4.19-8-b-2.js.
+    // `testResult[2]` is an externref-vec OOB read (the map-of-plain-object result
+    // is length 0 — a separate pre-existing bug). It passes only because the
+    // externref OOB default surfaces as a falsy value that the assert accepts.
+    // F1 deliberately does NOT change externref OOB behaviour, so this stays green.
+    it("testResult[2] === false (externref OOB behaviour preserved)", async () => {
+      expect(
+        await run(`
+          export function test(): boolean {
+            function callbackfn(val: any, idx: any, obj: any): boolean {
+              if (idx === 2 && val === "length") { return false; } else { return true; }
+            }
+            var obj: any = {};
+            Object.defineProperty(obj, "length", {
+              get: function () { obj[2] = "length"; return 3; },
+              configurable: true,
+            });
+            var testResult = Array.prototype.map.call(obj, callbackfn);
+            return testResult[2] === false;
+          }
+        `),
+      ).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## #2760 — Hybrid type-soundness floor F1

Implements floor fix **F1** of the hybrid soundness roadmap: an out-of-bounds read of a plain-array **primitive** element returns JS `undefined` (the SAFE default), not the type-default sentinel.

### What changed
- `number[]` (f64) and `boolean[]` (i32) OOB reads now return `undefined`. The unproven (non-bounds-eliminated) read widens its SAFE result to a **boxed-or-undefined externref** (box the in-bounds element; OOB → `__get_undefined`, or `ref.null.extern` under standalone where `undefined ≡ null`). The **proven** in-bounds read (`isSafeBoundsEliminated`) keeps the **unboxed fast path** — the hybrid invariant in miniature.
- New call-site helper `emitPlainArrayUndefinedOobGet` in `src/codegen/property-access.ts`, invoked from the two `compileElementAccessBody` plain-array read sites, gated on `classifyTypedArrayType(...) === "other"` (genuine array, not a typed-array view; the regex-match-vec exotic excluded).

### NOT the S2 shared-helper flip
The shared `emitBoundsCheckedArrayGet` default is **unchanged** — its `$__subview` / typed-array / array-method internal callers are byte-identical. Flipping that shared default was the S2 leak (#2198) that regressed `Array.prototype.map`-on-array-like.

### Deliberately deferred (with traced root cause)
- **Externref `any[]`/`string[]` OOB→undefined**: deferred. It regresses the S2 canary `built-ins/Array/prototype/map/15.4.4.19-8-b-2.js`, whose `testResult[2]` is an OOB read on a **length-0** map-of-array-like result (a separate pre-existing map bug). The test passes today only because OOB externref `null` coerces to the asserted `false`; the spec-correct `undefined` exposes that latent bug. Deferred to the IR `prove-then-specialize` work (#2766) / a map-length fix.
- **Object-element (`Foo[]`) arrays**: unchanged (widening to externref would break downstream `a[i].field`).

### Validation
- New `tests/issue-2760.test.ts` — 15 cases (primitive OOB→undefined host+standalone; in-bounds preserved incl. boolean tag + counted-loop fast path; typed-array unchanged; **map-on-array-like canary guard**).
- Local array/destructuring + `tests/equivalence/` batches: no new failures (only pre-existing `tests/helpers.js` infra + `fast-arrays`/`array-capacity`/equivalence failures that fail identically on clean `main`).
- Broad conformance: full CI / `merge_group` test262 regression gate + standalone-floor.

Closes #2760.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS