### PR TITLE
fix(#2729): apply ToUint8 on WasmGC Uint8Array element store

### DIFF
--- a/plan/issues/2729-wasmgc-uint8array-store-skips-touint8.md
+++ b/plan/issues/2729-wasmgc-uint8array-store-skips-touint8.md
@@ -1,8 +1,9 @@
 ---
 id: 2729
 title: "WasmGC backend: new Uint8Array(n) element store skips ToUint8 (u[0]=257 reads 257, u[0]=NaN reads NaN)"
-status: ready
-sprint: Backlog
+status: in-progress
+assignee: ttraenkler/agent-aa6c288d8cd3cb14b
+sprint: current
 created: 2026-06-26
 priority: medium
 feasibility: medium

--- a/plan/issues/2729-wasmgc-uint8array-store-skips-touint8.md
+++ b/plan/issues/2729-wasmgc-uint8array-store-skips-touint8.md
@@ -1,10 +1,11 @@
 ---
 id: 2729
 title: "WasmGC backend: new Uint8Array(n) element store skips ToUint8 (u[0]=257 reads 257, u[0]=NaN reads NaN)"
-status: in-progress
+status: done
 assignee: ttraenkler/agent-aa6c288d8cd3cb14b
 sprint: current
 created: 2026-06-26
+completed: 2026-06-28
 priority: medium
 feasibility: medium
 task_type: bug
@@ -53,6 +54,47 @@ backing store at all.
 - Re-add the `numeric/uint8-store-touint8` cross-backend corpus entry (removed in
   #2715 because of this divergence) so the gate covers it once both backends agree.
 - No regression in existing TypedArray tests.
+
+## Resolution
+
+Root cause confirmed: `typedArrayVecStorage` (src/codegen/index.ts) only packs a
+typed array into `i8`/`i16`/`i32` storage under **wasi/standalone**; on the
+default host/gc backend a `new Uint8Array(n)` is backed by an **f64 vec**. The
+f64 element-store path in `compileElementAssignment` (src/codegen/expressions/
+assignment.ts) applied no conversion, so the raw `f64` was stored and read back
+verbatim (`u[0]=257`→257, `u[0]=-1`→-1, `u[0]=3.7`→3.7, `u[0]=NaN`→NaN).
+
+Fix: when the element-assignment receiver is a `Uint8Array` whose backing element
+is `f64` (the host/gc case), apply ToUint8 (§7.1.10) explicitly before the store —
+`emitToInt32` (NaN/±Inf→0, truncate toward zero, reduce mod 2^32) then `& 0xFF`,
+then widen back to `f64` (`f64.convert_i32_u`) for the f64 vec element. This
+mirrors the linear backend (#2715) and the wasi/standalone `array.set`
+i8-truncation path, which are untouched (the fix is gated on `element.kind ===
+"f64"`).
+
+## Test Results (WasmGC / default backend)
+
+All pass: `u[0]=257`→1, `256`→0, `-1`→255, `-256`→0, `-257`→255, `1e20`→0,
+`3.7`→3, `255.9`→255, `511.5`→255, `0/0`→0, `±1/0`→0; in-range 0/200/255 and
+loop/variable-RHS writes unchanged. The restored `numeric/uint8-store-touint8`
+cross-backend corpus entry now AGREES across WasmGC and linear on all 11 calls.
+Regression suites green: cross-backend-diff, issue-2715, issue-2593
+(typedarray-intwidth), issue-1787 (packed-typedarray-semantics), issue-2648
+(typedarray-search-packed-elem). (`tests/typed-array-basic.test.ts` and
+`tests/arraybuffer-dataview.test.ts` have 17 pre-existing `string_constants`
+instantiate-harness failures unrelated to this change — they fail identically on
+pristine main.)
+
+## Follow-up (out of scope)
+
+- **Other integer views share the host/gc gap**: `new Int8Array(n)`,
+  `Int16Array`, `Uint16Array`, `Int32Array`, `Uint32Array` element stores on the
+  host/gc backend likewise skip their ToIntN coercion (`Int8Array[0]=257`→257).
+  `Uint8ClampedArray` is already correct (ToUint8Clamp). The linear backend does
+  not yet support these stores cross-backend, so they are not yet corpus-gated.
+- **Compound / unary element updates** (`u[0]+=n`, `u[0]++`) also skip ToUint8 on
+  the host/gc backend (separate code path); linear CE's on them, so they cannot
+  be added to the cross-backend corpus yet.
 
 ## Notes
 

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -3432,7 +3432,16 @@ function compileElementAssignment(
     // (#2593) `Uint8ClampedArray` write is NOT modulo — it is ToUint8Clamp
     // (clamp to [0,255] + round-half-even). Detect the view by name so the value
     // routes through `emitToUint8Clamp` below instead of the plain i32 truncation.
-    const isUint8Clamped = elementAccessTypedArrayName(ctx, target.expression) === "Uint8ClampedArray";
+    const taViewName = elementAccessTypedArrayName(ctx, target.expression);
+    const isUint8Clamped = taViewName === "Uint8ClampedArray";
+    // (#2729) On the WasmGC host/gc backend a `new Uint8Array(n)` element is
+    // stored in an `f64` vec (the i8 packed storage is wasi/standalone-only —
+    // see `typedArrayVecStorage`). The f64 store path applied NO conversion, so
+    // out-of-range / non-integer values read back raw (`u[0]=257`→257,
+    // `u[0]=-1`→-1, `u[0]=NaN`→NaN). When the backing element is f64 we must
+    // apply ToUint8 (§7.1.10) explicitly before the store. The wasi/standalone
+    // i8-packed path is handled by the `array.set` re-truncation branch below.
+    const isHostUint8 = taViewName === "Uint8Array" && arrDef.element.kind === "f64";
     const valueHint: ValType =
       arrDef.element.kind === "i8" || arrDef.element.kind === "i16"
         ? isUint8Clamped
@@ -3449,6 +3458,16 @@ function compileElementAssignment(
       // value is f64 first (a literal/i32 may have compiled to i32).
       if (elemValResult.kind === "i32") fctx.body.push({ op: "f64.convert_i32_s" } as Instr);
       emitToUint8Clamp(fctx);
+    } else if (isHostUint8) {
+      // (#2729) ToUint8 for the f64-backed host store: ToInt32 (NaN/±Inf→0,
+      // truncate toward zero, reduce mod 2^32) then mask the low byte (& 0xFF),
+      // then widen back to f64 for the f64 vec element. This matches the linear
+      // backend's ToUint8 (#2715) and the wasi/standalone i8-packed truncation.
+      if (elemValResult.kind !== "f64") coerceType(ctx, fctx, elemValResult, { kind: "f64" });
+      emitToInt32(fctx); // f64 → i32
+      fctx.body.push({ op: "i32.const", value: 0xff } as Instr);
+      fctx.body.push({ op: "i32.and" } as Instr);
+      fctx.body.push({ op: "f64.convert_i32_u" } as Instr);
     } else if ((arrDef.element.kind === "i8" || arrDef.element.kind === "i16") && elemValResult.kind === "f64") {
       // (#2593) Other packed i8/i16 views: truncate the f64 store value to i32
       // (ToInt32 modulo); `array.set` re-packs to the element width.

--- a/tests/cross-backend/corpus.ts
+++ b/tests/cross-backend/corpus.ts
@@ -112,13 +112,42 @@ export const CROSS_BACKEND_CORPUS: readonly CrossBackendProgram[] = [
       { fn: "compoundNan", args: [] },
     ],
   },
-  // NOTE: a Uint8Array ToUint8 store cross-backend entry is deliberately NOT
-  // added here — the WasmGC backend has a separate, pre-existing bug where
-  // `new Uint8Array(1)` element stores skip ToUint8 entirely (`u[0]=257` reads
-  // back 257, `u[0]=NaN` reads back NaN), so the two backends diverge for an
-  // unrelated reason. The linear ToUint8 fix is covered directly against the JS
-  // oracle in tests/issue-2715.test.ts; the WasmGC store bug is tracked
-  // separately (follow-up issue).
+  {
+    // #2729 — Uint8Array element store ToUint8 (§7.1.10): the assigned value is
+    // wrapped to a byte (truncate toward zero, modulo 256; NaN/±Infinity → 0)
+    // before storage. The linear backend was fixed in #2715; the WasmGC backend
+    // (#2729) used to store the raw f64 (`u[0]=257`→257, `u[0]=NaN`→NaN). This
+    // entry — removed in #2715 because of that divergence — is restored now both
+    // backends agree.
+    name: "numeric/uint8-store-touint8",
+    category: "numeric",
+    source: `
+      export function wrapOver(): number { const u = new Uint8Array(1); u[0] = 257; return u[0]; }
+      export function wrap256(): number { const u = new Uint8Array(1); u[0] = 256; return u[0]; }
+      export function wrapNeg(): number { const u = new Uint8Array(1); u[0] = -1; return u[0]; }
+      export function wrapNeg257(): number { const u = new Uint8Array(1); u[0] = -257; return u[0]; }
+      export function truncFrac(): number { const u = new Uint8Array(1); u[0] = 3.7; return u[0]; }
+      export function truncBig(): number { const u = new Uint8Array(1); u[0] = 511.5; return u[0]; }
+      export function nanZero(): number { const u = new Uint8Array(1); u[0] = 0 / 0; return u[0]; }
+      export function infZero(): number { const u = new Uint8Array(1); u[0] = 1 / 0; return u[0]; }
+      export function negInfZero(): number { const u = new Uint8Array(1); u[0] = -1 / 0; return u[0]; }
+      export function bigWrap(): number { const u = new Uint8Array(1); u[0] = 1e20; return u[0]; }
+      export function inRange(): number { const u = new Uint8Array(1); u[0] = 200; return u[0]; }
+    `,
+    calls: [
+      { fn: "wrapOver", args: [] },
+      { fn: "wrap256", args: [] },
+      { fn: "wrapNeg", args: [] },
+      { fn: "wrapNeg257", args: [] },
+      { fn: "truncFrac", args: [] },
+      { fn: "truncBig", args: [] },
+      { fn: "nanZero", args: [] },
+      { fn: "infZero", args: [] },
+      { fn: "negInfZero", args: [] },
+      { fn: "bigWrap", args: [] },
+      { fn: "inRange", args: [] },
+    ],
+  },
   {
     // Math.trunc is not yet lowered by the linear backend (Unsupported method
     // call: .trunc()). Tracked here so the gap is visible and the flag drops

--- a/tests/issue-2729.test.ts
+++ b/tests/issue-2729.test.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2729 — WasmGC backend: `new Uint8Array(n)` element store skips ToUint8.
+//
+// On the default WasmGC (host/gc) backend a `new Uint8Array(n)` (no explicit
+// ArrayBuffer) lowers to an f64-backed vec — the i8 packed storage is
+// wasi/standalone-only (see `typedArrayVecStorage`). The f64 store path applied
+// NO conversion, so an out-of-range or non-integer assignment read back the raw
+// value (`u[0]=257`→257, `u[0]=-1`→-1, `u[0]=NaN`→NaN) instead of the §7.1.10
+// ToUint8 byte. The fix applies ToUint8 (ToInt32 then & 0xFF; NaN/±Inf→0) before
+// the f64 store, matching the linear backend (#2715) and the wasi/standalone
+// i8-packed truncation.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+
+/** Compile + run a single `test()` body on the default WasmGC backend. */
+async function runGc(body: string): Promise<number> {
+  const result = await compile(`export function test(): number { ${body} }`);
+  if (!result.success) {
+    throw new Error(`compile failed: ${result.errors.map((e) => e.message).join("; ")}`);
+  }
+  const built = buildImports(result.imports, {}, result.stringPool);
+  const { instance } = await instantiateWasm(result.binary, built.env, built.string_constants);
+  built.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#2729 WasmGC Uint8Array element store applies ToUint8", () => {
+  // Acceptance criteria (issue body): out-of-range wraps, non-integer truncates,
+  // NaN/±Infinity → 0.
+  const cases: Array<[string, number]> = [
+    // Wrap modulo 256.
+    ["const u = new Uint8Array(1); u[0] = 257; return u[0];", 1],
+    ["const u = new Uint8Array(1); u[0] = 256; return u[0];", 0],
+    ["const u = new Uint8Array(1); u[0] = -1; return u[0];", 255],
+    ["const u = new Uint8Array(1); u[0] = -256; return u[0];", 0],
+    ["const u = new Uint8Array(1); u[0] = -257; return u[0];", 255],
+    ["const u = new Uint8Array(1); u[0] = 1e20; return u[0];", 0],
+    // Truncate toward zero, then wrap.
+    ["const u = new Uint8Array(1); u[0] = 3.7; return u[0];", 3],
+    ["const u = new Uint8Array(1); u[0] = 255.9; return u[0];", 255],
+    ["const u = new Uint8Array(1); u[0] = 511.5; return u[0];", 255],
+    // NaN / ±Infinity → 0.
+    ["const u = new Uint8Array(1); u[0] = 0 / 0; return u[0];", 0],
+    ["const u = new Uint8Array(1); u[0] = 1 / 0; return u[0];", 0],
+    ["const u = new Uint8Array(1); u[0] = -1 / 0; return u[0];", 0],
+    // In-range happy paths are unchanged.
+    ["const u = new Uint8Array(1); u[0] = 0; return u[0];", 0],
+    ["const u = new Uint8Array(1); u[0] = 200; return u[0];", 200],
+    ["const u = new Uint8Array(1); u[0] = 255; return u[0];", 255],
+  ];
+  for (const [body, expected] of cases) {
+    it(`${body} === ${expected}`, async () => {
+      expect(await runGc(body)).toBe(expected);
+    });
+  }
+
+  it("variable RHS is coerced (300 → 44)", async () => {
+    expect(await runGc("const u = new Uint8Array(1); let x = 300; u[0] = x; return u[0];")).toBe(44);
+  });
+
+  it("multiple distinct elements wrap independently", async () => {
+    expect(
+      await runGc("const u = new Uint8Array(3); u[0] = 10; u[1] = 20; u[2] = 257; return u[0] + u[1] + u[2];"),
+    ).toBe(10 + 20 + 1);
+  });
+
+  it("loop-written elements each apply ToUint8", async () => {
+    // i*100: 0, 100, 200, 300→44
+    expect(
+      await runGc(
+        "const u = new Uint8Array(4); for (let i = 0; i < 4; i++) { u[i] = i * 100; } return u[0] + u[1] + u[2] + u[3];",
+      ),
+    ).toBe(0 + 100 + 200 + 44);
+  });
+});


### PR DESCRIPTION
## Summary
On the default **WasmGC** (host/gc) backend a `new Uint8Array(n)` is backed by an **f64 vec** — the i8 packed storage is wasi/standalone-only (`typedArrayVecStorage`). The f64 element-store path in `compileElementAssignment` applied **no conversion**, so out-of-range / non-integer assignments read back the raw value:

```ts
const u = new Uint8Array(1);
u[0] = 257; u[0]; // was 257, now 1
u[0] = -1;  u[0]; // was -1,  now 255
u[0] = 3.7; u[0]; // was 3.7, now 3
u[0] = 0/0; u[0]; // was NaN, now 0
```

## Fix
When the element-assignment receiver is a `Uint8Array` whose backing element is `f64` (the host/gc case), apply ToUint8 (§7.1.10) explicitly before the store: `emitToInt32` (NaN/±Inf→0, truncate toward zero, reduce mod 2^32) then `& 0xFF`, then widen back to `f64` (`f64.convert_i32_u`) for the f64 vec element. Mirrors the linear backend (#2715) and the wasi/standalone `array.set` i8-truncation path, both **untouched** (gated on `element.kind === 'f64'`).

## Tests
- `tests/issue-2729.test.ts` — WasmGC ToUint8 store coverage (wrap, truncate, NaN/±Inf→0, in-range, variable RHS, loop writes).
- `tests/cross-backend/corpus.ts` — restores the `numeric/uint8-store-touint8` entry (removed in #2715 for this divergence); WasmGC and linear now AGREE on all 11 calls.
- Regression-green: cross-backend-diff, issue-2715, issue-2593, issue-1787, issue-2648.

## Acceptance criteria
- [x] `u[0]=257`→1, `u[0]=-1`→255, `u[0]=NaN`/`±Inf`→0 on WasmGC.
- [x] Re-added `numeric/uint8-store-touint8` cross-backend corpus entry.
- [x] No regression in existing TypedArray tests.

Out-of-scope follow-ups (documented in the issue): other integer views (Int8/Int16/Uint16/Int32/Uint32) and compound/unary element updates share the host/gc gap but are not yet cross-backend-gated (linear lacks support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS