### PR TITLE
fix(#2671): recognize Promise.resolve/reject capability-ctor sites (+6 test262)

### DIFF
--- a/plan/issues/2671-es6-builtin-spec-residuals-date-regexp-promise-json-super.md
+++ b/plan/issues/2671-es6-builtin-spec-residuals-date-regexp-promise-json-super.md
@@ -163,6 +163,40 @@ built-ins/Promise/all/invoke-resolve-error-close.js
 built-ins/Promise/prototype/then/S25.4.5.3_A1.1_T2.js
 ```
 
+**Progress (agent-af359e7cc95c024c6, 2026-06-28): GetCapabilitiesExecutor
+functions — `Promise.resolve`/`Promise.reject` capability-ctor sites — SHIPPED
+(+6 test262).**
+
+Verified-first through the real worker harness (`compile` + `__setExports` +
+`wrapExports`). Root cause: V8's `Promise.resolve.call(C)` / `Promise.reject.call(C)`
+run PromiseResolve(C) → NewPromiseCapability(C) → `Construct(C, «executor»)`,
+exactly like the four aggregators. When `C` is a user
+`function NotPromise(executor){ executor(fn1, fn2); }` (lowered to a WasmGC
+closure), the `executor(...)` call must wrap its closure arguments into
+host-callable functions through the `__call_function` host helper — otherwise
+V8's NewPromiseCapability throws "Promise resolve or reject function is not
+callable" (the wasm closures reach V8 as opaque structs). The codegen gate
+`calleeIsCapabilityCtorParam` (src/codegen/expressions/calls.ts) scanned only
+`Promise.{all,allSettled,race,any}.call(<fn>, …)`, so the `resolve`/`reject`
+capability sites fell through and the executor's closure args were never wrapped.
+- Fix: add `resolve`/`reject` to the scanned combinator set (one-line, additive,
+  JS-host-only — the `emitBoundFunctionCall` route is already gated by
+  `!ctx.standalone && !noJsHost(ctx)`, so standalone/WASI is untouched).
+- Flips **6** `built-ins/Promise/executor-function-*` files: `-extensible`,
+  `-length` (length 2), `-name` (""), `-not-a-constructor` (no own `.prototype`),
+  `-prototype` (`[[Prototype]]` === Function.prototype), `-property-order`
+  (length,name). Top-level `built-ins/Promise` survey: 46→52 pass, 0 regressions;
+  `resolve/` (26/4) and `reject/` (12/3) subdirs byte-identical vs pristine main
+  (baseline-toggle differential). `tests/promise-combinators.test.ts`'s 2
+  pre-existing failures are unrelated (present with the change reverted).
+- Guard: `tests/issue-2671-promise-executor.test.ts` (14/14).
+- ⏳ Remaining Promise: the `resolve-element-function-*` family
+  (`Promise.all.call(NotPromise, [thenable])`) is a SEPARATE, deeper marshaling
+  chain — the host must call a wasm-struct thenable's `then` method and store the
+  native resolve-element function back into a wasm `var`; `thenable.then` is never
+  invoked today (`resolveElementFunction` stays undefined). Not in this slice.
+  Also: invoke-resolve error-close paths, `then` spec asserts.
+
 ### JSON (44)
 reviver/replacer with non-configurable / define-prop-err properties
 (`Object.defineProperty called on non-object` — ties to #2668), replacer

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -1705,7 +1705,13 @@ function calleeIsCapabilityCtorParam(ctx: CodegenContext, expr: ts.Expression): 
   }
   if (fnName === undefined) return false;
   // Scan the source file for `Promise.<combinator>.call(<fnName>, …)`.
-  const COMBINATORS = new Set(["all", "allSettled", "race", "any"]);
+  // (#2671) `Promise.resolve` / `Promise.reject` are ALSO capability-ctor
+  // sites: V8's `Promise.resolve.call(C)` → PromiseResolve(C) →
+  // NewPromiseCapability(C) → `Construct(C, «GetCapabilitiesExecutor»)`. The
+  // user fn's `executor` param therefore receives a host executor and must
+  // wrap its closure args host-callable through `__call_function`, exactly
+  // like the four aggregators (executor-function-* test262 family).
+  const COMBINATORS = new Set(["all", "allSettled", "race", "any", "resolve", "reject"]);
   const sf = decl.getSourceFile();
   let found = false;
   const visit = (node: ts.Node): void => {

--- a/tests/issue-2671-promise-executor.test.ts
+++ b/tests/issue-2671-promise-executor.test.ts
@@ -1,0 +1,87 @@
+// #2671 (ES2015 builtin residual) — GetCapabilitiesExecutor functions
+// (§27.2.1.5.1 / sec-getcapabilitiesexecutor-functions).
+//
+// Root cause: V8's `Promise.resolve.call(C)` / `Promise.reject.call(C)` run
+// PromiseResolve(C) → NewPromiseCapability(C) → `Construct(C, «executor»)`,
+// exactly like the four aggregators (`Promise.all.call(C, …)` etc.). When `C`
+// is a user `function NotPromise(executor){ executor(fn1, fn2); }` lowered to a
+// WasmGC closure, the `executor(...)` call must wrap its closure arguments into
+// host-callable functions through the `__call_function` host helper — otherwise
+// V8's NewPromiseCapability throws "Promise resolve or reject function is not
+// callable" (the wasm closures reach V8 as opaque structs).
+//
+// The codegen gate `calleeIsCapabilityCtorParam` recognised only the four
+// aggregator combinators, so the `Promise.resolve`/`Promise.reject` capability
+// sites fell through and the executor's closure args were never wrapped. Fix:
+// add `resolve`/`reject` to the scanned combinator set
+// (src/codegen/expressions/calls.ts). This flips the six
+// `built-ins/Promise/executor-function-*` test262 files.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+
+async function captureExecutor(method: "resolve" | "reject"): Promise<any> {
+  // Mirrors built-ins/Promise/executor-function-*.js: a non-Promise constructor
+  // captures the GetCapabilitiesExecutor function V8 hands to `new C(executor)`.
+  const src = `export function test(): any {
+    var executorFunction;
+    function NotPromise(executor) {
+      executorFunction = executor;
+      executor(function() {}, function() {});
+    }
+    Promise.${method}.call(NotPromise);
+    return executorFunction;
+  }`;
+  const result: any = await compile(src, { fileName: "test.ts", skipSemanticDiagnostics: true } as any);
+  expect(result.binary?.length).toBeGreaterThan(0);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  const w: any = wrapExports(instance.exports, { signatures: result.exportSignatures });
+  return w.test();
+}
+
+describe("#2671 — Promise GetCapabilitiesExecutor functions", () => {
+  for (const method of ["resolve", "reject"] as const) {
+    describe(`Promise.${method}.call(NotPromise)`, () => {
+      it("captures a callable executor (NewPromiseCapability no longer throws)", async () => {
+        const ef = await captureExecutor(method);
+        expect(typeof ef).toBe("function");
+      });
+
+      it("the executor is extensible (executor-function-extensible)", async () => {
+        const ef = await captureExecutor(method);
+        expect(Object.isExtensible(ef)).toBe(true);
+      });
+
+      it("has length 2 (executor-function-length)", async () => {
+        const ef = await captureExecutor(method);
+        expect(ef.length).toBe(2);
+      });
+
+      it("has the empty-string name (executor-function-name)", async () => {
+        const ef = await captureExecutor(method);
+        expect(ef.name).toBe("");
+      });
+
+      it("is not a constructor — no own .prototype (executor-function-not-a-constructor)", async () => {
+        const ef = await captureExecutor(method);
+        expect(Object.prototype.hasOwnProperty.call(ef, "prototype")).toBe(false);
+      });
+
+      it("[[Prototype]] is Function.prototype (executor-function-prototype)", async () => {
+        const ef = await captureExecutor(method);
+        expect(Object.getPrototypeOf(ef)).toBe(Function.prototype);
+      });
+
+      it("own-property order is length,name (executor-function-property-order)", async () => {
+        const ef = await captureExecutor(method);
+        const names = Object.getOwnPropertyNames(ef);
+        const li = names.indexOf("length");
+        const ni = names.indexOf("name");
+        expect(li).toBeGreaterThanOrEqual(0);
+        expect(ni).toBe(li + 1);
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Part of the #2671 Promise area. Fixes the `built-ins/Promise/executor-function-*` test262 family (GetCapabilitiesExecutor functions, §27.2.1.5.1).

## Root cause

V8's `Promise.resolve.call(C)` / `Promise.reject.call(C)` run PromiseResolve(C) → NewPromiseCapability(C) → `Construct(C, «executor»)`, exactly like the four aggregators (`Promise.all.call(C, …)` etc). When `C` is a user `function NotPromise(executor){ executor(fn1, fn2); }` lowered to a WasmGC closure, the `executor(...)` call must wrap its closure arguments into host-callable functions through the `__call_function` host helper — otherwise V8's NewPromiseCapability throws "Promise resolve or reject function is not callable" (the wasm closures reach V8 as opaque structs).

The codegen gate `calleeIsCapabilityCtorParam` (`src/codegen/expressions/calls.ts`) scanned only `Promise.{all,allSettled,race,any}.call(<fn>, …)`, so the `resolve`/`reject` capability sites fell through and the executor's closure args were never wrapped.

## Fix

Add `resolve`/`reject` to the scanned combinator set — one line, additive, JS-host-only (the `emitBoundFunctionCall` route is already gated by `!ctx.standalone && !noJsHost(ctx)`, so standalone/WASI is untouched).

## Validation

- Flips **6** `built-ins/Promise/executor-function-*` files: `-extensible`, `-length` (length 2), `-name` (""), `-not-a-constructor` (no own `.prototype`), `-prototype` (`[[Prototype]]` === Function.prototype), `-property-order` (length,name).
- Top-level `built-ins/Promise` survey: **46 → 52 pass, 0 regressions**.
- `resolve/` (26/4) and `reject/` (12/3) subdirs byte-identical vs pristine main (baseline-toggle differential).
- `tests/promise-combinators.test.ts`'s 2 pre-existing failures are unrelated (present with the change reverted).
- Guard: `tests/issue-2671-promise-executor.test.ts` (14/14).

## Out of scope

The `resolve-element-function-*` family (`Promise.all.call(NotPromise, [thenable])`) is a separate, deeper marshaling chain (host calling a wasm-struct thenable's `then` and storing the native resolve-element fn back into a wasm var) — not in this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)