### PR TITLE
fix(#2669): typed in-bounds undefined/hole default-init fires for-of default

### DIFF
--- a/plan/issues/2669-es6-destructuring-correctness-residual-umbrella.md
+++ b/plan/issues/2669-es6-destructuring-correctness-residual-umbrella.md
@@ -268,6 +268,48 @@ PASS via fresh single-file runs; 12 sync improvements re-verified PASS.
 This slice keeps the umbrella OPEN (status stays `ready`) — it burns down the
 nested-array-default codegen corner, not the iterator-protocol tail.
 
+## Slice landed (issue-2669-typed-default-init, 2026-06-28) — typed in-bounds undefined/hole sentinel
+
+Resolves the **typed in-bounds `undefined`/hole default-init** carve named in the
+"Remaining umbrella tail" above (the `for (let [x=23] of [[undefined]])` / `[[,]]`
+case). Root-caused and fixed; guard tests `tests/issue-2669.test.ts` "Bug 3"
+(14/14 green).
+
+### Root cause
+An array whose element type is EXACTLY the `undefined` (or `void`) primitive —
+`[[undefined]]` (TS infers `undefined[][]`) or a hole-only literal `[[,]]` —
+resolved its element type to **i32** via `mapTsTypeToWasm` (which maps
+`undefined`/`void` → i32 for the "no result" case). The inner `[undefined]` vec,
+built as `vec_externref` holding the `undefined` externref, was then COERCED to
+`vec_i32` (`__unbox_number` → `i32.trunc_sat_f64_s` → `0`). The for-of array path
+read that i32 `0`, coerced it to f64 `0.0`, and the default-check
+(`i64.reinterpret_f64` == sNaN sentinel `0x7ff00000deadc0de`) never matched — so
+`[x = 23]` never fired and `x` stayed `0`. Distinct from the externref/OOB Bug 1
+(there the element is out-of-bounds; here it is in-bounds and present).
+
+### Fix (one site, `src/codegen/index.ts` `resolveWasmType` Array branch)
+Widen an exactly-`undefined`/`void` vec element type from i32 → externref, so the
+inner array is built as `vec_externref` (no lossy i32 coercion) and the existing
+`wantUndefinedSentinel` for-of path (`__extern_is_undefined`) fires the default.
+Mirrors the #1468 struct-FIELD widening for `{ k: undefined }`. Scoped to the
+EXACT `undefined`/`void` primitive — `T | undefined` unions are already widened by
+`mapTsTypeToWasm`, and Number/Boolean/symbol element types are excluded. NO touch
+to assignment-destructuring rest-target lowering (#2757/#2224).
+
+### Validation
+- 6 targeted test262 wins (all fail→pass): `language/statements/for-of/dstr/`
+  `{const,let,var}-ary-ptrn-elem-id-init-{undef,hole}.js`.
+- 8 collateral wins across for-of + assignment dstr (`array-elem-nested-{array,obj}-undefined-own`,
+  `array-rest-before-elision`, `array-rest-elision-invalid`, `obj-rest-not-last-element-invalid`).
+- 0 real regressions in scoped sweeps over for-of/dstr (569), let/dstr (94),
+  assignment/dstr (368). (THREW entries in the standalone sweep driver are a
+  state-accumulation harness artifact — all pass in a clean process; CI validates
+  full conformance.)
+- `tests/issue-2669.test.ts` 14/14; existing array suites green.
+
+Umbrella stays OPEN — remaining tail: nested **object**-default
+(`[{a}={a:1}]`, follow-up carve), iterator-protocol (#1642/#2566).
+
 ## Residual (as of #2199, PO reconcile 2026-06-28)
 
 NOT done — broad umbrella. The referencing PR landed the nested-array default-init codegen family (3 defects). The umbrella stays OPEN: iterator-close, defaults, holes, rest across for-of / assignment / binding / params (~696 fails) need further concrete slices carved.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -11283,9 +11283,35 @@ export function resolveWasmType(ctx: CodegenContext, tsType: ts.Type, _depth = 0
     if (sym?.name === "Array" || sym?.name === "ReadonlyArray") {
       const typeArgs = ctx.checker.getTypeArguments(tsType as ts.TypeReference);
       const elemTsType = typeArgs[0];
-      const elemWasm: ValType = elemTsType
+      let elemWasm: ValType = elemTsType
         ? resolveWasmType(ctx, elemTsType, _depth + 1, _visited)
         : { kind: "externref" };
+      // (#2669) An array whose element type is EXACTLY the `undefined` (or `void`)
+      // primitive — e.g. `[[undefined]]` (TS infers `undefined[][]`) or a
+      // hole-only literal `[[,]]` — resolves its element to i32 via
+      // `mapTsTypeToWasm` (which maps `undefined`/`void` → i32 for the "no result"
+      // case). That stores `undefined` as i32 `0` and LOSES its identity, so a
+      // destructuring default over the value (`for (const [x = 23] of [[undefined]])`)
+      // never fires — the value isn't observably `undefined` (the i32 `0` coerces
+      // to f64 `0.0`, never the sNaN sentinel the default-check looks for). Widen
+      // to externref so the `__get_undefined()` / `__extern_is_undefined` sentinel
+      // path preserves it and the for-of / binding default fast-path triggers.
+      // Mirrors the #1468 struct-FIELD widening for `{ k: undefined }`. Scoped to
+      // the EXACT `undefined`/`void` primitive — `T | undefined` unions are already
+      // widened by `mapTsTypeToWasm`'s union branch, and Number/Boolean/symbol
+      // element types are excluded.
+      if (elemTsType && elemWasm.kind === "i32") {
+        const f = elemTsType.flags;
+        const exactlyUndefinedOrVoid =
+          (f & ts.TypeFlags.Undefined || f & ts.TypeFlags.Void) &&
+          !(f & ts.TypeFlags.Boolean) &&
+          !(f & ts.TypeFlags.BooleanLiteral) &&
+          !(f & ts.TypeFlags.Number) &&
+          !(f & ts.TypeFlags.NumberLiteral) &&
+          !(f & ts.TypeFlags.ESSymbol) &&
+          !(f & ts.TypeFlags.UniqueESSymbol);
+        if (exactlyUndefinedOrVoid) elemWasm = { kind: "externref" };
+      }
       const elemKey =
         elemWasm.kind === "ref" || elemWasm.kind === "ref_null"
           ? `ref_${(elemWasm as { typeIdx: number }).typeIdx}`

--- a/tests/issue-2669.test.ts
+++ b/tests/issue-2669.test.ts
@@ -126,3 +126,56 @@ describe("#2669 — for-of nested destructuring default (Bug 2: nested default i
     expect(e.test!()).toBe(5);
   });
 });
+
+// ── Slice: typed in-bounds `undefined` / hole default-init (this slice) ──────────
+//
+// Bug 3 (typed in-bounds sentinel-propagation): an array whose element type is
+// EXACTLY the `undefined` (or `void`) primitive — `[[undefined]]` (TS infers
+// `undefined[][]`) or a hole-only literal `[[,]]` — resolved its element type to
+// i32 via `mapTsTypeToWasm`, storing `undefined` as i32 `0`. The for-of array
+// path then coerced that i32 `0` to f64 `0.0`, which never matched the f64 sNaN
+// sentinel the default-check looks for, so the default `[x = 23]` never fired
+// (`for (const [x = 23] of [[undefined]])` / `[[,]]` left x = 0). Distinct from
+// the externref/OOB Bug 1 above: here the element is IN BOUNDS and present as a
+// literal `undefined`/hole. Fix: widen an exactly-`undefined`/`void` vec element
+// type to externref in `resolveWasmType` (mirrors the #1468 struct-field widening)
+// so the `__get_undefined()` / `__extern_is_undefined` sentinel path preserves it.
+// Real test262: language/statements/for-of/dstr/{const,let,var}-ary-ptrn-elem-id-init-{undef,hole}.js
+describe("#2669 — typed in-bounds undefined/hole default-init (Bug 3)", () => {
+  it("for-of: default fires for an in-bounds explicit `undefined` element", async () => {
+    const e = await compileAndRun(`export function test(): number {
+      let out = 0;
+      for (let [x = 23] of [[undefined]]) { out = x; }
+      return out;
+    }`);
+    expect(e.test!()).toBe(23);
+  });
+
+  it("for-of: default fires for an in-bounds elision hole", async () => {
+    const e = await compileAndRun(`export function test(): number {
+      let out = 0;
+      for (let [x = 23] of [[,]]) { out = x; }
+      return out;
+    }`);
+    expect(e.test!()).toBe(23);
+  });
+
+  it("for-of: default SKIPPED when the element is present (regression guard)", async () => {
+    const e = await compileAndRun(`export function test(): number {
+      let out = 0;
+      for (let [x = 23] of [[7]]) { out = x; }
+      return out;
+    }`);
+    expect(e.test!()).toBe(7);
+  });
+
+  it("for-of: const/explicit-undefined matches the const-ary-ptrn-elem-id-init-undef shape", async () => {
+    const e = await compileAndRun(`export function test(): number {
+      let iterCount = 0;
+      let val = -1;
+      for (const [x = 23] of [[undefined]]) { val = x; iterCount += 1; }
+      return iterCount * 100 + val;   // expect 1*100 + 23 = 123
+    }`);
+    expect(e.test!()).toBe(123);
+  });
+});


### PR DESCRIPTION
## #2669 slice — typed in-bounds `undefined`/hole default-init

Burns down the **typed in-bounds `undefined`/hole default-init** carve from the
#2669 umbrella tail. Does NOT touch assignment-destructuring rest-target lowering
(that's #2757/#2224) — fix is confined to `resolveWasmType` + the for-of default path.

### Root cause
An array whose element type is EXACTLY the `undefined`/`void` primitive —
`[[undefined]]` (TS infers `undefined[][]`) or a hole-only literal `[[,]]` —
resolved its element to **i32** via `mapTsTypeToWasm`, storing `undefined` as i32 `0`.
The inner `[undefined]` vec (built as `vec_externref`) was coerced to `vec_i32`
(`__unbox_number` → `i32.trunc_sat_f64_s` → `0`); the for-of path then read i32 `0`,
coerced to f64 `0.0`, which never matched the f64 sNaN sentinel the default-check
looks for — so `[x = 23]` never fired and `x` stayed `0`.

### Fix
One site in `src/codegen/index.ts` `resolveWasmType` Array branch: widen an
exactly-`undefined`/`void` vec element type from i32 → externref so the inner array
is built as `vec_externref` (no lossy coercion) and the existing
`wantUndefinedSentinel` for-of path (`__extern_is_undefined`) fires the default.
Mirrors the #1468 struct-FIELD widening. Scoped to the EXACT `undefined`/`void`
primitive — `T | undefined` unions already widened by `mapTsTypeToWasm`;
Number/Boolean/symbol excluded.

### Validation
- **6 targeted test262 wins** (all fail→pass): `language/statements/for-of/dstr/{const,let,var}-ary-ptrn-elem-id-init-{undef,hole}.js`
- **8 collateral wins** across for-of + assignment dstr (`array-elem-nested-{array,obj}-undefined-own`, `array-rest-before-elision`, `array-rest-elision-invalid`, `obj-rest-not-last-element-invalid`)
- **0 real regressions** in scoped sweeps over for-of/dstr (569), let/dstr (94), assignment/dstr (368)
- Guard `tests/issue-2669.test.ts` Bug 3 added — 14/14 green; existing array suites green

Umbrella stays OPEN (status `ready`) — remaining tail: nested object-default (`[{a}={a:1}]`), iterator-protocol (#1642/#2566).

🤖 Generated with [Claude Code](https://claude.com/claude-code)