### PR TITLE
feat(codegen): #2773 S1 keystone — reserve fnctor struct types up-front (pass-invariant typeIdx)

### DIFF
--- a/plan/issues/2773-value-rep-substrate-epic.md
+++ b/plan/issues/2773-value-rep-substrate-epic.md
@@ -155,7 +155,7 @@ S1–S3 by separate devs (different files), but each is still broad-impact.
   symmetric read/write + compound + delete-aware routing, all typecheck-clean,
   minimal repros pass. S2/S2b **rebase this branch onto a merged S1**, they do not
   re-author it.
-- **Findings + probes** in that worktree: `plan/issues/2681-*.md` `## Implementation
+- **Findings + probes** in that worktree: the #2681 issue file's `## Implementation
   attempt + findings`; `.tmp/acorn-run.mjs` (single-compile worker watchdog +
   host-call signature), `.tmp/dbg-keys.mjs` (extern_get key histogram),
   `.tmp/identity*.mjs` (struct-identity repros). **Read these before touching S1–S3.**
@@ -426,8 +426,8 @@ design changes.**
 # SLICE S4 — full spec — plain-array OOB → `undefined` (consumer-scoped externref-or-undefined result rep) — #2760
 
 **Role: senior-dev. Broad-impact: full `merge_group` + standalone-floor.** Builds
-directly on dev-rescue's #2760 re-spec (`plan/issues/2760-*.md` `## ⚠️ Re-spec
-required`) — do NOT redo that investigation. Closes #2760, unblocks #2766.
+directly on dev-rescue's #2760 re-spec (the #2760 issue file's `## ⚠️ Re-spec
+required` section) — do NOT redo that investigation. Closes #2760, unblocks #2766.
 
 ## Root cause (re-confirmed by dev-rescue, do not re-verify)
 

--- a/plan/issues/2773-value-rep-substrate-epic.md
+++ b/plan/issues/2773-value-rep-substrate-epic.md
@@ -1,0 +1,759 @@
+---
+id: 2773
+title: "[EPIC][ARCH] Value-rep substrate: consistent native dispatch for reconstructed-struct field access + DCE/finalize-stable typeIdx"
+status: in-progress
+assignee: ttraenkler/sendev-substrate
+sprint: current
+created: 2026-06-28
+updated: 2026-06-28
+priority: high
+horizon: xl
+feasibility: hard
+reasoning_effort: high
+task_type: epic
+area: codegen
+language_feature: value-representation
+goal: value-rep-substrate
+related: [2681, 2686, 2760, 2674, 2664, 2660, 2075, 2151, 2357]
+blocks: [2681, 2686, 2760, 2767, 2768, 2770]
+---
+
+# #2773 — Value-rep substrate EPIC
+
+Umbrella for the value-representation substrate work. Three independent hard
+issues converged on the **same wall** this session; this epic is the shared
+substrate they all depend on. It was previously banked as "not this budget" —
+that deferral is now **lifted** (stakeholder committed the sprint to it).
+
+`#2681`, `#2686`, `#2760`, `#2767`, `#2768`, `#2770` all **depend on** this epic
+and should be closed by its slices, not by independent point-fixes.
+
+## The convergence (why this is one problem, not three)
+
+| Issue | Surface symptom | Underlying substrate defect |
+|---|---|---|
+| #2681 / #2686 (acorn parse walls) | `parse("x")` / `parse("1+2*3;")` moved from THROW to **HANG** after sr-acorn's A1–A3 `new this()` reconstruct landed the `parseExprAtom` switch. The hang is a `scope.flags` `__extern_get` that reads `undefined`; `currentVarScope()` loops forever. | A reconstructed-struct field read reached via a typed/`any` receiver routes through the host proxy (`__extern_get`) instead of native `struct.get`, diverging from the `struct.set`-written slot. The `Scope`-typed read path bakes a `ref.test $__fnctor_Scope` whose **typeIdx misses despite the struct being built+registered**. |
+| #2760 (plain-array OOB → undefined) | `a[OOB]` returns a type-default sentinel (sNaN / `false` / `null`), not `undefined`. | The element-read result needs an **externref-or-undefined** representation that ripples to every f64 consumer — a value-rep-shape decision, not a helper-flag flip. |
+| #2767 / #2768 / #2770 (bare-var nominal receiver dispatch) | Non-`Date` receivers regress; boolean-method results lose their brand. | `externref → ref` receiver recovery is **unguarded** across ~10 dispatch sites; the boolean-method result brand is dropped across 4 dispatch-result sites. |
+
+All three are facets of one substrate question: **what is the in-flight
+representation of a value as it crosses a dispatch/host/array boundary, and does
+native struct identity + brand + typeIdx survive that crossing?**
+
+## Root cause — pinned (keystone)
+
+The `$__fnctor_<F>` struct type for a reconstructed constructor is registered
+**on-demand at the `new F()` / `new this()` call-site compile time**
+(`src/codegen/expressions/new-super.ts:1147-1155` —
+`const structTypeIdx = ctx.mod.types.length; ctx.mod.types.push(...)`). The index
+is therefore assigned at a **non-deterministic mid-compile point** that depends on
+which function the compiler reached first. This produces **two** failure modes,
+which are the same bug seen from two angles:
+
+1. **Candidate-set freeze (`any`-receiver read path).** A lifted-method read site
+   that compiles *before* the `new F()` site enumerates its struct candidates via
+   `findAlternateStructsForField` (property-access.ts:1370), which reads
+   `ctx.structFields` + `ctx.structMap`. If `__fnctor_F` isn't registered yet, it
+   is **excluded** from the candidate set → no `ref.test` arm → the read falls to
+   `__extern_get`. The #2674 finalize-filled `__get_member_<name>` dispatcher
+   already fixes *this* facet for the `any` path (it re-enumerates at finalize).
+
+2. **typeIdx instability (typed-receiver read path) — THE UNFIXED KEYSTONE.** A
+   *concretely* typed receiver (`Scope`-typed) reads via a direct
+   `struct.get $__fnctor_Scope` / inline `ref.test $__fnctor_Scope`. The compiler
+   numbers types across **two passes** — an early measuring/hoist pass
+   (`inferLetConstInitializerWasmType`, sizes hoisted locals) and the final emit
+   pass. A type registered **on-demand** lands at a **different index in each
+   pass** (see `reference_subview_type_idx_stability`,
+   `project_type_index_shift_and_deadelim`), so the hoisted-local/`ref.test`
+   typeIdx disagrees with the emit-pass `struct.new` typeIdx → **`ref.test`
+   misses even though the struct is built**, and `dead-elimination.ts`'s
+   prune+renumber compounds the drift. This is the `scope.flags` miss
+   sendev-acorn pinned.
+
+Both facets collapse into a **single fix**: reserve every reconstructed-fnctor
+struct type slot at the **deterministic up-front type-init phase** (the same
+stable point as `reserveTypedArraySubviewTypes` / `reserveLinearU8AllocType` /
+`$ObjVecArr`), so the index is identical across passes AND the candidate set is
+complete at every read site. This is the **KEYSTONE SLICE (S1)** below.
+
+## Design
+
+### Invariant the substrate must enforce
+
+> A value's native representation (struct identity, primitive brand, and the
+> **typeIdx** used in its `ref.test`/`ref.cast`/`struct.get`/`struct.new`) is
+> **stable from declaration through every dispatch, host-boundary, and
+> array-element crossing**, and is **identical across the hoist pass, the emit
+> pass, and after dead-elimination renumbering**.
+
+Four sub-properties, each owned by a slice:
+
+1. **typeIdx stability (S1, keystone).** All reconstructed-fnctor struct types are
+   reserved at one deterministic up-front point so their index is pass-invariant
+   and DCE-survivable. ⇒ `ref.test`/`struct.get` hit.
+2. **Read/write/compound/delete-aware symmetry (S2).** *Every* field read of a
+   reconstructed struct reached via a typed or `any` receiver routes through the
+   same native dispatch its write uses — including `+=`/`++` compound ops and the
+   `tryEmitDeleteAware*` (`#2179`) paths. (sr-acorn's branch already implements
+   most of this; S2 lands + validates it on top of a stable S1.)
+2b. **`new this()` escape-gate reconstruct (S2b).** Teach the escape gate to
+   classify `new this()` inside a static/prototype method as an `F` reconstruct
+   site so `Parser` gets a `$__fnctor_Parser` struct (sr-acorn A1–A2). Inert
+   without S1+S2; load-bearing with them.
+3. **Array-element identity (S3).** A native struct ref stored into a host-backed
+   array (`arr.push(structRef)`) and read back must **not** be re-proxied to a
+   host externref — it must round-trip the same struct identity (so a parser that
+   `this.scopeStack.push(scope)` then re-reads `scope.flags` sees the native
+   slot).
+4. **OOB / brand result representation (S4, S5).** The element-read result carries
+   a true `undefined` singleton on OOB (#2760, S4); receiver recovery is guarded
+   and boolean-method results keep their brand across all dispatch sites
+   (#2767/#2768/#2770, S5).
+
+### Why up-front reservation (S1) is the keystone, mechanically
+
+`findAlternateStructsForField` (the candidate enumerator for BOTH read and write
+dispatch) is a pure function of `ctx.structFields` + `ctx.structMap`. The
+finalize-filled `__get_member`/`__set_member` dispatchers (#2674/#2664) already
+re-enumerate at finalize, so they are *complete* — but the **typed-receiver
+inline path bakes an absolute typeIdx** that the two-pass numbering desyncs.
+Reserving the slot up-front (placeholder→fill, exactly like class struct types in
+`class-bodies.ts`) makes the index pass-invariant, which is the one thing the
+finalize dispatcher cannot retroactively fix. Once S1 lands, sr-acorn's A1–A3
+read/write symmetry (S2) becomes load-bearing instead of inert, and the `Scope`
+typed-path `ref.test` hits.
+
+## Slice plan (ordered, independently shippable, KEYSTONE FIRST)
+
+Every slice is **broad-impact** → validate via **full `merge_group` +
+standalone-floor**, never a scoped sweep (`project_broad_impact_validate_full_ci`,
+`project_standalone_floor_only_on_merge_group`).
+
+| # | Slice | Scope | Unblocks | Role |
+|---|---|---|---|---|
+| **S1** | **Up-front fnctor struct-type reservation (KEYSTONE)** | Reserve every approved `$__fnctor_<F>` struct slot (incl. `new this()` owners) in the deterministic type-init phase; placeholder→fill; populate `structMap`/`structFields`/`typeIdxToStructName` up-front. | typeIdx stability for #2681/#2686; foundation for S2/S2b | **senior-dev** |
+| **S2** | Read/write/compound/delete-aware dispatch symmetry | Land + validate sr-acorn's A3 + beyond-A3 routing (compound `+=`/`++`, `tryEmitDeleteAware{Get,Set}` → `__get_member`/`__set_member` dispatchers) on top of S1. | #2681/#2686 read/write divergence | **senior-dev** |
+| **S2b** | `new this()` escape-gate reconstruct | sr-acorn A1–A2: classify `new this()` in static/prototype methods as `F` reconstruct; owner resolvers. | #2681/#2686 (Parser gets a struct) | **senior-dev** |
+| **S3** | Array-element struct identity (no re-proxy on `.push`/host calls) | Ensure native struct refs stored into host-backed arrays round-trip without `extern.convert_any`→host-proxy identity loss. | #2681 `scope.flags` via `scopeStack.push` | **senior-dev** |
+| **S4** | Plain-array OOB → `undefined` (externref-or-undefined result rep) | #2760 re-spec: discriminate plain-array vs typed-view at the vec site (`property-access.ts:6341`), return the `undefined` singleton; ripple the result-rep change to f64 consumers without the shared-helper flip. | #2760 | **senior-dev** |
+| **S5** | Guarded receiver recovery + brand-preserving boolean results | #2767/#2768/#2770: guard `externref→ref` recovery across ~10 dispatch sites (`emitThisReceiverGuardConvert`); preserve the boolean brand across the 4 dispatch-result sites. | #2767/#2768/#2770 | **dev** (S5a guard audit) + **senior-dev** (S5b brand-rep) |
+
+**Ordering rationale.** S1 must land first — it is the typeIdx-stability
+foundation that makes S2/S2b correct (without it the `ref.test` arms S2 emits miss
+at scale). S2 + S2b are a tight pair (the acorn parse fix) and should land in
+quick succession after S1, re-validating against the full acorn dogfood. S3 is
+independent of S1 mechanically but only *observable* once S1+S2 stop the parser
+from hanging earlier, so sequence it after S2. S4 (#2760) and S5 (#2767/8/70) are
+mechanically independent of the fnctor work and may proceed in **parallel** with
+S1–S3 by separate devs (different files), but each is still broad-impact.
+
+## Build-on, do NOT redo
+
+- **sr-acorn WIP**: branch `origin/issue-2681-acorn-new-this` (commit `ebc464375`),
+  worktree `/workspace/.claude/worktrees/agent-ae75b7409d6e143f8/`. Has A1–A3 +
+  symmetric read/write + compound + delete-aware routing, all typecheck-clean,
+  minimal repros pass. S2/S2b **rebase this branch onto a merged S1**, they do not
+  re-author it.
+- **Findings + probes** in that worktree: `plan/issues/2681-*.md` `## Implementation
+  attempt + findings`; `.tmp/acorn-run.mjs` (single-compile worker watchdog +
+  host-call signature), `.tmp/dbg-keys.mjs` (extern_get key histogram),
+  `.tmp/identity*.mjs` (struct-identity repros). **Read these before touching S1–S3.**
+- The #2674 `__get_member_<name>` (member-get-dispatch.ts) and #2664
+  `__set_member_<name>` (member-set-dispatch.ts) finalize-filled dispatchers are
+  **already correct** — S1 makes their typed-path siblings stable; do not rewrite
+  them.
+
+---
+
+# KEYSTONE SLICE (S1) — full spec
+
+**Title:** Reserve all reconstructed-fnctor struct types up-front (pass-invariant,
+DCE-stable typeIdx). **Role: senior-dev. Broad-impact: full `merge_group` +
+standalone-floor.**
+
+## Root cause (one sentence)
+
+`$__fnctor_<F>` struct types are registered on-demand at the `new F()` call site
+(`new-super.ts:1148`, `ctx.mod.types.length`), so their typeIdx differs between
+the hoist pass and the emit pass and may be absent from a read site's candidate
+set — making `ref.test $__fnctor_F` / `struct.get $__fnctor_F` miss despite the
+struct being built.
+
+## The fix — placeholder→fill at the up-front type-init phase
+
+Mirror the class-struct placeholder→fill pattern (`class-bodies.ts`
+`collectClassDeclaration`) and the subview/`$ObjVecArr` up-front reservations
+(`index.ts`). Reserve **all** approved fnctor struct slots before any function
+compiles, in two sub-passes so cross-fnctor field refs resolve.
+
+### Change 1 — new reservation pass
+
+**File: `src/codegen/fnctor-escape-gate.ts`** (new exported helper; it already
+owns the whole-program fnctor analysis and `approvedNames`)
+
+Add `export function deriveFnctorFields(ctx, funcDecl): FieldDef[]` by
+**extracting** the field-derivation logic currently inline in
+`new-super.ts:1064-1146` (`recordThisField` / `collectAssignmentChain` /
+`collectThisAssignments` + the `ref → ref_null` widening loop). This becomes the
+**single source of truth** for a fnctor's field shape, called by both the
+reservation pass and (as a fallback) `new-super.ts`.
+
+**File: `src/codegen/index.ts`** — new `reserveFnctorStructTypes(ctx, sourceFile)`
+called in the up-front type-init block, **immediately after**
+`reserveTypedArraySubviewTypes(ctx)` (≈ line 1138) and the `$ObjVecArr`
+reservation, and **after** `ctx.fnctorEscapeGate = analyzeFnctorEscapeGate(...)`
+(line 1081). Runs **unconditionally** (empty `approvedNames` ⇒ no-op ⇒
+byte-identical output for fnctor-free modules).
+
+```
+function reserveFnctorStructTypes(ctx):
+  gate = ctx.fnctorEscapeGate
+  if !gate or gate.approvedNames.size === 0: return
+  // Stable, deterministic order — sort the approved names so the reserved
+  // index is identical across the hoist pass and the emit pass.
+  names = [...gate.approvedNames]                       // incl. new this() owners (S2b)
+        + [...gate.newThisOwnerNames]                   // (S2b adds this set)
+  names = unique(names).sort()
+  // SUB-PASS 1: reserve every index + name FIRST, so cross-fnctor field type
+  // resolution in sub-pass 2 (a Parser field typed `Scope` → (ref null
+  // $__fnctor_Scope)) resolves against an already-registered structMap entry.
+  for F in names:
+    decl = resolveFnctorDecl(ctx, F)                    // symbol.valueDeclaration
+    if !decl or !decl.body: continue
+    structName = `__fnctor_${F}`
+    if ctx.structMap.has(structName): continue          // idempotent
+    idx = ctx.mod.types.length
+    ctx.mod.types.push({ kind:"struct", name:structName, fields: [] })  // placeholder
+    ctx.structMap.set(structName, idx)
+    ctx.typeIdxToStructName.set(idx, structName)
+    ctx.fnctorReservedTypeIdx.set(F, idx)               // new ctx map (context/types.ts)
+  // SUB-PASS 2: fill fields now that ALL names+indices exist.
+  for F in names:
+    idx = ctx.fnctorReservedTypeIdx.get(F); if idx === undefined: continue
+    decl = resolveFnctorDecl(ctx, F)
+    fields = deriveFnctorFields(ctx, decl)              // shared helper
+    ctx.mod.types[idx].fields = fields                  // FILL IN PLACE (index unchanged)
+    ctx.structFields.set(`__fnctor_${F}`, fields)       // candidate-set completeness
+```
+
+### Change 2 — `new-super.ts` consumes the reserved slot
+
+**File: `src/codegen/expressions/new-super.ts`**, `compileNewFunctionDeclaration`
+(line ~1147). Replace the on-demand registration:
+
+```
+// BEFORE:
+const structName = `__fnctor_${funcName}`;
+const structTypeIdx = ctx.mod.types.length;
+ctx.mod.types.push({ kind:"struct", name:structName, fields });
+ctx.structMap.set(structName, structTypeIdx);
+ctx.typeIdxToStructName.set(structTypeIdx, structName);
+ctx.structFields.set(structName, fields);
+
+// AFTER:
+const structName = `__fnctor_${funcName}`;
+let structTypeIdx = ctx.fnctorReservedTypeIdx.get(funcName);
+if (structTypeIdx !== undefined) {
+  // Reserved up-front (S1): the slot, structMap, structFields, and
+  // typeIdxToStructName are already populated with the SAME field shape
+  // (deriveFnctorFields). Trust the reserved index — do NOT push a new type
+  // (that would shift every downstream typeIdx and re-introduce the desync).
+  // Use the reserved `fields` for the struct.new field-init loop below.
+  fields.length = 0;
+  fields.push(...ctx.structFields.get(structName)!);
+} else {
+  // Not reserved (defensive fallback — e.g. a fnctor reached via a path the
+  // escape gate didn't approve): keep the legacy on-demand registration.
+  structTypeIdx = ctx.mod.types.length;
+  ctx.mod.types.push({ kind:"struct", name:structName, fields });
+  ctx.structMap.set(structName, structTypeIdx);
+  ctx.typeIdxToStructName.set(structTypeIdx, structName);
+  ctx.structFields.set(structName, fields);
+}
+```
+
+The `struct.new` field-init loop (lines 1168-1241) is **unchanged** — it iterates
+`fields`, which now references the reserved shape. Verify the `fields` array used
+by the init loop is **identical object/order** to the reserved one (the
+`fields.length=0; push(...)` re-sync above guarantees same order; do NOT re-derive
+independently here — divergent field order ⇒ `struct.new` arity mismatch).
+
+### Change 3 — context plumbing
+
+**File: `src/codegen/context/types.ts`** — add to `CodegenContext`:
+`fnctorReservedTypeIdx: Map<string, number>`, initialized to `new Map()` in
+`createCodegenContext`.
+
+**File: `src/codegen/fnctor-escape-gate.ts`** — add `newThisOwnerNames:
+ReadonlySet<string>` to the gate result (the `new this()` owners; S2b populates
+it, S1 reads it — ship S1 reading an empty set if S2b lands second, but prefer
+landing the gate-shape field in S1 so S2b is purely additive).
+
+## Edge cases
+
+- **Cross-fnctor ref fields.** A Parser field typed `Scope` resolves to
+  `(ref null $__fnctor_Scope)` only if `Scope` is in `structMap` when Parser's
+  fields are derived → **sub-pass 1 reserves ALL names before sub-pass 2 derives
+  ANY fields**. Do not collapse the two sub-passes.
+- **`ref → ref_null` widening** (new-super.ts:1136-1144) must run **inside**
+  `deriveFnctorFields` so the reserved field set matches what `struct.new`'s
+  `ref.null` default-init expects. (struct.new can't default a non-null ref.)
+- **DCE survival.** A reserved-but-never-constructed placeholder (escape-gate
+  approved but the `new` site is pruned) is **unreferenced** → `dead-elimination.ts`
+  prunes+renumbers it cleanly (instructions are remapped in the same pass). A
+  reserved-AND-filled struct is referenced by `struct.new`/`ref.test`/`struct.get`
+  → survives. Both are safe — but confirm via a WAT-diff that a fnctor-free module
+  is **byte-identical** (the pass is a no-op when `approvedNames` is empty).
+- **Idempotency across passes.** `reserveFnctorStructTypes` runs once per
+  `generateModule` invocation; `generateModule` runs fresh per pass. The sorted
+  `approvedNames` order + the fixed call-site position guarantee the **same index
+  in the hoist pass and the emit pass** — the entire point of the slice. The
+  `ctx.structMap.has(structName)` guard makes it idempotent within a pass.
+- **Empty-body fnctor / S3a reconstruct interaction.** The `compileFnctorNewAsObject`
+  S3a path (new-super.ts:1051, standalone empty-body `$Object` reconstruction)
+  fires BEFORE struct lowering and returns early — it never reaches the struct
+  registration, so a reserved-but-unused slot for an S3a fnctor is the
+  prune-cleanly case above. No conflict.
+- **A non-approved sibling `new F()` compiling first** (the cache-order note at
+  new-super.ts:1044) populates `funcConstructorMap[F]`; with S1 the struct type is
+  already reserved, so the cache holds the **reserved** index — consistent for both
+  approved and non-approved sites. Verify `funcConstructorMap` caching reads the
+  reserved index.
+
+## Test plan
+
+1. **Byte-identical no-op proof.** Compile a fnctor-free module (any existing
+   equivalence test) before/after; WAT-diff must be empty. The pass is gated on
+   `approvedNames.size > 0`.
+2. **typeIdx-stability unit repro** (`.tmp/`): a fnctor whose field is read in a
+   lifted method compiled *before* the `new` site, AND a sibling fnctor referenced
+   as a ref field — assert the read's `ref.test $__fnctor_F` matches the
+   `struct.new $__fnctor_F` typeIdx (dump WAT, grep the type indices agree).
+3. **sr-acorn minimal repros** (`.tmp/identity*.mjs` from the WIP branch): all must
+   still pass (`new Parser(); p.getType()` → 7; `p.bump();p.bump()` → 45; nested →
+   207).
+4. **Acorn dogfood (the real gate, with S2/S2b stacked):** S1 alone will NOT close
+   the acorn hang (it needs S2's read/write symmetry on the now-stable indices) —
+   so S1's acceptance is the **stability invariant + no regression**, and the acorn
+   `parse("x")`/`parse("1+2*3;")` AST result is **S2+S2b's** acceptance. Verify S1
+   does not *worsen* acorn (still hangs/throws is acceptable for S1-alone;
+   verify with `.tmp/acorn-run.mjs`).
+5. **Full `merge_group` + standalone-floor.** Broad-impact (changes struct-type
+   ordering for every module with a reconstructed fnctor). NEVER a scoped sweep.
+   Watch the standalone floor object-identity signature
+   (`reference_standalone_floor_object_identity_and_real_vs_drift`).
+
+## Acceptance criteria (S1)
+
+- All approved `$__fnctor_<F>` struct types are reserved at the up-front type-init
+  phase; their typeIdx is **identical across the hoist pass and the emit pass**
+  (verified by WAT type-index diff on the unit repro).
+- `findAlternateStructsForField` returns the complete candidate set at **every**
+  read site regardless of compile order (`__fnctor_Scope` is present before its
+  `new`-site compiles).
+- Fnctor-free modules are **byte-identical**.
+- No net test262 regression in `merge_group`; standalone floor holds.
+- sr-acorn minimal struct-identity repros pass; the acorn parse hang is **not made
+  worse** (its closure is S2/S2b).
+
+## Classification summary
+
+- **S1 (keystone), S2, S2b, S3, S4 → senior-dev** (Opus): typeIdx/representation
+  surgery, broad blast radius, two-pass numbering hazards.
+- **S5a (receiver-recovery guard audit) → dev**: mechanical guard insertion across
+  the ~10 `emitThisReceiverGuardConvert` sites with a clear pattern.
+- **S5b (boolean-result brand rep) → senior-dev**: result-representation change.
+
+## S1 — Implementation notes (sendev-substrate, 2026-06-28)
+
+**Landed exactly per the architect spec; the deviations below are mechanical, not
+design changes.**
+
+- **Reservation set = `approvedNames ∪ newThisOwnerNames`, SORTED.** `newThisOwnerNames`
+  is empty in S1 (S2b populates it), so today the set is exactly the
+  reconstruct-approved fnctor names. Verified empirically: for the keystone Parser
+  shape the gate reports `reconstruct=2 keep-typed=0` so `Parser` and `Node` are
+  both approved and both get reserved `$__fnctor_<Name>` slots. A `keep-static`
+  fnctor (`new F()` with no dynamic/typed use) is NOT approved → its slot is not
+  reserved → output stays byte-identical to main (proven below).
+- **WHY only approved names, not every fnctor that builds a struct:** field shapes
+  are INDEPENDENT of reservation order — `resolveWasmType` resolves a fnctor
+  instance type to `externref` (host, the #1712 guard) and never keys `structMap`
+  on the bare ctor name (`__fnctor_<Name>` ≠ `<Name>`), so a sibling fnctor field
+  is `externref`/`f64`, never a cross-`(ref $__fnctor_Sibling)`. Up-front
+  reservation therefore changes ONLY the type INDEX (the keystone), not the field
+  set. Reserving the approved set is sufficient to stabilize the typeIdx of every
+  fnctor whose typed/dynamic read desyncs; the two-sub-pass ordering is kept anyway
+  (reserve-all-then-fill) so it stays correct if `resolveWasmType` ever gains
+  fnctor-ref resolution.
+- **`deriveFnctorFields` is the single source of truth** (extracted verbatim from
+  the old inline `new-super.ts` logic, incl. the chained-assignment + if/loop
+  recursion and the `ref → ref_null` widening). Both the reservation pass and the
+  on-demand fallback call it ⇒ identical field set/order ⇒ no `struct.new`
+  arity mismatch against the reserved type.
+- **`new-super.ts` consumes the reserved slot** (FILL-in-place, never push) when
+  `ctx.fnctorReservedTypeIdx.has(funcName)`; the legacy on-demand `mod.types.push`
+  remains as a defensive fallback for a fnctor the gate didn't approve.
+- **Name→decl resolution:** added `ctorDeclByName` to the gate result (first-seen
+  decl per fnctor name, deterministic by source order) so the reservation pass
+  resolves a name to the SAME declaration the on-demand path uses.
+
+**Validation (all green locally):**
+
+- **Byte-identical no-op proof (TRUE cross-compile vs main):** 7 fnctor-free
+  modules + a keep-static fnctor, each ×{host, standalone, wasi}, emit
+  **byte-for-byte identical WAT** on this branch vs `/workspace/src` (main). The
+  reservation pass is provably inert when no fnctor is approved.
+- **typeIdx stability / candidate-set completeness:** the keystone shape (a fnctor
+  field read in a lifted method defined BEFORE the `new` site, plus a sibling
+  fnctor) reserves `$__fnctor_Parser` + `$__fnctor_Node` up-front; binary
+  instantiates and runs correctly (no `ref.test` miss / cast trap).
+- **sr-acorn minimal struct-identity repros:** `identity2.mjs` → 7 / 45,
+  `identity3.mjs` → 207 (the spec's stated targets). The `this:any` variant
+  (`identity.mjs`) returns NaN on **both this branch AND main** — a PRE-EXISTING
+  orthogonal dispatch gap, not made worse by S1 (closure is S2/S2b).
+- **Fnctor/new-expression test suite:** 67/68 green. The single failure
+  (`constructor-arity.test.ts`) is PRE-EXISTING and byte-identical to main — the
+  test hand-rolls `{ env: {} }` but the class module has always required a
+  `string_constants` import; unrelated to S1.
+- Full `merge_group` + standalone-floor is the broad-impact gate (CI).
+
+**S1 status: complete. S2/S2b rebase `origin/issue-2681-acorn-new-this` on top.**
+
+---
+
+# SLICE S4 — full spec — plain-array OOB → `undefined` (consumer-scoped externref-or-undefined result rep) — #2760
+
+**Role: senior-dev. Broad-impact: full `merge_group` + standalone-floor.** Builds
+directly on dev-rescue's #2760 re-spec (`plan/issues/2760-*.md` `## ⚠️ Re-spec
+required`) — do NOT redo that investigation. Closes #2760, unblocks #2766.
+
+## Root cause (re-confirmed by dev-rescue, do not re-verify)
+
+`const a: number[] = [1,4,5]; a[4]` lowers `number[]`/`string[]`/`any[]` to a
+**vec struct** and reaches the vec-struct element read at
+`property-access.ts:6341` (the `emitBoundsCheckedArrayGet(fctx, arrTypeIdx,
+arrDef.element, ctx, false, taSignedness)` call). That helper returns a
+**type-default sentinel** on OOB (sNaN for f64, `false` for boolean,
+`ref.null.extern`→`null` for externref), never the JS `undefined` singleton. The
+`property-access.ts:6390` raw-array path the *original* plan targeted is rarely
+reached → patching it fixes ~nothing. The shared-helper flip (parked S2/#2198)
+is the wrong fix: it perturbs typed-array/`$__subview`/array-method callers and
+regressed `built-ins/Array/prototype/map/15.4.4.19-8-b-2.js`.
+
+## Design — consumer-scoped OOB policy (bounds the f64-consumer ripple)
+
+The hard constraint dev-rescue flagged: making the element-read result
+**externref-or-undefined** "ripples to every f64 consumer of `a[i]`." The design
+**eliminates that ripple** by making the result-rep change **consumer-aware** and
+**scoped to the plain-array vec call site only** — the shared
+`emitBoundsCheckedArrayGet` default stays `false` (byte-identical for every other
+caller). Three policy arms at the read site, chosen by what is statically known:
+
+1. **Bounds-eliminated read (`isSafeBoundsEliminated(fctx, expr)` is true).** A
+   loop guard already proves `index < length`, so OOB is impossible →
+   **unchanged**: raw `array.get` returning the element ValType (f64/i32/externref).
+   Zero cost, zero blast radius. This is the hot path (`for(i<len) a[i]`).
+2. **Numeric consumer (the read's `expectedType` is `f64`/`i32`).** `a[OOB]` in a
+   numeric context (`a[k] + 1`, `const n: number = a[k]`, a store into an f64
+   slot) is observably `undefined` coerced to number = **`NaN`** in JS
+   (`undefined + 1` is `NaN`). The existing type-default **sNaN** sentinel already
+   yields `NaN` here → **keep the f64 sentinel path** for numeric consumers (no
+   box/unbox, no ripple). This arm is why the change does NOT ripple to f64
+   consumers: they never see an externref.
+3. **Reference / `any` / comparison consumer (expectedType is externref/`any`, or
+   absent).** This is the *only* arm where the true `undefined` singleton is
+   observable (`a[OOB] === undefined`, `String(a[OOB])`, spreading, passing to a
+   parameter). Here the read returns **externref-or-undefined**: in-bounds **boxes**
+   the element (`__box_number` for f64, `__box_boolean` for boolean, pass-through
+   for externref), OOB returns the `__get_undefined` singleton
+   (`ensureGetUndefined`). Result ValType = `{kind:"externref"}`. The existing
+   `coerceType(externref → …)` bridges to whatever the consumer ultimately needs.
+
+The blast radius is therefore the read site + the EXISTING `coerceType` paths —
+**not** every f64 consumer. Numeric consumers are observably identical to JS via
+the NaN sentinel they already use; only reference consumers pay the box, and only
+on the rare non-bounds-eliminated dynamic read.
+
+## Changes
+
+**File: `src/codegen/property-access.ts`**
+
+1. **Thread the consumer's expected type into the read.**
+   `compileElementAccessBody` (signature at line 5949) currently takes
+   `objType: ValType` but NOT the consumer's expected type. Add a parameter
+   `expectedType?: ValType` and pass it from the call sites (5653/5874/5882/5903/
+   5913 — the callers already have the target type in scope; 5882 already passes
+   an explicit `{kind:"externref"}`). For sites with no expected type, pass
+   `undefined` (→ arm 3, the safe `undefined`-preserving default).
+
+2. **Discriminate plain-array vs typed-array view at the vec site (≈6341).**
+   The vec read serves BOTH plain `T[]` and TypedArray views. Add an
+   `isPlainArrayElementRead` predicate: **true** when the receiver's static TS
+   type is a plain `Array<T>`/`T[]`/tuple (NOT a TypedArray view name
+   `Int8Array`…`Float64Array`/`DataView`, and NOT a `$__subview`). Reuse the
+   receiver-type classification already computed near here (the existing
+   `typedArrayViewSignedness(ctx, expr.expression)` returns a defined `"s"|"u"`
+   only for i8/i16 typed-array views; for the general check, test the receiver TS
+   type symbol name against the TypedArray view set, mirroring how
+   `compileTypedArray*` paths detect views). Only the **plain-array** branch gets
+   the new OOB policy; the TypedArray-view and `$__subview` branches keep their
+   current semantics **byte-identical** (a typed-array OOB is also `undefined`,
+   but it rides a different value-rep and is verified independently — explicitly
+   OUT of S4 scope to avoid the parked-S2 blast radius).
+
+3. **Apply the 3-arm policy** in the plain-array branch, replacing the single
+   `emitBoundsCheckedArrayGet(..., false, ...)` call at 6342:
+   - arm 1 (`isSafeBoundsEliminated`): unchanged raw `array.get` (+ existing
+     `emitHoleToUndefined` for externref holes).
+   - arm 2 (`expectedType` is f64/i32): keep
+     `emitBoundsCheckedArrayGet(..., useUndefinedSentinel=false, ...)` (current
+     sentinel → NaN in numeric context). Return the element ValType.
+   - arm 3 (else): emit a bounds-checked read that **boxes in-bounds / returns
+     `__get_undefined` on OOB**. Prefer reusing
+     `emitBoundsCheckedArrayGet(..., useUndefinedSentinel=true, ...)` — but note
+     that helper's `useUndefinedSentinel` only fires for `externref`/`ref_extern`
+     element types (array-methods.ts:411). For an **f64/i32/boolean** element the
+     helper does NOT currently emit the undefined branch, so arm 3 must wrap the
+     read: build the same `idx < array.len` guard as the helper, in-bounds box the
+     element to externref (`__box_number`/`__box_boolean`), OOB call
+     `__get_undefined`. Factor this as a small local `emitPlainArrayUndefOrBoxed`
+     in property-access.ts (do NOT widen the shared helper — that's the parked-S2
+     trap). Return `{kind:"externref"}`.
+
+**Do NOT touch:** `emitBoundsCheckedArrayGet`'s default (stays `false`); the
+`$__subview` call site (property-access.ts:6034); any `array-methods.ts` internal
+caller. They must be byte-identical (verify by WAT-diff).
+
+## Result-rep / f64-consumer correctness (the ripple, handled)
+
+- A consumer that requested **f64** gets arm 2 (NaN sentinel) — **no externref ever
+  reaches an f64 consumer**, so there is no ripple, no unbox inserted, no perf
+  change on numeric code.
+- A consumer that requested **externref/any** gets arm 3; the value is already
+  externref, consumed directly.
+- A consumer with **no expected type** (statement-position read, or a context that
+  later coerces) gets arm 3 (externref-or-undefined) and the standard
+  `coerceType(externref → target)` bridges it — including the existing
+  `null/undefined in f64 context → NaN` rule (type-coercion.ts) if it is later
+  forced to f64. This is the conservative, JS-correct default.
+
+## Edge cases
+
+- **Negative index** (`a[-1]`): the `i32.lt_u` guard already treats negatives as
+  huge-unsigned → OOB branch → `undefined` (arms 2/3). No extra handling.
+- **Hole-in-bounds** (`[1,,3][1]`): keep the existing `$Hole → undefined`
+  mapping (`emitHoleToUndefined`); S4 is about *absent* (OOB), F2 (holes) is
+  separate and unchanged.
+- **`number[]` OOB previously sNaN**: under arm 2 still NaN (numeric consumer) —
+  acceptance for `a[OOB] === undefined` requires arm 3, which fires for the `any`/
+  comparison consumer. Confirm `a[OOB] === undefined` reaches arm 3 (the `===`
+  operand is compiled with no f64 expectation → externref).
+- **`map`-on-array-like** (`built-ins/Array/prototype/map/15.4.4.19-8-b-2.js`):
+  goes through `array-methods.ts` internal callers, untouched → stays green.
+- **Boolean element `boolean[]`**: arm 3 boxes via `__box_boolean` (not
+  `__box_number`) — reuse the #2770 brand logic so `a[OOB-or-bool]` is a JS boolean,
+  not `1`.
+
+## Test plan
+
+1. `const a: number[] = [1,4,5]; a[4] === undefined` → `true`; `a[-1] === undefined`
+   → `true`; `a[1]` → `4` (in-bounds unchanged); `a[1] + 1` → `5` (arm 2, f64).
+2. `string[]` / `boolean[]` / `any[]` OOB → `undefined`; in-bounds unchanged.
+3. `built-ins/Array/prototype/map/15.4.4.19-8-b-2.js` green; typed-array reads
+   (`Int8Array`/`Float64Array`) byte-identical (WAT-diff a plain `for(i)a[i]` loop
+   and a typed-array read — expect no new instructions on the hot/typed paths).
+4. `.ts`/`.js` parity: the safe OOB read identical for typed and untyped source.
+5. Full `merge_group` + standalone-floor, net ≥ 0, no new bucket.
+
+## Acceptance criteria (S4)
+
+- `a[OOB]` on a plain `T[]` reads JS `undefined` for all element types (observable
+  via `=== undefined`).
+- `emitBoundsCheckedArrayGet` shared default UNCHANGED; typed-array / `$__subview` /
+  array-method callers byte-identical.
+- Hot numeric `a[i]` (bounds-eliminated and numeric-consumer) shows **zero** extra
+  instructions.
+- map-on-array-like green; no net test262 regression in `merge_group`.
+
+---
+
+# SLICE S5 — full spec — guarded receiver recovery (S5a) + boolean-result brand preservation (S5b) — #2767/#2768/#2770
+
+**Two independently-shippable sub-slices.** S5b (brand) is mechanically isolated
+from S5a (recovery guard) and can land first/in-parallel. Builds on dev-rescue's
+#2770 root-cause and #2768's per-type table — do NOT redo that investigation.
+**Context:** #2767 already MERGED (Date-only, via a `SAFE_BARE_VAR_RECOVERY_NOMINALS`
+safelist after the broad substitution regressed 6 non-Date receivers in
+`merge_group`). S5a = expand that safelist by hardening each type; S5b = the
+type-agnostic boolean-brand fix (#2770, supersedes #2768's boolean cases).
+
+## S5b — boolean-result brand preservation (#2770) — senior-dev, broad-impact
+
+### Root cause (measured, #2770)
+
+A boolean-returning builtin method on a **bare-var / dynamic** receiver returns a
+JS **number** (`1`/`0`) not a **boolean** (`true`/`false`):
+`var s; s = new Set(); s.add(3); s.has(3)` → `1`. Two coupled defects:
+
+1. **Extern-method boolean returns lose the `boolean: true` brand.** An extern
+   class method whose lib.d.ts return type is `boolean` is registered with
+   `results: [resolveWasmType(ctx, retType)]` = `{kind:"i32"}` — the boolean brand
+   is dropped (`declarations.ts:1655`; `registerBuiltinExternClasses` fallback in
+   `index.ts:~11878`). An unbranded i32 coerces to f64/number at the `any`/return
+   boundary instead of boxing as a JS boolean.
+2. **The brand is dropped at MULTIPLE dispatch-RESULT sites, not one.** dev-rescue
+   verified the bare-var `s.has(3)` does NOT return via `extern.ts`'s
+   `methodInfo.results[0]` (extern.ts:~150). It dispatches through one of the
+   `${className}_${methodName}` funcMap paths whose result ValType is
+   `getWasmFuncReturnType(ctx, finalIdx) ?? resolveWasmType(ctx, retType)` — a bare
+   i32 with the brand dropped — at **every** such site:
+   `calls.ts:8738, 9398, 9479, 9595, 9627, 9736, 12932, 13590, 13613, 13695,
+   13732, 14051` (the `?? resolveWasmType(ctx, retType)` extern-method-result
+   family; the #2770 note cited 4606/9220/9279/14077 as the routing sites — the
+   actual ValType sites are these `getWasmFuncReturnType` returns), plus
+   `extern.ts:~150` (`return methodInfo.results[0]`).
+   (Set is Map-backed, so a dynamic receiver routes to `Map_has` (i32, defect 1)
+   while a typed `Set` receiver routes to `Set_has` (externref) — why only the
+   bare-var case is wrong; S5b fixes the i32-return side so routing no longer
+   matters for booleans.)
+
+### Fix — a shared `brandExternMethodResult` helper applied at EVERY result site
+
+**New helper** (put in `shared.ts` so both `calls.ts` and `extern.ts` import it
+without a cycle):
+
+```ts
+// Brand an extern-method result ValType as a boolean when the method's declared
+// TS return type is boolean, so the any/return coercion boxes it via
+// __box_boolean (true/false) instead of __box_number (1/0). Over-boxing guards:
+// brand ONLY a bare i32 whose declared return type is exactly boolean; never
+// touch f64/externref/already-branded results.
+export function brandExternMethodResult(
+  ctx: CodegenContext, tsReturnType: ts.Type | undefined, valType: ValType,
+): ValType {
+  if (!tsReturnType) return valType;
+  if (valType.kind !== "i32" || (valType as { boolean?: boolean }).boolean) return valType;
+  if (!isBooleanType(ctx, tsReturnType)) return valType;   // strict: flags === boolean only
+  return { kind: "i32", boolean: true };
+}
+```
+
+**Apply at every extern-method-result return site.** Wrap the existing expression:
+```ts
+return brandExternMethodResult(ctx, retType,
+  getWasmFuncReturnType(ctx, finalMethodIdx) ?? resolveWasmType(ctx, retType));
+```
+at each of: `calls.ts:8738, 9398, 9479 (callReturnType=), 9595, 9627 (callReturnType=),
+9736, 12932, 13590, 13613 (callReturnType=), 13695, 13732, 14051`, and
+`extern.ts:~150` (`return brandExternMethodResult(ctx, <method TS return type>,
+methodInfo.results[0]!)`). For `extern.ts`, derive the TS return type from the
+method signature already resolved there (or thread `methodInfo`'s declared boolean
+flag — prefer branding `methodInfo.results[0]` at REGISTRATION too: defect 1, see
+below).
+
+**Also brand at registration (defect 1)** so the `extern.ts` `methodInfo.results[0]`
+path is correct at source: `declarations.ts:1655` and the `externMethod` fallback
+in `index.ts:~11878` — when the declared return type is boolean, register
+`results: [{kind:"i32", boolean:true}]`. This is the single-site fix that makes
+the registration honest; the per-call-site `brandExternMethodResult` wraps the
+`getWasmFuncReturnType` paths that bypass `methodInfo.results`.
+
+### Edge cases (S5b)
+
+- **Over-boxing guard**: brand ONLY when the declared return type is exactly
+  `boolean`. Number-returning methods (`map.get`, `indexOf`, the `size` accessor)
+  stay numbers; `isBooleanType` must reject `number`/`boolean | undefined` unions
+  unless they reduce to boolean. Verify `map.get` / `map.size` / `indexOf` stay
+  numbers.
+- **No double-box**: skip when `valType` is already externref (typed `Set_has`
+  path) or already `boolean:true`.
+- **ES2025 boolean Set methods**: `isSubsetOf`/`isSupersetOf`/`isDisjointFrom`
+  return boolean → covered by the same brand.
+- **`getWasmFuncReturnType` already returns a branded i32**: if a wasm func's
+  declared return is already `{i32,boolean:true}`, the `??` short-circuits and the
+  brand survives — the wrap is idempotent.
+
+### Acceptance (S5b)
+
+- `var s; s = new Set([1]); s.has(1)` → `true`; same for `map.has`, `set.delete`,
+  `map.delete`, `re.test`, and the ES2025 boolean Set methods.
+- Typed-receiver booleans unchanged; numeric methods stay numbers; no double-box.
+- `language/literals/regexp/y-assertion-start.js` (`re.test`) flips green.
+- Full `merge_group` green (extern method-call result path is hot/broad).
+
+## S5a — guarded externref→ref receiver recovery + safelist expansion (#2768) — senior-dev
+
+### What #2767 left (do not re-author)
+
+#2767 added `resolveAssignedNominalType` (recover the nominal type a bare-`var`/
+`let` identifier holds when the TS checker reports evolving-`any`) and substitutes
+it at the call dispatch hub (`calls.ts:~8746`), gated by a
+`SAFE_BARE_VAR_RECOVERY_NOMINALS` safelist = **Date only** (the broad substitution
+regressed 6 non-Date receivers in `merge_group`). S5a **expands the safelist one
+type at a time**, each behind a hardened recovery path + full `merge_group`.
+
+### The 6 regressors and their per-site fix (from #2228's merge_group delta)
+
+| type | test262 evidence | failure | per-site fix |
+| --- | --- | --- | --- |
+| **Promise** | `built-ins/Promise/prototype/finally/{rejected,resolved}-observable-then-calls-PromiseResolve.js` | `illegal_cast` in the recovered closure (`__closure_0`) | guard the externref→ref recovery with `ref.test` BEFORE `ref.cast` on the Promise/thenable path (the cast currently trusts the substituted type) |
+| **RegExp** | `language/literals/regexp/y-assertion-start.js` (`re.test`) | returns truthy `1` not `true` | **subsumed by S5b** (boolean brand). Land S5b first; RegExp recovery then only needs the `ref.test` guard. |
+| **SharedArrayBuffer / ArrayBuffer** | `built-ins/SharedArrayBuffer/prototype/grow/this-is-not-resizable-arraybuffer-object.js` | `.grow()` skips the spec TypeError | brand-check the recovered buffer receiver (`ref.test` the resizable-buffer brand; throw the spec TypeError on miss) before dispatch |
+| **super-spread** | `language/expressions/super/call-spread-obj-spread-order.js` | `wasm_compile` (invalid Wasm) | the recovered super/closure receiver emits invalid Wasm — the super-call lowering must tolerate the substituted type (do not substitute into the super path, or emit a valid coercion) |
+| **DisposableStack** | `built-ins/DisposableStack/prototype/dispose/throws-error-as-is-if-only-one-error-during-disposal.js` | `assertion_fail` | recovered dispatch path partial — harden the DisposableStack method dispatch before safelisting |
+
+### The guard pattern (the common mechanism)
+
+The shared defect across the cast/`illegal_cast`/`wasm_compile` regressors:
+`resolveAssignedNominalType` substitutes a nominal type, and the downstream
+value-recovery does an **unguarded** `externref → ref $T` (`coerceType` emits
+`any.convert_extern` + `ref.cast` — type-coercion.ts:~1466) that **traps** when the
+runtime value is NOT a `$T` (a `method.call({})`, a thenable that isn't the native
+Promise, etc.). The fix is the **`ref.test` before `ref.cast`** discipline the
+codebase already uses at `emitThisReceiverGuardConvert` (property-access.ts:5443,
+used at 4018/5868/array-object-proto:514) and the `.call`/`.apply` brand-guard at
+`calls.ts:4606` (which emits a `ref.test` guard + catchable TypeError on mismatch).
+
+**S5a per-type loop (one PR per type, or a small batch):**
+1. Route the recovered receiver's externref→ref recovery through a **guarded**
+   convert (`ref.test $T` → on true `ref.cast` + dispatch; on false → the type's
+   spec behavior: TypeError for brand-check methods, or fall through to dynamic
+   dispatch) — reuse/extend `emitThisReceiverGuardConvert` so the guard is shared,
+   not re-implemented per type.
+2. Add the type to `SAFE_BARE_VAR_RECOVERY_NOMINALS`.
+3. Validate the cited test262 file(s) + a full `merge_group` (net ≥ 0, no new
+   bucket) BEFORE moving to the next type.
+
+### Also (folded from original #2768): property read/write recovery
+
+Property **reads** (`d.field`) / **writes** (`d.x=…`) on a bare-var receiver
+compute their OWN `receiverType` in `property-access.ts`
+(`compilePropertyAccess`, the `objType = getTypeAtLocation(...)` site), separate
+from the call hub. Struct-field reads/writes already work (runtime recovery); the
+divergent cases are builtin property reads keyed on the static nominal symbol
+(`Map.size`, `Set.size`, `ArrayBuffer.byteLength`). When a type is hardened +
+safelisted, ALSO route `resolveAssignedNominalType` through the property
+read/write `objType` resolution, gated on the **same** safelist. Hoist the shared
+helper to `shared.ts` (calls.ts imports from property-access.ts → cannot live in
+either without a cycle).
+
+### Acceptance (S5a)
+
+- For each type added to `SAFE_BARE_VAR_RECOVERY_NOMINALS`: its externref→ref
+  recovery is `ref.test`-guarded, the cited test262 file(s) pass, full
+  `merge_group` net ≥ 0, no new bucket.
+- `resolveAssignedNominalType`'s var/let-only + all-assignments-agree + safelist
+  guards remain intact; never substitute a non-safelisted type.
+- Never remove a type from the safelist without a regression.
+
+## Classification (S4/S5)
+
+- **S4 → senior-dev** (result-rep union + consumer-aware threading, broad-impact).
+- **S5b → senior-dev** (multi-site result-brand + registration change, hot path).
+- **S5a → senior-dev** (per-type recovery guards + safelist; each addition is a
+  small PR but each touches the brand-guard mechanism and needs a `merge_group`
+  validation — senior-dev judgment per type). The mechanical guard insertion at a
+  single already-understood site could be a dev task, but the per-type spec
+  behavior (TypeError vs fall-through, super-path validity) is senior-dev.

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -39,6 +39,8 @@ export function createCodegenContext(
     structMap: new Map(),
     typeIdxToStructName: new Map(),
     structFields: new Map(),
+    fnctorReservedTypeIdx: new Map(), // #2773 S1 — up-front fnctor struct-type slots
+
     numImportFuncs: 0,
     jsStringImports: new Map(),
     currentFunc: null,

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1801,6 +1801,17 @@ export interface CodegenContext {
    */
   fnctorEscapeGate?: import("../fnctor-escape-gate.js").FnctorEscapeGateResult;
   /**
+   * #2773 S1 (keystone) — fnctor name → reserved `$__fnctor_<Name>` struct type
+   * index. Populated up-front by `reserveFnctorStructTypes` (index.ts) at the
+   * deterministic type-init phase so the index is IDENTICAL across the hoist pass
+   * and the emit pass (the on-demand registration at the `new F()` site landed at
+   * a pass-dependent index → `ref.test`/`struct.get` desync). When a name is
+   * present here, `compileNewFunctionDeclaration` FILLS the reserved slot in place
+   * instead of pushing a new type (which would re-shift every downstream typeIdx).
+   * Empty for fnctor-free modules ⇒ byte-identical no-op.
+   */
+  fnctorReservedTypeIdx: Map<string, number>;
+  /**
    * #1886 Slice B — Func index of the lazily-emitted
    * `__lin_u8_alloc(len:i32)->i32` bump allocator for linear-backed Uint8Array
    * buffers (`undefined` = not yet emitted). Allocates from a dedicated page-4

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -70,7 +70,7 @@ import {
 import { localGlobalIdx } from "../registry/imports.js";
 import { ensureLateImport, flushLateImportShifts } from "./late-imports.js";
 import { emitFnctorProtoGet } from "./fnctor-prototype.js"; // (#2660 S3a) reconstruct `new F()` as $Object
-import { resolveFnctorSymbol } from "../fnctor-escape-gate.js"; // (#2660 S3a) canonical fnctor-name key
+import { deriveFnctorFields, resolveFnctorSymbol } from "../fnctor-escape-gate.js"; // (#2660 S3a) canonical fnctor-name key; (#2773 S1) shared field derivation
 
 // #2146: resolveEnclosingClassName now lives in shared.ts (imported above).
 
@@ -1060,100 +1060,44 @@ function compileNewFunctionDeclaration(
     // bespoke struct lowering below (status quo, safe).
   }
 
-  // 1. Analyze the function body for `this.prop = value` assignments
-  const fields: FieldDef[] = [];
-  // Record one `this.<field>` slot from an assignment whose LHS is `this.<field>`.
-  // `valueExpr` is the value being assigned to THAT field (for type inference) —
-  // for a chained `this.a = this.b = expr`, the value flowing into `this.a` is the
-  // whole `this.b = expr` sub-assignment (whose result type === expr's type).
-  function recordThisField(lhs: ts.PropertyAccessExpression, valueExpr: ts.Expression): void {
-    const fieldName = lhs.name.text;
-    if (fields.some((f) => f.name === fieldName)) return;
-    // Prefer the RHS type — when `this` is `any`, the LHS type is also `any`
-    // (externref), but the RHS has concrete type info (e.g., number → f64).
-    const lhsType = ctx.checker.getTypeAtLocation(lhs);
-    const rhsType = ctx.checker.getTypeAtLocation(valueExpr);
-    const lhsWasm = resolveWasmType(ctx, lhsType);
-    const rhsWasm = resolveWasmType(ctx, rhsType);
-    const fieldType = lhsWasm.kind === "externref" ? rhsWasm : lhsWasm;
-    fields.push({ name: fieldName, type: fieldType, mutable: true });
-  }
-  // Walk an assignment EXPRESSION, collecting EVERY `this.<field>` LHS in a
-  // (possibly CHAINED) assignment. acorn's Parser ctor uses chained assignments
-  // heavily — `this.start = this.end = this.pos`,
-  // `this.lastTokEndLoc = this.lastTokStartLoc = null`,
-  // `this.yieldPos = this.awaitPos = this.awaitIdentPos = 0` — so the inner
-  // targets (`end`, `lastTokStartLoc`, `awaitPos`, `awaitIdentPos`, …) MUST be
-  // collected too. Missing them gave `$__fnctor_Parser` a SHORTER field set than
-  // the fields the parser later READS (`base.end`, `this.lastTokEnd`), so reads
-  // resolved to the wrong slot / fell through to `__extern_get` → `undefined` and
-  // `parseSubscripts`/expression-parse looped forever (the 9th acorn wall, #2674).
-  function collectAssignmentChain(expr: ts.Expression): void {
-    if (
-      ts.isBinaryExpression(expr) &&
-      expr.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
-      ts.isPropertyAccessExpression(expr.left) &&
-      expr.left.expression.kind === ts.SyntaxKind.ThisKeyword
-    ) {
-      recordThisField(expr.left, expr.right);
-      // The RHS may itself be `this.<field> = …` (chained) — recurse to collect it.
-      collectAssignmentChain(expr.right);
-    }
-  }
-  function collectThisAssignments(stmts: ts.NodeArray<ts.Statement> | readonly ts.Statement[]): void {
-    for (const stmt of stmts) {
-      if (ts.isExpressionStatement(stmt) && ts.isBinaryExpression(stmt.expression)) {
-        collectAssignmentChain(stmt.expression);
-      }
-      // Recurse into if/else blocks
-      if (ts.isIfStatement(stmt)) {
-        if (ts.isBlock(stmt.thenStatement)) {
-          collectThisAssignments(stmt.thenStatement.statements);
-        }
-        if (stmt.elseStatement && ts.isBlock(stmt.elseStatement)) {
-          collectThisAssignments(stmt.elseStatement.statements);
-        }
-      }
-      // Recurse into for/while/do blocks
-      if (
-        (ts.isForStatement(stmt) ||
-          ts.isForInStatement(stmt) ||
-          ts.isForOfStatement(stmt) ||
-          ts.isWhileStatement(stmt) ||
-          ts.isDoStatement(stmt)) &&
-        ts.isBlock(stmt.statement)
-      ) {
-        collectThisAssignments(stmt.statement.statements);
-      }
-    }
-  }
-  collectThisAssignments(body.statements);
-
-  // Empty constructors (no this.prop assignments) — create an empty struct.
-  // Many test262 tests define `var Con = function() {}; new Con()` to test
-  // prototype-based inheritance. We emit a minimal struct + constructor.
-
-  // Widen non-null ref fields to ref_null so struct.new can use ref.null defaults
-  for (const field of fields) {
-    if (field.type.kind === "ref") {
-      field.type = {
-        kind: "ref_null",
-        typeIdx: (field.type as { typeIdx: number }).typeIdx,
-      };
-    }
-  }
-
-  // 2. Create a struct type for the function constructor
+  // 1. Derive the fnctor's field shape from the ctor body's `this.<field> = …`
+  // writes. (#2773 S1) The derivation is the SHARED single source of truth
+  // `deriveFnctorFields` (fnctor-escape-gate.ts) — extracted verbatim from the
+  // logic that used to live inline here — so the up-front reservation pass and
+  // this on-demand path produce the SAME field set/order. Empty constructors yield
+  // `[]` → a minimal struct (the `var Con = function(){}; new Con()` prototype
+  // test262 pattern). The chained-assignment + if/loop recursion and the
+  // `ref → ref_null` widening (so `struct.new` can default a ref field) live
+  // INSIDE the shared helper.
   const structName = `__fnctor_${funcName}`;
-  const structTypeIdx = ctx.mod.types.length;
-  ctx.mod.types.push({
-    kind: "struct",
-    name: structName,
-    fields,
-  });
-  ctx.structMap.set(structName, structTypeIdx);
-  ctx.typeIdxToStructName.set(structTypeIdx, structName);
-  ctx.structFields.set(structName, fields);
+
+  // 2. Reserve-or-register the struct type. (#2773 S1) When the escape gate
+  // approved this fnctor, its `$__fnctor_<Name>` slot was reserved UP-FRONT at the
+  // deterministic type-init phase (reserveFnctorStructTypes, index.ts) — its index
+  // is pass-invariant, and `structMap` / `typeIdxToStructName` / `structFields` are
+  // already populated with the SAME field shape. Trust the reserved index and pull
+  // the reserved `fields` for the struct.new init loop below — do NOT push a new
+  // type (that would re-shift every downstream typeIdx and re-introduce the
+  // hoist-vs-emit desync this slice exists to kill). Otherwise (a fnctor the gate
+  // didn't approve) keep the legacy on-demand registration as a defensive fallback.
+  let structTypeIdx = ctx.fnctorReservedTypeIdx.get(funcName);
+  let fields: FieldDef[];
+  if (structTypeIdx !== undefined) {
+    // Reserved up-front — copy the reserved field set (same FieldDef objects, same
+    // order) so the struct.new field-init loop matches the reserved type's arity.
+    fields = [...ctx.structFields.get(structName)!];
+  } else {
+    fields = deriveFnctorFields(ctx, funcDecl);
+    structTypeIdx = ctx.mod.types.length;
+    ctx.mod.types.push({
+      kind: "struct",
+      name: structName,
+      fields,
+    });
+    ctx.structMap.set(structName, structTypeIdx);
+    ctx.typeIdxToStructName.set(structTypeIdx, structName);
+    ctx.structFields.set(structName, fields);
+  }
 
   // 3. Build the constructor function
   // Constructor params match the function declaration params

--- a/src/codegen/fnctor-escape-gate.ts
+++ b/src/codegen/fnctor-escape-gate.ts
@@ -43,7 +43,9 @@
  * share an alias oracle, but the questions they answer are distinct.
  */
 import { ts, forEachChild } from "../ts-api.js";
+import type { FieldDef } from "../ir/types.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
+import { resolveWasmType } from "./index.js";
 
 /** Classification of a `new F()` fnctor allocation site. */
 export type FnctorGateClass =
@@ -98,6 +100,28 @@ export interface FnctorEscapeGateResult {
    * `resolveReceiverStruct`; no lowering reads it, so emitted Wasm is byte-identical.
    */
   readonly receiverStruct: ReadonlyMap<ts.Expression, string>;
+  /**
+   * #2773 S2b — fnctor NAMES that own a `new this()` reconstruct site (a
+   * `new this()` inside a static / prototype method classified as an `F`
+   * reconstruct). The #2773 S1 up-front struct-type reservation
+   * (`reserveFnctorStructTypes`) unions this with {@link approvedNames} so a
+   * `Parser` reconstructed via `new this()` also gets a reserved
+   * `$__fnctor_Parser` slot. **S1 ships this as an EMPTY set** — S1 only READS it
+   * (so the reservation union is a no-op today); S2b populates it. Landing the
+   * field shape here keeps S2b purely additive.
+   */
+  readonly newThisOwnerNames: ReadonlySet<string>;
+  /**
+   * #2773 S1 — fnctor NAME → its function-like declaration (the body-bearer whose
+   * `this.<field> = …` writes derive the `$__fnctor_<Name>` struct shape). Covers
+   * EVERY fnctor `new F()` site seen (not just approved ones) so
+   * `reserveFnctorStructTypes` can resolve a name to the SAME declaration the
+   * on-demand `compileNewFunctionDeclaration` path uses — guaranteeing identical
+   * field derivation. A name with ≥2 distinct declarations keeps the first
+   * (deterministic by source order); ambiguity here only affects WHICH body shapes
+   * the reserved slot (matching the on-demand resolution at the dominant site).
+   */
+  readonly ctorDeclByName: ReadonlyMap<string, ts.FunctionDeclaration | ts.FunctionExpression>;
 }
 
 const EMPTY_RESULT: FnctorEscapeGateResult = {
@@ -105,7 +129,28 @@ const EMPTY_RESULT: FnctorEscapeGateResult = {
   approved: new Set(),
   approvedNames: new Set(),
   receiverStruct: new Map(),
+  newThisOwnerNames: new Set(),
+  ctorDeclByName: new Map(),
 };
+
+/**
+ * Resolve a fnctor symbol to the function-like declaration that supplies its
+ * constructor body — a top-level `function F(){…}`, a `var F = function(){…}`, or
+ * a bare `FunctionExpression`. Returns `undefined` for anything else (arrow, class
+ * — those never reach here via `resolveFnctorSymbol`).
+ */
+function fnctorDeclFromSymbol(sym: ts.Symbol): ts.FunctionDeclaration | ts.FunctionExpression | undefined {
+  for (const decl of sym.getDeclarations() ?? []) {
+    if (ts.isFunctionDeclaration(decl) && decl.body) return decl;
+    if (ts.isFunctionExpression(decl) && decl.body) return decl;
+    if (ts.isVariableDeclaration(decl) && decl.initializer) {
+      let init: ts.Expression = decl.initializer;
+      while (ts.isParenthesizedExpression(init)) init = init.expression;
+      if (ts.isFunctionExpression(init) && init.body) return init;
+    }
+  }
+  return undefined;
+}
 
 /** Max callee-chain depth the single-return struct inference will follow. */
 const RETURN_INFER_MAX_DEPTH = 6;
@@ -553,6 +598,15 @@ export function analyzeFnctorEscapeGate(checker: ts.TypeChecker, sourceFile: ts.
   collect(sourceFile);
   if (newSites.length === 0) return EMPTY_RESULT;
 
+  // #2773 S1 — index fnctor name → declaration (first-seen wins, deterministic by
+  // source order) for the up-front struct-type reservation pass.
+  const ctorDeclByName = new Map<string, ts.FunctionDeclaration | ts.FunctionExpression>();
+  for (const { ctorSym } of newSites) {
+    if (ctorDeclByName.has(ctorSym.name)) continue;
+    const decl = fnctorDeclFromSymbol(ctorSym);
+    if (decl) ctorDeclByName.set(ctorSym.name, decl);
+  }
+
   // 2. Build a per-binding-symbol index of identifier uses across the program,
   //    so a `const c = new F()` instance's uses can be found by symbol identity.
   const usesBySymbol = new Map<ts.Symbol, ts.Identifier[]>();
@@ -646,5 +700,113 @@ export function analyzeFnctorEscapeGate(checker: ts.TypeChecker, sourceFile: ts.
     );
   }
 
-  return { sites, approved, approvedNames, receiverStruct };
+  // #2773 S2b populates this set with `new this()` reconstruct owners; S1 ships
+  // it empty so the up-front reservation union is a no-op today.
+  const newThisOwnerNames = new Set<string>();
+
+  return { sites, approved, approvedNames, receiverStruct, newThisOwnerNames, ctorDeclByName };
+}
+
+/**
+ * #2773 S1 (keystone) — derive the WasmGC field shape of a fnctor's
+ * `$__fnctor_<Name>` struct from its constructor body's `this.<field> = …`
+ * assignments. This is the **single source of truth** for the field set,
+ * EXTRACTED verbatim from the on-demand inline logic that lived in
+ * `compileNewFunctionDeclaration` (new-super.ts) so both the up-front reservation
+ * pass and the legacy on-demand fallback produce the SAME shape — divergent field
+ * order would give `struct.new` a different arity than the reserved type and trap.
+ *
+ * Mirrors the original logic exactly:
+ *   - collects EVERY `this.<field>` LHS across (possibly CHAINED) assignments
+ *     (`this.a = this.b = expr`), recursing into if/else and loop blocks;
+ *   - prefers the RHS type when the LHS is `any` (externref) — the RHS carries the
+ *     concrete type (e.g. number → f64);
+ *   - widens non-null `ref` fields to `ref_null` so `struct.new`'s `ref.null`
+ *     default-init is well-typed (a struct.new can't default a non-null ref).
+ *
+ * @param ctx      codegen context (for the checker + `resolveWasmType`)
+ * @param funcDecl the fnctor's function-like declaration (its body is read)
+ * @returns the ordered field set, or `[]` for a body-less / empty-body fnctor.
+ */
+export function deriveFnctorFields(
+  ctx: CodegenContext,
+  funcDecl: ts.FunctionDeclaration | ts.FunctionExpression,
+): FieldDef[] {
+  const body = funcDecl.body;
+  if (!body) return [];
+
+  const fields: FieldDef[] = [];
+
+  // Record one `this.<field>` slot from an assignment whose LHS is `this.<field>`.
+  // `valueExpr` is the value being assigned to THAT field (for type inference) —
+  // for a chained `this.a = this.b = expr`, the value flowing into `this.a` is the
+  // whole `this.b = expr` sub-assignment (whose result type === expr's type).
+  function recordThisField(lhs: ts.PropertyAccessExpression, valueExpr: ts.Expression): void {
+    const fieldName = lhs.name.text;
+    if (fields.some((f) => f.name === fieldName)) return;
+    // Prefer the RHS type — when `this` is `any`, the LHS type is also `any`
+    // (externref), but the RHS has concrete type info (e.g., number → f64).
+    const lhsType = ctx.checker.getTypeAtLocation(lhs);
+    const rhsType = ctx.checker.getTypeAtLocation(valueExpr);
+    const lhsWasm = resolveWasmType(ctx, lhsType);
+    const rhsWasm = resolveWasmType(ctx, rhsType);
+    const fieldType = lhsWasm.kind === "externref" ? rhsWasm : lhsWasm;
+    fields.push({ name: fieldName, type: fieldType, mutable: true });
+  }
+  // Walk an assignment EXPRESSION, collecting EVERY `this.<field>` LHS in a
+  // (possibly CHAINED) assignment — `this.start = this.end = this.pos`, etc.
+  function collectAssignmentChain(expr: ts.Expression): void {
+    if (
+      ts.isBinaryExpression(expr) &&
+      expr.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isPropertyAccessExpression(expr.left) &&
+      expr.left.expression.kind === ts.SyntaxKind.ThisKeyword
+    ) {
+      recordThisField(expr.left, expr.right);
+      // The RHS may itself be `this.<field> = …` (chained) — recurse to collect it.
+      collectAssignmentChain(expr.right);
+    }
+  }
+  function collectThisAssignments(stmts: ts.NodeArray<ts.Statement> | readonly ts.Statement[]): void {
+    for (const stmt of stmts) {
+      if (ts.isExpressionStatement(stmt) && ts.isBinaryExpression(stmt.expression)) {
+        collectAssignmentChain(stmt.expression);
+      }
+      // Recurse into if/else blocks
+      if (ts.isIfStatement(stmt)) {
+        if (ts.isBlock(stmt.thenStatement)) {
+          collectThisAssignments(stmt.thenStatement.statements);
+        }
+        if (stmt.elseStatement && ts.isBlock(stmt.elseStatement)) {
+          collectThisAssignments(stmt.elseStatement.statements);
+        }
+      }
+      // Recurse into for/while/do blocks
+      if (
+        (ts.isForStatement(stmt) ||
+          ts.isForInStatement(stmt) ||
+          ts.isForOfStatement(stmt) ||
+          ts.isWhileStatement(stmt) ||
+          ts.isDoStatement(stmt)) &&
+        ts.isBlock(stmt.statement)
+      ) {
+        collectThisAssignments(stmt.statement.statements);
+      }
+    }
+  }
+  collectThisAssignments(body.statements);
+
+  // Widen non-null ref fields to ref_null so struct.new can use ref.null defaults.
+  // (Kept INSIDE the derivation so the reserved field set matches exactly what the
+  // struct.new default-init loop expects — see new-super.ts.)
+  for (const field of fields) {
+    if (field.type.kind === "ref") {
+      field.type = {
+        kind: "ref_null",
+        typeIdx: (field.type as { typeIdx: number }).typeIdx,
+      };
+    }
+  }
+
+  return fields;
 }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -3,7 +3,7 @@ import { ts, forEachChild } from "../ts-api.js";
 import { emitToBoolean } from "./coercion-engine.js";
 import { emitWasiErrorConstructor } from "./registry/error-types.js";
 import { analyzeLinearUint8 } from "./linear-uint8-analysis.js";
-import { analyzeFnctorEscapeGate } from "./fnctor-escape-gate.js";
+import { analyzeFnctorEscapeGate, deriveFnctorFields } from "./fnctor-escape-gate.js";
 import { isLinearU8RepresentableNew } from "./linear-uint8-signatures.js";
 import type { MultiTypedAST, TypedAST } from "../checker/index.js";
 import {
@@ -1144,6 +1144,19 @@ export function generateModule(
     if (sourceContainsClass(ast.sourceFile)) {
       reserveObjVecArrType(ctx);
     }
+
+    // (#2773 S1 KEYSTONE) Reserve every reconstructed-fnctor `$__fnctor_<Name>`
+    // struct type up-front, here — at the SAME deterministic point in every
+    // codegen pass — so the type index is identical across the hoist pass (which
+    // bakes a typed-receiver `ref.test $__fnctor_<Name>` / sizes a hoisted local)
+    // and the emit pass (which emits the matching `struct.new`). On-demand
+    // registration at the `new F()` site lands at a pass-dependent index,
+    // de-syncing the two. Gated on a non-empty approved set ⇒ byte-identical no-op
+    // for fnctor-free modules. Both targets (the fnctor struct path is
+    // target-independent). MUST run after the gate is built (above, line ~1081)
+    // and after the subview / ObjVecArr reservations so the type-table prefix is
+    // already stable.
+    reserveFnctorStructTypes(ctx);
 
     // $AnyValue struct type is now registered lazily via ensureAnyValueType()
 
@@ -6910,6 +6923,76 @@ export function reserveObjVecArrType(ctx: CodegenContext): void {
     mutable: true,
   });
   ctx.reservedObjVecArrTypeIdx = idx;
+}
+
+/**
+ * #2773 S1 (KEYSTONE) — reserve every reconstructed-fnctor `$__fnctor_<Name>`
+ * struct type at the deterministic up-front type-init phase (the same stable
+ * point as `reserveTypedArraySubviewTypes` / `reserveObjVecArrType`), so the type
+ * index is IDENTICAL across the hoist pass and the emit pass.
+ *
+ * ROOT CAUSE this fixes: the on-demand registration at the `new F()` call site
+ * (`compileNewFunctionDeclaration`, new-super.ts — `ctx.mod.types.length`) assigns
+ * the index at a NON-deterministic mid-compile point that depends on which
+ * function the compiler reached first. The two-pass type numbering then desyncs:
+ * a typed-receiver `ref.test $__fnctor_<Name>` baked in the hoist pass misses the
+ * emit-pass `struct.new` index, and a read site compiled before the `new` site is
+ * excluded from `findAlternateStructsForField`'s candidate set. Reserving up-front
+ * collapses BOTH facets — the index is pass-invariant AND the candidate set is
+ * complete at every read site. This is the one thing the #2674 finalize
+ * dispatcher cannot retroactively fix (it can't rewrite a baked typeIdx).
+ *
+ * Two sub-passes — the ORDER is load-bearing:
+ *   (1) reserve ALL indices + names FIRST (placeholder struct, `structMap`,
+ *       `typeIdxToStructName`, `fnctorReservedTypeIdx`), so a cross-fnctor ref
+ *       field in sub-pass 2 (a `Parser` field typed `Scope` →
+ *       `(ref null $__fnctor_Scope)`) resolves against an already-registered
+ *       `structMap` entry. Do NOT collapse the two sub-passes.
+ *   (2) FILL each placeholder's fields via the shared `deriveFnctorFields`
+ *       (single source of truth — identical to the on-demand derivation) and
+ *       record `structFields` for candidate-set completeness.
+ *
+ * Determinism: the name set is SORTED, and the call-site position is fixed, so the
+ * reserved index is identical across the hoist pass and the emit pass (the entire
+ * point of the slice). Gated on a non-empty approved set ⇒ fnctor-free modules are
+ * byte-identical (a true no-op). Runs in BOTH host and standalone — the on-demand
+ * struct path is target-independent. A reserved-but-never-constructed placeholder
+ * is unreferenced ⇒ `dead-elimination` prunes + renumbers it cleanly.
+ */
+export function reserveFnctorStructTypes(ctx: CodegenContext): void {
+  const gate = ctx.fnctorEscapeGate;
+  if (!gate) return;
+  // The set of fnctor names whose struct slot to reserve: the reconstruct-approved
+  // names plus (S2b) the `new this()` reconstruct owners. `newThisOwnerNames` is
+  // empty in S1, so this is exactly `approvedNames` today.
+  const names = [...new Set([...gate.approvedNames, ...gate.newThisOwnerNames])].sort();
+  if (names.length === 0) return; // no-op gate ⇒ byte-identical for fnctor-free code
+
+  // SUB-PASS 1 — reserve every index + name FIRST (placeholder, empty fields) so
+  // cross-fnctor ref fields in sub-pass 2 resolve against a registered structMap.
+  for (const name of names) {
+    const decl = gate.ctorDeclByName.get(name);
+    if (!decl || !decl.body) continue; // unresolved / body-less ⇒ skip (legacy fallback handles it)
+    const structName = `__fnctor_${name}`;
+    if (ctx.structMap.has(structName)) continue; // idempotent within a pass
+    const idx = ctx.mod.types.length;
+    ctx.mod.types.push({ kind: "struct", name: structName, fields: [] });
+    ctx.structMap.set(structName, idx);
+    ctx.typeIdxToStructName.set(idx, structName);
+    ctx.fnctorReservedTypeIdx.set(name, idx);
+  }
+
+  // SUB-PASS 2 — fill fields now that ALL names + indices exist.
+  for (const name of names) {
+    const idx = ctx.fnctorReservedTypeIdx.get(name);
+    if (idx === undefined) continue;
+    const decl = gate.ctorDeclByName.get(name);
+    if (!decl) continue;
+    const fields = deriveFnctorFields(ctx, decl);
+    const ty = ctx.mod.types[idx];
+    if (ty && ty.kind === "struct") ty.fields = fields; // FILL IN PLACE — index unchanged
+    ctx.structFields.set(`__fnctor_${name}`, fields); // candidate-set completeness
+  }
 }
 
 export function ensureLinearU8AllocHelper(ctx: CodegenContext): number {


### PR DESCRIPTION
## #2773 S1 (KEYSTONE) — up-front fnctor struct-type reservation

Foundation slice of the value-rep substrate epic (#2773). Reserves every
reconstruct-approved `\$__fnctor_<Name>` struct type at the **deterministic
up-front type-init phase** (next to `reserveTypedArraySubviewTypes` /
`reserveObjVecArrType`) instead of on-demand at the `new F()` call site.

### Root cause fixed
The on-demand registration (`ctx.mod.types.length` in `new-super.ts`) assigned the
struct index at a non-deterministic mid-compile point that **desynced between the
hoist pass and the emit pass**: a typed-receiver `ref.test \$__fnctor_<Name>` baked
in the hoist pass missed the emit-pass `struct.new` index, and a read site compiled
*before* the `new` site was excluded from `findAlternateStructsForField`'s
candidate set. Up-front reservation makes the index **pass-invariant** AND the
candidate set **complete** — the one thing the #2674 finalize dispatcher cannot
retroactively fix (it can't rewrite a baked typeIdx).

### Changes
- **`reserveFnctorStructTypes(ctx)`** (index.ts) — two sub-passes: reserve all
  indices+names first (cross-fnctor ref resolution), then fill fields. Sorted +
  fixed call-site position ⇒ identical index in both passes. Gated on a non-empty
  approved set ⇒ **byte-identical no-op** for fnctor-free modules.
- **`deriveFnctorFields(ctx, funcDecl)`** (fnctor-escape-gate.ts) — single source
  of truth for the field shape, extracted verbatim from `new-super.ts` (chained
  assignment + if/loop recursion + `ref → ref_null` widening).
- **`new-super.ts`** consumes the reserved slot (fill-in-place, never push);
  legacy on-demand path kept as a defensive fallback.
- **`ctx.fnctorReservedTypeIdx`** map; gate result gains `newThisOwnerNames`
  (empty in S1, S2b populates) + `ctorDeclByName`.

### Validation
- **Byte-identical no-op proof (cross-compile vs main):** 7 fnctor-free + 1
  keep-static module ×{host, standalone, wasi} → byte-for-byte identical WAT.
- **typeIdx stability:** keystone shape (field read in a lifted method defined
  before the `new` site + sibling fnctor) reserves both structs up-front; binary
  instantiates + runs correctly (no `ref.test` miss / cast trap).
- **sr-acorn identity repros:** 7 / 45 / 207.
- **Fnctor/new-expression suite:** 67/68 (the 1 fail, `constructor-arity`, is
  pre-existing + byte-identical to main).

Scope is S1 only — typeIdx stability + byte-identical-when-no-fnctor. S2/S2b
(read/write symmetry, `new this()` reconstruct) rebase
`origin/issue-2681-acorn-new-this` on top of this. Broad-impact → validated by
full `merge_group` + standalone-floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)