### PR TITLE
fix(#2774): relabel edition card summary % as edition-wide on landing page

### DIFF
--- a/plan/issues/2774-edition-card-summary-pct-vs-feature-rows.md
+++ b/plan/issues/2774-edition-card-summary-pct-vs-feature-rows.md
@@ -1,0 +1,75 @@
+---
+id: 2774
+title: Landing-page edition card summary % doesn't reconcile with its feature rows
+status: done
+sprint: current
+priority: low
+horizon: s
+feasibility: easy
+completed: 2026-06-28
+---
+
+## Problem
+
+On the landing page (`website/index.html`, "Goal: 100% ECMAScript
+compatibility" section), each ES-edition feature card shows a **summary
+percentage** in its header alongside a list of **individual feature rows**,
+each with a live `pass / total` count. The header `%` does not reconcile with
+the per-feature rows — summing the rows never reproduces the header number,
+which reads as a bug to visitors.
+
+## Root cause (not an arithmetic bug)
+
+The header `%` and the per-feature rows are computed from **two different
+datasets over two different populations**, so by construction they cannot sum:
+
+1. **Different populations (dominant).** The header aggregates *every* Test262
+   test classified into that edition; the rows only cover the curated subset of
+   features actually listed in the card. Most edition tests are not represented
+   by any visible row.
+   - Header: `website/index.html` `updateEditionPassBars` →
+     `loadEditionBuckets()` → `benchmarks/results/test262-editions.json`
+     (built by `scripts/generate-editions.ts`).
+   - Rows: `hydrateFeatureBadges` → `feature-examples.json` per-feature
+     `passCount` / `totalCount`.
+
+2. **Different classification axis.** Editions bucket by test **frontmatter**
+   (`es5id` / `es6id` / `features` tags, `generate-editions.ts:395-449`); rows
+   bucket by **file-path prefix** (`data-t262-paths`). The same test is
+   attributed to different editions by each axis — e.g. the "ES3 / Core" card's
+   path-matched rows pull 2,804 tests, but only 274 tests carry ES3-era
+   frontmatter.
+
+3. **Skip handling differs.** Header `pct = pass / (pass+fail+ce+skip)`
+   (`generate-editions.ts:601,612`, skip in denominator); per-feature
+   `total = pass+fail+ce` (skip excluded).
+
+A naive "Other = header − Σ(rows)" remainder row was evaluated and **rejected**:
+it produces negative remainders on the most prominent cards (ES3 −2,530,
+ES5 −1,526, ES2015 −1,029) precisely because of axis #2.
+
+## Fix (option B — relabel, display-only)
+
+Make the framing honest rather than forcing the two numbers to reconcile:
+
+- The edition header passbar now renders the **edition-wide `pass / total`
+  count** next to the `%` (the population the `%` is actually measured over).
+- A disclaimer above the cards states the percentage/count cover **every**
+  Test262 test in the edition, and the feature rows are **illustrative
+  examples**, not a complete breakdown, so their counts are not meant to sum to
+  the edition total.
+
+All changes are display-only in `website/index.html`; no data regeneration.
+
+## Acceptance criteria
+
+- [x] Edition card header shows the edition-wide `pass / total` count beside the `%`.
+- [x] A visible note clarifies the rows are illustrative and don't sum to the header.
+- [x] `node scripts/derive-feature-badges.mjs --check` passes (no `feat-row` changed).
+- [x] `prettier --check website/index.html` passes.
+
+## Out of scope (follow-ups)
+
+- Several cards (ES2019 / ES2022 / ES2024) have curated rows whose `.feat-name`
+  matches **nothing** in `feature-examples.json`, so they show blank `N / T`
+  chips today. Pre-existing, independent of this relabel.

--- a/website/index.html
+++ b/website/index.html
@@ -1173,6 +1173,25 @@
         min-width: 160px;
         justify-content: flex-end;
       }
+      .feat-edition-passbar-count {
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.04em;
+        color: rgba(255, 255, 255, 0.46);
+        white-space: nowrap;
+        text-transform: none;
+      }
+      .feat-tables-note {
+        margin-top: 1rem;
+        max-width: 60ch;
+        font-size: 13px;
+        line-height: 1.55;
+        color: var(--fg-faint);
+      }
+      .feat-tables-note-mono {
+        font-family: var(--mono);
+        font-size: 12px;
+      }
       .feat-edition-passbar-track {
         display: block;
         width: 92px;
@@ -1589,6 +1608,12 @@
           <p>
             Which JS language features compile to WebAssembly today, which still rely on host support, and which are
             still on the roadmap. Status is derived from ECMAScript Test262 pass rates and known compiler limitations.
+          </p>
+          <p class="feat-tables-note">
+            Each edition's percentage and <span class="feat-tables-note-mono">pass / total</span> count cover
+            <strong>every</strong> Test262 test in that edition. The feature rows below are illustrative
+            examples — a hand-picked subset, not a complete breakdown — so their individual counts are not meant
+            to sum to the edition total.
           </p>
           <p style="margin-top: 1.25rem">
             <a class="btn-outline" href="./benchmarks/report.html">Compatibility Test Report</a>
@@ -5480,6 +5505,7 @@ console.log(instance.exports.run()); // &rarr; 55</pre
             bar = document.createElement("span");
             bar.className = "feat-edition-passbar";
             bar.innerHTML = `
+              <span class="feat-edition-passbar-count"></span>
               <span class="feat-edition-passbar-track">
                 <span class="feat-edition-passbar-fill"></span>
               </span>
@@ -5560,6 +5586,7 @@ console.log(instance.exports.run()); // &rarr; 55</pre
               const bar = ensureEditionPassBar(ensured.el);
               const fill = bar.querySelector(".feat-edition-passbar-fill");
               const text = bar.querySelector(".feat-edition-passbar-text");
+              const count = bar.querySelector(".feat-edition-passbar-count");
               const pct = Math.max(0, Math.min(100, Number(bucket.pct ?? 0)));
               const title = `${bucket.pass.toLocaleString()} pass, ${bucket.fail.toLocaleString()} fail, ${bucket.ce.toLocaleString()} CE, ${bucket.skip.toLocaleString()} skip (${bucket.total.toLocaleString()} total)`;
               if (fill instanceof HTMLElement) {
@@ -5569,6 +5596,14 @@ console.log(instance.exports.run()); // &rarr; 55</pre
               if (text instanceof HTMLElement) {
                 text.textContent = `${pct}%`;
                 text.title = title;
+              }
+              // B (edition-card relabel): show the edition-wide population the
+              // header % is measured over — ALL test262 tests classified into
+              // this edition by frontmatter, NOT the sum of the illustrative
+              // feature rows below (which bucket by file path and don't add up).
+              if (count instanceof HTMLElement) {
+                count.textContent = `${bucket.pass.toLocaleString()} / ${bucket.total.toLocaleString()}`;
+                count.title = title;
               }
               bar.title = title;
             });


### PR DESCRIPTION
## Problem

On the landing page (`website/index.html`, "Goal: 100% ECMAScript compatibility"), each ES-edition feature card shows a header **summary %** alongside a list of feature rows with live `pass / total` counts. The header % never reconciles with the rows — summing the rows can't reproduce it — which reads as a bug to visitors.

## Root cause (not arithmetic)

The two numbers come from **different datasets over different populations**, so they can't sum by construction:

1. **Different populations (dominant)** — header aggregates *every* test262 test classified into the edition (`test262-editions.json` via `generate-editions.ts`); rows only cover the curated subset of features listed in the card (`feature-examples.json`).
2. **Different classification axis** — editions bucket by test **frontmatter** (`es5id`/`es6id`/`features`); rows bucket by **file-path prefix** (`data-t262-paths`). The same test lands in different editions per axis (e.g. the "ES3 / Core" card's path-matched rows pull 2,804 tests, but only 274 carry ES3-era frontmatter).
3. **Skip handling differs** — header `pct = pass/(pass+fail+ce+skip)`; per-feature `total = pass+fail+ce`.

A naive "Other = header − Σ(rows)" remainder was evaluated and rejected: it goes **negative** on the biggest cards (ES3 −2,530, ES5 −1,526, ES2015 −1,029) because of axis #2.

## Fix — option B (relabel, display-only)

- Edition header passbar now renders the **edition-wide `pass / total` count** beside the `%`, making explicit what population the `%` measures.
- A disclaimer above the cards states the `%`/count cover **every** test262 test in the edition, and the feature rows are **illustrative examples**, not a complete breakdown, so their counts aren't meant to sum to the edition total.

All changes are display-only in `website/index.html`; no data regeneration.

## Validation

- `node scripts/derive-feature-badges.mjs --check` → OK (no `feat-row` changed)
- `prettier --check website/index.html` → clean
- Minimal additive diff (no reformatting churn)

## Out of scope (follow-up)

Several cards (ES2019 / ES2022 / ES2024) have curated rows whose `.feat-name` matches nothing in `feature-examples.json`, so they show blank `N / T` chips today — pre-existing, independent of this relabel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)