### PR TITLE
fix(website): mobile-friendly feature test report layout

### DIFF
--- a/website/public/benchmarks/feature-report.html
+++ b/website/public/benchmarks/feature-report.html
@@ -45,6 +45,13 @@
         margin: 0 auto;
         padding: 32px 24px 80px;
       }
+      /* Let the test table scroll horizontally on its own instead of
+         pushing the whole page wide on narrow viewports. */
+      #test-table-wrap {
+        width: 100%;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+      }
       .breadcrumb {
         font-size: 12px;
         color: var(--fg-faint);
@@ -199,6 +206,38 @@
       }
       .error-msg-text {
         color: var(--fg-soft);
+      }
+      @media (max-width: 640px) {
+        .container {
+          padding: 20px 16px 56px;
+        }
+        h1 {
+          font-size: 20px;
+        }
+        .summary-row {
+          gap: 12px;
+          margin: 4px 0 10px;
+        }
+        /* Drop the hard nowrap caps so columns reflow to the phone width;
+           the wrapper still allows horizontal scroll if a cell is wide. */
+        .col-file {
+          white-space: normal;
+          word-break: break-word;
+          max-width: none;
+        }
+        .col-error {
+          max-width: none;
+        }
+        .test-table {
+          font-size: 12px;
+        }
+        .test-table thead th,
+        .test-table tbody td {
+          padding: 6px 8px;
+        }
+        .col-action {
+          white-space: normal;
+        }
       }
     </style>
   </head>


### PR DESCRIPTION
## Problem

The feature test report page (`/benchmarks/feature-report.html`, e.g. [`?feature=language/eval-code`](https://js2.loopdive.com/benchmarks/feature-report.html?feature=language%2Feval-code)) is not mobile-friendly. The results table forces a ~800px minimum width — `col-file` (`max-width: 280px`, `nowrap`) + `col-error` (`max-width: 480px`) + status + action columns — so on a phone the **entire page** scrolls sideways. The viewport meta tag was already present; the layout was the issue.

## Fix

- **`#test-table-wrap` now has its own horizontal scroll** (`overflow-x: auto`), so a genuinely wide row scrolls the table only, never the whole page/header.
- **`@media (max-width: 640px)`** tightens container padding, shrinks the H1 and table font, reduces cell padding, and drops the nowrap/`max-width` caps on the file & error columns so they reflow to the viewport width.

The breadcrumb, summary row, and filter buttons already used `flex-wrap`, so they were unaffected.

Static HTML only — `dashboard/build-data.js` produces the `feature-examples.json` data the page fetches, not the page itself, so this edit won't be overwritten by the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)