### PR TITLE
feat(compiler): #2771 bundle relative imports for standalone WASI compilation

### DIFF
--- a/plan/issues/2771-cli-relative-import-bundling-standalone.md
+++ b/plan/issues/2771-cli-relative-import-bundling-standalone.md
@@ -1,0 +1,109 @@
+---
+id: 2771
+title: "Bundle relative imports for standalone WASI CLI compilation (shared local helper + node:fs IO)"
+status: done
+assignee: ttraenkler/sdev-2771-bundling
+created: 2026-06-28
+completed: 2026-06-28
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: feature
+area: compiler
+goal: platform
+related: [2756, 389, 2655]
+sprint: current
+---
+
+# #2771 — bundle relative imports for standalone WASI compilation
+
+## Problem
+
+Sharing a local helper file across CLI-compiled standalone WASI examples was
+impossible in BOTH compile paths. A standalone program whose **entry** imports a
+local `./shared.ts`, with the `node:fs` fd-IO seam (`readSync`/`writeSync` over a
+`Uint8Array`) split across the two files, could not be compiled to a clean
+self-contained WASI command module. This is the compiler unblock for the #2756
+native-messaging dedup.
+
+Two independent blockers (verified by dev-2756):
+
+1. **Single-source CLI path** (`src/cli.ts`): the CLI calls `compile(source, …)`,
+   which reads exactly ONE file and strips every import in `preprocessImports`.
+   So `import { runEchoLoop } from "./nm_sync_framing"` was unresolved and
+   `runEchoLoop` lowered to a host import `env.runEchoLoop` → the WASI
+   strict-no-host-imports gate hard-rejects it (and even when dropped, the module
+   had no IO).
+
+2. **Multi-file `compileMultiSource()`** (`src/compiler.ts`): it DOES bundle
+   relative imports (TS program resolves them), but **never ran**
+   `detectNodeFsImports` / `detectRawWasiImports`, so `wasiNodeFsFuncs` stayed
+   undefined → a `node:fs` `readSync`/`writeSync` (even in the entry) lowered to
+   ZERO fd IO (`imports = []`). A `node:fs` program compiled to a module with no
+   `fd_read`/`fd_write`.
+
+## Fix — BOTH (a) and (b); neither alone suffices
+
+- **(a) CLI routing** (`src/cli.ts` + new `entryHasRelativeImports` in
+  `src/compiler.ts`): when the entry statically imports / `require`s a RELATIVE
+  module (`./x` / `../x`), route to the multi-file bundler `compileProject`
+  instead of single-source `compile`. Entries with no relative import (plain,
+  `node:`-only, bare-package) stay on the single-source path → **byte-identical**.
+- **(b) node:fs / raw-WASI detection in the bundler** (`src/compiler.ts
+  compileMultiSource`): union `detectNodeFsImports` / `detectRawWasiImports`
+  across EVERY bundled file (the CJS-rewritten map) and thread the resulting
+  `wasiNodeFsFuncs` / `wasiRawImports` / `wasiMemAccessors` into
+  `buildCodegenOptions`, so a `node:fs` fd call living in a SHARED helper lowers
+  to `fd_read`/`fd_write` module-wide. The unions are empty for any program that
+  imports none of these modules → existing multi-file compiles stay
+  byte-identical.
+
+(a) alone is insufficient: `compileProject` would still emit zero fd IO. (b)
+alone is insufficient: the CLI never reaches `compileProject`.
+
+## Implementation notes (WHY)
+
+- The `preprocessImports` strip-all-imports behaviour is correct for a single
+  file but cannot run in multi-mode (it would strip the cross-file relative
+  imports the TS program needs). So (b) does NOT run `preprocessImports`; it only
+  runs the two **string scanners** (`ts.createSourceFile` + import-decl walk),
+  which mutate nothing. Codegen already drops the `node:fs` import binding and
+  lowers the call sites purely on `ctx.wasiNodeFsFuncs` membership
+  (`node-fs-api.ts`, `index.ts:12423`), so populating the set is enough — no
+  source rewrite required.
+- `nodeBuiltins` / `jsxRuntime` parity for multi-mode is intentionally left out
+  of scope (a larger `preprocessImports`-parity change tracked alongside #2138);
+  #2771 only needs the WASI fd surfaces.
+- Routing on relative imports (not on `--target wasi`) is deliberately general:
+  relative-import programs were silently broken on ALL targets, so the bundler is
+  the right home for them regardless of target.
+
+## Acceptance — verified
+
+- Two-file standalone program (entry imports `./shared`, `node:fs` `readSync`/
+  `writeSync` IO in the shared helper) compiles under `--target wasi` to module
+  imports = `wasi_snapshot_preview1` ONLY (no `env.*`), and echoes a framed
+  message **byte-exact** under wasmtime (fd_read/fd_write work). See
+  `tests/issue-2771-relative-import-standalone-wasi.test.ts` (3 tests, incl. the
+  live wasmtime echo).
+- **Byte-neutral** for existing single-file programs: `nm_js2wasm.ts` (single
+  file, node:fs) produced sha256 `38a7a991…` / 60478 bytes on BOTH origin/main
+  and this branch; a `runTest262File` control batch (language/expressions/
+  addition) was identical on both trees (10/12 pass, same 2 pre-existing fails);
+  lodash-es `partial.js` multi-file compile produced byte-identical 305202-byte
+  output on both trees.
+- tsc + biome lint clean; prettier applied.
+
+## Downstream consumer
+
+After #2756 (example renames `nm_js2wasm`→`nm_node_fs`) and this issue land, a
+small follow-up re-applies the `nm_deno`/`nm_node_fs` shared-core dedup on top
+(dev-2756 preserved the experiment). Not part of #2771.
+
+## Files
+
+- `src/compiler.ts` — `entryHasRelativeImports` (exported); WASI-import detection
+  in `compileMultiSource`.
+- `src/index.ts` — re-export `entryHasRelativeImports`.
+- `src/cli.ts` — route relative-import entries to `compileProject`.
+- `tests/issue-2771-relative-import-standalone-wasi.test.ts` — focused test.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,7 @@ if (args.includes("--ts7")) {
   process.env.JS2WASM_TS7 = "1";
 }
 
-const { compile } = await import("./index.js");
+const { compile, compileProject, entryHasRelativeImports } = await import("./index.js");
 const { buildDefaultDefines } = await import("./compiler/define-substitution.js");
 
 if (args.includes("--version") || args.includes("-v")) {
@@ -358,7 +358,7 @@ if (!emulateExplicit && !emulateNode && /['"]node:[A-Za-z0-9_./-]+['"]/.test(sou
 const name = basename(absInput, ".ts");
 const dir = outDir ? resolve(outDir) : dirname(absInput);
 
-const result = await compile(source, {
+const compileOptions = {
   ...(optimize ? { optimize } : {}),
   ...(target ? { target } : {}),
   ...(allocator ? { allocator } : {}),
@@ -371,7 +371,19 @@ const result = await compile(source, {
   fileName: absInput,
   ...(strictNoHostImports !== undefined ? { strictNoHostImports } : {}),
   ...(Object.keys(defines).length > 0 ? { define: defines } : {}),
-});
+};
+
+// #2771 — a single-file `compile()` reads exactly ONE file and strips every
+// import, so an entry that imports a relative `./helper` module leaves those
+// bindings unresolved (they lower to bogus `env.*` host imports the WASI gate
+// rejects). When the entry statically imports/`require`s a relative module,
+// route to the multi-file bundler (`compileProject`), which resolves the
+// relative deps from disk through the TS program AND lowers cross-file
+// `node:fs`/WASI fd IO (compileMultiSource, #2771). Entries with no relative
+// import stay on the single-source path — byte-identical to before.
+const result = entryHasRelativeImports(source)
+  ? await compileProject(absInput, compileOptions)
+  : await compile(source, compileOptions);
 
 if (!result.success) {
   for (const e of result.errors) {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -548,6 +548,53 @@ function detectNodeFsImports(source: string): Set<string> {
 }
 
 /**
+ * #2771 — does the entry source statically import (or `require`) a RELATIVE
+ * module (`./x` / `../x`)? The single-source `compile()` path reads exactly one
+ * file and strips every import in `preprocessImports`, so a relative import is
+ * silently unresolved — its bindings lower to bogus `env.*` host imports (which
+ * the WASI strict-no-host gate then rejects). The CLI uses this to route such an
+ * entry to the multi-file bundler (`compileProject`), which resolves the
+ * relative deps through the TS program. Package / `node:` / bare-specifier
+ * imports are NOT relative and stay on the single-source path (byte-neutral).
+ */
+export function entryHasRelativeImports(source: string): boolean {
+  const sf = ts.createSourceFile("__detect_rel__.ts", source, ts.ScriptTarget.Latest, true);
+  const isRelativeSpec = (spec: string): boolean => spec.startsWith("./") || spec.startsWith("../");
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (found) return;
+    // `import … from "./x"` / `import "./x"` and `export … from "./x"`.
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier) &&
+      isRelativeSpec(node.moduleSpecifier.text)
+    ) {
+      found = true;
+      return;
+    }
+    // `require("./x")` (CJS) and dynamic `import("./x")`.
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      const isRequire = ts.isIdentifier(callee) && callee.text === "require";
+      const isDynImport = callee.kind === ts.SyntaxKind.ImportKeyword;
+      if (
+        (isRequire || isDynImport) &&
+        node.arguments.length > 0 &&
+        ts.isStringLiteral(node.arguments[0]) &&
+        isRelativeSpec(node.arguments[0].text)
+      ) {
+        found = true;
+        return;
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return found;
+}
+
+/**
  * #2657 — the source-import module string for js2wasm's raw linear-memory access
  * intrinsics (`store32`/`load32`/`store8`/`load8`). These are NOT WASI host
  * functions — they lower to inline `i32.store`/`i32.load`/`i32.store8`/
@@ -1353,13 +1400,40 @@ export async function compileMultiSource(
   for (const [name, content] of Object.entries(files)) {
     sourcesContent.set(name, content);
   }
+  // #2771 — detect WASI fd-IO surfaces across EVERY bundled file (entry + its
+  // relative `./*.ts` deps), not just the entry. The multi path resolves cross-
+  // file imports through the TS program and never runs `preprocessImports`, so
+  // before this it left `wasiNodeFsFuncs`/`wasiRawImports`/`wasiMemAccessors`
+  // undefined — a `node:fs` `readSync`/`writeSync` (or a raw
+  // `wasi_snapshot_preview1` fd call) living in a SHARED helper file silently
+  // lowered to a host `env.*` import (rejected by the WASI strict-no-host gate)
+  // instead of a WASI `fd_read`/`fd_write`. We union the same string scanners the
+  // single-source path uses (`detectNodeFsImports` / `detectRawWasiImports`) over
+  // the CJS-rewritten file map so codegen lowers those calls module-wide. The
+  // unions are empty for any program that imports none of these modules, so
+  // existing multi-file compiles stay byte-identical. (`nodeBuiltins`/`jsxRuntime`
+  // are a separate, larger preprocessImports-parity change — tracked alongside
+  // #2138.)
+  const wasiNodeFsFuncs = new Set<string>();
+  const wasiRawImports = new Set<string>();
+  const wasiMemAccessors = new Set<string>();
+  for (const content of Object.values(processedFiles)) {
+    for (const name of detectNodeFsImports(content)) wasiNodeFsFuncs.add(name);
+    const { rawWasi, memAccessors } = detectRawWasiImports(content);
+    for (const name of rawWasi) wasiRawImports.add(name);
+    for (const name of memAccessors) wasiMemAccessors.add(name);
+  }
   return applyOptimize(
     runPipeline({
       userSourceFiles: multiAst.sourceFiles,
       entryAst,
       multiAst,
       errors,
-      codegenOptions: buildCodegenOptions(options, emitSourceMap),
+      codegenOptions: buildCodegenOptions(options, emitSourceMap, {
+        wasiNodeFsFuncs,
+        wasiRawImports,
+        wasiMemAccessors,
+      }),
       sourcesContent,
       diagnosticAnchor: multiAst.entryFile,
       options,

--- a/src/index.ts
+++ b/src/index.ts
@@ -560,6 +560,7 @@ export function createIncrementalCompiler(defaultOptions?: CompileOptions): {
   };
 }
 
+export { entryHasRelativeImports } from "./compiler.js";
 export { getBarePackageName, ModuleResolver, resolveAllImports } from "./resolve.js";
 export { preloadLibFiles } from "./checker/index.js";
 export { getEntryExportNames, treeshake } from "./treeshake.js";

--- a/tests/issue-2771-relative-import-standalone-wasi.test.ts
+++ b/tests/issue-2771-relative-import-standalone-wasi.test.ts
@@ -1,0 +1,203 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2771 — a standalone WASI program whose ENTRY imports a local `./shared`
+ * helper, with the `node:fs` fd-IO seam split ACROSS the two files, must compile
+ * to a self-contained WASI command module importing ONLY `wasi_snapshot_preview1`
+ * (no `env.*` host imports) and echo byte-exact under wasmtime.
+ *
+ * Two blockers were fixed (both required — neither alone suffices):
+ *   (a) the single-source CLI `compile()` reads exactly ONE file and strips every
+ *       import, so `import { readExact } from "./shared"` was unresolved and
+ *       `readExact`/`writeAll` lowered to bogus `env.*` host imports the WASI gate
+ *       rejects. The CLI now routes an entry with a RELATIVE import to the
+ *       multi-file bundler `compileProject` (entryHasRelativeImports).
+ *   (b) the multi-file bundler `compileMultiSource` resolved relative imports but
+ *       NEVER ran node:fs / raw-WASI detection, so a `node:fs` `readSync`/
+ *       `writeSync` (even in the ENTRY) lowered to zero fd IO (imports = []). It
+ *       now unions `detectNodeFsImports`/`detectRawWasiImports` across every
+ *       bundled file so those calls lower to `fd_read`/`fd_write` module-wide.
+ *
+ * The runtime case requires REAL wasmtime and is skipped when it is not on PATH;
+ * the compile-only invariants always run.
+ */
+import { execFileSync, spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { compileProject, entryHasRelativeImports } from "../src/index.js";
+
+// wasmtime feature flags for the WasmGC + exception-handling binaries js2wasm emits.
+const WASMTIME_FLAGS = ["-W", "gc=y,function-references=y,exceptions=y"];
+
+function findWasmtime(): string | null {
+  for (const cand of ["wasmtime", "/usr/local/bin/wasmtime"]) {
+    try {
+      execFileSync(cand, ["--version"], { stdio: "ignore" });
+      return cand;
+    } catch {
+      /* try next */
+    }
+  }
+  return null;
+}
+const wasmtimeBin = findWasmtime();
+
+/** The (module) name of every import in a compiled WAT. */
+function importModules(wat: string): Set<string> {
+  const mods = new Set<string>();
+  for (const line of wat.split("\n")) {
+    const m = line.match(/\(import\s+"([^"]+)"/);
+    if (m) mods.add(m[1]!);
+  }
+  return mods;
+}
+
+/** Frame a body as a 4-byte LE length prefix + the body bytes (Native Messaging). */
+function frame(body: Uint8Array): Uint8Array {
+  const out = new Uint8Array(4 + body.length);
+  const n = body.length;
+  out[0] = n & 0xff;
+  out[1] = (n >> 8) & 0xff;
+  out[2] = (n >> 16) & 0xff;
+  out[3] = (n >> 24) & 0xff;
+  out.set(body, 4);
+  return out;
+}
+
+// The shared helper file — owns the node:fs fd-IO seam (read/write over fd 0/1).
+const SHARED_SRC = `import { readSync, writeSync } from "node:fs";
+
+export function readExact(buf: Uint8Array, n: number): boolean {
+  let got = 0;
+  while (got < n) {
+    const r = readSync(0, buf, { offset: got, length: n - got });
+    if (r <= 0) return false;
+    got = got + r;
+  }
+  return true;
+}
+
+export function writeAll(out: Uint8Array): void {
+  let n = 0;
+  while (n < out.length) {
+    const w = writeSync(1, out, n);
+    if (w <= 0) return;
+    n = n + w;
+  }
+}
+`;
+
+// The entry file — imports the local helper, does the framing, echoes verbatim.
+const ENTRY_SRC = `import { readExact, writeAll } from "./shared";
+
+export function main(): void {
+  const header = new Uint8Array(4);
+  while (true) {
+    if (!readExact(header, 4)) break;
+    const len = header[0] + header[1] * 256 + header[2] * 65536 + header[3] * 16777216;
+    if (len === 0) break;
+    const body = new Uint8Array(len);
+    if (!readExact(body, len)) break;
+    const out = new Uint8Array(4 + len);
+    out[0] = len & 0xff;
+    out[1] = (len >> 8) & 0xff;
+    out[2] = (len >> 16) & 0xff;
+    out[3] = (len >> 24) & 0xff;
+    let i = 0;
+    while (i < len) {
+      out[4 + i] = body[i];
+      i = i + 1;
+    }
+    writeAll(out);
+  }
+}
+
+main();
+`;
+
+interface RunResult {
+  stdout: Uint8Array;
+  exitCode: number | null;
+  timedOut: boolean;
+}
+
+function runWasmtimeStdin(binPath: string, input: Uint8Array, timeoutMs: number): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const child = spawn(wasmtimeBin!, [...WASMTIME_FLAGS, binPath], {
+      stdio: ["pipe", "pipe", "ignore"], // drop fd 2 diagnostics
+    });
+    const out: number[] = [];
+    child.stdout.on("data", (d: Buffer) => {
+      for (const b of d) out.push(b);
+    });
+    child.stdin.on("error", () => {});
+    let done = false;
+    const timer = setTimeout(() => {
+      if (done) return;
+      done = true;
+      child.kill("SIGKILL");
+      resolve({ stdout: Uint8Array.from(out), exitCode: null, timedOut: true });
+    }, timeoutMs);
+    child.on("exit", (code) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      resolve({ stdout: Uint8Array.from(out), exitCode: code, timedOut: false });
+    });
+    child.stdin.write(Buffer.from(input));
+    child.stdin.end(); // single frame then EOF
+  });
+}
+
+describe("#2771 — relative-import bundling for standalone WASI", () => {
+  let tmpDir: string;
+  let entryPath: string;
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "issue-2771-"));
+    writeFileSync(join(tmpDir, "shared.ts"), SHARED_SRC);
+    entryPath = join(tmpDir, "entry.ts");
+    writeFileSync(entryPath, ENTRY_SRC);
+  });
+  afterAll(() => {
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── routing predicate ────────────────────────────────────────────────────
+  it("entryHasRelativeImports distinguishes relative from node:/bare imports", () => {
+    expect(entryHasRelativeImports(ENTRY_SRC)).toBe(true);
+    expect(entryHasRelativeImports(SHARED_SRC)).toBe(false); // only node:fs
+    expect(entryHasRelativeImports(`import { x } from "lodash";`)).toBe(false);
+    expect(entryHasRelativeImports(`export { y } from "./m";`)).toBe(true);
+    expect(entryHasRelativeImports(`const m = require("../shared");`)).toBe(true);
+    expect(entryHasRelativeImports(`export function f() { return 1; }`)).toBe(false);
+  });
+
+  // ── compile-only invariants (always run, no runtime needed) ───────────────
+  it("a two-file standalone entry (node:fs IO in a shared helper) imports ONLY wasi_snapshot_preview1", async () => {
+    const r = await compileProject(entryPath, { target: "wasi", emitWat: true });
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+    expect(WebAssembly.validate(r.binary!), "binary must validate").toBe(true);
+    // The crux: NO `env.*` host import — only the WASI core module.
+    expect([...importModules(r.wat!)]).toEqual(["wasi_snapshot_preview1"]);
+    // And the fd syscalls the shared helper's readSync/writeSync lower to ARE present.
+    expect(r.wat!.includes("fd_read"), "shared-helper readSync must lower to fd_read").toBe(true);
+    expect(r.wat!.includes("fd_write"), "shared-helper writeSync must lower to fd_write").toBe(true);
+  });
+
+  // ── runtime behavior under real wasmtime (byte-exact echo) ─────────────────
+  const maybe = wasmtimeBin ? it : it.skip;
+  maybe("echoes a framed message byte-exact under wasmtime (fd_read/fd_write work)", { timeout: 30_000 }, async () => {
+    const r = await compileProject(entryPath, { target: "wasi" });
+    expect(r.success).toBe(true);
+    const binPath = join(tmpDir, "entry.wasm");
+    writeFileSync(binPath, r.binary!);
+
+    const body = new TextEncoder().encode('{"hello":"world","n":42}');
+    const input = frame(body);
+    const res = await runWasmtimeStdin(binPath, input, 20_000);
+    expect(res.timedOut, "must not hang").toBe(false);
+    // Echo: the program writes back the same 4-byte prefix + body it read.
+    expect(Buffer.from(res.stdout).equals(Buffer.from(input))).toBe(true);
+  });
+});


### PR DESCRIPTION
## #2771 — bundle relative imports for standalone WASI compilation

Compiler unblock for the #2756 native-messaging dedup: a standalone program whose **entry** imports a local `./shared` helper, with the `node:fs` fd-IO seam (`readSync`/`writeSync` over a `Uint8Array`) split across the two files, can now compile to a clean self-contained WASI command module.

### Two blockers — BOTH fixed (neither alone suffices)

**(a) CLI routing** (`src/cli.ts` + new `entryHasRelativeImports` in `src/compiler.ts`)
Single-source `compile()` reads exactly ONE file and strips every import, so a relative `./helper` import was unresolved → its bindings lowered to bogus `env.*` host imports the WASI strict-no-host gate rejects. The CLI now routes an entry with a relative static import / `require` to the multi-file bundler `compileProject`. Entries with **no** relative import (plain / `node:`-only / bare-package) stay on the single-source path → **byte-identical**.

**(b) node:fs / raw-WASI detection in the bundler** (`src/compiler.ts` `compileMultiSource`)
The multi path resolved relative imports but **never** ran `detectNodeFsImports` / `detectRawWasiImports`, so a `node:fs` `readSync`/`writeSync` (even in the entry) lowered to **zero fd IO** (`imports = []`). It now unions those string scanners across every bundled file and threads `wasiNodeFsFuncs` / `wasiRawImports` / `wasiMemAccessors` into `buildCodegenOptions`, so the calls lower to `fd_read`/`fd_write` module-wide. The unions are empty for any program that imports none of these modules → existing multi-file compiles stay byte-identical. (No `preprocessImports` strip in multi-mode — that would strip the cross-file relative imports; only the non-mutating scanners run.)

### Acceptance — verified
- Two-file standalone entry (`./shared` holds the `node:fs` IO) compiles under `--target wasi` to module imports = `wasi_snapshot_preview1` ONLY (no `env.*`), and echoes a framed message **byte-exact under wasmtime**. New `tests/issue-2771-relative-import-standalone-wasi.test.ts` (3 tests incl. the live wasmtime echo).
- **Byte-neutral** for existing single-file programs: `nm_js2wasm.ts` → sha256 `38a7a991…` / 60478 bytes on BOTH origin/main and this branch; a `runTest262File` control batch (language/expressions/addition) identical on both trees; lodash-es `partial.js` multi-file compile → byte-identical 305202-byte output on both trees.
- tsc + biome lint clean; prettier applied.

### Downstream
After #2756 (example renames) + this land, a follow-up re-applies the `nm_deno`/`nm_node_fs` shared-core dedup on top. Not part of #2771.

🤖 Generated with [Claude Code](https://claude.com/claude-code)