### PR TITLE
refactor(examples): #2778 share sync framing core for nm_deno + nm_node_fs (unblocked by #2771)

### DIFF
--- a/examples/native-messaging/nm_deno.ts
+++ b/examples/native-messaging/nm_deno.ts
@@ -70,10 +70,18 @@ function denoWrite(buf: Uint8Array): void {
   }
 }
 
+// No fd-2 telemetry in the verbatim variant (matches the pre-dedup nm_deno). The
+// verbatim path never invokes the diagnostics hook, so this is never called — it
+// exists only to satisfy the shared core's `log` parameter.
+function denoNoLog(declaredLen: number): void {
+  // intentionally empty; `declaredLen` is referenced so strict typecheck is happy
+  void declaredLen;
+}
+
 export function main(): void {
   // Verbatim echo: no browser re-chunk cap (maxFrameSize 0). Each framed message
   // is streamed back byte-for-byte until EOF / a zero-length shutdown frame.
-  runNmHost(denoRead, denoWrite, 0);
+  runNmHost(denoRead, denoWrite, denoNoLog, 0);
 }
 
 // Invoke the entry point. js2wasm compiles a top-level call into the module's

--- a/examples/native-messaging/nm_deno.ts
+++ b/examples/native-messaging/nm_deno.ts
@@ -19,115 +19,61 @@
 //
 //   Deno.stdin.readSync(p: Uint8Array): number | null   // bytes read, null @EOF
 //   Deno.stdout.writeSync(p: Uint8Array): number         // bytes written (fd 1)
-//   Deno.stderr.writeSync(p: Uint8Array): number         // bytes written (fd 2)
 //
-// `readSync` returns `null` at end-of-stream — the faithful EOF signal we use to
-// terminate the port loop. js2wasm lowers the `number | null` result to the
-// compiler's native nullable representation (no JS host needed), so `=== null`
-// works in the standalone module exactly as it does under real Deno.
+// `readSync` returns `null` at end-of-stream — the faithful EOF signal the shared
+// core uses to terminate the port loop. js2wasm lowers the `number | null` result
+// to the compiler's native nullable representation (no JS host needed), so
+// `=== null` works in the standalone module exactly as it does under real Deno.
 //
-// Contrast with the siblings:
-//   - `nm_node_fs.ts` uses Node's `node:fs` `readSync`/`writeSync(fd, …)` — also
-//     runs unmodified under real `node`.
-//   - `nm_wasi_p1.ts` imports `fd_read`/`fd_write` from `wasi_snapshot_preview1`
-//     directly (the rawest pure-WASI expression, no runtime API surface).
-// All three compile to the SAME pure-WASI-P1 shape; they differ only in which
-// runtime's source-level API they additionally run under, unmodified.
+// The Native Messaging FRAMING + verbatim streaming itself lives in the shared,
+// host-independent core `nm_sync_framing.ts` (#2778) — this file is just the thin
+// Deno adapter that injects `Deno.stdin.readSync` / `Deno.stdout.writeSync` into
+// the `runNmHost` seam and runs it with NO re-chunk cap (verbatim byte echo).
+// `nm_node_fs.ts` is the same core injected with `node:fs` IO and a 1 MiB cap;
+// `nm_wasi_p1.ts` is the raw `wasi_snapshot_preview1` `fd_read`/`fd_write` form.
+// All compile to the SAME pure-WASI-P1 shape; they differ only in which runtime's
+// source-level API they additionally run under, unmodified.
+//
+// The seam is two FUNCTION references (`denoRead` / `denoWrite`), not an object:
+// passing a struct value across the bundled-module boundary traps at runtime
+// under `--target wasi` today, while function references cross cleanly (#2778 —
+// see the note atop `nm_sync_framing.ts`).
 //
 // Native Messaging protocol: each message is a 4-byte little-endian length prefix
 // followed by a UTF-8 JSON body, exchanged over fd 0 (stdin) / fd 1 (stdout). See
 //   https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging
-//
-// This host echoes each framed message verbatim — prefix + body, byte-for-byte
-// (incl. high and null bytes). The body streams through a fixed-size window so
-// resident memory stays flat regardless of message size: it never holds the whole
-// body at once. Deno's `readSync`/`writeSync` fill/drain the WHOLE buffer passed
-// to them (no offset/length options), so each read/write run uses an exact-size
-// buffer.
 
-// 64 KiB streaming window — the largest body run read/written in one step.
-const WINDOW = 64 * 1024;
+import { runNmHost } from "./nm_sync_framing";
 
-// Read EXACTLY `n` bytes off stdin (fd 0) into a fresh `n`-byte buffer, looping
-// over short reads. Returns the buffer, or `null` at EOF / before `n` bytes
-// arrive. The first read fills the result buffer directly; a short read tops it
-// up via an exact-size temp (Deno fills the whole buffer it is handed, so we
-// cannot pass an offset — we copy the tail in instead).
-function readExact(n: number): Uint8Array | null {
-  const buf = new Uint8Array(n);
-  let got = 0;
-  while (got < n) {
-    if (got === 0) {
-      const r = Deno.stdin.readSync(buf);
-      if (r === null) return null; // EOF
-      got = got + r;
-    } else {
-      const tmp = new Uint8Array(n - got);
-      const r = Deno.stdin.readSync(tmp);
-      if (r === null) return null; // EOF mid-buffer
-      let i = 0;
-      while (i < r) {
-        buf[got + i] = tmp[i];
-        i = i + 1;
-      }
-      got = got + r;
-    }
-  }
-  return buf;
+// ONE Deno `readSync`: fills the whole buffer it is handed and returns the count,
+// or `null` at EOF (the core treats `null` / `<= 0` as EOF).
+function denoRead(buf: Uint8Array): number | null {
+  return Deno.stdin.readSync(buf);
 }
 
-// Write the WHOLE of `out` to stdout (fd 1), draining partial writes. Deno writes
-// the entire buffer it is handed and returns the count; on a partial write we
-// continue with an exact-size copy of the unwritten tail (no subarray).
-function writeFull(out: Uint8Array): void {
-  let buf = out;
-  while (buf.length > 0) {
-    const w = Deno.stdout.writeSync(buf);
+// Drain the WHOLE of `buf` to fd 1. Deno writes the entire buffer it is handed and
+// returns the count, so on a partial write we continue with an exact-size copy of
+// the unwritten tail (no subarray).
+function denoWrite(buf: Uint8Array): void {
+  let rest = buf;
+  while (rest.length > 0) {
+    const w = Deno.stdout.writeSync(rest);
     if (w <= 0) return; // error; nothing more we can do on this frame
-    if (w >= buf.length) return; // whole buffer written
-    const rest = new Uint8Array(buf.length - w);
+    if (w >= rest.length) return; // whole buffer written
+    const tail = new Uint8Array(rest.length - w);
     let i = 0;
-    while (i < rest.length) {
-      rest[i] = buf[w + i];
+    while (i < tail.length) {
+      tail[i] = rest[w + i];
       i = i + 1;
     }
-    buf = rest;
+    rest = tail;
   }
-}
-
-// Decode the little-endian uint32 the browser wrote as the first 4 bytes.
-function decodeLength(header: Uint8Array): number {
-  return header[0] + header[1] * 256 + header[2] * 65536 + header[3] * 16777216;
 }
 
 export function main(): void {
-  // Long-lived port loop: read framed messages off stdin and echo each one back
-  // on stdout until EOF. The body streams through the fixed window: a frame
-  // larger than the window is echoed in window-sized runs (the receiver
-  // concatenates the raw bytes, so prefix + body are byte-identical to the
-  // input).
-  while (true) {
-    // 4-byte LE length prefix. EOF (or a zero-length frame) = clean shutdown.
-    const header = readExact(4);
-    if (header === null) return;
-    const declaredLen = decodeLength(header);
-    if (declaredLen === 0) return;
-
-    // Echo the prefix back first.
-    writeFull(header);
-
-    // Stream the body through the window: read a run, write it straight back,
-    // repeat until the whole declared body is echoed.
-    let remaining = declaredLen;
-    while (remaining > 0) {
-      let run = WINDOW;
-      if (remaining < run) run = remaining;
-      const chunk = readExact(run);
-      if (chunk === null) return; // EOF mid-frame → stop
-      writeFull(chunk);
-      remaining = remaining - run;
-    }
-  }
+  // Verbatim echo: no browser re-chunk cap (maxFrameSize 0). Each framed message
+  // is streamed back byte-for-byte until EOF / a zero-length shutdown frame.
+  runNmHost(denoRead, denoWrite, 0);
 }
 
 // Invoke the entry point. js2wasm compiles a top-level call into the module's

--- a/examples/native-messaging/nm_node_fs.ts
+++ b/examples/native-messaging/nm_node_fs.ts
@@ -1,4 +1,5 @@
-// Native Messaging host, compiled to standalone WASI by js2wasm.
+// Native Messaging host, compiled to standalone WASI by js2wasm — the **node:fs**
+// synchronous-stdio variant.
 //
 //   npx js2wasm examples/native-messaging/nm_node_fs.ts --target wasi -o out
 //
@@ -11,20 +12,17 @@
 //
 // This source uses REAL Node fd-based synchronous IO — `fs.readSync(fd, …)` /
 // `fs.writeSync(fd, …)` from `node:fs` — so the SAME file ALSO runs UNMODIFIED
-// under real `node`. The earlier version used `process.stdin.read(buffer,
-// offset)`, which matches NO real Node API: `process.stdin` is an async Duplex
-// stream with no synchronous buffer-filling `read`. `fs.readSync` /
-// `fs.writeSync` are the faithful synchronous primitives (this is also what Javy
-// uses: `Javy.IO.readSync`).
+// under real `node`. `fs.readSync` / `fs.writeSync` are the faithful synchronous
+// primitives (this is also what Javy uses: `Javy.IO.readSync`). `readSync(0,…)` /
+// `writeSync(1,…)` are fd-based (integer fd 0=stdin, 1=stdout), NOT path-based —
+// no filesystem involved; under real node they call the real fs.
 //
 //   npx js2wasm examples/native-messaging/nm_node_fs.ts --target wasi --link-node-shims -o out
 //
 // is the VARIANT that lowers the same calls to imported `node:fs` shim calls
 // (`node-fs.wat`, which maps them to WASI fd_read / fd_write) — useful when the
 // same binary should link against an external `node:fs` provider rather than
-// owning the syscalls itself. Either way `readSync(0,…)` / `writeSync(1,…)` /
-// `writeSync(2,…)` are fd-based (integer fd 0=stdin, 1=stdout, 2=stderr), NOT
-// path-based — no filesystem involved; under real node they call the real fs.
+// owning the syscalls itself.
 //
 // Native Messaging protocol frames each message as a 4-byte little-endian length
 // prefix followed by a UTF-8 **JSON** body, exchanged over the host process's
@@ -43,291 +41,65 @@
 // whose elements, concatenated by the receiver, reproduce the original array.
 // A message that already fits in one frame is echoed verbatim.
 //
-// This host STREAMS the re-chunk through a single reused 1 MiB buffer: it never
-// holds the whole body, so resident memory stays flat (~a couple MiB) regardless
-// of message size or count. It also never calls `Uint8Array.prototype.subarray`
-// — under wasmtime that lowers to a native `array.copy` that is ~14x slower than
-// an element loop on i8 GC arrays — each frame is built with an element loop into
-// an exact-size buffer and written whole. Reads fill the buffer to its exact
-// capacity (or use an exact-size buffer for the final partial batch), so a read
-// can never pull bytes past the current message into the next one.
+// The Native Messaging FRAMING + browser-cap re-chunk streaming itself lives in
+// the shared, host-independent core `nm_sync_framing.ts` (#2778) — this file is
+// just the thin node:fs adapter that injects `readSync(0,…)` / `writeSync(1,…)`
+// into the `runNmHost` seam and runs it with a **1 MiB re-chunk cap** (the
+// browser per-host->extension-message limit). The re-chunk is this variant's
+// deliberate demo: a body > 1 MiB streams back through a single reused 1 MiB
+// buffer as a sequence of valid <=1 MiB JSON frames, so resident memory stays
+// flat (~a couple MiB) regardless of message size. `nm_deno.ts` injects Deno
+// stdio with NO cap (verbatim echo) into the SAME core.
 //
-// js2wasm support today:
+// The seam is two FUNCTION references (`nodeFsRead` / `nodeFsWrite`), not an
+// object: passing a struct value across the bundled-module boundary traps at
+// runtime under `--target wasi` today, while function references cross cleanly
+// (#2778 — see the note atop `nm_sync_framing.ts`).
+//
+// js2wasm support today (#2631):
 //   - stdin  : readSync(0, buf, { offset, length }) does one binary, incremental
-//              fd=0 read into the caller's typed buffer, returning the byte count
-//              (#2631). A read-until loop assembles exactly N. `length` is always
-//              passed as the remaining-to-target count so a read can never pull
-//              bytes past the current message into the next.
+//              fd=0 read into the caller's typed buffer, returning the byte count.
 //   - stdout : writeSync(1, bytes, off) writes raw bytes to fd=1 with NO trailing
-//              newline; the partial-write loop drains the whole buffer (#2631).
-//   - stderr : writeSync(2, bytes, …) writes to fd=2, off the protocol stream.
+//              newline; the partial-write loop drains the whole buffer.
 
 import { readSync, writeSync } from "node:fs";
+import { runNmHost } from "./nm_sync_framing";
 
-// Largest body browser Native Messaging implementation accepts in one host->extension message, and the size of
-// the single scratch buffer the whole stream flows through.
-const FRAME_CHUNK = 1024 * 1024;
-const MAX_RUN = FRAME_CHUNK - 2; // leave room for the framing `[` and `]` (or the two `"`)
-const COMMA = 44; // ,
-const OPEN_BRACKET = 91; // [
-const CLOSE_BRACKET = 93; // ]
-const DQUOTE = 34; // "
-
-// Read exactly `n` bytes into buf[0..n). Over-read-safe only when buf.length
-// === n (the read can't exceed the buffer; caller guarantees the stream has at
-// least `n` bytes left for this message). `length` is the remaining-to-target
-// count, so a single read never pulls bytes past `n`.
-/** @param {Uint8Array} buf @param {number} n @returns {boolean} */
-function readExact(buf: Uint8Array, n: number): boolean {
-  let got = 0;
-  while (got < n) {
-    const r = readSync(0, buf, { offset: got, length: n - got });
-    if (r <= 0) return false; // EOF or error
-    got = got + r;
-  }
-  return true;
+// ONE incremental fd=0 read filling the WHOLE buffer it is handed (offset 0,
+// length = buf.length); returns the byte count (0 at EOF — the core treats
+// `<= 0` as EOF).
+function nodeFsRead(buf: Uint8Array): number | null {
+  return readSync(0, buf, { offset: 0, length: buf.length });
 }
 
-// Read exactly `n` bytes into buf[start..start+n). Over-read-safe: `length` is
-// always `n - got`, so a single read can never pull bytes past `start+n` (and
-// thus never into the next message).
-/** @param {Uint8Array} buf @param {number} start @param {number} n @returns {boolean} */
-function readAt(buf: Uint8Array, start: number, n: number): boolean {
-  let got = 0;
-  while (got < n) {
-    const r = readSync(0, buf, { offset: start + got, length: n - got });
-    if (r <= 0) return false;
-    got = got + r;
-  }
-  return true;
-}
-
-// Write the whole buffer to stdout (fd=1), looping on partial writes. The
-// offset form writes from `out[n..]`; `writeSync` returns the byte count.
-/** @param {Uint8Array} out */
-function writeAll(out: Uint8Array): void {
+// Drain the WHOLE of `buf` to fd 1; the offset form writes from `buf[n..]`.
+function nodeFsWrite(buf: Uint8Array): void {
   let n = 0;
-  while (n < out.length) {
-    const w = writeSync(1, out, n);
+  while (n < buf.length) {
+    const w = writeSync(1, buf, n);
     if (w <= 0) return; // error; nothing more we can do on this frame
     n = n + w;
   }
 }
 
-// Decode the little-endian uint32 length browser wrote as the first 4 bytes.
-/** @param {Uint8Array} header @returns {number} */
-function decodeLength(header: Uint8Array): number {
-  return header[0] + header[1] * 256 + header[2] * 65536 + header[3] * 16777216;
-}
-
-// Debug telemetry to stderr (fd=2) so it never pollutes the stdout protocol
-// stream. Encode the message to bytes and writeSync(2, …). The reporter noted
-// stderr was the one part that didn't work in his hand-port — this makes it work.
-/** @param {number} declaredLen */
-function logFrameBodyRead(declaredLen: number): void {
-  const msg = `[host] received ${4 + declaredLen} chars, declared body length ${declaredLen}\n`;
-  // Encode the ASCII/UTF-8 message to bytes (the telemetry is ASCII-only).
-  const bytes = new Uint8Array(msg.length);
-  let i = 0;
-  while (i < msg.length) {
-    bytes[i] = msg.charCodeAt(i);
-    i = i + 1;
-  }
-  let n = 0;
-  while (n < bytes.length) {
-    const w = writeSync(2, bytes, n);
-    if (w <= 0) return;
-    n = n + w;
-  }
-}
-
-// Emit one frame: `[` + src[start..start+runLen) + `]`, built whole with an
-// element loop and written in one go (no subarray / no array.copy).
-/** @param {Uint8Array} src @param {number} start @param {number} runLen */
-function emitRun(src: Uint8Array, start: number, runLen: number): void {
-  // #2526: build the 4-byte LE length prefix + `[run]` body in ONE buffer and
-  // write it with a SINGLE writeAll (one fd_write). Writing the prefix and body
-  // as separate writes lets a streaming receiver misalign on pipe-chunk
-  // boundaries — loopdive/js2#389 (ComponentizeJS works because it frames
-  // atomically; we did not).
-  const bodyLen = runLen + 2; // `[` + run + `]`
-  const out = new Uint8Array(4 + bodyLen);
-  out[0] = bodyLen & 0xff;
-  out[1] = (bodyLen >> 8) & 0xff;
-  out[2] = (bodyLen >> 16) & 0xff;
-  out[3] = (bodyLen >> 24) & 0xff;
-  out[4] = OPEN_BRACKET;
-  let k = 0;
-  while (k < runLen) {
-    out[5 + k] = src[start + k];
-    k = k + 1;
-  }
-  out[4 + runLen + 1] = CLOSE_BRACKET;
-  writeAll(out);
-}
-
-// Emit one JSON-STRING frame: `"` + src[start..start+runLen) + `"`, built whole
-// and written atomically. Used to re-chunk a single >1 MiB JSON string body
-// (`"aaaa…"`) into a sequence of valid <=1 MiB JSON string frames. The receiver
-// concatenates the interiors to reproduce the original string. (The element loop
-// must not split a `\`-escape across frames; for the reported workload the body
-// is plain printable characters, so a fixed MAX_RUN split is valid.)
-/** @param {Uint8Array} src @param {number} start @param {number} runLen */
-function emitStringRun(src: Uint8Array, start: number, runLen: number): void {
-  const bodyLen = runLen + 2; // `"` + run + `"`
-  const out = new Uint8Array(4 + bodyLen);
-  out[0] = bodyLen & 0xff;
-  out[1] = (bodyLen >> 8) & 0xff;
-  out[2] = (bodyLen >> 16) & 0xff;
-  out[3] = (bodyLen >> 24) & 0xff;
-  out[4] = DQUOTE;
-  let k = 0;
-  while (k < runLen) {
-    out[5 + k] = src[start + k];
-    k = k + 1;
-  }
-  out[4 + runLen + 1] = DQUOTE;
-  writeAll(out);
-}
-
-// Stream a single large JSON string body `"chars…"` into valid <=1 MiB `"run"`
-// frames. The leading `"` has already been consumed; `interiorRemaining` counts
-// the interior characters (declaredLen - 2), and the trailing `"` is read last.
-// Returns false on EOF mid-frame. A fixed MAX_RUN split keeps each frame within
-// the cap (no comma boundaries to honor, unlike the array path).
-/** @param {Uint8Array} buf @param {number} interiorRemaining @returns {boolean} */
-function streamLargeString(buf: Uint8Array, interiorRemaining: number): boolean {
-  let remaining = interiorRemaining;
-  while (remaining > 0) {
-    let runLen = MAX_RUN;
-    if (remaining < runLen) runLen = remaining;
-    if (!readAt(buf, 0, runLen)) return false;
-    emitStringRun(buf, 0, runLen);
-    remaining = remaining - runLen;
-  }
-  return true;
-}
-
 export function main(): void {
-  // Long-lived port loop: read framed JSON messages off stdin until EOF and
-  // echo each one back as valid JSON within the browser 1 MiB per-message cap.
-  const header = new Uint8Array(4);
-  const one = new Uint8Array(1);
-  const buf = new Uint8Array(FRAME_CHUNK); // reused read/window buffer
-
-  while (true) {
-    // 4-byte LE length prefix. EOF (or a zero-length frame) = clean shutdown.
-    if (!readExact(header, 4)) break;
-    const declaredLen = decodeLength(header);
-    if (declaredLen === 0) break;
-    logFrameBodyRead(declaredLen);
-
-    if (declaredLen <= FRAME_CHUNK) {
-      // Already a single valid JSON message within the cap — echo verbatim.
-      // #2526: prefix + body in ONE buffer, ONE writeAll (one fd_write). Read
-      // the body straight into the buffer at offset 4.
-      const out = new Uint8Array(4 + declaredLen);
-      out[0] = declaredLen & 0xff;
-      out[1] = (declaredLen >> 8) & 0xff;
-      out[2] = (declaredLen >> 16) & 0xff;
-      out[3] = (declaredLen >> 24) & 0xff;
-      if (!readAt(out, 4, declaredLen)) break;
-      writeAll(out);
-      continue;
-    }
-
-    // Large body > 1 MiB. Peek the first byte to pick the re-chunk shape:
-    //   `"` → a single large JSON string  → `"run"` frames (streamLargeString);
-    //   `[` → a large JSON array          → `[run]` frames (below).
-    if (!readExact(one, 1)) break; // the opening `"` or `[`
-    if (one[0] === DQUOTE) {
-      // Large JSON string: interior = declaredLen - 2 (excludes the two `"`).
-      if (!streamLargeString(buf, declaredLen - 2)) break; // EOF mid-frame
-      if (!readExact(one, 1)) break; // the trailing `"`
-      continue;
-    }
-
-    // Large JSON array `[elem,...,elem]`: stream the interior, emitting valid
-    // `[run]` frames. The leading `[` is already consumed; the trailing `]` is
-    // read last.
-    let interiorRemaining = declaredLen - 2; // interior bytes (excludes `[` and `]`)
-    let fill = 0; // carry bytes held at buf[0..fill) (a partial element, no comma)
-    let truncated = false;
-
-    while (interiorRemaining > 0) {
-      const need = FRAME_CHUNK - fill; // fill the buffer exactly (over-read-safe)
-      if (interiorRemaining >= need) {
-        if (!readAt(buf, fill, need)) {
-          truncated = true;
-          break;
-        }
-        fill = FRAME_CHUNK;
-        interiorRemaining = interiorRemaining - need;
-        // Emit one frame up to the last comma within [0, MAX_RUN); carry the rest.
-        let last = MAX_RUN;
-        while (last > 0 && buf[last - 1] !== COMMA) last = last - 1;
-        let runLen: number;
-        let consumed: number;
-        if (last === 0) {
-          // No comma in [0, MAX_RUN): a single element exceeds the cap — emit
-          // MAX_RUN raw (degenerate; only for elements > ~1 MiB).
-          runLen = MAX_RUN;
-          consumed = MAX_RUN;
-        } else {
-          runLen = last - 1; // exclude the comma at last-1
-          consumed = last; // skip the comma too
-        }
-        emitRun(buf, 0, runLen);
-        // Shift the leftover buf[consumed..fill) to the front (small for typical
-        // element sizes — one element plus the 2 cap bytes).
-        const rem = fill - consumed;
-        let m = 0;
-        while (m < rem) {
-          buf[m] = buf[consumed + m];
-          m = m + 1;
-        }
-        fill = rem;
-      } else {
-        // Final interior batch: read exactly interiorRemaining (exact-size temp,
-        // over-read-safe), append to the carry, then drain to frames.
-        const tmp = new Uint8Array(interiorRemaining);
-        if (!readExact(tmp, interiorRemaining)) {
-          truncated = true;
-          break;
-        }
-        let t = 0;
-        while (t < interiorRemaining) {
-          buf[fill + t] = tmp[t];
-          t = t + 1;
-        }
-        fill = fill + interiorRemaining;
-        interiorRemaining = 0;
-        // Drain buf[0..fill) into <=MAX_RUN frames at comma boundaries; the last
-        // frame ends exactly at fill (the array has no trailing comma).
-        let startPos = 0;
-        while (startPos < fill) {
-          let stop = startPos + MAX_RUN;
-          if (stop >= fill) {
-            stop = fill;
-          } else {
-            let c = stop;
-            while (c > startPos && buf[c - 1] !== COMMA) c = c - 1;
-            if (c > startPos) stop = c - 1;
-          }
-          emitRun(buf, startPos, stop - startPos);
-          startPos = stop;
-          if (startPos < fill && buf[startPos] === COMMA) startPos = startPos + 1;
-        }
-        fill = 0;
-      }
-    }
-    if (truncated) break; // EOF mid-frame → stop
-    if (!readExact(one, 1)) break; // the trailing `]`
-  }
+  // Largest body the browser Native Messaging implementation accepts in one
+  // host->extension message, and the size of the single scratch buffer the whole
+  // stream flows through — passed as the shared core's re-chunk cap.
+  //
+  // Kept a LOCAL const (not a module-level one) on purpose: a module-level const
+  // lowers to a Wasm GLOBAL, and passing that global as the cap argument across
+  // the bundled-module call into the shared core mis-lowers under `--target wasi`
+  // → a runtime fault (a clean compile, but a fault) — the same class of node:fs
+  // multi-file index-shift gap noted in `nm_sync_framing.ts` (#2778). A local
+  // const (or an inline literal) compiles to a plain `i32.const` operand and is
+  // unaffected.
+  const frameChunk = 1024 * 1024;
+  // Re-chunk bodies larger than the browser 1 MiB cap into valid <=1 MiB JSON
+  // frames; smaller bodies echo verbatim. Streams to EOF / a zero-length frame.
+  runNmHost(nodeFsRead, nodeFsWrite, frameChunk);
 }
 
 // Invoke the entry point. js2wasm compiles a top-level call into the module's
-// `_start`, and under real `node` this runs the host loop directly. (The
-// reporter noted the earlier bundled output never called main — this makes the
-// entry explicit.)
+// `_start`, and under real `node` this runs the host loop directly.
 main();

--- a/examples/native-messaging/nm_node_fs.ts
+++ b/examples/native-messaging/nm_node_fs.ts
@@ -82,6 +82,71 @@ function nodeFsWrite(buf: Uint8Array): void {
   }
 }
 
+// Copy the ASCII bytes of a literal `s` into `out` at `pos`; return the new pos.
+function putAscii(out: Uint8Array, pos: number, s: string): number {
+  let i = 0;
+  while (i < s.length) {
+    out[pos + i] = s.charCodeAt(i);
+    i = i + 1;
+  }
+  return pos + s.length;
+}
+
+// Write the decimal ASCII of a non-negative integer `value` into `out` at `pos`;
+// return the new pos. Hand-rolled (no `Number.prototype.toString`): the number→
+// string path (`number_toString_radix`) mis-compiles to invalid Wasm when this
+// file is bundled with the shared core under `--target wasi` — the same node:fs
+// multi-file gap as the seam/cap shapes (#2778 / #2779). Plain f64 arithmetic
+// (`% 10`, `(v - v%10)/10`) is unaffected.
+function putUint(out: Uint8Array, pos: number, value: number): number {
+  if (value === 0) {
+    out[pos] = 48; // '0'
+    return pos + 1;
+  }
+  let digits = 0;
+  let n = value;
+  while (n > 0) {
+    digits = digits + 1;
+    n = (n - (n % 10)) / 10;
+  }
+  let v = value;
+  let i = digits - 1;
+  while (i >= 0) {
+    out[pos + i] = 48 + (v % 10);
+    v = (v - (v % 10)) / 10;
+    i = i - 1;
+  }
+  return pos + digits;
+}
+
+// Debug telemetry to stderr (fd=2) so it never pollutes the stdout protocol
+// stream — one line per input message. The reporter (loopdive/js2#389) noted
+// stderr was the one part that didn't work in his hand-port; this makes it work,
+// and the real-wasmtime smoke test pins the exact line (off-by-one guard).
+function nodeFsLog(declaredLen: number): void {
+  const scratch = new Uint8Array(96); // ample for the fixed text + two integers
+  let p = 0;
+  p = putAscii(scratch, p, "[host] received ");
+  p = putUint(scratch, p, 4 + declaredLen); // total chars on the wire (prefix + body)
+  p = putAscii(scratch, p, " chars, declared body length ");
+  p = putUint(scratch, p, declaredLen);
+  scratch[p] = 10; // '\n'
+  p = p + 1;
+  // Write exactly `p` bytes (writeSync drains buf.length - offset, so size to fit).
+  const bytes = new Uint8Array(p);
+  let k = 0;
+  while (k < p) {
+    bytes[k] = scratch[k];
+    k = k + 1;
+  }
+  let m = 0;
+  while (m < bytes.length) {
+    const w = writeSync(2, bytes, m);
+    if (w <= 0) return;
+    m = m + w;
+  }
+}
+
 export function main(): void {
   // Largest body the browser Native Messaging implementation accepts in one
   // host->extension message, and the size of the single scratch buffer the whole
@@ -97,7 +162,7 @@ export function main(): void {
   const frameChunk = 1024 * 1024;
   // Re-chunk bodies larger than the browser 1 MiB cap into valid <=1 MiB JSON
   // frames; smaller bodies echo verbatim. Streams to EOF / a zero-length frame.
-  runNmHost(nodeFsRead, nodeFsWrite, frameChunk);
+  runNmHost(nodeFsRead, nodeFsWrite, nodeFsLog, frameChunk);
 }
 
 // Invoke the entry point. js2wasm compiles a top-level call into the module's

--- a/examples/native-messaging/nm_sync_framing.ts
+++ b/examples/native-messaging/nm_sync_framing.ts
@@ -48,6 +48,15 @@ export type NmRead = (buf: Uint8Array) => number | null;
 /** Write the WHOLE of `buf` to fd 1, draining any partial writes internally. */
 export type NmWrite = (buf: Uint8Array) => void;
 
+/**
+ * Per-frame diagnostics hook (fd 2 telemetry), called once per INPUT message in
+ * the re-chunk path with its declared body length. Kept a callback (not string
+ * work in this host-independent core) so the adapter owns the message text + its
+ * fd-2 writer; the verbatim path never calls it (it emits no telemetry, matching
+ * the pre-dedup nm_deno). A no-op is a valid implementation.
+ */
+export type NmLog = (declaredLen: number) => void;
+
 // 64 KiB streaming window for the verbatim path — the largest body run read /
 // written in one step (invisible to the receiver, which concatenates raw bytes).
 const VERBATIM_WINDOW = 64 * 1024;
@@ -192,7 +201,7 @@ function runVerbatim(read: NmRead, write: NmWrite): void {
 // each one back as valid JSON within the browser `cap`-byte per-message cap. A
 // body that already fits is echoed verbatim; a larger array/string body is split
 // into valid <=cap frames. Streams through a single reused `cap` buffer.
-function runRechunk(read: NmRead, write: NmWrite, cap: number): void {
+function runRechunk(read: NmRead, write: NmWrite, log: NmLog, cap: number): void {
   const maxRun = cap - 2; // leave room for the framing `[`/`]` (or the two `"`)
   const header = new Uint8Array(4);
   const one = new Uint8Array(1);
@@ -203,6 +212,7 @@ function runRechunk(read: NmRead, write: NmWrite, cap: number): void {
     if (!readFillExact(read, header, 0, 4)) break;
     const declaredLen = decodeLength(header);
     if (declaredLen === 0) break;
+    log(declaredLen); // fd-2 telemetry (one line per input message)
 
     if (declaredLen <= cap) {
       // Already a single valid JSON message within the cap — echo verbatim.
@@ -315,13 +325,15 @@ function runRechunk(read: NmRead, write: NmWrite, cap: number): void {
  *                     `<= 0` at EOF. MUST be a standalone function reference (see
  *                     the cross-module-funcref note at the top of this file).
  * @param write        one host `writeSync` (fd 1); writes the whole buffer.
+ * @param log          per-frame fd-2 telemetry hook (re-chunk path only); pass a
+ *                     no-op when the host emits no diagnostics (e.g. nm_deno).
  * @param maxFrameSize `<= 0` → verbatim echo (no cap); `> 0` → re-chunk bodies
  *                     larger than this many bytes into valid <=`maxFrameSize`
  *                     JSON frames (the browser per-message cap).
  */
-export function runNmHost(read: NmRead, write: NmWrite, maxFrameSize: number): void {
+export function runNmHost(read: NmRead, write: NmWrite, log: NmLog, maxFrameSize: number): void {
   if (maxFrameSize > 0) {
-    runRechunk(read, write, maxFrameSize);
+    runRechunk(read, write, log, maxFrameSize);
   } else {
     runVerbatim(read, write);
   }

--- a/examples/native-messaging/nm_sync_framing.ts
+++ b/examples/native-messaging/nm_sync_framing.ts
@@ -1,0 +1,328 @@
+// Shared, host-INDEPENDENT Native Messaging synchronous framing/streaming core
+// (#2778). Both `nm_deno.ts` (Deno `readSync`/`writeSync`) and `nm_node_fs.ts`
+// (`node:fs` `readSync`/`writeSync`) are now THIN adapters that inject their
+// host's synchronous stdio into the `runNmHost` seam below and call into this one
+// core. This file has ZERO host API surface — it touches `Uint8Array` only, so it
+// compiles to the SAME pure-WASI-Preview-1 shape regardless of which host adapter
+// pulls it in (unblocked by #2771's relative-import bundling for standalone WASI).
+//
+// THE INJECTION SEAM IS TWO FUNCTION REFERENCES, NOT AN OBJECT (#2778). Passing
+// an interface/struct VALUE across the bundled-module boundary currently traps at
+// runtime under `--target wasi` (the relative-import bundler does not unify the
+// struct's type identity across files, so the cross-file `call_ref` / field read
+// faults — a clean compile, but a runtime fault; see the issue file for the
+// minimal repro). Passing standalone FUNCTION references across the boundary
+// works. So the host adapter injects two named functions — `read` and `write` —
+// rather than an `{ read, write }` object. (Follow-up: once the bundler unifies
+// cross-file nominal struct types, this can become the originally-specified
+// `NmHostIo` object seam.)
+//
+// Native Messaging protocol: each message is a 4-byte little-endian length prefix
+// followed by a UTF-8 (JSON) body, exchanged over fd 0 (stdin) / fd 1 (stdout).
+//   https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging
+//
+// Two framing modes, selected by `maxFrameSize`:
+//
+//   - `maxFrameSize <= 0` → VERBATIM streamer (the `nm_deno` demo): each framed
+//     message is echoed back byte-for-byte (prefix + body), streamed through a
+//     fixed window so resident memory stays flat regardless of body size.
+//
+//   - `maxFrameSize > 0`  → browser-cap RE-CHUNK streamer (the `nm_node_fs`
+//     demo): a body LARGER than the cap is split into a sequence of valid
+//     `<=maxFrameSize` JSON frames (`[run]` for an array body, `"run"` for a
+//     string body) whose interiors, concatenated by the receiver, reproduce the
+//     original body. A body that already fits in one frame is echoed verbatim.
+//     The re-chunk streams through a single reused `maxFrameSize` buffer.
+//
+// The `read` seam does ONE syscall per call; the read-until-N loops live here in
+// the core. EOF is signalled by `read` returning `null` or `<= 0`; a zero-length
+// frame (declared length 0) is the protocol's clean-shutdown signal.
+
+/**
+ * Read up to `buf.length` bytes into `buf` in ONE syscall. Returns the number of
+ * bytes read, or `null` / `<= 0` at end-of-stream. (Deno's `readSync` returns
+ * `null` at EOF; `node:fs` `readSync` returns `0` — the core treats both as EOF.)
+ */
+export type NmRead = (buf: Uint8Array) => number | null;
+
+/** Write the WHOLE of `buf` to fd 1, draining any partial writes internally. */
+export type NmWrite = (buf: Uint8Array) => void;
+
+// 64 KiB streaming window for the verbatim path — the largest body run read /
+// written in one step (invisible to the receiver, which concatenates raw bytes).
+const VERBATIM_WINDOW = 64 * 1024;
+
+const COMMA = 44; // ,
+const OPEN_BRACKET = 91; // [
+const CLOSE_BRACKET = 93; // ]
+const DQUOTE = 34; // "
+
+// Decode the little-endian uint32 the browser wrote as the first 4 bytes.
+function decodeLength(header: Uint8Array): number {
+  return header[0] + header[1] * 256 + header[2] * 65536 + header[3] * 16777216;
+}
+
+// Read EXACTLY `n` bytes into `buf[start..start+n)`, looping over short reads.
+// Over-read-safe: each syscall reads into an exact-size temp of `n - got`, so a
+// single read can never pull bytes past `start+n` (and thus never into the next
+// message). Returns false on EOF / error mid-fill.
+function readFillExact(read: NmRead, buf: Uint8Array, start: number, n: number): boolean {
+  let got = 0;
+  while (got < n) {
+    const tmp = new Uint8Array(n - got);
+    const r = read(tmp);
+    if (r === null || r <= 0) return false; // EOF or error
+    let i = 0;
+    while (i < r) {
+      buf[start + got + i] = tmp[i];
+      i = i + 1;
+    }
+    got = got + r;
+  }
+  return true;
+}
+
+// Emit one array frame: 4-byte LE length prefix + `[` + src[start..start+runLen)
+// + `]`, built whole with an element loop and written in ONE `write` (one
+// fd_write). #2526: prefix + body share one buffer so a streaming receiver never
+// misaligns on a pipe-chunk boundary (loopdive/js2#389). No subarray / no
+// `array.copy` — under wasmtime that is ~14x slower than an element loop on i8 GC
+// arrays.
+function emitRun(write: NmWrite, src: Uint8Array, start: number, runLen: number): void {
+  const bodyLen = runLen + 2; // `[` + run + `]`
+  const out = new Uint8Array(4 + bodyLen);
+  out[0] = bodyLen & 0xff;
+  out[1] = (bodyLen >> 8) & 0xff;
+  out[2] = (bodyLen >> 16) & 0xff;
+  out[3] = (bodyLen >> 24) & 0xff;
+  out[4] = OPEN_BRACKET;
+  let k = 0;
+  while (k < runLen) {
+    out[5 + k] = src[start + k];
+    k = k + 1;
+  }
+  out[4 + runLen + 1] = CLOSE_BRACKET;
+  write(out);
+}
+
+// Emit one JSON-STRING frame: prefix + `"` + src[start..start+runLen) + `"`,
+// built whole and written atomically. Re-chunks a single >cap JSON string body
+// (`"aaaa…"`) into valid <=cap string frames; the receiver concatenates the
+// interiors to reproduce the original string. (The element loop must not split a
+// `\`-escape across frames; for the reported workload the body is plain printable
+// characters, so a fixed-run split is valid.)
+function emitStringRun(write: NmWrite, src: Uint8Array, start: number, runLen: number): void {
+  const bodyLen = runLen + 2; // `"` + run + `"`
+  const out = new Uint8Array(4 + bodyLen);
+  out[0] = bodyLen & 0xff;
+  out[1] = (bodyLen >> 8) & 0xff;
+  out[2] = (bodyLen >> 16) & 0xff;
+  out[3] = (bodyLen >> 24) & 0xff;
+  out[4] = DQUOTE;
+  let k = 0;
+  while (k < runLen) {
+    out[5 + k] = src[start + k];
+    k = k + 1;
+  }
+  out[4 + runLen + 1] = DQUOTE;
+  write(out);
+}
+
+// Stream a single large JSON string body `"chars…"` into valid <=cap `"run"`
+// frames. The leading `"` has already been consumed; `interiorRemaining` counts
+// the interior characters (declaredLen - 2), and the trailing `"` is read by the
+// caller. Returns false on EOF mid-frame. A fixed `maxRun` split keeps each frame
+// within the cap (no comma boundaries to honor, unlike the array path).
+function streamLargeString(
+  read: NmRead,
+  write: NmWrite,
+  buf: Uint8Array,
+  interiorRemaining: number,
+  maxRun: number,
+): boolean {
+  let remaining = interiorRemaining;
+  while (remaining > 0) {
+    let runLen = maxRun;
+    if (remaining < runLen) runLen = remaining;
+    if (!readFillExact(read, buf, 0, runLen)) return false;
+    emitStringRun(write, buf, 0, runLen);
+    remaining = remaining - runLen;
+  }
+  return true;
+}
+
+// VERBATIM port loop (the `nm_deno` demo): read framed messages and echo each one
+// back byte-for-byte until EOF. The body streams through a fixed window; a frame
+// larger than the window is echoed in window-sized runs (the receiver
+// concatenates raw bytes, so prefix + body are byte-identical to the input).
+//
+// Reads fill exact-size fresh buffers via `readFillExact` (the same boolean-EOF
+// helper the re-chunk path uses) rather than a `Uint8Array | null`-returning
+// reader — a shared helper that returns a nullable reference type currently mis-
+// lowers when this module is bundled into a `node:fs` entry under `--target wasi`
+// (a cross-file function-index shift from the node:fs shim insertion; #2778),
+// even though the verbatim path itself never runs in the node:fs variant. Keeping
+// every shared reader on the `boolean` form sidesteps that gap for BOTH adapters.
+function runVerbatim(read: NmRead, write: NmWrite): void {
+  const header = new Uint8Array(4);
+  while (true) {
+    // 4-byte LE length prefix. EOF (or a zero-length frame) = clean shutdown.
+    if (!readFillExact(read, header, 0, 4)) return;
+    const declaredLen = decodeLength(header);
+    if (declaredLen === 0) return;
+
+    // Echo the prefix back first (synchronous write — safe to reuse `header`).
+    write(header);
+
+    // Stream the body through the window: read a run, write it straight back,
+    // repeat until the whole declared body is echoed.
+    let remaining = declaredLen;
+    while (remaining > 0) {
+      let run = VERBATIM_WINDOW;
+      if (remaining < run) run = remaining;
+      const chunk = new Uint8Array(run);
+      if (!readFillExact(read, chunk, 0, run)) return; // EOF mid-frame → stop
+      write(chunk);
+      remaining = remaining - run;
+    }
+  }
+}
+
+// RE-CHUNK port loop (the `nm_node_fs` demo): read framed JSON messages and echo
+// each one back as valid JSON within the browser `cap`-byte per-message cap. A
+// body that already fits is echoed verbatim; a larger array/string body is split
+// into valid <=cap frames. Streams through a single reused `cap` buffer.
+function runRechunk(read: NmRead, write: NmWrite, cap: number): void {
+  const maxRun = cap - 2; // leave room for the framing `[`/`]` (or the two `"`)
+  const header = new Uint8Array(4);
+  const one = new Uint8Array(1);
+  const buf = new Uint8Array(cap); // reused read/window buffer
+
+  while (true) {
+    // 4-byte LE length prefix. EOF (or a zero-length frame) = clean shutdown.
+    if (!readFillExact(read, header, 0, 4)) break;
+    const declaredLen = decodeLength(header);
+    if (declaredLen === 0) break;
+
+    if (declaredLen <= cap) {
+      // Already a single valid JSON message within the cap — echo verbatim.
+      // #2526: prefix + body in ONE buffer, ONE write. Read the body straight
+      // into the buffer at offset 4.
+      const out = new Uint8Array(4 + declaredLen);
+      out[0] = declaredLen & 0xff;
+      out[1] = (declaredLen >> 8) & 0xff;
+      out[2] = (declaredLen >> 16) & 0xff;
+      out[3] = (declaredLen >> 24) & 0xff;
+      if (!readFillExact(read, out, 4, declaredLen)) break;
+      write(out);
+      continue;
+    }
+
+    // Large body > cap. Peek the first byte to pick the re-chunk shape:
+    //   `"` → a single large JSON string → `"run"` frames (streamLargeString);
+    //   `[` → a large JSON array         → `[run]` frames (below).
+    if (!readFillExact(read, one, 0, 1)) break; // the opening `"` or `[`
+    if (one[0] === DQUOTE) {
+      // Large JSON string: interior = declaredLen - 2 (excludes the two `"`).
+      if (!streamLargeString(read, write, buf, declaredLen - 2, maxRun)) break; // EOF mid-frame
+      if (!readFillExact(read, one, 0, 1)) break; // the trailing `"`
+      continue;
+    }
+
+    // Large JSON array `[elem,...,elem]`: stream the interior, emitting valid
+    // `[run]` frames. The leading `[` is already consumed; the trailing `]` is
+    // read last.
+    let interiorRemaining = declaredLen - 2; // interior bytes (excludes `[` and `]`)
+    let fill = 0; // carry bytes held at buf[0..fill) (a partial element, no comma)
+    let truncated = false;
+
+    while (interiorRemaining > 0) {
+      const need = cap - fill; // fill the buffer exactly (over-read-safe)
+      if (interiorRemaining >= need) {
+        if (!readFillExact(read, buf, fill, need)) {
+          truncated = true;
+          break;
+        }
+        fill = cap;
+        interiorRemaining = interiorRemaining - need;
+        // Emit one frame up to the last comma within [0, maxRun); carry the rest.
+        let last = maxRun;
+        while (last > 0 && buf[last - 1] !== COMMA) last = last - 1;
+        let runLen: number;
+        let consumed: number;
+        if (last === 0) {
+          // No comma in [0, maxRun): a single element exceeds the cap — emit
+          // maxRun raw (degenerate; only for elements > ~cap bytes).
+          runLen = maxRun;
+          consumed = maxRun;
+        } else {
+          runLen = last - 1; // exclude the comma at last-1
+          consumed = last; // skip the comma too
+        }
+        emitRun(write, buf, 0, runLen);
+        // Shift the leftover buf[consumed..fill) to the front (small for typical
+        // element sizes — one element plus the 2 cap bytes).
+        const rem = fill - consumed;
+        let m = 0;
+        while (m < rem) {
+          buf[m] = buf[consumed + m];
+          m = m + 1;
+        }
+        fill = rem;
+      } else {
+        // Final interior batch: read exactly interiorRemaining (exact-size temp,
+        // over-read-safe), append to the carry, then drain to frames.
+        const tmp = new Uint8Array(interiorRemaining);
+        if (!readFillExact(read, tmp, 0, interiorRemaining)) {
+          truncated = true;
+          break;
+        }
+        let t = 0;
+        while (t < interiorRemaining) {
+          buf[fill + t] = tmp[t];
+          t = t + 1;
+        }
+        fill = fill + interiorRemaining;
+        interiorRemaining = 0;
+        // Drain buf[0..fill) into <=maxRun frames at comma boundaries; the last
+        // frame ends exactly at fill (the array has no trailing comma).
+        let startPos = 0;
+        while (startPos < fill) {
+          let stop = startPos + maxRun;
+          if (stop >= fill) {
+            stop = fill;
+          } else {
+            let c = stop;
+            while (c > startPos && buf[c - 1] !== COMMA) c = c - 1;
+            if (c > startPos) stop = c - 1;
+          }
+          emitRun(write, buf, startPos, stop - startPos);
+          startPos = stop;
+          if (startPos < fill && buf[startPos] === COMMA) startPos = startPos + 1;
+        }
+        fill = 0;
+      }
+    }
+    if (truncated) break; // EOF mid-frame → stop
+    if (!readFillExact(read, one, 0, 1)) break; // the trailing `]`
+  }
+}
+
+/**
+ * Drive the Native Messaging port loop over the injected host stdio seam.
+ *
+ * @param read         one host `readSync` (fd 0); returns bytes read, or `null` /
+ *                     `<= 0` at EOF. MUST be a standalone function reference (see
+ *                     the cross-module-funcref note at the top of this file).
+ * @param write        one host `writeSync` (fd 1); writes the whole buffer.
+ * @param maxFrameSize `<= 0` → verbatim echo (no cap); `> 0` → re-chunk bodies
+ *                     larger than this many bytes into valid <=`maxFrameSize`
+ *                     JSON frames (the browser per-message cap).
+ */
+export function runNmHost(read: NmRead, write: NmWrite, maxFrameSize: number): void {
+  if (maxFrameSize > 0) {
+    runRechunk(read, write, maxFrameSize);
+  } else {
+    runVerbatim(read, write);
+  }
+}

--- a/plan/issues/2778-nm-shared-sync-core-dedup.md
+++ b/plan/issues/2778-nm-shared-sync-core-dedup.md
@@ -55,13 +55,14 @@ files, so the cross-file `call_ref` / field read faults. Passing standalone
 
 ## Compiler gaps discovered (worked around here; tracked in #2779)
 
-All three are `node:fs`-multi-file (`compileProject`/`compileMultiSource`) +
-`--target wasi` codegen gaps. Each compiles to a clean wasi-only module but FAULTS
-at runtime; the Deno variant (no `node:fs` shim insertion → no index shift) is
-unaffected. Worked around in the example sources so the dedup ships working:
+All four are `node:fs`-multi-file (`compileProject`/`compileMultiSource`) +
+`--target wasi` codegen gaps. Each compiles to a clean wasi-only module but then
+FAULTS at runtime (or fails `WebAssembly.validate`); the Deno variant (no `node:fs`
+shim insertion → no index shift) is unaffected. Worked around in the example
+sources so the dedup ships working:
 
 1. **Struct/interface value across the bundle boundary** → fault. Workaround: the
-   seam passes two function references, not an object.
+   seam passes function references (`read`, `write`, `log`), not an object.
 2. **A shared-module helper returning a nullable reference type** (`Uint8Array |
    null`, e.g. the original `readExactNew`) → fault when bundled into a `node:fs`
    entry. Workaround: every shared reader uses the `boolean`-EOF form
@@ -70,6 +71,11 @@ unaffected. Worked around in the example sources so the dedup ships working:
 3. **A module-level `const` (lowered to a Wasm global) passed as a call argument**
    across the bundle boundary → fault. Workaround: the cap is a LOCAL const inside
    `main()` (compiles to a plain `i32.const` operand).
+4. **The number→string path (`number_toString_radix`)** — e.g. a template literal
+   `` `…${n}…` `` — compiles to INVALID Wasm in the bundled `node:fs` entry.
+   Surfaced restoring nm_node_fs's fd-2 telemetry (`[host] received N chars …`),
+   which the real-wasmtime smoke test asserts. Workaround: a hand-rolled decimal
+   formatter (`% 10`, `(v - v%10)/10`) instead of template-literal interpolation.
 
 These look like a single underlying defect: `node:fs` shim insertion shifts
 function/global/type indices in a multi-file bundle, but some references are not
@@ -85,14 +91,16 @@ WASI module — imports = `{wasi_snapshot_preview1}` ONLY, no `env::*`, with
 versions:
 
 - `nm_deno`: byte-exact verbatim echo at 1 / 64 / 128 MiB.
-- `nm_node_fs`: re-chunk round-trip at 1 KiB → 64 MiB — every emitted frame is a
+- `nm_node_fs`: re-chunk round-trip at 1 KiB → 128 MiB — every emitted frame is a
   valid `[…]` within the 1 MiB cap, and concatenating the frame interiors
-  reconstructs the original array body exactly.
+  reconstructs the original array body exactly; the fd-2 telemetry line is
+  byte-exact under real wasmtime (the `smoke` check).
 
 Pinned by `tests/native-messaging-matrix.test.ts` (1/64/128 MiB matrix),
 `tests/native-messaging-comparison.test.ts` (#2683/#2696 import-section + echo
-harness) and `tests/issue-2521-native-messaging-rechunk.test.ts` (linkNodeShims
-re-chunk). All three route nm_deno/nm_node_fs through `compileProject` (mirroring
+harness), `tests/issue-2521-native-messaging-rechunk.test.ts` (linkNodeShims
+re-chunk), and `examples/native-messaging/smoke-test.sh` (the `smoke` CI check —
+real wasmtime, `--link-node-shims`, asserts stdout frame + fd-2 stderr line). All three route nm_deno/nm_node_fs through `compileProject` (mirroring
 the CLI's #2771 `entryHasRelativeImports` dispatch); the other variants stay on
 single-source `compile()` so their output is byte-identical. The comparison
 harness's variant discovery excludes `nm_sync_framing.ts` (it is the shared core,

--- a/plan/issues/2778-nm-shared-sync-core-dedup.md
+++ b/plan/issues/2778-nm-shared-sync-core-dedup.md
@@ -1,0 +1,99 @@
+---
+id: 2778
+title: "Dedup native-messaging sync framing: share one host-independent core for nm_deno + nm_node_fs"
+status: done
+assignee: ttraenkler/dev-2778-nm-dedup
+created: 2026-06-28
+completed: 2026-06-28
+priority: medium
+feasibility: medium
+task_type: refactor
+area: examples
+goal: platform
+related: [2775, 2771, 389, 2655, 2779]
+sprint: current
+---
+
+# #2778 — share one sync framing core for nm_deno + nm_node_fs
+
+## Problem
+
+After #2775 renamed the Native Messaging examples to the host scheme, `nm_deno.ts`
+(Deno `readSync`/`writeSync`) and `nm_node_fs.ts` (`node:fs` `readSync`/`writeSync`)
+were MONOLITHIC: each re-implemented the whole Native Messaging framing/streaming
+protocol (4-byte LE length prefix, body streaming, framed response, zero-length
+shutdown frame, EOF handling). The two differ only in (a) which host stdio they
+call and (b) whether they re-chunk to the browser 1 MiB per-message cap — yet they
+duplicated the entire protocol loop. The dedup was blocked until #2771 made the
+CLI bundle relative imports for standalone WASI.
+
+## Fix
+
+Extract a shared, **host-INDEPENDENT** core — `examples/native-messaging/nm_sync_framing.ts`
+— that owns the framing/streaming over `Uint8Array` and is parameterized by the
+host stdio + an optional re-chunk cap. The two hosts become thin adapters:
+
+- `nm_deno.ts` injects `Deno.stdin.readSync` / `Deno.stdout.writeSync`, **no cap**
+  → verbatim byte echo.
+- `nm_node_fs.ts` injects `node:fs` `readSync(0,…)` / `writeSync(1,…)`, **cap =
+  1 MiB** → keeps its deliberate browser-cap re-chunk demo (a body > 1 MiB streams
+  back as a sequence of valid `<=1 MiB` `[run]` / `"run"` JSON frames).
+
+`nm_wasi_p1.ts` (raw linear-memory WASI) and `nm_node_process.ts` (async reactor)
+are deliberately NOT touched — they stay standalone.
+
+### The injection seam is two FUNCTION references, not an `NmHostIo` object
+
+The issue originally specified an `NmHostIo { read, write }` **object** seam. That
+does not work today: passing a struct/interface VALUE (or a method extracted from
+one) across the bundled-module boundary under `--target wasi` compiles clean
+(imports = `{wasi_snapshot_preview1}` only) but **traps at runtime** — the
+relative-import bundler does not unify the struct's nominal type identity across
+files, so the cross-file `call_ref` / field read faults. Passing standalone
+**function references** across the boundary works. So the seam is
+`runNmHost(read, write, maxFrameSize)`. See #2779 for the compiler follow-up.
+
+## Compiler gaps discovered (worked around here; tracked in #2779)
+
+All three are `node:fs`-multi-file (`compileProject`/`compileMultiSource`) +
+`--target wasi` codegen gaps. Each compiles to a clean wasi-only module but FAULTS
+at runtime; the Deno variant (no `node:fs` shim insertion → no index shift) is
+unaffected. Worked around in the example sources so the dedup ships working:
+
+1. **Struct/interface value across the bundle boundary** → fault. Workaround: the
+   seam passes two function references, not an object.
+2. **A shared-module helper returning a nullable reference type** (`Uint8Array |
+   null`, e.g. the original `readExactNew`) → fault when bundled into a `node:fs`
+   entry. Workaround: every shared reader uses the `boolean`-EOF form
+   (`readFillExact`) into a caller-provided buffer; the verbatim path allocates a
+   fresh exact-size buffer per run.
+3. **A module-level `const` (lowered to a Wasm global) passed as a call argument**
+   across the bundle boundary → fault. Workaround: the cap is a LOCAL const inside
+   `main()` (compiles to a plain `i32.const` operand).
+
+These look like a single underlying defect: `node:fs` shim insertion shifts
+function/global/type indices in a multi-file bundle, but some references are not
+consistently re-mapped past a threshold. The example sources carry comments at the
+exact sites so a future edit does not silently reintroduce a trap; the
+native-messaging tests run the binaries under an fd shim, so a regression FAILS CI.
+
+## Verification (acceptance)
+
+Both adapters compile via the real CLI / `compileProject` to a clean standalone
+WASI module — imports = `{wasi_snapshot_preview1}` ONLY, no `env::*`, with
+`nm_sync_framing.ts` bundled in. Behavior is IDENTICAL to the merged monolithic
+versions:
+
+- `nm_deno`: byte-exact verbatim echo at 1 / 64 / 128 MiB.
+- `nm_node_fs`: re-chunk round-trip at 1 KiB → 64 MiB — every emitted frame is a
+  valid `[…]` within the 1 MiB cap, and concatenating the frame interiors
+  reconstructs the original array body exactly.
+
+Pinned by `tests/native-messaging-matrix.test.ts` (1/64/128 MiB matrix),
+`tests/native-messaging-comparison.test.ts` (#2683/#2696 import-section + echo
+harness) and `tests/issue-2521-native-messaging-rechunk.test.ts` (linkNodeShims
+re-chunk). All three route nm_deno/nm_node_fs through `compileProject` (mirroring
+the CLI's #2771 `entryHasRelativeImports` dispatch); the other variants stay on
+single-source `compile()` so their output is byte-identical. The comparison
+harness's variant discovery excludes `nm_sync_framing.ts` (it is the shared core,
+not a host variant).

--- a/plan/issues/2779-nodefs-multifile-funcref-index-shift.md
+++ b/plan/issues/2779-nodefs-multifile-funcref-index-shift.md
@@ -29,7 +29,7 @@ Surfaced while doing the #2778 native-messaging dedup (a shared local helper
 imported by `nm_node_fs.ts`). #2771 made the bundle COMPILE; this is the runtime
 follow-up.
 
-## Three triggering shapes (each a clean compile, a runtime fault)
+## Four triggering shapes (each a clean compile, then a runtime/validate fault)
 
 1. **Struct / interface VALUE across the bundle boundary.** Passing an object
    (`{ read, write }`) — or a method extracted from one (`io.read`) — from the
@@ -42,6 +42,12 @@ follow-up.
 3. **A module-level `const` (lowered to a Wasm global) passed as a call argument**
    across the bundle boundary faults; a LOCAL const / inline literal (a plain
    `i32.const` operand) does not.
+4. **The number→string path (`number_toString_radix`)** — e.g. a template literal
+   `` `…${n}…` `` — mis-compiles to **invalid Wasm** in the bundled `node:fs`
+   entry (`WebAssembly.validate` fails: `not enough arguments on the stack for
+   f64.convert_i32_s @ number_toString_radix`). Plain f64 arithmetic is fine, so a
+   hand-rolled decimal formatter (`% 10`, `(v - v%10)/10`) is an unaffected
+   workaround (used by nm_node_fs's fd-2 telemetry).
 
 ## Hypothesis
 

--- a/plan/issues/2779-nodefs-multifile-funcref-index-shift.md
+++ b/plan/issues/2779-nodefs-multifile-funcref-index-shift.md
@@ -1,0 +1,69 @@
+---
+id: 2779
+title: "node:fs multi-file standalone-WASI bundle: cross-module struct/nullable-ref/global mis-lower (runtime fault)"
+status: ready
+created: 2026-06-28
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: bug
+area: compiler
+goal: platform
+related: [2771, 2778, 2655]
+sprint: Backlog
+---
+
+# #2779 — node:fs multi-file standalone-WASI bundle mis-lowers cross-module refs
+
+## Problem
+
+Building a standalone WASI module from a **multi-file** project whose entry imports
+`node:fs` (`compileProject` / `compileMultiSource`, `--target wasi`) compiles to a
+clean wasi-only module (imports = `{wasi_snapshot_preview1}` only) but **FAULTS at
+runtime** (`WebAssembly.Exception`) for several common code shapes. The equivalent
+SINGLE-file compile, and the equivalent multi-file compile using **Deno** stdio
+(`Deno.stdin.readSync` — no `node:fs` shim insertion), both run correctly. So the
+fault is specific to `node:fs` lowering in a multi-file bundle.
+
+Surfaced while doing the #2778 native-messaging dedup (a shared local helper
+imported by `nm_node_fs.ts`). #2771 made the bundle COMPILE; this is the runtime
+follow-up.
+
+## Three triggering shapes (each a clean compile, a runtime fault)
+
+1. **Struct / interface VALUE across the bundle boundary.** Passing an object
+   (`{ read, write }`) — or a method extracted from one (`io.read`) — from the
+   entry into a function defined in a bundled helper faults on the cross-file
+   `call_ref` / field access. Standalone function references cross fine.
+2. **A shared-helper function returning a nullable reference type** (e.g.
+   `function readExact(...): Uint8Array | null`) faults when that helper lives in a
+   bundled file and the entry imports `node:fs`. A `boolean`-returning equivalent
+   does not.
+3. **A module-level `const` (lowered to a Wasm global) passed as a call argument**
+   across the bundle boundary faults; a LOCAL const / inline literal (a plain
+   `i32.const` operand) does not.
+
+## Hypothesis
+
+`node:fs` shim insertion (`detectNodeFsImports` → `wasiNodeFsFuncs`, threaded in
+`compileMultiSource`) shifts function / global / type indices, but some references
+are not consistently re-mapped once the bundled module crosses a size/shape
+threshold — analogous to the documented `addUnionImports` "late import addition
+shifts function indices; must also shift the current body" hazard, but in the
+multi-file + node:fs path. The Deno path inserts no shim, so no shift, no fault.
+
+## Minimal repros
+
+See `.tmp/mini*` scratch built during #2778 (not committed). Reproduce with two
+files: an entry importing `node:fs` `readSync`/`writeSync` + a relative helper
+`./lib`, where `lib` exports a function the entry calls. Compile the entry with
+`compileProject(entry, { target: "wasi" })`, run under a raw fd shim. The struct /
+nullable-ref / module-global shapes fault; funcref / boolean / local-const shapes
+run. (#2778's example sources carry the working shapes + comments at each site.)
+
+## Acceptance
+
+`compileProject(entry, { target: "wasi" })` for a `node:fs` entry importing a
+relative helper runs identically to the single-file equivalent for ALL three
+shapes above — so the #2778 example sources can drop the workaround comments and use
+the originally-specified `NmHostIo` object seam / module-level cap const.

--- a/tests/issue-2521-native-messaging-rechunk.test.ts
+++ b/tests/issue-2521-native-messaging-rechunk.test.ts
@@ -15,10 +15,9 @@
 // size round-trips the whole sequence with no desync — demonstrating the stream
 // is correct and the #389 failure is the harness's 1:1 assumption, not the host.
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { compile } from "../src/index.js";
+import { compileProject } from "../src/index.js";
 import { buildNodeFsShim } from "../scripts/build-node-fs-shim.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -125,10 +124,13 @@ function parseFrames(bytes: Uint8Array): string[] {
 
 describe("#2521 Native Messaging host — >1 MiB re-chunking + multi-message sequence", () => {
   it("echoes a <=1 MiB message verbatim in a single frame", async () => {
-    const result = await compile(readFileSync(hostPath, "utf-8"), {
-      fileName: "nm_node_fs.ts",
+    // nm_node_fs now imports the shared `./nm_sync_framing` core (#2778), so it
+    // must compile through the multi-file bundler (mirrors the CLI's #2771
+    // routing); single-source `compile()` would strip the relative import.
+    const result = await compileProject(hostPath, {
       target: "wasi",
       linkNodeShims: true,
+      skipSemanticDiagnostics: true,
     });
     expect(result.success).toBe(true);
     const frames = parseFrames(runWasiRaw(result.binary, frame(JSON.stringify([1, 2, 3]))));
@@ -136,10 +138,13 @@ describe("#2521 Native Messaging host — >1 MiB re-chunking + multi-message seq
   });
 
   it("re-chunks a >1 MiB array into multiple <=1 MiB JSON-array frames that reassemble to the original", async () => {
-    const result = await compile(readFileSync(hostPath, "utf-8"), {
-      fileName: "nm_node_fs.ts",
+    // nm_node_fs now imports the shared `./nm_sync_framing` core (#2778), so it
+    // must compile through the multi-file bundler (mirrors the CLI's #2771
+    // routing); single-source `compile()` would strip the relative import.
+    const result = await compileProject(hostPath, {
       target: "wasi",
       linkNodeShims: true,
+      skipSemanticDiagnostics: true,
     });
     expect(result.success).toBe(true);
     const N = 209715 * 2; // ~2 MiB JSON body — strictly above the 1 MiB cap
@@ -161,10 +166,13 @@ describe("#2521 Native Messaging host — >1 MiB re-chunking + multi-message seq
   });
 
   it("processes the reporter's multi-message sequence (big then small) with no desync", async () => {
-    const result = await compile(readFileSync(hostPath, "utf-8"), {
-      fileName: "nm_node_fs.ts",
+    // nm_node_fs now imports the shared `./nm_sync_framing` core (#2778), so it
+    // must compile through the multi-file bundler (mirrors the CLI's #2771
+    // routing); single-source `compile()` would strip the relative import.
+    const result = await compileProject(hostPath, {
       target: "wasi",
       linkNodeShims: true,
+      skipSemanticDiagnostics: true,
     });
     expect(result.success).toBe(true);
     const N = 209715 * 2; // ~2 MiB

--- a/tests/native-messaging-comparison.test.ts
+++ b/tests/native-messaging-comparison.test.ts
@@ -36,7 +36,7 @@ import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "n
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { compile } from "../src/index.js";
+import { compile, compileProject, entryHasRelativeImports } from "../src/index.js";
 
 // wasmtime feature flags for the WasmGC + exception-handling binaries js2wasm
 // emits (structs/arrays + the exception tag).
@@ -58,10 +58,15 @@ const wasmtimeBin = findWasmtime();
 
 const NM_DIR = join(__dirname, "..", "examples", "native-messaging");
 
-/** The host-surface variants present on disk (any `nm_<surface>.ts`), sorted. */
+/**
+ * The host-surface variants present on disk (any `nm_<surface>.ts`), sorted.
+ * `nm_sync_framing.ts` is the SHARED host-independent framing core (#2778), not a
+ * host variant — it has no entry/`main` and never does fd IO itself — so it is
+ * excluded from the variant matrix (the host adapters that import it are tested).
+ */
 function discoverVariants(): string[] {
   return readdirSync(NM_DIR)
-    .filter((f) => /^nm_.*\.ts$/.test(f))
+    .filter((f) => /^nm_.*\.ts$/.test(f) && f !== "nm_sync_framing.ts")
     .sort();
 }
 
@@ -97,8 +102,16 @@ function frame(body: Uint8Array): Uint8Array {
 }
 
 async function compileVariant(file: string): Promise<Awaited<ReturnType<typeof compile>>> {
-  const src = readFileSync(join(NM_DIR, file), "utf-8");
-  return compile(src, { fileName: file, target: "wasi", skipSemanticDiagnostics: true });
+  const path = join(NM_DIR, file);
+  const src = readFileSync(path, "utf-8");
+  // Mirror the CLI's routing (#2771): an entry that statically imports a RELATIVE
+  // module (e.g. nm_deno / nm_node_fs → `./nm_sync_framing`) must go through the
+  // multi-file bundler so the shared core is pulled in and `node:fs` / raw-WASI
+  // lowering runs module-wide. Entries with no relative import (nm_wasi_p1 /
+  // nm_node_process / nm_wasi_p3) stay on the single-source path — byte-identical.
+  return entryHasRelativeImports(src)
+    ? compileProject(path, { target: "wasi", skipSemanticDiagnostics: true })
+    : compile(src, { fileName: file, target: "wasi", skipSemanticDiagnostics: true });
 }
 
 /**

--- a/tests/native-messaging-matrix.test.ts
+++ b/tests/native-messaging-matrix.test.ts
@@ -37,7 +37,7 @@ import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { compile } from "../src/index.js";
+import { compile, compileProject, entryHasRelativeImports } from "../src/index.js";
 
 const NM_DIR = join(__dirname, "..", "examples", "native-messaging");
 const MiB = 1024 * 1024;
@@ -68,8 +68,14 @@ const compileCache = new Map<string, Awaited<ReturnType<typeof compile>>>();
 async function getCompiled(file: string): Promise<Awaited<ReturnType<typeof compile>>> {
   let r = compileCache.get(file);
   if (!r) {
-    const src = await readFile(join(NM_DIR, file), "utf-8");
-    r = await compile(src, { fileName: file, target: "wasi", skipSemanticDiagnostics: true });
+    const path = join(NM_DIR, file);
+    const src = await readFile(path, "utf-8");
+    // Mirror the CLI's routing (#2771): nm_deno / nm_node_fs statically import the
+    // shared `./nm_sync_framing` core (#2778), so they must go through the
+    // multi-file bundler; the others stay on the single-source path.
+    r = entryHasRelativeImports(src)
+      ? await compileProject(path, { target: "wasi", skipSemanticDiagnostics: true })
+      : await compile(src, { fileName: file, target: "wasi", skipSemanticDiagnostics: true });
     compileCache.set(file, r);
   }
   return r;


### PR DESCRIPTION
## #2778 — share one sync framing core for nm_deno + nm_node_fs

Dedups the Native Messaging examples renamed by #2775. Extracts
`examples/native-messaging/nm_sync_framing.ts` — a **host-independent** NM
framing/streaming core over `Uint8Array`, parameterized by the host stdio + an
optional re-chunk cap. The two hosts become thin adapters:

- **`nm_deno.ts`** — injects `Deno.stdin.readSync` / `Deno.stdout.writeSync`, **no
  cap** → verbatim byte echo.
- **`nm_node_fs.ts`** — injects `node:fs` `readSync(0,…)` / `writeSync(1,…)`, **cap
  = 1 MiB** → keeps its deliberate browser-cap re-chunk demo.

`nm_wasi_p1.ts` (linear-memory) and `nm_node_process.ts` (async reactor) are NOT
touched — they stay standalone.

### Verification (the whole point)

Both adapters compile via the real CLI / `compileProject` to a clean standalone
WASI module — imports = `{wasi_snapshot_preview1}` **only**, no `env::*`, with
`nm_sync_framing.ts` bundled in (#2771). Behavior is IDENTICAL to the merged
monoliths:

- `nm_deno` byte-exact verbatim echo at **1 / 64 / 128 MiB**.
- `nm_node_fs` re-chunk round-trip **1 KiB → 128 MiB** — every emitted frame is a
  valid `[…]` within the 1 MiB cap, and concatenating the interiors reconstructs
  the input array exactly.

Pinned green by `tests/native-messaging-matrix.test.ts` (10/10, incl. 128 MiB),
`tests/native-messaging-comparison.test.ts` (#2683/#2696, 33), and
`tests/issue-2521-native-messaging-rechunk.test.ts` (3). The three tests route
nm_deno/nm_node_fs through `compileProject` (mirroring the CLI's #2771
`entryHasRelativeImports` dispatch); the other variants stay on single-source
`compile()` so their output is byte-identical. Variant discovery excludes the
shared core. `tsc` / biome lint / prettier clean.

### Compiler gap found → #2779 (worked around here)

The seam is **two function references, not the originally-specified `NmHostIo`
object**. Passing a struct value — or a module-level `const`, or a
nullable-ref-returning helper — across the bundled-module boundary compiles clean
but **faults at runtime** under `--target wasi` in the `node:fs` multi-file path (a
shim-insertion index-shift gap; the Deno path is unaffected). The example sources
use the working shapes with comments at each site; the NM tests run the binaries
under an fd shim, so a regression fails CI. Filed as **#2779**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)