### PR TITLE
feat(#2780): hybrid IR ArrayLiteral widening-escape gate

### DIFF
--- a/plan/issues/2780-hybrid-ir-arrayliteral-widening-escape.md
+++ b/plan/issues/2780-hybrid-ir-arrayliteral-widening-escape.md
@@ -1,0 +1,163 @@
+---
+id: 2780
+title: "Hybrid IR step 2: ArrayLiteral widening-escape check — vec.new_fixed only when the literal does not flow into an any/heterogeneous sink"
+status: done
+sprint: current
+created: 2026-06-28
+updated: 2026-06-28
+completed: 2026-06-28
+assignee: ttraenkler/sendev-arraylit-widening
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: max
+task_type: feature
+area: codegen, ir
+language_feature: array-literal
+goal: correctness
+related: [2755, 2762, 2766, 1530, 1804]
+depends_on: [2766]
+---
+
+# #2780 — Hybrid IR step 2: ArrayLiteral widening-escape check
+
+Second IR-adoption step of the hybrid roadmap
+([`docs/architecture/hybrid-soundness-ir-roadmap.md`](../../docs/architecture/hybrid-soundness-ir-roadmap.md)
+§(b); audit Row 6 in
+[`plan/log/hybrid-fastpath-audit.md`](../../plan/log/hybrid-fastpath-audit.md)).
+It is the clean **second exemplar** after #2766 that a safety proof can be
+**local** — a fresh allocation needs no whole-function dataflow.
+
+## Problem
+
+`#1804` lowers a fixed-length, non-spread, same-typed array literal to a packed
+`vec.new_fixed` IR node (`src/ir/from-ast.ts` `lowerArrayLiteral`). The fast path
+builds a **homogeneous NARROW vec** (`vec<f64>` for `number[]`, `vec<i32>` for
+`boolean[]`, …). Per the Hybrid Invariant (HI) that specialization is only sound
+when the literal **provably cannot be widened** to a heterogeneous / `any`
+element type.
+
+The "all elements same static type" half of Row 6's predicate is already
+enforced (the `irTypeEquals` element-type loop). The **gap** is the _"not later
+widened"_ half — there was **no explicit proof** that the homogeneous narrow vec
+won't flow into a wider/heterogeneous sink. Soundness today rests on two
+_incidental_ mechanisms rather than an explicit HI proof:
+
+1. the **selector** rejects functions whose locals carry a non-primitive type
+   annotation (`const a: any[] = …` ⇒ `body-shape-rejected`, because
+   `lowerVarDecl` only forwards **primitive** type nodes as the hint — `any[]`,
+   an `ArrayType`, is dropped), so the literal never reaches the IR; and
+2. for a literal **passed where an `any[]` is expected** (`g([1,2,3])`,
+   `g(x: any[])`), the IR claims the function and the literal _does_ reach
+   `lowerArrayLiteral` — where the externref-`hint` ≠ f64-element `irTypeEquals`
+   check raises a generic _"mixed-type"_ demotion.
+
+Both are fragile to the natural next expansion of #1804's claim scope: the moment
+the selector claims an annotated-`any[]`-local function, `lowerArrayLiteral` would
+infer the element type **from the elements** (`1,2,3` → f64) and build `vec<f64>`
+for an `any[]`-typed slot — a latent miscompile, since the packed `vec<f64>`
+cannot hold a later `a[0] = "x"` / `a.push({})`.
+
+This slice makes the proof **explicit and the primary gate**: prove
+no-widening-escape, else demote to the SAFE legacy lowering (which boxes each
+element). The explicit gate (a) replaces the incidental _"mixed-type"_ demotion
+for the reaching `any[]`-arg case with a clear HI reason, and (b) pre-empts the
+latent narrow-build miscompile if the selector's claim scope widens. The existing
+`irTypeEquals` / hint net remains as a **backstop** for any sink
+`getContextualType` cannot recover at the literal's site, so no miscompile is
+possible regardless of `getContextualType`'s positional reliability.
+
+## Fix (HI prove-then-specialize, mirrors #2766)
+
+Add a **local widening-escape proof** to `lowerArrayLiteral`. The fast
+`vec.new_fixed` fires **only** when the proof holds; otherwise demote to the SAFE
+correct path (legacy, which boxes each element to the dynamic externref
+representation).
+
+Proof predicate `arrayLiteralWideningEscapes(expr, cx)` — inspects only the
+literal's **own TS contextual type** (`checker.getContextualType(expr)`), no
+whole-function dataflow:
+
+- bare `any` / `unknown` sink (`const a: any = [...]`) → escape → SAFE;
+- array/tuple sink whose **element type** is `any` / `unknown` (`any[]`,
+  `unknown[]`) → escape → SAFE;
+- array/tuple sink whose element type is a **heterogeneous union**
+  (`(number | string)[]`) → escape → SAFE;
+- otherwise (concrete, homogeneous element type matching the narrow build, or no
+  contextual type at all) → P holds → FAST `vec.new_fixed`.
+
+### Why the comparison is on the TS _type_, never the Wasm kind (the Row-6 trap)
+
+`number[]`, `boolean[]` and `symbol[]` **all** lower to the same Wasm element
+ValType (`number[]` → f64; `boolean[]` and `symbol[]` → i32 — and packed-i32
+`number[]` would also be i32). Keying the proof on the ValType kind would
+misclassify a boolean-vs-number sink and either over-demote every `boolean[]`
+literal or miss a real confusion. The predicate therefore reads TS `TypeFlags`.
+
+One TS gotcha verified before coding (probe in `.tmp/`): the intrinsic `boolean`
+type is internally the union `true | false`, so `type.isUnion()` returns **true**
+for it. The predicate excludes it via the `ts.TypeFlags.Boolean` flag so
+`boolean[]` stays on the fast path. A genuine heterogeneous union
+(`string | number`) does **not** carry that flag.
+
+### Why SAFE = demote-to-legacy for this slice (not a SAFE IR lowering)
+
+The IR has **no number→externref box primitive** (see the `from-ast.ts`
+generator/coercion comments and #2766's `emitSafeVecGet` f64 note: a `number[]`
+value that must be observed as `any`/externref "already demotes the whole
+function to legacy"). Building a boxed `vec<externref>` _in the IR_ is therefore
+not available at this step; the SAFE correct path is the legacy lowering, which
+boxes each element via `__box_number` and produces the dynamic-correct array.
+This matches the roadmap's pragmatic stance ("when the IR cannot prove a
+specialization … it falls to the SAFE JS-correct lowering") — legacy is the SAFE
+lowering here, exactly as the #1804 spread/sparse/mixed arms already demote.
+
+## Blast radius
+
+Verified empirically on current main (`.tmp` probes):
+
+- **Reaching widening case = literal passed where `any[]` is expected**
+  (`g([1,2,3])`, `g(x: any[])`): reaches `lowerArrayLiteral` and now demotes with
+  the **explicit HI reason** instead of the incidental _"mixed-type"_ throw — same
+  outcome (legacy boxes; value identical), clearer cause.
+- **Annotated `any[]`/`unknown[]`/union local** (`const a: any[] = [...]`):
+  `body-shape-rejected` by the selector today, so it never reaches the IR — the
+  gate is dormant defense-in-depth for it (becomes load-bearing if that claim
+  scope widens).
+- **`unknown[]` / `(A|B)[]` call-args**: lower via a path that does **not** reach
+  `lowerArrayLiteral` and already produce JS-correct values; the gate does not
+  change them.
+- **FAST cases unaffected**: no-annotation `[1,2,3]`, `boolean[]` (the
+  `boolean = true|false` union-flag gotcha is excluded via the `Boolean` flag),
+  same-typed `number[]` call-args — all keep the fast `vec.new_fixed` path.
+
+Demoting to legacy is **correctness-neutral or a fix** (legacy is the semantic
+reference); it is never a miscompile. The only cost is a perf/byte deopt for the
+reaching `any[]`-arg case, which is the HI SAFE default.
+
+## Acceptance criteria
+
+- `const a: number[] = [1,2,3]` (and no-annotation `[1,2,3]`, `boolean[]`,
+  same-typed `number[]` params/returns) keep the FAST `array.new_fixed` IR path.
+- `const a: any[]/unknown[]/(number|string)[] = [1,2,3]` demote to legacy and
+  still return JS-correct values.
+- No test262 regression in the `merge_group` re-validation (IR change → validated
+  full-CI, not scoped).
+- `pnpm run check:ir-fallbacks` stays green (refresh the post-claim baseline if a
+  playground example legitimately newly demotes).
+
+## Scope / non-goals
+
+- Structural-supertype scalar sinks (`{}[]`, `object[]` of a scalar literal) are
+  **not** flagged by this local proof — they remain covered by the existing
+  downstream `irTypeEquals` net (same residual as today). Row 6 explicitly scopes
+  to `any` / `unknown` / heterogeneous sinks.
+- Whole-function / cross-function widening (a narrow literal assigned to a wide
+  variable several statements later, or passed through covariant array
+  positions) is out of the _local_ proof and stays caught by the downstream net.
+
+## Test Results
+
+See `tests/issue-2780.test.ts` — fast-path-when-safe (FAST, `array.new_fixed`
+present, no demotion) + safe-fallback-when-not (demotes via `irPostClaimErrors`,
+value still correct).

--- a/plan/log/hybrid-fastpath-audit.md
+++ b/plan/log/hybrid-fastpath-audit.md
@@ -55,7 +55,7 @@ gated rollout). Bands are for the *fast-path conversion only*; the §(e)
 | 3 | **Packed-`i32` arrays** — `src/codegen/array-element-typing.ts:212` `collectI32SpecializedArrays`, `:44` `isI32SafeExprForArray` | every value stored is an i32-safe integer **and** no read needs the f64 NaN / fractional / `>2³¹` distinction — `number[]` guarantees none of this (`as`, `any`, fractional literal, big magnitude) | whole-function flow proving **every** write i32-safe **and** **no** read observes a distinction i32 erases; a wrong `P` **MISCOMPILES** | `undischarged` (subtle) | subtle | **L** | — (spin from this row) |
 | 4 | **Monomorphic `struct.get`/`struct.set`** — `src/codegen/property-access.ts:990` `resolveStructName`, `:1392` `emitNullGuardedStructGet` | receiver is exactly that nominal struct layout — TS permits union arms, `any`-widening, covariant fields, divergent-layout subclasses | receiver provably the single nominal type (IR receiver-type narrowing) **and** no union / `any` / covariant / subclass-layout escape; **else** SAFE dynamic property read (or `ref.test`-guarded read, à la row 8) | `undischarged` (subtle) | subtle | **L** | — (spin from this row) |
 | 5 | **Unboxed `f64`/`i32` number locals (no-box)** — IR `src/ir/analysis/escape.ts:92` `analyzeEscape`; legacy numeric-local typing diffuse across `src/codegen/` | a number-typed local stays unboxed and never needs identity/boxing at an `any`/externref sink | escape analysis proving the value never flows to an `any`/union/externref sink without an explicit box | `partial` | easy (pure-numeric) / subtle (any-union boundary) | **M** | — (spin general arm) |
-| 6 | **`ArrayLiteral` → `vec.new_fixed`** — `src/ir/from-ast.ts:1444` `lowerArrayLiteral` (#1804) | all elements share one static type **and** the literal is not later widened to `any`/heterogeneous | **local** proof: fresh allocation, all elements same static type, no widening escape — cheap, no whole-function dataflow | `partial` (local) | easy | **S** | — (spin from this row) |
+| 6 | **`ArrayLiteral` → `vec.new_fixed`** — `src/ir/from-ast.ts:1516` `lowerArrayLiteral` (#1804) | all elements share one static type **and** the literal is not later widened to `any`/heterogeneous | **local** proof: fresh allocation, all elements same static type, no widening escape — cheap, no whole-function dataflow | `discharged` (local) | easy | **S** | **#2780** (`arrayLiteralWideningEscapes` gate; FAST only when the contextual sink is not `any`/`unknown`/heterogeneous) |
 | 7 | **`Binary` unboxed arithmetic** — IR `src/ir/from-ast.ts:3787` `lowerBinary`; legacy `src/codegen/binary-ops.ts:254` `compileBinaryExpression` / `:3660` `compileNumericBinaryOp` | both operands are `number` so emit an `f64`/`i32` op, and `+` is a numeric add — TS allows `any`/union/string-coercible operands and `+` can be string concat | operands provably `number` (not `any`/union/string-coercible) and `+` provably not string-`+`; **else** SAFE `emitAnyAdd` (`binary-ops.ts:3296`) / `emitAnyRelational` (`:3469`) | `partial` | easy (annotated-number) / subtle (`+` possibly-string) | **M** | — (spin general arm) |
 | 8 | **`this`-receiver typed read** — `src/codegen/property-access.ts:5443` `emitThisReceiverGuardConvert` | **none** — it does a runtime `ref.test` instead of trusting the static `this` type | runtime `ref.test` guard (the canonical runtime-guard discharge of `P`) | `discharged` (exemplar) | already-HI-compliant | **S** | F3: document as the HI reference pattern |
 | 9 | **Typed-array element read** — `src/codegen/property-access.ts` typed-array site `~:6341` in `compileElementAccessBody`; shared helper `src/codegen/array-methods.ts:386` `emitBoundsCheckedArrayGet` | view-length is the bound and OOB → `undefined` per spec, **but** the read is entangled with the **shared** helper (the S2 blast-radius lesson) | view length is the bound; OOB → `undefined`; **must stay scoped separately from F1's plain-array scope** — do NOT flip the shared helper default | `partial` | easy but entangled | **S–M** | kept separate from #2760 |
@@ -137,11 +137,12 @@ the expensive L tail (rows 3, 4) inherits the machinery the S/M rows establish.
    fallback) and the canonical end-to-end exemplar. Port `safeIndexedArrays`
    into the IR; `vec.get` only when in-bounds is proven, else the SAFE
    bounds-checked `undefined` read. **No new issue needed — track #2766.**
-2. **Row 6 — ArrayLiteral widening-escape check** (S, *needs an issue*).
+2. **Row 6 — ArrayLiteral widening-escape check** (S, **#2780 — landed**).
    Smallest blast radius, a *local* proof on a fresh allocation, no
    whole-function dataflow. The clean second exemplar that a proof need not be
-   global. Add the "not later widened to `any`/heterogeneous" check to
-   `lowerArrayLiteral`.
+   global. `arrayLiteralWideningEscapes` in `lowerArrayLiteral` gates the fast
+   `vec.new_fixed` on the literal's TS contextual type: FAST only when the sink
+   is not `any`/`unknown`/heterogeneous, else the SAFE boxed legacy lowering.
 3. **Row 7 — Binary `+` string-or-number proof-gate** (M, *needs an issue*).
    Builds the operand-type-proof / `any`-union-sink detection that rows 3, 5
    reuse. Proof-gate the unboxed numeric op in IR `lowerBinary`; SAFE-fall to
@@ -190,4 +191,6 @@ IR-adoption steps (§(b) of the roadmap), **not** a big-bang rewrite.
   fix (the SAFE lowering rows 1/2 reuse).
 - [#2766](../issues/2766-hybrid-ir-elementaccess-prove-then-specialize.md) — R2,
   the row-1 follow-up.
+- [#2780](../issues/2780-hybrid-ir-arrayliteral-widening-escape.md) — the row-6
+  follow-up (ArrayLiteral widening-escape gate).
 - [ir-adoption.md](./ir-adoption.md) — per-AST-kind IR status & ratchet.

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -1444,6 +1444,59 @@ function lowerExpr(expr: ts.Expression, cx: LowerCtx, hint: IrType): IrValueId {
 }
 
 /**
+ * #2780 (hybrid Row 6) — the widening-escape proof for the ArrayLiteral fast
+ * path. Returns `true` when the literal's result flows into a sink that demands a
+ * WIDER / heterogeneous element type than the homogeneous NARROW vec
+ * `vec.new_fixed` would build — `any[]` / `unknown[]` / a heterogeneous-union
+ * element, or a bare `any` / `unknown` slot. In that case the packed fast path is
+ * UNSOUND: a `vec<f64>` (etc.) handed to an `any`-typed alias could later receive
+ * a string/object element the packed vec cannot hold (e.g. `const a: any[] =
+ * [1,2,3]; a[0] = "x"`). When it returns `true`, codegen must fall to the SAFE
+ * legacy lowering, which boxes each element to the dynamic externref
+ * representation.
+ *
+ * This is a **local** proof (the Hybrid-Invariant point of Row 6): it inspects
+ * only the literal's own TS contextual type — no whole-function dataflow. The
+ * fresh allocation is decidable from the sink type at this single site.
+ *
+ * The comparison reads the TS **type** (`TypeFlags`), never the Wasm ValType
+ * kind: `number[]`, `boolean[]` and `symbol[]` all collapse to the same element
+ * ValType (f64 / i32 / i32) — keying on the kind would misclassify a
+ * boolean-vs-number sink. Note the TS gotcha that the intrinsic `boolean` type is
+ * internally the union `true | false`, so `isUnion()` is `true` for it; it is
+ * excluded via the `Boolean` flag so `boolean[]` stays on the fast path, while a
+ * genuine heterogeneous union (`string | number`) — which does not carry that
+ * flag — is correctly treated as a widening.
+ *
+ * Structural-supertype scalar sinks (`{}[]`, `object[]`) are intentionally NOT
+ * flagged here — Row 6 scopes to `any` / `unknown` / heterogeneous sinks, and
+ * those residuals stay covered by the existing downstream `irTypeEquals` net
+ * (a wider-typed write demotes the function to legacy), exactly as today.
+ */
+function arrayLiteralWideningEscapes(expr: ts.ArrayLiteralExpression, cx: LowerCtx): boolean {
+  const checker = cx.checker;
+  // No checker → cannot prove a sink at this site. The existing element-type
+  // (`irTypeEquals`) checks here plus the downstream demotion net still guard
+  // correctness, so keep the fast path (HI: a missing proof is not a license to
+  // miscompile — there is no narrow-vec build whose escape we are masking,
+  // because every boundary use is still type-checked).
+  if (!checker) return false;
+  const ctxType = checker.getContextualType(expr);
+  if (!ctxType) return false; // consumed at its own narrow type → no widening at this site.
+  // A bare `any` / `unknown` slot (e.g. `const a: any = [1,2,3]`): the literal
+  // escapes into a fully dynamic value.
+  if (ctxType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) return true;
+  // Array / tuple sink: inspect the element type the sink demands.
+  const ctxElem = ctxType.getNumberIndexType();
+  if (!ctxElem) return false; // non-indexable concrete sink → no array widening here.
+  if (ctxElem.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) return true; // any[] / unknown[].
+  // Heterogeneous element union (`(number | string)[]`) the packed vec cannot
+  // hold — but NOT the intrinsic `boolean` (= `true | false`) which is uniform.
+  if (ctxElem.isUnion() && !(ctxElem.flags & ts.TypeFlags.Boolean)) return true;
+  return false;
+}
+
+/**
  * #1804 — lower a fixed-length, non-spread, non-sparse, same-typed array
  * literal to a `vec.new_fixed` IR node. Out of scope (clean fallback to
  * legacy): spread elements (`[...xs]`), elision holes (`[1, , 3]`), mixed
@@ -1453,6 +1506,12 @@ function lowerExpr(expr: ts.Expression, cx: LowerCtx, hint: IrType): IrValueId {
  * the resolver can recover) — covers `const a: number[] = [1,2,3]` and the
  * empty `const a: number[] = []`; otherwise infer from the first element and
  * require every element to share that IrType.
+ *
+ * #2780 (hybrid Row 6) — before the fast `vec.new_fixed`, discharge the
+ * widening-escape proof (`arrayLiteralWideningEscapes`): the packed narrow vec is
+ * only sound when the literal does NOT flow into an `any` / `unknown` /
+ * heterogeneous sink. When it does, demote to the SAFE legacy lowering (which
+ * boxes each element) — this mirrors #2766's prove-then-specialize shape.
  */
 function lowerArrayLiteral(expr: ts.ArrayLiteralExpression, cx: LowerCtx, hint: IrType): IrValueId {
   // Reject spread / sparse — out of scope, keep on legacy.
@@ -1478,6 +1537,33 @@ function lowerArrayLiteral(expr: ts.ArrayLiteralExpression, cx: LowerCtx, hint: 
       throw new Error(`ir/from-ast: resolver cannot register vec for empty literal (${cx.funcName})`);
     }
     return cx.builder.emitVecNewFixed([], hintElemIr, irVal({ kind: "ref", typeIdx: vec.vecStructTypeIdx }));
+  }
+
+  // #2780 (hybrid Row 6) — widening-escape proof, the PRIMARY HI gate (run
+  // before element lowering, mirroring #2766's prove-then-specialize: prove the
+  // specialization is sound, else fall to the SAFE path). `vec.new_fixed` builds
+  // a homogeneous NARROW vec (`vec<f64>` / `vec<i32>` / …). That specialization
+  // is only sound when this non-empty literal does NOT flow into a sink that
+  // demands a WIDER / heterogeneous element type (`any[]` / `unknown[]` / a
+  // union). When it does — a literal passed where an `any[]` is expected
+  // (`g([1,2,3])`, `g(x: any[])`), or an annotated `const a: any[] = [1,2,3]`
+  // were the selector to claim it (today such functions are `body-shape-rejected`
+  // because `lowerVarDecl` only forwards PRIMITIVE type annotations; this gate
+  // keeps the fast path sound if that claim scope ever widens) — demote to the
+  // SAFE legacy lowering, which boxes each element to the dynamic externref
+  // representation. Gating here (before the element-type loop) makes the explicit
+  // HI reason the demotion cause rather than the incidental "mixed-type" throw
+  // that the externref-hint path would otherwise raise; the existing
+  // element-type / hint `irTypeEquals` checks remain as a backstop for any sink
+  // `getContextualType` cannot recover at this site. Empty literals are excluded
+  // (handled above): with a wide hint they already build a correct wide vec, so
+  // there is no narrow build to let escape.
+  if (arrayLiteralWideningEscapes(expr, cx)) {
+    throw new Error(
+      `ir/from-ast: array literal flows into a widening/heterogeneous sink ` +
+        `(any[]/unknown[]/union element) — the packed vec.new_fixed fast path is ` +
+        `unsound here; demote to the SAFE boxed legacy lowering (${cx.funcName})`,
+    );
   }
 
   // Lower each element. Use the hint element type as each element's hint when

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -227,6 +227,9 @@ export function compileIrPathFunctions(
         // boolean` + `anyStrTypeIdx: number` shortcuts that #1183 added.
         resolver: fromAstResolver,
         allocRegistry,
+        // #2780 (hybrid Row 6): thread the TS checker so `lowerArrayLiteral`
+        // can discharge the widening-escape proof via `getContextualType`.
+        checker: ctx.checker,
       });
       const mainErrors = verifyIrFunction(result.main);
       if (mainErrors.length > 0) {
@@ -324,6 +327,9 @@ export function compileIrPathFunctions(
             classShapes,
             resolver: fromAstResolver,
             allocRegistry,
+            // #2780 (hybrid Row 6): thread the TS checker for the
+            // ArrayLiteral widening-escape proof in method bodies too.
+            checker: ctx.checker,
           });
           const mainErrors = verifyIrFunction(result.main);
           if (mainErrors.length > 0) {

--- a/tests/issue-2780.test.ts
+++ b/tests/issue-2780.test.ts
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2780 — Hybrid IR step 2: ArrayLiteral widening-escape check.
+//
+// `#1804` lowers a fixed-length, same-typed array literal to a packed
+// `vec.new_fixed` (a homogeneous NARROW vec — `vec<f64>` for `number[]`,
+// `vec<i32>` for `boolean[]`). Per the Hybrid Invariant that specialization is
+// only sound when the literal provably is NOT widened to an `any` /
+// heterogeneous element type. This step adds a LOCAL widening-escape proof to
+// `lowerArrayLiteral` (mirroring #2766's prove-then-specialize shape):
+//   - FAST: the literal's contextual sink is concrete & homogeneous (or absent)
+//     → keep `vec.new_fixed`.
+//   - SAFE: the sink demands a WIDER / heterogeneous element type
+//     (`any[]` / `unknown[]` / a union) → demote to the legacy lowering, which
+//     boxes each element to the dynamic externref representation. Value-correct
+//     either way.
+//
+// The proof reads the TS TYPE (`TypeFlags`), never the Wasm kind: `number[]`,
+// `boolean[]` and `symbol[]` all collapse to the same element ValType, so keying
+// on the kind would misclassify. The intrinsic `boolean` type is internally the
+// union `true | false` (so `isUnion()` is true for it) — it is excluded via the
+// `Boolean` flag so `boolean[]` stays on the fast path.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { analyzeSource } from "../src/checker/index.js";
+import { planIrCompilation } from "../src/ir/select.js";
+
+const WIDENING = "widening/heterogeneous sink";
+
+/** The selector claims `fn` for IR compilation (proves it reaches the IR path). */
+function isClaimed(source: string, fn: string): boolean {
+  const ast = analyzeSource(source, "input.ts");
+  const sel = planIrCompilation(ast.sourceFile, { experimentalIR: true });
+  return sel.funcs.has(fn);
+}
+
+/** Compile via the IR path; return the run value + the widening-demotion list. */
+async function compileRun(
+  source: string,
+  fn: string,
+): Promise<{ value: unknown; wideningDemotions: number; success: boolean }> {
+  const r = await compile(source, { experimentalIR: true });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors[0]?.message ?? "unknown"}`);
+  }
+  const wideningDemotions = (r.irPostClaimErrors ?? []).filter((e) => e.message.includes(WIDENING)).length;
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports as unknown as WebAssembly.Imports);
+  (imports as { setExports?: (e: Record<string, Function>) => void }).setExports?.(
+    instance.exports as Record<string, Function>,
+  );
+  const f = (instance.exports as Record<string, unknown>)[fn];
+  if (typeof f !== "function") throw new Error(`export ${fn} missing`);
+  return { value: (f as () => unknown)(), wideningDemotions, success: r.success };
+}
+
+describe("#2780 — IR ArrayLiteral widening-escape check", () => {
+  // ── FAST: proof holds → packed vec.new_fixed kept, NO widening demotion ──────
+  describe("FAST path — no widening, fast vec.new_fixed kept", () => {
+    it("no-annotation number[] (no contextual sink) sums via the IR vec", async () => {
+      const src = `export function sum(): number { const a = [1,2,3]; let t = 0; for (const x of a) { t += x; } return t; }`;
+      expect(isClaimed(src, "sum"), "function IR-claimed").toBe(true);
+      const { value, wideningDemotions } = await compileRun(src, "sum");
+      expect(value).toBe(6);
+      expect(wideningDemotions, "no widening demotion on the FAST path").toBe(0);
+    });
+
+    it("no-annotation number[] indexed + length", async () => {
+      const src = `export function test(): number { const a = [10,20,30,40,50]; return a[2] + a.length; }`;
+      expect(isClaimed(src, "test")).toBe(true);
+      const { value, wideningDemotions } = await compileRun(src, "test");
+      expect(value).toBe(35);
+      expect(wideningDemotions).toBe(0);
+    });
+
+    it("literal passed where a concrete number[] is expected stays FAST (no widening)", async () => {
+      // A concrete, homogeneous contextual element type (`number`) at the call
+      // arg — the proof holds, so the widening gate does NOT fire.
+      const src = `function g(x: number[]): number { return x[0] + x.length; }
+        export function test(): number { return g([1,2,3]); }`;
+      expect(isClaimed(src, "test")).toBe(true);
+      const { value, wideningDemotions } = await compileRun(src, "test");
+      expect(value).toBe(4);
+      expect(wideningDemotions, "number[] sink is not a widening").toBe(0);
+    });
+
+    it("boolean[] is NOT treated as a union widening (the true|false flag gotcha)", async () => {
+      // `boolean` is internally `true | false`, so `isUnion()` is true — the gate
+      // must exclude it (via the Boolean flag) and keep boolean[] on the fast path.
+      const src = `function g(x: boolean[]): number { return x.length; }
+        export function test(): number { return g([true,false,true]); }`;
+      expect(isClaimed(src, "test")).toBe(true);
+      const { value, wideningDemotions } = await compileRun(src, "test");
+      expect(value).toBe(3);
+      expect(wideningDemotions, "boolean[] must stay FAST").toBe(0);
+    });
+  });
+
+  // ── SAFE: proof fails → demote to the boxed legacy lowering, still correct ───
+  describe("SAFE path — widening sink demotes to legacy, value-correct", () => {
+    it("literal passed where an any[] is expected demotes via the widening gate", async () => {
+      const src = `function g(x: any[]): number { return x.length; }
+        export function test(): number { return g([1,2,3]); }`;
+      // The function IS IR-claimed (so the literal reaches lowerArrayLiteral),
+      // and the widening gate is the demotion cause — not the incidental
+      // "mixed-type" throw.
+      expect(isClaimed(src, "test"), "function IR-claimed (literal reaches the lowerer)").toBe(true);
+      const { value, wideningDemotions } = await compileRun(src, "test");
+      expect(wideningDemotions, "demoted via the explicit widening-escape gate").toBeGreaterThan(0);
+      expect(value, "still JS-correct via the SAFE (boxed) legacy lowering").toBe(3);
+    });
+
+    it("unknown[] / union[] sinks remain JS-correct (handled SAFE)", async () => {
+      // These lower via a path that does not reach lowerArrayLiteral, but the HI
+      // guarantee is the same: the result is JS-correct regardless of mechanism.
+      const unk = `function g(x: unknown[]): number { return x.length; }
+        export function test(): number { return g([1,2,3]); }`;
+      const uni = `function g(x: (number|string)[]): number { return x.length; }
+        export function test(): number { return g([1,2,3]); }`;
+      expect((await compileRun(unk, "test")).value).toBe(3);
+      expect((await compileRun(uni, "test")).value).toBe(3);
+    });
+  });
+});


### PR DESCRIPTION
## #2780 — Hybrid IR step 2: ArrayLiteral widening-escape check (audit Row 6)

Second IR-adoption step of the hybrid type-soundness roadmap (after #2766/R2).
Makes the `ArrayLiteral → vec.new_fixed` fast path satisfy the **Hybrid Invariant**:
the packed homogeneous (NARROW) vec is only built when the literal **provably**
does not flow into a wider / heterogeneous sink; otherwise it demotes to the
SAFE legacy lowering (which boxes each element).

### What changed
- `src/ir/from-ast.ts`: new `arrayLiteralWideningEscapes(expr, cx)` — a **local**
  proof (mirrors #2766's prove-then-specialize) read off the literal's TS
  contextual type. Gates the fast `vec.new_fixed` **before** element lowering:
  FAST only when the contextual element type is **not** `any` / `unknown` / a
  heterogeneous union; else throw → SAFE legacy demotion.
- `src/ir/integration.ts`: thread `ctx.checker` into the IR lowerer (both call
  sites) so `getContextualType` is available — it was never passed before.
- Docs: `plan/log/hybrid-fastpath-audit.md` Row 6 → `discharged`, records #2780.

### Why TS type, not Wasm kind (the Row-6 trap)
`number[]`, `boolean[]`, `symbol[]` all collapse to the same element ValType
(f64 / i32). The proof reads `TypeFlags`. The intrinsic `boolean` type is
internally the union `true | false` (so `isUnion()` is true) — excluded via the
`Boolean` flag so `boolean[]` stays on the fast path.

### Safety / blast radius
- Reaching widening case = a literal **passed where `any[]` is expected**
  (`g([1,2,3])`, `g(x: any[])`): now demotes via the **explicit HI reason**
  instead of the incidental "mixed-type" throw — same outcome, value identical.
- Annotated `any[]` locals are `body-shape-rejected` by the selector today, so
  the gate is dormant defense-in-depth there (load-bearing if the claim scope
  widens).
- The existing `irTypeEquals` / hint net remains as a **backstop**, so no
  miscompile is possible regardless of `getContextualType`'s positional
  reliability.
- Demote → legacy is correctness-neutral or a fix; never a miscompile.

### Validation
- `tests/issue-2780.test.ts` — FAST (no-annotation, `number[]`/`boolean[]` sinks,
  no demotion) + SAFE (`any[]` sink demotes via the gate, value-correct).
- Green locally: #2780, #1804 (`ir-vec-new-fixed`), #2766, #1169o, #2760.
- `check:ir-fallbacks` clean (no post-claim bucket growth); `tsc --noEmit` clean.
- **Broad-impact (IR change)** → full test262 validated in `merge_group` (not a
  scoped sweep); enqueue only if the test262 gate is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS