### PR TITLE
feat(#2781): hybrid IR Row-7 — Binary `+` string-or-number proof-gate

### DIFF
--- a/plan/issues/2781-hybrid-ir-binary-proof-gate.md
+++ b/plan/issues/2781-hybrid-ir-binary-proof-gate.md
@@ -1,10 +1,11 @@
 ---
 id: 2781
 title: "Hybrid IR step 3: Binary `+` string-or-number proof-gate — unboxed numeric add / string concat only when the operand TS types are PROVEN, else SAFE dynamic `+`"
-status: in-progress
+status: done
 sprint: current
 created: 2026-06-28
 updated: 2026-06-28
+completed: 2026-06-28
 assignee: ttraenkler/sendev-binproof
 priority: medium
 horizon: m

--- a/plan/issues/2781-hybrid-ir-binary-proof-gate.md
+++ b/plan/issues/2781-hybrid-ir-binary-proof-gate.md
@@ -1,0 +1,136 @@
+---
+id: 2781
+title: "Hybrid IR step 3: Binary `+` string-or-number proof-gate — unboxed numeric add / string concat only when the operand TS types are PROVEN, else SAFE dynamic `+`"
+status: in-progress
+sprint: current
+created: 2026-06-28
+updated: 2026-06-28
+assignee: ttraenkler/sendev-binproof
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: max
+task_type: feature
+area: codegen, ir
+language_feature: binary-expression
+goal: correctness
+related: [2755, 2762, 2766, 2780, 1530]
+depends_on: [2766, 2780]
+---
+
+# #2781 — Hybrid IR step 3: Binary `+` string-or-number proof-gate
+
+Third IR-adoption step of the hybrid roadmap
+([`docs/architecture/hybrid-soundness-ir-roadmap.md`](../../docs/architecture/hybrid-soundness-ir-roadmap.md)
+§(b) step 3; audit **Row 7** in
+[`plan/log/hybrid-fastpath-audit.md`](../../plan/log/hybrid-fastpath-audit.md)).
+It builds the **operand-type proof** that rows 3 (packed-`i32`) and 5 (unboxed
+number locals) will reuse, mirroring the prove-then-specialize shape of #2766
+(`lowerElementAccess`) and #2780 (`lowerArrayLiteral` /
+`arrayLiteralWideningEscapes`).
+
+## Problem
+
+`lowerBinary` (`src/ir/from-ast.ts`) lowers both operands with an **f64 hint**,
+reads the **lowered IR types** (`lt`/`rt` from `typeOfValue`), and dispatches:
+
+- if either lowered IR type is `string` → string path (`emitStringConcat` /
+  `emitStringEq`), requiring **both** to be string;
+- otherwise both must be the same scalar kind (`f64`/`i32`) → unboxed numeric
+  op (`f64.add`, …).
+
+For `+` this is the classic JS unsoundness: `a + b` is **string-concat OR
+numeric-add chosen at runtime** (`ToPrimitive` on each operand, then "if either
+is a string → concatenate, else add"). The IR picks concat-vs-add from the
+**lowered Wasm kind**, but per the Hybrid Invariant (HI) a `T`-directed
+specialization must be discharged by a **proof on the TS type**, never the Wasm
+kind.
+
+### Why keying on the Wasm kind is unsound (the Row-7 trap — cost two prior R1 parks)
+
+`number`, `boolean` and `symbol` **all** collapse to the same Wasm scalar kind
+(`f64` / `i32`) at this site. So the lowered kind cannot, on its own, distinguish:
+
+- a genuine `number + number` (numeric add is correct), from
+- an operand whose TS type is `any` / `string` / a `string | number` union that
+  the f64-hint lowering opaquely coerced — where JS would `ToPrimitive` and
+  possibly **string-concat**, and an unconditional `f64.add` would **miscompile**.
+
+The existing IR-type dispatch incidentally catches *string-literal* operands
+(they lower to IR `string`), but it does **not** discharge a real proof: it
+trusts the post-lowering kind. HI requires an **explicit operand-type proof**,
+read from the TS `TypeFlags`, taken **before** the kind-based dispatch.
+
+## Fix (HI prove-then-specialize, mirrors #2766 / #2780)
+
+Add a reusable TS-type-keyed primitive classifier and gate the `+` fast paths
+on it, **before** lowering the operands (so no dead instrs are emitted and the
+demotion reason is the explicit HI one, not an incidental downstream throw):
+
+- `classifyPrimitiveProof(t: ts.Type)` → `"number" | "string" | "unprovable"`:
+  - `"number"` — `NumberLike` (`Number | NumberLiteral`, incl. numeric enum
+    literals), or a union whose **every** constituent is provably number;
+  - `"string"` — `StringLike` (`String | StringLiteral`), or an all-string
+    union;
+  - `"unprovable"` — `any` / `unknown` / `object` / `boolean` / `bigint` /
+    `symbol` / `null` / `undefined` / a **mixed** `number | string` union /
+    template-literal types / anything else.
+- `proveAdditiveOperand(node, cx)` wraps it per operand and returns
+  `"no-checker"` when `cx.checker` is absent.
+
+Gate in `lowerBinary`, for `op === PlusToken` only, **before** operand lowering:
+
+- **with a checker** — require a discharged proof that **both** operands share a
+  provable primitive class: both `number` (→ unboxed numeric add) or both
+  `string` (→ `emitStringConcat`). Any `unprovable`, or a **mixed**
+  number/string pair, throws a clean fallback → the function demotes to the
+  **SAFE legacy dynamic `+`** (`binary-ops.ts` `emitAnyAdd`, which does
+  `ToPrimitive` + string-concat-or-add).
+- **no checker** — leave the existing IR-type dispatch unchanged (exactly like
+  #2780's no-checker arm): there is no new build whose unsoundness we would be
+  masking, and the downstream kind-based checks remain as today's behavior.
+
+### Why this cannot cause a test262 correctness regression
+
+The gate only ever moves a `+` from the IR fast path to the **SAFE legacy**
+dynamic `+`, which is the semantic reference. Demoting is correctness-neutral
+(at worst a perf/byte deopt). The only currently-succeeding IR `+` cases are
+proven `number + number` and proven `string + string` — both keep the fast path
+(the proof holds). Mixed / `any` / union `+` already demoted today (via the
+incidental "mixed string/non-string" or `requireF64` throws); this slice makes
+the demotion reason the explicit HI one and pre-empts the latent
+Wasm-kind-trust miscompile if the IR claim scope widens to `any`/union operands.
+
+### Scope / non-goals
+
+- `+=` (`PlusEqualsToken`) is lowered elsewhere (compound assignment), not by
+  this `op === PlusToken` gate — out of scope; same operand proof can gate it in
+  a follow-up.
+- Arithmetic (`-`, `*`, `/`, …) and relational (`<`, …) ops always `ToNumber`
+  and are the "easy / already-fine" arm of Row 7; they are left on their current
+  path. The **reusable classifier** is built so they (and rows 3/5) can adopt it
+  without new infrastructure.
+- `bigint` `+` is `unprovable` here → SAFE legacy (bigint is gated off the IR
+  anyway).
+
+## Acceptance criteria
+
+- Proven `number + number` (params / literals) keeps the FAST unboxed numeric
+  IR path (no Row-7 demotion) and is value-correct.
+- Proven `string + string` keeps the FAST `emitStringConcat` IR path (no Row-7
+  demotion) and is value-correct.
+- A claimed `string + number` (mixed) `+` demotes via the **explicit Row-7
+  gate** to the SAFE legacy dynamic `+` and is value-correct (`"v" + 5` ⇒
+  `"v5"`).
+- `any` / union `+` produce JS-correct values regardless of mechanism.
+- No test262 regression in the `merge_group` re-validation (IR change →
+  validated full-CI, not scoped).
+- `pnpm run check:ir-fallbacks` stays green (refresh the post-claim baseline if a
+  playground example legitimately newly demotes).
+
+## Test Results
+
+See `tests/issue-2781.test.ts` — FAST-when-proven (number-add and string-concat,
+no demotion via `irPostClaimErrors`) + SAFE-when-not (mixed `string + number`
+demotes via the explicit Row-7 gate, value still correct) + value-correctness
+for `any`/union `+`.

--- a/plan/log/hybrid-fastpath-audit.md
+++ b/plan/log/hybrid-fastpath-audit.md
@@ -56,7 +56,7 @@ gated rollout). Bands are for the *fast-path conversion only*; the §(e)
 | 4 | **Monomorphic `struct.get`/`struct.set`** — `src/codegen/property-access.ts:990` `resolveStructName`, `:1392` `emitNullGuardedStructGet` | receiver is exactly that nominal struct layout — TS permits union arms, `any`-widening, covariant fields, divergent-layout subclasses | receiver provably the single nominal type (IR receiver-type narrowing) **and** no union / `any` / covariant / subclass-layout escape; **else** SAFE dynamic property read (or `ref.test`-guarded read, à la row 8) | `undischarged` (subtle) | subtle | **L** | — (spin from this row) |
 | 5 | **Unboxed `f64`/`i32` number locals (no-box)** — IR `src/ir/analysis/escape.ts:92` `analyzeEscape`; legacy numeric-local typing diffuse across `src/codegen/` | a number-typed local stays unboxed and never needs identity/boxing at an `any`/externref sink | escape analysis proving the value never flows to an `any`/union/externref sink without an explicit box | `partial` | easy (pure-numeric) / subtle (any-union boundary) | **M** | — (spin general arm) |
 | 6 | **`ArrayLiteral` → `vec.new_fixed`** — `src/ir/from-ast.ts:1516` `lowerArrayLiteral` (#1804) | all elements share one static type **and** the literal is not later widened to `any`/heterogeneous | **local** proof: fresh allocation, all elements same static type, no widening escape — cheap, no whole-function dataflow | `discharged` (local) | easy | **S** | **#2780** (`arrayLiteralWideningEscapes` gate; FAST only when the contextual sink is not `any`/`unknown`/heterogeneous) |
-| 7 | **`Binary` unboxed arithmetic** — IR `src/ir/from-ast.ts:3787` `lowerBinary`; legacy `src/codegen/binary-ops.ts:254` `compileBinaryExpression` / `:3660` `compileNumericBinaryOp` | both operands are `number` so emit an `f64`/`i32` op, and `+` is a numeric add — TS allows `any`/union/string-coercible operands and `+` can be string concat | operands provably `number` (not `any`/union/string-coercible) and `+` provably not string-`+`; **else** SAFE `emitAnyAdd` (`binary-ops.ts:3296`) / `emitAnyRelational` (`:3469`) | `partial` | easy (annotated-number) / subtle (`+` possibly-string) | **M** | — (spin general arm) |
+| 7 | **`Binary` unboxed arithmetic** — IR `src/ir/from-ast.ts:3787` `lowerBinary`; legacy `src/codegen/binary-ops.ts:254` `compileBinaryExpression` / `:3660` `compileNumericBinaryOp` | both operands are `number` so emit an `f64`/`i32` op, and `+` is a numeric add — TS allows `any`/union/string-coercible operands and `+` can be string concat | operands provably `number` (not `any`/union/string-coercible) and `+` provably not string-`+`; **else** SAFE `emitAnyAdd` (`binary-ops.ts:3296`) / `emitAnyRelational` (`:3469`) | `partial` (`+` arm discharged) | easy (annotated-number) / subtle (`+` possibly-string) | **M** | **#2781** (`+` proof-gate landed; relational/arith general arm reuses the same `classifyPrimitiveProof` helper) |
 | 8 | **`this`-receiver typed read** — `src/codegen/property-access.ts:5443` `emitThisReceiverGuardConvert` | **none** — it does a runtime `ref.test` instead of trusting the static `this` type | runtime `ref.test` guard (the canonical runtime-guard discharge of `P`) | `discharged` (exemplar) | already-HI-compliant | **S** | F3: document as the HI reference pattern |
 | 9 | **Typed-array element read** — `src/codegen/property-access.ts` typed-array site `~:6341` in `compileElementAccessBody`; shared helper `src/codegen/array-methods.ts:386` `emitBoundsCheckedArrayGet` | view-length is the bound and OOB → `undefined` per spec, **but** the read is entangled with the **shared** helper (the S2 blast-radius lesson) | view length is the bound; OOB → `undefined`; **must stay scoped separately from F1's plain-array scope** — do NOT flip the shared helper default | `partial` | easy but entangled | **S–M** | kept separate from #2760 |
 
@@ -143,10 +143,14 @@ the expensive L tail (rows 3, 4) inherits the machinery the S/M rows establish.
    global. `arrayLiteralWideningEscapes` in `lowerArrayLiteral` gates the fast
    `vec.new_fixed` on the literal's TS contextual type: FAST only when the sink
    is not `any`/`unknown`/heterogeneous, else the SAFE boxed legacy lowering.
-3. **Row 7 — Binary `+` string-or-number proof-gate** (M, *needs an issue*).
-   Builds the operand-type-proof / `any`-union-sink detection that rows 3, 5
-   reuse. Proof-gate the unboxed numeric op in IR `lowerBinary`; SAFE-fall to
-   `emitAnyAdd` when a `+` operand could be a string.
+3. **Row 7 — Binary `+` string-or-number proof-gate** (M, **#2781 — landed**).
+   Built the reusable operand-type-proof (`classifyPrimitiveProof` /
+   `proveAdditiveOperand` in `from-ast.ts`) that rows 3, 5 reuse. Proof-gates the
+   `+` fast path in IR `lowerBinary` on the TS *type* (never the Wasm kind): both
+   operands provably `number` → unboxed numeric add; both provably `string` →
+   `emitStringConcat`; otherwise (`any` / union / mixed) demote to the SAFE legacy
+   dynamic `+` (`emitAnyAdd`). The relational/arith general arm can now adopt the
+   same helper without new infrastructure.
 
 After these three, the L tail (rows **3** packed-i32 and **4** monomorphic
 struct) is architect-scoped / senior-dev implementation — the two paths where a

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -4079,6 +4079,65 @@ function lowerPrefixUnary(expr: ts.PrefixUnaryExpression, cx: LowerCtx): IrValue
   }
 }
 
+/**
+ * #2781 (hybrid Row 7) — TS-type-keyed primitive classifier. The reusable
+ * operand-type proof shared by the binary fast paths (and, going forward, rows
+ * 3 packed-`i32` and 5 unboxed-number-locals, which need the same "provably
+ * number / does-not-escape-to-`any`" judgement).
+ *
+ * Returns the provable primitive class of a TS type for the purpose of
+ * discharging a fast-path safety predicate `P`:
+ *   - `"number"`  — provably a pure number: `NumberLike` (`Number |
+ *     NumberLiteral`, incl. numeric enum literals), or a union whose EVERY
+ *     constituent is provably number.
+ *   - `"string"`  — provably a pure string: `StringLike` (`String |
+ *     StringLiteral`), template-literal / string-mapping types (always strings
+ *     at runtime), or an all-string union.
+ *   - `"unprovable"` — `any` / `unknown` / `object` / `boolean` (= the
+ *     `true | false` union of non-number/string literals) / `bigint` /
+ *     `symbol` / `null` / `undefined` / a MIXED `number | string` union /
+ *     intersections / anything else. Only the SAFE dynamic lowering is correct.
+ *
+ * CRITICAL (the Row-7 trap that parked two prior attempts): this keys on the TS
+ * *type*, NEVER the lowered Wasm kind. `number`, `boolean` and `symbol` all
+ * collapse to `i32` / `f64` at the Wasm level, so the kind cannot distinguish a
+ * numeric-add operand from a boolean / `any` one.
+ */
+const STRING_PROOF_FLAGS = ts.TypeFlags.StringLike | ts.TypeFlags.TemplateLiteral | ts.TypeFlags.StringMapping;
+
+function classifyPrimitiveProof(t: ts.Type): "number" | "string" | "unprovable" {
+  // Union (incl. the intrinsic `boolean`, which is internally `true | false`):
+  // every constituent must share the SAME provable class. Any unprovable
+  // constituent, a mixed number/string union, or an empty (`never`) union →
+  // unprovable.
+  if (t.isUnion()) {
+    let acc: "number" | "string" | null = null;
+    for (const c of t.types) {
+      const cc = classifyPrimitiveProof(c);
+      if (cc === "unprovable") return "unprovable";
+      if (acc === null) acc = cc;
+      else if (acc !== cc) return "unprovable";
+    }
+    return acc ?? "unprovable";
+  }
+  const f = t.flags;
+  if (f & ts.TypeFlags.NumberLike) return "number";
+  if (f & STRING_PROOF_FLAGS) return "string";
+  return "unprovable";
+}
+
+/**
+ * #2781 — per-operand wrapper around {@link classifyPrimitiveProof}. Returns
+ * `"no-checker"` when no TS checker is available, so the caller can leave the
+ * existing kind-based dispatch unchanged (mirrors #2780's no-checker arm: with
+ * no checker there is no specialization whose unsoundness we would be masking).
+ */
+function proveAdditiveOperand(node: ts.Expression, cx: LowerCtx): "number" | "string" | "unprovable" | "no-checker" {
+  const checker = cx.checker;
+  if (!checker) return "no-checker";
+  return classifyPrimitiveProof(checker.getTypeAtLocation(node));
+}
+
 function lowerBinary(expr: ts.BinaryExpression, cx: LowerCtx, hint: IrType): IrValueId {
   const op = expr.operatorToken.kind;
 
@@ -4122,6 +4181,39 @@ function lowerBinary(expr: ts.BinaryExpression, cx: LowerCtx, hint: IrType): IrV
   // recurse into a bare NullKeyword and throw).
   const nullFold = tryFoldNullCompare(expr, op, cx);
   if (nullFold !== null) return nullFold;
+
+  // #2781 (hybrid Row 7) — `+` operand-type proof gate. Run BEFORE operand
+  // lowering (mirrors #2780's pre-element widening gate), so no dead operand
+  // instrs are emitted and the demotion cause is the explicit HI reason rather
+  // than an incidental downstream "mixed string/non-string" / `requireF64`
+  // throw. `+` is string-concat-OR-numeric-add chosen at RUNTIME (ToPrimitive on
+  // each operand, then "if either is a string → concatenate, else add"). The
+  // kind-based dispatch below picks concat-vs-add from the lowered Wasm kind,
+  // but per the Hybrid Invariant a T-directed specialization must be discharged
+  // by a proof on the TS *type*, never the Wasm kind: number / boolean / symbol
+  // all collapse to f64 / i32, so the kind alone cannot tell a genuine
+  // numeric-add operand from an `any` / string / `string | number` one the f64
+  // hint coerced opaquely (the Row-7 trap). Prove BOTH operands number (→ the
+  // unboxed numeric add below) or BOTH string (→ `emitStringConcat`); anything
+  // unprovable — `any` / union / a MIXED number+string pair — demotes to the
+  // SAFE legacy dynamic `+` (`binary-ops.ts` `emitAnyAdd`, ToPrimitive +
+  // string-concat-or-add). No checker → leave the existing kind-based dispatch
+  // unchanged (#2780's no-checker arm). The same operand proof
+  // (`proveAdditiveOperand` / `classifyPrimitiveProof`) is the reusable
+  // infrastructure rows 3 / 5 adopt.
+  if (op === ts.SyntaxKind.PlusToken) {
+    const lProof = proveAdditiveOperand(expr.left, cx);
+    const rProof = proveAdditiveOperand(expr.right, cx);
+    if (lProof !== "no-checker" && rProof !== "no-checker") {
+      if (lProof === "unprovable" || rProof === "unprovable" || lProof !== rProof) {
+        throw new Error(
+          `ir/from-ast: '+' operands not provably both-number or both-string ` +
+            `(${lProof}/${rProof}) — the unboxed numeric-add / string-concat fast ` +
+            `path is unsound here; demote to the SAFE dynamic '+' (emitAnyAdd) in ${cx.funcName}`,
+        );
+      }
+    }
+  }
 
   const lhs = lowerExpr(expr.left, cx, irVal({ kind: "f64" }));
   const rhs = lowerExpr(expr.right, cx, irVal({ kind: "f64" }));

--- a/tests/issue-2781.test.ts
+++ b/tests/issue-2781.test.ts
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2781 — Hybrid IR step 3: Binary `+` string-or-number proof-gate (audit Row 7).
+//
+// `lowerBinary` (`src/ir/from-ast.ts`) lowers both operands with an f64 hint and
+// then picks the unboxed numeric add vs. `emitStringConcat` from the LOWERED
+// Wasm kind. Per the Hybrid Invariant a `T`-directed specialization must be
+// discharged by a proof on the TS TYPE, never the Wasm kind: `+` is
+// string-concat-OR-numeric-add chosen at runtime (ToPrimitive + "if either is a
+// string → concatenate, else add"), and `number` / `boolean` / `symbol` all
+// collapse to the same Wasm scalar kind. This step adds an operand-type proof to
+// the `+` path (mirroring #2766 / #2780's prove-then-specialize shape):
+//   - FAST: both operands provably `number` (→ unboxed numeric add) or both
+//     provably `string` (→ `emitStringConcat`) → keep the fast IR path.
+//   - SAFE: any operand `any` / union / a MIXED number+string pair → demote to
+//     the legacy dynamic `+` (`emitAnyAdd`, ToPrimitive + concat-or-add).
+//     Value-correct either way.
+//
+// The proof reads the TS `TypeFlags`, never the Wasm kind — the headline case
+// below compiles ONE `function f(x: any) { return x + x; }` and calls it with a
+// number AND a string: both are correct only because the gate demoted to the
+// runtime-dispatching SAFE `+`. Keying on the (identical) Wasm kind could not
+// distinguish them.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { analyzeSource } from "../src/checker/index.js";
+import { planIrCompilation } from "../src/ir/select.js";
+
+// Distinctive substring of the Row-7 gate's demotion throw (see `lowerBinary`).
+const GATE = "demote to the SAFE dynamic '+'";
+
+/** The selector claims `fn` for IR compilation (proves it reaches the IR path). */
+function isClaimed(source: string, fn: string): boolean {
+  const ast = analyzeSource(source, "input.ts");
+  const sel = planIrCompilation(ast.sourceFile, { experimentalIR: true });
+  return sel.funcs.has(fn);
+}
+
+/**
+ * Compile via the IR path; return a callable export + the count of Row-7 gate
+ * demotions recorded on `irPostClaimErrors`.
+ */
+async function compileFn(
+  source: string,
+  fn: string,
+): Promise<{ call: (...a: unknown[]) => unknown; gateDemotions: number }> {
+  const r = await compile(source, { experimentalIR: true });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors[0]?.message ?? "unknown"}`);
+  }
+  const gateDemotions = (r.irPostClaimErrors ?? []).filter((e) => e.message.includes(GATE)).length;
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports as unknown as WebAssembly.Imports);
+  (imports as { setExports?: (e: Record<string, Function>) => void }).setExports?.(
+    instance.exports as Record<string, Function>,
+  );
+  const f = (instance.exports as Record<string, unknown>)[fn];
+  if (typeof f !== "function") throw new Error(`export ${fn} missing`);
+  return { call: (...a: unknown[]) => (f as (...x: unknown[]) => unknown)(...a), gateDemotions };
+}
+
+describe("#2781 — IR Binary `+` string-or-number proof-gate", () => {
+  // ── FAST: proof holds → fast IR path kept, NO Row-7 demotion ────────────────
+  describe("FAST path — proven operand types keep the fast IR `+`", () => {
+    it("proven number + number (params) → unboxed numeric add, no demotion", async () => {
+      const src = `export function add(a: number, b: number): number { return a + b; }`;
+      expect(isClaimed(src, "add"), "function IR-claimed").toBe(true);
+      const { call, gateDemotions } = await compileFn(src, "add");
+      expect(call(2, 3)).toBe(5);
+      expect(gateDemotions, "no Row-7 demotion on the FAST numeric path").toBe(0);
+    });
+
+    it("proven number + number (literals) → numeric add, no demotion", async () => {
+      const src = `export function add(): number { return 2 + 3; }`;
+      expect(isClaimed(src, "add")).toBe(true);
+      const { call, gateDemotions } = await compileFn(src, "add");
+      expect(call()).toBe(5);
+      expect(gateDemotions).toBe(0);
+    });
+
+    it("proven string + string (params) → emitStringConcat, no demotion", async () => {
+      const src = `export function cat(a: string, b: string): string { return a + b; }`;
+      expect(isClaimed(src, "cat"), "function IR-claimed").toBe(true);
+      const { call, gateDemotions } = await compileFn(src, "cat");
+      expect(call("foo", "bar")).toBe("foobar");
+      expect(gateDemotions, "no Row-7 demotion on the FAST concat path").toBe(0);
+    });
+
+    it("proven string + string (literals) → concat, no demotion", async () => {
+      const src = `export function cat(): string { return "foo" + "bar"; }`;
+      expect(isClaimed(src, "cat")).toBe(true);
+      const { call, gateDemotions } = await compileFn(src, "cat");
+      expect(call()).toBe("foobar");
+      expect(gateDemotions).toBe(0);
+    });
+  });
+
+  // ── SAFE: proof fails → demote to legacy dynamic `+`, still value-correct ───
+  describe("SAFE path — unprovable operands demote via the Row-7 gate, value-correct", () => {
+    it("HEADLINE: `f(x: any) { return x + x }` is correct for BOTH a number and a string", async () => {
+      // ONE compiled function, called with two runtime types. The `any` operand
+      // is IR-claimed (so `x + x` reaches `lowerBinary`), the gate demotes it to
+      // the runtime-dispatching SAFE `+`, and BOTH results are correct — which is
+      // only possible because the proof keys on the TS type, not the (identical)
+      // Wasm kind both runtime values would share.
+      const src = `export function f(x: any): any { return x + x; }`;
+      expect(isClaimed(src, "f"), "any-operand function IS IR-claimed").toBe(true);
+      const { call, gateDemotions } = await compileFn(src, "f");
+      expect(gateDemotions, "demoted via the explicit Row-7 gate").toBeGreaterThan(0);
+      expect(call(4), "numeric add when the runtime value is a number").toBe(8);
+      expect(call("ab"), "string concat when the runtime value is a string").toBe("abab");
+    });
+
+    it("mixed string + number demotes via the Row-7 gate and concatenates", async () => {
+      const src = `export function f(s: string, n: number): string { return s + n; }`;
+      expect(isClaimed(src, "f"), "function IR-claimed (reaches lowerBinary)").toBe(true);
+      const { call, gateDemotions } = await compileFn(src, "f");
+      expect(gateDemotions, "demoted via the explicit Row-7 gate").toBeGreaterThan(0);
+      expect(call("v", 5), "SAFE legacy `+` does ToPrimitive + concat").toBe("v5");
+    });
+
+    it("mixed string literal + number literal demotes and concatenates", async () => {
+      const src = `export function f(): string { return "x" + 5; }`;
+      const { call, gateDemotions } = await compileFn(src, "f");
+      expect(gateDemotions).toBeGreaterThan(0);
+      expect(call()).toBe("x5");
+    });
+  });
+
+  // ── Non-claimed union `+` is untouched by this slice ────────────────────────
+  describe("non-claimed union `+` is unaffected by the Row-7 gate", () => {
+    it("a `string | number` union param is NOT IR-claimed → pure legacy path", async () => {
+      // A union param is rejected by the selector, so `g` never reaches the IR
+      // `+` gate at all — this slice does not change union-typed `+`. The numeric
+      // arm is value-correct on legacy today; the string arm is a SEPARATE,
+      // pre-existing legacy union-coercion gap (legacy returns NaN for `"z"+"z"`
+      // even with experimentalIR OFF) that the broader hybrid program owns, NOT
+      // this Row-7 IR slice. Asserted only to pin that the gate left it alone.
+      const src = `function g(x: string | number): any { return x + x; }
+        export function fn(): any { return g(3); }`;
+      expect(isClaimed(src, "g"), "union param ⇒ not IR-claimed").toBe(false);
+      const { call: fn, gateDemotions } = await compileFn(src, "fn");
+      expect(gateDemotions, "no Row-7 demotion — g never reaches the IR `+` gate").toBe(0);
+      expect(fn()).toBe(6);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Third IR-adoption step of the hybrid type-soundness roadmap (audit **Row 7** in `plan/log/hybrid-fastpath-audit.md`; §(b) step 3 of `docs/architecture/hybrid-soundness-ir-roadmap.md`). Builds the **reusable operand-type proof** that rows 3 (packed-`i32`) and 5 (unboxed number locals) will reuse, mirroring the prove-then-specialize shape of #2766 (`lowerElementAccess`) and #2780 (`lowerArrayLiteral`).

`lowerBinary` (`src/ir/from-ast.ts`) picks unboxed numeric-add vs. `emitStringConcat` for `+` from the **lowered Wasm kind**. Per the Hybrid Invariant a `T`-directed specialization must be discharged by a proof on the **TS type**, never the Wasm kind — `+` is string-concat-OR-numeric-add chosen at runtime (`ToPrimitive` + "if either operand is a string → concatenate, else add").

## Change

- New reusable helpers `classifyPrimitiveProof(t)` / `proveAdditiveOperand(node, cx)` — classify a TS type as `number` / `string` / `unprovable`, keyed on `TypeFlags`.
- Gate the `+` fast path in `lowerBinary`, **before** operand lowering: both operands provably `number` → unboxed numeric add; both provably `string` → `emitStringConcat`; anything `unprovable` (`any` / union / a **mixed** number+string pair) → demote to the **SAFE legacy dynamic `+`** (`binary-ops.ts` `emitAnyAdd`). No checker → existing kind-based dispatch unchanged (mirrors #2780's no-checker arm).

### The Row-7 trap (cost two prior R1 parks)

`number` / `boolean` / `symbol` all collapse to the same Wasm scalar kind (`f64`/`i32`), so the kind alone cannot tell a genuine numeric-add operand from an `any` / string one. The proof keys on the **TS type**. Headline test: ONE compiled `function f(x: any) { return x + x; }` returns `8` for input `4` **and** `"abab"` for input `"ab"` — correct only because the gate demoted to the runtime-dispatching SAFE `+`.

### Why this cannot cause a test262 correctness regression

The gate only moves a `+` from the IR fast path to the SAFE legacy dynamic `+` (the semantic reference). The only currently-succeeding IR `+` cases are proven `number+number` / `string+string` — both keep the fast path. Mixed/`any`/union `+` already demoted via incidental downstream throws today (values already correct); this slice gives them an explicit HI reason and pre-empts the latent Wasm-kind-trust miscompile if the IR claim scope widens.

## Validation

- `tsc --noEmit` clean.
- `tests/issue-2781.test.ts` — 8/8 (FAST-when-proven, no `irPostClaimErrors` Row-7 demotion; SAFE-when-not, demotes + value-correct; the any-headline both-types case).
- 128 existing IR binary/string/array tests green (#1169a/n/o, #1182, ir-vec-new-fixed, #2766, #2780).
- `pnpm run check:ir-fallbacks` OK — no unintended bucket growth, no post-claim demotions on the playground examples.
- BROAD-IMPACT (IR change) → relies on `merge_group` full-CI/test262 re-validation.

Closes #2781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)