### PR TITLE
fix(#2770): brand boolean extern-method results on bare-var receivers (S5b of #2773)

### DIFF
--- a/plan/issues/2770-dynamic-dispatch-boolean-boxing.md
+++ b/plan/issues/2770-dynamic-dispatch-boolean-boxing.md
@@ -1,11 +1,13 @@
 ---
 id: 2770
 title: "dynamic builtin boolean-method on a bare-var/dynamic receiver boxes the i32 result as a NUMBER not a boolean (set.has/map.has/re.test → 1 not true)"
-status: ready
+status: done
+assignee: ttraenkler/sendev-s5b-bool-brand
 sprint: current
 priority: high
 created: 2026-06-28
 updated: 2026-06-28
+completed: 2026-06-28
 feasibility: medium
 reasoning_effort: high
 task_type: bugfix
@@ -103,3 +105,48 @@ box-the-result change → **routing to architect for a spec** (which result site
 to brand, the shared helper signature, over-boxing guards, and the full-CI
 validation plan). The precise root cause + the divergent `Set_has`(externref) vs
 `Map_has`(i32) routing above give the architect a complete starting point.
+
+## Implementation note (S5b of #2773, senior-dev, 2026-06-28)
+
+**Why the per-call-site wrap is the load-bearing fix (and a registration-only
+fix is NOT sufficient).** `getWasmFuncReturnType` (`expressions/helpers.ts`)
+reads the result ValType back from the registered **func type** in
+`ctx.mod.types`. Func types are deduped by `funcTypeKey`
+(`registry/types.ts`), which keys results on **`r.kind` only** — so a branded
+`{kind:"i32",boolean:true}` result func type collapses onto a pre-existing
+*unbranded* `(externref,externref)->i32` type. The brand therefore never
+survives into the func type, and every dispatch-result site
+(`getWasmFuncReturnType(ctx, idx) ?? resolveWasmType(ctx, retType)`) reads back a
+bare i32. This is exactly why dev-rescue's localized registration-only attempt
+failed for the bare-var case. The fix re-derives the brand from the **call's TS
+return type** at each result site, independent of the deduped func type.
+
+**The fix has three parts:**
+1. **Shared helper** `brandExternMethodResult(ctx, tsReturnType, valType)` in
+   `src/codegen/shared.ts` (the acyclic sink — avoids the
+   `calls.ts ↔ property-access.ts` import cycle). Re-tags a **bare** i32 whose
+   declared return type is *exactly* `boolean` (via `isStrictBooleanReturnType`,
+   which checks `TypeFlags.Boolean | BooleanLiteral` so `number`,
+   `boolean | undefined` unions, and `void` are rejected). Over-box guards:
+   leaves f64 / externref / ref / already-`boolean:true` untouched; idempotent.
+2. **Per-call-site wrap** at all **14** extern-method-result sites in
+   `expressions/calls.ts` (the `getWasmFuncReturnType(...) ?? resolveWasmType(ctx,
+   retType)` family — `finalStaticIdx`, `finalMethodIdx`, `finalStructMethodIdx`,
+   `finalFuncIdx`, `funcIdx`, `finalCallIdx`, and the `callReturnType =` arms).
+   Each already has `const retType = checker.getReturnTypeOfSignature(sig)` in
+   scope, so the wrap is `brandExternMethodResult(ctx, retType, <expr>)`.
+3. **Registration brand** at the two extern-method-decl sites in `index.ts`
+   (`collectExternClass` ~12657 and `collectInterfaceMembers` ~12809, the Map/Set
+   `declare var`/interface path) so the direct `methodInfo.results[0]` consumption
+   path in `extern.ts` is honest at source. (The `registerBuiltinExternClasses`
+   fallback already registers boolean methods as **externref**, which boxes
+   correctly — left unchanged; branding it to i32 would break the host import
+   signature.)
+
+This **subsumes** the RegExp `.test` case (#2770 acceptance: `re.test` → boolean;
+test262 `language/literals/regexp/y-assertion-start.js`) and covers the ES2025
+Set predicates `isSubsetOf`/`isSupersetOf`/`isDisjointFrom`. Over-boxing verified
+absent: `map.get`/`map.size`/`indexOf` stay numbers. Tests in
+`tests/issue-2770.test.ts` (11 cases) + tsc clean + #2016/#2030 boolean-brand and
+collection suites green locally; conformance validated on full `merge_group` +
+standalone-floor (broad-impact result path, never a scoped sweep).

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -110,7 +110,7 @@ import {
 } from "../property-access.js";
 import { emitToNumber, emitToString } from "../coercion-engine.js";
 import type { InnerResult } from "../shared.js";
-import { coerceType, compileExpression, valTypesMatch, VOID_RESULT } from "../shared.js";
+import { brandExternMethodResult, coerceType, compileExpression, valTypesMatch, VOID_RESULT } from "../shared.js";
 // (#2193 PR-B) reflective `m.call(thisArg, …)` on a `$NativeProto` member-closure value.
 import { ensureArrayNativeProtoGlue, ensureObjectNativeProtoGlue } from "../array-object-proto.js";
 import {
@@ -8819,7 +8819,11 @@ function compileCallExpression(
             const retType = ctx.checker.getReturnTypeOfSignature(sig);
             if (isEffectivelyVoidReturn(ctx, retType, fullName)) return VOID_RESULT;
             if (wasmFuncReturnsVoid(ctx, finalStaticIdx)) return VOID_RESULT;
-            return getWasmFuncReturnType(ctx, finalStaticIdx) ?? resolveWasmType(ctx, retType);
+            return brandExternMethodResult(
+              ctx,
+              retType,
+              getWasmFuncReturnType(ctx, finalStaticIdx) ?? resolveWasmType(ctx, retType),
+            );
           }
           return VOID_RESULT;
         }
@@ -9488,7 +9492,11 @@ function compileCallExpression(
             const retType = ctx.checker.getReturnTypeOfSignature(sig);
             if (isEffectivelyVoidReturn(ctx, retType, fullName)) return VOID_RESULT;
             if (wasmFuncReturnsVoid(ctx, finalMethodIdx)) return VOID_RESULT;
-            return getWasmFuncReturnType(ctx, finalMethodIdx) ?? resolveWasmType(ctx, retType);
+            return brandExternMethodResult(
+              ctx,
+              retType,
+              getWasmFuncReturnType(ctx, finalMethodIdx) ?? resolveWasmType(ctx, retType),
+            );
           }
           return VOID_RESULT;
         }
@@ -9569,7 +9577,11 @@ function compileCallExpression(
           if (sig) {
             const retType = ctx.checker.getReturnTypeOfSignature(sig);
             if (!isEffectivelyVoidReturn(ctx, retType, fullName))
-              callReturnType = getWasmFuncReturnType(ctx, funcIdx) ?? resolveWasmType(ctx, retType);
+              callReturnType = brandExternMethodResult(
+                ctx,
+                retType,
+                getWasmFuncReturnType(ctx, funcIdx) ?? resolveWasmType(ctx, retType),
+              );
           }
           const tmp = allocLocal(fctx, `__ng_recv_${fctx.locals.length}`, recvType);
           fctx.body.push({ op: "local.tee", index: tmp });
@@ -9685,7 +9697,11 @@ function compileCallExpression(
           const retType = ctx.checker.getReturnTypeOfSignature(sig);
           if (isEffectivelyVoidReturn(ctx, retType, fullName)) return VOID_RESULT;
           if (wasmFuncReturnsVoid(ctx, finalMethodIdx)) return VOID_RESULT;
-          return getWasmFuncReturnType(ctx, finalMethodIdx) ?? resolveWasmType(ctx, retType);
+          return brandExternMethodResult(
+            ctx,
+            retType,
+            getWasmFuncReturnType(ctx, finalMethodIdx) ?? resolveWasmType(ctx, retType),
+          );
         }
         return VOID_RESULT;
       }
@@ -9717,7 +9733,11 @@ function compileCallExpression(
             if (sig) {
               const retType = ctx.checker.getReturnTypeOfSignature(sig);
               if (!isEffectivelyVoidReturn(ctx, retType, fullName))
-                callReturnType = getWasmFuncReturnType(ctx, funcIdx) ?? resolveWasmType(ctx, retType);
+                callReturnType = brandExternMethodResult(
+                  ctx,
+                  retType,
+                  getWasmFuncReturnType(ctx, funcIdx) ?? resolveWasmType(ctx, retType),
+                );
             }
             const tmp = allocLocal(fctx, `__ng_srecv_${fctx.locals.length}`, recvType);
             fctx.body.push({ op: "local.tee", index: tmp });
@@ -9826,7 +9846,11 @@ function compileCallExpression(
             const retType = ctx.checker.getReturnTypeOfSignature(sig);
             if (isEffectivelyVoidReturn(ctx, retType, fullName)) return VOID_RESULT;
             if (wasmFuncReturnsVoid(ctx, finalStructMethodIdx)) return VOID_RESULT;
-            return getWasmFuncReturnType(ctx, finalStructMethodIdx) ?? resolveWasmType(ctx, retType);
+            return brandExternMethodResult(
+              ctx,
+              retType,
+              getWasmFuncReturnType(ctx, finalStructMethodIdx) ?? resolveWasmType(ctx, retType),
+            );
           }
           return VOID_RESULT;
         }
@@ -13022,7 +13046,11 @@ function compileCallExpression(
       // functions with Promise<void>), the TS type may be misleading
       if (wasmFuncReturnsVoid(ctx, finalFuncIdx)) return VOID_RESULT;
       // Use actual Wasm return type to avoid TS 'any' → externref mismatch
-      return getWasmFuncReturnType(ctx, finalFuncIdx) ?? resolveWasmType(ctx, retType);
+      return brandExternMethodResult(
+        ctx,
+        retType,
+        getWasmFuncReturnType(ctx, finalFuncIdx) ?? resolveWasmType(ctx, retType),
+      );
     }
     return getWasmFuncReturnType(ctx, finalFuncIdx) ?? { kind: "f64" };
   }
@@ -13680,7 +13708,11 @@ function compileCallExpression(
             const retType = ctx.checker.getReturnTypeOfSignature(sig);
             if (isEffectivelyVoidReturn(ctx, retType, fullName)) return VOID_RESULT;
             if (wasmFuncReturnsVoid(ctx, funcIdx)) return VOID_RESULT;
-            return getWasmFuncReturnType(ctx, funcIdx) ?? resolveWasmType(ctx, retType);
+            return brandExternMethodResult(
+              ctx,
+              retType,
+              getWasmFuncReturnType(ctx, funcIdx) ?? resolveWasmType(ctx, retType),
+            );
           }
           return VOID_RESULT;
         }
@@ -13703,7 +13735,11 @@ function compileCallExpression(
             if (sig) {
               const retType = ctx.checker.getReturnTypeOfSignature(sig);
               if (!isEffectivelyVoidReturn(ctx, retType, fullName))
-                callReturnType = getWasmFuncReturnType(ctx, funcIdx) ?? resolveWasmType(ctx, retType);
+                callReturnType = brandExternMethodResult(
+                  ctx,
+                  retType,
+                  getWasmFuncReturnType(ctx, funcIdx) ?? resolveWasmType(ctx, retType),
+                );
             }
             const tmp = allocLocal(fctx, `__ng_ea_recv_${fctx.locals.length}`, recvType);
             fctx.body.push({ op: "local.tee", index: tmp });
@@ -13785,7 +13821,11 @@ function compileCallExpression(
             const retType = ctx.checker.getReturnTypeOfSignature(sig);
             if (isEffectivelyVoidReturn(ctx, retType, fullName)) return VOID_RESULT;
             if (wasmFuncReturnsVoid(ctx, funcIdx)) return VOID_RESULT;
-            return getWasmFuncReturnType(ctx, funcIdx) ?? resolveWasmType(ctx, retType);
+            return brandExternMethodResult(
+              ctx,
+              retType,
+              getWasmFuncReturnType(ctx, funcIdx) ?? resolveWasmType(ctx, retType),
+            );
           }
           return VOID_RESULT;
         }
@@ -13822,7 +13862,11 @@ function compileCallExpression(
               const retType = ctx.checker.getReturnTypeOfSignature(sig);
               if (isEffectivelyVoidReturn(ctx, retType, fullName)) return VOID_RESULT;
               if (wasmFuncReturnsVoid(ctx, funcIdx)) return VOID_RESULT;
-              return getWasmFuncReturnType(ctx, funcIdx) ?? resolveWasmType(ctx, retType);
+              return brandExternMethodResult(
+                ctx,
+                retType,
+                getWasmFuncReturnType(ctx, funcIdx) ?? resolveWasmType(ctx, retType),
+              );
             }
             return VOID_RESULT;
           }
@@ -14141,7 +14185,11 @@ function compileCallExpression(
             const retType = ctx.checker.getReturnTypeOfSignature(sig);
             if (isEffectivelyVoidReturn(ctx, retType, funcName)) return VOID_RESULT;
             if (wasmFuncReturnsVoid(ctx, finalFuncIdx)) return VOID_RESULT;
-            return getWasmFuncReturnType(ctx, finalFuncIdx) ?? resolveWasmType(ctx, retType);
+            return brandExternMethodResult(
+              ctx,
+              retType,
+              getWasmFuncReturnType(ctx, finalFuncIdx) ?? resolveWasmType(ctx, retType),
+            );
           }
           return getWasmFuncReturnType(ctx, finalFuncIdx) ?? { kind: "f64" };
         }
@@ -14202,7 +14250,11 @@ function compileCallExpression(
               const retType = ctx.checker.getReturnTypeOfSignature(sig);
               if (isEffectivelyVoidReturn(ctx, retType, fullName)) return VOID_RESULT;
               if (wasmFuncReturnsVoid(ctx, finalCallIdx)) return VOID_RESULT;
-              return getWasmFuncReturnType(ctx, finalCallIdx) ?? resolveWasmType(ctx, retType);
+              return brandExternMethodResult(
+                ctx,
+                retType,
+                getWasmFuncReturnType(ctx, finalCallIdx) ?? resolveWasmType(ctx, retType),
+              );
             }
             return VOID_RESULT;
           }
@@ -14742,7 +14794,11 @@ function compileConditionalCallee(
           const retType = ctx.checker.getReturnTypeOfSignature(branchSigs[0]!);
           if (isEffectivelyVoidReturn(ctx, retType, funcName)) return VOID_RESULT;
           if (wasmFuncReturnsVoid(ctx, finalFuncIdx)) return VOID_RESULT;
-          return getWasmFuncReturnType(ctx, finalFuncIdx) ?? resolveWasmType(ctx, retType);
+          return brandExternMethodResult(
+            ctx,
+            retType,
+            getWasmFuncReturnType(ctx, finalFuncIdx) ?? resolveWasmType(ctx, retType),
+          );
         }
         return callRetType ?? getWasmFuncReturnType(ctx, finalFuncIdx) ?? { kind: "f64" };
       }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -89,6 +89,7 @@ import {
   getRunLoopFuncIdxForWasiStart,
 } from "./async-scheduler.js";
 import {
+  brandExternMethodResult,
   ensureLateImport,
   flushLateImportShifts,
   registerAddStringImports,
@@ -12654,7 +12655,11 @@ function collectExternClass(ctx: CodegenContext, decl: ts.ClassDeclaration, name
           if (!p.questionToken && !p.initializer) requiredParams++;
         }
         const retType = ctx.checker.getReturnTypeOfSignature(sig);
-        const results: ValType[] = isVoidType(retType) ? [] : [mapTsTypeToWasm(retType, ctx.checker)];
+        // (#2770, S5b) Brand a boolean extern-method result at registration so the
+        // direct `methodInfo.results[0]` consumption path (extern.ts) is honest.
+        const results: ValType[] = isVoidType(retType)
+          ? []
+          : [brandExternMethodResult(ctx, retType, mapTsTypeToWasm(retType, ctx.checker))];
         info.methods.set(methodName, { params, results, requiredParams });
       }
     }
@@ -12806,7 +12811,11 @@ function collectInterfaceMembers(
           if (!p.questionToken && !p.initializer) requiredParams++;
         }
         const retType = ctx.checker.getReturnTypeOfSignature(sig);
-        const results: ValType[] = isVoidType(retType) ? [] : [mapTsTypeToWasm(retType, ctx.checker)];
+        // (#2770, S5b) Brand a boolean extern-method result at registration so the
+        // direct `methodInfo.results[0]` consumption path (extern.ts) is honest.
+        const results: ValType[] = isVoidType(retType)
+          ? []
+          : [brandExternMethodResult(ctx, retType, mapTsTypeToWasm(retType, ctx.checker))];
         info.methods.set(methodName, { params, results, requiredParams });
       }
     }

--- a/src/codegen/shared.ts
+++ b/src/codegen/shared.ts
@@ -392,6 +392,51 @@ export function isAnyValue(type: ValType, ctx: CodegenContext): boolean {
   );
 }
 
+/**
+ * True only when a declared TS return type is *exactly* `boolean` (or a boolean
+ * literal `true`/`false`). Strict by design (#2770): a `boolean | undefined`
+ * union, `number`, etc. carry the outer `Union`/`Number` flag — NOT the
+ * `Boolean` flag — so they are rejected. This gates the boolean-result branding
+ * below so only genuine boolean returns are re-tagged.
+ */
+function isStrictBooleanReturnType(t: ts.Type): boolean {
+  return (t.flags & (ts.TypeFlags.Boolean | ts.TypeFlags.BooleanLiteral)) !== 0;
+}
+
+/**
+ * (#2770, S5b of #2773) Brand an extern-method result ValType as a *boolean*
+ * when the method's declared TS return type is exactly `boolean`, so the
+ * `any`/return coercion boxes it via `__box_boolean` (→ `true`/`false`) instead
+ * of `__box_number` (→ `1`/`0`).
+ *
+ * Why a per-call-site wrap (not just registration): a boolean extern method's
+ * func type carries an `i32` result, and `funcTypeKey` (registry/types.ts) keys
+ * results on `.kind` only — so a branded `{i32,boolean:true}` result func type
+ * dedups to a pre-existing *unbranded* `…->i32` type. `getWasmFuncReturnType`
+ * then reads back the deduped unbranded i32 and the brand is lost at every
+ * `getWasmFuncReturnType(ctx, idx) ?? resolveWasmType(ctx, retType)` dispatch
+ * site. Re-branding from the call's TS return type here recovers it regardless
+ * of dedup. (Registration is also branded so the direct `methodInfo.results[0]`
+ * path in extern.ts is honest at source.)
+ *
+ * Over-boxing guards — idempotent, never widens:
+ *  - only a *bare* `i32` is touched (f64/externref/ref/ref_null pass through);
+ *  - an already `{i32,boolean:true}` value short-circuits (idempotent);
+ *  - only an *exactly*-`boolean` declared return is branded (numbers, unions,
+ *    `void`, etc. pass through unchanged — `map.get`/`indexOf`/`.size` stay
+ *    numbers).
+ */
+export function brandExternMethodResult(
+  _ctx: CodegenContext,
+  tsReturnType: ts.Type | undefined,
+  valType: ValType,
+): ValType {
+  if (!tsReturnType) return valType;
+  if (valType.kind !== "i32" || (valType as { boolean?: boolean }).boolean) return valType;
+  if (!isStrictBooleanReturnType(tsReturnType)) return valType;
+  return { kind: "i32", boolean: true };
+}
+
 // ── ensureAnyHelpers ──────────────────────────────────────────────────
 
 type EnsureAnyHelpersFn = (ctx: CodegenContext) => void;

--- a/tests/issue-2770.test.ts
+++ b/tests/issue-2770.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+// #2770 (S5b of #2773) — a boolean-returning builtin method on a BARE-`var`
+// (evolving-`any` / dynamic) receiver dispatched through the
+// `${className}_${methodName}` funcMap path returned a bare i32 with the
+// `boolean: true` brand dropped at the result site
+// (`getWasmFuncReturnType(...) ?? resolveWasmType(...)`). The unbranded i32 then
+// boxed as a JS *number* (`1`/`0`) at the `any`/return boundary instead of a JS
+// *boolean* (`true`/`false`). The string-concat context below exposes it: a
+// boolean stringifies "true"/"false", a number "1"/"0".
+//
+// Fix: `brandExternMethodResult` re-tags a bare-i32 result whose declared TS
+// return type is exactly `boolean`, applied at every dispatch-result site (and
+// at extern-method registration). Typed receivers, numeric methods, and
+// already-externref boolean results are unchanged.
+
+async function evalStr(body: string): Promise<unknown> {
+  const exports = await compileToWasm(body);
+  return (exports as { test: () => unknown }).test();
+}
+
+describe("#2770 bare-var boolean-method result brands as boolean (not number)", () => {
+  it("Set.has on a bare-var receiver → true/false (not 1/0)", async () => {
+    expect(
+      await evalStr(
+        `export function test(): string { var s: any; s = new Set([1]); return s.has(1) + "," + s.has(2); }`,
+      ),
+    ).toBe("true,false");
+  });
+
+  it("Set.delete on a bare-var receiver → true/false", async () => {
+    expect(
+      await evalStr(
+        `export function test(): string { var s: any; s = new Set([1]); return s.delete(1) + "," + s.delete(9); }`,
+      ),
+    ).toBe("true,false");
+  });
+
+  it("Map.has on a bare-var receiver → true/false", async () => {
+    expect(
+      await evalStr(
+        `export function test(): string { var m: any; m = new Map(); m.set(1, 9); return m.has(1) + "," + m.has(2); }`,
+      ),
+    ).toBe("true,false");
+  });
+
+  it("Map.delete on a bare-var receiver → true/false", async () => {
+    expect(
+      await evalStr(
+        `export function test(): string { var m: any; m = new Map(); m.set(1, 9); return m.delete(1) + "," + m.delete(1); }`,
+      ),
+    ).toBe("true,false");
+  });
+
+  it("RegExp.test on a bare-var receiver → true/false (subsumes the RegExp case)", async () => {
+    expect(
+      await evalStr(`export function test(): string { var r: any; r = /a/g; return r.test("a") + "," + r.test("b"); }`),
+    ).toBe("true,false");
+  });
+
+  it("ES2025 Set algebra predicates on a bare-var receiver → boolean", async () => {
+    expect(
+      await evalStr(
+        `export function test(): string {
+           var a: any; a = new Set([1, 2]);
+           var b: any; b = new Set([1, 2, 3]);
+           return a.isSubsetOf(b) + "," + a.isSupersetOf(b) + "," + a.isDisjointFrom(new Set([9]));
+         }`,
+      ),
+    ).toBe("true,false,true");
+  });
+});
+
+describe("#2770 typed-receiver booleans unchanged", () => {
+  it("Set.has on a typed const receiver still → true/false", async () => {
+    expect(
+      await evalStr(`export function test(): string { const s = new Set([1]); return s.has(1) + "," + s.has(2); }`),
+    ).toBe("true,false");
+  });
+
+  it("returns a truthy boolean value (typed receiver, raw i32 export)", async () => {
+    // A `boolean`-returning wasm *export* yields the unboxed i32 (1/0) — wasm has
+    // no bool type — so coerce with `!!` to check the value. This path is
+    // UNCHANGED by S5b (the typed `Set_has` route already returns the right bit);
+    // the brand only matters at the `any`/box boundary exercised above.
+    const exports = await compileToWasm(`export function test(): boolean { const s = new Set([1]); return s.has(1); }`);
+    expect(!!(exports as { test: () => unknown }).test()).toBe(true);
+  });
+});
+
+describe("#2770 no over-boxing — numeric methods stay numbers", () => {
+  it("Map.get on a bare-var receiver stays a number", async () => {
+    expect(
+      await evalStr(
+        `export function test(): string { var m: any; m = new Map(); m.set(1, 42); return "" + m.get(1); }`,
+      ),
+    ).toBe("42");
+  });
+
+  it("Map.size on a bare-var receiver stays a number", async () => {
+    expect(
+      await evalStr(
+        `export function test(): string { var m: any; m = new Map(); m.set(1, 9); m.set(2, 8); return "" + m.size; }`,
+      ),
+    ).toBe("2");
+  });
+
+  it("Array.indexOf stays a number (not a boolean)", async () => {
+    expect(
+      await evalStr(
+        `export function test(): string { var a: any; a = [10, 20, 30]; return a.indexOf(20) + "," + a.indexOf(99); }`,
+      ),
+    ).toBe("1,-1");
+  });
+});


### PR DESCRIPTION
## #2770 — boolean extern-method result on a bare-var/dynamic receiver boxes as number (S5b of #2773)

`var s; s = new Set([1]); s.has(1)` returned **`1`** instead of **`true`** (same for `map.has`, `set.delete`, `map.delete`, `re.test`, and the ES2025 Set predicates). A bare-`var` (evolving-`any`) receiver dispatches through the `${className}_${methodName}` funcMap path, whose result ValType is `getWasmFuncReturnType(ctx, idx) ?? resolveWasmType(ctx, retType)` — a **bare i32** with the `boolean: true` brand dropped at **every** such site. The unbranded i32 then boxed via `__box_number` at the `any`/return boundary.

### Why a registration-only fix is insufficient (root cause)
`getWasmFuncReturnType` reads the result back from the registered **func type**, but `funcTypeKey` (`registry/types.ts`) keys results on **`r.kind` only** — so a branded `{i32,boolean:true}` result collapses onto a pre-existing *unbranded* `…->i32` type and the brand never survives. The brand must be **re-derived from the call's TS return type** at each result site (this is why dev-rescue's localized registration-only attempt failed for the bare-var case).

### Fix
1. **Shared helper** `brandExternMethodResult(ctx, tsReturnType, valType)` in `src/codegen/shared.ts` (the acyclic sink — avoids the `calls.ts ↔ property-access.ts` cycle). Re-tags a **bare** i32 whose declared return is *exactly* `boolean` (`TypeFlags.Boolean | BooleanLiteral`, so `number` / `boolean | undefined` / `void` are rejected). Over-box guards: skips f64 / externref / ref / already-`boolean:true`; idempotent.
2. **Per-call-site wrap** at all **14** extern-method-result sites in `src/codegen/expressions/calls.ts`.
3. **Registration brand** at the two extern-method-decl sites in `src/codegen/index.ts` (`collectExternClass` + `collectInterfaceMembers`) so the direct `methodInfo.results[0]` path in `extern.ts` is honest at source. (The `registerBuiltinExternClasses` fallback already registers boolean methods as externref — correct — and is left unchanged.)

**Subsumes** the RegExp `.test` case (test262 `language/literals/regexp/y-assertion-start.js`) and covers ES2025 `isSubsetOf`/`isSupersetOf`/`isDisjointFrom`.

### Acceptance
- bare-var `Set.has`/`Set.delete`/`Map.has`/`Map.delete`/`RegExp.test`/ES2025 Set predicates → `true`/`false` ✓
- typed-receiver booleans **unchanged** ✓
- no over-boxing: `map.get` / `map.size` / `indexOf` stay numbers ✓
- `tests/issue-2770.test.ts` (11 cases) green; tsc clean; #2016/#2030 + collection suites green locally.

### Scope
S5b of #2773 only (epic referenced by number, not carried). Broad-impact (the extern method-call result path is hot) → validated on full `merge_group` + standalone-floor, never a scoped sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)