### PR TITLE
chore(release): v0.58.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.57.0",
+  "version": "0.58.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js2wasm",
-  "version": "0.57.0",
+  "version": "0.58.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC (unscoped proxy for @loopdive/js2)",
   "keywords": [
     "webassembly",


### PR DESCRIPTION
Cuts npm release **v0.58.0** of `@loopdive/js2` — the **first tokenless OIDC publish** validating the trusted-publisher setup (#2204), and the minor bump for the relative-import bundling capability.

## Why 0.58.0 (minor)
Everything merged since 0.57.0:
- **#2771** relative-import bundling — a new compiler capability (drives the minor bump)
- **#2775 / #2778** native-messaging gallery renames + shared-core dedup
- **#2777** nm_node_process O(n) perf

## What this is
`node scripts/release.mjs 0.58.0` — lockstep bump of BOTH `package.json` (root `@loopdive/js2`) and `packages/js2wasm/package.json` (proxy) to `0.58.0`, single `release: v0.58.0` commit + annotated `v0.58.0` tag (held local until merge per `docs/releasing.md`).

## Publish path (tokenless OIDC)
After this merges, pushing the `v0.58.0` tag fires `publish-npm.yml`:
- `verify-version` enforces tag == both package.json versions (0.58.0)
- `npm install -g npm@latest`, then `npm publish --provenance --access public` authenticated via GitHub Actions OIDC against the `@loopdive/js2` trusted publisher (no `NODE_AUTH_TOKEN`)
- the unscoped `js2wasm` proxy and JSR steps remain `if: false` (disabled)

Verifies `npm view @loopdive/js2 version` → `0.58.0` with a provenance attestation (0.57.0 was published locally and has none).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>