### PR TITLE
docs: #2787 track differential-test corpus failures (2 malformed_wasm + ~15 mismatch)

### DIFF
--- a/plan/issues/2787-differential-test-corpus-failures.md
+++ b/plan/issues/2787-differential-test-corpus-failures.md
@@ -1,0 +1,113 @@
+---
+id: 2787
+title: "Differential-test corpus failures — 2 malformed_wasm + 13 mismatch + 6 runtime_error"
+status: ready
+sprint: Backlog
+created: 2026-06-28
+updated: 2026-06-28
+priority: medium
+feasibility: medium
+reasoning_effort: medium
+task_type: bug
+area: conformance
+language_feature: compiler-internals
+goal: trustworthiness
+related: [389, 2143, 1941]
+origin: "2026-06-28 — diff-test red on main (job 83903650345, surfaced in #2252 merge_group); reply to loopdive/js2#389"
+---
+
+# #2787 — Differential-test corpus failures (umbrella tracking)
+
+## Problem
+
+The `diff-test` ("Differential test", `scripts/diff-test.ts`, corpus
+`tests/differential/corpus`, 104 programs) is a **non-required** gate that
+compares js2wasm output against the V8 reference engine (Node-host lane:
+in-process `compile()` → `WebAssembly.validate` → instantiate → compare
+stdout). It is currently **red on main**.
+
+The redness was surfaced in **#2252's `merge_group`** — a pure dependency
+**version bump** with no codegen change — so these failures are
+**pre-existing**, not release-caused. In that run the corpus actually
+**net-improved** (baseline 69/104 → current 83/104 match, 15 improvements);
+the delta gate failed on a **single new regression**
+(`array/01-basic.js: match → malformed_wasm`). This umbrella issue catalogs
+the full failing set so it can be triaged down over time.
+
+Source of truth for the list below: CI job **83903650345**
+(`gh run view --job 83903650345 -R loopdive/js2 --log`). The default lane and
+the `-O3` optimize lane show the **same** 21 failures, so none is
+wasm-opt-specific.
+
+## Failure buckets (21 failing programs of 104)
+
+### Bucket A — `malformed_wasm` (2) — INVALID output, highest severity
+
+The compiler reports `success` but `WebAssembly.validate` **rejects** the
+binary — a genuine codegen correctness bug (the module won't load on a strict
+engine at all). **Tracked separately and at higher priority in #2788**
+(`area: codegen`, `sprint: current`, `priority: high`) with reproduced
+validator errors.
+
+- `array/01-basic.js` — **new regression** this run (`match → malformed_wasm`);
+  `__module_init` type mismatch: `call[0] expected type f64, found if of type externref`
+- `closures/10-mutual.js` — already malformed on the baseline;
+  `__module_init` type mismatch: `call[0] expected type externref, found call of type i32`
+
+### Bucket B — `mismatch` (13) — VALID wasm, wrong output (conformance divergence)
+
+The binary validates and runs but produces output that differs from V8:
+
+- `array/12-from-of.js`
+- `builtins/01-json-stringify.js`
+- `builtins/04-symbol.js`
+- `builtins/07-promise-basic.js`
+- `builtins/08-promise-chain.js`
+- `builtins/09-async-await.js`
+- `classes/10-toString-impl.js`
+- `closures/07-arrow-this.js`
+- `closures/09-callback.js`
+- `control/12-for-in-object.js`
+- `object/02-spread.js`
+- `object/06-delete.js`
+- `object/12-assign.js`
+
+### Bucket C — `runtime_error` (6) — VALID wasm, traps/throws at instantiate
+
+The binary validates but throws during instantiation/execution:
+
+- `array/11-flat-flatMap.js`
+- `builtins/03-map-set.js`
+- `builtins/12-arraybuffer.js`
+- `builtins/14-spread-args.js`
+- `builtins/15-tag-template.js`
+- `closures/08-method-chain.js`
+
+## Severity ordering
+
+1. **Bucket A (malformed_wasm)** — real invalid-module codegen bugs. Higher
+   severity than a wrong-output mismatch because the module is not even
+   well-formed. Owned by **#2788**.
+2. **Buckets B + C** — conformance divergences on valid wasm. Lower severity
+   (the module is well-formed); these are feature-completeness gaps in
+   Promise/async, Map/Set, Symbol, spread, JSON.stringify, delete, for-in,
+   arrow-`this`, tagged templates, ArrayBuffer, etc. Several likely already
+   have feature-specific issues.
+
+## Acceptance criteria
+
+- Bucket A driven to zero via #2788 (so the diff-test delta gate goes green
+  again w.r.t. the `array/01-basic.js` regression).
+- Buckets B/C triaged: each mapped to an existing feature issue or a new
+  per-feature follow-up; the corpus baseline reflects intended state.
+
+## Notes
+
+- Relation to **#2143**: that issue added the `WebAssembly.validate` lane to
+  the default pipeline so malformed_wasm is _caught_; this issue is about
+  _fixing_ the programs it surfaces.
+- Relation to **#1941**: the optimize lane / corpus work.
+- Relation to **loopdive/js2#389**: the external reporter's `--target wasi`
+  output is **valid WasmGC** (verified — the `-0x9` `wasm-validate` error is
+  an old-wabt limitation, not a js2wasm bug); that is unrelated to these
+  diff-test codegen failures, which are on the default WasmGC + JS-host path.

--- a/plan/issues/2788-diff-test-malformed-wasm-module-init.md
+++ b/plan/issues/2788-diff-test-malformed-wasm-module-init.md
@@ -1,0 +1,122 @@
+---
+id: 2788
+title: "malformed_wasm: __module_init call type mismatch (array/01-basic, closures/10-mutual)"
+status: ready
+sprint: current
+created: 2026-06-28
+updated: 2026-06-28
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: bug
+area: codegen
+language_feature: compiler-internals
+goal: trustworthiness
+related: [2787, 2143]
+origin: "2026-06-28 — diff-test job 83903650345; reproduced locally on origin/main @867cdfbdb"
+---
+
+# #2788 — malformed_wasm: `__module_init` call argument type mismatch
+
+## Problem
+
+Two differential-test corpus programs compile **successfully** (the compiler
+reports `r.success === true`) but emit a binary that **fails
+`WebAssembly.validate`** — i.e. the codegen produces an invalid module. These
+are genuine correctness bugs (split from the #2787 umbrella because invalid
+output is higher severity than a wrong-output mismatch). Both fail at a
+**call site inside `__module_init`** with an argument-type mismatch, which
+points at the top-level / module-init lowering picking the wrong operand
+representation (boxed `externref` vs unboxed `f64`/`i32`) at a call.
+
+## Reproductions (origin/main @ 867cdfbdb)
+
+Both reproduce exactly as the `diff-test` harness classifies them — default
+pipeline, in-process `compile()` then `WebAssembly.validate`:
+
+### Case 1 — `tests/differential/corpus/array/01-basic.js`
+
+```js
+const a = [1, 2, 3];
+console.log(a.length);
+console.log(a[0]);
+console.log(a[a.length - 1]);
+```
+
+```
+compile success: true   binary bytes: 1335   WebAssembly.validate: false
+WebAssembly.compile() error:
+  Compiling function #4:"__module_init" failed:
+  call[0] expected type f64, found if of type externref @+442
+```
+
+The callee expects an `f64` argument but receives an `externref` produced by
+an `if` — most likely the `a[a.length - 1]` computed-index read (the
+`length - 1` index expression) lowering to a boxed `any`/`externref` where the
+call wants an unboxed `f64`. This is also flagged by the delta gate as a
+**new regression** (`match → malformed_wasm`), so it is the immediate cause of
+the red diff-test gate.
+
+### Case 2 — `tests/differential/corpus/closures/10-mutual.js`
+
+```
+compile success: true   binary bytes: 343   WebAssembly.validate: false
+WebAssembly.compile() error:
+  Compiling function #3:"__module_init" failed:
+  call[0] expected type externref, found call of type i32 @+262
+```
+
+Mutual-recursion closures: the callee expects an `externref` argument but
+receives an `i32` produced by a nested `call` — the inverse representation
+skew (unboxed `i32` where a boxed `externref` is required).
+
+### Local repro harness
+
+```ts
+import { readFileSync } from "node:fs";
+import { compile } from "../src/index.ts"; // run from a .tmp/ file via `npx tsx`
+for (const file of ["tests/differential/corpus/array/01-basic.js", "tests/differential/corpus/closures/10-mutual.js"]) {
+  const r = await compile(readFileSync(file, "utf-8"), { fileName: file });
+  if (!r.success) {
+    console.log(file, "compile_error", r.errors[0]?.message);
+    continue;
+  }
+  if (!WebAssembly.validate(r.binary)) {
+    try {
+      await WebAssembly.compile(r.binary);
+    } catch (e) {
+      console.log(file, (e as Error).message);
+    }
+  }
+}
+```
+
+## Hypothesis / where to look
+
+Both failures are a **call-argument coercion skew in `__module_init`** (the
+top-level statement function): the emitted argument's value type does not
+match the callee signature's parameter type. The two cases are mirror images
+(`externref` supplied where `f64` expected, and `i32` supplied where
+`externref` expected), so the root cause is likely a missing/incorrect
+`coerceType` (see `src/codegen/type-coercion.ts`) at the top-level call-emit
+path — possibly the boxing/unboxing decision for computed array-index reads
+and for closure-call arguments when emitted at module-init scope rather than
+inside a regular function body.
+
+## Acceptance criteria
+
+- `array/01-basic.js` and `closures/10-mutual.js` both pass
+  `WebAssembly.validate` after compile (no more `malformed_wasm`).
+- The `diff-test` delta gate no longer reports the `array/01-basic.js`
+  `match → malformed_wasm` regression.
+- An equivalence/regression test pins both programs (or the minimal computed-
+  index + mutual-recursion shapes) so the invalid-module skew can't recur.
+
+## Notes
+
+- Umbrella / sibling conformance failures (valid wasm, wrong output) are
+  tracked in **#2787**; this issue is scoped to the **2 invalid-module**
+  codegen bugs only.
+- #2143 added the default-pipeline `WebAssembly.validate` lane that catches
+  exactly this class of "compiler said success but the module is malformed"
+  bug.


### PR DESCRIPTION
## Summary

Files two tracking issues for the **non-required** `diff-test` ("Differential test", `scripts/diff-test.ts`, 104-program corpus) gate, which is currently **red on main** (surfaced in #2252's `merge_group` — a pure version bump, so the failures are pre-existing, not release-caused). Full failure list captured from CI job `83903650345`.

### #2787 — umbrella (`area: conformance`, `sprint: Backlog`)
Catalogs all 21 failing corpus programs, split by severity:
- **2 `malformed_wasm`** (invalid output): `array/01-basic.js`, `closures/10-mutual.js`
- **13 `mismatch`** + **6 `runtime_error`** (valid wasm, wrong output — conformance divergence)

In that CI run the corpus actually net-improved (69→83 match, 15 improvements); the gate is red only because `array/01-basic.js` regressed `match → malformed_wasm`.

### #2788 — codegen bug (`area: codegen`, `sprint: current`, `priority: high`)
Scopes the **2 genuine invalid-module codegen bugs**. Both reproduce locally on origin/main (`@867cdfbdb`) as a `__module_init` call-argument type mismatch:
- `array/01-basic.js`: `call[0] expected type f64, found if of type externref`
- `closures/10-mutual.js`: `call[0] expected type externref, found call of type i32`

i.e. an externref↔f64/i32 coercion skew at the top-level call-emit path.

## Related to loopdive/js2#389
Verified separately while preparing the #389 reply: a js2wasm `--target wasi` output **is valid WasmGC** (wasmtime accepts it on load); the reporter's `wasm-validate` `-0x9` error is the **i16 packed field type** (`(array (mut i16))` native string arrays), which older wabt builds don't support. Unrelated to these diff-test codegen failures (which are on the default WasmGC + JS-host path).

No source changes — issue files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)