### PR TITLE
feat(cli): #2783 S1-S3 general --link <namespace> dynamic-linking flag (generalize --link-node-shims)

### DIFF
--- a/plan/issues/2783-general-link-dynamic-linking-flag.md
+++ b/plan/issues/2783-general-link-dynamic-linking-flag.md
@@ -1,9 +1,11 @@
 ---
 id: 2783
 title: "General --link <namespace> dynamic-linking flag (generalize --link-node-shims)"
-status: ready
-sprint: Backlog
+status: done
+sprint: current
 created: 2026-06-28
+completed: 2026-06-28
+assignee: ttraenkler/agent-a957b1b8ea8d85c4a
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -13,6 +15,51 @@ language_feature: module-linking
 goal: platform
 related: [2527, 2655, 2657, 2771, 2779, 389]
 ---
+
+## Implementation (S1–S3 landed; S4 deferred)
+
+S1–S3 of the Implementation Plan are landed. **S4 (generalize the codegen
+branch sites) is deliberately deferred** as a follow-up — per the architect's
+verdict it is YAGNI until a *second* concrete lowerable namespace exists.
+
+- **S1 — flag + plumbing.** `--link <ns>` repeatable CLI parser (`--link node:fs`,
+  `--link=node:fs` both accepted); `--link-node-shims` kept as a deprecation
+  alias (emits a soft note) folding to `--link node:fs`. `link?: string[]` added
+  to `CompileOptions` (`src/index.ts`) and `CodegenOptions`
+  (`src/codegen/context/types.ts`). `buildCodegenOptions` (`src/compiler.ts`)
+  normalizes `link` ∪ (`linkNodeShims ? ["node:fs"]`) into one deduped set.
+  `create-context.ts` builds `ctx.linkedNamespaces` (WASI-gated, exactly as the
+  old boolean) and derives `ctx.linkNodeShims = linkedNamespaces.has("node:fs")`
+  so the ~30 existing `ctx.linkNodeShims` read sites are zero-churn and the two
+  can never drift. `--help` updated.
+- **S2 — strict-gate generalization (the one new capability).**
+  `isHostImportAllowed` / `scanForLeakedHostImports`
+  (`src/codegen/host-import-allowlist.ts`) take an optional `linkedNamespaces`
+  set; a `--link`'d namespace's imports now survive the `--no-host-imports` /
+  WASI strict gate (both the per-call `addImport` gate in
+  `src/codegen/registry/imports.ts` and the post-link
+  `assertNoLeakedHostImports` scan in `src/codegen/index.ts`). `env` host
+  bindings stay allowlist-gated (not `--link`-overridable). No lowering added.
+- **S3 — tests + back-compat lock-in.** `tests/issue-2783.test.ts` (10 tests):
+  `--link node:fs` byte-identical to `--link-node-shims`; gate permits an
+  arbitrary namespace (`acme:telemetry`) while rejecting an unlinked one;
+  per-namespace isolation; `env` not overridable; byte-neutral when no `--link`
+  (omitted ≡ `link: []`); deprecation warning fires for `--link-node-shims`;
+  multi-file `compileProject` forwards the `link` policy.
+
+## Test Results
+
+- `tests/issue-2783.test.ts` — 10/10 pass.
+- Regression set (no change): `issue-2633-process-io-to-node-fs`,
+  `issue-2631-node-fs-fd-shim`, `issue-2094-import-leak-scan`,
+  `host-import-allowlist-gate`, `host-import-allowlist-budget`,
+  `issue-1554-cli-flag-exclusion` — 45/45 pass.
+- Back-compat: `--link node:fs` ≡ `--link-node-shims` byte-for-byte (SHA match).
+- Byte-neutral: no-`link` single-source compiles unchanged (empty
+  `linkedNamespaces` → identical gate decisions and derived `linkNodeShims`).
+- `tsc --noEmit` clean; `biome lint` clean; `prettier` clean.
+- test262 smoke batch (addition/if): no new CEs (`other=0`); pre-existing
+  bigint/symbol fails unchanged.
 
 # #2783 — general `--link <namespace>` dynamic-linking flag
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -79,13 +79,19 @@ Options:
                     is ON by default; this restores the pre-#1950 behaviour.
                     (No-op when binaryen/wasm-opt is unavailable — that path
                     already degrades to a one-line note, never a failure.)
-  --link-node-shims (WASI, #2625/#2633) Emit the per-module linkable node:<mod>
-                    shims instead of inlining the host APIs. Std-IO goes through
-                    node:fs: the module imports readSync/writeSync + its memory
-                    from node:fs (no wasi_snapshot_preview1 for stream IO) and
-                    links node-fs.wasm. console.log / process.std*.write lower to
-                    writeSync(1|2, …); stdin is readSync(0, …). Off by default —
-                    the inline fd_read/fd_write path is self-contained.
+  --link <ns>       (WASI, #2783) Leave the external namespace <ns> as link-time
+                    imports (repeatable) instead of inline-lowering it. Satisfied
+                    at instantiation by a preloaded provider module (e.g.
+                    'wasmtime --preload <ns>=provider.wasm'). Any namespace works
+                    (leave-as-import is universal); '--link node:fs' additionally
+                    selects the import-and-link std-IO path: the module imports
+                    readSync/writeSync + its memory from node:fs (no
+                    wasi_snapshot_preview1 for stream IO) and links node-fs.wasm.
+                    console.log / process.std*.write lower to writeSync(1|2, ...),
+                    stdin is readSync(0, ...). Off by default — every namespace is
+                    inline-lowered into a self-contained module.
+  --link-node-shims DEPRECATED (#2783): alias for '--link node:fs'. Emits a
+                    deprecation note. Use '--link node:fs' instead.
   --emulate <env>   Emulate a host runtime's globals so they type-check without
                     @types/node. 'node' = ambient process/etc.; 'none' = off.
                     Auto-enabled (type-level only) when the source imports a
@@ -156,9 +162,11 @@ let utf8Storage = false;
 // default (strict-on under `--target wasi`); `true` / `false` = explicit
 // override from `--no-host-imports` / `--allow-host-imports`.
 let strictNoHostImports: boolean | undefined;
-// #2625 — emit the per-module linkable js2wasm:node-<mod> shims (WASI only);
-// default false keeps the self-contained inline fd_read/fd_write path.
-let linkNodeShims = false;
+// #2783 — general dynamic-linking axis: namespaces to leave as link-time
+// imports (satisfied by a preloaded provider) instead of inline-lowering.
+// `--link-node-shims` is a deprecated alias for `--link node:fs`. WASI only;
+// default empty keeps the self-contained inline path for every namespace.
+const linkedNamespaces = new Set<string>();
 // #2603 — `--emulate node`: opt into Node API emulation (ambient `process` typing).
 // `emulateExplicit` records that the user passed `--emulate`/`--no-emulate`, so a
 // `node:` import won't auto-enable over an explicit choice.
@@ -236,11 +244,24 @@ for (let i = 0; i < args.length; i++) {
     quiet = true;
   } else if (arg === "--utf8-storage") {
     utf8Storage = true;
+  } else if (arg === "--link" || arg.startsWith("--link=")) {
+    // #2783 — general `--link <namespace>` (repeatable): leave `<namespace>::*`
+    // as link-time imports for instantiation-time satisfaction instead of
+    // inline-lowering. Any external namespace works ("leave-as-import" is
+    // universal); `node:fs` additionally selects the import-and-link std-IO
+    // path. WASI only (ignored otherwise, mirroring the old linkNodeShims gate).
+    const ns = arg.startsWith("--link=") ? arg.slice("--link=".length) : args[++i];
+    if (!ns) {
+      console.error("--link requires a namespace argument (e.g. --link node:fs)");
+      process.exit(1);
+    }
+    linkedNamespaces.add(ns);
   } else if (arg === "--link-node-shims") {
-    // #2625 — emit the per-module linkable js2wasm:node-<mod> shims instead of
-    // inlining the host APIs (WASI only). Off by default; the self-contained
-    // inline fd_read/fd_write path stays.
-    linkNodeShims = true;
+    // #2783 — deprecated alias for `--link node:fs`. Kept working; emits a soft
+    // deprecation note. (#2625 originally introduced the per-module node:<mod>
+    // shims; the lower-vs-import decision is now the general `--link` axis.)
+    console.error("warning: --link-node-shims is deprecated; use --link node:fs instead.");
+    linkedNamespaces.add("node:fs");
   } else if (arg === "--emulate" || arg.startsWith("--emulate=")) {
     // #2603 — opt into (or out of) Node API emulation. `--emulate node` gives the
     // checker an ambient `process` typing so Node globals type-check without
@@ -365,7 +386,7 @@ const compileOptions = {
   ...(emitWit ? { wit: witPackageName ? { packageName: witPackageName } : true } : {}),
   ...(allowFs ? { allowFs: true } : {}),
   ...(utf8Storage ? { utf8Storage: true } : {}),
-  ...(linkNodeShims ? { linkNodeShims: true } : {}),
+  ...(linkedNamespaces.size ? { link: [...linkedNamespaces] } : {}),
   ...(emulateNode ? { emulateNode: true } : {}),
   ...(platform ? { platform } : {}),
   fileName: absInput,

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -32,6 +32,13 @@ export function createCodegenContext(
   const nativeStrings =
     options?.nativeStrings ??
     !!(options?.fast || options?.wasi || options?.standalone || strictNoHostImports || options?.utf8Storage);
+  // #2783 — the dynamic-linking set: external namespaces left as link-time
+  // imports (satisfied by a preloaded provider) instead of inline-lowering.
+  // WASI-gated exactly as the old `linkNodeShims` boolean was — ignored for
+  // non-WASI targets. `linkNodeShims` is derived from `node:fs` membership so
+  // the two can never drift. (`compiler.ts` already folded a legacy
+  // `linkNodeShims: true` into `options.link` as `"node:fs"`.)
+  const linkedNamespaces: ReadonlySet<string> = new Set(options?.wasi ? (options?.link ?? []) : []);
   const ctx: CodegenContext = {
     mod,
     checker,
@@ -221,8 +228,11 @@ export function createCodegenContext(
     nullThisTypeErrorReady: false, // (#2025)
     funcClosureGlobals: new Map(),
     wasi: options?.wasi ?? false,
-    // #2625 — the linkable js2wasm:node-<mod> shims only apply under WASI; ignored otherwise.
-    linkNodeShims: !!(options?.wasi && options?.linkNodeShims),
+    // #2783 — namespaces left as link-time imports (WASI-gated above).
+    linkedNamespaces,
+    // #2625/#2783 — the linkable js2wasm:node-<mod> std-IO path only applies under
+    // WASI; derived from `node:fs` membership in the (already WASI-gated) link set.
+    linkNodeShims: linkedNamespaces.has("node:fs"),
     nodeFsReadSyncIdx: -1,
     nodeFsWriteSyncIdx: -1,
     standalone: options?.standalone ?? false,

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -74,8 +74,17 @@ export interface CodegenOptions {
    * process.std*.write lower to `writeSync(1|2, …)`. `node-fs.wasm` implements
    * the interface over WASI. The bespoke `js2wasm:node-process` shim was retired
    * (#2633). Default off — the inline fd_read/fd_write path stays as fallback.
+   *
+   * @deprecated (#2783) Folded into `link` as `"node:fs"` by `buildCodegenOptions`.
    */
   linkNodeShims?: boolean;
+  /**
+   * #2783 — general dynamic-linking axis. Namespaces to leave as link-time
+   * imports (satisfied by a preloaded provider) instead of inline-lowering.
+   * `linkNodeShims: true` is folded in here as `"node:fs"`. WASI-gated in
+   * `create-context.ts` (ignored for non-WASI targets).
+   */
+  link?: string[];
   /** Standalone target (#1470): pure WasmGC, no JS host imports and no WASI
    *  runtime. Implies `nativeStrings: true` and refuses to emit any
    *  `wasm:js-string` namespace or `env::__concat_*` / `__extern_toString` /
@@ -1728,8 +1737,23 @@ export interface CodegenContext {
    * process.std*.write lower to `writeSync(1|2, …)`; the bespoke
    * `js2wasm:node-process` shim was retired (#2633). See `linkNodeShims` in
    * `CodegenOptions`.
+   *
+   * #2783 — now a **derived** value: `linkedNamespaces.has("node:fs")`. The two
+   * are computed together in `create-context.ts` from the same (WASI-gated)
+   * `link` set so they can never drift. Keeping this boolean lets the ~30
+   * existing `ctx.linkNodeShims` read sites stay zero-churn while the underlying
+   * state generalizes to an arbitrary set of linked namespaces.
    */
   linkNodeShims: boolean;
+  /**
+   * #2783 — the set of external namespaces left as **link-time imports** for
+   * this compile (WASI-gated; empty for non-WASI targets). `node:fs` membership
+   * additionally drives the import-and-link std-IO codegen path (see
+   * `linkNodeShims`, derived from this set). For an arbitrary namespace,
+   * membership only permits its imports past the strict `--no-host-imports` /
+   * WASI leaked-host-import gate (`assertNoLeakedHostImports`).
+   */
+  linkedNamespaces: ReadonlySet<string>;
   /** #2631/#2633: func index of the imported `node:fs::readSync` (fd,ptr,len)->i32 (-1 = not registered). */
   nodeFsReadSyncIdx: number;
   /** #2631/#2633: func index of the imported `node:fs::writeSync` (fd,ptr,len)->i32 (-1 = not registered). */

--- a/src/codegen/host-import-allowlist.ts
+++ b/src/codegen/host-import-allowlist.ts
@@ -429,6 +429,7 @@ export function lookupAllowlistEntry(name: string): HostImportAllowlistEntry | u
 export function isHostImportAllowed(
   module: string,
   name: string,
+  linkedNamespaces?: ReadonlySet<string>,
 ):
   | { allowed: true }
   | { allowed: false; reason: "non-env-host-module" }
@@ -442,6 +443,16 @@ export function isHostImportAllowed(
     return { allowed: false, reason: "env-not-on-allowlist" };
   }
   if (ALWAYS_ALLOWED_IMPORT_MODULES.has(module)) {
+    return { allowed: true };
+  }
+  // #2783 — a namespace the user explicitly `--link`'d is left as a link-time
+  // import (satisfied by a preloaded provider), so it is permitted past the
+  // strict gate even though it is not on the built-in always-allowed set. This
+  // is what lets an ARBITRARY external namespace (e.g. `acme:telemetry`) survive
+  // `--no-host-imports` / WASI strict mode: `--link` turns "reject the import"
+  // into "leave it for link-time satisfaction". `env` is deliberately NOT
+  // overridable this way — those are JS-host bindings, gated by the allowlist.
+  if (linkedNamespaces?.has(module)) {
     return { allowed: true };
   }
   // Any other module (wasm:js-string, string_constants, ...) is host-only.
@@ -507,14 +518,19 @@ export interface LeakedHostImport {
  * `module` / `name` fields are read, so the caller may pass any shape carrying
  * those two strings. Duplicate `module.name` pairs are de-duplicated.
  */
-export function scanForLeakedHostImports(imports: ReadonlyArray<{ module: string; name: string }>): LeakedHostImport[] {
+export function scanForLeakedHostImports(
+  imports: ReadonlyArray<{ module: string; name: string }>,
+  linkedNamespaces?: ReadonlySet<string>,
+): LeakedHostImport[] {
   const leaks: LeakedHostImport[] = [];
   const seen = new Set<string>();
   for (const imp of imports) {
     const key = `${imp.module} ${imp.name}`;
     if (seen.has(key)) continue;
     seen.add(key);
-    const decision = isHostImportAllowed(imp.module, imp.name);
+    // #2783 — `--link`'d namespaces (`ctx.linkedNamespaces`) are left as
+    // link-time imports and must survive the strict gate, not be flagged leaks.
+    const decision = isHostImportAllowed(imp.module, imp.name, linkedNamespaces);
     if (!decision.allowed) {
       leaks.push({ module: imp.module, name: imp.name, reason: decision.reason });
     }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1999,7 +1999,10 @@ export function generateModule(
  */
 function assertNoLeakedHostImports(ctx: CodegenContext, mod: WasmModule): void {
   if (!ctx.strictNoHostImports) return;
-  const leaks = scanForLeakedHostImports(mod.imports);
+  // #2783 — pass `ctx.linkedNamespaces` so an arbitrary `--link`'d namespace's
+  // imports survive the strict gate (left as link-time imports for a preloaded
+  // provider) instead of being rejected as leaked host imports.
+  const leaks = scanForLeakedHostImports(mod.imports, ctx.linkedNamespaces);
   for (const leak of leaks) {
     reportErrorNoNode(ctx, buildLeakedHostImportError(leak));
   }

--- a/src/codegen/registry/imports.ts
+++ b/src/codegen/registry/imports.ts
@@ -48,7 +48,11 @@ export function addImport(ctx: CodegenContext, module: string, name: string, des
     );
   }
   if (ctx.strictNoHostImports) {
-    const decision = isHostImportAllowed(module, name);
+    // #2783 — pass `ctx.linkedNamespaces` so an arbitrary `--link`'d namespace's
+    // import is actually REGISTERED (left as a link-time import for a preloaded
+    // provider) rather than dropped-and-degraded here. Dropping it would leave a
+    // stale funcMap index and the program could never satisfy the linked symbol.
+    const decision = isHostImportAllowed(module, name, ctx.linkedNamespaces);
     if (!decision.allowed) {
       const message = buildStrictHostImportError(module, name);
       // #1921 — this per-call gate *drops* the import and lets codegen

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -716,7 +716,11 @@ function buildCodegenOptions(
     utf8Storage: options.utf8Storage,
     testRuntime: options.testRuntime,
     wasi: options.target === "wasi",
-    linkNodeShims: options.linkNodeShims,
+    // #2783 — normalize the dynamic-linking axis into a single deduped `link`
+    // set. The deprecated `linkNodeShims: true` alias folds in as `"node:fs"`,
+    // so any programmatic caller (and the CLI's `--link-node-shims` alias) keeps
+    // working byte-identically while the underlying state generalizes.
+    link: [...new Set([...(options.link ?? []), ...(options.linkNodeShims ? ["node:fs"] : [])])],
     standalone: options.target === "standalone",
     strictNoHostImports: options.strictNoHostImports,
     // (#2119) thread module-strictness inference uniformly across all drivers.

--- a/src/index.ts
+++ b/src/index.ts
@@ -288,8 +288,28 @@ export interface CompileOptions {
    * bespoke `js2wasm:node-process` shim (`process.stdin.read`/`stdout_write`/…)
    * was retired in #2633; `process.stdin.read(buf, offset)` is no longer a
    * recognised API (it matched no real Node surface — use `node:fs` `readSync`).
+   *
+   * @deprecated (#2783) Use `link: ["node:fs"]` instead. Kept as a back-compat
+   * alias: `buildCodegenOptions` folds `linkNodeShims === true` into the `link`
+   * set as `"node:fs"`, so the observable behaviour is byte-identical.
    */
   linkNodeShims?: boolean;
+  /**
+   * #2783 — general `--link <namespace>` dynamic-linking axis. Each listed
+   * namespace is left as a **link-time import** (satisfied at instantiation by a
+   * preloaded provider module, e.g. `wasmtime --preload node:fs=node-fs.wasm`)
+   * instead of being inline-lowered to a self-contained module. "Leave-as-import"
+   * is the universal capability (any external namespace can be a wasm import);
+   * "inline-lower" is the special capability the compiler only has for a known
+   * few (`node:fs` fd IO). So for an arbitrary namespace `--link <ns>` simply
+   * permits its imports past the strict `--no-host-imports` / WASI gate; for
+   * `node:fs` it additionally selects the import-and-link codegen path.
+   *
+   * WASI-gated (mirrors `linkNodeShims`): ignored for non-WASI targets.
+   * `linkNodeShims: true` is folded in as `"node:fs"`. Default empty — every
+   * namespace stays standalone / inline-lowered.
+   */
+  link?: string[];
   /**
    * Node API emulation (#2603). Opt-in via `--emulate node`. When set, the
    * checker is given an ambient `process` declaration so Node globals js2wasm

--- a/tests/issue-2783.test.ts
+++ b/tests/issue-2783.test.ts
@@ -1,0 +1,171 @@
+// #2783 — general `--link <namespace>` dynamic-linking flag (S1–S3).
+//
+// Generalizes the single `--link-node-shims` boolean into an orthogonal,
+// per-namespace axis: `--link <ns>` (repeatable) leaves `<ns>::*` as link-time
+// imports (satisfied by a preloaded provider) instead of inline-lowering it.
+// `--link-node-shims` becomes a deprecated alias for `--link node:fs`.
+//
+// Coverage:
+//  S1/S3 (a) — `--link node:fs` is BYTE-IDENTICAL to `--link-node-shims`
+//              (the rename/generalization is pure; back-compat lock-in).
+//  S2     (b) — the strict-gate generalization: an ARBITRARY `--link`'d
+//              namespace's imports survive the `--no-host-imports` / WASI
+//              strict gate instead of being rejected (the one genuinely-new
+//              capability). Tested at the gate (`isHostImportAllowed` /
+//              `scanForLeakedHostImports`).
+//  S3     (c) — deprecation warning fires for `--link-node-shims`.
+//  S3     (d) — multi-file (`compileProject`) honors `link`.
+//  S3     (e) — byte-neutral when no `--link` is passed (existing single-source
+//              compiles are unchanged).
+
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { compile } from "../src/index.js";
+import { isHostImportAllowed, scanForLeakedHostImports } from "../src/codegen/host-import-allowlist.js";
+
+const ECHO = `export function main(): void { console.log("hello, link"); }`;
+
+describe("#2783 S1/S3 — `--link node:fs` ≡ `--link-node-shims` (back-compat byte-identical)", () => {
+  it("produces byte-identical output to the deprecated alias", async () => {
+    const viaAlias = await compile(ECHO, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
+    const viaLink = await compile(ECHO, { fileName: "x.ts", target: "wasi", link: ["node:fs"] });
+    expect(viaAlias.success, viaAlias.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(viaLink.success, viaLink.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(Buffer.compare(Buffer.from(viaLink.binary), Buffer.from(viaAlias.binary))).toBe(0);
+    // And both select the import-and-link std-IO path (node:fs writeSync import).
+    expect(viaLink.wat ?? "").toContain('(import "node:fs" "writeSync"');
+  });
+
+  it("`linkNodeShims: true` and `link: ['node:fs']` both leave node:fs as imports", async () => {
+    for (const opts of [{ linkNodeShims: true }, { link: ["node:fs"] }]) {
+      const r = await compile(ECHO, { fileName: "x.ts", target: "wasi", ...opts });
+      expect(r.success).toBe(true);
+      const wat = r.wat ?? "";
+      expect(wat).toContain('(import "node:fs" "memory" (memory');
+      expect(wat).toContain('(import "node:fs" "writeSync"');
+      expect(wat).not.toContain("wasi_snapshot_preview1");
+    }
+  });
+});
+
+describe("#2783 S2 — arbitrary `--link`'d namespace survives the strict gate", () => {
+  it("isHostImportAllowed permits a linked arbitrary namespace, rejects it otherwise", () => {
+    // Without --link: an arbitrary namespace is a host-only module → rejected.
+    expect(isHostImportAllowed("acme:telemetry", "record")).toEqual({
+      allowed: false,
+      reason: "non-env-host-module",
+    });
+    // With --link acme:telemetry: permitted (left as a link-time import).
+    expect(isHostImportAllowed("acme:telemetry", "record", new Set(["acme:telemetry"]))).toEqual({
+      allowed: true,
+    });
+  });
+
+  it("scanForLeakedHostImports does not flag a linked namespace's imports", () => {
+    const imports = [{ module: "acme:telemetry", name: "record" }];
+    // Strict gate WITHOUT the link set → a leak is reported.
+    const leaksUnlinked = scanForLeakedHostImports(imports);
+    expect(leaksUnlinked).toEqual([{ module: "acme:telemetry", name: "record", reason: "non-env-host-module" }]);
+    // Strict gate WITH the namespace linked → it survives (no leak).
+    const leaksLinked = scanForLeakedHostImports(imports, new Set(["acme:telemetry"]));
+    expect(leaksLinked).toEqual([]);
+  });
+
+  it("linking is per-namespace: an UNlinked host module is still rejected", () => {
+    // `--link acme:telemetry` does not blanket-permit a different host module.
+    const leaks = scanForLeakedHostImports(
+      [
+        { module: "acme:telemetry", name: "record" },
+        { module: "other:thing", name: "leak" },
+      ],
+      new Set(["acme:telemetry"]),
+    );
+    expect(leaks).toEqual([{ module: "other:thing", name: "leak", reason: "non-env-host-module" }]);
+  });
+
+  it("`env` host bindings are NOT overridable via --link (only real namespaces)", () => {
+    // Even if a user tried `--link env`, `env` JS-host bindings stay allowlist-gated.
+    expect(isHostImportAllowed("env", "__not_a_real_host_import", new Set(["env"]))).toEqual({
+      allowed: false,
+      reason: "env-not-on-allowlist",
+    });
+  });
+});
+
+describe("#2783 S3 — byte-neutral when no `--link` is passed", () => {
+  it("omitting link and passing an empty link array are byte-identical, and differ from linked", async () => {
+    const noField = await compile(ECHO, { fileName: "x.ts", target: "wasi" });
+    const emptyArr = await compile(ECHO, { fileName: "x.ts", target: "wasi", link: [] });
+    const linked = await compile(ECHO, { fileName: "x.ts", target: "wasi", link: ["node:fs"] });
+    expect(noField.success && emptyArr.success && linked.success).toBe(true);
+    // No `--link` (omitted) === empty array: unchanged standalone/inline path.
+    expect(Buffer.compare(Buffer.from(noField.binary), Buffer.from(emptyArr.binary))).toBe(0);
+    // And the default path is the self-contained inline fd_write path.
+    expect(noField.wat ?? "").toContain("wasi_snapshot_preview1");
+    expect(noField.wat ?? "").toContain("fd_write");
+    // Linking flips it: distinct output from the inline default.
+    expect(Buffer.compare(Buffer.from(noField.binary), Buffer.from(linked.binary))).not.toBe(0);
+  });
+});
+
+describe("#2783 S3 — deprecation warning for `--link-node-shims`", () => {
+  function runCli(extraArgs: string): { stderr: string; status: number } {
+    const dir = mkdtempSync(path.join(tmpdir(), "issue-2783-cli-"));
+    const inFile = path.join(dir, "input.ts");
+    writeFileSync(inFile, ECHO);
+    // spawnSync (not execSync): capture stderr regardless of exit code — the
+    // deprecation note is written to stderr even on a successful (status 0)
+    // compile, which execSync's return value would discard.
+    const args = [
+      path.resolve("src/cli.ts"),
+      inFile,
+      "--target",
+      "wasi",
+      "--no-dts",
+      "--quiet",
+      ...extraArgs.split(" ").filter(Boolean),
+    ];
+    const r = spawnSync("npx", ["-y", "tsx", ...args], { cwd: process.cwd(), encoding: "utf8" });
+    return { stderr: r.stderr ?? "", status: r.status ?? 1 };
+  }
+
+  it("emits a deprecation note for --link-node-shims and still compiles", () => {
+    const { stderr, status } = runCli("--link-node-shims");
+    expect(status).toBe(0);
+    expect(stderr).toMatch(/--link-node-shims is deprecated; use --link node:fs/);
+  });
+
+  it("--link node:fs compiles with NO deprecation note", () => {
+    const { stderr, status } = runCli("--link node:fs");
+    expect(status).toBe(0);
+    expect(stderr).not.toMatch(/deprecated/);
+  });
+});
+
+describe("#2783 S3 — multi-file (compileProject) honors `link`", () => {
+  it("a bundled program with link: ['node:fs'] forwards the link policy (node:fs left as imports)", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "issue-2783-proj-"));
+    const helper = path.join(dir, "helper.ts");
+    const entry = path.join(dir, "entry.ts");
+    writeFileSync(helper, `export function greet(): void { console.log("from helper"); }`);
+    writeFileSync(entry, `import { greet } from "./helper.js";\nexport function main(): void { greet(); }`);
+    const { compileProject } = await import("../src/index.js");
+    const linked = await compileProject(entry, { target: "wasi", link: ["node:fs"] });
+    expect(linked.success, linked.errors.map((e) => e.message).join("\n")).toBe(true);
+    // The `link` policy threaded through `compileProject` → `buildCodegenOptions`:
+    // node:fs is left as a link-time import (its shim-owned memory is imported)
+    // rather than the strict gate rejecting it or the inline path owning memory.
+    // (The full std-IO→node:fs writeSync lowering in the bundled path is the
+    // separate #2779 codegen-gap work — out of scope for this flag generalization;
+    // here we only assert the policy is FORWARDED, which the node:fs import proves.)
+    const wat = linked.wat ?? "";
+    expect(wat).toContain('(import "node:fs"');
+    // Control: WITHOUT link, the bundled program does not import node:fs.
+    const unlinked = await compileProject(entry, { target: "wasi" });
+    expect(unlinked.success).toBe(true);
+    expect(unlinked.wat ?? "").not.toContain('(import "node:fs"');
+  });
+});


### PR DESCRIPTION
Implements **#2783 slices S1–S3** — generalize the single `--link-node-shims` boolean into an orthogonal, per-namespace dynamic-linking axis. **S4 is deliberately deferred** (YAGNI until a second concrete lowerable namespace exists).

## The asymmetry that makes this cheap
"Leave-as-import" is universal (any external namespace can be a wasm import); "inline-lower" is the special capability only `node:fs` has. So `--link <ns>` for an arbitrary namespace needs exactly ONE new thing: the strict-host-import gate must not reject a `--link`'d namespace (S2). Everything else is mechanical plumbing.

## S1 — flag + plumbing
- `--link <ns>` repeatable CLI parser (`--link node:fs` / `--link=node:fs`); `--link-node-shims` kept as a deprecation alias (soft note) folding to `--link node:fs`.
- `link?: string[]` on `CompileOptions` (`src/index.ts`) and `CodegenOptions` (`src/codegen/context/types.ts`).
- `buildCodegenOptions` (`src/compiler.ts`) normalizes `link ∪ (linkNodeShims ? ["node:fs"])` into one deduped set.
- `create-context.ts` builds `ctx.linkedNamespaces` (WASI-gated, exactly as the old boolean) and derives `ctx.linkNodeShims = linkedNamespaces.has("node:fs")` — the ~30 existing `ctx.linkNodeShims` read sites are **zero-churn** and the two can never drift.
- `--help` updated.

## S2 — strict-gate generalization (the one new capability)
- `isHostImportAllowed` / `scanForLeakedHostImports` (`src/codegen/host-import-allowlist.ts`) take an optional `linkedNamespaces` set.
- Threaded into both the per-call `addImport` gate (`src/codegen/registry/imports.ts`) and the post-link `assertNoLeakedHostImports` scan (`src/codegen/index.ts`), so an arbitrary `--link`'d namespace's imports **survive** the `--no-host-imports` / WASI strict gate instead of being dropped/rejected.
- `env` host bindings stay allowlist-gated (not `--link`-overridable). No lowering added.

## S3 — tests + back-compat lock-in
`tests/issue-2783.test.ts` (10 tests):
- `--link node:fs` **byte-identical** to `--link-node-shims` (back-compat lock-in, SHA match).
- Gate permits an arbitrary namespace (`acme:telemetry`) while rejecting an unlinked one; per-namespace isolation; `env` not overridable.
- **Byte-neutral** when no `--link` is passed (omitted ≡ `link: []`).
- Deprecation warning fires for `--link-node-shims`.
- Multi-file `compileProject` forwards the `link` policy.

## Validation
- `tests/issue-2783.test.ts` 10/10 pass.
- Regression set 45/45 pass (`issue-2633`, `issue-2631`, `issue-2094`, `host-import-allowlist-gate`, `host-import-allowlist-budget`, `issue-1554-cli-flag-exclusion`).
- `--link node:fs` ≡ `--link-node-shims` byte-for-byte; no-`link` compiles byte-neutral (empty `linkedNamespaces` → identical gate decisions).
- `tsc --noEmit` clean; `biome lint` clean; `prettier` clean.
- test262 smoke batch: no new CEs (`other=0`); pre-existing bigint/symbol fails unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)