### PR TITLE
feat(cli): #2783 remove --link-node-shims alias entirely (--link node:fs only)

### DIFF
--- a/docs/architecture/node-fs-abi.md
+++ b/docs/architecture/node-fs-abi.md
@@ -86,7 +86,7 @@ Mirrors `examples/native-messaging/node-fs.wat`:
    issues the syscall; `edge.js` reads/writes the `[ptr, ptr+len)` range directly
    from JS (no scratch needed).
 
-Since #2633, **all** std-IO under `--link-node-shims` flows through `node:fs`:
+Since #2633, **all** std-IO under `--link node:fs` flows through `node:fs`:
 `console.log`/`warn`/`error` and `process.stdout`/`stderr.write` lower to
 `writeSync(1|2, …)`, and synchronous stdin is `readSync(0, …)`. `node:fs` owns
 the single shared linear memory; the bespoke `js2wasm:node-process` shim — and

--- a/examples/native-messaging/NODE-FS-SHIM.md
+++ b/examples/native-messaging/NODE-FS-SHIM.md
@@ -9,7 +9,7 @@ to WASI `fd_read` / `fd_write` with **no filesystem**. (The earlier example used
 `read` — loopdive/js2#389. `fs.readSync`/`fs.writeSync` are also what Javy uses:
 `Javy.IO.readSync`.)
 
-`--link-node-shims` keeps the syscall implementation **out of codegen**: the
+`--link node:fs` keeps the syscall implementation **out of codegen**: the
 compiler only wires `import { readSync, writeSync } from "node:fs"` to imports of
 a stable **`node:fs`** interface. The module declares **what** host API it needs
 (`node:fs`), not **how** it's satisfied — that is a link-time concern. The same
@@ -54,7 +54,7 @@ There is no cycle (the shim never imports anything from the user module). The
 shim reads/writes the user's bytes over the _same_ memory, builds the WASI iovec
 in its own reserved scratch, and issues the syscall.
 
-(Since #2633, **all** std-IO under `--link-node-shims` goes through `node:fs`:
+(Since #2633, **all** std-IO under `--link node:fs` goes through `node:fs`:
 console.log / process.stdout/stderr.write lower to `writeSync(1|2, …)` and
 synchronous stdin is `readSync(0, …)`. `node:fs` owns the single shared linear
 memory; the bespoke `js2wasm:node-process` shim was retired.)
@@ -64,7 +64,7 @@ memory; the bespoke `js2wasm:node-process` shim was retired.)
 Compile the user module:
 
 ```sh
-npx js2wasm examples/native-messaging/nm_node_fs.ts --target wasi --link-node-shims -o out
+npx js2wasm examples/native-messaging/nm_node_fs.ts --target wasi --link node:fs -o out
 ```
 
 The emitted `out/nm_node_fs.wasm` imports only `node:fs` (memory + `readSync` +

--- a/examples/native-messaging/README.md
+++ b/examples/native-messaging/README.md
@@ -41,7 +41,7 @@ progressively higher-level (and more Node-shaped) surfaces.
 | Variant                                      | Host surface                                    | Source import                                                                              | Sync or async                                                  | Emitted wasm imports                                                                       | Runs natively under                                       | Compiles to                                                         |
 | -------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | --------------------------------------------------------- | ------------------------------------------------------------------- |
 | [`nm_wasi_p1.ts`](./nm_wasi_p1.ts)           | Raw WASI Preview 1 syscalls over linear memory  | `wasi_snapshot_preview1` (`fd_read`/`fd_write`) + `wasm:memory` (intrinsic, lowers inline) | **sync** — blocking `fd_read`/`fd_write` loop                  | only `wasi_snapshot_preview1`                                                              | `wasmtime` / `wasmer` / `wazero`                          | standalone WASI P1 command module (owns + exports its own `memory`) |
-| [`nm_node_fs.ts`](./nm_node_fs.ts)           | Node synchronous `node:fs` fd IO                | `node:fs` (`readSync`/`writeSync`)                                                         | **sync** — `readSync`/`writeSync` read-until loop              | only `wasi_snapshot_preview1` (inlined); or a `node:fs` interface with `--link-node-shims` | `wasmtime` **and** unmodified under real `node`           | standalone WASI P1 command module (or a `node:fs`-linkable module)  |
+| [`nm_node_fs.ts`](./nm_node_fs.ts)           | Node synchronous `node:fs` fd IO                | `node:fs` (`readSync`/`writeSync`)                                                         | **sync** — `readSync`/`writeSync` read-until loop              | only `wasi_snapshot_preview1` (inlined); or a `node:fs` interface with `--link node:fs` | `wasmtime` **and** unmodified under real `node`           | standalone WASI P1 command module (or a `node:fs`-linkable module)  |
 | [`nm_node_process.ts`](./nm_node_process.ts) | Node async streaming stdio                      | `process.stdin` (global) Readable + `process.stdout.write`                                 | **async** — event-driven `'data'`/`'end'`, incremental framing | only `wasi_snapshot_preview1`                                                              | `wasmtime` (drives the injected fd0 reactor / event loop) | standalone WASI P1 command module with an event loop                |
 | [`nm_deno.ts`](./nm_deno.ts)                 | Deno stdio surface (`Deno.stdin`/`Deno.stdout`) | _(lands separately)_                                                                       | sync (`readSync`/`writeSync`)                                  | _(WASI-targeted; filled in when it lands)_                                                 | Deno / a WASI runtime                                     | standalone WASI module                                              |
 | [`nm_wasi_p3.ts`](./nm_wasi_p3.ts)           | WASI Preview 3 async streams                    | _(lands separately)_                                                                       | **async** — P3 stream reads                                    | WASI Preview 3 component interfaces                                                        | a Preview-3 / component-capable runner                    | WASI Preview 3 component                                            |
@@ -81,16 +81,16 @@ buffer-filling `read`; loopdive/js2#389). The same source now (a) compiles via
 js2wasm to standalone WASI **and** (b) runs **unmodified** under real `node`.
 
 **To get a module you can run directly under `wasmtime`, compile with `--target
-wasi` ALONE** (no `--link-node-shims`): the `node:fs` `readSync`/`writeSync` calls
+wasi` ALONE** (no `--link node:fs`): the `node:fs` `readSync`/`writeSync` calls
 lower **inline** to `wasi_snapshot_preview1` `fd_read`/`fd_write`, so the emitted
 module imports ONLY `wasi_snapshot_preview1` and owns its own memory (#2655). This
 is the runnable standalone path the loopdive/js2#389 reporter wanted.
 
-`--link-node-shims` is a **separate modular-linking variant**, NOT a
+`--link node:fs` is a **separate modular-linking variant**, NOT a
 run-directly-under-bare-wasmtime flag: it makes the module _import_ a stable
 `node:fs` interface (`readSync`/`writeSync` + its `memory`) that you then **link**
 against [`node-fs.wat`](./node-fs.wat) (which maps them to WASI `fd_read`/
-`fd_write`) — or satisfy from a JS host's real `node:fs`. A `--link-node-shims`
+`fd_write`) — or satisfy from a JS host's real `node:fs`. A `--link node:fs`
 module run under bare `wasmtime` with no link step fails with `unknown import:
 node:fs::readSync` (loopdive/js2#389 bug 2) — that is expected; link it first. See
 [`NODE-FS-SHIM.md`](./NODE-FS-SHIM.md) for the link step.
@@ -167,20 +167,20 @@ module: the `node:fs` `readSync`/`writeSync` calls lower **inline** to
 `wasi_snapshot_preview1`, owns + exports its own `memory`, and runs directly under
 `wasmtime` with no link step (#2655).
 
-**Optional modular-linking variant — `--link-node-shims`.** Adding
-`--link-node-shims` instead makes the module _import_ a stable `node:fs` interface
+**Optional modular-linking variant — `--link node:fs`.** Adding
+`--link node:fs` instead makes the module _import_ a stable `node:fs` interface
 (`readSync`/`writeSync` + the shared linear `memory`) rather than inlining the
 syscalls:
 
 ```bash
-npx tsx src/cli.ts examples/native-messaging/nm_node_fs.ts --target wasi --link-node-shims -o examples/native-messaging/out
+npx tsx src/cli.ts examples/native-messaging/nm_node_fs.ts --target wasi --link node:fs -o examples/native-messaging/out
 ```
 
 The result declares **what** host API it needs (`node:fs`), not how it's
 satisfied — so you must **link** it against `node-fs.wasm` (built from
 [`node-fs.wat`](./node-fs.wat), which maps `node:fs` → WASI `fd_read`/`fd_write`),
 a native WASI host, or the real `node:fs` module under a JS host BEFORE it can
-run. Running a `--link-node-shims` module directly under bare `wasmtime` with no
+run. Running a `--link node:fs` module directly under bare `wasmtime` with no
 link step fails with `unknown import: node:fs::readSync` (loopdive/js2#389 bug 2)
 — that is by design; link it first. See [`NODE-FS-SHIM.md`](./NODE-FS-SHIM.md) for
 the link step. Use this variant only when you want the same binary to link against
@@ -331,10 +331,10 @@ the compiled module's linear memory below a 512 MiB cap.
    raw bytes on stdin and produces correctly framed bytes on stdout via
    `process.stdout.write` (a `Uint8Array` prefix + the JSON body).
 
-## Linkable `node:fs` shim (`--link-node-shims`, #2625/#2633)
+## Linkable `node:fs` shim (`--link node:fs`, #2625/#2633)
 
 By default the stdin/stdout glue is inlined as `wasi_snapshot_preview1.fd_read`
-/ `fd_write` in every module. With `--target wasi --link-node-shims`, the module
+/ `fd_write` in every module. With `--target wasi --link node:fs`, the module
 instead imports a stable `node:fs` interface (fd-based `readSync`/`writeSync`,
 plus its linear memory) and links against a small, separately-compiled
 `node-fs.wasm` that implements that interface over WASI — proving the modular

--- a/examples/native-messaging/edge.js
+++ b/examples/native-messaging/edge.js
@@ -1,6 +1,6 @@
 // edge.js — a JS provider for the `node:fs` host-import interface (#1772 Phase 1).
 //
-// A js2wasm module compiled with `--target wasi --link-node-shims` imports its
+// A js2wasm module compiled with `--target wasi --link node:fs` imports its
 // fd-based synchronous IO from `node:fs`:
 //
 //   (import "node:fs" "memory"    (memory …))

--- a/examples/native-messaging/nm_node_fs.ts
+++ b/examples/native-messaging/nm_node_fs.ts
@@ -3,7 +3,7 @@
 //
 //   npx js2wasm examples/native-messaging/nm_node_fs.ts --target wasi -o out
 //
-// `--target wasi` ALONE (no `--link-node-shims`) emits a SELF-CONTAINED WASI
+// `--target wasi` ALONE (no `--link node:fs`) emits a SELF-CONTAINED WASI
 // Preview-1 command module: it imports ONLY `wasi_snapshot_preview1` (fd_read /
 // fd_write), owns + exports its own `memory`, and runs directly under a WASI
 // host such as wasmtime — no node:fs shim, no Node runtime (#2655). This is the
@@ -17,7 +17,7 @@
 // `writeSync(1,…)` are fd-based (integer fd 0=stdin, 1=stdout), NOT path-based —
 // no filesystem involved; under real node they call the real fs.
 //
-//   npx js2wasm examples/native-messaging/nm_node_fs.ts --target wasi --link-node-shims -o out
+//   npx js2wasm examples/native-messaging/nm_node_fs.ts --target wasi --link node:fs -o out
 //
 // is the VARIANT that lowers the same calls to imported `node:fs` shim calls
 // (`node-fs.wat`, which maps them to WASI fd_read / fd_write) — useful when the

--- a/examples/native-messaging/smoke-test.sh
+++ b/examples/native-messaging/smoke-test.sh
@@ -21,12 +21,12 @@ trap 'rm -rf "$OUT_DIR"' EXIT
 echo "== Compiling examples/native-messaging/nm_node_fs.ts --target wasi =="
 CLI="$OUT_DIR/js2wasm-cli.mjs"
 # #2631 — the host now uses node:fs readSync/writeSync via the linkable `node:fs`
-# shim, so compile with --link-node-shims and build node-fs.wasm to preload.
+# shim, so compile with --link node:fs and build node-fs.wasm to preload.
 SHIM="$OUT_DIR/node-fs.wasm"
 (
   cd "$REPO_ROOT"
   node scripts/build-standalone-cli.mjs --outfile "$CLI"
-  node "$CLI" examples/native-messaging/nm_node_fs.ts --target wasi --link-node-shims -o "$OUT_DIR" --quiet
+  node "$CLI" examples/native-messaging/nm_node_fs.ts --target wasi --link node:fs -o "$OUT_DIR" --quiet
   node scripts/build-node-fs-shim.mjs "$SHIM"
 )
 WASM="$OUT_DIR/nm_node_fs.wasm"

--- a/plan/issues/2783-general-link-dynamic-linking-flag.md
+++ b/plan/issues/2783-general-link-dynamic-linking-flag.md
@@ -22,16 +22,23 @@ S1–S3 of the Implementation Plan are landed. **S4 (generalize the codegen
 branch sites) is deliberately deferred** as a follow-up — per the architect's
 verdict it is YAGNI until a *second* concrete lowerable namespace exists.
 
+**Stakeholder decision (no alias):** the `--link-node-shims` CLI flag and the
+`linkNodeShims` INPUT option are **removed entirely**, not deprecated.
+`--link node:fs` (CLI) / `link: ["node:fs"]` (programmatic) is the only spelling.
+All in-repo callers (tests, `examples/native-messaging/*`, `scripts/`, docs) were
+migrated to the new spelling.
+
 - **S1 — flag + plumbing.** `--link <ns>` repeatable CLI parser (`--link node:fs`,
-  `--link=node:fs` both accepted); `--link-node-shims` kept as a deprecation
-  alias (emits a soft note) folding to `--link node:fs`. `link?: string[]` added
-  to `CompileOptions` (`src/index.ts`) and `CodegenOptions`
-  (`src/codegen/context/types.ts`). `buildCodegenOptions` (`src/compiler.ts`)
-  normalizes `link` ∪ (`linkNodeShims ? ["node:fs"]`) into one deduped set.
-  `create-context.ts` builds `ctx.linkedNamespaces` (WASI-gated, exactly as the
-  old boolean) and derives `ctx.linkNodeShims = linkedNamespaces.has("node:fs")`
-  so the ~30 existing `ctx.linkNodeShims` read sites are zero-churn and the two
-  can never drift. `--help` updated.
+  `--link=node:fs` both accepted); the removed `--link-node-shims` flag now errors
+  as an unknown option. `link?: string[]` added to `CompileOptions`
+  (`src/index.ts`) and `CodegenOptions` (`src/codegen/context/types.ts`); the
+  `linkNodeShims` input fields were dropped from both. `buildCodegenOptions`
+  (`src/compiler.ts`) dedupes `options.link`. `create-context.ts` builds
+  `ctx.linkedNamespaces` (WASI-gated) and derives the INTERNAL convenience
+  boolean `ctx.linkNodeShims = linkedNamespaces.has("node:fs")` so the ~30
+  existing `ctx.linkNodeShims` codegen read sites are zero-churn and the two can
+  never drift (`ctx.linkNodeShims` is no longer a user-facing option — just an
+  internal derived getter). `--help` updated.
 - **S2 — strict-gate generalization (the one new capability).**
   `isHostImportAllowed` / `scanForLeakedHostImports`
   (`src/codegen/host-import-allowlist.ts`) take an optional `linkedNamespaces`
@@ -40,26 +47,35 @@ verdict it is YAGNI until a *second* concrete lowerable namespace exists.
   `src/codegen/registry/imports.ts` and the post-link
   `assertNoLeakedHostImports` scan in `src/codegen/index.ts`). `env` host
   bindings stay allowlist-gated (not `--link`-overridable). No lowering added.
-- **S3 — tests + back-compat lock-in.** `tests/issue-2783.test.ts` (10 tests):
-  `--link node:fs` byte-identical to `--link-node-shims`; gate permits an
-  arbitrary namespace (`acme:telemetry`) while rejecting an unlinked one;
-  per-namespace isolation; `env` not overridable; byte-neutral when no `--link`
-  (omitted ≡ `link: []`); deprecation warning fires for `--link-node-shims`;
-  multi-file `compileProject` forwards the `link` policy.
+- **S3 — tests + migration.** `tests/issue-2783.test.ts`: `--link node:fs`
+  selects the import-and-link std-IO path; gate permits an arbitrary namespace
+  (`acme:telemetry`) while rejecting an unlinked one; per-namespace isolation;
+  `env` not overridable; byte-neutral when no `--link` (omitted ≡ `link: []`);
+  the removed `--link-node-shims` flag is rejected by the CLI; multi-file
+  `compileProject` forwards the `link` policy. Every `linkNodeShims: true` /
+  `--link-node-shims` caller across `tests/`, `examples/`, `scripts/`, `docs/`
+  migrated to `link: ["node:fs"]` / `--link node:fs`.
 
 ## Test Results
 
-- `tests/issue-2783.test.ts` — 10/10 pass.
-- Regression set (no change): `issue-2633-process-io-to-node-fs`,
-  `issue-2631-node-fs-fd-shim`, `issue-2094-import-leak-scan`,
+- `tests/issue-2783.test.ts` — pass.
+- `examples/native-messaging/smoke-test.sh` (now `--link node:fs`) — **PASS under
+  real wasmtime 44.0.0** (byte-exact Native Messaging round-trip). The real-link
+  gate.
+- Regression set unchanged: `issue-2633`, `issue-2631`, `issue-2094`,
   `host-import-allowlist-gate`, `host-import-allowlist-budget`,
-  `issue-1554-cli-flag-exclusion` — 45/45 pass.
-- Back-compat: `--link node:fs` ≡ `--link-node-shims` byte-for-byte (SHA match).
-- Byte-neutral: no-`link` single-source compiles unchanged (empty
-  `linkedNamespaces` → identical gate decisions and derived `linkNodeShims`).
-- `tsc --noEmit` clean; `biome lint` clean; `prettier` clean.
-- test262 smoke batch (addition/if): no new CEs (`other=0`); pre-existing
-  bigint/symbol fails unchanged.
+  `issue-1554-cli-flag-exclusion` pass.
+- Byte-neutral: `--link node:fs` output unchanged from the old
+  `linkNodeShims: true` (same create-context derivation; `node:fs` stays in
+  `ALWAYS_ALLOWED_IMPORT_MODULES`). No-`link` single-source compiles unchanged.
+- Pre-existing/unrelated: the heavy Native Messaging runtime tests (#1530, #1753,
+  #1767, #2526, #1768, #1886) fail identically on clean `origin/main` in this
+  container (large-memory/wasmtime env), so they are NOT a #2783 regression.
+- `tsc --noEmit` clean (also confirms no caller still passes the removed option);
+  `biome lint` clean; `prettier` clean.
+- No remaining input-side `--link-node-shims` / `linkNodeShims:`-as-input in
+  `src`/`tests`/`examples`/`scripts`/`docs` (grep clean; historical `plan/`
+  issue records intentionally preserved).
 
 # #2783 — general `--link <namespace>` dynamic-linking flag
 

--- a/scripts/build-node-fs-shim.mjs
+++ b/scripts/build-node-fs-shim.mjs
@@ -11,7 +11,7 @@
  * `node:fs` module (under a JS host) are other providers.
  *
  * The shim OWNS + exports the linear memory; a user module compiled with
- * `--link-node-shims` that uses ONLY node:fs (no process/console IO) IMPORTS
+ * `--link node:fs` that uses ONLY node:fs (no process/console IO) IMPORTS
  * that memory (memory index 0) plus the two IO functions, so the shim can
  * read/write the user's bytes over the SAME memory with no instantiation cycle
  * (the shim imports only `wasi_snapshot_preview1`).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -90,8 +90,6 @@ Options:
                     console.log / process.std*.write lower to writeSync(1|2, ...),
                     stdin is readSync(0, ...). Off by default — every namespace is
                     inline-lowered into a self-contained module.
-  --link-node-shims DEPRECATED (#2783): alias for '--link node:fs'. Emits a
-                    deprecation note. Use '--link node:fs' instead.
   --emulate <env>   Emulate a host runtime's globals so they type-check without
                     @types/node. 'node' = ambient process/etc.; 'none' = off.
                     Auto-enabled (type-level only) when the source imports a
@@ -164,8 +162,9 @@ let utf8Storage = false;
 let strictNoHostImports: boolean | undefined;
 // #2783 — general dynamic-linking axis: namespaces to leave as link-time
 // imports (satisfied by a preloaded provider) instead of inline-lowering.
-// `--link-node-shims` is a deprecated alias for `--link node:fs`. WASI only;
-// default empty keeps the self-contained inline path for every namespace.
+// `--link node:fs` is the spelling for what was once `--link-node-shims` (that
+// alias was removed, not deprecated). WASI only; default empty keeps the
+// self-contained inline path for every namespace.
 const linkedNamespaces = new Set<string>();
 // #2603 — `--emulate node`: opt into Node API emulation (ambient `process` typing).
 // `emulateExplicit` records that the user passed `--emulate`/`--no-emulate`, so a
@@ -249,19 +248,13 @@ for (let i = 0; i < args.length; i++) {
     // as link-time imports for instantiation-time satisfaction instead of
     // inline-lowering. Any external namespace works ("leave-as-import" is
     // universal); `node:fs` additionally selects the import-and-link std-IO
-    // path. WASI only (ignored otherwise, mirroring the old linkNodeShims gate).
+    // path. WASI only (ignored otherwise).
     const ns = arg.startsWith("--link=") ? arg.slice("--link=".length) : args[++i];
     if (!ns) {
       console.error("--link requires a namespace argument (e.g. --link node:fs)");
       process.exit(1);
     }
     linkedNamespaces.add(ns);
-  } else if (arg === "--link-node-shims") {
-    // #2783 — deprecated alias for `--link node:fs`. Kept working; emits a soft
-    // deprecation note. (#2625 originally introduced the per-module node:<mod>
-    // shims; the lower-vs-import decision is now the general `--link` axis.)
-    console.error("warning: --link-node-shims is deprecated; use --link node:fs instead.");
-    linkedNamespaces.add("node:fs");
   } else if (arg === "--emulate" || arg.startsWith("--emulate=")) {
     // #2603 — opt into (or out of) Node API emulation. `--emulate node` gives the
     // checker an ambient `process` typing so Node globals type-check without

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -34,10 +34,9 @@ export function createCodegenContext(
     !!(options?.fast || options?.wasi || options?.standalone || strictNoHostImports || options?.utf8Storage);
   // #2783 — the dynamic-linking set: external namespaces left as link-time
   // imports (satisfied by a preloaded provider) instead of inline-lowering.
-  // WASI-gated exactly as the old `linkNodeShims` boolean was — ignored for
-  // non-WASI targets. `linkNodeShims` is derived from `node:fs` membership so
-  // the two can never drift. (`compiler.ts` already folded a legacy
-  // `linkNodeShims: true` into `options.link` as `"node:fs"`.)
+  // WASI-gated — ignored for non-WASI targets. The internal `ctx.linkNodeShims`
+  // convenience boolean is derived from `node:fs` membership (below) so the ~30
+  // codegen read-sites stay zero-churn and the two can never drift.
   const linkedNamespaces: ReadonlySet<string> = new Set(options?.wasi ? (options?.link ?? []) : []);
   const ctx: CodegenContext = {
     mod,

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -66,23 +66,14 @@ export interface CodegenOptions {
   /** WASI target: emit WASI imports (fd_write, proc_exit) instead of JS host imports */
   wasi?: boolean;
   /**
-   * #2524 / #2633 — route std-IO through a separately compiled, linkable
-   * `node:fs` shim instead of inlining the `wasi_snapshot_preview1.fd_read`/
-   * `fd_write` glue. When set (WASI only), the user module imports
-   * `readSync`/`writeSync` plus its linear memory from `node:fs` and carries NO
+   * #2783 — the dynamic-linking axis: namespaces to leave as link-time imports
+   * (satisfied by a preloaded provider) instead of inline-lowering. `["node:fs"]`
+   * routes std-IO through the `node:fs` shim (the user module imports
+   * `readSync`/`writeSync` + its linear memory from `node:fs` and carries NO
    * `wasi_snapshot_preview1` import for the stream IO path; console.log /
-   * process.std*.write lower to `writeSync(1|2, …)`. `node-fs.wasm` implements
-   * the interface over WASI. The bespoke `js2wasm:node-process` shim was retired
-   * (#2633). Default off — the inline fd_read/fd_write path stays as fallback.
-   *
-   * @deprecated (#2783) Folded into `link` as `"node:fs"` by `buildCodegenOptions`.
-   */
-  linkNodeShims?: boolean;
-  /**
-   * #2783 — general dynamic-linking axis. Namespaces to leave as link-time
-   * imports (satisfied by a preloaded provider) instead of inline-lowering.
-   * `linkNodeShims: true` is folded in here as `"node:fs"`. WASI-gated in
-   * `create-context.ts` (ignored for non-WASI targets).
+   * process.std*.write lower to `writeSync(1|2, …)`; `node-fs.wasm` implements
+   * the interface over WASI). WASI-gated in `create-context.ts` (ignored for
+   * non-WASI targets). Default empty — the inline fd_read/fd_write path stays.
    */
   link?: string[];
   /** Standalone target (#1470): pure WasmGC, no JS host imports and no WASI
@@ -1735,10 +1726,12 @@ export interface CodegenContext {
    * `node:fs` `readSync`/`writeSync` calls (over a shim-owned, imported linear
    * memory) instead of inline `fd_read`/`fd_write`. console.log/warn/error and
    * process.std*.write lower to `writeSync(1|2, …)`; the bespoke
-   * `js2wasm:node-process` shim was retired (#2633). See `linkNodeShims` in
-   * `CodegenOptions`.
+   * `js2wasm:node-process` shim was retired (#2633). Driven by the `link` set
+   * (`["node:fs"]`).
    *
-   * #2783 — now a **derived** value: `linkedNamespaces.has("node:fs")`. The two
+   * #2783 — an INTERNAL convenience boolean, **derived** from
+   * `linkedNamespaces.has("node:fs")` (there is no user-facing `linkNodeShims`
+   * option anymore — `link: string[]` is the only input). The two
    * are computed together in `create-context.ts` from the same (WASI-gated)
    * `link` set so they can never drift. Keeping this boolean lets the ~30
    * existing `ctx.linkNodeShims` read sites stay zero-churn while the underlying

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -5973,7 +5973,7 @@ function collectConsoleImports(ctx: CodegenContext, sourceFile: ts.SourceFile): 
 
 /**
  * #2633 — does the source use stream-write IO that lowers, under
- * `--link-node-shims`, to `node:fs` `writeSync` (console.log/warn/error,
+ * `--link node:fs`, to `node:fs` `writeSync` (console.log/warn/error,
  * process.stdout/stderr.write)? Drives the node:fs import registration in
  * `registerWasiImports`: even a program that never `import`s `node:fs`
  * explicitly needs the `node:fs` `writeSync` import the moment it writes to a
@@ -6028,7 +6028,7 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
   // the write scratch in page 2 (WASI_WRITE_SCRATCH_START), well above any
   // data segment, and reserve 3 pages so both regions always exist.
   if (ctx.linkNodeShims) {
-    // #2633 — std-IO under `--link-node-shims` is satisfied entirely by the
+    // #2633 — std-IO under `--link node:fs` is satisfied entirely by the
     // `node:fs` interface (fd-based `readSync`/`writeSync`), the faithful
     // synchronous Node primitives. The bespoke `js2wasm:node-process` shim
     // (`stdout_write`/`stderr_write`/`stdin_read`) was retired: its functions
@@ -6139,7 +6139,7 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
   // #2684 — Deno synchronous stdio usage (`Deno.stdin.readSync` /
   // `Deno.{stdout,stderr}.writeSync`). Tracked separately from needsFdRead/Write
   // so the linkNodeShims recompute below can't drop the syscalls a Deno program
-  // needs (Deno lowers to the DIRECT WASI path regardless of --link-node-shims,
+  // needs (Deno lowers to the DIRECT WASI path regardless of --link node:fs,
   // exactly like the raw-wasi import path). Re-asserted after that recompute.
   let denoUsesReadSync = false;
   let denoUsesWriteSync = false;
@@ -6337,7 +6337,7 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
     needsFdRead = needsStdinReactor;
   } else {
     // #2655 — DIRECT WASI Preview-1 path: a standalone `--target wasi` module
-    // (no `--link-node-shims`) that imports `readSync`/`writeSync` from node:fs
+    // (no `--link node:fs`) that imports `readSync`/`writeSync` from node:fs
     // lowers fd-based `readSync(fd, buf, …)` / `writeSync(fd, buf, …)` straight to
     // `wasi_snapshot_preview1.fd_read` / `fd_write` (a plain BLOCKING read — NOT
     // the async reactor's non-blocking fd_read + poll_oneoff). `needsFdRead` is
@@ -6362,7 +6362,7 @@ function registerWasiImports(ctx: CodegenContext, sourceFile: ts.SourceFile): vo
   // #2684 — Deno synchronous stdio lowers to the DIRECT WASI fd_read/fd_write
   // path (deno-api.ts), so its syscall imports must be registered regardless of
   // the shim/direct recompute above (mirrors the raw-wasi re-assertion). A Deno
-  // program under --link-node-shims is nonsensical, but this keeps the direct
+  // program under --link node:fs is nonsensical, but this keeps the direct
   // path's imports from being dropped either way.
   if (denoUsesReadSync) needsFdRead = true;
   if (denoUsesWriteSync) needsFdWrite = true;
@@ -7502,7 +7502,7 @@ export function ensureWasiWriteAnyStringHelper(ctx: CodegenContext, useStderr: b
  * it to the *runtime* fd. This backs the STRING overload of `node:fs`
  * `writeSync(fd, str, position?, encoding?)`, where the fd is an arbitrary
  * integer (not just stdout/stderr). Two modes (#2655):
- *   - shim (`--link-node-shims`): `writeSync(fd, ptr, len)` returns the byte count.
+ *   - shim (`--link node:fs`): `writeSync(fd, ptr, len)` returns the byte count.
  *   - direct (standalone `--target wasi`): build a `{ base=ptr, len }` iovec at
  *     memory[0..7], call `fd_write(fd, iovs=0, 1, nwritten=8)`, load nwritten.
  */
@@ -13283,7 +13283,7 @@ function registerNodeBuiltinImports(ctx: CodegenContext, builtins: NodeBuiltinIm
       // program uses the fd-based synchronous primitives readSync / writeSync:
       // those are stripped by import preprocessing and lowered by node-fs-api.ts
       // (tryCompileNodeFsCall) to EITHER imported `node:fs` shim calls
-      // (--link-node-shims) OR direct `wasi_snapshot_preview1.fd_read`/`fd_write`
+      // (--link node:fs) OR direct `wasi_snapshot_preview1.fd_read`/`fd_write`
       // syscalls (standalone --target wasi, #2655). Either way the `fs` builtin
       // import itself is consumed at compile time and must not error here.
       // Path-based fs usage is rejected at the call site (PATH_BASED_FS_FNS in

--- a/src/codegen/node-fs-api.ts
+++ b/src/codegen/node-fs-api.ts
@@ -5,7 +5,7 @@
  * This keeps Node-shaped host API support out of the generic call-expression
  * compiler. It recognizes the synchronous std-IO surface — `node:fs`
  * `readSync`/`writeSync(fd, buf, …)` and `process.stdout`/`stderr.write` — and
- * lowers them to WASI syscalls (or, under `--link-node-shims`, to the imported
+ * lowers them to WASI syscalls (or, under `--link node:fs`, to the imported
  * `node:fs` shim). It also rejects the hallucinated `process.stdin.read(buf,
  * offset)` with a clear pointer to `node:fs` `readSync`.
  */
@@ -223,7 +223,7 @@ function matchProcessStdinRead(fctx: FunctionContext, expr: ts.CallExpression): 
 // fd-based (integer fd 0/1/2), NOT path-based: they map 1:1 to fd_read/fd_write
 // with NO filesystem. The path-based `fs` family (readFileSync(path)) stays on
 // the --allow-fs path and is rejected in standalone WASI. Since #2633 these are
-// also the sole std-IO substrate under `--link-node-shims`: console.log /
+// also the sole std-IO substrate under `--link node:fs`: console.log /
 // process.std*.write lower to `writeSync(1|2, …)`, and the bespoke
 // `js2wasm:node-process` shim was retired.
 //
@@ -244,7 +244,7 @@ export function tryCompileNodeFsCall(
   expr: ts.CallExpression,
 ): InnerResult | undefined {
   // The "no provider" gate (#1772 P2-a) fires under `--target wasi` regardless of
-  // `--link-node-shims`, so it must sit AFTER the `!ctx.wasi` guard but BEFORE the
+  // `--link node:fs`, so it must sit AFTER the `!ctx.wasi` guard but BEFORE the
   // combined `!ctx.linkNodeShims` short-circuit and the readSync/writeSync match.
   if (!ctx.wasi) return undefined;
 
@@ -288,7 +288,7 @@ export function tryCompileNodeFsCall(
   }
 
   // #2655 — fd-based readSync/writeSync lower via EITHER the `node:fs` shim
-  // (`--link-node-shims`: the imported `(fd,ptr,len) -> i32` shim funcs) OR the
+  // (`--link node:fs`: the imported `(fd,ptr,len) -> i32` shim funcs) OR the
   // DIRECT WASI Preview-1 path (`!ctx.linkNodeShims`: the
   // `wasi_snapshot_preview1.fd_read`/`fd_write` syscalls). The direct path makes
   // a standalone stdio program a self-contained WASI P1 command module importing

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -716,11 +716,10 @@ function buildCodegenOptions(
     utf8Storage: options.utf8Storage,
     testRuntime: options.testRuntime,
     wasi: options.target === "wasi",
-    // #2783 — normalize the dynamic-linking axis into a single deduped `link`
-    // set. The deprecated `linkNodeShims: true` alias folds in as `"node:fs"`,
-    // so any programmatic caller (and the CLI's `--link-node-shims` alias) keeps
-    // working byte-identically while the underlying state generalizes.
-    link: [...new Set([...(options.link ?? []), ...(options.linkNodeShims ? ["node:fs"] : [])])],
+    // #2783 — the dynamic-linking axis: namespaces to leave as link-time imports
+    // (deduped). `link: ["node:fs"]` is the only spelling; the old `linkNodeShims`
+    // boolean was removed.
+    link: [...new Set(options.link ?? [])],
     standalone: options.target === "standalone",
     strictNoHostImports: options.strictNoHostImports,
     // (#2119) thread module-strictness inference uniformly across all drivers.

--- a/src/index.ts
+++ b/src/index.ts
@@ -277,37 +277,23 @@ export interface CompileOptions {
    *  Default: false (calls to fs.readFileSync / fs.writeFileSync raise a compile error). */
   allowFs?: boolean;
   /**
-   * #2625 / #2633 — emit the per-module linkable `node:<mod>` shims instead of
-   * inlining the host APIs. WASI-only (ignored for other targets). When set,
-   * std-IO is routed through `node:fs`: the user module imports `readSync`/
-   * `writeSync` plus its linear memory from `node:fs` and carries no
-   * `wasi_snapshot_preview1` import for stream IO; console.log / process.std*.write
-   * lower to `writeSync(1|2, …)` and synchronous stdin is `readSync(0, …)`. Link
-   * against `node-fs.wasm` (or `--preload node:fs=node-fs.wasm` under wasmtime).
-   * Default off — the self-contained inline `fd_read`/`fd_write` path stays. The
-   * bespoke `js2wasm:node-process` shim (`process.stdin.read`/`stdout_write`/…)
-   * was retired in #2633; `process.stdin.read(buf, offset)` is no longer a
-   * recognised API (it matched no real Node surface — use `node:fs` `readSync`).
+   * #2783 — general `--link <namespace>` dynamic-linking axis (the ONLY
+   * link-vs-inline control; the old `linkNodeShims` boolean was removed). Each
+   * listed namespace is left as a **link-time import** (satisfied at
+   * instantiation by a preloaded provider module, e.g.
+   * `wasmtime --preload node:fs=node-fs.wasm`) instead of being inline-lowered to
+   * a self-contained module. "Leave-as-import" is the universal capability (any
+   * external namespace can be a wasm import); "inline-lower" is the special
+   * capability the compiler only has for a known few (`node:fs` fd IO). So for an
+   * arbitrary namespace `link: ["acme:telemetry"]` simply permits its imports
+   * past the strict `--no-host-imports` / WASI gate; for `node:fs` it
+   * additionally selects the import-and-link std-IO path (the user module imports
+   * `readSync`/`writeSync` + its linear memory from `node:fs` and carries no
+   * `wasi_snapshot_preview1` import for stream IO; console.log /
+   * process.std*.write lower to `writeSync(1|2, …)`, stdin is `readSync(0, …)`).
    *
-   * @deprecated (#2783) Use `link: ["node:fs"]` instead. Kept as a back-compat
-   * alias: `buildCodegenOptions` folds `linkNodeShims === true` into the `link`
-   * set as `"node:fs"`, so the observable behaviour is byte-identical.
-   */
-  linkNodeShims?: boolean;
-  /**
-   * #2783 — general `--link <namespace>` dynamic-linking axis. Each listed
-   * namespace is left as a **link-time import** (satisfied at instantiation by a
-   * preloaded provider module, e.g. `wasmtime --preload node:fs=node-fs.wasm`)
-   * instead of being inline-lowered to a self-contained module. "Leave-as-import"
-   * is the universal capability (any external namespace can be a wasm import);
-   * "inline-lower" is the special capability the compiler only has for a known
-   * few (`node:fs` fd IO). So for an arbitrary namespace `--link <ns>` simply
-   * permits its imports past the strict `--no-host-imports` / WASI gate; for
-   * `node:fs` it additionally selects the import-and-link codegen path.
-   *
-   * WASI-gated (mirrors `linkNodeShims`): ignored for non-WASI targets.
-   * `linkNodeShims: true` is folded in as `"node:fs"`. Default empty — every
-   * namespace stays standalone / inline-lowered.
+   * WASI-gated: ignored for non-WASI targets. Default empty — every namespace
+   * stays standalone / inline-lowered. CLI: `--link <ns>` (repeatable).
    */
   link?: string[];
   /**

--- a/tests/issue-1530.test.ts
+++ b/tests/issue-1530.test.ts
@@ -25,7 +25,7 @@ const hostPath = join(here, "..", "examples", "native-messaging", "nm_node_fs.ts
 describe("#1530 Native Messaging host example", () => {
   it("compiles examples/native-messaging/nm_node_fs.ts under --target wasi", async () => {
     const src = readFileSync(hostPath, "utf-8");
-    const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", linkNodeShims: true });
+    const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success).toBe(true);
     expect(result.binary.length).toBeGreaterThan(0);
   });
@@ -36,7 +36,7 @@ describe("#1530 Native Messaging host example", () => {
     // interface) and NOT wasi_snapshot_preview1 fd_read/fd_write directly. The
     // shim (node-fs.wat) maps node:fs → WASI; the user module stays host-agnostic.
     const src = readFileSync(hostPath, "utf-8");
-    const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", linkNodeShims: true });
+    const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success).toBe(true);
     expect(result.wat).toContain('(import "node:fs" "readSync"'); // fs.readSync(0, …)
     expect(result.wat).toContain('(import "node:fs" "writeSync"'); // fs.writeSync(1|2, …)
@@ -50,7 +50,7 @@ describe("#1530 Native Messaging host example", () => {
 
   it("produces a binary that WebAssembly accepts", async () => {
     const src = readFileSync(hostPath, "utf-8");
-    const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", linkNodeShims: true });
+    const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success).toBe(true);
     // Throws on an invalid module; passing means the structure/types are sound.
     expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
@@ -201,7 +201,7 @@ export function main(): void {
 
   it("compiles the shipped example and round-trips it byte-exactly", async () => {
     const src = readFileSync(hostPath, "utf-8");
-    const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", linkNodeShims: true });
+    const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success).toBe(true);
 
     // The shipped host echoes the received body verbatim (byte-for-byte, no
@@ -227,7 +227,7 @@ export function main(): void {
   // assert the response is the exact same 1 MiB body with the right prefix.
   it("echoes a 1 MiB framed body byte-exactly (#389 large-message regression)", async () => {
     const src = readFileSync(hostPath, "utf-8");
-    const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", linkNodeShims: true });
+    const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success).toBe(true);
 
     const SIZE = 1024 * 1024; // 1 MiB
@@ -266,7 +266,7 @@ export function main(): void {
   // exceeds the 1 MiB cap, and the flattened elements equal the inputs in order.
   it("re-chunks large JSON arrays into valid <=1 MiB JSON frames across one session (#389)", async () => {
     const src = readFileSync(hostPath, "utf-8");
-    const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", linkNodeShims: true });
+    const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success).toBe(true);
 
     const CHUNK = 1024 * 1024;

--- a/tests/issue-1751.test.ts
+++ b/tests/issue-1751.test.ts
@@ -7,7 +7,7 @@ import { compile } from "../src/index.js";
 
 // #2633 — the hallucinated `process.stdin.read` surface was removed; the
 // inline-WASI native-messaging shape now exercises the stdout-write + exit path
-// (synchronous stdin moved to `node:fs` `readSync` under --link-node-shims).
+// (synchronous stdin moved to `node:fs` `readSync` under --link node:fs).
 const NATIVE_MESSAGING_DECL = `declare const process: {
   stdout: { write(c: Uint8Array | string): boolean };
   exit(code: number): void;

--- a/tests/issue-1753.test.ts
+++ b/tests/issue-1753.test.ts
@@ -24,7 +24,7 @@ async function compileHost(): Promise<Uint8Array> {
   if (!hostBinary) {
     hostBinary = (async () => {
       const src = readFileSync(hostPath, "utf-8");
-      const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", linkNodeShims: true });
+      const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", link: ["node:fs"] });
       expect(result.success, result.success ? "" : result.errors.map((e) => e.message).join("\n")).toBe(true);
       expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
       return result.binary;

--- a/tests/issue-1767.test.ts
+++ b/tests/issue-1767.test.ts
@@ -29,7 +29,7 @@ async function compileHost(): Promise<Uint8Array> {
   if (!hostBinary) {
     hostBinary = (async () => {
       const src = readFileSync(hostPath, "utf-8");
-      const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", linkNodeShims: true });
+      const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", link: ["node:fs"] });
       expect(result.success, result.success ? "" : result.errors.map((e) => e.message).join("\n")).toBe(true);
       expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
       return result.binary;

--- a/tests/issue-1768.test.ts
+++ b/tests/issue-1768.test.ts
@@ -16,13 +16,13 @@ import { compile } from "../src/index.js";
 const here = dirname(fileURLToPath(import.meta.url));
 const hostPath = join(here, "..", "examples", "native-messaging", "nm_node_fs.ts");
 
-async function compileWasiJs(source: string, linkNodeShims = false) {
+async function compileWasiJs(source: string, linkNodeFs = false) {
   return await compile(source, {
     fileName: "nm_node_fs.js",
     allowJs: true,
     target: "wasi",
     optimize: 0,
-    ...(linkNodeShims ? { linkNodeShims: true } : {}),
+    ...(linkNodeFs ? { link: ["node:fs"] } : {}),
   });
 }
 
@@ -75,8 +75,8 @@ describe("#1768 allowJs Native Messaging sendMessage validates under --target wa
     }).outputText;
 
     // #2631 — the example now imports node:fs readSync/writeSync, lowered via the
-    // node:fs shim under --link-node-shims (the transpiled JS keeps the import).
-    const result = await compileWasiJs(source, /* linkNodeShims */ true);
+    // node:fs shim under --link node:fs (the transpiled JS keeps the import).
+    const result = await compileWasiJs(source, /* linkNodeFs */ true);
     expect(result.success, result.success ? "" : result.errors.map((e) => e.message).join("\n")).toBe(true);
     expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
     expect(result.wat).not.toContain('(import "env"');

--- a/tests/issue-1772-edge-dual-provider.test.ts
+++ b/tests/issue-1772-edge-dual-provider.test.ts
@@ -76,7 +76,7 @@ describe("#1772 — node:fs same-binary dual-provider compatibility", () => {
     const result = await compile(FRAMED_ECHO, {
       fileName: "nm.ts",
       target: "wasi",
-      linkNodeShims: true,
+      link: ["node:fs"],
     });
     expect(result.success, JSON.stringify(result.errors)).toBe(true);
     userBinary = result.binary;

--- a/tests/issue-1772-no-provider-gate.test.ts
+++ b/tests/issue-1772-no-provider-gate.test.ts
@@ -28,7 +28,7 @@ export function main(): void {
     const result = await compile(src, {
       fileName: "x.ts",
       target: "wasi",
-      linkNodeShims: true,
+      link: ["node:fs"],
     });
     expect(result.success).toBe(false);
     const msgs = (result.errors ?? []).map((e) => e.message).join("\n");
@@ -40,15 +40,15 @@ export function main(): void {
     expect(msgs).toMatch(/--target wasi/);
   });
 
-  it("the gate also fires WITHOUT --link-node-shims (it keys off --target wasi)", async () => {
+  it("the gate also fires WITHOUT --link node:fs (it keys off --target wasi)", async () => {
     const src = `
 import { readFileSync } from "node:fs";
 export function main(): void {
   const data = readFileSync("/etc/hostname");
 }
 `;
-    // No linkNodeShims: the gate must still fire (it sits after the !ctx.wasi
-    // guard but before the !ctx.linkNodeShims short-circuit).
+    // No `link`: the gate must still fire (it sits after the !ctx.wasi
+    // guard but before the internal !ctx.linkNodeShims short-circuit).
     const result = await compile(src, { fileName: "x.ts", target: "wasi" });
     expect(result.success).toBe(false);
     const msgs = (result.errors ?? []).map((e) => e.message).join("\n");
@@ -69,7 +69,7 @@ export function main(): void {
     const result = await compile(src, {
       fileName: "x.ts",
       target: "wasi",
-      linkNodeShims: true,
+      link: ["node:fs"],
     });
     expect(result.success).toBe(true);
   });
@@ -99,7 +99,7 @@ export function main(): number {
     const result = await compile(src, {
       fileName: "x.ts",
       target: "wasi",
-      linkNodeShims: true,
+      link: ["node:fs"],
     });
     // The local function is unrelated to node:fs; the gate keys off the
     // node:fs import set, so it must not fire here.

--- a/tests/issue-1886-slice-b.test.ts
+++ b/tests/issue-1886-slice-b.test.ts
@@ -11,7 +11,7 @@
  * #2633 — synchronous std-IO moved off the hallucinated `process.stdin.read`
  * surface onto `node:fs` fd-based `readSync(0, …)` / `writeSync(1, …)` (the
  * faithful Node primitives), so these tests now drive the linear I/O path via
- * `node:fs` under `--link-node-shims` (the node-fs shim owns the WASI fd_*).
+ * `node:fs` under `--link node:fs` (the node-fs shim owns the WASI fd_*).
  *
  * These tests guard:
  *   1. The emitted module is VALID wasm (the eager-allocator index-shift bug
@@ -35,21 +35,21 @@ import { buildNodeFsShim } from "../scripts/build-node-fs-shim.mjs";
 // { offset })` fills the buffer; `writeSync(1, buf)` echoes it.
 const FS_IO = `import { readSync, writeSync } from "node:fs";`;
 
-/** Compile `source` with --target wasi --link-node-shims; throw on compile error. */
+/** Compile `source` with --target wasi --link node:fs; throw on compile error. */
 async function compileWasi(source: string): Promise<Uint8Array> {
-  const result = await compile(source, { fileName: "test.ts", target: "wasi", linkNodeShims: true });
+  const result = await compile(source, { fileName: "test.ts", target: "wasi", link: ["node:fs"] });
   if (!result.success) {
     throw new Error(`compile failed: ${result.errors?.map((e) => e.message).join("; ") ?? "unknown"}`);
   }
   return result.binary;
 }
 
-/** Compile to WAT (emitText) under --link-node-shims; throw on compile error. */
+/** Compile to WAT (emitText) under --link node:fs; throw on compile error. */
 async function compileWat(source: string): Promise<string> {
   const result = await compile(source, {
     fileName: "test.ts",
     target: "wasi",
-    linkNodeShims: true,
+    link: ["node:fs"],
     emitText: true,
   } as never);
   if (!result.success) {

--- a/tests/issue-1886.test.ts
+++ b/tests/issue-1886.test.ts
@@ -75,11 +75,11 @@ async function compileWat(source: string): Promise<string> {
   return (result as unknown as { wat?: string }).wat ?? "";
 }
 
-// #2633 — node:fs readSync/writeSync are supported under --link-node-shims; the
+// #2633 — node:fs readSync/writeSync are supported under --link node:fs; the
 // node-fs shim owns the shared memory + WASI fd_*. These helpers compile + run a
 // user module that drives the linear I/O path through that shim.
 async function compileWasiShim(source: string): Promise<Uint8Array> {
-  const result = await compile(source, { fileName: "test.ts", target: "wasi", linkNodeShims: true });
+  const result = await compile(source, { fileName: "test.ts", target: "wasi", link: ["node:fs"] });
   if (!result.success) {
     throw new Error(`compile failed: ${result.errors?.map((e) => e.message).join("; ") ?? "unknown"}`);
   }
@@ -90,7 +90,7 @@ async function compileWat2(source: string): Promise<string> {
   const result = await compile(source, {
     fileName: "test.ts",
     target: "wasi",
-    linkNodeShims: true,
+    link: ["node:fs"],
     emitText: true,
   } as never);
   if (!result.success) {

--- a/tests/issue-2521-native-messaging-rechunk.test.ts
+++ b/tests/issue-2521-native-messaging-rechunk.test.ts
@@ -129,7 +129,7 @@ describe("#2521 Native Messaging host — >1 MiB re-chunking + multi-message seq
     // routing); single-source `compile()` would strip the relative import.
     const result = await compileProject(hostPath, {
       target: "wasi",
-      linkNodeShims: true,
+      link: ["node:fs"],
       skipSemanticDiagnostics: true,
     });
     expect(result.success).toBe(true);
@@ -143,7 +143,7 @@ describe("#2521 Native Messaging host — >1 MiB re-chunking + multi-message seq
     // routing); single-source `compile()` would strip the relative import.
     const result = await compileProject(hostPath, {
       target: "wasi",
-      linkNodeShims: true,
+      link: ["node:fs"],
       skipSemanticDiagnostics: true,
     });
     expect(result.success).toBe(true);
@@ -171,7 +171,7 @@ describe("#2521 Native Messaging host — >1 MiB re-chunking + multi-message seq
     // routing); single-source `compile()` would strip the relative import.
     const result = await compileProject(hostPath, {
       target: "wasi",
-      linkNodeShims: true,
+      link: ["node:fs"],
       skipSemanticDiagnostics: true,
     });
     expect(result.success).toBe(true);

--- a/tests/issue-2526-atomic-frame-writes.test.ts
+++ b/tests/issue-2526-atomic-frame-writes.test.ts
@@ -64,7 +64,7 @@ function runCaptureWrites(binary: Uint8Array, stdin: Uint8Array): { sizes: numbe
     },
   };
   // #2631 — the example now uses node:fs readSync/writeSync via the node:fs
-  // shim (--link-node-shims). Instantiate the shim FIRST (it owns the memory and
+  // shim (--link node:fs). Instantiate the shim FIRST (it owns the memory and
   // makes the fd_read/fd_write WASI calls), then the user module importing
   // {memory, readSync, writeSync} from the shim. fd=1 writes are still issued by
   // the shim's writeSync over the shared memory, so the size capture is unchanged.
@@ -98,7 +98,7 @@ describe("#2526 Native Messaging host — atomic frame writes", () => {
     const r = await compile(readFileSync(hostPath, "utf-8"), {
       fileName: "nm_node_fs.ts",
       target: "wasi",
-      linkNodeShims: true,
+      link: ["node:fs"],
     });
     expect(r.success).toBe(true);
     const { sizes } = runCaptureWrites(r.binary, frame(JSON.stringify([1, 2, 3])));
@@ -111,7 +111,7 @@ describe("#2526 Native Messaging host — atomic frame writes", () => {
     const r = await compile(readFileSync(hostPath, "utf-8"), {
       fileName: "nm_node_fs.ts",
       target: "wasi",
-      linkNodeShims: true,
+      link: ["node:fs"],
     });
     expect(r.success).toBe(true);
     const N = 209715 * 2; // ~2 MiB → multiple re-chunked frames

--- a/tests/issue-2631-node-fs-fd-shim.test.ts
+++ b/tests/issue-2631-node-fs-fd-shim.test.ts
@@ -7,7 +7,7 @@
 // `fs.writeSync(fd, …)` — fd-based (integer fd 0/1/2), NOT path-based, mapping
 // 1:1 to WASI fd_read / fd_write with no filesystem.
 //
-// Under `--target wasi` + `linkNodeShims: true`, a module that imports
+// Under `--target wasi` + `link: ["node:fs"]`, a module that imports
 // `{ readSync, writeSync } from "node:fs"` emits wasm imports against module
 // `"node:fs"` (the declared interface, not the shim that satisfies it) and
 // carries NO direct `wasi_snapshot_preview1` fd_read/fd_write import for that
@@ -115,7 +115,7 @@ export function main(): void {
 
 describe("#2631 — node:fs fd-based readSync/writeSync shim", () => {
   it("emits node:fs imports (memory + readSync/writeSync), no direct wasi fd_read/fd_write", async () => {
-    const result = await compile(FRAMED_ECHO, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
+    const result = await compile(FRAMED_ECHO, { fileName: "x.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success).toBe(true);
     const wat = result.wat ?? "";
     // Imports the node:fs interface: memory + the IO functions it uses.
@@ -132,7 +132,7 @@ describe("#2631 — node:fs fd-based readSync/writeSync shim", () => {
   });
 
   it("links node-fs.wasm and round-trips a framed message byte-for-byte", async () => {
-    const result = await compile(FRAMED_ECHO, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
+    const result = await compile(FRAMED_ECHO, { fileName: "x.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success).toBe(true);
     // frame: len=5 (LE) + a body with non-printable / high bytes.
     const frame = Uint8Array.from([0x05, 0x00, 0x00, 0x00, 0x00, 0xff, 0x0a, 0x7f, 0x80]);
@@ -161,7 +161,7 @@ export function main(): void {
   while (n < out.length) { const w = writeSync(1, out, n); if (w <= 0) break; n = n + w; }
 }
 `;
-    const result = await compile(src, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
+    const result = await compile(src, { fileName: "x.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success).toBe(true);
     // stdin has 5 bytes available, but we only ever request 3.
     const stdin = Uint8Array.from([0x41, 0x42, 0x43, 0x44, 0x45]);
@@ -183,7 +183,7 @@ export function main(): void {
   while (m < b.length) { const w = writeSync(1, b, m); if (w <= 0) break; m = m + w; }
 }
 `;
-    const result = await compile(src, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
+    const result = await compile(src, { fileName: "x.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success).toBe(true);
     const { stdout, stderr } = linkAndRun(result.binary, new Uint8Array(0));
     expect(Array.from(stdout)).toEqual([0x6f, 0x6b]); // "ok" only on fd=1
@@ -197,7 +197,7 @@ export function main(): string {
   return readFileSync("/etc/hostname", "utf-8");
 }
 `;
-    const result = await compile(src, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
+    const result = await compile(src, { fileName: "x.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success).toBe(false);
     const msgs = (result.errors ?? []).map((e) => e.message).join("\n");
     expect(msgs).toMatch(/readFileSync/);
@@ -207,12 +207,12 @@ export function main(): string {
     expect(msgs).toMatch(/(un)?available under `?--target wasi`?|no filesystem|filesystem provider|#2631/);
   });
 
-  it("linkNodeShims is ignored for non-WASI targets (no node:fs shim import)", async () => {
+  it("link: ['node:fs'] is ignored for non-WASI targets (no node:fs shim import)", async () => {
     const src = `
 import { readSync, writeSync } from "node:fs";
 export function noop(): void {}
 `;
-    const result = await compile(src, { fileName: "x.ts", linkNodeShims: true });
+    const result = await compile(src, { fileName: "x.ts", link: ["node:fs"] });
     // Non-WASI: the node:fs fd-shim path does not apply.
     expect(result.wat ?? "").not.toContain('(import "node:fs" "readSync"');
   });

--- a/tests/issue-2633-process-io-to-node-fs.test.ts
+++ b/tests/issue-2633-process-io-to-node-fs.test.ts
@@ -1,8 +1,8 @@
 // #2633 — std-IO routes through `node:fs` (fd-based readSync/writeSync) under
-// `--link-node-shims`; the bespoke `js2wasm:node-process` shim is retired and
+// `--link node:fs`; the bespoke `js2wasm:node-process` shim is retired and
 // the hallucinated `process.stdin.read(buf, offset)` is no longer recognised.
 //
-// Under `--target wasi --link-node-shims`, a module that writes to stdout/stderr
+// Under `--target wasi --link node:fs`, a module that writes to stdout/stderr
 // (console.log/warn/error, process.stdout/stderr.write) imports the `node:fs`
 // interface (writeSync) plus its linear memory from `node:fs` and carries NO
 // `wasi_snapshot_preview1` import and NO `js2wasm:node-process` import for the
@@ -78,7 +78,7 @@ function linkAndRun(userBinary: Uint8Array): Uint8Array {
 
 describe("#2633 — std-IO via node:fs (node-process shim retired)", () => {
   it("process.stdout.write lowers to node:fs writeSync, NOT js2wasm:node-process", async () => {
-    const result = await compile(ECHO_WRITE, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
+    const result = await compile(ECHO_WRITE, { fileName: "x.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
     const wat = result.wat ?? "";
     // Imports the node:fs interface: memory + writeSync.
@@ -96,18 +96,18 @@ describe("#2633 — std-IO via node:fs (node-process shim retired)", () => {
     expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
   });
 
-  it("console.log lowers to node:fs writeSync(1, …) under --link-node-shims", async () => {
+  it("console.log lowers to node:fs writeSync(1, …) under --link node:fs", async () => {
     const src = `export function main(): void { console.log("hi"); }`;
-    const result = await compile(src, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
+    const result = await compile(src, { fileName: "x.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
     const wat = result.wat ?? "";
     expect(wat).toContain('(import "node:fs" "writeSync"');
     expect(wat).not.toContain("js2wasm:node-process");
   });
 
-  it("console.error lowers to node:fs writeSync(2, …) under --link-node-shims", async () => {
+  it("console.error lowers to node:fs writeSync(2, …) under --link node:fs", async () => {
     const src = `export function main(): void { console.error("boom"); }`;
-    const result = await compile(src, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
+    const result = await compile(src, { fileName: "x.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
     const wat = result.wat ?? "";
     expect(wat).toContain('(import "node:fs" "writeSync"');
@@ -132,7 +132,7 @@ describe("#2633 — std-IO via node:fs (node-process shim retired)", () => {
         const buf = new Uint8Array(4);
         process.stdin.read(buf, 0);
       }`;
-    const result = await compile(src, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
+    const result = await compile(src, { fileName: "x.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success).toBe(false);
     const msg = result.errors.map((e) => e.message).join("\n");
     expect(msg).toContain("process.stdin.read");
@@ -153,15 +153,15 @@ describe("#2633 — std-IO via node:fs (node-process shim retired)", () => {
   });
 
   it("links node-fs.wasm and round-trips process.stdout.write byte-for-byte", async () => {
-    const result = await compile(ECHO_WRITE, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
+    const result = await compile(ECHO_WRITE, { fileName: "x.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
     const out = linkAndRun(result.binary);
     expect(Array.from(out)).toEqual([0x05, 0x00, 0x00, 0x00, 0x00, 0xff, 0x0a, 0x7f, 0x80]);
   });
 
-  it("linkNodeShims is ignored for non-WASI targets (no node shim imports)", async () => {
+  it("link: ['node:fs'] is ignored for non-WASI targets (no node shim imports)", async () => {
     const src = `export function add(a: number, b: number): number { return a + b; }`;
-    const result = await compile(src, { fileName: "x.ts", linkNodeShims: true });
+    const result = await compile(src, { fileName: "x.ts", link: ["node:fs"] });
     expect(result.success).toBe(true);
     expect(result.wat ?? "").not.toContain("js2wasm:node-process");
     expect(result.wat ?? "").not.toContain('(import "node:fs"');

--- a/tests/issue-2634-node-capability-map.test.ts
+++ b/tests/issue-2634-node-capability-map.test.ts
@@ -125,7 +125,7 @@ export function main(): void {
   const fd = openSync("/etc/hostname", "r");
 }
 `;
-    const result = await compile(src, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
+    const result = await compile(src, { fileName: "x.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success).toBe(false);
     const msgs = (result.errors ?? []).map((e) => e.message).join("\n");
     // Precise, deliberate — names the member and the target, not an opaque crash.
@@ -162,7 +162,7 @@ export function main(): void {
   while (n < r) { const w = writeSync(1, buf, n); if (w <= 0) break; n = n + w; }
 }
 `;
-    const result = await compile(src, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
+    const result = await compile(src, { fileName: "x.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success).toBe(true);
     const wat = result.wat ?? "";
     expect(wat).toContain('(import "node:fs" "readSync"');

--- a/tests/issue-2639-node-fs-writesync-string-dataview.test.ts
+++ b/tests/issue-2639-node-fs-writesync-string-dataview.test.ts
@@ -59,7 +59,7 @@ function linkAndRun(userBinary: Uint8Array): { stdout: Uint8Array; stderr: Uint8
 }
 
 async function compileWasi(src: string) {
-  return compile(src, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
+  return compile(src, { fileName: "x.ts", target: "wasi", link: ["node:fs"] });
 }
 
 describe("#2639 — node:fs writeSync string + DataView codegen", () => {

--- a/tests/issue-2647.test.ts
+++ b/tests/issue-2647.test.ts
@@ -31,7 +31,7 @@ describe("#2647 — plumb --allow-fs into the node:fs no-provider gate", () => {
     const result = await compile(readFileSyncSrc, {
       fileName: "x.ts",
       target: "wasi",
-      linkNodeShims: true,
+      link: ["node:fs"],
     });
     expect(result.success).toBe(false);
     const msgs = (result.errors ?? []).map((e) => e.message).join("\n");
@@ -44,7 +44,7 @@ describe("#2647 — plumb --allow-fs into the node:fs no-provider gate", () => {
     const result = await compile(readFileSyncSrc, {
       fileName: "x.ts",
       target: "wasi",
-      linkNodeShims: true,
+      link: ["node:fs"],
       allowFs: true,
     });
     // The capability map resolves the path-based member through the `js-host-fs`
@@ -53,7 +53,7 @@ describe("#2647 — plumb --allow-fs into the node:fs no-provider gate", () => {
     expect(msgs).not.toMatch(NO_PROVIDER_RE);
   });
 
-  it("the flag toggles the gate WITHOUT --link-node-shims too (gate keys off --target wasi)", async () => {
+  it("the flag toggles the gate WITHOUT --link node:fs too (gate keys off --target wasi)", async () => {
     // allowFs off → error fires.
     const off = await compile(readFileSyncSrc, { fileName: "x.ts", target: "wasi" });
     const offMsgs = (off.errors ?? []).map((e) => e.message).join("\n");
@@ -79,7 +79,7 @@ export function main(): void {
       const result = await compile(src, {
         fileName: "x.ts",
         target: "wasi",
-        linkNodeShims: true,
+        link: ["node:fs"],
         allowFs,
       });
       expect(result.success).toBe(true);

--- a/tests/issue-2655-direct-wasi-readsync-writesync.test.ts
+++ b/tests/issue-2655-direct-wasi-readsync-writesync.test.ts
@@ -3,14 +3,14 @@
 // loopdive/js2#389: the Native Messaging host reporter runs directly under a
 // WASI host (wasmtime) and is explicitly "not chasing Node.js". They want a
 // SELF-CONTAINED WASI P1 command module that imports ONLY
-// `wasi_snapshot_preview1` — no node:fs shim (`--link-node-shims`), no Node
+// `wasi_snapshot_preview1` — no node:fs shim (`--link node:fs`), no Node
 // runtime. #2631/#2633 gave the shim path; this adds the direct path: fd-based
 // `readSync(0, …)` / `writeSync(1, …)` lower straight to
 // `wasi_snapshot_preview1.fd_read` / `fd_write` (a plain BLOCKING read — NOT the
 // async reactor's non-blocking fd_read + poll_oneoff), and the command module
 // owns + exports its own `memory`.
 //
-// The `--link-node-shims` path (the "same file also runs unmodified under real
+// The `--link node:fs` path (the "same file also runs unmodified under real
 // node via node:fs" story) is unchanged — covered by issue-2631-node-fs-fd-shim.
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -87,10 +87,10 @@ describe("#2655 — direct WASI P1 readSync/writeSync (no shim)", () => {
     expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
   });
 
-  // Sanity: the SAME source still compiles under --link-node-shims to the shim
+  // Sanity: the SAME source still compiles under --link node:fs to the shim
   // imports (the node-runtime variant), proving the dual mode coexists.
-  it("--link-node-shims still emits the node:fs shim imports (dual mode preserved)", async () => {
-    const result = await compile(FRAMED_ECHO, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
+  it("--link node:fs still emits the node:fs shim imports (dual mode preserved)", async () => {
+    const result = await compile(FRAMED_ECHO, { fileName: "x.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success).toBe(true);
     const wat = result.wat ?? "";
     expect(wat).toContain('(import "node:fs" "readSync"');

--- a/tests/issue-2783.test.ts
+++ b/tests/issue-2783.test.ts
@@ -1,19 +1,20 @@
 // #2783 — general `--link <namespace>` dynamic-linking flag (S1–S3).
 //
-// Generalizes the single `--link-node-shims` boolean into an orthogonal,
-// per-namespace axis: `--link <ns>` (repeatable) leaves `<ns>::*` as link-time
-// imports (satisfied by a preloaded provider) instead of inline-lowering it.
-// `--link-node-shims` becomes a deprecated alias for `--link node:fs`.
+// Replaces the single `linkNodeShims` boolean with an orthogonal, per-namespace
+// axis: `--link <ns>` (repeatable) / `link: string[]` leaves `<ns>::*` as
+// link-time imports (satisfied by a preloaded provider) instead of
+// inline-lowering it. There is NO `--link-node-shims` alias — `--link node:fs`
+// (CLI) / `link: ["node:fs"]` (programmatic) is the only spelling.
 //
 // Coverage:
-//  S1/S3 (a) — `--link node:fs` is BYTE-IDENTICAL to `--link-node-shims`
-//              (the rename/generalization is pure; back-compat lock-in).
+//  S1     (a) — `--link node:fs` selects the import-and-link std-IO path
+//              (node:fs memory + writeSync imports; no wasi_snapshot_preview1).
 //  S2     (b) — the strict-gate generalization: an ARBITRARY `--link`'d
 //              namespace's imports survive the `--no-host-imports` / WASI
 //              strict gate instead of being rejected (the one genuinely-new
 //              capability). Tested at the gate (`isHostImportAllowed` /
 //              `scanForLeakedHostImports`).
-//  S3     (c) — deprecation warning fires for `--link-node-shims`.
+//  S3     (c) — the removed `--link-node-shims` flag is rejected by the CLI.
 //  S3     (d) — multi-file (`compileProject`) honors `link`.
 //  S3     (e) — byte-neutral when no `--link` is passed (existing single-source
 //              compiles are unchanged).
@@ -28,26 +29,15 @@ import { isHostImportAllowed, scanForLeakedHostImports } from "../src/codegen/ho
 
 const ECHO = `export function main(): void { console.log("hello, link"); }`;
 
-describe("#2783 S1/S3 — `--link node:fs` ≡ `--link-node-shims` (back-compat byte-identical)", () => {
-  it("produces byte-identical output to the deprecated alias", async () => {
-    const viaAlias = await compile(ECHO, { fileName: "x.ts", target: "wasi", linkNodeShims: true });
-    const viaLink = await compile(ECHO, { fileName: "x.ts", target: "wasi", link: ["node:fs"] });
-    expect(viaAlias.success, viaAlias.errors.map((e) => e.message).join("\n")).toBe(true);
-    expect(viaLink.success, viaLink.errors.map((e) => e.message).join("\n")).toBe(true);
-    expect(Buffer.compare(Buffer.from(viaLink.binary), Buffer.from(viaAlias.binary))).toBe(0);
-    // And both select the import-and-link std-IO path (node:fs writeSync import).
-    expect(viaLink.wat ?? "").toContain('(import "node:fs" "writeSync"');
-  });
-
-  it("`linkNodeShims: true` and `link: ['node:fs']` both leave node:fs as imports", async () => {
-    for (const opts of [{ linkNodeShims: true }, { link: ["node:fs"] }]) {
-      const r = await compile(ECHO, { fileName: "x.ts", target: "wasi", ...opts });
-      expect(r.success).toBe(true);
-      const wat = r.wat ?? "";
-      expect(wat).toContain('(import "node:fs" "memory" (memory');
-      expect(wat).toContain('(import "node:fs" "writeSync"');
-      expect(wat).not.toContain("wasi_snapshot_preview1");
-    }
+describe("#2783 S1 — `--link node:fs` selects the import-and-link std-IO path", () => {
+  it("`link: ['node:fs']` leaves node:fs (memory + writeSync) as imports", async () => {
+    const r = await compile(ECHO, { fileName: "x.ts", target: "wasi", link: ["node:fs"] });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    const wat = r.wat ?? "";
+    expect(wat).toContain('(import "node:fs" "memory" (memory');
+    expect(wat).toContain('(import "node:fs" "writeSync"');
+    // No wasi_snapshot_preview1 import survives for the stream IO path.
+    expect(wat).not.toContain("wasi_snapshot_preview1");
   });
 });
 
@@ -111,14 +101,12 @@ describe("#2783 S3 — byte-neutral when no `--link` is passed", () => {
   });
 });
 
-describe("#2783 S3 — deprecation warning for `--link-node-shims`", () => {
+describe("#2783 S3 — the removed `--link-node-shims` flag and the `--link` CLI", () => {
   function runCli(extraArgs: string): { stderr: string; status: number } {
     const dir = mkdtempSync(path.join(tmpdir(), "issue-2783-cli-"));
     const inFile = path.join(dir, "input.ts");
     writeFileSync(inFile, ECHO);
-    // spawnSync (not execSync): capture stderr regardless of exit code — the
-    // deprecation note is written to stderr even on a successful (status 0)
-    // compile, which execSync's return value would discard.
+    // spawnSync (not execSync): capture stderr regardless of exit code.
     const args = [
       path.resolve("src/cli.ts"),
       inFile,
@@ -132,13 +120,13 @@ describe("#2783 S3 — deprecation warning for `--link-node-shims`", () => {
     return { stderr: r.stderr ?? "", status: r.status ?? 1 };
   }
 
-  it("emits a deprecation note for --link-node-shims and still compiles", () => {
-    const { stderr, status } = runCli("--link-node-shims");
-    expect(status).toBe(0);
-    expect(stderr).toMatch(/--link-node-shims is deprecated; use --link node:fs/);
+  it("the removed --link-node-shims flag is rejected as unknown", () => {
+    const { status } = runCli("--link-node-shims");
+    // The CLI's unknown-flag handler exits non-zero; the alias no longer exists.
+    expect(status).not.toBe(0);
   });
 
-  it("--link node:fs compiles with NO deprecation note", () => {
+  it("--link node:fs compiles cleanly (no deprecation note)", () => {
     const { stderr, status } = runCli("--link node:fs");
     expect(status).toBe(0);
     expect(stderr).not.toMatch(/deprecated/);

--- a/tests/wasi-stdin.test.ts
+++ b/tests/wasi-stdin.test.ts
@@ -4,9 +4,9 @@ import { buildWasiPolyfill } from "../src/runtime.js";
 
 // #2633 — synchronous stdin is `node:fs` `readSync(0, …)` (the hallucinated
 // `process.stdin.read` surface was removed). `readSync`/`writeSync` are
-// supported under `--link-node-shims`; the shim owns the WASI fd_read/fd_write.
+// supported under `--link node:fs`; the shim owns the WASI fd_read/fd_write.
 describe("WASI stdin via fd_read (#1653/#2633)", () => {
-  it("imports node:fs readSync when readSync(0, …) is used (--link-node-shims)", async () => {
+  it("imports node:fs readSync when readSync(0, …) is used (--link node:fs)", async () => {
     const result = await compile(
       `
       import { readSync, writeSync } from "node:fs";
@@ -16,7 +16,7 @@ describe("WASI stdin via fd_read (#1653/#2633)", () => {
         writeSync(1, buf);
       }
       `,
-      { target: "wasi", linkNodeShims: true },
+      { target: "wasi", link: ["node:fs"] },
     );
     expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
     // The user module imports the node:fs interface; the shim owns fd_read.

--- a/tests/wasi.test.ts
+++ b/tests/wasi.test.ts
@@ -246,7 +246,7 @@ describe("WASI: fd_read — stdin polyfill", () => {
           writeSync(1, buf);
         }
       `,
-      { target: "wasi", linkNodeShims: true },
+      { target: "wasi", link: ["node:fs"] },
     );
     expect(used.success, used.errors.map((e) => e.message).join("\n")).toBe(true);
     expect(used.wat).toContain('(import "node:fs" "readSync"');


### PR DESCRIPTION
Fast follow-up to #2256 (which merged the S1–S3 `--link <namespace>` flag). Per stakeholder decision, **drop the `--link-node-shims` alias entirely — no deprecation**. `--link node:fs` (CLI) / `link: ["node:fs"]` (programmatic) is the only spelling.

## Removed (input-side)
- `--link-node-shims` CLI flag (`src/cli.ts`) — now errors as an unknown option.
- `linkNodeShims?: boolean` input on `CompileOptions` (`src/index.ts`) and `CodegenOptions` (`src/codegen/context/types.ts`), plus its fold in `buildCodegenOptions` (`src/compiler.ts`) — which now just dedupes `options.link`.

## Kept (internal, zero-churn)
- `ctx.linkedNamespaces` (source of truth) + the derived `ctx.linkNodeShims` convenience boolean (`linkedNamespaces.has("node:fs")`) for the ~30 codegen read-sites. No longer a user-facing option — just an internal getter.

## Migrated ALL in-repo callers
- `linkNodeShims: true` → `link: ["node:fs"]` across `tests/` (1530, 1751, 1753, 1767, 1768, 1772-*, 1886*, 2521, 2526, 2631, 2633, 2634, 2639, 2647, 2655, wasi, wasi-stdin) and `tests/issue-2783.test.ts` (alias/deprecation cases dropped; added "removed flag is rejected by CLI").
- `--link-node-shims` → `--link node:fs` in `examples/native-messaging/*` (smoke-test.sh, nm_node_fs.ts, edge.js, README.md, NODE-FS-SHIM.md), `scripts/build-node-fs-shim.mjs`, `docs/architecture/node-fs-abi.md`, and stale `src/codegen` comments.

## Validation
- **`examples/native-messaging/smoke-test.sh` (now `--link node:fs`) PASSES under real wasmtime 44.0.0** — byte-exact Native Messaging round-trip (the real-link gate).
- `tsc --noEmit` clean (proves no caller still passes the removed option); `biome lint` + `prettier` clean.
- Byte-neutral: `--link node:fs` output unchanged from the old `linkNodeShims: true`.
- grep clean: no input-side `--link-node-shims` / `linkNodeShims:` anywhere in src/tests/examples/scripts/docs (historical `plan/` records preserved).
- Heavy NM runtime tests (#1530/#1753/#1767/#2526/#1768/#1886) fail identically on clean `origin/main` in this container (large-memory/wasmtime env) — pre-existing, NOT a regression from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)