### PR TITLE
docs: #2787 triage differential-corpus divergences → root-cause clusters + plan

### DIFF
--- a/plan/issues/2787-differential-test-corpus-failures.md
+++ b/plan/issues/2787-differential-test-corpus-failures.md
@@ -104,10 +104,98 @@ The binary validates but throws during instantiation/execution:
 ## Notes
 
 - Relation to **#2143**: that issue added the `WebAssembly.validate` lane to
-  the default pipeline so malformed_wasm is _caught_; this issue is about
+  the default pipeline so malformed*wasm is \_caught*; this issue is about
   _fixing_ the programs it surfaces.
 - Relation to **#1941**: the optimize lane / corpus work.
 - Relation to **loopdive/js2#389**: the external reporter's `--target wasi`
   output is **valid WasmGC** (verified — the `-0x9` `wasm-validate` error is
   an old-wabt limitation, not a js2wasm bug); that is unrelated to these
   diff-test codegen failures, which are on the default WasmGC + JS-host path.
+
+---
+
+## Triage (2026-06-28) — full A/B/C classification + fix plan
+
+Re-ran `scripts/diff-test.ts` against current main. **Current set: 84 match /
+14 mismatch / 6 runtime_error / 0 malformed_wasm** (the 2 malformed cases —
+`array/01-basic.js`, `closures/10-mutual.js` — were fixed by #2259/#2788;
+`closures/10-mutual` now validates and is a `mismatch` instead).
+
+### (B) Harness quirk found + fixed inline — ANSI colour pollution
+
+The diff-test reference lane spawned `node <file>` **inheriting the
+environment**, and this dev container exports `FORCE_COLOR=3`, so Node
+colourises `console.log` output (`\x1b[33m42\x1b[39m`) even when stdout is
+piped. `normalize()` did not strip ANSI, so the V8 reference mismatched the
+plain js2wasm lane on **virtually every numeric/string program — 69 spurious
+mismatches locally** (CI doesn't set FORCE_COLOR, so it saw the true 14). This
+is a **harness-robustness bug, not a compiler bug**. Fixed in this PR:
+`runV8` now spawns with `FORCE_COLOR=0 NO_COLOR=1`, and `normalize()` strips
+ANSI SGR codes as belt-and-suspenders. After the fix the local run matches CI
+(84/14/6) regardless of the ambient colour env.
+
+### (A) Real js2wasm bugs — 20 programs, grouped into clusters
+
+All 20 remaining failures are genuine compiler gaps. Notably, **most map to
+feature issues already marked `done`** — yet they fail in the idiomatic-untyped
+default host path the corpus exercises (object literals as dynamic bags,
+untyped arrows). This is exactly the value differential testing (#1203) adds
+over test262: the "done" features were validated on narrower/typed shapes.
+**PO action: confirm regression vs current main and reopen the cited `done`
+issues where warranted.**
+
+| #   | program                    | kind          | root cause                                                                        | A/B/C | cluster / target issue                                         |
+| --- | -------------------------- | ------------- | --------------------------------------------------------------------------------- | ----- | -------------------------------------------------------------- |
+| 1   | classes/10-toString-impl   | mismatch      | `""+obj` / `${obj}` ignore user `toString()` → `[object Object]`                  | A     | **NEW #2795** (value→string rendering)                         |
+| 2   | builtins/04-symbol         | mismatch      | `Symbol.prototype.toString()` → `[object Object]`                                 | A     | **NEW #2795**                                                  |
+| 3   | closures/10-mutual         | mismatch      | boolean renders as `1` not `true` at console.log boundary                         | A     | **NEW #2795**                                                  |
+| 4   | control/12-for-in-object   | mismatch      | `for..in` over object yields no keys                                              | A     | **NEW #2796** (dyn-object enum/copy); rel #1243/#1271 (done)   |
+| 5   | object/02-spread           | mismatch      | `{...a}` wrong key order + values read back NaN                                   | A     | **NEW #2796**                                                  |
+| 6   | object/12-assign           | mismatch      | `Object.assign` copies no own keys (identity ok)                                  | A     | **NEW #2796**; rel #1336/#1630 (done)                          |
+| 7   | closures/07-arrow-this     | mismatch      | arrow lexical `this` via `.call({})` → NaN                                        | A     | **NEW #2797** (untyped arrow/closure dispatch); rel #11 (done) |
+| 8   | closures/09-callback       | mismatch      | arrow through untyped fn param drops return value → empty                         | A     | **NEW #2797**                                                  |
+| 9   | closures/08-method-chain   | runtime_error | dynamic method dispatch on returned object literal traps (WebAssembly.Exception)  | A     | **NEW #2797**; rel #1382 (done)                                |
+| 10  | builtins/07-promise-basic  | mismatch      | `Promise.resolve().then()` callback never runs (empty even after microtask drain) | A     | #1042 async/await (backlog); rel #1014                         |
+| 11  | builtins/08-promise-chain  | mismatch      | promise chain `.then` callbacks never run                                         | A     | #1042 (backlog)                                                |
+| 12  | builtins/09-async-await    | mismatch      | `await`/async no-op → empty output                                                | A     | #1042 (backlog)                                                |
+| 13  | builtins/01-json-stringify | mismatch      | `JSON.stringify(obj)` / `(array)` → `undefined` (primitives ok)                   | A     | #1324 JSON.stringify (done) — re-verify host path              |
+| 14  | array/11-flat-flatMap      | runtime_error | `arr.flat`/`flatMap` not a function                                               | A     | #1136 flat/flatMap (done) — re-verify host path                |
+| 15  | array/12-from-of           | mismatch      | `Array.from(arrayLike, mapFn)` 2-arg form missing (Array.of/from(string) ok)      | A     | #1160 Array.from (done) — re-verify                            |
+| 16  | builtins/03-map-set        | runtime_error | `new Set([...])` — source not iterable (Symbol.iterator)                          | A     | #1514 Set (done) / iterator protocol — re-verify               |
+| 17  | builtins/12-arraybuffer    | runtime_error | `DataView.setInt32` not a function                                                | A     | #1056 DataView setIntN (done) — re-verify                      |
+| 18  | builtins/14-spread-args    | runtime_error | `f(...arr)` / `Math.max(...arr)` → illegal cast                                   | A     | #1519 spread (done) — re-verify call-arg spread                |
+| 19  | builtins/15-tag-template   | runtime_error | tagged template — `strs.join` not a function (strings array lacks proto methods)  | A     | #109 tagged templates (done) — re-verify                       |
+| 20  | object/06-delete           | mismatch      | `delete o.a` does not remove the property                                         | A     | #1112 delete-via-sentinel (done) / #124 (wont-fix) — re-verify |
+
+### (C) Known-deferred — none
+
+No `eval`/`Proxy`/`with`/Temporal/SharedArrayBuffer programs in the failing set,
+so there is nothing to corpus-exclude as intentionally-unsupported.
+
+### Prioritized fix plan (cheap + high-value first)
+
+1. **#2795 — value→string rendering (toString/@@toPrimitive + boolean)** —
+   `current`, **P1**, ~M. Highest value/cost ratio: one coercion site, 3 corpus
+   programs, broad test262 ToString/ToPrimitive overlap. Do first.
+2. **#2796 — dynamic-object own-key enumerate/copy (for-in, spread, assign)** —
+   `current`, **P1**, ~M. Core ES2015 idioms; likely one shared property-bag
+   iterate+read primitive flips all 3.
+3. **Re-verify the "done"-but-failing builtins** (#1324 JSON.stringify-object,
+   #1136 flat/flatMap, #1160 Array.from(arrayLike,mapFn), #1056 DataView.setInt32,
+   #109 tagged-template `.join`, #1514 Map/Set-from-iterable, #1519 call-arg
+   spread, #1112 delete). These are **single-feature regressions/host-gaps** — PO
+   should reopen each (or file a focused follow-up) rather than re-file from
+   scratch; many are likely small "method not registered on host prototype" or
+   "host-mode path not wired" fixes. Cost: low-to-medium each; high cumulative
+   value (8 programs).
+4. **#1042 — async/await + Promise.then** — `backlog`, larger. Promise callbacks
+   never run (confirmed empty even after a 50ms + microtask drain, so NOT a
+   harness drain bug). State-machine lowering; defer behind the cheap wins.
+5. **#2797 — untyped arrow/closure + dynamic method dispatch** — `Backlog`,
+   **feasibility: hard**. Touches the `any`-receiver / funcref substrate; may
+   need an architect spec. Lowest priority of the new clusters.
+
+Cost summary: #2795 + #2796 (the two `current` clusters) are the cheap,
+high-value front — both ~M, both likely a single shared primitive each. The
+"done-but-failing" re-verifications are a PO reopening sweep. #1042 and #2797
+are the genuinely larger items, correctly deferred to backlog.

--- a/plan/issues/2795-diff-host-value-to-string-rendering.md
+++ b/plan/issues/2795-diff-host-value-to-string-rendering.md
@@ -1,0 +1,112 @@
+---
+id: 2795
+title: "diff-test host path: value→string rendering — object toString/@@toPrimitive ignored + boolean prints as 1/0"
+status: ready
+sprint: current
+created: 2026-06-28
+updated: 2026-06-28
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: bug
+area: codegen
+language_feature: type-coercion
+goal: trustworthiness
+related: [2787, 1917]
+origin: "2026-06-28 — #2787 differential-corpus triage (cluster A1)"
+---
+
+# #2795 — Host-path value→string rendering: object toString/@@toPrimitive ignored; boolean → 1/0
+
+## Problem (cluster from #2787 diff-test triage)
+
+In the default WasmGC + JS-host `compile()` path, several idiomatic programs
+render values to strings incorrectly. Common theme: when a value is coerced to
+a string (explicit `String(x)` / `"" + x` / template `${x}`) or handed to the
+host `console.log`, the **dynamic value-rendering path drops type fidelity**.
+
+Three corpus programs, each a distinct sub-root-cause under the same theme:
+
+### A — object → string coercion ignores user-defined `toString()`
+
+`tests/differential/corpus/classes/10-toString-impl.js`
+
+```js
+class Money {
+  constructor(n) {
+    this.n = n;
+  }
+  toString() {
+    return "$" + this.n;
+  }
+}
+console.log("" + new Money(42)); // V8: $42   js2wasm: [object Object]
+console.log(`val=${new Money(7)}`); // V8: val=$7 js2wasm: val=$7 (the literal part) but ${} → [object Object]
+```
+
+`ToString(object)` must run `ToPrimitive(obj, "string")` → call `obj.toString()`
+(or `@@toPrimitive` / `valueOf`). The host path emits the default
+`[object Object]` instead of dispatching to the instance method. (See coercion
+engine #1917 — `emitToPrimitive`; this is the non-`$Object` / nominal-class arm.)
+
+### B — `Symbol.prototype.toString()` returns `[object Object]`
+
+`tests/differential/corpus/builtins/04-symbol.js`
+
+```js
+const s = Symbol("desc");
+console.log(typeof s); // V8: symbol      js2wasm: symbol   ✓
+console.log(s.toString()); // V8: Symbol(desc) js2wasm: [object Object]  ✗
+console.log(s.description); // V8: desc         js2wasm: desc     ✓
+```
+
+`typeof` and `.description` work, but `Symbol.prototype.toString` is not wired —
+falls through to the generic object toString.
+
+### C — boolean value renders as `1` / `0`
+
+`tests/differential/corpus/closures/10-mutual.js`
+
+```js
+function isEven(n) {
+  return n === 0 ? true : isOdd(n - 1);
+}
+function isOdd(n) {
+  return n === 0 ? false : isEven(n - 1);
+}
+console.log(isEven(10)); // V8: true  js2wasm: 1   ✗
+console.log(isOdd(7)); // V8: true  js2wasm: 1   ✗
+```
+
+The boolean result reaches `console.log` as an i32/number and renders `1`
+instead of `true`. Booleans lose their boolean tag when boxed to `any`/externref
+for the host `console.log` import, so `ToString(boolean)` never fires.
+
+## Repro
+
+```bash
+FORCE_COLOR=0 npx tsx scripts/diff-test.ts   # see classes/10, builtins/04, closures/10 mismatch
+```
+
+## Root cause (hypothesis)
+
+The string-coercion / value-boxing path used when emitting `console.log` args
+and `"" + obj` / `${obj}` does not consult the value's runtime type tag to pick
+the correct `ToString` behaviour: nominal-class instances skip the `toString()`
+dispatch, `Symbol` lacks a `toString` wiring, and booleans are boxed as numbers.
+Likely a single coercion site (`type-coercion.ts` / `expressions.ts` string
+coercion + the `console.log` arg-boxing helper) with three missing arms.
+
+## Acceptance criteria
+
+- `classes/10-toString-impl.js`, `builtins/04-symbol.js`, `closures/10-mutual.js`
+  all match V8 in `scripts/diff-test.ts`.
+- `String(true) === "true"`, `String(new ClassWithToString()) === <toString>`,
+  `Symbol("d").toString() === "Symbol(d)"` in the host path.
+
+## Notes
+
+- Cheap + high-value: fundamental coercion correctness, 3 corpus programs, and
+  likely overlaps many test262 ToString/ToPrimitive cases. Related coercion
+  work: #1917. Possible regression of whatever wired class `toString` for
+  test262 — verify against current main.

--- a/plan/issues/2796-diff-host-dynamic-object-enumerate-copy.md
+++ b/plan/issues/2796-diff-host-dynamic-object-enumerate-copy.md
@@ -1,0 +1,103 @@
+---
+id: 2796
+title: "diff-test host path: dynamic-object own-key enumerate/copy — for-in empty, spread loses values, Object.assign loses keys"
+status: ready
+sprint: current
+created: 2026-06-28
+updated: 2026-06-28
+priority: high
+feasibility: medium
+reasoning_effort: medium
+task_type: bug
+area: codegen
+language_feature: objects
+goal: trustworthiness
+related: [2787, 1243, 1271, 1336, 1630]
+origin: "2026-06-28 — #2787 differential-corpus triage (cluster A2)"
+---
+
+# #2796 — Host-path dynamic-object own-key enumeration & copy
+
+## Problem (cluster from #2787 diff-test triage)
+
+Three idiomatic object programs fail in the default WasmGC + JS-host path. All
+three depend on **enumerating + reading the own enumerable string keys of a
+dynamically-built object literal**, and that path drops keys and/or values.
+
+### A — `for...in` over an object yields nothing
+
+`tests/differential/corpus/control/12-for-in-object.js`
+
+```js
+const o = { a: 1, b: 2 };
+const keys = [];
+for (const k in o) keys.push(k);
+console.log(keys.sort().join(",")); // V8: a,b   js2wasm: "" (empty)
+```
+
+Existing issue #1243/#1271 (for-in / Object.keys enumeration) are marked `done`
+but this corpus case **regresses or is uncovered** in the host path.
+
+### B — object spread `{ ...a }` wrong key order + values become NaN
+
+`tests/differential/corpus/object/02-spread.js`
+
+```js
+const a = { x: 1, y: 2 };
+const b = { ...a, z: 3 };
+console.log(Object.keys(b).join(",")); // V8: x,y,z   js2wasm: z,x,y  (wrong order)
+console.log(b.x); // V8: 1       js2wasm: NaN    (value dropped)
+console.log(b.z); // V8: 3       js2wasm: NaN
+```
+
+`Object.keys(b)` returns the keys (so spread does populate the bag), but in the
+**wrong insertion order** and with the **copied values lost** (read back as NaN).
+
+### C — `Object.assign` copies no keys
+
+`tests/differential/corpus/object/12-assign.js`
+
+```js
+const t = { a: 1 };
+const r = Object.assign(t, { b: 2 }, { c: 3 });
+console.log(Object.keys(r).join(",")); // V8: a,b,c   js2wasm: "" (empty)
+console.log(r === t); // V8: true    js2wasm: true ✓
+```
+
+Identity is preserved (`r === t`) but no own enumerable keys are copied from the
+sources. Existing issue #1336/#1630 (Object.assign getters/Symbol keys) `done`
+but the basic data-property copy **regresses or is uncovered** here.
+
+## Repro
+
+```bash
+FORCE_COLOR=0 npx tsx scripts/diff-test.ts   # control/12, object/02, object/12 mismatch
+```
+
+## Root cause (hypothesis)
+
+A shared "iterate own enumerable string keys of a dynamic object + read each
+value" primitive is incomplete in the host path:
+
+- enumeration order is not insertion order (spread reorders),
+- value read-back returns NaN (the boxed value is not recovered),
+- the for-in / Object.assign source-enumeration walks zero keys.
+
+Likely centred on the dynamic-object (`$Object` / property-bag) representation
+and its key-iteration + value-get helpers. Fixing the shared primitive should
+flip all three together.
+
+## Acceptance criteria
+
+- `control/12-for-in-object.js`, `object/02-spread.js`, `object/12-assign.js`
+  all match V8 in `scripts/diff-test.ts`.
+- Own enumerable string keys enumerate in insertion order; spread/assign copy
+  both keys **and** values.
+
+## Notes
+
+- High-value: object spread / assign / for-in are core ES2015+ idioms; this
+  cluster also likely covers many test262 object cases. The "done" status of
+  #1243/#1271/#1336/#1630 vs the corpus failure suggests these were validated on
+  a narrower path (typed objects / specific test262 shapes) than the idiomatic
+  untyped object literals the corpus uses — confirm regression vs current main.

--- a/plan/issues/2797-diff-host-untyped-arrow-closure-dispatch.md
+++ b/plan/issues/2797-diff-host-untyped-arrow-closure-dispatch.md
@@ -1,0 +1,117 @@
+---
+id: 2797
+title: "diff-test host path: untyped arrow/closure value & dynamic method dispatch — arrow-this NaN, callback drops result, method-chain traps"
+status: ready
+sprint: Backlog
+created: 2026-06-28
+updated: 2026-06-28
+priority: medium
+feasibility: hard
+reasoning_effort: high
+task_type: bug
+area: codegen
+language_feature: closures
+goal: trustworthiness
+related: [2787, 11, 1382]
+origin: "2026-06-28 — #2787 differential-corpus triage (cluster A3)"
+---
+
+# #2797 — Host-path untyped arrow/closure + dynamic method dispatch
+
+## Problem (cluster from #2787 diff-test triage)
+
+Three `closures/*` corpus programs fail. All use **untyped JS** (no type
+annotations), so the compiler cannot statically resolve the callee/`this` and
+must use the dynamic `any` dispatch path — which produces wrong values or traps.
+
+### A — arrow function captured `this` → NaN
+
+`tests/differential/corpus/closures/07-arrow-this.js`
+
+```js
+function f() {
+  this.x = 10;
+  const g = () => this.x; // arrow: lexical this
+  return g();
+}
+console.log(f.call({})); // V8: 10   js2wasm: NaN
+```
+
+The arrow should capture the enclosing function's `this` lexically. Via `.call({})`
+the dynamic `this.x` read returns NaN instead of 10.
+
+### B — arrow passed as a callback param drops its return value
+
+`tests/differential/corpus/closures/09-callback.js`
+
+```js
+function apply(arr, fn) {
+  const out = [];
+  for (let i = 0; i < arr.length; i++) out.push(fn(arr[i], i));
+  return out;
+}
+console.log(apply([1, 2, 3], (x) => x * x).join(",")); // V8: 1,4,9  js2wasm: ,, (empty)
+```
+
+The arrow `(x) => x*x` called through the untyped `fn` parameter yields
+undefined/empty for every element — the call-through-funcref returns nothing.
+
+### C — method chain on a returned object literal traps
+
+`tests/differential/corpus/closures/08-method-chain.js`
+
+```js
+function chain(start) {
+  let n = start;
+  const api = {
+    add(x) {
+      n += x;
+      return api;
+    },
+    sub(x) {
+      n -= x;
+      return api;
+    },
+    val() {
+      return n;
+    },
+  };
+  return api;
+}
+console.log(chain(10).add(5).sub(2).val()); // V8: 13   js2wasm: runtime: [object WebAssembly.Exception]
+```
+
+Dynamic method dispatch on the returned object-literal `api` (with closure
+captures over `n`) traps at runtime.
+
+## Repro
+
+```bash
+FORCE_COLOR=0 npx tsx scripts/diff-test.ts   # closures/07, 08, 09 (07/09 mismatch, 08 runtime_error)
+```
+
+## Root cause (hypothesis)
+
+The untyped/dynamic dispatch path mishandles:
+
+- arrow `this` capture when the enclosing function is invoked via `.call`,
+- calling an arrow through an untyped function-typed parameter (funcref call
+  returns the wrong/empty value),
+- method dispatch + closure-capture on an object literal returned from a
+  closure (illegal-cast / WasmGC trap).
+
+These may share one root cause (the `any`-receiver / funcref dynamic-call
+substrate) or be three adjacent bugs. Existing #11 (arrow callbacks) and #1382
+(wasm-closure not JS-callable bridge) are related and `done`; the corpus shows
+the untyped idiomatic forms still break — confirm regression vs current main.
+
+## Acceptance criteria
+
+- `closures/07-arrow-this.js`, `closures/09-callback.js`,
+  `closures/08-method-chain.js` all match V8 in `scripts/diff-test.ts`.
+
+## Notes
+
+- Harder (feasibility: hard) — touches the dynamic `any`-receiver / funcref
+  dispatch substrate. Lower priority than #2795/#2796 (which are more localized
+  coercion/enumeration fixes). May warrant an architect spec before dev work.

--- a/scripts/diff-test.ts
+++ b/scripts/diff-test.ts
@@ -84,9 +84,22 @@ interface Summary {
   results: FileResult[];
 }
 
-/** Normalize stdout for comparison. Strips trailing whitespace per line. */
+// #2787 — strip ANSI SGR escape sequences (e.g. `\x1b[33m…\x1b[39m`) before
+// comparing. Node's `console.log` colourises primitives (numbers yellow, etc.)
+// when `FORCE_COLOR` is set in the environment — which it is in some dev
+// containers (this repo's devcontainer exports `FORCE_COLOR=3`). The js2wasm
+// lane buffers plain strings and never colourises, so an un-stripped reference
+// spuriously mismatches on virtually every numeric/string program (69 false
+// mismatches locally vs 14 real ones in CI, where FORCE_COLOR is unset). The
+// reference lane (`runV8`) also forces colour OFF in its env; this strip is
+// belt-and-suspenders so the harness is robust regardless of the ambient env.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escapes are control characters by definition.
+const ANSI_SGR = /\x1b\[[0-9;]*m/g;
+
+/** Normalize stdout for comparison. Strips ANSI colour codes + trailing whitespace per line. */
 function normalize(s: string): string {
   return s
+    .replace(ANSI_SGR, "")
     .split("\n")
     .map((line) => line.replace(/\s+$/, ""))
     .join("\n")
@@ -122,6 +135,13 @@ function runV8(file: string): { stdout: string; error?: string; ms: number } {
       encoding: "utf-8",
       timeout: 5000,
       stdio: ["ignore", "pipe", "pipe"],
+      // #2787 — force colour OFF for the reference lane so `console.log` never
+      // emits ANSI SGR codes (the dev container sets FORCE_COLOR=3, which makes
+      // Node colourise even when stdout is piped). `FORCE_COLOR=0` overrides the
+      // ambient value; `NO_COLOR` is a secondary guard. Without this the
+      // reference output is polluted with `\x1b[33m…\x1b[39m` and mismatches the
+      // plain js2wasm lane on nearly every numeric/string program.
+      env: { ...process.env, FORCE_COLOR: "0", NO_COLOR: "1" },
     });
     return { stdout, ms: Date.now() - t0 };
   } catch (e: unknown) {


### PR DESCRIPTION
## Summary

Triage of the **#2787** differential-test corpus divergences — categorize,
root-cause, and prioritize the failing programs (no blind-fixing). Investigation
+ planning, plus one clear harness-robustness fix.

Re-ran `scripts/diff-test.ts` on current main: **84 match / 14 mismatch /
6 runtime_error / 0 malformed_wasm** (the 2 malformed cases were already fixed by
#2259/#2788). Full A/B/C breakdown + a per-program triage table + a prioritized
fix plan are written into `plan/issues/2787-*.md`.

## (B) Harness quirk found + fixed inline

The diff-test **reference lane** spawned `node <file>` inheriting the environment,
and this dev container exports `FORCE_COLOR=3` — so Node colourised `console.log`
output with ANSI SGR codes (`\x1b[33m42\x1b[39m`) even when stdout is piped.
`normalize()` did not strip ANSI, so the V8 reference spuriously mismatched the
plain js2wasm lane on **~69 numeric/string programs locally** (CI doesn't set
FORCE_COLOR, so it correctly saw only the 14 real mismatches). Fixed:
`runV8` now spawns with `FORCE_COLOR=0 NO_COLOR=1` and `normalize()` strips ANSI
SGR codes (belt-and-suspenders). Local run now matches CI (84/14/6) regardless of
the ambient colour env. **No-op in CI** (FORCE_COLOR is unset there).

## (A) Real bugs → 3 new focused cluster issues

All 20 remaining failures are genuine compiler gaps. Most map to feature issues
already marked `done` yet failing in the idiomatic-untyped **default host path**
the corpus exercises — exactly the value differential testing (#1203) adds over
test262. Grouped into 3 new clusters; the rest map to existing issues (flagged
for PO reopening in the triage table):

- **#2795** value→string rendering: object `toString()`/`@@toPrimitive` ignored
  + boolean prints as `1`/`0` (classes/10, builtins/04, closures/10) — `current`, P1
- **#2796** dynamic-object own-key enumerate/copy: for-in empty, spread loses
  values + reorders keys, Object.assign loses keys (control/12, object/02,
  object/12) — `current`, P1
- **#2797** untyped arrow/closure + dynamic method dispatch: arrow-this NaN,
  callback drops result, method-chain traps (closures/07, 08, 09) — `backlog`, hard

## (C) Known-deferred — none

No eval/Proxy/with/Temporal in the failing set, so nothing to corpus-exclude.

## Prioritized fix plan

1. #2795 (cheapest, broadest test262 overlap) → 2. #2796 (core ES2015 idioms) →
3. PO reopening sweep of the 8 "done"-but-failing single-feature builtins
(JSON.stringify-object, flat/flatMap, Array.from(arrayLike,mapFn),
DataView.setInt32, tagged-template join, Map/Set-from-iterable, call-arg spread,
delete) → 4. #1042 async/await (Promise.then callbacks never run — confirmed not
a harness drain bug) → 5. #2797 (substrate-level, hardest).

Triage-only + harness fix — **no compiler-codegen change**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)