### PR TITLE
docs(#2793): design recommendation — structural-narrowing fix is substrate work, not a localized patch

### DIFF
--- a/plan/issues/2793-structural-narrowing-struct-copy-breaks-mutation.md
+++ b/plan/issues/2793-structural-narrowing-struct-copy-breaks-mutation.md
@@ -253,3 +253,66 @@ substrate change, and it must also fix Gap A/Gap B first.
 Net: the `#2791` lock cannot be fully flipped (all 4) without Phase 3; the
 high-value, idiomatic interface cases flip after Phase 1+2. None of the three is
 a single safe senior-dev patch — they are sequenced substrate PRs.
+
+### Captured repros (cold-start — tracked here, not yet split into own issues)
+
+The investigation repros are inlined below so the next-window owner can reproduce
+from this file alone (the `.tmp/*.mjs` probes are gitignored). Compile each with
+`compile(src, { standalone })` and run `exports.test()`; all four **sibling
+miscompiles** are silently wrong on `origin/main` TODAY (same root cause as the
+headline `#2793` case — the structural-narrowing copy), host AND standalone:
+
+```ts
+// (1) return-the-param identity — main: 1   correct: 42
+interface I { v: number; }
+class A implements I { v: number; constructor(){this.v=1;} }
+function id(o: I): I { return o; }
+export function test(): number { const a=new A(); const r=id(a); r.v=42; return a.v; }
+
+// (2) interface-typed field, mutate via alias — main: 1   correct: 99
+interface I { v: number; }
+class A implements I { v: number; constructor(){this.v=1;} }
+class Box { h: I; constructor(h: I){ this.h=h; } }
+function bump(b: Box){ b.h.v = 99; }
+export function test(): number { const a=new A(); const b=new Box(a); bump(b); return a.v; }
+
+// (3) array-of-interface element mutation — main: 1   correct: 5
+interface I { v: number; }
+class A implements I { v: number; constructor(){this.v=1;} }
+function bump(arr: I[]){ arr[0].v = 5; }
+export function test(): number { const a=new A(); const arr:I[]=[a]; bump(arr); return a.v; }
+
+// (4) second-alias visibility — main: 1   correct: 77
+interface I { v: number; }
+class A implements I { v: number; constructor(){this.v=1;} }
+function setV(o: I, x: number){ o.v = x; }
+export function test(): number { const a=new A(); const b=a; setV(a,77); return b.v; }
+```
+
+The two probe-exposed regressions to watch (currently GREEN on `origin/main` —
+the narrow-copy masks them; the fix MUST keep them green):
+
+```ts
+// Gap A — anon-literal field order. main: 1020908 (correct). Interface→externref
+// probe regressed it to 1020809 because the copy currently reorders fields by
+// name; without it, `{ y:8, x:9 }` flows as a source-order anon struct and a
+// by-name dynamic read of `o.x` returns the wrong slot. FIX: store anon literals
+// in canonical (deduped) field order.
+interface I { x: number; y: number; }
+function sum(o: I): number { return o.x*100 + o.y; }
+export function test(): number { const a:I={x:1,y:2}; const b:I={y:8,x:9}; return sum(a)*10000+sum(b); }
+
+// Gap B — shape-dependent interface resolution. main: 4 (correct). With a SINGLE
+// implementer, getTypeAtLocation(param o:I) does not resolve through the interface
+// symbol, so a probe keyed off the resolved type left the param a monomorphic
+// `ref $I` while the call site still narrow-copies → illegal-cast trap. FIX: key
+// the widening off the param's DECLARED type node, not the checker's resolved type.
+interface I { v: number; }
+class A implements I { a: number; v: number; constructor(){this.a=3;this.v=4;} }
+function getV(o: I): number { return o.v; }
+export function test(): number { return getV(new A()); }
+```
+
+These six + the headline `#2793` param-mutation case are all tracked under THIS
+issue (no separate issue files filed). The architect/substrate owner may split
+Phase 3 (class-structural) into its own issue when scoping the next window.

--- a/plan/issues/2793-structural-narrowing-struct-copy-breaks-mutation.md
+++ b/plan/issues/2793-structural-narrowing-struct-copy-breaks-mutation.md
@@ -1,7 +1,8 @@
 ---
 id: 2793
 title: "[ARCH][SUBSTRATE] Structural-narrowing struct COPY at call boundary breaks reference semantics (mutation through interface/structural-class param lost)"
-status: ready
+status: blocked
+blocked_reason: "Senior-dev investigation (2026-06-28): no safe localized patch — needs phased substrate work (Gap A anon-literal field order → interfaces-as-externref everywhere → class-structural sibling detection). Routed to architect lane. See '## Senior-dev investigation & design recommendation'."
 sprint: current
 created: 2026-06-28
 updated: 2026-06-28
@@ -163,3 +164,92 @@ narrowed struct copy**:
   (must still value-copy where identity is not observed).
 - Broad-impact → full `merge_group` test262 + standalone-floor authoritative; do
   NOT scoped-sweep.
+
+## Senior-dev investigation & design recommendation (2026-06-28)
+
+**Verdict: confirmed root cause; NO safe localized patch exists — this is a
+substrate change (the issue's `[ARCH][SUBSTRATE]` tag is correct). Routing to the
+architect / substrate lane (#2773) with a validated fix direction + the exact
+gaps that must close.** Investigation done off `origin/main` ed1ef8e.
+
+### The hard constraint (why the call-site alone can't fix it)
+
+The copy lives in `type-coercion.ts coerceType` → `emitSafeStructConversion`
+Case 3 → `emitStructNarrowBody` (~L971), reached when coercing `ref $From →
+ref $To` for two **unrelated** Wasm struct types (`$To`'s fields ⊆ `$From`'s by
+name, `$From` not a declared Wasm subtype of `$To`). The Wasm verifier will not
+accept a `ref $From` where `ref $To` is declared, so the *only* way to SHARE the
+caller's object (not copy) is to **widen the parameter's Wasm type to a common
+supertype** (externref/anyref) — there is no call-site-only fix. Confirmed: the
+param Wasm type is the binding constraint.
+
+### Probe: interface → externref + dynamic dispatch WORKS, but exposes 2 latent gaps
+
+I prototyped the issue's "Preferred" direction (route a plain `interface` value
+type through externref + the existing union/`any` dynamic multi-struct dispatch,
+by returning externref from `resolveWasmType` for interface types and `undefined`
+from `resolveStructName` for them). Measured host **and** standalone:
+
+| Case (host+standalone)                         | main (baseline) | probe         |
+|------------------------------------------------|-----------------|---------------|
+| `#2793` interface mutation-through-param        | FAIL (lost)     | **FIXED**     |
+| return-the-param then mutate (identity)         | FAIL (=1)       | **FIXED (42)**|
+| interface-typed field, mutate via alias         | FAIL (=1)       | **FIXED (99)**|
+| array-of-interface element mutation             | FAIL (=1)       | **FIXED (5)** |
+| second-alias visibility                         | FAIL (=1)       | **FIXED (77)**|
+| reordered-anon read thru interface (#2791 lock) | OK (1020908)    | **REGRESS (1020809)** |
+| non-mutated single-implementer interface read   | OK (4)          | **REGRESS (trap "illegal cast")** |
+
+Takeaways: (1) the direction is **correct** — it fixes `#2793` AND **four more
+currently-silent interface-reference-semantics miscompiles** that share the same
+root cause (so `#2793` is the tip of an iceberg). (2) Naive widening **regresses
+two currently-green reads**, and the WAT shows the regressions are NOT in the new
+path — they are **latent bugs the narrow-copy was masking**:
+
+- **Gap A — anon-literal field order (the copy is load-bearing).** `const b: I =
+  { y: 8, x: 9 }` builds an anon struct in *source* order `[y,x]`, but the
+  structurally-deduped canonical struct order is `[x,y]`; today the narrow-copy
+  into `$I` **reorders by name** and masks this. Remove the copy and the value
+  flows as its own anon struct → a by-name dynamic read of `o.x` returns the
+  wrong slot (got 8, want 9). The literal builder must store in canonical field
+  order independent of the copy.
+- **Gap B — shape-dependent interface resolution.** With a *single* implementer,
+  `getTypeAtLocation(param o: I)` does not resolve through the interface symbol,
+  so the param was NOT widened (WAT: `getV` param stayed `(ref null $I)` and did a
+  monomorphic `struct.get`), while the call site still narrow-copies → the
+  inconsistency surfaces as an illegal cast. Widening must key off the param's
+  **declared type node**, not the checker's (sometimes narrowed) resolved type.
+
+### Why a localized params-only patch is unsound (do NOT ship it)
+
+Widening only the *param* (leaving returns/locals/fields as `ref $I`) creates
+impedance mismatches: `function f(o:I):I{return o}` and `this.field = o`
+(field: `I`) then coerce externref → `ref $I` via a guarded cast that **nulls on
+a non-`$I` runtime value** — trading the mutation miscompile for a
+returns-`null`/store-`null` miscompile. Consistency requires interface types to
+be externref **everywhere** (param + return + local + field). That is the
+substrate change, and it must also fix Gap A/Gap B first.
+
+### Recommended plan (architect / substrate lane, coordinate with #2773)
+
+1. **Phase 1 (prereq, low-risk):** fix Gap A — make anon object-literal
+   construction store fields in the deduped canonical order regardless of source
+   order. Land + validate independently; it is a real latent bug today.
+2. **Phase 2 (interfaces):** make `resolveWasmType` map a plain user `interface`
+   to externref **consistently** (param/return/local/field), keyed off the
+   declared type (fixes Gap B), and force `resolveStructName`/`resolveStructNameForExpr`
+   to `undefined` for interface receivers so all reads/writes use the proven
+   externref dynamic dispatch (`__set_member_*` / multi-struct get). This flips
+   the **interface** half of the `#2791` lock (2 of 4 cases) and the 4 sibling
+   miscompiles above. Broad value-rep change → full `merge_group` + standalone
+   floor authoritative; watch interface-typed **struct fields** (layout/boxing).
+3. **Phase 3 (class-structural, separate + riskier):** the `class A{x}` /
+   `class B{x}` case needs whole-program structural-sibling detection to decide
+   which *class* params to widen (a class with no structural sibling MUST keep
+   its fast monomorphic `ref $A` path — perf). Recommend splitting this into its
+   own issue; it is rarer and orthogonal to the idiomatic interface case that
+   drives `npm-library-support` / dogfood.
+
+Net: the `#2791` lock cannot be fully flipped (all 4) without Phase 3; the
+high-value, idiomatic interface cases flip after Phase 1+2. None of the three is
+a single safe senior-dev patch — they are sequenced substrate PRs.


### PR DESCRIPTION
## What this is

A **STOP-and-report design recommendation** for #2793 (not a fix). Per the senior-dev escalation protocol: a safe, conservative *localized* patch is intractable; this records the root cause, a validated fix direction, and the exact gaps to close so the architect / substrate lane (#2773) can execute it.

## Findings (host + standalone, off origin/main ed1ef8e)

- **Hard constraint:** the copy is in `type-coercion.ts emitStructNarrowBody`; the Wasm verifier forbids passing `ref $From` where `ref $To` is declared, so SHARING the caller's object requires widening the **param's Wasm type** to externref/anyref. There is **no call-site-only fix**.
- **Direction validated:** a probe routing `interface` values through externref + the existing union/`any` dynamic dispatch **fixes #2793 plus four more currently-silent interface reference-semantics miscompiles**.
- **But naive widening regresses two currently-green reads** — because the narrow-copy is *load-bearing*: it reorders fields (masking a latent anon-literal field-order bug, **Gap A**) and interface type resolution is shape-dependent (**Gap B**). A **params-only** patch is unsound: it trades the lost-mutation miscompile for a returns-`null`/store-`null` miscompile.

## Recommended phased plan (see the issue file's full `## Senior-dev investigation & design recommendation`)

1. **Gap A** — anon object-literal stores fields in canonical (deduped) order. Real latent bug today; land independently.
2. **Interfaces** — `resolveWasmType`(interface) → externref *consistently* (param/return/local/field) keyed off the declared type (fixes Gap B); force dynamic dispatch for interface receivers. Flips the interface half of the #2791 lock + the 4 sibling miscompiles. Broad value-rep → full `merge_group` + standalone floor authoritative.
3. **Class-structural** (`class A{x}`/`class B{x}`) — needs whole-program structural-sibling detection to preserve the monomorphic fast path; **split into its own issue** (rarer, orthogonal).

Issue set to `status: blocked` and routed to the architect lane. The four data-backed repro programs live in `.tmp/` (gitignored) and are summarized in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS