### PR TITLE
chore: bump wasmtime v44.0.0 → v46.0.1 (devcontainer + NM smoke CI)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -71,11 +71,11 @@ RUN ARCH=$(dpkg --print-architecture) && \
 
 # wasmtime CLI — runs the warm-runtime perf benchmarks (#1580/#1746) that
 # refresh the committed landing-page benchmark JSON, and the native-messaging
-# smoke test. Pinned to v44 to match CI
+# smoke test. Pinned to v46 to match CI
 # (.github/workflows/native-messaging-smoke.yml); do NOT switch to
-# --all-proposals (v44 rejects stack-switching). Arch-aware: amd64->x86_64,
-# arm64->aarch64.
-ARG WASMTIME_VERSION=v44.0.0
+# --all-proposals (it enables stack-switching, which these modules don't use).
+# Arch-aware: amd64->x86_64, arm64->aarch64.
+ARG WASMTIME_VERSION=v46.0.1
 RUN ARCH=$(dpkg --print-architecture) && \
   case "$ARCH" in \
     amd64) WT_ARCH=x86_64 ;; \

--- a/.github/workflows/native-messaging-smoke.yml
+++ b/.github/workflows/native-messaging-smoke.yml
@@ -44,12 +44,12 @@ jobs:
 
       - name: Install wasmtime (pinned)
         run: |
-          # Pin a current release for reproducibility. v44 is what the example
+          # Pin a current release for reproducibility. v46 is what the example
           # was verified against; it supports the GC / function-references /
           # tail-call / exceptions proposals the module uses via the explicit
           # -W flags the smoke script enables. (Do NOT bump to all-proposals:
-          # wasmtime 44 rejects stack-switching, which all-proposals turns on.)
-          WASMTIME_VERSION=v44.0.0
+          # it turns on stack-switching, which these modules don't use.)
+          WASMTIME_VERSION=v46.0.1
           curl -L "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/wasmtime-${WASMTIME_VERSION}-x86_64-linux.tar.xz" \
             | tar xJ
           echo "$PWD/wasmtime-${WASMTIME_VERSION}-x86_64-linux" >> "$GITHUB_PATH"


### PR DESCRIPTION
Bumps the pinned wasmtime from v44.0.0 to the latest release **v46.0.1** (2026-06-24) in both the devcontainer Dockerfile and the native-messaging-smoke CI workflow (kept in lockstep). Verified v46.0.1 runs the native-messaging GC modules with the same explicit `-W gc,function-references,tail-call,exceptions` flags — byte-exact echo for the bun- and esbuild-stripped `nm_deno.js` under real wasmtime. Comments updated; the all-proposals/stack-switching caveat kept (version-agnostic).