### PR TITLE
fix(#2804): object spread & Object.assign copy keys + values (rep mismatch)

### DIFF
--- a/plan/issues/2804-host-object-spread-assign-value-copy.md
+++ b/plan/issues/2804-host-object-spread-assign-value-copy.md
@@ -1,10 +1,12 @@
 ---
 id: 2804
 title: "host path: object spread `{...a}` & Object.assign drop copied values/keys (closed-struct representation mismatch)"
-status: ready
+status: done
+assignee: ttraenkler/sendev-objspread
 sprint: current
 created: 2026-06-28
 updated: 2026-06-28
+completed: 2026-06-28
 priority: medium
 feasibility: medium
 reasoning_effort: medium
@@ -100,3 +102,63 @@ read on the dynamic path.
 
 - Carved from #2796. #2796 fixed the `for…in` enumeration-timing case; this is
   the residual real codegen representation bug.
+
+## Implementation notes (resolved 2026-06-28, sendev-objspread)
+
+Root-caused both halves to a **representation/path mismatch**, not the
+hypothesised host-mirror gap. Fix keys on the **TS type / chosen representation**,
+never the Wasm kind.
+
+### A — spread `{ ...a, z: 3 }` (wrong key order + NaN values)
+
+The `#2714` routing already sent a spread literal in a NON-SPECIFIC context (no
+contextual type — exactly `const b = { ...a, z: 3 }`) to the host plain-object
+(`$Object`/externref) path. But the **variable** `b`'s slot was still typed as the
+struct TypeScript *infers* (`{z;x;y}`): the host `$Object` was then `ref.test`/
+`ref.cast` to that struct at runtime, the cast **failed**, `b` became null →
+`b.x`/`b.z` read NaN/null. And `Object.keys(b)` took a **compile-time struct-shape
+fast path** that lists the inferred field order (`z,x,y`, own-prop-first), not the
+spread's runtime CopyDataProperties **insertion order** (`x,y,z`).
+
+Fix — make the local/global representation follow the routing decision:
+- Extracted the routing predicate as `objectLiteralSpreadTakesHostPath`
+  (`literals.ts`) — the single source of truth.
+- Force an **externref** slot (+ `externrefAccessorVars` tag) for a host-path
+  spread initializer at **all four** variable-typing sites that pre-date
+  `compileVariableStatement`: `statements/variables.ts`, the var-hoist and the
+  authoritative `walkStmtForLetConst` TDZ pre-hoist in `index.ts`, and the
+  module-global typer `moduleInitForcesExternref` in `declarations.ts` (top-level
+  `const` becomes a global, NOT a function local — this was the one that kept the
+  corpus failing after the first three were fixed).
+- `Object.keys`/`values`/`entries` of an `externrefAccessorVars` var → route to
+  the runtime `__object_*` helper (`object-ops.ts`) so enumeration reflects the
+  live host object's insertion order, not the struct shape.
+- An explicit concrete-struct annotation pins a contextual type → predicate false
+  → struct path retained (#2714 control stays green).
+
+### B — `Object.assign(t, { b }, { c })` (sources dropped from keys)
+
+NOT a copy failure: the host `__object_assign` already copies source keys into the
+struct target's **sidecar** (for-in surfaced `a,b,c`). But the copy is a plain
+dynamic write recording **no descriptor**, and `__object_keys`/`values`/`entries`/
+`getOwnPropertyNames` only surface sidecar keys on a struct that carry a descriptor
+(`#2746`) — so `Object.keys` dropped them while for-in showed them (an existing
+keys-vs-for-in inconsistency). Fix: in `__object_assign` (`runtime.ts`, host),
+record an enumerable writable+configurable descriptor for each newly-copied
+non-static-field key — matching the spec data-property semantics Object.assign's
+`[[Set]]` creates, and making all four enumeration helpers consistent with for-in.
+
+### Validation
+
+- `object/02-spread` + `object/12-assign` now MATCH V8; full diff-test corpus
+  **+2 match / 0 regress** (94/104, object 11/12 — the lone remaining `06-delete`
+  is a pre-existing delete-on-struct issue, untouched here).
+- Host **and** standalone both correct (the runtime.ts change is host-only;
+  standalone uses the native `object-runtime.ts` `__object_assign` + native
+  `$Object`, which already passed — **no new unconditional standalone helper**, so
+  the #2097 floor is unaffected).
+- Green: `#2714` (11), `#2746` (14), `#2076`, `#1336`, `#1630`, `#2011`, `#1239`,
+  `#2127`, `#1901`, `#786`; `tests/issue-2804.test.ts` 20/20 (host+standalone);
+  `tsc` clean. The 9-file object/spread batch is byte-identical pass/fail to clean
+  `main` (the `spread-rest.test.ts` `string_constants`-harness failures are
+  pre-existing and 100% reproduce on `main`, not in any CI gate).

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -3722,6 +3722,27 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
         }
       }
     }
+    // (#2804) A spread-containing object literal in a NON-SPECIFIC context (no
+    // concrete contextual struct type — e.g. top-level `const b = { ...a, z: 3 }`)
+    // is built as a host `$Object` (externref) by the literals.ts routing, NOT
+    // the closed struct TS infers. The receiving global must be externref to
+    // match (else the host object is ref.cast to the inferred struct → read
+    // NaN/null), and reads route through `__extern_get`, preserving the spread's
+    // runtime insertion-order keys + values. Mirrors the function-local sites
+    // (statements/variables.ts, index.ts walkStmtForLetConst/hoistVarDecl);
+    // inlined to keep the same lockstep predicate as the literals.ts routing.
+    if (decl.initializer.properties.some((p) => ts.isSpreadAssignment(p))) {
+      const spreadCtxType = ctx.checker.getContextualType(decl.initializer);
+      if (
+        !spreadCtxType ||
+        (spreadCtxType.flags & ts.TypeFlags.Any) !== 0 ||
+        (spreadCtxType.flags & ts.TypeFlags.Unknown) !== 0 ||
+        (spreadCtxType.flags & ts.TypeFlags.NonPrimitive) !== 0 ||
+        spreadCtxType.getProperties().length === 0
+      ) {
+        return true;
+      }
+    }
     return false;
   }
 

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -13921,6 +13921,24 @@ function hoistVarDecl(ctx: CodegenContext, fctx: FunctionContext, decl: ts.Varia
           }
         }
       }
+      // (#2804) A spread-containing object literal in a NON-SPECIFIC context
+      // (no concrete contextual struct type — e.g. `var b = { ...a, z: 3 }`)
+      // takes the host plain-object path (compileObjectLiteralWithAccessors),
+      // building an externref `$Object`, NOT the closed struct TS infers. The
+      // hoisted slot must be externref to match (else the value is ref.cast to
+      // the inferred struct → read NaN/null). Mirrors the let/const path in
+      // statements/variables.ts (objectLiteralSpreadTakesHostPath); inlined here
+      // to avoid an index↔literals import cycle.
+      if (!initForcesExternref && decl.initializer.properties.some((p) => ts.isSpreadAssignment(p))) {
+        const spreadCtxType = ctx.checker.getContextualType(decl.initializer);
+        const nonSpecificCtx =
+          !spreadCtxType ||
+          (spreadCtxType.flags & ts.TypeFlags.Any) !== 0 ||
+          (spreadCtxType.flags & ts.TypeFlags.Unknown) !== 0 ||
+          (spreadCtxType.flags & ts.TypeFlags.NonPrimitive) !== 0 ||
+          spreadCtxType.getProperties().length === 0;
+        if (nonSpecificCtx) initForcesExternref = true;
+      }
     }
     const wasmType: ValType =
       initForcesExternref || isNullablePrimitiveType(varType)
@@ -14407,16 +14425,42 @@ function walkStmtForLetConst(ctx: CodegenContext, fctx: FunctionContext, stmt: t
           decl.initializer !== undefined &&
           ts.isObjectLiteralExpression(decl.initializer) &&
           decl.initializer.properties.some((p) => ts.isGetAccessorDeclaration(p) || ts.isSetAccessorDeclaration(p));
-        if (initIsAccessorLiteral) {
+        // (#2804) A spread-containing object literal in a NON-SPECIFIC context
+        // (no concrete contextual struct type — e.g. `const b = { ...a, z: 3 }`)
+        // is built as a host `$Object` (externref) by the literals.ts routing,
+        // NOT the closed struct TS infers for the variable. This pre-hoist
+        // allocator is the AUTHORITATIVE slot-typer for let/const (it runs
+        // before compileVariableStatement), so the externref override MUST be
+        // applied here too — otherwise the slot is the inferred struct and the
+        // initializer's externref is ref.cast to it at runtime (cast fails →
+        // `b.x` reads NaN/null). Mirrors statements/variables.ts; inlined to
+        // avoid an index↔literals import cycle.
+        let initIsHostSpreadLiteral = false;
+        if (
+          !initIsAccessorLiteral &&
+          decl.initializer !== undefined &&
+          ts.isObjectLiteralExpression(decl.initializer) &&
+          decl.initializer.properties.some((p) => ts.isSpreadAssignment(p))
+        ) {
+          const spreadCtxType = ctx.checker.getContextualType(decl.initializer);
+          initIsHostSpreadLiteral =
+            !spreadCtxType ||
+            (spreadCtxType.flags & ts.TypeFlags.Any) !== 0 ||
+            (spreadCtxType.flags & ts.TypeFlags.Unknown) !== 0 ||
+            (spreadCtxType.flags & ts.TypeFlags.NonPrimitive) !== 0 ||
+            spreadCtxType.getProperties().length === 0;
+        }
+        if (initIsAccessorLiteral || initIsHostSpreadLiteral) {
           ctx.externrefAccessorVars.add(name);
         }
-        const wasmType: ValType = initIsAccessorLiteral
-          ? { kind: "externref" }
-          : isI32Coerced
-            ? { kind: "i32" }
-            : isNullablePrimitiveType(varType)
-              ? { kind: "externref" }
-              : (inferLetConstInitializerWasmType(ctx, fctx, decl.initializer) ?? resolveWasmType(ctx, varType));
+        const wasmType: ValType =
+          initIsAccessorLiteral || initIsHostSpreadLiteral
+            ? { kind: "externref" }
+            : isI32Coerced
+              ? { kind: "i32" }
+              : isNullablePrimitiveType(varType)
+                ? { kind: "externref" }
+                : (inferLetConstInitializerWasmType(ctx, fctx, decl.initializer) ?? resolveWasmType(ctx, varType));
         allocLocal(fctx, name, wasmType);
         // Only add TDZ flag if static analysis can't prove all accesses are safe
         if (needsTdzFlag(ctx, decl)) {

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -911,6 +911,45 @@ function _hasRuntimeComputedKey(ctx: CodegenContext, expr: ts.ObjectLiteralExpre
   return false;
 }
 
+/**
+ * (#2714 / #2804) True when a spread-containing object literal must be built via
+ * the host plain-object (`$Object`/externref) path rather than a closed struct,
+ * because its evaluation context does not pin a CONCRETE object SHAPE the struct
+ * path could faithfully build/enumerate: `any` / `unknown` / `object`, NO
+ * contextual type at all, or a shapeless object type with zero own properties
+ * (e.g. the `object` param of `Object.keys`).
+ *
+ * This is the single source of truth for the routing decision below AND for the
+ * variable-declaration local typing (statements/variables.ts, index.ts var
+ * hoist). Keeping them in lockstep is what fixes #2804: `const b = { ...a, z: 3 }`
+ * (no annotation) has NO contextual type, so the literal takes the host path —
+ * but the receiving variable's INFERRED type is a concrete struct `{x;y;z}`, so
+ * without this shared predicate the local was typed as that struct while the
+ * initializer produced a host `$Object`, and the externref→struct coercion
+ * (ref.test/ref.cast) failed at runtime → `b.x` read NaN / null. The variable
+ * sites consult this predicate and force an externref local so the local
+ * representation matches the host-object value (and `b.x` routes through
+ * `__extern_get`, preserving the spread's insertion-order keys + values, which
+ * the struct path cannot — its field order follows TS's own-prop-first inferred
+ * type, not the runtime CopyDataProperties insertion order).
+ *
+ * A CONCRETE annotated target (`const x: { a: number } = { ...o }`, ≥1 property)
+ * has a specific contextual type → returns false → keeps the struct path so
+ * typed consumers still receive a struct (#2714 control).
+ */
+export function objectLiteralSpreadTakesHostPath(ctx: CodegenContext, expr: ts.ObjectLiteralExpression): boolean {
+  if (expr.properties.length === 0) return false;
+  if (!expr.properties.some((p) => ts.isSpreadAssignment(p))) return false;
+  const spreadCtxType = ctx.checker.getContextualType(expr);
+  return (
+    !spreadCtxType ||
+    (spreadCtxType.flags & ts.TypeFlags.Any) !== 0 ||
+    (spreadCtxType.flags & ts.TypeFlags.Unknown) !== 0 ||
+    (spreadCtxType.flags & ts.TypeFlags.NonPrimitive) !== 0 ||
+    spreadCtxType.getProperties().length === 0
+  );
+}
+
 export function compileObjectLiteral(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -960,23 +999,11 @@ export function compileObjectLiteral(
   // { ...o }`), keep the struct path so typed consumers still get a struct.
   // (Assigning to an `any`/untyped variable already worked via the host path;
   // this generalizes the same routing to the direct-call-argument position.)
-  if (expr.properties.length > 0 && expr.properties.some((p) => ts.isSpreadAssignment(p))) {
-    const spreadCtxType = ctx.checker.getContextualType(expr);
-    // Non-specific = the contextual type does not pin a concrete object SHAPE the
-    // struct path could build/enumerate: `any`/`unknown`/`object`, no contextual
-    // type at all, OR a shapeless object type with zero own properties (e.g. the
-    // `object` param of `Object.keys`, whose contextual type carries no fields).
-    // A CONCRETE target (`const x: { a: number } = { ...o }`) has ≥1 property and
-    // keeps the struct path so typed consumers still receive a struct.
-    const nonSpecificCtx =
-      !spreadCtxType ||
-      (spreadCtxType.flags & ts.TypeFlags.Any) !== 0 ||
-      (spreadCtxType.flags & ts.TypeFlags.Unknown) !== 0 ||
-      (spreadCtxType.flags & ts.TypeFlags.NonPrimitive) !== 0 ||
-      spreadCtxType.getProperties().length === 0;
-    if (nonSpecificCtx) {
-      return compileObjectLiteralWithAccessors(ctx, fctx, expr);
-    }
+  // (#2804) Routes through the shared `objectLiteralSpreadTakesHostPath`
+  // predicate so the variable-declaration local typing (variables.ts / index.ts)
+  // can make the IDENTICAL decision and force a matching externref local.
+  if (objectLiteralSpreadTakesHostPath(ctx, expr)) {
+    return compileObjectLiteralWithAccessors(ctx, fctx, expr);
   }
 
   // If this empty object literal is the initializer of a variable with widened

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -3846,8 +3846,20 @@ export function compileObjectKeysOrValues(
     return { kind: "externref" };
   }
 
+  // (#2804) When the argument is a variable that holds a HOST `$Object`
+  // (externref) rather than a closed struct — e.g. `const b = { ...a, z: 3 }`,
+  // whose spread routes it to the host plain-object path and tags it in
+  // `externrefAccessorVars` — the compile-time struct fast path below is WRONG:
+  // it would enumerate the keys in the var's INFERRED STRUCT field order (TS
+  // lists spread-merged own props first, e.g. `z,x,y`), but the live host object
+  // carries the runtime CopyDataProperties INSERTION order (`x,y,z`). Force the
+  // runtime `__object_keys`/`values`/`entries` helper (the `!structName` arm)
+  // so enumeration reflects the actual object, matching V8. Keyed on the SAME
+  // `externrefAccessorVars` tag the variable sites set, so the representation
+  // (externref host object) and the enumeration path stay in lockstep.
+  const argIsHostObjectVar = ts.isIdentifier(arg) && ctx.externrefAccessorVars.has(arg.text);
   // Resolve struct name from the argument type
-  const structName = resolveStructName(ctx, argType);
+  const structName = argIsHostObjectVar ? undefined : resolveStructName(ctx, argType);
   if (!structName) {
     // Check if the type is an empty object literal (not any/unknown) — if so,
     // compile away to an empty array since there's nothing to enumerate.

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -11,7 +11,7 @@ import type { CodegenContext, FunctionContext, NullGuardFact, NullishExclusion }
 import { emitCoercedLocalSet, noJsHost } from "../expressions/helpers.js";
 import { emitUndefined } from "../expressions/late-imports.js";
 import { needsTdzFlag, resolveWasmType } from "../index.js";
-import { resolveComputedKeyExpression } from "../literals.js";
+import { objectLiteralSpreadTakesHostPath, resolveComputedKeyExpression } from "../literals.js";
 import { localGlobalIdx } from "../registry/imports.js";
 import { getOrRegisterArrayType, getOrRegisterSubviewType, getOrRegisterVecType } from "../registry/types.js";
 import { coerceType, compileExpression, valTypesMatch } from "../shared.js";
@@ -718,7 +718,22 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
         }
         return false;
       });
-    if (initIsAccessorLiteral) {
+    // (#2804) A spread-containing object literal initializer that takes the host
+    // plain-object path (no concrete contextual struct type — e.g.
+    // `const b = { ...a, z: 3 }`) builds a host `$Object` (externref), NOT the
+    // closed struct TypeScript INFERS for the variable. The local must therefore
+    // be an externref so the value isn't ref.cast to that inferred struct (which
+    // fails at runtime → `b.x` reads NaN/null), and reads route through
+    // `__extern_get` — preserving the spread's runtime insertion-order keys +
+    // values. Uses the SAME predicate as the literals.ts routing so the local
+    // representation and the value representation stay in lockstep. An explicit
+    // concrete-struct annotation pins a contextual type → predicate false →
+    // struct path retained (#2714 control).
+    const initIsHostSpreadLiteral =
+      decl.initializer !== undefined &&
+      ts.isObjectLiteralExpression(decl.initializer) &&
+      objectLiteralSpreadTakesHostPath(ctx, decl.initializer);
+    if (initIsAccessorLiteral || initIsHostSpreadLiteral) {
       ctx.externrefAccessorVars.add(name);
     }
 
@@ -736,38 +751,39 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
       isProxyConstruction(decl.initializer) &&
       ts.isIdentifier(decl.name) &&
       !proxyResultEscapesToCall(decl, decl.name.text);
-    const wasmType: ValType = initIsAccessorLiteral
-      ? { kind: "externref" as const }
-      : isI32CoercedLocal
-        ? { kind: "i32" }
-        : isI32SpecializedArray
-          ? { kind: "ref_null" as const, typeIdx: getOrRegisterVecType(ctx, "i32", { kind: "i32" }) }
-          : widenedTypeIdx !== undefined
-            ? { kind: "ref_null" as const, typeIdx: widenedTypeIdx }
-            : (subarraySubviewType ??
-              inferredVecType ??
-              standaloneRegExpMatchArrayType ??
-              (decl.initializer && isStringMethodReturningHostArray(ctx, decl.initializer)
-                ? { kind: "externref" as const }
-                : decl.initializer && isPromiseHostCall(ctx, decl.initializer)
+    const wasmType: ValType =
+      initIsAccessorLiteral || initIsHostSpreadLiteral
+        ? { kind: "externref" as const }
+        : isI32CoercedLocal
+          ? { kind: "i32" }
+          : isI32SpecializedArray
+            ? { kind: "ref_null" as const, typeIdx: getOrRegisterVecType(ctx, "i32", { kind: "i32" }) }
+            : widenedTypeIdx !== undefined
+              ? { kind: "ref_null" as const, typeIdx: widenedTypeIdx }
+              : (subarraySubviewType ??
+                inferredVecType ??
+                standaloneRegExpMatchArrayType ??
+                (decl.initializer && isStringMethodReturningHostArray(ctx, decl.initializer)
                   ? { kind: "externref" as const }
-                  : // (#2615) `new Proxy(target, handler)` returns a host/native
-                    // Proxy externref. The checker types it as the TARGET's
-                    // struct (ProxyConstructor returns T), so the default slot
-                    // would `ref.test` the Proxy against that struct, fail, null
-                    // it, and trap every read via a direct `struct.get`. Force an
-                    // externref local so reads route through `__extern_get` (the
-                    // only path that runs the Proxy MOP / trap). Both modes emit
-                    // a Proxy externref, so this is mode-agnostic.
-                    initIsProxy
+                  : decl.initializer && isPromiseHostCall(ctx, decl.initializer)
                     ? { kind: "externref" as const }
-                    : // (#1337) `fn.bind(...)` / `Function.prototype.bind.call(...)`
-                      // returns a host bound-function externref in JS-host mode;
-                      // force an externref local so the value isn't ref.cast to
-                      // the target's closure struct (which traps → null binding).
-                      decl.initializer && !ctx.standalone && !noJsHost(ctx) && isBindHostCall(decl.initializer)
+                    : // (#2615) `new Proxy(target, handler)` returns a host/native
+                      // Proxy externref. The checker types it as the TARGET's
+                      // struct (ProxyConstructor returns T), so the default slot
+                      // would `ref.test` the Proxy against that struct, fail, null
+                      // it, and trap every read via a direct `struct.get`. Force an
+                      // externref local so reads route through `__extern_get` (the
+                      // only path that runs the Proxy MOP / trap). Both modes emit
+                      // a Proxy externref, so this is mode-agnostic.
+                      initIsProxy
                       ? { kind: "externref" as const }
-                      : localTypeForDeclaration(ctx, varType)));
+                      : // (#1337) `fn.bind(...)` / `Function.prototype.bind.call(...)`
+                        // returns a host bound-function externref in JS-host mode;
+                        // force an externref local so the value isn't ref.cast to
+                        // the target's closure struct (which traps → null binding).
+                        decl.initializer && !ctx.standalone && !noJsHost(ctx) && isBindHostCall(decl.initializer)
+                        ? { kind: "externref" as const }
+                        : localTypeForDeclaration(ctx, varType)));
 
     // If this var/let/const was already pre-hoisted at function entry, reuse that slot.
     // For let/const: the pre-pass (hoistLetConstWithTdz) always pre-allocates a slot

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -10310,6 +10310,46 @@ assert._isSameValue = isSameValue;
             const wrappedTarget = _wrapForHost(target, exports);
             const wrappedSources = (sources ?? []).map((s) => (_isWasmStruct(s) ? _wrapForHost(s, exports) : s));
             Object.assign(wrappedTarget, ...wrappedSources);
+            // (#2804) Object.assign performs CopyDataProperties via [[Set]] (§7.3.25),
+            // so each copied own enumerable source key becomes an ENUMERABLE own data
+            // property on the target. The proxy `set` trap above writes the value to
+            // the struct's sidecar (`_wasmStructProps`) but, being a plain dynamic
+            // write, records NO descriptor entry — and `__object_keys` /
+            // `__object_values` / `__object_entries` / `__getOwnPropertyNames` only
+            // surface sidecar keys on a STRUCT target that carry a descriptor (#2746).
+            // So the copied keys landed in the value store yet vanished from
+            // enumeration (`Object.keys` dropped Object.assign's source keys — the
+            // #2804 bug; for-in already surfaced them). Record an enumerable
+            // writable+configurable descriptor for each newly-copied non-static-field
+            // key so the enumeration helpers list them, matching the spec data-property
+            // semantics and the for-in result. Existing struct fields enumerate from
+            // the shape; keys with an existing descriptor (e.g. a defineProperty'd
+            // non-enumerable prop) are left untouched.
+            const targetDescs = _getSidecarDescs(target);
+            const staticFieldNames = new Set(_getStructFieldNames(target, exports) ?? []);
+            for (const ws of wrappedSources) {
+              if (ws == null || (typeof ws !== "object" && typeof ws !== "function")) continue;
+              let keys: (string | symbol)[];
+              try {
+                keys = Reflect.ownKeys(ws);
+              } catch {
+                continue;
+              }
+              for (const k of keys) {
+                let enumerable: boolean;
+                try {
+                  enumerable = Object.getOwnPropertyDescriptor(ws, k)?.enumerable === true;
+                } catch {
+                  enumerable = false;
+                }
+                if (!enumerable) continue;
+                if (typeof k === "string" && staticFieldNames.has(k)) continue;
+                const nk = _normalizeDescKey(k);
+                if (!targetDescs.has(nk)) {
+                  targetDescs.set(nk, _SC_WRITABLE | _SC_ENUMERABLE | _SC_CONFIGURABLE | _SC_DEFINED);
+                }
+              }
+            }
             return target;
           }
           // Non-struct target: wrap only wasmGC sources so their property

--- a/tests/issue-2804.test.ts
+++ b/tests/issue-2804.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+
+// #2804 — host object spread `{ ...a }` & `Object.assign` drop copied values/keys
+// (closed-struct representation mismatch). Carved from #2796 (the for…in case was
+// a harness exports-timing artifact; these two are a genuine codegen rep bug).
+//
+// Root cause A (spread): `const b = { ...a, z: 3 }` (no annotation) has NO
+// contextual type, so the literal takes the host plain-object ($Object/externref)
+// path — but the variable's INFERRED type is a concrete struct `{x;y;z}`, so the
+// local/global was typed as that struct while the value built was a $Object. The
+// externref→struct coercion failed at runtime → `b.x` read NaN/null, and
+// `Object.keys(b)` enumerated the struct's TS-inferred field order (own-prop-first:
+// `z,x,y`) instead of the spread's runtime insertion order (`x,y,z`). Fix: force
+// an externref local/global for such host-path spread literals (lockstep with the
+// literals.ts routing) and route `Object.keys/values/entries` on a host-object var
+// through the runtime helper.
+//
+// Root cause B (Object.assign): `Object.assign(structTarget, src)` copies the
+// source's own enumerable keys into the target struct's SIDECAR via a plain
+// dynamic write, which records no descriptor — and `__object_keys` (#2746) only
+// surfaces sidecar keys on a struct that carry a descriptor, so the copied keys
+// vanished from enumeration (while for-in already surfaced them). Fix: record an
+// enumerable data-property descriptor for each copied key in `__object_assign`.
+
+async function run(source: string, opts: { standalone?: boolean } = {}): Promise<unknown> {
+  const result: any = await compile(source, {
+    fileName: "test.ts",
+    ...(opts.standalone ? { standalone: true } : {}),
+  });
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e: any) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  const built = buildImports(result.imports, {}, result.stringPool);
+  const { instance } = await instantiateWasm(result.binary, built.env, built.string_constants);
+  built.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as any).test();
+}
+
+const MODES: Array<{ name: string; standalone?: boolean }> = [
+  { name: "host" },
+  { name: "standalone", standalone: true },
+];
+
+describe("#2804 — object spread & Object.assign copy keys + values", () => {
+  for (const mode of MODES) {
+    describe(mode.name, () => {
+      // ── A: object spread { ...a, z } ──────────────────────────────────────
+      it("A: spread copies keys in INSERTION order (x,y,z, not z,x,y)", async () => {
+        expect(
+          await run(
+            `export function test(): string {
+               const a = { x: 1, y: 2 };
+               const b = { ...a, z: 3 };
+               return Object.keys(b).join(",");
+             }`,
+            mode,
+          ),
+        ).toBe("x,y,z");
+      });
+
+      it("A: spread-copied VALUES read back (b.x === 1, b.z === 3)", async () => {
+        expect(
+          await run(
+            `export function test(): number {
+               const a = { x: 1, y: 2 };
+               const b = { ...a, z: 3 };
+               return b.x + b.z;
+             }`,
+            mode,
+          ),
+        ).toBe(4);
+      });
+
+      it("A: spread value read at every key", async () => {
+        expect(
+          await run(
+            `export function test(): string {
+               const a = { x: 1, y: 2 };
+               const b = { ...a, z: 3 };
+               return b.x + "," + b.y + "," + b.z;
+             }`,
+            mode,
+          ),
+        ).toBe("1,2,3");
+      });
+
+      it("A: spread-only { ...a } copies keys + values", async () => {
+        expect(
+          await run(
+            `export function test(): string {
+               const a = { x: 1, y: 2 };
+               const b = { ...a };
+               return Object.keys(b).join(",") + "|" + b.x + "," + b.y;
+             }`,
+            mode,
+          ),
+        ).toBe("x,y|1,2");
+      });
+
+      it("A: Object.values reflects insertion order", async () => {
+        expect(
+          await run(
+            `export function test(): string {
+               const a = { x: 1, y: 2 };
+               const b = { ...a, z: 3 };
+               return Object.values(b).join(",");
+             }`,
+            mode,
+          ),
+        ).toBe("1,2,3");
+      });
+
+      it("A CONTROL: an explicit concrete-struct annotation keeps struct semantics", async () => {
+        // #2714 control — a literal with a concrete contextual type stays on the
+        // struct path; values must still read back.
+        expect(
+          await run(
+            `export function test(): number {
+               const a = { x: 1, y: 2 };
+               const b: { x: number; y: number; z: number } = { ...a, z: 3 };
+               return b.x + b.z;
+             }`,
+            mode,
+          ),
+        ).toBe(4);
+      });
+
+      // ── B: Object.assign(target, ...sources) ──────────────────────────────
+      it("B: Object.assign copies own enumerable keys from all sources", async () => {
+        expect(
+          await run(
+            `export function test(): string {
+               const t = { a: 1 };
+               const r = Object.assign(t, { b: 2 }, { c: 3 });
+               return Object.keys(r).join(",");
+             }`,
+            mode,
+          ),
+        ).toBe("a,b,c");
+      });
+
+      it("B: Object.assign preserves target identity (r === t)", async () => {
+        expect(
+          await run(
+            `export function test(): number {
+               const t = { a: 1 };
+               const r = Object.assign(t, { b: 2 }, { c: 3 });
+               return r === t ? 1 : 0;
+             }`,
+            mode,
+          ),
+        ).toBe(1);
+      });
+
+      it("B: Object.getOwnPropertyNames agrees with Object.keys after assign", async () => {
+        expect(
+          await run(
+            `export function test(): string {
+               const t = { a: 1 };
+               const r = Object.assign(t, { b: 2 });
+               return Object.getOwnPropertyNames(r).join(",");
+             }`,
+            mode,
+          ),
+        ).toBe("a,b");
+      });
+
+      it("B: for-in and Object.keys are consistent after assign", async () => {
+        expect(
+          await run(
+            `export function test(): string {
+               const t = { a: 1 };
+               const r = Object.assign(t, { b: 2 }, { c: 3 });
+               let fk = "";
+               for (const k in r) fk += k;
+               return fk + "|" + Object.keys(r).join(",");
+             }`,
+            mode,
+          ),
+        ).toBe("abc|a,b,c");
+      });
+    });
+  }
+});


### PR DESCRIPTION
## #2804 — host object spread `{ ...a }` & `Object.assign` drop copied values/keys

Carved from #2796 (the `for…in` case was a harness exports-timing artifact #2796 fixed; these two are **genuine codegen representation bugs** that fail even with the runtime fully wired). Both root-cause to a **representation/path mismatch** — keyed on the TS-inferred type vs the chosen Wasm representation, not a host-mirror copy gap.

### A — spread `{ ...a, z: 3 }`: wrong key order + NaN values
`#2714` already routes a spread literal in a non-specific context (e.g. unannotated `const b = { ...a, z: 3 }`) to the host `$Object`/externref path — but the **variable slot** stayed the struct TypeScript *infers* (`{z;x;y}`). The host object was `ref.cast` to that struct at runtime, the cast **failed** (b → null), so `b.x`/`b.z` read NaN/null; and `Object.keys(b)` took a compile-time struct-shape fast path listing the inferred field order (`z,x,y`) rather than the spread's runtime insertion order (`x,y,z`).

**Fix:** force an **externref** slot (+ `externrefAccessorVars` tag) for a host-path spread initializer at all four variable-typing sites that pre-date `compileVariableStatement` — `statements/variables.ts`, the var-hoist + the authoritative `walkStmtForLetConst` TDZ pre-hoist in `index.ts`, and the module-global typer in `declarations.ts` (top-level `const` becomes a **global**, the site that kept the corpus failing). All share the new `objectLiteralSpreadTakesHostPath` predicate (single source of truth with the routing). `Object.keys`/`values`/`entries` of such a host-object var now route to the runtime helper so enumeration reflects insertion order. An explicit concrete-struct annotation keeps the struct path (#2714 control).

### B — `Object.assign(t, { b }, { c })`: sources dropped from keys
Sources already land in the struct target's **sidecar** (for-in saw `a,b,c`), but as plain dynamic writes with **no descriptor** — and `__object_keys`/`values`/`entries`/`getOwnPropertyNames` (#2746) only surface descriptor'd sidecar keys on a struct, so `Object.keys` dropped them (inconsistent with for-in). **Fix:** record an enumerable writable+configurable descriptor for each Object.assign-copied non-field key in `__object_assign` (host runtime), matching the spec `[[Set]]` data-property semantics.

### Validation
- `object/02-spread` + `object/12-assign` now **match V8**; full diff-test corpus **+2 match / 0 regress** (object 11/12 — lone `06-delete` is a pre-existing delete-on-struct issue, untouched).
- **Host + standalone** both correct. The `runtime.ts` change is **host-only** (standalone uses the native `object-runtime.ts` `__object_assign` + `$Object`, already passing) — **no new unconditional standalone helper**, so the #2097 floor is unaffected.
- Green: `tests/issue-2804.test.ts` 20/20 (host+standalone); `#2714` (11), `#2746` (14), `#2076`, `#1336`, `#1630`, `#2011`, `#1239`, `#2127`, `#1901`, `#786`; `tsc` clean. The 9-file object/spread vitest batch is byte-identical pass/fail to clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS