### PR TITLE
fix: present WasmGC vec fields to host as real JS arrays (#2801 layer-1)

### DIFF
--- a/plan/issues/2801-callexpression-arguments-marshal-empty-object.md
+++ b/plan/issues/2801-callexpression-arguments-marshal-empty-object.md
@@ -94,3 +94,52 @@ an empty object proxy. Candidate causes to pin (instrument, don't guess):
 - Depends on **#2794** (the `__is_data_struct` discriminator + vec read-methods).
   Branch fresh from `origin/main` AFTER #2794 (PR #2264) merges so this builds on
   that fix.
+
+## Implementation Notes (sendev-acorn-callargs, 2026-06-28)
+
+Instrument-first investigation (probes in `.tmp/callargs*.mjs`,
+`.tmp/elemdbg.mjs`) found the bug is **two distinct layers**, not one:
+
+### Layer 1 — host vec→array marshaling (FIXED, branch `issue-2801-callexpr-arguments-marshal`)
+
+The candidate "vec not recognized on read-back" was correct. The flow:
+
+- `Program.body` reaches the host as a **host-backed JS array** (`isArray=true,
+  isWasm=false`) whose elements are `_wrapForHost` proxies of the AST nodes — so
+  `ast.body` walked fine and looked like the bug was call-specific.
+- But it is **not** call-specific: `ArrayExpression.elements` is `{}` too. Any
+  array read **through** the `_wrapForHost` proxy chain (i.e. a nested array
+  field, not the top-level body) hit the get-handler vec branch
+  (`__is_vec(val)===1 → _wrapForHost(val)`), which returns the **generic object
+  proxy** of the vec. That proxy has no `length`/index surface → marshals as
+  `{}` (`Array.isArray` false, `length` undefined). `_structToPlainObject` is
+  only ever called for the top-level `Program` (confirmed by instrumentation);
+  the nested CallExpression/ArrayExpression nodes are lazy proxies, so the
+  marshaling decision is made entirely in `_wrapForHost`.
+- **Fix**: `_wrapVecForHost` in `src/runtime.ts` — a Proxy with a real `[]`
+  target (`Array.isArray` true) whose traps serve `length` + numeric indices
+  LIVE from the vec (`__vec_len`/`__vec_get`), reverse-mapped to the raw vec so
+  `__extern_method_call` (`scopeStack.push` → `__vec_push`) still works. Routed
+  at the top of `_wrapForHost` on the positive `__is_vec` discriminator. After
+  this, `arguments`/`elements` present as real JS arrays with correct length.
+
+### Layer 2 — vec element representation (NOT fixed — escalated; the real blocker)
+
+With Layer 1 in place, `arguments` is `[0, 0]`, not the two Identifier nodes.
+Decisive probe (`DBG2801` in `_wrapVecForHost.elemAt`):
+`__vec_get(argsVec, 0)` returns `number 0` (`rawTypeof=number, rawIsWasm=false`,
+`__vec_mut_supported=1`, `__vec_len=2`). So the `arguments` vec is a **real,
+growable vec whose backing-array element kind is numeric (f64)** — when acorn
+pushes AST node references they are coerced to f64 `0`. `__vec_get` faithfully
+returns `0`; `call.optional` likewise reads `0` not `false`.
+
+Origin: `compileArrayLiteral` empty-array path (`src/codegen/literals.ts`
+~3087-3162) resolves `emptyElemKind` from the contextual/`getTypeAtLocation`
+type of the `[]` literal. acorn is plain JS (no annotations); the
+`arguments`/`elements` array literals resolve to a **numeric** element kind
+(while `body` happens to resolve to a host externref array — hence the split).
+This is a vec **element-representation / type-inference** issue at the
+array-literal lowering site, a different substrate class from host marshaling,
+with broad blast radius (touches every untyped/evolving array). It needs an
+architect decision + full `merge_group` validation. **#2801 acceptance is
+blocked on Layer 2.** Layer 1 is committed as standalone, correct progress.

--- a/plan/issues/2801-callexpression-arguments-marshal-empty-object.md
+++ b/plan/issues/2801-callexpression-arguments-marshal-empty-object.md
@@ -14,8 +14,8 @@ task_type: bugfix
 area: codegen
 language_feature: value-representation
 goal: acorn-dogfood
-related: [2794, 2784, 2664, 2674]
-depends_on: [2794]
+related: [2794, 2784, 2664, 2674, 2806]
+depends_on: [2794, 2806]
 blocks: []
 ---
 

--- a/plan/issues/2801-callexpression-arguments-marshal-empty-object.md
+++ b/plan/issues/2801-callexpression-arguments-marshal-empty-object.md
@@ -1,8 +1,8 @@
 ---
 id: 2801
 title: "[SENIOR-DEV ONLY] compiled-acorn CallExpression `arguments` marshals as `{}` not an array (host vec→array gap)"
-status: in-progress
-assignee: ttraenkler/sendev-acorn-callargs
+status: blocked
+assignee: ttraenkler/unassigned
 sprint: current
 priority: high
 horizon: m

--- a/plan/issues/2801-callexpression-arguments-marshal-empty-object.md
+++ b/plan/issues/2801-callexpression-arguments-marshal-empty-object.md
@@ -1,8 +1,8 @@
 ---
 id: 2801
 title: "[SENIOR-DEV ONLY] compiled-acorn CallExpression `arguments` marshals as `{}` not an array (host vec→array gap)"
-status: ready
-assignee: ttraenkler/unassigned
+status: in-progress
+assignee: ttraenkler/sendev-acorn-callargs
 sprint: current
 priority: high
 horizon: m

--- a/plan/issues/2806-untyped-array-literal-numeric-vec-drops-ref-pushes.md
+++ b/plan/issues/2806-untyped-array-literal-numeric-vec-drops-ref-pushes.md
@@ -1,0 +1,136 @@
+---
+id: 2806
+title: "[SENIOR-DEV ONLY] untyped `[]` array literal lowers to a NUMERIC (f64) vec — ref pushes coerce to 0 (drops AST node refs)"
+status: ready
+assignee: ttraenkler/unassigned
+sprint: current
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+created: 2026-06-28
+task_type: bugfix
+area: codegen
+language_feature: value-representation
+goal: acorn-dogfood
+related: [2801, 2794, 2784]
+depends_on: []
+blocks: [2801]
+architect_spec: candidate
+---
+
+# #2806 — untyped `[]` lowers to a numeric vec, dropping reference-typed pushes
+
+**Carved out of #2801 (layer 2 of 2).** Distinct substrate class from the host
+vec→array *marshaling* fix that landed for #2801 layer-1. This is the **real
+blocker** for correct compiled-acorn call arguments — and it is **general**, not
+acorn-specific: it equally breaks `ArrayExpression.elements` and surfaces in
+`CallExpression.optional` reading `0` instead of `false`.
+
+## Symptom
+
+After the #2801 layer-1 host-marshaling fix (`_wrapVecForHost`), compiled-acorn
+`parse("foo(bar, baz)").arguments` is a **real JS array of length 2**, but its
+elements are `[0, 0]` — numeric zeros — instead of the two `Identifier` nodes.
+
+## Decisive root-cause probe
+
+Instrumenting the host read (`DBG2801` in `_wrapVecForHost.elemAt`,
+`src/runtime.ts`):
+
+```
+[DBG elem] i=0 rawTypeof=number rawIsWasm=false raw=0 mutSup=1 vecLen=2
+```
+
+So `__vec_get(argsVec, i)` returns a **`number 0`** (`rawIsWasm=false`), with
+`__vec_mut_supported=1`, `__vec_len=2`. The `arguments` vec is a genuine,
+growable vec whose **backing-array element kind is numeric (f64)**. When acorn
+pushes AST node references into it, each ref is coerced to f64 `0`; `__vec_get`
+faithfully reads back `0`. `call.optional` reading `0` (not `false`) is the same
+class of raw-scalar representation leak.
+
+`__vec_get` (`src/codegen/index.ts` ~4726-4900) is innocent: it does a
+`ref.test` chain over registered vec types and reads the matched backing array.
+The args vec genuinely **is** a numeric vec, so the read is correct for the
+(wrong) representation.
+
+## Origin — empty-array element-kind resolution
+
+`compileArrayLiteral` empty-array path, `src/codegen/literals.ts` ~3087-3162:
+
+```ts
+let emptyElemKind = "externref";
+const ctxType = ctx.checker.getContextualType(expr) ?? ctx.checker.getTypeAtLocation(expr);
+if (ctxType) {
+  const sym = (ctxType as ts.TypeReference).symbol ?? ctxType.symbol;
+  if (sym?.name === "Array") {
+    const typeArgs = ctx.checker.getTypeArguments(ctxType as ts.TypeReference);
+    if (typeArgs[0]) {
+      const elemWasmType = resolveWasmType(ctx, typeArgs[0]);
+      emptyElemKind = elemWasmType.kind === "ref" || elemWasmType.kind === "ref_null"
+        ? `ref_${(elemWasmType as { typeIdx: number }).typeIdx}`
+        : elemWasmType.kind;
+    }
+  }
+}
+const vecTypeIdx = getOrRegisterVecType(ctx, emptyElemKind);
+```
+
+acorn is **plain JS** (compiled with `skipSemanticDiagnostics: true`, no type
+annotations). For acorn's `arguments`/`elements` `[]` literals the contextual /
+`getTypeAtLocation` element type resolves to a **numeric** wasm kind, so the vec
+is created with an f64 backing array — and every subsequent reference push is
+coerced to f64.
+
+## The `body`-vs-`arguments` representation split (the tell)
+
+`Program.body` reaches the host as a **host-backed JS array** (externref,
+`isWasm=false`) of node proxies and works, while `CallExpression.arguments` /
+`ArrayExpression.elements` are **f64 vecs** that drop their node refs. Same
+"untyped `[]` + `.push(node)`" source pattern, different representation — so the
+element-kind decision is **inference-context dependent** (evolving-array flow
+analysis / contextual type), not uniform. Pinning *why* the two diverge is the
+first investigation step.
+
+## Fix direction (needs an architect representation-policy decision)
+
+An empty / untyped `[]` that subsequently receives **reference-typed** pushes
+must lower to an **externref/any-element vec** (boxed refs preserved), never an
+f64 vec. Candidate policies (DESIGN DECISION — architect-spec):
+
+1. **Default-to-any**: an untyped/`any[]`/`never[]` empty literal whose element
+   kind can't be proven numeric lowers to externref, not f64. Simple, but may
+   widen genuinely-numeric untyped arrays (perf/repr cost) — measure.
+2. **Flow-analyze pushes**: inspect the `.push(...)` / index-write sites feeding
+   the array binding; if any pushes a ref/`any`, choose externref. More precise,
+   more complex, must handle the evolving-array binding across the function.
+
+Either way: validate the `body`-style host-array path is unaffected, and run the
+**full `merge_group` + standalone-floor** (broad blast radius — touches every
+untyped/evolving array literal). Watch for regressions in numeric-array-heavy
+test262 buckets.
+
+## Acceptance
+
+- An empty/untyped `[]` that receives reference-typed pushes round-trips those
+  references (host reads them back as the pushed objects, not `0`).
+- Compiled-acorn `parse("foo(bar, baz)").arguments` structurally equals
+  node-acorn (two `Identifier` nodes) via the dogfood differential oracle —
+  closing **#2801**. Spot-check `f(1, 2+3)`, `f()`, `g(a)(b)`, `[1, 2]`.
+- `CallExpression.optional` reads `false` not `0` (same representation class).
+- Full `merge_group` + standalone-floor green; no numeric-array regressions.
+
+## Banked probes / method
+
+- `.tmp/callargs3.mjs` — parse + diffAst vs node-acorn oracle for arguments.
+- `.tmp/elemdbg.mjs` + `DBG2801` instrumentation in `_wrapVecForHost.elemAt` —
+  the decisive `__vec_get → number 0` classification.
+- Acorn compiles in ~40s (longer under load); reuse ONE compile per probe.
+- Depends on the #2801 layer-1 fix (`_wrapVecForHost`) being present so the
+  array surfaces at all — branch fresh from `origin/main` after that lands, or
+  cherry-pick it.
+
+## Build-on
+
+- **Blocks #2801** (its acceptance can't be met until node arrays preserve refs).
+- Sibling representation work: #2784 (vec-identity), #2794 (vec read-methods).

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -5182,9 +5182,136 @@ function _setLikeRecordForHost(
   return { size: fixField("size"), has: fixField("has"), keys: fixField("keys") };
 }
 
+// (#2801) Parse a property key into a canonical array index (uint32), or
+// `undefined` if it is not one. Mirrors the spec's CanonicalNumericIndexString
+// + array-index range so only genuine element keys (`"0"`, `"1"`, …) route to
+// `__vec_get`, while `"length"`, `"01"`, `"-1"`, `"1.5"` fall through to the
+// Array.prototype method path.
+function _asArrayIndex(key: string): number | undefined {
+  if (key === "0") return 0;
+  // Reject leading-zero / sign / non-digit forms — canonical indices only.
+  if (key.length === 0 || key.charCodeAt(0) === 48 /* '0' */) return undefined;
+  const n = Number(key);
+  if (Number.isInteger(n) && n >= 0 && n < 4294967295 && String(n) === key) return n;
+  return undefined;
+}
+
+// (#2801) Present a WasmGC vec (array) to the host as a REAL JS array view.
+//
+// Root cause this fixes: when a host reads an array-typed field through the
+// `_wrapForHost` proxy (e.g. acorn `CallExpression.arguments`,
+// `ArrayExpression.elements`), the value is a WasmGC vec struct. The previous
+// code wrapped it with the *generic* object proxy (`_wrapForHost`), which has
+// no `length` / numeric-index surface, so it marshalled as an empty object
+// `{}` (`Array.isArray` false, `length` undefined) — the parsed AST was
+// structurally wrong. A vec must instead present as an array.
+//
+// This returns a Proxy whose TARGET is a real `[]` (so `Array.isArray` is
+// true and `instanceof Array` holds) and whose traps serve `length` + numeric
+// indices LIVE from the underlying vec (`__vec_len` / `__vec_get`, elements
+// recursively `_wrapForHost`-wrapped). Native generic Array.prototype methods
+// (`map`, `forEach`, `slice`, `indexOf`, iteration, spread, `JSON.stringify`)
+// work because they read `length` + indices through these traps. The proxy is
+// registered in `_hostProxyReverse` → raw vec, so the existing
+// `__extern_method_call` mutation path (`scopeStack.push(...)` →
+// `_unwrapForHost` → `__vec_push`) still recovers the live vec and grows it;
+// because reads are live (not a snapshot), a later push is reflected.
+function _wrapVecForHost(vec: any, exports: Record<string, Function>): any {
+  const cached = _hostProxyCache.get(vec);
+  if (cached) return cached;
+  const lenFn = exports.__vec_len as ((v: any) => number) | undefined;
+  const getFn = exports.__vec_get as ((v: any, i: number) => any) | undefined;
+  // Defensive: if the read exports are missing, fall back to the generic
+  // object proxy rather than producing a broken array view.
+  if (typeof lenFn !== "function" || typeof getFn !== "function") return undefined;
+  const liveLen = (): number => {
+    try {
+      const n = lenFn(vec);
+      return typeof n === "number" && n >= 0 ? n : 0;
+    } catch {
+      return 0;
+    }
+  };
+  const elemAt = (i: number): any => {
+    try {
+      return _wrapForHost(getFn(vec, i), exports);
+    } catch {
+      return undefined;
+    }
+  };
+  const target: any[] = [];
+  const handler: ProxyHandler<any[]> = {
+    get(_t, key) {
+      if (key === "length") return liveLen();
+      if (typeof key === "string") {
+        const idx = _asArrayIndex(key);
+        if (idx !== undefined) return idx < liveLen() ? elemAt(idx) : undefined;
+      }
+      // Array.prototype methods, Symbol.iterator, constructor, etc. — read from
+      // the array target; native generics operate via the length/index traps.
+      return (target as Record<string | symbol, any>)[key as any];
+    },
+    has(_t, key) {
+      if (key === "length") return true;
+      if (typeof key === "string") {
+        const idx = _asArrayIndex(key);
+        if (idx !== undefined) return idx < liveLen();
+      }
+      return key in target;
+    },
+    ownKeys() {
+      const n = liveLen();
+      const keys: (string | symbol)[] = [];
+      for (let i = 0; i < n; i++) keys.push(String(i));
+      keys.push("length");
+      return keys;
+    },
+    getOwnPropertyDescriptor(_t, key) {
+      if (key === "length") {
+        return { value: liveLen(), writable: true, enumerable: false, configurable: false };
+      }
+      if (typeof key === "string") {
+        const idx = _asArrayIndex(key);
+        if (idx !== undefined && idx < liveLen()) {
+          return { value: elemAt(idx), writable: true, enumerable: true, configurable: true };
+        }
+      }
+      return undefined;
+    },
+    // Host-side writes are not part of the AST-read contract and the vec has no
+    // general element-setter export; accept silently (keep the target clean) so
+    // a stray host write neither throws nor leaves a phantom element. acorn's
+    // own mutations go through `__extern_method_call` (unwrap → `__vec_push`).
+    set() {
+      return true;
+    },
+  };
+  const proxy = new Proxy(target, handler);
+  _hostProxyCache.set(vec, proxy);
+  _hostProxyReverse.set(proxy, vec);
+  return proxy;
+}
+
 function _wrapForHost(obj: any, exports: Record<string, Function> | undefined): any {
   if (obj == null || typeof obj !== "object") return obj;
   if (!_isWasmStruct(obj)) return obj;
+
+  // (#2801) A WasmGC vec must present to the host as a real JS array, not a
+  // generic object proxy (which marshalled as `{}`). Detect via the positive
+  // `__is_vec` discriminator and route to the array-backed view. Done before
+  // the generic-proxy path so every consumer (struct field reads, set-algebra
+  // adapters, spread) sees array semantics uniformly.
+  if (exports) {
+    try {
+      const isVecFn = exports.__is_vec as ((v: any) => number) | undefined;
+      if (typeof isVecFn === "function" && isVecFn(obj) === 1) {
+        const vecView = _wrapVecForHost(obj, exports);
+        if (vecView !== undefined) return vecView;
+      }
+    } catch {
+      // discriminator unavailable — fall through to the generic object proxy
+    }
+  }
 
   const cached = _hostProxyCache.get(obj);
   if (cached) return cached;


### PR DESCRIPTION
## General vec-field → host-array marshaling fix (motivated by #2801)

This is a **general host-marshaling fix**, not acorn-specific. When the host reads
a WasmGC **vec** (array) field through the `_wrapForHost` proxy — e.g. any nested
array field on a returned object graph — the value previously fell to the
**generic object proxy**, which has no `length`/index surface and so marshaled as
an empty object `{}` (`Array.isArray` false, `length` undefined). Only top-level
host-backed arrays (already arrays of proxies) escaped this.

### Fix
`_wrapVecForHost` in `src/runtime.ts`: a Proxy whose **target is a real `[]`** (so
`Array.isArray` is true / `instanceof Array` holds) and whose traps serve `length`
+ numeric indices **live** from the vec (`__vec_len` / `__vec_get`, elements
recursively `_wrapForHost`-wrapped). It is registered in `_hostProxyReverse` → raw
vec, so the existing `__extern_method_call` mutation path
(`scopeStack.push(...)` → `__vec_push`) still recovers the live vec and grows it;
reads are live (not a snapshot), so a later push is reflected. Native generic
`Array.prototype` methods, iteration, spread and `JSON.stringify` all work via the
length/index traps. Routed at the top of `_wrapForHost` on the positive `__is_vec`
discriminator so every consumer sees array semantics uniformly.

After this, `CallExpression.arguments` / `ArrayExpression.elements` present as real
JS arrays (correct `length`, `Array.isArray` true) instead of `{}`.

### Scope / what this does NOT close
This is **layer 1 of 2** for #2801. It does **not** close #2801: a second, distinct
substrate bug remains (carved as **#2806**, which **blocks #2801**) — acorn's
node-arrays lower to a *numeric (f64)* vec at the array-literal site, so pushed AST
node references coerce to `0` (arguments → `[0, 0]`). That is a vec
element-representation / type-inference issue with broad blast radius, routed to an
architect for a representation-policy spec. **#2801 stays open.**

### Risk / validation
Broad-impact host-proxy marshaling — requires the **full `merge_group` +
standalone-floor** re-validation (vec fields across all modules now present as
arrays). Two-layer root-cause analysis is recorded in
`plan/issues/2801-...md` (`## Implementation Notes`) and `plan/issues/2806-...md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
