### PR TITLE
release: v0.59.0

### DIFF
--- a/docs/releases/0.59.0.md
+++ b/docs/releases/0.59.0.md
@@ -1,0 +1,44 @@
+# v0.59.0
+
+_Released 2026-06-28._
+
+## Highlight — Native Messaging transpiled-`.js` fix (loopdive/js2#389)
+
+**#2754** — a `bun build` / esbuild **type-stripped + bundled** `.js` of the
+synchronous Native-Messaging hosts no longer compiles to a zero-output module.
+Root cause: stripping the types made the injected `readSync`/`writeSync`
+callbacks `any`, so the call went through dynamic dispatch, whose funcref
+wrapper was registered _after_ the call site — the call lowered to a null
+reference and the callbacks were never invoked. The wrappers are now
+pre-registered regardless of compile order.
+
+Verified by hand byte-exact at **1 / 64 / 128 MiB** on the reporter's exact
+`bun build --target node` flow under **real wasmtime v46** for `nm_deno`,
+`nm_node_fs`, and the raw-WASI host. (The async `nm_node_process` host is
+byte-exact to 64 MiB; a ≥128 MiB buffer-growth bug is tracked in #2807.) The fix
+ships with a CI round-trip test (esbuild-bundled, in-process) that asserts a
+real byte-exact echo; switching that to **bun** + **real wasmtime** at scale for
+all variants is the #2807 follow-up.
+
+## Features
+
+- **#2783** — general `--link <namespace>` dynamic-linking flag (replaces
+  `--link-node-shims`; `--link node:fs` is the only spelling).
+- **#2784 / #2681** — native-vec-aware method + element dispatch.
+- **#2792** — `symbol[]` out-of-bounds → `undefined`, plus a native standalone
+  `__box_symbol`.
+- **#2788** — hybrid IR no-box NUMBER-local gate.
+
+## Notable fixes
+
+- **#2795** — `console.log` applies `ToString`/`ToPrimitive` and renders
+  booleans as `true`/`false`.
+- **#2801** — WasmGC vec fields are presented to the host as real JS arrays.
+- **#2804** — object spread & `Object.assign` copy both keys and values.
+- **#2787** — packed-i32 array read-side soundness (overflow/`-0` demoted to f64).
+- **#2777** — O(n) `process.stdin` byte accumulation.
+- **#2786** — server-side auto-enqueue as the single merge-queue enqueuer.
+- Toolchain: pinned wasmtime to **v46.0.1** (its `array.copy` fix makes
+  large-frame echo ~60× faster than v44).
+
+**Full changelog:** https://github.com/loopdive/js2/compare/v0.58.0...v0.59.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.58.0",
+  "version": "0.59.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js2wasm",
-  "version": "0.58.0",
+  "version": "0.59.0",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC (unscoped proxy for @loopdive/js2)",
   "keywords": [
     "webassembly",


### PR DESCRIPTION
Minor release (new features since 0.58.0, so not a patch).

**Headline (loopdive/js2#389):** #2754 — transpiled-`.js` Native-Messaging zero-output fix. Verified on the reporter's exact `bun build --target node` flow under real wasmtime v46: nm_deno / nm_node_fs / nm_wasi_p1 byte-exact at 1/64/128 MiB; nm_node_process byte-exact to 64 MiB (a separate ≥128 MiB async buffer-growth bug is tracked in #2807).

**New features since 0.58.0:** general `--link <namespace>` flag (#2783, `--link-node-shims` alias removed); native-vec method/element dispatch (#2784/#2681); `symbol[]` support (#2792); IR no-box NUMBER-local gate (#2788). Plus accumulated fixes.

After this merges, push tag `v0.59.0` to trigger the OIDC publish (verify-version gates tag == both package.json).