### PR TITLE
fix(#2758): eager-box caller-scope captures mutated by a called sibling (dstr init-skipped)

### DIFF
--- a/plan/issues/2758-dstr-default-side-effect-skipped-arm.md
+++ b/plan/issues/2758-dstr-default-side-effect-skipped-arm.md
@@ -1,7 +1,9 @@
 ---
 id: 2758
 title: "Object/array-pattern default-init side-effect runs when element is present (init-skipped) — call default eagerly evaluated / closure-box in skipped arm"
-status: ready
+status: done
+assignee: ttraenkler/dstr758
+completed: 2026-06-28
 created: 2026-06-28
 updated: 2026-06-28
 priority: medium
@@ -85,3 +87,74 @@ Broad closure-box surface → full `merge_group` floor + paired baseline diff
 
 Owner-claim released on the orphan ref (reserved only to allocate the id) — claim
 fresh via `claim-issue.mjs 2758 ttraenkler/<you> --branch …`.
+
+## Root-cause (verified)
+
+**Diagnosis: (b) — the captured-var box, NOT eager default evaluation.** Verified
+on `origin/main` @ `0a67b9a` by running the real runner
+(`runTest262File` on `obj-ptrn-id-init-skipped.js`) → `fail` on baseline,
+`pass` with the fix; and by WAT inspection.
+
+The test262 runner wraps the whole test body in `export function test()`, so
+`var initCount`, `function counter()` (which does `initCount += 1`) and
+`function f({ w = counter(), … })` all become **nested** in `test()`.
+`counter` mutably captures `initCount`; `f` ALSO captures `initCount` (its body
+reads it in `assert.sameValue(initCount, 0)`) **and** calls `counter` in its
+parameter defaults.
+
+`f`'s capture of `initCount` is by-VALUE (`f64` leading param) — `f`'s body never
+*directly* writes it. But because `f` calls `counter` (which mutates it), the
+call-site **lazy capture-box** machinery (`calls.ts` `nestedFuncCaptures`
+mutable branch, ~L12904) wraps `initCount` in a `struct (field (mut f64))` ref
+cell, stores it in a `$__boxed_initCount` local, and re-aims **all** of `f`'s
+reads of `initCount` to `struct.get` on that box. The box's `struct.new` /
+`local.tee` was emitted into **whatever body buffer was active at the first
+capturing call site** — and that first call site is `w = counter()`, inside the
+default's `__extern_is_undefined`-guarded `then`-arm.
+
+When the property is PRESENT (`null`/`0`/`false`/`''`), §13.3.3.7 step 6 means
+the default is correctly skipped — the `then`-arm does not run — so the box is
+**never created**. `f`'s later read `local.get $__boxed_initCount` finds it
+**null**, and the null-box read lowers to the sNaN sentinel
+(`i64.const 9218868440963334366; f64.reinterpret_i64`) → `initCount` reads NaN
+(WAT `$f` tail, the `if (result f64) (then <sNaN>) (else struct.get)`). The
+bindings (`w === null`, …) are correct — so asserts #1–#4 pass and only assert
+#5 (`initCount === 0`) fails, exactly as observed. The default call is **not**
+evaluated eagerly; `counter` never runs.
+
+This is the same class of bug #2692 fixed for the **declaring** scope
+(`emitEagerCaptureBoxes`), but in the **caller** scope: #2692 eagerly boxes vars
+captured by functions *declared* here; it does not cover a function that merely
+*calls* a sibling whose mutable capture it shares.
+
+## Fix
+
+`src/codegen/statements/nested-declarations.ts` — new
+`emitEagerNestedCallCaptureBoxes`, called in `compileNestedFunctionDeclaration`'s
+has-captures branch **before** `emitDefaultParamInit` / `destructureParamObject`.
+For each by-VALUE capture of the function that a referenced sibling (scanned in
+the body **and** the parameter default initializers) *mutably* captures, it
+materializes the ref-cell box at the unconditional function-top (mirroring
+#2692). The later default-arm call then takes its already-boxed branch (no second
+`struct.new`), and the body read derefs a live box holding the by-value capture's
+entry value. Same `__boxed_<name>` + lockstep `boxedCaptures`/`localMap`
+convention. Narrowing matches #2692: skips `mutable` (already a box param),
+`alreadyBoxed` (outer cell threaded through), and `hasTdzFlag` (`let`/`const`
+— eager-boxing races their block-scoped re-decl, the for-await regression
+rationale). `var`/param by-value captures only — exactly the captured-counter
+template.
+
+## Test Results (scoped, fix ON vs OFF on current main)
+
+- Real `obj-ptrn-id-init-skipped.js` via `runTest262File`: OFF=`fail`, ON=`pass`.
+- All 276 `*-init-skipped` (language/): OFF pass=180, **ON pass=222 (+42)**, no
+  new compile errors (ce=2 both).
+- for-await/for-of dstr `init`/`dflt` (677): OFF pass=415, **ON pass=439 (+24)**,
+  no regressions.
+- Non-skipped `-id-init` (defaults FIRE, 276): unchanged 271/271 both — no
+  regression.
+- Local vitest: `issue-2692-closure-box-eager`, `issue-2669`, `issue-1128-dstr-tdz`,
+  `issue-2158`, `issue-2512`, `issue-2545`, `issue-2567`, `issue-2568` all green;
+  pre-existing harness-import `LinkError`s in `illegal-cast-closures-585` and the
+  destructuring/generator batch are identical OFF and ON (not regressions).
+- New guard `tests/issue-2758.test.ts` — 3 cases green.

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -778,6 +778,20 @@ export function compileNestedFunctionDeclaration(
       })),
     );
 
+    // (#2758) Pre-box any by-value capture that a sibling this function CALLS
+    // mutably captures, BEFORE the parameter default-init / destructuring below
+    // can emit that call inside a conditionally-executed default `then`-arm.
+    // Collect callee references from BOTH the body AND the parameter default
+    // initializers — a destructuring default `{ w = counter() }` calls `counter`
+    // from the PARAMETER list, which the body-only `referencedNames` scan misses.
+    {
+      const referencedCalleeNames = new Set<string>(referencedNames);
+      for (const p of stmt.parameters) {
+        collectReferencedIdentifiers(p, referencedCalleeNames, ownLocals);
+      }
+      emitEagerNestedCallCaptureBoxes(ctx, liftedFctx, captures, referencedCalleeNames);
+    }
+
     // Emit default-value initialization for parameters with initializers
     // (offset by number of captures since they are prepended as leading params)
     emitDefaultParamInit(ctx, liftedFctx, stmt, paramTypes, captures.length);
@@ -1228,6 +1242,104 @@ function emitEagerCaptureBoxes(ctx: CodegenContext, fctx: FunctionContext, funcN
     fctx.localMap.set(cap.name, boxedLocalIdx);
     if (!fctx.boxedCaptures) fctx.boxedCaptures = new Map();
     fctx.boxedCaptures.set(cap.name, { refCellTypeIdx, valType: cap.valType });
+  }
+}
+
+/**
+ * (#2758) Eagerly materialize the ref-cell box for a by-VALUE capture of THIS
+ * nested function when a sibling nested function it *calls* mutably captures the
+ * same variable.
+ *
+ * Companion to `emitEagerCaptureBoxes` (#2692). That pass fixes the DECLARING
+ * scope: a var captured by a nested function declared here is boxed at this
+ * function's top. This pass fixes the CALLER scope: when THIS function
+ * (`function f({ w = counter() }) { …; use initCount; }`) merely *calls* a
+ * sibling (`counter`) that mutably captures an outer `var` (`initCount`) which
+ * THIS function ALSO captures and reads, the call-site lazy-box machinery
+ * (`calls.ts` `nestedFuncCaptures` mutable branch) creates the ref cell at the
+ * FIRST capturing call site — and for a destructuring/default param that first
+ * call site sits inside a conditionally-executed buffer (the default's
+ * `then`-arm). When the property is PRESENT the default is skipped, the box is
+ * never created, and the later body read of the captured var
+ * (`assert.sameValue(initCount, 0)`) dereferences the still-null box → the sNaN
+ * sentinel → NaN. That is the `*-id-init-skipped` family (§13.3.3.7: the
+ * initializer must NOT be evaluated when the property value is present, yet the
+ * captured-var read still corrupted).
+ *
+ * Fix: pre-create the box here, BEFORE the parameter default-init / destructuring
+ * emits any capturing call, so the `struct.new`/`local.set` lands in the
+ * UNCONDITIONAL function-top `liftedFctx.body`. The later call site then takes
+ * its already-boxed branch (no second `struct.new`), and the body read
+ * dereferences a live box holding the by-value capture's entry value. Same
+ * `__boxed_<name>` local-naming + lockstep `boxedCaptures` / `localMap` writes
+ * as the call site, so the two stay in sync.
+ *
+ * Scope-narrowing (mirrors #2692): SKIP captures that are already `mutable`
+ * (boxed as a ref-cell param), already a threaded outer cell (`alreadyBoxed`),
+ * or TDZ-flagged (`let`/`const` — eager boxing races their block-scoped
+ * re-declaration, the #2692 for-await regression rationale). Only `var`/param
+ * by-value captures qualify — exactly the captured-counter template. The
+ * ref-cell value type is taken from the CALLEE's recorded mutable-capture
+ * valType so the registered `refCellTypeIdx` matches the one the lazy call site
+ * will look up (guaranteeing its already-boxed branch fires).
+ */
+function emitEagerNestedCallCaptureBoxes(
+  ctx: CodegenContext,
+  liftedFctx: FunctionContext,
+  captures: ReadonlyArray<{
+    name: string;
+    type: ValType;
+    mutable: boolean;
+    alreadyBoxed: boolean;
+    hasTdzFlag: boolean;
+  }>,
+  referencedCalleeNames: ReadonlySet<string>,
+): void {
+  for (const cap of captures) {
+    // Same narrowing as the #2692 eager pass: only plain by-value `var`/param
+    // captures. Mutable → already a box param; alreadyBoxed → outer cell threaded
+    // through; hasTdzFlag → `let`/`const`, eager boxing races the re-declaration.
+    if (cap.mutable || cap.alreadyBoxed || cap.hasTdzFlag) continue;
+    // Find a referenced sibling that mutably captures this same name, and adopt
+    // ITS ref-cell value type so our refCellTypeIdx matches the lazy call-site's.
+    let calleeValType: ValType | undefined;
+    for (const g of referencedCalleeNames) {
+      const gCaps = ctx.nestedFuncCaptures.get(g);
+      if (!gCaps) continue;
+      const m = gCaps.find((c) => c.name === cap.name && c.mutable && c.valType);
+      if (m) {
+        calleeValType = m.valType;
+        break;
+      }
+    }
+    if (!calleeValType) continue;
+    // The box is built from the by-value param via `local.get` (type `cap.type`);
+    // the cell field type must match. Both derive from the SAME outer variable,
+    // so they are equal in practice — guard defensively and skip on any mismatch
+    // (falls back to the prior lazy path rather than emitting an invalid struct).
+    const sameValType =
+      cap.type.kind === calleeValType.kind &&
+      (cap.type.kind !== "ref" && cap.type.kind !== "ref_null"
+        ? true
+        : (cap.type as { typeIdx: number }).typeIdx === (calleeValType as { typeIdx: number }).typeIdx);
+    if (!sameValType) continue;
+    // Don't double-box (a prior pass / sibling already boxed this name).
+    if (liftedFctx.boxedCaptures?.has(cap.name)) continue;
+    const paramIdx = liftedFctx.localMap.get(cap.name);
+    if (paramIdx === undefined) continue;
+    const refCellTypeIdx = getOrRegisterRefCellType(ctx, calleeValType);
+    const boxedLocalIdx = allocLocal(liftedFctx, `__boxed_${cap.name}`, {
+      kind: "ref",
+      typeIdx: refCellTypeIdx,
+    });
+    // `local.set` (not `tee`) — the eager site leaves nothing on the stack; the
+    // later call site re-reads the box via its already-boxed branch.
+    liftedFctx.body.push({ op: "local.get", index: paramIdx });
+    liftedFctx.body.push({ op: "struct.new", typeIdx: refCellTypeIdx });
+    liftedFctx.body.push({ op: "local.set", index: boxedLocalIdx });
+    liftedFctx.localMap.set(cap.name, boxedLocalIdx);
+    if (!liftedFctx.boxedCaptures) liftedFctx.boxedCaptures = new Map();
+    liftedFctx.boxedCaptures.set(cap.name, { refCellTypeIdx, valType: calleeValType });
   }
 }
 

--- a/tests/issue-2758.test.ts
+++ b/tests/issue-2758.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #2758 — Object/array-pattern default-init side effect + captured-var read on
+// the "init-skipped" path (ES2015 §13.3.3.7 KeyedBindingInitialization).
+//
+// When a destructuring PARAMETER default references a nested closure that
+// mutably captures an outer `var` (`counter` ↦ `initCount`), and the function
+// ALSO reads that captured var, the call-site lazy-box machinery used to create
+// the ref-cell box inside the conditionally-executed default `then`-arm. With
+// the property PRESENT the default is skipped, the box was never created, and
+// the later read dereferenced a null box → sNaN/NaN. Fix (#2758): the box is now
+// materialized eagerly at the function top (companion to the #2692 declaring-
+// scope eager-box pass), so the read sees the live by-value capture.
+async function compileAndRun(source: string): Promise<Record<string, Function>> {
+  const result = await compile(source, { skipSemanticDiagnostics: true });
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as unknown as WebAssembly.Imports);
+  return instance.exports as Record<string, Function>;
+}
+
+describe("#2758 — dstr default side effect / captured-var read on init-skipped", () => {
+  it("present falsy props do NOT fire the default and the captured counter stays 0", async () => {
+    // Mirrors test262 language/statements/function/dstr/obj-ptrn-id-init-skipped.js,
+    // wrapped (as the runner does) so initCount/counter are captured locals.
+    const e = await compileAndRun(`
+      export function test(): number {
+        var initCount = 0;
+        function counter() { initCount += 1; }
+        function f({ w = counter(), x = counter(), y = counter(), z = counter() }) {
+          let code = 0;
+          if (w === null) code += 1;
+          if (x === 0) code += 2;
+          if (y === false) code += 4;
+          if (z === "") code += 8;
+          code += initCount * 16;   // initCount must read 0 (not NaN)
+          return code;
+        }
+        return f({ w: null, x: 0, y: false, z: "" });
+      }
+    `);
+    // 1+2+4+8 = 15, with initCount*16 == 0 (present → no default fired).
+    expect(e.test!()).toBe(15);
+  });
+
+  it("captured-var read returns the live value, never the sNaN sentinel", async () => {
+    const e = await compileAndRun(`
+      export function test(): number {
+        var initCount = 0;
+        function counter() { initCount += 1; }
+        function f({ w = counter() }) { return initCount; }
+        return f({ w: null });
+      }
+    `);
+    expect(e.test!()).toBe(0);
+  });
+
+  it("when the property IS undefined the default still fires (initCount mutates within f)", async () => {
+    const e = await compileAndRun(`
+      export function test(): number {
+        var initCount = 0;
+        function counter() { initCount += 1; }
+        function f({ w = counter(), x = counter() }) { return initCount; }
+        // both props undefined → both defaults fire → counter runs twice
+        return f({});
+      }
+    `);
+    expect(e.test!()).toBe(2);
+  });
+});


### PR DESCRIPTION
## #2758 — dstr default-init side effect / captured-var read on init-skipped

### Diagnosis: (b), the captured-var box — NOT eager default evaluation
The test262 runner wraps the test body in `export function test()`, so `var initCount`, `function counter()` (`initCount += 1`) and `function f({ w = counter(), … })` are all **nested**. `f` captures `initCount` by-VALUE (reads it in `assert.sameValue(initCount, 0)`) **and** calls sibling `counter` (which mutably captures it) in its parameter defaults.

The call-site **lazy capture-box** machinery (`calls.ts` `nestedFuncCaptures` mutable branch) wraps `initCount` in a ref cell and re-aims all of `f`'s reads to `struct.get` on that box — but emits the box `struct.new` into whatever buffer is active at the **first** capturing call site, which is `w = counter()`, **inside the default's `__extern_is_undefined`-guarded `then`-arm**. When the property is PRESENT (§13.3.3.7: default correctly skipped) the arm never runs, the box is never created, and `f`'s later read derefs the null box → sNaN sentinel → `initCount` reads **NaN**. The bindings are correct, so asserts #1–#4 pass and only assert #5 fails. `counter` never runs (no eager eval).

Verified on `origin/main` via the real `runTest262File`: baseline `fail`, fix `pass`; confirmed by WAT inspection of `$f`'s tail (`if (result f64) (then <sNaN>) (else struct.get)` over a null `$__boxed_initCount`).

### Fix
`src/codegen/statements/nested-declarations.ts` — new `emitEagerNestedCallCaptureBoxes`, called in `compileNestedFunctionDeclaration`'s has-captures branch **before** param default-init/destructuring. It is the **caller-scope** companion to #2692's declaring-scope `emitEagerCaptureBoxes`: for each by-value capture that a referenced sibling (scanned in the body **and** the parameter default initializers) *mutably* captures, it materializes the ref-cell box at the unconditional function-top. The later default-arm call then takes its already-boxed branch (no second `struct.new`); the body read derefs a live box. Same `__boxed_<name>`/`boxedCaptures`/`localMap` convention and the same narrowing as #2692 (skip `mutable`/`alreadyBoxed`/`hasTdzFlag`) so `let`/`const` and the for-await cluster are untouched.

### Scoped results (fix ON vs OFF on current main)
- Real `obj-ptrn-id-init-skipped.js` via `runTest262File`: **fail → pass**.
- All 276 `*-init-skipped` (language/): **+42** (pass 180 → 222), no new compile errors.
- for-await/for-of dstr `init`/`dflt` (677): **+24** (pass 415 → 439), no regressions.
- Non-skipped `-id-init` (defaults FIRE, 276): unchanged 271/271 — no regression.
- Local vitest `issue-2692-closure-box-eager` / `issue-2669` / `issue-1128-dstr-tdz` / `issue-2158` / `issue-2512` / `issue-2545` / `issue-2567` / `issue-2568` green; pre-existing harness-import `LinkError`s identical OFF and ON.
- New guard `tests/issue-2758.test.ts` (3 cases).

Broad closure-box surface → relies on the `merge_group` floor + paired baseline diff for full validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS