### PR TITLE
fix(#2769): for-of typed in-bounds undefined/hole default-init

### DIFF
--- a/plan/issues/2769-forof-typed-inbounds-undefined-default.md
+++ b/plan/issues/2769-forof-typed-inbounds-undefined-default.md
@@ -1,8 +1,9 @@
 ---
 id: 2769
 title: "[ARCH] for-of typed in-bounds undefined/hole default-init — representation-level carve (split from #2669)"
-status: in-progress
+status: done
 assignee: ttraenkler/forof769
+completed: 2026-06-28
 created: 2026-06-28
 updated: 2026-06-28
 priority: medium

--- a/plan/issues/2769-forof-typed-inbounds-undefined-default.md
+++ b/plan/issues/2769-forof-typed-inbounds-undefined-default.md
@@ -1,7 +1,8 @@
 ---
 id: 2769
 title: "[ARCH] for-of typed in-bounds undefined/hole default-init — representation-level carve (split from #2669)"
-status: ready
+status: in-progress
+assignee: ttraenkler/forof769
 created: 2026-06-28
 updated: 2026-06-28
 priority: medium

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -119,6 +119,32 @@ function _isUndefinedLike(node: ts.Node): boolean {
   );
 }
 
+// (#2769) Does an inner array literal carry an `undefined`/`void`/hole element
+// whose identity must survive construction? Used ONLY under the scoped
+// `_forOfPreserveUndefElem` flag (for-of over a direct array literal whose
+// binding pattern has an element default / nested sub-pattern). Returns true
+// when the literal is syntactically hole/undefined-bearing, OR its inferred TS
+// element type carries `Undefined|Void` (covers `nested-array/obj-undefined-own`
+// templates). Numeric/object literals like `[7]` return false → keep their
+// existing numeric-vec backing (no perturbation; the default correctly does NOT
+// fire for an in-bounds present value).
+function arrayLiteralCarriesUndefined(ctx: CodegenContext, arr: ts.ArrayLiteralExpression): boolean {
+  // Syntactic: any element is a hole (`[,]`) or an explicit `undefined`-like.
+  if (arr.elements.some((el) => ts.isOmittedExpression(el) || _isUndefinedLike(el))) return true;
+  // Typed: the literal's inferred element type(s) carry Undefined|Void.
+  const t = ctx.checker.getTypeAtLocation(arr);
+  const elemTypes = ctx.checker.getTypeArguments(t as ts.TypeReference);
+  const carries = (et: ts.Type | undefined): boolean => {
+    if (!et) return false;
+    if ((et.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void)) !== 0) return true;
+    if (et.isUnion?.()) {
+      return (et as ts.UnionType).types.some((m) => (m.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void)) !== 0);
+    }
+    return false;
+  };
+  return elemTypes.some(carries);
+}
+
 /**
  * Ensure that a struct registered for an object literal includes fields for
  * computed property names that TypeScript cannot statically resolve.
@@ -3430,6 +3456,29 @@ export function compileArrayLiteral(
         }
       }
     }
+  }
+  // (#2769) for-of over a direct array LITERAL whose binding pattern has an
+  // element default / nested sub-pattern: the OUTER literal must not coerce an
+  // inner `[undefined]` / `[hole]` array down to a numeric vec (the leaf
+  // `undefined`/`void` maps to i32 → `resolveWasmType(undefined[])` = `__vec_i32`,
+  // so the inner `[undefined]` — built fresh as `__vec_externref` — is COERCED to
+  // `__vec_i32` → `__unbox_number` → `i32.trunc_sat_f64_s` → 0, destroying the
+  // undefined identity at CONSTRUCTION; the vec-destructure then never fires the
+  // default). When the scoped `_forOfPreserveUndefElem` flag is set (set by
+  // compileForOfArray around the subject compile) AND the first element is an
+  // array literal that carries undefined/void/hole, re-key the OUTER element type
+  // to an externref vec so the inner undefined/$Hole survives to the EXISTING
+  // wantUndefinedSentinel / __extern_is_undefined read path. ZERO read-path edits;
+  // NO resolveWasmType change (that is what avoids the PR #2226 global-backing
+  // regressions). The flag is tightly scoped (set→subject→clear), so unrelated
+  // array literals are byte-identical.
+  if (
+    (ctx as any)._forOfPreserveUndefElem &&
+    ts.isArrayLiteralExpression(firstElem) &&
+    arrayLiteralCarriesUndefined(ctx, firstElem)
+  ) {
+    const innerVecIdx = getOrRegisterVecType(ctx, "externref", { kind: "externref" });
+    elemWasm = { kind: "ref_null", typeIdx: innerVecIdx };
   }
   elemKind = elemWasm.kind === "ref" || elemWasm.kind === "ref_null" ? `ref_${elemWasm.typeIdx}` : elemWasm.kind;
   const vecTypeIdx = getOrRegisterVecType(ctx, elemKind, elemWasm);

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -119,30 +119,23 @@ function _isUndefinedLike(node: ts.Node): boolean {
   );
 }
 
-// (#2769) Does an inner array literal carry an `undefined`/`void`/hole element
-// whose identity must survive construction? Used ONLY under the scoped
-// `_forOfPreserveUndefElem` flag (for-of over a direct array literal whose
-// binding pattern has an element default / nested sub-pattern). Returns true
-// when the literal is syntactically hole/undefined-bearing, OR its inferred TS
-// element type carries `Undefined|Void` (covers `nested-array/obj-undefined-own`
-// templates). Numeric/object literals like `[7]` return false → keep their
-// existing numeric-vec backing (no perturbation; the default correctly does NOT
-// fire for an in-bounds present value).
-function arrayLiteralCarriesUndefined(ctx: CodegenContext, arr: ts.ArrayLiteralExpression): boolean {
-  // Syntactic: any element is a hole (`[,]`) or an explicit `undefined`-like.
-  if (arr.elements.some((el) => ts.isOmittedExpression(el) || _isUndefinedLike(el))) return true;
-  // Typed: the literal's inferred element type(s) carry Undefined|Void.
-  const t = ctx.checker.getTypeAtLocation(arr);
-  const elemTypes = ctx.checker.getTypeArguments(t as ts.TypeReference);
-  const carries = (et: ts.Type | undefined): boolean => {
-    if (!et) return false;
-    if ((et.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void)) !== 0) return true;
-    if (et.isUnion?.()) {
-      return (et as ts.UnionType).types.some((m) => (m.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void)) !== 0);
-    }
-    return false;
-  };
-  return elemTypes.some(carries);
+// (#2769) Is this inner array literal `undefined`/`void`/hole-ONLY — i.e. it
+// would naturally build an externref-backed vec (every element falls into the
+// `_isUndefinedLike`/omitted branch of compileArrayLiteral) BUT
+// `resolveWasmType(its TS type)` lowers it to a numeric (`__vec_i32`/`__vec_f64`)
+// vec, so the OUTER literal coerces it and destroys the undefined/$Hole identity
+// at construction? Used ONLY under the scoped `_forOfPreserveUndefElem` flag.
+//
+// Narrowly the undefined/hole-ONLY case: a HETEROGENEOUS inner like
+// `[10, undefined]` already builds an `__vec_f64` via the existing sNaN-sentinel
+// path (and the OUTER derives `__vec_f64` too → they match, no coercion), so
+// re-keying THAT to externref would instead BREAK it (mismatched vec→vec
+// coercion → NaN). Empty inners (`[]`) are out-of-bounds, handled by the
+// existing default path — also excluded (length 0). Numeric/object literals like
+// `[7]` return false → byte-identical numeric-vec backing.
+function arrayLiteralIsUndefinedOrHoleOnly(arr: ts.ArrayLiteralExpression): boolean {
+  if (arr.elements.length === 0) return false;
+  return arr.elements.every((el) => ts.isOmittedExpression(el) || _isUndefinedLike(el));
 }
 
 /**
@@ -3475,7 +3468,7 @@ export function compileArrayLiteral(
   if (
     (ctx as any)._forOfPreserveUndefElem &&
     ts.isArrayLiteralExpression(firstElem) &&
-    arrayLiteralCarriesUndefined(ctx, firstElem)
+    arrayLiteralIsUndefinedOrHoleOnly(firstElem)
   ) {
     const innerVecIdx = getOrRegisterVecType(ctx, "externref", { kind: "externref" });
     elemWasm = { kind: "ref_null", typeIdx: innerVecIdx };

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -3680,6 +3680,65 @@ function compileForOfArrayFromLocal(
   compileForOfArray(ctx, fctx, stmt, undefined, { vecLocal, vecType });
 }
 
+// (#2769) Does this for-of need the in-bounds undefined/hole sentinel preserved
+// through the OUTER array-literal construction? True ONLY when the subject is a
+// *direct array literal* AND the for-of binding pattern has an element default
+// OR a nested sub-pattern — the exact #2769 template family
+// (`for (const [x = 23] of [[undefined]])`, `[[,]]`, nested-array/obj). When
+// true, compileForOfArray sets the scoped `_forOfPreserveUndefElem` flag around
+// the subject compile so `compileArrayLiteral` re-keys the outer element type to
+// an externref vec (literals.ts), letting the inner undefined/$Hole survive to
+// the existing wantUndefinedSentinel default-check. Plain `for (x of arr)` /
+// non-literal subjects / default-free patterns return false → untouched.
+function forOfDstrNeedsInboundsUndef(stmt: ts.ForOfStatement): boolean {
+  if (!ts.isArrayLiteralExpression(stmt.expression)) return false;
+  // Extract the for-of binding pattern (declaration or assignment form).
+  if (ts.isVariableDeclarationList(stmt.initializer)) {
+    const decl = stmt.initializer.declarations[0];
+    if (decl && (ts.isArrayBindingPattern(decl.name) || ts.isObjectBindingPattern(decl.name))) {
+      return bindingPatternHasDefaultOrNested(decl.name);
+    }
+    return false;
+  }
+  if (ts.isArrayLiteralExpression(stmt.initializer) || ts.isObjectLiteralExpression(stmt.initializer)) {
+    return assignPatternHasDefaultOrNested(stmt.initializer);
+  }
+  return false;
+}
+
+// Declaration-form binding pattern: any element with a default initializer
+// (`[x = 23]`) or a nested array/object sub-pattern (`[[y]]` / `[{z}]`).
+function bindingPatternHasDefaultOrNested(pattern: ts.ArrayBindingPattern | ts.ObjectBindingPattern): boolean {
+  return pattern.elements.some((el) => {
+    if (ts.isOmittedExpression(el)) return false;
+    const be = el as ts.BindingElement;
+    if (be.initializer) return true; // element default
+    return ts.isArrayBindingPattern(be.name) || ts.isObjectBindingPattern(be.name); // nested sub-pattern
+  });
+}
+
+// Assignment-form pattern (`for ([x = 23] of …)` / `for ({a = 1} of …)`): same
+// predicate over the literal AST (`x = 23` is a BinaryExpression with `=`; a
+// nested array/object literal is a sub-pattern).
+function assignPatternHasDefaultOrNested(pattern: ts.ArrayLiteralExpression | ts.ObjectLiteralExpression): boolean {
+  if (ts.isArrayLiteralExpression(pattern)) {
+    return pattern.elements.some((el) => {
+      if (ts.isOmittedExpression(el)) return false;
+      if (ts.isBinaryExpression(el) && el.operatorToken.kind === ts.SyntaxKind.EqualsToken) return true;
+      return ts.isArrayLiteralExpression(el) || ts.isObjectLiteralExpression(el);
+    });
+  }
+  return pattern.properties.some((p) => {
+    if (ts.isShorthandPropertyAssignment(p)) return !!p.objectAssignmentInitializer; // {a = 1}
+    if (ts.isPropertyAssignment(p)) {
+      const init = p.initializer;
+      if (ts.isBinaryExpression(init) && init.operatorToken.kind === ts.SyntaxKind.EqualsToken) return true;
+      return ts.isArrayLiteralExpression(init) || ts.isObjectLiteralExpression(init);
+    }
+    return false;
+  });
+}
+
 /** Compile for...of over an array using index-based loop (existing behavior) */
 function compileForOfArray(
   ctx: CodegenContext,
@@ -3695,7 +3754,17 @@ function compileForOfArray(
   // #1919 — snapshot so a non-array receiver rolls back body + locals + imports
   // before reporting. With `preVec` no compile happens, so rollback is a no-op.
   const snap = snapshotSpeculative(ctx, fctx);
+  // (#2769) Preserve in-bounds undefined/hole identity through the OUTER
+  // array-literal construction for the spec'd for-of-dstr template family. The
+  // flag is scoped tightly to the subject compile (set→compile→restore) so it
+  // can't leak into unrelated array literals; `iterableOverride` (`.values()`
+  // receiver) and `preVec` paths are not direct array literals, so the gate is
+  // false for them.
+  const preserveUndefElem = !preVec && !iterableOverride && forOfDstrNeedsInboundsUndef(stmt);
+  const prevPreserveUndefElem = (ctx as any)._forOfPreserveUndefElem;
+  if (preserveUndefElem) (ctx as any)._forOfPreserveUndefElem = true;
   const vecType = preVec ? preVec.vecType : compileExpression(ctx, fctx, iterableOverride ?? stmt.expression);
+  if (preserveUndefElem) (ctx as any)._forOfPreserveUndefElem = prevPreserveUndefElem;
   if (!vecType || (vecType.kind !== "ref" && vecType.kind !== "ref_null")) {
     rollbackSpeculative(ctx, fctx, snap);
     reportError(ctx, stmt, "for-of requires an array expression");


### PR DESCRIPTION
## Summary

Fixes #2769 — `for (const [x = 23] of [[undefined]])` (and the `[[,]]` hole form) bound `x` to `0` instead of firing the destructuring default (`x = 23`).

## Root cause

The OUTER `compileArrayLiteral` derives its element type from the first inner element `[undefined]`: `resolveWasmType(undefined[])` = `(ref __vec_i32)` (the leaf `undefined`/`void` maps to i32). The inner `[undefined]` naturally builds as `__vec_externref` (preserving `undefined`), but the outer element loop compiles it with the i32-vec hint, **coercing** `__vec_externref → __vec_i32` (`__unbox_number` → `i32.trunc_sat_f64_s` → `0`). The undefined identity is destroyed **at construction**, so the vec-destructure sees an i32 inner elem, `wantUndefinedSentinel` is false, and `x` binds `0`.

## Fix (representation-level, scoped — no `resolveWasmType` change)

Under a tightly-scoped `_forOfPreserveUndefElem` flag, set by `compileForOfArray` only around the for-of **subject** compile (set → compile → restore), re-key the OUTER literal's inner element type to an **externref vec** so the inner `undefined`/`$Hole` survives. The EXISTING `wantUndefinedSentinel` / `__extern_is_undefined` read path then fires the default. **Zero read-path edits. No `resolveWasmType` / `mapTsTypeToWasm` change** — this is what avoids the PR #2226 global-backing regressions (the architect explicitly routed away from both the `resolveWasmType` widen and the tuple route).

Two edits:
- `src/codegen/statements/loops.ts` — gate (`forOfDstrNeedsInboundsUndef`): subject is a direct array literal **AND** the binding pattern has an element default OR a nested sub-pattern (declaration + assignment forms). Sets/restores the scoped flag around the subject compile only.
- `src/codegen/literals.ts` — when the flag is set AND the first element is an array literal that is **undefined/hole-ONLY** (`arrayLiteralIsUndefinedOrHoleOnly`), re-key the outer element type to `(ref_null __vec_externref)`.

The trigger is narrowed to undefined/hole-**ONLY** inner literals: that is exactly when the inner naturally builds an externref vec but `resolveWasmType` maps it to a numeric vec. A heterogeneous inner like `[10, undefined]` already builds an `__vec_f64` via the existing sNaN-sentinel path (and the outer derives `__vec_f64` too — they match), so re-keying it would instead **break** it (vec→vec coercion → NaN); it is correctly excluded.

## Validation (scoped — full conformance via merge_group floor per the issue)

- `for (const [x = 23] of [[undefined]])` → **23**
- control `for (const [x = 23] of [[7]])` → **7**
- hole `for (const [x = 23] of [[,]])` → **23**
- nested `for (const [[y = 23] = []] of [[undefined]])` → **23**
- heterogeneous `for (const [a=1,b=2] of [[10, undefined]])` → **12** (no regression)
- assignment-form `for ([[x]] of [[undefined]])` → throws TypeError (counter stays 0)
- 24 existing for-of/destructuring tests + 48 dstr-default/array tests green; `tsc --noEmit`, biome lint, prettier all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)