### PR TITLE
refactor(examples): rename Native-Messaging hosts to nm_js2wasm_<variant> (#389)

### DIFF
--- a/examples/native-messaging/NODE-FS-SHIM.md
+++ b/examples/native-messaging/NODE-FS-SHIM.md
@@ -64,10 +64,10 @@ memory; the bespoke `js2wasm:node-process` shim was retired.)
 Compile the user module:
 
 ```sh
-npx js2wasm examples/native-messaging/nm_node_fs.ts --target wasi --link node:fs -o out
+npx js2wasm examples/native-messaging/nm_js2wasm_node_fs.ts --target wasi --link node:fs -o out
 ```
 
-The emitted `out/nm_node_fs.wasm` imports only `node:fs` (memory + `readSync` +
+The emitted `out/nm_js2wasm_node_fs.wasm` imports only `node:fs` (memory + `readSync` +
 `writeSync`) and carries **no** `wasi_snapshot_preview1` import for the IO path.
 
 (Re)generate the shim:
@@ -88,7 +88,7 @@ committed source. Run the generator once before linking, or call the exported
 import { readFileSync } from "node:fs";
 
 const shimBin = readFileSync("examples/native-messaging/node-fs.wasm");
-const userBin = readFileSync("out/nm_node_fs.wasm");
+const userBin = readFileSync("out/nm_js2wasm_node_fs.wasm");
 
 // Minimal WASI fd_read/fd_write over the shim-owned memory (or use a real WASI).
 let mem = null;
@@ -127,7 +127,7 @@ recompile.
 wasmtime run \
   --preload node:fs=examples/native-messaging/node-fs.wasm \
   --invoke main \
-  out/nm_node_fs.wasm
+  out/nm_js2wasm_node_fs.wasm
 ```
 
 `--preload <name>=<file>` registers the shim under the import module name

--- a/examples/native-messaging/README.md
+++ b/examples/native-messaging/README.md
@@ -12,15 +12,15 @@ script. This directory contains:
 
 ```
 examples/native-messaging/
-  nm_wasi_p1.ts       ← host via RAW wasi_snapshot_preview1 fd_read/fd_write
-  nm_node_fs.ts       ← host via synchronous node:fs readSync/writeSync
-  nm_node_process.ts  ← host via async process.stdin Readable + process.stdout.write
-  nm_deno.ts          ← host via the Deno stdio surface (lands separately)
-  nm_wasi_p3.ts       ← host via the WASI Preview 3 spike (lands separately)
+  nm_js2wasm_wasi_p1.ts       ← host via RAW wasi_snapshot_preview1 fd_read/fd_write
+  nm_js2wasm_node_fs.ts       ← host via synchronous node:fs readSync/writeSync
+  nm_js2wasm_node_process.ts  ← host via async process.stdin Readable + process.stdout.write
+  nm_js2wasm_deno.ts          ← host via the Deno stdio surface (lands separately)
+  nm_js2wasm_wasi_p3.ts       ← host via the WASI Preview 3 spike (lands separately)
   README.md           ← this file
-  nm_node_fs.json     ← Native host manifest template
+  nm_js2wasm_node_fs.json     ← Native host manifest template
   manifest.json       ← Web extension manifest
-  nm_node_fs.sh       ← wasmtime/wasmer wrapper the browser invokes
+  nm_js2wasm_node_fs.sh       ← wasmtime/wasmer wrapper the browser invokes
   background.js       ← MV3 Web extension background `ServiceWorker` script
 ```
 
@@ -35,16 +35,16 @@ What differs is the API each reaches for to touch stdio — and therefore the wa
 imports it emits, whether the read loop is synchronous or event-driven, and which
 runtimes can launch the result. The original report ([loopdive/js2#389](https://github.com/loopdive/js2/issues/389))
 asked for a host that runs under a WASI runtime, "not chasing Node.js" — the raw
-`nm_wasi_p1.ts` is that answer; the others show the same protocol expressed through
+`nm_js2wasm_wasi_p1.ts` is that answer; the others show the same protocol expressed through
 progressively higher-level (and more Node-shaped) surfaces.
 
 | Variant                                      | Host surface                                    | Source import                                                                              | Sync or async                                                  | Emitted wasm imports                                                                       | Runs natively under                                       | Compiles to                                                         |
 | -------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | --------------------------------------------------------- | ------------------------------------------------------------------- |
-| [`nm_wasi_p1.ts`](./nm_wasi_p1.ts)           | Raw WASI Preview 1 syscalls over linear memory  | `wasi_snapshot_preview1` (`fd_read`/`fd_write`) + `wasm:memory` (intrinsic, lowers inline) | **sync** — blocking `fd_read`/`fd_write` loop                  | only `wasi_snapshot_preview1`                                                              | `wasmtime` / `wasmer` / `wazero`                          | standalone WASI P1 command module (owns + exports its own `memory`) |
-| [`nm_node_fs.ts`](./nm_node_fs.ts)           | Node synchronous `node:fs` fd IO                | `node:fs` (`readSync`/`writeSync`)                                                         | **sync** — `readSync`/`writeSync` read-until loop              | only `wasi_snapshot_preview1` (inlined); or a `node:fs` interface with `--link node:fs` | `wasmtime` **and** unmodified under real `node`           | standalone WASI P1 command module (or a `node:fs`-linkable module)  |
-| [`nm_node_process.ts`](./nm_node_process.ts) | Node async streaming stdio                      | `process.stdin` (global) Readable + `process.stdout.write`                                 | **async** — event-driven `'data'`/`'end'`, incremental framing | only `wasi_snapshot_preview1`                                                              | `wasmtime` (drives the injected fd0 reactor / event loop) | standalone WASI P1 command module with an event loop                |
-| [`nm_deno.ts`](./nm_deno.ts)                 | Deno stdio surface (`Deno.stdin`/`Deno.stdout`) | _(lands separately)_                                                                       | sync (`readSync`/`writeSync`)                                  | _(WASI-targeted; filled in when it lands)_                                                 | Deno / a WASI runtime                                     | standalone WASI module                                              |
-| [`nm_wasi_p3.ts`](./nm_wasi_p3.ts)           | WASI Preview 3 async streams                    | _(lands separately)_                                                                       | **async** — P3 stream reads                                    | WASI Preview 3 component interfaces                                                        | a Preview-3 / component-capable runner                    | WASI Preview 3 component                                            |
+| [`nm_js2wasm_wasi_p1.ts`](./nm_js2wasm_wasi_p1.ts)           | Raw WASI Preview 1 syscalls over linear memory  | `wasi_snapshot_preview1` (`fd_read`/`fd_write`) + `wasm:memory` (intrinsic, lowers inline) | **sync** — blocking `fd_read`/`fd_write` loop                  | only `wasi_snapshot_preview1`                                                              | `wasmtime` / `wasmer` / `wazero`                          | standalone WASI P1 command module (owns + exports its own `memory`) |
+| [`nm_js2wasm_node_fs.ts`](./nm_js2wasm_node_fs.ts)           | Node synchronous `node:fs` fd IO                | `node:fs` (`readSync`/`writeSync`)                                                         | **sync** — `readSync`/`writeSync` read-until loop              | only `wasi_snapshot_preview1` (inlined); or a `node:fs` interface with `--link node:fs` | `wasmtime` **and** unmodified under real `node`           | standalone WASI P1 command module (or a `node:fs`-linkable module)  |
+| [`nm_js2wasm_node_process.ts`](./nm_js2wasm_node_process.ts) | Node async streaming stdio                      | `process.stdin` (global) Readable + `process.stdout.write`                                 | **async** — event-driven `'data'`/`'end'`, incremental framing | only `wasi_snapshot_preview1`                                                              | `wasmtime` (drives the injected fd0 reactor / event loop) | standalone WASI P1 command module with an event loop                |
+| [`nm_js2wasm_deno.ts`](./nm_js2wasm_deno.ts)                 | Deno stdio surface (`Deno.stdin`/`Deno.stdout`) | _(lands separately)_                                                                       | sync (`readSync`/`writeSync`)                                  | _(WASI-targeted; filled in when it lands)_                                                 | Deno / a WASI runtime                                     | standalone WASI module                                              |
+| [`nm_js2wasm_wasi_p3.ts`](./nm_js2wasm_wasi_p3.ts)           | WASI Preview 3 async streams                    | _(lands separately)_                                                                       | **async** — P3 stream reads                                    | WASI Preview 3 component interfaces                                                        | a Preview-3 / component-capable runner                    | WASI Preview 3 component                                            |
 
 The bottom two rows are pre-filled descriptively; the comparison test
 **discovers** variant files on disk and picks them up automatically as they land,
@@ -52,7 +52,7 @@ running each that lowers to a standalone WASI command module and asserting the
 byte-identical echo (the P3 component variant, which needs its own runner, is
 skipped gracefully).
 
-> **Why `nm_node_process.ts` writes a `Uint8Array`, not a string.** Its
+> **Why `nm_js2wasm_node_process.ts` writes a `Uint8Array`, not a string.** Its
 > `process.stdin` `'data'` chunks arrive as strings (one char per raw byte), but
 > the framed response is written via `process.stdout.write(uint8Array)` so the
 > binary 4-byte length prefix and any high body byte go out verbatim — a string
@@ -119,7 +119,7 @@ does not need to allocate the full request body at once.
 
 ## The host source
 
-[`nm_node_fs.ts`](./nm_node_fs.ts) follows the reference-host shape
+[`nm_js2wasm_node_fs.ts`](./nm_js2wasm_node_fs.ts) follows the reference-host shape
 guest271314 uses across runtimes:
 
 - **`readMessageLength()` / `readFrameBody()`** — read the 4-byte
@@ -155,13 +155,13 @@ From the repo root (works immediately after `pnpm install`, no build step):
 ```bash
 mkdir -p examples/native-messaging/out
 # Standalone, runs directly under wasmtime — imports ONLY wasi_snapshot_preview1:
-npx tsx src/cli.ts examples/native-messaging/nm_node_fs.ts --target wasi -o examples/native-messaging/out
+npx tsx src/cli.ts examples/native-messaging/nm_js2wasm_node_fs.ts --target wasi -o examples/native-messaging/out
 ```
 
 (Once the package is built — `pnpm run build` — or installed from npm, you can
-use the `js2wasm` bin directly: `npx js2wasm nm_node_fs.ts --target wasi -o out`.)
+use the `js2wasm` bin directly: `npx js2wasm nm_js2wasm_node_fs.ts --target wasi -o out`.)
 
-This produces `out/nm_node_fs.wasm`, a self-contained WASI Preview-1 command
+This produces `out/nm_js2wasm_node_fs.wasm`, a self-contained WASI Preview-1 command
 module: the `node:fs` `readSync`/`writeSync` calls lower **inline** to
 `wasi_snapshot_preview1` `fd_read`/`fd_write`, so the module imports ONLY
 `wasi_snapshot_preview1`, owns + exports its own `memory`, and runs directly under
@@ -173,7 +173,7 @@ module: the `node:fs` `readSync`/`writeSync` calls lower **inline** to
 syscalls:
 
 ```bash
-npx tsx src/cli.ts examples/native-messaging/nm_node_fs.ts --target wasi --link node:fs -o examples/native-messaging/out
+npx tsx src/cli.ts examples/native-messaging/nm_js2wasm_node_fs.ts --target wasi --link node:fs -o examples/native-messaging/out
 ```
 
 The result declares **what** host API it needs (`node:fs`), not how it's
@@ -188,18 +188,18 @@ an external `node:fs` provider; for a drop-in standalone host, prefer `--target
 wasi` alone above.
 
 > The `-o` flag is an **output directory**, not a filename. js2wasm names the
-> output after the input basename (`nm_node_fs.wasm`).
+> output after the input basename (`nm_js2wasm_node_fs.wasm`).
 
-### What is `out/nm_node_fs.imports.js`?
+### What is `out/nm_js2wasm_node_fs.imports.js`?
 
-Alongside `nm_node_fs.wasm`, js2wasm emits **`nm_node_fs.imports.js`** (plus `nm_node_fs.d.ts`).
+Alongside `nm_js2wasm_node_fs.wasm`, js2wasm emits **`nm_js2wasm_node_fs.imports.js`** (plus `nm_js2wasm_node_fs.d.ts`).
 It is the **generated host-imports glue** a compiled module needs when you
 instantiate it from a JavaScript host. It re-exports `createImports`,
 `instantiateBytes`, and `instantiateFromUrl` from the `js2wasm` runtime package,
 wiring up the module's import manifest and string pool:
 
 ```js
-import { instantiateBytes } from "./out/nm_node_fs.imports.js";
+import { instantiateBytes } from "./out/nm_js2wasm_node_fs.imports.js";
 const { instance } = await instantiateBytes(wasmBytes, deps, options);
 instance.exports.main();
 ```
@@ -207,8 +207,8 @@ instance.exports.main();
 For **this** example it is **not used at runtime**: the Native Messaging host
 is a fully standalone `--target wasi` module whose only imports are the WASI
 preview1 syscalls (`fd_read`/`fd_write`), which the runtime — `wasmtime`,
-`wasmer`, `wazero`, or Node's WASI — supplies directly. So the `nm_node_fs.sh`
-wrapper launches `nm_node_fs.wasm` under a WASI runtime and `nm_node_fs.imports.js` is
+`wasmer`, `wazero`, or Node's WASI — supplies directly. So the `nm_js2wasm_node_fs.sh`
+wrapper launches `nm_js2wasm_node_fs.wasm` under a WASI runtime and `nm_js2wasm_node_fs.imports.js` is
 never imported.
 
 The glue file is emitted unconditionally by the compiler because the **same
@@ -219,7 +219,7 @@ WASI path it is a harmless extra artifact you can ignore or delete.
 
 ## Run it under a WASI runtime
 
-`nm_node_fs.sh` wraps the runtime invocation. `wasmtime` is **not bundled** with this
+`nm_js2wasm_node_fs.sh` wraps the runtime invocation. `wasmtime` is **not bundled** with this
 repo — install it from <https://wasmtime.dev> (or use `wasmer` /
 [wazero](https://github.com/tetratelabs/wazero); see
 [`../wasi/README.md`](../wasi/README.md) for the full runtime matrix and how to
@@ -230,7 +230,7 @@ message. The 4-byte prefix below (`\x0d\x00\x00\x00`) declares a 13-byte body
 `{"ping":true}`:
 
 ```bash
-printf '\x0d\x00\x00\x00{"ping":true}' | ./examples/native-messaging/nm_node_fs.sh
+printf '\x0d\x00\x00\x00{"ping":true}' | ./examples/native-messaging/nm_js2wasm_node_fs.sh
 ```
 
 You'll see the host's stderr diagnostic (received-length + decoded body
@@ -282,17 +282,17 @@ the compiled module's linear memory below a 512 MiB cap.
 
 > If you don't have a WASI runtime installed, you can still confirm the module
 > is valid the same way the [`../wasi/README.md`](../wasi/README.md) Node
-> snippet does — `WebAssembly.compile(readFileSync('out/nm_node_fs.wasm'))` — and
+> snippet does — `WebAssembly.compile(readFileSync('out/nm_js2wasm_node_fs.wasm'))` — and
 > drive it against js2wasm's own `buildWasiPolyfill()` for a JS-side
 > round-trip.
 
 ## Wire it into the browser
 
-1. **Build** `out/nm_node_fs.wasm` (above) and make sure `nm_node_fs.sh` is executable
-   (`chmod +x nm_node_fs.sh`).
+1. **Build** `out/nm_js2wasm_node_fs.wasm` (above) and make sure `nm_js2wasm_node_fs.sh` is executable
+   (`chmod +x nm_js2wasm_node_fs.sh`).
 
-2. **Edit `nm_node_fs.json`**:
-   - `path` → the **absolute** path to `nm_node_fs.sh` (browsers require an absolute
+2. **Edit `nm_js2wasm_node_fs.json`**:
+   - `path` → the **absolute** path to `nm_js2wasm_node_fs.sh` (browsers require an absolute
      path and does not set a predictable working directory), and make sure the file is
      set to executable.
    - `allowed_origins` → `chrome-extension://YOUR_EXTENSION_ID/` for the
@@ -303,20 +303,20 @@ the compiled module's linear memory below a 512 MiB cap.
 
    | Platform | Manifest location                                                                                                                             |
    | -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-   | Linux    | `~/.config/google-chrome/NativeMessagingHosts/nm_node_fs.json`                                                                                |
-   | macOS    | `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/nm_node_fs.json`                                                            |
-   | Windows  | a registry key `HKCU\Software\Google\Chrome\NativeMessagingHosts\nm_node_fs` whose default value is the absolute path to the manifest `.json` |
+   | Linux    | `~/.config/google-chrome/NativeMessagingHosts/nm_js2wasm_node_fs.json`                                                                                |
+   | macOS    | `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/nm_js2wasm_node_fs.json`                                                            |
+   | Windows  | a registry key `HKCU\Software\Google\Chrome\NativeMessagingHosts\nm_js2wasm_node_fs` whose default value is the absolute path to the manifest `.json` |
 
    The manifest **filename** must match the host `name` field
-   (`nm_node_fs`). On Windows, `nm_node_fs.sh` won't run directly —
-   use a `run.bat` (`@echo off` + `wasmtime "%~dp0out\nm_node_fs.wasm"`) and point
+   (`nm_js2wasm_node_fs`). On Windows, `nm_js2wasm_node_fs.sh` won't run directly —
+   use a `run.bat` (`@echo off` + `wasmtime "%~dp0out\nm_js2wasm_node_fs.wasm"`) and point
    `path` at the `.bat`.
 
 4. **Connect from the extension.** With the `nativeMessaging` permission in the
    extension manifest:
 
    ```js
-   const port = chrome.runtime.connectNative("nm_node_fs");
+   const port = chrome.runtime.connectNative("nm_js2wasm_node_fs");
    port.onMessage.addListener((msg) => console.log("from host:", msg));
    port.onDisconnect.addListener((_) => {
      console.log("host disconnected");

--- a/examples/native-messaging/compare-memory.mjs
+++ b/examples/native-messaging/compare-memory.mjs
@@ -27,8 +27,8 @@
 //   # auto-download the linux build for the host arch
 //   node examples/native-messaging/compare-memory.mjs --download 44.0.2,45.0.0
 //
-// Sources default to nm_node_fs.ts (this repo's host) and, if present,
-// nm_node_fs_guest.ts. Override with --source LABEL=FILE (repeatable).
+// Sources default to nm_js2wasm_node_fs.ts (this repo's host) and, if present,
+// nm_js2wasm_node_fs_guest.ts. Override with --source LABEL=FILE (repeatable).
 
 import { spawn, spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -315,8 +315,8 @@ async function main() {
 
     // Resolve sources.
     if (opts.sources.length === 0) {
-      opts.sources.push({ label: "ours", file: join(SCRIPT_DIR, "nm_node_fs.ts") });
-      const guest = join(SCRIPT_DIR, "nm_node_fs_guest.ts");
+      opts.sources.push({ label: "ours", file: join(SCRIPT_DIR, "nm_js2wasm_node_fs.ts") });
+      const guest = join(SCRIPT_DIR, "nm_js2wasm_node_fs_guest.ts");
       if (existsSync(guest)) opts.sources.push({ label: "his", file: guest });
     }
 

--- a/examples/native-messaging/manifest.json
+++ b/examples/native-messaging/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "nm-node-fs",
-  "short_name": "nm_node_fs",
+  "short_name": "nm_js2wasm_node_fs",
   "version": "1.0",
   "manifest_version": 3,
   "permissions": ["nativeMessaging"],

--- a/examples/native-messaging/nm_js2wasm_deno.ts
+++ b/examples/native-messaging/nm_js2wasm_deno.ts
@@ -1,7 +1,7 @@
 // Native Messaging host, compiled to standalone WASI by js2wasm — the **Deno**
 // synchronous-stdio variant.
 //
-//   npx js2wasm examples/native-messaging/nm_deno.ts --target wasi -o out
+//   npx js2wasm examples/native-messaging/nm_js2wasm_deno.ts --target wasi -o out
 //
 // `--target wasi` emits a SELF-CONTAINED WASI Preview-1 command module: it
 // imports ONLY `wasi_snapshot_preview1` (fd_read / fd_write), owns + exports its
@@ -13,7 +13,7 @@
 // `Deno.stdout.writeSync` — so the SAME file ALSO runs UNMODIFIED under real
 // `deno` (which provides the `Deno` namespace):
 //
-//   deno run --allow-read --allow-write examples/native-messaging/nm_deno.ts
+//   deno run --allow-read --allow-write examples/native-messaging/nm_js2wasm_deno.ts
 //
 // Deno's stdio primitives are fd-based and synchronous, mapping 1:1 to WASI:
 //
@@ -26,24 +26,24 @@
 // `=== null` works in the standalone module exactly as it does under real Deno.
 //
 // The Native Messaging FRAMING + verbatim streaming itself lives in the shared,
-// host-independent core `nm_sync_framing.ts` (#2778) — this file is just the thin
+// host-independent core `nm_js2wasm_sync_framing.ts` (#2778) — this file is just the thin
 // Deno adapter that injects `Deno.stdin.readSync` / `Deno.stdout.writeSync` into
 // the `runNmHost` seam and runs it with NO re-chunk cap (verbatim byte echo).
-// `nm_node_fs.ts` is the same core injected with `node:fs` IO and a 1 MiB cap;
-// `nm_wasi_p1.ts` is the raw `wasi_snapshot_preview1` `fd_read`/`fd_write` form.
+// `nm_js2wasm_node_fs.ts` is the same core injected with `node:fs` IO and a 1 MiB cap;
+// `nm_js2wasm_wasi_p1.ts` is the raw `wasi_snapshot_preview1` `fd_read`/`fd_write` form.
 // All compile to the SAME pure-WASI-P1 shape; they differ only in which runtime's
 // source-level API they additionally run under, unmodified.
 //
 // The seam is two FUNCTION references (`denoRead` / `denoWrite`), not an object:
 // passing a struct value across the bundled-module boundary traps at runtime
 // under `--target wasi` today, while function references cross cleanly (#2778 —
-// see the note atop `nm_sync_framing.ts`).
+// see the note atop `nm_js2wasm_sync_framing.ts`).
 //
 // Native Messaging protocol: each message is a 4-byte little-endian length prefix
 // followed by a UTF-8 JSON body, exchanged over fd 0 (stdin) / fd 1 (stdout). See
 //   https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging
 
-import { runNmHost } from "./nm_sync_framing";
+import { runNmHost } from "./nm_js2wasm_sync_framing";
 
 // ONE Deno `readSync`: fills the whole buffer it is handed and returns the count,
 // or `null` at EOF (the core treats `null` / `<= 0` as EOF).
@@ -70,7 +70,7 @@ function denoWrite(buf: Uint8Array): void {
   }
 }
 
-// No fd-2 telemetry in the verbatim variant (matches the pre-dedup nm_deno). The
+// No fd-2 telemetry in the verbatim variant (matches the pre-dedup nm_js2wasm_deno). The
 // verbatim path never invokes the diagnostics hook, so this is never called — it
 // exists only to satisfy the shared core's `log` parameter.
 function denoNoLog(declaredLen: number): void {

--- a/examples/native-messaging/nm_js2wasm_node_fs.json
+++ b/examples/native-messaging/nm_js2wasm_node_fs.json
@@ -1,7 +1,7 @@
 {
-  "name": "nm_node_fs",
+  "name": "nm_js2wasm_node_fs",
   "description": "js2wasm Native Messaging host (WASI)",
-  "path": "/ABSOLUTE/PATH/TO/examples/native-messaging/nm_node_fs.sh",
+  "path": "/ABSOLUTE/PATH/TO/examples/native-messaging/nm_js2wasm_node_fs.sh",
   "type": "stdio",
   "allowed_origins": ["chrome-extension://YOUR_EXTENSION_ID_HERE/"]
 }

--- a/examples/native-messaging/nm_js2wasm_node_fs.sh
+++ b/examples/native-messaging/nm_js2wasm_node_fs.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S wasmtime -W gc=y,function-references=y,tail-call=y,exceptions=y /ABSOLUTE/PATH/TO/examples/native-messaging/out/nm_node_fs.wasm
+#!/usr/bin/env -S wasmtime -W gc=y,function-references=y,tail-call=y,exceptions=y /ABSOLUTE/PATH/TO/examples/native-messaging/out/nm_js2wasm_node_fs.wasm
 # Chrome launches the native messaging host by executing this script.
 # Replace /ABSOLUTE/PATH/TO/ above with the real absolute path to this repo.
 #

--- a/examples/native-messaging/nm_js2wasm_node_fs.ts
+++ b/examples/native-messaging/nm_js2wasm_node_fs.ts
@@ -1,7 +1,7 @@
 // Native Messaging host, compiled to standalone WASI by js2wasm — the **node:fs**
 // synchronous-stdio variant.
 //
-//   npx js2wasm examples/native-messaging/nm_node_fs.ts --target wasi -o out
+//   npx js2wasm examples/native-messaging/nm_js2wasm_node_fs.ts --target wasi -o out
 //
 // `--target wasi` ALONE (no `--link node:fs`) emits a SELF-CONTAINED WASI
 // Preview-1 command module: it imports ONLY `wasi_snapshot_preview1` (fd_read /
@@ -17,7 +17,7 @@
 // `writeSync(1,…)` are fd-based (integer fd 0=stdin, 1=stdout), NOT path-based —
 // no filesystem involved; under real node they call the real fs.
 //
-//   npx js2wasm examples/native-messaging/nm_node_fs.ts --target wasi --link node:fs -o out
+//   npx js2wasm examples/native-messaging/nm_js2wasm_node_fs.ts --target wasi --link node:fs -o out
 //
 // is the VARIANT that lowers the same calls to imported `node:fs` shim calls
 // (`node-fs.wat`, which maps them to WASI fd_read / fd_write) — useful when the
@@ -42,19 +42,19 @@
 // A message that already fits in one frame is echoed verbatim.
 //
 // The Native Messaging FRAMING + browser-cap re-chunk streaming itself lives in
-// the shared, host-independent core `nm_sync_framing.ts` (#2778) — this file is
+// the shared, host-independent core `nm_js2wasm_sync_framing.ts` (#2778) — this file is
 // just the thin node:fs adapter that injects `readSync(0,…)` / `writeSync(1,…)`
 // into the `runNmHost` seam and runs it with a **1 MiB re-chunk cap** (the
 // browser per-host->extension-message limit). The re-chunk is this variant's
 // deliberate demo: a body > 1 MiB streams back through a single reused 1 MiB
 // buffer as a sequence of valid <=1 MiB JSON frames, so resident memory stays
-// flat (~a couple MiB) regardless of message size. `nm_deno.ts` injects Deno
+// flat (~a couple MiB) regardless of message size. `nm_js2wasm_deno.ts` injects Deno
 // stdio with NO cap (verbatim echo) into the SAME core.
 //
 // The seam is two FUNCTION references (`nodeFsRead` / `nodeFsWrite`), not an
 // object: passing a struct value across the bundled-module boundary traps at
 // runtime under `--target wasi` today, while function references cross cleanly
-// (#2778 — see the note atop `nm_sync_framing.ts`).
+// (#2778 — see the note atop `nm_js2wasm_sync_framing.ts`).
 //
 // js2wasm support today (#2631):
 //   - stdin  : readSync(0, buf, { offset, length }) does one binary, incremental
@@ -63,7 +63,7 @@
 //              newline; the partial-write loop drains the whole buffer.
 
 import { readSync, writeSync } from "node:fs";
-import { runNmHost } from "./nm_sync_framing";
+import { runNmHost } from "./nm_js2wasm_sync_framing";
 
 // ONE incremental fd=0 read filling the WHOLE buffer it is handed (offset 0,
 // length = buf.length); returns the byte count (0 at EOF — the core treats
@@ -156,7 +156,7 @@ export function main(): void {
   // lowers to a Wasm GLOBAL, and passing that global as the cap argument across
   // the bundled-module call into the shared core mis-lowers under `--target wasi`
   // → a runtime fault (a clean compile, but a fault) — the same class of node:fs
-  // multi-file index-shift gap noted in `nm_sync_framing.ts` (#2778). A local
+  // multi-file index-shift gap noted in `nm_js2wasm_sync_framing.ts` (#2778). A local
   // const (or an inline literal) compiles to a plain `i32.const` operand and is
   // unaffected.
   const frameChunk = 1024 * 1024;

--- a/examples/native-messaging/nm_js2wasm_node_process.ts
+++ b/examples/native-messaging/nm_js2wasm_node_process.ts
@@ -1,11 +1,11 @@
 // Native Messaging host, compiled to standalone WASI by js2wasm — the
 // **`node:process` async-stream** variant.
 //
-//   npx js2wasm examples/native-messaging/nm_node_process.ts --target wasi -o out
+//   npx js2wasm examples/native-messaging/nm_js2wasm_node_process.ts --target wasi -o out
 //
 // This is the faithful Node `process.stdin` / `process.stdout` expression of the
-// host. Where the sibling `nm_node_fs.ts` uses the SYNCHRONOUS `node:fs`
-// `readSync`/`writeSync(fd, …)` primitives, and `nm_wasi_p1.ts` speaks RAW
+// host. Where the sibling `nm_js2wasm_node_fs.ts` uses the SYNCHRONOUS `node:fs`
+// `readSync`/`writeSync(fd, …)` primitives, and `nm_js2wasm_wasi_p1.ts` speaks RAW
 // `wasi_snapshot_preview1` syscalls over linear memory, THIS variant uses the
 // real Node **streaming** stdio surface:
 //

--- a/examples/native-messaging/nm_js2wasm_sync_framing.ts
+++ b/examples/native-messaging/nm_js2wasm_sync_framing.ts
@@ -1,5 +1,5 @@
 // Shared, host-INDEPENDENT Native Messaging synchronous framing/streaming core
-// (#2778). Both `nm_deno.ts` (Deno `readSync`/`writeSync`) and `nm_node_fs.ts`
+// (#2778). Both `nm_js2wasm_deno.ts` (Deno `readSync`/`writeSync`) and `nm_js2wasm_node_fs.ts`
 // (`node:fs` `readSync`/`writeSync`) are now THIN adapters that inject their
 // host's synchronous stdio into the `runNmHost` seam below and call into this one
 // core. This file has ZERO host API surface — it touches `Uint8Array` only, so it
@@ -23,11 +23,11 @@
 //
 // Two framing modes, selected by `maxFrameSize`:
 //
-//   - `maxFrameSize <= 0` → VERBATIM streamer (the `nm_deno` demo): each framed
+//   - `maxFrameSize <= 0` → VERBATIM streamer (the `nm_js2wasm_deno` demo): each framed
 //     message is echoed back byte-for-byte (prefix + body), streamed through a
 //     fixed window so resident memory stays flat regardless of body size.
 //
-//   - `maxFrameSize > 0`  → browser-cap RE-CHUNK streamer (the `nm_node_fs`
+//   - `maxFrameSize > 0`  → browser-cap RE-CHUNK streamer (the `nm_js2wasm_node_fs`
 //     demo): a body LARGER than the cap is split into a sequence of valid
 //     `<=maxFrameSize` JSON frames (`[run]` for an array body, `"run"` for a
 //     string body) whose interiors, concatenated by the receiver, reproduce the
@@ -53,7 +53,7 @@ export type NmWrite = (buf: Uint8Array) => void;
  * the re-chunk path with its declared body length. Kept a callback (not string
  * work in this host-independent core) so the adapter owns the message text + its
  * fd-2 writer; the verbatim path never calls it (it emits no telemetry, matching
- * the pre-dedup nm_deno). A no-op is a valid implementation.
+ * the pre-dedup nm_js2wasm_deno). A no-op is a valid implementation.
  */
 export type NmLog = (declaredLen: number) => void;
 
@@ -160,7 +160,7 @@ function streamLargeString(
   return true;
 }
 
-// VERBATIM port loop (the `nm_deno` demo): read framed messages and echo each one
+// VERBATIM port loop (the `nm_js2wasm_deno` demo): read framed messages and echo each one
 // back byte-for-byte until EOF. The body streams through a fixed window; a frame
 // larger than the window is echoed in window-sized runs (the receiver
 // concatenates raw bytes, so prefix + body are byte-identical to the input).
@@ -197,7 +197,7 @@ function runVerbatim(read: NmRead, write: NmWrite): void {
   }
 }
 
-// RE-CHUNK port loop (the `nm_node_fs` demo): read framed JSON messages and echo
+// RE-CHUNK port loop (the `nm_js2wasm_node_fs` demo): read framed JSON messages and echo
 // each one back as valid JSON within the browser `cap`-byte per-message cap. A
 // body that already fits is echoed verbatim; a larger array/string body is split
 // into valid <=cap frames. Streams through a single reused `cap` buffer.
@@ -326,7 +326,7 @@ function runRechunk(read: NmRead, write: NmWrite, log: NmLog, cap: number): void
  *                     the cross-module-funcref note at the top of this file).
  * @param write        one host `writeSync` (fd 1); writes the whole buffer.
  * @param log          per-frame fd-2 telemetry hook (re-chunk path only); pass a
- *                     no-op when the host emits no diagnostics (e.g. nm_deno).
+ *                     no-op when the host emits no diagnostics (e.g. nm_js2wasm_deno).
  * @param maxFrameSize `<= 0` → verbatim echo (no cap); `> 0` → re-chunk bodies
  *                     larger than this many bytes into valid <=`maxFrameSize`
  *                     JSON frames (the browser per-message cap).

--- a/examples/native-messaging/nm_js2wasm_wasi_p1.ts
+++ b/examples/native-messaging/nm_js2wasm_wasi_p1.ts
@@ -1,7 +1,7 @@
 // Native Messaging host, compiled to standalone WASI by js2wasm — the RAW
 // `wasi_snapshot_preview1` variant.
 //
-//   npx js2wasm examples/native-messaging/nm_wasi_p1.ts --target wasi -o out
+//   npx js2wasm examples/native-messaging/nm_js2wasm_wasi_p1.ts --target wasi -o out
 //
 // This is the MOST honest pure-WASI-Preview-1 expression of the host: it imports
 // `fd_read` / `fd_write` DIRECTLY from `wasi_snapshot_preview1` — the real WASI
@@ -10,7 +10,7 @@
 // module imports ONLY `wasi_snapshot_preview1`, owns + exports its own `memory`,
 // and runs directly under wasmtime.
 //
-// Contrast with the sibling `nm_node_fs.ts`, which uses `node:fs`
+// Contrast with the sibling `nm_js2wasm_node_fs.ts`, which uses `node:fs`
 // `readSync`/`writeSync(fd, …)` — faithful Node fd-based IO that ALSO runs
 // UNMODIFIED under real `node`. This file does NOT run under Node (it speaks raw
 // WASI syscalls over linear memory); it is the pure-WASI counterpart.

--- a/examples/native-messaging/nm_js2wasm_wasi_p3.ts
+++ b/examples/native-messaging/nm_js2wasm_wasi_p3.ts
@@ -14,11 +14,11 @@
 // └────────────────────────────────────────────────────────────────────────────┘
 //
 // Contrast the siblings:
-//   * `nm_wasi_p1.ts`    — WASI **Preview 1**: hand-marshals iovecs through linear
+//   * `nm_js2wasm_wasi_p1.ts`    — WASI **Preview 1**: hand-marshals iovecs through linear
 //                       memory in an explicit `fd_read`/`fd_write` loop. Runs
 //                       today under wasmtime via `--target wasi`.
-//   * `nm_node_fs.ts` — `node:fs` `readSync`/`writeSync(fd, …)`; runs under Node.
-//   * `nm_wasi_p3.ts` — WASI **Preview 3**: the host drives the byte copy over a
+//   * `nm_js2wasm_node_fs.ts` — `node:fs` `readSync`/`writeSync(fd, …)`; runs under Node.
+//   * `nm_js2wasm_wasi_p3.ts` — WASI **Preview 3**: the host drives the byte copy over a
 //                       native `stream<u8>`; the guest just plumbs the stream and
 //                       awaits. The async-lifted entry suspends/resumes via the
 //                       component-model scheduler (the substrate #2646 wants —
@@ -71,7 +71,7 @@ declare function writeViaStream(data: StreamU8): WriteFuture;
 // host pump. No 4-byte-prefix bookkeeping is needed at the syscall layer — a
 // Native Messaging frame is an opaque byte run, and the host copies it through
 // the stream byte-for-byte (prefix + body, including high/null bytes), so the
-// receiver reconstructs framing from the raw bytes exactly as in `nm_wasi_p1.ts`.
+// receiver reconstructs framing from the raw bytes exactly as in `nm_js2wasm_wasi_p1.ts`.
 
 export async function run(): Promise<void> {
   // Obtain the stdin readable stream. The paired read-future is left to the host

--- a/examples/native-messaging/p3-b0-spike/README.md
+++ b/examples/native-messaging/p3-b0-spike/README.md
@@ -53,5 +53,5 @@ run():
 
 The host drives the stdin→stdout copy and the async-lifted `run` suspends at the
 await — exactly the incremental loop-borrow #2646 needs, with no asyncify and no
-pre-drain. Contrast `../nm_wasi_p1.ts` (P1), which hand-marshals iovecs through
+pre-drain. Contrast `../nm_js2wasm_wasi_p1.ts` (P1), which hand-marshals iovecs through
 linear memory in an explicit `fd_read`/`fd_write` loop.

--- a/examples/native-messaging/p3-b0-spike/stream-echo.wat
+++ b/examples/native-messaging/p3-b0-spike/stream-echo.wat
@@ -10,7 +10,7 @@
 ;; The P3 echo is a host-driven stream HAND-OFF: read-via-stream() yields the
 ;; stdin readable stream; hand that same stream to write-via-stream(); the HOST
 ;; pumps stdin->stdout; the guest awaits the returned future<result>. The guest
-;; barely touches the bytes (contrast nm_wasi_p1.ts, which hand-marshals iovecs).
+;; barely touches the bytes (contrast nm_js2wasm_wasi_p1.ts, which hand-marshals iovecs).
 ;;
 ;; STATUS — parses with `jco parse`, but does NOT yet run under wasmtime 44:
 ;;   wasmtime rejects the `future<T>`-typed import at DECODE time:

--- a/examples/native-messaging/run-edge.mjs
+++ b/examples/native-messaging/run-edge.mjs
@@ -16,7 +16,7 @@ import { dirname, resolve } from "node:path";
 import { runWithEdge } from "./edge.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const wasmPath = process.argv[2] ? resolve(process.argv[2]) : resolve(here, "out", "nm_node_fs.wasm");
+const wasmPath = process.argv[2] ? resolve(process.argv[2]) : resolve(here, "out", "nm_js2wasm_node_fs.wasm");
 
 const userBinary = readFileSync(wasmPath);
 await runWithEdge(userBinary, { entry: "main" });

--- a/examples/native-messaging/smoke-test.sh
+++ b/examples/native-messaging/smoke-test.sh
@@ -18,7 +18,7 @@ REPO_ROOT=$(CDPATH= cd -- "$DIR/../.." && pwd)
 OUT_DIR=$(mktemp -d)
 trap 'rm -rf "$OUT_DIR"' EXIT
 
-echo "== Compiling examples/native-messaging/nm_node_fs.ts --target wasi =="
+echo "== Compiling examples/native-messaging/nm_js2wasm_node_fs.ts --target wasi =="
 CLI="$OUT_DIR/js2wasm-cli.mjs"
 # #2631 — the host now uses node:fs readSync/writeSync via the linkable `node:fs`
 # shim, so compile with --link node:fs and build node-fs.wasm to preload.
@@ -26,10 +26,10 @@ SHIM="$OUT_DIR/node-fs.wasm"
 (
   cd "$REPO_ROOT"
   node scripts/build-standalone-cli.mjs --outfile "$CLI"
-  node "$CLI" examples/native-messaging/nm_node_fs.ts --target wasi --link node:fs -o "$OUT_DIR" --quiet
+  node "$CLI" examples/native-messaging/nm_js2wasm_node_fs.ts --target wasi --link node:fs -o "$OUT_DIR" --quiet
   node scripts/build-node-fs-shim.mjs "$SHIM"
 )
-WASM="$OUT_DIR/nm_node_fs.wasm"
+WASM="$OUT_DIR/nm_js2wasm_node_fs.wasm"
 [ -f "$WASM" ] || { echo "FAIL: $WASM was not produced" >&2; exit 1; }
 [ -f "$SHIM" ] || { echo "FAIL: $SHIM was not produced" >&2; exit 1; }
 

--- a/examples/native-messaging/stress-memory.mjs
+++ b/examples/native-messaging/stress-memory.mjs
@@ -20,7 +20,7 @@ const WASMTIME_FLAGS = ["-W", "gc=y,function-references=y,tail-call=y,exceptions
 function usage() {
   console.log(`Usage: node examples/native-messaging/stress-memory.mjs [options]
 
-Builds examples/native-messaging/nm_node_fs.ts, runs it under wasmtime, streams
+Builds examples/native-messaging/nm_js2wasm_node_fs.ts, runs it under wasmtime, streams
 <=1 MiB Native Messaging request frames into stdin, drains framed stdout, and
 samples the wasmtime child RSS.
 
@@ -28,7 +28,7 @@ Options:
   --array-elements N          Send JSON.stringify(Array(N)); default ${DEFAULT_ARRAY_ELEMENTS}
   --reported-64mib           Shortcut for --array-elements ${REPORTED_ARRAY_ELEMENTS}
   --bytes N                  Send N raw patterned bytes instead of a JSON array body
-  --wasm PATH                Use an existing nm_node_fs.wasm instead of building
+  --wasm PATH                Use an existing nm_js2wasm_node_fs.wasm instead of building
   --wasmtime PATH            Runtime binary; default "wasmtime"
   --sample-ms N              RSS sample interval; default 100
   --timeout-ms N             Kill wasmtime if it runs too long; default 180000
@@ -379,11 +379,11 @@ function buildCompilerCli(repoRoot, outDir) {
 }
 
 function buildWasm(repoRoot, outDir) {
-  console.error("== Compiling examples/native-messaging/nm_node_fs.ts --target wasi ==");
+  console.error("== Compiling examples/native-messaging/nm_js2wasm_node_fs.ts --target wasi ==");
   const cli = buildCompilerCli(repoRoot, outDir);
   const result = spawnSync(
     process.execPath,
-    [cli, "examples/native-messaging/nm_node_fs.ts", "--target", "wasi", "-o", outDir, "--quiet"],
+    [cli, "examples/native-messaging/nm_js2wasm_node_fs.ts", "--target", "wasi", "-o", outDir, "--quiet"],
     {
       cwd: repoRoot,
       stdio: "inherit",
@@ -391,7 +391,7 @@ function buildWasm(repoRoot, outDir) {
   );
   if (result.error) throw result.error;
   if (result.status !== 0) throw new Error(`compiler exited with status ${result.status}`);
-  const wasm = join(outDir, "nm_node_fs.wasm");
+  const wasm = join(outDir, "nm_js2wasm_node_fs.wasm");
   if (!existsSync(wasm)) throw new Error(`${wasm} was not produced`);
   return wasm;
 }

--- a/src/codegen/deno-api.ts
+++ b/src/codegen/deno-api.ts
@@ -17,7 +17,7 @@
  * `wasi_snapshot_preview1.fd_read` / `fd_write`, reusing #2655's
  * `ctx.wasiFdReadIdx` / `wasiFdWriteIdx` (no duplicate import) and the
  * iovec/scratch machinery shared with `node-fs-api.ts`. The result: the SAME
- * `nm_deno.ts` source compiles to a self-contained WASI P1 command module
+ * `nm_js2wasm_deno.ts` source compiles to a self-contained WASI P1 command module
  * importing ONLY `wasi_snapshot_preview1`, AND runs unmodified under real Deno.
  *
  * The one intricate part is `readSync`'s `number | null` return. The compiler

--- a/src/codegen/expressions/late-imports.ts
+++ b/src/codegen/expressions/late-imports.ts
@@ -425,7 +425,7 @@ export function ensureLateImport(
   // predated the now-proven standalone path; leaving WASI on the host import
   // leaked an unsatisfiable `env::__extern_get` / `env::__extern_is_undefined`
   // the moment an `any`/externref receiver reached a dynamic `.length` / indexed
-  // read — exactly the bun/tsc-transpiled `nm_deno.js` symptom (the `Uint8Array`
+  // read — exactly the bun/tsc-transpiled `nm_js2wasm_deno.js` symptom (the `Uint8Array`
   // param types were stripped, so `out.length` / `out[i]` lower through the
   // polymorphic dyn-read dispatch whose host-object MISS arm calls
   // `__extern_get`). The Deno `fd_read`/`fd_write` stdio lowering itself already

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -12767,7 +12767,7 @@ function collectExternDeclarations(
       // inline-lowered to poll_oneoff/fd_read by tryWasiTimerCall (calls.ts) when
       // `ctx.wasi`. Registering them as `env.*` host imports here therefore only
       // leaks a spurious "not on the dual-mode allowlist" dropped-import warning
-      // on the otherwise-runnable standalone nm_node_process.ts module
+      // on the otherwise-runnable standalone nm_js2wasm_node_process.ts module
       // (loopdive/js2#389 bug 2). Skip the stub under WASI.
       if (ctx.wasi && WASI_STDIN_REACTOR_INTRINSICS.has(name)) continue;
       // #1663: parseInt / parseFloat have no JS host under WASI / standalone —
@@ -13464,7 +13464,7 @@ function collectDeclaredGlobals(ctx: CodegenContext, libFile: ts.SourceFile, use
     // addImport would drop it AND, because the dropped import leaves no funcMap
     // entry, the `declaredGlobals.set` below never fires either — the whole
     // registration is already a no-op EXCEPT for the spurious "not on the
-    // dual-mode allowlist" warning it emits. nm_node_process.ts trips this via
+    // dual-mode allowlist" warning it emits. nm_js2wasm_node_process.ts trips this via
     // the `String.fromCharCode` receiver in the injected process.stdin prelude
     // (loopdive/js2#389 bug 2: `env.global_String`). Skip it so the standalone
     // module compiles cleanly; bare identity uses already had no host global

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -235,7 +235,7 @@ export function buildVecFromExternref(
   // (`__box_number`, a defined func) and only THEN registered `__array_from_iter`
   // / `__extern_get_idx`, shifting `boxIdx` by one onto `__str_to_number` — which
   // emitted `call $__str_to_number` with an f64 index argument where an externref
-  // is required, producing invalid Wasm (loopdive/js2#389 bug 3, nm_wasi_p3.ts:
+  // is required, producing invalid Wasm (loopdive/js2#389 bug 3, nm_js2wasm_wasi_p3.ts:
   // `type mismatch: expected externref, found f64`). Mirror
   // buildTupleFromIterableFallback's register-all-then-freeze discipline.
   ensureLateImport(ctx, "__extern_length", [{ kind: "externref" }], [{ kind: "f64" }]);

--- a/src/process-stdin-prelude.ts
+++ b/src/process-stdin-prelude.ts
@@ -184,7 +184,7 @@ class __Js2wasmReadable {
   // of building each 'data' chunk via per-byte string concatenation. Building the
   // chunk by \`this.chunk = this.chunk + String.fromCharCode(b)\` made a large
   // frame's read side quadratic (the consumer then re-flattened the growing
-  // cons-rope on every charCodeAt/substring), which SIGKILLed nm_node_process at
+  // cons-rope on every charCodeAt/substring), which SIGKILLed nm_js2wasm_node_process at
   // multi-MiB. The bytes now live in \`buf[head..tail)\`; the chunk STRING the
   // Node 'data' contract delivers is materialised ONCE per emit/read from that
   // slice (a single flatten), so consumers receive a FLAT string and their

--- a/tests/issue-1411-wasi-main-start.test.ts
+++ b/tests/issue-1411-wasi-main-start.test.ts
@@ -7,7 +7,7 @@
  * call), moving init into a standalone `__module_init`. But `addWasiStartExport`
  * was left preferring `__module_init` unconditionally as the `_start` target,
  * so a `--target wasi` program WITH a user `main` (e.g. the Native Messaging
- * host, examples/native-messaging/nm_node_fs.ts) wrapped ONLY `__module_init`
+ * host, examples/native-messaging/nm_js2wasm_node_fs.ts) wrapped ONLY `__module_init`
  * in `_start`: top-level globals were initialised but the user `main()` never
  * ran. Under real wasmtime the program produced no stdout — the
  * native-messaging smoke check went red (FAIL: stdout frame mismatch).

--- a/tests/issue-1530.test.ts
+++ b/tests/issue-1530.test.ts
@@ -1,6 +1,6 @@
 // #1530 — Native Messaging host example compiles to a valid WASI module.
 //
-// The example under examples/native-messaging/nm_node_fs.ts demonstrates reading a
+// The example under examples/native-messaging/nm_js2wasm_node_fs.ts demonstrates reading a
 // Chrome Native Messaging framed message off stdin (fd=0 via process.stdin.read), routing
 // debug to stderr (fd=2 via console.error), and emitting a JSON response on
 // stdout (fd=1). This test pins down that the example still compiles to a valid
@@ -20,12 +20,12 @@ import { compile } from "../src/index.js";
 import { buildNodeFsShim } from "../scripts/build-node-fs-shim.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const hostPath = join(here, "..", "examples", "native-messaging", "nm_node_fs.ts");
+const hostPath = join(here, "..", "examples", "native-messaging", "nm_js2wasm_node_fs.ts");
 
 describe("#1530 Native Messaging host example", () => {
-  it("compiles examples/native-messaging/nm_node_fs.ts under --target wasi", async () => {
+  it("compiles examples/native-messaging/nm_js2wasm_node_fs.ts under --target wasi", async () => {
     const src = readFileSync(hostPath, "utf-8");
-    const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", link: ["node:fs"] });
+    const result = await compile(src, { fileName: "nm_js2wasm_node_fs.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success).toBe(true);
     expect(result.binary.length).toBeGreaterThan(0);
   });
@@ -36,7 +36,7 @@ describe("#1530 Native Messaging host example", () => {
     // interface) and NOT wasi_snapshot_preview1 fd_read/fd_write directly. The
     // shim (node-fs.wat) maps node:fs → WASI; the user module stays host-agnostic.
     const src = readFileSync(hostPath, "utf-8");
-    const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", link: ["node:fs"] });
+    const result = await compile(src, { fileName: "nm_js2wasm_node_fs.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success).toBe(true);
     expect(result.wat).toContain('(import "node:fs" "readSync"'); // fs.readSync(0, …)
     expect(result.wat).toContain('(import "node:fs" "writeSync"'); // fs.writeSync(1|2, …)
@@ -50,7 +50,7 @@ describe("#1530 Native Messaging host example", () => {
 
   it("produces a binary that WebAssembly accepts", async () => {
     const src = readFileSync(hostPath, "utf-8");
-    const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", link: ["node:fs"] });
+    const result = await compile(src, { fileName: "nm_js2wasm_node_fs.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success).toBe(true);
     // Throws on an invalid module; passing means the structure/types are sound.
     expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
@@ -201,7 +201,7 @@ export function main(): void {
 
   it("compiles the shipped example and round-trips it byte-exactly", async () => {
     const src = readFileSync(hostPath, "utf-8");
-    const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", link: ["node:fs"] });
+    const result = await compile(src, { fileName: "nm_js2wasm_node_fs.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success).toBe(true);
 
     // The shipped host echoes the received body verbatim (byte-for-byte, no
@@ -227,7 +227,7 @@ export function main(): void {
   // assert the response is the exact same 1 MiB body with the right prefix.
   it("echoes a 1 MiB framed body byte-exactly (#389 large-message regression)", async () => {
     const src = readFileSync(hostPath, "utf-8");
-    const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", link: ["node:fs"] });
+    const result = await compile(src, { fileName: "nm_js2wasm_node_fs.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success).toBe(true);
 
     const SIZE = 1024 * 1024; // 1 MiB
@@ -266,7 +266,7 @@ export function main(): void {
   // exceeds the 1 MiB cap, and the flattened elements equal the inputs in order.
   it("re-chunks large JSON arrays into valid <=1 MiB JSON frames across one session (#389)", async () => {
     const src = readFileSync(hostPath, "utf-8");
-    const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", link: ["node:fs"] });
+    const result = await compile(src, { fileName: "nm_js2wasm_node_fs.ts", target: "wasi", link: ["node:fs"] });
     expect(result.success).toBe(true);
 
     const CHUNK = 1024 * 1024;

--- a/tests/issue-1753.test.ts
+++ b/tests/issue-1753.test.ts
@@ -14,7 +14,7 @@ import { compile } from "../src/index.js";
 import { buildNodeFsShim } from "../scripts/build-node-fs-shim.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const hostPath = join(here, "..", "examples", "native-messaging", "nm_node_fs.ts");
+const hostPath = join(here, "..", "examples", "native-messaging", "nm_js2wasm_node_fs.ts");
 const ONE_MIB = 1024 * 1024;
 const SIXTY_FOUR_MIB = 64 * ONE_MIB;
 
@@ -24,7 +24,7 @@ async function compileHost(): Promise<Uint8Array> {
   if (!hostBinary) {
     hostBinary = (async () => {
       const src = readFileSync(hostPath, "utf-8");
-      const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", link: ["node:fs"] });
+      const result = await compile(src, { fileName: "nm_js2wasm_node_fs.ts", target: "wasi", link: ["node:fs"] });
       expect(result.success, result.success ? "" : result.errors.map((e) => e.message).join("\n")).toBe(true);
       expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
       return result.binary;

--- a/tests/issue-1767.test.ts
+++ b/tests/issue-1767.test.ts
@@ -14,7 +14,7 @@ import { compile } from "../src/index.js";
 import { buildNodeFsShim } from "../scripts/build-node-fs-shim.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const hostPath = join(here, "..", "examples", "native-messaging", "nm_node_fs.ts");
+const hostPath = join(here, "..", "examples", "native-messaging", "nm_js2wasm_node_fs.ts");
 const ONE_MIB = 1024 * 1024;
 const ARRAY_ELEMENTS_PER_MIB = 209715;
 const REPORTED_ARRAY_ELEMENTS = ARRAY_ELEMENTS_PER_MIB * 64;
@@ -29,7 +29,7 @@ async function compileHost(): Promise<Uint8Array> {
   if (!hostBinary) {
     hostBinary = (async () => {
       const src = readFileSync(hostPath, "utf-8");
-      const result = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", link: ["node:fs"] });
+      const result = await compile(src, { fileName: "nm_js2wasm_node_fs.ts", target: "wasi", link: ["node:fs"] });
       expect(result.success, result.success ? "" : result.errors.map((e) => e.message).join("\n")).toBe(true);
       expect(() => new WebAssembly.Module(result.binary)).not.toThrow();
       return result.binary;

--- a/tests/issue-1768.test.ts
+++ b/tests/issue-1768.test.ts
@@ -14,11 +14,11 @@ import ts from "typescript";
 import { compile } from "../src/index.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const hostPath = join(here, "..", "examples", "native-messaging", "nm_node_fs.ts");
+const hostPath = join(here, "..", "examples", "native-messaging", "nm_js2wasm_node_fs.ts");
 
 async function compileWasiJs(source: string, linkNodeFs = false) {
   return await compile(source, {
-    fileName: "nm_node_fs.js",
+    fileName: "nm_js2wasm_node_fs.js",
     allowJs: true,
     target: "wasi",
     optimize: 0,

--- a/tests/issue-1772-edge-dual-provider.test.ts
+++ b/tests/issue-1772-edge-dual-provider.test.ts
@@ -104,7 +104,7 @@ describe("#1772 — node:fs same-binary dual-provider compatibility", () => {
   it.runIf(hasWasmtime())(
     "provider (a): node-fs.wat under wasmtime echoes the same bytes; both providers agree",
     () => {
-      const wasmPath = join(tmp, "nm_wasi_p1.wasm");
+      const wasmPath = join(tmp, "nm_js2wasm_wasi_p1.wasm");
       const shimPath = join(tmp, "node-fs.wasm");
       writeFileSync(wasmPath, userBinary);
       writeFileSync(shimPath, buildNodeFsShim());

--- a/tests/issue-1886.test.ts
+++ b/tests/issue-1886.test.ts
@@ -351,7 +351,7 @@ describe("#1886 linear-safe Uint8Array analysis", () => {
     // faithful synchronous Node primitives) instead of process.std*.{read,write}.
     // The #1886 analysis recognises readSync(fd, buf, …)/writeSync(fd, buf, …) as
     // byte-I/O buffer sinks (ioBufferArgIndex), so every buffer stays linear-safe.
-    const nmPath = resolve(here, "../examples/native-messaging/nm_node_fs.ts");
+    const nmPath = resolve(here, "../examples/native-messaging/nm_js2wasm_node_fs.ts");
     const src = readFileSync(nmPath, "utf-8");
     const { safeNames, linearParamFns } = analyze(src);
     // Buffers declared in main + the per-frame temporaries + the write buffer
@@ -483,7 +483,7 @@ describe("#1886 Slice B intraprocedural eligibility (localOnlyBindings)", () => 
     // buffer in `logFrameBodyRead`) is built + written entirely within one
     // function and only flows into writeSync (an I/O sink), so it is Slice-B
     // (local-only) eligible.
-    const nmPath = resolve(here, "../examples/native-messaging/nm_node_fs.ts");
+    const nmPath = resolve(here, "../examples/native-messaging/nm_js2wasm_node_fs.ts");
     const src = readFileSync(nmPath, "utf-8");
     const { localOnlyNames } = analyze(src);
     // `bytes` (logFrameBodyRead) is local-only — never threaded into a user fn.

--- a/tests/issue-2521-native-messaging-rechunk.test.ts
+++ b/tests/issue-2521-native-messaging-rechunk.test.ts
@@ -21,7 +21,7 @@ import { compileProject } from "../src/index.js";
 import { buildNodeFsShim } from "../scripts/build-node-fs-shim.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const hostPath = join(here, "..", "examples", "native-messaging", "nm_node_fs.ts");
+const hostPath = join(here, "..", "examples", "native-messaging", "nm_js2wasm_node_fs.ts");
 const FRAME_CHUNK = 1024 * 1024;
 
 // Minimal raw-byte WASI shim (mirrors issue-1530.test.ts): fd_read drains a
@@ -124,7 +124,7 @@ function parseFrames(bytes: Uint8Array): string[] {
 
 describe("#2521 Native Messaging host — >1 MiB re-chunking + multi-message sequence", () => {
   it("echoes a <=1 MiB message verbatim in a single frame", async () => {
-    // nm_node_fs now imports the shared `./nm_sync_framing` core (#2778), so it
+    // nm_js2wasm_node_fs now imports the shared `./nm_js2wasm_sync_framing` core (#2778), so it
     // must compile through the multi-file bundler (mirrors the CLI's #2771
     // routing); single-source `compile()` would strip the relative import.
     const result = await compileProject(hostPath, {
@@ -138,7 +138,7 @@ describe("#2521 Native Messaging host — >1 MiB re-chunking + multi-message seq
   });
 
   it("re-chunks a >1 MiB array into multiple <=1 MiB JSON-array frames that reassemble to the original", async () => {
-    // nm_node_fs now imports the shared `./nm_sync_framing` core (#2778), so it
+    // nm_js2wasm_node_fs now imports the shared `./nm_js2wasm_sync_framing` core (#2778), so it
     // must compile through the multi-file bundler (mirrors the CLI's #2771
     // routing); single-source `compile()` would strip the relative import.
     const result = await compileProject(hostPath, {
@@ -166,7 +166,7 @@ describe("#2521 Native Messaging host — >1 MiB re-chunking + multi-message seq
   });
 
   it("processes the reporter's multi-message sequence (big then small) with no desync", async () => {
-    // nm_node_fs now imports the shared `./nm_sync_framing` core (#2778), so it
+    // nm_js2wasm_node_fs now imports the shared `./nm_js2wasm_sync_framing` core (#2778), so it
     // must compile through the multi-file bundler (mirrors the CLI's #2771
     // routing); single-source `compile()` would strip the relative import.
     const result = await compileProject(hostPath, {

--- a/tests/issue-2526-atomic-frame-writes.test.ts
+++ b/tests/issue-2526-atomic-frame-writes.test.ts
@@ -12,7 +12,7 @@ import { compile } from "../src/index.js";
 import { buildNodeFsShim } from "../scripts/build-node-fs-shim.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const hostPath = join(here, "..", "examples", "native-messaging", "nm_node_fs.ts");
+const hostPath = join(here, "..", "examples", "native-messaging", "nm_js2wasm_node_fs.ts");
 const FRAME_CHUNK = 1024 * 1024;
 
 // WASI shim that records the SIZE of every fd=1 write (not just the bytes).
@@ -96,7 +96,7 @@ function frame(jsonBody: string): Uint8Array {
 describe("#2526 Native Messaging host — atomic frame writes", () => {
   it("writes a small (<=1 MiB) message as one fd_write (no bare 4-byte length write)", async () => {
     const r = await compile(readFileSync(hostPath, "utf-8"), {
-      fileName: "nm_node_fs.ts",
+      fileName: "nm_js2wasm_node_fs.ts",
       target: "wasi",
       link: ["node:fs"],
     });
@@ -109,7 +109,7 @@ describe("#2526 Native Messaging host — atomic frame writes", () => {
 
   it("writes each re-chunked frame of a >1 MiB message atomically (writes == frames, none is 4 bytes)", async () => {
     const r = await compile(readFileSync(hostPath, "utf-8"), {
-      fileName: "nm_node_fs.ts",
+      fileName: "nm_js2wasm_node_fs.ts",
       target: "wasi",
       link: ["node:fs"],
     });

--- a/tests/issue-2657-raw-wasi-fd-import.test.ts
+++ b/tests/issue-2657-raw-wasi-fd-import.test.ts
@@ -19,10 +19,10 @@
  *      fd_write, no node:fs / no env), owns+exports `memory`, and round-trips a
  *      framed message byte-correctly (incl. high + null bytes) under a fd shim;
  *   2. `store32/load32/store8/load8` lower inline (NOT as imports);
- *   3. the full `examples/native-messaging/nm_wasi_p1.ts` host echoes a framed
+ *   3. the full `examples/native-messaging/nm_js2wasm_wasi_p1.ts` host echoes a framed
  *      Native-Messaging message byte-correctly under REAL wasmtime (gated on
  *      `findWasmtime()`), incl. a multi-window body;
- *   4. the existing `node:fs` example (`nm_node_fs.ts`) still compiles unchanged.
+ *   4. the existing `node:fs` example (`nm_js2wasm_node_fs.ts`) still compiles unchanged.
  */
 import { execFileSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -250,12 +250,12 @@ describe("#2657 raw fd echo — round-trip under a fd shim", () => {
   });
 });
 
-describe("#2657 nm_wasi_p1.ts example — real Native-Messaging host", () => {
-  const examplePath = join(__dirname, "..", "examples", "native-messaging", "nm_wasi_p1.ts");
+describe("#2657 nm_js2wasm_wasi_p1.ts example — real Native-Messaging host", () => {
+  const examplePath = join(__dirname, "..", "examples", "native-messaging", "nm_js2wasm_wasi_p1.ts");
 
   it("compiles under --target wasi importing ONLY wasi_snapshot_preview1", async () => {
     const src = readFileSync(examplePath, "utf-8");
-    const r = await compile(src, { fileName: "nm_wasi_p1.ts", target: "wasi", skipSemanticDiagnostics: true });
+    const r = await compile(src, { fileName: "nm_js2wasm_wasi_p1.ts", target: "wasi", skipSemanticDiagnostics: true });
     expect(r.success, r.success ? "" : r.errors?.[0]?.message).toBe(true);
     expect(importModules(r.wat!)).toEqual(new Set(["wasi_snapshot_preview1"]));
     expect(r.wat!).not.toContain("node:fs");
@@ -265,7 +265,7 @@ describe("#2657 nm_wasi_p1.ts example — real Native-Messaging host", () => {
 
   it("echoes a small framed JSON message byte-correctly under a fd shim", async () => {
     const src = readFileSync(examplePath, "utf-8");
-    const binary = await compileWasi(src, "nm_wasi_p1");
+    const binary = await compileWasi(src, "nm_js2wasm_wasi_p1");
     const body = new TextEncoder().encode('["hello",null,42]');
     const input = frame(body);
     const out = await runWithFdShim(binary, input);
@@ -274,7 +274,7 @@ describe("#2657 nm_wasi_p1.ts example — real Native-Messaging host", () => {
 
   it("echoes a multi-window body (> 64 KiB streams through the fixed window)", async () => {
     const src = readFileSync(examplePath, "utf-8");
-    const binary = await compileWasi(src, "nm_wasi_p1");
+    const binary = await compileWasi(src, "nm_js2wasm_wasi_p1");
     // 150 KiB body with a deterministic byte pattern incl. nulls + high bytes.
     const n = 150 * 1024;
     const body = new Uint8Array(n);
@@ -287,8 +287,8 @@ describe("#2657 nm_wasi_p1.ts example — real Native-Messaging host", () => {
 
   it.runIf(wasmtimeBin)("runs under REAL wasmtime: byte-correct framed echo", async () => {
     const src = readFileSync(examplePath, "utf-8");
-    const binary = await compileWasi(src, "nm_wasi_p1_wasmtime");
-    const path = join(tmpDir, "nm_wasi_p1.wasm");
+    const binary = await compileWasi(src, "nm_js2wasm_wasi_p1_wasmtime");
+    const path = join(tmpDir, "nm_js2wasm_wasi_p1.wasm");
     writeFileSync(path, binary);
     const body = Uint8Array.from([0x5b, 0x00, 0xff, 0x80, 0x41, 0x5d]); // [ \0 \xff \x80 A ]
     const input = frame(body);
@@ -298,9 +298,9 @@ describe("#2657 nm_wasi_p1.ts example — real Native-Messaging host", () => {
 });
 
 describe("#2657 — node:fs variant unchanged", () => {
-  it("the existing nm_node_fs.ts example still compiles under --target wasi", async () => {
-    const src = readFileSync(join(__dirname, "..", "examples", "native-messaging", "nm_node_fs.ts"), "utf-8");
-    const r = await compile(src, { fileName: "nm_node_fs.ts", target: "wasi", skipSemanticDiagnostics: true });
+  it("the existing nm_js2wasm_node_fs.ts example still compiles under --target wasi", async () => {
+    const src = readFileSync(join(__dirname, "..", "examples", "native-messaging", "nm_js2wasm_node_fs.ts"), "utf-8");
+    const r = await compile(src, { fileName: "nm_js2wasm_node_fs.ts", target: "wasi", skipSemanticDiagnostics: true });
     expect(r.success, r.success ? "" : r.errors?.[0]?.message).toBe(true);
     // The node:fs variant declares WHAT it needs as `node:fs`; it must NOT have
     // grown a raw `wasi_snapshot_preview1` direct import path by accident.

--- a/tests/issue-2684-deno-stdio.test.ts
+++ b/tests/issue-2684-deno-stdio.test.ts
@@ -116,16 +116,16 @@ export function main(): void { writeSync(1, "hi\\n"); }
     expect(wat).not.toContain("Deno");
   });
 
-  it("the nm_deno.ts example compiles to a pure-WASI P1 module", async () => {
+  it("the nm_js2wasm_deno.ts example compiles to a pure-WASI P1 module", async () => {
     const examplePath = join(
       dirname(fileURLToPath(import.meta.url)),
       "..",
       "examples",
       "native-messaging",
-      "nm_deno.ts",
+      "nm_js2wasm_deno.ts",
     );
     const src = readFileSync(examplePath, "utf-8");
-    const result = await compile(src, { fileName: "nm_deno.ts", target: "wasi" });
+    const result = await compile(src, { fileName: "nm_js2wasm_deno.ts", target: "wasi" });
     expect(result.success, result.success ? "" : result.errors?.[0]?.message).toBe(true);
     const wat = result.wat ?? "";
     const imports = [...wat.matchAll(/\(import "([^"]+)" "[^"]+"/g)].map((m) => m[1]);
@@ -167,16 +167,16 @@ export function main(): void { writeSync(1, "hi\\n"); }
       expect(out.length).toBe(0);
     });
 
-    it("the nm_deno.ts example round-trips multiple frames incl. a >window body", async () => {
+    it("the nm_js2wasm_deno.ts example round-trips multiple frames incl. a >window body", async () => {
       const examplePath = join(
         dirname(fileURLToPath(import.meta.url)),
         "..",
         "examples",
         "native-messaging",
-        "nm_deno.ts",
+        "nm_js2wasm_deno.ts",
       );
       const src = readFileSync(examplePath, "utf-8");
-      const result = await compile(src, { fileName: "nm_deno.ts", target: "wasi" });
+      const result = await compile(src, { fileName: "nm_js2wasm_deno.ts", target: "wasi" });
       expect(result.success).toBe(true);
 
       const frame = (body: number[]): Buffer => {
@@ -190,7 +190,7 @@ export function main(): void { writeSync(1, "hi\\n"); }
       const big: number[] = [];
       for (let i = 0; i < 150000; i++) big.push((i * 7 + 3) & 0xff); // > 64 KiB window
       const input = Buffer.concat([frame(small), frame(big)]);
-      const out = run(result.binary!, "nm_deno", input);
+      const out = run(result.binary!, "nm_js2wasm_deno", input);
       expect(Buffer.compare(out, input)).toBe(0);
     });
   });

--- a/tests/issue-2735-stdin-nonEOF-termination.test.ts
+++ b/tests/issue-2735-stdin-nonEOF-termination.test.ts
@@ -147,11 +147,11 @@ describe("#2735 — stdin reactor non-EOF termination", () => {
 
   // ── Compile-only invariants (always run, no runtime needed) ──────────────
 
-  it("nm_node_process.ts still lowers to a standalone module importing only wasi_snapshot_preview1", async () => {
+  it("nm_js2wasm_node_process.ts still lowers to a standalone module importing only wasi_snapshot_preview1", async () => {
     // The destroy() → __wasiStdinStop() lowering must NOT leak an `env.*` host
     // import (a regression of the #2696 zero-env-leak guarantee).
-    const src = readFileSync(join(NM_DIR, "nm_node_process.ts"), "utf-8");
-    const r = await compileWasi(src, "nm_node_process_imports");
+    const src = readFileSync(join(NM_DIR, "nm_js2wasm_node_process.ts"), "utf-8");
+    const r = await compileWasi(src, "nm_js2wasm_node_process_imports");
     expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
     expect(WebAssembly.validate(r.binary!)).toBe(true);
     expect([...importModules(r.wat!)]).toEqual(["wasi_snapshot_preview1"]);
@@ -177,7 +177,7 @@ describe("#2735 — stdin reactor non-EOF termination", () => {
       { timeout: 30_000 },
       async () => {
         const binPath = await buildToDisk(
-          readFileSync(join(NM_DIR, "nm_node_process.ts"), "utf-8"),
+          readFileSync(join(NM_DIR, "nm_js2wasm_node_process.ts"), "utf-8"),
           "nm_open_shutdown",
         );
         const input = new Uint8Array([...requestFrame, ...shutdownFrame]);
@@ -205,7 +205,7 @@ describe("#2735 — stdin reactor non-EOF termination", () => {
 
   maybe("under wasmtime (stdin CLOSED — EOF path stays green)", () => {
     it("EOF-closed stdin still echoes the frame and exits", { timeout: 30_000 }, async () => {
-      const binPath = await buildToDisk(readFileSync(join(NM_DIR, "nm_node_process.ts"), "utf-8"), "nm_eof_close");
+      const binPath = await buildToDisk(readFileSync(join(NM_DIR, "nm_js2wasm_node_process.ts"), "utf-8"), "nm_eof_close");
       // Same input, but the parent CLOSES stdin → the reactor's existing EOF
       // trigger fires. This must remain unaffected by the new escape hatch.
       const input = new Uint8Array([...requestFrame, ...shutdownFrame]);
@@ -215,7 +215,7 @@ describe("#2735 — stdin reactor non-EOF termination", () => {
     });
 
     it("a bounded buffer with no shutdown frame still exits on EOF", { timeout: 30_000 }, async () => {
-      const binPath = await buildToDisk(readFileSync(join(NM_DIR, "nm_node_process.ts"), "utf-8"), "nm_eof_plain");
+      const binPath = await buildToDisk(readFileSync(join(NM_DIR, "nm_js2wasm_node_process.ts"), "utf-8"), "nm_eof_plain");
       const res = await runWasmtimeStdin(binPath, requestFrame, { keepOpen: false, timeoutMs: 15_000 });
       expect(res.timedOut).toBe(false);
       expect(Array.from(res.stdout)).toEqual(Array.from(requestFrame));

--- a/tests/issue-2735-stdin-nonEOF-termination.test.ts
+++ b/tests/issue-2735-stdin-nonEOF-termination.test.ts
@@ -205,7 +205,10 @@ describe("#2735 — stdin reactor non-EOF termination", () => {
 
   maybe("under wasmtime (stdin CLOSED — EOF path stays green)", () => {
     it("EOF-closed stdin still echoes the frame and exits", { timeout: 30_000 }, async () => {
-      const binPath = await buildToDisk(readFileSync(join(NM_DIR, "nm_js2wasm_node_process.ts"), "utf-8"), "nm_eof_close");
+      const binPath = await buildToDisk(
+        readFileSync(join(NM_DIR, "nm_js2wasm_node_process.ts"), "utf-8"),
+        "nm_eof_close",
+      );
       // Same input, but the parent CLOSES stdin → the reactor's existing EOF
       // trigger fires. This must remain unaffected by the new escape hatch.
       const input = new Uint8Array([...requestFrame, ...shutdownFrame]);
@@ -215,7 +218,10 @@ describe("#2735 — stdin reactor non-EOF termination", () => {
     });
 
     it("a bounded buffer with no shutdown frame still exits on EOF", { timeout: 30_000 }, async () => {
-      const binPath = await buildToDisk(readFileSync(join(NM_DIR, "nm_js2wasm_node_process.ts"), "utf-8"), "nm_eof_plain");
+      const binPath = await buildToDisk(
+        readFileSync(join(NM_DIR, "nm_js2wasm_node_process.ts"), "utf-8"),
+        "nm_eof_plain",
+      );
       const res = await runWasmtimeStdin(binPath, requestFrame, { keepOpen: false, timeoutMs: 15_000 });
       expect(res.timedOut).toBe(false);
       expect(Array.from(res.stdout)).toEqual(Array.from(requestFrame));

--- a/tests/issue-2748-deno-transpile.test.ts
+++ b/tests/issue-2748-deno-transpile.test.ts
@@ -45,7 +45,13 @@ function findWasmtime(): string | null {
 }
 const wasmtimeBin = findWasmtime();
 
-const examplePath = join(dirname(fileURLToPath(import.meta.url)), "..", "examples", "native-messaging", "nm_js2wasm_deno.ts");
+const examplePath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "examples",
+  "native-messaging",
+  "nm_js2wasm_deno.ts",
+);
 
 /**
  * Reproduce `bun build <entry> --outfile out.js`: type-strip AND BUNDLE the entry

--- a/tests/issue-2748-deno-transpile.test.ts
+++ b/tests/issue-2748-deno-transpile.test.ts
@@ -1,9 +1,9 @@
-// #2748 — bun/tsc/esbuild-transpiled (TYPE-STRIPPED) `nm_deno.js` must compile to
+// #2748 — bun/tsc/esbuild-transpiled (TYPE-STRIPPED) `nm_js2wasm_deno.js` must compile to
 // the SAME pure-WASI-P1 module as the direct `.ts`, not leak `env::__extern_get`.
 //
 // loopdive/js2#389 (latest comment): the reporter's pipeline is
-//   bun build --no-bundle nm_deno.ts --outfile nm_deno.js   # strips TS types
-//   js2wasm nm_deno.js --target wasi
+//   bun build --no-bundle nm_js2wasm_deno.ts --outfile nm_js2wasm_deno.js   # strips TS types
+//   js2wasm nm_js2wasm_deno.js --target wasi
 // The direct `.ts` compile imports ONLY `wasi_snapshot_preview1` and echoes
 // byte-exactly (covered by issue-2684-deno-stdio.test.ts). The transpiled `.js`
 // regressed: its `Uint8Array` PARAM annotations were stripped (`writeFull(out)` /
@@ -45,11 +45,11 @@ function findWasmtime(): string | null {
 }
 const wasmtimeBin = findWasmtime();
 
-const examplePath = join(dirname(fileURLToPath(import.meta.url)), "..", "examples", "native-messaging", "nm_deno.ts");
+const examplePath = join(dirname(fileURLToPath(import.meta.url)), "..", "examples", "native-messaging", "nm_js2wasm_deno.ts");
 
 /**
  * Reproduce `bun build <entry> --outfile out.js`: type-strip AND BUNDLE the entry
- * (inlining the shared `./nm_sync_framing` core, #2778) into a single ESM `.js`
+ * (inlining the shared `./nm_js2wasm_sync_framing` core, #2778) into a single ESM `.js`
  * via esbuild. A transform-only strip would leave the relative import dangling —
  * the post-#2778 reality that made the transpiled-`.js` path regress (#2754).
  */
@@ -66,7 +66,7 @@ async function transpileStrippedBundle(entry: string): Promise<string> {
   return result.outputFiles[0]!.text;
 }
 
-// A hand-written TYPE-STRIPPED equivalent of the nm_deno framed-echo host — the
+// A hand-written TYPE-STRIPPED equivalent of the nm_js2wasm_deno framed-echo host — the
 // `writeFull`/`readExact` params carry NO `Uint8Array` annotation (exactly what a
 // transpiler emits), so the buffers are `any`/externref. This is the deterministic
 // backstop independent of esbuild's exact output.
@@ -131,22 +131,22 @@ function expectPureWasi(wat: string, binary: Uint8Array): void {
   expect(() => new WebAssembly.Module(binary)).not.toThrow();
 }
 
-describe("#2748 — type-stripped Deno nm_deno.js → pure-WASI P1 (no env::__extern_get)", () => {
+describe("#2748 — type-stripped Deno nm_js2wasm_deno.js → pure-WASI P1 (no env::__extern_get)", () => {
   it("the hand-written UNTYPED framed-echo compiles to a pure-WASI module", async () => {
-    const result = await compile(FRAMED_ECHO_UNTYPED, { fileName: "nm_deno.js", target: "wasi" });
+    const result = await compile(FRAMED_ECHO_UNTYPED, { fileName: "nm_js2wasm_deno.js", target: "wasi" });
     expect(result.success, result.success ? "" : result.errors?.[0]?.message).toBe(true);
     expectPureWasi(result.wat ?? "", result.binary!);
   });
 
-  it("the esbuild-transpiled (type-stripped) nm_deno.ts compiles to a pure-WASI module", async () => {
+  it("the esbuild-transpiled (type-stripped) nm_js2wasm_deno.ts compiles to a pure-WASI module", async () => {
     // The reporter's exact pipeline: `bun build` strips TS types AND BUNDLES the
-    // shared `./nm_sync_framing` core (#2778) into one file, then compiles the
+    // shared `./nm_js2wasm_sync_framing` core (#2778) into one file, then compiles the
     // `.js`. A transform-only strip would leave the relative import dangling.
     const code = await transpileStrippedBundle(examplePath);
     expect(code).toContain("Deno.stdin.readSync");
     expect(code).not.toContain(": Uint8Array"); // types really are stripped
-    expect(code).not.toContain("./nm_sync_framing"); // shared core was inlined
-    const result = await compile(code, { fileName: "nm_deno.js", target: "wasi" });
+    expect(code).not.toContain("./nm_js2wasm_sync_framing"); // shared core was inlined
+    const result = await compile(code, { fileName: "nm_js2wasm_deno.js", target: "wasi" });
     expect(result.success, result.success ? "" : result.errors?.[0]?.message).toBe(true);
     expectPureWasi(result.wat ?? "", result.binary!);
   });
@@ -191,16 +191,16 @@ describe("#2748 — type-stripped Deno nm_deno.js → pure-WASI P1 (no env::__ex
     };
 
     it("untyped host round-trips a framed message byte-for-byte (incl. high/null bytes)", async () => {
-      const result = await compile(FRAMED_ECHO_UNTYPED, { fileName: "nm_deno.js", target: "wasi" });
+      const result = await compile(FRAMED_ECHO_UNTYPED, { fileName: "nm_js2wasm_deno.js", target: "wasi" });
       expect(result.success).toBe(true);
       const input = frame([0x00, 0xff, 0x0a, 0x7f, 0x80, 0x41]);
       const out = run(result.binary!, "untyped_echo", input);
       expect(Buffer.compare(out, input)).toBe(0);
     });
 
-    it("esbuild-transpiled nm_deno.js round-trips multiple frames incl. a >window body", async () => {
+    it("esbuild-transpiled nm_js2wasm_deno.js round-trips multiple frames incl. a >window body", async () => {
       const code = await transpileStrippedBundle(examplePath);
-      const result = await compile(code, { fileName: "nm_deno.js", target: "wasi" });
+      const result = await compile(code, { fileName: "nm_js2wasm_deno.js", target: "wasi" });
       expect(result.success, result.success ? "" : result.errors?.[0]?.message).toBe(true);
 
       const small = [0x00, 0xff, 0x0a, 0x7f, 0x80, 0x41];

--- a/tests/issue-2752-stdin-prelude-js.test.ts
+++ b/tests/issue-2752-stdin-prelude-js.test.ts
@@ -37,7 +37,7 @@
  *      parsed as TS).
  *
  * The runtime gate (the unblocking criterion for loopdive/js2#389 + the v0.57.0
- * publish): the type-stripped `nm_node_process.js` echoes a framed message
+ * publish): the type-stripped `nm_js2wasm_node_process.js` echoes a framed message
  * byte-exact AND exits cleanly under wasmtime with stdin held OPEN + the in-band
  * zero-length shutdown frame (`process.stdin.destroy()`).
  */
@@ -171,13 +171,13 @@ main();
 describe("#2752 — type-stripped process.stdin program compiles + runs", () => {
   // ── Compile-only invariants (always run, no runtime needed) ──────────────
 
-  it("the esbuild-transpiled (type-stripped) nm_node_process.ts compiles to a pure-WASI module", async () => {
+  it("the esbuild-transpiled (type-stripped) nm_js2wasm_node_process.ts compiles to a pure-WASI module", async () => {
     // The reporter's exact pipeline: strip TS types, then compile the `.js`.
-    const tsSrc = readFileSync(join(NM_DIR, "nm_node_process.ts"), "utf-8");
+    const tsSrc = readFileSync(join(NM_DIR, "nm_js2wasm_node_process.ts"), "utf-8");
     const { code } = await esbuild.transform(tsSrc, { loader: "ts", format: "esm" });
     expect(code).toContain("process.stdin");
     expect(code).not.toContain(": string"); // types really are stripped
-    const r = await compile(code, { fileName: "nm_node_process.js", target: "wasi" });
+    const r = await compile(code, { fileName: "nm_js2wasm_node_process.js", target: "wasi" });
     expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
     expect(WebAssembly.validate(r.binary!)).toBe(true);
     // No `env::*` host-import leak; pure WASI P1 — same module shape as the `.ts`.
@@ -216,9 +216,9 @@ describe("#2752 — type-stripped process.stdin program compiles + runs", () => 
     });
 
     async function buildStripped(name: string): Promise<string> {
-      const tsSrc = readFileSync(join(NM_DIR, "nm_node_process.ts"), "utf-8");
+      const tsSrc = readFileSync(join(NM_DIR, "nm_js2wasm_node_process.ts"), "utf-8");
       const { code } = await esbuild.transform(tsSrc, { loader: "ts", format: "esm" });
-      const r = await compile(code, { fileName: "nm_node_process.js", target: "wasi" });
+      const r = await compile(code, { fileName: "nm_js2wasm_node_process.js", target: "wasi" });
       expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
       expect(WebAssembly.validate(r.binary!), "binary must validate").toBe(true);
       const path = join(tmpDir, `${name}.wasm`);

--- a/tests/issue-2754-transpiled-nm-roundtrip.test.ts
+++ b/tests/issue-2754-transpiled-nm-roundtrip.test.ts
@@ -1,19 +1,19 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /**
  * #2754 — a `bun build` / esbuild **type-stripped + bundled** `.js` of the
- * SYNCHRONOUS Native-Messaging hosts (`nm_deno.ts`, `nm_node_fs.ts`) must
+ * SYNCHRONOUS Native-Messaging hosts (`nm_js2wasm_deno.ts`, `nm_js2wasm_node_fs.ts`) must
  * round-trip a framed message exactly the way the direct `.ts` does. This is
  * loopdive/js2#389's exact pipeline:
  *
- *   bun build examples/native-messaging/nm_deno.ts --outfile nm_deno.js  # strips types + bundles
- *   js2wasm nm_deno.js --target wasi
+ *   bun build examples/native-messaging/nm_js2wasm_deno.ts --outfile nm_js2wasm_deno.js  # strips types + bundles
+ *   js2wasm nm_js2wasm_deno.js --target wasi
  *
  * The transpiled `.js` had broken THREE times because only the `.ts` path was
- * tested. The most recent regression (#2778's shared-`nm_sync_framing` core)
+ * tested. The most recent regression (#2778's shared-`nm_js2wasm_sync_framing` core)
  * surfaced as a **zero-output** miscompile: the host compiled clean to a pure
  * WASI module, instantiated, and exited 0 having read/written NOTHING.
  *
- * Root cause (#2754): once `nm_deno`/`nm_node_fs` inject their `readSync`/
+ * Root cause (#2754): once `nm_js2wasm_deno`/`nm_js2wasm_node_fs` inject their `readSync`/
  * `writeSync` as FUNCTION REFERENCES across the shared-core seam (`runNmHost(read,
  * write, …)`), stripping the types makes those params `any`. A call on an
  * `any`-typed value reaches the inline dynamic-dispatch path, which builds its
@@ -25,7 +25,7 @@
  * nothing. Pre-registering function-value wrappers before body codegen fixes it.
  *
  * This test type-strips AND BUNDLES (the reporter's real flow — not a
- * transform-only strip, which would leave the `./nm_sync_framing` import
+ * transform-only strip, which would leave the `./nm_js2wasm_sync_framing` import
  * dangling) **in-process via esbuild** (a devDep — no `bun` needed at test time),
  * compiles under `--target wasi`, drives the module through an in-process raw-fd
  * shim (so it runs on EVERY CI run, not only where `wasmtime` is installed), and
@@ -86,8 +86,8 @@ function jsonArrayBody(approx: number): Buffer {
 // ---- transpile (type-strip + bundle) the reporter's exact way -----------------
 /**
  * Reproduce `bun build <file> --outfile out.js`: BUNDLE the entry (inlining the
- * shared `./nm_sync_framing` core) and STRIP the TS types, in-process via esbuild.
- * `node:fs` is kept external (bun does the same), so `nm_node_fs` retains its
+ * shared `./nm_js2wasm_sync_framing` core) and STRIP the TS types, in-process via esbuild.
+ * `node:fs` is kept external (bun does the same), so `nm_js2wasm_node_fs` retains its
  * `import { readSync, writeSync } from "node:fs"` for the compiler's node:fs
  * sync-IO recognition.
  */
@@ -105,7 +105,7 @@ async function transpileStrippedBundle(file: string): Promise<string> {
   // The types REALLY are stripped (the seam params lose their annotations).
   expect(code).not.toContain(": Uint8Array");
   // The shared core was inlined (no dangling relative import).
-  expect(code).not.toContain("./nm_sync_framing");
+  expect(code).not.toContain("./nm_js2wasm_sync_framing");
   return code;
 }
 
@@ -196,9 +196,9 @@ async function compileStrippedJs(file: string): Promise<Uint8Array> {
 
 // =============================================================================
 describe("#2754 — bun/esbuild type-stripped+bundled sync NM hosts round-trip under WASI", () => {
-  // nm_deno = VERBATIM streamer: every framed message echoes back byte-for-byte.
-  it("nm_deno: stripped .js echoes a multi-frame stream byte-exact (incl. a 1 MiB body), matching .ts", async () => {
-    const [tsBin, jsBin] = await Promise.all([compileTs("nm_deno.ts"), compileStrippedJs("nm_deno.ts")]);
+  // nm_js2wasm_deno = VERBATIM streamer: every framed message echoes back byte-for-byte.
+  it("nm_js2wasm_deno: stripped .js echoes a multi-frame stream byte-exact (incl. a 1 MiB body), matching .ts", async () => {
+    const [tsBin, jsBin] = await Promise.all([compileTs("nm_js2wasm_deno.ts"), compileStrippedJs("nm_js2wasm_deno.ts")]);
 
     const small = new Uint8Array([0x00, 0xff, 0x0a, 0x7f, 0x80, 0x41]);
     const big = new Uint8Array(1 * MiB);
@@ -218,10 +218,10 @@ describe("#2754 — bun/esbuild type-stripped+bundled sync NM hosts round-trip u
     expect(Buffer.compare(Buffer.from(jsOut), Buffer.from(tsOut)), "stripped .js must match the .ts path").toBe(0);
   });
 
-  // nm_node_fs = re-chunk streamer: a body <= the 1 MiB cap echoes verbatim; a
+  // nm_js2wasm_node_fs = re-chunk streamer: a body <= the 1 MiB cap echoes verbatim; a
   // larger array body is re-chunked into valid <=1 MiB JSON frames.
-  it("nm_node_fs: stripped .js echoes under-cap frames byte-exact, matching .ts", async () => {
-    const [tsBin, jsBin] = await Promise.all([compileTs("nm_node_fs.ts"), compileStrippedJs("nm_node_fs.ts")]);
+  it("nm_js2wasm_node_fs: stripped .js echoes under-cap frames byte-exact, matching .ts", async () => {
+    const [tsBin, jsBin] = await Promise.all([compileTs("nm_js2wasm_node_fs.ts"), compileStrippedJs("nm_js2wasm_node_fs.ts")]);
 
     const small = new Uint8Array(Buffer.from("[1,2,3]", "ascii"));
     const end = new Uint8Array([0x5b, 0x5d]); // "[]"
@@ -235,8 +235,8 @@ describe("#2754 — bun/esbuild type-stripped+bundled sync NM hosts round-trip u
     expect(Buffer.compare(Buffer.from(jsOut), Buffer.from(tsOut)), "stripped .js must match the .ts path").toBe(0);
   });
 
-  it("nm_node_fs: stripped .js re-chunks a >1 MiB array body into valid frames, matching .ts", async () => {
-    const [tsBin, jsBin] = await Promise.all([compileTs("nm_node_fs.ts"), compileStrippedJs("nm_node_fs.ts")]);
+  it("nm_js2wasm_node_fs: stripped .js re-chunks a >1 MiB array body into valid frames, matching .ts", async () => {
+    const [tsBin, jsBin] = await Promise.all([compileTs("nm_js2wasm_node_fs.ts"), compileStrippedJs("nm_js2wasm_node_fs.ts")]);
 
     const body = new Uint8Array(jsonArrayBody(2 * MiB)); // > the 1 MiB browser cap
     const input = frame(body);

--- a/tests/issue-2754-transpiled-nm-roundtrip.test.ts
+++ b/tests/issue-2754-transpiled-nm-roundtrip.test.ts
@@ -198,7 +198,10 @@ async function compileStrippedJs(file: string): Promise<Uint8Array> {
 describe("#2754 — bun/esbuild type-stripped+bundled sync NM hosts round-trip under WASI", () => {
   // nm_js2wasm_deno = VERBATIM streamer: every framed message echoes back byte-for-byte.
   it("nm_js2wasm_deno: stripped .js echoes a multi-frame stream byte-exact (incl. a 1 MiB body), matching .ts", async () => {
-    const [tsBin, jsBin] = await Promise.all([compileTs("nm_js2wasm_deno.ts"), compileStrippedJs("nm_js2wasm_deno.ts")]);
+    const [tsBin, jsBin] = await Promise.all([
+      compileTs("nm_js2wasm_deno.ts"),
+      compileStrippedJs("nm_js2wasm_deno.ts"),
+    ]);
 
     const small = new Uint8Array([0x00, 0xff, 0x0a, 0x7f, 0x80, 0x41]);
     const big = new Uint8Array(1 * MiB);
@@ -221,7 +224,10 @@ describe("#2754 — bun/esbuild type-stripped+bundled sync NM hosts round-trip u
   // nm_js2wasm_node_fs = re-chunk streamer: a body <= the 1 MiB cap echoes verbatim; a
   // larger array body is re-chunked into valid <=1 MiB JSON frames.
   it("nm_js2wasm_node_fs: stripped .js echoes under-cap frames byte-exact, matching .ts", async () => {
-    const [tsBin, jsBin] = await Promise.all([compileTs("nm_js2wasm_node_fs.ts"), compileStrippedJs("nm_js2wasm_node_fs.ts")]);
+    const [tsBin, jsBin] = await Promise.all([
+      compileTs("nm_js2wasm_node_fs.ts"),
+      compileStrippedJs("nm_js2wasm_node_fs.ts"),
+    ]);
 
     const small = new Uint8Array(Buffer.from("[1,2,3]", "ascii"));
     const end = new Uint8Array([0x5b, 0x5d]); // "[]"
@@ -236,7 +242,10 @@ describe("#2754 — bun/esbuild type-stripped+bundled sync NM hosts round-trip u
   });
 
   it("nm_js2wasm_node_fs: stripped .js re-chunks a >1 MiB array body into valid frames, matching .ts", async () => {
-    const [tsBin, jsBin] = await Promise.all([compileTs("nm_js2wasm_node_fs.ts"), compileStrippedJs("nm_js2wasm_node_fs.ts")]);
+    const [tsBin, jsBin] = await Promise.all([
+      compileTs("nm_js2wasm_node_fs.ts"),
+      compileStrippedJs("nm_js2wasm_node_fs.ts"),
+    ]);
 
     const body = new Uint8Array(jsonArrayBody(2 * MiB)); // > the 1 MiB browser cap
     const input = frame(body);

--- a/tests/native-messaging-comparison.test.ts
+++ b/tests/native-messaging-comparison.test.ts
@@ -6,12 +6,12 @@
  * a 4-byte little-endian length prefix + body off fd 0, write the framed response
  * to fd 1) implemented against several host surfaces, so they can be compared:
  *
- *   - `nm_wasi_p1.ts`         RAW `wasi_snapshot_preview1` fd_read/fd_write + linear
+ *   - `nm_js2wasm_wasi_p1.ts`         RAW `wasi_snapshot_preview1` fd_read/fd_write + linear
  *                          memory (`wasm:memory`)                              (#2657)
- *   - `nm_node_fs.ts`      synchronous `node:fs` readSync/writeSync(fd, …)     (#2655)
- *   - `nm_node_process.ts` async `process.stdin` Readable + process.stdout.write (#2683/#2632)
- *   - `nm_deno.ts`         the Deno stdio surface (lands separately)
- *   - `nm_wasi_p3.ts`      the WASI Preview 3 spike (lands separately)
+ *   - `nm_js2wasm_node_fs.ts`      synchronous `node:fs` readSync/writeSync(fd, …)     (#2655)
+ *   - `nm_js2wasm_node_process.ts` async `process.stdin` Readable + process.stdout.write (#2683/#2632)
+ *   - `nm_js2wasm_deno.ts`         the Deno stdio surface (lands separately)
+ *   - `nm_js2wasm_wasi_p3.ts`      the WASI Preview 3 spike (lands separately)
  *
  * Despite the different host APIs, every variant speaks the IDENTICAL wire
  * protocol, so a single framed request must come back BYTE-IDENTICAL from each.
@@ -22,7 +22,7 @@
  *      subset of `wasi_snapshot_preview1` / `env`) echoes a shared frame
  *      BYTE-IDENTICALLY. Synchronous variants run in-process under a raw fd shim
  *      (CI-safe, no external runtime); reactor-driven async variants (e.g.
- *      `nm_node_process.ts`, whose `process.stdin` needs the event loop) run under
+ *      `nm_js2wasm_node_process.ts`, whose `process.stdin` needs the event loop) run under
  *      real `wasmtime` when it is on PATH.
  *
  * It is written DEFENSIVELY so the later variants are picked up with no edits:
@@ -60,13 +60,13 @@ const NM_DIR = join(__dirname, "..", "examples", "native-messaging");
 
 /**
  * The host-surface variants present on disk (any `nm_<surface>.ts`), sorted.
- * `nm_sync_framing.ts` is the SHARED host-independent framing core (#2778), not a
+ * `nm_js2wasm_sync_framing.ts` is the SHARED host-independent framing core (#2778), not a
  * host variant — it has no entry/`main` and never does fd IO itself — so it is
  * excluded from the variant matrix (the host adapters that import it are tested).
  */
 function discoverVariants(): string[] {
   return readdirSync(NM_DIR)
-    .filter((f) => /^nm_.*\.ts$/.test(f) && f !== "nm_sync_framing.ts")
+    .filter((f) => /^nm_.*\.ts$/.test(f) && f !== "nm_js2wasm_sync_framing.ts")
     .sort();
 }
 
@@ -105,10 +105,10 @@ async function compileVariant(file: string): Promise<Awaited<ReturnType<typeof c
   const path = join(NM_DIR, file);
   const src = readFileSync(path, "utf-8");
   // Mirror the CLI's routing (#2771): an entry that statically imports a RELATIVE
-  // module (e.g. nm_deno / nm_node_fs → `./nm_sync_framing`) must go through the
+  // module (e.g. nm_js2wasm_deno / nm_js2wasm_node_fs → `./nm_js2wasm_sync_framing`) must go through the
   // multi-file bundler so the shared core is pulled in and `node:fs` / raw-WASI
-  // lowering runs module-wide. Entries with no relative import (nm_wasi_p1 /
-  // nm_node_process / nm_wasi_p3) stay on the single-source path — byte-identical.
+  // lowering runs module-wide. Entries with no relative import (nm_js2wasm_wasi_p1 /
+  // nm_js2wasm_node_process / nm_js2wasm_wasi_p3) stay on the single-source path — byte-identical.
   return entryHasRelativeImports(src)
     ? compileProject(path, { target: "wasi", skipSemanticDiagnostics: true })
     : compile(src, { fileName: file, target: "wasi", skipSemanticDiagnostics: true });
@@ -176,7 +176,7 @@ async function runFdShim(binary: Uint8Array, stdin: Uint8Array): Promise<Uint8Ar
 /**
  * A variant lowers to a runnable standalone WASI command module when the compile
  * succeeds, the binary validates, AND it imports nothing beyond the WASI core
- * module / `env`. SOURCE-REFERENCE arms (e.g. `nm_wasi_p3.ts`, which awaits the
+ * module / `env`. SOURCE-REFERENCE arms (e.g. `nm_js2wasm_wasi_p3.ts`, which awaits the
  * P3 component producer and currently requests a deferred `env.readViaStream`
  * host import → an invalid standalone binary) are excluded here and gated out of
  * the run.
@@ -185,7 +185,7 @@ function isRunnableStandalone(r: Awaited<ReturnType<typeof compile>>): boolean {
   if (!r.success || !r.binary || !WebAssembly.validate(r.binary)) return false;
   const imports = importModules(r.wat!);
   // #2696 — a runnable NM host MUST import `wasi_snapshot_preview1` (it does fd
-  // 0/1 IO). The WASI Preview-3 source-reference arm `nm_wasi_p3.ts` imports only
+  // 0/1 IO). The WASI Preview-3 source-reference arm `nm_js2wasm_wasi_p3.ts` imports only
   // `env` P3-component placeholder stubs and never touches a fd, so it is NOT a
   // runnable command module even though its standalone binary now VALIDATES (the
   // #2696 bug-3 coercion fix removed the invalid `__str_to_number` Wasm that
@@ -201,14 +201,14 @@ describe("#2683 Native Messaging comparison harness — every variant compiles",
 
   it("discovers the baseline variants on disk", () => {
     // The two landed variants plus this PR's node:process variant must be present;
-    // later variants (nm_deno.ts, nm_wasi_p3.ts) are picked up automatically.
-    expect(variants).toContain("nm_wasi_p1.ts");
-    expect(variants).toContain("nm_node_fs.ts");
-    expect(variants).toContain("nm_node_process.ts");
+    // later variants (nm_js2wasm_deno.ts, nm_js2wasm_wasi_p3.ts) are picked up automatically.
+    expect(variants).toContain("nm_js2wasm_wasi_p1.ts");
+    expect(variants).toContain("nm_js2wasm_node_fs.ts");
+    expect(variants).toContain("nm_js2wasm_node_process.ts");
   });
 
   // The three runnable baselines MUST lower to a valid standalone WASI module.
-  for (const file of ["nm_wasi_p1.ts", "nm_node_fs.ts", "nm_node_process.ts"]) {
+  for (const file of ["nm_js2wasm_wasi_p1.ts", "nm_js2wasm_node_fs.ts", "nm_js2wasm_node_process.ts"]) {
     it(`${file} compiles to a runnable standalone WASI module`, async () => {
       const r = await compileVariant(file);
       expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
@@ -221,7 +221,7 @@ describe("#2683 Native Messaging comparison harness — every variant compiles",
   // allowed to be a SOURCE-REFERENCE arm that does not yet produce a runnable
   // standalone binary (e.g. the WASI P3 component variant) — the byte-identical
   // test gates those out — but the compiler must not crash on it.
-  for (const file of variants.filter((f) => !["nm_wasi_p1.ts", "nm_node_fs.ts", "nm_node_process.ts"].includes(f))) {
+  for (const file of variants.filter((f) => !["nm_js2wasm_wasi_p1.ts", "nm_js2wasm_node_fs.ts", "nm_js2wasm_node_process.ts"].includes(f))) {
     it(`${file} compiles under --target wasi (runnable or source-reference)`, async () => {
       const r = await compileVariant(file);
       expect(r, `${file} produced no compile result`).toBeDefined();
@@ -310,10 +310,10 @@ describe("#2683 Native Messaging comparison harness — byte-identical framed ec
 //
 // guest271314 ran these hosts (npm `@loopdive/js2` + `bun build`) and hit three
 // compile bugs: (1) `wasm:memory` store32/load32/store8/load8 leaked as dropped
-// `env.*` host imports (nm_wasi_p1.ts); (2) node:fs/node:process flags + the #2632
+// `env.*` host imports (nm_js2wasm_wasi_p1.ts); (2) node:fs/node:process flags + the #2632
 // stdin-reactor / `String.fromCharCode` leaked `env.__wasiStdin*` / `env.global_
-// String` (nm_node_process.ts); (3) a stale late-import funcIdx mis-called
-// `__str_to_number` with an f64, producing invalid Wasm (nm_wasi_p3.ts). After
+// String` (nm_js2wasm_node_process.ts); (3) a stale late-import funcIdx mis-called
+// `__str_to_number` with an f64, producing invalid Wasm (nm_js2wasm_wasi_p3.ts). After
 // the fixes, pin the reporter's exact payloads:
 //
 //   • the import section of every WORKING variant is EXACTLY {wasi_snapshot_
@@ -323,7 +323,7 @@ describe("#2683 Native Messaging comparison harness — byte-identical framed ec
 //     length 0) is the protocol's clean-shutdown signal → no echo. (Runs under
 //     real wasmtime when on PATH; synchronous variants also run in-process under
 //     the fd shim, so the small-payload echo executes even without wasmtime.)
-//   • nm_wasi_p3.ts stays skipped — the P3 async component backend is not done
+//   • nm_js2wasm_wasi_p3.ts stays skipped — the P3 async component backend is not done
 //     (#2658); it MUST NOT gate CI.
 // ────────────────────────────────────────────────────────────────────────────
 describe("#2696 — Native Messaging #389 reporter payloads", () => {
@@ -384,10 +384,10 @@ describe("#2696 — Native Messaging #389 reporter payloads", () => {
     'JSON object {"0":97}': enc('{"0":97}'),
   };
 
-  // Every working variant present on disk. nm_wasi_p3.ts is intentionally absent
-  // (skipped below). nm_deno.ts is included; it is skipped per-test if it has not
+  // Every working variant present on disk. nm_js2wasm_wasi_p3.ts is intentionally absent
+  // (skipped below). nm_js2wasm_deno.ts is included; it is skipped per-test if it has not
   // landed / is not a runnable standalone module.
-  const WORKING = ["nm_wasi_p1.ts", "nm_node_fs.ts", "nm_deno.ts", "nm_node_process.ts"];
+  const WORKING = ["nm_js2wasm_wasi_p1.ts", "nm_js2wasm_node_fs.ts", "nm_js2wasm_deno.ts", "nm_js2wasm_node_process.ts"];
 
   for (const file of WORKING) {
     describe(file, () => {
@@ -428,12 +428,12 @@ describe("#2696 — Native Messaging #389 reporter payloads", () => {
 
   // The 1 MiB browser-message-cap payload — a complete single Native Messaging
   // frame echoed verbatim. Restricted to the SYNCHRONOUS variants (raw WASI / Deno
-  // / node:fs): the nm_node_process async reactor rebuilds the body via per-byte
+  // / node:fs): the nm_js2wasm_node_process async reactor rebuilds the body via per-byte
   // `String.fromCharCode` + string concat, which is not CI-feasible at 1 MiB (its
   // wire protocol is already covered by the synchronous variants + the small
-  // payloads above). 1 MiB is exactly at the cap, so even nm_node_fs (which
+  // payloads above). 1 MiB is exactly at the cap, so even nm_js2wasm_node_fs (which
   // re-chunks bodies LARGER than 1 MiB, per its README) echoes it as one frame.
-  for (const file of ["nm_wasi_p1.ts", "nm_node_fs.ts", "nm_deno.ts"]) {
+  for (const file of ["nm_js2wasm_wasi_p1.ts", "nm_js2wasm_node_fs.ts", "nm_js2wasm_deno.ts"]) {
     it(`${file} echoes a 1 MiB frame verbatim`, { timeout: 60_000 }, async () => {
       const r = await getCompiled(file);
       if (!isRunnableStandalone(r)) return;
@@ -448,13 +448,13 @@ describe("#2696 — Native Messaging #389 reporter payloads", () => {
   }
 
   // A LARGE multi-MiB single frame echoed verbatim. Restricted to the RAW
-  // byte-streaming variants (nm_wasi_p1 / nm_deno), which stream any frame through a
-  // fixed window byte-for-byte regardless of size. nm_node_fs deliberately
+  // byte-streaming variants (nm_js2wasm_wasi_p1 / nm_js2wasm_deno), which stream any frame through a
+  // fixed window byte-for-byte regardless of size. nm_js2wasm_node_fs deliberately
   // re-chunks bodies > 1 MiB into <=1 MiB JSON response frames (browser cap), so a
   // single >1 MiB frame does NOT come back byte-identical from it — that is its
   // documented design, exercised separately. The reporter verified a 64 MiB body
   // manually; 3 MiB is the CI-feasible stand-in for the same streaming path.
-  for (const file of ["nm_wasi_p1.ts", "nm_deno.ts"]) {
+  for (const file of ["nm_js2wasm_wasi_p1.ts", "nm_js2wasm_deno.ts"]) {
     it(`${file} echoes a 3 MiB frame verbatim (reporter verified 64 MiB manually)`, { timeout: 120_000 }, async () => {
       const r = await getCompiled(file);
       if (!isRunnableStandalone(r)) return;
@@ -468,14 +468,14 @@ describe("#2696 — Native Messaging #389 reporter payloads", () => {
     });
   }
 
-  // nm_wasi_p3.ts is the WASI Preview 3 async-component source-reference arm. The
+  // nm_js2wasm_wasi_p3.ts is the WASI Preview 3 async-component source-reference arm. The
   // js2wasm P3 producer backend is NOT done (async-lifted `run`, `stream<u8>` /
   // `future<T>` canonical-ABI lowering) — tracked by #2658. The #2696 bug-3 fix
   // made its standalone binary VALID Wasm (it no longer mis-calls __str_to_number),
   // but it still imports only `env` P3 placeholder stubs and does not echo, so it
   // is NOT runnable here. It MUST NOT gate CI — keep it skipped until the P3
   // backend lands.
-  it.skip("nm_wasi_p3.ts — P3 async component backend not done (tracked by #2658)", () => {
+  it.skip("nm_js2wasm_wasi_p3.ts — P3 async component backend not done (tracked by #2658)", () => {
     /* intentionally skipped — see #2658 */
   });
 });

--- a/tests/native-messaging-comparison.test.ts
+++ b/tests/native-messaging-comparison.test.ts
@@ -221,7 +221,9 @@ describe("#2683 Native Messaging comparison harness — every variant compiles",
   // allowed to be a SOURCE-REFERENCE arm that does not yet produce a runnable
   // standalone binary (e.g. the WASI P3 component variant) — the byte-identical
   // test gates those out — but the compiler must not crash on it.
-  for (const file of variants.filter((f) => !["nm_js2wasm_wasi_p1.ts", "nm_js2wasm_node_fs.ts", "nm_js2wasm_node_process.ts"].includes(f))) {
+  for (const file of variants.filter(
+    (f) => !["nm_js2wasm_wasi_p1.ts", "nm_js2wasm_node_fs.ts", "nm_js2wasm_node_process.ts"].includes(f),
+  )) {
     it(`${file} compiles under --target wasi (runnable or source-reference)`, async () => {
       const r = await compileVariant(file);
       expect(r, `${file} produced no compile result`).toBeDefined();
@@ -387,7 +389,12 @@ describe("#2696 — Native Messaging #389 reporter payloads", () => {
   // Every working variant present on disk. nm_js2wasm_wasi_p3.ts is intentionally absent
   // (skipped below). nm_js2wasm_deno.ts is included; it is skipped per-test if it has not
   // landed / is not a runnable standalone module.
-  const WORKING = ["nm_js2wasm_wasi_p1.ts", "nm_js2wasm_node_fs.ts", "nm_js2wasm_deno.ts", "nm_js2wasm_node_process.ts"];
+  const WORKING = [
+    "nm_js2wasm_wasi_p1.ts",
+    "nm_js2wasm_node_fs.ts",
+    "nm_js2wasm_deno.ts",
+    "nm_js2wasm_node_process.ts",
+  ];
 
   for (const file of WORKING) {
     describe(file, () => {

--- a/tests/native-messaging-matrix.test.ts
+++ b/tests/native-messaging-matrix.test.ts
@@ -15,16 +15,16 @@
  * runtime — the matrix therefore runs in every CI shard, not only where
  * `wasmtime` happens to be installed.
  *
- *   - `nm_deno.ts`    / `nm_wasi_p1.ts`  — VERBATIM streamers: a frame of any size
+ *   - `nm_js2wasm_deno.ts`    / `nm_js2wasm_wasi_p1.ts`  — VERBATIM streamers: a frame of any size
  *     is echoed back byte-for-byte through a fixed window. Asserted byte-EXACT at
  *     1 / 64 / 128 MiB.
- *   - `nm_node_fs.ts` — re-chunks a body LARGER than the browser 1 MiB cap into a
+ *   - `nm_js2wasm_node_fs.ts` — re-chunks a body LARGER than the browser 1 MiB cap into a
  *     sequence of valid <=1 MiB JSON frames (its documented design). A single
  *     >1 MiB frame does NOT come back byte-identical, so it is asserted on
  *     ROUND-TRIP correctness instead: every emitted frame is <=1 MiB and a valid
  *     `[…]`, and concatenating the frame interiors reconstructs the original
  *     array body exactly. Tested at 1 / 64 / 128 MiB.
- *   - `nm_node_process.ts` — async `process.stdin` reactor. #2777 replaced the
+ *   - `nm_js2wasm_node_process.ts` — async `process.stdin` reactor. #2777 replaced the
  *     prelude's per-byte chunk build (and the example's growing-cons-rope
  *     `buffered`) with amortized-growth BYTE buffers, making the read side O(n);
  *     it now echoes 1 / 64 / 128 MiB byte-EXACT under the in-process reactor shim
@@ -43,7 +43,7 @@ const SIZES: { label: string; bytes: number }[] = [
   { label: "64 MiB", bytes: 64 * MiB },
   { label: "128 MiB", bytes: 128 * MiB },
 ];
-// The browser per-host->extension-message cap nm_node_fs re-chunks to stay under.
+// The browser per-host->extension-message cap nm_js2wasm_node_fs re-chunks to stay under.
 const FRAME_CAP = 1 * MiB;
 
 // ---- compile cache -----------------------------------------------------------
@@ -53,8 +53,8 @@ async function getCompiled(file: string): Promise<Awaited<ReturnType<typeof comp
   if (!r) {
     const path = join(NM_DIR, file);
     const src = await readFile(path, "utf-8");
-    // Mirror the CLI's routing (#2771): nm_deno / nm_node_fs statically import the
-    // shared `./nm_sync_framing` core (#2778), so they must go through the
+    // Mirror the CLI's routing (#2771): nm_js2wasm_deno / nm_js2wasm_node_fs statically import the
+    // shared `./nm_js2wasm_sync_framing` core (#2778), so they must go through the
     // multi-file bundler; the others stay on the single-source path.
     r = entryHasRelativeImports(src)
       ? await compileProject(path, { target: "wasi", skipSemanticDiagnostics: true })
@@ -94,7 +94,7 @@ function parseFrames(stream: Uint8Array): Uint8Array[] {
 /**
  * Build a valid JSON-array body `[null,null,…,null]` of approximately `approx`
  * bytes, as a lean Buffer (no giant intermediate JS string). Used to exercise
- * nm_node_fs's >1 MiB re-chunk path with a realistic browser payload (the #389
+ * nm_js2wasm_node_fs's >1 MiB re-chunk path with a realistic browser payload (the #389
  * reporter's `Array(n).fill(null)`).
  */
 function jsonArrayBody(approx: number): Buffer {
@@ -186,7 +186,7 @@ async function runFdShim(binary: Uint8Array, stdin: Uint8Array): Promise<Uint8Ar
 
 // ---- in-process async-reactor shim (bulk copies) -----------------------------
 /**
- * Drive the `nm_node_process` ASYNC `process.stdin` reactor in-process — the
+ * Drive the `nm_js2wasm_node_process` ASYNC `process.stdin` reactor in-process — the
  * event-loop analogue of {@link runFdShim} for the synchronous variants. The
  * compiled module's `_start` runs a synchronous run loop that calls
  * `poll_oneoff` (fd0 FD_READ + clock subscriptions), then `__rl_stdin_drain`
@@ -304,7 +304,7 @@ async function runReactorShim(binary: Uint8Array, stdin: Uint8Array): Promise<Ui
 
 // =============================================================================
 describe("#2775 — verbatim streamers echo 1/64/128 MiB byte-for-byte", () => {
-  for (const file of ["nm_deno.ts", "nm_wasi_p1.ts"]) {
+  for (const file of ["nm_js2wasm_deno.ts", "nm_js2wasm_wasi_p1.ts"]) {
     describe(file, () => {
       for (const { label, bytes } of SIZES) {
         it(`echoes a ${label} frame byte-identically`, { timeout: 180_000 }, async () => {
@@ -323,10 +323,10 @@ describe("#2775 — verbatim streamers echo 1/64/128 MiB byte-for-byte", () => {
   }
 });
 
-describe("#2775 — nm_node_fs re-chunk round-trips 1/64/128 MiB correctly", () => {
+describe("#2775 — nm_js2wasm_node_fs re-chunk round-trips 1/64/128 MiB correctly", () => {
   for (const { label, bytes } of SIZES) {
     it(`reassembles a ~${label} array body from valid <=1 MiB frames`, { timeout: 180_000 }, async () => {
-      const r = await getCompiled("nm_node_fs.ts");
+      const r = await getCompiled("nm_js2wasm_node_fs.ts");
       expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
       const body = jsonArrayBody(bytes);
       const out = await runFdShim(r.binary!, frame(body));
@@ -355,8 +355,8 @@ describe("#2775 — nm_node_fs re-chunk round-trips 1/64/128 MiB correctly", () 
   }
 });
 
-describe("#2777 — nm_node_process echoes 1/64/128 MiB byte-for-byte (async reactor)", () => {
-  // nm_node_process is reactor-driven (async `process.stdin`), so it is driven by
+describe("#2777 — nm_js2wasm_node_process echoes 1/64/128 MiB byte-for-byte (async reactor)", () => {
+  // nm_js2wasm_node_process is reactor-driven (async `process.stdin`), so it is driven by
   // the in-process {@link runReactorShim} (poll_oneoff/fd_read/fd_write) rather
   // than the synchronous {@link runFdShim}. Before #2777 its read side was O(n^2)
   // — the prelude built each chunk byte-by-byte and the example re-flattened its
@@ -366,15 +366,15 @@ describe("#2777 — nm_node_process echoes 1/64/128 MiB byte-for-byte (async rea
   // EVERY CI run, byte-identical, matching the other three streaming variants.
   for (const { label, bytes } of SIZES) {
     it(`echoes a ${label} frame byte-identically`, { timeout: 180_000 }, async () => {
-      const r = await getCompiled("nm_node_process.ts");
+      const r = await getCompiled("nm_js2wasm_node_process.ts");
       expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
-      expect(WebAssembly.validate(r.binary!), "nm_node_process.ts must validate").toBe(true);
+      expect(WebAssembly.validate(r.binary!), "nm_js2wasm_node_process.ts must validate").toBe(true);
       const input = frame(new Uint8Array(bytes).fill(0x61));
       const out = await runReactorShim(r.binary!, input);
-      expect(out.length, `nm_node_process ${label} echo length`).toBe(input.length);
+      expect(out.length, `nm_js2wasm_node_process ${label} echo length`).toBe(input.length);
       expect(
         Buffer.compare(Buffer.from(out), Buffer.from(input)),
-        `nm_node_process ${label} must be byte-identical`,
+        `nm_js2wasm_node_process ${label} must be byte-identical`,
       ).toBe(0);
     });
   }


### PR DESCRIPTION
Mechanical rename of the Native-Messaging example hosts to the `nm_js2wasm_<variant>` scheme agreed with the reporter on loopdive/js2#389. No logic changes.

## Renames (history preserved via `git mv`)
- `nm_deno.ts` → `nm_js2wasm_deno.ts`
- `nm_node_fs.ts` → `nm_js2wasm_node_fs.ts` (+ `nm_node_fs.json`/`.sh` companions)
- `nm_node_process.ts` → `nm_js2wasm_node_process.ts`
- `nm_wasi_p1.ts` → `nm_js2wasm_wasi_p1.ts`
- `nm_wasi_p3.ts` → `nm_js2wasm_wasi_p3.ts`
- `nm_sync_framing.ts` → `nm_js2wasm_sync_framing.ts` (shared core)

## References updated
All active references in `examples/`, `tests/`, `.github/`, and `src/` doc-comments migrated (host imports, manifest/metadata/scripts, every NM vitest test, the smoke workflow). `plan/**` history left untouched (historical records).

## Verification (scoped)
- `bash examples/native-messaging/smoke-test.sh` PASSES under real wasmtime v46.
- `tests/native-messaging-comparison.test.ts` (32 passed) and `tests/native-messaging-matrix.test.ts` (12 passed) green with new names.
- `git grep` for old names returns nothing outside `plan/`.

## Coordination
Concurrent with sdev-2807's `nm_js2wasm_node_process` ≥128 MiB fix; `origin/main` merged before opening — no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)