### PR TITLE
fix(#2807): chunk WASI fd_write below wasmtime's ~128 MiB single-write cap

### DIFF
--- a/.github/workflows/native-messaging-smoke.yml
+++ b/.github/workflows/native-messaging-smoke.yml
@@ -57,5 +57,16 @@ jobs:
       - name: Verify wasmtime is on PATH
         run: wasmtime --version
 
+      - name: Install bun (the reporter's bundler — loopdive/js2#389)
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
       - name: Native Messaging round-trip smoke test
         run: ./examples/native-messaging/smoke-test.sh
+
+      - name: Native Messaging real-wasmtime SCALE test (all 4 variants, #2807)
+        # bun-bundles each variant the reporter's way and round-trips it under
+        # real wasmtime at 1/64/128/256 MiB. This catches the #2807 ≥128 MiB
+        # silent fd_write failure that the in-process-shim unit tests mask.
+        run: node examples/native-messaging/scale-test.mjs

--- a/examples/native-messaging/scale-test.mjs
+++ b/examples/native-messaging/scale-test.mjs
@@ -1,0 +1,264 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2807 — REAL-WASMTIME scale round-trip for ALL FOUR Native-Messaging host
+// variants, the reporter's exact pipeline (loopdive/js2#389):
+//
+//   bun build <variant>.ts --target node [externals] --outfile <variant>.js
+//   js2wasm <variant>.js --target wasi [--link node:fs]
+//   wasmtime <variant>.wasm  < framed-input  > echoed-output
+//
+// WHY THIS EXISTS (the #2807 coverage hole): the in-process WASI shim used by
+// `tests/native-messaging-matrix.test.ts` / `issue-2754-transpiled-nm-roundtrip`
+// bulk-copies each `fd_write` iovec in one JS array slice, so it happily "writes"
+// a 256 MiB buffer that REAL wasmtime rejects. wasmtime (v46) fails a single
+// `fd_write` whose iovec length is ≥ ~128 MiB with errno 48 and `nwritten = 0`;
+// the `nm_node_process` host (which builds the WHOLE response frame and writes it
+// in ONE `process.stdout.write`) therefore echoed ZERO bytes and exited 0 at
+// ≥128 MiB — invisible to the shim-based tests. This driver runs the compiled
+// modules under the ACTUAL `wasmtime` binary at sizes that straddle the cap, so
+// the regression cannot recur silently.
+//
+// It ALSO bundles with **bun** (not esbuild): bun's DEFAULT browser target
+// silently stubs `node:fs` → `{}` (a false zero-output), so the variants that
+// speak `node:fs` MUST be built `--target node`; `nm_wasi_p1` keeps its
+// `wasi_snapshot_preview1` / `wasm:memory` intrinsic imports external.
+//
+// Requires `bun` and `wasmtime` on PATH (the native-messaging-smoke CI job
+// installs both). Run: `node examples/native-messaging/scale-test.mjs`.
+// Override the size sweep with `NM_SCALE_SIZES_MIB="1 128 256"`.
+
+import { spawnSync } from "node:child_process";
+import { closeSync, mkdtempSync, openSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const NM_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(NM_DIR, "..", "..");
+const MiB = 1024 * 1024;
+const WASMTIME_FLAGS = ["-W", "gc=y,function-references=y,tail-call=y,exceptions=y"];
+
+const SIZES_MIB = (process.env.NM_SCALE_SIZES_MIB ?? "1 64 128 256")
+  .trim()
+  .split(/\s+/)
+  .map((s) => Number(s))
+  .filter((n) => Number.isFinite(n) && n > 0);
+
+const WORK = mkdtempSync(join(tmpdir(), "nm-scale-"));
+process.on("exit", () => {
+  try {
+    rmSync(WORK, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+function run(cmd, args, opts = {}) {
+  const r = spawnSync(cmd, args, { encoding: "utf-8", ...opts });
+  if (r.status !== 0 && !opts.allowFail) {
+    throw new Error(`\`${cmd} ${args.join(" ")}\` failed (status ${r.status}):\n${r.stderr ?? ""}${r.stdout ?? ""}`);
+  }
+  return r;
+}
+
+// ---- framing helpers (mirror nm_*.ts wire format) ---------------------------
+function writeFrameFile(path, body) {
+  const buf = Buffer.allocUnsafe(4 + body.length);
+  buf.writeUInt32LE(body.length, 0);
+  body.copy(buf, 4);
+  writeFileSync(path, buf);
+}
+
+// Deterministic non-ASCII byte pattern (covers high + null bytes — a string
+// re-encode would corrupt these, so a byte-exact echo proves the raw path).
+function patternBody(bytes) {
+  const b = Buffer.allocUnsafe(bytes);
+  for (let i = 0; i < bytes; i++) b[i] = (i * 7 + 3) & 0xff;
+  return b;
+}
+
+// A valid JSON-array body `[null,null,…]` of ~`approx` bytes (the #389 payload
+// shape the nm_node_fs re-chunker splits on).
+function jsonArrayBody(approx) {
+  const m = Math.max(1, Math.floor((approx - 6) / 5) + 1);
+  const total = 2 + 4 + 5 * (m - 1);
+  const buf = Buffer.alloc(total);
+  let p = 0;
+  buf[p++] = 0x5b; // [
+  buf.write("null", p, "ascii");
+  p += 4;
+  for (let i = 1; i < m; i++) {
+    buf.write(",null", p, "ascii");
+    p += 5;
+  }
+  buf[p++] = 0x5d; // ]
+  return buf;
+}
+
+function parseFrames(stream) {
+  const frames = [];
+  let p = 0;
+  while (p + 4 <= stream.length) {
+    const len = stream[p] + stream[p + 1] * 256 + stream[p + 2] * 65536 + stream[p + 3] * 16777216;
+    p += 4;
+    if (p + len > stream.length) break;
+    frames.push(stream.subarray(p, p + len));
+    p += len;
+  }
+  return frames;
+}
+
+// ---- wasmtime invocation with file-backed stdio (no JS-side buffering) -------
+function runWasmtime({ wasm, preload, inPath, outPath }) {
+  const args = [...WASMTIME_FLAGS];
+  if (preload) args.push("--preload", preload);
+  args.push(wasm);
+  const inFd = openSync(inPath, "r");
+  const outFd = openSync(outPath, "w");
+  try {
+    const r = spawnSync("wasmtime", args, { stdio: [inFd, outFd, "pipe"], encoding: "utf-8" });
+    if (r.status !== 0) {
+      throw new Error(`wasmtime exited ${r.status}\n${r.stderr ?? ""}`);
+    }
+    return r.stderr ?? "";
+  } finally {
+    closeSync(inFd);
+    closeSync(outFd);
+  }
+}
+
+// ---- per-variant build (bun bundle → js2wasm) -------------------------------
+const CLI = join(WORK, "js2wasm-cli.mjs");
+const SHIM = join(WORK, "node-fs.wasm");
+
+function buildToolchain() {
+  run("node", ["scripts/build-standalone-cli.mjs", "--outfile", CLI], { cwd: REPO_ROOT });
+  run("node", ["scripts/build-node-fs-shim.mjs", SHIM], { cwd: REPO_ROOT });
+}
+
+function bunBundle(srcTs, outJs, extraArgs) {
+  run("bun", ["build", join(NM_DIR, srcTs), "--target", "node", ...extraArgs, "--outfile", outJs], { cwd: REPO_ROOT });
+}
+
+function js2wasm(jsFile, extraArgs) {
+  run("node", [CLI, jsFile, "--target", "wasi", ...extraArgs, "-o", WORK, "--quiet"], { cwd: REPO_ROOT });
+}
+
+// Each variant: build once, then echo-test across the size sweep.
+const VARIANTS = [
+  {
+    name: "nm_node_process",
+    src: "nm_node_process.ts",
+    bunExtra: [],
+    js2wasmExtra: [],
+    preload: null,
+    // verbatim single-write echoer — THE #2807 variant (the only one that issues
+    // one >128 MiB fd_write).
+    mode: "verbatim",
+  },
+  { name: "nm_deno", src: "nm_deno.ts", bunExtra: [], js2wasmExtra: [], preload: null, mode: "verbatim" },
+  {
+    name: "nm_wasi_p1",
+    src: "nm_wasi_p1.ts",
+    bunExtra: ["--external", "wasi_snapshot_preview1", "--external", "wasm:memory"],
+    js2wasmExtra: [],
+    preload: null,
+    mode: "verbatim",
+  },
+  {
+    name: "nm_node_fs",
+    src: "nm_node_fs.ts",
+    bunExtra: [],
+    js2wasmExtra: ["--link", "node:fs"],
+    preload: () => `node:fs=${SHIM}`,
+    mode: "rechunk",
+  },
+];
+
+function buildVariant(v) {
+  const js = join(WORK, `${v.name}.js`);
+  bunBundle(v.src, js, v.bunExtra);
+  js2wasm(js, v.js2wasmExtra);
+  const wasm = join(WORK, `${v.name}.js.wasm`);
+  if (!statSync(wasm, { throwIfNoEntry: false })) throw new Error(`${wasm} not produced`);
+  return wasm;
+}
+
+function checkVerbatim(v, wasm, sizeMiB) {
+  const body = patternBody(sizeMiB * MiB);
+  const inPath = join(WORK, "in.bin");
+  const outPath = join(WORK, "out.bin");
+  writeFrameFile(inPath, body);
+  const stderr = runWasmtime({ wasm, preload: v.preload?.(), inPath, outPath });
+  const inBuf = readFileSync(inPath);
+  const outBuf = readFileSync(outPath);
+  if (outBuf.length === 0) {
+    throw new Error(`${v.name} @ ${sizeMiB} MiB: ZERO output (the #2807 silent fd_write failure). stderr=[${stderr}]`);
+  }
+  if (Buffer.compare(inBuf, outBuf) !== 0) {
+    throw new Error(`${v.name} @ ${sizeMiB} MiB: echo mismatch (in=${inBuf.length} out=${outBuf.length})`);
+  }
+}
+
+function checkRechunk(v, wasm, sizeMiB) {
+  const body = jsonArrayBody(sizeMiB * MiB);
+  const inPath = join(WORK, "in.bin");
+  const outPath = join(WORK, "out.bin");
+  writeFrameFile(inPath, body);
+  const stderr = runWasmtime({ wasm, preload: v.preload?.(), inPath, outPath });
+  const outBuf = readFileSync(outPath);
+  if (outBuf.length === 0) {
+    throw new Error(`${v.name} @ ${sizeMiB} MiB: ZERO output. stderr=[${stderr}]`);
+  }
+  // Reassemble the re-chunked array frames' interiors back into the body.
+  const frames = parseFrames(outBuf);
+  if (frames.length < 1) throw new Error(`${v.name} @ ${sizeMiB} MiB: no frames parsed from output`);
+  const parts = [];
+  for (let i = 0; i < frames.length; i++) {
+    const f = frames[i];
+    if (f.length > MiB) throw new Error(`${v.name} @ ${sizeMiB} MiB: frame ${i} exceeds the 1 MiB cap (${f.length})`);
+    if (i > 0) parts.push(Buffer.from([0x2c])); // ,
+    parts.push(Buffer.from(f.subarray(1, f.length - 1))); // strip [ … ]
+  }
+  const recon = Buffer.concat([Buffer.from([0x5b]), Buffer.concat(parts), Buffer.from([0x5d])]);
+  if (Buffer.compare(recon, body) !== 0) {
+    throw new Error(`${v.name} @ ${sizeMiB} MiB: reassembled array body != input`);
+  }
+}
+
+// ---- run --------------------------------------------------------------------
+console.log(`== Native-Messaging real-wasmtime scale test (sizes: ${SIZES_MIB.join(", ")} MiB) ==`);
+console.log(run("wasmtime", ["--version"]).stdout.trim());
+console.log(`bun ${run("bun", ["--version"]).stdout.trim()}`);
+buildToolchain();
+
+let failures = 0;
+for (const v of VARIANTS) {
+  let wasm;
+  try {
+    wasm = buildVariant(v);
+  } catch (e) {
+    console.error(`FAIL build ${v.name}: ${e.message}`);
+    failures++;
+    continue;
+  }
+  for (const sizeMiB of SIZES_MIB) {
+    const t0 = Date.now();
+    try {
+      if (v.mode === "verbatim") checkVerbatim(v, wasm, sizeMiB);
+      else checkRechunk(v, wasm, sizeMiB);
+      console.log(
+        `OK   ${v.name.padEnd(16)} ${String(sizeMiB).padStart(4)} MiB  (${((Date.now() - t0) / 1000).toFixed(1)}s)`,
+      );
+    } catch (e) {
+      console.error(`FAIL ${v.name.padEnd(16)} ${String(sizeMiB).padStart(4)} MiB: ${e.message}`);
+      failures++;
+    }
+  }
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} scale check(s) FAILED.`);
+  process.exit(1);
+}
+console.log("\nPASS: all four Native-Messaging variants echo byte-exact under real wasmtime at every size.");

--- a/plan/issues/2807-nm-node-process-128mib-zero-output.md
+++ b/plan/issues/2807-nm-node-process-128mib-zero-output.md
@@ -1,7 +1,9 @@
 ---
 id: 2807
 title: "nm_node_process (async process.stdin) emits ZERO output at 128 MiB under real wasmtime — and the in-process shim masks it"
-status: ready
+status: done
+assignee: ttraenkler/sendev-2807
+completed: 2026-06-28
 created: 2026-06-28
 updated: 2026-06-28
 priority: high
@@ -89,3 +91,59 @@ browser target silently stubs `node:fs`).
 - #2775 — the matrix test whose in-process shim masks this.
 - #2777 — async read-side amortized byte buffer (suspect path).
 - #1767 — native-messaging 64-MiB memory growth.
+
+## Root cause (white-box confirmed) + fix
+
+**It was NOT the buffer growth / async reactor / GC allocation.** White-box
+tracing of the `nm_node_process` read+drain path showed every byte arrived
+(`totalAppended = 134217732`), the full frame was assembled, and `drain()` fired
+ONCE with the correct `len = 134217728` — i.e. `process.stdout.write(out)` was
+reached with the whole 128 MiB frame — yet `out_size = 0`.
+
+The fault is **`fd_write` itself, in wasmtime**: a hand-written WAT probe (no
+js2wasm codegen) that grows memory and issues a single-iovec `fd_write` proved
+wasmtime v46 **rejects any single `fd_write` whose iovec length is ≥ ~128 MiB**
+— the empirical cap is `len ≤ 0x07FFFFF8` (134217720) OK, `len ≥ 0x07FFFFF9`
+returns **errno 48 with `nwritten = 0`**, *identically for a redirected file and
+a pipe*. So it is a fixed structural cap (wasmtime bounds the guest→host buffer
+it stages per write), not real memory pressure. js2wasm's WASI write helpers map
+a non-zero errno to "0 bytes written" and **drop** it, so the host wrote zero
+bytes and exited 0 — a silent failure.
+
+Why only `nm_node_process`: it is the ONLY variant that builds the WHOLE
+response frame and writes it in ONE `process.stdout.write`. `nm_deno` /
+`nm_wasi_p1` stream through a 64 KiB verbatim window and `nm_node_fs` re-chunks
+to ≤1 MiB frames — none ever issues a >128 MiB single `fd_write`, which is why
+they passed at every size.
+
+**Fix** — a chunked WASI write helper `__wasi_fd_write_all(fd, ptr, len)`
+(`src/codegen/index.ts`) that writes in pieces of at most
+`WASI_FD_WRITE_MAX_CHUNK` (64 MiB — 2× under the cap, confirmed on file + pipe)
+and advances by the ACTUAL `nwritten` each iteration (so a kernel short-write is
+handled too — the old single-shot tail ignored `nwritten` entirely). All three
+direct-WASI write sites route through it: the linear-backed zero-copy path
+(`tryEmitLinearU8StdWrite` — the path `nm_node_process` actually uses), the
+GC-array/string/ArrayBuffer tail (`emitWasiWriteTail`), and `node:fs writeSync` /
+`Deno.stdout.write` (`emitFdWriteRuntime`). The `--link node:fs` shim path is
+unaffected (it forwards to the shim's own `writeSync`).
+
+Index-shift note: `__wasi_fd_write_all` is pre-created at the TOP of each
+`ensure*Helper` (before each reserves its own funcidx) so the lazy creation
+inside `emitWasiWriteTail` never pushes a function mid-body and shifts the
+outer helper's reserved index.
+
+**Verified** byte-exact under REAL wasmtime v46 (bun-transpiled, `--target node`):
+`nm_node_process` 128 / 200 / 256 MiB; `nm_deno` & `nm_wasi_p1` 1 + 256 MiB;
+`nm_node_fs` round-trips with the node:fs shim. All 18 existing NM unit tests
+still pass.
+
+**Coverage hardening (decision #2):**
+- `examples/native-messaging/scale-test.mjs` + the `native-messaging-smoke` job
+  (now installs **bun**) — bun-bundles all four variants the reporter's way
+  (`--target node`; `--external wasi_snapshot_preview1 --external wasm:memory`
+  for `nm_wasi_p1`) and round-trips each under **real wasmtime** at
+  1/64/128/256 MiB.
+- `tests/issue-2807-fd-write-cap.test.ts` — an always-on vitest guard that drives
+  `nm_node_process` through a reactor shim whose `fd_write` FAITHFULLY rejects an
+  oversized single iovec the way wasmtime does (the #2775 bulk-copy shim could
+  not). Proven to FAIL on the pre-fix single-shot write and pass after.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -7021,6 +7021,23 @@ export const WASI_STDIN_BUF_START = 64 * 1024;
 export const WASI_WRITE_SCRATCH_START = 128 * 1024;
 
 /**
+ * #2807 — maximum byte length of a SINGLE `fd_write` iovec. wasmtime (verified
+ * v46.0.1) rejects a one-iovec `fd_write` whose length is at/above ~128 MiB
+ * (empirically the cap is `len <= 0x07FFFFF8`; `len >= 0x07FFFFF9` returns errno
+ * 48 / `ENOMEM` with `nwritten = 0`, identically for a redirected file and a
+ * pipe — wasmtime bounds the guest→host buffer it stages per write, so this is a
+ * fixed structural cap, NOT real memory pressure). Because the `__wasi_write_*`
+ * tails mapped a non-zero errno to "0 bytes", a single `process.stdout.write` of
+ * a ≥128 MiB Native-Messaging body wrote ZERO bytes and the host exited 0 with
+ * no output (the nm_node_process 128-MiB silent-failure of #2807).
+ *
+ * 64 MiB sits a comfortable 2× below the cap and is confirmed to write fully on
+ * both a file and a pipe; the chunk count for even a 256 MiB body is trivial (4),
+ * dwarfed by the per-byte GC→scratch staging copy, so there is no perf cost.
+ */
+export const WASI_FD_WRITE_MAX_CHUNK = 64 * 1024 * 1024;
+
+/**
  * #2655 — DIRECT `readSync` iovec + nread scratch (page 0). The blocking
  * `wasi_snapshot_preview1.fd_read(fd, iovs, iovs_len, nread)` syscall needs a
  * `{ base, len }` iovec (8 bytes) and a `nread` out-slot (4 bytes) in linear
@@ -7068,6 +7085,23 @@ function emitWasiWriteTail(ctx: CodegenContext, fd: number, srcConst: number, le
       { op: "drop" } as Instr, // drop bytes-written
     ];
   }
+  // #2807 — route the direct-WASI write through the chunked `__wasi_fd_write_all`
+  // helper so a ≥128 MiB buffer (a large Native-Messaging frame) is written in
+  // bounded pieces below wasmtime's single-iovec cap, instead of one oversized
+  // fd_write that returns errno 48 and silently drops every byte. The helper is
+  // pre-created at the top of each `__wasi_write_*` helper (and by any inline
+  // caller), so this lookup never pushes a function mid-body — keeping the
+  // outer helper's reserved funcidx stable.
+  const writeAllIdx = ensureWasiFdWriteAllHelper(ctx);
+  if (writeAllIdx >= 0) {
+    return [
+      { op: "i32.const", value: fd } as Instr,
+      { op: "i32.const", value: srcConst } as Instr,
+      { op: "local.get", index: lenLocalIdx } as Instr,
+      { op: "call", funcIdx: writeAllIdx } as Instr,
+      { op: "drop" } as Instr, // drop total bytes-written
+    ];
+  }
   return [
     // iovec.buf = srcConst at memory[0]
     { op: "i32.const", value: 0 } as Instr,
@@ -7085,6 +7119,141 @@ function emitWasiWriteTail(ctx: CodegenContext, fd: number, srcConst: number, le
     { op: "call", funcIdx: ctx.wasiFdWriteIdx } as Instr,
     { op: "drop" } as Instr,
   ];
+}
+
+/**
+ * #2807 — ensure the `__wasi_fd_write_all(fd, ptr, len) -> i32` helper exists and
+ * return its function index (lazy). It writes `len` bytes from linear `ptr` to
+ * `fd` in bounded chunks of at most {@link WASI_FD_WRITE_MAX_CHUNK}, advancing by
+ * the ACTUAL `nwritten` each iteration so a kernel short-write is handled too,
+ * until all bytes are written. Stops on a non-zero errno or a zero-progress write
+ * (never loops forever). Returns the total bytes written.
+ *
+ * This is the single point that defeats wasmtime's ~128 MiB single-`fd_write`
+ * cap (see {@link WASI_FD_WRITE_MAX_CHUNK}). It is a no-op (`-1`) under the
+ * node-shim write path (`ctx.linkNodeShims`) — that path forwards to the shim's
+ * own `writeSync` — and when no direct `fd_write` is registered.
+ *
+ * The iovec at memory[0..7] and nwritten at memory[8..11] are the same page-0
+ * scratch slots the inline tail used; callers stage the data into `ptr` and grow
+ * memory before calling, so this helper only loops the syscall.
+ */
+export function ensureWasiFdWriteAllHelper(ctx: CodegenContext): number {
+  if (!ctx.wasi || ctx.linkNodeShims || ctx.wasiFdWriteIdx === undefined) return -1;
+  const helperName = "__wasi_fd_write_all";
+  const existing = ctx.funcMap.get(helperName);
+  if (existing !== undefined) return existing;
+
+  // params: fd(0), ptr(1), len(2); locals: base(3), remaining(4), total(5),
+  // chunk(6), errno(7), nw(8)
+  const FD = 0;
+  const PTR = 1;
+  const LEN = 2;
+  const BASE = 3;
+  const REMAINING = 4;
+  const TOTAL = 5;
+  const CHUNK = 6;
+  const ERRNO = 7;
+  const NW = 8;
+
+  const funcTypeIdx = addFuncType(ctx, [{ kind: "i32" }, { kind: "i32" }, { kind: "i32" }], [{ kind: "i32" }]);
+  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  ctx.funcMap.set(helperName, funcIdx);
+
+  const loopBody: Instr[] = [
+    // if (remaining <= 0) break out of the block
+    { op: "local.get", index: REMAINING } as Instr,
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "i32.le_s" } as Instr,
+    { op: "br_if", depth: 1 } as Instr,
+    // chunk = min(remaining, MAX_CHUNK) = remaining < MAX ? remaining : MAX
+    { op: "local.get", index: REMAINING } as Instr,
+    { op: "i32.const", value: WASI_FD_WRITE_MAX_CHUNK } as Instr,
+    { op: "local.get", index: REMAINING } as Instr,
+    { op: "i32.const", value: WASI_FD_WRITE_MAX_CHUNK } as Instr,
+    { op: "i32.lt_s" } as Instr,
+    { op: "select" } as Instr,
+    { op: "local.set", index: CHUNK } as Instr,
+    // iovec.buf = base at memory[0]
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "local.get", index: BASE } as Instr,
+    { op: "i32.store", align: 2, offset: 0 } as Instr,
+    // iovec.buf_len = chunk at memory[4]
+    { op: "i32.const", value: 4 } as Instr,
+    { op: "local.get", index: CHUNK } as Instr,
+    { op: "i32.store", align: 2, offset: 0 } as Instr,
+    // errno = fd_write(fd, iovs=0, iovs_len=1, nwritten=8)
+    { op: "local.get", index: FD } as Instr,
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "i32.const", value: 1 } as Instr,
+    { op: "i32.const", value: 8 } as Instr,
+    { op: "call", funcIdx: ctx.wasiFdWriteIdx } as Instr,
+    { op: "local.set", index: ERRNO } as Instr,
+    // if (errno != 0) break — return whatever was written so far
+    { op: "local.get", index: ERRNO } as Instr,
+    { op: "br_if", depth: 1 } as Instr,
+    // nw = memory[8]
+    { op: "i32.const", value: 8 } as Instr,
+    { op: "i32.load", align: 2, offset: 0 } as Instr,
+    { op: "local.set", index: NW } as Instr,
+    // if (nw <= 0) break — no progress, never spin
+    { op: "local.get", index: NW } as Instr,
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "i32.le_s" } as Instr,
+    { op: "br_if", depth: 1 } as Instr,
+    // total += nw
+    { op: "local.get", index: TOTAL } as Instr,
+    { op: "local.get", index: NW } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "local.set", index: TOTAL } as Instr,
+    // base += nw
+    { op: "local.get", index: BASE } as Instr,
+    { op: "local.get", index: NW } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "local.set", index: BASE } as Instr,
+    // remaining -= nw
+    { op: "local.get", index: REMAINING } as Instr,
+    { op: "local.get", index: NW } as Instr,
+    { op: "i32.sub" } as Instr,
+    { op: "local.set", index: REMAINING } as Instr,
+    // continue
+    { op: "br", depth: 0 } as Instr,
+  ];
+
+  const body: Instr[] = [
+    // base = ptr
+    { op: "local.get", index: PTR } as Instr,
+    { op: "local.set", index: BASE } as Instr,
+    // remaining = len
+    { op: "local.get", index: LEN } as Instr,
+    { op: "local.set", index: REMAINING } as Instr,
+    // total = 0
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "local.set", index: TOTAL } as Instr,
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr],
+    } as Instr,
+    { op: "local.get", index: TOTAL } as Instr,
+  ];
+
+  ctx.mod.functions.push({
+    name: helperName,
+    typeIdx: funcTypeIdx,
+    locals: [
+      { name: "base", type: { kind: "i32" } },
+      { name: "remaining", type: { kind: "i32" } },
+      { name: "total", type: { kind: "i32" } },
+      { name: "chunk", type: { kind: "i32" } },
+      { name: "errno", type: { kind: "i32" } },
+      { name: "nw", type: { kind: "i32" } },
+    ],
+    body,
+    exported: false,
+  });
+
+  return funcIdx;
 }
 
 /**
@@ -7699,6 +7868,11 @@ export function ensureWasiWriteAnyStringHelper(ctx: CodegenContext, useStderr: b
   // response in the Native Messaging host (#1723).
   const anyStrTypeIdx = ctx.anyStrTypeIdx >= 0 ? ctx.anyStrTypeIdx : strTypeIdx;
 
+  // #2807 — create the chunked-write helper BEFORE reserving this helper's
+  // funcidx, so the `emitWasiWriteTail` lookup in the body below never pushes a
+  // function mid-build (which would shift this reserved index).
+  ensureWasiFdWriteAllHelper(ctx);
+
   // One param (s=0) ⇒ work-locals start at index 1.
   const layout = wasiStrEncodeLayout(1);
   const funcTypeIdx = addFuncType(ctx, [{ kind: "ref", typeIdx: anyStrTypeIdx }], []);
@@ -7852,6 +8026,10 @@ export function ensureWasiWriteUint8ArrayHelper(
   const I = 3;
   const NEED_PAGES = 4;
 
+  // #2807 — pre-create the chunked-write helper before reserving this funcidx
+  // (see note in ensureWasiWriteAnyStringHelper).
+  ensureWasiFdWriteAllHelper(ctx);
+
   const funcTypeIdx = addFuncType(ctx, [{ kind: "ref", typeIdx: vecTypeIdx }], []);
   const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
   ctx.funcMap.set(helperName, funcIdx);
@@ -7999,6 +8177,10 @@ export function ensureWasiWriteArrayBufferHelper(
   const DATA = 2;
   const I = 3;
   const NEED_PAGES = 4;
+
+  // #2807 — pre-create the chunked-write helper before reserving this funcidx
+  // (see note in ensureWasiWriteAnyStringHelper).
+  ensureWasiFdWriteAllHelper(ctx);
 
   const funcTypeIdx = addFuncType(ctx, [{ kind: "ref", typeIdx: vecTypeIdx }], []);
   const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;

--- a/src/codegen/linear-uint8-codegen.ts
+++ b/src/codegen/linear-uint8-codegen.ts
@@ -23,7 +23,7 @@ import type { Instr, ValType } from "../ir/types.js";
 import { ts } from "../ts-api.js";
 import { allocLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
-import { ensureLinearU8AllocHelper } from "./index.js";
+import { ensureLinearU8AllocHelper, ensureWasiFdWriteAllHelper } from "./index.js";
 import {
   getLinearU8Buffer as lookupLinearU8Buffer,
   isLinearU8SafeBinding,
@@ -444,6 +444,23 @@ export function tryEmitLinearU8StdWrite(
     fctx.body.push({ op: "local.get", index: buf.ptrLocalIdx } as Instr);
     fctx.body.push({ op: "local.get", index: buf.lenLocalIdx } as Instr);
     fctx.body.push({ op: "call", funcIdx: writeSinkIdx } as Instr);
+    fctx.body.push({ op: "drop" } as Instr);
+    return true;
+  }
+
+  // #2807 — route through the chunked `__wasi_fd_write_all` helper so a
+  // ≥128 MiB linear-backed frame (the nm_node_process large-message echo) is
+  // split into pieces below wasmtime's single-iovec fd_write cap. A single
+  // oversized fd_write returns errno 48 with nwritten 0, which the drop here
+  // would silently swallow → zero output, exit 0 (#2807). The helper reads
+  // straight from `ptr` for each chunk (still zero-copy) and returns total
+  // bytes written (dropped to match the stack contract).
+  const writeAllIdx = ensureWasiFdWriteAllHelper(ctx);
+  if (writeAllIdx >= 0) {
+    fctx.body.push({ op: "i32.const", value: fd } as Instr);
+    fctx.body.push({ op: "local.get", index: buf.ptrLocalIdx } as Instr);
+    fctx.body.push({ op: "local.get", index: buf.lenLocalIdx } as Instr);
+    fctx.body.push({ op: "call", funcIdx: writeAllIdx } as Instr);
     fctx.body.push({ op: "drop" } as Instr);
     return true;
   }

--- a/src/codegen/node-fs-api.ts
+++ b/src/codegen/node-fs-api.ts
@@ -19,6 +19,7 @@ import { emitDataViewToWriteScratch } from "./dataview-native.js";
 import { noJsHost } from "./expressions/helpers.js";
 import { flushLateImportShifts } from "./expressions/late-imports.js";
 import {
+  ensureWasiFdWriteAllHelper,
   ensureWasiWriteAnyStringFdHelper,
   ensureWasiWriteAnyStringHelper,
   ensureWasiWriteArrayBufferHelper,
@@ -398,6 +399,19 @@ export function emitFdWriteRuntime(
     fctx.body.push({ op: "local.get", index: ptrLocal } as Instr);
     fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
     fctx.body.push({ op: "call", funcIdx: sinkIdx } as Instr);
+    return;
+  }
+  // #2807 — write via the chunked `__wasi_fd_write_all` helper so a ≥128 MiB
+  // buffer is split below wasmtime's single-iovec fd_write cap (errno 48 /
+  // silent 0-byte write otherwise). Returns total bytes written (i32), matching
+  // the inline path's stack contract. Falls back to the inline single fd_write
+  // when the helper is unavailable.
+  const writeAllIdx = ensureWasiFdWriteAllHelper(ctx);
+  if (writeAllIdx >= 0) {
+    fctx.body.push({ op: "local.get", index: fdLocal } as Instr);
+    fctx.body.push({ op: "local.get", index: ptrLocal } as Instr);
+    fctx.body.push({ op: "local.get", index: lenLocal } as Instr);
+    fctx.body.push({ op: "call", funcIdx: writeAllIdx } as Instr);
     return;
   }
   // iovec.base = ptr at memory[0]; iovec.len = len at memory[4].

--- a/tests/issue-2807-fd-write-cap.test.ts
+++ b/tests/issue-2807-fd-write-cap.test.ts
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2807 — `nm_node_process` (async `process.stdin`) echoed ZERO bytes for a
+ * framed body ≥ ~128 MiB under REAL wasmtime, while the in-process matrix shim
+ * passed. Root cause: it builds the WHOLE response frame and writes it in ONE
+ * `process.stdout.write`, and wasmtime (v46) REJECTS a single `fd_write` whose
+ * iovec length is ≥ ~128 MiB (errno 48 / `nwritten = 0`); the WASI write helper
+ * mapped that non-zero errno to "0 bytes" and the host exited 0 with no output.
+ *
+ * The fix chunks every WASI `fd_write` into pieces of at most
+ * {@link WASI_FD_WRITE_MAX_CHUNK} (`__wasi_fd_write_all`). The #2775 matrix shim
+ * bulk-copies each iovec in one JS slice, so it can't model wasmtime's cap and
+ * MASKED this. This test drives `nm_node_process` through a reactor shim whose
+ * `fd_write` FAITHFULLY rejects an oversized single iovec exactly the way
+ * wasmtime does — so a regression to a single full-frame write fails HERE, on
+ * every CI run, with no wasmtime binary required (the real-wasmtime guard lives
+ * in `examples/native-messaging/scale-test.mjs` / the native-messaging-smoke job).
+ *
+ * It is sized at just over one chunk so the buffers stay ~64 MiB (matching the
+ * existing matrix cost) while still crossing the chunk boundary that the fix
+ * must split.
+ */
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { WASI_FD_WRITE_MAX_CHUNK } from "../src/codegen/index.js";
+import { readFileSync } from "node:fs";
+
+const NM_DIR = join(__dirname, "..", "examples", "native-messaging");
+
+// Model wasmtime's structural single-`fd_write` cap. The real value is ~128 MiB
+// (0x07FFFFF9); we model it at one byte ABOVE the compiler's chunk size so the
+// test stays ~64 MiB yet still proves the fix never emits a write larger than
+// the chunk. A static guard below pins the chunk safely under the REAL cap too.
+const MODELLED_CAP = WASI_FD_WRITE_MAX_CHUNK + 1;
+const WASMTIME_REAL_CAP = 0x07ff_fff9; // first length wasmtime v46 rejects (errno 48)
+
+function frame(body: Uint8Array): Uint8Array {
+  const out = new Uint8Array(4 + body.length);
+  const n = body.length;
+  out[0] = n & 0xff;
+  out[1] = (n >> 8) & 0xff;
+  out[2] = (n >> 16) & 0xff;
+  out[3] = (n >> 24) & 0xff;
+  out.set(body, 4);
+  return out;
+}
+
+/**
+ * Reactor shim for `nm_node_process`, with a wasmtime-FAITHFUL capped `fd_write`:
+ * a single iovec whose length exceeds {@link MODELLED_CAP} is rejected with errno
+ * 48 and `nwritten` left at 0 (exactly wasmtime's behaviour), instead of being
+ * bulk-copied. Tracks the largest single fd1 write seen so the test can assert
+ * the helper chunked. (poll_oneoff / fd_read mirror the #2775 matrix shim.)
+ */
+async function runReactorShimCapped(
+  binary: Uint8Array,
+  stdin: Uint8Array,
+): Promise<{ out: Uint8Array; maxWrite: number; rejected: number }> {
+  let inPos = 0;
+  const chunks: Uint8Array[] = [];
+  let outLen = 0;
+  let maxWrite = 0;
+  let rejected = 0;
+  const ref: { mem?: WebAssembly.Memory } = {};
+  const wasi = {
+    fd_read(_fd: number, iovs: number, iovsLen: number, nread: number): number {
+      const v = new DataView(ref.mem!.buffer);
+      const mem = new Uint8Array(ref.mem!.buffer);
+      let total = 0;
+      for (let i = 0; i < iovsLen; i++) {
+        const buf = v.getUint32(iovs + i * 8, true);
+        const len = v.getUint32(iovs + i * 8 + 4, true);
+        if (len === 0) continue;
+        const n = Math.min(len, stdin.length - inPos);
+        if (n <= 0) break;
+        mem.set(stdin.subarray(inPos, inPos + n), buf);
+        inPos += n;
+        total += n;
+        if (n < len) break;
+      }
+      v.setUint32(nread, total, true);
+      return 0;
+    },
+    fd_write(fd: number, iovs: number, iovsLen: number, nwritten: number): number {
+      const v = new DataView(ref.mem!.buffer);
+      const mem = new Uint8Array(ref.mem!.buffer);
+      let total = 0;
+      for (let i = 0; i < iovsLen; i++) {
+        const buf = v.getUint32(iovs + i * 8, true);
+        const len = v.getUint32(iovs + i * 8 + 4, true);
+        if (fd === 1 && len > 0) {
+          if (len > maxWrite) maxWrite = len;
+          if (len > MODELLED_CAP) {
+            // wasmtime rejects the oversized single write: errno 48, nwritten
+            // untouched (the helper breaks on a non-zero errno before reading it).
+            rejected++;
+            return 48;
+          }
+          chunks.push(mem.slice(buf, buf + len));
+          outLen += len;
+        }
+        total += len;
+      }
+      v.setUint32(nwritten, total, true);
+      return 0;
+    },
+    poll_oneoff(inPtr: number, outPtr: number, nsubs: number, neventsOut: number): number {
+      const v = new DataView(ref.mem!.buffer);
+      type Sub = { type: number; fd: number; userdata: bigint };
+      const subs: Sub[] = [];
+      for (let s = 0; s < nsubs; s++) {
+        const off = inPtr + s * 48;
+        const userdata = v.getBigUint64(off, true);
+        const tag = v.getUint8(off + 8);
+        const fd = tag === 1 ? v.getUint32(off + 16, true) : -1;
+        subs.push({ type: tag, fd, userdata });
+      }
+      const fd0Readable = stdin.length - inPos > 0;
+      const fd0Sub = subs.find((x) => x.type === 1 && x.fd === 0);
+      const clockSub = subs.find((x) => x.type === 0);
+      const fired: Sub[] = [];
+      if (fd0Sub && fd0Readable) fired.push(fd0Sub);
+      else if (clockSub) fired.push(clockSub);
+      else if (fd0Sub) fired.push(fd0Sub);
+      else if (subs.length > 0) fired.push(subs[0]!);
+      let n = 0;
+      for (const ev of fired) {
+        const eoff = outPtr + n * 32;
+        for (let i = 0; i < 32; i++) v.setUint8(eoff + i, 0);
+        v.setBigUint64(eoff, ev.userdata, true);
+        v.setUint16(eoff + 8, 0, true);
+        v.setUint8(eoff + 10, ev.type);
+        n++;
+      }
+      v.setUint32(neventsOut, n, true);
+      return 0;
+    },
+    fd_fdstat_set_flags(): number {
+      return 0;
+    },
+    clock_time_get(): number {
+      return 0;
+    },
+    proc_exit(): void {},
+    random_get(): number {
+      return 0;
+    },
+  };
+  const { instance } = await WebAssembly.instantiate(binary, {
+    wasi_snapshot_preview1: wasi as unknown as WebAssembly.ModuleImports,
+    env: {},
+  });
+  ref.mem = instance.exports.memory as WebAssembly.Memory;
+  const start = (instance.exports._start ?? instance.exports.main) as () => void;
+  start();
+  const out = new Uint8Array(outLen);
+  let o = 0;
+  for (const c of chunks) {
+    out.set(c, o);
+    o += c.length;
+  }
+  return { out, maxWrite, rejected };
+}
+
+describe("#2807 — nm_node_process echoes a >chunk frame under a wasmtime-faithful fd_write cap", () => {
+  it(
+    "chunks the write so no single fd_write exceeds the cap, and echoes byte-exact",
+    { timeout: 180_000 },
+    async () => {
+      // The chunk size must sit safely below wasmtime's real ~128 MiB cap, or a
+      // single chunk would itself be rejected by real wasmtime.
+      expect(WASI_FD_WRITE_MAX_CHUNK).toBeLessThan(WASMTIME_REAL_CAP);
+
+      const src = readFileSync(join(NM_DIR, "nm_node_process.ts"), "utf-8");
+      const r = await compile(src, { fileName: "nm_node_process.ts", target: "wasi", skipSemanticDiagnostics: true });
+      expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+      expect(WebAssembly.validate(r.binary!), "nm_node_process.ts must validate").toBe(true);
+
+      // One chunk + a remainder: the OLD single-shot write would be one
+      // (chunk + remainder) iovec — rejected by the modelled cap → zero output.
+      const body = new Uint8Array(WASI_FD_WRITE_MAX_CHUNK + 8192).fill(0x61);
+      const input = frame(body);
+
+      const { out, maxWrite, rejected } = await runReactorShimCapped(r.binary!, input);
+
+      expect(rejected, "no fd_write may exceed the cap (the #2807 single-shot regression)").toBe(0);
+      expect(out.length, "must not emit zero bytes (the #2807 silent failure)").toBe(input.length);
+      expect(Buffer.compare(Buffer.from(out), Buffer.from(input)), "echo must be byte-identical").toBe(0);
+      expect(maxWrite, "every single fd_write stays within the chunk cap").toBeLessThanOrEqual(WASI_FD_WRITE_MAX_CHUNK);
+    },
+  );
+});


### PR DESCRIPTION
## Problem (#2807)
`nm_node_process` (async `process.stdin`, **bun-transpiled**) echoed **ZERO bytes and exited 0** for a framed body **≥128 MiB** under real wasmtime v46; ≤127 MiB and the other three NM variants were byte-exact at all sizes.

## Root cause (white-box confirmed)
**Not** the buffer growth / async reactor / GC allocation. Tracing showed every byte arrived, the full frame was assembled, and `process.stdout.write(out)` was reached — yet 0 bytes out. A hand-written WAT probe (no js2wasm codegen) proved **wasmtime v46's `fd_write` rejects any single iovec whose length is ≥ ~128 MiB**: `len ≤ 0x07FFFFF8` OK, `len ≥ 0x07FFFFF9` → **errno 48, `nwritten = 0`**, *identically for a redirected file and a pipe* (a fixed structural cap — wasmtime bounds the guest→host staging buffer — not memory pressure). js2wasm's WASI write helpers mapped that errno to "0 bytes" and dropped it → silent zero output.

Only `nm_node_process` hit it: it builds the whole frame and writes it in ONE call. `nm_deno`/`nm_wasi_p1` stream through a 64 KiB window; `nm_node_fs` re-chunks to ≤1 MiB — none issues a >128 MiB single write.

## Fix
New chunked helper `__wasi_fd_write_all(fd, ptr, len)` writes in pieces ≤ `WASI_FD_WRITE_MAX_CHUNK` (64 MiB, 2× under the cap; confirmed on file + pipe) and advances by the **actual** `nwritten` each iteration (also fixing the previously-ignored short-write). All three direct-WASI write sites route through it: `tryEmitLinearU8StdWrite` (the path nm_node_process uses), `emitWasiWriteTail` (GC array/string/ArrayBuffer), `emitFdWriteRuntime` (node:fs `writeSync` / `Deno.stdout.write`). The `--link node:fs` shim path is unchanged. The helper is pre-created at the top of each `ensure*Helper` so lazy creation never shifts a reserved funcidx mid-body.

## Verified (real wasmtime v46, bun `--target node`)
- nm_node_process: **128 / 200 / 256 MiB byte-exact**
- nm_deno, nm_wasi_p1: 1 + 256 MiB byte-exact
- nm_node_fs: round-trips via the node:fs shim
- All 18 existing NM unit tests pass.

## Coverage hardening (decision #2 — why CI stayed green on a broken case)
- `examples/native-messaging/scale-test.mjs` + the `native-messaging-smoke` job (now installs **bun**): bun-bundles all four variants the reporter's way (`--target node`; `--external wasi_snapshot_preview1 --external wasm:memory` for nm_wasi_p1) and round-trips each under **real wasmtime** at 1/64/128/256 MiB.
- `tests/issue-2807-fd-write-cap.test.ts`: always-on vitest guard with a wasmtime-faithful capped `fd_write` (the #2775 bulk-copy shim masked this). **Proven to fail on the pre-fix single-shot write and pass after.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)