### PR TITLE
fix: adopt nm_js2wasm_* rename in #2807's new test + scale files (broken main)

### DIFF
--- a/examples/native-messaging/scale-test.mjs
+++ b/examples/native-messaging/scale-test.mjs
@@ -12,7 +12,7 @@
 // bulk-copies each `fd_write` iovec in one JS array slice, so it happily "writes"
 // a 256 MiB buffer that REAL wasmtime rejects. wasmtime (v46) fails a single
 // `fd_write` whose iovec length is ≥ ~128 MiB with errno 48 and `nwritten = 0`;
-// the `nm_node_process` host (which builds the WHOLE response frame and writes it
+// the `nm_js2wasm_node_process` host (which builds the WHOLE response frame and writes it
 // in ONE `process.stdout.write`) therefore echoed ZERO bytes and exited 0 at
 // ≥128 MiB — invisible to the shim-based tests. This driver runs the compiled
 // modules under the ACTUAL `wasmtime` binary at sizes that straddle the cap, so
@@ -20,7 +20,7 @@
 //
 // It ALSO bundles with **bun** (not esbuild): bun's DEFAULT browser target
 // silently stubs `node:fs` → `{}` (a false zero-output), so the variants that
-// speak `node:fs` MUST be built `--target node`; `nm_wasi_p1` keeps its
+// speak `node:fs` MUST be built `--target node`; `nm_js2wasm_wasi_p1` keeps its
 // `wasi_snapshot_preview1` / `wasm:memory` intrinsic imports external.
 //
 // Requires `bun` and `wasmtime` on PATH (the native-messaging-smoke CI job
@@ -78,7 +78,7 @@ function patternBody(bytes) {
 }
 
 // A valid JSON-array body `[null,null,…]` of ~`approx` bytes (the #389 payload
-// shape the nm_node_fs re-chunker splits on).
+// shape the nm_js2wasm_node_fs re-chunker splits on).
 function jsonArrayBody(approx) {
   const m = Math.max(1, Math.floor((approx - 6) / 5) + 1);
   const total = 2 + 4 + 5 * (m - 1);
@@ -147,8 +147,8 @@ function js2wasm(jsFile, extraArgs) {
 // Each variant: build once, then echo-test across the size sweep.
 const VARIANTS = [
   {
-    name: "nm_node_process",
-    src: "nm_node_process.ts",
+    name: "nm_js2wasm_node_process",
+    src: "nm_js2wasm_node_process.ts",
     bunExtra: [],
     js2wasmExtra: [],
     preload: null,
@@ -156,18 +156,18 @@ const VARIANTS = [
     // one >128 MiB fd_write).
     mode: "verbatim",
   },
-  { name: "nm_deno", src: "nm_deno.ts", bunExtra: [], js2wasmExtra: [], preload: null, mode: "verbatim" },
+  { name: "nm_js2wasm_deno", src: "nm_js2wasm_deno.ts", bunExtra: [], js2wasmExtra: [], preload: null, mode: "verbatim" },
   {
-    name: "nm_wasi_p1",
-    src: "nm_wasi_p1.ts",
+    name: "nm_js2wasm_wasi_p1",
+    src: "nm_js2wasm_wasi_p1.ts",
     bunExtra: ["--external", "wasi_snapshot_preview1", "--external", "wasm:memory"],
     js2wasmExtra: [],
     preload: null,
     mode: "verbatim",
   },
   {
-    name: "nm_node_fs",
-    src: "nm_node_fs.ts",
+    name: "nm_js2wasm_node_fs",
+    src: "nm_js2wasm_node_fs.ts",
     bunExtra: [],
     js2wasmExtra: ["--link", "node:fs"],
     preload: () => `node:fs=${SHIM}`,

--- a/tests/issue-2807-fd-write-cap.test.ts
+++ b/tests/issue-2807-fd-write-cap.test.ts
@@ -173,7 +173,11 @@ describe("#2807 — nm_js2wasm_node_process echoes a >chunk frame under a wasmti
       expect(WASI_FD_WRITE_MAX_CHUNK).toBeLessThan(WASMTIME_REAL_CAP);
 
       const src = readFileSync(join(NM_DIR, "nm_js2wasm_node_process.ts"), "utf-8");
-      const r = await compile(src, { fileName: "nm_js2wasm_node_process.ts", target: "wasi", skipSemanticDiagnostics: true });
+      const r = await compile(src, {
+        fileName: "nm_js2wasm_node_process.ts",
+        target: "wasi",
+        skipSemanticDiagnostics: true,
+      });
       expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
       expect(WebAssembly.validate(r.binary!), "nm_js2wasm_node_process.ts must validate").toBe(true);
 

--- a/tests/issue-2807-fd-write-cap.test.ts
+++ b/tests/issue-2807-fd-write-cap.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 /**
- * #2807 — `nm_node_process` (async `process.stdin`) echoed ZERO bytes for a
+ * #2807 — `nm_js2wasm_node_process` (async `process.stdin`) echoed ZERO bytes for a
  * framed body ≥ ~128 MiB under REAL wasmtime, while the in-process matrix shim
  * passed. Root cause: it builds the WHOLE response frame and writes it in ONE
  * `process.stdout.write`, and wasmtime (v46) REJECTS a single `fd_write` whose
@@ -10,7 +10,7 @@
  * The fix chunks every WASI `fd_write` into pieces of at most
  * {@link WASI_FD_WRITE_MAX_CHUNK} (`__wasi_fd_write_all`). The #2775 matrix shim
  * bulk-copies each iovec in one JS slice, so it can't model wasmtime's cap and
- * MASKED this. This test drives `nm_node_process` through a reactor shim whose
+ * MASKED this. This test drives `nm_js2wasm_node_process` through a reactor shim whose
  * `fd_write` FAITHFULLY rejects an oversized single iovec exactly the way
  * wasmtime does — so a regression to a single full-frame write fails HERE, on
  * every CI run, with no wasmtime binary required (the real-wasmtime guard lives
@@ -47,7 +47,7 @@ function frame(body: Uint8Array): Uint8Array {
 }
 
 /**
- * Reactor shim for `nm_node_process`, with a wasmtime-FAITHFUL capped `fd_write`:
+ * Reactor shim for `nm_js2wasm_node_process`, with a wasmtime-FAITHFUL capped `fd_write`:
  * a single iovec whose length exceeds {@link MODELLED_CAP} is rejected with errno
  * 48 and `nwritten` left at 0 (exactly wasmtime's behaviour), instead of being
  * bulk-copied. Tracks the largest single fd1 write seen so the test can assert
@@ -163,7 +163,7 @@ async function runReactorShimCapped(
   return { out, maxWrite, rejected };
 }
 
-describe("#2807 — nm_node_process echoes a >chunk frame under a wasmtime-faithful fd_write cap", () => {
+describe("#2807 — nm_js2wasm_node_process echoes a >chunk frame under a wasmtime-faithful fd_write cap", () => {
   it(
     "chunks the write so no single fd_write exceeds the cap, and echoes byte-exact",
     { timeout: 180_000 },
@@ -172,10 +172,10 @@ describe("#2807 — nm_node_process echoes a >chunk frame under a wasmtime-faith
       // single chunk would itself be rejected by real wasmtime.
       expect(WASI_FD_WRITE_MAX_CHUNK).toBeLessThan(WASMTIME_REAL_CAP);
 
-      const src = readFileSync(join(NM_DIR, "nm_node_process.ts"), "utf-8");
-      const r = await compile(src, { fileName: "nm_node_process.ts", target: "wasi", skipSemanticDiagnostics: true });
+      const src = readFileSync(join(NM_DIR, "nm_js2wasm_node_process.ts"), "utf-8");
+      const r = await compile(src, { fileName: "nm_js2wasm_node_process.ts", target: "wasi", skipSemanticDiagnostics: true });
       expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
-      expect(WebAssembly.validate(r.binary!), "nm_node_process.ts must validate").toBe(true);
+      expect(WebAssembly.validate(r.binary!), "nm_js2wasm_node_process.ts must validate").toBe(true);
 
       // One chunk + a remainder: the OLD single-shot write would be one
       // (chunk + remainder) iovec — rejected by the modelled cap → zero output.


### PR DESCRIPTION
**Fixes broken main.** #2282 (rename) and #2283 (#2807 fix) merged back-to-back; #2282 landed first (already queued — the hold couldn't dequeue it), so #2283's two new files still reference the pre-rename names and now load renamed-away files: `tests/issue-2807-fd-write-cap.test.ts` (readFileSync+compile `nm_node_process.ts`) and `examples/native-messaging/scale-test.mjs` (`src: nm_*.ts`). Repointed both to `nm_js2wasm_*`; verified the target files exist. Pure reference fix.