### PR TITLE
fix(#2808): for-of object-binding head recurses into nested sub-patterns

### DIFF
--- a/plan/issues/2808-forof-object-binding-nested-subpattern.md
+++ b/plan/issues/2808-forof-object-binding-nested-subpattern.md
@@ -1,0 +1,135 @@
+---
+id: 2808
+parent: 2669
+title: "for-of OBJECT-binding head drops nested sub-patterns (no bind, no RequireObjectCoercible throw)"
+status: done
+created: 2026-06-28
+completed: 2026-06-28
+assignee: ttraenkler/dstr2
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen
+es_edition: 2015
+language_feature: destructuring
+goal: spec-completeness
+sprint: current
+---
+
+# #2808 — for-of OBJECT-binding head drops nested sub-patterns
+
+Slice of the #2669 ES2015 destructuring-correctness umbrella. Concentrated in the
+for-of / for-await loop-head binding path, which is a **separate, less-complete
+reimplementation** of destructuring (`compileForOfDestructuring`,
+`src/codegen/statements/loops.ts`) than the binding-declaration / param paths
+(those already pass these tests).
+
+## Cluster + net-recovery
+
+Verify-first re-sweep of the whole `/dstr/` surface on current `origin/main`
+(post-#2279). The binding-declaration, object-method and class dirs already
+PASS the nested-`null`/`undefined`-must-throw and nested-value-extract templates
+(137 / 156). The residual is **for-of-specific**: the for-of binding head drops
+nested object/array sub-patterns. Path-classified clean (non-generator,
+non-custom-iterable) for-of fails:
+
+| sub-pattern family | tests |
+|--------------------|-------|
+| `for-of/dstr` `{var,let,const}-obj-ptrn-prop-{obj,ary}{,-init,-value-null,-trailing-comma,-value-undef}` | **18** |
+| `for-await-of` `async-{func,gen}-dstr-{var,let,const}-obj-ptrn-prop-{obj,ary}*` | **24** |
+
+**Net recovery: +42 test262, 0 regressions** (full before/after on `for-of/dstr`
+(569) and the flat `for-await-of` dstr dir (1215), swapping `loops.ts` clean-main
+vs fixed).
+
+## Root cause
+
+`compileForOfDestructuring`'s ARRAY-pattern branch recurses into nested
+sub-patterns (#2216 / #2669), but the **OBJECT-pattern struct branch dropped
+them**: after resolving the property name it hit
+
+```ts
+if (!ts.isIdentifier(element.name)) continue; // skip non-identifier binding names
+```
+
+For `for (const { w: { x } } of …)` the binding element's `name` is a nested
+`ObjectBindingPattern`/`ArrayBindingPattern`, not an `Identifier`, so the element
+was **skipped entirely**:
+
+1. the inner names (`x`,`y`,`z`) were never bound — wrong value
+   (`*-prop-obj`, `*-prop-ary`, `*-trailing-comma`); and
+2. for a `null`/`undefined` property value the nested pattern was never applied,
+   so **RequireObjectCoercible (object sub-pattern) / GetIterator (array
+   sub-pattern) never ran and no `TypeError` was thrown**
+   (`*-prop-{obj,ary}-value-null`, ECMA-262 §13.15.5.5 / §8.5.2).
+
+## Fix
+
+`src/codegen/statements/loops.ts`, in the object-pattern struct branch of
+`compileForOfDestructuring`, handle a nested sub-pattern **before** the
+identifier-only `continue`, mirroring the proven array-branch handler:
+
+- **field present** (`fieldIdx >= 0`): `struct.get` the value into a fresh
+  `nestedLocal`, apply `emitNestedBindingDefault` (fires only on `undefined`,
+  never `null` — KeyedBindingInitialization §13.3.3.7 step 3), then recurse
+  `compileForOfDestructuring(element.name, nestedLocal, fieldType, stmt)`. The
+  recursion's own `emitNullGuard` / externref RequireObjectCoercible guard throws
+  `TypeError` for a `null`/`undefined` target — so the throw is handled by the
+  recursion, not re-emitted here.
+- **field absent** (`fieldIdx === -1`, value is `undefined`): if a pure default
+  is present, compile it as the nested source and recurse; otherwise force a
+  nullable carrier and recurse so the guard throws.
+
+The nested **default** is gated `!stmt.awaitModifier && !ts.isCallExpression(...)`
+— identical to the array branch. A call default compiled in a conditionally-
+skipped arm materialises its capture box on the not-taken branch (#2692) /
+over-consumes a generator (#2566); the `awaitModifier` exclusion matches the
+#2216 for-await regression precedent. Pure literal/identifier defaults have no
+side effect or capture box, so they are safe.
+
+## Why for-of had the gap (and the dec/param paths did not)
+
+The binding-declaration (`compileVariableDeclaration`), function-param
+(`destructureParamObject`) and assignment (`expressions/assignment.ts`) paths all
+recurse into nested sub-patterns already. `compileForOfDestructuring` is the
+fourth, loop-head-specific lowering; its object branch was the only one that
+never gained nested recursion. This slice closes that asymmetry for the SYNC
+object branch.
+
+## Scope / residual (NOT this slice)
+
+- The **object** nested-default-FIRES sub-case where the property *value* is
+  `undefined` (so the struct field lowers to **externref**) is recovered for the
+  test262 cluster (`*-obj-ptrn-prop-obj-init`, passes under the production
+  runner) but is representation-sensitive under a bare standalone `compile()`
+  (externref-field default coercion → `__extern_get` on a wrapped GC struct;
+  #2769-adjacent). Tracked under the #2669 tail, not regressed by this slice.
+- The for-of / plain **ASSIGNMENT** destructuring nested cases
+  (`obj-prop-nested-*`, `expressions/assignment/dstr/obj-prop-nested-*`) live in
+  `compileForOfAssignDestructuring` / `expressions/assignment.ts` — a different
+  lowering — and remain under the umbrella.
+- Generator-source / custom-iterable nested cases stay blocked on #2566 / #2662.
+- Heterogeneous typed-vec `[10, undefined]` → NaN is the pre-existing #2769
+  array-branch representation gap (untouched by this object-branch slice).
+
+## Acceptance criteria
+
+- `for (const { a: { x }, b: [y] } of arr)` binds inner names correctly. ✓
+- A nested object/array sub-pattern over a `null`/`undefined` property value
+  throws `TypeError` (RequireObjectCoercible / GetIterator). ✓
+- A nested default fires only on `undefined`, never `null`. ✓
+- No regression in currently-passing for-of / for-await destructuring tests
+  (full before/after: 0 regressions). ✓
+
+## Validation
+
+- Guard test `tests/issue-2808.test.ts` — 10/10 green (value extraction, nested
+  array default, the three null/undefined throw cases, three controls).
+- test262 before/after (clean-main `loops.ts` vs fixed, identical
+  `runTest262File` harness):
+  - `for-of/dstr` (569 files): **+18, 0 regressions**.
+  - `for-await-of` dstr (1215 files): **+24, 0 regressions**.
+- Blast radius is exactly `compileForOfDestructuring` (for-of / for-await loop
+  heads). The binding-declaration / object-method / class / param dstr dirs use
+  different lowerings and are unaffected.

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -1496,6 +1496,62 @@ function compileForOfDestructuring(
         if (!propNameText && ts.isComputedPropertyName(propNameNode)) {
           propNameText = resolveComputedKeyExpression(ctx, propNameNode.expression);
         }
+        // (#2808) Nested sub-pattern in a for-of OBJECT binding head:
+        //   for (const { a: { x }, b: [y] } of arr)
+        // The struct branch previously DROPPED these at the identifier-only
+        // `continue` just below, so a nested object/array sub-pattern never
+        // bound its inner names and — for a null/undefined property value —
+        // never threw. Mirror the array branch (#2669/#2216): extract the
+        // field value, apply the (undefined-only) nested default, then recurse.
+        // `compileForOfDestructuring`'s own RequireObjectCoercible / GetIterator
+        // null guard throws TypeError for a null/undefined nested target
+        // (§13.15.5.5 / §8.5.2 BindingInitialization), so the throw is handled
+        // by the recursion rather than re-emitted here.
+        if (propNameText && (ts.isObjectBindingPattern(element.name) || ts.isArrayBindingPattern(element.name))) {
+          const nestedFieldIdx = fields.findIndex((f) => f.name === propNameText);
+          // A default initializer fires ONLY when the property value is
+          // `undefined` (never `null`) — KeyedBindingInitialization §13.3.3.7
+          // step 3. Restricted to PURE (non-call) defaults: a call default
+          // compiled in a conditionally-skipped arm materialises its capture box
+          // on the not-taken branch (#2692) / over-consumes a generator (#2566),
+          // exactly the for-await regression class the array branch guards against.
+          const nestedInit =
+            element.initializer && !stmt.awaitModifier && !ts.isCallExpression(element.initializer)
+              ? element.initializer
+              : undefined;
+          if (nestedFieldIdx >= 0) {
+            const nestedFieldType = fields[nestedFieldIdx]!.type;
+            const nestedLocal = allocLocal(fctx, `__forof_obj_nested_${fctx.locals.length}`, nestedFieldType);
+            fctx.body.push({ op: "local.get", index: elemLocal });
+            fctx.body.push({ op: "struct.get", typeIdx: structTypeIdx, fieldIdx: nestedFieldIdx });
+            fctx.body.push({ op: "local.set", index: nestedLocal });
+            if (nestedInit) {
+              emitNestedBindingDefault(ctx, fctx, nestedLocal, nestedFieldType, nestedInit);
+            }
+            compileForOfDestructuring(ctx, fctx, element.name, nestedLocal, nestedFieldType, stmt);
+          } else {
+            // Property absent ⇒ the value is `undefined`.
+            const dfltTsType = ctx.checker.getTypeAtLocation(element);
+            let dfltType = resolveWasmType(ctx, dfltTsType);
+            // For an absent property with no default the value is undefined and
+            // must throw; force a nullable carrier so the recursion's guard fires.
+            if (!nestedInit && dfltType.kind !== "ref_null" && dfltType.kind !== "externref") {
+              dfltType = { kind: "externref" };
+            }
+            const nestedLocal = allocLocal(fctx, `__forof_obj_nested_${fctx.locals.length}`, dfltType);
+            if (nestedInit) {
+              const dt = compileExpression(ctx, fctx, nestedInit, dfltType);
+              if (dt && !valTypesMatch(dt, dfltType)) coerceType(ctx, fctx, dt, dfltType);
+            } else if (dfltType.kind === "ref_null") {
+              fctx.body.push({ op: "ref.null", typeIdx: (dfltType as { typeIdx: number }).typeIdx });
+            } else {
+              fctx.body.push({ op: "ref.null.extern" });
+            }
+            fctx.body.push({ op: "local.set", index: nestedLocal });
+            compileForOfDestructuring(ctx, fctx, element.name, nestedLocal, dfltType, stmt);
+          }
+          continue;
+        }
         if (!ts.isIdentifier(element.name)) continue; // skip non-identifier binding names
         const localName = element.name.text;
         if (!propNameText) continue; // skip truly unresolvable computed property names

--- a/tests/issue-2808.test.ts
+++ b/tests/issue-2808.test.ts
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+/**
+ * #2808 (parent #2669) — for-of OBJECT-binding head with a NESTED sub-pattern.
+ *
+ * `compileForOfDestructuring` (src/codegen/statements/loops.ts) is a separate,
+ * less-complete reimplementation of destructuring for the for-of / for-await
+ * loop head. Its ARRAY-pattern branch already recurses into nested sub-patterns
+ * (#2216), but the OBJECT-pattern struct branch DROPPED them at the
+ * identifier-only `continue` — so:
+ *
+ *   for (const { w: { x, y, z } } of [{ w: { x: 1, y: 2, z: 3 } }])  // x,y,z never bound
+ *   for (const { w: [x] } of [{ w: null }])                          // never threw
+ *
+ * Fix: mirror the array branch — extract the field value, apply the
+ * (undefined-only) nested default, then recurse. The recursion's own
+ * RequireObjectCoercible / GetIterator null guard throws TypeError for a
+ * null/undefined nested target (ECMA-262 §13.15.5.5 / §8.5.2), so a nested
+ * pattern over `null`/`undefined` now correctly throws.
+ *
+ * Recovers 18 for-of + 24 for-await `obj-ptrn-prop-{obj,ary}` test262 tests with
+ * 0 regressions (full before/after on for-of/dstr + for-await-of/dstr).
+ *
+ * NOTE: the object-nested-default-FIRES sub-case where the source property value
+ * is `undefined` (so the field lowers to externref) is validated through the
+ * test262 cluster (`*-obj-ptrn-prop-obj-init`), not asserted here — that path is
+ * representation-sensitive (externref-field default coercion, #2769-adjacent) and
+ * not reliably reproducible via a standalone `compile()` shape. The core fix —
+ * nested recursion + null/undefined RequireObjectCoercible throw + undefined-only
+ * default + nested ARRAY default — is locked in below.
+ */
+
+async function run(source: string): Promise<number> {
+  const result = await compile(source, { fileName: "test.ts" });
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as unknown as WebAssembly.Imports);
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#2808 — for-of object-binding nested sub-pattern: value extraction", () => {
+  it("nested object sub-pattern binds inner names", async () => {
+    expect(
+      await run(
+        `export function test(): number { let s = 0; for (const { w: { x, y, z } } of [{ w: { x: 1, y: 2, z: 3 } }]) { s = x * 100 + y * 10 + z; } return s; }`,
+      ),
+    ).toBe(123);
+  });
+
+  it("nested array sub-pattern binds inner elements", async () => {
+    expect(
+      await run(
+        `export function test(): number { let s = 0; for (const { w: [x, y, z] } of [{ w: [7, 8, 9] }]) { s = x * 100 + y * 10 + z; } return s; }`,
+      ),
+    ).toBe(789);
+  });
+
+  it("nested sub-pattern with a trailing comma in the outer object pattern", async () => {
+    expect(
+      await run(
+        `export function test(): number { let s = 0; for (const { x: [y], } of [{ x: [45] }]) { s = y; } return s; }`,
+      ),
+    ).toBe(45);
+  });
+
+  it("nested array default fires when the property value is undefined", async () => {
+    expect(
+      await run(
+        `export function test(): number { let s = 0; for (const { w: [x, y, z] = [4, 5, 6] } of [{ w: undefined }]) { s = x * 100 + y * 10 + z; } return s; }`,
+      ),
+    ).toBe(456);
+  });
+});
+
+describe("#2808 — for-of object-binding nested sub-pattern: RequireObjectCoercible / GetIterator throws", () => {
+  it("nested object sub-pattern over a null value throws TypeError", async () => {
+    await expect(
+      run(
+        `export function test(): number { let s = 0; for (const { w: { x } } of [{ w: null }]) { s = 1; } return s; }`,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("nested array sub-pattern over a null value throws TypeError", async () => {
+    await expect(
+      run(`export function test(): number { let s = 0; for (const { w: [x] } of [{ w: null }]) { s = 1; } return s; }`),
+    ).rejects.toThrow();
+  });
+
+  it("a default does NOT fire on null — the null nested target still throws", async () => {
+    // KeyedBindingInitialization §13.3.3.7 step 3: the default applies only when
+    // the value is `undefined`, never `null`. So `{ w: null }` keeps null, and
+    // the nested `{ x }` over null throws.
+    await expect(
+      run(
+        `export function test(): number { let s = 0; for (const { w: { x } = { x: 1 } } of [{ w: null }]) { s = 1; } return s; }`,
+      ),
+    ).rejects.toThrow();
+  });
+});
+
+describe("#2808 — controls (must stay unchanged)", () => {
+  it("flat object pattern in for-of head is unaffected", async () => {
+    expect(
+      await run(
+        `export function test(): number { let s = 0; for (const { a, b } of [{ a: 1, b: 2 }]) { s = a + b; } return s; }`,
+      ),
+    ).toBe(3);
+  });
+
+  it("nested array-in-array binding (array branch) is unaffected", async () => {
+    expect(
+      await run(
+        `export function test(): number { let s = 0; for (const [[a, b]] of [[[10, 20]]]) { s = a + b; } return s; }`,
+      ),
+    ).toBe(30);
+  });
+
+  it("object sub-pattern inside an array pattern (array branch) is unaffected", async () => {
+    expect(
+      await run(
+        `export function test(): number { let s = 0; for (const [{ a }] of [[{ a: 99 }]]) { s = a; } return s; }`,
+      ),
+    ).toBe(99);
+  });
+});


### PR DESCRIPTION
## Summary

Slice of the **#2669** ES2015 destructuring-correctness umbrella. The for-of /
for-await loop-head destructuring lowering (`compileForOfDestructuring`,
`src/codegen/statements/loops.ts`) is a separate, less-complete reimplementation
of destructuring. Its **array**-pattern branch already recurses into nested
sub-patterns (#2216), but the **object**-pattern struct branch DROPPED them at
the identifier-only `continue`:

```ts
for (const { w: { x, y, z } } of [{ w: { x: 1, y: 2, z: 3 } }])  // inner names never bound
for (const { w: [x] } of [{ w: null }])                          // RequireObjectCoercible never ran -> no throw
```

## Root cause

A binding element whose `name` is a nested `Object`/`ArrayBindingPattern` (not an
`Identifier`) fell through `if (!ts.isIdentifier(element.name)) continue` and was
skipped entirely — so (1) inner names were never bound and (2) a `null`/`undefined`
property value never triggered the spec's RequireObjectCoercible / GetIterator
`TypeError` (ECMA-262 §13.15.5.5 / §8.5.2).

## Fix

In the object-pattern struct branch, handle a nested sub-pattern **before** the
identifier-only `continue`, mirroring the proven array branch: `struct.get` the
field value into a fresh local, apply the **undefined-only** nested default
(KeyedBindingInitialization §13.3.3.7 step 3 — fires on `undefined`, never `null`;
gated `!awaitModifier && !isCallExpression` per the #2216 / #2692 / #2566
precedent), then recurse. The recursion's own `emitNullGuard` / externref
RequireObjectCoercible guard throws `TypeError` for a null/undefined target.

## Net recovery — +42 test262, 0 regressions

Full before/after (clean-`main` `loops.ts` vs fixed, identical `runTest262File` harness):

| dir | files | result |
|-----|-------|--------|
| `statements/for-of/dstr` | 569 | **+18, 0 regressions** |
| `statements/for-await-of` dstr | 1215 | **+24, 0 regressions** |

Blast radius is exactly `compileForOfDestructuring` (for-of / for-await loop
heads). Binding-declaration / object-method / class / param dstr dirs use
different lowerings and are unaffected.

## Tests

- `tests/issue-2808.test.ts` — 10/10: nested value extraction (obj + ary),
  nested array default, three null/undefined RequireObjectCoercible/GetIterator
  throw cases, three controls.

Issue: `plan/issues/2808-forof-object-binding-nested-subpattern.md` (parent #2669).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS