### PR TITLE
refactor(examples): #2810 nm_node_process re-chunks writes to the ≤1 MiB browser cap

### DIFF
--- a/examples/native-messaging/nm_js2wasm_node_process.ts
+++ b/examples/native-messaging/nm_js2wasm_node_process.ts
@@ -25,17 +25,26 @@
 // Because the read side is event-driven, the framed protocol is parsed
 // incrementally: buffer incoming `'data'` chunks, and whenever the buffer holds a
 // complete frame (the 4-byte little-endian length prefix plus that many body
-// bytes), echo the whole frame — prefix + body — straight back as one
-// `process.stdout.write`, then advance past it. A `'data'` chunk can carry a
+// bytes), echo it back, then advance past it. A `'data'` chunk can carry a
 // partial frame, exactly one frame, or several; the incremental parser handles
 // all three. The leftover tail (a partial next frame) stays buffered until the
 // following chunk completes it.
+//
+// On the WRITE side the echo is re-chunked to the 1 MiB browser cap (#2808): a
+// body within the cap is echoed verbatim — prefix + body — as one
+// `process.stdout.write`; a body LARGER than the cap is split into a sequence of
+// valid <=1 MiB JSON frames (`[run]` for an array body, `"run"` for a string
+// body) whose interiors, concatenated by the receiver, reproduce the original
+// body. This matches the sibling `nm_js2wasm_node_fs` re-chunker, keeps every
+// host->extension message within the real Chrome 1 MiB cap, and bounds resident
+// memory on the write side. See the FRAME_CAP / `rechunk*` helpers below.
 //
 // Native Messaging protocol: each message is a 4-byte little-endian length prefix
 // followed by a UTF-8 JSON body, exchanged over stdin (fd 0) / stdout (fd 1). See
 //   https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging
 //
-// This variant echoes a framed message verbatim, byte-for-byte. NOTE: `process`
+// This variant echoes a framed message back, re-chunked to the 1 MiB browser cap
+// (verbatim when it already fits). NOTE: `process`
 // is referenced as the Node **global** (not `import process from "node:process"`).
 // The prelude injection that backs `process.stdin` deliberately leaves a
 // user-declared/-imported `process` binding alone, so the faithful global surface
@@ -66,6 +75,98 @@ let tail: number = 0;
 // Set once a zero-length frame (clean shutdown) is seen, matching the sibling
 // variants which treat a declared length of 0 as end-of-stream.
 let stopped: boolean = false;
+
+// Browser per-host->extension-message cap: 1 MiB (#2808). A real Chrome Native-
+// Messaging host may send AT MOST 1 MiB per host->extension message, so a body
+// larger than this isn't even valid on that surface. Like the sibling
+// `nm_js2wasm_node_fs.ts` re-chunker, a >1 MiB response body is split on the
+// WRITE side into a sequence of valid <=1 MiB JSON frames whose interiors,
+// concatenated by the receiver, reproduce the original body; a body that already
+// fits is echoed verbatim. This also BOUNDS resident memory on the write side
+// (per-frame 1 MiB out buffers instead of one full-size frame) and brings this
+// async host in line with `nm_js2wasm_deno` / `nm_js2wasm_wasi_p1` (64 KiB
+// window) and `nm_js2wasm_node_fs` (1 MiB re-chunk) — it was the lone variant
+// that built the WHOLE frame and wrote it in ONE process.stdout.write, the
+// shape that hit wasmtime's single-fd_write cap in #2807.
+const FRAME_CAP: number = 1024 * 1024;
+const COMMA: number = 44; // ,
+const OPEN_BRACKET: number = 91; // [
+const CLOSE_BRACKET: number = 93; // ]
+const DQUOTE: number = 34; // "
+
+// Emit ONE re-chunked JSON frame: 4-byte LE length prefix + `open` + the run
+// `buf[srcStart..srcStart+runLen)` + `close`, built whole and written in ONE
+// process.stdout.write (atomic framing — a streaming receiver must never see a
+// prefix split from its body; #2526). `open`/`close` are `[`/`]` for an array
+// body or `"`/`"` for a string body. The 4-byte prefix declares the JSON body
+// length (`open` + run + `close`), which stays <= FRAME_CAP because the caller
+// keeps `runLen <= FRAME_CAP - 2`.
+function emitRun(srcStart: number, runLen: number, open: number, close: number): void {
+  const bodyLen = runLen + 2; // delimiter + run + delimiter
+  const out = new Uint8Array(4 + bodyLen);
+  out[0] = bodyLen & 0xff;
+  out[1] = (bodyLen >> 8) & 0xff;
+  out[2] = (bodyLen >> 16) & 0xff;
+  out[3] = (bodyLen >> 24) & 0xff;
+  out[4] = open;
+  let k = 0;
+  while (k < runLen) {
+    out[5 + k] = buf[srcStart + k];
+    k = k + 1;
+  }
+  out[4 + runLen + 1] = close;
+  process.stdout.write(out);
+}
+
+// Re-chunk a large JSON ARRAY body `[elem,...,elem]` into valid <=FRAME_CAP
+// `[run]` frames, split at COMMA boundaries so each frame is itself a valid JSON
+// array; the receiver concatenates the interiors (re-inserting one comma between
+// frames) to reproduce the original array. `ip0` is the first interior byte
+// (after the leading `[`), `interiorLen` the interior byte count (body length
+// minus the outer `[` and `]`). Mirrors the final-batch drain of the shared
+// `nm_js2wasm_sync_framing` core's re-chunker (which streams the same split);
+// the whole body is already buffered here, so the split is a pure in-memory walk.
+function rechunkArray(ip0: number, interiorLen: number): void {
+  const maxRun = FRAME_CAP - 2; // leave room for the framing `[` / `]`
+  let startPos = 0;
+  while (startPos < interiorLen) {
+    let stop = startPos + maxRun;
+    if (stop >= interiorLen) {
+      stop = interiorLen; // final frame ends exactly at the interior end
+    } else {
+      // Back up to the last comma within [startPos, startPos+maxRun) so each
+      // frame holds whole elements; exclude that comma (it's the separator).
+      let c = stop;
+      while (c > startPos && buf[ip0 + c - 1] !== COMMA) c = c - 1;
+      if (c > startPos) stop = c - 1;
+      // else: no comma in the window — a single element exceeds the cap; emit
+      // maxRun raw (degenerate, only for elements > ~FRAME_CAP bytes), matching
+      // the shared core.
+    }
+    emitRun(ip0 + startPos, stop - startPos, OPEN_BRACKET, CLOSE_BRACKET);
+    startPos = stop;
+    if (startPos < interiorLen && buf[ip0 + startPos] === COMMA) startPos = startPos + 1;
+  }
+}
+
+// Re-chunk a large JSON STRING body `"chars..."` into valid <=FRAME_CAP `"run"`
+// frames; the receiver concatenates the interiors to reproduce the original
+// string. A fixed `maxRun` split keeps each frame within the cap (no comma
+// boundaries to honor, unlike the array path). `ip0` is the first interior byte
+// (after the leading `"`), `interiorLen` = body length minus the two `"`. (The
+// fixed-run split must not bisect a `\`-escape; for the reported workload the
+// body is plain printable characters, so a fixed split is valid — same caveat as
+// the shared core's emitStringRun.)
+function rechunkString(ip0: number, interiorLen: number): void {
+  const maxRun = FRAME_CAP - 2; // leave room for the two framing `"`
+  let startPos = 0;
+  while (startPos < interiorLen) {
+    let runLen = maxRun;
+    if (interiorLen - startPos < runLen) runLen = interiorLen - startPos;
+    emitRun(ip0 + startPos, runLen, DQUOTE, DQUOTE);
+    startPos = startPos + runLen;
+  }
+}
 
 // Append a `'data'` chunk's raw bytes into `buf` — O(chunk). The prelude (#2777)
 // delivers each chunk as a FLAT string, so `chunk.charCodeAt(k)` is O(1). Grows
@@ -133,20 +234,37 @@ function drain(): void {
     const frameLen = 4 + len;
     if (tail - head < frameLen) return; // body not fully arrived yet
 
-    // Re-frame prefix + body into one raw-byte buffer. The prefix is rebuilt from
-    // the decoded length (identical bytes); the body bytes are a straight O(1)
-    // typed-array copy out of `buf`.
-    const out = new Uint8Array(frameLen);
-    out[0] = len & 0xff;
-    out[1] = (len >> 8) & 0xff;
-    out[2] = (len >> 16) & 0xff;
-    out[3] = (len >> 24) & 0xff;
-    let i = 0;
-    while (i < len) {
-      out[4 + i] = buf[head + 4 + i];
-      i = i + 1;
+    if (len <= FRAME_CAP) {
+      // Body already within the 1 MiB browser cap — echo the frame VERBATIM
+      // (prefix + body) in ONE write. Re-frame prefix + body into one raw-byte
+      // buffer: the prefix is rebuilt from the decoded length (identical bytes);
+      // the body bytes are a straight O(1) typed-array copy out of `buf`.
+      const out = new Uint8Array(frameLen);
+      out[0] = len & 0xff;
+      out[1] = (len >> 8) & 0xff;
+      out[2] = (len >> 16) & 0xff;
+      out[3] = (len >> 24) & 0xff;
+      let i = 0;
+      while (i < len) {
+        out[4 + i] = buf[head + 4 + i];
+        i = i + 1;
+      }
+      process.stdout.write(out);
+    } else {
+      // Body exceeds the 1 MiB browser cap — RE-CHUNK into valid <=1 MiB JSON
+      // frames (#2808), matching the `nm_js2wasm_node_fs` re-chunker. Peek the
+      // first body byte to pick the shape: `"` → a JSON string split into `"run"`
+      // frames; otherwise a JSON array split into `[run]` frames at comma
+      // boundaries. The interior excludes the outer `[`/`]` (or the two `"`):
+      // it starts at `head + 5` and is `len - 2` bytes long.
+      const ip0 = head + 5;
+      const interiorLen = len - 2;
+      if (buf[head + 4] === DQUOTE) {
+        rechunkString(ip0, interiorLen);
+      } else {
+        rechunkArray(ip0, interiorLen);
+      }
     }
-    process.stdout.write(out);
 
     // Drop the echoed frame; keep any trailing partial frame for the next chunk.
     head = head + frameLen;

--- a/examples/native-messaging/scale-test.mjs
+++ b/examples/native-messaging/scale-test.mjs
@@ -147,14 +147,15 @@ function js2wasm(jsFile, extraArgs) {
 // Each variant: build once, then echo-test across the size sweep.
 const VARIANTS = [
   {
-    name: "nm_node_process",
-    src: "nm_node_process.ts",
+    name: "nm_js2wasm_node_process",
+    src: "nm_js2wasm_node_process.ts",
     bunExtra: [],
     js2wasmExtra: [],
     preload: null,
-    // verbatim single-write echoer — THE #2807 variant (the only one that issues
-    // one >128 MiB fd_write).
-    mode: "verbatim",
+    // Re-chunks bodies > 1 MiB into valid <=1 MiB JSON frames on the WRITE side
+    // (#2808) — formerly THE #2807 variant that built the whole frame and issued
+    // one >128 MiB fd_write; now bounded like nm_js2wasm_node_fs.
+    mode: "rechunk",
   },
   { name: "nm_deno", src: "nm_deno.ts", bunExtra: [], js2wasmExtra: [], preload: null, mode: "verbatim" },
   {

--- a/plan/issues/2808-nm-node-process-rechunk-writes.md
+++ b/plan/issues/2808-nm-node-process-rechunk-writes.md
@@ -1,0 +1,92 @@
+---
+id: 2808
+title: "nm_js2wasm_node_process: re-chunk host->extension writes to the ≤1 MiB browser cap (like nm_js2wasm_node_fs)"
+status: done
+assignee: ttraenkler/agent-ad343
+completed: 2026-06-28
+created: 2026-06-28
+updated: 2026-06-28
+priority: medium
+feasibility: medium
+task_type: refactor
+area: runtime
+language_feature: native-messaging
+goal: platform
+sprint: current
+horizon: m
+related: [389, 2807, 2775, 2778]
+---
+
+# nm_js2wasm_node_process: re-chunk writes to the ≤1 MiB browser cap
+
+## Problem
+
+`nm_js2wasm_node_process` (the async `process.stdin` reactor variant) was the
+architectural outlier among the four Native-Messaging host examples: it
+accumulated the WHOLE response frame and wrote it in ONE `process.stdout.write`,
+whereas `nm_js2wasm_deno` / `nm_js2wasm_wasi_p1` stream through a 64 KiB window
+and `nm_js2wasm_node_fs` re-chunks to ≤1 MiB. That single-big-write shape is why
+it was the only host to hit wasmtime's ≥128 MiB single-`fd_write` cap (#2807).
+
+Beyond consistency: a real Chrome Native-Messaging host is capped at **1 MB per
+host→extension message**, so a >1 MB single response isn't even valid on that
+surface — `nm_js2wasm_node_fs` re-chunks precisely for that cap.
+`nm_js2wasm_node_process` should too, and re-chunking also **bounds resident
+memory on the write side** (per-frame 1 MiB out buffers instead of one
+full-size frame).
+
+## Change
+
+- `nm_js2wasm_node_process`'s echo now **re-chunks to ≤1 MiB JSON frames** on the
+  WRITE side, matching `nm_js2wasm_node_fs`'s browser-cap re-chunk. A body within
+  the cap is echoed verbatim (prefix + body) in one write; a body larger than the
+  cap is split into a sequence of valid ≤1 MiB JSON frames whose interiors,
+  concatenated by the receiver, reproduce the original body:
+  - peek the first body byte — `"` → split the JSON string into `"run"` frames
+    (fixed-run split); otherwise split the JSON array into `[run]` frames at comma
+    boundaries (mirrors the final-batch drain of the shared
+    `nm_js2wasm_sync_framing` re-chunker).
+  - The faithful async `process.stdin` reactor on the READ side is unchanged; the
+    whole frame body is already buffered by drain-time, so the re-chunk is a pure
+    in-memory split (no streaming-read seam needed — the async path can't reuse
+    the pull-based `runNmHost` core, so the emit/split logic is mirrored on the
+    write side).
+- Updated the #2807 scale coverage so `nm_js2wasm_node_process` is now a
+  **re-chunk** variant (multiple ≤1 MiB frames), not a single byte-exact echo:
+  - `examples/native-messaging/scale-test.mjs`: `nm_js2wasm_node_process` switched
+    from `mode: "verbatim"` to `mode: "rechunk"` (driven with the `jsonArrayBody`
+    payload, asserting every frame ≤1 MiB and reassembled == input — like
+    `nm_js2wasm_node_fs`).
+  - `tests/issue-2807-fd-write-cap.test.ts`: drives a >1 MiB JSON-array body and
+    asserts re-chunk round-trip (every frame body ≤1 MiB; reassembled interiors ==
+    input), plus a sub-1 MiB body that still echoes verbatim. The capped-`fd_write`
+    guard from #2807 stays (no single fd_write exceeds `WASI_FD_WRITE_MAX_CHUNK`).
+
+## Acceptance criteria
+
+- `nm_js2wasm_node_process` re-chunks a 1 / 64 / 128 / 256 MiB JSON body into
+  valid ≤1 MiB frames that reassemble byte-exact, under **real wasmtime v46**.
+- The other three variants and the #2807 capped-`fd_write` guard still pass.
+
+## Test Results
+
+Validated 2026-06-28 in this worktree:
+
+- In-process (compile → reactor shim): JSON **array** body 3 MiB → 4 frames, each
+  body ≤1 MiB (max 1048571), reassemble == input; JSON **string** body 3 MiB → 4
+  frames, each ≤1 MiB, reassemble == input; sub-1 MiB body echoes byte-exact.
+- Real wasmtime v46.0.1 (`bun build --target node` → standalone `js2wasm` CLI →
+  `wasmtime`), `jsonArrayBody`:
+  - 1 MiB → 1 frame (1048576 ≤ cap), reassemble == input.
+  - 64 MiB → 65 frames, max frame body 1048571 ≤ 1 MiB, reassemble == input.
+  - 128 MiB → 129 frames (the original #2807 zero-output size) — re-chunks, all
+    ≤1 MiB, reassemble == input.
+  - 256 MiB → 257 frames, all ≤1 MiB, reassemble == input.
+
+## Dependencies
+
+- #2282 (rename `nm_*` → `nm_js2wasm_*`) — the file is
+  `examples/native-messaging/nm_js2wasm_node_process.ts`.
+- #2283 (#2807 `fd_write` cap fix) — adds `scale-test.mjs`,
+  `tests/issue-2807-fd-write-cap.test.ts`, and the `WASI_FD_WRITE_MAX_CHUNK`
+  export this issue extends.

--- a/tests/issue-2807-fd-write-cap.test.ts
+++ b/tests/issue-2807-fd-write-cap.test.ts
@@ -46,6 +46,53 @@ function frame(body: Uint8Array): Uint8Array {
   return out;
 }
 
+const MiB = 1024 * 1024;
+
+// A valid JSON-array body `[null,null,…]` of ~`approx` bytes — the loopdive/js2#389
+// payload shape the re-chunker splits on. nm_js2wasm_node_process now re-chunks a
+// body > 1 MiB into a sequence of valid <=1 MiB `[run]` frames (#2808), so the
+// #2807 coverage drives a JSON body (not arbitrary bytes) and asserts re-chunk
+// round-trip rather than a single byte-exact echo.
+function jsonArrayBody(approx: number): Uint8Array {
+  const m = Math.max(1, Math.floor((approx - 6) / 5) + 1);
+  const total = 2 + 4 + 5 * (m - 1);
+  const buf = new Uint8Array(total);
+  let p = 0;
+  buf[p++] = 0x5b; // [
+  for (const c of "null") buf[p++] = c.charCodeAt(0);
+  for (let i = 1; i < m; i++) for (const c of ",null") buf[p++] = c.charCodeAt(0);
+  buf[p++] = 0x5d; // ]
+  return buf;
+}
+
+// Split a stream of `[4-byte LE length][body]` Native-Messaging frames into the
+// body slices.
+function parseFrames(stream: Uint8Array): Uint8Array[] {
+  const frames: Uint8Array[] = [];
+  let p = 0;
+  while (p + 4 <= stream.length) {
+    const len = stream[p]! + stream[p + 1]! * 256 + stream[p + 2]! * 65536 + stream[p + 3]! * 16777216;
+    p += 4;
+    if (p + len > stream.length) break;
+    frames.push(stream.subarray(p, p + len));
+    p += len;
+  }
+  return frames;
+}
+
+// Reassemble re-chunked `[run]` array frames: concatenate each frame's interior
+// (drop the outer `[` / `]`), re-inserting one comma between frames, and wrap the
+// whole in `[` … `]` — must reproduce the original array body byte-for-byte.
+function reassembleArrayFrames(frames: Uint8Array[]): Buffer {
+  const parts: Buffer[] = [];
+  for (let i = 0; i < frames.length; i++) {
+    const f = frames[i]!;
+    if (i > 0) parts.push(Buffer.from([0x2c])); // ,
+    parts.push(Buffer.from(f.subarray(1, f.length - 1))); // strip [ … ]
+  }
+  return Buffer.concat([Buffer.from([0x5b]), Buffer.concat(parts), Buffer.from([0x5d])]);
+}
+
 /**
  * Reactor shim for `nm_node_process`, with a wasmtime-FAITHFUL capped `fd_write`:
  * a single iovec whose length exceeds {@link MODELLED_CAP} is rejected with errno
@@ -163,31 +210,73 @@ async function runReactorShimCapped(
   return { out, maxWrite, rejected };
 }
 
-describe("#2807 — nm_node_process echoes a >chunk frame under a wasmtime-faithful fd_write cap", () => {
+describe("#2808 — nm_js2wasm_node_process re-chunks to <=1 MiB frames under a wasmtime-faithful fd_write cap", () => {
   it(
-    "chunks the write so no single fd_write exceeds the cap, and echoes byte-exact",
+    "re-chunks a >1 MiB JSON body into valid <=1 MiB frames that reassemble byte-exact, with no fd_write over the cap",
     { timeout: 180_000 },
     async () => {
       // The chunk size must sit safely below wasmtime's real ~128 MiB cap, or a
-      // single chunk would itself be rejected by real wasmtime.
+      // single chunk would itself be rejected by real wasmtime. (#2807 guard: it
+      // still holds even though the re-chunk now keeps every write <=1 MiB.)
       expect(WASI_FD_WRITE_MAX_CHUNK).toBeLessThan(WASMTIME_REAL_CAP);
 
-      const src = readFileSync(join(NM_DIR, "nm_node_process.ts"), "utf-8");
-      const r = await compile(src, { fileName: "nm_node_process.ts", target: "wasi", skipSemanticDiagnostics: true });
+      const src = readFileSync(join(NM_DIR, "nm_js2wasm_node_process.ts"), "utf-8");
+      const r = await compile(src, {
+        fileName: "nm_js2wasm_node_process.ts",
+        target: "wasi",
+        skipSemanticDiagnostics: true,
+      });
       expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
-      expect(WebAssembly.validate(r.binary!), "nm_node_process.ts must validate").toBe(true);
+      expect(WebAssembly.validate(r.binary!), "nm_js2wasm_node_process.ts must validate").toBe(true);
 
-      // One chunk + a remainder: the OLD single-shot write would be one
-      // (chunk + remainder) iovec — rejected by the modelled cap → zero output.
-      const body = new Uint8Array(WASI_FD_WRITE_MAX_CHUNK + 8192).fill(0x61);
+      // Just over one compiler-chunk of valid JSON array body: the OLD single-shot
+      // write would be one (chunk + remainder) iovec — rejected by the modelled
+      // cap → zero output (the #2807 regression). The re-chunk now splits this into
+      // valid <=1 MiB JSON frames.
+      const body = jsonArrayBody(WASI_FD_WRITE_MAX_CHUNK + 8192);
       const input = frame(body);
 
       const { out, maxWrite, rejected } = await runReactorShimCapped(r.binary!, input);
 
+      // #2807 capped-fd_write guard STAYS: no single fd_write may exceed the cap,
+      // and output is non-zero. (Re-chunking keeps every write <=1 MiB, far under
+      // the modelled cap, so `rejected` is 0 by construction.)
       expect(rejected, "no fd_write may exceed the cap (the #2807 single-shot regression)").toBe(0);
-      expect(out.length, "must not emit zero bytes (the #2807 silent failure)").toBe(input.length);
-      expect(Buffer.compare(Buffer.from(out), Buffer.from(input)), "echo must be byte-identical").toBe(0);
+      expect(out.length, "must not emit zero bytes (the #2807 silent failure)").toBeGreaterThan(0);
       expect(maxWrite, "every single fd_write stays within the chunk cap").toBeLessThanOrEqual(WASI_FD_WRITE_MAX_CHUNK);
+
+      // #2808 re-chunk round-trip: every emitted frame body is within the 1 MiB
+      // browser cap, and the frame interiors reassemble to the original body.
+      const frames = parseFrames(out);
+      expect(frames.length, "the >1 MiB body must be split into multiple frames").toBeGreaterThan(1);
+      for (let i = 0; i < frames.length; i++) {
+        expect(frames[i]!.length, `frame ${i} body must be within the 1 MiB browser cap`).toBeLessThanOrEqual(MiB);
+      }
+      expect(
+        Buffer.compare(reassembleArrayFrames(frames), Buffer.from(body)),
+        "reassembled frame interiors must equal the input array body",
+      ).toBe(0);
     },
   );
+
+  it("echoes a body within the 1 MiB cap verbatim, in a single frame", { timeout: 120_000 }, async () => {
+    const src = readFileSync(join(NM_DIR, "nm_js2wasm_node_process.ts"), "utf-8");
+    const r = await compile(src, {
+      fileName: "nm_js2wasm_node_process.ts",
+      target: "wasi",
+      skipSemanticDiagnostics: true,
+    });
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+
+    // A sub-1 MiB JSON body fits the cap → echoed verbatim (prefix + body) as a
+    // single frame, byte-identical to the input.
+    const body = jsonArrayBody(64 * 1024);
+    const input = frame(body);
+
+    const { out, rejected } = await runReactorShimCapped(r.binary!, input);
+
+    expect(rejected).toBe(0);
+    expect(out.length, "verbatim echo is one frame, same size as input").toBe(input.length);
+    expect(Buffer.compare(Buffer.from(out), Buffer.from(input)), "sub-cap body echoes byte-identical").toBe(0);
+  });
 });


### PR DESCRIPTION
## #2810 — re-chunk `nm_js2wasm_node_process` writes to the ≤1 MiB browser cap

`nm_js2wasm_node_process` (the async `process.stdin` reactor variant) was the lone
Native-Messaging host that built the WHOLE response frame and wrote it in ONE
`process.stdout.write` — the shape that hit wasmtime's ≥128 MiB single-`fd_write`
cap (#2807) and is invalid on the real Chrome surface (**1 MB per host→extension
message**). `nm_js2wasm_deno` / `nm_js2wasm_wasi_p1` stream through a 64 KiB
window and `nm_js2wasm_node_fs` re-chunks to ≤1 MiB; this brings the outlier in
line.

### Change
- **Re-chunk on the WRITE side** into valid ≤1 MiB JSON frames (matching
  `nm_js2wasm_node_fs`):
  - body within the cap → echoed verbatim (prefix + body) in one write;
  - body > cap → peek the first byte: `"` → split the JSON string into `"run"`
    frames; otherwise split the JSON array into `[run]` frames at comma
    boundaries (mirrors the shared `nm_js2wasm_sync_framing` re-chunker).
  - The faithful async `process.stdin` reactor (READ side) is unchanged; the whole
    frame is buffered by drain-time, so the split is a pure in-memory walk. Also
    bounds write-side resident memory (per-frame 1 MiB buffers, not one full frame).
- **#2807 scale coverage updated** for the new shape (re-chunk, not a single echo):
  - `examples/native-messaging/scale-test.mjs`: `nm_js2wasm_node_process` is now
    `mode: "rechunk"`.
  - `tests/issue-2807-fd-write-cap.test.ts`: drives a >1 MiB JSON-array body and
    asserts re-chunk round-trip (every frame body ≤1 MiB; reassembled interiors ==
    input) plus a sub-1 MiB verbatim sub-case. The #2807 capped-`fd_write` guard
    stays (no single `fd_write` exceeds `WASI_FD_WRITE_MAX_CHUNK`).

### Validation
- Unit test (in-process reactor shim): 2/2 pass; in-process probes pass for array
  + string bodies.
- **Real wasmtime v46.0.1** (`bun build --target node` → standalone `js2wasm` CLI →
  `wasmtime`), `jsonArrayBody` at **1 / 64 / 128 / 256 MiB**: all re-chunk to ≤1 MiB
  frames that reassemble byte-exact (128 MiB was the original #2807 zero-output size).

Issue id re-allocated 2808 → **2810** (the parallel for-of #2808 landed on main first).

Closes #2810.

🤖 Generated with [Claude Code](https://claude.com/claude-code)