### PR TITLE
release: v0.59.1

### DIFF
--- a/docs/releases/0.59.1.md
+++ b/docs/releases/0.59.1.md
@@ -1,0 +1,34 @@
+# v0.59.1
+
+_Released 2026-06-29._
+
+## Highlight — Native Messaging large-frame fix + example consistency (loopdive/js2#389)
+
+- **#2807** — silent **zero-output for large single writes** is fixed. Real
+  wasmtime rejects any single `fd_write` whose length is ≥ ~128 MiB (errno 48,
+  `nwritten=0` — a fixed structural cap, identical for a file or a pipe), and
+  js2wasm's WASI write helper was silently mapping that errno to "0 bytes" and
+  dropping it (also a latent **ignored short-write**). The write path now chunks
+  through `__wasi_fd_write_all` (≤64 MiB/call, advancing by the actual
+  `nwritten`). Verified byte-exact at **1 / 64 / 128 / 256 MiB** under real
+  wasmtime v46 across all four hosts; a real-wasmtime scale test (4 hosts × 4
+  sizes) plus an always-on capped-`fd_write` guard now run in CI.
+- **#2810** — the async `nm_js2wasm_node_process` host now **re-chunks its echo
+  to the ≤1 MiB browser cap** like `nm_js2wasm_node_fs` (the real Chrome
+  native-messaging host→extension message limit) — for consistency, realism, and
+  bounded memory rather than buffering and writing the whole frame at once.
+
+## Refactor
+
+- **#389** — the Native-Messaging example hosts are renamed
+  `nm_*` → `nm_js2wasm_*` (`deno`, `node_fs`, `node_process`, `wasi_p1`,
+  `wasi_p3`, `sync_framing`).
+
+## Notable fixes
+
+- **#2769** — for-of object-binding head recurses into nested sub-patterns;
+  in-bounds `undefined`/hole defaults preserved.
+- **#2758** — eager-box caller-scope captures mutated by a called sibling.
+- **#2806** — `var x = (void 0)` treated as evolving-any/externref.
+
+**Full changelog:** https://github.com/loopdive/js2/compare/v0.59.0...v0.59.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.59.0",
+  "version": "0.59.1",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js2wasm",
-  "version": "0.59.0",
+  "version": "0.59.1",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC (unscoped proxy for @loopdive/js2)",
   "keywords": [
     "webassembly",


### PR DESCRIPTION
Patch release (no `feat()` since 0.59.0 — fixes + the #389 example rename).

**Headline (loopdive/js2#389):**
- **#2807** — Native-Messaging silent zero-output for ≥128 MiB single writes (wasmtime's `fd_write` cap + js2wasm's dropped short-write errno); chunked write helper + real-wasmtime scale tests. Byte-exact 1/64/128/256 MiB.
- **#2810** — `nm_js2wasm_node_process` re-chunks writes to the ≤1 MiB browser cap like `nm_js2wasm_node_fs`.
- **#389 rename** — example hosts `nm_*` → `nm_js2wasm_*`.

Plus fixes (#2769, #2758, #2806). Notes: `docs/releases/0.59.1.md`. After merge, push tag `v0.59.1` to publish (OIDC; verify-version gates tag == both package.json).