### PR TITLE
fix(#2811): capture/globalize builtin-named vars + dstr-param closure TDZ-flag offset

### DIFF
--- a/plan/issues/2811-dstr-captured-builtin-name-and-dstr-param-closure-offset.md
+++ b/plan/issues/2811-dstr-captured-builtin-name-and-dstr-param-closure-offset.md
@@ -1,0 +1,142 @@
+---
+id: 2811
+title: "Destructuring closure-capture residual: captured builtin-named var (length/concat/…) + dstr-param closure TDZ-flag offset (split from #2669)"
+parent: 2669
+status: done
+completed: 2026-06-29
+created: 2026-06-29
+assignee: ttraenkler/dstr3
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen
+es_edition: 2015
+language_feature: destructuring
+goal: spec-completeness
+sprint: current
+horizon: m
+related: [2669, 2758, 2808, 1205, 1607, 1177]
+---
+
+# #2811 — destructuring closure-capture residual (captured builtin-named var + dstr-param closure offset)
+
+## Cluster
+
+Highest-yield residual under #2669, found by re-sweeping `/dstr/` fails on
+current `origin/main` (post-#2808). The dominant clean cluster is
+**`ary-ptrn-rest-obj-prop-id`** (73 tests, all FAIL):
+`[...{ 0: v, 1: w, 2: x, 3: y, length: z }]` destructured against `[7,8,9]`,
+guarded by an outer `let length = "outer"` + the assertion *"the length prop is
+not set as a binding name"*. Every test262 dstr file of this family pairs the
+pattern with a captured outer variable named `length`.
+
+Net recovery of **this PR (fixes A+B below): +16** on that 73-cluster
+(generator / async-generator function bodies, named function expressions, and
+object-method contexts), plus the broader builtin-named-capture family across
+the suite. The remaining 57 (function-declaration / class-method contexts) are
+gated by bug **C** (carved below, → architect).
+
+## Root causes (three distinct bugs on the path)
+
+Verify-first, fresh single-file process repros (host/gc lane). All three are
+**pre-existing**; the cluster needs all three. A and B are fixed here; C is
+carved to architect.
+
+### A — a module/outer variable named like a wasm:js-string builtin is never globalized / captured  (FIXED)
+
+`addStringImports` (`src/codegen/index.ts`) registers the five wasm:js-string
+builtins — `concat`, `length`, `equals`, `substring`, `charCodeAt` — into
+`ctx.funcMap` (and mirrors them in `ctx.jsStringImports`, #1072). Multiple
+capture/global gates skip a name when `ctx.funcMap.has(name)`, intending to skip
+*user functions*. The builtin names collide:
+
+- `registerModuleGlobal` (`declarations.ts`) skipped a module-level `let length`
+  → it stayed a `__module_init` local, invisible to every other function (reads
+  return null).
+- the closure/nested-fn capture-collection loops (`closures.ts`,
+  `nested-declarations.ts`) skipped `length` from the captured set → a nested fn
+  reading `length` read null.
+
+Repro: `let length="outer"; function g(){return length;}` → `g()` returns
+`null` (should be `"outer"`). Only `length`/`concat`/`equals`/`substring`/
+`charCodeAt` are affected; every other name works.
+
+**Fix:** discriminate by index — skip only when the funcMap entry is a *genuine
+user function*, i.e. `ctx.funcMap.get(name) !== ctx.jsStringImports.get(name)`.
+A builtin-only collision falls through and the var is globalized/captured.
+Sites: `declarations.ts:registerModuleGlobal`, `closures.ts` (×3 capture loops),
+`nested-declarations.ts` (×2 capture loops). The function-name gates (keyed on
+`funcName`) are left untouched.
+
+### B — capturing function with a destructuring param reads the wrong param slot when it captures a TDZ-flagged (let/read) variable → malformed Wasm  (FIXED)
+
+`nested-declarations.ts` lifts a capturing FunctionDeclaration with the param
+layout `[valueCap_0..N-1, tdzFlagBox_0..K-1, userParam_0..]` (value captures,
+then one i32-cell TDZ flag box per TDZ-flagged capture, then the user params).
+The default-init / destructuring / arguments offset used `captures.length` (N)
+only, **ignoring the K prepended TDZ-flag boxes**. So a capturing function with a
+*destructuring* param destructured a TDZ i32-flag cell as the array argument →
+invalid Wasm (`any.convert_extern[0] expected type externref, found … (ref null
+N)`). `var` write-only captures have no TDZ flag (K=0) and were unaffected — why
+`callCount`-style tests compiled while the `length`-read dstr family trapped once
+bug A let `length` be captured.
+
+Repro: `let c=5; function f([a]){ return c; }` → malformed Wasm; `var c=0;
+function f([a]){ c++; }` → fine.
+
+**Fix:** `const leadingParamCount = captures.length + tdzFlaggedCaptures.length;`
+and use it for `emitDefaultParamInit`, the destructure-param loop, and
+`emitArgumentsObject`. No-op when K=0 (strictly additive for TDZ-flag captures,
+which previously always produced malformed Wasm).
+
+### C — block-scoped `let` captured by a *hoisted function declaration* → duplicate local, capture reads the uninitialized slot  (NOT fixed — → architect)
+
+A `let`/`const` declared inside a block (try/plain block) and captured by a
+nested **function declaration** in the same block reads null. Arrow functions,
+function expressions, `var` captures, and outer-(function-)scope captures all
+work — it is specifically the hoisted-FunctionDeclaration path.
+
+Mechanism (WAT-confirmed): the enclosing function ends up with **two** `$s`
+locals. `saveBlockScopedShadows` removes the pre-hoisted `s` localMap entry on
+block entry, so the block's `let s` allocates a *fresh* slot (e.g. idx 4) and
+writes `"outer"` there, while the capture list for the hoisted `f` recorded the
+pre-removal slot (idx 2). `emitFuncRefAsClosure`'s immutable-capture path pushes
+`cap.outerLocalIdx` (idx 2, uninitialized → null). The obvious capture-side fix
+(localMap-first resolution) was **already tried and reverted** for regressions
+(`closures.ts:3509`, "Stage 1 localMap-first lookup reverted"), so this needs a
+deliberate design over the block-scope-shadow / hoist / capture interaction
+(#1205 / #1607 / #1177 territory), not an inline patch.
+
+Repro: `{ let s="outer"; function f(){ return s; } f(); }` (returns null).
+**This is broad** (every block-nested function declaration capturing a block let)
+and is the keystone for the remaining 57 of the 73-cluster (class-method &
+function-declaration contexts, which compile via the hoisted-decl path). It is a
+scoping/hoisting bug, not destructuring-specific. → route to architect.
+
+## Acceptance criteria (this PR — A+B)
+
+- Module/outer variables named `length`/`concat`/`equals`/`substring`/
+  `charCodeAt` globalize + capture correctly (return the stored value, not null).
+- A capturing function with a destructuring param that captures a TDZ-flagged
+  (let / read) variable compiles to valid Wasm and reads the correct param.
+- `+16` on the `ary-ptrn-rest-obj-prop-id` cluster (generator/async-gen bodies,
+  named function expressions, object-method contexts) + broader builtin-capture
+  family. No regression in `.length`/`.concat`/… member access, var-write
+  capture, fn-scope-let capture, simple/dstr bindings (11/11 controls green).
+- No new malformed-Wasm in the cluster (0 traps across the 73).
+
+## Test Results (fresh single-file, host/gc)
+
+- `ary-ptrn-rest-obj-prop-id` 73-cluster: **0→16 PASS**, 57 FAIL (all bug C),
+  **0 traps** (bug B's malformed Wasm eliminated).
+- 11/11 regression controls green (member `.length`/`.concat`/`.substring`/
+  `.charCodeAt`, bare-`length` local, var-write capture, fn-scope-let capture,
+  simple param, array/object dstr bindings).
+- `tests/issue-2811.test.ts` — A+B repros (currently-failing-on-main → pass).
+
+## Follow-up
+
+- **Bug C** → carve/route to **architect** (block-scoped let captured by hoisted
+  function declaration; previously-reverted localMap-first approach). Unblocks
+  the remaining 57 of this cluster + a broad block-let-capture class suite-wide.

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -376,7 +376,12 @@ export function promoteAccessorCapturesToGlobals(
     if (name === "this") continue;
 
     // Skip if it's a known function name (not a variable capture)
-    if (ctx.funcMap.has(name)) continue;
+    // #2669: skip names bound to a *user* function (a function reference, not a
+    // captured variable) — but NOT a wasm:js-string builtin import
+    // (concat/length/equals/substring/charCodeAt), which lives in funcMap yet
+    // must not block capture of a same-named outer local (e.g. the test262
+    // `let length = "outer"` dstr template). Discriminate by index.
+    if (ctx.funcMap.has(name) && ctx.funcMap.get(name) !== ctx.jsStringImports.get(name)) continue;
 
     // Get the local's type
     const localType =
@@ -1693,7 +1698,12 @@ export function compileArrowAsClosure(
       }
     }
     if (localIdx === undefined) continue;
-    if (ctx.funcMap.has(name)) continue;
+    // #2669: skip names bound to a *user* function (a function reference, not a
+    // captured variable) — but NOT a wasm:js-string builtin import
+    // (concat/length/equals/substring/charCodeAt), which lives in funcMap yet
+    // must not block capture of a same-named outer local (e.g. the test262
+    // `let length = "outer"` dstr template). Discriminate by index.
+    if (ctx.funcMap.has(name) && ctx.funcMap.get(name) !== ctx.jsStringImports.get(name)) continue;
     // Skip if the name is the arrow's own parameter (including destructuring bindings)
     if (isOwnParamName(arrow, name)) continue;
     // Skip if the name is a named function expression's own name (self-reference)
@@ -2707,7 +2717,12 @@ export function compileArrowAsCallback(
   for (const name of referencedNames) {
     const localIdx = fctx.localMap.get(name);
     if (localIdx === undefined) continue;
-    if (ctx.funcMap.has(name)) continue;
+    // #2669: skip names bound to a *user* function (a function reference, not a
+    // captured variable) — but NOT a wasm:js-string builtin import
+    // (concat/length/equals/substring/charCodeAt), which lives in funcMap yet
+    // must not block capture of a same-named outer local (e.g. the test262
+    // `let length = "outer"` dstr template). Discriminate by index.
+    if (ctx.funcMap.has(name) && ctx.funcMap.get(name) !== ctx.jsStringImports.get(name)) continue;
     // Skip if the name is the arrow's own parameter (including destructuring bindings)
     if (isOwnParamName(arrow, name)) continue;
     const type =

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -3623,7 +3623,22 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
   // Fourth: collect module-level variable declarations as wasm globals
   /** Register a single module-level global variable with the given name and wasm type. */
   function registerModuleGlobal(name: string, wasmType: ValType): void {
-    if (ctx.funcMap.has(name)) return; // skip if shadowed by function
+    // Skip if shadowed by a *user* function — but NOT by a wasm:js-string
+    // builtin import (#2669). `addStringImports` registers `concat`, `length`,
+    // `equals`, `substring`, `charCodeAt` into `ctx.funcMap` (and mirrors them
+    // in `ctx.jsStringImports`). Those builtin names are not user bindings, so a
+    // module-level variable that merely *collides* with one — e.g. the test262
+    // `let length = "outer"` dstr template (`ary-ptrn-rest-obj-prop-id` family),
+    // or any captured `let concat`/`equals`/`substring`/`charCodeAt` — must still
+    // be promoted to a `$__mod_<name>` global. Otherwise it stays a
+    // `__module_init` local, invisible to every other function: reads from a
+    // nested/exported function return null. The bare `funcMap.has` gate
+    // conflated the two. Discriminate by index: when the funcMap entry IS the
+    // js-string builtin (no genuine user function shadows the name), fall
+    // through and register the global; a real user function of the same name
+    // keeps the original skip behaviour.
+    const fnIdx = ctx.funcMap.get(name);
+    if (fnIdx !== undefined && fnIdx !== ctx.jsStringImports.get(name)) return; // shadowed by a user function
     if (ctx.moduleGlobals.has(name)) return; // skip if already registered
     if (ctx.classSet.has(name)) return; // skip class expression variables
 

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -294,7 +294,11 @@ export function compileNestedFunctionDeclaration(
     if (name === "this" || name === "super") continue;
     const localIdx = fctx.localMap.get(name);
     if (localIdx === undefined) continue;
-    if (ctx.funcMap.has(name)) continue;
+    // #2669: skip names bound to a *user* function — but NOT a wasm:js-string
+    // builtin import (concat/length/equals/substring/charCodeAt), which lives in
+    // funcMap yet must not block capture of a same-named outer local (the
+    // test262 `let length = "outer"` dstr template captured by a nested fn).
+    if (ctx.funcMap.has(name) && ctx.funcMap.get(name) !== ctx.jsStringImports.get(name)) continue;
     const type =
       localIdx < fctx.params.length
         ? fctx.params[localIdx]!.type
@@ -792,14 +796,29 @@ export function compileNestedFunctionDeclaration(
       emitEagerNestedCallCaptureBoxes(ctx, liftedFctx, captures, referencedCalleeNames);
     }
 
-    // Emit default-value initialization for parameters with initializers
-    // (offset by number of captures since they are prepended as leading params)
-    emitDefaultParamInit(ctx, liftedFctx, stmt, paramTypes, captures.length);
+    // #2669: the user parameters are preceded by BOTH the value-capture params
+    // AND the TDZ-flag-box params (layout above:
+    //   [valueCap_0..N-1, tdzFlagBox_0..K-1, userParam_0..]).
+    // The leading offset for default-init / destructuring / arguments must be
+    // `captures.length + tdzFlaggedCaptures.length`, NOT just `captures.length`.
+    // Using `captures.length` alone (ignoring the K TDZ-flag boxes) made a
+    // capturing function with a *destructuring* param read the wrong param slot
+    // — e.g. `let length="outer"; function f([...{length:z}]){ ...length... }`
+    // (a TDZ-flagged `let`/read capture) destructured a TDZ i32-flag cell as the
+    // array argument → invalid Wasm (`any.convert_extern` on a non-externref).
+    // `var` write-only captures have no TDZ flag (K=0) so they were unaffected,
+    // which is why `callCount`-style tests compiled while the `length`-read dstr
+    // family trapped.
+    const leadingParamCount = captures.length + tdzFlaggedCaptures.length;
 
-    // Destructure parameters with binding patterns (offset by captures)
+    // Emit default-value initialization for parameters with initializers
+    // (offset by all prepended leading params — value captures + TDZ flag boxes)
+    emitDefaultParamInit(ctx, liftedFctx, stmt, paramTypes, leadingParamCount);
+
+    // Destructure parameters with binding patterns (offset by leading params)
     for (let pi = 0; pi < stmt.parameters.length; pi++) {
       const param = stmt.parameters[pi]!;
-      const paramIdx = captures.length + pi;
+      const paramIdx = leadingParamCount + pi;
       if (ts.isObjectBindingPattern(param.name)) {
         destructureParamObject(ctx, liftedFctx, paramIdx, param.name, paramTypes[pi]!);
       } else if (ts.isArrayBindingPattern(param.name)) {
@@ -813,7 +832,7 @@ export function compileNestedFunctionDeclaration(
     if (stmt.body && bodyUsesArguments(stmt.body)) {
       const unmapped =
         isStrictFunction(stmt, ctx.inferModuleStrictArguments) || !isSimpleParameterList(stmt.parameters);
-      emitArgumentsObject(ctx, liftedFctx, paramTypes, captures.length, unmapped);
+      emitArgumentsObject(ctx, liftedFctx, paramTypes, leadingParamCount, unmapped);
     }
 
     if (isGenerator) {
@@ -1390,7 +1409,11 @@ export function hoistFunctionDeclarations(
         if (name === "this" || name === "super") continue;
         if (ownLocals.has(name)) continue;
         if (siblingFuncNames.has(name)) continue;
-        if (ctx.funcMap.has(name)) continue;
+        // #2669: skip names bound to a *user* function — but NOT a wasm:js-string
+        // builtin import (concat/length/equals/substring/charCodeAt), which lives in
+        // funcMap yet must not block capture of a same-named outer local (the
+        // test262 `let length = "outer"` dstr template captured by a nested fn).
+        if (ctx.funcMap.has(name) && ctx.funcMap.get(name) !== ctx.jsStringImports.get(name)) continue;
         if (fctx.localMap.has(name)) {
           capturesOuter = true;
           break;

--- a/tests/issue-2811.test.ts
+++ b/tests/issue-2811.test.ts
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+/**
+ * #2811 (parent #2669) — destructuring closure-capture residual.
+ *
+ * Two pre-existing codegen bugs, both on the path of the test262
+ * `ary-ptrn-rest-obj-prop-id` dstr cluster (`[...{ …, length: z }]` guarded by an
+ * outer `let length = "outer"`):
+ *
+ *   A. A module/outer variable named like a wasm:js-string builtin
+ *      (`concat`/`length`/`equals`/`substring`/`charCodeAt`) was never globalized
+ *      / captured. `addStringImports` registers those names into `ctx.funcMap`
+ *      (mirrored in `ctx.jsStringImports`, #1072); the capture/global gates
+ *      `funcMap.has(name)` then skipped a *user* variable of the same name, so it
+ *      stayed a `__module_init` local / was dropped from the capture set → reads
+ *      from another function returned null. Fix: skip only a genuine user
+ *      function — `funcMap.get(name) !== jsStringImports.get(name)`.
+ *
+ *   B. A capturing function with a destructuring param read the WRONG param slot
+ *      when it captured a TDZ-flagged (let / read) variable. The lifted param
+ *      layout is [valueCaps(N), tdzFlagBoxes(K), userParams]; the destructure /
+ *      default-init / arguments offset used `captures.length` (N) only, ignoring
+ *      the K prepended TDZ-flag boxes → the destructuring read a TDZ i32-flag cell
+ *      as the array argument → invalid Wasm (`any.convert_extern` on a non-extern
+ *      ref). `var` write-only captures (K=0) were unaffected. Fix: offset by
+ *      `captures.length + tdzFlaggedCaptures.length`.
+ *
+ * Bug C (block-scoped let captured by a hoisted FUNCTION DECLARATION → null) is
+ * carved to architect and NOT covered here; it gates the function-declaration /
+ * class-method contexts of the same cluster.
+ */
+
+async function run(source: string): Promise<number> {
+  const result = await compile(source, { fileName: "test.ts", skipSemanticDiagnostics: true });
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool) as unknown as {
+    importObject?: WebAssembly.Imports;
+    setExports?: (e: WebAssembly.Exports) => void;
+  } & WebAssembly.Imports;
+  const { instance } = await WebAssembly.instantiate(
+    result.binary,
+    (imports.importObject ?? imports) as WebAssembly.Imports,
+  );
+  if (typeof imports.setExports === "function") imports.setExports(instance.exports);
+  return (instance.exports as { test: () => number }).test();
+}
+
+describe("#2811 A — captured/globalized variable named like a js-string builtin", () => {
+  // Each builtin name, declared at module scope and read from a nested function.
+  // Pre-fix: the gate `funcMap.has(name)` skipped it → the read returned null.
+  for (const name of ["length", "concat", "equals", "substring", "charCodeAt"]) {
+    it(`module-level \`let ${name}\` is captured by a nested function`, async () => {
+      expect(
+        await run(
+          `let ${name} = 42;
+           function g(): number { return ${name} as number; }
+           export function test(): number { return g(); }`,
+        ),
+      ).toBe(42);
+    });
+  }
+
+  it("a `{ length: z }` binding KEY does not shadow an outer captured `length`", async () => {
+    // The crux of the test262 `ary-ptrn-rest-obj-prop-id` cluster: the property
+    // KEY `length` in the destructuring pattern binds z, while the outer captured
+    // `length` variable (read inside the same function) must still resolve to its
+    // own value — not collapse to the js-string builtin / null.
+    expect(
+      await run(
+        `let length = 7;
+         let out = 0;
+         function f([...{ 0: a, length: z }]: number[]): void { out = (length as number) * 100 + (z as number); }
+         f([7, 8, 9]);
+         export function test(): number { return out; }`,
+      ),
+    ).toBe(703); // outer length stays 7, z = rest-array length = 3
+  });
+});
+
+describe("#2811 B — capturing function with a destructuring param + TDZ-flagged capture", () => {
+  it("array-pattern param capturing a `let` (read) compiles to valid Wasm", async () => {
+    // Pre-fix: invalid Wasm (`any.convert_extern` on a non-externref) — the
+    // destructuring read a prepended TDZ-flag i32 cell as the array argument.
+    expect(
+      await run(
+        `let c = 5;
+         let out = 0;
+         function f([a]: number[]): void { out = a * 10 + c; }
+         f([7]);
+         export function test(): number { return out; }`,
+      ),
+    ).toBe(75);
+  });
+
+  it("rest-into-object param capturing a `let` reads the array `.length` and indices", async () => {
+    expect(
+      await run(
+        `let len = 0;
+         let v = 0;
+         let z = 0;
+         function f([...{ 0: a, 2: c, length: n }]: number[]): void { v = a; z = c; n; len = n; }
+         f([7, 8, 9]);
+         export function test(): number { return v * 100 + z * 10 + len; }`,
+      ),
+    ).toBe(793); // v=7, z(index2)=9, len=3
+  });
+
+  it("var write-capture (no TDZ flag) still works — offset unchanged when K=0", async () => {
+    expect(
+      await run(
+        `export function test(): number { var c = 0; function f([a]: number[]): void { c = c + a; } f([4]); f([6]); return c; }`,
+      ),
+    ).toBe(10);
+  });
+});


### PR DESCRIPTION
## #2811 (parent #2669) — destructuring closure-capture residual

Two **pre-existing** codegen bugs under the #2669 destructuring umbrella, both on the path of the test262 `ary-ptrn-rest-obj-prop-id` cluster (`[...{ …, length: z }]` guarded by an outer `let length = "outer"`). Found verify-first by re-sweeping `/dstr/` fails on current `origin/main` (post-#2808).

### A — variable named like a wasm:js-string builtin never globalizes / captures
`addStringImports` registers `concat`/`length`/`equals`/`substring`/`charCodeAt` into `ctx.funcMap` (mirrored in `ctx.jsStringImports`, #1072). The capture/global gates `funcMap.has(name)` then skipped a **user** variable of the same name → it stayed a `__module_init` local / was dropped from the capture set, so reads from another function returned `null`. (`let length="outer"; function g(){return length;}` → `null`.)

**Fix:** discriminate by index — skip only a genuine user function, `funcMap.get(name) !== jsStringImports.get(name)`. Sites: `declarations.ts:registerModuleGlobal`, `closures.ts` (×3 capture loops), `nested-declarations.ts` (×2 capture loops). Function-name gates (keyed on `funcName`) untouched.

### B — capturing function with a dstr param + TDZ-flagged capture → malformed Wasm
Lifted param layout is `[valueCaps(N), tdzFlagBoxes(K), userParams]`, but the destructure / default-init / arguments offset used `captures.length` (N) only, ignoring the K prepended TDZ-flag boxes → the destructuring read a TDZ i32-flag cell as the array argument → invalid Wasm (`any.convert_extern` on a non-externref). `var` write-only captures (K=0) were unaffected — why `callCount`-style tests compiled while the `length`-read dstr family trapped once A let `length` capture. (`let c=5; function f([a]){return c}` → malformed Wasm.)

**Fix:** offset by `captures.length + tdzFlaggedCaptures.length` (no-op when K=0, strictly additive for the previously-always-malformed TDZ-flag case).

### Results
- `ary-ptrn-rest-obj-prop-id` 73-cluster: **0 → 16 PASS** (generator/async-gen bodies, named function expressions, object-method contexts), **0 traps** (bug B's malformed Wasm eliminated). Plus the broader builtin-named-capture family suite-wide.
- **11/11 regression controls green** (member `.length`/`.concat`/`.substring`/`.charCodeAt`, bare-`length` local, var-write capture, fn-scope-let capture, simple/array/object dstr bindings).
- `tests/issue-2811.test.ts` (9 tests) — A+B repros (fail on main → pass).

### Not in this PR (→ architect)
The remaining 57 of the cluster (function-declaration / class-method contexts) are gated by a **distinct** bug C: a block-scoped `let` captured by a hoisted **FunctionDeclaration** reads null (duplicate local — `saveBlockScopedShadows` removes the hoisted slot, the `let` re-allocates a fresh one, the capture keeps the stale `cap.outerLocalIdx`). The obvious capture-side fix (localMap-first) was already tried and reverted (`closures.ts:3509`). Carved + routed to architect (see issue notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS