### PR TITLE
docs: file #2812 + #2813 (native-messaging deployment + runtime docs from #389)

### DIFF
--- a/plan/issues/2812-native-messaging-deployment-recipe.md
+++ b/plan/issues/2812-native-messaging-deployment-recipe.md
@@ -1,0 +1,57 @@
+---
+id: 2812
+title: "Native Messaging deployment recipe: ship a Chrome NM host from js2wasm output (wasmtime shebang / bun -b / deno compile + manifest)"
+status: ready
+created: 2026-06-29
+updated: 2026-06-29
+priority: medium
+feasibility: medium
+task_type: docs
+area: examples
+language_feature: native-messaging
+goal: platform
+sprint: current
+horizon: m
+related: [389, 2778, 2807]
+---
+
+# Native Messaging deployment recipe
+
+## Problem
+
+The native-messaging examples compile to a `.wasm`, but there's no documented,
+turnkey path to a **deployable** Chrome native-messaging host — which is a single
+executable Chrome launches per the host manifest. The loopdive/js2#389 reporter
+is hand-assembling this:
+
+- a `#!/usr/bin/env -S wasmtime -W gc=y,function-references=y,tail-call=y,exceptions=y host.wasm`
+  shebang script that Chrome launches,
+- `bun -b host.wasm` direct WASM-GC execution,
+- `deno compile` to a standalone executable.
+
+## Scope
+
+Document (a `docs/` section + the `examples/native-messaging/README.md`) a
+turnkey recipe from a js2wasm-compiled host to a deployable Chrome host:
+
+1. **Compile:** `js2wasm examples/native-messaging/nm_js2wasm_node_fs.ts --target wasi -o .`
+2. **Pick a runner:**
+   - wasmtime shebang script (the exact `-W` flags; **not** `--all-proposals`, which enables stack-switching wasmtime rejects),
+   - `bun -b host.wasm` (direct WASM-GC execution),
+   - `deno` / `deno compile` standalone executable.
+3. **Wire the manifest:** point the Chrome `com.example.host.json` `path` at the runner script/executable.
+4. **node:fs hosts** need `--preload node:fs=<shim>` (`scripts/build-node-fs-shim.mjs`) — document the wasmtime/bun/deno equivalents.
+
+Optionally a small `scripts/make-nm-host.sh` helper that emits the runner + a
+manifest template.
+
+## Acceptance
+
+A user can follow the doc to produce a runnable Chrome native-messaging host
+from an example — manifest wiring included — for at least the wasmtime-shebang
+and `bun -b` paths.
+
+## Related
+
+- #389 — reporter's deployment exploration (shebang runner, `bun -b`, `deno compile`).
+- #2778 / #2807 — the example hosts themselves.

--- a/plan/issues/2813-run-wasi-output-across-runtimes-doc.md
+++ b/plan/issues/2813-run-wasi-output-across-runtimes-doc.md
@@ -1,0 +1,49 @@
+---
+id: 2813
+title: "Doc: running js2wasm --target wasi output across runtimes (wasmtime / bun -b / deno) + required -W flags"
+status: ready
+created: 2026-06-29
+updated: 2026-06-29
+priority: low
+feasibility: easy
+task_type: docs
+area: docs
+goal: platform
+sprint: current
+horizon: s
+related: [389, 2812]
+---
+
+# Running js2wasm `--target wasi` output across runtimes
+
+## Problem
+
+A `--target wasi` build is a WasmGC module that needs specific runtime flags,
+and there's no single doc listing what each runtime requires. The loopdive/js2#389
+reporter is discovering this ad hoc:
+
+- **wasmtime** needs `-W gc=y,function-references=y,tail-call=y,exceptions=y` —
+  and **not** `-W all-proposals=y` (that turns on stack-switching, which wasmtime
+  rejects).
+- **`bun -b host.wasm`** executes the WASM-GC binary directly.
+- **deno** runs it too.
+
+## Scope
+
+Add a "Running the output" section to `docs/standalone-io.md` (or a new
+`docs/runtimes.md`):
+
+- a runtime matrix — wasmtime (exact `-W` flags + the all-proposals caveat),
+  `bun -b`, deno — and what each needs;
+- the `node:fs` `--preload` shim note for the node:fs host;
+- cross-links from `docs/cli.md` and `examples/native-messaging/README.md`.
+
+## Acceptance
+
+A reader can pick a runtime and run a `--target wasi` `.wasm` without
+trial-and-error on the flags.
+
+## Related
+
+- #389 — reporter running the output under wasmtime / `bun -b` / deno.
+- #2812 — the deployment recipe that builds on this.


### PR DESCRIPTION
Follow-ups from loopdive/js2#389's deployment exploration: **#2812** turnkey Chrome NM host (wasmtime shebang / `bun -b` / `deno compile` + manifest); **#2813** doc the `--target wasi` runtime/flags matrix. Both `sprint: current`. (#2811 'suppress Cannot find name Deno' implemented directly.)