### PR TITLE
fix(#2815): suppress spurious 'Cannot find name Deno' on recognized stdio surface

### DIFF
--- a/plan/issues/2815-suppress-deno-not-found-warning.md
+++ b/plan/issues/2815-suppress-deno-not-found-warning.md
@@ -58,6 +58,7 @@ member-call shape syntactically regardless of types).
 ## Test Results
 
 `tests/issue-2815-deno-not-found-warning.test.ts` — 5/5 pass:
+
 - recognized `Deno.stdin`/`Deno.stdout` surface (multi-file): no TS2304 'Deno'
 - Deno adapter compiles to a valid wasi module, no warning
 - `Deno.notAThing` still warns

--- a/plan/issues/2815-suppress-deno-not-found-warning.md
+++ b/plan/issues/2815-suppress-deno-not-found-warning.md
@@ -1,0 +1,65 @@
+---
+id: 2815
+title: "Suppress spurious 'Cannot find name Deno' (TS2304) warning on the recognized Deno stdio surface"
+status: done
+sprint: current
+priority: low
+area: checker
+related: [389, 2684, 1951, 2603]
+completed: 2026-06-29
+assignee: ttraenkler/agent-a9c3d48
+---
+
+# Suppress spurious `Cannot find name 'Deno'` (TS2304)
+
+> Note: this issue was originally requested as id `2811`, but `2811` was already
+> taken on `main` (`2811-dstr-captured-builtin-name-and-dstr-param-closure-offset`).
+> Re-allocated to `2815` via `claim-issue.mjs --allocate` to satisfy the
+> `check:issue-ids:against-main` dup-id gate.
+
+## Problem
+
+js2wasm natively recognizes the `Deno.stdin/stdout.{readSync,writeSync}` surface
+(`src/codegen/deno-api.ts`) and lowers it to WASI fd IO. But the checker still
+emits `warning: Cannot find name 'Deno'. (2×)` when compiling a Deno host — the
+loopdive/js2#389 reporter flagged it ("What's up with that warning?"). It's noise,
+the same class as the `Cannot find name 'process'` (TS2580) already downgraded
+(#1951/#2603).
+
+Root cause: the **single-source** checker path (`analyzeSource`) injects an
+ambient `Deno` `.d.ts` (`buildDenoEnvDtsForSource`, #2684), so it never warns. But
+the **multi-file** paths (`analyzeMultiSource` / `analyzeFiles`) inject no such
+d.ts. The moment a real Deno host imports a shared, host-agnostic core (the
+reporter's exact layout — `examples/native-messaging/nm_js2wasm_deno.ts` imports
+`nm_js2wasm_sync_framing.ts`), compilation routes through the multi-file analyzer
+and TS2304 leaks as the `(2×)` warning. The diagnostic is downgraded to a warning
+(`DOWNGRADE_DIAG_CODES` includes 2304) but is still printed.
+
+## Fix
+
+In `src/checker/index.ts`, drop the TS2304 `Cannot find name 'Deno'` diagnostic in
+the multi-file analyze paths **only** when the flagged `Deno` identifier is the
+root object of a recognized `Deno.{stdin,stdout,stderr}` property access
+(`isRecognizedDenoStdioNotFound` + `filterRecognizedDenoStdioDiagnostics`). This is
+scoped to the natively-lowered stdio surface — a genuinely-unknown reference (bare
+`Deno`, `Deno.notAThing`, or any other unknown name) still surfaces its error. No
+blanket identifier suppression; codegen is unchanged (deno-api.ts lowers the
+member-call shape syntactically regardless of types).
+
+## Verify
+
+- `npx tsx src/cli.ts examples/native-messaging/nm_js2wasm_deno.ts --target wasi`
+  no longer emits `Cannot find name 'Deno'`; it compiles to a valid pure-WASI-P1
+  module that framed-echo round-trips byte-for-byte under real wasmtime v46
+  (`~/.local/bin/wasmtime`).
+- Scoping holds: `Deno.notAThing`, bare `Deno`, and unrelated `Foo` all still warn.
+- The `process` downgrade and unrelated diagnostics are unaffected.
+
+## Test Results
+
+`tests/issue-2815-deno-not-found-warning.test.ts` — 5/5 pass:
+- recognized `Deno.stdin`/`Deno.stdout` surface (multi-file): no TS2304 'Deno'
+- Deno adapter compiles to a valid wasi module, no warning
+- `Deno.notAThing` still warns
+- bare `Deno` still warns
+- unrelated `Foo` still warns

--- a/src/checker/index.ts
+++ b/src/checker/index.ts
@@ -678,6 +678,62 @@ export function buildDenoEnvDtsForSource(source: string): string | undefined {
   return /\bDeno\b/.test(source) ? DENO_STDIO_DECLS : undefined;
 }
 
+/** The `Deno` stdio streams js2wasm natively lowers (deno-api.ts). */
+const DENO_STDIO_STREAMS = new Set(["stdin", "stdout", "stderr"]);
+
+/** Innermost AST node whose span contains `pos` (used to inspect a diagnostic site). */
+function findNodeAtPosition(sf: ts.SourceFile, pos: number): ts.Node | undefined {
+  function recurse(node: ts.Node): ts.Node | undefined {
+    if (pos < node.getStart(sf) || pos >= node.getEnd()) return undefined;
+    return ts.forEachChild(node, recurse) ?? node;
+  }
+  return recurse(sf);
+}
+
+/**
+ * #2815 — js2wasm natively recognizes the ambient `Deno.{stdin,stdout,stderr}`
+ * synchronous-stdio surface and lowers it to WASI fd IO (src/codegen/deno-api.ts),
+ * so the checker's TS2304 "Cannot find name 'Deno'" on that recognized shape is
+ * pure noise — the same class as the `process` TS2580 that loopdive/js2#389 asked
+ * about (downgraded in #1951/#2603) and the ambient `Deno` d.ts the single-source
+ * path injects (#2684). The multi-file paths (analyzeMultiSource / analyzeFiles)
+ * don't inject that d.ts, so the warning still leaks for a real Deno program that
+ * imports a shared core (the reporter's exact case).
+ *
+ * Returns true ONLY when the flagged `Deno` identifier is the root object of a
+ * recognized `Deno.{stdin,stdout,stderr}` property access — so a genuinely-unknown
+ * reference (a bare `Deno`, or `Deno.notAThing`) still surfaces its TS2304. This
+ * is the scoped suppression #2815 asks for, NOT a blanket identifier silence.
+ */
+function isRecognizedDenoStdioNotFound(diag: ts.Diagnostic): boolean {
+  if (diag.code !== 2304) return false;
+  const text = typeof diag.messageText === "string" ? diag.messageText : diag.messageText.messageText;
+  if (!text.includes("'Deno'")) return false;
+  const sf = diag.file;
+  if (!sf || diag.start === undefined) return false;
+  const node = findNodeAtPosition(sf, diag.start);
+  if (!node || !ts.isIdentifier(node) || node.text !== "Deno") return false;
+  const parent = node.parent;
+  return (
+    parent !== undefined &&
+    ts.isPropertyAccessExpression(parent) &&
+    parent.expression === node &&
+    DENO_STDIO_STREAMS.has(parent.name.text)
+  );
+}
+
+/**
+ * #2815 — drop the benign TS2304 "Cannot find name 'Deno'" diagnostics that flag
+ * the natively-lowered `Deno.{stdin,stdout,stderr}` stdio surface. Used by the
+ * multi-file analyze paths, which (unlike the single-source path, #2684) do not
+ * inject the ambient `Deno` d.ts. Path-agnostic and precisely scoped via
+ * `isRecognizedDenoStdioNotFound`; leaves every other diagnostic untouched.
+ */
+function filterRecognizedDenoStdioDiagnostics(diagnostics: ts.Diagnostic[]): ts.Diagnostic[] {
+  if (!diagnostics.some(isRecognizedDenoStdioNotFound)) return diagnostics;
+  return diagnostics.filter((d) => !isRecognizedDenoStdioNotFound(d));
+}
+
 /**
  * Parse and type-check a TS or JS source file.
  * In-memory CompilerHost – no filesystem needed.
@@ -1039,7 +1095,9 @@ export function analyzeMultiSource(
   const semanticDiagnostics = analyzeOptions?.skipSemanticDiagnostics
     ? ([] as ts.Diagnostic[])
     : program.getSemanticDiagnostics();
-  const diagnostics = [...syntacticDiagnostics, ...semanticDiagnostics];
+  // #2815 — drop the benign "Cannot find name 'Deno'" on the natively-lowered
+  // Deno stdio surface (this path injects no ambient `Deno` d.ts, unlike #2684).
+  const diagnostics = filterRecognizedDenoStdioDiagnostics([...syntacticDiagnostics, ...semanticDiagnostics]);
 
   const entrySourceFile = program.getSourceFile(normalizedEntry)!;
 
@@ -1134,7 +1192,9 @@ export function analyzeFiles(entryPath: string, analyzeOptions?: AnalyzeOptions)
   const semanticDiagnostics = analyzeOptions?.skipSemanticDiagnostics
     ? ([] as ts.Diagnostic[])
     : program.getSemanticDiagnostics();
-  const diagnostics = [...syntacticDiagnostics, ...semanticDiagnostics];
+  // #2815 — drop the benign "Cannot find name 'Deno'" on the natively-lowered
+  // Deno stdio surface (this path injects no ambient `Deno` d.ts, unlike #2684).
+  const diagnostics = filterRecognizedDenoStdioDiagnostics([...syntacticDiagnostics, ...semanticDiagnostics]);
 
   const entrySourceFile = program.getSourceFile(resolvedEntry);
   if (!entrySourceFile) {

--- a/tests/issue-2815-deno-not-found-warning.test.ts
+++ b/tests/issue-2815-deno-not-found-warning.test.ts
@@ -1,0 +1,75 @@
+// #2815 — suppress the spurious TS2304 "Cannot find name 'Deno'" diagnostic on
+// the natively-lowered `Deno.{stdin,stdout,stderr}` synchronous-stdio surface.
+//
+// loopdive/js2#389: js2wasm recognizes `Deno.stdin/stdout.{readSync,writeSync}`
+// and lowers it to WASI fd IO (src/codegen/deno-api.ts), and the single-source
+// checker path injects an ambient `Deno` d.ts (#2684) so it never warns. But the
+// MULTI-FILE paths (analyzeMultiSource / analyzeFiles — used the moment the entry
+// imports a shared core, the reporter's exact layout) inject no d.ts, so TS2304
+// leaked as `warning: Cannot find name 'Deno'. (2×)`. The reporter asked "what's
+// up with that warning?" — it's noise, same class as the `process` TS2580 that
+// was already downgraded (#1951/#2603).
+//
+// The fix suppresses TS2304 'Deno' ONLY when the flagged identifier is the root
+// of a recognized `Deno.{stdin,stdout,stderr}` property access — a genuinely
+// unknown reference (bare `Deno`, `Deno.notAThing`, or any other unknown name)
+// still surfaces its error.
+import { describe, expect, it } from "vitest";
+import { analyzeMultiSource } from "../src/checker/index.js";
+import { ts } from "../src/ts-api.js";
+import { compileMultiSource } from "../src/compiler.js";
+
+/** TS2304 messages mentioning a specific name, across all user files. */
+function notFoundFor(files: Record<string, string>, entry: string, name: string): string[] {
+  const ast = analyzeMultiSource(files, entry);
+  return ast.diagnostics
+    .filter((d) => d.category === 1 && d.code === 2304)
+    .map((d) => ts.flattenDiagnosticMessageText(d.messageText, " "))
+    .filter((m) => m.includes(`'${name}'`));
+}
+
+// The reporter's layout: a thin Deno adapter that imports a shared, host-agnostic
+// core. The import routes compilation through the multi-file analyzer.
+const CORE = `export function run(read: (b: Uint8Array) => number | null, write: (b: Uint8Array) => number): number {
+  const buf = new Uint8Array(4);
+  const r = read(buf);
+  if (r === null) return 0;
+  return write(buf);
+}`;
+const DENO_ADAPTER = `import { run } from "./core";
+function denoRead(b: Uint8Array): number | null { return Deno.stdin.readSync(b); }
+function denoWrite(b: Uint8Array): number { return Deno.stdout.writeSync(b); }
+export function main(): number { return run(denoRead, denoWrite); }`;
+
+describe("#2815 — suppress spurious 'Cannot find name Deno'", () => {
+  it("does NOT warn on the recognized Deno.stdin/stdout stdio surface (multi-file)", () => {
+    expect(notFoundFor({ "core.ts": CORE, "main.ts": DENO_ADAPTER }, "main.ts", "Deno")).toEqual([]);
+  });
+
+  it("still compiles the Deno adapter to a valid wasi module without the warning", async () => {
+    const r = await compileMultiSource({ "core.ts": CORE, "main.ts": DENO_ADAPTER }, "main.ts", {
+      target: "wasi",
+    });
+    expect(r.success).toBe(true);
+    expect(r.binary).toBeInstanceOf(Uint8Array);
+    expect(r.binary?.length ?? 0).toBeGreaterThan(8);
+    // No "Cannot find name 'Deno'" in either errors or warnings.
+    const all = [...(r.errors ?? [])];
+    expect(all.some((e) => e.message.includes("Cannot find name 'Deno'"))).toBe(false);
+  });
+
+  it("STILL warns on a non-stdio Deno member (genuinely unknown)", () => {
+    const files = { "core.ts": "export const x = 1;", "main.ts": `import { x } from "./core"; Deno.notAThing.foo();` };
+    expect(notFoundFor(files, "main.ts", "Deno")).not.toEqual([]);
+  });
+
+  it("STILL warns on a bare Deno reference (not a recognized member access)", () => {
+    const files = { "core.ts": "export const x = 1;", "main.ts": `import { x } from "./core"; const d = Deno; d;` };
+    expect(notFoundFor(files, "main.ts", "Deno")).not.toEqual([]);
+  });
+
+  it("does not affect unrelated unknown identifiers", () => {
+    const files = { "core.ts": "export const x = 1;", "main.ts": `import { x } from "./core"; Foo.bar();` };
+    expect(notFoundFor(files, "main.ts", "Foo")).not.toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

js2wasm natively recognizes `Deno.stdin/stdout.{readSync,writeSync}` and lowers it to WASI fd IO (`src/codegen/deno-api.ts`), but the checker still emitted `warning: Cannot find name 'Deno'. (2×)` when compiling a Deno host — loopdive/js2#389's reporter flagged it. Same noise class as the `process` TS2580 that was already downgraded (#1951/#2603).

**Root cause:** the single-source checker path (`analyzeSource`) injects an ambient `Deno` d.ts (#2684) so it never warns, but the **multi-file** paths (`analyzeMultiSource` / `analyzeFiles`) inject none. A real Deno host that imports a shared, host-agnostic core (the reporter's exact layout — `examples/native-messaging/nm_js2wasm_deno.ts` imports `nm_js2wasm_sync_framing.ts`) routes through the multi-file analyzer, so TS2304 leaked.

## Fix

In `src/checker/index.ts`, drop the TS2304 `Cannot find name 'Deno'` diagnostic in the multi-file paths **only** when the flagged `Deno` identifier is the root of a recognized `Deno.{stdin,stdout,stderr}` property access (`isRecognizedDenoStdioNotFound` + `filterRecognizedDenoStdioDiagnostics`). Scoped — bare `Deno`, `Deno.notAThing`, and unrelated unknowns still warn. Codegen is untouched.

## Verify

- `npx tsx src/cli.ts examples/native-messaging/nm_js2wasm_deno.ts --target wasi` no longer emits `Cannot find name 'Deno'`; compiles to a valid pure-WASI-P1 module that framed-echo round-trips byte-for-byte under real wasmtime v46.
- `tests/issue-2815-deno-not-found-warning.test.ts` — 5/5 pass (suppression + scoping: `Deno.notAThing`, bare `Deno`, unrelated `Foo` all still warn).
- `tsc --noEmit` clean.

> Note: requested as id 2811, but 2811 was already taken on main (`2811-dstr-captured-builtin-name-...`); re-allocated to 2815 via `claim-issue.mjs --allocate` to satisfy the dup-id CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)