### PR TITLE
fix(#2814): re-chunk ALL Native-Messaging hosts to <=1 MiB JSON frames

### DIFF
--- a/examples/native-messaging/nm_js2wasm_deno.ts
+++ b/examples/native-messaging/nm_js2wasm_deno.ts
@@ -25,14 +25,21 @@
 // to the compiler's native nullable representation (no JS host needed), so
 // `=== null` works in the standalone module exactly as it does under real Deno.
 //
-// The Native Messaging FRAMING + verbatim streaming itself lives in the shared,
-// host-independent core `nm_js2wasm_sync_framing.ts` (#2778) — this file is just the thin
-// Deno adapter that injects `Deno.stdin.readSync` / `Deno.stdout.writeSync` into
-// the `runNmHost` seam and runs it with NO re-chunk cap (verbatim byte echo).
-// `nm_js2wasm_node_fs.ts` is the same core injected with `node:fs` IO and a 1 MiB cap;
-// `nm_js2wasm_wasi_p1.ts` is the raw `wasi_snapshot_preview1` `fd_read`/`fd_write` form.
-// All compile to the SAME pure-WASI-P1 shape; they differ only in which runtime's
-// source-level API they additionally run under, unmodified.
+// The Native Messaging FRAMING + browser-cap re-chunk streaming itself lives in
+// the shared, host-independent core `nm_js2wasm_sync_framing.ts` (#2778) — this file is
+// just the thin Deno adapter that injects `Deno.stdin.readSync` /
+// `Deno.stdout.writeSync` into the `runNmHost` seam and runs it with a **1 MiB
+// re-chunk cap** (#2814), exactly like `nm_js2wasm_node_fs.ts`. A body larger than
+// the browser 1 MiB per-host->extension-message cap is split into a sequence of
+// valid <=1 MiB JSON frames (`[run]` for an array body, `"run"` for a string body)
+// whose interiors, concatenated by the receiver, reproduce the original body; a
+// body that already fits is echoed verbatim. This keeps every host->extension
+// message within the real Chrome cap and bounds resident memory on the write side.
+// `nm_js2wasm_wasi_p1.ts` is the raw `wasi_snapshot_preview1` `fd_read`/`fd_write`
+// form (it re-chunks too, in linear memory). All compile to the SAME pure-WASI-P1
+// shape; they differ only in which runtime's source-level API they additionally
+// run under, unmodified. NO Native-Messaging host echoes a single >1 MiB frame
+// (#2814 — re-chunking is not optional; loopdive/js2#389).
 //
 // The seam is two FUNCTION references (`denoRead` / `denoWrite`), not an object:
 // passing a struct value across the bundled-module boundary traps at runtime
@@ -70,18 +77,30 @@ function denoWrite(buf: Uint8Array): void {
   }
 }
 
-// No fd-2 telemetry in the verbatim variant (matches the pre-dedup nm_js2wasm_deno). The
-// verbatim path never invokes the diagnostics hook, so this is never called — it
-// exists only to satisfy the shared core's `log` parameter.
+// No fd-2 telemetry in the Deno variant (the fd-2 diagnostics line is the
+// `nm_js2wasm_node_fs` demo's deliberate extra; this thin Deno adapter keeps the
+// no-op to stay focused on the stdio seam). The shared core's re-chunk path calls
+// this once per input message with the declared body length; a no-op is a valid
+// implementation of the `log` hook.
 function denoNoLog(declaredLen: number): void {
   // intentionally empty; `declaredLen` is referenced so strict typecheck is happy
   void declaredLen;
 }
 
 export function main(): void {
-  // Verbatim echo: no browser re-chunk cap (maxFrameSize 0). Each framed message
-  // is streamed back byte-for-byte until EOF / a zero-length shutdown frame.
-  runNmHost(denoRead, denoWrite, denoNoLog, 0);
+  // Largest body the browser Native-Messaging implementation accepts in one
+  // host->extension message — the shared core's re-chunk cap (#2814). A body
+  // larger than this is split into valid <=1 MiB JSON frames; a smaller body is
+  // echoed verbatim. Streams to EOF / a zero-length shutdown frame.
+  //
+  // Kept a LOCAL const (not module-level) on purpose: a module-level const lowers
+  // to a Wasm GLOBAL, and passing that global as the cap argument across the
+  // bundled-module call into the shared core mis-lowers under `--target wasi` → a
+  // runtime fault (a clean compile, but a fault) — the same multi-file
+  // index-shift gap noted in `nm_js2wasm_node_fs.ts` (#2778). A local const (or an
+  // inline literal) compiles to a plain `i32.const` operand and is unaffected.
+  const frameChunk = 1024 * 1024;
+  runNmHost(denoRead, denoWrite, denoNoLog, frameChunk);
 }
 
 // Invoke the entry point. js2wasm compiles a top-level call into the module's

--- a/examples/native-messaging/nm_js2wasm_wasi_p1.ts
+++ b/examples/native-messaging/nm_js2wasm_wasi_p1.ts
@@ -32,14 +32,34 @@
 // followed by a UTF-8 JSON body, exchanged over fd 0 (stdin) / fd 1 (stdout). See
 //   https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging
 //
-// This raw variant echoes a framed message verbatim: it reads the 4-byte LE
-// length prefix, then the body, then writes the prefix + body straight back —
-// byte-for-byte, including high and null bytes (a frame is an opaque byte run to
-// the syscall layer). It streams through a single fixed linear-memory window, so
-// resident memory stays flat regardless of message size. (The 64-MiB re-chunking
-// the `node:fs` variant does for the browser 1-MiB cap is orthogonal to the raw
-// syscall layer and omitted here to keep the pure-WASI example focused on the
-// fd_read/fd_write ABI.)
+// Two hard browser constraints drive the response shape (the same two that drive
+// `nm_js2wasm_node_fs.ts`):
+//   1. The browser deserializes EVERY host->extension message as JSON, so each
+//      frame we write must be a complete, valid JSON value — not an arbitrary byte
+//      slice.
+//   2. A single host->extension message is capped at 1 MiB.
+//
+// So this raw variant RE-CHUNKS on the WRITE side (#2814) — it is no longer a
+// verbatim echo. It reads the 4-byte LE length prefix, then:
+//   - a body that already fits the cap is echoed verbatim (prefix + body), built
+//     whole and written in ONE `fd_write`;
+//   - a body LARGER than the cap is split into a sequence of valid JSON frames
+//     within the cap. Peek the first body byte: `"` → a large JSON string split
+//     into `"run"` frames; otherwise a large JSON array `[elem,…]` split into
+//     `[run]` frames at comma boundaries. The receiver concatenates the frame
+//     interiors (re-inserting one comma between array frames) to reproduce the
+//     original body. This mirrors the shared `nm_js2wasm_sync_framing` re-chunker,
+//     keeping the raw linear-memory IO (this file's demo value) while bounding the
+//     OUTPUT to valid <=cap frames — so NO host echoes a single >1 MiB frame.
+//
+// The cap here is a 64 KiB linear-memory window, NOT the full 1 MiB: this raw-WASI
+// module owns a FIXED 3-page (192 KiB) linear memory and the `"wasm:memory"`
+// accessor surface exposes no `memory.grow`, so a full 1 MiB pair of in-memory
+// work buffers would not fit. 64 KiB is comfortably <= the 1 MiB browser cap (a
+// host may always send SMALLER frames), keeps two work buffers (interior
+// read/carry + frame build) well within 3 pages, and still demonstrates the
+// re-chunk → valid-JSON-frames behavior the reporter asked for across all four
+// hosts. The two node hosts re-chunk to the full 1 MiB; this one to 64 KiB.
 
 import { fd_read, fd_write } from "wasi_snapshot_preview1";
 import { store32, load32, store8, load8 } from "wasm:memory";
@@ -49,12 +69,25 @@ import { store32, load32, store8, load8 } from "wasm:memory";
 type i32 = number;
 
 // ---- linear-memory scratch layout (the module owns + exports `memory`) --------
-// The default WASI memory is 3 pages (192 KiB). We reserve a small fixed control
-// region at the base and stream the body through a window well clear of it.
+// The default WASI memory is 3 pages (192 KiB). A small fixed control region sits
+// at the base; two CAP-sized work buffers (interior read/carry + frame build) live
+// above it, both well clear of the 192 KiB ceiling.
 const IOV: i32 = 0; // iovec[0] = { buf: i32 @0, buf_len: i32 @4 } (8 bytes)
 const RESULT: i32 = 8; // nread / nwritten result slot (4 bytes)
-const DATA: i32 = 64; // body window base (page-aligned headroom over the control region)
-const WINDOW: i32 = 64 * 1024; // 64 KiB streaming window (fits in the 3-page default)
+const HDR: i32 = 16; // 4-byte LE length-prefix read scratch
+const ONE: i32 = 20; // 1-byte peek scratch (`[` / `"` / trailing delimiter)
+
+// Per-emitted-frame JSON body cap (see the header note on the 192 KiB budget):
+// 64 KiB, comfortably <= the 1 MiB browser per-host->extension-message limit.
+const CAP: i32 = 64 * 1024; // max JSON body bytes per emitted frame
+const MAXRUN: i32 = CAP - 2; // run bytes per frame, leaving room for `[`/`]` (or two `"`)
+const INBUF: i32 = 4096; // interior read + carry buffer  [INBUF, INBUF+CAP)
+const OUTBUF: i32 = INBUF + CAP; // frame build buffer       [OUTBUF, OUTBUF+4+CAP)
+
+const COMMA: i32 = 44; // ,
+const OPEN_BRACKET: i32 = 91; // [
+const CLOSE_BRACKET: i32 = 93; // ]
+const DQUOTE: i32 = 34; // "
 
 // Set iovec[0] = { buf, len } and zero the result slot, ready for one fd_read /
 // fd_write of a single contiguous run.
@@ -73,8 +106,10 @@ function readSome(fd: i32, buf: i32, len: i32): i32 {
   return load32(RESULT);
 }
 
-// Read EXACTLY `n` bytes from `fd` into `buf`, looping over short reads. Returns
-// false on EOF / error before `n` bytes arrive.
+// Read EXACTLY `n` bytes from `fd` into `buf`, looping over short reads. Each
+// syscall reads at most the remaining `n - got` bytes, so it never pulls bytes
+// past `buf+n` (and thus never into the next message). Returns false on EOF /
+// error before `n` bytes arrive.
 function readExact(fd: i32, buf: i32, n: i32): boolean {
   let got: i32 = 0;
   while (got < n) {
@@ -100,57 +135,169 @@ function writeExact(fd: i32, buf: i32, n: i32): boolean {
   return true;
 }
 
-// Decode the little-endian uint32 the browser wrote as the first 4 bytes.
+// Decode the little-endian uint32 the browser wrote as the 4 bytes at `p`.
 function decodeLength(p: i32): i32 {
   return load8(p) + load8(p + 1) * 256 + load8(p + 2) * 65536 + load8(p + 3) * 16777216;
 }
 
-// Re-encode `len` as a 4-byte LE prefix at `p` (so we write the frame back whole).
-function encodeLength(p: i32, len: i32): void {
-  store8(p, len & 0xff);
-  store8(p + 1, (len >> 8) & 0xff);
-  store8(p + 2, (len >> 16) & 0xff);
-  store8(p + 3, (len >> 24) & 0xff);
+// Build ONE re-chunk frame in OUTBUF — 4-byte LE prefix + `open` + the run
+// INBUF[srcOff..srcOff+runLen) + `close` — and write it whole in ONE `fd_write`
+// (atomic framing: a streaming receiver must never see a prefix split from its
+// body; #2526). `open`/`close` are `[`/`]` for an array body or the two `"` for a
+// string body. The declared body length (open + run + close = runLen + 2) stays
+// <= CAP because every caller keeps runLen <= MAXRUN. INBUF and OUTBUF never
+// overlap, so the copy is safe. The write is best-effort: a broken pipe just makes
+// the next read/write fail and the outer loop stop.
+function emitFrame(srcOff: i32, runLen: i32, open: i32, close: i32): void {
+  const bodyLen: i32 = runLen + 2;
+  store8(OUTBUF, bodyLen & 0xff);
+  store8(OUTBUF + 1, (bodyLen >> 8) & 0xff);
+  store8(OUTBUF + 2, (bodyLen >> 16) & 0xff);
+  store8(OUTBUF + 3, (bodyLen >> 24) & 0xff);
+  store8(OUTBUF + 4, open);
+  let k: i32 = 0;
+  while (k < runLen) {
+    store8(OUTBUF + 5 + k, load8(INBUF + srcOff + k));
+    k = k + 1;
+  }
+  store8(OUTBUF + 5 + runLen, close);
+  writeExact(1, OUTBUF, 4 + bodyLen);
+}
+
+// Stream a single large JSON STRING body `"chars…"` into valid <=CAP `"run"`
+// frames. The leading `"` has already been consumed; `interiorRemaining` is the
+// interior character count (declaredLen - 2). A fixed `MAXRUN` split keeps each
+// frame within the cap (no comma boundaries to honor, unlike the array path). The
+// caller reads the trailing `"`. Returns false on EOF mid-frame. (The fixed split
+// must not bisect a `\`-escape; for the reported workload the body is plain
+// printable characters, so a fixed-run split is valid — same caveat as the shared
+// core's emitStringRun.)
+function streamLargeString(interiorRemaining: i32): boolean {
+  let remaining: i32 = interiorRemaining;
+  while (remaining > 0) {
+    let runLen: i32 = MAXRUN;
+    if (remaining < runLen) runLen = remaining;
+    if (!readExact(0, INBUF, runLen)) return false;
+    emitFrame(0, runLen, DQUOTE, DQUOTE);
+    remaining = remaining - runLen;
+  }
+  return true;
+}
+
+// RE-CHUNK port loop: read framed JSON messages off stdin (fd 0) and echo each one
+// back on stdout (fd 1) within the CAP-byte per-frame cap, until EOF (or a
+// zero-length frame = clean shutdown). A body that already fits is echoed
+// verbatim; a larger array/string body is split into valid <=CAP frames. Mirrors
+// the shared `nm_js2wasm_sync_framing` re-chunker, in raw linear memory.
+function runRechunk(): void {
+  while (true) {
+    // 4-byte LE length prefix. EOF (or a zero-length frame) = clean shutdown.
+    if (!readExact(0, HDR, 4)) return;
+    const declaredLen: i32 = decodeLength(HDR);
+    if (declaredLen === 0) return;
+
+    if (declaredLen <= CAP) {
+      // Already a valid JSON message within the cap — echo VERBATIM, prefix +
+      // body in ONE buffer and ONE write. Read the body straight into OUTBUF[4..].
+      store8(OUTBUF, declaredLen & 0xff);
+      store8(OUTBUF + 1, (declaredLen >> 8) & 0xff);
+      store8(OUTBUF + 2, (declaredLen >> 16) & 0xff);
+      store8(OUTBUF + 3, (declaredLen >> 24) & 0xff);
+      if (!readExact(0, OUTBUF + 4, declaredLen)) return;
+      if (!writeExact(1, OUTBUF, 4 + declaredLen)) return;
+      continue;
+    }
+
+    // Large body > cap. Peek the first byte to pick the re-chunk shape:
+    //   `"` → a single large JSON string → `"run"` frames (streamLargeString);
+    //   `[` → a large JSON array         → `[run]` frames (below).
+    if (!readExact(0, ONE, 1)) return; // the opening `"` or `[`
+    const first: i32 = load8(ONE);
+    if (first === DQUOTE) {
+      // Large JSON string: interior = declaredLen - 2 (excludes the two `"`).
+      if (!streamLargeString(declaredLen - 2)) return; // EOF mid-frame
+      if (!readExact(0, ONE, 1)) return; // the trailing `"`
+      continue;
+    }
+
+    // Large JSON array `[elem,...,elem]`: stream the interior, emitting valid
+    // `[run]` frames. The leading `[` is already consumed; the trailing `]` is
+    // read last. `fill` carries leftover bytes (a partial element, no comma) at
+    // INBUF[0..fill) across iterations.
+    let interiorRemaining: i32 = declaredLen - 2; // interior bytes (excludes `[` and `]`)
+    let fill: i32 = 0;
+    let truncated: boolean = false;
+
+    while (interiorRemaining > 0) {
+      const need: i32 = CAP - fill; // fill INBUF exactly (over-read-safe)
+      if (interiorRemaining >= need) {
+        if (!readExact(0, INBUF + fill, need)) {
+          truncated = true;
+          break;
+        }
+        fill = CAP;
+        interiorRemaining = interiorRemaining - need;
+        // Emit one frame up to the last comma within [0, MAXRUN); carry the rest.
+        let last: i32 = MAXRUN;
+        while (last > 0 && load8(INBUF + last - 1) !== COMMA) last = last - 1;
+        let runLen: i32 = 0;
+        let consumed: i32 = 0;
+        if (last === 0) {
+          // No comma in [0, MAXRUN): a single element exceeds the cap — emit
+          // MAXRUN raw (degenerate; only for elements > ~CAP bytes).
+          runLen = MAXRUN;
+          consumed = MAXRUN;
+        } else {
+          runLen = last - 1; // exclude the comma at last-1
+          consumed = last; // skip the comma too
+        }
+        emitFrame(0, runLen, OPEN_BRACKET, CLOSE_BRACKET);
+        // Shift the leftover INBUF[consumed..fill) to the front for the next frame.
+        const rem: i32 = fill - consumed;
+        let m: i32 = 0;
+        while (m < rem) {
+          store8(INBUF + m, load8(INBUF + consumed + m));
+          m = m + 1;
+        }
+        fill = rem;
+      } else {
+        // Final interior batch: read exactly interiorRemaining (over-read-safe),
+        // append to the carry, then drain to frames at comma boundaries; the last
+        // frame ends exactly at fill (the array has no trailing comma).
+        if (!readExact(0, INBUF + fill, interiorRemaining)) {
+          truncated = true;
+          break;
+        }
+        fill = fill + interiorRemaining;
+        interiorRemaining = 0;
+        let startPos: i32 = 0;
+        while (startPos < fill) {
+          let stop: i32 = startPos + MAXRUN;
+          if (stop >= fill) {
+            stop = fill;
+          } else {
+            let c: i32 = stop;
+            while (c > startPos && load8(INBUF + c - 1) !== COMMA) c = c - 1;
+            if (c > startPos) stop = c - 1;
+          }
+          emitFrame(startPos, stop - startPos, OPEN_BRACKET, CLOSE_BRACKET);
+          startPos = stop;
+          if (startPos < fill && load8(INBUF + startPos) === COMMA) startPos = startPos + 1;
+        }
+        fill = 0;
+      }
+    }
+    if (truncated) return; // EOF mid-frame → stop
+    if (!readExact(0, ONE, 1)) return; // the trailing `]`
+  }
 }
 
 export function main(): void {
   // Long-lived port loop: read framed messages off stdin (fd 0) and echo each one
-  // back on stdout (fd 1) until EOF. The 4-byte prefix lives at DATA[0..4); the
-  // body streams through DATA[4..4+window). A frame larger than the window is
-  // echoed in window-sized runs (the receiver concatenates the raw bytes, so the
-  // framing prefix + body are byte-identical to the input).
-  const bodyBase: i32 = DATA + 4; // body bytes follow the 4-byte prefix slot
-  const cap: i32 = WINDOW - 4; // bytes of body that fit after the prefix
-
-  while (true) {
-    // 4-byte LE length prefix. EOF (or a zero-length frame) = clean shutdown.
-    if (!readExact(0, DATA, 4)) break;
-    const declaredLen: i32 = decodeLength(DATA);
-    if (declaredLen === 0) break;
-
-    // Write the prefix back first (built whole from the decoded length).
-    encodeLength(DATA, declaredLen);
-    if (!writeExact(1, DATA, 4)) break;
-
-    // Stream the body through the fixed window: read a run into the body window,
-    // write it straight back, repeat until the whole declared body is echoed.
-    let remaining: i32 = declaredLen;
-    let truncated: boolean = false;
-    while (remaining > 0) {
-      let run: i32 = cap;
-      if (remaining < run) run = remaining;
-      if (!readExact(0, bodyBase, run)) {
-        truncated = true;
-        break;
-      }
-      if (!writeExact(1, bodyBase, run)) {
-        truncated = true;
-        break;
-      }
-      remaining = remaining - run;
-    }
-    if (truncated) break; // EOF mid-frame → stop
-  }
+  // back on stdout (fd 1), re-chunked to valid <=CAP JSON frames, until EOF (or a
+  // zero-length frame). All work flows through two fixed linear-memory buffers, so
+  // resident memory stays flat regardless of message size.
+  runRechunk();
 }
 
 // Invoke the entry point. js2wasm compiles a top-level call into the module's

--- a/examples/native-messaging/scale-test.mjs
+++ b/examples/native-messaging/scale-test.mjs
@@ -7,6 +7,14 @@
 //   js2wasm <variant>.js --target wasi [--link node:fs]
 //   wasmtime <variant>.wasm  < framed-input  > echoed-output
 //
+// As of #2814 ALL FOUR hosts RE-CHUNK: a body larger than the per-host frame cap
+// is streamed back as a sequence of valid <=1 MiB JSON frames whose interiors,
+// reassembled by the receiver, reproduce the input — no host echoes a single
+// >1 MiB frame (the real Chrome host->extension cap). The node hosts cap at 1 MiB;
+// the raw-WASI `nm_js2wasm_wasi_p1` caps at 64 KiB (its fixed 3-page linear memory
+// has no memory.grow), still comfortably <= 1 MiB. The round-trip check (every
+// frame body <=1 MiB; reassembled interiors == input) is identical for all four.
+//
 // WHY THIS EXISTS (the #2807 coverage hole): the in-process WASI shim used by
 // `tests/native-messaging-matrix.test.ts` / `issue-2754-transpiled-nm-roundtrip`
 // bulk-copies each `fd_write` iovec in one JS array slice, so it happily "writes"
@@ -163,7 +171,9 @@ const VARIANTS = [
     bunExtra: [],
     js2wasmExtra: [],
     preload: null,
-    mode: "verbatim",
+    // Re-chunks bodies > 1 MiB into valid <=1 MiB JSON frames via the shared
+    // nm_js2wasm_sync_framing core (#2814) — formerly a verbatim echo.
+    mode: "rechunk",
   },
   {
     name: "nm_js2wasm_wasi_p1",
@@ -171,7 +181,11 @@ const VARIANTS = [
     bunExtra: ["--external", "wasi_snapshot_preview1", "--external", "wasm:memory"],
     js2wasmExtra: [],
     preload: null,
-    mode: "verbatim",
+    // Re-chunks bodies > its 64 KiB linear-memory cap into valid <=1 MiB JSON
+    // frames in raw linear memory (#2814) — formerly a verbatim echo. The raw-WASI
+    // module owns a fixed 3-page memory (no memory.grow), so its cap is 64 KiB,
+    // comfortably <= the 1 MiB browser limit the round-trip check asserts.
+    mode: "rechunk",
   },
   {
     name: "nm_js2wasm_node_fs",
@@ -269,4 +283,6 @@ if (failures > 0) {
   console.error(`\n${failures} scale check(s) FAILED.`);
   process.exit(1);
 }
-console.log("\nPASS: all four Native-Messaging variants echo byte-exact under real wasmtime at every size.");
+console.log(
+  "\nPASS: all four Native-Messaging variants re-chunk to valid <=1 MiB JSON frames under real wasmtime at every size (no host echoes a single >1 MiB frame).",
+);

--- a/plan/issues/2814-all-nm-hosts-rechunk.md
+++ b/plan/issues/2814-all-nm-hosts-rechunk.md
@@ -1,0 +1,76 @@
+---
+id: 2814
+title: All Native-Messaging example hosts must re-chunk (≤1 MiB JSON frames)
+status: done
+sprint: current
+priority: medium
+area: examples
+related: [389, 2807, 2810, 2775]
+assignee: ttraenkler/agent-a089c35fb80d8f342
+completed: 2026-06-29
+---
+
+# All Native-Messaging example hosts re-chunk consistently
+
+## Problem
+
+The four `examples/native-messaging/` host variants compiled to standalone WASI
+should all behave the same on the WRITE side: accept a large (64 MiB+) framed
+input and stream the response back as a sequence of **valid `≤1 MiB` JSON
+frames** — the real Chrome native-messaging host→extension cap (a host literally
+cannot send more than 1 MB per message). Before this issue only
+`nm_js2wasm_node_fs` and `nm_js2wasm_node_process` re-chunked; `nm_js2wasm_deno`
+and `nm_js2wasm_wasi_p1` were VERBATIM echoers (they streamed the whole 64 MiB
+back in one logical message), which the loopdive/js2#389 reporter flagged as a
+break from the intended design.
+
+Per the maintainer, re-chunking (64 MiB in, ≤1 MiB JSON frames back) is **NOT
+optional** — the examples should behave consistently where they can, and no
+verbatim hosts should remain.
+
+## Change
+
+- **`nm_js2wasm_deno.ts`** — uses the shared `nm_js2wasm_sync_framing` core; now
+  passes a 1 MiB re-chunk cap (a LOCAL const, mirroring `nm_js2wasm_node_fs`'s
+  `frameChunk`) to `runNmHost` instead of `0` (verbatim). Bodies > 1 MiB split
+  into valid `[run]`/`"run"` frames; ≤1 MiB bodies echo verbatim.
+- **`nm_js2wasm_wasi_p1.ts`** — does NOT use the shared core (raw
+  `wasi_snapshot_preview1` `fd_read`/`fd_write` over `wasm:memory` linear-memory
+  accessors). Added a linear-memory re-chunker mirroring the shared core: peek the
+  first body byte (`"` → `"run"` string frames; else `[run]` array frames split at
+  comma boundaries), streamed through two fixed work buffers. Keeps the raw
+  linear-memory IO (its demo value); only the OUTPUT is bounded. Because the
+  raw-WASI module owns a FIXED 3-page (192 KiB) linear memory and `wasm:memory`
+  exposes no `memory.grow`, its frame cap is **64 KiB** (comfortably ≤ the 1 MiB
+  browser cap — a host may always send smaller frames). The two node hosts cap at
+  1 MiB.
+- **Tests / scale**:
+  - `examples/native-messaging/scale-test.mjs`: `nm_js2wasm_deno` and
+    `nm_js2wasm_wasi_p1` set to `mode: "rechunk"`; header + final message updated.
+  - `tests/native-messaging-matrix.test.ts`: the verbatim describe for deno +
+    wasi_p1 replaced with the re-chunk round-trip check (now covers deno, wasi_p1,
+    node_fs); the node_process describe converted from byte-identical to the same
+    round-trip check (it had been silently failing at 64/128 MiB since #2810
+    re-chunked its writes but this file's assertion was not updated).
+  - `tests/native-messaging-comparison.test.ts`: the 1 MiB + 3 MiB "verbatim"
+    large-payload cases converted to re-chunk round-trip checks.
+  - `tests/issue-2657-raw-wasi-fd-import.test.ts`: the ">64 KiB streams through the
+    fixed window" verbatim case converted to a re-chunk round-trip check.
+  - `tests/issue-2684-deno-stdio.test.ts`: the deno-example case now compiles via
+    `compileProject` (the example imports the shared core, so single-file `compile`
+    left `runNmHost` as an unsatisfiable `env.*` host import — a pre-existing bug
+    masked because the wasmtime describe is skipped where wasmtime is absent).
+
+## Acceptance
+
+All four hosts re-chunk 1 / 64 / 128 / 256 MiB: every output frame body ≤ 1 MiB,
+reassembled interiors == input. No host echoes a single > 1 MiB frame.
+
+## Verification
+
+- In-process fd-shim + real wasmtime v46 round-trips at 1/64/128/256 MiB for all
+  four hosts (array + string bodies): every frame ≤ 1 MiB, reassemble == input.
+- `tests/native-messaging-matrix.test.ts`, `native-messaging-comparison.test.ts`,
+  `issue-2657-raw-wasi-fd-import.test.ts`, `issue-2684-deno-stdio.test.ts`,
+  `issue-2748-deno-transpile.test.ts`, `issue-2754-transpiled-nm-roundtrip.test.ts`
+  all pass.

--- a/tests/issue-2657-raw-wasi-fd-import.test.ts
+++ b/tests/issue-2657-raw-wasi-fd-import.test.ts
@@ -143,6 +143,37 @@ function frame(body: Uint8Array): Uint8Array {
   return out;
 }
 
+/** Split a framed stream back into its body frames (4-byte LE prefix + body). */
+function parseFrames(stream: Uint8Array): Uint8Array[] {
+  const frames: Uint8Array[] = [];
+  let p = 0;
+  while (p + 4 <= stream.length) {
+    const len = stream[p]! + stream[p + 1]! * 256 + stream[p + 2]! * 65536 + stream[p + 3]! * 16777216;
+    p += 4;
+    if (p + len > stream.length) break;
+    frames.push(stream.subarray(p, p + len));
+    p += len;
+  }
+  return frames;
+}
+
+/** A valid JSON-array body `[null,null,…,null]` of approximately `approx` bytes. */
+function jsonArrayBody(approx: number): Buffer {
+  const m = Math.max(1, Math.floor((approx - 6) / 5) + 1);
+  const total = 2 + 4 + 5 * (m - 1);
+  const buf = Buffer.alloc(total);
+  let p = 0;
+  buf[p++] = 0x5b; // [
+  buf.write("null", p, "ascii");
+  p += 4;
+  for (let i = 1; i < m; i++) {
+    buf.write(",null", p, "ascii");
+    p += 5;
+  }
+  buf[p++] = 0x5d; // ]
+  return buf;
+}
+
 /** A minimal raw-fd echo: read a framed message and write it back verbatim. */
 const RAW_ECHO_SRC = `
 import { fd_read, fd_write } from "wasi_snapshot_preview1";
@@ -272,17 +303,32 @@ describe("#2657 nm_js2wasm_wasi_p1.ts example — real Native-Messaging host", (
     expect(Array.from(out)).toEqual(Array.from(input));
   });
 
-  it("echoes a multi-window body (> 64 KiB streams through the fixed window)", async () => {
+  it("re-chunks a multi-window (> 64 KiB) array body into valid <=1 MiB JSON frames", async () => {
     const src = readFileSync(examplePath, "utf-8");
     const binary = await compileWasi(src, "nm_js2wasm_wasi_p1");
-    // 150 KiB body with a deterministic byte pattern incl. nulls + high bytes.
-    const n = 150 * 1024;
-    const body = new Uint8Array(n);
-    for (let i = 0; i < n; i++) body[i] = (i * 31 + (i >> 7)) & 0xff;
+    // A ~150 KiB valid JSON array body, larger than the host's 64 KiB re-chunk cap
+    // (#2814): the raw-WASI host streams it back as a sequence of valid <=1 MiB
+    // `[run]` frames whose interiors, reassembled with one comma between frames,
+    // reproduce the original array body. (The host owns a fixed 3-page memory with
+    // no memory.grow, so it caps frames at 64 KiB — comfortably <= the 1 MiB
+    // browser cap.)
+    const body = jsonArrayBody(150 * 1024);
     const input = frame(body);
     const out = await runWithFdShim(binary, input);
-    expect(out.length).toBe(input.length);
-    expect(Array.from(out)).toEqual(Array.from(input));
+    const frames = parseFrames(out);
+    // A > 64 KiB body MUST come back re-chunked into multiple <=1 MiB frames.
+    expect(frames.length, "must re-chunk into multiple frames").toBeGreaterThan(1);
+    const parts: Buffer[] = [];
+    for (let i = 0; i < frames.length; i++) {
+      const f = frames[i]!;
+      expect(f.length, "frame must be <= 1 MiB (browser cap)").toBeLessThanOrEqual(1024 * 1024);
+      expect(f[0], "frame must open with '['").toBe(0x5b);
+      expect(f[f.length - 1], "frame must close with ']'").toBe(0x5d);
+      if (i > 0) parts.push(Buffer.from([0x2c])); // ,
+      parts.push(Buffer.from(f.subarray(1, f.length - 1)));
+    }
+    const recon = Buffer.concat([Buffer.from([0x5b]), Buffer.concat(parts), Buffer.from([0x5d])]);
+    expect(Buffer.compare(recon, body), "reassembled array must equal the input").toBe(0);
   });
 
   it.runIf(wasmtimeBin)("runs under REAL wasmtime: byte-correct framed echo", async () => {

--- a/tests/issue-2684-deno-stdio.test.ts
+++ b/tests/issue-2684-deno-stdio.test.ts
@@ -20,7 +20,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { compile } from "../src/index.js";
+import { compile, compileProject } from "../src/index.js";
 
 const WASMTIME_FLAGS = ["run", "-W", "gc=y,function-references=y,exceptions=y"];
 
@@ -167,7 +167,7 @@ export function main(): void { writeSync(1, "hi\\n"); }
       expect(out.length).toBe(0);
     });
 
-    it("the nm_js2wasm_deno.ts example round-trips multiple frames incl. a >window body", async () => {
+    it("the nm_js2wasm_deno.ts example round-trips multiple frames (a sub-cap body echoes verbatim)", async () => {
       const examplePath = join(
         dirname(fileURLToPath(import.meta.url)),
         "..",
@@ -175,9 +175,13 @@ export function main(): void { writeSync(1, "hi\\n"); }
         "native-messaging",
         "nm_js2wasm_deno.ts",
       );
-      const src = readFileSync(examplePath, "utf-8");
-      const result = await compile(src, { fileName: "nm_js2wasm_deno.ts", target: "wasi" });
-      expect(result.success).toBe(true);
+      // The deno example statically imports the shared `./nm_js2wasm_sync_framing`
+      // core, so it MUST go through the multi-file bundler (compileProject) — a
+      // single-file `compile` leaves `runNmHost` as an unsatisfiable `env.*` host
+      // import and the module never echoes. (Mirrors the CLI's relative-import
+      // routing, #2771.)
+      const result = await compileProject(examplePath, { target: "wasi", skipSemanticDiagnostics: true });
+      expect(result.success, result.success ? "" : result.errors?.[0]?.message).toBe(true);
 
       const frame = (body: number[]): Buffer => {
         const n = body.length;
@@ -187,8 +191,12 @@ export function main(): void { writeSync(1, "hi\\n"); }
         ]);
       };
       const small = [0x00, 0xff, 0x0a, 0x7f, 0x80, 0x41];
+      // 150 KiB body — below the deno host's 1 MiB browser-cap re-chunk threshold
+      // (#2814), so it is echoed VERBATIM (prefix + body) byte-for-byte. (A body
+      // LARGER than 1 MiB would be re-chunked into <=1 MiB JSON frames instead; the
+      // re-chunk round-trip is covered by the matrix + comparison tests.)
       const big: number[] = [];
-      for (let i = 0; i < 150000; i++) big.push((i * 7 + 3) & 0xff); // > 64 KiB window
+      for (let i = 0; i < 150000; i++) big.push((i * 7 + 3) & 0xff);
       const input = Buffer.concat([frame(small), frame(big)]);
       const out = run(result.binary!, "nm_js2wasm_deno", input);
       expect(Buffer.compare(out, input)).toBe(0);

--- a/tests/issue-2754-transpiled-nm-roundtrip.test.ts
+++ b/tests/issue-2754-transpiled-nm-roundtrip.test.ts
@@ -196,7 +196,10 @@ async function compileStrippedJs(file: string): Promise<Uint8Array> {
 
 // =============================================================================
 describe("#2754 — bun/esbuild type-stripped+bundled sync NM hosts round-trip under WASI", () => {
-  // nm_js2wasm_deno = VERBATIM streamer: every framed message echoes back byte-for-byte.
+  // nm_js2wasm_deno re-chunks bodies > the 1 MiB browser cap (#2814); a body <= the cap
+  // (here: small + an exactly-1 MiB body) echoes back byte-for-byte. This case stays
+  // at/under the cap so the stream is a byte-exact echo, which still pins the #2754
+  // stripped-bundle round-trip.
   it("nm_js2wasm_deno: stripped .js echoes a multi-frame stream byte-exact (incl. a 1 MiB body), matching .ts", async () => {
     const [tsBin, jsBin] = await Promise.all([
       compileTs("nm_js2wasm_deno.ts"),

--- a/tests/native-messaging-comparison.test.ts
+++ b/tests/native-messaging-comparison.test.ts
@@ -101,6 +101,62 @@ function frame(body: Uint8Array): Uint8Array {
   return out;
 }
 
+/** Split a framed stream back into its body frames (4-byte LE prefix + body). */
+function parseFrames(stream: Uint8Array): Uint8Array[] {
+  const frames: Uint8Array[] = [];
+  let p = 0;
+  while (p + 4 <= stream.length) {
+    const len = stream[p]! + stream[p + 1]! * 256 + stream[p + 2]! * 65536 + stream[p + 3]! * 16777216;
+    p += 4;
+    if (p + len > stream.length) break; // truncated tail — stop
+    frames.push(stream.subarray(p, p + len));
+    p += len;
+  }
+  return frames;
+}
+
+/** A valid JSON-array body `[null,null,…,null]` of approximately `approx` bytes. */
+function jsonArrayBody(approx: number): Buffer {
+  const m = Math.max(1, Math.floor((approx - 6) / 5) + 1);
+  const total = 2 + 4 + 5 * (m - 1);
+  const buf = Buffer.alloc(total);
+  let p = 0;
+  buf[p++] = 0x5b; // [
+  buf.write("null", p, "ascii");
+  p += 4;
+  for (let i = 1; i < m; i++) {
+    buf.write(",null", p, "ascii");
+    p += 5;
+  }
+  buf[p++] = 0x5d; // ]
+  return buf;
+}
+
+// The browser per-host->extension-message cap every host re-chunks to stay under.
+const FRAME_CAP_1MIB = 1024 * 1024;
+
+/**
+ * Assert one host's re-chunked echo (#2814): every emitted frame is a valid `[…]`
+ * within the 1 MiB browser cap, and concatenating the frame interiors (re-inserting
+ * one comma between consecutive frames) reconstructs the original array body.
+ */
+function assertRechunkRoundTrip(file: string, body: Buffer, out: Uint8Array): void {
+  const frames = parseFrames(out);
+  expect(frames.length, `${file}: expected at least one response frame`).toBeGreaterThanOrEqual(1);
+  const parts: Buffer[] = [];
+  for (let i = 0; i < frames.length; i++) {
+    const f = frames[i]!;
+    expect(f.length, `${file}: frame must be <= 1 MiB (browser cap)`).toBeLessThanOrEqual(FRAME_CAP_1MIB);
+    expect(f[0], `${file}: frame must open with '['`).toBe(0x5b);
+    expect(f[f.length - 1], `${file}: frame must close with ']'`).toBe(0x5d);
+    if (i > 0) parts.push(Buffer.from([0x2c])); // ,
+    parts.push(Buffer.from(f.subarray(1, f.length - 1)));
+  }
+  const recon = Buffer.concat([Buffer.from([0x5b]), Buffer.concat(parts), Buffer.from([0x5d])]);
+  expect(recon.length, `${file}: reconstructed body length`).toBe(body.length);
+  expect(Buffer.compare(recon, body), `${file}: reassembled array must equal the input`).toBe(0);
+}
+
 async function compileVariant(file: string): Promise<Awaited<ReturnType<typeof compile>>> {
   const path = join(NM_DIR, file);
   const src = readFileSync(path, "utf-8");
@@ -433,46 +489,49 @@ describe("#2696 — Native Messaging #389 reporter payloads", () => {
     });
   }
 
-  // The 1 MiB browser-message-cap payload — a complete single Native Messaging
-  // frame echoed verbatim. Restricted to the SYNCHRONOUS variants (raw WASI / Deno
-  // / node:fs): the nm_js2wasm_node_process async reactor rebuilds the body via per-byte
-  // `String.fromCharCode` + string concat, which is not CI-feasible at 1 MiB (its
-  // wire protocol is already covered by the synchronous variants + the small
-  // payloads above). 1 MiB is exactly at the cap, so even nm_js2wasm_node_fs (which
-  // re-chunks bodies LARGER than 1 MiB, per its README) echoes it as one frame.
+  // The 1 MiB browser-message-cap payload. As of #2814 ALL hosts re-chunk a body
+  // larger than their per-host cap, so this is asserted on re-chunk ROUND-TRIP, not
+  // a byte-identical echo: a valid `[null,null,…]` array body is split into valid
+  // <=1 MiB JSON frames whose interiors reassemble to the input. Restricted to the
+  // SYNCHRONOUS variants (raw WASI / Deno / node:fs): the nm_js2wasm_node_process async
+  // reactor rebuilds the body via per-byte `String.fromCharCode`, not CI-feasible at
+  // 1 MiB (its wire protocol is covered by the matrix test + the small payloads
+  // above). node_fs/deno cap at 1 MiB (a ~1 MiB body echoes as one frame); wasi_p1
+  // caps at 64 KiB (its fixed 3-page memory has no memory.grow) so it splits into
+  // ~64 KiB frames — both round-trip identically.
   for (const file of ["nm_js2wasm_wasi_p1.ts", "nm_js2wasm_node_fs.ts", "nm_js2wasm_deno.ts"]) {
-    it(`${file} echoes a 1 MiB frame verbatim`, { timeout: 60_000 }, async () => {
+    it(`${file} re-chunks a 1 MiB array body into valid <=1 MiB frames`, { timeout: 60_000 }, async () => {
       const r = await getCompiled(file);
       if (!isRunnableStandalone(r)) return;
-      const frameIn = frame(new Uint8Array(1024 * 1024).fill(0x61));
-      const out = await echoOnce(r, file.replace(/\.ts$/, "-1mib"), frameIn);
+      const body = jsonArrayBody(1024 * 1024);
+      const out = await echoOnce(r, file.replace(/\.ts$/, "-1mib"), frame(body));
       if (out === null) return;
-      expect(out.length, `${file} 1 MiB echo length`).toBe(frameIn.length);
-      expect(Buffer.compare(Buffer.from(out), Buffer.from(frameIn)), `${file} 1 MiB echo must be byte-identical`).toBe(
-        0,
-      );
+      assertRechunkRoundTrip(file, body, out);
     });
   }
 
-  // A LARGE multi-MiB single frame echoed verbatim. Restricted to the RAW
-  // byte-streaming variants (nm_js2wasm_wasi_p1 / nm_js2wasm_deno), which stream any frame through a
-  // fixed window byte-for-byte regardless of size. nm_js2wasm_node_fs deliberately
-  // re-chunks bodies > 1 MiB into <=1 MiB JSON response frames (browser cap), so a
-  // single >1 MiB frame does NOT come back byte-identical from it — that is its
-  // documented design, exercised separately. The reporter verified a 64 MiB body
-  // manually; 3 MiB is the CI-feasible stand-in for the same streaming path.
+  // A LARGE multi-MiB body. As of #2814 the raw byte-streaming variants
+  // (nm_js2wasm_wasi_p1 / nm_js2wasm_deno) re-chunk too (formerly verbatim), so this is
+  // asserted on re-chunk ROUND-TRIP like nm_js2wasm_node_fs: a >cap array body splits into
+  // valid <=1 MiB JSON frames whose interiors reassemble to the input. The reporter
+  // verified a 64 MiB body manually; 3 MiB is the CI-feasible stand-in.
   for (const file of ["nm_js2wasm_wasi_p1.ts", "nm_js2wasm_deno.ts"]) {
-    it(`${file} echoes a 3 MiB frame verbatim (reporter verified 64 MiB manually)`, { timeout: 120_000 }, async () => {
-      const r = await getCompiled(file);
-      if (!isRunnableStandalone(r)) return;
-      const frameIn = frame(new Uint8Array(3 * 1024 * 1024).fill(0x62));
-      const out = await echoOnce(r, file.replace(/\.ts$/, "-large"), frameIn);
-      if (out === null) return;
-      expect(out.length, `${file} 3 MiB echo length`).toBe(frameIn.length);
-      expect(Buffer.compare(Buffer.from(out), Buffer.from(frameIn)), `${file} 3 MiB echo must be byte-identical`).toBe(
-        0,
-      );
-    });
+    it(
+      `${file} re-chunks a 3 MiB array body into valid <=1 MiB frames (reporter verified 64 MiB manually)`,
+      {
+        timeout: 120_000,
+      },
+      async () => {
+        const r = await getCompiled(file);
+        if (!isRunnableStandalone(r)) return;
+        const body = jsonArrayBody(3 * 1024 * 1024);
+        const out = await echoOnce(r, file.replace(/\.ts$/, "-large"), frame(body));
+        if (out === null) return;
+        assertRechunkRoundTrip(file, body, out);
+        // Sanity: a >cap body MUST come back as multiple frames (re-chunked, not one).
+        expect(parseFrames(out).length, `${file} 3 MiB must re-chunk into multiple frames`).toBeGreaterThan(1);
+      },
+    );
   }
 
   // nm_js2wasm_wasi_p3.ts is the WASI Preview 3 async-component source-reference arm. The

--- a/tests/native-messaging-matrix.test.ts
+++ b/tests/native-messaging-matrix.test.ts
@@ -15,21 +15,23 @@
  * runtime — the matrix therefore runs in every CI shard, not only where
  * `wasmtime` happens to be installed.
  *
- *   - `nm_js2wasm_deno.ts`    / `nm_js2wasm_wasi_p1.ts`  — VERBATIM streamers: a frame of any size
- *     is echoed back byte-for-byte through a fixed window. Asserted byte-EXACT at
- *     1 / 64 / 128 MiB.
- *   - `nm_js2wasm_node_fs.ts` — re-chunks a body LARGER than the browser 1 MiB cap into a
- *     sequence of valid <=1 MiB JSON frames (its documented design). A single
- *     >1 MiB frame does NOT come back byte-identical, so it is asserted on
- *     ROUND-TRIP correctness instead: every emitted frame is <=1 MiB and a valid
- *     `[…]`, and concatenating the frame interiors reconstructs the original
- *     array body exactly. Tested at 1 / 64 / 128 MiB.
- *   - `nm_js2wasm_node_process.ts` — async `process.stdin` reactor. #2777 replaced the
- *     prelude's per-byte chunk build (and the example's growing-cons-rope
- *     `buffered`) with amortized-growth BYTE buffers, making the read side O(n);
- *     it now echoes 1 / 64 / 128 MiB byte-EXACT under the in-process reactor shim
- *     on EVERY CI run, matching the other three variants (previously the large
- *     cases were gated on #2777 because the O(n^2) read SIGKILLed at multi-MiB).
+ * #2814 — ALL FOUR hosts now RE-CHUNK a body LARGER than their per-host frame cap
+ * into a sequence of valid <=1 MiB JSON frames (no host echoes a single >1 MiB
+ * frame any more). A re-chunked >cap body does NOT come back byte-identical, so
+ * every host is asserted on ROUND-TRIP correctness: every emitted frame is <=1 MiB
+ * and a valid `[…]`, and concatenating the frame interiors (re-inserting one comma
+ * between consecutive frames) reconstructs the original array body exactly. Tested
+ * at 1 / 64 / 128 MiB.
+ *
+ *   - `nm_js2wasm_node_fs.ts` / `nm_js2wasm_deno.ts` — re-chunk to the 1 MiB browser
+ *     cap via the shared `nm_js2wasm_sync_framing` core (synchronous fd IO).
+ *   - `nm_js2wasm_wasi_p1.ts` — re-chunks in RAW linear memory to a 64 KiB cap (its
+ *     fixed 3-page memory has no memory.grow; 64 KiB is still <= the 1 MiB browser
+ *     cap). Synchronous raw `wasi_snapshot_preview1` fd IO.
+ *   - `nm_js2wasm_node_process.ts` — async `process.stdin` reactor. #2777 made the read
+ *     side O(n) (amortized-growth BYTE buffers — it previously SIGKILLed at
+ *     multi-MiB); #2810 re-chunked its WRITE side to the 1 MiB cap. Driven by the
+ *     in-process reactor shim; same round-trip assertion as the other three.
  */
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
@@ -302,80 +304,75 @@ async function runReactorShim(binary: Uint8Array, stdin: Uint8Array): Promise<Ui
   return out;
 }
 
+// ---- shared re-chunk round-trip assertion -----------------------------------
+/**
+ * Assert one host's re-chunked echo of a `~bytes` JSON-array body: every emitted
+ * frame is a valid `[…]` within the 1 MiB browser cap, and concatenating the
+ * frame interiors (re-inserting one comma between consecutive frames) reconstructs
+ * the original array body byte-for-byte (the receiver's reassembly semantics).
+ */
+function assertRechunkRoundTrip(file: string, label: string, body: Buffer, out: Uint8Array): void {
+  const frames = parseFrames(out);
+  expect(frames.length, `${file} ${label}: expected at least one response frame`).toBeGreaterThanOrEqual(1);
+
+  for (const f of frames) {
+    expect(f.length, `${file} ${label}: frame must be <= 1 MiB (browser cap)`).toBeLessThanOrEqual(FRAME_CAP);
+    expect(f[0], `${file} ${label}: frame must open with '['`).toBe(0x5b);
+    expect(f[f.length - 1], `${file} ${label}: frame must close with ']'`).toBe(0x5d);
+  }
+
+  const parts: Buffer[] = [];
+  for (let i = 0; i < frames.length; i++) {
+    if (i > 0) parts.push(Buffer.from([0x2c])); // ,
+    parts.push(Buffer.from(frames[i]!.subarray(1, frames[i]!.length - 1)));
+  }
+  const recon = Buffer.concat([Buffer.from([0x5b]), Buffer.concat(parts), Buffer.from([0x5d])]);
+  expect(recon.length, `${file} ${label}: reconstructed body length`).toBe(body.length);
+  expect(Buffer.compare(recon, body), `${file} ${label}: reassembled array must equal the input`).toBe(0);
+}
+
 // =============================================================================
-describe("#2775 — verbatim streamers echo 1/64/128 MiB byte-for-byte", () => {
-  for (const file of ["nm_js2wasm_deno.ts", "nm_js2wasm_wasi_p1.ts"]) {
+// #2814 — ALL FOUR hosts now RE-CHUNK a body larger than their frame cap into
+// valid <=1 MiB JSON frames; none is a verbatim streamer any more. The node hosts
+// cap at 1 MiB; the raw-WASI `nm_js2wasm_wasi_p1` caps at 64 KiB (its fixed 3-page
+// linear memory has no memory.grow), still comfortably <= 1 MiB. The round-trip
+// assertion (every frame body <=1 MiB; reassembled interiors == input) is
+// identical for every host. The three SYNCHRONOUS hosts run under the raw-fd
+// {@link runFdShim}; the async `nm_js2wasm_node_process` runs under the reactor
+// {@link runReactorShim}.
+describe("#2814 — sync re-chunk streamers round-trip 1/64/128 MiB into valid <=1 MiB frames", () => {
+  for (const file of ["nm_js2wasm_deno.ts", "nm_js2wasm_wasi_p1.ts", "nm_js2wasm_node_fs.ts"]) {
     describe(file, () => {
       for (const { label, bytes } of SIZES) {
-        it(`echoes a ${label} frame byte-identically`, { timeout: 180_000 }, async () => {
+        it(`reassembles a ~${label} array body from valid <=1 MiB frames`, { timeout: 180_000 }, async () => {
           const r = await getCompiled(file);
           expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
           expect(WebAssembly.validate(r.binary!), `${file} must validate`).toBe(true);
-          const input = frame(new Uint8Array(bytes).fill(0x61));
-          const out = await runFdShim(r.binary!, input);
-          expect(out.length, `${file} ${label} echo length`).toBe(input.length);
-          expect(Buffer.compare(Buffer.from(out), Buffer.from(input)), `${file} ${label} must be byte-identical`).toBe(
-            0,
-          );
+          const body = jsonArrayBody(bytes);
+          const out = await runFdShim(r.binary!, frame(body));
+          assertRechunkRoundTrip(file, label, body, out);
         });
       }
     });
   }
 });
 
-describe("#2775 — nm_js2wasm_node_fs re-chunk round-trips 1/64/128 MiB correctly", () => {
-  for (const { label, bytes } of SIZES) {
-    it(`reassembles a ~${label} array body from valid <=1 MiB frames`, { timeout: 180_000 }, async () => {
-      const r = await getCompiled("nm_js2wasm_node_fs.ts");
-      expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
-      const body = jsonArrayBody(bytes);
-      const out = await runFdShim(r.binary!, frame(body));
-      const frames = parseFrames(out);
-      expect(frames.length, `${label}: expected at least one response frame`).toBeGreaterThanOrEqual(1);
-
-      // Every emitted frame must be a valid `[…]` JSON array within the 1 MiB cap.
-      for (const f of frames) {
-        expect(f.length, `${label}: frame must be <= 1 MiB (browser cap)`).toBeLessThanOrEqual(FRAME_CAP);
-        expect(f[0], `${label}: frame must open with '['`).toBe(0x5b);
-        expect(f[f.length - 1], `${label}: frame must close with ']'`).toBe(0x5d);
-      }
-
-      // Concatenating the frame interiors (with a comma between consecutive
-      // frames) reconstructs the original array interior byte-for-byte — the
-      // receiver's reassembly semantics.
-      const parts: Buffer[] = [];
-      for (let i = 0; i < frames.length; i++) {
-        if (i > 0) parts.push(Buffer.from([0x2c])); // ,
-        parts.push(Buffer.from(frames[i]!.subarray(1, frames[i]!.length - 1)));
-      }
-      const recon = Buffer.concat([Buffer.from([0x5b]), Buffer.concat(parts), Buffer.from([0x5d])]);
-      expect(recon.length, `${label}: reconstructed body length`).toBe(body.length);
-      expect(Buffer.compare(recon, body), `${label}: reassembled array must equal the input`).toBe(0);
-    });
-  }
-});
-
-describe("#2777 — nm_js2wasm_node_process echoes 1/64/128 MiB byte-for-byte (async reactor)", () => {
+describe("#2814 — nm_js2wasm_node_process re-chunk round-trips 1/64/128 MiB (async reactor)", () => {
   // nm_js2wasm_node_process is reactor-driven (async `process.stdin`), so it is driven by
   // the in-process {@link runReactorShim} (poll_oneoff/fd_read/fd_write) rather
-  // than the synchronous {@link runFdShim}. Before #2777 its read side was O(n^2)
-  // — the prelude built each chunk byte-by-byte and the example re-flattened its
-  // growing cons-rope `buffered` on every charCodeAt/substring — so it SIGKILLed
-  // at multi-MiB and the large sizes were gated. The #2777 byte-buffer
-  // accumulation makes it O(n), so it now runs the FULL 1/64/128 MiB sweep on
-  // EVERY CI run, byte-identical, matching the other three streaming variants.
+  // than the synchronous {@link runFdShim}. The #2777 byte-buffer accumulation
+  // made the read side O(n) (it previously SIGKILLed at multi-MiB); #2810 then
+  // re-chunked its WRITE side to the 1 MiB browser cap, so — like the other three
+  // hosts — it no longer echoes a single >1 MiB frame and is asserted on re-chunk
+  // ROUND-TRIP correctness rather than a byte-identical echo (#2814).
   for (const { label, bytes } of SIZES) {
-    it(`echoes a ${label} frame byte-identically`, { timeout: 180_000 }, async () => {
+    it(`reassembles a ~${label} array body from valid <=1 MiB frames`, { timeout: 180_000 }, async () => {
       const r = await getCompiled("nm_js2wasm_node_process.ts");
       expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
       expect(WebAssembly.validate(r.binary!), "nm_js2wasm_node_process.ts must validate").toBe(true);
-      const input = frame(new Uint8Array(bytes).fill(0x61));
-      const out = await runReactorShim(r.binary!, input);
-      expect(out.length, `nm_js2wasm_node_process ${label} echo length`).toBe(input.length);
-      expect(
-        Buffer.compare(Buffer.from(out), Buffer.from(input)),
-        `nm_js2wasm_node_process ${label} must be byte-identical`,
-      ).toBe(0);
+      const body = jsonArrayBody(bytes);
+      const out = await runReactorShim(r.binary!, frame(body));
+      assertRechunkRoundTrip("nm_js2wasm_node_process.ts", label, body, out);
     });
   }
 });


### PR DESCRIPTION
## Summary

Makes ALL four `examples/native-messaging/` host variants re-chunk consistently: accept a large (64 MiB+) framed input and stream the response back as a sequence of valid **≤1 MiB JSON frames** — the real Chrome native-messaging host→extension cap. Before this, `nm_js2wasm_deno` and `nm_js2wasm_wasi_p1` were the last VERBATIM echoers (whole 64 MiB back in one logical message), which the loopdive/js2#389 reporter flagged. Per the maintainer, re-chunking is **not optional** and no verbatim host should remain.

## Changes

- **`nm_js2wasm_deno.ts`** — uses the shared `nm_js2wasm_sync_framing` core; now passes a **1 MiB** re-chunk cap (a LOCAL const, mirroring `nm_js2wasm_node_fs`'s `frameChunk`) to `runNmHost` instead of `0` (verbatim).
- **`nm_js2wasm_wasi_p1.ts`** — does NOT use the shared core (raw `wasi_snapshot_preview1` `fd_read`/`fd_write` over `wasm:memory` linear-memory accessors). Added a linear-memory re-chunker mirroring the shared core (peek first body byte: `"` → `"run"` string frames; else `[run]` array frames split at comma boundaries; two fixed work buffers). Keeps the raw linear-memory IO (its demo value); only the OUTPUT is bounded. Its fixed 3-page (192 KiB) memory has no `memory.grow`, so its frame cap is **64 KiB** (comfortably ≤ the 1 MiB browser cap — a host may always send smaller frames). The two node hosts cap at 1 MiB.
- **scale-test.mjs** — `nm_js2wasm_deno` + `nm_js2wasm_wasi_p1` set to `mode: "rechunk"`.
- **NM vitest tests** — verbatim assertions for the re-chunking hosts converted to re-chunk round-trip checks (every frame body ≤1 MiB; reassembled interiors == input), matching `node_fs`/`node_process`.

### Incidental pre-existing-bug fixes (both on `main`, masked because the wasmtime/large-payload paths are skipped in the equivalence shards)

- `native-messaging-matrix.test.ts` node_process **64/128 MiB** cases had asserted a byte-identical echo but have been red since #2810 re-chunked node_process's writes (that PR updated `issue-2807-fd-write-cap.test.ts`, not this file). Converted to the same round-trip check.
- `issue-2684-deno-stdio.test.ts` compiled the deno example with single-file `compile`, but the example imports the shared core, so `runNmHost` became an unsatisfiable `env.*` host import and the module never echoed under wasmtime. Now uses `compileProject` (the CLI's relative-import path).

## Verification

Real wasmtime **v46.0.1** + bun 1.3.14, all four hosts at **1 / 64 / 128 / 256 MiB**: every output frame ≤1 MiB, reassembled interiors == input, no host echoes a single >1 MiB frame:

```
PASS: all four Native-Messaging variants re-chunk to valid <=1 MiB JSON frames under real wasmtime at every size (no host echoes a single >1 MiB frame).
```

NM vitest suite green (matrix, comparison, issue-2657/2684/2748/2754/2815): 67 passed, 1 skipped (P3, #2658). `prettier --check`, `tsc --noEmit`, and `check:issue-ids:against-main` all clean.

Closes #2814.

🤖 Generated with [Claude Code](https://claude.com/claude-code)