### PR TITLE
release: v0.59.2

### DIFF
--- a/docs/releases/0.59.2.md
+++ b/docs/releases/0.59.2.md
@@ -1,0 +1,34 @@
+# v0.59.2
+
+_Released 2026-06-29._
+
+## Native Messaging — all hosts re-chunk (loopdive/js2#389)
+
+- **#2814** — all four example hosts now re-chunk their responses to the **≤1 MiB
+  browser cap**. `nm_js2wasm_deno` and `nm_js2wasm_wasi_p1` were echoing the whole
+  message verbatim; they now stream ≤1 MiB JSON frames like
+  `nm_js2wasm_node_fs`/`nm_js2wasm_node_process`, so no host sends >1 MB in a
+  single message (the real Chrome native-messaging host→extension limit). Verified
+  byte-exact reassembly at 1 / 64 / 128 / 256 MiB under real wasmtime v46 for all
+  four. Two incidental main bugs were fixed along the way: the matrix
+  `node_process` 64/128 MiB cases (red since #2810) and `issue-2684`'s single-file
+  compile of the bundled deno example (unsatisfiable `env.runNmHost` import).
+
+## Fixes
+
+- **#2815** — suppress the spurious `Cannot find name 'Deno'` diagnostic for the
+  recognized `Deno.{stdin,stdout,stderr}` surface (the multi-file analyzer wasn't
+  injecting the ambient `Deno` d.ts the single-source path already had).
+- **#2811** — capture/globalize builtin-named vars + destructuring-param closure
+  TDZ-flag offset.
+
+## Docs
+
+- **#2812** — Native Messaging deployment recipe (wasmtime shebang / `bun -b` /
+  `deno compile` + manifest).
+- **#2813** — running `--target wasi` output across runtimes (wasmtime `-W` flags
+  + the all-proposals caveat, `bun -b`, deno).
+- **#2817** — tracked: `nm_node_process`'s `env.__wasiStdinStop` host import needs
+  a WASI-native fallback.
+
+**Full changelog:** https://github.com/loopdive/js2/compare/v0.59.1...v0.59.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.59.1",
+  "version": "0.59.2",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js2wasm",
-  "version": "0.59.1",
+  "version": "0.59.2",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC (unscoped proxy for @loopdive/js2)",
   "keywords": [
     "webassembly",


### PR DESCRIPTION
Patch (no `feat()` since 0.59.1). Headline: **#2814** — all four Native-Messaging hosts now re-chunk to the ≤1 MiB browser cap (`nm_js2wasm_deno` + `nm_js2wasm_wasi_p1` join node_fs/node_process; no verbatim host remains), verified 1/64/128/256 MiB under real wasmtime v46. Plus **#2815** (suppress `Cannot find name 'Deno'`), **#2811** (builtin-named-var capture + dstr-param TDZ), and docs **#2812/#2813/#2817**. Notes: `docs/releases/0.59.2.md`. After merge, push tag `v0.59.2` to publish.