### PR TITLE
fix(#2726): sloppy delete of unresolvable identifier returns true (group a)

### DIFF
--- a/plan/issues/2726-delete-residual-sloppy-return-hasownproperty-accessor-mapped.md
+++ b/plan/issues/2726-delete-residual-sloppy-return-hasownproperty-accessor-mapped.md
@@ -1,7 +1,7 @@
 ---
 id: 2726
 title: "delete residual: sloppy return-value semantics, hasOwnProperty-after-delete, accessor descriptor configurability, mapped-arguments delete"
-status: in-progress
+status: ready
 sprint: current
 goal: test262-conformance
 feasibility: medium
@@ -10,18 +10,21 @@ priority: medium
 es_edition: ES5
 language_feature: delete
 task_type: bug
-assignee: ttraenkler/del2726
 created: 2026-06-26
 updated: 2026-06-29
 ---
 
-> **Partial resolution (2026-06-27, dev2).** Groups **(c)** and **(d)** are
-> DONE (+6 test262 incl. siblings, 0 regressions — see `## Resolution`).
-> Remaining open scope: **(a)** sloppy unresolvable-identifier oracle and
-> **(b)** sloppy global-object model are STRUCTURAL (architect-spec first);
-> **(e)** mapped-arguments delete is DEFERRED to #1726 (mapped-arguments
-> exotic); **(f)**/**(g)** re-route to their owning feature issues (not delete
-> bugs). This issue stays open (`status: ready`) for (a)/(b).
+> **Partial resolution (2026-06-29, del2726).** Group **(a)** is now DONE
+> (sloppy `delete <unresolvable identifier>` → `true`; +4 test262, 0
+> regressions — see `## Resolution — group (a)`). Groups **(c)** and **(d)**
+> were DONE earlier (+6 test262 incl. siblings, 0 regressions — see
+> `## Resolution — groups (c) + (d)`). Remaining open scope: **(b)** sloppy
+> global-object model (now 3/4 — `S11.4.1_A3.2_T1` implicit-global was carried
+> by the (a) oracle as a bonus; `S11.4.1_A3.1`, `S11.4.1_A3.3_T1`,
+> `11.4.1-4.a-8` remain) is STRUCTURAL (architect-spec first); **(e)**
+> mapped-arguments delete is DEFERRED to #1726; **(f)**/**(g)** re-route to
+> their owning feature issues (not delete bugs). This issue stays open
+> (`status: ready`) for (b) — route to architect before further dispatch.
 
 # #2726 — delete residual (non-throw) semantics
 
@@ -33,10 +36,10 @@ on its throw-semantics scope.
 
 ## Sub-groups (14 tests, all `test/language/expressions/delete/` unless noted)
 
-### (a) Sloppy-mode `delete <unresolvable identifier>` → `true` (3)
+### (a) Sloppy-mode `delete <unresolvable identifier>` → `true` (3) — DONE (2026-06-29)
 `S11.4.1_A2.2_T1.js`, `S11.4.1_A3.3_T6.js`, `11.4.1-3-1.js`
 - `delete x` where `x` resolves to **no binding anywhere** returns `true` in
-  sloppy mode (§13.5.1.2: unresolvable Reference ⇒ true). We currently return
+  sloppy mode (§13.5.1.2: unresolvable Reference ⇒ true). We previously returned
   `false` for every bare identifier (variables-not-deletable path in
   `compileDeleteExpression`).
 - **Hazard**: a naive "unknown to the compiler ⇒ unresolvable ⇒ true" flip
@@ -44,6 +47,11 @@ on its throw-semantics scope.
   non-configurable globals ⇒ must stay `false`). Needs a reliable
   "is this a real global binding" oracle, not the `isUnresolvableIdent`
   compiler-knowledge heuristic.
+- **Resolved** — see `## Resolution — group (a)`. The reliable oracle is
+  TS-checker **symbol presence** (`getSymbolAtLocation === undefined` ⇒
+  unresolvable), which keeps `undefined`/`arguments`/`globalThis` (symbol, no
+  value decl) and `NaN`/`Infinity`/`JSON` (lib-declared) out of the `true`
+  bucket. +4 test262 (the 3 targets + bonus implicit-global `S11.4.1_A3.2_T1`).
 
 ### (b) Sloppy global-object model (4)
 `S11.4.1_A3.1.js` (#2 `delete this.y === false`), `S11.4.1_A3.2_T1.js`
@@ -89,6 +97,50 @@ on its throw-semantics scope.
 The (a)–(e) groups flip from fail to pass with no regression in
 `expressions/delete/` or `built-ins/Object/defineProperty/`. (f) and (g) may be
 re-routed to their owning feature issues. Full CI green.
+
+## Resolution — group (a) (2026-06-29, del2726)
+
+**Root cause (a).** The bare-identifier arm of `compileDeleteExpression`
+(`src/codegen/typeof-delete.ts`) unconditionally emitted `i32.const 0` ("variables
+are not deletable") for **every** `delete <Identifier>`. §13.5.1.2 step 4 says a
+`delete` of an **UnresolvableReference** (the name resolves to no binding
+anywhere) evaluates to `true` in sloppy mode. Strict mode makes
+`delete <bare identifier>` an early SyntaxError
+(`early-errors/node-checks.ts` already enforces this), so the codegen arm is
+reached only in sloppy code — exactly where step 4 applies.
+
+**Oracle (the issue's stated hazard).** A reliable "real binding vs unresolvable"
+test is **TS-checker symbol presence**: `ctx.checker.getSymbolAtLocation(ident)`
+returns `undefined` only for a genuinely unresolvable name. The three
+non-configurable intrinsic globals that MUST stay `false`
+(`undefined`/`arguments`/`globalThis`) return a **symbol with no
+`valueDeclaration`**, and every lib-declared global (`NaN`/`Infinity`/`JSON`/…)
+returns a symbol **with** a value decl — so symbol-presence keeps all of them out
+of the `true` bucket, where the weaker `!valueDeclaration` heuristic would
+wrongly flip `undefined`/`arguments`/`globalThis`.
+
+**Fix (a).** When the bare-identifier reference is unresolvable
+(`getSymbolAtLocation === undefined`), emit `i32.const 1` (true); otherwise keep
+the `false`. **Eval guard**: an identifier inside an inlined `eval("<literal>")`
+body lives in a foreign `SourceFile` (`EVAL_SOURCE_FILENAME`, exported from
+`expressions/eval-inline.ts`) the checker never bound, so its symbol is *always*
+`undefined` even for a name resolving to an outer var. The flip is gated to skip
+eval-body nodes (`ident.getSourceFile().fileName !== EVAL_SOURCE_FILENAME`),
+preserving `var x = 1; eval('delete x') === false` (`11.4.1-4.a-7`). Precise
+eval-scope delete resolution stays out of scope (eval-substrate lane).
+`src/codegen/typeof-delete.ts`, `src/codegen/expressions/eval-inline.ts`.
+
+### Test Results — group (a) (host/gc lane, authoritative `runTest262File`)
+
+| cluster | baseline → fix |
+|---|---|
+| `language/expressions/delete` | 59 → **63** pass, **0 regressions** |
+| 98 other test262 files containing a bare-identifier `delete` | no change (0 collateral) |
+
+Net **+4** test262. Flipped fail→pass: `S11.4.1_A2.2_T1`, `S11.4.1_A3.3_T6`,
+`11.4.1-3-1` (group (a)) plus bonus `S11.4.1_A3.2_T1` (group (b) implicit-global
+`x = 1; delete x === true`, carried by the same oracle). Regression test:
+`tests/issue-2726-sloppy-unresolvable-delete.test.ts`.
 
 ## Resolution — groups (c) + (d) (2026-06-27, dev2)
 
@@ -142,6 +194,16 @@ flipped fail→pass: `11.4.1-4.a-1`, `11.4.1-4.a-2`, `11.4.1-4-a-4-s` (c),
 `Object/seal/object-seal-inherited-accessor-properties-are-ignored`.
 Regression test: `tests/issue-2726.test.ts`.
 
-## Residual (as of #2199, PO reconcile 2026-06-28)
+## Residual (as of #2199, PO reconcile 2026-06-28; updated 2026-06-29 del2726)
 
-NOT done — partially resolved. Groups (c) hasOwnProperty-after-configurable-delete + (d) non-configurable accessor delete are DONE (+6 test262, 0 regressions). Remaining OPEN: (a) sloppy unresolvable-identifier oracle + (b) sloppy global-object model — both STRUCTURAL and need an architect spec first (NOT dev-claimable as-is). (e) mapped-arguments delete → #1726; (f)/(g) re-routed to owning feature issues. Stays ready for (a)/(b) — route to architect before dispatch.
+NOT done — partially resolved. DONE so far: (a) sloppy unresolvable-identifier
+oracle (+4 test262, 0 regressions, 2026-06-29), (c) hasOwnProperty-after-
+configurable-delete + (d) non-configurable accessor delete (+6 test262, 0
+regressions). Remaining OPEN: **(b) sloppy global-object model** — now 3/4
+(`S11.4.1_A3.2_T1` implicit-global was carried by the (a) oracle; still failing:
+`S11.4.1_A3.1` `delete this.y === false`, `S11.4.1_A3.3_T1` `delete x; x` →
+ReferenceError, `11.4.1-4.a-8` `delete JSON === true`). (b) is STRUCTURAL (needs
+top-level-`this`-as-global-object + configurable-global tracking) and needs an
+architect spec first (NOT dev-claimable as-is). (e) mapped-arguments delete →
+#1726; (f)/(g) re-routed to owning feature issues. Stays `in-progress` for (b) —
+route to architect before further dispatch.

--- a/plan/issues/2726-delete-residual-sloppy-return-hasownproperty-accessor-mapped.md
+++ b/plan/issues/2726-delete-residual-sloppy-return-hasownproperty-accessor-mapped.md
@@ -1,7 +1,7 @@
 ---
 id: 2726
 title: "delete residual: sloppy return-value semantics, hasOwnProperty-after-delete, accessor descriptor configurability, mapped-arguments delete"
-status: ready
+status: in-progress
 sprint: current
 goal: test262-conformance
 feasibility: medium
@@ -10,8 +10,9 @@ priority: medium
 es_edition: ES5
 language_feature: delete
 task_type: bug
+assignee: ttraenkler/del2726
 created: 2026-06-26
-updated: 2026-06-27
+updated: 2026-06-29
 ---
 
 > **Partial resolution (2026-06-27, dev2).** Groups **(c)** and **(d)** are

--- a/src/codegen/expressions/eval-inline.ts
+++ b/src/codegen/expressions/eval-inline.ts
@@ -25,6 +25,17 @@ import { coerceType, compileExpression, compileStatement } from "../shared.js";
 import { emitUndefined } from "./late-imports.js";
 
 /**
+ * Synthetic file name for the foreign `SourceFile` an inlined `eval("<literal>")`
+ * body is parsed into (see `inlineStaticEval` below). The TypeScript checker has
+ * NO bindings for nodes in this file, so `getSymbolAtLocation` returns
+ * `undefined` for every identifier — symbol-presence cannot be used to classify
+ * resolvability inside an eval body. Consumers that rely on that oracle (e.g.
+ * the unresolvable-`delete` flip in typeof-delete.ts, #2726 group (a)) must
+ * detect and skip eval-body nodes via this sentinel.
+ */
+export const EVAL_SOURCE_FILENAME = "<eval>.ts";
+
+/**
  * Recursively resolve a compile-time-constant string from an expression.
  * Returns the string value, or null if the expression is not a constant.
  */
@@ -84,7 +95,13 @@ export function tryStaticEvalInline(
 
   // Parse the eval source as a Script with parent pointers set so the
   // nested codegen paths (which walk upward via node.parent) work.
-  const sf = ts.createSourceFile("<eval>.ts", src, ts.ScriptTarget.Latest, /* setParentNodes */ true, ts.ScriptKind.JS);
+  const sf = ts.createSourceFile(
+    EVAL_SOURCE_FILENAME,
+    src,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.JS,
+  );
 
   // If the parse produced diagnostics we're looking at malformed eval source.
   // Real JS would throw SyntaxError at runtime — for now, fall through to the

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -10,6 +10,7 @@ import { reportError } from "./context/errors.js";
 import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { isStrictContext } from "./expressions/assignment.js";
+import { EVAL_SOURCE_FILENAME } from "./expressions/eval-inline.js";
 import { ensureLateImport, flushLateImportShifts, shiftLateImportIndices } from "./expressions/late-imports.js";
 import { resolveStructName } from "./expressions/misc.js";
 import { addUnionImports, parseRegExpLiteral, resolveWasmType } from "./index.js";
@@ -245,7 +246,19 @@ export function compileDeleteExpression(
     // through to the resolvable-binding case below. Using symbol-presence — not
     // the weaker `!valueDeclaration` heuristic — is what keeps those three
     // intrinsics out of the `true` bucket (they have a symbol but no value decl).
-    if (ctx.checker.getSymbolAtLocation(ident) === undefined) {
+    //
+    // EXCEPTION — a node inside an inlined `eval("<literal>")` body lives in a
+    // foreign `SourceFile` (EVAL_SOURCE_FILENAME) the checker never bound, so
+    // `getSymbolAtLocation` is `undefined` for EVERY identifier there — including
+    // a name that resolves to an outer binding (`var x = 1; eval('delete x')` ⇒
+    // x is a non-deletable var ⇒ `false`). The symbol oracle is meaningless for
+    // such nodes, so fall through to the existing `false` (the prior behaviour,
+    // correct for the resolvable-outer-binding case `11.4.1-4.a-7.js`). Precise
+    // eval-scope delete resolution is out of scope (eval-substrate lane).
+    if (
+      ctx.checker.getSymbolAtLocation(ident) === undefined &&
+      ident.getSourceFile().fileName !== EVAL_SOURCE_FILENAME
+    ) {
       fctx.body.push({ op: "i32.const", value: 1 });
       return { kind: "i32" };
     }

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -229,7 +229,28 @@ export function compileDeleteExpression(
       emitOuterDelete();
       return { kind: "i32" };
     }
-    // Variables are not deletable — return false
+    // (#2726 group (a)) §13.5.1.2 step 4: `delete IdentifierReference` whose
+    // reference is UNRESOLVABLE (the name resolves to NO binding anywhere — not
+    // a local var/let/const/param/function, nor a real global property)
+    // evaluates to `true` in sloppy mode. Strict mode would already be an early
+    // SyntaxError (`Delete of an unqualified identifier in strict mode`, see
+    // early-errors/node-checks.ts), so this codegen path is reached only in
+    // sloppy code — exactly where step 4 applies.
+    //
+    // Oracle: the TS checker returns NO symbol (`getSymbolAtLocation === undefined`)
+    // for a truly unresolvable identifier. The non-configurable intrinsic globals
+    // that MUST stay `false` (`undefined`, `arguments`, `globalThis`) and every
+    // lib-declared global (`NaN`, `Infinity`, `JSON`, `Object`, …) instead return
+    // a symbol (with or without a `valueDeclaration`), so they correctly fall
+    // through to the resolvable-binding case below. Using symbol-presence — not
+    // the weaker `!valueDeclaration` heuristic — is what keeps those three
+    // intrinsics out of the `true` bucket (they have a symbol but no value decl).
+    if (ctx.checker.getSymbolAtLocation(ident) === undefined) {
+      fctx.body.push({ op: "i32.const", value: 1 });
+      return { kind: "i32" };
+    }
+    // A resolvable binding (var/let/const/param/function/intrinsic global) is
+    // not deletable — return false.
     fctx.body.push({ op: "i32.const", value: 0 });
     return { kind: "i32" };
   }

--- a/tests/issue-2726-sloppy-unresolvable-delete.test.ts
+++ b/tests/issue-2726-sloppy-unresolvable-delete.test.ts
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #2726 group (a) — sloppy-mode `delete <unresolvable identifier>` → true.
+//
+// §13.5.1.2 (Runtime Semantics: Evaluation of `delete UnaryExpression`) step 4:
+// if the reference produced by the operand IsUnresolvableReference (the name
+// resolves to NO binding anywhere), `delete` evaluates to `true` in sloppy mode.
+// (Strict mode makes `delete <bare identifier>` an early SyntaxError, so this
+// path is only ever reached in sloppy code — `isStrictMode` returns false for a
+// plain non-`"use strict"` source, matching test262 `noStrict` scripts.)
+//
+// Previously the compiler returned `false` for EVERY bare-identifier delete
+// (the "variables are not deletable" path), so the three test262 targets
+// (S11.4.1_A2.2_T1, S11.4.1_A3.3_T6, 11.4.1-3-1) failed.
+//
+// Root-cause / oracle: an unresolvable identifier yields NO symbol from the TS
+// checker (`getSymbolAtLocation === undefined`). The non-configurable intrinsic
+// globals that MUST stay `false` (`undefined`, `arguments`, `globalThis`) and
+// all lib-declared globals (`NaN`, `Infinity`, `JSON`, …) DO return a symbol, so
+// they correctly remain `false`. Symbol-presence — not the weaker
+// `!valueDeclaration` heuristic — is what keeps those intrinsics out of `true`.
+
+async function run(source: string): Promise<unknown> {
+  const result = await compile(source);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as { setExports?: (e: Record<string, (...a: unknown[]) => unknown>) => void }).setExports?.(
+    instance.exports as Record<string, (...a: unknown[]) => unknown>,
+  );
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>).test();
+}
+
+async function runStandalone(source: string): Promise<unknown> {
+  const result = await compile(source, { target: "standalone" });
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const { instance } = await WebAssembly.instantiate(result.binary, {});
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>).test();
+}
+
+describe("#2726 (a) sloppy delete of unresolvable identifier", () => {
+  // §13.5.1.2 step 4: a bare identifier that resolves to no binding → true.
+  const unresolvableSrc = `
+    export function test(): number {
+      if ((delete unresolvableXyz) !== true) return 10;
+      return 1;
+    }`;
+
+  it("delete of a never-declared identifier returns true (host)", async () => {
+    expect(await run(unresolvableSrc)).toBe(1);
+  });
+
+  it("delete of a never-declared identifier returns true (standalone)", async () => {
+    expect(await runStandalone(unresolvableSrc)).toBe(1);
+  });
+
+  // Mirrors S11.4.1_A3.3_T6: a typo'd identifier (a similar name IS declared)
+  // is still unresolvable → true.
+  it("delete of a typo'd identifier (similar name declared) returns true", async () => {
+    const src = `
+      export function test(): number {
+        var MyObjectVar = 1;
+        if ((delete MyObjectNotVar) !== true) return 10;
+        return 1;
+      }`;
+    expect(await run(src)).toBe(1);
+  });
+
+  // Hazard guard — these MUST stay false (non-configurable / real bindings):
+  // a naive "unknown ⇒ true" flip would wrongly delete them.
+  it("delete NaN / Infinity / undefined / globalThis stay false (non-configurable globals)", async () => {
+    const src = `
+      export function test(): number {
+        if ((delete NaN) !== false) return 11;
+        if ((delete Infinity) !== false) return 12;
+        if ((delete undefined) !== false) return 13;
+        if ((delete globalThis) !== false) return 14;
+        return 1;
+      }`;
+    expect(await run(src)).toBe(1);
+  });
+
+  it("delete of a declared variable stays false (environment binding)", async () => {
+    const src = `
+      export function test(): number {
+        var declared = 5;
+        if ((delete declared) !== false) return 11;
+        return 1;
+      }`;
+    expect(await run(src)).toBe(1);
+  });
+
+  it("delete of a lib-declared global (JSON / Object) stays false", async () => {
+    const src = `
+      export function test(): number {
+        if ((delete JSON) !== false) return 11;
+        if ((delete Object) !== false) return 12;
+        return 1;
+      }`;
+    expect(await run(src)).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2726 group (a) — sloppy `delete <unresolvable identifier>` → `true`

Split-out residual of #2703. This PR closes **group (a)** of #2726 (the issue stays open at `status: ready` for the remaining structural **group (b)** sloppy global-object model).

### Root cause
The bare-identifier arm of `compileDeleteExpression` (`src/codegen/typeof-delete.ts`) unconditionally emitted `i32.const 0` ("variables are not deletable") for **every** `delete <Identifier>`. Per **§13.5.1.2 step 4**, `delete` of an **UnresolvableReference** (the name resolves to no binding anywhere) evaluates to `true` in sloppy mode. (Strict mode is already an early SyntaxError — `early-errors/node-checks.ts` — so this codegen arm is reached only in sloppy code, exactly where step 4 applies.)

### Fix + the stated hazard oracle
The reliable "real binding vs unresolvable" test is **TS-checker symbol presence**: `ctx.checker.getSymbolAtLocation(ident) === undefined` ⇒ unresolvable ⇒ emit `true`. This is what the issue asked for — it is **stronger than the `!valueDeclaration` heuristic**:
- `undefined` / `arguments` / `globalThis` return a **symbol with no `valueDeclaration`** → stay `false` (non-configurable globals / bindings). ✓
- `NaN` / `Infinity` / `JSON` / `Object` return a **symbol with a value decl** → stay `false`. ✓
- genuinely undeclared names return **no symbol** → `true`. ✓

**Eval guard:** an identifier inside an inlined `eval("<literal>")` body lives in a foreign `SourceFile` the checker never bound, so its symbol is *always* `undefined` even for a name resolving to an outer var. The flip is gated to skip eval-body nodes (`ident.getSourceFile().fileName !== EVAL_SOURCE_FILENAME`, exported from `expressions/eval-inline.ts`), preserving `var x = 1; eval('delete x') === false` (`11.4.1-4.a-7`). Precise eval-scope delete resolution stays out of scope (eval-substrate lane).

### Scoped validation (authoritative `runTest262File`, host/gc lane)
| cluster | baseline → fix |
|---|---|
| `language/expressions/delete` | **59 → 63 pass, 0 regressions** |
| 98 other test262 files containing a bare-identifier `delete` | no change (0 collateral) |

Net **+4** test262. Flipped fail→pass: `S11.4.1_A2.2_T1`, `S11.4.1_A3.3_T6`, `11.4.1-3-1` (group (a)) + bonus `S11.4.1_A3.2_T1` (group (b) implicit-global `x = 1; delete x === true`, carried by the same oracle). Regression test: `tests/issue-2726-sloppy-unresolvable-delete.test.ts` (6/6, host + standalone).

### Files
- `src/codegen/typeof-delete.ts` — unresolvable-reference flip + eval guard
- `src/codegen/expressions/eval-inline.ts` — export `EVAL_SOURCE_FILENAME` sentinel
- `tests/issue-2726-sloppy-unresolvable-delete.test.ts` — regression test
- `plan/issues/2726-…md` — mark (a) done, note remaining (b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS