### PR TITLE
fix(#2816): default CLI output dir to cwd, strip source extension

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,7 +27,10 @@ Every successful compile writes the following alongside the input (or in
 
 ### `-o, --out <dir>`
 
-Output directory. Defaults to the directory of the input file.
+Output directory. Defaults to the current working directory (#2816). Writing
+beside the input was a footgun for inputs that live inside the installed package
+(e.g. an example under `node_modules/@loopdive/js2/examples/...`), which would
+dump artifacts into `node_modules`.
 
 ```bash
 js2wasm src/main.ts -o dist/

--- a/plan/issues/2816-cli-default-output-dir-cwd.md
+++ b/plan/issues/2816-cli-default-output-dir-cwd.md
@@ -1,0 +1,66 @@
+---
+id: 2816
+title: CLI default output dir should be the cwd, not next to the input
+status: done
+sprint: current
+priority: medium
+area: cli
+related: [389]
+completed: 2026-06-29
+assignee: ttraenkler/agent-dev
+---
+
+## Problem
+
+`src/cli.ts` defaulted the output directory to the **input file's directory**
+when `-o`/`--out` was omitted:
+
+```ts
+const name = basename(absInput, ".ts");
+const dir = outDir ? resolve(outDir) : dirname(absInput);
+```
+
+Two footguns followed:
+
+1. **Artifacts dumped into `node_modules`.** The examples ship *inside* the
+   installed package (`node_modules/@loopdive/js2/examples/...`). Compiling one
+   without `-o` wrote `.wasm`/`.wat`/`.d.ts`/`.imports.js`/`.wit` straight into
+   `node_modules` — exactly what the loopdive/js2#389 reporter hit.
+2. **Double extension for non-`.ts` inputs.** `basename(absInput, ".ts")` only
+   strips `.ts`, so a `.js` input yielded `nm_deno.js.wasm`.
+
+## Fix
+
+- Default `dir` to `process.cwd()` (overridable with `-o <dir>`).
+- Strip the full source extension from the output name:
+  `basename(absInput).replace(/\.(ts|mts|cts|js|mjs|cjs)$/i, "")` so
+  `nm_deno.js` → `nm_deno.wasm`.
+- Updated the `-o` help text in `src/cli.ts` and the `-o` section of
+  `docs/cli.md` (default is now the cwd).
+- Removed the now-unused `dirname` import.
+
+## Blast-radius audit
+
+`git grep` of CLI invocations (`cli.ts`/`cli.js`, `js2wasm`,
+`build-standalone-cli`) across `scripts/`, `.github/`, `playground/`,
+`package.json`, `docs/` found **no production callers** that compile without
+`-o` expecting output beside the input. The only affected callers were test
+files. Tests that read emitted artifacts back from the input directory or that
+would otherwise pollute the repo root now pass an explicit `-o <tmpdir>`:
+
+- `tests/issue-1043.test.ts` (2 invocations) — read `dir/input.wat`
+- `tests/issue-1751.test.ts` — read `dir/native-messaging-host.wit`
+- `tests/issue-1590-cli-run-hint.test.ts`
+- `tests/issue-2520-host-import-warning-verbosity.test.ts`
+- `tests/issue-1554-cli-flag-exclusion.test.ts`
+- `tests/issue-2783.test.ts`
+
+(`tests/issue-1950`, `tests/issue-2603`, `tests/issue-2736` already passed `-o`.)
+
+## Verify
+
+- `js2wasm <file>.ts` with no `-o` writes `<name>.wasm` into the cwd.
+- A `node_modules/...` input writes to the cwd, not into `node_modules`.
+- `nm_deno.js` → `nm_deno.wasm` (no double extension).
+- `-o <dir>` still overrides.
+- CLI tests pass.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
 import { createRequire } from "node:module";
 import { readFileSync, writeFileSync } from "node:fs";
-import { basename, dirname, resolve } from "node:path";
+import { basename, resolve } from "node:path";
 
 declare const __JS2WASM_CLI_VERSION__: string | undefined;
 
@@ -38,7 +38,7 @@ if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
 Compile a TypeScript file to WebAssembly (GC proposal).
 
 Options:
-  -o, --out <dir>   Output directory (default: same as input)
+  -o, --out <dir>   Output directory (default: the current working directory)
   --target <t>      Host/output target — the single host axis (#2736):
                       web   (default) WasmGC / JS-host browser surface (DOM
                             ambient globals in scope);
@@ -369,8 +369,14 @@ if (!emulateExplicit && !emulateNode && /['"]node:[A-Za-z0-9_./-]+['"]/.test(sou
   console.error("note: auto-enabled Node API emulation (found a `node:` import). Pass --emulate none to disable.");
 }
 
-const name = basename(absInput, ".ts");
-const dir = outDir ? resolve(outDir) : dirname(absInput);
+// #2816 — strip the source extension (not just `.ts`) so a `.js`/`.mjs`/...
+// input produces `<name>.wasm`, never `<name>.js.wasm`.
+const name = basename(absInput).replace(/\.(ts|mts|cts|js|mjs|cjs)$/i, "");
+// #2816 — default output to the CWD, not the input's directory. The examples
+// ship INSIDE the installed package, so a bare `js2wasm node_modules/.../ex.ts`
+// used to dump artifacts into `node_modules` (loopdive/js2#389). Writing to the
+// CWD keeps output in the user's working tree; `-o <dir>` still overrides.
+const dir = outDir ? resolve(outDir) : process.cwd();
 
 const compileOptions = {
   ...(optimize ? { optimize } : {}),

--- a/tests/issue-1043.test.ts
+++ b/tests/issue-1043.test.ts
@@ -241,7 +241,7 @@ describe("#1043 — process.env.NODE_ENV compile-time substitution + DCE", () =>
         }`,
       );
       execSync(
-        `npx -y tsx ${JSON.stringify(path.resolve("src/cli.ts"))} ${JSON.stringify(inFile)} --define 'process.env.NODE_ENV="production"' --no-dts`,
+        `npx -y tsx ${JSON.stringify(path.resolve("src/cli.ts"))} ${JSON.stringify(inFile)} -o ${JSON.stringify(dir)} --define 'process.env.NODE_ENV="production"' --no-dts`,
         { cwd: process.cwd(), stdio: "pipe" },
       );
       const watFile = path.join(dir, "input.wat");
@@ -269,7 +269,7 @@ describe("#1043 — process.env.NODE_ENV compile-time substitution + DCE", () =>
         }`,
       );
       execSync(
-        `npx -y tsx ${JSON.stringify(path.resolve("src/cli.ts"))} ${JSON.stringify(inFile)} --mode production --no-dts`,
+        `npx -y tsx ${JSON.stringify(path.resolve("src/cli.ts"))} ${JSON.stringify(inFile)} -o ${JSON.stringify(dir)} --mode production --no-dts`,
         {
           cwd: process.cwd(),
           stdio: "pipe",

--- a/tests/issue-1554-cli-flag-exclusion.test.ts
+++ b/tests/issue-1554-cli-flag-exclusion.test.ts
@@ -12,7 +12,7 @@ function runCli(extraArgs: string): { stdout: string; stderr: string; status: nu
   const dir = mkdtempSync(path.join(tmpdir(), "issue-1554-cli-"));
   const inFile = path.join(dir, "input.ts");
   writeFileSync(inFile, `export function test(): number { return 42; }`);
-  const cmd = `npx -y tsx ${JSON.stringify(path.resolve("src/cli.ts"))} ${JSON.stringify(inFile)} --no-dts --quiet ${extraArgs}`;
+  const cmd = `npx -y tsx ${JSON.stringify(path.resolve("src/cli.ts"))} ${JSON.stringify(inFile)} -o ${JSON.stringify(dir)} --no-dts --quiet ${extraArgs}`;
   try {
     const stdout = execSync(cmd, { cwd: process.cwd(), stdio: ["ignore", "pipe", "pipe"] }).toString();
     return { stdout, stderr: "", status: 0 };

--- a/tests/issue-1590-cli-run-hint.test.ts
+++ b/tests/issue-1590-cli-run-hint.test.ts
@@ -13,7 +13,7 @@ function compileAndCapture(extraArgs: string): string {
   const inFile = path.join(dir, "input.ts");
   writeFileSync(inFile, `export function test(): number { return 42; }`);
   return execSync(
-    `npx -y tsx ${JSON.stringify(path.resolve("src/cli.ts"))} ${JSON.stringify(inFile)} --no-dts ${extraArgs}`,
+    `npx -y tsx ${JSON.stringify(path.resolve("src/cli.ts"))} ${JSON.stringify(inFile)} -o ${JSON.stringify(dir)} --no-dts ${extraArgs}`,
     { cwd: process.cwd(), stdio: "pipe" },
   ).toString();
 }

--- a/tests/issue-1751.test.ts
+++ b/tests/issue-1751.test.ts
@@ -69,6 +69,8 @@ describe("#1751 WIT generator complete world surface", () => {
           "tsx",
           path.resolve("src/cli.ts"),
           inFile,
+          "-o",
+          dir,
           "--target",
           "wasi",
           "--wit-package",

--- a/tests/issue-2520-host-import-warning-verbosity.test.ts
+++ b/tests/issue-2520-host-import-warning-verbosity.test.ts
@@ -22,7 +22,7 @@ function compileAndCapture(extraArgs: string): string {
     `export function f(x: any): boolean { return x === Uint8Array || x === Int8Array || x === Float64Array; }`,
   );
   return execSync(
-    `npx -y tsx ${JSON.stringify(path.resolve("src/cli.ts"))} ${JSON.stringify(inFile)} --no-dts --target wasi ${extraArgs} 2>&1`,
+    `npx -y tsx ${JSON.stringify(path.resolve("src/cli.ts"))} ${JSON.stringify(inFile)} -o ${JSON.stringify(dir)} --no-dts --target wasi ${extraArgs} 2>&1`,
     { cwd: process.cwd(), stdio: "pipe" },
   ).toString();
 }

--- a/tests/issue-2783.test.ts
+++ b/tests/issue-2783.test.ts
@@ -110,6 +110,8 @@ describe("#2783 S3 — the removed `--link-node-shims` flag and the `--link` CLI
     const args = [
       path.resolve("src/cli.ts"),
       inFile,
+      "-o",
+      dir,
       "--target",
       "wasi",
       "--no-dts",


### PR DESCRIPTION
## Problem
`src/cli.ts` defaulted the output directory to `dirname(input)` when `-o`/`--out` was omitted. Two footguns:
1. The examples ship **inside** the installed package (`node_modules/@loopdive/js2/examples/...`), so compiling one without `-o` dumped `.wasm`/`.wat`/`.d.ts`/`.imports.js`/`.wit` into `node_modules` — the loopdive/js2#389 reporter hit this.
2. `basename(absInput, ".ts")` only stripped `.ts`, so a `.js` input yielded `nm_deno.js.wasm` (double extension).

## Fix
- Default `dir` to `process.cwd()` (overridable with `-o <dir>`).
- Strip the full source extension: `basename(absInput).replace(/\.(ts|mts|cts|js|mjs|cjs)$/i, "")` so `nm_deno.js` → `nm_deno.wasm`.
- Updated `-o` help text in `src/cli.ts` and the `-o` section of `docs/cli.md`; removed the now-unused `dirname` import.

## Blast-radius audit
`git grep` of CLI invocations across `scripts/`, `.github/`, `playground/`, `package.json`, `docs/` found **no production callers** that compile without `-o` expecting output beside the input. Only test files were affected; those that read artifacts back from the input dir (or would pollute the repo root) now pass an explicit `-o <tmpdir>`: issue-1043 (×2), issue-1751, issue-1590, issue-2520, issue-1554, issue-2783. (issue-1950/2603/2736 already passed `-o`.)

## Verify
- Bare `js2wasm <file>` writes `<name>.wasm` into the cwd; a `node_modules/...` input writes to the cwd, not into `node_modules`; `nm_deno.js` → `nm_deno.wasm`; `-o <dir>` still overrides. Confirmed manually + the modified CLI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)