### PR TITLE
fix(#2821): harden deno-stdio test EPIPE flake via stdin file fd

### DIFF
--- a/plan/issues/2821-harden-deno-stdio-epipe-flake.md
+++ b/plan/issues/2821-harden-deno-stdio-epipe-flake.md
@@ -1,0 +1,50 @@
+---
+id: 2821
+title: "Harden the flaky EPIPE in tests/issue-2684-deno-stdio.test.ts"
+status: done
+sprint: current
+priority: medium
+area: tests
+task_type: test
+related: [389, 2684]
+completed: 2026-06-29
+---
+
+# Harden the flaky EPIPE in `tests/issue-2684-deno-stdio.test.ts`
+
+## Problem
+
+`tests/issue-2684-deno-stdio.test.ts` drives a `--target wasi` Deno
+Native-Messaging host through real `wasmtime` via `execFileSync`, streaming the
+framed input over `{ input }` (a parent-owned stdin pipe). It intermittently
+fails with `EPIPE` on the write to wasmtime's stdin, more often under box load.
+
+This is a **test-harness flake, not a host/compiler bug.** The host
+round-trips deterministically — it passed 20× back-to-back under load on
+wasmtime v44 and v46. The `EPIPE` is the vitest/`execFileSync` harness racing
+wasmtime's stdin pipe: a pure-WASI command that hits EOF (`readSync` → `null`)
+or finishes echoing can close fd 0 *before* the parent finishes writing the
+input frame, so the parent's write end breaks (`EPIPE`). Box load widens the
+race window.
+
+## Fix
+
+Test-infra robustness only — no host or codegen change.
+
+Feed wasmtime's stdin from a **regular file** (written to the temp dir, opened
+read-only, handed to the child as fd 0 via `stdio: [inFd, "pipe", "inherit"]`)
+instead of streaming `input` over a parent-owned pipe. A file fd has no
+parent-side write end, so there is no pipe to break — EOF is the natural end of
+the file and the race is eliminated. `execFileSync` is synchronous, so the
+wasmtime invocations remain serialized (one spawn at a time, never
+oversubscribed).
+
+Assertion semantics are unchanged: the same byte-exact round-trip checks run
+against the real wasmtime execution; only the stdin plumbing changed.
+
+## Verification
+
+- `npm test -- tests/issue-2684-deno-stdio.test.ts` run repeatedly (10×, and
+  under background load) passes every time with no `EPIPE`.
+- The test still exercises the real wasmtime round-trip (it is not weakened into
+  a no-op).

--- a/tests/issue-2684-deno-stdio.test.ts
+++ b/tests/issue-2684-deno-stdio.test.ts
@@ -15,7 +15,7 @@
 // boxed-number externref or `ref.null extern`) — `=== null` works in the
 // standalone module with NO JS host import.
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { closeSync, mkdtempSync, openSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -143,10 +143,29 @@ export function main(): void { writeSync(1, "hi\\n"); }
       if (tmp) rmSync(tmp, { recursive: true, force: true });
     });
 
+    // #2821: feed wasmtime's stdin from a regular file (opened read-only and
+    // handed to the child as fd 0) instead of streaming the input over a parent-
+    // owned pipe. Piping `input` to the child races wasmtime's stdin close — a
+    // pure-WASI command that hits EOF (readSync→null) or finishes echoing can
+    // close fd 0 before the parent finishes writing the frame, surfacing as a
+    // flaky EPIPE on the write end (aggravated by box load). A file fd has no
+    // parent-side write end, so there is no pipe to break: EOF is the natural
+    // end of file. Invocations are also serialized (execFileSync is synchronous,
+    // one wasmtime spawn at a time) so concurrent runs never oversubscribe.
     function run(binary: Uint8Array, name: string, input: Buffer): Buffer {
       const p = join(tmp, `${name}.wasm`);
       writeFileSync(p, binary);
-      return execFileSync(wasmtimeBin!, [...WASMTIME_FLAGS, p], { input, maxBuffer: 8 * 1024 * 1024 });
+      const inPath = join(tmp, `${name}.in`);
+      writeFileSync(inPath, input);
+      const inFd = openSync(inPath, "r");
+      try {
+        return execFileSync(wasmtimeBin!, [...WASMTIME_FLAGS, p], {
+          stdio: [inFd, "pipe", "inherit"],
+          maxBuffer: 8 * 1024 * 1024,
+        });
+      } finally {
+        closeSync(inFd);
+      }
     }
 
     it("framed echo round-trips a message byte-for-byte (incl. high/null bytes)", async () => {


### PR DESCRIPTION
## Problem

`tests/issue-2684-deno-stdio.test.ts` drives a `--target wasi` Deno NM host through real wasmtime via `execFileSync`, streaming the framed input over a parent-owned stdin pipe (`{ input }`). It intermittently fails with `EPIPE` on the write to wasmtime's stdin, more often under box load.

This is a **test-harness flake, not a host/compiler bug**. The host round-trips deterministically (passed 20x back-to-back under load on wasmtime v44 and v46). The `EPIPE` is the vitest/`execFileSync` harness racing wasmtime's stdin pipe: a pure-WASI command that hits EOF (`readSync`→`null`) or finishes echoing can close fd 0 *before* the parent finishes writing the input frame, breaking the parent's write end.

## Fix (test-infra only — no host/codegen change)

Feed wasmtime's stdin from a **regular file** (written to the temp dir, opened read-only, handed to the child as fd 0 via `stdio: [inFd, "pipe", "inherit"]`) instead of streaming `input` over a parent-owned pipe. A file fd has no parent-side write end, so there is no pipe to break — EOF is the natural end of file. `execFileSync` stays synchronous, so wasmtime invocations remain serialized (one spawn at a time).

Assertion semantics are unchanged: the same byte-exact round-trip checks run against the real wasmtime execution; only the stdin plumbing changed. The test still exercises the real round-trip (not weakened to a no-op).

## Verification

- `npm test -- tests/issue-2684-deno-stdio.test.ts` run 15x (12 clean + 3 under CPU background load) — all 6 tests pass every time, no `EPIPE`.

Closes #2821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)