### PR TITLE
docs(#2818): architect specs — carve #2826 (CPS-capture) + #2825 (class-method captured-globals)

### DIFF
--- a/plan/issues/2821-block-let-immutably-captured-by-async-gen-cps-leading-param-slot.md
+++ b/plan/issues/2821-block-let-immutably-captured-by-async-gen-cps-leading-param-slot.md
@@ -1,0 +1,262 @@
+---
+id: 2821
+title: "Bug C (CPS-capture half): block-scoped let immutably captured by a hoisted async/generator declaration reads the stale pre-hoisted slot"
+parent: 2818
+related: [2820, 2818, 2811, 2669]
+status: ready
+created: 2026-06-29
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen
+es_edition: 2017
+language_feature: closures
+goal: spec-completeness
+sprint: current
+horizon: m
+architect_spec: done
+---
+
+# #2821 — Bug C (CPS-capture half): block-`let` immutably captured by a hoisted async/generator declaration
+
+Carved from #2818 (parent) and #2820 (the plain-function half of Bug C, fixed
+there). This is the **async / generator capturer** residual of the
+`ary-ptrn-rest-obj-prop-id` block-`let`-capture cluster — the half #2820's
+producer-side slot-reuse gate *deliberately excludes* (the gate fires only when
+the block-`let` is captured by ≥1 plain function and **zero** CPS-lowered
+async/generator functions, because the broad reuse regressed 43
+`for-await-of/async-{func,gen}-decl-dstr-*` tests, net −14).
+
+It is a **distinct** bug from #2825 (the class-method captured-globals half):
+this one is in the **leading-capture-param** channel, #2825 is in the
+**captured-globals** channel.
+
+## Reproduction (verified on current main, host/gc lane)
+
+```ts
+// async capturer
+export async function t5(): Promise<number> {
+  { let s = 42; async function f(): Promise<number> { return s; } return await f(); }
+}
+// => 0   (should be 42)
+
+// generator capturer
+export function t6(): number {
+  { let s = 42; function* g(): Generator<number> { yield s; } return g().next().value; }
+}
+// => 0   (should be 42)
+```
+
+Controls that **PASS** (function-scope `let`, not in a block):
+
+```ts
+export async function t4(): Promise<number> {
+  let s = 42; async function f(): Promise<number> { return s; } return await f();
+}                                                            // => 42 ✓
+export function t7(): number {
+  let s = 42; function* g(): Generator<number> { yield s; } return g().next().value;
+}                                                            // => 42 ✓
+```
+
+The block-nested capturer reads `0` — the numeric zero-init of an **un-written
+pre-hoisted slot** — not the captured `42`. (Empirically reproduced via
+`compileAndInstantiate` on `369f37442cd`.)
+
+## Root cause (verified)
+
+A nested function declaration that captures outer locals is lowered with the
+captures as **leading parameters** (`compileNestedFunctionDeclaration`,
+`src/codegen/statements/nested-declarations.ts:617-783`). The capture metadata is
+recorded in `ctx.nestedFuncCaptures` at the point the nested fn is
+**hoist-compiled** (`nested-declarations.ts:773-783`), pinning each capture to
+the outer-frame slot it sees *then* via `outerLocalIdx`
+(`src/codegen/context/types.ts:1254`).
+
+The construction/call site reads the capture value out of that pinned slot. For
+an **immutable** capture this is a bare `local.get cap.outerLocalIdx`
+(`src/codegen/expressions/calls.ts:12941`; the parallel mutable paths are at
+12892 / 12912). The `localMap.get(name) ?? cap.outerLocalIdx` re-resolve was
+tried in #1177 and **reverted** (100+ regressions where main's wrong-slot null
+was load-bearing) — so the immutable path is hard-pinned to `outerLocalIdx`.
+
+Now the duplicate-slot mechanism (the Bug C core, see #2820):
+
+1. `walkStmtForLetConst` (`src/codegen/index.ts:14626`) pre-allocates a slot for
+   every block-`let`/`const` at **function entry** (the *pre-hoisted slot A*),
+   recorded in `fctx.preHoistedLetConstSlots` (added by #2820).
+2. A function declaration nested in a block is **hoisted to the top of that
+   block** and compiled before `let s` runs, so its `nestedFuncCaptures` entry
+   records `outerLocalIdx = A`.
+3. On **block entry** `saveBlockScopedShadows` removes the block-`let` from
+   `localMap`/`tdzFlagLocals`. When `let s = 42` finally executes,
+   `compileVariableStatement` (`src/codegen/statements/variables.ts`) sees
+   `!localMap.has(name)` and — because **#2820's reuse gate is skipped for CPS
+   capturers** (`variables.ts` ~837, the `cpsCaptured && !capturedByPlainFn`
+   branch does nothing) — falls through `freshLocalForLetConst` and
+   `allocLocal`s a **fresh slot B**, storing `42` into **B**.
+4. The capture is still pinned to **A** (never written) → the construction reads
+   `A = 0`, not `B = 42`.
+
+For a **plain** function #2820 collapses A and B (reuse), so `outerLocalIdx = A =
+B` and the read is correct. For a **CPS** function the collapse perturbs the
+`for-await-of` continuation state machine (43 regressions), so #2820 skips it —
+leaving the immutable CPS capture pinned to the stale A. **That is this bug.**
+
+Why only *immutable* captures: a **mutable** CPS capture is boxed into a ref
+cell at the call site (`calls.ts:12904-12928`), and that boxed cell already
+threads the value correctly (per #2820's gate comment) — and is exactly the path
+the broad reuse *broke*. So the fix must touch **only** the immutable,
+unboxed CPS capture, never the mutable boxed one.
+
+## Implementation Plan
+
+### Design 1A — producer-side capture re-point (preferred)
+
+Symmetric with #2820 (producer-side, in `variables.ts`), but **without** the
+slot collapse that perturbs the CPS state machine. Instead of reusing A, keep
+both slots (B stays the real storage, A stays a dead pre-hoist slot) and
+**re-point the already-recorded capture metadata from A to B**.
+
+**File: `src/codegen/statements/variables.ts`** — in the block immediately after
+the existing #2820 reuse gate (~line 837), and after the fresh `localIdx` (slot
+B) for the block-`let` is allocated + the initializer stored:
+
+- Compute `preHoisted = fctx.preHoistedLetConstSlots?.get(decl)` (already in
+  scope from the #2820 gate) — its `valueSlot` is the stale slot **A**.
+- Guard: run **only** when the block-`let` was *not* reused (i.e. the
+  `freshLocalForLetConst` path produced a distinct `localIdx` **B** with
+  `B !== A`), i.e. the CPS-excluded branch — this is the exact inverse of
+  #2820's `capturedByPlainFn && !cpsCaptured` gate, so the two compose with no
+  overlap.
+- Iterate `ctx.nestedFuncCaptures`. For every capturer `capName` and capture
+  entry `cap` where:
+  - `cap.name === name`, **and**
+  - `cap.mutable !== true` (immutable / unboxed only — never touch boxed
+    mutable captures: that is the 43-regression class), **and**
+  - `cap.outerLocalIdx === preHoisted.valueSlot` (still pinned to the stale A),
+  - re-point `cap.outerLocalIdx = localIdx` (B), and if a TDZ flag was
+    re-allocated for this decl (the `freshLocalForLetConst` re-alloc at
+    `variables.ts:~1607`-region), also re-point `cap.outerTdzFlagIdx` from the
+    pre-hoist flag slot to the new `fctx.tdzFlagLocals.get(name)`.
+
+Because the re-point mutates the **single source of truth**
+(`nestedFuncCaptures[*].outerLocalIdx`), **all** downstream construction sites
+that read it (`calls.ts:12941` immutable, plus the lazy
+`emitFuncRefAsClosure` / closure-builder reads near `calls.ts:15414-15531`)
+automatically resolve to **B** — no edit needed at the read sites.
+
+Producer slot **count/layout is unchanged** (A is left allocated, just dead), so
+the `for-await-of` continuation state-struct snapshot is byte-identical to
+baseline for the regression cluster → no perturbation.
+
+### Ordering guarantee
+
+The re-point is valid because:
+- The capture entry already exists when `let s` runs (the nested fn is
+  block-hoisted → compiled before the `let`). The `cap.outerLocalIdx === A`
+  guard makes the re-point a no-op if the entry does not yet exist or already
+  points at B.
+- A **non-hoisted** capturer (async arrow / async fn-expr assigned *after* the
+  `let`) records its capture with `localMap` already at B → guard fails → no
+  re-point needed (already correct).
+
+### Design 1B — construction-site narrowed re-resolve (fallback only)
+
+If 1A proves insufficient for some shape, the alternative is to re-resolve the
+immutable capture by name at `calls.ts:12941` (`fctx.localMap.get(cap.name) ??
+cap.outerLocalIdx`) **gated narrowly** on: capturer is async/generator
+(`ctx.asyncFunctions`/`ctx.generatorFunctions`), the name is a pre-hoisted
+block-`let`/`const`, and `localMap.get(name) !== cap.outerLocalIdx`. This is the
+*minefield* #1177 hit with the blanket version (the async-null-deref tests rely
+on the wrong slot) — prefer 1A; only fall back here with full merge_group
+validation. **Do not** ship the un-gated `?? outerLocalIdx` form.
+
+### Edge cases
+
+- **Immutable vs mutable**: re-point immutable only. Mutable boxed captures are
+  the #2820-gate's "already threads correctly" path and the 43-regression class
+  — leave them untouched. (`length` in the dstr cluster is immutable; the loop
+  counters `iterCount`/`nextCount` are mutable.)
+- **TDZ interaction**: a block-`let` read before init must still throw. The
+  call-site TDZ check (`calls.ts:12840-12848`, `analyzeTdzAccessByPos`) keys on
+  `fctx.tdzFlagLocals.get(cap.name)`; re-point `outerTdzFlagIdx` in lockstep so
+  the flag the callee tests is the live one (B's), not the dead pre-hoist flag.
+  The construction in the repro is textually after `let s`, so the analysis is
+  "skip" — but a transitive call through a closure that captured the flag must
+  still observe the live flag.
+- **Nested destructuring patterns** (`let [...{ length: z }]`): the *outer*
+  immutable capture is the plain identifier `length`/`s`, not the pattern
+  binding `z`. Pattern bindings are not pre-allocated by `walkStmtForLetConst`
+  (`index.ts:14732`) so they carry no pre-hoist slot — the guard
+  (`outerLocalIdx === preHoisted.valueSlot`) naturally excludes them.
+- **#2820 boundary (must compose, no overlap)**: #2820 fires iff
+  `capturedByPlainFn && !cpsCaptured`; this fix fires on the complementary CPS
+  branch. A block-`let` captured by **both** a plain fn and a CPS fn: #2820's
+  gate already declines reuse (because `cpsCaptured`), so slot B is fresh; this
+  fix then re-points the CPS capture's `outerLocalIdx` to B, and the plain
+  capturer — also reading via `nestedFuncCaptures` against the same producer
+  frame — likewise benefits from the re-point. Confirm the mixed case in a test.
+- **generators vs async**: both are CPS-lowered; gate on
+  `ctx.asyncFunctions.has(capName) || ctx.generatorFunctions.has(capName)` if a
+  capturer-kind gate is wanted, but Design 1A's `mutable !== true` + slot-guard
+  already restricts to the right entries without an explicit kind check.
+
+### Scoped repro / acceptance
+
+Add `tests/issue-2821.test.ts`:
+
+- `t5` (block async), `t6` (block generator) above return **42** (and a string
+  variant returns the captured string).
+- Controls `t4`/`t7` (fn-scope) still return 42.
+- Mixed plain+CPS capturer of the same block-`let` returns the captured value
+  from both.
+- A block-`let` read-before-init inside the CPS body still throws
+  ReferenceError (TDZ regression control).
+
+### test262 paths this unblocks (conformance target)
+
+Async / generator analogs of the `ary-ptrn-rest-obj-prop-id` cluster where an
+outer `let` is **immutably read** inside the CPS body, e.g.:
+
+- `language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-obj-prop-id.js`
+  (asserts `length === "outer"` — the outer immutable `let length` read inside
+  the `async function *fn()` body).
+- `language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-obj-prop-id.js`
+  and the `const` / `async`-prefixed siblings in the same directory.
+
+### Full-merge_group regression guard (REQUIRED)
+
+These pass/fail flips **only manifest on the merged baseline** — they are the
+exact 43-test `for-await-of/async-{func,gen}-decl-dstr-*` class #2820 had to
+exclude. **Validate on the full `merge_group` / full CI, never a scoped sweep.**
+Specifically confirm **zero** regressions in:
+
+- `for-await-of/async-func-decl-dstr-*` (e.g. `array-rest-after-element` —
+  `[x, ...y]`-style mutable loop-var captures), and
+- `for-await-of/async-gen-decl-dstr-*` (the `iterCount`/`nextCount`/`iterator`
+  loop-state-var class),
+
+i.e. the mutable boxed-capture path must stay byte-identical. (See #2820's gate
+comment for the precise regression signature.)
+
+## Dependencies
+
+- **Depends on #2820** (PR #2293) being merged: this fix reuses
+  `fctx.preHoistedLetConstSlots` and the `cpsCaptured` detection introduced
+  there, and lives directly beside that gate in `variables.ts`. Branch should be
+  taken **after** #2293 lands (or predecessor-stacked on it).
+- **In-lane** (closures / nested-fn lowering / `nestedFuncCaptures`); no
+  dependency on the parallel substrate work ($Object dynamic reader /
+  any-receiver dispatch / `calls.ts` host-dispatch / acorn / NM). The only
+  `calls.ts` touch is the *fallback* Design 1B; Design 1A leaves `calls.ts`
+  untouched.
+
+## Acceptance criteria
+
+- `t5`/`t6` (and string variants) return the captured value; `t4`/`t7` controls
+  unchanged.
+- The immutable-`let`-read async/generator `dstr-*` cluster members return pass.
+- **Zero** regressions in the 43-test `for-await-of/async-{func,gen}-decl-dstr-*`
+  mutable-capture class on full merge_group.
+- TDZ throws for pre-init reads through a CPS capture preserved.

--- a/plan/issues/2825-block-nested-class-method-capture-deferred-compile-ordering.md
+++ b/plan/issues/2825-block-nested-class-method-capture-deferred-compile-ordering.md
@@ -2,7 +2,7 @@
 id: 2825
 title: "Bug C (class-method half, spec'd): block-nested class compiled eagerly, so captured-globals promotion never fires for an outer block-let"
 parent: 2818
-related: [2820, 2818, 2811, 2669, 1672]
+related: [2820, 2818, 2826, 2811, 2669, 1672]
 status: ready
 created: 2026-06-29
 priority: high
@@ -23,11 +23,11 @@ architect_spec: done
 The actionable, spec'd carve of **#2818** (the class-method context of the
 `ary-ptrn-rest-obj-prop-id` block-`let`-capture cluster — the `meth-…` /
 `gen-meth-…` / `private-meth-…` members and their `-dflt` / `-static`
-variants). Sibling carve: **#2821** (the async/generator CPS-capture half).
+variants). Sibling carve: **#2826** (the async/generator CPS-capture half).
 Implements #2818's "Direction (for the architect)"; #2818 stays the parent
 bucket.
 
-This is a **distinct subsystem** from #2820 / #2821: class methods do not take
+This is a **distinct subsystem** from #2820 / #2826: class methods do not take
 lifted leading capture params — they capture an outer local by **promotion to a
 `__captured_<name>` global** (`promoteAccessorCapturesToGlobals`). The bug is a
 **class-body-compile ordering** defect that makes that promotion never run for a
@@ -240,7 +240,7 @@ ordering changes). Watch specifically for:
 
 - **In-lane** (class-collection ordering + captured-globals promotion;
   `declarations.ts` / `nested-declarations.ts` / `closures.ts`). **No** overlap
-  with #2820 / #2821 (those touch `variables.ts` slot reuse and
+  with #2820 / #2826 (those touch `variables.ts` slot reuse and
   `nestedFuncCaptures` leading-param capture — disjoint files/mechanism), so this
   composes cleanly with both.
 - No dependency on the parallel substrate work ($Object dynamic reader /

--- a/plan/issues/2825-block-nested-class-method-capture-deferred-compile-ordering.md
+++ b/plan/issues/2825-block-nested-class-method-capture-deferred-compile-ordering.md
@@ -1,0 +1,257 @@
+---
+id: 2825
+title: "Bug C (class-method half, spec'd): block-nested class compiled eagerly, so captured-globals promotion never fires for an outer block-let"
+parent: 2818
+related: [2820, 2818, 2811, 2669, 1672]
+status: ready
+created: 2026-06-29
+priority: high
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen
+es_edition: 2015
+language_feature: closures
+goal: spec-completeness
+sprint: current
+horizon: m
+architect_spec: done
+---
+
+# #2825 — Bug C (class-method half): block-nested class compiled eagerly → captured-globals promotion skipped
+
+The actionable, spec'd carve of **#2818** (the class-method context of the
+`ary-ptrn-rest-obj-prop-id` block-`let`-capture cluster — the `meth-…` /
+`gen-meth-…` / `private-meth-…` members and their `-dflt` / `-static`
+variants). Sibling carve: **#2821** (the async/generator CPS-capture half).
+Implements #2818's "Direction (for the architect)"; #2818 stays the parent
+bucket.
+
+This is a **distinct subsystem** from #2820 / #2821: class methods do not take
+lifted leading capture params — they capture an outer local by **promotion to a
+`__captured_<name>` global** (`promoteAccessorCapturesToGlobals`). The bug is a
+**class-body-compile ordering** defect that makes that promotion never run for a
+block-nested class.
+
+## Reproduction (verified on current main, host/gc lane)
+
+```ts
+export function test(): number {
+  { let s = 42; class C { m(): number { return s; } } return new C().m(); }
+}
+// => 0   (should be 42)
+
+// arrow inside the method — the method's capture channel never fires at all
+export function t3(): number {
+  { let s = 42; class C { m(): number { const g = () => s; return g(); } } return new C().m(); }
+}
+// => 0   (should be 42)
+```
+
+Control that **PASSES** (same class at **function scope**, not in a block):
+
+```ts
+export function t2(): number {
+  let s = 42; class C { m(): number { return s; } } return new C().m();
+}                                                       // => 42 ✓
+```
+
+(Empirically reproduced via `compileAndInstantiate` on `369f37442cd`: block
+variants return `0`, the fn-scope control returns `42`.)
+
+## Root cause (verified)
+
+Class **bodies** are compiled in a pre-pass, `compileClassesFromStatements`
+(`src/codegen/declarations.ts:4169`). A class declaration is handled at
+`declarations.ts:4181-4193`:
+
+```ts
+if (ts.isClassDeclaration(stmt) && stmt.name && !isAmbient) {
+  if (insideFunction) {
+    ctx.deferredClassBodies.add(stmt.name.text);   // defer → compiled in compileNestedClassDeclaration
+  } else {
+    compileClassBodies(ctx, stmt, funcByName);     // eager
+  }
+}
+```
+
+The function-body recursion **passes `insideFunction = true`**
+(`declarations.ts:4214`). **But the nested-scope recursions drop it** — the block
+recursion at `declarations.ts:4222-4223`:
+
+```ts
+} else if (ts.isBlock(stmt)) {
+  compileClassesFromStatements(stmt.statements);   // ← second arg omitted → insideFunction defaults to FALSE
+}
+```
+
+and likewise the `if` / `for` / `while` / `switch` / `try` / labeled recursions
+(`declarations.ts:4215-4251`). So a class nested in a **block inside a function**
+is treated as **NOT** `insideFunction` → its body is compiled **eagerly** in the
+pre-pass, at module-compile time, **before** the enclosing function `$test` runs
+and before block-`let s` is a promotable local.
+
+Consequences (WAT-confirmed in #2818):
+
+1. The eager body compile resolves `s` against an empty `localMap` → falls to the
+   `ref.null.extern` graceful default (`src/codegen/expressions/identifiers.ts`),
+   so `$C_m` compiles to `ref.null extern; return` (→ `0` numeric / `null`).
+2. `promoteAccessorCapturesToGlobals` (`src/codegen/closures.ts:345`) never runs
+   in a context where `s` is a local, so **no** `__captured_s` global and **no**
+   `local.get s; global.set __captured_s` sync is emitted in `$test`.
+3. When `$test` is later compiled and `compileStatement` reaches `class C`,
+   `compileNestedClassDeclaration` (`nested-declarations.ts:82`) **early-returns**
+   at lines 99-106 because `structMap.has("C") && !isDeferred` (C was collected
+   *and* eagerly compiled, and never added to `deferredClassBodies`), so the
+   promotion loop (`nested-declarations.ts:125-138`) + `compileClassBodies`
+   (line 147) at the textual, in-scope position are skipped.
+
+The fn-scope control passes because the class is a **direct** function-body
+statement → reached with `insideFunction = true` → **deferred** → promotion runs
+at the textual position, after `let s`, with `s` in `localMap`.
+
+Note the COLLECTION pass `collectClassesFromStatements`
+(`declarations.ts:2986`) recurses into blocks too (line 3024) and *does* register
+the struct + method stubs up-front — that part is correct and must stay; only
+the **body-compile timing** is wrong.
+
+## Implementation Plan
+
+### Fix — defer block-nested class bodies (propagate `insideFunction`)
+
+Treat a class nested in any control-flow scope **inside a function** exactly like
+a direct function-body class: defer it to `compileNestedClassDeclaration`, which
+runs at the textual position (after `let s`) where promotion can see the local.
+
+**File: `src/codegen/declarations.ts`**, function `compileClassesFromStatements`
+(line 4169): propagate the current `insideFunction` value through every
+nested-scope recursion that currently drops it:
+
+- `ts.isBlock` (line 4223): `compileClassesFromStatements(stmt.statements, insideFunction)`
+- `if` then/else (lines 4217, 4220)
+- `for` / `for-in` / `for-of` / `while` / `do` body block (line 4233)
+- `switch` clause statements (line 4237)
+- `try` / `catch` / `finally` blocks (lines 4240, 4242, 4245)
+- labeled-statement block (line 4249)
+
+Each must forward the **current** `insideFunction` (not a hardcoded `true`): a
+**top-level** (module) block must stay `insideFunction = false` so its class is
+still compiled eagerly (no enclosing fctx exists to defer into). The
+function-decl recursion at line 4214 and the arrow/fn-expr recursions in
+`compileClassesFromFunctionBody` (lines 4258-4269) already pass `true` — leave
+them.
+
+With this, a block-nested-in-function class is added to `deferredClassBodies`;
+`compileNestedClassDeclaration` then takes the `isDeferred === true` path (skips
+the 99-106 early-return), runs the promotion loop (125-138) with `s` live in
+`localMap` → emits `__captured_s` + the `local.get s; global.set` sync in
+`$test`, and `compileClassBodies` (147) compiles `$C_m` to read
+`global.get __captured_s`. Method, and any arrow inside it, both resolve `s`.
+
+### Why this is the right lever (vs. patching the early-return)
+
+The alternative (#2818 candidate 2: run `promoteAccessorCapturesToGlobals` on
+the `structMap.has` early-return path) would have to **re-compile** an already-
+emitted `ref.null` method body — messy and duplicative. Deferral reuses the
+**existing, proven** mechanism that already makes direct-function-body classes
+work; it changes *when* the body is compiled, not *how*.
+
+### Edge cases
+
+- **Reachability of the deferred body**: deferral compiles the body only when
+  `compileStatement` reaches the class declaration during function compilation.
+  `compileStatement` visits **every** statement of every block (it does not skip
+  on runtime conditions — both `if` arms, loop bodies, etc. are compiled), and
+  direct-function-body classes already rely on this guarantee, so the
+  reachability profile is identical. **Risk to verify**: a block-nested class
+  whose enclosing function is itself *never compiled* (dead/uncalled nested fn)
+  was eagerly compiled before and would now be deferred-and-unreached → its
+  method stub (created in the collection pass) would have no body. Confirm such
+  shapes either still get compiled or are harmless (validate full CI; if a gap
+  appears, add a post-pass sweep that `compileClassBodies` any name left in
+  `deferredClassBodies`).
+- **`-dflt`** (param-default initializers referencing the outer local, e.g.
+  `m(x = s) {}`): already covered — the promotion loop scans `member.parameters`
+  initializers via the `paramInits` `extraNodes` arg
+  (`nested-declarations.ts:127-136`, `closures.ts:359-365`).
+- **`-static` / generator / async-generator / private methods**: the promotion
+  loop currently handles `MethodDeclaration` / `Constructor` / get/set accessors
+  (`nested-declarations.ts:125-137`). Verify static + private + `*`/`async *`
+  method members are included (they are `MethodDeclaration` nodes; private uses a
+  `PrivateIdentifier` name but is still a method). Extend the member filter if a
+  generator/async-generator/static/private member is missed.
+- **Mutable vs immutable capture / #1672 stale-global-sync**: if the method
+  observes a *later* write to `s`, the promoted global must be re-synced. This is
+  the #1672 stale-`__captured_<name>` hazard. With deferral the initial
+  `local.get s; global.set` is emitted **after** `let s`'s store (correct
+  initial value); for subsequent mutation, follow the existing
+  `wasCapturedGlobalBefore` re-sync pattern in
+  `variables.ts` (the `(#1672)` block) so writes to `s` after the class
+  declaration also update the global.
+- **TDZ**: a `let`/`const` read before init promotes its `__tdz_<name>` flag to a
+  global too (`closures.ts:426-448`). Because deferral runs promotion *after*
+  `let s` initialised, the common case is "already initialised"; preserve the TDZ
+  flag promotion for the read-before-init shape (block-nested class whose method
+  is invoked while `s` is still in TDZ).
+- **Same-named classes in sibling blocks** (`{ class C {} } { class C {} }`):
+  `structMap` / `deferredClassBodies` are name-keyed, so the second `C`'s deferral
+  is consumed by the first's `delete` — a **pre-existing** name-collision
+  limitation, not introduced here; note it but it is out of scope.
+- **Module-top-level block** (`{ let s; class C { m(){return s;} } }` at module
+  scope): stays `insideFunction = false` → eager, unchanged by this fix. The
+  block-`let` is a module global there, a different channel; track separately if
+  the cluster needs it (the test262 cluster wraps in functions, so this fix
+  covers it).
+
+### Scoped repro / acceptance
+
+Add `tests/issue-2825.test.ts`:
+
+- `test` and `t3` (arrow-in-method) above return **42** (and a string variant
+  returns the captured string).
+- Control `t2` (fn-scope class) still returns 42.
+- `-static`, generator-method, and private-method variants of the block-nested
+  capture return the captured value.
+- A `-dflt` variant (`m(x = s) { return x; }`) returns 42.
+- fn-scope accessor-capture regression control (#1672) unchanged.
+
+### test262 paths this unblocks (conformance target)
+
+The class-method members of the `ary-ptrn-rest-obj-prop-id` cluster (and the
+broader block-nested-class-method-capture class), e.g. the `meth-…` /
+`gen-meth-…` / `private-meth-…` (+ `-dflt` / `-static`) dstr members where the
+method reads an outer block-scoped `let`. (The cluster is dominated by these
+members per #2818.)
+
+### Full-merge_group regression guard (REQUIRED)
+
+Changing class-body-compile *timing* is broad-impact. **Validate on full CI /
+`merge_group`, not a scoped sweep** (per project policy for broad-impact codegen
+ordering changes). Watch specifically for:
+
+- fn-scope class-method / accessor capture (#1672) — must stay green,
+- any class nested in a loop / `if` / `try` whose body previously compiled
+  eagerly (now deferred) — confirm no `class-body` / missing-method regressions,
+- the standalone floor (object-identity / native-equality) is unaffected (this
+  is purely a host/gc class-body ordering change), but confirm on merge_group
+  since the floor only runs there.
+
+## Dependencies
+
+- **In-lane** (class-collection ordering + captured-globals promotion;
+  `declarations.ts` / `nested-declarations.ts` / `closures.ts`). **No** overlap
+  with #2820 / #2821 (those touch `variables.ts` slot reuse and
+  `nestedFuncCaptures` leading-param capture — disjoint files/mechanism), so this
+  composes cleanly with both.
+- No dependency on the parallel substrate work ($Object dynamic reader /
+  any-receiver dispatch / host-`calls.ts` / acorn / NM). Captured-globals
+  promotion is a closures/codegen-ordering concern.
+
+## Acceptance criteria
+
+- `{ let s=42; class C { m(){ return s; } } new C().m(); }` returns 42 (string +
+  numeric), and the arrow-inside-method variant too.
+- `meth-…` / `gen-meth-…` / `private-meth-…` (+ `-dflt` / `-static`) cluster
+  members return pass.
+- No regression in fn-scope class-method/accessor capture (#1672), the #2820
+  function-declaration fix, or TDZ throws — on full merge_group.

--- a/plan/issues/2826-block-let-immutably-captured-by-async-gen-cps-leading-param-slot.md
+++ b/plan/issues/2826-block-let-immutably-captured-by-async-gen-cps-leading-param-slot.md
@@ -1,8 +1,8 @@
 ---
-id: 2821
+id: 2826
 title: "Bug C (CPS-capture half): block-scoped let immutably captured by a hoisted async/generator declaration reads the stale pre-hoisted slot"
 parent: 2818
-related: [2820, 2818, 2811, 2669]
+related: [2820, 2818, 2825, 2811, 2669]
 status: ready
 created: 2026-06-29
 priority: high
@@ -18,7 +18,7 @@ horizon: m
 architect_spec: done
 ---
 
-# #2821 — Bug C (CPS-capture half): block-`let` immutably captured by a hoisted async/generator declaration
+# #2826 — Bug C (CPS-capture half): block-`let` immutably captured by a hoisted async/generator declaration
 
 Carved from #2818 (parent) and #2820 (the plain-function half of Bug C, fixed
 there). This is the **async / generator capturer** residual of the
@@ -204,7 +204,7 @@ validation. **Do not** ship the un-gated `?? outerLocalIdx` form.
 
 ### Scoped repro / acceptance
 
-Add `tests/issue-2821.test.ts`:
+Add `tests/issue-2826.test.ts`:
 
 - `t5` (block async), `t6` (block generator) above return **42** (and a string
   variant returns the captured string).


### PR DESCRIPTION
Architect specs for the **#2818** Bug C residual — the two block-`let`-capture cases #2820's slot-reuse gate deliberately excludes. Carved into two cleanly-separable sub-issues (disjoint subsystems), each with a full `## Implementation Plan`, exact `file:line` anchors, edge cases, scoped repro, test262 targets, and a merge_group regression guard.

**#2826 — CPS-capture half** (leading-capture-param channel): a block-`let` immutably captured by a hoisted `async`/generator declaration reads the stale pre-hoisted slot A because #2820's reuse is skipped for CPS capturers (the collapse perturbs the for-await-of state machine -> 43 regressions). Fix: producer-side re-point of `nestedFuncCaptures[*].outerLocalIdx` A->B in `variables.ts`, immutable captures only, **no** slot collapse -> no state-machine perturbation. Composes with #2820's gate as its exact inverse.

**#2825 — class-method half** (captured-globals channel): a block-nested class is compiled **eagerly** because `compileClassesFromStatements`'s block/control-flow recursions (`declarations.ts:4222-4251`) drop the `insideFunction` flag, so `promoteAccessorCapturesToGlobals` never fires and the method compiles to `ref.null`. Fix: propagate `insideFunction` so the body is deferred to its textual position (after the block-`let`), reusing the proven deferred path.

Both empirically reproduced on current main (`compileAndInstantiate`): block-nested capturer returns `0`, fn-scope control returns `42`.

> Note: the CPS-capture spec was originally allocated 2821, but #2298 (deno-stdio EPIPE flake, since merged) also claimed 2821 and landed first — so this spec was renumbered 2821 -> 2826 to clear check:issue-ids:against-main. #2825 is unchanged.

Issue files only — no compiler code touched, trivially mergeable. Does **not** touch the `2818-*.md` file (owned by #2293 / bugC) to avoid an add/add conflict; the two sub-issues carry `parent: 2818`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS