### PR TITLE
fix(#2809): undefined[] externref representation — finish Sites C+D (acorn arguments milestone)

### DIFF
--- a/plan/issues/2806-untyped-array-literal-numeric-vec-drops-ref-pushes.md
+++ b/plan/issues/2806-untyped-array-literal-numeric-vec-drops-ref-pushes.md
@@ -1,8 +1,8 @@
 ---
 id: 2806
 title: "[SENIOR-DEV ONLY] untyped `[]` array literal lowers to a NUMERIC (f64) vec — ref pushes coerce to 0 (drops AST node refs)"
-status: ready
-assignee: ttraenkler/unassigned
+status: in-progress
+assignee: ttraenkler/senior-dev
 sprint: current
 priority: high
 horizon: l
@@ -134,3 +134,101 @@ test262 buckets.
 
 - **Blocks #2801** (its acceptance can't be met until node arrays preserve refs).
 - Sibling representation work: #2784 (vec-identity), #2794 (vec read-methods).
+
+---
+
+## Implementation Plan (architect arch-arrayrep — CANDIDATE, superseded by Step-0; see below)
+
+**Reframing (architect):** empty `[]` already defaults to `externref`
+(`literals.ts:3126`). The generic evolving-local array is already ref-safe. The
+bug is a NUMERIC OVERRIDE: when the contextual/location type resolves to
+`Array<number>`, `emptyElemKind` becomes f64/i32, the vec is f64-backed, and
+pushed AST-node refs coerce to `f64 0`. The fix must make actual ref writes WIN
+over the inferred-numeric kind — not merely default to externref.
+
+Policy as specified:
+- **(B) push-flow override** at the empty-`[]` site (~`literals.ts:3140`): after
+  `emptyElemKind` is computed, if it is primitive numeric (`f64`/`i32`), scan the
+  containing function for writes to this array's binding via a
+  `classifyArrayWriteElemKind(ctx, expr) → "ref"|"numeric"|"mixed"|"unknown"`
+  helper (reuse the forward-walk infra at `detectCountedPushLoopSize` ~2782 /
+  `detectCountedFillLoopBound` ~2867). If any write stores a reference, or
+  numeric+ref mixed → override `emptyElemKind = "externref"`. All-numeric /
+  no-writes → keep numeric (preserve `var a=[]; a.push(1)` fast path).
+- **(A′) bounded allowJs fallback** in `resolveWasmType`'s Array branch
+  (`index.ts` ~11610): only if the numeric comes from the binding/field/return
+  `Array<number>`, and only under `ctx.allowJs`/`skipSemanticDiagnostics` with a
+  WIDENED/inferred `number` element — prefer `externref`. Gated strictly so
+  annotated TS `number[]` stays f64. (B) and (A′) must pick the SAME kind for a
+  given binding or `struct.new` mismatches the local/field type → validation
+  failure.
+
+## Step-0 findings (instrument-verified — SUPERSEDE the plan above)
+
+The (B)+(A′) premise does **not** hold on current `main` (post-#2275). Instrumented
+`emptyElemKind`, the push-site element kind, and the host read for the real acorn
+compile + minimal repros:
+
+1. **Empty `[]` is already externref everywhere.** All **71** empty-`[]` literals
+   in acorn — including `parseExprList`'s `arguments` array (`acorn.mjs:3613`) —
+   resolve `emptyElemKind=externref`. **Zero** are f64/i32. So (B) (which only
+   fires when `emptyElemKind` is numeric) is a **no-op**, and (A′) does not apply
+   (the element type is not inferred-`number`).
+
+2. **The f64/`0` comes from the binding's inferred element type, not the
+   literal.** `parseExprList`'s `elts.push(elt)` (`acorn.mjs:3630`) compiles with
+   `elemKind=i32` because `elts` infers `undefined[]`
+   (`resolveWasmType` Array branch: `elemTs=undefined elemFlags=32768`). Each
+   pushed AST-node ref coerces to i32 `0`. `__vec_get` faithfully returns
+   `number 0`.
+
+3. **Root cause = the `var elt = (void 0)` idiom.** acorn's `parseExprList`:
+   `var elt = (void 0); ... elt = this.parseMaybeAssign(...); elts.push(elt)`.
+   The `void 0` EXPRESSION pins the binding to TS type `undefined` (unlike
+   `var elt = undefined`, which TS treats as **evolving-any**). Minimal repro
+   (`.tmp/repro-variants.mjs`) confirms the split decisively:
+   `var e=(void 0); e=ref; return e` → **undefined/0** (BROKEN);
+   `var e=undefined` / `=null` / `var e;` (no init) → **object** (all WORK).
+   Only the `void 0` form breaks. This also explains the issue's `body`-vs-
+   `arguments` split: `Program.body` pushes a directly-typed ref (works);
+   `CallExpression.arguments` flows through the `var elt = void 0` intermediate
+   (drops the ref).
+
+4. The `undefined` declared type then drops the ref at **multiple** codegen
+   sites that each consult it independently: the local slot type
+   (`localTypeForDeclaration`), the array element-kind inference
+   (`inferArrayVecType` — picks the first non-`any` push value type =
+   `undefined` → i32 vec), and at least one more value-coercion boundary (the
+   array element STILL reads `0` even after the slot + vec are forced to
+   externref — the value is lost at the assignment/return/push-arg coercion,
+   not yet fully isolated). `call.optional` reading `0` not `false` is the same
+   class (a `boolean` local/field carrying `0`).
+
+### Partial fixes landed on this branch (correct but INSUFFICIENT alone)
+
+- `inferArrayVecType` (`statements/variables.ts`): a write whose value type is
+  purely `undefined`/`void`/`null` no longer pins the array element kind to a
+  numeric vec (treated like `any`). → the `arguments` vec is now externref.
+- `localTypeForDeclaration` (`statements/variables.ts`): a variable whose
+  declared type is purely `undefined`/`void` gets an externref slot (matching
+  `never`, `null`). → the `var elt = (void 0)` local is now externref.
+
+With both, the vec + the local are externref, yet the host still reads `0` —
+so a third value-coercion site remains. The complete fix needs the
+`var x = (void 0)` binding to be treated as **evolving-any / externref
+uniformly** across declaration + assignment + reads + return + push-arg (i.e.
+make `void 0`-init behave like `undefined`-init, which already works
+end-to-end). That is a cross-cutting representation change, broader than the
+empty-array (B)+(A′) scope.
+
+### Recommendation (ESCALATED to tech lead)
+
+The architect's (B)+(A′) plan does not address the real root cause and would be a
+no-op. Recommend a re-spec targeting the `var x = (void 0)` idiom: recognise a
+`void`-expression initializer at the variable declaration and route the binding
+through the same evolving-any path that `var x = undefined` already uses, so all
+downstream coercion sites see externref. Broad blast radius → full `merge_group`
++ standalone-floor; watch `built-ins/Array/**` + TypedArray buckets.
+
+Repros banked in `.tmp/`: `repro-variants.mjs` (the decisive void-0 split),
+`repro-voidinit.mjs` (array + scalar), `callargs3.mjs`/`elemdbg.mjs` (acorn).

--- a/plan/issues/2806-untyped-array-literal-numeric-vec-drops-ref-pushes.md
+++ b/plan/issues/2806-untyped-array-literal-numeric-vec-drops-ref-pushes.md
@@ -1,8 +1,9 @@
 ---
 id: 2806
 title: "[SENIOR-DEV ONLY] untyped `[]` array literal lowers to a NUMERIC (f64) vec — ref pushes coerce to 0 (drops AST node refs)"
-status: in-progress
+status: done
 assignee: ttraenkler/senior-dev
+completed: 2026-06-28
 sprint: current
 priority: high
 horizon: l
@@ -232,3 +233,89 @@ downstream coercion sites see externref. Broad blast radius → full `merge_grou
 
 Repros banked in `.tmp/`: `repro-variants.mjs` (the decisive void-0 split),
 `repro-voidinit.mjs` (array + scalar), `callargs3.mjs`/`elemdbg.mjs` (acorn).
+
+---
+
+## RESOLUTION (root cause corrected + fix landed)
+
+**The title's "lowers to a NUMERIC (f64) vec" framing and the architect's
+empty-`[]` numeric-override premise were both wrong.** The real root cause is the
+`var x = (void 0)` idiom (acorn's `parseExprList`):
+
+```js
+var elt = (void 0);          // the `void 0` EXPRESSION pins TS type `undefined`
+elt = this.parseMaybeAssign(...);  // a REFERENCE
+elts.push(elt);
+return elts;
+```
+
+Unlike `var x = undefined` / `var x = null` / `var x;` (which TS treats as
+**evolving-any** → `any` → externref), the `void 0` expression pins the binding to
+type `undefined`. `resolveWasmType(undefined)` is numeric (i32), so the `undefined`
+type drops the reference at **three independent codegen sites**, each verified by
+WAT disassembly:
+
+1. **The local slot** — `var elt`'s slot typed i32 → `elt = <ref>` coerces to i32 `0`.
+2. **The array element-kind** — `inferArrayVecType` picked the first non-`any`
+   push-value type (`undefined`) → an i32-backed `elts` vec.
+3. **The function return type** — TS infers `parseExprList`'s return type as
+   `undefined[]`, so the returned vec type was an i32 vec while the local `elts`
+   was an externref vec; `return elts` coerced every pushed ref to i32 `0`.
+
+### Fix (one root rule, applied consistently)
+
+A `void`-expression initializer (`var x = void <expr>`) or a purely
+`undefined`/`void` type is treated as **externref** (the same slot `= undefined`
+gets) everywhere a binding/array/return type is resolved:
+
+- `varBindingNeedsExternrefForUndefined(decl, type)` helper (`src/codegen/index.ts`)
+  — shared by the `var` hoister (`hoistVarDecl`) and the let/const declaration
+  path (`localTypeForDeclaration`, `statements/variables.ts`) so the hoisted slot
+  and the declaration agree (a `var` reuses its hoisted slot).
+- `inferArrayVecType` (`statements/variables.ts`) — `undefined`/`void`/`null`
+  push-value types no longer pin the array element kind to a numeric vec.
+- `resolveWasmType` Array branch (`src/codegen/index.ts`) — a purely
+  `undefined`/`void` array element resolves to an externref vec (fixes the
+  function-return-type site so it matches the externref local).
+
+### Milestone — ACHIEVED
+
+`parse("foo(bar, baz)").arguments` → `[Identifier(bar), Identifier(baz)]`
+end-to-end via the dogfood oracle (closes **#2801**'s arguments blocker). Spot
+checks: `f(1, 2+3)` → `[Literal, BinaryExpression]`; `h([1,2], {x:3})` nested
+`ArrayExpression.elements` carry their node refs; all-numeric arrays still use the
+f64 vec (`range = [pos, 0]` etc. unaffected — only purely undefined/void elements
+change).
+
+### Out of scope / separate classes (do NOT block #2806)
+
+- **`CallExpression.optional` reads `0` not `false`** — a `boolean`-field-boxing
+  class, NOT the void-0 binding type (it did NOT fall out of this fix; confirmed
+  separate). Tracked separately.
+- **Scalar `return <void-0-typed-var>` returns `undefined`** — a `var e = (void 0);
+  e = <ref>; return e` standalone function infers a `void` RETURN TYPE, so the
+  function emits no result and drops the value at the return. This is the
+  function-return-type analogue of the same root and does NOT affect acorn's
+  arguments (`parseExprList` returns an array). Follow-up if it surfaces.
+- **`sourceFile` extra-field** in the dogfood diff — a harness/options field
+  difference, unrelated.
+
+### Path confirmation (direct AST→Wasm, not IR)
+
+acorn compiles via the **direct AST→Wasm path** (`src/codegen/`), not an IR
+partial — proven empirically: the fix lives entirely in `src/codegen/` and it
+fixes acorn's `arguments` end-to-end, which is only possible if `parseExprList`'s
+var-declaration + array-local lowering runs through that path (an IR-handled
+declaration would make these changes no-ops).
+
+## IR-path follow-up (#1530)
+
+This fix lives on the **direct/legacy front-end** (`src/codegen/`) — the one
+#1530 is retiring — because acorn compiles there today. The **same representation
+rule** must be reproduced on the IR path (`src/ir/`) when it adopts
+var-declarations + array-locals for modules this dynamic: a `void`-expression
+initializer (`var x = void <expr>`), and any purely `undefined`/`void` binding
+type, must be treated as **evolving-any / externref** (exactly like
+`var x = undefined`), so a later reference assignment / push / return is not
+coerced to numeric `0`. Without this, the IR path will reintroduce the #2801
+node-ref drop once it owns these node kinds.

--- a/plan/issues/2809-undefined-array-representation-conflation.md
+++ b/plan/issues/2809-undefined-array-representation-conflation.md
@@ -1,0 +1,188 @@
+---
+id: 2809
+title: "[SENIOR-DEV ONLY] undefined[] representation conflation — acorn's void-0 evolving array vs genuine undefined[]"
+status: ready
+assignee: ttraenkler/unassigned
+sprint: current
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+created: 2026-06-29
+task_type: bugfix
+area: codegen
+language_feature: value-representation
+goal: acorn-dogfood
+related: [2806, 2801, 2379]
+depends_on: []
+blocks: [2801]
+architect_spec: candidate
+---
+
+# #2809 — `undefined[]` representation conflation: acorn evolving-array (refs) vs genuine `undefined[]` (numeric)
+
+**Carved from #2806.** #2806 took compiled-acorn `parse("foo(bar,baz)").arguments`
+from `[0,0]` to the correct `[Identifier, Identifier]` end-to-end — but the fix's
+third site (the `resolveWasmType` Array branch) is **load-bearing for acorn yet
+over-broad for test262**, causing a real merge_group regression. This issue carves
+out the underlying **representation-design decision** for an architect spec.
+
+## TL;DR for the architect
+
+Two distinct things share the TypeScript type `Array<undefined>` and must lower
+**differently**:
+
+- **acorn's evolving array** — `var elt = (void 0); elt = <nodeRef>;
+  elts.push(elt); return elts`. The `void 0` expression pins `elt` to type
+  `undefined`, so `elts` and the function's return type infer as `undefined[]`,
+  but the runtime values are **references** (AST nodes). This MUST be an
+  **externref** vec, or the refs coerce to `0`.
+- **genuine `undefined[]`** — `Array(undefined, undefined)`, `[undefined,
+  undefined]`, sparse `[,,,]`. These hold real `undefined` VALUES and today
+  lower to **numeric** (i32/f64) vecs with the undefined sentinel, and pass
+  test262.
+
+**Core design question:** can we route acorn's evolving array to externref via
+the **void-0 signal** (at element-type AND return-type inference) so genuine
+`undefined[]` stays numeric — WITHOUT the blunt global `resolveWasmType`
+override? If not, the fallback is to make `undefined[]` **uniformly**
+externref-boxed-undefined across every construction/access/method path.
+
+## Background: the #2806 fix (3 sites)
+
+The #2806 root cause is the `var x = (void 0)` idiom: the `void 0` expression pins
+the binding to TS type `undefined` (unlike `= undefined`/`= null`/no-init, which
+TS treats as evolving-any → externref), and `resolveWasmType(undefined)` is a
+numeric (i32) slot, so a later REFERENCE assignment/push/return is coerced to `0`.
+The landed fix (branch `issue-2806-untyped-array-ref-vec`, PR #2284) has three
+sites:
+
+1. **Void-expr slot** (`varBindingNeedsExternrefForUndefined` in
+   `src/codegen/index.ts`, used by `hoistVarDecl` + `localTypeForDeclaration` in
+   `src/codegen/statements/variables.ts`): a `var x = (void 0)` binding gets an
+   externref slot. NARROW (void-EXPRESSION only — a bare `undefined`-typed binding
+   like `const afterA = obj.a` after `delete` must stay numeric for the f64-sNaN
+   delete sentinel, #1112). **CLEAN — keep.**
+2. **`inferArrayVecType`** (`statements/variables.ts`): undefined/void/null
+   push-value types no longer pin the array's element kind to a numeric vec
+   (treated like `any`). Makes the evolving LOCAL `elts` an externref vec.
+   **CLEAN — keep.**
+3. **`resolveWasmType` Array branch** (`src/codegen/index.ts` ~11610): a purely
+   `undefined`/`void` array element → externref vec. **REQUIRED for acorn (the
+   function RETURN type of `parseExprList` is `undefined[]` and must match the
+   externref local), but OVER-BROAD — it is the regression source.**
+
+Sites #1 + #2 are the clean foundation and should be preserved by any solution.
+
+## The merge_group regression (REAL, net-positive, ratio-gated)
+
+PR #2284 passed PR-level checks but was auto-parked on the merge_group
+"check for test262 regressions" required gate. Delta (from the
+`test262-merged-report` artifact diffed against baseline):
+
+```
+pass  34266 → 34273  (+7 net)
+Regressions (pass→other): 5   Improvements (other→pass): 12
+GATE FAIL: regression ratio 41.7% (5/12) ≥ 10% limit
+Regression categories: wasm_compile 2, null_deref 1, assertion_fail 1, illegal_cast 1
+```
+
+The change is **net-positive** (+7 pass, 12 real improvements from the void-0
+fix); the gate fails on the **ratio**, and the 5 regressions are **real** (not
+drift — confirmed by local reproduction).
+
+### The 5 regressed tests
+
+1. `test/built-ins/Array/S15.4.1_A2.1_T1.js` — `Array(undefined, undefined).length`
+   returns 0, expected 2.
+2. `test/built-ins/Array/S15.4.2.1_A2.1_T1.js` — `new Array(undefined, undefined)`
+   → invalid wasm (`array.new_fixed[0] expected type`).
+3. `test/built-ins/Array/prototype/sort/S15.4.4.11_A1.3_T1.js` —
+   `new Array(undefined, undefined).sort()` → invalid wasm.
+4. `test/built-ins/Array/prototype/reduceRight/15.4.4.22-8-c-4.js` — sparse
+   `[, , , ]` → null_deref.
+5. `test/language/module-code/top-level-await/syntax/for-in-await-expr-this.js` —
+   illegal_cast. **Likely drift/collateral, NOT Array** — verify against another
+   PR's regression list / a clean re-merge.
+
+### Mechanism of the regression
+
+Site #3 makes `Array<undefined>` an externref vec on the **TYPE** side (the
+variable's declared type, `.length` access, the function return type). But the
+**CONSTRUCTION/access** side still builds **numeric (i32) vecs**:
+
+- `compileArrayConstructorCall` (`Array(...)`, `literals.ts:3944`) computes the
+  element via `resolveWasmType(undefined)` [SCALAR] = i32 — NOT the Array branch
+  — so it builds an i32 vec while consumers resolve the value's
+  `Array<undefined>` type to externref → mismatch (wrong `.length`,
+  `array.new_fixed` validation failure).
+- `new Array(...)` (new-super.ts path) — same, separately.
+- Sparse `[, , ,]` holes — externref vec but hole/access path null-derefs.
+- `.sort()` — rebuilds the backing array, same mismatch.
+
+The plain array **literal** `[undefined, undefined]` already defaults all-undefined
+to externref (literals.ts ~3219), so it is CONSISTENT and was NOT regressed —
+which is the existence proof that uniform externref CAN work, just not yet wired
+through the builtins/sparse/method paths.
+
+### Why #3 can't simply be reverted
+
+Verified: reverting #3 makes all 4 Array tests pass **but regresses real acorn back
+to `[0,0]`** — `parseExprList`'s return type `undefined[]` resolves to a numeric vec
+while the local `elts` is an externref vec, and `return elts` coerces every pushed
+ref to `0`. #3 is the only site that currently fixes the return type. So the
+acorn win and the test262 Array correctness are coupled through `undefined[]`.
+
+## Prototype already explored (in branch worktree)
+
+Aligning `compileArrayConstructorCall` with #3 (a `pureUndefinedVoidElem →
+externref` branch) **fixed** `Array(undefined,undefined).length === 2` and left
+numeric arrays (`Array(0,1,0,1)`) untouched — but `new Array(...)`, sparse holes,
+and sort each still need the same alignment. That spreading across ~4–5
+construction/method paths is the **reference_2379 "representation-scale" hazard**:
+a representation change that can't be safely validated without full merge_group.
+
+## Options (with assessment)
+
+- **(a) Uniform `undefined[]` → externref-boxed-undefined** across every
+  construction/access/method path (literal ✓ already; + `Array()`, `new Array`,
+  sparse holes, sort, reduceRight, indexed read/write). More spec-correct
+  (undefined boxed as externref, not an f64 sentinel) and keeps the acorn win.
+  But broad blast radius; needs 1–2 merge_group rounds to validate. **The correct
+  end-state if the void-0 signal can't be exploited.**
+- **(b) Surgical func-result-type adaptation** — drop global #3; instead adapt
+  `parseExprList`'s function RESULT TYPE to externref at body-end (the
+  `func.typeIdx` reassignment infra exists, `function-body.ts:126`) so test262
+  undefined-arrays stay numeric. **REJECTED by tech-lead** — funcIdx/caller-order
+  desync risk (#1257 class); a hack.
+- **(c) Split** — drop #3, land the clean #1 + #2 (real improvements, no Array
+  break) now, re-spec the return-type later. **REJECTED by tech-lead** — defers
+  the acorn goal.
+
+**Preferred direction (architect to confirm):** a principled inference fix —
+make acorn's evolving array infer as `any[]`/evolving-any (→ externref) via the
+**void-0 signal**, at BOTH the array-element-type and the function-return-type
+inference, so genuine `undefined[]` stays numeric and there is NO test262
+regression and NO blunt global override. If that inference path is not feasible,
+fall back to (a). Either way, preserve #1 + #2.
+
+## Acceptance
+
+- Compiled-acorn `parse("foo(bar,baz)").arguments` → `[Identifier, Identifier]`
+  (the #2806/#2801 milestone) stays green.
+- All 4 `built-ins/Array/**` regressions above pass; genuine `undefined[]` /
+  `Array(undefined,...)` / sparse arrays keep correct length + element semantics.
+- Full `merge_group` + standalone-floor green (ratio < 10%, no bucket > 50),
+  watch `built-ins/Array/**` + TypedArray.
+
+## Pointers
+
+- Branch with the full #2806 fix + the `compileArrayConstructorCall` prototype
+  to build on / cherry-pick: `issue-2806-untyped-array-ref-vec` (PR #2284,
+  PARKED — do not unpark until this is resolved).
+- Repros banked in that worktree's `.tmp/`: `repro-variants.mjs`,
+  `repro-voidinit.mjs`, `callargs3.mjs`/`elemdbg.mjs` (acorn), `arrundef.mjs`
+  (the Array-undefined construction cases).
+- Memory: `reference_2379_new_array_n_boxed_any_elem_rep` /
+  `reference_2379_new_array_n_arraymethod_invalid_cast` — the representation-scale
+  precedent.

--- a/plan/issues/2809-undefined-array-representation-conflation.md
+++ b/plan/issues/2809-undefined-array-representation-conflation.md
@@ -1,8 +1,8 @@
 ---
 id: 2809
 title: "[SENIOR-DEV ONLY] undefined[] representation conflation — acorn's void-0 evolving array vs genuine undefined[]"
-status: ready
-assignee: ttraenkler/unassigned
+status: in-progress
+assignee: ttraenkler/senior-developer
 sprint: current
 priority: high
 horizon: l
@@ -186,3 +186,192 @@ fall back to (a). Either way, preserve #1 + #2.
 - Memory: `reference_2379_new_array_n_boxed_any_elem_rep` /
   `reference_2379_new_array_n_arraymethod_invalid_cast` — the representation-scale
   precedent.
+
+## Implementation Plan
+
+**Architect verdict: implement Option 2 (uniform `undefined[]`/`void[]` →
+externref-boxed-undefined). Option 1 (distinguish at inference / per-path
+wasm-type overrides) was empirically DISPROVEN for full acorn — see below.**
+`reasoning_effort: max`, senior-dev only.
+
+### Why Option 1 fails (verified on current main, 2026-06-29)
+
+The conflation is irreducible **at the TS type level**: acorn's evolving array
+and genuine `Array(undefined,undefined)` / `[undefined,undefined]` / sparse
+`[,,,]` all resolve to the *identical* `ts.Type` `undefined[]`. The `void 0`
+signal is purely **syntactic/local** — it never reaches the structural type, so
+`resolveWasmType(undefined[])` cannot tell them apart. Option 1 therefore has to
+fix the **value-carrying positions** (locals, returns, params, fields) one
+registration-path at a time.
+
+I built and ran Option 1 end-to-end (keep #1+#2, drop #3, add a narrowly-gated
+function-**return-type** override that fires only when a returned identifier is
+bound to an empty-array-literal evolving local). Results:
+
+- Minimal repro (top-level `export function parseExprList(){ var elts=[]; var
+  elt=(void 0); elt=ref; elts.push(elt); return elts; }`) → **FIXED**
+  (`[Identifier, Identifier]`), and genuine `Array(undefined,undefined).length`
+  stayed `2`, `return [undefined,undefined]` / `return Array(undefined,undefined)`
+  correctly stayed numeric (override did not fire). Blast radius looked ~zero.
+- **BUT real acorn (`tests/dogfood/.acorn/.../acorn.mjs`, 147 s compile) still
+  returned `arguments: [0,0]`.** Root cause: acorn's `parseExprList` is a
+  **prototype method assigned to a function expression** (`pp.parseExprList =
+  function(...){…}`), NOT a top-level `FunctionDeclaration`. Its result type is
+  registered on a different code path, so the declaration-path override never
+  fires. To make Option 1 cover acorn you would have to replicate the override
+  across **every** function-like + field registration path (FunctionDeclaration,
+  FunctionExpression, prototype method, ArrowFunction, object/struct field, param)
+  and never miss one — any gap silently coerces a ref to `0`. That is exactly the
+  uniformity #3 already provides type-side for free. Option 1 is fragile and
+  higher-effort than Option 2.
+
+Conclusion: **keep #3 (uniform type→externref) and align the construction/access
+side to match it.** Type and value then agree at every boundary with no
+per-path coverage table to maintain.
+
+### Root cause (Option 2 framing)
+
+#3 makes `resolveWasmType(undefined[]/void[])` an **externref vec** uniformly
+(variable types, return types, params, fields, `.length`). But every
+**construction** site computes its element representation from the *scalar*
+element type via `resolveWasmType(undefinedElem)` = `i32`/`f64`, NOT from the
+array type's vec element. So construction builds a numeric vec while consumers
+resolve the value to an externref vec → mismatch (`array.new_fixed[0] expected
+type externref, f64`, wrong `.length`, null-deref). The unifying fix: **every
+construction/hole/method site must derive its element representation from the
+array type's resolved vec (the #3-governed externref vec), pushing
+`emitUndefined` / externref-undefined for `undefined`/holes when the vec element
+is externref — never the f64 sNaN sentinel.**
+
+### Keep (the clean #2806 foundation — do not touch)
+
+- **#1** `varBindingNeedsExternrefForUndefined` (`src/codegen/index.ts`) + uses in
+  `hoistVarDecl` and `localTypeForDeclaration` (`statements/variables.ts`).
+- **#2** `inferArrayVecType` unpinnable-write-type rule (`statements/variables.ts`).
+- **#3** `resolveWasmType` Array branch (`src/codegen/index.ts`, the
+  `sym==="Array"` block, ~line 11610 on the branch): pure `undefined`/`void`
+  element → externref vec. **This stays — it is the uniform type-side anchor.**
+
+### Changes — align construction/access to the externref vec
+
+Each site below currently diverges by resolving the **scalar** element. The fix
+is the same shape used in the landed `compileArrayConstructorCall` prototype:
+detect `pureUndefinedVoidElem` (element flags are only `Undefined`/`Void`) and
+force `elemWasm = { kind: "externref" }` so the pushed values, the
+`array.new_fixed`/`array.new_default` type, and the vec struct all agree with #3.
+
+**Site A — `Array(...)` (non-`new`). DONE on the branch (keep).**
+`src/codegen/literals.ts` `compileArrayConstructorCall` (~3957): the
+`pureUndefinedVoidElem → externref` branch. Verified: `Array(undefined,
+undefined).length === 2`. ✓
+
+**Site B — `new Array(elem, …)`. `src/codegen/expressions/new-super.ts`, the
+`if (className === "Array")` block (~line 4744; line 4780 on current main).**
+The bug: `vecTypeIdx` is taken from `resolveWasmType(ctx, exprType)` (externref
+vec via #3, line ~4776) but `elemWasm = elemTsType ? resolveWasmType(ctx,
+elemTsType) : {f64}` (line ~4780) resolves the **scalar** undefined → `f64`, so
+`array.new_fixed` pushes f64 into the externref array → the verified
+`CompileError: array.new_fixed[0] expected type externref, f64`. **Fix:** after
+computing `elemWasm`, apply the same `pureUndefinedVoidElem` guard (using
+`typeArgs[0]`) → `elemWasm = {kind:"externref"}` (vecTypeIdx already externref).
+Also ensure the per-arg compile pushes each arg with `expectedType = elemWasm`
+(externref → ref/box path), and any padding/default uses `emitUndefined`, not the
+f64 sNaN. This fixes regressed tests S15.4.2.1_A2.1_T1 (T2) and unblocks sort
+(T3 — its failure was the `new Array` construction, not sort itself).
+
+**Site C — sparse / hole array literals `[, , ,]` and `[undefined, …]`.
+`src/codegen/literals.ts` `compileArrayLiteral` (~3080) and the hole path
+(`emitHoleSentinel` / the `_isUndefinedLike` + `expectedType.kind === "f64"`
+sNaN branch, ~2764).** When the literal's vec element is externref (all-hole /
+all-undefined → #3 externref vec), holes and `undefined` elements must be emitted
+as externref-undefined (`emitUndefined`) — the existing tuple path at ~2780
+already does this for `expectedType.kind === "externref"`; the **vec** literal
+path must do the same instead of the f64 sNaN sentinel. This fixes the
+reduceRight sparse case (T4: `15.4.4.22-8-c-4.js`); verify holes remain
+**absent** for `HasProperty` (reduceRight/forEach must skip holes), i.e. the
+hole sentinel for an externref vec must still be recognized as a hole by the
+iteration/HasProperty path (`array-holes.ts`), not as a present `undefined`.
+
+**Site D — array methods that rebuild the backing array for an `undefined[]`
+receiver.** `src/codegen/array-methods.ts`: `sort`/`toSorted`
+(`compileArrayToSorted` ~3336, `array.new_default` ~3262), and any method using
+`array.new*`/element copy. These read the receiver's vec type; once B/C build
+externref vecs they should largely follow, but **audit every `array.new_fixed` /
+`array.new_default` / element load-store in sort/reduce/reduceRight/concat/slice/
+splice/copyWithin for the externref-element case** — the canonical failure
+signal is `array.new_fixed[N] expected type externref, …`. Spec test: `new
+Array(undefined,undefined).sort()` (T3) and the reduceRight test (T4).
+
+**Site E — indexed read/write of an `undefined[]`.** The generic element-access
+path should already handle an externref vec (it keys off the vec type), but add a
+scoped check: `var a = Array(undefined,undefined); a[0]` and `a[0] = x` must read
+back `undefined` / store correctly. Low risk; verify, don't pre-emptively change.
+
+### Wasm IR pattern (the invariant to hold at every site)
+
+```wasm
+;; vec element type (from #3) === value pushed === array.new_* element type
+;; undefined[] / void[]  ⇒  $vec_externref { (field $len i32) (field $data (ref $arr_externref)) }
+;; undefined value / hole ⇒ call $__get_undefined   (NOT i64.const 0x7FF00000DEADC0DE ; f64.reinterpret_i64)
+```
+
+The sNaN f64 sentinel is ONLY for f64-vec/scalar undefined; for an externref vec
+the undefined/hole sentinel is the host-undefined singleton via `emitUndefined`.
+
+### Edge cases
+
+- **Genuine evolving undefined returned** (`function f(){ var a=[];
+  a.push(undefined); return a; }`): verified CORRECT under externref — boxed
+  undefined preserves `a[0] === undefined`. No special-casing needed.
+- **`number[]` / `boolean[]`**: element flags carry Number/Boolean, not pure
+  Undefined/Void → guard does not fire → stay f64/i32. Verified `Array(0,1,0,1)`
+  and `[1,2]` untouched.
+- **`number | undefined` (union)**: carries the Union flag, NOT pure Undefined →
+  must NOT become an externref-of-boxed vec via these guards (it has its own
+  union representation). Guard's `& ~(Undefined|Void) === 0` test already excludes
+  it; keep that exact predicate at every site.
+- **delete/optional-property f64-sNaN sentinel (#1112)**: unaffected — those are
+  scalar `undefined`-typed bindings (no array), gated by #1's void-EXPRESSION-only
+  rule. Do not widen #1.
+- **Holes vs present-undefined for HasProperty**: reduceRight/forEach/every/some
+  must still SKIP holes (§ spec). Ensure the externref hole sentinel is
+  distinguishable from a stored externref-undefined where the spec requires it
+  (array-holes.ts). This is the subtle one — test `15.4.4.22-8-c-4.js` and a
+  `forEach` over `[,,,]` (callback must not run).
+- **Mixed `[undefined, 1]`**: element type is `number` (or `number|undefined`),
+  not pure undefined → stays numeric/union; not in scope.
+
+### Test plan (gate: ZERO regressions — the ratio gate requires clean, not net-positive)
+
+Scoped local (dev, fast):
+1. `parse("foo(bar,baz)").arguments` → `[Identifier, Identifier]` via the acorn
+   dogfood harness (`tests/dogfood/acorn-harness.mjs`) — the milestone MUST hold.
+2. The 4 regressed tests must PASS:
+   - `built-ins/Array/S15.4.1_A2.1_T1.js` (`Array(undefined,undefined).length===2`)
+   - `built-ins/Array/S15.4.2.1_A2.1_T1.js` (`new Array(undefined,undefined)`)
+   - `built-ins/Array/prototype/sort/S15.4.4.11_A1.3_T1.js`
+   - `built-ins/Array/prototype/reduceRight/15.4.4.22-8-c-4.js`
+3. `tests/issue-2806.test.ts` stays green.
+4. Quick smoke (the probes used to validate this spec, banked in the architect's
+   `.tmp/probe-opt2.mjs`): `Array(undefined,undefined).length`, `new
+   Array(undefined,undefined).length`, `.sort().length`, sparse-`[,,,]`
+   reduceRight visit-count (0), numeric `Array(0,1,0,1)` / `[1,2]` unchanged.
+
+Full CI (REQUIRED — representation-scale, reference_2379): full `merge_group` +
+standalone-floor. Watch `built-ins/Array/**`, `built-ins/Array/prototype/**`, and
+TypedArray buckets. **Do not enqueue on net-positive-with-regressions** — the
+ratio gate (≥10% = 5/12 last time) requires a clean run. Budget 1–2 merge_group
+rounds to chase any straggler `array.new_*` divergence (the canonical signal:
+`array.new_fixed[N] expected type externref, …`).
+
+### Blast radius + classification
+
+- **Files:** `literals.ts` (Site A done + Site C), `expressions/new-super.ts`
+  (Site B), `array-methods.ts` (Site D audit), `array-holes.ts` (hole-sentinel
+  for externref), plus the preserved #1/#2/#3. ~4–5 files, all in the array
+  construction/access lane.
+- **Class:** representation-scale change (reference_2379 hazard) — **senior-dev,
+  `reasoning_effort: max`**, validate on full `merge_group`, not a scoped sweep.
+- **Base branch:** build on the preserved `issue-2806-untyped-array-ref-vec`
+  (commit `babfff3ce`, has #1+#2+#3 + Site A). Add Sites B–D; re-merge
+  `origin/main`; enqueue only on a clean merge_group.

--- a/plan/issues/2809-undefined-array-representation-conflation.md
+++ b/plan/issues/2809-undefined-array-representation-conflation.md
@@ -1,8 +1,10 @@
 ---
 id: 2809
 title: "[SENIOR-DEV ONLY] undefined[] representation conflation — acorn's void-0 evolving array vs genuine undefined[]"
-status: in-progress
+status: done
+completed: 2026-06-29
 assignee: ttraenkler/senior-developer
+supersedes: 2284
 sprint: current
 priority: high
 horizon: l
@@ -375,3 +377,57 @@ rounds to chase any straggler `array.new_*` divergence (the canonical signal:
 - **Base branch:** build on the preserved `issue-2806-untyped-array-ref-vec`
   (commit `babfff3ce`, has #1+#2+#3 + Site A). Add Sites B–D; re-merge
   `origin/main`; enqueue only on a clean merge_group.
+
+## Resolution (2026-06-29, branch `issue-2809-rep-final`)
+
+All five sites resolved; the four regressed test262 cases pass, the acorn
+milestone holds, and numeric arrays are untouched.
+
+- **#1 / #2 / #3** (the #2806 foundation), **Site A** (`Array(...)`), **Site B**
+  (`new Array(...)`) — preserved from the base branch
+  `issue-2809-array-rep-impl` (commit `39e8d7e2`). Verified still correct.
+- **Site C — the only remaining code change.** The spec framed Site C as a
+  *construction* fix in `literals.ts`, but the literal hole path already emitted
+  the `$Hole` sentinel correctly (#2001 S1). The real regression was downstream
+  in **`compileArrayReduceRight`** (`src/codegen/array-methods.ts`): a sparse
+  `[,,,]` externref vec with **no initial value** trapped
+  ("dereferencing a null pointer").
+
+  **Root cause (reference_1461 class — late-import funcIdx shift, NOT a
+  representation bug).** The no-init seed (`acc = data[len-1]`) and the
+  per-iteration element load map a `$Hole`→`undefined` via
+  `holeToUndefinedInstrs`, which runs `emitUndefined` into a **detached** body.
+  `emitUndefined`'s internal `flushLateImportShifts` therefore patches that
+  detached array, not the real `fctx.body` holding the callback closure's
+  `ref.func`. When `__get_undefined` is *first* registered there, the
+  late-import funcIdx shift is silently consumed and the closure `ref.func` is
+  left pointing at the wrong (pre-shift) function — so `call_ref` dereferences a
+  stale/null funcref and traps. An *explicit* `[undefined, undefined]` array did
+  NOT regress, because it registers `__get_undefined` during construction
+  (before the closure is emitted) — that asymmetry was the diagnostic key.
+
+  **Fix:** pre-ensure `__get_undefined` + flush against the real body at the top
+  of `compileArrayReduceRight`, *before* `setupArrayCallback` emits the closure
+  `ref.func`. The later `holeToUndefinedInstrs` registrations are then idempotent
+  (no further shift). Surgical: it relocates the function's existing pre-ensure
+  block earlier. An earlier exploration also widened the reduce/reduceRight
+  accumulator to externref for externref vecs, but the funcIdx fix alone is
+  sufficient, so that change was reverted to keep the blast radius minimal.
+- **Site D** (sort/toSorted backing) and **Site E** (indexed read/write) —
+  **verified, no change needed.** `new Array(undefined,undefined).sort()` already
+  builds an externref vec via Site B and passes; indexed reads of
+  `Array(undefined,…)` behave byte-identically to `main` (so any divergence there
+  is pre-existing, not a regression of this work).
+
+### Test Results (local)
+
+- 4 regressed test262 tests PASS: `S15.4.1_A2.1_T1`, `S15.4.2.1_A2.1_T1`,
+  `prototype/sort/S15.4.4.11_A1.3_T1`, `prototype/reduceRight/15.4.4.22-8-c-4`.
+- acorn milestone HOLDS: compiled-acorn `parse("foo(bar,baz)").arguments` →
+  `["Identifier","Identifier"]` (full pinned acorn, 85 s compile).
+- `tests/issue-2806.test.ts` green (5/5); new `tests/issue-2809.test.ts` green
+  (6/6); broad array-method smoke (numeric reduce/reduceRight/sort/map/filter,
+  string reduce, `Array`/`new Array(undefined,…)` length) clean.
+
+Supersedes #2284 (the PARKED #2806 PR). Closes the #2801/#2806 acorn-arguments
+milestone path. Full `merge_group` + standalone-floor validation on the PR.

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -6842,6 +6842,24 @@ function compileArrayReduceRight(
 
   const numKind = ctx.fast ? "i32" : "f64";
   const bridgeName = ctx.fast ? "__call_2_i32" : "__call_2_f64";
+
+  // (#2809) Pre-ensure `__get_undefined` BEFORE `setupArrayCallback` emits the
+  // callback closure's `ref.func`. The seed/loop below map a `$Hole` element to
+  // `undefined` via `holeToUndefinedInstrs`, which calls `emitUndefined` into a
+  // DETACHED body — so its internal `flushLateImportShifts` patches that detached
+  // array, NOT the real `fctx.body` holding the closure `ref.func`. If
+  // `__get_undefined` is first registered there, the late-import funcIdx shift is
+  // silently consumed and the closure `ref.func` is left pointing at the wrong
+  // (pre-shift) function → `call_ref` dereferences a stale/null funcref and traps
+  // (the regressed sparse-`[,,,]` `reduceRight` null-deref, reference_1461 class).
+  // Registering it here, while `fctx.body` is the real body, makes the shift flush
+  // against the right instrs and renders the later `holeToUndefinedInstrs`
+  // registrations idempotent (no further shift).
+  if (ctx.usesArrayHoles && elemType.kind === "externref") {
+    ensureGetUndefined(ctx);
+    flushLateImportShifts(ctx, fctx);
+  }
+
   const setup = setupArrayCallback(ctx, fctx, callExpr, "reduceRight", "rr", bridgeName);
   if (!setup) return null;
 
@@ -6902,13 +6920,9 @@ function compileArrayReduceRight(
     fctx.body.push({ op: "local.set", index: iTmp });
   }
 
-  // (#2001 S1) Pre-ensure `__get_undefined` (reduceRight builds its loop struct
-  // manually, not via setupArrayLoop) so the detached `holeToUndefinedInstrs`
-  // for the per-iteration element load below can't shift a captured funcIdx.
-  if (ctx.usesArrayHoles && elemType.kind === "externref") {
-    ensureGetUndefined(ctx);
-    flushLateImportShifts(ctx, fctx);
-  }
+  // (#2001 S1 / #2809) `__get_undefined` is pre-ensured at the top of this
+  // function (before the closure `ref.func` is emitted) so the detached
+  // `holeToUndefinedInstrs` below can't shift a captured funcIdx.
 
   // Build the loop locals struct for buildClosureCallInstrs compatibility
   const loop: ArrayLoopLocals = {

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -4780,6 +4780,34 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       elemWasm = elemTsType ? resolveWasmType(ctx, elemTsType) : { kind: "f64" };
     }
 
+    // (#2809 Site B) `new Array(undefined, …)` / `new Array<void>(…)`: keep the
+    // construction's element/vec representation in lockstep with the
+    // `Array<undefined>`/`Array<void>` → externref rule in `resolveWasmType`'s
+    // Array branch (#2806 site #3). The vec type above is taken from
+    // `resolveWasmType(exprType)` (an externref vec via #3), but `elemWasm` is
+    // resolved from the *scalar* undefined element → i32/f64, so `array.new_fixed`
+    // pushes a numeric value into an externref array and validation fails
+    // (`array.new_fixed[0] expected type externref, f64`) while consumers
+    // mis-read `.length`. Force the element (and vec/arr) to externref so the
+    // pushed boxed-undefined values, the array.new_* element type, and the vec
+    // struct all agree. Pure Undefined/Void only — `number[]` (f64) / `boolean[]`
+    // (i32) carry Number/Boolean and `number | undefined` carries the Union flag,
+    // so the guard does not fire and they stay numeric.
+    {
+      const ctorTypeArgs = ctx.checker.getTypeArguments(exprType as ts.TypeReference);
+      const ctorElemTs = ctorTypeArgs?.[0];
+      const pureUndefinedVoidElem =
+        !!ctorElemTs &&
+        (elemWasm.kind === "i32" || elemWasm.kind === "f64") &&
+        (ctorElemTs.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void)) !== 0 &&
+        (ctorElemTs.flags & ~(ts.TypeFlags.Undefined | ts.TypeFlags.Void)) === 0;
+      if (pureUndefinedVoidElem) {
+        elemWasm = { kind: "externref" };
+        vecTypeIdx = getOrRegisterVecType(ctx, "externref", { kind: "externref" });
+        arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+      }
+    }
+
     // #1197: i32-specialized number[] override — caller (variable-declaration
     // codegen) flagged this `new Array(...)` as belonging to an i32-specialized
     // local. Override the element kind from f64 to i32. We must also re-resolve

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -11610,9 +11610,31 @@ export function resolveWasmType(ctx: CodegenContext, tsType: ts.Type, _depth = 0
     if (sym?.name === "Array" || sym?.name === "ReadonlyArray") {
       const typeArgs = ctx.checker.getTypeArguments(tsType as ts.TypeReference);
       const elemTsType = typeArgs[0];
-      const elemWasm: ValType = elemTsType
+      let elemWasm: ValType = elemTsType
         ? resolveWasmType(ctx, elemTsType, _depth + 1, _visited)
         : { kind: "externref" };
+      // (#2806) An array whose element type is **purely** `undefined` / `void`
+      // must lower to an externref-element vec, not a numeric (i32) vec — the
+      // same alignment applied to `var x = (void 0)` slots. The canonical source
+      // is acorn's `parseExprList`: `var elt = (void 0); … elt = <nodeRef>;
+      // elts.push(elt); return elts`. TS infers the *function return type* as
+      // `undefined[]`, so the returned vec type would be an i32 vec while the
+      // local `elts` is an externref vec — `return elts` then copies/coerces
+      // each pushed REFERENCE to i32 `0`, dropping the AST node refs (#2801).
+      // Resolving `undefined[]`/`void[]` to externref here keeps the return type
+      // (and any field/param so typed) in lockstep with the externref local.
+      // `never[]` already resolves to externref; this closes the `undefined[]`
+      // gap. Pure undefined/void only (no Number/Boolean/etc.) so `number[]`
+      // (f64) and `boolean[]` (i32) are untouched; `number | undefined` carries
+      // the Union flag, not Undefined, and is left alone.
+      if (
+        elemTsType &&
+        (elemWasm.kind === "i32" || elemWasm.kind === "f64") &&
+        (elemTsType.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void)) !== 0 &&
+        (elemTsType.flags & ~(ts.TypeFlags.Undefined | ts.TypeFlags.Void)) === 0
+      ) {
+        elemWasm = { kind: "externref" };
+      }
       const elemKey =
         elemWasm.kind === "ref" || elemWasm.kind === "ref_null"
           ? `ref_${(elemWasm as { typeIdx: number }).typeIdx}`
@@ -13867,6 +13889,40 @@ export function collectEnumDeclarations(ctx: CodegenContext, sourceFile: ts.Sour
  * variable not yet in localMap, so identifiers are valid before their
  * declaration site (JavaScript var-hoisting semantics).
  */
+/**
+ * (#2806) Does this variable binding require an **externref** slot because its
+ * declared type is (only) `undefined` / `void`?
+ *
+ * Root cause of the compiled-acorn `CallExpression.arguments` drop: acorn writes
+ * `var elt = (void 0); … elt = this.parseMaybeAssign(...); elts.push(elt)`. The
+ * `void 0` EXPRESSION pins the binding to TS type `undefined` — UNLIKE
+ * `var elt = undefined` / `var elt;`, which TS treats as evolving-any (→ `any`,
+ * → externref). `resolveWasmType(undefined)` is a numeric (i32) slot, so a later
+ * REFERENCE assignment is coerced to i32 `0` and the node ref is dropped.
+ *
+ * The fix routes a `void`-expression initializer (and any purely `undefined` /
+ * `void` declared type) through the SAME externref slot that `= undefined`
+ * already gets — a correctness alignment, not new behaviour. Used by BOTH the
+ * `var` hoister and the let/const declaration path so the slot type is uniform
+ * (a `var` reuses its hoisted slot, so both sites MUST agree).
+ */
+export function varBindingNeedsExternrefForUndefined(
+  decl: ts.VariableDeclaration | undefined,
+  varType: ts.Type,
+): boolean {
+  // `var x = (void 0)` / `var x = void <expr>` — strip parens to find the void.
+  let init = decl?.initializer;
+  while (init && ts.isParenthesizedExpression(init)) init = init.expression;
+  if (init && ts.isVoidExpression(init)) return true;
+  // Purely `undefined` / `void` declared type (no other union constituents).
+  // Unions like `number | undefined` carry the Union flag, not Undefined, so
+  // they are left alone; genuine numeric/boolean/string locals are untouched.
+  return (
+    (varType.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void)) !== 0 &&
+    (varType.flags & ~(ts.TypeFlags.Undefined | ts.TypeFlags.Void)) === 0
+  );
+}
+
 export function hoistVarDeclarations(
   ctx: CodegenContext,
   fctx: FunctionContext,
@@ -14019,7 +14075,7 @@ function hoistVarDecl(ctx: CodegenContext, fctx: FunctionContext, decl: ts.Varia
       }
     }
     const wasmType: ValType =
-      initForcesExternref || isNullablePrimitiveType(varType)
+      initForcesExternref || isNullablePrimitiveType(varType) || varBindingNeedsExternrefForUndefined(decl, varType)
         ? { kind: "externref" as const }
         : resolveWasmType(ctx, varType);
     if (initForcesExternref) ctx.externrefAccessorVars.add(name);

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -13900,27 +13900,27 @@ export function collectEnumDeclarations(ctx: CodegenContext, sourceFile: ts.Sour
  * → externref). `resolveWasmType(undefined)` is a numeric (i32) slot, so a later
  * REFERENCE assignment is coerced to i32 `0` and the node ref is dropped.
  *
- * The fix routes a `void`-expression initializer (and any purely `undefined` /
- * `void` declared type) through the SAME externref slot that `= undefined`
- * already gets — a correctness alignment, not new behaviour. Used by BOTH the
- * `var` hoister and the let/const declaration path so the slot type is uniform
- * (a `var` reuses its hoisted slot, so both sites MUST agree).
+ * The fix routes a `void`-expression initializer through the SAME externref slot
+ * that `= undefined` already gets — a correctness alignment, not new behaviour.
+ * Used by BOTH the `var` hoister and the let/const declaration path so the slot
+ * type is uniform (a `var` reuses its hoisted slot, so both sites MUST agree).
+ *
+ * IMPORTANT — trigger on the `void`-EXPRESSION INITIALIZER ONLY, not on a bare
+ * "purely `undefined`/`void` declared type". A binding can be `undefined`-typed
+ * for unrelated reasons (e.g. `const afterA = obj.a` reading an optional
+ * `a?: number` after `delete obj.a`), and those MUST stay a numeric slot — the
+ * delete / optional-property machinery encodes `undefined` as an f64 sNaN
+ * sentinel and relies on the local being f64/i32 so `afterA === undefined`
+ * detects the sentinel. Forcing those to externref boxes the sentinel via
+ * `__box_number` and breaks the `=== undefined` check (regressed
+ * delete-sentinel #1112). The `void 0` expression is the precise, narrow signal
+ * for the acorn evolving-local idiom.
  */
-export function varBindingNeedsExternrefForUndefined(
-  decl: ts.VariableDeclaration | undefined,
-  varType: ts.Type,
-): boolean {
+export function varBindingNeedsExternrefForUndefined(decl: ts.VariableDeclaration | undefined): boolean {
   // `var x = (void 0)` / `var x = void <expr>` — strip parens to find the void.
   let init = decl?.initializer;
   while (init && ts.isParenthesizedExpression(init)) init = init.expression;
-  if (init && ts.isVoidExpression(init)) return true;
-  // Purely `undefined` / `void` declared type (no other union constituents).
-  // Unions like `number | undefined` carry the Union flag, not Undefined, so
-  // they are left alone; genuine numeric/boolean/string locals are untouched.
-  return (
-    (varType.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void)) !== 0 &&
-    (varType.flags & ~(ts.TypeFlags.Undefined | ts.TypeFlags.Void)) === 0
-  );
+  return init !== undefined && ts.isVoidExpression(init);
 }
 
 export function hoistVarDeclarations(
@@ -14075,7 +14075,7 @@ function hoistVarDecl(ctx: CodegenContext, fctx: FunctionContext, decl: ts.Varia
       }
     }
     const wasmType: ValType =
-      initForcesExternref || isNullablePrimitiveType(varType) || varBindingNeedsExternrefForUndefined(decl, varType)
+      initForcesExternref || isNullablePrimitiveType(varType) || varBindingNeedsExternrefForUndefined(decl)
         ? { kind: "externref" as const }
         : resolveWasmType(ctx, varType);
     if (initForcesExternref) ctx.externrefAccessorVars.add(name);

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -3957,7 +3957,24 @@ export function compileArrayConstructorCall(
   const rawTypeArgs = ctx.checker.getTypeArguments(exprType as ts.TypeReference);
   const elemTsType = rawTypeArgs?.[0];
   const untypedElem = !elemTsType || (elemTsType.flags & ts.TypeFlags.Any) !== 0;
-  if (!untypedElem) {
+  // (#2809 PROTOTYPE — partial; see issue) Keep this builtin's vec representation
+  // in lockstep with the `Array<undefined>`/`Array<void>` → externref rule in
+  // `resolveWasmType`'s Array branch (#2806 site #3). Without this,
+  // `Array(undefined, undefined)` builds an i32 vec here (scalar
+  // `resolveWasmType(undefined)` = i32) while every CONSUMER resolves the value's
+  // `Array<undefined>` type to an externref vec — a type/value mismatch that
+  // mis-reads `.length` and trips `array.new_fixed` validation. This fixes the
+  // non-`new` `Array(undefined, …)` case (test262 S15.4.1) and leaves numeric
+  // arrays untouched. NOTE: `new Array(…)` (new-super.ts), sparse `[,,,]` holes,
+  // and `.sort()` still need the SAME alignment — that spread is the
+  // representation-scale decision #2809 carves for the architect.
+  const pureUndefinedVoidElem =
+    !!elemTsType &&
+    (elemTsType.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void)) !== 0 &&
+    (elemTsType.flags & ~(ts.TypeFlags.Undefined | ts.TypeFlags.Void)) === 0;
+  if (pureUndefinedVoidElem) {
+    elemWasm = { kind: "externref" };
+  } else if (!untypedElem) {
     elemWasm = resolveWasmType(ctx, elemTsType!);
   } else if (args.length === 1 && !ts.isSpreadElement(args[0]!)) {
     // #1998: `Array(n)` with an untyped element type is a *sparse* array of `n`

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -42,6 +42,20 @@ function inferArrayVecType(ctx: CodegenContext, decl: ts.VariableDeclaration): V
 
   let inferredElemType: ts.Type | null = null;
 
+  // (#2806) A write whose value type is purely `undefined` / `void` / `null`
+  // must NOT pin the array's element kind to a numeric (i32) vec. The canonical
+  // source is acorn's `var elt = (void 0); elt = <nodeRef>; elts.push(elt)`:
+  // the binding's DECLARED type is `undefined`, but the runtime value is an AST
+  // node reference. Letting `undefined` resolve the element type to i32 lowers
+  // `elts` to an i32 vec, so every pushed reference coerces to i32 `0` — silently
+  // dropping the node refs (#2801, the compiled-acorn `arguments` bug). Skip such
+  // writes exactly like `any` (let a later concrete write pin the kind; if none,
+  // the caller falls through to `any[]` → externref). Genuine numeric pushes
+  // (`number`/`boolean` literals) still pin f64/i32 and keep the fast path.
+  const isUnpinnableWriteType = (t: ts.Type): boolean =>
+    (t.flags & (ts.TypeFlags.Any | ts.TypeFlags.Undefined | ts.TypeFlags.Void | ts.TypeFlags.Null)) !== 0 &&
+    (t.flags & ~(ts.TypeFlags.Any | ts.TypeFlags.Undefined | ts.TypeFlags.Void | ts.TypeFlags.Null)) === 0;
+
   function visit(node: ts.Node) {
     if (inferredElemType) return;
 
@@ -54,7 +68,7 @@ function inferArrayVecType(ctx: CodegenContext, decl: ts.VariableDeclaration): V
       node.left.expression.text === varName
     ) {
       const valType = ctx.checker.getTypeAtLocation(node.right);
-      if (!(valType.flags & ts.TypeFlags.Any)) {
+      if (!isUnpinnableWriteType(valType)) {
         inferredElemType = valType;
         return;
       }
@@ -70,7 +84,7 @@ function inferArrayVecType(ctx: CodegenContext, decl: ts.VariableDeclaration): V
       node.arguments.length >= 1
     ) {
       const valType = ctx.checker.getTypeAtLocation(node.arguments[0]!);
-      if (!(valType.flags & ts.TypeFlags.Any)) {
+      if (!isUnpinnableWriteType(valType)) {
         inferredElemType = valType;
         return;
       }
@@ -98,7 +112,25 @@ function inferArrayVecType(ctx: CodegenContext, decl: ts.VariableDeclaration): V
 const HOST_ARRAY_STRING_METHODS = new Set(["split"]);
 
 function localTypeForDeclaration(ctx: CodegenContext, type: ts.Type): ValType {
-  return isNullablePrimitiveType(type) ? { kind: "externref" } : resolveWasmType(ctx, type);
+  if (isNullablePrimitiveType(type)) return { kind: "externref" };
+  // (#2806) A variable whose declared type is **purely** `undefined` / `void`
+  // must get an externref slot, not a numeric (i32) one. The canonical source is
+  // `var elt = (void 0)` — the `void 0` expression pins the binding to type
+  // `undefined` (unlike `var elt = undefined`, which TS treats as evolving-any).
+  // Lowering that to an i32 local means a later REFERENCE assignment
+  // (`elt = this.parseMaybeAssign(...)`) is coerced to i32 `0` / dropped — the
+  // root of compiled-acorn's `CallExpression.arguments` dropping its node refs
+  // (#2801). An externref slot holds the `undefined` sentinel AND any later ref.
+  // Gated on a pure undefined/void type so genuine numeric/boolean/string locals
+  // are untouched; unions (`number | undefined`) carry the Union flag, not
+  // Undefined, and are left alone.
+  if (
+    (type.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void)) !== 0 &&
+    (type.flags & ~(ts.TypeFlags.Undefined | ts.TypeFlags.Void)) === 0
+  ) {
+    return { kind: "externref" };
+  }
+  return resolveWasmType(ctx, type);
 }
 
 function stripInferenceWrapper(expr: ts.Expression): ts.Expression {

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -113,12 +113,14 @@ const HOST_ARRAY_STRING_METHODS = new Set(["split"]);
 
 function localTypeForDeclaration(ctx: CodegenContext, type: ts.Type, decl?: ts.VariableDeclaration): ValType {
   if (isNullablePrimitiveType(type)) return { kind: "externref" };
-  // (#2806) A `var x = (void 0)` / purely `undefined`|`void` binding needs an
-  // externref slot (the same one `= undefined` gets), so a later reference
-  // assignment isn't coerced to numeric `0`. Shared with the var-hoister so the
-  // hoisted slot and this declaration path agree (a `var` reuses its hoisted
-  // slot). See `varBindingNeedsExternrefForUndefined`.
-  if (varBindingNeedsExternrefForUndefined(decl, type)) return { kind: "externref" };
+  // (#2806) A `var x = (void 0)` binding needs an externref slot (the same one
+  // `= undefined` gets), so a later reference assignment isn't coerced to numeric
+  // `0`. Shared with the var-hoister so the hoisted slot and this declaration path
+  // agree (a `var` reuses its hoisted slot). NARROW: void-EXPRESSION initializer
+  // only — a bare `undefined`-typed binding (e.g. an optional-property read) must
+  // stay numeric for the delete/undefined f64-sentinel machinery (#1112). See
+  // `varBindingNeedsExternrefForUndefined`.
+  if (varBindingNeedsExternrefForUndefined(decl)) return { kind: "externref" };
   return resolveWasmType(ctx, type);
 }
 

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -10,7 +10,7 @@ import { allocLocal, getLocalType } from "../context/locals.js";
 import type { CodegenContext, FunctionContext, NullGuardFact, NullishExclusion } from "../context/types.js";
 import { emitCoercedLocalSet, noJsHost } from "../expressions/helpers.js";
 import { emitUndefined } from "../expressions/late-imports.js";
-import { needsTdzFlag, resolveWasmType } from "../index.js";
+import { needsTdzFlag, resolveWasmType, varBindingNeedsExternrefForUndefined } from "../index.js";
 import { objectLiteralSpreadTakesHostPath, resolveComputedKeyExpression } from "../literals.js";
 import { localGlobalIdx } from "../registry/imports.js";
 import { getOrRegisterArrayType, getOrRegisterSubviewType, getOrRegisterVecType } from "../registry/types.js";
@@ -111,25 +111,14 @@ function inferArrayVecType(ctx: CodegenContext, decl: ts.VariableDeclaration): V
  *  that resolveWasmType would produce for the TS return type (e.g. string[]). */
 const HOST_ARRAY_STRING_METHODS = new Set(["split"]);
 
-function localTypeForDeclaration(ctx: CodegenContext, type: ts.Type): ValType {
+function localTypeForDeclaration(ctx: CodegenContext, type: ts.Type, decl?: ts.VariableDeclaration): ValType {
   if (isNullablePrimitiveType(type)) return { kind: "externref" };
-  // (#2806) A variable whose declared type is **purely** `undefined` / `void`
-  // must get an externref slot, not a numeric (i32) one. The canonical source is
-  // `var elt = (void 0)` — the `void 0` expression pins the binding to type
-  // `undefined` (unlike `var elt = undefined`, which TS treats as evolving-any).
-  // Lowering that to an i32 local means a later REFERENCE assignment
-  // (`elt = this.parseMaybeAssign(...)`) is coerced to i32 `0` / dropped — the
-  // root of compiled-acorn's `CallExpression.arguments` dropping its node refs
-  // (#2801). An externref slot holds the `undefined` sentinel AND any later ref.
-  // Gated on a pure undefined/void type so genuine numeric/boolean/string locals
-  // are untouched; unions (`number | undefined`) carry the Union flag, not
-  // Undefined, and are left alone.
-  if (
-    (type.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void)) !== 0 &&
-    (type.flags & ~(ts.TypeFlags.Undefined | ts.TypeFlags.Void)) === 0
-  ) {
-    return { kind: "externref" };
-  }
+  // (#2806) A `var x = (void 0)` / purely `undefined`|`void` binding needs an
+  // externref slot (the same one `= undefined` gets), so a later reference
+  // assignment isn't coerced to numeric `0`. Shared with the var-hoister so the
+  // hoisted slot and this declaration path agree (a `var` reuses its hoisted
+  // slot). See `varBindingNeedsExternrefForUndefined`.
+  if (varBindingNeedsExternrefForUndefined(decl, type)) return { kind: "externref" };
   return resolveWasmType(ctx, type);
 }
 
@@ -815,7 +804,7 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
                         // the target's closure struct (which traps → null binding).
                         decl.initializer && !ctx.standalone && !noJsHost(ctx) && isBindHostCall(decl.initializer)
                         ? { kind: "externref" as const }
-                        : localTypeForDeclaration(ctx, varType)));
+                        : localTypeForDeclaration(ctx, varType, decl)));
 
     // If this var/let/const was already pre-hoisted at function entry, reuse that slot.
     // For let/const: the pre-pass (hoistLetConstWithTdz) always pre-allocates a slot

--- a/tests/issue-2806.test.ts
+++ b/tests/issue-2806.test.ts
@@ -1,0 +1,148 @@
+// #2806 — a `var x = (void 0)` binding must not drop a later REFERENCE write.
+//
+// Root cause (corrected from the issue's original "untyped [] → f64 vec"
+// framing): acorn's `parseExprList` does
+//
+//   var elt = (void 0);                 // `void 0` pins the TS type to `undefined`
+//   elt = this.parseMaybeAssign(...);    // a node REFERENCE
+//   elts.push(elt);
+//   return elts;
+//
+// Unlike `var x = undefined` / `var x = null` / `var x;` (which TS treats as
+// evolving-any → externref), the `void 0` EXPRESSION pins `elt` to type
+// `undefined`. `resolveWasmType(undefined)` is a numeric (i32) slot, so the
+// `undefined` type dropped the reference at three sites: the local slot, the
+// array element-kind inference, and the function RETURN type. Each coerced the
+// pushed node reference to i32 `0` — so compiled-acorn `parse(...).arguments`
+// came back as `[0, 0]` instead of two `Identifier` nodes (the #2801 blocker).
+//
+// Fix: a `void`-expression initializer (or any purely `undefined`/`void` type)
+// is treated as externref — the same slot `= undefined` already gets — at the
+// var hoister, the let/const declaration path, `inferArrayVecType`, and the
+// `resolveWasmType` Array branch.
+//
+// These tests compile plain-JS source with `skipSemanticDiagnostics: true`
+// (the acorn dogfood compile mode) and round-trip values through the host
+// proxy via `wrapExports` to assert the reference survives.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+
+async function run(src: string): Promise<any> {
+  const result: any = await compile(src, { fileName: "mod.mjs", skipSemanticDiagnostics: true });
+  expect(result.success).toBe(true);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  return wrapExports(instance.exports, { signatures: result.exportSignatures });
+}
+
+describe("#2806 — `var x = (void 0)` must not drop later reference writes", () => {
+  it("pushes a node reference through a void-0 intermediate into an untyped array (the acorn arguments pattern)", async () => {
+    const exp = await run(`
+      function makeId(n) { var id = {}; id.type = "Identifier"; id.name = n; return id; }
+      export function parseExprList() {
+        var elts = [];
+        var elt = (void 0);
+        elt = makeId("bar");
+        elts.push(elt);
+        elt = makeId("baz");
+        elts.push(elt);
+        return elts;
+      }
+    `);
+    const args = exp.parseExprList();
+    expect(Array.isArray(args)).toBe(true);
+    expect(args.length).toBe(2);
+    // The decisive assertion: elements are the pushed Identifier objects, NOT `0`.
+    expect(typeof args[0]).toBe("object");
+    expect(args[0].type).toBe("Identifier");
+    expect(args[0].name).toBe("bar");
+    expect(args[1].type).toBe("Identifier");
+    expect(args[1].name).toBe("baz");
+  });
+
+  it("preserves the reference for a conditionally-assigned void-0 local", async () => {
+    const exp = await run(`
+      function makeId(n) { var id = {}; id.type = "Identifier"; id.name = n; return id; }
+      export function build() {
+        var elts = [];
+        for (var i = 0; i < 1; i++) {
+          var elt = (void 0);
+          elt = makeId("x");
+          elts.push(elt);
+        }
+        return elts;
+      }
+    `);
+    const a = exp.build();
+    expect(a.length).toBe(1);
+    expect(a[0].type).toBe("Identifier");
+    expect(a[0].name).toBe("x");
+  });
+
+  it("PRESERVES the all-numeric fast path — an untyped array of numbers stays numeric", async () => {
+    // The fix must NOT widen genuinely-numeric arrays. `var a = []; a.push(1)`
+    // must keep round-tripping numbers (and use the f64/i32 vec backing).
+    const exp = await run(`
+      export function nums() {
+        var a = [];
+        for (var i = 0; i < 4; i++) a.push(i * 2);
+        return a;
+      }
+    `);
+    const a = exp.nums();
+    expect(a.length).toBe(4);
+    expect(a[0]).toBe(0);
+    expect(a[1]).toBe(2);
+    expect(a[2]).toBe(4);
+    expect(a[3]).toBe(6);
+  });
+
+  it("PRESERVES a numeric accumulator threaded through a void-0 local", async () => {
+    // The pushed value is a real number (not a reference) — the array must
+    // stay numeric and read back the numbers, not box them away.
+    const exp = await run(`
+      export function sums() {
+        var out = [];
+        var v = (void 0);
+        v = 10;
+        out.push(v);
+        v = 20;
+        out.push(v);
+        return out;
+      }
+    `);
+    const a = exp.sums();
+    expect(a.length).toBe(2);
+    expect(a[0]).toBe(10);
+    expect(a[1]).toBe(20);
+  });
+
+  it("round-trips an arguments array (built via a void-0 push) stored on an object field (the acorn CallExpression shape)", async () => {
+    // acorn's `node.arguments = this.parseExprList(...)` — the array of node
+    // refs is assigned to a dynamic object field, then read back by the host.
+    const exp = await run(`
+      function makeId(n) { var id = {}; id.type = "Identifier"; id.name = n; return id; }
+      export function build() {
+        var node = {};
+        node.type = "CallExpression";
+        var elts = [];
+        var elt = (void 0);
+        elt = makeId("bar");
+        elts.push(elt);
+        elt = makeId("baz");
+        elts.push(elt);
+        node.arguments = elts;
+        return node;
+      }
+    `);
+    const node = exp.build();
+    expect(node.type).toBe("CallExpression");
+    expect(Array.isArray(node.arguments)).toBe(true);
+    expect(node.arguments.length).toBe(2);
+    expect(node.arguments[0].type).toBe("Identifier");
+    expect(node.arguments[0].name).toBe("bar");
+    expect(node.arguments[1].name).toBe("baz");
+  });
+});

--- a/tests/issue-2809.test.ts
+++ b/tests/issue-2809.test.ts
@@ -1,0 +1,87 @@
+// #2809 — uniform `undefined[]`/`void[]` externref representation.
+//
+// Carved from #2806: an `any[]`/`undefined[]` receiver lowers to an externref
+// vec (the uniform externref-undefined representation, #2806 site #3). The
+// construction/method sites must derive their element rep from that externref
+// vec — emitting `$Hole`/`undefined` for holes/undefined, never the f64 sNaN
+// sentinel — so the type-side (consumers, `.length`) and value-side
+// (construction, method backing) agree.
+//
+// Site C regression fixed here: `compileArrayReduceRight` over a sparse
+// (`[, , ,]`) externref vec with NO initial value. The seed/loop map a `$Hole`
+// element to `undefined` via `holeToUndefinedInstrs`, which emits `__get_undefined`
+// into a DETACHED body — its internal `flushLateImportShifts` patched that
+// detached array, not the real body holding the callback closure's `ref.func`.
+// `__get_undefined` first registering there silently consumed the late-import
+// funcIdx shift, leaving the closure `ref.func` pointing at the wrong function →
+// `call_ref` dereferenced a stale/null funcref and trapped ("dereferencing a
+// null pointer"). Pre-ensuring `__get_undefined` before the closure is emitted
+// fixes the desync (reference_1461 class). Regressed test262:
+// `built-ins/Array/prototype/reduceRight/15.4.4.22-8-c-4.js`.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runRet(src: string): Promise<unknown> {
+  const r: any = await compile(src, { fileName: "test.ts", skipSemanticDiagnostics: true });
+  expect(r.binary).toBeTruthy();
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  const imp: any = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imp);
+  imp.setExports?.(instance.exports);
+  return (instance.exports as any).test();
+}
+
+describe("#2809 — undefined[] externref representation", () => {
+  it("reduceRight (no initial value) over a sparse hole array does not trap", async () => {
+    // The regressed sparse-`[,,,]` reduceRight null-deref.
+    expect(
+      await runRet(`export function test(): number {
+        var arr = [, , ,];
+        arr.reduceRight(function () {});
+        return 1;
+      }`),
+    ).toBe(1);
+  });
+
+  it("reduceRight (no initial value, 2-arg cb) over a sparse hole array does not trap", async () => {
+    expect(
+      await runRet(`export function test(): number {
+        var arr = [, , ,];
+        arr.reduceRight(function (a: any, b: any) { return a; });
+        return 1;
+      }`),
+    ).toBe(1);
+  });
+
+  it("Array(undefined, undefined).length === 2", async () => {
+    expect(await runRet(`export function test(): number { return Array(undefined, undefined).length; }`)).toBe(2);
+  });
+
+  it("new Array(undefined, undefined).length === 2 and sort() preserves length", async () => {
+    expect(await runRet(`export function test(): number { return new Array(undefined, undefined).length; }`)).toBe(2);
+    expect(
+      await runRet(`export function test(): number { return new Array(undefined, undefined).sort().length; }`),
+    ).toBe(2);
+  });
+
+  it("new Array(undefined, undefined) elements read back as undefined", async () => {
+    expect(
+      await runRet(
+        `export function test(): number { var a: any[] = new Array(undefined, undefined); return (typeof a[0] === "undefined" && typeof a[1] === "undefined") ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("numeric arrays and reduceRight are untouched", async () => {
+    expect(await runRet(`export function test(): number { return Array(0, 1, 0, 1).length; }`)).toBe(4);
+    expect(await runRet(`export function test(): number { return [1, 2, 3, 4].reduceRight((a, b) => a + b); }`)).toBe(
+      10,
+    );
+    expect(
+      await runRet(
+        `export function test(): number { var a = [3, 1, 2].sort(); return a[0] * 100 + a[1] * 10 + a[2]; }`,
+      ),
+    ).toBe(123);
+  });
+});


### PR DESCRIPTION
## Summary

Finishes #2809 (Option 2: uniform `undefined[]`/`void[]` → externref representation), the last fix on the **"make compiled acorn work"** goal. Builds on the #2806 foundation (sites #1/#2/#3 + Site A + Site B) carried by the base branch `issue-2809-array-rep-impl`. **Supersedes the PARKED #2284**; closes the #2801/#2806 acorn-arguments milestone path.

## What changed

The only remaining code change is **Site C**, and the root cause turned out to be narrower (and different) than the spec's "construction emits sNaN" framing — the literal hole path already emitted the `$Hole` sentinel correctly (#2001 S1). The real regression was in **`compileArrayReduceRight`** (`src/codegen/array-methods.ts`): a sparse `[,,,]` externref vec `reduceRight` with **no initial value** trapped ("dereferencing a null pointer", regressed `built-ins/Array/prototype/reduceRight/15.4.4.22-8-c-4.js`).

**Root cause — late-import funcIdx shift (reference_1461 class), not a representation bug.** The no-init seed and per-iteration load map a `$Hole`→`undefined` via `holeToUndefinedInstrs`, which runs `emitUndefined` into a **detached** body. `emitUndefined`'s internal `flushLateImportShifts` therefore patched that detached array, not the real `fctx.body` holding the callback closure's `ref.func`. When `__get_undefined` was *first* registered there, the late-import funcIdx shift was silently consumed and the closure `ref.func` was left pointing at the wrong (pre-shift) function → `call_ref` dereferenced a stale/null funcref and trapped. An *explicit* `[undefined, undefined]` array did NOT regress (it registers `__get_undefined` during construction, before the closure is emitted) — that asymmetry was the diagnostic key.

**Fix:** pre-ensure `__get_undefined` + flush against the real body at the top of `compileArrayReduceRight`, *before* `setupArrayCallback` emits the closure `ref.func`. Later `holeToUndefinedInstrs` registrations are then idempotent. Surgical — it relocates the function's existing pre-ensure block earlier (net +21/−7 in one file).

- **Site D** (sort/toSorted backing) and **Site E** (indexed read/write): **verified, no change needed** — `new Array(undefined,undefined).sort()` already builds an externref vec via Site B and passes; indexed reads behave byte-identically to `main`.

## Validation (local)

- 4 regressed test262 tests PASS: `S15.4.1_A2.1_T1`, `S15.4.2.1_A2.1_T1`, `prototype/sort/S15.4.4.11_A1.3_T1`, `prototype/reduceRight/15.4.4.22-8-c-4`.
- **acorn milestone HOLDS**: compiled-acorn `parse("foo(bar,baz)").arguments` → `["Identifier","Identifier"]` (full pinned acorn, 85 s compile).
- `tests/issue-2806.test.ts` green (5/5); new `tests/issue-2809.test.ts` green (6/6); broad array-method smoke clean; numeric arrays untouched.

Full `merge_group` + standalone-floor validates conformance (representation-scale change, reference_2379 hazard — gate requires zero net regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)