### PR TITLE
fix(#2816): NM smoke scale-test expects stripped CLI output name

### DIFF
--- a/examples/native-messaging/scale-test.mjs
+++ b/examples/native-messaging/scale-test.mjs
@@ -201,7 +201,9 @@ function buildVariant(v) {
   const js = join(WORK, `${v.name}.js`);
   bunBundle(v.src, js, v.bunExtra);
   js2wasm(js, v.js2wasmExtra);
-  const wasm = join(WORK, `${v.name}.js.wasm`);
+  // #2816 stripped the source extension from CLI output names, so compiling
+  // `<name>.js -o WORK` now writes `<name>.wasm`, not `<name>.js.wasm`.
+  const wasm = join(WORK, `${v.name}.wasm`);
   if (!statSync(wasm, { throwIfNoEntry: false })) throw new Error(`${wasm} not produced`);
   return wasm;
 }


### PR DESCRIPTION
**Regression hotfix.** #2816 (merged, unreleased — NOT in 0.59.2) changed the CLI to strip the source extension from output names, so `js2wasm <name>.js -o WORK` now writes `<name>.wasm`, not `<name>.js.wasm`. `examples/native-messaging/scale-test.mjs` still expected `<name>.js.wasm`, so all four variant builds reported 'not produced' → the `native-messaging-smoke` job went **red on main and on every PR that merged main** (3 PRs blocked, e.g. runs 28346080776 / 28345983248).

One-line fix: expect the post-#2816 `<name>.wasm` name. **Verified locally** — scale-test.mjs builds all four hosts and round-trips byte-exact under real wasmtime 46.0.1 at 1/64/128/256 MiB.

dev-2816's blast-radius audit caught 6 `tests/` files but missed this example script (it passes `-o`, so the *dir* was fine — the *name* strip wasn't considered).