### PR TITLE
feat(#2827): statusline + dashboard render sprint:current window (finish #2751)

### DIFF
--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -323,10 +323,17 @@ if [ -z "$in_worktree" ] && [ "$branch" = "main" ]; then
     # stale) pre-built cache directly (deduplicated, wont-fix counted as done).
     sprints_json="/workspace/website/dashboard/data/sprints.json"
     if [ -f "$sprints_json" ]; then
+      # Prefer the live `current` window (#2751); else the latest active numbered
+      # sprint. The label is "cur" for the current window, else its number.
       sprint_data=$(jq -r '
-        [ .[] | select(.sprintNumber != null and .isClosed == false and .isPlanning == false) ]
-        | sort_by(.sprintNumber) | last
-        | "\(.sprintNumber) \(.completedIssueIds | length) \(.issueIds | length)"
+        ( ( [ .[] | select(.isCurrent == true) ] | first )
+          // ( [ .[] | select(.sprintNumber != null and .isClosed == false and .isPlanning == false) ]
+               | sort_by(.sprintNumber) | last ) ) as $s
+        | if $s == null then empty
+          else (if $s.isCurrent then "cur" else ($s.sprintNumber | tostring) end)
+               + " " + ($s.completedIssueIds | length | tostring)
+               + " " + ($s.issueIds | length | tostring)
+          end
       ' "$sprints_json" 2>/dev/null)
       if [ -n "$sprint_data" ]; then
         sprint_n=$(echo "$sprint_data" | awk '{print $1}')
@@ -337,13 +344,19 @@ if [ -z "$in_worktree" ] && [ "$branch" = "main" ]; then
   fi
   if [ -n "$sprint_n" ] && [ "$sprint_total" -gt 0 ]; then
     sprint_pct=$((sprint_done * 100 / sprint_total))
-    awk -v p="$sprint_pct" -v n="$sprint_n" -v done="$sprint_done" -v total="$sprint_total" 'BEGIN {
+    # Numbered sprint → "sN"; the live `current` window emits the non-numeric
+    # token "cur" → render it as-is (no `s` prefix, and never coerce to s0).
+    case "$sprint_n" in
+      ''|*[!0-9]*) sprint_label="$sprint_n" ;;
+      *)           sprint_label="s$sprint_n" ;;
+    esac
+    awk -v p="$sprint_pct" -v lbl="$sprint_label" -v done="$sprint_done" -v total="$sprint_total" 'BEGIN {
       if (p >= 67)      { fill=42;         fg=30 }
       else if (p >= 33) { fill=43;         fg=30 }
       else              { fill="48;5;196"; fg=30 }
       width = 12
       filled = int(p * width / 100)
-      label = sprintf(" %d/%d s%d", done, total, n)
+      label = sprintf(" %d/%d %s", done, total, lbl)
       bar = ""
       for (i = 0; i < width; i++) bar = bar " "
       bar = label substr(bar, length(label) + 1)

--- a/plan/issues/2827-statusline-dashboard-render-sprint-current.md
+++ b/plan/issues/2827-statusline-dashboard-render-sprint-current.md
@@ -3,15 +3,16 @@ id: 2827
 title: "Statusline + dashboard kanban ignore `sprint: current` (unfinished #2751 acceptance criterion)"
 parent: 2751
 related: [2751, 2750]
-status: ready
+status: done
 created: 2026-06-29
+completed: 2026-06-29
 priority: medium
 feasibility: medium
 reasoning_effort: medium
 task_type: chore
 area: tooling
 goal: maintainability
-sprint: Backlog
+sprint: current
 horizon: s
 architect_spec: done
 ---
@@ -160,9 +161,27 @@ highest-priority-status dedupe at build-data.js:173-181 should cover it; verify)
 - No regression for repos/branches still on the numbered-only model (empty
   `current` bucket → previous behaviour).
 
-## Notes
+## Resolution (implemented in this PR)
 
-- **No source change in this issue** — spec only (this PR adds the issue file
-  alone). Do not edit `statusline-sprint.mjs` / `build-data.js` / `index.html`
-  here; that is the implementation issue, scheduled later.
-- In-lane tooling; no dependency on codegen / substrate work.
+Both halves landed together (issue file + source):
+
+- **Statusline** (`scripts/statusline-sprint.mjs`): added a `current` bucket —
+  the remote grep and local scan now recognize `sprint: current`, and when any
+  `current` work exists it is emitted as the active window with the `cur` token
+  (`--porcelain` → `cur <done> <total>`); numbered sprints remain the fallback
+  when there is no `current` work. `.claude/statusline-command.sh` renders the
+  badge label as `cur <done>/<total>` for the non-numeric token (numeric
+  sprints still render `s<N> …`), and its `sprints.json` last-resort fallback
+  emits `cur` for the `isCurrent` entry. Budget chips (`wkly`/`d left`)
+  unchanged.
+- **Dashboard** (`website/dashboard/build-data.js`): `sprint: current` issues are
+  routed into a synthetic active-window sprint object
+  (`{ name:"current", sprintNumber: maxNumbered+1, isCurrent:true,
+  isClosed:false, isPlanning:false, issueIds, completedIssueIds }`) appended to
+  `sprints.json` instead of being dropped. `website/dashboard/index.html`:
+  `getLatestActiveSprint` prefers the `isCurrent` window and the sprint dropdown
+  labels it `current`; the existing `Number.isFinite(sprintNumber)` filters
+  already include it (the synthetic carries a finite number).
+
+In-lane tooling; no dependency on codegen / substrate work. Numbered-sprint
+fallback preserved (empty `current` bucket → previous behaviour).

--- a/scripts/statusline-sprint.mjs
+++ b/scripts/statusline-sprint.mjs
@@ -49,7 +49,7 @@ function sprintFromRemote(remote) {
   // git grep output format: <ref>:<path>:<matched-line>
   const grepResult = spawnSync(
     "git",
-    ["-C", ROOT, "grep", "-E", "^(sprint: [0-9]|status: )", ref, "--", "plan/issues/*.md"],
+    ["-C", ROOT, "grep", "-E", "^(sprint: [0-9]|sprint: current|status: )", ref, "--", "plan/issues/*.md"],
     { encoding: "utf8", timeout: 8000, maxBuffer: 16 * 1024 * 1024 },
   );
 
@@ -58,7 +58,7 @@ function sprintFromRemote(remote) {
 
   // Parse output lines: <ref>:<path>:<content>
   // Split only on the first two colons (paths never contain colons on Linux).
-  const byFile = new Map(); // path -> { sprint?, status? }
+  const byFile = new Map(); // path -> { sprint?, current?, status? }
   for (const line of grepResult.stdout.split("\n")) {
     if (!line) continue;
     const c1 = line.indexOf(":");
@@ -76,9 +76,10 @@ function sprintFromRemote(remote) {
 
     const file = byFile.get(path) ?? {};
     // First-wins: frontmatter appears before body text
-    if (file.sprint === undefined) {
+    if (file.sprint === undefined && file.current === undefined) {
       const m = content.match(/^sprint:\s*(\d+)\s*$/);
       if (m) file.sprint = Number(m[1]);
+      else if (/^sprint:\s*current\s*$/.test(content)) file.current = true;
     }
     if (file.status === undefined) {
       const m = content.match(/^status:\s*(\S+)/);
@@ -110,9 +111,17 @@ function sprintFromRemote(remote) {
     }
   }
 
-  // Build sprint buckets from the parsed file map.
+  // Build sprint buckets from the parsed file map. The rolling budget-window
+  // model (#2751) tags live work `sprint: current`; that is the active window
+  // and takes precedence over any frozen numbered sprint.
   const bySprint = new Map(); // sprintNum -> { total, done }
-  for (const { sprint, status } of byFile.values()) {
+  const current = { total: 0, done: 0 }; // the `sprint: current` window
+  for (const { sprint, current: isCurrent, status } of byFile.values()) {
+    if (isCurrent) {
+      current.total++;
+      if (status === "done" || status === "wont-fix") current.done++;
+      continue;
+    }
     if (!sprint) continue;
     const bucket = bySprint.get(sprint) ?? { total: 0, done: 0 };
     bucket.total++;
@@ -120,9 +129,12 @@ function sprintFromRemote(remote) {
     bySprint.set(sprint, bucket);
   }
 
+  // The live `current` window wins when it has any work.
+  if (current.total > 0) return { sprint: "cur", done: current.done, total: current.total };
+
   if (bySprint.size === 0) return null;
 
-  // Current sprint = highest numbered sprint that is not inactive.
+  // Fallback: highest numbered sprint that is not inactive.
   const nums = [...bySprint.keys()].filter((n) => !inactive.has(n)).sort((a, b) => b - a);
   const sprintNum = nums[0] ?? 0;
   if (!sprintNum) return null;
@@ -137,15 +149,18 @@ function fromJson() {
   if (!existsSync(SPRINTS_JSON)) return null;
   try {
     const sprints = JSON.parse(readFileSync(SPRINTS_JSON, "utf8"));
-    // Active sprint: not closed, not planning (same logic as dashboard)
-    const active = sprints
-      .filter((s) => Number.isFinite(s.sprintNumber) && !s.isClosed && !s.isPlanning)
-      .sort((a, b) => a.sprintNumber - b.sprintNumber)
-      .at(-1);
+    // Prefer the live `current` window (#2751); else the latest active numbered
+    // sprint (not closed, not planning — same logic as the dashboard).
+    const active =
+      sprints.find((s) => s.isCurrent) ??
+      sprints
+        .filter((s) => Number.isFinite(s.sprintNumber) && !s.isClosed && !s.isPlanning)
+        .sort((a, b) => a.sprintNumber - b.sprintNumber)
+        .at(-1);
     if (!active) return null;
     const total = (active.issueIds || []).length;
     const done = (active.completedIssueIds || []).length;
-    return { sprint: active.sprintNumber, done, total };
+    return { sprint: active.isCurrent ? "cur" : active.sprintNumber, done, total };
   } catch {
     return null;
   }
@@ -154,14 +169,16 @@ function fromJson() {
 const ISSUE_FILE_RE = /^\d+[a-z]?(?:[-_].+)?\.md$/i;
 const NON_ISSUE = new Set(["backlog.md", "index.md", "SCHEMA.md", "log.md", "1578-test262-analysis.md"]);
 
-// Scan the flat issue tree once, bucketing by numeric `sprint:` value.
+// Scan the flat issue tree once, bucketing by numeric `sprint:` value plus the
+// live `sprint: current` window (#2751).
 function scanFlatTree() {
   const bySprint = new Map(); // sprintNum -> { total, done }
+  const current = { total: 0, done: 0 }; // the `sprint: current` window
   let names = [];
   try {
     names = readdirSync(ISSUES_DIR);
   } catch {
-    return bySprint;
+    return { bySprint, current };
   }
   for (const f of names) {
     if (NON_ISSUE.has(f) || !ISSUE_FILE_RE.test(f)) continue;
@@ -172,14 +189,20 @@ function scanFlatTree() {
       continue;
     }
     const sprintRaw = content.match(/^sprint:\s*(\S+)/m)?.[1] ?? "";
+    const isDone = /^status:\s*(done|wont-fix)\b/m.test(content);
+    if (sprintRaw === "current") {
+      current.total++;
+      if (isDone) current.done++;
+      continue;
+    }
     if (!/^\d+$/.test(sprintRaw)) continue; // skip Backlog / 0 / unset
     const n = Number(sprintRaw);
     const bucket = bySprint.get(n) ?? { total: 0, done: 0 };
     bucket.total++;
-    if (/^status:\s*(done|wont-fix)\b/m.test(content)) bucket.done++;
+    if (isDone) bucket.done++;
     bySprint.set(n, bucket);
   }
-  return bySprint;
+  return { bySprint, current };
 }
 
 let _flatCache = null;
@@ -213,15 +236,20 @@ function inactiveSprintNumbers() {
   return out;
 }
 
+// Returns "cur" when the live `current` window has work, else the highest
+// non-inactive numbered sprint (or 0).
 function currentSprintLocal() {
-  const buckets = flatTree();
+  const { bySprint, current } = flatTree();
+  if (current.total > 0) return "cur";
   const inactive = inactiveSprintNumbers();
-  const nums = [...buckets.keys()].filter((n) => !inactive.has(n)).sort((a, b) => b - a);
+  const nums = [...bySprint.keys()].filter((n) => !inactive.has(n)).sort((a, b) => b - a);
   return nums[0] ?? 0;
 }
 
 function sprintProgressLocal(n) {
-  return flatTree().get(n) ?? { done: 0, total: 0 };
+  const { bySprint, current } = flatTree();
+  if (n === "cur") return current;
+  return bySprint.get(n) ?? { done: 0, total: 0 };
 }
 
 // ── Main ────────────────────────────────────────────────────────────────────
@@ -283,4 +311,6 @@ const [r, g, b] = interpolateColor(pct);
 const colored = `\x1b[38;2;${r};${g};${b}m`;
 const reset = "\x1b[0m";
 
-process.stdout.write(`${colored}s${sprint} ${done}/${total}${reset}`);
+// Numbered sprint → "sN"; the live `current` window → "cur" (no `s` prefix).
+const sprintLabel = sprint === "cur" ? "cur" : `s${sprint}`;
+process.stdout.write(`${colored}${sprintLabel} ${done}/${total}${reset}`);

--- a/website/dashboard/build-data.js
+++ b/website/dashboard/build-data.js
@@ -218,7 +218,17 @@ const allIssueEntries = [
 ];
 const issueIdsBySprint = new Map();
 const completedIssueIdsBySprint = new Map();
+// The rolling budget-window model (#2751) tags live work `sprint: current` — a
+// non-numeric value the numbered bucketing below would drop. Collect it into a
+// dedicated active-window bucket and emit a synthetic sprint object afterwards.
+const currentIssueIds = new Set();
+const currentCompletedIssueIds = new Set();
 for (const issue of allIssueEntries) {
+  if (issue.sprint === "current") {
+    currentIssueIds.add(String(issue.id));
+    if (issue.status === "done" || issue.status === "wont-fix") currentCompletedIssueIds.add(String(issue.id));
+    continue;
+  }
   const sprintNumber = extractSprintNumberFromLabel(issue.sprint);
   if (!Number.isFinite(sprintNumber)) continue;
   if (!issueIdsBySprint.has(sprintNumber)) issueIdsBySprint.set(sprintNumber, new Set());
@@ -364,6 +374,34 @@ for (const sprint of sprints) {
     // Legacy sprint with no status field: closed if at or below the explicit threshold.
     sprint.isClosed = sprint.sprintNumber <= explicitlyClosedMax || sprint.explicitCarryOver;
   }
+}
+
+// Synthetic active-window sprint for the rolling `sprint: current` model (#2751).
+// It has no `sprints/<N>.md` doc, so it is built here from the collected current
+// bucket and appended with a finite sentinel number (highest numbered sprint + 1)
+// so the dashboard's `Number.isFinite(sprintNumber)` filters include it and
+// `getLatestActiveSprint` selects it. `isCurrent` lets consumers label it "current".
+if (currentIssueIds.size > 0) {
+  const maxSprintNumber = sprints.reduce(
+    (m, s) => Math.max(m, Number.isFinite(s.sprintNumber) ? s.sprintNumber : 0),
+    0,
+  );
+  const sortIds = (a, b) => String(a).localeCompare(String(b), undefined, { numeric: true });
+  sprints.push({
+    name: "current",
+    sprintNumber: maxSprintNumber + 1,
+    status: "active",
+    date: "",
+    baseline: "",
+    result: "",
+    issueCount: currentIssueIds.size,
+    issueIds: [...currentIssueIds].sort(sortIds),
+    completedIssueIds: [...currentCompletedIssueIds].sort(sortIds),
+    explicitCarryOver: false,
+    isCurrent: true,
+    isClosed: false,
+    isPlanning: false,
+  });
 }
 writeFileSync(join(OUT, "sprints.json"), JSON.stringify(sprints, null, 2));
 console.log(`Sprints: ${sprints.length} entries`);

--- a/website/dashboard/index.html
+++ b/website/dashboard/index.html
@@ -907,6 +907,11 @@
       }
 
       function getLatestActiveSprint(sprints) {
+        // The rolling budget-window model (#2751) tags live work `sprint: current`;
+        // build-data emits it as a synthetic `isCurrent` window which is the active
+        // board, taking precedence over any frozen numbered sprint.
+        const current = sprints.find((s) => s.isCurrent);
+        if (current) return current;
         return (
           [...sprints]
             .filter((s) => Number.isFinite(s.sprintNumber))
@@ -1202,7 +1207,7 @@
 
         sprintSelect.innerHTML = sprintOptions
           .filter((s) => Number.isFinite(s.sprintNumber))
-          .map((s) => `<option value="${s.sprintNumber}">${s.sprintNumber}</option>`)
+          .map((s) => `<option value="${s.sprintNumber}">${s.isCurrent ? "current" : s.sprintNumber}</option>`)
           .join("");
 
         if (currentSelectedSprint) {


### PR DESCRIPTION
Lands the **implementation** for #2827 (finishes the outstanding #2751 acceptance criterion). The earlier spec-capture PR #2303 auto-merged with only the issue file (`status: ready`, `sprint: Backlog`) before the source landed; this PR carries the source changes and flips the issue to `status: done` / `sprint: current`.

The terminal statusline and the website dashboard/kanban recognized **numbered** sprints only and silently dropped `sprint: current` (the rolling budget-window live work). Now both render the `current` window.

**Source (generated dashboard data intentionally NOT committed — regenerated at deploy via `deploy-pages.yml`; no CI freshness gate):**
- `scripts/statusline-sprint.mjs` — `current` bucket in the remote grep + local scan; when current work exists it is the active window, emitted as the `cur` token (`--porcelain` → `cur <done> <total>`); numbered sprints remain the fallback.
- `.claude/statusline-command.sh` — badge renders `cur <done>/<total>` for the non-numeric token (numeric → `s<N>`, never coerced to `s0`); `sprints.json` fallback prefers/labels the `isCurrent` entry. Budget chips unchanged.
- `website/dashboard/build-data.js` — routes `sprint: current` issues into a synthetic active-window sprint object (`isCurrent`, finite sentinel number) instead of dropping them.
- `website/dashboard/index.html` — `getLatestActiveSprint` prefers the `isCurrent` window; sprint dropdown labels it `current`.

**Scoped validation:**
- `node scripts/statusline-sprint.mjs --porcelain` → `cur 52 101` (was `67 23 40`).
- `node website/dashboard/build-data.js` → `sprints.json` current entry `{ isCurrent:true, total:102, done:53 }`, no choke.
- `pnpm run build:pages` exit 0; `format:check` / `lint` / `check:issues` / `check:issue-ids:against-main` / `check:issue-spec-coverage` green.
- Numbered-sprint fallback preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS