### PR TITLE
release: v0.59.3

### DIFF
--- a/docs/releases/0.59.3.md
+++ b/docs/releases/0.59.3.md
@@ -1,0 +1,40 @@
+# v0.59.3
+
+_Released 2026-06-29._
+
+Patch release — Native-Messaging/CLI polish from the loopdive/js2#389 thread,
+plus two language-semantics fixes. No new features.
+
+## CLI & Native Messaging (loopdive/js2#389)
+
+- **#2816** — `js2wasm <input>` without `-o` now writes output to the **current
+  working directory** (was: next to the input), and strips the full source
+  extension from the output name (`nm_deno.js` → `nm_deno.wasm`, not
+  `nm_deno.js.wasm`). Compiling an example that ships inside an installed package
+  no longer pollutes `node_modules`.
+- **#2817** — stop emitting a dead `env.__wasiStdinStop` host import under
+  `--target wasi`. It was already inline-lowered at every call site (a native
+  `global.set`, no host call) but missing from the reactor-intrinsics skip-set,
+  so it re-registered as a dead import and fired a spurious
+  "host import not on the dual-mode allowlist" warning on
+  `nm_js2wasm_node_process.ts`. No host import, no allowlist growth.
+- **#2821** — harden the `issue-2684` deno-stdio test against a flaky `EPIPE`: it
+  now feeds wasmtime's stdin from a temp-file fd instead of a parent-owned pipe,
+  so a child that hits EOF before the parent finishes writing can't break the
+  pipe. Test-only; the host round-trips deterministically.
+- **#2816 (follow-up)** — `examples/native-messaging/scale-test.mjs` now expects
+  the post-#2816 `<name>.wasm` output name (the smoke harness still looked for
+  `<name>.js.wasm`).
+
+All four Native-Messaging hosts continue to round-trip byte-exact under real
+wasmtime 46.0.1 at 1 / 64 / 128 / 256 MiB.
+
+## Language fixes
+
+- **#2726** — sloppy-mode `delete` of an unresolvable identifier returns `true`
+  (including inside inlined `eval` bodies), per spec.
+- **#2814** — tighten the block-`let` slot-reuse gate so a hoisted function
+  declaration that captures a block-scoped `let` reads the correct slot
+  (byte-identity preserved for the affected async cases).
+
+**Full changelog:** https://github.com/loopdive/js2/compare/v0.59.2...v0.59.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.59.2",
+  "version": "0.59.3",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js2wasm",
-  "version": "0.59.2",
+  "version": "0.59.3",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC (unscoped proxy for @loopdive/js2)",
   "keywords": [
     "webassembly",


### PR DESCRIPTION
Patch (no `feat()` since 0.59.2). Bundles the loopdive/js2#389 CLI/Native-Messaging follow-ups — **#2816** (default output dir → cwd + strip source extension), **#2817** (drop the dead `env.__wasiStdinStop` import under `--target wasi`), **#2821** (harden the deno-stdio EPIPE flake), and the **#2304** smoke-harness name fix — plus language fixes **#2726** (sloppy unresolvable-`delete`) and **#2814** (block-`let` slot-reuse). Notes: `docs/releases/0.59.3.md`. After merge, push tag `v0.59.3` to publish.