### PR TITLE
chore: acorn real-world differential — mark walls #2681/#2686/#2801 done

### DIFF
--- a/plan/issues/2681-acorn-parse-10th-wall-unexpected-on-name.md
+++ b/plan/issues/2681-acorn-parse-10th-wall-unexpected-on-name.md
@@ -1,7 +1,8 @@
 ---
 id: 2681
 title: "[ARCH] acorn parse() 10th wall — identifier expression-statement throws (unexpected() on a `name` token); root cause = Parser not reconstructed (new this() in static methods), substrate-scoped"
-status: in-progress
+status: done
+completed: 2026-06-29
 assignee: ttraenkler/sendev-substrate
 sprint: current
 created: 2026-06-26
@@ -19,6 +20,14 @@ origin: "Surfaced by dev-acorn fixing #2664 (under-applied dynamic method dispat
 ---
 
 # #2681 — acorn `parse()` 10th wall: identifier path throws `unexpected()` on a `name` token
+
+> **Resolution (2026-06-29).** Resolved by the acorn Parser-reconstruction
+> substrate chain (#2264/#2272/#2275/#2301). Verified on freshly-compiled pinned
+> acorn@8.16.0 (`skipSemanticDiagnostics: true`): `parse("x")` → `ExpressionStatement`
+> and `parse("var x = 1;")` → `VariableDeclaration` (both previously threw a
+> `WebAssembly.Exception`). The identifier `name`-token wall is gone. (The next,
+> separate wall — function/arrow bodies throw `illegal cast` at
+> `__set_member_labels` — is tracked under the still-open #1712.)
 
 ## Context (the acorn dogfood chain)
 

--- a/plan/issues/2686-acorn-binary-expression-throws.md
+++ b/plan/issues/2686-acorn-binary-expression-throws.md
@@ -1,7 +1,8 @@
 ---
 id: 2686
 title: "[ARCH] acorn parse() — binary-expression statement throws (parse(\"1 + 2 * 3;\") → WebAssembly.Exception); same root as #2681 (Parser not reconstructed), substrate-scoped"
-status: in-progress
+status: done
+completed: 2026-06-29
 assignee: ttraenkler/sendev-substrate
 sprint: current
 created: 2026-06-26
@@ -19,6 +20,14 @@ origin: "Surfaced re-verifying the acorn dogfood after #2085 fixed the 9th-wall 
 ---
 
 # #2686 — acorn `parse()`: binary-expression statement throws
+
+> **Resolution (2026-06-29).** Resolved by the acorn Parser-reconstruction
+> substrate chain (#2264/#2272/#2275/#2301) — same root as #2681. Verified on
+> freshly-compiled pinned acorn@8.16.0 (`skipSemanticDiagnostics: true`):
+> `parse("1 + 2 * 3;")` → `ExpressionStatement` (no throw), where it previously
+> threw a `WebAssembly.Exception`. The `parseExprOp` operator-precedence path now
+> runs end-to-end. (The remaining function/arrow-body wall is tracked under the
+> still-open #1712.)
 
 ## Context (the acorn dogfood chain → #1712)
 

--- a/plan/issues/2801-callexpression-arguments-marshal-empty-object.md
+++ b/plan/issues/2801-callexpression-arguments-marshal-empty-object.md
@@ -1,7 +1,8 @@
 ---
 id: 2801
 title: "[SENIOR-DEV ONLY] compiled-acorn CallExpression `arguments` marshals as `{}` not an array (host vec→array gap)"
-status: blocked
+status: done
+completed: 2026-06-29
 assignee: ttraenkler/unassigned
 sprint: current
 priority: high
@@ -20,6 +21,14 @@ blocks: []
 ---
 
 # #2801 — compiled-acorn CallExpression `arguments` marshals as `{}` not an array
+
+> **Resolution (2026-06-29).** Resolved by the untyped-array-representation fix
+> #2806 + #2809 (route acorn's `void 0`-pinned evolving `undefined[]` to an
+> externref vec so pushed AST-node refs survive instead of coercing to `0`).
+> Verified on freshly-compiled pinned acorn@8.16.0 (`skipSemanticDiagnostics:
+> true`): `parse("foo(bar,baz)").arguments` → `["Identifier","Identifier"]` (a
+> real JS array of nodes, no longer `{}`/`[0,0]`). The substrate enablement from
+> the #2264/#2272/#2275/#2301 chain (call-expression parsing) is also in place.
 
 **Carved out of #2794.** Compiled acorn parses a call expression to the right
 top-level shape, but the `arguments` array of the `CallExpression` node comes


### PR DESCRIPTION
Real-world differential validation of compiled acorn on main (acorn now passes the narrow expression walls; this PR records that + a real-world residual finding) plus a small status cleanup.

## acorn.wasm size (pinned acorn@8.16.0, \`skipSemanticDiagnostics: true\`)
- raw: **675,021 B (659.2 KB)** — compile ~70 s
- wasm-opt \`-O3\` (Binaryen): **387,766 B (378.7 KB)**, validates — **−287,255 B / −42.6%**

## Status flips (plan-only — verified, not asserted)
Verified on freshly-compiled compiled acorn vs node-acorn oracle:
- **#2681** \`parse("x")\` → \`ExpressionStatement\`, \`parse("var x = 1;")\` → \`VariableDeclaration\` (was \`WebAssembly.Exception\`)
- **#2686** \`parse("1 + 2 * 3;")\` → \`ExpressionStatement\` (was \`WebAssembly.Exception\`)
- **#2801** \`parse("foo(bar,baz)").arguments\` → \`["Identifier","Identifier"]\` (was \`{}\`/\`[0,0]\`)
- **#2806 / #2809** already \`done\` (the array-representation fix that enables #2801)

Resolved by the Parser-reconstruction substrate chain (#2264/#2272/#2275/#2301) + #2806/#2809.

## Real-world differential verdict (native-messaging sources)
Differential = compiled acorn.wasm \`parse\` vs node-acorn (same pinned tarball oracle), structural AST diff.

| file | sourceType | oracle nodes | verdict |
|---|---|---|---|
| sanity \`foo(bar,baz)\` | script | 6 | structurally equal (modulo marshalling: always-null \`sourceFile\`, boolean \`optional\` as i32 \`0\`) |
| \`background.js\` | script | 32 | **compiled parse THROWS** |
| \`edge.js\` | module | 1190 | **compiled parse THROWS** |

**Residual bug found (escalated, NOT fixed here):** any function declaration or arrow function traps inside the wasm — \`RuntimeError: illegal cast\` at \`__set_member_labels\` (wasm-function[174]), confirmed on the **raw export** (not a host-marshalling artifact). Minimal repro: \`parse("function f() {}")\` / \`parse("var g = (x) => x;")\`. Real NM files are full of functions, so they fail. This is a *new, later* wall beyond the expression-level milestones above and stays tracked under the still-open **#1712** (acorn full-file acceptance). No source changed in this PR.

Differential infra: \`.tmp/nm-diff.mjs\` (gitignored). smoke is non-required.