### PR TITLE
fix(#2828): ship examples/ in the npm tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/",
+    "examples/",
     "README.md",
     "LICENSE",
     "CHANGELOG.md"

--- a/plan/issues/2828-ship-examples-on-npm.md
+++ b/plan/issues/2828-ship-examples-on-npm.md
@@ -1,0 +1,45 @@
+---
+id: 2828
+title: Ship examples/ in the npm tarball
+status: done
+sprint: current
+priority: high
+area: packaging
+related: [389]
+assignee: ttraenkler/agent-a8f0d6a619ca48044
+completed: 2026-06-29
+---
+
+# Ship `examples/` on npm
+
+## Problem
+
+The `package.json` `files` allowlist was
+`["dist/", "README.md", "LICENSE", "CHANGELOG.md"]` — the published npm tarball
+shipped **no `examples/` directory at all**. The loopdive/js2#389 reporter could
+not obtain the native-messaging host sources via `npm i @loopdive/js2` and had to
+fall back to `bun install` straight from the GitHub repo.
+
+The example native-messaging hosts (`examples/native-messaging/*.ts`), the WASI
+example, and the edge-platform example are reference material users need; they
+should ride along in the package.
+
+## Fix
+
+Add `"examples/"` to the `files` allowlist in the root `package.json` (the
+published `@loopdive/js2` package). The proxy package
+`packages/js2wasm/package.json` is a thin dependency-only proxy (it ships only
+`index.js`/`cli.js`/`README`/`LICENSE` and depends on `@loopdive/js2`), so it
+does **not** need the examples — they are added to the published package only.
+
+The whole `examples/` tree is git-tracked source (~276 KB: `.ts`/`.js`/`.mjs`/
+`.sh`/`.json`/`.wat`/`.wit`/`.md`), with no `node_modules` and no generated
+`.wasm` artifacts (each example subdir has its own `.gitignore` keeping build
+output out of git, hence out of the npm tarball too). A plain `"examples/"` glob
+therefore ships source only.
+
+## Verify
+
+`npm pack --dry-run` now lists `examples/native-messaging/*.ts` (and the rest of
+the `examples/` source tree). The tarball size increase is small (the examples
+total ~276 KB of source). See `## Test Results`.

--- a/plan/issues/2829-verify-multihost-browser-nm-0593.md
+++ b/plan/issues/2829-verify-multihost-browser-nm-0593.md
@@ -1,0 +1,47 @@
+---
+id: 2829
+title: Retest all four native-messaging hosts in Chrome on 0.59.3
+status: ready
+sprint: current
+priority: high
+area: examples
+task_type: bug
+related: [389, 2814, 2807]
+---
+
+# Verify all four native-messaging hosts work in the browser on 0.59.3
+
+## Problem
+
+The loopdive/js2#389 reporter says only `nm_js2wasm_node_fs` works as a Chrome
+native-messaging host. `nm_js2wasm_deno`, `nm_js2wasm_wasi_p1`, and
+`nm_js2wasm_node_process` all fail in the browser:
+
+- `nm_js2wasm_deno` and `nm_js2wasm_wasi_p1` → `"Error when communicating with
+  the native messaging host"`.
+- `nm_js2wasm_node_process` → climbed to ~98% memory echoing a 64 MiB frame and
+  never replied.
+
+The reporter tested a **pre-0.59.2** build. The symptoms he saw — the `.js.wasm`
+output names, the 64 MiB echo, and the `Cannot find name 'Deno'` warning — all
+predate fixes that have since landed:
+
+- re-chunk to ≤1 MiB JSON frames (#2814),
+- the Deno-warning suppression (#2815),
+- the output-name fix (#2816),
+
+all of which are now in 0.59.3.
+
+## Goal
+
+Retest all four hosts as **actual Chrome native-messaging hosts** on 0.59.3. For
+each host, either:
+
+1. document a working build + manifest recipe, or
+2. root-cause the remaining failure and file the residual bug.
+
+Note the two failure classes are likely distinct: the
+`"Error when communicating"` on `deno`/`wasi_p1` may be a launcher/runtime issue,
+whereas the `node_process` memory blowup should already be fixed by the #2814
+re-chunk. Confirm the re-chunk resolves `node_process` and pin down whatever
+remains for `deno`/`wasi_p1`.

--- a/plan/issues/2830-document-wasi-p1-no-bundle-recipe.md
+++ b/plan/issues/2830-document-wasi-p1-no-bundle-recipe.md
@@ -1,0 +1,32 @@
+---
+id: 2830
+title: Document the wasi_p1 --no-bundle build recipe
+status: ready
+sprint: current
+priority: low
+area: docs
+task_type: docs
+related: [389]
+---
+
+# Document the wasi_p1 `--no-bundle` build recipe
+
+## Problem
+
+`examples/native-messaging/nm_js2wasm_wasi_p1.ts` imports `wasi_snapshot_preview1`
+(`fd_read`/`fd_write`) and `wasm:memory` (`store32`/`load32`/…). These are
+compiler intrinsics with **no resolvable JS module**, so bundling with
+`bun build` fails unless the example is built with `--no-bundle` (or each ghost
+import is marked `--external`). The loopdive/js2#389 reporter hit exactly this.
+
+## Goal
+
+Document the wasi_p1 build recipe in `examples/native-messaging/README.md` and/or
+the runtimes doc:
+
+- `bun build --no-bundle`, or
+- the `--external wasi_snapshot_preview1 --external 'wasm:memory'` form already
+  used in `examples/native-messaging/scale-test.mjs`.
+
+Note the ghost-import ergonomics tradeoff (already discussed on #389) so users
+understand why these imports cannot be bundled.


### PR DESCRIPTION
## #2828 — ship `examples/` on npm

**Problem:** the root `package.json` `files` allowlist was
`["dist/", "README.md", "LICENSE", "CHANGELOG.md"]`, so the published
`@loopdive/js2` tarball shipped **no `examples/`**. The loopdive/js2#389 reporter
could not get the native-messaging host sources via `npm i` and had to
`bun install` from GitHub.

**Fix:** add `"examples/"` to the `files` allowlist in the root `package.json`
(the published package). The proxy `packages/js2wasm/package.json` is a
dependency-only proxy and does not ship examples, so it is left unchanged.

**Verify — `npm pack --dry-run`:**
- 30 `examples/` source files included (`.ts`/`.md`/`.mjs`/`.sh`/`.json`/`.wat`/`.wit`)
- all `examples/native-messaging/*.ts` hosts present (deno, node_fs, node_process, wasi_p1, wasi_p3, sync_framing)
- **no `.wasm`, no `node_modules`** shipped — each example subdir's `.gitignore` keeps build output out
- tarball ~96 KB, unpacked ~305 KB (examples are ~276 KB of source)

## Also: tracking issues (no code)

- **#2829** — retest all four NM hosts as real Chrome native-messaging hosts on 0.59.3 (`deno`/`wasi_p1` "Error communicating"; `node_process` 64 MiB echo memory blowup — reporter tested a pre-0.59.2 build predating #2814/#2815/#2816). `status: ready`.
- **#2830** — document the `wasi_p1` `--no-bundle` build recipe (ghost imports `wasi_snapshot_preview1`/`wasm:memory` can't be bundled). `status: ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)