### PR TITLE
fix(#2832): bound nm_js2wasm_node_process read-side memory (streaming re-chunk)

### DIFF
--- a/examples/native-messaging/nm_js2wasm_node_process.ts
+++ b/examples/native-messaging/nm_js2wasm_node_process.ts
@@ -15,20 +15,53 @@
 //     source-prelude (`src/process-stdin-prelude.ts`) so the public Node API
 //     compiles under `--target wasi`; each `'data'` chunk is delivered as a
 //     **string** whose char codes are the raw incoming bytes (one char per byte,
-//     built via `String.fromCharCode`).
+//     built via `String.fromCharCode`). The fd0 reactor reads at most ONE 64 KiB
+//     page per tick (`RL_STDIN_BUF_CAP` in `src/codegen/async-scheduler.ts`), so
+//     each `'data'` chunk is itself bounded (~64 KiB) regardless of frame size.
 //   - `process.stdout.write(bytes)` writes to fd 1 (#1651). We hand it a
 //     **`Uint8Array`** so the framed response goes out as RAW bytes — a string
 //     argument would be UTF-8 re-encoded, which would corrupt the binary 4-byte
 //     length prefix (its bytes are not all ASCII) and any high body byte. The
 //     `Uint8Array` overload bypasses string encoding and writes the bytes verbatim.
 //
-// Because the read side is event-driven, the framed protocol is parsed
-// incrementally: buffer incoming `'data'` chunks, and whenever the buffer holds a
-// complete frame (the 4-byte little-endian length prefix plus that many body
-// bytes), echo it back, then advance past it. A `'data'` chunk can carry a
-// partial frame, exactly one frame, or several; the incremental parser handles
-// all three. The leftover tail (a partial next frame) stays buffered until the
-// following chunk completes it.
+// READ-SIDE STREAMING — bounded resident memory (#2832). An earlier version
+// BUFFERED THE WHOLE INPUT FRAME: it concatenated every `'data'` chunk into one
+// growing `Uint8Array` and only echoed a frame once the entire body had arrived
+// (`drain` required `tail - head >= 4 + len`). That made the read side's peak RSS
+// scale ~8x the frame size (≈530 MB at 64 MiB, ≈2 GB at 256 MiB) — exactly the
+// loopdive/js2#389 reporter's "node_process climbed to ~98% memory on a 64 MiB
+// frame". #2814 re-chunked only the WRITE side; the read side still held the full
+// frame. The sibling SYNCHRONOUS hosts (`nm_js2wasm_node_fs`, `nm_js2wasm_deno` via
+// the shared `nm_js2wasm_sync_framing` core, and `nm_js2wasm_wasi_p1`) stay flat
+// (tens of MB) because their `readSync` seam lets them pull the body in a fixed
+// window and re-chunk on the fly, never holding the whole frame.
+//
+// This variant now does the SAME, push-driven against the async `'data'` reactor:
+// an incremental STATE MACHINE consumes each bounded `'data'` chunk and re-frames
+// the protocol WITHOUT ever buffering a whole multi-MiB frame. The only resident
+// buffers are (a) a single reused `FRAME_CAP` re-chunk window, (b) the per-output
+// frame buffer (<= FRAME_CAP), and (c) for a body that already fits the cap, one
+// verbatim frame buffer (<= FRAME_CAP). Peak resident is therefore ~a couple of
+// MiB — flat across 64/128/256 MiB, matching the other three hosts. This mirrors
+// the streaming/re-chunk logic of the shared `nm_js2wasm_sync_framing` core
+// (`runRechunk`), turned inside-out: instead of PULLING exact-size reads, the
+// reactor PUSHES <=64 KiB chunks and the state machine advances across them.
+//
+// CODEGEN CONSTRAINT — module-global Uint8Array reads (#2832). A js2wasm quirk
+// shapes the structure below: a module-scope `Uint8Array` that is *read* (by
+// element) DIRECTLY inside a function it was not assigned in compiles to a
+// throwing null-guard ("Cannot access property on null or undefined"), and the
+// same array *passed through TWO function-parameter levels* degrades to an
+// externref whose element reads lower to a host `__extern_get` import (which is
+// absent under standalone WASI). Both miscompile the read side. The pattern that
+// compiles correctly: WRITE the module-global window directly in the chunk handler
+// (`onData`), and do every window READ inside a ONE-LEVEL helper that takes the
+// window as a parameter and copies inline — never reading the global directly and
+// never calling a second window-reading helper. That is why the 4-byte length
+// prefix is decoded with a running NUMBER accumulator (no header array) and why
+// the array re-chunk helpers inline their output-frame copy instead of sharing
+// one `emitFrame`. (The string path can call `emitFrame` because it is reached at
+// exactly one level from `onData`.)
 //
 // On the WRITE side the echo is re-chunked to the 1 MiB browser cap (#2810): a
 // body within the cap is echoed verbatim — prefix + body — as one
@@ -37,7 +70,7 @@
 // body) whose interiors, concatenated by the receiver, reproduce the original
 // body. This matches the sibling `nm_js2wasm_node_fs` re-chunker, keeps every
 // host->extension message within the real Chrome 1 MiB cap, and bounds resident
-// memory on the write side. See the FRAME_CAP / `rechunk*` helpers below.
+// memory on the write side.
 //
 // Native Messaging protocol: each message is a 4-byte little-endian length prefix
 // followed by a UTF-8 JSON body, exchanged over stdin (fd 0) / stdout (fd 1). See
@@ -61,47 +94,75 @@
 // after the same subscription drop.) Feeding the host a bounded buffer that hits
 // EOF still exits via the `'end'` path, exactly as before.
 
-// The buffered, not-yet-echoed input, held as a raw BYTE buffer (#2777). An
-// earlier version kept this as a growing STRING (`buffered = buffered + chunk`)
-// and recovered bytes with `buffered.charCodeAt(i)` / `buffered.substring(...)`.
-// js2wasm native strings are cons-ropes, so every `charCodeAt`/`substring` over
-// the growing buffer re-flattened the WHOLE buffer — O(n) per access, O(n^2) for
-// a multi-MiB frame (which SIGKILLed this host). A `Uint8Array` gives O(1)
-// indexed reads, so parsing is linear. `tail - head` is the live byte count;
-// `head` advances past echoed frames and both reset to 0 once fully drained.
-let buf: Uint8Array = new Uint8Array(1024);
-let head: number = 0;
-let tail: number = 0;
-// Set once a zero-length frame (clean shutdown) is seen, matching the sibling
-// variants which treat a declared length of 0 as end-of-stream.
-let stopped: boolean = false;
-
 // Browser per-host->extension-message cap: 1 MiB (#2810). A real Chrome Native-
 // Messaging host may send AT MOST 1 MiB per host->extension message, so a body
 // larger than this isn't even valid on that surface. Like the sibling
 // `nm_js2wasm_node_fs.ts` re-chunker, a >1 MiB response body is split on the
 // WRITE side into a sequence of valid <=1 MiB JSON frames whose interiors,
 // concatenated by the receiver, reproduce the original body; a body that already
-// fits is echoed verbatim. This also BOUNDS resident memory on the write side
-// (per-frame 1 MiB out buffers instead of one full-size frame) and brings this
-// async host in line with `nm_js2wasm_deno` / `nm_js2wasm_wasi_p1` (64 KiB
-// window) and `nm_js2wasm_node_fs` (1 MiB re-chunk) — it was the lone variant
-// that built the WHOLE frame and wrote it in ONE process.stdout.write, the
-// shape that hit wasmtime's single-fd_write cap in #2807.
+// fits is echoed verbatim.
 const FRAME_CAP: number = 1024 * 1024;
+// Largest re-chunk run: leave room for the framing `[`/`]` (or the two `"`), so a
+// re-chunked frame body (`open` + run + `close`) stays within FRAME_CAP.
+const MAX_RUN: number = FRAME_CAP - 2;
 const COMMA: number = 44; // ,
 const OPEN_BRACKET: number = 91; // [
 const CLOSE_BRACKET: number = 93; // ]
 const DQUOTE: number = 34; // "
 
-// Emit ONE re-chunked JSON frame: 4-byte LE length prefix + `open` + the run
-// `buf[srcStart..srcStart+runLen)` + `close`, built whole and written in ONE
-// process.stdout.write (atomic framing — a streaming receiver must never see a
-// prefix split from its body; #2526). `open`/`close` are `[`/`]` for an array
-// body or `"`/`"` for a string body. The 4-byte prefix declares the JSON body
-// length (`open` + run + `close`), which stays <= FRAME_CAP because the caller
-// keeps `runLen <= FRAME_CAP - 2`.
-function emitRun(srcStart: number, runLen: number, open: number, close: number): void {
+// ── Incremental read-side state machine ──────────────────────────────────────
+// The reactor PUSHES <=64 KiB `'data'` chunks; this state machine advances across
+// frame boundaries that may fall anywhere within (or across) a chunk. None of its
+// buffers grow with the frame size — `win` is a fixed FRAME_CAP window, `vbuf` is
+// a per-frame verbatim buffer (<= FRAME_CAP), and the remaining state is counters.
+const ST_HEADER: number = 0; // filling the 4-byte length prefix
+const ST_VERBATIM: number = 1; // body <= cap: filling vbuf[4..], then one write
+const ST_PEEK: number = 2; // body > cap: read the opening `[`/`"` to pick the shape
+const ST_ARRAY: number = 3; // body > cap, array: stream interior → `[run]` frames
+const ST_STRING: number = 4; // body > cap, string: stream interior → `"run"` frames
+const ST_TRAILER: number = 5; // body > cap: discard the closing `]`/`"` byte
+
+let st: number = ST_HEADER;
+// Set once a zero-length frame (clean shutdown) is seen, matching the sibling
+// variants which treat a declared length of 0 as end-of-stream.
+let stopped: boolean = false;
+
+// 4-byte LE length prefix decoded with a running NUMBER accumulator across chunk
+// boundaries (NOT a `header` Uint8Array — see the "CODEGEN CONSTRAINT" note: a
+// module-global array read directly inside a function miscompiles to a throwing
+// null-guard). `headerMul` is 256^headerFill; little-endian byte k contributes
+// `byte * 256^k`. js2wasm numbers are f64, so the max prefix value (~4.29e9) is
+// exact.
+let headerAcc: number = 0;
+let headerMul: number = 1;
+let headerFill: number = 0;
+
+// Verbatim path (body <= cap): one per-frame buffer holding prefix + body; emitted
+// in ONE write once full. Sized per frame (<= 4 + FRAME_CAP), allocated then
+// released — bounded at ~1 MiB. `vbuf` is read only as a whole value (passed to
+// `process.stdout.write`) and element-WRITTEN in `onData`, so it is exempt from
+// the element-read miscompile.
+let vbuf: Uint8Array = new Uint8Array(4);
+let vfill: number = 0; // bytes written into vbuf so far (includes the 4 prefix bytes)
+let vneed: number = 0; // total bytes = 4 + body length
+
+// Re-chunk path (body > cap): a single reused FRAME_CAP window the interior is
+// streamed through, plus the count of interior bytes not yet pushed into it.
+// `onData` only ever WRITES `win` (element writes are safe); every READ of `win`
+// happens inside a one-level helper that receives it as a parameter.
+const win: Uint8Array = new Uint8Array(FRAME_CAP);
+let fill: number = 0; // live bytes in win[0..fill)
+let interiorRemaining: number = 0; // interior input bytes not yet consumed
+
+// Emit ONE re-chunked JSON frame from a window passed by parameter: 4-byte LE
+// length prefix + `open` + `w[srcStart..srcStart+runLen)` + `close`, built whole
+// and written in ONE process.stdout.write (atomic framing — a streaming receiver
+// must never see a prefix split from its body; #2526). `open`/`close` are `[`/`]`
+// for an array body or `"`/`"` for a string body. The 4-byte prefix declares the
+// JSON body length (`open` + run + `close`), which stays <= FRAME_CAP because
+// `runLen <= MAX_RUN`. Used by the STRING path (reached at one level from
+// `onData`); the array path inlines this copy to stay within one read level.
+function emitFrame(w: Uint8Array, srcStart: number, runLen: number, open: number, close: number): void {
   const bodyLen = runLen + 2; // delimiter + run + delimiter
   const out = new Uint8Array(4 + bodyLen);
   out[0] = bodyLen & 0xff;
@@ -111,166 +172,217 @@ function emitRun(srcStart: number, runLen: number, open: number, close: number):
   out[4] = open;
   let k = 0;
   while (k < runLen) {
-    out[5 + k] = buf[srcStart + k];
+    out[5 + k] = w[srcStart + k];
     k = k + 1;
   }
   out[4 + runLen + 1] = close;
   process.stdout.write(out);
 }
 
-// Re-chunk a large JSON ARRAY body `[elem,...,elem]` into valid <=FRAME_CAP
-// `[run]` frames, split at COMMA boundaries so each frame is itself a valid JSON
-// array; the receiver concatenates the interiors (re-inserting one comma between
-// frames) to reproduce the original array. `ip0` is the first interior byte
-// (after the leading `[`), `interiorLen` the interior byte count (body length
-// minus the outer `[` and `]`). Mirrors the final-batch drain of the shared
-// `nm_js2wasm_sync_framing` core's re-chunker (which streams the same split);
-// the whole body is already buffered here, so the split is a pure in-memory walk.
-function rechunkArray(ip0: number, interiorLen: number): void {
-  const maxRun = FRAME_CAP - 2; // leave room for the framing `[` / `]`
-  let startPos = 0;
-  while (startPos < interiorLen) {
-    let stop = startPos + maxRun;
-    if (stop >= interiorLen) {
-      stop = interiorLen; // final frame ends exactly at the interior end
-    } else {
-      // Back up to the last comma within [startPos, startPos+maxRun) so each
-      // frame holds whole elements; exclude that comma (it's the separator).
-      let c = stop;
-      while (c > startPos && buf[ip0 + c - 1] !== COMMA) c = c - 1;
-      if (c > startPos) stop = c - 1;
-      // else: no comma in the window — a single element exceeds the cap; emit
-      // maxRun raw (degenerate, only for elements > ~FRAME_CAP bytes), matching
-      // the shared core.
-    }
-    emitRun(ip0 + startPos, stop - startPos, OPEN_BRACKET, CLOSE_BRACKET);
-    startPos = stop;
-    if (startPos < interiorLen && buf[ip0 + startPos] === COMMA) startPos = startPos + 1;
+// Window full (fill === FRAME_CAP) mid-array: emit ONE `[run]` frame ending at the
+// last comma within [0, MAX_RUN) so the frame holds whole elements, then shift the
+// leftover (a partial trailing element) to the front. Mirrors the per-buffer step
+// of the shared core's `runRechunk` array path. The output-frame copy is INLINED
+// (not delegated to `emitFrame`) so `w` is read at exactly one level — see the
+// "CODEGEN CONSTRAINT" note.
+function emitArrayWindow(w: Uint8Array): void {
+  let last = MAX_RUN;
+  while (last > 0 && w[last - 1] !== COMMA) last = last - 1;
+  let runLen: number;
+  let consumed: number;
+  if (last === 0) {
+    // No comma in [0, MAX_RUN): a single element exceeds the cap — emit MAX_RUN raw
+    // (degenerate; only for elements > ~FRAME_CAP bytes), matching the shared core.
+    runLen = MAX_RUN;
+    consumed = MAX_RUN;
+  } else {
+    runLen = last - 1; // exclude the comma at last-1
+    consumed = last; // skip the comma too
   }
-}
-
-// Re-chunk a large JSON STRING body `"chars..."` into valid <=FRAME_CAP `"run"`
-// frames; the receiver concatenates the interiors to reproduce the original
-// string. A fixed `maxRun` split keeps each frame within the cap (no comma
-// boundaries to honor, unlike the array path). `ip0` is the first interior byte
-// (after the leading `"`), `interiorLen` = body length minus the two `"`. (The
-// fixed-run split must not bisect a `\`-escape; for the reported workload the
-// body is plain printable characters, so a fixed split is valid — same caveat as
-// the shared core's emitStringRun.)
-function rechunkString(ip0: number, interiorLen: number): void {
-  const maxRun = FRAME_CAP - 2; // leave room for the two framing `"`
-  let startPos = 0;
-  while (startPos < interiorLen) {
-    let runLen = maxRun;
-    if (interiorLen - startPos < runLen) runLen = interiorLen - startPos;
-    emitRun(ip0 + startPos, runLen, DQUOTE, DQUOTE);
-    startPos = startPos + runLen;
-  }
-}
-
-// Append a `'data'` chunk's raw bytes into `buf` — O(chunk). The prelude (#2777)
-// delivers each chunk as a FLAT string, so `chunk.charCodeAt(k)` is O(1). Grows
-// the backing array with amortized doubling, reclaiming the consumed prefix
-// (`head > 0`) first so a long-lived stream does not grow without bound.
-function append(chunk: string): void {
-  const n = chunk.length;
-  if (tail + n > buf.length) {
-    if (head > 0) {
-      const m = tail - head;
-      let i = 0;
-      while (i < m) {
-        buf[i] = buf[head + i];
-        i = i + 1;
-      }
-      head = 0;
-      tail = m;
-    }
-    if (tail + n > buf.length) {
-      let cap = buf.length;
-      while (cap < tail + n) {
-        cap = cap * 2;
-      }
-      const nb = new Uint8Array(cap);
-      let j = 0;
-      while (j < tail) {
-        nb[j] = buf[j];
-        j = j + 1;
-      }
-      buf = nb;
-    }
-  }
+  const bodyLen = runLen + 2;
+  const out = new Uint8Array(4 + bodyLen);
+  out[0] = bodyLen & 0xff;
+  out[1] = (bodyLen >> 8) & 0xff;
+  out[2] = (bodyLen >> 16) & 0xff;
+  out[3] = (bodyLen >> 24) & 0xff;
+  out[4] = OPEN_BRACKET;
   let k = 0;
-  while (k < n) {
-    buf[tail] = chunk.charCodeAt(k) & 0xff;
-    tail = tail + 1;
+  while (k < runLen) {
+    out[5 + k] = w[k];
     k = k + 1;
   }
+  out[4 + runLen + 1] = CLOSE_BRACKET;
+  process.stdout.write(out);
+  // Shift the leftover w[consumed..fill) to the front for the next window fill.
+  const rem = fill - consumed;
+  let m = 0;
+  while (m < rem) {
+    w[m] = w[consumed + m];
+    m = m + 1;
+  }
+  fill = rem;
 }
 
-// Decode the little-endian uint32 the browser wrote as the first 4 buffered
-// bytes (at the current `head`).
-function decodeLength(): number {
-  return buf[head] + buf[head + 1] * 256 + buf[head + 2] * 65536 + buf[head + 3] * 16777216;
-}
-
-// Echo every complete frame currently buffered, advancing `head` past each. A
-// frame is the 4-byte LE prefix + `len` body bytes; we re-emit prefix + body as
-// raw bytes in ONE `process.stdout.write` (atomic framing — a streaming receiver
-// must never see a prefix split from its body).
-function drain(): void {
-  while (!stopped) {
-    if (tail - head < 4) return; // need the full length prefix first
-    const len = decodeLength();
-    if (len === 0) {
-      stopped = true; // zero-length frame = clean shutdown
-      // #2735: in-band shutdown. The peer (a long-lived Native-Messaging port)
-      // keeps stdin OPEN — it signals "done" with a zero-length frame rather
-      // than by closing the pipe, so stdin never reaches EOF. `.destroy()`
-      // drops the fd0 reactor subscription so `_start` returns cleanly; without
-      // it the reactor's only exit is stdin EOF and the program HANGS forever.
-      process.stdin.destroy();
-      return;
-    }
-    const frameLen = 4 + len;
-    if (tail - head < frameLen) return; // body not fully arrived yet
-
-    if (len <= FRAME_CAP) {
-      // Body already within the 1 MiB browser cap — echo the frame VERBATIM
-      // (prefix + body) in ONE write. Re-frame prefix + body into one raw-byte
-      // buffer: the prefix is rebuilt from the decoded length (identical bytes);
-      // the body bytes are a straight O(1) typed-array copy out of `buf`.
-      const out = new Uint8Array(frameLen);
-      out[0] = len & 0xff;
-      out[1] = (len >> 8) & 0xff;
-      out[2] = (len >> 16) & 0xff;
-      out[3] = (len >> 24) & 0xff;
-      let i = 0;
-      while (i < len) {
-        out[4 + i] = buf[head + 4 + i];
-        i = i + 1;
-      }
-      process.stdout.write(out);
+// Final array batch: the whole interior has been streamed into `w[0..fill)` (the
+// last frame ends exactly at `fill` — a JSON array has no trailing comma). Drain it
+// into <=MAX_RUN `[run]` frames at comma boundaries. Mirrors the final-batch drain
+// of the shared core's `runRechunk`. Output-frame copy is INLINED (one read level).
+function drainArrayFinal(w: Uint8Array): void {
+  let startPos = 0;
+  while (startPos < fill) {
+    let stop = startPos + MAX_RUN;
+    if (stop >= fill) {
+      stop = fill;
     } else {
-      // Body exceeds the 1 MiB browser cap — RE-CHUNK into valid <=1 MiB JSON
-      // frames (#2810), matching the `nm_js2wasm_node_fs` re-chunker. Peek the
-      // first body byte to pick the shape: `"` → a JSON string split into `"run"`
-      // frames; otherwise a JSON array split into `[run]` frames at comma
-      // boundaries. The interior excludes the outer `[`/`]` (or the two `"`):
-      // it starts at `head + 5` and is `len - 2` bytes long.
-      const ip0 = head + 5;
-      const interiorLen = len - 2;
-      if (buf[head + 4] === DQUOTE) {
-        rechunkString(ip0, interiorLen);
-      } else {
-        rechunkArray(ip0, interiorLen);
-      }
+      let c = stop;
+      while (c > startPos && w[c - 1] !== COMMA) c = c - 1;
+      if (c > startPos) stop = c - 1;
     }
+    const runLen = stop - startPos;
+    const bodyLen = runLen + 2;
+    const out = new Uint8Array(4 + bodyLen);
+    out[0] = bodyLen & 0xff;
+    out[1] = (bodyLen >> 8) & 0xff;
+    out[2] = (bodyLen >> 16) & 0xff;
+    out[3] = (bodyLen >> 24) & 0xff;
+    out[4] = OPEN_BRACKET;
+    let k = 0;
+    while (k < runLen) {
+      out[5 + k] = w[startPos + k];
+      k = k + 1;
+    }
+    out[4 + runLen + 1] = CLOSE_BRACKET;
+    process.stdout.write(out);
+    startPos = stop;
+    if (startPos < fill && w[startPos] === COMMA) startPos = startPos + 1;
+  }
+  fill = 0;
+}
 
-    // Drop the echoed frame; keep any trailing partial frame for the next chunk.
-    head = head + frameLen;
-    if (head >= tail) {
-      head = 0;
-      tail = 0;
+// Process one bounded `'data'` chunk through the state machine. Each loop iteration
+// performs ONE state step over `chunk[ci..]`; body states (VERBATIM/ARRAY/STRING)
+// consume a SPAN at a time (not byte-by-byte) so a 64 KiB chunk is handled in a
+// handful of steps. The chunk is a FLAT string (one char per byte), so
+// `charCodeAt` is O(1).
+function onData(chunk: string): void {
+  if (stopped) return;
+  const n = chunk.length;
+  let ci = 0;
+  while (ci < n && !stopped) {
+    if (st === ST_HEADER) {
+      while (headerFill < 4 && ci < n) {
+        headerAcc = headerAcc + (chunk.charCodeAt(ci) & 0xff) * headerMul;
+        headerMul = headerMul * 256;
+        headerFill = headerFill + 1;
+        ci = ci + 1;
+      }
+      if (headerFill < 4) return; // prefix split across chunks — wait for more
+      const len = headerAcc;
+      headerAcc = 0;
+      headerMul = 1;
+      headerFill = 0;
+      if (len === 0) {
+        stopped = true; // zero-length frame = clean shutdown
+        // #2735: in-band shutdown. The peer keeps stdin OPEN — `.destroy()` drops
+        // the fd0 reactor subscription so `_start` returns cleanly.
+        process.stdin.destroy();
+        return;
+      }
+      if (len <= FRAME_CAP) {
+        // Body already within the cap — accumulate prefix + body, emit once full.
+        vneed = 4 + len;
+        vbuf = new Uint8Array(vneed);
+        vbuf[0] = len & 0xff;
+        vbuf[1] = (len >> 8) & 0xff;
+        vbuf[2] = (len >> 16) & 0xff;
+        vbuf[3] = (len >> 24) & 0xff;
+        vfill = 4;
+        st = ST_VERBATIM;
+      } else {
+        // Interior excludes the outer `[`/`]` (or the two `"`): the opening byte is
+        // consumed in ST_PEEK, the closing byte in ST_TRAILER.
+        interiorRemaining = len - 2;
+        fill = 0;
+        st = ST_PEEK;
+      }
+    } else if (st === ST_VERBATIM) {
+      let avail = n - ci;
+      const space = vneed - vfill;
+      if (avail > space) avail = space;
+      let k = 0;
+      while (k < avail) {
+        vbuf[vfill + k] = chunk.charCodeAt(ci + k) & 0xff;
+        k = k + 1;
+      }
+      vfill = vfill + avail;
+      ci = ci + avail;
+      if (vfill === vneed) {
+        process.stdout.write(vbuf);
+        st = ST_HEADER;
+      }
+    } else if (st === ST_PEEK) {
+      // First interior byte picks the re-chunk shape: `"` → JSON string, else array.
+      const b = chunk.charCodeAt(ci) & 0xff;
+      ci = ci + 1;
+      if (b === DQUOTE) {
+        st = ST_STRING;
+      } else {
+        st = ST_ARRAY;
+      }
+    } else if (st === ST_ARRAY) {
+      // Stream interior into the window up to FRAME_CAP (or until the interior is
+      // exhausted), emitting `[run]` frames as the window fills.
+      let avail = n - ci;
+      const space = FRAME_CAP - fill;
+      if (avail > space) avail = space;
+      if (avail > interiorRemaining) avail = interiorRemaining;
+      let k = 0;
+      while (k < avail) {
+        win[fill + k] = chunk.charCodeAt(ci + k) & 0xff;
+        k = k + 1;
+      }
+      fill = fill + avail;
+      ci = ci + avail;
+      interiorRemaining = interiorRemaining - avail;
+      if (interiorRemaining === 0) {
+        drainArrayFinal(win);
+        st = ST_TRAILER;
+      } else if (fill === FRAME_CAP) {
+        emitArrayWindow(win);
+      }
+    } else if (st === ST_STRING) {
+      // Stream interior into the window up to MAX_RUN, emitting `"run"` frames at a
+      // fixed run (no comma boundaries to honor, unlike the array path). The fixed
+      // split must not bisect a `\`-escape; for the reported workload the body is
+      // plain printable characters, so a fixed split is valid — same caveat as the
+      // shared core's emitStringRun.
+      let avail = n - ci;
+      const space = MAX_RUN - fill;
+      if (avail > space) avail = space;
+      if (avail > interiorRemaining) avail = interiorRemaining;
+      let k = 0;
+      while (k < avail) {
+        win[fill + k] = chunk.charCodeAt(ci + k) & 0xff;
+        k = k + 1;
+      }
+      fill = fill + avail;
+      ci = ci + avail;
+      interiorRemaining = interiorRemaining - avail;
+      if (fill === MAX_RUN) {
+        emitFrame(win, 0, MAX_RUN, DQUOTE, DQUOTE);
+        fill = 0;
+      }
+      if (interiorRemaining === 0) {
+        if (fill > 0) {
+          emitFrame(win, 0, fill, DQUOTE, DQUOTE);
+          fill = 0;
+        }
+        st = ST_TRAILER;
+      }
+    } else if (st === ST_TRAILER) {
+      // Discard the closing `]`/`"` byte; the frame is fully echoed.
+      ci = ci + 1;
+      st = ST_HEADER;
     }
   }
 }
@@ -283,18 +395,17 @@ function drain(): void {
 // frame twice. Keeping `main` non-exported makes `_start` wrap module-init, which
 // calls `main()` exactly once (the `main()`-calls-itself convention).
 function main(): void {
-  // Long-lived port loop, async-stream style: accumulate stdin chunks and echo
-  // each complete framed message as it arrives, until EOF (or a zero-length
-  // frame). The reactor injected for `process.stdin` drives the `'data'`/`'end'`
-  // callbacks after `_start` returns.
+  // Long-lived port loop, async-stream style: feed each stdin chunk through the
+  // incremental state machine, which echoes complete frames (re-chunked to the
+  // 1 MiB cap) as their bytes arrive, until EOF (or a zero-length frame). The
+  // reactor injected for `process.stdin` drives the `'data'`/`'end'` callbacks
+  // after `_start` returns.
   process.stdin.on("data", (chunk: string) => {
-    if (stopped) return;
-    append(chunk);
-    drain();
+    onData(chunk);
   });
   process.stdin.on("end", () => {
-    // EOF: anything left buffered is an incomplete frame and is dropped,
-    // matching the sibling variants which stop on a short/truncated read.
+    // EOF: anything mid-frame in the state machine is an incomplete frame and is
+    // dropped, matching the sibling variants which stop on a short/truncated read.
   });
 }
 

--- a/plan/issues/2832-nm-node-process-readside-unbounded-memory.md
+++ b/plan/issues/2832-nm-node-process-readside-unbounded-memory.md
@@ -1,0 +1,106 @@
+---
+id: 2832
+title: nm_js2wasm_node_process READ side buffers the whole input frame (unbounded memory)
+status: done
+sprint: current
+priority: high
+area: examples
+language_feature: native-messaging
+task_type: bug
+related: [389, 2814, 2807]
+assignee: ttraenkler/agent-dev
+completed: 2026-06-29
+---
+
+# nm_js2wasm_node_process READ side is unbounded
+
+## Problem (measured on 0.59.3)
+
+`examples/native-messaging/nm_js2wasm_node_process.ts` round-trips correctly
+under wasmtime but its **read side buffers the entire input frame** — peak RSS
+scales ~**8x the frame size** (≈530 MB @ 64 MiB, ≈2 GB @ 256 MiB). The sibling
+hosts (`nm_js2wasm_deno`, `nm_js2wasm_node_fs`, `nm_js2wasm_wasi_p1`) are
+**flat/bounded** (16–27 MB regardless of frame size). #2814 re-chunked only the
+WRITE side; the read side still accumulated the whole frame. This is exactly the
+loopdive/js2#389 reporter's "node_process climbed to ~98% memory on a 64 MiB
+frame" — the one remaining real bug among the four hosts.
+
+### Root cause
+
+The async `process.stdin` reactor delivers each `'data'` chunk bounded at one
+64 KiB page (`RL_STDIN_BUF_CAP` in `src/codegen/async-scheduler.ts`). The old
+host nevertheless `append`-ed every chunk into one growing `Uint8Array` and only
+echoed a frame once the WHOLE body had arrived — `drain()` required
+`tail - head >= 4 + len`. So a 64 MiB frame forced the read buffer to grow to
+~64 MiB (amortized doubling overshoots further), and the >1 MiB re-chunk path
+then read from that full-size buffer. The blow-up is entirely in the host `.ts`,
+not the compiler.
+
+## Goal
+
+Make node_process's read side **bounded** like the other three: read/process
+stdin in a fixed window and re-chunk to ≤1 MiB output frames WITHOUT holding the
+whole input frame in memory at once. node_process uses the async
+`process.stdin` reactor, so the fix is on the async read path — process each
+chunk incrementally against a bounded buffer rather than concatenating the full
+frame.
+
+## Fix
+
+Replace the buffer-everything `append`/`drain` with an **incremental state
+machine** driven by the pushed `'data'` chunks. It mirrors the streaming
+re-chunk logic of the shared `nm_js2wasm_sync_framing` core (`runRechunk`),
+turned inside-out (push-driven instead of pull-driven):
+
+- `ST_HEADER` — accumulate the 4-byte LE length prefix (across chunk
+  boundaries); a declared length 0 is the in-band clean-shutdown frame
+  (`process.stdin.destroy()`).
+- `ST_VERBATIM` (body ≤ 1 MiB) — accumulate prefix+body into one per-frame
+  buffer (≤ 1 MiB), emit in ONE `process.stdout.write`.
+- `ST_PEEK` → `ST_ARRAY` / `ST_STRING` (body > 1 MiB) — stream the interior
+  through a single reused 1 MiB window, emitting valid `[run]` (at comma
+  boundaries) / `"run"` (fixed run) frames as the window fills; `ST_TRAILER`
+  discards the closing `]`/`"`.
+
+The only resident buffers are the fixed 1 MiB window, the per-output frame
+buffer (≤ 1 MiB), and a per-frame verbatim buffer (≤ 1 MiB) — peak ≈ a couple of
+MiB, flat across all frame sizes. Byte-exact echo/round-trip semantics and the
+write-side re-chunk (#2814) / EOF+shutdown handling are preserved.
+
+## Verify (acceptance bar — measure RSS)
+
+- `node examples/native-messaging/scale-test.mjs` (NM_SCALE_SIZES_MIB="1 64 128
+  256") — all four hosts still PASS byte-exact.
+- Independently sample peak RSS (VmHWM) of the wasmtime process running the NEW
+  node_process build at 64/128/256 MiB. **Acceptance: peak RSS is roughly flat /
+  bounded — NOT ~8x the frame size** (tens of MB, like the other hosts).
+
+## Test Results
+
+`node examples/native-messaging/scale-test.mjs` (NM_SCALE_SIZES_MIB="1 64 128
+256") — all four hosts PASS byte-exact (reassembled interiors == input, every
+frame ≤ 1 MiB).
+
+Peak RSS (VmHWM of the wasmtime process, array body, polled `/proc/<pid>/status`):
+
+| frame  | OLD (origin/main) | NEW (#2832) |
+| ------ | ----------------- | ----------- |
+| 64 MiB | 530.5 MB          | 35.5 MB     |
+| 128 MiB| 1042.5 MB         | 35.5 MB     |
+| 256 MiB| 2066.5 MB         | 35.4 MB     |
+
+OLD scales ~8x the frame size (reproduces the loopdive/js2#389 "~98% memory on a
+64 MiB frame" report). NEW is flat/bounded (~35 MB) regardless of frame size,
+the same order of magnitude as the sibling hosts (16–27 MB). Acceptance met.
+
+### Codegen note (worked around in the host `.ts`, not a compiler change)
+
+A module-scope `Uint8Array` read by element DIRECTLY inside a function (not the
+one it was assigned in) miscompiles to a throwing null-guard, and passing such an
+array through TWO function-parameter levels degrades it to an externref whose
+element reads lower to an absent `__extern_get` host import. The streaming host
+therefore (1) decodes the 4-byte prefix with a running number accumulator (no
+header array), (2) only ever element-WRITES the module-global window in `onData`,
+and (3) does every window READ inside a ONE-LEVEL helper that takes the window as
+a parameter and copies inline. Filed mentally as a latent compiler gap; the
+example stays within the supported surface by following this pattern.


### PR DESCRIPTION
## Problem (#2832, loopdive/js2#389)

`examples/native-messaging/nm_js2wasm_node_process.ts` round-trips correctly but its **read side buffered the entire input frame** — it concatenated every async `'data'` chunk into one growing `Uint8Array` and only echoed a frame once the whole body had arrived. Peak RSS scaled **~8x the frame size**, reproducing the #389 reporter's "node_process climbed to ~98% memory on a 64 MiB frame". #2814 re-chunked only the WRITE side; this was the one remaining real bug among the four hosts (the siblings are flat at 16–27 MB).

## Fix

Replace the buffer-everything `append`/`drain` with an **incremental state machine** driven by the bounded (≤64 KiB/tick) `'data'` chunks, mirroring the shared `nm_js2wasm_sync_framing` `runRechunk` logic but push-driven:

- header decoded with a running number accumulator (across chunk boundaries);
- body ≤ 1 MiB → echoed verbatim (one per-frame buffer, one write);
- body > 1 MiB → streamed through a single reused 1 MiB window, re-chunked to valid ≤1 MiB `[run]`/`"run"` frames (array split at comma boundaries, string at fixed runs);
- zero-length frame → `process.stdin.destroy()` clean shutdown (#2735) preserved.

The only resident buffers are the fixed 1 MiB window + a per-output frame buffer (≤1 MiB) + a verbatim buffer (≤1 MiB). Echo is byte-exact; the write-side re-chunk (#2814) and EOF/shutdown handling are unchanged.

A js2wasm miscompile is worked around in the host `.ts` (no compiler change): module-global `Uint8Array` element reads inside a helper compile to a throwing null-guard, and two-level parameter passing degrades the array to an externref (`__extern_get`). The host therefore writes the window only in `onData` and reads it via one-level parameter helpers with inline copies. Documented in the file + issue.

## Verification

`node examples/native-messaging/scale-test.mjs` (NM_SCALE_SIZES_MIB="1 64 128 256") — **all four hosts PASS byte-exact** (reassembled interiors == input, every frame ≤ 1 MiB).

Peak RSS (VmHWM of the wasmtime process, array body, polled `/proc/<pid>/status`):

| frame   | OLD (origin/main) | NEW (#2832) |
| ------- | ----------------- | ----------- |
| 64 MiB  | 530.5 MB          | 35.5 MB     |
| 128 MiB | 1042.5 MB         | 35.5 MB     |
| 256 MiB | 2066.5 MB         | 35.4 MB     |

NEW is flat/bounded (~35 MB) regardless of frame size — same order as the sibling hosts. Acceptance met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)