### PR TITLE
release: v0.59.4

### DIFF
--- a/docs/releases/0.59.4.md
+++ b/docs/releases/0.59.4.md
@@ -1,0 +1,34 @@
+# v0.59.4
+
+_Released 2026-06-29._
+
+Patch release. Native-Messaging memory + packaging follow-ups from the
+loopdive/js2#389 thread, plus a couple of compiler fixes. (No published-package
+features; the #2827 statusline/dashboard change is repo tooling only.)
+
+## Packaging
+
+- **#2828** — the npm package now ships `examples/` (the native-messaging hosts
+  and the other examples). Previously only `dist/` was published, so
+  `npm i @loopdive/js2` did not include the hosts and you had to fetch them from
+  GitHub.
+
+## Native Messaging (loopdive/js2#389)
+
+- **#2832** — `nm_js2wasm_node_process` now bounds its **read-side** memory. It
+  previously buffered the entire incoming frame, so peak RSS scaled ~8× the frame
+  size (≈530 MB for a 64 MiB request, ≈2 GB at 256 MiB) and could exhaust memory
+  on a constrained machine. It now streams the input through a reused bounded
+  window like the other three hosts — peak RSS is **flat ~35 MB regardless of
+  frame size**. (0.59.2's #2814 bounded the write side; this completes it.) All
+  four hosts round-trip byte-exact under wasmtime 46.0.1 at 1/64/128/256 MiB with
+  flat memory.
+
+## Compiler fixes
+
+- **#2809** — sparse-array `reduceRight` with no initial value (funcIdx desync);
+  `new Array(undefined, …)` builds an externref vec.
+- **#2806** — narrow the void-undefined slot rule to `void`-expression
+  initializers; `var x = (void 0)` stays evolving-any/externref.
+
+**Full changelog:** https://github.com/loopdive/js2/compare/v0.59.3...v0.59.4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.59.3",
+  "version": "0.59.4",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js2wasm",
-  "version": "0.59.3",
+  "version": "0.59.4",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC (unscoped proxy for @loopdive/js2)",
   "keywords": [
     "webassembly",


### PR DESCRIPTION
Patch. Native-Messaging memory + packaging follow-ups from loopdive/js2#389 — **#2828** (ship `examples/` on npm) and **#2832** (bound `nm_js2wasm_node_process` read-side memory: peak RSS 530 MB→flat ~35 MB at 64 MiB, no longer scales with frame size) — plus compiler fixes **#2809** and **#2806**. No published-package features (#2827 is repo tooling). Notes: `docs/releases/0.59.4.md`. After merge, push tag `v0.59.4` to publish.