### PR TITLE
fix(#2831): host-externref→wasm-vec materializer for dynamic vec-field writes

### DIFF
--- a/plan/issues/2831-member-set-dispatch-value-cast-traps.md
+++ b/plan/issues/2831-member-set-dispatch-value-cast-traps.md
@@ -1,0 +1,406 @@
+---
+id: 2831
+title: "[SENIOR-DEV ONLY] member-WRITE dispatcher `__set_member_<name>` traps `illegal cast` on the value coercion — compiled acorn cannot parse ANY function/arrow body"
+status: in-progress
+assignee: ttraenkler/sendev-2831
+sprint: current
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+created: 2026-06-29
+task_type: bugfix
+area: codegen
+language_feature: value-representation
+goal: acorn-dogfood
+related: [2664, 2659, 2805, 2806, 2809, 1917, 2379]
+depends_on: []
+blocks: [1712]
+architect_spec: done
+---
+
+# #2831 — `__set_member_<name>` value-coercion `ref.cast` traps; compiled acorn can't parse function/arrow bodies
+
+**The genuine blocker for #1712 (acorn parses a real file).** Surfaced by a
+real-world differential (compiled acorn.wasm vs node-acorn) on the
+native-messaging sources `examples/native-messaging/{edge.js,background.js}`:
+both throw inside compiled acorn. Localized to **any function declaration or
+arrow function** — the bulk of any real file.
+
+## Minimal repros (RAW export, fresh single instance, first & only call)
+
+Compile pinned acorn@8.16.0 with `skipSemanticDiagnostics: true`, instantiate,
+`__setExports`, then on `instance.exports.parse(src, {ecmaVersion:2022,sourceType:"script"})`:
+
+```
+parse("function f() {}")      -> RuntimeError: illegal cast
+parse("var g = (x) => x;")    -> RuntimeError: illegal cast
+parse("async function f(){}") -> RuntimeError: illegal cast
+```
+
+Expression-level inputs ALL pass (call/member/var-decl/ternary/for-of/spread/
+optional-chain/template), so the expression walls #2681/#2686/#2801 are genuinely
+fixed — this is a **new, later wall**. Stack (raw export, not host marshalling):
+
+```
+RuntimeError: illegal cast
+  at __set_member_labels   (wasm-function[174])
+  at __closure_507         (wasm-function[888])   ; acorn parseFunctionBody-family
+  at __call_fn_method_8    (wasm-function[1535])
+```
+
+## Root cause (WAT ground truth, NOT hand-waved)
+
+`__set_member_labels` is the deferred-fill member-WRITE dispatcher
+(`src/codegen/member-set-dispatch.ts`, #2664). Dumped body from compiled acorn:
+
+```wat
+(func $__set_member_labels (type 21) (local $__any anyref)
+  local.get 0  any.convert_extern  local.tee 2
+  ref.test (ref 6)                      ;; receiver shape A ($__fnctor_… )
+  (if (then
+      local.get 2  ref.cast (ref 6)     ;; receiver cast — GATED by ref.test, SAFE
+      local.get 1  any.convert_extern
+      ref.cast null (ref null 2)         ;; <-- VALUE coercion, UNGUARDED narrowing cast -> TRAPS
+      struct.set 6 30)                    ;; field $labels, slot 30, type (ref null 2)
+    (else
+      local.get 2  ref.test (ref 47)     ;; receiver shape B (dual Parser struct, #2664)
+      (if (then
+          local.get 2  ref.cast (ref 47)
+          local.get 1  any.convert_extern
+          ref.cast null (ref null 2)      ;; <-- same unguarded value cast
+          struct.set 47 30)
+        (else local.get 0 global.get 561 local.get 1 call 39))))) ;; __extern_set_strict sidecar
+```
+
+Type 2 = `$__vec_externref` (the externref array-vec). So the `labels` field is an
+**externref vec** (correct — #2806/#2809 routed acorn's evolving arrays to
+externref). The trap is the **VALUE** coercion, not the receiver cast:
+`coercionInstrs(ctx, {externref}, cand.fieldType)` at `member-set-dispatch.ts:180`
+emits `any.convert_extern; ref.cast (ref null $__vec_externref)` on the inbound
+value with **no `ref.test` guard**. acorn's `parseFunctionBody` does
+`this.labels = []` on an `any`-typed `this` (a prototype method → dynamic
+dispatch). The contextless empty `[]` at a dynamic any-receiver write has **no
+expected-type propagation**, so it lowers to a *different* vec representation
+(the #2806/#2809 numeric-vs-externref-vec family) than the field's
+`$__vec_externref`; boxed to externref, the unguarded narrowing cast traps.
+
+### The read-vs-write asymmetry (why only writes trap)
+
+- **READ** (`__get_member_<name>`, `member-get-dispatch.ts:174`): after the gated
+  receiver cast + `struct.get`, it coerces the field **UP to externref** —
+  `externref` no-op / `__box_number` / `extern.convert_any`. Boxing up never
+  narrows, so the read side **cannot** trap.
+- **WRITE** (`__set_member_<name>`, `member-set-dispatch.ts:180`): it coerces the
+  inbound value **DOWN** `externref → fieldType`. For a ref/vec field that is an
+  **unguarded narrowing `ref.cast`** on a value whose runtime representation the
+  dispatcher cannot know (the receiver is dynamic). This is the asymmetry: there
+  is no "box up" equivalent for a write — `struct.set` requires the exact field
+  type.
+
+## #2805 verdict — this is NOT #2805
+
+The coordinator's hypothesis (this = #2805's write-side substrate gap) is
+**disproven**:
+
+| | #2805 | #2831 (this) |
+|---|---|---|
+| symptom | silent **dropped write** (field stays default) | **`illegal cast` TRAP** |
+| timing | MODULE-INIT (`start` section, before `__setExports`) | parse-time RUNTIME (long after `__setExports`) |
+| mechanism | host setter `__sset_<field>` unreachable at init | unguarded narrowing `ref.cast` on the value coercion |
+| code path | `tryEmitDeleteAwareDynamicSet` host-set gate | `fillMemberSetDispatch` value coercion (line 180) |
+
+Same *family* (write-side, member-set-dispatch #2664/#2659), but a distinct bug.
+Closest relative is the **#2806/#2809 array-representation** work (value-rep
+mismatch on an externref-vec field), now manifesting at the **dynamic-write value
+position**.
+
+## Why this is architecture-scope (escalated for an architect spec)
+
+A naive "guard the value cast with `ref.test`, else fall to the sidecar" is
+**WRONG**: for a genuine write whose value is in a mismatched representation,
+diverting to `__extern_set_strict` stores it in the JS sidecar while later reads
+use the struct **slot** (`struct.get`) — reintroducing the exact #2664
+"write-leaks-to-sidecar / read-uses-slot" desync that member-set-dispatch was
+created to fix (it was the 8th acorn dogfood wall: `while (this.type !== eof)`
+never terminating).
+
+The correct fix is **representation-aware** and couples several substrates:
+- **member-set-dispatch** (#2664) — the dispatcher value coercion must convert
+  (not hard-cast) a vec value whose element-rep differs from the field's vec, and
+  only sidecar genuinely host/incompatible values;
+- **coercion engine** (#1917/#2108) — needs a guarded/representation-aware
+  `externref → (ref $vec)` path (test + convert, not bare `ref.cast`);
+- **#2806/#2809 array-rep family** — unify the empty/contextless `[]` vec rep so a
+  value written to an externref-vec field is an externref vec (or convertible);
+- **value-representation substrate** — the contextless empty `[]` at a dynamic
+  any-receiver write currently has no expected-type and lowers to the wrong vec.
+
+Blast radius: **every dynamic `any`-receiver WRITE of a ref/vec-typed field** —
+a representation-scale change (reference_2379 hazard, explicitly flagged in
+#2809). Requires full `merge_group` + standalone-floor validation, not a scoped
+sweep. **Senior-dev / architect, `reasoning_effort: max`.**
+
+## Acceptance
+
+- `parse("function f(){}")`, `parse("(x) => x")`, `parse("async function f(){}")`
+  on compiled acorn return the correct AST (no `illegal cast`).
+- The real-world NM differential (`edge.js` module + `background.js` script)
+  compiled-acorn vs node-acorn is **structurally equal** (modulo the known
+  marshalling quirks: always-null `sourceFile`, boolean as i32) — THE #1712 bar.
+- 0-regression `merge_group` + standalone-floor (watch the member-set-dispatch /
+  any-receiver-write and `built-ins/Array/**` buckets); the #2664 slot/sidecar
+  invariant (`while (this.type !== eof)` terminates) must NOT regress.
+
+## Pointers
+
+- `src/codegen/member-set-dispatch.ts:180` (the unguarded value coercion);
+  contrast `src/codegen/member-get-dispatch.ts:174` (safe box-up).
+- `findAlternateStructsForField` + `coercionInstrs` (`type-coercion.ts`).
+- Repro infra (this branch `.tmp/`, gitignored): `nm-diff.mjs` (full-file
+  differential), `nm-bisect.mjs` / `nm-isolate.mjs` / `nm-stack.mjs` (localization
+  to the raw-export wasm trap), `dump-setlabels.mjs` (WAT dump of the dispatcher).
+- Verified on freshly-compiled pinned acorn@8.16.0, 2026-06-29 (sendev).
+
+## Implementation Plan
+
+> Architect note (2026-06-29): reproduced on current `origin/main` and dumped the
+> WAT for the actual write path. The diagnosis below **refines** the issue body
+> with two load-bearing facts the original pinning did not have, both confirmed by
+> WAT — and one is the difference between a fix that works and one that silently
+> drops the write.
+
+### Root cause (refined, WAT-confirmed on main)
+
+Two facts change the shape of the correct fix:
+
+1. **The inbound value at the dynamic write is a HOST externref, not a wasm vec.**
+   For `this.x = []` on an `any` receiver, the RHS `[]` is built as a wasm
+   `$__vec_externref` and then **marshalled to a host iterable via the
+   `__make_iterable` import** *before* it is passed to the dispatcher
+   (`__set_member_<name>`). So the value param is an opaque host externref whose
+   `any.convert_extern` is **not** any `$__vec_*` struct. The dispatcher then does
+   the unguarded narrowing `any.convert_extern; ref.cast(_null) (ref null $vecT)`
+   (from `coercionInstrs(externref → ref/ref_null $vec)` with **no `fctx`**, the
+   "No fctx available" branch of `type-coercion.ts:3013-3015 / 3036-3037`) → the
+   host externref is non-null and not `$vecT` → **`illegal cast` trap**.
+   Minimal local repro (traps on main in `__set_member_labels`; marshal path
+   identical to acorn):
+   ```ts
+   var P = function P(){ this.labels = [{k:1}]; };
+   P.prototype.reset = function(){ this.labels = []; };       // dynamic any-recv []
+   P.prototype.run   = function(){ this.reset(); return this.labels.length; };
+   ```
+   WAT confirms the reset closure does: build `$__vec_externref` → `extern.convert_any`
+   → `call $__make_iterable` → `call $__set_member_labels`. Because the value is a
+   **host** value, a fix that only `ref.test`s it against `$__vec_base` (a wasm-vec
+   check) does **NOT** see it as a vec, drops to the sidecar, and the write is
+   **silently lost** (read-uses-slot desync — the exact #2664 hazard). I verified
+   this empirically: a wasm-vec-only empty fast-path turned the trap into a dropped
+   write (`run()` returned the stale length, not 0). **The conversion MUST be
+   host-externref-aware.**
+
+2. **The same unguarded narrowing cast is emitted by THREE setter emitters, not
+   just `member-set-dispatch.ts:180`.** All three lower `externref → (ref $vecT)`
+   with a bare `ref.cast`/`ref.cast_null`:
+   - `src/codegen/member-set-dispatch.ts:180` — `__set_member_<name>` (#2664
+     dispatcher; the pinned acorn stack frame, called from wasm at the dynamic
+     write site).
+   - `src/codegen/index.ts:2685-2689` (`buildSetterStore`) — the exported
+     `__sset_<field>` host setter (#2659/#2805). Confirmed present in the same
+     module with `any.convert_extern; ref.cast null (ref null 8)`. (Wrapped by the
+     host `_safeSet` try/catch → degrades to sidecar-only, so it does not crash but
+     **silently drops** the cross-rep write — still wrong.)
+   - inline static-receiver writes also funnel through `coercionInstrs` /
+     `emitSafeStructConversion`.
+   A member-set-dispatch-only patch fixes the acorn raw-export trap but leaves the
+   sibling `__sset_<field>` path dropping the same writes. **Fix the conversion
+   once, centrally, and apply it at all three sites.**
+
+### The correct conversion already exists: `buildVecFromExternref`
+
+`src/codegen/type-coercion.ts:209` `buildVecFromExternref(ctx, fctx, externLocal,
+vecTypeIdx, {arrTypeIdx, elemType})` is the **host-externref → wasm-vec**
+materializer used by destructuring-params (#1464) and literal coercion (#3633). It
+reads `__extern_length(extern)` and per-element `__extern_get` / `__extern_get_idx`
+(standalone), coerces each element to the target vec's element type (box/unbox /
+guarded ref element cast / tuple build), and `struct.new`s a **fresh vec of the
+exact target type**. It is the representation-consistent **inverse of
+`__make_iterable`**. It handles **empty, non-empty, and host arrays/iterables
+uniformly**, and — critically — produces a value the `struct.set` stores **on the
+slot** (no sidecar, no desync, no aliasing trap, no `ref.cast`).
+
+The only obstacles to calling it from the dispatcher *fill*: it needs (a) an
+`fctx` (it `allocLocal`s temps) and (b) it `ensureLateImport`s its helpers and
+`flushLateImportShifts` — and **registering imports at finalize shifts every baked
+func index** (the reserve-then-fill invariant this subsystem protects). So it
+cannot be called raw inside `fillMemberSetDispatch`.
+
+### Recommended approach — reserved per-target-vec materializer (Option A)
+
+Introduce a reusable, finalize-safe **materializer helper per distinct target vec
+type**:
+
+```
+__vec_from_extern_<vecTypeIdx>(val: externref) -> (ref null $__vec_<elem>)
+```
+
+whose body is `buildVecFromExternref(...)` over its single externref param. The
+three setter emitters then emit, for a **vec-typed** field, simply:
+
+```wat
+local.get <recv-any> ; ref.cast $S
+local.get <val-extern>
+call $__vec_from_extern_<vecTypeIdx>      ;; host-extern → exact target vec, on the slot
+struct.set $S <fieldIdx>
+```
+
+Lifecycle (mirrors `fillClosedMethodDispatch` #2151 / `fillExternGetIdxVecArms`
+#2190 reserve-then-fill discipline → **no funcIdx churn at fill**):
+
+1. **New finalize sub-pass `reserveVecFieldMaterializers(ctx)`**, run **before**
+   `fillMemberSetDispatch` / `fillMemberGetDispatch` and before the `__sset_*`
+   bodies are baked. It:
+   - scans every `memberSetDispatchNames` candidate (`findAlternateStructsForField`
+     filtered to `mutable`) **plus** every `__sset_*` entry list, collects the
+     distinct vec-typed `fieldType.typeIdx` (a `$__vec_*` / `$__template_vec*`
+     struct — detect via `ctx.typeIdxToStructName`);
+   - for each distinct target vec type, reserves a function with a **real
+     `FunctionContext`** and builds its body via `buildVecFromExternref` (which
+     does its own `ensureLateImport` + single `flushLateImportShifts` against that
+     fctx — correct, because this pass runs at a point where index shifts are still
+     allowed and it owns the shift, exactly like other late-registered helpers).
+     Records `ctx.vecFromExternMap: Map<number, funcIdx>`.
+2. `fillMemberSetDispatch` (and the `__sset` builder, and the inline path) then
+   **read-only** look up `ctx.vecFromExternMap.get(targetVecIdx)` and emit a
+   `call`. For a **non-vec ref field** (object struct), use a guarded form (see
+   edge cases). For **scalar fields** keep the existing `coercionInstrs` (unbox)
+   path — unchanged, it never traps.
+
+Writes and reads stay on the **same representation (the struct slot)**, so it does
+**not** reintroduce the #2664 write-leaks-to-sidecar / read-uses-slot desync; the
+sidecar terminal is reached **only** for an unmatched *receiver* (a genuine host
+object), never for a representation-mismatched value on a matched struct receiver.
+
+### Files / functions to change
+
+**`src/codegen/type-coercion.ts`**
+- `buildVecFromExternref` (line 209) — no behavior change; becomes the body of the
+  reserved helper. Optionally factor a thin
+  `buildVecFromExternMaterializer(ctx, targetVecIdx): funcIdx` that constructs the
+  per-vec `FunctionContext` + calls `buildVecFromExternref`, shared by all call
+  sites and the reserve pass.
+- `coercionInstrs` (line 2876), `externref → ref_null` (2994-3016) and
+  `externref → ref` (3017-3038) arms — when `to` is a vec type **and** a
+  materializer funcIdx exists in `ctx.vecFromExternMap`, return
+  `[{op:"call", funcIdx}]` instead of the bare `any.convert_extern; ref.cast`.
+  This automatically fixes the **inline static-write** path too. Guard on
+  `ctx.vecFromExternMap` being populated (only after the reserve pass) so
+  pre-finalize callers (which pass `fctx` and can already do guarded casts) are
+  unaffected.
+
+**`src/codegen/member-set-dispatch.ts`**
+- `fillMemberSetDispatch` (line 136), inner `buildSetDispatch` (line 170): replace
+  the `coercionInstrs(ctx,{externref},cand.fieldType)` value coercion (line 180)
+  with: vec field → `call ctx.vecFromExternMap.get(vecIdx)`; ref/ref_null (object)
+  → guarded arm (below); scalar → existing `coercionInstrs`.
+
+**`src/codegen/index.ts`**
+- `buildSetterStore` (line 2657, `__sset_<field>`), `valMode === "extern"`,
+  `ft.kind === "ref" | "ref_null"` (2685-2689): same substitution — `call
+  $__vec_from_extern_<vecIdx>` for vec fields; guarded ref.test for object refs.
+- Wire `reserveVecFieldMaterializers(ctx)` into the finalize sequence **before**
+  `fillMemberSetDispatch`, `fillMemberGetDispatch`, and `__sset_*` emit.
+
+### Wasm IR pattern (per vec-typed field arm)
+
+```wat
+;; recv already ref.test'd to $S, in the matched arm
+local.get $__any            ;; receiver anyref
+ref.cast $S
+local.get 1                 ;; val (externref) — host iterable from __make_iterable, or any externref
+call $__vec_from_extern_<vecIdx>   ;; -> (ref null $__vec_<elem>) built on the slot's exact type
+struct.set $S <fieldIdx>
+```
+
+`$__vec_from_extern_<vecIdx>` body == `buildVecFromExternref` output:
+`__extern_length(val)` → `array.new_default` → loop `__extern_get(val,i)` →
+per-elem coerce → `array.set` → `struct.new $__vec_<elem>`; add a null/undefined
+guard at the top returning `ref.null $vec` so `this.x = null` stores null on the
+slot (do NOT route null to the sidecar).
+
+### Edge cases (each needs a test)
+
+- **Empty `[]` (acorn case, dominant):** host iterable length 0 → fresh empty
+  target vec on the slot; `.push`/`.length` work. (The wasm-vec-only fast-path got
+  this WRONG — must use the host-aware helper.)
+- **Non-empty cross-rep value:** materializer copies + element-coerces into the
+  target rep, on the slot. A copy (no aliasing) — strictly better than today's
+  trap; at a dynamic any-receiver write the value was already marshalled by
+  `__make_iterable`, so there is no wasm-identity to preserve.
+- **Same-rep value (`this.x = oldVecReadBack`):** still goes through the
+  materializer (re-reads host extern → rebuilds). Correct; if it costs on the
+  floor, add a `ref.test $vecT` short-circuit (direct guarded `ref.cast`) *before*
+  the materializer call. Recommend including the short-circuit from the start.
+- **`null` / `undefined` write:** materializer guard → `ref.null $vec`.
+- **Non-vec ref field (object struct):** no materializer; guarded `ref.test $objT →
+  ref.cast; struct.set` else **sidecar** (pre-existing narrower gap; guarding stops
+  the trap; full object-rep conversion is out of scope here).
+- **Scalar field (f64/i32/i64/externref):** unchanged `coercionInstrs`. Never
+  trapped; do not touch.
+- **standalone vs host:** `buildVecFromExternref` already branches
+  (`useNativeObjVec = ctx.standalone`, `__extern_get_idx` vs `__array_from_iter`)
+  — both covered. Validate the standalone floor.
+- **funcIdx stability:** materializers reserved in one pre-fill pass that owns its
+  import shifts; `fill*`/`buildSetterStore` only `call` them. Do NOT
+  `ensureLateImport` inside any `fill*`.
+
+### Reduced-scope fallback (only if Option A is too large)
+
+Inline in `fillMemberSetDispatch` + `buildSetterStore` for a vec field: pre-
+register `buildVecFromExternref`'s imports at *reserve* time (so the fill-time
+`ensureLateImport` is a no-op and its flush shifts nothing), build a **minimal
+`FunctionContext` shim** at fill whose `allocLocal` appends to the
+dispatcher/setter `locals`, and call `buildVecFromExternref` inline. Same runtime
+behavior, no separate helper/pass, but duplicates local plumbing across two
+emitters and is more fragile around the import flush — Option A preferred. **The
+empty-only wasm-`$__vec_base`-test fast-path is NOT a valid fallback** — proven
+insufficient (host-marshalled value → dropped write).
+
+### Test plan (bar = #1712)
+
+1. **Unit (`tests/issue-2831-*.test.ts`):** the reduced repros must round-trip
+   (compile → instantiate → `__setExports` → `wrapExports`), asserting post-write
+   `.length`/contents:
+   - `this.x = []` after object pushes → length 0 (NOT stale);
+   - `this.x = []` on a fresh fnctor → `.push` then `.length` works;
+   - `this.x = null` → reads null;
+   - same-rep restore (`this.x = old`) → length preserved;
+   - non-empty cross-rep (`this.labels = [{..},{..}]`) → length 2, elements read.
+   Plus a structural guard that the vec-field write routes through
+   `__vec_from_extern_*` (no bare unguarded `ref.cast (ref null $__vec_*)` on the
+   value in `__set_member_*`/`__sset_*`).
+2. **#2664 non-regression:**
+   `tests/issue-2664-member-set-dispatch-deferred-fill.test.ts` stays green (the
+   `while (this.type !== eof)` terminate invariant).
+3. **Acceptance bar — real acorn NM differential** (acorn-realworld's
+   `.tmp/nm-diff.mjs`): compile pinned acorn@8.16.0 (`skipSemanticDiagnostics:true`),
+   parse `examples/native-messaging/edge.js` (module) + `background.js` (script);
+   assert AST **structurally equal** to node-acorn (modulo known quirks: null
+   `sourceFile`, boolean-as-i32). The three function repros parse with no
+   `illegal cast`.
+4. **Full `merge_group` + standalone-floor**, 0 regressions. Watch buckets:
+   `built-ins/Array/**`, any-receiver member-write, member-set-dispatch family.
+   Broad-impact (representation-scale, reference_2379) ⇒ full CI, never scoped.
+
+### Blast radius & classification
+
+- **Scope:** every dynamic `any`-receiver **write** of a vec-typed field, across
+  all three setter emitters (`__set_member_*`, `__sset_*`, inline) —
+  representation-scale (reference_2379 hazard, #2809). Reads already box-up safely
+  (member-get-dispatch.ts:174); untouched.
+- **Classification:** senior-dev, `reasoning_effort: max`, `horizon: l`. Touches
+  the coercion engine (#1917), the vec-rep family (#2806/#2809), and
+  member-set-dispatch (#2664) — but the change **substitutes one conversion for a
+  safe existing one** (`buildVecFromExternref`), not a coercion-engine rewrite, so
+  it does **not** meet the bar for a deeper engine rework.

--- a/plan/issues/2831-member-set-dispatch-value-cast-traps.md
+++ b/plan/issues/2831-member-set-dispatch-value-cast-traps.md
@@ -1,7 +1,8 @@
 ---
 id: 2831
 title: "[SENIOR-DEV ONLY] member-WRITE dispatcher `__set_member_<name>` traps `illegal cast` on the value coercion — compiled acorn cannot parse ANY function/arrow body"
-status: in-progress
+status: done
+completed: 2026-06-29
 assignee: ttraenkler/sendev-2831
 sprint: current
 priority: high
@@ -404,3 +405,65 @@ insufficient (host-marshalled value → dropped write).
   member-set-dispatch (#2664) — but the change **substitutes one conversion for a
   safe existing one** (`buildVecFromExternref`), not a coercion-engine rewrite, so
   it does **not** meet the bar for a deeper engine rework.
+
+## Implementation Notes (sendev-2831, 2026-06-29) — DONE
+
+Implemented Option A exactly. Files changed:
+- `src/codegen/type-coercion.ts` — `buildVecFromExternMaterializer(ctx, vecIdx)`
+  (reserves `__vec_from_extern_<vecIdx>(externref)->(ref null $vec)` built from a
+  real synthetic `FunctionContext` + `buildVecFromExternref`, with a null guard
+  and a same-rep `ref.test` identity short-circuit) and `vecFromExternFuncIdx`
+  (name-based funcMap resolve). The two `externref→ref`/`ref_null` arms of
+  `coercionInstrs` now return `[call materializer]` (+`ref.as_non_null` for the
+  non-null arm) when `ctx.vecFromExternMap` has the target — which auto-fixes
+  BOTH the member-set-dispatch fill (it calls `coercionInstrs`) and the inline
+  static-write path.
+- `src/codegen/member-set-dispatch.ts` — `reserveVecFieldMaterializers(ctx)`
+  (the up-front reserve-then-fill pass; enumerates distinct mutable vec-typed
+  field types from the dispatcher candidates AND the `__sset` struct fields).
+- `src/codegen/index.ts` — wired `reserveVecFieldMaterializers` into BOTH
+  finalize paths before `emitStructFieldSetters`/`fill*`; `buildSetterStore`
+  (`__sset_*`) emits `call materializer` for vec fields (threaded `ctx`).
+- `src/codegen/context/types.ts` — `vecFromExternMap?: Map<number,string>`.
+- `tests/issue-2831-vec-from-extern-materializer.test.ts` — 6 unit tests.
+
+**Why name-based, not funcIdx (the load-bearing decision):** the materializer is
+reserved early in finalize; later fill passes (member-get-dispatch, etc.) still
+register late imports and shift func indices. Storing the funcIdx in the map
+would go stale. Storing the NAME and resolving via `funcMap` at each emit site is
+immune (funcMap is kept in lockstep by every shift, and baked calls are walked by
+`shiftLateImportIndices`). This is the #1461/#2193 late-funcIdx-shift hazard.
+
+### Verification (local)
+- The 3 function repros on freshly-compiled acorn@8.16.0:
+  `function f(){}` → **PARSE OK**, `async function f(){}` → **PARSE OK**.
+  `var g=(x)=>x;` → **no longer `illegal cast`** (the #2831 wall is cleared) but
+  advances to the NEXT wall (below).
+- NM differential: `foo(bar,baz)` is structurally equal modulo the known quirks
+  (always-null `sourceFile`, boolean-as-i32 `optional`). `background.js`/`edge.js`
+  now reach the SAME next wall (arrow params), not the illegal cast.
+- `tests/issue-2831-*` (6) + #2664/#2806/#2809 non-regression all green; typecheck
+  + prettier + biome clean.
+
+### NEXT WALL (newly exposed — routes to a follow-up, NOT #2831)
+Arrow functions **with ≥1 parameter** throw acorn's own
+`SyntaxError: "Assigning to rvalue"` (a `toAssignable` divergence in arrow-param
+reinterpretation). Isolation:
+- `() => 1` (zero params) → **OK**
+- `x => x`, `(x) => x`, `(a,b) => a`, `f((x)=>x)` → **THROW "Assigning to rvalue (1:NaN)"**
+- `(1)`, `(x)`, `var y=(1);` (parenthesized exprs, no arrow) → **OK**
+
+So the wall is specifically acorn's `parseParenAndDistinguishExpression` →
+arrow-param `toAssignable(Identifier)` path. `background.js` and `edge.js` both
+contain parameterized arrows, so this is what now blocks the full NM differential.
+The `(1:NaN)` column hints a position/number field reads NaN on the raise path —
+worth a look when scoping the follow-up. This is a distinct parser-logic bug, not
+the value-representation write trap #2831 fixed.
+
+### Known narrow gaps (architect-scoped OUT, not regressions)
+- Dynamic any-receiver `.push()` on a vec read back through the host boundary
+  doesn't persist the mutation (host-marshalling copy) — orthogonal any-receiver
+  array-method gap; pre-existing, trapped earlier before this fix.
+- A vec-of-**ref-struct** field given GENUINE host-object elements can still trap
+  inside the materializer's element `ref.cast_null` (the architect's "object-rep
+  conversion is out of scope"). acorn uses externref-elem vecs, which work.

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1077,6 +1077,28 @@ export interface CodegenContext {
    */
   memberGetDispatchNames?: Set<string>;
   /**
+   * (#2831) Per-target-vec-type host-externref → wasm-vec materializer helpers.
+   * Maps a vec struct typeIdx (`$__vec_*`) → the reserved helper function NAME
+   * `__vec_from_extern_<vecTypeIdx>(externref) -> (ref null $vec)`. The helper
+   * body is `buildVecFromExternref` (the read-consistent inverse of
+   * `__make_iterable`): it reads `__extern_length` + per-element `__extern_get`
+   * and `struct.new`s a fresh vec of the EXACT target type, handling
+   * empty/non-empty/host-array/null uniformly, with a same-rep `ref.test`
+   * short-circuit that preserves wasm-vec identity.
+   *
+   * Reserved ONCE up-front by `reserveVecFieldMaterializers` (a finalize sub-pass
+   * that owns its import shifts — the #2043 reserve-then-fill discipline), BEFORE
+   * the `__sset_*` setters and `fillMemberSetDispatch` bake. The three setter
+   * emitters then look the helper up by NAME (funcMap stays in lockstep across
+   * later import shifts) and emit a `call` instead of an UNGUARDED narrowing
+   * `ref.cast` on the inbound value — which traps `illegal cast` on a
+   * host-marshalled `[]` at a dynamic any-receiver write (the #2831 blocker), or
+   * (with a wasm-vec-only guard) silently DROPS the write (the #2664 desync).
+   * Empty/undefined until a vec-typed field write site exists ⇒ byte-identical
+   * for modules without the pattern.
+   */
+  vecFromExternMap?: Map<number, string>;
+  /**
    * (#1904) True once the standalone `__extern_is_array(externref) -> i32`
    * helper placeholder has been emitted by the object runtime. Its body is
    * filled in post-processing after all Wasm array carrier types (`__vec_*`

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -47,7 +47,7 @@ import { scanForArrayHoles, ensureHoleType } from "./array-holes.js"; // (#2001 
 import { ensureDynReadHelpers } from "./dyn-read.js"; // (#2580 M0)
 import { ensureNativeIteratorRuntime, fillNativeIteratorUserArms } from "./iterator-native.js";
 import { fillClosedMethodDispatch } from "./closed-method-dispatch.js";
-import { fillMemberSetDispatch } from "./member-set-dispatch.js";
+import { fillMemberSetDispatch, reserveVecFieldMaterializers } from "./member-set-dispatch.js";
 import { fillMemberGetDispatch } from "./member-get-dispatch.js";
 import { emitUndefined, ensureGetUndefined, reconcileNativeStrFinalizeShift } from "./expressions/late-imports.js";
 import { fillProtoIteratorDriver } from "./expressions/proto-override.js";
@@ -1679,6 +1679,13 @@ export function generateModule(
     // that genuinely collide are touched; everything else is byte-identical.
     resolveSameShapeFieldNameCollisions(ctx);
 
+    // (#2831) Reserve the per-target-vec host-externref → wasm-vec materializers
+    // BEFORE the setter/dispatch emitters bake their value coercions. This pass
+    // OWNS its import shifts (reserve-then-fill); the three setter emitters then
+    // only `call` the materializer (no funcIdx churn). Must precede
+    // emitStructFieldSetters + fillMemberSetDispatch + fillMemberGetDispatch.
+    reserveVecFieldMaterializers(ctx);
+
     // Emit exported struct field getter helpers for the runtime.
     // These allow JS host imports to read WasmGC struct fields that are
     // otherwise opaque to JS (V8 returns undefined for direct property access).
@@ -2583,7 +2590,7 @@ function _emitStructFieldSettersInner(ctx: CodegenContext): void {
     const funcIdx = ctx.numImportFuncs + mod.functions.length;
     const anyLocal = 2; // locals after the two params (local 0 = obj, local 1 = val)
 
-    const funcBody = buildSetterNestedIfElse(entries, anyLocal, valMode);
+    const funcBody = buildSetterNestedIfElse(ctx, entries, anyLocal, valMode);
 
     mod.functions.push({
       name: funcName,
@@ -2602,6 +2609,7 @@ function _emitStructFieldSettersInner(ctx: CodegenContext): void {
 
 /** Build nested if/else for struct field setter dispatch. */
 function buildSetterNestedIfElse(
+  ctx: CodegenContext,
   entries: { typeIdx: number; fieldIdx: number; fieldType: ValType; shapeId?: number; shapeFieldIdx?: number }[],
   anyLocal: number,
   valMode: "extern" | "f64" | "i32",
@@ -2618,7 +2626,7 @@ function buildSetterNestedIfElse(
 
   for (let i = entries.length - 1; i >= 0; i--) {
     const entry = entries[i]!;
-    let thenBranch = buildSetterStore(entry, anyLocal, valMode);
+    let thenBranch = buildSetterStore(ctx, entry, anyLocal, valMode);
 
     // (#2009) Colliding struct: `ref.test typeIdx` matched, but same-shape
     // canonicalization means the instance might be a DIFFERENT struct that
@@ -2656,6 +2664,7 @@ function buildSetterNestedIfElse(
 
 /** Build the "then" branch that stores `val` (local 1) into a struct field. */
 function buildSetterStore(
+  ctx: CodegenContext,
   entry: { typeIdx: number; fieldIdx: number; fieldType: ValType },
   anyLocal: number,
   valMode: "extern" | "f64" | "i32",
@@ -2672,6 +2681,23 @@ function buildSetterStore(
   then.push({ op: "local.get", index: 1 } as Instr);
 
   if (valMode === "extern") {
+    // (#2831) Vec-typed field: the inbound externref may be a HOST-marshalled
+    // array (or any externref), NOT a wasm vec — the prior unguarded
+    // `any.convert_extern; ref.cast(_null) $vec` traps `illegal cast` (or, under
+    // the `_safeSet` try/catch, degrades to a SILENTLY-DROPPED cross-rep write).
+    // Route through the reserved host-aware materializer instead, which builds a
+    // fresh vec of the exact target type on the slot (empty/non-empty/host/
+    // same-rep/null uniformly). Value (local 1, externref) is already on stack.
+    // Name-based lookup (funcMap stays in lockstep across late-import shifts);
+    // undefined pre-reserve ⇒ falls back to the guarded cast below.
+    const vecMatName = ft.kind === "ref" || ft.kind === "ref_null" ? ctx.vecFromExternMap?.get(ft.typeIdx) : undefined;
+    const vecMatIdx = vecMatName !== undefined ? ctx.funcMap.get(vecMatName) : undefined;
+    if (vecMatIdx !== undefined) {
+      then.push({ op: "call", funcIdx: vecMatIdx } as Instr);
+      if (ft.kind === "ref") then.push({ op: "ref.as_non_null" } as Instr);
+      then.push({ op: "struct.set", typeIdx: entry.typeIdx, fieldIdx: entry.fieldIdx } as Instr);
+      return then;
+    }
     // Field kinds are restricted by isRefKind above to: ref / ref_null /
     // anyref / externref / ref_extern. externref & ref_extern need no
     // conversion; everything else converts externref → anyref first, then
@@ -5996,6 +6022,12 @@ export function generateMultiModule(
       for (const [k, v] of ctx.exportSignatures) obj[k] = v;
       mod.exportSignatures = obj;
     }
+
+    // (#2831) Reserve the host-externref → wasm-vec materializers before the
+    // `__sset_*` setters bake their value coercions (mirrors the generateModule
+    // path). No member-set-dispatch in this multi-source path, so only the
+    // `__sset_*` (b) enumeration contributes; no-op without a vec write target.
+    reserveVecFieldMaterializers(ctx);
 
     // Emit exported struct field getter helpers for the runtime (mirrors
     // generateModule path — #1308 surfaced that multi-source projects

--- a/src/codegen/member-set-dispatch.ts
+++ b/src/codegen/member-set-dispatch.ts
@@ -42,7 +42,7 @@ import { findAlternateStructsForField } from "./property-access.js";
 import { addStringConstantGlobal } from "./registry/imports.js";
 import { addFuncType } from "./registry/types.js";
 import { addUnionImportsViaRegistry, ensureLateImport, flushLateImportShifts } from "./shared.js";
-import { coercionInstrs } from "./type-coercion.js";
+import { buildVecFromExternMaterializer, coercionInstrs, getVecInfo } from "./type-coercion.js";
 
 /**
  * Mangle a property name + fallback strictness into the reserved dispatcher name.
@@ -204,5 +204,66 @@ export function fillMemberSetDispatch(ctx: CodegenContext): void {
       { op: "local.set", index: 2 } as Instr, // __any
       ...buildSetDispatch(0),
     ];
+  }
+}
+
+/**
+ * (#2831) FINALIZE sub-pass — reserve ONE host-externref → wasm-vec materializer
+ * `__vec_from_extern_<vecTypeIdx>` per DISTINCT vec-typed struct field that a
+ * dynamic write can target, BEFORE the value-coercion fills bake.
+ *
+ * Why a separate up-front pass: the materializer body (`buildVecFromExternref`)
+ * `ensureLateImport`s its helpers and `flushLateImportShifts` — registering an
+ * import after the index-space freeze, or mid-`fill*`, shifts already-baked func
+ * indices (the addUnionImports hazard the reserve-then-fill pattern exists to
+ * avoid). Reserving here — where shifts are still legal and this pass OWNS them —
+ * lets `coercionInstrs` (member-set-dispatch + inline) and `buildSetterStore`
+ * (`__sset_*`) merely `call` the materializer (read-only over funcMap), with NO
+ * funcIdx churn at fill. Must run BEFORE `emitStructFieldSetters`,
+ * `fillMemberSetDispatch`, and `fillMemberGetDispatch`.
+ *
+ * Scope: every MUTABLE vec-typed field reachable from
+ *   (a) the member-set dispatcher candidates (`findAlternateStructsForField`),
+ *       i.e. the dynamic `any`-receiver write path (the acorn `this.x = []` trap);
+ *   (b) the `__sset_<field>` exported host setters (the same mutable struct
+ *       fields the `_safeSet` MOP-write path narrows).
+ * No-op when no vec-typed write target exists ⇒ byte-identical.
+ */
+export function reserveVecFieldMaterializers(ctx: CodegenContext): void {
+  const targetVecIdxs = new Set<number>();
+  const consider = (ft: ValType | undefined): void => {
+    if (!ft || (ft.kind !== "ref" && ft.kind !== "ref_null")) return;
+    const idx = (ft as { typeIdx: number }).typeIdx;
+    if (getVecInfo(ctx, idx)) targetVecIdxs.add(idx);
+  };
+
+  // (a) member-set dispatcher candidates — the dynamic any-receiver write path.
+  for (const key of ctx.memberSetDispatchNames ?? []) {
+    const sep = key.lastIndexOf("\0");
+    const propName = sep >= 0 ? key.slice(0, sep) : key;
+    for (const cand of findAlternateStructsForField(ctx, propName, -1)) {
+      if (cand.mutable) consider(cand.fieldType);
+    }
+  }
+
+  // (b) `__sset_<field>` exported host setters — mirror the field-enumeration
+  // skip rules of `_emitStructFieldSettersInner` (mutable, non-`$`, non-carrier).
+  for (const [structName, fields] of ctx.structFields) {
+    if (
+      structName.startsWith("Wrapper") ||
+      structName === "$AnyValue" ||
+      structName.startsWith("__vec_") ||
+      structName.startsWith("__arr_")
+    ) {
+      continue;
+    }
+    for (const field of fields) {
+      if (!field || !field.type || !field.name || field.name.startsWith("$") || !field.mutable) continue;
+      consider(field.type);
+    }
+  }
+
+  for (const vecIdx of targetVecIdxs) {
+    buildVecFromExternMaterializer(ctx, vecIdx);
   }
 }

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -14,7 +14,7 @@ import type { ClosureInfo, CodegenContext, FunctionContext, OptionalParamInfo } 
 import { addUnionImports, ensureAnyHelpers, ensureAnyToExternHelper, isAnyValue } from "./index.js";
 import { ensureAnyToStringHelper, stringConstantExternrefInstrs } from "./native-strings.js";
 import { addStringConstantGlobal } from "./registry/imports.js";
-import { getArrTypeIdxFromVec } from "./registry/types.js";
+import { addFuncType, getArrTypeIdxFromVec } from "./registry/types.js";
 import { ensureLateImport, flushLateImportShifts, materializeStructAsObject, registerCoerceType } from "./shared.js";
 
 /**
@@ -401,6 +401,117 @@ export function buildVecFromExternref(
     { op: "local.get", index: arrLocal } as Instr,
     { op: "struct.new", typeIdx: vecTypeIdx } as Instr,
   ];
+}
+
+/**
+ * (#2831) Reserve (or fetch) the per-target-vec materializer
+ * `__vec_from_extern_<vecTypeIdx>(val: externref) -> (ref null $vec)` and record
+ * its NAME in `ctx.vecFromExternMap`. Returns the helper name (so callers resolve
+ * the funcIdx via `funcMap` at emit time, immune to later import shifts), or
+ * `undefined` if `vecTypeIdx` is not a vec struct or the index space is frozen.
+ *
+ * The body is the host-externref → wasm-vec conversion, guarded so it is safe at
+ * a dynamic any-receiver write where the inbound value is an OPAQUE host
+ * externref (a `[]` already marshalled by `__make_iterable`), not a wasm vec:
+ *
+ *   1. `null`/`undefined` input            → `ref.null $vec` (store null on the
+ *      slot; do NOT route to the sidecar — keeps reads+writes on the same rep).
+ *   2. already this exact vec rep (a wasm  → `ref.cast $vec` (identity-preserving
+ *      vec boxed via `extern.convert_any`)   short-circuit; no rebuild/copy).
+ *   3. otherwise (host array / cross-rep)  → `buildVecFromExternref`: read
+ *      `__extern_length` + per-element `__extern_get`, element-coerce, and
+ *      `struct.new` a FRESH vec of the exact target type.
+ *
+ * This is the read-consistent inverse of `__make_iterable`; the produced value is
+ * stored by `struct.set` directly on the slot (no sidecar ⇒ no #2664 desync, no
+ * unguarded `ref.cast` ⇒ no #2831 `illegal cast` trap).
+ *
+ * Built with a REAL FunctionContext so `buildVecFromExternref` owns its
+ * `ensureLateImport` + single `flushLateImportShifts` — this MUST be called from
+ * the pre-fill reserve pass (`reserveVecFieldMaterializers`), where index shifts
+ * are still permitted, NOT from inside any `fill*` (which must be funcIdx-stable).
+ */
+/**
+ * (#2831) Resolve the funcIdx of the reserved `__vec_from_extern_<vecTypeIdx>`
+ * materializer for `vecTypeIdx`, or `undefined` if none was reserved. Name-based
+ * (via `funcMap`) so it stays correct across late-import index shifts. Returns
+ * `undefined` pre-reserve, so coercion call sites fall back to their guarded cast.
+ */
+export function vecFromExternFuncIdx(ctx: CodegenContext, vecTypeIdx: number): number | undefined {
+  const name = ctx.vecFromExternMap?.get(vecTypeIdx);
+  if (name === undefined) return undefined;
+  return ctx.funcMap.get(name);
+}
+
+export function buildVecFromExternMaterializer(ctx: CodegenContext, vecTypeIdx: number): string | undefined {
+  const name = `__vec_from_extern_${vecTypeIdx}`;
+  if (ctx.funcMap.get(name) !== undefined) return name; // idempotent
+  if (ctx.indexSpaceFrozen) return undefined; // cannot register a defining func / import past the freeze
+  const vecInfo = getVecInfo(ctx, vecTypeIdx);
+  if (!vecInfo) return undefined;
+
+  const resultType: ValType = { kind: "ref_null", typeIdx: vecTypeIdx };
+  // Synthetic FunctionContext: one externref param (the value), returns ref_null
+  // vec. buildVecFromExternref allocLocals on this fctx and reads param slot 0.
+  const fctx: FunctionContext = {
+    name,
+    params: [{ name: "val", type: { kind: "externref" } }],
+    locals: [],
+    localMap: new Map<string, number>(),
+    returnType: resultType,
+    body: [],
+    blockDepth: 0,
+    breakStack: [],
+    continueStack: [],
+    labelMap: new Map(),
+    savedBodies: [],
+  };
+
+  // The cross-rep / host-array conversion (registers its late imports + flushes
+  // against fctx; produces ref_null $vec). Built first so its locals are
+  // allocated before the short-circuit temp below.
+  const matInstrs = buildVecFromExternref(ctx, fctx, 0, vecTypeIdx, vecInfo);
+  const tmpAny = allocLocal(fctx, `__vfe_any_${fctx.locals.length}`, { kind: "anyref" } as ValType);
+
+  const body: Instr[] = [
+    // (1) null/undefined guard.
+    { op: "local.get", index: 0 } as Instr,
+    { op: "ref.is_null" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "val", type: resultType },
+      then: [{ op: "ref.null", typeIdx: vecTypeIdx } as Instr],
+      else: [
+        // (2) same-rep short-circuit: a wasm vec of this exact type, boxed via
+        // extern.convert_any, is cast straight through (identity preserved). The
+        // value is non-null here, so the non-null ref.test/ref.cast pair is safe.
+        { op: "local.get", index: 0 } as Instr,
+        { op: "any.convert_extern" } as Instr,
+        { op: "local.tee", index: tmpAny } as Instr,
+        { op: "ref.test", typeIdx: vecTypeIdx } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "val", type: resultType },
+          then: [{ op: "local.get", index: tmpAny } as Instr, { op: "ref.cast", typeIdx: vecTypeIdx } as Instr],
+          // (3) host externref / cross-rep → materialize a fresh exact-type vec.
+          else: matInstrs,
+        } as Instr,
+      ],
+    } as Instr,
+  ];
+
+  const typeIdx = addFuncType(ctx, [{ kind: "externref" }], [resultType], "$vec_from_extern_type");
+  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  ctx.mod.functions.push({
+    name,
+    typeIdx,
+    locals: fctx.locals,
+    body,
+    exported: false,
+  });
+  ctx.funcMap.set(name, funcIdx);
+  (ctx.vecFromExternMap ??= new Map<number, string>()).set(vecTypeIdx, name);
+  return name;
 }
 
 /**
@@ -2994,6 +3105,16 @@ export function coercionInstrs(ctx: CodegenContext, from: ValType, to: ValType, 
   // externref → ref_null: any.convert_extern + guarded ref.cast_null
   if (from.kind === "externref" && to.kind === "ref_null") {
     const toIdx = (to as { typeIdx: number }).typeIdx;
+    // (#2831) Vec-typed target: the inbound externref may be a HOST value (a `[]`
+    // already marshalled by `__make_iterable` at a dynamic any-receiver write),
+    // NOT a wasm vec. A bare/guarded ref.cast either TRAPS (no fctx) or silently
+    // returns null → DROPPED write (the #2664 desync). Route through the reserved
+    // per-vec materializer (host-externref-aware; empty/non-empty/host/same-rep/
+    // null uniformly → fresh vec of the exact type, on the slot). Only once
+    // `reserveVecFieldMaterializers` has populated the map (finalize); pre-finalize
+    // callers keep the guarded-cast path below (byte-identical).
+    const vecMatIdx = vecFromExternFuncIdx(ctx, toIdx);
+    if (vecMatIdx !== undefined) return [{ op: "call", funcIdx: vecMatIdx } as Instr];
     if (fctx) {
       const tmp = allocTempLocal(fctx, { kind: "anyref" } as ValType);
       const result: Instr[] = [
@@ -3017,6 +3138,13 @@ export function coercionInstrs(ctx: CodegenContext, from: ValType, to: ValType, 
   // externref → ref: any.convert_extern + guarded ref.cast
   if (from.kind === "externref" && to.kind === "ref") {
     const toIdx = (to as { typeIdx: number }).typeIdx;
+    // (#2831) Vec-typed non-null target — same materializer routing as the
+    // ref_null arm above; the materializer returns ref_null $vec, so assert
+    // non-null for the (ref $vec) field type (a null write traps, matching the
+    // non-null field contract — never silently dropped).
+    const vecMatIdx = vecFromExternFuncIdx(ctx, toIdx);
+    if (vecMatIdx !== undefined)
+      return [{ op: "call", funcIdx: vecMatIdx } as Instr, { op: "ref.as_non_null" } as Instr];
     if (fctx) {
       const tmp = allocTempLocal(fctx, { kind: "anyref" } as ValType);
       const result: Instr[] = [

--- a/tests/issue-2831-vec-from-extern-materializer.test.ts
+++ b/tests/issue-2831-vec-from-extern-materializer.test.ts
@@ -1,0 +1,113 @@
+// #2831 — the member-WRITE value coercion `__set_member_<name>` / `__sset_<name>`
+// emitted an UNGUARDED narrowing `ref.cast` on the inbound externref value. At a
+// dynamic any-receiver write `this.x = []`, the `[]` is built as a wasm
+// `$__vec_externref` then marshalled to a HOST externref via `__make_iterable`
+// before the setter — so the host value is not the wasm vec struct and the
+// unguarded cast trapped `illegal cast` (compiled acorn could not parse ANY
+// function/arrow body, whose `parseFunctionBody` does `this.labels = []`).
+//
+// Fix (#2831): a reserved per-target-vec materializer
+// `__vec_from_extern_<vecIdx>(externref) -> (ref null $vec)` —
+// `buildVecFromExternref`, the read-consistent inverse of `__make_iterable` —
+// converts the host externref (empty / non-empty / host-array / same-rep / null)
+// into a FRESH vec of the EXACT target type on the SLOT (no sidecar ⇒ no #2664
+// desync; no bare ref.cast ⇒ no trap). Routed at all three setter emitters via
+// `coercionInstrs` (member-set-dispatch + inline) and `buildSetterStore`
+// (`__sset_*`).
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+
+async function run(src: string): Promise<{ exp: any; wat: string }> {
+  const result: any = await compile(src, { fileName: "probe.ts" });
+  expect(result.success).toBe(true);
+  const io: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, io);
+  io.__setExports?.(instance.exports);
+  return { exp: wrapExports(instance.exports, { signatures: result.exportSignatures }), wat: result.wat as string };
+}
+
+describe("#2831 — host-externref → wasm-vec materializer for dynamic vec-field writes", () => {
+  it("empty `this.x = []` on a dynamic any-receiver does NOT trap and is not stale (length 0)", async () => {
+    // The architect's minimal repro: `reset()` writes `[]` on a prototype-method
+    // `this` (dynamic any-receiver). Pre-fix this trapped `illegal cast` in
+    // `__set_member_labels`; the wasm-vec-only guard alternative SILENTLY DROPPED
+    // the write (returned the stale length). Must read back 0.
+    const { exp } = await run(`
+      // @ts-nocheck
+      var P = function P(){ this.labels = [{k:1},{k:2}]; };
+      P.prototype.reset = function(){ this.labels = []; };
+      P.prototype.run = function(){ this.reset(); return this.labels.length; };
+      export function probe(){ return new P().run(); }
+    `);
+    expect(exp.probe()).toBe(0);
+  });
+
+  it("`this.x = null` then a fresh `this.x = []` does NOT trap and the slot is usable (length 0)", async () => {
+    // The materializer's null guard returns `ref.null $vec` (no `__extern_length`
+    // on null). A null write must not corrupt the slot for a later vec write —
+    // the subsequent `[]` materializes a fresh empty vec and reads back length 0.
+    const { exp } = await run(`
+      // @ts-nocheck
+      var P = function P(){ this.labels = [{k:1}]; };
+      P.prototype.clear = function(){ this.labels = null; };
+      P.prototype.reset = function(){ this.labels = []; };
+      P.prototype.run = function(){ this.clear(); this.reset(); return this.labels.length; };
+      export function probe(){ return new P().run(); }
+    `);
+    expect(exp.probe()).toBe(0);
+  });
+
+  it("same-rep restore (`this.x = oldVecReadBack`) preserves length (identity short-circuit)", async () => {
+    const { exp } = await run(`
+      // @ts-nocheck
+      var P = function P(){ this.labels = [{k:1},{k:2},{k:3}]; };
+      P.prototype.restore = function(){ var t = this.labels; this.labels = t; };
+      P.prototype.run = function(){ this.restore(); return this.labels.length; };
+      export function probe(){ return new P().run(); }
+    `);
+    expect(exp.probe()).toBe(3);
+  });
+
+  it("non-empty cross-rep numeric write materializes the exact vec (length + element readback)", async () => {
+    const { exp } = await run(`
+      // @ts-nocheck
+      var P = function P(){ this.vals = [1]; };
+      P.prototype.reset = function(){ this.vals = [10, 20, 30]; };
+      P.prototype.run = function(){ this.reset(); return this.vals.length * 100 + this.vals[1]; };
+      export function probe(){ return new P().run(); }
+    `);
+    expect(exp.probe()).toBe(320);
+  });
+
+  it("the vec-field write routes through `__vec_from_extern_*` (no unguarded value ref.cast)", async () => {
+    const { wat } = await run(`
+      // @ts-nocheck
+      var P = function P(){ this.labels = [{k:1}]; };
+      P.prototype.reset = function(){ this.labels = []; };
+      P.prototype.run = function(){ this.reset(); return this.labels.length; };
+      export function probe(){ return new P().run(); }
+    `);
+    // The reserved materializer helper must exist and be called from the setter.
+    expect(wat).toContain("__vec_from_extern_");
+  });
+
+  it("the #2664 slot/sidecar terminate invariant still holds with the new value coercion", async () => {
+    // A closure `this.type = v` write + a loop reading `this.type` MUST terminate
+    // (the write hits the slot the read uses). Unchanged by #2831 — scalar field,
+    // not a vec — but guard against the materializer pass perturbing it.
+    const { exp } = await run(`
+      // @ts-nocheck
+      var P = function P() { this.type = 0; };
+      var pp = P.prototype;
+      pp.finishToken = function(t) { this.type = t; };
+      pp.run = function() {
+        var guard = 0;
+        while (this.type !== 99 && guard < 1000) { this.finishToken(99); guard = guard + 1; }
+        return this.type;
+      };
+      export function probe() { return new P().run(); }
+    `);
+    expect(exp.probe()).toBe(99);
+  });
+});


### PR DESCRIPTION
## #2831 — `__set_member_<name>` / `__sset_<name>` value coercion traps `illegal cast` on `this.x = []`

**Blocks #1712 (acorn parses a real file).** The member-WRITE value coercion emitted an UNGUARDED narrowing `ref.cast` on the inbound externref value. At a dynamic any-receiver write `this.x = []`, the `[]` is built as a wasm `$__vec_externref` then marshalled to a **host externref** via `__make_iterable` before the setter — so the host value is not the wasm vec struct and the unguarded cast trapped `illegal cast`. This blocked compiled acorn on **any function/arrow body** (`parseFunctionBody` does `this.labels = []`).

A wasm-vec-only `ref.test` guard is NOT a valid fix — it doesn't recognise the host value and silently DROPS the write (the #2664 slot/sidecar desync). The conversion MUST be host-externref-aware.

## Fix (architect Option A)
Reserve ONE per-target-vec materializer `__vec_from_extern_<vecIdx>(externref) -> (ref null $vec)` — `buildVecFromExternref`, the read-consistent inverse of `__make_iterable` — in a finalize sub-pass `reserveVecFieldMaterializers` that **owns its import shifts** (reserve-then-fill, #2043), BEFORE the setter/dispatch emitters bake. The helper:
1. null-guards (`ref.null $vec`),
2. same-rep `ref.test` short-circuits (identity-preserving — no rebuild/copy),
3. else materializes a FRESH vec of the EXACT target type **on the slot** (empty/non-empty/host/cross-rep uniformly; no sidecar ⇒ no #2664 desync, no bare `ref.cast` ⇒ no trap).

Routed at all **three** setter sites: the two `externref→ref`/`ref_null` arms of `coercionInstrs` (covers the `__set_member_*` dispatcher fill **and** the inline static write) and `buildSetterStore` (`__sset_*`). Name-based `funcMap` lookup keeps the call correct across later late-import index shifts (#1461/#2193 hazard).

## Result
- `parse("function f(){}")` / `parse("async function f(){}")` on compiled acorn@8.16.0 → **PARSE OK** (no `illegal cast`).
- `parse("var g=(x)=>x;")` → **no longer `illegal cast`**; advances to a distinct NEXT wall (arrow-param `toAssignable` — see issue notes, a separate follow-up).
- NM differential: `foo(bar,baz)` structurally equal to node-acorn modulo the known marshalling quirks (null `sourceFile`, boolean-as-i32). `background.js`/`edge.js` now reach the same arrow-param wall instead of the cast trap.
- New `tests/issue-2831-*` (6) + #2664/#2806/#2809 non-regression green; typecheck + prettier + biome clean.

Representation-scale change (reference_2379) → full `merge_group` + standalone-floor validation.

Closes #2831.

🤖 Generated with [Claude Code](https://claude.com/claude-code)