### PR TITLE
fix(#2833): add .ts extension to native-messaging relative imports

### DIFF
--- a/examples/native-messaging/nm_js2wasm_deno.ts
+++ b/examples/native-messaging/nm_js2wasm_deno.ts
@@ -50,7 +50,7 @@
 // followed by a UTF-8 JSON body, exchanged over fd 0 (stdin) / fd 1 (stdout). See
 //   https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging
 
-import { runNmHost } from "./nm_js2wasm_sync_framing";
+import { runNmHost } from "./nm_js2wasm_sync_framing.ts";
 
 // ONE Deno `readSync`: fills the whole buffer it is handed and returns the count,
 // or `null` at EOF (the core treats `null` / `<= 0` as EOF).

--- a/examples/native-messaging/nm_js2wasm_node_fs.ts
+++ b/examples/native-messaging/nm_js2wasm_node_fs.ts
@@ -63,7 +63,7 @@
 //              newline; the partial-write loop drains the whole buffer.
 
 import { readSync, writeSync } from "node:fs";
-import { runNmHost } from "./nm_js2wasm_sync_framing";
+import { runNmHost } from "./nm_js2wasm_sync_framing.ts";
 
 // ONE incremental fd=0 read filling the WHOLE buffer it is handed (offset 0,
 // length = buf.length); returns the byte count (0 at EOF — the core treats

--- a/plan/issues/2833-nm-extensionless-relative-imports-break-deno.md
+++ b/plan/issues/2833-nm-extensionless-relative-imports-break-deno.md
@@ -1,0 +1,77 @@
+---
+id: 2833
+title: Extension-less relative imports break Deno / `deno bundle` in native-messaging examples
+status: done
+sprint: current
+priority: medium
+area: examples
+task_type: bug
+related: [389]
+assignee: ttraenkler/agent-a5eb860ae7564464e
+completed: 2026-06-29
+---
+
+# Extension-less relative imports break Deno in native-messaging examples
+
+## Problem
+
+`examples/native-messaging/nm_js2wasm_deno.ts` and
+`examples/native-messaging/nm_js2wasm_node_fs.ts` both imported the shared
+framing core with **no file extension**:
+
+```ts
+import { runNmHost } from "./nm_js2wasm_sync_framing";
+```
+
+Deno's module resolver (used by `deno run`, `deno check`, and `deno bundle`)
+cannot resolve an extension-less relative import without
+`--unstable-sloppy-imports` plus an import-map alias. The loopdive/js2#389
+reporter hit exactly this:
+
+```
+error: Cannot find module 'file:///…/nm_js2wasm_sync_framing'.
+       Maybe add a '.ts' extension or run with --sloppy-imports
+```
+
+The `nm_js2wasm_deno.ts` doc comment explicitly promises the file runs
+UNMODIFIED under real `deno run`, so the missing extension was a direct
+contradiction of the example's stated contract.
+
+## Fix
+
+Add the explicit `.ts` extension to the relative imports:
+
+```ts
+import { runNmHost } from "./nm_js2wasm_sync_framing.ts";
+```
+
+Applied to both `nm_js2wasm_deno.ts:53` and `nm_js2wasm_node_fs.ts:66`. A grep
+of ALL of `examples/` for other extension-less relative imports
+(`from "./…"` / `from "../…"` and dynamic `import("./…")`) found no others —
+these two were the only occurrences. The `.ts`-extension import form is
+TypeScript's NodeNext / `allowImportingTsExtensions` style and resolves cleanly
+across every consumer here (Deno, bun, and the js2wasm CLI), so no tsconfig
+change was needed.
+
+## Test Results
+
+Toolchain available: deno 2.8.3, bun 1.3.14, node v25.9.0, wasmtime 46.0.1.
+
+- **`deno check` (strict resolver — the failing path):**
+  - Control (extension-less, on a temp copy) → FAILS with the reporter's exact
+    error: `Cannot find module '…nm_js2wasm_sync_framing'. Maybe add a '.ts'
+    extension or run with --sloppy-imports`.
+  - Fixed (`.ts`) → `deno check nm_js2wasm_node_fs.ts` and
+    `deno check nm_js2wasm_deno.ts` both PASS.
+- **`deno bundle … -o /tmp/x.js` WITHOUT `--sloppy-imports`** → succeeds for
+  both `nm_js2wasm_node_fs.ts` and `nm_js2wasm_deno.ts` (2 modules bundled
+  each). (Note: deno 2.8's esbuild-based `deno bundle` is itself lenient about
+  the extension; `deno check`/`deno run` are the strict path the reporter hit,
+  and those are now fixed.)
+- **`node examples/native-messaging/scale-test.mjs`** with
+  `NM_SCALE_SIZES_MIB="1 64"` → PASS: all four variants
+  (`node_process`, `deno`, `wasi_p1`, `node_fs`) build via `bun build` and
+  round-trip the 1 MiB and 64 MiB framed bodies under real wasmtime, re-chunking
+  to valid ≤1 MiB JSON frames.
+- **js2wasm CLI `--target wasi`** on both changed files → compiles cleanly to
+  `.wasm` (no import-resolution regression).

--- a/plan/issues/2834-nm-node-process-not-node-runnable-buffer-chunks.md
+++ b/plan/issues/2834-nm-node-process-not-node-runnable-buffer-chunks.md
@@ -1,0 +1,49 @@
+---
+id: 2834
+title: nm_js2wasm_node_process example is not node-runnable (Buffer stdin chunks)
+status: ready
+sprint: current
+priority: low
+area: examples
+task_type: bug
+related: [389, 2832]
+---
+
+# nm_js2wasm_node_process is not node-runnable (Buffer stdin chunks)
+
+## Problem
+
+`examples/native-messaging/nm_js2wasm_node_process.ts`, run under **real
+`node`** via the bun-bundled `.js`, throws:
+
+```
+TypeError: chunk.charCodeAt is not a function
+```
+
+Real node delivers `process.stdin` `'data'` chunks as **`Buffer`** objects, but
+the host assumes **string** chunks (the shape the js2wasm prelude / bundled
+harness provides), calling `chunk.charCodeAt(...)` on them. A `Buffer` has no
+`charCodeAt`, so it throws on the first chunk.
+
+The loopdive/js2#389 reporter confirmed: "node_process doesn't work using node
+and the .js file." The example README only claims this variant runs under
+**wasmtime**, so the source is doc-consistent — but the `node_process` source is
+not actually node-runnable despite its name implying a `process.stdin`/`process`
+Node host.
+
+## Decision / Goal
+
+Pick per maintainer preference:
+
+- **(a) Make the host accept `Buffer` chunks** — read bytes via
+  `Buffer.prototype` access / `.toString()` / byte indexing instead of
+  `charCodeAt`, so the same source runs under real node as well as wasmtime.
+- **(b) Document it as wasmtime-only** — explicitly state (and guard/clarify the
+  entry point) that `nm_js2wasm_node_process` targets a WASI host and is not
+  intended to run under real node, removing the misleading "node" framing or
+  adding a clear runtime note.
+
+## Notes
+
+Tracking only — no implementation in the PR that created this file. Related to
+the #389 native-messaging example hardening series (#2832, #2833).


### PR DESCRIPTION
Fixes the extension-less relative imports in the native-messaging examples that break Deno (loopdive/js2#389).

## #2833 — implementation
`nm_js2wasm_deno.ts` and `nm_js2wasm_node_fs.ts` imported the shared core as `"./nm_js2wasm_sync_framing"` with no extension. Deno's strict resolver (`deno run`/`deno check`) cannot resolve that without `--unstable-sloppy-imports` + an import-map alias — the #389 reporter hit `Cannot find module … Maybe add a '.ts' extension`. Added the explicit `.ts` extension to both. A grep of all of `examples/` found no other extension-less relative imports.

### Verified
- **`deno check`** (the strict path): control without extension reproduces the reporter's exact error; both fixed files now pass.
- **`deno bundle … -o /tmp/x.js` WITHOUT `--sloppy-imports`** → succeeds for both variants.
- **`node examples/native-messaging/scale-test.mjs`** `NM_SCALE_SIZES_MIB="1 64"` → PASS, all four variants build (bun) + round-trip 1 MiB and 64 MiB under wasmtime.
- **js2wasm CLI `--target wasi`** compiles both changed files cleanly (no import-resolution regression).

Sets issue #2833 `status: done`.

## #2834 — tracking only (no code)
Also files `plan/issues/2834-…` (status: ready): `nm_js2wasm_node_process` under real node throws `chunk.charCodeAt is not a function` — node delivers `process.stdin` `'data'` chunks as `Buffer`, but the host assumes string chunks. Decision deferred to maintainer: accept Buffer chunks, or document as wasmtime-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)