### PR TITLE
fix(#2834): make nm_js2wasm_node_process node-runnable via stdin setEncoding

### DIFF
--- a/examples/native-messaging/nm_js2wasm_node_process.ts
+++ b/examples/native-messaging/nm_js2wasm_node_process.ts
@@ -400,6 +400,18 @@ function main(): void {
   // 1 MiB cap) as their bytes arrive, until EOF (or a zero-length frame). The
   // reactor injected for `process.stdin` drives the `'data'`/`'end'` callbacks
   // after `_start` returns.
+  //
+  // setEncoding("latin1") — node-runnability (#2834). Under REAL node a stream with
+  // NO explicit encoding delivers each `'data'` chunk as a `Buffer`, which has no
+  // `.charCodeAt` — so the state machine's `chunk.charCodeAt(...)` byte reads threw
+  // `TypeError: chunk.charCodeAt is not a function` when this source was run as
+  // plain JS under node (loopdive/js2#389). Declaring the "latin1" encoding makes
+  // node deliver one-char-per-byte STRING chunks instead, so `charCodeAt` recovers
+  // the raw byte exactly as it does for the js2wasm prelude's string chunks. Under
+  // `--target wasi` the injected `process.stdin` prelude already materialises every
+  // chunk as a one-char-per-byte string, so `setEncoding` is a faithful no-op there
+  // (the SAME source now runs unchanged under both node and wasmtime).
+  process.stdin.setEncoding("latin1");
   process.stdin.on("data", (chunk: string) => {
     onData(chunk);
   });

--- a/plan/issues/2834-nm-node-process-not-node-runnable-buffer-chunks.md
+++ b/plan/issues/2834-nm-node-process-not-node-runnable-buffer-chunks.md
@@ -1,12 +1,14 @@
 ---
 id: 2834
 title: nm_js2wasm_node_process example is not node-runnable (Buffer stdin chunks)
-status: ready
+status: done
+completed: 2026-06-29
+assignee: ttraenkler/agent-aca3caf083aabc01b
 sprint: current
 priority: low
 area: examples
 task_type: bug
-related: [389, 2832]
+related: [389, 2832, 2831]
 ---
 
 # nm_js2wasm_node_process is not node-runnable (Buffer stdin chunks)
@@ -47,3 +49,46 @@ Pick per maintainer preference:
 
 Tracking only — no implementation in the PR that created this file. Related to
 the #389 native-messaging example hardening series (#2832, #2833).
+
+## Resolution (option a — node-runnable via setEncoding)
+
+Fixed by declaring the stdin encoding instead of per-byte Buffer handling:
+
+- `examples/native-messaging/nm_js2wasm_node_process.ts` calls
+  `process.stdin.setEncoding("latin1")` BEFORE subscribing. Under REAL node this
+  switches the stream to deliver one-char-per-byte latin1 **string** chunks, so
+  the state machine's `chunk.charCodeAt(...)` byte reads recover the raw byte
+  exactly as they do for the js2wasm prelude's string chunks — no
+  `TypeError: chunk.charCodeAt is not a function`.
+- `src/process-stdin-prelude.ts` `__Js2wasmReadable` gains a faithful
+  `setEncoding(encoding?)` no-op (returns `this`). The prelude already
+  materialises every chunk as a one-char-per-byte string, so there is no Buffer
+  mode to switch — the SAME source compiles to Wasm unchanged.
+
+This is preferred over per-byte `chunk[i]` access: a js2wasm **native string**'s
+`chunk[i]` yields a 1-char string (not a byte code), and reading bytes off an
+`any`/union/`Buffer` value in compiled code lowers through the externref vec path
+(`__vec_from_extern`), which is invalid under standalone WASI. `setEncoding` keeps
+the wasm path byte-identical (string `charCodeAt`) while making node deliver the
+same string shape.
+
+### Verification
+
+- **Under real node** (`bun build --target node` + transpiled `.js`): framed
+  message round-trips **byte-exact**, exit 0, NO `charCodeAt` error.
+- **New regression test** `tests/issue-2834-nm-node-process-node-runnable.test.ts`
+  runs the transpiled example under the actual `node` binary (single frame +
+  >64 KiB multi-chunk body) and asserts byte-exact echo with no `charCodeAt`
+  TypeError. Passes.
+- **Wasm path** stays covered by the existing `#2735`/`#2752` compile +
+  byte-exact wasmtime round-trip tests (setEncoding is a no-op there).
+
+### Pre-existing blocker (NOT this issue): #2831
+
+`native-messaging-smoke` (`scale-test.mjs`) and the standalone-WASI `process.stdin`
+tests (`issue-2735`, `issue-2752`) are currently **RED on origin/main**, broken by
+#2831 ("host-externref→wasm-vec materializer") since the merge of #2311 — they
+fail at compile with `__vec_from_extern_* … type mismatch: expected i32, found
+externref`. This reproduces on the **unedited** origin/main file (confirmed via
+`git stash`), so it is independent of this change and must be fixed under #2831.
+The node-runnability fix here is verified on the paths #2831 does not break.

--- a/src/process-stdin-prelude.ts
+++ b/src/process-stdin-prelude.ts
@@ -344,6 +344,18 @@ class __Js2wasmReadable {
     return out;
   }
 
+  // setEncoding(encoding): faithful Node Readable surface. In Node a stream with
+  // NO explicit encoding delivers raw \`Buffer\` 'data' chunks; calling
+  // \`setEncoding("latin1")\` (or "utf8", etc.) switches it to deliver decoded
+  // STRING chunks instead. This prelude has no Buffer mode — it ALWAYS materialises
+  // each chunk as a one-char-per-byte (latin1-equivalent) string via
+  // \`String.fromCharCode\` — so under standalone Wasm \`setEncoding\` is a faithful
+  // no-op that simply returns \`this\`. Exposing it lets a single source call
+  // \`process.stdin.setEncoding("latin1")\` so the SAME program runs under REAL node
+  // (where it switches the real stream to latin1 string chunks, so byte-reading
+  // consumers like \`charCodeAt\` work) AND compiles to Wasm unchanged (#2834).
+  setEncoding(encoding?: string): __Js2wasmReadable { return this; }
+
   pause(): __Js2wasmReadable { this.paused = true; return this; }
 
   resume(): __Js2wasmReadable {

--- a/tests/issue-2834-nm-node-process-node-runnable.test.ts
+++ b/tests/issue-2834-nm-node-process-node-runnable.test.ts
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2834 — `nm_js2wasm_node_process` must be runnable under REAL node, not only
+ * compiled to WASI.
+ *
+ * Run as plain JS under real `node` (the reporter's `bun build`/transpile → `.js`
+ * pipeline, loopdive/js2#389), the host threw:
+ *
+ *   TypeError: chunk.charCodeAt is not a function
+ *
+ * Real node delivers `process.stdin` `'data'` chunks as **`Buffer`** objects (no
+ * `.charCodeAt`), but the incremental state machine reads bytes with
+ * `chunk.charCodeAt(...)` — the shape the js2wasm `process.stdin` prelude delivers
+ * (one-char-per-byte STRING chunks). So the very first chunk threw.
+ *
+ * Fix (option a): the host declares its stdin encoding —
+ * `process.stdin.setEncoding("latin1")` — BEFORE subscribing. Under real node that
+ * switches the stream to deliver one-char-per-byte latin1 STRING chunks, so
+ * `charCodeAt` recovers the raw byte exactly as it does for the prelude's string
+ * chunks. Under `--target wasi` the injected prelude's `__Js2wasmReadable` exposes
+ * a faithful `setEncoding` no-op (it already materialises every chunk as a
+ * one-char-per-byte string), so the SAME source compiles to Wasm unchanged — the
+ * compile + byte-exact wasmtime round-trip stay covered by #2735 / #2752.
+ *
+ * This test runs the transpiled `.js` under the ACTUAL `node` binary, feeds it a
+ * framed Native-Messaging message + an in-band zero-length shutdown frame, and
+ * asserts a byte-exact echo with NO `charCodeAt` error.
+ */
+import { spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as esbuild from "esbuild";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const NM_DIR = join(__dirname, "..", "examples", "native-messaging");
+
+/** Frame a body as a 4-byte LE length prefix + the body bytes (Native Messaging). */
+function frame(body: Uint8Array): Uint8Array {
+  const out = new Uint8Array(4 + body.length);
+  const n = body.length;
+  out[0] = n & 0xff;
+  out[1] = (n >> 8) & 0xff;
+  out[2] = (n >> 16) & 0xff;
+  out[3] = (n >> 24) & 0xff;
+  out.set(body, 4);
+  return out;
+}
+
+interface RunResult {
+  stdout: Uint8Array;
+  stderr: string;
+  exitCode: number | null;
+  timedOut: boolean;
+}
+
+/** Spawn `node <jsPath>`, write `input` to stdin (then EOF), resolve on exit. */
+function runNodeStdin(jsPath: string, input: Uint8Array, timeoutMs: number): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [jsPath], { stdio: ["pipe", "pipe", "pipe"] });
+    const out: number[] = [];
+    let err = "";
+    child.stdout.on("data", (d: Buffer) => {
+      for (const b of d) out.push(b);
+    });
+    child.stderr.on("data", (d: Buffer) => {
+      err += d.toString("utf8");
+    });
+    child.stdin.on("error", () => {});
+    let done = false;
+    const timer = setTimeout(() => {
+      if (done) return;
+      done = true;
+      child.kill("SIGKILL");
+      resolve({ stdout: Uint8Array.from(out), stderr: err, exitCode: null, timedOut: true });
+    }, timeoutMs);
+    child.on("exit", (code) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      resolve({ stdout: Uint8Array.from(out), stderr: err, exitCode: code, timedOut: false });
+    });
+    child.stdin.write(Buffer.from(input));
+    child.stdin.end();
+  });
+}
+
+describe("#2834 — nm_js2wasm_node_process runs under real node (Buffer stdin chunks)", () => {
+  let tmpDir: string;
+  let jsPath: string;
+
+  beforeAll(async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "nm-2834-"));
+    // Reporter pipeline: transpile the .ts to plain .js (types stripped), run under node.
+    const tsSrc = readFileSync(join(NM_DIR, "nm_js2wasm_node_process.ts"), "utf-8");
+    const { code } = await esbuild.transform(tsSrc, { loader: "ts", format: "cjs" });
+    jsPath = join(tmpDir, "nm_js2wasm_node_process.js");
+    writeFileSync(jsPath, code);
+  });
+
+  afterAll(() => {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  });
+
+  it("declares stdin encoding so the .js source uses setEncoding (not charCodeAt-on-Buffer)", () => {
+    const tsSrc = readFileSync(join(NM_DIR, "nm_js2wasm_node_process.ts"), "utf-8");
+    expect(tsSrc).toContain('process.stdin.setEncoding("latin1")');
+  });
+
+  it("echoes a framed message byte-exact under real node with NO charCodeAt TypeError", async () => {
+    const bodyStr = JSON.stringify({ hello: "world", n: 42, arr: [1, 2, 3] });
+    const body = Buffer.from(bodyStr, "utf8");
+    const shutdown = new Uint8Array(4); // zero-length frame = in-band clean shutdown
+    const input = new Uint8Array(frame(body).length + shutdown.length);
+    input.set(frame(body), 0);
+    input.set(shutdown, frame(body).length);
+
+    const r = await runNodeStdin(jsPath, input, 10000);
+
+    expect(r.timedOut, "node host hung").toBe(false);
+    expect(r.stderr).not.toContain("charCodeAt"); // the #2834 regression signature
+    expect(r.exitCode).toBe(0);
+    // One echoed frame: 4-byte prefix + the original body, byte-exact.
+    expect(r.stdout.length).toBe(4 + body.length);
+    const echoedLen = r.stdout[0]! + r.stdout[1]! * 256 + r.stdout[2]! * 65536 + r.stdout[3]! * 16777216;
+    expect(echoedLen).toBe(body.length);
+    expect(Buffer.from(r.stdout.slice(4)).toString("utf8")).toBe(bodyStr);
+  });
+
+  it("round-trips a multi-chunk (>64 KiB) body byte-exact under real node", async () => {
+    // A body larger than node's default 64 KiB stdin highWaterMark arrives across
+    // several Buffer 'data' chunks — exercises the cross-chunk state machine with
+    // the latin1 string chunks setEncoding now delivers.
+    const elems: string[] = [];
+    for (let i = 0; i < 20000; i = i + 1) elems.push(String(i));
+    const bodyStr = `[${elems.join(",")}]`; // ~100 KiB JSON array, still < 1 MiB cap
+    const body = Buffer.from(bodyStr, "utf8");
+    const shutdown = new Uint8Array(4);
+    const input = new Uint8Array(frame(body).length + shutdown.length);
+    input.set(frame(body), 0);
+    input.set(shutdown, frame(body).length);
+
+    const r = await runNodeStdin(jsPath, input, 15000);
+
+    expect(r.timedOut).toBe(false);
+    expect(r.stderr).not.toContain("charCodeAt");
+    expect(r.exitCode).toBe(0);
+    // Body is within the 1 MiB cap, so it is echoed verbatim as one frame.
+    expect(r.stdout.length).toBe(4 + body.length);
+    expect(Buffer.from(r.stdout.slice(4)).toString("utf8")).toBe(bodyStr);
+  });
+});


### PR DESCRIPTION
## Problem

`examples/native-messaging/nm_js2wasm_node_process.ts`, run as plain JS under
**real `node`** (the reporter's `bun build`/transpile → `.js` pipeline,
loopdive/js2#389), threw:

```
TypeError: chunk.charCodeAt is not a function
```

Real node delivers `process.stdin` `'data'` chunks as **`Buffer`** objects (no
`.charCodeAt`), but the incremental state machine reads bytes with
`chunk.charCodeAt(...)` — the shape the js2wasm `process.stdin` prelude delivers
(one-char-per-byte STRING chunks). So the first chunk threw.

## Fix (option a — node-runnable via setEncoding)

- `nm_js2wasm_node_process.ts` calls `process.stdin.setEncoding("latin1")` BEFORE
  subscribing. Under real node this switches the stream to deliver
  one-char-per-byte latin1 **string** chunks, so `charCodeAt` recovers the raw
  byte exactly as for the prelude's string chunks.
- `src/process-stdin-prelude.ts` `__Js2wasmReadable` gains a faithful
  `setEncoding(encoding?)` no-op (returns `this`) — the prelude already
  materialises every chunk as a one-char-per-byte string, so the SAME source
  compiles to Wasm unchanged.

Preferred over per-byte `chunk[i]`: a js2wasm **native string**'s `chunk[i]`
yields a 1-char string (not a byte code), and reading bytes off an
`any`/union/`Buffer` in compiled code lowers through the externref vec path
(`__vec_from_extern`), invalid under standalone WASI. `setEncoding` keeps the
wasm path byte-identical.

## Verification

- **Under real node** (`bun build --target node` + transpiled `.js`): framed
  message round-trips **byte-exact**, exit 0, NO `charCodeAt` error.
- **New test** `tests/issue-2834-nm-node-process-node-runnable.test.ts` runs the
  transpiled example under the actual `node` binary (single frame + >64 KiB
  multi-chunk body); byte-exact echo, no `charCodeAt` TypeError. Passes.
- **Wasm path** stays covered by existing `#2735`/`#2752` compile + byte-exact
  wasmtime round-trip tests (setEncoding is a no-op there).

## Pre-existing blocker — NOT this PR (#2831)

`native-messaging-smoke` (`scale-test.mjs`) and the standalone-WASI
`process.stdin` tests (`issue-2735`, `issue-2752`) are **already RED on
origin/main** since #2311 — #2831 ("host-externref→wasm-vec materializer") broke
the standalone-WASI `process.stdin` compile (`__vec_from_extern_* … expected
i32, found externref`). Reproduces on the **unedited** origin/main file
(git-stash confirmed), so it is independent of this change and tracked under
#2831. The node-runnability fix here is verified on the paths #2831 does not
break.

Closes #2834.

🤖 Generated with [Claude Code](https://claude.com/claude-code)