### PR TITLE
fix(#2837): route growable object literals to externref $Object (no more dropped out-of-shape writes)

### DIFF
--- a/plan/issues/2837-block-body-arrow-param-wall.md
+++ b/plan/issues/2837-block-body-arrow-param-wall.md
@@ -1,7 +1,9 @@
 ---
 id: 2837
-title: "[SENIOR-DEV ONLY] dynamic property-add to a NON-EMPTY object literal is silently dropped (closed struct, no sidecar) — breaks `Object.defineProperties` getters → compiled acorn throws on every `return` statement"
-status: ready
+title: "[SENIOR-DEV ONLY] dynamic property-add to a NON-EMPTY object literal is silently dropped (closed struct, no sidecar) — route growable literals to externref $Object (Approach A)"
+status: done
+completed: 2026-06-29
+assignee: ttraenkler/sendev-arrowparam
 sprint: current
 priority: high
 horizon: l
@@ -436,9 +438,11 @@ FUNCTION directly in wasm — `po.inFn.get()` — not the installed-accessor cha
 **Conclusion:** Approach A is NECESSARY but NOT SUFFICIENT for acorn's `return`.
 Layer 3 needs its own architect design (member-get on a typed receiver must
 consult runtime-installed prototype accessors via the host MOP, or acorn-shape
-`prototypeAccessors` getters must be modeled statically). ESCALATED — do not land
-a broad object-rep change that does not reach the milestone without the lead's
-decision on landing-as-stepping-stone vs combining with the Layer-3 fix.
+`prototypeAccessors` getters must be modeled statically). **Carved as #2838**
+(dynamic prototype-accessor dispatch; `depends_on: 2837`). Per the tech lead's
+Option-1 decision, this PR lands Approach A as a stepping stone (it fixes the REAL
+general dropped-out-of-shape-write data-loss bug, valuable beyond acorn); #2838
+tracks the orthogonal accessor-dispatch layer.
 
 ### NOTE — possible round 6 (set expectation)
 

--- a/plan/issues/2837-block-body-arrow-param-wall.md
+++ b/plan/issues/2837-block-body-arrow-param-wall.md
@@ -1,10 +1,10 @@
 ---
 id: 2837
-title: "[SENIOR-DEV ONLY] compiled acorn throws on BLOCK-BODY arrow functions with params — `(a) => { … }` / `x => { … }` (round-4 acorn-dogfood wall, blocks full edge.js equality)"
+title: "[SENIOR-DEV ONLY] dynamic property-add to a NON-EMPTY object literal is silently dropped (closed struct, no sidecar) — breaks `Object.defineProperties` getters → compiled acorn throws on every `return` statement"
 status: ready
 sprint: current
 priority: high
-horizon: m
+horizon: l
 feasibility: hard
 reasoning_effort: max
 created: 2026-06-29
@@ -12,77 +12,440 @@ task_type: bugfix
 area: codegen
 language_feature: value-representation
 goal: acorn-dogfood
-related: [2836, 2831, 2806, 2809, 2379, 2151]
-depends_on: [2836]
+related: [2836, 2831, 2664, 2151, 2186, 2379]
+depends_on: []
 blocks: [1712]
-architect_spec: needed
+architect_spec: done
 ---
 
-# #2837 — compiled acorn throws on block-body arrow functions with params
+# #2837 — dynamic property-add to a non-empty object literal is silently dropped (closed struct, no sidecar)
 
-**Round-4 acorn-dogfood wall, exposed after #2836.** #2836 (host-shim
-`__make_iterable`/`_convertIterableForHost` `__is_vec` gate) cleared the
-arrow-param wall for **expression-body** arrows and, as a bonus, **default and
-rest params** — those now parse on compiled acorn. The remaining wall blocking
-full `edge.js` (module, 1190 nodes) structural equality is **block-body arrows**.
+**Round-4 acorn-dogfood wall, exposed after #2836.** The carve title ("block-body
+arrow") was a RED HERRING — WAT-grounded isolation shows the real trigger is the
+**`return` statement**, and the true root cause is a general
+object-representation bug: **a property added to a NON-EMPTY object literal after
+creation is silently compiled away.**
 
-## Repro (freshly-compiled pinned acorn@8.16.0, AFTER #2836)
+## Trigger isolation (compiled acorn@8.16.0, AFTER #2836)
 
-`instance.exports.parse(src, {ecmaVersion:2022,sourceType:"script"})`:
+`parse(src, {ecmaVersion:2022})`:
 
 ```
-x => x                 -> OK    (expression-body, #2836)
-(a,b) => a             -> OK    (#2836)
-(a=1) => a             -> OK    (default param, fixed by #2836)
-(...a) => a            -> OK    (rest param, fixed by #2836)
-function f(a = 1) {}   -> OK    (default param, fixed by #2836)
-function f(...a) {}    -> OK    (rest param, fixed by #2836)
-
-x => { return x; }     -> THROW WebAssembly.Exception   (BLOCK-BODY arrow, 1 param)
-(a) => { return a; }   -> THROW WebAssembly.Exception   (BLOCK-BODY arrow)
+function f(){}              OK     function f(){ 1; }        OK
+function f(){ x; }          OK     function f(){ var x=1; }  OK
+function f(){ f(); }        OK     function f(){ ; }         OK
+() => {}                    OK     () => { 1; }              OK
+function f(){ return; }     THROW  function f(){ return 1; } THROW
+() => { return 1; }         THROW  x => { return x; }        THROW
 ```
 
-So the wall is **specifically the block-body (`=> { … }`) arrow when it has ≥1
-param**. Zero-param block-body arrows (`() => { return 1; }`) and all
-expression-body arrows parse. `edge.js` contains parameterized block-body arrows,
-so this is what now blocks the full NM differential (`background.js` is already
-at the #1712 bar after #2836).
+Not block-body, not params — **only a `return` statement throws.** (My round-3
+carve guessed block-body arrow; that was wrong — the block bodies that "threw" all
+happened to contain `return`.)
 
-## Likely area (NOT yet root-caused — needs the same WAT-grounded isolation)
+## Why `return` throws (acorn raise path → getter → root cause)
 
-acorn's `parseArrowExpression` → `parseFunctionBody` (acorn.mjs:3546) branches on
-`isExpression = isArrowFunction && this.type !== braceL`:
-- **expression body** (`isExpression` true) → `node.body = parseMaybeAssign()` —
-  works (#2836).
-- **block body** (`isExpression` false) → `this.enterScope`, `parseBlock`,
-  **`this.checkParams(node, …)`** (acorn.mjs ~3585) which walks `node.params`
-  through `checkLValSimple`/`checkLValPattern` / scope-declaration. The params
-  list survived #2836; the divergence is most likely in the **block-body-only**
-  `checkParams` / scope-binding path (a value-rep or dispatch divergence specific
-  to that branch), not in `toAssignableList` (now correct).
+`parseReturnStatement` (acorn.mjs:1191): `if (!this.allowReturn) { this.raise(…,
+"'return' outside of function") }`. Instrumented compiled acorn:
+`allowReturn = 0` (typeof number), `inFunction = 0`, **but** my direct
+`currentVarScope().flags & SCOPE_FUNCTION = 2` (correct). So the getter
+`inFunction` returns 0 despite `flags&2 == 2`.
 
-Recommend reproducing on the issue branch, instrumenting `parseFunctionBody`'s
-block branch + `checkParams`, and dumping the WAT for the divergent read/dispatch
-(mirror the #2836 verify-first method: static-vs-dynamic WAT diff, pin the exact
-field/op that reads wrong). It may be another host-shim/marshalling asymmetry
-(like #2836) or a distinct value-rep gap.
+`inFunction`/`allowReturn`/`inGenerator`/`inAsync`/`canAwait`/… are **getters
+installed via `Object.defineProperties(Parser.prototype, prototypeAccessors)`**
+(acorn.mjs:600/608/624). Instrumenting the getter body proved **it is never
+invoked** (its `console.log` never fires, while a `console.log` in
+`parseReturnStatement` does). So `this.inFunction` reads a **default 0**, not the
+getter result → `allowReturn` 0 → every `return` raises.
 
-## Acceptance
+## Root cause (minimal repro + WAT, NOT hand-waved)
 
-- `parse("x => { return x; }")`, `parse("(a) => { return a; }")`,
-  `parse("(a,b) => { return a + b; }")` on compiled acorn return the correct AST
-  (no `WebAssembly.Exception`), structurally equal to node-acorn.
-- The real-world NM differential `edge.js` (module) compiled-acorn vs node-acorn
-  is **structurally equal** modulo the documented quirks (null `sourceFile`,
-  boolean-as-i32) — completes the #1712 bar started by #2831/#2836.
-- 0-regression `merge_group` + standalone-floor (broad-impact ⇒ full CI).
+acorn's idiom: `var prototypeAccessors = { inFunction: { configurable: true },
+… }` then `prototypeAccessors.inFunction.get = function(){…}` then
+`Object.defineProperties(Parser.prototype, prototypeAccessors)`. The getter is
+added to the descriptor via a **property assignment after the literal**.
+
+Minimal repros (no acorn):
+
+| repro | result | |
+|---|---|---|
+| `var o={}; o.f=7; o.f` | `number:7` | empty literal → dynamic `$Object`, grows fine |
+| `var o={}; o.type="X"; o.start=5; o.get=fn` (all late) | works | empty literal grows fine |
+| `var o={c:1}; o.d=7; o.d` | **`object`/null** | **non-empty literal → write DROPPED** |
+| `{inFn:{configurable:true}}` then `.inFn.get=fn`, read `.get` | **`typeof "object"`** | acorn's exact pattern — getter lost |
+| `Object.defineProperty(proto,…)` (singular) | works | install+dispatch machinery is fine |
+| `Object.defineProperties(proto,{x:{get:fn}})` (inline literal) | works | inline descriptors fine |
+
+WAT for `var o={c:1}; o.d=7; return o.d`:
+
+```wat
+(func $probe (result externref)
+  (local $o (ref null 2))   ;; o = closed struct type 2 (only field 'c': f64)
+  f64.const 1
+  struct.new 2              ;; build {c:1}
+  local.set 0
+  f64.const 0
+  drop                      ;; o.d = 7   → WRITE SILENTLY DROPPED (no sidecar)
+  ref.null extern           ;; return o.d → null
+  return)
+```
+
+**A non-empty object literal is lowered to a CLOSED struct with no sidecar
+fallback.** A write to a field not in the literal shape is silently dropped; the
+read returns null. An EMPTY literal `{}` uses the dynamic `$Object`
+representation and grows correctly — so the divergence is purely the
+representation choice (`{}` → `$Object`; `{…fields}` → closed struct). acorn's
+`prototypeAccessors` (and its nested `{configurable:true}` descriptors) are
+non-empty literals → closed structs → the later `.get =` assignment is dropped →
+no getters installed → `inFunction` reads default 0 → `return` throws.
+
+(`Object.defineProperty` singular and inline-literal `defineProperties`
+descriptors work — this is NOT a defineProperties bug; it is the descriptor
+object losing its late-added `.get` field.)
+
+## Why this is architecture-scope (escalated for an architect spec)
+
+This is the **object-representation substrate** (the `$Object` dynamic
+reader / member-set-dispatch #2664 / member-get-dispatch #2151 family). Blast
+radius: **every non-empty object literal that later receives a property not in
+its literal shape** — a representation-scale change (reference_2379 hazard).
+Candidate approaches, each with real tradeoffs an architect should weigh:
+
+- **A — escape/flow analysis at the literal:** if an object created by a
+  non-empty literal is ever the target of a property write whose key is not in
+  the literal shape (or an `Object.define*` target), represent it as `$Object`
+  (dynamic), like empty literals already are. Precise but needs intra/inter-proc
+  escape analysis; misses dynamically-keyed writes.
+- **B — sidecar fallback on closed structs:** make a write of an unknown field to
+  a closed-struct object route to the sidecar, and member-get fall through to the
+  sidecar on a miss (the machinery the empty-`$Object` path already uses). Uniform,
+  no analysis, but adds a sidecar branch to every struct member-set/get (perf;
+  the #2664 slot-vs-sidecar desync hazard must be respected).
+- **C — always represent object literals as `$Object`:** simplest, but a broad
+  perf regression for the common closed-record case.
+
+**Senior-dev / architect, `reasoning_effort: max`, `horizon: l`. Broad-impact ⇒
+full `merge_group` + standalone-floor.**
+
+## Acceptance (bar = #1712)
+
+- `var o={c:1}; o.d=7` reads back 7; the acorn `prototypeAccessors` idiom installs
+  working getters; `parse("function f(){ return 1; }")`, `parse("() => { return
+  x; }")` on compiled acorn return the correct AST (no `WebAssembly.Exception`).
+- The real-world NM differential `edge.js` (module, 1190 nodes) compiled-acorn vs
+  node-acorn is **structurally equal** modulo documented quirks (null
+  `sourceFile`, boolean-as-i32) — completes the #1712 bar started by
+  #2831/#2836. `background.js` must STAY structurally-equal (it already is — no
+  `return`-in-non-empty-literal pattern).
+- 0-regression `merge_group` + standalone-floor (broad-impact ⇒ full CI). Watch
+  the object-literal / member-set-dispatch / `built-ins/Object/**` buckets and the
+  #2664 invariant.
 
 ## Pointers
 
-- acorn: `parseFunctionBody` block branch acorn.mjs:3546, `checkParams` ~3585,
-  `parseArrowExpression` 3524.
-- Repro infra (round-3 branch `issue-arrowparam-toassignable` `.tmp/`):
-  `r4-probe.mjs` (the table above), `arrow-instr*.mjs` (instrumentation harness to
-  clone), `nm-diff.mjs` (full-file differential), the architect's
-  `edge-bisect.mjs` (in `/workspace/.claude/worktrees/agent-acac33ff565981548/.tmp/`).
-- Verified after #2836 on compiled acorn@8.16.0, 2026-06-29 (sendev round 3).
+- acorn: `parseReturnStatement` 1191, `allowReturn`/`inFunction` getters 624/608,
+  `Object.defineProperties(Parser.prototype, prototypeAccessors)` ~600, getter
+  assignments 608+.
+- Compiler: object-literal lowering (closed struct vs `$Object`) — the
+  `struct.new` vs dynamic-object decision; member-set-dispatch (#2664,
+  `src/codegen/member-set-dispatch.ts`), member-get-dispatch (#2151), the
+  `$Object` sidecar reader.
+- Repro infra (branch `issue-2837-blockbody-arrow` `.tmp/`): `bb-probe2.mjs`
+  (return trigger), `bb-instr*.mjs` (getter-never-invoked proof),
+  `getter-repro{,2,3,4,5}.mjs` (the table above), `dump-lit.mjs` + `lit.wat` (the
+  dropped-write WAT), `nm-diff.mjs` (edge.js still throws; background.js stays
+  equal).
+- Verified after #2836 on compiled acorn@8.16.0, 2026-06-29 (sendev round 4).
+
+## Implementation Plan
+
+**Architect verify-first (2026-06-29, branched off origin/main @805c980d5 — has
+#2831+#2836). Chosen approach: A (escape/flow-analysis → existing externref
+`$Object` route), SCOPED. Confirmed by WAT + end-to-end runs, NOT hand-waved.**
+
+### Verify-first findings (these overturn part of the issue framing)
+
+1. **The divergence is NOT "empty → `$Object`, non-empty → closed struct."** The
+   EMPTY case works via **struct WIDENING**, not `$Object`: `var o={}; o.d=7`
+   compiles `o` to a closed struct `(struct (field $d (mut f64)))` — the pre-pass
+   `collectEmptyObjectWidening` (declarations.ts:2176) scans later `o.X=` writes
+   and bakes field `d` into the struct at construction. The non-empty path skips
+   that scan (declarations.ts:**2189** `if (decl.initializer.properties.length > 0)
+   continue;`), so `{c:1}` stays a closed `{c}`-only struct and `o.d=7` lowers to
+   `f64.const 0; drop`. WAT-confirmed (`lit-nonempty.wat` vs `lit-empty.wat`).
+
+2. **acorn's real trigger is a NESTED write, not a direct one.** acorn.mjs:600–685
+   (verified against `tests/dogfood/.acorn/package/dist/acorn.mjs`):
+   ```js
+   var prototypeAccessors = { inFunction: { configurable: true }, /* +10 more */ };
+   prototypeAccessors.inFunction.get = function () { ... };   // 608
+   prototypeAccessors.inGenerator.get = function () { ... };  // 610
+   ...                                                        // individual stmts
+   Object.defineProperties( Parser.prototype, prototypeAccessors ); // 685
+   ```
+   The out-of-shape writes are **`prototypeAccessors.<field>.get = fn`** — depth-2
+   writes onto the *nested* descriptor objects `{configurable:true}`. The widening
+   scan keys off `varName.prop=` (direct identifier base), so it can **never**
+   reach the nested descriptor. WAT-confirmed (`d2-nested_host.wat`: `po.inFn.get=5`
+   → `f64.const 0; drop`). The idiom is **individual statements, no loop, no
+   computed key → fully statically scannable.**
+
+3. **The fix target representation ALREADY EXISTS and WORKS in host mode.** The
+   `$Object`/plain-object builder `compileObjectLiteralAsExternref`
+   (literals.ts:204) uses host imports `__new_plain_object` + `__extern_set` (NOT
+   standalone-gated — works in JS-host mode, which is the mode the NM differential
+   compiles in: `nm-diff.mjs` calls `compile(src)` with **no `target`**). It
+   **recursively** builds nested object-literal values as growable objects
+   (literals.ts:**298–307**). Proof: forcing the receiver to `any` (which already
+   routes the literal to this builder + types the local externref) makes BOTH the
+   direct and the full nested acorn pattern work end-to-end in host mode:
+   ```
+   var o:any  = { c: 1 };               o.d = 7;            o.d  → number:7      ✓
+   var po:any = { inFn:{configurable:true} }; po.inFn.get = fn; po.inFn.get() → 9 ✓
+   ```
+   (`anychk.mjs`.) So **the entire machinery is in place**; the ONLY missing piece
+   is the routing DECISION — making a non-`any` var that is later mutated
+   out-of-shape behave like an `any`-typed one.
+
+### Root cause (one sentence)
+
+A non-empty object literal assigned to a variable is lowered to a **closed
+struct** whose field set is frozen at the literal's static shape; the compiler
+never detects that the variable (or a nested literal value it holds) later
+receives an out-of-shape property write, so those writes lower to `drop` and the
+reads to `ref.null extern`.
+
+### Chosen approach: A (scoped flow-analysis → existing externref `$Object`), with rationale
+
+| | A (chosen) | B (sidecar on closed structs) | C (always `$Object`) |
+|---|---|---|---|
+| Solves nested acorn case | **yes** (recursion in the builder) | yes, but needs the static `struct.set`-of-unknown-field path rewritten to a sidecar-set AND every struct gains a sidecar field | yes |
+| Perf | **no regression** — scoped to objects PROVEN to grow; the 99% closed-record case keeps `struct.get/set` | regresses the hottest path (sidecar branch on every member get/set) | broad regression |
+| #2664 desync hazard | **N/A** — pure externref `$Object`, no slot-vs-sidecar split | **high** — the exact write-leaks-to-sidecar / read-uses-slot trap | N/A |
+| #1897/-45 hazard | avoided by the consumer-safety guard (below) | N/A | **re-triggers it** — 116 regressions when struct-typed consumers see `$Object` (`struct.get` null-deref, `(o as any)-0` mis-coerce). The #1901 comment block (literals.ts:1080–1163) is the documented record that "always `$Object`" was tried and reverted |
+| New infrastructure | **almost none** — reuses `compileObjectLiteralAsExternref` + `externrefAccessorVars`; adds one detection pre-pass | a new sidecar struct field + member-dispatch rewrite | trivial routing, catastrophic fallout |
+
+**C is off the table** (quantified: #1897's 116 regressions). **B is heavy and
+re-opens #2664.** **A is minimal, validated, and mode-uniform.**
+
+A is "lower to `$Object` when the literal escapes to an out-of-shape write" — the
+issue's Approach A — but realized by reusing the **existing recursive externref
+builder** and the **existing `externrefAccessorVars` dispatch hook** rather than
+writing new escape analysis or a new representation.
+
+### Changes
+
+**1. New ctx field — `src/codegen/context/types.ts` (~line 1525, beside `objectHashConsumerVars`) + `src/codegen/context/create-context.ts:191`**
+- Add `growableObjectLiteralVars: Set<string>` to the context type, init `new Set()`.
+  (It is the detection output; membership then feeds both the literal routing and
+  the existing `externrefAccessorVars` tagging. You MAY instead fold the result
+  directly into `externrefAccessorVars` — see step 4 — but keeping a distinct set
+  makes the routing decision inspectable/testable.)
+
+**2. New detection pre-pass — `src/codegen/declarations.ts`, beside `collectEmptyObjectWidening` (line 2176)**
+- Add `export function collectGrowableObjectLiterals(ctx, checker, sourceFile)`.
+  Mirror `collectEmptyObjectWidening`'s statement walker (it already recurses into
+  function bodies / try / if / loops / switch — copy that traversal).
+- For each `var/let/const V = <NON-EMPTY ObjectLiteralExpression>` (i.e. the case
+  the empty pre-pass skips at line 2189), scan the enclosing statement list for an
+  **out-of-shape mutation rooted at `V`**:
+  - **Direct rule:** an assignment `V.k = …` where `k` is NOT a property name
+    present in `V`'s literal shape → mark `V`.
+  - **Nested rule (this is the acorn trigger):** an assignment whose LHS is a
+    `PropertyAccessExpression` chain whose **root identifier is `V`** and whose
+    **depth ≥ 2** (`V.a.b … = …`). Walk `lhs.expression` until you hit the root
+    Identifier, counting hops; depth ≥ 2 ⇒ mark `V`. (Conservative: a depth-≥2
+    write to an already-in-shape nested field also marks `V` — a safe
+    over-approximation; such objects are being deep-mutated and growable is
+    correct, only marginally slower. Refine later if a perf case appears.)
+  - Also walk into the same nested statement scopes the empty pre-pass walks
+    (blocks, if/else, try/catch/finally, for/while/switch).
+- On a match, `ctx.growableObjectLiteralVars.add(V)`.
+- **Consumer-safety guard (avoids the #1897/-45 regression).** Do NOT mark `V`
+  growable if it has a consumer that requires the closed-struct representation —
+  mirror the poison logic the empty pre-pass already applies
+  (`objectHashConsumerVars` #2584, `dynamicDescriptorWidenVars` #2372). Concretely
+  bail (leave `V` on the struct path) when any of:
+  - a field of `V` is read in a numeric/typed context that expects `struct.get`
+    f64 (e.g. `V.x - 0`, `V.x * n`),
+  - `V` is passed as an argument to a **non-`any`** typed parameter, returned as a
+    concrete struct type, or destructured into typed slots.
+  For acorn's `prototypeAccessors` none of these hold (it is consumed ONLY by
+  `Object.defineProperties` iterating keys), so it marks cleanly. When in doubt,
+  prefer NOT marking (leaves the pre-existing bug for that var — acceptable; it is
+  not the acorn blocker) over an unsound externref route.
+
+**3. Wire the pre-pass — `src/codegen/index.ts:1221` and `:5902`**
+- Call `collectGrowableObjectLiterals(ctx, …)` at BOTH sites where
+  `collectEmptyObjectWidening` is already called (single-file and multi-file
+  compile paths), immediately after it.
+
+**4. Local typing — `src/codegen/statements/variables.ts:755–779`**
+- Add, beside `initIsHostSpreadLiteral`:
+  ```ts
+  const initIsGrowableObjectLiteral =
+    decl.initializer !== undefined &&
+    ts.isObjectLiteralExpression(decl.initializer) &&
+    ts.isIdentifier(decl.name) &&
+    ctx.growableObjectLiteralVars.has(decl.name.text);
+  ```
+- Include it in the `externrefAccessorVars.add(name)` condition (line 759) and in
+  the `wasmType` externref selection (line 777–779). This makes the var's local an
+  externref AND — because `externrefAccessorVars` is consulted by member dispatch
+  (property-access.ts:1039/1082 for reads, the member-set path for writes) —
+  routes every `V.k` read/write through `__extern_get`/`__extern_set`. (If you
+  folded detection straight into `externrefAccessorVars` in step 2, this reduces
+  to just the `wasmType` arm.)
+
+**5. Literal lowering — `src/codegen/literals.ts`, `compileObjectLiteral`**
+- For a NON-EMPTY literal whose parent is `var V = …` with
+  `ctx.growableObjectLiteralVars.has(V)`, route to
+  `compileObjectLiteralAsExternref(ctx, fctx, expr)` and return its result —
+  **NOT** standalone-gated (the builder works in host mode; the existing
+  `ctx.standalone` gate at line 1110 is the #1901 *decision* gate, not a builder
+  limitation). Place this check **before** the `if (!contextType)` closed-struct
+  fallthrough (line 1165) and before the concrete-`contextType` struct path (line
+  1198), so a marked var never reaches `compileObjectLiteralForStruct`. The
+  builder's line-298 recursion then builds the nested descriptor objects growable
+  automatically — no extra work for the nested case.
+- If `compileObjectLiteralAsExternref` returns null (e.g. the literal has
+  methods/accessors/computed keys it cannot build — see its prop guard at
+  literals.ts:275/321), fall through to the existing paths (graceful). acorn's
+  `prototypeAccessors` is all data props, so it never declines.
+
+### Wasm IR pattern (target, post-fix — already produced today for `any`-typed vars)
+
+```wat
+;; var prototypeAccessors = { inFunction: { configurable: true }, ... }
+call $__new_plain_object              ;; outer object
+local.set $po
+;; inner descriptor (built recursively as growable too)
+call $__new_plain_object
+local.tee $desc
+(global.get $configurable) (global.get $true) call $__extern_set
+local.get $po (global.get $inFunction) local.get $desc call $__extern_set
+;; ... late: prototypeAccessors.inFunction.get = fn
+local.get $po (global.get $inFunction) call $__extern_get   ;; → $desc externref
+(global.get $get) <fn-closure>        call $__extern_set      ;; LANDS (was drop)
+```
+
+### Edge cases (call these out in tests)
+
+- **Out-of-shape write then read** (direct): `var o={c:1}; o.d=7; o.d` → `7`.
+- **In-shape write unaffected**: `var o={c:1}; o.c=2; o.c` → must still be `2`
+  (marked var: now via `__extern_set`/`__extern_get`; verify the in-shape field
+  round-trips through the `$Object`, not just the new one).
+- **Nested (acorn)**: `var po={inFn:{configurable:true}}; po.inFn.get=fn` then read
+  → getter installed & callable.
+- **Numeric vs ref fields**: a marked var's numeric field read in arithmetic
+  (`o.n + 1`) — this is the #1897 hazard; the consumer-safety guard MUST keep such
+  a var OFF the externref route (or box/unbox correctly). Add a test that a struct
+  var with a numeric field used arithmetically and NO out-of-shape write stays on
+  the struct path (no regression).
+- **`delete`**: `delete o.d` on a marked (externref) var routes through the
+  `$Object` delete path — verify it does not trap; not required for acorn but
+  in-scope for the representation.
+- **Unmarked vars are byte-identical**: a plain `var o={c:1}; o.c` with no
+  out-of-shape write keeps the exact closed-struct lowering (regression floor).
+- **Standalone parity**: the same routing must hold under `--target standalone`
+  (the native `$Object` runtime `__extern_get/set/__new_plain_object` is emitted
+  there too); the floor must stay green.
+
+### Blast radius & classification
+
+- **Scope of behavioral change**: ONLY variables initialized by a non-empty object
+  literal that (a) are later out-of-shape mutated (direct or nested) AND (b) pass
+  the consumer-safety guard. Everything else is byte-identical. This is the
+  reference_2379-class "every non-empty object literal later written out-of-shape"
+  set, but the consumer-safety guard keeps it from touching struct-typed consumers.
+- **Risk axes**: (1) detection precision — a false-positive mark routes a
+  struct-consumed var to externref → #1897-style breakage (mitigated by the guard;
+  prefer under-marking). (2) member-dispatch coverage for externref receivers —
+  already proven by the `any`-typed runs. (3) standalone vs host — both exercised
+  by existing #1901/#2542 code.
+- **Senior-dev, `reasoning_effort: max`, `horizon: l`.** Broad-impact ⇒ FULL
+  `merge_group` + standalone-floor, never scoped CI.
+
+### Test plan (acceptance bar)
+
+1. **Unit (tests/, equivalence)** — add cases:
+   - `var o={c:1}; o.d=7;` reads back `7`; in-shape `o.c` still correct.
+   - acorn `prototypeAccessors` idiom: `var po={inFn:{configurable:true}};
+     po.inFn.get=function(){return 9}; ` then `Object.defineProperties(T,po)` →
+     getter installed (returns the computed value).
+   - Regression control: `var o={n:1}; (o.n+1)` with no out-of-shape write stays a
+     struct (assert via WAT it still emits `struct.get`, not `__extern_get`).
+2. **Return repros parse** on compiled acorn (the #1712 bar opener):
+   `parse("function f(){ return 1; }")` and `parse("(a)=>{ return a; }")` return a
+   correct AST with **no `WebAssembly.Exception`**.
+3. **Real NM differential** (harness: copy
+   `/workspace/.claude/worktrees/agent-ab738eabb9262d2f2/.tmp/nm-diff.mjs` into a
+   `.tmp/` subdir of a worktree at main):
+   - **edge.js** (module, 1190 nodes): compiled-acorn vs node-acorn **structurally
+     equal** modulo documented quirks (null `sourceFile`, boolean-as-i32).
+   - **background.js** STAYS structurally equal (no regression).
+4. **0-regression** `merge_group` + standalone-floor. Watch the
+   object-literal / member-set-dispatch / `built-ins/Object/**` buckets and the
+   #2664 invariant.
+
+## Implementation Notes (sendev, 2026-06-29) — Approach A IMPLEMENTED but NOT SUFFICIENT for acorn `return`
+
+Implemented Approach A exactly (6 edits: context/types, create-context,
+declarations `collectGrowableObjectLiterals` pre-pass, index.ts wiring,
+variables.ts local typing, literals.ts routing), PLUS three edits the architect's
+`:any`-only verify-first did not surface as necessary:
+- **Module-global typing** (`moduleGlobalWasmType`, declarations.ts): acorn's
+  `prototypeAccessors` is a TOP-LEVEL `var` → a module GLOBAL, which bypasses the
+  function-local typing path. The global must be externref too.
+- **Nested-chain member dispatch** (`chainRootIsGrowable`, property-access.ts):
+  `prototypeAccessors.inFunction.get = fn` is a depth-2 write; the receiver
+  `prototypeAccessors.inFunction` is a property-access (not a bare ident), so the
+  dispatch must force the externref path for a chain ROOTED at a growable var.
+- **Hoisted-`var` slot re-type** (variables.ts): the default re-type guard treats
+  externref as "primitive" and refuses the `ref → externref` narrowing for a
+  pre-hoisted struct slot; added a growable branch (like the accessor/Proxy ones).
+- **defineProperties wasm-closure wrap** (runtime.ts `definePropertiesHandler`):
+  a host `$Object` descsObj whose accessor get/set are RAW wasm closures was
+  rejected by native `Object.defineProperties` ("Getter must be a function");
+  route it through the wrapping per-key path (`_descsHaveWasmClosureAccessor`).
+
+**Verified working** (`.tmp/regr-control.mjs`, `getter-repro*.mjs`):
+`var o={c:1}; o.d=7` → 7; nested `o.inner.n=7` → 7; module-global + function-local;
+regression controls (`{n:1}; o.n+1`, plain structs) STAY on the struct path
+(`usesExternObj=false`, byte-identical). Object-literal/accessor/defineProperty
+suites: 8/9 files green (the 1 failure is the pre-existing stale-harness
+`getters-setters.test.ts` — instantiate with `{env:{}}`, unrelated).
+
+### BLOCKER — Layer 3 (architecture-scale, NOT object-literal growth, NOT in this spec)
+
+With all of the above, acorn module-init no longer crashes (descriptors install,
+getters wrap), **but `function f(){ return 1 }` STILL throws** acorn's
+`'return' outside of function`. WAT-grounded isolation (`.tmp/bb-instr2.mjs`):
+`this.inFunction` reads a static **default 0** — the runtime-installed prototype
+getter **is never invoked** (its injected `console.log` never fires while one in
+`parseReturnStatement` does). Root cause: the compiler lowers `this.inFunction`
+(a typed-receiver member access) as a STATIC field read, with no knowledge that
+`inFunction` is a getter installed at RUNTIME via
+`Object.defineProperties(Parser.prototype, …)`. This is **dynamic-prototype-accessor
+dispatch on a statically-typed receiver** — a distinct, architecture-scale issue
+the documented #2837 root cause (object-literal growth) does NOT cover, and which
+the architect's `:any` verify-first did not exercise (it called the getter
+FUNCTION directly in wasm — `po.inFn.get()` — not the installed-accessor chain
+`Object.defineProperties` + `this.inFunction` that acorn actually uses).
+
+**Conclusion:** Approach A is NECESSARY but NOT SUFFICIENT for acorn's `return`.
+Layer 3 needs its own architect design (member-get on a typed receiver must
+consult runtime-installed prototype accessors via the host MOP, or acorn-shape
+`prototypeAccessors` getters must be modeled statically). ESCALATED — do not land
+a broad object-rep change that does not reach the milestone without the lead's
+decision on landing-as-stepping-stone vs combining with the Layer-3 fix.
+
+### NOTE — possible round 6 (set expectation)
+
+The NM differential reveals walls one at a time: it currently stops at the FIRST
+`return`, so **edge.js may hide additional walls behind this one** that only
+surface once `return` parses (1190 nodes exercises far more grammar than
+background.js). Landing #2837 unblocks the next diff delta; budget for a
+**round-6** carve if edge.js surfaces a new structural mismatch after returns
+parse. background.js already being equal is a good sign the substrate is close,
+but do not assume edge.js is one fix away.

--- a/plan/issues/2838-dynamic-prototype-accessor-dispatch.md
+++ b/plan/issues/2838-dynamic-prototype-accessor-dispatch.md
@@ -1,0 +1,116 @@
+---
+id: 2838
+title: "[SENIOR-DEV ONLY] dynamic prototype-accessor dispatch on statically-typed receivers — `Object.defineProperties(Proto, {get})` getters never fire on `this.field` (acorn `return` wall)"
+status: ready
+sprint: current
+priority: high
+horizon: l
+feasibility: hard
+reasoning_effort: max
+created: 2026-06-29
+task_type: bugfix
+area: codegen
+language_feature: value-representation
+goal: acorn-dogfood
+related: [2837, 2831, 2664, 2151, 1239]
+depends_on: [2837]
+blocks: [1712]
+architect_spec: candidate
+---
+
+# #2838 — runtime-installed prototype accessors are never invoked via `this.field` on a typed receiver
+
+**Layer 3 of the acorn `return` wall (round 5).** #2837 (object-literal growth →
+externref `$Object`) is NECESSARY but NOT SUFFICIENT for compiled acorn to parse
+a `return` statement. After #2837, acorn module-init succeeds (the
+`prototypeAccessors` descriptors build and the getter closures install), but
+`function f(){ return 1 }` STILL throws acorn's own `'return' outside of
+function`. This issue is the remaining, ORTHOGONAL blocker.
+
+## Root cause (WAT-grounded, NOT hand-waved)
+
+acorn installs its parser-state predicates as **prototype getters at runtime**:
+
+```js
+var prototypeAccessors = { inFunction: { configurable: true }, /* +10 */ };
+prototypeAccessors.inFunction.get = function () {
+  return (this.currentVarScope().flags & SCOPE_FUNCTION) > 0;
+};
+Object.defineProperties(Parser.prototype, prototypeAccessors);   // runtime install
+```
+
+`parseReturnStatement` (acorn.mjs:1191) then does `if (!this.allowReturn) raise(…)`,
+where `allowReturn` → `this.inFunction` → the runtime-installed getter.
+
+Instrumented compiled acorn (`.tmp/bb-instr.mjs` / `bb-instr2.mjs`):
+- `this.inFunction` reads **0** (`typeof number`), `allowReturn` reads **0**, so
+  every `return` raises `'return' outside of function`.
+- BUT a direct `this.currentVarScope().flags & SCOPE_FUNCTION` computes **2**
+  (correct) — the scope state is fine.
+- The injected `console.log` inside the `inFunction` getter body **never fires**,
+  while one in `parseReturnStatement` does. **The runtime-installed getter is
+  NEVER invoked.**
+
+**Mechanism:** the compiler lowers `this.inFunction` (a member access on a
+statically-typed receiver) as a **STATIC struct-field read**, with no knowledge
+that `inFunction` is an **accessor installed at runtime** via
+`Object.defineProperties(Parser.prototype, …)`. So it reads the struct's default
+slot value (0) instead of dispatching to the getter. (#2837 already made the
+*storage* of the getter closure + its host-callable wrapping work — verified the
+descriptors install and `definePropertiesHandler` wraps the wasm closures; the
+gap is purely the **invocation** at the `this.field` read site.)
+
+## Minimal repro (no acorn)
+
+```ts
+function C(this: any) {}
+Object.defineProperties((C as any).prototype, {
+  f: { get(this: any) { return 1; }, configurable: true },
+});
+export function probe(): number {
+  return new (C as any)().f;   // must return 1; currently reads the struct default (0/undefined)
+}
+```
+
+Acceptance: `new C().f` invokes the runtime-installed getter (returns 1), and the
+acorn return repros parse:
+`parse("function f(){ return 1; }")`, `parse("(a)=>{ return a; }")` →
+correct AST, no `WebAssembly.Exception`.
+
+## Scope / candidate approaches (architect to choose)
+
+This is the **accessor-dispatch** substrate (member-get on a typed receiver vs the
+host MOP), ORTHOGONAL to #2837's literal-growth representation. Candidates:
+
+- **A — host-MOP fallthrough on member-get:** when a `this.field` / `o.field` read
+  targets a field that is NOT a statically-known struct slot (or whose receiver's
+  prototype had a runtime `Object.defineProperties` accessor install), route the
+  read through `__extern_get` (the host MOP), which already consults
+  runtime-installed prototype accessors. Risk: perf on the hot struct-field path;
+  needs a precise "this field might be a runtime accessor" predicate.
+- **B — static modelling of `Object.defineProperties(Proto, {…})`:** detect the
+  acorn-shape install at compile time and register the prototype keys as
+  accessor-backed members so `this.field` lowers to a getter call. Narrower; may
+  not generalise beyond the statically-analysable install shape.
+- **C — represent such prototype-accessor-bearing instances as `$Object`:** if a
+  constructor's prototype receives runtime accessors, route its instances through
+  the externref `$Object` path (reads go through `__extern_get` → host accessor).
+  Broad; perf + identity considerations.
+
+Recommend an architect spec choosing A/B/C. **Verify-first MUST exercise the
+actual `Object.defineProperties(Proto, {get})` + `new C().field` install-and-invoke
+chain** — NOT a direct `desc.get()` call (the #2837 architect's `:any` verify used
+`po.inFn.get()`, a direct call, which masked this invocation gap). **Senior-dev,
+`reasoning_effort: max`, `horizon: l`. Broad-impact ⇒ full `merge_group` +
+standalone-floor.**
+
+## Pointers
+
+- acorn: `parseReturnStatement` 1191, `allowReturn`/`inFunction` getters 624/608,
+  `Object.defineProperties(Parser.prototype, prototypeAccessors)` ~685.
+- Compiler: member-get dispatch (`property-access.ts`), `__extern_get` host MOP,
+  the struct-field-read fast path; runtime `definePropertiesHandler`
+  (`src/runtime.ts`) where the accessors install (#2837 wraps the closures there).
+- Repro infra (branch `issue-2837-objrep` `.tmp/`): `bb-instr.mjs`,
+  `bb-instr2.mjs` (getter-never-invoked proof), `bb-probe2.mjs` (return trigger).
+- Diagnosed after #2837 on compiled acorn@8.16.0, 2026-06-29 (sendev round 5).

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -189,6 +189,7 @@ export function createCodegenContext(
     widenedDefinePropertyKeys: new Set(),
     dynamicDescriptorWidenVars: new Set(),
     objectHashConsumerVars: new Set(),
+    growableObjectLiteralVars: new Set(),
     externrefAccessorVars: new Set(),
     pendingMathMethods: new Set(),
     pendingMethodTrampolines: [],

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1524,6 +1524,23 @@ export interface CodegenContext {
    */
   objectHashConsumerVars: Set<string>;
   /**
+   * (#2837) Variable names initialized by a NON-EMPTY object literal that later
+   * receives an OUT-OF-SHAPE property write (a direct `V.k=` with `k` not in the
+   * literal's static shape, or a nested depth-≥2 write `V.a.b…=` onto a nested
+   * descriptor object — the acorn `prototypeAccessors.inFunction.get = fn`
+   * idiom). A non-empty literal is otherwise lowered to a CLOSED struct whose
+   * field set is frozen at the literal shape, so such a write lowers to
+   * `drop` and the read to `ref.null extern` (the getter is never installed →
+   * `inFunction` reads 0 → every `return` throws). Membership routes the literal
+   * through the existing recursive externref `$Object` builder
+   * (`compileObjectLiteralAsExternref`) and types the local externref (via
+   * `externrefAccessorVars`), so every access goes through `__extern_get`/`set`.
+   * Populated by `collectGrowableObjectLiterals` (declarations.ts); a
+   * consumer-safety guard keeps struct-typed-consumer vars OFF this set to avoid
+   * the #1897 closed-struct-consumer regression.
+   */
+  growableObjectLiteralVars: Set<string>;
+  /**
    * (#1239) Variable names whose initializer is an object literal carrying
    * `get`/`set` accessors. Such variables are stored as plain JS host
    * objects (via `__new_plain_object` + `__defineProperty_accessor`) and

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -2288,6 +2288,191 @@ export function collectEmptyObjectWidening(
   scanStatements(sourceFile.statements);
 }
 
+/**
+ * (#2837) Detection pre-pass: mark variables initialized by a NON-EMPTY object
+ * literal that later receive an OUT-OF-SHAPE property write, so `compileObjectLiteral`
+ * (literals.ts) routes them through the recursive externref `$Object` builder
+ * instead of a closed struct (whose unknown-field writes lower to `drop`).
+ *
+ * Two trigger rules (mirroring the issue's WAT-grounded isolation):
+ *   - **Direct:**  `V.k = …` where `k` is NOT a property name in `V`'s literal shape.
+ *   - **Nested (the acorn trigger):** any assignment whose LHS is a property-access
+ *     chain rooted at `V` with depth ≥ 2 (`V.a.b… = …`) — e.g.
+ *     `prototypeAccessors.inFunction.get = fn` onto the nested `{configurable:true}`
+ *     descriptor. Conservative over-approximation: a depth-≥2 write to an
+ *     already-in-shape nested field also marks `V` (it is being deep-mutated;
+ *     growable is correct, only marginally slower).
+ *
+ * Consumer-safety guard (avoids the #1897 closed-struct-consumer regression):
+ * a marked var becomes an externref `$Object`, so a consumer that requires the
+ * closed-struct representation (a `struct.get` numeric read used in arithmetic, or
+ * a pass into a CONCRETE nominal-struct-typed parameter / return / assignment)
+ * would null-deref or mis-coerce. When such a consumer is detected, do NOT mark
+ * (leave the pre-existing closed-struct lowering — the var keeps working for its
+ * struct consumers; it just retains the dropped-write bug, which is acceptable —
+ * it is not the acorn blocker). When in doubt, prefer NOT marking.
+ *
+ * Runs BEFORE collectDeclarations (alongside `collectEmptyObjectWidening`) so the
+ * variable's representation decision is made before its type is resolved.
+ */
+export function collectGrowableObjectLiterals(
+  ctx: CodegenContext,
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+): void {
+  // A literal property name we can build onto a $Object (data prop, statically-known key).
+  function literalShapeNames(obj: ts.ObjectLiteralExpression): Set<string> | null {
+    const names = new Set<string>();
+    for (const p of obj.properties) {
+      if (ts.isPropertyAssignment(p) || ts.isShorthandPropertyAssignment(p)) {
+        const nm = p.name;
+        if (ts.isIdentifier(nm) || ts.isStringLiteral(nm) || ts.isNumericLiteral(nm)) {
+          names.add(nm.text);
+        } else {
+          return null; // computed / symbol key — externref builder may decline; skip marking
+        }
+      } else {
+        return null; // spread / method / accessor — not a pure data literal
+      }
+    }
+    return names;
+  }
+
+  // Resolve a property-access chain's root identifier + depth. Returns null if the
+  // base is not ultimately a plain identifier (e.g. a call result).
+  function chainRoot(pae: ts.PropertyAccessExpression): { root: string; depth: number } | null {
+    let e: ts.Expression = pae;
+    let depth = 0;
+    while (ts.isPropertyAccessExpression(e)) {
+      depth++;
+      e = e.expression;
+    }
+    if (ts.isIdentifier(e)) return { root: e.text, depth };
+    return null;
+  }
+
+  // Does a contextual type at a use site REQUIRE the closed-struct representation?
+  // True only for a CONCRETE nominal struct (named own properties, not any/unknown/
+  // `object`, not a pure string-index dictionary). any/object/index-sig consumers
+  // (e.g. `Object.defineProperties`' PropertyDescriptorMap param) are SAFE.
+  function typeRequiresStruct(t: ts.Type | undefined): boolean {
+    if (!t) return false;
+    if (t.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags.NonPrimitive)) return false;
+    if (t.flags & (ts.TypeFlags.StringLike | ts.TypeFlags.NumberLike | ts.TypeFlags.BooleanLike)) return false;
+    // A pure string-index dictionary (no named own props) is an open object → safe.
+    const props = t.getProperties();
+    const hasStringIndex = !!checker.getIndexInfoOfType(t, ts.IndexKind.String);
+    if (props.length === 0 && hasStringIndex) return false;
+    if (props.length === 0) return false; // empty/object-ish → safe
+    return true; // concrete shape with named props → struct consumer
+  }
+
+  function scanStatements(stmts: readonly ts.Statement[]): void {
+    for (const stmt of stmts) {
+      if (ts.isVariableStatement(stmt)) {
+        for (const decl of stmt.declarationList.declarations) {
+          if (!ts.isIdentifier(decl.name)) continue;
+          if (!decl.initializer || !ts.isObjectLiteralExpression(decl.initializer)) continue;
+          if (decl.initializer.properties.length === 0) continue; // empty handled by widening
+          const varName = decl.name.text;
+          const shape = literalShapeNames(decl.initializer);
+          if (!shape) continue; // not a pure data literal → skip (externref builder would decline)
+
+          let grows = false;
+          let poisoned = false;
+
+          const visit = (node: ts.Node): void => {
+            // Out-of-shape write rooted at varName.
+            if (
+              ts.isBinaryExpression(node) &&
+              node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+              ts.isPropertyAccessExpression(node.left)
+            ) {
+              const info = chainRoot(node.left);
+              if (info && info.root === varName) {
+                if (info.depth >= 2) {
+                  grows = true; // nested deep-mutation (the acorn descriptor case)
+                } else if (info.depth === 1 && !shape.has(node.left.name.text)) {
+                  grows = true; // direct out-of-shape field add
+                }
+              }
+            }
+            // Consumer-safety: a numeric/arithmetic read of a field off varName needs
+            // the struct `struct.get` f64 contract (#1897) → poison.
+            if (
+              ts.isBinaryExpression(node) &&
+              isArithmeticOperator(node.operatorToken.kind) &&
+              (isFieldReadOf(node.left, varName) || isFieldReadOf(node.right, varName))
+            ) {
+              poisoned = true;
+            }
+            if (
+              ts.isPrefixUnaryExpression(node) &&
+              (node.operator === ts.SyntaxKind.MinusToken || node.operator === ts.SyntaxKind.PlusToken) &&
+              isFieldReadOf(node.operand, varName)
+            ) {
+              poisoned = true;
+            }
+            // Consumer-safety: varName flows into a CONCRETE-struct-typed position
+            // (call/new argument, return, or assignment target) → poison.
+            if (ts.isIdentifier(node) && node.text === varName && isValueUseOfIdentifier(node)) {
+              if (typeRequiresStruct(checker.getContextualType(node))) {
+                poisoned = true;
+              }
+            }
+            forEachChild(node, visit);
+          };
+          for (const s of stmts) visit(s);
+          if (grows && !poisoned) {
+            ctx.growableObjectLiteralVars.add(varName);
+          }
+        }
+      }
+      if (ts.isFunctionDeclaration(stmt) && stmt.body) {
+        scanStatements(stmt.body.statements);
+      }
+      if (ts.isTryStatement(stmt)) {
+        scanStatements(stmt.tryBlock.statements);
+        if (stmt.catchClause) scanStatements(stmt.catchClause.block.statements);
+        if (stmt.finallyBlock) scanStatements(stmt.finallyBlock.statements);
+      }
+    }
+  }
+
+  scanStatements(sourceFile.statements);
+}
+
+/** (#2837) `V.field` (depth-1 property read) where the chain root is `varName`. */
+function isFieldReadOf(expr: ts.Expression, varName: string): boolean {
+  if (!ts.isPropertyAccessExpression(expr)) return false;
+  return ts.isIdentifier(expr.expression) && expr.expression.text === varName;
+}
+
+/** (#2837) Arithmetic binary operators whose operands need the f64 struct contract. */
+function isArithmeticOperator(kind: ts.SyntaxKind): boolean {
+  return (
+    kind === ts.SyntaxKind.MinusToken ||
+    kind === ts.SyntaxKind.AsteriskToken ||
+    kind === ts.SyntaxKind.SlashToken ||
+    kind === ts.SyntaxKind.PercentToken ||
+    kind === ts.SyntaxKind.AsteriskAsteriskToken
+  );
+}
+
+/** (#2837) The identifier is used as a value (arg / return / RHS), not as an
+ * assignment target or the base of its own property-write. */
+function isValueUseOfIdentifier(id: ts.Identifier): boolean {
+  const p = id.parent;
+  if (ts.isCallExpression(p) || ts.isNewExpression(p)) {
+    return (p.arguments?.indexOf(id) ?? -1) >= 0;
+  }
+  if (ts.isReturnStatement(p)) return true;
+  if (ts.isBinaryExpression(p) && p.operatorToken.kind === ts.SyntaxKind.EqualsToken && p.right === id) {
+    return true;
+  }
+  return false;
+}
+
 /** Returns true if an Object.defineProperty descriptor ObjectLiteral is an accessor descriptor
  * with an ACTUAL function getter or setter that needs the sidecar/extern path.
  * Descriptors with `get: undefined` or `set: undefined` are NOT treated as accessor descriptors —
@@ -3770,6 +3955,18 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
    */
   function moduleGlobalWasmType(decl: ts.VariableDeclaration, varType: ts.Type): ValType {
     if (moduleInitForcesExternref(decl) && ts.isIdentifier(decl.name)) {
+      ctx.externrefAccessorVars.add(decl.name.text);
+      return { kind: "externref" };
+    }
+    // (#2837) A module-level `var V = {non-empty literal}` marked growable by the
+    // detection pre-pass (later out-of-shape / nested write, e.g. acorn's
+    // `prototypeAccessors.inFunction.get = fn`) is built as an externref `$Object`
+    // by the literals.ts routing, so the receiving GLOBAL must be externref too —
+    // else the $Object is stored into a struct-typed global, the out-of-shape /
+    // nested write is dropped, and the getter is never installed. Mirrors the
+    // accessor-literal override above and the function-local sites
+    // (statements/variables.ts).
+    if (ts.isIdentifier(decl.name) && ctx.growableObjectLiteralVars.has(decl.name.text)) {
       ctx.externrefAccessorVars.add(decl.name.text);
       return { kind: "externref" };
     }

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -2420,6 +2420,33 @@ export function collectGrowableObjectLiterals(
                 poisoned = true;
               }
             }
+            // (#2837 regression fix) Consumer-safety: `delete V.k`, element/bracket
+            // access `V[expr]`, and `for (k in V)` lower against V's STATIC struct
+            // type (`ref.cast` to the inferred struct + `struct.set`/enumerate).
+            // Routing V to externref `$Object` would make those casts `illegal cast`
+            // (the consumers don't consult `externrefAccessorVars`). Such objects are
+            // ALREADY handled correctly by the existing dynamic-consumer machinery
+            // (they passed pre-fix), so do NOT mark them growable — leave them on the
+            // struct path, byte-identical. acorn's `prototypeAccessors` has none of
+            // these (consumed only by `Object.defineProperties`), so it stays marked.
+            if (
+              ts.isDeleteExpression(node) &&
+              ts.isPropertyAccessExpression(node.expression) &&
+              ts.isIdentifier(node.expression.expression) &&
+              node.expression.expression.text === varName
+            ) {
+              poisoned = true;
+            }
+            if (
+              ts.isElementAccessExpression(node) &&
+              ts.isIdentifier(node.expression) &&
+              node.expression.text === varName
+            ) {
+              poisoned = true;
+            }
+            if (ts.isForInStatement(node) && ts.isIdentifier(node.expression) && node.expression.text === varName) {
+              poisoned = true;
+            }
             forEachChild(node, visit);
           };
           for (const s of stmts) visit(s);

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -122,6 +122,7 @@ import {
   collectDeclarations,
   inferNumericReturnTypes,
   collectEmptyObjectWidening,
+  collectGrowableObjectLiterals,
   compileDeclarations,
   createUnifiedCollectorState,
   finalizeUnifiedCollector,
@@ -1219,6 +1220,9 @@ export function generateModule(
     // Pre-pass: detect empty object literals that get properties assigned later
     // Must run before import collectors so that widened types are known
     collectEmptyObjectWidening(ctx, ast.checker, ast.sourceFile);
+    // (#2837) Detect NON-empty object literals later written out-of-shape (incl.
+    // nested depth-2 descriptors) → route them to the externref $Object builder.
+    collectGrowableObjectLiterals(ctx, ast.checker, ast.sourceFile);
 
     // Register only the extern class imports actually used in source code
     collectUsedExternImports(ctx, ast.sourceFile);
@@ -5900,6 +5904,8 @@ export function generateMultiModule(
     // Must run before import collectors so that widened types are known
     for (const sf of multiAst.sourceFiles) {
       collectEmptyObjectWidening(ctx, multiAst.checker, sf);
+      // (#2837) see single-file path above.
+      collectGrowableObjectLiterals(ctx, multiAst.checker, sf);
     }
 
     // Single-pass collection of all source imports for each file (#592)

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -1162,6 +1162,33 @@ export function compileObjectLiteral(
     }
   }
 
+  // (#2837) A NON-EMPTY object literal initializing a variable that the detection
+  // pre-pass (collectGrowableObjectLiterals) marked growable — i.e. it later
+  // receives an OUT-OF-SHAPE property write (direct unknown key, or a nested
+  // depth-≥2 write onto a descriptor object, the acorn
+  // `prototypeAccessors.inFunction.get = fn` idiom). Build it as an open `$Object`
+  // via the EXISTING recursive externref builder rather than a closed struct
+  // (whose unknown-field writes lower to `drop` and reads to `ref.null extern`).
+  // NOT standalone-gated: `compileObjectLiteralAsExternref` works in host mode
+  // (`__new_plain_object` + `__extern_set`), which is the mode the NM differential
+  // compiles in; the #1901 `ctx.standalone` gate above is a DECISION gate for the
+  // any-context route, not a builder limitation. Placed BEFORE the closed-struct
+  // contextType resolution so a marked var never reaches `compileObjectLiteralForStruct`.
+  // The builder recurses on nested object-literal values (literals.ts:298), so the
+  // nested descriptor objects are built growable automatically. The local typing in
+  // variables.ts makes the binding externref in lockstep. If the builder declines
+  // (methods/accessors/computed keys), fall through to the existing paths.
+  if (
+    expr.properties.length > 0 &&
+    ts.isVariableDeclaration(expr.parent) &&
+    ts.isIdentifier(expr.parent.name) &&
+    ctx.growableObjectLiteralVars.has(expr.parent.name.text)
+  ) {
+    const growableResult = compileObjectLiteralAsExternref(ctx, fctx, expr);
+    if (growableResult) return growableResult;
+    // builder declined — fall through to the struct paths below.
+  }
+
   const contextType = ctx.checker.getContextualType(expr);
   if (!contextType) {
     // #1606: `getTypeAtLocation` can crash inside TypeScript's `checkObjectLiteral`

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -1011,6 +1011,37 @@ export function resolveStructName(ctx: CodegenContext, tsType: ts.Type): string 
 }
 
 /**
+ * (#2837) True if `expr` is a property-access chain whose ROOT identifier is a
+ * growable-object-literal var. Such a var is an externref `$Object`, so reading a
+ * member off it (`o.inner`) yields a nested externref `$Object` too — therefore a
+ * further member access (`o.inner.get = fn`, the acorn descriptor write) must ALSO
+ * route through the externref host path, not the receiver's static struct type
+ * (which would `struct.set`/`drop` the out-of-shape field). Scoped to
+ * `growableObjectLiteralVars` (not all externref vars) to keep the #2837 change
+ * from perturbing unrelated accessor/Proxy member dispatch.
+ */
+function chainRootIsGrowable(ctx: CodegenContext, expr: ts.Expression): boolean {
+  let e: ts.Expression = expr;
+  for (;;) {
+    while (
+      ts.isParenthesizedExpression(e) ||
+      ts.isAsExpression(e) ||
+      ts.isNonNullExpression(e) ||
+      ts.isSatisfiesExpression(e) ||
+      ts.isTypeAssertionExpression(e)
+    ) {
+      e = (e as ts.ParenthesizedExpression | ts.AsExpression | ts.NonNullExpression).expression;
+    }
+    if (ts.isPropertyAccessExpression(e)) {
+      e = e.expression;
+      continue;
+    }
+    break;
+  }
+  return ts.isIdentifier(e) && ctx.growableObjectLiteralVars.has(e.text);
+}
+
+/**
  * Resolve a struct name for a property access/assignment target expression,
  * with fallbacks for widened variables and `this` in function constructors.
  */
@@ -1037,6 +1068,12 @@ export function resolveStructNameForExpr(
     bareIdent = (bareIdent as ts.ParenthesizedExpression | ts.AsExpression | ts.NonNullExpression).expression;
   }
   if (ts.isIdentifier(bareIdent) && ctx.externrefAccessorVars.has(bareIdent.text)) {
+    return undefined;
+  }
+  // (#2837) A member access on a chain rooted at a growable-object-literal var
+  // (`o.inner` / `o.inner.get`) operates on a nested externref `$Object` →
+  // force the externref host path so out-of-shape writes/reads land.
+  if (chainRootIsGrowable(ctx, expression)) {
     return undefined;
   }
   const objType = ctx.checker.getTypeAtLocation(expression);
@@ -1080,6 +1117,11 @@ export function resolveEffectiveStructName(
       bare = (bare as ts.ParenthesizedExpression | ts.AsExpression | ts.NonNullExpression).expression;
     }
     if (ts.isIdentifier(bare) && ctx.externrefAccessorVars.has(bare.text)) {
+      return undefined;
+    }
+    // (#2837) member access on a chain rooted at a growable-object-literal var
+    // → nested externref `$Object`, force the host path.
+    if (chainRootIsGrowable(ctx, expression)) {
       return undefined;
     }
   }

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -756,7 +756,17 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
       decl.initializer !== undefined &&
       ts.isObjectLiteralExpression(decl.initializer) &&
       objectLiteralSpreadTakesHostPath(ctx, decl.initializer);
-    if (initIsAccessorLiteral || initIsHostSpreadLiteral) {
+    // (#2837) A non-empty object literal that the detection pre-pass marked
+    // growable (later out-of-shape / nested write) is built as an externref
+    // `$Object`; the local must be externref so reads/writes route through
+    // `__extern_get`/`__extern_set` (via the same `externrefAccessorVars` hook the
+    // member dispatch consults), matching the value representation.
+    const initIsGrowableObjectLiteral =
+      decl.initializer !== undefined &&
+      ts.isObjectLiteralExpression(decl.initializer) &&
+      ts.isIdentifier(decl.name) &&
+      ctx.growableObjectLiteralVars.has(decl.name.text);
+    if (initIsAccessorLiteral || initIsHostSpreadLiteral || initIsGrowableObjectLiteral) {
       ctx.externrefAccessorVars.add(name);
     }
 
@@ -775,7 +785,7 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
       ts.isIdentifier(decl.name) &&
       !proxyResultEscapesToCall(decl, decl.name.text);
     const wasmType: ValType =
-      initIsAccessorLiteral || initIsHostSpreadLiteral
+      initIsAccessorLiteral || initIsHostSpreadLiteral || initIsGrowableObjectLiteral
         ? { kind: "externref" as const }
         : isI32CoercedLocal
           ? { kind: "i32" }
@@ -952,6 +962,16 @@ export function compileVariableStatement(ctx: CodegenContext, fctx: FunctionCont
           // externref here is safe — and required, otherwise the Proxy externref
           // is `ref.test`-coerced into the struct slot (fails → null → trap on
           // every read). Same rationale as the accessor-literal branch above.
+          localSlot.type = wasmType;
+        } else if (initIsGrowableObjectLiteral && existingIsRef && wasmType.kind === "externref") {
+          // (#2837) A `var o = {c:1}` later written out-of-shape was pre-hoisted as
+          // the inferred closed struct, but the literal is built as an externref
+          // `$Object` (so the out-of-shape write lands). Narrow the hoisted ref slot
+          // to externref — required, otherwise the $Object is `ref.test`-coerced into
+          // the struct slot (fails → null → every read/write lost). Same rationale as
+          // the accessor-literal / Proxy branches above (hoist pass emits no init for
+          // ref-typed locals, so ref → externref is safe). The default re-type guard
+          // below treats externref as "primitive" and would refuse this narrowing.
           localSlot.type = wasmType;
         } else if (standaloneRegExpMatchArrayType !== null && existingIsExternref && newIsRef) {
           localSlot.type = wasmType;

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -2166,25 +2166,44 @@ function _isWasmClosureValue(
  */
 function _descsHaveWasmClosureAccessor(
   descsObj: any,
-  getField: (o: any, k: string) => any,
-  getKeys: (o: any) => (string | symbol)[],
   callbackState?: { getExports: () => Record<string, Function> | undefined },
 ): boolean {
   if (descsObj == null || typeof descsObj !== "object") return false;
-  let keys: (string | symbol)[];
+  // NON-INVOKING scan: read via `Object.getOwnPropertyDescriptor` (never fires a
+  // getter), NOT `getField` (which WOULD invoke host getters — that double-invoke
+  // perturbed `Object/defineProperties` tests with Error-object descriptors and
+  // ToPrimitive side effects, #2837 regression). Only a DATA descriptor whose
+  // stored value is a nested descriptor object with a wasm-closure get/set (our
+  // `$Object` shape, populated via `__extern_set`) qualifies; an ACCESSOR
+  // descriptor (a real host getter, e.g. the Error test's `prop`) is skipped
+  // without invocation, so arbitrary host descriptor objects take the native path
+  // unchanged.
+  let keys: string[];
   try {
-    keys = getKeys(descsObj);
+    keys = Object.getOwnPropertyNames(descsObj);
   } catch {
     return false;
   }
   for (const key of keys) {
-    const rawDesc = getField(descsObj, key as string);
+    let outer: PropertyDescriptor | undefined;
+    try {
+      outer = Object.getOwnPropertyDescriptor(descsObj, key);
+    } catch {
+      continue;
+    }
+    if (!outer || !("value" in outer)) continue; // accessor / no stored value → skip (no invoke)
+    const rawDesc = outer.value;
     if (rawDesc == null || typeof rawDesc !== "object") continue;
-    if (
-      _isWasmClosureValue(getField(rawDesc, "get"), callbackState) ||
-      _isWasmClosureValue(getField(rawDesc, "set"), callbackState)
-    ) {
-      return true;
+    for (const acc of ["get", "set"] as const) {
+      let inner: PropertyDescriptor | undefined;
+      try {
+        inner = Object.getOwnPropertyDescriptor(rawDesc, acc);
+      } catch {
+        continue;
+      }
+      if (inner && "value" in inner && _isWasmClosureValue(inner.value, callbackState)) {
+        return true;
+      }
     }
   }
   return false;
@@ -9725,7 +9744,7 @@ assert._isSameValue = isSameValue;
           // function"). Route through the manual per-key path that wraps wasm
           // closures to host callables (no-op for real JS functions). Gated on
           // detection so the common host-literal path is byte-identical.
-          if (_descsHaveWasmClosureAccessor(descsObj, getField, getKeys, callbackState)) {
+          if (_descsHaveWasmClosureAccessor(descsObj, callbackState)) {
             const keys = getKeys(descsObj);
             const gathered: { key: string | symbol; desc: PropertyDescriptor }[] = [];
             for (const key of keys) {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -2133,6 +2133,63 @@ function _wrapWasmClosureUnknownArity(
  * The wrapper is cached per (closure, arity), which preserves accessor
  * descriptor identity for `Object.getOwnPropertyDescriptor(...).get`.
  */
+/**
+ * (#2837) True if `val` is a raw wasm closure (a WasmGC struct the runtime can
+ * wrap into a host callable), i.e. not already a JS function. Used to detect
+ * descriptor get/set fields that need wrapping before a native
+ * `Object.defineProperties` (which rejects `[object Object]` getters/setters).
+ */
+function _isWasmClosureValue(
+  val: any,
+  callbackState?: { getExports: () => Record<string, Function> | undefined },
+): boolean {
+  if (val == null || typeof val !== "object") return false;
+  const exports = callbackState?.getExports();
+  const isClosureFn = exports?.__is_closure as ((v: any) => number) | undefined;
+  if (typeof isClosureFn === "function") {
+    try {
+      return isClosureFn(val) === 1;
+    } catch {
+      /* fall through */
+    }
+  }
+  return _isWasmStruct(val);
+}
+
+/**
+ * (#2837) True if `descsObj` carries at least one accessor descriptor whose
+ * `get`/`set` is a raw wasm closure. Such a descriptors object (e.g. a host
+ * `$Object` built by `__new_plain_object` and populated via `__extern_set` — the
+ * acorn `prototypeAccessors` idiom) cannot go through native
+ * `Object.defineProperties` (it throws "Getter must be a function"); it must take
+ * the manual per-key path that wraps the closures to host callables.
+ */
+function _descsHaveWasmClosureAccessor(
+  descsObj: any,
+  getField: (o: any, k: string) => any,
+  getKeys: (o: any) => (string | symbol)[],
+  callbackState?: { getExports: () => Record<string, Function> | undefined },
+): boolean {
+  if (descsObj == null || typeof descsObj !== "object") return false;
+  let keys: (string | symbol)[];
+  try {
+    keys = getKeys(descsObj);
+  } catch {
+    return false;
+  }
+  for (const key of keys) {
+    const rawDesc = getField(descsObj, key as string);
+    if (rawDesc == null || typeof rawDesc !== "object") continue;
+    if (
+      _isWasmClosureValue(getField(rawDesc, "get"), callbackState) ||
+      _isWasmClosureValue(getField(rawDesc, "set"), callbackState)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function _maybeWrapCallable(
   val: any,
   arity: number,
@@ -9658,6 +9715,25 @@ assert._isSameValue = isSameValue;
               } else {
                 Object.defineProperty(obj, key, desc);
               }
+            }
+            return obj;
+          }
+          // (#2837) A host `$Object` descsObj (built by `__new_plain_object`,
+          // populated via `__extern_set` — the acorn `prototypeAccessors` idiom)
+          // can carry accessor descriptors whose get/set are RAW wasm closures.
+          // Native `Object.defineProperties` rejects those ("Getter must be a
+          // function"). Route through the manual per-key path that wraps wasm
+          // closures to host callables (no-op for real JS functions). Gated on
+          // detection so the common host-literal path is byte-identical.
+          if (_descsHaveWasmClosureAccessor(descsObj, getField, getKeys, callbackState)) {
+            const keys = getKeys(descsObj);
+            const gathered: { key: string | symbol; desc: PropertyDescriptor }[] = [];
+            for (const key of keys) {
+              const rawDesc = getField(descsObj, key as string);
+              gathered.push({ key, desc: _toPropertyDescriptorValidate(rawDesc, getField, wrap, hasField) });
+            }
+            for (const { key, desc } of gathered) {
+              Object.defineProperty(obj, key, desc);
             }
             return obj;
           }


### PR DESCRIPTION
## Summary

Fixes a real, general **data-loss bug**: a property written to a NON-EMPTY object literal that is NOT in the literal's static shape was **silently compiled away**. `var o = {a:1}; o.b = 2; o.b` returned `undefined` (WAT: the write lowered to `f64.const 0; drop`, the read to `ref.null extern`) because a non-empty literal is lowered to a CLOSED struct with no sidecar. An empty literal `{}` already used the dynamic `$Object` path and grew fine.

This is the architect's **Approach A**: when the detection pre-pass finds a non-empty-literal var that later receives an out-of-shape write (direct unknown key, or a nested depth-≥2 descriptor write like `acc.x.get = fn`), route the literal through the existing recursive externref `$Object` builder and type the binding externref in lockstep. A **consumer-safety guard** keeps struct-typed-consumer vars OFF the externref path (avoids the #1897 closed-struct-consumer regression). Approaches B (sidecar on closed structs — reopens #2664 slot/sidecar desync) and C (always `$Object` — #1897's 116 regressions) were rejected.

## Scope of behavioral change

ONLY variables initialized by a non-empty object literal that (a) are later out-of-shape mutated AND (b) pass the consumer-safety guard. Everything else is **byte-identical** (regression controls `{n:1}; o.n+1` and plain structs verified to stay on the `struct.get`/`struct.set` path).

## Changes

- `collectGrowableObjectLiterals` detection pre-pass + `ctx.growableObjectLiteralVars` (declarations.ts, context).
- Local + module-global externref typing (variables.ts incl. hoisted-var slot re-type; `moduleGlobalWasmType`).
- Literal routing to `compileObjectLiteralAsExternref` (literals.ts).
- Nested-chain member dispatch `chainRootIsGrowable` (property-access.ts) so `o.inner.x = …` on a growable root routes through the host path.
- Runtime `definePropertiesHandler`: wrap wasm-closure get/set on a host `$Object` descsObj (native `Object.defineProperties` rejected `[object Object]` getters).

## Verification

- `var o={c:1}; o.d=7` → 7; nested `o.inner.n=7` → 7; module-global + function-local; `null`/data fields.
- Regression controls stay struct (byte-identical); object-literal/accessor/defineProperty suites 8/9 files green (the 1 failure is a pre-existing stale-harness test that instantiates with `{env:{}}`, unrelated).

## IMPORTANT — necessary but NOT sufficient for acorn `return`

This fixes the **object-literal-growth** layer. Compiled acorn's `return` does NOT parse from this alone — it is also blocked by an **orthogonal** Layer 3 (runtime-installed prototype accessors via `Object.defineProperties` are never invoked by `this.field` on a typed receiver), tracked separately in **#2838**. A reviewer should NOT expect acorn to parse from this PR.

Note: the issue **filename** (`block-body-arrow`) is a stale misnomer from the original carve; the real root cause is object-literal growth (see the issue body).

Broad-impact (object representation) ⇒ validated by the FULL `merge_group` + standalone-floor.

Closes #2837.

🤖 Generated with [Claude Code](https://claude.com/claude-code)