### PR TITLE
fix(#2838): L3 — wasmClosureBridge method-this arity fallback

### DIFF
--- a/plan/issues/2838-dynamic-prototype-accessor-dispatch.md
+++ b/plan/issues/2838-dynamic-prototype-accessor-dispatch.md
@@ -1,7 +1,8 @@
 ---
 id: 2838
 title: "[SENIOR-DEV ONLY] dynamic prototype-accessor dispatch on statically-typed receivers — `Object.defineProperties(Proto, {get})` getters never fire on `this.field` (acorn `return` wall)"
-status: ready
+status: in-progress
+assignee: sendev-2838
 sprint: current
 priority: high
 horizon: l
@@ -114,3 +115,28 @@ standalone-floor.**
 - Repro infra (branch `issue-2837-objrep` `.tmp/`): `bb-instr.mjs`,
   `bb-instr2.mjs` (getter-never-invoked proof), `bb-probe2.mjs` (return trigger).
 - Diagnosed after #2837 on compiled acorn@8.16.0, 2026-06-29 (sendev round 5).
+
+---
+
+## Implementation (sendev-2838, 2026-06-29) — 3-PR epic per architect round-7
+
+Driving the full 6-layer stack to acorn-`return`-parses (and on to the edge.js
+NM differential). Chunked into 3 PRs to isolate the broad L6 dispatch change.
+
+### PR1 — L3: `wasmClosureBridge` method-`this` arity fallback (this branch)
+`src/runtime.ts`, `_wrapWasmClosure` → `wasmClosureBridge` (~2009). When the
+exact `__call_fn_method_${arity}` dispatcher is ABSENT, fall back to the highest
+available `__call_fn_method_M` (M from 8 down to arity), padding args to M. The
+wasm method-dispatch arm hands each closure exactly its own declared arity, so a
+higher-M dispatch still threads `this` correctly. LAZY bridge ⇒ module-init-safe
+(resolves exports at call time, after `Object.defineProperties` runs pre-`__setExports`).
+This is the round-5/6 drafted-and-reverted fix, re-applied. **Verified
+non-regressing**: closure/accessor + class-method/dispatch suites
+(`illegal-cast-closures-585`, `issue-1712*`, `getters-setters`,
+`accessor-side-effects`, `class-method-calls`, `class-methods`,
+`computed-setter-class`, `issue-1364a`, `issue-1672`, `issue-2174`) produce
+**identical** pass/fail counts with and without the change. L3 alone does not fix
+acorn — it is the isolated prerequisite for L6.
+
+### PR2 — L4+L5: member-read host-MOP routing + `this`-truth (next)
+### PR3 — L6: `effectiveReceiverType` method-call dispatch redesign (the wall)

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -2016,10 +2016,40 @@ function _wrapWasmClosure(
     // dropped (JS spec for fewer/more args than declared params).
     const padded: any[] = [];
     for (let i = 0; i < arity; i++) padded.push(args[i]);
-    const methodCallFn = exports?.[`__call_fn_method_${arity}`];
-    if (typeof methodCallFn === "function" && this !== undefined && this !== globalThis) {
-      const rawThis = this !== null && typeof this === "object" ? _unwrapForHost(this) : this;
-      return methodCallFn(_isWasmStruct(rawThis) ? rawThis : this, closure, ...padded);
+    if (this !== undefined && this !== globalThis) {
+      // (#2838 L3) Method-`this` dispatch. Prefer the exact-arity method
+      // dispatcher; when it is ABSENT, fall back to the HIGHEST available
+      // `__call_fn_method_M` (M from 8 down to `arity`), padding the args to M.
+      // The wasm method-dispatch arm hands each closure exactly its own declared
+      // arity (extra positional args are dropped — emitClosureMethodCallExportN
+      // in index.ts), so dispatching at a higher M still invokes THIS closure at
+      // its real arity while threading `this` via `__current_this`. Without this
+      // fallback, a getter/setter closure wrapped at fixed arity 0/1 whose exact
+      // `__call_fn_method_${arity}` happens not to be emitted silently lost its
+      // receiver (`this` inert) and fell back to the plain `__call_fn_${arity}`
+      // path. This is the LAZY bridge (it resolves exports at call time), so it
+      // is module-init-safe: `Object.defineProperties` runs before
+      // `__setExports`, and the availability check happens only when the wrapped
+      // accessor is actually invoked post-instantiation. Mirrors the dynamic
+      // bridge's `methodMaxArity` logic (`_wrapWasmClosureUnknownArity`).
+      let methodArity = -1;
+      if (typeof exports?.[`__call_fn_method_${arity}`] === "function") {
+        methodArity = arity;
+      } else if (exports) {
+        for (let a = 8; a >= arity; a--) {
+          if (typeof exports[`__call_fn_method_${a}`] === "function") {
+            methodArity = a;
+            break;
+          }
+        }
+      }
+      if (methodArity >= 0) {
+        const methodCallFn = exports![`__call_fn_method_${methodArity}`]!;
+        const methodPadded: any[] = [];
+        for (let i = 0; i < methodArity; i++) methodPadded.push(args[i]);
+        const rawThis = this !== null && typeof this === "object" ? _unwrapForHost(this) : this;
+        return methodCallFn(_isWasmStruct(rawThis) ? rawThis : this, closure, ...methodPadded);
+      }
     }
     return callFn(closure, ...padded);
   };


### PR DESCRIPTION
## #2838 epic, PR 1 of 3 — L3 (isolated, non-regressing)

First chunk of the acorn `return`-wall epic (architect round-7 6-layer stack). This PR lands **L3 only** — the `this`-threading prerequisite — isolated so its blast radius is tractable.

### Change
`src/runtime.ts`, `_wrapWasmClosure` → inner `wasmClosureBridge` (~line 2009). When the exact `__call_fn_method_${arity}` dispatcher is **absent**, fall back to the **highest available** `__call_fn_method_M` (M from 8 down to `arity`), padding args to M. The wasm method-dispatch arm hands each closure exactly its own declared arity (extra positional args dropped), so dispatching at a higher M still invokes the closure at its real arity while threading `this` via `__current_this`.

This is the **lazy** bridge (resolves exports at call time) ⇒ module-init-safe: `Object.defineProperties` runs before `__setExports`, and the availability check only happens when the wrapped accessor is actually invoked post-instantiation. Mirrors the dynamic bridge's `methodMaxArity` logic. Re-applies the round-5/6 drafted-and-reverted fix.

### Validation
L3 alone does **not** fix acorn (the method-call dispatch wall is L6, PR3). It is the isolated prerequisite. Verified **non-regressing**: identical pass/fail counts with and without the change across `illegal-cast-closures-585`, `issue-1712*`, `getters-setters`, `accessor-side-effects`, `class-method-calls`, `class-methods`, `computed-setter-class`, `issue-1364a`, `issue-1672`, `issue-2174`. Typecheck + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)