### PR TITLE
fix(#2839): externref→vec materializer i8/i16 coerce + WASI native reader (#2311 regression)

### DIFF
--- a/plan/issues/2839-externref-vec-materializer-missing-i8-i16-coerce.md
+++ b/plan/issues/2839-externref-vec-materializer-missing-i8-i16-coerce.md
@@ -1,0 +1,83 @@
+---
+id: 2839
+title: externref→wasm-vec materializer missing i8/i16 coerce + WASI host-import leak (#2311 regression)
+status: done
+sprint: current
+priority: high
+area: codegen
+task_type: bug
+related: [389, 2831, 2311, 2832]
+assignee: ttraenkler/agent-senior-2839
+completed: 2026-06-29
+---
+
+## Problem
+
+#2311 (`fix(#2831): host-externref→wasm-vec materializer`) added
+`buildVecFromExternref` / `buildElemCoerce` in `src/codegen/type-coercion.ts`.
+The new materializer regressed the standalone-WASI Native-Messaging hosts —
+`native-messaging-smoke` and the standalone `process.stdin` tests
+(`tests/issue-2735*`, `tests/issue-2752*`) have failed on `main` since #2311
+merged (~05:38 2026-06-29). The bun-bundled standalone-WASI compile of
+`nm_js2wasm_node_process` (and the other byte host `nm_js2wasm_node_fs`) was
+the failing case.
+
+Two distinct defects, both in `buildVecFromExternref`, both surfacing only when a
+dynamic/externref value is materialized into a **packed byte/short vec**
+(`Uint8Array` = packed `i8`, etc.) under `--target wasi`:
+
+1. **Missing packed element coercion (compile-time validation failure).**
+   `buildElemCoerce` handled element kinds `f64` / `i32` / `externref` / `ref`
+   but **not `i8` / `i16`**. A packed element fell through to the empty
+   `return []`, leaving an `externref` on the stack where the packed
+   `array.set` expects `i32`:
+   `[wasm-validator error in function __vec_from_extern_55] array.set must have
+   the proper type` → `Fatal: error validating input`. No wasm was emitted.
+
+2. **WASI host-import leak (runtime instantiation failure).** Once (1) is fixed
+   the module compiles, but `useNativeObjVec` was gated on `ctx.standalone`
+   **alone**. WASI is host-free at runtime (the scale-test runs the module under
+   **raw wasmtime**), yet the non-standalone branch emits the JS-host import
+   `env::__array_from_iter`, which has no definition under wasmtime:
+   `unknown import: env::__array_from_iter` → instantiation fails → ZERO output.
+
+## Root cause
+
+`src/codegen/type-coercion.ts`, function `buildVecFromExternref`:
+
+- `buildElemCoerce` only matched `f64`/`i32`/`externref`/`ref` element kinds.
+  Packed typed-array vecs use `i8`/`i16` element kinds.
+- `const useNativeObjVec = ctx.standalone;` — should be
+  `ctx.standalone || ctx.wasi` (the host-free idiom used everywhere else in
+  codegen, incl. this same file at lines ~1367/1454/3023). `__array_from_iter`
+  is the only construct on this path that is a host import with no native
+  definition; `__extern_get_idx` / `__extern_get` / `__box_number` /
+  `__unbox_number` are all emitted as defined funcs under WASI.
+
+## Fix
+
+`src/codegen/type-coercion.ts` only:
+
+1. Add `i8` / `i16` to the `i32` arm of `buildElemCoerce`. The value-position
+   rep of a packed element is `i32`; a packed `array.set` truncates the `i32`
+   modulo the storage width (8/16 bits), so the unbox→`i32.trunc_sat_f64_s`
+   sequence is identical to the `i32` arm. **Signedness is irrelevant on the
+   WRITE side** — it only governs the READ op (`array.get_s`/`array.get_u`),
+   driven by the view name elsewhere. `f64`/`i32`/`externref`/`ref` arms
+   unchanged.
+2. `useNativeObjVec = ctx.standalone || ctx.wasi` — WASI takes the native
+   `__extern_get_idx` reader and never imports `__array_from_iter`.
+
+## Verification (acceptance — all green)
+
+- The exact failing compile now succeeds: standalone bun-bundled
+  `nm_js2wasm_node_process` compiles `--target wasi`; the emitted module has
+  **no** `env::__array_from_iter` import.
+- `node examples/native-messaging/scale-test.mjs` (NM_SCALE_SIZES_MIB
+  "1 64 128 256") — all four hosts round-trip byte-exact at every size.
+- `npm test -- tests/issue-2735*.test.ts tests/issue-2752*.test.ts` — green.
+- Typed-array / Uint8Array / DataView suites — no regression to the
+  i32/f64/externref arms.
+- Full CI (test262 shards + quality + native-messaging-smoke) validates.
+</content>
+</invoke>

--- a/plan/issues/2839-externref-vec-materializer-missing-i8-i16-coerce.md
+++ b/plan/issues/2839-externref-vec-materializer-missing-i8-i16-coerce.md
@@ -75,9 +75,34 @@ dynamic/externref value is materialized into a **packed byte/short vec**
   **no** `env::__array_from_iter` import.
 - `node examples/native-messaging/scale-test.mjs` (NM_SCALE_SIZES_MIB
   "1 64 128 256") — all four hosts round-trip byte-exact at every size.
-- `npm test -- tests/issue-2735*.test.ts tests/issue-2752*.test.ts` — green.
+- `tests/issue-2752*.test.ts` — green.
 - Typed-array / Uint8Array / DataView suites — no regression to the
   i32/f64/externref arms.
-- Full CI (test262 shards + quality + native-messaging-smoke) validates.
+- Full CI (test262 shards + quality + native-messaging-smoke) validates. The
+  `native-messaging-smoke` job (which runs the scale-test under real wasmtime —
+  the exact #389 reporter pipeline) goes green.
+
+### Note — pre-existing `#1886` on the RAW-`.ts` compile path (separate bug)
+
+`tests/issue-2735*` has 4 wasmtime-gated cases that compile the **raw**
+`nm_js2wasm_node_process.ts` directly via `compile(..., { target: "wasi" })`
+(no bun bundle). These fail with `Codegen error: linear Uint8Array helper
+argument is not backed by linear memory (#1886)` — a defect in the **linear-Uint8
+escape analysis** (`src/codegen/expressions/calls.ts`), a different subsystem
+from this issue's externref→vec materializer (`type-coercion.ts`). This error:
+
+- is **pre-existing on `origin/main`** (verified: identical failure with this
+  fix reverted), fires earlier in codegen than the i8 validation error, and so
+  masked it on the raw-`.ts` path;
+- was **not** introduced by this fix, and is **not** in this issue's scope
+  (#2311 never touched the linear-Uint8 subsystem);
+- does **not** gate required CI — the cases are wrapped in
+  `maybe = wasmtimeBin ? describe : describe.skip`, so the `quality` vitest job
+  (no wasmtime) skips them; they only run locally when wasmtime is on PATH.
+
+The **bun-bundled** path — the real #389 reporter pipeline and the
+`native-messaging-smoke` CI job — is fully fixed (all 4 NM variants × 4 sizes
+round-trip byte-exact). The raw-`.ts` `#1886` escape failure should be tracked
+as a **separate follow-up** against the linear-Uint8 analysis.
 </content>
 </invoke>

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -225,7 +225,18 @@ export function buildVecFromExternref(
   // never leaking `env::__array_from_iter`. (Generators / custom @@iterator
   // standalone materialization is a separate slice — those don't reach an
   // $ObjVec source.) The JS-host path is unchanged.
-  const useNativeObjVec = ctx.standalone;
+  //
+  // WASI is host-free at runtime too (the module runs under raw wasmtime — see
+  // `examples/native-messaging/scale-test.mjs`), so it must take the SAME native
+  // reader path: `__extern_get_idx` / `__extern_get` / `__box_number` /
+  // `__unbox_number` are all emitted as DEFINED funcs under WASI, but
+  // `__array_from_iter` is only ever a host import — emitting it makes the WASI
+  // module fail instantiation (`unknown import: env::__array_from_iter`). #2311
+  // gated this on `ctx.standalone` alone, which left the WASI nm_js2wasm_node_*
+  // hosts importing `__array_from_iter` (loopdive/js2#389 / #2311 regression);
+  // `ctx.standalone || ctx.wasi` is the established host-free idiom used
+  // throughout codegen (and elsewhere in this file). (#2839)
+  const useNativeObjVec = ctx.standalone || ctx.wasi;
   // #2696 — register EVERY late import (helper) FIRST, flush ONCE, then read the
   // funcIdx values from funcMap. ensureLateImport for a NEW env import shifts the
   // index of every DEFINED helper func (the native `__box_number` /
@@ -276,7 +287,17 @@ export function buildVecFromExternref(
     if (et.kind === "f64" && unboxIdx !== undefined) {
       return [{ op: "call", funcIdx: unboxIdx } as Instr];
     }
-    if (et.kind === "i32" && unboxIdx !== undefined) {
+    // i8/i16 are PACKED array element kinds (Uint8Array, Int8Array, Uint16Array,
+    // …). Their value-position representation is i32: a packed `array.set`
+    // truncates the i32 modulo the storage width (8/16 bits), so the unbox→i32
+    // path is identical to the i32 arm here. Signedness is irrelevant on WRITE —
+    // it only governs the READ op (`array.get_s`/`array.get_u`), driven
+    // elsewhere by the view name. Without this arm the externref falls through
+    // to the empty `return []`, leaving an externref on the stack where the
+    // packed `array.set` expects i32 → `array.set must have the proper type`
+    // (loopdive/js2#389 / #2311 regression — buildElemCoerce only handled
+    // f64/i32/externref/ref). (#2839)
+    if ((et.kind === "i32" || et.kind === "i8" || et.kind === "i16") && unboxIdx !== undefined) {
       return [{ op: "call", funcIdx: unboxIdx } as Instr, { op: "i32.trunc_sat_f64_s" }];
     }
     if (et.kind === "externref") return [];


### PR DESCRIPTION
Fix-forward of the #2311 regression (loopdive/js2#389) that broke the
standalone-WASI Native-Messaging hosts.

## Root cause

#2311's `buildVecFromExternref` / `buildElemCoerce` in
`src/codegen/type-coercion.ts` had two defects on the path that materializes a
dynamic/externref value into a **packed byte/short vec** (`Uint8Array` =
packed `i8`, …) under `--target wasi`:

1. **Missing packed coercion (compile-time validation failure).**
   `buildElemCoerce` matched `f64`/`i32`/`externref`/`ref` element kinds but
   **not `i8`/`i16`**. The packed element fell through to the empty `return []`,
   leaving an `externref` where the packed `array.set` expects `i32`:
   `array.set must have the proper type` → `Fatal: error validating input`.

2. **WASI host-import leak (runtime instantiation failure).**
   `useNativeObjVec` gated on `ctx.standalone` alone. WASI is host-free at
   runtime (the scale-test runs under raw wasmtime), but the non-standalone
   branch emits the JS-host import `env::__array_from_iter`, which has no
   definition under wasmtime → `unknown import: env::__array_from_iter`.

## Fix (`src/codegen/type-coercion.ts` only)

1. Add `i8`/`i16` to the `i32` arm of `buildElemCoerce`. The value-position rep
   of a packed element is `i32`; a packed `array.set` truncates the `i32` modulo
   the storage width, so the `unbox → i32.trunc_sat_f64_s` sequence is identical
   to the `i32` arm. Signedness only governs the READ op (`array.get_s/_u`), not
   the write. `f64`/`i32`/`externref`/`ref` arms unchanged.
2. `useNativeObjVec = ctx.standalone || ctx.wasi` — the established host-free
   idiom used throughout codegen (incl. this file). WASI now uses the native
   `__extern_get_idx` reader and never imports `__array_from_iter`.

## Verification

- `nm_js2wasm_node_process` compiles `--target wasi`; emitted module has **no**
  `env::__array_from_iter` import.
- `examples/native-messaging/scale-test.mjs` (NM_SCALE_SIZES_MIB "1 64 128 256")
  — all 4 NM variants × 4 sizes round-trip **byte-exact** under real wasmtime.
- `tests/issue-2752*` green; packed typed-array suites
  (#1787/#2593/#2648, 57 tests) green — no regression to the existing arms.

### Note (separate, pre-existing)

`tests/issue-2735*`'s wasmtime-gated cases compile the **raw** `.ts` (not the
bun-bundled form) and fail with `#1886` (linear-Uint8 escape analysis in
`calls.ts`) — a **different subsystem**, **present on origin/main** with this
fix reverted, **not** introduced here, and **not** gated by required CI
(`maybe = wasmtimeBin ? describe : describe.skip`). Tracked as a follow-up. The
bun-bundled path — the real #389 pipeline and the `native-messaging-smoke` CI
job — is fully fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)