### PR TITLE
perf(#2835): pack ArrayBuffer/DataView byte buffer as array(mut i8) — 4× smaller GC footprint

### DIFF
--- a/plan/issues/2835-pack-vec-i32-byte-to-i8.md
+++ b/plan/issues/2835-pack-vec-i32-byte-to-i8.md
@@ -1,7 +1,8 @@
 ---
 id: 2835
 title: "Pack $__vec_i32_byte byte backing as array(mut i8) — 4× smaller DataView/ArrayBuffer/Uint8Array GC footprint"
-status: in-progress
+status: done
+completed: 2026-06-29
 assignee: ttraenkler/sendev-2835
 sprint: Backlog
 created: 2026-06-29
@@ -431,3 +432,108 @@ The Native-Messaging `nm_js2wasm_node_process` scale-test fails to compile on
 (`i8_byte`) vec field pushes an externref into an `i8` array. node_fs (the other
 byte-buffer NM host) passes. This is a separate latent issue (the NM scale-test is
 not a CI gate) and is unrelated to the #2835 key split — worth its own issue.
+
+---
+
+## PR-2 implementation notes (the packing — the 4× win, closes #2835)
+
+**Status: PR-2 of 2. Closes #2835.** PR-1 split the overloaded key so the
+ArrayBuffer/DataView byte buffer (`i32_byte`) is disentangled from Int32/Uint32
+element storage (`i32_elem`). This PR flips the byte buffer to a packed
+`array(mut i8)` (1 byte/element), delivering the 4× GC-footprint cut.
+
+### Representation decision — keep the `i32_byte` KEY, change its element type
+
+I did **not** converge the byte buffer onto the existing `i8_byte` key. Instead
+the `i32_byte` key/struct (`$__vec_i32_byte`) is **retained as a distinct type**
+but its data array element type changed `i32 → i8`. Rationale:
+
+- `recoverDvBacking`, `getOrRegisterDvWindowType` (`buf` field), `emitArrayBufferSlice`,
+  `emitTypedArrayFromByteBuffer`, the `.buffer` synth, `__dv_byte_*` exports and
+  the `node:fs` write helpers all `ref.test`/`ref.cast` to the **`i32_byte` vec
+  type** to recover a DataView/ArrayBuffer backing. Native `Uint8Array` is a
+  **separate** value that uses `i8_byte`. Converging the two onto one struct
+  would make a `Uint8Array` and an ArrayBuffer backing structurally
+  indistinguishable to every `ref.test`-based dispatch (e.g. a windowed DataView
+  over a Uint8Array vs over an ArrayBuffer) — a needless ambiguity. Keeping
+  `i32_byte` distinct preserves the existing dispatch exactly; only the per-byte
+  storage shrinks. The two i8-element arrays (`__arr_i32_byte`, `__arr_i8_byte`)
+  are deduped under distinct cache keys, so they stay separate types.
+- **Single consistency invariant:** `getOrRegisterVecType` caches by key, so the
+  FIRST registration's element-type override wins. Every `i32_byte` registration
+  site (dataview-native, property-access, new-super ArrayBuffer/DataView ctors +
+  `emitTypedArrayFromByteBuffer`, node-fs-api) was therefore switched to
+  `{ kind: "i8" }` in lockstep — a mismatch would have desynced the array
+  element type from the read opcode.
+
+### Reads → `array.get_u`, writes unchanged (`array.set` truncates)
+
+`array.get` on a packed array is **invalid Wasm**, so every hardcoded byte READ
+on the `i32_byte` backing became `array.get_u` (unsigned, zero-extended to i32 —
+this is the validator's safety net: a missed site fails module validation, never
+silently miscompiles):
+
+- `dataview-native.ts`: `pushByte`, `buildIntoBranch` byteAt, `emitReadI64`
+  byteAt, `emitArrayBufferSlice` copy, `emitDataViewToWriteScratch`.
+- `index.ts`: `__vec_get` (i32_byte joins the `array.get_u` branch), `__vec_pop`
+  (i32_byte joins `isPackedByte`), `__dv_byte_get`, `ensureWasiWriteArrayBufferHelper`.
+- `new-super.ts`: `emitTypedArrayFromByteBuffer` source read.
+
+WRITES (`emitStoreByte`, `__dv_byte_set`, `emitVecSetByteExport`, the slice/synth
+`array.set`/`array.new`) need **no change** — `array.set`/`array.new` on a packed
+i8 array auto-truncate the i32 to the low byte, exactly the `& 0xff` semantics the
+byte writers already enforced (the masks are now redundant but kept defensively).
+
+### Why this is byte-exact / soundness
+
+- **Bytes are the provably-safe packing case** (per §4 of the feasibility): every
+  value stored is `0..255` and read back zero-extended, so `array.get_u(i8) ∈
+  [0,255]` is bit-identical to the value the old i32 slot held. No `-0`, no
+  fraction, no `>2^31` hazard — the canonical-i32 proof is trivial.
+- **Signedness:** the DataView accessors sign-extend the *assembled* value
+  (`getInt8`/`getInt16`/…) themselves, so the backing read is ALWAYS unsigned
+  (`array.get_u`) regardless of the accessor's signedness — unchanged contract.
+- Most typed-array element reads (`property-access.ts`, `calls.ts` TA-from-TA
+  copy, the `array.get_u`-for-i8 helper in `new-super.ts`) already derive the
+  opcode from `arrDef.element.kind`, so they handle the i8 byte buffer correctly
+  with no edit.
+- `i32_elem` (Int32/Uint32 element storage) is deliberately **untouched** — it
+  stays full 32-bit (plain `array.get`, signed/unsigned box). Packing it would
+  truncate every 32-bit element (the MISCOMPILE the PR-1 split exists to prevent).
+
+### Type-index / DCE discipline
+
+The `i32_byte` vec still registers **lazily** (the byte buffer has no `subarray`
+view, so no eager pre-reservation slot is needed — unchanged from PR-1). Changing
+only the element type does not alter *when* it registers, so no new
+type-index/DCE-remap hazard is introduced
+(`project_type_index_shift_and_deadelim`, `reference_subview_type_idx_stability`).
+
+### Verification
+
+- `tsc --noEmit` clean.
+- DataView / ArrayBuffer / TypedArray / Uint8Array suites green, byte-identical:
+  `issue-1654` (5), `issue-2199` (bounds), `issue-2199b` (setter order),
+  `issue-2593` (typed-array int-width), `issue-2639` (node:fs writeSync
+  string+DataView, incl. windowed byteOffset/byteLength), `issue-2648`,
+  `issue-1670`, `issue-1787` (packed-typedarray-semantics), `issue-2379` — all pass.
+- **NM scale-test** (`node examples/native-messaging/scale-test.mjs`,
+  `NM_SCALE_SIZES_MIB="1 64 128 256"`): all four hosts (`node_process`, `deno`,
+  `wasi_p1`, `node_fs`) round-trip byte-exact at every size up to **256 MiB**
+  under real wasmtime 46. A 256 MiB ArrayBuffer now materialises as a 256 MiB GC
+  array instead of ~1 GiB (4× cut). `nm_js2wasm_node_process` — which PR-1 noted
+  failed on origin/main before #2839 — now passes (the #2839 `buildElemCoerce`
+  i8 arm landed; this PR keeps the byte buffer consistent with it).
+- Pre-existing failures confirmed IDENTICAL on base origin/main (NOT introduced
+  here): `arraybuffer-dataview.test.ts` (6 — the JS-host harness doesn't stub the
+  default string backend's `string_constants` import) and the one
+  `issue-1655` Uint8Array.**subarray** WASI-write `illegal cast` (base-commit
+  bug flagged in PR-1 notes). Verified by running both files on a detached
+  origin/main worktree: same 7-failed/7-passed split with and without this PR.
+
+### Validator note
+
+Packed `i8` arrays encode the element as an SLEB storage byte (`-0x8`), a
+GC-aware-validator-only encoding (like the i16 string `-0x9`). This is already
+true for the shipping `i8_byte`/`i16_byte` typed arrays, so wasmtime / wasm-tools
+/ Binaryen already accept it — confirmed by the 256 MiB real-wasmtime scale-test.

--- a/src/codegen/dataview-native.ts
+++ b/src/codegen/dataview-native.ts
@@ -15,12 +15,23 @@
  *
  * This module emits Wasm-native byte read/write directly into the `i32_byte`
  * vec struct that backs ArrayBuffer / DataView (field 0 = length i32, field 1 =
- * array of i32, one byte per element, values 0..255). Multi-byte accessors
- * honour the `littleEndian` flag at runtime.
+ * a PACKED `array(mut i8)`, one byte per element, values 0..255). Multi-byte
+ * accessors honour the `littleEndian` flag at runtime.
  *
  * Backing-store representation:
- *   ArrayBuffer / DataView  → vec "i32_byte"  (one i32 per byte, 0..255)
+ *   ArrayBuffer / DataView  → vec "i32_byte"  (packed i8, one byte per element)
  *   Uint8Array (native)     → vec "i8_byte"   (packed bytes, unsigned reads)
+ *
+ * (#2835) The `i32_byte` byte buffer is now backed by `array(mut i8)` (was
+ * `array(mut i32)`) — a 4× GC-footprint cut for ArrayBuffer / DataView. The KEY
+ * string is kept (`$__vec_i32_byte`, a type DISTINCT from Uint8Array's
+ * `i8_byte`, so `ref.cast`-based DataView/ArrayBuffer dispatch stays
+ * unambiguous), only the element type changed. Byte READS therefore MUST use
+ * `array.get_u` (plain `array.get` is invalid Wasm on a packed array); the
+ * assembled value is zero-extended, so the DataView accessor's own
+ * sign-extension (`getInt8`/`getInt16`/…) is unaffected. WRITES use `array.set`,
+ * which truncates the i32 to the low byte (the `& 0xff` masks become redundant
+ * but are kept defensively).
  *
  * The receiver (`this`) of a DataView accessor is an externref holding the
  * i32_byte vec; we `any.convert_extern` + `ref.cast` to recover the struct.
@@ -85,7 +96,7 @@ export function emitArrayBufferSlice(
   args: readonly import("../ts-api.js").ts.Expression[],
   compileExpr: (expr: import("../ts-api.js").ts.Expression, hint?: ValType) => ValType | null,
 ): ValType | null {
-  const vecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i32" });
+  const vecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i8" }); // (#2835) packed byte buffer
   const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
   if (arrTypeIdx < 0) return null;
 
@@ -184,7 +195,8 @@ export function emitArrayBufferSlice(
     { op: "local.get", index: beginLocal } as Instr,
     { op: "local.get", index: iLocal } as Instr,
     { op: "i32.add" } as Instr,
-    { op: "array.get", typeIdx: arrTypeIdx } as Instr,
+    // (#2835) packed i8 src/dst; read unsigned, `array.set` truncates to low byte.
+    { op: "array.get_u", typeIdx: arrTypeIdx } as Instr,
     { op: "array.set", typeIdx: arrTypeIdx } as Instr,
     { op: "local.get", index: iLocal } as Instr,
     { op: "i32.const", value: 1 } as Instr,
@@ -254,7 +266,7 @@ function emitNormalizeIndex(fctx: FunctionContext, idxLocal: number, lenLocal: n
 
 /** Lazily ensure the i32_byte vec type exists and return its struct/array indices. */
 function i32ByteVec(ctx: CodegenContext): { vecTypeIdx: number; arrTypeIdx: number } {
-  const vecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i32" });
+  const vecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i8" }); // (#2835) packed byte buffer
   const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
   return { vecTypeIdx, arrTypeIdx };
 }
@@ -273,7 +285,7 @@ function i32ByteVec(ctx: CodegenContext): { vecTypeIdx: number; arrTypeIdx: numb
  */
 export function getOrRegisterDvWindowType(ctx: CodegenContext): number {
   if (ctx.dvWindowTypeIdx >= 0) return ctx.dvWindowTypeIdx;
-  const vecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i32" });
+  const vecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i8" }); // (#2835) packed byte buffer
   const idx = ctx.mod.types.length;
   ctx.mod.types.push({
     kind: "struct",
@@ -580,8 +592,10 @@ function pushByte(fctx: FunctionContext, arrLocal: number, offLocal: number, k: 
     fctx.body.push({ op: "i32.const", value: k } as Instr);
     fctx.body.push({ op: "i32.add" } as Instr);
   }
-  fctx.body.push({ op: "array.get", typeIdx: arrTypeIdx } as Instr);
-  // Mask to a byte — the backing array holds 0..255 already, but defensively
+  // (#2835) Packed `i8` backing → unsigned zero-extended read (plain `array.get`
+  // is invalid on a packed array). Result already in [0,255].
+  fctx.body.push({ op: "array.get_u", typeIdx: arrTypeIdx } as Instr);
+  // Mask to a byte — `array.get_u` already yields 0..255, but defensively
   // keep only the low 8 bits so sign/overflow can't leak in.
   fctx.body.push({ op: "i32.const", value: 0xff } as Instr);
   fctx.body.push({ op: "i32.and" } as Instr);
@@ -694,7 +708,7 @@ function buildIntoBranch(
       seq.push({ op: "i32.const", value: k } as Instr);
       seq.push({ op: "i32.add" } as Instr);
     }
-    seq.push({ op: "array.get", typeIdx: arrTypeIdx } as Instr);
+    seq.push({ op: "array.get_u", typeIdx: arrTypeIdx } as Instr); // (#2835) packed i8 byte read
     seq.push({ op: "i32.const", value: 0xff } as Instr);
     seq.push({ op: "i32.and" } as Instr);
     return seq;
@@ -732,7 +746,7 @@ function emitReadI64(
         seq.push({ op: "i32.const", value: k } as Instr);
         seq.push({ op: "i32.add" } as Instr);
       }
-      seq.push({ op: "array.get", typeIdx: arrTypeIdx } as Instr);
+      seq.push({ op: "array.get_u", typeIdx: arrTypeIdx } as Instr); // (#2835) packed i8 byte read
       seq.push({ op: "i32.const", value: 0xff } as Instr);
       seq.push({ op: "i32.and" } as Instr);
       seq.push({ op: "i64.extend_i32_u" } as Instr);
@@ -964,12 +978,12 @@ export function emitDataViewToWriteScratch(
     { op: "i32.const", value: scratchStart } as Instr,
     { op: "local.get", index: jLocal } as Instr,
     { op: "i32.add" } as Instr,
-    // value = arr[base + j] & 0xff
+    // value = arr[base + j] & 0xff  ((#2835) packed i8 → unsigned read)
     { op: "local.get", index: arrLocal } as Instr,
     { op: "local.get", index: baseLocal } as Instr,
     { op: "local.get", index: jLocal } as Instr,
     { op: "i32.add" } as Instr,
-    { op: "array.get", typeIdx: arrTypeIdx } as Instr,
+    { op: "array.get_u", typeIdx: arrTypeIdx } as Instr,
     { op: "i32.const", value: 0xff } as Instr,
     { op: "i32.and" } as Instr,
     { op: "i32.store8", align: 0, offset: 0 } as Instr,

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -4427,9 +4427,10 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
     }
   }
 
-  // new ArrayBuffer(byteLength) → vec struct with i32 elements (1 byte per element)
+  // new ArrayBuffer(byteLength) → vec struct with packed i8 elements (1 byte per
+  // element, (#2835) — 4× smaller than the former i32-per-byte backing)
   if (className === "ArrayBuffer") {
-    const elemType: ValType = { kind: "i32" };
+    const elemType: ValType = { kind: "i8" };
     const vecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", elemType);
     const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
     const args = expr.arguments ?? [];
@@ -4481,7 +4482,7 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
 
   // new DataView(buffer) / new DataView(buffer, byteOffset) / new DataView(buffer, byteOffset, byteLength)
   if (className === "DataView") {
-    const elemType: ValType = { kind: "i32" };
+    const elemType: ValType = { kind: "i8" }; // (#2835) packed byte buffer
     const vecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", elemType);
     const args = expr.arguments ?? [];
 
@@ -4938,7 +4939,7 @@ function emitTypedArrayFromByteBuffer(
   dstVecTypeIdx: number,
   dstArrTypeIdx: number,
 ): boolean {
-  const srcVecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i32" });
+  const srcVecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i8" }); // (#2835) packed byte buffer
   const srcArrTypeIdx = getArrTypeIdxFromVec(ctx, srcVecTypeIdx);
   if (srcArrTypeIdx < 0 || dstArrTypeIdx < 0) return false;
 
@@ -5016,7 +5017,8 @@ function emitTypedArrayFromByteBuffer(
     { op: "local.get", index: iLocal } as Instr,
     { op: "local.get", index: srcArrLocal } as Instr,
     { op: "local.get", index: iLocal } as Instr,
-    { op: "array.get", typeIdx: srcArrTypeIdx } as Instr,
+    // (#2835) packed i8 source byte → unsigned read.
+    { op: "array.get_u", typeIdx: srcArrTypeIdx } as Instr,
     { op: "i32.const", value: 0xff } as Instr,
     { op: "i32.and" } as Instr,
     ...(dstElemKind === "f64" ? ([{ op: "f64.convert_i32_u" } as Instr] as Instr[]) : []),

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -4971,9 +4971,12 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
         { op: "local.get", index: 1 } as Instr, // index
         // (#2593) Packed i8/i16 elements REQUIRE array.get_u/_s (plain array.get
         // is invalid Wasm on a packed array); read zero-extended in this generic
-        // path. i32_byte/f64 use plain array.get.
+        // path. (#2835) `i32_byte` (the ArrayBuffer/DataView byte buffer) is now
+        // ALSO packed i8 — it joins the `array.get_u` branch (its box arm already
+        // does the unsigned i32→f64 conversion). `i32_elem` (Int32/Uint32 element
+        // storage) and `f64` stay on plain `array.get`.
         {
-          op: elemKey === "i8_byte" || elemKey === "i16_byte" ? "array.get_u" : "array.get",
+          op: elemKey === "i8_byte" || elemKey === "i16_byte" || elemKey === "i32_byte" ? "array.get_u" : "array.get",
           typeIdx: arrTypeIdx,
         } as Instr,
         ...boxInstrs,
@@ -5296,7 +5299,10 @@ function _emitVecAccessExportsInner(ctx: CodegenContext): void {
       // (#2593) Packed i8/i16 elements need array.get_u and unsigned→f64; plain
       // `array.get` is invalid Wasm on a packed array. Generic dynamic path reads
       // zero-extended (the per-view signedness is at the typed `a[i]` site).
-      const isPackedByte = elemKey === "i8_byte" || elemKey === "i16_byte";
+      // (#2835) `i32_byte` (ArrayBuffer/DataView byte buffer) is now packed i8 too
+      // — same unsigned read/box. `i32_elem` (Int32/Uint32 element storage) stays
+      // full-width signed (plain `array.get`), preserving its pre-split behaviour.
+      const isPackedByte = elemKey === "i8_byte" || elemKey === "i16_byte" || elemKey === "i32_byte";
       const boxInstrs: Instr[] =
         elemKey === "externref"
           ? []
@@ -5649,7 +5655,8 @@ function emitDataViewByteExports(ctx: CodegenContext): void {
           { op: "ref.cast", typeIdx: byteVecTypeIdx },
           { op: "struct.get", typeIdx: byteVecTypeIdx, fieldIdx: 1 },
           { op: "local.get", index: 1 } as Instr,
-          { op: "array.get", typeIdx: arrTypeIdx },
+          // (#2835) packed i8 backing → unsigned zero-extended byte read.
+          { op: "array.get_u", typeIdx: arrTypeIdx },
           { op: "return" } as Instr,
         ],
         else: [],
@@ -8225,10 +8232,10 @@ export function ensureWasiWriteUint8ArrayHelper(
  *
  * Companion to `ensureWasiWriteUint8ArrayHelper` for the ArrayBuffer-backing
  * representation. Under `--target wasi` / `--target standalone`, an
- * `ArrayBuffer` is lowered to a vec struct of i32 bytes (one byte per
- * element, values 0..255 — see dataview-native.ts comment block) rather than
- * the Uint8Array f64-element shape. The element conversion is therefore a
- * direct i32 read (no `i32.trunc_sat_f64_s`).
+ * `ArrayBuffer` is lowered to a vec struct of packed `i8` bytes (one byte per
+ * element, values 0..255 — (#2835), see dataview-native.ts comment block)
+ * rather than the Uint8Array f64-element shape. The element read is therefore a
+ * packed `array.get_u` (no `i32.trunc_sat_f64_s`).
  */
 export function ensureWasiWriteArrayBufferHelper(
   ctx: CodegenContext,
@@ -8323,10 +8330,11 @@ export function ensureWasiWriteArrayBufferHelper(
             { op: "local.get", index: I } as Instr,
             { op: "i32.add" } as Instr,
 
-            // value = data[i] (i32; low byte kept by i32.store8)
+            // value = data[i] ((#2835) packed i8 byte → unsigned read; low byte
+            // kept by i32.store8)
             { op: "local.get", index: DATA } as Instr,
             { op: "local.get", index: I } as Instr,
-            { op: "array.get", typeIdx: arrTypeIdx } as Instr,
+            { op: "array.get_u", typeIdx: arrTypeIdx } as Instr,
 
             { op: "i32.store8", align: 0, offset: 0 },
 

--- a/src/codegen/node-fs-api.ts
+++ b/src/codegen/node-fs-api.ts
@@ -117,8 +117,10 @@ export function tryCompileNodeProcessCall(
   const isArrayBufferArg = argSymName === "ArrayBuffer" || argSymName === "SharedArrayBuffer";
   const elemKey: "i8_byte" | "i32_byte" | "f64" =
     noJsHost(ctx) && argSymName === "Uint8Array" ? "i8_byte" : isArrayBufferArg ? "i32_byte" : "f64";
+  // (#2835) Both `i8_byte` (Uint8Array) and `i32_byte` (ArrayBuffer byte buffer)
+  // are now packed `i8` arrays — the byte-buffer rep cut to 1 byte/element.
   const elemType: ValType =
-    elemKey === "i8_byte" ? { kind: "i8" } : elemKey === "i32_byte" ? { kind: "i32" } : { kind: "f64" };
+    elemKey === "i8_byte" ? { kind: "i8" } : elemKey === "i32_byte" ? { kind: "i8" } : { kind: "f64" };
   const vecTypeIdx = getOrRegisterVecType(ctx, elemKey, elemType);
   const argType = compileExpression(ctx, fctx, argExpr);
   flushLateImportShifts(ctx, fctx);

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -2909,7 +2909,7 @@ export function compilePropertyAccess(
     // read its byteOffset / byteLength fields; for the bare vec, byteOffset = 0
     // and byteLength = vec.length (one i32 per byte ⇒ length IS the byte count).
     if (isDataView && noJsHost(ctx) && propName !== "BYTES_PER_ELEMENT") {
-      const vecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i32" });
+      const vecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i8" });
       const dvWinTypeIdx = getOrRegisterDvWindowType(ctx);
       const fieldIdx = propName === "byteOffset" ? 1 : 2;
       const recvType = compileExpression(ctx, fctx, expr.expression);
@@ -2972,7 +2972,7 @@ export function compilePropertyAccess(
         // (i8/i16/i32_byte), not just Uint8Array. Casting an Int32Array (i32_byte)
         // receiver to an f64 vec read the wrong field-0 → wrong byteLength.
         const storage = isBuffer
-          ? { key: "i32_byte", type: { kind: "i32" } as ValType }
+          ? { key: "i32_byte", type: { kind: "i8" } as ValType } // (#2835) packed byte buffer
           : typedArrayVecStorage(ctx, recvName!);
         const elemKey = storage.key;
         const elemType: ValType = storage.type;
@@ -3036,7 +3036,7 @@ export function compilePropertyAccess(
     const bufIsTypedArr = bufRecvName !== undefined && TYPED_ARRAY_BYTES_PER_ELEMENT[bufRecvName] !== undefined;
     const bufIsDataView = bufRecvName === "DataView";
     if (bufIsTypedArr || bufIsDataView) {
-      const byteVecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i32" });
+      const byteVecTypeIdx = getOrRegisterVecType(ctx, "i32_byte", { kind: "i8" });
       const byteArrTypeIdx = getArrTypeIdxFromVec(ctx, byteVecTypeIdx);
       if (byteArrTypeIdx >= 0) {
         const byteLenLocal = allocLocal(fctx, `__tabuf_len_${fctx.locals.length}`, { kind: "i32" });


### PR DESCRIPTION
**PR-2 of 2 — closes #2835.** PR-1 (#2316) split the overloaded `i32_byte` key so the ArrayBuffer/DataView byte buffer is disentangled from Int32/Uint32 element storage (`i32_elem`); #2839 (#2321) added the `i8`/`i16` arm to `buildElemCoerce`. This PR delivers the actual packing.

## What changed
Flip the ArrayBuffer/DataView byte buffer's data array from `array(mut i32)` to a **packed `array(mut i8)`** (1 byte/element) — a **4× GC-footprint cut** for ArrayBuffer / DataView / native byte buffers.

- **Kept the `i32_byte` KEY/struct distinct** from native Uint8Array's `i8_byte` (so every `ref.cast`-based DataView/ArrayBuffer backing-recovery — `recoverDvBacking`, `__dv_window`, `emitArrayBufferSlice`, `emitTypedArrayFromByteBuffer`, `.buffer` synth, `__dv_byte_*`, node:fs write helpers — stays unambiguous). Only the element type changed to `i8`. Every `i32_byte` registration site switched to `{ kind: "i8" }` in lockstep (the `getOrRegisterVecType` cache makes the first override win).
- **Reads → `array.get_u`** (plain `array.get` is invalid Wasm on a packed array; a missed site fails module validation rather than miscompiling): `pushByte`, `buildIntoBranch`, `emitReadI64`, `emitArrayBufferSlice`, `emitDataViewToWriteScratch`, `__vec_get`, `__vec_pop`, `__dv_byte_get`, `ensureWasiWriteArrayBufferHelper`, `emitTypedArrayFromByteBuffer`.
- **Writes unchanged** — `array.set`/`array.new` on a packed i8 array truncate the i32 to the low byte (the `& 0xff` masks become redundant but are kept defensively).
- **`i32_elem` (Int32/Uint32) untouched** — stays full 32-bit (packing it would truncate every element — the MISCOMPILE the PR-1 split prevents).

## Soundness
Bytes are the provably-safe packing case: every value stored is `0..255` and read back zero-extended, so `array.get_u(i8) ∈ [0,255]` is bit-identical to the old i32 slot. DataView accessors sign-extend the *assembled* value themselves (`getInt8`/`getInt16`/…), so the backing read is always unsigned. Packed i8 arrays are a GC-aware-validator-only encoding (like the i16 string `-0x9`) — already shipping for `i8_byte`/`i16_byte`, so wasmtime/wasm-tools/Binaryen accept it.

## Verification
- `tsc --noEmit` clean.
- DataView / ArrayBuffer / TypedArray / Uint8Array suites green and byte-identical: `issue-1654`, `issue-2199`, `issue-2199b`, `issue-2593`, `issue-2639` (incl. windowed DataView byteOffset/byteLength), `issue-2648`, `issue-1670`, `issue-1787`, `issue-2379`.
- **NM scale-test** (`node examples/native-messaging/scale-test.mjs`, `NM_SCALE_SIZES_MIB="1 64 128 256"`): all four hosts (`node_process`, `deno`, `wasi_p1`, `node_fs`) round-trip **byte-exact at every size up to 256 MiB** under real wasmtime 46. A 256 MiB ArrayBuffer now materialises as a 256 MiB GC array instead of ~1 GiB.
- Pre-existing base-commit failures (`arraybuffer-dataview.test.ts` `string_constants` harness-stub gap; one `issue-1655` Uint8Array.**subarray** WASI `illegal cast`) confirmed **identical** with and without this PR (ran both files on a detached origin/main worktree: same 7-failed/7-passed split).

**Broad-impact codegen** → must be validated via full CI / `merge_group` (test262 merge-shard reports + standalone floor), not scoped checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)