### PR TITLE
release: v0.59.5

### DIFF
--- a/docs/releases/0.59.5.md
+++ b/docs/releases/0.59.5.md
@@ -1,0 +1,47 @@
+# v0.59.5
+
+_Released 2026-06-29._
+
+Patch release. Completes the Native-Messaging hardening from the loopdive/js2#389
+thread (all four hosts now work end-to-end on both compile paths), a 4× memory
+cut for byte buffers, and a few compiler fixes. No new features.
+
+Verified end-to-end on the final tree: guest271314's exact flow — both the
+`.js` (bun-bundle → js2wasm → wasmtime) and `.ts`-direct compile paths, all four
+hosts byte-exact at 1/64/128/256 MiB under real wasmtime 46, with
+`nm_js2wasm_node_process` peak RSS flat at ~35 MB.
+
+## Native Messaging (loopdive/js2#389)
+
+- **#2839 / #2831** — the host-externref→wasm-vec materializer now handles packed
+  `i8`/`i16` element kinds and emits a WASI-native reader instead of a JS-host
+  import. This fixes the `__vec_from_extern … expected i32, found externref`
+  validation failure that broke the standalone `process.stdin` compile (the `.js`
+  host path).
+- **#2840** — module-scope `Uint8Array` buffers are excluded from the linear-safe
+  analysis, fixing four `linear Uint8Array helper argument is not backed by linear
+  memory (#1886)` errors when compiling `nm_js2wasm_node_process.ts` **directly**
+  (`.ts`-direct path).
+- **#2834** — `nm_js2wasm_node_process` is now runnable under real `node` too
+  (via `process.stdin.setEncoding("latin1")`), not just compiled to wasm.
+- **#2833** — native-messaging relative imports carry an explicit `.ts` extension,
+  so Deno / `deno bundle` resolve them without `--unstable-sloppy-imports`.
+
+## Performance
+
+- **#2835** — the ArrayBuffer / DataView / `Uint8Array` byte buffer is now backed
+  by a packed `array(mut i8)` (one byte per element) instead of `array(mut i32)`
+  — a **4× GC-footprint reduction** (a 256 MiB ArrayBuffer materializes as ~256 MiB
+  instead of ~1 GiB). DataView/typed-array behavior is byte-identical.
+
+## Other compiler fixes
+
+- **#2836** — keep object elements across dynamic-dispatch `any` args (gate the
+  host-shim vec conversion on `__is_vec`).
+- **#2838** — `wasmClosureBridge` method-`this` arity fallback (L3).
+
+## Chore
+
+- **#2320** — devcontainer binds the host SSH pubkey into `authorized_keys`.
+
+**Full changelog:** https://github.com/loopdive/js2/compare/v0.59.4...v0.59.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loopdive/js2",
-  "version": "0.59.4",
+  "version": "0.59.5",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC",
   "keywords": [
     "webassembly",

--- a/packages/js2wasm/package.json
+++ b/packages/js2wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js2wasm",
-  "version": "0.59.4",
+  "version": "0.59.5",
   "description": "Direct AOT compilation from JavaScript and TypeScript to WebAssembly GC (unscoped proxy for @loopdive/js2)",
   "keywords": [
     "webassembly",


### PR DESCRIPTION
Patch (0 `feat()` since 0.59.4). Completes the loopdive/js2#389 Native-Messaging hardening — **#2839/#2831** (externref→vec materializer i8/i16 + WASI-native reader: fixes the standalone `process.stdin` `__vec_from_extern` failure), **#2840** (`.ts`-direct #1886), **#2834** (node-runnable), **#2833** (`.ts` import extensions) — plus **#2835** (pack byte buffers to `i8`, **4× GC-footprint cut**) and compiler fixes **#2836**/**#2838**. **Verified end-to-end** on the final tree: guest's exact `.js` and `.ts`-direct flows, all four hosts byte-exact at 1/64/128/256 MiB, node_process peak RSS ~35 MB. Notes: `docs/releases/0.59.5.md`. After merge, push tag `v0.59.5` to publish.