### PR TITLE
chore(plan): close #2829; file #2842/#2843 cleanups

### DIFF
--- a/plan/issues/2829-verify-multihost-browser-nm-0593.md
+++ b/plan/issues/2829-verify-multihost-browser-nm-0593.md
@@ -1,13 +1,32 @@
 ---
 id: 2829
 title: Retest all four native-messaging hosts in Chrome on 0.59.3
-status: ready
+status: done
 sprint: current
 priority: high
 area: examples
 task_type: bug
-related: [389, 2814, 2807]
+related: [389, 2814, 2807, 2832, 2839, 2840]
 ---
+
+## Resolution (verified — all four work)
+
+Retested via `examples/native-messaging/scale-test.mjs` under real wasmtime 46
+and end-to-end on the final 0.59.5 tree. **All four hosts work**; the reporter's
+"only node_fs works" was a pre-0.59.2 build:
+
+- `nm_js2wasm_deno`, `nm_js2wasm_wasi_p1`, `nm_js2wasm_node_fs` — round-trip
+  byte-exact at 1/64/128/256 MiB, bounded memory. The `"Error communicating with
+  the native messaging host"` was the pre-#2814 verbatim echo of a single
+  >1 MiB frame (Chrome drops any host→extension message >1 MB); #2814's re-chunk
+  fixed it.
+- `nm_js2wasm_node_process` — the ~98%-memory blowup was the unbounded read side
+  (RSS ~8× frame: ~530 MB @ 64 MiB). Fixed by #2832 (read-side streaming) →
+  flat ~35 MB. The `.js` standalone compile (`__vec_from_extern` externref) was
+  fixed by #2839; the `.ts`-direct compile (`#1886`) by #2840.
+
+All shipped in 0.59.4/0.59.5. Closing as done.
+
 
 # Verify all four native-messaging hosts work in the browser on 0.59.3
 

--- a/plan/issues/2842-stale-issue-1886-test-nm-host-buffers.md
+++ b/plan/issues/2842-stale-issue-1886-test-nm-host-buffers.md
@@ -1,0 +1,41 @@
+---
+id: 2842
+title: "Stale test: issue-1886 \"classifies every buffer in the native-messaging host as linear-safe\""
+status: ready
+sprint: Backlog
+priority: low
+area: tests
+task_type: test
+related: [389, 1886, 2832, 2778]
+---
+
+# Stale `issue-1886.test.ts` native-messaging-host linear-safe assertion
+
+## Problem
+
+`tests/issue-1886.test.ts` has a case — `"classifies every buffer in the
+native-messaging host as linear-safe"` — that runs the single-file linear-Uint8
+`analyze()` over `examples/native-messaging/nm_js2wasm_node_fs.ts` and asserts it
+sees a fixed set of buffer names (`header` / `one` / `tmp` / `buf` / `src`).
+
+That example was refactored (#2778/#2832) to delegate to the shared
+`nm_js2wasm_sync_framing` core, so a single-file `analyze()` of `nm_js2wasm_node_fs.ts`
+no longer sees those locals — the assertion is **stale and fails identically on
+`origin/main`** (confirmed by sdev-2840 with the fix reverted).
+
+It is **not CI-gated** (`quality` runs lint/typecheck/`check:*`, not vitest; the
+`linear-tests` job globs only `tests/linear-*.test.ts` and is non-required), so it
+went unnoticed.
+
+## Fix
+
+Update the test to the post-refactor reality — either point `analyze()` at the
+shared `nm_js2wasm_sync_framing` core (where the buffer locals now live), or
+rewrite the assertion against a current host's actual buffer set. Keep it
+asserting the linear-safe classification it was written to guard, just against
+the right source.
+
+## Acceptance
+
+`npm test -- tests/issue-1886.test.ts` passes; the linear-safe classification of
+the native-messaging host buffers is still meaningfully asserted.

--- a/plan/issues/2843-uint8array-subarray-wasi-illegal-cast.md
+++ b/plan/issues/2843-uint8array-subarray-wasi-illegal-cast.md
@@ -1,0 +1,35 @@
+---
+id: 2843
+title: "Uint8Array.subarray WASI-write illegal cast (issue-1655)"
+status: ready
+sprint: Backlog
+priority: low
+area: codegen
+task_type: bug
+related: [389, 1655, 2835]
+---
+
+# `Uint8Array.subarray` WASI write → `illegal cast`
+
+## Problem
+
+A pre-existing failure surfaced during the #2835 i8-pack work (sdev-2835p2): one
+`tests/issue-1655` case — a `Uint8Array.subarray` followed by a WASI write —
+fails at runtime with an `illegal cast`. It reproduces **identically on a clean
+`origin/main` worktree** (with and without the #2835 change), so it is **not** a
+regression from the byte-buffer packing — it is a standalone, pre-existing bug in
+the `subarray`-view → WASI-write path.
+
+## Investigate / fix
+
+Trace the `subarray` view's backing + the cast emitted on the WASI write path
+(`fd_write` / the linear-Uint8 or byte-buffer write helpers). A `subarray`
+returns a view sharing the parent's backing at an offset; the WASI write likely
+casts the view to a concrete array type that doesn't match the (now packed `i8`,
+post-#2835) byte-buffer rep or the view wrapper. Confirm whether it predates
+#2835 entirely (it does, per the clean-main repro) and fix the cast.
+
+## Acceptance
+
+The `issue-1655` `Uint8Array.subarray` WASI-write case passes; no regression to
+other `subarray`/typed-array WASI paths.


### PR DESCRIPTION
Planning-only. Closes **#2829** (all four native-messaging hosts verified working on 0.59.4/0.59.5 end-to-end — the #389 reporter's failures were a pre-0.59.2 build) and files two pre-existing, **non-CI-gated** cleanups flagged by the senior-devs: **#2842** (stale `issue-1886` NM-host linear-safe test, fails identically on main after the #2778/#2832 refactor) and **#2843** (`Uint8Array.subarray` WASI `illegal cast`, issue-1655, reproduces on clean main — predates #2835). Both filed to Backlog, low priority.