### PR TITLE
fix(#2844): destructure for-of/for-await array rest element bound to object pattern

### DIFF
--- a/plan/issues/2844-forof-forawait-rest-element-nested-pattern-target.md
+++ b/plan/issues/2844-forof-forawait-rest-element-nested-pattern-target.md
@@ -3,7 +3,8 @@ id: 2844
 parent: 2669
 related: [2602, 2826]
 sprint: current
-status: in-progress
+status: done
+completed: 2026-06-29
 assignee: ttraenkler/restobj
 priority: medium
 horizon: m
@@ -98,6 +99,54 @@ no regression, and out of the cluster's scope.
   pattern at all. The cluster's RHS `[[7,8,9]]` is `number[][]` -> the **vec**
   branch, so the tuple branch is not hit. Tracked as a follow-up.
 
+## Implementation
+
+- `src/codegen/destructuring-params.ts`: new exported helper
+  `emitObjectPatternRestFromVec(ctx, fctx, vecLocal, vecTypeIdx, arrTypeIdx,
+  objPattern, isDecl)` — the array-like object-from-rest-vec read (`length` -> vec
+  field 0, integer key `k` -> `A.data[k]` via `emitBoundsCheckedArrayGetUndef`,
+  OOB -> undefined). Extracted from the inline block in `destructureParamArray`,
+  which now calls the helper (behaviourally identical — param/var-decl lanes
+  re-verified).
+- `src/codegen/statements/loops.ts`: `compileForOfDestructuring` vec-array rest
+  branch now splits the rest-target-is-pattern case — array sub-pattern keeps
+  recursing (already worked); object sub-pattern routes through
+  `emitObjectPatternRestFromVec` instead of the generic by-name struct destructure.
+  Fixes both `for`-of and `for await`-of (all loop-head callers funnel through
+  `compileForOfDestructuring`).
+
+Import-neutral: standalone/WASI import sets are byte-identical to main; no new host
+import. tsc + biome + prettier clean.
+
 ## Test Results
 
-(filled in after implementation — see `tests/issue-2844.test.ts`)
+`tests/issue-2844.test.ts` — 11/11 pass. Scoped manual repro (host + WASI):
+
+| case                                              | result |
+| ------------------------------------------------- | ------ |
+| for-of `[...{ 0: v, length: z }]`                 | 703 ✓  |
+| for-await `[...{ 0: v, length: z }]`              | 703 ✓  |
+| for-of full `[...{0:v,1:w,2:x,3:y,length:z}]` (y=undefined) | 107893 ✓ |
+| for-of `[...{ length }]` shorthand                | 3 ✓    |
+| for-of `[a, ...{ 0: b, length: z }]` (mixed)      | 7803 ✓ |
+| for-await full cluster shape                      | 107893 ✓ |
+| control: for-of `[...[a, b]]` (array target)      | 708 ✓  |
+| control: for-of `[...rest]` (identifier)          | 703 ✓  |
+| control: for-await `[...[a, b]]`                  | 708 ✓  |
+| param lane `function([...{0:v,length:z}])`        | 703 ✓  |
+| var-decl lane `var [...{0:v,length:z}] = [...]`   | 703 ✓  |
+
+Regression batch (loadable dstr/for-of/rest tests): `class-dstr-rest-in-rest`,
+`fn-param-dstr-rest-in-rest`, `issue-1128-dstr-tdz`, `issue-2602-forof-assign-rest`,
+`issue-2158-dstr-param-default-nested-pattern`, `issue-1372-ir-destructuring-params`
+— 40/40 pass. (`spread-rest.test.ts` and `*helpers.js`-importing files fail
+identically on pristine main — pre-existing test-infra issues, unrelated.)
+
+Authoritative test262 conformance validated by the `merge_group` full run.
+
+### Follow-up
+
+- The for-of **tuple-struct** branch (`loops.ts` ~1680) still handles rest only for
+  identifier targets (externref slice) and does not recurse into a nested pattern.
+  Not exercised by this cluster (`[[7,8,9]]` is `number[][]` -> vec branch). Track
+  separately if a `[number,number][]` rest-to-pattern case surfaces.

--- a/plan/issues/2844-forof-forawait-rest-element-nested-pattern-target.md
+++ b/plan/issues/2844-forof-forawait-rest-element-nested-pattern-target.md
@@ -1,0 +1,103 @@
+---
+id: 2844
+parent: 2669
+related: [2602, 2826]
+sprint: current
+status: in-progress
+assignee: ttraenkler/restobj
+priority: medium
+horizon: m
+area: codegen
+language_feature: destructuring
+goal: spec-completeness
+---
+
+# for-of / for-await array-pattern REST element bound to an OBJECT pattern is dropped
+
+## Problem
+
+A `for`-`of` / `for await`-`of` loop head whose array binding pattern has a REST
+element bound to a **nested object pattern** silently drops the object-pattern
+bindings:
+
+```ts
+for await (let [...{ 0: v, length: z }] of [[7, 8, 9]]) { /* v should be 7, z = 3 */ }
+//                ^^^^^^^^^^^^^^^^^^^^^ rest collects [7,8,9] into a fresh Array A,
+//                                      then { 0: v, length: z } destructures A:
+//                                      v = A[0] = 7, z = A.length = 3
+```
+
+Observed on current main (`out = v*100 + z`):
+
+| pattern                          | for-of | for-await |
+| -------------------------------- | ------ | --------- |
+| `[...{ 0: v, length: z }]`       | NaN    | NaN       |  <- bug (`v` dropped)
+| `[...[a, b]]`  (array target)    | PASS   | PASS      |
+| `[...rest]`    (identifier)      | PASS   | PASS      |
+
+This is the concrete blocker for the test262 `*-ary-ptrn-rest-obj-{id,prop-id}`
+cluster (for-of, for-await-of, async-gen/async-func variants) — found by impl2826
+to fail HERE, before any iterator-capture concern.
+
+Spec: §13.3.3.6 (8.5.2) IteratorBindingInitialization,
+`BindingRestElement : ... BindingPattern` — the rest creates `Array A`, then runs
+BindingInitialization of the inner BindingPattern with `A`.
+
+## Root cause
+
+The for-of / for-await loop head does NOT route array destructuring through the
+shared `destructureParamArray` helper. It has its OWN array-destructure
+reimplementation in `compileForOfDestructuring` (`src/codegen/statements/loops.ts`).
+
+In the vec-array branch's rest-element handling, when the rest target is itself a
+binding pattern it recurses generically:
+
+```ts
+// loops.ts ~1894 (before fix)
+if (ts.isArrayBindingPattern(element.name) || ts.isObjectBindingPattern(element.name)) {
+  compileForOfDestructuring(ctx, fctx, element.name, restIdx, restVecType, stmt);
+}
+```
+
+- For an **array** sub-pattern this works: the recursion hits the vec-array branch
+  and reads `A.data[i]`.
+- For an **object** sub-pattern it breaks: the recursion hits `compileForOfDestructuring`'s
+  object branch, which treats `restVecType` (the `__vec` struct `{length, data}`)
+  as a plain named struct and resolves fields **by name** via `struct.get`. The vec
+  struct has no field named `0`, so the numeric-key binding `0: v` is skipped and
+  `v` keeps its NaN default. (`length: z` happens to coincide with the vec's real
+  `length` field, so only the numeric keys are dropped.)
+
+The function-parameter / `var`-decl lane (`destructureParamArray`,
+`src/codegen/destructuring-params.ts`) already handles this correctly with
+dedicated inline code that knows the rest vec is **array-like**: `length` -> vec
+field 0, non-negative integer key `k` -> `A.data[k]` (OOB -> undefined). That lane's
+`function([...{0:v,...}])` and `var [...{0:v,...}] = [...]` already pass. The for-of
+lane simply lacks that array-like object-read.
+
+## Fix
+
+Extract the param lane's array-like object-from-vec read into a shared exported
+helper `emitObjectPatternRestFromVec(ctx, fctx, vecLocal, vecTypeIdx, arrTypeIdx,
+objPattern, isDecl)` in `destructuring-params.ts`, and call it from BOTH:
+
+1. `destructureParamArray` (replaces the inline block — byte-identical output).
+2. `compileForOfDestructuring`'s vec-array rest branch, for the object-target case
+   (the array-target case keeps recursing, which already works).
+
+Keyed on spec semantics (§13.3.3.6 array-like reads), not on Wasm kind. Scope
+matches the cluster: shorthand / renamed identifier targets keyed by `length` or a
+non-negative integer (OOB -> undefined). Rest-within-rest, nested sub-patterns, and
+defaults *inside* the rest object stay as the prior param-lane behaviour (skipped) —
+no regression, and out of the cluster's scope.
+
+### Out of scope (pre-existing, not exercised by this cluster)
+
+- The **tuple-struct** for-of branch (`loops.ts` ~1680) handles rest only for
+  identifier targets via externref slice and does not recurse into a nested
+  pattern at all. The cluster's RHS `[[7,8,9]]` is `number[][]` -> the **vec**
+  branch, so the tuple branch is not hit. Tracked as a follow-up.
+
+## Test Results
+
+(filled in after implementation — see `tests/issue-2844.test.ts`)

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -265,6 +265,80 @@ function emitBoundsCheckedArrayGetUndef(
   });
 }
 
+/**
+ * (#2844) Destructure an OBJECT binding pattern from a freshly-built rest vec.
+ *
+ * Per §13.3.3.6 `BindingRestElement : ... BindingPattern`, an array-pattern rest
+ * element collects the remaining iterator values into a fresh `Array A`, then runs
+ * BindingInitialization of the inner BindingPattern with `A`. When that inner
+ * pattern is an OBJECT pattern (`[...{ 0: v, length: z }]`), the bindings are
+ * property reads on the Array object: `length` -> A.length, a non-negative integer
+ * key `k` -> A[k] (OOB -> undefined).
+ *
+ * The generic struct-by-name object destructure does NOT know the rest vec is
+ * array-like (the `__vec` struct has no field named `0`), so it silently drops
+ * numeric-key bindings. This helper supplies the array-like reads. It is SHARED by
+ * the two lanes that build a rest vec and then need an object-from-vec read:
+ *   - the function-parameter / decl rest lane (`destructureParamArray`), and
+ *   - the for-of / for-await loop-head rest lane (`compileForOfDestructuring`).
+ *
+ * `vecLocal` holds the (non-null) rest vec ref; `vecTypeIdx`/`arrTypeIdx` describe
+ * the vec struct and its backing array. `isDecl` flips per-binding TDZ flags for
+ * let/const declarations (a no-op when no flag exists).
+ *
+ * Scope matches the test262 `*-ary-ptrn-rest-obj-{id,prop-id}` cluster: shorthand
+ * / renamed identifier targets keyed by `length` or a non-negative integer.
+ * Rest-within-rest, nested sub-patterns, and defaults inside the rest object are
+ * out of scope (skipped) — consistent across both lanes.
+ */
+export function emitObjectPatternRestFromVec(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  vecLocal: number,
+  vecTypeIdx: number,
+  arrTypeIdx: number,
+  objPattern: ts.ObjectBindingPattern,
+  isDecl: boolean,
+): void {
+  ensureBindingLocals(ctx, fctx, objPattern);
+  for (const nested of objPattern.elements) {
+    if (!ts.isBindingElement(nested)) continue;
+    if (nested.dotDotDotToken) continue;
+    if (!ts.isIdentifier(nested.name)) continue;
+    const propNode = nested.propertyName ?? nested.name;
+    let key: string | undefined;
+    if (ts.isIdentifier(propNode)) key = propNode.text;
+    else if (ts.isStringLiteral(propNode)) key = propNode.text;
+    else if (ts.isNumericLiteral(propNode)) key = propNode.text;
+    if (key === undefined) continue;
+    const localName = nested.name.text;
+    const localIdx = fctx.localMap.get(localName);
+    if (localIdx === undefined) continue;
+    const localType = getLocalType(fctx, localIdx);
+    if (!localType) continue;
+    if (key === "length") {
+      fctx.body.push({ op: "local.get", index: vecLocal });
+      fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 });
+      coerceType(ctx, fctx, { kind: "i32" }, localType);
+      fctx.body.push({ op: "local.set", index: localIdx });
+      if (isDecl) emitLocalTdzInit(fctx, localName);
+      continue;
+    }
+    const numKey = Number(key);
+    if (Number.isInteger(numKey) && numKey >= 0 && String(numKey) === key) {
+      const arrDef = ctx.mod.types[arrTypeIdx];
+      const elemWasmType = arrDef && arrDef.kind === "array" ? arrDef.element : ({ kind: "externref" } as ValType);
+      fctx.body.push({ op: "local.get", index: vecLocal });
+      fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 });
+      fctx.body.push({ op: "i32.const", value: numKey });
+      emitBoundsCheckedArrayGetUndef(ctx, fctx, arrTypeIdx, elemWasmType);
+      coerceType(ctx, fctx, elemWasmType, localType);
+      fctx.body.push({ op: "local.set", index: localIdx });
+      if (isDecl) emitLocalTdzInit(fctx, localName);
+    }
+  }
+}
+
 function boxToExternref(ctx: CodegenContext, elemKey: string, srcElemType?: ValType): Instr[] {
   // (#2669) When the backing array ALREADY stores externref elements, the value
   // produced by `array.get` is already an externref and needs no conversion.
@@ -1886,52 +1960,15 @@ export function destructureParamArray(
         fctx.body.push({ op: "local.set", index: nestedTmpLocal });
         destructureParamArray(ctx, fctx, nestedTmpLocal, element.name, nestedType, opts);
       } else if (ts.isObjectBindingPattern(element.name)) {
-        // Nested rest with object pattern: function([...{length}]) or [...{0:v}]
-        // The rest array is array-like: destructure "length" from vec field 0
-        // and numeric properties via vec's data array. destructureParamObject
-        // on the vec type only knows "length" and "data" — numeric keys would
-        // be skipped. Emit property access inline to cover both shapes.
-        const nestedType: ValType = { kind: "ref", typeIdx: vecTypeIdx };
-        const nestedTmpLocal = allocLocal(fctx, `__rest_nested_${fctx.locals.length}`, nestedType);
+        // Nested rest with object pattern: function([...{length}]) or [...{0:v}].
+        // The rest array is array-like: `length` -> vec field 0, numeric keys ->
+        // vec data array (#2844 shared helper, also used by the for-of lane).
+        const nestedTmpLocal = allocLocal(fctx, `__rest_nested_${fctx.locals.length}`, {
+          kind: "ref",
+          typeIdx: vecTypeIdx,
+        });
         fctx.body.push({ op: "local.set", index: nestedTmpLocal });
-        ensureBindingLocals(ctx, fctx, element.name);
-        for (const nested of element.name.elements) {
-          if (!ts.isBindingElement(nested)) continue;
-          if (nested.dotDotDotToken) continue;
-          if (!ts.isIdentifier(nested.name)) continue;
-          const propNode = nested.propertyName ?? nested.name;
-          let key: string | undefined;
-          if (ts.isIdentifier(propNode)) key = propNode.text;
-          else if (ts.isStringLiteral(propNode)) key = propNode.text;
-          else if (ts.isNumericLiteral(propNode)) key = propNode.text;
-          if (key === undefined) continue;
-          const localName = nested.name.text;
-          const localIdx = fctx.localMap.get(localName);
-          if (localIdx === undefined) continue;
-          const localType = getLocalType(fctx, localIdx);
-          if (!localType) continue;
-          if (key === "length") {
-            fctx.body.push({ op: "local.get", index: nestedTmpLocal });
-            fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 0 });
-            coerceType(ctx, fctx, { kind: "i32" }, localType);
-            fctx.body.push({ op: "local.set", index: localIdx });
-            if (isDecl) emitLocalTdzInit(fctx, localName);
-            continue;
-          }
-          const numKey = Number(key);
-          if (Number.isInteger(numKey) && numKey >= 0 && String(numKey) === key) {
-            const arrDef = ctx.mod.types[arrTypeIdx];
-            const elemWasmType =
-              arrDef && arrDef.kind === "array" ? arrDef.element : ({ kind: "externref" } as ValType);
-            fctx.body.push({ op: "local.get", index: nestedTmpLocal });
-            fctx.body.push({ op: "struct.get", typeIdx: vecTypeIdx, fieldIdx: 1 });
-            fctx.body.push({ op: "i32.const", value: numKey });
-            emitBoundsCheckedArrayGetUndef(ctx, fctx, arrTypeIdx, elemWasmType);
-            coerceType(ctx, fctx, elemWasmType, localType);
-            fctx.body.push({ op: "local.set", index: localIdx });
-            if (isDecl) emitLocalTdzInit(fctx, localName);
-          }
-        }
+        emitObjectPatternRestFromVec(ctx, fctx, nestedTmpLocal, vecTypeIdx, arrTypeIdx, element.name, isDecl);
       } else {
         fctx.body.push({ op: "drop" });
       }

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -11,7 +11,7 @@ import { reportError, reportErrorNoNode } from "../context/errors.js";
 import { allocLocal, getLocalType } from "../context/locals.js";
 import { snapshotSpeculative, rollbackSpeculative } from "../context/speculative.js";
 import type { CodegenContext, FunctionContext, HoistedCharRead } from "../context/types.js";
-import { emitExternrefDestructureGuard } from "../destructuring-params.js";
+import { emitExternrefDestructureGuard, emitObjectPatternRestFromVec } from "../destructuring-params.js";
 import {
   findUnresolvableInArrayPattern,
   findUnresolvableInObjectPattern,
@@ -1889,10 +1889,19 @@ function compileForOfDestructuring(
           }
           fctx.body.push({ op: "local.set", index: restIdx });
 
-          // If the rest target is itself a binding pattern (e.g. [...[...x]]),
-          // recurse into it with the freshly built rest vec as the element.
-          if (ts.isArrayBindingPattern(element.name) || ts.isObjectBindingPattern(element.name)) {
+          // If the rest target is itself a binding pattern, destructure the
+          // freshly built rest vec into it.
+          if (ts.isArrayBindingPattern(element.name)) {
+            // Nested array sub-pattern (e.g. [...[a, b]]): recurse — the
+            // recursion's vec-array branch reads A.data[i].
             compileForOfDestructuring(ctx, fctx, element.name, restIdx, restVecType, stmt);
+          } else if (ts.isObjectBindingPattern(element.name)) {
+            // (#2844) Nested object sub-pattern (e.g. [...{ 0: v, length: z }]):
+            // the rest vec is array-like. The generic object destructure resolves
+            // struct fields by name (no field `0`) and dropped numeric-key
+            // bindings — route through the shared array-like object read instead.
+            // For-of/for-await loop heads are always declarations -> isDecl=true.
+            emitObjectPatternRestFromVec(ctx, fctx, restIdx, structTypeIdx, innerArrTypeIdx, element.name, true);
           }
           continue;
         }

--- a/tests/issue-2844.test.ts
+++ b/tests/issue-2844.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+import { buildImports } from "../src/runtime.ts";
+
+// #2844 — for-of / for-await array-pattern REST element bound to a nested OBJECT
+// pattern (`[...{ 0: v, length: z }]`) dropped the object-pattern bindings: the
+// rest vec was treated as a plain named struct (no field `0`), so numeric-key
+// bindings stayed at their NaN default. The rest target is array-like per
+// §13.3.3.6 — `length` -> A.length, integer key k -> A[k] (OOB -> undefined).
+
+async function run(source: string): Promise<number> {
+  const r = await compile(source, { fileName: "test.ts" });
+  if (!r.success) throw new Error("CE: " + r.errors[0]?.message);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  let ret = (instance.exports as any).test();
+  if (ret && typeof ret.then === "function") ret = await ret;
+  return ret;
+}
+
+describe("#2844 for-of/for-await array rest element bound to a nested pattern", () => {
+  it("for-of: rest -> object pattern with numeric + length keys", async () => {
+    const src = `
+      export function test(): number {
+        let out = 0;
+        for (let [...{ 0: v, length: z }] of [[7, 8, 9]]) { out = v * 100 + z; }
+        return out; // v=7, z=3 -> 703
+      }`;
+    expect(await run(src)).toBe(703);
+  });
+
+  it("for-await: rest -> object pattern with numeric + length keys", async () => {
+    const src = `
+      export async function test(): Promise<number> {
+        let out = 0;
+        for await (let [...{ 0: v, length: z }] of [[7, 8, 9]]) { out = v * 100 + z; }
+        return out; // v=7, z=3 -> 703
+      }`;
+    expect(await run(src)).toBe(703);
+  });
+
+  it("for-of: full cluster shape — OOB key binds undefined, length reads vec length", async () => {
+    // Mirrors test262 for-of/dstr/let-ary-ptrn-rest-obj-prop-id:
+    //   [...{ 0: v, 1: w, 2: x, 3: y, length: z }] over [[7,8,9]]
+    //   v=7, w=8, x=9, y=undefined (OOB), z=3
+    const src = `
+      export function test(): number {
+        let out = 0;
+        for (let [...{ 0: v, 1: w, 2: x, 3: y, length: z }] of [[7, 8, 9]]) {
+          let yUndef = (y !== y) ? 1 : 0; // OOB read is undefined (NaN in f64)
+          out = v * 1000 + w * 100 + x * 10 + z + yUndef * 100000;
+        }
+        return out; // 100000 + 7000 + 800 + 90 + 3
+      }`;
+    expect(await run(src)).toBe(107893);
+  });
+
+  it("for-of: rest -> object pattern shorthand { length } (obj-id cluster)", async () => {
+    // Mirrors test262 for-of/dstr/let-ary-ptrn-rest-obj-id: [...{ length }]
+    const src = `
+      export function test(): number {
+        let out = -1;
+        for (let [...{ length }] of [[1, 2, 3]]) { out = length; }
+        return out; // 3
+      }`;
+    expect(await run(src)).toBe(3);
+  });
+
+  it("for-of: fixed bindings followed by rest -> object pattern", async () => {
+    const src = `
+      export function test(): number {
+        let out = 0;
+        for (let [a, ...{ 0: b, length: z }] of [[7, 8, 9, 10]]) {
+          out = a * 1000 + b * 100 + z; // a=7, rest=[8,9,10] -> b=8, z=3
+        }
+        return out; // 7000 + 800 + 3
+      }`;
+    expect(await run(src)).toBe(7803);
+  });
+
+  it("for-await: full cluster shape (async)", async () => {
+    const src = `
+      export async function test(): Promise<number> {
+        let out = 0;
+        for await (let [...{ 0: v, 1: w, 2: x, 3: y, length: z }] of [[7, 8, 9]]) {
+          let yUndef = (y !== y) ? 1 : 0;
+          out = v * 1000 + w * 100 + x * 10 + z + yUndef * 100000;
+        }
+        return out;
+      }`;
+    expect(await run(src)).toBe(107893);
+  });
+
+  // ---- Controls that must keep working (regression guards) ----
+
+  it("control: for-of rest -> array pattern [...[a, b]] (already worked)", async () => {
+    const src = `
+      export function test(): number {
+        let out = 0;
+        for (let [...[a, b]] of [[7, 8, 9]]) { out = a * 100 + b; }
+        return out; // 708
+      }`;
+    expect(await run(src)).toBe(708);
+  });
+
+  it("control: for-of rest -> identifier [...rest] (already worked)", async () => {
+    const src = `
+      export function test(): number {
+        let out = 0;
+        for (let [...rest] of [[7, 8, 9]]) { out = rest[0] * 100 + rest.length; }
+        return out; // 703
+      }`;
+    expect(await run(src)).toBe(703);
+  });
+
+  it("control: for-await rest -> array pattern [...[a, b]] (already worked)", async () => {
+    const src = `
+      export async function test(): Promise<number> {
+        let out = 0;
+        for await (let [...[a, b]] of [[7, 8, 9]]) { out = a * 100 + b; }
+        return out; // 708
+      }`;
+    expect(await run(src)).toBe(708);
+  });
+
+  // ---- Param / var-decl lanes (shared helper) stay correct ----
+
+  it("param lane: function([...{ 0: v, length: z }]) (shared helper)", async () => {
+    const src = `
+      function f([...{ 0: v, length: z }]: number[]): number { return v * 100 + z; }
+      export function test(): number { return f([7, 8, 9]); }`;
+    expect(await run(src)).toBe(703);
+  });
+
+  it("var-decl lane: var [...{ 0: v, length: z }] = [...] (shared helper)", async () => {
+    const src = `
+      export function test(): number {
+        var [...{ 0: v, length: z }] = [7, 8, 9];
+        return v * 100 + z;
+      }`;
+    expect(await run(src)).toBe(703);
+  });
+});


### PR DESCRIPTION
## Problem

`for`-of / `for await`-of loop heads silently drop the bindings when an array-pattern REST element is bound to a nested **object** pattern:

```ts
for await (let [...{ 0: v, length: z }] of [[7, 8, 9]]) { /* v should be 7, z = 3 */ }
```

`v` came out NaN. This is the concrete blocker for the test262 `*-ary-ptrn-rest-obj-{id,prop-id}` cluster (for-of, for-await-of, async-gen/async-func), found by impl2826.

## Root cause

The for-of / for-await loop head does not route array destructuring through the shared `destructureParamArray` helper — it has its own reimplementation in `compileForOfDestructuring` (`src/codegen/statements/loops.ts`). Its vec-array rest branch recursed **generically** into the rest target's sub-pattern:

- An **array** sub-pattern (`[...[a, b]]`) worked — the recursion's vec-array branch reads `A.data[i]`.
- An **object** sub-pattern (`[...{ 0: v, length: z }]`) hit the generic by-name struct destructure, which resolves `struct.get` fields by name. The `__vec` struct has no field named `0`, so numeric-key bindings were skipped and stayed at their NaN default.

Per spec §13.3.3.6 (`BindingRestElement : ... BindingPattern`), the rest collects the remaining values into a fresh `Array A`, then runs BindingInitialization of the inner pattern with `A` — an array-like object: `length` -> `A.length`, integer key `k` -> `A[k]` (OOB -> undefined). The function-param / `var`-decl lane already did exactly this inline (and passes); the for-of lane just lacked it.

## Fix

Extract the param lane's array-like object-from-vec read into a shared exported helper `emitObjectPatternRestFromVec` (`src/codegen/destructuring-params.ts`) and call it from **both** lanes:

1. `destructureParamArray` — replaces its inline block (behaviourally identical; param/var-decl lanes re-verified).
2. `compileForOfDestructuring` vec-array rest branch — object sub-pattern routes through the helper; array sub-pattern keeps recursing. All for-of/for-await callers funnel through `compileForOfDestructuring`, so this fixes sync and async in one place.

Correctness keyed on spec semantics, not Wasm kind. **Import-neutral**: standalone/WASI import sets are byte-identical to main; WASI repro returns 703.

## Tests

`tests/issue-2844.test.ts` — 11/11 pass: for-of + for-await rest->object (incl. full cluster shape with OOB `y=undefined` and `{ length }` shorthand), mixed `[a, ...{...}]`, plus controls that must stay working (`[...[a,b]]`, `[...rest]`) and the param/var-decl lanes. Regression batch of loadable dstr/for-of/rest suites: 40/40 pass. Authoritative test262 conformance validated by the `merge_group` full run.

Closes #2844.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS