### PR TITLE
fix(#2841): wrap host-array struct elements so arrow/expr params keep name+type

### DIFF
--- a/plan/issues/2841-arrow-param-name-type-marshalling.md
+++ b/plan/issues/2841-arrow-param-name-type-marshalling.md
@@ -140,9 +140,13 @@ is a cached lazy wrapper, no copy).
 
 - [x] `background.js` uncapped differential: ZERO non-quirk divergences.
 - [x] arrow/expr params carry correct `name`+`type`; decl params stay correct.
-- [~] `edge.js` ZERO non-quirk: arrow-param half verified (with #2325 stacked);
-  the remaining `edge.js` non-quirk is the spurious `attributes: []` →
-  carved to **#2849** (distinct codegen bug, also blocked behind #2325).
+- [x] `edge.js` arrow/expr params: ALL cleared. With #2325 now merged to `main`,
+  edge.js parses and the uncapped differential shows **4** non-quirk
+  divergences, ALL the spurious `attributes: []` (every one of the 62 arrow/expr
+  params + all other prior divergences are gone; the 276 boolean mismatches are
+  the accepted bool-as-i32 quirk). The remaining 4 `attributes` are carved to
+  **#2849** (distinct dynamic-property type-inference codegen bug). edge.js will
+  reach 0 non-quirk once #2849 lands.
 - [x] 0 test262 regressions expected (host-marshalling, additive); full
   merge_group + standalone-floor on CI.
 

--- a/plan/issues/2841-arrow-param-name-type-marshalling.md
+++ b/plan/issues/2841-arrow-param-name-type-marshalling.md
@@ -1,0 +1,157 @@
+---
+id: 2841
+title: "arrow / function-expression param Identifier nodes lose name+type on HOST readback (compiled-acorn AST != node-acorn)"
+status: done
+completed: 2026-06-29
+assignee: ttraenkler/agent-senior-2841
+sprint: current
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: max
+created: 2026-06-29
+task_type: bugfix
+area: runtime-marshalling
+language_feature: ast-readback
+goal: acorn-dogfood
+related: [2836, 2837, 2838, 2801, 2186, 2151, 1712]
+depends_on: []
+blocks: [1712]
+umbrella: 1712
+---
+
+> **DONE (agent-senior-2841, 2026-06-29).** Root cause is HOST MARSHALLING, not
+> value-rep and not codegen — the arrow param Identifier node's `name`/`type`
+> ARE present in-wasm (reachable via `__extern_get`). The bug: a wasm vec that
+> crosses a dynamic-dispatch `any` boundary is materialised by the host shim
+> `__make_iterable` into a REAL host JS array of OPAQUE wasm structs (#2836). When
+> that array is then read back as a struct field through the `_wrapForHost` proxy
+> (acorn `node.params`), the proxy returned the JS array RAW, leaving its
+> Identifier elements unwrapped → `param.type`/`param.name` read `undefined`.
+> Declaration / function-expression params take the `parseBindingList` path and
+> stay a genuine wasm vec (routed to `_wrapVecForHost`, which wraps elements), so
+> ONLY arrow params (and any field arriving as a host JS array of structs) were
+> affected. Fix: wrap host-array struct elements on read in the `_wrapForHost`
+> proxy `get` (load-bearing), plus the symmetric `_wasmToPlain` host-array
+> recursion for the marshal:"copy"/JSON consumers. **Verified: the uncapped NM
+> differential `background.js` went from 2 non-quirk divergences
+> (`params[0].type`, `params[0].name`) to ZERO.** A SEPARATE gap surfaced (the
+> spurious `attributes: []` on import/export nodes) — it is NOT marshalling but a
+> distinct dynamic-property type-inference codegen bug (ecmaVersion 2022 is not
+> normalised to 13, so `2022 >= 16` wrongly enables import-attributes). Carved to
+> **#2849** and escalated (separate root cause; also blocked behind #2325 for
+> edge.js).
+
+# #2841 — arrow / fn-expression param Identifier nodes lose `name`+`type` on host readback
+
+The genuine remaining gap (after #2836 broke the `Assigning to rvalue` arrow
+wall) for compiled acorn to parse real Native-Messaging files LITERALLY equal to
+node-acorn. Surfaced by the UNCAPPED NM differential (the default
+`maxDivergences:8` truncated before reaching function bodies, hiding it — #2836's
+"zero non-quirk" claim was a capped-diff artifact).
+
+## Symptom (uncapped differential, ecmaVersion 2022)
+
+- `background.js`: 2 non-quirk divergences, both on the arrow passed to
+  `chrome.runtime.onMessage.addListener((reason) => …)`:
+  `…arguments[0].params[0].type` (`"Identifier"` → `undefined`) and
+  `.params[0].name` (`"reason"` → `undefined`).
+- `edge.js`: 62 such arrow/fn-expr params — but edge.js cannot be parsed on
+  current `main` (it hits the #2838 `return` wall, fixed only by the in-flight
+  PR #2325). Verified separately by stacking #2325.
+
+## Control (proves it is marshalling, not value-rep)
+
+- Function **declaration** params marshal correctly:
+  `parse("function f(reason){g(reason)}").body[0].params[0]` →
+  `{type:"Identifier", name:"reason"}`. ✓
+- Function **expression** params also marshal correctly (same `parseBindingList`
+  path). ✓
+- Only **arrow** params come back `{}` (empty). The data IS in-wasm: hooking the
+  host `__extern_get` import shows `get(arrowParamsContainer, 0)` →
+  `{type:"Identifier", name:"reason"}` for BOTH decl and arrow.
+
+## Root cause (host marshalling)
+
+`compiled.parse(...)` returns a `_wrapForHost` proxy tree. Reading a struct
+field whose value is a wasm vec routes through `_wrapVecForHost` (line ~5519:
+`__is_vec(val)===1`), which wraps each element on index read — so decl/fn-expr
+params (genuine wasm vecs) navigate fine.
+
+Arrow params are different: acorn parses `(reason)` as a paren `exprList`, then
+calls `this.parseArrowExpression(node, exprList, …)` — a **dynamic method
+dispatch**. The vec arg is coerced `(ref $vec) → externref` at the any-boundary,
+which attaches the host shim `__make_iterable`. `__make_iterable` materialises
+the vec into a **real host JS array** of the (opaque, post-#2836) Identifier
+structs, and that JS array becomes `node.params`. On readback the `_wrapForHost`
+proxy `get` reached its fall-through `return val;` for a non-wasm-struct value —
+a host JS array is NOT a wasm struct (`__is_vec` is 0, `Array.isArray` is true),
+so it was returned RAW. Its element `params[0]` was therefore an UNWRAPPED wasm
+struct; plain JS access (`.type`/`.name`) on a raw struct yields `undefined`.
+
+`__sget_type` returns "Identifier" on the raw struct, but `name` lives in the
+node's dynamic-property store (no `__sget_name` of its own shape) — both are only
+reachable through the `_wrapForHost` proxy / `__extern_get`, which the raw
+element bypassed.
+
+## Fix (contained, host-only)
+
+`src/runtime.ts`:
+
+1. **`_wrapForHost` proxy `get` (load-bearing)** — before the final
+   `return val`, when the resolved field value is a real host JS array, return a
+   cached view (`_wrapHostArrayElems`) that `_wrapForHost`-wraps each STRUCT
+   element on index read (mirrors `_wrapVecForHost`). Primitives / plain objects
+   pass through; genuine wasm vecs were already handled above and are not
+   `Array.isArray`. This alone takes `background.js` to 0 non-quirk.
+2. **`_wasmToPlain` host-array recursion (symmetric robustness)** — the
+   marshal:"copy" / `JSON.stringify` flatten path returned host JS arrays as-is
+   (`!_isWasmStruct` early-out), so a copy/JSON consumer would also see opaque
+   elements. Recurse element-wise (with cycle guard) so the deep copy reaches the
+   structs.
+
+Both are host-mode marshalling only; standalone keeps the native WasmGC vec
+readers (no parallel bug, floor cannot regress).
+
+## Why NOT value-rep / NOT escalated for the arrow fix
+
+The architect-escalation trigger ("needs a broad value-rep change") did not fire:
+the in-wasm AST is already correct (data present and reachable). #2836's earlier
+Candidate-A/B value-rep normalisation is unnecessary; the smallest correct fix is
+two host-marshalling sites. Container + element identity are preserved (the view
+is a cached lazy wrapper, no copy).
+
+## Verification
+
+- Uncapped NM differential (`maxDivergences: 100000`): `background.js`
+  **2 → 0** non-quirk divergences; `sanity` 0; the only remaining divergences
+  across the suite are the two accepted quirks (`sourceFile`, boolean-as-i32).
+- `parse("x=>x" | "(x)=>x" | "(a,b)=>a" | "(reason)=>g(reason)")` →
+  `params[*]` carry `{type:"Identifier", name:…}`.
+- `function f(reason)` declaration params stay correct (control).
+- Regression test `tests/issue-2841-arrow-param-name-type-marshalling.test.ts`
+  (4 cases; the host-array element wrapping + scalar no-regression). Guards the
+  `_wasmToPlain` twin directly; the proxy twin is guarded by the NM differential
+  + the #1712 dogfood gate.
+- `#2836` regression suite + dogfood `acorn.test.ts` still green; full typecheck
+  clean.
+
+## Acceptance
+
+- [x] `background.js` uncapped differential: ZERO non-quirk divergences.
+- [x] arrow/expr params carry correct `name`+`type`; decl params stay correct.
+- [~] `edge.js` ZERO non-quirk: arrow-param half verified (with #2325 stacked);
+  the remaining `edge.js` non-quirk is the spurious `attributes: []` →
+  carved to **#2849** (distinct codegen bug, also blocked behind #2325).
+- [x] 0 test262 regressions expected (host-marshalling, additive); full
+  merge_group + standalone-floor on CI.
+
+## Pointers
+
+- `src/runtime.ts`: `_wrapHostArrayElems` (new), `_wrapForHost` proxy `get`
+  fall-through, `_wasmToPlain` array branch; contrast `_wrapVecForHost`
+  (the wasm-vec analog) and the #2836 `__is_vec` gate in `__make_iterable`.
+- acorn arrow path: `parseArrowExpression(node, exprList)` (entry module
+  ~3535 `toAssignableList`); the paren `exprList` is the dynamic-dispatch vec arg.
+- Follow-up: **#2849** (spurious import/export `attributes: []` from failed
+  ecmaVersion normalisation — dynamic-property type-inference codegen bug).

--- a/plan/issues/2849-ecmaversion-normalize-dynamic-prop-type-inference.md
+++ b/plan/issues/2849-ecmaversion-normalize-dynamic-prop-type-inference.md
@@ -1,0 +1,111 @@
+---
+id: 2849
+title: "dynamic-object numeric property reads back 0 when the same property is also compared via === string / == null (acorn ecmaVersion 2022 not normalised → spurious import attributes)"
+status: ready
+sprint: current
+priority: medium
+horizon: l
+feasibility: hard
+reasoning_effort: max
+created: 2026-06-29
+task_type: bugfix
+area: codegen
+language_feature: dynamic-object-property-type-inference
+goal: acorn-dogfood
+related: [2841, 2836, 1712]
+depends_on: []
+blocks: [1712]
+umbrella: 1712
+---
+
+# #2849 — dynamic-object property mis-typed when read in heterogeneous (string-`===` / `==null` AND numeric) contexts
+
+Carved out of **#2841**. Distinct root cause: a **compiler codegen bug** in how a
+dynamic-object property is typed/stored when the SAME property is used both in a
+string/null equality and in a numeric arithmetic/relational context. NOT a
+marshalling issue.
+
+## Observable gap (the edge.js half of #1712)
+
+The uncapped NM differential on a module source shows compiled acorn emitting a
+spurious `attributes: []` on every `ImportDeclaration` / `ExportNamedDeclaration`
+that node-acorn lacks (edge.js had 4; reproducible on a 1-line module). Both run
+the SAME pinned acorn@8.16.0.
+
+```
+import x from "y";   // ecmaVersion: 2022, sourceType: "module"
+// node-acorn : body[0].attributes  -> absent (undefined)
+// compiled    : body[0].attributes -> []        (SPURIOUS)
+```
+
+## Root cause (verified by bisected repro)
+
+acorn sets `node.attributes` ONLY when `this.options.ecmaVersion >= 16`
+(acorn.mjs:1813/1838/1965 — `16` is the YEAR-normalised form of ES2025).
+`getOptions` normalises the caller's year-form value:
+`else if (options.ecmaVersion >= 2015) { options.ecmaVersion -= 2009; }`
+(acorn.mjs:443-444), so `2022 → 13`, and `13 >= 16` is false → no attributes.
+
+Compiled acorn does NOT apply that normalisation: `this.options.ecmaVersion`
+stays `2022`, so `2022 >= 16` is TRUE and import-attributes are wrongly enabled.
+
+Minimal repro (no acorn) — the normalisation step is fine in isolation, but
+breaks when the property is ALSO compared to a string / null:
+
+```ts
+// @ts-nocheck
+var d = { ecmaVersion: null, sourceType: 0 };
+export function run(ev) {
+  var opts = { ecmaVersion: ev, sourceType: 1 };
+  var o = {};
+  for (var k in d) { o[k] = opts[k]; }
+  if (o.ecmaVersion >= 2015) { o.ecmaVersion -= 2009; }   // WORKS: run(2022)=13
+  return o.ecmaVersion;
+}
+```
+
+Adding the acorn-shaped `=== "latest"` / `== null` guards BEFORE the numeric
+branch breaks it — `o.ecmaVersion` then reads back **0** in the numeric context:
+
+```ts
+  if (o.ecmaVersion === "latest") { o.ecmaVersion = 1e8; }       // <- either of
+  else if (o.ecmaVersion == null) { o.ecmaVersion = 11; }        //    these two
+  else if (o.ecmaVersion >= 2015) { o.ecmaVersion -= 2009; }     // run(2022)=0 (BUG)
+```
+
+Both `=== "latest"` (string compare) and `== null` independently trigger it. The
+property `o.ecmaVersion` is used in a STRING/null-equality context AND a numeric
+context; the compiler appears to commit the dynamic-object property slot to a
+representation that makes the numeric read return 0 (a default/empty slot). This
+is a **dynamic-object property type-inference / storage** bug, likely broad
+(value-rep scale), and should get an architect spec before coding.
+
+## Scope / why separate from #2841
+
+- #2841 was a HOST-MARSHALLING fix (arrow param `name`/`type`); shipped & verified
+  (`background.js` 0 non-quirk).
+- This is a CODEGEN bug (dynamic-property polymorphic-type handling). Different
+  layer, different fix.
+- It only surfaces in the differential on **edge.js** (module sourceType), which
+  also cannot parse on `main` until the #2838 return-stack PR **#2325** lands —
+  so verification is doubly gated. Recommend scheduling after #2325 merges.
+
+## Acceptance
+
+- `import x from "y";` parsed by compiled acorn at `ecmaVersion: 2022` has NO
+  `attributes` field (matches node-acorn); `ecmaVersion: 2025/16` still DOES.
+- The minimal repro `run(2022) === 13` with the `=== "latest"` / `== null`
+  guards present.
+- With #2325 stacked, edge.js uncapped NM differential reaches ZERO non-quirk
+  divergences (completing the #1712 edge.js bar together with #2841).
+- 0 test262 regressions; full merge_group + standalone-floor.
+
+## Pointers
+
+- acorn: `getOptions` ecmaVersion normalisation (entry module ~443-444);
+  `node.attributes` gates (~1813 / ~1838 / ~1965).
+- Compiler: dynamic-object property read/write typing for a property used across
+  string-equality and numeric contexts (`$Object` slot typing /
+  `__extern_get`/`__extern_set` numeric coercion). Likely the same family as the
+  any-value polymorphic-read substrate work.
+- Repro scripts (this branch, `.tmp/nm-2841/repro-ecma*.mjs`, gitignored).

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -3543,6 +3543,31 @@ function _installErrorCause(inst: any, options: any, exports: Record<string, Fun
  */
 function _wasmToPlain(val: any, exports: Record<string, Function> | undefined, seen?: Set<any>): any {
   if (val == null || typeof val !== "object") return val;
+  // (#2841) A real host JS array can still hold RAW wasm-struct elements. This
+  // happens when a wasm vec crosses a dynamic-dispatch boundary as an `any`
+  // argument and the host shim `__make_iterable` materialises it into a JS
+  // array of opaque structs (#2836 — e.g. acorn's arrow-function param list:
+  // the paren `exprList` is passed to `parseArrowExpression` indirectly, so
+  // `node.params` ends up a host JS array whose Identifier elements are wasm
+  // structs). `_wasmToPlain` previously returned such an array as-is (the
+  // `!_isWasmStruct` early-out below), leaving the elements opaque so a
+  // marshal:"copy"/JSON.stringify consumer saw `param.type`/`.name` as
+  // `undefined`. Decl/fn-expr params take the `parseBindingList` path and stay a
+  // genuine wasm vec, which the `__vec_get` branch below already converts —
+  // hence only ARROW params lost their fields. Recurse element-wise so the deep
+  // copy reaches the structs. (A wasm vec is NOT a JS array — `Array.isArray`
+  // is false for it — so this never double-handles the `__vec_get` path.)
+  if (Array.isArray(val)) {
+    if (seen) {
+      if (seen.has(val)) throw new TypeError("Converting circular structure to JSON");
+      seen.add(val);
+    }
+    try {
+      return val.map((e) => _wasmToPlain(e, exports, seen));
+    } finally {
+      if (seen) seen.delete(val);
+    }
+  }
   if (!_isWasmStruct(val)) return val;
 
   // (#2671) Cycle detection for the JSON.stringify flatten fast path. When a
@@ -5403,6 +5428,48 @@ function _wrapVecForHost(vec: any, exports: Record<string, Function>): any {
   return proxy;
 }
 
+// (#2841) Present a REAL host JS array (not a wasm vec) that may hold RAW
+// wasm-struct elements as an array whose elements are `_wrapForHost`-wrapped on
+// read. Root cause: when a wasm vec crosses a dynamic-dispatch boundary as an
+// `any` argument, the host shim `__make_iterable` materialises it into a real
+// JS array of OPAQUE wasm structs (#2836). When such an array is then read back
+// as a struct field (acorn arrow-fn `node.params` — the paren `exprList` is
+// passed to `parseArrowExpression` indirectly, so the param list is this host
+// array, not a wasm vec), the `_wrapForHost` proxy returned it RAW, so its
+// Identifier elements stayed opaque and `param.type` / `param.name` read back
+// `undefined`. Decl / fn-expr params take the `parseBindingList` path and stay a
+// genuine wasm vec (routed to `_wrapVecForHost`, which wraps elements), so only
+// ARROW params were affected. This view wraps each struct element lazily on
+// index read (mirroring `_wrapVecForHost`); primitives and already-plain
+// elements pass through. The proxy target is a real `[]`-backed array so
+// `Array.isArray` holds and native Array.prototype methods / iteration work via
+// the index trap. Cached so repeated `node.params` reads keep identity.
+function _wrapHostArrayElems(arr: any[], exports: Record<string, Function> | undefined): any[] {
+  const cached = _hostProxyCache.get(arr);
+  if (cached) return cached;
+  const wrapElem = (el: any): any =>
+    el != null && typeof el === "object" && _isWasmStruct(el) ? _wrapForHost(el, exports) : el;
+  const handler: ProxyHandler<any[]> = {
+    get(target, key) {
+      if (typeof key === "string") {
+        const idx = _asArrayIndex(key);
+        if (idx !== undefined) return wrapElem(target[idx]);
+      }
+      return (target as Record<string | symbol, any>)[key as any];
+    },
+    getOwnPropertyDescriptor(target, key) {
+      const desc = Object.getOwnPropertyDescriptor(target, key);
+      if (desc && typeof key === "string" && _asArrayIndex(key) !== undefined && "value" in desc) {
+        desc.value = wrapElem(desc.value);
+      }
+      return desc;
+    },
+  };
+  const proxy = new Proxy(arr, handler);
+  _hostProxyCache.set(arr, proxy);
+  return proxy;
+}
+
 function _wrapForHost(obj: any, exports: Record<string, Function> | undefined): any {
   if (obj == null || typeof obj !== "object") return obj;
   if (!_isWasmStruct(obj)) return obj;
@@ -5579,6 +5646,15 @@ function _wrapForHost(obj: any, exports: Record<string, Function> | undefined): 
         // Non-closure WasmGC struct (e.g. nested object with valueOf/toString) —
         // wrap with _wrapForHost so its properties are accessible from JS (#1090)
         return _wrapForHost(val, exports);
+      }
+      // (#2841) A field value that is a REAL host JS array may hold raw
+      // wasm-struct elements (acorn arrow-fn `node.params` — a host array from
+      // #2836's `__make_iterable`, NOT a wasm vec). Return a view that wraps
+      // those elements so `param.type` / `param.name` resolve through the proxy.
+      // Genuine wasm vecs were already routed to `_wrapVecForHost` above; this
+      // catches only true JS arrays the resolver returned directly.
+      if (Array.isArray(val) && exports) {
+        return _wrapHostArrayElems(val, exports);
       }
       return val;
     },

--- a/tests/issue-2841-arrow-param-name-type-marshalling.test.ts
+++ b/tests/issue-2841-arrow-param-name-type-marshalling.test.ts
@@ -1,0 +1,91 @@
+// #2841 — arrow / function-expression parameter Identifier nodes lost their
+// `name` and `type` on HOST readback (compiled acorn's parsed AST did not match
+// node-acorn for `(reason) => …` / `function (reason) {}`).
+//
+// Root cause (host marshalling, NOT codegen, NOT value-rep): #2836 fixed the
+// IN-WASM read of an arrow param list by keeping object elements opaque across
+// the dynamic-dispatch `any` boundary — but that boundary's host shim
+// (`__make_iterable`) materialises the wasm vec into a REAL host JS array of
+// opaque wasm structs. When such an array is then read back as a struct field
+// through the `_wrapForHost` proxy (acorn's `node.params`), the proxy returned
+// the JS array RAW, so its Identifier elements stayed unwrapped wasm structs and
+// `param.type` / `param.name` read back `undefined`. Declaration / function-
+// expression params take the `parseBindingList` path and stay a genuine wasm vec
+// (routed to `_wrapVecForHost`, which wraps elements), so ONLY arrow params and
+// any other field that arrives as a host JS array of structs were affected.
+//
+// Fix (#2841): in the `_wrapForHost` proxy `get` (and symmetrically in
+// `_wasmToPlain` for the marshal:"copy" / JSON paths), when the resolved field
+// value is a real host JS array, present a view whose struct elements are
+// `_wrapForHost`-wrapped on access. Genuine wasm vecs are unaffected (they are
+// not `Array.isArray`). Host-only marshalling; standalone is unchanged.
+//
+// Verified end-to-end by the real-world native-messaging differential: compiled
+// acorn vs node-acorn on `background.js` went from 2 non-quirk divergences
+// (`params[0].type`, `params[0].name`) to ZERO.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+
+async function run(src: string): Promise<any> {
+  const result: any = await compile(src, { fileName: "probe.ts" });
+  expect(result.success).toBe(true);
+  const io: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, io);
+  io.__setExports?.(instance.exports);
+  return wrapExports(instance.exports, { signatures: result.exportSignatures });
+}
+
+describe("#2841 — host readback of an array-of-struct field built across a dynamic-dispatch boundary", () => {
+  // The `node.params = params` assignment where `params` crossed an indirect
+  // call (mirrors acorn `parseArrowExpression(node, exprList)`): `params`
+  // reaches the host as a JS array of opaque structs. The host must read each
+  // element's fields.
+  it("host reads .type / .name of array elements stored via a dynamic-dispatch param list", async () => {
+    const exp = await run(`
+      // @ts-nocheck
+      function mkId(name){ var n = {}; n.type = "Identifier"; n.name = name; return n; }
+      function buildNode(params){ var node = {}; node.type = "ArrowFunctionExpression"; node.params = params; return node; }
+      export function probe(){ var f = buildNode; return f([mkId("reason")]); }
+    `);
+    const node = exp.probe();
+    expect(Array.isArray(node.params)).toBe(true);
+    expect(node.params.length).toBe(1);
+    expect(node.params[0].type).toBe("Identifier");
+    expect(node.params[0].name).toBe("reason");
+  });
+
+  it("multiple elements all read back their fields", async () => {
+    const exp = await run(`
+      // @ts-nocheck
+      function mkId(name){ var n = {}; n.type = "Identifier"; n.name = name; return n; }
+      function buildNode(params){ var node = {}; node.params = params; return node; }
+      export function probe(){ var f = buildNode; return f([mkId("a"), mkId("b")]); }
+    `);
+    const node = exp.probe();
+    expect(node.params.map((p: any) => p.name)).toEqual(["a", "b"]);
+    expect(node.params.map((p: any) => p.type)).toEqual(["Identifier", "Identifier"]);
+  });
+
+  it("iteration / spread over the wrapped array also sees element fields", async () => {
+    const exp = await run(`
+      // @ts-nocheck
+      function mkId(name){ var n = {}; n.type = "Identifier"; n.name = name; return n; }
+      function buildNode(params){ var node = {}; node.params = params; return node; }
+      export function probe(){ var f = buildNode; return f([mkId("x")]); }
+    `);
+    const node = exp.probe();
+    const names = [...node.params].map((p: any) => p.name);
+    expect(names).toEqual(["x"]);
+  });
+
+  it("scalar-element arrays still round-trip unchanged (no over-wrapping regression)", async () => {
+    const exp = await run(`
+      // @ts-nocheck
+      function buildNode(xs){ var node = {}; node.xs = xs; return node; }
+      export function probe(){ var f = buildNode; return f([1, 2, 3]); }
+    `);
+    const node = exp.probe();
+    expect([...node.xs]).toEqual([1, 2, 3]);
+  });
+});


### PR DESCRIPTION
## #2841 — arrow / function-expression param Identifier nodes lose name+type on host readback

The genuine remaining gap for compiled acorn to parse real Native-Messaging files LITERALLY equal to node-acorn. Surfaced by the UNCAPPED NM differential (the default `maxDivergences:8` truncated before reaching function bodies, hiding it — #2836's "zero non-quirk" claim was a capped-diff artifact).

### Root cause — HOST MARSHALLING, not value-rep, not codegen
The arrow param Identifier's `name`/`type` ARE present in-wasm (reachable via `__extern_get`). acorn parses `(reason)` as a paren `exprList`, then calls `parseArrowExpression(node, exprList)` — a **dynamic method dispatch**. The vec arg is coerced to `externref` at the any-boundary, where the host shim `__make_iterable` (#2836) materialises it into a **real host JS array** of opaque wasm structs, which becomes `node.params`. On readback the `_wrapForHost` proxy returned that JS array RAW (a JS array is not a wasm struct; `__is_vec` is 0), leaving its Identifier elements unwrapped → plain JS `.type`/`.name` read `undefined`. Declaration / function-expression params take the `parseBindingList` path and stay a genuine wasm vec (routed to `_wrapVecForHost`, which wraps elements) — so only ARROW params were affected.

### Fix (`src/runtime.ts`, host-only marshalling)
1. **`_wrapForHost` proxy `get` (load-bearing)** — wrap real-JS-array struct elements on index read via the new `_wrapHostArrayElems` cached view (mirrors `_wrapVecForHost`). This alone takes background.js to 0 non-quirk.
2. **`_wasmToPlain` host-array recursion** — symmetric robustness for the marshal:`"copy"` / `JSON.stringify` consumers (guarded by the unit test).

Standalone keeps native WasmGC vec readers — no floor impact.

### Verification (uncapped NM differential, `maxDivergences: 100000`)
| file | before | after |
|---|---|---|
| `background.js` | 2 non-quirk (`params[0].type`, `.name`) | **0** |
| `edge.js` (post-#2325) | n/a (return wall) | **4**, ALL `attributes` → #2849; every one of the 62 arrow/expr params cleared |

The only remaining divergences anywhere are the two accepted quirks (`sourceFile`, bool-as-i32). Decl params stay correct (control). `#2836` + dogfood `acorn.test.ts` green; full typecheck clean. Regression test: `tests/issue-2841-arrow-param-name-type-marshalling.test.ts` (4 cases).

### Separate gap carved out → #2849
The spurious `attributes: []` on edge.js import/export nodes is NOT marshalling — it's a distinct dynamic-property type-inference codegen bug (compiled acorn doesn't normalise `ecmaVersion 2022 → 13`, so `2022 >= 16` wrongly enables import-attributes). Distinct root cause, distinct layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)