### PR TITLE
fix(#2845): fire assignment-destructuring defaults on absent element/property

### DIFF
--- a/plan/issues/2845-dstr-assign-expr-default-init-firing.md
+++ b/plan/issues/2845-dstr-assign-expr-default-init-firing.md
@@ -1,0 +1,134 @@
+---
+id: 2845
+title: "Assignment-expression destructuring default initializers don't fire on absent element/property (`[a=d]=src`, `{k:x=d}=src`)"
+status: done
+assignee: ttraenkler/dstr4
+created: 2026-06-29
+updated: 2026-06-29
+completed: 2026-06-29
+priority: high
+feasibility: hard
+reasoning_effort: high
+task_type: bug
+area: codegen
+es_edition: 2015
+language_feature: destructuring
+goal: spec-completeness
+parent: 2669
+related: [2669, 2758, 2808, 2811, 2769]
+sprint: current
+---
+
+# #2845 — assignment-expression destructuring default-init firing
+
+Carved from the #2669 destructuring umbrella (dstr4, 2026-06-29). The largest
+clean single-root-cause cluster in `language/expressions/assignment/dstr/` that
+is NOT iterator-protocol (#1642), generator-over-consumption (#2566), or
+rest-element (restobj's lane).
+
+## Problem
+
+Assignment-EXPRESSION destructuring (`[a = d] = src`, `{ k: x = d } = src` —
+where the LHS is an assignment target, not a `let`/`const` binding) failed to
+fire the default Initializer when the source element/property was **absent**.
+Per ECMA-262 §13.15.5.5 (AssignmentElement / IteratorDestructuringAssignment)
+and §13.15.5.3 (ObjectAssignmentPattern), the default fires **iff** the read
+value is `undefined` — which for an array means out-of-bounds, and for an object
+means a missing-or-`undefined` property. The binding-pattern path (`let [...] =`)
+already does this correctly; the **assignment** path (added piecemeal) did not.
+
+```js
+// all WRONG before the fix:
+var a, b; [a = 1, b = 2] = [];            // a,b => NaN     (want 1, 2)
+var a, x=0; [a = (x += 1)] = [];          // a=NaN, x=0     (want a=1, x=1)
+var x; ({ y: x = 1 } = { y: undefined }); // x => undefined (want 1)
+var x; ({ y: x = 1 } = {});               // x untouched    (want 1)
+```
+
+## Root cause — three sibling defects, one conceptual bug
+
+All in `src/codegen/expressions/assignment.ts`. Each is a place where "fire the
+default iff the value is `undefined`" was mis-implemented:
+
+**A. Array, numeric element (`compileArrayDestructuringAssignment`).** The
+default branch only handled `ref`/`externref` element types; for `f64`/`i32`
+elements it fell into an `else` that **dropped the default entirely** and just
+`local.set` the read value. And the read itself (`emitBoundsCheckedArrayGet`)
+returns a *value sentinel* on OOB (NaN/0 for numerics; `ref.null` =
+JS `null`, not `undefined`, for externref), so OOB never looked like
+`undefined`. Net: numeric defaults vanished, and externref OOB read `null` so the
+undefined-check missed it.
+
+**B. Object `{ k: x = d }` typed-struct property target.** Two bugs: (1) used
+`ref.is_null` instead of `__extern_is_undefined`, so an `undefined`-valued
+externref field (`{ y: undefined }`) did not fire the default (and a `null`
+field wrongly *would* have, had the value differed); (2) a **missing field**
+(`fieldIdx === -1`) was `reportSilentFallback` + `continue`, so the default
+never ran for `{ y: x = 1 } = {…no y…}`. The shorthand path (`{ x = d }`) already
+did both correctly — the property path was simply never brought to parity.
+
+**C. Object no-struct (externref RHS) path.** The `{} = vals` fallback loop
+(`__extern_get(rhs, key)` per property) skipped every non-shorthand prop
+(`if (!isShorthandPropertyAssignment) continue`), so `{ y: x = 1 } = {}` (empty
+object ⇒ externref RHS, property form) dropped the binding.
+
+## Fix
+
+`src/codegen/expressions/assignment.ts` (172 +/72 −, single file):
+
+- **A.** Rewrote the array identifier-target default branch to compute an
+  explicit `absent` flag: for a vec, `i < length` gates an in-bounds read
+  (so a non-null `ref` element never traps on an OOB `ref.as_non_null`); for a
+  tuple it's compile-time. In bounds, externref reads map array holes →
+  `undefined` (`emitHoleToUndefined`) and set `absent` from
+  `__extern_is_undefined`; `ref` uses `ref.is_null`; numerics set `absent = 0`.
+  Default fires iff `absent`, uniformly across numeric/externref/ref elements.
+- **B.** Object property path: hoist the target/default extraction above the
+  field lookup; on `fieldIdx === -1` with an identifier target + default, fire
+  the default (mirror of the shorthand arm). For a present externref field, use
+  `__extern_is_undefined` (not `ref.is_null`); keep `ref.is_null` for plain
+  wasm `ref`/`ref_null` (no JS-undefined sentinel there).
+- **C.** No-struct loop now derives `(keyName, targetName, propDefault)` for
+  both shorthand and `{ k: x = d }` property forms and runs the existing
+  `__extern_get` + `__extern_is_undefined` default logic for both.
+
+### Why it needed care (downstream effects considered)
+
+- **OOB trap avoidance:** a non-null `ref` element vec read past `length` would
+  trap on `ref.as_non_null` inside `emitBoundsCheckedArrayGet`. The fix only
+  emits the element read inside the in-bounds arm, so the OOB path never touches
+  it.
+- **Stack balance / late-import shifts:** the `__extern_is_undefined` ensure +
+  `flushLateImportShifts` is sequenced before the branch-instruction arrays are
+  detached via the saved-body swap, matching the existing shorthand pattern, so
+  funcIdx shifts land in the authoritative body.
+- **null vs undefined:** kept strictly distinct — `{ y: x = 1 } = { y: null }`
+  must leave `x = null` (default does NOT fire); regression-controlled.
+- **Heterogeneous elements (#2769 trap):** correctness is keyed on TS-type /
+  spec semantics (absent ⇒ default), not Wasm kind. Verified with
+  `[v=10, vN=11, vH=12, vU=13, vO=14] = [2, null, , undefined]` on an explicit
+  `any[]` source → `2, null, 12, 13, 14` (present / null-kept / hole→default /
+  undefined→default / OOB→default).
+
+## Out of scope (residual, separate root causes)
+
+- `array-elem-init-assignment.js` (untyped `[2, null, , undefined]`): the
+  *untyped* array infers a numeric-lowered element type, so `null` reads back as
+  `0` and `=== null` fails. This is a value-representation issue (#2769 family),
+  NOT default-firing — fails identically before the fix.
+- `*-simple-no-strict` (`arguments` / sloppy-mode), `*-init-let` (let TDZ
+  ReferenceError), `*-put-obj-literal-prop-ref-init*` (member-expression target
+  with a setter + default) — distinct clusters, deliberately untouched.
+
+## Result
+
+`language/expressions/assignment/dstr/` (368 files): **137 → 128 fail (+9 pass,
+0 regressions)**. Newly passing: `array-elem-init-evaluation`,
+`array-elem-init-order`, `array-elem-init-yield-ident-valid`,
+`obj-prop-elem-init-assignment-{missing,null,undef}`,
+`obj-prop-elem-init-evaluation`, `obj-prop-elem-init-in`,
+`obj-prop-elem-init-yield-ident-valid`.
+
+Guard test: `tests/issue-2845.test.ts` (13/13). Pre-existing `issue-43`
+assignment-dstr-default suite stays green; `tsc` clean; 0 regressions across the
+full assignment/dstr scan.

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -6,6 +6,7 @@ import { ts, forEachChild } from "../../ts-api.js";
 import { isBooleanType, isExternalDeclaredClass, isStringType } from "../../checker/type-mapper.js";
 import type { FieldDef, Instr, ValType } from "../../ir/types.js";
 import { emitBoundsCheckedArrayGet, resolveArrayInfo } from "../array-methods.js";
+import { emitHoleToUndefined } from "../array-holes.js";
 import { tryEmitLinearU8ElementCompound, tryEmitLinearU8ElementSet } from "../linear-uint8-codegen.js";
 import { emitAnyAdd, emitModulo, emitToInt32, emitToUint8Clamp } from "../binary-ops.js";
 import { pushBody } from "../context/bodies.js";
@@ -826,8 +827,36 @@ function compileDestructuringAssignment(
 
       if (getIdx !== undefined && undefIdx !== undefined) {
         for (const prop of target.properties) {
-          if (!ts.isShorthandPropertyAssignment(prop)) continue;
-          const name = prop.name.text;
+          // Determine (keyName to read, targetName to write, default). Handle
+          // both shorthand `{ x = d }` (key === target) and the property form
+          // `{ y: x = d }` with an identifier target (key !== target). The old
+          // path only handled shorthand, so `{ y: x = 1 } = {}` silently dropped
+          // the binding and never fired the default. (#2845)
+          let keyName: string | undefined;
+          let targetName: string | undefined;
+          let propDefault: ts.Expression | undefined;
+          if (ts.isShorthandPropertyAssignment(prop)) {
+            keyName = prop.name.text;
+            targetName = keyName;
+            propDefault = prop.objectAssignmentInitializer;
+          } else if (ts.isPropertyAssignment(prop)) {
+            keyName =
+              ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name) || ts.isNumericLiteral(prop.name)
+                ? prop.name.text
+                : undefined;
+            let te: ts.Expression = prop.initializer;
+            if (
+              ts.isBinaryExpression(te) &&
+              te.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+              ts.isIdentifier(te.left)
+            ) {
+              propDefault = te.right;
+              te = te.left;
+            }
+            if (ts.isIdentifier(te)) targetName = te.text;
+          }
+          if (keyName === undefined || targetName === undefined) continue;
+          const name = targetName;
 
           // Resolve write target: local first, then module global. Allocate
           // a local only if neither exists.
@@ -844,15 +873,15 @@ function compileDestructuringAssignment(
             targetType = { kind: "externref" as const };
           }
 
-          // Read prop value: tmp = __extern_get(rhs, "name")
-          addStringConstantGlobal(ctx, name);
+          // Read prop value: tmp = __extern_get(rhs, "keyName")
+          addStringConstantGlobal(ctx, keyName);
 
           const tmpVal = allocLocal(fctx, `__destruct_val_${fctx.locals.length}`, { kind: "externref" });
           fctx.body.push({ op: "local.get", index: rhsTmp });
           // (#2515 S0 / #1623) sentinel-safe key push — nativeStrings stores `-1`
           // for the string-constant global, so materialize the key inline as
           // externref instead of `global.get -1`.
-          for (const instr of stringConstantExternrefInstrs(ctx, name)) fctx.body.push(instr);
+          for (const instr of stringConstantExternrefInstrs(ctx, keyName)) fctx.body.push(instr);
           fctx.body.push({ op: "call", funcIdx: getIdx });
           fctx.body.push({ op: "local.set", index: tmpVal });
 
@@ -874,7 +903,7 @@ function compileDestructuringAssignment(
             }
           };
 
-          if (prop.objectAssignmentInitializer) {
+          if (propDefault) {
             // Per spec: defaults fire ONLY on undefined. Use
             // __extern_is_undefined (not ref.is_null) so JS null falls
             // through to the assignment branch.
@@ -885,7 +914,7 @@ function compileDestructuringAssignment(
             const trueInstrs: Instr[] = [];
             const savedTrueBody = fctx.body;
             fctx.body = trueInstrs;
-            const initType = compileExpression(ctx, fctx, prop.objectAssignmentInitializer, targetType);
+            const initType = compileExpression(ctx, fctx, propDefault, targetType);
             if (initType && !valTypesMatch(initType, targetType)) {
               coerceType(ctx, fctx, initType, targetType);
             }
@@ -1117,14 +1146,9 @@ function compileDestructuringAssignment(
         propName = resolveComputedKeyExpression(ctx, prop.name.expression);
       }
       if (!propName) continue; // truly unresolvable property name — skip
-      const fieldIdx = fields.findIndex((f) => f.name === propName);
-      if (fieldIdx === -1) {
-        reportSilentFallback(ctx, "lookup-miss-skip", "assignment:destructure-assign-property-field-miss", prop);
-        continue;
-      }
-      const fieldType = fields[fieldIdx]!.type;
 
-      // Determine the target and optional default value
+      // Determine the target and optional default value FIRST — the missing-
+      // field arm below needs the default to fire it on an absent property. (#2845)
       let targetExpr = prop.initializer;
       let defaultExpr: ts.Expression | undefined;
 
@@ -1137,6 +1161,28 @@ function compileDestructuringAssignment(
         defaultExpr = targetExpr.right;
         targetExpr = targetExpr.left;
       }
+
+      const fieldIdx = fields.findIndex((f) => f.name === propName);
+      if (fieldIdx === -1) {
+        // The source struct has no matching field → reading `obj[prop]` yields
+        // `undefined`. Per §13.15.5.5 the default Initializer fires on undefined,
+        // so `{ y: x = d } = {}` (no `y`) must evaluate `d` and assign it to the
+        // target. The old path skipped the binding entirely, leaving the local at
+        // its zero/null. Mirrors the shorthand `fieldIdx === -1` arm above. (#2845)
+        if (defaultExpr && ts.isIdentifier(targetExpr)) {
+          const localName = targetExpr.text;
+          let localIdx = fctx.localMap.get(localName);
+          if (localIdx === undefined) localIdx = allocLocal(fctx, localName, { kind: "externref" });
+          const targetType = getLocalType(fctx, localIdx) ?? { kind: "externref" as const };
+          const initType = compileExpression(ctx, fctx, defaultExpr, targetType);
+          if (initType && !valTypesMatch(initType, targetType)) coerceType(ctx, fctx, initType, targetType);
+          fctx.body.push({ op: "local.set", index: localIdx });
+          continue;
+        }
+        reportSilentFallback(ctx, "lookup-miss-skip", "assignment:destructure-assign-property-field-miss", prop);
+        continue;
+      }
+      const fieldType = fields[fieldIdx]!.type;
 
       if (ts.isIdentifier(targetExpr)) {
         // { prop: ident } or { prop: ident = default }
@@ -1158,7 +1204,28 @@ function compileDestructuringAssignment(
           if (fieldType.kind === "externref" || fieldType.kind === "ref" || fieldType.kind === "ref_null") {
             const tmpField = allocLocal(fctx, `__dflt_${fctx.locals.length}`, fieldType);
             fctx.body.push({ op: "local.tee", index: tmpField });
-            fctx.body.push({ op: "ref.is_null" } as Instr);
+            // Per §13.15.5.5 the default fires ONLY when the read value is
+            // `undefined`, never JS `null`. JS `null` is `ref.null extern`
+            // (ref.is_null === 1), so a bare `ref.is_null` wrongly fired the
+            // default for `{ y: x = d } = { y: null }`. Use __extern_is_undefined
+            // for externref (strict === undefined); keep ref.is_null for plain
+            // wasm ref/ref_null (no JS-undefined sentinel — null slot = missing). (#2845)
+            if (fieldType.kind === "externref") {
+              const undefIdxP = ensureLateImport(
+                ctx,
+                "__extern_is_undefined",
+                [{ kind: "externref" }],
+                [{ kind: "i32" }],
+              );
+              if (undefIdxP !== undefined) {
+                flushLateImportShifts(ctx, fctx);
+                fctx.body.push({ op: "call", funcIdx: undefIdxP } as Instr);
+              } else {
+                fctx.body.push({ op: "ref.is_null" } as Instr);
+              }
+            } else {
+              fctx.body.push({ op: "ref.is_null" } as Instr);
+            }
             fctx.body.push({
               op: "if",
               blockType: { kind: "empty" },
@@ -1736,72 +1803,105 @@ function compileArrayDestructuringAssignment(
         if (localIdx === undefined) {
           localIdx = allocLocal(fctx, localName, elemType);
         }
-        emitElementGet(i);
-        if (elemType.kind === "externref" || elemType.kind === "ref" || elemType.kind === "ref_null") {
-          const tmpElem = allocLocal(fctx, `__dflt_${fctx.locals.length}`, elemType);
-          // Per ECMA-262 §13.15.5.5 (AssignmentElement) the default initializer
-          // fires ONLY when the read value is `undefined`, never for JS `null`.
-          // JS `null` maps to `ref.null extern` in the WebAssembly JS API, so a
-          // bare `ref.is_null` guard wrongly fired the default for `[a=1] = [null]`.
-          // For externref elements, use __extern_is_undefined (strict === undefined);
-          // for plain wasm ref/ref_null elements (no JS-undefined sentinel) keep
-          // ref.is_null — a wasm-null slot there means "missing", which fires.
+        const localType = getLocalType(fctx, localIdx);
+
+        // Per ECMA-262 §13.15.5.5 (AssignmentElement /
+        // IteratorDestructuringAssignmentEvaluation) the default Initializer
+        // fires when the source element is ABSENT — i.e. the array/iterator
+        // yields `undefined`. For a backing vec that means the index is OUT OF
+        // BOUNDS (`i >= length`); for an `any`-typed (externref) element it ALSO
+        // means an in-bounds slot holding the JS `undefined` sentinel (or an
+        // array hole). The previous lowering (a) DROPPED the default entirely
+        // for numeric (f64/i32) elements and (b) missed the OOB case for
+        // externref elements (OOB read produced `ref.null` = JS `null`, which is
+        // NOT `undefined`), so `[a = d] = []` left `a` at a garbage sentinel and
+        // never evaluated `d`. (#2845)
+        //
+        // Strategy: only READ the element when in bounds (so a non-null `ref`
+        // element never traps on an OOB `ref.as_non_null`), recording the value
+        // in `tmpElem` and an `absent` i32 flag; then fire the default iff
+        // absent, else assign the read value.
+        const elemValType: ValType = elemType.kind === "i8" || elemType.kind === "i16" ? { kind: "i32" } : elemType;
+        const tmpElem = allocLocal(fctx, `__dflt_${fctx.locals.length}`, elemValType);
+        const absentLocal = allocLocal(fctx, `__dflt_absent_${fctx.locals.length}`, { kind: "i32" });
+
+        // Build the IN-BOUNDS path: read element → tmpElem, set absent from the
+        // value's undefined-ness (externref/ref) or 0 (numeric).
+        const buildInBoundsInit = (): Instr[] => {
+          const saved = fctx.body;
+          fctx.body = [];
+          emitElementGet(i); // safe: guarded by the in-bounds check below
+          // An in-bounds `any[]` slot may hold the `$Hole` sentinel for a literal
+          // elision (`[1, , 3]`); per Get it reads as `undefined`, so map it.
+          if (elemType.kind === "externref" && ctx.usesArrayHoles) emitHoleToUndefined(ctx, fctx);
+          fctx.body.push({ op: "local.set", index: tmpElem } as Instr);
           if (elemType.kind === "externref") {
-            const undefIdxTuple = ensureLateImport(
-              ctx,
-              "__extern_is_undefined",
-              [{ kind: "externref" }],
-              [{ kind: "i32" }],
-            );
+            const undefIdx = ensureLateImport(ctx, "__extern_is_undefined", [{ kind: "externref" }], [{ kind: "i32" }]);
             flushLateImportShifts(ctx, fctx);
-            fctx.body.push({ op: "local.tee", index: tmpElem });
-            if (undefIdxTuple !== undefined) {
-              fctx.body.push({ op: "call", funcIdx: undefIdxTuple });
-            } else {
-              fctx.body.push({ op: "ref.is_null" } as Instr);
-            }
-          } else {
-            fctx.body.push({ op: "local.tee", index: tmpElem });
+            fctx.body.push({ op: "local.get", index: tmpElem } as Instr);
+            if (undefIdx !== undefined) fctx.body.push({ op: "call", funcIdx: undefIdx } as Instr);
+            else fctx.body.push({ op: "ref.is_null" } as Instr);
+            fctx.body.push({ op: "local.set", index: absentLocal } as Instr);
+          } else if (elemType.kind === "ref" || elemType.kind === "ref_null") {
+            fctx.body.push({ op: "local.get", index: tmpElem } as Instr);
             fctx.body.push({ op: "ref.is_null" } as Instr);
+            fctx.body.push({ op: "local.set", index: absentLocal } as Instr);
+          } else {
+            fctx.body.push({ op: "i32.const", value: 0 } as Instr);
+            fctx.body.push({ op: "local.set", index: absentLocal } as Instr);
           }
-          const localType = getLocalType(fctx, localIdx);
+          const instrs = fctx.body;
+          fctx.body = saved;
+          return instrs;
+        };
+
+        if (isVecStruct) {
+          // inBounds = i < length  (emitted as `length > i`)
+          fctx.body.push({ op: "local.get", index: tmpLocal });
+          fctx.body.push({ op: "struct.get", typeIdx, fieldIdx: 0 }); // length
+          fctx.body.push({ op: "i32.const", value: i });
+          fctx.body.push({ op: "i32.gt_s" } as Instr);
           fctx.body.push({
             op: "if",
             blockType: { kind: "empty" },
-            then: [
-              ...(() => {
-                const saved = fctx.body;
-                fctx.body = [];
-                compileExpression(ctx, fctx, defaultExpr, localType ?? elemType);
-                fctx.body.push({ op: "local.set", index: localIdx! } as Instr);
-                const instrs = fctx.body;
-                fctx.body = saved;
-                return instrs;
-              })(),
-            ],
-            else: [
-              { op: "local.get", index: tmpElem } as Instr,
-              ...(() => {
-                if (localType && !valTypesMatch(elemType, localType)) {
-                  const saved = fctx.body;
-                  fctx.body = [];
-                  coerceType(ctx, fctx, elemType, localType);
-                  const instrs = fctx.body;
-                  fctx.body = saved;
-                  return instrs;
-                }
-                return [];
-              })(),
-              { op: "local.set", index: localIdx! } as Instr,
-            ],
-          });
+            then: buildInBoundsInit(),
+            else: [{ op: "i32.const", value: 1 } as Instr, { op: "local.set", index: absentLocal } as Instr],
+          } as Instr);
+        } else if (i < typeDef.fields.length) {
+          // Tuple field present (compile-time known).
+          fctx.body.push(...buildInBoundsInit());
         } else {
-          const localType = getLocalType(fctx, localIdx);
-          if (localType && !valTypesMatch(elemType, localType)) {
-            coerceType(ctx, fctx, elemType, localType);
-          }
-          fctx.body.push({ op: "local.set", index: localIdx });
+          // Tuple shorter than the pattern → element absent.
+          fctx.body.push({ op: "i32.const", value: 1 } as Instr);
+          fctx.body.push({ op: "local.set", index: absentLocal } as Instr);
         }
+
+        const thenInit: Instr[] = (() => {
+          const saved = fctx.body;
+          fctx.body = [];
+          compileExpression(ctx, fctx, defaultExpr, localType ?? elemType);
+          fctx.body.push({ op: "local.set", index: localIdx! } as Instr);
+          const instrs = fctx.body;
+          fctx.body = saved;
+          return instrs;
+        })();
+        const elseAssign: Instr[] = (() => {
+          const saved = fctx.body;
+          fctx.body = [];
+          fctx.body.push({ op: "local.get", index: tmpElem } as Instr);
+          if (localType && !valTypesMatch(elemValType, localType)) coerceType(ctx, fctx, elemValType, localType);
+          fctx.body.push({ op: "local.set", index: localIdx! } as Instr);
+          const instrs = fctx.body;
+          fctx.body = saved;
+          return instrs;
+        })();
+        fctx.body.push({ op: "local.get", index: absentLocal });
+        fctx.body.push({
+          op: "if",
+          blockType: { kind: "empty" },
+          then: thenInit,
+          else: elseAssign,
+        } as Instr);
       }
     }
     // else: unsupported element target — skip

--- a/tests/issue-2845.test.ts
+++ b/tests/issue-2845.test.ts
@@ -1,0 +1,224 @@
+/**
+ * #2845 — Assignment-EXPRESSION destructuring default initializers
+ * (`[a = d] = src` and `{ k: x = d } = src`) did not fire correctly when the
+ * source element/property was ABSENT (out-of-bounds for arrays, or an
+ * `undefined`/missing property for objects). Carved from the #2669 umbrella.
+ *
+ * Three sibling defects in `compileArrayDestructuringAssignment` /
+ * `compileDestructuringAssignment` (all "default fires iff the value is
+ * `undefined`" mis-implementations of §13.15.5.5 AssignmentElement /
+ * §13.15.5.3 ObjectAssignmentPattern):
+ *
+ *   A. Array, numeric (f64/i32) element: the default branch DROPPED the default
+ *      entirely (only ref/externref elements were handled), and an out-of-bounds
+ *      vec read produced a garbage sentinel (NaN/0) rather than firing the
+ *      default. `[a = 1, b = 2] = []` left a/b at NaN; `[a = (x+=1)] = []`
+ *      returned NaN and never ran the side effect.
+ *   B. Object `{ k: x = d }` (property-renamed target, typed struct): used
+ *      `ref.is_null` instead of `__extern_is_undefined`, so an `undefined`-valued
+ *      property did not fire the default (`{ y: x = 1 } = { y: undefined }` left
+ *      x at undefined→0); and a MISSING field (`{ y: x = 1 } = {}`) was skipped
+ *      entirely so the default never ran.
+ *   C. Object no-struct (externref) path only handled shorthand props, so
+ *      `{ y: x = 1 } = {}` (property form) dropped the binding.
+ *
+ * Fix (assignment.ts): the array default now bounds-checks (`i < length`) and
+ * only reads in-bounds (so a non-null `ref` element never traps on OOB
+ * `ref.as_non_null`), mapping array holes → undefined; OOB / undefined / hole all
+ * fire the default uniformly for numeric AND externref elements. The object
+ * property path now fires the default on a missing field and uses
+ * `__extern_is_undefined` for externref fields; the no-struct path handles
+ * `{ k: x = d }` property form too.
+ *
+ * Recovered +9 in language/expressions/assignment/dstr/ (incl. 2 yield-in-default
+ * bonus tests), 0 regressions. The residual heterogeneous-null cases
+ * (`[v = 11] = [null]` typed numeric → null reads as 0) are a separate
+ * value-representation issue (#2769 family), not default-firing.
+ */
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { wrapTest } from "./test262-runner.js";
+
+async function runWrappedJs(jsSource: string): Promise<unknown> {
+  const wrapped = wrapTest(jsSource, {} as any);
+  const r = await compile(wrapped.source, { fileName: "test.ts", allowJs: true });
+  if (!r.success) {
+    throw new Error(`compile failed: ${r.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const importResult = buildImports(r.imports, undefined, r.stringPool, { globalSandbox: {} });
+  const { instance } = await WebAssembly.instantiate(r.binary, importResult as any);
+  importResult.setExports?.(instance.exports as any);
+  return (instance.exports as any).test();
+}
+
+describe("#2845 — assignment-expression destructuring default initializers", () => {
+  // ---- Defect A: array numeric-element default + out-of-bounds ----
+
+  it("array-elem-init-evaluation — default fires only for the absent (OOB) element", async () => {
+    // vals=[14]: element 0 present (default skipped → flag1 stays false),
+    // element 1 out of bounds (default fires → flag2 = true).
+    const js = `
+      var flag1 = false, flag2 = false;
+      var _;
+      var result;
+      var vals = [14];
+      result = [ _ = flag1 = true, _ = flag2 = true ] = vals;
+      assert.sameValue(flag1, false);
+      assert.sameValue(flag2, true);
+      assert.sameValue(result, vals);
+    `;
+    expect(await runWrappedJs(js)).toBe(1);
+  });
+
+  it("array-elem-init-order — OOB defaults evaluate left-to-right with side effects", async () => {
+    const js = `
+      var x = 0;
+      var a, b;
+      var result;
+      var vals = [];
+      result = [ a = x += 1, b = x *= 2 ] = vals;
+      assert.sameValue(a, 1);
+      assert.sameValue(b, 2);
+      assert.sameValue(x, 2);
+      assert.sameValue(result, vals);
+    `;
+    expect(await runWrappedJs(js)).toBe(1);
+  });
+
+  it("array numeric default fires when source shorter than pattern", async () => {
+    const js = `
+      var a, b, c;
+      var vals = [7];
+      [ a = 1, b = 2, c = 3 ] = vals;
+      assert.sameValue(a, 7);
+      assert.sameValue(b, 2);
+      assert.sameValue(c, 3);
+    `;
+    expect(await runWrappedJs(js)).toBe(1);
+  });
+
+  it("array numeric default skipped when element present (regression control)", async () => {
+    const js = `
+      var a, b;
+      var vals = [5, 6];
+      [ a = 9, b = 9 ] = vals;
+      assert.sameValue(a, 5);
+      assert.sameValue(b, 6);
+    `;
+    expect(await runWrappedJs(js)).toBe(1);
+  });
+
+  // ---- Defect B: object { k: x = d } typed-struct property target ----
+
+  it("obj-prop-elem-init-assignment-undef — default fires for undefined property", async () => {
+    const js = `
+      var x;
+      var result;
+      var vals = { y: undefined };
+      result = { y: x = 1 } = vals;
+      assert.sameValue(x, 1);
+      assert.sameValue(result, vals);
+    `;
+    expect(await runWrappedJs(js)).toBe(1);
+  });
+
+  it("obj-prop-elem-init-assignment-null — default does NOT fire for null (regression control)", async () => {
+    const js = `
+      var x;
+      var result;
+      var vals = { y: null };
+      result = { y: x = 1 } = vals;
+      assert.sameValue(x, null);
+      assert.sameValue(result, vals);
+    `;
+    expect(await runWrappedJs(js)).toBe(1);
+  });
+
+  it("obj-prop-elem-init present property skips default (regression control)", async () => {
+    const js = `
+      var x;
+      var vals = { y: 9 };
+      ({ y: x = 1 } = vals);
+      assert.sameValue(x, 9);
+    `;
+    expect(await runWrappedJs(js)).toBe(1);
+  });
+
+  it("obj-prop-elem-init-evaluation — present skips, absent fires (left-to-right)", async () => {
+    const js = `
+      var flag1 = false;
+      var flag2 = false;
+      var x, y;
+      var result;
+      var vals = { y: 1 };
+      result = { x: x = flag1 = true, y: y = flag2 = true } = vals;
+      assert.sameValue(x, true, 'value of x');
+      assert.sameValue(flag1, true, 'value of flag1');
+      assert.sameValue(y, 1, 'value of y');
+      assert.sameValue(flag2, false, 'value of flag2');
+      assert.sameValue(result, vals);
+    `;
+    expect(await runWrappedJs(js)).toBe(1);
+  });
+
+  // ---- Defect C: object { k: x = d } with an absent/no-struct source ----
+
+  it("obj-prop-elem-init-assignment-missing — default fires for absent field", async () => {
+    const js = `
+      var x;
+      var result;
+      var vals = {};
+      result = { y: x = 1 } = vals;
+      assert.sameValue(x, 1);
+      assert.sameValue(result, vals);
+    `;
+    expect(await runWrappedJs(js)).toBe(1);
+  });
+
+  it("obj-prop-elem-init-in — default expression (the `in` operator) evaluates for absent field", async () => {
+    const js = `
+      var prop;
+      var result;
+      var vals = {};
+      result = { x: prop = 'x' in {} } = vals;
+      assert.sameValue(prop, false);
+      assert.sameValue(result, vals);
+    `;
+    expect(await runWrappedJs(js)).toBe(1);
+  });
+
+  // ---- Regression controls: shorthand + no-default still correct ----
+
+  it("shorthand object default still fires on missing field", async () => {
+    const js = `
+      var x;
+      var vals = {};
+      ({ x = 1 } = vals);
+      assert.sameValue(x, 1);
+    `;
+    expect(await runWrappedJs(js)).toBe(1);
+  });
+
+  it("property-renamed target without default still extracts the value", async () => {
+    const js = `
+      var x;
+      var vals = { y: 7 };
+      ({ y: x } = vals);
+      assert.sameValue(x, 7);
+    `;
+    expect(await runWrappedJs(js)).toBe(1);
+  });
+
+  it("plain array assignment destructuring (no default) unchanged", async () => {
+    const js = `
+      var a, b, c;
+      var vals = [3, 4, 5];
+      [a, b, c] = vals;
+      assert.sameValue(a, 3);
+      assert.sameValue(b, 4);
+      assert.sameValue(c, 5);
+    `;
+    expect(await runWrappedJs(js)).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2845 — assignment-expression destructuring default-init firing

Carved from the #2669 destructuring umbrella. Assignment-EXPRESSION
destructuring (`[a = d] = src`, `{ k: x = d } = src`) failed to fire the
default Initializer when the source element/property was **absent** — per
§13.15.5.5 / §13.15.5.3 the default fires iff the read value is `undefined`
(out-of-bounds for arrays; missing/`undefined` property for objects). The
binding-pattern path already did this; the assignment path (added piecemeal)
did not.

### Root cause — three sibling defects (one conceptual bug), all in `src/codegen/expressions/assignment.ts`

- **A. Array numeric element**: the default branch only handled
  `ref`/`externref`; for `f64`/`i32` it **dropped the default** and an OOB vec
  read returned a garbage sentinel (NaN/0). Rewrote to compute an explicit
  `absent` flag — bounds-check `i < length`, only read in-bounds (so a non-null
  `ref` element never traps on an OOB `ref.as_non_null`), map array holes →
  `undefined`; OOB / undefined / hole now fire the default uniformly across
  numeric and externref elements.
- **B. Object `{ k: x = d }` typed-struct property target**: used `ref.is_null`
  instead of `__extern_is_undefined` (missed `undefined`-valued fields) and
  skipped a **missing** field entirely. Now mirrors the already-correct
  shorthand arm.
- **C. Object no-struct (externref) path**: only handled shorthand props, so
  `{ y: x = 1 } = {}` dropped the binding. Now derives `(key, target, default)`
  for the property form too.

### Result

`language/expressions/assignment/dstr/` (368 files): **137 → 128 fail
(+9 pass, 0 regressions)**. Newly passing incl. `array-elem-init-{evaluation,order}`,
`obj-prop-elem-init-{assignment-missing,assignment-null,assignment-undef,evaluation,in}`,
and 2 yield-in-default bonus tests.

`null` vs `undefined` kept strictly distinct (`{ y: x = 1 } = { y: null }` →
`x = null`, default does NOT fire — regression-controlled). Residual
heterogeneous-`null` cases (untyped `[2, null, , undefined]` → `null` reads as
`0`) are a separate value-representation issue (#2769 family), not default-firing.

### Tests

`tests/issue-2845.test.ts` (13/13), mirroring the exact test262 patterns +
regression controls. Pre-existing `issue-43` assignment-dstr-default suite stays
green; `tsc` clean.

Note: non-required `smoke` may show UNSTABLE (pre-existing NM churn on main),
unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS