### PR TITLE
docs(#2813): runtime matrix for running --target wasi output (wasmtime/bun/deno)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -121,6 +121,10 @@ js2wasm hello.ts --target wasi
 The WASI target auto-enables native (WasmGC i16) string arrays in place of
 `wasm:js-string` builtins, so the binary runs in any WASI host without JS glue.
 
+To **run** the resulting `.wasm` — the exact Wasmtime `-W` proposal flags (and
+the `all-proposals` caveat), plus `bun -b` and Deno — see the runtime matrix in
+[Standalone I/O → Running the output across runtimes](./standalone-io.md#running-the-output-across-runtimes).
+
 ## Permission flags
 
 ### `--allow-fs`

--- a/docs/standalone-io.md
+++ b/docs/standalone-io.md
@@ -104,6 +104,39 @@ $ cat out.txt
 file contents
 ```
 
+## Running the output across runtimes
+
+A `--target wasi` build is a **WasmGC** module. Any runtime that runs it must
+support the proposals the codegen relies on — **GC, typed function references,
+tail calls, and exception handling**. The flags differ per runtime:
+
+| Runtime | Command | Notes |
+| --- | --- | --- |
+| **Wasmtime** (44+) | `wasmtime -W gc=y,function-references=y,tail-call=y,exceptions=y program.wasm` | Use this **targeted** flag set, **not** `-W all-proposals=y` — all-proposals also turns on stack-switching, which Wasmtime 44/45 rejects at module load (`the wasm_stack_switching feature is not supported on this compiler configuration`), so the module exits before running. Add `--dir .` to grant filesystem access (see [Writing arbitrary files](#writing-arbitrary-files)). |
+| **Bun** | `bun -b program.wasm` | Executes the WasmGC module directly; the required proposals are on by default — no extra flags. |
+| **Deno** | `deno run --allow-read --allow-write program.wasm` (or via a small `WebAssembly.instantiate` loader) | Runs the module on the V8 WasmGC engine; grant the `--allow-*` permissions the program needs. |
+
+> **STDIN/STDOUT/STDERR** map to WASI fds 0/1/2 in every runtime above — the I/O
+> patterns on this page are runtime-independent. Only the launch flags differ.
+
+### The `node:fs` host variant (`--link node:fs`)
+
+If you compiled a `node:fs` host module instead of a pure WASI command (i.e. the
+source uses `readSync`/`writeSync` from `node:fs`), there are two ways to run it:
+
+- **`--target wasi` alone** (no `--link`): the `node:fs` calls are lowered
+  **inline** to WASI `fd_read`/`fd_write`, so the module is a self-contained WASI
+  command — run it under any runtime in the table above.
+- **`--link node:fs`**: the module instead *imports* a stable `node:fs`
+  interface and must be linked against a provider before it runs — the
+  [`node-fs.wat`](../examples/native-messaging/node-fs.wat) adapter (maps
+  `node:fs` → WASI `fd_read`/`fd_write`), a native WASI host, or the real
+  `node:fs` module under a JS host. Running a `--link node:fs` module under bare
+  `wasmtime` with no link step fails with `unknown import: node:fs::readSync`
+  (loopdive/js2#389 bug 2) — link it first. See
+  [`examples/native-messaging/README.md`](../examples/native-messaging/README.md)
+  for the full recipe.
+
 ## Summary
 
 | Operation | JS you write | WASI mechanism |

--- a/examples/native-messaging/README.md
+++ b/examples/native-messaging/README.md
@@ -187,6 +187,10 @@ the link step. Use this variant only when you want the same binary to link again
 an external `node:fs` provider; for a drop-in standalone host, prefer `--target
 wasi` alone above.
 
+> **Running the output under a runtime** (the exact Wasmtime `-W` proposal flags
+> plus `bun -b` / Deno) is documented in
+> [Standalone I/O → Running the output across runtimes](../../docs/standalone-io.md#running-the-output-across-runtimes).
+
 > The `-o` flag is an **output directory**, not a filename. js2wasm names the
 > output after the input basename (`nm_js2wasm_node_fs.wasm`).
 

--- a/plan/issues/2813-run-wasi-output-across-runtimes-doc.md
+++ b/plan/issues/2813-run-wasi-output-across-runtimes-doc.md
@@ -1,9 +1,10 @@
 ---
 id: 2813
 title: "Doc: running js2wasm --target wasi output across runtimes (wasmtime / bun -b / deno) + required -W flags"
-status: ready
+status: done
+completed: 2026-06-30
 created: 2026-06-29
-updated: 2026-06-29
+updated: 2026-06-30
 priority: low
 feasibility: easy
 task_type: docs


### PR DESCRIPTION
Closes **#2813** (sprint: current, docs, low priority).

Adds a consolidated **"Running the output across runtimes"** section to
`docs/standalone-io.md` so a reader can pick a runtime and run a `--target wasi`
`.wasm` without trial-and-error on the proposal flags:

- **Wasmtime** — the exact `-W gc=y,function-references=y,tail-call=y,exceptions=y`
  flag set, with the `all-proposals=y` stack-switching caveat (Wasmtime 44/45
  rejects stack-switching at load).
- **Bun** — `bun -b program.wasm` (proposals on by default).
- **Deno** — `deno run --allow-read --allow-write`.
- The **`--link node:fs`** host variant note (inline-WASI vs linked provider,
  with the `unknown import: node:fs::readSync` gotcha from loopdive/js2#389).

Cross-linked from `docs/cli.md` and `examples/native-messaging/README.md`.
Doc-only; no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)