### PR TITLE
fix(#2818): defer block-nested class bodies inside functions (captured block-let reads null)

### DIFF
--- a/plan/issues/2818-block-let-captured-by-class-method-captured-globals-ordering.md
+++ b/plan/issues/2818-block-let-captured-by-class-method-captured-globals-ordering.md
@@ -2,8 +2,10 @@
 id: 2818
 title: "Bug C (class-method half): block-scoped let captured by a class method reads null (captured-globals promotion ordering)"
 parent: 2669
-related: [2820, 2811, 1672]
-status: ready
+related: [2820, 2811, 1672, 2854]
+status: done
+completed: 2026-06-30
+assignee: sendev-ecmaver
 created: 2026-06-29
 priority: high
 feasibility: hard
@@ -109,3 +111,42 @@ async-generator methods, private methods, and the TDZ flag promotion
   the #2820 function-declaration fix, or TDZ throws.
 - `tests/issue-2818.test.ts` with the repros + a class-method cluster slice +
   fn-scope-capture regression controls.
+
+---
+
+## Resolution (sendev-ecmaver, 2026-06-30)
+
+**Root cause (refined from the issue's "early-return skips promotion" framing):**
+the bug was upstream of the `compileNestedClassDeclaration` early-return — in the
+**eager class-body compile pass** `compileClassesFromStatements`
+(`declarations.ts`). It only propagated its `insideFunction` flag when recursing
+into a **function body** (`stmt.body.statements, true`); it **dropped the flag**
+when recursing into `block` / `if` / `for|while|do` / `switch` / `try` /
+`labeled` statements. So a class nested in such a statement *inside a function*
+was treated as `insideFunction === false` and compiled **eagerly** via
+`compileClassBodies` (line ~4412) instead of being added to `deferredClassBodies`.
+Eager compilation happens before the enclosing function runs, so the block-`let`
+is not yet a promotable local → `promoteAccessorCapturesToGlobals` never fires →
+`$C_m` resolves `s` to the `ref.null.extern` fallback (the early-return at
+`nested-declarations.ts:99` is then a *symptom*: `structMap.has` is true and the
+class is **not** in `deferredClassBodies`, so it bails before promotion).
+
+**Fix:** propagate `insideFunction` through every control-flow recursion in
+`compileClassesFromStatements`. A function-nested class is now **deferred** and
+compiled in-scope by `compileNestedClassDeclaration` (after the block-`let`
+stores), where promotion + the `local.get; global.set __captured_<name>` sync
+land correctly. Module-level blocks keep `insideFunction === false` (eager,
+unchanged). ~9 call sites, +`insideFunction` arg each.
+
+**Verify-first (host/gc, `buildImports`):** before → `methodCapture: null`,
+`arrowInMethod: null`, `numeric: 0`, `fnScopeControl: "outer"` (control passes);
+after → all return the captured value. `tests/issue-2818.test.ts` (11 cases:
+string/numeric, arrow-in-method, generator/private/static methods, param-default,
+mutation-observed, if-block, for-block, fn-scope control) green.
+
+**Adjacent pre-existing bug found & filed as #2854 (NOT fixed here):** a
+**doubly-nested** (if-in-for) **numeric** block-`let` *captured* by a closure
+(arrow OR class method) fails Wasm validation with `ref.is_null[0] expected
+reference type, found local.get of type f64` — a TDZ-flag-on-numeric-capture
+bug. It reproduces on `main` with a plain arrow (no class) and is independent of
+this deferral fix (broken identically before & after). Out of scope; see #2854.

--- a/plan/issues/2854-tdz-numeric-capture-doubly-nested-block-ref-is-null.md
+++ b/plan/issues/2854-tdz-numeric-capture-doubly-nested-block-ref-is-null.md
@@ -1,0 +1,94 @@
+---
+id: 2854
+title: "Wasm validation: ref.is_null on f64 when a doubly-nested (if-in-for) numeric block-let is captured by a closure (TDZ flag mis-typed)"
+status: ready
+created: 2026-06-30
+priority: medium
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen
+es_edition: 2015
+language_feature: closures
+goal: spec-completeness
+sprint: Backlog
+horizon: m
+related: [2818, 1672, 1177, 1128]
+architect_spec: candidate
+---
+
+# #2854 — `ref.is_null` on an f64 captured local (doubly-nested numeric block-`let` TDZ)
+
+Discovered while fixing #2818. **Distinct, pre-existing bug** (reproduces on
+`main` independent of #2818's deferral fix, and with a plain arrow — no class).
+
+## Reproduction (host/gc lane)
+
+```ts
+// Arrow capture — no class needed:
+export function test(): number {
+  let acc = 0;
+  for (let i = 0; i < 3; i++) {
+    if (i >= 0) { let bump = 10; const g = () => bump; acc += g(); }
+  }
+  return acc;
+}
+// => CompileError: WebAssembly.instantiate(): Compiling function "test" failed:
+//    ref.is_null[0] expected reference type, found local.get of type f64
+```
+
+The class-method variant fails identically:
+
+```ts
+export function test(): number {
+  let acc = 0;
+  for (let i = 0; i < 3; i++) {
+    if (i >= 0) { let bump = 10; class C { m(): number { return bump; } } acc += new C().m(); }
+  }
+  return acc;
+}
+```
+
+## What is and isn't required to trigger
+
+- **Required:** (a) a **numeric** (`f64`) block-scoped `let`, (b) **doubly
+  nested** in `if`-inside-`for` (single nesting does NOT trigger — see controls),
+  (c) **captured** by a closure (arrow or class method — the capture is what
+  applies the TDZ/box machinery).
+- **Controls that PASS** (validate + correct value):
+  - `if`-only numeric block-let captured → `10`.
+  - `for`-only numeric block-let captured → `30`.
+  - doubly-nested numeric block-let **not** captured (`acc += bump`) → `30`.
+  - string (`externref`) doubly-nested captured → fine (the `ref.is_null` is
+    well-typed for a ref).
+
+## Root cause (hypothesis — needs confirmation)
+
+The capture path promotes/boxes the block-`let` and, for a doubly-nested block,
+assigns it a **TDZ flag** (`__tdz_<name>` / boxed ref-cell, #1177/#1128). The
+TDZ "is-initialised" guard emits `ref.is_null` — correct for an `externref`
+value, but for an **f64** local the guard is emitted against the **f64 value
+local itself** instead of an `i32`/ref TDZ flag, producing
+`ref.is_null[0] expected reference type, found local.get of type f64`.
+
+The fix likely lives in the same TDZ-flag promotion/guard code touched by #1177
+(`boxedTdzFlags`) and `promoteAccessorCapturesToGlobals`
+(`src/codegen/closures.ts:426-448`) — ensure the TDZ guard is emitted against
+the (i32) TDZ flag, never the numeric value, and that the f64 box/cell path
+carries a separate init-flag.
+
+## Acceptance
+
+- Both repros above compile, validate, and return `30`.
+- The capture controls (string, single-nest, uncaptured) keep working.
+- 0 test262 regressions; the closure/TDZ suites (#1128, #1177, #1672, #2623)
+  stay green.
+
+## Pointers
+
+- `src/codegen/closures.ts:426-448` — `__tdz_<name>` global promotion + boxed
+  TDZ flag (`boxedTdzFlags`).
+- TDZ guard emission (`ref.is_null` on the init flag) — locate the site that
+  reads the flag for a numeric capture.
+- Probe (gitignored, on the #2818 branch): `.tmp/probe-2818/noclass.mjs`,
+  `.tmp/probe-2818/iso.mjs`.

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -4437,14 +4437,24 @@ export function compileDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
       } else if (ts.isFunctionDeclaration(stmt) && stmt.body) {
         compileClassesFromStatements(stmt.body.statements, true);
       } else if (ts.isIfStatement(stmt)) {
+        // (#2818) Propagate `insideFunction` through every control-flow
+        // recursion below. A class nested in a block/if/loop/switch/try/labeled
+        // statement *inside a function* must be DEFERRED (compiled in-scope by
+        // compileNestedClassDeclaration after its enclosing block-scoped locals
+        // initialise) so its method bodies can capture those locals via
+        // promoteAccessorCapturesToGlobals. Dropping the flag here compiled such
+        // a class EAGERLY (as if module-level), before the block-`let` exists,
+        // so a method reading the captured local resolved to the ref.null.extern
+        // fallback → read back null. Module-level blocks keep `insideFunction`
+        // false (eager, unchanged).
         if (ts.isBlock(stmt.thenStatement)) {
-          compileClassesFromStatements(stmt.thenStatement.statements);
+          compileClassesFromStatements(stmt.thenStatement.statements, insideFunction);
         }
         if (stmt.elseStatement && ts.isBlock(stmt.elseStatement)) {
-          compileClassesFromStatements(stmt.elseStatement.statements);
+          compileClassesFromStatements(stmt.elseStatement.statements, insideFunction);
         }
       } else if (ts.isBlock(stmt)) {
-        compileClassesFromStatements(stmt.statements);
+        compileClassesFromStatements(stmt.statements, insideFunction);
       } else if (
         ts.isForStatement(stmt) ||
         ts.isForInStatement(stmt) ||
@@ -4454,23 +4464,23 @@ export function compileDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
       ) {
         const body = stmt.statement;
         if (ts.isBlock(body)) {
-          compileClassesFromStatements(body.statements);
+          compileClassesFromStatements(body.statements, insideFunction);
         }
       } else if (ts.isSwitchStatement(stmt)) {
         for (const clause of stmt.caseBlock.clauses) {
-          compileClassesFromStatements(clause.statements);
+          compileClassesFromStatements(clause.statements, insideFunction);
         }
       } else if (ts.isTryStatement(stmt)) {
-        compileClassesFromStatements(stmt.tryBlock.statements);
+        compileClassesFromStatements(stmt.tryBlock.statements, insideFunction);
         if (stmt.catchClause) {
-          compileClassesFromStatements(stmt.catchClause.block.statements);
+          compileClassesFromStatements(stmt.catchClause.block.statements, insideFunction);
         }
         if (stmt.finallyBlock) {
-          compileClassesFromStatements(stmt.finallyBlock.statements);
+          compileClassesFromStatements(stmt.finallyBlock.statements, insideFunction);
         }
       } else if (ts.isLabeledStatement(stmt)) {
         if (ts.isBlock(stmt.statement)) {
-          compileClassesFromStatements(stmt.statement.statements);
+          compileClassesFromStatements(stmt.statement.statements, insideFunction);
         }
       }
       // Compile bodies for anonymous class expressions in new expressions

--- a/tests/issue-2818.test.ts
+++ b/tests/issue-2818.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #2818 — Bug C (class-method half): a block-scoped `let`/`const` captured by a
+// class method read back null. Root cause: the eager class-body compile pass
+// (`compileClassesFromStatements` in declarations.ts) dropped its
+// `insideFunction` flag when recursing into block / if / loop / switch / try /
+// labeled statements, so a class nested in such a statement *inside a function*
+// was compiled EAGERLY (as if module-level) instead of being deferred to
+// `compileNestedClassDeclaration`. Eager compilation runs before the enclosing
+// block-`let` initialises, so `promoteAccessorCapturesToGlobals` never fired and
+// the method body resolved the captured name to the `ref.null.extern` fallback.
+// Fix: propagate `insideFunction` through every control-flow recursion so the
+// class is deferred and compiled in-scope (after the block-`let` runs).
+async function run(source: string, fn = "test", args: unknown[] = []): Promise<unknown> {
+  const result = await compile(source);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>)[fn](...args);
+}
+
+describe("#2818 block-scoped let captured by a class method", () => {
+  it("method reads the captured block-let (string)", async () => {
+    expect(
+      await run(`export function test(): string {
+        { let s = "outer"; class C { m(): string { return s; } } return new C().m(); }
+      }`),
+    ).toBe("outer");
+  });
+
+  it("method reads the captured block-let (numeric)", async () => {
+    expect(
+      await run(`export function test(): number {
+        { let n = 42; class C { m(): number { return n; } } return new C().m(); }
+      }`),
+    ).toBe(42);
+  });
+
+  it("arrow inside the method reaches the captured block-let", async () => {
+    expect(
+      await run(`export function test(): string {
+        { let s = "outer"; class C { m(): string { const g = () => s; return g(); } } return new C().m(); }
+      }`),
+    ).toBe("outer");
+  });
+
+  it("generator method captures the block-let", async () => {
+    expect(
+      await run(`export function test(): number {
+        { let n = 7; class C { *m() { yield n; yield n + 1; } }
+          const it = new C().m(); return (it.next().value as number) + (it.next().value as number); }
+      }`),
+    ).toBe(15);
+  });
+
+  it("private method captures the block-let", async () => {
+    expect(
+      await run(`export function test(): string {
+        { let s = "p"; class C { #m(): string { return s; } call(): string { return this.#m(); } }
+          return new C().call(); }
+      }`),
+    ).toBe("p");
+  });
+
+  it("static method captures the block-let", async () => {
+    expect(
+      await run(`export function test(): string {
+        { let s = "st"; class C { static m(): string { return s; } } return C.m(); }
+      }`),
+    ).toBe("st");
+  });
+
+  it("param-default referencing the block-let", async () => {
+    expect(
+      await run(`export function test(): number {
+        { let base = 100; class C { m(x: number = base): number { return x; } } return new C().m(); }
+      }`),
+    ).toBe(100);
+  });
+
+  it("method observes a later mutation of the captured let (shared global)", async () => {
+    expect(
+      await run(`export function test(): number {
+        { let n = 1; class C { m(): number { return n; } } const c = new C(); n = 5; return c.m(); }
+      }`),
+    ).toBe(5);
+  });
+
+  it("class in an if-block inside a function captures the block-let", async () => {
+    expect(
+      await run(`export function test(): number {
+        if (1 > 0) { let bump = 10; class C { m(): number { return bump; } } return new C().m(); }
+        return -1;
+      }`),
+    ).toBe(10);
+  });
+
+  it("class in a for-block inside a function captures the block-let", async () => {
+    expect(
+      await run(`export function test(): number {
+        let acc = 0;
+        for (let i = 0; i < 3; i++) { let bump = 10; class C { m(): number { return bump; } } acc += new C().m(); }
+        return acc;
+      }`),
+    ).toBe(30);
+  });
+
+  // Regression control: fn-scope (non-block) capture must keep working (#1672).
+  it("fn-scope let captured by a class method (control, unchanged)", async () => {
+    expect(
+      await run(`export function test(): string {
+        let s = "outer"; class C { m(): string { return s; } } return new C().m();
+      }`),
+    ).toBe("outer");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2818 — a block-scoped `let`/`const` captured by a **class method** read back `null` (0 for numeric). The `meth-…` / `gen-meth-…` / `private-meth-…` cluster of the `ary-ptrn-rest-obj-prop-id` test262 family hits this.

```ts
export function test(): string {
  { let s = "outer"; class C { m(): string { return s; } } return new C().m(); }
}
// before: null   after: "outer"
```

## Root cause

The eager class-body compile pass `compileClassesFromStatements` (`src/codegen/declarations.ts`) propagated its `insideFunction` flag only when recursing into a **function body**, but **dropped it** for `block` / `if` / `for|while|do` / `switch` / `try` / `labeled` recursions. So a class nested in such a statement *inside a function* was compiled **eagerly** (as if module-level) via `compileClassBodies` instead of being added to `deferredClassBodies`. Eager compilation runs before the enclosing block-`let` initialises, so `promoteAccessorCapturesToGlobals` never fired and the method body resolved the captured name to the `ref.null.extern` fallback. (The `compileNestedClassDeclaration` early-return the issue cited is a *symptom*: the class isn't deferred, so it bails before promotion.)

## Fix

Propagate `insideFunction` through every control-flow recursion (~9 call sites). A function-nested class is now **deferred** and compiled in-scope by `compileNestedClassDeclaration` after the block-`let` stores, where promotion + the `local.get; global.set __captured_<name>` sync land correctly. Module-level blocks keep `insideFunction === false` (eager, **unchanged**).

## Verify-first (host/gc)

| case | before | after |
|---|---|---|
| `methodCapture` (block-let, method) | `null` | `"outer"` |
| `arrowInMethod` | `null` | `"outer"` |
| `numeric` block-let | `0` | `42` |
| `fnScopeControl` (non-block, regression control) | `"outer"` | `"outer"` |

`tests/issue-2818.test.ts` (11 cases: string/numeric, arrow-in-method, generator / private / static methods, param-default, mutation-observed, if-block, for-block, fn-scope control) — all green. Proper-harness closure/class/TDZ suites (#1672, #2623, #2587, #1128, #1573, class-static-private-this) have **identical** pass/fail on base vs this branch (no regression; the 2 pre-existing fails in #1712/generator-nested fail the same way on `main`).

## Out of scope — filed as #2854

Verify-first surfaced an **orthogonal pre-existing** bug: a **doubly-nested** (if-in-for) **numeric** block-`let` *captured* by a closure (arrow OR class method) fails Wasm validation with `ref.is_null[0] expected reference type, found local.get of type f64` (TDZ-flag-on-numeric-capture). It reproduces on `main` with a plain arrow (no class) and is independent of this fix. Filed as #2854.

🤖 Generated with [Claude Code](https://claude.com/claude-code)