### PR TITLE
docs(#2818,#2826): record merge-group regressions + narrowing direction; mark blocked

### DIFF
--- a/plan/issues/2818-block-let-captured-by-class-method-captured-globals-ordering.md
+++ b/plan/issues/2818-block-let-captured-by-class-method-captured-globals-ordering.md
@@ -3,7 +3,7 @@ id: 2818
 title: "Bug C (class-method half): block-scoped let captured by a class method reads null (captured-globals promotion ordering)"
 parent: 2669
 related: [2820, 2811, 1672]
-status: ready
+status: blocked
 created: 2026-06-29
 priority: high
 feasibility: hard
@@ -109,3 +109,54 @@ async-generator methods, private methods, and the TDZ flag promotion
   the #2820 function-declaration fix, or TDZ throws.
 - `tests/issue-2818.test.ts` with the repros + a class-method cluster slice +
   fn-scope-capture regression controls.
+
+## Merge-group regression (do not re-enqueue as-is)
+
+The first implementation attempt (PR #2335, branch `issue-2818-blocklet-classmethod-capture`,
+commit `498f7b9f7` "defer block-nested class bodies inside functions") was
+**auto-parked** (`hold` + `auto-park-bot:merge-group-failure`) on a LARGE, REAL,
+net-negative test262 regression caught only in `merge_group`. It is NOT
+baseline drift.
+
+**Why PR-level missed it:** at PR level the test262 shards are skipped — the
+`check for test262 regressions` check ran in ~3s on a stub with no shard data.
+Full conformance is only validated in `merge_group`. So "PR-green" never
+validated test262 here.
+
+**Delta (merge_group, baseline f8c1aa5):**
+- **545 regressions / 74 improvements → net −471**, ratio 736%, signature `9c6151da5837060f`.
+- Two buckets EACH over the 50-test gate limit:
+  `language/expressions/class/dstr` (335) + `language/expressions/class/elements` (165),
+  plus class `method-static` / `gen-method-static` / `arguments-object cls-expr-meth-static`.
+- Confirmed PR-caused (not drift/flake): on `class/dstr/async-gen-meth-obj-ptrn-list-err.js`
+  the WAT shrinks 54869→51844 bytes (≈3 KB of class codegen DROPPED), and a
+  runtime probe via the exact CI path (`runTest262File`) flips it from
+  **pass on main** to **fail on branch**.
+- Cross-checked against #2333/#2826: DIFFERENT signature, ZERO shared regressed
+  tests → not a shared drift cluster.
+
+**Root cause of the regression:** the fix propagates `insideFunction=true`
+through the block/if/loop/switch/try/labeled recursion in
+`compileClassesFromStatements` (`src/codegen/declarations.ts`), which adds those
+classes to `ctx.deferredClassBodies`. The deferred-compilation path
+(`compileNestedClassDeclaration` in `src/codegen/statements/nested-declarations.ts`,
+reached from `compileStatement`) does NOT fully cover all the now-deferred
+shapes — in particular class **expressions** assigned in variable statements
+(`const C = class {…}`) and block-nested classes — so their method/element
+bodies are never compiled and the codegen is silently dropped. The pre-#2818
+eager path compiled them correctly (at the cost of the one narrow capture bug
+this issue targets).
+
+**Narrowing direction for the rework — two viable options:**
+1. **Defer only when there is an actual capture:** restrict the
+   `insideFunction` deferral to classes that genuinely capture a block-scoped
+   `let` declared in the enclosing block (the exact #2818 case), and keep all
+   other block-nested / class-expression classes on the eager path.
+2. **Fix the deferred path to be complete:** make the deferred-class compilation
+   cover class **expressions** in variable statements and block-nested class
+   declarations, so deferral never drops codegen.
+
+Option 1 is the lower-risk, more surgical fix. Either way, **validate against a
+full `merge_group` / local-CI test262 run BEFORE re-enqueue** — a scoped check
+cannot see this 545-test cluster. PR #2335 branch + this diagnosis must survive;
+re-open this issue for the narrowed attempt.

--- a/plan/issues/2826-block-let-immutably-captured-by-async-gen-cps-leading-param-slot.md
+++ b/plan/issues/2826-block-let-immutably-captured-by-async-gen-cps-leading-param-slot.md
@@ -3,7 +3,7 @@ id: 2826
 title: "Bug C (CPS-capture half): block-scoped let immutably captured by a hoisted async/generator declaration reads the stale pre-hoisted slot"
 parent: 2818
 related: [2820, 2818, 2825, 2811, 2669]
-status: ready
+status: blocked
 created: 2026-06-29
 priority: high
 feasibility: hard
@@ -260,3 +260,40 @@ comment for the precise regression signature.)
 - **Zero** regressions in the 43-test `for-await-of/async-{func,gen}-decl-dstr-*`
   mutable-capture class on full merge_group.
 - TDZ throws for pre-init reads through a CPS capture preserved.
+
+## Merge-group regression (do not re-enqueue as-is)
+
+The first implementation attempt (PR #2333, branch `issue-2826-bugc-cps-capture-repoint`,
+commit `7eba3f486` "re-point immutable CPS block-let captures to fresh slot (Bug C)")
+was **auto-parked** (`hold` + `auto-park-bot:merge-group-failure`) on a REAL,
+net-negative test262 regression caught only in `merge_group`. It is NOT
+baseline drift.
+
+**Why PR-level missed it:** at PR level the test262 shards are skipped — the
+`check for test262 regressions` check ran in ~3s on a stub with no shard data.
+Full conformance is only validated in `merge_group`. So "PR-green" never
+validated test262 here.
+
+**Delta (merge_group, baseline f8c1aa5):**
+- 30 regressions / 22 improvements → **net −8**, ratio 136%, signature `dd4fa22aa1d2c2a1`.
+- ALL 30 regressed tests are `for-await-of` dstr
+  (`async-func-decl-dstr-*` / `async-gen-decl-dstr-*` array/obj rest+elem,
+  e.g. `async-func-decl-dstr-array-elem-iter-nrml-close.js`).
+- The 22 improvements are also for-await/await dstr — so the fix is a
+  **same-area tradeoff that breaks more than it fixes**.
+- Confirmed PR-caused (not drift/flake): WAT differs branch vs `origin/main`,
+  and a runtime probe via the exact CI path (`runTest262File`) flips
+  `async-func-decl-dstr-array-elem-iter-nrml-close.js` from **pass on main**
+  to **fail on branch** ("assert.sameValue(nextCount, 1)").
+- Cross-checked against #2335/#2818: DIFFERENT signature, ZERO shared regressed
+  tests, no `S15.3_A3_T1`/TLA markers → not a shared drift cluster.
+
+**Narrowing direction for the rework:** the slot re-point is over-applied. It
+must re-point ONLY the CPS capture that genuinely needs a fresh slot (the exact
+immutable-`let`-captured-by-hoisted-async/gen case this issue targets), and
+leave the mutable `for-await-of/async-{func,gen}-decl-dstr-*` capture path on
+its existing slot — that path is what regressed. Gate the re-point on the same
+predicate #2820 used to *exclude* CPS capturers, inverted to its single
+intended case. **Validate against a full `merge_group` / local-CI test262 run
+BEFORE re-enqueue** — a scoped check cannot see this cluster. PR #2333 branch
++ this diagnosis must survive; re-open this issue for the narrowed attempt.


### PR DESCRIPTION
Records the diagnosis of the two auto-parked PRs so they aren't blindly re-attempted, and marks both issues `status: blocked` (removing them from the current TaskList).

## Context
PRs #2335 (#2818) and #2333 (#2826) were auto-parked (`hold` + `auto-park-bot:merge-group-failure`) on REAL, net-negative test262 regressions caught only in `merge_group`. At PR level the test262 shards are skipped (the regression check runs in ~3s on a stub), so "PR-green" never validated conformance — exactly the auto-park (#2547) scenario.

## Findings (both confirmed PR-caused, not drift)
- **#2818 / #2335**: 545 regressions / net −471, signature `9c6151da5837060f`. Buckets `class/dstr` (335) + `class/elements` (165), both over the 50 limit. `insideFunction` deferral over-broadens; the deferred path drops class-expression / block-nested class codegen (~3KB; WAT 54869→51844 on `async-gen-meth-obj-ptrn-list-err.js`; runtime flips pass→fail).
- **#2826 / #2333**: 30 regressions / net −8, signature `dd4fa22aa1d2c2a1`. All for-await-of dstr; the CPS slot re-point over-applies to the mutable for-await capture path (runtime flips pass→fail on `async-func-decl-dstr-array-elem-iter-nrml-close.js`).
- **Drift rule-out**: distinct signatures, ZERO shared regressed tests, no `S15.3_A3_T1`/TLA markers.

## Action
- Both issue files now carry a `## Merge-group regression (do not re-enqueue as-is)` section with the delta + the narrowing direction for a re-worked attempt.
- `status: blocked` on both; the parked PR branches and diagnosis survive on the issues.

Holds on #2333/#2335 are left in place (correct). Per tech-lead decision, the reworks are lower priority than the standalone-gap sprint focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)