### PR TITLE
docs(#2860): standalone-vs-js-host test262 gap triage — 8 clusters + umbrella

### DIFF
--- a/plan/issues/2860-standalone-vs-js-host-test262-gap-umbrella.md
+++ b/plan/issues/2860-standalone-vs-js-host-test262-gap-umbrella.md
@@ -1,0 +1,86 @@
+---
+id: 2860
+title: "Umbrella: close the standalone-vs-js-host test262 gap (9,177 tests)"
+status: ready
+created: 2026-06-30
+updated: 2026-06-30
+priority: high
+feasibility: hard
+task_type: epic
+area: codegen
+goal: standalone
+sprint: current
+horizon: xl
+related: [2861, 2862, 2863, 2864, 2865, 2866, 2867, 2868]
+---
+
+# Umbrella: close the standalone-vs-js-host test262 gap
+
+## The gap
+
+js-host passes **33,032 / 43,135** official tests; `--target standalone`
+passes **24,656**. The **standalone-only failure set** (tests that PASS in
+js-host but FAIL or compile-error in standalone) is **9,177 tests**.
+
+Measured 2026-06-30 from the two lane baselines in `loopdive/js2wasm-baselines`
+(`test262-current.jsonl` vs `test262-standalone-current.jsonl`, official-scope,
+matched by file+strict). Method: `host.status==pass AND standalone.status!=pass`.
+The standalone baseline tags each row with `host_import_leak_class` and the
+leaked `imports` set, which drives the clustering below.
+
+By standalone status: **5,989 fail, 3,187 compile_error, 1 timeout.**
+
+## Clusters (by root cause → est. tests → issue)
+
+Counts are **overlapping** for the cross-cutting substrate signatures (a test
+can leak a host import AND fail at ToPrimitive); the "pure" column is the count
+where that cluster is the sole blocker (no host-import leak), i.e. the count a
+single fix flips directly.
+
+| # | Cluster | total | pure | tractability | issue |
+| - | ------- | ----- | ---- | ------------ | ----- |
+| 1 | built-in static/proto value read refused (CE) | 882 | 882 | mechanical (glue pattern) | **2861** |
+| 2 | ToPrimitive over built-in exotics + inherited valueOf/toString | 2,039 | 728 | medium (extend `__to_primitive`) | **2862** |
+| 3 | dynamic-shape object/property codegen (`__get_builtin`, `__extern_toLocaleString`) CE | 365 | 365 | medium codegen | **2863** |
+| 4 | sync generators — no standalone carrier (`__gen_*`/`__create_generator`) | 697 | — | hard (new carrier) | **2864** |
+| 5 | async generators — no standalone carrier (`__create_async_generator`) | 986 | — | hard (dep #2864) | **2865** |
+| 6 | Symbol — standalone carrier (`__box_symbol`) | 418 | — | medium-hard | **2866** |
+| 7 | Promise / async microtask — standalone carrier (`Promise_*`, `__make_callback`) | 375 | — | hard | **2867** |
+| 8 | invalid Wasm binary emitted in standalone (correctness) | 523 | 118 | triage-then-fix | **2868** |
+
+### Not-yet-issued follow-ons (tracked here)
+
+- **$Object dynamic-object-property reader** (`__extern_get`/`__extern_rest_object`
+  leak) — ~669 tests. The known substrate root
+  (`project_standalone_any_string_value_read_substrate`). Heavily overlaps
+  clusters 2/3; revisit after #2862/#2863 land to measure the true residual.
+- **spread / `Array.from(iter, n)`** (`__array_from_iter_n`) — ~321 tests.
+  Depends on the iterator-protocol carrier (#2864).
+- **Namespace static reads** (`Math.PI`, `JSON.stringify`, `Reflect.get`,
+  `Atomics.add`) — ~120 tests. Split out of #2861 (different mechanism: not
+  `.prototype` proto-glue).
+- **illegal cast** — 1,177 total but only ~102 pure; the rest are inside the
+  generator/iterator machinery and clear when #2864/#2865 land. The ~102 pure
+  ref.test-before-cast misses fold into #2863/#2868 triage.
+- **null deref in `__str_flatten`/RegExp** — ~185, mostly `String.prototype.split`
+  with a RegExp arg + RegExp character-class escapes; standalone-native string/regex
+  bug. File separately if it doesn't clear with #2863.
+
+## Sequencing
+
+1. **#2861** (mechanical, ~882, start now) — dev-standalone.
+2. **#2862** ToPrimitive (architect_spec) + **#2863** dynamic-shape — these two
+   substrate fixes likely also drop a chunk of the "leak" buckets' proximate
+   failures. Re-measure the gap after they land.
+3. **#2868** invalid-wasm (correctness — broken binaries are worst-class).
+4. Carriers **#2866** (Symbol), **#2864→#2865** (generators, epic), **#2867**
+   (Promise) — biggest but architecture-scale; #2864/#2865 are the largest
+   single lever (1,683 combined) and warrant an architect design pass.
+
+## Definition of done (umbrella)
+
+Standalone official_pass climbs from 24,656 toward the 33,032 host figure.
+Each child issue's test plan = its cluster's standalone-CE/fail tests flip to
+pass under full `merge_group` + the standalone high-water floor
+(`check-standalone-highwater.mjs`), with zero host-mode regression (all changes
+`ctx.standalone`-gated).

--- a/plan/issues/2861-standalone-builtin-static-value-read-native-proto-glue.md
+++ b/plan/issues/2861-standalone-builtin-static-value-read-native-proto-glue.md
@@ -1,0 +1,152 @@
+---
+id: 2861
+title: "Standalone: built-in static/prototype property value read not supported — extend native-proto glue (ArrayBuffer, DataView, Promise, Iterator, Error subclasses, …)"
+status: ready
+created: 2026-06-30
+updated: 2026-06-30
+priority: high
+feasibility: medium
+task_type: feature
+area: codegen
+goal: standalone
+sprint: current
+horizon: l
+related: [2860, 1907, 1888, 2175, 2651, 2193]
+umbrella: 2860
+---
+
+# Standalone: built-in static/prototype property VALUE read refused — extend native-proto glue
+
+## Problem
+
+In `--target standalone`, reading a built-in's static property or a
+`<Builtin>.prototype.<member>` as a **first-class value** (not calling it)
+refuses with:
+
+```
+Codegen error: <Builtin>.<prop> built-in static property value read is not
+supported in --target standalone (#1907 / #1888 S6-b). Add a native built-in
+method closure for this pair.
+```
+
+This is a **pure compile-error** cluster (the module never builds), so every
+affected test is host-pass / standalone-CE. It is the single largest
+compile-error cluster in the standalone gap.
+
+### Impact (measured 2026-06-30, host vs standalone baseline jsonl)
+
+**~882 standalone-only failures** carry this signature. Breakdown by builtin
+(top of the residual — these are the ones with NO native-proto glue yet):
+
+| builtin            | tests | builtin             | tests |
+| ------------------ | ----- | ------------------- | ----- |
+| ArrayBuffer        | 166   | Atomics             | 33    |
+| DataView           | 89    | SharedArrayBuffer   | 29    |
+| Promise            | 78    | DisposableStack     | 27    |
+| Iterator           | 65    | AsyncDisposableStack| 25    |
+| Math               | 59    | Symbol              | 16    |
+| TypeError          | 42    | JSON                | 16    |
+| Object (residual)  | 41    | Reflect             | 13    |
+| Array (residual)   | 26    | WeakRef             | 11    |
+|                    |       | FinalizationRegistry| 10    |
+|                    |       | Error subclasses (Range/Reference/…) | ~30 |
+
+(The `<View>.prototype` TypedArray residual already has glue via #2651; these
+are the still-unwired builtins.)
+
+## Root cause
+
+`tryEnsureNativeProtoBrand` (`src/codegen/property-access.ts:696`) maps a
+builtin name to a registered `$NativeProto` brand + glue. It already wires
+Array, Object, String, Number, Boolean, Date, Error, Map, Set, Function,
+Symbol, BigInt, WeakMap, WeakSet, RegExp, and the TypedArray views. Builtins
+**not** in that switch fall through to
+`reportUnsupportedStandaloneBuiltinValueRead` (`property-access.ts:624`), which
+emits the refusal.
+
+The glue is cheap: a `$NativeProto` value object is materialized from the
+glue's `memberCsv` + `name` only — `emitLazyNativeProtoGet` never calls
+`emitMemberBody` for a plain value read. Reflective member-CLOSURE reads degrade
+to a **catchable TypeError** until a native body lands (the established #2193 /
+#2651 pattern). So wiring a builtin's glue flips the value-read CE to a working
+value object without needing every method body implemented.
+
+## Implementation Plan
+
+### Pattern to follow (already used for Error/Map/Set, `array-object-proto.ts:661`)
+
+```ts
+export function ensureArrayBufferNativeProtoGlue(ctx: CodegenContext): number | undefined {
+  const brand = getBuiltinBrand(ctx, "ArrayBuffer");
+  if (brand === undefined) return undefined;
+  if (!getNativeProtoBuiltinGlue(ctx, brand)) {
+    registerNativeProtoBuiltin(ctx, makeGlue(ctx, brand, "ArrayBuffer", ARRAYBUFFER_PROTO_METHODS));
+  }
+  return brand;
+}
+```
+
+### Changes
+
+**File: `src/codegen/array-object-proto.ts`**
+- Add a `*_PROTO_METHODS` member list per builtin (the spec'd
+  `<Builtin>.prototype` own enumerable + standard method/getter names — pull
+  from the ES spec / the host-mode member set; getters like `ArrayBuffer.prototype.byteLength`,
+  `DataView.prototype.byteLength/buffer/byteOffset` must be marked `memberKind: "getter"`
+  so `.length` meta folds to 0, see `makeTypedArrayGlue` at line 570 for the getter pattern).
+- Add `ensure<Builtin>NativeProtoGlue` for each, mirroring `ensureErrorNativeProtoGlue`
+  (line 661). Reuse `makeGlue` (line 536); for builtins with accessor getters,
+  add a `makeGlue`-variant that takes a getter-name set (model on `makeTypedArrayGlue`).
+- Member bodies degrade to `emitProtoMemberBodyRefusal` (catchable TypeError) —
+  do NOT implement every method body in this issue. The value-read object only
+  needs the member CSV.
+
+**File: `src/codegen/property-access.ts`**
+- In `tryEnsureNativeProtoBrand` (line 696), add a `if (builtinName === "ArrayBuffer") return ensureArrayBufferNativeProtoGlue(ctx);`
+  arm per newly-wired builtin, before the final `getBuiltinBrand` fallthrough (line 781).
+- Order by impact: ArrayBuffer, DataView, Promise, Iterator, then the Error
+  subclasses (TypeError/RangeError/ReferenceError/SyntaxError/EvalError/URIError —
+  these likely already share the `Error` glue brand; verify `getBuiltinBrand`
+  returns a brand for each, or alias them to the Error glue member set).
+
+### Sub-case: namespace static reads (Math.PI, JSON.stringify, Reflect.get, Atomics.add)
+
+`Math`, `JSON`, `Reflect`, `Atomics` are **namespaces**, not ctors — the read is
+`Math.LN2` (a static data prop), not `Math.prototype.x`. These do NOT go through
+`$NativeProto` proto-glue. Handle them in a **separate follow-up** (note in
+umbrella #2860): emit the constant value directly for the data props
+(Math.PI/LN2/…) and a native static-method closure for the methods. **Scope THIS
+issue to the ctor/prototype value reads** (ArrayBuffer, DataView, Promise,
+Iterator, Error subclasses, WeakRef, FinalizationRegistry, DisposableStack,
+AsyncDisposableStack) — ~700 of the 882. Math/JSON/Reflect/Atomics (~120) split out.
+
+### Edge cases
+- A builtin whose ctor brand isn't reserved (`getBuiltinBrand` returns
+  `undefined`) → return `undefined` (caller keeps the refusal — no fabricated
+  value). Confirm ArrayBuffer/DataView/Promise/Iterator brands ARE reserved
+  (they're real ctors; if not reserved, the brand reservation must be added
+  first — check `BUILTIN_CTOR_NAMES` includes them in property-access.ts:818).
+- Shadowed builtin identifier (`const ArrayBuffer = …`) → `isShadowed` guard
+  already handles it (property-access.ts:819/854).
+- Promise proto glue was **deliberately excluded** for instance reads in #1907
+  (a runtime null-deref in a passing Promise test — async-capability state
+  collides with the value-read path, see property-access.ts:736-739 comment).
+  For Promise, wire ONLY the static `.prototype` VALUE read (pure value object,
+  `emitLazyNativeProtoGet` never touches runtime state) and re-run the Promise
+  tests to confirm no regression before keeping it; if it re-traps, drop Promise
+  from this issue and defer to a dedicated investigation.
+
+## Test plan
+
+These standalone-CE tests must flip to **pass** (host already passes them):
+- `test/built-ins/ArrayBuffer/prototype/**` (byteLength getter, slice, etc.)
+- `test/built-ins/DataView/prototype/**` (byteLength/buffer/byteOffset getters)
+- `test/built-ins/Promise/prototype/**` (finally/then/catch name+length reads)
+- `test/built-ins/Iterator/prototype/**`
+- `test/built-ins/{TypeError,RangeError,ReferenceError}/**` prototype reads
+- `test/built-ins/Boolean/S15.6.3_A3.js` (`Boolean.length`)
+
+Validation: full `merge_group` (test262 merge shard reports) + standalone-floor
+high-water (`check-standalone-highwater.mjs`). Expect a net standalone pass gain
+of several hundred with **zero** host-mode regression (these paths are
+`ctx.standalone`-gated).

--- a/plan/issues/2862-standalone-toprimitive-builtin-exotics.md
+++ b/plan/issues/2862-standalone-toprimitive-builtin-exotics.md
@@ -1,0 +1,119 @@
+---
+id: 2862
+title: "Standalone: ToPrimitive throws 'Cannot convert object to primitive value' for built-in exotics + inherited valueOf/toString"
+status: ready
+created: 2026-06-30
+updated: 2026-06-30
+priority: high
+feasibility: hard
+task_type: feature
+area: codegen
+goal: standalone
+sprint: current
+horizon: l
+related: [2860, 1900, 2358, 2638, 1910]
+umbrella: 2860
+architect_spec: candidate
+---
+
+# Standalone: ToPrimitive incomplete for built-in exotics + inherited methods
+
+## Problem
+
+In `--target standalone`, converting many objects to a primitive throws
+`TypeError: Cannot convert object to primitive value` where js-host succeeds.
+
+### Impact (measured 2026-06-30)
+
+**2,039 standalone-only failures** carry this signature (the single largest
+error signature in the gap). Of these, **728 are "pure"** (no host-import leak —
+ToPrimitive is the sole blocker; the rest also leak a generator/promise/symbol
+import and additionally need their carrier). By category among the 2,039:
+Object 476, TypedArray 304, language/expressions 293, String 189, RegExp 125,
+Array 88, DataView 43, Set/Map/Iterator/Function ~80.
+
+Note: the proximate throw is often in **harness** code (`assert.sameValue`/
+`String(x)` formatting a value), so flipping these also depends on the value's
+own representation reaching a primitive.
+
+## Root cause
+
+The Wasm-native `__to_primitive` engine (`src/codegen/object-runtime.ts:2011`,
+#1900/#2358/#2638) implements §7.1.1.1 OrdinaryToPrimitive over the standalone
+runtime, with arms for:
+- non-objects → unchanged
+- `$__vec_base` (arrays) → `__array_to_primitive_string` (#2358)
+- nominal class structs → `__class_to_primitive` valueOf/toString dispatch (#2638)
+- `$Object` wrapper internal slot (`new Number/String/Boolean`) → slot value (#1910)
+- `$Object` own-prop `valueOf`/`toString` via `__extern_get` + call, with a
+  `"[object Object]"` default when `toString` is missing.
+
+It falls to the `throwTypeError()` (object-runtime.ts:2278) when **none** match.
+The misses are:
+
+1. **Built-in exotic instances not modeled as `$Object`/`$Vec`/class-struct** —
+   TypedArray views, DataView, ArrayBuffer, RegExp, boxed wrappers backed by a
+   nominal runtime struct. These reach the non-`$Object` arm (line 2192), miss
+   `ref.test $__vec_base` and `__class_to_primitive` (no user valueOf/toString
+   dispatcher), and return **unchanged** → caller's `__unbox_number`/string
+   coercion then fails, or a later ToPrimitive throws.
+2. **`$Object` instances whose `valueOf`/`toString` are INHERITED** (on a
+   prototype, not own) — `__extern_get(obj, "toString")` only reads OWN props in
+   standalone (the prototype chain / `Object.prototype.toString` is not
+   materialized), so both probes miss. For the **number/default** hint the
+   `"[object Object]"` default is only supplied on the `toString` arm
+   (`defaultObjectToStringOnMissing`), and `valueOf` missing returns nothing →
+   falls through to throw.
+
+## Implementation Plan
+
+This is substrate-scale; **tagged `architect_spec: candidate`** — wants a design
+pass on the value-representation classifier before coding. Sketch:
+
+### A. Built-in exotic → primitive arm (object-runtime.ts ~line 2196, the
+`!ref.test $Object` block)
+- After the `$__vec_base` and `__class_to_primitive` arms, add a
+  brand-dispatch over the built-in nominal structs (TypedArray view structs,
+  DataView, RegExp, ArrayBuffer). Each has a spec'd OrdinaryToPrimitive result:
+  - TypedArray / Array-like → `Array.prototype.toString` style join (reuse the
+    `__array_to_primitive_string` reservation pattern, array-to-primitive.ts).
+  - RegExp → `RegExp.prototype.toString` (`"/source/flags"`) — native string.
+  - DataView/ArrayBuffer → inherit `Object.prototype.toString` → `"[object DataView]"`/`"[object ArrayBuffer]"`.
+- Use the reserve-placeholder-funcIdx + fill-in-post-processing discipline
+  (array-to-primitive.ts / class-to-primitive.ts) since these helpers depend on
+  carriers registered AFTER `__to_primitive`.
+
+### B. Default Object.prototype.toString for the number/default hint
+(object-runtime.ts:2138 `tryOrdinaryMethod`)
+- When BOTH `valueOf` and `toString` own-prop probes miss on a `$Object`, supply
+  the `"[object Object]"` default on the **final** probe regardless of hint
+  (today only the `toString`-arm default fires). Spec: a plain object with no own
+  valueOf/toString uses `Object.prototype.{valueOf,toString}`; valueOf returns
+  the object (not primitive) so toString wins → `"[object Object]"`. So: if both
+  own probes miss, return `"[object Object]"` rather than throwing. The throw
+  must remain reachable ONLY when a present `toString`/`valueOf` returns an
+  object (the genuine §7.1.1.1 TypeError — keep the existing return-if-primitive
+  guard so a present-but-object-returning method still throws).
+
+### Edge cases / regression guards
+- A user object with `Symbol.toPrimitive` must still take precedence (that path
+  is handled before `__to_primitive` in the coercion engine — verify it isn't
+  short-circuited by the new exotic arm).
+- `new Number(5)` etc. wrapper slot (line 2240) must still win over the new
+  default-toString arm (order preserved).
+- Confirm the genuine §7.1.1.1 TypeError tests still throw:
+  `test/.../Symbol.toPrimitive/*returns-object*`, ordinary toString/valueOf
+  returning an object.
+
+## Test plan
+
+Standalone fail/CE → pass:
+- `test/built-ins/TypedArray/prototype/**` (toLocaleString, join via ToPrimitive)
+- `test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-*` (object formatting)
+- `test/built-ins/Iterator/prototype/drop|take/**`
+- `test/built-ins/RegExp/prototype/test/S15.10.6.3*`
+- `test/language/expressions/**` ToPrimitive coercions
+
+Validate full `merge_group` + standalone high-water. Expect the **728 pure**
+to flip directly; re-measure the leak-bucket residual after #2864-#2867 land.
+Zero host-mode regression (all arms `ctx.standalone`).

--- a/plan/issues/2863-standalone-dynamic-shape-get-builtin.md
+++ b/plan/issues/2863-standalone-dynamic-shape-get-builtin.md
@@ -1,0 +1,96 @@
+---
+id: 2863
+title: "Standalone: dynamic-shape object/property ops refused — __get_builtin (reflective builtin/namespace read), __extern_toLocaleString, __object_groupBy/fromEntries"
+status: ready
+created: 2026-06-30
+updated: 2026-06-30
+priority: high
+feasibility: medium
+task_type: feature
+area: codegen
+goal: standalone
+sprint: current
+horizon: m
+related: [2860, 1472, 2861]
+umbrella: 2860
+---
+
+# Standalone: dynamic-shape object/property operations refused
+
+## Problem
+
+`--target standalone` refuses several dynamic-shape object/property operations
+with:
+
+```
+Codegen error: '<op>' (dynamic-shape object/property operation) is not yet
+supported in --target standalone (#1472 Phase B).
+```
+
+### Impact (measured 2026-06-30) — 365 standalone-only failures (all CE)
+
+| op | tests | meaning |
+| -- | ----- | ------- |
+| `__get_builtin` | 314 | reflective read of a built-in/namespace member that missed every fast path |
+| `__extern_toLocaleString` | 34 | `.toLocaleString()` on a dynamic receiver |
+| `__object_groupBy` | 10 | `Object.groupBy` |
+| `__object_fromEntries` | 7 | `Object.fromEntries` |
+
+## Root cause
+
+`refuseStandaloneObjectImport` (`src/codegen/expressions/late-imports.ts:85`,
+list at lines 56-75) hard-refuses these `__*` imports under standalone. They are
+the host-mode dynamic fallbacks that have no Wasm-native carrier yet.
+
+`__get_builtin` dominates: it is the generic fallback emitted by
+`compileMemberRead` when a property access resolves to a built-in **by name at
+runtime** and no fast path / native-proto glue matched (see
+`property-access.ts:170-186, 382-386`). A large share of the 314 are
+**namespace static reads** — `Math.PI`/`Math.LN2`, `JSON.stringify`,
+`Reflect.get`, `Atomics.add` — and reflective `obj[computedName]` against a
+built-in. This overlaps with the namespace-static-read follow-on noted in
+umbrella #2860 and with #2861.
+
+## Implementation Plan
+
+### Phase 1 — namespace static reads (the bulk of `__get_builtin`)
+**File: `src/codegen/property-access.ts`** (`compileMemberRead` / the
+`__get_builtin` shortcut site, ~line 382)
+- For `Math`/`JSON`/`Reflect`/`Atomics`/`Number`/`Symbol` **namespace** members
+  with a statically-known property name:
+  - **Data constants** (`Math.PI`, `Math.E`, `Math.LN2`, `Number.MAX_SAFE_INTEGER`,
+    `Symbol.iterator`/well-knowns): emit the constant value directly (f64 const,
+    or the interned well-known symbol). `Math.PI` etc. already have an exclusion
+    note at property-access.ts:382 — extend it to emit the value rather than
+    refuse.
+  - **Static methods** (`JSON.stringify`, `Reflect.get`, `Math.max`): emit a
+    native static-method closure (reuse the `ensureStandaloneBuiltinStaticMethodClosure`
+    factory, property-access.ts:686 / the #2175 `"static"` path).
+
+### Phase 2 — `__extern_toLocaleString`
+- Route `.toLocaleString()` on a dynamic receiver to the receiver's
+  `.toString()` native path (per spec the default `Object.prototype.toLocaleString`
+  calls `toString`); for Number/Array/Date use the existing native toString.
+
+### Phase 3 — `Object.groupBy` / `Object.fromEntries`
+- Implement as native helpers over the `$Object` runtime + iterator protocol.
+  `fromEntries` depends on the iterator carrier — sequence AFTER #2864 if it
+  needs generic iteration; the common `Object.fromEntries(array)` case can use
+  the `$__vec_base` fast path now.
+
+### Edge cases
+- A genuinely dynamic `obj[expr]` where `obj` is user-typed must keep routing to
+  the typed struct.get fast path, not `__get_builtin` (unchanged).
+- Shadowed namespace identifiers (`const Math = …`) → keep refusing / route to
+  the local (guard like property-access.ts:819).
+
+## Test plan
+
+Standalone CE → pass:
+- `test/built-ins/Math/**` (PI/LN2/E value reads, max/min static methods)
+- `test/built-ins/Atomics/**`, `test/built-ins/JSON/**`, `test/built-ins/Reflect/**`
+- `test/built-ins/TypedArray/prototype/toLocaleString/**`
+- `test/built-ins/Object/{groupBy,fromEntries}/**`
+
+Full `merge_group` + standalone high-water; zero host-mode regression
+(`ctx.standalone`-gated).

--- a/plan/issues/2864-standalone-generator-carrier.md
+++ b/plan/issues/2864-standalone-generator-carrier.md
@@ -1,0 +1,86 @@
+---
+id: 2864
+title: "Standalone: no Wasm-native generator carrier — sync generators leak __create_generator/__gen_* host imports"
+status: ready
+created: 2026-06-30
+updated: 2026-06-30
+priority: high
+feasibility: hard
+task_type: feature
+area: codegen
+goal: standalone
+sprint: current
+horizon: xl
+related: [2860, 680, 2865]
+umbrella: 2860
+architect_spec: candidate
+---
+
+# Standalone: Wasm-native generator carrier (sync)
+
+## Problem
+
+Sync generators (`function*`, generator methods, `yield`/`yield*`) work in
+js-host via host imports but have **no general standalone carrier**. Only
+"sequential numeric yields" are lowered natively (#680); anything else leaks
+`__create_generator` / `__gen_create_buffer` / `__gen_next` / `__gen_yield_star`
+/ `__gen_result_value` / `__gen_set_return` / `__gen_push_ref` / `__gen_push_f64`,
+which under standalone either fail instantiation or hit the #680 refusal
+(`src/codegen/function-body.ts:1020`).
+
+### Impact (measured 2026-06-30) — ~697 standalone-only failures
+
+Leaked imports across the gap: `__gen_create_buffer` 1,648, `__gen_next` 1,070,
+`__create_generator` 748, `__gen_yield_star` 505 (these counts include the async
+cases tracked in #2865). Manifests as `fail` (598) and CE (99); many proximate
+errors are `illegal cast [in __obj_find() ← __extern_set]` inside the
+destructuring/iterator machinery that the generator drives.
+
+## Root cause
+
+There is no Wasm-native coroutine/state-machine lowering for general generator
+bodies in standalone. The host carrier buffers yields in a JS-side structure
+(`__gen_*`). A standalone generator needs either:
+1. a **resumable state-machine transform** (CPS / explicit state var + switch on
+   re-entry, locals spilled to a heap frame struct), or
+2. WasmGC **stack-switching** (the `stack-switching` proposal) if the target
+   runtime enables it — but CLAUDE.md notes wasmtime rejects all-proposals; this
+   is not portable yet.
+
+Approach (1) is the portable path: lower a generator body to a `$GenFrame`
+struct (captured locals + an i32 `state`), and a `next(frame, sentValue)`
+function that `br_table`s on `state` to the resume point, runs to the next
+`yield`, stores the next state, and returns `{value, done}`. `yield*` delegates
+to the inner iterator's `next`.
+
+## Implementation Plan
+
+**Architecture-scale — tagged `architect_spec: candidate`.** Design needed
+before coding. Key decisions for the architect:
+- Frame representation: `struct $GenFrame (field $state (mut i32)) (field $localN (mut T))…`
+  one field per live-across-yield local; reuse the ref-cell pattern for captures.
+- State-machine transform location: in IR lowering (`src/ir/lower.ts`) vs the
+  legacy codegen generator path (`src/codegen/function-body.ts`,
+  `class-bodies.ts`, `closures.ts`). Prefer IR if generator nodes are adopted;
+  else extend the #680 native path in function-body.ts:1020.
+- `IteratorResult` representation: reuse the existing `{value, done}` $Object or
+  a nominal struct; must satisfy the for-of / spread / destructuring consumers
+  natively (overlaps #2863 `__array_from_iter_n` spread).
+- `return()`/`throw()` completion (try/finally inside generators) → finally
+  blocks must run on early completion; the state machine must encode finally
+  regions.
+
+Start scope: plain `function*` with value yields + `yield*` over an array /
+another native generator. Defer `[Symbol.iterator]`-driven `yield*` over an
+arbitrary host iterator until the iterator-protocol carrier is native.
+
+## Test plan
+
+Standalone fail/CE → pass:
+- `test/language/expressions/yield/**`, `test/language/statements/generators/**`
+- `test/built-ins/GeneratorFunction/**`, `test/built-ins/GeneratorPrototype/**`
+- `test/built-ins/Iterator/prototype/{map,take,drop,flatMap}/**` (driven by gens)
+
+Full `merge_group` + standalone high-water. This is the single largest lever
+(sync 697 + async 986 = 1,683 combined with #2865). Sequence #2864 before #2865
+(async generators build on this).

--- a/plan/issues/2865-standalone-async-generator-carrier.md
+++ b/plan/issues/2865-standalone-async-generator-carrier.md
@@ -1,0 +1,65 @@
+---
+id: 2865
+title: "Standalone: no Wasm-native async-generator / for-await carrier — leaks __create_async_generator + Promise_* host imports"
+status: ready
+created: 2026-06-30
+updated: 2026-06-30
+priority: medium
+feasibility: hard
+task_type: feature
+area: codegen
+goal: standalone
+sprint: current
+horizon: xl
+related: [2860, 2864, 2867]
+umbrella: 2860
+architect_spec: candidate
+depends_on: [2864, 2867]
+---
+
+# Standalone: async-generator / for-await-of carrier
+
+## Problem
+
+`async function*`, `for await...of`, and async-generator destructuring have no
+standalone carrier. They leak `__create_async_generator`, the `__gen_*` family,
+and the `Promise_*` microtask imports.
+
+### Impact (measured 2026-06-30) — ~986 standalone-only failures
+
+The largest single cluster by my classifier. Proximate errors are
+`illegal cast [in __iterator() ← fn]` / `[in __obj_find() ← __extern_set]`
+inside async destructuring + for-await machinery (867 fail, 119 CE).
+
+## Root cause
+
+Async generators compose two missing standalone substrates: the **generator
+state machine** (#2864) and the **Promise/microtask** runtime (#2867). An async
+generator's `next()` returns a Promise of `{value, done}`; `for await` drives it
+through the microtask queue. Neither exists natively in standalone.
+
+## Implementation Plan
+
+**Architecture-scale — `architect_spec: candidate`; depends on #2864 (generator
+state machine) and #2867 (Promise carrier).** Do NOT start before both land.
+
+Design sketch (for the architect):
+- Reuse #2864's `$GenFrame` state machine; the resume function returns a Promise
+  built on #2867's capability instead of a bare `{value,done}`.
+- `for await (x of g)`: lower to a microtask-driven loop — `await g.next()`,
+  unwrap `{value,done}`, run body, repeat — using the same await-lowering as
+  async functions (verify async functions are already native in standalone; if
+  they too leak `Promise_*`, that work is #2867).
+- Async `yield*` delegates to the inner async iterator with await between steps.
+
+## Test plan
+
+Standalone fail/CE → pass:
+- `test/language/statements/for-await-of/**`
+- `test/language/statements/async-generator/**`,
+  `test/language/expressions/async-generator/**`
+- `test/built-ins/AsyncGeneratorFunction/**`, `AsyncFromSyncIteratorPrototype/**`
+- `test/built-ins/Array/fromAsync/**`
+
+Full `merge_group` + standalone high-water. Largest cluster but gated on two
+predecessors — schedule after #2864/#2867.

--- a/plan/issues/2866-standalone-symbol-carrier.md
+++ b/plan/issues/2866-standalone-symbol-carrier.md
@@ -1,0 +1,73 @@
+---
+id: 2866
+title: "Standalone: Symbol values leak __box_symbol — no Wasm-native Symbol carrier"
+status: ready
+created: 2026-06-30
+updated: 2026-06-30
+priority: medium
+feasibility: hard
+task_type: feature
+area: codegen
+goal: standalone
+sprint: current
+horizon: l
+related: [2860]
+umbrella: 2860
+architect_spec: candidate
+---
+
+# Standalone: Wasm-native Symbol carrier
+
+## Problem
+
+Symbol creation/usage leaks the `env::__box_symbol` host import (and related
+well-known-symbol machinery). Under standalone there is no JS host to box a
+Symbol, so these tests fail/CE.
+
+### Impact (measured 2026-06-30) — ~418 standalone-only failures
+
+`__box_symbol` leaks in 950 gap tests (overlapping with other clusters); ~418
+have Symbol as the dominant blocker (306 fail, 112 CE). Proximate errors include
+`illegal cast [in __proxy_revoke() ← __closure]` where a Symbol-keyed access /
+`Symbol.toPrimitive` / well-known symbol dispatch mis-resolves.
+
+## Root cause
+
+A Symbol is currently represented by boxing through the host (`__box_symbol`).
+Standalone needs a native Symbol value representation:
+- a nominal `$Symbol` struct carrying an optional description (native string) +
+  a unique identity (the struct reference itself gives identity via `ref.eq` —
+  cf. `reference_standalone_floor_object_identity_and_real_vs_drift`: native
+  equality must preserve identity via `ref.eq`).
+- well-known symbols (`Symbol.iterator`, `Symbol.toPrimitive`, `Symbol.asyncIterator`,
+  `Symbol.hasInstance`, …) as interned singleton `$Symbol` globals.
+- `Symbol.for`/`Symbol.keyFor` registry as a native map keyed by description.
+- Symbol-keyed property storage: the `$Object` runtime must accept a `$Symbol`
+  key (not just a native-string key) — extend the key normalization in
+  `object-runtime.ts` (the `__extern_get`/`set`/`has` key path) to test
+  `ref.test $Symbol` alongside `$AnyString`.
+
+## Implementation Plan
+
+**`architect_spec: candidate`** — value-representation design needed (interning,
+identity, the `$Object` key-channel widening). Sketch:
+- Define `$Symbol` struct + register interned well-known globals at module init.
+- Route `typeof sym === "symbol"` to a `ref.test $Symbol` predicate
+  (`__typeof_symbol`), replacing the `__box_symbol`-tag check.
+- Widen the `$Object` property key channel to accept `$Symbol` keys with
+  `ref.eq` identity comparison in the find loop (object-runtime.ts key dispatch,
+  ~line 464 where `$AnyString`/`$BoxNum` keys are already handled).
+- `Symbol.toPrimitive` lookup in the coercion engine must resolve the
+  well-known `$Symbol` global key (ties into #2862 ToPrimitive).
+
+## Test plan
+
+Standalone fail/CE → pass:
+- `test/built-ins/Symbol/**`, `test/built-ins/Symbol/{for,keyFor,iterator,…}/**`
+- `test/built-ins/Object/getOwnPropertySymbols/**`
+- `test/built-ins/*/prototype/Symbol.toPrimitive/**`,
+  `test/built-ins/*/*/Symbol.iterator/**`
+
+Full `merge_group` + standalone high-water; preserve Symbol identity via
+`ref.eq` (regression guard: two `Symbol("x")` must be `!==`, the same well-known
+must be `===`). Zero host-mode regression.

--- a/plan/issues/2867-standalone-promise-microtask-carrier.md
+++ b/plan/issues/2867-standalone-promise-microtask-carrier.md
@@ -1,0 +1,74 @@
+---
+id: 2867
+title: "Standalone: Promise / async microtask leaks Promise_resolve/reject/then + __make_callback host imports"
+status: ready
+created: 2026-06-30
+updated: 2026-06-30
+priority: medium
+feasibility: hard
+task_type: feature
+area: codegen
+goal: standalone
+sprint: current
+horizon: l
+related: [2860, 1326]
+umbrella: 2860
+architect_spec: candidate
+---
+
+# Standalone: Wasm-native Promise / microtask carrier
+
+## Problem
+
+Promise construction and `.then`/`.catch`/`.finally`, plus async-function await
+points, leak `env::Promise_resolve`, `Promise_reject`, `Promise_then`,
+`Promise_then2`, and `__make_callback` to the JS host. Under standalone there is
+no host microtask queue.
+
+### Impact (measured 2026-06-30) — ~375 standalone-only failures (non-generator)
+
+`Promise_then2` 766, `Promise_resolve` 788, `Promise_reject` 809,
+`__make_callback` 1,198 across the gap (overlapping with async-generator #2865);
+~375 have Promise/async as the dominant blocker once generators are excluded
+(231 fail, 144 CE). (#1326c began standalone microtask/then work — verify what
+landed.)
+
+## Root cause
+
+No standalone microtask queue + Promise state machine. Needs:
+- a native `$Promise` struct (state: pending/fulfilled/rejected, value, reaction
+  list).
+- a native **microtask queue** drained at top-of-job / after the main module
+  body (a Wasm-side ring buffer of pending reactions).
+- `await` lowering in async functions that suspends the async frame (shares the
+  resumable-frame machinery with #2864 generators) and resumes from the
+  microtask drain.
+- `Promise.resolve/reject/all/race/allSettled/any` as native statics.
+
+## Implementation Plan
+
+**`architect_spec: candidate`** — overlaps the generator-frame design (#2864).
+Recommend the architect design the **resumable-frame substrate once** and share
+it between async functions, generators, and async generators. Check #1326c
+(`1326c-microtask-queue-and-promise-then-standalone.md`) for the partial
+microtask work already present before re-deriving.
+
+Sketch:
+- `$Promise` + microtask ring in the object-runtime; drain entry called after
+  module main + at each await resume.
+- Replace the `Promise_*`/`__make_callback` host-import emission sites (search
+  `src/codegen/**` for these names) with calls into the native carrier under
+  `ctx.standalone`.
+- `then`/reaction scheduling enqueues a native reaction record (closure +
+  capability) instead of `__make_callback`.
+
+## Test plan
+
+Standalone fail/CE → pass:
+- `test/built-ins/Promise/**` (resolve/reject/then/finally/all/race/allSettled/any)
+- `test/language/expressions/await/**`, `test/language/statements/async-function/**`
+
+Full `merge_group` + standalone high-water. Sequence before async generators
+(#2865 depends on this + #2864). Preserve the #2375 caution: Promise proto
+value-read path must not collide with runtime async-capability state (the
+null-deref noted in property-access.ts:736).

--- a/plan/issues/2868-standalone-invalid-wasm-emission.md
+++ b/plan/issues/2868-standalone-invalid-wasm-emission.md
@@ -1,0 +1,93 @@
+---
+id: 2868
+title: "Standalone: invalid Wasm binary emitted (correctness) — __uri_encode/__uri_decode, __str_flatten, and common user-body shapes"
+status: ready
+created: 2026-06-30
+updated: 2026-06-30
+priority: high
+feasibility: medium
+task_type: bug
+area: codegen
+goal: standalone
+sprint: current
+horizon: m
+related: [2860]
+umbrella: 2860
+---
+
+# Standalone: invalid Wasm binary emitted
+
+## Problem
+
+In `--target standalone`, some modules compile to a binary the engine rejects:
+
+```
+invalid Wasm binary (WebAssembly.instantiate(): Compiling function #N:"<fn>" ...)
+```
+
+This is a **correctness** bug — the worst class, since the module is structurally
+broken, not merely missing a feature.
+
+### Impact (measured 2026-06-30) — 523 standalone-only failures (all CE)
+
+By the rejected function name:
+
+| function | tests | note |
+| -------- | ----- | ---- |
+| `test` (harness/user) | 199 | a common emitted body shape |
+| `inner` | 81 | nested function shape |
+| `__uri_decode` | 46 | native decodeURI/decodeURIComponent impl |
+| `fn` | 42 | |
+| `__uri_encode` | 18 | native encodeURI/encodeURIComponent impl |
+| `__str_flatten` | 10 | native string flatten |
+| `C_setPrivateReference` | 10 | private-field accessor |
+| `gen` / `__closure_*` / `__cb_*` | ~40 | |
+
+The `__uri_encode`/`__uri_decode` (64 combined) and `__str_flatten` carriers are
+concrete native helpers emitting invalid bytes — the most isolated sub-bugs.
+
+## Root cause (to confirm during triage)
+
+Standalone-only invalid binaries usually mean a stack-balance / type-mismatch in
+a `ctx.standalone`-gated emission path, or a late-import funcIdx shift that
+wasn't propagated (cf. the `addUnionImports` index-shift hazards in CLAUDE.md and
+`reference_1461`/`reference_2191`/`reference_2193`). The two named native
+helpers (`__uri_*`, `__str_flatten`) are self-contained — disassemble one failing
+module with `binaryen`/`wasm-objdump` to get the exact validation error
+(stack-height, type, or bad funcref).
+
+## Implementation Plan
+
+This is **triage-then-fix**, not a single known edit. Procedure:
+
+1. **Reproduce minimally** — pick one test per named function (e.g.
+   `test/built-ins/decodeURI/**` for `__uri_decode`,
+   `test/built-ins/String/prototype/split/**` for `__str_flatten`). Compile with
+   `--target standalone`, dump the WAT, and read the validator's exact complaint
+   (write probes under `.tmp/`).
+2. **`__uri_encode`/`__uri_decode`** (64): inspect the native helper emission
+   (grep `__uri_encode`/`__uri_decode` in `src/codegen/`); fix the
+   stack/type/funcidx defect. Likely a single shared bug across both.
+3. **`__str_flatten`** (10): same approach — overlaps the null-deref string
+   cluster (umbrella #2860 note).
+4. **`test`/`inner`/`fn` body shapes** (322): these are user/harness bodies, so
+   the defect is a general codegen construct mis-emitted under standalone.
+   Cluster the offending source constructs (look for a shared syntactic feature
+   across the failing files) and fix the emitter. Use the validator error to
+   localize (e.g. "type mismatch in ... expected externref got anyref" →
+   a missing `extern.convert_any`/`any.convert_extern` on a standalone path).
+
+Split into sub-tasks if the `__uri_*`/`__str_flatten` fixes are independent from
+the body-shape fix (they likely are — file a follow-on for the residual after
+the named helpers are fixed).
+
+## Test plan
+
+Standalone CE → pass:
+- `test/built-ins/{decodeURI,decodeURIComponent,encodeURI,encodeURIComponent}/**`
+- `test/built-ins/String/prototype/split/**` (RegExp-arg `__str_flatten`)
+- the `reduceRight`/`substring`/`func-decl-forbidden-ext` examples listed in the
+  triage.
+
+Validate by re-compiling each repro to a valid module, then full `merge_group` +
+standalone high-water. Pure correctness win — no host-mode path touched.


### PR DESCRIPTION
Files the standalone-focus sprint queue: an umbrella (#2860) + 8 root-cause cluster issues (#2861-#2868) covering the **9,177-test** standalone-only test262 gap (host passes 33,032; standalone official_pass 24,656).

Measured 2026-06-30 from the two lane baselines in `loopdive/js2wasm-baselines` (`test262-current.jsonl` vs `test262-standalone-current.jsonl`), official-scope, matched by file+strict (`host==pass AND standalone!=pass`). The standalone baseline's `host_import_leak_class` + leaked `imports` drove the clustering.

Top clusters (total / pure / issue):
- builtin static/proto value read refused — 882 / 882 — **#2861** (start now, mechanical glue pattern)
- ToPrimitive over built-in exotics + inherited methods — 2,039 / 728 — **#2862** (architect_spec)
- dynamic-shape `__get_builtin`/namespace reads — 365 / 365 — **#2863**
- sync generators carrier — 697 — **#2864** (architect_spec, epic)
- async generators carrier — 986 — **#2865** (architect_spec, dep #2864/#2867)
- Symbol carrier — 418 — **#2866** (architect_spec)
- Promise/microtask carrier — 375 — **#2867** (architect_spec)
- invalid Wasm emission (correctness) — 523 / 118 — **#2868**

Docs-only (plan/issues). Each child carries a `## Implementation Plan` with file:line and a test plan (standalone CE/fail → pass under full merge_group + standalone high-water floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)