### PR TITLE
fix(#2846): keep bigint-branded i64 funcType distinct in dedup

### DIFF
--- a/plan/issues/2846-acorn-bigint-literal-corrupted-to-f64.md
+++ b/plan/issues/2846-acorn-bigint-literal-corrupted-to-f64.md
@@ -1,12 +1,13 @@
 ---
 id: 2846
 title: "compiled-acorn corrupts BigInt literals — parsed/marshalled as float64, losing value AND the `bigint` string"
-status: ready
+status: done
 sprint: current
 priority: high
 horizon: m
 feasibility: hard
 created: 2026-06-29
+completed: 2026-06-30
 task_type: bugfix
 area: codegen, runtime
 language_feature: bigint
@@ -65,3 +66,31 @@ string corruption; the `value` BigInt object may defer to the i64-brand work.
   string field exact (no `primitive-mismatch @ .bigint`).
 - `value` either a real BigInt or documented-deferred to the i64-brand gate.
 - No test262 regression.
+
+## Resolution (2026-06-30)
+
+Fixed via the architect's narrow path (a): a 2-LOC change to the func-type
+dedup chokepoint in `src/codegen/registry/types.ts`.
+
+- `funcTypeKey` now emits a `:big` suffix for a bigint-branded i64 result/param,
+  so a `(...)->i64:big` signature keys distinctly from a plain `(...)->i64`.
+- `valTypeEq` gains an i64 `bigint`-brand equality check so structural-match
+  callers (`funcTypeEq`) do not re-merge the two.
+
+Root cause confirmed by probe: acorn's `stringToBigInt` has signature
+`(externref) -> i64:big`; on unfixed main its brand-blind key `externref|i64`
+collided (cacheHit) with a pre-existing plain `(externref) -> i64` def, so
+`getWasmFuncReturnType` returned a plain i64 → boxed via `__box_number`
+(`f64.convert_i64_s`) → precision loss past 2^53. Same class as #2795 (i32
+boolean/symbol brand).
+
+### Verify-first (acorn differential corpus, `corpus/literals.js` = `const big = 9007199254740993n;`)
+
+- BEFORE (main): `REAL×2` — `bigint-mismatch @ .value` expected `9007199254740993n`
+  actual `9007199254740992`; `primitive-mismatch @ .bigint` expected
+  `"9007199254740993"` actual `"9007199254740992"`.
+- AFTER (fix): `corpus/literals.js: EQUAL(±quirks)`, REAL=0 — `value` is a real
+  BigInt and `bigint` is the exact source digit string.
+
+Regression test: `tests/issue-2846.test.ts` (registry-level dedup-distinctness
+assertion that fails on unfixed main + BigInt round-trip e2e guards).

--- a/src/codegen/registry/types.ts
+++ b/src/codegen/registry/types.ts
@@ -25,6 +25,18 @@ function funcTypeKey(params: ValType[], results: ValType[]): string {
       if ((v as { boolean?: true }).boolean) s += ":bool";
       else if ((v as { symbol?: true }).symbol) s += ":sym";
     }
+    // (#2846) Same brand-propagation hazard as i32 (#2795), one slot down: a
+    // bigint-branded `i64` (`{ kind:"i64"; bigint:true }`) backs a BigInt and
+    // boxes to the host via `__box_bigint`, whereas a plain native `i64`
+    // (`type i64 = number`) boxes via `__box_number` (`f64.convert_i64_s`,
+    // lossy past 2^53). A brand-blind dedup collapses a `(...)->bigint`
+    // signature onto a previously-registered plain-`i64` one, so
+    // `getWasmFuncReturnType` hands callers a PLAIN i64 and acorn's
+    // `stringToBigInt` return got boxed as a rounded number (#2846). Keep the
+    // branded i64 signature distinct.
+    else if (v.kind === "i64") {
+      if ((v as { bigint?: true }).bigint) s += ":big";
+    }
     return s;
   };
   return params.map(part).join(",") + "|" + results.map(part).join(",");
@@ -49,6 +61,12 @@ function valTypeEq(a: ValType, b: ValType): boolean {
   if (a.kind !== b.kind) return false;
   if ((a.kind === "ref" || a.kind === "ref_null") && (b.kind === "ref" || b.kind === "ref_null")) {
     return a.typeIdx === (b as { typeIdx: number }).typeIdx;
+  }
+  // (#2846) Keep the two i64 brands non-equal so `funcTypeEq` (structural-match
+  // callers) does not re-merge a bigint-branded i64 with a plain i64 — mirrors
+  // the `funcTypeKey` `:big` bucket above and the #2795 i32 precedent.
+  if (a.kind === "i64") {
+    return Boolean((a as { bigint?: true }).bigint) === Boolean((b as { bigint?: true }).bigint);
   }
   return true;
 }

--- a/tests/issue-2846.test.ts
+++ b/tests/issue-2846.test.ts
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2846 — compiled-acorn corrupted BigInt literals (parsed/marshalled as f64,
+// losing the value AND the `bigint` digit string past 2^53).
+//
+// Root cause: the function-type dedup key (`funcTypeKey`) and equality
+// (`valTypeEq`) in `src/codegen/registry/types.ts` IGNORED the `bigint` flag on
+// `{ kind: "i64"; bigint?: boolean }`. A bigint-returning function (acorn's
+// `stringToBigInt`, signature `(externref) -> i64:big`) therefore DEDUPLICATED
+// onto a previously-registered plain `(externref) -> i64` FuncTypeDef. At the
+// call site `getWasmFuncReturnType` then read `results[0]` from that shared,
+// UNBRANDED def and handed the caller a plain i64, which boxed to the host via
+// `__box_number` (`f64.convert_i64_s`) → precision loss past 2^53
+// (`9007199254740993n` → `9007199254740992`). acorn derives the node's `bigint`
+// STRING field from that rounded number, so both reported symptoms share the
+// one root cause. This is the SAME brand-propagation hole #2795 fixed for the
+// boolean/symbol i32 brand, one Wasm slot down.
+//
+// Fix (2 LOC): emit a distinct `:big` dedup-key suffix for a bigint-branded i64
+// in `funcTypeKey`, and add an i64 `bigint`-brand equality check to `valTypeEq`
+// so structural-match callers do not re-merge the two.
+//
+// The unit test below pins the dedup chokepoint directly: a branded i64 result
+// must NOT collapse onto a plain i64 result. (On unfixed `main` they share a
+// type index — the exact collision that corrupted the value.) The end-to-end
+// cases guard BigInt round-trips through the codegen.
+
+import { describe, expect, it } from "vitest";
+import ts from "typescript";
+
+import { createEmptyModule, type ValType } from "../src/ir/types.js";
+import { createCodegenContext } from "../src/codegen/index.js";
+import { addFuncType } from "../src/codegen/registry/types.js";
+import { compileAndInstantiate } from "../src/runtime.js";
+
+function makeDummyChecker(): ts.TypeChecker {
+  return {} as unknown as ts.TypeChecker;
+}
+
+describe("#2846 bigint-branded i64 func-type stays distinct in dedup", () => {
+  it("a branded (externref)->i64:big result does NOT dedup onto plain (externref)->i64", () => {
+    const ctx = createCodegenContext(createEmptyModule(), makeDummyChecker());
+    const params: ValType[] = [{ kind: "externref" }];
+    const plain: ValType[] = [{ kind: "i64" }];
+    const branded: ValType[] = [{ kind: "i64", bigint: true } as ValType];
+
+    const plainIdx = addFuncType(ctx, params, plain, "plain_i64");
+    const brandedIdx = addFuncType(ctx, params, branded, "bigint_i64");
+
+    // On unfixed main these collapse to the SAME index (brand-blind key) — the
+    // collision that made getWasmFuncReturnType return a plain i64 for acorn's
+    // stringToBigInt. With the fix they are distinct FuncTypeDefs.
+    expect(brandedIdx).not.toBe(plainIdx);
+
+    // The branded def must actually carry the brand on its result ValType.
+    const brandedDef = ctx.mod.types[brandedIdx];
+    expect(brandedDef?.kind).toBe("func");
+    if (brandedDef?.kind === "func") {
+      expect(brandedDef.results[0]?.kind).toBe("i64");
+      expect((brandedDef.results[0] as { bigint?: boolean }).bigint).toBe(true);
+    }
+  });
+
+  it("re-registering the SAME branded i64 signature is still deduped (idempotent)", () => {
+    const ctx = createCodegenContext(createEmptyModule(), makeDummyChecker());
+    const params: ValType[] = [{ kind: "externref" }];
+    const branded: ValType[] = [{ kind: "i64", bigint: true } as ValType];
+    const a = addFuncType(ctx, params, branded, "b1");
+    const b = addFuncType(ctx, params, branded, "b2");
+    expect(b).toBe(a);
+  });
+
+  it("native plain i64 signatures keep deduping unchanged (no brand growth)", () => {
+    const ctx = createCodegenContext(createEmptyModule(), makeDummyChecker());
+    const params: ValType[] = [{ kind: "i64" }];
+    const plain: ValType[] = [{ kind: "i64" }];
+    const a = addFuncType(ctx, params, plain, "p1");
+    const b = addFuncType(ctx, params, plain, "p2");
+    expect(b).toBe(a);
+  });
+});
+
+describe("#2846 BigInt values round-trip exact (no f64 precision loss)", () => {
+  // 9007199254740993 === 2^53 + 1 — the smallest integer float64 cannot
+  // represent; rounding to ...992 is the tell-tale that the value passed
+  // through an f64 during marshalling.
+  const HARD = "9007199254740993";
+
+  it("a BigInt literal past 2^53 stored in an `any` field is exact", async () => {
+    const ex = (await compileAndInstantiate(`
+      export function test(): any {
+        const n: any = {};
+        n.value = 9007199254740993n;
+        return n.value;
+      }
+    `)) as { test(): unknown };
+    const v = ex.test();
+    expect(typeof v).toBe("bigint");
+    expect((v as bigint).toString()).toBe(HARD);
+  });
+
+  it("BigInt(string) returned from a function preserves the value and the brand", async () => {
+    const ex = (await compileAndInstantiate(`
+      function toBig(s: string): bigint { return BigInt(s); }
+      export function value(): bigint { return toBig("${HARD}"); }
+      export function isBig(): boolean { return typeof toBig("5") === "bigint"; }
+    `)) as { value(): unknown; isBig(): unknown };
+    const v = ex.value();
+    expect(typeof v).toBe("bigint");
+    expect((v as bigint).toString()).toBe(HARD);
+    // The brand surviving the function return means typeof reads "bigint".
+    expect(Boolean(ex.isBig())).toBe(true);
+  });
+});


### PR DESCRIPTION
## #2846 — compiled-acorn corrupted BigInt literals (parsed/marshalled as f64)

A `BigInt` literal past 2^53 lost precision through the compiled-acorn parser:
`9007199254740993n` → value `9007199254740992` (a number, not a bigint) and the
derived `bigint` string field `"9007199254740992"`.

### Root cause (verified)

The func-type dedup key (`funcTypeKey`) and equality (`valTypeEq`) in
`src/codegen/registry/types.ts` **ignored the `bigint` flag** on
`{ kind:"i64", bigint? }`. acorn's `stringToBigInt` (signature
`(externref) -> i64:big`) therefore deduplicated onto a pre-existing plain
`(externref) -> i64` FuncTypeDef (its brand-blind key `externref|i64` was a
cache hit). `getWasmFuncReturnType` then read `results[0]` from that shared,
**unbranded** def and handed the caller a plain i64 → boxed via `__box_number`
(`f64.convert_i64_s`) → precision loss past 2^53. acorn derives the node's
`bigint` STRING field from that rounded number, so both reported symptoms share
the one root cause.

Same brand-propagation hole that #2795 fixed for the boolean/symbol i32 brand,
one Wasm slot down.

### Fix (2 LOC)

- `funcTypeKey`: emit a `:big` suffix for a bigint-branded i64 so it keys
  distinctly from plain i64.
- `valTypeEq`: add an i64 `bigint`-brand equality check so `funcTypeEq` does not
  re-merge the two.

Native `type i64 = number` stays byte-identical (flag defaults unbranded); only
modules with a genuinely bigint-returning function gain one extra FuncTypeDef.

### Verify-first (acorn differential corpus — `corpus/literals.js`)

- BEFORE (main): `REAL×2` — `bigint-mismatch @ .value` expected `9007199254740993n`
  actual `9007199254740992`; `primitive-mismatch @ .bigint` expected
  `"9007199254740993"` actual `"9007199254740992"`.
- AFTER (fix): `corpus/literals.js: EQUAL(±quirks)`, REAL=0 — `value` is a real
  BigInt and `bigint` is the exact source digit string.

### Tests

`tests/issue-2846.test.ts` — registry-level dedup-distinctness assertion (fails
on unfixed main: branded `i64:big` and plain `i64` collapse to the same type
index) + BigInt round-trip e2e guards. Native-i64 brand guards
(`tests/issue-1644*.test.ts`, 24 tests) still pass.

Touches the shared func-type registry → broad-impact; full `merge_group`
validation expected (auto-enqueue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)