### PR TITLE
feat(#2861): native-proto glue for standalone ArrayBuffer/DataView.prototype value reads

### DIFF
--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -447,6 +447,78 @@ const PROTO_METHOD_LENGTH: Readonly<Record<string, number>> = {
   toJSON: 1,
 };
 
+// ── ArrayBuffer.prototype (ES2024 §25.1.5) ────────────────────────────────────
+// Method names + accessor getters. Getters (`byteLength`/`maxByteLength`/
+// `detached`/`resizable`) are marked below so their `.length` meta folds to 0.
+// The value-read OBJECT only needs the member set; reflective member closures
+// degrade to a catchable TypeError until per-member native bodies land.
+const ARRAYBUFFER_PROTO_METHODS = [
+  "slice",
+  "resize",
+  "transfer",
+  "transferToFixedLength",
+  // Accessor getters (§25.1.5.{1,2,3,4}).
+  "byteLength",
+  "maxByteLength",
+  "detached",
+  "resizable",
+] as const;
+const ARRAYBUFFER_PROTO_GETTERS: ReadonlySet<string> = new Set([
+  "byteLength",
+  "maxByteLength",
+  "detached",
+  "resizable",
+]);
+const ARRAYBUFFER_PROTO_METHOD_LENGTH: Readonly<Record<string, number>> = {
+  slice: 2,
+  resize: 1,
+  transfer: 0,
+  transferToFixedLength: 0,
+};
+
+// ── DataView.prototype (ES2024 §25.3.4) ───────────────────────────────────────
+// All `get<Type>` methods are arity 1, all `set<Type>` arity 2. The accessor
+// getters `buffer`/`byteLength`/`byteOffset` (§25.3.4.{1,2,3}) fold to 0.
+const DATAVIEW_GET_TYPES = [
+  "getInt8",
+  "getUint8",
+  "getInt16",
+  "getUint16",
+  "getInt32",
+  "getUint32",
+  "getFloat16",
+  "getFloat32",
+  "getFloat64",
+  "getBigInt64",
+  "getBigUint64",
+] as const;
+const DATAVIEW_SET_TYPES = [
+  "setInt8",
+  "setUint8",
+  "setInt16",
+  "setUint16",
+  "setInt32",
+  "setUint32",
+  "setFloat16",
+  "setFloat32",
+  "setFloat64",
+  "setBigInt64",
+  "setBigUint64",
+] as const;
+const DATAVIEW_PROTO_METHODS = [
+  ...DATAVIEW_GET_TYPES,
+  ...DATAVIEW_SET_TYPES,
+  // Accessor getters (§25.3.4.{1,2,3}).
+  "buffer",
+  "byteLength",
+  "byteOffset",
+] as const;
+const DATAVIEW_PROTO_GETTERS: ReadonlySet<string> = new Set(["buffer", "byteLength", "byteOffset"]);
+const DATAVIEW_PROTO_METHOD_LENGTH: Readonly<Record<string, number>> = {
+  ...Object.fromEntries(DATAVIEW_GET_TYPES.map((m) => [m, 1])),
+  ...Object.fromEntries(DATAVIEW_SET_TYPES.map((m) => [m, 2])),
+};
+
 /**
  * Graceful member-body refusal: the value-read object (PR-A) does not need
  * member bodies, but if a reflective member closure is materialized for a member
@@ -574,6 +646,33 @@ function makeTypedArrayGlue(brand: number, name: string): NativeProtoBuiltinGlue
     memberCsv: TYPED_ARRAY_PROTO_METHODS.join(","),
     memberKind: (member) => (TYPED_ARRAY_PROTO_GETTERS.has(member) ? "getter" : "method"),
     memberLength: (member) => TYPED_ARRAY_PROTO_METHOD_LENGTH[member] ?? 1,
+    emitMemberBody: (c, fctx, member) => emitProtoMemberBodyRefusal(c, fctx, name, member),
+  };
+}
+
+/**
+ * (#2861) Generic glue factory for a ctor-prototype value object whose member
+ * set mixes data methods and accessor getters (ArrayBuffer / DataView / …).
+ * Differs from `makeGlue` only in marking the `getters` members as getters so
+ * the `.length` meta-fold reports 0 arity, and consulting a per-builtin length
+ * table. The proto OBJECT is a pure value object (member CSV + name;
+ * `emitLazyNativeProtoGet` never calls `emitMemberBody`); a reflective member
+ * CLOSURE read degrades to a catchable TypeError until a native body lands (the
+ * established #2193 / #2651 pattern).
+ */
+function makeGlueWithGetters(
+  brand: number,
+  name: string,
+  members: readonly string[],
+  getters: ReadonlySet<string>,
+  lengthTable: Readonly<Record<string, number>>,
+): NativeProtoBuiltinGlue {
+  return {
+    brand,
+    name,
+    memberCsv: members.join(","),
+    memberKind: (member) => (getters.has(member) ? "getter" : "method"),
+    memberLength: (member) => lengthTable[member] ?? 1,
     emitMemberBody: (c, fctx, member) => emitProtoMemberBodyRefusal(c, fctx, name, member),
   };
 }
@@ -733,6 +832,58 @@ export function ensureWeakSetNativeProtoGlue(ctx: CodegenContext): number | unde
   if (brand === undefined) return undefined;
   if (!getNativeProtoBuiltinGlue(ctx, brand)) {
     registerNativeProtoBuiltin(ctx, makeGlue(ctx, brand, "WeakSet", WEAKSET_PROTO_METHODS));
+  }
+  return brand;
+}
+
+/**
+ * (#2861) Register `ArrayBuffer.prototype` glue (idempotent) and return its
+ * brand. The ArrayBuffer brand is pre-reserved in `BUILTIN_BRAND_TABLE`; this
+ * fills in the member CSV (with the accessor getters marked) so a bare
+ * `ArrayBuffer.prototype` / `ArrayBuffer.prototype.<member>` value read resolves
+ * host-free instead of refusing. ArrayBuffer's proto value object carries no
+ * vec/runtime-state entanglement (the byte vec lives on the INSTANCE, never the
+ * proto), so the materialization is clean. Reflective member-CLOSURE bodies
+ * degrade to a catchable TypeError until native bodies land.
+ */
+export function ensureArrayBufferNativeProtoGlue(ctx: CodegenContext): number | undefined {
+  const brand = getBuiltinBrand(ctx, "ArrayBuffer");
+  if (brand === undefined) return undefined;
+  if (!getNativeProtoBuiltinGlue(ctx, brand)) {
+    registerNativeProtoBuiltin(
+      ctx,
+      makeGlueWithGetters(
+        brand,
+        "ArrayBuffer",
+        ARRAYBUFFER_PROTO_METHODS,
+        ARRAYBUFFER_PROTO_GETTERS,
+        ARRAYBUFFER_PROTO_METHOD_LENGTH,
+      ),
+    );
+  }
+  return brand;
+}
+
+/**
+ * (#2861) Register `DataView.prototype` glue (idempotent) and return its brand.
+ * Same shape as ArrayBuffer — the get/set accessors operate on the INSTANCE's
+ * viewed buffer, so the proto value object is pure (member CSV only). The three
+ * `buffer`/`byteLength`/`byteOffset` accessor getters fold their `.length` to 0.
+ */
+export function ensureDataViewNativeProtoGlue(ctx: CodegenContext): number | undefined {
+  const brand = getBuiltinBrand(ctx, "DataView");
+  if (brand === undefined) return undefined;
+  if (!getNativeProtoBuiltinGlue(ctx, brand)) {
+    registerNativeProtoBuiltin(
+      ctx,
+      makeGlueWithGetters(
+        brand,
+        "DataView",
+        DATAVIEW_PROTO_METHODS,
+        DATAVIEW_PROTO_GETTERS,
+        DATAVIEW_PROTO_METHOD_LENGTH,
+      ),
+    );
   }
   return brand;
 }

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -78,6 +78,8 @@ import {
   ensureBigIntNativeProtoGlue,
   ensureWeakMapNativeProtoGlue,
   ensureWeakSetNativeProtoGlue,
+  ensureArrayBufferNativeProtoGlue,
+  ensureDataViewNativeProtoGlue,
   ensureTypedArrayViewNativeProtoGlue,
 } from "./array-object-proto.js";
 import { isBuiltinSubtype, isBuiltinTypeName } from "./builtin-tags.js";
@@ -762,6 +764,17 @@ function tryEnsureNativeProtoBrand(ctx: CodegenContext, builtinName: string): nu
   }
   if (builtinName === "WeakSet") {
     return ensureWeakSetNativeProtoGlue(ctx);
+  }
+  // (#2861) ArrayBuffer / DataView protos — the single largest standalone-CE
+  // builtin cluster (ArrayBuffer 166, DataView 89). Their proto value objects
+  // carry no runtime-state entanglement (the byte vec lives on the INSTANCE,
+  // never the proto), so the `$NativeProto` materialization is clean. The
+  // accessor getters (`byteLength`/`buffer`/`byteOffset`/…) fold `.length` to 0.
+  if (builtinName === "ArrayBuffer") {
+    return ensureArrayBufferNativeProtoGlue(ctx);
+  }
+  if (builtinName === "DataView") {
+    return ensureDataViewNativeProtoGlue(ctx);
   }
   // (#2651 M1 / D2) Concrete TypedArray view protos — `Int8Array.prototype`,
   // `Uint8Array.prototype`, … This is the measured Slice-0 lever: the

--- a/tests/issue-2861-arraybuffer-dataview-proto-value-read.test.ts
+++ b/tests/issue-2861-arraybuffer-dataview-proto-value-read.test.ts
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #2861 — standalone `ArrayBuffer.prototype` / `DataView.prototype` value reads,
+// extending the native-proto-glue chain (#2376 Date, #2377 Error/Map/Set, #2378
+// Function/Symbol/BigInt/Weak, #2374 String/Number/Boolean, #2193 Array/Object,
+// #2651 TypedArray views, #2175 RegExp).
+//
+// Reading `ArrayBuffer.prototype.<member>` (or bare `ArrayBuffer.prototype`) AS A
+// VALUE — not invoking it — refused in standalone:
+//   "Codegen error: ArrayBuffer.prototype built-in static property value read is
+//    not supported in --target standalone (#1907 / #1888 S6-b)".
+// Root cause: tryEnsureNativeProtoBrand (property-access.ts) never wired the
+// ArrayBuffer / DataView $NativeProto glue, though both ctor brands are
+// pre-reserved in native-proto.ts. Fix: register native-proto glue for both
+// (array-object-proto.ts, with the accessor getters byteLength/buffer/byteOffset
+// marked so their `.length` meta folds to 0) and wire into
+// tryEnsureNativeProtoBrand. Both protos carry no vec/runtime brand entanglement
+// — the byte vec lives on the INSTANCE, never the proto — so the value-object
+// materialization is clean (member bodies degrade to a catchable TypeError until
+// native bodies land, the #2193/#2651 pattern).
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  expect((r.imports ?? []).map((i) => i.name)).toEqual([]);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2861 — standalone ArrayBuffer.prototype value reads", () => {
+  it("ArrayBuffer.prototype reads to a truthy value (was a compile refusal)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const p: any = ArrayBuffer.prototype; return p ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("ArrayBuffer.prototype.slice value read compiles (was a hard compile refusal)", async () => {
+    const r = await compile(
+      `export function test(): number { const m: any = ArrayBuffer.prototype.slice; return 1; }`,
+      { target: "standalone" },
+    );
+    expect(r.success, JSON.stringify(r.errors)).toBe(true);
+    expect((r.imports ?? []).map((i) => i.name)).toEqual([]);
+  });
+
+  it("ArrayBuffer.prototype.slice.length folds the spec arity (2)", async () => {
+    expect(await runStandalone(`export function test(): number { return ArrayBuffer.prototype.slice.length; }`)).toBe(
+      2,
+    );
+  });
+
+  it("ArrayBuffer.prototype.resize.length folds the spec arity (1)", async () => {
+    expect(await runStandalone(`export function test(): number { return ArrayBuffer.prototype.resize.length; }`)).toBe(
+      1,
+    );
+  });
+
+  it("ArrayBuffer.prototype.byteLength is an accessor getter — .length folds to 0", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { return (ArrayBuffer.prototype as any).byteLength.length; }`,
+      ),
+    ).toBe(0);
+  });
+
+  it("ArrayBuffer.prototype === ArrayBuffer.prototype (reference identity, single global)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { return ArrayBuffer.prototype === ArrayBuffer.prototype ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+});
+
+describe("#2861 — standalone DataView.prototype value reads", () => {
+  it("DataView.prototype reads to a truthy value (was a compile refusal)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const p: any = DataView.prototype; return p ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("DataView.prototype.getInt8 value read compiles (was a hard compile refusal)", async () => {
+    const r = await compile(`export function test(): number { const m: any = DataView.prototype.getInt8; return 1; }`, {
+      target: "standalone",
+    });
+    expect(r.success, JSON.stringify(r.errors)).toBe(true);
+    expect((r.imports ?? []).map((i) => i.name)).toEqual([]);
+  });
+
+  it("DataView.prototype.getInt8.length folds the spec arity (1)", async () => {
+    expect(await runStandalone(`export function test(): number { return DataView.prototype.getInt8.length; }`)).toBe(1);
+  });
+
+  it("DataView.prototype.setFloat64.length folds the spec arity (2)", async () => {
+    expect(await runStandalone(`export function test(): number { return DataView.prototype.setFloat64.length; }`)).toBe(
+      2,
+    );
+  });
+
+  it("DataView.prototype.byteLength is an accessor getter — .length folds to 0", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return (DataView.prototype as any).byteLength.length; }`),
+    ).toBe(0);
+  });
+
+  it("DataView.prototype.buffer is an accessor getter — .length folds to 0", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return (DataView.prototype as any).buffer.length; }`),
+    ).toBe(0);
+  });
+});
+
+describe("#2861 — no regression on instance use / sibling proto glue", () => {
+  it("instance ArrayBuffer.byteLength still works", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const b = new ArrayBuffer(16); return b.byteLength; }`),
+    ).toBe(16);
+  });
+
+  it("instance DataView round-trips through getInt32/setInt32", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const b = new ArrayBuffer(8);
+          const dv = new DataView(b);
+          dv.setInt32(0, 12345);
+          return dv.getInt32(0);
+        }
+      `),
+    ).toBe(12345);
+  });
+
+  it("sibling: TypedArray view proto value read (the #2651 path) still resolves", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const p: any = Int8Array.prototype; return p ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("sibling: Date.prototype value read (the #2376 path) still resolves", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const p: any = Date.prototype; return p ? 1 : 0; }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2861 slice: ArrayBuffer + DataView (255 standalone-CE tests)

Wires **ArrayBuffer** and **DataView** into `tryEnsureNativeProtoBrand` so a
`<Builtin>.prototype` / `.prototype.<member>` **value read** (not a call)
resolves to a `$NativeProto` value object **host-free** under `--target standalone`,
instead of the hard refusal:

```
Codegen error: ArrayBuffer.prototype built-in static property value read is not
supported in --target standalone (#1907 / #1888 S6-b).
```

This is the top of the single largest standalone compile-error cluster
(umbrella #2861 / #2860): ArrayBuffer 166 + DataView 89 tests, all host-pass /
standalone-CE.

### Changes
- **`src/codegen/array-object-proto.ts`**: `ARRAYBUFFER_PROTO_METHODS` /
  `DATAVIEW_PROTO_METHODS` member lists + accessor-getter sets
  (`byteLength`/`maxByteLength`/`detached`/`resizable` for ArrayBuffer;
  `buffer`/`byteLength`/`byteOffset` for DataView) + spec-arity tables, a generic
  `makeGlueWithGetters` factory (getter members fold `.length` to 0), and
  `ensure{ArrayBuffer,DataView}NativeProtoGlue`.
- **`src/codegen/property-access.ts`**: two builtin-name arms in
  `tryEnsureNativeProtoBrand` + the import.

### Why it's safe
Both protos carry **no vec/runtime-state entanglement** — the byte vec lives on
the **instance**, never the proto — so the value-object materialization is clean
(unlike the TypedArray init-trap caution in #2375). Member-CLOSURE bodies degrade
to a **catchable TypeError** until native bodies land (the established
#2193/#2651 pattern); the value-read object + `.length`/`.name` meta folds only
need the member set. The change is **purely additive and `ctx.standalone`-gated**
→ host-mode output is byte-identical.

### Verify-first
On current main, `ArrayBuffer.prototype` and `DataView.prototype` value reads
both CE with the exact refusal message. After this PR they compile to a valid
host-import-free module with correct `.length` folds. Confirmed identical
behavior to the already-wired Date (#2376) and TypedArray (#2651) glue.

### Tests
`tests/issue-2861-arraybuffer-dataview-proto-value-read.test.ts` — 16 tests:
value reads compile + materialize, method/getter `.length` folds, reference
identity, no host-import leak, and no regression on instance `new ArrayBuffer` /
`new DataView` round-trips or sibling proto glue.

> Note: this PR intentionally does **not** add the `plan/issues/2861-*.md` file
> (it lands via arch-standalone-gap's umbrella PR). One of several per-builtin
> slices of #2861.

🤖 Generated with [Claude Code](https://claude.com/claude-code)