### PR TITLE
feat(#2861): native-proto glue for standalone SharedArrayBuffer/WeakRef/FinalizationRegistry.prototype value reads

### DIFF
--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -445,6 +445,13 @@ const PROTO_METHOD_LENGTH: Readonly<Record<string, number>> = {
   // toString/valueOf/… default to 0 or 1; the value-read OBJECT does not depend
   // on exact arities, only the member set.
   toJSON: 1,
+  // WeakRef.prototype.deref (ES2024 §26.1.3.2) is 0-arity; FinalizationRegistry.
+  // prototype.register (§26.2.3.1) is arity 2, unregister (§26.2.3.2) arity 1.
+  // These names don't collide with other builtins, so they live in the shared
+  // table safely.
+  deref: 0,
+  register: 2,
+  unregister: 1,
 };
 
 // ── ArrayBuffer.prototype (ES2024 §25.1.5) ────────────────────────────────────
@@ -518,6 +525,24 @@ const DATAVIEW_PROTO_METHOD_LENGTH: Readonly<Record<string, number>> = {
   ...Object.fromEntries(DATAVIEW_GET_TYPES.map((m) => [m, 1])),
   ...Object.fromEntries(DATAVIEW_SET_TYPES.map((m) => [m, 2])),
 };
+
+// ── SharedArrayBuffer.prototype (ES2024 §25.2.5) ──────────────────────────────
+// Mirrors ArrayBuffer's shape: `slice`/`grow` methods + `byteLength`/
+// `maxByteLength`/`growable` accessor getters (getters fold `.length` to 0).
+const SHAREDARRAYBUFFER_PROTO_METHODS = ["slice", "grow", "byteLength", "maxByteLength", "growable"] as const;
+const SHAREDARRAYBUFFER_PROTO_GETTERS: ReadonlySet<string> = new Set(["byteLength", "maxByteLength", "growable"]);
+const SHAREDARRAYBUFFER_PROTO_METHOD_LENGTH: Readonly<Record<string, number>> = {
+  slice: 2,
+  grow: 1,
+};
+
+// ── WeakRef.prototype (ES2024 §26.1.3) ── single `deref` method (0-arity). ────
+const WEAKREF_PROTO_METHODS = ["deref"] as const;
+
+// ── FinalizationRegistry.prototype (ES2024 §26.2.3) ───────────────────────────
+// `register` (arity 2) + `unregister` (arity 1). Arities live in the shared
+// PROTO_METHOD_LENGTH table (no cross-builtin collision).
+const FINALIZATIONREGISTRY_PROTO_METHODS = ["register", "unregister"] as const;
 
 /**
  * Graceful member-body refusal: the value-read object (PR-A) does not need
@@ -884,6 +909,56 @@ export function ensureDataViewNativeProtoGlue(ctx: CodegenContext): number | und
         DATAVIEW_PROTO_METHOD_LENGTH,
       ),
     );
+  }
+  return brand;
+}
+
+/**
+ * (#2861) Register `SharedArrayBuffer.prototype` glue (idempotent). Same clean
+ * value-object shape as ArrayBuffer (the shared byte vec lives on the instance).
+ */
+export function ensureSharedArrayBufferNativeProtoGlue(ctx: CodegenContext): number | undefined {
+  const brand = getBuiltinBrand(ctx, "SharedArrayBuffer");
+  if (brand === undefined) return undefined;
+  if (!getNativeProtoBuiltinGlue(ctx, brand)) {
+    registerNativeProtoBuiltin(
+      ctx,
+      makeGlueWithGetters(
+        brand,
+        "SharedArrayBuffer",
+        SHAREDARRAYBUFFER_PROTO_METHODS,
+        SHAREDARRAYBUFFER_PROTO_GETTERS,
+        SHAREDARRAYBUFFER_PROTO_METHOD_LENGTH,
+      ),
+    );
+  }
+  return brand;
+}
+
+/**
+ * (#2861) Register `WeakRef.prototype` glue (idempotent). Single `deref` method;
+ * no accessor getters — plain `makeGlue`. The held value lives on the instance,
+ * so the proto value object is pure.
+ */
+export function ensureWeakRefNativeProtoGlue(ctx: CodegenContext): number | undefined {
+  const brand = getBuiltinBrand(ctx, "WeakRef");
+  if (brand === undefined) return undefined;
+  if (!getNativeProtoBuiltinGlue(ctx, brand)) {
+    registerNativeProtoBuiltin(ctx, makeGlue(ctx, brand, "WeakRef", WEAKREF_PROTO_METHODS));
+  }
+  return brand;
+}
+
+/**
+ * (#2861) Register `FinalizationRegistry.prototype` glue (idempotent). The
+ * FinalizationRegistry brand is newly appended to `BUILTIN_BRAND_TABLE` (slot 40).
+ * `register`/`unregister` methods; no getters — plain `makeGlue`.
+ */
+export function ensureFinalizationRegistryNativeProtoGlue(ctx: CodegenContext): number | undefined {
+  const brand = getBuiltinBrand(ctx, "FinalizationRegistry");
+  if (brand === undefined) return undefined;
+  if (!getNativeProtoBuiltinGlue(ctx, brand)) {
+    registerNativeProtoBuiltin(ctx, makeGlue(ctx, brand, "FinalizationRegistry", FINALIZATIONREGISTRY_PROTO_METHODS));
   }
   return brand;
 }

--- a/src/codegen/native-proto.ts
+++ b/src/codegen/native-proto.ts
@@ -122,7 +122,10 @@ const BUILTIN_BRAND_TABLE: Readonly<Record<string, number>> = {
   EvalError: BUILTIN_BRAND_BASE + 38,
   ReferenceError: BUILTIN_BRAND_BASE + 39,
 
-  // Next free slot: BUILTIN_BRAND_BASE + 40 (append only).
+  // ── Resource-management / weak builtins ──────────────────────────────────
+  FinalizationRegistry: BUILTIN_BRAND_BASE + 40,
+
+  // Next free slot: BUILTIN_BRAND_BASE + 41 (append only).
 };
 
 /**

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -80,6 +80,9 @@ import {
   ensureWeakSetNativeProtoGlue,
   ensureArrayBufferNativeProtoGlue,
   ensureDataViewNativeProtoGlue,
+  ensureSharedArrayBufferNativeProtoGlue,
+  ensureWeakRefNativeProtoGlue,
+  ensureFinalizationRegistryNativeProtoGlue,
   ensureTypedArrayViewNativeProtoGlue,
 } from "./array-object-proto.js";
 import { isBuiltinSubtype, isBuiltinTypeName } from "./builtin-tags.js";
@@ -775,6 +778,18 @@ function tryEnsureNativeProtoBrand(ctx: CodegenContext, builtinName: string): nu
   }
   if (builtinName === "DataView") {
     return ensureDataViewNativeProtoGlue(ctx);
+  }
+  // (#2861) SharedArrayBuffer mirrors ArrayBuffer's clean value-object shape;
+  // WeakRef / FinalizationRegistry are plain-method protos (held value / cells
+  // live on the instance, never the proto).
+  if (builtinName === "SharedArrayBuffer") {
+    return ensureSharedArrayBufferNativeProtoGlue(ctx);
+  }
+  if (builtinName === "WeakRef") {
+    return ensureWeakRefNativeProtoGlue(ctx);
+  }
+  if (builtinName === "FinalizationRegistry") {
+    return ensureFinalizationRegistryNativeProtoGlue(ctx);
   }
   // (#2651 M1 / D2) Concrete TypedArray view protos — `Int8Array.prototype`,
   // `Uint8Array.prototype`, … This is the measured Slice-0 lever: the

--- a/tests/issue-2861-sab-weakref-finreg-proto-value-read.test.ts
+++ b/tests/issue-2861-sab-weakref-finreg-proto-value-read.test.ts
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #2861 (slice 2) — standalone `SharedArrayBuffer.prototype` / `WeakRef.prototype`
+// / `FinalizationRegistry.prototype` value reads, extending the ArrayBuffer +
+// DataView slice and the native-proto-glue chain (#2376 Date, #2651 TypedArray,
+// #2374 String/Number/Boolean, #2193 Array/Object, #2175 RegExp).
+//
+// Reading `<Builtin>.prototype.<member>` (or bare `<Builtin>.prototype`) AS A
+// VALUE refused in standalone with the "built-in static property value read is
+// not supported in --target standalone (#1907 / #1888 S6-b)" compile error.
+// Fix: register native-proto glue for SharedArrayBuffer (mirrors ArrayBuffer's
+// getter shape), WeakRef (single `deref` method) and FinalizationRegistry
+// (`register`/`unregister`; brand newly appended to native-proto.ts slot 40),
+// and wire them into tryEnsureNativeProtoBrand. All three carry their state on
+// the INSTANCE (held value / shared byte vec / registry cells), never the proto,
+// so the value-object materialization is clean. Member-CLOSURE bodies degrade to
+// a catchable TypeError until native bodies land (the #2193/#2651 pattern).
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  expect((r.imports ?? []).map((i) => i.name)).toEqual([]);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2861 slice 2 — standalone SharedArrayBuffer.prototype value reads", () => {
+  it("SharedArrayBuffer.prototype reads to a truthy value (was a compile refusal)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const p: any = SharedArrayBuffer.prototype; return p ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("SharedArrayBuffer.prototype.slice.length folds the spec arity (2)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return SharedArrayBuffer.prototype.slice.length; }`),
+    ).toBe(2);
+  });
+
+  it("SharedArrayBuffer.prototype.grow.length folds the spec arity (1)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return SharedArrayBuffer.prototype.grow.length; }`),
+    ).toBe(1);
+  });
+
+  it("SharedArrayBuffer.prototype.byteLength is an accessor getter — .length folds to 0", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { return (SharedArrayBuffer.prototype as any).byteLength.length; }`,
+      ),
+    ).toBe(0);
+  });
+});
+
+describe("#2861 slice 2 — standalone WeakRef.prototype value reads", () => {
+  it("WeakRef.prototype reads to a truthy value (was a compile refusal)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const p: any = WeakRef.prototype; return p ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("WeakRef.prototype.deref value read compiles (was a hard compile refusal)", async () => {
+    const r = await compile(`export function test(): number { const m: any = WeakRef.prototype.deref; return 1; }`, {
+      target: "standalone",
+    });
+    expect(r.success, JSON.stringify(r.errors)).toBe(true);
+    expect((r.imports ?? []).map((i) => i.name)).toEqual([]);
+  });
+
+  it("WeakRef.prototype.deref.length folds the spec arity (0)", async () => {
+    expect(await runStandalone(`export function test(): number { return WeakRef.prototype.deref.length; }`)).toBe(0);
+  });
+});
+
+describe("#2861 slice 2 — standalone FinalizationRegistry.prototype value reads", () => {
+  it("FinalizationRegistry.prototype reads to a truthy value (was a compile refusal)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const p: any = FinalizationRegistry.prototype; return p ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("FinalizationRegistry.prototype.register.length folds the spec arity (2)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return FinalizationRegistry.prototype.register.length; }`),
+    ).toBe(2);
+  });
+
+  it("FinalizationRegistry.prototype.unregister.length folds the spec arity (1)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { return FinalizationRegistry.prototype.unregister.length; }`,
+      ),
+    ).toBe(1);
+  });
+});
+
+describe("#2861 slice 2 — no regression on sibling proto glue", () => {
+  it("sibling: ArrayBuffer.prototype value read (the #2861 slice-1 path) still resolves", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const p: any = ArrayBuffer.prototype; return p ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("sibling: WeakSet.prototype value read still resolves", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const p: any = WeakSet.prototype; return p ? 1 : 0; }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2861 slice 2: SharedArrayBuffer + WeakRef + FinalizationRegistry (~50 standalone-CE tests)

Follows the merged ArrayBuffer+DataView slice (#2340). Wires three more ctor
prototypes into `tryEnsureNativeProtoBrand` so a `<Builtin>.prototype` /
`.prototype.<member>` **value read** resolves to a `$NativeProto` value object
**host-free** under `--target standalone`, instead of the hard refusal:

```
Codegen error: SharedArrayBuffer.prototype built-in static property value read is
not supported in --target standalone (#1907 / #1888 S6-b).
```

### Changes
- **`src/codegen/native-proto.ts`**: append the `FinalizationRegistry` brand
  (slot 40, append-only). SharedArrayBuffer (slot 16) / WeakRef (slot 29) brands
  were already reserved.
- **`src/codegen/array-object-proto.ts`**: `SharedArrayBuffer` reuses the
  `makeGlueWithGetters` factory (`slice`/`grow` methods + `byteLength`/
  `maxByteLength`/`growable` accessor getters, which fold `.length` to 0);
  `WeakRef` (`deref`) and `FinalizationRegistry` (`register`/`unregister`) use
  plain `makeGlue`. Arities for `deref`/`register`/`unregister` added to the
  shared `PROTO_METHOD_LENGTH` table (no cross-builtin collision).
- **`src/codegen/property-access.ts`**: three builtin-name arms + imports.

### Why it's safe
All three carry their state on the **instance** (held value / shared byte vec /
registry cells), never the proto, so the value-object materialization is clean.
Member-CLOSURE bodies degrade to a **catchable TypeError** until native bodies
land (the #2193/#2651 pattern). Purely additive + `ctx.standalone`-gated → host
mode byte-identical.

### Verify-first
On pre-#2340 main, all three protos CE'd with the exact refusal. After this PR
they compile to a valid host-import-free module with correct `.length` folds.

### Tests
`tests/issue-2861-sab-weakref-finreg-proto-value-read.test.ts` — 12 tests: value
reads compile + materialize, method/getter `.length` folds, no host-import leak,
no regression on sibling proto glue.

> Does not add `plan/issues/2861-*.md` (lands via the umbrella PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)