### PR TITLE
docs(#2860): file de-masked standalone clusters #2872-#2877

### DIFF
--- a/plan/issues/2872-standalone-typedarray-prototype-cluster.md
+++ b/plan/issues/2872-standalone-typedarray-prototype-cluster.md
@@ -1,0 +1,48 @@
+---
+id: 2872
+title: "Standalone: TypedArray.prototype.* cluster (294 host-pass/standalone-fail, de-masked from #2862)"
+status: ready
+created: 2026-06-30
+priority: high
+task_type: bug
+area: codegen
+goal: standalone
+sprint: current
+horizon: l
+related: [2860, 2870, 2862, 2651]
+umbrella: 2860
+---
+
+# Standalone: TypedArray.prototype.\* failures (de-masked)
+
+## Problem
+
+The single largest concrete standalone cluster surfaced by the #2870 de-mask:
+~**294** `built-ins/TypedArray/prototype/**` tests are host-pass but
+standalone-fail (previously mis-recorded under the phantom "Cannot convert object
+to primitive value" signature, #2862). Plus ~39 `TypedArrayConstructors/**`.
+
+## Representative repros
+
+- `test/built-ins/TypedArray/prototype/fill/length.js` — `verifyProperty`
+  /`propertyHelper` over `%TypedArray%.prototype.fill` (arity/name + descriptor).
+- `test/built-ins/TypedArray/prototype/toLocaleString/prop-desc.js`.
+
+These hit `propertyHelper.js`/`verifyProperty` reflective descriptor reads over
+TypedArray prototype members and throw a Wasm exception in standalone.
+
+## Root cause (to triage)
+
+Likely a mix of: (a) `%TypedArray%.prototype` member descriptor reflection not
+materialised standalone (overlaps the native-proto glue work #2651/#2861), and
+(b) `ToIndex`/`ToNumber` coercion of object args (`fill(value,start,end)` with
+object bounds). Triage per sub-path with `runTest262File(file,cat,undefined,"standalone")`,
+group by the exact assertion that throws.
+
+## Test plan
+
+`test/built-ins/TypedArray/prototype/**` standalone fail → pass; full
+`merge_group` + standalone high-water. `ctx.standalone` only.
+
+(Large — split into sub-tasks per failing member family if the root causes
+diverge.)

--- a/plan/issues/2873-standalone-language-expressions-cluster.md
+++ b/plan/issues/2873-standalone-language-expressions-cluster.md
@@ -1,0 +1,36 @@
+---
+id: 2873
+title: "Standalone: language/expressions cluster (276 host-pass/standalone-fail, de-masked from #2862)"
+status: ready
+created: 2026-06-30
+priority: high
+task_type: bug
+area: codegen
+goal: standalone
+sprint: current
+horizon: l
+related: [2860, 2870, 2862]
+umbrella: 2860
+---
+
+# Standalone: language/expressions failures (de-masked)
+
+## Problem
+
+~**276** `test/language/expressions/**` tests are host-pass but standalone-fail,
+de-masked by #2870 from the phantom ToPrimitive signature (#2862). Plus ~108
+`language/statements/**` and ~57 `language/function-code/**` in the same surface.
+
+## Triage needed
+
+This is a broad bucket — expression-level coercions/operators that throw a Wasm
+exception standalone. Likely sub-clusters: object→primitive in operators
+(`+`/`==`/relational), `ToPropertyKey` in member access, default-value/`ToNumber`
+coercions. Triage with `runTest262File(file, cat, undefined, "standalone")`,
+cluster by the operator/feature directory under `language/expressions/`, and
+split into focused sub-tasks.
+
+## Test plan
+
+Per sub-cluster: standalone fail → pass, verify-first, full `merge_group` +
+standalone high-water. `ctx.standalone` only.

--- a/plan/issues/2874-standalone-getownpropertydescriptor-numeric-key-coercion.md
+++ b/plan/issues/2874-standalone-getownpropertydescriptor-numeric-key-coercion.md
@@ -1,0 +1,70 @@
+---
+id: 2874
+title: "Standalone: Object.getOwnPropertyDescriptor (and defineProperty) numeric/object property-key → string coercion drops the lookup"
+status: ready
+created: 2026-06-30
+priority: high
+task_type: bug
+area: codegen
+goal: standalone
+sprint: current
+horizon: m
+related: [2860, 2870, 2862]
+umbrella: 2860
+---
+
+# Standalone: property-key coercion in Object.getOwnPropertyDescriptor / defineProperty
+
+## Problem
+
+In `--target standalone`, `Object.getOwnPropertyDescriptor(obj, key)` (and the
+`defineProperty` / `create` / `defineProperties` family) fail to find a property
+when the **key is not already a native string** — a number, `+Infinity`, an
+object with a `toString`, etc. The §7.1.19 `ToPropertyKey`/`ToString` coercion on
+the key is not applied (or applied differently) on the standalone path, so the
+lookup misses, returns `undefined`, and the test then null-derefs on
+`desc.value` → throws.
+
+This cluster was previously **masked** by the exception-formatter bug (#2870);
+de-masking surfaced it as a concrete, isolated standalone gap.
+
+### Impact (host-pass / standalone-fail, measured 2026-06-30)
+
+~**164** `built-ins/Object/getOwnPropertyDescriptor/**`, plus large adjacent
+counts in the same key-coercion family:
+`Object/defineProperty` 93, `Object/create` 97, `Object/defineProperties` 69.
+
+## Representative repro
+
+```js
+// test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-14.js
+var obj = { Infinity: 1 };
+var desc = Object.getOwnPropertyDescriptor(obj, +Infinity); // key +Infinity → "Infinity"
+assert.sameValue(desc.value, 1); // standalone: desc is undefined → throws
+```
+
+Host mode passes; standalone throws (a Wasm exception, recorded post-#2870 as
+`uncaught Wasm-GC exception`).
+
+## Root cause (to confirm)
+
+The standalone lowering of `Object.getOwnPropertyDescriptor` / `defineProperty`
+passes the key argument to the native `$Object` lookup without the
+`ToPropertyKey` → `ToString` coercion that host mode applies (number → its string
+form, e.g. `+Infinity` → `"Infinity"`, `0` → `"0"`). Inspect the standalone
+descriptor/define lowering in `src/codegen/` (grep
+`getOwnPropertyDescriptor`/`defineProperty`/`__obj_define`/`__obj_get_descriptor`)
+and route the key through the native number→string (`__num_to_string`) / general
+`ToPropertyKey` path before the `$Object` probe.
+
+## Test plan
+
+Standalone fail/CE → pass:
+
+- `test/built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-*.js`,
+  `15.2.3.3-4-*.js`
+- `test/built-ins/Object/defineProperty/15.2.3.6-3-*.js`
+- `test/built-ins/Object/{create,defineProperties}/**` (shared coercion)
+
+Verify-first with `runTest262File(file, cat, undefined, "standalone")`. Full
+`merge_group` + standalone high-water. Pure correctness — `ctx.standalone` only.

--- a/plan/issues/2874-standalone-getownpropertydescriptor-numeric-key-coercion.md
+++ b/plan/issues/2874-standalone-getownpropertydescriptor-numeric-key-coercion.md
@@ -1,6 +1,6 @@
 ---
 id: 2874
-title: "Standalone: Object.getOwnPropertyDescriptor (and defineProperty) numeric/object property-key → string coercion drops the lookup"
+title: "Standalone: Object.getOwnPropertyDescriptor on a statically-typed receiver leaks the host import __create_descriptor (no native fallback)"
 status: ready
 created: 2026-06-30
 priority: high
@@ -46,16 +46,48 @@ assert.sameValue(desc.value, 1); // standalone: desc is undefined → throws
 Host mode passes; standalone throws (a Wasm exception, recorded post-#2870 as
 `uncaught Wasm-GC exception`).
 
-## Root cause (to confirm)
+## Root cause (CONFIRMED via verify-first — NOT key coercion)
 
-The standalone lowering of `Object.getOwnPropertyDescriptor` / `defineProperty`
-passes the key argument to the native `$Object` lookup without the
-`ToPropertyKey` → `ToString` coercion that host mode applies (number → its string
-form, e.g. `+Infinity` → `"Infinity"`, `0` → `"0"`). Inspect the standalone
-descriptor/define lowering in `src/codegen/` (grep
-`getOwnPropertyDescriptor`/`defineProperty`/`__obj_define`/`__obj_get_descriptor`)
-and route the key through the native number→string (`__num_to_string`) / general
-`ToPropertyKey` path before the `$Object` probe.
+The original key-coercion hypothesis was **disproved**. Bisection (wrapTest +
+`compile({target:"standalone"})`):
+
+- `Object.getOwnPropertyDescriptor({…}, key)` on an **inline object literal** or
+  an **`any`-typed** receiver → native path, **no host import, works** (the key
+  form — `+Infinity`, `0`, `"a"` — does NOT matter).
+- `var o = {…}; Object.getOwnPropertyDescriptor(o, key)` where `o` has a
+  **statically-typed structural/nominal object type** → emits the **host import
+  `env::__create_descriptor`**, which has **no standalone native fallback**, so
+  the standalone module throws/traps. (Confirmed: the typed-receiver case lists
+  `imports: __create_descriptor`; the `any` case lists `imports: none` and
+  returns the right value.)
+
+The throw is therefore a **host-import leak on the typed-receiver fast path**,
+not a key coercion. The real test `15.2.3.3-2-14.js` fails because the harness
+writes `var obj = {…}` (inferred structural type), not because of `+Infinity`.
+
+### Exact site
+
+`src/codegen/expressions/calls.ts:6652` — the
+`Object.getOwnPropertyDescriptor` "fast path: known struct type + string literal
+prop" inlines `struct.get` + a call to the host import `__create_descriptor`
+(also at `:6808` for the field-value path). `__create_descriptor(value, flags)`
+is host-only (`src/runtime.ts:10032`): it builds
+`{value, writable:!!(flags&1), enumerable:!!(flags&2), configurable:!!(flags&4)}`.
+
+### Fix direction
+
+Provide a **standalone-native `__create_descriptor`** (register it in
+`src/codegen/object-runtime.ts` like the existing native
+`__getOwnPropertyDescriptor` at :5149): build a fresh 4-key `$Object`
+(`value` = the externref value; `writable`/`enumerable`/`configurable` = boxed
+booleans decoded from the `flags` bits). Then the typed-receiver fast path
+resolves natively under `--target standalone` instead of leaking a host import.
+Alternatively, under `ctx.standalone` route the typed fast path through the
+existing native descriptor builder. Either way — additive, `ctx.standalone`-gated.
+
+Note: this also unblocks the adjacent `defineProperty`/`create`/`defineProperties`
+counts insofar as they share the typed-receiver descriptor-construction path
+(verify each).
 
 ## Test plan
 

--- a/plan/issues/2875-standalone-string-prototype-cluster.md
+++ b/plan/issues/2875-standalone-string-prototype-cluster.md
@@ -1,0 +1,36 @@
+---
+id: 2875
+title: "Standalone: String.prototype.* cluster (159 host-pass/standalone-fail, de-masked from #2862)"
+status: ready
+created: 2026-06-30
+priority: high
+task_type: bug
+area: codegen
+goal: standalone
+sprint: current
+horizon: m
+related: [2860, 2870, 2862]
+umbrella: 2860
+---
+
+# Standalone: String.prototype.\* failures (de-masked)
+
+## Problem
+
+~**159** `built-ins/String/prototype/**` (plus ~25 `built-ins/String/**`) tests
+are host-pass but standalone-fail, de-masked by #2870 from the phantom
+ToPrimitive signature (#2862).
+
+## Triage needed
+
+Likely sub-clusters: (a) `this`/argument `ToString`/`ToPrimitive` coercion of
+object args in String prototype methods, (b) reflective descriptor reads over
+`String.prototype` members (overlaps native-proto glue), (c) RegExp-arg methods
+(`split`/`replace`/`match`) routing through `__str_flatten` (overlaps the
+invalid-Wasm #2868 carrier). Triage with
+`runTest262File(file, cat, undefined, "standalone")`, group by method.
+
+## Test plan
+
+Per sub-cluster: standalone fail → pass, verify-first, full `merge_group` +
+standalone high-water. `ctx.standalone` only.

--- a/plan/issues/2876-standalone-regexp-cluster.md
+++ b/plan/issues/2876-standalone-regexp-cluster.md
@@ -1,0 +1,45 @@
+---
+id: 2876
+title: "Standalone: RegExp cluster (125 host-pass/standalone-fail, de-masked from #2862)"
+status: ready
+created: 2026-06-30
+priority: high
+task_type: bug
+area: codegen
+goal: standalone
+sprint: current
+horizon: m
+related: [2860, 2870, 2862, 682]
+umbrella: 2860
+---
+
+# Standalone: RegExp.\* failures (de-masked)
+
+## Problem
+
+~**125** `built-ins/RegExp/**` tests are host-pass but standalone-fail, de-masked
+by #2870 from the phantom ToPrimitive signature (#2862).
+
+## Representative repro
+
+```js
+// test/built-ins/RegExp/prototype/global/this-val-regexp-prototype.js
+var get = Object.getOwnPropertyDescriptor(RegExp.prototype, "global").get;
+assert.sameValue(get.call(RegExp.prototype), undefined);
+```
+
+`getOwnPropertyDescriptor(RegExp.prototype, 'global').get` → getter-reflection on
+`RegExp.prototype` accessor members; standalone throws a Wasm exception.
+
+## Root cause (to triage)
+
+Standalone RegExp reflection (`.source`/`.flags`/`.global`/`.sticky`/… getters)
+over `RegExp.prototype` is the established #1914 surface; the accessor-descriptor
+`.get` reflection + brand-checked invocation on the prototype object is not fully
+materialised standalone. Overlaps the dual RegExp backend (#682) and native-proto
+glue. Triage with `runTest262File(file, cat, undefined, "standalone")`.
+
+## Test plan
+
+Standalone fail → pass, verify-first, full `merge_group` + standalone high-water.
+`ctx.standalone` only.

--- a/plan/issues/2877-standalone-exception-no-readable-message.md
+++ b/plan/issues/2877-standalone-exception-no-readable-message.md
@@ -1,0 +1,55 @@
+---
+id: 2877
+title: "Standalone exceptions expose no JS-readable message (__sget_message returns null) — blocks message-level triage"
+status: ready
+created: 2026-06-30
+priority: medium
+task_type: enhancement
+area: tooling
+goal: standalone
+sprint: current
+horizon: s
+related: [2870, 2862, 2860]
+umbrella: 2860
+---
+
+# Standalone exceptions expose no JS-readable message
+
+## Problem
+
+A `--target standalone` module throws a Wasm-GC error struct as the exception
+payload. From the JS test harness the payload is opaque: `String(payload)` throws
+(fixed in #2870 by guarding it), and the obvious accessor
+`instance.exports.__sget_message(payload)` returns **null** for the thrown
+payloads sampled in #2870's de-mask. So the harness cannot recover the REAL
+per-test failure message — the #2870 de-mask falls back to a stable label
+(`uncaught Wasm-GC exception (non-stringifiable payload)`).
+
+### Why it matters
+
+Without a readable message, standalone-gap triage can only cluster by **test
+path/feature**, not by the actual error (`x is not a function`, a specific
+TypeError text, a trap reason). A readable message would let triage group the
+~2,014 de-masked failures (#2870) by real signature and pinpoint shared root
+causes far faster.
+
+## Investigation / fix sketch
+
+1. Determine what the standalone throw payload actually is for these cases
+   (a `__new_TypeError` struct with a null message field? a non-error value? the
+   null/undefined access sentinel?). `__sget_message` returning null suggests
+   either the message field is unset at throw time or the payload is not the
+   error struct `__sget_message` expects.
+2. Either (a) ensure native error constructors populate a readable `message`
+   field reachable via an exported accessor, or (b) export a dedicated
+   `__exn_message(payload) -> externref(nativeString)` helper the harness can
+   call (returning the flattened message or a class label), and wire
+   `extractWasmExceptionMessage` (both `tests/test262-runner.ts` and
+   `scripts/test262-worker.mjs`) to prefer it over the #2870 stable fallback.
+
+## Acceptance
+
+The harness records the real error message (or a precise class label) for a
+standalone-thrown exception instead of the generic #2870 fallback, with zero
+pass/fail movement (tooling-only). Enables message-level re-triage of #2862's
+de-masked clusters.


### PR DESCRIPTION
Re-files the #2862 phantom-signature collapse into concrete, claimable clusters surfaced by the #2870 de-mask (host-pass / standalone-fail). One issue per real cluster with feature path + representative repro:

- **#2872** TypedArray/prototype (294) — `horizon: l`
- **#2873** language/expressions (276) — `horizon: l`
- **#2874** Object.getOwnPropertyDescriptor numeric/object key coercion (164) — `horizon: m` (e.g. `getOwnPropertyDescriptor(obj, +Infinity)` → key `"Infinity"`)
- **#2875** String/prototype (159) — `horizon: m`
- **#2876** RegExp (125) — `horizon: m`
- **#2877** (tooling follow-up) standalone exceptions expose no readable message (`__sget_message` returns null) — blocks message-level triage

All `sprint: current`, `status: ready` so the self-serving devs can claim them. #2862 stays blocked, superseded by these. I'm taking #2874 next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)