### PR TITLE
feat(#2863): native standalone .toLocaleString() (Phase 2 — Array/TypedArray/dynamic receivers)

### DIFF
--- a/plan/issues/2863-standalone-dynamic-shape-get-builtin.md
+++ b/plan/issues/2863-standalone-dynamic-shape-get-builtin.md
@@ -94,3 +94,23 @@ Standalone CE → pass:
 
 Full `merge_group` + standalone high-water; zero host-mode regression
 (`ctx.standalone`-gated).
+
+## Progress (2026-06-30)
+
+- **Phase 2 (`__extern_toLocaleString`) — DONE** (this slice). Array/TypedArray
+  receivers route to the native comma-join (shared with `toString`, gated to
+  standalone/wasi in `array-methods.ts`); generic dynamic receivers route to the
+  native `__extern_toString` (`expressions/calls.ts`). Host (gc) mode keeps
+  `__extern_toLocaleString` for real Intl. Tests:
+  `tests/issue-2863-standalone-tolocalestring.test.ts`.
+- **Phase 1 staleness note** — the issue's premise that namespace data constants
+  (`Math.PI`/`E`/`LN2`, `Number.MAX_SAFE_INTEGER`/`EPSILON`) refuse is now
+  **partly stale**: those statically-named reads already compile + fold on
+  current main. The remaining Phase 1 work is the static-METHOD **value reads**
+  (`JSON.stringify`/`Reflect.get` as a value), reflective `any`-typed
+  `namespace[computedKey]` (currently TRAPs, not CE), and any residual
+  `__get_builtin` after #2861 landed — re-measure the 314 bucket against current
+  main before picking it up.
+- **Phase 3 (`Object.groupBy`/`fromEntries`)** — NOT started. `Object.groupBy`
+  also needs a lib-types update (currently a TS-level "does not exist on
+  ObjectConstructor" error, separate from codegen).

--- a/scripts/coercion-sites-baseline.json
+++ b/scripts/coercion-sites-baseline.json
@@ -9,7 +9,7 @@
   "codegen/declarations.ts": 20,
   "codegen/expressions/assignment.ts": 12,
   "codegen/expressions/calls-closures.ts": 2,
-  "codegen/expressions/calls.ts": 27,
+  "codegen/expressions/calls.ts": 28,
   "codegen/expressions/identifiers.ts": 2,
   "codegen/expressions/late-imports.ts": 4,
   "codegen/expressions/logical-ops.ts": 2,

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -2171,6 +2171,9 @@ export function compileArrayPrototypeCall(
 
   // Check if the method is a known array method
   if (!ARRAY_METHODS.has(methodName)) return undefined;
+  // (#2863 Phase 2) `toLocaleString` is array-native only under standalone/wasi;
+  // host keeps the `__extern_toLocaleString` path.
+  if (methodName === "toLocaleString" && !ctx.standalone && !ctx.wasi) return undefined;
 
   // Resolve array info from shape map or TypeScript type
   let receiverTsType: ts.Type | undefined;
@@ -2845,6 +2848,11 @@ const ARRAY_METHODS = new Set([
   // default "," separator. Without this, it fell through to the generic object
   // dispatch and produced "[object Array]".
   "toString",
+  // (#2863 Phase 2) Array/TypedArray.prototype.toLocaleString — recognised only
+  // under --target standalone/wasi (host-guarded at the gates below), where it
+  // has no host `__extern_toLocaleString` carrier. The locale-independent
+  // default collapses to the same comma-join as toString (§23.1.3.32).
+  "toLocaleString",
   // TypedArray-specific (#1664) — native WasmGC lowering avoids the generic
   // __extern_get / __extern_length host-import fallback under --target wasi.
   "set",
@@ -2869,6 +2877,11 @@ export function compileArrayMethodCall(
   const methodName =
     overrideMethodName ?? (ts.isPropertyAccessExpression(propAccess) ? propAccess.name.text : undefined);
   if (!methodName || !ARRAY_METHODS.has(methodName)) return undefined;
+  // (#2863 Phase 2) `toLocaleString` is array-dispatched ONLY under standalone/
+  // wasi (no host `__extern_toLocaleString` carrier). In host (gc) mode fall
+  // through to the host `__extern_toLocaleString` path (real Intl grouping +
+  // per-element abrupt-completion propagation) — return undefined here.
+  if (methodName === "toLocaleString" && !ctx.standalone && !ctx.wasi) return undefined;
 
   // (#2007/#1448) Record closure-allocating array methods so the standalone
   // vec-concat join fast-path can avoid a late `number_toString` registration
@@ -3045,6 +3058,10 @@ export function compileArrayMethodCall(
     // with the default "," separator. compileArrayJoin already defaults the
     // separator to "," when no argument is present, and toString receives no
     // arguments, so the two share the same lowering.
+    // (#2863 Phase 2) Array/TypedArray.prototype.toLocaleString — standalone/wasi
+    // only (host-guarded above); the locale-independent default is the same
+    // comma-join. Shares the join lowering.
+    case "toLocaleString":
     case "toString":
       // #1286: when the probe found the receiver to be externref at runtime,
       // route through the host-import fallback. The WasmGC-native path expects

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -10831,12 +10831,18 @@ function compileCallExpression(
     // graceful null-extern fallback and the test fails with "null/undefined
     // access" instead of reaching the expected throw.
     if (propAccess.name.text === "toLocaleString" && expr.arguments.length === 0) {
-      const toLSIdx = ensureLateImport(
-        ctx,
-        "__extern_toLocaleString",
-        [{ kind: "externref" }],
-        [{ kind: "externref" }],
-      );
+      // (#2863 Phase 2) Standalone/WASI have no host `__extern_toLocaleString`
+      // (it's a dynamic-shape refusal — a host-only import with no native
+      // carrier). Without ECMA-402 the spec default
+      // `Object.prototype.toLocaleString` (§20.1.3.5) just calls the receiver's
+      // `toString`, and `Array.prototype.toLocaleString` (§23.1.3.32) joins the
+      // per-element `toLocaleString` results — both collapse to the same comma-
+      // join as `toString` in a locale-independent runtime. Route to the NATIVE
+      // `__extern_toString` (registered host-free under standalone via #1866),
+      // which removes the CE while matching the locale-independent value. Host
+      // (gc) mode keeps `__extern_toLocaleString` for real Intl grouping.
+      const toLSName = ctx.standalone || ctx.wasi ? "__extern_toString" : "__extern_toLocaleString";
+      const toLSIdx = ensureLateImport(ctx, toLSName, [{ kind: "externref" }], [{ kind: "externref" }]);
       flushLateImportShifts(ctx, fctx);
       if (toLSIdx !== undefined) {
         const recvType = compileExpression(ctx, fctx, propAccess.expression, { kind: "externref" });

--- a/tests/issue-2863-standalone-tolocalestring.test.ts
+++ b/tests/issue-2863-standalone-tolocalestring.test.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #2863 Phase 2 — standalone `.toLocaleString()` on a dynamic / Array / TypedArray
+// receiver no longer refuses.
+//
+// Under `--target standalone`/`wasi` there is no host `__extern_toLocaleString`
+// carrier, so `arr.toLocaleString()` / `dynObj.toLocaleString()` hit the #1472
+// "dynamic-shape object/property operation is not supported" compile refusal.
+// Without ECMA-402 the spec default collapses to ToString:
+//   - Object.prototype.toLocaleString (§20.1.3.5) → this.toString()  → "[object Object]"
+//   - Array.prototype.toLocaleString (§23.1.3.32) joins per-element toLocaleString
+//     → same comma-join as toString in a locale-independent runtime
+//   - %TypedArray%.prototype.toLocaleString (§23.2.3.32) → same comma-join
+// Fix: Array/TypedArray receivers route to the native join lowering (shared with
+// `toString`); generic dynamic receivers route to the native `__extern_toString`
+// (#1866). Host (gc) mode keeps `__extern_toLocaleString` for real Intl grouping.
+//
+// String returns from a standalone module are native-string refs (not JS
+// strings), so these assert via `.length` (a number export).
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  // No host-object import may leak under standalone.
+  expect((r.imports ?? []).map((i) => i.name).filter((n) => /^__extern_toLocaleString$/.test(n))).toEqual([]);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2863 Phase 2 — standalone Array.prototype.toLocaleString", () => {
+  it("number array joins with comma (was a compile refusal)", async () => {
+    // "1,2,3".length === 5
+    expect(await runStandalone(`export function test(): number { return [1, 2, 3].toLocaleString().length; }`)).toBe(5);
+  });
+
+  it("string array joins with comma", async () => {
+    // "a,b".length === 3
+    expect(await runStandalone(`export function test(): number { return ["a", "b"].toLocaleString().length; }`)).toBe(
+      3,
+    );
+  });
+
+  it("empty array → empty string", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a: number[] = []; return a.toLocaleString().length; }`,
+      ),
+    ).toBe(0);
+  });
+});
+
+describe("#2863 Phase 2 — standalone TypedArray.prototype.toLocaleString", () => {
+  it("Int32Array joins with comma", async () => {
+    // "1,2,3".length === 5
+    expect(
+      await runStandalone(
+        `export function test(): number { const a = new Int32Array([1, 2, 3]); return a.toLocaleString().length; }`,
+      ),
+    ).toBe(5);
+  });
+
+  it("Uint8Array joins with comma", async () => {
+    // "10,20".length === 5
+    expect(
+      await runStandalone(
+        `export function test(): number { const a = new Uint8Array([10, 20]); return a.toLocaleString().length; }`,
+      ),
+    ).toBe(5);
+  });
+});
+
+describe("#2863 Phase 2 — standalone generic object toLocaleString", () => {
+  it("plain object → '[object Object]' via ToString default", async () => {
+    // "[object Object]".length === 15
+    expect(
+      await runStandalone(`export function test(): number { const o: any = {}; return o.toLocaleString().length; }`),
+    ).toBe(15);
+  });
+});
+
+describe("#2863 Phase 2 — host (gc) mode is unchanged", () => {
+  it("host mode keeps the __extern_toLocaleString import (real Intl path)", async () => {
+    const r = await compile(`export function test(): string { return [1, 2, 3].toLocaleString(); }`, {});
+    expect(r.success, JSON.stringify(r.errors)).toBe(true);
+    const usesHostTLS = (r.imports ?? []).some((i) => i.name === "__extern_toLocaleString");
+    expect(usesHostTLS, "host mode must still route Array.toLocaleString to the host import").toBe(true);
+  });
+});


### PR DESCRIPTION
## #2863 Phase 2: standalone `.toLocaleString()` (~34 standalone-CE tests)

Under `--target standalone`/`wasi` there is no host `__extern_toLocaleString`
carrier, so `arr.toLocaleString()` / `dynObj.toLocaleString()` hit the #1472
dynamic-shape compile refusal. Without ECMA-402 the spec default collapses to
ToString:
- `Array`/`%TypedArray%.prototype.toLocaleString` (§23.1.3.32 / §23.2.3.32) → the
  same comma-join as `toString` in a locale-independent runtime.
- `Object.prototype.toLocaleString` (§20.1.3.5) → `this.toString()` → `"[object Object]"`.

### Changes
- **`src/codegen/array-methods.ts`**: recognise `toLocaleString` as an
  Array/TypedArray method **only** under standalone/wasi (host-guarded at both
  dispatch gates), routing it to the existing native join lowering shared with
  `toString`.
- **`src/codegen/expressions/calls.ts`**: the generic dynamic-receiver
  `.toLocaleString()` fallback routes to the native `__extern_toString` (#1866)
  under standalone/wasi instead of `__extern_toLocaleString`.

### Why it's safe
Host (gc) mode is **unchanged** — it keeps `__extern_toLocaleString` for real
Intl grouping + per-element abrupt-completion propagation (verified: host still
imports the host helper). All new routing is `ctx.standalone`/`ctx.wasi`-gated.

### Verify-first
On current main `arr.toLocaleString()` CEs with the `__extern_toLocaleString`
dynamic-shape refusal; after this PR Array/TypedArray produce the correct
comma-join and generic objects produce `"[object Object]"`.

### Tests
`tests/issue-2863-standalone-tolocalestring.test.ts` — 7 tests (Array, TypedArray,
generic object, host-mode-unchanged). No regression on issue-1997 / array-methods
/ issue-1664 / issue-2160 (40+ passing locally).

### Scope
Phase 2 of #2863 only. The issue stays open for Phase 1 (`__get_builtin`
namespace static reads — partly **stale** post-#2861: `Math.PI`/`E`/`LN2` etc.
already fold; re-measure the 314 bucket) and Phase 3 (`Object.groupBy`/
`fromEntries`). Progress + staleness note recorded in the issue file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)