### PR TITLE
fix(#2868): fresh-Instr factory for throwURIError (standalone invalid-Wasm)

### DIFF
--- a/plan/issues/2868-standalone-invalid-wasm-emission.md
+++ b/plan/issues/2868-standalone-invalid-wasm-emission.md
@@ -1,7 +1,8 @@
 ---
 id: 2868
 title: "Standalone: invalid Wasm binary emitted (correctness) — __uri_encode/__uri_decode, __str_flatten, and common user-body shapes"
-status: ready
+status: done
+completed: 2026-06-30
 created: 2026-06-30
 updated: 2026-06-30
 priority: high
@@ -91,3 +92,52 @@ Standalone CE → pass:
 
 Validate by re-compiling each repro to a valid module, then full `merge_group` +
 standalone high-water. Pure correctness win — no host-mode path touched.
+
+## Resolution (2026-06-30) — URI carriers fixed; residual → #2878
+
+Fixed the `__uri_encode`/`__uri_decode` carriers (the named, most-isolated
+sub-bugs — 81 invalid binaries across the four URI test dirs alone, > the 64
+estimate).
+
+### Root cause
+
+`src/codegen/uri-encoding-native.ts` built `throwURIError` as a **shared
+`const Instr[]`** and spread it (`...throwURIError`) at ~13 throw sites in each
+helper. A spread is shallow, so the single `{ op:"call", funcIdx: uriErrCtorIdx }`
+(and the `{ op:"throw", tagIdx }`) Instr **objects** were aliased at every site.
+When a late import was added after the helper was emitted (e.g. a thrown user
+class + `e instanceof URIError` pulling in `__box_boolean` / the error
+constructor), the index-shift walker `shiftLateImportIndices`
+(`src/codegen/expressions/late-imports.ts`) mutates `instr.funcIdx += delta`
+**once per occurrence** while walking the body — so the shared `call` object was
+shifted ~13× instead of once, landing on an out-of-range / wrong-signature
+function. The single-occurrence `__str_flatten` call was shifted correctly, which
+is why only the URIError-throw path corrupted. Class: shared-Instr-object
+aliasing (`reference_shared_instr_object_dce_double_remap`).
+
+### Fix
+
+Make `throwURIError` a **factory** (`(): Instr[] => [...]`) returning fresh Instr
+objects per call; replace every `...throwURIError` with `...throwURIError()`.
+Each emitted `call`/`throw` is now an independent object the shift visits exactly
+once. Two-line shape, applied to both the encode and decode helpers. Not
+standalone-gated, but host mode was unaffected (it adds these late imports too,
+just didn't surface the same shape) and is re-verified.
+
+### Verify-first
+
+Sweep of `test/built-ins/{decodeURI,decodeURIComponent,encodeURI,encodeURIComponent}`
+via the test262 `wrapTest` path, `--target standalone`:
+- BEFORE: 92 valid / **81 invalid** (`__uri_decode`/`__uri_encode failed: call[0]
+  expected type i32 …` / `throw[0] expected type externref …` / `not enough
+  arguments on the stack`).
+- AFTER: **173 valid / 0 invalid**; functional round-trips correct
+  (decode/encode lengths, non-ASCII round-trip, catchable `URIError` on malformed
+  input). `tests/issue-2868.test.ts` regression test fails on main / passes on fix.
+
+### Residual (out of scope here) → #2878
+
+`__str_flatten` (10) and the `test`/`inner`/`fn` user-body-shape clusters (322)
+were NOT addressed by the URI-carrier fix and are tracked in **#2878** (with a
+hypothesis that some may share this aliasing class, and a proposed
+walker-idempotency hardening).

--- a/plan/issues/2878-standalone-invalid-wasm-residual-strflatten-bodyshapes.md
+++ b/plan/issues/2878-standalone-invalid-wasm-residual-strflatten-bodyshapes.md
@@ -1,0 +1,62 @@
+---
+id: 2878
+title: "Standalone: invalid Wasm residual — __str_flatten + user-body shapes (test/inner/fn) after #2868 URI-carrier fix"
+status: ready
+created: 2026-06-30
+updated: 2026-06-30
+priority: high
+feasibility: medium
+task_type: bug
+area: codegen
+goal: standalone
+sprint: current
+horizon: m
+related: [2860, 2868]
+umbrella: 2860
+---
+
+# Standalone: invalid Wasm — residual after #2868
+
+#2868 fixed the `__uri_encode`/`__uri_decode` carriers (root cause: a shared
+`throwURIError` `Instr[]` aliased the same `call`/`throw` Instr objects across
+~13 spread sites, so `shiftLateImportIndices` over-shifted the shared `funcIdx`
+once per occurrence — fixed by making it a fresh-Instr factory). This follow-on
+tracks the **rest** of the #2868 invalid-Wasm surface that the URI fix did not
+cover.
+
+## Remaining buckets (from the #2868 measurement, 2026-06-30)
+
+| function | tests | note |
+| -------- | ----- | ---- |
+| `test` (harness/user) | 199 | a common emitted body shape |
+| `inner` | 81 | nested function shape |
+| `fn` | 42 | |
+| `__str_flatten` | 10 | native string flatten (String split RegExp-arg path) |
+| `C_setPrivateReference` | 10 | private-field accessor |
+| `gen` / `__closure_*` / `__cb_*` | ~40 | |
+
+## Root-cause hypothesis
+
+The `__uri_*` fix shows one concrete instance of the **shared-Instr-object
+aliasing** hazard interacting with the late-import index-shift walker
+(`shiftLateImportIndices` mutates `instr.funcIdx += delta` per occurrence; a
+spread-shared `call`/`ref.func` Instr is shifted N×). The `test`/`inner`/`fn`
+body-shape failures (322) may share this class (another emitter that spreads a
+shared `Instr[]` containing a `call`/`ref.func`) **or** be a distinct
+stack-balance / type-mismatch on a `ctx.standalone`-gated path. Triage one repro
+per named function (disassemble with binaryen, read the exact validator error),
+then cluster.
+
+A defensive hardening worth evaluating: make `shiftLateImportIndices` (and the
+sibling string-import shift in `index.ts`) **idempotent per Instr object** (track
+a `Set<Instr>` of already-shifted call/ref.func nodes), so a shared Instr can
+never be double-shifted regardless of emitter aliasing. That would neutralize the
+whole bug class at the walker instead of fixing each emitter. Weigh against the
+"never alias one Instr[]" convention (memory
+`reference_shared_instr_object_dce_double_remap`).
+
+## Test plan
+
+Standalone CE → pass: `test/built-ins/String/prototype/split/**` (RegExp-arg
+`__str_flatten`), plus the clustered `test`/`inner`/`fn` body-shape examples once
+the shared construct is identified. Full `merge_group`.

--- a/src/codegen/uri-encoding-native.ts
+++ b/src/codegen/uri-encoding-native.ts
@@ -215,7 +215,15 @@ export function emitNativeUriEncode(ctx: CodegenContext): void {
   // ── URIError throw sequence (raw Instrs) ──
   // (ctor + string constant + exn tag were registered up top so they don't shift
   // our funcIdx; reuse the captured `uriErrCtorIdx` / `tagIdx`.)
-  const throwURIError: Instr[] = [
+  // (#2868) A FACTORY, not a shared const: `throwURIError` is spread at ~13
+  // sites in the helper body. A spread is shallow, so a single shared
+  // `{ op:"call", funcIdx }` Instr OBJECT would alias every throw site; the
+  // late-import index-shift walker (`shiftLateImportIndices`) mutates
+  // `instr.funcIdx += delta` once PER occurrence, over-shifting the shared
+  // object to an out-of-range funcIdx and emitting an invalid binary (the
+  // single-occurrence `flattenIdx` call stayed correct). Returning fresh Instr
+  // objects per call keeps every `call` independently shiftable.
+  const throwURIError = (): Instr[] => [
     ...stringConstantExternrefInstrs(ctx, "URI malformed"),
     { op: "call", funcIdx: uriErrCtorIdx } as Instr,
     { op: "throw", tagIdx } as Instr,
@@ -311,7 +319,7 @@ export function emitNativeUriEncode(ctx: CodegenContext): void {
                 get(L_I),
                 get(L_LEN),
                 { op: "i32.ge_s" } as Instr,
-                { op: "if", blockType: { kind: "empty" }, then: [...throwURIError] } as Instr,
+                { op: "if", blockType: { kind: "empty" }, then: [...throwURIError()] } as Instr,
                 // lo = data[i]
                 get(L_DATA),
                 get(L_I),
@@ -326,7 +334,7 @@ export function emitNativeUriEncode(ctx: CodegenContext): void {
                 { op: "i32.le_u" } as Instr,
                 { op: "i32.and" } as Instr,
                 { op: "i32.eqz" } as Instr,
-                { op: "if", blockType: { kind: "empty" }, then: [...throwURIError] } as Instr,
+                { op: "if", blockType: { kind: "empty" }, then: [...throwURIError()] } as Instr,
                 // cp = 0x10000 + ((c-0xD800)<<10) + (lo-0xDC00)
                 c(0x10000),
                 get(L_C),
@@ -355,7 +363,7 @@ export function emitNativeUriEncode(ctx: CodegenContext): void {
             c(0xdfff),
             { op: "i32.le_u" } as Instr,
             { op: "i32.and" } as Instr,
-            { op: "if", blockType: { kind: "empty" }, then: [...throwURIError] } as Instr,
+            { op: "if", blockType: { kind: "empty" }, then: [...throwURIError()] } as Instr,
 
             // ── UTF-8 encode cp into %XX bytes ──
             // nbytes = cp<=0x7F?1 : cp<=0x7FF?2 : cp<=0xFFFF?3 : 4
@@ -562,7 +570,15 @@ export function emitNativeUriDecode(ctx: CodegenContext): void {
   const set = (i: number): Instr => ({ op: "local.set", index: i }) as Instr;
   const c = (value: number): Instr => ({ op: "i32.const", value }) as Instr;
 
-  const throwURIError: Instr[] = [
+  // (#2868) A FACTORY, not a shared const: `throwURIError` is spread at ~13
+  // sites in the helper body. A spread is shallow, so a single shared
+  // `{ op:"call", funcIdx }` Instr OBJECT would alias every throw site; the
+  // late-import index-shift walker (`shiftLateImportIndices`) mutates
+  // `instr.funcIdx += delta` once PER occurrence, over-shifting the shared
+  // object to an out-of-range funcIdx and emitting an invalid binary (the
+  // single-occurrence `flattenIdx` call stayed correct). Returning fresh Instr
+  // objects per call keeps every `call` independently shiftable.
+  const throwURIError = (): Instr[] => [
     ...stringConstantExternrefInstrs(ctx, "URI malformed"),
     { op: "call", funcIdx: uriErrCtorIdx } as Instr,
     { op: "throw", tagIdx } as Instr,
@@ -652,19 +668,19 @@ export function emitNativeUriDecode(ctx: CodegenContext): void {
     { op: "i32.add" } as Instr,
     get(L_LEN),
     { op: "i32.ge_s" } as Instr,
-    { op: "if", blockType: { kind: "empty" }, then: [...throwURIError] } as Instr,
+    { op: "if", blockType: { kind: "empty" }, then: [...throwURIError()] } as Instr,
     // data[idx] == '%' ?
     ...dataAt([get(idxLocal)]),
     c(37 /* '%' */),
     { op: "i32.ne" } as Instr,
-    { op: "if", blockType: { kind: "empty" }, then: [...throwURIError] } as Instr,
+    { op: "if", blockType: { kind: "empty" }, then: [...throwURIError()] } as Instr,
     // hi = hexVal(data[idx+1]); if hi<0 throw
     ...hexVal(dataAt([get(idxLocal), c(1), { op: "i32.add" } as Instr])),
     set(targetLocal),
     get(targetLocal),
     c(0),
     { op: "i32.lt_s" } as Instr,
-    { op: "if", blockType: { kind: "empty" }, then: [...throwURIError] } as Instr,
+    { op: "if", blockType: { kind: "empty" }, then: [...throwURIError()] } as Instr,
     // byte = hi<<4
     get(targetLocal),
     c(4),
@@ -678,7 +694,7 @@ export function emitNativeUriDecode(ctx: CodegenContext): void {
     get(L_LO2),
     c(0),
     { op: "i32.lt_s" } as Instr,
-    { op: "if", blockType: { kind: "empty" }, then: [...throwURIError] } as Instr,
+    { op: "if", blockType: { kind: "empty" }, then: [...throwURIError()] } as Instr,
     get(targetLocal),
     get(L_LO2),
     { op: "i32.or" } as Instr,
@@ -831,7 +847,7 @@ export function emitNativeUriDecode(ctx: CodegenContext): void {
                           op: "if",
                           blockType: { kind: "empty" },
                           then: [c(4), set(L_NB), get(L_B0), c(0x07), { op: "i32.and" } as Instr, set(L_CP)],
-                          else: [...throwURIError],
+                          else: [...throwURIError()],
                         } as Instr,
                       ],
                     } as Instr,
@@ -903,7 +919,7 @@ export function emitNativeUriDecode(ctx: CodegenContext): void {
                     { op: "i32.and" } as Instr,
                     c(0x80),
                     { op: "i32.ne" } as Instr,
-                    { op: "if", blockType: { kind: "empty" }, then: [...throwURIError] } as Instr,
+                    { op: "if", blockType: { kind: "empty" }, then: [...throwURIError()] } as Instr,
                     // cp = (cp << 6) | (cb & 0x3F)
                     get(L_CP),
                     c(6),
@@ -936,7 +952,7 @@ export function emitNativeUriDecode(ctx: CodegenContext): void {
                 get(L_CP),
                 c(0x80),
                 { op: "i32.lt_u" } as Instr,
-                { op: "if", blockType: { kind: "empty" }, then: [...throwURIError] } as Instr,
+                { op: "if", blockType: { kind: "empty" }, then: [...throwURIError()] } as Instr,
               ],
             } as Instr,
             get(L_NB),
@@ -949,7 +965,7 @@ export function emitNativeUriDecode(ctx: CodegenContext): void {
                 get(L_CP),
                 c(0x800),
                 { op: "i32.lt_u" } as Instr,
-                { op: "if", blockType: { kind: "empty" }, then: [...throwURIError] } as Instr,
+                { op: "if", blockType: { kind: "empty" }, then: [...throwURIError()] } as Instr,
                 // surrogate range 0xD800..0xDFFF is invalid in UTF-8
                 get(L_CP),
                 c(0xd800),
@@ -958,7 +974,7 @@ export function emitNativeUriDecode(ctx: CodegenContext): void {
                 c(0xdfff),
                 { op: "i32.le_u" } as Instr,
                 { op: "i32.and" } as Instr,
-                { op: "if", blockType: { kind: "empty" }, then: [...throwURIError] } as Instr,
+                { op: "if", blockType: { kind: "empty" }, then: [...throwURIError()] } as Instr,
               ],
             } as Instr,
             get(L_NB),
@@ -975,7 +991,7 @@ export function emitNativeUriDecode(ctx: CodegenContext): void {
                 c(0x10ffff),
                 { op: "i32.gt_u" } as Instr,
                 { op: "i32.or" } as Instr,
-                { op: "if", blockType: { kind: "empty" }, then: [...throwURIError] } as Instr,
+                { op: "if", blockType: { kind: "empty" }, then: [...throwURIError()] } as Instr,
               ],
             } as Instr,
             // emit cp as UTF-16: BMP -> 1 unit; astral -> surrogate pair

--- a/tests/issue-2868.test.ts
+++ b/tests/issue-2868.test.ts
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2868 — `--target standalone` emitted an INVALID Wasm binary for modules that
+// use decodeURI/encodeURI together with a later-added late import (a thrown user
+// class + `e instanceof URIError`, which pulls in `__box_boolean` and an error
+// constructor AFTER the URI helper is emitted). The validator rejected
+// `__uri_decode`/`__uri_encode` with, e.g.:
+//
+//   call[0] expected type i32, found extern.convert_any of type (ref extern)
+//
+// Root cause: the helpers built `throwURIError` as a SHARED `const Instr[]` and
+// spread it (`...throwURIError`) at ~13 throw sites. A spread is shallow, so the
+// single `{ op:"call", funcIdx: uriErrCtorIdx }` (and the `throw`) Instr OBJECTS
+// were aliased at every site. When a late import was added, the index-shift
+// walker (`shiftLateImportIndices`) mutates `instr.funcIdx += delta` once per
+// occurrence in the body — so the shared call object was shifted ~13× instead of
+// once, landing on an out-of-range / wrong-signature function (the
+// single-occurrence `__str_flatten` call stayed correct). Fix: make
+// `throwURIError` a FACTORY returning fresh Instr objects per call, so each
+// emitted `call`/`throw` is an independent object the shift visits exactly once.
+//
+// `WebAssembly.compile(binary)` is the precise regression check: it validates
+// the module structurally and is exactly what threw "invalid Wasm binary"
+// pre-fix. A subset is also instantiated+run for functional proof.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileStandalone(src: string): Promise<Uint8Array> {
+  const r = await compile(src, { target: "standalone", skipSemanticDiagnostics: true } as never);
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  return r.binary;
+}
+
+/** Compile standalone and assert the emitted binary is structurally VALID. */
+async function expectValid(src: string): Promise<void> {
+  const binary = await compileStandalone(src);
+  // Pre-fix this rejected with "invalid Wasm binary: ... __uri_decode failed".
+  await expect(WebAssembly.compile(binary)).resolves.toBeDefined();
+}
+
+/** Compile standalone, instantiate with no host imports, and run `test()`. */
+async function runStandalone(src: string): Promise<unknown> {
+  const binary = await compileStandalone(src);
+  const { instance } = await WebAssembly.instantiate(binary, {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+describe("#2868 standalone URI helpers emit a VALID binary (shared-Instr shift bug)", () => {
+  // The thrown user class + `instanceof URIError` adds late imports AFTER
+  // `__uri_decode` is emitted — the exact late-import shift that over-shifted the
+  // aliased throw/call. This shape reproduced the invalid binary on pre-fix main.
+  it("decodeURI in a throw/instanceof guard emits a valid binary", async () => {
+    await expectValid(`
+      class Test262Error { message: string; constructor(m: string = "") { this.message = m; } }
+      function check(): number {
+        try { decodeURI("%"); throw new Test262Error("no throw"); }
+        catch (e) { if (!(e instanceof URIError)) throw new Test262Error("bad"); }
+        return 1;
+      }
+      export function test(): number { return check(); }
+    `);
+  });
+
+  it("encodeURI in a throw/instanceof guard emits a valid binary", async () => {
+    await expectValid(`
+      class Test262Error { message: string; constructor(m: string = "") { this.message = m; } }
+      function check(): number {
+        var s = encodeURIComponent("a b&c");
+        if (s.length === 0) throw new Test262Error("empty");
+        try { decodeURI("%"); throw new Test262Error("no throw"); }
+        catch (e) { if (!(e instanceof URIError)) throw new Test262Error("bad"); }
+        return 1;
+      }
+      export function test(): number { return check(); }
+    `);
+  });
+
+  it("decodeURIComponent decodes correctly under standalone (functional)", async () => {
+    expect(await runStandalone(`export function test(): number { return decodeURIComponent("a%20b").length; }`)).toBe(
+      3,
+    ); // "a b"
+  });
+
+  it("encodeURIComponent encodes correctly under standalone (functional)", async () => {
+    expect(await runStandalone(`export function test(): number { return encodeURIComponent("a b").length; }`)).toBe(5); // "a%20b"
+  });
+
+  it("encode/decode round-trip preserves a non-ASCII string under standalone (functional)", async () => {
+    // Returned as raw i32 1 (=== true) under direct standalone instantiation
+    // (no wrapExports boolean marshalling).
+    expect(
+      await runStandalone(
+        `export function test(): boolean { return decodeURIComponent(encodeURIComponent("héllo")) === "héllo"; }`,
+      ),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2868 — standalone invalid Wasm for URI helpers (correctness)

`--target standalone` emitted a binary the engine rejects for modules using
decodeURI/encodeURI alongside a late-added import — e.g. a thrown user class +
`e instanceof URIError`, which pulls in `__box_boolean` / the error constructor
**after** the URI helper is emitted:

```
__uri_decode failed: call[0] expected type i32, found extern.convert_any of type (ref extern)
__uri_encode failed: not enough arguments on the stack for call (need 2, got 1)
```

### Root cause

`src/codegen/uri-encoding-native.ts` built `throwURIError` as a **shared
`const Instr[]`** and spread it (`...throwURIError`) at ~13 throw sites in each
helper. A spread is shallow, so the single `{ op:"call", funcIdx: uriErrCtorIdx }`
(and `{ op:"throw", tagIdx }`) Instr **objects** were aliased at every site. When
a late import is added, `shiftLateImportIndices` mutates `instr.funcIdx += delta`
**once per occurrence** while walking the body — so the shared `call` object got
shifted ~13× instead of once → out-of-range / wrong-signature `funcIdx` → invalid
binary. The single-occurrence `__str_flatten` call shifted correctly, which is
why only the URIError-throw path corrupted. Class: shared-Instr-object aliasing.

### Fix (one shape, both helpers)

Make `throwURIError` a **factory** (`(): Instr[] => [...]`) returning fresh Instr
objects per call; replace each `...throwURIError` with `...throwURIError()`. Each
emitted `call`/`throw` is now an independent object the shift visits exactly once.

### Verify-first (standalone, test262 `wrapTest` path)

Sweep of `test/built-ins/{decodeURI,decodeURIComponent,encodeURI,encodeURIComponent}`:
- BEFORE: 92 valid / **81 invalid**
- AFTER: **173 valid / 0 invalid**; functional round-trips correct (decode/encode
  lengths, non-ASCII round-trip, catchable `URIError` on malformed input). Host
  mode re-verified.

`String/prototype/split` (120) also all-valid. `tests/issue-2868.test.ts`
regression test fails on main (`__uri_decode`/`__uri_encode` invalid) / passes on
fix.

### Scope / residual

This fixes the named, most-isolated URI carriers. The `__str_flatten` (10) and
`test`/`inner`/`fn` user-body-shape clusters (322) are **not** addressed here and
are tracked in **#2878** (added in this PR), with a hypothesis that some share
this aliasing class and a proposed walker-idempotency hardening.

Touches a shared codegen emitter (object identity only, semantically identical)
→ full `merge_group` validation (auto-enqueue). Expectation: 0 regression + a
standalone-CE gain in the URI cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)