### PR TITLE
fix(#2851,#2852): deep-marshal sidecar struct/array props in _structToPlainObject

### DIFF
--- a/plan/issues/2851-acorn-template-element-marshalled-blank.md
+++ b/plan/issues/2851-acorn-template-element-marshalled-blank.md
@@ -1,7 +1,8 @@
 ---
 id: 2851
 title: "compiled-acorn marshals TemplateLiteral `quasis[]` TemplateElement nodes BLANK (type/value/tail dropped across host boundary)"
-status: ready
+status: done
+completed: 2026-06-30
 sprint: current
 priority: high
 horizon: m
@@ -71,3 +72,24 @@ marshalling for array-of-struct fields, and whether `TemplateElement`'s
 - A focused equivalence test asserting a marshalled `TemplateLiteral` carries
   `type`, `value.raw`, `value.cooked`, `tail` on each `quasis` element.
 - No test262 regression.
+
+## Resolution (2026-06-30) — fixed with #2852 (shared root cause)
+
+Root cause: `_structToPlainObject` (`src/runtime.ts`) deep-converted the
+NOMINAL struct fields (`val = _wasmToPlain(getter(obj))`) but merged the
+SIDECAR (dynamically-assigned) props VERBATIM: `result[key] = sc[key]`. acorn
+builds nodes via `new Node()` then assigns `node.quasis = [...]` etc., so
+`quasis` is a sidecar prop holding an array of WasmGC `TemplateElement` structs.
+Merged raw, those struct elements stayed opaque → `marshal:"copy"`/JSON saw the
+fields blank. (Distinct from #2841, which fixed the host-JS-array path in
+`_wasmToPlain`; sidecar values never reached that recursion.)
+
+Fix (1 line): recurse `_wasmToPlain` on sidecar values —
+`result[key] = _wasmToPlain(sc[key], exports, seen)` — mirroring the
+nominal-field path. Idempotent for plain JS values.
+
+Verify-first (acorn differential corpus): BEFORE `corpus/templates.js` had
+REAL `missing-field @ quasis[*].{type,value,tail}`; AFTER `templates.js`,
+`escapes-unicode.js`, `sequence-misc.js`, `operators.js` are all
+EQUAL(±quirks), REAL=0. Regression test: `tests/issue-2851.test.ts`. The one
+fix also closes **#2852** (SequenceExpression `expressions[]`).

--- a/plan/issues/2852-acorn-sequence-expression-children-blank.md
+++ b/plan/issues/2852-acorn-sequence-expression-children-blank.md
@@ -1,7 +1,8 @@
 ---
 id: 2852
 title: "compiled-acorn marshals SequenceExpression `expressions[]` child nodes BLANK (all fields dropped across host boundary)"
-status: ready
+status: done
+completed: 2026-06-30
 sprint: current
 priority: high
 horizon: m
@@ -73,3 +74,13 @@ with #2841/#2851.
 - A focused equivalence test asserting a marshalled `SequenceExpression` carries
   fully-populated child nodes.
 - No test262 regression.
+
+## Resolution (2026-06-30) — fixed together with #2851 (shared root cause)
+
+Same root cause and fix as #2851: `_structToPlainObject` merged SIDECAR
+(dynamically-assigned) props verbatim instead of recursing `_wasmToPlain`, so a
+sidecar array of child WasmGC structs (`node.expressions = [...]`) came back
+with blank elements. Fix: `result[key] = _wasmToPlain(sc[key], exports, seen)`
+in `src/runtime.ts`. Verify-first: `corpus/operators.js` (`const seq = (1,2,3)`)
+and `corpus/sequence-misc.js` go from REAL `missing-field @ expressions[*].*`
+to EQUAL(±quirks), REAL=0. Covered by `tests/issue-2851.test.ts`.

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -3483,11 +3483,19 @@ function _structToPlainObject(
       result[key] = val;
     }
   }
-  // Also include sidecar properties
+  // Also include sidecar properties (dynamically-assigned own props, e.g.
+  // acorn's `node.quasis = [...]` / `node.expressions = [...]`).
+  // (#2851/#2852) These MUST be deep-converted the same way nominal fields are
+  // (the `val = _wasmToPlain(getter(obj))` above): a sidecar value that is —
+  // or contains — raw WasmGC structs (a child AST node, or an ARRAY of child
+  // nodes) was previously merged verbatim, so a `marshal:"copy"`/JSON consumer
+  // saw `quasis[*]` / `expressions[*]` elements as blank/opaque. Recurse so the
+  // deep copy reaches struct values and array-of-struct elements. Idempotent
+  // for plain JS values (`_wasmToPlain` returns primitives as-is).
   const sc = _wasmStructProps.get(obj);
   if (sc) {
     for (const key of Object.keys(sc)) {
-      if (!(key in result)) result[key] = sc[key];
+      if (!(key in result)) result[key] = _wasmToPlain(sc[key], exports, seen);
     }
   }
   return result;

--- a/tests/issue-2851.test.ts
+++ b/tests/issue-2851.test.ts
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2851 / #2852 / #2841 — `marshal:"copy"` (wrapExports) dropped the fields of
+// WasmGC-struct values held in a SIDECAR (dynamically-assigned) property. acorn
+// builds AST nodes by `new Node()` then assigning extra fields
+// (`node.quasis = [...]`, `node.expressions = [...]`, `node.params = [...]`).
+// Those assigned fields are stored as sidecar props. `_structToPlainObject` deep-
+// converted the NOMINAL struct fields (`val = _wasmToPlain(getter(obj))`) but
+// merged the sidecar props VERBATIM (`result[key] = sc[key]`), so a sidecar
+// value that was — or contained — raw WasmGC structs came back blank/opaque:
+//   - #2851 TemplateLiteral.quasis[*]  (TemplateElement nodes blank)
+//   - #2852 SequenceExpression.expressions[*]  (child nodes blank)
+//   - #2841 ArrowFunctionExpression.params[*]  (Identifier nodes blank)
+//
+// Fix: recurse `_wasmToPlain` on sidecar values too, mirroring the nominal-field
+// path. One change in `_structToPlainObject` covers all three array-of-child-node
+// shapes.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { instantiateWasm, wrapExports, buildImports } from "../src/runtime.js";
+
+async function runMarshalled(src: string): Promise<any> {
+  const r = await compile(src, { fileName: "test.ts" });
+  if (!r.success) throw new Error("compile error: " + (r.errors?.[0]?.message ?? "unknown"));
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await instantiateWasm(new Uint8Array(r.binary), imports.env, imports.string_constants);
+  if (imports.setExports) imports.setExports(instance.exports as Record<string, Function>);
+  return wrapExports(instance.exports, { marshal: "copy" }).test();
+}
+
+// A minimal stand-in for acorn's `Node` class: a couple of nominal fields, then
+// the parser assigns the rest dynamically (→ sidecar props).
+const NODE = `class Node { type: string = ""; start: number = 0; constructor() {} }`;
+
+describe("#2851/#2852/#2841 sidecar array-of-struct fields marshal deeply", () => {
+  it("#2851 TemplateLiteral.quasis[*] carry type/value.raw/value.cooked/tail", async () => {
+    const node = await runMarshalled(`
+      ${NODE}
+      function mkElem(raw: string, tail: boolean): any {
+        const e: any = new Node();
+        e.type = "TemplateElement"; e.value = { raw: raw, cooked: raw }; e.tail = tail;
+        return e;
+      }
+      export function test(): any {
+        const n: any = new Node();
+        n.type = "TemplateLiteral";
+        n.quasis = [mkElem("hello ", false), mkElem(" world", true)];
+        n.expressions = [];
+        return n;
+      }
+    `);
+    expect(node.type).toBe("TemplateLiteral");
+    expect(node.quasis).toHaveLength(2);
+    expect(node.quasis[0]).toMatchObject({
+      type: "TemplateElement",
+      value: { raw: "hello ", cooked: "hello " },
+      tail: false,
+    });
+    expect(node.quasis[1]).toMatchObject({
+      type: "TemplateElement",
+      value: { raw: " world", cooked: " world" },
+      tail: true,
+    });
+  });
+
+  it("#2852 SequenceExpression.expressions[*] carry their child fields", async () => {
+    const node = await runMarshalled(`
+      ${NODE}
+      function lit(v: number): any { const n: any = new Node(); n.type = "Literal"; n.value = v; n.raw = "" + v; return n; }
+      export function test(): any {
+        const n: any = new Node();
+        n.type = "SequenceExpression";
+        n.expressions = [lit(1), lit(2), lit(3)];
+        return n;
+      }
+    `);
+    expect(node.expressions).toHaveLength(3);
+    expect(node.expressions.map((e: any) => e.type)).toEqual(["Literal", "Literal", "Literal"]);
+    expect(node.expressions.map((e: any) => e.value)).toEqual([1, 2, 3]);
+    expect(node.expressions[0]).toMatchObject({ type: "Literal", value: 1, raw: "1" });
+  });
+
+  it("#2841 ArrowFunctionExpression.params[*] carry type/name", async () => {
+    const node = await runMarshalled(`
+      ${NODE}
+      function id(nm: string): any { const n: any = new Node(); n.type = "Identifier"; n.name = nm; return n; }
+      export function test(): any {
+        const n: any = new Node();
+        n.type = "ArrowFunctionExpression";
+        n.params = [id("a"), id("b")];
+        return n;
+      }
+    `);
+    expect(node.params).toHaveLength(2);
+    expect(node.params[0]).toMatchObject({ type: "Identifier", name: "a" });
+    expect(node.params[1]).toMatchObject({ type: "Identifier", name: "b" });
+  });
+
+  it("a sidecar value that is a single nested struct (not an array) is also deep-converted", async () => {
+    const node = await runMarshalled(`
+      ${NODE}
+      export function test(): any {
+        const inner: any = new Node(); inner.type = "Identifier"; inner.name = "x";
+        const n: any = new Node(); n.type = "ExpressionStatement"; n.expression = inner;
+        return n;
+      }
+    `);
+    expect(node.expression).toMatchObject({ type: "Identifier", name: "x" });
+  });
+});


### PR DESCRIPTION
## #2851 + #2852 — compiled-acorn marshalled array-of-child-node fields BLANK

Closes **#2851** (TemplateLiteral `quasis[]`) and **#2852** (SequenceExpression
`expressions[]`) — one shared root cause.

### Root cause

`_structToPlainObject` (`src/runtime.ts`) deep-converted the **nominal** struct
fields (`val = _wasmToPlain(getter(obj))`) but merged the **sidecar**
(dynamically-assigned) props **verbatim**: `result[key] = sc[key]`.

acorn builds nodes by `new Node()` (a couple of nominal fields) then assigns the
rest dynamically — `node.quasis = [...]`, `node.expressions = [...]`,
`node.params = [...]` — so those land as sidecar props. When a sidecar value was,
or contained, raw WasmGC structs (a child AST node, or an array of them), the
verbatim merge left them opaque, so a `marshal:"copy"` / JSON consumer saw the
child fields blank:

```
missing-field  ...init.quasis[*].{type,value,tail}        (#2851)
missing-field  ...init.expressions[*].{type,value,...}    (#2852)
```

This is distinct from #2841 (already merged), which fixed the host-**JS-array**
path in `_wasmToPlain`; sidecar values never reached that recursion.

### Fix (1 line)

Recurse `_wasmToPlain` on sidecar values too, mirroring the nominal-field path:

```ts
result[key] = _wasmToPlain(sc[key], exports, seen);
```

Idempotent for plain JS values (`_wasmToPlain` returns primitives as-is); threads
the JSON cycle-detection `seen` set.

### Verify-first (acorn differential corpus)

- BEFORE: `corpus/templates.js` REAL `missing-field @ quasis[*]`;
  `corpus/operators.js`/`sequence-misc.js` REAL `missing-field @ expressions[*]`.
- AFTER: `templates.js`, `escapes-unicode.js`, `sequence-misc.js`, `operators.js`
  all **EQUAL(±quirks), REAL=0**.

Regression test `tests/issue-2851.test.ts` (quasis + expressions + a
single-nested-struct sidecar + the param shape). 102 existing JSON/marshalling
tests still green; the 3 `#1599` standalone-JSON failures are pre-existing on
main (unrelated).

Touches the shared host marshaller → full `merge_group` (auto-enqueue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)