### PR TITLE
fix(#2883): hint-less object-literal [Symbol.toPrimitive]() emits valid Wasm

### DIFF
--- a/plan/issues/2883-toprimitive-hintless-objlit-invalid-wasm.md
+++ b/plan/issues/2883-toprimitive-hintless-objlit-invalid-wasm.md
@@ -1,0 +1,101 @@
+---
+id: 2883
+title: "Hint-less object-literal [Symbol.toPrimitive]() emits invalid Wasm — __call_@@toPrimitive arity mismatch (expected externref, got (ref N))"
+status: done
+sprint: current
+created: 2026-06-30
+updated: 2026-06-30
+completed: 2026-06-30
+assignee: ttraenkler/explore4
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: max
+task_type: bugfix
+area: codegen
+language_feature: symbol-toprimitive
+goal: core-semantics
+depends_on: []
+related: [1716, 2083, 2638, 2679]
+---
+
+# #2883 — hint-less `[Symbol.toPrimitive]()` produces an invalid Wasm module
+
+## Symptom
+
+Any module containing an object literal (or class) whose `[Symbol.toPrimitive]`
+method **does not declare a hint parameter** failed `WebAssembly.instantiate`:
+
+```
+WebAssembly.instantiate(): Compiling function #N:"__call_@@toPrimitive" failed:
+  type error in fallthru[0] (expected externref, got (ref 25)) @+4400 in __call_@@toPrimitive()
+```
+
+This is the extremely common abrupt-completion test shape
+`{ [Symbol.toPrimitive]() { throw new Test262Error(); } }` and the forked
+two-literal shape. Because the whole module fails to instantiate, the affected
+tests register as `compile_error`, not `fail`.
+
+## Blast radius (fresh single-file scan, current origin/main)
+
+40 test262 tests across the suite produced the invalid `__call_@@toPrimitive`
+module: `AggregateError`/`SuppressedError` message-ToString-abrupt,
+`String.prototype.replaceAll` this-tostring / replaceValue-tostring,
+`Array.prototype.flatMap` poisoned-length, `Atomics.waitAsync` argument
+coercion (×23), `TypedArray.prototype.sort` sort-tonumber, annexB
+`escape`/`unescape` to-primitive, `Iterator.zip*` options-mode, `ShadowRealm`,
+`Intl` Segmenter/DisplayNames.
+
+Measured net over the 291 `Symbol.toPrimitive`-touching tests:
+**compile_error 49 → 9, pass 89 → 103 (+14), 0 regressions.**
+
+## Root cause (ECMA-262 §7.1.1 ToPrimitive)
+
+§7.1.1 step 2: when `input[@@toPrimitive]` is callable,
+`Return ? Call(exoticToPrim, input, « hint »)`. The hint is _passed_, but a
+method that ignores it (declares zero params) is still valid.
+
+`emitToPrimitiveMethodExport` (src/codegen/index.ts) emits the runtime
+`__call_@@toPrimitive(self, hint) -> externref` dispatcher. It resolved the
+method via `classMemberFuncKey(ctx, "${structName}_@@toPrimitive")` and then
+**unconditionally pushed `self + hint` (2 args)** into the `call`.
+
+For a nominal/object-literal `[Symbol.toPrimitive](hint)` the resolved function
+really is `(self/capture, hint) -> result` (2 params) — fine. But a **hint-less**
+`[Symbol.toPrimitive]()` compiles to a single-param `(self/capture) -> result`
+body (for an object literal the closure captures the object itself, so the lone
+param is the object struct). Pushing 2 args into a 1-param callee is an arity
+mismatch; a downstream arg-coercion/repair pass "fixed" it by consuming the hint
+as the single param, **dropping the call result, and leaving the `self` struct
+ref on the stack** — so the dispatcher's `if (result externref)` arm fell
+through with `(ref N)` instead of `externref` → invalid module.
+
+The 2-param (with-hint) shape always validated, which is why this hid behind the
+more common explicitly-typed-hint tests.
+
+## Fix
+
+Branch the dispatch on the resolved method's **real param count**:
+
+- `params.length >= 2` → forward the hint (`local.get 1`) — byte-identical to
+  the old path (and still skips nativeStrings non-externref hint params).
+- `params.length < 2` → call with `self` only (no hint push).
+
+`ref.cast typeIdx` yields `(ref typeIdx)`, a subtype of the callee's
+`(ref null typeIdx)` self/capture param, so the 1-arg call validates and
+dispatches to the correct body. Result coercion (`extern.convert_any` /
+`__box_number`) is unchanged.
+
+Single localized change in `emitToPrimitiveMethodExport`; the dispatcher is only
+emitted for modules that actually have a `_@@toPrimitive` method, so modules
+without one are unaffected, and the with-hint path is unchanged — there is no
+code path by which a previously-passing test can regress (confirmed: 0 losses
+over the 291-test diff and the full TypedArray/DataView/ArrayBuffer/Iterator/
+Promise/Error/Symbol lane re-scan).
+
+## Test
+
+`tests/issue-2883.test.ts` — `compileToWasm` validity guards for the hint-less
+throwing / forked / multi-method shapes, plus `assertEquivalent` value checks on
+the runtime ToPrimitive paths the dispatcher backs (`Number(o)`, `String(o)`,
+object-key coercion) and the unchanged with-hint path.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -3245,7 +3245,7 @@ function emitToPrimitiveMethodExport(ctx: CodegenContext): void {
     addUnionImports(ctx);
   }
 
-  const entries: { typeIdx: number; funcIdx: number; resultType: ValType }[] = [];
+  const entries: { typeIdx: number; funcIdx: number; resultType: ValType; takesHint: boolean }[] = [];
 
   for (const [structName] of ctx.structFields) {
     const typeIdx = ctx.structMap.get(structName);
@@ -3268,13 +3268,26 @@ function emitToPrimitiveMethodExport(ctx: CodegenContext): void {
         ? funcType.results[0]!
         : { kind: "externref" };
 
-    // The hint param is param[1] (param[0] is `self`). Only forward when it is
-    // an externref; skip nativeStrings string-ref params (see doc comment).
-    const hintParamType =
-      funcType && funcType.kind === "func" && funcType.params.length > 1 ? funcType.params[1] : undefined;
+    // (#2883) The resolved `${structName}_@@toPrimitive` function is either a
+    // 2-param `(self, hint) -> result` method (the method declared its hint
+    // param — nominal class OR object literal `[Symbol.toPrimitive](hint)`) or a
+    // 1-param `(self) -> result` body (the method ignores the hint, e.g. the very
+    // common `[Symbol.toPrimitive]() { throw … }` abrupt-completion shape, whose
+    // object-literal closure body is `(captureStruct) -> result`). The dispatcher
+    // must forward the hint ONLY in the 2-param case; pushing `self + hint` into a
+    // 1-param callee produced an arity mismatch that a downstream arg-coercion
+    // pass "repaired" by dropping the result and leaving the struct ref on the
+    // stack — yielding an invalid `fallthru[0] (expected externref, got (ref N))`
+    // module for ~40 suite-wide tests. Branch on the real param count.
+    const paramCount = funcType && funcType.kind === "func" ? funcType.params.length : 1;
+    const takesHint = paramCount >= 2;
+    // When the hint IS forwarded, skip nativeStrings non-externref string-ref
+    // hint params (the runtime that calls `__call_@@toPrimitive` is JS-host-only
+    // and cannot synthesize the WasmGC string-ref hint inline — see doc comment).
+    const hintParamType = takesHint && funcType && funcType.kind === "func" ? funcType.params[1] : undefined;
     if (hintParamType !== undefined && hintParamType.kind !== "externref") continue;
 
-    entries.push({ typeIdx, funcIdx, resultType });
+    entries.push({ typeIdx, funcIdx, resultType, takesHint });
   }
 
   if (entries.length === 0) return;
@@ -3299,9 +3312,15 @@ function emitToPrimitiveMethodExport(ctx: CodegenContext): void {
     const testAndCall: Instr[] = [
       { op: "local.get", index: 2 } as Instr,
       { op: "ref.cast", typeIdx: entry.typeIdx } as Instr,
-      { op: "local.get", index: 1 } as Instr, // hint (externref)
-      { op: "call", funcIdx: entry.funcIdx } as Instr,
     ];
+    // (#2883) Forward the ToPrimitive hint ONLY to a method that declared it.
+    // A hint-less `[Symbol.toPrimitive]()` body takes a single (self/capture)
+    // param; pushing the hint there is an arity mismatch that corrupts the
+    // dispatcher (see entry-collection comment above).
+    if (entry.takesHint) {
+      testAndCall.push({ op: "local.get", index: 1 } as Instr); // hint (externref)
+    }
+    testAndCall.push({ op: "call", funcIdx: entry.funcIdx } as Instr);
 
     if (entry.resultType.kind === "ref" || entry.resultType.kind === "ref_null") {
       testAndCall.push({ op: "extern.convert_any" } as Instr);

--- a/tests/issue-2883.test.ts
+++ b/tests/issue-2883.test.ts
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2883 — object-literal `[Symbol.toPrimitive]` with NO declared hint param
+// produced an INVALID Wasm module. The `__call_@@toPrimitive` runtime dispatcher
+// (`emitToPrimitiveMethodExport` in src/codegen/index.ts) unconditionally pushed
+// `self + hint` (2 args) into the resolved method, but a hint-less
+// `[Symbol.toPrimitive]() { … }` (the very common abrupt-completion test shape)
+// compiles to a single-param `(self) -> result` body. The arity mismatch was
+// "repaired" by a downstream arg-coercion pass that dropped the result and left
+// the struct ref on the stack, so the dispatcher fell through with `(ref N)`
+// where its block type demanded `externref` —
+//   "type error in fallthru[0] (expected externref, got (ref N))"
+// — failing `WebAssembly.instantiate` for ~40 suite-wide test262 tests
+// (AggregateError/SuppressedError message-ToString-abrupt, String.replaceAll
+// this-tostring, Array flatMap poisoned-length, Atomics.waitAsync arg coercion,
+// TypedArray sort-tonumber, annexB escape/unescape, …; +14 flip straight to pass).
+//
+// ECMA-262 §7.1.1 ToPrimitive step 2: when `input[@@toPrimitive]` is callable,
+// `Return ? Call(exoticToPrim, input, « hint »)`. The hint is *passed*, but a
+// method that ignores it (declares zero params) is still valid — the dispatcher
+// must forward the hint ONLY when the method declared it.
+//
+// Fix: branch the dispatch on the resolved method's real param count — forward
+// the hint to a 2-param `(self, hint)` method, call a 1-param `(self)` method
+// with `self` only.
+//
+// `compileToWasm` internally runs `WebAssembly.validate` + `instantiate` and
+// THROWS on an invalid module, so a callable `test` export guards the core
+// regression (the pre-fix module was invalid). `assertEquivalent` runs compiled
+// wasm AND native JS and asserts agreement on the runtime ToPrimitive paths
+// (`String`/`Number`/object-key) the dispatcher actually backs.
+import { describe, it, expect } from "vitest";
+import { assertEquivalent, compileToWasm } from "./equivalence/helpers.js";
+
+describe("#2883 hint-less object-literal [Symbol.toPrimitive] dispatch", () => {
+  it("hint-less [Symbol.toPrimitive]() that throws compiles to a VALID module", async () => {
+    // Pre-fix this failed WebAssembly.instantiate outright (compileToWasm throws).
+    const exports = await compileToWasm(`
+      export function test(): number {
+        const o: any = { [Symbol.toPrimitive]() { throw 7; } };
+        const s: any = String(o as any);
+        return 0;
+      }
+    `);
+    expect(typeof exports.test).toBe("function");
+  });
+
+  it("two forked hint-less object literals compile to a VALID module", async () => {
+    const exports = await compileToWasm(`
+      export function test(): number {
+        const a: any = { [Symbol.toPrimitive]() { return 1; } };
+        const b: any = { [Symbol.toPrimitive]() { return 2; } };
+        const s: any = String(a as any);
+        const t: any = String(b as any);
+        return 0;
+      }
+    `);
+    expect(typeof exports.test).toBe("function");
+  });
+
+  it("multi-method object (toPrimitive+toString+valueOf) compiles to a VALID module", async () => {
+    const exports = await compileToWasm(`
+      export function test(): number {
+        const o: any = {
+          [Symbol.toPrimitive]() { return 9; },
+          toString() { return "ts"; },
+          valueOf() { return 3; },
+        };
+        return Number(o as any);
+      }
+    `);
+    expect(typeof exports.test).toBe("function");
+  });
+
+  it("Number(o): hint-less toPrimitive numeric result is dispatched correctly", async () => {
+    await assertEquivalent(
+      `
+      export function test(): number {
+        const o: any = { [Symbol.toPrimitive]() { return 7; } };
+        return Number(o as any) === 7 ? 1 : 0;
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("String(o): hint-less toPrimitive string-coercion is dispatched correctly", async () => {
+    await assertEquivalent(
+      `
+      export function test(): number {
+        const o: any = { [Symbol.toPrimitive]() { return "hi"; } };
+        const s: any = String(o as any);
+        return s === "hi" ? 1 : 0;
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("object-key coercion routes through hint-less toPrimitive", async () => {
+    await assertEquivalent(
+      `
+      export function test(): number {
+        const o: any = { [Symbol.toPrimitive]() { return "k"; } };
+        const m: any = {};
+        m[o as any] = 9;
+        return m["k"] === 9 ? 1 : 0;
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+
+  it("with-hint [Symbol.toPrimitive](hint) still receives the hint (unchanged 2-param path)", async () => {
+    await assertEquivalent(
+      `
+      export function test(): number {
+        const o: any = { [Symbol.toPrimitive](hint: string) { return hint === "number" ? 11 : 22; } };
+        return Number(o as any);
+      }
+      `,
+      [{ fn: "test", args: [] }],
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Any module with an object literal (or class) whose `[Symbol.toPrimitive]` method **declares no hint parameter** failed `WebAssembly.instantiate`:

```
__call_@@toPrimitive failed: type error in fallthru[0] (expected externref, got (ref N))
```

This is the extremely common abrupt-completion shape `{ [Symbol.toPrimitive]() { throw new Test262Error(); } }` (and the forked two-literal shape). The whole module fails to instantiate, so affected tests register as `compile_error`.

## Root cause (ECMA-262 §7.1.1 ToPrimitive)

`emitToPrimitiveMethodExport` (`src/codegen/index.ts`) emits the `__call_@@toPrimitive(self, hint) -> externref` dispatcher and **unconditionally pushed `self + hint` (2 args)** into the resolved method. A hint-less `[Symbol.toPrimitive]()` compiles to a single-param `(self/capture) -> result` body (an object literal's closure captures the object itself). Pushing 2 args into a 1-param callee is an arity mismatch; a downstream arg-coercion pass "repaired" it by **dropping the call result and leaving the `self` struct ref on the stack**, so the dispatcher's `if (result externref)` arm fell through with `(ref N)` instead of `externref` → invalid module. The 2-param (explicit-hint) shape always validated, which hid the bug.

## Fix

Branch the dispatch on the resolved method's real param count:
- `params.length >= 2` → forward the hint (byte-identical to the old path; still skips nativeStrings non-externref hint params).
- `params.length < 2` → call with `self` only.

`ref.cast typeIdx` yields `(ref typeIdx)`, a subtype of the callee's `(ref null typeIdx)` self/capture param, so the 1-arg call validates and dispatches correctly. Result coercion is unchanged. The dispatcher is only emitted for modules that have a `_@@toPrimitive` method, so modules without one are unaffected.

## Measured impact (fresh single-file scans vs current `main`)

- Over the **291 `Symbol.toPrimitive`-touching** test262 tests: `compile_error` 49 → 9, `pass` 89 → 103 (**+14, 0 regressions**). Wins include AggregateError/SuppressedError message-ToString-abrupt, String.replaceAll this/replaceValue-tostring, Array flatMap poisoned-length, Atomics.waitAsync arg coercion, TypedArray sort-tonumber, annexB escape/unescape.
- Full **TypedArray/DataView/ArrayBuffer/Iterator/Promise/Error/Symbol lane re-scan** (4377 tests): **+2 / -0**.

## Test

`tests/issue-2883.test.ts` — `compileToWasm` validity guards (hint-less throwing / forked / multi-method shapes) + `assertEquivalent` value checks on the runtime ToPrimitive paths the dispatcher backs (`Number(o)`, `String(o)`, object-key) and the unchanged with-hint path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS