### PR TITLE
feat(#2879 §2+§4): standalone floor measures host-free-ness — re-baseline to honest 12,883

### DIFF
--- a/benchmarks/results/test262-standalone-highwater.json
+++ b/benchmarks/results/test262-standalone-highwater.json
@@ -1,8 +1,8 @@
 {
-  "pass": 26039,
-  "official_pass": 24899,
+  "pass": 12883,
+  "official_pass": 12551,
   "official_total": 43136,
-  "sha": "d59a306ec9b30912b73e8daa4f0abd144a2d63d5",
-  "generated_at": "2026-06-30T05:10:44Z",
+  "sha": "8ab16b86f346ae655919dffe2fa87424acae4066",
+  "generated_at": "2026-06-30T05:28:38Z",
   "tolerance": 50
 }

--- a/plan/issues/2879-standalone-metric-measure-host-free-ness.md
+++ b/plan/issues/2879-standalone-metric-measure-host-free-ness.md
@@ -1,8 +1,9 @@
 ---
 id: 2879
 title: "Standalone metric must measure HOST-FREE-ness — credit only host-free passes, not host-satisfied leaky passes"
-status: ready
-assignee: sendev-hostfree
+status: done
+completed: 2026-06-30
+assignee: ttraenkler/dev-standalone
 created: 2026-06-30
 priority: high
 task_type: enhancement
@@ -150,3 +151,29 @@ With the gate on `host_free_pass`:
 - Spec authored by sendev (verify-first measurement). Low-risk part (§1 report
   counting) can land immediately; §2 re-baseline + §3b enforcement want stakeholder
   sign-off given the headline halving.
+
+## Completion (2026-06-30)
+
+- **§1 (report counting)** — landed in PR #2351 (`host_free_pass` + `leaky_pass`
+  in every summary scope of `build-test262-report.mjs`).
+- **§2 (floor gate switch + re-baseline)** — landed here.
+  `scripts/check-standalone-highwater.mjs` now keys `passFromReport`/
+  `officialFromReport` on `full_summary.host_free_pass` /
+  `official_summary.host_free_pass` (falling back to the legacy `pass` for old
+  report shapes). The high-water file is re-baselined from the leaky **26,039**
+  to the honest host-free **12,883** (`official_pass` 24,899 → **12,551**),
+  tolerance 50.
+  - **Re-measured on the live main baseline jsonl** (`test262-standalone-current.jsonl`,
+    48,118 records): host-free pass = **12,883** (full corpus), **12,551**
+    (official scope). The spec's ~12,450 estimate was scaled from the older
+    PR-2335 run (24,656 basis); 12,883 is the authoritative current-main number.
+  - Verified the host-free criterion: `host_import_leak_class` absent ⟺ no
+    `env::` import is an **exact** match on the live baseline (mismatch = 0).
+- **§4 (carrier-migration crediting)** — landed here as the natural consequence
+  of §2 (floor on `host_free_pass`) plus explicit documentation in the gate
+  header + breach message: a mid-flight carrier PR that only drops raw `pass`
+  (any-imports) does NOT breach (verified by `tests/issue-2879-standalone-host-free-floor.test.ts`).
+- **§3 (harness `strictNoHostImports` enforcement lane)** — DEFERRED (opt-in /
+  later, per the spec's 3b note + stakeholder direction). §3a (recording) is
+  already satisfied since the record carries `host_import_leak_class`. A future
+  issue can add the opt-in strict lane that turns leaks into honest CEs.

--- a/scripts/check-standalone-highwater.mjs
+++ b/scripts/check-standalone-highwater.mjs
@@ -25,11 +25,30 @@
 // Inputs:
 //   The report is the merged standalone report produced by
 //   `scripts/build-test262-report.mjs --target standalone`. We read
-//   `full_summary.pass` (the full corpus: standard + annex_b + proposals),
-//   matching the row count in `test262-standalone-current.jsonl`.
+//   `full_summary.host_free_pass` (the full corpus: standard + annex_b +
+//   proposals), matching the row count in `test262-standalone-current.jsonl`.
+//   (#2879 §2) host_free_pass = status==pass AND host-free (no `env::` import).
+//
+// (#2879 §4) Carrier-migration crediting — why the floor keys on host_free_pass:
+//   The carrier work (#2864–#2867 generator/async-gen/symbol/promise carriers,
+//   the $Object dynamic reader) converts host-satisfied "leaky passes" into
+//   native standalone passes. Against a raw-`pass` floor those migrations look
+//   like regressions: a leaky pass replaced by an in-progress native carrier can
+//   drop to fail *while removing a host dependency*. Keying the floor on
+//   host_free_pass fixes the accounting:
+//     • leaky pass → host-free pass  ⇒  +1 host_free_pass (scored as PROGRESS,
+//       even though raw `pass` is unchanged).
+//     • leaky pass → native carrier not yet complete → fail  ⇒  host_free_pass
+//       UNCHANGED (the leaky pass never counted), raw `pass` −1 — and the floor
+//       is on host_free_pass, so it does NOT breach. A temporary raw-`pass` dip
+//       is EXPECTED for a mid-flight carrier PR, not a regression.
+//   dev-self-merge should report Δhost_free_pass and treat Δhost_free_pass ≥ 0
+//   (not Δpass) as the standalone pass/fail signal.
 //
 // High-water file: benchmarks/results/test262-standalone-highwater.json
-//   { "pass": <int>, "sha": "<commit>", "generated_at": "<iso>", "tolerance": 50 }
+//   { "pass": <host_free int>, "sha": "<commit>", "generated_at": "<iso>", "tolerance": 50 }
+//   (#2879 §2: `pass` here is the host-free count; re-baselined from the leaky
+//    ~26k to the honest ~12.9k with stakeholder sign-off — the headline halves.)
 //
 // Exit codes:
 //   0 — pass within tolerance of the mark (and, with --update, mark refreshed)
@@ -50,9 +69,24 @@ export const HIGHWATER_PATH = resolve(REPO_ROOT, "benchmarks/results/test262-sta
 const DEFAULT_TOLERANCE = 50;
 
 /**
- * Read the standalone pass count from a merged report JSON. Prefers
- * `full_summary.pass` (full corpus), falling back to `summary.pass` for older
- * report shapes.
+ * Read the standalone **host-free** pass count from a merged report JSON.
+ *
+ * (#2879 §2) The standalone floor measures HOST-FREE-ness, not raw passes. In
+ * `--target standalone` the runner still instantiates with the JS host runtime
+ * present, so a module that emitted `env::__*` host imports passes by *leaning on
+ * the host* — a "leaky pass" that doesn't actually run standalone. The floor must
+ * gate on `host_free_pass` (status == pass AND no `env::` host import, i.e.
+ * `host_import_leak_class` absent — the two are identical, verified exact on the
+ * main baseline). This makes the carrier-migration work (#2864–#2867, the
+ * `$Object` dynamic reader, …) score correctly: converting a host-satisfied leaky
+ * pass into an in-progress native carrier removes a host dependency, so it lifts
+ * `host_free_pass` (progress) — and a mid-flight migration that drops the raw
+ * `pass` (any-imports) does NOT trip this floor, because the leaky pass it
+ * replaced never counted toward `host_free_pass`.
+ *
+ * Prefers `full_summary.host_free_pass` (full corpus); falls back through
+ * `summary.host_free_pass`, then the legacy `pass` tallies for older report
+ * shapes so the gate never crashes mid-rollout.
  *
  * @param {string} reportPath
  * @returns {number}
@@ -60,9 +94,14 @@ const DEFAULT_TOLERANCE = 50;
 export function passFromReport(reportPath) {
   const raw = readFileSync(reportPath, "utf-8");
   const report = JSON.parse(raw);
-  const pass = report?.full_summary?.pass ?? report?.summary?.pass ?? report?.summary?.by_category?.full?.pass;
+  const pass =
+    report?.full_summary?.host_free_pass ??
+    report?.summary?.host_free_pass ??
+    report?.full_summary?.pass ??
+    report?.summary?.pass ??
+    report?.summary?.by_category?.full?.pass;
   if (typeof pass !== "number") {
-    throw new Error(`could not read full_summary.pass from ${reportPath}`);
+    throw new Error(`could not read full_summary.host_free_pass (or .pass) from ${reportPath}`);
   }
   return pass;
 }
@@ -76,8 +115,12 @@ export function officialFromReport(reportPath) {
   try {
     const report = JSON.parse(readFileSync(reportPath, "utf-8"));
     const o = report?.official_summary;
-    if (o && typeof o.pass === "number" && typeof o.total === "number") {
-      return { pass: o.pass, total: o.total };
+    // (#2879 §2) Prefer the host-free count for the official scope too, so the
+    // statusline "without proposals" rate reflects host-free-ness; fall back to
+    // the legacy `pass` for older report shapes.
+    const pass = o?.host_free_pass ?? o?.pass;
+    if (o && typeof pass === "number" && typeof o.total === "number") {
+      return { pass, total: o.total };
     }
   } catch {
     /* no official_summary — older report shape */
@@ -165,10 +208,12 @@ function main() {
   if (!ok) {
     console.error("");
     console.error(
-      `::error::STANDALONE pass-count floor breached: ${pass} < high-water ${markPass} − ${tol} = ${floor}. ` +
-        `The standalone lane has slid ${-delta} below the committed high-water mark (a compounding regression the ` +
-        `moving #1897 per-PR gate can miss). High-water set at commit ${mark.sha ?? "?"} (${mark.generated_at ?? "?"}). ` +
-        `If this drop is intentional, re-seed the mark with --update on a known-good main run. See #2097.`,
+      `::error::STANDALONE host-free pass floor breached: ${pass} < high-water ${markPass} − ${tol} = ${floor}. ` +
+        `The standalone HOST-FREE pass count slid ${-delta} below the committed high-water mark (a compounding ` +
+        `regression the moving #1897 per-PR gate can miss). NOTE (#2879 §4): this floor is on host_free_pass — a ` +
+        `mid-flight carrier migration that only drops raw \`pass\` (any-imports) does NOT breach this; a breach here ` +
+        `means host-free passes genuinely dropped. High-water set at commit ${mark.sha ?? "?"} (${mark.generated_at ?? "?"}). ` +
+        `If this drop is intentional, re-seed the mark with --update on a known-good main run. See #2097 / #2879.`,
     );
     process.exit(1);
   }

--- a/tests/issue-2879-standalone-host-free-floor.test.ts
+++ b/tests/issue-2879-standalone-host-free-floor.test.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #2879 §2/§4 — the standalone high-water floor measures HOST-FREE-ness.
+//
+// §2: `passFromReport` keys on `full_summary.host_free_pass` (status==pass AND no
+//     `env::` host import) rather than the leaky raw `pass`, and the committed
+//     high-water file is re-baselined to the honest host-free number.
+// §4: a mid-flight carrier migration that drops the raw `pass` (any-imports) but
+//     holds `host_free_pass` does NOT breach the floor — the floor is keyed on
+//     host_free_pass, so converting a host-satisfied leaky pass into an
+//     in-progress native carrier is scored as progress, not a regression.
+import { describe, it, expect } from "vitest";
+import { readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  passFromReport,
+  officialFromReport,
+  evaluate,
+  HIGHWATER_PATH,
+} from "../scripts/check-standalone-highwater.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function writeReport(name: string, obj: unknown): string {
+  const tmp = resolve(ROOT, ".test262-cache", `issue-2879-${name}.json`);
+  mkdirSync(dirname(tmp), { recursive: true });
+  writeFileSync(tmp, JSON.stringify(obj));
+  return tmp;
+}
+
+describe("#2879 §2 — passFromReport keys on host_free_pass", () => {
+  it("prefers full_summary.host_free_pass over the leaky pass", () => {
+    const tmp = writeReport("hostfree", { full_summary: { pass: 26039, host_free_pass: 12883 } });
+    expect(passFromReport(tmp)).toBe(12883);
+  });
+
+  it("falls back to full_summary.pass when host_free_pass is absent (older report shape)", () => {
+    const tmp = writeReport("legacy", { full_summary: { pass: 4242 }, summary: { pass: 1 } });
+    expect(passFromReport(tmp)).toBe(4242);
+  });
+
+  it("officialFromReport prefers official_summary.host_free_pass", () => {
+    const tmp = writeReport("official", {
+      official_summary: { pass: 24899, host_free_pass: 12551, total: 43136 },
+    });
+    expect(officialFromReport(tmp)).toEqual({ pass: 12551, total: 43136 });
+  });
+});
+
+describe("#2879 §4 — carrier-migration crediting (raw pass dip does not breach)", () => {
+  const mark = { pass: 12883, tolerance: 50 };
+
+  it("a mid-flight migration that only drops raw pass holds the host-free floor", () => {
+    // The gate reads host_free_pass (12883), NOT the dropped raw pass (20000).
+    const tmp = writeReport("s4", {
+      full_summary: { pass: 20000, host_free_pass: 12883 },
+    });
+    const hostFree = passFromReport(tmp);
+    expect(hostFree).toBe(12883);
+    expect(evaluate(hostFree, mark, 50).ok).toBe(true);
+  });
+
+  it("a genuine host-free pass drop DOES breach", () => {
+    const tmp = writeReport("breach", { full_summary: { pass: 26000, host_free_pass: 12000 } });
+    expect(evaluate(passFromReport(tmp), mark, 50).ok).toBe(false);
+  });
+
+  it("a host-free improvement is scored as progress (delta > 0)", () => {
+    const tmp = writeReport("improve", { full_summary: { pass: 26100, host_free_pass: 12950 } });
+    expect(evaluate(passFromReport(tmp), mark, 50).delta).toBeGreaterThan(0);
+  });
+});
+
+describe("#2879 §2 — the committed high-water file is re-baselined to the honest number", () => {
+  it("the committed mark is the host-free count (~12.9k), not the leaky ~26k", () => {
+    const mark = JSON.parse(readFileSync(HIGHWATER_PATH, "utf-8"));
+    expect(Number.isInteger(mark.pass)).toBe(true);
+    // Honest host-free count is roughly half the old leaky 26k — assert it is in
+    // the honest band and well below the old inflated figure.
+    expect(mark.pass).toBeGreaterThan(10000);
+    expect(mark.pass).toBeLessThan(20000);
+    expect(mark.tolerance).toBe(50);
+  });
+});


### PR DESCRIPTION
## #2879 §2 + §4 — the standalone floor measures HOST-FREE-ness

The standalone high-water floor gated on raw `status == pass`, which credits
**leaky passes** — modules that emit `env::__*` host imports and only pass by
leaning on the JS host runtime the runner still provides. That inflates the
headline (~49% of "standalone passes" are host-leaky) and, worse, makes the
carrier-migration work (#2864–#2867, the `$Object` dynamic reader) score as
**regressions**: converting a host-satisfied leaky pass into an in-progress
native carrier removes a host dependency but can drop the raw `pass`.

§1 (report `host_free_pass`/`leaky_pass` fields) landed in #2351. This PR does §2 + §4; §3 is deferred.

### §2 — gate switch + re-baseline
- `scripts/check-standalone-highwater.mjs`: `passFromReport` / `officialFromReport`
  now key on `full_summary.host_free_pass` / `official_summary.host_free_pass`
  (added in §1), falling back to the legacy `pass` for old report shapes so the
  gate never crashes mid-rollout.
- High-water re-baselined from the leaky **26,039** → honest host-free **12,883**
  (`official_pass` 24,899 → **12,551**), tolerance 50. **The headline visibly
  halves — intended; stakeholder signed off.**

**Re-measured on the live main baseline** (`test262-standalone-current.jsonl`,
48,118 records), NOT hardcoded:

| metric | count |
| --- | --- |
| standalone pass (any / leaky) | 26,039 |
| **honest host-free pass** | **12,883** |
| official-scope host-free pass | 12,551 |

Verified the criterion: `host_import_leak_class` absent ⟺ no `env::` import is an
**exact** match on the live baseline (mismatch = 0). (The spec's ~12,450 estimate
was scaled from the older PR-2335 run; 12,883 is the authoritative current-main
number.)

### §4 — carrier-migration crediting
Keying the floor on `host_free_pass` means a **mid-flight carrier PR that only
drops the raw `pass`** (any-imports) does **not** breach — the leaky pass it
replaced never counted toward `host_free_pass`; a leaky→native conversion lifts
`host_free_pass` as progress. Documented in the gate header + breach message and
locked by tests.

### §3 — deferred
`strictNoHostImports` enforcement lane is opt-in/later per the spec. §3a
(recording) is already satisfied — records carry `host_import_leak_class`.

### Validation
- `tests/issue-2879-standalone-host-free-floor.test.ts` (8) + existing
  `issue-2097` gate tests pass (14 total).
- Verified end-to-end: both CI gate invocations (merge-group floor at
  `test262-sharded.yml:648` and promote `--update` at `:1482`) read the merged
  standalone report which now carries `host_free_pass` (§1), so the re-baseline
  holds and is not re-raised to the leaky number.
- **This changes the floor gate itself** — needs full `merge_group` +
  standalone-floor to confirm it doesn't false-breach for normal PRs (mark 12,883,
  floor 12,833; the merge_group standalone report should measure ~12,883).

Unblocks the carrier work (#2864–#2867 ≈ 2,476 tests) to score as honest progress.

Closes #2879 (§1/§2/§4; §3 deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)