### PR TITLE
fix(#2884): port decimalToHexString.js harness shim correctly (+37 test262)

### DIFF
--- a/plan/issues/2884-decimaltohex-harness-shim.md
+++ b/plan/issues/2884-decimaltohex-harness-shim.md
@@ -1,0 +1,126 @@
+---
+id: 2884
+title: "test262 runner stubs decimalToHexString.js harness incorrectly — false failures across encode/decode-URI"
+status: done
+sprint: current
+priority: high
+horizon: s
+area: testing
+language_feature: global-functions
+assignee: ttraenkler/explore6
+feasibility: easy
+created: 2026-06-30
+completed: 2026-06-30
+---
+
+## Problem
+
+~37 test262 tests under `built-ins/{decodeURI,decodeURIComponent,encodeURI,encodeURIComponent}/`
+and `harness/decimalToHexString.js` fail with a false `#…`-coded failure even
+though the underlying `decodeURI`/`encodeURI` runtime behaviour is correct
+(verified — those functions throw `URIError` on malformed UTF-8 / unpaired
+surrogates, and `e instanceof URIError` is observed correctly through the wasm
+boundary).
+
+Root cause is in the **test262 runner harness shim**, not in the compiler or
+runtime. The `decimalToHexString.js` harness (`test262/harness/decimalToHexString.js`)
+`defines: [decimalToHexString, decimalToPercentHexString]`. The runner's
+`buildPreamble` in `tests/test262-runner.ts` injected only a **constant stub**:
+
+```ts
+function decimalToHexString(n: number): string { return "0"; }
+```
+
+This is wrong in two ways:
+
+1. **`decimalToPercentHexString` was never defined at all.** The encode/decode-URI
+   tests build their percent-encoded **test input** with this function
+   (e.g. `decodeURI(decimalToPercentHexString(0xC0) + decimalToPercentHexString(0x00))`
+   = `decodeURI("%C0%00")`). With the function undefined, the input came out as
+   garbage, so the spec-required `URIError` was never triggered, and the test
+   recorded a false `result = false` → `errorCount > 0` →
+   `throw new Test262Error('#…')`. This affected the entire `A1.*` (decode) and
+   `A2.*` (encode) families.
+
+2. **`decimalToHexString` returned a constant `"0"`.** The harness self-test
+   `test/harness/decimalToHexString.js` asserts `decimalToHexString(-1) === "FFFFFFFF"`,
+   `decimalToHexString(0.5) === "0000"`, `decimalToHexString(65536) === "10000"`,
+   etc., which the constant stub failed.
+
+## Spec
+
+ECMA-262 §19.2.6.1 `decodeURI ( encodedURI )` → `Decode(encodedURI, …)`
+(§19.2.6.5) throws **URIError** for malformed escape sequences and invalid
+UTF-8 continuation bytes. §19.2.6.4 `encodeURI` → `Encode` throws **URIError**
+for unpaired surrogate code points. The harness `decimalToHexString.js` helpers
+are pure `number → string` formatters used by these tests to construct inputs
+and (on failure) error messages.
+
+## Fix
+
+Replace the constant stub in `buildPreamble` (`tests/test262-runner.ts`) with a
+faithful TypeScript port of **both** harness functions, and widen the
+`needsDecimalToHex` detection to fire when a test references either
+`decimalToHexString` **or** `decimalToPercentHexString`:
+
+```ts
+function decimalToHexString(n: number): string {
+  const hex = "0123456789ABCDEF";
+  n = n >>> 0;
+  let s = "";
+  while (n) { s = hex[n & 0xf] + s; n = n >>> 4; }
+  while (s.length < 4) { s = "0" + s; }
+  return s;
+}
+function decimalToPercentHexString(n: number): string {
+  const hex = "0123456789ABCDEF";
+  return "%" + hex[(n >> 4) & 0xf] + hex[n & 0xf];
+}
+```
+
+Both compile through the standard codegen path with **no new host imports**
+(verified). `decimalToHexString` is only ever called in test error-message
+construction (never on the pass path) except in the harness self-test, so making
+it real cannot regress a currently-passing test; the only assertion-level
+consumer is the self-test, which moves fail → pass.
+
+## Why this is a runner fix, not a compiler fix
+
+`decodeURI`/`encodeURI`/`decodeURIComponent`/`encodeURIComponent` already behave
+to spec (host imports delegate to the native global, which throws the native
+`URIError`; the wasm `instanceof URIError` check resolves correctly). The sole
+blocker was the runner feeding the tests a broken harness shim. No `src/` change
+is required.
+
+## Net recovery (fresh single-file processes, mirror of CI worker)
+
+| dir                     | before fail | after fail | recovered |
+| ----------------------- | ----------- | ---------- | --------- |
+| decodeURI               | 15          | 3          | 12        |
+| decodeURIComponent      | 16          | 4          | 12        |
+| encodeURI               | 9           | 3          | 6         |
+| encodeURIComponent      | 9           | 3          | 6         |
+| harness/decimalToHexString | 1        | 0          | 1         |
+| **total**               |             |            | **37**    |
+
+Remaining URI failures (`A5.2` missing `.length`, `A5.7` `new X()` should throw
+TypeError, `A6_T1` object-ToPrimitive, `throw-URIError` null-deref) are
+**separate root causes** outside this cluster — candidate follow-up issues.
+
+## Acceptance criteria
+
+- `built-ins/{decodeURI,decodeURIComponent}/S15.1.3.*_A1.*_T*.js` pass.
+- `built-ins/{encodeURI,encodeURIComponent}/S15.1.3.*_A2.*_T*.js` pass.
+- `harness/decimalToHexString.js` passes.
+- No regression in any test that includes `decimalToHexString.js`.
+
+## Test Results
+
+Verified via fresh single-file worker processes (TEST262_WORKER_RECYCLE_INTERVAL=1,
+mirrors `scripts/test262-worker.mjs`):
+- 36 URI tests fail → pass.
+- `harness/decimalToHexString.js` fail → pass.
+- Control `decodeURI/S15.1.3.1_A5.7.js` (separate cause) still fails — confirms
+  the fix is scoped to the harness-shim cluster.
+- `tests/issue-2884.test.ts` added (compiles the harness shim + exercises the
+  decode/encode URIError path).

--- a/tests/issue-2884.test.ts
+++ b/tests/issue-2884.test.ts
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Issue #2884 — test262 runner stubbed the `decimalToHexString.js` harness
+ * incorrectly, causing ~37 false failures across the encode/decode-URI families
+ * (built-ins/{decodeURI,decodeURIComponent,encodeURI,encodeURIComponent}) and
+ * the harness self-test (harness/decimalToHexString.js).
+ *
+ * Root cause was in `tests/test262-runner.ts` `buildPreamble`: it injected only
+ *
+ *     function decimalToHexString(n: number): string { return "0"; }
+ *
+ * which (a) never defined `decimalToPercentHexString` — the function those
+ * tests use to BUILD their percent-encoded input — and (b) returned a constant
+ * "0" for `decimalToHexString`. With the input function missing, the wrapped
+ * test fed garbage to `decodeURI`/`encodeURI`, the spec-required `URIError`
+ * never fired, and the test recorded a false `#…`-coded failure.
+ *
+ * The fix replaces the stub with a faithful TS port of BOTH harness functions.
+ * `decodeURI`/`encodeURI` themselves are already correct — see the runtime path
+ * exercised below — so the cluster was purely a harness-shim artifact.
+ *
+ * This test guards the fix two ways:
+ *   1. Drives the real runner path (`parseMeta` + `wrapTest`) on a synthetic
+ *      test that `includes: [decimalToHexString.js]` and asserts the generated
+ *      preamble now defines `decimalToPercentHexString` and a non-constant
+ *      `decimalToHexString`.
+ *   2. Compiles + runs the exact harness shim functions and the
+ *      malformed-UTF-8 / unpaired-surrogate URIError loops, asserting the
+ *      spec-required throws are observed through the wasm boundary.
+ */
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+import { parseMeta, wrapTest } from "./test262-runner.js";
+
+async function runWasm(src: string): Promise<unknown> {
+  const exports = await compileToWasm(src);
+  const fn = exports.test as () => unknown;
+  return fn();
+}
+
+// The faithful harness shim, identical to what buildPreamble now injects.
+const HARNESS_SHIM = `
+function decimalToHexString(n: number): string {
+  const hex = "0123456789ABCDEF";
+  n = n >>> 0;
+  let s = "";
+  while (n) { s = hex[n & 0xf] + s; n = n >>> 4; }
+  while (s.length < 4) { s = "0" + s; }
+  return s;
+}
+function decimalToPercentHexString(n: number): string {
+  const hex = "0123456789ABCDEF";
+  return "%" + hex[(n >> 4) & 0xf] + hex[n & 0xf];
+}
+`;
+
+describe("#2884 — runner harness shim: decimalToHexString.js", () => {
+  it("wrapTest now defines decimalToPercentHexString and a non-constant decimalToHexString", () => {
+    const source = `/*---
+includes: [decimalToHexString.js]
+---*/
+var a = decimalToPercentHexString(0xC0);
+var b = decimalToHexString(0xC0);
+`;
+    const meta = parseMeta(source);
+    const { source: wrapped } = wrapTest(source, meta);
+    // The missing function is now declared in the injected preamble.
+    expect(wrapped).toContain("function decimalToPercentHexString");
+    // And the constant "0" stub is gone.
+    expect(wrapped).not.toContain('function decimalToHexString(n: number): string { return "0"; }');
+    expect(wrapped).toContain("function decimalToHexString");
+  });
+
+  it("decimalToHexString matches harness self-test assertions", async () => {
+    expect(
+      await runWasm(`
+        ${HARNESS_SHIM}
+        export function test(): number {
+          if (decimalToHexString(-1) !== "FFFFFFFF") return 0;
+          if (decimalToHexString(0.5) !== "0000") return 0;
+          if (decimalToHexString(1) !== "0001") return 0;
+          if (decimalToHexString(100) !== "0064") return 0;
+          if (decimalToHexString(65535) !== "FFFF") return 0;
+          if (decimalToHexString(65536) !== "10000") return 0;
+          return 1;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("decimalToPercentHexString builds correct percent escapes", async () => {
+    expect(
+      await runWasm(`
+        ${HARNESS_SHIM}
+        export function test(): number {
+          if (decimalToPercentHexString(0xC0) !== "%C0") return 0;
+          if (decimalToPercentHexString(0x00) !== "%00") return 0;
+          if (decimalToPercentHexString(0x7F) !== "%7F") return 0;
+          return 1;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("decodeURI throws URIError on malformed UTF-8 built via the harness (mirrors decodeURI A1.13)", async () => {
+    // For every lead byte 0xC0..0xDF followed by a non-continuation byte
+    // 0x00..0x7F, decodeURI must throw URIError. This is the exact loop the
+    // false-failing A1.* tests run, now fed correct input by the shim.
+    expect(
+      await runWasm(`
+        ${HARNESS_SHIM}
+        export function test(): number {
+          for (let indexB = 0xC0; indexB <= 0xDF; indexB++) {
+            const hexB = decimalToPercentHexString(indexB);
+            for (let indexC = 0x00; indexC <= 0x7F; indexC++) {
+              const hexC = decimalToPercentHexString(indexC);
+              let threw = 0;
+              try { decodeURI(hexB + hexC); }
+              catch (e) { if (e instanceof URIError) threw = 1; }
+              if (threw === 0) return 0;
+            }
+          }
+          return 1;
+        }
+      `),
+    ).toBe(1);
+  });
+
+  it("encodeURI throws URIError on an unpaired surrogate (mirrors encodeURI A2.*)", async () => {
+    // Build the lone high surrogate at runtime (String.fromCharCode) rather
+    // than as a literal so the test does not depend on 16-bit string-constant
+    // import wiring in the equivalence helper.
+    expect(
+      await runWasm(`
+        export function test(): number {
+          const lone: string = String.fromCharCode(0xD800);
+          let threw = 0;
+          try { encodeURI(lone); }
+          catch (e) { if (e instanceof URIError) threw = 1; }
+          return threw;
+        }
+      `),
+    ).toBe(1);
+  });
+});

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -1693,9 +1693,38 @@ function isConstructor(f: number): number { return 0; }`;
   }
 
   if (needsDecimalToHex) {
+    // Faithful port of test262/harness/decimalToHexString.js — defines BOTH
+    // `decimalToHexString` and `decimalToPercentHexString`. The previous stub
+    // returned a constant "0" for decimalToHexString and never defined
+    // decimalToPercentHexString at all, which silently broke every
+    // encode/decode-URI test (built-ins/{decodeURI,decodeURIComponent,
+    // encodeURI,encodeURIComponent}/*) that builds its percent-encoded test
+    // input via decimalToPercentHexString: the input came out as garbage, so
+    // the expected URIError was never thrown and the test recorded a false
+    // `#…` failure. The harness self-test (test/harness/decimalToHexString.js)
+    // also asserts decimalToHexString(-1) === "FFFFFFFF" etc., which the
+    // constant stub failed. Both functions are pure number→string and compile
+    // through the standard codegen path (verified: no host imports added).
     p += `
 
-function decimalToHexString(n: number): string { return "0"; }`;
+function decimalToHexString(n: number): string {
+  const hex = "0123456789ABCDEF";
+  n = n >>> 0;
+  let s = "";
+  while (n) {
+    s = hex[n & 0xf] + s;
+    n = n >>> 4;
+  }
+  while (s.length < 4) {
+    s = "0" + s;
+  }
+  return s;
+}
+
+function decimalToPercentHexString(n: number): string {
+  const hex = "0123456789ABCDEF";
+  return "%" + hex[(n >> 4) & 0xf] + hex[n & 0xf];
+}`;
   }
 
   if (needsNans) {
@@ -2140,7 +2169,8 @@ export function wrapTest(source: string, meta?: Test262Meta): WrapResult {
   const needsPropertyHelper = includes.includes("propertyHelper.js");
   const needsFnGlobalObject = includes.includes("fnGlobalObject.js") && /\bfnGlobalObject\b/.test(body);
   const needsIsConstructor = includes.includes("isConstructor.js") && /\bisConstructor\b/.test(body);
-  const needsDecimalToHex = includes.includes("decimalToHexString.js") && /\bdecimalToHexString\b/.test(body);
+  const needsDecimalToHex =
+    includes.includes("decimalToHexString.js") && /\bdecimalTo(?:Percent)?HexString\b/.test(body);
   const needsNans = includes.includes("nans.js") && /\bdistinctNaNs\b/.test(body);
   const needsIsNativeFunction = includes.includes("nativeFunctionMatcher.js") && /\bisNativeFunction\b/.test(body);
   const needsAssertNativeFunction =


### PR DESCRIPTION
## Problem

~37 test262 tests under `built-ins/{decodeURI,decodeURIComponent,encodeURI,encodeURIComponent}/` and `harness/decimalToHexString.js` fail with a false `#…`-coded failure even though `decodeURI`/`encodeURI` themselves are spec-correct.

Root cause is in the **test262 runner harness shim** (`tests/test262-runner.ts` `buildPreamble`), not the compiler. The `decimalToHexString.js` harness `defines: [decimalToHexString, decimalToPercentHexString]`, but the runner injected only a constant stub:

```ts
function decimalToHexString(n: number): string { return "0"; }
```

This (1) never defined `decimalToPercentHexString` — the function the encode/decode-URI tests use to build their percent-encoded **input** (`decodeURI(decimalToPercentHexString(0xC0)+decimalToPercentHexString(0x00))` = `decodeURI("%C0%00")`), so the input came out as garbage and the spec-required `URIError` (ECMA-262 §19.2.6) never fired → false `#…` failure; and (2) returned a constant `"0"` that failed the harness self-test's `decimalToHexString(-1) === "FFFFFFFF"` assertions.

## Fix

Replace the stub with a faithful TS port of **both** pure `number → string` helpers (no new host imports), and widen `needsDecimalToHex` detection to fire on either name. `decodeURI`/`encodeURI` were already correct — this was purely a harness-shim artifact, so **no `src/` change** is required.

## Net recovery (fresh single-file worker processes, mirror of CI)

| dir | before fail | after fail | recovered |
|---|---|---|---|
| decodeURI | 15 | 3 | 12 |
| decodeURIComponent | 16 | 4 | 12 |
| encodeURI | 9 | 3 | 6 |
| encodeURIComponent | 9 | 3 | 6 |
| harness/decimalToHexString | 1 | 0 | 1 |
| **total** | | | **+37** |

0 regressions — every remaining failure was already failing (separate root causes: `A5.2` missing `.length`, `A5.7` `new X()` TypeError, `A6_T1` object-ToPrimitive — candidate follow-ups). Blast radius is fully contained to the 82 files that `includes: [decimalToHexString.js]`.

`tests/issue-2884.test.ts` drives the real runner path (`wrapTest`) + compiles/runs the shim and the malformed-UTF-8/unpaired-surrogate URIError loops.

Closes #2884.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS