### PR TITLE
fix(#2886): new <global-non-constructor-builtin>() throws TypeError

### DIFF
--- a/plan/issues/2886-new-global-nonconstructor-typeerror.md
+++ b/plan/issues/2886-new-global-nonconstructor-typeerror.md
@@ -1,0 +1,111 @@
+---
+id: 2886
+title: "new <global-non-constructor-builtin>() must throw TypeError (decodeURI/encodeURI/…/parseInt/parseFloat/isNaN/isFinite)"
+status: done
+sprint: current
+priority: medium
+horizon: s
+area: codegen
+language_feature: global-functions
+assignee: ttraenkler/explore7
+feasibility: medium
+reasoning_effort: max
+task_type: bug
+goal: test262-conformance
+related: [2884, 2500]
+created: 2026-06-30
+completed: 2026-06-30
+---
+
+# #2886 — `new <global-non-constructor-builtin>()` must throw `TypeError`
+
+## Problem
+
+The global builtin **functions** `decodeURI`, `decodeURIComponent`, `encodeURI`,
+`encodeURIComponent`, `parseInt`, `parseFloat`, `isNaN`, `isFinite` are ordinary
+built-in function objects that do **not** implement the `[[Construct]]` internal
+method (ECMA-262 §19.2). Therefore `new decodeURI()` (etc.) must throw a
+`TypeError`.
+
+Before this fix, a `new <id>()` whose `<id>` was one of these names fell through
+the `new`-expression dispatch in `compileNewExpression` to the _unknown
+constructor_ path and was mis-routed to an `extern_class` host import. At runtime
+the host resolver threw a **bare** `Error: No dependency provided for extern
+class "decodeURI"` — an `Error`, **not** a `TypeError`.
+
+The Sputnik tests check `e instanceof TypeError` strictly:
+
+```js
+try {
+  new decodeURI();
+  throw new Test262Error("#1.1: …");
+} catch (e) {
+  if (e instanceof TypeError !== true) {
+    // ← fails: e is a bare Error
+    throw new Test262Error("#1.2: new decodeURI() throw TypeError. Actual: " + e);
+  }
+}
+```
+
+`isNaN`/`isFinite`'s `_A2.7` tests use the looser `assert.throws(TypeError, …)`
+harness shim (which accepts any throw) and so already passed; the 4 URI `_A5.7`
+tests and `parseFloat`'s `_A7.7` use the strict Sputnik shape and failed.
+
+## Spec
+
+- ECMA-262 §13.3.5.1 `EvaluateNew`, step 5: _"If `IsConstructor(constructor)` is
+  `false`, throw a `TypeError` exception."_
+- §19.2 _Function Properties of the Global Object_ — these are function objects
+  with no `[[Construct]]` (their definitions never state "is a constructor").
+
+## Root cause
+
+`src/codegen/expressions/new-super.ts` already had a `NAMESPACE_NON_CONSTRUCTORS`
+identifier guard (`Math`/`JSON`/`Reflect`/`Atomics`) that emits a real
+`TypeError` throw via `emitThrowTypeError`. The global **functions** had no
+equivalent guard, so they reached the unknown-ctor → `extern_class` fallback.
+They are ambient `FunctionDeclaration`s (not `VariableDeclaration`s), so
+`resolvesToConstructableFunctionValue` / `resolvesToNonConstructableValue` do not
+classify them, and the existing throwing paths never fired.
+
+## Fix
+
+In `compileNewExpression` (`src/codegen/expressions/new-super.ts`), extend the
+existing identifier non-constructor block with a `GLOBAL_NON_CONSTRUCTOR_FUNCTIONS`
+set covering the 8 global functions. When the `new`-target identifier is one of
+them AND resolves to the **ambient global** binding (all declarations in lib
+`.d.ts` files — see `resolvesToAmbientGlobal`), emit
+`emitThrowTypeError(ctx, fctx, "<name> is not a constructor")` and return.
+
+The ambient-binding guard is the load-bearing safety check: a user-defined
+shadow such as `function parseInt() { this.x = 7 }` **is** constructable, so a
+declaration in a real (non-`.d.ts`) source file disqualifies the intercept and
+the normal constructor path runs. `ctx.classSet` / `ctx.externClasses` are also
+excluded.
+
+`emitThrowTypeError` already falls back to a plain string throw when
+`__new_TypeError` is unregistered (standalone/WASI), so standalone is strictly
+improved (a throw instead of the extern-class host `Error`) and never made worse.
+The ordinary CALL form (`decodeURI(x)`, `parseInt(s)`) is untouched — only the
+`new` dispatch changed.
+
+## test262 impact (fresh single-file scan vs current origin/main)
+
+5 tests flip CE/FAIL → PASS, 0 regressions across all 8 global-function dirs
+(312 files scanned fresh, one process per file):
+
+- `built-ins/decodeURI/S15.1.3.1_A5.7.js`
+- `built-ins/decodeURIComponent/S15.1.3.2_A5.7.js`
+- `built-ins/encodeURI/S15.1.3.3_A5.7.js`
+- `built-ins/encodeURIComponent/S15.1.3.4_A5.7.js`
+- `built-ins/parseFloat/S15.1.2.3_A7.7.js`
+
+(`isNaN`/`isFinite` `_A2.7` and the `not-a-constructor.js` files already passed
+and remain green; the `_A6_T1` ToPrimitive and `_A5.2` `.length`-own-property
+families are separate root causes, out of scope here.)
+
+## Tests
+
+`tests/issue-2886.test.ts` — `new <fn>()` throws a `TypeError` instance for all
+8 functions; CALL form still works; and two regression controls verify a
+user-defined shadow stays constructable.

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -239,6 +239,42 @@ function resolvesToConstructableFunctionValue(ctx: CodegenContext, calleeExpr: t
   return true;
 }
 
+/**
+ * (#2886) The global builtin **functions** that are NOT constructors per
+ * ECMA-262 §19.2 (`decodeURI`/`encodeURI`/…/`parseInt`/`parseFloat`/`isNaN`/
+ * `isFinite`). Each is an ordinary built-in function object that does **not**
+ * implement `[[Construct]]`, so `new <fn>()` must throw a `TypeError`
+ * (§13.3.5.1 EvaluateNew step 5: `IsConstructor(constructor) === false`).
+ * `eval` is intentionally omitted — it is filtered out of test262 and handled
+ * elsewhere.
+ */
+const GLOBAL_NON_CONSTRUCTOR_FUNCTIONS = new Set([
+  "decodeURI",
+  "decodeURIComponent",
+  "encodeURI",
+  "encodeURIComponent",
+  "parseInt",
+  "parseFloat",
+  "isNaN",
+  "isFinite",
+]);
+
+/**
+ * (#2886) Does `id` resolve to the **ambient global** binding (declared only in
+ * the TypeScript lib `.d.ts` files), rather than a user-defined shadow? A user
+ * who writes `function parseInt() {}` (or `class isNaN {}`) has a declaration in
+ * a real source file and *is* constructable — we must not intercept those. The
+ * ambient builtin's symbol has all of its declarations in declaration files.
+ * Unresolved symbols (no declaration anywhere) are treated as the global.
+ */
+function resolvesToAmbientGlobal(ctx: CodegenContext, id: ts.Identifier): boolean {
+  const sym = ctx.checker.getSymbolAtLocation(id);
+  if (!sym) return true;
+  const decls = sym.declarations;
+  if (!decls || decls.length === 0) return true;
+  return decls.every((d) => d.getSourceFile().isDeclarationFile);
+}
+
 /** Compile super.method(args) — resolve to ParentClass_method and call with this */
 /**
  * (#1614) Dispatch `super.method(args)` where the parent is a builtin extern
@@ -2709,6 +2745,24 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
         // in test262 negative cases (S11.2.2_A4_T*) observes a TypeError
         // instance, not a bare string. Falls back to a string throw when
         // `__new_TypeError` isn't registered (standalone mode).
+        emitThrowTypeError(ctx, fctx, `${name} is not a constructor`);
+        fctx.body.push({ op: "ref.null.extern" });
+        return { kind: "externref" };
+      }
+      // (#2886) Global builtin FUNCTIONS that lack [[Construct]] — `new
+      // decodeURI()`, `new parseFloat()`, etc. Without this, the callee falls
+      // through to the unknown-ctor path and is mis-routed to an `extern_class`
+      // host import, which throws a bare `Error: No dependency provided for
+      // extern class "decodeURI"` at runtime — not a `TypeError`. The Sputnik
+      // `S15.1.*_A5.7`/`A7.7` tests strictly check `e instanceof TypeError`.
+      // Gate on the ambient-global binding so a user-defined shadow (e.g.
+      // `function parseInt(){}`, which IS constructable) keeps the normal path.
+      if (
+        GLOBAL_NON_CONSTRUCTOR_FUNCTIONS.has(name) &&
+        !ctx.classSet.has(name) &&
+        !ctx.externClasses.has(name) &&
+        resolvesToAmbientGlobal(ctx, unwrapped)
+      ) {
         emitThrowTypeError(ctx, fctx, `${name} is not a constructor`);
         fctx.body.push({ op: "ref.null.extern" });
         return { kind: "externref" };

--- a/tests/issue-2886.test.ts
+++ b/tests/issue-2886.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #2886 — `new <global-non-constructor-builtin>()` must throw a real TypeError.
+//
+// The global builtin FUNCTIONS decodeURI / decodeURIComponent / encodeURI /
+// encodeURIComponent / parseInt / parseFloat / isNaN / isFinite are ordinary
+// built-in function objects that do NOT implement [[Construct]] (ECMA-262
+// §19.2). Per §13.3.5.1 EvaluateNew step 5, `new <fn>()` must throw a TypeError
+// because IsConstructor(fn) is false.
+//
+// Before the fix, these identifiers fell through the `new`-expression dispatch
+// to the unknown-constructor path and were mis-routed to an `extern_class` host
+// import, which throws a BARE `Error: No dependency provided for extern class
+// "decodeURI"` at runtime — not a TypeError. The Sputnik tests
+// `built-ins/{decodeURI,decodeURIComponent,encodeURI,encodeURIComponent}/
+// S15.1.3.*_A5.7.js` and `built-ins/parseFloat/S15.1.2.3_A7.7.js` strictly check
+// `e instanceof TypeError`, so they failed.
+
+async function run(source: string, fn = "test", args: unknown[] = []): Promise<unknown> {
+  const result = await compile(source);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  expect(WebAssembly.validate(result.binary)).toBe(true);
+  const imports = buildImports(result.imports, {}, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as { setExports?: (e: object) => void }).setExports?.(instance.exports as object);
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>)[fn]!(...args);
+}
+
+// Returns 1 if `new <name>()` throws a TypeError, 2 if it throws something else,
+// 0 if it does not throw — mirrors the Sputnik S15.1.*_A5.7 / A7.7 shape.
+const NEW_THROWS_TYPEERROR = (name: string) =>
+  `export function test(): number {
+     var caught = 0;
+     try { new ${name}(); caught = 0; }
+     catch (e) { if ((e instanceof TypeError) === true) caught = 1; else caught = 2; }
+     return caught;
+   }`;
+
+const GLOBAL_NON_CONSTRUCTORS = [
+  "decodeURI",
+  "decodeURIComponent",
+  "encodeURI",
+  "encodeURIComponent",
+  "parseInt",
+  "parseFloat",
+  "isNaN",
+  "isFinite",
+];
+
+describe("#2886 new <global-non-constructor-builtin>() throws TypeError", () => {
+  for (const name of GLOBAL_NON_CONSTRUCTORS) {
+    it(`new ${name}() throws a TypeError instance`, async () => {
+      expect(await run(NEW_THROWS_TYPEERROR(name))).toBe(1);
+    });
+  }
+
+  // The ordinary CALL form must keep working — only `new` is rejected.
+  it("decodeURI(...) call still decodes", async () => {
+    expect(await run(`export function test(): string { return decodeURI("abc%20def"); }`)).toBe("abc def");
+  });
+  it("encodeURIComponent(...) call still encodes", async () => {
+    expect(await run(`export function test(): string { return encodeURIComponent("a b"); }`)).toBe("a%20b");
+  });
+  it("parseInt(...) call still parses", async () => {
+    expect(await run(`export function test(): number { return parseInt("42"); }`)).toBe(42);
+  });
+
+  // Regression control: a USER-DEFINED function shadowing a global name IS
+  // constructable; `new <shadow>()` must run the user constructor, not throw.
+  it("user-defined shadow `function parseInt(){ this.x = 7 }` stays constructable", async () => {
+    const src = `function parseInt(this: any) { this.x = 7; }
+      export function test(): number { var o: any = new parseInt(); return o.x; }`;
+    expect(await run(src)).toBe(7);
+  });
+  it("user-defined shadow `function isNaN(){ this.x = 9 }` stays constructable", async () => {
+    const src = `function isNaN(this: any) { this.x = 9; }
+      export function test(): number { var o: any = new isNaN(); return o.x; }`;
+    expect(await run(src)).toBe(9);
+  });
+});


### PR DESCRIPTION
Closes #2886.

## Problem

The global builtin **functions** \`decodeURI\`, \`decodeURIComponent\`, \`encodeURI\`, \`encodeURIComponent\`, \`parseInt\`, \`parseFloat\`, \`isNaN\`, \`isFinite\` are ordinary built-in function objects with no \`[[Construct]]\` (ECMA-262 §19.2). Per §13.3.5.1 EvaluateNew step 5, \`new <fn>()\` must throw a **TypeError**.

Before this fix, those identifiers fell through the \`new\`-expression dispatch to the unknown-constructor path and were mis-routed to an \`extern_class\` host import, throwing a **bare** \`Error: No dependency provided for extern class "decodeURI"\` — not a TypeError. The strict-instanceof Sputnik tests (\`S15.1.3.{1,2,3,4}_A5.7\`, \`parseFloat S15.1.2.3_A7.7\`) check \`e instanceof TypeError\` and failed.

## Fix

Extend the existing \`NAMESPACE_NON_CONSTRUCTORS\` identifier guard (\`Math\`/\`JSON\`/\`Reflect\`/\`Atomics\`) in \`compileNewExpression\` with a \`GLOBAL_NON_CONSTRUCTOR_FUNCTIONS\` set, gated on the ambient-global binding (\`resolvesToAmbientGlobal\`) so a user-defined shadow (\`function parseInt(){...}\`, which IS constructable) keeps the normal constructor path. Standalone/WASI falls back to the existing string-throw path (strictly better than the old extern-class Error). The CALL form is untouched.

## Validation

Fresh single-file scan (one process per file, mirroring \`scripts/test262-worker.mjs\`) vs current \`origin/main\`, all 8 global-function dirs (312 files): **+5 PASS, 0 regressions**.

Flipped: \`decodeURI/S15.1.3.1_A5.7\`, \`decodeURIComponent/S15.1.3.2_A5.7\`, \`encodeURI/S15.1.3.3_A5.7\`, \`encodeURIComponent/S15.1.3.4_A5.7\`, \`parseFloat/S15.1.2.3_A7.7\`.

\`tests/issue-2886.test.ts\` (13 tests) — TypeError for all 8 \`new <fn>()\`, CALL form intact, plus 2 user-shadow regression controls. Existing new-expression suites (issue-1528, 1528-closure-construct, 2608) still green (23 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS