### PR TITLE
fix(#2887): exact integer-exponent path for runtime ** / **= / Math.pow

### DIFF
--- a/plan/issues/2887-pow-integer-exponent-precision.md
+++ b/plan/issues/2887-pow-integer-exponent-precision.md
@@ -1,0 +1,91 @@
+---
+id: 2887
+title: "Runtime `**` / `**=` / Math.pow imprecise for integer exponents (3**3 → 26.99…)"
+status: done
+sprint: current
+priority: medium
+horizon: s
+area: codegen
+language_feature: exponentiation-operator
+assignee: ttraenkler/explore5
+completed: 2026-06-30
+---
+
+## Problem
+
+The runtime `Math_pow` Wasm helper (`src/codegen/math-helpers.ts`,
+`buildPowBody`) — used by the `**` operator, the `**=` compound assignment, and
+`Math.pow` — computed `base ** exp` via the generic `exp(exp * log(base))`
+approximation **even for integer exponents**. That path is ~1 ULP low for
+non-power-of-two integer results:
+
+```
+3 ** 3   → 26.999999999461526   (should be 27)
+5 ** 3   → 124.99999999999974   (should be 125)
+10 ** 3  → 999.999999999998     (should be 1000)
+```
+
+The error was masked for compile-time-constant operands (those are
+constant-folded to an exact `f64.const`), so it only surfaced for **runtime**
+operands. It became _visibly_ wrong for `**=` on an integer-typed local: the
+compiler stores such a local as `i32`, so the imprecise f64 result is truncated
+by `i32.trunc_sat_f64_s`:
+
+```
+var base = -3; base **= 3;   // → -26  (should be -27)
+```
+
+ECMA-262 §13.6 (exponentiation) / §21.3.2.26 (`Math.pow`) defines the result via
+the abstract operation **Number::exponentiate**. While the spec permits
+implementation-approximated results for irrational cases, test262 hard-codes the
+exact integer results (e.g. `language/expressions/exponentiation/exp-assignment-operator.js`
+asserts `(base **= 3) === -27`), and the conformance oracle (V8) returns exact
+integers for integer exponents via its `power_double_int` fast path.
+
+## Root cause
+
+`buildPowBody` special-cased `exp ∈ {0, 1, -1, 0.5, 2}` and the
+base ∈ `{0, ±1, ±Infinity}` cases, but **every other integer exponent fell
+through to `exp(exp * log(base))`** (and the negative-base branch did the same
+with `|base|` + an odd/even sign flip). No exact integer path existed.
+
+## Fix
+
+Add an exact **exponentiation-by-squaring** fast path to `buildPowBody`, reached
+after the existing special-value early-returns. It applies when the exponent is
+an integer that fits an i32 loop counter (`trunc(exp) == exp && |exp| < 2^31`):
+
+```
+res = 1; b = base; n = |exp| (i32)
+while (n) { if (n & 1) res *= b; b *= b; n >>= 1; }
+if (exp < 0) res = 1 / res
+return res
+```
+
+This mirrors V8's `power_double_int` and is **exact** for integer base/exponent
+within f64 range. Repeated multiplication carries the sign of a negative base
+correctly (no separate odd/even negation), and overflows to ±Inf / underflows to
+±0 the same way the generic path would for huge exponents. `±Infinity` and
+`|exp| ≥ 2^31` exponents skip the fast path (`|exp| < 2^31` is false) and keep
+the original `exp(exp * log|base|)` behaviour — important because `trunc(±Inf) ==
+±Inf`, so e.g. `Math.pow(-1.5, Infinity) === +Infinity` (not NaN). Fractional
+exponents (`base ** 0.5` aside, which is special-cased to `f64.sqrt`) keep the
+generic approximation.
+
+Files: `src/codegen/math-helpers.ts` (`buildPowBody` + 3 added locals
+`powRes`/`powBase`/`powN`).
+
+## Acceptance
+
+- `3 ** 3 === 27`, `5 ** 3 === 125`, `10 ** 3 === 1000`, `(-3) ** 3 === -27` at
+  runtime (non-folded operands).
+- `base **= 3` exact for integer-typed locals.
+- No regression in the `Math.pow` special-value suite
+  (`applying-the-exp-operator_A5/A6/A9/A10`, ±Infinity exponents, negative base).
+- Negative base + non-integer exponent → NaN; fractional exponents unchanged.
+
+## Test Results
+
+`tests/issue-2887.test.ts` — 5/5 pass. Comprehensive 33-case check vs JS
+`Math.pow` (integer, negative, fractional, NaN, ±Inf, ±0 bases/exponents) — all
+match.

--- a/src/codegen/math-helpers.ts
+++ b/src/codegen/math-helpers.ts
@@ -982,7 +982,12 @@ export function emitInlineMathFunctions(ctx: CodegenContext, needed: Set<string>
       name: "Math_pow",
       params: [f64Type, f64Type],
       results: f64Result,
-      locals: [{ name: "absBase", type: f64Type }],
+      locals: [
+        { name: "absBase", type: f64Type }, // 2
+        { name: "powRes", type: f64Type }, // 3 — squaring accumulator
+        { name: "powBase", type: f64Type }, // 4 — repeatedly squared base
+        { name: "powN", type: i32Type }, // 5 — |exponent| as i32 loop counter
+      ],
       body: buildPowBody(expIdx, logIdx),
     });
   }
@@ -1551,7 +1556,84 @@ function buildPowBody(expIdx: number, logIdx: number): Instr[] {
       ],
     } as Instr,
 
-    // base < 0: non-integer exp → NaN; integer exp → handle sign
+    // ── Integer-exponent fast path (exact) ─────────────────────────────
+    // For an integer exponent that fits in an i32 counter, compute base^|exp|
+    // by exponentiation-by-squaring (mirrors V8's `power_double_int`). This is
+    // EXACT for integer base/exponent within f64 range, so e.g. 3**3 === 27 and
+    // (-3)**3 === -27, instead of the ~1-ULP-low `exp(exp*log|base|)` result
+    // (3**3 → 26.999…) the generic path below produces. Repeated multiplication
+    // also carries the sign of a negative base correctly (no separate odd/even
+    // negation needed) and overflows to ±Inf / underflows to ±0 the same way the
+    // generic path would for huge exponents. Reached only after the
+    // exp ∈ {0,1,-1,0.5,2} and base ∈ {0,±1,±Inf} special cases returned, so the
+    // base here is finite, non-zero, ≠ ±1 and the exponent is a finite integer
+    // not already handled. (#2887)
+    localGet(1),
+    localGet(1),
+    ftrunc,
+    feq, // exponent is an integer?
+    localGet(1),
+    fabs,
+    f64c(2147483648), // |exp| < 2^31 so it fits the i32 loop counter
+    flt,
+    { op: "i32.and" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        f64c(1),
+        localSet(3), // powRes = 1
+        localGet(0),
+        localSet(4), // powBase = base
+        localGet(1),
+        fabs,
+        truncSatI32,
+        localSet(5), // powN = |exp|
+        blockLoop([
+          localGet(5),
+          i32eqz,
+          { op: "br_if", depth: 1 } as Instr,
+          // if (powN & 1) powRes *= powBase
+          localGet(5),
+          i32const(1),
+          { op: "i32.and" } as Instr,
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [localGet(3), localGet(4), mul, localSet(3)],
+          } as Instr,
+          // powBase *= powBase
+          localGet(4),
+          localGet(4),
+          mul,
+          localSet(4),
+          // powN >>= 1 (unsigned)
+          localGet(5),
+          i32const(1),
+          { op: "i32.shr_u" } as Instr,
+          localSet(5),
+          { op: "br", depth: 0 } as Instr,
+        ]),
+        // Negative exponent → reciprocal
+        localGet(1),
+        f64c(0),
+        flt,
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [f64c(1), localGet(3), div, localSet(3)],
+        } as Instr,
+        localGet(3),
+        ret,
+      ],
+    } as Instr,
+
+    // base < 0: non-integer exp → NaN; otherwise (a non-finite |exp|, i.e.
+    // ±Infinity, or an integer exponent too large for the i32 fast path above)
+    // → exp(exp * log(|base|)) with the sign reapplied for odd integer exponents.
+    // The common small-integer base<0 case already returned from the fast path;
+    // this branch only covers |exp| ≥ 2^31 and ±Infinity (where the result is
+    // ±Inf / 0 anyway, so the exp/log approximation is exact enough).
     localGet(0),
     f64c(0),
     flt,
@@ -1559,13 +1641,13 @@ function buildPowBody(expIdx: number, logIdx: number): Instr[] {
       op: "if",
       blockType: { kind: "empty" },
       then: [
-        // Non-integer exponent → NaN
+        // Non-integer (finite) exponent → NaN
         localGet(1),
         localGet(1),
         ftrunc,
         fne,
         { op: "if", blockType: { kind: "empty" }, then: [f64c(NaN), ret] } as Instr,
-        // Integer exponent: result = exp(exp * log(|base|))
+        // |exp| == Infinity or huge integer: result = exp(exp * log(|base|))
         localGet(0),
         fabs,
         localSet(2),
@@ -1575,8 +1657,7 @@ function buildPowBody(expIdx: number, logIdx: number): Instr[] {
         mul,
         call(expIdx),
         localSet(2), // reuse absBase local to store result
-        // If exponent is odd, negate the result
-        // odd check: floor(exp/2)*2 != exp (for integer exp)
+        // If exponent is odd, negate the result (odd: floor(exp/2)*2 != exp)
         localGet(1),
         ftrunc,
         f64c(2),
@@ -1596,7 +1677,7 @@ function buildPowBody(expIdx: number, logIdx: number): Instr[] {
       ],
     } as Instr,
 
-    // General case: exp(exponent * log(base))
+    // General case (base > 0, non-integer exponent): exp(exponent * log(base))
     localGet(1),
     localGet(0),
     call(logIdx),

--- a/tests/issue-2887.test.ts
+++ b/tests/issue-2887.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+// #2887 — the runtime Math_pow helper (used by the `**` operator, `**=`
+// compound assignment, and Math.pow) computed base^exp via the generic
+// `exp(exp * log(base))` path even for integer exponents. That is ~1 ULP low
+// for non-power-of-two integer results (3**3 → 26.999999999461526,
+// 5**3 → 124.99999…, 10**3 → 999.99999…). With an i32-typed accumulator this
+// truncated to a visibly wrong integer (3 **= 3 → 26, -3 **= 3 → -26).
+//
+// Fix: an exact exponentiation-by-squaring fast path for integer exponents
+// that fit an i32 counter (mirrors V8's `power_double_int`), so integer
+// powers are exact while ±Infinity / huge / fractional exponents keep the
+// existing exp/log behaviour.
+
+async function pow(): Promise<(x: number, y: number) => number> {
+  const exports = await compileToWasm(`export function test(x: number, y: number): number { return x ** y; }`);
+  return (exports as { test: (x: number, y: number) => number }).test;
+}
+
+async function powAssign(base: number, exp: number): Promise<number> {
+  // Use a parameter as the base so the operation is NOT constant-folded.
+  const exports = await compileToWasm(`export function test(b: number): number { b **= ${exp}; return b; }`);
+  return (exports as { test: (b: number) => number }).test(base);
+}
+
+describe("#2887 runtime exponentiation precision", () => {
+  it("integer powers are exact via the `**` operator at runtime", async () => {
+    const p = await pow();
+    expect(p(3, 3)).toBe(27);
+    expect(p(5, 3)).toBe(125);
+    expect(p(10, 3)).toBe(1000);
+    expect(p(-3, 3)).toBe(-27);
+    expect(p(7, 4)).toBe(2401);
+    expect(p(2, 10)).toBe(1024);
+  });
+
+  it("negative and zero integer exponents are exact", async () => {
+    const p = await pow();
+    expect(p(2, -3)).toBe(0.125);
+    expect(p(-2, -3)).toBe(-0.125);
+    expect(p(5, 0)).toBe(1);
+    expect(p(-3, 2)).toBe(9);
+  });
+
+  it("`**=` compound assignment is exact (was 3**=3 → 26)", async () => {
+    expect(await powAssign(3, 3)).toBe(27);
+    expect(await powAssign(-3, 3)).toBe(-27);
+    expect(await powAssign(5, 3)).toBe(125);
+    expect(await powAssign(10, 3)).toBe(1000);
+  });
+
+  it("preserves fractional / sqrt exponents", async () => {
+    const p = await pow();
+    // exp == 0.5 is special-cased to f64.sqrt → exact.
+    expect(p(4, 0.5)).toBe(2);
+    expect(p(9, 0.5)).toBe(3);
+    // Other fractional exponents keep the generic exp(exp*log(base)) path
+    // (documented ~4-ULP approximation); the fast path must NOT hijack them.
+    expect(Math.abs(p(27, 1 / 3) - 3)).toBeLessThan(1e-6);
+  });
+
+  it("preserves the special-value semantics (Infinity / NaN / negative base)", async () => {
+    const p = await pow();
+    // |base| > 1 with ±Infinity exponent
+    expect(p(-1.5, Infinity)).toBe(Infinity);
+    expect(p(-1.5, -Infinity)).toBe(0);
+    expect(p(2, Infinity)).toBe(Infinity);
+    // negative base with a non-integer exponent → NaN
+    expect(Number.isNaN(p(-8, 0.5))).toBe(true);
+    expect(Number.isNaN(p(-2, 2.5))).toBe(true);
+    // NaN propagation
+    expect(Number.isNaN(p(NaN, 2))).toBe(true);
+    expect(Number.isNaN(p(2, NaN))).toBe(true);
+    // base 0
+    expect(p(0, 3)).toBe(0);
+    expect(p(0, -1)).toBe(Infinity);
+  });
+});


### PR DESCRIPTION
## Problem

The runtime `Math_pow` Wasm helper (used by the `**` operator, `**=` compound assignment, and `Math.pow`) computed `base ** exp` via the generic `exp(exp * log(base))` approximation **even for integer exponents** — ~1 ULP low for non-power-of-two integer results: `3**3 → 26.999…`, `5**3 → 124.999…`, `10**3 → 999.999…`.

Masked for constant operands (constant-folded), it only surfaced at **runtime**. It became *visibly* wrong for `**=` on an integer-typed local (stored as `i32`), where the imprecise f64 is truncated: `var base=-3; base**=3` → -26 (should be -27).

## Root cause

`buildPowBody` special-cased `exp ∈ {0,1,-1,0.5,2}` and base ∈ `{0,±1,±Infinity}`, but every other integer exponent fell through to `exp(exp*log(base))`. No exact integer path.

## Fix

Add an exact **exponentiation-by-squaring** fast path (mirrors V8's `power_double_int`), gated on `trunc(exp)==exp && |exp| < 2^31`. `±Infinity` / `|exp| ≥ 2^31` / fractional exponents keep the original behaviour, so the `Math.pow` special-value suite (`applying-the-exp-operator_A5/A6/A9/A10`) is **unaffected**.

## Validation

- `tests/issue-2887.test.ts` — 5/5 pass.
- 33-case parity check vs JS `Math.pow` — all match.
- Fresh single-file test262 sweep (`exponentiation` + `Math/pow`): recovers `exp-assignment-operator`, zero new failures.

Renumbered from #2885 after a cross-session id collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS