### PR TITLE
feat(#2864): heterogeneous boxed-any carrier for native generators (F1)

### DIFF
--- a/plan/issues/2864-standalone-generator-carrier.md
+++ b/plan/issues/2864-standalone-generator-carrier.md
@@ -1,7 +1,8 @@
 ---
 id: 2864
 title: "Standalone: no Wasm-native generator carrier — sync generators leak __create_generator/__gen_* host imports"
-status: ready
+status: in-progress
+assignee: ttraenkler/sendev-genframe
 created: 2026-06-30
 updated: 2026-06-30
 priority: high
@@ -84,3 +85,80 @@ Standalone fail/CE → pass:
 Full `merge_group` + standalone high-water. This is the single largest lever
 (sync 697 + async 986 = 1,683 combined with #2865). Sequence #2864 before #2865
 (async generators build on this).
+
+## F1 — heterogeneous (boxed-`any`) carrier (landed)
+
+**Scope shipped:** object / mixed-type yields now lower to the Wasm-native
+generator carrier host-free in standalone/WASI, via the dominant consumers:
+`.next()` / `.next().value` (open dispatch), `for-of`, and array destructuring.
+Verify-first (`function* g(){ yield {a:1}; yield 2 }` → `r1.value.a + r2.value`)
+compiles with **zero host imports** and returns `3` (the yielded object survives
+the frame). gc-mode unchanged; numeric / string carriers byte-for-byte unchanged.
+
+### Why these decisions (root-cause, not symptom)
+
+The resumable frame already existed — `src/codegen/generators-native.ts` is a
+`br_table`-on-state-machine, but its `value`/`sent`/`abrupt`/spill slots were
+f64-only (#1665) or a uniform native-string ref (#2171). `generatorElemValType`
+returned `null` for object/mixed yields, which routed them to the eager-buffer
+**host** path (`__gen_*` imports) — fatal under standalone. F1 generalises the
+frame rather than building a new one.
+
+- **Carrier = `externref`, not a bespoke tagged struct.** The `any` TS type
+  already maps to `externref` (`type-mapper.ts`), and the boxing seams
+  (`__box_number`, `extern.convert_any`) are **native defined funcs** under
+  `target: standalone|wasi` (`addUnionImportsAsNativeFuncs`), so every JS value
+  boxes to externref with NO host import. Using externref (over anyref) means a
+  consumer reading `.value` / a for-of loop var as `any` needs no extra coercion
+  — the carrier IS the `any` representation the rest of codegen agrees on.
+- **`sent`/`abrupt` typed PER-CARRIER** (`genCarrierFieldType`): externref for
+  the boxed-any carrier, f64 for numeric/string. The state struct is minted
+  per-generator, so this keeps the numeric/string structs and all their call
+  sites byte-identical — zero regression risk to the ~250 existing native-gen
+  tests — while the any frame carries arbitrary `.next(v)`/`.return(v)` values.
+- **Open dispatch (`buildNativeGeneratorDispatch`) was the load-bearing path.**
+  `let it = g()` types `it` as `Generator<…>` → externref (the state struct is
+  boxed), so `it.next()` routes through the open anyref dispatch, NOT the
+  concrete-typed direct path. The dispatch keyed its enclosing block on the f64
+  IteratorResult singleton and set one shared f64 `sent` across branches — it
+  could not host a boxed-any branch (distinct result struct, externref sent). Fix
+  is **gated on `hasAny`**: a module with no any-carrier generator keeps the
+  exact f64-singleton dispatch (byte-identical); a module that has one switches
+  the block type to `eqref` (common supertype of all result structs) and emits
+  the `.next(v)` arg both as externref (any branches) and f64 (numeric branches,
+  derived by one unbox so a side-effecting arg evals once). This confines all
+  behavioural change to modules that actually use the new carrier.
+- **Open result reader** (`tryCompileNativeGeneratorResultProperty`) now
+  ref-tests EVERY distinct result struct (not just the f64 singleton): `.done`
+  is uniformly i32; `.value` picks its return ValType from the **static** type of
+  the `.value` property (number → f64 fast path preserved; object/any →
+  externref). This is why numeric `.next().value` reads are unchanged.
+
+### Deferred (follow-ups; all bail cleanly / are non-regressing today)
+
+- **Typed LOCAL spills for the any carrier** — a live-across-yield local of
+  object type lowers to a concrete `ref $Object`, whose exact wasm type the
+  up-front state-struct layout cannot know without a body pre-pass (the "deeper
+  rewrite" the architect flagged). So an any-carrier generator that needs to
+  spill ANY local bails to the host path in `buildNativeGeneratorPlan`
+  (consistent across the candidate gate and registration). Numeric/string spills
+  (f64) are unaffected. This is the single biggest remaining widener — needs a
+  two-pass spill-typing pass.
+- **Spread / `Array.from` precision for the boxed-any carrier** — drains to a
+  vec whose element type must match the array-literal heuristic; for an object
+  generator the literal infers a concrete-struct vec ≠ the externref drain vec,
+  so the conservative skip leaves an (empty, host-free, valid) array. Strictly
+  better than the pre-F1 host-import instantiation failure, but semantically
+  incomplete. Array destructuring (which uses the carrier vec directly) DOES work.
+- **F2** (try/catch/finally across yield + `return()`/`throw()`), **F3**
+  (`yield*` over arbitrary iterables) — separate PRs per the issue's slicing.
+
+### Files
+
+- `src/codegen/generators-native.ts` — carrier decision, per-carrier frame
+  field typing, boxed-any yield/sent/abrupt emission, gated open dispatch +
+  generalised open result reader.
+- `src/codegen/literals.ts`, `src/codegen/statements/destructuring.ts` — vec
+  drain consumers parametrised on the generator's carrier element type.
+- `tests/issue-2864-standalone-generator-carrier.test.ts` — 8 standalone cases
+  (zero-host-import asserted).

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -26,7 +26,7 @@
  *     (try/finally without catch is, as in Phase 1).
  */
 import { ts } from "../ts-api.js";
-import { isBooleanType, isNumberType, isStringType } from "../checker/type-mapper.js";
+import { isBooleanType, isNumberType, isStringType, mapTsTypeToWasm } from "../checker/type-mapper.js";
 import type { FieldDef, Instr, ValType, WasmFunction } from "../ir/types.js";
 import { allocLocal } from "./context/locals.js";
 import { popBody, pushBody } from "./context/bodies.js";
@@ -134,15 +134,26 @@ function isStringYieldExpression(ctx: CodegenContext, expr: ts.Expression | unde
 }
 
 /**
- * Decide a generator's uniform yield element ValType, or null when the yields
- * are mixed / unsupported (caller bails). Walks every `yield` in the body
- * (not descending into nested functions). Returns `{kind:"f64"}` when there are
- * no yields (degenerate; the plan rejects zero-yield generators separately).
+ * Decide a generator's uniform yield element ValType. Walks every `yield` in
+ * the body (not descending into nested functions).
+ *
+ *  - all-numeric (or zero-yield) → `{kind:"f64"}` (the historical fast path);
+ *  - all-string → the native `$AnyString` ref (#2171);
+ *  - anything else (object yields, or a MIX of numeric/string/object) →
+ *    `{kind:"externref"}`, the universal boxed-`any` carrier (#2864 F1). Every
+ *    JS value coerces to externref host-free in standalone/WASI (numbers via the
+ *    native `__box_number`, objects/strings via `extern.convert_any`), so the
+ *    heterogeneous frame needs no host import. This is the seam that unblocks
+ *    object/mixed-yield generators that previously bailed to the eager-buffer
+ *    host path (and thus refused under standalone).
+ *
+ * Never returns null now — the externref carrier subsumes the formerly-bailing
+ * cases; zero-yield generators are rejected separately by the plan builder.
  */
-function generatorElemValType(ctx: CodegenContext, decl: GeneratorDecl): ValType | null {
+function generatorElemValType(ctx: CodegenContext, decl: GeneratorDecl): ValType {
   let sawNumeric = false;
   let sawString = false;
-  let unsupported = false;
+  let sawOther = false;
   const visit = (node: ts.Node): void => {
     if (
       ts.isFunctionDeclaration(node) ||
@@ -155,15 +166,32 @@ function generatorElemValType(ctx: CodegenContext, decl: GeneratorDecl): ValType
     if (ts.isYieldExpression(node) && !node.asteriskToken) {
       if (isNumericExpression(ctx, node.expression)) sawNumeric = true;
       else if (isStringYieldExpression(ctx, node.expression)) sawString = true;
-      else unsupported = true;
+      else sawOther = true;
     }
     ts.forEachChild(node, visit);
   };
   if (decl.body) visit(decl.body);
-  if (unsupported) return null;
-  if (sawString && sawNumeric) return null; // mixed — deferred follow-up
-  if (sawString) return nativeStringType(ctx);
-  return { kind: "f64" };
+  // Uniform numeric (or no yields): the f64 fast path, byte-identical to before.
+  if (!sawOther && !sawString) return { kind: "f64" };
+  // Uniform string: the native-string carrier (#2171), byte-identical to before.
+  if (!sawOther && !sawNumeric && sawString) return nativeStringType(ctx);
+  // Heterogeneous (object and/or mixed types): the boxed-any externref carrier.
+  return { kind: "externref" };
+}
+
+/** True when a generator uses the boxed-`any` externref carrier (#2864 F1). */
+function carrierIsAny(elemValType: ValType): boolean {
+  return elemValType.kind === "externref";
+}
+
+/**
+ * The ValType of the per-frame `sent` / `abrupt` scalar fields. For the boxed-any
+ * carrier these hold a boxed `any` (externref) so `.next(v)` / `.return(v)` carry
+ * an arbitrary value; for the numeric & string carriers they stay f64 (a
+ * `.next(v)`/`.return(v)` argument coerces to f64, byte-identical to pre-#2864).
+ */
+function genCarrierFieldType(elemValType: ValType): ValType {
+  return carrierIsAny(elemValType) ? { kind: "externref" } : { kind: "f64" };
 }
 
 function statementContainsYield(stmt: ts.Statement): boolean {
@@ -241,16 +269,17 @@ function nodeContainsYield(root: ts.Node): boolean {
 function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): NativeGeneratorPlan | null {
   if (!decl.body) return null;
 
-  // (#2171) Decide the uniform yield element type up-front. Numeric → f64 (the
-  // historical path); all-string → native string ref; mixed / unsupported →
-  // bail. `yieldValueOk` then gates each per-yield check on that decision so a
-  // string yield is accepted only in a string-typed generator (and a numeric
-  // yield only in a numeric one).
+  // (#2171/#2864) Decide the uniform yield element type up-front. Numeric → f64
+  // (the historical path); all-string → native string ref; mixed / object →
+  // the boxed-any externref carrier. `yieldValueOk` then gates each per-yield
+  // check on that decision: a string yield is accepted only in a string-typed
+  // generator, a numeric yield only in a numeric one, and ANY yield is accepted
+  // in the boxed-any carrier (every value coerces to externref).
   const elemValType = generatorElemValType(ctx, decl);
-  if (elemValType === null) return null;
   const elemIsString = elemValType.kind === "ref" || elemValType.kind === "ref_null";
+  const elemIsAny = carrierIsAny(elemValType);
   const yieldValueOk = (expr: ts.Expression | undefined): boolean =>
-    elemIsString ? isStringYieldExpression(ctx, expr) : isNumericExpression(ctx, expr);
+    elemIsAny ? true : elemIsString ? isStringYieldExpression(ctx, expr) : isNumericExpression(ctx, expr);
 
   const states: NativeGeneratorState[] = [];
   const spills: string[] = [];
@@ -751,6 +780,19 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
   if (suspendCount === 0) return null;
   if (states.length > MAX_NATIVE_GENERATOR_STATES) return null;
 
+  // (#2864 F1) The boxed-any carrier types only the per-frame scalars (sent /
+  // abrupt / yielded value) as externref; it does NOT yet type the spill slots
+  // for live-across-yield LOCALS. A faithful spill field must carry the local's
+  // exact wasm type (an object literal lowers to a concrete `ref $Object`, which
+  // the up-front struct layout cannot know without a body pre-pass — the
+  // "deeper rewrite" flagged in the #2864 plan). So a heterogeneous generator
+  // that needs to spill any local bails to the host path here (consistent across
+  // `isNativeGeneratorCandidate` and `registerNativeGenerator`, both of which
+  // route through this builder, so the host imports stay registered and no
+  // undefined funcidx is baked). Numeric / string carriers are unaffected (their
+  // spills are f64). Follow-up: two-pass spill typing widens this.
+  if (elemIsAny && spills.length > 0) return null;
+
   return { states, spills, elemValType, delegationSites };
 }
 
@@ -1088,11 +1130,15 @@ export function registerNativeGenerator(
   // with the caller's `paramTypes[0] === receiverType`. User params follow.
   const userParamNames = decl.parameters.map((p) => (ts.isIdentifier(p.name) ? p.name.text : ""));
   const paramNames = synthesizedThis ? ["this", ...userParamNames] : userParamNames;
+  // (#2864 F1) `sent` / `abrupt` carry the `.next(v)` / `.return(v)` value. For
+  // the boxed-any carrier they are externref so an arbitrary value survives; for
+  // numeric / string carriers they stay f64 (byte-identical to before).
+  const carrierFieldType = genCarrierFieldType(elemValType);
   const stateFields: FieldDef[] = [
     { name: "state", type: { kind: "i32" }, mutable: true },
-    { name: "sent", type: { kind: "f64" }, mutable: true },
+    { name: "sent", type: carrierFieldType, mutable: true },
     { name: "mode", type: { kind: "i32" }, mutable: true },
-    { name: "abrupt", type: { kind: "f64" }, mutable: true },
+    { name: "abrupt", type: carrierFieldType, mutable: true },
   ];
   for (let i = 0; i < paramTypes.length; i++) {
     stateFields.push({
@@ -1179,6 +1225,8 @@ function ensureRegisteredNativeGenerator(ctx: CodegenContext, name: string): Nat
 function defaultElemValueInstr(elemValType: ValType): Instr {
   if (elemValType.kind === "f64") return { op: "f64.const", value: 0 };
   if (elemValType.kind === "i32") return { op: "i32.const", value: 0 };
+  // (#2864 F1) The boxed-any carrier's inert default is a null externref.
+  if (elemValType.kind === "externref") return { op: "ref.null.extern" } as Instr;
   return { op: "ref.null", typeIdx: (elemValType as { typeIdx: number }).typeIdx } as Instr;
 }
 
@@ -1272,6 +1320,63 @@ function emitExpressionAsF64(ctx: CodegenContext, fctx: FunctionContext, expr: t
     coerceType(ctx, fctx, resultType, { kind: "f64" });
   }
   const tmp = allocLocal(fctx, `__gen_value_${fctx.locals.length}`, { kind: "f64" });
+  fctx.body.push({ op: "local.set", index: tmp });
+  return tmp;
+}
+
+/**
+ * (#2864 F1) Compile a `.next(v)` / `.return(v)` argument to the generator's
+ * carrier field type and return a local holding it. For numeric / string
+ * carriers this is exactly `emitExpressionAsF64` (the f64 `sent`/`abrupt` field,
+ * byte-identical to before). For the boxed-any carrier the value is compiled to
+ * externref (host-free boxing in standalone/WASI), so an arbitrary `.next(v)`
+ * survives into the resume function. A missing arg yields the carrier default
+ * (`NaN` for f64, null externref for the boxed-any carrier).
+ */
+function emitCarrierValue(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.Expression | undefined,
+  info: NativeGeneratorInfo,
+): number {
+  if (!carrierIsAny(info.elemValType)) return emitExpressionAsF64(ctx, fctx, expr);
+  const carrier: ValType = { kind: "externref" };
+  const tmp = allocLocal(fctx, `__gen_carrier_${fctx.locals.length}`, carrier);
+  if (!expr) {
+    fctx.body.push({ op: "ref.null.extern" } as Instr);
+    fctx.body.push({ op: "local.set", index: tmp });
+    return tmp;
+  }
+  const t = compileExpression(ctx, fctx, expr, carrier);
+  if (t === null) {
+    fctx.body.push({ op: "ref.null.extern" } as Instr);
+  } else if (!valTypesMatch(t, carrier)) {
+    coerceType(ctx, fctx, t, carrier);
+  }
+  fctx.body.push({ op: "local.set", index: tmp });
+  return tmp;
+}
+
+/**
+ * (#2864 F1) Compile a `.next(v)` / `.return(v)` argument to externref (the
+ * boxed-`any` representation) for the open dispatch, returning a local holding
+ * it. A missing argument is a null externref. Used only when the dispatch chain
+ * includes an any-carrier generator.
+ */
+function emitOpenAnyArgValue(ctx: CodegenContext, fctx: FunctionContext, expr: ts.Expression | undefined): number {
+  const carrier: ValType = { kind: "externref" };
+  const tmp = allocLocal(fctx, `__gen_any_arg_${fctx.locals.length}`, carrier);
+  if (!expr) {
+    fctx.body.push({ op: "ref.null.extern" } as Instr);
+    fctx.body.push({ op: "local.set", index: tmp });
+    return tmp;
+  }
+  const t = compileExpression(ctx, fctx, expr, carrier);
+  if (t === null) {
+    fctx.body.push({ op: "ref.null.extern" } as Instr);
+  } else if (!valTypesMatch(t, carrier)) {
+    coerceType(ctx, fctx, t, carrier);
+  }
   fctx.body.push({ op: "local.set", index: tmp });
   return tmp;
 }
@@ -1456,12 +1561,14 @@ function compileState(
     }
     abruptBody.push(...storeSpills(info, fctx, selfLocal));
     abruptBody.push(...setStateInstrs(info, selfLocal, info.doneState));
-    // (#2171) `.return(v)` value lives in the f64 `abrupt` field. For a numeric
-    // generator that f64 IS the completion value; for a string generator the
-    // result `value` is a string ref, and string `.return(v)` is not yet wired
-    // (the abrupt field stays f64) — complete with the elem-type default so the
-    // result struct typechecks. (String `.return(v)` is a documented follow-up.)
-    if (info.elemValType.kind === "f64") {
+    // (#2171/#2864) `.return(v)` value lives in the `abrupt` field. When the
+    // field carrier matches the result `value` type — numeric (both f64) or the
+    // boxed-any carrier (both externref) — the abrupt field IS the completion
+    // value, so read it. For a string generator the result `value` is a string
+    // ref while `abrupt` stays f64, so string `.return(v)` is not yet wired —
+    // complete with the elem-type default so the result struct typechecks.
+    // (String `.return(v)` is a documented follow-up.)
+    if (valTypesMatch(genCarrierFieldType(info.elemValType), info.elemValType)) {
       abruptBody.push({ op: "local.get", index: selfLocal });
       abruptBody.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.abruptFieldIdx });
     } else {
@@ -1744,11 +1851,17 @@ export function compileNativeGeneratorFunction(
   info: NativeGeneratorInfo,
 ): void {
   ensureNativeGeneratorResumeFunction(ctx, info);
-  // Construct the state struct: state=0, sent=NaN, mode=0, abrupt=NaN, params…, spills(NaN)…
+  // Construct the state struct: state=0, sent=⊥, mode=0, abrupt=⊥, params…, spills(NaN)…
+  // (#2864 F1) `sent`/`abrupt` init to the carrier default — `f64 NaN` for the
+  // numeric/string carriers (unchanged) or a null externref for the boxed-any
+  // carrier so the struct.new typechecks before the first `.next(v)`.
+  const carrierInit: Instr = carrierIsAny(info.elemValType)
+    ? ({ op: "ref.null.extern" } as Instr)
+    : { op: "f64.const", value: NaN };
   fctx.body.push({ op: "i32.const", value: 0 });
-  fctx.body.push({ op: "f64.const", value: NaN });
+  fctx.body.push(carrierInit);
   fctx.body.push({ op: "i32.const", value: 0 });
-  fctx.body.push({ op: "f64.const", value: NaN });
+  fctx.body.push(carrierInit);
   // (#2571) Read every wasm param into its `param_*` state slot. For an instance
   // method generator the synthetic `this` is wasm param 0 and user params are
   // 1..n, so iterate `info.paramTypes.length` (which includes the synthetic
@@ -1830,7 +1943,7 @@ function compileDirectNativeGeneratorMethod(
   fctx.body.push({ op: "local.set", index: selfLocal });
 
   if (methodName === "next") {
-    const sentTmp = emitExpressionAsF64(ctx, fctx, args[0]);
+    const sentTmp = emitCarrierValue(ctx, fctx, args[0], info);
     compileIgnoredArgs(ctx, fctx, args.slice(1));
     fctx.body.push(...setStateFieldFromLocal(info, selfLocal, info.sentFieldIdx, sentTmp));
     fctx.body.push(...setStateI32FromConst(info, selfLocal, info.modeFieldIdx, 0));
@@ -1840,7 +1953,7 @@ function compileDirectNativeGeneratorMethod(
   }
 
   if (methodName === "return") {
-    const valueTmp = emitExpressionAsF64(ctx, fctx, args[0]);
+    const valueTmp = emitCarrierValue(ctx, fctx, args[0], info);
     compileIgnoredArgs(ctx, fctx, args.slice(1));
     fctx.body.push({ op: "local.get", index: selfLocal });
     fctx.body.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: STATE_FIELD });
@@ -1886,9 +1999,32 @@ function buildNativeGeneratorDispatch(
   anyLocal: number,
   methodName: string,
   valueLocal?: number,
-): Instr[] {
+  // (#2864 F1) The boxed-`any` carrier's `sent`/`abrupt`/result are externref.
+  // When the dispatch chain includes an any-carrier generator the caller emits
+  // the `.next(v)`/`.return(v)` argument BOTH as f64 (`valueLocal`, for numeric /
+  // string branches, unchanged) AND as externref (`valueAnyLocal`, for any
+  // branches). When no any-carrier generator participates this is undefined and
+  // the dispatch is byte-identical to pre-#2864.
+  valueAnyLocal?: number,
+): { instrs: Instr[]; resultType: ValType } {
   const infos = Array.from(ctx.nativeGenerators.values());
-  const resultType: ValType = { kind: "ref", typeIdx: ensureNativeGeneratorResultType(ctx) };
+  // (#2864 F1) When ANY generator in the chain uses the boxed-any carrier, the
+  // enclosing block must accept every carrier's result struct, so its type is
+  // `eqref` (the common supertype) and the chain produces concrete result
+  // structs (eqref subtypes). For numeric/string-only modules (the existing,
+  // dominant case) there is no any carrier — keep the f64 IteratorResult
+  // singleton block type, byte-identical to before, so no numeric generator
+  // regresses.
+  const hasAny = infos.some((i) => carrierIsAny(i.elemValType));
+  const resultType: ValType = hasAny
+    ? { kind: "eqref" }
+    : { kind: "ref", typeIdx: ensureNativeGeneratorResultType(ctx) };
+  // The per-branch `.next(v)`/`.return(v)` value local: an any-carrier branch
+  // consumes the externref `valueAnyLocal`; numeric / string branches consume the
+  // f64 `valueLocal` (unchanged). `valueLocal` is always present when valueAnyLocal
+  // is (the caller derives one from the other).
+  const branchValueLocal = (info: NativeGeneratorInfo): number =>
+    carrierIsAny(info.elemValType) ? valueAnyLocal! : valueLocal!;
   // #1344 — the receiver matched NONE of the native generator state types, i.e.
   // `[[GeneratorState]]` is absent (e.g. `GeneratorPrototype.next.call({})`).
   // Per §27.5.3.2 GeneratorValidate step 2 / §27.5.1.2-4, throw a *catchable*
@@ -1901,12 +2037,13 @@ function buildNativeGeneratorDispatch(
   function branch(index: number): Instr[] {
     if (index >= infos.length) return fallback;
     const info = infos[index]!;
+    const vLocal = branchValueLocal(info);
     let thenBody: Instr[];
     if (methodName === "next") {
       thenBody = [
         { op: "local.get", index: anyLocal },
         { op: "ref.cast", typeIdx: info.stateTypeIdx },
-        { op: "local.get", index: valueLocal! },
+        { op: "local.get", index: vLocal },
         { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: info.sentFieldIdx },
         { op: "local.get", index: anyLocal },
         { op: "ref.cast", typeIdx: info.stateTypeIdx },
@@ -1935,7 +2072,7 @@ function buildNativeGeneratorDispatch(
             { op: "ref.cast", typeIdx: info.stateTypeIdx },
             { op: "i32.const", value: 0 },
             { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: info.modeFieldIdx },
-            { op: "local.get", index: valueLocal! },
+            { op: "local.get", index: vLocal },
             { op: "i32.const", value: 1 },
             { op: "struct.new", typeIdx: info.resultTypeIdx },
           ],
@@ -1953,14 +2090,14 @@ function buildNativeGeneratorDispatch(
                 { op: "ref.cast", typeIdx: info.stateTypeIdx },
                 { op: "i32.const", value: 0 },
                 { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: info.modeFieldIdx },
-                { op: "local.get", index: valueLocal! },
+                { op: "local.get", index: vLocal },
                 { op: "i32.const", value: 1 },
                 { op: "struct.new", typeIdx: info.resultTypeIdx },
               ],
               else: [
                 { op: "local.get", index: anyLocal },
                 { op: "ref.cast", typeIdx: info.stateTypeIdx },
-                { op: "local.get", index: valueLocal! },
+                { op: "local.get", index: vLocal },
                 { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: info.abruptFieldIdx },
                 { op: "local.get", index: anyLocal },
                 { op: "ref.cast", typeIdx: info.stateTypeIdx },
@@ -1986,7 +2123,7 @@ function buildNativeGeneratorDispatch(
       },
     ];
   }
-  return branch(0);
+  return { instrs: branch(0), resultType };
 }
 
 export function tryCompileNativeGeneratorMethodCall(
@@ -2019,14 +2156,33 @@ export function tryCompileNativeGeneratorMethodCall(
   const anyLocal = allocLocal(fctx, `__native_gen_any_${fctx.locals.length}`, { kind: "anyref" });
   fctx.body.push({ op: "local.set", index: anyLocal });
 
+  // (#2864 F1) When the open dispatch must service an any-carrier generator, the
+  // `.next(v)`/`.return(v)` argument is needed BOTH as externref (any branches)
+  // and as f64 (numeric / string branches). Compile it ONCE to externref (its
+  // natural representation when `it` is statically opaque), then derive the f64
+  // by unboxing — so a side-effecting argument is evaluated exactly once. For
+  // numeric/string-only modules (no any carrier) keep the historical f64-only
+  // emission, byte-identical to before.
+  const dispatchHasAny = Array.from(ctx.nativeGenerators.values()).some((i) => carrierIsAny(i.elemValType));
   let valueLocal: number | undefined;
+  let valueAnyLocal: number | undefined;
   if (methodName === "return" || methodName === "next") {
-    valueLocal = emitExpressionAsF64(ctx, fctx, args[0]);
-    compileIgnoredArgs(ctx, fctx, args.slice(1));
+    if (dispatchHasAny) {
+      valueAnyLocal = emitOpenAnyArgValue(ctx, fctx, args[0]);
+      compileIgnoredArgs(ctx, fctx, args.slice(1));
+      valueLocal = allocLocal(fctx, `__gen_sent_f64_${fctx.locals.length}`, { kind: "f64" });
+      fctx.body.push({ op: "local.get", index: valueAnyLocal });
+      coerceType(ctx, fctx, { kind: "externref" }, { kind: "f64" });
+      fctx.body.push({ op: "local.set", index: valueLocal });
+    } else {
+      valueLocal = emitExpressionAsF64(ctx, fctx, args[0]);
+      compileIgnoredArgs(ctx, fctx, args.slice(1));
+    }
   }
 
-  fctx.body.push(...buildNativeGeneratorDispatch(ctx, anyLocal, methodName, valueLocal));
-  return { kind: "ref", typeIdx: ctx.nativeGeneratorResultTypeIdx };
+  const { instrs, resultType } = buildNativeGeneratorDispatch(ctx, anyLocal, methodName, valueLocal, valueAnyLocal);
+  fctx.body.push(...instrs);
+  return resultType;
 }
 
 export function tryCompileNativeGeneratorResultProperty(
@@ -2067,24 +2223,107 @@ export function tryCompileNativeGeneratorResultProperty(
 
   const anyLocal = allocLocal(fctx, `__native_gen_result_${fctx.locals.length}`, { kind: "anyref" });
   fctx.body.push({ op: "local.set", index: anyLocal });
-  const fieldType: ValType = propName === "value" ? { kind: "f64" } : { kind: "i32" };
-  fctx.body.push({ op: "local.get", index: anyLocal });
-  fctx.body.push({ op: "ref.test", typeIdx: ctx.nativeGeneratorResultTypeIdx });
-  fctx.body.push({
-    op: "if",
-    blockType: { kind: "val", type: fieldType },
-    then: [
-      { op: "local.get", index: anyLocal },
-      { op: "ref.cast", typeIdx: ctx.nativeGeneratorResultTypeIdx },
-      {
-        op: "struct.get",
-        typeIdx: ctx.nativeGeneratorResultTypeIdx,
-        fieldIdx: propName === "value" ? RESULT_VALUE_FIELD : RESULT_DONE_FIELD,
-      },
-    ],
-    else: [propName === "value" ? { op: "f64.const", value: 0 } : { op: "i32.const", value: 1 }],
-  });
+
+  // (#2864 F1) Distinct IteratorResult struct types in this module: the f64
+  // singleton (when present) plus each registered generator's per-elem result
+  // type (native string, boxed-any externref). The open reader must runtime-test
+  // every one, not just the f64 singleton — otherwise a `.done`/`.value` read off
+  // an any-carrier result (which is NOT the singleton) fell through to the
+  // default (`done:true` / `0`).
+  const resultEntries: { typeIdx: number; elemValType: ValType }[] = [];
+  const seenResult = new Set<number>();
+  const pushEntry = (typeIdx: number, elem: ValType): void => {
+    if (typeIdx >= 0 && !seenResult.has(typeIdx)) {
+      seenResult.add(typeIdx);
+      resultEntries.push({ typeIdx, elemValType: elem });
+    }
+  };
+  if (ctx.nativeGeneratorResultTypeIdx >= 0) pushEntry(ctx.nativeGeneratorResultTypeIdx, { kind: "f64" });
+  for (const info of ctx.nativeGenerators.values()) pushEntry(info.resultTypeIdx, info.elemValType);
+
+  if (propName === "done") {
+    // `done` is i32 for every carrier — test each result type, read field 1.
+    fctx.body.push(buildOpenResultRead(anyLocal, resultEntries, RESULT_DONE_FIELD, { kind: "i32" }));
+    return { kind: "i32" };
+  }
+
+  // `value`: choose the return ValType from the STATIC type of the result's
+  // `value` property. A numeric generator keeps the f64 fast path (byte-identical
+  // to before); an object / mixed (boxed-any) generator returns externref. This
+  // is what keeps existing numeric `.next().value` reads unchanged.
+  let valueWantsRef = false;
+  const itType = ctx.checker.getTypeAtLocation(resultExpr);
+  const valSym = itType.getProperty?.("value");
+  if (valSym) {
+    const mapped = mapTsTypeToWasm(ctx.checker.getTypeOfSymbolAtLocation(valSym, resultExpr), ctx.checker);
+    valueWantsRef =
+      mapped.kind === "externref" ||
+      mapped.kind === "anyref" ||
+      mapped.kind === "eqref" ||
+      mapped.kind === "ref" ||
+      mapped.kind === "ref_null";
+  }
+
+  if (valueWantsRef) {
+    // Read the value off whichever boxed-any result type matched, leaving an
+    // externref. Only the any-carrier (externref-elem) result types carry an
+    // externref value; a numeric result's f64 value can't be returned here, so it
+    // falls to the inert null default (a numeric value statically typed `any` is
+    // not a shape F1 targets).
+    const anyEntries = resultEntries.filter((e) => e.elemValType.kind === "externref");
+    fctx.body.push(buildOpenResultRead(anyLocal, anyEntries, RESULT_VALUE_FIELD, { kind: "externref" }));
+    return { kind: "externref" };
+  }
+
+  // Numeric value (or no static info): the historical f64-singleton fast path.
+  const fieldType: ValType = { kind: "f64" };
+  const f64Entries = resultEntries.filter((e) => e.elemValType.kind === "f64");
+  fctx.body.push(buildOpenResultRead(anyLocal, f64Entries, RESULT_VALUE_FIELD, fieldType));
   return fieldType;
+}
+
+/**
+ * (#2864 F1) Build a runtime ref.test chain over candidate IteratorResult struct
+ * types, reading `fieldIdx` off the first match and leaving a `returnVT`. The
+ * default (no match) is the inert value for the field: `i32.const 1` (done) /
+ * `f64.const 0` / null externref. The matched struct's field type already equals
+ * `returnVT` for both the f64 singleton (value f64 / done i32) and the boxed-any
+ * result (value externref / done i32), so no per-entry coercion is needed.
+ */
+function buildOpenResultRead(
+  anyLocal: number,
+  entries: { typeIdx: number; elemValType: ValType }[],
+  fieldIdx: number,
+  returnVT: ValType,
+): Instr {
+  const def: Instr =
+    fieldIdx === RESULT_DONE_FIELD
+      ? { op: "i32.const", value: 1 }
+      : returnVT.kind === "externref"
+        ? ({ op: "ref.null.extern" } as Instr)
+        : { op: "f64.const", value: 0 };
+  // Each level emits its own `ref.test` condition then the `if`; the tail (no
+  // match) yields the inert default.
+  const wrap = (i: number): Instr[] => {
+    if (i >= entries.length) return [def];
+    const e = entries[i]!;
+    return [
+      { op: "local.get", index: anyLocal },
+      { op: "ref.test", typeIdx: e.typeIdx },
+      {
+        op: "if",
+        blockType: { kind: "val", type: returnVT },
+        then: [
+          { op: "local.get", index: anyLocal },
+          { op: "ref.cast", typeIdx: e.typeIdx },
+          { op: "struct.get", typeIdx: e.typeIdx, fieldIdx },
+        ],
+        else: wrap(i + 1),
+      } as Instr,
+    ];
+  };
+  // Wrap the chain in a single block so the caller pushes exactly one Instr.
+  return { op: "block", blockType: { kind: "val", type: returnVT }, body: wrap(0) } as Instr;
 }
 
 /**

--- a/src/codegen/literals.ts
+++ b/src/codegen/literals.ts
@@ -3590,12 +3590,18 @@ export function compileArrayLiteral(
       // normal materialized vec spread (same shape as the externref path).
       const genInfo = nativeGeneratorInfoForForOfSubject(ctx, srcType);
       if (genInfo) {
-        const genVecTypeIdx = getOrRegisterVecType(ctx, "f64");
+        // (#2864 F1) Drain into a vec whose element type matches the generator's
+        // carrier: f64 for numeric (unchanged) or externref for the boxed-any
+        // carrier (object / mixed yields). The native-string carrier is handled
+        // by the dedicated string-spread arm below, so only f64 / externref reach
+        // here; anything else keeps the f64 default and is skipped by the guard.
+        const genElemKind = genInfo.elemValType.kind === "externref" ? "externref" : "f64";
+        const genVecTypeIdx = getOrRegisterVecType(ctx, genElemKind);
         const genArrTypeIdx = getArrTypeIdxFromVec(ctx, genVecTypeIdx);
         if (vecTypeIdx !== genVecTypeIdx) {
-          // Result element type isn't f64 (mixed literal whose first-element
-          // heuristic picked another type) — copying f64s into that array would
-          // be invalid Wasm. Preserve the conservative skip for this rare shape.
+          // Result element type doesn't match the generator's carrier (mixed
+          // literal whose first-element heuristic picked another type) — copying
+          // into that array would be invalid Wasm. Conservative skip.
           fctx.body.push({ op: "drop" });
           continue;
         }

--- a/src/codegen/statements/destructuring.ts
+++ b/src/codegen/statements/destructuring.ts
@@ -1057,7 +1057,12 @@ export function compileArrayDestructuring(
   if (!isVecArray) {
     const genInfo = nativeGeneratorInfoForForOfSubject(ctx, resultType);
     if (genInfo) {
-      const genVecTypeIdx = getOrRegisterVecType(ctx, "f64");
+      // (#2864 F1) Drain into a vec whose element type matches the generator's
+      // carrier: f64 for numeric (unchanged) or externref for the boxed-any
+      // carrier (object / mixed yields), so the destructured bindings receive a
+      // faithful `any` value rather than a mis-typed f64.
+      const genElemKind = genInfo.elemValType.kind === "externref" ? "externref" : "f64";
+      const genVecTypeIdx = getOrRegisterVecType(ctx, genElemKind);
       const genArrTypeIdx = getArrTypeIdxFromVec(ctx, genVecTypeIdx);
       // genState ref is currently on the stack; emitNativeGeneratorToVec
       // consumes it and leaves (ref $vec_f64). trimToLength=true: the

--- a/tests/issue-2864-standalone-generator-carrier.test.ts
+++ b/tests/issue-2864-standalone-generator-carrier.test.ts
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2864 F1 — heterogeneous (boxed-`any`) carrier for the Wasm-native generator
+ * frame in standalone.
+ *
+ * The native generator (#1665/#2079/#2171) carried numeric (f64) or uniform
+ * string payloads; an OBJECT yield or a MIX of yield types bailed to the
+ * eager-buffer host path, which under standalone leaks `__gen_*` /
+ * `__create_generator` imports and refuses (#680). F1 adds a third carrier: when
+ * the yields are object-typed or mixed, the result `value` field and the
+ * per-frame `sent` / `abrupt` scalars become **externref** (the universal boxed
+ * `any`). Every value coerces to externref host-free in standalone (numbers via
+ * the native `__box_number`, objects via `extern.convert_any`), so the frame
+ * needs no host import.
+ *
+ * Scope (F1): object / mixed yields with straight-line, NON-spilling bodies, via
+ * the dominant consumers — `.next()` / `.next().value` (open dispatch), for-of,
+ * and array destructuring. Deferred follow-ups (documented): live-across-yield
+ * non-numeric LOCAL spills (needs two-pass spill typing — they bail cleanly to
+ * host today), spread / Array.from precision for the boxed-any carrier, and
+ * try/catch-across-yield (F2) / `yield*` over arbitrary iterables (F3).
+ *
+ * Every case compiles standalone with ZERO host imports.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const imports = WebAssembly.Module.imports(mod).map((i) => `${i.module}::${i.name}`);
+  expect(imports, "standalone module must have zero host imports").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2864 F1 boxed-any native generator carrier (standalone)", () => {
+  it("verify-first: mixed object+number yields, read via .next().value host-free", async () => {
+    // The exact case from the issue: `function* g(){ yield {a:1}; yield 2 }`.
+    expect(
+      await runStandalone(`function* g() { yield {a:1}; yield 2; }
+export function test(): number {
+  let it = g();
+  let r1 = it.next();
+  let r2 = it.next();
+  return (r1.value as any).a + (r2.value as number);
+}`),
+    ).toBe(3); // 1 + 2 — the yielded object survives the frame
+  });
+
+  it("uniform object yields consumed via for-of", async () => {
+    expect(
+      await runStandalone(`function* g() { yield {a:10}; yield {a:20}; }
+export function test(): number {
+  let sum = 0;
+  for (const o of g()) { sum += (o as any).a; }
+  return sum;
+}`),
+    ).toBe(30);
+  });
+
+  it("three object yields summed via for-of", async () => {
+    expect(
+      await runStandalone(`function* g() { yield {v:1}; yield {v:2}; yield {v:3}; }
+export function test(): number { let n = 0; for (const o of g()) n += (o as any).v; return n; }`),
+    ).toBe(6);
+  });
+
+  it("array destructuring of an object generator", async () => {
+    expect(
+      await runStandalone(`function* g() { yield {a:7}; yield {a:8}; }
+export function test(): number { let [x, y] = g(); return (x as any).a + (y as any).a; }`),
+    ).toBe(15);
+  });
+
+  it("mixed module: numeric generator (open dispatch) coexists with an object generator", async () => {
+    expect(
+      await runStandalone(`function* gn() { yield 10; yield 20; }
+function* go() { yield {a:1}; }
+export function test(): number {
+  let itn = gn();
+  let a = itn.next();
+  let b = itn.next();
+  let ito = go();
+  let c = ito.next();
+  return (a.value as number) + (b.value as number) + ((c.value as any).a);
+}`),
+    ).toBe(31);
+  });
+
+  it(".return() on an object generator completes (done:true)", async () => {
+    expect(
+      await runStandalone(`function* g() { yield {a:1}; yield {a:2}; }
+export function test(): number {
+  let it = g();
+  it.next();
+  let r = it.return({a:9} as any);
+  return r.done ? 1 : 0;
+}`),
+    ).toBe(1);
+  });
+
+  it("done flag reads true after exhausting an object generator", async () => {
+    expect(
+      await runStandalone(`function* g() { yield {a:1}; yield 2; }
+export function test(): number {
+  let it = g();
+  it.next();
+  it.next();
+  let r = it.next();
+  return r.done ? 1 : 0;
+}`),
+    ).toBe(1);
+  });
+
+  it("numeric-only generators are byte-for-byte unaffected (f64 fast path)", async () => {
+    expect(
+      await runStandalone(`function* g() { yield 1; yield 2; yield 3; }
+export function test(): number { let s = 0; for (const x of g()) s += x; return s; }`),
+    ).toBe(6);
+  });
+});


### PR DESCRIPTION
## #2864 F1 — heterogeneous (boxed-`any`) carrier for the native generator frame

Object / mixed-type yields now lower to the Wasm-native generator state machine **host-free** in standalone/WASI, instead of bailing to the eager-buffer host path (which leaks `__gen_*` / `__create_generator` and refuses under #680). The resumable frame already existed (`generators-native.ts`, the `br_table`-on-state machine) but its `value`/`sent`/`abrupt`/spill slots were f64-only (#1665) or a uniform native-string ref (#2171). F1 **generalises the frame** rather than building a new one.

### Verify-first (the issue's exact case)
`function* g(){ yield {a:1}; yield 2 }` consumed via `r1.value.a + r2.value`:
- **before:** CE-refused in standalone (leaks `__gen_create_buffer`/`__gen_next`/`__create_generator`/…)
- **after:** compiles with **zero host imports**, returns `3` — the yielded object survives the frame.

### What changed (root-cause, not symptom)
- **Carrier = `externref`** for object/mixed yields (was `null` → host bail). `any` already maps to externref and boxes host-free in standalone (native `__box_number` / `extern.convert_any`), so the consumer reading `.value` / a for-of var as `any` needs no extra coercion.
- **`sent`/`abrupt` typed per-carrier** (externref for any, f64 for numeric/string) — the state struct is minted per-generator, so numeric & string structs + all call sites stay **byte-identical** (zero regression risk).
- **Open dispatch gated on `hasAny`** — `let it = g()` boxes `it` to externref, so `it.next()` routes through the open anyref dispatch (the load-bearing path). Numeric/string-only modules keep the exact f64-singleton dispatch; a module with an any-carrier generator switches the block type to `eqref` (common supertype) and emits the `.next(v)` arg both as externref (any branches) and f64 (numeric branches, one unbox).
- **Open result reader** ref-tests every result struct; `.done` uniformly i32, `.value` picks f64 vs externref from the **static** type (numeric `.next().value` preserved).
- **Spread / destructuring** vec drains parametrised on the carrier element type (destructuring works; spread of an object generator is host-free but semantically incomplete — see deferred).

### Tests
- New `tests/issue-2864-standalone-generator-carrier.test.ts` (8 cases, **zero-host-import asserted**): verify-first, for-of, destructuring, mixed-module open dispatch, `.return()`, done-flag, numeric-unchanged.
- All ~250 existing native-generator tests pass (2079 / 1665 / 2169 / 2170 / 2171 / 2571 / 2581 / 2157 / 1017 / generators).

### Deferred (bail cleanly, **non-regressing** today; tracked on the issue)
- **Typed live-across-yield LOCAL spills** for the any carrier — an object local lowers to a concrete `ref $Object` whose exact type the up-front struct layout can't know without a body pre-pass (the architect-flagged "deeper rewrite"); such generators bail to host consistently across the candidate gate + registration. **Biggest remaining widener.**
- **Spread / `Array.from` precision** for the boxed-any carrier (array destructuring already works).
- **F2** (try/finally-across-yield + `return()`/`throw()`), **F3** (`yield*` over arbitrary iterables) — separate PRs.

This is the substrate primitive that unblocks #2865 (async generators).

🤖 Generated with [Claude Code](https://claude.com/claude-code)