### PR TITLE
fix(#2888): standalone relational with String wrapper operand emitted invalid Wasm

### DIFF
--- a/plan/issues/2873-standalone-language-expressions-cluster.md
+++ b/plan/issues/2873-standalone-language-expressions-cluster.md
@@ -34,3 +34,18 @@ split into focused sub-tasks.
 
 Per sub-cluster: standalone fail → pass, verify-first, full `merge_group` +
 standalone high-water. `ctx.standalone` only.
+
+## Progress (2026-06-30)
+
+Triaged the operator sub-dirs (`addition`/`equals`/relational/...). Findings:
+- **Relational `<`/`<=`/`>`/`>=` with a `String` wrapper operand emitted invalid
+  Wasm** standalone (`S11.8.x_A3.2_T1.x`) → split out as **#2888** and FIXED
+  (native `ref $AnyString` lowering of both operands before `__str_compare`).
+- The large residual `fail | "Cannot convert object to primitive value"` bucket
+  (the `_A1`/`_A2.2` object-`valueOf` relational + `addition` object operands)
+  is the **#2862 ToPrimitive** cluster (object→primitive in operators), NOT a
+  relational-codegen bug — verified identical on unedited main. Track under
+  #2862 / a dedicated ToPrimitive-in-operators sub-task.
+- `subtraction/bigint-and-number.js` needs the `BigInt` extern class (separate).
+
+Remaining #2873 work is dominated by the #2862 ToPrimitive-in-operators surface.

--- a/plan/issues/2888-standalone-string-wrapper-relational-invalid-wasm.md
+++ b/plan/issues/2888-standalone-string-wrapper-relational-invalid-wasm.md
@@ -1,0 +1,71 @@
+---
+id: 2888
+title: "Standalone: relational `<`/`<=`/`>`/`>=` with a String wrapper operand emits invalid Wasm"
+status: done
+created: 2026-06-30
+completed: 2026-06-30
+priority: high
+feasibility: medium
+task_type: bug
+area: codegen
+goal: standalone
+sprint: current
+horizon: s
+related: [2873, 2870, 2862]
+umbrella: 2873
+assignee: ttraenkler/agent-abb00
+---
+
+# Standalone: relational with a String wrapper operand emits invalid Wasm
+
+Sub-slice of the #2873 `language/expressions` standalone cluster.
+
+## Problem
+
+Under `--target standalone`, a relational comparison (`<`, `<=`, `>`, `>=`)
+where one operand is a `String` **wrapper object** (`new String("1")`) produced
+an **invalid Wasm module** (compiled `success: true`, failed at
+`WebAssembly.instantiate`):
+
+```
+new String("1") < "1"   → call[0] expected type (ref null 6), found local.tee of type externref
+"1" < new String("1")   → any.convert_extern[0] expected externref, found ref.cast null of type (ref null 6)
+```
+
+This de-masked (post-#2870) the test262 cluster
+`language/expressions/{less-than,greater-than,less-than-or-equal,greater-than-or-equal}/S11.8.x_A3.2_T1.x`
+(`Type(Primitive(x))` varies between primitive string and `String` object),
+all reported as `compile_error` standalone while passing host-mode.
+
+## Root cause
+
+`compileStringBinaryOp`'s relational arm (`src/codegen/string-ops.ts` ~1677)
+pushed both operands **raw** via `compileExpression`, then called the native
+`__str_compare` helper, whose signature is `(ref $AnyString, ref $AnyString)`.
+A `String` wrapper object lowers to an `externref` (boxed), not a native
+`ref $AnyString`, so the call tripped the helper's parameter type → the module
+failed Wasm validation. The `+` concat case already lowered each operand to a
+native `ref $AnyString` via `compileNativeConcatOperand` (ToString); relational
+did not.
+
+## Fix
+
+In the relational arm, under `noJsHost` (standalone / WASI), lower each operand
+to a native `ref $AnyString` via `compileNativeConcatOperand` (String wrapper →
+`tryStructToString`/`$__any_to_string`, dynamic externref → `__extern_toString`,
+number → `number_toString`) before calling `__str_compare` — mirroring the `+`
+path. The legacy JS-host `nativeStrings` path keeps its original raw push (host
+(gc) mode is byte-unaffected).
+
+## Result
+
+- `S11.8.x_A3.2_T1.x` String-wrapper relational tests: standalone
+  `compile_error` → `pass`, host-free (`result.imports` empty).
+- Relational dirs scan (host-pass tests): 160 standalone pass / 8 fail; the 8
+  residual fails are the `_A1`/`_A2.2` object-`valueOf` relational tests
+  ("Cannot convert object to primitive value"), a separate pre-existing #2862
+  ToPrimitive cluster (verified identical on unedited main, untouched by this
+  change).
+- Zero host (gc) regression.
+
+Regression test: `tests/issue-2888.test.ts`.

--- a/src/codegen/string-ops.ts
+++ b/src/codegen/string-ops.ts
@@ -1674,9 +1674,26 @@ export function compileStringBinaryOp(
       case ts.SyntaxKind.LessThanEqualsToken:
       case ts.SyntaxKind.GreaterThanToken:
       case ts.SyntaxKind.GreaterThanEqualsToken: {
-        // Lexicographic comparison via __str_compare (returns -1, 0, 1)
-        compileExpression(ctx, fctx, expr.left);
-        compileExpression(ctx, fctx, expr.right);
+        // Lexicographic comparison via __str_compare (returns -1, 0, 1).
+        // `__str_compare` takes `(ref $AnyString, ref $AnyString)`. A non-native
+        // string operand — e.g. a `String` wrapper object (`new String("1")`),
+        // a boxed/dynamic externref, or a number — must be lowered to a native
+        // `ref $AnyString` first or the module is invalid (#2873: standalone
+        // `new String("1") < "1"` pushed the raw struct/externref and tripped
+        // `__str_compare`'s param type → CompileError). The `+` concat case
+        // already does this via `compileNativeConcatOperand`; relational did
+        // not. Mirror it under `noJsHost` (standalone / WASI), where every
+        // operand lowers to a native `ref $AnyString` in pure Wasm via
+        // ToString (String wrapper → `tryStructToString`/`$__any_to_string`,
+        // dynamic externref → `__extern_toString`, number → `number_toString`).
+        // The legacy JS-host `nativeStrings` path keeps its original raw push.
+        if (noJsHost(ctx)) {
+          compileNativeConcatOperand(ctx, fctx, expr.left);
+          compileNativeConcatOperand(ctx, fctx, expr.right);
+        } else {
+          compileExpression(ctx, fctx, expr.left);
+          compileExpression(ctx, fctx, expr.right);
+        }
         const funcIdx = ctx.nativeStrHelpers.get("__str_compare");
         if (funcIdx !== undefined) {
           fctx.body.push({ op: "call", funcIdx });

--- a/tests/issue-2888.test.ts
+++ b/tests/issue-2888.test.ts
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #2888 (sub-slice of #2873) — standalone relational comparison (`<`,`<=`,`>`,
+// `>=`) with a `String` wrapper-object operand emitted invalid Wasm.
+//
+// `compileStringBinaryOp`'s relational arm pushed both operands raw and called
+// the native `__str_compare` helper, which takes `(ref $AnyString,
+// ref $AnyString)`. A non-native-string operand — a `String` wrapper object
+// (`new String("1")`), a boxed/dynamic externref, or a number — is NOT a native
+// `ref $AnyString`, so the call tripped the helper's param type and the module
+// failed Wasm validation:
+//   `call[0] expected type (ref null 6), found local.tee of type externref`
+//   `any.convert_extern[0] expected externref, found ref.cast null of (ref null 6)`
+// The `+` concat case already lowered each operand to a native `ref $AnyString`
+// via `compileNativeConcatOperand` (ToString); relational did not. Fix: mirror
+// that under `noJsHost` (standalone / WASI). This flips the test262
+// `language/expressions/{less-than,greater-than,less-than-or-equal,
+// greater-than-or-equal}/S11.8.x_A3.2_T1.x` String-wrapper relational cluster
+// from compile_error to pass, host-free, with zero host (gc) regression.
+//
+// String returns from a standalone module are native-string refs (not JS
+// strings), so these assert via boolean → number (1/0) exports.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  // No host import may leak under standalone.
+  expect(r.imports ?? []).toEqual([]);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2888 — standalone relational with String wrapper operand (was invalid Wasm)", () => {
+  it("new String('1') < '1'  →  false", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const a = new String("1"); return (a < "1") ? 1 : 0; }`),
+    ).toBe(0);
+  });
+
+  it("'1' < new String('1')  →  false", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const b = new String("1"); return ("1" < b) ? 1 : 0; }`),
+    ).toBe(0);
+  });
+
+  it("new String('1') < new String('2')  →  true", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a = new String("1"); const b = new String("2"); return (a < b) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("new String('x') > '1'  →  true (lexicographic)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const a = new String("x"); return (a > "1") ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("new String('2') >= '10'  →  true (code-unit order, '2' > '1')", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const a = new String("2"); return (a >= "10") ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("new String('1') <= new String('1')  →  true", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const a = new String("1"); const b = new String("1"); return (a <= b) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("plain string relational still works (no regression)", async () => {
+    expect(await runStandalone(`export function test(): number { return ("a" < "b") ? 1 : 0; }`)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

Under `--target standalone`, a relational comparison (`<`, `<=`, `>`, `>=`) where one operand is a `String` **wrapper object** (`new String("1")`) produced an **invalid Wasm module** (compiled `success: true`, failed at `WebAssembly.instantiate`):

```
new String("1") < "1"   → call[0] expected type (ref null 6), found local.tee of type externref
"1" < new String("1")   → any.convert_extern[0] expected externref, found ref.cast null of type (ref null 6)
```

This de-masked (post-#2870) the test262 cluster `language/expressions/{less-than,greater-than,less-than-or-equal,greater-than-or-equal}/S11.8.x_A3.2_T1.x` — all `compile_error` standalone, host-pass. Sub-slice of the #2873 umbrella.

## Root cause

`compileStringBinaryOp`'s relational arm pushed both operands **raw** via `compileExpression`, then called the native `__str_compare` helper, whose signature is `(ref $AnyString, ref $AnyString)`. A `String` wrapper lowers to an `externref` (boxed), not a native `ref $AnyString`, so the call tripped the helper's parameter type → invalid Wasm. The `+` concat case already lowered each operand to a native string via `compileNativeConcatOperand` (ToString); relational did not.

## Fix

In the relational arm, under `noJsHost` (standalone / WASI), lower each operand to a native `ref $AnyString` via `compileNativeConcatOperand` (String wrapper → `tryStructToString`/`$__any_to_string`, dynamic externref → `__extern_toString`, number → `number_toString`) before `__str_compare` — mirroring the `+` path. The legacy JS-host `nativeStrings` path keeps its original raw push (host (gc) mode byte-unaffected).

## Result

- `S11.8.x_A3.2_T1.x` String-wrapper relational tests: standalone `compile_error` → `pass`, host-free (`result.imports` empty).
- Relational-dirs scan (host-pass tests): 160 standalone pass / 8 fail; the 8 residual are the `_A1`/`_A2.2` object-`valueOf` relational tests ("Cannot convert object to primitive value") — a separate pre-existing **#2862** ToPrimitive cluster, verified identical on unedited main, untouched here.
- Zero host (gc) regression.

Regression test: `tests/issue-2888.test.ts` (7 cases, all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)