### PR TITLE
fix(#2889): standalone high-water WRITE side keys on host_free_pass — undo the leaky-26k clobber

### DIFF
--- a/benchmarks/results/test262-standalone-highwater.json
+++ b/benchmarks/results/test262-standalone-highwater.json
@@ -1,8 +1,9 @@
 {
-  "pass": 26040,
-  "official_pass": 24900,
+  "pass": 12883,
+  "host_free_pass": 12883,
+  "official_pass": 12551,
   "official_total": 43136,
-  "sha": "15ef5a1c79e5e966d89c80938a09179df81f1b8b",
-  "generated_at": "2026-06-30T05:45:58Z",
+  "sha": "d0b37757d7373b1486b4023c323218761999aeb0",
+  "generated_at": "2026-06-30T06:30:00Z",
   "tolerance": 50
 }

--- a/plan/issues/2889-standalone-highwater-writeside-hostfree.md
+++ b/plan/issues/2889-standalone-highwater-writeside-hostfree.md
@@ -1,0 +1,94 @@
+---
+id: 2889
+title: "Standalone high-water WRITE side must emit host_free_pass — promote-baseline clobbered the honest mark back to the leaky 26k"
+status: in-progress
+assignee: ttraenkler/sendev-highwater
+created: 2026-06-30
+priority: high
+task_type: bug
+area: tooling
+goal: standalone
+sprint: current
+horizon: m
+related: [2879, 2360, 2097, 2366, 2367]
+umbrella: 2860
+---
+
+# Standalone high-water WRITE side must emit `host_free_pass`
+
+## Problem (CI-FIX — blocks the carrier track)
+
+#2879 §2 switched the standalone-floor **read/gate** to `host_free_pass`
+(`scripts/check-standalone-highwater.mjs` `passFromReport` /
+`officialFromReport`) and re-baselined
+`benchmarks/results/test262-standalone-highwater.json` to the honest host-free
+**12,883** (official 12,551). That landed in `5e3d9aca7`.
+
+The **post-merge `promote-baseline` job** (in
+`.github/workflows/test262-sharded.yml`, step "Raise standalone pass-count
+high-water mark (#2097)", line ~1480) then clobbered it. Commit
+`d4bc147d3` overwrote the file back to `pass: 26040, official_pass: 24900` with
+**no `host_free_pass` field**. The floor gate then compared current host-free
+(~12,883) against high-water 26040 → **breach** on every standalone / carrier
+PR's `merge_group`, and `tests/issue-2879-standalone-host-free-floor.test.ts`
+went RED on `main` (it asserts `mark.pass ∈ (10000, 20000)`).
+
+## Root cause (verified, not a `--update` leaky-read)
+
+`check-standalone-highwater.mjs --update` already used `passFromReport`
+(host-free) for the _raise_ value, so it did not itself write a leaky number
+from the report. The clobber was a **stale-checkout + ratchet-up-only +
+no-`host_free_pass`-field** interaction:
+
+1. The promote run that produced `d4bc147d3` was triggered by the push of
+   `15ef5a1c7` (#2359), whose tree was branched **before** §2 (`5e3d9aca7` is
+   **not** an ancestor of `15ef5a1c7`). So its checked-out high-water file was
+   the **pre-§2 leaky** `{pass: 26040, official_pass: 24900}` — which had **no
+   `host_free_pass` field**.
+2. `--update` is ratchet-**up-only**: the report's host-free `12,883` did **not**
+   exceed the stale loaded mark `26,040`, so it did **not** rewrite the file.
+3. The job committed the baseline refresh onto the _then-current_ `main` HEAD
+   (which already had §2's honest `12,883`). The **unchanged stale leaky file**
+   from the §2-less checkout landed on top of §2 → silent revert `12,883 →
+26,040`, dropping the `host_free_pass` field.
+
+The disambiguator that was missing: a **`host_free_pass` field in the
+high-water file**. Without it, a stale leaky `pass: 26040` is indistinguishable
+from a genuine host-free 26k, so the ratchet can't reject it.
+
+## Fix (write-side, symmetric with the §2 read)
+
+`scripts/check-standalone-highwater.mjs`:
+
+1. **Strict host-free WRITE reader** — add `hostFreeFromReport` /
+   `officialHostFreeFromReport` that read **only** `…host_free_pass` (NO fallback
+   to the leaky `pass`). `--update` uses these: a report lacking `host_free_pass`
+   (pre-#2879-§1 shape, or one whose rows dropped the leak class) **refuses to
+   raise** instead of inflating the mark with a leaky pass. (The gate _read_
+   `passFromReport` keeps its leaky fallback — safe there: a leaky number ≥ an
+   honest floor never false-breaches.)
+2. **Always emit a `host_free_pass` field** — every `--update` write carries both
+   `pass` (= host-free, kept for back-compat with `evaluate`/the test) and an
+   explicit `host_free_pass` (= same host-free number), plus host-free
+   `official_pass`. This makes a stale leaky file structurally impossible going
+   forward: no honest write ever puts a leaky number anywhere, and a stale
+   checkout can now only ever hold an honest host-free mark.
+3. **Ratchet / evaluate key on `host_free_pass`** — `evaluate` and the raise
+   decision read `mark.host_free_pass ?? mark.pass` so the field, once present,
+   is authoritative.
+
+`benchmarks/results/test262-standalone-highwater.json`: **restored** to the
+honest live-main numbers (re-measured on the live baseline jsonl, 48,118
+records): `pass`/`host_free_pass` **12,883**, `official_pass` **12,551**,
+`official_total` 43,136, tolerance 50. Host-free criterion
+(`host_import_leak_class` absent) re-confirmed against current main.
+
+## Verification
+
+- `tests/issue-2879-standalone-host-free-floor.test.ts` green (restored mark in
+  band) + new write-side strictness cases.
+- Traced the promote path: single writer (line ~1483, staged ~1797); no second
+  job (no `benchmark-refresh.yml` etc.) touches the file. Next post-merge refresh
+  reads host-free `12,883`, mark `12,883` → no raise, file unchanged → no
+  re-clobber. A leak-less report can no longer raise (strict reader → skip).
+- Carriers (#2366/#2367) pass the restored honest floor (host-free ≥ 12,883 − 50).

--- a/plan/issues/2889-standalone-highwater-writeside-hostfree.md
+++ b/plan/issues/2889-standalone-highwater-writeside-hostfree.md
@@ -1,7 +1,8 @@
 ---
 id: 2889
 title: "Standalone high-water WRITE side must emit host_free_pass — promote-baseline clobbered the honest mark back to the leaky 26k"
-status: in-progress
+status: done
+completed: 2026-06-30
 assignee: ttraenkler/sendev-highwater
 created: 2026-06-30
 priority: high

--- a/scripts/check-standalone-highwater.mjs
+++ b/scripts/check-standalone-highwater.mjs
@@ -46,9 +46,14 @@
 //   (not Δpass) as the standalone pass/fail signal.
 //
 // High-water file: benchmarks/results/test262-standalone-highwater.json
-//   { "pass": <host_free int>, "sha": "<commit>", "generated_at": "<iso>", "tolerance": 50 }
+//   { "pass": <host_free int>, "host_free_pass": <host_free int>,
+//     "official_pass": <host_free official>, "official_total": <int>,
+//     "sha": "<commit>", "generated_at": "<iso>", "tolerance": 50 }
 //   (#2879 §2: `pass` here is the host-free count; re-baselined from the leaky
 //    ~26k to the honest ~12.9k with stakeholder sign-off — the headline halves.)
+//   (#2889: every write also emits the explicit, self-describing `host_free_pass`
+//    field — `pass` is kept == it for back-compat. The field is what lets the
+//    WRITE side refuse to clobber the honest mark with a stale leaky number.)
 //
 // Exit codes:
 //   0 — pass within tolerance of the mark (and, with --update, mark refreshed)
@@ -128,6 +133,52 @@ export function officialFromReport(reportPath) {
   return null;
 }
 
+/**
+ * (#2889) STRICT host-free WRITE reader — the value used to RATCHET the mark.
+ *
+ * Unlike `passFromReport` (the gate READ, which deliberately falls back to the
+ * leaky `pass` so the gate never crashes mid-rollout), the WRITE path must
+ * NEVER ratchet the high-water mark from a leaky pass. A report that lacks
+ * `host_free_pass` (a pre-#2879-§1 report shape, or one whose rows dropped the
+ * `host_import_leak_class`) would otherwise let the leaky ~26k inflate the
+ * honest ~12.9k mark and breach every later standalone PR — exactly the
+ * `d4bc147d3` clobber. So read host_free_pass STRICTLY here and return `null`
+ * when it is absent, signalling "refuse to raise".
+ *
+ * @param {string} reportPath
+ * @returns {number|null} host-free full-corpus pass, or null if not present
+ */
+export function hostFreeFromReport(reportPath) {
+  try {
+    const report = JSON.parse(readFileSync(reportPath, "utf-8"));
+    const hf = report?.full_summary?.host_free_pass ?? report?.summary?.host_free_pass;
+    return typeof hf === "number" ? hf : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * (#2889) STRICT host-free OFFICIAL-scope reader for the WRITE path. Reads only
+ * `official_summary.host_free_pass` (no leaky fallback); returns null when
+ * absent so the write never records a leaky official number.
+ *
+ * @param {string} reportPath
+ * @returns {{pass:number, total:number}|null}
+ */
+export function officialHostFreeFromReport(reportPath) {
+  try {
+    const report = JSON.parse(readFileSync(reportPath, "utf-8"));
+    const o = report?.official_summary;
+    if (o && typeof o.host_free_pass === "number" && typeof o.total === "number") {
+      return { pass: o.host_free_pass, total: o.total };
+    }
+  } catch {
+    /* no official_summary — older report shape */
+  }
+  return null;
+}
+
 /** Load the committed high-water mark, or null if it does not exist yet. */
 export function loadHighwater() {
   if (!existsSync(HIGHWATER_PATH)) return null;
@@ -135,10 +186,23 @@ export function loadHighwater() {
 }
 
 /**
+ * (#2889) The authoritative host-free count stored in a committed mark.
+ * Prefers the explicit `host_free_pass` field (every #2889+ write emits it);
+ * falls back to `pass` for marks written before the field existed (where, by
+ * the #2879 §2 convention, `pass` already held the host-free count).
+ *
+ * @param {{pass?:number, host_free_pass?:number}|null} mark
+ * @returns {number}
+ */
+export function markHostFree(mark) {
+  return mark?.host_free_pass ?? mark?.pass ?? 0;
+}
+
+/**
  * Evaluate the current pass count against the committed mark.
  *
- * @param {number} pass current standalone pass count
- * @param {{pass:number, tolerance?:number}|null} mark committed high-water
+ * @param {number} pass current standalone host-free pass count
+ * @param {{pass:number, host_free_pass?:number, tolerance?:number}|null} mark committed high-water
  * @param {number} tolerance slack below the mark
  * @returns {{ ok: boolean, floor: number, delta: number, mark: number }}
  */
@@ -146,8 +210,9 @@ export function evaluate(pass, mark, tolerance) {
   // No mark yet → nothing to breach; treat as a pass (the --update path seeds it).
   if (!mark) return { ok: true, floor: 0, delta: pass, mark: 0 };
   const tol = mark.tolerance ?? tolerance;
-  const floor = mark.pass - tol;
-  return { ok: pass >= floor, floor, delta: pass - mark.pass, mark: mark.pass };
+  const markPass = markHostFree(mark);
+  const floor = markPass - tol;
+  return { ok: pass >= floor, floor, delta: pass - markPass, mark: markPass };
 }
 
 function parseArgs(argv) {
@@ -219,24 +284,53 @@ function main() {
   }
 
   if (args.update) {
-    // Ratchet UP only: never lower the committed mark here (that is the job of
-    // an explicit re-seed). A net improvement raises the floor so future
-    // slides are caught against the new, higher reference.
-    if (!mark || pass > mark.pass) {
-      const official = args.report ? officialFromReport(resolve(args.report)) : null;
+    // (#2889) WRITE side — STRICT host-free ratchet. The mark is RAISED only
+    // from a genuine host-free measurement read STRICTLY (no leaky-`pass`
+    // fallback). This is the asymmetry that closes the d4bc147d3 clobber: the
+    // gate READ above may fall back to the leaky `pass` (safe — a leaky number
+    // ≥ an honest floor never false-breaches), but if the WRITE ratcheted on a
+    // leaky pass it would inflate the honest ~12.9k mark back to the leaky
+    // ~26k and breach every later standalone PR. So:
+    //   • a report lacking `host_free_pass` (pre-#2879-§1 shape, or rows that
+    //     dropped the leak class) → REFUSE to touch the file (no raise).
+    //   • every write emits an explicit `host_free_pass` field (== `pass`) so a
+    //     stale checkout can only ever hold an honest host-free mark — a leaky
+    //     number can never re-enter the file.
+    const hostFree = args.report
+      ? hostFreeFromReport(resolve(args.report))
+      : // --pass escape hatch: the caller asserts N is the host-free count.
+        Number.isFinite(args.pass)
+        ? args.pass
+        : null;
+
+    if (hostFree === null) {
+      console.warn(
+        "[standalone-highwater] report has no host_free_pass (leaky/old report shape) — NOT raising the mark " +
+          "(refusing to clobber the honest host-free high-water with a leaky pass; see #2889).",
+      );
+    } else if (!mark || hostFree > markHostFree(mark)) {
+      const official = args.report ? officialHostFreeFromReport(resolve(args.report)) : null;
       const next = {
-        pass,
-        // official-scope (no-proposals) count for the statusline / "without
-        // proposals" rate — falls back to absent on older report shapes.
+        // `pass` kept == host-free for back-compat (evaluate / the #2879 test
+        // read `pass`); `host_free_pass` is the explicit, self-describing field
+        // (#2889) that makes a future leaky clobber structurally impossible.
+        pass: hostFree,
+        host_free_pass: hostFree,
+        // official-scope (no-proposals) HOST-FREE count for the statusline /
+        // "without proposals" rate — absent on older report shapes.
         ...(official ? { official_pass: official.pass, official_total: official.total } : {}),
         sha: args.sha ?? mark?.sha ?? "unknown",
         generated_at: new Date().toISOString().replace(/\.\d+Z$/, "Z"),
         tolerance: mark?.tolerance ?? args.tolerance,
       };
       writeFileSync(HIGHWATER_PATH, `${JSON.stringify(next, null, 2)}\n`);
-      console.log(`[standalone-highwater] raised mark ${mark?.pass ?? 0} → ${pass} (commit ${next.sha}).`);
+      console.log(
+        `[standalone-highwater] raised host-free mark ${markHostFree(mark)} → ${hostFree} (commit ${next.sha}).`,
+      );
     } else {
-      console.log(`[standalone-highwater] mark unchanged (current ${pass} ≤ mark ${mark.pass}); within tolerance.`);
+      console.log(
+        `[standalone-highwater] mark unchanged (host-free ${hostFree} ≤ mark ${markHostFree(mark)}); within tolerance.`,
+      );
     }
   }
 

--- a/tests/issue-2879-standalone-host-free-floor.test.ts
+++ b/tests/issue-2879-standalone-host-free-floor.test.ts
@@ -16,6 +16,9 @@ import {
   passFromReport,
   officialFromReport,
   evaluate,
+  hostFreeFromReport,
+  officialHostFreeFromReport,
+  markHostFree,
   HIGHWATER_PATH,
 } from "../scripts/check-standalone-highwater.mjs";
 
@@ -80,5 +83,55 @@ describe("#2879 §2 — the committed high-water file is re-baselined to the hon
     expect(mark.pass).toBeGreaterThan(10000);
     expect(mark.pass).toBeLessThan(20000);
     expect(mark.tolerance).toBe(50);
+  });
+
+  it("(#2889) the committed mark carries an explicit host_free_pass field == pass", () => {
+    const mark = JSON.parse(readFileSync(HIGHWATER_PATH, "utf-8"));
+    // The self-describing field is what makes a future leaky clobber impossible.
+    expect(Number.isInteger(mark.host_free_pass)).toBe(true);
+    expect(mark.host_free_pass).toBe(mark.pass);
+    expect(mark.host_free_pass).toBeGreaterThan(10000);
+    expect(mark.host_free_pass).toBeLessThan(20000);
+  });
+});
+
+describe("#2889 — the WRITE side keys on host_free_pass and refuses to clobber", () => {
+  it("hostFreeFromReport reads full_summary.host_free_pass (the ratchet value)", () => {
+    const tmp = writeReport("w-hf", { full_summary: { pass: 26039, host_free_pass: 12883 } });
+    expect(hostFreeFromReport(tmp)).toBe(12883);
+  });
+
+  it("hostFreeFromReport returns null when host_free_pass is ABSENT (no leaky fallback)", () => {
+    // A pre-#2879-§1 / leak-less report shape: only a leaky `pass`. The WRITE
+    // reader must NOT fall back to it — returning null tells --update to refuse
+    // to raise, so the leaky 26k can never inflate the honest mark (d4bc147d3).
+    const tmp = writeReport("w-legacy", { full_summary: { pass: 26039 } });
+    expect(hostFreeFromReport(tmp)).toBeNull();
+  });
+
+  it("officialHostFreeFromReport reads official_summary.host_free_pass strictly", () => {
+    const tmp = writeReport("w-off", {
+      official_summary: { pass: 24899, host_free_pass: 12551, total: 43136 },
+    });
+    expect(officialHostFreeFromReport(tmp)).toEqual({ pass: 12551, total: 43136 });
+  });
+
+  it("officialHostFreeFromReport returns null when official host_free_pass is absent", () => {
+    const tmp = writeReport("w-off-legacy", { official_summary: { pass: 24899, total: 43136 } });
+    expect(officialHostFreeFromReport(tmp)).toBeNull();
+  });
+
+  it("markHostFree prefers host_free_pass, falls back to pass for pre-#2889 marks", () => {
+    expect(markHostFree({ host_free_pass: 12883, pass: 12883 })).toBe(12883);
+    // A mark written before the field existed (§2 stored host-free in `pass`).
+    expect(markHostFree({ pass: 12883 })).toBe(12883);
+    expect(markHostFree(null)).toBe(0);
+  });
+
+  it("evaluate keys on the mark's host_free_pass when present", () => {
+    const mark = { pass: 12883, host_free_pass: 12883, tolerance: 50 };
+    expect(evaluate(12883, mark, 50).ok).toBe(true);
+    expect(evaluate(12832, mark, 50).ok).toBe(false); // below floor 12833
+    expect(evaluate(12833, mark, 50).ok).toBe(true);
   });
 });


### PR DESCRIPTION
## CI-FIX — unblocks the carrier track (#2366/#2367) and greens main

### The regression
#2879 §2 switched the standalone-floor **read/gate** to `host_free_pass` and re-baselined `benchmarks/results/test262-standalone-highwater.json` to the honest host-free **12,883**. The post-merge `promote-baseline` job (test262-sharded.yml, "Raise standalone pass-count high-water mark") then **clobbered it back to the leaky `pass: 26040`** (commit `d4bc147d3`, no `host_free_pass` field). The floor gate then compared current host-free (~12,883) against high-water 26,040 → **breach** on every standalone/carrier `merge_group`, and `tests/issue-2879-standalone-host-free-floor.test.ts` went **RED on main** (it asserts `mark.pass ∈ (10000,20000)`).

### Root cause (verified — not a `--update` leaky read)
`--update` already used the host-free `passFromReport` for the raise value. The clobber was a **stale-checkout + ratchet-up-only + no-`host_free_pass`-field** interaction:
1. The promote run was triggered by the push of `15ef5a1c7` (#2359), whose tree was branched **before** §2 (`5e3d9aca7` is **not** an ancestor of `15ef5a1c7`) → its checked-out high-water file was the **pre-§2 leaky** `{pass: 26040}` with **no `host_free_pass`** field.
2. `--update` is ratchet-up-only: the report's honest `12,883` did not exceed the stale loaded `26,040`, so it didn't rewrite the file.
3. The job committed onto the then-current main HEAD (already §2's `12,883`) → the unchanged stale leaky file landed on top of §2, silently reverting `12,883 → 26,040`.

The missing disambiguator: a **`host_free_pass` field** in the file. Without it a stale leaky `26040` is indistinguishable from a genuine host-free 26k.

### Fix (write-side, symmetric with the §2 read)
- **Strict host-free WRITE readers** `hostFreeFromReport` / `officialHostFreeFromReport` — read **only** `…host_free_pass` (NO leaky-`pass` fallback). `--update` now **refuses to raise** when `host_free_pass` is absent (pre-§1/leak-less report) instead of inflating the mark with a leaky pass. The gate *read* `passFromReport` keeps its leaky fallback (safe: a leaky number ≥ an honest floor never false-breaches).
- **Every write emits an explicit `host_free_pass` field** (`pass` kept == it for back-compat) → a stale leaky clobber is structurally impossible going forward.
- `evaluate` / the ratchet key on `mark.host_free_pass ?? mark.pass`.
- **Restored** the high-water file to the honest **12,883** (official **12,551**), re-measured on the live main baseline jsonl (48,118 records; `host_import_leak_class`-absent ⟺ no `env::` import re-confirmed).

### Verification
- Traced & **simulated** the promote path: leaky report (no `host_free_pass`) → **refuses to raise** (was: raised to 26,040); steady-state 12,883 → no raise; genuine improvement → raises with the field; gate read 12,883 vs floor 12,833 → no breach; genuine host-free drop → breaches. **Single writer** confirmed (line ~1483, staged ~1797) — no second job touches the file. Heavy standalone shards are **merge_group-only**, so the floor only ever sees the full corpus → no scoped false-breach.
- `tests/issue-2879-standalone-host-free-floor.test.ts` green (14 tests; restored mark in band + new write-side strictness cases).
- Carriers (#2366/#2367) pass the restored honest floor (host-free ≥ 12,883 − 50; they only add host-free passes / mid-flight drops only raw `pass`).

Closes #2889.

🤖 Generated with [Claude Code](https://claude.com/claude-code)