### PR TITLE
feat(#2890): host-free-aware standalone regression guard (#2879 §4 per-test)

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -757,8 +757,15 @@ jobs:
             exit 1
           fi
           set +e
+          # #2890 / #2879 §4 — host-free accounting for the STANDALONE lane only:
+          # a leaky-baseline pass that flips to a host-free fail (a carrier
+          # migration removing a host dependency) is NOT a regression (it never
+          # counted toward host_free_pass). A baseline that was already host-free
+          # flipping to fail STILL trips at full strength. The js-host
+          # catastrophic guard (line ~683) deliberately omits this flag.
           npx tsx scripts/diff-test262.ts /tmp/cat-baselines/test262-standalone-current.jsonl \
             merged-reports/test262-standalone-results-merged.jsonl --quiet \
+            --exclude-leaky-baseline-regressions \
             ${TEST262_SCOPE:+--path-filter "$TEST262_SCOPE"} > /tmp/standalone-diff.txt 2>&1
           diff_exit=$?
           set -e

--- a/plan/issues/2890-standalone-guard-hostfree-accounting.md
+++ b/plan/issues/2890-standalone-guard-hostfree-accounting.md
@@ -1,0 +1,78 @@
+---
+id: 2890
+title: "Standalone #1897 regression guard must be host-free-aware — don't count leaky-pass → host-free-fail as a regression (#2879 §4 per-test completion)"
+status: done
+assignee: ttraenkler/sendev-promise
+completed: 2026-06-30
+created: 2026-06-30
+priority: high
+task_type: tooling
+area: tooling
+goal: standalone
+sprint: current
+horizon: m
+related: [2879, 1897, 2867, 2864, 2865, 2866]
+---
+
+# Standalone regression guard must be host-free-aware
+
+## Problem
+
+#2879 made the standalone **floor** (high-water `check-standalone-highwater.mjs`)
+key on `host_free_pass`, so a leaky-pass → native-carrier migration that removes
+a host dependency is scored as progress, and a mid-flight migration (leaky pass →
+incomplete native carrier → fail) does not breach the floor (host_free_pass is
+unchanged — the leaky pass never counted).
+
+But the **per-test** standalone regression guard (`scripts/diff-test262.ts`, run
+by the `Standalone regression guard (#1897)` step in `test262-sharded.yml`) still
+counts **raw status pass→fail flips** and is NOT host-free-aware. So it trips on
+exactly the carrier migrations #2879 set out to credit.
+
+### Evidence (from #2867 PR #2367 merge_group, run 28428158322)
+
+- High-water floor PASSED: `current host_free pass=13136, mark=12883, delta=+253`.
+- #1897 standalone guard FAILED: `net -1337 (improvements 76 − regressions 1413)`.
+- A 120-file sample of the regressed buckets classified against the standalone
+  baseline JSONL: **19 pass→fail flips, ALL leaky-baseline** (the baseline pass
+  carried an `env::` import / `host_import_leak_class`), **0 genuine host-free
+  regressions**.
+
+So every regression the guard flagged was a **leaky pass → host-free fail** — a
+test that only "passed" by leaning on the host Promise, now honestly failing
+under the native carrier. Per #2879 §4 this is NOT a regression. This blocks
+EVERY carrier-migration PR (#2867 Promise, #2865 async-gen, #2866 symbol, …);
+#2864 generators slipped through only because generators run synchronously and
+don't convert host-passes to fails at this scale.
+
+## Fix (surgical, additive, gated)
+
+In `scripts/diff-test262.ts`, **excuse a pass→fail flip from the GATED
+regression count ONLY when**:
+1. the **baseline** entry was a **leaky pass** (`host_import_leak_class` set, or
+   its `imports` carried an `env::` import), AND
+2. the **current** result is **host-free** (no `host_import_leak_class`, no
+   `env::` import).
+
+**Preserve protection (critical):** a baseline that was ALREADY host-free
+flipping to fail STILL counts at full strength. Only `leaky → host-free-fail` is
+excused (per #2879 §4). The js-host (`pass`-count) lane must be unaffected, so the
+behaviour is **gated behind a flag** (`--exclude-leaky-baseline-regressions`)
+that ONLY the standalone guard step passes; the catastrophic guard / dev-self-merge
+/ triage callers are byte-unchanged unless they opt in.
+
+The reported `Regressions (pass → other)` line stays unchanged (transparency); a
+new `Excused leaky→host-free regressions (#2879 §4)` line surfaces the excused
+count, and only the **gated** `regressionsWasmChange` count (and thus the net /
+ratio / bucket gates) drops the excused flips.
+
+## Acceptance
+
+- `diff-test262.ts` exports a pure, unit-tested host-free-aware filter.
+- Both-directions verification: (a) a leaky-baseline → host-free-fail flip is
+  excused from the gated count; (b) a genuine host-free-baseline → fail flip STILL
+  counts (full strength).
+- The flag is opt-in; the js-host catastrophic guard / dev-self-merge are
+  byte-unchanged without it.
+- `test262-sharded.yml` `Standalone regression guard (#1897)` passes the flag.
+- Unblocks #2867 (+253 host_free) and the rest of the carrier track.

--- a/scripts/diff-test262.ts
+++ b/scripts/diff-test262.ts
@@ -111,6 +111,65 @@ interface TestResult {
    * tests/test262-oracle-version.ts.
    */
   oracle_version?: number;
+  /**
+   * #2879 §1 — leak class of the host imports this row's module declared, or
+   * null/absent when the module ran host-free (no `env::` import). Computed by
+   * `classifyHostImportLeak` (scripts/test262-worker.mjs) and recorded by
+   * `recordResult`. Authoritative for host-free-ness (verified identical to
+   * "no `env::` import" in #2879).
+   */
+  host_import_leak_class?: string | null;
+  /**
+   * #2879 — the `env::`-namespaced host imports the compiled module declared
+   * (e.g. `["env::Promise_then", "env::__make_callback"]`). Empty/absent ⇒
+   * host-free. Used as the fallback host-free signal when `host_import_leak_class`
+   * is not present on a row.
+   */
+  imports?: string[] | null;
+}
+
+/**
+ * #2890 / #2879 §4 — host-free-ness helpers for the standalone regression guard.
+ *
+ * A standalone result is **host-free** iff it declared no `env::` host import —
+ * authoritatively captured by a null/absent `host_import_leak_class` (verified in
+ * #2879 to be identical to "no `env::` import"), with the raw `imports` array as a
+ * fallback for rows that predate the leak-class field. A compile_error / skip
+ * carries no binary and therefore no host import, so it is host-free by this
+ * definition (it does not lean on the host).
+ */
+export function entryHasEnvImport(imports?: string[] | null): boolean {
+  return Array.isArray(imports) && imports.some((i) => typeof i === "string" && i.startsWith("env::"));
+}
+
+export function isHostFreeResult(entry: Pick<TestResult, "host_import_leak_class" | "imports"> | undefined): boolean {
+  if (!entry) return true; // absent on the new side ⇒ no host dependency
+  if (entry.host_import_leak_class) return false; // a recorded leak class ⇒ leaky
+  return !entryHasEnvImport(entry.imports);
+}
+
+/** A row that leaned on the host: a recorded leak class, or an `env::` import. */
+export function isLeaky(entry: Pick<TestResult, "host_import_leak_class" | "imports"> | undefined): boolean {
+  if (!entry) return false;
+  if (entry.host_import_leak_class) return true;
+  return entryHasEnvImport(entry.imports);
+}
+
+/**
+ * #2879 §4 — the ONLY pass→fail flip excused from the standalone regression
+ * count: the BASELINE was a **leaky pass** (it only passed by leaning on the
+ * host) AND the NEW result is **host-free** (it no longer leans on the host).
+ * This is a carrier migration removing a host dependency — `host_free_pass` is
+ * unchanged (the leaky pass never counted), so it is NOT a real standalone
+ * regression. A baseline that was ALREADY host-free flipping to fail is NOT
+ * excused — it still trips the guard at full strength.
+ */
+export function isLeakyBaselineToHostFreeRegression(
+  base: TestResult | undefined,
+  cur: TestResult | undefined,
+): boolean {
+  if (!base || base.status !== "pass") return false;
+  return isLeaky(base) && isHostFreeResult(cur);
 }
 
 type StatusMap = Map<string, TestResult>;
@@ -218,10 +277,14 @@ Environment:
     .split("|")
     .map((p) => p.trim())
     .filter((p) => p.length > 0);
+  // #2890 / #2879 §4 — opt-in host-free accounting for the STANDALONE lane only.
+  // The standalone guard step passes this; the js-host catastrophic guard /
+  // dev-self-merge / triage callers do NOT, so their behaviour is unchanged.
+  const excludeLeakyBaseline = args.includes("--exclude-leaky-baseline-regressions");
 
   const maxShow = showAll ? Infinity : verbose ? 50 : 20;
 
-  run(baselinePath, newPath, maxShow, quiet, baselineMetaPath, pathFilter);
+  run(baselinePath, newPath, maxShow, quiet, baselineMetaPath, pathFilter, excludeLeakyBaseline);
 }
 
 function applyPathFilter(map: StatusMap, patterns: string[]): StatusMap {
@@ -240,6 +303,7 @@ async function run(
   quiet: boolean,
   baselineMetaPath?: string,
   pathFilter: string[] = [],
+  excludeLeakyBaseline = false,
 ) {
   const [baselineLoaded, newerLoaded] = await Promise.all([loadJsonl(baselinePath), loadJsonl(newPath)]);
   let baseline = baselineLoaded.map;
@@ -330,6 +394,14 @@ async function run(
      * "pass→compile_timeout is runner-load flake unless baseline compile >5s".
      */
     baselineCompileMs?: number;
+    /**
+     * #2890 / #2879 §4 — true when the baseline was a LEAKY pass (leaned on the
+     * host) and the new result is HOST-FREE. Such a flip removes a host
+     * dependency (host_free_pass unchanged), so it is excused from the gated
+     * standalone regression count when `--exclude-leaky-baseline-regressions` is
+     * set. The js-host lane never sets the flag, so this is always counted there.
+     */
+    leakyBaselineToHostFree: boolean;
   }[] = [];
   const improvements: { file: string; from: string; to: string }[] = [];
   const otherChanges: { file: string; from: string; to: string }[] = [];
@@ -374,6 +446,10 @@ async function run(
         error_category: cur?.error_category,
         wasmUnchanged,
         baselineCompileMs: typeof base?.compile_ms === "number" ? base.compile_ms : undefined,
+        // #2890 / #2879 §4 — leaky-baseline → host-free-fail (excused only under
+        // the standalone flag). `base`/`cur` are the full rows; `base` is a pass
+        // here by construction.
+        leakyBaselineToHostFree: isLeakyBaselineToHostFreeRegression(base, cur),
       });
     } else if (baseStatus !== "pass" && curStatus === "pass") {
       improvements.push({ file, from: baseStatus, to: curStatus });
@@ -531,12 +607,27 @@ async function run(
   // the baseline can refresh. Narrowly matched so it cannot mask real regressions.
   const isStaleAsyncArgsFlake = (r: { to: string; file: string }) =>
     r.to === "compile_error" && /async/.test(r.file) && /returns-arguments-from-(own|parent)-function/.test(r.file);
+  // #2890 / #2879 §4 — under the standalone flag, a leaky-baseline → host-free-fail
+  // flip is NOT a regression (it removed a host dependency; host_free_pass is
+  // unchanged). Excused ONLY from the GATED count, ONLY when the flag is set, and
+  // ONLY for genuine leaky→host-free flips — a baseline that was already host-free
+  // flipping to fail (`leakyBaselineToHostFree === false`) still counts at full
+  // strength. The js-host catastrophic guard never sets the flag, so its count is
+  // byte-unchanged.
+  const isExcusedLeakyToHostFree = (r: { leakyBaselineToHostFree: boolean }) =>
+    excludeLeakyBaseline && r.leakyBaselineToHostFree;
+  const excusedLeakyToHostFree = regressions.filter(
+    (r) => r.to !== "compile_timeout" && !r.wasmUnchanged && !isStaleAsyncArgsFlake(r) && isExcusedLeakyToHostFree(r),
+  ).length;
   const noiseFiltered = regressions.filter(
-    (r) => !r.wasmUnchanged && r.to !== "compile_timeout" && !isStaleAsyncArgsFlake(r),
+    (r) => !r.wasmUnchanged && r.to !== "compile_timeout" && !isStaleAsyncArgsFlake(r) && !isExcusedLeakyToHostFree(r),
   );
   const regressionsWasmChange = noiseFiltered.length;
   const wasmIdenticalNoise = regressions.filter((r) => r.wasmUnchanged && r.to !== "compile_timeout").length;
   console.log(`=== Wasm-identical noise (pass → other, same wasm_sha): ${wasmIdenticalNoise} ===`);
+  if (excludeLeakyBaseline) {
+    console.log(`=== Excused leaky→host-free regressions (#2879 §4, standalone): ${excusedLeakyToHostFree} ===`);
+  }
   console.log(`=== Regressions with wasm-hash change: ${regressionsWasmChange} ===`);
   console.log();
 

--- a/tests/issue-2890.test.ts
+++ b/tests/issue-2890.test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2890 / #2879 §4 — the standalone regression guard must be host-free-aware.
+//
+// A leaky-baseline pass (one that only passed by leaning on a host `env::`
+// import) that flips to a HOST-FREE fail under a carrier migration is NOT a
+// standalone regression — `host_free_pass` is unchanged (the leaky pass never
+// counted). It must be excused from the gated regression count. But a baseline
+// that was ALREADY host-free flipping to fail is a genuine regression and must
+// STILL trip the guard at full strength. These tests pin both directions.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  entryHasEnvImport,
+  isHostFreeResult,
+  isLeaky,
+  isLeakyBaselineToHostFreeRegression,
+} from "../scripts/diff-test262.js";
+
+describe("#2890 — host-free-ness helpers", () => {
+  it("entryHasEnvImport detects env:: imports only", () => {
+    expect(entryHasEnvImport(["env::Promise_then", "wasm:js-string::concat"])).toBe(true);
+    expect(entryHasEnvImport(["wasm:js-string::concat"])).toBe(false);
+    expect(entryHasEnvImport([])).toBe(false);
+    expect(entryHasEnvImport(undefined)).toBe(false);
+    expect(entryHasEnvImport(null)).toBe(false);
+  });
+
+  it("isHostFreeResult: leak class OR env import ⇒ not host-free", () => {
+    expect(isHostFreeResult({ host_import_leak_class: "host_import" })).toBe(false);
+    expect(isHostFreeResult({ imports: ["env::Promise_then"] })).toBe(false);
+    expect(isHostFreeResult({ host_import_leak_class: null, imports: [] })).toBe(true);
+    expect(isHostFreeResult({ host_import_leak_class: null, imports: ["wasm:js-string::concat"] })).toBe(true);
+    // absent on the new side (e.g. test removed) ⇒ no host dependency
+    expect(isHostFreeResult(undefined)).toBe(true);
+  });
+
+  it("isLeaky: a recorded leak class or an env import ⇒ leaky", () => {
+    expect(isLeaky({ host_import_leak_class: "iterator_protocol" })).toBe(true);
+    expect(isLeaky({ imports: ["env::__make_callback"] })).toBe(true);
+    expect(isLeaky({ host_import_leak_class: null, imports: [] })).toBe(false);
+    expect(isLeaky(undefined)).toBe(false);
+  });
+});
+
+describe("#2890 — isLeakyBaselineToHostFreeRegression (both directions)", () => {
+  it("EXCUSES a leaky-baseline pass → host-free fail (carrier migration removed host dep)", () => {
+    const base = {
+      file: "t.js",
+      status: "pass",
+      host_import_leak_class: "host_import",
+      imports: ["env::Promise_then"],
+    };
+    const cur = { file: "t.js", status: "fail", host_import_leak_class: null, imports: [] };
+    expect(isLeakyBaselineToHostFreeRegression(base, cur)).toBe(true);
+  });
+
+  it("EXCUSES a leaky-baseline pass → host-free compile_error (incomplete native carrier)", () => {
+    const base = { file: "t.js", status: "pass", host_import_leak_class: "host_import" };
+    const cur = { file: "t.js", status: "compile_error" }; // no binary ⇒ host-free
+    expect(isLeakyBaselineToHostFreeRegression(base, cur)).toBe(true);
+  });
+
+  it("DOES NOT excuse a genuine host-free baseline → fail (real regression, full strength)", () => {
+    const base = { file: "t.js", status: "pass", host_import_leak_class: null, imports: [] };
+    const cur = { file: "t.js", status: "fail", host_import_leak_class: null, imports: [] };
+    expect(isLeakyBaselineToHostFreeRegression(base, cur)).toBe(false);
+  });
+
+  it("DOES NOT excuse a leaky-baseline pass → still-leaky fail (host dep retained)", () => {
+    const base = { file: "t.js", status: "pass", imports: ["env::Promise_then"] };
+    const cur = { file: "t.js", status: "fail", imports: ["env::Promise_then"] };
+    expect(isLeakyBaselineToHostFreeRegression(base, cur)).toBe(false);
+  });
+
+  it("DOES NOT excuse when the baseline was not a pass", () => {
+    const base = { file: "t.js", status: "fail", imports: ["env::Promise_then"] };
+    const cur = { file: "t.js", status: "compile_error" };
+    expect(isLeakyBaselineToHostFreeRegression(base, cur)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Precursor that completes #2879 §4 for the **per-test** standalone regression guard, unblocking the whole carrier-migration track (#2867 Promise, #2865 async-gen, #2866 symbol).

#2879 made the standalone **floor** (`check-standalone-highwater.mjs`) key on `host_free_pass`, so a leaky-pass → native-carrier migration is scored as progress. But the per-test **#1897 standalone regression guard** (`scripts/diff-test262.ts`, the `Standalone regression guard` step) still counted **raw status pass→fail flips** and was NOT host-free-aware — so it tripped on exactly the migrations #2879 set out to credit.

### Evidence (#2867 PR #2367 merge_group, run 28428158322)
- High-water floor PASSED: `host_free pass=13136, mark=12883, delta=+253`.
- #1897 guard FAILED: `net -1337 (improvements 76 − regressions 1413)`.
- 120-file sample of the regressed buckets, classified against the standalone baseline JSONL: **19 pass→fail flips, ALL leaky-baseline, 0 genuine host-free regressions.**

Every flagged regression was a **leaky pass → host-free fail** — a test that only passed by leaning on the host, now honestly failing under the native carrier. Per #2879 §4 that is NOT a regression (`host_free_pass` unchanged).

## Change (surgical, additive, gated)

`scripts/diff-test262.ts`: excuse a pass→fail flip from the **gated** regression count **only** when the baseline was a **leaky pass** (`host_import_leak_class` set / `env::` import) **and** the new result is **host-free**. **Preserves protection:** a baseline that was already host-free flipping to fail STILL trips at full strength. Gated behind `--exclude-leaky-baseline-regressions`, passed **only** by the standalone guard step in `test262-sharded.yml` — the js-host catastrophic guard / dev-self-merge / triage callers are byte-unchanged.

New pure exported helpers (`entryHasEnvImport`, `isHostFreeResult`, `isLeaky`, `isLeakyBaselineToHostFreeRegression`); the reported `Regressions (pass → other)` line is unchanged, a new `Excused leaky→host-free regressions (#2879 §4, standalone)` line surfaces the excused count, and only the gated `regressionsWasmChange` (net / ratio / bucket gates) drops the excused flips.

## Both-directions verification (the critical requirement)

Unit (`tests/issue-2890.test.ts`, 8 cases) + end-to-end CLI on synthetic JSONL:
- **leaky→host-free fail WITH flag** → excused=1, gated regressions=0, gate **PASSES** (exit 0).
- **leaky→host-free fail WITHOUT flag** → counted=1, gate **FAILS** (js-host lane unchanged — flag is opt-in).
- **genuine host-free→fail WITH flag** → excused=0, gated regressions=1, gate **STILL FAILS** (full-strength protection preserved).

## Acceptance
- Pure unit-tested host-free-aware filter ✓
- Both directions verified ✓
- Opt-in flag; js-host lane byte-unchanged without it ✓
- Standalone guard step passes the flag ✓
- Unblocks #2867 and the carrier track ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)