### PR TITLE
fix(#2885): standalone descriptor-reflection core — builtin-proto intrinsic accessors

### DIFF
--- a/plan/issues/2885-standalone-descriptor-reflection-core.md
+++ b/plan/issues/2885-standalone-descriptor-reflection-core.md
@@ -1,7 +1,9 @@
 ---
 id: 2885
 title: "Standalone descriptor-reflection core: materialise builtin-proto intrinsic accessors for gOPD / reflection (unblocks #2875/#2876/#2872)"
-status: ready
+status: done
+assignee: ttraenkler/sr-reflect
+completed: 2026-06-30
 created: 2026-06-30
 priority: high
 task_type: bug
@@ -44,19 +46,19 @@ it as a concrete, shared standalone gap.
 ## Three coupled defect sites (verified against current main 2026-06-30)
 
 1. **Getter-closure factory** — `ensureStandaloneNativeMethodClosure(brand,
-   member, "getter")` (`native-proto.ts:387`) + the per-builtin getter body
+member, "getter")` (`native-proto.ts:387`) + the per-builtin getter body
    (`regexp-standalone.ts:emitRegExpProtoMemberBody`, `:2459`, getter arm at
    `:2470`). The brand-recovery prologue (`recoverRegExpStructFromExternref`,
    `:907`) `ref.test $NativeRegExp` and throws TypeError on failure. For a genuine
    non-RegExp `this` (`g.call({})`) the throw is correct; but for `this ===
-   RegExp.prototype` (the proto object) §22.2.6 step "if SameValue(R,
+RegExp.prototype` (the proto object) §22.2.6 step "if SameValue(R,
    %RegExp.prototype%) return undefined" requires **undefined, not a throw** —
    that arm is missing. Also `.name` is recorded as the bare member (`"global"`)
    not the accessor spelling `"get global"` (`native-proto.ts:439`).
 
 2. **`getOwnPropertyDescriptor` call-site** — `calls.ts:6693`. Its dynamic
    fallback (`:6903`+) only special-cases a bare builtin-ctor identifier (`arg0 ==
-   RegExp`) via `__get_builtin`; for `arg0 == RegExp.prototype` (a property
+RegExp`) via `__get_builtin`; for `arg0 == RegExp.prototype` (a property
    access) it compiles the receiver to externref and calls native
    `__getOwnPropertyDescriptor`, which finds no own entry on the `$NativeProto`
    and returns undefined. There is **no builtin-proto-accessor synthesis path**.
@@ -113,10 +115,10 @@ the tests read the OWN descriptor on the proto directly, so (b) covers them.
 
 **Site 1 — getter closure: proto-identity arm + accessor `.name`**
 
-*File: `src/codegen/native-proto.ts`*
+_File: `src/codegen/native-proto.ts`_
 
 - Add an exported helper `emitNativeProtoIdentityReturnUndefined(ctx, fctx,
-  brand, thisParamIdx, undefinedResult)` near `emitBrandCheckTypeError` (`:460`).
+brand, thisParamIdx, undefinedResult)` near `emitBrandCheckTypeError` (`:460`).
   It loads `this` (externref param), `any.convert_extern`, `ref.eq`-compares
   against the materialized proto global for `brand` (reuse the global from
   `nativeProtoGlobalMap` — export a `getNativeProtoGlobalIdx(ctx, brand)` or call
@@ -125,17 +127,16 @@ the tests read the OWN descriptor on the proto directly, so (b) covers them.
   spec's "SameValue(R, %Proto%) → undefined" arm so each builtin glue opts in
   with one call, keeping the shared factory's structure intact.
 - In `ensureStandaloneNativeMethodClosure` (`:439`), record the accessor name as
-  `kind === "getter" ? \`get ${member}\` : member` in `nativeClosureMeta`
-  (§10.2.9 — accessor functions are named `"get <key>"`). Spec-correct uniformly
+  `kind === "getter" ? \`get ${member}\` : member`in`nativeClosureMeta`(§10.2.9 — accessor functions are named`"get <key>"`). Spec-correct uniformly
   across all wired getter brands; verify no currently-passing test asserts the
   bare getter name (grep the standalone baseline before/after).
 
-*File: `src/codegen/regexp-standalone.ts`*
+_File: `src/codegen/regexp-standalone.ts`_
 
 - In `emitRegExpProtoMemberBody` getter arm (`:2470`), BEFORE
   `recoverRegExpStructFromExternref` throws, insert the proto-identity guard:
   call `emitNativeProtoIdentityReturnUndefined(ctx, fctx, brand=RegExp, 1,
-  <push undefined of the member's result type>)`. The member result type for
+<push undefined of the member's result type>)`. The member result type for
   RegExp getters is externref (flags/source) or i32/f64 (flag bits/lastIndex) —
   for the proto-identity arm return the externref-null form and unify the closure
   result type to externref for getters (box i32/f64 results via `__box_*`), so
@@ -147,7 +148,7 @@ the tests read the OWN descriptor on the proto directly, so (b) covers them.
 
 **Site 2 — gOPD builtin-proto descriptor synthesis**
 
-*File: `src/codegen/object-runtime.ts`*
+_File: `src/codegen/object-runtime.ts`_
 
 - Add native `__create_accessor_descriptor(get, set, flags) -> externref` as a
   sibling of `__create_descriptor` (`:5296`). Identical scaffold
@@ -156,7 +157,7 @@ the tests read the OWN descriptor on the proto directly, so (b) covers them.
   `value`/`writable`. Reuse the exact `setKeyCd`/`boolFlagCd` closures. params:
   0=get(externref) 1=set(externref) 2=flags(i32); local 3=desc.
 
-*File: `src/codegen/expressions/calls.ts`*
+_File: `src/codegen/expressions/calls.ts`_
 
 - In the gOPD handler, after the typed-receiver fast path and BEFORE the dynamic
   `__getOwnPropertyDescriptor` fallback (insert at `:6902`, just before the
@@ -173,14 +174,14 @@ the tests read the OWN descriptor on the proto directly, so (b) covers them.
     call `__create_accessor_descriptor`.
   - method → `ensureStandaloneNativeMethodClosure(brand, member, "method")`,
     wrap as a DATA descriptor `{value:<closure>, writable:true, enumerable:false,
-    configurable:true}` via the existing `__create_descriptor` (flags =
+configurable:true}` via the existing `__create_descriptor` (flags =
     `FLAG_WRITABLE | FLAG_CONFIGURABLE` = 0x05).
   - Return `{kind:"externref"}`. If the member/brand doesn't resolve, fall
     through to the existing dynamic fallback (no behavior change for other cases).
 
 **Site 3 — plain getter read invokes the closure**
 
-*File: `src/codegen/property-access.ts`*
+_File: `src/codegen/property-access.ts`_
 
 - In `tryCompileStandaloneBuiltinProtoMemberRead` (`:919-927`): split on
   `kind`. For `kind === "method"` keep the current closure-value emit. For
@@ -217,7 +218,7 @@ end
 - `ensureStandaloneNativeMethodClosure` and `emitNativeProtoIdentityReturnUndefined`
   are SHARED across ~30 wired brands. The `.name = "get <member>"` change and the
   getter-result-type unification to externref affect every wired getter brand
-  (ArrayBuffer.byteLength, DataView.*, TypedArray accessors, …).
+  (ArrayBuffer.byteLength, DataView.\*, TypedArray accessors, …).
   - **Guard A:** the proto-identity arm is OPT-IN per glue (only brands whose
     `emitMemberBody` calls the helper get it) — RegExp-only in PR1, so other
     brands are byte-unchanged until their cluster lands.
@@ -271,4 +272,76 @@ PR1+PR2 (the core) are the shared lever; the per-cluster issues retag
 - `test/built-ins/String/prototype/*/length.js`, `*/name.js` (#2875)
 - `test/built-ins/TypedArray/prototype/byteLength/length.js`,
   `*/prop-desc.js` (#2872 accessor reflection)
-</content>
+
+## Implementation Notes (sr-reflect, 2026-06-30)
+
+**Scope landed in this PR: PR1 + PR2 together (the #2885 core).** The architect's
+slicing kept PR1 (Site 1 + Site 3 + native helper) separate from PR2 (Site 2 gOPD
+synthesis) for review granularity. I combined them in one PR because:
+
+- The issue's **headline acceptance** is the gOPD verify-first
+  (`Object.getOwnPropertyDescriptor(RegExp.prototype, "global")` → proper accessor
+  descriptor, host-free), which is a PR2 deliverable — PR1 alone could not satisfy it.
+- **Blast radius is identical.** PR2 (Site 2) is purely additive: a new
+  `ctx.standalone` + `<Builtin>.prototype` + advertised-member–gated branch inserted
+  _before_ the existing dynamic gOPD fallback. It adds zero reach over PR1's shared
+  changes (Guard B `.name`, getter-result externref unification), which dominate the
+  risk regardless.
+- One merge-queue / CI cycle instead of two, unblocking #2875/#2876/#2872 faster.
+
+PR3 (per-cluster String/TypedArray `emitMemberBody` glue) remains a follow-up under
+those issues.
+
+**What works now (verified host-free, `imports: []`):**
+
+- gOPD returns a proper ACCESSOR descriptor `{get:<fn>, set:undefined,
+enumerable:false, configurable:true}` for `RegExp.prototype.<getter>` (was
+  `undefined` → deref-trap on main).
+- `get.call(RegExp.prototype) === undefined` (§22.2.6 proto-identity arm).
+- Plain read `RegExp.prototype.<getter>` invokes the getter → `undefined` for the
+  proto receiver (was: returned the getter closure value).
+- Native `__create_accessor_descriptor(get, set, flags)` carries the accessor
+  descriptor host-free (sibling of `__create_descriptor`).
+
+**Known follow-up (NOT a regression — same behaviour on main):** reflective
+operations on the _opaque descriptor-retrieved_ getter closure —
+`desc.get.call(<instance>)` returning the boolean, `desc.get.call(<non-RegExp>)`
+throwing TypeError, and `desc.get.name === "get global"` — still do not fully
+resolve. They route through `tryEmitNativeProtoReflectiveCall`, which recovers the
+brand+member from the _receiver's TS symbol_; a value pulled out of a descriptor has
+no such symbol, so the call falls to the legacy drop-`thisArg` path (returns
+undefined). This is the pre-existing #2193 reflective-call-on-opaque-closure
+limitation, independent of descriptor synthesis. Consequently
+`this-val-non-obj.js` / `name.js` stay `fail` (they were `fail`/errored on main too),
+while `this-val-regexp-prototype.js`, `global/length.js`, `source/length.js` flip to
+`pass`.
+
+### Changes
+
+- `src/codegen/native-proto.ts` — `emitNativeProtoIdentityReturnUndefined()`
+  helper (ref.eq identity vs the materialized proto global via `EQ_HEAP_TYPE`
+  cast); accessor `.name = "get <member>"` in `ensureStandaloneNativeMethodClosure`
+  (§10.2.9).
+- `src/codegen/regexp-standalone.ts` — getter arm runs the proto-identity arm
+  BEFORE brand recovery; getter result unified to externref (i32 flag bools box
+  via `__box_boolean`, defensive f64 via `__box_number`).
+- `src/codegen/object-runtime.ts` — native `__create_accessor_descriptor`.
+- `src/codegen/expressions/calls.ts` — Site 2 gOPD builtin-proto descriptor
+  synthesis (getter → accessor descriptor; method → data descriptor).
+- `src/codegen/property-access.ts` — Site 3 plain getter read invokes the
+  closure on the proto; exported `tryEnsureNativeProtoBrand` + `BUILTIN_CTOR_NAMES`.
+
+### Test Results
+
+- `tests/issue-2885.test.ts` — 5/5 pass (gOPD accessor shape, proto-identity
+  call, plain-read undefined, host-free zero-imports, user-struct gOPD unchanged).
+- `runTest262File(..., "standalone")`: `RegExp/prototype/global/this-val-regexp-prototype.js`
+  `pass`, `global/length.js` `pass`, `source/length.js` `pass`
+  (all errored on main); `this-val-non-obj.js` / `name.js` remain `fail`
+  (follow-up above — not regressions).
+- Regression smoke (identical output on main vs branch): `re.test`, `/x/g.global`,
+  `Array.prototype.slice.call`, method `.name`/`.length` meta-fold, gOPD on a user
+  struct — no behaviour change introduced.
+- `tsc --noEmit` clean.
+- Full conformance + the honest standalone floor (12,889) validated by CI
+  `merge_group`.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -103,11 +103,13 @@ import {
   emitNonObjectArgGuard,
 } from "../object-ops.js";
 import {
+  BUILTIN_CTOR_NAMES,
   emitArrayIsArrayExternrefPredicate,
   emitNullCheckThrow,
   receiverIsCaughtErrorStringRead,
   receiverIsNativeStringValType,
   receiverMayBeNativeStringAtRuntime,
+  tryEnsureNativeProtoBrand,
   typeErrorThrowInstrs,
 } from "../property-access.js";
 import { emitToNumber, emitToString } from "../coercion-engine.js";
@@ -6895,6 +6897,73 @@ function compileCallExpression(
               if (argResult) fctx.body.push({ op: "drop" });
               fctx.body.push({ op: "ref.null.extern" });
               return { kind: "externref" };
+            }
+          }
+        }
+      }
+
+      // (#2885 Site 2) Standalone builtin-proto descriptor synthesis. The native
+      // `__getOwnPropertyDescriptor` only understands `$Object`; an INTRINSIC
+      // accessor/method on a virtual `$NativeProto` (e.g. `RegExp.prototype.global`)
+      // is invisible to it, so gOPD returns undefined and `desc.get` then derefs
+      // undefined → trap. Synthesize the descriptor directly from the brand-keyed
+      // closure factory when arg0 is a literal `<Builtin>.prototype` and arg1 names
+      // a member the glue advertises. Anything that doesn't resolve falls through
+      // to the dynamic fallback below (no behavior change for other receivers).
+      if (
+        ctx.standalone &&
+        propLiteral !== undefined &&
+        ts.isPropertyAccessExpression(arg0) &&
+        !ts.isPrivateIdentifier(arg0.name) &&
+        arg0.name.text === "prototype" &&
+        ts.isIdentifier(arg0.expression) &&
+        BUILTIN_CTOR_NAMES.has(arg0.expression.text) &&
+        !(fctx.localMap.has(arg0.expression.text) || (fctx.boxedCaptures?.has(arg0.expression.text) ?? false))
+      ) {
+        const protoBuiltin = arg0.expression.text;
+        const protoBrand = tryEnsureNativeProtoBrand(ctx, protoBuiltin);
+        const protoGlue = protoBrand !== undefined ? getNativeProtoBuiltinGlue(ctx, protoBrand) : undefined;
+        if (protoBrand !== undefined && protoGlue && protoGlue.memberCsv.split(",").includes(propLiteral)) {
+          const memberKind = protoGlue.memberKind(propLiteral);
+          const protoClosure = ensureStandaloneNativeMethodClosure(ctx, protoBrand, propLiteral, memberKind);
+          if (protoClosure) {
+            if (memberKind === "getter") {
+              // Accessor descriptor: get=<closure>, set=undefined,
+              // {enumerable:false, configurable:true} (intrinsic accessor attrs).
+              const createAccIdx = ensureLateImport(
+                ctx,
+                "__create_accessor_descriptor",
+                [{ kind: "externref" }, { kind: "externref" }, { kind: "i32" }],
+                [{ kind: "externref" }],
+              );
+              flushLateImportShifts(ctx, fctx);
+              if (createAccIdx !== undefined) {
+                fctx.body.push({ op: "ref.func", funcIdx: protoClosure.funcIdx } as Instr);
+                fctx.body.push({ op: "struct.new", typeIdx: protoClosure.type.typeIdx } as Instr);
+                fctx.body.push({ op: "extern.convert_any" } as Instr); // get
+                fctx.body.push({ op: "ref.null.extern" } as Instr); // set = undefined
+                fctx.body.push({ op: "i32.const", value: 0x04 } as Instr); // FLAG_CONFIGURABLE
+                fctx.body.push({ op: "call", funcIdx: createAccIdx } as Instr);
+                return { kind: "externref" };
+              }
+            } else {
+              // Data descriptor: value=<method closure>,
+              // {writable:true, enumerable:false, configurable:true}.
+              const createIdx = ensureLateImport(
+                ctx,
+                "__create_descriptor",
+                [{ kind: "externref" }, { kind: "i32" }],
+                [{ kind: "externref" }],
+              );
+              flushLateImportShifts(ctx, fctx);
+              if (createIdx !== undefined) {
+                fctx.body.push({ op: "ref.func", funcIdx: protoClosure.funcIdx } as Instr);
+                fctx.body.push({ op: "struct.new", typeIdx: protoClosure.type.typeIdx } as Instr);
+                fctx.body.push({ op: "extern.convert_any" } as Instr); // value
+                fctx.body.push({ op: "i32.const", value: 0x05 } as Instr); // FLAG_WRITABLE | FLAG_CONFIGURABLE
+                fctx.body.push({ op: "call", funcIdx: createIdx } as Instr);
+                return { kind: "externref" };
+              }
             }
           }
         }

--- a/src/codegen/native-proto.ts
+++ b/src/codegen/native-proto.ts
@@ -36,6 +36,7 @@ import { getOrCreateFuncRefWrapperTypes } from "./closures.js";
 import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { emitWasiErrorConstructor } from "./registry/error-types.js";
+import { allocLocal } from "./context/locals.js";
 
 // ── Brand space (shared with #2101 — MUST stay coherent) ──────────────────────
 //
@@ -436,7 +437,12 @@ export function ensureStandaloneNativeMethodClosure(
     ctx.funcMap.set(funcName, funcIdx);
 
     if (!ctx.nativeClosureMeta) ctx.nativeClosureMeta = new Map();
-    ctx.nativeClosureMeta.set(funcIdx, { name: member, length: arity });
+    // (#2885) §10.2.9 — accessor functions are named `"get <key>"` (resp.
+    // `"set <key>"`). The reflective `desc.get.name` read resolves the closure's
+    // name from `nativeClosureMeta`, so getter closures must carry the accessor
+    // spelling, not the bare member. Methods keep the bare member name.
+    const accessorName = kind === "getter" ? `get ${member}` : member;
+    ctx.nativeClosureMeta.set(funcIdx, { name: accessorName, length: arity });
   }
 
   // (#2193 PR-B) A `"method"` closure's first user param is the receiver
@@ -466,4 +472,65 @@ export function emitBrandCheckTypeError(ctx: CodegenContext, body: Instr[], mess
     body.push({ op: "call", funcIdx: newTypeErrorIdx } as Instr);
   }
   body.push({ op: "throw", tagIdx: ensureExnTag(ctx) } as Instr);
+}
+
+/** The `eq` abstract heap type, signed-LEB128 -19 (= 0x6d). `ref.test`/`ref.cast`
+ *  against it narrow an `anyref` to an `eqref` so `ref.eq` (which requires eqref
+ *  operands) can run. Mirrors the constant in `binary-ops.ts`. */
+const EQ_HEAP_TYPE = -19;
+
+/**
+ * (#2885 Site 1) Emit the spec's "SameValue(thisValue, %Proto%) → return
+ * undefined" identity arm for a builtin-proto accessor getter. Per §22.2.6 (and
+ * the analogous String/TypedArray accessor steps), reading an intrinsic getter
+ * with `this === <Builtin>.prototype` returns `undefined` rather than throwing
+ * the brand-check TypeError — so the getter closure must short-circuit BEFORE the
+ * brand-recovery prologue throws.
+ *
+ * Appends to `fctx.body`: force-materialize the `$NativeProto` global for `brand`,
+ * compare it by reference identity (`ref.eq`) against the closure's externref
+ * `this` (param `thisParamIdx`), and on a match emit `undefinedResult` followed by
+ * `return`. A non-eqref / non-matching `this` falls through unchanged so the
+ * caller's brand check still runs.
+ *
+ * The getter closure result type is unified to `externref` (callers box i32/f64
+ * field results), so `undefinedResult` is the `ref.null.extern` form.
+ */
+export function emitNativeProtoIdentityReturnUndefined(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  brand: number,
+  thisParamIdx: number,
+  undefinedResult: Instr[],
+): void {
+  // Force-materialize the proto object and stash its anyref view.
+  const protoAny = allocLocal(fctx, `__proto_id_proto_${fctx.locals.length}`, { kind: "anyref" } as ValType);
+  emitLazyNativeProtoGet(ctx, fctx, brand); // leaves the proto externref on the stack
+  fctx.body.push({ op: "any.convert_extern" } as Instr);
+  fctx.body.push({ op: "local.set", index: protoAny } as Instr);
+
+  // `this` (externref) → anyref; only an eqref can be `ref.eq`-compared.
+  const thisAny = allocLocal(fctx, `__proto_id_this_${fctx.locals.length}`, { kind: "anyref" } as ValType);
+  fctx.body.push({ op: "local.get", index: thisParamIdx } as Instr);
+  fctx.body.push({ op: "any.convert_extern" } as Instr);
+  fctx.body.push({ op: "local.tee", index: thisAny } as Instr);
+  fctx.body.push({ op: "ref.test", typeIdx: EQ_HEAP_TYPE } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "val", type: { kind: "i32" } },
+    then: [
+      { op: "local.get", index: thisAny } as Instr,
+      { op: "ref.cast", typeIdx: EQ_HEAP_TYPE } as Instr,
+      { op: "local.get", index: protoAny } as Instr,
+      { op: "ref.cast", typeIdx: EQ_HEAP_TYPE } as Instr,
+      { op: "ref.eq" } as Instr,
+    ],
+    else: [{ op: "i32.const", value: 0 } as Instr],
+  } as Instr);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [...undefinedResult, { op: "return" } as Instr],
+    else: [],
+  } as Instr);
 }

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -5359,6 +5359,68 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     );
   }
 
+  // ── __create_accessor_descriptor(get, set, flags) -> externref (#2885) ──────
+  //
+  // Accessor sibling of `__create_descriptor`. Builds a fresh ACCESSOR descriptor
+  // `$Object` `{ get, set, enumerable, configurable }` from the get/set closure
+  // externrefs (null → undefined) + the flag bits (2=enumerable, 4=configurable).
+  // Used by the standalone builtin-proto descriptor-synthesis path in
+  // `Object.getOwnPropertyDescriptor(<Builtin>.prototype, "<getter>")`
+  // (expressions/calls.ts) so an intrinsic accessor reflects host-free, mirroring
+  // the accessor branch of the native `__getOwnPropertyDescriptor` above and the
+  // host `runtime.ts:__create_descriptor` shape. Keys are native `$AnyString`s;
+  // attribute booleans are boxed via `__box_boolean`. Intrinsic accessors are
+  // `{enumerable:false, configurable:true}` (flags = 0x04), so `writable` is
+  // intentionally absent (accessor descriptors carry no `value`/`writable`).
+  //
+  // params: 0=get(externref) 1=set(externref) 2=flags(i32) ; locals: 3=desc(externref)
+  {
+    addUnionImportsViaRegistry(ctx);
+    const boxBoolIdx = ctx.funcMap.get("__box_boolean")!;
+    const newPlainObjectIdx = ctx.funcMap.get("__new_plain_object")!;
+    const externSetCdIdx = ctx.funcMap.get("__extern_set")!;
+
+    // `desc["<key>"] = <value externref>` — desc is in local 3.
+    const setKeyAcc = (key: string, valueInstrs: Instr[]): Instr[] => [
+      { op: "local.get", index: 3 },
+      ...nativeStringLiteralInstrs(ctx, key),
+      { op: "extern.convert_any" } as Instr,
+      ...valueInstrs,
+      { op: "call", funcIdx: externSetCdIdx },
+    ];
+
+    // Box `(flags & mask) != 0` as a JS boolean externref.
+    const boolFlagAcc = (mask: number): Instr[] => [
+      { op: "local.get", index: 2 },
+      { op: "i32.const", value: mask },
+      { op: "i32.and" },
+      { op: "i32.const", value: 0 },
+      { op: "i32.ne" },
+      { op: "call", funcIdx: boxBoolIdx },
+    ];
+
+    const body: Instr[] = [
+      // desc = __new_plain_object()
+      { op: "call", funcIdx: newPlainObjectIdx },
+      { op: "local.set", index: 3 },
+      // desc.get = get (param 0) ; desc.set = set (param 1)
+      ...setKeyAcc("get", [{ op: "local.get", index: 0 }]),
+      ...setKeyAcc("set", [{ op: "local.get", index: 1 }]),
+      // desc.enumerable / configurable = box(flags & bit)
+      ...setKeyAcc("enumerable", boolFlagAcc(FLAG_ENUMERABLE)),
+      ...setKeyAcc("configurable", boolFlagAcc(FLAG_CONFIGURABLE)),
+      // return desc
+      { op: "local.get", index: 3 },
+    ];
+    registerNative(
+      "__create_accessor_descriptor",
+      [{ kind: "externref" }, { kind: "externref" }, { kind: "i32" }],
+      [{ kind: "externref" }],
+      [{ name: "desc", type: { kind: "externref" } }],
+      body,
+    );
+  }
+
   // ── __getOwnPropertyNames(externref obj) -> externref (#2042 S3) ──────────
   //
   // `Object.getOwnPropertyNames(obj)` / `Reflect.ownKeys(obj)` (string subset)

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -127,7 +127,7 @@ import { reserveAccessorGetDriver } from "./accessor-driver.js";
 import { S5C_STRUCT_ACCESSOR_CLOSURE } from "./struct-accessor-closure.js";
 import { tryCompileTemporalPropertyAccess } from "./temporal-native.js";
 
-const BUILTIN_CTOR_NAMES = new Set([
+export const BUILTIN_CTOR_NAMES = new Set([
   "Object",
   "Array",
   "Function",
@@ -701,7 +701,7 @@ function ensureStandaloneNativeMethodClosureLocal(
  * core (caller falls through to the existing refusal). S1 wires RegExp only;
  * S3 adds %TypedArray% / the concrete views.
  */
-function tryEnsureNativeProtoBrand(ctx: CodegenContext, builtinName: string): number | undefined {
+export function tryEnsureNativeProtoBrand(ctx: CodegenContext, builtinName: string): number | undefined {
   if (builtinName === "RegExp") {
     return ensureRegExpNativeProtoGlue(ctx);
   }
@@ -920,6 +920,31 @@ function tryCompileStandaloneBuiltinProtoMemberRead(
   const kind = glue.memberKind(member);
   const closure = ensureStandaloneNativeMethodClosure(ctx, brand, member, kind);
   if (!closure) return undefined;
+
+  if (kind === "getter") {
+    // (#2885 Site 3) A plain read of `<Builtin>.prototype.<getter>` must INVOKE
+    // the accessor on the receiver, not return the getter closure value. This
+    // site only fires for the literal `<Builtin>.prototype.<getter>` shape, so
+    // the receiver is always the proto object (`$NativeProto` externref): the
+    // proto-identity arm in the getter body (Site 1) then yields `undefined`
+    // (§22.2.6), e.g. `RegExp.prototype.global === undefined`. Instance reads
+    // (`re.global`) route through `tryCompileStandaloneRegExpPropertyRead`, not
+    // here. Returns externref (the unified getter result type).
+    const closureInfo = ctx.closureInfoByTypeIdx.get(closure.type.typeIdx);
+    if (!closureInfo) return undefined;
+
+    // self struct (param 0) — unused by the body (no captures) but type-required.
+    fctx.body.push({ op: "ref.func", funcIdx: closure.funcIdx } as Instr);
+    fctx.body.push({ op: "struct.new", typeIdx: closure.type.typeIdx } as Instr);
+    // `this` arg (param 1): the builtin proto object externref.
+    if (!emitLazyNativeProtoGet(ctx, fctx, brand)) return undefined;
+    // call_ref operand: the typed funcref. `ref.func` yields `(ref liftedType)`
+    // directly (the func's declared type IS the lifted closure type), so no
+    // struct.get / guard-cast is needed.
+    fctx.body.push({ op: "ref.func", funcIdx: closure.funcIdx } as Instr);
+    fctx.body.push({ op: "call_ref", typeIdx: closureInfo.funcTypeIdx } as Instr);
+    return closureInfo.returnType ?? { kind: "externref" };
+  }
 
   fctx.body.push({ op: "ref.func", funcIdx: closure.funcIdx } as Instr);
   fctx.body.push({ op: "struct.new", typeIdx: closure.type.typeIdx } as Instr);

--- a/src/codegen/regexp-standalone.ts
+++ b/src/codegen/regexp-standalone.ts
@@ -61,6 +61,7 @@ import {
 import { compilePattern, RepeatTooLargeError } from "./regex/compile.js";
 import {
   emitBrandCheckTypeError,
+  emitNativeProtoIdentityReturnUndefined,
   getBuiltinBrand,
   registerNativeProtoBuiltin,
   type NativeProtoBuiltinGlue,
@@ -2462,28 +2463,55 @@ function emitRegExpProtoMemberBody(
   member: string,
   kind: "getter" | "method",
 ): ValType | null {
-  // Brand-recovery prologue: `this` is closure param index 1 (externref).
-  const recovered = recoverRegExpStructFromExternref(ctx, fctx, 1);
-  if (recovered === null) return null;
-  const { regexpLocal, structTypeIdx } = recovered;
-
   if (kind === "getter") {
-    // Reuse the exact static-path field-read sequence. lastIndex is a data
-    // property, not an accessor — but reading it as a getter is harmless and
-    // keeps the closure-table uniform.
+    // (#2885 Site 1) The proto-identity arm MUST run BEFORE brand recovery:
+    // reading an intrinsic getter with `this === RegExp.prototype` returns
+    // `undefined` per §22.2.6 ("If SameValue(R, %RegExp.prototype%) return
+    // undefined"), NOT the brand-check TypeError. The getter-closure result is
+    // unified to externref (the undefined sentinel + every boxed field value
+    // share one type), so the proto-identity arm yields `ref.null.extern`.
+    const brand = getBuiltinBrand(ctx, "RegExp");
+    if (brand !== undefined) {
+      emitNativeProtoIdentityReturnUndefined(ctx, fctx, brand, 1, [{ op: "ref.null.extern" } as Instr]);
+    }
+
+    // Brand-recovery prologue: `this` is closure param index 1 (externref). On a
+    // genuine non-RegExp `this` (e.g. `get.call({})`) this throws a catchable
+    // TypeError (§22.2.6 step 2) — unchanged.
+    const recovered = recoverRegExpStructFromExternref(ctx, fctx, 1);
+    if (recovered === null) return null;
+    const { regexpLocal, structTypeIdx } = recovered;
+
+    // Reuse the exact static-path field-read sequence, then unify the result to
+    // externref so the closure-call ABI and the descriptor `.get` both see one
+    // type: native-string refs (`.flags`/`.source`) box via `extern.convert_any`,
+    // i32 flag booleans via `__box_boolean` (a JS boolean, not the number 0/1),
+    // and the defensive f64 (lastIndex is a method-kind member, never a getter)
+    // via `__box_number`.
     const fieldType = emitRegExpReflectionFieldRead(ctx, fctx, member, regexpLocal, structTypeIdx);
-    // The closure-call ABI is uniform on externref/i32/f64 results; a native
-    // string ref (`.flags`/`.source`) must be boxed to externref so it survives
-    // the `call_ref` boundary and the receiving `any` comparison. i32 flag
-    // booleans and the f64 lastIndex pass through unchanged.
     if (fieldType.kind === "ref" || fieldType.kind === "ref_null") {
       fctx.body.push({ op: "extern.convert_any" } as Instr);
+      return { kind: "externref" };
+    }
+    if (fieldType.kind === "i32") {
+      const boxBoolIdx = ensureLateImport(ctx, "__box_boolean", [{ kind: "i32" }], [{ kind: "externref" }]);
+      flushLateImportShifts(ctx, fctx);
+      if (boxBoolIdx !== undefined) fctx.body.push({ op: "call", funcIdx: boxBoolIdx } as Instr);
+      return { kind: "externref" };
+    }
+    if (fieldType.kind === "f64") {
+      coerceType(ctx, fctx, { kind: "f64" }, { kind: "externref" });
       return { kind: "externref" };
     }
     return fieldType;
   }
 
-  // Method bodies.
+  // Method bodies. Brand-recovery prologue: `this` is closure param index 1
+  // (externref) → `$NativeRegExp` or a catchable TypeError on a wrong `this`.
+  const recovered = recoverRegExpStructFromExternref(ctx, fctx, 1);
+  if (recovered === null) return null;
+  const { regexpLocal, structTypeIdx } = recovered;
+
   if (member === "test" || member === "@@9") {
     // `.test(s)` and `[Symbol.search]`-adjacent forms both run the search and
     // return an i32-ish result; here we return the i32 match flag for `.test`.

--- a/tests/issue-2885.test.ts
+++ b/tests/issue-2885.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2885 — Standalone descriptor-reflection core: builtin-proto intrinsic
+// accessors are now reflectable host-free.
+//
+// Under `--target standalone`, `Object.getOwnPropertyDescriptor(RegExp.prototype,
+// "global")` previously returned `undefined` (the virtual `$NativeProto` is not
+// an `$Object`, so the native `__getOwnPropertyDescriptor` found no own entry),
+// and the test then derefed `.get` on `undefined` → Wasm trap. This wires:
+//   - a `ctx.standalone`-gated builtin-proto accessor SYNTHESIS path in the gOPD
+//     call-site (Site 2) backed by the native `__create_accessor_descriptor`,
+//   - the §22.2.6 "SameValue(R, %RegExp.prototype%) → undefined" proto-identity
+//     arm in the getter closure (Site 1),
+//   - a plain `<Builtin>.prototype.<getter>` read that INVOKES the getter (Site 3).
+//
+// All host-free: the emitted module must declare ZERO imports.
+
+async function compileStandalone(src: string) {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  if (!r.success) throw new Error("compile failed: " + JSON.stringify(r.errors?.map((e) => e.message)));
+  return r;
+}
+
+async function runStandalone(src: string): Promise<{ ret: unknown; importCount: number }> {
+  const r = await compileStandalone(src);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return { ret: (instance.exports.test as () => unknown)?.(), importCount: r.imports.length };
+}
+
+describe("#2885 standalone descriptor-reflection core (RegExp pilot)", () => {
+  it("gOPD(RegExp.prototype, 'global') returns a proper accessor descriptor", async () => {
+    const { ret } = await runStandalone(`
+      export function test(): number {
+        const d = Object.getOwnPropertyDescriptor(RegExp.prototype, "global");
+        if (d === undefined) return 100;            // was the bug: undefined → trap
+        if (typeof (d as any).get !== "function") return 101;
+        if ((d as any).set !== undefined) return 102;
+        if ((d as any).enumerable !== false) return 103;
+        if ((d as any).configurable !== true) return 104;
+        return 1;
+      }
+    `);
+    expect(ret).toBe(1);
+  });
+
+  it("get.call(RegExp.prototype) === undefined (§22.2.6 proto-identity arm)", async () => {
+    const { ret } = await runStandalone(`
+      export function test(): number {
+        const g = (Object.getOwnPropertyDescriptor(RegExp.prototype, "global") as any).get;
+        return g.call(RegExp.prototype) === undefined ? 1 : 0;
+      }
+    `);
+    expect(ret).toBe(1);
+  });
+
+  it("plain read RegExp.prototype.global is undefined (Site 3 invokes the getter)", async () => {
+    const { ret } = await runStandalone(`
+      export function test(): number {
+        return (RegExp.prototype as any).global === undefined ? 1 : 0;
+      }
+    `);
+    expect(ret).toBe(1);
+  });
+
+  it("descriptor synthesis is host-free (zero imports)", async () => {
+    const { importCount } = await runStandalone(`
+      export function test(): number {
+        const d = Object.getOwnPropertyDescriptor(RegExp.prototype, "global");
+        return d === undefined ? 0 : 1;
+      }
+    `);
+    expect(importCount).toBe(0);
+  });
+
+  it("gOPD on a user-struct receiver still works (typed-receiver fast path unchanged)", async () => {
+    const { ret } = await runStandalone(`
+      class C { x = 5; }
+      export function test(): number {
+        const d = Object.getOwnPropertyDescriptor(new C(), "x");
+        return (d as any).value;
+      }
+    `);
+    expect(ret).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2885. Under `--target standalone`, `Object.getOwnPropertyDescriptor(RegExp.prototype, "global")` returned `undefined` — the virtual `$NativeProto` is not an `$Object`, so native `__getOwnPropertyDescriptor` found no own entry, and the test then derefed `.get` on `undefined` → Wasm trap. This lands the host-free descriptor-reflection core (architect PR1 + PR2 combined — identical blast radius; the headline acceptance is the gOPD synthesis).

## Verify-first (`--target standalone`, `imports: []`)

| | main | this PR |
|---|---|---|
| `gOPD(RegExp.prototype,"global")` | `undefined` → deref-trap | `{get:<fn>, set:undefined, enumerable:false, configurable:true}` |
| `get.call(RegExp.prototype)` | trap | `undefined` (§22.2.6 proto-identity) |
| `RegExp.prototype.global` plain read | getter closure value | `undefined` |
| imports | — | `[]` (host-free) |

## Changes

- **Site 1** `native-proto.ts` — `emitNativeProtoIdentityReturnUndefined()` (§22.2.6 `SameValue(R,%Proto%) → undefined` via `ref.eq` vs the materialized proto global); accessor `.name = "get <member>"` (§10.2.9).
- **Site 1** `regexp-standalone.ts` — getter arm runs the proto-identity arm BEFORE brand recovery; getter result unified to externref (flag-bool i32 → `__box_boolean`).
- **Site 2** `calls.ts` — `ctx.standalone`-gated builtin-proto descriptor SYNTHESIS before the dynamic gOPD fallback (getter → accessor descriptor, method → data descriptor).
- **Site 2** `object-runtime.ts` — native `__create_accessor_descriptor(get,set,flags)`.
- **Site 3** `property-access.ts` — plain `<Builtin>.prototype.<getter>` read INVOKES the getter on the proto; exported `tryEnsureNativeProtoBrand` + `BUILTIN_CTOR_NAMES`.

## Tests

- `tests/issue-2885.test.ts` — 5/5 pass.
- `runTest262File(..., "standalone")`: `RegExp/prototype/global/this-val-regexp-prototype.js`, `global/length.js`, `source/length.js` flip to **pass** (all errored on main). `this-val-non-obj.js` / `name.js` stay `fail` — the #2193 reflective-call-on-opaque-closure gap (a follow-up; same on main, **not a regression**).
- Regression smoke: identical output on main vs branch for `re.test`, `/x/g.global`, `Array.prototype.slice.call`, method `.name`/`.length` meta-fold, user-struct gOPD.
- `tsc --noEmit` clean.

Unblocks #2876 (RegExp), #2875 (String), #2872 (TypedArray accessors). PR3 (per-cluster `emitMemberBody` glue) + the reflective-call-on-opaque-closure gap remain follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)