### PR TITLE
feat(#2864 F1b): type live-across-yield local spills for standalone generators

### DIFF
--- a/plan/issues/2864-standalone-generator-carrier.md
+++ b/plan/issues/2864-standalone-generator-carrier.md
@@ -2,7 +2,7 @@
 id: 2864
 title: "Standalone: no Wasm-native generator carrier — sync generators leak __create_generator/__gen_* host imports"
 status: in-progress
-assignee: ttraenkler/sendev-genframe
+assignee: ttraenkler/sr-frame
 created: 2026-06-30
 updated: 2026-06-30
 priority: high
@@ -162,3 +162,82 @@ frame rather than building a new one.
   drain consumers parametrised on the generator's carrier element type.
 - `tests/issue-2864-standalone-generator-carrier.test.ts` — 8 standalone cases
   (zero-host-import asserted).
+
+## F1b — typed live-across-yield LOCAL spills (landed)
+
+**Scope shipped:** a generator that carries an OBJECT / STRING / typed-struct
+local across a `yield` now compiles host-free in standalone/WASI, instead of
+mis-compiling (the f64 spill field could not hold a `ref`) or bailing. The
+spill field, the resume-function load local, and the state-struct construction
+default are all minted at the local's **actual** ValType.
+
+Verify-first (`function* g(){ let o={n:1}; yield 1; yield o.n }`, read via
+`.next().value`): **CE-refused** on main → host-free + returns `2` after F1b
+(`result.imports` empty). Also host-free: numeric/string LOCAL spills, an
+object-yield carrier WITH an object local spill, and loop-carried object spills
+drained via `for-of`. gc-mode unchanged (the native path is gated
+`noJsHostTarget`); numeric spills stay byte-identical (f64).
+
+### Why these decisions (root-cause, not symptom)
+
+The F1 notes framed this as gated on the **any** carrier, but the dominant
+failure is broader: a generator with **numeric** yields and an **object/string
+LOCAL** (e.g. `let o={…}; yield 1; yield o.n`) is an f64-carrier generator whose
+spill field was hardcoded f64 (`stateFields … {kind:"f64"}`), the resume-load
+local was hardcoded f64, and the struct-init pushed `f64.const NaN` — so the
+object local's `ref` value mis-stored against an f64 field → a hard wasm
+validation error (`local.set expected (ref null N), found struct.get of type
+f64`). The fix types all three sites per-spill.
+
+- **Spill type resolved by `resolveSpillLocalValType` (in `variables.ts`).** The
+  resume function compiles the body with a FRESH `FunctionContext` whose analysis
+  caches are empty and whose locals never resolve to a module global, so the type
+  its var-declaration computes reduces to the **fctx-independent** subset of the
+  `compileVariableStatement` cascade — the ctx/AST externref-forcing overrides
+  plus `localTypeForDeclaration`. The helper replicates exactly that subset (it
+  lives next to those predicates so they stay in lockstep) and returns `null` for
+  any form whose representation the up-front layout cannot match (Proxy, accessor
+  / spread / growable object literals, `subarray` subview, regexp-match arrays,
+  `Array<any>` vecs, …). A `null` for ANY spill keeps the WHOLE generator on the
+  host path — a conservative, non-regressing bail consistent across the candidate
+  gate and registration.
+- **Non-null `ref` widened to `ref_null`.** `resolveWasmType` returns a non-null
+  `ref` for object literals, but a wasm local is widened to nullable and a
+  non-null ref struct field has no `struct.new` default. So spills carry
+  `ref_null`; `struct.get` of a nullable ref is valid and traps-on-null exactly
+  as the source semantics require.
+- **Post-emission reconcile.** The body's var-declaration reuses the
+  pre-allocated spill slot and may re-type it (e.g. narrow `ref_null` → non-null
+  `ref`). After the resume body is emitted, each spill's FINAL local type is
+  read back, widened to `ref_null`, and pinned onto BOTH the local slot and the
+  state-struct field (+ `info.spillTypes`, which the constructor init reads). This
+  runs before any `struct.new` of the state struct (the constructor calls the
+  resume builder first), so the init defaults observe the reconciled types — no
+  prediction-vs-emission divergence can slip through.
+
+### Deferred (F1b — kept on the host path; correctness-preserving)
+
+- **Boxed-any `.next(v)` RESUME bindings** (`let x = yield …` where the yields are
+  object/mixed → externref carrier): the sent value is an externref whose later
+  **member** reads need the any-receiver dispatch (#2151), which silently computes
+  a wrong value here. So an any-carrier generator with a resume binding still
+  bails to the host path (exactly as F1 did) — a CE-refusal is correct, a wrong
+  answer is not. Numeric/native-string resume bindings (sent = f64 / string) ARE
+  supported. Widening the boxed-any sent-value reads is an F1c follow-up that
+  builds on #2151.
+- **String-ELEM generators read via `.next().value as string`** remain blocked on
+  a PRE-EXISTING #2171 string-carrier result-reader mismatch (result `value`
+  typeIdx ≠ the produced string vec), independent of spills — reproduces with a
+  zero-spill string generator. Not in F1b scope.
+
+### Files (F1b)
+
+- `src/codegen/statements/variables.ts` — new exported `resolveSpillLocalValType`.
+- `src/codegen/generators-native.ts` — per-spill `spillTypes` in the plan + info,
+  typed spill fields / resume-load locals / `struct.new` defaults
+  (`defaultSpillInstr`), the any-carrier resume-binding bail, and the
+  post-emission spill-type reconcile. Retired the F1 `elemIsAny && spills>0` and
+  string-elem spill guards (subsumed by per-spill resolution).
+- `src/codegen/context/types.ts` — `NativeGeneratorInfo.spillTypes`.
+- `tests/issue-2864-standalone-generator-carrier.test.ts` — 6 F1b standalone
+  cases (zero-host-import asserted).

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -238,6 +238,13 @@ export interface NativeGeneratorInfo {
   abruptFieldIdx: number;
   /** Function-local names spilled into the state struct across suspensions. */
   spillNames: string[];
+  /**
+   * (#2864 F1b) Wasm ValType of each spilled local, aligned 1:1 with
+   * `spillNames`. The state-struct spill field, the resume-load local, and the
+   * struct-construction init default are all minted at this type so object /
+   * string / typed-struct locals survive across a `yield` (historically f64).
+   */
+  spillTypes: ValType[];
   /** Field index where spilled locals start in the state struct. */
   spillFieldOffset: number;
   /** Number of top-level yield suspension points. */

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -37,6 +37,7 @@ import { emitBrandCheckTypeError } from "./native-proto.js";
 import { addFuncType } from "./registry/types.js";
 import { coerceType, compileExpression, compileStatement, valTypesMatch } from "./shared.js";
 import { bodyUsesArguments } from "./helpers/body-uses-arguments.js";
+import { resolveSpillLocalValType } from "./statements/variables.js";
 
 const STATE_FIELD = 0;
 const SENT_FIELD = 1;
@@ -95,6 +96,15 @@ interface NativeGeneratorState {
 interface NativeGeneratorPlan {
   states: NativeGeneratorState[];
   spills: string[];
+  /**
+   * (#2864 F1b) The wasm ValType for each spilled local, keyed by name. A local
+   * carried across a `yield` gets a state-struct field at its ACTUAL type
+   * (object → `ref_null $Object`, string → the native-string ref, number → f64),
+   * not the historical f64. A `let x = yield …` resume binding takes the carrier
+   * (`sent`-field) type. Every spill resolves to a supported kind or the plan
+   * bails to the host path (see `buildNativeGeneratorPlan`).
+   */
+  spillTypes: Map<string, ValType>;
   /** (#2171) Uniform yield element ValType — f64 (numeric) or native string. */
   elemValType: ValType;
   /**
@@ -287,7 +297,11 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
   // this array is the terminator's `siteIndex`.
   const delegationSites: { innerName: string }[] = [];
   const spillSet = new Set<string>();
-  const addSpill = (name: string): void => {
+  // (#2864 F1b) The variable declaration that introduced each spilled name, so
+  // the spill's wasm type can be resolved at its actual ValType.
+  const spillDecls = new Map<string, ts.VariableDeclaration>();
+  const addSpill = (name: string, decl?: ts.VariableDeclaration): void => {
+    if (decl !== undefined && !spillDecls.has(name)) spillDecls.set(name, decl);
     if (spillSet.has(name)) return;
     spillSet.add(name);
     spills.push(name);
@@ -746,7 +760,7 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
   function collectSpillsIn(node: ts.Node): void {
     function visit(n: ts.Node): void {
       if (ts.isVariableDeclaration(n) && ts.isIdentifier(n.name)) {
-        addSpill(n.name.text);
+        addSpill(n.name.text, n);
       }
       if (
         ts.isFunctionDeclaration(n) ||
@@ -780,20 +794,43 @@ function buildNativeGeneratorPlan(ctx: CodegenContext, decl: GeneratorDecl): Nat
   if (suspendCount === 0) return null;
   if (states.length > MAX_NATIVE_GENERATOR_STATES) return null;
 
-  // (#2864 F1) The boxed-any carrier types only the per-frame scalars (sent /
-  // abrupt / yielded value) as externref; it does NOT yet type the spill slots
-  // for live-across-yield LOCALS. A faithful spill field must carry the local's
-  // exact wasm type (an object literal lowers to a concrete `ref $Object`, which
-  // the up-front struct layout cannot know without a body pre-pass — the
-  // "deeper rewrite" flagged in the #2864 plan). So a heterogeneous generator
-  // that needs to spill any local bails to the host path here (consistent across
-  // `isNativeGeneratorCandidate` and `registerNativeGenerator`, both of which
-  // route through this builder, so the host imports stay registered and no
-  // undefined funcidx is baked). Numeric / string carriers are unaffected (their
-  // spills are f64). Follow-up: two-pass spill typing widens this.
-  if (elemIsAny && spills.length > 0) return null;
+  // (#2864 F1b) Type every spilled local at its ACTUAL wasm ValType so a live-
+  // across-yield object / string / typed-struct local survives the frame, rather
+  // than the F1 blanket bail (`elemIsAny && spills.length > 0`) or the historical
+  // f64-only assumption. Two kinds of spill:
+  //   • a `let x = yield …` RESUME BINDING — its value comes from the `sent`
+  //     carrier field, so it must match the carrier type (f64 for numeric/string,
+  //     externref for the boxed-any carrier), NOT resolveWasmType(x) (the declared
+  //     `TNext`, usually `any`).
+  //   • a plain body LOCAL — resolved via `resolveSpillLocalValType`, which mirrors
+  //     the type the resume function's var-declaration will assign it.
+  // If ANY spill cannot be resolved to a supported, struct-storable kind, the
+  // whole generator bails to the host path (return null) — consistent across the
+  // candidate gate and registration (both route through this builder), so the
+  // host imports stay registered and no undefined funcidx is baked.
+  const resumeBindingNames = new Set<string>();
+  for (const s of states) for (const b of s.resumeBindings) resumeBindingNames.add(b);
+  const carrierType = genCarrierFieldType(elemValType);
+  const spillTypes = new Map<string, ValType>();
+  for (const name of spills) {
+    if (resumeBindingNames.has(name)) {
+      // A `let x = yield …` binding reads `.next(v)`'s value from the `sent`
+      // carrier field. For numeric / native-string carriers (sent = f64 / string)
+      // this round-trips and was already supported. For the BOXED-ANY carrier the
+      // sent value is an externref whose later member reads need the any-receiver
+      // dispatch (#2151) — not yet correct here (it silently computes a wrong
+      // value), so keep bailing that shape to the host path, exactly as F1 did.
+      if (carrierIsAny(elemValType)) return null;
+      spillTypes.set(name, carrierType);
+      continue;
+    }
+    const declNode = spillDecls.get(name);
+    const resolved = declNode ? resolveSpillLocalValType(ctx, declNode) : null;
+    if (!resolved) return null;
+    spillTypes.set(name, resolved);
+  }
 
-  return { states, spills, elemValType, delegationSites };
+  return { states, spills, spillTypes, elemValType, delegationSites };
 }
 
 /** A `break`/`continue` inside a yield-loop body is not modeled in this slice. */
@@ -1113,17 +1150,10 @@ export function registerNativeGenerator(
   if (!plan) return null;
 
   const elemValType = plan.elemValType;
-  const elemIsString = elemValType.kind !== "f64";
-  // (#2171) Scope guard for the string slice: spilled locals are typed f64 in
-  // the state struct, so a string generator that needs to spill a live local
-  // across a suspension can't faithfully store it yet. Bail to the host/#680
-  // path for that shape (numeric generators are unaffected — they spill f64).
-  // This keeps the slice to the dominant `yield "a"; yield "b"` shape; spilled
-  // non-numeric locals are the documented follow-up.
-  const bodySpillsForGuard = plan.spills.filter(
-    (s) => !decl.parameters.some((p) => ts.isIdentifier(p.name) && p.name.text === s),
-  );
-  if (elemIsString && bodySpillsForGuard.length > 0) return null;
+  // (#2864 F1b) Spilled locals are now typed at their actual ValType
+  // (`plan.spillTypes`), so the historical string/any guards that bailed any
+  // generator with a live-across-yield non-numeric local are retired — the plan
+  // builder already returned null for any spill whose type it could not resolve.
 
   const resultTypeIdx = ensureNativeGeneratorResultType(ctx, elemValType);
   // (#2571) The synthetic `this` (when present) is the FIRST param name, aligned
@@ -1152,10 +1182,15 @@ export function registerNativeGenerator(
   // but params already live in the struct. Spills cover body-declared locals.
   const paramNameSet = new Set(paramNames);
   const bodySpills = plan.spills.filter((s) => !paramNameSet.has(s));
-  for (const spill of bodySpills) {
+  // (#2864 F1b) Spill field at the local's actual ValType (object → ref_null
+  // struct, string → native-string ref, number → f64), aligned 1:1 with
+  // `bodySpills` so the resume-load local, store/load, and struct-init default
+  // all agree. `plan.spillTypes` is guaranteed to hold an entry for each spill.
+  const spillTypes: ValType[] = bodySpills.map((s) => plan.spillTypes.get(s) ?? { kind: "f64" });
+  for (let i = 0; i < bodySpills.length; i++) {
     stateFields.push({
-      name: `spill_${spill}`,
-      type: { kind: "f64" },
+      name: `spill_${bodySpills[i]}`,
+      type: spillTypes[i]!,
       mutable: true,
     });
   }
@@ -1198,6 +1233,7 @@ export function registerNativeGenerator(
     modeFieldIdx: MODE_FIELD,
     abruptFieldIdx: ABRUPT_FIELD,
     spillNames: bodySpills,
+    spillTypes,
     spillFieldOffset,
     yieldCount,
     doneState: plan.states.length - 1, // the final `done` state id
@@ -1236,6 +1272,25 @@ function emptyResult(info: NativeGeneratorInfo): Instr[] {
     { op: "i32.const", value: 1 },
     { op: "struct.new", typeIdx: info.resultTypeIdx },
   ];
+}
+
+// (#2864 F1b) The inert default a spill field is constructed with, by ValType.
+// Overwritten by the body's declaration on first entry into the owning state, so
+// it only has to satisfy `struct.new`'s field type. Mirrors `defaultElemValueInstr`
+// but spans the full set of supported spill kinds.
+function defaultSpillInstr(type: ValType): Instr {
+  switch (type.kind) {
+    case "f64":
+      return { op: "f64.const", value: NaN };
+    case "i32":
+      return { op: "i32.const", value: 0 };
+    case "i64":
+      return { op: "i64.const", value: 0n } as Instr;
+    case "externref":
+      return { op: "ref.null.extern" } as Instr;
+    default:
+      return { op: "ref.null", typeIdx: (type as { typeIdx: number }).typeIdx } as Instr;
+  }
 }
 
 function emptyResultForType(resultTypeIdx: number): Instr[] {
@@ -1812,9 +1867,13 @@ export function ensureNativeGeneratorResumeFunction(ctx: CodegenContext, info: N
     resumeFctx.body.push({ op: "local.set", index: localIdx });
   }
 
-  // Load spills into locals.
+  // Load spills into locals. (#2864 F1b) The load local is minted at the spill's
+  // actual ValType so the `struct.get` (of the same-typed field) round-trips. The
+  // body's var-declaration reuses this exact slot (it is already in `localMap`),
+  // and because the resume fctx carries no analysis caches, its computed type
+  // equals `resolveSpillLocalValType` → no slot re-type, no mismatch.
   for (let i = 0; i < info.spillNames.length; i++) {
-    const localIdx = allocLocal(resumeFctx, info.spillNames[i]!, { kind: "f64" });
+    const localIdx = allocLocal(resumeFctx, info.spillNames[i]!, info.spillTypes[i]!);
     resumeFctx.body.push({ op: "local.get", index: 0 });
     resumeFctx.body.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.spillFieldOffset + i });
     resumeFctx.body.push({ op: "local.set", index: localIdx });
@@ -1834,6 +1893,32 @@ export function ensureNativeGeneratorResumeFunction(ctx: CodegenContext, info: N
       resumeFctx.body.push(...emitTrampoline(ctx, resumeFctx, info, plan, 0, resultLocal));
     } finally {
       ctx.currentFunc = savedFunc;
+    }
+  }
+
+  // (#2864 F1b) Reconcile each spill's struct field with the FINAL type its
+  // resume-function local settled on. The body's var-declaration reuses the
+  // pre-allocated spill slot and may re-type it (e.g. a predicted `ref_null`
+  // narrowed by the declaration to a non-null `ref`); a non-null ref has no
+  // struct-construction default and would not round-trip through `struct.get`,
+  // so widen it back to `ref_null` and pin BOTH the local slot and the spill
+  // field (+ `info.spillTypes`, which the constructor's init default reads) to
+  // that common type. This runs before any `struct.new` of the state struct —
+  // the constructor (`compileNativeGeneratorFunction`) calls this function
+  // first — so the init defaults observe the reconciled types.
+  const stateStruct = ctx.mod.types[info.stateTypeIdx];
+  for (let i = 0; i < info.spillNames.length; i++) {
+    const localIdx = resumeFctx.localMap.get(info.spillNames[i]!);
+    if (localIdx === undefined || localIdx < resumeFctx.params.length) continue;
+    const slot = resumeFctx.locals[localIdx - resumeFctx.params.length];
+    if (!slot) continue;
+    let finalType = slot.type;
+    if (finalType.kind === "ref") finalType = { kind: "ref_null", typeIdx: finalType.typeIdx };
+    slot.type = finalType;
+    info.spillTypes[i] = finalType;
+    if (stateStruct && stateStruct.kind === "struct") {
+      const field = stateStruct.fields[info.spillFieldOffset + i];
+      if (field) field.type = finalType;
     }
   }
 
@@ -1870,8 +1955,12 @@ export function compileNativeGeneratorFunction(
   for (let i = 0; i < info.paramTypes.length; i++) {
     fctx.body.push({ op: "local.get", index: i });
   }
+  // (#2864 F1b) Spill slots start at their type's inert default — `f64 NaN`
+  // (numeric, unchanged), `i32`/`i64` 0, a null ref for object/string spills, or
+  // a null externref for boxed-any spills — so the `struct.new` typechecks before
+  // the body's declaration overwrites the slot on first entry.
   for (let i = 0; i < info.spillNames.length; i++) {
-    fctx.body.push({ op: "f64.const", value: NaN });
+    fctx.body.push(defaultSpillInstr(info.spillTypes[i]!));
   }
   // (#2170) `yield*` delegation slots start null — the inner generator is
   // materialized lazily on first entry into the yield-star state.

--- a/src/codegen/statements/variables.ts
+++ b/src/codegen/statements/variables.ts
@@ -124,6 +124,99 @@ function localTypeForDeclaration(ctx: CodegenContext, type: ts.Type, decl?: ts.V
   return resolveWasmType(ctx, type);
 }
 
+/**
+ * (#2864 F1b) Resolve the wasm ValType a body-local would receive **in the
+ * native-generator resume function**, so the generator's spill field, its
+ * resume-load local, and the state-struct init default can all be minted at the
+ * local's actual type (object / string / typed-struct locals carried across a
+ * `yield`), not the historical f64.
+ *
+ * The resume function compiles the generator body with a FRESH FunctionContext
+ * whose analysis caches (`i32CoercedLocals`, `i32SpecializedArrays`,
+ * `pendingStringBuilders`, …) are empty and whose locals never resolve to a
+ * module global (the spill is always a local shadow). So the type the resume
+ * var-declaration computes reduces to the **fctx-independent** subset of the
+ * `compileVariableStatement` cascade: the ctx/AST externref-forcing overrides
+ * plus `localTypeForDeclaration`. This helper replicates exactly that subset and
+ * returns `null` for any form whose representation the up-front spill layout
+ * cannot match (the caller then keeps the whole generator on the host path — a
+ * conservative, non-regressing bail). Returning `null` for non-nullable `ref`
+ * types is deliberate: the state-struct field needs a valid default value at
+ * construction, and only `ref_null` refs have one (`ref.null`).
+ */
+export function resolveSpillLocalValType(ctx: CodegenContext, decl: ts.VariableDeclaration): ValType | null {
+  if (!ts.isIdentifier(decl.name)) return null;
+  const name = decl.name.text;
+  // Names the main-body analysis already routed to a host / externref slot
+  // (accessor literal, host-spread literal, growable / out-of-shape object).
+  if (ctx.externrefAccessorVars.has(name)) return { kind: "externref" };
+  if (ctx.growableObjectLiteralVars.has(name)) return { kind: "externref" };
+  // A var whose properties were widened (empty-obj + later prop writes) gets a
+  // synthesized struct; mirror it if the struct is registered, else bail.
+  const widenedStructName = ctx.widenedVarStructMap.get(name);
+  if (widenedStructName !== undefined) {
+    const idx = ctx.structMap.get(widenedStructName);
+    return idx === undefined ? null : { kind: "ref_null", typeIdx: idx };
+  }
+  const init = decl.initializer;
+  if (init) {
+    if (ts.isObjectLiteralExpression(init)) {
+      const forcesHostObject = init.properties.some(
+        (p) =>
+          ts.isGetAccessorDeclaration(p) ||
+          ts.isSetAccessorDeclaration(p) ||
+          (ts.isMethodDeclaration(p) && ts.isComputedPropertyName(p.name)) ||
+          (ts.isPropertyAssignment(p) && p.name !== undefined && ts.isComputedPropertyName(p.name)),
+      );
+      if (forcesHostObject) return { kind: "externref" };
+      if (objectLiteralSpreadTakesHostPath(ctx, init)) return { kind: "externref" };
+    }
+    if (isProxyConstruction(init)) return { kind: "externref" };
+    // Representations the var-decl path computes from a decl/receiver-driven
+    // inference that diverges from resolveWasmType — defer to the host path.
+    if (inferStandaloneRegExpMatchArrayType(ctx, init) !== null) return null;
+    const unwrapped = stripInferenceWrapper(init);
+    if (
+      ts.isCallExpression(unwrapped) &&
+      ts.isPropertyAccessExpression(unwrapped.expression) &&
+      unwrapped.expression.name.text === "subarray"
+    ) {
+      return null;
+    }
+    if (isPromiseHostCall(ctx, init) || isBindHostCall(init) || isStringMethodReturningHostArray(ctx, init)) {
+      return null;
+    }
+  }
+  const varType = ctx.checker.getTypeAtLocation(decl);
+  // Array<any> takes a decl-driven vec inference (inferArrayVecType) ≠ the
+  // generic resolveWasmType vec — defer.
+  if (varType.flags & ts.TypeFlags.Object) {
+    const sym = (varType as ts.TypeReference).symbol ?? varType.symbol;
+    if (sym?.name === "Array") {
+      const typeArgs = ctx.checker.getTypeArguments(varType as ts.TypeReference);
+      if (typeArgs?.[0] && typeArgs[0].flags & ts.TypeFlags.Any) return null;
+    }
+  }
+  const t = localTypeForDeclaration(ctx, varType, decl);
+  switch (t.kind) {
+    case "f64":
+    case "i32":
+    case "i64":
+    case "externref":
+    case "ref_null":
+      return t;
+    // A non-nullable `ref` has no struct-construction default and a wasm local is
+    // widened to nullable anyway, so carry it as `ref_null` — the same type the
+    // resume var-declaration's slot settles on (the spill field, load local, and
+    // init default then all agree; reads `struct.get` a nullable ref, which is
+    // valid and traps-on-null exactly as the source semantics require).
+    case "ref":
+      return { kind: "ref_null", typeIdx: t.typeIdx };
+    default:
+      return null;
+  }
+}
+
 function stripInferenceWrapper(expr: ts.Expression): ts.Expression {
   while (
     ts.isParenthesizedExpression(expr) ||

--- a/tests/issue-2864-standalone-generator-carrier.test.ts
+++ b/tests/issue-2864-standalone-generator-carrier.test.ts
@@ -121,3 +121,84 @@ export function test(): number { let s = 0; for (const x of g()) s += x; return 
     ).toBe(6);
   });
 });
+
+// #2864 F1b — typed live-across-yield LOCAL spills. F1 spilled only f64 (numeric)
+// or a uniform native-string ref; a generator with an OBJECT / STRING / typed
+// local carried across a `yield` either mis-compiled (the f64 spill field could
+// not hold a `ref`) or bailed to the host path. F1b types each spill field at the
+// local's ACTUAL ValType (resolved by `resolveSpillLocalValType`, mirroring the
+// resume function's var-declaration), so the value survives the frame host-free.
+describe("#2864 F1b typed live-across-yield local spills (standalone)", () => {
+  it("verify-first: object local carried across a yield, host-free + correct", async () => {
+    // The exact case from the issue: `function* g(){ let o={n:1}; yield 1; yield o.n }`.
+    expect(
+      await runStandalone(`function* g() { let o = {n:1}; yield 1; yield o.n; }
+export function test(): number {
+  let it = g();
+  let a = it.next().value as number;
+  let b = it.next().value as number;
+  return a + b; // 1 + 1 — the object survived the suspension and o.n read back
+}`),
+    ).toBe(2);
+  });
+
+  it("string local carried across a yield in a numeric generator", async () => {
+    expect(
+      await runStandalone(`function* g() { let s = "abc"; yield 1; yield s.length; }
+export function test(): number {
+  let it = g();
+  let a = it.next().value as number;
+  let b = it.next().value as number;
+  return a + b; // 1 + 3
+}`),
+    ).toBe(4);
+  });
+
+  it("object yield carrier WITH an object local spill (both externref)", async () => {
+    expect(
+      await runStandalone(`function* g() { let o = {a:1}; yield {a:10}; yield o; }
+export function test(): number {
+  let it = g();
+  let r1 = it.next().value as any;
+  let r2 = it.next().value as any;
+  return r1.a + r2.a; // 10 + 1
+}`),
+    ).toBe(11);
+  });
+
+  it("loop-carried object spill consumed via for-of, host-free", async () => {
+    expect(
+      await runStandalone(`function* g() {
+  let base = {a:5};
+  let i = 0;
+  while (i < 2) { yield {a: base.a + i}; i = i + 1; }
+}
+export function test(): number {
+  let s = 0;
+  for (const o of g()) { s += (o as any).a; }
+  return s; // (5+0) + (5+1) = 11
+}`),
+    ).toBe(11);
+  });
+
+  it("numeric local spill stays on the f64 fast path (unchanged)", async () => {
+    expect(
+      await runStandalone(`function* g() { let n = 5; yield 1; yield n; }
+export function test(): number {
+  let it = g();
+  return (it.next().value as number) + (it.next().value as number); // 1 + 5
+}`),
+    ).toBe(6);
+  });
+
+  it("typed-numeric .next(v) resume binding carried across a yield", async () => {
+    expect(
+      await runStandalone(`function* g(): Generator<number, void, number> { let x = yield 1; yield x + 10; }
+export function test(): number {
+  let it = g();
+  it.next();
+  return it.next(5).value as number; // 5 + 10
+}`),
+    ).toBe(15);
+  });
+});


### PR DESCRIPTION
## #2864 F1b — typed live-across-yield LOCAL spills

F1 (boxed-any carrier) only flipped ~6 of the 697 sync-gen standalone failures; the bulk is gated on **typed live-across-yield local spills**. F1 spilled only f64 (numeric) or a uniform native-string ref — a generator carrying an **object/string/typed LOCAL** across a `yield` either mis-compiled (the f64 spill field can't hold a `ref` → wasm validation error `local.set expected (ref null N), found struct.get of type f64`) or bailed to the host path.

F1b types each spill's **field, resume-load local, and `struct.new` init default** at the local's actual ValType.

### Verify-first (`--target standalone`)
`function* g(){ let o={n:1}; yield 1; yield o.n }` read via `.next().value`:
- **before:** CE-refused (#680) / mis-compiled on `main`
- **after:** host-free (`result.imports` empty) and returns `2`

Also host-free + correct: numeric/string local spills, an object-yield carrier WITH an object local spill, loop-carried object spills drained via `for-of`, and typed-numeric `.next(v)` resume bindings.

### Approach (root-cause)
- `resolveSpillLocalValType` (new, `variables.ts`) mirrors the resume function's var-declaration type — the resume fctx has empty analysis caches, so the type reduces to the fctx-independent subset of the var-decl cascade (ctx/AST externref overrides + `localTypeForDeclaration`). Returns `null` for any unmatchable form → the whole generator bails to host (conservative, non-regressing).
- Non-null `ref` widened to `ref_null` (no `struct.new` default otherwise; wasm locals are nullable anyway).
- **Post-emission reconcile** pins each spill's struct field to the FINAL local type the body settled on, before any `struct.new` — so prediction can't diverge from emission.
- Retired the F1 `elemIsAny && spills>0` and string-elem spill guards (subsumed).
- Any-carrier `.next(v)` resume bindings still bail (boxed-any sent-value member reads need #2151) — a CE-refusal beats a wrong answer.

### Acceptance
- gc-mode unchanged: the native path is gated `noJsHostTarget` (standalone/wasi only).
- numeric spills byte-identical (f64).
- `tests/issue-2864-standalone-generator-carrier.test.ts`: 14/14 (8 F1 + 6 new F1b), zero-host-import asserted.

Issue stays `in-progress` (F2 try/finally-across-yield, F3 yield* remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)