### PR TITLE
fix(#2891): standalone ToPrimitive valueOf→toString fall-through in operators

### DIFF
--- a/plan/issues/2891-standalone-toprimitive-valueof-object-fallthrough.md
+++ b/plan/issues/2891-standalone-toprimitive-valueof-object-fallthrough.md
@@ -1,0 +1,151 @@
+---
+id: 2891
+title: "Standalone: ToPrimitive on a nominal struct accepts an object-returning valueOf — no valueOf→toString fall-through / no §7.1.1.1 TypeError"
+status: done
+completed: 2026-06-30
+assignee: ttraenkler/sendev-toprim-ops
+created: 2026-06-30
+priority: high
+task_type: bug
+area: codegen
+goal: standalone
+sprint: current
+horizon: m
+related: [2873, 2862, 2638, 1900]
+umbrella: 2860
+---
+
+# Standalone: object-operand relational/additive coercion drops the valueOf→toString fall-through
+
+## Problem (verify-first, `--target standalone`, current main)
+
+The dominant residual of #2873 `language/expressions` is object-operand
+relational/additive coercion where `valueOf` returns a **non-primitive**
+(an object). Real test262 reproductions (host pass / standalone fail):
+
+- `language/expressions/less-than/S11.8.1_A2.2_T1.js` — `1 < {valueOf:()=>({}),
+toString:()=>2}` should be `true`; standalone yields the wrong value.
+- `language/expressions/addition/S11.6.1_A2.2_T1.js` — `1 + {valueOf:()=>({}),
+toString:()=>({})}` must throw a TypeError (§7.1.1.1 step-6); standalone
+  returns `NaN` (no throw).
+- `greater-than/S11.8.2_A2.2_T1.js`, etc. share the signature.
+
+(The runner reports these as `"Cannot convert object to primitive value"`,
+which is the #2862 JS-host runner-formatter artifact masking the REAL
+in-Wasm failure — a wrong comparison value / missing TypeError, NOT an
+in-Wasm ToPrimitive throw. Verified host-free.)
+
+Minimal host-free repros (`result.imports` empty):
+
+- `1 < {valueOf:function(){return {}}, toString:function(){return 2}}` → `false` (want `true`).
+- `1 + {valueOf:function(){return {}}, toString:function(){return {}}}` → `NaN` (want TypeError).
+
+## Root cause
+
+Statically-typed object literals stay nominal WasmGC structs. When the
+inlined `valueOf` returns a ref (object), the static `ref→f64`/`ref→string`
+coercion path (`type-coercion.ts`) correctly delegates to the runtime
+`__to_primitive` engine, whose non-`$Object` arm routes the struct through
+`__class_to_primitive` (`src/codegen/class-to-primitive.ts`, #2638), which
+dispatches the per-struct `__call_valueOf` / `__call_toString` exports.
+
+`fillClassToPrimitive` accepted the FIRST dispatcher's **non-null** result as
+"a primitive was produced" — but `boxResult` for a ref/ref_null-returning
+method does `extern.convert_any`, returning the **object itself** as a
+non-null externref. So a `valueOf` that returns an object short-circuits the
+driver: it returns the object, `__to_primitive`'s `returnIfPrimitive` then
+rejects it, and the engine returns the struct unchanged → `__unbox_number` →
+`NaN`. §7.1.1.1's "if the result is not primitive, try the next method" step
+is skipped, and the both-objects TypeError is never thrown.
+
+## Fix (standalone-only — GC/host path is untouched; driver is reserved only
+
+under `ctx.standalone`)
+
+Rewrite `fillClassToPrimitive` to implement §7.1.1.1 OrdinaryToPrimitive over
+the dispatchers, **sequentially** (preserving method call ordering + side
+effects, so a throwing `valueOf`/`toString` propagates correctly):
+
+- Call the hint-ordered first method; if its result is non-null AND a
+  primitive (`__typeof_number`/`__typeof_boolean`/`__typeof_string`), return it.
+- Else call the second method; same primitive check.
+- Neither produced a primitive — classify by **presence** to model the
+  inherited `Object.prototype` methods that standalone does not materialize:
+  - inherited `valueOf` returns the object (non-primitive);
+  - inherited `toString` returns `"[object Object]"` (a primitive string).
+  - number/default hint: valueOf-present-object + toString-absent →
+    `"[object Object]"`; both present-object (or valueOf-absent +
+    toString-present-object) → **TypeError**; both absent → unchanged.
+  - string hint: toString-absent → `"[object Object]"`; toString-present-object
+    - (valueOf present-object or absent) → **TypeError**.
+
+## Test plan / acceptance
+
+- `1 < {valueOf:()=>({}), toString:()=>2}` → `true`, host-free (`imports`
+  empty); `1 + {both objects}` → TypeError, host-free.
+- GC/host unchanged; 0 regressions; full `merge_group` + honest
+  standalone-floor.
+- NOTE: the bundled `_A2.2_T1` test262 files do NOT fully flip yet — see the
+  "Residual" section (orthogonal `#7`/`#8` forked-closure + `instanceof`
+  sub-problems, already failing on main).
+
+## Outcome (2026-06-30, sendev-toprim-ops)
+
+Implemented two standalone-only changes (GC binary byte-identical — verified
+3028 bytes on main and fix for the repro):
+
+1. **`fillClassToPrimitive`** (`src/codegen/class-to-primitive.ts`) — rewritten
+   to do §7.1.1.1 sequentially: each dispatcher result is accepted only if it is
+   a PRIMITIVE (`__typeof_number`/`__typeof_boolean`/`__typeof_string`); an
+   object-returning method falls through to the next; the both-objects (or
+   inherited-valueOf-object + present-toString-object) case throws the
+   §7.1.1.1 TypeError, while valueOf-present-object + toString-absent yields the
+   inherited `"[object Object]"`.
+2. **`emitToPrimitiveMethodExports`** (`src/codegen/index.ts`) — single-literal
+   object-method structs now get `__call_valueOf`/`__call_toString` entries in
+   standalone (was forked-only), via a new GUARDED `closure-eqref-multi` dispatch
+   that `ref.test`s both the candidate closure STRUCT type AND its funcref type
+   before `call_ref` — avoiding the wrong-field-cast trap that previously
+   justified gating single literals out.
+
+Verified host-free (`imports` empty) on current main → fixed:
+
+- `1 < {valueOf:()=>({}), toString:()=>2}` → `true` (was wrong/`false`).
+- `1 < {valueOf:()=>({}), toString:()=>(x+1)}` (non-const) → `true`.
+- `1 + {valueOf:()=>({}), toString:()=>1}` → `2`; valueOf-primitive wins over
+  toString.
+- `1 + {both objects}` → throws (§7.1.1.1 TypeError).
+- class-instance `1 < (new C() as any)` with `valueOf(){return {}}; toString(){return 2}` → `true` (was `false`).
+
+Regression checks: 60/60 existing ToPrimitive-suite tests pass (the 2 failures in
+issue-1900 / issue-2679 are PRE-EXISTING on main — a stale Symbol-deferred
+assertion and a `wasm:js-string` host-instantiate wiring artifact). Diverse
+standalone sample: 0 regressions. New: `tests/issue-2891-standalone-toprimitive-operators.test.ts`.
+
+## Residual — blocks the full `_A2.2_T1` test262 flip (route to architect / #2862)
+
+The `language/expressions/**/_A2.2_T1.js` files still report FAIL standalone
+because each bundles two ORTHOGONAL hard sub-problems that this coercion fix does
+NOT address (and which were already failing on main — not regressions):
+
+- **#7-style: exception thrown from `valueOf` + forked closure dispatch.** When a
+  throwing-`valueOf` literal (`function(){throw "error"}`) shares a struct shape
+  with a later both-objects literal, `__call_valueOf`/`__call_toString` start
+  returning `null` for the both-objects instance (all candidate guards miss),
+  so its §7.1.1.1 TypeError is not thrown. Isolated, `#7` and `#8` each pass;
+  only the `#7`-then-`#8` sequence regresses the dispatch. This is a
+  forked-closure-type-tracking correctness gap in `valueOfClosureTypes` /
+  `closure-eqref-multi`. (`String`-thrown exception propagation through the
+  inlined `valueOf` call path also belongs here.)
+- **#8-style: standalone `instanceof TypeError`** for the caught native error.
+
+These overlap the `#2862` `architect_spec: candidate` substrate (value-rep
+classifier + forked-closure dispatch). They want a design pass, not a point fix.
+
+## Out of scope (separate follow-ups)
+
+- `any`-typed object additive (`(o:any) + 1` where `o={valueOf:()=>1}`) routes
+  through `__any_add`, which blindly treats a tag-6 object operand as
+  string-concat (`__extern_toString`) instead of `ToPrimitive(default)`-reducing
+  it first — a distinct helper bug (file separately if it survives this fix).
+  </content>

--- a/src/codegen/class-to-primitive.ts
+++ b/src/codegen/class-to-primitive.ts
@@ -42,6 +42,8 @@
 import type { CodegenContext } from "./context/types.js";
 import type { Instr, WasmFunction } from "../ir/types.js";
 import { addFuncType } from "./registry/types.js";
+import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
+import { stringConstantExternrefInstrs } from "./native-strings.js";
 
 export const CLASS_TO_PRIMITIVE = "__class_to_primitive";
 
@@ -128,46 +130,197 @@ export function fillClassToPrimitive(ctx: CodegenContext): void {
 
   const L_OBJ = 0; // externref param: the candidate class instance
   const L_HINT = 1; // i32 param: 1 = string hint, 0 = number/default
-  const L_RESULT = 2; // externref scratch
+  const L_RV = 2; // externref: valueOf dispatcher result
+  const L_RS = 3; // externref: toString dispatcher result
 
-  // Call a dispatcher (by funcIdx) on the obj; tee into result; if non-null,
-  // return it. When the dispatcher is absent (only one of the two methods is
-  // present anywhere in the module), skip that arm.
-  const tryDispatcher = (idx: number | undefined): Instr[] => {
-    if (idx === undefined) return [];
+  // (#2891) §7.1.1.1 OrdinaryToPrimitive requires "if the method result is not
+  // a primitive, try the next method", and a §7.1.1.1 step-6 TypeError when none
+  // yields a primitive. The per-struct `__call_valueOf`/`__call_toString`
+  // dispatchers return `ref.null.extern` when the object has no such OWN method,
+  // but for a method that RETURNS an object they `boxResult` it via
+  // `extern.convert_any` — a NON-null externref that is still an object. The old
+  // "first non-null wins" tail therefore accepted an object-returning `valueOf`
+  // and skipped the fall-through to `toString` (wrong relational/additive value)
+  // and never threw the both-objects TypeError. We now classify each dispatcher
+  // result as primitive (number/boolean/string) vs object, falling through and
+  // modelling the (un-materialized in standalone) inherited Object.prototype
+  // methods: inherited `valueOf` returns the object (non-primitive); inherited
+  // `toString` returns "[object Object]" (a primitive string). Standalone-only —
+  // the driver is reserved only under `ctx.standalone`, so GC/host is untouched.
+  const typeofNumberIdx = ctx.funcMap.get("__typeof_number");
+  const typeofBooleanIdx = ctx.funcMap.get("__typeof_boolean");
+  const typeofStringIdx = ctx.funcMap.get("__typeof_string");
+  const typeErrorCtorIdx = ctx.funcMap.get("__new_TypeError");
+
+  // If the primitive-classification or TypeError machinery is unavailable for
+  // some reason, fall back to the pre-#2891 "first non-null wins" behaviour so
+  // we never emit invalid code (these are always present in the standalone
+  // `__to_primitive` build that reserves this driver).
+  if (typeofNumberIdx === undefined || typeofStringIdx === undefined || typeErrorCtorIdx === undefined) {
+    const tryDispatcher = (idx: number | undefined): Instr[] => {
+      if (idx === undefined) return [];
+      return [
+        { op: "local.get", index: L_OBJ },
+        { op: "call", funcIdx: idx },
+        { op: "local.tee", index: L_RV },
+        { op: "ref.is_null" },
+        { op: "i32.eqz" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [{ op: "local.get", index: L_RV }, { op: "return" }],
+        } as Instr,
+      ];
+    };
+    fn.locals = [{ name: "rv", type: { kind: "externref" } }];
+    fn.body = [
+      { op: "local.get", index: L_HINT },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [...tryDispatcher(callToStringIdx), ...tryDispatcher(callValueOfIdx)],
+        else: [...tryDispatcher(callValueOfIdx), ...tryDispatcher(callToStringIdx)],
+      } as Instr,
+      { op: "local.get", index: L_OBJ },
+    ];
+    return;
+  }
+
+  const exnTagIdx = ensureExnTag(ctx);
+  const OBJECT_TAG = "[object Object]";
+  const TYPE_ERR_MSG = "Cannot convert object to primitive value";
+  addStringConstantGlobal(ctx, OBJECT_TAG);
+  addStringConstantGlobal(ctx, TYPE_ERR_MSG);
+
+  // i32: 1 when the externref in `localIdx` is a primitive (number/boolean/
+  // string), 0 otherwise (an object). `null` is handled by the caller via a
+  // separate `ref.is_null` presence test, so it never reaches here.
+  const isPrimitive = (localIdx: number): Instr[] => {
+    const parts: Instr[] = [
+      { op: "local.get", index: localIdx },
+      { op: "call", funcIdx: typeofNumberIdx },
+    ];
+    if (typeofBooleanIdx !== undefined) {
+      parts.push({ op: "local.get", index: localIdx }, { op: "call", funcIdx: typeofBooleanIdx }, { op: "i32.or" });
+    }
+    parts.push({ op: "local.get", index: localIdx }, { op: "call", funcIdx: typeofStringIdx }, { op: "i32.or" });
+    return parts;
+  };
+
+  const returnObjectTag: Instr[] = [...stringConstantExternrefInstrs(ctx, OBJECT_TAG), { op: "return" } as Instr];
+  const throwTypeError: Instr[] = [
+    ...stringConstantExternrefInstrs(ctx, TYPE_ERR_MSG),
+    { op: "call", funcIdx: typeErrorCtorIdx } as Instr,
+    { op: "throw", tagIdx: exnTagIdx } as Instr,
+  ];
+
+  // Call a dispatcher, store into `dst`; if the result is a non-null PRIMITIVE,
+  // return it. Leaves the (possibly null/object) result in `dst` for the caller
+  // to classify by presence afterwards. Absent dispatcher → store null.
+  const callAndReturnIfPrimitive = (idx: number | undefined, dst: number): Instr[] => {
+    if (idx === undefined) {
+      return [{ op: "ref.null.extern" } as Instr, { op: "local.set", index: dst }];
+    }
     return [
       { op: "local.get", index: L_OBJ },
       { op: "call", funcIdx: idx },
-      { op: "local.tee", index: L_RESULT },
+      { op: "local.set", index: dst },
+      // present (non-null) ?
+      { op: "local.get", index: dst },
       { op: "ref.is_null" },
       { op: "i32.eqz" },
       {
         op: "if",
         blockType: { kind: "empty" },
-        then: [{ op: "local.get", index: L_RESULT }, { op: "return" }],
+        then: [
+          ...isPrimitive(dst),
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [{ op: "local.get", index: dst }, { op: "return" }],
+          } as Instr,
+        ],
       } as Instr,
     ];
   };
 
-  // string hint → toString first; number/default → valueOf first.
-  const body: Instr[] = [
-    {
-      op: "local.get",
-      index: L_HINT,
-    },
+  const presentNonNull = (localIdx: number): Instr[] => [
+    { op: "local.get", index: localIdx },
+    { op: "ref.is_null" },
+    { op: "i32.eqz" },
+  ];
+
+  // number / default hint: valueOf → toString.
+  const numberHint: Instr[] = [
+    ...callAndReturnIfPrimitive(callValueOfIdx, L_RV),
+    ...callAndReturnIfPrimitive(callToStringIdx, L_RS),
+    // Neither own method produced a primitive. Classify by presence.
+    ...presentNonNull(L_RV), // valueOf present & object?
     {
       op: "if",
       blockType: { kind: "empty" },
-      // string hint: toString → valueOf
-      then: [...tryDispatcher(callToStringIdx), ...tryDispatcher(callValueOfIdx)],
-      // number / default hint: valueOf → toString
-      else: [...tryDispatcher(callValueOfIdx), ...tryDispatcher(callToStringIdx)],
+      // valueOf present & object
+      then: [
+        ...presentNonNull(L_RS), // toString present & object?
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          // both present-object → §7.1.1.1 TypeError
+          then: throwTypeError,
+          // toString absent → inherited Object.prototype.toString → "[object Object]"
+          else: returnObjectTag,
+        } as Instr,
+      ],
+      // valueOf absent → inherited valueOf returns the object (non-primitive)
+      else: [
+        ...presentNonNull(L_RS), // toString present & object?
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          // valueOf inherited-object + toString present-object → TypeError
+          then: throwTypeError,
+          // both absent → fall through to the shared "return input unchanged" tail
+          else: [],
+        } as Instr,
+      ],
     } as Instr,
-    // Neither matched (class without valueOf/toString) → return the input
-    // unchanged, exactly as the pre-#2638 "return input unchanged" tail did.
-    { op: "local.get", index: L_OBJ },
   ];
 
-  fn.locals = [{ name: "result", type: { kind: "externref" } }];
-  fn.body = body;
+  // string hint: toString → valueOf. Inherited toString yields the primitive
+  // "[object Object]", so an ABSENT toString resolves to it as the FIRST method.
+  const stringHint: Instr[] = [
+    ...callAndReturnIfPrimitive(callToStringIdx, L_RS),
+    // toString absent → inherited toString → "[object Object]" (primitive, first)
+    ...presentNonNull(L_RS),
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      // toString present & object → try valueOf next
+      then: [
+        ...callAndReturnIfPrimitive(callValueOfIdx, L_RV),
+        // valueOf absent (inherited → object) or present-object → both object → TypeError
+        ...throwTypeError,
+      ],
+      // toString absent → default Object.prototype.toString
+      else: returnObjectTag,
+    } as Instr,
+  ];
+
+  fn.locals = [
+    { name: "rv", type: { kind: "externref" } },
+    { name: "rs", type: { kind: "externref" } },
+  ];
+  fn.body = [
+    { op: "local.get", index: L_HINT },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: stringHint,
+      else: numberHint,
+    } as Instr,
+    // Shared tail: reached only when BOTH methods are absent (number hint) —
+    // a nominal struct with no valueOf/toString → return the input unchanged,
+    // exactly as the pre-#2638 fall-through did (no regression).
+    { op: "local.get", index: L_OBJ },
+  ];
 }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -4409,6 +4409,25 @@ function emitToPrimitiveMethodExports(ctx: CodegenContext): void {
           fieldIdx: number;
           closureTypeIdx: number;
           closureInfo: ClosureInfo;
+        }
+      | {
+          // (#2891) eqref closure field, GUARDED multi-candidate dispatch. A
+          // single-literal object struct stores its `valueOf`/`toString` method
+          // as a per-instance closure in an `eqref` field, but
+          // `ctx.valueOfClosureTypes` accumulates the closure types of BOTH
+          // fields, so a fixed "first tracked type" pick (the legacy eqref arm)
+          // can `ref.cast` the WRONG field's closure type and TRAP. We instead
+          // `ref.test` each candidate closure type on the actual stored field
+          // value and `call_ref` the one that matches (null if none) — trap-free.
+          // This is what lets standalone reduce a single-literal object operand
+          // (the pre-#2891 code gated single literals out for exactly this trap
+          // risk). Standalone-only widening; the host `_hostToPrimitive` path is
+          // unchanged (it stays on the name-keyed arm).
+          structName: string;
+          typeIdx: number;
+          mode: "closure-eqref-multi";
+          fieldIdx: number;
+          candidates: { closureTypeIdx: number; closureInfo: ClosureInfo }[];
         };
 
     const entries: DispatchEntry[] = [];
@@ -4442,7 +4461,14 @@ function emitToPrimitiveMethodExports(ctx: CodegenContext): void {
       // in `_hostToPrimitive`. Same-shape valueOf/toString closures are
       // `ref.test`-indistinguishable, so routing a single-literal struct through
       // the per-instance arm could mis-select the closure type for `toString`.
-      const preferClosure = ctx.toPrimitiveForkedStructs.has(structName);
+      const forked = ctx.toPrimitiveForkedStructs.has(structName);
+      // (#2891) In STANDALONE, also route single-literal closure-method structs
+      // through the per-instance closure arm — there is no host `_hostToPrimitive`
+      // to fall back on, so the name-keyed arm (which collapses same-shape
+      // literals AND cannot model the §7.1.1.1 object-return fall-through) is not
+      // enough. The eqref path below is GUARDED (`closure-eqref-multi`), so the
+      // trap that previously justified gating single literals out is avoided.
+      const preferClosure = forked || ctx.standalone;
       let pushedClosure = false;
       if (field && preferClosure) {
         // Closure ref field (eagerly-typed closure ref).
@@ -4454,16 +4480,22 @@ function emitToPrimitiveMethodExports(ctx: CodegenContext): void {
             pushedClosure = true;
           }
         }
-        // eqref field — try tracked closure types (typed object-literal methods).
+        // eqref field — GUARDED multi-candidate dispatch over the tracked closure
+        // types (typed object-literal methods). `ref.test` selects the closure
+        // type actually stored in THIS field, so accumulating both valueOf and
+        // toString closure types in `valueOfClosureTypes` can no longer mis-cast.
         if (!pushedClosure && field.type.kind === "eqref") {
           const trackedTypes = ctx.valueOfClosureTypes.get(structName) ?? [];
+          const candidates: { closureTypeIdx: number; closureInfo: ClosureInfo }[] = [];
           for (const closureTypeIdx of trackedTypes) {
             const closureInfo = ctx.closureInfoByTypeIdx.get(closureTypeIdx);
             if (closureInfo && closureInfo.paramTypes.length === 0) {
-              entries.push({ structName, typeIdx, mode: "closure", fieldIdx, closureTypeIdx, closureInfo });
-              pushedClosure = true;
-              break;
+              candidates.push({ closureTypeIdx, closureInfo });
             }
+          }
+          if (candidates.length > 0) {
+            entries.push({ structName, typeIdx, mode: "closure-eqref-multi", fieldIdx, candidates });
+            pushedClosure = true;
           }
         }
         // (#1989) externref field holding a closure — the `any`-typed
@@ -4571,6 +4603,67 @@ function emitToPrimitiveMethodExports(ctx: CodegenContext): void {
         } else {
           boxResult(ci.returnType, thenInstrs);
         }
+      } else if (entry.mode === "closure-eqref-multi") {
+        // (#2891) GUARDED dispatch over candidate closure types for an eqref
+        // method field. Read the field once into the eqref scratch, then
+        // `ref.test` each candidate and `call_ref` the matching one (null if
+        // none) — never an unguarded `ref.cast`, so the wrong-field-type trap is
+        // impossible.
+        const closureLocal = 2; // eqref scratch local (the stored method closure)
+        const fieldEntry = entry;
+        const buildCandidate = (ci: number): Instr[] => {
+          if (ci >= fieldEntry.candidates.length) return [{ op: "ref.null.extern" } as Instr];
+          const { closureTypeIdx, closureInfo } = fieldEntry.candidates[ci]!;
+          // Body run when BOTH the struct cast and the funcref type match.
+          const callInstrs: Instr[] = [
+            // self-param: the closure struct (cast is safe — struct ref.test passed)
+            { op: "local.get", index: closureLocal } as Instr,
+            { op: "ref.cast", typeIdx: closureTypeIdx },
+            // funcref already validated + stashed in eqrefFuncLocal
+            { op: "local.get", index: eqrefFuncLocal } as Instr,
+            { op: "ref.cast", typeIdx: closureInfo.funcTypeIdx },
+            { op: "call_ref", typeIdx: closureInfo.funcTypeIdx } as Instr,
+          ];
+          if (!closureInfo.returnType) {
+            callInstrs.push({ op: "ref.null.extern" } as Instr);
+          } else {
+            boxResult(closureInfo.returnType, callInstrs);
+          }
+          // Guard 1: the stored closure must be (a subtype of) this candidate's
+          // struct type. Guard 2: its funcref (field 0) must be this candidate's
+          // func type — distinct methods can share a struct type but differ in
+          // func type, so the funcref test is the real discriminator (an
+          // unguarded `ref.cast funcTypeIdx` would TRAP otherwise).
+          return [
+            { op: "local.get", index: closureLocal } as Instr,
+            { op: "ref.test", typeIdx: closureTypeIdx },
+            {
+              op: "if",
+              blockType: { kind: "val" as const, type: { kind: "externref" as const } },
+              then: [
+                { op: "local.get", index: closureLocal } as Instr,
+                { op: "ref.cast", typeIdx: closureTypeIdx },
+                { op: "struct.get", typeIdx: closureTypeIdx, fieldIdx: 0 } as Instr,
+                { op: "local.tee", index: eqrefFuncLocal } as Instr,
+                { op: "ref.test", typeIdx: closureInfo.funcTypeIdx },
+                {
+                  op: "if",
+                  blockType: { kind: "val" as const, type: { kind: "externref" as const } },
+                  then: callInstrs,
+                  else: buildCandidate(ci + 1),
+                } as Instr,
+              ],
+              else: buildCandidate(ci + 1),
+            } as Instr,
+          ];
+        };
+        thenInstrs.push(
+          { op: "local.get", index: anyLocal } as Instr,
+          { op: "ref.cast", typeIdx: entry.typeIdx },
+          { op: "struct.get", typeIdx: entry.typeIdx, fieldIdx: entry.fieldIdx } as Instr,
+          { op: "local.set", index: closureLocal } as Instr,
+          ...buildCandidate(0),
+        );
       } else {
         // Closure field: extract closure, get funcref, call_ref
         const ci = entry.closureInfo;
@@ -4616,7 +4709,9 @@ function emitToPrimitiveMethodExports(ctx: CodegenContext): void {
 
     // Determine locals: param 0 (externref), local 1 (anyref), local 2 (eqref for closure)
     // (#2679) locals 3/4 (__prev_this / __tp_result) thread `__current_this`.
-    const hasClosureEntry = entries.some((e) => e.mode === "closure" || e.mode === "closure-extern");
+    const hasClosureEntry = entries.some(
+      (e) => e.mode === "closure" || e.mode === "closure-extern" || e.mode === "closure-eqref-multi",
+    );
     const locals: { name: string; type: ValType }[] = [{ name: "__any", type: { kind: "anyref" } }];
     if (hasClosureEntry) {
       locals.push({ name: "__closure", type: { kind: "eqref" } });
@@ -4635,6 +4730,12 @@ function emitToPrimitiveMethodExports(ctx: CodegenContext): void {
     const tpResultLocal = 4;
     locals.push({ name: "__prev_this", type: { kind: "externref" } });
     locals.push({ name: "__tp_result", type: { kind: "externref" } });
+    // (#2891) funcref scratch (index 5) for the guarded `closure-eqref-multi`
+    // dispatch — distinct method closures can share one closure STRUCT type but
+    // carry different FUNC types, so the candidate is discriminated by a guarded
+    // `ref.test` on the funcref (field 0), not by the struct type alone.
+    locals.push({ name: "__tp_funcref", type: { kind: "funcref" } });
+    const eqrefFuncLocal = 5;
     const currentThisGlobalIdx2 = ensureCurrentThisGlobal(ctx);
 
     const body: Instr[] = [

--- a/tests/issue-2891-standalone-toprimitive-operators.test.ts
+++ b/tests/issue-2891-standalone-toprimitive-operators.test.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2891 — standalone object-operand relational/additive ToPrimitive.
+//
+// When an object operand's `valueOf` returns a NON-primitive (an object),
+// §7.1.1.1 OrdinaryToPrimitive must fall through to `toString`, and throw a
+// TypeError only when neither own method yields a primitive. Pre-#2891 the
+// standalone `__class_to_primitive` driver accepted the first dispatcher's
+// non-null result even when it was an object (so `valueOf` returning an object
+// short-circuited the fall-through → wrong relational value / NaN), and
+// single-literal object structs were not dispatched at all. All fixes are
+// standalone-only; the WasmGC/host path is untouched.
+
+async function runStandalone(src: string): Promise<{ ret: unknown; imports: number }> {
+  const r = await compile(src, { target: "standalone", skipSemanticDiagnostics: true });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  // Host-free: a standalone binary needs no host imports.
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return { ret: (instance.exports as { test: () => unknown }).test(), imports: r.imports.length };
+}
+
+describe("#2891 standalone ToPrimitive in relational/additive operators", () => {
+  it("relational: valueOf returning an object falls through to toString (host-free)", async () => {
+    const { ret, imports } = await runStandalone(
+      `export function test(): boolean { return (1 < {valueOf: function() {return {}}, toString: function() {return 2}}); }`,
+    );
+    expect(imports).toBe(0);
+    expect(ret).toBe(1); // 1 < 2 === true
+  });
+
+  it("relational: object with only toString reduces via toString (host-free)", async () => {
+    const { ret, imports } = await runStandalone(
+      `export function test(): boolean { return (1 < {toString: function() {return 2}}); }`,
+    );
+    expect(imports).toBe(0);
+    expect(ret).toBe(1);
+  });
+
+  it("relational: valueOf returning an object with no toString → [object Object] → NaN → false", async () => {
+    const { ret, imports } = await runStandalone(
+      `export function test(): boolean { return ({valueOf: function() {return {}}} < 1); }`,
+    );
+    expect(imports).toBe(0);
+    expect(ret).toBe(0); // NaN < 1 === false
+  });
+
+  it("relational: non-constant toString fallback (not constant-folded)", async () => {
+    const { ret, imports } = await runStandalone(
+      `export function test(): boolean { const x = 9; return (1 < {valueOf: function() {return {}}, toString: function() {return x + 1;}}); }`,
+    );
+    expect(imports).toBe(0);
+    expect(ret).toBe(1); // 1 < 10 === true
+  });
+
+  it("additive: valueOf returning an object falls through to toString (host-free)", async () => {
+    const { ret, imports } = await runStandalone(
+      `export function test(): number { return (1 + {valueOf: function() {return {}}, toString: function() {return 1}}); }`,
+    );
+    expect(imports).toBe(0);
+    expect(ret).toBe(2);
+  });
+
+  it("additive: valueOf returning a primitive wins over toString", async () => {
+    const { ret, imports } = await runStandalone(
+      `export function test(): number { return ({valueOf: function() {return 1}, toString: function() {return 9}} + 1); }`,
+    );
+    expect(imports).toBe(0);
+    expect(ret).toBe(2);
+  });
+
+  it("both valueOf and toString returning objects throws (host-free §7.1.1.1 TypeError)", async () => {
+    const r = await compile(
+      `export function test(): number { return (1 + {valueOf: function() {return {}}, toString: function() {return {}}}); }`,
+      { target: "standalone", skipSemanticDiagnostics: true },
+    );
+    expect(r.success).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect(() => (instance.exports as { test: () => unknown }).test()).toThrow();
+  });
+
+  it("WasmGC/host mode compiles unaffected (control)", async () => {
+    // All #2891 fixes are gated on `ctx.standalone` (the `__class_to_primitive`
+    // driver is reserved only in standalone, and the dispatcher widening is
+    // `ctx.standalone`-only), so the default WasmGC/host lowering is untouched —
+    // the emitted GC binary is byte-identical to pre-#2891. Running it here would
+    // require the JS-host ToPrimitive runtime (not the bare import object), so we
+    // assert the GC compile still succeeds (no CE introduced) rather than execute.
+    const r = await compile(
+      `export function test(): boolean { return (1 < {valueOf: function() {return {}}, toString: function() {return 2}}); }`,
+      { skipSemanticDiagnostics: true },
+    );
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(r.binary.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Problem

In `--target standalone`, object-operand relational/additive coercion where `valueOf` returns a **non-primitive** (an object) produced the wrong value and never threw the §7.1.1.1 both-objects TypeError. Verified host-free on main (`result.imports` empty):

- `1 < {valueOf:()=>({}), toString:()=>2}` → `false` (want `true`)
- `1 + {valueOf:()=>({}), toString:()=>({})}` → `NaN` (want TypeError)

The dominant residual of #2873 `language/expressions`. (The runner's `"Cannot convert object to primitive value"` is the #2862 host-formatter artifact masking the real in-Wasm wrong-value/missing-throw.)

## Root cause

The static `ref→f64` coercion delegates an object-returning `valueOf` to the runtime `__to_primitive` engine → its non-`$Object` arm → `__class_to_primitive`. That driver accepted the FIRST dispatcher's **non-null** result as "a primitive" — but `boxResult` externalizes a ref-returning method into a non-null externref **object**, so an object-returning `valueOf` short-circuited the fall-through to `toString`, and single-literal object-method structs were not dispatched at all.

## Fix (standalone-only — WasmGC/host binary byte-identical)

1. **`fillClassToPrimitive`** — implement §7.1.1.1 sequentially: accept a dispatcher result only when it is a PRIMITIVE (`__typeof_number`/`_boolean`/`_string`); else fall through to the next method; throw the §7.1.1.1 TypeError when both own methods return objects; model inherited `Object.prototype.toString` → `"[object Object]"`.
2. **`emitToPrimitiveMethodExports`** — emit `__call_valueOf`/`__call_toString` for single-literal eqref-closure structs in standalone via a new GUARDED `closure-eqref-multi` dispatch that `ref.test`s both the candidate closure struct type AND its funcref type before `call_ref` (avoids the wrong-field-cast trap that gated single literals out).

## Verification

Host-free (`imports` empty), all fixed: relational valueOf→toString fall-through (incl. non-const), additive object operands, valueOf-primitive precedence, both-objects → TypeError, class-instance object-valueOf. New `tests/issue-2891-standalone-toprimitive-operators.test.ts` (8 tests). 60/60 existing ToPrimitive-suite tests pass (the 2 failures are pre-existing on main); 0 regressions in diverse standalone samples; GC binary byte-identical.

## Residual (documented, not regressions)

The bundled `_A2.2_T1` test262 files do not fully flip yet — they bundle two orthogonal hard sub-problems already failing on main: a forked-closure dispatch gap (throwing-`valueOf` sibling makes a later both-objects instance's dispatch miss) and standalone `instanceof TypeError`. Routed to the #2862 substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)