### PR TITLE
feat(#2866 slice 3): standalone Object.getOwnPropertySymbols SELECT side

### DIFF
--- a/plan/issues/2866-standalone-symbol-carrier.md
+++ b/plan/issues/2866-standalone-symbol-carrier.md
@@ -215,6 +215,50 @@ answer.)
 
 **Deferred to follow-ups (pre-existing gaps, NOT regressions):**
 
-- slice 3 SELECT side — `__getOwnPropertySymbols` still returns `[]` (stub); needs the
-  `symbol[]` read path so the returned carriers are usable as symbol values.
+- ~~slice 3 SELECT side~~ **DONE (sendev-promisecarrier, 2026-06-30).** See
+  "## Implementation — slice 3" below.
 - slice 4 — `Symbol.toPrimitive` dispatch in the coercion engine (ties into #2862).
+
+## Implementation — slice 3 (getOwnPropertySymbols SELECT side), 2026-06-30
+
+`Object.getOwnPropertySymbols(o)` now returns the object's own symbol keys
+host-free (was the `[]` stub). Three coordinated pieces:
+
+1. **`object-runtime.ts` — `__obj_ordered_symbols` + real `__getOwnPropertySymbols`.**
+   The SELECT counterpart to PR1's string-key EXCLUSION: a new
+   `__obj_ordered_symbols(ref $Object) -> ref $PropMap` compacts the LIVE own
+   `$Symbol`-keyed entries (INCLUDING non-enumerable — §20.5.2.9 returns all own
+   symbol keys) and selection-sorts them by `$PropEntry.seq` (insertion order;
+   symbols are never integer indices, so NO `entryIndexOf`/`ref.cast $AnyString`
+   which would trap on a `$Symbol` key). `__getOwnPropertySymbols` (under
+   `symbolKeysEnabled`) walks that compacted map and pushes each stored `$Symbol`
+   carrier (`extern.convert_any(e.key)`) into a fresh `$ObjVec`; the `[]`-stub is
+   kept for host/gc mode and symbol-free modules (byte-identical).
+
+2. **`symbol-native.ts` — INTERN `__box_symbol` carriers by id.** A standalone
+   symbol VALUE is a bare i32 id, but every externref crossing (object key,
+   `symbol[]` element, an `any`-typed arg like `assert.sameValue(syms[0], sym)`)
+   boxes it via `__box_symbol`. The generic externref `===` paths
+   (`__extern_strict_eq`/`__any_strict_eq`, array `indexOf`) compare boxed objects
+   with `ref.eq`, so a fresh struct per box made two boxings of the SAME symbol
+   unequal (broke `getOwnPropertySymbols` identity, `sym in obj`,
+   `[sym].indexOf(sym)`). A growable id→carrier intern table makes `ref.eq` hold
+   for same-id boxings — symbol identity now works uniformly with **no change to
+   the central equality helpers**.
+
+3. **`type-coercion.ts` — carrier → i32-id unbox.** For the symbol-TYPED path
+   (`let s2: symbol = syms[0]`, whose value-position rep is the i32 id), both the
+   scalar `externref → i32` coercion and the typed-vec element materialization
+   (`buildElemCoerce`) recover `$Symbol.id`. The vec path runtime-dispatches
+   (`ref.test $Symbol` → id, else `__unbox_number`) because `symbol[]` shares the
+   unbranded `$__arr_i32` element type with `number[]` and can't be disambiguated
+   statically. All gated on the carrier being registered → byte-identical for
+   symbol-free / host modules.
+
+All gated on `symbolKeysEnabled` / `ctx.symbolTypeIdx >= 0`; zero host imports.
+Verified: 7 new standalone tests in `tests/issue-2866.test.ts` (length, identity,
+re-index, insertion order, string-key disjointness, empty, any-boundary `===`);
+the `built-ins/Object/getOwnPropertySymbols` standalone dir improves (the
+remaining fails are Proxy-dependent / ToObject-coercion / not-a-constructor —
+separate concerns). The full merge_group standalone report is the conformance
+gate.

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -3321,6 +3321,210 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     // __obj_ordered_all — live, INCLUDING non-enumerable (#2042 S3,
     // Object.getOwnPropertyNames). Same ordering + sort; enumerable filter off.
     registerNative("__obj_ordered_all", [objRef], [propMapRef], makeOrderedLocals(), buildOrderedBody(true));
+
+    // (#2866 slice 3) __obj_ordered_symbols — the SELECT counterpart to the
+    // string-key exclusion above: collect this object's LIVE own SYMBOL-keyed
+    // entries (INCLUDING non-enumerable ones — Object.getOwnPropertySymbols
+    // returns own symbol keys regardless of enumerability, §20.5.2.9) into a
+    // compacted $PropMap in insertion order. Symbol keys are never integer
+    // indices and never interleave with string keys, so OrdinaryOwnPropertyKeys
+    // order among symbols is purely creation order (`$PropEntry.seq` ascending) —
+    // a plain seq selection sort, with NO `entryIndexOf` (its `ref.cast
+    // $AnyString` would trap on a `$Symbol` key).
+    //
+    // param: 0=o(ref $Object) ; locals (reuse makeOrderedLocals): 1=arr 2=cap 3=i
+    //   4=e 5=out 6=m 7=j 8=best 9=k 10=cand 11=bestE 15=bestSeq 14=candSeq 16=tmp
+    const buildOrderedSymbolsBody = (): Instr[] => [
+      // arr = o.props ; cap = arr.len
+      { op: "local.get", index: 0 },
+      { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 1 },
+      { op: "local.tee", index: 1 },
+      { op: "array.len" },
+      { op: "local.set", index: 2 },
+      // out = new $PropMap[o.count] (upper bound; trailing slots stay null)
+      { op: "local.get", index: 0 },
+      { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 2 },
+      { op: "array.new_default", typeIdx: propMapTypeIdx },
+      { op: "local.set", index: 5 },
+      // m = 0 ; i = 0 — first pass: compact live symbol-keyed entries into out
+      { op: "i32.const", value: 0 },
+      { op: "local.set", index: 6 },
+      { op: "i32.const", value: 0 },
+      { op: "local.set", index: 3 },
+      {
+        op: "block",
+        blockType: { kind: "empty" },
+        body: [
+          {
+            op: "loop",
+            blockType: { kind: "empty" },
+            body: [
+              { op: "local.get", index: 3 },
+              { op: "local.get", index: 2 },
+              { op: "i32.ge_u" },
+              { op: "br_if", depth: 1 },
+              // e = arr[i]
+              { op: "local.get", index: 1 },
+              { op: "local.get", index: 3 },
+              { op: "array.get", typeIdx: propMapTypeIdx },
+              { op: "local.tee", index: 4 },
+              { op: "ref.is_null" },
+              { op: "i32.eqz" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  // !tombstone
+                  { op: "local.get", index: 4 },
+                  { op: "ref.as_non_null" },
+                  { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 2 },
+                  { op: "i32.const", value: FLAG_TOMBSTONE },
+                  { op: "i32.and" },
+                  { op: "i32.eqz" },
+                  // && ref.test $Symbol(key) — SELECT only symbol keys
+                  { op: "local.get", index: 4 },
+                  { op: "ref.as_non_null" },
+                  { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 0 },
+                  { op: "ref.test", typeIdx: symbolTypeIdx },
+                  { op: "i32.and" },
+                  {
+                    op: "if",
+                    blockType: { kind: "empty" },
+                    then: [
+                      { op: "local.get", index: 5 },
+                      { op: "local.get", index: 6 },
+                      { op: "local.get", index: 4 },
+                      { op: "array.set", typeIdx: propMapTypeIdx },
+                      { op: "local.get", index: 6 },
+                      { op: "i32.const", value: 1 },
+                      { op: "i32.add" },
+                      { op: "local.set", index: 6 },
+                    ],
+                  },
+                ],
+              },
+              { op: "local.get", index: 3 },
+              { op: "i32.const", value: 1 },
+              { op: "i32.add" },
+              { op: "local.set", index: 3 },
+              { op: "br", depth: 0 },
+            ],
+          },
+        ],
+      },
+      // Second pass: selection sort out[0..m) by seq ascending (insertion order).
+      { op: "i32.const", value: 0 },
+      { op: "local.set", index: 7 }, // j
+      {
+        op: "block",
+        blockType: { kind: "empty" },
+        body: [
+          {
+            op: "loop",
+            blockType: { kind: "empty" },
+            body: [
+              { op: "local.get", index: 7 },
+              { op: "local.get", index: 6 },
+              { op: "i32.ge_u" },
+              { op: "br_if", depth: 1 },
+              // best = j ; bestE = out[j] ; bestSeq = bestE.seq
+              { op: "local.get", index: 7 },
+              { op: "local.set", index: 8 },
+              { op: "local.get", index: 5 },
+              { op: "local.get", index: 7 },
+              { op: "array.get", typeIdx: propMapTypeIdx },
+              { op: "local.set", index: 11 },
+              { op: "local.get", index: 11 },
+              { op: "ref.as_non_null" },
+              { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 3 },
+              { op: "local.set", index: 15 },
+              // for k in j+1..m
+              { op: "local.get", index: 7 },
+              { op: "i32.const", value: 1 },
+              { op: "i32.add" },
+              { op: "local.set", index: 9 },
+              {
+                op: "block",
+                blockType: { kind: "empty" },
+                body: [
+                  {
+                    op: "loop",
+                    blockType: { kind: "empty" },
+                    body: [
+                      { op: "local.get", index: 9 },
+                      { op: "local.get", index: 6 },
+                      { op: "i32.ge_u" },
+                      { op: "br_if", depth: 1 },
+                      // cand = out[k] ; candSeq = cand.seq
+                      { op: "local.get", index: 5 },
+                      { op: "local.get", index: 9 },
+                      { op: "array.get", typeIdx: propMapTypeIdx },
+                      { op: "local.set", index: 10 },
+                      { op: "local.get", index: 10 },
+                      { op: "ref.as_non_null" },
+                      { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 3 },
+                      { op: "local.set", index: 14 },
+                      // if candSeq < bestSeq → best = k, bestSeq = candSeq, bestE = cand
+                      { op: "local.get", index: 14 },
+                      { op: "local.get", index: 15 },
+                      { op: "i32.lt_s" },
+                      {
+                        op: "if",
+                        blockType: { kind: "empty" },
+                        then: [
+                          { op: "local.get", index: 9 },
+                          { op: "local.set", index: 8 },
+                          { op: "local.get", index: 14 },
+                          { op: "local.set", index: 15 },
+                          { op: "local.get", index: 10 },
+                          { op: "local.set", index: 11 },
+                        ],
+                      },
+                      { op: "local.get", index: 9 },
+                      { op: "i32.const", value: 1 },
+                      { op: "i32.add" },
+                      { op: "local.set", index: 9 },
+                      { op: "br", depth: 0 },
+                    ],
+                  },
+                ],
+              },
+              // swap out[j] <-> out[best] (only if best != j)
+              { op: "local.get", index: 8 },
+              { op: "local.get", index: 7 },
+              { op: "i32.ne" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  { op: "local.get", index: 5 },
+                  { op: "local.get", index: 7 },
+                  { op: "array.get", typeIdx: propMapTypeIdx },
+                  { op: "local.set", index: 16 },
+                  { op: "local.get", index: 5 },
+                  { op: "local.get", index: 7 },
+                  { op: "local.get", index: 11 },
+                  { op: "array.set", typeIdx: propMapTypeIdx },
+                  { op: "local.get", index: 5 },
+                  { op: "local.get", index: 8 },
+                  { op: "local.get", index: 16 },
+                  { op: "array.set", typeIdx: propMapTypeIdx },
+                ],
+              },
+              { op: "local.get", index: 7 },
+              { op: "i32.const", value: 1 },
+              { op: "i32.add" },
+              { op: "local.set", index: 7 },
+              { op: "br", depth: 0 },
+            ],
+          },
+        ],
+      },
+      { op: "local.get", index: 5 },
+    ];
+    if (symbolKeysEnabled) {
+      registerNative("__obj_ordered_symbols", [objRef], [propMapRef], makeOrderedLocals(), buildOrderedSymbolsBody());
+    }
     void entryRef;
   }
   const objOrderedIdx = ctx.funcMap.get("__obj_ordered")!;
@@ -5710,17 +5914,111 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     );
   }
 
-  // ── __getOwnPropertySymbols(externref obj) -> externref (#2042 S3) ────────
+  // ── __getOwnPropertySymbols(externref obj) -> externref (#2042 S3, #2866 s3) ─
   //
-  // The string-keyed `$Object` runtime holds NO symbol keys, so the own-symbol
-  // list is always empty. Returning an empty `$ObjVec` (rather than refusing)
-  // lets the large body of symbol-free `getOwnPropertySymbols` tests pass —
-  // §20.1.2.9 returns [] for an object with no symbol-keyed own properties,
-  // which is every `$Object` here. (When symbol keys are added to the open-object
-  // runtime this helper grows a real body.)
+  // §20.1.2.10 / OrdinaryOwnPropertyKeys §10.1.11.1 — own SYMBOL-keyed property
+  // keys in creation (insertion) order.
   //
-  // params: 0=obj(externref) — unused (always [] for the string-keyed runtime)
-  {
+  // Without the native Symbol carrier (host/gc mode, or a standalone module with
+  // no symbol keys in its type space) the `$Object` runtime holds no symbol keys,
+  // so the list is always empty — return a fresh empty `$ObjVec` (the historical
+  // #2042 S3 stub; lets the large body of symbol-free tests pass).
+  //
+  // With the carrier enabled (#2866 PR1: `$PropEntry.key` is `anyref` and may
+  // hold a `$Symbol`), delegate selection + ordering to `__obj_ordered_symbols`
+  // (live own symbol entries, incl. non-enumerable, in seq order), then push each
+  // entry's key — the stored `$Symbol` carrier, `extern.convert_any`'d back to an
+  // externref symbol VALUE — into the result vec. Identity is by the i32
+  // `$Symbol.id`, so the returned carrier `===` the original symbol and re-indexes
+  // the same own property. Non-`$Object` receivers return an empty vec.
+  //
+  // params: 0=obj(externref)
+  // locals: 1=any(anyref) 2=o(ref null $Object) 3=arr(ref $PropMap) 4=cap
+  //         5=i 6=e(ref null $PropEntry) 7=vec(externref)
+  if (symbolKeysEnabled) {
+    const objOrderedSymbolsIdx = ctx.funcMap.get("__obj_ordered_symbols")!;
+    const body: Instr[] = [
+      // vec = __objvec_new()
+      { op: "call", funcIdx: objVecNewIdx },
+      { op: "local.set", index: 7 },
+      // any = any.convert_extern(obj); if !$Object → return empty vec
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "local.tee", index: 1 },
+      { op: "ref.test", typeIdx: objectTypeIdx },
+      { op: "i32.eqz" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "local.get", index: 7 }, { op: "return" }],
+      },
+      // o = cast<$Object>(any) ; arr = __obj_ordered_symbols(o) ; cap = arr.len
+      { op: "local.get", index: 1 },
+      { op: "ref.cast", typeIdx: objectTypeIdx },
+      { op: "local.tee", index: 2 },
+      { op: "call", funcIdx: objOrderedSymbolsIdx },
+      { op: "local.tee", index: 3 },
+      { op: "array.len" },
+      { op: "local.set", index: 4 },
+      // i = 0
+      { op: "i32.const", value: 0 },
+      { op: "local.set", index: 5 },
+      {
+        op: "block",
+        blockType: { kind: "empty" },
+        body: [
+          {
+            op: "loop",
+            blockType: { kind: "empty" },
+            body: [
+              // if i >= cap break
+              { op: "local.get", index: 5 },
+              { op: "local.get", index: 4 },
+              { op: "i32.ge_s" },
+              { op: "br_if", depth: 1 },
+              // e = arr[i] ; ordered array is compacted — stop at first null
+              { op: "local.get", index: 3 },
+              { op: "local.get", index: 5 },
+              { op: "array.get", typeIdx: propMapTypeIdx },
+              { op: "local.tee", index: 6 },
+              { op: "ref.is_null" },
+              { op: "br_if", depth: 1 },
+              // __objvec_push(vec, extern.convert_any(e.key))  — key is a $Symbol carrier
+              { op: "local.get", index: 7 },
+              { op: "local.get", index: 6 },
+              { op: "ref.as_non_null" },
+              { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 0 },
+              { op: "extern.convert_any" },
+              { op: "call", funcIdx: objVecPushIdx },
+              // i++ ; loop
+              { op: "local.get", index: 5 },
+              { op: "i32.const", value: 1 },
+              { op: "i32.add" },
+              { op: "local.set", index: 5 },
+              { op: "br", depth: 0 },
+            ],
+          },
+        ],
+      },
+      { op: "local.get", index: 7 },
+    ];
+    registerNative(
+      "__getOwnPropertySymbols",
+      [{ kind: "externref" }],
+      [{ kind: "externref" }],
+      [
+        { name: "any", type: { kind: "anyref" } },
+        { name: "o", type: objRefNull },
+        { name: "arr", type: propMapRef },
+        { name: "cap", type: { kind: "i32" } },
+        { name: "i", type: { kind: "i32" } },
+        { name: "e", type: entryRefNull },
+        { name: "vec", type: { kind: "externref" } },
+      ],
+      body,
+    );
+  } else {
+    // String-keyed runtime (host/gc, or no symbol keys): always [].
     const body: Instr[] = [{ op: "call", funcIdx: objVecNewIdx }];
     registerNative("__getOwnPropertySymbols", [{ kind: "externref" }], [{ kind: "externref" }], [], body);
   }

--- a/src/codegen/symbol-native.ts
+++ b/src/codegen/symbol-native.ts
@@ -76,19 +76,135 @@ export function ensureSymbolCarrier(ctx: CodegenContext): number {
   if (ctx.funcMap.get("__box_symbol") === undefined) {
     const symIdx = ctx.symbolTypeIdx;
     const anyStrTypeIdx = ctx.anyStrTypeIdx;
+    // (#2866 slice 3) INTERN carriers by id. A standalone symbol VALUE is a bare
+    // i32 id; whenever it crosses an externref channel (`$Object` key, `symbol[]`
+    // element, an `any`-typed argument such as `assert.sameValue(syms[0], sym)`)
+    // it is boxed via `__box_symbol`. Identity is decided by the i32 id, but the
+    // generic externref `===` paths (`__extern_strict_eq`/`__any_strict_eq`,
+    // array `indexOf`) compare boxed objects with `ref.eq`. A fresh struct per box
+    // made two boxings of the SAME symbol compare unequal (`getOwnPropertySymbols`
+    // identity, `sym in obj`, `[sym].indexOf(sym)`). Interning — one canonical
+    // `$Symbol` per id in a growable id→carrier table — makes `ref.eq` hold for
+    // same-id boxings, so symbol identity works uniformly with no change to the
+    // central equality helpers. The table is lazily allocated and grown ×2.
+    const internArrTypeIdx = getOrRegisterArrayType(ctx, `symref_${symIdx}`, {
+      kind: "ref_null",
+      typeIdx: symIdx,
+    });
+    const internGlobalIdx = ctx.numImportGlobals + ctx.mod.globals.length;
+    ctx.mod.globals.push({
+      name: "__symbol_intern_table",
+      type: { kind: "ref_null", typeIdx: internArrTypeIdx },
+      mutable: true,
+      init: [{ op: "ref.null", typeIdx: internArrTypeIdx } as Instr],
+    });
+    const symNull: ValType = { kind: "ref_null", typeIdx: symIdx };
+    const arrNull: ValType = { kind: "ref_null", typeIdx: internArrTypeIdx };
     const typeIdx = addFuncType(ctx, [{ kind: "i32" }], [{ kind: "externref" }]);
     const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
     ctx.funcMap.set("__box_symbol", funcIdx);
+    // params: 0=id(i32). locals: 1=tbl 2=existing 3=grow
+    const TBL = 1;
+    const EXISTING = 2;
+    const GROW = 3;
     ctx.mod.functions.push({
       name: "__box_symbol",
       typeIdx,
-      locals: [],
+      locals: [
+        { name: "tbl", type: arrNull },
+        { name: "existing", type: symNull },
+        { name: "grow", type: arrNull },
+      ],
       body: [
-        // struct.new $Symbol { id = param0, desc = null } ; extern.convert_any
+        // tbl = global; allocate (id+1, min 16) slots if null.
+        { op: "global.get", index: internGlobalIdx },
+        { op: "local.tee", index: TBL },
+        { op: "ref.is_null" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            // allocate id+1 slots; the grow loop below extends ×2 as ids climb.
+            { op: "local.get", index: 0 } as Instr,
+            { op: "i32.const", value: 1 } as Instr,
+            { op: "i32.add" } as Instr,
+            { op: "array.new_default", typeIdx: internArrTypeIdx } as Instr,
+            { op: "local.set", index: TBL } as Instr,
+            { op: "local.get", index: TBL } as Instr,
+            { op: "global.set", index: internGlobalIdx } as Instr,
+          ],
+        },
+        // grow ×2 until id < tbl.len
+        {
+          op: "block",
+          blockType: { kind: "empty" },
+          body: [
+            {
+              op: "loop",
+              blockType: { kind: "empty" },
+              body: [
+                { op: "local.get", index: 0 },
+                { op: "local.get", index: TBL },
+                { op: "ref.as_non_null" },
+                { op: "array.len" },
+                { op: "i32.lt_s" },
+                { op: "br_if", depth: 1 },
+                { op: "local.get", index: TBL },
+                { op: "ref.as_non_null" },
+                { op: "array.len" },
+                { op: "i32.const", value: 2 },
+                { op: "i32.mul" },
+                { op: "array.new_default", typeIdx: internArrTypeIdx } as Instr,
+                { op: "local.set", index: GROW },
+                { op: "local.get", index: GROW },
+                { op: "ref.as_non_null" },
+                { op: "i32.const", value: 0 },
+                { op: "local.get", index: TBL },
+                { op: "ref.as_non_null" },
+                { op: "i32.const", value: 0 },
+                { op: "local.get", index: TBL },
+                { op: "ref.as_non_null" },
+                { op: "array.len" },
+                { op: "array.copy", dstTypeIdx: internArrTypeIdx, srcTypeIdx: internArrTypeIdx } as Instr,
+                { op: "local.get", index: GROW },
+                { op: "local.set", index: TBL },
+                { op: "local.get", index: TBL },
+                { op: "global.set", index: internGlobalIdx },
+                { op: "br", depth: 0 },
+              ],
+            } as Instr,
+          ],
+        },
+        // existing = tbl[id]; if null create + store; return extern(existing).
+        { op: "local.get", index: TBL },
+        { op: "ref.as_non_null" },
         { op: "local.get", index: 0 },
-        { op: "ref.null", typeIdx: anyStrTypeIdx } as Instr,
-        { op: "struct.new", typeIdx: symIdx } as Instr,
-        { op: "extern.convert_any" },
+        { op: "array.get", typeIdx: internArrTypeIdx } as Instr,
+        { op: "local.tee", index: EXISTING },
+        { op: "ref.is_null" },
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "externref" } },
+          then: [
+            // tbl[id] = new $Symbol{id, null}; tee into `existing`
+            { op: "local.get", index: TBL } as Instr,
+            { op: "ref.as_non_null" } as Instr,
+            { op: "local.get", index: 0 } as Instr,
+            { op: "local.get", index: 0 } as Instr,
+            { op: "ref.null", typeIdx: anyStrTypeIdx } as Instr,
+            { op: "struct.new", typeIdx: symIdx } as Instr,
+            { op: "local.tee", index: EXISTING } as Instr,
+            { op: "array.set", typeIdx: internArrTypeIdx } as Instr,
+            { op: "local.get", index: EXISTING } as Instr,
+            { op: "ref.as_non_null" } as Instr,
+            { op: "extern.convert_any" } as Instr,
+          ],
+          else: [
+            { op: "local.get", index: EXISTING } as Instr,
+            { op: "ref.as_non_null" } as Instr,
+            { op: "extern.convert_any" } as Instr,
+          ],
+        },
       ],
       exported: false,
     });

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -298,6 +298,38 @@ export function buildVecFromExternref(
     // (loopdive/js2#389 / #2311 regression — buildElemCoerce only handled
     // f64/i32/externref/ref). (#2839)
     if ((et.kind === "i32" || et.kind === "i8" || et.kind === "i16") && unboxIdx !== undefined) {
+      // (#2866 slice 3) In a symbol-bearing module the externref element may be a
+      // `$Symbol` carrier (materialising `Object.getOwnPropertySymbols(o)` into a
+      // typed `symbol[]` whose value-position rep is the i32 id) rather than a
+      // boxed number. `symbol[]` shares the unbranded `$__arr_i32` element type
+      // with `number[]`, so it can't be disambiguated statically — dispatch at
+      // runtime: a `$Symbol` carrier yields its i32 id (`$Symbol.id`), anything
+      // else unboxes as a number. Gated on the carrier being registered
+      // (standalone/WASI symbol modules); plain numeric modules are byte-identical.
+      if ((ctx.standalone || ctx.wasi) && ctx.symbolTypeIdx >= 0 && et.kind === "i32") {
+        const symIdx = ctx.symbolTypeIdx;
+        const tmpSym = allocLocal(fctx, `__sym_elem_${fctx.locals.length}`, { kind: "externref" });
+        return [
+          { op: "local.tee", index: tmpSym } as Instr,
+          { op: "any.convert_extern" } as Instr,
+          { op: "ref.test", typeIdx: symIdx } as Instr,
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "i32" } },
+            then: [
+              { op: "local.get", index: tmpSym } as Instr,
+              { op: "any.convert_extern" } as Instr,
+              { op: "ref.cast", typeIdx: symIdx } as Instr,
+              { op: "struct.get", typeIdx: symIdx, fieldIdx: 0 } as Instr,
+            ],
+            else: [
+              { op: "local.get", index: tmpSym } as Instr,
+              { op: "call", funcIdx: unboxIdx } as Instr,
+              { op: "i32.trunc_sat_f64_s" } as Instr,
+            ],
+          } as Instr,
+        ];
+      }
       return [{ op: "call", funcIdx: unboxIdx } as Instr, { op: "i32.trunc_sat_f64_s" }];
     }
     if (et.kind === "externref") return [];
@@ -1520,6 +1552,21 @@ export function coerceType(
   }
   // externref → i32 (unbox as number to preserve value, then truncate)
   if (from.kind === "externref" && to.kind === "i32") {
+    // (#2866 slice 3) symbol carrier → i32 id. A standalone/WASI symbol VALUE is
+    // a bare i32 counter id; when it has crossed an externref channel (e.g. a
+    // single `symbol` element of `Object.getOwnPropertySymbols(o)`) it is a
+    // `$Symbol` struct. Unboxing to a symbol slot is the inverse of the
+    // `__box_symbol` boxing path: recover the canonical i32 id (`$Symbol.id`) so
+    // symbol identity (`===`, id-compare) and re-indexing (`o[sym]`) work on the
+    // returned carrier. Narrowly gated on a symbol-branded target with the
+    // carrier registered; never touches number/boolean i32 coercions.
+    if (to.symbol === true && (ctx.standalone || ctx.wasi) && ctx.symbolTypeIdx >= 0) {
+      const symIdx = ctx.symbolTypeIdx;
+      fctx.body.push({ op: "any.convert_extern" });
+      fctx.body.push({ op: "ref.cast", typeIdx: symIdx } as Instr);
+      fctx.body.push({ op: "struct.get", typeIdx: symIdx, fieldIdx: 0 } as Instr);
+      return;
+    }
     addUnionImports(ctx);
     const funcIdx = ctx.funcMap.get("__unbox_number");
     if (funcIdx !== undefined) {

--- a/tests/issue-2866.test.ts
+++ b/tests/issue-2866.test.ts
@@ -126,3 +126,61 @@ describe("#2866 native Symbol carrier — Symbol-keyed $Object ops (standalone)"
     ).toBe(210);
   });
 });
+
+describe("#2866 slice 3 — Object.getOwnPropertySymbols SELECT side (standalone)", () => {
+  it("returns the object's own symbol keys (length)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o: any = {}; const s = Symbol("k"); o[s] = 42; return Object.getOwnPropertySymbols(o).length; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("returned symbol === the original (identity preserved, host-free)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o: any = {}; const s = Symbol("k"); o[s] = 7; const syms = Object.getOwnPropertySymbols(o); return (syms[0] === s) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("returned symbol re-indexes the same own property", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o: any = {}; const s = Symbol("k"); o[s] = 9; const syms = Object.getOwnPropertySymbols(o); return o[syms[0]] as number; }`,
+      ),
+    ).toBe(9);
+  });
+
+  it("preserves insertion order across multiple symbols", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o: any = {}; const a = Symbol("a"); const b = Symbol("b"); o[a] = 1; o[b] = 2; const syms = Object.getOwnPropertySymbols(o); return (syms.length === 2 && syms[0] === a && syms[1] === b) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("excludes string keys; getOwnPropertySymbols and keys are disjoint", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o: any = { x: 1 }; const s = Symbol("s"); o[s] = 9; return Object.getOwnPropertySymbols(o).length * 10 + Object.keys(o).length; }`,
+      ),
+    ).toBe(11);
+  });
+
+  it("returns an empty array for a symbol-free object", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o: any = { a: 1, b: 2 }; const s = Symbol("force-carrier"); const o2: any = {}; o2[s] = 1; return Object.getOwnPropertySymbols(o).length; }`,
+      ),
+    ).toBe(0);
+  });
+
+  it("symbol identity holds through an any-typed boundary (===)", async () => {
+    expect(
+      await runStandalone(
+        `function eq(a: any, b: any): boolean { return a === b; } export function test(): number { const o: any = {}; const s = Symbol("k"); o[s] = 1; const syms = Object.getOwnPropertySymbols(o); return eq(syms[0], s) ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2866 slice 3 — `Object.getOwnPropertySymbols` SELECT side (standalone)

Builds on PR1 (#2377, the native `$Symbol` carrier + `$Object` anyref key channel). `Object.getOwnPropertySymbols(o)` now returns an object's own symbol keys **host-free** (was the `[]` stub).

### Changes
1. **`object-runtime.ts`** — new `__obj_ordered_symbols` (the SELECT counterpart to PR1's string-key EXCLUSION): compacts LIVE own `$Symbol`-keyed entries (incl. non-enumerable — §20.5.2.9) and selection-sorts by `$PropEntry.seq` (insertion order; no `entryIndexOf`/`ref.cast $AnyString`, which would trap on a symbol key). `__getOwnPropertySymbols` walks it and pushes the stored `$Symbol` carriers into a `$ObjVec`. The `[]` stub stays for host/gc and symbol-free modules.
2. **`symbol-native.ts`** — INTERN `__box_symbol` carriers by id (growable id→carrier table) so `ref.eq` holds for same-id boxings. Fixes symbol identity at the `any`/`===` boundary (`assert.sameValue(syms[0], sym)`), object keys, and arrays **with no change to the central equality helpers**.
3. **`type-coercion.ts`** — carrier→i32-id unbox for the symbol-typed path (scalar `externref→i32` + `buildElemCoerce` runtime-dispatch on `symbol[]`, since it shares the unbranded `$__arr_i32` element type with `number[]`).

All gated on `symbolKeysEnabled` / `ctx.symbolTypeIdx >= 0` → **byte-identical for symbol-free and host/gc modules** (no regression possible there by construction).

### Verification
- 7 new standalone tests in `tests/issue-2866.test.ts` (length, identity-preserved, re-index, insertion order, string-key disjointness, empty, any-boundary `===`) — all green; **zero host imports**.
- `built-ins/Object/getOwnPropertySymbols` standalone dir improves (2→4+ pass; remaining fails are Proxy / ToObject-coercion / not-a-constructor — separate concerns).
- The full `merge_group` standalone report is the authoritative conformance gate.

Slice 4 (`Symbol.toPrimitive`) remains; issue stays `in-progress`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)