### PR TITLE
fix(#2892): key native generator open-dispatch result type on per-elem result struct

### DIFF
--- a/plan/issues/2892-standalone-string-elem-generator-value-reader.md
+++ b/plan/issues/2892-standalone-string-elem-generator-value-reader.md
@@ -1,8 +1,10 @@
 ---
 id: 2892
 title: "Standalone: string-ELEM native generator `.next().value as string` mis-types the result value (typeIdx mismatch) — fails wasm validation"
-status: ready
+status: done
 created: 2026-06-30
+completed: 2026-06-30
+assignee: ttraenkler/sr-genframe
 priority: medium
 feasibility: medium
 task_type: bug
@@ -91,3 +93,49 @@ Surfaced while implementing #2864 F1b (typed spills). F1b deliberately scoped
 AROUND this: F1b enables string LOCAL spills in _numeric_-elem generators (which
 work), and string-elem generators with spills inherit this pre-existing reader
 bug regardless of spilling.
+
+## Resolution (2026-06-30)
+
+**Actual root cause was the open `.next()` DISPATCH, not the result reader.**
+When the iterator local is statically opaque (`let it = g()` types `it` as
+`externref`, the common shape), `it.next()` lowers through the OPEN dispatch
+(`buildNativeGeneratorDispatch`), not the direct path. That function hard-coded
+its enclosing-block result type to the **f64 IteratorResult singleton** for any
+non-`any`-carrier module:
+
+```ts
+const resultType = hasAny ? { kind: "eqref" }
+                          : { kind: "ref", typeIdx: ensureNativeGeneratorResultType(ctx) }; // f64 singleton!
+```
+
+But each per-generator branch produces `struct.new info.resultTypeIdx` — for a
+string generator that is the native-string `__NativeGeneratorResult_refN`
+(typeIdx 35 in the repro), not the f64 singleton (41, which this very call
+spuriously minted). So `if` branches typed `ref 35` flowed into a block declared
+`ref 41` → `type error in fallthru[0] (expected (ref null 41), got (ref null 35))`.
+
+**Fix** (`buildNativeGeneratorDispatch`): key the block type on the result
+structs actually present rather than always the f64 singleton:
+- any boxed-`any` carrier present, OR generators with **distinct** result
+  structs (e.g. a numeric AND a string generator in one module) → `eqref`
+  (the common `eq` supertype);
+- all generators share ONE result-struct typeIdx → `ref <that idx>`. This covers
+  both the dominant numeric-only case (every numeric generator shares the f64
+  singleton — **byte-identical** to before) and the single-string-elem case.
+
+For the single-string-generator case the dispatch now yields `ref <stringResult>`,
+so the downstream `.value`/`.done` read takes the existing DIRECT reader path and
+reads the value at the correct native-string typeIdx — no reader change needed.
+
+**Verified host-free + correct** (`result.imports == []`): `.next().value as
+string).length`, `=== "aa"`, annotated `Generator<string>` iterator, string
+generator with a `return` value, `.done` after exhaustion, and a numeric
+`.next().value` regression case. Tests: `tests/issue-2892-string-gen-value-reader.test.ts`
+(6 cases). gc (JS-host) mode validates unchanged; numeric path emits identical bytes.
+
+**Out of scope (pre-existing, separate path):** `for-of` over an *un-annotated*
+string generator returns 0 on `origin/main` too — that is the documented #2171
+loop-var-typing limitation (the loop var must be statically `string`), not this
+reader/dispatch bug. Mixed numeric+string generators now *validate* (eqref) but
+the open `.value` reader's string arm is still unimplemented — a strict
+improvement over the prior CE; a narrow follow-up if needed.

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -2182,17 +2182,32 @@ function buildNativeGeneratorDispatch(
   errorLocal?: number,
 ): { instrs: Instr[]; resultType: ValType } {
   const infos = Array.from(ctx.nativeGenerators.values());
-  // (#2864 F1) When ANY generator in the chain uses the boxed-any carrier, the
-  // enclosing block must accept every carrier's result struct, so its type is
-  // `eqref` (the common supertype) and the chain produces concrete result
-  // structs (eqref subtypes). For numeric/string-only modules (the existing,
-  // dominant case) there is no any carrier — keep the f64 IteratorResult
-  // singleton block type, byte-identical to before, so no numeric generator
-  // regresses.
+  // (#2864 F1 / #2892) The enclosing dispatch block must accept every branch's
+  // produced result struct. Each branch for generator `info` produces a value of
+  // type `ref info.resultTypeIdx`, so the block type must be a supertype of all
+  // of them:
+  //   - ANY boxed-any carrier present → `eqref` (the common eq supertype), as in
+  //     #2864 F1.
+  //   - all generators share ONE result-struct typeIdx → `ref <that idx>`. This
+  //     covers the dominant numeric-only case (every numeric generator shares the
+  //     f64 IteratorResult singleton, byte-identical to before) AND the #2892
+  //     single-string-elem case (the string carrier's per-elem result struct).
+  //     Previously this branch hard-coded the f64 singleton even for a string
+  //     generator, so the branches' `ref <stringResult>` mismatched the block's
+  //     `ref <f64Result>` and the module failed wasm validation.
+  //   - generators with DISTINCT result structs (e.g. a numeric AND a string
+  //     generator in one module) have no shared nominal supertype → `eqref`.
   const hasAny = infos.some((i) => carrierIsAny(i.elemValType));
-  const resultType: ValType = hasAny
-    ? { kind: "eqref" }
-    : { kind: "ref", typeIdx: ensureNativeGeneratorResultType(ctx) };
+  const distinctResultIdxs = new Set(infos.map((i) => i.resultTypeIdx));
+  let resultType: ValType;
+  if (hasAny || distinctResultIdxs.size > 1) {
+    resultType = { kind: "eqref" };
+  } else if (distinctResultIdxs.size === 1) {
+    resultType = { kind: "ref", typeIdx: infos[0]!.resultTypeIdx };
+  } else {
+    // No generators registered (defensive) — fall back to the f64 singleton.
+    resultType = { kind: "ref", typeIdx: ensureNativeGeneratorResultType(ctx) };
+  }
   // The per-branch `.next(v)`/`.return(v)` value local: an any-carrier branch
   // consumes the externref `valueAnyLocal`; numeric / string branches consume the
   // f64 `valueLocal` (unchanged). `valueLocal` is always present when valueAnyLocal

--- a/tests/issue-2892-string-gen-value-reader.test.ts
+++ b/tests/issue-2892-string-gen-value-reader.test.ts
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2892 — standalone string-elem native generator `.next().value` reader.
+ *
+ * A `function*` whose yields are all strings (the #2171 native-string carrier)
+ * compiled, but reading its result `.value` as a string via `it.next().value`
+ * in `--target standalone` failed wasm validation:
+ *
+ *   type error in fallthru[0] (expected (ref null 41), got (ref null 35))
+ *
+ * Root cause: when the iterator `it` is statically opaque (externref — the
+ * common shape for `let it = g()`), `.next()` lowers through the OPEN dispatch
+ * (`buildNativeGeneratorDispatch`). That block hard-coded its result type to the
+ * **f64 IteratorResult singleton**, while each per-generator branch produces its
+ * own per-elem result struct (the native-string `__NativeGeneratorResult_refN`).
+ * For a string generator the branch's `ref <stringResult>` mismatched the
+ * block's `ref <f64Result>`, so the module failed validation. The fix keys the
+ * dispatch block type on the generators actually present: one shared result
+ * struct → `ref <that idx>` (covers both the numeric singleton AND the single
+ * string carrier); distinct result structs / any-carrier → the `eqref` common
+ * supertype.
+ *
+ * This is independent of spills — it reproduces with a zero-spill string
+ * generator (`yield "aa"; yield "bbb"`). Every case compiles standalone with
+ * ZERO host imports.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const imports = WebAssembly.Module.imports(mod).map((i) => `${i.module}::${i.name}`);
+  expect(imports, "standalone module must have zero host imports").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2892 string-elem generator .next().value reader (standalone)", () => {
+  it("reads .value as string and takes .length (the original repro)", async () => {
+    expect(
+      await runStandalone(`function* g() { yield "aa"; yield "bbb"; }
+export function test(): number {
+  let it = g();
+  let a = (it.next().value as string).length;
+  let b = (it.next().value as string).length;
+  return a + b;
+}`),
+    ).toBe(5); // 2 + 3
+  });
+
+  it("string === comparison on .next().value", async () => {
+    expect(
+      await runStandalone(`function* g() { yield "aa"; yield "bbb"; }
+export function test(): number {
+  let it = g();
+  return (it.next().value as string) === "aa" ? 1 : 0;
+}`),
+    ).toBe(1);
+  });
+
+  it("annotated Generator<string> iterator reads .value", async () => {
+    expect(
+      await runStandalone(`function* g(): Generator<string> { yield "xy"; yield "z"; }
+export function test(): number {
+  let it: Generator<string> = g();
+  return (it.next().value as string).length + (it.next().value as string).length;
+}`),
+    ).toBe(3); // 2 + 1
+  });
+
+  it("string generator with a return value, then .done", async () => {
+    expect(
+      await runStandalone(`function* g() { yield "aa"; return "zzzz"; }
+export function test(): number {
+  let it = g();
+  let a = (it.next().value as string).length;
+  let r = it.next();
+  return a + (r.done ? 100 : 0);
+}`),
+    ).toBe(102); // 2 + 100
+  });
+
+  it(".done flips true after exhausting a string generator", async () => {
+    expect(
+      await runStandalone(`function* g() { yield "aa"; yield "bbb"; }
+export function test(): number {
+  let it = g();
+  it.next();
+  it.next();
+  return it.next().done ? 1 : 0;
+}`),
+    ).toBe(1);
+  });
+});
+
+describe("#2892 regression — numeric .next().value unchanged", () => {
+  it("numeric generator .next().value still sums", async () => {
+    expect(
+      await runStandalone(`function* n() { yield 1; yield 2; }
+export function test(): number {
+  let it = n();
+  return (it.next().value as number) + (it.next().value as number);
+}`),
+    ).toBe(3);
+  });
+});


### PR DESCRIPTION
## Problem

A string-elem native generator (#2171 native-string carrier) read via an opaque iterator fails wasm validation in `--target standalone`:

```ts
function* g() { yield "aa"; yield "bbb"; }
export function test(): number {
  let it = g();
  return (it.next().value as string).length + (it.next().value as string).length;
}
```
```
WebAssembly.compile() failed: type error in fallthru[0] (expected (ref null 41), got (ref null 35))
```
Zero host imports, but throws `CompileError` at instantiate. Independent of spills (#2864 F1b scoped around this).

## Root cause

When the iterator local is statically opaque (`let it = g()` types `it` as `externref`), `it.next()` lowers through the OPEN dispatch (`buildNativeGeneratorDispatch`), **not** the direct path. That function hard-coded its enclosing-block result type to the **f64 IteratorResult singleton** for any non-`any`-carrier module, while each per-generator branch produces its own per-elem result struct (`struct.new info.resultTypeIdx`). For a string generator the branch's `ref <stringResult>` (35) mismatched the block's `ref <f64Result>` (41, which the call also spuriously minted) → validation error.

## Fix

Key the dispatch block result type on the result structs actually present:
- any boxed-`any` carrier present, OR generators with **distinct** result structs → `eqref` (common `eq` supertype);
- all generators share ONE result-struct typeIdx → `ref <that idx>`.

This covers both the dominant numeric-only case (every numeric generator shares the f64 singleton — **byte-identical** to before) and the single-string-elem case. The single-string case now yields a concrete result ref, so the existing direct `.value`/`.done` reader handles it unchanged — no reader change needed.

## Verification (host-free, `imports == []`)

`.value as string).length`, `=== "aa"`, annotated `Generator<string>` iterator, string generator with a `return` value, `.done` after exhaustion, plus a numeric `.next().value` regression case. Tests: `tests/issue-2892-string-gen-value-reader.test.ts` (6 cases, all pass). Numeric path emits identical bytes; gc (JS-host) mode validates unchanged; related generator suites (#2171, #2864, generators, for-of-string-generator — 37 tests) pass.

Out of scope (pre-existing, separate path): `for-of` over an *un-annotated* string generator returns 0 on `origin/main` too (documented #2171 loop-var-typing limitation). Mixed numeric+string generators now *validate* (eqref) — a strict improvement over the prior CE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)