### PR TITLE
feat(#2866 slice 4): standalone Symbol.toPrimitive string-hint dispatch

### DIFF
--- a/plan/issues/2866-standalone-symbol-carrier.md
+++ b/plan/issues/2866-standalone-symbol-carrier.md
@@ -1,10 +1,11 @@
 ---
 id: 2866
 title: "Standalone: Symbol values leak __box_symbol — no Wasm-native Symbol carrier"
-status: in-progress
+status: done
 assignee: ttraenkler/sendev-symbol
 created: 2026-06-30
 updated: 2026-06-30
+completed: 2026-06-30
 priority: medium
 feasibility: hard
 task_type: feature

--- a/plan/issues/2866-standalone-symbol-carrier.md
+++ b/plan/issues/2866-standalone-symbol-carrier.md
@@ -218,3 +218,58 @@ answer.)
 - slice 3 SELECT side — `__getOwnPropertySymbols` still returns `[]` (stub); needs the
   `symbol[]` read path so the returned carriers are usable as symbol values.
 - slice 4 — `Symbol.toPrimitive` dispatch in the coercion engine (ties into #2862).
+
+## Implementation — slice 4 (Symbol.toPrimitive STRING-hint dispatch), sendev-symbol 2026-06-30
+
+**Verify-first re-grounded the gap (the earlier "illegal cast" finding was stale).**
+On current `origin/main` (post-PR1 #2377 + the #2891 ToPrimitive-operators landing),
+the NUMBER-hint path already dispatches `[Symbol.toPrimitive]` host-free: `+o` /
+`o*1` return the right value via `coerceType(ref→f64, "number")` →
+`${name}_@@toPrimitive`. The remaining gap was the **STRING-hint** coercion
+contexts — a template-literal span `` `${o}` `` and `String(o)` — which did NOT
+dispatch the well-known method:
+
+- **Template literal** → `tryStructToString` (type-coercion.ts), which only checked
+  a `toString` field/`${name}_toString` and fell through to `$__any_to_string`
+  ("[object Object]"). `[Symbol.toPrimitive]` was explicitly deferred there (old
+  doc comment).
+- **`String(o)`** → `coerceType(ref→externref, "string")` already dispatched
+  `${name}_@@toPrimitive`, but for a **numeric** result it `__box_number`-boxed the
+  number and returned the _boxed number_ as the "string" — which then null-derefs
+  on the next string op (`String(o).length`).
+
+**Fix (standalone/native only; gc structurally untouched):**
+
+1. `tryStructToString` (type-coercion.ts): add a §7.1.1.1-precedence `@@toPrimitive`
+   arm BEFORE the `toString` lookup — push the `"string"` hint, call
+   `${name}_@@toPrimitive`, then normalise the result to a `ref $AnyString`. A
+   numeric (f64/i32) result is ToString'd via the native `number_toString`
+   formatter (registered on demand — `emitNativeNumberFormat` only APPENDS defined
+   funcs, **no import-insert → no funcIdx-shift hazard**). This is preferred over
+   `normaliseToString`'s `__box_number`→`$__any_to_string` route, whose boxed-number
+   arm is OMITTED when `number_toString` was absent at the (cached) helper's build
+   time (an object-only program never registers it → "[object Object]").
+2. `coerceType(ref→externref)` `@@toPrimitive` arm: under a **STRING hint** (and
+   `ctx.nativeStrings`), ToString a numeric result via `number_toString` (returns
+   an externref wrapping a native string) instead of `__box_number`. **Gated on
+   `ctx.nativeStrings`** so gc mode keeps the exact prior `__box_number` branch —
+   byte-identical (verified: gc `String(o)` WAT still calls `__box_number`).
+
+**Verified host-free (`--target standalone`, 0 imports):** `` `${o}` `` /
+`String(o)` dispatch `[Symbol.toPrimitive]("string")` for both string- and
+number-returning methods (`String(o).length` correct); class `[Symbol.toPrimitive]`
+in string context; `+o` number-hint unchanged; toString-only + valueOf + plain
+`[object Object]` objects unregressed. 20/20 in `tests/issue-2866.test.ts`; related
+toprimitive/string-coercion suites green (#1716, #1806, #2163, #1470, #2610, #1732,
+#2891, #2358-nominal, #2638, #1917). gc byte-unchanged by construction (native-gated).
+
+**Side-benefit + a known minor edge (NOT a regression):** the native `+`-concat
+path (`obj + str`) also routes objects through `tryStructToString`, so it now
+dispatches `[Symbol.toPrimitive]` too — a strict improvement over the prior
+"[object Object]" (which ignored the method entirely). Its hint is `"string"`
+rather than the spec's `"default"` for `+`; this only differs for the rare method
+that distinguishes `default` vs `string`, and the prior behaviour was already
+wrong, so it is net-positive. Threading the exact `"default"` hint through
+`tryStructToString`'s callers is a follow-up. **Not addressed (separate gates):**
+abstract `==` ToPrimitive dispatch; `obj + str` default-hint `valueOf`-only
+(pre-existing native-concat gap, unrelated to symbols).

--- a/scripts/coercion-sites-baseline.json
+++ b/scripts/coercion-sites-baseline.json
@@ -33,5 +33,5 @@
   "codegen/statements/loops.ts": 1,
   "codegen/statements/nested-declarations.ts": 2,
   "codegen/string-ops.ts": 19,
-  "codegen/type-coercion.ts": 29
+  "codegen/type-coercion.ts": 33
 }

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -13,6 +13,7 @@ import { allocLocal, allocTempLocal, releaseTempLocal } from "./context/locals.j
 import type { ClosureInfo, CodegenContext, FunctionContext, OptionalParamInfo } from "./context/types.js";
 import { addUnionImports, ensureAnyHelpers, ensureAnyToExternHelper, isAnyValue } from "./index.js";
 import { ensureAnyToStringHelper, stringConstantExternrefInstrs } from "./native-strings.js";
+import { emitNativeNumberFormat } from "./number-format-native.js";
 import { addStringConstantGlobal } from "./registry/imports.js";
 import { addFuncType, getArrTypeIdxFromVec } from "./registry/types.js";
 import { ensureLateImport, flushLateImportShifts, materializeStructAsObject, registerCoerceType } from "./shared.js";
@@ -1755,17 +1756,24 @@ export function coerceType(
         const funcType = funcDef ? ctx.mod.types[funcDef.typeIdx] : undefined;
         // Default to "externref" for imports (funcDefIdx < 0) which typically return externref
         const retKind = (funcType?.kind === "func" && funcType.results?.[0]?.kind) || "externref";
-        if (retKind === "f64") {
-          // Ensure __box_number is available via union imports
-          addUnionImports(ctx);
-          const boxIdx = ctx.funcMap.get("__box_number")!;
-          fctx.body.push({ op: "call", funcIdx: boxIdx });
-        } else if (retKind === "i32") {
-          fctx.body.push({ op: "f64.convert_i32_s" });
-          // Ensure __box_number is available via union imports
-          addUnionImports(ctx);
-          const boxIdx = ctx.funcMap.get("__box_number")!;
-          fctx.body.push({ op: "call", funcIdx: boxIdx });
+        if (retKind === "f64" || retKind === "i32") {
+          if (retKind === "i32") fctx.body.push({ op: "f64.convert_i32_s" });
+          // (#2866 slice 4) Under a STRING hint (String()/concat ToString context,
+          // target externref), a numeric `@@toPrimitive` result must be ToString'd
+          // — NOT boxed. Returning a boxed-number externref as the "string" result
+          // null-derefs on the next string op (e.g. `String(o).length`). Use the
+          // native `number_toString` formatter (registered eagerly for String()
+          // calls), which returns an externref wrapping a native string. Fall back
+          // to boxing when it is unavailable (no string-hint context, or host mode
+          // without the formatter) — preserves prior behaviour, no regression.
+          const numToStrIdx = hint === "string" && ctx.nativeStrings ? ctx.funcMap.get("number_toString") : undefined;
+          if (numToStrIdx !== undefined) {
+            fctx.body.push({ op: "call", funcIdx: numToStrIdx });
+          } else {
+            addUnionImports(ctx);
+            const boxIdx = ctx.funcMap.get("__box_number")!;
+            fctx.body.push({ op: "call", funcIdx: boxIdx });
+          }
         }
         // externref/ref return → use extern.convert_any for ref types
         if (retKind === "ref" || retKind === "ref_null") {
@@ -2626,9 +2634,48 @@ export function tryStructToString(ctx: CodegenContext, fctx: FunctionContext, fr
     return ft?.kind === "func" ? ft.results?.[0]?.kind : undefined;
   };
 
+  // 0. `[Symbol.toPrimitive]` method (`${name}_@@toPrimitive`) — takes precedence
+  // over toString/valueOf per §7.1.1.1 (ToString(obj) = ToString(ToPrimitive(obj,
+  // "string"))). (#2866 slice 4) Mirrors the numeric (ref→f64) @@toPrimitive
+  // dispatch in `coerceType`: self is already on the stack, push the "string" hint
+  // externref, call the wrapper, then normalise the result (f64/i32/string-ref) to
+  // a `ref $AnyString`. Host-free: the only late import is `__box_number` (native
+  // in standalone), reached only when the method returns a number. This was the
+  // deferred residual noted in the old comment below — String()/template-literal
+  // string coercion now dispatches `[Symbol.toPrimitive]("string")` natively.
+  const toPrimFuncIdx = ctx.funcMap.get(`${name}_@@toPrimitive`);
+  if (toPrimFuncIdx !== undefined) {
+    pushStringHint(ctx, fctx, "string");
+    fctx.body.push({ op: "call", funcIdx: toPrimFuncIdx });
+    const retKind = funcResultKind(toPrimFuncIdx);
+    if (retKind === "f64" || retKind === "i32") {
+      // Numeric primitive result → ToString via the native `number_toString`
+      // formatter (host-free), mirroring the f64→string bridge in
+      // `coercion-engine.ts`. Register it on demand — `emitNativeNumberFormat`
+      // only APPENDS defined funcs (no import insertion → no funcIdx-shift
+      // hazard). This is preferred over `normaliseToString`'s
+      // `__box_number`→`$__any_to_string` route, whose boxed-number arm is
+      // OMITTED when `number_toString` was absent at the (cached) helper's build
+      // time (an object-only program never registers it otherwise → the result
+      // would mis-stringify to "[object Object]").
+      if (retKind === "i32") fctx.body.push({ op: "f64.convert_i32_s" });
+      let numToStrIdx = ctx.funcMap.get("number_toString");
+      if (numToStrIdx === undefined) {
+        emitNativeNumberFormat(ctx, new Set(["number_toString"]));
+        numToStrIdx = ctx.funcMap.get("number_toString");
+      }
+      if (numToStrIdx !== undefined) {
+        fctx.body.push({ op: "call", funcIdx: numToStrIdx });
+        fctx.body.push({ op: "any.convert_extern" } as Instr);
+        fctx.body.push({ op: "ref.cast", typeIdx: ctx.anyStrTypeIdx } as Instr);
+        return true;
+      }
+    }
+    normaliseToString(retKind);
+    return true;
+  }
+
   // 1. `toString` closure field (object-literal method) via call_ref.
-  // (A user `[Symbol.toPrimitive]` would take precedence per §7.1.1.1, but its
-  // native-string hint marshalling is deferred — see the function doc comment.)
   const fields = ctx.structFields.get(name);
   if (fields) {
     const toStrFieldIdx = fields.findIndex((f) => f.name === "toString");

--- a/tests/issue-2866.test.ts
+++ b/tests/issue-2866.test.ts
@@ -126,3 +126,78 @@ describe("#2866 native Symbol carrier — Symbol-keyed $Object ops (standalone)"
     ).toBe(210);
   });
 });
+
+describe("#2866 slice 4 — Symbol.toPrimitive string-hint dispatch (standalone)", () => {
+  // Pre-slice-4: `+obj` already dispatched `[Symbol.toPrimitive]("number")`
+  // host-free (#2891), but the STRING-hint coercion contexts — a template-literal
+  // span `\`${o}\`` and `String(o)` — did NOT dispatch the well-known
+  // `Symbol.toPrimitive` method: the template path's `tryStructToString` only
+  // checked `toString`, and the `String()` path's `coerceType(ref→externref,
+  // "string")` BOXED a numeric `@@toPrimitive` result instead of stringifying it
+  // (a boxed-number externref then null-derefs on the next string op). Slice 4
+  // wires `[Symbol.toPrimitive]("string")` into both, host-free.
+
+  it("template literal dispatches @@toPrimitive with the 'string' hint", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o = { [Symbol.toPrimitive](hint: string): string { return hint === "string" ? "S" : "N"; } }; return \`\${o}\` === "S" ? 1 : -1; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("String(o) dispatches @@toPrimitive with the 'string' hint", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o = { [Symbol.toPrimitive](hint: string): string { return hint === "string" ? "S" : "N"; } }; return String(o) === "S" ? 1 : -1; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("a numeric @@toPrimitive('string') result is ToString'd, not boxed (template)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o = { [Symbol.toPrimitive](hint: string): number { return hint === "string" ? 2 : 1; } }; return \`\${o}\` === "2" ? 1 : -1; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("a numeric @@toPrimitive('string') result is ToString'd, not boxed (String + .length)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o = { [Symbol.toPrimitive](hint: string): number { return hint === "string" ? 2 : 1; } }; return String(o).length; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("the 'number' hint still wins for unary + (no string-path regression)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o = { [Symbol.toPrimitive](hint: string): number { return hint === "number" ? 42 : 0; } }; return +o; }`,
+      ),
+    ).toBe(42);
+  });
+
+  it("a class [Symbol.toPrimitive] dispatches in string context", async () => {
+    expect(
+      await runStandalone(
+        `class C { [Symbol.toPrimitive](hint: string): string { return hint === "string" ? "CS" : "CN"; } } export function test(): number { const c = new C(); return \`\${c}\` === "CS" ? 1 : -1; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("toString-only objects are unregressed (no @@toPrimitive)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o = { toString(): string { return "TS"; } }; return (\`\${o}\` === "TS" && String(o) === "TS") ? 1 : -1; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("plain objects still stringify to [object Object]", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const o = { a: 1 }; return \`\${o}\` === "[object Object]" ? 1 : -1; }`,
+      ),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Completes **slice 4** of the standalone native Symbol carrier (#2866): a user
`[Symbol.toPrimitive]("string")` is now dispatched **host-free** in the STRING
coercion contexts — template literals (`` `${o}` ``) and `String(o)`.

Verify-first re-grounded the gap (the issue's earlier "illegal cast" note was
stale on current main): post-PR1 (#2377) + #2891, the **number-hint** path (`+o`,
`o*1`) already dispatched `[Symbol.toPrimitive]` host-free. The remaining gap was
**string-hint**:

- **Template literal** → `tryStructToString` only checked `toString` and fell
  through to `$__any_to_string` ("[object Object]"); `@@toPrimitive` was explicitly
  deferred there.
- **`String(o)`** → `coerceType(ref→externref, "string")` dispatched
  `@@toPrimitive` but for a numeric result **boxed** it (`__box_number`) and
  returned the boxed number as the "string" → null-deref on the next string op
  (`String(o).length`).

## Changes (standalone/native only; gc byte-unchanged by construction)

- `tryStructToString` (`type-coercion.ts`): §7.1.1.1-precedence `@@toPrimitive` arm
  before the `toString` lookup. Numeric result ToString'd via the native
  `number_toString` formatter (registered on demand — `emitNativeNumberFormat`
  only APPENDS defined funcs → **no funcIdx-shift hazard**), avoiding
  `normaliseToString`'s `__box_number`→`$__any_to_string` route whose number arm is
  omitted when `number_toString` was absent at the cached helper's build time.
- `coerceType(ref→externref)` `@@toPrimitive` arm: under a **STRING hint** (gated on
  `ctx.nativeStrings`) ToString a numeric result via `number_toString` instead of
  `__box_number`. The gate keeps gc mode on the exact prior `__box_number` branch.

## Verification

Host-free (`--target standalone`, 0 imports), all correct: `` `${o}` `` /
`String(o)` for string- and number-returning `@@toPrimitive`; `String(o).length`;
class `[Symbol.toPrimitive]` in string context; `+o` number-hint unchanged;
toString-only / valueOf / plain `[object Object]` objects unregressed.

- `tests/issue-2866.test.ts`: **27/27** (12 PR1 + 7 slice-3 + 8 new slice-4).
- Related suites green: #1716, #1806, #2163, #1470, #2610, #1732, #2891,
  #2358-nominal, #2638, #1917.
- gc byte-unchanged (verified gc `String(o)` WAT still calls `__box_number`).

Side-benefit (not a regression): the native `+`-concat path now also dispatches
`[Symbol.toPrimitive]` for objects — a strict improvement over the prior
"[object Object]". Its hint is `"string"` vs the spec's `"default"` for `+` (only
differs for the rare method distinguishing the two; prior behaviour was already
wrong). Threading the exact `"default"` hint is a follow-up.

Merged origin/main: slice 3 (#2379) landed during development; both test blocks +
issue notes coexist. **Full merge_group standalone report is the gate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)