### PR TITLE
refactor(#2895 PR1): extract resumable-frame core (byte-identical for generators)

### DIFF
--- a/src/codegen/frame-core.ts
+++ b/src/codegen/frame-core.ts
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Resumable-frame core (#2895 PR1) — the host-free state-machine substrate
+ * shared by the Wasm-native suspendable lowerings.
+ *
+ * This module is the **mechanism layer** extracted from `generators-native.ts`
+ * (#680/#2079/#2864): the frame ABI (state-struct field offsets + resume modes),
+ * the per-spill default initialiser, and the small state-struct field-I/O +
+ * spill-store emit helpers. It is generator-agnostic — every helper operates on
+ * the structural {@link FrameLayout} subset of a frame's state struct, so the
+ * Wasm-native **generator** path (`generators-native.ts`) and the upcoming
+ * host-free **async** path (#2895 PATH B: `await`-suspend → microtask resume)
+ * both consume the exact same primitives instead of forking the substrate.
+ *
+ * PR1 is a pure extraction: the helpers emit byte-identical instructions to the
+ * copies they replaced (`NativeGeneratorInfo` structurally satisfies
+ * `FrameLayout`, so generator call sites pass `info` unchanged). No behaviour
+ * change; the ~250 native-generator tests are the safety gate. The async result/
+ * drive layer (`$Promise` + microtask) builds on this stable core in PR2+.
+ */
+import type { Instr, ValType } from "../ir/types.js";
+import type { FunctionContext } from "./context/types.js";
+
+// ── Frame ABI ──────────────────────────────────────────────────────────────
+// Fixed leading fields of every resumable frame's state struct, followed by the
+// captured params (at PARAM_FIELD_OFFSET) and the live-across-suspend spills.
+
+/** State-struct field: the i32 resume state (`br_table` selector). */
+export const STATE_FIELD = 0;
+/** State-struct field: the value delivered on resume (`.next(v)` / awaited value). */
+export const SENT_FIELD = 1;
+/** State-struct field: the i32 resume mode (see MODE_*). */
+export const MODE_FIELD = 2;
+/** State-struct field: the value passed to `.return(v)` (abrupt completion). */
+export const ABRUPT_FIELD = 3;
+/**
+ * State-struct field: the error payload for a `.throw(e)` abrupt resume (#2864
+ * F2). Always externref (an Error object), independent of the carrier — the
+ * `sent`/`abrupt` carrier fields can be f64 in a numeric generator, so the
+ * thrown value needs its own slot. Resume mode 2 reads it and re-throws after
+ * running enclosing finalizers.
+ */
+export const ERROR_FIELD = 4;
+/** First field index of the captured params in the state struct. */
+export const PARAM_FIELD_OFFSET = 5;
+
+/** Result-struct (`{value, done}`) field: the yielded/returned value. */
+export const RESULT_VALUE_FIELD = 0;
+/** Result-struct field: the i32 `done` flag. */
+export const RESULT_DONE_FIELD = 1;
+
+/** Resume modes stored in MODE_FIELD. */
+export const MODE_NEXT = 0;
+export const MODE_RETURN = 1;
+export const MODE_THROW = 2;
+
+/**
+ * The structural subset of a frame's state-struct layout the field-I/O helpers
+ * below depend on. {@link import("./context/types.js").NativeGeneratorInfo}
+ * satisfies this, and the async-frame info (#2895 PR2) will too, so both drive
+ * the shared helpers without a wrapper.
+ */
+export interface FrameLayout {
+  /** Per-frame state struct type index. */
+  stateTypeIdx: number;
+  /** Field index of the i32 resume mode. */
+  modeFieldIdx: number;
+  /** Function-local names spilled into the state struct across suspensions. */
+  spillNames: string[];
+  /** Wasm ValType of each spilled local, aligned 1:1 with `spillNames`. */
+  spillTypes: ValType[];
+  /** Field index where spilled locals start in the state struct. */
+  spillFieldOffset: number;
+}
+
+export function sanitizeTypeName(name: string): string {
+  return name.replace(/[^A-Za-z0-9_$]/g, "_");
+}
+
+/**
+ * The inert default a spill field is constructed with, by ValType (#2864 F1b).
+ * Overwritten by the body's declaration on first entry into the owning state, so
+ * it only has to satisfy `struct.new`'s field type.
+ */
+export function defaultSpillInstr(type: ValType): Instr {
+  switch (type.kind) {
+    case "f64":
+      return { op: "f64.const", value: NaN };
+    case "i32":
+      return { op: "i32.const", value: 0 };
+    case "i64":
+      return { op: "i64.const", value: 0n } as Instr;
+    case "externref":
+      return { op: "ref.null.extern" } as Instr;
+    default:
+      return { op: "ref.null", typeIdx: (type as { typeIdx: number }).typeIdx } as Instr;
+  }
+}
+
+export function setStateInstrs(layout: FrameLayout, selfLocal: number, state: number): Instr[] {
+  return [
+    { op: "local.get", index: selfLocal },
+    { op: "i32.const", value: state },
+    { op: "struct.set", typeIdx: layout.stateTypeIdx, fieldIdx: STATE_FIELD },
+  ];
+}
+
+export function setModeInstrs(layout: FrameLayout, selfLocal: number, mode: number): Instr[] {
+  return [
+    { op: "local.get", index: selfLocal },
+    { op: "i32.const", value: mode },
+    { op: "struct.set", typeIdx: layout.stateTypeIdx, fieldIdx: layout.modeFieldIdx },
+  ];
+}
+
+export function setStateFieldFromLocal(
+  layout: FrameLayout,
+  selfLocal: number,
+  fieldIdx: number,
+  valueLocal: number,
+): Instr[] {
+  return [
+    { op: "local.get", index: selfLocal },
+    { op: "local.get", index: valueLocal },
+    { op: "struct.set", typeIdx: layout.stateTypeIdx, fieldIdx },
+  ];
+}
+
+export function setStateI32FromConst(layout: FrameLayout, selfLocal: number, fieldIdx: number, value: number): Instr[] {
+  return [
+    { op: "local.get", index: selfLocal },
+    { op: "i32.const", value },
+    { op: "struct.set", typeIdx: layout.stateTypeIdx, fieldIdx },
+  ];
+}
+
+/**
+ * Store each live spill local back into its state-struct field before a
+ * suspension. Skips spills not currently bound in `fctx.localMap` (a spill whose
+ * owning state has not declared it yet).
+ */
+export function storeSpills(layout: FrameLayout, fctx: FunctionContext, selfLocal: number): Instr[] {
+  const body: Instr[] = [];
+  for (let i = 0; i < layout.spillNames.length; i++) {
+    const localIdx = fctx.localMap.get(layout.spillNames[i]!);
+    if (localIdx === undefined) continue;
+    body.push({ op: "local.get", index: selfLocal });
+    body.push({ op: "local.get", index: localIdx });
+    body.push({ op: "struct.set", typeIdx: layout.stateTypeIdx, fieldIdx: layout.spillFieldOffset + i });
+  }
+  return body;
+}

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -39,23 +39,29 @@ import { coerceType, compileExpression, compileStatement, valTypesMatch } from "
 import { bodyUsesArguments } from "./helpers/body-uses-arguments.js";
 import { resolveSpillLocalValType } from "./statements/variables.js";
 import { ensureExnTag } from "./registry/imports.js";
+// (#2895 PR1) The frame ABI (state-struct field offsets + resume modes) and the
+// field-I/O / spill-store emit helpers now live in the shared resumable-frame
+// core, consumed unchanged here and by the host-free async path (PATH B).
+import {
+  STATE_FIELD,
+  SENT_FIELD,
+  MODE_FIELD,
+  ABRUPT_FIELD,
+  ERROR_FIELD,
+  RESULT_VALUE_FIELD,
+  RESULT_DONE_FIELD,
+  PARAM_FIELD_OFFSET,
+  MODE_NEXT,
+  MODE_THROW,
+  sanitizeTypeName,
+  defaultSpillInstr,
+  setStateInstrs,
+  setModeInstrs,
+  setStateFieldFromLocal,
+  setStateI32FromConst,
+  storeSpills,
+} from "./frame-core.js";
 
-const STATE_FIELD = 0;
-const SENT_FIELD = 1;
-const MODE_FIELD = 2;
-const ABRUPT_FIELD = 3;
-// (#2864 F2) `gen.throw(e)` error payload. Always externref (an Error object),
-// independent of the carrier — the `abrupt`/`sent` carrier fields can be f64 in a
-// numeric generator, so the thrown value needs its own slot. Resume mode 2 reads
-// it and re-throws after running enclosing finalizers.
-const ERROR_FIELD = 4;
-const RESULT_VALUE_FIELD = 0;
-const RESULT_DONE_FIELD = 1;
-const PARAM_FIELD_OFFSET = 5;
-// Resume modes stored in MODE_FIELD: 0 = next, 1 = return (abrupt), 2 = throw.
-const MODE_NEXT = 0;
-const MODE_RETURN = 1;
-const MODE_THROW = 2;
 const MAX_NATIVE_GENERATOR_STATES = 256;
 
 /**
@@ -129,10 +135,6 @@ interface NativeGeneratorPlan {
 
 function noJsHostTarget(ctx: CodegenContext): boolean {
   return ctx.standalone || ctx.wasi;
-}
-
-function sanitizeTypeName(name: string): string {
-  return name.replace(/[^A-Za-z0-9_$]/g, "_");
 }
 
 function isNumericExpression(ctx: CodegenContext, expr: ts.Expression | undefined): boolean {
@@ -1286,67 +1288,11 @@ function emptyResult(info: NativeGeneratorInfo): Instr[] {
   ];
 }
 
-// (#2864 F1b) The inert default a spill field is constructed with, by ValType.
-// Overwritten by the body's declaration on first entry into the owning state, so
-// it only has to satisfy `struct.new`'s field type. Mirrors `defaultElemValueInstr`
-// but spans the full set of supported spill kinds.
-function defaultSpillInstr(type: ValType): Instr {
-  switch (type.kind) {
-    case "f64":
-      return { op: "f64.const", value: NaN };
-    case "i32":
-      return { op: "i32.const", value: 0 };
-    case "i64":
-      return { op: "i64.const", value: 0n } as Instr;
-    case "externref":
-      return { op: "ref.null.extern" } as Instr;
-    default:
-      return { op: "ref.null", typeIdx: (type as { typeIdx: number }).typeIdx } as Instr;
-  }
-}
-
 function emptyResultForType(resultTypeIdx: number): Instr[] {
   return [
     { op: "f64.const", value: 0 },
     { op: "i32.const", value: 1 },
     { op: "struct.new", typeIdx: resultTypeIdx },
-  ];
-}
-
-function setStateInstrs(info: NativeGeneratorInfo, selfLocal: number, state: number): Instr[] {
-  return [
-    { op: "local.get", index: selfLocal },
-    { op: "i32.const", value: state },
-    { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: STATE_FIELD },
-  ];
-}
-
-function setModeInstrs(info: NativeGeneratorInfo, selfLocal: number, mode: number): Instr[] {
-  return [
-    { op: "local.get", index: selfLocal },
-    { op: "i32.const", value: mode },
-    { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: info.modeFieldIdx },
-  ];
-}
-
-function setStateFieldFromLocal(
-  info: NativeGeneratorInfo,
-  selfLocal: number,
-  fieldIdx: number,
-  valueLocal: number,
-): Instr[] {
-  return [
-    { op: "local.get", index: selfLocal },
-    { op: "local.get", index: valueLocal },
-    { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx },
-  ];
-}
-
-function setStateI32FromConst(info: NativeGeneratorInfo, selfLocal: number, fieldIdx: number, value: number): Instr[] {
-  return [
-    { op: "local.get", index: selfLocal },
-    { op: "i32.const", value },
-    { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx },
   ];
 }
 
@@ -1356,18 +1302,6 @@ function nativeReturnResultFromLocal(info: NativeGeneratorInfo, valueLocal: numb
     { op: "i32.const", value: 1 },
     { op: "struct.new", typeIdx: info.resultTypeIdx },
   ];
-}
-
-function storeSpills(info: NativeGeneratorInfo, fctx: FunctionContext, selfLocal: number): Instr[] {
-  const body: Instr[] = [];
-  for (let i = 0; i < info.spillNames.length; i++) {
-    const localIdx = fctx.localMap.get(info.spillNames[i]!);
-    if (localIdx === undefined) continue;
-    body.push({ op: "local.get", index: selfLocal });
-    body.push({ op: "local.get", index: localIdx });
-    body.push({ op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: info.spillFieldOffset + i });
-  }
-  return body;
 }
 
 function emitExpressionAsF64(ctx: CodegenContext, fctx: FunctionContext, expr: ts.Expression | undefined): number {


### PR DESCRIPTION
## Summary

PR1 of PATH B (#2895) — a **pure, byte-identical extraction** of the resumable-frame mechanism out of `generators-native.ts` into a shared `src/codegen/frame-core.ts`. This is the stable base the host-free **async** result/drive layer (PR2+) builds on, so async and generators consume one frame substrate instead of forking it (Option P per the coordinator).

No behaviour change. The safety gate is **zero native-generator regression** — confirmed byte-identical + the generator test suites green.

### What moved (verbatim, behind a structural `FrameLayout` interface)

- The frame ABI constants: `STATE_FIELD`/`SENT_FIELD`/`MODE_FIELD`/`ABRUPT_FIELD`/`ERROR_FIELD`/`PARAM_FIELD_OFFSET`/`RESULT_VALUE_FIELD`/`RESULT_DONE_FIELD`/`MODE_NEXT`/`MODE_RETURN`/`MODE_THROW`.
- `sanitizeTypeName`, `defaultSpillInstr`, and the state-struct field-I/O + spill-store emit helpers: `setStateInstrs`, `setModeInstrs`, `setStateFieldFromLocal`, `setStateI32FromConst`, `storeSpills`.

`NativeGeneratorInfo` structurally satisfies `FrameLayout`, so generator call sites pass `info` unchanged — the emitted instructions are identical.

### Verification

- **Byte-identical generator emission**: 8 generator programs (numeric / object / string / spill / loop / try-finally / yield\* / return) × 3 targets (gc / standalone / wasi) → identical binaries, base-vs-refactored, re-proven against current `main` (incl. #2892).
- Native-generator test suites: 47/47 pass (the 1 file-load failure is the pre-existing repo-wide `tests/helpers.js` env artifact, unrelated).
- tsc + prettier + biome clean.
- **The `merge_group` must confirm zero generator regression** (the ~250 native-generator tests) — that is the whole point of doing the extraction byte-identical first.

### Follow-up

PR2+ adds the async result/drive layer (`$AsyncFrame`, `__async_resume_f`, await-suspend → microtask resume, `__async_step_f` adapter, settle-on-completion) on this frame-core, per the #2895 implementation plan. Independent of #2380 (AG0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)