### PR TITLE
chore(dashboard): show host-mode conformance only on landing + report pages

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1653,7 +1653,7 @@
                  baseline. Off by default so the headline number reflects
                  shipped ECMAScript only. -->
             <div class="feat-filter conformance-scope-toggle">
-              <label class="feat-toggle">
+              <label class="feat-toggle" style="display: none">
                 <input type="checkbox" id="host-support-toggle" checked />
                 <span>JS host</span>
               </label>

--- a/website/public/benchmarks/report.html
+++ b/website/public/benchmarks/report.html
@@ -2625,13 +2625,13 @@
 
           // Mode switch (only shown when standalone data is available).
           const conformanceHost = el("div");
-          let activeMode = standaloneView && localStorage.getItem("t262-mode") === "standalone" ? "standalone" : "host";
+          let activeMode = "host";
           const renderActive = () => {
             conformanceHost.textContent = "";
             const view = activeMode === "standalone" && standaloneView ? standaloneView : hostView;
             renderConformance(view, conformanceHost, conformanceRuns);
           };
-          if (standaloneView) {
+          if (false) {
             const modeSwitch = el("div", { className: "mode-switch" });
             const mkBtn = (mode, main, sub) => {
               const b = el(


### PR DESCRIPTION
Simplifies the conformance display scope on both dashboard pages to a single host-mode number.

- **Landing page** (`website/index.html`): hides the JS-host scope toggle label via `style="display: none"`. The `#host-support-toggle` checkbox stays in the DOM and `checked` (it is read at three JS sites for the feature table), so the view is locked to host mode.
- **Report page** (`website/public/benchmarks/report.html`): forces `activeMode = "host"` and guards the Host/Standalone mode-switch construction with `if (false)`, so the switch never renders and only the host number is shown.

Website-only display-scope change. `report.html` is copied verbatim by `scripts/build-pages.js`; the landing page is the Vite root — verified the built `dist/playground/index.html` keeps the input element and applies the hidden style, with the Strict-mode toggle untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)