### PR TITLE
chore(es3): file #2897-#2900 for the 100%-ES3 gaps + bump #2676 (high/current)

### DIFF
--- a/plan/issues/2676-es3-mapped-arguments-strict-delete-aliased-throw.md
+++ b/plan/issues/2676-es3-mapped-arguments-strict-delete-aliased-throw.md
@@ -4,7 +4,7 @@ title: "≤ES3: mapped arguments — strict-mode aliased `delete args[i]` must t
 status: ready
 created: 2026-06-25
 updated: 2026-06-25
-priority: medium
+priority: high
 feasibility: hard
 reasoning_effort: high
 task_type: bug
@@ -14,7 +14,7 @@ language_feature: arguments-object
 goal: spec-completeness
 depends_on: []
 related: [2667, 1511]
-sprint: Backlog
+sprint: current
 ---
 # #2676 — ≤ES3 mapped-arguments strict aliased delete throws (residual of #2667)
 

--- a/plan/issues/2897-es3-arguments-assignment-target-null-deref.md
+++ b/plan/issues/2897-es3-arguments-assignment-target-null-deref.md
@@ -1,0 +1,34 @@
+---
+id: 2897
+title: "≤ES3: `arguments` as assignment target crashes (null-deref)"
+status: ready
+priority: high
+sprint: current
+created: 2026-06-30
+feasibility: medium
+task_type: bug
+area: codegen
+es_edition: 3
+language_feature: arguments
+goal: spec-completeness
+related: [2676, 2667]
+---
+
+# #2897 — `arguments` identifier-reference assignment target null-derefs
+
+One of the **8 tests blocking 100% ≤ES3 conformance** (ES3 edition currently 266/274 ≈ 97%).
+
+## Failing test
+`test/language/expressions/assignmenttargettype/simple-basic-identifierreference-arguments.js`
+
+→ **`L41:3 dereferencing a null pointer [in test()]`** — a compiler/runtime **crash**, not a wrong value.
+
+## What it checks
+`arguments` is a valid `SimpleAssignmentTarget` (AssignmentTargetType = "simple") in non-strict code, so an assignment whose target is the `arguments` identifier reference must compile and run. The test drives the assignment-target-type machinery using `arguments` as the LHS.
+
+## Root-cause direction
+The codegen path for an assignment whose LHS resolves to the `arguments` binding dereferences a null pointer — the `arguments` object/local is likely not materialized on the **assignment-target (lvalue)** path the way it is on the read path. Look at identifier-reference assignment lowering (`src/codegen/expressions/assignment.ts`) and how `arguments` is bound as an lvalue (the eager-arguments-materialization site).
+
+## Acceptance
+- The test compiles + runs without the null-deref and passes.
+- No regression in other `arguments`/assignment tests.

--- a/plan/issues/2898-es3-yield-assignment-target-early-error.md
+++ b/plan/issues/2898-es3-yield-assignment-target-early-error.md
@@ -1,0 +1,34 @@
+---
+id: 2898
+title: "≤ES3: `yield` as assignment target should be an early SyntaxError (currently compiles)"
+status: ready
+priority: high
+sprint: current
+created: 2026-06-30
+feasibility: medium
+task_type: bug
+area: codegen
+es_edition: 3
+language_feature: early-error
+goal: spec-completeness
+related: [2897]
+---
+
+# #2898 — `yield`-expression as assignment target is missing its early SyntaxError
+
+One of the **8 tests blocking 100% ≤ES3 conformance**.
+
+## Failing test
+`test/language/expressions/assignmenttargettype/direct-yieldexpression-0.js`
+
+→ **`expected parse/early SyntaxError but compiled and instantiated successfully`** — we accept a program the spec rejects at parse time.
+
+## What it checks
+A `YieldExpression` has AssignmentTargetType "invalid", so using it as an assignment target is an **early SyntaxError** (negative test, `phase: parse`). We currently compile + instantiate it instead of rejecting it.
+
+## Root-cause direction
+Early-error / negative-test handling: the parser or the pre-codegen early-error pass does not flag a `yield`-expression in assignment-target position. Find where AssignmentTargetType invalidity is (or isn't) enforced — the negative `phase: parse` test expects a `SyntaxError` raised before compilation. Note this is an **edition-heuristic ≤ES3 bucket** (yield is ES6); it counts toward the project's ES3 metric but is an early-error/generator concern.
+
+## Acceptance
+- The test raises the expected early `SyntaxError` and is recorded as pass.
+- No regression in valid `yield`/generator tests.

--- a/plan/issues/2899-es3-function-caller-poison-pill-set.md
+++ b/plan/issues/2899-es3-function-caller-poison-pill-set.md
@@ -1,0 +1,34 @@
+---
+id: 2899
+title: "≤ES3: Function `.caller` poison-pill must throw TypeError on set (`bound.caller = {}`)"
+status: ready
+priority: high
+sprint: current
+created: 2026-06-30
+feasibility: medium
+task_type: bug
+area: runtime
+es_edition: 3
+language_feature: function-caller
+goal: spec-completeness
+related: [2897]
+---
+
+# #2899 — bound-function `.caller` poison-pill does not throw on assignment
+
+One of the **8 tests blocking 100% ≤ES3 conformance**.
+
+## Failing test
+`test/language/statements/function/13.2-30-s.js`
+
+→ **`returned 5 — assert #4 at L22: assert.throws(TypeError, function() { bound.caller = {}; })`** — assigning to `.caller` should throw `TypeError`, but doesn't.
+
+## What it checks
+`Function.prototype.caller` / `Function.prototype.arguments` are "poison-pill" accessor properties: their `[[Get]]`/`[[Set]]` throw a `TypeError` (especially on a bound/strict function). `bound.caller = {}` must throw. We currently allow the assignment (the property isn't a throwing accessor).
+
+## Root-cause direction
+The function-object property model needs `caller`/`arguments` realized as poison-pill accessors (throwing getter+setter) on the relevant functions (bound functions, strict functions). Look at how function objects expose `caller`/`arguments` and the assignment path for those keys. (Technically an ES5-strict semantic that the edition heuristic buckets as ≤ES3.)
+
+## Acceptance
+- `bound.caller = {}` (and `.arguments` set/get) throw `TypeError`; the test passes.
+- No regression in normal function-property tests.

--- a/plan/issues/2900-es3-module-indirect-default-binding-update.md
+++ b/plan/issues/2900-es3-module-indirect-default-binding-update.md
@@ -1,0 +1,34 @@
+---
+id: 2900
+title: "≤ES3 (edition bucket): module indirect default-export binding update returns wrong value"
+status: ready
+priority: high
+sprint: current
+created: 2026-06-30
+feasibility: hard
+task_type: bug
+area: codegen
+es_edition: 3
+language_feature: module-code
+goal: spec-completeness
+related: [2898]
+---
+
+# #2900 — module indirect global-binding update of a default export reads stale
+
+One of the **8 tests blocking 100% ≤ES3 conformance** (edition-heuristic bucket — this is module/ESM code, surfaced under ≤ES3 because it lacks version frontmatter).
+
+## Failing test
+`test/language/module-code/eval-gtbndng-indirect-update-dflt.js`
+
+→ **`returned 2`** (assertion failure — the indirectly-updated binding reads the wrong value).
+
+## What it checks
+ES module semantics: a `default` export bound indirectly (via an indirect/re-exported binding) must observe later updates to the live binding (module bindings are live, not snapshots). The test mutates the binding and asserts the indirect reference sees the new value.
+
+## Root-cause direction
+Module-code (ESM) live-binding handling for the `default` export through an indirect binding. Likely the default-export slot is read as a value copy rather than through the live module-environment binding. This is part of broader module-code support; scope to this single default-export-indirect-update case unless a shared root cause covers more `module-code/eval-gtbndng-*` tests.
+
+## Acceptance
+- The indirect default-binding update is observed; the test passes.
+- No regression in other `module-code/` tests.


### PR DESCRIPTION
ES3 (≤ES3 edition) is **266/274 ≈ 97%**; 8 tests block 100%. This files high-priority `sprint: current` issues for the 4 uncovered root causes and raises the existing #2676 (mapped-`arguments` strict-`delete` cluster, 4 tests) to high/current.

| Issue | Gap | Tests |
|---|---|---|
| #2676 (bumped) | mapped `arguments` strict `delete args[i]` → TypeError | 4 |
| #2897 | `arguments` as assignment target null-deref crash | 1 |
| #2898 | `yield` as assignment target missing early SyntaxError | 1 |
| #2899 | Function `.caller` poison-pill must throw on set | 1 |
| #2900 | module indirect default-export binding update | 1 |

Issue-files only, no code.