### PR TITLE
docs(#2893,#2862): architect implementation specs for two standalone-gap substrate fronts

### DIFF
--- a/plan/issues/2862-standalone-toprimitive-builtin-exotics.md
+++ b/plan/issues/2862-standalone-toprimitive-builtin-exotics.md
@@ -174,3 +174,199 @@ failures, all collapsed onto one signature by the runner's error-formatter.
 already tagged for (`architect_spec: candidate`). The claim is released so the
 de-mask step (a test-infra change, not this compiler substrate) can be routed
 independently.
+
+## Implementation Plan (architect design pass, 2026-06-30)
+
+This design pass **honors the verify-first finding above** and supersedes the
+A/B sketch in the original "Implementation Plan". The headline correction: the
+proximate `"Cannot convert object to primitive value"` signature is *mostly* a
+test-runner stringify artifact, NOT one compiler bug. So #2862 is **not one
+substrate change** — it is (0) a test-infra de-mask, then (1) a genuinely
+bounded value-rep substrate change for built-in exotics reaching a primitive,
+which the operator paths (`==`/`+`/relational) already call into. **#2862 must
+be SPLIT.**
+
+### The value-rep substrate, as it actually stands (read against current main)
+
+The standalone `any` value representation is the `$AnyValue` struct
+(`ensureAnyValueType`, any-helpers.ts:23): fields `tag:i32, i32val, f64val,
+refval:eqref, externval:externref`. Tags: `0=null 1=undefined 2=i32 3=f64
+4=bool 5=string/boxed 7=function`; `tag>=5 ⇒ truthy object`. The "tag-5 field-4
+3-way classifier" (`tag5StringEqThen`/`tag5ToNumber`, any-helpers.ts:685/1138)
+discriminates *within* tag-5 between an `$AnyString` ref and a boxed-number
+carrier using `externval` (field 4) + `ref.test $AnyString` — that classifier is
+**equality/ToNumber-local and must NOT be widened blindly** (the #2040 note in
+any-helpers.ts:1677-1686 explicitly DROPS extra tag-5 classifier arms because
+changing the boxed-value shape regressed dstr defaults — `reference_2040`,
+`project_2040_tag5_classifier_dstr_default_regression`). **Do not route the
+exotic-to-primitive fix through the tag-5 classifier.** The correct seam is
+`__to_primitive` (object-runtime.ts:2194), which the operators already call.
+
+### Operators already call `__to_primitive` — the gap is its COVERAGE, not the wiring
+
+- Loose `==`/`!=` (binary-ops.ts:2310-2329): when exactly one operand is an
+  object (`typeofObject` XOR), it overwrites the operand in place with
+  `__to_primitive(operand, default)`. **Wired.**
+- Binary `+` and relational (binary-ops.ts:2034): a struct-ref operand is
+  coerced to f64 via `coerceType(..., hint)` which bottoms out in
+  `__to_primitive`. **Wired.**
+
+So the substrate change is entirely *inside* `__to_primitive`'s arm cascade
+(object-runtime.ts:2361-2462). Today it handles: non-object (unchanged) ·
+`$__vec_base` array → `__array_to_primitive_string` · nominal class struct →
+`__class_to_primitive` · `$Object` wrapper internal slot · `$Object` own
+`valueOf`/`toString` with a `"[object Object]"` default. It **falls through to
+`return unchanged`** (object-runtime.ts:2408-2413, NOT a throw) for a built-in
+exotic that is none of those — a TypedArray view, DataView, ArrayBuffer, RegExp,
+or boxed wrapper backed by a nominal runtime struct. "Return unchanged" then
+makes the caller's `__unbox_number`/string coercion produce the WRONG value
+(0/NaN) — it does **not** itself throw the headline TypeError (the verify-first
+probes confirmed: `"" + new Uint8Array([1,2,3])` already works via the
+`$__vec_base` arm; `"" + /x/` returns the wrong value but does not throw).
+
+### Changes — bounded, all in the `!ref.test $Object` block (object-runtime.ts ~2378)
+
+Add a brand-dispatch BETWEEN the existing `$__vec_base` arm (2384) and the
+`__class_to_primitive` arm (2399), reducing each built-in exotic to its spec
+OrdinaryToPrimitive result. Each reuses the **reserve-placeholder-funcIdx +
+fill-in-post-processing** discipline (the established
+`reserveArrayToPrimitiveString` / `reserveClassToPrimitive` /
+`fillClassToPrimitive` pattern, class-to-primitive.ts:58/111) because these
+helpers depend on carriers/structs registered AFTER `__to_primitive`:
+
+1. **RegExp exotic** → `RegExp.prototype.toString` = `"/" + source + "/" + flags`.
+   The `$NativeRegExp` struct is recoverable via the existing
+   `recoverRegExpStructFromExternref` (regexp-standalone.ts:908) and the field
+   reads already exist (`emitRegExpReflectionFieldRead`). Arm: after the
+   `$__vec_base` test, `ref.test` the standalone RegExp struct
+   (`ensureStandaloneRegExpStruct`) → if hit, build the source/flags string and
+   `return`. (This is the only exotic with a non-`[object X]` ToPrimitive.)
+2. **TypedArray view** → `%TypedArray%.prototype.join(",")` (Array-like
+   toString). **This arm DEPENDS ON #2893's `recoverTypedArrayViewFromExternref`
+   classifier** — without a view brand the engine cannot tell a view from a
+   `number[]` here either (the integer views are already type-distinct so
+   `ref.test $__vec_i8_byte`/… classifies them; the float views need #2893 PR-2).
+   So gate this arm behind #2893 and reuse its classifier. NOTE: integer-view
+   concat *already* works via the `$__vec_base` arm (a view IS a `$__vec_base`
+   subtype) → so this arm is only needed for the float-view + correct-formatting
+   subset; verify-first to confirm it is even a gap before coding.
+3. **DataView / ArrayBuffer** → inherit `Object.prototype.toString` →
+   `"[object DataView]"` / `"[object ArrayBuffer]"` native string constants.
+   These are `__vec_i32_byte` structs (new-super.ts:4484) — `ref.test
+   $__vec_i32_byte` distinguishes them, but that key is SHARED by both
+   ArrayBuffer and DataView (and SharedArrayBuffer), so the exact `[object X]`
+   label cannot be recovered from the vec type alone. **This is a real
+   sub-blocker** — either accept a generic `"[object Object]"` for these (spec
+   wants the specific tag, but a generic label flips the no-throw subset), or
+   defer DataView/ArrayBuffer ToPrimitive to a follow-up that gives them a brand
+   (parallels #2893). Recommend: ship the generic-label arm first (unblocks the
+   no-throw rows), file the specific-tag refinement separately.
+
+For the §7.1.1.1 step-6 "must return primitive" TypeError, keep the existing
+`returnIfPrimitive` guard (object-runtime.ts:2256) so a present-but-object-
+returning `valueOf`/`toString` STILL throws (the genuine-TypeError tests).
+
+### Default `Object.prototype.toString` for inherited-method misses (object-runtime.ts:2321 `tryOrdinaryMethod`)
+
+Today the `"[object Object]"` default fires only on the `toString`-arm when the
+own probe misses (`defaultObjectToStringOnMissing`). Per §7.1.1.1 a plain object
+with neither own `valueOf` nor own `toString` resolves to
+`Object.prototype.toString` → `"[object Object]"`. When BOTH own probes miss
+(standalone `__extern_get` is OWN-only; the prototype chain is not materialized),
+return `"[object Object]"` rather than falling through to `throwTypeError`. Guard:
+this default must NOT mask the genuine TypeError when a present method returns an
+object — keep the `returnIfPrimitive` guard on present methods.
+
+### Late-funcIdx discipline (has bitten before — `reference_1461`/`reference_2191`/`reference_2193`)
+
+- The new exotic arms call helpers (`__array_to_primitive_string`, the RegExp
+  source/flags builders, string-constant globals) that are registered AFTER
+  `__to_primitive`. **Reserve a stable placeholder funcIdx at `__to_primitive`
+  build time and FILL the body post-processing** — never read the helper's
+  funcIdx inline (it does not exist yet). Mirror `reserveArrayToPrimitiveString`
+  (object-runtime.ts:2223) exactly.
+- `addUnionImportsViaRegistry` is already called at the top of the
+  `__to_primitive` block (object-runtime.ts:2208) — keep any new `ensureLateImport`
+  BEFORE the funcIdx reads, and if a late import is added inside the body, flush
+  with the established shift discipline so the in-progress body's call targets
+  don't desync (the #1890/#329 finalization-shift class that corrupted strict
+  `===`, binary-ops.ts:2249).
+- The fill helpers must run in the correct post-processing ORDER relative to
+  `emitToPrimitiveMethodExports` / `fillClassToPrimitive` (object-runtime.ts
+  finalize) — add the new fills alongside them, after the carrier structs exist.
+
+### Edge cases / regression guards
+
+- `Symbol.toPrimitive` precedence: a user `@@toPrimitive` is handled in the
+  coercion engine BEFORE `__to_primitive` — verify the new exotic arms don't
+  short-circuit it (they run only in the `!ref.test $Object` block, which a
+  `$Object` with `@@toPrimitive` never reaches). The
+  `structHasStaticNumericToPrimitive` fast-path (binary-ops.ts:3188) must still
+  win for nominal structs with a static numeric ToPrimitive.
+- `new Number(5)` etc. wrapper-slot arm (object-runtime.ts:2423) must keep
+  winning over the new default-toString arm — it runs in the `$Object` block,
+  before the cascade reaches the exotic arms. Order preserved.
+- Genuine `§7.1.1.1` TypeError tests MUST still throw: `Symbol.toPrimitive`
+  returning an object, ordinary `toString`/`valueOf` returning an object. Keep
+  the `returnIfPrimitive` guard + the trailing `throwTypeError()`.
+- All new arms `ctx.standalone`-gated (the host lane uses `_hostToPrimitive`).
+
+### Verify-first plan (run BEFORE coding — the verify-first finding is mandatory)
+
+0. **PREREQUISITE (route as a SEPARATE test-infra task, NOT this issue):** the
+   de-mask of `extractWasmExceptionMessage` (test262-runner.ts:2913/2927) +
+   `scripts/compiler-fork-worker.mjs` — wrap `String(payload)` in try/catch.
+   **Error-text only, flips zero pass/fail.** Until this lands, the ~2014
+   mis-labeled rows cannot be re-triaged and the true #2862 cluster size is
+   unknown. Do not start the compiler work until the de-mask reveals the real
+   per-exotic counts.
+1. Probe each exotic on current main via the EXACT CI standalone path
+   (`runTest262File(file, cat, undefined, "standalone")`): `"" + /x/`,
+   `"" + new DataView(new ArrayBuffer(8))`, `\`${new Float64Array([1])}\``,
+   `1 + {}` (inherited toString). Record actual vs spec. Only code the arms that
+   are a REAL gap (the integer-view concat is already correct — do not re-add it).
+2. After coding, re-run the relevant `language/expressions/**` operator dirs
+   (`addition`, `equals`, relational) + `built-ins/RegExp/prototype/Symbol.*` +
+   the genuine-TypeError tests. Confirm fail→pass on the targeted exotics AND no
+   pass→fail on the genuine-TypeError set.
+3. Full `merge_group` + standalone high-water; 0 host-mode regression.
+
+### Files
+
+- `src/codegen/object-runtime.ts` — `__to_primitive` arm cascade (the
+  `!ref.test $Object` block, 2378-2413) + `tryOrdinaryMethod` default (2321) +
+  the new reserve/fill placeholders alongside `reserveArrayToPrimitiveString`.
+- `src/codegen/regexp-standalone.ts` — read-only reuse of
+  `recoverRegExpStructFromExternref` / `emitRegExpReflectionFieldRead`.
+- `src/codegen/array-to-primitive.ts`, `src/codegen/class-to-primitive.ts` —
+  reserve/fill template (read-only reference).
+- `tests/test262-runner.ts` + `scripts/compiler-fork-worker.mjs` — the de-mask
+  (SEPARATE task, step 0).
+
+### Estimated cluster size + split verdict
+
+The original "728 pure" figure is **not** the deliverable of this substrate
+change (verify-first proved it heterogeneous). Realistic per-arm yields after
+de-mask: RegExp ToPrimitive ~20-40 (`RegExp` 125 total, only the
+concat/format subset); built-in-exotic concat/format across DataView/
+ArrayBuffer/float-TypedArray ~30-60; inherited-default `[object Object]` for
+plain objects ~30-80. **Total realistic ~80-180 standalone rows** — materially
+smaller than 728, with the remainder belonging to the re-triaged real clusters
+(number→string key coercion, `ToIndex` object coercion, getter reflection,
+propertyHelper formatting) that the de-mask exposes as SEPARATE issues.
+
+**SPLIT VERDICT: #2862 is bigger than one focused effort — split into:**
+- **#2862-A (test-infra, do FIRST, unblocks triage):** the runner de-mask
+  (step 0). Flips zero tests but is the prerequisite for sizing everything else.
+- **#2862-B (this substrate change):** the `__to_primitive` exotic arms +
+  inherited-default. The TypedArray-view arm DEPENDS ON #2893 (shared brand
+  classifier) — sequence after #2893 PR-1, or scope #2862-B to RegExp + DataView/
+  ArrayBuffer generic-label + inherited-default and leave the float-view arm to
+  ride #2893.
+- **#2862-C..n (re-triaged clusters):** filed from the de-mask output (number→
+  string key coercion, ToIndex, getter reflection, propertyHelper) — NOT this
+  issue.
+
+Dispatch #2862-A immediately (independent, low-risk). Hold #2862-B until the
+de-mask reveals real counts AND #2893 PR-1 lands (for the view arm). Do NOT sell
+#2862-B as flipping the 728.

--- a/plan/issues/2893-standalone-typedarray-view-brand.md
+++ b/plan/issues/2893-standalone-typedarray-view-brand.md
@@ -94,6 +94,210 @@ track those separately.
   `get.call(view)` returns the value, `get.call(<non-view>)` throws TypeError.
 - Verify-first standalone; full `merge_group` + standalone high-water; 0 regressions.
 
+## Implementation Plan (architect, 2026-06-30)
+
+### Re-grounded against current main — the rep gap is SMALLER than the issue body claims
+
+The issue body cites the stale `index.ts ~#1700` comment ("`Uint8Array` and
+`number[]` share `(ref null $Vec[f64])`"). That comment **predates #2593/#2835**.
+On current main (`origin/main`, verified) the standalone vec types are **already
+disjoint** for the integer views:
+
+| value | standalone vec struct (key) | width |
+|---|---|---|
+| `number[]` | `__vec_f64` | — |
+| `Int8Array` / `Uint8Array` / `Uint8ClampedArray` | `__vec_i8_byte` | 1 |
+| `Int16Array` / `Uint16Array` | `__vec_i16_byte` | 2 |
+| `Int32Array` / `Uint32Array` | `__vec_i32_elem` | 4 |
+| `ArrayBuffer` / `DataView` / `SharedArrayBuffer` byte buffer | `__vec_i32_byte` | (bytes) |
+| `Float32Array` / `Float64Array` | `__vec_f64` ← **collides with `number[]`** | 4 / 8 |
+
+(Source: `TYPED_ARRAY_PACKED_STORAGE` index.ts:205, gated `wasi||standalone`;
+`typedArrayVecStorage` index.ts:223 is the single source of truth; `i32_byte`
+byte-buffer split from `i32_elem` element storage at #2835; ArrayBuffer→i32_byte
+at new-super.ts:4484.)
+
+So `ref.test $__vec_i8_byte` on an opaque `externref` **already** proves "a byte
+view, not a `number[]` and not an ArrayBuffer". The *only* residual
+classification wall is the **float views vs `number[]`** (both `__vec_f64`) and
+**Float32 vs Float64** (same struct). That collapses the "representation change"
+to a single, bounded float-view split — everything else is getter-body wiring on
+types that are already distinct.
+
+### Approach — split into THREE PRs; only PR-2 is a rep change
+
+**PR-1 (NO representation change) — integer-view §23.2.3 accessor getter bodies.**
+Wire `makeTypedArrayGlue`'s `emitMemberBody` (array-object-proto.ts:696/703,
+currently `emitProtoMemberBodyRefusal` for every member) to a new
+`emitTypedArrayProtoMemberBody`, modelled **exactly** on
+`emitRegExpProtoMemberBody` (regexp-standalone.ts:2460). For a getter:
+1. **Proto-identity arm first** — `emitNativeProtoIdentityReturnUndefined(ctx,
+   fctx, brand, 1, [ref.null.extern])` (native-proto.ts:499) so reading the
+   getter with `this === %TypedArray%.prototype` returns `undefined` per
+   §23.2.3.x (the proto-receiver case returns undefined), BEFORE the brand check.
+2. **View brand-recovery prologue** — a new
+   `recoverTypedArrayViewFromExternref(ctx, fctx, thisParamIdx=1)` returning
+   `{ viewLocal, vecTypeIdx, width }` or `null`. Implement it by mirroring
+   `recoverRegExpStructFromExternref` (regexp-standalone.ts:908) but over the
+   **set** of view vec type idxs, reusing the cascade shape of
+   `emitThisReceiverGuardConvert` (property-access.ts:6092): `any.convert_extern`
+   `this` → for each view vec idx emit `ref.test`; on the first hit `ref.cast`
+   and record the compile-time width; if **no** view type matches, emit a
+   catchable TypeError (`emitBrandCheckTypeError`, the §23.2.3 RequireInternalSlot
+   throw the `this-val-*` tests gate on). The candidate set in PR-1 is
+   `{i8_byte, i16_byte, i32_elem}` (the registered keys whose `typedArrayVecStorage`
+   maps to a TA view — derive from `ctx.vecTypeMap` filtered to those three keys,
+   NOT all of `vecTypeMap`, so a plain `number[]`/ArrayBuffer is correctly
+   rejected). Width is the compile-time constant per matched type (1/2/4).
+3. **Member body off the recovered local:**
+   - `length` → `struct.get fieldIdx 0` (the `$__vec_base` length prefix), box via `__box_number`.
+   - `byteLength` → `length × width` (width is the compile-time constant), box.
+   - `byteOffset` → `0` for a plain view; if the matched type is a
+     `$__subview_<k>` (isSubviewTypeIdx, registry/types.ts:268) read field 2
+     (`byteOffset`, in elements) × width. PR-1 may scope to plain views (offset
+     0) and add the subview arm in the same PR if cheap.
+   - `buffer` → defer to PR-3 (needs an ArrayBuffer materialization off the view;
+     return the catchable refusal for `buffer` only in PR-1).
+
+   Box every getter result to `externref` (the closure-call ABI + descriptor
+   `.get` unify on externref — copy the box-by-kind tail of
+   `emitRegExpProtoMemberBody`: i32→`__box_number` via f64, ref→`extern.convert_any`).
+
+PR-1 flips the integer-view accessor subset (`this-val-*`, `prop-desc` accessor
+reads, `desc.get.call(view)`) for `length`/`byteLength`/`byteOffset` **for free**
+through the already-merged #2885 gOPD-synthesis + #2876 reflective-`.call`
+machinery — mirroring the RegExp 28→47 result. **Zero rep change, so zero
+element-path risk.**
+
+**PR-2 (THE representation change) — float-view brand split.**
+Give `Float32Array`/`Float64Array` their own standalone vec keys, distinct from
+`number[]`'s `__vec_f64`:
+- `TYPED_ARRAY_PACKED_STORAGE` (index.ts:205): add
+  `Float32Array → { key: "f32_view", type: { kind: "f64" } }` and
+  `Float64Array → { key: "f64_view", type: { kind: "f64" } }`. **Keep the
+  element type `f64`** — do NOT switch Float32 to real `f32` storage here (that
+  is f32 element-fidelity / `Math.fround`-on-write, a SEPARATE issue). The split
+  is purely a distinct *struct identity* for the brand; the data array stays
+  f64, so every existing float-element read/write keeps working unchanged once
+  the key flows through `typedArrayVecStorage`.
+- `reserveTypedArraySubviewTypes` (index.ts:7499): add
+  `getOrRegisterSubviewType(ctx, "f32_view", {kind:"f64"})` and `"f64_view"` so
+  `Float*Array.subarray()` is idx-stable (see hazards).
+- Extend the PR-1 classifier candidate set to `{i8_byte, i16_byte, i32_elem,
+  f32_view, f64_view}` with widths `{1,2,4,4,8}`. `number[]` stays `__vec_f64`
+  → correctly rejected by the brand check.
+- The marshalling boundary (`classifyTypedArrayType` index.ts:267, `wrapExports`)
+  is **standalone-only affected** and standalone has no JS-host marshalling — but
+  audit: host/gc mode keeps float views on `__vec_f64` (the packed map is gated
+  `wasi||standalone`), so the host signature identity (`Uint8Array==number[]`) is
+  untouched. No boundary work.
+
+PR-2 unblocks the float-view accessor subset and fixes the latent
+`Float32Array.byteLength` width bug (×4 vs the ×8 a shared f64 struct implied).
+
+**PR-3 (follow-up, may be a separate issue) — `buffer` getter + per-view name
+brand.** `buffer` needs an ArrayBuffer (`__vec_i32_byte`) materialized as a
+window over the view's bytes (mirror the existing DataView `.buffer` recovery,
+property-access.ts:3149). The `@@toStringTag` / `.constructor` subset and the
+per-method `RequireInternalSlot` bodies additionally need the **signed/unsigned
+within-width distinction** (Int8 vs Uint8 vs Uint8Clamped all share
+`__vec_i8_byte`); that needs either distinct per-name view structs or a brand
+*field*, which IS the larger rep change — keep it OUT of #2893. The issue's
+acceptance (the four accessors, starting with `length`) is met by PR-1+PR-2.
+
+### Index-stability / funcIdx hazards (these have bitten before)
+
+- **Type-index stability (`project_type_index_shift_and_deadelim`,
+  `reference_subview_type_idx_stability`):** the new `f32_view`/`f64_view` subview
+  backing MUST be reserved in `reserveTypedArraySubviewTypes` at the deterministic
+  up-front type-init point (index.ts:1146 call site), exactly like the existing
+  `i16_byte`/`i32_elem` reservations — NEVER mint the float-view struct lazily
+  mid-class-collection. The keystone bug #2593 hit (an inline
+  `new Int32Array(4).byteLength` reading through a vec cast that never matched)
+  was precisely a hoist-pass-vs-emit-pass type-index desync; the float views must
+  follow the same reserve-late-once discipline. The classifier's `ref.test`
+  cascade reads the type idxs from `ctx.vecTypeMap`/`ctx.subviewTypeMap` at
+  body-emit time, so the reserved slots must already exist.
+- **Late-import funcIdx shift (`reference_1461`/`reference_2193`):** the getter
+  body boxes results via `__box_number`/`__box_boolean` — call `ensureLateImport`
+  + `flushLateImportShifts(ctx, fctx)` (the exact pattern in `unboxArgToI32`,
+  array-object-proto.ts:598) so a late import added inside the body cannot desync
+  the in-progress closure's own funcIdx refs. Do NOT read typeof/box funcIdxs
+  before `addUnionImports`/the late-import flush.
+- **DCE renumber:** a reserved-but-unused `f32_view`/`f64_view` struct is pruned +
+  renumbered cleanly by dead-elimination (it is unreferenced when the source has
+  no float typed array), so the reservation is a true no-op for non-float-TA
+  modules — gate-free, byte-identical.
+
+### Edge cases
+
+- `get.call(number[])` and `get.call(new ArrayBuffer(8))` MUST throw TypeError
+  (RequireInternalSlot) — guaranteed because `number[]`=`__vec_f64` (not in the
+  candidate set) and ArrayBuffer=`__vec_i32_byte` (not in the set).
+- `get.call(%TypedArray%.prototype)` → `undefined` (proto-identity arm, before
+  brand check).
+- Empty view (`new Int32Array(0)`): `length`→0, `byteLength`→0 (no trap — the
+  recovery casts the struct, reads field 0; the #2593 empty-view trap was the
+  construction-vs-read key mismatch, already fixed).
+- A subview (`a.subarray(1)`): `length` is the window length (field 0 of the
+  `$__subview` struct, also a `$__vec_base` prefix), `byteOffset` = field 2 ×
+  width. Add `$__subview_<k>` idxs to the candidate set if the subview-accessor
+  tests are in scope.
+- Signed/unsigned share a type → fine for these four accessors (identical width &
+  semantics); only `@@toStringTag` cares (PR-3).
+
+### Verify-first recipe (run BEFORE coding each PR)
+
+```ts
+// .tmp/probe-2893.mts — run the EXACT CI standalone path on current main
+runTest262File(file, cat, undefined, "standalone")
+```
+1. Confirm the integer-view accessor tests FAIL today and the proto refusal is
+   the cause: probe `Object.getOwnPropertyDescriptor(Uint8Array.prototype,
+   "byteLength").get.call(new Uint8Array(8))` standalone → expect the
+   "not yet implemented" refusal (the `emitProtoMemberBodyRefusal` text), proving
+   the wall is the glue body, not the classifier.
+2. PR-1 corpus: `test/built-ins/TypedArray/prototype/{length,byteLength,byteOffset}/`
+   — `this-val-*.js`, `prop-desc.js`, `BigInt`-free view files. Expect fail→pass
+   for the integer-view rows after PR-1.
+3. PR-2 corpus: the same files' `Float32Array`/`Float64Array` rows + any
+   `byteLength` width assertion on a Float32Array. Verify `number[]` length/...
+   getters still THROW (no false-positive view classification).
+4. Full `merge_group` + standalone high-water; 0 regression on the host lane
+   (all new arms `ctx.standalone`/`noJsHost`-gated; host float views stay
+   `__vec_f64`).
+
+### Files
+
+- `src/codegen/array-object-proto.ts` — `makeTypedArrayGlue` (696/703) →
+  `emitTypedArrayProtoMemberBody` (new); reuse `emitNativeProtoIdentityReturnUndefined`.
+- `src/codegen/typed-array-proto.ts` (new) or co-locate in array-object-proto.ts —
+  `recoverTypedArrayViewFromExternref` + `emitTypedArrayProtoMemberBody`.
+- `src/codegen/index.ts` — `TYPED_ARRAY_PACKED_STORAGE` (205, PR-2 float keys);
+  `reserveTypedArraySubviewTypes` (7499, PR-2 float subview backing).
+- `src/codegen/property-access.ts` — reuse `emitThisReceiverGuardConvert` (6092)
+  cascade shape; `isSubviewTypeIdx`/`getSubviewArrTypeIdx` for the byteOffset arm.
+- `src/codegen/regexp-standalone.ts` — read-only template
+  (`recoverRegExpStructFromExternref` 908, `emitRegExpProtoMemberBody` 2460).
+
+### Estimated cluster size + split verdict
+
+#2872 totals ~294 `TypedArray/prototype/**` + ~39 `TypedArrayConstructors/**`.
+**#2893 unblocks only the reflective-ACCESSOR subset** (length/byteLength/
+byteOffset/buffer `this-val`/`prop-desc`/`desc.get.call` across the view family),
+estimated **~50-90 rows** (mirrors RegExp's +19 but over 9 views × 4 getters).
+The remaining ~200 rows are the per-METHOD reflective bodies (`fill`/`set`/
+`copyWithin`/`slice`/`map`/`subarray`/`join`/`toLocaleString` …) + the
+`@@toStringTag`/`*.name`/mutable-descriptor subset — those are NOT unblocked by
+#2893 and belong to #2872 sub-tasks split per member family.
+
+**SPLIT VERDICT: #2893 is bigger than one PR — split into PR-1 (integer-view
+accessors, no rep change), PR-2 (float-view brand split, the rep change), PR-3
+(`buffer` + per-name brand, likely a separate issue).** PR-1 alone is a focused,
+low-risk slice that proves the recovery shape and banks the integer-view rows
+without touching the element representation at all. Dispatch PR-1 immediately;
+PR-2 only after PR-1's recovery shape is proven green.
+
 ## Notes
 
 Filed after #2876 landed the reflective `.call` lever. The "#2872 just needs


### PR DESCRIPTION
Lands the architect implementation specs for two standalone-gap substrate fronts so next-window devs can pull them from main.

- **#2893** — distinct %TypedArray% view brand (unblocks #2872 reflective getter/method bodies)
- **#2862** — standalone ToPrimitive for built-in exotics + inherited valueOf/toString

Docs-only: appends the `## Implementation Plan` specs to the existing `plan/issues/2893-*.md` and `plan/issues/2862-*.md` issue files (cherry-pick of arch-rep's commit 10235a391, which the isolation hook blocked from writing to shared /workspace). 400 insertions, no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)