### PR TITLE
fix(#2897): rebind arguments as a SimpleAssignmentTarget (null-deref)

### DIFF
--- a/plan/issues/2897-es3-arguments-assignment-target-null-deref.md
+++ b/plan/issues/2897-es3-arguments-assignment-target-null-deref.md
@@ -1,10 +1,12 @@
 ---
 id: 2897
 title: "≤ES3: `arguments` as assignment target crashes (null-deref)"
-status: ready
+status: done
 priority: high
 sprint: current
 created: 2026-06-30
+completed: 2026-06-30
+assignee: ttraenkler/es3-2897
 feasibility: medium
 task_type: bug
 area: codegen
@@ -32,3 +34,47 @@ The codegen path for an assignment whose LHS resolves to the `arguments` binding
 ## Acceptance
 - The test compiles + runs without the null-deref and passes.
 - No regression in other `arguments`/assignment tests.
+
+## Root cause (confirmed)
+`arguments` is eagerly materialized as a **concrete non-null vec ref** local
+(`(ref null $__vec_externref)`) for fast `.length` / `[i]` access
+(`src/codegen/function-body.ts` → `allocLocal(fctx, "arguments", vecRef)`). On
+the assignment path (`compileAssignment`, `src/codegen/expressions/assignment.ts`)
+a whole-identifier write `arguments = X` resolved that local and compiled the RHS
+with the vec-ref type as the expected type. Coercing an arbitrary RHS (e.g. the
+f64 `1`) into a non-null vec ref produced:
+
+```wat
+f64.const 1
+drop
+ref.null $__vec_externref
+ref.as_non_null     ;; <-- traps: "dereferencing a null pointer"
+local.set $arguments
+```
+
+i.e. the placeholder `ref.null` is forced non-null and traps at runtime.
+
+## Fix
+In the identifier-assignment branch of `compileAssignment`, detect when the LHS
+is the materialized `arguments` vec local (`name === "arguments"` + ref-typed +
+not a closure ref). In non-strict code `arguments` is a valid
+`SimpleAssignmentTarget` (§13.15.1), so `arguments = X` **rebinds** the
+identifier: compile the RHS as `externref` (the universal value carrier), store
+it into a fresh `externref` local (which `allocLocal` re-points `arguments` to in
+`localMap`), and clear `fctx.mappedArgsInfo` (the arguments object is replaced).
+The assignment expression evaluates to the RHS value. Subsequent reads of
+`arguments` resolve to the rebound externref; `.length` / `[i]` on a non-vec
+value degrade to `undefined` via the externref `__vec_len`/`__vec_get` helpers,
+matching JS.
+
+## Test Results
+- New unit tests: `tests/issue-2897.test.ts` — 6/6 pass.
+  - `arguments = 1` runs (no crash), evaluates to RHS, rebinds (`return arguments`),
+    string RHS, formal param intact after reassign, mapped `arguments[i]` write
+    still reflects into the param (regression control).
+- Repro (exact test262 wrapper + `inferModuleStrictArguments:false`,
+  `skipSemanticDiagnostics:true`): `arguments = 1` → `test()` returns 1 (was a
+  null-deref trap).
+- `tsc --noEmit` clean; `biome lint` clean; prettier clean.
+- The one pre-existing failure in `tests/issue-1053-arguments-global-staleness.test.ts`
+  reproduces on unmodified `origin/main` (unrelated to this change).

--- a/src/codegen/expressions/assignment.ts
+++ b/src/codegen/expressions/assignment.ts
@@ -213,6 +213,45 @@ export function compileAssignment(ctx: CodegenContext, fctx: FunctionContext, ex
     }
     const localIdx = fctx.localMap.get(name);
     if (localIdx !== undefined) {
+      // (#2897) Reassigning the materialized `arguments` binding. In non-strict
+      // code `arguments` is a valid SimpleAssignmentTarget (§13.15.1), so
+      // `arguments = X` rebinds the identifier to X. `arguments` is materialized
+      // as a concrete (non-null) vec ref local for fast `.length` / `[i]` access;
+      // coercing an arbitrary RHS (e.g. an f64 `1`) to that vec-ref type emits a
+      // trapping `ref.as_non_null (ref.null …)` — the L41:3 "dereferencing a null
+      // pointer" crash. Instead, rebind the name to a fresh externref local
+      // holding X (the universal value carrier) and sever the param↔arguments
+      // map, since the arguments object has been replaced.
+      {
+        const argsLocalType =
+          localIdx < fctx.params.length
+            ? fctx.params[localIdx]!.type
+            : fctx.locals[localIdx - fctx.params.length]?.type;
+        const isArgsVecLocal =
+          name === "arguments" &&
+          argsLocalType !== undefined &&
+          (argsLocalType.kind === "ref" || argsLocalType.kind === "ref_null") &&
+          !ctx.closureInfoByTypeIdx.has((argsLocalType as { typeIdx: number }).typeIdx);
+        if (isArgsVecLocal) {
+          const rhsType = compileExpression(ctx, fctx, expr.right, { kind: "externref" });
+          if (!rhsType) {
+            reportError(ctx, expr, "Failed to compile assignment value");
+            return null;
+          }
+          if (rhsType.kind !== "externref") {
+            coerceType(ctx, fctx, rhsType, { kind: "externref" });
+          }
+          // allocLocal re-points fctx.localMap["arguments"] to the new slot, so
+          // subsequent reads resolve to the rebound value.
+          const newIdx = allocLocal(fctx, "arguments", { kind: "externref" });
+          // The arguments object is replaced; later `arguments[i]` writes must no
+          // longer flow back into named params.
+          fctx.mappedArgsInfo = undefined;
+          fctx.body.push({ op: "local.tee", index: newIdx });
+          // Assignment expression evaluates to the RHS value.
+          return { kind: "externref" };
+        }
+      }
       // Check if this is a boxed (ref cell) mutable capture
       const boxed = fctx.boxedCaptures?.get(name);
       if (boxed) {

--- a/tests/issue-2897.test.ts
+++ b/tests/issue-2897.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports as buildRuntimeImports } from "../src/runtime.js";
+import { buildImports } from "./equivalence/helpers.js";
+
+// #2897 — ≤ES3: `arguments` as a SimpleAssignmentTarget crashed (null-deref).
+//
+// test262: language/expressions/assignmenttargettype/simple-basic-identifierreference-arguments.js
+//   → `arguments = 1;` (flags: [noStrict])
+//
+// In non-strict code `arguments` is a valid SimpleAssignmentTarget (§13.15.1),
+// so `arguments = X` rebinds the identifier to X. `arguments` is materialized as
+// a concrete (non-null) vec ref local; coercing an arbitrary RHS to that vec-ref
+// type previously emitted a trapping `ref.as_non_null (ref.null …)` — the
+// "dereferencing a null pointer" crash. The fix rebinds `arguments` to a fresh
+// externref local holding X and severs the param↔arguments map.
+//
+// These are `noStrict` cases — the test262 harness compiles such script tests
+// with `inferModuleStrictArguments: false` so the synthetic `export function
+// test()` wrapper does not force module-strict (which would unmap `arguments`
+// and reject the assignment as a strict-mode violation). We mirror that here.
+async function compileSloppyToWasm(source: string) {
+  // Mirror the test262 runner (tests/test262-runner.ts): script tests compile
+  // with `inferModuleStrictArguments: false` (sloppy/mapped arguments) and
+  // `skipSemanticDiagnostics: true` (TS would otherwise reject `arguments = X`
+  // as a strict-mode violation / `number`-not-assignable-to-`IArguments`).
+  const result = await compile(source, {
+    inferModuleStrictArguments: false,
+    skipSemanticDiagnostics: true,
+  });
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const manualImports = buildImports(result);
+  let setExportsFn: ((exports: Record<string, Function>) => void) | undefined;
+  if (result.imports && result.imports.length > 0) {
+    const runtimeResult = buildRuntimeImports(result.imports, undefined, result.stringPool);
+    setExportsFn = runtimeResult.setExports;
+    manualImports.env = { ...(manualImports.env as Record<string, Function>), ...runtimeResult.env };
+    if (runtimeResult.string_constants) manualImports.string_constants = runtimeResult.string_constants;
+  }
+  const { instance } = await WebAssembly.instantiate(result.binary, manualImports);
+  if (setExportsFn) setExportsFn(instance.exports as Record<string, Function>);
+  return instance.exports as Record<string, Function>;
+}
+
+describe("#2897 arguments as assignment target", () => {
+  // The exact test262 shape: `arguments = 1;` must compile + run (no crash).
+  it("`arguments = 1` runs without a null-deref crash", async () => {
+    const exports = await compileSloppyToWasm(`
+      export function test(): number {
+        arguments = 1;
+        return 1;
+      }
+    `);
+    expect((exports as any).test()).toBe(1);
+  });
+
+  // The assignment expression evaluates to the RHS value.
+  it("`arguments = X` evaluates to X", async () => {
+    const exports = await compileSloppyToWasm(`
+      export function test(): number {
+        const r: any = (arguments = 7);
+        return r as number;
+      }
+    `);
+    expect((exports as any).test()).toBe(7);
+  });
+
+  // Reassignment rebinds the identifier: a subsequent read of `arguments`
+  // returns the rebound value, not the original arguments object.
+  it("`arguments = X; return arguments` returns X", async () => {
+    const exports = await compileSloppyToWasm(`
+      export function test(): number {
+        arguments = 42;
+        return arguments as number;
+      }
+    `);
+    expect((exports as any).test()).toBe(42);
+  });
+
+  // A non-number RHS (string) also rebinds without trapping.
+  it('`arguments = "str"` rebinds to the string', async () => {
+    const exports = await compileSloppyToWasm(`
+      export function fn(): any {
+        arguments = "hello";
+        return arguments;
+      }
+      export function test(): number {
+        return (fn() === "hello") ? 1 : 0;
+      }
+    `);
+    expect((exports as any).test()).toBe(1);
+  });
+
+  // Reassigning `arguments` severs the param↔arguments map: the formal
+  // parameter keeps its passed value, unaffected by the rebind.
+  it("reassigning `arguments` leaves the formal parameter intact", async () => {
+    const exports = await compileSloppyToWasm(`
+      export function fn(a: number): number {
+        arguments = 99;
+        return a;
+      }
+      export function test(): number {
+        return fn(5);
+      }
+    `);
+    expect((exports as any).test()).toBe(5);
+  });
+
+  // Regression control: mapped arguments still sync param ↔ arguments[i] when
+  // `arguments` is NOT reassigned.
+  it("mapped arguments[i] write still reflects into the param (no regression)", async () => {
+    const exports = await compileSloppyToWasm(`
+      export function fn(a: number): number {
+        arguments[0] = 5;
+        return a;
+      }
+      export function test(): number {
+        return fn(1);
+      }
+    `);
+    expect((exports as any).test()).toBe(5);
+  });
+});


### PR DESCRIPTION
## #2897 — `arguments` as an assignment target crashed (null-deref)

Fixes test262 `language/expressions/assignmenttargettype/simple-basic-identifierreference-arguments.js` — one of the 8 tests blocking 100% ≤ES3 conformance.

### Root cause
`arguments` is eagerly materialized as a **concrete non-null vec ref** local (`(ref null $__vec_externref)`) for fast `.length` / `[i]` access. The whole-identifier write `arguments = X` resolved that local in `compileAssignment` and compiled the RHS with the vec-ref type as the expected type. Coercing an arbitrary value (e.g. the f64 `1`) into a non-null vec ref emitted a placeholder `ref.null + ref.as_non_null`, which traps at runtime:

```wat
f64.const 1
drop
ref.null $__vec_externref
ref.as_non_null     ;; traps: 'dereferencing a null pointer'
local.set $arguments
```

### Fix
In non-strict code `arguments` is a valid `SimpleAssignmentTarget` (§13.15.1), so `arguments = X` **rebinds** the identifier. In the identifier-assignment branch of `compileAssignment`, detect the materialized `arguments` vec local (`name === "arguments"` + ref-typed + not a closure ref) and rebind it to a fresh `externref` local holding X (the universal value carrier), severing `fctx.mappedArgsInfo` (the arguments object is replaced). The assignment expression evaluates to the RHS value; subsequent reads resolve to the rebound externref.

### Tests
- New `tests/issue-2897.test.ts` — 6/6 pass: `arguments = 1` runs (no crash), evaluates to RHS, rebinds (`return arguments`), string RHS, formal param intact after reassign, mapped `arguments[i]` write still reflects into the param (regression control).
- `tsc --noEmit` clean, `biome lint` clean, prettier clean.
- No regressions: the one failure in `tests/issue-1053-arguments-global-staleness.test.ts` reproduces unmodified on `origin/main` (unrelated, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS