### PR TITLE
fix(#2899): regression guard for bound-function caller/arguments poison-pill

### DIFF
--- a/plan/issues/2899-es3-function-caller-poison-pill-set.md
+++ b/plan/issues/2899-es3-function-caller-poison-pill-set.md
@@ -1,7 +1,8 @@
 ---
 id: 2899
 title: "≤ES3: Function `.caller` poison-pill must throw TypeError on set (`bound.caller = {}`)"
-status: ready
+status: done
+completed: 2026-06-30
 priority: high
 sprint: current
 created: 2026-06-30
@@ -32,3 +33,33 @@ The function-object property model needs `caller`/`arguments` realized as poison
 ## Acceptance
 - `bound.caller = {}` (and `.arguments` set/get) throw `TypeError`; the test passes.
 - No regression in normal function-property tests.
+
+## Resolution (2026-06-30)
+Already fixed on `main` when re-verified against the live tree — the filed
+baseline was stale. `test/language/statements/function/13.2-30-s.js` returns
+`status: pass` via `runTest262File` (and the runner was sanity-checked to
+report `fail` on a deliberately-broken `assert.throws` variant, so the pass is
+real, not a false positive).
+
+Root cause of the prior fix: **#2745**. `target.bind(self)` yields a real JS
+bound-function exotic (host `Function.prototype.bind`, runtime.ts §`__bind_function`),
+which inherits `caller`/`arguments` from `%FunctionPrototype%` as `%ThrowTypeError%`
+poison-pill accessors. Member-assignment (`bound.caller = {}`) routes through
+`__extern_set_strict` → `_safeSet(strict=true)`, whose `strictAccessorWrite`
+path (runtime.ts:4699-4738) walks the prototype chain, finds the inherited
+poison-pill setter, runs the write, and **re-throws** the setter's TypeError so
+the user's `try/catch` sees it. The get arms throw via the host `__extern_get`
+invoking the inherited poison-pill getter.
+
+This PR adds a regression guard (`tests/issue-2899.test.ts`): the four
+get/set arms each throw `TypeError`, bound functions have no own
+`caller`/`arguments`, ordinary object/function-custom property set/get is
+unaffected, plus an end-to-end `runTest262File` check (skipped when the
+test262 submodule isn't present). No compiler-source change was required.
+
+Note (out of scope for #2899): a *narrow, separate* quirk surfaced while
+probing — reading `bound.caller` inside a nested `(fn: any)` callback that
+captures a **module-level** `bound` returns `null` instead of throwing
+(the production test262 wrapper declares `bound` *local* to `test()` with a
+`() => void` callback, so it is unaffected and the conformance test passes).
+Flagged to the lead as a possible follow-up; does not block this issue.

--- a/tests/issue-2899.test.ts
+++ b/tests/issue-2899.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { existsSync } from "fs";
+import { join } from "path";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { runTest262File } from "./test262-runner.js";
+
+// #2899 — ≤ES3: Function `.caller` / `.arguments` poison-pill must throw
+// TypeError on get AND set (`bound.caller`, `bound.caller = {}`, etc.).
+//
+// `Function.prototype.caller` / `Function.prototype.arguments` are poison-pill
+// accessor properties whose `[[Get]]` and `[[Set]]` invoke %ThrowTypeError%
+// (ES5 §13.2.3 / ES2015+ §9.2.7). A bound function inherits them from
+// %FunctionPrototype%, so reading or writing `bound.caller` / `bound.arguments`
+// must raise a catchable TypeError.
+//
+// The originally-failing test262 case
+// (language/statements/function/13.2-30-s.js, assert #4 at L22) was
+// `bound.caller = {}` silently no-op'ing instead of throwing. The fix landed
+// via #2745's `_safeSet` strictAccessorWrite path: member-assignment routes
+// through `__extern_set_strict`, which walks the prototype chain, finds the
+// inherited poison-pill setter, lets the write run, and re-throws the setter's
+// TypeError so the user's try/catch sees it. The get arms throw via the host
+// `__extern_get` invoking the inherited poison-pill getter. This test locks
+// the behaviour in so a future change to the member-set/get dispatch or the
+// `_safeSet` strict path cannot silently regress it.
+
+async function compileAndRun(source: string): Promise<Record<string, Function>> {
+  const result = await compile(source);
+  if (!result.success) {
+    throw new Error(`Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports as unknown as WebAssembly.Imports);
+  // The bound-function bridge needs the live exports to dispatch the wasm
+  // closure target (#1632a/#2745).
+  (imports as { setExports?: (e: Record<string, Function>) => void }).setExports?.(
+    instance.exports as Record<string, Function>,
+  );
+  return instance.exports as Record<string, Function>;
+}
+
+describe("#2899 — bound-function caller/arguments poison-pill throws on get and set", () => {
+  it("get/set of bound.caller and bound.arguments all throw TypeError", async () => {
+    // Mirrors the test262 wrapper shape (void `() => void` callbacks + a
+    // module-level accumulator, exactly like the runner's synthesised
+    // `assert_throws`). Each throwing arm contributes a distinct decimal digit
+    // so a single return value pinpoints which arm failed to throw:
+    //   1 = get bound.caller, 10 = set bound.caller (#2899's original gap),
+    //   100 = get bound.arguments, 1000 = set bound.arguments.
+    const e = await compileAndRun(`
+      let __score: number = 0;
+      function expectThrowsTE(bit: number, fn: () => void): void {
+        try { fn(); } catch (err) { if (err instanceof TypeError) { __score = __score + bit; } return; }
+      }
+      export function test(): number {
+        function target() {}
+        var self = {};
+        var bound = target.bind(self);
+        expectThrowsTE(1,    function() { return bound.caller; });
+        expectThrowsTE(10,   function() { bound.caller = {}; });
+        expectThrowsTE(100,  function() { return bound.arguments; });
+        expectThrowsTE(1000, function() { bound.arguments = {}; });
+        return __score;
+      }
+    `);
+    expect(e.test!()).toBe(1111);
+  });
+
+  it("bound functions have no own caller/arguments (inherited from %FunctionPrototype%)", async () => {
+    const e = await compileAndRun(`
+      export function test(): number {
+        function target() {}
+        var self = {};
+        var bound = target.bind(self);
+        var r = 0;
+        if (bound.hasOwnProperty('caller') === false) r += 1;
+        if (bound.hasOwnProperty('arguments') === false) r += 10;
+        return r;
+      }
+    `);
+    expect(e.test!()).toBe(11);
+  });
+
+  it("control: ordinary object & function-custom property set/get is unaffected", async () => {
+    const e = await compileAndRun(`
+      export function test(): number {
+        var o: any = {}; o.x = 7;          // ordinary object property
+        function f() {}
+        (f as any).foo = 42;               // function's own non-poison property
+        return o.x + (f as any).foo;       // 49
+      }
+    `);
+    expect(e.test!()).toBe(49);
+  });
+
+  // Authoritative end-to-end guard: the exact test262 case, run through the
+  // production runner. Skipped gracefully when the test262 submodule isn't
+  // checked out (e.g. lightweight `quality` job) — the unit tests above still
+  // guard the behaviour.
+  it("test262 language/statements/function/13.2-30-s.js passes", async () => {
+    const file = join(
+      import.meta.dirname ?? ".",
+      "..",
+      "test262",
+      "test",
+      "language",
+      "statements",
+      "function",
+      "13.2-30-s.js",
+    );
+    if (!existsSync(file)) {
+      // submodule not present in this job — the unit tests cover the behaviour
+      return;
+    }
+    const r = await runTest262File(file, "language");
+    expect(r.status).toBe("pass");
+  });
+});


### PR DESCRIPTION
## #2899 — bound-function `.caller` / `.arguments` poison-pill (≤ES3)

One of the 8 tests blocking 100% ≤ES3 conformance:
`test/language/statements/function/13.2-30-s.js`.

### Finding
**Already fixed on `main`** — the filed baseline was stale. Re-verified against
the live tree via `runTest262File`: the test returns `status: pass` (and the
runner was sanity-checked to report `fail` on a deliberately-broken
`assert.throws` variant, so the pass is real).

### Root cause of the prior fix (#2745)
`target.bind(self)` yields a real JS bound-function exotic (host
`Function.prototype.bind`), which inherits `caller`/`arguments` from
`%FunctionPrototype%` as `%ThrowTypeError%` poison-pill accessors.
Member-assignment (`bound.caller = {}`) routes through `__extern_set_strict`
→ `_safeSet(strict=true)`, whose `strictAccessorWrite` path
(`runtime.ts:4699-4738`) walks the prototype chain, finds the inherited
poison-pill setter, runs the write, and **re-throws** the setter's TypeError
so the user's `try/catch` sees it. The get arms throw via the host
`__extern_get` invoking the inherited poison-pill getter.

### This PR
- Adds `tests/issue-2899.test.ts` — a regression guard: all four get/set arms
  throw `TypeError`, bound functions have no own `caller`/`arguments`, ordinary
  object/function-custom property set/get is unaffected, plus a guarded
  end-to-end `runTest262File` check (skipped when the test262 submodule isn't
  present).
- Marks the issue `status: done`.
- **No compiler-source change** — the fix already exists; this locks it in so a
  future change to the member-set/get dispatch or `_safeSet` strict path cannot
  silently regress it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS
