### PR TITLE
fix(#2676): strict aliased delete of non-configurable mapped-arguments index throws

### DIFF
--- a/plan/issues/2676-es3-mapped-arguments-strict-delete-aliased-throw.md
+++ b/plan/issues/2676-es3-mapped-arguments-strict-delete-aliased-throw.md
@@ -1,9 +1,11 @@
 ---
 id: 2676
 title: "≤ES3: mapped arguments — strict-mode aliased `delete args[i]` must throw TypeError on a non-configurable index (residual of #2667)"
-status: ready
+status: done
+assignee: ttraenkler/es3-2676
 created: 2026-06-25
-updated: 2026-06-25
+updated: 2026-06-30
+completed: 2026-06-30
 priority: high
 feasibility: hard
 reasoning_effort: high
@@ -75,3 +77,46 @@ Three things make this harder than the #2667 static path:
   `mappedArgsInfo`, or (b) a runtime descriptor on the arguments object so a
   strict `delete` consults real configurability and throws. Option (b) overlaps
   with the broader arguments-object descriptor-fidelity gap (#2668).
+
+## Resolution (option (a), compile-time alias resolution)
+
+Chose option (a) — no substrate/runtime-descriptor change (option (b) is
+deferred with #2668). The compile-time `nonConfigurableIndices` set from #2667
+is already authoritative for the statically-resolvable
+`Object.defineProperty(arguments, "<i>", { configurable:false })` shape these
+tests use; the only missing piece was making it reachable from the aliased
+delete site in the nested strict closure.
+
+- **Expose the info across the closure boundary.** Added
+  `ctx.mappedArgsInfoByFunc: Map<ts.Node, mappedArgsInfo>`, populated wherever a
+  mapped (sloppy, simple-param) function's `mappedArgsInfo` is created — the
+  top-level path (`compileFunctionBody`) and both nested-lift paths
+  (`nested-declarations.ts`). The stored value is the **live** info object, so
+  the `nonConfigurableIndices` set it carries reflects every `defineProperty`
+  processed before the delete is compiled. (Ordering holds: the
+  `defineProperty` textually precedes the `assert.throws(...)` closure, and the
+  map entry itself is created at function-entry, before either.)
+- **Resolve the alias at the delete site** (`typeof-delete.ts`,
+  `resolveAliasedMappedArgs`): for `delete <id>[<literal>]`, walk `<id>`'s symbol
+  → its `var <id> = arguments` value declaration → the nearest enclosing
+  non-arrow function (the `arguments` owner) → `ctx.mappedArgsInfoByFunc`. A hit
+  whose `nonConfigurableIndices` contains the literal index means OrdinaryDelete
+  fails: emit `i32.const 0` (`false`) and route it through the **existing**
+  `emitStrictDeleteCheck`, which throws TypeError in a strict context
+  (§13.5.1.2 step 6.b) and leaves `false` in a sloppy one — identical to the
+  #2667 direct-`arguments[i]` arm.
+- **Why this is downstream-safe.** No emitted-code change to any existing path:
+  the new map is pure bookkeeping, and the delete arm is gated on a *non-empty*
+  `nonConfigurableIndices` + an in-range literal index on a resolved
+  `arguments` alias. Configurable indices, unmapped/strict `arguments` (which
+  never get `mappedArgsInfo`), transitive aliases, and all non-arguments
+  deletes fall straight through to the prior behaviour. Stack balance is
+  unchanged — the arm produces exactly one i32 like every other delete arm.
+
+**Verification** — fresh single-file runs (mirroring `test262-worker`): all 4
+`mapped-arguments-nonconfigurable-strict-delete-{1..4}` flip fail→pass. The
+`language/arguments-object/mapped` directory goes 35→39 pass (the 4 targets),
+0 regressions; the remaining 4 fails there are pre-existing descriptor-fidelity
+cases (#2668), unchanged. `tests/issue-2676.test.ts` adds the core case plus
+sloppy-returns-false, configurable-index-does-not-throw, and regular-object
+strict-delete controls.

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -268,6 +268,7 @@ export function createCodegenContext(
     sidecarDefinedPropertyKeys: new Set(),
     definePropertyReceiverKeys: new Set(),
     nonConfigurableAccessorKeys: new Set(),
+    mappedArgsInfoByFunc: new Map(),
     nonExtensibleVars: new Set(),
     frozenVars: new Set(),
     sealedVars: new Set(),

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -2005,6 +2005,21 @@ export interface CodegenContext {
    * (#2726 group (d): `11.4.1-4-a-2-s`). Consumed ONLY by the delete site.
    */
   nonConfigurableAccessorKeys: Set<string>;
+  /**
+   * (#2676) Maps a mapped-`arguments` function's declaration node to its live
+   * `mappedArgsInfo`. A `delete args[i]` in a *nested* closure — typically the
+   * strict callback in `assert.throws(TypeError, function(){ "use strict";
+   * delete args[0]; })` after `var args = arguments` — has no `mappedArgsInfo`
+   * of its own and reads the alias `args`, not the literal `arguments`, so the
+   * #2667 direct-`arguments[i]` delete arm never fires. The delete site walks
+   * the alias' declaration initializer (`= arguments`) up to the enclosing
+   * (non-arrow) function that owns `arguments` and reads this map to recover the
+   * outer function's per-index `nonConfigurableIndices`. Populated when
+   * `mappedArgsInfo` is created (the `compileFunctionBody` path); read live at
+   * the delete site, so the index reflects every `Object.defineProperty(...,
+   * { configurable:false })` processed before the delete is compiled.
+   */
+  mappedArgsInfoByFunc: Map<ts.Node, NonNullable<FunctionContext["mappedArgsInfo"]>>;
   /** Object mutability state sets */
   nonExtensibleVars: Set<string>;
   frozenVars: Set<string>;

--- a/src/codegen/function-body.ts
+++ b/src/codegen/function-body.ts
@@ -996,6 +996,12 @@ export function compileFunctionBody(ctx: CodegenContext, decl: ts.FunctionDeclar
         paramOffset: 0,
         paramTypes: params.map((p) => p.type),
       };
+      // (#2676) Record this mapped function's live `mappedArgsInfo` keyed by its
+      // declaration node so a `delete args[i]` in a nested (strict) closure can
+      // resolve an aliased `arguments` (`var args = arguments`) back to this
+      // function's per-index `nonConfigurableIndices`. See the delete site in
+      // typeof-delete.ts (resolveAliasedMappedArgs).
+      ctx.mappedArgsInfoByFunc.set(decl, fctx.mappedArgsInfo);
     }
 
     // Build the arguments vec by concatenating formal params with

--- a/src/codegen/statements/nested-declarations.ts
+++ b/src/codegen/statements/nested-declarations.ts
@@ -528,6 +528,11 @@ export function compileNestedFunctionDeclaration(
       const unmapped =
         isStrictFunction(stmt, ctx.inferModuleStrictArguments) || !isSimpleParameterList(stmt.parameters);
       emitArgumentsObject(ctx, liftedFctx, paramTypes, 0, unmapped);
+      // (#2676) Expose this nested mapped function's live `mappedArgsInfo` keyed
+      // by its declaration node so a `delete args[i]` in a deeper (strict)
+      // closure can resolve an aliased `arguments` (`var args = arguments`) back
+      // to this function's per-index `nonConfigurableIndices`.
+      if (liftedFctx.mappedArgsInfo) ctx.mappedArgsInfoByFunc.set(stmt, liftedFctx.mappedArgsInfo);
     }
 
     if (nativeGenInfo) {
@@ -833,6 +838,9 @@ export function compileNestedFunctionDeclaration(
       const unmapped =
         isStrictFunction(stmt, ctx.inferModuleStrictArguments) || !isSimpleParameterList(stmt.parameters);
       emitArgumentsObject(ctx, liftedFctx, paramTypes, leadingParamCount, unmapped);
+      // (#2676) See the sibling site above — expose the live `mappedArgsInfo`
+      // by decl node for aliased-`arguments` strict-delete resolution.
+      if (liftedFctx.mappedArgsInfo) ctx.mappedArgsInfoByFunc.set(stmt, liftedFctx.mappedArgsInfo);
     }
 
     if (isGenerator) {

--- a/src/codegen/typeof-delete.ts
+++ b/src/codegen/typeof-delete.ts
@@ -99,6 +99,49 @@ function emitStrictDeleteCheck(ctx: CodegenContext, fctx: FunctionContext, expr:
   fctx.body.push({ op: "local.get", index: resLocal });
 }
 
+/**
+ * (#2676) Resolve an identifier that aliases a mapped-`arguments` object back to
+ * the owning function's live `mappedArgsInfo`. Matches the statically-tractable
+ * shape `var <alias> = arguments` (the alias' value declaration is a
+ * VariableDeclaration whose initializer is the bare `arguments` identifier). The
+ * `arguments` it reads belongs to the nearest enclosing *non-arrow* function;
+ * that function's `mappedArgsInfo` is looked up from `ctx.mappedArgsInfoByFunc`
+ * (present only for sloppy, simple-parameter functions — exactly the mapped
+ * case). Returns `undefined` for anything else (no alias, a strict/unmapped
+ * owner, or a transitive alias). Lets an aliased `delete args[i]` in a nested
+ * strict closure consult the outer function's per-index non-configurability.
+ */
+function resolveAliasedMappedArgs(
+  ctx: CodegenContext,
+  sym: ts.Symbol | undefined,
+): NonNullable<FunctionContext["mappedArgsInfo"]> | undefined {
+  const decls = sym?.declarations;
+  if (!decls) return undefined;
+  for (const d of decls) {
+    if (!ts.isVariableDeclaration(d)) continue;
+    const init = d.initializer;
+    if (!init || !ts.isIdentifier(init) || init.text !== "arguments") continue;
+    // The aliased `arguments` read resolves to the nearest enclosing non-arrow
+    // function (arrows do not bind their own `arguments`, so walk past them).
+    let owner: ts.Node | undefined = d.parent;
+    while (
+      owner &&
+      !ts.isFunctionDeclaration(owner) &&
+      !ts.isFunctionExpression(owner) &&
+      !ts.isMethodDeclaration(owner) &&
+      !ts.isConstructorDeclaration(owner) &&
+      !ts.isGetAccessorDeclaration(owner) &&
+      !ts.isSetAccessorDeclaration(owner)
+    ) {
+      owner = owner.parent;
+    }
+    if (!owner) continue;
+    const info = ctx.mappedArgsInfoByFunc.get(owner);
+    if (info) return info;
+  }
+  return undefined;
+}
+
 // ── Delete expression ─────────────────────────────────────────────────
 
 /**
@@ -296,6 +339,36 @@ export function compileDeleteExpression(
         return { kind: "i32" };
       }
       (fctx.mappedArgsInfo.unmappedIndices ??= new Set<number>()).add(argIndex);
+    }
+  }
+
+  // (#2676) Aliased mapped-`arguments` strict delete. `var args = arguments;
+  // ... delete args[i]` — the delete frequently lives in a nested *strict*
+  // closure (e.g. the `assert.throws(TypeError, function(){ "use strict";
+  // delete args[0]; })` callback) that captures `args` and has no
+  // `mappedArgsInfo` of its own, so the #2667 direct-`arguments[i]` arm above
+  // never fires. Resolve the alias through the AST back to the owning
+  // function's live `nonConfigurableIndices`. A non-configurable index makes
+  // the delete FAIL (OrdinaryDelete ⇒ false): emit `false` and route it through
+  // the strict check so a strict caller throws TypeError (§13.5.1.2 step 6.b)
+  // while a sloppy caller observes `false` — exactly mirroring the #2667 direct
+  // case (which the outer sloppy function takes via the arm above).
+  if (ts.isElementAccessExpression(inner) && ts.isIdentifier(inner.expression)) {
+    const aliasInfo = resolveAliasedMappedArgs(ctx, ctx.checker.getSymbolAtLocation(inner.expression));
+    if (aliasInfo?.nonConfigurableIndices && aliasInfo.nonConfigurableIndices.size > 0) {
+      const idxArg = inner.argumentExpression;
+      const idxText = ts.isNumericLiteral(idxArg) ? idxArg.text : ts.isStringLiteral(idxArg) ? idxArg.text : undefined;
+      const argIndex = idxText !== undefined ? Number(idxText) : NaN;
+      if (
+        Number.isInteger(argIndex) &&
+        argIndex >= 0 &&
+        argIndex < aliasInfo.paramCount &&
+        aliasInfo.nonConfigurableIndices.has(argIndex)
+      ) {
+        fctx.body.push({ op: "i32.const", value: 0 });
+        emitStrictDeleteCheck(ctx, fctx, expr);
+        return { kind: "i32" };
+      }
     }
   }
 

--- a/tests/issue-2676.test.ts
+++ b/tests/issue-2676.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+import { buildImports } from "../src/runtime.ts";
+
+// #2676 — ≤ES3 mapped `arguments`: a strict-mode **aliased** `delete args[i]`
+// on a non-configurable index must throw TypeError (residual of #2667).
+//
+// Shape of the 4 failing test262 cases
+// (language/arguments-object/mapped/mapped-arguments-nonconfigurable-strict-delete-{1..4}.js):
+//
+//   function f(a) {
+//     Object.defineProperty(arguments, "0", { configurable: false });
+//     var args = arguments;                                    // (1) alias
+//     assert.throws(TypeError, function() {                    // (3) nested fn
+//       "use strict";                                          // (2) strict
+//       delete args[0];                                        //     must THROW
+//     });
+//     assert.sameValue(a, 1);
+//     assert.sameValue(arguments[0], 1);
+//   }
+//
+// Three obstacles over the #2667 direct `delete arguments[i]` path:
+//   1. the receiver is the alias `args`, not the literal `arguments`;
+//   2. the delete lives in a nested *strict* closure that captures `args` and
+//      has no `mappedArgsInfo` of its own;
+//   3. the throw is conditional on the index being non-configurable.
+//
+// Fix: record each mapped function's live `mappedArgsInfo` keyed by its decl
+// node (`ctx.mappedArgsInfoByFunc`); at the delete site resolve `args` →
+// `var args = arguments` → owning function → its `nonConfigurableIndices`. A
+// non-configurable index makes OrdinaryDelete fail (`false`); routing that
+// `false` through the existing strict-delete check makes a strict caller throw
+// TypeError (§13.5.1.2 step 6.b) while a sloppy caller observes `false`.
+
+async function run(code: string): Promise<unknown> {
+  const result = await compile(code, { fileName: "test.ts" });
+  if (!result.success) throw new Error(`CE: ${result.errors[0]?.message}`);
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  return (instance.exports as { main(): unknown }).main();
+}
+
+describe("#2676 — mapped arguments: strict aliased delete of a non-configurable index throws", () => {
+  it("strict aliased `delete args[0]` throws TypeError; value + mapping intact", async () => {
+    // Mirrors mapped-arguments-nonconfigurable-strict-delete-1.js. Returns the
+    // throw flag (1) only when the inner strict delete threw AND `a` /
+    // `arguments[0]` are untouched.
+    const r = await run(`
+      function throws(fn: () => void): number { try { fn(); return 0; } catch (e) { return 1; } }
+      function f(a: any): number {
+        Object.defineProperty(arguments, "0", { configurable: false });
+        var args: any = arguments;
+        var t: number = throws(function (): void { "use strict"; delete args[0]; });
+        if (a !== 1) return 10;            // param untouched
+        if (arguments[0] !== 1) return 11; // mapping/value untouched
+        return t;                          // 1 = inner delete threw
+      }
+      export function main(): f64 { return f(1); }
+    `);
+    expect(r).toBe(1);
+  });
+
+  it("throws with the closure passed inline as a call argument (assert.throws shape)", async () => {
+    // The real tests pass the strict callback DIRECTLY as a call argument
+    // (`assert.throws(TypeError, function(){...})`), not via an intermediate
+    // local — exercise that exact shape so the alias resolves through a
+    // function-expression argument, and confirm the slot value is preserved.
+    const r = await run(`
+      function expectThrow(fn: () => void): number { try { fn(); return 0; } catch (e) { return 1; } }
+      function f(a: any): number {
+        Object.defineProperty(arguments, "0", { configurable: false });
+        var args: any = arguments;
+        if (expectThrow(function (): void { "use strict"; delete args[0]; }) !== 1) return 20;
+        if (arguments[0] !== 1) return 21; // value/mapping untouched by failed delete
+        return 1;
+      }
+      export function main(): f64 { return f(1); }
+    `);
+    expect(r).toBe(1);
+  });
+
+  it("CONTROL: sloppy aliased delete of a non-configurable index returns false, no throw, value intact", async () => {
+    const r = await run(`
+      function f(a: any): number {
+        Object.defineProperty(arguments, "0", { configurable: false });
+        var args: any = arguments;
+        if (delete args[0]) return 2;       // sloppy delete must be falsy
+        if (a !== 1) return 3;
+        if (arguments[0] !== 1) return 4;   // value intact
+        return 1;
+      }
+      export function main(): f64 { return f(1); }
+    `);
+    expect(r).toBe(1);
+  });
+
+  it("CONTROL: strict aliased delete of a CONFIGURABLE mapped index does NOT throw", async () => {
+    // Index 0 left at its default (configurable). The non-configurable arm must
+    // NOT fire, so the strict delete succeeds without a spurious TypeError.
+    const r = await run(`
+      function throws(fn: () => void): number { try { fn(); return 0; } catch (e) { return 1; } }
+      function f(a: any): number {
+        var args: any = arguments;
+        return throws(function (): void { "use strict"; delete args[0]; });
+      }
+      export function main(): f64 { return f(1); }
+    `);
+    expect(r).toBe(0); // 0 = did not throw
+  });
+
+  it("CONTROL: regular-object strict delete of a non-configurable property still throws", async () => {
+    // Guards the shared strict-delete path (must be untouched by the alias arm).
+    const r = await run(`
+      function g(): number {
+        "use strict";
+        var o: any = {};
+        Object.defineProperty(o, "x", { value: 1, configurable: false });
+        delete o.x; // strict + non-configurable → TypeError
+        return 0;
+      }
+      export function main(): f64 { try { g(); return 0; } catch (e) { return 1; } }
+    `);
+    expect(r).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2676 — ≤ES3 mapped `arguments`: strict aliased `delete args[i]` must throw on a non-configurable index

Residual of #2667 (which handled the direct, sloppy `delete arguments[i]` shape). The 4 failing test262 cases run the delete inside the strict callback of `assert.throws(TypeError, function(){ "use strict"; delete args[0]; })` after `var args = arguments`:

```js
function f(a) {
  Object.defineProperty(arguments, "0", { configurable: false });
  var args = arguments;                                   // alias
  assert.throws(TypeError, function() { "use strict"; delete args[0]; });
  assert.sameValue(a, 1);
  assert.sameValue(arguments[0], 1);
}
```

That nested closure has no `mappedArgsInfo` of its own and reads the alias `args`, not the literal `arguments`, so #2667's direct-delete arm never fired — the delete returned normally instead of throwing TypeError (§13.5.1.2 step 6.b).

### Fix (option (a) — compile-time alias resolution; no substrate change)
- **`ctx.mappedArgsInfoByFunc: Map<ts.Node, mappedArgsInfo>`** — records each mapped function's *live* `mappedArgsInfo` keyed by its decl node (populated in `compileFunctionBody` + both nested-lift paths).
- **`resolveAliasedMappedArgs`** (`typeof-delete.ts`) — at `delete <id>[<literal>]`, resolves `<id>` → `var <id> = arguments` → enclosing non-arrow function → its per-index `nonConfigurableIndices`. A non-configurable index makes OrdinaryDelete fail: emit `false` and route it through the existing `emitStrictDeleteCheck`, which throws TypeError in strict context and leaves `false` in sloppy — mirroring the #2667 direct case.

### Why downstream-safe
No emitted-code change to existing paths: the map is pure bookkeeping, and the new delete arm is gated on a non-empty `nonConfigurableIndices` + an in-range literal index on a resolved `arguments` alias. Configurable indices, unmapped/strict `arguments` (no `mappedArgsInfo`), and all non-arguments deletes fall straight through. Produces exactly one i32 — stack balance unchanged.

### Verification (fresh single-file runs, mirroring `test262-worker`)
- All 4 `mapped-arguments-nonconfigurable-strict-delete-{1..4}` flip fail→pass.
- `language/arguments-object/mapped` dir: **35→39 pass, 0 regressions** (remaining 4 fails are pre-existing #2668 descriptor-fidelity cases).
- `tests/issue-2676.test.ts`: core case + sloppy-returns-false, configurable-index-does-not-throw, and regular-object strict-delete controls (5 passing).
- `tsc --noEmit` clean; biome lint + prettier clean.

Closes #2676.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS