### PR TITLE
fix(#2898): reject top-level yield expression as an early SyntaxError

### DIFF
--- a/plan/issues/2898-es3-yield-assignment-target-early-error.md
+++ b/plan/issues/2898-es3-yield-assignment-target-early-error.md
@@ -1,7 +1,8 @@
 ---
 id: 2898
 title: "≤ES3: `yield` as assignment target should be an early SyntaxError (currently compiles)"
-status: ready
+status: done
+completed: 2026-06-30
 priority: high
 sprint: current
 created: 2026-06-30
@@ -19,16 +20,53 @@ related: [2897]
 One of the **8 tests blocking 100% ≤ES3 conformance**.
 
 ## Failing test
+
 `test/language/expressions/assignmenttargettype/direct-yieldexpression-0.js`
 
 → **`expected parse/early SyntaxError but compiled and instantiated successfully`** — we accept a program the spec rejects at parse time.
 
 ## What it checks
+
 A `YieldExpression` has AssignmentTargetType "invalid", so using it as an assignment target is an **early SyntaxError** (negative test, `phase: parse`). We currently compile + instantiate it instead of rejecting it.
 
 ## Root-cause direction
+
 Early-error / negative-test handling: the parser or the pre-codegen early-error pass does not flag a `yield`-expression in assignment-target position. Find where AssignmentTargetType invalidity is (or isn't) enforced — the negative `phase: parse` test expects a `SyntaxError` raised before compilation. Note this is an **edition-heuristic ≤ES3 bucket** (yield is ES6); it counts toward the project's ES3 metric but is an early-error/generator concern.
 
 ## Acceptance
+
 - The test raises the expected early `SyntaxError` and is recorded as pass.
 - No regression in valid `yield`/generator tests.
+
+## Resolution (2026-06-30)
+
+**Root cause.** TypeScript parses the top-level `yield x = 1;` as a single
+`YieldExpression` whose operand is `x = 1` (i.e. `yield (x = 1)`), not as
+`(yield x) = 1`. Outside a generator, `yield` is not a yield expression at all —
+in sloppy code it is an `Identifier` — so TS leniently consuming an operand here
+is exactly the parse error the spec demands. The early-error pass
+(`detectEarlyErrors`) had no rule for a `YieldExpression` outside a generator, so
+it compiled through (the negative test only "passed" incidentally via the
+runner's warning→pass heuristic + the `$DONOTEVALUATE` undefined-name warning —
+fragile and not a real rejection).
+
+**Fix.** `src/compiler/early-errors/node-checks.ts` — in the `YieldExpression`
+branch, after the existing generator-params check, flag a `YieldExpression` that
+is **not inside any function** as an early SyntaxError. This is the _sound_
+invariant (yield is only valid inside a generator, which is a function), so it
+has **zero false positives**: a `[yield]`/`[yield 9]` `ComputedPropertyName` on a
+non-generator method _inside_ a generator (evaluated in the enclosing generator
+scope — test262 `name-prop-name-yield-expr`, `cpn-class-*-from-yield-expression`)
+sits under a `MethodDeclaration`, so `isInsideFunction` is true and it is left
+untouched. The broader in-function generator-context cases are out of scope.
+
+**Validation.**
+
+- `tests/issue-2898.test.ts` (14 unit cases) — rejects `yield x = 1;` / `yield 1;`
+  at the top level; accepts every valid generator yield form + the computed
+  property-name-in-generator regression guards + sloppy `yield`-as-identifier.
+- Real test262 runner verdict `pass` for `direct-yieldexpression-0/1`,
+  `parenthesized-yieldexpression-0/1`.
+- AST scan of all 23,629 `language/` test262 files: **0** positive tests carry a
+  top-level (outside-any-function) `YieldExpression` → no over-rejection.
+- Valid generators still compile + run (`for-of` over a generator).

--- a/src/compiler/early-errors/node-checks.ts
+++ b/src/compiler/early-errors/node-checks.ts
@@ -239,6 +239,27 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
   if (ts.isYieldExpression(node)) {
     if (isInsideGeneratorParams(node)) {
       ctx.addError(node, "Yield expression is not allowed in generator function parameters");
+    } else if (!isInsideFunction(node)) {
+      // ── Top-level YieldExpression (outside any function) (#2898) ──────
+      // ES: `yield` is only a YieldExpression inside a generator (a function).
+      // A YieldExpression that is not inside ANY function is therefore always
+      // invalid — in sloppy top-level code `yield` is an Identifier (TS parses
+      // those as Identifier nodes, not YieldExpression), so a top-level
+      // YieldExpression node means TS leniently consumed an operand the spec
+      // rejects at parse time, e.g. `yield x = 1;` (which the
+      // assignmenttargettype test treats as `(yield x)` in invalid LHS
+      // position) or a bare `yield 1;`. Both are early SyntaxErrors.
+      //
+      // We test `!isInsideFunction` rather than `!isInsideGeneratorFunction`
+      // deliberately: it is the SOUND invariant (no false positives). A yield
+      // nested in a non-generator function/method *inside* a generator can be
+      // valid — e.g. a `[yield]` ComputedPropertyName on a non-generator method
+      // is evaluated in the enclosing generator's scope (test262
+      // name-prop-name-yield-expr / cpn-class-*-from-yield-expression). Those
+      // sit under a MethodDeclaration, so `isInsideFunction` is true and we
+      // correctly leave them alone. The narrower in-function generator-context
+      // cases are out of scope for #2898.
+      ctx.addError(node, "A 'yield' expression is only allowed within a generator body");
     }
   }
   if (ts.isAwaitExpression(node)) {

--- a/tests/issue-2898.test.ts
+++ b/tests/issue-2898.test.ts
@@ -1,0 +1,75 @@
+// #2898 — `yield` as an assignment target must be an early SyntaxError.
+//
+// test262 `language/expressions/assignmenttargettype/direct-yieldexpression-0.js`
+// is a `negative: { phase: parse, type: SyntaxError }` test whose body is
+// `yield x = 1;` at the top level of a script. TypeScript leniently parses that
+// as a YieldExpression(`x = 1`) even though `yield` outside a generator is not a
+// yield expression at all — so the early-error pass previously let it compile.
+//
+// Fix: a YieldExpression that is not inside ANY function is always invalid
+// (yield is only valid inside a generator, which is a function), so it is flagged
+// as an early SyntaxError. The rule is deliberately the SOUND `!isInsideFunction`
+// invariant — a `[yield]` ComputedPropertyName on a non-generator method *inside*
+// a generator is valid (evaluated in the enclosing generator scope) and must stay
+// accepted; those sit under a MethodDeclaration so they are untouched.
+import { describe, it, expect } from "vitest";
+import { ts } from "../src/ts-api.js";
+import { detectEarlyErrors } from "../src/compiler/validation.js";
+
+function earlyErrors(src: string) {
+  const sf = ts.createSourceFile("test.js", src, ts.ScriptTarget.ESNext, /*setParentNodes*/ true, ts.ScriptKind.JS);
+  return detectEarlyErrors(sf);
+}
+
+function hasYieldError(src: string): boolean {
+  return earlyErrors(src).some((e) => e.severity === "error" && /yield/i.test(e.message));
+}
+
+describe("#2898 — top-level yield expression is an early SyntaxError", () => {
+  it("rejects `yield x = 1;` (the assignmenttargettype negative test body)", () => {
+    expect(hasYieldError("yield x = 1;")).toBe(true);
+  });
+
+  it("rejects a bare top-level `yield 1;`", () => {
+    expect(hasYieldError("yield 1;")).toBe(true);
+  });
+
+  // Note: `yield * x = 1;` and `yield* g();` at the top level are NOT
+  // YieldExpressions — sloppy-mode TS reads them as `(yield) * (...)`
+  // multiplication with `yield` as an identifier, which is syntactically valid.
+  // The matching test262 negative test (direct-yieldexpression-1) is covered by
+  // other early-error/warning paths, not this rule.
+
+  // ── Must stay accepted: valid generator yields ───────────────────────────
+  it.each([
+    ["yield in a generator declaration", "function* g(){ yield 1; }"],
+    ["yield as RHS of assignment in a generator", "function* g(){ x = yield 1; }"],
+    ["bare yield in a generator", "function* g(){ yield; }"],
+    ["yield* delegation in a generator", "function* g(){ yield* h(); }"],
+    ["async generator yield", "async function* g(){ yield 1; }"],
+    ["class generator method yield", "class C { *m(){ yield 1; } }"],
+    ["object generator method yield", "({ *m(){ yield 1; } });"],
+  ])("accepts %s", (_label, src) => {
+    expect(hasYieldError(src)).toBe(false);
+  });
+
+  // ── Regression guards: `[yield]` computed property name inside a generator ──
+  // The computed name is evaluated in the enclosing generator's scope, so the
+  // yield is valid even though it sits under a *non-generator* method.
+  it("accepts `[yield]` computed prop name on a method inside a generator", () => {
+    const src = "var iter = (function*() { ({ [yield]() {} }); })();";
+    expect(hasYieldError(src)).toBe(false);
+  });
+
+  it("accepts `[yield 9]` computed class-member names inside a generator", () => {
+    const src = "function * g() { let C = class { [yield 9]() { return 9; } static [yield 9]() { return 9; } }; }";
+    expect(hasYieldError(src)).toBe(false);
+  });
+
+  // ── Must stay accepted: `yield` as a sloppy-mode identifier ──────────────
+  // TS parses these as Identifier nodes (not YieldExpression), so the rule never
+  // fires; assert it explicitly to lock the boundary.
+  it.each([["var yield = 1;"], ["yield = 1;"], ["yield;"]])("accepts sloppy identifier use %s", (src) => {
+    expect(hasYieldError(src)).toBe(false);
+  });
+});


### PR DESCRIPTION
## #2898 — `yield` as an assignment target must be an early SyntaxError

test262 `language/expressions/assignmenttargettype/direct-yieldexpression-0.js`
is a `negative: { phase: parse, type: SyntaxError }` test whose body is
`yield x = 1;` at the top level of a script.

### Root cause
TypeScript parses top-level `yield x = 1;` as a single `YieldExpression`
whose operand is `x = 1` (i.e. `yield (x = 1)`), not `(yield x) = 1`. Outside a
generator, `yield` is not a yield expression at all — in sloppy code it is an
`Identifier` — so TS leniently consuming an operand here is exactly the parse
error the spec demands. The early-error pass (`detectEarlyErrors`) had **no rule**
for a `YieldExpression` outside a generator, so it compiled through. (The negative
test only "passed" incidentally via the runner's warning→pass heuristic + the
`$DONOTEVALUATE` undefined-name warning — fragile, not a real rejection.)

### Fix
`src/compiler/early-errors/node-checks.ts` — in the `YieldExpression` branch,
after the existing generator-params check, flag a `YieldExpression` that is **not
inside ANY function** as an early SyntaxError. This is the **sound** invariant
(yield is only valid inside a generator, which is a function), so it has **zero
false positives**: a `[yield]` / `[yield 9]` `ComputedPropertyName` on a
non-generator method *inside* a generator (evaluated in the enclosing generator
scope — test262 `name-prop-name-yield-expr`, `cpn-class-*-from-yield-expression`)
sits under a `MethodDeclaration`, so `isInsideFunction` is true and it is left
untouched. The narrower in-function generator-context cases are out of scope.

### Validation
- `tests/issue-2898.test.ts` (14 unit cases) — rejects top-level `yield x = 1;` /
  `yield 1;`; accepts every valid generator yield form, the computed
  property-name-in-generator regression guards, and sloppy `yield`-as-identifier.
- Real test262 runner verdict `pass` for `direct-yieldexpression-0/1`,
  `parenthesized-yieldexpression-0/1`.
- AST scan of **all 23,629 `language/` test262 files**: **0** positive tests
  carry a top-level (outside-any-function) `YieldExpression` → no over-rejection.
- Valid generators still compile + run (`for-of` over a generator).

Closes #2898.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS