### PR TITLE
feat(#2895 PATH B 1a): host-free async-frame foundation ($AsyncFrame + drive runtime accessors)

### DIFF
--- a/plan/issues/2895-standalone-await-frame-suspension.md
+++ b/plan/issues/2895-standalone-await-frame-suspension.md
@@ -1,7 +1,8 @@
 ---
 id: 2895
 title: "Standalone: genuinely-pending await needs true frame suspension (AG1 / PATH B) — await-on-$Frame + microtask resume"
-status: ready
+status: in-progress
+assignee: ttraenkler/sendev-asyncdrive
 created: 2026-06-30
 priority: medium
 feasibility: hard
@@ -167,3 +168,67 @@ ResumeFunction`): reserve slot first; load params+spills; **br_table over
 FRESH budget window (a full per-agent share) — do not begin late in a draining
 window (the XL would strand at the freeze). PR1 (#2384 frame-core) and the #2865
 AG0 reconcile (PR #2380) are the landed predecessors.
+
+## Implementation notes — PATH B build log (sendev-asyncdrive)
+
+Building PATH B incrementally on `origin/main` (post-#2380 AG0 reconcile, which
+landed: `isStandalonePromiseActive` + `isStandaloneThenChainNativeActive` are
+`wasi`-only, `emitStandaloneAwaitUnwrap` is the AG0 one-level unwrap). Each
+sub-slice is a separate, independently-mergeable PR; the broad carrier-gate
+re-widen (1d) is LAST, only after the drive layer is measured net-positive (a
+premature widen is the AG0 −31 regression — do NOT repeat it).
+
+### Slice 1a — frame-layout foundation (THIS PR, inert / zero-risk)
+
+- `src/codegen/async-frame.ts` (new): `isAsyncDriveActive(ctx)` (standalone||wasi
+  drive-layer gate, distinct from the `isStandalonePromiseActive` *carrier*
+  gate), `AsyncFrameInfo` (satisfies frame-core `FrameLayout`), and
+  `buildAsyncFrameInfo(...)` which registers the per-async-fn `$AsyncFrame_<name>`
+  state struct: fixed frame ABI fields (`STATE` i32, `SENT`/`ABRUPT`/`ERROR`
+  externref — awaited values are always boxed, unlike a numeric generator
+  carrier, `MODE` i32), captured params at `PARAM_FIELD_OFFSET`, live-across-await
+  spills (computed from `analyzeAsyncBody` liveness minus params minus the
+  resume binding — mirrors the generator `bodySpills`), then a trailing
+  `result_promise` field (after spills so `spillFieldOffset` is stable, same
+  discipline as generator `yield*` delegation slots).
+- `src/codegen/async-scheduler.ts`: added public accessors
+  `getOrRegisterPromiseCallbackTypeIdx` + `ensureAsyncDriveRuntime` (returns the
+  stable `$Promise`/reaction-node typeIdxs and the settle/enqueue/drain funcIdxs)
+  so the frame driver reuses the EXISTING Promise+microtask substrate verbatim
+  rather than forking a parallel scheduler.
+- `tests/issue-2895-async-frame.test.ts`: pins the gate + the `$AsyncFrame`
+  struct ABI (5 leading frame fields, param field, spill of a live body local
+  excluding param/resume-binding, trailing `(ref $Promise)`).
+- **Inert**: nothing in the live compile path imports `async-frame.ts` yet, so
+  output is byte-identical (the #2384 frame-core extraction pattern). No gate
+  flip, no regression surface.
+
+### Remaining slices (next sessions, build order)
+
+1b. **resume fn + step adapters + settle** — `ensureAsyncResumeFunction(info)`
+    builds `__async_resume_f<name>(frame)` with the generator slot-reservation
+    funcIdx-stability idiom (reserve placeholder slot BEFORE body emit). For the
+    single-await canonical shape it is a 2-state machine: `br_table` over
+    `STATE_FIELD` → seg0 (entry: prefix + awaited-expr assimilate → if FULFILLED
+    set SENT and fall through, else `storeSpills` + set STATE=1 + register a
+    `$PromiseCallback{__async_step_fulfill_f<name>, frame, __async_step_reject_f
+    <name>, frame, next}` reaction on the awaited promise's callbacks + `return`)
+    → seg1 (continuation: bind `x = SENT`, suffix). `__async_step_*` adapters
+    store the settled value into `SENT`/`ERROR` then call resume. `return v` in
+    a resume body settles `frame.result_promise` via `__promise_fulfill` (new
+    `compileReturnStatement` hook keyed off a `fctx.asyncDriveResultLocal`,
+    mirroring the `fctx.isGenerator` arm); `throw e` → `__promise_reject`.
+1c. **wire live + call-site + runner drain hook** — in `function-body.ts`, when
+    `isAsyncDriveActive(ctx) && asyncFnNeedsCps(...)`, alloc the frame (params
+    spilled), create the pending result `$Promise`, call `__async_resume_f` once
+    (runs seg0 to first real suspension), return the result promise. **Runner
+    drain hook** (`tests/test262-runner.ts`): for `flags:[async]`
+    standalone/wasi tests, drain `__drain_microtasks` after `test()` runs and
+    before reading `__fail` — REQUIRED for any harness credit (the trap AG0 fell
+    into). Verify-first on REAL failing test262 async paths (async-function/dstr,
+    class async methods, `Promise.all().then` chains, async-generator/dstr) via
+    the corpus `wrapTest`/`runTest262File(...,"standalone")`; require
+    NET-POSITIVE on the full `merge_group` standalone report.
+1d. **re-widen carrier gates** — flip `isStandalonePromiseActive` +
+    `isStandaloneThenChainNativeActive` to include `ctx.standalone` TOGETHER,
+    only after 1c proves net-positive.

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -1,0 +1,264 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * Host-free async-frame substrate (#2895 PATH B, slice 1 — foundation).
+ *
+ * This is the **frame-layout layer** of the standalone/WASI async drive: it
+ * registers the per-async-function `$AsyncFrame` state struct and the
+ * {@link AsyncFrameInfo} that the resume-function emitter (next slice) consumes.
+ * It deliberately mirrors the Wasm-native **generator** substrate
+ * (`generators-native.ts` `buildNativeGeneratorInfo`) so both suspendable
+ * lowerings share one frame ABI ({@link import("./frame-core.js").FrameLayout})
+ * and one set of spill helpers (`frame-core.ts`) instead of forking.
+ *
+ * **Why a separate drive layer at all** (the measured #2865 AG0 root cause): a
+ * *genuinely-pending* await — a promise that only settles on a later microtask
+ * (an executor that resolves async, `Promise.all` of pending promises, a `.then`
+ * chain observed across a microtask) — cannot be served by AG0's one-level
+ * `$Promise.value` unwrap (`expressions.ts` `emitStandaloneAwaitUnwrap`): the
+ * value is simply not present during the synchronous body execution. PATH B
+ * builds a real resumable frame: at an await we spill live locals into the
+ * frame, register a reaction (a resume-step funcref + the frame) on the awaited
+ * `$Promise`'s callback list, and return the result `$Promise`; the microtask
+ * drain resumes the frame at the saved state with the settled value. The
+ * `$Promise` + reaction-node + microtask-ring + settle substrate already exists
+ * (`async-scheduler.ts`), so this layer only adds the *frame* and the resume
+ * trampoline; it reuses the scheduler verbatim via {@link
+ * import("./async-scheduler.js").ensureAsyncDriveRuntime}.
+ *
+ * **Slice scope.** This file lands the inert foundation (predicate + frame
+ * struct + info builder). It is NOT yet wired into `function-body.ts`, so
+ * compilation output is byte-identical — exactly the #2384 frame-core extraction
+ * pattern. The resume-function emitter, await-suspend lowering, settle-on-return,
+ * call-site allocation, and the runner microtask-drain hook follow in the next
+ * slices, and the broad `isStandalonePromiseActive` gate is re-widened to
+ * `standalone` only *together with* that drive layer (re-widening it before the
+ * drive layer exists is precisely the AG0 −31 regression).
+ */
+import { ts, forEachChild } from "../ts-api.js";
+import type { CodegenContext } from "./context/types.js";
+import type { ValType } from "../ir/types.js";
+import { PARAM_FIELD_OFFSET, SENT_FIELD, MODE_FIELD, ERROR_FIELD, sanitizeTypeName } from "./frame-core.js";
+import type { AsyncCpsPlan } from "./async-cps.js";
+import { splitBodyAtAwait } from "./async-cps.js";
+import { resolveSpillLocalValType } from "./statements/variables.js";
+
+/**
+ * Is the host-free async **drive layer** (#2895 PATH B) active for this module?
+ *
+ * Gated on the host-free targets — `--target standalone` and `--target wasi` —
+ * where the JS-host async-CPS imports (`Promise_resolve`/`Promise_then2`/
+ * `__make_callback`) are unavailable, so a genuinely-suspending async function
+ * must be driven by the native `$Promise` + microtask substrate instead. The
+ * JS-host path keeps its existing CPS state machine (`async-cps.ts`).
+ *
+ * NOTE: this is the *drive-layer* gate (does this fn get a real resumable
+ * frame), distinct from {@link import("./async-scheduler.js").isStandalonePromiseActive}
+ * (the *carrier* gate: does `await`/`Promise.resolve` use the native `$Promise`).
+ * The carrier gate stays `wasi`-only until this drive layer makes a native async
+ * result observable to the `flags:[async]` harness — see the file header.
+ */
+export function isAsyncDriveActive(ctx: CodegenContext): boolean {
+  return ctx.standalone === true || ctx.wasi === true;
+}
+
+/**
+ * Per-async-function frame metadata produced by {@link buildAsyncFrameInfo} and
+ * consumed by the resume-function emitter (next slice). Structurally satisfies
+ * {@link import("./frame-core.js").FrameLayout} (`stateTypeIdx`, `modeFieldIdx`,
+ * `spillNames`, `spillTypes`, `spillFieldOffset`) so the shared `frame-core.ts`
+ * spill/state helpers drive it with no wrapper — identical to how
+ * `NativeGeneratorInfo` satisfies the same interface.
+ */
+export interface AsyncFrameInfo {
+  /** Source function name (the `__async_resume_f<name>` / struct name stem). */
+  functionName: string;
+  /** The async function/method declaration this frame belongs to. */
+  decl: ts.FunctionLikeDeclaration;
+  /** Per-frame `$AsyncFrame_<name>` state struct typeIdx. */
+  stateTypeIdx: number;
+  /** Field index of the i32 resume mode (`MODE_FIELD`). FrameLayout. */
+  modeFieldIdx: number;
+  /** Field index of the settled-awaited-value slot (`SENT_FIELD`). */
+  sentFieldIdx: number;
+  /** Field index of the rejection-reason slot (`ERROR_FIELD`). */
+  errorFieldIdx: number;
+  /** Captured-parameter names, aligned 1:1 with `paramTypes`. */
+  paramNames: string[];
+  /** Wasm ValType of each captured parameter. */
+  paramTypes: ValType[];
+  /** First struct field index of the captured params (`PARAM_FIELD_OFFSET`). */
+  paramFieldOffset: number;
+  /** Names of body locals live across the await, spilled into the frame. FrameLayout. */
+  spillNames: string[];
+  /** Wasm ValType of each spilled local, aligned 1:1 with `spillNames`. FrameLayout. */
+  spillTypes: ValType[];
+  /** First struct field index where spills start. FrameLayout. */
+  spillFieldOffset: number;
+  /** Field index of the result `$Promise` the async fn returns / settles. */
+  resultPromiseFieldIdx: number;
+  /** `$Promise` struct typeIdx (the result-promise field's element type). */
+  promiseTypeIdx: number;
+  /** `__async_resume_f<name>(frame) -> void` funcIdx — filled by the emitter slice. */
+  resumeFuncIdx?: number;
+  /** `__async_step_fulfill_f<name>(caps, value) -> externref` funcIdx — emitter slice. */
+  stepFulfillFuncIdx?: number;
+  /** `__async_step_reject_f<name>(caps, value) -> externref` funcIdx — emitter slice. */
+  stepRejectFuncIdx?: number;
+}
+
+/**
+ * Build (and register the state struct for) the `$AsyncFrame` of one async
+ * function. Mirrors `buildNativeGeneratorInfo`: fixed leading frame fields
+ * (`STATE`/`SENT`/`MODE`/`ABRUPT`/`ERROR`), then the captured params at
+ * `PARAM_FIELD_OFFSET`, then the live-across-await spills, then a trailing
+ * result-`$Promise` field (placed after spills so the `spillFieldOffset`
+ * indexing the shared helpers use is unaffected — same discipline as the
+ * generator `yield*` delegation slots).
+ *
+ * Field ValTypes:
+ *   - `STATE`/`MODE`: i32 (the `br_table` selector + resume mode).
+ *   - `SENT`/`ABRUPT`/`ERROR`: externref. Unlike a numeric generator's carrier,
+ *     an awaited value is always boxed (`$Promise.value` is externref), so the
+ *     settled value, the (unused-here) `.return` carrier, and the rejection
+ *     reason are all externref.
+ *   - params/spills: their natural Wasm ValType.
+ *   - result promise: `(ref $Promise)`.
+ *
+ * @param promiseTypeIdx the module's `$Promise` struct typeIdx (from
+ *   `getOrRegisterPromiseType` — caller registers the drive runtime first so the
+ *   type exists and the funcIdx baseline is stable).
+ */
+export function buildAsyncFrameInfo(
+  ctx: CodegenContext,
+  decl: ts.FunctionLikeDeclaration,
+  plan: AsyncCpsPlan,
+  paramNames: string[],
+  paramTypes: ValType[],
+  promiseTypeIdx: number,
+): AsyncFrameInfo {
+  const functionName = asyncFnName(decl);
+
+  // Fixed leading frame fields (frame-core ABI). SENT/ABRUPT/ERROR are externref
+  // for async (awaited values are always boxed), unlike the generator carrier.
+  const stateFields: { name: string; type: ValType; mutable: boolean }[] = [
+    { name: "state", type: { kind: "i32" }, mutable: true },
+    { name: "sent", type: { kind: "externref" }, mutable: true },
+    { name: "mode", type: { kind: "i32" }, mutable: true },
+    { name: "abrupt", type: { kind: "externref" }, mutable: true },
+    { name: "error", type: { kind: "externref" }, mutable: true },
+  ];
+
+  for (let i = 0; i < paramTypes.length; i++) {
+    stateFields.push({ name: `param_${paramNames[i] ?? i}`, type: paramTypes[i]!, mutable: false });
+  }
+
+  const spillFieldOffset = PARAM_FIELD_OFFSET + paramTypes.length;
+  const { spillNames, spillTypes } = computeAsyncSpills(ctx, decl, plan, paramNames);
+  for (let i = 0; i < spillNames.length; i++) {
+    stateFields.push({ name: `spill_${spillNames[i]}`, type: spillTypes[i]!, mutable: true });
+  }
+
+  // Trailing result-promise field — after spills so `spillFieldOffset` is stable.
+  const resultPromiseFieldIdx = spillFieldOffset + spillNames.length;
+  stateFields.push({ name: "result_promise", type: { kind: "ref", typeIdx: promiseTypeIdx }, mutable: true });
+
+  const stateName = `$AsyncFrame_${sanitizeTypeName(functionName)}`;
+  const stateTypeIdx = ctx.mod.types.length;
+  ctx.mod.types.push({ kind: "struct", name: stateName, fields: stateFields });
+  ctx.structMap.set(stateName, stateTypeIdx);
+  ctx.typeIdxToStructName.set(stateTypeIdx, stateName);
+  ctx.structFields.set(stateName, stateFields);
+
+  return {
+    functionName,
+    decl,
+    stateTypeIdx,
+    modeFieldIdx: MODE_FIELD,
+    sentFieldIdx: SENT_FIELD,
+    errorFieldIdx: ERROR_FIELD,
+    paramNames,
+    paramTypes,
+    paramFieldOffset: PARAM_FIELD_OFFSET,
+    spillNames,
+    spillTypes,
+    spillFieldOffset,
+    resultPromiseFieldIdx,
+    promiseTypeIdx,
+  };
+}
+
+// ── internal ────────────────────────────────────────────────────────────────
+
+/** A stable, sanitizable name for the async function (for the struct + resume fn). */
+function asyncFnName(decl: ts.FunctionLikeDeclaration): string {
+  if (ts.isFunctionDeclaration(decl) && decl.name) return decl.name.text;
+  if ((ts.isMethodDeclaration(decl) || ts.isFunctionExpression(decl)) && decl.name && ts.isIdentifier(decl.name)) {
+    return decl.name.text;
+  }
+  // Arrow / anonymous — synthesize from source position (unique within a module).
+  const pos = decl.pos >= 0 ? decl.pos : 0;
+  return `anon_${pos}`;
+}
+
+/**
+ * The body locals that are live across the (single, slice-1) await and so must
+ * be spilled into the frame. Mirrors the generator's `bodySpills`: the
+ * live-after-await set MINUS params (already captured in param fields) MINUS the
+ * resume binding (`const x = await P` — `x` is delivered fresh from `SENT_FIELD`
+ * on resume, never snapshotted at suspend time). Spill ValTypes are resolved
+ * from the declaring `VariableDeclaration` via `resolveSpillLocalValType`,
+ * defaulting to externref when a precise type is not recoverable.
+ */
+function computeAsyncSpills(
+  ctx: CodegenContext,
+  decl: ts.FunctionLikeDeclaration,
+  plan: AsyncCpsPlan,
+  paramNames: string[],
+): { spillNames: string[]; spillTypes: ValType[] } {
+  if (plan.awaitPoints.length === 0) return { spillNames: [], spillTypes: [] };
+  const live = plan.liveAfterAwait.get(plan.awaitPoints[0]!) ?? new Set<string>();
+  const split = splitBodyAtAwait(decl, plan);
+  const resumeBindingName = split?.resumeBinding?.name;
+  const paramSet = new Set(paramNames);
+
+  const declByName = collectVarDeclsByName(decl);
+  const spillNames: string[] = [];
+  const spillTypes: ValType[] = [];
+  for (const name of live) {
+    if (paramSet.has(name)) continue;
+    if (resumeBindingName !== undefined && name === resumeBindingName) continue;
+    const declNode = declByName.get(name);
+    const resolved = declNode ? resolveSpillLocalValType(ctx, declNode) : null;
+    spillNames.push(name);
+    spillTypes.push(resolved ?? { kind: "externref" });
+  }
+  return { spillNames, spillTypes };
+}
+
+/** Map each body `var`/`let`/`const` declaration name → its declaration node. */
+function collectVarDeclsByName(decl: ts.FunctionLikeDeclaration): Map<string, ts.VariableDeclaration> {
+  const out = new Map<string, ts.VariableDeclaration>();
+  const body = decl.body;
+  if (body === undefined) return out;
+  const walk = (node: ts.Node): void => {
+    if (isNestedScope(node)) return;
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+      out.set(node.name.text, node);
+    }
+    forEachChild(node, walk);
+  };
+  forEachChild(body, walk);
+  return out;
+}
+
+function isNestedScope(node: ts.Node): boolean {
+  return (
+    ts.isFunctionDeclaration(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isArrowFunction(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node) ||
+    ts.isConstructorDeclaration(node)
+  );
+}

--- a/src/codegen/async-scheduler.ts
+++ b/src/codegen/async-scheduler.ts
@@ -1157,6 +1157,63 @@ export function exportDrainMicrotasksIfRegistered(ctx: CodegenContext): void {
 }
 
 /**
+ * The stable runtime handles the host-free async drive layer (#2895 PATH B)
+ * depends on: the native `$Promise` carrier + its `$PromiseCallback` reaction
+ * node, the microtask ring, and the one-shot settle helpers. All of these are
+ * the SAME substrate the standalone `.then` machinery
+ * ({@link emitStandalonePromiseThen}) and the WASI async path already use — the
+ * async frame driver reuses them rather than forking a parallel scheduler.
+ */
+export interface AsyncDriveRuntime {
+  /** `$Promise` struct typeIdx (`{state i32, value externref, callbacks externref}`). */
+  promiseTypeIdx: number;
+  /** `$PromiseCallback` reaction-node typeIdx ({@link getOrRegisterPromiseCallbackTypeIdx}). */
+  callbackTypeIdx: number;
+  /** `__promise_fulfill(promise, value) -> value` funcIdx (settles + drains callbacks). */
+  fulfillFuncIdx: number;
+  /** `__promise_reject(promise, value) -> value` funcIdx. */
+  rejectFuncIdx: number;
+  /** `__microtask_enqueue(funcref, caps externref, value externref)` funcIdx. */
+  enqueueFuncIdx: number;
+  /** `__drain_microtasks()` funcIdx. */
+  drainFuncIdx: number;
+}
+
+/**
+ * (#2895 PATH B) Public accessor for the `$PromiseCallback` reaction-node type.
+ * The async frame driver prepends a reaction (its per-fn resume-step funcref +
+ * the frame as caps) onto a pending awaited promise's `callbacks` list, so it
+ * needs the node's typeIdx. Internally identical to the private registrar the
+ * `.then` machinery uses — same node shape, same cache.
+ */
+export function getOrRegisterPromiseCallbackTypeIdx(ctx: CodegenContext): number {
+  return getOrRegisterPromiseCallbackType(ctx);
+}
+
+/**
+ * (#2895 PATH B) Idempotently register the full async-drive runtime substrate
+ * (Promise type, reaction node, microtask ring, settle helpers) and return the
+ * stable func/type indices. Must be invoked BEFORE emitting any function body
+ * that bakes these `call`/`struct.new` indices — registering mid-body would
+ * shift subsequent funcIdx values (the late-import-shift hazard #1677/#1809).
+ * The async frame driver calls this from its prepass / call-site emission, which
+ * runs before the resume function body is filled.
+ */
+export function ensureAsyncDriveRuntime(ctx: CodegenContext): AsyncDriveRuntime {
+  ensureMicrotaskQueue(ctx);
+  ensurePromiseSettleFunctions(ctx);
+  const state = getOrInitState(ctx as CodegenContextWithScheduler);
+  return {
+    promiseTypeIdx: getOrRegisterPromiseType(ctx),
+    callbackTypeIdx: getOrRegisterPromiseCallbackType(ctx),
+    fulfillFuncIdx: state.promiseFulfillFuncIdx,
+    rejectFuncIdx: state.promiseRejectFuncIdx,
+    enqueueFuncIdx: state.enqueueFuncIdx,
+    drainFuncIdx: state.drainFuncIdx,
+  };
+}
+
+/**
  * #1326 Phase 1C-A — Auto-drain hook for WASI `_start`. Returns the funcIdx
  * of `__drain_microtasks` when the queue is registered, or `null` when not
  * (queue was never used by this module; no drain call needed). Callers

--- a/tests/issue-2895-async-frame.test.ts
+++ b/tests/issue-2895-async-frame.test.ts
@@ -1,0 +1,144 @@
+// #2895 PATH B (slice 1 — foundation) — the host-free async-frame substrate.
+//
+// Validates the inert frame-layout layer: the `isAsyncDriveActive` gate and the
+// per-async-function `$AsyncFrame` state-struct shape built by
+// `buildAsyncFrameInfo`. The resume-function emitter, await-suspend lowering,
+// and call-site wiring land in following slices; this file pins the ABI the
+// emitter builds against.
+import { describe, it, expect } from "vitest";
+import * as ts from "typescript";
+// Import the top compiler entry first so the codegen module graph initializes in
+// the correct order (the regexp-standalone → string-ops → coercion-engine init
+// cycle is otherwise tripped by loading the barrel cold). Not otherwise used.
+import "../src/index.js";
+import { createEmptyModule } from "../src/ir/types.js";
+import { createCodegenContext } from "../src/codegen/index.js";
+import { getOrRegisterPromiseType } from "../src/codegen/async-scheduler.js";
+import { analyzeAsyncBody } from "../src/codegen/async-cps.js";
+import { isAsyncDriveActive, buildAsyncFrameInfo } from "../src/codegen/async-frame.js";
+import {
+  PARAM_FIELD_OFFSET,
+  STATE_FIELD,
+  SENT_FIELD,
+  MODE_FIELD,
+  ABRUPT_FIELD,
+  ERROR_FIELD,
+} from "../src/codegen/frame-core.js";
+import type { CodegenContext } from "../src/codegen/context/types.js";
+import type { ValType, StructTypeDef } from "../src/ir/types.js";
+
+function makeDummyChecker(): ts.TypeChecker {
+  return {} as unknown as ts.TypeChecker;
+}
+
+/** First top-level async function declaration in `src`. */
+function firstAsyncFn(src: string): ts.FunctionDeclaration {
+  const sf = ts.createSourceFile("_t.ts", src, ts.ScriptTarget.Latest, true);
+  const fn = sf.statements.find(ts.isFunctionDeclaration);
+  if (!fn) throw new Error("test setup: no function declaration");
+  return fn;
+}
+
+/** A real bound Program+checker over a single in-memory source file. */
+function programChecker(src: string): { fn: ts.FunctionDeclaration; checker: ts.TypeChecker } {
+  const fileName = "/_t.ts";
+  const sf = ts.createSourceFile(fileName, src, ts.ScriptTarget.Latest, true);
+  const host: ts.CompilerHost = {
+    getSourceFile: (name) => (name === fileName ? sf : undefined),
+    getDefaultLibFileName: () => "lib.d.ts",
+    writeFile: () => {},
+    getCurrentDirectory: () => "/",
+    getCanonicalFileName: (n) => n,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+    fileExists: (name) => name === fileName,
+    readFile: (name) => (name === fileName ? src : undefined),
+  };
+  const program = ts.createProgram([fileName], { noLib: true, noResolve: true }, host);
+  const checker = program.getTypeChecker();
+  const root = program.getSourceFile(fileName)!;
+  const fn = root.statements.find(ts.isFunctionDeclaration);
+  if (!fn) throw new Error("test setup: no function declaration");
+  return { fn, checker };
+}
+
+function makeCtx(options?: { standalone?: boolean; wasi?: boolean }, checker?: ts.TypeChecker): CodegenContext {
+  return createCodegenContext(createEmptyModule(), checker ?? makeDummyChecker(), options);
+}
+
+describe("#2895 PATH B foundation — isAsyncDriveActive", () => {
+  it("is active for --target standalone", () => {
+    expect(isAsyncDriveActive(makeCtx({ standalone: true }))).toBe(true);
+  });
+  it("is active for --target wasi", () => {
+    expect(isAsyncDriveActive(makeCtx({ wasi: true }))).toBe(true);
+  });
+  it("is inactive for the default JS-host target", () => {
+    expect(isAsyncDriveActive(makeCtx())).toBe(false);
+  });
+});
+
+describe("#2895 PATH B foundation — $AsyncFrame state struct", () => {
+  it("registers the fixed frame ABI fields, a param field, and a trailing result promise", () => {
+    const ctx = makeCtx({ standalone: true });
+    const promiseTypeIdx = getOrRegisterPromiseType(ctx);
+    const fn = firstAsyncFn(`async function f(a: number) { await p(); return a; }`);
+    const plan = analyzeAsyncBody(ctx, fn);
+
+    const info = buildAsyncFrameInfo(ctx, fn, plan, ["a"], [{ kind: "f64" }], promiseTypeIdx);
+
+    // Leading frame ABI (frame-core constants), all at their canonical offsets.
+    const struct = ctx.mod.types[info.stateTypeIdx] as StructTypeDef;
+    expect(struct.kind).toBe("struct");
+    const f = struct.fields;
+    expect(f[STATE_FIELD]).toMatchObject({ name: "state", type: { kind: "i32" } });
+    expect(f[SENT_FIELD]).toMatchObject({ name: "sent", type: { kind: "externref" } });
+    expect(f[MODE_FIELD]).toMatchObject({ name: "mode", type: { kind: "i32" } });
+    expect(f[ABRUPT_FIELD]).toMatchObject({ name: "abrupt", type: { kind: "externref" } });
+    expect(f[ERROR_FIELD]).toMatchObject({ name: "error", type: { kind: "externref" } });
+
+    // Param captured at PARAM_FIELD_OFFSET with its natural ValType.
+    expect(info.paramFieldOffset).toBe(PARAM_FIELD_OFFSET);
+    expect(f[PARAM_FIELD_OFFSET]).toMatchObject({ name: "param_a", type: { kind: "f64" } });
+
+    // No body local is live across the await (only the param `a` is), so no spills.
+    expect(info.spillNames).toEqual([]);
+    expect(info.spillFieldOffset).toBe(PARAM_FIELD_OFFSET + 1);
+
+    // Trailing result-promise field of type (ref $Promise).
+    expect(info.resultPromiseFieldIdx).toBe(info.spillFieldOffset);
+    const resultField = f[info.resultPromiseFieldIdx]!;
+    expect(resultField.name).toBe("result_promise");
+    expect(resultField.type).toMatchObject({ kind: "ref", typeIdx: promiseTypeIdx });
+
+    expect(info.modeFieldIdx).toBe(MODE_FIELD);
+    expect(info.promiseTypeIdx).toBe(promiseTypeIdx);
+  });
+
+  it("spills a body local live across the await, excluding params and the resume binding", () => {
+    const { fn, checker } = programChecker(
+      `async function f(a: number): Promise<number> {
+         let keep: number = a + 1;
+         const r = await p();
+         return keep + r;
+       }`,
+    );
+    const ctx = makeCtx({ standalone: true }, checker);
+    const promiseTypeIdx = getOrRegisterPromiseType(ctx);
+    const plan = analyzeAsyncBody(ctx, fn);
+
+    const info = buildAsyncFrameInfo(ctx, fn, plan, ["a"], [{ kind: "f64" } as ValType], promiseTypeIdx);
+
+    // `keep` is read after the await → spilled. `a` is a param (param field, not
+    // a spill). `r` is the resume binding (delivered from SENT_FIELD) → not a spill.
+    expect(info.spillNames).toContain("keep");
+    expect(info.spillNames).not.toContain("a");
+    expect(info.spillNames).not.toContain("r");
+
+    // Each spill field sits at/after spillFieldOffset and is mutable.
+    const struct = ctx.mod.types[info.stateTypeIdx] as StructTypeDef;
+    const keepIdx = info.spillFieldOffset + info.spillNames.indexOf("keep");
+    expect(struct.fields[keepIdx]!.name).toBe("spill_keep");
+    expect(struct.fields[keepIdx]!.mutable).toBe(true);
+  });
+});


### PR DESCRIPTION
## #2895 PATH B — standalone async drive layer, slice 1a (foundation)

Builds the **frame-layout substrate** for the host-free standalone/WASI async
drive layer (PATH B — the biggest standalone-conformance lever, ~986 async
cluster). This first slice is **inert / zero-risk**: nothing in the live compile
path imports it yet, so output is byte-identical (the #2384 frame-core
extraction pattern). It exists so the resume-function emitter, await-suspend
lowering, and call-site wiring (following slices) build on a stable, reviewed ABI.

### What landed
- **`src/codegen/async-frame.ts`** (new):
  - `isAsyncDriveActive(ctx)` — the drive-layer gate (`standalone || wasi`),
    deliberately distinct from the `isStandalonePromiseActive` *carrier* gate
    (the carrier gate stays `wasi`-only until the drive layer makes a native
    async result observable to the `flags:[async]` harness — re-widening it
    early is exactly the #2865 AG0 −31 regression).
  - `AsyncFrameInfo` — satisfies frame-core `FrameLayout`, so the shared
    `frame-core.ts` spill/state helpers drive it with no wrapper (same as
    `NativeGeneratorInfo`).
  - `buildAsyncFrameInfo(...)` — registers the per-async-fn `$AsyncFrame_<name>`
    state struct: fixed frame ABI fields (`STATE` i32, `SENT`/`ABRUPT`/`ERROR`
    externref — awaited values are always boxed, unlike a numeric generator
    carrier, `MODE` i32), captured params at `PARAM_FIELD_OFFSET`,
    live-across-await spills (liveness minus params minus the resume binding,
    mirroring the generator `bodySpills`), then a trailing `result_promise`
    field placed after spills so `spillFieldOffset` is stable.
- **`src/codegen/async-scheduler.ts`**: public accessors
  `getOrRegisterPromiseCallbackTypeIdx` + `ensureAsyncDriveRuntime` — the frame
  driver reuses the **existing** `$Promise` + reaction-node + microtask-ring +
  settle substrate verbatim instead of forking a parallel scheduler.
- **`tests/issue-2895-async-frame.test.ts`**: pins the gate + the `$AsyncFrame`
  struct ABI (5 leading frame fields, param field, spill of a live body local
  excluding param/resume-binding, trailing `(ref $Promise)`). 5 tests, green.

### Next slices (tracked in the issue impl-notes)
- **1b** — `ensureAsyncResumeFunction` (2-state `br_table` resume fn, generator
  slot-reservation funcIdx-stability idiom) + `__async_step_*` adapters + settle.
- **1c** — live wiring in `function-body.ts` + call-site frame alloc + the
  **runner microtask-drain hook** (REQUIRED for harness credit — the trap AG0
  fell into); verify-first net-positive on real test262 async paths.
- **1d** — re-widen `isStandalonePromiseActive`/`isStandaloneThenChainNativeActive`
  to `standalone` **together** with the drive layer, only after measured net-positive.

Builds on #2384 (frame-core) and #2380 (AG0 reconcile, landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)