### PR TITLE
feat(#2895 PATH B 1b/1c): host-free async resume fn + live wiring (genuinely-pending await suspends & resumes)

### DIFF
--- a/plan/issues/2895-standalone-await-frame-suspension.md
+++ b/plan/issues/2895-standalone-await-frame-suspension.md
@@ -232,3 +232,39 @@ premature widen is the AG0 −31 regression — do NOT repeat it).
 1d. **re-widen carrier gates** — flip `isStandalonePromiseActive` +
     `isStandaloneThenChainNativeActive` to include `ctx.standalone` TOGETHER,
     only after 1c proves net-positive.
+
+### Slice 1b/1c — resume fn + live wiring (LANDED + VALIDATED on wasi)
+
+Built and validated the host-free drive layer end-to-end on the native-`$Promise`
+carrier target (`--target wasi`, where the carrier gate is already on; the
+`--target standalone` re-widen is slice 1d):
+
+- `async-frame.ts`: `ensureAsyncResumeFunction` (2-state resume fn — `if(state==0)`
+  entry → assimilate awaited `$Promise`, FULFILLED → deliver `SENT` + fall
+  through, PENDING → `storeSpills` + STATE=1 + register a `$PromiseCallback`
+  reaction + `return`; continuation reads `SENT`), `__async_step_f<name>_{fulfill,
+  reject}` microtask adapters, and `emitAsyncFrameStateMachine` call-site shim
+  (alloc frame + pending result `$Promise`, kick resume once, return the promise).
+  Uses the generator slot-reservation funcIdx-stability idiom.
+- `function-body.ts`: wires it for `isStandalonePromiseActive(ctx) && asyncFnNeedsCps`
+  — gating on the **carrier** predicate so 1d's standalone widen flips carrier +
+  drive layer **together** (AG0-safe). The JS-host CPS branch is preserved.
+- `control-flow.ts`: `return v` in a resume body settles `result_promise` via
+  `__promise_fulfill` (keyed off `fctx.asyncDriveReturn`, mirrors the generator arm).
+
+**Validated** (`tests/issue-2895-async-frame.test.ts`, all green, host-free —
+`result.imports` empty, `WebAssembly.validate` true):
+- FULFILLED fast path: `await g()` (sync-settled async fn) delivers the value.
+- chained drive-lowered async fns thread the value through both frames.
+- **GENUINELY-PENDING**: `await Promise.resolve(1).then(cb)` (pending until the
+  microtask runs `cb`) SUSPENDS (continuation not run), and `__drain_microtasks`
+  resumes the frame to deliver the settled value — the exact case AG0 cannot serve.
+
+**Codegen lesson banked**: repeated `local.get <externref>; any.convert_extern;
+ref.cast $T` confuses the `stack-balance` type-repair pass (it splices a bogus
+`ref.cast_null; any.convert_extern`). Narrow the awaited `$Promise` into a single
+typed `(ref $Promise)` local once and reuse it.
+
+Remaining: **1d** — widen `isStandalonePromiseActive`/`isStandaloneThenChainNativeActive`
+to `standalone` + the runner `__drain_microtasks` hook for `flags:[async]` tests,
+measured NET-POSITIVE on the full `merge_group` standalone report.

--- a/plan/issues/2895-standalone-await-frame-suspension.md
+++ b/plan/issues/2895-standalone-await-frame-suspension.md
@@ -268,3 +268,41 @@ typed `(ref $Promise)` local once and reuse it.
 Remaining: **1d** — widen `isStandalonePromiseActive`/`isStandaloneThenChainNativeActive`
 to `standalone` + the runner `__drain_microtasks` hook for `flags:[async]` tests,
 measured NET-POSITIVE on the full `merge_group` standalone report.
+
+### Slice 1d — carrier re-widen: MEASURED NET-NEGATIVE, NOT shipped (verify-first)
+
+Per the spec's verify-first mandate, I measured the `--target standalone` carrier
+re-widen (`isStandalonePromiseActive` + `isStandaloneThenChainNativeActive` →
+`standalone`) on the real `language/statements/async-function` corpus (74 files)
+under `runTest262File(..., "standalone")`, before vs after:
+
+| gates | pass | fail | ce |
+|-------|------|------|----|
+| baseline (wasi-only) | **61** | 6 | 7 |
+| widened (+standalone) | **45** | 22 | 7 |
+
+**−16 pass / 0 gains** — the AG0 −31 pattern repeats. So the widen is **NOT
+shipped**; gates stay `wasi`-only. The drive layer itself is correct (validated
+host-free on wasi + on standalone-with-widen for the slice-1 shapes), but the
+carrier widen turns on the native `$Promise`/`.then`/async-result substrate for
+the WHOLE standalone async surface, while slice-1's drive layer only covers the
+single tail-await canonical shape. Async fns that pass in the legacy synchronous
+standalone model regress under the partial drive layer. Sampled regressions:
+`dflt-params-abrupt`, `evaluation-body-that-throws`, `returns-async-arrow`,
+`returns-async-function`, `try-reject-finally-throw`, `try-return-finally-return`
+— i.e. **try/finally-across-await, throw-to-rejection, async-arrow/return-shape,
+and default-param** async bodies the slice-1 `splitBodyAtAwait` shape does not
+cover (they fall through to a now-inconsistent legacy path, or are mis-driven).
+
+**1d is therefore BLOCKED on broader drive-layer shape coverage** (a multi-slice
+effort), not a single gate flip. Sequence for the follow-up: extend
+`asyncFnNeedsCps`/`splitBodyAtAwait` (or the resume builder) to cover
+try/finally-across-await, throw→reject, multi-await, async-arrow, and
+default-param bodies; re-measure the full corpus per shape; widen the carrier
+only once the standalone async corpus is net-positive.
+
+**Shipped scaffolding (inert on the CI lanes today):** the `__drain_microtasks()`
+compiler intrinsic (carrier-gated: real drain on wasi, void no-op on
+standalone/gc while the carrier is wasi-only) + the test262 runner hook that
+emits it for `flags:[async]` tests. These are no-ops on the gc + standalone CI
+lanes now and auto-activate when 1d eventually widens the carrier.

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -35,12 +35,35 @@
  * drive layer exists is precisely the AG0 −31 regression).
  */
 import { ts, forEachChild } from "../ts-api.js";
-import type { CodegenContext } from "./context/types.js";
-import type { ValType } from "../ir/types.js";
-import { PARAM_FIELD_OFFSET, SENT_FIELD, MODE_FIELD, ERROR_FIELD, sanitizeTypeName } from "./frame-core.js";
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import type { Instr, ValType, WasmFunction } from "../ir/types.js";
+import {
+  PARAM_FIELD_OFFSET,
+  STATE_FIELD,
+  SENT_FIELD,
+  MODE_FIELD,
+  ERROR_FIELD,
+  sanitizeTypeName,
+  storeSpills,
+  setStateI32FromConst,
+  defaultSpillInstr,
+} from "./frame-core.js";
 import type { AsyncCpsPlan } from "./async-cps.js";
 import { splitBodyAtAwait } from "./async-cps.js";
 import { resolveSpillLocalValType } from "./statements/variables.js";
+import { allocLocal } from "./context/locals.js";
+import { addFuncType } from "./registry/types.js";
+import { compileExpression, compileStatement, coerceType } from "./shared.js";
+import { reportError } from "./context/errors.js";
+import { resolveWasmType } from "./index.js";
+import {
+  ensureAsyncDriveRuntime,
+  getOrRegisterPromiseType,
+  type AsyncDriveRuntime,
+  PROMISE_STATE_PENDING,
+  PROMISE_STATE_FULFILLED,
+  PROMISE_STATE_REJECTED,
+} from "./async-scheduler.js";
 
 /**
  * Is the host-free async **drive layer** (#2895 PATH B) active for this module?
@@ -261,4 +284,470 @@ function isNestedScope(node: ts.Node): boolean {
     ts.isSetAccessorDeclaration(node) ||
     ts.isConstructorDeclaration(node)
   );
+}
+
+// ── PATH B slice 1b: resume function + step adapters + call-site shim ─────────
+
+/**
+ * Build (idempotently) the host-free async **resume function**
+ * `__async_resume_f<name>(frame) -> void` and its two microtask **step
+ * adapters** for one async function. Returns the resume funcIdx.
+ *
+ * For the slice-1 single-await canonical shape (`splitBodyAtAwait`) the resume
+ * function is a **2-state** machine driven by `frame.STATE_FIELD`:
+ *   - state 0 (entry): run the synchronous prefix, evaluate the awaited operand
+ *     and assimilate it to a `$Promise`. If it is already FULFILLED, deliver its
+ *     value into `SENT_FIELD` and fall through into the continuation (fast path).
+ *     If still PENDING, `storeSpills`, set STATE=1, register a reaction
+ *     (`__async_step_fulfill_f<name>` / `__async_step_reject_f<name>` funcrefs +
+ *     this frame as caps) on the awaited promise's callback list, and `return`
+ *     (suspend). A non-`$Promise` operand is delivered straight through.
+ *   - state 1 (continuation): bind the resume value from `SENT_FIELD`, then run
+ *     the suffix. `return v` settles `frame.result_promise` (the
+ *     `asyncDriveReturn` hook); a fall-through end settles it with undefined.
+ *
+ * Uses the generator slot-reservation discipline (#2079/#1677/#1809): the resume
+ * function and both step adapters reserve their funcIdx slots with placeholder
+ * bodies BEFORE the resume body is emitted, because `compileStatement` on the
+ * prefix/suffix can lazily append helper functions to `ctx.mod.functions` — a
+ * stale capture would otherwise repoint every baked `call`/`ref.func`.
+ */
+export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameInfo, plan: AsyncCpsPlan): number {
+  if (info.resumeFuncIdx !== undefined) return info.resumeFuncIdx;
+
+  const split = splitBodyAtAwait(info.decl, plan);
+  if (split === null) {
+    reportError(ctx, info.decl, "internal: async-frame resume built on an unsupported body shape (#2895 slice 1)");
+    info.resumeFuncIdx = -1;
+    return -1;
+  }
+
+  const rt = ensureAsyncDriveRuntime(ctx);
+  const frameRef: ValType = { kind: "ref", typeIdx: info.stateTypeIdx };
+  const stem = sanitizeTypeName(info.functionName);
+
+  // Reserve slots: resume fn, then the two step adapters. The microtask wrapper
+  // ABI is (caps externref, value externref) -> externref (result dropped).
+  const resumeName = `__async_resume_f${stem}`;
+  const resumeTypeIdx = addFuncType(ctx, [frameRef], [], `${resumeName}_type`);
+  const stepName = `__async_step_f${stem}`;
+  const stepTypeIdx = addFuncType(
+    ctx,
+    [{ kind: "externref" }, { kind: "externref" }],
+    [{ kind: "externref" }],
+    `${stepName}_type`,
+  );
+
+  const resumeFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  info.resumeFuncIdx = resumeFuncIdx;
+  ctx.funcMap.set(resumeName, resumeFuncIdx);
+  const resumePlaceholder: WasmFunction = {
+    name: resumeName,
+    typeIdx: resumeTypeIdx,
+    locals: [],
+    body: [{ op: "unreachable" } as Instr],
+    exported: false,
+  };
+  ctx.mod.functions.push(resumePlaceholder);
+
+  const stepFulfillFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  info.stepFulfillFuncIdx = stepFulfillFuncIdx;
+  ctx.funcMap.set(`${stepName}_fulfill`, stepFulfillFuncIdx);
+  ctx.mod.functions.push({
+    name: `${stepName}_fulfill`,
+    typeIdx: stepTypeIdx,
+    locals: buildStepAdapterLocals(info),
+    body: buildStepAdapterBody(info, resumeFuncIdx, /*reject*/ false),
+    exported: false,
+  });
+
+  const stepRejectFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  info.stepRejectFuncIdx = stepRejectFuncIdx;
+  ctx.funcMap.set(`${stepName}_reject`, stepRejectFuncIdx);
+  ctx.mod.functions.push({
+    name: `${stepName}_reject`,
+    typeIdx: stepTypeIdx,
+    locals: buildStepAdapterLocals(info),
+    body: buildStepAdapterBody(info, resumeFuncIdx, /*reject*/ true),
+    exported: false,
+  });
+
+  // ── Build the resume function body. ──
+  const resumeFctx: FunctionContext = {
+    name: resumeName,
+    params: [{ name: "__frame", type: frameRef }],
+    locals: [],
+    localMap: new Map([["__frame", 0]]),
+    returnType: null,
+    body: [],
+    blockDepth: 0,
+    breakStack: [],
+    continueStack: [],
+    labelMap: new Map(),
+    savedBodies: [],
+  };
+  const frameLocal = 0;
+
+  // Load captured params from the frame into locals.
+  for (let i = 0; i < info.paramNames.length; i++) {
+    const idx = allocLocal(resumeFctx, info.paramNames[i]!, info.paramTypes[i]!);
+    resumeFctx.body.push({ op: "local.get", index: frameLocal });
+    resumeFctx.body.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.paramFieldOffset + i });
+    resumeFctx.body.push({ op: "local.set", index: idx });
+  }
+  // Load spills from the frame into locals (overwritten by the prefix on first
+  // entry; restored from the frame on resume).
+  for (let i = 0; i < info.spillNames.length; i++) {
+    const idx = allocLocal(resumeFctx, info.spillNames[i]!, info.spillTypes[i]!);
+    resumeFctx.body.push({ op: "local.get", index: frameLocal });
+    resumeFctx.body.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.spillFieldOffset + i });
+    resumeFctx.body.push({ op: "local.set", index: idx });
+  }
+  // Load the result promise into a local; wire the `return` settle hook.
+  const resultPromiseLocal = allocLocal(resumeFctx, "__async_result", {
+    kind: "ref",
+    typeIdx: info.promiseTypeIdx,
+  });
+  resumeFctx.body.push({ op: "local.get", index: frameLocal });
+  resumeFctx.body.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: info.resultPromiseFieldIdx });
+  resumeFctx.body.push({ op: "local.set", index: resultPromiseLocal });
+  resumeFctx.asyncDriveReturn = {
+    resultPromiseLocal,
+    promiseTypeIdx: info.promiseTypeIdx,
+    fulfillFuncIdx: rt.fulfillFuncIdx,
+  };
+
+  // Resume binding (`const x = await P`) — declared up-front so the continuation
+  // and (harmlessly) the entry segment share the slot.
+  let resumeBindingLocal: number | undefined;
+  let resumeBindingType: ValType | undefined;
+  if (split.resumeBinding) {
+    resumeBindingType = split.resumeBinding.type
+      ? resolveWasmType(ctx, ctx.checker.getTypeAtLocation(split.resumeBinding.type))
+      : { kind: "externref" };
+    resumeBindingLocal = allocLocal(resumeFctx, split.resumeBinding.name, resumeBindingType);
+  }
+
+  // Compile the entry + continuation segments under this resume context (so late
+  // imports shift THIS body). `liveBodies` guards the detached outer arrays.
+  const savedFunc = ctx.currentFunc;
+  ctx.currentFunc = resumeFctx;
+  let entrySeg: Instr[];
+  let contSeg: Instr[];
+  try {
+    entrySeg = buildEntrySegment(ctx, resumeFctx, info, split, rt, frameLocal);
+    contSeg = buildContinuationSegment(
+      ctx,
+      resumeFctx,
+      info,
+      split,
+      resultPromiseLocal,
+      rt,
+      frameLocal,
+      resumeBindingLocal,
+      resumeBindingType,
+    );
+  } finally {
+    ctx.currentFunc = savedFunc;
+  }
+
+  // 2-state dispatch: state 0 runs the entry (which either suspends with
+  // `return` or falls through delivering SENT); any other state skips straight
+  // to the continuation. The entry's fall-through and the state!=0 path both
+  // reach the continuation that follows the `if`.
+  resumeFctx.body.push({ op: "local.get", index: frameLocal });
+  resumeFctx.body.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: STATE_FIELD });
+  resumeFctx.body.push({ op: "i32.eqz" });
+  resumeFctx.body.push({ op: "if", blockType: { kind: "empty" }, then: entrySeg } as Instr);
+  for (const instr of contSeg) resumeFctx.body.push(instr);
+
+  resumePlaceholder.locals = resumeFctx.locals;
+  resumePlaceholder.body = resumeFctx.body;
+  return resumeFuncIdx;
+}
+
+/** Step-adapter locals: param 0/1 = (caps, value); local 2 = the cast frame. */
+function buildStepAdapterLocals(info: AsyncFrameInfo): { name: string; type: ValType }[] {
+  return [{ name: "$frame", type: { kind: "ref", typeIdx: info.stateTypeIdx } }];
+}
+
+/**
+ * `__async_step_f<name>_{fulfill,reject}(caps, value) -> externref`: cast caps
+ * back to the frame, store the settled value into `SENT_FIELD` (and, for the
+ * reject adapter, the reason into `ERROR_FIELD` + `MODE_FIELD=MODE_THROW`), then
+ * call the resume function. This is the funcref enqueued on the awaited
+ * promise's reaction list and run by the microtask drain.
+ */
+function buildStepAdapterBody(info: AsyncFrameInfo, resumeFuncIdx: number, reject: boolean): Instr[] {
+  const capsLocal = 0;
+  const valueLocal = 1;
+  const frameLocal = 2;
+  const body: Instr[] = [
+    { op: "local.get", index: capsLocal },
+    { op: "any.convert_extern" } as Instr,
+    { op: "ref.cast", typeIdx: info.stateTypeIdx } as Instr,
+    { op: "local.set", index: frameLocal },
+    // SENT_FIELD = value (the settled awaited value the continuation reads).
+    { op: "local.get", index: frameLocal },
+    { op: "local.get", index: valueLocal },
+    { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: SENT_FIELD } as Instr,
+  ];
+  if (reject) {
+    // ERROR_FIELD = reason; MODE_FIELD = MODE_THROW (2). (Slice-1 surfaces the
+    // reason via SENT for the fast path; the throw-on-rejected-await refinement
+    // reads ERROR/MODE — wired here so the field is populated.)
+    body.push(
+      { op: "local.get", index: frameLocal },
+      { op: "local.get", index: valueLocal },
+      { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: ERROR_FIELD } as Instr,
+      ...setStateI32FromConst(info, frameLocal, MODE_FIELD, 2),
+    );
+  }
+  body.push(
+    { op: "local.get", index: frameLocal },
+    { op: "call", funcIdx: resumeFuncIdx },
+    { op: "ref.null.extern" } as Instr, // dropped by the drain
+  );
+  return body;
+}
+
+/**
+ * Entry segment (state 0): synchronous prefix → assimilate awaited operand → on
+ * FULFILLED deliver value to SENT and fall through; on PENDING register the
+ * reaction and `return` (suspend); a non-`$Promise` operand is delivered
+ * straight through. Built into a detached `Instr[]`.
+ */
+function buildEntrySegment(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  info: AsyncFrameInfo,
+  split: ReturnType<typeof splitBodyAtAwait> & object,
+  rt: AsyncDriveRuntime,
+  frameLocal: number,
+): Instr[] {
+  const promiseTypeIdx = info.promiseTypeIdx;
+  const saved = fctx.body;
+  ctx.liveBodies.add(saved);
+  const seg: Instr[] = [];
+  fctx.body = seg;
+  try {
+    for (const stmt of split.prefix) compileStatement(ctx, fctx, stmt);
+
+    // Awaited operand → externref.
+    const awaitedType = compileExpression(ctx, fctx, split.awaitedExpr);
+    if (awaitedType !== null && awaitedType !== undefined) {
+      coerceType(ctx, fctx, awaitedType as ValType, { kind: "externref" });
+    } else {
+      seg.push({ op: "ref.null.extern" } as Instr);
+    }
+    const awaitedLocal = allocLocal(fctx, "__async_awaited", { kind: "externref" });
+    seg.push({ op: "local.set", index: awaitedLocal });
+
+    // Cast the awaited `$Promise` into a single typed local and reuse it for
+    // every field access / reaction receiver. A repeated `local.get <externref>;
+    // any.convert_extern; ref.cast` pattern confuses the stack-balance
+    // type-repair pass (it re-infers the value and splices a bogus
+    // `ref.cast_null; any.convert_extern` "fixup"), so we narrow once here.
+    const pLocal = allocLocal(fctx, "__async_p", { kind: "ref", typeIdx: promiseTypeIdx });
+
+    // frame.SENT = pLocal.value — minted fresh per use (FULFILLED + REJECTED
+    // arms) so no `Instr[]` is aliased into two branch slots (a later
+    // type/funcIdx-shift pass would double-mutate a shared array; memory
+    // `reference_shared_instr_object_dce_double_remap`).
+    const deliverFromP = (): Instr[] => [
+      { op: "local.get", index: frameLocal },
+      { op: "local.get", index: pLocal },
+      { op: "struct.get", typeIdx: promiseTypeIdx, fieldIdx: 1 } as Instr,
+      { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: SENT_FIELD } as Instr,
+    ];
+    const deliverPlain: Instr[] = [
+      { op: "local.get", index: frameLocal },
+      { op: "local.get", index: awaitedLocal },
+      { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: SENT_FIELD } as Instr,
+    ];
+
+    // Suspend arm: storeSpills + STATE=1 + register reaction + return.
+    const suspend: Instr[] = [
+      ...storeSpills(info, fctx, frameLocal),
+      ...setStateI32FromConst(info, frameLocal, STATE_FIELD, 1),
+      // promise.callbacks = $PromiseCallback{stepFulfill, frame, stepReject, frame, promise.callbacks}
+      { op: "local.get", index: pLocal }, // receiver for struct.set callbacks
+      { op: "ref.func", funcIdx: info.stepFulfillFuncIdx! } as Instr,
+      { op: "local.get", index: frameLocal },
+      { op: "extern.convert_any" } as Instr,
+      { op: "ref.func", funcIdx: info.stepRejectFuncIdx! } as Instr,
+      { op: "local.get", index: frameLocal },
+      { op: "extern.convert_any" } as Instr,
+      { op: "local.get", index: pLocal },
+      { op: "struct.get", typeIdx: promiseTypeIdx, fieldIdx: 2 } as Instr, // current callbacks (next)
+      { op: "struct.new", typeIdx: rt.callbackTypeIdx } as Instr,
+      { op: "extern.convert_any" } as Instr,
+      { op: "struct.set", typeIdx: promiseTypeIdx, fieldIdx: 2 } as Instr,
+      { op: "return" },
+    ];
+
+    // PENDING-or-rejected discrimination inside the "is a promise" arm.
+    const pendingOrRejected: Instr[] = [
+      { op: "local.get", index: pLocal },
+      { op: "struct.get", typeIdx: promiseTypeIdx, fieldIdx: 0 } as Instr,
+      { op: "i32.const", value: PROMISE_STATE_REJECTED },
+      { op: "i32.eq" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: deliverFromP(), // rejected-now: deliver reason as value (slice-1)
+        else: suspend, // genuinely pending: suspend
+      } as Instr,
+    ];
+
+    // is it a $Promise?
+    seg.push(
+      { op: "local.get", index: awaitedLocal },
+      { op: "any.convert_extern" } as Instr,
+      { op: "ref.test", typeIdx: promiseTypeIdx } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          // narrow once: pLocal = (ref $Promise) awaitedLocal
+          { op: "local.get", index: awaitedLocal },
+          { op: "any.convert_extern" } as Instr,
+          { op: "ref.cast", typeIdx: promiseTypeIdx } as Instr,
+          { op: "local.set", index: pLocal },
+          // state == FULFILLED ?
+          { op: "local.get", index: pLocal },
+          { op: "struct.get", typeIdx: promiseTypeIdx, fieldIdx: 0 } as Instr,
+          { op: "i32.const", value: PROMISE_STATE_FULFILLED },
+          { op: "i32.eq" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: deliverFromP(), // fulfilled: deliver value, fall through
+            else: pendingOrRejected,
+          } as Instr,
+        ],
+        else: deliverPlain, // non-promise: deliver straight through
+      } as Instr,
+    );
+  } finally {
+    fctx.body = saved;
+    ctx.liveBodies.delete(saved);
+  }
+  return seg;
+}
+
+/**
+ * Continuation segment (state 1): bind the resume value from `SENT_FIELD`, run
+ * the suffix (whose `return v` settles `result_promise` via the
+ * `asyncDriveReturn` hook), then settle with undefined on fall-through.
+ */
+function buildContinuationSegment(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  info: AsyncFrameInfo,
+  split: ReturnType<typeof splitBodyAtAwait> & object,
+  resultPromiseLocal: number,
+  rt: AsyncDriveRuntime,
+  frameLocal: number,
+  resumeBindingLocal: number | undefined,
+  resumeBindingType: ValType | undefined,
+): Instr[] {
+  const saved = fctx.body;
+  ctx.liveBodies.add(saved);
+  const seg: Instr[] = [];
+  fctx.body = seg;
+  try {
+    // Bind `x = SENT` (coerced) for `const x = await P`.
+    if (resumeBindingLocal !== undefined && resumeBindingType) {
+      seg.push({ op: "local.get", index: frameLocal });
+      seg.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: SENT_FIELD });
+      coerceType(ctx, fctx, { kind: "externref" }, resumeBindingType);
+      seg.push({ op: "local.set", index: resumeBindingLocal });
+    }
+
+    if (split.isReturnAwait) {
+      // `return await P`: the resolved value IS the result. Settle with SENT.
+      seg.push({ op: "local.get", index: resultPromiseLocal });
+      seg.push({ op: "local.get", index: frameLocal });
+      seg.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: SENT_FIELD });
+      seg.push({ op: "call", funcIdx: rt.fulfillFuncIdx });
+      seg.push({ op: "drop" });
+      seg.push({ op: "return" });
+    } else {
+      for (const stmt of split.suffix) compileStatement(ctx, fctx, stmt);
+      // Fall-through (no explicit return): settle result with undefined.
+      seg.push({ op: "local.get", index: resultPromiseLocal });
+      seg.push({ op: "ref.null.extern" } as Instr);
+      seg.push({ op: "call", funcIdx: rt.fulfillFuncIdx });
+      seg.push({ op: "drop" });
+    }
+  } finally {
+    fctx.body = saved;
+    ctx.liveBodies.delete(saved);
+  }
+  return seg;
+}
+
+/**
+ * Call-site / function-body shim (#2895 slice 1c entry point). Emitted in place
+ * of the normal statement loop for a host-free async function that genuinely
+ * suspends: allocate the `$AsyncFrame` (params spilled into fields, a fresh
+ * pending result `$Promise`), kick the resume function once (runs entry to the
+ * first real suspension), and leave the result `$Promise` (externref) on the
+ * stack as the async function's return value. The function's result type must
+ * already be rewritten to externref by the caller.
+ */
+export function emitAsyncFrameStateMachine(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  decl: ts.FunctionLikeDeclaration,
+  plan: AsyncCpsPlan,
+): void {
+  const rt = ensureAsyncDriveRuntime(ctx);
+  const promiseTypeIdx = getOrRegisterPromiseType(ctx);
+  const paramNames = fctx.params.map((p) => p.name);
+  const paramTypes = fctx.params.map((p) => p.type);
+  const info = buildAsyncFrameInfo(ctx, decl, plan, paramNames, paramTypes, promiseTypeIdx);
+  const resumeFuncIdx = ensureAsyncResumeFunction(ctx, info, plan);
+  if (resumeFuncIdx < 0) {
+    reportError(ctx, decl, "internal: async-frame resume function unavailable (#2895 slice 1)");
+    fctx.body.push({ op: "ref.null.extern" } as Instr);
+    return;
+  }
+
+  // Fresh pending result promise → local.
+  const resultPromiseLocal = allocLocal(fctx, "__async_resultp", { kind: "ref", typeIdx: promiseTypeIdx });
+  fctx.body.push({ op: "i32.const", value: PROMISE_STATE_PENDING });
+  fctx.body.push({ op: "ref.null.extern" } as Instr);
+  fctx.body.push({ op: "ref.null.extern" } as Instr);
+  fctx.body.push({ op: "struct.new", typeIdx: promiseTypeIdx } as Instr);
+  fctx.body.push({ op: "local.set", index: resultPromiseLocal });
+
+  // Build the $AsyncFrame: state=0, sent=null, mode=0, abrupt=null, error=null,
+  // params (from this fn's wasm params), spills(default), result_promise.
+  fctx.body.push({ op: "i32.const", value: 0 }); // state
+  fctx.body.push({ op: "ref.null.extern" } as Instr); // sent
+  fctx.body.push({ op: "i32.const", value: 0 }); // mode = MODE_NEXT
+  fctx.body.push({ op: "ref.null.extern" } as Instr); // abrupt
+  fctx.body.push({ op: "ref.null.extern" } as Instr); // error
+  for (let i = 0; i < info.paramTypes.length; i++) {
+    fctx.body.push({ op: "local.get", index: i });
+  }
+  for (let i = 0; i < info.spillNames.length; i++) {
+    fctx.body.push(defaultSpillInstr(info.spillTypes[i]!));
+  }
+  fctx.body.push({ op: "local.get", index: resultPromiseLocal });
+  fctx.body.push({ op: "struct.new", typeIdx: info.stateTypeIdx } as Instr);
+  const frameLocal = allocLocal(fctx, "__async_frame", { kind: "ref", typeIdx: info.stateTypeIdx });
+  fctx.body.push({ op: "local.set", index: frameLocal });
+
+  // Kick the resume function once (runs the entry segment to the first real
+  // suspension or to synchronous completion).
+  fctx.body.push({ op: "local.get", index: frameLocal });
+  fctx.body.push({ op: "call", funcIdx: resumeFuncIdx });
+
+  // Return the result promise (externref).
+  fctx.body.push({ op: "local.get", index: resultPromiseLocal });
+  fctx.body.push({ op: "extern.convert_any" } as Instr);
+  fctx.body.push({ op: "return" });
 }

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -346,6 +346,22 @@ export interface FunctionContext {
    * emitted Wasm is byte-identical.
    */
   asyncCpsActive?: boolean;
+  /**
+   * (#2895 PATH B) Set while emitting a host-free async **resume** function body
+   * (`__async_resume_f<name>`). When present, `return v` settles the frame's
+   * result `$Promise` (`__promise_fulfill(resultPromise, v)`) and emits a void
+   * `return`, instead of the generic value-return — the resume function returns
+   * void; the async result is delivered through the promise. Mirrors the
+   * `isGenerator` `return` arm. Undefined on every non-resume body.
+   */
+  asyncDriveReturn?: {
+    /** Local holding the frame's result `$Promise` (loaded at resume entry). */
+    resultPromiseLocal: number;
+    /** `$Promise` struct typeIdx. */
+    promiseTypeIdx: number;
+    /** `__promise_fulfill(promise, value) -> value` funcIdx. */
+    fulfillFuncIdx: number;
+  };
   /** Set of variable names that are read-only bindings (e.g. named function expression name) */
   readOnlyBindings?: Set<string>;
   /** Set of variable names that are const bindings — assignment throws TypeError at runtime */

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -20,6 +20,7 @@ import {
   emitStandalonePromiseResolve,
   getOrRegisterPromiseType,
   isStandalonePromiseActive,
+  emitDrainMicrotasks,
   PROMISE_STATE_FULFILLED,
   PROMISE_STATE_REJECTED,
 } from "./async-scheduler.js";
@@ -1205,6 +1206,21 @@ function compileExpressionInner(
   }
 
   if (ts.isCallExpression(expr)) {
+    // (#2895 PATH B) `__drain_microtasks()` intrinsic — lets the test262 harness
+    // (and standalone entrypoints) pump the microtask ring so genuinely-pending
+    // async-frame continuations run before a settled value is observed. On the
+    // host-free targets it lowers to the native drain; on the JS-host target
+    // there is no native microtask ring (async is synchronous there), so it is a
+    // void no-op — keeping the gc lane byte-identical.
+    if (ts.isIdentifier(expr.expression) && expr.expression.text === "__drain_microtasks") {
+      // Gate on the native-`$Promise` CARRIER (not merely `isAsyncDriveActive`):
+      // emit the real drain only where the drive layer actually produces native
+      // promises. With the carrier `wasi`-only today, `--target standalone` and
+      // the gc lane get a void no-op (no microtask infra registered, output
+      // unchanged); the #2895-1d carrier re-widen auto-activates it for standalone.
+      if (isStandalonePromiseActive(ctx)) emitDrainMicrotasks(ctx, fctx);
+      return VOID_RESULT;
+    }
     const callStart = fctx.body.length;
     const callResult = compileCallExpression(ctx, fctx, expr, expectedType);
     if (fctx.pendingCallbackWritebacks && fctx.pendingCallbackWritebacks.length > 0) {

--- a/src/codegen/function-body.ts
+++ b/src/codegen/function-body.ts
@@ -53,6 +53,8 @@ import { collectI32SpecializedArrays } from "./array-element-typing.js";
 import { detectArrayReduceFusion, applyArrayReduceFusion } from "./array-reduce-fusion.js";
 import { compileNativeGeneratorFunction } from "./generators-native.js";
 import { ASYNC_CPS_ENABLED, analyzeAsyncBody, asyncFnNeedsCps, emitAsyncStateMachine } from "./async-cps.js";
+import { emitAsyncFrameStateMachine } from "./async-frame.js";
+import { isStandalonePromiseActive } from "./async-scheduler.js";
 import {
   functionHasLinearU8Params,
   getLinearU8ParamIndicesForDeclaration,
@@ -1140,7 +1142,38 @@ export function compileFunctionBody(ctx: CodegenContext, decl: ts.FunctionDeclar
       // fn now returns a real Promise object), drive emitAsyncStateMachine, and
       // skip the normal statement loop.
       let asyncCpsHandled = false;
-      if (ASYNC_CPS_ENABLED && isAsync && !ctx.wasi && !ctx.standalone && ts.isFunctionDeclaration(decl) && decl.body) {
+      // (#2895 PATH B) Host-free async drive layer. Gated on the native-`$Promise`
+      // *carrier* (`isStandalonePromiseActive`, currently `wasi`-only): when the
+      // awaited operand resolves to a native `$Promise`, a genuinely-suspending
+      // async fn is driven by a real resumable `$AsyncFrame` (await → spill +
+      // reaction + return result-promise; microtask drain resumes). Gating the
+      // wiring on the carrier predicate makes the standalone re-widen (#2895 1d)
+      // flip the carrier AND the drive layer together — exactly the AG0-safe
+      // coupling. The result is a real `$Promise` (externref), not a sync value.
+      if (
+        ASYNC_CPS_ENABLED &&
+        isAsync &&
+        isStandalonePromiseActive(ctx) &&
+        ts.isFunctionDeclaration(decl) &&
+        decl.body
+      ) {
+        const asyncPlan = analyzeAsyncBody(ctx, decl);
+        if (asyncFnNeedsCps(decl, asyncPlan)) {
+          rewriteFuncResultType(ctx, func, { kind: "externref" });
+          fctx.returnType = { kind: "externref" };
+          emitAsyncFrameStateMachine(ctx, fctx, decl, asyncPlan);
+          asyncCpsHandled = true;
+        }
+      }
+      if (
+        !asyncCpsHandled &&
+        ASYNC_CPS_ENABLED &&
+        isAsync &&
+        !ctx.wasi &&
+        !ctx.standalone &&
+        ts.isFunctionDeclaration(decl) &&
+        decl.body
+      ) {
         const asyncPlan = analyzeAsyncBody(ctx, decl);
         if (asyncFnNeedsCps(decl, asyncPlan)) {
           // The async function returns a Promise object (externref), not the

--- a/src/codegen/statements/control-flow.ts
+++ b/src/codegen/statements/control-flow.ts
@@ -170,6 +170,29 @@ export function compileReturnStatement(ctx: CodegenContext, fctx: FunctionContex
     return;
   }
 
+  // (#2895 PATH B) Inside a host-free async resume function, `return v` settles
+  // the frame's result `$Promise` with `v` (`__promise_fulfill`) and returns
+  // void — the resume function carries the async result through the promise, not
+  // its wasm return value. Mirrors the generator arm above.
+  if (fctx.asyncDriveReturn) {
+    const { resultPromiseLocal, fulfillFuncIdx } = fctx.asyncDriveReturn;
+    fctx.body.push({ op: "local.get", index: resultPromiseLocal });
+    if (stmt.expression) {
+      const t = compileExpression(ctx, fctx, stmt.expression);
+      if (t !== null && t !== undefined) {
+        coerceType(ctx, fctx, t as ValType, { kind: "externref" });
+      } else {
+        fctx.body.push({ op: "ref.null.extern" });
+      }
+    } else {
+      fctx.body.push({ op: "ref.null.extern" });
+    }
+    fctx.body.push({ op: "call", funcIdx: fulfillFuncIdx });
+    fctx.body.push({ op: "drop" }); // __promise_fulfill returns the value
+    fctx.body.push({ op: "return" });
+    return;
+  }
+
   const hasPendingFinally = fctx.finallyStack && fctx.finallyStack.length > 0;
 
   // Derived class constructors: per §10.2.1.3 step 13c, returning a non-object

--- a/tests/issue-2895-async-frame.test.ts
+++ b/tests/issue-2895-async-frame.test.ts
@@ -9,8 +9,8 @@ import { describe, it, expect } from "vitest";
 import * as ts from "typescript";
 // Import the top compiler entry first so the codegen module graph initializes in
 // the correct order (the regexp-standalone → string-ops → coercion-engine init
-// cycle is otherwise tripped by loading the barrel cold). Not otherwise used.
-import "../src/index.js";
+// cycle is otherwise tripped by loading the barrel cold).
+import { compile } from "../src/index.js";
 import { createEmptyModule } from "../src/ir/types.js";
 import { createCodegenContext } from "../src/codegen/index.js";
 import { getOrRegisterPromiseType } from "../src/codegen/async-scheduler.js";
@@ -140,5 +140,63 @@ describe("#2895 PATH B foundation — $AsyncFrame state struct", () => {
     const keepIdx = info.spillFieldOffset + info.spillNames.indexOf("keep");
     expect(struct.fields[keepIdx]!.name).toBe("spill_keep");
     expect(struct.fields[keepIdx]!.mutable).toBe(true);
+  });
+});
+
+// ── PATH B slice 1b/1c: the live host-free async drive layer (validated on the
+// native-`$Promise` carrier target — `--target wasi`, where the carrier gate is
+// already on; the `--target standalone` re-widen is slice 1d). ────────────────
+
+/** Compile a host-free async program and instantiate it (imports must be empty). */
+async function instantiateWasi(src: string): Promise<WebAssembly.Exports> {
+  const r = await compile(src, { fileName: "test.ts", target: "wasi" });
+  expect(r.success, r.success ? "" : JSON.stringify(r.errors?.slice(0, 3))).toBe(true);
+  // The drive layer is host-free: the module must request no imports.
+  expect((r.imports ?? []).map((i) => `${i.module}.${i.name}`)).toEqual([]);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return instance.exports;
+}
+
+describe("#2895 PATH B drive layer — host-free async frame suspension", () => {
+  it("synchronously-settled await delivers the resolved value (FULFILLED fast path)", async () => {
+    const ex = (await instantiateWasi(`
+      let cap: number = 0;
+      async function g(): Promise<number> { return 41; }
+      async function f(): Promise<number> { const x = await g(); cap = x; return x + 1; }
+      export function test(): number { f() as any; return cap; }
+    `)) as { test: () => number };
+    expect(ex.test()).toBe(41);
+  });
+
+  it("chained drive-lowered async fns thread the value through both frames", async () => {
+    const ex = (await instantiateWasi(`
+      let cap: number = 0;
+      async function g(): Promise<number> { return 41; }
+      async function h(): Promise<number> { const a = await g(); return a + 1; }
+      async function f(): Promise<number> { const x = await h(); cap = x; return x + 1; }
+      export function test(): number { f() as any; return cap; }
+    `)) as { test: () => number };
+    expect(ex.test()).toBe(42); // g→41, h→42, f reads 42
+  });
+
+  it("GENUINELY-PENDING await suspends, then the microtask drain resumes the frame", async () => {
+    // `Promise.resolve(1).then(cb)` is PENDING until the drain runs `cb` on a
+    // microtask — the await must spill, register a reaction, and return; the
+    // drain settles the awaited promise, fires the reaction, and resumes the
+    // frame at the saved state with the delivered value. This is the case AG0's
+    // one-level unwrap cannot serve.
+    const ex = (await instantiateWasi(`
+      let cap: number = 0;
+      async function consumer(): Promise<void> {
+        const x = await Promise.resolve(1).then((v: number) => v + 40);
+        cap = x;
+      }
+      export function kick(): number { consumer() as any; return cap; }
+      export function getCap(): number { return cap; }
+    `)) as { kick: () => number; getCap: () => number; __drain_microtasks: () => void };
+    expect(ex.kick()).toBe(0); // suspended: continuation has not run yet
+    ex.__drain_microtasks(); // run the pending `.then` + the resumed continuation
+    expect(ex.getCap()).toBe(41); // 1 + 40, delivered on resume
   });
 });

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -2487,8 +2487,17 @@ export function test(): number {
     };
   }
 
+  // (#2895 PATH B) Async tests: pump the microtask ring before reading the
+  // result so genuinely-pending async-frame continuations (which carry the
+  // assertions) run. `__drain_microtasks()` is a compiler intrinsic — the native
+  // drain on the host-free targets (`--target standalone`/`wasi`), a void no-op
+  // on the JS-host gc lane (which has no native microtask ring), so the gc lane
+  // stays byte-identical. Declared so the wrapped TS type-checks.
+  const isAsyncTest = resolvedMeta.flags?.includes("async") || needsAsyncTest;
+  const asyncDrainDecl = isAsyncTest ? `declare function __drain_microtasks(): void;\n` : "";
+  const asyncDrainCall = isAsyncTest ? `  __drain_microtasks();\n` : "";
   const preBody = `${strictDirective}
-${preamble}
+${asyncDrainDecl}${preamble}
 ${hoistedDecls}
 export function test(): number {
   ${implicitDecls}
@@ -2499,7 +2508,7 @@ export function test(): number {
     if (!__fail) __fail = -1;
     throw e;
   }
-  if (__fail) { return __fail; }
+${asyncDrainCall}  if (__fail) { return __fail; }
   return 1;
 }
 `;


### PR DESCRIPTION
## #2895 PATH B — standalone async drive layer, slices 1b + 1c

**Stacked on #2393 (slice 1a foundation).** Builds the resumable-frame drive
layer and wires it live for the native-`$Promise` carrier target. **Validated
end-to-end host-free** (`result.imports` empty, `WebAssembly.validate` true) on
`--target wasi`, where the carrier gate is already on.

This is the part AG0 (#2865) could not do: a **genuinely-pending** await — a
promise that only settles on a later microtask — now suspends a real frame and
resumes on the drain.

### What landed
- **`async-frame.ts` `ensureAsyncResumeFunction`** — a 2-state resume function:
  `if (state==0)` entry assimilates the awaited `$Promise`; **FULFILLED** →
  deliver value to `SENT_FIELD` + fall through; **PENDING** → `storeSpills` +
  `STATE=1` + register a `$PromiseCallback` reaction (`__async_step_f<name>_*`
  funcref + the frame) on the promise's callback list + `return` (suspend); the
  continuation reads `SENT_FIELD`. Plus the `__async_step_f<name>_{fulfill,
  reject}` microtask adapters and `emitAsyncFrameStateMachine` call-site shim
  (alloc frame + pending result `$Promise`, kick resume once, return the
  promise). Generator slot-reservation funcIdx-stability idiom.
- **`function-body.ts`** wires it for `isStandalonePromiseActive(ctx) &&
  asyncFnNeedsCps` — gating on the **carrier** predicate so 1d's `standalone`
  re-widen flips the carrier AND the drive layer **together** (the AG0-safe
  coupling). The JS-host CPS branch is preserved (20 `issue-1042` tests green).
- **`control-flow.ts`** — `return v` in a resume body settles `result_promise`
  via `__promise_fulfill` (keyed off `fctx.asyncDriveReturn`; mirrors the
  generator `return` arm).

### Validation (`tests/issue-2895-async-frame.test.ts`, 8 green)
- FULFILLED fast path (`await g()` of a sync-settled async fn) delivers the value.
- chained drive-lowered async fns thread the value through both frames.
- **GENUINELY-PENDING**: `await Promise.resolve(1).then(cb)` (pending until the
  microtask runs `cb`) **suspends** (continuation not run), and
  `__drain_microtasks` **resumes** the frame to deliver the settled value.

### Scope / safety
Carrier-gated to `wasi`, so **zero `--target standalone` regression surface**.
The standalone re-widen + the runner `__drain_microtasks` hook for `flags:[async]`
tests + the `merge_group` net-positive measurement are **slice 1d**.

### Codegen lesson
Repeated `local.get <externref>; any.convert_extern; ref.cast $T` trips the
`stack-balance` type-repair pass into splicing a bogus `ref.cast_null;
any.convert_extern` — narrow the awaited `$Promise` into a typed `(ref $Promise)`
local **once** and reuse it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)