### PR TITLE
feat(#2902): native standalone Test262Error (eliminate __new_Test262Error host-import leak)

### DIFF
--- a/plan/issues/2902-native-test262error.md
+++ b/plan/issues/2902-native-test262error.md
@@ -1,0 +1,98 @@
+---
+id: 2902
+title: "Standalone: native Test262Error construction eliminates env::__new_Test262Error host-import leak (~2,779 tests)"
+status: done
+created: 2026-06-30
+completed: 2026-06-30
+updated: 2026-06-30
+assignee: ttraenkler/sendev-error
+priority: high
+feasibility: hard
+task_type: feature
+area: codegen
+goal: standalone
+sprint: current
+horizon: m
+related: [1104, 1536, 2188, 2862]
+---
+
+# Standalone: native Test262Error construction (eliminate `__new_Test262Error` leak)
+
+## Problem
+
+The test262 harness (`wrapTest`, `tests/test262-runner.ts:1536`) injects
+`class Test262Error { message }` into every wrapped test, and the test body
+contains `throw new Test262Error(...)` on its failure path. `Test262Error` is
+listed in `KNOWN_CONSTRUCTORS` (`src/codegen/index.ts`) and intercepted in the
+Error-constructor branch of `compileNewExpression`
+(`src/codegen/expressions/new-super.ts`). Because `Test262Error` is **not** in
+`WASI_ERROR_NAMES`, that branch fell through to a `__new_Test262Error` **host
+import** even in `--target standalone` / `--target wasi`, where there is no JS
+host to satisfy it.
+
+A leak-analysis of the merge_group standalone report (2026-06-30) found
+**~2,779 tests import ONLY `env::__new_Test262Error`**. These tests *pass* —
+they never reach the `throw` — so the import is dead weight that nonetheless
+keeps the module out of host-free. Fixing this one lowering flips ~2,779 tests
+host-free and removes a co-blocker on thousands of exception-touching tests.
+
+## Root cause (verified on current main)
+
+`new-super.ts` Error branch: `(ctx.wasi || ctx.standalone) && isWasiErrorName(ctorName)`
+builds an in-module `$Error_struct`; otherwise it calls
+`ensureLateImport("__new_Test262Error", ...)`. `isWasiErrorName("Test262Error")`
+is `false`, so standalone always took the host-import path.
+
+Measured (standalone, current main, via `wrapTest` + `compile({target:"standalone"})`):
+`test262/test/language/types/boolean/S8.3_A1_T1.js` and
+`.../expressions/addition/S11.6.1_A1.js` each leaked exactly `[__new_Test262Error]`.
+A 250-file stride sample: 15 leak ONLY `__new_Test262Error`, 16 leak it + others.
+
+## Fix
+
+In standalone/WASI mode, lower `new Test262Error(msg)` to an in-module
+`$Error_struct` — the *same* struct the WASI error constructors use — tagged as
+`Error` (`BUILTIN_TYPE_TAGS.Error`, so `instanceof Error` holds, matching the
+harness's `Test262Error extends Error`) with `$name` = `"Test262Error"`.
+
+- `src/codegen/registry/error-types.ts`: extracted the shared
+  `emitErrorStructConstructor(ctx, importName, displayName, tagValue, argCount)`
+  body out of `emitWasiErrorConstructor` (byte-identical struct shape); added
+  `emitStandaloneTest262Error(ctx, argCount)` that calls it with name
+  `"Test262Error"` and the `Error` tag.
+- `src/codegen/expressions/new-super.ts`: after the `isWasiErrorName` branch,
+  added a sibling `(ctx.wasi || ctx.standalone) && ctorName === "Test262Error"`
+  branch that emits the native constructor and calls it, returning before the
+  `ensureLateImport` host-import path.
+
+**JS-host mode is deliberately unchanged** — it keeps the `__new_Test262Error`
+host import (a real `Error` subclass) so message serialization across the wasm
+boundary is unaffected. This follows the dual-mode principle (host fast path +
+standalone-native fallback).
+
+### Why tag = `Error` (not a new builtin tag)
+
+Giving `Test262Error` the `Error` tag (rather than registering it in
+`BUILTIN_TYPE_TAGS`, which would make `isBuiltinTypeName` true everywhere and
+widen blast radius) makes `instanceof Error` true while keeping `.name` =
+`"Test262Error"` via the `$name` field. `Test262Error` is conceptually an Error
+subclass, so this is the most faithful and lowest-surprise representation.
+
+## Verification
+
+- Standalone throw/catch (`.tmp` probe + `tests/issue-2902.test.ts`): a thrown
+  `Test262Error` yields correct `.message` (`"boom"`), `.name`
+  (`"Test262Error"`), and `instanceof Error` (true) — score 7/7. Module is
+  host-free (`imports == []`).
+- 250-file standalone survey after the fix: "leak ONLY `__new_Test262Error`"
+  15 → 0; host-free 74 → 89 (+15); all co-leaked `Test262Error` imports removed
+  (16 → 0). Compile-error count unchanged (8 → 8).
+- JS-host mode: `__new_Test262Error` import still present (unchanged).
+- `tests/issue-2902.test.ts` (7 cases, standalone+wasi+host) pass.
+- Regression batch (60 tests): `issue-1104-phase1/2/3`, `issue-1536`,
+  `issue-1536c`, `error-reporting-catchpaths` all green.
+- The 3 pre-existing `error-reporting.test.ts` failures (`with`/`eval` compile
+  line numbers) reproduce on clean `origin/main` — unrelated to this change.
+
+The full merge_group standalone report is the corpus arbiter (must be a large
+NET-POSITIVE with zero regression to throw/catch/message/instanceof paths).

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -40,7 +40,7 @@ import {
   isGlobalRegExpIdentifier,
   isGlobalRegExpType,
 } from "../regexp-standalone.js";
-import { emitWasiErrorConstructor, isWasiErrorName } from "../registry/error-types.js";
+import { emitStandaloneTest262Error, emitWasiErrorConstructor, isWasiErrorName } from "../registry/error-types.js";
 import type { InnerResult } from "../shared.js";
 import {
   coerceType,
@@ -2903,6 +2903,22 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
       // #1473 — standalone mode also has no JS host; build the Error in-module.
       if ((ctx.wasi || ctx.standalone) && isWasiErrorName(ctorName)) {
         emitWasiErrorConstructor(ctx, ctorName, 1);
+        const internalFuncIdx = ctx.funcMap.get(importName);
+        if (internalFuncIdx !== undefined) {
+          fctx.body.push({ op: "call", funcIdx: internalFuncIdx });
+        }
+        return { kind: "externref" };
+      }
+      // (#2902) `Test262Error` is not a WASI builtin error, but the test262
+      // harness declares it (`class Test262Error extends Error`) and `throw new
+      // Test262Error(...)` appears in nearly every wrapped test. In standalone /
+      // WASI mode the `__new_Test262Error` host import is unsatisfiable and
+      // leaks the module out of host-free — yet the ctor is only reached on the
+      // untaken failure path of a passing test. Build it natively as an
+      // $Error_struct (tagged Error, name "Test262Error") so ~2,779 such tests
+      // become host-free. JS-host mode keeps the host import (real Error).
+      if ((ctx.wasi || ctx.standalone) && ctorName === "Test262Error") {
+        emitStandaloneTest262Error(ctx, 1);
         const internalFuncIdx = ctx.funcMap.get(importName);
         if (internalFuncIdx !== undefined) {
           fctx.body.push({ op: "call", funcIdx: internalFuncIdx });

--- a/src/codegen/registry/error-types.ts
+++ b/src/codegen/registry/error-types.ts
@@ -147,17 +147,54 @@ export function getOrRegisterErrorStructType(ctx: CodegenContext): number {
  * helper finds it in `ctx.stringGlobalMap`.
  */
 export function emitWasiErrorConstructor(ctx: CodegenContext, errorName: WasiErrorName, argCount: number): void {
-  const importName = `__new_${errorName}`;
+  emitErrorStructConstructor(ctx, `__new_${errorName}`, errorName, BUILTIN_TYPE_TAGS[errorName], argCount);
+}
+
+/**
+ * (#2902) Standalone/WASI-native `new Test262Error(msg)` construction.
+ *
+ * The test262 harness injects `class Test262Error { message }` (and, in the
+ * JS-host eval shim, `class Test262Error extends Error`) into every wrapped
+ * test. In JS-host mode `new Test262Error(msg)` lowers to a `__new_Test262Error`
+ * host import that yields a real `Error` subclass. In standalone mode there is
+ * no JS host, so that import is unsatisfiable and leaks into the module — even
+ * though the constructor is only ever reached on the (untaken) failure path of
+ * a passing test. A leak-analysis of the merge_group standalone report found
+ * ~2,779 tests that import ONLY `env::__new_Test262Error`, so building it
+ * in-module flips them host-free.
+ *
+ * The value is built as the SAME `$Error_struct` the WASI error constructors
+ * use, tagged as `Error` (so `instanceof Error` holds, matching
+ * `Test262Error extends Error`) with `$name` = "Test262Error" (so `err.name`
+ * and the standalone exception formatter read the correct constructor name).
+ * `err.message` reads the first-arg field via the existing property-access
+ * fast path. Host mode is unchanged — it keeps the `__new_Test262Error` import.
+ */
+export function emitStandaloneTest262Error(ctx: CodegenContext, argCount: number): void {
+  emitErrorStructConstructor(ctx, "__new_Test262Error", "Test262Error", BUILTIN_TYPE_TAGS.Error, argCount);
+}
+
+/**
+ * Shared builder for an in-module `$Error_struct` constructor. `displayName` is
+ * materialized into the `$name` field; `tagValue` is written to `$tag` (drives
+ * standalone `instanceof`). Idempotent on `importName`.
+ */
+function emitErrorStructConstructor(
+  ctx: CodegenContext,
+  importName: string,
+  displayName: string,
+  tagValue: number,
+  argCount: number,
+): void {
   if (ctx.funcMap.has(importName)) return;
 
   const structIdx = getOrRegisterErrorStructType(ctx);
-  const tagValue = BUILTIN_TYPE_TAGS[errorName];
 
   // #1536 Phase 2 — register the class-name string so the $name field can be
   // materialized below. Must run BEFORE building the body so the dual-mode
   // helper finds the interned global.
-  addStringConstantGlobal(ctx, errorName);
-  const nameInstrs = stringConstantExternrefInstrs(ctx, errorName);
+  addStringConstantGlobal(ctx, displayName);
+  const nameInstrs = stringConstantExternrefInstrs(ctx, displayName);
 
   const params: ValType[] = Array.from({ length: argCount }, () => ({ kind: "externref" }) as ValType);
   const typeIdx = addFuncType(ctx, params, [{ kind: "externref" }], `${importName}_type`);

--- a/tests/issue-2902.test.ts
+++ b/tests/issue-2902.test.ts
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2902 — Native standalone `Test262Error` construction.
+//
+// The test262 harness injects `class Test262Error extends Error` (and a
+// `throw new Test262Error(...)` failure path) into nearly every wrapped test.
+// `Test262Error` is listed in KNOWN_CONSTRUCTORS and intercepted in
+// new-super.ts, so in standalone/WASI mode `new Test262Error(msg)` lowered to
+// an unsatisfiable `env::__new_Test262Error` host import — leaking the module
+// out of host-free even though the constructor is only ever reached on the
+// (untaken) failure path of a *passing* test. A leak-analysis of the
+// merge_group standalone report found ~2,779 tests that import ONLY
+// `__new_Test262Error`.
+//
+// This builds it in-module as the same `$Error_struct` the WASI error
+// constructors use (tagged Error, name "Test262Error"), so those tests become
+// host-free while `.message` / `.name` / `instanceof Error` keep working.
+// JS-host mode is unchanged (keeps the real-Error host import).
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+const HARNESS_T262 = `
+class Test262Error {
+  message: string;
+  constructor(msg: string = "") { this.message = msg; }
+}
+`;
+
+describe("#2902 — native standalone Test262Error", () => {
+  for (const target of ["standalone", "wasi"] as const) {
+    describe(`${target} mode`, () => {
+      it("does NOT register env.__new_Test262Error", async () => {
+        const src = `${HARNESS_T262}
+          export function test(): number {
+            if (1 + 1 !== 2) { throw new Test262Error("unreachable"); }
+            return 0;
+          }
+        `;
+        const r = await compile(src, { target, skipSemanticDiagnostics: true });
+        expect(r.success).toBe(true);
+        const envImports = r.imports.filter((i) => i.module === "env").map((i) => i.name);
+        expect(envImports).not.toContain("__new_Test262Error");
+      });
+
+      it("a passing test that never throws is fully host-free", async () => {
+        const src = `${HARNESS_T262}
+          export function test(): number {
+            let x: number = 41;
+            if (x + 1 !== 42) { throw new Test262Error("bad"); }
+            return x + 1;
+          }
+        `;
+        const r = await compile(src, { target, skipSemanticDiagnostics: true });
+        expect(r.success).toBe(true);
+        const envImports = r.imports.filter((i) => i.module === "env").map((i) => i.name);
+        expect(envImports).toEqual([]);
+        const { instance } = await WebAssembly.instantiate(r.binary, {});
+        expect((instance.exports as { test(): number }).test()).toBe(42);
+      });
+
+      it("throw/catch yields correct .message, .name and instanceof Error", async () => {
+        const src = `${HARNESS_T262}
+          export function test(): number {
+            try {
+              throw new Test262Error("boom");
+            } catch (e: any) {
+              let score: number = 0;
+              if (e.message === "boom") { score = score + 1; }
+              if (e.name === "Test262Error") { score = score + 2; }
+              if (e instanceof Error) { score = score + 4; }
+              return score;
+            }
+          }
+        `;
+        const r = await compile(src, { target, skipSemanticDiagnostics: true });
+        expect(r.success).toBe(true);
+        const envImports = r.imports.filter((i) => i.module === "env").map((i) => i.name);
+        expect(envImports).toEqual([]);
+        const { instance } = await WebAssembly.instantiate(r.binary, {});
+        // 1 (message) + 2 (name) + 4 (instanceof Error) = 7
+        expect((instance.exports as { test(): number }).test()).toBe(7);
+      });
+    });
+  }
+
+  describe("JS-host mode unchanged", () => {
+    it("still registers env.__new_Test262Error (real Error subclass)", async () => {
+      const src = `${HARNESS_T262}
+        export function test(): number {
+          if (1 + 1 !== 2) { throw new Test262Error("unreachable"); }
+          return 0;
+        }
+      `;
+      const r = await compile(src, { skipSemanticDiagnostics: true });
+      expect(r.success).toBe(true);
+      const envImports = r.imports.filter((i) => i.module === "env").map((i) => i.name);
+      expect(envImports).toContain("__new_Test262Error");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

In `--target standalone` / `--target wasi`, `new Test262Error(msg)` lowered to an unsatisfiable `env::__new_Test262Error` **host import**. A leak-analysis of the merge_group standalone report (2026-06-30) found **~2,779 tests import ONLY `__new_Test262Error`** — they *pass* (never reach the harness's `throw new Test262Error(...)`), so the import is dead weight that keeps the module out of host-free.

This lowers `new Test262Error(msg)` in standalone/WASI mode to an in-module `$Error_struct` (the same struct the WASI error constructors use), tagged `Error` (so `instanceof Error` holds, matching the harness's `Test262Error extends Error`) with `$name` = `"Test262Error"`. **JS-host mode is unchanged** — it keeps the real-Error host import.

## Root cause

`new-super.ts` Error branch built a native struct only when `isWasiErrorName(ctorName)`; `Test262Error` isn't a WASI builtin error, so standalone always took the `ensureLateImport("__new_Test262Error")` path.

## Changes

- `src/codegen/registry/error-types.ts`: extracted shared `emitErrorStructConstructor(...)` (byte-identical struct shape) out of `emitWasiErrorConstructor`; added `emitStandaloneTest262Error`.
- `src/codegen/expressions/new-super.ts`: added a `(ctx.wasi || ctx.standalone) && ctorName === "Test262Error"` branch that emits the native ctor and returns before the host-import path.
- `tests/issue-2902.test.ts`: 7 cases (standalone + wasi + host).

## Verification (measured)

- Standalone throw/catch: thrown `Test262Error` yields correct `.message`, `.name`, `instanceof Error` (7/7); module host-free.
- 250-file standalone survey: "leak ONLY `__new_Test262Error`" 15 → 0; host-free 74 → 89; co-leaked Test262Error 16 → 0; CE count unchanged.
- JS-host mode: `__new_Test262Error` import still present.
- Regression batch (60 tests: issue-1104 phase1/2/3, 1536, 1536c, error-reporting-catchpaths) all green.
- The 3 pre-existing `error-reporting.test.ts` failures reproduce on clean `origin/main` (unrelated).

The full merge_group standalone report is the corpus arbiter (expect large NET-POSITIVE, zero regression to throw/catch/message/instanceof).

Closes #2902

🤖 Generated with [Claude Code](https://claude.com/claude-code)