### PR TITLE
feat(#2904): native __array_from_iter_n drain for standalone fixed-arity destructure

### DIFF
--- a/plan/issues/2904-standalone-fixed-arity-destructure-iter-drain.md
+++ b/plan/issues/2904-standalone-fixed-arity-destructure-iter-drain.md
@@ -1,7 +1,7 @@
 ---
 id: 2904
 title: Standalone fixed-arity array destructuring leaks env::__array_from_iter_n
-status: in-progress
+status: done
 assignee: ttraenkler/sendev-iterdrain
 sprint: current
 priority: high
@@ -9,6 +9,7 @@ horizon: l
 feasibility: hard
 goal: standalone-host-free
 created: 2026-06-30
+completed: 2026-06-30
 ---
 
 ## Problem
@@ -99,4 +100,41 @@ byte-identical in host mode.
 
 ## Test Results
 
-(filled during implementation)
+`tests/issue-2904-standalone-fixed-dstr-iter-drain.test.ts` (7 cases, all green):
+decl 2-of-3 / 3-of-3 positional, out-of-length default, elision, array-pattern
+param, >4-element grow, undefined-check. Each asserts **zero host imports** + the
+correct value. Regression sweep clean: #1592, #2169 (generator/spread/arrayfrom),
+#1021/#1024/#1158 all green. The two pre-existing `#1320` `arr.entries()` failures
+(`for (const pair of storedEntries)` → `pair.length`) reproduce **identically on
+clean `origin/main`** — they are the #1888/#2177 open-any retrieval gap, NOT a
+regression here (my new function is only reachable from the destructure site).
+
+Host/gc mode still emits `env::__array_from_iter_n` → byte-identical, zero risk to
+the JS-host lane.
+
+## Scope landed vs. deferred
+
+**Landed (this PR):** the dominant cluster — `const/let [a,b] = anyExpr` and
+`function f([a,b]: any)` — both route through `destructureParamArray`'s externref
+fallback and now drain host-free. Measured: the leak is gone and individual
+destructured values bind correctly (`return a` → 10, defaults fire, elision works).
+
+**Deferred (separate follow-ups, NOT regressions — all fail on base too):**
+
+1. **`any + any` arithmetic on values read out of an `any` source.** `const [a,b] =
+   anyArr; return a + b` yields 0/NaN — but so does `anyArr[0] + anyArr[1]` with NO
+   destructuring at all. This is the pre-existing boxed-number value-read substrate
+   gap (`project_standalone_any_string_value_read_substrate`), orthogonal to the
+   host-import leak this issue targets. Individual reads and `any * number` work.
+2. **Generator-as-`any` / Set-as-`any` destructure** (`const y:any = g(); const
+   [a,b] = y`) traps `illegal cast` in the native `__iterator` USER arm — the
+   #2157/#2864 standalone-iterator-of-`any` substrate. On base these failed at
+   instantiation (the leak); now they trap at runtime (strictly no worse, and other
+   functions in the same module become usable).
+3. **Assignment-target destructure** (`[a,b] = anyExpr`, the
+   `compileExternrefArrayDestructuringAssignment` site) still leaks. Swapping its
+   materialise to the native helper removes the leak but its element reads use
+   `__extern_get(box(i))`, which casts the boxed-number key to `$AnyString` and
+   traps `illegal cast` in standalone. Converting those reads to `__extern_get_idx`
+   surfaced a deeper USER-arm-fill dependency in that path; deferred to keep this PR
+   zero-regression. The decl/param cluster is the overwhelming majority of the ~889.

--- a/plan/issues/2904-standalone-fixed-arity-destructure-iter-drain.md
+++ b/plan/issues/2904-standalone-fixed-arity-destructure-iter-drain.md
@@ -98,6 +98,32 @@ byte-identical in host mode.
 - gc-mode output unchanged.
 - Full merge_group NET-POSITIVE, zero regression.
 
+## merge_group regression + fix (post-#2835 interaction)
+
+The first cut regressed **440 standalone `*/dstr/*` tests (net -404)**, caught only
+in the merge_group standalone-floor re-validation (PR checks were green). Root
+cause — NOT a type-index shift (the i8-pack hypothesis): the unconditional native
+`__array_from_iter_n` drain routed EVERY externref destructure source through the
+native `__iterator`, whose **vec-only carrier hard-casts a non-`__vec_externref`
+subject → `illegal cast`**. Indexable sources (function / class-method / for-of
+array-pattern destructuring — `ary-ptrn-*`, `iter-close`, `iter-step-err`) that
+passed on baseline via the `buildVecFromExternref` indexed-read fallback now
+trapped.
+
+Why baseline passed: `destructureParamArray`'s externref fallback has TWO
+sub-paths — block A (`__array_from_iter_n` materialise + `__extern_length` /
+`__extern_get_idx` read) and block B (`buildVecFromExternref`, indexed read). On
+baseline the host `__array_from_iter_n` either didn't run for these or block B
+handled them; my native helper made block A's `__iterator` drain ALWAYS run →
+trap.
+
+Fix (commit `b0e8e3bb9`): gate the iterator drain on `ref.test __vec_externref`.
+A non-`$Vec` source is returned UNCHANGED so block A's own indexed read
+(`__extern_length`/`__extern_get_idx`) handles it — byte-equivalent to the legacy
+host result for an indexable source, host-free, and never trapping. Verified
+30/30 previously-regressed dstr tests now pass; de-leak preserved; non-vec
+iterables (generator/Set-as-any) degrade gracefully (they failed on baseline too).
+
 ## Test Results
 
 `tests/issue-2904-standalone-fixed-dstr-iter-drain.test.ts` (7 cases, all green):

--- a/plan/issues/2904-standalone-fixed-arity-destructure-iter-drain.md
+++ b/plan/issues/2904-standalone-fixed-arity-destructure-iter-drain.md
@@ -1,0 +1,102 @@
+---
+id: 2904
+title: Standalone fixed-arity array destructuring leaks env::__array_from_iter_n
+status: in-progress
+assignee: ttraenkler/sendev-iterdrain
+sprint: current
+priority: high
+horizon: l
+feasibility: hard
+goal: standalone-host-free
+created: 2026-06-30
+---
+
+## Problem
+
+On `--target standalone`, fixed-arity array destructuring of an `any`-typed
+(externref) source leaks the host import `env::__array_from_iter_n`. A
+leak-analysis of the full merge_group standalone report found ~889 tests leak
+ONLY this import. #681 (iterator protocol) handled the general native-iterator
+helpers and #2169 handled the native-generator / custom-iterable destructure
+sources, but the fixed-N drain in `destructureParamArray`'s externref fallback
+still emits the host import.
+
+A leaked `env::` import makes the standalone module fail zero-import
+instantiation, so every test in this cluster currently fails in standalone.
+
+### Measured trigger (current main)
+
+```
+const [a,b] = (x as any)   →  LEAKS env::__array_from_iter_n
+function f([a,b]: any) {}   →  LEAKS
+[a,b] = (x as any)          →  LEAKS (assignment path, separate site)
+const [a,b] = arr           →  clean (typed vec)
+const [a,b] = gen()         →  clean (#2169 native-generator path)
+const [a,b] = new Set(...)  →  clean
+[...x]  (x: any)            →  clean (buildVecFromExternref indexed read)
+```
+
+The `any`-source path routes through `destructureParamArray`'s externref
+fallback (`src/codegen/destructuring-params.ts` ~line 1340 + 1456), which
+materialises via `__array_from_iter_n(param, stepCount)` then reads the result
+with `__extern_length` + `__extern_get_idx` (both already native in standalone).
+`compileExternrefArrayDestructuringDecl` (decl `const [a,b]=x`) and array-pattern
+params both delegate here, so a single fix covers both.
+
+## Root cause
+
+`__array_from_iter_n` is defined ONLY in `src/runtime.ts` (the JS host). There
+is no native/standalone Wasm definition, so `ensureLateImport` registers it as a
+plain `env::` host import under standalone. The general native iterator runtime
+(`__iterator` / `__iterator_next`, #681/#2038) already exists in standalone and
+already handles both the VEC arm (native indexable vecs) and the USER arm
+(generators / custom `@@iterator`, filled at finalize by
+`fillNativeIteratorUserArms`). The fixed-N drain simply never reused it.
+
+## Fix
+
+Add a native standalone `__array_from_iter_n(externref, f64) -> externref`
+defined function (`ensureNativeArrayFromIterN` in `iterator-native.ts`) that
+drains via the existing `__iterator` / `__iterator_next` into a growable
+`__vec_externref`, returning it as externref. Downstream `__extern_length` /
+`__extern_get_idx` already read `__vec_externref` (it is a `vecTypeMap` carrier),
+so the consuming code is unchanged.
+
+The drain loop mirrors the proven spread-override drain
+(`src/codegen/literals.ts` ~line 3806): array-doubling growth + `array.copy`,
+`(done,value)=__iterator_next(iter)`, bounded by the f64 step count for no-rest
+patterns (exactly N `.next()` calls per §8.5.2) or unbounded for rest (-1). A
+`ref.is_null` guard returns an empty vec for null/undefined sources, matching the
+host `_arrayFromIter(null) → []`.
+
+Gate the `ensureLateImport(ctx, "__array_from_iter_n", …)` call site(s): under
+`ctx.standalone || ctx.wasi` call `ensureNativeArrayFromIterN(ctx)` (appends a
+defined func — no funcIdx shift), else keep the host import. The existing
+`ctx.funcMap.get("__array_from_iter_n")` re-resolution is unchanged and
+byte-identical in host mode.
+
+## Why this is safe (downstream effects)
+
+- Registering a DEFINED function is append-only — it does NOT shift existing
+  function indices the way adding an `env` import does. The helper body's
+  `call __iterator` / `call __iterator_next` funcIdx are captured post-runtime
+  registration and patched by `shiftLateImportIndices` like every other defined
+  body if a later import shifts them.
+- Host mode (`!standalone && !wasi`) keeps the `env::__array_from_iter_n` import
+  → byte-identical, zero risk to the JS-host lane.
+- `fillNativeIteratorUserArms` runs unconditionally at finalize (index.ts:1752)
+  gated on `nativeIteratorUserArmPending`, which `ensureNativeIteratorRuntime`
+  (called transitively) sets — so generator / custom-iterable `any` sources get
+  the USER arm.
+
+## Acceptance
+
+- The `any`-source fixed-arity destructure cluster compiles host-free (no
+  `env::__array_from_iter_n`).
+- Corpus-verify via wrapTest on real destructuring test262 cases.
+- gc-mode output unchanged.
+- Full merge_group NET-POSITIVE, zero regression.
+
+## Test Results
+
+(filled during implementation)

--- a/src/codegen/destructuring-params.ts
+++ b/src/codegen/destructuring-params.ts
@@ -36,6 +36,7 @@ import {
   valTypesMatch,
 } from "./shared.js";
 import { buildVecFromExternref, getVecInfo } from "./type-coercion.js";
+import { ensureNativeArrayFromIterN } from "./iterator-native.js";
 import { arrayIteratorOverrideGlobalIdx } from "./expressions/proto-override.js";
 // (#1719 CPR-2) `arrayDstrNeedsIdentity` / `tryEmitArrayProtoIteratorReadDrive` /
 // `syncDestructuredLocalsToGlobals` live in statements/destructuring.ts, which
@@ -1337,7 +1338,18 @@ export function destructureParamArray(
       // pass -1 → unbounded drain, byte-identical to legacy __array_from_iter
       // and preserving its IteratorClose tuning (#1219, #1592).
       const fbIterStepCount = patternIteratorStepCount(pattern.elements);
-      ensureLateImport(ctx, "__array_from_iter_n", [{ kind: "externref" }, { kind: "f64" }], [{ kind: "externref" }]);
+      // (#2904) Standalone/WASI are host-free: instead of leaking the JS-host
+      // `env::__array_from_iter_n` import (which breaks zero-import
+      // instantiation), register a NATIVE `__array_from_iter_n` that drains the
+      // source through the existing native `__iterator` / `__iterator_next`
+      // runtime into a `__vec_externref` — byte-identical for the downstream
+      // `__extern_length` / `__extern_get_idx` reads below. JS-host mode keeps
+      // the import (byte-identical).
+      if (ctx.standalone || ctx.wasi) {
+        ensureNativeArrayFromIterN(ctx);
+      } else {
+        ensureLateImport(ctx, "__array_from_iter_n", [{ kind: "externref" }, { kind: "f64" }], [{ kind: "externref" }]);
+      }
       flushLateImportShifts(ctx, fctx);
 
       // Else: try each other known vec type and convert element-by-element

--- a/src/codegen/iterator-native.ts
+++ b/src/codegen/iterator-native.ts
@@ -243,6 +243,186 @@ export function ensureNativeIteratorRuntime(ctx: CodegenContext): void {
 }
 
 /**
+ * (#2904) Register a native standalone `__array_from_iter_n(externref, f64) ->
+ * externref` defined function, reusing the existing native iterator runtime
+ * (`__iterator` / `__iterator_next`). This replaces the JS-host
+ * `env::__array_from_iter_n` import that fixed-arity array destructuring of an
+ * `any`-typed (externref) source otherwise leaks — a leak that breaks
+ * zero-import instantiation under `--target standalone`/`wasi`.
+ *
+ * Semantics mirror the host `_arrayFromIter(obj, limit)`:
+ *   - `n < 0` (rest patterns): unbounded drain until the iterator reports done.
+ *   - `n >= 0` (no-rest patterns, §8.5.3): consume AT MOST `n` IteratorSteps —
+ *     exactly one `.next()` per binding slot, never over-draining a lazy
+ *     generator. Stopping at the bound is a NormalCompletion (no IteratorClose).
+ *   - `null`/`undefined` source: return an empty vec (host returns `[]`).
+ *
+ * Returns a canonical externref `$Vec` (`__vec_externref`), which the downstream
+ * `__extern_length` / `__extern_get_idx` consumers already read natively (it is
+ * a `vecTypeMap` carrier). Drain loop = array-doubling growth + `array.copy`,
+ * byte-shaped after the proven spread-override drain in literals.ts (#1749).
+ *
+ * Append-only: registering a DEFINED function does NOT shift existing function
+ * indices the way `addImport` does. The body's `call __iterator` /
+ * `call __iterator_next` funcIdx are captured here (post `ensureNativeIteratorRuntime`)
+ * and patched by `shiftLateImportIndices` like any other defined body if a later
+ * import shifts them.
+ */
+export function ensureNativeArrayFromIterN(ctx: CodegenContext): number {
+  const existing = ctx.funcMap.get("__array_from_iter_n");
+  if (existing !== undefined) return existing;
+
+  // Guarantee the iterator runtime (and the $Vec/$IterRec geometry) exist.
+  ensureNativeIteratorRuntime(ctx);
+  const { vecTypeIdx, arrTypeIdx } = iterRuntimeTypes(ctx);
+  const iteratorIdx = ctx.funcMap.get("__iterator");
+  const iteratorNextIdx = ctx.funcMap.get("__iterator_next");
+  if (iteratorIdx === undefined || iteratorNextIdx === undefined) {
+    // Should never happen (ensureNativeIteratorRuntime just ran) — fall back to
+    // a host import so the caller still resolves a funcIdx by name.
+    const typeIdx = addFuncType(ctx, [{ kind: "externref" }, { kind: "f64" }], [{ kind: "externref" }]);
+    const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+    ctx.funcMap.set("__array_from_iter_n", funcIdx);
+    ctx.mod.functions.push({ name: "__array_from_iter_n", typeIdx, locals: [], body: [], exported: false });
+    return funcIdx;
+  }
+
+  // Local layout:
+  //   0 = obj   (externref, param)
+  //   1 = n     (f64, param)
+  //   2 = iter  (externref)        the $IterRec, as externref
+  //   3 = limit (i32)              n<0 ? -1 : trunc_sat(n)
+  //   4 = cap   (i32)              backing-array capacity
+  //   5 = len   (i32)              logical element count
+  //   6 = data  (ref $arrExtern)   backing array
+  //   7 = grow  (ref $arrExtern)   doubled array on growth
+  //   8 = done  (i32)
+  //   9 = value (externref)
+  const arrRef: ValType = { kind: "ref", typeIdx: arrTypeIdx };
+  const locals: { name: string; type: ValType }[] = [
+    { name: "iter", type: { kind: "externref" } },
+    { name: "limit", type: { kind: "i32" } },
+    { name: "cap", type: { kind: "i32" } },
+    { name: "len", type: { kind: "i32" } },
+    { name: "data", type: arrRef },
+    { name: "grow", type: arrRef },
+    { name: "done", type: { kind: "i32" } },
+    { name: "value", type: { kind: "externref" } },
+  ];
+
+  // Build an empty `__vec_externref` and convert to externref.
+  const emptyVec: Instr[] = [
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "array.new_default", typeIdx: arrTypeIdx } as Instr,
+    { op: "struct.new", typeIdx: vecTypeIdx } as Instr,
+    { op: "extern.convert_any" } as Instr,
+  ];
+
+  // Grow: cap *= 2; grow = new array[cap]; array.copy grow[0..len]=data[0..len]; data = grow.
+  const growInstrs: Instr[] = [
+    { op: "local.get", index: 4 } as Instr,
+    { op: "i32.const", value: 2 } as Instr,
+    { op: "i32.mul" } as Instr,
+    { op: "local.set", index: 4 } as Instr,
+    { op: "local.get", index: 4 } as Instr,
+    { op: "array.new_default", typeIdx: arrTypeIdx } as Instr,
+    { op: "local.set", index: 7 } as Instr,
+    { op: "local.get", index: 7 } as Instr, // dst
+    { op: "i32.const", value: 0 } as Instr, // dstOffset
+    { op: "local.get", index: 6 } as Instr, // src
+    { op: "i32.const", value: 0 } as Instr, // srcOffset
+    { op: "local.get", index: 5 } as Instr, // len
+    { op: "array.copy", dstTypeIdx: arrTypeIdx, srcTypeIdx: arrTypeIdx } as Instr,
+    { op: "local.get", index: 7 } as Instr,
+    { op: "local.set", index: 6 } as Instr,
+  ];
+
+  const loopBody: Instr[] = [
+    // Bounded break: if (limit >= 0) && (len >= limit) → break.
+    { op: "local.get", index: 3 } as Instr,
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "i32.ge_s" } as Instr,
+    { op: "local.get", index: 5 } as Instr,
+    { op: "local.get", index: 3 } as Instr,
+    { op: "i32.ge_s" } as Instr,
+    { op: "i32.and" } as Instr,
+    { op: "br_if", depth: 1 } as Instr,
+    // (done, value) = __iterator_next(iter)
+    { op: "local.get", index: 2 } as Instr,
+    { op: "call", funcIdx: iteratorNextIdx } as Instr,
+    { op: "local.set", index: 9 } as Instr, // value (top of stack)
+    { op: "local.set", index: 8 } as Instr, // done
+    // if done → break
+    { op: "local.get", index: 8 } as Instr,
+    { op: "br_if", depth: 1 } as Instr,
+    // grow if len == cap
+    { op: "local.get", index: 5 } as Instr,
+    { op: "local.get", index: 4 } as Instr,
+    { op: "i32.ge_s" } as Instr,
+    { op: "if", blockType: { kind: "empty" }, then: growInstrs, else: [] } as Instr,
+    // data[len] = value
+    { op: "local.get", index: 6 } as Instr,
+    { op: "local.get", index: 5 } as Instr,
+    { op: "local.get", index: 9 } as Instr,
+    { op: "array.set", typeIdx: arrTypeIdx } as Instr,
+    // len++
+    { op: "local.get", index: 5 } as Instr,
+    { op: "i32.const", value: 1 } as Instr,
+    { op: "i32.add" } as Instr,
+    { op: "local.set", index: 5 } as Instr,
+    { op: "br", depth: 0 } as Instr,
+  ];
+
+  const body: Instr[] = [
+    // null/undefined guard → return empty vec (host `_arrayFromIter(null) → []`).
+    { op: "local.get", index: 0 } as Instr,
+    { op: "ref.is_null" } as Instr,
+    { op: "if", blockType: { kind: "empty" }, then: [...emptyVec, { op: "return" } as Instr], else: [] } as Instr,
+    // iter = __iterator(obj)
+    { op: "local.get", index: 0 } as Instr,
+    { op: "call", funcIdx: iteratorIdx } as Instr,
+    { op: "local.set", index: 2 } as Instr,
+    // limit = (n < 0) ? -1 : trunc_sat(n)
+    { op: "local.get", index: 1 } as Instr,
+    { op: "f64.const", value: 0 } as Instr,
+    { op: "f64.lt" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "i32" } },
+      then: [{ op: "i32.const", value: -1 } as Instr],
+      else: [{ op: "local.get", index: 1 } as Instr, { op: "i32.trunc_sat_f64_s" } as Instr],
+    } as Instr,
+    { op: "local.set", index: 3 } as Instr,
+    // cap = 4; data = array.new_default(4); len = 0
+    { op: "i32.const", value: 4 } as Instr,
+    { op: "local.set", index: 4 } as Instr,
+    { op: "local.get", index: 4 } as Instr,
+    { op: "array.new_default", typeIdx: arrTypeIdx } as Instr,
+    { op: "local.set", index: 6 } as Instr,
+    { op: "i32.const", value: 0 } as Instr,
+    { op: "local.set", index: 5 } as Instr,
+    // drain loop
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [{ op: "loop", blockType: { kind: "empty" }, body: loopBody } as Instr],
+    } as Instr,
+    // return $Vec{len, data} as externref
+    { op: "local.get", index: 5 } as Instr,
+    { op: "local.get", index: 6 } as Instr,
+    { op: "struct.new", typeIdx: vecTypeIdx } as Instr,
+    { op: "extern.convert_any" } as Instr,
+  ];
+
+  const typeIdx = addFuncType(ctx, [{ kind: "externref" }, { kind: "f64" }], [{ kind: "externref" }]);
+  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  ctx.funcMap.set("__array_from_iter_n", funcIdx);
+  ctx.mod.functions.push({ name: "__array_from_iter_n", typeIdx, locals, body, exported: false });
+  return funcIdx;
+}
+
+/**
  * (#2038, reserve-then-fill #1719) Rebuild the `__iterator` / `__iterator_next`
  * bodies with the USER `{next()}`-protocol arm, now that the closed-struct
  * dispatchers (`__call_@@iterator`, `__call_next`, `__sget_value`, `__sget_done`)

--- a/src/codegen/iterator-native.ts
+++ b/src/codegen/iterator-native.ts
@@ -379,7 +379,31 @@ export function ensureNativeArrayFromIterN(ctx: CodegenContext): number {
     { op: "local.get", index: 0 } as Instr,
     { op: "ref.is_null" } as Instr,
     { op: "if", blockType: { kind: "empty" }, then: [...emptyVec, { op: "return" } as Instr], else: [] } as Instr,
-    // iter = __iterator(obj)
+    // (#2904) Only drain a genuine native externref `$Vec` through the iterator
+    // protocol. A NON-`__vec_externref` source — a JS array / `$ObjVec` / typed
+    // vec / custom iterable arriving as externref — would hit `__iterator`'s
+    // vec-only carrier and hard-cast → `illegal cast` (the vec-only carrier traps
+    // on a non-vec subject by design). The legacy JS-host `__array_from_iter_n`
+    // handled those via the JS iterator protocol; in standalone the indexable
+    // ones are read directly by the caller's downstream
+    // `__extern_length`/`__extern_get_idx` (and the `buildVecFromExternref`
+    // fallback, #792). So for a non-`$Vec` source, return it UNCHANGED and let
+    // that indexed reader handle it — byte-equivalent to the host result for an
+    // indexable source, and crucially NEVER trapping. This preserves the ~440
+    // indexable-source destructure tests that the unconditional drain regressed
+    // (the `__iterator` USER arm is unfilled in a bare destructure module, so a
+    // non-vec source has no safe drain path here).
+    { op: "local.get", index: 0 } as Instr,
+    { op: "any.convert_extern" } as Instr,
+    { op: "ref.test", typeIdx: vecTypeIdx } as Instr,
+    { op: "i32.eqz" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [{ op: "local.get", index: 0 } as Instr, { op: "return" } as Instr],
+      else: [],
+    } as Instr,
+    // iter = __iterator(obj)  (only reached for a genuine `$Vec`)
     { op: "local.get", index: 0 } as Instr,
     { op: "call", funcIdx: iteratorIdx } as Instr,
     { op: "local.set", index: 2 } as Instr,

--- a/tests/issue-2904-standalone-fixed-dstr-iter-drain.test.ts
+++ b/tests/issue-2904-standalone-fixed-dstr-iter-drain.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2904 — fixed-arity array destructuring of an `any`-typed (externref) source
+ * must NOT leak the JS-host `env::__array_from_iter_n` import under
+ * `--target standalone`. A leaked `env::` import breaks zero-import
+ * instantiation, so every test in the ~889-case cluster failed standalone.
+ *
+ * Fix: `destructureParamArray`'s externref fallback now drains the source
+ * through the native `__array_from_iter_n` defined function
+ * (`ensureNativeArrayFromIterN`, iterator-native.ts), which reuses the existing
+ * native `__iterator` / `__iterator_next` runtime — no host import. JS-host mode
+ * keeps the import (byte-identical).
+ *
+ * Both the variable-declaration path (`const [a,b]=x`) and the array-pattern
+ * param path (`function f([a,b]: any)`) delegate to `destructureParamArray`, so
+ * one fix covers both.
+ *
+ * NOTE on scope: `any + any` arithmetic on values read out of an `any` array
+ * (`x[0] + x[1]`, and equivalently destructured boxed bindings) is a separate,
+ * pre-existing standalone substrate gap (the boxed-number value-read path —
+ * project_standalone_any_string_value_read_substrate). These cases use
+ * individual value reads / `any * number` arithmetic, which exercise the drain
+ * + bind without depending on that orthogonal gap.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+  const mod = await WebAssembly.compile(r.binary);
+  const imports = WebAssembly.Module.imports(mod).map((i) => `${i.module}::${i.name}`);
+  expect(imports, "standalone module must have zero host imports").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2904 fixed-arity array destructuring drains natively (no __array_from_iter_n)", () => {
+  it("decl: two bindings, three-element any source — positional values", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const x:any=[10,20,30]; const [a,b]=x; return a*10+b; }`),
+    ).toBe(120);
+  });
+
+  it("decl: three bindings, three-element any source", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const x:any=[10,20,30]; const [a,b,c]=x; return a*100+b*10+c; }`,
+      ),
+    ).toBe(1230);
+  });
+
+  it("decl: out-of-length binding default fires (short source)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { const x:any=[5]; const [a,b=9]=x; return a*10+b; }`),
+    ).toBe(59);
+  });
+
+  it("decl: elision skips an element", async () => {
+    expect(await runStandalone(`export function test(): number { const x:any=[7,8]; const [,b]=x; return b; }`)).toBe(
+      8,
+    );
+  });
+
+  it("array-pattern param of any drains natively", async () => {
+    expect(
+      await runStandalone(
+        `function f([a,b]: any): number { return a*10+b; } export function test(): number { return f([3,4]); }`,
+      ),
+    ).toBe(34);
+  });
+
+  it("decl: more than the drain's initial capacity (>4 elements exercises grow)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const x:any=[1,2,3,4,5,6]; const [a,b,c,d,e,f]=x; return a*100000+b*10000+c*1000+d*100+e*10+f; }`,
+      ),
+    ).toBe(123456);
+  });
+
+  it("decl: neither binding is undefined when source has enough elements", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const x:any=[10,20,30]; const [a,b]=x; return (a===undefined?1:0)+(b===undefined?1:0); }`,
+      ),
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

On `--target standalone`/`wasi`, fixed-arity array destructuring of an `any`-typed
(externref) source leaked the JS-host import `env::__array_from_iter_n`. A leaked
`env::` import breaks zero-import instantiation, so the whole standalone module
fails — a ~889-test leak cluster (measured: leaks **only** this import).

`#681` added the native iterator helpers and `#2169` handled native-generator /
custom-iterable destructure sources, but the fixed-N drain in
`destructureParamArray`'s externref fallback still emitted the host import.

## Root cause

`__array_from_iter_n` is defined ONLY in `src/runtime.ts` (JS host); there is no
native definition, so `ensureLateImport` registers it as a plain `env::` import
under standalone. The native iterator runtime (`__iterator` / `__iterator_next`,
#681/#2038) already exists in standalone and handles both the VEC arm and the USER
arm — the fixed-N drain just never reused it.

## Fix

`ensureNativeArrayFromIterN` (iterator-native.ts): a native **defined** function
that drains the source through `__iterator` / `__iterator_next` into a growable
`__vec_externref` (array-doubling + `array.copy`, byte-shaped after the proven
spread-override drain), bounded by the f64 step count for no-rest patterns or
unbounded (`-1`) for rest. A `ref.is_null` guard returns an empty vec for
null/undefined (matching host `_arrayFromIter(null) -> []`). The result is read by
the existing `__extern_length` / `__extern_get_idx` consumers unchanged (the
`__vec_externref` is a `vecTypeMap` carrier they already recognise).

`destructureParamArray`'s externref fallback is gated: standalone/wasi use the
native helper (appends a defined func — **no funcIdx shift**), host mode keeps the
import (**byte-identical**). This covers BOTH `const/let [a,b] = anyExpr` and
`function f([a,b]: any)` — both delegate to `destructureParamArray`.

## Tests

`tests/issue-2904-standalone-fixed-dstr-iter-drain.test.ts` (7 cases, all green):
positional values, out-of-length default, elision, array-pattern param, >4-element
grow, undefined-check — each asserts **zero host imports** + correct value.

Regression sweep clean (#1592, #2169 ×3, #1021/#1024/#1158). The 2 pre-existing
`#1320` `arr.entries()` failures reproduce identically on clean `origin/main` (the
#1888/#2177 open-any retrieval gap) — not touched by this change (the new function
is only reachable from the destructure site).

## Scope (deferred, all fail on base too — no regressions)

- `any + any` arithmetic on values read from an `any` source (also fails for
  `anyArr[0]+anyArr[1]` without destructuring — the boxed-number value-read
  substrate gap).
- generator-as-`any` / Set-as-`any` destructure (the #2157 standalone-iterator-of-
  `any` substrate).
- the assignment-target site (`[a,b] = anyExpr`) — its `__extern_get(box)` reads
  trap in standalone; converting them surfaced a deeper USER-arm-fill dependency.

See the issue file for the full deferral rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)