### PR TITLE
fix(#2867 Gap 1): recursive thenable assimilation in native Promise carrier

### DIFF
--- a/plan/issues/2867-standalone-promise-microtask-carrier.md
+++ b/plan/issues/2867-standalone-promise-microtask-carrier.md
@@ -1,7 +1,8 @@
 ---
 id: 2867
 title: "Standalone: Promise / async microtask leaks Promise_resolve/reject/then + __make_callback host imports"
-status: ready
+status: in-progress
+assignee: ttraenkler/sendev-carrier
 created: 2026-06-30
 updated: 2026-06-30
 priority: high
@@ -72,3 +73,57 @@ Full `merge_group` + standalone high-water. Sequence before async generators
 (#2865 depends on this + #2864). Preserve the #2375 caution: Promise proto
 value-read path must not collide with runtime async-capability state (the
 null-deref noted in property-access.ts:736).
+
+## Implementation notes — Gap 1 LANDED (recursive thenable assimilation), sendev-carrier 2026-06-30
+
+This is the **carrier-completion track** (the blocking half of the standalone
+async unlock). The async-frame **drive layer** (#2895 slices 1a–1c, PRs
+#2393/#2394) is done and host-free-validated on `--target wasi`; the standalone
+count-move is gated on completing the native `$Promise` carrier so the slice-1d
+gate-widen (`isStandalonePromiseActive` + `isStandaloneThenChainNativeActive` →
+`standalone`) stops regressing. sendev-asyncdrive's A/B/C isolation proved the
+drive layer alone = 0 regression and the broad carrier widen = −16 (async-function
+74) / −29 (150-sample cluster); the carrier gaps are the cause.
+
+**Gap 1 of 5 — recursive thenable assimilation in native `.then`/`.catch`.** The
+dominant regressor (e.g. `language/statements/async-function/returns-async-function.js`:
+`.then(retFn => retFn())` must settle with the inner value `1`, not the promise
+object). Two coupled fixes, BOTH gated on the native-`$Promise` carrier
+(`isStandalonePromiseActive`, wasi-only today → widens to standalone in lockstep
+at slice 1d), so the default gc/host lane **and** the still-host-backed standalone
+lane are byte-unchanged (the −16/−29 guard's "gc-lane unchanged" requirement):
+
+1. `src/codegen/async-scheduler.ts` — new `__promise_resolve_value(promise, value)`
+   runtime helper implementing the spec "Resolve(promise, value)" step: if `value`
+   is a native `$Promise`, the chained promise ADOPTS its eventual state
+   (FULFILLED → enqueue identity-fulfill reaction with `inner.value`; REJECTED →
+   identity-reject; PENDING → prepend a `$PromiseCallback` reaction onto
+   `inner.callbacks`) via a `caps{callback:null, chained:promise}` capture;
+   otherwise it fulfils directly (drop-in for `__promise_fulfill`). The `.then`/
+   `.catch` **handler** wrappers and the identity-fulfill passthrough now settle
+   through it; because identity-fulfill itself routes back through resolve-value,
+   a chain of promises-returning-promises is assimilated **recursively**. Reject
+   reasons are never assimilated (identity-reject stays a direct reject). FuncIdx
+   reserved up-front (slot `base+4`) for late-shift safety.
+2. `src/codegen/closures.ts` — root cause of the corruption: a NON-async closure
+   whose return type is `Promise<T>` (a `.then` handler `v => Promise.resolve(...)`)
+   had `resolveWasmType(Promise<T>)` unwrap it to `T` (f64), coercing the returned
+   `$Promise` externref to **NaN inside the body** before the settle site ever saw
+   it. Now, under the carrier, such a closure resolves to `externref` so the real
+   `$Promise` reaches `__promise_resolve_value`.
+
+**Verification** (`tests/issue-2867.test.ts`, host-free wasi, `__drain_microtasks`):
+inferred + explicit-`Promise<number>`-annotated + recursive-pending-inner handler
+returns all adopt (→ correct value, was NaN); plain non-promise chains unchanged.
+gc + standalone lanes proven inert (carrier-gated; `ensurePromiseSettleFunctions`
+unreached without the native `.then` path). Typecheck clean, valid Wasm. The
+pre-existing `tests/promise-combinators.test.ts` 2-failures reproduce on clean
+`upstream/main` (gc/host `Promise.race` runtime shim — not this change).
+
+**Remaining carrier gaps (still deferred, each measured vs the −16/−29 guard before
+the slice-1d widen):** 2 async-fn throw→reject routing · 3 try/finally-across-await
+(drive-layer-coupled, #2895) · 4 `Promise.all`/`race`/`allSettled`/`any` native
+combinators · 5 `for-await-of`/async-generator native drive (drive-layer-coupled).
+Do NOT widen the carrier gates until all gap fixes land and the corpus measures
+net-positive. Gaps 3 & 5 touch the #2895 drive layer (owned by sendev-asyncdrive)
+— coordinate, don't fork.

--- a/src/codegen/async-scheduler.ts
+++ b/src/codegen/async-scheduler.ts
@@ -88,6 +88,16 @@ export interface AsyncSchedulerState {
   identityFulfillWrapperFuncIdx: number;
   /** Function index of the identity rejection task wrapper. */
   identityRejectWrapperFuncIdx: number;
+  /**
+   * Function index of `__promise_resolve_value((ref $Promise), externref) ->
+   * externref` — the spec "Resolve(promise, value)" primitive (#2867 Gap 1).
+   * If `value` is itself a native `$Promise` (the result of an async-fn call or
+   * a `.then` handler that returns a promise), the chained promise ADOPTS that
+   * inner promise's eventual state (recursive thenable assimilation) instead of
+   * fulfilling with the promise object. Otherwise it fulfils directly — so it is
+   * a drop-in for `__promise_fulfill` at every settle-with-handler-result site.
+   */
+  promiseResolveValueFuncIdx: number;
   /** Counter for generated `__then_fulfill_N` / `__then_reject_N` wrappers. */
   thenWrapperCounter: number;
   /** Whether `__drain_microtasks` has been added to the module's exports. */
@@ -190,6 +200,7 @@ function getOrInitState(ctx: CodegenContextWithScheduler): AsyncSchedulerState {
       promiseRejectFuncIdx: -1,
       identityFulfillWrapperFuncIdx: -1,
       identityRejectWrapperFuncIdx: -1,
+      promiseResolveValueFuncIdx: -1,
       thenWrapperCounter: 0,
       drainExported: false,
       timerFuncArrTypeIdx: -1,
@@ -754,6 +765,10 @@ function ensurePromiseSettleFunctions(ctx: CodegenContext): void {
   state.promiseRejectFuncIdx = baseFuncIdx + 1;
   state.identityFulfillWrapperFuncIdx = baseFuncIdx + 2;
   state.identityRejectWrapperFuncIdx = baseFuncIdx + 3;
+  // (#2867 Gap 1) reserve the resolve-value slot up-front so the identity
+  // fulfill wrapper below (and the `.then` handler wrappers) can reference it
+  // before its body is pushed — late assignment would shift later funcIdxs.
+  state.promiseResolveValueFuncIdx = baseFuncIdx + 4;
 
   ctx.mod.functions.push({
     name: "__promise_fulfill",
@@ -773,11 +788,17 @@ function ensurePromiseSettleFunctions(ctx: CodegenContext): void {
   });
   ctx.funcMap.set("__promise_reject", state.promiseRejectFuncIdx);
 
+  // The identity FULFILL wrapper settles its chained promise via
+  // resolve-value (not fulfill) so a passed-through value that is itself a
+  // `$Promise` is adopted, AND so the adoption reactions this resolve-value
+  // helper registers on a pending inner promise recurse correctly (#2867 Gap 1).
+  // The identity REJECT wrapper stays a direct reject — rejection reasons are
+  // never assimilated.
   ctx.mod.functions.push({
     name: "__then_identity_fulfill",
     typeIdx: state.microtaskFuncTypeIdx,
     locals: buildIdentityWrapperLocals(capsTypeIdx),
-    body: buildIdentityWrapperBody(capsTypeIdx, state.promiseFulfillFuncIdx),
+    body: buildIdentityWrapperBody(capsTypeIdx, state.promiseResolveValueFuncIdx),
     exported: false,
   });
   ctx.funcMap.set("__then_identity_fulfill", state.identityFulfillWrapperFuncIdx);
@@ -790,6 +811,15 @@ function ensurePromiseSettleFunctions(ctx: CodegenContext): void {
     exported: false,
   });
   ctx.funcMap.set("__then_identity_reject", state.identityRejectWrapperFuncIdx);
+
+  ctx.mod.functions.push({
+    name: "__promise_resolve_value",
+    typeIdx: settleTypeIdx,
+    locals: buildPromiseResolveValueLocals(promiseTypeIdx),
+    body: buildPromiseResolveValueBody(state, promiseTypeIdx, callbackTypeIdx, capsTypeIdx),
+    exported: false,
+  });
+  ctx.funcMap.set("__promise_resolve_value", state.promiseResolveValueFuncIdx);
 }
 
 function buildPromiseSettleLocals(callbackTypeIdx: number): LocalDef[] {
@@ -899,6 +929,121 @@ function buildIdentityWrapperBody(capsTypeIdx: number, settleFuncIdx: number): I
     { op: "struct.get", typeIdx: capsTypeIdx, fieldIdx: 1 },
     { op: "local.get", index: valueLocal },
     { op: "call", funcIdx: settleFuncIdx },
+  ];
+}
+
+function buildPromiseResolveValueLocals(promiseTypeIdx: number): LocalDef[] {
+  // Params 0/1: (promise, value). Locals start at 2.
+  return [
+    { name: "$inner", type: { kind: "ref", typeIdx: promiseTypeIdx } },
+    { name: "$caps", type: { kind: "externref" } },
+  ];
+}
+
+/**
+ * (#2867 Gap 1) `__promise_resolve_value(promise, value)` — the spec
+ * "Resolve(promise, value)" step for the native `$Promise` carrier.
+ *
+ * If `value` is a native `$Promise`, `promise` ADOPTS that inner promise's
+ * eventual state instead of fulfilling with the promise object:
+ *   - inner FULFILLED  → enqueue `__then_identity_fulfill(caps, inner.value)`
+ *   - inner REJECTED   → enqueue `__then_identity_reject(caps, inner.value)`
+ *   - inner PENDING    → prepend a `$PromiseCallback` reaction onto inner.callbacks
+ * where `caps` is `$__then_caps{callback: null, chained: promise}`, so the
+ * identity wrappers settle `promise` when the inner promise eventually settles.
+ * Because `__then_identity_fulfill` itself routes back through this helper, a
+ * chain of promises-returning-promises is assimilated recursively.
+ *
+ * If `value` is not a `$Promise`, it fulfils `promise` directly — byte-behaviour
+ * identical to the previous unconditional `__promise_fulfill` at the settle site.
+ */
+function buildPromiseResolveValueBody(
+  state: AsyncSchedulerState,
+  promiseTypeIdx: number,
+  callbackTypeIdx: number,
+  capsTypeIdx: number,
+): Instr[] {
+  const promiseLocal = 0;
+  const valueLocal = 1;
+  const innerLocal = 2;
+  const capsLocal = 3;
+  return [
+    { op: "local.get", index: valueLocal },
+    { op: "any.convert_extern" },
+    { op: "ref.test", typeIdx: promiseTypeIdx } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "val", type: { kind: "externref" } },
+      then: [
+        // inner = (ref $Promise) value
+        { op: "local.get", index: valueLocal },
+        { op: "any.convert_extern" },
+        { op: "ref.cast", typeIdx: promiseTypeIdx } as Instr,
+        { op: "local.set", index: innerLocal },
+        // caps = $__then_caps{ callback: null, chained: promise }
+        { op: "ref.null.extern" },
+        { op: "local.get", index: promiseLocal },
+        { op: "struct.new", typeIdx: capsTypeIdx } as Instr,
+        { op: "extern.convert_any" },
+        { op: "local.set", index: capsLocal },
+        // dispatch on inner.state
+        { op: "local.get", index: innerLocal },
+        { op: "struct.get", typeIdx: promiseTypeIdx, fieldIdx: 0 },
+        { op: "i32.const", value: PROMISE_STATE_FULFILLED },
+        { op: "i32.eq" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            // already fulfilled: schedule fulfill reaction with inner.value
+            { op: "ref.func", funcIdx: state.identityFulfillWrapperFuncIdx },
+            { op: "local.get", index: capsLocal },
+            { op: "local.get", index: innerLocal },
+            { op: "struct.get", typeIdx: promiseTypeIdx, fieldIdx: 1 },
+            { op: "call", funcIdx: state.enqueueFuncIdx },
+          ],
+          else: [
+            { op: "local.get", index: innerLocal },
+            { op: "struct.get", typeIdx: promiseTypeIdx, fieldIdx: 0 },
+            { op: "i32.const", value: PROMISE_STATE_REJECTED },
+            { op: "i32.eq" },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [
+                // already rejected: schedule reject reaction with inner.value
+                { op: "ref.func", funcIdx: state.identityRejectWrapperFuncIdx },
+                { op: "local.get", index: capsLocal },
+                { op: "local.get", index: innerLocal },
+                { op: "struct.get", typeIdx: promiseTypeIdx, fieldIdx: 1 },
+                { op: "call", funcIdx: state.enqueueFuncIdx },
+              ],
+              else: [
+                // pending: prepend a reaction node onto inner.callbacks
+                { op: "local.get", index: innerLocal },
+                { op: "ref.func", funcIdx: state.identityFulfillWrapperFuncIdx },
+                { op: "local.get", index: capsLocal },
+                { op: "ref.func", funcIdx: state.identityRejectWrapperFuncIdx },
+                { op: "local.get", index: capsLocal },
+                { op: "local.get", index: innerLocal },
+                { op: "struct.get", typeIdx: promiseTypeIdx, fieldIdx: 2 },
+                { op: "struct.new", typeIdx: callbackTypeIdx } as Instr,
+                { op: "extern.convert_any" },
+                { op: "struct.set", typeIdx: promiseTypeIdx, fieldIdx: 2 } as Instr,
+              ],
+            } as Instr,
+          ],
+        } as Instr,
+        // result (unused by the microtask drain, but the type must be externref)
+        { op: "local.get", index: valueLocal },
+      ],
+      else: [
+        // not a promise: fulfil directly
+        { op: "local.get", index: promiseLocal },
+        { op: "local.get", index: valueLocal },
+        { op: "call", funcIdx: state.promiseFulfillFuncIdx },
+      ],
+    } as Instr,
   ];
 }
 
@@ -2985,11 +3130,15 @@ export function emitStandalonePromiseThen(
   const callbackTypeIdx = getOrRegisterPromiseCallbackType(ctx);
   const capsTypeIdx = getOrRegisterThenCapsType(ctx);
 
+  // (#2867 Gap 1) handler results settle the chained promise via resolve-value
+  // (not fulfill) so a handler that RETURNS a promise/thenable causes the chain
+  // to adopt that inner promise's eventual state. A reject handler that returns
+  // normally also fulfils the chain (catch-recovery), so it routes the same way.
   const fulfillWrapperFuncIdx = onFulfilled
-    ? emitThenWrapperFunction(ctx, onFulfilled.closureInfo, state.promiseFulfillFuncIdx, "__then_fulfill")
+    ? emitThenWrapperFunction(ctx, onFulfilled.closureInfo, state.promiseResolveValueFuncIdx, "__then_fulfill")
     : state.identityFulfillWrapperFuncIdx;
   const rejectWrapperFuncIdx = onRejected
-    ? emitThenWrapperFunction(ctx, onRejected.closureInfo, state.promiseFulfillFuncIdx, "__then_reject")
+    ? emitThenWrapperFunction(ctx, onRejected.closureInfo, state.promiseResolveValueFuncIdx, "__then_reject")
     : state.identityRejectWrapperFuncIdx;
 
   const promiseLocal = allocLocal(fctx, `__then_promise_${fctx.locals.length}`, {

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -15,8 +15,9 @@
  */
 
 import { ts, forEachChild } from "../ts-api.js";
-import { isVoidType, unwrapPromiseType } from "../checker/type-mapper.js";
+import { isVoidType, unwrapPromiseType, isPromiseType } from "../checker/type-mapper.js";
 import type { FieldDef, Instr, LocalDef, StructTypeDef, ValType } from "../ir/types.js";
+import { isStandalonePromiseActive } from "./async-scheduler.js"; // (#2867 Gap 1) native-$Promise carrier gate
 import { classMemberFuncKey } from "./class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
 import { addStringConstantGlobal } from "./registry/imports.js"; // (#2025)
 import { stringConstantExternrefInstrs } from "./native-strings.js"; // (#2025)
@@ -1500,11 +1501,25 @@ export function compileArrowAsClosure(
     if (isAsync) {
       retType = unwrapPromiseType(retType, ctx.checker);
     }
+    // (#2867 Gap 1) A NON-async closure that returns a `Promise<T>` — e.g. a
+    // `.then`/`.catch` handler `v => Promise.resolve(...)` — produces a real
+    // Promise OBJECT at runtime, not a `T`. Under the host-free native-`$Promise`
+    // carrier, `resolveWasmType(Promise<T>)` would unwrap to `T` (e.g. f64),
+    // coercing the promise externref to NaN inside the body and breaking recursive
+    // thenable assimilation (the chained promise must ADOPT the returned inner
+    // promise's state). Keep the result `externref` so `__promise_resolve_value`
+    // at the settle site sees a real `$Promise`. Gated on the carrier predicate
+    // (wasi today; widens to standalone in lockstep at #2895 slice 1d) so the
+    // default gc/host `.then` path — and the standalone lane while its carrier is
+    // still host-backed — stay byte-unchanged.
+    if (!isAsync && isStandalonePromiseActive(ctx) && isPromiseType(retType)) {
+      closureReturnType = { kind: "externref" };
+    }
     // Treat `never` the same as `void` — a function returning `never` (e.g.
     // always throws) never produces a value, so it should have no Wasm result.
     // Without this, `never` resolves to externref and creates a mismatched
     // closure wrapper type vs. the `() => void` signature expected by callers.
-    if (!isVoidType(retType) && !(retType.flags & ts.TypeFlags.Never)) {
+    if (closureReturnType === null && !isVoidType(retType) && !(retType.flags & ts.TypeFlags.Never)) {
       closureReturnType = resolveWasmType(ctx, retType);
     }
   }

--- a/tests/issue-2867.test.ts
+++ b/tests/issue-2867.test.ts
@@ -1,0 +1,70 @@
+// #2867 Gap 1 — recursive thenable assimilation in the native `$Promise` carrier.
+//
+// When a `.then`/`.catch` handler RETURNS a promise (or a passthrough value that
+// is itself a promise), the chained promise must ADOPT that inner promise's
+// eventual state instead of fulfilling with the promise object. Before this fix
+// the chained promise fulfilled with the promise OBJECT, so the next handler saw
+// a promise where the spec requires the settled value (the dominant regressor in
+// the standalone async-function corpus — see the #2895 −16/−29 breakdown).
+//
+// The carrier is active under `--target wasi` today (it widens to `standalone`
+// in lockstep at #2895 slice 1d); these tests pin the behaviour on the lane where
+// the native carrier is live. They are host-free: instantiate with no imports and
+// drive settlement with the module's own `__drain_microtasks` export.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runWasi(body: string): Promise<number> {
+  const src = `
+let result = 0;
+export function run(): void { ${body} }
+export function getResult(): number { return result; }
+`;
+  const r = await compile(src, { fileName: "t.ts", target: "wasi" });
+  expect(r.success, r.success ? "" : `CE: ${r.errors?.[0]?.message}`).toBe(true);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const ex = instance.exports as Record<string, CallableFunction>;
+  ex.run!();
+  // settlement happens on microtasks; drive them to completion host-free.
+  ex.__drain_microtasks?.();
+  return ex.getResult!() as number;
+}
+
+describe("#2867 Gap 1 — native Promise thenable assimilation (wasi carrier)", () => {
+  it("a .then handler that returns a Promise is adopted (inferred return type)", async () => {
+    // retFn returns Promise.resolve(11); the chain must settle with 11, not the promise.
+    expect(
+      await runWasi(
+        `Promise.resolve(1).then((v: number) => Promise.resolve(v + 10)).then((v: number) => { result = v; });`,
+      ),
+    ).toBe(11);
+  });
+
+  it("a .then handler returning a Promise is adopted (explicit Promise<number> annotation)", async () => {
+    expect(
+      await runWasi(
+        `Promise.resolve(1).then((v: number): Promise<number> => Promise.resolve(v + 10)).then((v: number) => { result = v; });`,
+      ),
+    ).toBe(11);
+  });
+
+  it("assimilation recurses through a pending inner promise", async () => {
+    // The inner promise is itself produced by a prior .then, so it is pending when
+    // adopted — the reaction must be registered and fire on drain.
+    expect(
+      await runWasi(
+        `Promise.resolve(1)
+           .then((v: number) => Promise.resolve(v).then((w: number) => w + 10))
+           .then((v: number) => { result = v; });`,
+      ),
+    ).toBe(11);
+  });
+
+  it("does not perturb a plain (non-promise-returning) chain", async () => {
+    expect(await runWasi(`Promise.resolve(1).then((v: number) => v + 10).then((v: number) => { result = v; });`)).toBe(
+      11,
+    );
+    expect(await runWasi(`Promise.resolve(7).then((v: number) => { result = v; });`)).toBe(7);
+  });
+});


### PR DESCRIPTION
## Summary

First independently-mergeable increment of the **native Promise carrier completion** (#2867) — the blocking half of the standalone async unlock. The async-frame **drive layer** (#2895 slices 1a–1c, PRs #2393/#2394) is done and host-free-validated on `--target wasi`; the standalone count-move is gated on completing the carrier so the slice-1d gate-widen (`isStandalonePromiseActive` + `isStandaloneThenChainNativeActive` → `standalone`) stops regressing. sendev-asyncdrive's A/B/C isolation proved: **drive layer alone = 0 regression, broad carrier widen = −16/−29** — the carrier completeness gaps are the cause, not the drive layer.

## Gap 1 — recursive thenable assimilation (the dominant regressor)

A `.then`/`.catch` handler that **returns a promise** (e.g. `returns-async-function.js`'s `.then(retFn => retFn())`) must make the chained promise **adopt** that inner promise's eventual state, not fulfill with the promise object. Two coupled fixes:

1. **`async-scheduler.ts`** — new `__promise_resolve_value(promise, value)` implementing the spec *Resolve(promise, value)* step. If `value` is a native `$Promise`, the chain adopts it (FULFILLED/REJECTED → enqueue an identity reaction carrying `inner.value`; PENDING → prepend a `$PromiseCallback` onto `inner.callbacks`); otherwise it fulfils directly (drop-in for `__promise_fulfill`). The `.then`/`.catch` handler wrappers and the identity-fulfill passthrough now settle through it; because identity-fulfill routes back through resolve-value, promises-returning-promises assimilate **recursively**. FuncIdx reserved up-front (late-shift safety).
2. **`closures.ts`** — the root corruption: a **non-async** closure returning `Promise<T>` had `resolveWasmType(Promise<T>)` unwrap it to `T` (f64), coercing the returned `$Promise` externref to **NaN inside the body** before the settle site saw it. Under the carrier it now resolves to `externref`.

## Safety / guard

Both fixes are gated on the native-`$Promise` carrier predicate (`isStandalonePromiseActive`, **wasi-only today**, widens to standalone in lockstep at slice 1d). So:
- **gc/host lane: byte-unchanged** (the −16/−29 guard's hard requirement) — `ensurePromiseSettleFunctions` is unreached without the native `.then` path.
- **standalone lane: unchanged** (carrier still host-backed there) — this increment is **inert on all CI-measured lanes**; it completes the carrier on the wasi lane where it is live, ready for the deferred slice-1d widen.

## Verification

`tests/issue-2867.test.ts` (host-free wasi, driven via `__drain_microtasks`): inferred, explicit-`Promise<number>`-annotated, and recursive-pending-inner handlers all adopt → correct value (was NaN); plain non-promise chains unchanged. Typecheck clean, valid Wasm. The pre-existing `promise-combinators.test.ts` 2-failures reproduce on clean `upstream/main` (gc/host `Promise.race` shim — not this change).

## Remaining carrier gaps (deferred, each measured vs the −16/−29 guard before the widen)

2 async-fn throw→reject routing · 3 try/finally-across-await (drive-coupled, #2895) · 4 `Promise.all`/`race`/`allSettled`/`any` · 5 `for-await-of`/async-generator drive (drive-coupled). Carrier gates stay wasi-only until all land and the corpus measures net-positive. Gaps 3 & 5 touch the #2895 drive layer (sendev-asyncdrive) — coordinate, don't fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)