### PR TITLE
fix(#2867 Gap 2): async throw→reject routing + drive-result .then observability

### DIFF
--- a/plan/issues/2867-standalone-promise-microtask-carrier.md
+++ b/plan/issues/2867-standalone-promise-microtask-carrier.md
@@ -2,9 +2,9 @@
 id: 2867
 title: "Standalone: Promise / async microtask leaks Promise_resolve/reject/then + __make_callback host imports"
 status: in-progress
-assignee: ttraenkler/sendev-carrier
+assignee: ttraenkler/sendev-carrier-gaps
 created: 2026-06-30
-updated: 2026-06-30
+updated: 2026-07-01
 priority: high
 feasibility: hard
 task_type: feature
@@ -127,3 +127,63 @@ combinators · 5 `for-await-of`/async-generator native drive (drive-layer-couple
 Do NOT widen the carrier gates until all gap fixes land and the corpus measures
 net-positive. Gaps 3 & 5 touch the #2895 drive layer (owned by sendev-asyncdrive)
 — coordinate, don't fork.
+
+## Implementation notes — Gap 2 LANDED (throw→reject routing) + the call-site observability prerequisite, sendev-carrier-gaps 2026-07-01
+
+**Gap 2 of 5 — async-fn throw → reject routing**, plus a **foundational
+prerequisite** that was NOT in the original gap roadmap but blocks ALL of them:
+a drive-lowered async result (a real `$Promise`) was **not observable via
+`.then` at all** (the landed #2895 drive layer was only validated via
+side-effects + `await`, never `.then`). Without this, the test262
+`asyncTest(fn)` harness — which does `fn().then(verifyFulfill, $DONE)`, inline
+`.then` on the async call — can read nothing, so any gap-completion + widen would
+score 0 (the AG0 trap). Three coupled, **carrier-gated** fixes (wasi-only today →
+widen at slice 1d; gc/host + still-host-backed standalone lanes byte-unchanged):
+
+1. `src/codegen/expressions.ts` — **call-site double-wrap (the prerequisite).**
+   A genuinely-suspending async fn under the drive layer ALREADY returns a real
+   `$Promise` (externref). The legacy call-site contract (#1313/#1727) still
+   applied `wrapAsyncReturn` for a *thenable* consumer (`f().then(...)`), wrapping
+   the `$Promise` in a SECOND native `$Promise` (`wrapAsyncReturn`'s `struct.new`
+   arm) → `.then`/assignment read **NaN / illegal-cast** (Promise-of-Promise).
+   New predicate `calleeIsDriveLowered(ctx, expr)` (mirrors the
+   `function-body.ts` drive gate exactly: carrier active + async `function`
+   declaration + `asyncFnNeedsCps`) → skip the wrap, leave the `$Promise`
+   un-wrapped. Verified: `f().then(onF)` now threads the settled value; was NaN.
+2. `src/codegen/async-frame.ts` — **async-body throw / rejected-await → reject.**
+   Wrapped the resume-fn dispatch in `try/catch $exn → __promise_reject(result, e)`
+   (a `throw` in the body or a re-thrown rejected await now settles the result
+   `$Promise` REJECTED instead of escaping uncaught → trap / stranded-pending).
+   The continuation re-throws a microtask-delivered rejection (MODE_THROW +
+   ERROR_FIELD, set by the reject step adapter); the entry's rejected-now arm
+   arms MODE_THROW (was: delivered the reason as a fulfil value — the slice-1
+   placeholder).
+3. `src/codegen/async-scheduler.ts` — **throwing `.then`/`.catch` handler → reject
+   chain.** `emitThenWrapperFunction` now runs the user handler inside
+   `try/catch $exn → __promise_reject(chained, e)` (spec PerformPromiseThen reject
+   step) instead of letting a handler throw escape the microtask wrapper uncaught
+   (which trapped the whole `__drain_microtasks` pass).
+
+**Verification** (`tests/issue-2867-gap2.test.ts`, host-free wasi, `__drain_microtasks`,
+all green): drive result observable via inline `.then` (was NaN); throw-after-pending-await
+rejects (→ reject handler gets the reason); rejected genuinely-pending await rejects;
+throwing `.then` handler rejects the chain (was a trap); normal fulfilment still routes
+to the fulfil handler. The existing #2867 Gap-1 + #2895 drive-layer suites stay green;
+`tests/async-await.test.ts` (gc/host) + `issue-2671-promise-executor` stay green; typecheck clean.
+
+**KNOWN-OUT-OF-SCOPE / flagged for the tech lead (architectural — do NOT churn):**
+- **`const p = f(); p.then(...)` (and any `Promise<T>`-typed *binding/param/field*) still
+  corrupts** — `resolveWasmType(Promise<T>)` unwraps to `T` (f64) at index.ts:12046
+  ("async fns compiled synchronously"), which is false under the carrier; the inline
+  `.then($DONE,$DONE)` harness path (Gap-2 fix) is unaffected, but stored-promise
+  consumption needs a **broad `resolveWasmType(Promise<T>) → externref` decision under the
+  carrier** with wide blast radius (every Promise-typed slot) — the #2367-graveyard class.
+- **Pre-existing AG0 value-consumer regression** (`tests/issue-2865-...`: 2 fails — `let p =
+  Promise.resolve(7); return await p` consumed as `f() as number`): reproduces IDENTICALLY on
+  the unmodified Gap-1 base. The #2895 drive layer makes `return await <var>` genuinely-suspend
+  (returns a `$Promise`), which the `f() as number` *value*-consumer idiom can't unwrap
+  host-free — a #2895/sendev-asyncdrive contract item, not introduced here.
+
+Both feed slice 1d. **Gaps 3/4/5 + the runner-drain hook + the gate-widen remain**; the widen
+stays blocked until the stored-`Promise<T>` consumption decision lands and the corpus measures
+net-positive. Gap 2 is independently-mergeable and inert.

--- a/src/codegen/async-frame.ts
+++ b/src/codegen/async-frame.ts
@@ -42,12 +42,14 @@ import {
   STATE_FIELD,
   SENT_FIELD,
   MODE_FIELD,
+  MODE_THROW,
   ERROR_FIELD,
   sanitizeTypeName,
   storeSpills,
   setStateI32FromConst,
   defaultSpillInstr,
 } from "./frame-core.js";
+import { ensureExnTag } from "./registry/imports.js";
 import type { AsyncCpsPlan } from "./async-cps.js";
 import { splitBodyAtAwait } from "./async-cps.js";
 import { resolveSpillLocalValType } from "./statements/variables.js";
@@ -455,11 +457,43 @@ export function ensureAsyncResumeFunction(ctx: CodegenContext, info: AsyncFrameI
   // `return` or falls through delivering SENT); any other state skips straight
   // to the continuation. The entry's fall-through and the state!=0 path both
   // reach the continuation that follows the `if`.
-  resumeFctx.body.push({ op: "local.get", index: frameLocal });
-  resumeFctx.body.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: STATE_FIELD });
-  resumeFctx.body.push({ op: "i32.eqz" });
-  resumeFctx.body.push({ op: "if", blockType: { kind: "empty" }, then: entrySeg } as Instr);
-  for (const instr of contSeg) resumeFctx.body.push(instr);
+  const dispatch: Instr[] = [
+    { op: "local.get", index: frameLocal },
+    { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: STATE_FIELD },
+    { op: "i32.eqz" },
+    { op: "if", blockType: { kind: "empty" }, then: entrySeg } as Instr,
+    ...contSeg,
+  ];
+
+  // (#2867 Gap 2) Throw → reject routing. An async function that throws — a bare
+  // `throw e` in the body, OR a rejected await whose reason the continuation
+  // re-throws (see `buildContinuationSegment`'s MODE_THROW arm and the
+  // `rejectFromP` rejected-now arm in `buildEntrySegment`) — must settle the
+  // frame's result `$Promise` REJECTED, not let the exception escape the resume
+  // function uncaught (which traps / strands the promise pending). Wrap the whole
+  // dispatch in a `try`/`catch $exn` that `__promise_reject`s the result with the
+  // caught reason. The suspend `return` and the fulfil-settle `return` exit the
+  // function cleanly (a `return` inside `try` does NOT invoke `catch`), so only a
+  // genuine throw reaches here.
+  const exnTag = ensureExnTag(ctx);
+  const reasonLocal = allocLocal(resumeFctx, "__async_reason", { kind: "externref" });
+  resumeFctx.body.push({
+    op: "try",
+    blockType: { kind: "empty" },
+    body: dispatch,
+    catches: [
+      {
+        tagIdx: exnTag,
+        body: [
+          { op: "local.set", index: reasonLocal },
+          { op: "local.get", index: resultPromiseLocal },
+          { op: "local.get", index: reasonLocal },
+          { op: "call", funcIdx: rt.rejectFuncIdx },
+          { op: "drop" },
+        ],
+      },
+    ],
+  } as Instr);
 
   resumePlaceholder.locals = resumeFctx.locals;
   resumePlaceholder.body = resumeFctx.body;
@@ -566,6 +600,19 @@ function buildEntrySegment(
       { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: SENT_FIELD } as Instr,
     ];
 
+    // (#2867 Gap 2) Rejected-now: stash the reason into ERROR_FIELD and arm
+    // MODE_THROW, then fall through into the continuation — whose MODE_THROW arm
+    // re-throws it (→ result-promise reject, or an enclosing try/catch under
+    // Gap 3). Minted fresh per use so no `Instr[]` is aliased into two branch
+    // slots (`reference_shared_instr_object_dce_double_remap`).
+    const rejectFromP = (): Instr[] => [
+      { op: "local.get", index: frameLocal },
+      { op: "local.get", index: pLocal },
+      { op: "struct.get", typeIdx: promiseTypeIdx, fieldIdx: 1 } as Instr,
+      { op: "struct.set", typeIdx: info.stateTypeIdx, fieldIdx: ERROR_FIELD } as Instr,
+      ...setStateI32FromConst(info, frameLocal, MODE_FIELD, MODE_THROW),
+    ];
+
     // Suspend arm: storeSpills + STATE=1 + register reaction + return.
     const suspend: Instr[] = [
       ...storeSpills(info, fctx, frameLocal),
@@ -595,7 +642,7 @@ function buildEntrySegment(
       {
         op: "if",
         blockType: { kind: "empty" },
-        then: deliverFromP(), // rejected-now: deliver reason as value (slice-1)
+        then: rejectFromP(), // rejected-now: arm MODE_THROW, continuation re-throws (Gap 2)
         else: suspend, // genuinely pending: suspend
       } as Instr,
     ];
@@ -657,6 +704,29 @@ function buildContinuationSegment(
   const seg: Instr[] = [];
   fctx.body = seg;
   try {
+    // (#2867 Gap 2) A rejected await delivers its reason through MODE_THROW +
+    // ERROR_FIELD — set either by the reject step adapter (microtask-delivered
+    // rejection) or by the `rejectFromP` rejected-now arm in the entry segment.
+    // Re-throw the reason here so it propagates to the result-promise reject
+    // wrapper in `ensureAsyncResumeFunction` (or, once Gap 3 lands, an enclosing
+    // try/catch across the await). On the fulfil path MODE is NEXT, so this is a
+    // no-op. Emitted BEFORE binding the resume value because a rejection has no
+    // value to bind.
+    const exnTag = ensureExnTag(ctx);
+    seg.push({ op: "local.get", index: frameLocal });
+    seg.push({ op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: MODE_FIELD });
+    seg.push({ op: "i32.const", value: MODE_THROW });
+    seg.push({ op: "i32.eq" });
+    seg.push({
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: frameLocal },
+        { op: "struct.get", typeIdx: info.stateTypeIdx, fieldIdx: ERROR_FIELD } as Instr,
+        { op: "throw", tagIdx: exnTag } as Instr,
+      ],
+    } as Instr);
+
     // Bind `x = SENT` (coerced) for `const x = await P`.
     if (resumeBindingLocal !== undefined && resumeBindingType) {
       seg.push({ op: "local.get", index: frameLocal });

--- a/src/codegen/async-scheduler.ts
+++ b/src/codegen/async-scheduler.ts
@@ -21,6 +21,7 @@ import type { ClosureInfo, CodegenContext, FunctionContext } from "./context/typ
 import { allocLocal } from "./context/locals.js";
 import { addFuncType, getOrRegisterArrayType } from "./registry/types.js";
 import { addUnionImportsViaRegistry } from "./shared.js";
+import { ensureExnTag } from "./registry/imports.js";
 
 /**
  * #1326 — Sentinel state values for `$Promise.state`. Match the JS spec
@@ -1210,33 +1211,67 @@ function emitThenWrapperFunction(
     { op: "any.convert_extern" },
     { op: "ref.cast", typeIdx: info.structTypeIdx },
     { op: "local.set", index: callbackLocal },
+  ];
 
+  // (#2867 Gap 2) Run the user `.then`/`.catch` handler inside a try/catch: a
+  // handler that THROWS must REJECT the chained promise (spec PerformPromiseThen
+  // reject step), not let the exception escape the microtask wrapper uncaught —
+  // which traps the entire `__drain_microtasks` pass. Applies uniformly to the
+  // fulfill-handler and reject-handler wrappers (the reject arm of
+  // `.then(onF, onR)` / `.catch` throwing must also reject the chain). Reuses the
+  // module's single exception tag and the native `__promise_reject` settle.
+  const exnTag = ensureExnTag(ctx);
+  const reasonLocal = 5;
+  locals.push({ name: "$reason", type: { kind: "externref" } });
+
+  // Happy path: call the handler, coerce its result, settle the chained promise.
+  const tryBody: Instr[] = [
     // call_ref stack shape: [closure_self, ...user_args, typed_funcref]
     { op: "local.get", index: callbackLocal },
   ];
-
   for (let i = 0; i < info.paramTypes.length; i++) {
     if (i === 0) {
-      pushExternrefLocalAsType(ctx, body, 1, info.paramTypes[i]!);
+      pushExternrefLocalAsType(ctx, tryBody, 1, info.paramTypes[i]!);
     } else {
-      pushDefaultForType(body, info.paramTypes[i]!);
+      pushDefaultForType(tryBody, info.paramTypes[i]!);
     }
   }
-
-  body.push(
+  tryBody.push(
     { op: "local.get", index: callbackLocal },
     { op: "struct.get", typeIdx: info.structTypeIdx, fieldIdx: 0 } as Instr,
     { op: "ref.cast", typeIdx: info.funcTypeIdx } as Instr,
     { op: "call_ref", typeIdx: info.funcTypeIdx },
   );
-  coerceStackValueToExternref(ctx, body, info.returnType);
-  body.push(
+  coerceStackValueToExternref(ctx, tryBody, info.returnType);
+  tryBody.push(
     { op: "local.set", index: resultLocal },
     { op: "local.get", index: capLocal },
     { op: "struct.get", typeIdx: capsTypeIdx, fieldIdx: 1 } as Instr,
     { op: "local.get", index: resultLocal },
     { op: "call", funcIdx: settleFuncIdx },
+    { op: "drop" }, // settle returns the value; the drain ignores the wrapper result
   );
+
+  body.push({
+    op: "try",
+    blockType: { kind: "empty" },
+    body: tryBody,
+    catches: [
+      {
+        tagIdx: exnTag,
+        body: [
+          { op: "local.set", index: reasonLocal },
+          { op: "local.get", index: capLocal },
+          { op: "struct.get", typeIdx: capsTypeIdx, fieldIdx: 1 } as Instr,
+          { op: "local.get", index: reasonLocal },
+          { op: "call", funcIdx: state.promiseRejectFuncIdx },
+          { op: "drop" },
+        ],
+      },
+    ],
+  } as Instr);
+  // Wrapper result (externref) — dropped by the drain; always null now.
+  body.push({ op: "ref.null.extern" });
 
   ctx.mod.functions.push({
     name: wrapperName,

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -13,7 +13,7 @@
  */
 import { ts } from "../ts-api.js";
 import { isBooleanType, isPromiseType, mapTsTypeToWasm } from "../checker/type-mapper.js";
-import { classifyAsyncConsumer } from "./async-cps.js";
+import { classifyAsyncConsumer, analyzeAsyncBody, asyncFnNeedsCps } from "./async-cps.js";
 import type { Instr, ValType } from "../ir/types.js";
 import {
   emitStandalonePromiseReject,
@@ -338,6 +338,35 @@ function asyncResultConsumedAsValue(ctx: CodegenContext, expr: ts.CallExpression
   // This stays behaviour-identical until #1796 changes the value/thenable
   // dispatch. The rich rationale for each case is documented above.
   return classifyAsyncConsumer(ctx.checker, expr) !== "thenable";
+}
+
+/**
+ * (#2867 Gap 2 prerequisite) Is the callee of `expr` an async function that is
+ * **drive-lowered** under the host-free native-`$Promise` carrier — i.e. it is
+ * compiled by the #2895 async-frame drive layer and therefore ALREADY returns a
+ * real `$Promise` object (externref), not a raw `T`?
+ *
+ * The legacy call-site contract (#1313/#1727) assumes an async call leaves a raw
+ * `T` on the stack and wraps it in `Promise.resolve(...)` for thenable consumers
+ * (`f().then(...)`, `const p: Promise<T> = f()`). That double-wraps a
+ * drive-lowered result — the `$Promise` externref is wrapped in a SECOND native
+ * `$Promise` (`wrapAsyncReturn`'s `struct.new` arm), so `.then`/assignment sees a
+ * Promise-of-Promise and reads NaN / illegal-casts. When the callee is
+ * drive-lowered we must leave its `$Promise` result un-wrapped.
+ *
+ * Mirrors the drive-layer gate in `function-body.ts` exactly: carrier active +
+ * the callee is a plain async (non-generator) `function` declaration whose body
+ * genuinely suspends (`asyncFnNeedsCps`). Inert off the carrier (gc/host).
+ */
+function calleeIsDriveLowered(ctx: CodegenContext, expr: ts.CallExpression): boolean {
+  if (!isStandalonePromiseActive(ctx)) return false;
+  const sig = ctx.checker.getResolvedSignature(expr);
+  const decl = sig?.getDeclaration();
+  if (!decl || !ts.isFunctionDeclaration(decl) || decl.body === undefined) return false;
+  if (decl.asteriskToken) return false; // async generator — returns AsyncGenerator, not Promise
+  const isAsyncDecl = (decl.modifiers ?? []).some((m) => m.kind === ts.SyntaxKind.AsyncKeyword);
+  if (!isAsyncDecl) return false;
+  return asyncFnNeedsCps(decl, analyzeAsyncBody(ctx, decl));
 }
 
 /**
@@ -1267,6 +1296,18 @@ function compileExpressionInner(
         // Skip the wrap; the raw value on the stack is what the consumer
         // (await passthrough or primitive cast sink) expects.
         return callResult;
+      }
+      // (#2867) A drive-lowered async callee already returns a real `$Promise`
+      // (externref) — the #2895 frame driver settled it. Re-wrapping it via
+      // `wrapAsyncReturn` would build a Promise-of-Promise (the native
+      // `struct.new` arm), so `.then`/assignment reads NaN / illegal-casts. Leave
+      // the `$Promise` un-wrapped for the thenable consumer. Carrier-gated → inert
+      // on gc/host.
+      if (calleeIsDriveLowered(ctx, expr)) {
+        if (callResult !== null && callResult !== VOID_RESULT && (callResult as ValType).kind !== "externref") {
+          coerceType(ctx, fctx, callResult as ValType, { kind: "externref" });
+        }
+        return { kind: "externref" };
       }
       const wrappedType = wrapAsyncReturn(ctx, fctx, callResult);
       // Wrap the call+Promise.resolve in try/catch so synchronous throws from

--- a/tests/issue-2867-gap2.test.ts
+++ b/tests/issue-2867-gap2.test.ts
@@ -1,0 +1,123 @@
+// #2867 Gap 2 — async-fn throw → reject routing in the native `$Promise` carrier,
+// plus the call-site prerequisite that makes a drive-lowered async result
+// (a real `$Promise`) observable via `.then` at all.
+//
+// Three coupled fixes, ALL gated on the native-`$Promise` carrier
+// (`isStandalonePromiseActive`, wasi-only today → widens to standalone in lockstep
+// at #2895 slice 1d), so the gc/host lane and the still-host-backed standalone
+// lane are byte-unchanged:
+//
+//  1. async-frame.ts — a `throw` in an async body, OR a rejected await, settles the
+//     frame's result `$Promise` REJECTED (was: uncaught Wasm throw → trap / promise
+//     stranded pending). Wrapped the resume dispatch in `try/catch $exn → __promise_reject`;
+//     the continuation re-throws a microtask-delivered rejection (MODE_THROW+ERROR),
+//     and the rejected-now entry arm arms MODE_THROW instead of delivering the reason
+//     as a value.
+//  2. async-scheduler.ts — a `.then`/`.catch` HANDLER that throws now rejects the
+//     chained promise (spec PerformPromiseThen reject step) instead of letting the
+//     exception escape the microtask wrapper uncaught (which trapped the whole drain).
+//  3. expressions.ts — a drive-lowered async call (`f()` for a genuinely-suspending
+//     async fn) already returns a real `$Promise`; the legacy call-site contract
+//     (#1313/#1727) double-wrapped it in a second `Promise.resolve`, so `.then`/
+//     assignment read NaN / illegal-cast. Skip the wrap for drive-lowered callees.
+//
+// Host-free: instantiate with no imports, drive settlement with the module's own
+// `__drain_microtasks` export. This is exactly the test262 `asyncTest(fn)` shape
+// (`fn().then(verifyFulfill, $DONE)` — inline `.then` on the async call).
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runWasi(body: string, reads: string[]): Promise<Record<string, number>> {
+  const src = `
+let ff = 0;
+let rj = 0;
+let val = 0;
+${body}
+export function getFf(): number { return ff; }
+export function getRj(): number { return rj; }
+export function getVal(): number { return val; }
+`;
+  const r = await compile(src, { fileName: "t.ts", target: "wasi" });
+  expect(r.success, r.success ? "" : `CE: ${r.errors?.[0]?.message}`).toBe(true);
+  // The carrier is host-free under wasi: the module must request no imports.
+  expect((r.imports ?? []).map((i) => `${i.module}.${i.name}`)).toEqual([]);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const ex = instance.exports as Record<string, CallableFunction>;
+  ex.run!();
+  ex.__drain_microtasks?.();
+  const out: Record<string, number> = {};
+  for (const n of reads) out[n] = ex[n]!() as number;
+  return out;
+}
+
+describe("#2867 Gap 2 — async throw→reject routing (wasi carrier)", () => {
+  it("a drive-lowered async result is observable via inline .then (call-site no double-wrap)", async () => {
+    // The dominant prerequisite: `f().then(onF)` must thread f()'s settled value,
+    // not a Promise-of-Promise (was NaN). A genuinely-pending await drives f().
+    const r = await runWasi(
+      `
+      async function f(): Promise<number> { await Promise.resolve(1).then((w: number) => w + 40); return 42; }
+      export function run(): void { f().then((v: number) => { val = v; }); }
+      `,
+      ["getVal"],
+    );
+    expect(r.getVal).toBe(42);
+  });
+
+  it("a throw after a genuinely-pending await rejects the result promise", async () => {
+    const r = await runWasi(
+      `
+      async function f(): Promise<number> {
+        const x = await Promise.resolve(1).then((v: number) => v + 40);
+        throw x; // 41
+      }
+      export function run(): void { f().then((v: number) => { ff = 1; }, (e: number) => { rj = e; }); }
+      `,
+      ["getFf", "getRj"],
+    );
+    expect(r).toEqual({ getFf: 0, getRj: 41 });
+  });
+
+  it("a rejected genuinely-pending await propagates as a rejection", async () => {
+    const r = await runWasi(
+      `
+      async function f(): Promise<number> {
+        const x = await Promise.resolve(1).then((v: number) => { throw v + 40; });
+        return x;
+      }
+      export function run(): void { f().then((v: number) => { ff = 1; }, (e: number) => { rj = e; }); }
+      `,
+      ["getFf", "getRj"],
+    );
+    expect(r).toEqual({ getFf: 0, getRj: 41 });
+  });
+
+  it("a throwing .then handler rejects the chained promise (not a trap)", async () => {
+    const r = await runWasi(
+      `
+      export function run(): void {
+        Promise.resolve(1)
+          .then((v: number) => { throw v + 8; })
+          .then((v: number) => { ff = 1; }, (e: number) => { rj = e; });
+      }
+      `,
+      ["getFf", "getRj"],
+    );
+    expect(r).toEqual({ getFf: 0, getRj: 9 });
+  });
+
+  it("a normal (non-throwing) async fulfilment still routes to the fulfil handler", async () => {
+    const r = await runWasi(
+      `
+      async function f(): Promise<number> {
+        const x = await Promise.resolve(1).then((v: number) => v + 40);
+        return x + 1; // 42
+      }
+      export function run(): void { f().then((v: number) => { val = v; }, (e: number) => { rj = -1; }); }
+      `,
+      ["getVal", "getRj"],
+    );
+    expect(r).toEqual({ getVal: 42, getRj: 0 });
+  });
+});


### PR DESCRIPTION
## Summary

**Gap 2 of the native Promise carrier completion (#2867)** — async-fn **throw → reject** routing — **plus a foundational prerequisite the 5-gap roadmap missed**: a drive-lowered async result (a real `$Promise`) was **not observable via `.then` at all**. The landed #2895 drive layer was validated only via side-effects + `await`, never `.then`; but the test262 `asyncTest(fn)` harness does `fn().then(verifyFulfill, $DONE)` — **inline `.then` on the async call** — so without this fix the whole gap-completion + slice-1d widen would score 0 (the AG0 trap). All three fixes are **carrier-gated** (`isStandalonePromiseActive`, **wasi-only today** → widens to standalone in lockstep at slice 1d), so the gc/host lane **and** the still-host-backed standalone lane are **byte-unchanged**.

> ⚠️ **Stacked on #2400 (Gap 1).** This PR's diff currently includes the Gap-1 commit because #2400 has not merged yet — **merge #2400 first**; this PR then reduces to just the Gap-2 commit (`9ca1d406c`). sr-shepherd owns enqueue ordering.

## The three coupled fixes

1. **`expressions.ts` — call-site double-wrap (the prerequisite).** A genuinely-suspending async fn under the #2895 drive layer ALREADY returns a real `$Promise` (externref). The legacy call-site contract (#1313/#1727) still applied `wrapAsyncReturn` for a *thenable* consumer (`f().then(...)`), wrapping the `$Promise` in a SECOND native `$Promise` (the `struct.new` arm) → `.then`/assignment read **NaN / illegal-cast** (Promise-of-Promise). New `calleeIsDriveLowered(ctx, expr)` predicate — mirrors the `function-body.ts` drive gate exactly (carrier active + async `function` decl + `asyncFnNeedsCps`) — skips the wrap.
2. **`async-frame.ts` — async-body throw / rejected-await → reject.** Wrapped the resume-fn dispatch in `try/catch $exn → __promise_reject(result, e)` (a `throw` in the body or a re-thrown rejected await now settles the result `$Promise` REJECTED instead of escaping uncaught → trap / stranded-pending). The continuation re-throws a microtask-delivered rejection (MODE_THROW + ERROR_FIELD); the entry's rejected-now arm arms MODE_THROW instead of delivering the reason as a fulfil value (the slice-1 placeholder).
3. **`async-scheduler.ts` — throwing `.then`/`.catch` handler → reject chain.** `emitThenWrapperFunction` now runs the user handler inside `try/catch $exn → __promise_reject(chained, e)` (spec *PerformPromiseThen* reject step) instead of letting a handler throw escape the microtask wrapper uncaught (which trapped the whole `__drain_microtasks` pass).

## Verification

`tests/issue-2867-gap2.test.ts` (host-free wasi, `__drain_microtasks`, all green):
- drive result observable via inline `.then` (was NaN);
- throw-after-pending-await rejects (→ reject handler gets the reason);
- rejected genuinely-pending await rejects;
- throwing `.then` handler rejects the chain (was a **trap**);
- normal fulfilment still routes to the fulfil handler.

Existing **#2867 Gap-1** + **#2895 drive-layer** suites stay green; **`tests/async-await.test.ts`** (gc/host) + **`issue-2671-promise-executor`** stay green; **typecheck clean**.

## Out of scope / flagged (architectural — do NOT churn, escalated to tech lead)

- **`const p = f(); p.then(...)` (and any `Promise<T>`-typed *binding/param/field*) still corrupts** — `resolveWasmType(Promise<T>)` unwraps to `T` at `index.ts:12046` ("async fns compiled synchronously", false under the carrier). The inline `.then($DONE,$DONE)` harness path is fixed here; stored-promise consumption needs a **broad `resolveWasmType(Promise<T>) → externref` decision under the carrier** (wide blast radius — the #2367-graveyard class).
- **Pre-existing AG0 value-consumer regression** (`tests/issue-2865-...`: 2 fails — `let p = Promise.resolve(7); return await p` consumed as `f() as number`) reproduces **identically on the unmodified Gap-1 base** — a #2895/sendev-asyncdrive contract item, not introduced here.

**Gaps 3/4/5 + the runner-drain hook + the gate-widen (slice 1d) remain**; the widen stays blocked until the stored-`Promise<T>` consumption decision lands and the corpus measures net-positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)