### PR TITLE
fix(#2905): carrier-gate resolveWasmType(Promise<T>) → externref (stored/typed promise contract)

### DIFF
--- a/plan/issues/2905-promise-type-contract-carrier-externref.md
+++ b/plan/issues/2905-promise-type-contract-carrier-externref.md
@@ -1,0 +1,160 @@
+---
+id: 2905
+title: "Standalone/WASI Promise carrier: resolveWasmType(Promise<T>) must lower to externref (stored/typed promise contract)"
+status: done
+created: 2026-07-01
+updated: 2026-07-01
+completed: 2026-07-01
+assignee: ttraenkler/sendev-promise
+priority: high
+feasibility: medium
+task_type: bug
+area: codegen
+goal: standalone
+sprint: current
+horizon: m
+related: [2867, 2895, 2865, 1313, 1727, 1936]
+umbrella: 2860
+architect_spec: authored
+blocks: [2895]
+---
+
+# Promise type contract: `resolveWasmType(Promise<T>) → externref` under the native carrier
+
+## Problem
+
+Under the native `$Promise` carrier (the `isStandalonePromiseActive(ctx)` gate —
+today `ctx.wasi`, widened to `ctx.standalone` by #2895 slice 1d), an async call
+`f()` leaves a **real `$Promise` (externref)** on the stack — produced either by
+`wrapAsyncReturn` (synchronously-compiled async fn,
+`expressions.ts:378-389`) or by the drive layer's result-promise
+(`emitAsyncFrameStateMachine`, `function-body.ts:1159-1173`).
+
+But the **type contract for a stored/typed `Promise<T>`** disagreed:
+`resolveWasmType(ctx, Promise<T>)` unwrapped the promise to `T` at
+**`src/codegen/index.ts:12044-12054`** (comment: "Async functions are compiled
+synchronously, so Promise<T> is just T at the Wasm level" — **false under the
+carrier**). So every place that typed a *value as `Promise<T>`* resolved to
+`f64`/`i32`/etc., and storing the externref `$Promise` into that slot coerced
+`externref → f64` via `__unbox_number($Promise)` = **NaN** (or `ref.cast` into a
+struct slot = illegal-cast trap).
+
+PR for #2401 fixed only the **inline** `f().then()` / `await f()` path (the type
+flows straight from the call expression, never through a `Promise<T>`-typed
+slot). The **stored / typed** path was still corrupted:
+
+```ts
+const p = f();            // p : Promise<T>  → f64 slot  ← NaN
+p.then(cb);               // receiver typed Promise<T>   ← any.convert_extern on f64
+async function g(q: Promise<T>) { await q; }  // param typed Promise<T> ← NaN
+interface H { p: Promise<T> }                  // field typed Promise<T> ← NaN
+function h(): Promise<T> { return Promise.resolve(x); }  // non-async return ← NaN
+```
+
+## Implementation Plan (authored — read-only analysis of current `main`)
+
+[Full architect spec retained — see below for the as-built notes that supersede
+the gating mechanism the spec left open.]
+
+### The fix (one focused change)
+
+**File: `src/codegen/index.ts`** — `resolveWasmType`, the `Promise` branch.
+Carrier-gate the unwrap so a `Promise<T>` value slot lowers to `externref` when
+`isStandalonePromiseActive(ctx)`; the host/GC unwrap-to-`T` path is unchanged.
+
+### Signature-stability guard (the −16/−29 hazard)
+
+The three sites that compute a function's **own** wasm return via
+`resolveWasmType(retType)` **without** the async unwrap
+(`declarations.ts:1655` `findCallSignature`, `:3742` `module.exports = function`,
+`:3804` CJS named export) were guarded: an async fn's own wasm result is the
+**unwrapped `T`** (its body returns raw `T`; `wrapAsyncReturn` boxes to
+`$Promise` only at the *call* site), so declaring `externref` for a
+synchronously-compiled async fn whose body returns `f64` would be **invalid
+Wasm**. Each site now pre-unwraps async returns to match the four main
+async-return sites.
+
+## As-built implementation notes (sendev-promise) — WHY, not just WHAT
+
+### Gating decision: import the predicate, do NOT inline `ctx.wasi === true`
+
+The spec advised **against** importing `isStandalonePromiseActive` into
+`index.ts` (and `declarations.ts`), fearing an import cycle because
+"`async-scheduler.ts` imports `getOrRegisterPromiseType` etc. FROM `index.ts`".
+**That premise is false** — verified on current `main`:
+
+- `getOrRegisterPromiseType` is **defined in** `async-scheduler.ts:255`, not
+  imported from `index.ts`.
+- `async-scheduler.ts` contains **no `import … from "./index"`** at all (the only
+  `index.ts` mention is a comment at line 1425).
+- `index.ts` **already** imports from `./async-scheduler.js` (the
+  `enableStdinReactor`/`ensureTimerHeap` block).
+
+So the dependency is strictly one-way `index → async-scheduler`. Importing
+`isStandalonePromiseActive` into both `index.ts` and `declarations.ts` adds **no
+cycle**, and is strictly better than inlining `ctx.wasi === true`: it keeps a
+**single source of truth**, so when #2895 slice 1d widens the predicate to
+`ctx.standalone` it widens here automatically — **no lockstep two-place edit**,
+which is exactly the failure mode the spec's "keep in sync" comment was trying to
+guard against.
+
+### Own-return guard is carrier-gated too (defends GC byte-identity by construction)
+
+The spec's literal `isAsync ? unwrapPromiseType(retType) : retType` is correct
+under the carrier but would **change off-carrier bytes for the
+async-`Promise<void>` edge** at these three sites (today
+`resolveWasmType(Promise<void>) → externref`; the bare unwrap would yield `[]`).
+To make GC byte-identity hold **by construction** rather than by argument, the
+guard is gated on the carrier as well:
+
+```ts
+const effRet = isStandalonePromiseActive(ctx) && isAsync
+  ? unwrapPromiseType(retType, ctx.checker)
+  : retType;
+```
+
+Off-carrier `effRet === retType` **always** → byte-identical. On-carrier: async
+fns pre-unwrap to `T` (matches the raw-`T` body), non-async `Promise<T>` returns
+stay `Promise<T>` → `resolveWasmType` → `externref` (correct — their body returns
+a real promise). For site 1655 `isAsync` is derived from
+`sig.getDeclaration()` via `hasAsyncModifier` (same pattern as
+`expressions.ts:194`); sites 3742/3804 read `hasAsyncModifier(fnExpr)` directly.
+
+### Verification (local, verify-first)
+
+- **GC byte-identity (hard gate): PASS.** Compiled a 5-case corpus
+  (stored-binding, `Promise<T>` param, interface field, non-async `(): Promise<T>`
+  return, `Promise<T>[]`) at `target: "gc"` before/after — **bytes identical**
+  (629 / 418 / 974 / 628 / 1271 each lane).
+- **WASI carrier (the fix is exercisable today, no #2895 1d needed):** all five
+  cases compile + `WebAssembly.validate` true on both lanes.
+- **Mechanism proof (WAT diff of `$test` for `const p = f(); p.then(cb)`,
+  `--target wasi`):**
+  - *Before:* `(local $0 f64)`; `local.set $0 (call $__unbox_number (… struct.new
+    $Promise …))` — the `$Promise` is unboxed to f64 = `Number($Promise)` = **NaN**,
+    then re-`__box_number`'d and `ref.cast (ref $Promise)` of a boxed-number =
+    **illegal cast**.
+  - *After:* `(local $0 externref)`; the `$Promise` is stored **directly (no
+    `__unbox_number`)**; `.then` reads it via `any.convert_extern (local.get $0);
+    ref.cast (ref $Promise)` — a **valid** cast. NaN round-trip and illegal cast
+    both eliminated.
+- **AG0 value-consumer fails (#2895-owned):** untouched — `await asyncCall()` /
+  `asyncCall() as number` skip `wrapAsyncReturn` and never flow through a
+  `Promise<T>` slot, so they neither regress nor get fixed here (as designed).
+- **Authoritative gate:** full `merge_group` standalone/test262 report
+  net-positive (CI).
+
+### Files changed
+
+- `src/codegen/index.ts` — import `isStandalonePromiseActive`; carrier-gate the
+  `Promise<T>` branch of `resolveWasmType` to `externref`.
+- `src/codegen/declarations.ts` — import `isStandalonePromiseActive`; carrier-gate
+  the own-return unwrap at the three `resolveWasmType(retType)` signature sites
+  (`findCallSignature`, default-export function-expression, CJS named export).
+
+## Cross-references
+
+- #2867 — umbrella standalone Promise/microtask carrier.
+- #2895 — async-frame drive layer; **this issue unblocks #2895 slice 1d** (the
+  standalone gate widen), plus carrier gaps 3/4/5.
+- #1313/#1727/#1936 — the call-site async contract this type contract agrees with.

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -53,6 +53,7 @@ import {
   STRING_METHODS,
   unwrapGeneratorYieldType,
 } from "./index.js";
+import { isStandalonePromiseActive } from "./async-scheduler.js";
 import { ensureNativeStringExternBridge, ensureNativeStringHelpers } from "./native-strings.js";
 import { emitNativeParseNumber } from "./parse-number-native.js";
 import { emitNativeUriDecode, emitNativeUriEncode } from "./uri-encoding-native.js";
@@ -1652,7 +1653,21 @@ export function resolveGenericCallSiteTypes(
           params.push(resolveWasmType(ctx, paramType));
         }
         const retType = ctx.checker.getReturnTypeOfSignature(sig);
-        const results: ValType[] = isVoidType(retType) ? [] : [resolveWasmType(ctx, retType)];
+        // (#2905) Carrier own-return guard. resolveWasmType(Promise<T>) lowers to
+        // externref under the native $Promise carrier (index.ts), but an async
+        // callee's OWN wasm result is the unwrapped T — its body returns raw T;
+        // wrapAsyncReturn boxes to $Promise only at the *call* site. So for an
+        // async callee under the carrier, pre-unwrap to keep this inferred
+        // signature matching the actually-compiled fn (else externref-result vs
+        // f64-body = invalid Wasm). Gated on the carrier so off-carrier bytes are
+        // identical (effRet === retType). Non-async fns returning Promise<T> keep
+        // retType → resolveWasmType → externref, which is correct (body returns a
+        // real promise). Mirrors the main async-return sites (e.g. :2930).
+        const callDecl = sig.getDeclaration();
+        const calleeIsAsync = callDecl ? hasAsyncModifier(callDecl) : false;
+        const effRetType =
+          isStandalonePromiseActive(ctx) && calleeIsAsync ? unwrapPromiseType(retType, ctx.checker) : retType;
+        const results: ValType[] = isVoidType(effRetType) ? [] : [resolveWasmType(ctx, effRetType)];
         found = { params, results };
       }
     }
@@ -3739,7 +3754,16 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
               params.push(resolveWasmType(ctx, paramType));
             }
             const retType = ctx.checker.getReturnTypeOfSignature(sig);
-            const results = isVoidType(retType) ? [] : [resolveWasmType(ctx, retType)];
+            // (#2905) Carrier own-return guard — see findCallSignature. An async
+            // function-expression export's own wasm result is the unwrapped T;
+            // pre-unwrap under the carrier so the declared result matches the
+            // raw-T body (else externref-result vs f64-body = invalid Wasm).
+            // Carrier-gated → off-carrier bytes identical.
+            const effRetType =
+              isStandalonePromiseActive(ctx) && hasAsyncModifier(fnExpr)
+                ? unwrapPromiseType(retType, ctx.checker)
+                : retType;
+            const results = isVoidType(effRetType) ? [] : [resolveWasmType(ctx, effRetType)];
             const typeIdx = addFuncType(ctx, params, results, `${name}_type`);
             const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
             ctx.funcMap.set(name, funcIdx);
@@ -3801,7 +3825,15 @@ export function collectDeclarations(ctx: CodegenContext, sourceFile: ts.SourceFi
             params.push(resolveWasmType(ctx, paramType));
           }
           const retType = ctx.checker.getReturnTypeOfSignature(sig);
-          const results = isVoidType(retType) ? [] : [resolveWasmType(ctx, retType)];
+          // (#2905) Carrier own-return guard — see findCallSignature. CJS named
+          // function-expression export; pre-unwrap an async fn's Promise<T>
+          // result under the carrier so the declared result matches the raw-T
+          // body. Carrier-gated → off-carrier bytes identical.
+          const effRetType =
+            isStandalonePromiseActive(ctx) && hasAsyncModifier(fnExpr)
+              ? unwrapPromiseType(retType, ctx.checker)
+              : retType;
+          const results = isVoidType(effRetType) ? [] : [resolveWasmType(ctx, effRetType)];
           const typeIdx = addFuncType(ctx, params, results, `${name}_type`);
           const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
           ctx.funcMap.set(name, funcIdx);

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -87,6 +87,7 @@ import {
   exportDrainMicrotasksIfRegistered,
   getDrainFuncIdxForWasiStart,
   getRunLoopFuncIdxForWasiStart,
+  isStandalonePromiseActive,
 } from "./async-scheduler.js";
 import {
   brandExternMethodResult,
@@ -12041,13 +12042,28 @@ export function resolveWasmType(ctx: CodegenContext, tsType: ts.Type, _depth = 0
       return { kind: "externref" };
     }
 
-    // Promise<T> → unwrap to T.
-    // Async functions are compiled synchronously, so Promise<T> is just T at the Wasm level.
+    // Promise<T> → unwrap to T (host/GC) OR externref (native carrier).
     if (sym?.name === "Promise") {
       const typeArgs = ctx.checker.getTypeArguments(tsType as ts.TypeReference);
       if (typeArgs.length > 0) {
         const inner = typeArgs[0]!;
         if (isVoidType(inner)) return { kind: "externref" }; // Promise<void> → externref (no value)
+        // (#2905) Under the native `$Promise` carrier (isStandalonePromiseActive
+        // — today WASI, widened to standalone by #2895 slice 1d) a STORED/TYPED
+        // `Promise<T>` is a real `$Promise` externref (produced by wrapAsyncReturn
+        // at the call site / the drive-layer result), NOT the unwrapped `T`.
+        // Lower the value slot to externref so it matches the value end-to-end;
+        // storing the externref into an f64/struct slot would otherwise coerce
+        // `externref → f64` via __unbox_number = NaN (or an illegal struct cast).
+        //
+        // GC/host stays byte-identical: the unwrap-to-T contract only held
+        // because async fns are compiled synchronously, which is exactly when the
+        // carrier is OFF. An async fn's OWN wasm return signature pre-unwraps via
+        // unwrapPromiseType (function-body.ts / declarations.ts), so this branch
+        // is only hit for *value* slots (bindings / params / fields / non-async
+        // returns), never an async fn's own result type. externref is a leaf
+        // valtype — registers no new type, so no DCE remap / funcIdx churn.
+        if (isStandalonePromiseActive(ctx)) return { kind: "externref" };
         return resolveWasmType(ctx, inner, _depth + 1, _visited);
       }
       return { kind: "externref" }; // bare Promise without type arg


### PR DESCRIPTION
Closes #2905. Predecessor that unblocks #2895 slice 1d + the stored/typed Promise carrier gaps (3/4/5).

## Problem
Under the native `\$Promise` carrier (`isStandalonePromiseActive` — today WASI), an async call leaves a real `\$Promise` externref on the stack, but `resolveWasmType(Promise<T>)` unwrapped the value-slot type to `T` (f64/i32). Storing the externref into that slot coerced `externref → f64` via `__unbox_number(\$Promise)` = **NaN**, then re-boxed + `ref.cast`'d to `\$Promise` = **illegal cast**. This corrupted every *stored/typed* promise: `const p = f()`, `Promise<T>` params/fields, non-async `(): Promise<T>` returns. (#2401 fixed only the inline `f().then()`/`await f()` path.)

## Fix
- **`src/codegen/index.ts`** — carrier-gate the `Promise<T>` branch of `resolveWasmType` to `externref` when `isStandalonePromiseActive(ctx)`. Host/GC keeps the unwrap-to-`T` contract unchanged.
- **`src/codegen/declarations.ts`** — guard the three sites that compute a function's *own* wasm result via `resolveWasmType(retType)` without the async unwrap (`findCallSignature`, `module.exports = function`, CJS named export). An async fn's own result is the unwrapped `T` (body returns raw `T`; `wrapAsyncReturn` boxes to `\$Promise` only at the *call* site), so declaring `externref` there for a sync-compiled async fn = invalid Wasm. The guard is **carrier-gated** (`effRet === retType` off-carrier), so GC bytes stay identical by construction.
- `isStandalonePromiseActive` is imported directly (no import cycle — `async-scheduler` never imports `index`), keeping the predicate single-source for #2895 slice 1d's widen.

## Verification (verify-first)
- **GC byte-identity (hard gate): PASS** — 5-case corpus (stored binding, `Promise<T>` param, interface field, non-async return, `Promise<T>[]`) compiled at `target: gc` before/after = **identical bytes** (629/418/974/628/1271).
- **WASI carrier** — all 5 cases compile + `WebAssembly.validate` true.
- **Mechanism proof (WAT diff, `const p = f(); p.then(cb)` `--target wasi`):** before = `(local \$0 f64)` + `__unbox_number(\$Promise)` (NaN) + illegal `ref.cast`; after = `(local \$0 externref)`, `\$Promise` stored directly, `.then` does a valid `any.convert_extern; ref.cast (ref \$Promise)`.
- **AG0 value-consumer fails (#2895-owned)** untouched — they skip `wrapAsyncReturn` and never flow through a `Promise<T>` slot.
- Authoritative gate: full `merge_group` standalone/test262 report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)