### PR TITLE
feat(#2867 Gap 4): native host-free Promise.all / Promise.race combinators

### DIFF
--- a/plan/issues/2867-standalone-promise-microtask-carrier.md
+++ b/plan/issues/2867-standalone-promise-microtask-carrier.md
@@ -2,7 +2,7 @@
 id: 2867
 title: "Standalone: Promise / async microtask leaks Promise_resolve/reject/then + __make_callback host imports"
 status: in-progress
-assignee: ttraenkler/sendev-carrier-gaps
+assignee: ttraenkler/sendev-carriergap4
 created: 2026-06-30
 updated: 2026-07-01
 priority: high
@@ -37,6 +37,7 @@ landed.)
 ## Root cause
 
 No standalone microtask queue + Promise state machine. Needs:
+
 - a native `$Promise` struct (state: pending/fulfilled/rejected, value, reaction
   list).
 - a native **microtask queue** drained at top-of-job / after the main module
@@ -55,6 +56,7 @@ it between async functions, generators, and async generators. Check #1326c
 microtask work already present before re-deriving.
 
 Sketch:
+
 - `$Promise` + microtask ring in the object-runtime; drain entry called after
   module main + at each await resume.
 - Replace the `Promise_*`/`__make_callback` host-import emission sites (search
@@ -66,6 +68,7 @@ Sketch:
 ## Test plan
 
 Standalone fail/CE → pass:
+
 - `test/built-ins/Promise/**` (resolve/reject/then/finally/all/race/allSettled/any)
 - `test/language/expressions/await/**`, `test/language/statements/async-function/**`
 
@@ -82,8 +85,7 @@ async unlock). The async-frame **drive layer** (#2895 slices 1a–1c, PRs
 count-move is gated on completing the native `$Promise` carrier so the slice-1d
 gate-widen (`isStandalonePromiseActive` + `isStandaloneThenChainNativeActive` →
 `standalone`) stops regressing. sendev-asyncdrive's A/B/C isolation proved the
-drive layer alone = 0 regression and the broad carrier widen = −16 (async-function
-74) / −29 (150-sample cluster); the carrier gaps are the cause.
+drive layer alone = 0 regression and the broad carrier widen = −16 (async-function 74) / −29 (150-sample cluster); the carrier gaps are the cause.
 
 **Gap 1 of 5 — recursive thenable assimilation in native `.then`/`.catch`.** The
 dominant regressor (e.g. `language/statements/async-function/returns-async-function.js`:
@@ -143,7 +145,7 @@ widen at slice 1d; gc/host + still-host-backed standalone lanes byte-unchanged):
 1. `src/codegen/expressions.ts` — **call-site double-wrap (the prerequisite).**
    A genuinely-suspending async fn under the drive layer ALREADY returns a real
    `$Promise` (externref). The legacy call-site contract (#1313/#1727) still
-   applied `wrapAsyncReturn` for a *thenable* consumer (`f().then(...)`), wrapping
+   applied `wrapAsyncReturn` for a _thenable_ consumer (`f().then(...)`), wrapping
    the `$Promise` in a SECOND native `$Promise` (`wrapAsyncReturn`'s `struct.new`
    arm) → `.then`/assignment read **NaN / illegal-cast** (Promise-of-Promise).
    New predicate `calleeIsDriveLowered(ctx, expr)` (mirrors the
@@ -172,18 +174,84 @@ to the fulfil handler. The existing #2867 Gap-1 + #2895 drive-layer suites stay 
 `tests/async-await.test.ts` (gc/host) + `issue-2671-promise-executor` stay green; typecheck clean.
 
 **KNOWN-OUT-OF-SCOPE / flagged for the tech lead (architectural — do NOT churn):**
-- **`const p = f(); p.then(...)` (and any `Promise<T>`-typed *binding/param/field*) still
+
+- **`const p = f(); p.then(...)` (and any `Promise<T>`-typed _binding/param/field_) still
   corrupts** — `resolveWasmType(Promise<T>)` unwraps to `T` (f64) at index.ts:12046
   ("async fns compiled synchronously"), which is false under the carrier; the inline
   `.then($DONE,$DONE)` harness path (Gap-2 fix) is unaffected, but stored-promise
   consumption needs a **broad `resolveWasmType(Promise<T>) → externref` decision under the
   carrier** with wide blast radius (every Promise-typed slot) — the #2367-graveyard class.
 - **Pre-existing AG0 value-consumer regression** (`tests/issue-2865-...`: 2 fails — `let p =
-  Promise.resolve(7); return await p` consumed as `f() as number`): reproduces IDENTICALLY on
+Promise.resolve(7); return await p` consumed as `f() as number`): reproduces IDENTICALLY on
   the unmodified Gap-1 base. The #2895 drive layer makes `return await <var>` genuinely-suspend
-  (returns a `$Promise`), which the `f() as number` *value*-consumer idiom can't unwrap
+  (returns a `$Promise`), which the `f() as number` _value_-consumer idiom can't unwrap
   host-free — a #2895/sendev-asyncdrive contract item, not introduced here.
 
 Both feed slice 1d. **Gaps 3/4/5 + the runner-drain hook + the gate-widen remain**; the widen
 stays blocked until the stored-`Promise<T>` consumption decision lands and the corpus measures
 net-positive. Gap 2 is independently-mergeable and inert.
+
+## Implementation notes — Gap 4 LANDED (native Promise.all / Promise.race combinators), sendev-carriergap4 2026-07-01
+
+**Gap 4 of 5 — native, host-free `Promise.all` / `Promise.race`.** Today these
+leak `Promise_all` / `Promise_race` host imports **even on the carrier target**
+(`--target wasi`): `declarations.ts`'s aggregator pre-registration only skipped
+`resolve`/`reject` for wasi, so every `Promise.all` module was unsatisfiable
+host-free. This slice lowers the **array-literal** form
+(`Promise.all([a, b])` / `Promise.race([a, b])`) directly onto the EXISTING
+carrier substrate — it forks nothing:
+
+- New `src/codegen/promise-combinators.ts`. `ensureCombinatorFunctions(ctx)`
+  registers two small struct types — `$CombinatorState{ resultPromise, resultsArr,
+length, remaining(mut) }` and `$CombinatorElemCaps{ state, index }` — plus four
+  shared runtime helpers with funcIdx slots reserved up-front (the generator
+  slot-reservation idiom, late-shift-safe): `__combinator_subscribe` (normalises an
+  input to a `$Promise`, builds the per-element caps, and either enqueues an
+  already-settled reaction or prepends a `$PromiseCallback` onto a pending input's
+  callbacks list), `__combinator_all_fulfill` (writes `results[index]`, decrements
+  `remaining`, and on 0 fulfils the result `$Promise` with the results vec),
+  `__combinator_race_fulfill` (one-shot fulfil — first wins), and
+  `__combinator_reject` (one-shot reject — shared by all & race). All reuse
+  `ensureAsyncDriveRuntime` (Promise type, reaction node, microtask ring,
+  `__promise_fulfill`/`__promise_reject`).
+- `expressions/calls.ts` aggregator branch: under `isStandalonePromiseActive` +
+  array-literal arg (no spread/elision) + non-subclass receiver →
+  `emitStandalonePromiseCombinator`; everything else (generic iterables,
+  `allSettled`/`any`, subclass capability-ctor receivers) falls through to the
+  host path unchanged.
+- `declarations.ts`: skip the `Promise_all`/`Promise_race` host-import
+  pre-registration under the carrier (mirrors the resolve/reject wasi skip); the
+  host path still lazily `ensureLateImport`s for the genuine non-native cases.
+
+**Result array representation:** the fulfilled `Promise.all` value is an
+externref vec (`getOrRegisterVecType("externref")`) — i.e. boxed elements, so the
+natural consumer type is `any[]`. A `number[]`-typed `.then` handler casts the
+fulfilled value to an f64-element vec and traps (`illegal cast`); that is the
+expected representation contract, not a combinator bug (`any[]` access unboxes
+correctly).
+
+**Verification** (`tests/issue-2867-gap4.test.ts`, host-free wasi,
+`__drain_microtasks`, all green): all-fulfil (correct values array), all-reject
+(first rejection), `all([])` immediate fulfil, **genuinely-pending all** (inputs
+settle only on a later microtask → aggregate suspends and resumes across the
+drain — the case the host import cannot serve host-free), race-fulfil (first
+wins), race-reject. **Inertness proven by byte-hash:** gc/host
+(`691d10aac350c024`) and `--target standalone` (`43d3f001a1be11aa`) binaries are
+**identical** base-vs-branch (both still host-route the combinators); only the
+wasi carrier lane changes. Typecheck clean; the pre-existing
+`tests/promise-combinators.test.ts` 2 gc/host `Promise.race` runtime-shim failures
+reproduce on the unmodified base (documented in the Gap-1 note — not this change).
+
+**Scope deferred (follow-ups within this gap):** `allSettled` (needs per-element
+`{status,value}` status objects) and `any` (needs `AggregateError`) — both add
+object/error construction coupling; and the **generic-iterable** argument form
+(non-array-literal) which needs host-free `GetIterator` driving. These stay on
+the host path and are inert.
+
+**Remaining for the unlock:** Gap 3 (try/finally-across-await, drive-layer
+coupled) · Gap 5 (for-await-of / async-generator drive, drive-layer coupled) ·
+the runner `__drain_microtasks` hook (sr-pathb's 1d-scaffolding, in branch
+`issue-2895-async-drive-1b`) · then the slice-1d gate-widen, measured
+NET-POSITIVE on the full `merge_group` standalone corpus AFTER #2402 (the stored
+`Promise<T>` consumption contract, now LANDED on main). Gap 4 is
+independently-mergeable and inert.

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -1396,6 +1396,12 @@ export function finalizeUnifiedCollector(ctx: CodegenContext, state: UnifiedColl
   for (const method of state.promiseNeeded) {
     if (method === "then" || method === "catch" || method === "finally") continue;
     if (ctx.wasi && (method === "resolve" || method === "reject")) continue;
+    // (#2867 Gap 4) Under the native-`$Promise` carrier, `Promise.all`/`Promise.race`
+    // over an array literal lower to the host-free native combinator (no host
+    // import). Skip the unsatisfiable `Promise_all`/`Promise_race` pre-registration
+    // here; the host path (generic iterables / subclass receivers) still
+    // lazily `ensureLateImport`s it at the call site when actually needed.
+    if (isStandalonePromiseActive(ctx) && (method === "all" || method === "race")) continue;
     const importName = `Promise_${method}`;
     if (!ctx.funcMap.has(importName)) {
       const isAggregator = method === "all" || method === "race" || method === "allSettled" || method === "any";

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -147,6 +147,7 @@ import { tryCompileNodeFsCall, tryCompileNodeProcessCall } from "../node-fs-api.
 import { tryCompileDenoStdioCall } from "../deno-api.js";
 import { tryCompileRawWasiCall } from "../raw-wasi-api.js";
 import { resolvePromiseSubclassName, tryEmitPromiseSubclassReceiver } from "./promise-subclass.js";
+import { emitStandalonePromiseCombinator, isNativeCombinatorMethod } from "../promise-combinators.js";
 import { isSupportedBuiltinStaticProperty, resolveBuiltinNamespaceValueName } from "../builtin-static-globals.js";
 import {
   defaultValueInstrs,
@@ -8515,6 +8516,37 @@ function compileCallExpression(
         (propAccess.name.text === "resolve" || propAccess.name.text === "reject");
       if (isAggregator) {
         const methodName = propAccess.name.text;
+        // (#2867 Gap 4) Native host-free `Promise.all`/`Promise.race` over an
+        // array literal under the native-`$Promise` carrier. Gated on
+        // `isStandalonePromiseActive` (wasi-only today → widens to standalone at
+        // slice 1d), so gc/host + still-host-backed standalone lanes are
+        // byte-unchanged. Only the literal, no-spread, non-subclass form is
+        // intercepted; `allSettled`/`any`, generic iterables, and subclass
+        // capability-ctor receivers fall through to the host path (follow-ups).
+        const arg0 = expr.arguments[0];
+        if (
+          isStandalonePromiseActive(ctx) &&
+          isNativeCombinatorMethod(methodName) &&
+          !isPromiseSubclassReceiver &&
+          expr.arguments.length === 1 &&
+          arg0 !== undefined &&
+          ts.isArrayLiteralExpression(arg0) &&
+          arg0.elements.every((el) => !ts.isSpreadElement(el) && !ts.isOmittedExpression(el))
+        ) {
+          const elementInstrs: Instr[][] = [];
+          for (const el of arg0.elements) {
+            const buf: Instr[] = [];
+            const savedBody = fctx.body;
+            fctx.body = buf;
+            try {
+              compileExpression(ctx, fctx, el, { kind: "externref" });
+            } finally {
+              fctx.body = savedBody;
+            }
+            elementInstrs.push(buf);
+          }
+          return emitStandalonePromiseCombinator(ctx, fctx, methodName, elementInstrs);
+        }
         const importName = `Promise_${methodName}`;
         // Three-arg signature: (thisArg, iterable, directCall) → result
         // (#1116) directCall=1 means "no explicit `.call` was used; default to

--- a/src/codegen/promise-combinators.ts
+++ b/src/codegen/promise-combinators.ts
@@ -1,0 +1,479 @@
+// (#2867 Gap 4) Native, host-free `Promise.all` / `Promise.race` combinators.
+//
+// Under the native-`$Promise` carrier (`isStandalonePromiseActive`, today
+// `--target wasi`; widens to `--target standalone` at the #2895 slice-1d gate),
+// `Promise.all([...])` / `Promise.race([...])` must NOT leak the `Promise_all` /
+// `Promise_race` host imports (unsatisfiable with no JS host). This module emits
+// the combinators directly on the existing carrier substrate
+// (`async-scheduler.ts`): the `$Promise` struct, the `$PromiseCallback` reaction
+// node, the microtask ring, and the one-shot `__promise_fulfill`/`__promise_reject`
+// settle helpers. It forks NOTHING — it composes the same primitives the native
+// `.then` machinery and the #2895 async drive layer already use.
+//
+// Scope (this slice): the **array-literal** argument form — `Promise.all([a, b])`
+// — which is the dominant test262 shape and statically gives the element count.
+// Non-literal iterables (`Promise.all(genericIterable)`) and the `allSettled` /
+// `any` combinators (which additionally need per-element status objects /
+// `AggregateError`) fall through to the existing host path and are follow-ups.
+//
+// **Inert until the widen.** Every emission site is gated on
+// `isStandalonePromiseActive(ctx)`, which is `ctx.wasi`-only today, so the
+// default gc/host lane AND the still-host-backed `--target standalone` lane are
+// byte-identical. The combinator becomes live for standalone only when slice 1d
+// widens the carrier gate (together with all other carrier gaps), never piecemeal
+// (the AG0 −31 / #2367-graveyard lesson).
+
+import type { CodegenContext, FunctionContext } from "./context/types.js";
+import type { Instr, LocalDef, ValType } from "../ir/types.js";
+import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
+import { allocLocal } from "./context/locals.js";
+import {
+  ensureAsyncDriveRuntime,
+  getOrRegisterPromiseType,
+  PROMISE_STATE_FULFILLED,
+  PROMISE_STATE_PENDING,
+  PROMISE_STATE_REJECTED,
+} from "./async-scheduler.js";
+
+const EXTERNREF: ValType = { kind: "externref" };
+
+type AsyncDriveRuntimeT = ReturnType<typeof ensureAsyncDriveRuntime>;
+
+/** The combinators this module lowers natively. `allSettled`/`any` are deferred. */
+export type NativeCombinator = "all" | "race";
+
+export function isNativeCombinatorMethod(method: string): method is NativeCombinator {
+  return method === "all" || method === "race";
+}
+
+interface CombinatorRuntime {
+  /** `$CombinatorState { resultPromise: ref $Promise, resultsArr: ref $arr_ext, length: i32, remaining (mut) i32 }`. */
+  stateTypeIdx: number;
+  /** `$CombinatorElemCaps { state: ref $CombinatorState, index: i32 }`. */
+  elemCapsTypeIdx: number;
+  /** `$Promise` struct typeIdx. */
+  promiseTypeIdx: number;
+  /** externref vec struct typeIdx (the `Promise.all` result array wrapper). */
+  vecTypeIdx: number;
+  /** backing externref array typeIdx (inside the vec). */
+  arrTypeIdx: number;
+  /** `__combinator_subscribe(input, state, index, fulfillFn, rejectFn) -> void`. */
+  subscribeFuncIdx: number;
+  /** `__combinator_all_fulfill(caps, value) -> value`. */
+  allFulfillFuncIdx: number;
+  /** `__combinator_race_fulfill(caps, value) -> value`. */
+  raceFulfillFuncIdx: number;
+  /** `__combinator_reject(caps, reason) -> reason` (shared all/race). */
+  rejectFuncIdx: number;
+}
+
+type CtxWithCombinators = CodegenContext & { __promiseCombinators?: CombinatorRuntime };
+
+function registerStruct(
+  ctx: CodegenContext,
+  name: string,
+  fields: { name: string; type: ValType; mutable: boolean }[],
+): number {
+  const typeIdx = ctx.mod.types.length;
+  ctx.mod.types.push({ kind: "struct", name, fields });
+  // Mirror the bookkeeping $Promise does so the verifier/walker resolve by name.
+  ctx.structMap.set(name, typeIdx);
+  ctx.typeIdxToStructName.set(typeIdx, name);
+  ctx.structFields.set(
+    name,
+    fields.map((f) => ({ name: f.name, type: f.type, mutable: f.mutable })),
+  );
+  return typeIdx;
+}
+
+/**
+ * Idempotently register the combinator state/caps struct types and the four
+ * shared runtime helpers, reserving their funcIdx slots up-front (the generator
+ * slot-reservation discipline — a late funcIdx assignment would shift the
+ * indices the call-site `ref.func`s bake in; #1677/#1809/#1899).
+ */
+export function ensureCombinatorFunctions(ctx: CodegenContext): CombinatorRuntime {
+  const cached = (ctx as CtxWithCombinators).__promiseCombinators;
+  if (cached) return cached;
+
+  // The async-drive runtime (Promise type, reaction node, microtask ring, settle
+  // helpers) MUST be registered first — it appends functions, which would shift
+  // our reserved slots if done after. ensureAsyncDriveRuntime is idempotent.
+  const rt = ensureAsyncDriveRuntime(ctx);
+  const promiseTypeIdx = getOrRegisterPromiseType(ctx);
+  const vecTypeIdx = getOrRegisterVecType(ctx, "externref", EXTERNREF);
+  const arrTypeIdx = getArrTypeIdxFromVec(ctx, vecTypeIdx);
+
+  const stateTypeIdx = registerStruct(ctx, "$CombinatorState", [
+    { name: "resultPromise", type: { kind: "ref", typeIdx: promiseTypeIdx }, mutable: false },
+    { name: "resultsArr", type: { kind: "ref", typeIdx: arrTypeIdx }, mutable: false },
+    { name: "length", type: { kind: "i32" }, mutable: false },
+    { name: "remaining", type: { kind: "i32" }, mutable: true },
+  ]);
+  const elemCapsTypeIdx = registerStruct(ctx, "$CombinatorElemCaps", [
+    { name: "state", type: { kind: "ref", typeIdx: stateTypeIdx }, mutable: false },
+    { name: "index", type: { kind: "i32" }, mutable: false },
+  ]);
+
+  // Func types. The fulfill/reject wrappers share the microtask wrapper shape
+  // `(caps externref, value externref) -> externref` (addFuncType dedups, so this
+  // resolves to the existing `$__mt_func_type`). subscribe is void-returning.
+  const wrapperTypeIdx = addFuncType(ctx, [EXTERNREF, EXTERNREF], [EXTERNREF]);
+  const subscribeTypeIdx = addFuncType(
+    ctx,
+    [EXTERNREF, EXTERNREF, { kind: "i32" }, { kind: "funcref" }, { kind: "funcref" }],
+    [],
+  );
+
+  const base = ctx.numImportFuncs + ctx.mod.functions.length;
+  const subscribeFuncIdx = base;
+  const allFulfillFuncIdx = base + 1;
+  const raceFulfillFuncIdx = base + 2;
+  const rejectFuncIdx = base + 3;
+
+  const ids: CombinatorRuntime = {
+    stateTypeIdx,
+    elemCapsTypeIdx,
+    promiseTypeIdx,
+    vecTypeIdx,
+    arrTypeIdx,
+    subscribeFuncIdx,
+    allFulfillFuncIdx,
+    raceFulfillFuncIdx,
+    rejectFuncIdx,
+  };
+
+  ctx.mod.functions.push({
+    name: "__combinator_subscribe",
+    typeIdx: subscribeTypeIdx,
+    locals: buildSubscribeLocals(promiseTypeIdx),
+    body: buildSubscribeBody(ids, rt),
+    exported: false,
+  });
+  ctx.funcMap.set("__combinator_subscribe", subscribeFuncIdx);
+
+  ctx.mod.functions.push({
+    name: "__combinator_all_fulfill",
+    typeIdx: wrapperTypeIdx,
+    locals: buildAllFulfillLocals(ids),
+    body: buildAllFulfillBody(ids, rt),
+    exported: false,
+  });
+  ctx.funcMap.set("__combinator_all_fulfill", allFulfillFuncIdx);
+
+  ctx.mod.functions.push({
+    name: "__combinator_race_fulfill",
+    typeIdx: wrapperTypeIdx,
+    locals: buildSettleWrapperLocals(ids),
+    body: buildRaceFulfillBody(ids, rt),
+    exported: false,
+  });
+  ctx.funcMap.set("__combinator_race_fulfill", raceFulfillFuncIdx);
+
+  ctx.mod.functions.push({
+    name: "__combinator_reject",
+    typeIdx: wrapperTypeIdx,
+    locals: buildSettleWrapperLocals(ids),
+    body: buildRejectBody(ids, rt),
+    exported: false,
+  });
+  ctx.funcMap.set("__combinator_reject", rejectFuncIdx);
+
+  (ctx as CtxWithCombinators).__promiseCombinators = ids;
+  return ids;
+}
+
+// ── __combinator_subscribe ───────────────────────────────────────────────────
+// params: 0 input externref, 1 state externref, 2 index i32, 3 fulfillFn funcref,
+//         4 rejectFn funcref. locals: 5 p (ref $Promise), 6 caps externref.
+
+function buildSubscribeLocals(promiseTypeIdx: number): LocalDef[] {
+  return [
+    { name: "$p", type: { kind: "ref", typeIdx: promiseTypeIdx } },
+    { name: "$caps", type: EXTERNREF },
+  ];
+}
+
+function buildSubscribeBody(ids: CombinatorRuntime, rt: AsyncDriveRuntimeT): Instr[] {
+  const INPUT = 0;
+  const STATE = 1;
+  const INDEX = 2;
+  const FULFILL_FN = 3;
+  const REJECT_FN = 4;
+  const P = 5;
+  const CAPS = 6;
+  const cbTypeIdx = rt.callbackTypeIdx;
+  return [
+    // Normalize `input` to a `$Promise`. A native `$Promise` passes through; any
+    // other value is wrapped in a synchronously-FULFILLED `$Promise` so the
+    // dispatch below is uniform (mirrors spec PromiseResolve for a non-thenable).
+    { op: "local.get", index: INPUT },
+    { op: "any.convert_extern" },
+    { op: "ref.test", typeIdx: ids.promiseTypeIdx } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: INPUT },
+        { op: "any.convert_extern" },
+        { op: "ref.cast", typeIdx: ids.promiseTypeIdx } as Instr,
+        { op: "local.set", index: P },
+      ],
+      else: [
+        { op: "i32.const", value: PROMISE_STATE_FULFILLED },
+        { op: "local.get", index: INPUT },
+        { op: "ref.null.extern" },
+        { op: "struct.new", typeIdx: ids.promiseTypeIdx } as Instr,
+        { op: "local.set", index: P },
+      ],
+    } as Instr,
+
+    // caps = $CombinatorElemCaps{ state, index } (boxed to externref).
+    { op: "local.get", index: STATE },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: ids.stateTypeIdx } as Instr,
+    { op: "local.get", index: INDEX },
+    { op: "struct.new", typeIdx: ids.elemCapsTypeIdx } as Instr,
+    { op: "extern.convert_any" },
+    { op: "local.set", index: CAPS },
+
+    // Dispatch on the (possibly already-settled) promise state.
+    { op: "local.get", index: P },
+    { op: "struct.get", typeIdx: ids.promiseTypeIdx, fieldIdx: 0 } as Instr,
+    { op: "i32.const", value: PROMISE_STATE_FULFILLED },
+    { op: "i32.eq" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        // enqueue(fulfillFn, caps, p.value)
+        { op: "local.get", index: FULFILL_FN },
+        { op: "local.get", index: CAPS },
+        { op: "local.get", index: P },
+        { op: "struct.get", typeIdx: ids.promiseTypeIdx, fieldIdx: 1 } as Instr,
+        { op: "call", funcIdx: rt.enqueueFuncIdx },
+      ],
+      else: [
+        { op: "local.get", index: P },
+        { op: "struct.get", typeIdx: ids.promiseTypeIdx, fieldIdx: 0 } as Instr,
+        { op: "i32.const", value: PROMISE_STATE_REJECTED },
+        { op: "i32.eq" },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            // enqueue(rejectFn, caps, p.value)
+            { op: "local.get", index: REJECT_FN },
+            { op: "local.get", index: CAPS },
+            { op: "local.get", index: P },
+            { op: "struct.get", typeIdx: ids.promiseTypeIdx, fieldIdx: 1 } as Instr,
+            { op: "call", funcIdx: rt.enqueueFuncIdx },
+          ],
+          else: [
+            // pending: prepend a reaction node onto p.callbacks.
+            { op: "local.get", index: P },
+            { op: "local.get", index: FULFILL_FN },
+            { op: "local.get", index: CAPS },
+            { op: "local.get", index: REJECT_FN },
+            { op: "local.get", index: CAPS },
+            { op: "local.get", index: P },
+            { op: "struct.get", typeIdx: ids.promiseTypeIdx, fieldIdx: 2 } as Instr,
+            { op: "struct.new", typeIdx: cbTypeIdx } as Instr,
+            { op: "extern.convert_any" },
+            { op: "struct.set", typeIdx: ids.promiseTypeIdx, fieldIdx: 2 } as Instr,
+          ],
+        } as Instr,
+      ],
+    } as Instr,
+  ];
+}
+
+// ── __combinator_all_fulfill ─────────────────────────────────────────────────
+// params: 0 caps externref, 1 value externref.
+// locals: 2 c (ref $CombinatorElemCaps), 3 st (ref $CombinatorState), 4 rem i32.
+
+function buildAllFulfillLocals(ids: CombinatorRuntime): LocalDef[] {
+  return [
+    { name: "$c", type: { kind: "ref", typeIdx: ids.elemCapsTypeIdx } },
+    { name: "$st", type: { kind: "ref", typeIdx: ids.stateTypeIdx } },
+    { name: "$rem", type: { kind: "i32" } },
+  ];
+}
+
+function buildAllFulfillBody(ids: CombinatorRuntime, rt: AsyncDriveRuntimeT): Instr[] {
+  const CAPS = 0;
+  const VALUE = 1;
+  const C = 2;
+  const ST = 3;
+  const REM = 4;
+  return [
+    { op: "local.get", index: CAPS },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: ids.elemCapsTypeIdx } as Instr,
+    { op: "local.set", index: C },
+    { op: "local.get", index: C },
+    { op: "struct.get", typeIdx: ids.elemCapsTypeIdx, fieldIdx: 0 } as Instr,
+    { op: "local.set", index: ST },
+
+    // results[index] = value
+    { op: "local.get", index: ST },
+    { op: "struct.get", typeIdx: ids.stateTypeIdx, fieldIdx: 1 } as Instr,
+    { op: "local.get", index: C },
+    { op: "struct.get", typeIdx: ids.elemCapsTypeIdx, fieldIdx: 1 } as Instr,
+    { op: "local.get", index: VALUE },
+    { op: "array.set", typeIdx: ids.arrTypeIdx } as Instr,
+
+    // remaining -= 1
+    { op: "local.get", index: ST },
+    { op: "local.get", index: ST },
+    { op: "struct.get", typeIdx: ids.stateTypeIdx, fieldIdx: 3 } as Instr,
+    { op: "i32.const", value: 1 },
+    { op: "i32.sub" },
+    { op: "local.tee", index: REM },
+    { op: "struct.set", typeIdx: ids.stateTypeIdx, fieldIdx: 3 } as Instr,
+
+    // if remaining == 0: fulfill the result promise with the results vec.
+    { op: "local.get", index: REM },
+    { op: "i32.eqz" },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: ST },
+        { op: "struct.get", typeIdx: ids.stateTypeIdx, fieldIdx: 0 } as Instr,
+        // vec = struct.new $vec(length, resultsArr)
+        { op: "local.get", index: ST },
+        { op: "struct.get", typeIdx: ids.stateTypeIdx, fieldIdx: 2 } as Instr,
+        { op: "local.get", index: ST },
+        { op: "struct.get", typeIdx: ids.stateTypeIdx, fieldIdx: 1 } as Instr,
+        { op: "struct.new", typeIdx: ids.vecTypeIdx } as Instr,
+        { op: "extern.convert_any" },
+        { op: "call", funcIdx: rt.fulfillFuncIdx },
+        { op: "drop" },
+      ],
+    } as Instr,
+
+    { op: "local.get", index: VALUE },
+  ];
+}
+
+// ── __combinator_race_fulfill / __combinator_reject ──────────────────────────
+// params: 0 caps externref, 1 value externref. locals: 2 c, 3 st.
+
+function buildSettleWrapperLocals(ids: CombinatorRuntime): LocalDef[] {
+  return [
+    { name: "$c", type: { kind: "ref", typeIdx: ids.elemCapsTypeIdx } },
+    { name: "$st", type: { kind: "ref", typeIdx: ids.stateTypeIdx } },
+  ];
+}
+
+function buildSettleResultBody(ids: CombinatorRuntime, settleFuncIdx: number): Instr[] {
+  const CAPS = 0;
+  const VALUE = 1;
+  const C = 2;
+  const ST = 3;
+  // Settle (fulfill for race, reject for both all & race) the shared result
+  // promise with `value`. Settlement is one-shot, so a second settle no-ops —
+  // exactly the "first wins" (race) / "first rejection wins" (all) semantics.
+  return [
+    { op: "local.get", index: CAPS },
+    { op: "any.convert_extern" },
+    { op: "ref.cast", typeIdx: ids.elemCapsTypeIdx } as Instr,
+    { op: "local.set", index: C },
+    { op: "local.get", index: C },
+    { op: "struct.get", typeIdx: ids.elemCapsTypeIdx, fieldIdx: 0 } as Instr,
+    { op: "local.set", index: ST },
+    { op: "local.get", index: ST },
+    { op: "struct.get", typeIdx: ids.stateTypeIdx, fieldIdx: 0 } as Instr,
+    { op: "local.get", index: VALUE },
+    { op: "call", funcIdx: settleFuncIdx },
+    // __promise_fulfill/__promise_reject return the settled value — that is the
+    // wrapper's externref result, so leave it on the stack.
+  ];
+}
+
+function buildRaceFulfillBody(ids: CombinatorRuntime, rt: AsyncDriveRuntimeT): Instr[] {
+  return buildSettleResultBody(ids, rt.fulfillFuncIdx);
+}
+
+function buildRejectBody(ids: CombinatorRuntime, rt: AsyncDriveRuntimeT): Instr[] {
+  return buildSettleResultBody(ids, rt.rejectFuncIdx);
+}
+
+/**
+ * Emit a native `Promise.all([...])` / `Promise.race([...])`. `elementInstrs` is
+ * the pre-compiled list of element expressions (each already coerced to
+ * externref). Leaves the aggregate result `$Promise` on the stack as externref.
+ */
+export function emitStandalonePromiseCombinator(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  method: NativeCombinator,
+  elementInstrs: Instr[][],
+): ValType {
+  const ids = ensureCombinatorFunctions(ctx);
+  const rt = ensureAsyncDriveRuntime(ctx);
+  const n = elementInstrs.length;
+
+  const resultLocal = allocLocal(fctx, `__comb_result_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: ids.promiseTypeIdx,
+  });
+  const arrLocal = allocLocal(fctx, `__comb_arr_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: ids.arrTypeIdx,
+  });
+  const stateLocal = allocLocal(fctx, `__comb_state_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: ids.stateTypeIdx,
+  });
+
+  // Pending result promise.
+  fctx.body.push({ op: "i32.const", value: PROMISE_STATE_PENDING });
+  fctx.body.push({ op: "ref.null.extern" });
+  fctx.body.push({ op: "ref.null.extern" });
+  fctx.body.push({ op: "struct.new", typeIdx: ids.promiseTypeIdx } as Instr);
+  fctx.body.push({ op: "local.set", index: resultLocal });
+
+  // Backing results array (only meaningful for `all`; `race` ignores it).
+  fctx.body.push({ op: "i32.const", value: n });
+  fctx.body.push({ op: "array.new_default", typeIdx: ids.arrTypeIdx } as Instr);
+  fctx.body.push({ op: "local.set", index: arrLocal });
+
+  // $CombinatorState{ resultPromise, resultsArr, length=n, remaining=n }.
+  fctx.body.push({ op: "local.get", index: resultLocal });
+  fctx.body.push({ op: "local.get", index: arrLocal });
+  fctx.body.push({ op: "i32.const", value: n });
+  fctx.body.push({ op: "i32.const", value: n });
+  fctx.body.push({ op: "struct.new", typeIdx: ids.stateTypeIdx } as Instr);
+  fctx.body.push({ op: "local.set", index: stateLocal });
+
+  if (n === 0) {
+    // `Promise.all([])` fulfills immediately with an empty array. `Promise.race([])`
+    // stays pending forever (spec) — emit nothing.
+    if (method === "all") {
+      fctx.body.push({ op: "local.get", index: resultLocal });
+      fctx.body.push({ op: "i32.const", value: 0 });
+      fctx.body.push({ op: "local.get", index: arrLocal });
+      fctx.body.push({ op: "struct.new", typeIdx: ids.vecTypeIdx } as Instr);
+      fctx.body.push({ op: "extern.convert_any" });
+      fctx.body.push({ op: "call", funcIdx: rt.fulfillFuncIdx });
+      fctx.body.push({ op: "drop" });
+    }
+  } else {
+    const fulfillFn = method === "all" ? ids.allFulfillFuncIdx : ids.raceFulfillFuncIdx;
+    for (let i = 0; i < n; i++) {
+      for (const instr of elementInstrs[i]!) fctx.body.push(instr);
+      fctx.body.push({ op: "local.get", index: stateLocal });
+      fctx.body.push({ op: "extern.convert_any" });
+      fctx.body.push({ op: "i32.const", value: i });
+      fctx.body.push({ op: "ref.func", funcIdx: fulfillFn } as Instr);
+      fctx.body.push({ op: "ref.func", funcIdx: ids.rejectFuncIdx } as Instr);
+      fctx.body.push({ op: "call", funcIdx: ids.subscribeFuncIdx });
+    }
+  }
+
+  fctx.body.push({ op: "local.get", index: resultLocal });
+  fctx.body.push({ op: "extern.convert_any" });
+  return EXTERNREF;
+}

--- a/tests/issue-2867-gap4.test.ts
+++ b/tests/issue-2867-gap4.test.ts
@@ -1,0 +1,121 @@
+// #2867 Gap 4 — native, host-free `Promise.all` / `Promise.race` combinators on
+// the native-`$Promise` carrier (`isStandalonePromiseActive`, wasi-only today →
+// widens to standalone at #2895 slice 1d). Currently `Promise.all`/`race` leak
+// the unsatisfiable `Promise_all`/`Promise_race` host imports even on the carrier
+// target; these lower to the existing `$Promise` + reaction + microtask substrate
+// instead — composing the same primitives the native `.then` machinery uses.
+//
+// Host-free: instantiate with no imports and drive settlement with the module's
+// own `__drain_microtasks` export — the test262 `asyncTest(fn)` shape.
+//
+// Inert on gc/host + still-host-backed standalone lanes (the gate is wasi-only).
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runWasi(body: string, reads: string[]): Promise<Record<string, number>> {
+  const src = `
+let ff = 0;
+let rj = 0;
+let val = 0;
+${body}
+export function getFf(): number { return ff; }
+export function getRj(): number { return rj; }
+export function getVal(): number { return val; }
+`;
+  const r = await compile(src, { fileName: "t.ts", target: "wasi" });
+  expect(r.success, r.success ? "" : `CE: ${r.errors?.[0]?.message}`).toBe(true);
+  // The carrier is host-free under wasi: the native combinators must request no imports.
+  expect((r.imports ?? []).map((i) => `${i.module}.${i.name}`)).toEqual([]);
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const ex = instance.exports as Record<string, CallableFunction>;
+  ex.run!();
+  ex.__drain_microtasks?.();
+  const out: Record<string, number> = {};
+  for (const n of reads) out[n] = ex[n]!() as number;
+  return out;
+}
+
+describe("#2867 Gap 4 — native Promise.all/race (wasi carrier)", () => {
+  it("Promise.all over already-fulfilled promises fulfils with the values array", async () => {
+    const r = await runWasi(
+      `
+      export function run(): void {
+        Promise.all([Promise.resolve(1), Promise.resolve(2)])
+          .then((arr: any[]) => { val = arr[0] + arr[1]; }, (e: number) => { rj = -1; });
+      }
+      `,
+      ["getVal", "getRj"],
+    );
+    expect(r).toEqual({ getVal: 3, getRj: 0 });
+  });
+
+  it("Promise.all rejects as soon as one input rejects", async () => {
+    const r = await runWasi(
+      `
+      export function run(): void {
+        Promise.all([Promise.resolve(1), Promise.reject(9)])
+          .then((arr: any[]) => { ff = 1; }, (e: number) => { rj = e; });
+      }
+      `,
+      ["getFf", "getRj"],
+    );
+    expect(r).toEqual({ getFf: 0, getRj: 9 });
+  });
+
+  it("Promise.all([]) fulfils immediately", async () => {
+    const r = await runWasi(
+      `
+      export function run(): void {
+        Promise.all([]).then((arr: any[]) => { ff = 1; }, (e: number) => { rj = -1; });
+      }
+      `,
+      ["getFf", "getRj"],
+    );
+    expect(r).toEqual({ getFf: 1, getRj: 0 });
+  });
+
+  it("Promise.all waits for genuinely-pending inputs before fulfilling", async () => {
+    // Both inputs settle only on a later microtask (via .then), so the aggregate
+    // must suspend and resume across the drain — the case the host import cannot
+    // serve host-free.
+    const r = await runWasi(
+      `
+      export function run(): void {
+        Promise.all([
+          Promise.resolve(1).then((v: number) => v + 10),
+          Promise.resolve(2).then((v: number) => v + 20),
+        ]).then((arr: any[]) => { val = arr[0] + arr[1]; }, (e: number) => { rj = -1; });
+      }
+      `,
+      ["getVal", "getRj"],
+    );
+    expect(r).toEqual({ getVal: 33, getRj: 0 });
+  });
+
+  it("Promise.race fulfils with the first settled value", async () => {
+    const r = await runWasi(
+      `
+      export function run(): void {
+        Promise.race([Promise.resolve(5), Promise.resolve(6)])
+          .then((v: number) => { val = v; }, (e: number) => { rj = -1; });
+      }
+      `,
+      ["getVal", "getRj"],
+    );
+    expect(r).toEqual({ getVal: 5, getRj: 0 });
+  });
+
+  it("Promise.race rejects when the first settled input rejects", async () => {
+    const r = await runWasi(
+      `
+      export function run(): void {
+        Promise.race([Promise.reject(7), Promise.resolve(6)])
+          .then((v: number) => { ff = 1; }, (e: number) => { rj = e; });
+      }
+      `,
+      ["getFf", "getRj"],
+    );
+    expect(r).toEqual({ getFf: 0, getRj: 7 });
+  });
+});


### PR DESCRIPTION
## Gap 4 of the standalone async unlock (#2867)

Native, host-free **`Promise.all`** / **`Promise.race`** over an array literal,
lowered onto the existing native-`$Promise` carrier substrate instead of leaking
the unsatisfiable `Promise_all` / `Promise_race` host imports on the carrier
target. Forks nothing — composes the same `$Promise` struct + `$PromiseCallback`
reaction node + microtask ring + `__promise_fulfill`/`__promise_reject` settle
helpers the native `.then` machinery and the #2895 drive layer already use.

### What landed
- **`src/codegen/promise-combinators.ts`** (new): `$CombinatorState` /
  `$CombinatorElemCaps` struct types + four funcIdx-reserved runtime helpers
  (`__combinator_subscribe`, `__combinator_all_fulfill`, `__combinator_race_fulfill`,
  `__combinator_reject`).
- **`expressions/calls.ts`**: aggregator call-site emits the native combinator for
  the literal, no-spread, non-subclass form under the carrier; everything else
  falls through to the host path.
- **`declarations.ts`**: skip the `Promise_all`/`Promise_race` host-import
  pre-registration under the carrier (host path still lazily `ensureLateImport`s
  for genuine non-native uses).

### Gating / inertness
All sites gated on `isStandalonePromiseActive` (**`--target wasi` only today**;
widens to `--target standalone` at #2895 slice 1d, never piecemeal — the
#2367-graveyard lesson). Proven byte-identical base-vs-branch on the non-carrier
lanes: gc/host `691d10aac350c024`, `--target standalone` `43d3f001a1be11aa`. Only
the wasi carrier lane changes.

### Tests
`tests/issue-2867-gap4.test.ts` (host-free wasi — `result.imports` empty,
`WebAssembly.validate` true — driven by the module's own `__drain_microtasks`):
all-fulfil (values array), all-reject (first rejection), `all([])` immediate
fulfil, **genuinely-pending all** (inputs settle only on a later microtask →
aggregate suspends and resumes across the drain), race-fulfil (first wins),
race-reject. All green; typecheck clean.

### Scope deferred (follow-ups, inert)
`allSettled` (per-element status objects) / `any` (`AggregateError`); the
generic-iterable (non-literal) argument form; subclass capability-ctor receivers.

Part of #2867. Gaps 3/5 + the runner drain-hook + the slice-1d widen (measured
net-positive on the full `merge_group` standalone corpus, after #2402 — now
landed) remain as follow-on slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)