### PR TITLE
feat(#2895): __drain_microtasks intrinsic + test262 runner hook (1d-scaffolding, inert)

### DIFF
--- a/plan/issues/2895-standalone-await-frame-suspension.md
+++ b/plan/issues/2895-standalone-await-frame-suspension.md
@@ -181,7 +181,7 @@ premature widen is the AG0 −31 regression — do NOT repeat it).
 ### Slice 1a — frame-layout foundation (THIS PR, inert / zero-risk)
 
 - `src/codegen/async-frame.ts` (new): `isAsyncDriveActive(ctx)` (standalone||wasi
-  drive-layer gate, distinct from the `isStandalonePromiseActive` *carrier*
+  drive-layer gate, distinct from the `isStandalonePromiseActive` _carrier_
   gate), `AsyncFrameInfo` (satisfies frame-core `FrameLayout`), and
   `buildAsyncFrameInfo(...)` which registers the per-async-fn `$AsyncFrame_<name>`
   state struct: fixed frame ABI fields (`STATE` i32, `SENT`/`ABRUPT`/`ERROR`
@@ -206,32 +206,32 @@ premature widen is the AG0 −31 regression — do NOT repeat it).
 ### Remaining slices (next sessions, build order)
 
 1b. **resume fn + step adapters + settle** — `ensureAsyncResumeFunction(info)`
-    builds `__async_resume_f<name>(frame)` with the generator slot-reservation
-    funcIdx-stability idiom (reserve placeholder slot BEFORE body emit). For the
-    single-await canonical shape it is a 2-state machine: `br_table` over
-    `STATE_FIELD` → seg0 (entry: prefix + awaited-expr assimilate → if FULFILLED
-    set SENT and fall through, else `storeSpills` + set STATE=1 + register a
-    `$PromiseCallback{__async_step_fulfill_f<name>, frame, __async_step_reject_f
+builds `__async_resume_f<name>(frame)` with the generator slot-reservation
+funcIdx-stability idiom (reserve placeholder slot BEFORE body emit). For the
+single-await canonical shape it is a 2-state machine: `br_table` over
+`STATE_FIELD` → seg0 (entry: prefix + awaited-expr assimilate → if FULFILLED
+set SENT and fall through, else `storeSpills` + set STATE=1 + register a
+`$PromiseCallback{__async_step_fulfill_f<name>, frame, __async_step_reject_f
     <name>, frame, next}` reaction on the awaited promise's callbacks + `return`)
-    → seg1 (continuation: bind `x = SENT`, suffix). `__async_step_*` adapters
-    store the settled value into `SENT`/`ERROR` then call resume. `return v` in
-    a resume body settles `frame.result_promise` via `__promise_fulfill` (new
-    `compileReturnStatement` hook keyed off a `fctx.asyncDriveResultLocal`,
-    mirroring the `fctx.isGenerator` arm); `throw e` → `__promise_reject`.
+→ seg1 (continuation: bind `x = SENT`, suffix). `__async_step_*` adapters
+store the settled value into `SENT`/`ERROR` then call resume. `return v` in
+a resume body settles `frame.result_promise` via `__promise_fulfill` (new
+`compileReturnStatement` hook keyed off a `fctx.asyncDriveResultLocal`,
+mirroring the `fctx.isGenerator` arm); `throw e` → `__promise_reject`.
 1c. **wire live + call-site + runner drain hook** — in `function-body.ts`, when
-    `isAsyncDriveActive(ctx) && asyncFnNeedsCps(...)`, alloc the frame (params
-    spilled), create the pending result `$Promise`, call `__async_resume_f` once
-    (runs seg0 to first real suspension), return the result promise. **Runner
-    drain hook** (`tests/test262-runner.ts`): for `flags:[async]`
-    standalone/wasi tests, drain `__drain_microtasks` after `test()` runs and
-    before reading `__fail` — REQUIRED for any harness credit (the trap AG0 fell
-    into). Verify-first on REAL failing test262 async paths (async-function/dstr,
-    class async methods, `Promise.all().then` chains, async-generator/dstr) via
-    the corpus `wrapTest`/`runTest262File(...,"standalone")`; require
-    NET-POSITIVE on the full `merge_group` standalone report.
+`isAsyncDriveActive(ctx) && asyncFnNeedsCps(...)`, alloc the frame (params
+spilled), create the pending result `$Promise`, call `__async_resume_f` once
+(runs seg0 to first real suspension), return the result promise. **Runner
+drain hook** (`tests/test262-runner.ts`): for `flags:[async]`
+standalone/wasi tests, drain `__drain_microtasks` after `test()` runs and
+before reading `__fail` — REQUIRED for any harness credit (the trap AG0 fell
+into). Verify-first on REAL failing test262 async paths (async-function/dstr,
+class async methods, `Promise.all().then` chains, async-generator/dstr) via
+the corpus `wrapTest`/`runTest262File(...,"standalone")`; require
+NET-POSITIVE on the full `merge_group` standalone report.
 1d. **re-widen carrier gates** — flip `isStandalonePromiseActive` +
-    `isStandaloneThenChainNativeActive` to include `ctx.standalone` TOGETHER,
-    only after 1c proves net-positive.
+`isStandaloneThenChainNativeActive` to include `ctx.standalone` TOGETHER,
+only after 1c proves net-positive.
 
 ### Slice 1b/1c — resume fn + live wiring (LANDED + VALIDATED on wasi)
 
@@ -243,7 +243,7 @@ carrier target (`--target wasi`, where the carrier gate is already on; the
   entry → assimilate awaited `$Promise`, FULFILLED → deliver `SENT` + fall
   through, PENDING → `storeSpills` + STATE=1 + register a `$PromiseCallback`
   reaction + `return`; continuation reads `SENT`), `__async_step_f<name>_{fulfill,
-  reject}` microtask adapters, and `emitAsyncFrameStateMachine` call-site shim
+reject}` microtask adapters, and `emitAsyncFrameStateMachine` call-site shim
   (alloc frame + pending result `$Promise`, kick resume once, return the promise).
   Uses the generator slot-reservation funcIdx-stability idiom.
 - `function-body.ts`: wires it for `isStandalonePromiseActive(ctx) && asyncFnNeedsCps`
@@ -254,6 +254,7 @@ carrier target (`--target wasi`, where the carrier gate is already on; the
 
 **Validated** (`tests/issue-2895-async-frame.test.ts`, all green, host-free —
 `result.imports` empty, `WebAssembly.validate` true):
+
 - FULFILLED fast path: `await g()` (sync-settled async fn) delivers the value.
 - chained drive-lowered async fns thread the value through both frames.
 - **GENUINELY-PENDING**: `await Promise.resolve(1).then(cb)` (pending until the
@@ -268,3 +269,32 @@ typed `(ref $Promise)` local once and reuse it.
 Remaining: **1d** — widen `isStandalonePromiseActive`/`isStandaloneThenChainNativeActive`
 to `standalone` + the runner `__drain_microtasks` hook for `flags:[async]` tests,
 measured NET-POSITIVE on the full `merge_group` standalone report.
+
+### Slice 1d-scaffolding — `__drain_microtasks` intrinsic + runner hook (LANDED, inert)
+
+sendev-carriergap4 2026-07-01. Rescued from the dormant `issue-2895-async-drive-1b`
+branch and shipped as its own small inert PR (de-risks the eventual 1d widen
+measurement — without a drain the `flags:[async]` harness can't observe a
+genuinely-pending async result, the AG0 score-0 trap):
+
+- `src/codegen/expressions.ts`: a `__drain_microtasks()` **compiler intrinsic** —
+  under the native-`$Promise` carrier (`isStandalonePromiseActive`, wasi-only
+  today) it lowers to the existing native `emitDrainMicrotasks`; on the gc/host
+  lane (no native microtask ring) and `--target standalone` (carrier not yet
+  widened) it is a **void no-op**, so those lanes stay byte-identical.
+- `tests/test262-runner.ts`: for `flags:[async]` / `needsAsyncTest` tests, declare
+  `__drain_microtasks` and call it after `test()` runs and before reading `__fail`.
+  Inert on the measured (gc + standalone) lanes — the intrinsic emits nothing
+  there; it only fires once 1d widens the carrier to standalone.
+
+Verified (`tests/issue-2895-drain-hook.test.ts`): an in-source `__drain_microtasks()`
+under wasi resumes a genuinely-pending continuation (→ 41); host-free
+(`result.imports` empty); a `--target standalone` `__drain_microtasks()` is a
+host-free void no-op. Existing carrier suites (`issue-2867-gap2`,
+`issue-2895-async-frame`, `async-await`) stay green; typecheck clean.
+
+**The slice-1d widen itself stays blocked** — it gates on the general multi-state
+CFG-aware CPS resume machine (Gaps 3/5 = try/finally-across-await + for-await/
+async-gen, which the single-await `splitBodyAtAwait` cannot express; tracked as a
+new XL substrate issue) landing AND the full `merge_group` standalone corpus
+measuring net-positive.

--- a/plan/issues/2906-async-drive-multistate-cfg-resume-machine.md
+++ b/plan/issues/2906-async-drive-multistate-cfg-resume-machine.md
@@ -1,0 +1,147 @@
+---
+id: 2906
+title: "Standalone: generalize the async drive layer → multi-state, CFG-aware CPS resume machine (unlocks try/finally-across-await, for-await, multi-await)"
+status: ready
+assignee: null
+created: 2026-07-01
+priority: high
+feasibility: hard
+task_type: feature
+area: codegen
+goal: standalone
+sprint: current
+horizon: xl
+related: [2895, 2867, 2864, 2865, 2367]
+umbrella: 2860
+architect_spec: authored
+---
+
+# Generalize the async drive layer to a multi-state CFG-aware CPS resume machine
+
+## Problem
+
+The landed host-free async **drive layer** (#2895 slices 1a–1c, PRs #2393/#2394)
+is **single-await by construction**. It only drives the three canonical shapes
+that `async-cps.ts splitBodyAtAwait` accepts and rejects everything else:
+
+```ts
+// src/codegen/async-cps.ts:594  splitBodyAtAwait(...)
+if (plan.awaitPoints.length !== 1) return null; // L596 — multiple awaits → reject
+if (plan.hasTryAcrossAwait) return null; // L597 — try/finally/catch around an await → reject
+// supported shapes only: `return await P` | `const x = await P; <rest>` | `await P; <rest>`
+```
+
+`asyncFnNeedsCps` (async-cps.ts:292) gates on `splitBodyAtAwait`, so an async
+function whose body has **any** richer control flow around an await — a
+`try/finally` across an await, a `for-await-of` loop, or simply two awaits — is
+**not driven**: it falls back to the synchronous AG0 one-level unwrap, which
+returns the pending `$Promise.value` (null/stale) for a genuinely-pending await.
+
+`async-frame.ts ensureAsyncResumeFunction` (L317) hard-codes a **2-state**
+machine (entry segment + single continuation) built from that single split — it
+has no finally-region routing, no loop back-edge, and no general br_table over N
+suspend points.
+
+This blocks the two remaining standalone-async carrier gaps and the count-move:
+
+- **Gap 3** (#2867) — `try/finally`-across-await: the finally region must run on
+  the normal continuation AND on the abrupt (throw / rejected-await / return) arms
+  after resume.
+- **Gap 5** (#2867) — `for-await-of` / async-generator drive: awaits iterated
+  inside a loop body (the AG2 generator/async-frame convergence).
+- multi-await-in-linear-code (`const a = await p; const b = await q; ...`).
+
+All three need the **same** thing: a general resume machine. They cannot each be
+bolted onto the 2-state machine as inert slices without re-deriving the same
+generalization three times (a partial machine strands — the #2367 graveyard). So
+this is one XL substrate issue that **unlocks Gap 3 + Gap 5 + multi-await
+together**, after which those become bounded slices and the slice-1d carrier
+widen can finally be measured.
+
+## Root cause / design (the general machine)
+
+Replace the single-await `splitBodyAtAwait` + 2-state resume with a **CFG-numbered
+multi-state** lowering, reusing the existing substrate (do NOT fork it):
+
+1. **Suspend-point numbering.** Walk the async body and assign each `await` (and
+   each loop-iteration await) a distinct **state id**. State 0 = entry. The body
+   is lowered into a `br_table` over `frame.STATE_FIELD` (frame-core ABI), exactly
+   the dispatch shape `generators-native.ts ensureNativeGeneratorResumeFunction`
+   (L1781) already uses for `yield`. Reuse `frame-core.ts`
+   `setStateInstrs`/`storeSpills`/`defaultSpillInstr` verbatim; the `$AsyncFrame`
+   struct (`buildAsyncFrameInfo`) already carries `STATE`/`SENT`/`MODE`/`ABRUPT`/
+   `ERROR` + params + spills + `result_promise`.
+
+2. **Structured control flow → state transitions.** Lower the async body's
+   statement tree to segments split at each suspend point, preserving structure:
+   - **sequence**: segment N runs to the next await, suspends (storeSpills + set
+     STATE=N+1 + register reaction + return), resumes at segment N+1.
+   - **`try/finally`-across-await (Gap 3)**: the finally block is emitted as a
+     **shared finally region** reached from (a) the normal end of the try body and
+     (b) every abrupt completion that crosses it — a `throw` in the try, a
+     rejected-await (`MODE_THROW` arm, already wired by Gap 2), and a `return`
+     inside the try (route the `asyncDriveReturn` settle through finally first).
+     Model abrupt completion with the frame `MODE_FIELD`/`ABRUPT_FIELD`/`ERROR_FIELD`
+     (frame-core already defines them) — finally runs, then the pending completion
+     is replayed (re-throw / settle-return). `try/catch` is the same skeleton with
+     a catch target instead of/in addition to finally.
+   - **`for-await-of` / loops (Gap 5)**: a loop with an await in its body is a
+     back-edge in the state graph — the continuation after the body's await branches
+     back to the loop-head state. for-await-of additionally drives the async
+     iterator protocol (`[Symbol.asyncIterator]()` → `next()` returns a `$Promise`
+     of `{value,done}`), each `next()` await being a suspend point. Async generators
+     converge the `$Frame` (generators-native) and `$AsyncFrame` (async-frame) — the
+     AG2 convergence noted in #2895/#2865.
+
+3. **Settle / reject routing.** Reuse `async-scheduler.ts` `__promise_fulfill`/
+   `__promise_reject` + the microtask ring + `$PromiseCallback` reactions verbatim
+   (the same primitives Gap 1/2/4 already compose). The step adapters
+   (`__async_step_f<name>_{fulfill,reject}`) and the call-site shim
+   (`emitAsyncFrameStateMachine`) generalize from 2 states to N with no ABI change.
+
+## Hazards to spec against (cite in the build)
+
+- **funcIdx / type-index stability** (#1677/#1809/#1899): reserve the resume-fn +
+  step-adapter funcIdx slots with placeholder bodies BEFORE emitting the body —
+  `compileStatement` lazily appends helper functions. The N-segment body emits more
+  helpers than the 2-state machine, widening this window. Register all shared types
+  (`$Promise`, `$PromiseCallback`, `$AsyncFrame_<name>`) up-front.
+- **stack-balance type-repair** (#2895 codegen lesson): narrow an awaited
+  `$Promise` into a single typed `(ref $Promise)` local once; repeated
+  `local.get externref; any.convert_extern; ref.cast` confuses the repair pass.
+- **liveness across multiple awaits**: the spill set must include every local live
+  across ANY suspend point (union over states), not just one await's suffix
+  (`computeAsyncSpills` currently computes for the single split — generalize to the
+  CFG).
+- **carrier-gating + the −16/−29 corpus guard**: keep every new path gated on the
+  carrier (`isStandalonePromiseActive`, wasi-only until slice 1d) so gc/host and
+  still-host-backed standalone stay **byte-identical** (verify by binary hash, the
+  discipline Gap 4 / the drain-hook used). The slice-1d widen is a SEPARATE final
+  step, measured NET-POSITIVE on the full `merge_group` standalone corpus.
+
+## Suggested slicing (each inert, carrier-gated, independently mergeable)
+
+1. **multi-await-in-linear-code** — generalize numbering + br_table for ≥2
+   sequential awaits, no try/loop. Smallest validation of the N-state machine.
+2. **Gap 3 — try/finally-across-await** — add the shared finally region + abrupt
+   routing on the normal + reject + return arms.
+3. **Gap 5 — for-await-of** — loop back-edges + the async-iterator protocol drive.
+4. **Gap 5 — async generators** — the `$Frame`/`$AsyncFrame` AG2 convergence.
+5. **slice-1d widen** (owned by #2895/#2867) — widen `isStandalonePromiseActive` +
+   `isStandaloneThenChainNativeActive` to `standalone`, measured net-positive.
+
+## Predecessors (LANDED)
+
+Drive layer #2393/#2394 (async-frame.ts), carrier Gaps 1/2 (#2867), Gap 4 native
+combinators (#2867, PR #2403), the `__drain_microtasks` runner hook (#2895, PR
+#2404), the Test262Error native carrier (#2397), and the stored-`Promise<T>`
+consumption contract (#2402/#2905) are all on `main` — so the eventual widen sees
+the compounded async unlock.
+
+## Test plan
+
+Per slice, host-free wasi tests (`__drain_microtasks`, `result.imports` empty)
+covering the new shape, plus the byte-hash inertness proof (gc/host + standalone
+unchanged). The slice-1d widen is gated on the full `merge_group` standalone
+corpus (sr-pathb's 74-file async-function + the 150-sample for-await/async-gen/
+Promise.then/all cluster) measuring NET-POSITIVE — the authoritative gate.

--- a/src/codegen/expressions.ts
+++ b/src/codegen/expressions.ts
@@ -20,6 +20,7 @@ import {
   emitStandalonePromiseResolve,
   getOrRegisterPromiseType,
   isStandalonePromiseActive,
+  emitDrainMicrotasks,
   PROMISE_STATE_FULFILLED,
   PROMISE_STATE_REJECTED,
 } from "./async-scheduler.js";
@@ -1234,6 +1235,21 @@ function compileExpressionInner(
   }
 
   if (ts.isCallExpression(expr)) {
+    // (#2895 PATH B) `__drain_microtasks()` intrinsic — lets the test262 harness
+    // (and standalone entrypoints) pump the microtask ring so genuinely-pending
+    // async-frame continuations run before a settled value is observed. On the
+    // host-free targets it lowers to the native drain; on the JS-host target
+    // there is no native microtask ring (async is synchronous there), so it is a
+    // void no-op — keeping the gc lane byte-identical.
+    if (ts.isIdentifier(expr.expression) && expr.expression.text === "__drain_microtasks") {
+      // Gate on the native-`$Promise` CARRIER (not merely `isAsyncDriveActive`):
+      // emit the real drain only where the drive layer actually produces native
+      // promises. With the carrier `wasi`-only today, `--target standalone` and
+      // the gc lane get a void no-op (no microtask infra registered, output
+      // unchanged); the #2895-1d carrier re-widen auto-activates it for standalone.
+      if (isStandalonePromiseActive(ctx)) emitDrainMicrotasks(ctx, fctx);
+      return VOID_RESULT;
+    }
     const callStart = fctx.body.length;
     const callResult = compileCallExpression(ctx, fctx, expr, expectedType);
     if (fctx.pendingCallbackWritebacks && fctx.pendingCallbackWritebacks.length > 0) {

--- a/tests/issue-2895-drain-hook.test.ts
+++ b/tests/issue-2895-drain-hook.test.ts
@@ -1,0 +1,47 @@
+// #2895 PATH B slice-1d scaffolding — the `__drain_microtasks()` compiler
+// intrinsic + the test262 runner hook. The intrinsic lets the test262
+// `flags:[async]` harness (and standalone entrypoints) pump the native
+// microtask ring so a genuinely-pending async-frame continuation runs before a
+// settled value is observed — the prerequisite for the eventual slice-1d carrier
+// widen measurement (without it even a correct drive layer scores 0 — the AG0 trap).
+//
+// Gated on the native-`$Promise` carrier (`isStandalonePromiseActive`, wasi-only
+// today → widens to standalone at slice 1d): on the host-free targets it lowers
+// to the real native drain; on the gc/host lane it is a void no-op (no native
+// microtask ring), keeping that lane byte-identical.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+describe("#2895 __drain_microtasks intrinsic (wasi carrier)", () => {
+  it("an in-source __drain_microtasks() drives a genuinely-pending continuation", async () => {
+    const src = `
+let val = 0;
+async function f(): Promise<number> {
+  const x = await Promise.resolve(1).then((v: number) => v + 40);
+  return x; // 41
+}
+export function run(): number {
+  f().then((v: number) => { val = v; }); // suspends; continuation carries the value
+  __drain_microtasks();                  // pump the ring → f resumes → .then runs → val = 41
+  return val;
+}
+`;
+    const r = await compile(src, { fileName: "t.ts", target: "wasi" });
+    expect(r.success, r.success ? "" : `CE: ${r.errors?.[0]?.message}`).toBe(true);
+    // Host-free: the intrinsic + carrier request no imports.
+    expect((r.imports ?? []).map((i) => `${i.module}.${i.name}`)).toEqual([]);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as { run(): number }).run()).toBe(41);
+  });
+
+  it("is a host-free void no-op under --target standalone (inert until slice 1d)", async () => {
+    const src = `export function run(): void { __drain_microtasks(); }`;
+    const r = await compile(src, { fileName: "t.ts", target: "standalone" });
+    expect(r.success).toBe(true);
+    expect((r.imports ?? []).length).toBe(0);
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect(() => (instance.exports as { run(): void }).run()).not.toThrow();
+  });
+});

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -2487,8 +2487,17 @@ export function test(): number {
     };
   }
 
+  // (#2895 PATH B) Async tests: pump the microtask ring before reading the
+  // result so genuinely-pending async-frame continuations (which carry the
+  // assertions) run. `__drain_microtasks()` is a compiler intrinsic — the native
+  // drain on the host-free targets (`--target standalone`/`wasi`), a void no-op
+  // on the JS-host gc lane (which has no native microtask ring), so the gc lane
+  // stays byte-identical. Declared so the wrapped TS type-checks.
+  const isAsyncTest = resolvedMeta.flags?.includes("async") || needsAsyncTest;
+  const asyncDrainDecl = isAsyncTest ? `declare function __drain_microtasks(): void;\n` : "";
+  const asyncDrainCall = isAsyncTest ? `  __drain_microtasks();\n` : "";
   const preBody = `${strictDirective}
-${preamble}
+${asyncDrainDecl}${preamble}
 ${hoistedDecls}
 export function test(): number {
   ${implicitDecls}
@@ -2499,7 +2508,7 @@ export function test(): number {
     if (!__fail) __fail = -1;
     throw e;
   }
-  if (__fail) { return __fail; }
+${asyncDrainCall}  if (__fail) { return __fail; }
   return 1;
 }
 `;


### PR DESCRIPTION
## Slice-1d scaffolding for the standalone async unlock (#2895)

Rescues the runner `__drain_microtasks` hook from the dormant
`issue-2895-async-drive-1b` branch and ships it as its own small **inert** PR. It
de-risks the eventual slice-1d carrier-widen measurement: without a drain, the
test262 `flags:[async]` harness cannot observe a genuinely-pending native async
result, so even a correct drive layer would score 0 (the AG0 trap).

### What landed
- **`src/codegen/expressions.ts`**: a `__drain_microtasks()` compiler intrinsic.
  Under the native-`$Promise` carrier (`isStandalonePromiseActive`, **wasi-only
  today**) it lowers to the existing native `emitDrainMicrotasks`; on the gc/host
  lane (no native microtask ring) and `--target standalone` (carrier not yet
  widened) it is a **void no-op** — those lanes stay byte-identical.
- **`tests/test262-runner.ts`**: for `flags:[async]` / `needsAsyncTest` tests,
  declare `__drain_microtasks` and call it after `test()` and before reading
  `__fail`. Inert on the measured gc + standalone lanes (the intrinsic emits
  nothing there); it only fires once slice 1d widens the carrier to standalone.

### Inertness / tests
`tests/issue-2895-drain-hook.test.ts`: an in-source `__drain_microtasks()` under
wasi resumes a genuinely-pending continuation (→ 41, host-free — `result.imports`
empty); a `--target standalone` `__drain_microtasks()` is a host-free void no-op.
Existing carrier suites (`issue-2867-gap2`, `issue-2895-async-frame`,
`async-await`) stay green; typecheck clean.

### Why this is safe to land alone
The slice-1d **widen** itself stays blocked — it gates on the general multi-state
CFG-aware CPS resume machine (Gaps 3/5 = try/finally-across-await + for-await/
async-gen, which the single-await `splitBodyAtAwait` cannot express; being tracked
as a new XL substrate issue) landing AND the full `merge_group` standalone corpus
measuring net-positive. This PR is pure prerequisite scaffolding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)