### PR TITLE
fix(#2908): standalone obj[key] dynamic read is host-free (no env::__extern_get leak)

### DIFF
--- a/plan/issues/2908-standalone-externget-elemaccess-leak.md
+++ b/plan/issues/2908-standalone-externget-elemaccess-leak.md
@@ -1,0 +1,101 @@
+---
+id: 2908
+title: standalone obj[key] dynamic read leaks env::__extern_get (largest host-import leak class)
+area: codegen-standalone
+feasibility: hard
+status: done
+completed: 2026-07-01
+assignee: ttraenkler/sdev-2908-externget-leak
+related: [2748, 2879, 2372, 2572, 1472]
+sprint: current
+priority: high
+horizon: m
+---
+
+## Problem
+
+`--target standalone` (pure-Wasm, no JS host) modules still emit an
+unsatisfiable `env::__extern_get` HOST import for the ordinary dynamic
+property-read pattern `obj[key]` / `obj.prop` on an `any`/externref receiver.
+This is the **single largest standalone host-import leak class**
+(`dynamic_object_property`): on the fresh merge_group standalone report at head
+`20474543f` (run 28483020330, 2026-06-30), **4,514** tests import
+`env::__extern_get`, of which **3,379** leak it as their _only_ `env::__*` host
+import (1,733 pass, 1,636 fail). It is driven at scale by test262 harness code —
+`propertyHelper.js`'s `verifyProperty` reads `obj[name]` on a generic `any`
+receiver.
+
+## Root cause (verified on current main, verdict (c))
+
+`ensureLateImport(ctx, "__extern_get", …)` at every dynamic-read site _already_
+routes `OBJECT_RUNTIME_HELPER_NAMES` (which includes `__extern_get`) to the
+Wasm-NATIVE `ensureObjectRuntime` definition under `ctx.standalone || ctx.wasi`
+(the #2748 WASI routing + the #1472 Phase B native `$Object` runtime). sr-dynobj's
+native `$Object` reader is real and value-correct.
+
+BUT the AST pre-scan `collectUsedExternImports` (`src/codegen/index.ts`, the
+`ElementAccessExpression` arm ~line 13767) eagerly registered `env::__extern_get`
+as a HOST import for **every** `obj[idx]` element-access on an externref-typed
+receiver, with **no host-free-mode guard**. That seeded `__extern_get` into
+`funcMap` BEFORE any read-site ran. `ensureLateImport` short-circuits on
+`funcMap.has(name)` (returns the existing index without routing), so the
+pre-seeded HOST import pre-empted the native routing and the module shipped the
+unsatisfiable `env::__extern_get`.
+
+So this is **distinct** from sr-dynobj's value-correctness fix (the native reader
+exists and is correct) and from #2748 (which fixed the `ensureLateImport` WASI
+routing but not the pre-scan). The pre-scan wins the race and the import leaks.
+Confirmed by an `addImport` stack trace: the leak enters at
+`collectUsedExternImports`'s element-access arm, with `ctx.standalone === true`
+and `ctx.strictNoHostImports === false`.
+
+## Fix
+
+Guard the pre-scan host-import registration for `__extern_get` on
+`ctx.standalone || ctx.wasi` — skip the eager `register("__extern_get", …)` in
+host-free modes so the compile-path `ensureLateImport` binds the native
+`ensureObjectRuntime` `__extern_get`. Host/gc mode is byte-identical (the guard
+wraps the unchanged `register(...)` call).
+
+`src/codegen/index.ts` — `collectUsedExternImports`, the `obj[idx]`-on-externref
+arm.
+
+## Verification (fresh data, head 20474543f)
+
+- **GC/host byte-identity**: same input compiled `--target gc` is byte-identical
+  pre/post fix (3919 == 3919 bytes) and still imports `env::__extern_get` there.
+- **standalone**: the import is removed (main=leak, fix=host-free); the module
+  grows (native `$Object` runtime now emitted inline) — the intended dual-mode
+  tradeoff.
+- **Corpus verify** (compile + instantiate + run `test()` via the runner's
+  `buildImports`, fixed compiler):
+  - 300 stratified baseline-pass leaky tests → 297 stay pass, **0** non-arguments
+    fix-induced regressions (the 3 were `arguments-object`); all host-free.
+  - 400 fresh non-arguments baseline-pass → 396 pass, **0 fix-induced
+    regressions** (4 apparent CEs are pre-existing TS-level errors, byte-identical
+    on main and fix — a local-harness artifact, not the fix).
+  - 23 `arguments-object` leaky-pass → 14 stay pass, **9 flip pass→fail**: a
+    pre-existing native mapped-arguments `[[DefineOwnProperty]]` descriptor gap
+    the fully-native read path now _exposes_ (the old mixed host-read /
+    native-descriptor path masked it). Tracked as follow-up **#2909**.
+  - **0** tests still leaking `env::__extern_get` in any sample.
+
+## Net accounting (standalone floor keys on host_free_pass, #2879 §4)
+
+The floor gate (`scripts/check-standalone-highwater.mjs`) scores
+`host_free_pass` (pass AND host-free), not raw pass. A leaky pass has
+`host_free_pass = 0`. Therefore:
+
+- ~1,710 non-arguments leaky-pass → host-free-pass ⇒ **Δhost_free_pass ≈ +1,710**
+  (progress).
+- ~9–13 `arguments-object` leaky-pass → host-free-fail ⇒ host_free_pass
+  UNCHANGED (was 0, stays 0) — **does NOT breach the floor** (the exact
+  "mid-flight carrier raw-pass dip" the #2879 §4 accounting anticipates).
+
+Net: unambiguously NET-POSITIVE on the gated metric with zero floor breach.
+
+## Tests
+
+`tests/issue-2908-standalone-externget-elemaccess-leak.test.ts` — asserts
+computed/named/verifyProperty-shaped/absent dynamic reads compile host-free
+(`env` imports == []) and evaluate correctly in `--target standalone`.

--- a/plan/issues/2909-standalone-mapped-arguments-descriptor-native-read.md
+++ b/plan/issues/2909-standalone-mapped-arguments-descriptor-native-read.md
@@ -1,0 +1,53 @@
+---
+id: 2909
+title: standalone mapped-arguments [[DefineOwnProperty]] descriptor semantics under fully-native read
+area: codegen-standalone
+feasibility: hard
+status: ready
+related: [2908, 1472]
+sprint: Backlog
+priority: low
+horizon: m
+---
+
+## Problem
+
+Surfaced by #2908. Once the standalone dynamic property read `obj[key]` is fully
+host-free (routed to the native `$Object` `__extern_get` rather than the host
+import), a bounded set of `language/arguments-object/mapped/*` test262 cases
+that manipulate an arguments object's property _descriptors_ flip pass→fail.
+
+Fresh head 20474543f: **23** `arguments-object` tests were leaky-pass (importing
+only `env::__extern_get`); with #2908 landed, ~9–13 of them flip pass→fail. They
+remain host-free-fail (`host_free_pass` unchanged — no standalone-floor breach),
+so this is a follow-up quality gap, not a floor regression.
+
+Example: `nonconfigurable-nonwritable-descriptors-set-by-arguments.js`:
+
+```js
+function fn(a) {
+  Object.defineProperty(arguments, "0", {configurable: false});
+  arguments[0] = 2;
+  Object.defineProperty(arguments, "0", {writable: false});
+  verifyProperty(arguments, "0", { value: 2, writable: false, enumerable: true, configurable: false });
+  a = 3; // mapping already removed → value stays 2
+  verifyProperty(arguments, "0", { value: 2, ... });
+}
+```
+
+## Root cause (to confirm)
+
+The old mixed path — host `__extern_get` VALUE read + native
+`defineProperty`/`getOwnPropertyDescriptor` — happened to pass. The
+fully-native read exposes that the native `$Object`/arguments representation does
+not implement mapped-arguments exotic `[[DefineOwnProperty]]` + mapping-removal
+semantics (§10.4.4) the way the host reader's view did. A plain native
+`arguments[0]` read works (verified); the gap is specifically the
+descriptor-manipulation + `verifyProperty` interaction on a mapped arguments
+object.
+
+## Acceptance
+
+The ~9–13 `arguments-object/mapped/*` descriptor tests that #2908 flips to
+host-free-fail return to pass, host-free (`host_free_pass` +9–13), with no other
+regressions.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -13764,7 +13764,23 @@ function collectUsedExternImports(ctx: CodegenContext, sourceFile: ts.SourceFile
       ) {
         const wasmType = mapTsTypeToWasm(objType, ctx.checker);
         if (wasmType.kind === "externref") {
-          register("__extern_get", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
+          // (#2908) Host-free modes: DO NOT eagerly seed the `env::__extern_get`
+          // HOST import here. `__extern_get` is a member of
+          // OBJECT_RUNTIME_HELPER_NAMES, so under `--target standalone`/`wasi`
+          // the compile-path `ensureLateImport(ctx, "__extern_get", …)` at every
+          // dynamic-read site routes the name to the Wasm-native `__extern_get`
+          // defined by `ensureObjectRuntime` (object-runtime.ts) — a DEFINED
+          // function, no host import. But `ensureLateImport` short-circuits on
+          // `funcMap.has(name)`: if THIS pre-scan has already registered the
+          // host import into funcMap, that native routing never fires and the
+          // module ships an unsatisfiable `env::__extern_get` (the standalone
+          // dynamic-object-property leak — the single largest host-import leak
+          // class, harness `verifyProperty`/`obj[name]` drives it into ~4.5k
+          // tests). Skipping the pre-registration lets the native routing win;
+          // host/gc mode is unchanged (still eagerly seeds the host import).
+          if (!(ctx.standalone || ctx.wasi)) {
+            register("__extern_get", [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
+          }
         }
       }
     }

--- a/tests/issue-2908-standalone-externget-elemaccess-leak.test.ts
+++ b/tests/issue-2908-standalone-externget-elemaccess-leak.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2908 — a dynamic `obj[key]` / `obj.prop` read on an `any`/externref receiver
+ * must NOT leak the `env::__extern_get` HOST import in `--target standalone`.
+ *
+ * Defect (the single largest standalone host-import leak class,
+ * `dynamic_object_property`, ~4.5k test262 rows): the AST pre-scan
+ * `collectUsedExternImports` (src/codegen/index.ts) eagerly registered
+ * `env::__extern_get` as a HOST import for every `obj[idx]` element-access on an
+ * externref-typed receiver, WITHOUT a host-free-mode guard. That seeded the name
+ * into `funcMap` BEFORE any read-site ran. The compile-path
+ * `ensureLateImport(ctx, "__extern_get", …)` routes `OBJECT_RUNTIME_HELPER_NAMES`
+ * to the Wasm-NATIVE `ensureObjectRuntime` definition under
+ * `ctx.standalone || ctx.wasi` — but it short-circuits on `funcMap.has(name)`, so
+ * the pre-seeded host import pre-empted that native routing and the module
+ * shipped an unsatisfiable `env::__extern_get`. Harness code
+ * (`propertyHelper.js`'s `verifyProperty`, i.e. `obj[name]`) drives this pattern
+ * into thousands of tests.
+ *
+ * Fix: skip the pre-scan host-import registration for `__extern_get` under
+ * `ctx.standalone || ctx.wasi`, letting the compile-path `ensureLateImport`
+ * bind the native `ensureObjectRuntime` `__extern_get`. Host/gc mode is
+ * byte-identical (the guard wraps the unchanged `register(...)` call).
+ */
+
+async function buildStandalone(body: string): Promise<{
+  result: number;
+  envImports: string[];
+}> {
+  const src = `export function test(): number { ${body} }`;
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const envImports = WebAssembly.Module.imports(new WebAssembly.Module(r.binary))
+    .filter((i) => i.module === "env")
+    .map((i) => i.name);
+  const importObject: Record<string, unknown> = {};
+  const { instance } = await WebAssembly.instantiate(r.binary, importObject);
+  (importObject as { __setExports?: (e: unknown) => void }).__setExports?.(instance.exports);
+  const result = (instance.exports as { test(): number }).test();
+  return { result, envImports };
+}
+
+describe("#2908 — standalone dynamic obj[key] read is host-import-free", () => {
+  it("computed key read on an any receiver does not leak env::__extern_get", async () => {
+    const { result, envImports } = await buildStandalone(
+      `const o: any = { a: 1, b: 2 }; const k: any = "b"; return o[k] as number;`,
+    );
+    expect(result).toBe(2);
+    expect(envImports).not.toContain("__extern_get");
+    expect(envImports).toEqual([]);
+  });
+
+  it("named property read on an any receiver does not leak env::__extern_get", async () => {
+    const { result, envImports } = await buildStandalone(`const o: any = { code: 7 }; return o.code as number;`);
+    expect(result).toBe(7);
+    expect(envImports).toEqual([]);
+  });
+
+  it("verifyProperty-shaped read (obj[name] in a generic helper) is host-free", async () => {
+    // Mirrors propertyHelper.js's `verifyProperty` core: an `any`-typed `obj`
+    // indexed by an `any`-typed key — the exact harness shape that drove the
+    // ~4.5k-row `dynamic_object_property` leak class.
+    const { result, envImports } = await buildStandalone(
+      `function read(obj: any, name: any): any { return obj[name]; }
+       const o: any = { x: 5 };
+       return read(o, "x") as number;`,
+    );
+    expect(result).toBe(5);
+    expect(envImports).toEqual([]);
+  });
+
+  it("dynamic read of an absent property yields undefined, still host-free", async () => {
+    const { result, envImports } = await buildStandalone(
+      `const o: any = { a: 1 }; const v: any = o["missing"]; return (v === undefined) ? 1 : 99;`,
+    );
+    expect(result).toBe(1);
+    expect(envImports).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the **single largest standalone host-import leak class**
(`dynamic_object_property`): a dynamic `obj[key]` / `obj.prop` read on an
`any`/externref receiver under `--target standalone` leaked an unsatisfiable
`env::__extern_get` HOST import. On the fresh `20474543f` merge_group standalone
report, **4,514** tests import it (3,379 leak it as their only `env::__*`
import). It is driven at scale by `propertyHelper.js`'s `verifyProperty`
(`obj[name]`).

## Root cause (verdict c — distinct from sr-dynobj / #2748)

The native `$Object` `__extern_get` already exists (sr-dynobj / #1472 Phase B)
and `ensureLateImport` already routes `OBJECT_RUNTIME_HELPER_NAMES` to it under
`standalone || wasi`. But the AST pre-scan `collectUsedExternImports`
(`src/codegen/index.ts`, `ElementAccessExpression` arm) eagerly registered the
`env::__extern_get` HOST import for every externref `obj[idx]`, with **no
host-free-mode guard** — seeding `funcMap` before any read-site ran.
`ensureLateImport` short-circuits on `funcMap.has(name)`, so the pre-seeded host
import pre-empted the native routing and the import leaked. Confirmed via an
`addImport` stack trace (`ctx.standalone === true`, the pre-scan arm).

## Fix

Guard the pre-registration on `ctx.standalone || ctx.wasi` — skip it in
host-free modes so the compile-path `ensureLateImport` binds the native
`ensureObjectRuntime` `__extern_get`. **GC/host mode is byte-identical** (the
guard wraps the unchanged `register(...)` call).

## Verification (fresh head 20474543f, local compile+instantiate+run)

- **GC byte-identity**: same input `--target gc` is byte-identical pre/post
  (3919 == 3919) and still imports `env::__extern_get` there.
- **Standalone**: import removed; module grows (native runtime now inline).
- **Corpus** (via the runner's `buildImports`, fixed compiler):
  - 400 non-arguments baseline-pass leaky tests → **0 fix-induced regressions**
    (4 apparent CEs are pre-existing TS errors, byte-identical main vs fix); all
    host-free.
  - 23 `arguments-object` leaky-pass → 14 stay pass, ~9 flip pass→fail: a
    pre-existing native mapped-arguments `[[DefineOwnProperty]]` descriptor gap
    the fully-native read exposes → follow-up **#2909**.
  - **0** tests still leaking `env::__extern_get` in any sample.

## Net accounting (standalone floor keys on `host_free_pass`, #2879 §4)

- ~1,710 non-arguments leaky-pass → host-free-pass ⇒ **Δhost_free_pass ≈ +1,710**.
- ~9–13 arguments leaky-pass → host-free-fail ⇒ `host_free_pass` unchanged (was
  0) — **no floor breach** (the anticipated mid-flight raw-pass dip).

Unambiguously NET-POSITIVE on the gated metric; the merge_group is the final
arbiter.

## Tests

`tests/issue-2908-standalone-externget-elemaccess-leak.test.ts` (4 cases, pass
locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8