### PR TITLE
feat(#2907): native well-known-global bare-value carriers (standalone global_<Name> leak)

### DIFF
--- a/plan/issues/2907-standalone-wellknown-global-identity-carriers.md
+++ b/plan/issues/2907-standalone-wellknown-global-identity-carriers.md
@@ -1,0 +1,141 @@
+---
+id: 2907
+title: "Standalone: native well-known-global bare-value carriers (global_<Name> leak)"
+status: done
+assignee: ttraenkler/sendev-globals
+completed: 2026-07-01
+created: 2026-07-01
+priority: high
+feasibility: hard
+task_type: feature
+area: codegen
+goal: standalone
+sprint: current
+horizon: l
+related: [2866, 2696, 2520, 1888, 1065]
+---
+
+# Standalone: native well-known-global bare-value carriers
+
+## Problem
+
+Referencing a well-known global as a **first-class object VALUE** — not a method
+call, not a `new` callee — under `--target standalone` leaked an
+`env.global_<Name>` host import to materialize the global's identity. Standalone
+has no JS host to satisfy it, so the module could not instantiate host-free and
+failed the standalone floor.
+
+The native METHOD bodies already exist (`Math.*` #1902, `JSON.*` #1538/#2166,
+native throw/catch #1536, static `instanceof <Error>` tag registry #1325); the
+gap was only the bare-value BINDING.
+
+## Root cause (measured on origin/main, 2026-07-01)
+
+Two `global_<Name>` emission loops in `src/codegen/index.ts::collectDeclaredGlobals`:
+
+1. **declared-globals loop** (~13826): emits `global_<Name>` for any
+   `isExternalDeclaredClass` lib global. `TypeError`, `Error`, `RegExp`,
+   `Reflect`, the `*Error` subtypes are **NOT** in `BUILTIN_TYPES`
+   (`src/checker/type-mapper.ts`), so they pass `isExternalDeclaredClass` and hit
+   this loop. It had **no host-import guard at all**.
+2. **ambient-ctor loop** (~13906, #1065): emits `global_<Ctor>` for
+   `AMBIENT_BUILTIN_CTORS` used as bare values (`Math`, `JSON`, TypedArray
+   ctors, …). Its #2696 guard was `if (ctx.strictNoHostImports) continue;`.
+
+The real defect: **`strictNoHostImports` is NOT auto-on for `standalone`** —
+`create-context.ts:25` sets it from `options.strictNoHostImports ?? options.wasi
+?? false`, i.e. only `wasi`. So both loops leaked `global_<Name>` under
+standalone even though standalone is a no-JS-host target. `instanceof <Error>` is
+resolved statically (`builtin-tags.ts` negative-tag registry) and `new
+X(...)`/`X(...)` are intercepted at the call/new site BEFORE identifier
+resolution, so **only genuine bare-VALUE uses leaked**.
+
+### Measured cluster (targeted leaking-idiom corpus, `wrapTest` + `--target standalone`)
+
+Sampling the ~650 test262 files matching the bare-value idioms
+(`expectedError = TypeError`, `[TypeError, RangeError]`, `Object.isFrozen(Math)`,
+`Object.getPrototypeOf(Reflect)`, `instanceof <Error>` inside bodies):
+
+- **`global_TypeError` dominates** (sole ~11 / touch ~29 per 200-sample →
+  ~35 sole / ~90+ touch corpus-wide). `global_JSON` sole 4/4 (pure-JSON tests).
+  `global_Math`, `global_Reflect`, `global_String`, `global_Number`,
+  TypedArray-ctor group (`[Int8Array, …].forEach`) also leaked.
+- The dominant `assert.throws(TypeError, fn)` inline form is **stripped by the
+  harness** (`transformAssertThrows`), so the leak rides mainly on the INDIRECT
+  idiom (`expectedError = TypeError; assert.throws(expectedError, fn)`) and on
+  value-used-as-object cases.
+
+### Honest net finding (measure-first)
+
+Removing the leak flips these tests **host-free** (the stated acceptance), but
+the immediate PASS-conversion is smaller than the sole-count suggests: many
+sole-`global_` tests fail for **unrelated** reasons once host-free (e.g. the
+DataView `resizable-buffer` cluster needs resizable-ArrayBuffer support, not the
+`TypeError` binding). The genuine pass conversions come from **value-used-as-
+object** cases where the null-default gave a wrong answer — those need a real
+extensible object carrier (`Object.isFrozen(Math) === false`,
+`Object.isSealed(Math) === false`, `typeof Math === "object"`).
+
+## Fix (this PR)
+
+All changes gated `ctx.standalone` (or `strictNoHostImports`) — **gc/host mode is
+byte-identical** (verified: 469-byte program using TypeError/Error/RangeError/
+Math/JSON/Reflect as values compiles to an identical binary on main vs branch,
+host still provides `global_*`).
+
+1. **`codegen/index.ts` — extend both `global_<Name>` guards to
+   `ctx.strictNoHostImports || ctx.standalone`.** Standalone stops leaking the
+   host constructor object; bare-value uses fall through to the native carrier or
+   the `ref.null.extern` graceful default. (The ambient-loop comment claiming
+   strict mode was "auto-on for standalone" was factually wrong and is corrected.)
+
+2. **`codegen/builtin-static-globals.ts` — native bare-value carriers** for the
+   well-known namespace + Error-family globals via the existing #1888
+   `emitBuiltinNamespaceObject` infra (an EMPTY supported-prop list ⇒ materialize
+   an extensible `$Object` singleton for the bare identifier without claiming any
+   static property):
+   `Math`, `JSON`, `Reflect`, `Error`, `TypeError`, `RangeError`, `SyntaxError`,
+   `ReferenceError`, `EvalError`, `URIError`, `AggregateError`.
+   `isSupportedBuiltinStaticProperty(ns, m)` stays **false** for all of these, so
+   `Math.PI` / `JSON.stringify` / `Reflect.ownKeys` keep their existing
+   property-access fast paths (intercepted at the property-access site, before
+   identifier resolution of the receiver). `new TypeError(...)` /
+   `throw new RangeError(...)` / `e instanceof TypeError` are unchanged
+   (native-error construction / static tag registry, both pre-identifier).
+
+### Verified (host-free, empty-import instantiation)
+
+- Leaks gone: `expectedError = TypeError`, `[TypeError, RangeError, …]`,
+  `Object.isFrozen(Math)`, DataView `expectedError = TypeError` — all 0 imports,
+  no `global_`.
+- Conversions fail→pass: `Object.isFrozen(Math) === false`,
+  `Object.isSealed(Math) === false`, `typeof Math === "object"`, bare `TypeError`
+  truthy, `Object.isFrozen(TypeError) === false`.
+- No hot-path regression: `Math.PI`/`Math.max`/`Math.floor`, `JSON.stringify`/
+  `JSON.parse`, `Reflect.ownKeys`/`Reflect.has`, `new`/`throw`/`instanceof` for
+  the Error family — all still pass host-free.
+- gc-mode byte-identical; `tsc --noEmit` clean; `tests/issue-2907.test.ts` 10/10.
+
+## Follow-ups (deferred, documented for the next slice)
+
+- **Canonical-singleton identity** — `Object.getPrototypeOf(Reflect) ===
+Object.prototype` and `[].filter(fn, JSON)` thisArg-identity (`this === JSON`)
+  still return the wrong answer: the carrier singleton is not `===`-identical to
+  the canonical `Object.prototype` / the value re-read at the comparison. Needs
+  the carrier interned as THE one canonical object and threaded identically as a
+  thisArg. (Value-rep follow-up.)
+- **`.name` / `.prototype` on the Error-family carriers** (`TypeError.name ===
+"TypeError"`, `TypeError.prototype`) — the empty carrier returns `undefined`.
+  Populate the carrier with `name`/`prototype` where cheap.
+- **WASI parity** — the carrier is `ctx.standalone`-gated; bare `Math`/`TypeError`
+  under `--target wasi` still resolves to the `ref.null.extern` default (already
+  host-free, just not carrier-backed). Extend to wasi for consistency.
+- **`RegExp`/`Date`/`String`/`Number`/`Boolean`/`Function` bare-value carriers**
+  — lower-frequency; same infra, add when their sole-clusters justify a slice.
+
+## Acceptance
+
+- `global_<Name>` sole tests flip host-free (verified). ✓
+- gc byte-unchanged (verified). ✓
+- Value-used-as-object conversions (`isFrozen`/`isSealed`/`typeof`) pass. ✓
+- Full `merge_group` standalone floor is the conformance gate.

--- a/src/codegen/builtin-static-globals.ts
+++ b/src/codegen/builtin-static-globals.ts
@@ -20,6 +20,33 @@ import { stringConstantExternrefInstrs } from "./native-strings.js";
 const SUPPORTED_STATIC_PROPS: ReadonlyMap<string, readonly string[]> = new Map([
   ["Array", ["isArray"]],
   ["Object", ["keys"]],
+  // #2907 — bare-value carriers for the well-known namespace globals. An EMPTY
+  // supported-prop list means: materialize a native extensible `$Object`
+  // singleton for the bare identifier (`Math`, `JSON`, `Reflect` used as a
+  // VALUE — `Object.isFrozen(Math)`, `[].filter(fn, JSON)` thisArg,
+  // `Object.getPrototypeOf(Reflect)`), WITHOUT claiming any supported static
+  // property. `isSupportedBuiltinStaticProperty(ns, m)` stays false for these,
+  // so `Math.PI` / `JSON.stringify` / `Reflect.ownKeys` keep their existing
+  // property-access fast paths (those are intercepted at the property-access
+  // site, before identifier resolution of the receiver). This only affects the
+  // bare-identifier value read, which previously leaked `env.global_<Name>`.
+  ["Math", []],
+  ["JSON", []],
+  ["Reflect", []],
+  // #2907 — Error-family constructors as bare-value carriers. `expectedError =
+  // TypeError`, `[TypeError, RangeError]`, `Object.isFrozen(TypeError)`. A `new
+  // TypeError(...)` / `TypeError(...)` callee and `e instanceof TypeError` are
+  // resolved BEFORE identifier resolution (native-error construction /
+  // static builtin-tag registry), so the carrier only backs the bare-value read
+  // — which previously leaked `env.global_<Name>` or fell to a null default.
+  ["Error", []],
+  ["TypeError", []],
+  ["RangeError", []],
+  ["SyntaxError", []],
+  ["ReferenceError", []],
+  ["EvalError", []],
+  ["URIError", []],
+  ["AggregateError", []],
 ]);
 
 export function isSupportedBuiltinNamespace(name: string): boolean {

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -13832,6 +13832,22 @@ function collectDeclaredGlobals(ctx: CodegenContext, libFile: ts.SourceFile, use
       if (ctx.declaredGlobals.has(name)) continue;
       const type = ctx.checker.getTypeAtLocation(decl);
       if (!isExternalDeclaredClass(type, ctx.checker)) continue;
+      // #2907 — under no-JS-host mode (standalone as well as
+      // strictNoHostImports/wasi) there is no host to satisfy
+      // `env.global_<Name>`. `TypeError`, `Error`, `RegExp`, `Reflect`, the
+      // *Error subtypes etc. are NOT in `BUILTIN_TYPES`, so they reach here via
+      // `isExternalDeclaredClass` and leaked a `global_<Name>` host import in
+      // standalone — the ambient-ctor loop below already skips under strict mode
+      // (#2696) but this earlier declared-globals loop had no such guard. A bare
+      // value use of the global (the harness `expectedError = TypeError` idiom,
+      // an array literal `[TypeError, RangeError]`, `Object.getPrototypeOf(Reflect)`)
+      // was the sole standalone blocker for a large cluster. `instanceof`/`new`
+      // are resolved BEFORE identifier resolution (static builtin-tag registry in
+      // builtin-tags.ts / `new`-callee interception), so dropping the host value
+      // binding here only affects genuine bare-value uses, which fall through to
+      // the native-namespace carrier (identifiers.ts:emitBuiltinNamespaceObject)
+      // or the `ref.null.extern` graceful default. Host/gc mode is unchanged.
+      if (ctx.strictNoHostImports || ctx.standalone) continue;
       const importName = `global_${name}`;
       const typeIdx = addFuncType(ctx, [], [{ kind: "externref" }]);
       addImport(ctx, "env", importName, { kind: "func", typeIdx });
@@ -13893,17 +13909,25 @@ function collectDeclaredGlobals(ctx: CodegenContext, libFile: ts.SourceFile, use
     // native fast paths and needs no host constructor object.
     if (!valueRefNames.has(name)) continue;
     if (ctx.declaredGlobals.has(name)) continue;
-    // #2696 — under strict-no-host-imports (auto-on for --target wasi /
-    // standalone) there is no JS host to satisfy `env.global_<Ctor>`, so
-    // addImport would drop it AND, because the dropped import leaves no funcMap
-    // entry, the `declaredGlobals.set` below never fires either — the whole
-    // registration is already a no-op EXCEPT for the spurious "not on the
-    // dual-mode allowlist" warning it emits. nm_js2wasm_node_process.ts trips this via
-    // the `String.fromCharCode` receiver in the injected process.stdin prelude
+    // #2696 — under strict-no-host-imports (auto-on for --target wasi) there is
+    // no JS host to satisfy `env.global_<Ctor>`, so addImport would drop it AND,
+    // because the dropped import leaves no funcMap entry, the
+    // `declaredGlobals.set` below never fires either — the whole registration is
+    // already a no-op EXCEPT for the spurious "not on the dual-mode allowlist"
+    // warning it emits. nm_js2wasm_node_process.ts trips this via the
+    // `String.fromCharCode` receiver in the injected process.stdin prelude
     // (loopdive/js2#389 bug 2: `env.global_String`). Skip it so the standalone
     // module compiles cleanly; bare identity uses already had no host global
     // under strict mode, so behavior is unchanged.
-    if (ctx.strictNoHostImports) continue;
+    // #2907 — `ctx.standalone` is a SEPARATE flag from `strictNoHostImports`
+    // (create-context.ts: strictNoHostImports defaults to `wasi`, NOT
+    // `standalone`), so the guard above missed `--target standalone`. A bare
+    // value use of an ambient ctor there (`[Int8Array, Uint8Array, …].forEach`,
+    // `expectedError = TypeError`) leaked `env.global_<Ctor>` with no host to
+    // satisfy it. Include `ctx.standalone` so standalone stops leaking the host
+    // constructor object; bare-value uses fall through to the native carrier /
+    // ref.null.extern default exactly as under wasi.
+    if (ctx.strictNoHostImports || ctx.standalone) continue;
     const importName = `global_${name}`;
     const typeIdx = addFuncType(ctx, [], [{ kind: "externref" }]);
     addImport(ctx, "env", importName, { kind: "func", typeIdx });

--- a/tests/issue-2907.test.ts
+++ b/tests/issue-2907.test.ts
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2907 — Standalone well-known-global bare-value carriers.
+ *
+ * A well-known global referenced as a FIRST-CLASS VALUE (not a method call or a
+ * `new` callee) — `expectedError = TypeError`, `[TypeError, RangeError]`,
+ * `Object.isFrozen(Math)`, `Object.getPrototypeOf(Reflect)` — used to leak an
+ * `env.global_<Name>` host import under `--target standalone`, which has no JS
+ * host to satisfy it. Root cause: the two `global_<Name>` emission loops in
+ * codegen/index.ts guarded only on `strictNoHostImports` (auto-on for `wasi`,
+ * NOT `standalone`), so standalone leaked the import.
+ *
+ * Fix:
+ *  1. extend both loops' guard to `ctx.strictNoHostImports || ctx.standalone`
+ *     so standalone stops importing the host constructor object; and
+ *  2. materialize a native extensible `$Object` singleton carrier for the
+ *     namespace globals `Math`/`JSON`/`Reflect` used as bare VALUES (via the
+ *     existing #1888 `emitBuiltinNamespaceObject` infra), so value-used-as-object
+ *     cases answer correctly host-free.
+ *
+ * Method/value bodies (`Math.*`, `JSON.*`, `Reflect.*`, native throw/catch,
+ * `instanceof <Error>` static-tag resolution) already exist; this only wires the
+ * bare-value binding. gc/host mode is untouched (all changes gated
+ * `ctx.standalone`).
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<{ imports: number; globalImports: string[]; ret: unknown }> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  if (!r.success) {
+    throw new Error("CE: " + (r.errors?.[0]?.message ?? "unknown"));
+  }
+  const globalImports = (r.imports ?? [])
+    .filter((i) => i.name.startsWith("global_"))
+    .map((i) => `${i.module}::${i.name}`);
+  // Instantiate with EMPTY imports — the standalone floor requires host-free.
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const ret = (instance.exports.test as (() => unknown) | undefined)?.();
+  return { imports: (r.imports ?? []).length, globalImports, ret };
+}
+
+describe("#2907 standalone well-known-global bare-value carriers", () => {
+  it("does not leak global_TypeError for a bare-value (indirect) TypeError reference", async () => {
+    const src = `export function test(): number {
+      const expectedError: any = TypeError;
+      return expectedError ? 1 : 0;
+    }`;
+    const r = await runStandalone(src);
+    expect(r.globalImports).toEqual([]);
+    expect(r.imports).toBe(0);
+    expect(r.ret).toBe(1);
+  });
+
+  it("does not leak global_<Name> for an Error-family array literal", async () => {
+    const src = `export function test(): number {
+      const errs: any[] = [TypeError, RangeError, SyntaxError, ReferenceError, Error];
+      return errs.length === 5 ? 1 : 0;
+    }`;
+    const r = await runStandalone(src);
+    expect(r.globalImports).toEqual([]);
+    expect(r.ret).toBe(1);
+  });
+
+  it("bare TypeError is a truthy extensible carrier (Object.isFrozen(TypeError) === false)", async () => {
+    const src = `export function test(): number {
+      return (TypeError as any) && Object.isFrozen(TypeError as any) === false ? 1 : 0;
+    }`;
+    const r = await runStandalone(src);
+    expect(r.globalImports).toEqual([]);
+    expect(r.ret).toBe(1);
+  });
+
+  it("keeps native throw/catch + static instanceof for the Error family host-free", async () => {
+    const src = `export function test(): number {
+      try {
+        throw new RangeError("bad");
+      } catch (e: any) {
+        return e instanceof RangeError && e instanceof Error && e.message === "bad" ? 1 : 0;
+      }
+    }`;
+    const r = await runStandalone(src);
+    expect(r.globalImports).toEqual([]);
+    expect(r.ret).toBe(1);
+  });
+
+  it("resolves bare Math to an extensible native singleton (Object.isFrozen(Math) === false)", async () => {
+    const src = `export function test(): number {
+      return Object.isFrozen(Math as any) === false ? 1 : 0;
+    }`;
+    const r = await runStandalone(src);
+    expect(r.globalImports).toEqual([]);
+    expect(r.ret).toBe(1);
+  });
+
+  it("resolves bare Math to an extensible native singleton (Object.isSealed(Math) === false)", async () => {
+    const src = `export function test(): number {
+      return Object.isSealed(Math as any) === false ? 1 : 0;
+    }`;
+    const r = await runStandalone(src);
+    expect(r.globalImports).toEqual([]);
+    expect(r.ret).toBe(1);
+  });
+
+  it("typeof Math === 'object' host-free", async () => {
+    const src = `export function test(): number { return typeof Math === "object" ? 1 : 0; }`;
+    const r = await runStandalone(src);
+    expect(r.globalImports).toEqual([]);
+    expect(r.ret).toBe(1);
+  });
+
+  it("does not hijack Math.* method/const fast paths", async () => {
+    const src = `export function test(): number {
+      return Math.PI > 3.14 && Math.PI < 3.15 && Math.max(2, 7, 3) === 7 && Math.floor(2.9) === 2 ? 1 : 0;
+    }`;
+    const r = await runStandalone(src);
+    expect(r.globalImports).toEqual([]);
+    expect(r.ret).toBe(1);
+  });
+
+  it("does not hijack JSON.* method fast paths", async () => {
+    const src = `export function test(): number {
+      const o: any = JSON.parse('{"x":5}');
+      return JSON.stringify([1, 2]) === "[1,2]" && o.x === 5 ? 1 : 0;
+    }`;
+    const r = await runStandalone(src);
+    expect(r.globalImports).toEqual([]);
+    expect(r.ret).toBe(1);
+  });
+
+  it("does not hijack Reflect.* method fast paths", async () => {
+    const src = `export function test(): number {
+      const o: any = { a: 1, b: 2 };
+      return Reflect.ownKeys(o).length === 2 && Reflect.has(o, "a") ? 1 : 0;
+    }`;
+    const r = await runStandalone(src);
+    expect(r.globalImports).toEqual([]);
+    expect(r.ret).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

Referencing a well-known global as a **first-class VALUE** (not a method call, not a `new` callee) under `--target standalone` leaked an `env.global_<Name>` host import to materialize the global's identity. Standalone has no JS host to satisfy it, so the module could not instantiate host-free and failed the standalone floor. `global_TypeError` dominated (rides in via the harness `expectedError = TypeError` idiom); `global_JSON`/`global_Math`/`global_Reflect` and the TypedArray-ctor group also leaked.

## Root cause

Both `global_<Name>` emission loops in `collectDeclaredGlobals` (`src/codegen/index.ts`) guarded only on `strictNoHostImports`, which `create-context.ts:25` derives from `wasi`, **not** `standalone`. So standalone leaked the host constructor object for bare-value uses. The declared-globals loop had **no guard at all** — `TypeError`/`Error`/`RegExp`/`Reflect`/`*Error` are not in `BUILTIN_TYPES`, so they reached it via `isExternalDeclaredClass`. `instanceof <Error>` (static tag registry, #1325) and `new`/call callees are resolved *before* identifier resolution, so only genuine bare-VALUE uses leaked.

## Fix (all gated `ctx.standalone`; gc/host **byte-identical**)

1. `codegen/index.ts` — extend both guards to `strictNoHostImports || standalone`.
2. `builtin-static-globals.ts` — native extensible `$Object` singleton carriers for the bare-value read of `Math`/`JSON`/`Reflect` + the Error family (`Error`/`TypeError`/`RangeError`/`SyntaxError`/`ReferenceError`/`EvalError`/`URIError`/`AggregateError`) via the existing #1888 `emitBuiltinNamespaceObject` infra (empty supported-prop list ⇒ bare-value only, no static-property hijack).

## Measure-first / honest net

Removing the leak flips the sole-`global_` tests **host-free** (the stated acceptance). Immediate pass-conversion is smaller than the sole-count suggests — many sole-global tests fail for **unrelated** reasons once host-free (e.g. the DataView `resizable-buffer` cluster). The genuine conversions come from **value-used-as-object** cases: `Object.isFrozen(Math) === false`, `Object.isSealed(Math) === false`, `typeof Math === "object"` now pass. Full detail + deferred follow-ups (canonical-singleton identity, `.name`/`.prototype`, WASI parity, RegExp/Date/wrapper carriers) in the issue file.

## Verified

- Leaks gone (0 imports, no `global_`) for `expectedError = TypeError`, `[TypeError, RangeError, …]`, `Object.isFrozen(Math)`, DataView `expectedError = TypeError`.
- fail→pass: `isFrozen(Math)`, `isSealed(Math)`, `typeof Math`, bare-`TypeError` truthy, `isFrozen(TypeError)`.
- No hot-path regression: `Math.PI`/`max`/`floor`, `JSON.stringify`/`parse`, `Reflect.ownKeys`/`has`, `new`/`throw`/`instanceof` Error family — all host-free pass.
- gc-mode **byte-identical** (main vs branch); `tsc --noEmit` clean; `tests/issue-2907.test.ts` **10/10**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8