### PR TITLE
docs(test262): review #2911 findings + 3 follow-up defects (#2912/#2913/#2914)

### DIFF
--- a/plan/issues/2911-review-test262-setup-host-standalone-classification.md
+++ b/plan/issues/2911-review-test262-setup-host-standalone-classification.md
@@ -1,0 +1,234 @@
+---
+id: 2911
+title: "Review: test262 setup + host-vs-standalone classification and pass-rate computation"
+status: in-review
+priority: medium
+sprint: current
+created: 2026-07-01
+feasibility: medium
+task_type: review
+area: tooling
+goal: developer-experience
+related: [2910, 2774, 2636, 2097, 2912, 2913, 2914]
+---
+
+# #2911 — Review the test262 setup + host/standalone classification & pass rates
+
+**Audit task (execute it — produce findings, don't just fix piecemeal).** Verify
+that the test262 pipeline is set up correctly and that tests are classified into
+**JS-host** vs **standalone** pass rates accurately and consistently.
+
+## Scope — answer each with evidence
+1. **Runner setup.** How test262 runs end-to-end: `pnpm run test:262` /
+   `tests/test262-runner.ts` / `scripts/test262-worker.mjs`, the sharded CI
+   (`test262-sharded.yml`), worker recycling, skip filters
+   (eval/with/Proxy/SharedArrayBuffer/Temporal/…), and how a per-test verdict
+   (`pass`/`fail`/`compile_error`/`skip`) is decided. Flag any verdict heuristics
+   that can mislabel (e.g. the warning→pass path #2898 hit; the in-process
+   batch-scanner cross-test-state false positives; negative/early-error tests).
+2. **Host vs standalone modes.** How the SAME test is run in **JS-host** mode
+   (host imports) vs **standalone** mode (`--target wasi`/pure-wasm, no JS
+   runtime). Where each result is recorded and how the two are kept in sync
+   (`build-standalone-cli.mjs`, `build-test262-report.mjs`,
+   `test262-standalone-report.json`, `test262-standalone-editions.json`,
+   `check-standalone-highwater.mjs`, the #2097 absolute standalone floor).
+3. **Classification correctness.** Are tests classified into host/standalone
+   pass rates on a sound axis? Is a test that is host-only (uses a host import
+   with no standalone fallback) counted correctly in the standalone denominator,
+   or does it deflate/inflate the standalone rate? Cross-check against #2910's
+   edition/feature classification work — do the standalone editions
+   (`test262-standalone-editions.json`) use the same classifier?
+4. **Pass-rate math.** Denominators (skip in/out?), dedup (the baseline has
+   duplicate records — e.g. `eval-gtbndng-indirect-update-dflt.js` appears
+   twice; does that double-count?), and whether host + standalone totals are
+   over the same population so they're comparable.
+5. **Baseline & staleness.** The committed summary vs the fetched JSONL vs the
+   separate `loopdive/js2wasm-baselines` repo; `check-baseline-floor-staleness`;
+   how stale the numbers can get and whether the dashboard reflects current main.
+
+## Deliverable
+- A written findings section appended to this issue (or a short
+  `docs/` note linked here): what's correct, what's wrong/misleading, and
+  concrete recommendations.
+- File **follow-up issues** (via `claim-issue.mjs --allocate`) for each concrete
+  defect found (e.g. double-counting, host-only-in-standalone-denominator,
+  classifier divergence), tagged `sprint: current`.
+- If a fix is small + safe, it may be done inline; larger fixes → follow-up
+  issues routed appropriately.
+
+## Acceptance
+- Each scope item (1–5) answered with file:line evidence.
+- Any real defect either fixed (small) or filed as a follow-up issue.
+- A clear statement of whether the reported host + standalone pass rates are
+  trustworthy and comparable, with the caveats enumerated.
+
+---
+
+## Findings (review 2026-07-01)
+
+Audited on `origin/main` @ `a84fe6e80447` (+ fetched HEAD `e63f677`). Evidence is
+`file:line` against the tree at review time. Follow-up defects filed: **#2912,
+#2913, #2914**.
+
+### Architecture in one paragraph (so the evidence reads cleanly)
+
+The authoritative runner is the sharded CI matrix
+(`.github/workflows/test262-sharded.yml:428-434`): the **same** 57 chunk files
+(`tests/test262-chunk*.test.ts` → `runTest262Chunk`, `tests/test262-shared.ts:450`)
+run under **two targets** — `gc` (JS-host, `result_prefix: test262`) and
+`standalone` (`result_prefix: test262-standalone`). `test262-shared.ts` forks the
+unified worker `scripts/test262-worker.mjs`, passing `target: TEST262_TARGET`
+(`tests/test262-shared.ts:803`), which decides each per-test verdict. The
+`merge-report` job concatenates the shard JSONLs and runs
+`scripts/build-test262-report.mjs` once per lane
+(`.github/workflows/test262-sharded.yml:601-635`). `tests/test262-vitest.test.ts`
+is a **secondary** two-phase (precompile-cache) runner, not the CI path; it
+mirrors the same verdict logic.
+
+### 1. Runner setup — verdict heuristics
+
+**Correct / sound:**
+- Positive-test verdict is a real signal: `test()` must return `1`
+  (`scripts/test262-worker.mjs:1318`, `ret === 1 ? "pass" : "fail"`); `wrapTest`
+  makes the harness return 1 only when assertions hold.
+- Worker recycling is thorough: prototype-poison restore + realm-canary drift
+  detection request a fork recycle (`scripts/test262-worker.mjs:503-784, 1428-1627`),
+  and the pool retries poison-class verdicts in a clean fork
+  (`tests/test262-shared.ts:826-964`). This is the right defense against the
+  in-process cross-test-state contamination the review flagged.
+- `instantiate`-time throws are correctly split: `CompileError`/`LinkError` →
+  `compile_error`+`malformed_wasm` hard-error bucket; a start-function throw →
+  `fail` (`scripts/test262-worker.mjs:1247-1281`, `tests/test262-vitest.test.ts:730-751`).
+- Skip filters are narrow and each carries an issue reference
+  (`tests/test262-runner.ts:324-397`); proposals are excluded by default and
+  counted separately, not silently dropped.
+
+**Wrong / misleading — DEFECT (→ #2912):** negative `phase:parse|early|resolution`
+tests are recorded **pass on ANY compile error**. The intended error-code gate is
+dead code: `scripts/test262-worker.mjs:1150` is `status: hasEarlyError ? "pass" :
+"pass"` (both arms identical), and `tests/test262-vitest.test.ts:616-624` has the
+same `if (hasEarlyError) …pass… else …pass…` shape. `ES_EARLY_ERRORS` and
+`hasEarlyError` are computed and thrown away; the runner never checks the test's
+`negative.type`. This inflates the negative-test pass population equally on both
+lanes.
+
+**Misleading — warning→pass (caveat, tracked under #2855/#2898):** the verdict
+gate blocks only on `severity === "error"` (`scripts/test262-worker.mjs:1103`),
+so a compile that emits **warnings** proceeds to execute. Because the IR/codegen
+fallback demotes non-hard failures to warnings
+(`src/codegen/index.ts:1054`, `severity: hard ? "error" : "warning"`), a
+miscompiled test that still returns `1` can be scored pass. #2898's own
+resolution documents a negative test that "only 'passed' incidentally via the
+runner's warning→pass heuristic." Not separately filed — it is the exact thing
+#2855 (retire IR fallback demotion) is chartered to remove; noted here and cross-
+referenced from #2912.
+
+### 2. Host vs standalone modes
+
+**Correct:** the two lanes are produced from the **same population** (same chunk
+files, same `shouldSkip`) under different `TEST262_TARGET`
+(`.github/workflows/test262-sharded.yml:428-451`). Each lane's rows carry a
+`host_import_leak_class` computed by the worker
+(`scripts/test262-worker.mjs:803-826`) so the report can tell host-satisfied
+passes from host-free ones. The standalone report headlines on the **honest**
+metric `host_free_pass = status==="pass" && !host_import_leak_class`
+(`scripts/build-test262-report.mjs:844`, #2879), and the #2097 absolute floor
+keys on the same field (`scripts/check-standalone-highwater.mjs:28` reads
+`full_summary.host_free_pass`; highwater is fresh — `host_free_pass: 15043`,
+`generated_at 2026-06-30`). This is a sound design: a leaky (host-dependent) pass
+under `--target standalone` is credited as `leaky_pass`, not as standalone
+conformance.
+
+### 3. Classification correctness
+
+**Sound axis, one real divergence.** Host↔standalone is split on a sound axis
+(same tests, different target, honest host-free crediting — see item 2). A
+host-only test does **not** deflate/inflate unfairly: under standalone it either
+fails to compile (counted in `total`) or passes-but-leaky (in `total`, excluded
+from `host_free_pass`), so it stays in the shared denominator without being
+mis-credited.
+
+**DEFECT (→ #2914):** the **per-edition** standalone numbers use a *different*
+pass definition than the standalone headline. Per #2636 the standalone editions
+file is produced by running the host classifier over the standalone JSONL
+(`scripts/run-pages-build.mjs:47-63`, `generate-editions.ts --results …standalone-current.jsonl`),
+but `scripts/generate-editions.ts` counts raw `status === "pass"`
+(`normalizeStatus`, lines 457-461) and its record type has no
+`host_import_leak_class` (lines 487-493) — no host-free notion at all. So the
+landing-page standalone **donut** shows host-free while the standalone **edition
+slider** shows leaky-inflated per-edition rates. The edition *classifier*
+(es5id/es6id/features/path) is shared and fine; the divergence is purely the
+pass definition. (#2910, cited by this review as the classifier cross-check, has
+no issue file on `origin/main` or the review branch — only referenced in
+`related:`; treated as "no divergent second classifier exists," the single
+classifier is `generate-editions.ts`.)
+
+### 4. Pass-rate math
+
+**Denominators — correct:** `build-test262-report.mjs` cleanly separates
+`standard`/`annex_b` (official headline) from `proposal`
+(`scripts/build-test262-report.mjs:856-865, 897-926`); skips are counted but
+excluded from `compilable`. Host and standalone totals are over the same
+population → **comparable in principle**.
+
+**DEFECT (→ #2913): duplicate rows are double-counted.** `build-test262-report.mjs`
+does `statuses.total++` / `statuses[status]++` per record with **no dedup**
+(`scripts/build-test262-report.mjs:846`; no `seen` set anywhere in `main()`),
+and `generate-editions.ts` buckets per-record with no dedup either. Measured on
+the committed baselines 2026-07-01:
+- host `test262-current.jsonl`: 48,142 rows / 48,088 distinct files → **54
+  duplicate rows**, ALL in `language/module-code`, **27 with disagreeing
+  statuses** (`compile_error` on one row, `fail` on the other for the same file).
+- `test262-standalone-results.jsonl`: 48,117 rows / 48,088 distinct → **29 dups**.
+
+`findTestFiles` returns each file once (`tests/test262-runner.ts:2630-2644`) and
+each category is iterated once (`tests/test262-shared.ts:456-470`) — so this is a
+double-**write** (most likely the retry path `tests/test262-shared.ts:826-964`,
+which the code even warns can double-write at lines 766-774), not enumeration.
+Magnitude ~0.1% of the denominator, but it makes the headline **non-deterministic**
+(the duplicated row's status depends on retry timing).
+
+### 5. Baseline & staleness
+
+**Correct machinery:** the committed host summary
+`benchmarks/results/test262-current.json` is fresh (`baseline_sha 20474543…`,
+`generated_at 2026-06-30T23:50Z`, 33,147/43,135). The staleness self-check
+watches **both** floors in the baselines repo
+(`scripts/check-baseline-floor-staleness.mjs:215-216`,
+`test262-standalone-current.json` + `test262-current.json`), counting only
+test262-relevant commits, threshold 25, exit-2-on-breach without ever promoting
+(sound: never blocks on uncertainty). The authoritative JSONL is fetched fresh
+from `loopdive/js2wasm-baselines` (`scripts/fetch-baseline-jsonl.mjs`), not the
+committed blob.
+
+**Caveat (not separately filed):** the **committed** standalone report in the main
+repo is stale and mislabeled — `benchmarks/results/test262-standalone-report.json`
+symlinks a 2026-06-16 file with an **empty `baseline_sha`** and `summary.pass =
+20274` (a raw-pass number, ~2 weeks behind the host summary and inconsistent with
+the fresh highwater's host-free 15043/official 14694). It is a fallback, not the
+dashboard's live source (#2636 has the Pages build fetch fresh standalone JSONL),
+but it is a stale, easily-misread artifact in-tree. Overlaps existing
+staleness/deploy issues (#1880, #1885); flagged here rather than re-filed.
+
+### Overall verdict
+
+**The reported host + standalone pass rates are broadly trustworthy and
+comparable, with three enumerated caveats.**
+
+- **Comparable?** Yes — both lanes run the identical test population under the
+  same skip filter and are aggregated by the same report builder; standalone is
+  credited honestly on `host_free_pass`, and the #2097 floor guards it. The
+  host/standalone split is on a sound axis.
+- **Exactly trustworthy?** Not to the last ~0.1–0.5%. Three defects make the
+  numbers slightly optimistic and/or non-deterministic, in priority order:
+  1. **#2912** — negative parse/early tests pass on any compile error (dead
+     error-code gate); inflates the negative population on **both** lanes.
+     Needs a **PO decision** (tighten-and-re-baseline vs. document the lenient
+     policy + delete dead code) → this issue is left `in-review`.
+  2. **#2914** — standalone per-edition slider counts leaky passes while the
+     donut/floor count host-free; the two standalone surfaces disagree.
+  3. **#2913** — duplicate result rows are double-counted (no dedup in the
+     report/editions builders); makes the headline non-deterministic.
+- None of the three breaks host↔standalone comparability (they hit both lanes
+  symmetrically, or only the standalone *edition* sub-view). The core headline
+  (host 76.8%, standalone host-free ~34% official) is directionally sound.

--- a/plan/issues/2912-negative-test-verdict-dead-early-error-gate.md
+++ b/plan/issues/2912-negative-test-verdict-dead-early-error-gate.md
@@ -1,0 +1,81 @@
+---
+id: 2912
+title: "test262 runner marks negative parse/early tests pass on ANY compile error (dead `? \"pass\" : \"pass\"` gate)"
+status: ready
+priority: medium
+sprint: current
+created: 2026-07-01
+feasibility: medium
+task_type: bug
+area: tooling
+goal: developer-experience
+related: [2911, 2898]
+---
+
+# #2912 — Negative parse/early tests pass on ANY compile error; the error-code gate is dead code
+
+Found during the #2911 test262-setup audit.
+
+## Problem
+
+For a negative test with `phase: parse | early | resolution`, the runner is
+supposed to count it as a conformance pass only when the compiler rejected the
+program for the *right* reason. The code computes `hasEarlyError` from an
+`ES_EARLY_ERRORS` code set — then throws the result away with a ternary whose
+two arms are identical:
+
+- **`scripts/test262-worker.mjs:1146-1155`** (the authoritative CI worker):
+  ```js
+  if (execute && isNegative) {
+    const ES_EARLY_ERRORS = new Set([1102, 1103, 1210, 1213, 1214, 1359, 1360, 2300, 18050]);
+    const hasEarlyError = errorCodes.some((c) => ES_EARLY_ERRORS.has(c));
+    sendResult({ id, status: hasEarlyError ? "pass" : "pass", ... });  // both arms "pass"
+  }
+  ```
+- **`tests/test262-vitest.test.ts:616-626`** (secondary two-phase runner) has the
+  same shape:
+  ```js
+  if (hasEarlyError) { recordResult(..., "pass", ...); }
+  else               { recordResult(..., "pass", ...); }   // both "pass"
+  ```
+
+Net effect: a `phase:parse|early|resolution` test is recorded **pass whenever
+the compiler emits any compile error**, regardless of the error code or type.
+`ES_EARLY_ERRORS` + `hasEarlyError` are dead code that *look* like a gate.
+
+## Why it's a defect
+
+- **Inflates the negative-test pass count.** A negative test that our compiler
+  rejects for an *unrelated* reason (an unsupported-syntax CE, a codegen bug, a
+  TS parse error on a different construct) is scored as a conformance pass — we
+  never verify the rejection is the spec-mandated `SyntaxError`/`type`.
+- **No error-type verification at all.** test262 negative metadata carries the
+  exact `type` (e.g. `SyntaxError`); the runner ignores it.
+- **Interacts with the warning→pass fragility (#2898).** #2898's resolution
+  notes a negative test that "only 'passed' incidentally via the runner's
+  warning→pass heuristic" — the verdict gate at `test262-worker.mjs:1103` blocks
+  only on `severity === "error"`, so a compile that emits *warnings* (e.g. the
+  IR-fallback demotion at `src/codegen/index.ts:1054`, `severity: hard ? "error"
+  : "warning"`) sails through to execution/instantiation and can be scored pass.
+
+Applies identically to host (`gc`) and standalone targets, so it does **not**
+break host↔standalone comparability, but it makes **both** lanes optimistic on
+the negative-parse/early population.
+
+## Fix direction
+
+- Make the ternary a real gate: pass only when `hasEarlyError` (an ES early-error
+  code was raised) OR the compile error's reported type matches the test's
+  `negative.type`. Otherwise record `compile_error`/`fail`, not `pass`.
+- Consider verifying `negative.type` for the instantiate-fails arm too
+  (`test262-worker.mjs:1220-1236`).
+- **Judgment call for the PO:** tightening this will *lower* the reported pass
+  count (some current "passes" flip to fail) while making the number honest.
+  Decide whether to (a) land the gate + re-baseline, or (b) keep the lenient
+  "rejected-for-any-reason = pass" policy but *delete the dead `ES_EARLY_ERRORS`
+  code* and document the policy so it stops masquerading as a strict gate.
+
+## Acceptance
+- No dead `? "pass" : "pass"` gate; negative-test verdict is either a real
+  error-type/early-error gate or an explicitly-documented lenient policy.
+- Behaviour identical across `gc` and `standalone` targets.

--- a/plan/issues/2913-report-double-counts-duplicate-records.md
+++ b/plan/issues/2913-report-double-counts-duplicate-records.md
@@ -1,0 +1,79 @@
+---
+id: 2913
+title: "test262 report + editions double-count duplicate result rows (no dedup by file)"
+status: ready
+priority: medium
+sprint: current
+created: 2026-07-01
+feasibility: medium
+task_type: bug
+area: tooling
+goal: developer-experience
+related: [2911]
+---
+
+# #2913 — Merged test262 report and editions double-count duplicate result rows
+
+Found during the #2911 test262-setup audit.
+
+## Problem
+
+The merged results JSONL contains duplicate rows for some tests, and the report
+builders count **every row** with no dedup, so the same test lands in the
+pass/total numerator and denominator more than once.
+
+Evidence (committed baselines, measured 2026-07-01):
+
+- `benchmarks/results/test262-current.jsonl` (host): 48,142 records over 48,088
+  distinct files → **54 duplicate rows**; **all** in category
+  `language/module-code`; **27 of the 54** have *disagreeing* statuses
+  (`compile_error` on one row, `fail` on the other) for the same file.
+- `benchmarks/results/test262-standalone-results.jsonl`: 48,117 records over
+  48,088 distinct files → **29 duplicate rows**.
+
+Counting sites with no dedup:
+
+- **`scripts/build-test262-report.mjs:846`** — `statuses.total++` /
+  `statuses[status]++` runs per record; there is no `seen`/dedup set anywhere in
+  `main()` (`scripts/build-test262-report.mjs:822-888`).
+- **`scripts/generate-editions.ts`** — buckets each `ResultRecord` with no dedup
+  (`normalizeStatus` + per-record accumulate), so editions inherit the same
+  double-count.
+
+## Root cause (direction, not yet pinned)
+
+Not enumeration: `findTestFiles` (`tests/test262-runner.ts:2630-2644`) is a
+`readdirSync` directory walk + `.sort()` that returns each file once, and
+`runTest262Chunk` iterates each `TEST_CATEGORIES` entry once
+(`tests/test262-shared.ts:456-470`). The dups are same-category, same-file, and
+sometimes carry *different* statuses — the signature of a **double-WRITE**, most
+likely the poison/flake **retry path** in `tests/test262-shared.ts:826-964`
+recording both the original and the retry row (the code even warns about a
+double-write hazard at `tests/test262-shared.ts:766-774`), or a shard artifact
+concatenated twice in `merge-report`
+(`.github/workflows/test262-sharded.yml:601-613`).
+
+## Impact
+
+Small in magnitude (~0.1% of the denominator) but it makes the headline pass
+rate **non-deterministic** (a duplicated row's status depends on retry timing)
+and means host and standalone totals are each computed over a population that is
+not exactly one-row-per-test. Because both lanes go through the same
+`build-test262-report.mjs`, comparability is preserved, but both numbers are
+slightly wrong and can drift run-to-run.
+
+## Fix direction
+
+1. **Defensive dedup in the report builder** — in
+   `scripts/build-test262-report.mjs`, key on `record.file` (last-write-wins, or
+   deterministic worst-status precedence `compile_error > fail > pass`) before
+   counting. Same in `scripts/generate-editions.ts`.
+2. **Fix the source of the duplicate write** — trace the retry path in
+   `tests/test262-shared.ts:826-964`: ensure exactly one `recordResult` per test
+   (the retry must *replace*, not append). Confirm `merge-report` isn't
+   concatenating a shard artifact twice.
+
+## Acceptance
+- A merged JSONL with N distinct files produces a report whose
+  `summary.total === N_official`; duplicate rows never double-count.
+- No same-file duplicate rows emitted by the runner for the retry path.

--- a/plan/issues/2914-standalone-editions-count-leaky-pass.md
+++ b/plan/issues/2914-standalone-editions-count-leaky-pass.md
@@ -1,0 +1,66 @@
+---
+id: 2914
+title: "Standalone per-edition pass rates count leaky (host-import) passes, diverging from the host-free headline/floor"
+status: ready
+priority: medium
+sprint: current
+created: 2026-07-01
+feasibility: medium
+task_type: bug
+area: tooling
+goal: developer-experience
+related: [2911, 2636, 2879, 2097]
+---
+
+# #2914 — Standalone editions JSON counts raw `pass`, not `host_free_pass`
+
+Found during the #2911 test262-setup audit.
+
+## Problem
+
+The standalone lane has **two different definitions of "pass" in production at
+the same time**:
+
+- **Honest metric (headline + floor).** `scripts/build-test262-report.mjs:844`
+  defines `hostFreePass = status === "pass" && !record.host_import_leak_class`
+  and the `--target standalone` report headlines on `host_free_pass` (#2879).
+  The #2097 absolute floor also keys on it —
+  `scripts/check-standalone-highwater.mjs:28` reads
+  `full_summary.host_free_pass`. This correctly *excludes* "leaky" passes (a
+  standalone-compiled test that only passed because it still pulled a JS host
+  `env::__*` import).
+
+- **Leaky metric (per-edition landing slider).** Per #2636, the standalone
+  per-edition file is produced by running the **host** classifier over the
+  standalone JSONL: `scripts/run-pages-build.mjs:47-63` calls
+  `generate-editions.ts --results …standalone-current.jsonl --output
+  …test262-standalone-editions.json`. But `scripts/generate-editions.ts` counts
+  raw `status === "pass"` (`normalizeStatus`, lines 457-461) and its
+  `ResultRecord` type (lines 487-493) has **no** `host_import_leak_class` field —
+  it has no notion of host-free at all.
+
+So the landing page's standalone **donut/headline** shows the honest host-free
+number while the standalone **ES-edition slider** shows a leaky-pass-inflated
+number for each edition. The two disagree, and the per-edition standalone rates
+are optimistic.
+
+The edition *classifier* (es5id/es6id/features/path → edition) is shared and
+fine — the divergence is purely in the **pass definition**.
+
+## Fix direction
+
+- Give `scripts/generate-editions.ts` a `--host-free` (or `--target standalone`)
+  flag that, when set, counts a pass only when
+  `status === "pass" && !record.host_import_leak_class` — mirroring
+  `build-test262-report.mjs:844`. Wire it in the standalone invocation at
+  `scripts/run-pages-build.mjs:55-59`.
+- Verify the standalone JSONL rows actually carry `host_import_leak_class` (the
+  worker emits it via `metadataFromWorkerResult`; confirm the fetched
+  `test262-standalone-current.jsonl` preserves the field).
+- Keep the host (`gc`) editions counting raw `pass` (host imports are expected
+  there).
+
+## Acceptance
+- Standalone per-edition pass rates and the standalone headline both use
+  `host_free_pass`; the landing-page slider and donut agree for the standalone
+  toggle.


### PR DESCRIPTION
Executes the #2911 audit of the test262 setup and host-vs-standalone pass-rate classification. Docs/issue-files only.

## What's here
- Appends a `## Findings (review 2026-07-01)` section to the #2911 issue file, answering scope items 1–5 with `file:line` evidence, plus an overall verdict.
- Files three concrete follow-up defects (ids via `claim-issue.mjs --allocate`):
  - **#2912** — negative `phase:parse|early|resolution` tests are recorded **pass on ANY compile error**; the intended error-code gate is dead (`scripts/test262-worker.mjs:1150` `status: hasEarlyError ? "pass" : "pass"`, both arms identical; same shape at `tests/test262-vitest.test.ts:616-624`). No `negative.type` verification. **Needs a PO decision** (tighten+re-baseline vs. document lenient policy + delete dead code).
  - **#2913** — merged report + editions **double-count duplicate result rows** (no dedup in `build-test262-report.mjs:846` / `generate-editions.ts`). Measured: 54 host + 29 standalone dup rows; 27 host dups have disagreeing statuses → non-deterministic headline. Likely source: the retry double-write path in `test262-shared.ts:826-964`.
  - **#2914** — standalone **per-edition** slider counts raw `status==="pass"` (`generate-editions.ts` fed the standalone JSONL via `run-pages-build.mjs:47-63`) while the standalone **donut/floor** count `host_free_pass` (`build-test262-report.mjs:844`, `check-standalone-highwater.mjs:28`). The two standalone surfaces disagree.

## Verdict
Host + standalone pass rates are **comparable and broadly trustworthy** (same test population, same skip filter, same report builder; standalone credited honestly on `host_free_pass` and guarded by the #2097 floor), with the three enumerated caveats above making them slightly optimistic and/or non-deterministic at the ~0.1–0.5% level. #2911 left `in-review` pending the #2912 PO decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS