### PR TITLE
docs(#2872,#2909,#2162): measure-first verdicts — 2 stale fronts, 1 blocked

### DIFF
--- a/plan/issues/2162-standalone-map-set-weak-collections-residual.md
+++ b/plan/issues/2162-standalone-map-set-weak-collections-residual.md
@@ -377,3 +377,37 @@ the umbrella as `done` once the 4 sub-issues are confirmed merged (they are), wi
 the residual carried by #2580/#2104 (value-rep), #1472/#2158 (reflection),
 #2622 (native subclass), and the iterator-object follow-up. No new dev slice from
 this architect pass — do NOT re-dispatch #2162 as fresh dev work.
+
+## Re-measurement (2026-07-01, sdev-tail) — residual leaks are NOT pass-convertible; no follow-up filed
+
+A "round-2 residual" of ~33 sole leaks (`WeakMap_new`/`WeakSet_new`/`Set_new`/
+`Set_forEach`/`Set_entries`) was floated as a candidate follow-up. **Measured on
+current main** (`a8dba40bc`) — leak probe (env-import section of the emitted
+standalone module) + host-vs-standalone `runTest262File` pass/fail:
+
+| Leak class | leaks | of those, host-pass AND standalone-fail (convertible) |
+|---|---|---|
+| `WeakMap_new` (ctor-with-iterable) | 23 | **2** (`empty-iterable`, `get-set-method-failure`) |
+| `WeakSet_new` (ctor-with-iterable) | 13 | **0** convertible (1 host-pass but sa=compile_error) |
+| `Set_forEach`/`Set_entries`/`Set_new` | ~10 | **0** convertible (all host=compile_error except 1) |
+
+**~30 of the ~33 leaking tests are `host=compile_error`** — they do not compile in
+**host** mode either (they use custom-iterator / `$262` / Symbol.iterator-protocol
+harness objects the compiler doesn't yet accept). They are therefore **not
+leaky-passes**: removing the host-import leak cannot convert them to
+host-free-pass, because they never passed. This is the exact "host-free ≠ pass"
+trap — the leak is real but the pass-conversion is not. The ~3 genuinely
+host-passing candidates each need bespoke constructor-iterable / error-path
+semantics and even then land as `compile_error`/`fail` standalone (the native
+side CEs, not merely leaks) — marginal value for the substrate cost.
+
+The big Set leak clusters (`__gen_create_buffer`/`__create_generator`/
+`__get_caught_exception`, ~38 each) are the **set-like-object dynamic-read**
+family (`prototype/{difference,isSubsetOf,…}/allows-set-like-object`) — the
+value-rep / `__dyn_get` substrate already tracked to **#2580 M2**, not a native
+body.
+
+**Disposition:** no new follow-up issue filed — it would be a stale front. The
+collection residual is substrate-deferred (#2580/#2104, #1472/#2158) exactly as
+the umbrella reconciliation above concluded; this pass confirms it with concrete
+leaky-vs-convertible counts.

--- a/plan/issues/2872-standalone-typedarray-prototype-cluster.md
+++ b/plan/issues/2872-standalone-typedarray-prototype-cluster.md
@@ -1,7 +1,7 @@
 ---
 id: 2872
 title: "Standalone: TypedArray.prototype.* cluster (294 host-pass/standalone-fail, de-masked from #2862)"
-status: ready
+status: blocked
 created: 2026-06-30
 priority: high
 task_type: bug
@@ -13,6 +13,34 @@ related: [2860, 2870, 2862, 2651, 2885, 2876, 2893]
 umbrella: 2860
 blocked_on: 2893
 ---
+
+## Measure-first verdict (2026-07-01, sdev-tail) — CONFIRMED BLOCKED, brand not on main
+
+Do **not** dispatch the residual TypedArray.prototype *method* native-body work
+yet. The dependency #2893 (distinct %TypedArray% view brand) is **NOT on main** —
+its implementation lives in **OPEN PR #2395** (`feat(#2901,#2893): standalone
+%TypedArray% intrinsic ctor chain + integer-view accessor getters`, by
+sr-typedarray). Only the #2893 *docs/spec* PR (#2376) merged; the brand runtime
+has not. Marked `status: blocked` to stop it being pulled off the `current`
+TaskList before the brand lands.
+
+**Measured** on current main (leak-probe over `built-ins/TypedArray/prototype/fill`,
+51 files): the method leaks that remain are **not** brand-independent. `.fill()`
+on a **statically-typed** concrete TA (`Int8Array` etc.) already lowers host-free
+(20/51 host-free). The residual leaks are on an **`any`/opaque-externref** receiver
+(the `testWithTypedArrayConstructors(TA => …)` callback form): `.fill` there
+dispatches through the generic extern-method resolver and leaks
+`CanvasRenderingContext2D_fill` (a name-collision host import) — 12/51. A native
+body for that path needs a **runtime brand** to classify an opaque externref as a
+TA view vs a plain `number[]` (TA views share the `$Vec` type with plain arrays,
+no tag — the exact #2893 gap). So the method work is **brand-gated too**, not just
+the reflective getter/descriptor subset. Building it now (branching off main
+without the brand) risks the plain-array-vs-view mis-dispatch regression this
+umbrella already warns about.
+
+**Unblock condition:** PR #2395 (#2893 brand) merges to main. Then predecessor-stack
+the method native bodies on that landed work (or branch fresh from the post-#2395
+main). Until then this stays `blocked`.
 
 > **Blocked on #2893** (distinct %TypedArray% view brand). Traced 2026-06-30: the
 > #2885 gOPD synthesis + #2876 reflective `.call` machinery light up the reflective

--- a/plan/issues/2909-standalone-mapped-arguments-descriptor-native-read.md
+++ b/plan/issues/2909-standalone-mapped-arguments-descriptor-native-read.md
@@ -3,12 +3,45 @@ id: 2909
 title: standalone mapped-arguments [[DefineOwnProperty]] descriptor semantics under fully-native read
 area: codegen-standalone
 feasibility: hard
-status: ready
+status: wont-fix
 related: [2908, 1472]
 sprint: Backlog
 priority: low
 horizon: m
 ---
+
+## Measure-first verdict (2026-07-01, sdev-tail) — NOT REPRODUCIBLE, closing wont-fix
+
+Re-measured on a tree that **includes #2908** (fix commit `005e92a6b` verified an
+ancestor of the measured HEAD `a8dba40bc`), i.e. the post-#2908 fully-native
+`obj[key]` read is in effect. Ran the whole `language/arguments-object/mapped/**`
+corpus (43 files) host-mode vs `--target standalone` via
+`runTest262File(..., "standalone")`:
+
+```
+CONVERTIBLE (host=pass, standalone=fail) = 0
+both-pass  = 39
+other      = 4   (all host=fail AND standalone=fail — pre-existing gaps that
+                  affect HOST too, so not standalone-specific)
+```
+
+Every host-passing mapped-arguments test **also passes standalone**. The
+env-import leak is likewise gone: the whole `mapped/**` dir compiles **host-free**
+(`leaky=0` — zero `env::` imports in the emitted module). The specific descriptor
+test this issue cited,
+`nonconfigurable-nonwritable-descriptors-set-by-arguments.js`, is **both-pass**
+(host=pass, sa=pass). The 4 `other` files
+(`enumerable-configurable-accessor-descriptor.js`,
+`nonconfigurable-descriptors-define-failure.js`,
+`nonwritable-nonenumerable-nonconfigurable-descriptors-set-by-define-property.js`,
+`writable-enumerable-configurable-descriptor.js`) fail **identically** in host and
+standalone — a host-mode gap, out of scope for a standalone-specific issue.
+
+**Conclusion:** the predicted pass→host-free-fail flip (#2908 exposing a native
+mapped-arguments `[[DefineOwnProperty]]`/mapping-removal gap) does **not**
+reproduce on current main — #2908 as-merged did not regress these tests. There is
+nothing to convert. Closing `wont-fix`; re-file with a concrete
+host-pass/standalone-fail repro if one surfaces.
 
 ## Problem
 


### PR DESCRIPTION
## Summary

Measure-first pass over the three standalone-tail fronts before any implementation. All three are **stale or blocked** — this PR banks the verdicts in the issue files so future sessions do not re-chase them. **No code change** (issue-file annotations only).

Method: leak-probe over the emitted standalone module's `env::` import section + host-vs-standalone `runTest262File` pass/fail, on current main (`a8dba40bc`; #2908 fix `005e92a6b` verified an ancestor).

### #2909 mapped-arguments descriptor → `wont-fix` (NOT REPRODUCIBLE)
All 43 `language/arguments-object/mapped/**` tests behave identically host vs standalone: **39 both-pass, 4 both-fail, 0 host-pass/standalone-fail**. The dir is host-free (`leaky=0`). The predicted #2908 pass→host-free-fail flip does not happen; the cited descriptor test is both-pass.

### #2872 TypedArray.prototype methods → `blocked` (was `ready` on `sprint:current`)
The #2893 view brand is **NOT on main** — it lives in **OPEN PR #2395**; only the #2893 docs PR #2376 merged. Measured: the residual method leaks (e.g. `CanvasRenderingContext2D_fill` on an `any`-receiver) are **brand-gated too**, not just the reflective getters (statically-typed TA `.fill` already lowers host-free). Building now risks the plain-array-vs-view mis-dispatch regression. Unblock when #2395 lands.

### #2162 collection residual → no follow-up filed (NOT PASS-CONVERTIBLE)
Of the ~33 `WeakMap_new`/`WeakSet_new`/`Set_new`/`Set_forEach`/`Set_entries` leaking tests, **~30 are `host=compile_error`** — they fail in host mode too, so they are not leaky-passes and removing the leak cannot convert them. Only ~3 are genuine host-pass, and even those land `compile_error`/`fail` standalone. `host-free != pass`. Residual stays substrate-deferred (#2580/#2104, #1472/#2158) as the umbrella already concluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8