### PR TITLE
feat(#2863): native standalone Object.groupBy (array/array-like receiver)

### DIFF
--- a/plan/issues/2863-standalone-dynamic-shape-get-builtin.md
+++ b/plan/issues/2863-standalone-dynamic-shape-get-builtin.md
@@ -1,9 +1,10 @@
 ---
 id: 2863
 title: "Standalone: dynamic-shape object/property ops refused — __get_builtin (reflective builtin/namespace read), __extern_toLocaleString, __object_groupBy/fromEntries"
-status: ready
+status: done
 created: 2026-06-30
-updated: 2026-06-30
+updated: 2026-07-02
+completed: 2026-07-02
 priority: high
 feasibility: medium
 task_type: feature
@@ -11,7 +12,7 @@ area: codegen
 goal: standalone
 sprint: current
 horizon: m
-related: [2860, 1472, 2861]
+related: [2860, 1472, 2861, 2864]
 umbrella: 2860
 ---
 
@@ -29,12 +30,12 @@ supported in --target standalone (#1472 Phase B).
 
 ### Impact (measured 2026-06-30) — 365 standalone-only failures (all CE)
 
-| op | tests | meaning |
-| -- | ----- | ------- |
-| `__get_builtin` | 314 | reflective read of a built-in/namespace member that missed every fast path |
-| `__extern_toLocaleString` | 34 | `.toLocaleString()` on a dynamic receiver |
-| `__object_groupBy` | 10 | `Object.groupBy` |
-| `__object_fromEntries` | 7 | `Object.fromEntries` |
+| op                        | tests | meaning                                                                    |
+| ------------------------- | ----- | -------------------------------------------------------------------------- |
+| `__get_builtin`           | 314   | reflective read of a built-in/namespace member that missed every fast path |
+| `__extern_toLocaleString` | 34    | `.toLocaleString()` on a dynamic receiver                                  |
+| `__object_groupBy`        | 10    | `Object.groupBy`                                                           |
+| `__object_fromEntries`    | 7     | `Object.fromEntries`                                                       |
 
 ## Root cause
 
@@ -54,8 +55,10 @@ umbrella #2860 and with #2861.
 ## Implementation Plan
 
 ### Phase 1 — namespace static reads (the bulk of `__get_builtin`)
+
 **File: `src/codegen/property-access.ts`** (`compileMemberRead` / the
 `__get_builtin` shortcut site, ~line 382)
+
 - For `Math`/`JSON`/`Reflect`/`Atomics`/`Number`/`Symbol` **namespace** members
   with a statically-known property name:
   - **Data constants** (`Math.PI`, `Math.E`, `Math.LN2`, `Number.MAX_SAFE_INTEGER`,
@@ -68,17 +71,20 @@ umbrella #2860 and with #2861.
     factory, property-access.ts:686 / the #2175 `"static"` path).
 
 ### Phase 2 — `__extern_toLocaleString`
+
 - Route `.toLocaleString()` on a dynamic receiver to the receiver's
   `.toString()` native path (per spec the default `Object.prototype.toLocaleString`
   calls `toString`); for Number/Array/Date use the existing native toString.
 
 ### Phase 3 — `Object.groupBy` / `Object.fromEntries`
+
 - Implement as native helpers over the `$Object` runtime + iterator protocol.
   `fromEntries` depends on the iterator carrier — sequence AFTER #2864 if it
   needs generic iteration; the common `Object.fromEntries(array)` case can use
   the `$__vec_base` fast path now.
 
 ### Edge cases
+
 - A genuinely dynamic `obj[expr]` where `obj` is user-typed must keep routing to
   the typed struct.get fast path, not `__get_builtin` (unchanged).
 - Shadowed namespace identifiers (`const Math = …`) → keep refusing / route to
@@ -87,6 +93,7 @@ umbrella #2860 and with #2861.
 ## Test plan
 
 Standalone CE → pass:
+
 - `test/built-ins/Math/**` (PI/LN2/E value reads, max/min static methods)
 - `test/built-ins/Atomics/**`, `test/built-ins/JSON/**`, `test/built-ins/Reflect/**`
 - `test/built-ins/TypedArray/prototype/toLocaleString/**`
@@ -114,3 +121,58 @@ Full `merge_group` + standalone high-water; zero host-mode regression
 - **Phase 3 (`Object.groupBy`/`fromEntries`)** — NOT started. `Object.groupBy`
   also needs a lib-types update (currently a TS-level "does not exist on
   ObjectConstructor" error, separate from codegen).
+
+## Progress (2026-07-02) — remeasured vs current main, groupBy landed. status → done
+
+Re-probed every op in the impact table against current `main` (standalone
+`compile(..., { target: "standalone" })`). The bulk of the original `__get_builtin`
+(314) bucket has already been closed by intervening work; the genuine remainder
+splits cleanly into two OTHER issues, and the one self-contained slice left in
+`#2863`'s own title (`__object_groupBy`) is implemented here.
+
+- **`__get_builtin` (was 314) — essentially RESOLVED on current main.** Namespace
+  static data reads (`Math.PI`/`E`/`LN2`, `Number.MAX_SAFE_INTEGER`) fold to
+  constants, and static-method **calls** (`Math.max(…)`, `JSON.stringify(…)`,
+  `JSON.parse`, `Reflect.ownKeys(…)`, `Reflect.has`, `Number.isNaN`,
+  `String.fromCharCode`, `Array.isArray`/`of`, `Object.keys`, `Symbol.iterator`)
+  now compile in standalone without hitting the `__get_builtin` refusal. What
+  remains are NOT `#2863`:
+  - static-method **value reads** (`const f = JSON.stringify; f(x)`,
+    `Math.max`/`Number.isInteger` as a value) → still refuse with the
+    `#1907 / #1888 S6-b` "built-in static property value read" message → owned by
+    **#2861**.
+  - a few reflective _correctness_ bugs (not CE): `Math[computedKey]` and
+    `Reflect.ownKeys(o).length` read back `0`; `globalThis.Math.PI` traps. Wrong
+    value, not a refusal — left for a targeted follow-up under umbrella **#2860**.
+- **`__extern_toLocaleString` (34) — DONE** (Phase 2, prior slice).
+- **`__object_groupBy` (10) — DONE (this slice), array / array-like receiver.**
+  Native Wasm helper `ensureObjectGroupBy` (`object-runtime.ts`): iterates the
+  items via `__extern_length`/`__extern_get_idx` (real Array `$__vec_base` +
+  array-like `$Object`), invokes the callback through the proven open-`any`
+  closure bridge `__apply_closure` (`keyFn(value, index)`, adapts to arity ≤ 2),
+  and groups the ORIGINAL elements into a null-proto `$Object` of `$ObjVec`
+  arrays keyed by `ToPropertyKey(callback result)` (uniform via
+  `__extern_get`/`__extern_set`). Registered lazily from the call site
+  (`expressions/calls.ts`, append-only — no funcidx shift); the callback lowers
+  via `compileArrowAsClosure` (NOT `__make_callback`, which would leak an `env`
+  import). Zero host imports in the emitted module. The lib-types 2550 "does not
+  exist on ObjectConstructor" diagnostic is **non-fatal** in both modes (host
+  mode already compiled groupBy fine), so no lib change was needed. Host (gc)
+  mode keeps the `__object_groupBy` import unchanged. Tests:
+  `tests/issue-2863-standalone-groupby.test.ts`.
+  - **Gate:** only array-like items (numeric index signature / array literal)
+    take the native path. `Map`/`Set`/generic iterables keep refusing loudly
+    (fail-loud, no silent mis-grouping) — their native iteration is the iterator
+    carrier follow-up **#2864**.
+- **`__object_fromEntries` (7) — array-LITERAL already works** (the existing
+  `$ObjVec` normalization at the call site). The runtime/variable and
+  generic-iterable cases mis-cast through the nested `__extern_get_idx` boundary
+  (`illegal cast` on `[K,V][]`; `0` on `any[]`) — this is the same nested
+  array-of-arrays extraction that the iterator carrier **#2864** owns; deferred
+  there (as the original plan already sequenced).
+
+**Net for #2863:** the ops named in the title are addressed — `__extern_toLocaleString`
+(done), `__object_groupBy` (done, array case), `__get_builtin` (resolved). The
+residual sub-cases are genuinely owned by **#2861** (built-in value reads) and
+**#2864** (iterator carrier → fromEntries/groupBy over generic iterables), so this
+issue is closed and its remainder tracked there under umbrella **#2860**.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -26,7 +26,7 @@ import { classMemberFuncKey } from "../class-member-keys.js"; // (#1983) collisi
 import { ensureNativeIteratorRuntime } from "../iterator-native.js"; // (#2169c) native Array.from drain
 import { reserveClosedMethodDispatch, reserveClosedMethodDispatchVararg } from "../closed-method-dispatch.js";
 import { emitNativeDateParse } from "../date-parse-native.js"; // (#2164) pure-Wasm Date.parse / new Date(str)
-import { ensureObjVecBuilders, ensureObjectRuntime } from "../object-runtime.js";
+import { ensureObjVecBuilders, ensureObjectGroupBy, ensureObjectRuntime } from "../object-runtime.js";
 import {
   emitMicrotaskEnqueue,
   emitStandalonePromiseReject,
@@ -7725,6 +7725,38 @@ function compileCallExpression(
       propAccess.name.text === "groupBy" &&
       expr.arguments.length >= 2
     ) {
+      // (#2863 Phase 3) Standalone has no host `__object_groupBy`; register the
+      // native helper (array / array-like receiver) instead of refusing. The
+      // helper needs the closure bridge, so register it BEFORE lowering the args
+      // (append-only; no funcidx shift of this in-flight function). Generic
+      // iterables (Map/Set/user iterators) are the #2864 iterator-carrier
+      // follow-up and still fall through to the refusing host import below.
+      // Only take the native array/array-like path when the items arg is
+      // indexable (real Array, tuple, `any`, or an array-like with a numeric
+      // index signature). Map/Set/generic iterables have no numeric index →
+      // `__extern_length`/`__extern_get_idx` can't iterate them; keep refusing
+      // loudly there (the #2864 iterator carrier is the follow-up) rather than
+      // silently returning an empty grouping.
+      const gbItemsType = ctx.checker.getTypeAtLocation(expr.arguments[0]!);
+      const gbItemsIndexable =
+        ts.isArrayLiteralExpression(expr.arguments[0]!) || gbItemsType.getNumberIndexType() !== undefined;
+      if (ctx.standalone && gbItemsIndexable) {
+        const groupByIdx = ensureObjectGroupBy(ctx);
+        const iterTypeS = compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "externref" });
+        if (iterTypeS && iterTypeS.kind !== "externref") coerceType(ctx, fctx, iterTypeS, { kind: "externref" });
+        // Compile the callback as a raw GC closure (call_ref via __apply_closure),
+        // NOT a host callback — `compileExpression` on an arrow that flows to a
+        // host import would insert `__make_callback`, leaking an env import into
+        // the standalone module (#2863). Mirrors the array-method callback path.
+        const cbArg = expr.arguments[1]!;
+        const fnTypeS =
+          ts.isArrowFunction(cbArg) || ts.isFunctionExpression(cbArg)
+            ? compileArrowAsClosure(ctx, fctx, cbArg)
+            : compileExpression(ctx, fctx, cbArg, { kind: "externref" });
+        if (fnTypeS && fnTypeS.kind !== "externref") coerceType(ctx, fctx, fnTypeS, { kind: "externref" });
+        fctx.body.push({ op: "call", funcIdx: groupByIdx });
+        return { kind: "externref" };
+      }
       const iterType = compileExpression(ctx, fctx, expr.arguments[0]!, { kind: "externref" });
       if (iterType && iterType.kind !== "externref") coerceType(ctx, fctx, iterType, { kind: "externref" });
       const fnType = compileExpression(ctx, fctx, expr.arguments[1]!, { kind: "externref" });

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -7804,6 +7804,160 @@ export function ensureObjVecBuilders(ctx: CodegenContext): { newIdx: number; pus
 }
 
 /**
+ * (#2863 Phase 3) Native standalone `Object.groupBy(items, keyFn)` — ES2024
+ * §20.1.2.14 (GroupBy with keyCoercion PROPERTY). Under `--target
+ * standalone`/`wasi` there is no host `__object_groupBy`, so the call site
+ * (`expressions/calls.ts`) hits the #1472 dynamic-shape refusal. This registers
+ * a Wasm-native helper that:
+ *
+ *   out = OrdinaryObjectCreate(null)                   // __new_plain_object
+ *   for i in 0 .. __extern_length(items):
+ *     val = __extern_get_idx(items, i)
+ *     key = keyFn(val, i)  via __apply_closure(keyFn, undefined, [val, boxNum(i)])
+ *     group = __extern_get(out, key)                   // ToPropertyKey done inside
+ *     if group is null: group = __objvec_new(); __extern_set(out, key, group)
+ *     __objvec_push(group, val)
+ *   return out
+ *
+ * The keyFn is invoked through the proven open-`any` closure bridge
+ * `__apply_closure` (the same path Proxy traps / `__extern_method_call` use), so
+ * any user callback arity ≤ 2 is dispatched correctly (§ passes `(value,
+ * index)`; a 1-arg arrow ignores the index). ToPropertyKey is applied uniformly
+ * by `__extern_get`/`__extern_set`, so the get-probe and the set use the same
+ * coerced key. Each group value is the ORIGINAL element (a `$ObjVec`, i.e. a
+ * real Array on read-back).
+ *
+ * Registered lazily (append-only — no funcidx shift of the in-flight function)
+ * from the call site, NOT unconditionally in `ensureObjectRuntime`, so a module
+ * with no `Object.groupBy` pays nothing (and does not reserve the closure
+ * bridge). Returns the `__object_groupBy` funcIdx.
+ *
+ * `items` is iterated via `__extern_length`/`__extern_get_idx`, which index a
+ * real Array (`$__vec_base`) and array-like `$Object`s reliably — generic
+ * iterables (Map/Set/user iterators) are the separate iterator-carrier follow-up
+ * (#2864) and are NOT handled here.
+ */
+export function ensureObjectGroupBy(ctx: CodegenContext): number {
+  ensureObjectRuntime(ctx);
+  const existing = ctx.funcMap.get("__object_groupBy");
+  if (existing !== undefined) return existing;
+
+  const applyClosureIdx = reserveApplyClosure(ctx);
+  const newPlainObjectIdx = ctx.funcMap.get("__new_plain_object")!;
+  const externLengthIdx = ctx.funcMap.get("__extern_length")!;
+  const externGetIdxIdx = ctx.funcMap.get("__extern_get_idx")!;
+  const externGetIdx = ctx.funcMap.get("__extern_get")!;
+  const externSetIdx = ctx.funcMap.get("__extern_set")!;
+  const objVecNewIdx = ctx.funcMap.get("__objvec_new")!;
+  const objVecPushIdx = ctx.funcMap.get("__objvec_push")!;
+  const boxNumIdx = ctx.funcMap.get("__box_number")!;
+
+  // params: 0=items 1=keyFn
+  // locals: 2=len(f64) 3=i(i32) 4=out 5=val 6=key 7=group 8=args
+  const body: Instr[] = [
+    { op: "call", funcIdx: newPlainObjectIdx },
+    { op: "local.set", index: 4 },
+    { op: "local.get", index: 0 },
+    { op: "call", funcIdx: externLengthIdx },
+    { op: "local.set", index: 2 },
+    { op: "i32.const", value: 0 },
+    { op: "local.set", index: 3 },
+    {
+      op: "block",
+      blockType: { kind: "empty" },
+      body: [
+        {
+          op: "loop",
+          blockType: { kind: "empty" },
+          body: [
+            // if f64(i) >= len → break
+            { op: "local.get", index: 3 },
+            { op: "f64.convert_i32_s" },
+            { op: "local.get", index: 2 },
+            { op: "f64.ge" },
+            { op: "br_if", depth: 1 },
+            // val = __extern_get_idx(items, f64(i))
+            { op: "local.get", index: 0 },
+            { op: "local.get", index: 3 },
+            { op: "f64.convert_i32_s" },
+            { op: "call", funcIdx: externGetIdxIdx },
+            { op: "local.set", index: 5 },
+            // args = __objvec_new(); push(val); push(box(i))
+            { op: "call", funcIdx: objVecNewIdx },
+            { op: "local.set", index: 8 },
+            { op: "local.get", index: 8 },
+            { op: "local.get", index: 5 },
+            { op: "call", funcIdx: objVecPushIdx },
+            { op: "local.get", index: 8 },
+            { op: "local.get", index: 3 },
+            { op: "f64.convert_i32_s" },
+            { op: "call", funcIdx: boxNumIdx },
+            { op: "call", funcIdx: objVecPushIdx },
+            // key = __apply_closure(keyFn, undefined, args)
+            { op: "local.get", index: 1 },
+            { op: "ref.null.extern" },
+            { op: "local.get", index: 8 },
+            { op: "call", funcIdx: applyClosureIdx },
+            { op: "local.set", index: 6 },
+            // group = __extern_get(out, key)
+            { op: "local.get", index: 4 },
+            { op: "local.get", index: 6 },
+            { op: "call", funcIdx: externGetIdx },
+            { op: "local.set", index: 7 },
+            // if group is null → group = __objvec_new(); __extern_set(out, key, group)
+            { op: "local.get", index: 7 },
+            { op: "ref.is_null" },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [
+                { op: "call", funcIdx: objVecNewIdx },
+                { op: "local.set", index: 7 },
+                { op: "local.get", index: 4 },
+                { op: "local.get", index: 6 },
+                { op: "local.get", index: 7 },
+                { op: "call", funcIdx: externSetIdx },
+              ],
+            },
+            // __objvec_push(group, val)
+            { op: "local.get", index: 7 },
+            { op: "local.get", index: 5 },
+            { op: "call", funcIdx: objVecPushIdx },
+            // i++
+            { op: "local.get", index: 3 },
+            { op: "i32.const", value: 1 },
+            { op: "i32.add" },
+            { op: "local.set", index: 3 },
+            { op: "br", depth: 0 },
+          ],
+        },
+      ],
+    },
+    { op: "local.get", index: 4 },
+  ];
+
+  const typeIdx = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
+  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  ctx.funcMap.set("__object_groupBy", funcIdx);
+  ctx.mod.functions.push({
+    name: "__object_groupBy",
+    typeIdx,
+    locals: [
+      { name: "len", type: { kind: "f64" } },
+      { name: "i", type: { kind: "i32" } },
+      { name: "out", type: { kind: "externref" } },
+      { name: "val", type: { kind: "externref" } },
+      { name: "key", type: { kind: "externref" } },
+      { name: "group", type: { kind: "externref" } },
+      { name: "args", type: { kind: "externref" } },
+    ],
+    body,
+    exported: false,
+  });
+  return funcIdx;
+}
+
+/**
  * (#1888 Slice 1) Reserve the `__apply_closure(externref fn, externref recv,
  * externref args) -> externref` arity-bridge funcIdx with a placeholder
  * `unreachable` body, registered in `funcMap`. The real body (an arity switch

--- a/tests/issue-2863-standalone-groupby.test.ts
+++ b/tests/issue-2863-standalone-groupby.test.ts
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #2863 Phase 3 — standalone `Object.groupBy(array, callback)` no longer refuses.
+//
+// Under `--target standalone`/`wasi` there is no host `__object_groupBy`, so
+// `Object.groupBy([...], fn)` hit the #1472 "dynamic-shape object/property
+// operation is not supported" compile refusal. This slice adds a Wasm-native
+// `__object_groupBy` helper (object-runtime.ts) for array / array-like receivers:
+// it iterates via `__extern_length`/`__extern_get_idx`, invokes the callback
+// through the open-`any` closure bridge `__apply_closure`, and groups the
+// original elements into a null-prototype `$Object` of `$ObjVec` arrays keyed by
+// ToPropertyKey(callback(value, index)) (ES2024 §20.1.2.14, keyCoercion PROPERTY).
+//
+// Generic iterables (Map/Set/user iterators) still refuse loudly — the native
+// iterator carrier is the #2864 follow-up. Host (gc) mode keeps the
+// `__object_groupBy` host import unchanged.
+//
+// String returns from a standalone module are native-string refs; these assert
+// via numeric exports (group `.length`, element values) — never a JS string.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  // A standalone module must not leak any host import (e.g. __object_groupBy or
+  // __make_callback from the callback lowering).
+  expect((r.imports ?? []).map((i) => i.name)).toEqual([]);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2863 Phase 3 — standalone Object.groupBy (array receiver)", () => {
+  it("groups by even/odd string key — correct group sizes (was a compile refusal)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const g: any = Object.groupBy([1, 2, 3, 4, 5, 6], (x: number) => (x % 2 === 0 ? "even" : "odd"));
+           return g.even.length;
+         }`,
+      ),
+    ).toBe(3);
+  });
+
+  it("preserves the original element values in group order", async () => {
+    // g.k === [10, 20, 30]; g.k[1] === 20
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const g: any = Object.groupBy([10, 20, 30], (_x: number) => "k");
+           return g.k[1];
+         }`,
+      ),
+    ).toBe(20);
+  });
+
+  it("passes the index as the second callback argument", async () => {
+    // first two → "lo", last two → "hi"; lo.length + hi.length*10 === 2 + 2*10
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const g: any = Object.groupBy([5, 5, 5, 5], (_x: number, i: number) => (i < 2 ? "lo" : "hi"));
+           return g.lo.length + g.hi.length * 10;
+         }`,
+      ),
+    ).toBe(22);
+  });
+
+  it('ToPropertyKeys a numeric callback result (0/1 → "0"/"1")', async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const g: any = Object.groupBy([1, 2, 3, 4], (x: number) => x % 2);
+           return g["0"].length + g["1"].length * 10;
+         }`,
+      ),
+    ).toBe(22);
+  });
+
+  it("empty array → empty grouping object (callback never called)", async () => {
+    // g has no own key "k" → g.k is undefined → return -1
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const g: any = Object.groupBy([] as number[], (_x: number) => "k");
+           return g.k === undefined ? -1 : g.k.length;
+         }`,
+      ),
+    ).toBe(-1);
+  });
+
+  it("single group collects every element", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number {
+           const g: any = Object.groupBy([1, 2, 3], (_x: number) => "same");
+           return g.same.length;
+         }`,
+      ),
+    ).toBe(3);
+  });
+});
+
+describe("#2863 Phase 3 — non-array iterables still refuse (fail-loud, #2864 follow-up)", () => {
+  it("a Map receiver is refused loudly, not silently mis-grouped", async () => {
+    const r = await compile(
+      `export function test(): number {
+         const m = new Map<number, number>();
+         m.set(1, 2);
+         const g: any = Object.groupBy(m, (_x: any) => "k");
+         return 0;
+       }`,
+      { target: "standalone" },
+    );
+    expect(r.success).toBe(false);
+    expect((r.errors ?? []).some((e) => /__object_groupBy/.test(String(e.message)))).toBe(true);
+  });
+});
+
+describe("#2863 Phase 3 — host (gc) mode is unchanged", () => {
+  it("host mode keeps the __object_groupBy import (native JS Object.groupBy)", async () => {
+    const r = await compile(
+      `export function test(): number {
+         const g: any = Object.groupBy([1, 2, 3, 4], (x: number) => (x % 2 === 0 ? "even" : "odd"));
+         return g.even.length;
+       }`,
+      {},
+    );
+    expect(r.success, JSON.stringify(r.errors)).toBe(true);
+    expect((r.imports ?? []).some((i) => i.name === "__object_groupBy")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Standalone `Object.groupBy(items, keyFn)` hit the #1472 dynamic-shape refusal (no host `__object_groupBy` carrier). This adds a Wasm-native helper for the **array / array-like receiver** case — the common test262 shape.

`ensureObjectGroupBy` (`src/codegen/object-runtime.ts`):
- iterates items via `__extern_length`/`__extern_get_idx` (real Array `$__vec_base` + array-like `$Object`),
- invokes the callback through the open-`any` closure bridge `__apply_closure` (`keyFn(value, index)`, adapts to arity <= 2 so 1-arg arrows work),
- groups the **original** elements into a null-proto `$Object` of `$ObjVec` arrays keyed by `ToPropertyKey(callback result)` (uniform via `__extern_get`/`__extern_set`), per ES2024 §20.1.2.14.

Call site (`src/codegen/expressions/calls.ts`) registers the helper lazily (append-only — no funcidx shift of the in-flight function) and lowers the callback via `compileArrowAsClosure`, **not** `__make_callback` (which would leak an `env` import into the standalone module — verified: emitted module has zero imports).

**Gate / fail-loud:** only array-like items (numeric index signature / array literal) take the native path. `Map`/`Set`/generic iterables keep refusing loudly (their native iteration is the iterator-carrier follow-up #2864) — no silent mis-grouping.

**Host (gc) mode unchanged** — keeps the `__object_groupBy` host import. The lib-types 2550 "does not exist on ObjectConstructor" diagnostic is non-fatal in both modes, so no lib change was needed.

## Re-scope (measured vs current main)

The original `__get_builtin` (314) bucket is essentially **resolved** on current main (namespace static reads fold; static-method *calls* compile). The genuine remainder splits to other issues: static-method **value reads** -> #2861; `fromEntries`/`groupBy` over **generic iterables** -> #2864. `__extern_toLocaleString` was Phase 2 (already merged). So #2863's named ops are addressed and it is marked `status: done` with the residual tracked under umbrella #2860.

## Test plan

- `tests/issue-2863-standalone-groupby.test.ts` — 8 cases: even/odd string keys, value/order preservation, index arg, numeric-key ToPropertyKey coercion, empty array, single group; a Map receiver refuses loudly; host mode keeps the import. All pass.
- Phase 2 `tests/issue-2863-standalone-tolocalestring.test.ts` still green (no regression).
- `tsc --noEmit` clean; prettier clean; standalone module emits **zero** host imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS