### PR TITLE
feat(#2921): bank __drain_microtasks() carrier intrinsic (inert) + architect specs for #2818/#2826

### DIFF
--- a/plan/issues/2818-block-let-captured-by-class-method-captured-globals-ordering.md
+++ b/plan/issues/2818-block-let-captured-by-class-method-captured-globals-ordering.md
@@ -31,7 +31,15 @@ desync.
 
 ```ts
 export function test(): string {
-  { let s = "outer"; class C { m(): string { return s; } } return new C().m(); }
+  {
+    let s = "outer";
+    class C {
+      m(): string {
+        return s;
+      }
+    }
+    return new C().m();
+  }
 }
 // => null   (should be "outer")
 ```
@@ -41,6 +49,7 @@ Also fails for an **arrow inside the method** (`m(){ const g = () => s; return g
 reach `s` either.
 
 Controls that PASS:
+
 - `let s` at **function scope** (not in a block) → "outer" (promotion fires;
   `$C_m` reads `global.get __captured_s`).
 - the same with a hoisted **function declaration** instead of a class → "outer"
@@ -100,6 +109,130 @@ local — already scanned via `extraNodes`), `-static` methods, generator /
 async-generator methods, private methods, and the TDZ flag promotion
 (`__tdz_<name>` global) for a `let`/`const` read before init.
 
+## Implementation Plan
+
+_(architect spec, senior-conflicts 2026-07-02 — written after closing the broad
+attempt PR #2335. Read the `## Merge-group regression` section below FIRST: the
+whole-hog `insideFunction` propagation is proven **−471** and must NOT be retried.)_
+
+### Root cause (exact site)
+
+`compileClassesFromStatements` (`src/codegen/declarations.ts:4431`, nested closure
+in `compileDeclarations`) recurses into the control-flow carriers — `if`
+(~4477), bare `block` (~4484), the `for*`/`while`/`do` loop bodies (~4487),
+`switch` clauses, `try`/`catch`/`finally`, and labeled blocks (~4477–4507) —
+**without forwarding its `insideFunction` parameter**, so those recursions run
+with the default `insideFunction = false`. A class textually nested in a block
+_inside a function body_ is therefore collected + compiled **eagerly** via the
+`else` arm (line 4448 `compileClassBodies` for a declaration; line 4461 for a
+`const C = class{}` expression) at module-collection time — **before** the
+enclosing block's `let`s have been allocated/initialised. Its method body then
+resolves the captured `let` to the `ref.null.extern` graceful fallback
+(`identifiers.ts`), and no `local.get <slot>; global.set __captured_s` value-sync
+is emitted in the enclosing function → the method reads **null**. The fn-scope
+control (a `let` NOT in a block) passes because that class is collected at a
+point where `promoteAccessorCapturesToGlobals`
+(`src/codegen/statements/nested-declarations.ts:128–136`) can promote the local.
+
+### Why the broad fix regressed (PR #2335, net −471) — DO NOT retry
+
+PR #2335 forwarded `insideFunction` through **every** control-flow recursion
+(`compileClassesFromStatements(…, insideFunction)` everywhere). That routes
+**every** block-nested class — including non-capturing ones **and class
+expressions** (`const C = class{}`, line 4458) — into `ctx.deferredClassBodies`
+(lines 4447 / 4460). But the deferred-compile path
+(`compileNestedClassDeclaration`, `nested-declarations.ts:82`) is only reached
+from `compileStatement` for class **declaration statements**; a class
+**expression** in a variable initializer, and some deeply-nested declaration
+shapes, are **never revisited**, so their method/element bodies are silently
+dropped. Merge_group proof: net −471 (545 regressions / 74 improvements, ratio
+736%), two buckets over the 50-gate — `class/dstr` (335) + `class/elements`
+(165); on `class/dstr/async-gen-meth-obj-ptrn-list-err.js` the WAT shrinks
+54869→51844 bytes (≈3 KB of class codegen dropped) and a `runTest262File` probe
+flips it pass→fail. **The invariant this violated: never add a class to
+`deferredClassBodies` unless the deferred path is guaranteed to re-compile that
+exact shape.**
+
+### Work Item A: narrow the deferral to genuine block-`let` capturers only
+
+**Risk**: Medium — touches class-collection ordering, but strictly shrinks the
+set of deferred classes vs PR #2335. **Priority**: 1st.
+
+**File: `src/codegen/declarations.ts`**, `compileClassesFromStatements`
+(line ~4431) and its control-flow recursions (~4477–4507):
+
+- Forward `insideFunction` into the control-flow recursions **only for class
+  _declarations_ that actually capture** an enclosing block-scoped `let`/`const`
+  — never for class expressions, never for non-capturing classes. Concretely,
+  gate the `ctx.deferredClassBodies.add(...)` at line 4447 behind a capture
+  pre-scan: `classMethodCapturesEnclosingBlockLet(stmt, enclosingBlockLets)` —
+  a member-body identifier walk (mirror the existing accessor-capture scan used
+  by `promoteAccessorCapturesToGlobals`) that returns true iff a method/getter/
+  setter/param-default of the class references a name declared `let`/`const` in
+  an enclosing block of the **same function** (not module scope, not a param).
+- All other block-nested classes (non-capturing declarations **and every class
+  expression**, line 4458) stay on the **eager** `else` arm — byte-identical to
+  today, so the −471 `class/dstr` + `class/elements` clusters do not move.
+- Do NOT change the module-level (`insideFunction` already false at top) path.
+
+The #2818 repro (`class C { m(){ return s; } }` capturing block-`let s`) is a
+capturing block-nested **declaration** → it is the _only_ shape this newly
+defers, and it IS reachable by `compileNestedClassDeclaration` via
+`compileStatement` when the block is compiled.
+
+### Work Item B: make the deferred capturer promote in-scope (ordering fix)
+
+**Risk**: Medium — the #1672 stale-global-sync subsystem. **Priority**: 2nd
+(coupled to A; land together).
+
+**File: `src/codegen/statements/nested-declarations.ts`**,
+`compileNestedClassDeclaration` (line ~82):
+
+- With the class now in `deferredClassBodies`, `isDeferred` (line 97) is true so
+  the `structMap.has && !isDeferred` early-return (line 99) is correctly skipped
+  and the body is compiled at the class's **textual position in the block** —
+  i.e. after `let s = "outer"` has executed and been allocated. Verify
+  `promoteAccessorCapturesToGlobals` (lines 128–136) now sees `s` as a live
+  promotable local and emits `(global $__captured_s …)` + the enclosing-function
+  `local.get <s-slot>; global.set __captured_s` sync, and the method body reads
+  `global.get __captured_s`.
+- **#1672 guard**: the `global.set` sync MUST run **after** the block-`let`'s
+  store (not at the pre-hoist slot), and re-sync on any later mutation the method
+  observes. Confirm against the fn-scope accessor-capture regression controls.
+
+### Edge cases (must all be covered by `tests/issue-2818.test.ts`)
+
+- `meth-` / `gen-meth-` / `private-meth-` (+ `-dflt` / `-static`) cluster members
+  return 1. `-dflt`: param-default initializers referencing the outer local are
+  scanned via `extraNodes` — include them in the capture pre-scan.
+- Arrow inside the method (`m(){ const g = () => s; return g(); }`) — the
+  method's capture channel must fire so the inner closure reaches `s`.
+- TDZ: a block-`let`/`const` read before init through the method still throws
+  (promote the `__tdz_<name>` flag global in lockstep).
+- **Non-capturing** block-nested class + **`const C = class{}`** expression stay
+  on the eager path (regression control — these are the −471 shapes).
+- generator / async-generator / static / private methods as capturers.
+
+### Test / validation (REQUIRED)
+
+`tests/issue-2818.test.ts` with the repros + the cluster slice + the fn-scope
+capture regression control + the non-capturing/class-expression eager-path
+controls. **This class of flip only manifests on the merged baseline** — the PR
+checks stub test262. **Validate on a full `merge_group` / local-CI test262 run
+BEFORE re-enqueue** (`JS2WASM_LOCAL_CI=1 ./scripts/local-ci.sh`), and confirm
+**zero** movement in `class/dstr` + `class/elements` (the −471 buckets). A scoped
+sweep cannot see this 545-test cluster.
+
+### Residual design risk to resolve during implementation
+
+The completeness invariant (Work Item A) assumes every _capturing declaration_
+shape the pre-scan defers is reachable by `compileNestedClassDeclaration`.
+Confirm this for capturing classes nested inside `for`/`switch`/`try` bodies
+(not just a bare block) — if any such shape is NOT revisited by
+`compileStatement`, either (i) extend the eager arm to compile it in-scope
+instead of deferring, or (ii) add the missing deferred-compile entry point. Do
+not defer a shape you have not proven is re-compiled.
+
 ## Acceptance criteria
 
 - `{ let s="outer"; class C { m(){ return s; } } new C().m(); }` returns "outer"
@@ -124,6 +257,7 @@ Full conformance is only validated in `merge_group`. So "PR-green" never
 validated test262 here.
 
 **Delta (merge_group, baseline f8c1aa5):**
+
 - **545 regressions / 74 improvements → net −471**, ratio 736%, signature `9c6151da5837060f`.
 - Two buckets EACH over the 50-test gate limit:
   `language/expressions/class/dstr` (335) + `language/expressions/class/elements` (165),
@@ -148,6 +282,7 @@ eager path compiled them correctly (at the cost of the one narrow capture bug
 this issue targets).
 
 **Narrowing direction for the rework — two viable options:**
+
 1. **Defer only when there is an actual capture:** restrict the
    `insideFunction` deferral to classes that genuinely capture a block-scoped
    `let` declared in the enclosing block (the exact #2818 case), and keep all

--- a/plan/issues/2826-block-let-immutably-captured-by-async-gen-cps-leading-param-slot.md
+++ b/plan/issues/2826-block-let-immutably-captured-by-async-gen-cps-leading-param-slot.md
@@ -24,7 +24,7 @@ blocked_reason: "THREE approaches now fail: Design 1A re-point (impl2826) AND wr
 Carved from #2818 (parent) and #2820 (the plain-function half of Bug C, fixed
 there). This is the **async / generator capturer** residual of the
 `ary-ptrn-rest-obj-prop-id` block-`let`-capture cluster — the half #2820's
-producer-side slot-reuse gate *deliberately excludes* (the gate fires only when
+producer-side slot-reuse gate _deliberately excludes_ (the gate fires only when
 the block-`let` is captured by ≥1 plain function and **zero** CPS-lowered
 async/generator functions, because the broad reuse regressed 43
 `for-await-of/async-{func,gen}-decl-dstr-*` tests, net −14).
@@ -38,13 +38,25 @@ this one is in the **leading-capture-param** channel, #2825 is in the
 ```ts
 // async capturer
 export async function t5(): Promise<number> {
-  { let s = 42; async function f(): Promise<number> { return s; } return await f(); }
+  {
+    let s = 42;
+    async function f(): Promise<number> {
+      return s;
+    }
+    return await f();
+  }
 }
 // => 0   (should be 42)
 
 // generator capturer
 export function t6(): number {
-  { let s = 42; function* g(): Generator<number> { yield s; } return g().next().value; }
+  {
+    let s = 42;
+    function* g(): Generator<number> {
+      yield s;
+    }
+    return g().next().value;
+  }
 }
 // => 0   (should be 42)
 ```
@@ -53,11 +65,19 @@ Controls that **PASS** (function-scope `let`, not in a block):
 
 ```ts
 export async function t4(): Promise<number> {
-  let s = 42; async function f(): Promise<number> { return s; } return await f();
-}                                                            // => 42 ✓
+  let s = 42;
+  async function f(): Promise<number> {
+    return s;
+  }
+  return await f();
+} // => 42 ✓
 export function t7(): number {
-  let s = 42; function* g(): Generator<number> { yield s; } return g().next().value;
-}                                                            // => 42 ✓
+  let s = 42;
+  function* g(): Generator<number> {
+    yield s;
+  }
+  return g().next().value;
+} // => 42 ✓
 ```
 
 The block-nested capturer reads `0` — the numeric zero-init of an **un-written
@@ -71,7 +91,7 @@ captures as **leading parameters** (`compileNestedFunctionDeclaration`,
 `src/codegen/statements/nested-declarations.ts:617-783`). The capture metadata is
 recorded in `ctx.nestedFuncCaptures` at the point the nested fn is
 **hoist-compiled** (`nested-declarations.ts:773-783`), pinning each capture to
-the outer-frame slot it sees *then* via `outerLocalIdx`
+the outer-frame slot it sees _then_ via `outerLocalIdx`
 (`src/codegen/context/types.ts:1254`).
 
 The construction/call site reads the capture value out of that pinned slot. For
@@ -84,7 +104,7 @@ was load-bearing) — so the immutable path is hard-pinned to `outerLocalIdx`.
 Now the duplicate-slot mechanism (the Bug C core, see #2820):
 
 1. `walkStmtForLetConst` (`src/codegen/index.ts:14626`) pre-allocates a slot for
-   every block-`let`/`const` at **function entry** (the *pre-hoisted slot A*),
+   every block-`let`/`const` at **function entry** (the _pre-hoisted slot A_),
    recorded in `fctx.preHoistedLetConstSlots` (added by #2820).
 2. A function declaration nested in a block is **hoisted to the top of that
    block** and compiled before `let s` runs, so its `nestedFuncCaptures` entry
@@ -104,13 +124,21 @@ B` and the read is correct. For a **CPS** function the collapse perturbs the
 `for-await-of` continuation state machine (43 regressions), so #2820 skips it —
 leaving the immutable CPS capture pinned to the stale A. **That is this bug.**
 
-Why only *immutable* captures: a **mutable** CPS capture is boxed into a ref
+Why only _immutable_ captures: a **mutable** CPS capture is boxed into a ref
 cell at the call site (`calls.ts:12904-12928`), and that boxed cell already
 threads the value correctly (per #2820's gate comment) — and is exactly the path
-the broad reuse *broke*. So the fix must touch **only** the immutable,
+the broad reuse _broke_. So the fix must touch **only** the immutable,
 unboxed CPS capture, never the mutable boxed one.
 
 ## Implementation Plan
+
+> **SUPERSEDED (senior-conflicts 2026-07-02).** Designs 1A (re-point A→B) and 1B
+> (construction-site re-resolve) below, **and** the later write-through-to-A
+> (see `## Implementation attempt 2`), are **all three proven net-negative and
+> un-gateable at the let-init site** — do NOT retry any producer-side point-fix.
+> The real spec is **`## Implementation Plan — v2`** (transitive
+> continuation-snapshot discriminator) further down. Designs 1A/1B are retained
+> only as the historical record of what fails and why.
 
 ### Design 1A — producer-side capture re-point (preferred)
 
@@ -125,7 +153,7 @@ B) for the block-`let` is allocated + the initializer stored:
 
 - Compute `preHoisted = fctx.preHoistedLetConstSlots?.get(decl)` (already in
   scope from the #2820 gate) — its `valueSlot` is the stale slot **A**.
-- Guard: run **only** when the block-`let` was *not* reused (i.e. the
+- Guard: run **only** when the block-`let` was _not_ reused (i.e. the
   `freshLocalForLetConst` path produced a distinct `localIdx` **B** with
   `B !== A`), i.e. the CPS-excluded branch — this is the exact inverse of
   #2820's `capturedByPlainFn && !cpsCaptured` gate, so the two compose with no
@@ -154,11 +182,12 @@ baseline for the regression cluster → no perturbation.
 ### Ordering guarantee
 
 The re-point is valid because:
+
 - The capture entry already exists when `let s` runs (the nested fn is
   block-hoisted → compiled before the `let`). The `cap.outerLocalIdx === A`
   guard makes the re-point a no-op if the entry does not yet exist or already
   points at B.
-- A **non-hoisted** capturer (async arrow / async fn-expr assigned *after* the
+- A **non-hoisted** capturer (async arrow / async fn-expr assigned _after_ the
   `let`) records its capture with `localMap` already at B → guard fails → no
   re-point needed (already correct).
 
@@ -169,7 +198,7 @@ immutable capture by name at `calls.ts:12941` (`fctx.localMap.get(cap.name) ??
 cap.outerLocalIdx`) **gated narrowly** on: capturer is async/generator
 (`ctx.asyncFunctions`/`ctx.generatorFunctions`), the name is a pre-hoisted
 block-`let`/`const`, and `localMap.get(name) !== cap.outerLocalIdx`. This is the
-*minefield* #1177 hit with the blanket version (the async-null-deref tests rely
+_minefield_ #1177 hit with the blanket version (the async-null-deref tests rely
 on the wrong slot) — prefer 1A; only fall back here with full merge_group
 validation. **Do not** ship the un-gated `?? outerLocalIdx` form.
 
@@ -186,7 +215,7 @@ validation. **Do not** ship the un-gated `?? outerLocalIdx` form.
   The construction in the repro is textually after `let s`, so the analysis is
   "skip" — but a transitive call through a closure that captured the flag must
   still observe the live flag.
-- **Nested destructuring patterns** (`let [...{ length: z }]`): the *outer*
+- **Nested destructuring patterns** (`let [...{ length: z }]`): the _outer_
   immutable capture is the plain identifier `length`/`s`, not the pattern
   binding `z`. Pattern bindings are not pre-allocated by `walkStmtForLetConst`
   (`index.ts:14732`) so they carry no pre-hoist slot — the guard
@@ -241,6 +270,104 @@ Specifically confirm **zero** regressions in:
 i.e. the mutable boxed-capture path must stay byte-identical. (See #2820's gate
 comment for the precise regression signature.)
 
+## Implementation Plan — v2 (transitive continuation-snapshot discriminator)
+
+_(architect spec, senior-conflicts 2026-07-02 — the un-gateability of all three
+producer-side point-fixes is PROVEN, see `## Implementation attempt 2`. This is
+recommendation #1 made concrete. It is genuinely whole-program and NOT a
+~20-line patch; scope it as a `feasibility: hard`, `reasoning_effort: max`
+analysis-pass task and validate on full merge_group.)_
+
+### Why a local predicate cannot work (the proven blocker)
+
+At `compileVariableStatement` (the let-init site) the name that **needs** the fix
+(`length`) and the names that **regress** (`nextCount`, `iterator`, `iterations`)
+are **byte-identical in every materialised signal**: same `cap.mutable`, same
+not-a-captured-global, same single direct capturer. The distinguishing property
+is **runtime dataflow of the captured value through a suspending CPS
+continuation**, which is not represented as metadata when the slot decision is
+made. Gates (a) per-entry `mutable`, (b) per-name "no mutable cap anywhere",
+(c) "no direct capturer is itself captured", (d) `!capturedGlobals.has(name)`
+were each disproven on the sample. Therefore the fix MUST be driven by a
+**pre-codegen whole-program pass** that materialises the missing property.
+
+### The safety predicate to compute
+
+Apply the producer-side slot fix (re-point `cap.outerLocalIdx` A→B, or the
+equivalent) for a block-`let` `name` **iff NO function in the transitive
+capturer+callee closure of `name` snapshots `name` (or a value derived from it)
+into a _suspending_ continuation state struct.** `length` qualifies (safe);
+`nextCount`/`iterator`/`iterations` do not (each reaches a suspending
+continuation, directly or transitively).
+
+### Pass design (new, e.g. `src/codegen/analysis/continuation-capture-graph.ts`)
+
+Run **before** slot assignment in `compileVariableStatement`, cache the verdict
+on `fctx` keyed by the decl. Build two graphs over the function's nested
+declarations + object-literal methods:
+
+1. **Capture graph** (edges available today from `ctx.nestedFuncCaptures`,
+   `types.ts:1312`): `capturer → capturedName`, and transitively
+   `capturer → names captured by fns it captures`.
+2. **Call graph** (does NOT exist today — build it): scan every nested-fn body
+   and every **object-literal method / accessor** (`{ next(){…} }`,
+   get/set) for `CallExpression`s that resolve to a named nested fn, an
+   object-method, or a direct funcIdx call into an async/generator body. The
+   `iterations` case reaches its suspending `callAsync` via a **direct call
+   edge** (`pushAwait()`), invisible to the capture graph — so the call graph is
+   mandatory, not optional.
+
+Per node, compute **`spillsIntoSuspendingContinuation`**: the fn is CPS-lowered
+(`ctx.asyncFunctions`/`ctx.generatorFunctions`, `types.ts:1289/1291`, incl.
+async-generators) **and** it has a `yield`/`await` point at which the capture is
+live (i.e. the captured value is spilled into the resumable `$Frame`/state
+struct across a suspend). Also mark **object-literal iterator/accessor methods
+that mutate the name** (`next(){ nextCount += 1 }`) — that mutation escapes into
+the iteration protocol and is invisible to a `nestedFuncCaptures` mutability
+scan, so treat such a method as an unsafe spiller of `name`.
+
+`name` is **safe** iff the transitive closure (capture ∪ call edges) from every
+direct capturer of `name` contains **no** node with
+`spillsIntoSuspendingContinuation` and **no** escaping-mutation object-method for
+`name`. Only then apply the re-point.
+
+### Where it plugs in
+
+`src/codegen/statements/variables.ts` — the same block after #2820's reuse gate
+(~line 837) where Design 1A lived. Replace 1A's local `cap.mutable !== true`
+guard with `isSafeToRepointName(fctx, name)` from the new pass. When true,
+re-point `cap.outerLocalIdx` (and `cap.outerTdzFlagIdx`) A→B exactly as Design 1A
+specifies; when false, leave the capture on slot A (today's behaviour → the
+`for-await-of` cluster stays byte-identical, zero regression).
+
+### Edge cases
+
+- Mixed plain + CPS capturer of the same `name`: the plain capturer benefits from
+  the re-point; safety is governed solely by the CPS side's suspend-spill.
+- TDZ flag re-point in lockstep (see Design 1A ordering guarantee).
+- Nested destructuring pattern bindings carry no pre-hoist slot (guard excludes).
+- Recursion / cycles in the call graph: use a visited-set; a cycle through a
+  suspending node makes the whole component unsafe.
+
+### Validation (REQUIRED — same as attempt 2)
+
+The flips manifest ONLY on the merged baseline. Confirm on full
+`merge_group`/local-CI: (i) `t5`/`t6`/`t8` + the `length` `dstr` targets flip
+fail→pass; (ii) **zero** regressions in the 43-test
+`for-await-of/async-{func,gen}-decl-dstr-*` class (the named guardrails
+`async-generator-interleaved.js` + `array-elem-iter-nrml-close.js` stay pass).
+A scoped sweep cannot see this cluster. Harness preserved under `.tmp/`
+(`probe-2826.mts`, `run262-2826.mts`).
+
+### Do NOT retry (proven-failed point-fixes)
+
+- **Design 1A** re-point A→B (PR #2333): net −8, perturbs the CPS state struct.
+- **Design 1B** construction-site `localMap.get(name) ?? outerLocalIdx`: the
+  #1177 minefield (async-null-deref tests rely on the wrong slot).
+- **write-through-to-A** (attempt 2): identical CPS perturbation as 1A, reached
+  via the write instead of the re-point.
+  All three are un-gateable by any predicate computable at the let-init site.
+
 ## Dependencies
 
 - **Depends on #2820** (PR #2293) being merged: this fix reuses
@@ -250,7 +377,7 @@ comment for the precise regression signature.)
 - **In-lane** (closures / nested-fn lowering / `nestedFuncCaptures`); no
   dependency on the parallel substrate work ($Object dynamic reader /
   any-receiver dispatch / `calls.ts` host-dispatch / acorn / NM). The only
-  `calls.ts` touch is the *fallback* Design 1B; Design 1A leaves `calls.ts`
+  `calls.ts` touch is the _fallback_ Design 1B; Design 1A leaves `calls.ts`
   untouched.
 
 ## Acceptance criteria
@@ -276,6 +403,7 @@ Full conformance is only validated in `merge_group`. So "PR-green" never
 validated test262 here.
 
 **Delta (merge_group, baseline f8c1aa5):**
+
 - 30 regressions / 22 improvements → **net −8**, ratio 136%, signature `dd4fa22aa1d2c2a1`.
 - ALL 30 regressed tests are `for-await-of` dstr
   (`async-func-decl-dstr-*` / `async-gen-decl-dstr-*` array/obj rest+elem,
@@ -294,15 +422,16 @@ must re-point ONLY the CPS capture that genuinely needs a fresh slot (the exact
 immutable-`let`-captured-by-hoisted-async/gen case this issue targets), and
 leave the mutable `for-await-of/async-{func,gen}-decl-dstr-*` capture path on
 its existing slot — that path is what regressed. Gate the re-point on the same
-predicate #2820 used to *exclude* CPS capturers, inverted to its single
+predicate #2820 used to _exclude_ CPS capturers, inverted to its single
 intended case. **Validate against a full `merge_group` / local-CI test262 run
 BEFORE re-enqueue** — a scoped check cannot see this cluster. PR #2333 branch
-+ this diagnosis must survive; re-open this issue for the narrowed attempt.
+
+- this diagnosis must survive; re-open this issue for the narrowed attempt.
 
 ## Implementation attempt 2 (cps2826, senior-dev) — write-through-to-A is ALSO unsafe; PROVEN un-gateable → architect
 
 **Verdict: STOP / defer to architect (third strike).** The corrected approach —
-impl2826's recommendation #2, *write-through-to-A* (leave `outerLocalIdx = A`,
+impl2826's recommendation #2, _write-through-to-A_ (leave `outerLocalIdx = A`,
 also store the block-`let`'s value INTO slot A at let-init so the stale-A
 read/CPS-snapshot observes the live value) — was implemented and **reproduces the
 EXACT same CPS-state perturbation as the reverted Design 1A re-point.** Reverted;
@@ -311,47 +440,53 @@ host/gc lane. Harness: `.tmp/probe-2826.mts` (t5/t6/t8 + controls),
 `.tmp/run262-2826.mts` (guardrail + 43-class samples + the 4 cited targets).
 
 ### Re-grounding: #2844 advanced the cited targets, but NOT to the #2826 assert
+
 The premise for the retry was that #2844 (for-await rest→object-pattern dstr,
 now merged) unblocks the cited `ary-ptrn-rest-obj-prop-id` targets. Confirmed
 #2844 is on main — the targets advanced from **assert #1** (`v===7`) to **assert
 #5** (`z===3`, "returned 6"). But assert #5 (`length: z` reads the rest array's
 `.length`) is **yet another orthogonal dstr bug**, still short of assert #6
 (`length === "outer"` — the actual #2826 immutable-outer-`let` capture). So on a
-*correct* baseline the cited targets remain blocked upstream of #2826.
+_correct_ baseline the cited targets remain blocked upstream of #2826.
 
 ### What write-through fixes
+
 Synthetic repro fixed: `t5`/`t6`/`t5s`/`t8` (mixed plain+CPS) return the captured
 value (42 / "hi" / 28) vs 0 on baseline; `t4`/`t7` fn-scope controls unchanged.
 And — notably — write-through on `length` **flips all 4 cited targets fail→pass**
-(it satisfies assert #5+#6 together), so the conformance payoff is real *when it
-fires on the right name*.
+(it satisfies assert #5+#6 together), so the conformance payoff is real _when it
+fires on the right name_.
 
 ### Why it is unsafe (same mechanism as Design 1A, reached via the write)
+
 Writing B→A at the let-init **clobbers slot A, which the CPS continuation relies
 on** (it is NOT a dead pre-hoist slot for escaping/suspending capturers). Two
 named regressions, **identical signatures to the reverted re-point** (PR #2333):
+
 - `language/expressions/await/async-generator-interleaved.js` (NAMED guardrail):
-  pass→fail, *"dereferencing a null pointer in pushAwait()"* (`actual`/`iterations`).
+  pass→fail, _"dereferencing a null pointer in pushAwait()"_ (`actual`/`iterations`).
 - `for-await-of/async-{func,gen}-decl-dstr-array-elem-iter-nrml-close.js` (43-class):
-  pass→fail, *`assert.sameValue(nextCount, 1)` returned 2* (`nextCount`/`iterator`).
+  pass→fail, _`assert.sameValue(nextCount, 1)` returned 2_ (`nextCount`/`iterator`).
 
 ### The decisive finding: the regression is UN-GATEABLE at the let-init site
+
 Instrumented every write-through firing. The name that **must** get the fix
 (`length`) and the names that **regress** (`nextCount`, `iterations`, `iterator`)
 have **identical state** at `compileVariableStatement` — no discriminator exists:
 
-| name (test)                     | mutable-cap? | captured-global? | capturers | write-through |
-| ------------------------------- | ------------ | ---------------- | --------- | ------------- |
-| `length` (target) — **needs fix** | no         | no               | `[fn]`    | **safe (fix)** |
-| `nextCount` (array-elem) — **regresses** | no  | no               | `[fn]`    | **null/2**    |
-| `iterator` (array-elem) — **regresses**  | no  | no               | `[fn]`    | **regress**   |
-| `iterations` (interleaved) — **regresses** | no | no             | `[callAsync]` | **null-deref** |
-| `x`/`y` (array-rest) — harmless | no           | no               | `[fn]`    | stays green   |
+| name (test)                                | mutable-cap? | captured-global? | capturers     | write-through  |
+| ------------------------------------------ | ------------ | ---------------- | ------------- | -------------- |
+| `length` (target) — **needs fix**          | no           | no               | `[fn]`        | **safe (fix)** |
+| `nextCount` (array-elem) — **regresses**   | no           | no               | `[fn]`        | **null/2**     |
+| `iterator` (array-elem) — **regresses**    | no           | no               | `[fn]`        | **regress**    |
+| `iterations` (interleaved) — **regresses** | no           | no               | `[callAsync]` | **null-deref** |
+| `x`/`y` (array-rest) — harmless            | no           | no               | `[fn]`        | stays green    |
 
 `length` (safe) and `nextCount`/`iterator` (regress) are **byte-for-byte identical
 in every signal available** — same `mutable` across all cap entries, same
 not-a-captured-global, same single capturer `fn`. The difference is purely the
 **runtime dataflow of the captured value through the CPS continuation**:
+
 - `length` — a plain immutable read inside the for-await body of an inline-driven
   `fn().next()`;
 - `nextCount`/`returnCount`/`args` — mutated inside **object-literal iterator
@@ -371,11 +506,12 @@ captured" (transitive); (d) `!capturedGlobals.has(name)`. **None** separate
 timing) is **not materialized as metadata** when `compileVariableStatement` runs.
 
 ### Recommendation → architect (recommendation #1 only; #2 disproven)
+
 A producer-side slot fix (whether re-point A→B or write-through B→A) **cannot be
 made safe by any predicate computable at the let-init site.** Both perturb the
 CPS state and the safe/unsafe boundary is whole-program. The only remaining
 viable path is impl2826 **recommendation #1**: build the **transitive
-capture+call graph** and a per-nested-fn **"spills captures into a *suspending*
+capture+call graph** and a per-nested-fn **"spills captures into a _suspending_
 continuation state struct"** predicate; apply the fix **only** when no capturer
 of the name (directly or transitively, including through object-literal
 iterator/accessor methods and direct calls into suspending async/gen bodies)

--- a/plan/issues/2921-bank-drain-microtasks-intrinsic.md
+++ b/plan/issues/2921-bank-drain-microtasks-intrinsic.md
@@ -1,0 +1,87 @@
+---
+id: 2921
+title: "Bank the __drain_microtasks() carrier intrinsic (inert) extracted from the closed #2367 PR-B"
+status: done
+assignee: ttraenkler/senior-conflicts
+created: 2026-07-02
+completed: 2026-07-02
+parent: 2867
+related: [2867, 2918, 2864]
+priority: medium
+feasibility: medium
+task_type: feature
+area: codegen
+goal: standalone
+sprint: current
+horizon: s
+---
+
+# #2921 — Bank the `__drain_microtasks()` carrier intrinsic (inert)
+
+## Problem
+
+PR #2367 ("standalone native Promise carrier — funcIdx-shift + verdict drain",
+#2867 PR-B) was **closed** because its central change — broadening
+`isStandalonePromiseActive` to `ctx.standalone` — is a proven merged-baseline
+regression (−1404) blocked on the native resumable-frame substrate (#2864, still
+`in-progress`). See the close comment on PR #2367.
+
+That PR also carried two pieces of **regression-free** infrastructure that are
+inert without the gate-broaden and worth banking so they are ready when #2864
+unblocks the carrier activation:
+
+1. a **late-import funcIdx-shift fix** in the native `.then` receiver/callback
+   buffers, and
+2. the **`__drain_microtasks()` compiler intrinsic**.
+
+On re-grounding against current `origin/main`, piece (1) **already landed** via
+#2918 (`fctx.savedBodies.push/pop`, a cleaner mechanism than PR #2367's
+`ctx.liveBodies.add(savedBody)`). The `target: wasi` repro that broke pre-#2918
+("not enough arguments on the stack for call", the −601 invalid-Wasm) now
+instantiates cleanly on main. So only piece (2) remained to bank.
+
+## What this issue lands
+
+The `__drain_microtasks()` intrinsic in `src/codegen/expressions/calls.ts`
+(`compileCallExpression`). When the identifier `__drain_microtasks` is called
+with zero args:
+
+- if a native microtask queue is registered (`getDrainFuncIdxForWasiStart(ctx)`
+  is non-null — i.e. some `.then`/Promise was lowered on a carrier target), emit
+  a single `call` to the drain function;
+- otherwise emit **nothing** and return `VOID_RESULT`.
+
+The interceptor is guarded purely by the callee identifier, so any module that
+does not literally write `__drain_microtasks()` is byte-identical to before — the
+change is fully inert to gc/host/linear codegen and to Promise-free WASI modules.
+It does **not** re-introduce the #2367 gate-broaden; `isStandalonePromiseActive`
+is untouched (stays `ctx.wasi === true`).
+
+This is the "runner `__drain_microtasks` hook" listed under
+"Remaining for the unlock" in #2867. It gives a standalone/WASI embedder (and,
+once #2864 unblocks activating the carrier for `--target standalone`, the
+test262 harness verdict-read) a way to flush pending native `$Promise` reactions
+before observing module state. The **harness-side** injection of this call (the
+verdict-changing `tests/test262-runner.ts` edit from PR #2367) is deliberately
+NOT banked here — it flips verdicts and belongs with the carrier activation, not
+this inert infra bank.
+
+## Test Results
+
+`tests/issue-2921.test.ts` (all green):
+
+- WASI carrier: a queued `.then` fulfil reaction (`ran = v`) does NOT run before
+  `__drain_microtasks()` (returns 0), and DOES run after it (returns 5) — proves
+  the intrinsic drives the drain, not eager `.then`.
+- gc/host: `__drain_microtasks()` is a silent no-op (returns 7, no trap, no
+  `__drain_microtasks` import leak).
+- WASI with no registered queue: silent no-op (returns 7).
+
+Typecheck clean. The intrinsic path is unreachable for any module not calling
+`__drain_microtasks()`, so gc/host/linear/standalone output is byte-identical.
+
+## Notes
+
+This PR also carries `## Implementation Plan` architect specs for the two
+block-`let`-capture issues whose regressing PRs were closed alongside #2367
+(#2818, #2826) — they ride this PR rather than a doc-only push to main.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -41,6 +41,7 @@ import {
   emitTimerCallbackWrapper,
   emitTimerCancel,
   ensureTimerHeap,
+  getDrainFuncIdxForWasiStart,
   getRunLoopNowFuncIdx,
   isStandalonePromiseActive,
   isStandaloneThenChainNativeActive,
@@ -3921,6 +3922,34 @@ function compileCallExpression(
   {
     const r = tryWasiTimerCall(ctx, fctx, expr);
     if (r !== undefined) return r;
+  }
+
+  // (#2921) `__drain_microtasks()` — explicit microtask-queue drain intrinsic
+  // (banked from the closed #2367/#2867 PR-B; the funcIdx-shift half already
+  // landed via #2918). Lets a standalone/WASI embedder — and, once the carrier
+  // is activated for `--target standalone` (blocked on #2864's native $Frame),
+  // the test262 harness verdict-read — flush pending native `$Promise` reactions
+  // before observing module state. Native `.then` reactions are QUEUED, not run
+  // synchronously, so assertions inside them set state only once the queue drains.
+  //
+  // Fully INERT until something *calls* it: it emits the native drain ONLY when
+  // the microtask queue is already registered (some `.then`/Promise lowered
+  // earlier on a carrier target, `getDrainFuncIdxForWasiStart` non-null).
+  // Otherwise — every JS-host compile (the host owns its own microtask queue),
+  // and any carrier module with no Promise — it is a silent VOID no-op that emits
+  // NOTHING, so the identifier can be introduced into a wrapper unconditionally
+  // without leaking an import, forcing queue infra into Promise-free modules, or
+  // disturbing JS-host / gc / linear codegen (byte-identical off the carrier path).
+  if (
+    ts.isIdentifier(expr.expression) &&
+    expr.expression.text === "__drain_microtasks" &&
+    expr.arguments.length === 0
+  ) {
+    const drainIdx = getDrainFuncIdxForWasiStart(ctx);
+    if (drainIdx !== null) {
+      fctx.body.push({ op: "call", funcIdx: drainIdx });
+    }
+    return VOID_RESULT;
   }
 
   // Node-shaped process APIs are lowered in their own module so the generic

--- a/tests/issue-2921.test.ts
+++ b/tests/issue-2921.test.ts
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2921 — Bank the `__drain_microtasks()` compiler intrinsic (extracted from the
+// closed #2367/#2867 PR-B). The funcIdx-shift half of that PR already landed via
+// #2918 (`fctx.savedBodies` push/pop), so only the drain intrinsic remained.
+//
+// The intrinsic lets a standalone/WASI embedder (and, once the carrier is
+// activated for `--target standalone` — blocked on #2864 — the test262 harness
+// verdict-read) flush pending native `$Promise` reactions before observing
+// module state. Native `.then` reactions are QUEUED on the carrier microtask
+// ring, not run synchronously, so assertions inside them only take effect after
+// `__drain_microtasks()` runs.
+//
+// It is fully INERT until something calls it:
+//   - it emits the native drain ONLY when a microtask queue is already
+//     registered (a `.then`/Promise was lowered on a carrier target);
+//   - it emits NOTHING (a silent VOID no-op) on every JS-host/gc/linear compile
+//     and on any carrier module with no Promise, so it never leaks an import,
+//     forces queue infra into Promise-free modules, or perturbs non-carrier
+//     codegen. The interceptor is guarded purely by the callee identifier, so a
+//     module that never writes `__drain_microtasks()` is byte-identical.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+
+/** Stub import object so a leaked host import never blocks instantiation — we are
+ *  checking codegen behaviour, not host linkage. */
+function stubImports(): WebAssembly.Imports {
+  const env = new Proxy({}, { get: () => () => {}, has: () => true });
+  return new Proxy({}, { get: () => env, has: () => true }) as WebAssembly.Imports;
+}
+
+async function instantiate(src: string, target: "wasi" | "gc") {
+  const r = await compile(src, { fileName: "test.ts", target, skipSemanticDiagnostics: true });
+  expect(r.errors.filter((e) => e.severity === "error")).toEqual([]);
+  expect(r.success).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary!, stubImports());
+  return { r, instance };
+}
+
+describe("#2921 — __drain_microtasks() intrinsic (banked carrier infra)", () => {
+  it("drains a queued native .then fulfil reaction on the WASI carrier before the verdict read", async () => {
+    // The reaction writes `ran = v`. On the WASI carrier the reaction is QUEUED,
+    // so `ran` is still 0 at the point after `.then(...)`; `__drain_microtasks()`
+    // runs the queued reaction, so `test()` observes the fulfilled value 5.
+    const { instance } = await instantiate(
+      `
+      let ran = 0;
+      export function test(): number {
+        Promise.resolve(5).then(function (v) { ran = v; });
+        __drain_microtasks();
+        return ran;
+      }
+    `,
+      "wasi",
+    );
+    expect((instance.exports as { test(): number }).test()).toBe(5);
+  });
+
+  it("without the drain call the reaction stays queued (proves the intrinsic, not eager .then, is what fires it)", async () => {
+    const { instance } = await instantiate(
+      `
+      let ran = 0;
+      export function test(): number {
+        Promise.resolve(5).then(function (v) { ran = v; });
+        return ran;
+      }
+    `,
+      "wasi",
+    );
+    expect((instance.exports as { test(): number }).test()).toBe(0);
+  });
+
+  it("is a silent no-op on the gc/host target (no trap, no import leak)", async () => {
+    const { r, instance } = await instantiate(
+      `
+      export function test(): number {
+        __drain_microtasks();
+        return 7;
+      }
+    `,
+      "gc",
+    );
+    expect((instance.exports as { test(): number }).test()).toBe(7);
+    expect((r.imports ?? []).map((i) => i.name)).not.toContain("__drain_microtasks");
+  });
+
+  it("is a silent no-op on a WASI module that registered no microtask queue", async () => {
+    const { instance } = await instantiate(
+      `
+      export function test(): number {
+        __drain_microtasks();
+        return 7;
+      }
+    `,
+      "wasi",
+    );
+    expect((instance.exports as { test(): number }).test()).toBe(7);
+  });
+});


### PR DESCRIPTION
## What

Follow-up to closing the three stranded #2367/#2335/#2333 PRs. Two deliverables in one inert PR:

### (a) Bank the `__drain_microtasks()` carrier intrinsic
Extracted from the **closed** #2367 (#2867 PR-B). That PR's central change (broadening `isStandalonePromiseActive` to `ctx.standalone`) is a proven −1404 regression blocked on #2864 and was closed. But it carried regression-free infra worth banking:
- the **late-import funcIdx-shift fix** — on re-grounding, this **already landed via #2918** (`fctx.savedBodies` push/pop); the `target: wasi` repro that broke pre-#2918 now instantiates cleanly on main, so nothing to bank there.
- the **`__drain_microtasks()` intrinsic** — banked here. In `compileCallExpression`: when `__drain_microtasks()` is called and a native microtask queue is registered (`getDrainFuncIdxForWasiStart` non-null), emit one `call` to the drain fn; otherwise emit nothing and return `VOID_RESULT`.

**Fully inert.** The interceptor is guarded purely by the callee identifier, so any module not literally calling `__drain_microtasks()` is byte-identical — no effect on gc/host/linear codegen or Promise-free WASI. `isStandalonePromiseActive` is **untouched** (stays `ctx.wasi === true`); this does NOT re-introduce the #2367 gate-broaden. The verdict-changing `test262-runner.ts` harness injection from PR #2367 is deliberately **not** banked (it belongs with the carrier activation).

`tests/issue-2921.test.ts` (4 green): WASI carrier drains a queued `.then` fulfil reaction (ret `5` with drain vs `0` without — proves the intrinsic drives it, not eager `.then`); gc/host and no-queue-WASI are silent no-ops (ret `7`, no trap, no import leak).

### (b) Architect specs (ride this PR, no doc-only push to main)
`## Implementation Plan` specs written into the two block-`let`-capture issues whose regressing PRs I closed:
- **#2818** — narrowed Option-1 deferral (defer only genuine block-`let` capturers; keep class expressions + non-capturers on the eager path) + complete the deferred class-body path. Records the broad `insideFunction` propagation as **proven −471** so no future dev retries it.
- **#2826** — v2 **transitive continuation-snapshot discriminator** (recommendation #1: build the capture+call graph, apply the slot fix only when no capturer transitively spills the name into a suspending continuation). Records Design 1A / 1B / write-through-to-A as **proven un-gateable** point-fixes.

## Risk
Inert compiler change (identifier-guarded) + two markdown spec additions + one new test. No behavior change for any existing module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)