### PR TITLE
fix(#2873): standalone String-wrapper `+` equality misclassified as any

### DIFF
--- a/plan/issues/2873-standalone-language-expressions-cluster.md
+++ b/plan/issues/2873-standalone-language-expressions-cluster.md
@@ -1,9 +1,10 @@
 ---
 id: 2873
 title: "Standalone: language/expressions cluster (276 host-pass/standalone-fail, de-masked from #2862)"
-status: ready
+status: in-progress
+assignee: ttraenkler/dev-2873
 created: 2026-06-30
-updated: 2026-06-30
+updated: 2026-07-02
 priority: high
 task_type: bug
 area: codegen
@@ -39,6 +40,7 @@ standalone high-water. `ctx.standalone` only.
 ## Progress (2026-06-30)
 
 Triaged the operator sub-dirs (`addition`/`equals`/relational/...). Findings:
+
 - **Relational `<`/`<=`/`>`/`>=` with a `String` wrapper operand emitted invalid
   Wasm** standalone (`S11.8.x_A3.2_T1.x`) → split out as **#2888** and FIXED
   (native `ref $AnyString` lowering of both operands before `__str_compare`).
@@ -50,3 +52,39 @@ Triaged the operator sub-dirs (`addition`/`equals`/relational/...). Findings:
 - `subtraction/bigint-and-number.js` needs the `BigInt` extern class (separate).
 
 Remaining #2873 work is dominated by the #2862 ToPrimitive-in-operators surface.
+
+## Reground + landed slice (2026-07-02, dev-2873)
+
+**The "276" figure is stale.** A full fresh triage of all 11,036
+`language/expressions/**` files against current `main` (via
+`runTest262File(..., "standalone")`) shows only **10** host-pass /
+host-free-standalone-fail — the valueOf-`ToPrimitive`-in-operators cluster (the
+bulk of the original 276) was fixed by merges landed since 2026-06-30
+(object→primitive via an OWN `valueOf` now works host-free: `1 < o`, `1 + o`,
+`2 == o` all correct standalone). All 10 residual hard-fails are in `addition/`.
+
+**Landed slice — String-wrapper `+` compared via `===`/`!==` (net +5).**
+Root cause: TypeScript infers `new String("1") + <non-string>` as `any` (only
+`String-wrapper + primitive-string` narrows to `string`). The concat itself
+compiles correctly (`compileStringBinaryOp` → native `ref $AnyString` → "11"),
+but the OUTER `=== "11"` saw an `any` LEFT, missed the native string-equality
+dispatch, and fell to `ref.eq`/tag-dispatch → spurious `false`. Fix in
+`src/codegen/binary-ops.ts` (standalone/WASI-only): `isStringConcatExpr` treats a
+`+` with a string-/String-wrapper-typed operand as a string-producing expression
+at the AST level, wired into `leftIsStrLike`/`rightIsStrLike` so the `===`/`!==`
+classification routes to `__str_equals` (content compare). Mirrors the #2192
+caught-`Error.message` and #2888 relational augmentations. Tests:
+`tests/issue-2873.test.ts`. Verified host-free (`imports == []`), host (gc) mode
+byte-unaffected (gated), and the full 11,036-file expr triage drops 10→5 with
+**zero new fails**. Flips standalone:
+`language/expressions/addition/S11.6.1_A3.2_T{1.1,2.1,2.2,2.3,2.4}`.
+
+**Remaining residual (5 files, all tracked by sibling issues — nothing tractable
+left in this cluster for a dev slice):**
+
+- `S11.6.1_A2.1_T1` — `new Object().prop` numeric read backs 0 → **#2849**.
+- `S11.6.1_A2.2_T1` — object literal with INHERITED `valueOf`/`toString` (default
+  hint falls valueOf→toString) → **#2862** (ToPrimitive, `wont-fix`/hard).
+- `coerce-symbol-to-prim-return-obj`, `get-symbol-to-prim-err` — `@@toPrimitive`
+  dispatch (throw-if-result-Object; getter throws) → **#2862**.
+- `subtraction/bigint-and-number` — `BigInt` extern class → separate carrier.

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -1143,13 +1143,46 @@ export function compileBinaryExpression(
   // falling through to `ref.eq` (struct identity → always false for equal
   // content). Recognise the read shape at the AST level so `id.name === "x"`
   // routes to content-based string equality.
+  // (#2873) A `+` binary expression is a STRING concatenation — always a string
+  // at runtime — whenever either operand is statically string- or String-wrapper
+  // typed (`isStringType` covers both). TypeScript infers `new String("1") + 1`
+  // (and `new String("1") + new String("1")`, `1 + new String("1")`) as `any`,
+  // NOT `string`: only `String-wrapper + primitive-string` narrows to `string`.
+  // So an outer `=== "11"` / `!== "11"` sees an `any` LEFT, misses the native
+  // string-equality dispatch, and falls to `ref.eq`/tag-dispatch → a spurious
+  // `false` even though the concat itself is correct ("11"). This de-masked the
+  // standalone `language/expressions/addition/S11.6.1_A3.2_T{1.1,2.1-2.4}`
+  // cluster (String/Number/Boolean wrapper `+` operands). Recognise the concat
+  // shape at the AST level and treat it as a string operand so the comparison
+  // routes to `__str_equals`. Standalone/WASI (native-string) only — mirrors the
+  // `isStandaloneErrorStringPropRead` augmentation above and the #2888 relational
+  // String-wrapper lowering.
+  const isStringConcatExpr = (node: ts.Expression): boolean => {
+    if (!(ctx.standalone || ctx.wasi)) return false;
+    let cur: ts.Expression = node;
+    while (
+      ts.isParenthesizedExpression(cur) ||
+      ts.isAsExpression(cur) ||
+      ts.isNonNullExpression(cur) ||
+      ts.isTypeAssertionExpression(cur)
+    ) {
+      cur = (cur as ts.ParenthesizedExpression | ts.AsExpression | ts.NonNullExpression | ts.TypeAssertion).expression;
+    }
+    if (!ts.isBinaryExpression(cur) || cur.operatorToken.kind !== ts.SyntaxKind.PlusToken) return false;
+    const lt = ctx.checker.getTypeAtLocation(cur.left);
+    const rt = ctx.checker.getTypeAtLocation(cur.right);
+    if (isBigIntType(lt) || isBigIntType(rt)) return false;
+    return isStringType(lt) || isStringType(rt);
+  };
   const leftIsStrLike =
     isStringOrNullableString(leftTsType) ||
     isStandaloneErrorStringPropRead(expr.left) ||
+    isStringConcatExpr(expr.left) ||
     isLogicalAssignNamedEvalNameRead(ctx, expr.left);
   const rightIsStrLike =
     isStringOrNullableString(rightTsType) ||
     isStandaloneErrorStringPropRead(expr.right) ||
+    isStringConcatExpr(expr.right) ||
     isLogicalAssignNamedEvalNameRead(ctx, expr.right);
   if (
     ctx.nativeStrings &&

--- a/tests/issue-2873.test.ts
+++ b/tests/issue-2873.test.ts
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #2873 (language/expressions standalone cluster) — standalone `+` with a
+// `String` wrapper-object operand (`new String("1")`) produced a spurious
+// `false` on the outer `===`/`!==`.
+//
+// Root cause: TypeScript infers `new String("1") + <non-string>` as `any`
+// (only `String-wrapper + primitive-string` narrows to `string`). The concat
+// itself is compiled CORRECTLY (`compileStringBinaryOp` lowers each operand to a
+// native `ref $AnyString` via ToString → "11"), but the outer `=== "11"` sees an
+// `any` LEFT, misses the native string-equality dispatch, and falls to
+// `ref.eq`/tag-dispatch → `false`. This de-masked the standalone
+// `language/expressions/addition/S11.6.1_A3.2_T{1.1,2.1,2.2,2.3,2.4}` cluster
+// (String/Number/Boolean wrapper `+` operands, mixed with number/boolean/
+// undefined/null).
+//
+// Fix (binary-ops.ts, standalone/WASI-only): recognise a `+` whose operand is
+// string- or String-wrapper-typed as a STRING-producing expression at the AST
+// level (`isStringConcatExpr`, wired into `leftIsStrLike`/`rightIsStrLike`), so
+// the `===`/`!==` classification routes to `__str_equals` (content compare).
+// Mirrors the #2192 caught-Error `.message` and #2888 relational augmentations.
+//
+// String returns from a standalone module are native-string refs (not JS
+// strings), so these assert via boolean → number (1/0) exports.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  // No host import may leak under standalone (host-free pass).
+  expect(r.imports ?? []).toEqual([]);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2873 — standalone `+` with a String wrapper operand, compared via ===/!==", () => {
+  it("new String('1') + new String('1') === '11'  →  true", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { return (new String("1") + new String("1") === "11") ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("new String('1') + 1 === '11'  →  true", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return (new String("1") + 1 === "11") ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("1 + new String('1') === '11'  →  true", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return (1 + new String("1") === "11") ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("new String('1') + new Number(1) === '11'  →  true", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { return (new String("1") + new Number(1) === "11") ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("true + new String('1') === 'true1'  →  true (boolean coerced)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return (true + new String("1") === "true1") ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("new Boolean(true) + new String('1') === 'true1'  →  true", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { return (new Boolean(true) + new String("1") === "true1") ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("new String('1') + undefined === '1undefined'  →  true", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { return (new String("1") + undefined === "1undefined") ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("new String('1') + null === '1null'  →  true", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return (new String("1") + null === "1null") ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("!== is the mirror: new String('1') + 1 !== '99'  →  true", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return (new String("1") + 1 !== "99") ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  // ── Regression guards ──
+  it("String-wrapper + primitive-string still passes (already-string TS type)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return (new String("1") + "1" === "11") ? 1 : 0; }`),
+    ).toBe(1);
+  });
+
+  it("Number wrapper + number stays NUMERIC: new Number(1) + 1 === 2", async () => {
+    expect(await runStandalone(`export function test(): number { return (new Number(1) + 1 === 2) ? 1 : 0; }`)).toBe(1);
+  });
+
+  it("plain numeric equality unaffected: 1 + 1 === 2", async () => {
+    expect(await runStandalone(`export function test(): number { return (1 + 1 === 2) ? 1 : 0; }`)).toBe(1);
+  });
+
+  it("plain string concat equality unaffected: 'a' + 'b' === 'ab'", async () => {
+    expect(await runStandalone(`export function test(): number { return ("a" + "b" === "ab") ? 1 : 0; }`)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Sub-slice of the #2873 `language/expressions` standalone cluster.

**Reground:** a fresh full triage of all 11,036 `language/expressions/**` files
on current `main` shows only **10** host-pass / host-free-standalone-fail — not
276. The valueOf-`ToPrimitive`-in-operators bulk of the original 276 was fixed
by merges since 2026-06-30 (object→primitive via an OWN `valueOf` now works
host-free standalone).

**This PR** fixes the largest tractable residual bucket: `+` with a `String`
wrapper operand compared via `===`/`!==`.

## Root cause

TypeScript infers `new String("1") + <non-string>` (and `+ new String`,
`+ new Number/Boolean`, `+ undefined/null`) as **`any`**, not `string` — only
`String-wrapper + primitive-string` narrows to `string`. The concat itself
lowers correctly to a native `ref $AnyString` ("11"), but the outer `=== "11"`
saw an `any` operand, missed the native string-equality dispatch, and fell to
`ref.eq`/tag-dispatch → a spurious `false` standalone (host-free). Host (gc)
mode was unaffected (its `+`/`==` take a different path).

## Fix

`src/codegen/binary-ops.ts` (standalone/WASI-only): `isStringConcatExpr`
recognises a `+` whose operand is string-/String-wrapper-typed as a
string-producing expression at the AST level, wired into
`leftIsStrLike`/`rightIsStrLike` so the `===`/`!==` classification routes to
`__str_equals` (content compare). Mirrors the #2192 caught-`Error.message` and
#2888 relational augmentations. Gated on `ctx.standalone || ctx.wasi`, so host
(gc) mode is byte-unaffected.

## Validation

- Full 11,036-file `language/expressions` standalone triage: **10 → 5**
  host-pass/standalone-fail, **zero new fails**.
- Flips standalone (host-free):
  `addition/S11.6.1_A3.2_T{1.1,2.1,2.2,2.3,2.4}`.
- `tests/issue-2873.test.ts` — 13 cases incl. regression guards
  (`new Number(1) + 1 === 2` stays numeric; plain numeric/string equality
  unaffected). All host-free (`imports == []`).

## Residual (routed to sibling issues — nothing tractable left here)

- `S11.6.1_A2.1_T1` → **#2849** (`new Object().prop` numeric read backs 0)
- `S11.6.1_A2.2_T1`, `coerce-symbol-to-prim-return-obj`, `get-symbol-to-prim-err`
  → **#2862** (inherited valueOf / `@@toPrimitive` — ToPrimitive substrate)
- `subtraction/bigint-and-number` → `BigInt` extern class (separate carrier)

Issue #2873 kept `in-progress` (umbrella partial slice); residual fully covered
by the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)