### PR TITLE
fix(#2849): extend $Object-hash poison to host so static writes don't shadow the sidecar

### DIFF
--- a/plan/issues/2849-ecmaversion-normalize-dynamic-prop-type-inference.md
+++ b/plan/issues/2849-ecmaversion-normalize-dynamic-prop-type-inference.md
@@ -1,7 +1,9 @@
 ---
 id: 2849
 title: "dynamic-object numeric property reads back 0 when the same property is also compared via === string / == null (acorn ecmaVersion 2022 not normalised → spurious import attributes)"
-status: ready
+status: done
+completed: 2026-07-02
+assignee: ttraenkler/fable-dev
 sprint: current
 priority: medium
 horizon: l
@@ -38,7 +40,106 @@ import x from "y";   // ecmaVersion: 2022, sourceType: "module"
 // compiled    : body[0].attributes -> []        (SPURIOUS)
 ```
 
-## Root cause (verified by bisected repro)
+## Corrected Root Cause & Design (2026-07-02, supersedes the original diagnosis below)
+
+> The original "Root cause" section below is **superseded**. Two of its
+> framings were wrong when re-measured on current `main`:
+>
+> 1. **The "no-guards WORKS: run(2022)=13" claim did NOT reproduce** — the whole
+>    for-in-copy family read back `undefined`/`0` in my minimal harness. That was
+>    itself a **harness false-negative**: the repro never called
+>    `importResult.setExports(instance.exports)`, so host `__extern_get`/`_safeGet`
+>    on a struct returned `undefined`. With `setExports` wired (as the test262
+>    runner does), the no-guards case already returns 13 on current main — for-in
+>    over a closed struct is NOT broken.
+> 2. **The bug is NOT string/null-specific.** A numeric-only guard triggers it
+>    too. The "`=== string` / `== null`" framing is incidental.
+
+### Actual mechanism (bisected, `setExports` wired)
+
+The trigger needs BOTH:
+
+- `o = {}` populated via **dynamic-key writes** `o[k]=v` (the for-in copy loop) —
+  these land in `o`'s dynamic `$Object` **sidecar**; AND
+- a **STATIC-named write** `o.ecmaVersion = <const>` somewhere in the function
+  (even an **unreached** branch — `if (ev<0) { o.ecmaVersion=999 }` is enough).
+
+The static-named write makes the compile-time widening pre-pass
+`collectEmptyObjectWidening` (`src/codegen/declarations.ts:2197`, via
+`collectPropsFromStatements`) register `ecmaVersion` as a **real struct field**
+on `o`'s widened `__anon_N` struct type (default 0). The scan is
+**reachability-blind**, so an unreached branch still registers it. Thereafter
+every read `o.ecmaVersion` (static OR computed) resolves `o` to that struct and
+lowers to `struct.get` of the empty field → **0**, while the for-in values sit
+untouched in the sidecar. A COMPUTED write `o["ecmaVersion"]=v` does NOT trigger
+it (the pre-pass only scans `PropertyAccessExpression` targets), and neither does
+`direct`/literal-key construction (their writes hit the same field the reads use).
+
+Proof points (host lane, `setExports` wired): `F; return o.ecmaVersion` = 2022;
+add an unreached `o.ecmaVersion=999` → 0; only the written prop corrupts
+(`o.sourceType` still 1).
+
+### Candidate strategies
+
+- **(a) write-through coherence** — when a static write widens a field on an
+  object that also takes dynamic-key writes, mirror dynamic writes of that name
+  into the field. Rejected: fragile (must intercept every dynamic-key write and
+  reflect it into the right field at runtime), and doubles the storage.
+- **(b) sidecar-wins (CHOSEN)** — a `{}` var that is ALSO the subject of any
+  `$Object`-hash consumer (computed `o[k]` read/write, `k in o`, `for (k in o)`,
+  `Object.keys/values/entries/…`) must NOT be struct-widened; it stays a
+  `$Object` so static-named reads/writes route through the SAME sidecar the
+  dynamic writes land in. **This mechanism already exists** — `#2584`'s
+  `objectHashConsumerVars` poison-set (`markObjectHashConsumers`,
+  `declarations.ts:2569`) + the widening-suppression at `declarations.ts:2252`.
+  It was **gated `if (ctx.standalone)`** (declarations.ts:2228) on the assumption
+  "host keeps the struct fast path via the live-mirror Proxy" — but the Proxy
+  does NOT bridge the for-in `o[k]=` → static `struct.get` divergence, so host
+  regressed (#2849). Fix: extend the poison to host mode.
+- **(c) read-side sidecar fallback** — on a `struct.get` that yields the default,
+  consult the sidecar. Rejected as **unsound**: a genuine 0 is indistinguishable
+  from an unset field default.
+
+**Chosen: (b).** Rationale — it reuses the exact precedent designed for this
+class (#2584 for computed-access divergence, #2372 for dynamic-descriptor
+divergence), keeps the static fast path byte-for-byte untouched (only vars with
+a dynamic-access consumer are poisoned), and unifies host with standalone
+(both now keep such objects on `$Object`). Blast radius: host `{}`-with-dynamic-
+access vars move struct→`$Object` (a representation change for that narrow class,
+already the standalone behavior); validated by full `merge_group` + standalone
+floor. Note: this touches the widening **decision** pre-pass (extends an existing
+suppression), not struct layout/registration logic.
+
+### Change
+
+`src/codegen/declarations.ts:2228` — drop the `ctx.standalone` gate on the
+`markObjectHashConsumers` scan so the `objectHashConsumerVars` poison (and its
+widening-suppression at 2252) applies in host mode too.
+
+### Guardrails
+
+- byte-diff (sha256) neutrality on a corpus of `{}`-with-only-static-access
+  programs — the static fast path must be untouched;
+- equivalence tests green;
+- new `tests/issue-2849.test.ts`: the dead-branch repro + the guarded
+  (`==null` / `=== "latest"` / numeric-only) for-in-copy family, host AND
+  standalone;
+- full `merge_group` + standalone floor for the representation change.
+
+### Follow-up (separate, pre-existing — NOT this issue)
+
+The **standalone** lane has a distinct, pre-existing gap for the same for-in-copy
+shape: `var o={}; for (k in d) o[k]=opts[k]; … o.ecmaVersion` reads back
+`0`/`null` under `--target standalone` (the `$Object` dynamic read-back of a
+value copied from a struct receiver via a runtime key). This is unaffected by
+#2849 (my fix only extends the host poison; standalone codegen is byte-identical
+— sha256 verified) and is out of scope here (the #2849 / edge.js acorn use case
+is host/node-acorn). Should be filed separately against the standalone
+`$Object`/struct dynamic-read substrate (relates to #2896 / the value-rep work).
+The #2849 tests therefore assert the standalone lane only for **purity + no
+trap**, not the normalised numeric.
+
+## ~~Root cause (verified by bisected repro)~~ (SUPERSEDED — see above)
 
 acorn sets `node.attributes` ONLY when `this.options.ecmaVersion >= 16`
 (acorn.mjs:1813/1838/1965 — `16` is the YEAR-normalised form of ES2025).
@@ -58,8 +159,12 @@ var d = { ecmaVersion: null, sourceType: 0 };
 export function run(ev) {
   var opts = { ecmaVersion: ev, sourceType: 1 };
   var o = {};
-  for (var k in d) { o[k] = opts[k]; }
-  if (o.ecmaVersion >= 2015) { o.ecmaVersion -= 2009; }   // WORKS: run(2022)=13
+  for (var k in d) {
+    o[k] = opts[k];
+  }
+  if (o.ecmaVersion >= 2015) {
+    o.ecmaVersion -= 2009;
+  } // WORKS: run(2022)=13
   return o.ecmaVersion;
 }
 ```
@@ -68,9 +173,15 @@ Adding the acorn-shaped `=== "latest"` / `== null` guards BEFORE the numeric
 branch breaks it — `o.ecmaVersion` then reads back **0** in the numeric context:
 
 ```ts
-  if (o.ecmaVersion === "latest") { o.ecmaVersion = 1e8; }       // <- either of
-  else if (o.ecmaVersion == null) { o.ecmaVersion = 11; }        //    these two
-  else if (o.ecmaVersion >= 2015) { o.ecmaVersion -= 2009; }     // run(2022)=0 (BUG)
+if (o.ecmaVersion === "latest") {
+  o.ecmaVersion = 1e8;
+} // <- either of
+else if (o.ecmaVersion == null) {
+  o.ecmaVersion = 11;
+} //    these two
+else if (o.ecmaVersion >= 2015) {
+  o.ecmaVersion -= 2009;
+} // run(2022)=0 (BUG)
 ```
 
 Both `=== "latest"` (string compare) and `== null` independently trigger it. The

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -2217,18 +2217,28 @@ export function collectEmptyObjectWidening(
           // Scan all following statements in the same block for property assignments
           collectPropsFromStatements(checker, ctx, stmts, varName, extraProps, seenProps);
 
-          // (#2584) Standalone: if this var is ALSO the subject of any
+          // (#2584/#2849) If this var is ALSO the subject of any
           // `$Object`-hash-only consumer (bracket read/write, `in`, Object.keys
           // / values / entries / GOPD / GOPN / assign, for-in), a widened closed
           // struct would be invisible to that consumer (`o.a=7; o["a"]` → 0).
           // Mark it poisoned so widening is suppressed below and the receiver
           // stays a `$Object`. Scan the whole enclosing statement list (the same
-          // tree `collectPropsFromStatements` walks). Standalone-gated — host
-          // keeps the struct fast path via the live-mirror Proxy.
-          if (ctx.standalone) {
-            for (const s of stmts) {
-              markObjectHashConsumers(s, varName, ctx.objectHashConsumerVars);
-            }
+          // tree `collectPropsFromStatements` walks).
+          //
+          // (#2849) This was ORIGINALLY `ctx.standalone`-gated on the assumption
+          // "host keeps the struct fast path via the live-mirror Proxy". That
+          // assumption is false for the for-in copy pattern
+          // (`o={}; for (k in d) o[k]=src[k]; … o.prop`): the dynamic-key writes
+          // `o[k]=` land in the sidecar, but a STATIC-named write `o.prop = c`
+          // anywhere (even an unreached branch) widens `prop` into a real struct
+          // field via `collectPropsFromStatements`, so the read `o.prop` lowers
+          // to `struct.get` of the empty field (0) — the Proxy never bridges the
+          // for-in-write→struct-read divergence. Applying the poison in host mode
+          // too keeps such objects on `$Object` so writes + reads share one
+          // representation. Vars with only static access are NOT poisoned, so the
+          // struct fast path (and its byte output) is unchanged.
+          for (const s of stmts) {
+            markObjectHashConsumers(s, varName, ctx.objectHashConsumerVars);
           }
 
           // (#2372) Standalone: if any `Object.defineProperty(varName, …)` on

--- a/tests/issue-2849.test.ts
+++ b/tests/issue-2849.test.ts
@@ -1,0 +1,111 @@
+// (#2849) A `{}` object populated via dynamic-key writes (`o[k]=v`, e.g. a
+// for-in copy loop) keeps its values in the dynamic `$Object` sidecar. A
+// STATIC-named write `o.prop = <const>` anywhere in the function — even an
+// UNREACHED branch — used to widen `prop` into a real WasmGC struct field
+// (default 0) via the reachability-blind `collectEmptyObjectWidening` pre-pass.
+// Every read `o.prop` then lowered to `struct.get` of the empty field → 0,
+// while the for-in values sat untouched in the sidecar. The `#2584`
+// `objectHashConsumerVars` poison (keep such objects on `$Object`) already fixed
+// this for standalone but was `ctx.standalone`-gated; #2849 extends it to host
+// (the "live-mirror Proxy" the gate assumed does NOT bridge the for-in-write →
+// struct-read divergence).
+//
+// This is the acorn `getOptions` ecmaVersion-normalisation shape:
+//   var o = {}; for (var k in defaults) o[k] = opts[k];
+//   if (o.ecmaVersion === "latest") …            // static-named guard write
+//   else if (o.ecmaVersion == null) …
+//   else if (o.ecmaVersion >= 2015) o.ecmaVersion -= 2009;   // 2022 → 13
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// Host-mode harness (buildImports + setExports — the canonical host runtime
+// glue; without setExports a struct-sidecar read returns undefined, which is the
+// harness false-negative that masked this bug during triage).
+async function runHost(source: string, arg: number, fn = "run"): Promise<unknown> {
+  const result = await compile(source);
+  expect(result.success, result.errors.map((e) => e.message).join("\n")).toBe(true);
+  const imports = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as Record<string, (...a: unknown[]) => unknown>)[fn](arg);
+}
+
+// Standalone harness — compiles with `--target standalone` and instantiates
+// with EMPTY imports (a leaked host import fails instantiation). #2849 is a
+// HOST-mode bug: the `objectHashConsumerVars` poison was already applied for
+// standalone (this fix only extends it to host), so standalone codegen is
+// byte-identical before/after (verified via sha256 in the issue). Standalone
+// also has a SEPARATE, pre-existing `$Object` dynamic-read-back gap for the
+// for-in-copy pattern (`o[k]=src[k]` then `o.prop` reads back 0/undefined —
+// filed separately), so we do NOT assert the normalised numeric here; we assert
+// standalone stays PURE (no host-import leak) and does not trap.
+async function compileStandalonePureRuns(source: string, arg: number, fn = "run"): Promise<void> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  // Must not trap (invalid Wasm / null-deref) — result value is out of scope here.
+  (instance.exports as Record<string, (...a: unknown[]) => unknown>)[fn](arg);
+}
+
+const FORIN_COPY = `// @ts-nocheck
+var defaults = { ecmaVersion: null, sourceType: 0 };
+export function run(ev) {
+  var opts = { ecmaVersion: ev, sourceType: 1 };
+  var o = {};
+  for (var k in defaults) { o[k] = opts[k]; }
+  __GUARD__
+  return o.ecmaVersion;
+}`;
+
+const variants: Record<string, string> = {
+  "no-guard": `if (o.ecmaVersion >= 2015) { o.ecmaVersion -= 2009; }`,
+  "== null guard": `if (o.ecmaVersion == null) { o.ecmaVersion = 11; } else if (o.ecmaVersion >= 2015) { o.ecmaVersion -= 2009; }`,
+  '=== "latest" guard': `if (o.ecmaVersion === "latest") { o.ecmaVersion = 1e8; } else if (o.ecmaVersion >= 2015) { o.ecmaVersion -= 2009; }`,
+  "numeric-only guard": `if (o.ecmaVersion > 5000) { o.ecmaVersion = 1; } else if (o.ecmaVersion >= 2015) { o.ecmaVersion -= 2009; }`,
+};
+
+describe("#2849 dynamic-object static-write field-vs-sidecar coherence", () => {
+  for (const [name, guard] of Object.entries(variants)) {
+    const src = FORIN_COPY.replace("__GUARD__", guard);
+    it(`host: for-in copy + [${name}] normalises 2022 → 13`, async () => {
+      expect(await runHost(src, 2022)).toBe(13);
+    });
+    it(`standalone: for-in copy + [${name}] stays pure and does not trap`, async () => {
+      await compileStandalonePureRuns(src, 2022);
+    });
+  }
+
+  // The minimal proof: an UNREACHED static-named write must NOT shadow the
+  // sidecar value the for-in loop wrote.
+  const DEAD_BRANCH = `// @ts-nocheck
+var defaults = { ecmaVersion: null, sourceType: 0 };
+export function run(ev) {
+  var opts = { ecmaVersion: ev, sourceType: 1 };
+  var o = {};
+  for (var k in defaults) { o[k] = opts[k]; }
+  if (ev < 0) { o.ecmaVersion = 999; }   // never taken for ev = 2022
+  return o.ecmaVersion;
+}`;
+  it("host: unreached static write does not shadow the sidecar (reads 2022)", async () => {
+    expect(await runHost(DEAD_BRANCH, 2022)).toBe(2022);
+  });
+  it("standalone: unreached static write compiles pure and does not trap", async () => {
+    await compileStandalonePureRuns(DEAD_BRANCH, 2022);
+  });
+
+  // Guardrail: a `{}` var with ONLY static-named access keeps the struct fast
+  // path and stays correct (this class is NOT poisoned, so its codegen is
+  // byte-identical to pre-fix — see the sha256 neutrality check in the issue).
+  const STATIC_ONLY = `// @ts-nocheck
+export function run(x) {
+  var o = {};
+  o.v = x;
+  if (o.v >= 2015) { o.v -= 2009; }
+  return o.v;
+}`;
+  it("host: static-only-access object unchanged (2022 → 13)", async () => {
+    expect(await runHost(STATIC_ONLY, 2022)).toBe(13);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2849. A `{}` object populated via dynamic-key writes (`o[k]=v`, e.g. a for-in copy loop) keeps its values in the dynamic `$Object` **sidecar**. A **static-named write** `o.prop = <const>` anywhere in the function — **even an unreached branch** — used to widen `prop` into a real WasmGC struct field (default 0) via the reachability-blind `collectEmptyObjectWidening` pre-pass. Every read `o.prop` then lowered to `struct.get` of the empty field (0), while the for-in values sat in the sidecar.

This is the acorn `getOptions` ecmaVersion-normalisation shape — `2022` read back as `0` instead of `13`:
```js
var o = {}; for (var k in defaults) o[k] = opts[k];
if (o.ecmaVersion === "latest") …            // static-named guard write
else if (o.ecmaVersion == null) …
else if (o.ecmaVersion >= 2015) o.ecmaVersion -= 2009;   // 2022 → 13
```

## Root cause & fix

The #2584 `objectHashConsumerVars` poison (keep a `{}` var that also has computed/`in`/`for-in`/`Object.keys` access on `$Object`, so static and dynamic access share one representation) already fixed this class — but it was **`ctx.standalone`-gated** on the assumption "host keeps the struct fast path via the live-mirror Proxy". That assumption is false for the for-in-write → static-`struct.get` divergence, so host regressed.

**Fix (strategy (b) sidecar-wins, one-line):** drop the `ctx.standalone` gate on the `markObjectHashConsumers` scan in `src/codegen/declarations.ts` so the poison + its widening-suppression apply in host mode too. Full design + rejected alternatives are in the issue file.

## Guardrails

- **Static fast path untouched** — `{}` vars with only static-named access are NOT poisoned; sha256 byte-diff over a static-only corpus is identical pre/post.
- **Standalone byte-identical** — the poison was already on for standalone, so standalone codegen is unchanged (sha256-verified). This is a host-only fix.
- `tests/issue-2849.test.ts` — guarded (`==null` / `=== "latest"` / numeric-only) for-in-copy family + the dead-branch repro; host asserts `2022 → 13`, standalone asserts purity + no-trap.
- Widening/poison/for-in mechanism suites green (#2372, #2584, #2572, for-in, ir-frontend-widening, #1712 — 68 tests).

## Scope note

The **standalone** lane has a separate, pre-existing `$Object` dynamic read-back gap for the same for-in-copy shape (reads back 0/null), unaffected by this fix and out of scope (the #2849/edge.js acorn use case is host/node-acorn). Noted as a follow-up in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)