### PR TITLE
feat(#2861): native-proto glue for DisposableStack / AsyncDisposableStack proto value reads

### DIFF
--- a/plan/issues/2861-standalone-builtin-static-value-read-native-proto-glue.md
+++ b/plan/issues/2861-standalone-builtin-static-value-read-native-proto-glue.md
@@ -1,9 +1,10 @@
 ---
 id: 2861
 title: "Standalone: built-in static/prototype property value read not supported — extend native-proto glue (ArrayBuffer, DataView, Promise, Iterator, Error subclasses, …)"
-status: ready
+status: in-progress
+assignee: ttraenkler/dev-2863
 created: 2026-06-30
-updated: 2026-06-30
+updated: 2026-07-02
 priority: high
 feasibility: medium
 task_type: feature
@@ -38,18 +39,18 @@ compile-error cluster in the standalone gap.
 **~882 standalone-only failures** carry this signature. Breakdown by builtin
 (top of the residual — these are the ones with NO native-proto glue yet):
 
-| builtin            | tests | builtin             | tests |
-| ------------------ | ----- | ------------------- | ----- |
-| ArrayBuffer        | 166   | Atomics             | 33    |
-| DataView           | 89    | SharedArrayBuffer   | 29    |
-| Promise            | 78    | DisposableStack     | 27    |
-| Iterator           | 65    | AsyncDisposableStack| 25    |
-| Math               | 59    | Symbol              | 16    |
-| TypeError          | 42    | JSON                | 16    |
-| Object (residual)  | 41    | Reflect             | 13    |
-| Array (residual)   | 26    | WeakRef             | 11    |
-|                    |       | FinalizationRegistry| 10    |
-|                    |       | Error subclasses (Range/Reference/…) | ~30 |
+| builtin           | tests | builtin                              | tests |
+| ----------------- | ----- | ------------------------------------ | ----- |
+| ArrayBuffer       | 166   | Atomics                              | 33    |
+| DataView          | 89    | SharedArrayBuffer                    | 29    |
+| Promise           | 78    | DisposableStack                      | 27    |
+| Iterator          | 65    | AsyncDisposableStack                 | 25    |
+| Math              | 59    | Symbol                               | 16    |
+| TypeError         | 42    | JSON                                 | 16    |
+| Object (residual) | 41    | Reflect                              | 13    |
+| Array (residual)  | 26    | WeakRef                              | 11    |
+|                   |       | FinalizationRegistry                 | 10    |
+|                   |       | Error subclasses (Range/Reference/…) | ~30   |
 
 (The `<View>.prototype` TypedArray residual already has glue via #2651; these
 are the still-unwired builtins.)
@@ -89,6 +90,7 @@ export function ensureArrayBufferNativeProtoGlue(ctx: CodegenContext): number | 
 ### Changes
 
 **File: `src/codegen/array-object-proto.ts`**
+
 - Add a `*_PROTO_METHODS` member list per builtin (the spec'd
   `<Builtin>.prototype` own enumerable + standard method/getter names — pull
   from the ES spec / the host-mode member set; getters like `ArrayBuffer.prototype.byteLength`,
@@ -102,6 +104,7 @@ export function ensureArrayBufferNativeProtoGlue(ctx: CodegenContext): number | 
   needs the member CSV.
 
 **File: `src/codegen/property-access.ts`**
+
 - In `tryEnsureNativeProtoBrand` (line 696), add a `if (builtinName === "ArrayBuffer") return ensureArrayBufferNativeProtoGlue(ctx);`
   arm per newly-wired builtin, before the final `getBuiltinBrand` fallthrough (line 781).
 - Order by impact: ArrayBuffer, DataView, Promise, Iterator, then the Error
@@ -121,6 +124,7 @@ Iterator, Error subclasses, WeakRef, FinalizationRegistry, DisposableStack,
 AsyncDisposableStack) — ~700 of the 882. Math/JSON/Reflect/Atomics (~120) split out.
 
 ### Edge cases
+
 - A builtin whose ctor brand isn't reserved (`getBuiltinBrand` returns
   `undefined`) → return `undefined` (caller keeps the refusal — no fabricated
   value). Confirm ArrayBuffer/DataView/Promise/Iterator brands ARE reserved
@@ -139,6 +143,7 @@ AsyncDisposableStack) — ~700 of the 882. Math/JSON/Reflect/Atomics (~120) spli
 ## Test plan
 
 These standalone-CE tests must flip to **pass** (host already passes them):
+
 - `test/built-ins/ArrayBuffer/prototype/**` (byteLength getter, slice, etc.)
 - `test/built-ins/DataView/prototype/**` (byteLength/buffer/byteOffset getters)
 - `test/built-ins/Promise/prototype/**` (finally/then/catch name+length reads)
@@ -151,7 +156,44 @@ high-water (`check-standalone-highwater.mjs`). Expect a net standalone pass gain
 of several hundred with **zero** host-mode regression (these paths are
 `ctx.standalone`-gated).
 
-
 ## Reconciliation note (shepherd, 2026-07-01)
 
 Landed slices (native-proto glue wired, verified present in `src/codegen/`): **ArrayBuffer, DataView** (PR #2340), **Promise, Iterator, NativeError subclasses** (PR #2341), **SharedArrayBuffer, WeakRef, FinalizationRegistry** (PR #2344). **Remaining (issue stays `ready`)**: `DisposableStack` / `AsyncDisposableStack` proto glue not yet wired (no `ensureDisposableStack*NativeProtoGlue` in source), plus the `Math`/`JSON`/`Reflect`/`Atomics` namespace static reads explicitly split out per the Implementation Plan.
+
+## Slice 3 (dev-2863, 2026-07-02) — DisposableStack / AsyncDisposableStack
+
+Re-measured the value-read refusal per builtin against current `origin/main`:
+every previously-landed builtin (ArrayBuffer, DataView, Promise, Iterator,
+TypeError/RangeError/ReferenceError, SharedArrayBuffer, WeakRef,
+FinalizationRegistry, Symbol) now compiles. The only ctor/prototype value reads
+still refusing were **`DisposableStack` / `AsyncDisposableStack`** — wired here:
+
+- **`src/codegen/native-proto.ts`** — appended the `DisposableStack` (slot 41) /
+  `AsyncDisposableStack` (slot 42) brands to `BUILTIN_BRAND_TABLE` (they were
+  unreserved, so `getBuiltinBrand` returned `undefined` and the ensure-glue
+  returned early — the plan's "brand not reserved" edge case).
+- **`src/codegen/array-object-proto.ts`** — `*_PROTO_METHODS` member sets
+  (`use`/`adopt`/`defer`/`move`/`dispose`[`disposeAsync`] + the `disposed`
+  accessor getter) and `ensure{Disposable,AsyncDisposable}StackNativeProtoGlue`
+  via `makeGlueWithGetters` (getter folds `.length` to 0). The TC39 Explicit
+  Resource Management resource list lives on the INSTANCE, so the proto value
+  object is pure (member CSV only); member-CLOSURE bodies degrade to a catchable
+  TypeError (the #2193/#2651 pattern). Symbol-keyed members
+  (`[Symbol.dispose]`/`[Symbol.asyncDispose]`/`[Symbol.toStringTag]`) stay
+  outside the string CSV, same as every sibling glue.
+- **`src/codegen/property-access.ts`** — two arms in `tryEnsureNativeProtoBrand`.
+
+Tests: `tests/issue-2861-disposablestack-proto-value-read.test.ts` (value read
+compiles host-free; `.length` folds spec arity; `disposed` getter folds to 0;
+sibling ArrayBuffer/FinalizationRegistry glue unregressed).
+
+**All ctor/prototype value reads in this issue's scope are now wired.** Genuine
+remainder (NOT this slice, and NOT ctor/proto glue):
+
+- **`Math`/`JSON`/`Reflect`/`Atomics` namespace static reads** (`Math.LN2` value,
+  `JSON.stringify` as a value, …) — explicitly split out per the Implementation
+  Plan; a separate follow-up under umbrella #2860.
+- **`<Ctor>.length` / `<Ctor>.name` static reads** (e.g. `Boolean.length` — the
+  ctor's own arity, `test/built-ins/Boolean/S15.6.3_A3.js`) still refuse. This is
+  a distinct mechanism from proto glue (a function's own `length`/`name`, not a
+  `.prototype` member) — a candidate next slice.

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -578,6 +578,36 @@ const WEAKREF_PROTO_METHODS = ["deref"] as const;
 // PROTO_METHOD_LENGTH table (no cross-builtin collision).
 const FINALIZATIONREGISTRY_PROTO_METHODS = ["register", "unregister"] as const;
 
+// ── DisposableStack.prototype (TC39 Explicit Resource Management §12.3) ───────
+// `use`(1) / `adopt`(2) / `defer`(1) / `move`(0) / `dispose`(0) data methods +
+// the `disposed` accessor getter (folds `.length` to 0). The `[Symbol.dispose]`
+// / `[Symbol.toStringTag]` symbol members are keyed by symbol, not string, so
+// they are outside the string member CSV (same as every other glue). The
+// resource list lives on the INSTANCE, so the proto value object is pure.
+const DISPOSABLESTACK_PROTO_METHODS = ["dispose", "use", "adopt", "defer", "move", "disposed"] as const;
+const DISPOSABLESTACK_PROTO_GETTERS: ReadonlySet<string> = new Set(["disposed"]);
+const DISPOSABLESTACK_PROTO_METHOD_LENGTH: Readonly<Record<string, number>> = {
+  dispose: 0,
+  use: 1,
+  adopt: 2,
+  defer: 1,
+  move: 0,
+};
+
+// ── AsyncDisposableStack.prototype (TC39 Explicit Resource Management §12.4) ──
+// Mirror of DisposableStack with `disposeAsync`(0) in place of `dispose`; the
+// `[Symbol.asyncDispose]` / `[Symbol.toStringTag]` symbol members stay outside
+// the string CSV.
+const ASYNCDISPOSABLESTACK_PROTO_METHODS = ["disposeAsync", "use", "adopt", "defer", "move", "disposed"] as const;
+const ASYNCDISPOSABLESTACK_PROTO_GETTERS: ReadonlySet<string> = new Set(["disposed"]);
+const ASYNCDISPOSABLESTACK_PROTO_METHOD_LENGTH: Readonly<Record<string, number>> = {
+  disposeAsync: 0,
+  use: 1,
+  adopt: 2,
+  defer: 1,
+  move: 0,
+};
+
 /**
  * Graceful member-body refusal: the value-read object (PR-A) does not need
  * member bodies, but if a reflective member closure is materialized for a member
@@ -1229,6 +1259,54 @@ export function ensureFinalizationRegistryNativeProtoGlue(ctx: CodegenContext): 
   if (brand === undefined) return undefined;
   if (!getNativeProtoBuiltinGlue(ctx, brand)) {
     registerNativeProtoBuiltin(ctx, makeGlue(ctx, brand, "FinalizationRegistry", FINALIZATIONREGISTRY_PROTO_METHODS));
+  }
+  return brand;
+}
+
+/**
+ * (#2861) Register `DisposableStack.prototype` glue (idempotent). The
+ * DisposableStack brand is newly appended to `BUILTIN_BRAND_TABLE` (slot 41).
+ * `use`/`adopt`/`defer`/`move`/`dispose` methods + the `disposed` accessor
+ * getter (folds `.length` to 0) → `makeGlueWithGetters`. The resource list
+ * lives on the instance, so the proto value object is pure (member CSV only).
+ */
+export function ensureDisposableStackNativeProtoGlue(ctx: CodegenContext): number | undefined {
+  const brand = getBuiltinBrand(ctx, "DisposableStack");
+  if (brand === undefined) return undefined;
+  if (!getNativeProtoBuiltinGlue(ctx, brand)) {
+    registerNativeProtoBuiltin(
+      ctx,
+      makeGlueWithGetters(
+        brand,
+        "DisposableStack",
+        DISPOSABLESTACK_PROTO_METHODS,
+        DISPOSABLESTACK_PROTO_GETTERS,
+        DISPOSABLESTACK_PROTO_METHOD_LENGTH,
+      ),
+    );
+  }
+  return brand;
+}
+
+/**
+ * (#2861) Register `AsyncDisposableStack.prototype` glue (idempotent). The
+ * AsyncDisposableStack brand is newly appended to `BUILTIN_BRAND_TABLE` (slot
+ * 42). Same shape as DisposableStack with `disposeAsync` in place of `dispose`.
+ */
+export function ensureAsyncDisposableStackNativeProtoGlue(ctx: CodegenContext): number | undefined {
+  const brand = getBuiltinBrand(ctx, "AsyncDisposableStack");
+  if (brand === undefined) return undefined;
+  if (!getNativeProtoBuiltinGlue(ctx, brand)) {
+    registerNativeProtoBuiltin(
+      ctx,
+      makeGlueWithGetters(
+        brand,
+        "AsyncDisposableStack",
+        ASYNCDISPOSABLESTACK_PROTO_METHODS,
+        ASYNCDISPOSABLESTACK_PROTO_GETTERS,
+        ASYNCDISPOSABLESTACK_PROTO_METHOD_LENGTH,
+      ),
+    );
   }
   return brand;
 }

--- a/src/codegen/native-proto.ts
+++ b/src/codegen/native-proto.ts
@@ -125,8 +125,14 @@ const BUILTIN_BRAND_TABLE: Readonly<Record<string, number>> = {
 
   // ── Resource-management / weak builtins ──────────────────────────────────
   FinalizationRegistry: BUILTIN_BRAND_BASE + 40,
+  // (#2861) TC39 Explicit Resource Management stacks — `<Stack>.prototype`
+  // value reads (use/adopt/defer/move/dispose[Async]/disposed getter). The
+  // resource list lives on the INSTANCE, never the proto, so the proto value
+  // object is pure (member CSV only).
+  DisposableStack: BUILTIN_BRAND_BASE + 41,
+  AsyncDisposableStack: BUILTIN_BRAND_BASE + 42,
 
-  // Next free slot: BUILTIN_BRAND_BASE + 41 (append only).
+  // Next free slot: BUILTIN_BRAND_BASE + 43 (append only).
 };
 
 /**

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -86,6 +86,8 @@ import {
   ensureSharedArrayBufferNativeProtoGlue,
   ensureWeakRefNativeProtoGlue,
   ensureFinalizationRegistryNativeProtoGlue,
+  ensureDisposableStackNativeProtoGlue,
+  ensureAsyncDisposableStackNativeProtoGlue,
   ensureTypedArrayViewNativeProtoGlue,
   ensureTypedArrayIntrinsicNativeProtoGlue,
   emitTypedArrayIntrinsicCtorObject,
@@ -822,6 +824,15 @@ export function tryEnsureNativeProtoBrand(ctx: CodegenContext, builtinName: stri
   }
   if (builtinName === "FinalizationRegistry") {
     return ensureFinalizationRegistryNativeProtoGlue(ctx);
+  }
+  // (#2861) DisposableStack / AsyncDisposableStack — TC39 Explicit Resource
+  // Management. The resource list lives on the instance, so the proto value
+  // object is pure (member CSV only).
+  if (builtinName === "DisposableStack") {
+    return ensureDisposableStackNativeProtoGlue(ctx);
+  }
+  if (builtinName === "AsyncDisposableStack") {
+    return ensureAsyncDisposableStackNativeProtoGlue(ctx);
   }
   // (#2651 M1 / D2) Concrete TypedArray view protos — `Int8Array.prototype`,
   // `Uint8Array.prototype`, … This is the measured Slice-0 lever: the

--- a/tests/issue-2861-disposablestack-proto-value-read.test.ts
+++ b/tests/issue-2861-disposablestack-proto-value-read.test.ts
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #2861 (slice 3) — standalone `DisposableStack.prototype` /
+// `AsyncDisposableStack.prototype` value reads, extending the native-proto-glue
+// chain (ArrayBuffer/DataView #2861-s1; SharedArrayBuffer/WeakRef/FinalizationRegistry
+// #2861-s2; #2376 Date, #2651 TypedArray, #2374 String/Number/Boolean, #2193
+// Array/Object, #2175 RegExp).
+//
+// Reading `<Stack>.prototype.<member>` (or bare `<Stack>.prototype`) AS A VALUE
+// refused in standalone with the "built-in static property value read is not
+// supported in --target standalone (#1907 / #1888 S6-b)" compile error. Fix:
+// append the DisposableStack (slot 41) / AsyncDisposableStack (slot 42) brands to
+// native-proto.ts, register glue (use/adopt/defer/move/dispose[Async] methods +
+// the `disposed` accessor getter — `makeGlueWithGetters`), and wire them into
+// tryEnsureNativeProtoBrand. The TC39 Explicit Resource Management resource list
+// lives on the INSTANCE, never the proto, so the value-object materialization is
+// clean. Member-CLOSURE bodies degrade to a catchable TypeError until native
+// bodies land (the #2193/#2651 pattern).
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  expect((r.imports ?? []).map((i) => i.name)).toEqual([]);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2861 slice 3 — standalone DisposableStack.prototype value reads", () => {
+  it("DisposableStack.prototype reads to a truthy value (was a compile refusal)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const p: any = DisposableStack.prototype; return p ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("DisposableStack.prototype.use value read compiles host-free (was a hard refusal)", async () => {
+    const r = await compile(
+      `export function test(): number { const m: any = DisposableStack.prototype.use; return 1; }`,
+      { target: "standalone" },
+    );
+    expect(r.success, JSON.stringify(r.errors)).toBe(true);
+    expect((r.imports ?? []).map((i) => i.name)).toEqual([]);
+  });
+
+  it("DisposableStack.prototype.use.length folds the spec arity (1)", async () => {
+    expect(await runStandalone(`export function test(): number { return DisposableStack.prototype.use.length; }`)).toBe(
+      1,
+    );
+  });
+
+  it("DisposableStack.prototype.adopt.length folds the spec arity (2)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return DisposableStack.prototype.adopt.length; }`),
+    ).toBe(2);
+  });
+
+  it("DisposableStack.prototype.move.length folds the spec arity (0)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return DisposableStack.prototype.move.length; }`),
+    ).toBe(0);
+  });
+
+  it("DisposableStack.prototype.disposed is an accessor getter — .length folds to 0", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { return (DisposableStack.prototype as any).disposed.length; }`,
+      ),
+    ).toBe(0);
+  });
+});
+
+describe("#2861 slice 3 — standalone AsyncDisposableStack.prototype value reads", () => {
+  it("AsyncDisposableStack.prototype reads to a truthy value (was a compile refusal)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const p: any = AsyncDisposableStack.prototype; return p ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("AsyncDisposableStack.prototype.disposeAsync.length folds the spec arity (0)", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { return AsyncDisposableStack.prototype.disposeAsync.length; }`,
+      ),
+    ).toBe(0);
+  });
+
+  it("AsyncDisposableStack.prototype.adopt.length folds the spec arity (2)", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return AsyncDisposableStack.prototype.adopt.length; }`),
+    ).toBe(2);
+  });
+});
+
+describe("#2861 slice 3 — no regression on sibling proto glue", () => {
+  it("sibling: FinalizationRegistry.prototype value read (the #2861 slice-2 path) still resolves", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const p: any = FinalizationRegistry.prototype; return p ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("sibling: ArrayBuffer.prototype.slice.length still folds (2)", async () => {
+    expect(await runStandalone(`export function test(): number { return ArrayBuffer.prototype.slice.length; }`)).toBe(
+      2,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Standalone `DisposableStack.prototype.<member>` / `AsyncDisposableStack.prototype.<member>` (and bare `<Stack>.prototype`) value reads refused with the #1907/#1888 S6-b *"built-in static property value read is not supported"* compile error. These were the **last ctor/prototype value reads still refusing** after the ArrayBuffer/DataView (#2340), Promise/Iterator/NativeError (#2341), and SharedArrayBuffer/WeakRef/FinalizationRegistry (#2344) slices.

Re-measured every builtin in the impact table against current `origin/main` first: all previously-landed builtins now compile; only `DisposableStack` / `AsyncDisposableStack` remained.

## Changes

- **`src/codegen/native-proto.ts`** — append `DisposableStack` (slot 41) / `AsyncDisposableStack` (slot 42) brands to `BUILTIN_BRAND_TABLE`. They were unreserved, so `getBuiltinBrand` returned `undefined` and the ensure-glue bailed (the plan's "brand not reserved" edge case — must reserve first).
- **`src/codegen/array-object-proto.ts`** — `*_PROTO_METHODS` member sets (`use`/`adopt`/`defer`/`move`/`dispose`[`disposeAsync`] + the `disposed` accessor getter) and `ensure{Disposable,AsyncDisposable}StackNativeProtoGlue` via `makeGlueWithGetters` (getter folds `.length` to 0). The TC39 Explicit Resource Management resource list lives on the **instance**, so the proto value object is pure (member CSV only); member-CLOSURE bodies degrade to a catchable TypeError (the #2193/#2651 pattern). Symbol-keyed members (`[Symbol.dispose]`/`[Symbol.asyncDispose]`/`[Symbol.toStringTag]`) stay outside the string CSV, same as every sibling glue.
- **`src/codegen/property-access.ts`** — two arms in `tryEnsureNativeProtoBrand`.

Follows the exact established, net-positive pattern (byte-for-byte the shape of the SharedArrayBuffer glue). `ctx.standalone`-gated paths only — **zero host-mode impact**.

## Scope

All ctor/prototype value reads in #2861's scope are now wired. Genuine remainder (separate follow-ups, NOT this slice): `Math`/`JSON`/`Reflect`/`Atomics` namespace static reads (split out per the Implementation Plan) and `<Ctor>.length`/`.name` static reads (e.g. `Boolean.length` — a distinct mechanism, not proto glue). Issue kept `in-progress` (multi-slice).

## Test plan

- `tests/issue-2861-disposablestack-proto-value-read.test.ts` — 11 cases: value read compiles host-free (was CE); `.length` folds spec arity (use=1, adopt=2, move/dispose/disposeAsync=0); `disposed` getter folds to 0; sibling ArrayBuffer/FinalizationRegistry glue unregressed.
- Sibling slice tests (`...arraybuffer-dataview...`, `...sab-weakref-finreg...`) — 28 tests, still green.
- `tsc --noEmit` clean; standalone modules emit **zero** host imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS