### PR TITLE
fix(#2930): resolve import bindings whose local name differs from the target decl name

### DIFF
--- a/plan/issues/2900-es3-module-indirect-default-binding-update.md
+++ b/plan/issues/2900-es3-module-indirect-default-binding-update.md
@@ -13,7 +13,7 @@ language_feature: module-code
 goal: spec-completeness
 related: [2898]
 assignee: ttraenkler/dev-2900
-blocked_reason: "3 independent root causes (see Implementation Plan); RC1 (.js module-dep compile) is broad-impact and needs a full test262 diff. Recommend splitting into #2900a/b/c + architect review."
+blocked_reason: "Umbrella — split into #2930 (RC2 alias, done), #2931 (RC3 live bindings), #2932 (RC1 .js module-dep compile, broad-impact/needs full test262 diff). Closes when all three land."
 ---
 
 # #2900 — module indirect global-binding update of a default export reads stale
@@ -21,17 +21,21 @@ blocked_reason: "3 independent root causes (see Implementation Plan); RC1 (.js m
 One of the **8 tests blocking 100% ≤ES3 conformance** (edition-heuristic bucket — this is module/ESM code, surfaced under ≤ES3 because it lacks version frontmatter).
 
 ## Failing test
+
 `test/language/module-code/eval-gtbndng-indirect-update-dflt.js`
 
 → **`returned 2`** (assertion failure — the indirectly-updated binding reads the wrong value).
 
 ## What it checks
+
 ES module semantics: a `default` export bound indirectly (via an indirect/re-exported binding) must observe later updates to the live binding (module bindings are live, not snapshots). The test mutates the binding and asserts the indirect reference sees the new value.
 
 ## Root-cause direction
+
 Module-code (ESM) live-binding handling for the `default` export through an indirect binding. Likely the default-export slot is read as a value copy rather than through the live module-environment binding. This is part of broader module-code support; scope to this single default-export-indirect-update case unless a shared root cause covers more `module-code/eval-gtbndng-*` tests.
 
 ## Acceptance
+
 - The indirect default-binding update is observed; the test passes.
 - No regression in other `module-code/` tests.
 
@@ -47,6 +51,7 @@ test; all three must be fixed for it to pass. This is a broader module-binding
 change, not a single-site patch — hence this plan instead of a partial fix.
 
 ### How the runner compiles this test
+
 `tests/test262-shared.ts` (and the sharded worker) detect the `_FIXTURE.js` import
 (`resolveFixtures`) and compile via `compileMulti(vfiles, "./test.ts", { skipSemanticDiagnostics: true, target, inferModuleStrictArguments })`
 — note **no `allowJs`**. `analyzeMultiSource` (`src/checker/index.ts`) builds one TS
@@ -54,6 +59,7 @@ program from `{ "./test.ts": <wrapped test>, "./…_FIXTURE.js": <fixture> }` an
 codegen concatenates all files into one Wasm module.
 
 ### Ground-truth traces
+
 - Real wrapped test → `test()` returns **2** (reproduces baseline).
 - Probe injected after the import: `val()` **=== null** (fixture not linked).
 - WAT of the merged module: **no `fn` function exists**; both `val()` and the `val`
@@ -61,9 +67,11 @@ codegen concatenates all files into one Wasm module.
   asserts compare `null` vs `1`/`2`.)
 
 ### Root cause 1 — `.js` module dependency is not compiled (fixture → null)
+
 Without `allowJs`, TypeScript excludes `.js` **root** files from the program, so the
 fixture's top-level `export default function fn` is never codegen'd. Proof (minimal,
 `skipSemanticDiagnostics: true`):
+
 - file **key** `./h.js`, `export function add` + `import {add}` → `test()` calls `add(1,2)` returns **0** (unlinked).
 - identical content, file **key** `./h.ts` → returns **3** (linked).
 - `{ allowJs: true }` with the `.js` key → returns **3** (linked).
@@ -73,6 +81,7 @@ fails on main** for exactly this reason (`expected 2 to be 1`) — cross-module 
 import of `add` returns 0.
 
 **Fix options (broad-impact — MUST validate via full CI / merge_group, not a scoped sweep):**
+
 - (a) Compiler: in `analyzeMultiSource` (`src/checker/index.ts`), auto-set
   `allowJs: true` (keep `checkJs` off to limit diagnostics) when any root file has a
   `.js`/`.jsx`/`.cjs`/`.mjs` extension. Correct for real bundler use (importing `.js`
@@ -84,10 +93,12 @@ import of `add` returns 0.
   so it needs a full test262 diff before merge.
 
 ### Root cause 2 — import-alias name mismatch (local name ≠ target decl name)
+
 Codegen keys `funcMap`/`moduleGlobals`/`closureMap` by the **declaration's own name**
 and never registers the differing **local import binding** name. So any import whose
 local name differs from the imported symbol's declaration name resolves to `null`.
 Proven on `.ts` fixtures (no `.js`/`allowJs` confound):
+
 - `import fn from "./h.ts"` where fixture is `export default function fn(){…}` (local == decl) → `fn()` = **7** ✓
 - `import val from "./h.ts"` (local `val` ≠ decl `fn`) → `val()` = **0** ✗
 - `import { add as plus } from …` (renamed **named** import) → `plus(1,2)` = **0** ✗
@@ -110,6 +121,7 @@ resolved name at the identifier-read, call, `new`, and `typeof` sites. Model it 
 pre-registration (that is why `val()` returned a non-null value in one earlier probe).
 
 ### Root cause 3 — reassigned function-declaration is not a live binding
+
 A function declaration whose name is **assigned to** (`fn = 2`) is bound to an
 immutable Wasm func index, not a mutable slot. In `emitIdentifierWriteFromLocal`
 (`src/codegen/expressions/assignment.ts`) the LHS `fn` is not in `localMap`,
@@ -119,10 +131,12 @@ local"** arm — the `fn = 2` value is written to a throwaway local and never ob
 Reads of `fn` as a value emit a cached closure struct
 (`emitCachedFuncClosureAccess`), disconnected from that write. Proven (single module,
 name-matching, so RC1/RC2 don't apply):
+
 - `function fn(){ fn = 2; return 1; } … fn(); (fn as any) === 2` → returns **200** (the read still sees the function, not `2`).
 - cross-module name-matching `.js` + allowJs, same shape → returns **200** likewise.
 
 **Fix (additive / narrow — only reassigned function decls change):**
+
 1. Static scan (declaration/setup pass in `src/codegen/index.ts` /
    `src/codegen/declarations.ts`): collect function-declaration names that appear as
    an assignment **target** (`fn = …`) anywhere in the module (rare pattern).
@@ -130,7 +144,7 @@ name-matching, so RC1/RC2 don't apply):
    initialized in `__module_init` to the function's closure value (funcref-as-closure,
    mirroring `emitCachedFuncClosureAccess`); ensure a `closureMap` entry exists so the
    existing read arm at `identifiers.ts:~926` (`existingClosure && closureModGlobal →
-   global.get`) fires.
+global.get`) fires.
 3. Reads → `global.get` (through the arm above); writes → already route to
    `moduleGlobals` in `emitIdentifierWriteFromLocal`; calls `fn()` → keep the direct
    `funcMap` call (valid: at call time the slot still holds the function).
@@ -144,19 +158,20 @@ existing "reserve struct/global indices up-front, register shared types late+onc
 discipline (memory `project_type_index_shift_and_deadelim`,
 `reference_subview_type_idx_stability`) to avoid an index-desync.
 
-### Recommendation
-Split into three issues (each independently valuable and testable):
-- **#2900a** — RC2 import-alias resolution (renamed/default/anonymous imports). Clean,
-  additive, unit-testable with `.ts` fixtures; likely a broad conformance win.
-- **#2900b** — RC3 live bindings for reassigned function declarations. Narrow,
-  additive, unit-testable single-module.
-- **#2900c** — RC1 compile `.js` module dependencies (option a or b). **Broad-impact;
-  gate on a full test262 diff.** This is the piece that actually lets `#2900`'s runner
-  path exercise a & b.
+### Split (filed 2026-07-02)
 
-`#2900` closes only when all three land. RC2 + RC3 alone do not flip this test (the
-fixture still would not compile); RC1 alone does not either (alias + live-binding
-still fail). Recommend architect review before implementation, given RC1's conformance
-surface. Repro scripts used for this analysis are ephemeral (`.tmp/`); the key
-controls are the `.ts`-fixture probes above (no `.js`/allowJs needed to reproduce
-RC2 and RC3).
+Split into three issues (each independently valuable and testable):
+
+- **#2930** — RC2 import-alias resolution (renamed/default/anonymous imports).
+  Clean, additive, unit-testable with `.ts` fixtures. **DONE** (this PR).
+- **#2931** — RC3 live bindings for reassigned function declarations. Narrow,
+  additive, unit-testable single-module. Ready (dev-2900 next).
+- **#2932** — RC1 compile `.js` module dependencies. **Broad-impact; gate on a full
+  test262 diff.** Blocked pending tech-lead sign-off on option + run slot. This is
+  the piece that actually lets `#2900`'s runner path exercise #2930 & #2931.
+
+`#2900` closes only when all three land. #2930 + #2931 alone do not flip this test
+(the `.js` fixture still would not compile); #2932 alone does not either (alias +
+live-binding still fail). Repro scripts used for this analysis are ephemeral
+(`.tmp/`); the key controls are the `.ts`-fixture probes above (no `.js`/allowJs
+needed to reproduce RC2 and RC3).

--- a/plan/issues/2930-import-alias-name-mismatch-resolution.md
+++ b/plan/issues/2930-import-alias-name-mismatch-resolution.md
@@ -1,0 +1,63 @@
+---
+id: 2930
+title: "codegen: import binding whose local name differs from the target declaration name resolves to null"
+status: done
+priority: high
+sprint: current
+created: 2026-07-02
+completed: 2026-07-02
+assignee: ttraenkler/dev-2900
+feasibility: medium
+task_type: bug
+area: codegen
+goal: spec-completeness
+related: [2900, 2931, 2932]
+parent: 2900
+---
+
+# #2930 — import-alias name mismatch (local name ≠ declaration name) → null
+
+Split from #2900 (RC2). Root-caused by dev-2900 — see #2900's Implementation Plan.
+
+## Problem
+
+Codegen keys `funcMap` / `closureMap` / `moduleGlobals` (and per-name call
+metadata) by the imported symbol's **declaration name**, never by the **local
+import binding**. So any import whose local name differs from the target's
+declaration name left the local binding unresolved — every read/call of it fell
+through to the graceful-null default (returned 0 / null / a wrong closure).
+
+Proven on `.ts` fixtures (no `.js`/allowJs involved) on `origin/main`:
+
+- `import fn from './h.ts'` where `./h.ts` is `export default function fn(){…}` (local == decl) → `fn()` = 7 ✓
+- `import val from './h.ts'` (local `val` ≠ decl `fn`) → `val()` = **0** ✗
+- `import { add as plus } from './h.ts'` (renamed named import) → `plus(1,2)` = **0** ✗
+- `function g(){…} export { g as default }` + `import v from './h.ts'` → `v()` = **0** ✗
+- anonymous `export default function(){…}` + `import val` → `val()` = **0** ✗
+
+## Fix (implemented)
+
+New pass `registerImportBindingAliases(ctx, sourceFiles)` in
+`src/codegen/index.ts`, run **after** `collectDeclarations` (targets registered)
+and **before** function bodies compile. For each default / named import binding
+it follows the checker alias (`getSymbolAtLocation` → `getAliasedSymbol`) to the
+target declaration's name (or `"default"` for anonymous default), then copies the
+resolution entries (`funcMap`, `closureMap`, `moduleGlobals`, `funcOptionalParams`,
+`nestedFuncCaptures`) onto the local name. Purely **additive** — writes only
+local-name keys that are currently absent, so every already-resolving binding
+stays byte-identical; only currently-null sites change.
+
+## Acceptance
+
+- Default / renamed-named / `export { x as default }` / anonymous-default imports
+  resolve to the imported target for both **call** and **value read**.
+- No regression in existing multi-file / module tests (CI full test262; the delta
+  is expected to be net-positive — many `_FIXTURE`-independent renamed/default
+  imports start resolving).
+
+## Notes
+
+- Unrelated pre-existing quirk (out of scope): `typeof <function-value>` does not
+  report `'function'` — true for local functions too, so not introduced here.
+- The cross-module `.js`-fixture case (#2900's real test) additionally needs
+  #2932 (compile `.js` module deps) and #2931 (live function-decl bindings).

--- a/plan/issues/2931-live-binding-reassigned-function-decl.md
+++ b/plan/issues/2931-live-binding-reassigned-function-decl.md
@@ -1,0 +1,72 @@
+---
+id: 2931
+title: "codegen: reassigned function declaration is not a live binding (fn = 2 is lost)"
+status: ready
+priority: high
+sprint: current
+created: 2026-07-02
+assignee: ttraenkler/dev-2900
+feasibility: medium
+task_type: bug
+area: codegen
+goal: spec-completeness
+related: [2900, 2930, 2932]
+parent: 2900
+---
+
+# #2931 — reassigned function declaration is not a live binding
+
+Split from #2900 (RC3). Root-caused by dev-2900 — see #2900's Implementation Plan.
+
+## Problem
+
+A function declaration whose name is **assigned to** (`fn = 2`) is bound to an
+immutable Wasm func index, not a mutable slot. In `emitIdentifierWriteFromLocal`
+(`src/codegen/expressions/assignment.ts`) the LHS `fn` is not in `localMap`,
+`capturedGlobals`, or `moduleGlobals` (function decls live in `funcMap`), so the
+write falls through to the **"undeclared sloppy implicit global → auto-allocate a
+throwaway local"** arm — the assigned value is written to a discarded local and
+never observed. Reads of `fn` emit a cached closure struct, disconnected from that
+write.
+
+Proven single-module (name-matching, so #2930 does not apply):
+`function fn(){ fn = 2; return 1; } … fn(); (fn as any) === 2` → returns **200**
+(the read still sees the function, not `2`).
+
+Per ES semantics module bindings are live: the #2900 test
+(`test/language/module-code/eval-gtbndng-indirect-update-dflt.js`) reassigns the
+default-exported function and asserts the indirect import observes the new value.
+
+## Fix (planned)
+
+1. Static scan (between `collectDeclarations` and body compilation): collect
+   function-declaration names that appear as an assignment **target** anywhere in
+   the realm (rare pattern) — `ts.isBinaryExpression` with `=` whose LHS resolves
+   to a `FunctionDeclaration`.
+2. For each, register a **mutable** `externref` module global (bypassing
+   `registerModuleGlobal`'s function-shadow skip) and record the name in a new
+   `ctx.liveFuncBindingGlobals: Set<string>`.
+3. **Read** path (`identifiers.ts`): early arm — if `name ∈ liveFuncBindingGlobals`,
+   `global.get moduleGlobals[name]`.
+4. **Write** path already routes an identifier assignment to `moduleGlobals` via
+   `global.set` once the global exists — no change needed.
+5. **Init**: in `__module_init`, initialize each live global to the function's
+   closure value (`emitCachedFuncClosureAccess` — NOT via the identifier read
+   path, which would recurse into the new global.get arm) so reading the name
+   **before** any reassignment still yields the function (avoids regressing
+   `const g = fn; fn = 2`).
+6. **#2930 interplay**: extend `registerImportBindingAliases` to propagate
+   `liveFuncBindingGlobals` membership to aliased local names, so a cross-module
+   `import val from` reads module A's live global (`moduleGlobals[val]` copied from
+   `moduleGlobals[fn]`).
+7. **Calls** keep the direct `funcMap` call (valid: the test calls before the
+   reassignment). Calling a reassigned name _after_ reassignment (would throw in
+   real JS) is out of scope — noted as a known narrow limitation.
+
+Index-shift discipline: register the live globals in the same Phase-2.5 window as
+other module globals (reserve up-front, avoid late-global index desync).
+
+## Acceptance
+
+- Single-module: `function fn(){fn=2;return 1} fn(); fn===2` observes `2`.
+- No regression in `module-code/` or existing tests (CI).

--- a/plan/issues/2932-compile-js-module-dependencies.md
+++ b/plan/issues/2932-compile-js-module-dependencies.md
@@ -1,0 +1,63 @@
+---
+id: 2932
+title: "codegen: .js module dependencies are not compiled in multi-file mode (imports resolve to null)"
+status: blocked
+priority: high
+sprint: current
+created: 2026-07-02
+feasibility: medium
+task_type: bug
+area: codegen
+goal: spec-completeness
+related: [2900, 2930, 2931]
+parent: 2900
+blocked_reason: "Broad-impact (~172 _FIXTURE.js test262 tests + any .js multi-compile). Must be validated by a full test262 diff / merge_group, never a scoped sweep. Coordinate a dedicated run slot with the tech lead (see #2900 plan). Do NOT start without lead sign-off."
+---
+
+# #2932 — compile `.js` module dependencies in multi-file mode
+
+Split from #2900 (RC1). Root-caused by dev-2900 — see #2900's Implementation Plan.
+
+## Problem
+
+`compileMultiSource` / `analyzeMultiSource` build the TS program **without
+`allowJs`**, so TypeScript excludes `.js` **root** files from the program. A `.js`
+module dependency's top-level declarations are therefore never codegen'd, and any
+import of them resolves to `null`.
+
+Proof (`skipSemanticDiagnostics: true`, `origin/main`):
+
+- file key `./h.js`, `export function add`, `import { add }` → `add(1,2)` returns **0** (unlinked)
+- identical content with key `./h.ts` → **3** (linked)
+- `{ allowJs: true }` with the `.js` key → **3** (linked)
+
+`tests/issue-1015.test.ts` ("positive fixture test") already fails on main for
+exactly this (`expected 2 to be 1`). The test262 runner's `_FIXTURE.js` path
+(`tests/test262-shared.ts` + the sharded fork worker) calls `compileMulti` with no
+`allowJs`, so **every** fixture-based module test compiles the fixture to nothing.
+
+## Fix options (BROAD — pick with architect/lead; validate on full test262)
+
+- **(a) Compiler**: in `analyzeMultiSource` (`src/checker/index.ts`), auto-set
+  `allowJs: true` (keep `checkJs` off) when any root file has a
+  `.js`/`.jsx`/`.cjs`/`.mjs` extension. Correct for real bundler use; changes every
+  multi-file `.js` compile.
+- **(b) Harness-scoped**: pass `allowJs: true` only in the FIXTURE branch of
+  `tests/test262-shared.ts` (+ the sharded fork worker). Blast radius bounded to
+  ~172 `_FIXTURE.js` tests, but still a conformance shift for that bucket.
+
+## Why blocked
+
+This is the piece that lets #2900's runner path actually exercise #2930 + #2931.
+It is **broad-impact and conformance-shifting** — many `instn-*` / `eval-gtbndng-*`
+module tests currently pass/fail on the null-import artifact. It must be validated
+by a **full test262 diff** (merge_group), and likely wants its **own dedicated run
+slot** so its large delta does not overlap with another baseline swing in one
+window. Do NOT implement without tech-lead sign-off on the option and timing.
+
+## Acceptance
+
+- `.js` module dependencies compile and link in multi-file mode.
+- `tests/issue-1015.test.ts` positive case passes.
+- Full test262 diff reviewed; net conformance change is understood and accepted.
+- #2900 (needs #2930 + #2931 + this) passes.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -5973,6 +5973,100 @@ function buildGetterExtract(
 }
 
 /**
+ * (#2930) Register import-binding local-name aliases.
+ *
+ * Codegen keys `funcMap` / `closureMap` / `moduleGlobals` (and the per-name call
+ * metadata) by the imported symbol's *declaration name*, never by the local
+ * import binding. So an import whose LOCAL name differs from the target's
+ * declaration name — a default import (`import val from './m'` where `./m`
+ * declares `function fn`), a renamed named import (`import { add as plus }`), an
+ * anonymous `export default function () {}`, or `export { g as default }` — left
+ * the local binding (`val` / `plus`) unresolved: every read/call of it fell
+ * through to the graceful-null default (returned 0 / null / a wrong closure).
+ *
+ * This pass runs AFTER `collectDeclarations` (targets are registered) and BEFORE
+ * function bodies compile (which reference the local names). For each import
+ * binding it follows the checker alias to the target declaration's name and
+ * copies the resolution entries onto the local name. Purely additive: it writes
+ * ONLY local-name keys that are currently absent, so every already-resolving
+ * name stays byte-identical.
+ */
+function registerImportBindingAliases(ctx: CodegenContext, sourceFiles: readonly ts.SourceFile[]): void {
+  const aliasOneBinding = (localId: ts.Identifier): void => {
+    const localName = localId.text;
+    // Already resolvable under the local name (e.g. `import { add }` where the
+    // local name equals the export) — nothing to alias.
+    if (ctx.funcMap.has(localName) || ctx.moduleGlobals.has(localName) || ctx.closureMap.has(localName)) {
+      return;
+    }
+    let sym: ts.Symbol | undefined;
+    try {
+      sym = ctx.checker.getSymbolAtLocation(localId);
+    } catch {
+      return;
+    }
+    if (!sym) return;
+    let target: ts.Symbol | undefined = sym;
+    if (sym.flags & ts.SymbolFlags.Alias) {
+      try {
+        target = ctx.checker.getAliasedSymbol(sym);
+      } catch {
+        return;
+      }
+    }
+    if (!target) return;
+    const decl = target.valueDeclaration ?? target.declarations?.[0];
+    if (!decl) return;
+    // The name the target was registered under in funcMap/moduleGlobals/closureMap.
+    let targetName: string | undefined;
+    const declName = (decl as { name?: ts.Node }).name;
+    if (declName && ts.isIdentifier(declName)) {
+      targetName = declName.text;
+    } else if (
+      (ts.isFunctionDeclaration(decl) || ts.isClassDeclaration(decl)) &&
+      ts.canHaveModifiers(decl) &&
+      ts.getModifiers(decl)?.some((m) => m.kind === ts.SyntaxKind.DefaultKeyword)
+    ) {
+      // Anonymous `export default function () {}` / `export default class {}`
+      // is registered under the synthetic name "default".
+      targetName = "default";
+    }
+    if (!targetName || targetName === localName) return;
+    // Copy each resolution entry keyed by the target name onto the local name.
+    // Every write is guarded so a genuine same-named binding is never clobbered.
+    const fnIdx = ctx.funcMap.get(targetName);
+    if (fnIdx !== undefined && !ctx.funcMap.has(localName)) ctx.funcMap.set(localName, fnIdx);
+    const closure = ctx.closureMap.get(targetName);
+    if (closure !== undefined && !ctx.closureMap.has(localName)) ctx.closureMap.set(localName, closure);
+    const modGlobal = ctx.moduleGlobals.get(targetName);
+    if (modGlobal !== undefined && !ctx.moduleGlobals.has(localName)) ctx.moduleGlobals.set(localName, modGlobal);
+    const optParams = ctx.funcOptionalParams.get(targetName);
+    if (optParams !== undefined && !ctx.funcOptionalParams.has(localName)) {
+      ctx.funcOptionalParams.set(localName, optParams);
+    }
+    const nested = ctx.nestedFuncCaptures.get(targetName);
+    if (nested !== undefined && !ctx.nestedFuncCaptures.has(localName)) ctx.nestedFuncCaptures.set(localName, nested);
+  };
+
+  for (const sf of sourceFiles) {
+    for (const stmt of sf.statements) {
+      if (!ts.isImportDeclaration(stmt)) continue;
+      const clause = stmt.importClause;
+      if (!clause) continue;
+      // Default import: `import val from './m'`.
+      if (clause.name) aliasOneBinding(clause.name);
+      // Named imports: `import { a, b as c } from './m'`.
+      const nb = clause.namedBindings;
+      if (nb && ts.isNamedImports(nb)) {
+        for (const el of nb.elements) aliasOneBinding(el.name);
+      }
+      // Namespace import (`import * as ns`) resolves to a module object, not a
+      // single function/global binding — nothing to alias here.
+    }
+  }
+}
+
+/**
  * Compile multiple typed source files into a single WasmModule IR.
  * All source files share the same codegen context (funcMap, structMap, etc.).
  * Only functions exported from the entry file become Wasm exports.
@@ -6121,6 +6215,12 @@ export function generateMultiModule(
     // exports that install / restore this global are emitted later in
     // post-processing — registering the global here keeps both sides in sync.
     ensureCurrentThisGlobal(ctx);
+
+    // (#2930) Register import-binding aliases (default / renamed / anonymous-default
+    // imports whose LOCAL name differs from the imported target's declaration name)
+    // so their reads and calls resolve to the target instead of the graceful-null
+    // default. Runs after collectDeclarations (targets registered), before bodies.
+    registerImportBindingAliases(ctx, multiAst.sourceFiles);
 
     // Phase 3: Compile all function bodies
     for (const sf of multiAst.sourceFiles) {

--- a/tests/issue-2930.test.ts
+++ b/tests/issue-2930.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { compileMulti } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #2930 — an import binding whose LOCAL name differs from the imported symbol's
+// declaration name must resolve to the imported target (not the graceful-null
+// default). Uses `.ts` fixtures so the alias resolution is isolated from #2932
+// (`.js` module-dependency compilation) and #2931 (live function bindings).
+async function runTest(files: Record<string, string>, entry = "./test.ts"): Promise<number> {
+  const result = await compileMulti(files, entry, { skipSemanticDiagnostics: true });
+  expect(result.success).toBe(true);
+  expect(result.binary.length).toBeGreaterThan(0);
+  const importObj = buildImports(result.imports, undefined, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, importObj as any);
+  if (typeof (importObj as any).setExports === "function") {
+    (importObj as any).setExports(instance.exports);
+  }
+  const testFn = (instance.exports as any).test;
+  expect(typeof testFn).toBe("function");
+  return testFn();
+}
+
+describe("#2930 — import-alias name mismatch resolution", () => {
+  it("default import with a differing local name resolves to the default export (call)", async () => {
+    const ret = await runTest({
+      "./test.ts": `import val from "./h.ts"; export function test(): number { return val(); }`,
+      "./h.ts": `export default function fn(){ return 7; }`,
+    });
+    expect(ret).toBe(7);
+  });
+
+  it("default import whose local name matches the declaration still works (no regression)", async () => {
+    const ret = await runTest({
+      "./test.ts": `import fn from "./h.ts"; export function test(): number { return fn(); }`,
+      "./h.ts": `export default function fn(){ return 7; }`,
+    });
+    expect(ret).toBe(7);
+  });
+
+  it("renamed named import ({ add as plus }) resolves to the exported function", async () => {
+    const ret = await runTest({
+      "./test.ts": `import { add as plus } from "./h.ts"; export function test(): number { return plus(1, 2); }`,
+      "./h.ts": `export function add(a: number, b: number){ return a + b; }`,
+    });
+    expect(ret).toBe(3);
+  });
+
+  it("plain named import still works (no regression)", async () => {
+    const ret = await runTest({
+      "./test.ts": `import { add } from "./h.ts"; export function test(): number { return add(1, 2); }`,
+      "./h.ts": `export function add(a: number, b: number){ return a + b; }`,
+    });
+    expect(ret).toBe(3);
+  });
+
+  it("export { g as default } resolves through the default import", async () => {
+    const ret = await runTest({
+      "./test.ts": `import v from "./h.ts"; export function test(): number { return v(); }`,
+      "./h.ts": `function g(){ return 5; } export { g as default };`,
+    });
+    expect(ret).toBe(5);
+  });
+
+  it("anonymous default function resolves through the default import", async () => {
+    const ret = await runTest({
+      "./test.ts": `import val from "./h.ts"; export function test(): number { return val(); }`,
+      "./h.ts": `export default function(){ return 9; }`,
+    });
+    expect(ret).toBe(9);
+  });
+
+  it("a differing-name default import read as a value is the callable target", async () => {
+    const ret = await runTest({
+      "./test.ts": `import val from "./h.ts"; export function test(): number { const x: any = val; return x(); }`,
+      "./h.ts": `export default function fn(){ return 7; }`,
+    });
+    expect(ret).toBe(7);
+  });
+});


### PR DESCRIPTION
## Summary

**RC2** of the #2900 module default-import decomposition (root-caused by dev-2900;
full analysis landed in #2900's Implementation Plan via #2430).

Codegen keyed `funcMap` / `closureMap` / `moduleGlobals` (and per-name call
metadata) by the imported symbol's **declaration name**, never by the **local
import binding**. So an import whose local name differs from the target's
declaration name resolved to the graceful-null default (returned 0 / null / a
wrong closure):

- `import val from './m'` where `./m` declares `function fn`
- renamed named import `{ add as plus }`
- anonymous `export default function () {}`
- `export { g as default }`

Proven on `.ts` fixtures (isolated from the `.js`-compile and live-binding root
causes): `import fn` → 7, but `import val` → **0** on `main`.

## Fix

New pass `registerImportBindingAliases(ctx, sourceFiles)` in `src/codegen/index.ts`,
run **after** `collectDeclarations` (targets registered) and **before** function
bodies compile. It follows the checker alias (`getSymbolAtLocation` →
`getAliasedSymbol`) to the target declaration's name (or `"default"` for anonymous
default) and copies the resolution entries onto the local name. **Purely additive**
— writes only local-name keys currently absent, so every already-resolving binding
is byte-identical; only currently-null sites change. Expected **net-positive**
conformance (renamed/default imports start resolving); read the ci-status delta in
both directions.

## Tests

- `tests/issue-2930.test.ts` — 7/7: default / renamed-named / anonymous-default /
  `export { x as default }` resolution for **call** and **value read**, plus
  name-match no-regression controls.
- typecheck clean; multi-file regression set green (1061 allowJs-`.js`, 1279 CJS,
  1527, 1929, lodash-es-e2e).

## Scope / follow-ups (issue files filed here, no code)

- **#2931** (RC3) — live bindings for reassigned function declarations. dev-2900 next.
- **#2932** (RC1) — compile `.js` module dependencies. **Broad-impact / blocked** on
  tech-lead sign-off + a full test262 diff run slot.
- **#2900** umbrella stays `blocked`; closes when #2930 + #2931 + #2932 all land.

Note: the #2900 root-cause plan already landed via #2430 (the doc-only precursor
that auto-merged); this PR carries the RC2 code + the three split-issue files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS