### PR TITLE
feat(#2861): fold <Ctor>.length / <Ctor>.name value reads in standalone

### DIFF
--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -432,6 +432,68 @@ const TYPED_ARRAY_BYTES_PER_ELEMENT: Record<string, number> = {
 };
 
 /**
+ * (#2861) A built-in **constructor**'s own `length` (declared arity, a
+ * non-configurable data property) — statically known per ctor name, so
+ * `<Ctor>.length` folds to a numeric constant and `<Ctor>.name` folds to the
+ * ctor-name string (`Ctor.name === "Ctor"` for every standard builtin). Both
+ * refuse under `--target standalone` today (`#1907`/`#1888 S6-b` builtin static
+ * value read); host mode reads the identical value via `__get_builtin`, so the
+ * fold is observationally identical and host-mode never reaches the fold (the
+ * `__get_builtin` branch returns first).
+ *
+ * Values verified against the host runtime (Node). The NAMESPACES `Math` / `JSON`
+ * / `Reflect` / `Atomics` are deliberately EXCLUDED — they are not functions, so
+ * their `.length`/`.name` are `undefined`; folding a name/arity for them would be
+ * wrong, so they keep refusing (namespace static reads are a separate #2860
+ * follow-up).
+ */
+const BUILTIN_CTOR_ARITY: Record<string, number> = {
+  Object: 1,
+  Array: 1,
+  Function: 1,
+  Symbol: 0,
+  Proxy: 2,
+  BigInt: 1,
+  Date: 7,
+  RegExp: 2,
+  ArrayBuffer: 1,
+  SharedArrayBuffer: 1,
+  DataView: 1,
+  Promise: 1,
+  WeakMap: 0,
+  WeakSet: 0,
+  WeakRef: 1,
+  FinalizationRegistry: 1,
+  Iterator: 0,
+  Map: 0,
+  Set: 0,
+  Error: 1,
+  TypeError: 1,
+  RangeError: 1,
+  SyntaxError: 1,
+  URIError: 1,
+  EvalError: 1,
+  ReferenceError: 1,
+  SuppressedError: 3,
+  String: 1,
+  Number: 1,
+  Boolean: 1,
+  Int8Array: 3,
+  Uint8Array: 3,
+  Uint8ClampedArray: 3,
+  Int16Array: 3,
+  Uint16Array: 3,
+  Int32Array: 3,
+  Uint32Array: 3,
+  Float32Array: 3,
+  Float64Array: 3,
+  BigInt64Array: 3,
+  BigUint64Array: 3,
+  DisposableStack: 0,
+  AsyncDisposableStack: 0,
+};
+
+/**
  * (#2593) Recover the packed-element signedness ("s"/"u") of a typed-array
  * element-access receiver from its TS type. Returns undefined when the receiver
  * is not a recognised integer typed-array view (callers then fall back to the
@@ -468,6 +530,14 @@ function typedArrayViewSignedness(ctx: CodegenContext, receiver: ts.Expression):
  * to the S6-b builtins-as-globals lever.
  */
 function hasNativeBuiltinConstantHandler(builtinName: string, propName: string): boolean {
+  // (#2861) `<Ctor>.length` (declared arity) / `<Ctor>.name` (ctor name string)
+  // have a downstream constant emitter; defer the standalone refusal to it. Only
+  // for real constructors (BUILTIN_CTOR_ARITY excludes the Math/JSON/Reflect/
+  // Atomics namespaces, whose `.length`/`.name` are undefined). Checked FIRST so
+  // it isn't pre-empted by the per-builtin branches below (e.g. the `Symbol`
+  // branch returns for any non-well-known prop, which would refuse `Symbol.length`).
+  // `length`/`name` never collide with a Math/Number constant name.
+  if ((propName === "length" || propName === "name") && builtinName in BUILTIN_CTOR_ARITY) return true;
   if (builtinName === "Math") return MATH_CONSTANT_PROPS.has(propName);
   if (builtinName === "Number") return NUMBER_CONSTANT_PROPS.has(propName);
   // (#2610) `Symbol.<wellKnown>` as a VALUE folds to its small i32 sentinel id
@@ -4838,6 +4908,35 @@ export function compilePropertyAccess(
       const bytes = TYPED_ARRAY_BYTES_PER_ELEMENT[builtinName]!;
       fctx.body.push({ op: ctx.fast ? "i32.const" : "f64.const", value: bytes });
       return ctx.fast ? { kind: "i32" } : { kind: "f64" };
+    }
+  }
+
+  // (#2861) `<Ctor>.length` (declared arity) / `<Ctor>.name` (ctor name string)
+  // — a built-in constructor's own function properties. Statically known per ctor
+  // name, so emit as a constant. Standalone otherwise reaches
+  // `reportUnsupportedStandaloneBuiltinValueRead` (the generic builtin-static-value
+  // -read refusal); host mode reads the same value via `__get_builtin` and returns
+  // BEFORE this point, so folding here is observationally identical and never
+  // fires in host mode for a ctor. Namespaces (Math/JSON/Reflect/Atomics) are not
+  // in BUILTIN_CTOR_ARITY (their `.length`/`.name` are undefined), so they keep
+  // refusing. Skip when the name is shadowed by a local.
+  if (
+    (propName === "length" || propName === "name") &&
+    ts.isIdentifier(expr.expression) &&
+    expr.expression.text in BUILTIN_CTOR_ARITY
+  ) {
+    const builtinName = expr.expression.text;
+    const isShadowed = fctx.localMap.has(builtinName) || (fctx.boxedCaptures?.has(builtinName) ?? false);
+    if (!isShadowed) {
+      if (propName === "length") {
+        const arity = BUILTIN_CTOR_ARITY[builtinName]!;
+        fctx.body.push({ op: ctx.fast ? "i32.const" : "f64.const", value: arity });
+        return ctx.fast ? { kind: "i32" } : { kind: "f64" };
+      }
+      // `<Ctor>.name` === "<Ctor>" for every standard builtin constructor.
+      addStringConstantGlobal(ctx, builtinName);
+      fctx.body.push(...stringConstantExternrefInstrs(ctx, builtinName));
+      return { kind: "externref" };
     }
   }
 

--- a/tests/issue-2861-ctor-length-name-value-read.test.ts
+++ b/tests/issue-2861-ctor-length-name-value-read.test.ts
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #2861 (slice 4) — standalone `<Ctor>.length` (declared arity) / `<Ctor>.name`
+// (ctor name string) value reads.
+//
+// Reading a built-in constructor's own `length`/`name` AS A VALUE refused in
+// standalone with the "built-in static property value read is not supported in
+// --target standalone (#1907 / #1888 S6-b)" compile error (e.g.
+// `test/built-ins/Boolean/S15.6.3_A3.js` reads `Boolean.length`). Both are
+// statically known per constructor name, so they fold to a constant:
+//   - `<Ctor>.length` → the ctor's declared arity (an `f64.const` / `i32.const`),
+//     via the new BUILTIN_CTOR_ARITY table (values verified against Node).
+//   - `<Ctor>.name`   → the ctor-name string (`Ctor.name === "Ctor"`).
+// The fold is wired through the existing native-constant defer path
+// (`hasNativeBuiltinConstantHandler` → downstream emitter), mirroring the
+// `BYTES_PER_ELEMENT` / `Math.PI` folds. Host (gc) mode is unchanged — it reads
+// the identical value via `__get_builtin` and never reaches the fold. The
+// NAMESPACES (Math/JSON/Reflect/Atomics) are excluded (their `.length`/`.name`
+// are `undefined`), so they keep refusing (namespace static reads are the #2860
+// follow-up).
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  expect((r.imports ?? []).map((i) => i.name)).toEqual([]);
+  expect(WebAssembly.validate(r.binary), "module must be valid Wasm").toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test(): number }).test();
+}
+
+describe("#2861 slice 4 — standalone <Ctor>.length declared-arity fold", () => {
+  it("Boolean.length === 1 (was a compile refusal — S15.6.3_A3)", async () => {
+    expect(await runStandalone(`export function test(): number { return Boolean.length; }`)).toBe(1);
+  });
+
+  it("Symbol.length === 0 (not pre-empted by the Symbol well-known branch)", async () => {
+    expect(await runStandalone(`export function test(): number { return Symbol.length; }`)).toBe(0);
+  });
+
+  it("Date.length === 7", async () => {
+    expect(await runStandalone(`export function test(): number { return Date.length; }`)).toBe(7);
+  });
+
+  it("RegExp.length === 2", async () => {
+    expect(await runStandalone(`export function test(): number { return RegExp.length; }`)).toBe(2);
+  });
+
+  it("Map.length === 0", async () => {
+    expect(await runStandalone(`export function test(): number { return Map.length; }`)).toBe(0);
+  });
+
+  it("Int8Array.length === 3", async () => {
+    expect(await runStandalone(`export function test(): number { return Int8Array.length; }`)).toBe(3);
+  });
+
+  it("TypeError.length === 1", async () => {
+    expect(await runStandalone(`export function test(): number { return TypeError.length; }`)).toBe(1);
+  });
+
+  it("DisposableStack.length === 0", async () => {
+    expect(await runStandalone(`export function test(): number { return DisposableStack.length; }`)).toBe(0);
+  });
+});
+
+describe("#2861 slice 4 — standalone <Ctor>.name string fold", () => {
+  it("Boolean.name is a string equal to 'Boolean'", async () => {
+    expect(await runStandalone(`export function test(): number { return Boolean.name === "Boolean" ? 1 : 0; }`)).toBe(
+      1,
+    );
+  });
+
+  it("Array.name.length === 5 ('Array')", async () => {
+    expect(await runStandalone(`export function test(): number { const n: any = Array.name; return n.length; }`)).toBe(
+      5,
+    );
+  });
+
+  it("TypeError.name === 'TypeError'", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return TypeError.name === "TypeError" ? 1 : 0; }`),
+    ).toBe(1);
+  });
+});
+
+describe("#2861 slice 4 — a shadowing local wins over the ctor fold", () => {
+  it("a local `Boolean = { length: 42 }` reads 42, not the fold", async () => {
+    expect(
+      await runStandalone(
+        `export function test(): number { const Boolean: any = { length: 42 }; return Boolean.length; }`,
+      ),
+    ).toBe(42);
+  });
+});
+
+describe("#2861 slice 4 — namespaces still refuse (out of scope, #2860)", () => {
+  it("Math.length refuses loudly (Math is not a function; .length is undefined)", async () => {
+    const r = await compile(`export function test(): number { const v: any = Math.length; return 0; }`, {
+      target: "standalone",
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("#2861 slice 4 — sibling native-constant reads unregressed", () => {
+  it("Int8Array.BYTES_PER_ELEMENT still folds to 1", async () => {
+    expect(await runStandalone(`export function test(): number { return Int8Array.BYTES_PER_ELEMENT; }`)).toBe(1);
+  });
+
+  it("Math.PI still folds", async () => {
+    expect(
+      await runStandalone(`export function test(): number { return Math.PI > 3.14 && Math.PI < 3.15 ? 1 : 0; }`),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Reading a built-in constructor's own `length` (declared arity) or `name` (ctor-name string) **as a value** refused in standalone with the #1907/#1888 S6-b *"built-in static property value read is not supported"* compile error — every constructor's `.length`/`.name` descriptor test was standalone-CE (e.g. `test/built-ins/Boolean/S15.6.3_A3.js` reads `Boolean.length`). Measured against current `origin/main`: **all** `<Ctor>.length` and `<Ctor>.name` reads refused.

Both are statically known per constructor name, so fold them to a constant via the existing native-constant defer path (`hasNativeBuiltinConstantHandler` → downstream emitter, mirroring the `BYTES_PER_ELEMENT` / `Math.PI` folds):
- `<Ctor>.length` → the declared arity (`f64.const` / `i32.const` in fast mode) via a new `BUILTIN_CTOR_ARITY` table (values verified against the Node host runtime: Date=7, RegExp/Proxy=2, TypedArrays/SuppressedError=3, Symbol/Map/Set/WeakMap/WeakSet/Iterator/DisposableStack/AsyncDisposableStack=0, most=1).
- `<Ctor>.name` → the ctor-name string (`Ctor.name === "Ctor"`).

The `.length`/`.name` check runs **first** in `hasNativeBuiltinConstantHandler` so it isn't pre-empted by the per-builtin branches (the `Symbol` branch would otherwise refuse `Symbol.length`).

**Host (gc) mode unchanged** — it reads the identical value via `__get_builtin` and returns before the fold (verified: host still emits `__get_builtin`/`__extern_get`). The **namespaces** `Math`/`JSON`/`Reflect`/`Atomics` are excluded from `BUILTIN_CTOR_ARITY` (their `.length`/`.name` are `undefined`), so they keep refusing (namespace static reads are the #2860 follow-up). A shadowing local wins (`isShadowed` guard).

## Relation to slice 3 (#2433)

Part of #2861 (multi-slice). Slice 3 (PR #2433, native-proto glue for DisposableStack/AsyncDisposableStack) is in the merge queue. This slice edits **disjoint** regions of `property-access.ts` (the `hasNativeBuiltinConstantHandler` gate + a new arity table + the downstream fold) and does **not** touch the issue file, so there is no conflict with #2433. With slices 3+4, #2861's ctor/prototype value reads and ctor `.length`/`.name` are complete; the remaining namespace static reads are split out per the plan (#2860).

## Test plan

- `tests/issue-2861-ctor-length-name-value-read.test.ts` — 15 cases: `.length` folds per ctor (incl. `Symbol.length===0`, `Date.length===7`, `Int8Array.length===3`, `DisposableStack.length===0`); `.name` string composes with `===`/`.length`; a shadowing local wins; a namespace (`Math.length`) still refuses; sibling `BYTES_PER_ELEMENT`/`Math.PI` folds unregressed.
- `tsc --noEmit` clean; standalone modules emit **zero** host imports; host mode still uses `__get_builtin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS