### PR TITLE
fix(#2849): keep dynamic-key-written objects open (numeric property reads back 0)

### DIFF
--- a/plan/issues/2849-ecmaversion-normalize-dynamic-prop-type-inference.md
+++ b/plan/issues/2849-ecmaversion-normalize-dynamic-prop-type-inference.md
@@ -1,7 +1,9 @@
 ---
 id: 2849
 title: "dynamic-object numeric property reads back 0 when the same property is also compared via === string / == null (acorn ecmaVersion 2022 not normalised → spurious import attributes)"
-status: ready
+status: done
+assignee: ttraenkler/dev-2878
+completed: 2026-07-02
 sprint: current
 priority: medium
 horizon: l
@@ -109,3 +111,59 @@ is a **dynamic-object property type-inference / storage** bug, likely broad
   `__extern_get`/`__extern_set` numeric coercion). Likely the same family as the
   any-value polymorphic-read substrate work.
 - Repro scripts (this branch, `.tmp/nm-2841/repro-ecma*.mjs`, gitignored).
+
+## Resolution (2026-07-02, dev-2878)
+
+### Root cause (WAT-bisected, host mode)
+
+Not a numeric-vs-string type-inference issue as originally hypothesised — the
+trigger is a **representation-coherence** split between a dynamic-key write and a
+widened struct read:
+
+1. `var o = {}` is given a **concrete WasmGC struct** type by
+   `collectEmptyObjectWidening` (declarations.ts) because a sibling STATIC
+   dot-write `o.ecmaVersion = 1e8` (inside the never-taken `=== "latest"` /
+   `== null` guard body) contributes an `f64 ecmaVersion` field. Widening makes
+   the dot-reads lower to a direct, unguarded `struct.get $N 0`.
+2. The for-in write `for (k in d) o[k] = opts[k]` has a **non-literal computed
+   key** (`k` is the loop var), so it CANNOT resolve to a struct field and lowers
+   to the dynamic `__extern_set` **sidecar** — NOT the struct slot.
+3. Read/write diverge: `struct.get` returns the field default (`0`), never the
+   sidecar-written `2022`. (Bisected: `var k = "x"; o[k]=v` const-propagates the
+   key → lowers to `struct.set` → coherent → no bug; only the non-resolvable key
+   breaks.)
+
+Why host-only: the demotion guard that keeps such objects open
+(`markObjectHashConsumers`, #2584) is **standalone-gated**, and the host
+"live-mirror Proxy writeback" does NOT cover a dynamic-key write.
+
+### Fix
+
+`src/codegen/declarations.ts` — new `hasNonLiteralComputedWrite` detector, wired
+into `collectEmptyObjectWidening` **mode-agnostically**: a non-literal
+computed-key write `o[<expr>] = v` suppresses empty-object struct widening, so
+the receiver stays a `$Object` and both the dynamic write and the dot reads route
+through the same (guarded / sidecar) representation. String/number-**literal**
+computed keys are deliberately NOT matched — they resolve to a field and lower to
+`struct.set`, staying coherent (and keeping the struct fast path). Standalone was
+already covered by the (broader) `markObjectHashConsumers` poison.
+
+### Verification
+
+- Minimal repro `run(2022) === 13` with the `=== "latest"` / `== null` guards
+  present (host). All variant forms correct; literal-key writes still fast-path;
+  pure-numeric path unchanged.
+- **0 regressions** in a base-vs-mine differential over 1,399 object / for-in /
+  property-accessor test262 files (the directly-affected surface).
+- Test: `tests/issue-2849-dynamic-key-object-numeric-read.test.ts`.
+
+### Out of scope (separate pre-existing gaps)
+
+- **Standalone** (`--target standalone`) still reads the property back as an
+  externref/object (returns `{}`, not `13`) — an INDEPENDENT gap in the
+  standalone dynamic-`$Object` numeric substrate (verified identical on `main`,
+  unaffected by this fix). Tracked with the `$Object` dynamic-reader value-rep
+  work.
+- The acorn `attributes` acceptance (edge.js module differential) remains gated
+  on #2325 (edge.js can't parse module source on `main` yet); the underlying
+  compiler mis-read that produced it is fixed here.

--- a/plan/issues/2934-standalone-invalid-wasm-heterogeneous-tail.md
+++ b/plan/issues/2934-standalone-invalid-wasm-heterogeneous-tail.md
@@ -1,0 +1,66 @@
+---
+id: 2934
+title: "Standalone: invalid-Wasm heterogeneous tail after #2878 (test/__closure_*/__cb_0 — distinct codegen bugs)"
+status: ready
+created: 2026-07-02
+updated: 2026-07-02
+priority: medium
+feasibility: medium
+task_type: bug
+area: codegen
+goal: standalone
+related: [2860, 2868, 2878]
+umbrella: 2860
+---
+
+# Standalone: invalid-Wasm heterogeneous tail after #2878
+
+#2878 retired the `externref → eqref` coercion class (the
+`__call_toString`/`__call_valueOf`/`__set_member_toString` invalid-Wasm bucket).
+This tracks the **residual tail** measured on current `main` after that fix — a
+set of **heterogeneous, unrelated** codegen defects (NOT a single mechanism, NOT
+the eqref/funcIdx-shift class), so each needs its own triage.
+
+## Measurement (2026-07-02, dev-2878)
+
+`--target standalone` compile + `WebAssembly.compile` validate over a 3,500-file
+`built-ins` stride sample, AFTER #2878: **26 invalid binaries** remaining.
+Clustered by failing function + validator signature:
+
+| failing fn | count | validator signature (representative) | example test |
+| ---------- | ----- | ------------------------------------ | ------------ |
+| `test` | ~15 | `call[0] expected type (ref null …)` | `String/prototype/concat/S15.5.4.6_A1_T8.js` |
+| `test` | (in above) | `call[0] expected type externref` | `RegExp/prototype/test/S15.10.6.3_A8.js` |
+| `test` | (in above) | `array.get: Array type N has packed…` / `array.set[2] expected type i32` | `TypedArray/prototype/set/array-arg-value-conversion-resizes-array-buffer.js`, `Uint8Array/prototype/toBase64/results.js` |
+| `__closure_2/4/7/20` | ~8 | `call[1] expected type f64` / `call[0] expected type (…)` / `struct.get[0]` | `Array/prototype/map/15.4.4.19-4-7.js`, `Array/prototype/filter/create-species-poisoned.js`, `Proxy/revocable/tco-fn-realm.js` |
+| `__closure_5` | 1 | `not enough arguments on the stack` (funcIdx-shift-shaped) | `AsyncFromSyncIteratorPrototype/next/for-await-next-rejected-promise-close.js` |
+| `__cb_0` | 1 | `array.set[2] expected type i32` | `TypedArray/prototype/set/typedarray-arg-set-values-diff-buffer-other-type-conversions-sab.js` |
+
+(3,500-file sample → the full `built-ins` corpus + `language`/other roots scale
+this ~3–4×.)
+
+## Likely sub-clusters (triage-then-split)
+
+1. **TypedArray resizable-buffer `array.get`/`array.set` type mismatch** — the
+   `array.get: Array type N has packed…` / `array.set[2] expected i32` family
+   (TypedArray `set` with a resizable `ArrayBuffer`, `Uint8Array.toBase64`). A
+   packed-array element-type / i32-vs-i8 mismatch on a standalone-gated path.
+2. **`call[0]/call[1] expected type …` in `test`/`__closure_*`** — a wrong-typed
+   argument at a call site (String/concat, RegExp/test, Array map/filter species
+   callbacks). Some are `species-poisoned` / `create-species-*` — likely a
+   Symbol.species / callback-thunk typing issue, NOT funcIdx-shift.
+3. **`__closure_5` `not enough arguments on the stack`** — the one funcIdx-shift-
+   shaped failure (for-await async path); may share the #2918 late-import class.
+
+## Approach
+
+Per the #2868/#2878 playbook: pick one repro per cluster, disassemble with
+`node_modules/.bin/wasm-dis`, read the exact validator complaint, cluster by
+shared construct, fix the emitter. Split into sub-issues if the clusters are
+independent (they likely are).
+
+## Acceptance
+
+- Each named cluster: standalone CE/invalid → valid module for its repros.
+- 0 test262 regressions; full `merge_group` + standalone floor.
+- Pure correctness (invalid binary → valid) — no host-mode path touched.

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -2231,6 +2231,24 @@ export function collectEmptyObjectWidening(
             }
           }
 
+          // (#2849) Mode-agnostic (host AND standalone): a NON-LITERAL
+          // computed-key write `varName[<expr>] = v` (e.g. `for (k in d)
+          // o[k] = opts[k]`) lowers to the dynamic `__extern_set` sidecar, which
+          // a widened closed-struct read (`struct.get`) would miss → the value
+          // reads back 0. Host was previously unprotected (the
+          // `markObjectHashConsumers` poison above is standalone-gated, and the
+          // "live-mirror Proxy writeback" does NOT cover a dynamic-key write).
+          // Suppress widening so the receiver stays a `$Object` and every access
+          // — the dynamic write AND the dot reads — routes through the same
+          // (guarded / sidecar) representation. String/number-literal computed
+          // keys are intentionally NOT matched (they lower to `struct.set`).
+          for (const s of stmts) {
+            if (hasNonLiteralComputedWrite(s, varName)) {
+              ctx.objectHashConsumerVars.add(varName);
+              break;
+            }
+          }
+
           // (#2372) Standalone: if any `Object.defineProperty(varName, …)` on
           // this receiver used a *dynamic* (non-inline-literal) descriptor, the
           // struct-widening fast path is unsound — the dynamic define is applied
@@ -2566,6 +2584,51 @@ function isAccessorDescriptor(descArg: ts.Expression): boolean {
  * matching the existing widening pre-pass (aliasing is a shared, documented
  * limitation — see the issue's `## Deferred`).
  */
+/**
+ * (#2849) Does `node` contain a COMPUTED-key write `varName[<non-literal>] = …`
+ * whose key is NOT a static string/number literal (e.g. `o[k] = v` inside
+ * `for (var k in d)`, a parameter key, or any expression key)?
+ *
+ * Such a write cannot be resolved to a static struct field, so codegen lowers it
+ * to the dynamic `__extern_set` **sidecar**. If `varName` were ALSO widened to a
+ * closed WasmGC struct (because a sibling STATIC dot-write `varName.k = v`
+ * triggered `collectEmptyObjectWidening`), the widened `struct.get` read would
+ * MISS the sidecar-written value and return the field default (0). That is the
+ * `for (k in d) o[k] = opts[k]; … o.ecmaVersion` mis-read (compiled acorn
+ * `getOptions` normalisation reading back 0).
+ *
+ * A string/number LITERAL computed key (`o["ecmaVersion"] = v`) is SAFE — it
+ * resolves to a field and lowers to `struct.set`, staying coherent with the
+ * struct read — so it is deliberately NOT matched here. Compound assignments
+ * (`o[k] += v`) are matched too (they also write through the sidecar).
+ */
+function hasNonLiteralComputedWrite(node: ts.Node, varName: string): boolean {
+  const isVarRef = (n: ts.Node): boolean => ts.isIdentifier(n) && n.text === varName;
+  const isLiteralKey = (e: ts.Expression): boolean =>
+    ts.isStringLiteralLike(e) ||
+    ts.isNumericLiteral(e) ||
+    // `-1` / `+2` style numeric-literal keys (unary on a numeric literal).
+    (ts.isPrefixUnaryExpression(e) && ts.isNumericLiteral(e.operand));
+  let found = false;
+  const visit = (n: ts.Node): void => {
+    if (found) return;
+    if (
+      ts.isBinaryExpression(n) &&
+      n.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
+      n.operatorToken.kind <= ts.SyntaxKind.LastAssignment &&
+      ts.isElementAccessExpression(n.left) &&
+      isVarRef(n.left.expression) &&
+      !isLiteralKey(n.left.argumentExpression)
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(n, visit);
+  };
+  visit(node);
+  return found;
+}
+
 function markObjectHashConsumers(node: ts.Node, varName: string, poisonSet: Set<string>): void {
   const isVarRef = (n: ts.Node): boolean => ts.isIdentifier(n) && n.text === varName;
 

--- a/tests/issue-2849-dynamic-key-object-numeric-read.test.ts
+++ b/tests/issue-2849-dynamic-key-object-numeric-read.test.ts
@@ -1,0 +1,98 @@
+// #2849 — a dynamic-object numeric property reads back 0 when the object is
+// BOTH populated by a computed/dynamic-key write (`for (k in d) o[k] = opts[k]`)
+// AND widened to a closed WasmGC struct by a sibling STATIC dot-write
+// (`o.ecmaVersion = <number>`).
+//
+// Root cause: the non-literal computed-key write lowers to the dynamic
+// `__extern_set` SIDECAR (the key can't be resolved to a struct field), but the
+// static dot-write triggered `collectEmptyObjectWidening` to give `o` a closed
+// struct, so the dot-read `o.ecmaVersion` lowered to an unguarded `struct.get`
+// that MISSED the sidecar value and returned the field default (0). The demotion
+// guard that keeps such objects open (`markObjectHashConsumers`) was
+// standalone-gated, and the host "live-mirror Proxy" does NOT cover a
+// dynamic-key write — so host mode mis-read.
+//
+// Fix (declarations.ts): a NON-LITERAL computed-key write suppresses empty-object
+// widening in ALL modes, so the receiver stays a `$Object` and both the dynamic
+// write and the dot reads route through the same (guarded / sidecar)
+// representation. This mirrors compiled acorn's `getOptions` ecmaVersion
+// normalisation (`2022 -> 13`).
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function run(src: string, target?: "standalone"): Promise<(ev: number) => number> {
+  const result: any = await compile(src, { fileName: "probe.ts", ...(target ? { target } : {}) });
+  expect(result.success).toBe(true);
+  const importObject: any = result.importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(result.binary, importObject);
+  importObject.__setExports?.(instance.exports);
+  return instance.exports.run as (ev: number) => number;
+}
+
+// The acorn-shaped normalisation body: an equality guard (`=== "latest"` /
+// `== null`) reads the property, its then-body reassigns a NUMBER, and the
+// numeric `>= 2015` branch does the actual normalisation.
+const ACORN_SHAPE = `// @ts-nocheck
+var d = { ecmaVersion: null, sourceType: 0 };
+export function run(ev) {
+  var opts = { ecmaVersion: ev, sourceType: 1 };
+  var o = {};
+  for (var k in d) { o[k] = opts[k]; }
+  if (o.ecmaVersion === "latest") { o.ecmaVersion = 1e8; }
+  else if (o.ecmaVersion == null) { o.ecmaVersion = 11; }
+  else if (o.ecmaVersion >= 2015) { o.ecmaVersion -= 2009; }
+  return o.ecmaVersion;
+}`;
+
+describe("#2849 — dynamic-key object numeric property read", () => {
+  it("host mode: acorn-shape normalisation run(2022) === 13", async () => {
+    const fn = await run(ACORN_SHAPE);
+    expect(fn(2022)).toBe(13);
+  });
+
+  // NOTE: standalone (`--target standalone`) does NOT yet return 13 here — it
+  // reads the `$Object` property back as an externref/object, an INDEPENDENT
+  // pre-existing gap in the standalone dynamic-`$Object` numeric substrate
+  // (verified identical on `main`, unaffected by this fix). #2849 scope is the
+  // host/edge.js differential; the standalone numeric-substrate work is tracked
+  // separately (the `$Object` dynamic-reader value-rep line).
+
+  it("equality guard (not taken) does not corrupt the dynamic-written value", async () => {
+    // Both `=== "latest"` and `== null` independently triggered the bug: the
+    // guard + then-body reassignment widened `o` to a struct while the for-in
+    // wrote the sidecar. With the fix, the untaken guard leaves 2022 intact.
+    const strGuard = await run(`// @ts-nocheck
+var d = { ecmaVersion: 0 };
+export function run(ev) { var opts = { ecmaVersion: ev }; var o = {};
+  for (var k in d) { o[k] = opts[k]; }
+  if (o.ecmaVersion === "latest") { o.ecmaVersion = 1e8; }
+  return o.ecmaVersion; }`);
+    expect(strGuard(2022)).toBe(2022);
+
+    const nullGuard = await run(`// @ts-nocheck
+var d = { ecmaVersion: 0 };
+export function run(ev) { var opts = { ecmaVersion: ev }; var o = {};
+  for (var k in d) { o[k] = opts[k]; }
+  if (o.ecmaVersion == null) { o.ecmaVersion = 11; }
+  return o.ecmaVersion; }`);
+    expect(nullGuard(2022)).toBe(2022);
+  });
+
+  it("literal-key computed writes keep the struct fast path (still correct)", async () => {
+    // A string-LITERAL computed key resolves to a field and lowers to
+    // `struct.set`, so it is NOT demoted — and must remain correct.
+    const fn = await run(`// @ts-nocheck
+export function run(ev) { var o = {}; o.ecmaVersion = 0; o["ecmaVersion"] = ev; return o.ecmaVersion; }`);
+    expect(fn(2022)).toBe(2022);
+  });
+
+  it("pure numeric normalisation (no equality guard) still works", async () => {
+    const fn = await run(`// @ts-nocheck
+var d = { ecmaVersion: 0 };
+export function run(ev) { var opts = { ecmaVersion: ev }; var o = {};
+  for (var k in d) { o[k] = opts[k]; }
+  if (o.ecmaVersion >= 2015) { o.ecmaVersion -= 2009; }
+  return o.ecmaVersion; }`);
+    expect(fn(2022)).toBe(13);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2849 — a dynamic-object numeric property read back **0** in host mode when
the object is BOTH populated by a computed/dynamic-key write
(`for (k in d) o[k] = opts[k]`) AND widened to a closed WasmGC struct by a
sibling static dot-write (`o.ecmaVersion = <number>`). This is the compiler
mis-read behind compiled-acorn's `getOptions` ecmaVersion normalisation
(`2022 → 13` reading back `0`), the edge.js half of #1712.

## Root cause (WAT-bisected)

Not the numeric-vs-string type-inference originally hypothesised — a
**representation-coherence split**:

1. `var o = {}` is given a concrete WasmGC **struct** type by
   `collectEmptyObjectWidening` because the static dot-write
   `o.ecmaVersion = 1e8` (inside the never-taken `=== "latest"` / `== null`
   guard) contributes an `f64 ecmaVersion` field. Dot-reads then lower to an
   unguarded `struct.get`.
2. The for-in write `o[k] = opts[k]` has a **non-literal computed key** (`k` is
   the loop var), so it can't resolve to a struct field and lowers to the dynamic
   `__extern_set` **sidecar** — not the struct slot.
3. Read/write diverge → `struct.get` returns the field default `0`, never the
   sidecar's `2022`. (Bisected: `var k="x"; o[k]=v` const-propagates the key →
   `struct.set` → coherent → no bug; only the non-resolvable key breaks.)

Host-only because the demotion guard that keeps such objects open
(`markObjectHashConsumers`, #2584) is **standalone-gated**, and the host
"live-mirror Proxy writeback" does not cover a dynamic-key write.

## Fix

`src/codegen/declarations.ts` — new `hasNonLiteralComputedWrite` detector, wired
into `collectEmptyObjectWidening` **mode-agnostically**: a non-literal
computed-key write `o[<expr>] = v` suppresses empty-object struct widening, so
the receiver stays a `$Object` and both the dynamic write and the dot reads route
through the same guarded/sidecar representation. String/number-**literal**
computed keys are intentionally NOT matched (they lower to `struct.set`, keeping
the struct fast path). Standalone was already covered by the broader
`markObjectHashConsumers` poison.

## Verification

- Minimal repro `run(2022) === 13` with the `=== "latest"` / `== null` guards
  present; all variant forms correct; literal-key writes still fast-path;
  pure-numeric path unchanged.
- **0 regressions** in a base-vs-mine differential over 1,399
  object / for-in / property-accessor test262 files. A broader in-process sweep
  flagged 40 Array "regressions" — all confirmed **false positives** (pass in
  per-file isolation; the two-runner-in-one-process harness produces spurious
  `compile_error`s under memory pressure).
- Test: `tests/issue-2849-dynamic-key-object-numeric-read.test.ts`.

## Out of scope (separate pre-existing gaps, verified identical on `main`)

- **Standalone** (`--target standalone`) still reads the property back as an
  externref/object (`{}`, not `13`) — an independent gap in the standalone
  dynamic-`$Object` numeric substrate.
- The acorn `attributes` differential (edge.js module source) stays gated on
  #2325; the underlying compiler mis-read is fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS