### PR TITLE
fix(#2923): any-typed closure param dispatch honors JS arity semantics (unblocks #2921)

### DIFF
--- a/plan/agent-context/dev-a.md
+++ b/plan/agent-context/dev-a.md
@@ -1,0 +1,106 @@
+---
+agent: dev-a
+session_end: 2026-07-02
+sprint: current
+issues: [2849, 2861, 2923]
+prs: [2432, 2436, 2441]
+---
+
+# dev-a session summary (2026-07-02)
+
+Five PRs, all root-caused via measure-first deep-tracing (not spec-following).
+Two of the assigned fronts (#2875, first-pass #2861) were found stale/blocked and
+released/reported rather than built — the measure-first discipline paid off.
+
+## PRs this session
+
+1. **PR #2432 — `fix(#2849)`** dynamic-object static-write shadows sidecar. MERGED
+   (its `tests/issue-2849.test.ts` is on main).
+2. **PR #2436 — `feat(#2861 residual)`** standalone native-proto glue for
+   DisposableStack / AsyncDisposableStack / SuppressedError. **+55 standalone
+   flips**. Green, stood down.
+3. **PR #2441 — `fix(#2923)`** any-typed closure-param dispatch arity semantics.
+   (Status at session end: riding CI / BEHIND-drift, auto-refresh handling.)
+
+## #2849 — the one-line coherence fix (MERGED)
+
+Root cause: a `{}` object populated via dynamic-key writes `o[k]=v` (for-in copy)
+keeps values in the dynamic `$Object` **sidecar**, but a STATIC-named write
+`o.prop = <const>` anywhere (even an UNREACHED branch) makes the
+reachability-blind `collectEmptyObjectWidening` pre-pass register a real struct
+field (default 0) that SHADOWS the sidecar — reads return 0.
+Fix: the #2584 `objectHashConsumerVars` poison (keep such objects on `$Object`)
+was `ctx.standalone`-gated on a false "host live-mirror Proxy covers it"
+assumption; dropped the gate at `src/codegen/declarations.ts:~2228`.
+Note: my first theory (for-in enumeration) was a **harness false-negative** — the
+repro didn't call `setExports`; once wired, for-in over a struct already works.
+**Lesson baked in:** always `setExports(instance.exports)` when host-probing a
+struct-sidecar read, else `__extern_get`/`_safeGet` returns undefined.
+
+## #2861 residual — native-proto glue (MERGED/green)
+
+Earlier PRs 2340/2341/2344 wired most builtins; the residual was
+DisposableStack/AsyncDisposableStack (`makeGlueWithGetters`, `disposed` getter) +
+SuppressedError (reuses NativeError glue). Brand slots 41-43 in
+`native-proto.ts`. Standalone-only, purely additive → host unchanged, 42 existing
+native-proto tests green. **Still open follow-up:** Math/JSON/Reflect/Atomics
+namespace *static* reads (not `$NativeProto` proto glue) — separate task.
+
+## #2923 — dispatch arity fix (SITE REFINEMENT — read this for #2931)
+
+**The spec (`2923-...md`, on the #2921 branch) pointed at
+`calls-closures.ts:688` (the `compileCallablePropertyCall` PROPERTY-call path).
+That is NOT where the actual test262 harness bug lives.** Measured via the
+inject-throw probe: the real harness `fn(ctor, makeCtorArg)` is a **bare
+identifier** call, which routes through **`tryEmitInlineDynamicCall` in
+`src/codegen/expressions/calls.ts` (~L2911)** — a different function. If a #2931
+(or renumbered) issue file is written from the spec, correct the site pointer:
+**L2911 in calls.ts, not L688 in calls-closures.ts.**
+
+Fix: removed the `if (info.paramTypes.length < arity) continue;` hard pre-filter.
+The per-candidate dispatch arm ALREADY marshals exactly the candidate's declared
+formals (truncates extras, pads `undefined`), and every call-site arg is
+evaluated into a temp local first (side effects preserved), so dropping the
+filter simply adopts JS §7.3.14 arity semantics. **Kept** the #1837
+void-OVER-arity guard (a void-result closure padded past its arity marshals a
+stack-invalid `call_ref`) — so "fewer args + void callback" is a KNOWN remaining
+gap, not covered here (the harness is the "more args" shape).
+
+**Measurement discipline (per project rule):** proved the callback body EXECUTES
+via **inject-throw** (a `throw` in the body traps iff it ran) on BOTH standalone
+and gc/host lanes — a vanished import is NOT proof of execution.
+
+### #2923 shim dependency (now its own queued task)
+
+The test262 flip MEASUREMENT (output-vs-js-host on the 468+ BigInt corpus,
+honest-pass fraction) requires **#2921's runner-shim** (dev-callback): add a
+`testWithBigIntTypedArrayConstructors` wrapper + passthrough `makeCtorArg` +
+regex `/testWith(?:BigInt)?TypedArrayConstructors/` in `tests/test262-runner.ts`.
+The shim ALONE (without my dispatch fix) produces **dishonest vacuous host-free
+passes** — leak-elim must prove bodies execute. My dispatch fix is safe to land
+independently (no harness change → cannot itself create a vacuous pass). Whoever
+picks up the shim task: gate honest-pass scoring with the inject-throw + output
+diff described in the #2923 spec's acceptance section.
+
+### #2923 issue-file caveat
+
+I deliberately did NOT include `plan/issues/2923-*.md` in PR #2441 — it lives on
+the #2921/#2429 branch and was being re-id'd for a dup-id collision. Adding it
+would risk a `merge_group` id collision. Status reconciliation left to
+lead/dev-callback.
+
+## Released / reported (not built)
+
+- **#2875** (String.prototype standalone cluster) — dominant sub-cluster
+  (descriptor reflection over method objects) is BLOCKED on unimplemented **#2896**
+  (native function-object metadata substrate, XL/hard). Released.
+- **#2873 / #2878** — correctly skipped (owned by other devs, exit-3 locks).
+
+## Key files touched
+
+- `src/codegen/declarations.ts` (~L2228 — #2849 poison gate)
+- `src/codegen/native-proto.ts`, `src/codegen/array-object-proto.ts`,
+  `src/codegen/property-access.ts` (#2861 glue, brand slots 41-43)
+- `src/codegen/expressions/calls.ts` (~L2911 — #2923 arity filter)
+- `tests/issue-2849.test.ts`, `tests/issue-2861-disposablestack-glue.test.ts`,
+  `tests/issue-2923.test.ts`

--- a/plan/agent-context/dev-a.md
+++ b/plan/agent-context/dev-a.md
@@ -44,11 +44,11 @@ DisposableStack/AsyncDisposableStack (`makeGlueWithGetters`, `disposed` getter) 
 SuppressedError (reuses NativeError glue). Brand slots 41-43 in
 `native-proto.ts`. Standalone-only, purely additive → host unchanged, 42 existing
 native-proto tests green. **Still open follow-up:** Math/JSON/Reflect/Atomics
-namespace *static* reads (not `$NativeProto` proto glue) — separate task.
+namespace _static_ reads (not `$NativeProto` proto glue) — separate task.
 
 ## #2923 — dispatch arity fix (SITE REFINEMENT — read this for #2931)
 
-**The spec (`2923-...md`, on the #2921 branch) pointed at
+**The #2923 spec (living on the #2921 branch, not yet on main) pointed at
 `calls-closures.ts:688` (the `compileCallablePropertyCall` PROPERTY-call path).
 That is NOT where the actual test262 harness bug lives.** Measured via the
 inject-throw probe: the real harness `fn(ctor, makeCtorArg)` is a **bare
@@ -84,7 +84,7 @@ diff described in the #2923 spec's acceptance section.
 
 ### #2923 issue-file caveat
 
-I deliberately did NOT include `plan/issues/2923-*.md` in PR #2441 — it lives on
+I deliberately did NOT include the #2923 issue file in PR #2441 — it lives on
 the #2921/#2429 branch and was being re-id'd for a dup-id collision. Adding it
 would risk a `merge_group` id collision. Status reconciliation left to
 lead/dev-callback.

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -2909,11 +2909,28 @@ function tryEmitInlineDynamicCall(
 
   const allCandidates: Cand[] = [];
   for (const [typeIdx, info] of ctx.closureInfoByTypeIdx) {
-    if (info.paramTypes.length < arity) continue;
-    // (#1837) Over-arity padding only for candidates with a NON-VOID result.
-    // Void-result closures (Promise resolve/reject element fns) marshal their
-    // padded self/args into a stack-invalid call_ref; the async-gen-meth-dflt
-    // win (the reason for padding) all have a non-void result (the generator).
+    // (#2923) JS §7.3.14: a call whose arg count differs from the callee's
+    // declared param count still INVOKES the callee — extra args are ignored,
+    // missing params are `undefined`. The per-candidate dispatch arm below
+    // already honours this: it marshals exactly `info.paramTypes.length`
+    // formals (pulling `argLocals[i]` for `i < arity`, padding `undefined` for
+    // `i >= arity`), so an UNDER-arity candidate (fewer params than args)
+    // simply drops the extra args, and an OVER-arity candidate pads. Every
+    // call-site arg is still evaluated into a temp local above, so a truncated
+    // extra arg keeps its side effects. The old `paramTypes.length < arity`
+    // hard filter therefore SILENTLY DROPPED an entire class of higher-order
+    // calls (the test262 `testWith*TypedArrayConstructors(fn)` harness calls
+    // `fn(ctor, makeCtorArg)` — 2 args — but the callback declares `(TA)` — 1
+    // param — so the whole test body was dead; 468+ BigInt tests). Removing it
+    // adopts the JS arity semantics the direct-closure path (`compileClosureCall`
+    // L122-129) already implements.
+    //
+    // (#1837) Over-arity padding stays gated to NON-VOID results: a void-result
+    // closure padded past its arity marshals its padded self/args into a
+    // stack-invalid `call_ref` (the async-gen-meth-dflt win — the reason padding
+    // exists — all have a non-void generator result). An UNDER-arity void
+    // candidate is fine (no padding, just truncation), so only skip when the
+    // candidate is strictly OVER-arity AND void.
     if (info.paramTypes.length > arity && info.returnType === null) continue;
     if (!supported(info.returnType)) continue;
     let ok = true;

--- a/tests/issue-2923.test.ts
+++ b/tests/issue-2923.test.ts
@@ -1,0 +1,74 @@
+// (#2923) Dynamic dispatch of an any-typed closure param `fn(...)` must honour
+// JS §7.3.14 Call arity semantics: extra args are ignored (truncated), missing
+// params are `undefined`-filled — the callback is INVOKED regardless of an
+// arg-count mismatch. Previously `tryEmitInlineDynamicCall` (calls.ts) hard-
+// filtered candidates on `paramTypes.length < arity`, so a call with MORE args
+// than the callback declares (the test262 `testWith*TypedArrayConstructors(fn)`
+// harness — `fn(ctor, makeCtorArg)` (2 args) into a `function (TA) {…}` (1
+// param)) matched NO candidate and silently lowered to `ref.null.extern` — the
+// whole test body was dead (a vacuous pass; 468+ BigInt TypedArray tests).
+//
+// This exercises EXECUTION directly via the mandated inject-throw probe: a
+// `throw` in the callback body makes `test()` trap iff the body actually ran.
+// (A return-value probe would conflate "not invoked" with an externref→number
+// coercion returning 0, so it is unreliable here.)
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function invoked(source: string, target?: "standalone"): Promise<boolean> {
+  const r = await compile(source, target ? { target } : {});
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const imports: WebAssembly.Imports = target
+    ? {}
+    : (buildImports(r.imports, undefined, r.stringPool) as WebAssembly.Imports);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  if (!target) (imports as { setExports?: (e: unknown) => void }).setExports?.(instance.exports);
+  try {
+    (instance.exports as Record<string, (...a: unknown[]) => unknown>).test();
+    return false; // returned normally → callback body was DROPPED
+  } catch {
+    return true; // trapped on the injected throw → callback body EXECUTED
+  }
+}
+
+// A named top-level callback (so its funcref wrapper is registered as a
+// dispatch candidate) whose body throws — proves execution.
+const prog = (call: string, cbParams: string) => `// @ts-nocheck
+function cb(${cbParams}) { throw 7; }
+function driver(fn: any): number { ${call}; return 0; }
+export function test(): number { return driver(cb); }`;
+
+describe("#2923 any-typed closure param dispatch — JS arity semantics", () => {
+  it("standalone: MORE args than params still invokes (extra args ignored)", async () => {
+    // The harness shape: 2 args into a 1-param callback.
+    expect(await invoked(prog(`fn(1, 2)`, `TA: any`), "standalone")).toBe(true);
+  });
+
+  it("standalone: exact arity still invokes (no regression)", async () => {
+    expect(await invoked(prog(`fn(1)`, `TA: any`), "standalone")).toBe(true);
+  });
+
+  it("standalone: the spec's BigInt-harness shape executes the body", async () => {
+    const harness = `// @ts-nocheck
+function __ta_passthrough(x: any): any { return x; }
+function testWithBigIntTypedArrayConstructors(fn: any): void {
+  const constructors = [1, 2];
+  for (let i = 0; i < constructors.length; i++) {
+    fn(constructors[i], __ta_passthrough);
+  }
+}
+function body(TA: any): void { throw 7; }
+export function test(): number { testWithBigIntTypedArrayConstructors(body); return 0; }`;
+    expect(await invoked(harness, "standalone")).toBe(true);
+  });
+
+  it("gc/host: MORE args than params still invokes", async () => {
+    expect(await invoked(prog(`fn(1, 2)`, `TA: any`))).toBe(true);
+  });
+
+  it("gc/host: exact arity still invokes (no regression)", async () => {
+    expect(await invoked(prog(`fn(1)`, `TA: any`))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2923. Dynamic dispatch of an **any-typed closure param** `fn(...)` (`tryEmitInlineDynamicCall`, `src/codegen/expressions/calls.ts`) hard-filtered candidates on `paramTypes.length < arity`, so a call with **more args than the callback declares** matched no candidate and silently lowered to `ref.null.extern` — the callback body never ran. This violates JS §7.3.14 Call (extra args ignored, missing params `undefined`) and silently no-ops higher-order code.

It is the blocker under #2921: the test262 `testWith*TypedArrayConstructors(fn)` harness calls `fn(ctor, makeCtorArg)` (2 args) but the callback declares `(TA)` (1 param), so the whole test body was dead — a **vacuous pass** (468+ BigInt TypedArray tests).

## Root cause & fix

The per-candidate dispatch arm **already** marshals exactly the candidate's declared formals (pulls `argLocals[i]` for `i < arity`, pads `undefined` for `i >= arity`), so an under-arity candidate already truncates extras and an over-arity one already pads. Every call-site arg is still evaluated into a temp local, so a **truncated extra keeps its side effects**. Only the pre-filter excluded under-arity candidates.

Remove the `paramTypes.length < arity` hard filter (keeping the #1837 void-**over**-arity guard — a void-result closure padded past its arity marshals a stack-invalid `call_ref`). This adopts the same arity semantics the direct-closure path (`compileClosureCall`, L122–129) already implements.

Site note: the actual harness `fn(...)` is a **bare identifier**, routing through `tryEmitInlineDynamicCall` (calls.ts) — not the `compileCallablePropertyCall` (calls-closures.ts:688) site the spec pointed at (that's the property-call path). Pinned via the inject-throw measurement below.

## Guardrails

- **Proven EXECUTED** (not just "import disappeared") via the mandated inject-throw probe — a `throw` in the callback traps iff the body ran — on **both** standalone and gc/host lanes, incl. the spec's exact BigInt-harness shape.
- **Byte-inert (sha256)** on the typed corpus (direct closures / typed HOFs / array methods) — the fix only touches the any/dynamic-dispatch path, which typed code never invokes.
- Direct dispatch/arity regression tests green locally (`issue-1712-dynamic-dispatch`, `#1837`, `#2174`, `#2512`, `#1718`); the 2 pre-existing failures in `issue-1712-capture-closure-dispatch` fail **identically on baseline** (not a regression). Full equivalence suite runs in CI (local run blocked by a pre-existing missing-`tests/helpers.js` worktree artifact affecting many unrelated files).
- `tests/issue-2923.test.ts`: more-args + exact-arity invoke on both lanes + the BigInt-harness shape.

## Scope / sequencing

The test262 **flip measurement** (output-vs-js-host on the BigInt corpus, honest-pass fraction) requires #2921's runner shim (Part-1) and must land alongside it. This dispatch fix is the **correctness half** and is safe to land independently — it adds no test262 harness change, so it cannot itself produce a dishonest vacuous pass; it only makes more callbacks execute.

The #2923 issue file currently lives on the #2921 branch (being re-id'd for a dup-id collision), so it is intentionally **not** included here to avoid a `merge_group` id collision — status reconciliation tracked with the lead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)