### PR TITLE
fix(#2934): coerce function-object receiver to externref in hasOwnProperty/propertyIsEnumerable (standalone invalid-Wasm)

### DIFF
--- a/plan/issues/2934-standalone-invalid-wasm-heterogeneous-tail.md
+++ b/plan/issues/2934-standalone-invalid-wasm-heterogeneous-tail.md
@@ -2,7 +2,7 @@
 id: 2934
 title: "Standalone: invalid-Wasm heterogeneous tail after #2878 (test/__closure_*/__cb_0 — distinct codegen bugs)"
 status: in-progress
-assignee: ttraenkler/dev-2878
+assignee: ttraenkler/dev-2934b
 created: 2026-07-02
 updated: 2026-07-02
 priority: medium
@@ -63,11 +63,32 @@ not one — triaged 2026-07-02:
   likely warrants an architect spec.
 - [ ] **(1d) simple `for (const v of u.values())`** — demotes to the IR path
   (`ir/from-ast: unknown class`), a separate IR-adoption gap.
-- [ ] **(2) `call[0]/call[1] expected type …` in `test`/`__closure_*`** — a
-  wrong-typed argument at a call site (`String/concat` → `call[0] expected (ref
-  null 6), found call of externref`; `RegExp/test` → `call[0] expected externref,
-  found struct.new of (ref 101)` — a missing `extern.convert_any`; Array
-  map/filter `create-species-*` callbacks). Each a coercion/typing site.
+- [x] **(2a) `RegExp/test` receiver → `hasOwnProperty`/`propertyIsEnumerable`
+  missing `extern.convert_any`** — DONE (dev-2934b, slice 2). `RegExp.prototype.
+  test.hasOwnProperty('length')` — the receiver `RegExp.prototype.test` is a
+  function object, compiled to a concrete function-object struct `(ref $fn)`.
+  `compilePropertyIntrospection` (`object-ops.ts`) takes the `receiverWasm.kind
+  === "externref"` branch because `resolveWasmType` reports the receiver's
+  *static* (method) type as `externref` — then pushed the receiver with
+  `compileExpression` but **did not coerce** the actually-emitted `(ref $fn)` to
+  externref, while the key argument WAS coerced. Result: `call[0] expected type
+  externref, found struct.new of type (ref …)` invalid Wasm. Fix: coerce the
+  receiver's *compiled* type (`recvType.kind !== "externref"` → `coerceType`
+  → `extern.convert_any`), mirroring the existing key-arg coercion. Verified
+  before/after over the 90-file `.hasOwnProperty/.propertyIsEnumerable('length')`
+  DontEnum-length family: **9 standalone INVALID → 0** (RegExp `test`/`exec`/
+  `toString` `_A8/_A9/_A10`); the other 81 were already valid and stay valid.
+  Host-mode byte-neutral (host receiver is already externref → guard skips it;
+  `S15.10.6.3_A8` et al. still pass host). Standalone runtime still fails these
+  on the separate `__hasOwnProperty` function-`.length`-own semantics gap — a
+  distinct issue, not this slice.
+- [ ] **(2b) remaining `call[0]/call[1] expected type …` coercion sites** — still
+  open, DISTINCT from (2a): `String/concat` → `call[0] expected (ref null 6),
+  found call of externref` (reverse direction — an internal ref expected, an
+  externref supplied); `RegExp.prototype.exec(...).toString()` → `call[0]
+  expected externref, found if of (ref null 98)` (nullable-ref receiver to
+  `.toString()`); Array map/filter `create-species-*` callbacks in `__closure_*`.
+  Each a separate coercion/typing site.
 - [ ] **(3) `__closure_5` `not enough arguments on the stack`** — the one
   funcIdx-shift-shaped failure (for-await async path); may share the #2918
   late-import class.

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -4237,8 +4237,18 @@ export function compilePropertyIntrospection(
     const hopIdx = ensureLateImport(ctx, importName, [{ kind: "externref" }, { kind: "externref" }], [{ kind: "i32" }]);
     flushLateImportShifts(ctx, fctx);
     if (hopIdx !== undefined) {
-      // Push receiver
-      compileExpression(ctx, fctx, propAccess.expression);
+      // Push receiver. `receiverWasm` is the receiver's STATIC type, which
+      // `resolveWasmType` reports as `externref` for a function/method type
+      // (e.g. `RegExp.prototype.test`). But the member access actually emits a
+      // concrete function-object struct `(ref $fn)`, not an externref — so the
+      // pushed value must still be coerced (`extern.convert_any`) to match the
+      // helper's `externref` param. Without this the receiver reached the call
+      // as a raw `struct.new` and produced `call[0] expected type externref,
+      // found struct.new of type (ref …)` invalid Wasm in standalone (#2934).
+      const recvType = compileExpression(ctx, fctx, propAccess.expression);
+      if (recvType && recvType.kind !== "externref") {
+        coerceType(ctx, fctx, recvType, { kind: "externref" });
+      }
       // Push key argument (or null if missing)
       if (expr.arguments[0]) {
         const argType = compileExpression(ctx, fctx, expr.arguments[0]);


### PR DESCRIPTION
## Summary

Slice 2 of #2934 (standalone invalid-Wasm heterogeneous tail): the **RegExp/test missing-`extern.convert_any` cluster**.

`RegExp.prototype.test.hasOwnProperty('length')` (and the `propertyIsEnumerable` / `exec` / `toString` variants) produced invalid Wasm in `--target standalone`:

```
Compiling function "test" failed: call[0] expected type externref, found struct.new of type (ref …)
```

### Root cause

The receiver `RegExp.prototype.test` is a **function object**, compiled to a concrete function-object struct `(ref $fn)`. In `compilePropertyIntrospection` (`src/codegen/object-ops.ts`), the `receiverWasm.kind === "externref"` branch is taken because `resolveWasmType` reports the receiver's **static** (method) type as `externref` — but it then pushed the receiver via `compileExpression` **without coercing** the actually-emitted `(ref $fn)` to externref, while the key argument *was* coerced. So `call[0]` (the receiver) reached `__hasOwnProperty` / `__propertyIsEnumerable` (both `externref` params) as a raw internal ref.

### Fix

Coerce the receiver's **compiled** type to externref, mirroring the existing key-arg coercion:

```ts
const recvType = compileExpression(ctx, fctx, propAccess.expression);
if (recvType && recvType.kind !== "externref") {
  coerceType(ctx, fctx, recvType, { kind: "externref" }); // ref → extern.convert_any
}
```

### Validation (before/after, validity-only sweep over the 90-file `.hasOwnProperty/.propertyIsEnumerable('length')` DontEnum-length family)

| | invalid | valid |
|---|---|---|
| origin/main | **9** | 81 |
| this PR | **0** | 90 |

The 9 flipped are exactly the target signature — RegExp `test`/`exec`/`toString` `_A8`/`_A9`/`_A10`. The other 81 were already valid and stay valid (no VALID→INVALID possible: a non-externref receiver at an externref param is *necessarily* invalid, so any previously-passing test already had an externref receiver, which the `!== "externref"` guard skips).

- **Host mode byte-neutral**: host receivers are already externref → guard skips the new coercion. `S15.10.6.3_A8` / `S15.10.6.2_A8` / `S15.10.6.4_A8` still **pass** in host mode.
- Standalone runtime for these still fails on the *separate* `__hasOwnProperty` function-`.length`-own semantics gap — a distinct issue, tracked as remaining item (2b) in #2934.

Pure correctness (invalid binary → valid). Scoped, independently-landable net-positive slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS