### PR TITLE
probe(#2927): Acorn self-compile findings + generic-built-in audit; file #2937 regression

### DIFF
--- a/plan/issues/2927-interpreter-foundation-acorn-builtin-audit.md
+++ b/plan/issues/2927-interpreter-foundation-acorn-builtin-audit.md
@@ -87,3 +87,149 @@ Consumes the boxed-any substrate — land after the corresponding value-rep
 substrate fixes, don't race them (roadmap §8). Umbrella: #1584. Goal:
 `runtime-eval`. This is #1584 scope items 1 + 9, extracted so the parser +
 library land and validate before the VM core (#2928).
+
+---
+
+## Probe results — Acorn-via-js2wasm self-compile (dev-2927, 2026-07-02)
+
+Ran the committed #1710 dogfood harness (`tests/dogfood/acorn-corpus.mjs`,
+pinned `acorn@8.16.0`, `skipSemanticDiagnostics: true`) + a direct throw-payload
+probe against current `main` (`c26fc059a3422`).
+
+### Path "Acorn source → valid Wasm that parses hello-world" — honest %
+
+| Stage | Status on current `main` |
+|---|---|
+| Acorn source → **compiles** through js2wasm (no manual edits) | ✅ 100% — `success:true` |
+| → **valid Wasm** (`WebAssembly.compile` / instantiate) | ✅ 100% — 651 KB binary validates, exposes callable `parse` |
+| → `parse(<hello-world>)` **returns a correct AST** | ❌ **0% on current main** — throws for **every** input, incl. `""` |
+
+**Bottom line: ~66% of the way** (compile + validate work; runtime parsing is
+regressed to 0%). This is a **regression**, not a greenfield gap: two days ago
+(harness re-run 2026-06-30, per `tests/dogfood/CORPUS-GAP-MAP.md`) the same
+harness parsed **13/22 corpus inputs** to structural parity (equal±quirks). The
+regression bisects cleanly to **`4173306a9b29`** (PR #2432 / #2849) — filed as
+**#2937** (host-mode `$Object`-hash poison → uniform null-deref at parser setup).
+
+With #2937 fixed, the path returns to **~59% structural parity** (13/22 inputs
+equal modulo cosmetic quirks), with the remaining ~41% being the already-filed
+host-marshalling / parser gaps below.
+
+### Catalogue of failures (all distinct root causes)
+
+| Root cause | Issue | Status | New? |
+|---|---|---|---|
+| **Host `$Object`-hash poison → uniform parse null-deref** (parser setup; masks all others) | **#2937** | **filed here, sprint: current, P1** | **NEW** |
+| regex char-class `[…]`/`\d` + named-group `(?<n>…)` validation-throws | #2850 | prior art, sprint: current, ready | no |
+| self-parse: division-after-number + regex-group throw | #2853 | prior art, sprint: current, ready | no |
+| `params[]` (arrow/fn-expr, incl. destructure/default/rest) marshalled blank | #2841 | prior art, in-progress | no |
+| `TemplateElement` quasis marshalled blank | #2851 | prior art, ready | no |
+| `SequenceExpression` children marshalled blank | #2852 | prior art, ready | no |
+| BigInt literal → f64 corruption | #2846 | prior art, ready | no |
+| cosmetic marshalling quirks (`sourceFile:null`, bool→i32) | #2847 | prior art, ready (cosmetic) | no |
+
+**Only one NEW distinct root cause found (#2937).** All input-specific gaps were
+already filed by prior sessions; per reground I did **not** re-file them.
+Critically, **#2850 / #2853 are currently unobservable** — #2937 kills the parser
+at setup, before any regex/division logic runs — so #2937 gates their
+re-verification and must land first. I did **not** fix #2850/#2853 in this probe
+for the same reason (they cannot be exercised on current main).
+
+### Why I did not fix #2937 inline
+
+#2937 is a deep `$Object`-representation interaction (needs #2849/#2584 context);
+a blind revert (re-gate to `ctx.standalone`) fixes Acorn but reintroduces the
+#2849 host bug and breaks `tests/issue-2849.test.ts`. Seven reduced shapes did
+not reproduce, so there is no minimal repro yet. This is an **escalation + focused
+follow-up**, not a small/safe inline fix. See #2937 for the fix-direction
+analysis and the recommended reduction step (instrument the null-guard throw
+site with a per-site-unique message).
+
+### Harness-measures-host-boundary caveat (important for strategy 2a)
+
+The #1710/#1712 corpus reads the AST **across the host boundary** via
+`wrapExports`, so it conflates (a) real parser-correctness bugs (#2850/#2853/
+#2846) with (b) host-marshalling losses (#2841/#2851/#2852/#2847) that are
+**irrelevant to the self-compiled interpreter** — under strategy 2(a) the
+bytecode emitter consumes the AST **in-Wasm** via WasmGC struct access, never
+through `wrapExports`. **Recommended #2928-prep artifact:** an *in-Wasm* AST
+consumer probe — a small TS harness compiled alongside Acorn that calls `parse`
+**and walks the resulting AST inside Wasm**, returning a scalar (node count / a
+specific field). That isolates true parser bugs from marshalling artifacts and is
+the correct fidelity metric for the interpreter. (Blocked on #2937.)
+
+### IR front-end alignment (project-lead north star)
+
+The interpreter's compiled substrate should assume the **IR front-end** ("everything
+through the IR, backends are the only fork"), not the legacy AST→Wasm path. Acorn
+currently compiles via the legacy path (with IR fallbacks); the dispatch loop +
+bytecode emitter (#2928) should be authored to compile cleanly through IR. Acorn
+self-compilation is therefore also an **IR-adoption stress test** (surfaced gaps
+file under #1058 / #2855), and the built-in audit below should be read as "what
+the IR-lowered interpreter can call generically".
+
+---
+
+## Generic built-in audit (Part 2)
+
+**Question:** the interpreter's future `CallBuiltin(name, recv: any, args: any[])`
+(#2928) operates on **boxed-`any`** operands. Which built-ins can already be
+invoked that way, and which are compile-time-type-specialized only?
+
+**Dispatch surfaces found (current `main`):**
+
+- **Host mode** — `__extern_method_call(recv, name, argsVec)` in `src/runtime.ts`
+  is a **fully generic** JS bridge (resolves + calls the real JS method on any
+  receiver). Complete, but **host-only** (traps standalone) → serves an
+  interpreter *Tier-1* only, not the 2(a) standalone goal.
+- **Standalone** — native `__extern_method_call` in `src/codegen/object-runtime.ts`
+  (#1888 Slice 2): open-`$Object` receivers resolve `name` via `__extern_get`
+  (own + prototype walk) and invoke through the `__apply_closure` arity bridge
+  (`__call_fn_method_0..4`). **Non-`$Object` brand arms (String / Array-vec /
+  Map / Set built-in prototype methods on a genuinely-`any` receiver) are stubs
+  that return `undefined`.**
+- **`__call_m_<name>_<arity>` / `_vararg`** (`src/codegen/closed-method-dispatch.ts`,
+  #2151): per-method-name type-switch dispatchers over **user closed
+  object-literal** structs — NOT built-in prototypes. Standalone-gated.
+- **`__get_builtin(name)`** (#2863): resolves a built-in **global/function** by
+  name to a callable externref, standalone.
+- **`__str_*` / `__vec_*` / `__arr_*`**: type-**specialized** helpers, emitted
+  when the receiver type is statically known (String / Array / TypedArray).
+
+**Coverage table (generic `(any,…)→any` callability for the standalone interpreter):**
+
+| Built-in family | Specialized (AOT, static type)? | Generic `(any,…)→any` today? | What's missing for `CallBuiltin` |
+|---|---|---|---|
+| User object-literal methods (on `$Object`) | n/a | ✅ standalone via `__extern_method_call` → `__extern_get` → `__apply_closure` (arity 0–4) | **args not passed**: caller `emitWrapperDynamicMethodCall` gates `wantArgs` off for standalone/wasi; arity >4; keyed-by-name only |
+| `Array.prototype.*` (map/filter/push/slice/indexOf/…) | ✅ `__vec_*`/`__arr_*` (typed receiver) | ⚠️ brand arm is a **stub → undefined**; partial only via `__call_m_*` for closed-literal methods | generic vec brand arm in `__extern_method_call`: type-switch `ref.test $Vec` → route to `__vec_*` with boxed args |
+| `String.prototype.*` (slice/charAt/indexOf/split/replace/…) | ✅ `__str_*` (native string) | ⚠️ brand arm **stub → undefined** | generic string brand arm → `__str_*` over `ref $NativeString` with boxed args |
+| `Map`/`Set`/`WeakMap` methods (get/set/has/add/…) | ✅ typed | ⚠️ brand arm **stub → undefined** | generic Map/Set brand arms |
+| `Object.*` (keys/values/entries/assign/GOPD/GOPN/freeze) | ✅ typed + `__extern_*` | ✅ mostly generic (open-`$Object` path) | completeness pass; some standalone (`groupBy` via #2863) |
+| Global functions (`parseInt`/`parseFloat`/`isNaN`/`String`/`Number`/`Boolean`) | ✅ imports | ✅ resolvable via `__get_builtin` standalone | wire `__get_builtin` result into a generic `__apply_closure` call w/ boxed args |
+| `Math.*`, `JSON.*` (namespace statics) | ✅ specialized | ⚠️ via `__get_builtin` for the namespace object; per-method generic dispatch untested | generic static-method dispatch (namespace + method name) |
+| Number/String/Boolean **wrapper** proto (via boxed primitive) | ✅ | ⚠️ depends on the boxed-primitive read substrate (memory `reference_1629b…`) | boxed-primitive → brand classification in the generic dispatcher |
+| Arithmetic / operators (`+ - * / %`, `<` …) | ✅ `add_int_int` etc. (typed) | ⚠️ generic `(any,any)→any` `__to_primitive`/toNumber arms partial (#2358/#2873) | complete the generic operator arms (roadmap §4.2 completeness) |
+
+**Headline gap for #2928:** standalone has a **generic dispatcher skeleton**
+(`__extern_method_call` open-`$Object` path + `__get_builtin` + the #2151 family)
+but the **non-`$Object` brand arms are unimplemented stubs**, and the caller does
+**not pass args** to the generic path in standalone. The interpreter's
+`CallBuiltin` needs:
+
+1. **Brand-arm completion** in the standalone `__extern_method_call` (or a new
+   sibling): type-switch the boxed receiver (`ref.test` $Vec / $NativeString /
+   $Map / $Set / boxed-number) and route to the existing specialized `__str_*` /
+   `__vec_*` helpers with **boxed args**. This is the #2151 "Slice 4 brand arms"
+   made real, and is **shared work** with standalone AOT any-receiver dispatch —
+   not interpreter-only overhead (roadmap §4.2).
+2. **Args on the standalone generic path**: grow the `$ObjVec` args builder in
+   `emitWrapperDynamicMethodCall` for standalone/wasi (currently empty-args only)
+   and lift the arity-4 ceiling on `__apply_closure`/`__call_fn_method_N`.
+3. **A unified `CallBuiltin(name, recv, argsVec)` entry** (the standalone analog
+   of host `__extern_method_call`) the bytecode emitter targets — layered over
+   1+2, keyed by method name, boxed-`any` in/out.
+
+These three are the concrete #2928 prerequisites this audit gates; each maps to
+existing infra (#2151 dispatchers, #2863 `__get_builtin`, `__str_*`/`__vec_*`
+helpers) rather than net-new machinery.
+

--- a/plan/issues/2927-interpreter-foundation-acorn-builtin-audit.md
+++ b/plan/issues/2927-interpreter-foundation-acorn-builtin-audit.md
@@ -1,7 +1,8 @@
 ---
 id: 2927
 title: "Interpreter foundation: Acorn-via-js2wasm runtime parser + generic-built-in audit"
-status: backlog
+status: in-progress
+assignee: ttraenkler/dev-2927
 created: 2026-07-02
 updated: 2026-07-02
 priority: medium
@@ -12,7 +13,7 @@ task_type: feature
 area: runtime
 language_feature: eval
 goal: runtime-eval
-sprint: Backlog
+sprint: current
 parent: 1584
 depends_on: [1058, 1710, 2527]
 related: [1584, 1715, 1066]

--- a/plan/issues/2937-acorn-host-object-hash-poison-null-deref-regression.md
+++ b/plan/issues/2937-acorn-host-object-hash-poison-null-deref-regression.md
@@ -1,0 +1,148 @@
+---
+id: 2937
+title: "Regression: host-mode $Object-hash poison (#2849) makes compiled-acorn parse null-deref on every input"
+status: ready
+created: 2026-07-02
+updated: 2026-07-02
+priority: high
+horizon: m
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen
+language_feature: object
+goal: runtime-eval
+sprint: current
+parent: 2927
+depends_on: []
+related: [2849, 2584, 2432, 1712, 1710, 2850, 2853]
+---
+
+# #2937 — host-mode `$Object`-hash poison regresses compiled-acorn to a uniform null-deref
+
+**Blocker for #2927** (Acorn-via-js2wasm interpreter foundation) and for the
+prior acorn self-host work (#2850 / #2853), which this regression **masks**.
+
+## Symptom
+
+On current `main` (`c26fc059a3422`), the compiled-Acorn parser throws at
+runtime for **every** input — including the empty program `""`:
+
+```
+parse("")            => TypeError: Cannot access property on null or undefined
+parse("1")           => TypeError: Cannot access property on null or undefined
+parse("var x = 1;")  => TypeError: Cannot access property on null or undefined
+```
+
+The `#1712` differential corpus harness went from **13 equal±quirks / 8 real / 1
+threw** (documented in `tests/dogfood/CORPUS-GAP-MAP.md`, re-run 2026-06-30) to
+**22 / 22 `compiled-parse-threw`**. The throw fires on `""` too, so it happens
+during **parser setup** (the `Parser` constructor / `getOptions`), before any
+real parsing — i.e. it is upstream of the input-specific gaps #2850/#2853, which
+can no longer be observed until this is fixed.
+
+The compile itself still succeeds and the binary still validates — this is a
+pure **runtime** null-deref (`typeErrorThrowInstrs` in
+`src/codegen/property-access.ts`), a member access on a receiver that is null at
+runtime when it should be a live object.
+
+## Root cause — bisected
+
+`git bisect` (compile Acorn → `parse("1")`; GOOD = returns a `Program`, BAD =
+null-deref) over the 2026-07-01 evening merge batch pins the first bad commit:
+
+```
+4173306a9b29f3d1884cebf6e1972dea32508c75
+fix(#2849): extend $Object-hash poison to host so static writes don't shadow the sidecar
+(landed via PR #2432 — issue-2849-acorn-ecmaversion-normalize)
+```
+
+That commit, in `src/codegen/declarations.ts` (`collectEmptyObjectWidening`),
+**dropped the `if (ctx.standalone)` gate** around the `markObjectHashConsumers`
+loop so the `#2584` `objectHashConsumerVars` **poison applies in host mode too**:
+
+```ts
+// BEFORE (standalone-only):
+if (ctx.standalone) {
+  for (const s of stmts) markObjectHashConsumers(s, varName, ctx.objectHashConsumerVars);
+}
+// AFTER (#2849 — host too):
+for (const s of stmts) markObjectHashConsumers(s, varName, ctx.objectHashConsumerVars);
+```
+
+The poison keeps a `{}` var that has **both** dynamic-key access (`o[k]=`, for-in,
+`in`, `Object.keys/values/entries`) **and** static-named access on the `$Object`
+sidecar, suppressing widening into a closed WasmGC struct. #2849 needed this in
+host mode to fix the acorn `getOptions` for-in-copy shape (ecmaVersion `2022`
+read back as `0` instead of `13`). But extending the poison to host mode makes
+some access shape Acorn uses read back a **null receiver**, and the null guard
+throws.
+
+## Fix direction (confirmed) — and why a plain revert is NOT acceptable
+
+Re-adding the `ctx.standalone` gate makes compiled-Acorn parse again (verified —
+the bisect probe returns GOOD with the gate restored). **But** re-gating
+reintroduces the exact #2849 host bug (getOptions `2022 → 0`) and breaks the host
+assertion in `tests/issue-2849.test.ts`. So the fix must **preserve #2849 while
+not regressing the broader host-mode `$Object` read path** — either:
+
+1. Fix the host-mode `$Object` read path so a poisoned object reads correctly for
+   **all** access shapes (not just the for-in-copy shape #2849 tested), or
+2. Narrow the host-mode poison trigger to the precise for-in-write→static-widen
+   divergence #2849 needs, leaving Acorn's shape on the (working) struct/Proxy
+   fast path.
+
+`(1)` is the principled fix. `(2)` risks reintroducing #2849 for the narrowed-out
+shapes and needs the exact Acorn trigger to draw the line safely.
+
+## Reduction status
+
+Seven reduced shapes did **NOT** reproduce (they return the correct value in host
+mode on current main): for-in-copy of a primitive with a poisoning static write
+(`o.extra=1`); object-valued copy + chained read; bracket-write of an object +
+member access; copy-then-local + member access; **object escape** (poisoned
+object returned from a function and read chained by the caller); poisoned object
+stored on `this.options` and read by a method; and a `getOptions`-exact
+default-copy + `in`-guard + `ecmaVersion` normalise (returns `13` correctly). So
+the trigger is a **larger / class-shaped** Acorn pattern, not a trivial one.
+
+**Recommended next reduction step:** instrument `typeErrorThrowInstrs` /
+`emitNullCheckThrow` to emit a **per-call-site-unique** message (the current
+throw has line/col `0`, so it can't be located from the payload), recompile
+Acorn, and read which member-access site fires — then reduce from that site.
+
+## Repro
+
+Deterministic, committed, one command (the #1710 dogfood harness):
+
+```bash
+# in a worktree off current main:
+ln -s /workspace/node_modules node_modules
+npx tsx tests/dogfood/acorn-corpus.mjs        # 22/22 compiled-parse-threw
+```
+
+Minimal throw-payload probe (extracts the real thrown value via the exported
+`__exn_tag`): compile pinned acorn (`skipSemanticDiagnostics: true`),
+instantiate, `wrapExports`, call `parse("")` — throws `TypeError: Cannot access
+property on null or undefined`.
+
+## Impact
+
+- **Invisible to test262** (Acorn is not in the suite; the baseline stayed
+  33,147 across the #2432 merge), so no conformance gate caught it — the dogfood
+  harness is the only thing that did. This is the case for wiring the corpus
+  harness into a CI signal (follow-up).
+- **Blocks the entire #2927 critical path** ("Acorn source → valid Wasm that
+  parses hello-world") and **masks** #2850 / #2853 (they cannot be re-verified
+  until the parser survives setup).
+- Likely regresses other **host-mode** programs with the same
+  dynamic-key-write + static-named-access `{}` shape at scale.
+
+## Acceptance criteria
+
+- [ ] Compiled-Acorn `parse("")` / `parse("1")` return a `Program` in host mode
+      (dogfood corpus back to ≥ the 2026-06-30 baseline: ≥13 equal±quirks).
+- [ ] `tests/issue-2849.test.ts` still passes (host `2022 → 13` preserved).
+- [ ] Standalone codegen byte-identical (poison was already on there — no change).
+- [ ] A regression test captures the Acorn-shaped null-deref (reduced repro, or a
+      guarded compiled-Acorn smoke assertion in `tests/`).


### PR DESCRIPTION
Foundation probe for the standalone bytecode interpreter (roadmap slice D, #2927 / #1584). No compiler source changes — this PR lands the probe findings + the generic-built-in audit into the issue files, and files the one NEW distinct blocker (#2937). Promotes #2927 to \`sprint: current\`.

## Part 1 — Acorn-via-js2wasm self-compile probe

Ran the committed #1710 dogfood harness (\`tests/dogfood/acorn-corpus.mjs\`, pinned acorn@8.16.0) + a throw-payload probe against current \`main\`.

**Path "Acorn source → valid Wasm that parses hello-world" — ~66%, and REGRESSED:**
- Acorn source → compiles + validates to Wasm: **100%** (651 KB, callable \`parse\`).
- \`parse(<any input, incl "">)\` → correct AST: **0% on current main** — uniform runtime \`TypeError: Cannot access property on null or undefined\` at parser setup.
- Two days ago the same harness parsed **13/22** corpus inputs to structural parity. This is a **regression**, bisected to \`4173306a9b29\` (PR #2432 / #2849) — the host-mode \`$Object\`-hash poison. Filed as **#2937** (P1, sprint: current) with bisect evidence + confirmed fix-direction (a plain revert reintroduces the #2849 host bug).

**Catalogue:** only **one NEW** distinct root cause (#2937). All input-specific gaps (#2841/#2850/#2851/#2852/#2846/#2853/#2847) were already filed by prior sessions — not re-filed. #2937 **masks** #2850/#2853 (parser dies before their logic runs), so it gates their re-verification and must land first; did not fix them for that reason.

## Part 2 — generic-built-in audit

Written into #2927 as a coverage table. Headline: standalone has a generic-dispatch **skeleton** (open-\`$Object\` \`__extern_method_call\` + \`__get_builtin\` + the #2151 \`__call_m_*\` family) but the **non-\`$Object\` brand arms (String / Array-vec / Map / Set) are undefined stubs**, and the caller passes **no args** on the standalone generic path. Host \`__extern_method_call\` is fully generic but host-only. Three concrete \`CallBuiltin\` prerequisites for #2928 identified, each mapping to existing infra.

## Notes
- The harness measures the **host boundary** (conflates real parser bugs with marshalling losses irrelevant to the self-compiled interpreter) — recommend an in-Wasm AST-consumer probe as #2928-prep.
- Interpreter substrate assumes the **IR front-end** (project-lead north star).

Files: \`plan/issues/2927-*.md\` (probe results + audit), \`plan/issues/2937-*.md\` (new blocker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)