### PR TITLE
revert(#2920): restore CI guard levers — #1668 threshold 500→200, intentional-drop budget removed

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -662,17 +662,7 @@ jobs:
       - name: Catastrophic regression guard (#1668)
         if: env.SHARDS_RAN == 'true'
         env:
-          # TEMPORARY (#2920): raised 200 -> 500 to land the maintainer-approved
-          # intentional −439 negative-verdict drop (the strict compile-SUCCEEDED
-          # arm). The CI shard JSONL carries no wasm_sha, so diff-test262's
-          # byte-identical "wasm-identical noise" filter is inert here and all
-          # 439 verdict-only flips (byte-identical compiled Wasm) count as
-          # wasm-change regressions — which would otherwise trip this guard on
-          # #2920's own merge_group run. 439 < 500 lets the merged tree through;
-          # promote-baseline then re-seeds the honest baseline on push:main.
-          # REVERT to "200" immediately after #2920 merges — tracked by the
-          # revert PR referenced in #2920. Do NOT leave this at 500.
-          CATASTROPHIC_REGRESSION_THRESHOLD: "500"
+          CATASTROPHIC_REGRESSION_THRESHOLD: "200"
           # #1954 — on a scoped PR run the merged JSONL only covers the scope;
           # restrict the baseline the same way or every out-of-scope baseline
           # pass counts as a pass→absent "regression". Empty on merge_group/
@@ -1256,17 +1246,6 @@ jobs:
           # #1954 — scoped PR runs: restrict the baseline to the scope or
           # every out-of-scope baseline pass reads as a pass→absent regression.
           TEST262_SCOPE: ${{ needs.changes.outputs.test262_scope }}
-          # TEMPORARY (#2920): intentional-drop budget for the maintainer-approved
-          # −439 negative-verdict tightening (strict compile-SUCCEEDED arm). The
-          # CI shard JSONL has no wasm_sha, so diff-test262 can't classify the
-          # byte-identical verdict-only flips as wasm-identical noise and counts
-          # them as real regressions here. This waives diff-test262's
-          # net/ratio/bucket gates when the wasm-change regression count is ≤ 500
-          # (a real regression > 500 still fails). Mirrors the #1668 200→500 raise
-          # in the merge-report guard above. REVERT to remove (set back to
-          # default 0) together with the #1668 restore — see the #2920 revert PR.
-          # Permanent fix: #2926 (emit wasm_sha in the shard JSONL).
-          INTENTIONAL_REGRESSION_BUDGET: "500"
         run: |
           BASELINE="benchmarks/results/test262-current.jsonl"
           if [ ! -f "$BASELINE" ]; then

--- a/plan/issues/2920-strict-negative-verdict-succeeded-arm.md
+++ b/plan/issues/2920-strict-negative-verdict-succeeded-arm.md
@@ -137,3 +137,30 @@ the value self-heals to exact.
 - Behaviour identical across `gc` and `standalone`, and across all three
   runners (single shared helper).
 - Lands with a coordinated baseline refresh so the merge queue is not wedged.
+
+## Revert record (2026-07-02, the revert PR)
+
+Re-seed verified before reverting (required ordering — the revert's own gates
+at 200/budget-0 must diff against the honest baseline):
+
+- #2424 merged at `9d37728` (2026-07-02T01:05Z). Its own push:main run passed
+  `merge shard reports` but its `promote-baseline` job **failed** — a
+  persistent push race against `js2wasm-baselines` (another run's promote
+  landed first; the wholesale-regenerated JSONLs never rebase cleanly, so all
+  5 retries conflicted identically).
+- The **next** push:main run (`dacd7fd`, run 28558439826 — a descendant of
+  #2424) promoted successfully at 01:28Z: baselines-repo HEAD `71d3569`
+  ("33283/43135 host, 25825/43137 standalone (dacd7fd)"). The gate baseline is
+  honest/post-#2424.
+- Standalone high-water: the same promote raised the host-free mark
+  17802 → 18353 in-job; the direct-to-main commit of the refreshed mark was
+  deferred ("merge queue has 3 entries", #1951 fail-open) and lands via the
+  scheduled refresh. The committed 17802 floor is strictly permissive — the
+  revert leaves `test262-standalone-highwater.json` untouched.
+
+Levers restored by the revert PR: `CATASTROPHIC_REGRESSION_THRESHOLD`
+500 → 200 (#1668 guard), `INTENTIONAL_REGRESSION_BUDGET` removed from the
+regression-diff step AND the temporary waiver block removed from
+`scripts/diff-test262.ts` (its default was already 0; the block self-documented
+as revert-together). Permanent fix for this class of landing: #2926 (emit
+`wasm_sha` in the shard JSONL — filed with the revert PR).

--- a/plan/issues/2926-emit-wasm-sha-in-shard-jsonl.md
+++ b/plan/issues/2926-emit-wasm-sha-in-shard-jsonl.md
@@ -1,0 +1,80 @@
+---
+id: 2926
+title: "Emit wasm_sha in the CI shard JSONL so diff-test262's wasm-identical-noise filter works in CI"
+status: backlog
+priority: medium
+sprint: Backlog
+created: 2026-07-02
+feasibility: medium
+task_type: improvement
+area: tooling
+goal: developer-experience
+related: [2920, 2912, 1222, 1943]
+---
+
+# #2926 — Emit `wasm_sha` in the CI shard JSONL (permanent fix for verdict-only landings)
+
+## Problem
+
+`scripts/diff-test262.ts` classifies a `pass → fail` regression as
+**"wasm-identical noise"** (excluded from every gated regression count — the
+`check for test262 regressions` net gate, the `#1668` catastrophic guard, and
+the `#1897` standalone guard) **only when both the baseline row and the new row
+carry the same non-null `wasm_sha`** (`diff-test262.ts` `wasmUnchanged`, ~line
+440; the #1222 byte-identical filter). If either side lacks `wasm_sha`, the
+regression is conservatively counted as real.
+
+**The CI shard runner never emits `wasm_sha`.** `tests/test262-shared.ts`
+`recordResult` (the producer of the sharded JSONL that CI merges and the
+baseline is promoted from) has no `wasm_sha` field — confirmed against
+`.test262-cache/test262-current.jsonl` (keys: category, compile_ms, exec_ms,
+file, host_import_leak_class, imports, oracle_version, reached_test, scope,
+scope_official, status, strict, timestamp — no `wasm_sha`). Only the legacy
+`tests/test262-vitest.test.ts` runner computes it (`computeWasmSha`,
+`tests/test262-runner.ts:136`), and that runner is not the CI path.
+
+So the #1222 wasm-identical-noise filter is **completely inert in CI**: a
+verdict-only change (byte-identical compiled Wasm; only the pass/fail score
+flips) reads as N real regressions.
+
+## Impact — why this matters (the #2920 landing)
+
+This is exactly why #2920 (the strict negative-verdict arm, an intentional −439
+that changes NO codegen) could not land through the normal gates and needed a
+**temporary `#1668` threshold bump (200→500)** plus a manual standalone
+high-water lower. If the shard JSONL carried `wasm_sha`, all 439 verdict-only
+flips would classify as wasm-identical noise and pass `#1668` / `#1897` / the
+regression gate **cleanly** — leaving only the absolute `#2097` floor to adjust.
+Every future oracle/verdict tightening (there will be more as the negative-test
+and error-classification oracle sharpens) hits the same wall.
+
+## Fix direction
+
+1. **Compute `wasm_sha` in the CI path** — `tests/test262-shared.ts` (and, for
+   the worker-driven main path, `scripts/test262-worker.mjs` /
+   `metadataFromWorkerResult`): hash the compiled binary (reuse
+   `computeWasmSha` from `tests/test262-runner.ts`) and thread it through
+   `recordResult` into the JSONL row (same field name `wasm_sha` that
+   `diff-test262.ts` already reads). Emit it for BOTH pass and fail rows (a
+   flip needs the hash on both sides) whenever a binary was produced; leave it
+   absent when no binary exists (compile_error) so the conservative
+   "count-as-real" fallback still applies there.
+2. **Refresh the baseline** so the committed/promoted baseline rows also carry
+   `wasm_sha` (a normal push:main `promote-baseline` after the emitter lands).
+   Until both baseline and candidate carry it, the filter stays inert — so this
+   is a land-then-one-clean-baseline-cycle change.
+3. Once in place, verdict-only landings need no threshold bump — verify by
+   re-checking that a no-codegen oracle change nets 0 gated regressions.
+
+## Acceptance
+
+- CI shard JSONL rows carry `wasm_sha` for every row where a binary was
+  produced (host and standalone lanes).
+- After one baseline refresh, a verdict-only (byte-identical-Wasm) change nets
+  **0** `regressionsWasmChange` in `diff-test262.ts` and passes `#1668` /
+  `#1897` / the regression gate without any threshold change.
+
+## Context
+
+Filed from the #2920 landing-blocker analysis (2026-07-02). See
+`plan/issues/2920-strict-negative-verdict-succeeded-arm.md` "Landing mechanics".

--- a/scripts/diff-test262.ts
+++ b/scripts/diff-test262.ts
@@ -738,32 +738,12 @@ async function run(
     }
   }
 
-  // (#2920, TEMPORARY) Intentional-drop budget. A maintainer-approved
-  // conformance drop — an ORACLE/verdict tightening that flips N tests
-  // pass→fail with NO codegen change — would otherwise trip these gates,
-  // because the CI shard JSONL carries no `wasm_sha`, so a byte-identical
-  // verdict-only flip can't be classified as "wasm-identical noise" and counts
-  // as a real regression. When `INTENTIONAL_REGRESSION_BUDGET` is set and the
-  // wasm-change regression count is within it, waive the net/ratio/bucket gates
-  // for this run. Default 0 (no effect); the only setter is the merge_group
-  // regression-diff step in test262-sharded.yml, TEMPORARY, mirroring the #1668
-  // 200→500 raise. REVERT together with that (#2920 revert PR); a real
-  // regression > budget still fails. The permanent fix is #2926 (emit wasm_sha
-  // in the shard JSONL so the wasm-identical filter works in CI).
-  const intentionalBudget = Number(process.env.INTENTIONAL_REGRESSION_BUDGET ?? "0") || 0;
-  const withinIntentionalBudget = intentionalBudget > 0 && regressionsWasmChange <= intentionalBudget;
-  if (withinIntentionalBudget) {
-    console.log(
-      `=== INTENTIONAL-DROP WAIVER (#2920, TEMPORARY): ${regressionsWasmChange} wasm-change regressions ≤ budget ${intentionalBudget} — net/ratio/bucket gates waived for this run. ===`,
-    );
-  }
-
   // Exit code: non-zero when the change is a net negative using wasm-hash-filtered regressions.
   // Compile_timeout flaps (timing noise) and wasm-identical flips are excluded via
   // regressionsWasmChange. Gate: improvements.length - regressionsWasmChange < 0.
   const netPerTest = improvements.length - regressionsWasmChange;
   let gateFailed = false;
-  if (!withinIntentionalBudget && netPerTest < 0) {
+  if (netPerTest < 0) {
     console.log(
       `=== GATE FAIL: net_per_test ${netPerTest} < 0 (${improvements.length} improvements − ${regressionsWasmChange} regressions) ===`,
     );
@@ -774,16 +754,14 @@ async function run(
   // that previously lived only in the dev-self-merge skill text. Same
   // wasm-hash-filtered count the net gate uses (`noiseFiltered`), so
   // compile_timeout flaps and byte-identical flips never trip these either.
-  if (!withinIntentionalBudget) {
-    const thresholdFailures = evaluateRegressionThresholds({
-      improvements: improvements.length,
-      regressionsWasmChange,
-      regressedFiles: noiseFiltered.map((r) => r.file),
-    });
-    for (const reason of thresholdFailures) {
-      console.log(`=== GATE FAIL: ${reason} ===`);
-      gateFailed = true;
-    }
+  const thresholdFailures = evaluateRegressionThresholds({
+    improvements: improvements.length,
+    regressionsWasmChange,
+    regressedFiles: noiseFiltered.map((r) => r.file),
+  });
+  for (const reason of thresholdFailures) {
+    console.log(`=== GATE FAIL: ${reason} ===`);
+    gateFailed = true;
   }
 
   if (gateFailed) {


### PR DESCRIPTION
The immediate revert of the two TEMPORARY gate levers #2424 carried to land the maintainer-approved intentional −439 negative-verdict drop (#2920). Filed per the revert tracking in the #2424 comments and `plan/issues/2920-*.md` — do-not-leave-at-500.

## What reverts

- **`.github/workflows/test262-sharded.yml`**: `CATASTROPHIC_REGRESSION_THRESHOLD` **500 → 200** (the #1668 guard inside required `merge shard reports`); the `INTENTIONAL_REGRESSION_BUDGET: "500"` env removed from the merge_group regression-diff step.
- **`scripts/diff-test262.ts`**: the temporary #2920 intentional-drop waiver block removed entirely (it self-documented as revert-together-with-the-workflow; default was 0, so removal is behavior-neutral with the env unset and closes the waiver surface). Verified locally: net-negative diff exits 1 even with `INTENTIONAL_REGRESSION_BUDGET=500` set; identical inputs exit 0.
- Exact-inverse check: the diff to these two files is line-for-line the inverse of #2424's lever hunks (no post-#2424 interference).

## What deliberately does NOT revert

- **`benchmarks/results/test262-standalone-highwater.json`** stays at the committed 17802: the post-#2424 promote (run 28558439826) raised the host-free mark 17802 → 18353 in-job but deferred the direct-to-main commit (merge queue busy, #1951 fail-open) — it lands via the scheduled refresh. Committed-lower is strictly permissive; nothing to restore here.

## Re-seed verification (the ordering requirement)

The revert must not merge before the honest baseline is seeded — verified done:

- #2424's own push:main run (28558202948) passed `merge shard reports` but its `promote-baseline` **failed**: persistent push race against `js2wasm-baselines` (a concurrent promote landed first; wholesale-regenerated JSONLs never rebase cleanly — all 5 retries conflicted).
- The **next** push:main run (dacd7fd, 28558439826) promoted successfully at 01:28Z → baselines-repo HEAD `71d3569` ("33283/43135 host, 25825/43137 standalone (dacd7fd)"). The gate baseline this PR diffs against is honest/post-#2424, so 200/budget-0 gates run clean.

## Bundled

- `plan/issues/2926-emit-wasm-sha-in-shard-jsonl.md` (Backlog) — the **permanent fix**: emit `wasm_sha` in the CI shard JSONL so the wasm-identical-noise filter works in CI and verdict-only landings never need a threshold bump again. Id 2926 reserved via `claim-issue --allocate`; file salvaged from dev-2912's worktree.
- `plan/issues/2920-*.md`: "Revert record" section documenting the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS