### PR TITLE
chore(#2926,#2934,#2937): rescue stranded dead-agent artifacts

### DIFF
--- a/plan/issues/2926-emit-wasm-sha-in-shard-jsonl.md
+++ b/plan/issues/2926-emit-wasm-sha-in-shard-jsonl.md
@@ -1,0 +1,80 @@
+---
+id: 2926
+title: "Emit wasm_sha in the CI shard JSONL so diff-test262's wasm-identical-noise filter works in CI"
+status: backlog
+priority: medium
+sprint: Backlog
+created: 2026-07-02
+feasibility: medium
+task_type: improvement
+area: tooling
+goal: developer-experience
+related: [2920, 2912, 1222, 1943]
+---
+
+# #2926 — Emit `wasm_sha` in the CI shard JSONL (permanent fix for verdict-only landings)
+
+## Problem
+
+`scripts/diff-test262.ts` classifies a `pass → fail` regression as
+**"wasm-identical noise"** (excluded from every gated regression count — the
+`check for test262 regressions` net gate, the `#1668` catastrophic guard, and
+the `#1897` standalone guard) **only when both the baseline row and the new row
+carry the same non-null `wasm_sha`** (`diff-test262.ts` `wasmUnchanged`, ~line
+440; the #1222 byte-identical filter). If either side lacks `wasm_sha`, the
+regression is conservatively counted as real.
+
+**The CI shard runner never emits `wasm_sha`.** `tests/test262-shared.ts`
+`recordResult` (the producer of the sharded JSONL that CI merges and the
+baseline is promoted from) has no `wasm_sha` field — confirmed against
+`.test262-cache/test262-current.jsonl` (keys: category, compile_ms, exec_ms,
+file, host_import_leak_class, imports, oracle_version, reached_test, scope,
+scope_official, status, strict, timestamp — no `wasm_sha`). Only the legacy
+`tests/test262-vitest.test.ts` runner computes it (`computeWasmSha`,
+`tests/test262-runner.ts:136`), and that runner is not the CI path.
+
+So the #1222 wasm-identical-noise filter is **completely inert in CI**: a
+verdict-only change (byte-identical compiled Wasm; only the pass/fail score
+flips) reads as N real regressions.
+
+## Impact — why this matters (the #2920 landing)
+
+This is exactly why #2920 (the strict negative-verdict arm, an intentional −439
+that changes NO codegen) could not land through the normal gates and needed a
+**temporary `#1668` threshold bump (200→500)** plus a manual standalone
+high-water lower. If the shard JSONL carried `wasm_sha`, all 439 verdict-only
+flips would classify as wasm-identical noise and pass `#1668` / `#1897` / the
+regression gate **cleanly** — leaving only the absolute `#2097` floor to adjust.
+Every future oracle/verdict tightening (there will be more as the negative-test
+and error-classification oracle sharpens) hits the same wall.
+
+## Fix direction
+
+1. **Compute `wasm_sha` in the CI path** — `tests/test262-shared.ts` (and, for
+   the worker-driven main path, `scripts/test262-worker.mjs` /
+   `metadataFromWorkerResult`): hash the compiled binary (reuse
+   `computeWasmSha` from `tests/test262-runner.ts`) and thread it through
+   `recordResult` into the JSONL row (same field name `wasm_sha` that
+   `diff-test262.ts` already reads). Emit it for BOTH pass and fail rows (a
+   flip needs the hash on both sides) whenever a binary was produced; leave it
+   absent when no binary exists (compile_error) so the conservative
+   "count-as-real" fallback still applies there.
+2. **Refresh the baseline** so the committed/promoted baseline rows also carry
+   `wasm_sha` (a normal push:main `promote-baseline` after the emitter lands).
+   Until both baseline and candidate carry it, the filter stays inert — so this
+   is a land-then-one-clean-baseline-cycle change.
+3. Once in place, verdict-only landings need no threshold bump — verify by
+   re-checking that a no-codegen oracle change nets 0 gated regressions.
+
+## Acceptance
+
+- CI shard JSONL rows carry `wasm_sha` for every row where a binary was
+  produced (host and standalone lanes).
+- After one baseline refresh, a verdict-only (byte-identical-Wasm) change nets
+  **0** `regressionsWasmChange` in `diff-test262.ts` and passes `#1668` /
+  `#1897` / the regression gate without any threshold change.
+
+## Context
+
+Filed from the #2920 landing-blocker analysis (2026-07-02). See
+`plan/issues/2920-strict-negative-verdict-succeeded-arm.md` "Landing mechanics".

--- a/plan/issues/2937-acorn-host-object-hash-poison-null-deref-regression.md
+++ b/plan/issues/2937-acorn-host-object-hash-poison-null-deref-regression.md
@@ -111,6 +111,54 @@ the trigger is a **larger / class-shaped** Acorn pattern, not a trivial one.
 throw has line/col `0`, so it can't be located from the payload), recompile
 Acorn, and read which member-access site fires — then reduce from that site.
 
+### Reduced shapes (verbatim — all returned the CORRECT value in host mode on
+current `main`; extend these toward the Acorn trigger)
+
+Each is `compile(src, { fileName: "t.ts" })` → instantiate → `wrapExports` →
+`exp.test()`. All 7 returned the expected number (no throw):
+
+```ts
+// P1 — for-in copy of a primitive + a poisoning static write, static read (=13)
+const src: any = { ecmaVersion: 13 }; const o: any = {};
+for (const k in src) { o[k] = src[k]; } o.extra = 1; return o.ecmaVersion;
+
+// P2 — copied value is an OBJECT, then chained read (=42)
+const inner: any = { v: 42 }; const src: any = { node: inner }; const o: any = {};
+for (const k in src) { o[k] = src[k]; } o.extra = 1; return o.node.v;
+
+// P3 — bracket-write of an object, static read returns object, member access (=7)
+const o: any = {}; const key = "node"; o[key] = { v: 7 }; o.flag = 1; return o.node.v;
+
+// P4 — static read of copied object into a local, then member access (=99)
+const inner: any = { v: 99 }; const src: any = { keywords: inner }; const o: any = {};
+for (const k in src) { o[k] = src[k]; } o.pos = 0; const kw: any = o.keywords; return kw.v;
+
+// E1 — ESCAPE: poisoned object RETURNED from a fn, caller reads chained (=42)
+function make(): any { const src: any = { ecmaVersion: 13, node: { v: 42 } };
+  const o: any = {}; for (const k in src) { o[k] = src[k]; } o.extra = 1; return o; }
+// test(): const opts: any = make(); return opts.node.v;
+
+// E2 — ESCAPE via `this`: ctor builds poisoned obj on this.options, method reads (=13)
+class P { options: any; constructor(opts: any) { const src: any = opts; const o: any = {};
+  for (const k in src) { o[k] = src[k]; } o.extra = 1; this.options = o; }
+  read(): number { return this.options.ecmaVersion; } }
+// test(): const p = new P({ ecmaVersion: 13 }); return p.read();
+
+// E3 — getOptions-exact: default-copy + `in`-guard + ecmaVersion normalize (=13)
+const defaults: any = { ecmaVersion: 5, sourceType: "script" };
+function getOptions(opts: any): any { const options: any = {};
+  for (const opt in defaults) { options[opt] = (opts && opt in opts) ? opts[opt] : defaults[opt]; }
+  if (options.ecmaVersion >= 2015) { options.ecmaVersion -= 2009; } return options; }
+// test(): const o: any = getOptions({ ecmaVersion: 2022 }); return o.ecmaVersion;  // 13
+```
+
+The Acorn `Parser` constructor is class-based and combines `getOptions` (E3
+shape) with keyword/reserved-word table construction and prototype-method
+dispatch on `this` — the trigger is likely the **interaction** of the poisoned
+options/state object with a larger class + prototype-walk shape, not any single
+snippet above. Bisecting Acorn's own source (or the instrumented-throw-site
+approach) is the fastest route to the exact member access.
+
 ## Repro
 
 Deterministic, committed, one command (the #1710 dogfood harness):

--- a/tests/issue-2934-hasown-function-receiver-coerce.test.ts
+++ b/tests/issue-2934-hasown-function-receiver-coerce.test.ts
@@ -1,0 +1,46 @@
+// #2934 slice 2 — `<fn>.hasOwnProperty(k)` / `<fn>.propertyIsEnumerable(k)` on a
+// FUNCTION-valued receiver emitted invalid Wasm in standalone.
+//
+// Root cause: the `object-ops.ts` externref-receiver branch for
+// hasOwnProperty/propertyIsEnumerable pushed the receiver via `compileExpression`
+// WITHOUT coercing it — it assumed the STATIC type (externref) matched the
+// compiled value. But a builtin function value like `RegExp.prototype.test`
+// compiles to a concrete funcref-holder `struct` `(ref $N)`, so the
+// `__hasOwnProperty` / `__propertyIsEnumerable` helper (externref receiver) got a
+// bare GC ref → "call[0] expected type externref, found struct.new of (ref N)".
+//
+// Fix: coerce the receiver ref→externref (extern.convert_any), exactly as the key
+// argument already is. Flips 12 standalone test262 files invalid→valid
+// (RegExp.prototype.{exec,test,toString}.{hasOwnProperty,propertyIsEnumerable}),
+// no regressions.
+//
+// NOTE: this fixes the BINARY validity (#2934's invalid→valid acceptance). A
+// SEPARATE, pre-existing semantic gap remains — the standalone function-object
+// property model does not track a function's own `length`, so
+// `fn.hasOwnProperty("length")` currently answers `false` (should be `true`).
+// That is out of scope here (a valid module that runs beats an invalid binary
+// that cannot instantiate at all).
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileStandalone(src: string) {
+  return compile(src, { fileName: "t.ts", target: "standalone", skipSemanticDiagnostics: true });
+}
+
+describe("#2934 — hasOwnProperty/propertyIsEnumerable on a function receiver (standalone valid Wasm)", () => {
+  const cases: Record<string, string> = {
+    hasOwnProperty: `export function test(): number { return RegExp.prototype.test.hasOwnProperty("length") ? 1 : 0; }`,
+    propertyIsEnumerable: `export function test(): number { return RegExp.prototype.test.propertyIsEnumerable("length") ? 1 : 0; }`,
+    hasOwnProperty_toString: `export function test(): number { return RegExp.prototype.toString.hasOwnProperty("name") ? 1 : 0; }`,
+  };
+
+  for (const [name, src] of Object.entries(cases)) {
+    it(`compiles ${name} on a function receiver to valid standalone Wasm`, async () => {
+      const r = await compileStandalone(src);
+      expect(r.success).toBe(true);
+      // Previously rejected with "call[0] expected externref, found struct.new";
+      // must now be an engine-acceptable module.
+      await expect(WebAssembly.compile(r.binary)).resolves.toBeDefined();
+    });
+  }
+});


### PR DESCRIPTION
Shepherd rescue PR — lands three artifacts stranded by dead agents tonight:

1. **#2937 handoff appendix** (cherry-picked commit f11bc8b9, authorship preserved): the verbatim reduced-shape appendix for the dev-2937f handoff. Its original push to `issue-2927-interpreter-foundation` was rejected because it raced the 01:33:52Z auto-enqueue of PR #2449 (merge-queue branch lock); PR #2449 has since merged without it.
2. **plan/issues/2926-emit-wasm-sha-in-shard-jsonl.md**: complete backlog issue file (emit wasm_sha in CI shard JSONL) found untracked in the dead agent-a681b1c worktree (issue-2920). Never committed anywhere. Id 2926 is now claimed on the issue-assignments ref, and this PR passes the check:issue-ids:against-main gate (2926 not on main).
3. **tests/issue-2934-hasown-function-receiver-coerce.test.ts**: 46-line test from the superseded duplicate #2934 fix (agent-ab98a9d, commit 8510a8e3a). The src fix landed via PR #2448 in a more general form, but no test landed with it. Validated locally: 3/3 green against merged main.

Plan-and-test-only PR — no src changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS