### PR TITLE
feat(#2856): IR body-shape-rejected Step-1 diagnostic — opt-in reject-arm recorder

### DIFF
--- a/plan/issues/2856-ir-body-shape-rejected-to-zero.md
+++ b/plan/issues/2856-ir-body-shape-rejected-to-zero.md
@@ -80,16 +80,37 @@ kind:
    precisely scoped. If the histogram shows several independent kinds, split
    this issue into per-kind child issues (one PR each) rather than a single
    mega-PR.
-2. **Land the highest-count kind first** (likely `SwitchStatement` or a
-   loop-control kind — confirm from the histogram). Add the `from-ast.ts`
-   handler + selector acceptance + IR lowering, with legacy-parity equivalence
-   coverage.
+2. **Land the highest-count kind first.** Per the Step-1 histogram (below,
+   2026-07-02) the highest-count arm is **host-global member access in `const`
+   initializers** (`vardecl-init-expr:PropertyAccessExpression` 13 +
+   `CallExpression` 4 = **17/31, 55%**) — `document.*`/`window.*`/`Math.*`/
+   `performance.*` receivers not in scope. **This is the approved first slice
+   (2026-07-02).** Add IR selector + `from-ast.ts` handling for host-global
+   receivers (a resolver notion of host globals whose member access lowers to
+   the existing extern-member path), with legacy-parity equivalence coverage.
+   **Mutable-assignment is demoted to the SECOND slice** (the original heuristic
+   over-weighted it — the recorder shows **0** mutable-assignment rejections in
+   this corpus). NB: this slice may reveal that some host-global access is
+   legitimately out-of-IR-scope (no closed shape) — if so, split those into a
+   `deferred`-category note rather than forcing them native.
 3. **Re-run the gate after each slice** and bank the decrease:
    `pnpm run check:ir-fallbacks -- --update-on-decrease`, commit the lowered
-   `scripts/ir-fallback-baseline.json`.
+   `scripts/ir-fallback-baseline.json`. **Verify adopted functions actually take
+   the IR path** — re-run the `--shape-diag` recorder / `trackFallbacks` and
+   confirm the target functions leave the `body-shape-rejected` set, not merely
+   that tests stay green (the hazard is a silent legacy-fallback that keeps tests
+   green while the IR path is NOT exercised).
 4. When the bucket reaches **0**, add `"body-shape-rejected"` to
    `STRICT_IR_REASONS` (`src/codegen/index.ts:1013`) and promote the affected
    rows in `plan/log/ir-adoption.md` (`pnpm run gen:ir-adoption`).
+
+**Slice order (re-scoped 2026-07-02, PO/lead approved):**
+
+1. **Host-global member access in const initializers** (17/31) — FIRST.
+2. Mutable-assignment / element-assignment — SECOND (0 hits in this corpus, but
+   kept for the broader IR surface).
+3. `vardecl-typenode:ArrayType` (2), body/tail `if`-statement arms (4), the 4
+   `unattributed-arm` class-member helper internals — later, smaller slices.
 
 ## Step-1 diagnostic pass (2026-07-01, dev-b) — hypothesis CORRECTED
 

--- a/plan/issues/2856-ir-body-shape-rejected-to-zero.md
+++ b/plan/issues/2856-ir-body-shape-rejected-to-zero.md
@@ -139,6 +139,55 @@ committed — the exact instrumentation supersedes it). Routing: this epic needs
 `senior-developer` for the selector instrumentation + the mutable-assignment IR
 lowering.
 
+## Step-1 diagnostic DONE (2026-07-02, sr-funcidx) — heuristic OVERTURNED
+
+Implemented the opt-in reject-arm recorder (`shapeNo`/`takeShapeRejectDetail` in
+`src/ir/select.ts`, gated on `JS2WASM_IR_SHAPE_DIAG=1`, byte-inert when off) and a
+`--shape-diag` mode in `scripts/check-ir-fallbacks.ts`. Every instrumented
+`return false` in the Phase-1 shape gate (`isPhase1StatementList`,
+`isPhase1VarDecl`, `isPhase1Expr`, `isPhase1Tail`, `isPhase1BodyStatement`) records
+its `"<arm>:<NodeKind>"`; the FIRST (deepest) wins.
+
+Run: `JS2WASM_IR_SHAPE_DIAG=1 pnpm run check:ir-fallbacks -- --shape-diag`.
+
+**Exact histogram (31/31 attributed) — the "mutable assignment ~11 + 17
+unclassified" heuristic was WRONG:**
+
+| count | reject arm                                   | meaning                                                                                                                                                                  |
+| ----- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 13    | `vardecl-init-expr:PropertyAccessExpression` | `const x = <host-global>.<prop>` — receiver identifier not in scope (`document.*`, `window.*`, `Math.*`, DOM globals)                                                    |
+| 4     | `vardecl-init-expr:CallExpression`           | `const x = <host-global-or-method>(...)` — call receiver/callee not IR-claimable                                                                                         |
+| 4     | `unattributed-arm:helper-internal`           | class-member reject inside an as-yet-uninstrumented helper (`isPhase1ObjectLiteral`/`TryStatement`/`ClosureLiteral`/`ForStatement` internals) — Step-1b to sub-attribute |
+| 3     | `body-unhandled-stmt:IfStatement`            | `if` in a constructor/body-statement position (non-tail body list)                                                                                                       |
+| 2     | `vardecl-typenode:ArrayType`                 | `const x: number[] = …` — `isPhase1TypeNode` rejects the array annotation                                                                                                |
+| 2     | `nontail-callstmt:CallExpression`            | non-tail call statement whose call isn't IR-claimable                                                                                                                    |
+| 1     | `tail-unhandled:ExpressionStatement`         | non-void tail expression statement                                                                                                                                       |
+| 1     | `nontail-if-cond:BinaryExpression`           | `if` condition expr not Phase-1                                                                                                                                          |
+| 1     | `nontail-unhandled-stmt:IfStatement`         | `if`-with-`else` at a non-tail (non-early-return) position                                                                                                               |
+
+**Key finding — the corpus is DOM / benchmark code dominated by host-global
+member access (`document`/`window`/`Math`/`performance`), NOT the compiler-
+internal statement-kind gaps the issue originally hypothesised, and NOT
+mutable-assignment (0 hits).** So driving THIS corpus's `body-shape-rejected` to
+zero is mostly about **host-global member access in `const` initializers** (17 of
+31 = 55%), not a `from-ast.ts` statement handler. That is a very different (and
+larger / possibly out-of-IR-scope) problem than a kind-slice — it likely needs a
+resolver notion of host-global receivers, or the corpus/gate scope revisited.
+**Recommend PO/architect re-scope #2856 around this finding before any lowering
+slice.**
+
+**Verification:** the `check:ir-fallbacks` gate is byte-unchanged with the
+recorder off (`body-shape-rejected: 31`, "IR fallback gate: OK"); typecheck
+clean; behaviour-neutral (identical IR-test pass/fail counts with vs. without the
+instrumentation — the ~28 pre-existing `ir-*-equivalence` failures in this
+container are unrelated and present on the pristine base).
+
+### Remaining (Step-1b, small)
+
+Instrument the 4 `unattributed-arm` helper internals (`isPhase1ObjectLiteral`,
+`isPhase1TryStatement`, `isPhase1ClosureLiteral`, `isPhase1ForStatement`
+internals) for full sub-attribution of the class-member rejects.
+
 ## Acceptance criteria
 
 1. `body-shape-rejected` count in `scripts/ir-fallback-baseline.json` is `0`

--- a/scripts/check-ir-fallbacks.ts
+++ b/scripts/check-ir-fallbacks.ts
@@ -161,6 +161,9 @@ async function aggregate(): Promise<{
   deferred: Partial<Record<IrFallbackReason, number>>;
   postClaim: PostClaimBuckets;
   perFile: Array<{ file: string; reasons: Partial<Record<IrFallbackReason, number>> }>;
+  // (#2856 Step-1) Per-rejection reject-arm detail for `body-shape-rejected`,
+  // populated only when JS2WASM_IR_SHAPE_DIAG=1 (select.ts records it).
+  shapeDetails: Array<{ file: string; name: string; detail: string }>;
 }> {
   const corpus = CORPUS_ROOTS.flatMap(listTsFiles);
 
@@ -173,6 +176,7 @@ async function aggregate(): Promise<{
   // — they happen during build/verify/lower AFTER the selector claims).
   const postClaim = emptyPostClaim();
   const perFile: Array<{ file: string; reasons: Partial<Record<IrFallbackReason, number>> }> = [];
+  const shapeDetails: Array<{ file: string; name: string; detail: string }> = [];
 
   const compilerOptions: ts.CompilerOptions = {
     target: ts.ScriptTarget.ES2022,
@@ -227,6 +231,9 @@ async function aggregate(): Promise<{
       const bucket = UNINTENDED.has(fb.reason) ? unintended : deferred;
       bucket[fb.reason] = (bucket[fb.reason] ?? 0) + 1;
       fileReasons[fb.reason] = (fileReasons[fb.reason] ?? 0) + 1;
+      if (fb.reason === "body-shape-rejected" && fb.detail) {
+        shapeDetails.push({ file: relative(REPO_ROOT, filePath), name: fb.name, detail: fb.detail });
+      }
     }
     perFile.push({ file: relative(REPO_ROOT, filePath), reasons: fileReasons });
 
@@ -244,7 +251,7 @@ async function aggregate(): Promise<{
       // ignore — example-file compile failures are not the gate's concern
     }
   }
-  return { unintended, deferred, postClaim, perFile };
+  return { unintended, deferred, postClaim, perFile, shapeDetails };
 }
 
 function loadBaseline(): Baseline | undefined {
@@ -335,8 +342,38 @@ async function main(): Promise<void> {
         ? "json"
         : "gate";
   const verbose = args.has("--verbose");
+  const shapeDiag = args.has("--shape-diag");
 
-  const { unintended, deferred, postClaim, perFile } = await aggregate();
+  const { unintended, deferred, postClaim, perFile, shapeDetails } = await aggregate();
+
+  // (#2856 Step-1) `--shape-diag`: print the `body-shape-rejected` reject-arm
+  // histogram. Requires `JS2WASM_IR_SHAPE_DIAG=1` in the env (select.ts reads it
+  // at module load to enable the opt-in recorder). This attributes each of the
+  // rejected functions to its proximate `isPhase1*` reject arm + node kind.
+  if (shapeDiag) {
+    if (process.env.JS2WASM_IR_SHAPE_DIAG !== "1") {
+      process.stderr.write(
+        "--shape-diag requires JS2WASM_IR_SHAPE_DIAG=1 in the environment (the recorder is gated at module load).\n" +
+          "Re-run: JS2WASM_IR_SHAPE_DIAG=1 pnpm run check:ir-fallbacks -- --shape-diag\n",
+      );
+      process.exitCode = 2;
+      return;
+    }
+    const hist = new Map<string, number>();
+    for (const d of shapeDetails) hist.set(d.detail, (hist.get(d.detail) ?? 0) + 1);
+    const total = shapeDetails.length;
+    process.stdout.write(`\n=== body-shape-rejected reject-arm histogram (#2856 Step-1) ===\n`);
+    process.stdout.write(`  attributed: ${total} rejections\n\n`);
+    for (const [arm, n] of [...hist.entries()].sort((a, b) => b[1] - a[1])) {
+      process.stdout.write(`  ${String(n).padStart(4)}  ${arm}\n`);
+    }
+    process.stdout.write(`\n=== per-function ===\n`);
+    for (const d of shapeDetails.sort((a, b) => a.file.localeCompare(b.file))) {
+      process.stdout.write(`  ${d.file}  ${d.name}  →  ${d.detail}\n`);
+    }
+    process.stdout.write("\n");
+    return;
+  }
 
   if (mode === "json") {
     process.stdout.write(JSON.stringify({ unintended, deferred, postClaim, perFile }, null, 2) + "\n");

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -101,6 +101,44 @@ export type IrFallbackReason =
 export interface IrFallback {
   readonly name: string;
   readonly reason: IrFallbackReason;
+  /**
+   * (#2856 Step-1) Opt-in diagnostic detail for `body-shape-rejected` — the
+   * proximate reject arm + offending node kind (e.g. `stmt-assign-nonprop:
+   * BinaryExpression`). Populated only when `JS2WASM_IR_SHAPE_DIAG=1`; `undefined`
+   * on the normal path so the fallback record and the CI gate are byte-unchanged.
+   */
+  readonly detail?: string;
+}
+
+/**
+ * (#2856 Step-1) Opt-in reject-arm recorder for the `body-shape-rejected`
+ * bucket. The bucket's reason string ("body-shape-rejected") is uniform, so the
+ * 31 rejections cannot be attributed to a specific `isPhase1*` reject arm from
+ * the reason alone. When `JS2WASM_IR_SHAPE_DIAG=1`, every instrumented
+ * `return false` in the Phase-1 shape gate first calls {@link shapeNo}, which
+ * records a `"<arm>:<NodeKind>"` label. `whyNotIrClaimable` resets the recorder
+ * per function and, when it ultimately returns `body-shape-rejected`, exposes
+ * the FIRST recorded label (the proximate cause) via {@link takeShapeRejectDetail}.
+ *
+ * Behaviour is byte-identical when the env var is unset: `shapeNo` becomes a
+ * bare `return false`, the recorder stays null, and no `detail` is attached.
+ */
+const SHAPE_DIAG_ON = process.env.JS2WASM_IR_SHAPE_DIAG === "1";
+let shapeRejectDetail: string | null = null;
+
+/** Record the proximate reject arm (first-wins) and return false. */
+function shapeNo(arm: string, node: ts.Node): false {
+  if (SHAPE_DIAG_ON && shapeRejectDetail === null) {
+    shapeRejectDetail = `${arm}:${ts.SyntaxKind[node.kind]}`;
+  }
+  return false;
+}
+
+/** Read and clear the recorded reject detail (used by `planIrCompilation`). */
+function takeShapeRejectDetail(): string | undefined {
+  const d = shapeRejectDetail ?? undefined;
+  shapeRejectDetail = null;
+  return d;
 }
 
 /**
@@ -228,6 +266,18 @@ export function planIrCompilation(
   // log/throw on legacy fallback. Only populated when trackFallbacks is on.
   const trackFallbacks = options?.trackFallbacks === true;
   const fallbackReasons = new Map<string, IrFallbackReason>();
+  // (#2856 Step-1) Parallel to `fallbackReasons`: the opt-in reject-arm detail
+  // for `body-shape-rejected` entries (populated only when JS2WASM_IR_SHAPE_DIAG=1).
+  const fallbackDetails = new Map<string, string>();
+  const captureShapeDetail = (name: string, reason: IrFallbackReason): void => {
+    if (!SHAPE_DIAG_ON) return;
+    if (reason !== "body-shape-rejected") return;
+    // A `body-shape-rejected` that reached an as-yet-uninstrumented helper arm
+    // (e.g. inside `isPhase1ObjectLiteral` / `isPhase1TryStatement` /
+    // `isPhase1ClosureLiteral`) records nothing; label it `unattributed-arm`
+    // so the histogram still accounts for all rejections (completeness).
+    fallbackDetails.set(name, takeShapeRejectDetail() ?? "unattributed-arm:helper-internal");
+  };
   // Track unnamed FunctionDeclarations too (rare but possible — `default`
   // export of an anonymous function, etc.) so callers can see them.
   let unnamedCount = 0;
@@ -247,6 +297,7 @@ export function planIrCompilation(
       individuallyClaimed.add(stmt.name.text);
     } else if (trackFallbacks) {
       fallbackReasons.set(stmt.name.text, reason);
+      captureShapeDetail(stmt.name.text, reason);
     }
   }
 
@@ -339,6 +390,7 @@ export function planIrCompilation(
         individuallyClaimedClassMembers.add(memberName);
       } else if (trackFallbacks) {
         fallbackReasons.set(memberName, reason);
+        captureShapeDetail(memberName, reason);
       }
     }
   }
@@ -352,7 +404,7 @@ export function planIrCompilation(
       return { funcs: new Set<string>(), classMembers: individuallyClaimedClassMembers };
     }
     const fallbacks: IrFallback[] = [];
-    for (const [name, reason] of fallbackReasons) fallbacks.push({ name, reason });
+    for (const [name, reason] of fallbackReasons) fallbacks.push({ name, reason, detail: fallbackDetails.get(name) });
     for (let i = 0; i < unnamedCount; i++) fallbacks.push({ name: `<unnamed:${i}>`, reason: "unnamed" });
     if (individuallyClaimedClassMembers.size === 0) {
       return { funcs: new Set<string>(), fallbacks };
@@ -427,7 +479,7 @@ export function planIrCompilation(
   }
 
   const fallbacks: IrFallback[] = [];
-  for (const [name, reason] of fallbackReasons) fallbacks.push({ name, reason });
+  for (const [name, reason] of fallbackReasons) fallbacks.push({ name, reason, detail: fallbackDetails.get(name) });
   for (let i = 0; i < unnamedCount; i++) fallbacks.push({ name: `<unnamed:${i}>`, reason: "unnamed" });
   return classMembers ? { funcs: claimed, classMembers, fallbacks } : { funcs: claimed, fallbacks };
 }
@@ -510,6 +562,9 @@ function whyNotIrClaimable(
   localClasses: ReadonlySet<string>,
   isMethod: boolean = false,
 ): IrFallbackReason | null {
+  // (#2856 Step-1) Clear any stale reject detail from a prior subject; the body
+  // walk below repopulates it via `shapeNo` when SHAPE_DIAG_ON.
+  if (SHAPE_DIAG_ON) shapeRejectDetail = null;
   // Top-level FunctionDeclaration must be named; constructor declarations
   // never carry a `name`; a MethodDeclaration with an undefined / computed
   // name is rejected as a Phase-A method-shape failure.
@@ -763,12 +818,13 @@ function isPhase1StatementList(
   // (the lowerer synthesizes the implicit empty-values return).
   isVoidReturn: boolean = false,
 ): boolean {
-  if (stmts.length < 1) return false;
+  if (stmts.length < 1)
+    return shapeNo("stmt-list-empty", stmts.length ? stmts[0]! : ({ kind: ts.SyntaxKind.Block } as ts.Node));
   for (let i = 0; i < stmts.length - 1; i++) {
     const s = stmts[i]!;
     // Phase 1: VariableStatements before the tail.
     if (ts.isVariableStatement(s)) {
-      if (!isPhase1VarDecl(s, scope, localClasses)) return false;
+      if (!isPhase1VarDecl(s, scope, localClasses)) return shapeNo("nontail-vardecl", s);
       continue;
     }
     // Slice 3 (#1169c): nested function declaration. Treated like a
@@ -789,7 +845,7 @@ function isPhase1StatementList(
     // shape; if not, the function falls back to legacy.
     if (ts.isExpressionStatement(s)) {
       if (ts.isCallExpression(s.expression)) {
-        if (!isPhase1Expr(s.expression, scope, localClasses)) return false;
+        if (!isPhase1Expr(s.expression, scope, localClasses)) return shapeNo("nontail-callstmt", s.expression);
         continue;
       }
       // Slice 7a/7b (#1169f): `yield`/`yield <expr>`/`yield* <expr>` as a
@@ -813,11 +869,12 @@ function isPhase1StatementList(
       //                             gen.yieldStar(coerced_iterable).
       if (ts.isYieldExpression(s.expression)) {
         if (s.expression.expression) {
-          if (!isPhase1Expr(s.expression.expression, scope, localClasses)) return false;
+          if (!isPhase1Expr(s.expression.expression, scope, localClasses))
+            return shapeNo("nontail-yield-expr", s.expression);
         } else if (s.expression.asteriskToken) {
           // `yield*` MUST have an expression — TS parser enforces this,
           // but be defensive.
-          return false;
+          return shapeNo("nontail-yieldstar-noexpr", s.expression);
         }
         continue;
       }
@@ -827,21 +884,39 @@ function isPhase1StatementList(
         ts.isPropertyAccessExpression(s.expression.left)
       ) {
         // LHS: <expr>.<id> — receiver expr must be Phase-1, prop must be Identifier.
-        if (!ts.isIdentifier(s.expression.left.name)) return false;
-        if (!isPhase1Expr(s.expression.left.expression, scope, localClasses)) return false;
+        if (!ts.isIdentifier(s.expression.left.name)) return shapeNo("nontail-assign-computedprop", s.expression);
+        if (!isPhase1Expr(s.expression.left.expression, scope, localClasses))
+          return shapeNo("nontail-assign-recv", s.expression.left.expression);
         // RHS: any Phase-1 expression.
-        if (!isPhase1Expr(s.expression.right, scope, localClasses)) return false;
+        if (!isPhase1Expr(s.expression.right, scope, localClasses))
+          return shapeNo("nontail-assign-rhs", s.expression.right);
         continue;
       }
-      return false;
+      // (#2856) Catch-all for ExpressionStatements outside the accepted set:
+      // mutable local assignment `x = e` / element assignment `arr[i] = e`
+      // (LHS not a PropertyAccess), postfix/prefix `++`/`--`, compound
+      // assignment `+=`, etc. Label by the offending expression kind + operator
+      // so the histogram distinguishes assignment from inc-dec.
+      const es = s.expression;
+      let arm = "nontail-exprstmt-other";
+      if (ts.isBinaryExpression(es)) {
+        arm =
+          es.operatorToken.kind === ts.SyntaxKind.EqualsToken
+            ? "nontail-assign-nonprop-lhs"
+            : "nontail-compound-or-binary-stmt";
+      } else if (ts.isPrefixUnaryExpression(es) || ts.isPostfixUnaryExpression(es)) {
+        arm = "nontail-incdec-stmt";
+      }
+      return shapeNo(arm, es);
     }
     // Phase 2 extension: an `if (cond) <tail>` with NO else and the rest
     // of the statements forming a tail. This is the classic early-return
     // pattern: `if (base) return x; <recursive body>`. We structurally
     // reinterpret as `if (cond) <tail> else { <rest> }`.
     if (ts.isIfStatement(s) && !s.elseStatement) {
-      if (!isPhase1Expr(s.expression, scope, localClasses)) return false;
-      if (!isPhase1Tail(s.thenStatement, new Set(scope), localClasses, isGenerator, isVoidReturn)) return false;
+      if (!isPhase1Expr(s.expression, scope, localClasses)) return shapeNo("nontail-if-cond", s.expression);
+      if (!isPhase1Tail(s.thenStatement, new Set(scope), localClasses, isGenerator, isVoidReturn))
+        return shapeNo("nontail-if-then", s.thenStatement);
       const rest = stmts.slice(i + 1);
       return isPhase1StatementList(rest, new Set(scope), localClasses, isGenerator, isVoidReturn);
     }
@@ -851,18 +926,18 @@ function isPhase1StatementList(
     // the iterable's IR type resolves to a vec ref; non-vec iterables
     // throw and the function falls back to legacy.
     if (ts.isForOfStatement(s)) {
-      if (!isPhase1ForOf(s, scope, localClasses)) return false;
+      if (!isPhase1ForOf(s, scope, localClasses)) return shapeNo("nontail-forof", s);
       continue;
     }
     // Slice 12 (#1280) — `while` / `for` (C-style) as non-tail
     // statements. The body is shape-checked via `isPhase1BodyStatement`
     // (same restrictions as for-of).
     if (ts.isWhileStatement(s)) {
-      if (!isPhase1WhileStatement(s, scope, localClasses)) return false;
+      if (!isPhase1WhileStatement(s, scope, localClasses)) return shapeNo("nontail-while", s);
       continue;
     }
     if (ts.isForStatement(s)) {
-      if (!isPhase1ForStatement(s, scope, localClasses)) return false;
+      if (!isPhase1ForStatement(s, scope, localClasses)) return shapeNo("nontail-for", s);
       // Add init's let-declared names into outer scope so subsequent
       // statements can reference the loop counter (TypeScript would
       // narrow scope to the for-statement, but our scope tracker is
@@ -880,14 +955,17 @@ function isPhase1StatementList(
     // implicit unreachable. (Code AFTER a throw in the same block is
     // dead but structurally valid.)
     if (ts.isThrowStatement(s)) {
-      if (!isPhase1ThrowStatement(s, scope, localClasses)) return false;
+      if (!isPhase1ThrowStatement(s, scope, localClasses)) return shapeNo("nontail-throw", s);
       continue;
     }
     if (ts.isTryStatement(s)) {
-      if (!isPhase1TryStatement(s, scope, localClasses)) return false;
+      if (!isPhase1TryStatement(s, scope, localClasses)) return shapeNo("nontail-try", s);
       continue;
     }
-    return false;
+    // (#2856) Unhandled statement KIND at non-tail position — `if`-with-`else`,
+    // `switch`, `do`, labeled, `break`/`continue`, `for-in`, empty, etc. The
+    // node kind is the discriminator.
+    return shapeNo("nontail-unhandled-stmt", s);
   }
   return isPhase1Tail(stmts[stmts.length - 1]!, scope, localClasses, isGenerator, isVoidReturn);
 }
@@ -1185,7 +1263,7 @@ function isPhase1BodyStatement(stmt: ts.Statement, scope: Set<string>, localClas
         return ts.isIdentifier(stmt.expression.operand) && scope.has(stmt.expression.operand.text);
       }
     }
-    return false;
+    return shapeNo("body-exprstmt-other", stmt.expression);
   }
   if (ts.isForOfStatement(stmt)) {
     return isPhase1ForOf(stmt, scope, localClasses);
@@ -1214,7 +1292,7 @@ function isPhase1BodyStatement(stmt: ts.Statement, scope: Set<string>, localClas
   if (ts.isTryStatement(stmt)) {
     return isPhase1TryStatement(stmt, scope, localClasses);
   }
-  return false;
+  return shapeNo("body-unhandled-stmt", stmt);
 }
 
 function isPhase1Tail(
@@ -1232,14 +1310,14 @@ function isPhase1Tail(
     //
     // Slice 14 (#1228): bare `return;` is also allowed in void-returning
     // functions. The lowerer's void branch terminates with empty values.
-    if (!stmt.expression) return isGenerator || isVoidReturn;
+    if (!stmt.expression) return isGenerator || isVoidReturn ? true : shapeNo("tail-bare-return-nonvoid", stmt);
     return isPhase1Expr(stmt.expression, scope, localClasses);
   }
   if (ts.isBlock(stmt)) {
     return isPhase1StatementList(stmt.statements, new Set(scope), localClasses, isGenerator, isVoidReturn);
   }
   if (ts.isIfStatement(stmt)) {
-    if (!stmt.elseStatement) return false;
+    if (!stmt.elseStatement) return shapeNo("tail-if-noelse", stmt);
     if (!isPhase1Expr(stmt.expression, scope, localClasses)) return false;
     if (!isPhase1Tail(stmt.thenStatement, new Set(scope), localClasses, isGenerator, isVoidReturn)) return false;
     if (!isPhase1Tail(stmt.elseStatement, new Set(scope), localClasses, isGenerator, isVoidReturn)) return false;
@@ -1258,13 +1336,13 @@ function isPhase1Tail(
   if (isVoidReturn && ts.isExpressionStatement(stmt)) {
     return isPhase1Expr(stmt.expression, scope, localClasses);
   }
-  return false;
+  return shapeNo("tail-unhandled", stmt);
 }
 
 function isPhase1VarDecl(stmt: ts.VariableStatement, scope: Set<string>, localClasses: ReadonlySet<string>): boolean {
   const flags = stmt.declarationList.flags;
-  if (!(flags & ts.NodeFlags.Let) && !(flags & ts.NodeFlags.Const)) return false;
-  if (stmt.modifiers && stmt.modifiers.length > 0) return false;
+  if (!(flags & ts.NodeFlags.Let) && !(flags & ts.NodeFlags.Const)) return shapeNo("vardecl-var-kind", stmt);
+  if (stmt.modifiers && stmt.modifiers.length > 0) return shapeNo("vardecl-modifier", stmt);
   const isConst = !!(flags & ts.NodeFlags.Const);
   for (const d of stmt.declarationList.declarations) {
     // Slice 8a (#1169g): destructuring binding patterns for `const`-bound
@@ -1274,39 +1352,40 @@ function isPhase1VarDecl(stmt: ts.VariableStatement, scope: Set<string>, localCl
     // rest. Anything wider (rest, defaults, nested patterns) defers to
     // slice 8.5+ — the legacy `destructuring.ts` path remains for those.
     if (ts.isObjectBindingPattern(d.name) || ts.isArrayBindingPattern(d.name)) {
-      if (!isConst) return false;
-      if (!d.initializer) return false;
-      if (!isPhase1BindingPattern(d.name, scope)) return false;
+      if (!isConst) return shapeNo("vardecl-dstr-let", d.name);
+      if (!d.initializer) return shapeNo("vardecl-dstr-noinit", d.name);
+      if (!isPhase1BindingPattern(d.name, scope)) return shapeNo("vardecl-dstr-pattern", d.name);
       // Initializer must be Phase-1 expressible. The lowerer inspects
       // its IrType to decide between object.get (object pattern) and
       // vec.get (array pattern); if the resolved IrType isn't compatible
       // with the pattern shape, lowering throws and the function falls
       // back to legacy.
-      if (!isPhase1Expr(d.initializer, scope, localClasses)) return false;
+      if (!isPhase1Expr(d.initializer, scope, localClasses)) return shapeNo("vardecl-dstr-init", d.initializer);
       // Pre-add every leaf identifier to scope so subsequent statements
       // see the new names.
       collectPatternNames(d.name, scope);
       continue;
     }
-    if (!ts.isIdentifier(d.name)) return false;
-    if (scope.has(d.name.text)) return false;
-    if (!d.initializer) return false;
+    if (!ts.isIdentifier(d.name)) return shapeNo("vardecl-nonident-name", d.name);
+    if (scope.has(d.name.text)) return shapeNo("vardecl-shadow", d.name);
+    if (!d.initializer) return shapeNo("vardecl-noinit", d);
     // Slice 3 (#1169c): closure-literal initializer. Only accepted for
     // `const` (no `let` arrow rebinding in slice 3). The closure
     // shape-check enforces the slice-3 surface (every param + return
     // annotated, body is a Phase-1 tail, no generator/async/named).
     if (ts.isArrowFunction(d.initializer) || ts.isFunctionExpression(d.initializer)) {
-      if (!isConst) return false;
+      if (!isConst) return shapeNo("vardecl-let-closure", d.initializer);
       // Permit an explicit closure type annotation (like `: (n: number) => number`)
       // — it's a shape-only signal, not a primitive type. Since the IR doesn't
       // syntactically check the annotation against the body, just accept any
       // annotation (the lowerer enforces semantic match).
-      if (!isPhase1ClosureLiteral(d.initializer, scope, localClasses)) return false;
+      if (!isPhase1ClosureLiteral(d.initializer, scope, localClasses))
+        return shapeNo("vardecl-closure-init", d.initializer);
       scope.add(d.name.text);
       continue;
     }
-    if (d.type && !isPhase1TypeNode(d.type)) return false;
-    if (!isPhase1Expr(d.initializer, scope, localClasses)) return false;
+    if (d.type && !isPhase1TypeNode(d.type)) return shapeNo("vardecl-typenode", d.type);
+    if (!isPhase1Expr(d.initializer, scope, localClasses)) return shapeNo("vardecl-init-expr", d.initializer);
     scope.add(d.name.text);
   }
   return true;
@@ -1603,11 +1682,13 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
     return scope.has("this");
   }
   if (ts.isPrefixUnaryExpression(expr)) {
-    if (!isPhase1PrefixOp(expr.operator)) return false;
+    if (!isPhase1PrefixOp(expr.operator))
+      return shapeNo(`expr-prefix-op-${ts.tokenToString(expr.operator) ?? expr.operator}`, expr);
     return isPhase1Expr(expr.operand, scope, localClasses);
   }
   if (ts.isBinaryExpression(expr)) {
-    if (!isPhase1BinaryOp(expr.operatorToken.kind)) return false;
+    if (!isPhase1BinaryOp(expr.operatorToken.kind))
+      return shapeNo(`expr-binary-op-${ts.tokenToString(expr.operatorToken.kind) ?? expr.operatorToken.kind}`, expr);
     return isPhase1Expr(expr.left, scope, localClasses) && isPhase1Expr(expr.right, scope, localClasses);
   }
   if (ts.isConditionalExpression(expr)) {
@@ -1758,10 +1839,10 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
     // loop's cond/body blocks — distinct from the working forof.vec path). When
     // this function contains such a loop, withhold the claim so the whole
     // function reverts to the (correct) legacy path, as it did pre-#1804.
-    if (currentFnHasCStyleLoop) return false;
+    if (currentFnHasCStyleLoop) return shapeNo("expr-arraylit-cloop-guard-1804", expr);
     for (const el of expr.elements) {
-      if (ts.isSpreadElement(el)) return false; // out of scope
-      if (ts.isOmittedExpression(el)) return false; // sparse — out of scope
+      if (ts.isSpreadElement(el)) return shapeNo("expr-arraylit-spread", el); // out of scope
+      if (ts.isOmittedExpression(el)) return shapeNo("expr-arraylit-sparse", expr); // sparse — out of scope
       if (!isPhase1Expr(el, scope, localClasses)) return false;
     }
     return true;
@@ -1781,7 +1862,9 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
   if (ts.isVoidExpression(expr)) {
     return isPhase1Expr(expr.expression, scope, localClasses);
   }
-  return false;
+  // (#2856) Unhandled expression KIND — closures (Arrow/FunctionExpression),
+  // await, spread outside the accepted sites, etc. The node kind discriminates.
+  return shapeNo("expr-unhandled", expr);
 }
 
 /**


### PR DESCRIPTION
## What

Step-1 of #2856 (drive the `body-shape-rejected` IR fallback bucket to zero). Implements the opt-in **reject-arm recorder** the issue's Step-1 calls for, and produces the exact per-arm histogram.

- `src/ir/select.ts`: `shapeNo(arm, node)` / `takeShapeRejectDetail()`, gated on `JS2WASM_IR_SHAPE_DIAG=1`, threaded through the `return false` sites of `isPhase1StatementList`, `isPhase1VarDecl`, `isPhase1Expr`, `isPhase1Tail`, `isPhase1BodyStatement` (first/deepest wins). Adds an optional `detail` field to `IrFallback`.
- `scripts/check-ir-fallbacks.ts`: `--shape-diag` mode prints a `<arm>:<NodeKind>` histogram + per-function attribution.

Run: `JS2WASM_IR_SHAPE_DIAG=1 pnpm run check:ir-fallbacks -- --shape-diag`

## Finding — the prior heuristic is OVERTURNED

31/31 attributed. Dominant cause is **host-global member access in `const` initializers** (`vardecl-init-expr:PropertyAccessExpression` 13 + `CallExpression` 4 = **17/31**) — `document.*`/`window.*`/`Math.*`/`performance.*` receivers not in scope. **NOT** mutable-assignment (0 hits) and NOT statement-kind gaps. The example corpus is DOM/benchmark code, so driving THIS corpus's bucket to zero is a host-global-receiver problem, not a `from-ast.ts` statement handler. Full histogram + re-scope recommendation recorded in `plan/issues/2856-ir-body-shape-rejected-to-zero.md` (acceptance criterion 2).

## Safety

- **Byte-inert when the env var is off**: the gate still reports `body-shape-rejected: 31`, "IR fallback gate: OK" — no baseline change.
- Behaviour-neutral: identical IR-test pass/fail counts with vs. without the instrumentation (the ~28 pre-existing `ir-*-equivalence` failures in-container are unrelated, present on the pristine base).
- Typecheck clean. No `from-ast.ts` / lowering change — this is diagnosis only; the kind-slice work follows once the PO/architect re-scopes around the host-global finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8