### PR TITLE
fix(#2942): promote-baseline push race — Option-A re-anchor + superseded-drop guard (rebase loop exhausted deterministically)

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -1612,33 +1612,81 @@ jobs:
             echo "No baseline changes to push."
           else
             git commit -m "chore(test262): refresh baselines — ${PASS}/${TOTAL} host, ${STANDALONE_PASS}/${STANDALONE_TOTAL} standalone (${{ github.sha }})"
-            # The baselines repo can advance under us when two promote-baseline
-            # runs (from concurrent main pushes) race. Retry with
-            # fetch + rebase so the refreshed baseline lands on top of the
-            # concurrent run instead of being dropped (#1861). The clone is
-            # shallow (--depth=1); --unshallow on first fetch so the rebase has
-            # a merge base.
+            # (#2942, supersedes the #1861 fetch+rebase loop) Two promote-baseline
+            # runs racing on the baselines repo both REWRITE the same generated
+            # files (test262-current.jsonl etc.), so once the remote advances,
+            # `git rebase` hits the SAME content conflict on every retry and the
+            # loop exhausts deterministically (run 28554922430 stranded the
+            # baseline pre-#2873; every later PR then diffed a stale floor →
+            # phantom regressions, bot park-holds on innocent PRs). Generated
+            # files must never be line-merged — RE-ANCHOR instead (Option-A,
+            # the same pattern as the main-repo summary push below): snapshot
+            # the files THIS run promoted, hard-reset onto the fresh remote
+            # tip, re-apply the snapshot wholesale, re-commit, push. Latest
+            # wins, with an ordering guard: if the remote tip already promotes
+            # a main SHA that DESCENDS from ours, our promote is superseded —
+            # drop it and succeed. Do NOT "fix" this with a job-level
+            # concurrency group instead: the per-SHA push groups are
+            # load-bearing (#2178, header comment) and a shared group's single
+            # pending slot silently cancels intermediate promotes.
             BR=$(git rev-parse --abbrev-ref HEAD)
-            BASELINE_PUSHED=0
-            for attempt in 1 2 3 4 5; do
-              git fetch --unshallow origin "$BR" 2>/dev/null \
-                || git fetch origin "$BR"
-              if ! git rebase --autostash "origin/$BR"; then
-                git rebase --abort || true
-                echo "baselines rebase failed (attempt ${attempt}) — retrying"
-                sleep $((attempt * 5))
-                continue
+            OUR_COMMIT=$(git rev-parse HEAD)
+            MSG=$(git log -1 --format=%s)
+            SNAP=$(mktemp -d)
+            git diff-tree --no-commit-id --name-only -r "$OUR_COMMIT" | while IFS= read -r f; do
+              if [ -f "$f" ]; then
+                mkdir -p "$SNAP/$(dirname "$f")"
+                cp "$f" "$SNAP/$f"
               fi
+            done
+            # Deepen MAIN-repo history once so the ancestry guard can resolve
+            # ancestor checks (the workspace checkout is depth-1).
+            git -C "$GITHUB_WORKSPACE" fetch --depth=200 --filter=blob:none origin main 2>/dev/null || true
+            BASELINE_PUSHED=0
+            for attempt in 1 2 3 4 5 6 7 8; do
               if git push origin "HEAD:$BR"; then
                 echo "Pushed baselines (attempt ${attempt})."
                 BASELINE_PUSHED=1
                 break
               fi
-              echo "baselines push race lost (attempt ${attempt}) — refetching and retrying"
-              sleep $((attempt * 5))
+              echo "baselines push race lost (attempt ${attempt}) — re-anchoring on the fresh remote tip"
+              git fetch origin "$BR" || { sleep 5; continue; }
+              # Ordering guard: baseline commit subjects end with the promoted
+              # main SHA (the same convention the #1668 stale guard parses).
+              # If OUR sha is an ancestor of the remote tip's promoted sha, a
+              # newer promote already landed — ours is superseded. Fail-open
+              # (proceed with the overwrite) when either sha is unresolvable.
+              REMOTE_MSHA=$(git log -1 --format=%s "origin/$BR" | grep -oE '[0-9a-f]{7,40}' | tail -1 || true)
+              if [ -n "$REMOTE_MSHA" ] \
+                && git -C "$GITHUB_WORKSPACE" cat-file -e "${REMOTE_MSHA}^{commit}" 2>/dev/null \
+                && git -C "$GITHUB_WORKSPACE" merge-base --is-ancestor "${{ github.sha }}" "$REMOTE_MSHA" 2>/dev/null; then
+                echo "Remote baseline already promotes ${REMOTE_MSHA} (descendant of ${{ github.sha }}) — this promote is superseded; dropping."
+                BASELINE_PUSHED=1
+                break
+              fi
+              git checkout -f -B "$BR" "origin/$BR"
+              (cd "$SNAP" && find . -type f | sed 's|^\./||') | while IFS= read -r f; do
+                mkdir -p "$(dirname "$f")"
+                cp "$SNAP/$f" "$f"
+              done
+              git add -A
+              if git diff --cached --quiet; then
+                echo "Re-anchored tree is identical to the remote tip — nothing left to promote."
+                BASELINE_PUSHED=1
+                break
+              fi
+              git commit -m "$MSG"
+              SLEEP=$((attempt * 5)); [ "$SLEEP" -gt 30 ] && SLEEP=30
+              sleep "$SLEEP"
             done
             if [ "$BASELINE_PUSHED" != "1" ]; then
-              echo "::error::Failed to push baselines after 5 attempts (persistent, not a transient race)."
+              echo "::error::Failed to push baselines after 8 re-anchor attempts (persistent failure, not a transient race). The promoted baseline is STRANDED at the previous main SHA — every subsequent PR's regression gate diffs a stale floor (phantom regressions / park-holds) until a later push:main promote succeeds or this workflow is re-run via workflow_dispatch. See #2942."
+              {
+                echo "## promote-baseline FAILED (#2942)"
+                echo ""
+                echo "Baselines push exhausted 8 re-anchor attempts; baseline stranded pre-\`${{ github.sha }}\`."
+                echo "PR regression gates will show phantom drift until the next successful promote."
+              } >> "$GITHUB_STEP_SUMMARY"
               exit 1
             fi
           fi

--- a/plan/issues/2942-promote-baseline-push-race-reanchor.md
+++ b/plan/issues/2942-promote-baseline-push-race-reanchor.md
@@ -1,0 +1,73 @@
+---
+id: 2942
+title: "ci: promote-baseline push race — rebase-conflict exhaustion strands the baseline and manufactures phantom regressions on every subsequent PR"
+status: done
+completed: 2026-07-02
+assignee: ttraenkler/dev-f2
+created: 2026-07-02
+updated: 2026-07-02
+priority: medium
+sprint: current
+horizon: m
+task_type: bug
+area: ci
+goal: developer-experience
+related: [1861, 2178, 1668]
+origin: "2026-07-02 tech-lead task #15 from the #2873 promote failure (run 28554922430, job 84660851424)."
+---
+
+# #2942 — promote-baseline push loop: fetch+rebase deterministically exhausts on generated-file conflicts
+
+## Problem
+
+Concrete instance 2026-07-02: #2873's `promote-baseline` job (run 28554922430,
+job 84660851424) exhausted all 5 rebase-retry attempts pushing to
+`loopdive/js2wasm-baselines`, leaving the promoted baseline stranded at
+`d12fc59b7` (pre-#2873).
+
+Root cause: two promote-baseline runs racing on the baselines repo both
+REWRITE the same generated files (`test262-current.jsonl` etc.). Once the
+remote advances, `git rebase --autostash origin/$BR` (the #1861 loop) hits the
+**same content conflict on every retry** — generated files cannot be
+line-merged — so the loop exhausts deterministically, not transiently. The
+sleep/backoff never helps.
+
+Effect: every subsequent PR's regression gate diffs against the stale
+baseline → phantom wasm-hash-changed regressions (e.g. #2424's net −2, proven
+drift by the shepherd) → bot park-holds on innocent PRs. The failure is only
+discovered indirectly (a parked PR's drift analysis); the #1668 stale guard
+fires only at ≥50 relevant commits behind.
+
+## Fix (this issue)
+
+Replace the fetch+rebase loop in the baselines-repo push with the **Option-A
+re-anchor** pattern already used by the main-repo summary push (#1861 follow-up):
+
+1. Snapshot the files THIS run promoted (from the promote commit's
+   `diff-tree`) before the loop.
+2. On a lost push race: fetch, **hard-reset onto the fresh remote tip**
+   (`git checkout -f -B`), re-apply the snapshot wholesale, `git add -A`,
+   re-commit. Generated files are replaced, never line-merged → no conflict is
+   possible.
+3. **Ordering guard (latest-wins)**: baseline commit subjects embed the
+   promoted main SHA (the same convention the #1668 stale guard parses). If
+   OUR `github.sha` is an **ancestor** of the remote tip's promoted SHA, a
+   newer promote already landed — ours is superseded; drop it and succeed.
+   (Main-repo history is deepened `--depth=200 --filter=blob:none` for the
+   ancestry check; fail-open to overwrite if either SHA is unresolvable.)
+4. Retry budget 5 → 8 with capped backoff; empty re-anchored diff = converged,
+   success.
+5. Louder stranding signal: final failure writes a `GITHUB_STEP_SUMMARY`
+   block + `::error` explaining the stale-floor consequence and the
+   `workflow_dispatch` re-run remedy.
+
+Explicitly NOT done: a job-level `concurrency` group on `promote-baseline` —
+the per-SHA push groups are load-bearing (#2178): a shared group's single
+pending slot silently cancels the intermediate run's promote, which is the
+exact failure mode #2178 fixed. See the workflow header comment.
+
+## Test plan
+
+Workflow-only change (the push loop is push:main-scoped); validated by shell
+syntax review + the next push:main promote. The re-anchor pattern is the same
+one the adjacent main-repo push step has used successfully since #1861.


### PR DESCRIPTION
Fixes the stranded-baseline failure from run 28554922430 (task #15): #2873's promote-baseline job exhausted all 5 rebase retries pushing to `loopdive/js2wasm-baselines`, leaving the baseline at d12fc59b7 — every later PR diffed a stale floor (phantom wasm-hash regressions, bot park-holds on innocent PRs, e.g. #2424's proven-drift net −2).

## Root cause
The #1861 fetch+rebase retry loop cannot succeed when two promotes race: both commits REWRITE the same generated files (`test262-current.jsonl` etc.), so `git rebase` hits the identical content conflict on every attempt — the exhaustion is deterministic, not transient. Sleep/backoff never helps.

## Fix (in the baselines-repo push step)
- **Option-A re-anchor** (the same pattern the adjacent main-repo summary push has used since #1861): snapshot the files THIS run promoted (from the promote commit's diff-tree), and on a lost race hard-reset onto the fresh remote tip, re-apply the snapshot wholesale, re-commit. Generated files are replaced, never line-merged — no conflict possible.
- **Superseded-drop ordering guard (latest-wins)**: baseline commit subjects embed the promoted main SHA (the convention the #1668 stale guard parses). If OUR `github.sha` is an ancestor of the remote tip's promoted SHA, a newer promote already landed — drop ours and succeed. Fail-open to overwrite when either SHA is unresolvable (main history deepened `--depth=200 --filter=blob:none` for the check).
- Retries 5 → 8 with capped backoff; converged (empty re-anchored diff) = success.
- Louder stranding signal: final failure writes a `GITHUB_STEP_SUMMARY` block + `::error` naming the stale-floor consequence and the workflow_dispatch remedy.

**Deliberately NOT a job-level `concurrency` group** — the per-SHA push groups are load-bearing (#2178): a shared group's single pending slot silently cancels intermediate promotes, the exact failure #2178 fixed. Comment added in the workflow to prevent that regression.

## Validation
- YAML lints clean.
- Two-clone bare-repo race simulation exercises the exact loop body in both directions: (1) newer-SHA promote loses the push race → re-anchors onto the winner's tip → lands its content on top; (2) older-SHA promote loses to an already-landed newer promote → ancestry guard detects supersession → drops cleanly, newer content preserved.

Issue file `plan/issues/2942-promote-baseline-push-race-reanchor.md` rides this PR with `status: done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8