### PR TITLE
fix(#2896): standalone native function-object metadata — runtime name/length + descriptor reads

### DIFF
--- a/plan/issues/2896-standalone-native-function-object-metadata-descriptors.md
+++ b/plan/issues/2896-standalone-native-function-object-metadata-descriptors.md
@@ -1,7 +1,9 @@
 ---
 id: 2896
 title: "Standalone: native function-object metadata + property descriptors (.name/.length, getOwnPropertyDescriptor) — blocks builtin static-method value-read cluster"
-status: ready
+status: done
+completed: 2026-07-02
+assignee: ttraenkler/dev-f1
 created: 2026-06-30
 priority: medium
 feasibility: hard
@@ -34,15 +36,15 @@ do **not** carry faithful function-object metadata:
 This is true **even for already-wired methods** (verified against the control
 `Array.isArray`, which has a registered static closure):
 
-| read (standalone)                                    | result |
-| ---------------------------------------------------- | ------ |
-| `typeof Array.isArray === "function"`                | ✅ 1   |
-| value-call `let f = Array.isArray; f([1,2])`         | ✅ 1   |
-| `new (Array.isArray)()` throws (not-a-constructor)   | ✅ 1   |
-| `Array.isArray.name === "isArray"`                   | ❌ 0   |
-| `Array.isArray.length === 1`                         | ❌ 0   |
-| `[[1],2].filter(Array.isArray)` (pass as callback)   | ❌ 0   |
-| `getOwnPropertyDescriptor(Array.isArray,"name")`     | ❌ 0   |
+| read (standalone)                                  | result |
+| -------------------------------------------------- | ------ |
+| `typeof Array.isArray === "function"`              | ✅ 1   |
+| value-call `let f = Array.isArray; f([1,2])`       | ✅ 1   |
+| `new (Array.isArray)()` throws (not-a-constructor) | ✅ 1   |
+| `Array.isArray.name === "isArray"`                 | ❌ 0   |
+| `Array.isArray.length === 1`                       | ❌ 0   |
+| `[[1],2].filter(Array.isArray)` (pass as callback) | ❌ 0   |
+| `getOwnPropertyDescriptor(Array.isArray,"name")`   | ❌ 0   |
 
 ## Why it matters
 
@@ -54,7 +56,7 @@ native closures expose no descriptor-visible `name`/`length` property, those
 tests fail (or CE) regardless of any direct-access meta-fold.
 
 This is the substrate blocker behind the **builtin static-method value-read
-cluster** (#2861 residual / #2863 Phase 1): direct *calls* of builtin static
+cluster** (#2861 residual / #2863 Phase 1): direct _calls_ of builtin static
 methods already work host-free (`Number.isInteger(5)`, `ArrayBuffer.isView(...)`),
 and bare value-reads can be wired per-method — but per-method wiring flips only
 the `not-a-constructor.js`-style test each, while `name.js`/`length.js`/
@@ -100,7 +102,7 @@ per-builtin value-read wiring in #2861/#2863:
 
 - `Object.getOwnPropertyDescriptor(fn, "name")` / `(fn, "length")` over a native
   builtin function value returns the spec value + `{writable:false,
-  enumerable:false, configurable:true}`.
+enumerable:false, configurable:true}`.
 - test262 `built-ins/**/{name,length,prop-desc}.js` flip to **pass** host-free
   for the wired builtin functions (and unblock the #2861/#2863 static-method
   value-read cluster once individual methods are wired).
@@ -157,23 +159,23 @@ those flips only `not-a-constructor.js` until this lands).
 
 Direct probes (`.tmp/mech*.mts`, host-free unless noted):
 
-| read (standalone)                                       | today | want |
-| ------------------------------------------------------- | ----- | ---- |
-| `typeof Array.isArray === "function"`                   | ✅    | ✅   |
-| `Array.isArray.name === "isArray"` (direct)             | ✅    | ✅   |
-| `Array.isArray.length === 1` (direct)                   | ❌ 0  | ✅   |
-| `String.prototype.charAt.name/.length` (direct)         | ✅    | ✅   |
-| `Object.getOwnPropertyDescriptor(fn,"name").value`      | ❌ und | ✅   |
-| `Object.getOwnPropertyDescriptor(fn,"length").value`    | ❌ und | ✅   |
-| `fn["name"]` dynamic (computed key)                     | ❌ **leaks host import** | ✅ host-free |
-| `Object.prototype.hasOwnProperty.call(fn,"name")`       | ❌ 0  | ✅   |
-| `Object.getOwnPropertyNames(fn)` includes name/length   | ❌    | ✅   |
-| `[[1],2].filter(Array.isArray)` (callback)              | ❌ 0  | ✅   |
+| read (standalone)                                     | today                    | want         |
+| ----------------------------------------------------- | ------------------------ | ------------ |
+| `typeof Array.isArray === "function"`                 | ✅                       | ✅           |
+| `Array.isArray.name === "isArray"` (direct)           | ✅                       | ✅           |
+| `Array.isArray.length === 1` (direct)                 | ❌ 0                     | ✅           |
+| `String.prototype.charAt.name/.length` (direct)       | ✅                       | ✅           |
+| `Object.getOwnPropertyDescriptor(fn,"name").value`    | ❌ und                   | ✅           |
+| `Object.getOwnPropertyDescriptor(fn,"length").value`  | ❌ und                   | ✅           |
+| `fn["name"]` dynamic (computed key)                   | ❌ **leaks host import** | ✅ host-free |
+| `Object.prototype.hasOwnProperty.call(fn,"name")`     | ❌ 0                     | ✅           |
+| `Object.getOwnPropertyNames(fn)` includes name/length | ❌                       | ✅           |
+| `[[1],2].filter(Array.isArray)` (callback)            | ❌ 0                     | ✅           |
 
 **Root cause (two distinct gaps):**
 
-1. **No metadata on the value.** A native function value is a *closure wrapper
-   struct* (`getOrCreateFuncRefWrapperTypes` → field 0 = the funcref;
+1. **No metadata on the value.** A native function value is a _closure wrapper
+   struct_ (`getOrCreateFuncRefWrapperTypes` → field 0 = the funcref;
    `makeBuiltinClosureFctx` builds the static/proto builtin closures). It carries
    **no name/length**. The `.length` direct read in
    `src/codegen/dyn-read.ts` (`closureBaseWrapperTypeIdxs`, the closure arm of
@@ -229,7 +231,7 @@ shared user-closure wrapper struct. Two viable shapes (pick at build time;
   registration never shifts it — see `reference_subview_type_idx_stability` /
   `project_type_index_shift_and_deadelim`. User closures and gc mode are
   untouched → gc bytes stable.
-  - *Cost:* the value is no longer the bare funcref-wrapper the call sites expect;
+  - _Cost:_ the value is no longer the bare funcref-wrapper the call sites expect;
     `call_ref` and callback-dispatch must read `$BuiltinFn.$fn` before the indirect
     call. This is the `filter(Array.isArray)` fix too (see gap 1/callback below).
 
@@ -276,7 +278,7 @@ the carrier shape before the broad reflective work:
 4. **Slice 4 — callback dispatch + destructive `verifyProperty`.** Ensure
    passing a `$BuiltinFn` value where a callback funcref is expected reads
    `$BuiltinFn.$fn` (fixes `filter(Array.isArray) → 0`). `verifyProperty` is
-   *destructive* (it `delete`s the configurable prop then redefines): name/length
+   _destructive_ (it `delete`s the configurable prop then redefines): name/length
    are `configurable:true`, so `delete fn.name` / `Object.defineProperty(fn,…)`
    on a `$BuiltinFn` must at least not trap. Decide scope: a faithful mutable
    own-property table on function values is a large extension — if too big, gate
@@ -323,3 +325,59 @@ the carrier shape before the broad reflective work:
   `__hasOwnProperty`; new `$BuiltinFn` type reservation alongside the other
   shared standalone runtime types.
 - `src/codegen/closures.ts` — `getOrCreateFuncRefWrapperTypes` (only if Option B).
+
+---
+
+## Implementation (dev-f1, 2026-07-02 — PR)
+
+Shipped a variant of the spec's Option B that avoids BOTH hazards the spec
+flagged (no shared-wrapper widening, no early type-index reservation needed):
+
+- **Per-(builtin, member) meta SUBTYPE** (`builtin-fn-meta.ts`
+  `ensureBuiltinFnMetaType`): each builtin closure value gets a unique struct
+  subtype of its signature wrapper — `{funcref func; (mut i32) bfnstate}`.
+  Subtyping keeps every call path untouched (static closure call, reflective
+  `.call`, any-typed callback dispatch all cast to the sig wrapper/root).
+  `name`/`length` are NOT fields — they are compile-time constants keyed by the
+  meta type index (`ctx.builtinFnMetaByTypeIdx`); `bfnstate` is a per-instance
+  deleted-bits mask (bit0 name / bit1 length) so `verifyProperty`'s destructive
+  `isConfigurable` (`delete fn.name` → `!hasOwnProperty`) genuinely works.
+- **Reserve/fill reflective natives** (`object-runtime.ts`):
+  `__builtinfn_get_meta` / `__builtinfn_gopd` / `__builtinfn_delete` /
+  `__builtinfn_push_ownnames` registered with constant default bodies
+  (standalone-gated; gc bytes untouched); `ref.test <metaType>` arms SPLICED at
+  finalize by `fillBuiltinFnMeta` (index.ts, next to `fillExternGetIdxVecArms`)
+  — same discipline as `fillExternIsArray`, so compile-order can't freeze an
+  incomplete type list. Eager arms in `__extern_get`, `__hasOwnProperty` /
+  `__object_hasOwn`, `__getOwnPropertyDescriptor`, `__getOwnPropertyNames`,
+  `__delete_property` call the reserved helpers (funcIdx baked at registration
+  → shift-invariant preserved).
+- **dyn-read `.length` closure arm** now consults `__builtinfn_get_meta`
+  (standalone) instead of flat `box_number(0)`; null → 0 (matches
+  `Function.prototype.length` after delete).
+- **Direct-read meta fold generalized**: `BUILTIN_STATIC_METHOD_ARITY` (spec
+  arities of every standard builtin static method, host-generated) folds
+  `<Builtin>.<staticMethod>.length/.name` — subsumes the wired-closure-only
+  path and answers methods whose VALUE-read is not yet wired (the dominant
+  corpus shape after the runner's `verifyProperty` transform).
+
+### Test Results (A/B vs branch base d0bfaa7d6, standalone, real runner)
+
+| corpus                                                        | base               | patched            | delta                                                                                                                |
+| ------------------------------------------------------------- | ------------------ | ------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| mechanism probes (13)                                         | 5 pass             | 12 pass            | +7 (13th is the pre-existing `hasOwnProperty.call` invalid-wasm bug, unchanged — separate issue)                     |
+| `built-ins/**/{name,length,prop-desc}.js` sample (184/1836)   | 99 pass / 31 fail  | 109 pass / 21 fail | **+10 flips, 0 regressions** (≈ +100 extrapolated)                                                                   |
+| direct-reflective corpus (281 files with gOPD-on-fn reads)    | 53 pass / 225 fail | 66 pass / 212 fail | **+13 flips, 0 regressions** (accessor-getter name tests: `gOPD(RegExp.prototype,"dotAll").get.name` → "get dotAll") |
+| `tests/issue-2896.test.ts` (new, 11 tests)                    | —                  | 11 pass            | host-free asserted (zero env imports)                                                                                |
+| related suites (2885/2876/2923/2193/2861/2580/2175, 69 tests) | —                  | all pass           | no regression                                                                                                        |
+
+**Honest-scope note (measure-first):** the spec's ≈250–360 "directly
+addressable" estimate assumed test262's `propertyHelper.js` runs verbatim; this
+repo's runner TRANSFORMS `verifyProperty(obj, k, {value: X})` into a direct
+`assert_sameValue(obj[k], X)` read and strips attribute checks
+(`tests/test262-runner.ts:1333`). So the reflective descriptor substrate is
+exercised by the corpus mainly via dynamic receivers (accessor `.get`
+extraction, harness-loop receivers), and the DIRECT-read fold is the bigger
+corpus lever today. The substrate is in place for when the runner shim is
+retired. The `Object.prototype.hasOwnProperty.call(fn, k)` invalid-wasm CE
+(`call[0] expected type externref`) is pre-existing on base and unrelated.

--- a/src/codegen/builtin-fn-meta.ts
+++ b/src/codegen/builtin-fn-meta.ts
@@ -53,6 +53,130 @@ export const STANDALONE_STATIC_METHOD_META: Record<string, { name: string; lengt
 };
 
 /**
+ * (#2896) Spec arity of every standard builtin STATIC method (own
+ * function-valued data properties of the global constructors/namespaces), for
+ * the direct-access `<Builtin>.<method>.length` / `.name` meta fold. `.name`
+ * equals the property key for all of these (§10.2.9); `.length` values are the
+ * ECMA-262 declared arities (generated from a conforming host — V8/Node — and
+ * spot-checked against the spec). This is a compile-time COMPANION of the
+ * runtime metadata substrate above: the fold answers direct syntactic reads
+ * (no closure materialization, so it also covers methods whose value-read is
+ * not yet wired host-free); the meta subtypes answer reflective/runtime reads
+ * for the wired closures.
+ */
+export const BUILTIN_STATIC_METHOD_ARITY: Record<string, Record<string, number>> = {
+  Array: { isArray: 1, from: 1, fromAsync: 1, of: 0 },
+  ArrayBuffer: { isView: 1 },
+  BigInt: { asUintN: 2, asIntN: 2 },
+  Date: { now: 0, parse: 1, UTC: 7 },
+  Error: { isError: 1 },
+  Map: { groupBy: 2 },
+  Number: { isFinite: 1, isInteger: 1, isNaN: 1, isSafeInteger: 1, parseFloat: 1, parseInt: 2 },
+  Object: {
+    assign: 2,
+    getOwnPropertyDescriptor: 2,
+    getOwnPropertyDescriptors: 1,
+    getOwnPropertyNames: 1,
+    getOwnPropertySymbols: 1,
+    hasOwn: 2,
+    is: 2,
+    preventExtensions: 1,
+    seal: 1,
+    create: 2,
+    defineProperties: 2,
+    defineProperty: 3,
+    freeze: 1,
+    getPrototypeOf: 1,
+    setPrototypeOf: 2,
+    isExtensible: 1,
+    isFrozen: 1,
+    isSealed: 1,
+    keys: 1,
+    entries: 1,
+    fromEntries: 1,
+    values: 1,
+    groupBy: 2,
+  },
+  Promise: { all: 1, allSettled: 1, any: 1, race: 1, resolve: 1, reject: 1, withResolvers: 0, try: 1 },
+  Proxy: { revocable: 2 },
+  Reflect: {
+    defineProperty: 3,
+    deleteProperty: 2,
+    apply: 3,
+    construct: 2,
+    get: 2,
+    getOwnPropertyDescriptor: 2,
+    getPrototypeOf: 1,
+    has: 2,
+    isExtensible: 1,
+    ownKeys: 1,
+    preventExtensions: 1,
+    set: 3,
+    setPrototypeOf: 2,
+  },
+  RegExp: { escape: 1 },
+  String: { fromCharCode: 1, fromCodePoint: 1, raw: 1 },
+  Symbol: { for: 1, keyFor: 1 },
+  Math: {
+    abs: 1,
+    acos: 1,
+    acosh: 1,
+    asin: 1,
+    asinh: 1,
+    atan: 1,
+    atanh: 1,
+    atan2: 2,
+    ceil: 1,
+    cbrt: 1,
+    expm1: 1,
+    clz32: 1,
+    cos: 1,
+    cosh: 1,
+    exp: 1,
+    floor: 1,
+    fround: 1,
+    hypot: 2,
+    imul: 2,
+    log: 1,
+    log1p: 1,
+    log2: 1,
+    log10: 1,
+    max: 2,
+    min: 2,
+    pow: 2,
+    random: 0,
+    round: 1,
+    sign: 1,
+    sin: 1,
+    sinh: 1,
+    sqrt: 1,
+    tan: 1,
+    tanh: 1,
+    trunc: 1,
+    f16round: 1,
+  },
+  JSON: { parse: 2, stringify: 3, rawJSON: 1, isRawJSON: 1 },
+  Atomics: {
+    load: 2,
+    store: 3,
+    add: 3,
+    sub: 3,
+    and: 3,
+    or: 3,
+    xor: 3,
+    exchange: 3,
+    compareExchange: 4,
+    isLockFree: 1,
+    wait: 4,
+    waitAsync: 4,
+    notify: 3,
+    pause: 0,
+  },
+  Iterator: { from: 1 },
+  Uint8Array: { fromBase64: 1, fromHex: 1 },
+};
+
+/**
  * Register (idempotently, keyed by `cacheKey`) the unique metadata-carrying
  * struct subtype for one builtin function closure and return its type index.
  *

--- a/src/codegen/builtin-fn-meta.ts
+++ b/src/codegen/builtin-fn-meta.ts
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * (#2896) Standalone native function-object metadata.
+ *
+ * A builtin function value under `--target standalone` is a closure wrapper
+ * struct (`getOrCreateFuncRefWrapperTypes`); it carries no `name`/`length`, so
+ * every REFLECTIVE read (`Object.getOwnPropertyDescriptor(fn, "name")`,
+ * `fn[key]` with a runtime key, `hasOwnProperty`, `getOwnPropertyNames`) sees
+ * nothing — which fails test262's `propertyHelper.js verifyProperty` for every
+ * builtin `name.js` / `length.js` / `prop-desc.js` even where a compile-time
+ * direct-access meta fold exists (the helper's receiver/key are runtime params).
+ *
+ * ## Mechanism — per-(builtin, member) meta SUBTYPE, constant metadata per type
+ *
+ * For each distinct builtin function we materialize, register a UNIQUE struct
+ * subtype of its signature wrapper:
+ *
+ *   `$__builtinfn_<n> { funcref func; (mut i32) bfnstate }  <: $__fn_wrap_<sig>`
+ *
+ * - Being a SUBTYPE of the signature wrapper keeps every existing call path
+ *   working untouched (static closure calls, reflective `.call`, any-typed
+ *   callback dispatch — they cast to the sig wrapper / root, and a subtype
+ *   passes).
+ * - The metadata itself ({name, length}) is statically known per (builtin,
+ *   member), so it is NOT stored in fields — it lives in
+ *   `ctx.builtinFnMetaByTypeIdx` keyed by the meta type index. The reflective
+ *   runtime natives discriminate the receiver with `ref.test <metaType>` arms
+ *   (type indices are rec-group/dead-elim stable — no funcidx hazard) that are
+ *   SPLICED IN AT FINALIZE by `fillBuiltinFnMeta` (object-runtime.ts), after
+ *   every meta type is known — same reserve/fill discipline as
+ *   `fillExternIsArray` / `fillExternGetIdxVecArms`.
+ * - `bfnstate` is the one piece of per-INSTANCE state: a deleted-bits mask
+ *   (bit 0 = `name` deleted, bit 1 = `length` deleted). `verifyProperty`'s
+ *   `isConfigurable` arm `delete`s the property and then requires
+ *   `hasOwnProperty` to report false, so delete must genuinely work.
+ *   `struct.new` sites therefore push an extra `i32.const 0`
+ *   (`pushBuiltinFnClosureValueInstrs` below).
+ */
+import type { Instr } from "../ir/types.js";
+import type { ClosureInfo, CodegenContext } from "./context/types.js";
+
+/**
+ * Spec `{name, length}` for the builtin STATIC method closures wired in
+ * `ensureStandaloneBuiltinStaticMethodClosure` (property-access.ts). Keep in
+ * sync with its `switch (key)`. Also consumed by the direct-access
+ * `.name`/`.length` meta fold so the constant fold and the runtime descriptor
+ * agree.
+ */
+export const STANDALONE_STATIC_METHOD_META: Record<string, { name: string; length: number }> = {
+  "Array.isArray": { name: "isArray", length: 1 },
+  "Object.keys": { name: "keys", length: 1 },
+  "Object.getOwnPropertyDescriptor": { name: "getOwnPropertyDescriptor", length: 2 },
+};
+
+/**
+ * Register (idempotently, keyed by `cacheKey`) the unique metadata-carrying
+ * struct subtype for one builtin function closure and return its type index.
+ *
+ * - `baseStructTypeIdx` — the signature wrapper struct (the supertype).
+ * - `baseClosureInfo` — the signature wrapper's ClosureInfo; a copy with
+ *   `structTypeIdx` re-pointed at the meta type is registered in
+ *   `ctx.closureInfoByTypeIdx` so the static closure-call path and the
+ *   reflective `.call` recovery resolve the meta-typed value exactly like the
+ *   base wrapper (the lifted func type takes `(ref $sigWrapper)` self — a meta
+ *   instance passes as a subtype).
+ */
+export function ensureBuiltinFnMetaType(
+  ctx: CodegenContext,
+  baseStructTypeIdx: number,
+  baseClosureInfo: ClosureInfo,
+  cacheKey: string,
+  name: string,
+  length: number,
+): number {
+  if (!ctx.builtinFnMetaTypeByKey) ctx.builtinFnMetaTypeByKey = new Map();
+  const existing = ctx.builtinFnMetaTypeByKey.get(cacheKey);
+  if (existing !== undefined) return existing;
+
+  const typeIdx = ctx.mod.types.length;
+  ctx.mod.types.push({
+    kind: "struct",
+    name: `__builtinfn_meta_${typeIdx}_struct`,
+    fields: [
+      // Field 0 must mirror the supertype exactly (same type + mutability).
+      { name: "func", type: { kind: "funcref" as const }, mutable: false },
+      // Deleted-bits mask: bit 0 = "name" deleted, bit 1 = "length" deleted.
+      { name: "bfnstate", type: { kind: "i32" as const }, mutable: true },
+    ],
+    superTypeIdx: baseStructTypeIdx,
+  });
+
+  ctx.closureInfoByTypeIdx.set(typeIdx, { ...baseClosureInfo, structTypeIdx: typeIdx });
+  if (!ctx.builtinFnMetaByTypeIdx) ctx.builtinFnMetaByTypeIdx = new Map();
+  ctx.builtinFnMetaByTypeIdx.set(typeIdx, { name, length });
+  ctx.builtinFnMetaTypeByKey.set(cacheKey, typeIdx);
+  return typeIdx;
+}
+
+/** Bit set in `bfnstate` when the `name` own property was deleted. */
+export const BFN_STATE_NAME_DELETED = 1;
+/** Bit set in `bfnstate` when the `length` own property was deleted. */
+export const BFN_STATE_LENGTH_DELETED = 2;
+
+/**
+ * The instruction sequence that materializes a builtin closure VALUE from a
+ * factory result. A meta-typed closure struct has the extra `(mut i32)
+ * bfnstate` field, so its `struct.new` needs one more operand than the plain
+ * 2-op `ref.func` + `struct.new` sequence; non-meta types keep the old shape.
+ */
+export function pushBuiltinFnClosureValueInstrs(
+  ctx: CodegenContext,
+  closure: { type: { kind: "ref"; typeIdx: number }; funcIdx: number },
+): Instr[] {
+  const isMeta = ctx.builtinFnMetaByTypeIdx?.has(closure.type.typeIdx) ?? false;
+  const instrs: Instr[] = [{ op: "ref.func", funcIdx: closure.funcIdx } as Instr];
+  if (isMeta) instrs.push({ op: "i32.const", value: 0 } as Instr);
+  instrs.push({ op: "struct.new", typeIdx: closure.type.typeIdx } as Instr);
+  return instrs;
+}

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1825,6 +1825,19 @@ export interface CodegenContext {
    *  member name (e.g. `RegExp.prototype.test.length === 1`,
    *  `.name === "test"`). Populated by `ensureStandaloneNativeMethodClosure`. */
   nativeClosureMeta?: Map<number, { name: string; length: number }>;
+  /** (#2896) Struct-type index → static `{name, length}` metadata for builtin
+   *  function-closure values under `--target standalone`. Each (builtin, member)
+   *  closure gets a UNIQUE wrapper-struct SUBTYPE (fields `[funcref func,
+   *  (mut i32) bfnstate]`, supertype = its signature wrapper struct), so the
+   *  reflective runtime natives (`__getOwnPropertyDescriptor` / `__extern_get` /
+   *  `__hasOwnProperty` / `__getOwnPropertyNames` / `__delete_property`) can
+   *  `ref.test` the value at RUNTIME and answer its spec `name`/`length` own
+   *  properties. Populated by `ensureBuiltinFnMetaType` (builtin-fn-meta.ts);
+   *  consumed by `fillBuiltinFnMeta` (object-runtime.ts) at finalize. */
+  builtinFnMetaByTypeIdx?: Map<number, { name: string; length: number }>;
+  /** (#2896) Cache: `(builtin, member)` key → the meta struct-type index above.
+   *  Keeps `ensureBuiltinFnMetaType` idempotent per closure identity. */
+  builtinFnMetaTypeByKey?: Map<string, number>;
   /** (#2193 PR-B) Struct-type indices of `$NativeProto` member closures whose
    *  FIRST user param is the receiver (`this`) — e.g. `Array.prototype.slice`'s
    *  `(self, this, start, end)` closure. Unlike a plain user function (which

--- a/src/codegen/dyn-read.ts
+++ b/src/codegen/dyn-read.ts
@@ -252,6 +252,17 @@ export function emitDynGet(ctx: CodegenContext, fctx: FunctionContext, keyName: 
   if (keyName === "length") {
     ensureLateImport(ctx, "__box_number", [{ kind: "f64" }], [{ kind: "externref" }]);
     ensureLateImport(ctx, "__extern_is_undefined", [{ kind: "externref" }], [{ kind: "i32" }]);
+    // (#2896) Builtin-fn metadata read for the closure arm (standalone only):
+    // a builtin function value's `.length` is its spec arity, answered by the
+    // finalize-filled `__builtinfn_get_meta` native instead of the flat 0.
+    if (ctx.standalone) {
+      ensureLateImport(
+        ctx,
+        "__builtinfn_get_meta",
+        [{ kind: "externref" }, { kind: "externref" }],
+        [{ kind: "externref" }],
+      );
+    }
   }
   addStringConstantGlobal(ctx, keyName);
   flushLateImportShifts(ctx, fctx);
@@ -288,6 +299,31 @@ export function emitDynGet(ctx: CodegenContext, fctx: FunctionContext, keyName: 
     // no funcidx hazard). Closure base types are derived inline from
     // `ctx.closureInfoByTypeIdx` (walking each to its root struct) to avoid a
     // circular import on index.ts's private `collectClosureBaseWrapperTypeIdxs`.
+    // (#2896) Standalone: a builtin function value carries its spec arity in
+    // the finalize-filled `__builtinfn_get_meta` native — ask it first; a null
+    // result (plain user closure, or a builtin fn whose `length` was deleted →
+    // inherited Function.prototype.length === 0) keeps the prior flat 0.
+    const bfnGetMetaIdx = ctx.standalone ? ctx.funcMap.get("__builtinfn_get_meta") : undefined;
+    const closureArmThen = (): Instr[] => {
+      if (bfnGetMetaIdx === undefined) {
+        // arity fallback: box_number(0.0) — matches the prior numeric path.
+        return [{ op: "f64.const", value: 0 } as Instr, { op: "call", funcIdx: boxNumIdx } as Instr];
+      }
+      const metaTmp = allocLocal(fctx, `__dg_bfnmeta_${fctx.locals.length}`, { kind: "externref" });
+      return [
+        { op: "local.get", index: recvTmp } as Instr,
+        ...stringConstantExternrefInstrs(ctx, keyName),
+        { op: "call", funcIdx: bfnGetMetaIdx } as Instr,
+        { op: "local.tee", index: metaTmp } as Instr,
+        { op: "ref.is_null" } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "val", type: { kind: "externref" } as ValType },
+          then: [{ op: "f64.const", value: 0 } as Instr, { op: "call", funcIdx: boxNumIdx } as Instr],
+          else: [{ op: "local.get", index: metaTmp } as Instr],
+        } as Instr,
+      ];
+    };
     for (const closureBaseTypeIdx of closureBaseWrapperTypeIdxs(ctx)) {
       chain = [
         { op: "local.get", index: anyTmp } as Instr,
@@ -295,11 +331,7 @@ export function emitDynGet(ctx: CodegenContext, fctx: FunctionContext, keyName: 
         {
           op: "if",
           blockType: { kind: "val", type: { kind: "externref" } as ValType },
-          then: [
-            // arity fallback: box_number(0.0) — matches the prior numeric path.
-            { op: "f64.const", value: 0 } as Instr,
-            { op: "call", funcIdx: boxNumIdx } as Instr,
-          ],
+          then: closureArmThen(),
           else: chain,
         } as Instr,
       ];

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -137,6 +137,7 @@ import {
   ensureStandaloneNativeMethodClosure,
   getNativeProtoBuiltinGlue,
 } from "../native-proto.js";
+import { pushBuiltinFnClosureValueInstrs } from "../builtin-fn-meta.js";
 import { compileStatement, hoistFunctionDeclarations } from "../statements.js";
 import {
   emitSetExtrasArgv,
@@ -7303,8 +7304,7 @@ function compileCallExpression(
               );
               flushLateImportShifts(ctx, fctx);
               if (createAccIdx !== undefined) {
-                fctx.body.push({ op: "ref.func", funcIdx: protoClosure.funcIdx } as Instr);
-                fctx.body.push({ op: "struct.new", typeIdx: protoClosure.type.typeIdx } as Instr);
+                fctx.body.push(...pushBuiltinFnClosureValueInstrs(ctx, protoClosure));
                 fctx.body.push({ op: "extern.convert_any" } as Instr); // get
                 fctx.body.push({ op: "ref.null.extern" } as Instr); // set = undefined
                 fctx.body.push({ op: "i32.const", value: 0x04 } as Instr); // FLAG_CONFIGURABLE
@@ -7322,8 +7322,7 @@ function compileCallExpression(
               );
               flushLateImportShifts(ctx, fctx);
               if (createIdx !== undefined) {
-                fctx.body.push({ op: "ref.func", funcIdx: protoClosure.funcIdx } as Instr);
-                fctx.body.push({ op: "struct.new", typeIdx: protoClosure.type.typeIdx } as Instr);
+                fctx.body.push(...pushBuiltinFnClosureValueInstrs(ctx, protoClosure));
                 fctx.body.push({ op: "extern.convert_any" } as Instr); // value
                 fctx.body.push({ op: "i32.const", value: 0x05 } as Instr); // FLAG_WRITABLE | FLAG_CONFIGURABLE
                 fctx.body.push({ op: "call", funcIdx: createIdx } as Instr);

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -52,7 +52,13 @@ import { fillMemberGetDispatch } from "./member-get-dispatch.js";
 import { emitUndefined, ensureGetUndefined, reconcileNativeStrFinalizeShift } from "./expressions/late-imports.js";
 import { fillProtoIteratorDriver } from "./expressions/proto-override.js";
 import { fillAccessorDrivers } from "./accessor-driver.js";
-import { fillApplyClosure, fillExternGetIdxVecArms, fillExternIsArray, fillProxyDispatch } from "./object-runtime.js";
+import {
+  fillApplyClosure,
+  fillBuiltinFnMeta,
+  fillExternGetIdxVecArms,
+  fillExternIsArray,
+  fillProxyDispatch,
+} from "./object-runtime.js";
 import { fillArrayToPrimitive } from "./array-to-primitive.js";
 import { fillClassToPrimitive } from "./class-to-primitive.js";
 import {
@@ -1905,6 +1911,16 @@ export function generateModule(
     // `.length` fix, so `(arr as any)[i]` through the externref boundary reads
     // the element instead of null/0. Standalone only (no-op otherwise).
     fillExternGetIdxVecArms(ctx);
+
+    // (#2896) Fill the reserved builtin-fn metadata natives
+    // (`__builtinfn_get_meta` / `__builtinfn_gopd` / `__builtinfn_delete` /
+    // `__builtinfn_push_ownnames`) now that every builtin closure meta type
+    // (builtin-fn-meta.ts) is registered — the reflective
+    // `Object.getOwnPropertyDescriptor(fn, "name")` / `fn[key]` /
+    // `hasOwnProperty` / `getOwnPropertyNames` reads over a builtin function
+    // value resolve its spec `name`/`length` at runtime, host-free. No-op when
+    // no builtin closure was materialized (standalone only).
+    fillBuiltinFnMeta(ctx);
 
     // (#2358 #10) Fill the reserved `__array_to_primitive_string` body now that
     // `__extern_length`/`__extern_get_idx` (filled just above) and the native

--- a/src/codegen/native-proto.ts
+++ b/src/codegen/native-proto.ts
@@ -33,6 +33,7 @@
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { getOrCreateFuncRefWrapperTypes } from "./closures.js";
+import { ensureBuiltinFnMetaType } from "./builtin-fn-meta.js";
 import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { emitWasiErrorConstructor } from "./registry/error-types.js";
@@ -451,16 +452,38 @@ export function ensureStandaloneNativeMethodClosure(
     ctx.nativeClosureMeta.set(funcIdx, { name: accessorName, length: arity });
   }
 
+  // (#2896) The value struct is the UNIQUE per-(brand, member) metadata subtype
+  // of the signature wrapper, so the reflective runtime natives
+  // (`__getOwnPropertyDescriptor` / `__extern_get` / `__hasOwnProperty` /
+  // `__getOwnPropertyNames`) can `ref.test` the value and answer its spec
+  // `name`/`length` own properties at RUNTIME (test262 propertyHelper reads
+  // them through runtime params — a compile-time fold cannot satisfy it). All
+  // call paths are unaffected: the meta type subtypes the wrapper the lifted
+  // func expects. Getters carry the §10.2.9 accessor spelling ("get <key>").
+  const metaName = kind === "getter" ? `get ${member}` : member;
+  const metaTypeIdx = ensureBuiltinFnMetaType(
+    ctx,
+    wrapperTypes.structTypeIdx,
+    wrapperTypes.closureInfo,
+    `proto:${brand}:${kind}:${member}`,
+    metaName,
+    arity,
+  );
+
   // (#2193 PR-B) A `"method"` closure's first user param is the receiver
   // (`this`); record its struct type so a reflective `m.call(thisArg, …args)`
   // threads `thisArg` into param 1 instead of dropping it (the plain-function
   // `.call` default). Getters carry no user-visible receiver-arg semantics here.
+  // Both the base wrapper AND the meta subtype are recorded — call sites key
+  // this set by the ClosureInfo's structTypeIdx, which is the meta type for
+  // values produced by this factory.
   if (kind === "method") {
     if (!ctx.nativeProtoReceiverClosureStructTypes) ctx.nativeProtoReceiverClosureStructTypes = new Set();
     ctx.nativeProtoReceiverClosureStructTypes.add(wrapperTypes.structTypeIdx);
+    ctx.nativeProtoReceiverClosureStructTypes.add(metaTypeIdx);
   }
 
-  return { type: { kind: "ref", typeIdx: wrapperTypes.structTypeIdx }, funcIdx };
+  return { type: { kind: "ref", typeIdx: metaTypeIdx }, funcIdx };
 }
 
 /**

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -448,6 +448,79 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
   const strFlattenIdx = ctx.nativeStrHelpers.get("__str_flatten")!;
   const strEqualsIdx = ctx.nativeStrHelpers.get("__str_equals")!;
 
+  // ── (#2896) Reserved builtin-fn metadata natives (standalone only) ────────
+  //
+  // Builtin function values (the per-(builtin, member) closure meta subtypes —
+  // see builtin-fn-meta.ts) answer their spec `name`/`length` own properties at
+  // RUNTIME through these four helpers. They are REGISTERED here with valid
+  // constant default bodies (so a module with no builtin closures is
+  // unaffected), and their `ref.test <metaType>` arms are SPLICED IN AT
+  // FINALIZE by `fillBuiltinFnMeta` once every meta type is known — the same
+  // reserve/fill discipline as `__extern_is_array` above. The reflective
+  // consumers below (`__extern_get` / `__hasOwnProperty` /
+  // `__getOwnPropertyDescriptor` / `__getOwnPropertyNames` /
+  // `__delete_property`) bake eager `call`s to these funcIdxs at their own
+  // registration, keeping the late-import shift invariant intact.
+  //
+  //   __builtinfn_get_meta(v, key)  -> externref   name string / boxed length,
+  //                                                 null when not a builtin fn,
+  //                                                 not "name"/"length", or the
+  //                                                 property was deleted.
+  //   __builtinfn_gopd(v, key)      -> externref   full data descriptor
+  //                                                 ({writable:false,
+  //                                                 enumerable:false,
+  //                                                 configurable:true}) or null.
+  //   __builtinfn_delete(v, key)    -> i32          1 = handled (deleted-bit
+  //                                                 set on the instance).
+  //   __builtinfn_push_ownnames(v, vec) -> i32      1 = v is a builtin fn (its
+  //                                                 undeleted own names were
+  //                                                 pushed into vec).
+  //
+  // Gated on ctx.standalone: in gc/host mode this runtime is also pulled in
+  // (Object.keys etc.) but builtin function values are host objects there — the
+  // host imports own their metadata, and registering these would only shift
+  // funcMap indices (gc bytes must stay unchanged).
+  const bfnMetaLocals = [
+    { name: "any", type: { kind: "anyref" } as ValType },
+    { name: "fkey", type: { kind: "ref_null", typeIdx: nativeStrTypeIdx } as ValType },
+    { name: "isName", type: { kind: "i32" } as ValType },
+    { name: "isLen", type: { kind: "i32" } as ValType },
+  ];
+  if (ctx.standalone) {
+    registerNative(
+      "__builtinfn_get_meta",
+      [{ kind: "externref" }, { kind: "externref" }],
+      [{ kind: "externref" }],
+      bfnMetaLocals,
+      [{ op: "ref.null.extern" } as Instr],
+    );
+    registerNative(
+      "__builtinfn_gopd",
+      [{ kind: "externref" }, { kind: "externref" }],
+      [{ kind: "externref" }],
+      [{ name: "v", type: { kind: "externref" } as ValType }],
+      [{ op: "ref.null.extern" } as Instr],
+    );
+    registerNative(
+      "__builtinfn_delete",
+      [{ kind: "externref" }, { kind: "externref" }],
+      [{ kind: "i32" }],
+      bfnMetaLocals,
+      [{ op: "i32.const", value: 0 } as Instr],
+    );
+    registerNative(
+      "__builtinfn_push_ownnames",
+      [{ kind: "externref" }, { kind: "externref" }],
+      [{ kind: "i32" }],
+      [{ name: "any", type: { kind: "anyref" } as ValType }],
+      [{ op: "i32.const", value: 0 } as Instr],
+    );
+  }
+  const bfnGetMetaIdx = ctx.standalone ? ctx.funcMap.get("__builtinfn_get_meta") : undefined;
+  const bfnGopdIdx = ctx.standalone ? ctx.funcMap.get("__builtinfn_gopd") : undefined;
+  const bfnDeleteIdx = ctx.standalone ? ctx.funcMap.get("__builtinfn_delete") : undefined;
+  const bfnPushOwnNamesIdx = ctx.standalone ? ctx.funcMap.get("__builtinfn_push_ownnames") : undefined;
+
   // #2042 R2 — held reference to `__to_property_key`'s body so the object-key
   // arm can be spliced in after `__extern_toString` is registered later in this
   // pass (forward dependency; see the splice below the `__extern_toString` reg).
@@ -950,6 +1023,24 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     // keeps the late-import shifter in sync (#329/#1899).
     const callAccessorGetIdx = reserveAccessorGetDriver(ctx);
     const body: Instr[] = [
+      // (#2896) Builtin-fn metadata arm: `fn[key]` for key "name"/"length" on a
+      // builtin function value answers its spec metadata (host-free). Non-meta
+      // receivers/keys fall through unchanged (the helper returns null).
+      ...(bfnGetMetaIdx !== undefined
+        ? ([
+            { op: "local.get", index: 0 },
+            { op: "local.get", index: 1 },
+            { op: "call", funcIdx: bfnGetMetaIdx },
+            { op: "local.tee", index: 6 },
+            { op: "ref.is_null" },
+            { op: "i32.eqz" },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [{ op: "local.get", index: 6 }, { op: "return" }],
+            },
+          ] as Instr[])
+        : []),
       // any = any.convert_extern(obj)
       { op: "local.get", index: 0 },
       { op: "any.convert_extern" },
@@ -1054,6 +1145,7 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
         { name: "e", type: entryRefNull },
         { name: "any", type: { kind: "anyref" } },
         { name: "getter", type: { kind: "externref" } }, // (#1888 S5b) accessor $get
+        { name: "bfmeta", type: { kind: "externref" } }, // (#2896) builtin-fn meta
       ],
       body,
     );
@@ -1771,6 +1863,22 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
   // locals: 2=any(anyref) 3=o(ref null $Object) 4=e(ref null $PropEntry)
   {
     const body: Instr[] = [
+      // (#2896) Builtin-fn metadata arm: `delete fn.name` / `delete fn.length`
+      // on a builtin function value marks the instance's deleted bit (the
+      // properties are configurable, §10.2.9) and reports success. Other
+      // receivers/keys fall through (the helper returns 0).
+      ...(bfnDeleteIdx !== undefined
+        ? ([
+            { op: "local.get", index: 0 },
+            { op: "local.get", index: 1 },
+            { op: "call", funcIdx: bfnDeleteIdx },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [{ op: "i32.const", value: 1 }, { op: "return" }],
+            },
+          ] as Instr[])
+        : []),
       // any = any.convert_extern(obj) ; if !ref.test $Object → return 1 (no-op success)
       { op: "local.get", index: 0 },
       { op: "any.convert_extern" },
@@ -2029,6 +2137,23 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
   // own-only predicate, so both names register the same body.
   const emitHasOwn = (name: string): void => {
     const body: Instr[] = [
+      // (#2896) Builtin-fn metadata arm: name/length are OWN properties of a
+      // builtin function value (until deleted). get_meta returns non-null
+      // exactly when the own property exists.
+      ...(bfnGetMetaIdx !== undefined
+        ? ([
+            { op: "local.get", index: 0 },
+            { op: "local.get", index: 1 },
+            { op: "call", funcIdx: bfnGetMetaIdx },
+            { op: "ref.is_null" },
+            { op: "i32.eqz" },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [{ op: "i32.const", value: 1 }, { op: "return" }],
+            },
+          ] as Instr[])
+        : []),
       // any = any.convert_extern(obj); if !ref.test $Object → 0
       { op: "local.get", index: 0 },
       { op: "any.convert_extern" },
@@ -5604,6 +5729,26 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     ];
 
     const body: Instr[] = [
+      // (#2896) Builtin-fn metadata arm: gOPD over a builtin function value
+      // synthesizes the spec data descriptor for its "name"/"length" own
+      // properties ({writable:false, enumerable:false, configurable:true}).
+      // The helper is filled at finalize; non-meta receivers return null and
+      // fall through to the `$Object` path below.
+      ...(bfnGopdIdx !== undefined
+        ? ([
+            { op: "local.get", index: 0 },
+            { op: "local.get", index: 1 },
+            { op: "call", funcIdx: bfnGopdIdx },
+            { op: "local.tee", index: 6 }, // desc local (externref) — reused
+            { op: "ref.is_null" },
+            { op: "i32.eqz" },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [{ op: "local.get", index: 6 }, { op: "return" }],
+            },
+          ] as Instr[])
+        : []),
       // any = any.convert_extern(obj) ; if !$Object → return undefined (null)
       { op: "local.get", index: 0 },
       { op: "any.convert_extern" },
@@ -5842,6 +5987,21 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     const body: Instr[] = [
       { op: "call", funcIdx: objVecNewIdx },
       { op: "local.set", index: 7 },
+      // (#2896) Builtin-fn metadata arm: a builtin function value's own string
+      // keys are ["length", "name"] in spec order (minus deleted ones). The
+      // filled helper pushes them into the vec and returns 1 on a hit.
+      ...(bfnPushOwnNamesIdx !== undefined
+        ? ([
+            { op: "local.get", index: 0 },
+            { op: "local.get", index: 7 },
+            { op: "call", funcIdx: bfnPushOwnNamesIdx },
+            {
+              op: "if",
+              blockType: { kind: "empty" },
+              then: [{ op: "local.get", index: 7 }, { op: "return" }],
+            },
+          ] as Instr[])
+        : []),
       { op: "local.get", index: 0 },
       { op: "any.convert_extern" },
       { op: "local.tee", index: 1 },
@@ -8499,6 +8659,271 @@ export function fillExternGetIdxVecArms(ctx: CodegenContext): void {
 }
 
 /**
+ * (#2896) Finalize-time fill for the reserved builtin-fn metadata natives
+ * (`__builtinfn_get_meta` / `__builtinfn_gopd` / `__builtinfn_delete` /
+ * `__builtinfn_push_ownnames` — registered by `ensureObjectRuntime` under
+ * `--target standalone` with constant default bodies). Runs from index.ts
+ * finalize, right after `fillExternGetIdxVecArms`, once EVERY builtin closure
+ * meta type (`ctx.builtinFnMetaByTypeIdx`, see builtin-fn-meta.ts) is known —
+ * a meta type registered after an eagerly-baked ref.test chain would otherwise
+ * be invisible (the same compile-order snapshot bug `fillExternIsArray` fixes
+ * for Array.isArray).
+ *
+ * Shift-safety: the arms are SPLICED into the existing default bodies (never
+ * rebuilt — see `reference_no_rebuild_helper_body_at_finalize`); the `call`
+ * funcIdxs baked here read `funcMap` at fill time, and any later import shift
+ * walks + adjusts spliced instrs like all others. `ref.test`/`ref.cast`/
+ * `struct.get`/`struct.set` use TYPE indices (rec-group stable, no funcidx
+ * hazard).
+ */
+export function fillBuiltinFnMeta(ctx: CodegenContext): void {
+  const metaMap = ctx.builtinFnMetaByTypeIdx;
+  if (!metaMap || metaMap.size === 0) return;
+  const getMetaFuncIdx = ctx.funcMap.get("__builtinfn_get_meta");
+  if (getMetaFuncIdx === undefined) return; // object runtime never ensured
+  const boxNumIdx = ctx.funcMap.get("__box_number");
+  const strFlattenIdx = ctx.nativeStrHelpers.get("__str_flatten");
+  const strEqualsIdx = ctx.nativeStrHelpers.get("__str_equals");
+  const anyStrTypeIdx = ctx.anyStrTypeIdx;
+  if (boxNumIdx === undefined || strFlattenIdx === undefined || strEqualsIdx === undefined || anyStrTypeIdx < 0) {
+    return;
+  }
+  // Resolve fill targets BY NAME (funcIdx math across phases is shift-sensitive).
+  const findFn = (name: string) => ctx.mod.functions.find((f) => f.name === name);
+  const getMetaFn = findFn("__builtinfn_get_meta");
+  const gopdFn = findFn("__builtinfn_gopd");
+  const deleteFn = findFn("__builtinfn_delete");
+  const pushOwnFn = findFn("__builtinfn_push_ownnames");
+
+  // Deterministic arm order.
+  const entries = Array.from(metaMap.entries()).sort((a, b) => a[0] - b[0]);
+
+  // Shared preamble for get_meta / delete (locals: 2=any 3=fkey 4=isName 5=isLen):
+  // convert the receiver, classify the key ONCE (string → flattened; isName /
+  // isLen flags). A non-string key can never be "name"/"length" — the flags
+  // stay 0 and the guarded arm block is skipped (falls to the default tail).
+  // A FACTORY (fresh Instr objects per call): the same preamble goes into TWO
+  // function bodies, and aliasing one Instr[] into both would double-remap
+  // (see reference_shared_instr_object_dce_double_remap).
+  const classifyPreamble = (): Instr[] => [
+    { op: "local.get", index: 0 },
+    { op: "any.convert_extern" },
+    { op: "local.set", index: 2 },
+    { op: "local.get", index: 1 },
+    { op: "any.convert_extern" },
+    { op: "ref.test", typeIdx: anyStrTypeIdx },
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [
+        { op: "local.get", index: 1 },
+        { op: "any.convert_extern" },
+        { op: "ref.cast", typeIdx: anyStrTypeIdx },
+        { op: "call", funcIdx: strFlattenIdx },
+        { op: "local.set", index: 3 },
+        { op: "local.get", index: 3 },
+        { op: "ref.as_non_null" },
+        ...nativeStringLiteralInstrs(ctx, "name"),
+        { op: "call", funcIdx: strEqualsIdx },
+        { op: "local.set", index: 4 },
+        { op: "local.get", index: 3 },
+        { op: "ref.as_non_null" },
+        ...nativeStringLiteralInstrs(ctx, "length"),
+        { op: "call", funcIdx: strEqualsIdx },
+        { op: "local.set", index: 5 },
+      ],
+    } as Instr,
+  ];
+
+  // ── __builtinfn_get_meta arms ──
+  if (getMetaFn) {
+    const arms: Instr[] = [];
+    for (const [typeIdx, meta] of entries) {
+      arms.push({ op: "local.get", index: 2 }, { op: "ref.test", typeIdx }, {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 4 }, // isName
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              // deleted? (state & NAME_DELETED)
+              { op: "local.get", index: 2 },
+              { op: "ref.cast", typeIdx },
+              { op: "struct.get", typeIdx, fieldIdx: 1 },
+              { op: "i32.const", value: 1 },
+              { op: "i32.and" },
+              { op: "i32.eqz" },
+              {
+                op: "if",
+                blockType: { kind: "empty" },
+                then: [
+                  ...nativeStringLiteralInstrs(ctx, meta.name),
+                  { op: "extern.convert_any" } as Instr,
+                  { op: "return" },
+                ],
+              },
+              { op: "ref.null.extern" },
+              { op: "return" },
+            ],
+          },
+          // length: deleted? (state & LENGTH_DELETED)
+          { op: "local.get", index: 2 },
+          { op: "ref.cast", typeIdx },
+          { op: "struct.get", typeIdx, fieldIdx: 1 },
+          { op: "i32.const", value: 2 },
+          { op: "i32.and" },
+          { op: "i32.eqz" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [{ op: "f64.const", value: meta.length }, { op: "call", funcIdx: boxNumIdx }, { op: "return" }],
+          },
+          { op: "ref.null.extern" },
+          { op: "return" },
+        ],
+      } as Instr);
+    }
+    getMetaFn.body.splice(
+      0,
+      0,
+      ...classifyPreamble(),
+      // Guard: only enter the arm block when the key is "name" or "length".
+      { op: "local.get", index: 4 } as Instr,
+      { op: "local.get", index: 5 } as Instr,
+      { op: "i32.or" } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: arms,
+      } as Instr,
+    );
+  }
+
+  // ── __builtinfn_gopd: get_meta(v, key) → __create_descriptor(value, 0x04) ──
+  const createDescIdx = ctx.funcMap.get("__create_descriptor");
+  if (gopdFn && createDescIdx !== undefined) {
+    gopdFn.body.splice(
+      0,
+      0,
+      { op: "local.get", index: 0 } as Instr,
+      { op: "local.get", index: 1 } as Instr,
+      { op: "call", funcIdx: getMetaFuncIdx } as Instr,
+      { op: "local.tee", index: 2 } as Instr,
+      { op: "ref.is_null" } as Instr,
+      { op: "i32.eqz" } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          { op: "local.get", index: 2 },
+          { op: "i32.const", value: FLAG_CONFIGURABLE }, // {writable:F, enumerable:F, configurable:T}
+          { op: "call", funcIdx: createDescIdx },
+          { op: "return" },
+        ],
+      } as Instr,
+    );
+  }
+
+  // ── __builtinfn_delete arms: set the instance's deleted bit, return 1 ──
+  if (deleteFn) {
+    const arms: Instr[] = [];
+    for (const [typeIdx] of entries) {
+      arms.push({ op: "local.get", index: 2 }, { op: "ref.test", typeIdx }, {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          // state |= isName ? 1 : 2
+          { op: "local.get", index: 2 },
+          { op: "ref.cast", typeIdx },
+          { op: "local.get", index: 2 },
+          { op: "ref.cast", typeIdx },
+          { op: "struct.get", typeIdx, fieldIdx: 1 },
+          { op: "local.get", index: 4 },
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "i32" } },
+            then: [{ op: "i32.const", value: 1 }],
+            else: [{ op: "i32.const", value: 2 }],
+          },
+          { op: "i32.or" },
+          { op: "struct.set", typeIdx, fieldIdx: 1 },
+          { op: "i32.const", value: 1 },
+          { op: "return" },
+        ],
+      } as Instr);
+    }
+    deleteFn.body.splice(
+      0,
+      0,
+      ...classifyPreamble(),
+      { op: "local.get", index: 4 } as Instr,
+      { op: "local.get", index: 5 } as Instr,
+      { op: "i32.or" } as Instr,
+      { op: "if", blockType: { kind: "empty" }, then: arms } as Instr,
+    );
+  }
+
+  // ── __builtinfn_push_ownnames arms: push undeleted ["length","name"] ──
+  const objVecPushIdx = ctx.funcMap.get("__objvec_push");
+  if (pushOwnFn && objVecPushIdx !== undefined) {
+    const arms: Instr[] = [];
+    for (const [typeIdx] of entries) {
+      arms.push({ op: "local.get", index: 2 }, { op: "ref.test", typeIdx }, {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [
+          // "length" first (spec order: OrdinaryOwnPropertyKeys creation order).
+          { op: "local.get", index: 2 },
+          { op: "ref.cast", typeIdx },
+          { op: "struct.get", typeIdx, fieldIdx: 1 },
+          { op: "i32.const", value: 2 },
+          { op: "i32.and" },
+          { op: "i32.eqz" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "local.get", index: 1 }, // vec
+              ...nativeStringLiteralInstrs(ctx, "length"),
+              { op: "extern.convert_any" } as Instr,
+              { op: "call", funcIdx: objVecPushIdx },
+            ],
+          },
+          { op: "local.get", index: 2 },
+          { op: "ref.cast", typeIdx },
+          { op: "struct.get", typeIdx, fieldIdx: 1 },
+          { op: "i32.const", value: 1 },
+          { op: "i32.and" },
+          { op: "i32.eqz" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: [
+              { op: "local.get", index: 1 }, // vec
+              ...nativeStringLiteralInstrs(ctx, "name"),
+              { op: "extern.convert_any" } as Instr,
+              { op: "call", funcIdx: objVecPushIdx },
+            ],
+          },
+          { op: "i32.const", value: 1 },
+          { op: "return" },
+        ],
+      } as Instr);
+    }
+    pushOwnFn.body.splice(
+      0,
+      0,
+      { op: "local.get", index: 0 } as Instr,
+      { op: "any.convert_extern" } as Instr,
+      { op: "local.set", index: 2 } as Instr,
+      ...arms,
+    );
+  }
+}
+
+/**
  * Names of the object-runtime host imports that `ensureObjectRuntime` provides
  * Wasm-native implementations for. `ensureLateImport` routes these here under
  * `ctx.standalone` (mirrors `UNION_NATIVE_HELPER_NAMES` for the #1471 boxing
@@ -8508,6 +8933,8 @@ export function fillExternGetIdxVecArms(ctx: CodegenContext): void {
  * `ensureLateImport`.
  */
 export const OBJECT_RUNTIME_HELPER_NAMES: ReadonlySet<string> = new Set([
+  // (#2896) builtin-fn metadata read (dyn-read `.length` closure arm routes here).
+  "__builtinfn_get_meta",
   "__new_plain_object",
   "__extern_is_array",
   "__extern_get",

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -26,6 +26,12 @@ import { snapshotSpeculative, rollbackSpeculative } from "./context/speculative.
 import { emitDynGet } from "./dyn-read.js"; // (#2580 M2 slice 1)
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { emitCachedMethodClosureAccess, emitFuncRefAsClosure, getOrCreateFuncRefWrapperTypes } from "./closures.js";
+import {
+  BUILTIN_STATIC_METHOD_ARITY,
+  ensureBuiltinFnMetaType,
+  pushBuiltinFnClosureValueInstrs,
+  STANDALONE_STATIC_METHOD_META,
+} from "./builtin-fn-meta.js";
 import { emitLazyClassObjectGet, emitLazyProtoGet, findExternInfoForMember } from "./expressions/extern.js";
 import {
   classifyPrivateMember,
@@ -960,6 +966,26 @@ function tryCompileStandaloneBuiltinProtoMemberMeta(
   const memberAccess = skipTransparentExpressions(expr.expression);
   if (!ts.isPropertyAccessExpression(memberAccess)) return undefined;
   const inner = skipTransparentExpressions(memberAccess.expression);
+  // (#2896) `<Builtin>.<staticMethod>.length` / `.name` — fold the spec
+  // metadata for direct reads of ANY standard builtin static method (the
+  // BUILTIN_STATIC_METHOD_ARITY table; `.name` === the property key per
+  // §10.2.9). No closure is materialized, so this also answers methods whose
+  // VALUE-read is not yet wired host-free (`Number.isNaN.length` etc.).
+  // Sibling of the `<Builtin>.prototype.<member>` fold below; the runtime
+  // reflective reads for wired closures resolve through the #2896 meta
+  // subtypes instead (same values — STANDALONE_STATIC_METHOD_META agrees with
+  // this table).
+  if (ts.isIdentifier(inner)) {
+    const staticShadowed = fctx.localMap.has(inner.text) || (fctx.boxedCaptures?.has(inner.text) ?? false);
+    const staticArity = BUILTIN_STATIC_METHOD_ARITY[inner.text]?.[memberAccess.name.text];
+    if (!staticShadowed && staticArity !== undefined) {
+      if (metaProp === "length") {
+        fctx.body.push({ op: "f64.const", value: staticArity } as Instr);
+        return { kind: "f64" };
+      }
+      return compileStringLiteral(ctx, fctx, memberAccess.name.text) ?? undefined;
+    }
+  }
   if (!ts.isPropertyAccessExpression(inner)) return undefined;
   if (inner.name.text !== "prototype" || !ts.isIdentifier(inner.expression)) return undefined;
   const builtinName = inner.expression.text;
@@ -1025,8 +1051,7 @@ function tryCompileStandaloneBuiltinProtoMemberRead(
     if (!closureInfo) return undefined;
 
     // self struct (param 0) — unused by the body (no captures) but type-required.
-    fctx.body.push({ op: "ref.func", funcIdx: closure.funcIdx } as Instr);
-    fctx.body.push({ op: "struct.new", typeIdx: closure.type.typeIdx } as Instr);
+    fctx.body.push(...pushBuiltinFnClosureValueInstrs(ctx, closure));
     // `this` arg (param 1): the builtin proto object externref.
     if (!emitLazyNativeProtoGet(ctx, fctx, brand)) return undefined;
     // call_ref operand: the typed funcref. `ref.func` yields `(ref liftedType)`
@@ -1037,8 +1062,7 @@ function tryCompileStandaloneBuiltinProtoMemberRead(
     return closureInfo.returnType ?? { kind: "externref" };
   }
 
-  fctx.body.push({ op: "ref.func", funcIdx: closure.funcIdx } as Instr);
-  fctx.body.push({ op: "struct.new", typeIdx: closure.type.typeIdx } as Instr);
+  fctx.body.push(...pushBuiltinFnClosureValueInstrs(ctx, closure));
   return closure.type;
 }
 
@@ -1115,6 +1139,23 @@ function ensureStandaloneBuiltinStaticMethodClosure(
       exported: false,
     });
     ctx.funcMap.set(funcName, funcIdx);
+  }
+
+  // (#2896) The value struct is the UNIQUE per-(builtin, method) metadata
+  // subtype of the signature wrapper, so the reflective runtime natives can
+  // `ref.test` it and answer its spec `name`/`length` own properties. All call
+  // paths are unaffected (subtype of the wrapper the lifted func expects).
+  const meta = STANDALONE_STATIC_METHOD_META[key];
+  if (meta) {
+    const metaTypeIdx = ensureBuiltinFnMetaType(
+      ctx,
+      wrapperTypes.structTypeIdx,
+      wrapperTypes.closureInfo,
+      `static:${key}`,
+      meta.name,
+      meta.length,
+    );
+    return { type: { kind: "ref", typeIdx: metaTypeIdx }, funcIdx };
   }
 
   return { type: { kind: "ref", typeIdx: wrapperTypes.structTypeIdx }, funcIdx };
@@ -3913,8 +3954,7 @@ export function compilePropertyAccess(
       }
       const closure = ensureStandaloneBuiltinStaticMethodClosure(ctx, builtinName, propName, expr);
       if (closure) {
-        fctx.body.push({ op: "ref.func", funcIdx: closure.funcIdx });
-        fctx.body.push({ op: "struct.new", typeIdx: closure.type.typeIdx });
+        fctx.body.push(...pushBuiltinFnClosureValueInstrs(ctx, closure));
         return closure.type;
       }
       reportUnsupportedStandaloneBuiltinValueRead(ctx, builtinName, propName);

--- a/tests/issue-2896.test.ts
+++ b/tests/issue-2896.test.ts
@@ -1,0 +1,122 @@
+// (#2896) Standalone native function-object metadata: builtin function values
+// answer their spec `name`/`length` own properties through the REFLECTIVE
+// runtime paths (getOwnPropertyDescriptor / dynamic key read / hasOwnProperty /
+// getOwnPropertyNames / delete), host-free.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, r.errors?.[0]?.message).toBe(true);
+  const mod = await WebAssembly.compile(r.binary!);
+  const envImports = WebAssembly.Module.imports(mod).filter((i) => i.module === "env");
+  expect(envImports, "must stay host-free").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary!, {});
+  return (instance.exports as { test?: () => unknown }).test?.();
+}
+
+describe("#2896 standalone builtin function-object metadata", () => {
+  it("direct .length of a wired static method folds to its arity", async () => {
+    expect(await runStandalone(`export function test(): number { return Array.isArray.length === 1 ? 1 : 0; }`)).toBe(
+      1,
+    );
+  });
+
+  it("getOwnPropertyDescriptor(fn, 'name') returns the spec data descriptor", async () => {
+    const src = `export function test(): number {
+      const d = Object.getOwnPropertyDescriptor(Array.isArray, "name");
+      if (!d) return 0;
+      if (d.value !== "isArray") return 2;
+      if (d.writable !== false) return 3;
+      if (d.enumerable !== false) return 4;
+      if (d.configurable !== true) return 5;
+      return 1;
+    }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+
+  it("getOwnPropertyDescriptor(fn, 'length') returns the spec arity", async () => {
+    const src = `export function test(): number {
+      const d = Object.getOwnPropertyDescriptor(Array.isArray, "length");
+      if (!d) return 0;
+      return d.value === 1 && d.writable === false && d.configurable === true ? 1 : 2;
+    }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+
+  it("reflective read works with RUNTIME receiver + key (the propertyHelper shape)", async () => {
+    const src = `function probe(obj: any, key: any): any {
+      return Object.getOwnPropertyDescriptor(obj, key);
+    }
+    export function test(): number {
+      const d = probe(Array.isArray, "name");
+      if (!d) return 0;
+      return d.value === "isArray" ? 1 : 2;
+    }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+
+  it("proto-method closures carry metadata too (String.prototype.charAt)", async () => {
+    const src = `export function test(): number {
+      const d = Object.getOwnPropertyDescriptor(String.prototype.charAt, "name");
+      if (!d) return 0;
+      return d.value === "charAt" ? 1 : 2;
+    }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+
+  it("dynamic key read fn[k] resolves name host-free", async () => {
+    const src = `export function test(): number {
+      const k = "name";
+      const fn: any = Array.isArray;
+      return fn[k] === "isArray" ? 1 : 0;
+    }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+
+  it("getOwnPropertyNames(fn) lists ['length','name'] in spec order", async () => {
+    const src = `export function test(): number {
+      const names = Object.getOwnPropertyNames(Array.isArray);
+      if (names.length !== 2) return 2;
+      return names[0] === "length" && names[1] === "name" ? 1 : 0;
+    }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+
+  it("delete fn.name works (configurable) and only on that instance", async () => {
+    const src = `export function test(): number {
+      const fn: any = Array.isArray;
+      const had = Object.getOwnPropertyDescriptor(fn, "name") !== undefined;
+      const del = delete fn["name"];
+      const gone = Object.getOwnPropertyDescriptor(fn, "name") === undefined;
+      const lenKept = Object.getOwnPropertyDescriptor(fn, "length") !== undefined;
+      return had && del && gone && lenKept ? 1 : 0;
+    }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+
+  it("writes to fn.name do not stick (writable:false observable via read-back)", async () => {
+    const src = `export function test(): number {
+      const fn: any = Array.isArray;
+      fn["name"] = "other";
+      return fn["name"] === "isArray" ? 1 : 0;
+    }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+
+  it("callback-passing a builtin method value still dispatches (meta subtype)", async () => {
+    const src = `export function test(): number {
+      const arr: any[] = [[1], 2];
+      const out = arr.filter(Array.isArray);
+      return out.length === 1 ? 1 : 0;
+    }`;
+    expect(await runStandalone(src)).toBe(1);
+  });
+
+  it("gc (JS-host) mode is unaffected", async () => {
+    const r = await compile(`export function test(): number { return Array.isArray([1]) ? 1 : 0; }`, {
+      fileName: "test.ts",
+    });
+    expect(r.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Delivers the #2896 substrate: builtin function values under `--target standalone` now answer their spec `name`/`length` own properties through the REFLECTIVE runtime paths, host-free — plus a generalized compile-time meta fold for direct reads.

### Mechanism
- **Per-(builtin, member) meta SUBTYPE** (`src/codegen/builtin-fn-meta.ts`): each builtin closure gets a unique struct subtype of its signature wrapper (`{funcref func; (mut i32) bfnstate}`). Subtyping keeps every existing call path untouched (static calls, reflective `.call`, any-typed callback dispatch). `name`/`length` are per-TYPE constants (`ctx.builtinFnMetaByTypeIdx`); `bfnstate` is a per-instance deleted-bits mask so `verifyProperty`'s destructive `isConfigurable` (`delete fn.name`) genuinely works.
- **Reserve/fill reflective natives** (`object-runtime.ts`): `__builtinfn_get_meta/_gopd/_delete/_push_ownnames` registered with constant default bodies (standalone-gated — gc bytes untouched); `ref.test` arms SPLICED at finalize by `fillBuiltinFnMeta` (same discipline as `fillExternIsArray`; fresh Instr objects, no shared-body aliasing; calls resolved by name at fill). Eager arms in `__extern_get` / `__hasOwnProperty` / `__object_hasOwn` / `__getOwnPropertyDescriptor` / `__getOwnPropertyNames` / `__delete_property` bake their funcIdx at registration (shift-invariant preserved).
- **dyn-read `.length` closure arm** consults the meta native instead of flat `box_number(0)` (standalone).
- **`BUILTIN_STATIC_METHOD_ARITY`**: spec arities of every standard builtin static method → direct `<Builtin>.<staticMethod>.length/.name` reads fold for ALL of them (covers methods whose value-read is not yet wired, e.g. `Number.isNaN.length`).

### Measured (A/B vs branch base, standalone, real runner)
| corpus | base | patched |
| --- | --- | --- |
| mechanism probes (13) | 5 pass | **13 pass** (post-merge with #2934) |
| `built-ins/**/{name,length,prop-desc}.js` sample (184/1836) | 99 pass / 31 fail | **109 pass / 21 fail** (+10, 0 regressions; ≈ +100 extrapolated) |
| direct-reflective corpus (281 gOPD-on-fn files) | 53 pass / 225 fail | **66 pass / 212 fail** (+13, 0 regressions) |
| `tests/issue-2896.test.ts` (new) | — | 11/11, zero env imports asserted |
| related suites 2885/2876/2923/2193/2861/2580/2175 | — | 69/69 |

Honest-scope note (in the issue file): the repo runner transforms `verifyProperty` into a direct read, so the reflective substrate's corpus wins today come via dynamic receivers (accessor `.get` name tests) and the direct-read fold; the substrate is in place for full propertyHelper fidelity later.

Issue file rides with `status: done`. Unblocks the parked #2875 String.prototype cluster task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8