### PR TITLE
fix(#2941): native-generator resumeFuncIdx un-shifted late-import side-channel

### DIFF
--- a/plan/issues/2941-nativegen-funcidx-sidechannel.md
+++ b/plan/issues/2941-nativegen-funcidx-sidechannel.md
@@ -1,0 +1,87 @@
+---
+id: 2941
+title: "Native SYNC-generator resumeFuncIdx is an un-shifted late-import side-channel (funcIdx desync)"
+status: done
+assignee: ttraenkler/sr-funcidx
+created: 2026-07-02
+completed: 2026-07-02
+priority: high
+feasibility: hard
+task_type: bug
+area: codegen
+goal: standalone
+related: [2938, 2936, 2918, 1461, 2193]
+---
+
+# #2941 — native-generator `resumeFuncIdx` un-shifted side-channel
+
+## Problem
+
+`ctx.nativeGenerators[].resumeFuncIdx` (the generated `__gen_resume_*` function
+index, cached on each `NativeGeneratorInfo`) is a plain number read at every
+`.next()` / `.return()` / `.throw()` / for-of driver + `yield*` bake site via
+`ensureNativeGeneratorResumeFunction`. Unlike the other funcIdx side-channels
+(`nativeStrHelpers`, `mapHelpers`, `pendingMethodTrampolines`, the
+async-scheduler / combinator fields), **no late-import shift pass walked
+`ctx.nativeGenerators`**. So once a resume function is emitted, a late import
+that lands afterwards bumps the `funcMap` entry (and the shifter's body walk
+repairs already-baked `call` instrs), but the **cached `resumeFuncIdx` stays
+stale-low**. A _new_ bake after that shift reads the stale cache and targets one
+function too early → the class-static generator invalid module
+`call[…] not enough arguments on the stack for call (need N, got 1)`.
+
+This is the reference_1461 / reference_2193 lineage (a side-channel funcIdx not
+kept in lockstep with late-import shifts) — a **sibling of #2936, distinct
+mechanism**: #2936 fixed the `ensureLateImport` batch-regime _mix_ (settling
+native-string finalize drift before a deferred batch) and is on `main`, yet does
+NOT fix this — proving the two are independent.
+
+## Origin
+
+Surfaced as ~16 of the 20 `#2938` no-yield-relax merge_group regressions
+(`class/elements/*-gen-rs-static-*` → invalid Wasm). The no-yield relax makes
+those class-static generators native candidates, exposing the desync; the hazard
+is general (with-yield native generators cross the same shift paths), so it is
+worth fixing independent of whether the #2938 relax ever ships.
+
+## Fix (2 files)
+
+1. `src/codegen/generators-native.ts` — `ensureNativeGeneratorResumeFunction`
+   re-reads `ctx.funcMap` (the shift-maintained source of truth) on every cached
+   hit and refreshes the cache. Primary fix: bakes always get the current idx.
+2. `src/codegen/expressions/late-imports.ts` — `shiftLateImportIndices` now
+   walks `ctx.nativeGenerators` and bumps each `resumeFuncIdx >= importsBefore`,
+   keeping the cached field itself in lockstep for any direct reader
+   (belt-and-suspenders, mirrors the trampoline / async side-channel walks).
+
+Both are inert unless native generators were emitted (gc/host default path never
+registers any) → byte-inert off-carrier.
+
+## Validation
+
+- **Empirical proof (the load-bearing one):** the 20 `#2938` merge_group
+  standalone regressions, re-run with this fix layered onto the relax branch:
+  **18 pass / 2 fail / 0 invalid modules** (was 0/0/16-invalid). All ~16
+  class-static invalid-Wasm regressions become valid. The 2 residual fails are
+  the orthogonal no-yield `.value` semantic bug (#2938 bug (b)), which this fix
+  correctly does not touch. Reproduce: overlay `generators-native.ts` from
+  `issue-2933-noyield-relax` + this fix, run
+  `.tmp/2930/corpus.mts .tmp/2938/reg20fix.txt`.
+- **Byte-inert:** 50 non-generator gc test262 files sha256-identical vs
+  `main` (the fix is unreachable without native generators).
+- Regression test: `tests/issue-2941.test.ts` compiles a native sync generator
+  in `--target standalone` across a late-import boundary and asserts the module
+  validates (guards the general resume-idx path). NB the _observable_ class-static
+  desync only manifests with the #2938 relax active (the failing files are
+  no-yield), so the committed test guards the path and the authoritative proof is
+  the corpus flip above.
+
+## Note for #2938 corpus design
+
+The 542-file no-yield sample missed these class-statics because it filtered
+generators by `!yield` and sampled by directory: the `class/elements/*` templates
+that carry static generators were dropped (they contain an `async *` sibling → a
+`yield` match) and the sample was directory-strided, not construct-strided. The
+next corpus must **sample by construct** (class-static generator, object-method
+generator, free-function, …), not by directory, and validate on the full
+`merge_group` standalone lane, never a scoped sample.

--- a/src/codegen/expressions/late-imports.ts
+++ b/src/codegen/expressions/late-imports.ts
@@ -299,6 +299,24 @@ export function shiftLateImportIndices(
     if (t.methodFuncIdx >= importsBefore) t.methodFuncIdx += added;
     if (t.trampolineFuncIdx >= importsBefore) t.trampolineFuncIdx += added;
   }
+  // (#2941) Same lockstep for the native SYNC-generator resume-function indices.
+  // `ctx.nativeGenerators[].resumeFuncIdx` is a plain cached number read at every
+  // `.next()`/`.return()`/`.throw()`/for-of + `yield*` bake site (via
+  // `ensureNativeGeneratorResumeFunction`). It is NOT `funcMap` and was walked by
+  // NO shift pass, so a late import landing after a resume function was emitted
+  // left the cache stale-low — a NEW bake reading it targeted one function too
+  // early (`call[…] need N got 1` invalid module; the #2938 class-static-generator
+  // merge_group regression). `ensureNativeGeneratorResumeFunction` now re-reads
+  // funcMap on cached hits (the primary fix); this keeps the cached field itself
+  // in lockstep for any direct reader — mirrors the trampoline / async
+  // side-channel walks above. Inert unless native generators were emitted.
+  if (ctx.nativeGenerators) {
+    for (const info of ctx.nativeGenerators.values()) {
+      if (typeof info.resumeFuncIdx === "number" && info.resumeFuncIdx >= importsBefore) {
+        info.resumeFuncIdx += added;
+      }
+    }
+  }
   // (#2632 / #2918) Same lockstep for the async-scheduler / event-loop helper
   // func indices AND the Promise.all/race combinator helper indices. They are
   // stored as plain numbers on `ctx.asyncScheduler` / `ctx.__promiseCombinators`

--- a/src/codegen/generators-native.ts
+++ b/src/codegen/generators-native.ts
@@ -1779,9 +1779,27 @@ function compileState(
 }
 
 export function ensureNativeGeneratorResumeFunction(ctx: CodegenContext, info: NativeGeneratorInfo): number {
-  if (info.resumeFuncIdx !== undefined) return info.resumeFuncIdx;
-
   const fnName = `__gen_resume_${sanitizeTypeName(info.functionName)}`;
+  // (#2941) SINGLE SOURCE OF TRUTH = `ctx.funcMap`, which every late-import
+  // shifter (`shiftLateImportIndices` / `addStringImports` / `addUnionImports`)
+  // keeps current. `info.resumeFuncIdx` is a plain cached number that NO shift
+  // pass walked (unlike `nativeStrHelpers` / `mapHelpers` / the async-scheduler
+  // side-channels), so once the resume function is emitted, a late import that
+  // lands afterwards bumps the funcMap entry but leaves the cache stale-low.
+  // Already-baked `call` instrs are repaired by the shifter's body walk, but a
+  // NEW bake after the shift that reads the stale cache targets one function too
+  // early — the class-static generator `call[…] need N got 1` invalid-module
+  // desync (#2938 merge_group). Re-reading funcMap on every cached hit makes the
+  // returned idx always current (reference_2193 lineage: read the shift-maintained
+  // map, never a cached number). We also refresh the cache so a direct reader of
+  // `info.resumeFuncIdx` sees the current value; `shiftLateImportIndices` now
+  // walks `ctx.nativeGenerators` too (belt-and-suspenders lockstep, #2941).
+  if (info.resumeFuncIdx !== undefined) {
+    const current = ctx.funcMap.get(fnName);
+    if (current !== undefined && current !== info.resumeFuncIdx) info.resumeFuncIdx = current;
+    return info.resumeFuncIdx;
+  }
+
   const existing = ctx.funcMap.get(fnName);
   if (existing !== undefined) {
     info.resumeFuncIdx = existing;

--- a/tests/issue-2941.test.ts
+++ b/tests/issue-2941.test.ts
@@ -1,0 +1,53 @@
+// #2941 — native SYNC-generator `resumeFuncIdx` is an un-shifted late-import
+// side-channel. `ctx.nativeGenerators[].resumeFuncIdx` (read at every
+// .next()/.return()/.throw()/for-of/yield* bake site) was a cached plain number
+// that no shift pass walked, so a late import landing after the resume function
+// was emitted left the cache stale-low → a new bake targeted the wrong function
+// ("call[…] need N got 1" invalid module; the ~16 class-static regressions in the
+// #2938 no-yield-relax merge_group). Fix: ensureNativeGeneratorResumeFunction
+// re-reads funcMap on cached hits, and shiftLateImportIndices walks
+// ctx.nativeGenerators.
+//
+// NB the *observable* class-static desync only manifests with the #2938 relax
+// active (those files are no-yield). This test guards the general native-generator
+// resume-idx path across a late-import boundary; the authoritative proof is the
+// 18/20 (16 invalid→valid) flip on the relax corpus documented in the issue file.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+describe("issue #2941 — native-generator resume-idx across a late-import boundary", () => {
+  it("standalone: native sync generator + native strings validates", async () => {
+    const src = `
+      function mk(n: number): number {
+        function* g() { yield n; yield n + 1; }
+        const it = g();
+        const a = it.next();
+        const b = it.next();
+        return (a.value ?? 0) + (b.value ?? 0);
+      }
+      const label = (s: string): string => "v=" + s;
+      export function test(): string {
+        return label(String(mk(5)));
+      }
+    `;
+    const r = await compile(src, {
+      fileName: "issue-2941.ts",
+      target: "standalone",
+      skipSemanticDiagnostics: true,
+    });
+    // Either the shape is accepted (valid module) or it cleanly bails to a
+    // compile error — but it must NEVER produce an invalid module.
+    if (r.success && r.binary) {
+      expect(WebAssembly.validate(r.binary)).toBe(true);
+    } else {
+      expect(r.errors.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("gc/host lane compiles unchanged (byte-inert path — no native generators)", async () => {
+    const src = `export function add(a: number, b: number): number { return a + b; }`;
+    const r = await compile(src, { fileName: "issue-2941-gc.ts", skipSemanticDiagnostics: true });
+    expect(r.success).toBe(true);
+    expect(WebAssembly.validate(r.binary!)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

`ctx.nativeGenerators[].resumeFuncIdx` (the `__gen_resume_*` index cached on each `NativeGeneratorInfo`, read at every `.next()`/`.return()`/`.throw()`/for-of/`yield*` bake site) is a plain number that **no late-import shift pass walked** — unlike `nativeStrHelpers`/`mapHelpers`/`pendingMethodTrampolines`/the async-scheduler side-channels. A late import landing after a resume function is emitted bumps the `funcMap` entry (and the shifter's body walk fixes already-baked `call`s), but the cached `resumeFuncIdx` stays stale-low; a **new** bake reads it and targets one function too early → `call[…] not enough arguments on the stack for call (need N, got 1)` invalid module.

This is the reference_1461 / reference_2193 lineage (side-channel funcIdx not kept in lockstep). It is a **sibling of #2936 but a distinct mechanism** — #2936 (the `ensureLateImport` batch-regime mix) is already on `main` and does not fix this.

## Origin & scope

Surfaced as ~16 of the 20 #2938 no-yield-relax merge_group regressions (`class/elements/*-gen-rs-static-*` → invalid Wasm). The relax makes those class-static generators native candidates, exposing the desync. The hazard is **general** (with-yield native generators cross the same shift paths), so this lands **independently of the #2938 relax**.

## Fix (2 files)

1. `generators-native.ts` — `ensureNativeGeneratorResumeFunction` re-reads `ctx.funcMap` (the shift-maintained source of truth) on cached hits and refreshes the cache (primary fix; reference_2193 lineage).
2. `late-imports.ts` — `shiftLateImportIndices` walks `ctx.nativeGenerators`, bumping each `resumeFuncIdx >= importsBefore` (belt-and-suspenders lockstep, mirrors the trampoline/async side-channel walks).

Both inert unless native generators were emitted → byte-inert on gc/host.

## Validation

- **Empirical (load-bearing):** the 20 #2938 merge_group standalone regressions, re-run with this fix layered on the relax branch: **18 pass / 2 fail / 0 invalid modules** (was 16 invalid). All ~16 class-static invalid-Wasm regressions become valid; the 2 residual fails are the orthogonal no-yield `.value` semantic bug (#2938 bug (b)), untouched by this fix — confirming the two bugs are independent.
- **Byte-inert:** 50 non-generator gc test262 files sha256-identical vs `main`.
- `tests/issue-2941.test.ts` — native sync generator across a late-import boundary validates; gc lane unchanged.

Issue: `plan/issues/2941-nativegen-funcidx-sidechannel.md` (incl. a note on why the #2938 542-file sample missed class-statics — sample by construct, not directory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8