### PR TITLE
fix(#2943): claim-issue --allocate open-PR scan — batch, retry, fail-loud (silent misses allocated colliding ids)

### DIFF
--- a/plan/issues/2943-allocator-open-pr-scan-hardening.md
+++ b/plan/issues/2943-allocator-open-pr-scan-hardening.md
@@ -1,0 +1,65 @@
+---
+id: 2943
+title: "tooling: claim-issue --allocate open-PR scan missed in-flight issue files (silent gh-failure fan-out) — batch, retry, fail-loud"
+status: done
+completed: 2026-07-02
+assignee: ttraenkler/dev-f2
+created: 2026-07-02
+updated: 2026-07-02
+priority: low
+sprint: current
+horizon: s
+task_type: bug
+area: tooling
+goal: developer-experience
+related: [2531, 1858]
+origin: "2026-07-02 tech-lead task #14 from the 2920/2921 allocation collisions."
+---
+
+# #2943 — `--allocate` open-PR scan: silent fan-out failures narrow the id universe
+
+## Problem
+
+Concrete repro: 2026-07-02 ~00:30Z, `claim-issue.mjs --allocate` returned
+**2920** although open PR loopdive/js2#2424 (created 23:07Z) already added
+`plan/issues/2920-strict-negative-verdict-succeeded-arm.md`. Same pattern hit
+**2921** (PR #2425). Downstream cost: one analysis file burned the
+2921→2931→2937→**2940** re-id chain across parallel-session collisions.
+
+## Root cause (investigated, not pagination)
+
+PR #2424 has only 9 changed files and today's scan sees it — so the miss was
+NOT the 100-file cap or PR-list pagination. The old scan fanned out **1 + N
+`gh` calls** (`gh pr list`, then `gh pr view --json files` per open PR) and
+swallowed every failure silently (`catch { /* skip this PR */ }`, and a full
+list failure returned an empty set). Under gh rate-limit / API contention
+(7+ concurrent agents, each with CI watchers polling `gh`), any dropped call
+narrowed the id universe with **no signal** — `--allocate` then computed
+max+1 over a universe missing in-flight files. (A second latent miss source:
+`gh pr view --json files` silently truncates at 100 files.)
+
+## Fix
+
+`scripts/claim-issue.mjs`:
+
+1. **One batched GraphQL query** (100 PRs × 100 files per page, cursor
+   pagination) replaces the fan-out — ~2 orders of magnitude fewer API calls,
+   one failure point instead of N.
+2. **REST `--paginate` fallback** fetches the full file list for the rare
+   > 100-file PR (`files.pageInfo.hasNextPage`).
+3. **3× retry with backoff** around the whole scan.
+4. **Fail-LOUD degraded mode**: on persistent failure the scan returns
+   `complete:false`; `--allocate` prints a prominent stderr warning and the
+   `--json` output carries `prScanDegraded:true`. Still fail-open by design
+   (offline/unauthenticated use keeps working; the CI gate
+   `check-issue-ids --against-main` remains the hard backstop) — but never
+   fail-silent again.
+5. **`--debug-pr-scan` mode** prints `{ids,complete}` for diagnosis and tests.
+
+## Test Results
+
+`tests/issue-2943.test.ts` (4/4) drives `--debug-pr-scan` through a
+PATH-injected fake `gh`: batched-query parsing, >100-file REST fallback,
+persistent-failure → `complete:false`, transient-failure → retry succeeds.
+Live check: scan sees all in-flight PR ids (2896…2941), `--dry-run` proposes
+the correct next id.

--- a/scripts/claim-issue.mjs
+++ b/scripts/claim-issue.mjs
@@ -116,15 +116,17 @@ const positional = argv.filter((a, i) => !a.startsWith("--") && argv[i - 1] !== 
 
 const mode = flags.has("--list")
   ? "list"
-  : flags.has("--allocate")
-    ? "allocate"
-    : flags.has("--check")
-      ? "check"
-      : flags.has("--release")
-        ? "release"
-        : flags.has("--complete")
-          ? "complete"
-          : "claim";
+  : flags.has("--debug-pr-scan")
+    ? "debug-pr-scan"
+    : flags.has("--allocate")
+      ? "allocate"
+      : flags.has("--check")
+        ? "check"
+        : flags.has("--release")
+          ? "release"
+          : flags.has("--complete")
+            ? "complete"
+            : "claim";
 
 function normalizeAssignee(raw) {
   if (!raw) return "";
@@ -254,49 +256,97 @@ function idsFromAssignRef(sha) {
 
 // Ids added by currently-open PRs. Uses `gh` when available (the only way to
 // see a fork-headed PR whose branch is NOT a refs/remotes/origin/* ref here).
-// Best-effort: on any gh failure (offline, unauthenticated, old gh) we return
-// an empty set and fall back to main ∪ ref — the PR-time CI gate
-// (check-issue-ids --against-main) is the hard backstop, this scan only shrinks
-// the race window at allocation time.
-function idsFromOpenPRs() {
-  const out = new Set();
-  const repo = process.env.CLAIM_PR_REPO || "loopdive/js2";
-  // List open PR numbers (cap to keep the per-PR file query bounded).
-  let prNumbers = [];
-  try {
-    const raw = execFileSync(
-      "gh",
-      ["pr", "list", "-R", repo, "--state", "open", "--limit", "200", "--json", "number"],
-      {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "ignore"],
-      },
-    );
-    prNumbers = JSON.parse(raw).map((p) => p.number);
-  } catch {
-    return out; // gh unavailable / unauthenticated — fall back to main ∪ ref
-  }
-  for (const n of prNumbers) {
-    try {
-      const raw = execFileSync("gh", ["pr", "view", String(n), "-R", repo, "--json", "files"], {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "ignore"],
-      });
-      for (const f of JSON.parse(raw).files || []) {
-        const m = (f.path || "").match(ISSUE_ID_RE);
-        if (m) out.add(Number(m[1]));
-      }
-    } catch {
-      /* skip this PR */
+//
+// #2943 hardening — the original implementation fanned out 1 + N gh calls
+// (`gh pr list` then `gh pr view --json files` per PR), which made EVERY open
+// PR an independent, silently-swallowed failure point. Under gh rate-limit /
+// API contention (many concurrent agents), a dropped call narrowed the id
+// universe with NO signal: on 2026-07-02 an --allocate returned 2920 while
+// open PR #2424 already added plan/issues/2920-*.md (same pattern hit 2921 /
+// PR #2425; downstream, one analysis file burned the 2921→2931→2937→2940
+// re-id chain on parallel-session collisions). Now:
+//   - ONE batched GraphQL query (100 PRs × 100 files per page, paginated)
+//     replaces the fan-out — two orders of magnitude fewer API calls, one
+//     failure point instead of N;
+//   - a per-PR REST `--paginate` fallback covers the rare >100-file PR
+//     (`gh pr view --json files` also silently truncates at 100 — a second
+//     latent miss source in the old code);
+//   - the whole scan retries 3× with backoff, and on total failure returns
+//     `complete: false` so the caller can WARN LOUDLY instead of proceeding
+//     silently. Still fail-open by design (offline/unauthenticated use keeps
+//     working; the PR-time CI gate check-issue-ids --against-main is the hard
+//     backstop) — but no longer fail-SILENT.
+function sleepMs(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+const PR_FILES_QUERY = `query($owner:String!,$name:String!,$cursor:String){
+  repository(owner:$owner,name:$name){
+    pullRequests(states:OPEN,first:100,after:$cursor){
+      pageInfo{hasNextPage endCursor}
+      nodes{number files(first:100){pageInfo{hasNextPage} nodes{path}}}
     }
   }
-  return out;
+}`;
+
+function idsFromOpenPRs() {
+  const repo = process.env.CLAIM_PR_REPO || "loopdive/js2";
+  const [owner, name] = repo.split("/");
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const ids = new Set();
+      const bigPRs = [];
+      let cursor = null;
+      for (;;) {
+        const args = ["api", "graphql", "-f", `query=${PR_FILES_QUERY}`, "-F", `owner=${owner}`, "-F", `name=${name}`];
+        if (cursor) args.push("-F", `cursor=${cursor}`);
+        const raw = execFileSync("gh", args, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+        const prs = JSON.parse(raw)?.data?.repository?.pullRequests;
+        if (!prs) throw new Error("unexpected GraphQL shape");
+        for (const pr of prs.nodes || []) {
+          for (const f of pr.files?.nodes || []) {
+            const m = (f.path || "").match(ISSUE_ID_RE);
+            if (m) ids.add(Number(m[1]));
+          }
+          if (pr.files?.pageInfo?.hasNextPage) bigPRs.push(pr.number);
+        }
+        if (!prs.pageInfo?.hasNextPage) break;
+        cursor = prs.pageInfo.endCursor;
+      }
+      // >100-file PRs: fetch the full file list via REST pagination.
+      for (const n of bigPRs) {
+        const raw = execFileSync(
+          "gh",
+          ["api", `repos/${repo}/pulls/${n}/files`, "--paginate", "--jq", ".[].filename"],
+          { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+        );
+        for (const p of raw.split("\n")) {
+          const m = p.match(ISSUE_ID_RE);
+          if (m) ids.add(Number(m[1]));
+        }
+      }
+      return { ids, complete: true };
+    } catch {
+      if (attempt < 3) sleepMs(attempt * 1000);
+    }
+  }
+  console.error(
+    "warning: open-PR id scan FAILED after 3 attempts (gh offline/unauthenticated/rate-limited). " +
+      "Allocating against main ∪ reservations ONLY — the id may collide with an in-flight PR's issue file " +
+      "(#2943). The CI gate check-issue-ids --against-main remains the hard backstop.",
+  );
+  return { ids: new Set(), complete: false };
 }
 
 function allUsedIds(sha, { scanPRs }) {
   const all = new Set([...idsFromMain(), ...idsFromAssignRef(sha)]);
-  if (scanPRs) for (const id of idsFromOpenPRs()) all.add(id);
-  return all;
+  let prScanComplete = true;
+  if (scanPRs) {
+    const pr = idsFromOpenPRs();
+    for (const id of pr.ids) all.add(id);
+    prScanComplete = pr.complete;
+  }
+  return { ids: all, prScanComplete };
 }
 
 // Build a new tree = base tree with `<id>.json` set to `content`, then
@@ -393,19 +443,23 @@ function doAllocate(assignee) {
     const sha = remoteAssignSha();
     fetchAssign(sha);
 
-    const used = allUsedIds(sha, { scanPRs });
+    const { ids: used, prScanComplete } = allUsedIds(sha, { scanPRs });
     // contiguousMax+1 is always strictly above the contiguous body, so it can
     // never alias an in-use id (strays sit > STRAY_GAP above max, never at +1).
     const id = String(contiguousMax(used) + 1);
+    // #2943: degraded-scan marker — idsFromOpenPRs already warned on stderr;
+    // also carried in the --json output so tooling can react.
+    const degraded = scanPRs && !prScanComplete;
 
     // --dry-run: preview the candidate without reserving (no push). Useful to
     // see "what id would I get" without burning a reservation. NOT collision-
     // safe on its own — only the real reserve+push is atomic.
     if (flags.has("--dry-run")) {
-      if (wantJson) process.stdout.write(JSON.stringify({ id: Number(id), dryRun: true }) + "\n");
+      if (wantJson)
+        process.stdout.write(JSON.stringify({ id: Number(id), dryRun: true, prScanDegraded: degraded }) + "\n");
       else {
         console.error(
-          `(dry-run) next free id would be #${id} (scanned ${used.size} used ids; PR-scan ${scanPRs ? "on" : "off"})`,
+          `(dry-run) next free id would be #${id} (scanned ${used.size} used ids; PR-scan ${scanPRs ? (degraded ? "DEGRADED" : "on") : "off"})`,
         );
         process.stdout.write(`${id}\n`);
       }
@@ -429,7 +483,12 @@ function doAllocate(assignee) {
       // stdout = just the id (scriptable); details to stderr unless --json.
       if (wantJson) {
         process.stdout.write(
-          JSON.stringify({ id: Number(id), assignee: assignee || null, branch: entry.branch || null }) + "\n",
+          JSON.stringify({
+            id: Number(id),
+            assignee: assignee || null,
+            branch: entry.branch || null,
+            prScanDegraded: degraded,
+          }) + "\n",
         );
       } else {
         console.error(
@@ -516,6 +575,12 @@ function writeMode(target, assignee, kind) {
 // --- dispatch ---------------------------------------------------------------
 if (mode === "list") {
   doList();
+} else if (mode === "debug-pr-scan") {
+  // #2943: expose the open-PR id scan for tests/diagnosis. Prints
+  // {ids:[...],complete:bool} as JSON. Exit 0 even on a degraded scan —
+  // `complete` carries the signal.
+  const r = idsFromOpenPRs();
+  process.stdout.write(JSON.stringify({ ids: [...r.ids].sort((a, b) => a - b), complete: r.complete }) + "\n");
 } else if (mode === "allocate") {
   // --allocate [<assignee>] — reserve the next fresh id. Assignee optional.
   doAllocate(normalizeAssignee(positional[0] || process.env.CLAIM_ASSIGNEE || ""));

--- a/tests/issue-2943.test.ts
+++ b/tests/issue-2943.test.ts
@@ -1,0 +1,105 @@
+// #2943 — claim-issue.mjs --allocate open-PR scan hardening.
+//
+// The old scan fanned out 1+N `gh` calls and swallowed every failure silently,
+// so under gh rate-limit contention an in-flight PR's issue file vanished from
+// the id universe and --allocate handed out a colliding id (2920 vs PR #2424).
+// The scan is now one batched GraphQL query with retries, a REST pagination
+// fallback for >100-file PRs, and a LOUD degraded-mode signal. These tests
+// drive `--debug-pr-scan` through a PATH-injected fake `gh`.
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "child_process";
+import { mkdtempSync, writeFileSync, chmodSync } from "fs";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+
+const SCRIPT = resolve(__dirname, "..", "scripts", "claim-issue.mjs");
+
+function runWithFakeGh(fakeGhBody: string): { out: string; err: string } {
+  const dir = mkdtempSync(join(tmpdir(), "fake-gh-"));
+  const gh = join(dir, "gh");
+  writeFileSync(gh, `#!/usr/bin/env bash\n${fakeGhBody}\n`);
+  chmodSync(gh, 0o755);
+  try {
+    const out = execFileSync(process.execPath, [SCRIPT, "--debug-pr-scan"], {
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${dir}:${process.env.PATH}` },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { out, err: "" };
+  } catch (e: any) {
+    // execFileSync throws on non-zero exit; --debug-pr-scan must exit 0.
+    throw new Error(`--debug-pr-scan exited non-zero: ${e.stderr}`);
+  }
+}
+
+describe("#2943 claim-issue --debug-pr-scan (open-PR id scan)", () => {
+  it("collects issue ids from the batched GraphQL query", () => {
+    const body = `
+if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
+  cat <<'EOF'
+{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"number":1,"files":{"pageInfo":{"hasNextPage":false},"nodes":[{"path":"plan/issues/9999-foo-bar.md"},{"path":"src/x.ts"}]}},
+  {"number":2,"files":{"pageInfo":{"hasNextPage":false},"nodes":[{"path":"README.md"}]}}
+]}}}}
+EOF
+  exit 0
+fi
+exit 1`;
+    const { out } = runWithFakeGh(body);
+    const r = JSON.parse(out);
+    expect(r.complete).toBe(true);
+    expect(r.ids).toEqual([9999]);
+  });
+
+  it("falls back to REST pagination for >100-file PRs", () => {
+    const body = `
+if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
+  cat <<'EOF'
+{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"number":7,"files":{"pageInfo":{"hasNextPage":true},"nodes":[{"path":"plan/issues/9998-first-page.md"}]}}
+]}}}}
+EOF
+  exit 0
+fi
+if [ "$1" = "api" ] && [[ "$2" == repos/*/pulls/7/files ]]; then
+  printf 'src/a.ts\\nplan/issues/9997-tail-page.md\\n'
+  exit 0
+fi
+exit 1`;
+    const { out } = runWithFakeGh(body);
+    const r = JSON.parse(out);
+    expect(r.complete).toBe(true);
+    expect(r.ids).toEqual([9997, 9998]);
+  });
+
+  it("returns complete:false (not a silent empty set) when gh fails persistently", () => {
+    const { out } = runWithFakeGh("exit 1");
+    const r = JSON.parse(out);
+    expect(r.complete).toBe(false);
+    expect(r.ids).toEqual([]);
+  });
+
+  it("retries transient gh failures and succeeds", () => {
+    // Fail the first call, succeed afterwards (state via a marker file next to
+    // the fake gh binary).
+    const body = `
+MARK="$(dirname "$0")/.called"
+if [ ! -f "$MARK" ]; then
+  touch "$MARK"
+  exit 1
+fi
+if [ "$1" = "api" ] && [ "$2" = "graphql" ]; then
+  cat <<'EOF'
+{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+  {"number":3,"files":{"pageInfo":{"hasNextPage":false},"nodes":[{"path":"plan/issues/9996-retry-win.md"}]}}
+]}}}}
+EOF
+  exit 0
+fi
+exit 1`;
+    const { out } = runWithFakeGh(body);
+    const r = JSON.parse(out);
+    expect(r.complete).toBe(true);
+    expect(r.ids).toEqual([9996]);
+  });
+});


### PR DESCRIPTION
Fixes task #14's allocator gap: on 2026-07-02 `--allocate` returned 2920 while open PR #2424 already added `plan/issues/2920-*.md` (same pattern hit 2921/PR #2425 — which downstream burned the 2921→2931→2937→2940 re-id chain on one analysis file).

## Root cause (investigated — NOT pagination)
PR #2424 has 9 files and today's scan sees it, so the miss wasn't the file cap. The old scan fanned out **1+N `gh` calls** (`pr list` + `pr view --json files` per PR) and swallowed every failure silently — under gh rate-limit/API contention (7+ agents each polling gh) any dropped call narrowed the id universe with no signal, and max+1 allocated over a universe missing in-flight files. (`--json files` also silently truncates at 100 files — a second latent miss source.)

## Fix (scripts/claim-issue.mjs)
- ONE batched GraphQL query (100 PRs × 100 files/page, cursor-paginated) — ~2 orders of magnitude fewer API calls, one failure point instead of N.
- REST `--paginate` fallback for the rare >100-file PR.
- 3× retry with backoff around the whole scan.
- **Fail-loud degraded mode**: persistent failure ⇒ `complete:false`, prominent stderr warning, `prScanDegraded:true` in `--json`. Still fail-open by design (offline use works; the CI `check-issue-ids --against-main` gate stays the hard backstop) — never fail-silent again.
- `--debug-pr-scan` mode for diagnosis + tests.

## Validation
- `tests/issue-2943.test.ts` (4/4): PATH-injected fake `gh` covers batched parsing, >100-file REST fallback, persistent-failure ⇒ `complete:false`, transient-failure ⇒ retry-succeeds.
- Live: scan returns all in-flight PR ids (2896…2941) `complete:true`; `--dry-run` proposes the correct next id.

Issue file rides the PR with `status: done`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8