### PR TITLE
revert(#2937): back out #2432's host extension of the $Object-hash poison (compiled-acorn null-deref on all host-mode inputs)

### DIFF
--- a/plan/issues/2849-ecmaversion-normalize-dynamic-prop-type-inference.md
+++ b/plan/issues/2849-ecmaversion-normalize-dynamic-prop-type-inference.md
@@ -1,8 +1,7 @@
 ---
 id: 2849
 title: "dynamic-object numeric property reads back 0 when the same property is also compared via === string / == null (acorn ecmaVersion 2022 not normalised → spurious import attributes)"
-status: done
-completed: 2026-07-02
+status: blocked
 assignee: ttraenkler/fable-dev
 sprint: current
 priority: medium
@@ -14,11 +13,25 @@ task_type: bugfix
 area: codegen
 language_feature: dynamic-object-property-type-inference
 goal: acorn-dogfood
-related: [2841, 2836, 1712]
+related: [2841, 2836, 1712, 2937, 2944]
 depends_on: []
+blocked_on: 2944
 blocks: [1712]
 umbrella: 1712
 ---
+
+> **REOPENED 2026-07-02 (was `done`).** The host-mode fix (PR #2432, extend the
+> `objectHashConsumerVars` poison to host) was **REVERTED in #2937**: keeping
+> acorn's poisoned `{}` vars on `$Object` in host mode broke compiled-acorn with
+> a uniform null-deref on EVERY input, because the poisoned value ESCAPES the
+> identifier into struct-typed slots (`getOptions` return, `this.options` field)
+> that the poison never re-types — a total host-mode parse break, strictly worse
+> than this narrow `getOptions` quirk. So this host bug is live again. The
+> **real cure is the escape-discipline substrate slice #2944** (externref-typed
+> escapes for poisoned `$Object` values); this issue is `blocked_on: 2944`.
+> Standalone is UNAFFECTED (its poison was never reverted). The reduced host
+> arms in `tests/issue-2849.test.ts` are marked `it.fails` pinned here — they
+> flip red (forcing restoration) when #2944 lands.
 
 # #2849 — dynamic-object property mis-typed when read in heterogeneous (string-`===` / `==null` AND numeric) contexts
 

--- a/plan/issues/2937-acorn-host-object-hash-poison-null-deref-regression.md
+++ b/plan/issues/2937-acorn-host-object-hash-poison-null-deref-regression.md
@@ -1,7 +1,8 @@
 ---
 id: 2937
 title: "Regression: host-mode $Object-hash poison (#2849) makes compiled-acorn parse null-deref on every input"
-status: ready
+status: done
+completed: 2026-07-02
 created: 2026-07-02
 updated: 2026-07-02
 priority: high
@@ -15,8 +16,26 @@ goal: runtime-eval
 sprint: current
 parent: 2927
 depends_on: []
-related: [2849, 2584, 2432, 1712, 1710, 2850, 2853]
+related: [2849, 2584, 2432, 1712, 1710, 2850, 2853, 2944]
 ---
+
+> **FIXED BY REVERT (2026-07-02, tech-lead decision).** Backed out PR #2432's
+> host extension of the `objectHashConsumerVars` poison — restored the
+> `if (ctx.standalone)` gate at `declarations.ts` `collectEmptyObjectWidening`.
+> Compiled-acorn `parse("")`/`parse("1")`/all corpus inputs parse again in host
+> mode; standalone codegen is byte-identical (its poison was never touched). The
+> narrow #2849 host bug the extension had fixed **reopens** (`plan/issues/2849`
+> back to `blocked`), because the two constraints genuinely conflict under the
+> current representation model — the poisoned `$Object` value ESCAPES the
+> identifier (returned from `getOptions`, stored in the struct-typed
+> `this.options` field) into struct-typed slots the poison never re-types, so a
+> scoped receiver bail cannot fix it (measured: host poison + bail → 22/23 acorn
+> corpus inputs still throw; pure revert → all parse). Full escape analysis is
+> seeded into **#2944**. The **proper cure for BOTH** is the escape-discipline
+> substrate slice **#2944** (externref-typed escapes for poisoned `$Object`
+> values); the reverted host arms in `tests/issue-2849.test.ts` are
+> `it.fails`-pinned to it. (The "Fix direction" section below is the pre-decision
+> investigation record, superseded by this banner.)
 
 # #2937 — host-mode `$Object`-hash poison regresses compiled-acorn to a uniform null-deref
 
@@ -112,6 +131,7 @@ throw has line/col `0`, so it can't be located from the payload), recompile
 Acorn, and read which member-access site fires — then reduce from that site.
 
 ### Reduced shapes (verbatim — all returned the CORRECT value in host mode on
+
 current `main`; extend these toward the Acorn trigger)
 
 Each is `compile(src, { fileName: "t.ts" })` → instantiate → `wrapExports` →
@@ -119,36 +139,84 @@ Each is `compile(src, { fileName: "t.ts" })` → instantiate → `wrapExports` �
 
 ```ts
 // P1 — for-in copy of a primitive + a poisoning static write, static read (=13)
-const src: any = { ecmaVersion: 13 }; const o: any = {};
-for (const k in src) { o[k] = src[k]; } o.extra = 1; return o.ecmaVersion;
+const src: any = { ecmaVersion: 13 };
+const o: any = {};
+for (const k in src) {
+  o[k] = src[k];
+}
+o.extra = 1;
+return o.ecmaVersion;
 
 // P2 — copied value is an OBJECT, then chained read (=42)
-const inner: any = { v: 42 }; const src: any = { node: inner }; const o: any = {};
-for (const k in src) { o[k] = src[k]; } o.extra = 1; return o.node.v;
+const inner: any = { v: 42 };
+const src: any = { node: inner };
+const o: any = {};
+for (const k in src) {
+  o[k] = src[k];
+}
+o.extra = 1;
+return o.node.v;
 
 // P3 — bracket-write of an object, static read returns object, member access (=7)
-const o: any = {}; const key = "node"; o[key] = { v: 7 }; o.flag = 1; return o.node.v;
+const o: any = {};
+const key = "node";
+o[key] = { v: 7 };
+o.flag = 1;
+return o.node.v;
 
 // P4 — static read of copied object into a local, then member access (=99)
-const inner: any = { v: 99 }; const src: any = { keywords: inner }; const o: any = {};
-for (const k in src) { o[k] = src[k]; } o.pos = 0; const kw: any = o.keywords; return kw.v;
+const inner: any = { v: 99 };
+const src: any = { keywords: inner };
+const o: any = {};
+for (const k in src) {
+  o[k] = src[k];
+}
+o.pos = 0;
+const kw: any = o.keywords;
+return kw.v;
 
 // E1 — ESCAPE: poisoned object RETURNED from a fn, caller reads chained (=42)
-function make(): any { const src: any = { ecmaVersion: 13, node: { v: 42 } };
-  const o: any = {}; for (const k in src) { o[k] = src[k]; } o.extra = 1; return o; }
+function make(): any {
+  const src: any = { ecmaVersion: 13, node: { v: 42 } };
+  const o: any = {};
+  for (const k in src) {
+    o[k] = src[k];
+  }
+  o.extra = 1;
+  return o;
+}
 // test(): const opts: any = make(); return opts.node.v;
 
 // E2 — ESCAPE via `this`: ctor builds poisoned obj on this.options, method reads (=13)
-class P { options: any; constructor(opts: any) { const src: any = opts; const o: any = {};
-  for (const k in src) { o[k] = src[k]; } o.extra = 1; this.options = o; }
-  read(): number { return this.options.ecmaVersion; } }
+class P {
+  options: any;
+  constructor(opts: any) {
+    const src: any = opts;
+    const o: any = {};
+    for (const k in src) {
+      o[k] = src[k];
+    }
+    o.extra = 1;
+    this.options = o;
+  }
+  read(): number {
+    return this.options.ecmaVersion;
+  }
+}
 // test(): const p = new P({ ecmaVersion: 13 }); return p.read();
 
 // E3 — getOptions-exact: default-copy + `in`-guard + ecmaVersion normalize (=13)
 const defaults: any = { ecmaVersion: 5, sourceType: "script" };
-function getOptions(opts: any): any { const options: any = {};
-  for (const opt in defaults) { options[opt] = (opts && opt in opts) ? opts[opt] : defaults[opt]; }
-  if (options.ecmaVersion >= 2015) { options.ecmaVersion -= 2009; } return options; }
+function getOptions(opts: any): any {
+  const options: any = {};
+  for (const opt in defaults) {
+    options[opt] = opts && opt in opts ? opts[opt] : defaults[opt];
+  }
+  if (options.ecmaVersion >= 2015) {
+    options.ecmaVersion -= 2009;
+  }
+  return options;
+}
 // test(): const o: any = getOptions({ ecmaVersion: 2022 }); return o.ecmaVersion;  // 13
 ```
 

--- a/plan/issues/2944-poisoned-object-escape-externref-discipline.md
+++ b/plan/issues/2944-poisoned-object-escape-externref-discipline.md
@@ -93,11 +93,11 @@ stays fixed.
 
 - **The escape mechanism, instrumented firing site, and measured
   revert-vs-bail comparison** are captured in the "The conflict" section above
-  (root-caused during #2937). `plan/issues/2937-*.md` has the symptom, the
+  (root-caused during #2937). The #2937 issue file has the symptom, the
   bisect to PR #2432, and the fixed-by-revert banner.
 - **#2849 design** (the poison, `objectHashConsumerVars`, the sidecar-wins
-  strategy (b) and why (a)/(c) were rejected): `plan/issues/2849-*.md`
-  "Corrected Root Cause & Design".
+  strategy (b) and why (a)/(c) were rejected): the #2849 issue file's
+  "Corrected Root Cause & Design" section.
 - WIP receiver-identifier bail (the incomplete first half — a foundation, NOT a
   fix): earlier commit on branch `issue-2937-acorn-host-poison` history
   (superseded by the revert; recover from git if useful).

--- a/plan/issues/2944-poisoned-object-escape-externref-discipline.md
+++ b/plan/issues/2944-poisoned-object-escape-externref-discipline.md
@@ -1,0 +1,105 @@
+---
+id: 2944
+title: "Substrate: poisoned $Object values escape into struct-typed slots — externref-typed escape discipline for hash-consumer vars"
+status: ready
+created: 2026-07-02
+priority: high
+horizon: xl
+feasibility: hard
+reasoning_effort: max
+task_type: bug
+area: codegen
+language_feature: dynamic-object-property-type-inference
+goal: acorn-dogfood
+related: [2849, 2937, 2584, 2372, 2432, 2896, 1712]
+depends_on: []
+blocks: [2849, 2937]
+---
+
+# #2944 — externref-typed escape discipline for poisoned `$Object` (hash-consumer) vars
+
+**[SENIOR-DEV ONLY] — substrate slice.** This is the proper home for BOTH #2849
+(dynamic-object static-write shadows sidecar, host mode) and #2937 (the acorn
+uniform null-deref that the #2849 host fix caused). A scoped resolver change
+cannot satisfy both; a value-representation slice is required.
+
+## The conflict (why a scoped fix is impossible)
+
+The `#2584`/`#2372`/`#2849` **poison** (`ctx.objectHashConsumerVars`,
+`markObjectHashConsumers` in `declarations.ts`) keeps a `{}` var that has BOTH
+dynamic-key access (`o[k]=`, `k in o`, `for (k in o)`, `Object.keys/…`) AND
+static-named access on the `$Object` **sidecar** — it suppresses widening into a
+closed WasmGC struct so writes + reads share one representation.
+
+**The gap (root-caused for #2937, instrumented):** the poison is honored **ONLY
+at the widening DECISION**. `objectHashConsumerVars` is consulted nowhere in the
+read/write codegen. So:
+
+1. The poison keeps the _value_ a `$Object`, but the read/write paths still
+   resolve the receiver via `resolveStructName(TS-type)`, which can bind the
+   poisoned var to a colliding `__anon` struct registered under the SAME TS
+   object type by a _different_ (non-poisoned) same-shaped var. Instrumented on
+   acorn: `options.ecmaVersion` → `resolveStructName` returns `__anon_4`
+   (idx 46, an `ecmaVersion`-bearing struct) while `poisoned=true` and
+   `widenedVarStruct=undefined` → `struct.get` on a `$Object` value → null.
+2. Worse, the poisoned `$Object` value **ESCAPES the identifier**: `getOptions`
+   RETURNS `options`, the caller stores it in the struct-typed `this.options`
+   field, then reads `this.options.ecmaVersion` via that struct binding — a
+   **non-identifier** access. A receiver-identifier bail (attempted in #2937,
+   commit on branch `issue-2937-acorn-host-poison`) fixes parser SETUP but only
+   1/23 corpus inputs, because the escaped value is read through struct-typed
+   slots the bail cannot reach.
+
+Measured proof (#2937): host poison ON + identifier bail → 22/23 acorn corpus
+inputs still throw; pure revert (poison OFF in host) → all 23 parse but #2849
+reopens. The two constraints (**#2849 fixed AND compiled-acorn parses**) cannot
+both hold with a scoped resolver change — the poison's "keep as `$Object`" only
+half-propagates.
+
+## Required fix (the substrate slice)
+
+Propagate the "this value is a `$Object` (poisoned), not a struct" decision
+through every place a poisoned value **escapes** the declaring identifier, so
+downstream reads use the dynamic host/`$Object` path instead of `struct.get`:
+
+- **Return type**: a function that returns a poisoned var must have its inferred
+  return type lowered to externref/`$Object`, not the colliding anon struct.
+- **Field assignment**: `this.f = <poisoned>` (and any `x.f = <poisoned>`) must
+  type field `f` as externref so `x.f.prop` reads via `__extern_get`.
+- **Param passing / aliasing**: passing a poisoned var as an argument, or
+  `const y = <poisoned>`, must carry the externref typing to the callee/alias.
+
+Equivalent alternative (broader, more work): unify the `$Object`/struct read
+path so ANY read of a _possibly_-`$Object` value uses the dynamic host path —
+this is the value-rep substrate direction (#2896 family). Either way the read
+site must stop binding a poisoned/escaped value to a struct type it isn't.
+
+Then RE-EXTEND the poison to host (re-drop the `ctx.standalone` gate that #2937
+restored) — with escapes handled, host acorn stays green AND #2849's host bug
+stays fixed.
+
+## Acceptance
+
+- Re-drop the host gate in `collectEmptyObjectWidening` AND land the escape
+  discipline together: compiled-acorn dogfood corpus back to ≥ the 2026-06-30
+  baseline (≥13 equal±quirks) in host mode.
+- `tests/issue-2849.test.ts`: the 4 host arms currently marked `it.fails`
+  (3 guard variants + DEAD_BRANCH) flip back to plain `it` and pass
+  (host `2022 → 13`, unreached-write reads `2022`).
+- Standalone codegen byte-identical (its poison is unchanged throughout).
+- 0 test262 regressions; full `merge_group` + standalone floor.
+
+## Seed material
+
+- **The escape mechanism, instrumented firing site, and measured
+  revert-vs-bail comparison** are captured in the "The conflict" section above
+  (root-caused during #2937). `plan/issues/2937-*.md` has the symptom, the
+  bisect to PR #2432, and the fixed-by-revert banner.
+- **#2849 design** (the poison, `objectHashConsumerVars`, the sidecar-wins
+  strategy (b) and why (a)/(c) were rejected): `plan/issues/2849-*.md`
+  "Corrected Root Cause & Design".
+- WIP receiver-identifier bail (the incomplete first half — a foundation, NOT a
+  fix): earlier commit on branch `issue-2937-acorn-host-poison` history
+  (superseded by the revert; recover from git if useful).
+- Instrumentation recipe: `DBG_THROW_SITES` env hooks in `typeErrorThrowInstrs`
+  / `resolveStructNameForExpr` / `markObjectHashConsumers` (see #2937 analysis).

--- a/src/codegen/declarations.ts
+++ b/src/codegen/declarations.ts
@@ -2225,20 +2225,29 @@ export function collectEmptyObjectWidening(
           // stays a `$Object`. Scan the whole enclosing statement list (the same
           // tree `collectPropsFromStatements` walks).
           //
-          // (#2849) This was ORIGINALLY `ctx.standalone`-gated on the assumption
-          // "host keeps the struct fast path via the live-mirror Proxy". That
-          // assumption is false for the for-in copy pattern
-          // (`o={}; for (k in d) o[k]=src[k]; … o.prop`): the dynamic-key writes
-          // `o[k]=` land in the sidecar, but a STATIC-named write `o.prop = c`
-          // anywhere (even an unreached branch) widens `prop` into a real struct
-          // field via `collectPropsFromStatements`, so the read `o.prop` lowers
-          // to `struct.get` of the empty field (0) — the Proxy never bridges the
-          // for-in-write→struct-read divergence. Applying the poison in host mode
-          // too keeps such objects on `$Object` so writes + reads share one
-          // representation. Vars with only static access are NOT poisoned, so the
-          // struct fast path (and its byte output) is unchanged.
-          for (const s of stmts) {
-            markObjectHashConsumers(s, varName, ctx.objectHashConsumerVars);
+          // (#2849 extended this poison to host; #2937 REVERTS that extension —
+          // restored to standalone-only.) Why the revert: extending the poison to
+          // host kept acorn's for-in-copied `{}` vars (e.g. `getOptions`'s
+          // `options`) on `$Object`, but the poison is honored ONLY at this
+          // widening DECISION — the read/write codegen still resolves such a
+          // receiver via `resolveStructName(TS-type)`, which mis-binds it to a
+          // colliding `__anon` struct registered under the same TS object type.
+          // Worse, the poisoned `$Object` value ESCAPES the identifier (returned
+          // from `getOptions`, stored in the struct-typed `this.options` field,
+          // read via `this.options.ecmaVersion`) into struct-typed slots a
+          // receiver-level bail cannot reach → compiled-acorn null-dereferenced on
+          // EVERY host-mode input (#2937). A total host-mode parse break is
+          // strictly worse than the narrow `getOptions` shape bug the host
+          // extension fixed (which existed quietly for months), so the gate is
+          // restored to standalone-only. The proper cure — externref-typed escape
+          // discipline for poisoned `$Object` values — is the substrate slice
+          // #2944 (see #2937 / #2849). Standalone keeps the poison (unchanged; the
+          // #2584/#2372 divergences it guards are real there, and standalone
+          // codegen stays byte-identical).
+          if (ctx.standalone) {
+            for (const s of stmts) {
+              markObjectHashConsumers(s, varName, ctx.objectHashConsumerVars);
+            }
           }
 
           // (#2372) Standalone: if any `Object.defineProperty(varName, …)` on

--- a/tests/issue-2849.test.ts
+++ b/tests/issue-2849.test.ts
@@ -15,6 +15,20 @@
 //   if (o.ecmaVersion === "latest") …            // static-named guard write
 //   else if (o.ecmaVersion == null) …
 //   else if (o.ecmaVersion >= 2015) o.ecmaVersion -= 2009;   // 2022 → 13
+//
+// (#2937 REVERT) The host extension of the poison was REVERTED in #2937: extending
+// it to host kept acorn's poisoned `{}` vars on `$Object`, but the poisoned value
+// ESCAPES into struct-typed slots (return / `this.options` field) the poison never
+// re-types, so compiled-acorn null-dereferenced on EVERY host-mode input — strictly
+// worse than this narrow `getOptions` quirk. So the HOST for-in-copy-WITH-GUARD arms
+// below now reopen the pre-#2849 host bug (`o.ecmaVersion` reads back the widened
+// struct default, not the sidecar value) and are marked `it.fails` — a HONEST
+// known-fail pinned to reopened #2849, whose real cure is the escape-discipline
+// substrate slice #2944. When #2944 lands, `it.fails` flips red, forcing these arms
+// back to plain `it`. Standalone is UNCHANGED (its poison was never reverted) and
+// the host NO-GUARD + STATIC-ONLY arms still pass (the guard is what triggers the
+// widen→sidecar divergence).
+const HOST_KNOWN_FAIL_2849 = new Set(["== null guard", '=== "latest" guard', "numeric-only guard"]);
 
 import { describe, it, expect } from "vitest";
 import { compile } from "../src/index.js";
@@ -69,7 +83,11 @@ const variants: Record<string, string> = {
 describe("#2849 dynamic-object static-write field-vs-sidecar coherence", () => {
   for (const [name, guard] of Object.entries(variants)) {
     const src = FORIN_COPY.replace("__GUARD__", guard);
-    it(`host: for-in copy + [${name}] normalises 2022 → 13`, async () => {
+    // (#2937) The guard-bearing host arms reopen the #2849 host bug after the
+    // revert — mark them known-fail (blocked on substrate #2944). The no-guard
+    // host arm still normalises correctly (no string/null guard → no divergence).
+    const hostIt = HOST_KNOWN_FAIL_2849.has(name) ? it.fails : it;
+    hostIt(`host: for-in copy + [${name}] normalises 2022 → 13`, async () => {
       expect(await runHost(src, 2022)).toBe(13);
     });
     it(`standalone: for-in copy + [${name}] stays pure and does not trap`, async () => {
@@ -88,7 +106,9 @@ export function run(ev) {
   if (ev < 0) { o.ecmaVersion = 999; }   // never taken for ev = 2022
   return o.ecmaVersion;
 }`;
-  it("host: unreached static write does not shadow the sidecar (reads 2022)", async () => {
+  // (#2937) Known-fail after the revert (reopened #2849, blocked on #2944): the
+  // unreached static write again shadows the sidecar in host mode.
+  it.fails("host: unreached static write does not shadow the sidecar (reads 2022)", async () => {
     expect(await runHost(DEAD_BRANCH, 2022)).toBe(2022);
   });
   it("standalone: unreached static write compiles pure and does not trap", async () => {


### PR DESCRIPTION
Revert of #2432's host extension — fixes #2937 (compiled-acorn null-deref on all host-mode inputs); #2849 host-mode bug reopens, blocked on the escapes substrate (#2944).

## What changed
PR #2432 dropped the `ctx.standalone` gate on `collectEmptyObjectWidening`'s `markObjectHashConsumers` loop (`src/codegen/declarations.ts`), extending the #2584/#2849 `objectHashConsumerVars` poison to host mode. This restores the standalone-only gate.

## Why revert (the two constraints genuinely conflict)
The poison is honored ONLY at the widening DECISION — no read/write codegen site consults `objectHashConsumerVars`. So it keeps a for-in-copied `{}` var's VALUE a `$Object`, but reads/writes still resolve the receiver via `resolveStructName(TS-type)`, which mis-binds it to a colliding `__anon` struct; and worse, the poisoned value ESCAPES the identifier (`getOptions` returns `options` → struct-typed `this.options` field → `this.options.ecmaVersion`) into struct-typed slots a receiver-level bail cannot reach. Result: compiled-acorn null-dereferenced on EVERY host-mode input, including `parse("")` (parser setup) — a total host-parse block, strictly worse than the narrow `getOptions` shape bug the host extension fixed (which existed quietly for months).

Measured (dev-f2, instrumented): host poison + a scoped receiver-identifier bail → 22/23 acorn corpus inputs still throw; pure revert → all parse. So no scoped resolver change satisfies both #2849-fixed AND acorn-parses.

## Evidence
- Acorn dogfood corpus: **22/22 threw → 21 equal±quirks / 0 real / 2 threw** (above the 2026-06-30 baseline of 13 equal±quirks). `parse("")`/`parse("1")`/all corpus inputs return a `Program` again. The 2 residual throws are the pre-existing #2850/#2853 gaps (unmasked, not this regression).
- Standalone codegen byte-identical (its poison is untouched).
- `tests/issue-2849.test.ts`: 11/11 green — the 4 host for-in-copy-WITH-GUARD arms are marked `it.fails` (honest known-fail pinned to reopened #2849 / substrate #2944; they flip red, forcing restoration, once #2944 lands). Host no-guard + static-only + all standalone arms still pass.

## Issue bookkeeping
- **#2849** reopened: `done → blocked`, `blocked_on: 2944`.
- **#2937** `done` (fixed-by-revert), cross-refs #2944.
- **#2944** filed [SENIOR-DEV]: "poisoned $Object values escape into struct-typed slots — externref-typed escape discipline for hash-consumer vars", carrying the full escape analysis + #2849 design as the spec seed. This is the proper home for BOTH bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8

---

## Accepted-cost accounting (merge_group re-validation, run 28565120195)

This revert is **net −137 host test262** and was **greenlit by the tech lead** with the rationale below. Recording the full accounting for the queue and the reporting record.

**1. Full −137 accounting**
- **Host lane:** 151 regressions, **net −137 pass** (34773 → 34636), 14 improvements. Categories: `assertion_fail` 126, `other` 14, `runtime_error` 8, `type_error` 2, `wasm_compile` 1. The lone compile regression is `test/built-ins/Object/defineProperty/15.2.3.6-4-394.js`. **All 151 are the `dynamic_object_property` (#2849) class** — zero unrelated collateral.
- **Standalone lane:** **0 regressions, net +0** (27190 → 27190) — the revert is **byte-inert on standalone** (its poison was never touched), as claimed.

**2. Acorn-vs-test262 rationale (tech-lead decision, for the record)**
A silent wrong-value / null-deref on **every input** of compiled-acorn (a flagship real program, the #2927 critical path) is the worst failure class — strictly worse than visible, catalogued test262 fails. The −137 merely **restores the pre-#2432 status quo** of two days ago (red for months; nothing depends on 1-day-old green). #2432's host-poison extension was a net-positive test262 change that _also_ silently broke compiled-acorn via the escape case; keeping it would strand the entire acorn critical path.

**3. Metric note (carry in gap reporting)**
The js-host baseline drops ~137, which **mechanically shrinks the standalone-vs-host gap for a non-improvement reason**. Gap accounting must flag this so the narrowed gap is NOT reported as progress.

**4. Proper fix**
Both #2849 (host getOptions shape) and #2937 (acorn null-deref) are properly fixed by **#2944** — externref-typed escape discipline for poisoned `$Object` values — which keeps the 151 host wins AND fixes acorn. Filed, spec-seeded (full escape analysis + #2849 design), senior-queued `[SENIOR-DEV][XL]`. This revert is the interim measure until #2944 lands; #2849 is reopened `blocked_on: #2944`, its 4 host arms `it.fails`-pinned so they flip red (forcing restoration) when #2944 fixes them.