### PR TITLE
feat(#2924): new Function(<const>) compile-away — slice-1 (JS-host lane)

### DIFF
--- a/plan/issues/2924-new-function-constant-body-compile-away.md
+++ b/plan/issues/2924-new-function-constant-body-compile-away.md
@@ -1,6 +1,6 @@
 ---
 id: 2924
-title: "new Function(\"<const>\") compile-away MVP — replace the no-op stub"
+title: 'new Function("<const>") compile-away MVP — replace the no-op stub'
 status: ready
 created: 2026-07-02
 updated: 2026-07-02
@@ -29,7 +29,7 @@ Second landable slice — pure AOT, **standalone-safe**, no interpreter.
 `new Function(...)` / `Function(...)` currently lowers to a **no-op stub**
 (`src/codegen/expressions/new-super.ts` ~line 3179): it evaluates the arguments
 for side effects and returns `ref.null.extern` — a "function" that returns
-`undefined`. Every test that actually *calls* the constructed function fails
+`undefined`. Every test that actually _calls_ the constructed function fails
 (119 `new Function(` tests fail today, roadmap §5.2), and standalone gets
 nothing.
 
@@ -61,7 +61,7 @@ Replace the no-op stub with a compile-away path:
 ## Edge cases
 
 - **`Function()` no args** → `function anonymous() {}` (empty body). Returns a
-  callable that returns `undefined` — but a *real* callable, not `ref.null`.
+  callable that returns `undefined` — but a _real_ callable, not `ref.null`.
 - **Multiple param strings** — `new Function("a", "b,c", "return a+b+c")`:
   params flatten across args (`a`, `b`, `c`).
 - **Body parse error** → real JS throws `SyntaxError`. Emit the compile-time
@@ -74,12 +74,63 @@ Replace the no-op stub with a compile-away path:
 
 ## Acceptance criteria
 
-- [ ] `new Function("a","b","return a+b")(1,2) === 3` in **standalone** mode.
-- [ ] `Function("return 42")() === 42` (plain call form) standalone.
-- [ ] `new Function("a", "b,c", "return a+b+c")(1,2,3) === 6` standalone.
-- [ ] A body referencing a caller local resolves it as a global (no capture).
-- [ ] `new Function("return")()` returns `undefined` via a real callable.
-- [ ] No regression in existing `new Function` tests.
+**Slice 1 (this PR) — JS-host lane only:**
+
+- [x] `new Function("a","b","return a+b")(1,2) === 3` on the **JS-host lane**.
+      (headline, minus the standalone half — see the gate rationale below)
+- [x] single-param + no-param const bodies, single call — host.
+- [x] reuse across **separate statements** correct — host.
+- [x] a **non-constant** argument bails gracefully to the legacy stub — compiles,
+      never miscompiles (negative test).
+- [x] **standalone / WASI**: the compile-away is GATED OFF → the pre-existing
+      stub (compiles host-free, no miscompile, no trap) — verified by test.
+- [x] No regression in existing `new Function` tests (the stub still handles
+      every non-const / unsupported / standalone case).
+
+**Gate rationale (ship decision, tech-lead call 2026-07-02):** the synthesized
+function has all-externref params, and externref-param closures hit a
+**PRE-EXISTING standalone call-marshalling bug** — two calls coexisting in one
+expression (`f(1)+f(2)`) or a ≥3-arg call silently return a WRONG value on the
+standalone lane. **Control-verified this is NOT this feature's bug and NOT a
+quick temp fix**: a plain `function(a:any){ return a+10; }` closure reused as
+`f(1)+f(2)` returns the same wrong value in standalone (a typed `a:number`
+closure is correct — typed params take a different, working path). Since those
+edges can't be detected at the `new Function` site to bail, and we do not ship
+silent wrong values in ANY lane (never-miscompile bar), the compile-away is
+gated to the JS-host lane. Standalone enablement is **#2945**, blocked on fixing
+the externref-param-closure standalone marshalling bug.
+
+**Deferred to follow-up slices (explicit NON-GOALS of slice 1):**
+
+- [ ] **Standalone enablement — #2945** (blocked on the externref-param-closure
+      standalone marshalling fix; carries the full collision analysis).
+- [ ] Plain-call value form `Function("return 42")()` — routed in `calls.ts`,
+      not `compileNewExpression`; not yet wired.
+- [ ] `new Function("return")()` / `new Function()()` → `undefined` — currently
+      the no-value result is the stub `null`, not the `undefined` singleton.
+- [ ] no-capture `typeof x` string-return — the empty-`localMap` global compile
+      is in place; the string-return marshalling needs confirming.
+
+## Implementation (dev-f2, 2026-07-02) — slice 1, JS-host lane
+
+`tryCompileConstantFunctionCtor` in `src/codegen/expressions/new-super.ts`,
+wired into the `new Function(...)` stub. On the JS-host lane, when every arg is
+a constant string it: resolves them via `resolveConstantString`, synthesizes
+`function <synth>(<params>) { <body> }` as a foreign `SourceFile`, compiles it
+with an **empty enclosing `localMap`** (global scope, no lexical capture —
+§20.2.1.1), and escapes it as a callable via `emitCachedFuncClosureAccess`
+(stable identity, reusable) / `emitFuncRefAsClosure`. Reuses #2442's
+foreign-binding-less `compileNestedFunctionDeclaration` tolerance.
+Rollback-guarded (snapshots `mod.functions.length` + `funcMap` so a mid-body
+compile throw can't leave a half-registered empty-body function). Standalone /
+WASI return early → the pre-existing stub (see the gate rationale above).
+
+`tests/issue-2924.test.ts` (6/6): host working shapes, host reuse-across-
+statements, the graceful non-const bail (negative), and the standalone
+gated-to-stub clean-compile assertion.
+
+Stacked on #2442 (the eval-broaden `compileNestedFunctionDeclaration`
+foreign-tolerance); re-base onto `main` once #2442 lands, then PR.
 
 ## Notes
 

--- a/plan/issues/2945-externref-param-closure-standalone-call-marshalling.md
+++ b/plan/issues/2945-externref-param-closure-standalone-call-marshalling.md
@@ -1,0 +1,89 @@
+---
+id: 2945
+title: "Standalone: externref/any-param closure returns a wrong value on multi-arg or two-calls-in-one-expression (call-marshalling temp collision)"
+status: ready
+created: 2026-07-02
+priority: medium
+horizon: l
+feasibility: hard
+task_type: bug
+area: codegen
+language_feature: closures
+goal: standalone
+related: [2924, 2442]
+blocks: [2924]
+---
+
+# #2945 — externref/any-param closure standalone call-marshalling temp collision
+
+## Problem
+
+On the **standalone** lane, a closure whose parameters are `any`/externref
+returns a WRONG value when either:
+
+- two calls to the same closure coexist in ONE expression (`f(1)+f(2)`), or
+- the call passes **≥3 args**.
+
+Single calls and reuse across **separate statements** are correct, and the
+**JS-host lane is correct** on every shape. A **typed**-param closure
+(`function(a:number){…}`) is also correct — only the `any`/externref-param path
+is affected.
+
+This is a general standalone closure-call correctness bug (not specific to any
+feature). It surfaced while shipping #2924 (`new Function(<const>)`
+compile-away): a `new Function`-synthesized function has all-externref params
+(foreign, binding-less), so it inherits this bug — which is why #2924 slice-1 is
+gated to the JS-host lane. **This issue blocks #2924's standalone enablement.**
+
+## Repro (standalone; measured 2026-07-02)
+
+```ts
+// WRONG (standalone): returns an empty/garbage value instead of 23
+export function test(): any {
+  const f: any = function (a: any) {
+    return a + 10;
+  };
+  return f(1) + f(2); // two calls coexisting in one expression
+}
+
+// WRONG (standalone): ≥3 args → NaN
+export function test(): any {
+  const f: any = function (a: any, b: any, c: any) {
+    return a + b + c;
+  };
+  return f(1, 2, 3);
+}
+
+// CORRECT (standalone) — same shapes that WORK, for contrast:
+//  - typed params:            function (a: number) { … }; f(1)+f(2)  === 23
+//  - reuse across statements: const x=f(1); const y=f(2); return x+y === 23
+//  - single call:             f(1) === 11
+```
+
+Host lane (`compile(src, { fileName })`) returns the correct value for ALL of
+the above.
+
+## Suspected mechanism
+
+A **temp-local collision** in the standalone `call_ref`/closure-call arg
+marshalling for externref-param closures: when two calls' argument temps (or the
+call results) must coexist on the stack in one expression, the second call
+reuses a fixed temp that clobbers the first, and the ≥3-arg case overruns a
+fixed set of arg temps. Typed-param and single-call paths avoid the shared
+temp. Start from the closure-call lowering (`compileClosureCall` /
+`tryEmitInlineDynamicCall` and the externref-arg marshalling), auditing temp
+allocation for per-call uniqueness (`allocTempLocal`/release scoping).
+
+## Acceptance
+
+- The two repros above return `23` / `6` in **standalone** (and stay correct in
+  host); typed-param + single-call + reuse-across-statements stay correct.
+- Then #2924 can drop its `ctx.standalone || ctx.wasi` gate and enable the
+  compile-away on the standalone lane (host-free `new Function`).
+- 0 test262 regressions; full `merge_group` + standalone floor.
+
+## Pointers
+
+- #2924 gate site: `src/codegen/expressions/new-super.ts`
+  (`tryCompileConstantFunctionCtor`, the `if (ctx.standalone || ctx.wasi) return`).
+- Repro scripts (this branch, `.tmp/probe-2924-anyparam.mjs`, gitignored).

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -8,6 +8,7 @@ import { forEachChild, ts } from "../../ts-api.js";
 import {
   collectReferencedIdentifiers,
   collectWrittenIdentifiers,
+  emitCachedFuncClosureAccess,
   emitFuncRefAsClosure,
   isOwnParamName,
 } from "../closures.js";
@@ -50,7 +51,8 @@ import {
   registerCompileSuperPropertyAccess,
   resolveEnclosingClassName,
 } from "../shared.js";
-import { maybeSetArgcForKnownCall } from "../statements/nested-declarations.js";
+import { compileNestedFunctionDeclaration, maybeSetArgcForKnownCall } from "../statements/nested-declarations.js";
+import { resolveConstantString } from "./eval-inline.js";
 import { compileStringLiteral } from "../string-ops.js";
 import { coerceType as coerceTypeImpl, pushDefaultValue } from "../type-coercion.js";
 import { ensureDateDaysFromCivilHelper, ensureDateStruct } from "./builtins.js";
@@ -2425,6 +2427,133 @@ function emitCoerceElemToAnyrefInto(ctx: CodegenContext, fctx: FunctionContext, 
   for (const instr of scratch) out.push(instr);
 }
 
+// (#2924) Monotonic suffix so each synthesized Function-ctor gets a unique
+// funcMap name even when two call sites share a `pos` (a main-source site and a
+// same-offset site inside a foreign eval SourceFile).
+let __fnCtorSeq = 0;
+
+/**
+ * (#2924) `new Function("p1",…,"pn","body")` / `Function(…)` compile-away MVP.
+ *
+ * When EVERY argument is a compile-time-constant string, synthesize
+ * `function (<p1,…,pn>) { <body> }` and emit it as a real callable closure
+ * value. Per §20.2.1.1 the created function's scope is ALWAYS the global
+ * environment — it never captures the caller's lexical scope — so we compile
+ * the synthesized declaration with an EMPTY enclosing `localMap` (below): any
+ * free identifier in the body resolves as a global, never a caller local
+ * (the no-lexical-capture requirement).
+ *
+ * Returns the result `ValType` on success, or `undefined` to fall through to
+ * the legacy no-op stub (non-constant args, a parse error, an unsupported body,
+ * or a compile bail — all rolled back cleanly so the module is never corrupted).
+ */
+function tryCompileConstantFunctionCtor(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  expr: ts.NewExpression | ts.CallExpression,
+): ValType | undefined {
+  // (#2924 slice-1 — host-lane only.) The synthesized function has all-externref
+  // params (a binding-less foreign body degrades every param to `any`/externref
+  // per #2442). Externref-param closures hit a PRE-EXISTING standalone
+  // call-marshalling bug: two calls coexisting in one expression (`f(1)+f(2)`)
+  // or a ≥3-arg call silently return a WRONG value on the standalone lane —
+  // reproducible with a plain `function(a:any){…}` closure, so it is NOT this
+  // feature's bug and NOT a quick temp fix (it is a whole externref-closure
+  // class). Since those edges can't be detected at the `new Function` site to
+  // bail, and we do not ship silent wrong values in ANY lane, gate the
+  // compile-away to the JS-host lane; standalone / WASI keep the legacy stub
+  // (no miscompile). Standalone enablement is the follow-up #2945, which is
+  // blocked on fixing the externref-param-closure standalone marshalling bug.
+  if (ctx.standalone || ctx.wasi) return undefined;
+
+  const args = expr.arguments ?? [];
+
+  // Every argument must be a compile-time-constant string.
+  const parts: string[] = [];
+  for (const a of args) {
+    const s = resolveConstantString(a);
+    if (s === null) return undefined;
+    parts.push(s);
+  }
+
+  // Last arg is the body; the rest are the parameter list (comma-flattened per
+  // §20.2.1.1.1 CreateDynamicFunction, which joins the param args with ",").
+  const body = parts.length > 0 ? parts[parts.length - 1]! : "";
+  const paramList = parts.slice(0, -1).join(",");
+
+  const synthName = `__fn_ctor_${expr.pos}_${__fnCtorSeq++}`;
+  // Newlines around the body isolate a trailing `//` line comment from the
+  // closing brace, and match acorn's own `function anonymous(<params>\n) {\n<body>\n}`.
+  const src = `function ${synthName}(${paramList}) {\n${body}\n}`;
+
+  const sf = ts.createSourceFile(
+    "<Function>.ts",
+    src,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.JS,
+  );
+  // A parse error means the params/body were malformed. Real `Function` throws
+  // SyntaxError; for the MVP we fall through to the legacy path (no regression
+  // vs. today's stub). Emitting the SyntaxError is a follow-up (#2928 lane).
+  const parseDiag = (sf as unknown as { parseDiagnostics?: readonly ts.Diagnostic[] }).parseDiagnostics;
+  if (parseDiag && parseDiag.length > 0) return undefined;
+
+  const fnDecl = sf.statements[0];
+  if (!fnDecl || !ts.isFunctionDeclaration(fnDecl) || sf.statements.length !== 1) return undefined;
+
+  // Rollback anchors so a mid-body compile throw on a binding-less foreign node
+  // never leaves a half-registered (empty-body) function in the module.
+  const fnCountBefore = ctx.mod.functions.length;
+  const hadName = ctx.funcMap.has(synthName);
+
+  // Global-scope compile: swap the enclosing capture context to empty so the
+  // synthesized function captures NOTHING from the caller (§20.2.1.1). Capture
+  // detection in compileNestedFunctionDeclaration is name-based against
+  // `fctx.localMap`, so an empty map guarantees a no-capture (global) function.
+  const savedLocalMap = fctx.localMap;
+  const savedBoxed = fctx.boxedCaptures;
+  const savedTdz = fctx.tdzFlagLocals;
+  fctx.localMap = new Map();
+  fctx.boxedCaptures = undefined;
+  fctx.tdzFlagLocals = undefined;
+
+  let ok = false;
+  try {
+    compileNestedFunctionDeclaration(ctx, fctx, fnDecl);
+    ok = ctx.funcMap.has(synthName);
+  } catch {
+    ok = false;
+  } finally {
+    fctx.localMap = savedLocalMap;
+    fctx.boxedCaptures = savedBoxed;
+    fctx.tdzFlagLocals = savedTdz;
+  }
+
+  if (!ok) {
+    // Roll back any partial registration and fall through to the stub.
+    if (!hadName) {
+      ctx.funcMap.delete(synthName);
+      ctx.nestedFuncCaptures.delete(synthName);
+    }
+    if (ctx.mod.functions.length > fnCountBefore) ctx.mod.functions.length = fnCountBefore;
+    return undefined;
+  }
+
+  const funcIdx = ctx.funcMap.get(synthName);
+  if (funcIdx === undefined) return undefined;
+
+  // Escape the compiled global function as a first-class callable value.
+  // Prefer the cached-closure access (stable identity, reusable across multiple
+  // calls) exactly as the bare-function-identifier path does (identifiers.ts);
+  // the synthesized function is no-capture, so the cache applies. Fall back to a
+  // per-site closure struct if the cache emit is unavailable.
+  const cachedRefType = emitCachedFuncClosureAccess(ctx, fctx, synthName, funcIdx);
+  if (cachedRefType) return cachedRefType;
+  const refType = emitFuncRefAsClosure(ctx, fctx, synthName, funcIdx);
+  return refType ?? undefined;
+}
+
 function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: ts.NewExpression): ValType | null {
   // Handle `new function() { ... }(args)` — constructor with function expression
   if (ts.isFunctionExpression(expr.expression)) {
@@ -3172,12 +3301,21 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
     return { kind: "externref" };
   }
 
-  // Handle `new Function(...)` — dynamic code generation is not possible in Wasm.
-  // Emit a no-op function that returns undefined (ref.null extern) to prevent
-  // compile errors. Tests that rely on dynamic behavior will fail at runtime
-  // instead of at compile time, which is more informative.
+  // Handle `new Function(...)` / `Function(...)`.
+  // (#2924) MVP compile-away: when EVERY argument is a compile-time-constant
+  // string, `new Function(p1, …, pn, body)` is — per §20.2.1.1 — semantically a
+  // `function (p1,…,pn) { body }` whose scope is ALWAYS the global environment
+  // (never the caller's lexical scope), so it is identical to compiling that
+  // function at this site. Synthesize + compile it as a real callable value.
+  // Non-constant args fall through to the legacy no-op stub below.
   if (ts.isIdentifier(expr.expression) && expr.expression.text === "Function") {
-    // Compile and discard all arguments (they may have side effects)
+    const compiled = tryCompileConstantFunctionCtor(ctx, fctx, expr);
+    if (compiled !== undefined) return compiled;
+
+    // Legacy fallback (non-constant args, unsupported body, or a compile bail):
+    // evaluate args for side effects, return ref.null extern (a "function" that
+    // returns undefined). Dynamic-body `new Function` is deferred to the Tier-2
+    // interpreter (#2928).
     const args = expr.arguments ?? [];
     for (const arg of args) {
       const argResult = compileExpression(ctx, fctx, arg);
@@ -3185,7 +3323,6 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
         fctx.body.push({ op: "drop" });
       }
     }
-    // Return ref.null extern — represents a function that returns undefined
     fctx.body.push({ op: "ref.null.extern" });
     return { kind: "externref" };
   }

--- a/tests/issue-2924.test.ts
+++ b/tests/issue-2924.test.ts
@@ -1,0 +1,86 @@
+// (#2924) `new Function("<const>")` compile-away MVP — slice 1 (JS-host lane).
+//
+// When every argument to `new Function(...)` is a compile-time-constant string,
+// the constructor is compiled away into a real callable value (a global-scope
+// function, no lexical capture — §20.2.1.1) on the JS-host lane. Non-constant
+// args bail to the legacy no-op stub — never a miscompile.
+//
+// Slice-1 is deliberately HOST-LANE ONLY. The synthesized function has
+// all-externref params, and externref-param closures hit a pre-existing
+// standalone call-marshalling bug (two calls coexisting in one expression, or
+// ≥3 args, silently return a wrong value — reproducible with a plain
+// `function(a:any){…}`, so NOT this feature's bug). Rather than ship a silent
+// wrong value in the standalone lane, the compile-away is gated to JS-host;
+// standalone / WASI keep the pre-existing stub. Standalone enablement is #2945
+// (blocked on the externref-param-closure standalone marshalling fix).
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { wrapExports } from "../src/runtime.js";
+
+async function runHost(source: string): Promise<unknown> {
+  const r = await compile(source, { fileName: "t.ts" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const io: Record<string, unknown> = (r as unknown as { importObject?: Record<string, unknown> }).importObject ?? {};
+  const { instance } = await WebAssembly.instantiate(r.binary, io as WebAssembly.Imports);
+  (io.__setExports as ((e: unknown) => void) | undefined)?.(instance.exports);
+  const exp = wrapExports(instance.exports, {
+    signatures: (r as unknown as { exportSignatures?: unknown }).exportSignatures as never,
+  }) as Record<string, (...a: unknown[]) => unknown>;
+  return exp.test();
+}
+
+// Standalone: verify the compile-away is GATED OFF — the module compiles (bails
+// to the legacy stub), instantiates with EMPTY imports (host-free), and does not
+// trap. We deliberately do NOT assert the call's value (the stub is a no-op);
+// the point is "no miscompile, no leak, no crash".
+async function compileStandaloneCleanly(source: string): Promise<void> {
+  const r = await compile(source, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  (instance.exports as Record<string, (...a: unknown[]) => unknown>).test();
+}
+
+describe("#2924 new Function(<const>) compile-away — slice 1 (host lane)", () => {
+  it("two-param body, single call — host === 3", async () => {
+    expect(
+      await runHost(
+        `export function test(): number { const f: any = new Function("a","b","return a+b"); return f(1,2); }`,
+      ),
+    ).toBe(3);
+  });
+
+  it("one-param body — host === 42", async () => {
+    expect(
+      await runHost(`export function test(): number { const f: any = new Function("x","return x*2"); return f(21); }`),
+    ).toBe(42);
+  });
+
+  it("no-param body — host === 5", async () => {
+    expect(
+      await runHost(`export function test(): number { const f: any = new Function("return 5"); return f(); }`),
+    ).toBe(5);
+  });
+
+  it("reuse across separate statements — host === 23", async () => {
+    expect(
+      await runHost(
+        `export function test(): number { const f: any = new Function("a","return a+10"); const x: number = f(1); const y: number = f(2); return x+y; }`,
+      ),
+    ).toBe(23);
+  });
+
+  // NEGATIVE (host): a non-constant argument must bail to the legacy stub —
+  // compiles, the result is the null "function" placeholder, no miscompile.
+  it("non-constant arg bails gracefully to the stub (host)", async () => {
+    const src = `export function make(s: any): any { return new Function(s); }
+export function test(): number { const f: any = make("return 7"); return (f == null) ? 2 : (typeof f === "function" ? 1 : 3); }`;
+    expect(await runHost(src)).toBe(2); // f == null (stub) — not a wrong-value miscompile
+  });
+
+  // Standalone lane is gated off (→ stub): must compile clean + host-free + not trap.
+  it("standalone: gated to the stub — compiles host-free, no miscompile/trap", async () => {
+    await compileStandaloneCleanly(
+      `export function test(): number { const f: any = new Function("a","b","return a+b"); return typeof f === "function" ? 1 : 0; }`,
+    );
+  });
+});


### PR DESCRIPTION
Slice-1 of the runtime-eval roadmap (#1584 umbrella, §6-B). Replaces the `new Function(...)` no-op stub with a real compile-away on the **JS-host lane** when every argument is a compile-time-constant string.

## What it does
`new Function(p1,…,pn, body)` with all-const args is — per §20.2.1.1 — semantically `function (p1,…,pn){ body }` with **global scope** (never the caller's lexical scope). `tryCompileConstantFunctionCtor` (`src/codegen/expressions/new-super.ts`) synthesizes that function as a foreign `SourceFile`, compiles it with an **empty enclosing `localMap`** (so it captures NOTHING from the caller — the no-lexical-capture requirement), and escapes it as a callable via `emitCachedFuncClosureAccess`/`emitFuncRefAsClosure`. Reuses #2442's foreign-binding-less `compileNestedFunctionDeclaration` tolerance. Rollback-guarded: snapshots `mod.functions.length` + `funcMap` so a mid-body compile throw on a binding-less node can never leave a half-registered empty-body function.

## Working (tests/issue-2924.test.ts, 6/6)
- `new Function("a","b","return a+b")(1,2) === 3`, single-param, no-param, reuse-across-statements — **JS-host lane**.
- **Non-constant arg bails gracefully to the legacy stub** (negative test) — compiles, returns the null placeholder, never miscompiles.
- **Standalone/WASI gated to the stub** — compiles host-free, no miscompile, no trap (asserted).

## Why host-lane only (ship decision, tech-lead call)
The synthesized function has all-externref params, and externref-param closures hit a **pre-existing standalone call-marshalling bug**: two calls coexisting in one expression (`f(1)+f(2)`) or a ≥3-arg call silently return a WRONG value on the standalone lane. **Control-verified NOT feature-specific**: a plain `function(a:any){ return a+10; }` reused as `f(1)+f(2)` returns the same wrong value in standalone (a typed `a:number` closure is correct). Since these can't be detected at the `new Function` site to bail, and we don't ship silent wrong values in ANY lane, the compile-away is gated to JS-host. Standalone enablement is **#2945** (filed, carries the full collision analysis; blocks the standalone half of #2924).

## Non-goals (documented in the issue, follow-up slices)
Standalone enablement (#2945), plain-call value form `Function(...)()`, `undefined`-return representation, no-capture `typeof x` string-return.

Issue file rides the PR with the slice-1 acceptance checked + gate rationale + non-goals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8