### PR TITLE
refactor(#1916) S1: resolveLayout seam — handle→index resolution at emit (identity phase)

### DIFF
--- a/plan/issues/1916-symbolic-function-references-codegen.md
+++ b/plan/issues/1916-symbolic-function-references-codegen.md
@@ -1,13 +1,13 @@
 ---
 id: 1916
 title: "Symbolic function references in WasmGC codegen — retire the late-import index-shift machinery"
-status: blocked
-blocked_by: [2167]
+status: in-progress
+assignee: ttraenkler/dev-1916f
 pipeline_unblocked: 1927
 sprint: current
 model: fable
 created: 2026-06-10
-updated: 2026-06-24
+updated: 2026-07-02
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -15,6 +15,7 @@ task_type: refactor
 area: codegen
 language_feature: compiler-internals
 goal: maintainability
+related: [2710, 1899, 1985]
 ---
 # #1916 — Symbolic function references in WasmGC codegen
 
@@ -90,3 +91,73 @@ ts.Symbol**, with names demoted to debug metadata. The instance-side twin
 ($shape, #2009) covers struct identity; this issue owns function/registry
 identity. Full analysis: plan/log/analysis-2026-06/05-structure-review.md
 §3.
+
+## Reconciliation with #2710 + staged plan (dev-1916f, 2026-07-02)
+
+Unblocked: #2167 resolved — Fable re-enabled 2026-07-02 (coordinator
+direction); `blocked_by` cleared.
+
+**Foundation decision: #1916 builds ON #2710's landed FuncHandle
+foundation — it does NOT introduce a second identity mechanism.** While
+this issue was Fable-parked, #2710 ("late-bind module indices") landed
+slices 0+1 of the same migration: the `scripts/prove-emit-identity.mjs`
+byte-identity oracle and the `FuncHandle`/`GlobalHandle`/`TypeHandle`
+vocabulary pinned onto the discriminated `Instr` arms
+(`src/ir/types.ts`). #1916's original sketch (shared mutable `{index}`
+cells mutated by shifters) is **rejected** in favour of #2710's stable
+counter-minted handles + one `resolveLayout()` at serialization, for two
+reasons grounded in prior findings:
+
+1. **Mutable cells keep the class reachable** — every shifter must still
+   know about every cell holder (the same "did you remember to chase this
+   side-channel" discipline that produced the 7 regressions). Stable
+   handles + late resolve delete the shifters instead of teaching them.
+2. **#1899's implementation notes prove idx-keyed repair is unsound** —
+   a numeric funcIdx is ambiguous across shifts (a freed slot gets reused
+   by a different function), so identity must ride IN the instruction as
+   a layout-independent value. That is exactly the #2710 handle.
+
+The #1916 amendment's collision-free requirement is satisfied for the
+handle itself (monotonic counter, never reused, never renumbered — no
+name derivation). The registry-key collision class (name-keyed
+`funcMap.get(name)` returning the wrong entry — #1983/#1989) is
+orthogonal to index binding and stays tracked in those issues.
+
+**Slice mapping (each ships green + byte-identical via
+`prove-emit-identity`; #2710 slice numbers in parens):**
+
+- **S1 (=2710 slice 2) — resolver seam, identity.** THIS SLICE.
+  `src/emit/resolve-layout.ts` (`ModuleLayout` + identity `resolveLayout`)
+  armed per-emit in `emitBinaryWithSourceMap` next to `valCtx`; every
+  func/global reference serialization in `src/emit/binary.ts` now
+  dereferences through it: `call`, `return_call`, `ref.func`,
+  `global.{get,set}`, func/global export descriptors, element-segment
+  function lists, `declaredFuncRefs`, start section. Proof: 1215
+  (file,target) records — playground examples + 392-file test262 sample
+  × {gc, standalone, wasi}, 992 real binaries — **byte-identical**.
+  Late-shift class holds: issue-329/1677/1809/1839/1899/2191/2193/2918
+  suites green (51 tests) + new `tests/issue-1916-symbolic-func-refs.test.ts`.
+- **S2 (=2710 slice 3) — convert positional reads.** The ~94
+  `mod.functions[idx - numImportFuncs]` reads + `idx - numImportFuncs`
+  arithmetic become chokepoint accessors (registry-keyed); globals'
+  `localGlobalIdx`/`nextModuleGlobalIdx` analogues audited. Enumerate by
+  temporarily flipping the brand to `unique symbol` (tsc lists every
+  violation), convert, keep byte-identity.
+- **S3 (=2710 slice 4b/4c, func space — the heart of #1916).** Mint
+  stable func handles at registration; `resolveLayout` computes the real
+  permutation (imports in declaration order, then live defined funcs in
+  array order post-DCE — reproduces today's layout byte-for-byte); DELETE
+  the four func-index shifters (`shiftLateImportIndices`,
+  `reconcileNativeStrFinalizeShift`, the `addStringImports` /
+  `addUnionImports` inline shifters) + the `liveBodies`/
+  `parentBodiesStack` reachability bookkeeping; dead-elim stops
+  renumbering func refs (drops dead defs; layout skips dead handles).
+  Full CI + merge_group (broad-impact — never a scoped sweep).
+- **S4 (=2710 slice 4a/4d) — globals (`fixupModuleGlobalIndices` + ~25
+  cached fields, the #2078 site), then types (DCE renumber through
+  `resolveLayout`).** May land under #2710 directly.
+
+Coordination note: #2710 is claim-held by `ttraenkler/sd-indexshift`
+(2026-06-26, no active agent, no open PR). S1–S3 are being advanced
+under #1916 by `ttraenkler/dev-1916f` with a cross-note in #2710's log;
+the two issues share one mechanism and MUST NOT diverge.

--- a/plan/issues/2710-late-bind-module-indices-eliminate-index-shift-class.md
+++ b/plan/issues/2710-late-bind-module-indices-eliminate-index-shift-class.md
@@ -527,3 +527,33 @@ Files touched: `scripts/prove-emit-identity.mjs` (new), `src/ir/types.ts`
 ## Residual (as of #2199, PO reconcile 2026-06-28)
 
 NOT done — multi-slice refactor. Slices 0 (proof harness, no behavior change) + 1 (foundation) landed. Slices 2-4 — the actual late-bind of func/global/type indices that retires the late-index-shift class, each byte-identity-provable — remain. Stays in-progress.
+
+### Slice 2 — resolver seam landed under #1916 S1 (dev-1916f, 2026-07-02)
+
+#1916 (symbolic function references — Fable-gated, unblocked when #2167
+resolved 2026-07-02) is the same migration for the function index space;
+its slices are being executed AGAINST THIS PLAN, not as a parallel
+mechanism — see the "Reconciliation with #2710 + staged plan" section in
+`plan/issues/1916-symbolic-function-references-codegen.md` for the
+mapping (#1916 S1/S2/S3 = this issue's slices 2/3/4b+4c; slice 4a globals
++ 4d types stay here as S4).
+
+Slice 2 as landed: `src/emit/resolve-layout.ts` (`ModuleLayout` +
+identity `resolveLayout`, with the flip preconditions documented in the
+header) is armed per-emit in `emitBinaryWithSourceMap` (same lifecycle as
+`valCtx`); every func/global reference serialization in `binary.ts`
+dereferences through `fIdx`/`gIdx`: `call`, `return_call`, `ref.func`,
+`global.{get,set}`, func/global export descriptors, element-segment
+function lists, `declaredFuncRefs`, start section. Exported encode
+helpers run unarmed (raw passthrough) for the object-emitter path —
+identical to historical behaviour. Type-index seams intentionally NOT
+wired yet (slice 4d; the module-scoped arming pattern means no exported
+signature needs to change when they are). Proof: byte-identical over
+1215 (file,target) records (992 real binaries; playground + 392-file
+test262 sample × {gc, standalone, wasi}); late-shift regression suites
+(329/1677/1809/1839/1899/2191/2193/2918) green.
+
+Claim note: this issue's git lock (`ttraenkler/sd-indexshift`,
+2026-06-26) is stale — no active agent, no open PR on
+`issue-2710-late-bind-handles`. Work continues under #1916's claim
+(`ttraenkler/dev-1916f`).

--- a/src/emit/binary.ts
+++ b/src/emit/binary.ts
@@ -14,6 +14,7 @@ import type {
 } from "../ir/types.js";
 import { WasmEncoder } from "./encoder.js";
 import { GC, OP, SECTION, SIMD, TYPE } from "./opcodes.js";
+import { resolveLayout, type ModuleLayout } from "./resolve-layout.js";
 
 /** A source map entry: maps a wasm byte offset to a source position */
 export interface SourceMapEntry {
@@ -153,6 +154,34 @@ interface EmitValidationCtx {
 
 let valCtx: EmitValidationCtx | null = null;
 
+// ---------------------------------------------------------------------------
+// #1916/#2710 — handle→final-index resolution seam.
+//
+// `layout` is armed per-emit in `emitBinaryWithSourceMap` (same lifecycle as
+// `valCtx`) and dereferenced by `fIdx`/`gIdx` at every seam where a function or
+// global reference becomes bytes: `call`, `return_call`, `ref.func`,
+// `global.{get,set}`, export descriptors, element-segment function lists,
+// `declaredFuncRefs`, and the start section. When unarmed (the relocatable
+// object emitter and other direct callers of the exported encode helpers),
+// handles pass through raw — identical to the historical behaviour.
+//
+// IDENTITY PHASE: `resolveLayout` is the identity map (handles == live
+// indices), so this seam is byte-neutral (proven by
+// `scripts/prove-emit-identity.mjs`). The flip to real permutation happens in
+// `resolve-layout.ts` ONLY — see the preconditions documented there.
+// ---------------------------------------------------------------------------
+let layout: ModuleLayout | null = null;
+
+/** Resolve a function handle to its final function-index-space position. */
+function fIdx(h: number): number {
+  return layout ? layout.func(h) : h;
+}
+
+/** Resolve a global handle to its final global-index-space position. */
+function gIdx(h: number): number {
+  return layout ? layout.global(h) : h;
+}
+
 function makeValidationCtx(mod: WasmModule): EmitValidationCtx {
   let numImportFuncs = 0;
   let numImportGlobals = 0;
@@ -266,10 +295,15 @@ export function emitBinary(mod: WasmModule): Uint8Array {
  */
 export function emitBinaryWithSourceMap(mod: WasmModule): EmitResult {
   valCtx = process.env.JS2WASM_SKIP_INDEX_VALIDATION ? null : makeValidationCtx(mod);
+  // #1916/#2710 — resolve the final index layout once, at serialization: the
+  // single point that sees the fully-settled index space (post late imports,
+  // post DCE). All func/global references below dereference through it.
+  layout = resolveLayout(mod);
   try {
     return emitBinaryWithSourceMapUnguarded(mod);
   } finally {
     valCtx = null;
+    layout = null;
   }
 }
 
@@ -408,11 +442,12 @@ function emitBinaryWithSourceMapUnguarded(mod: WasmModule): EmitResult {
   // Start section — auto-run function on instantiation (#907)
   if (mod.startFuncIdx !== undefined) {
     enc.section(SECTION.start, (s) => {
+      const start = fIdx(mod.startFuncIdx!);
       if (valCtx) {
         valCtx.where = "start function";
-        vIdx("function", mod.startFuncIdx!, valCtx.numFuncs);
+        vIdx("function", start, valCtx.numFuncs);
       }
-      s.u32(mod.startFuncIdx!);
+      s.u32(start);
     });
   }
 
@@ -434,9 +469,10 @@ function emitBinaryWithSourceMapUnguarded(mod: WasmModule): EmitResult {
         s.byte(OP.end);
         s.u32(elem.funcIndices.length);
         if (valCtx) valCtx.where = "element-segment function list";
-        for (const idx of elem.funcIndices) {
-          if (valCtx) vIdx("function", idx, valCtx.numFuncs);
-          s.u32(idx);
+        for (const h of elem.funcIndices) {
+          const resolved = fIdx(h);
+          if (valCtx) vIdx("function", resolved, valCtx.numFuncs);
+          s.u32(resolved);
         }
       }
       // Declarative element segment for ref.func targets
@@ -445,9 +481,10 @@ function emitBinaryWithSourceMapUnguarded(mod: WasmModule): EmitResult {
         s.byte(0x00); // elemkind = funcref
         s.u32(mod.declaredFuncRefs.length);
         if (valCtx) valCtx.where = "declared func ref";
-        for (const idx of mod.declaredFuncRefs) {
-          if (valCtx) vIdx("function", idx, valCtx.numFuncs);
-          s.u32(idx);
+        for (const h of mod.declaredFuncRefs) {
+          const resolved = fIdx(h);
+          if (valCtx) vIdx("function", resolved, valCtx.numFuncs);
+          s.u32(resolved);
         }
       }
     });
@@ -510,7 +547,11 @@ function emitBinaryWithSourceMapUnguarded(mod: WasmModule): EmitResult {
     });
   }
 
-  // Custom "name" section — function names for debugging/treemap
+  // Custom "name" section — function names for debugging/treemap.
+  // NOTE (#1916/#2710): this section is built POSITIONALLY (imports in
+  // declaration order, then mod.functions in array order), which IS the final
+  // layout order by construction — it reads no handles, so it needs no
+  // resolution and stays correct after the handle flip.
   {
     const nameEntries: { index: number; name: string }[] = [];
     // Import functions
@@ -810,13 +851,16 @@ export function encodeGlobal(g: GlobalDef, enc: WasmEncoder): void {
 }
 
 export function encodeExport(exp: WasmExport, enc: WasmEncoder, _numImportFuncs: number): void {
+  // #1916/#2710 — func/global export descriptors carry handles; resolve to
+  // final indices here. Table/memory/tag spaces never shift and stay raw.
+  const k = exp.desc.kind;
+  const resolved = k === "func" ? fIdx(exp.desc.index) : k === "global" ? gIdx(exp.desc.index) : exp.desc.index;
   if (valCtx) {
-    const k = exp.desc.kind;
-    if (k === "func") vIdx("function", exp.desc.index, valCtx.numFuncs);
-    else if (k === "global") vIdx("global", exp.desc.index, valCtx.numGlobals);
-    else if (k === "table") vIdx("table", exp.desc.index, valCtx.numTables);
-    else if (k === "tag") vIdx("exception tag", exp.desc.index, valCtx.numTags);
-    else vIdx("memory", exp.desc.index, valCtx.numMemories);
+    if (k === "func") vIdx("function", resolved, valCtx.numFuncs);
+    else if (k === "global") vIdx("global", resolved, valCtx.numGlobals);
+    else if (k === "table") vIdx("table", resolved, valCtx.numTables);
+    else if (k === "tag") vIdx("exception tag", resolved, valCtx.numTags);
+    else vIdx("memory", resolved, valCtx.numMemories);
   }
   enc.name(exp.name);
   const kindByte =
@@ -830,7 +874,7 @@ export function encodeExport(exp: WasmExport, enc: WasmEncoder, _numImportFuncs:
             ? 0x04
             : 0x03;
   enc.byte(kindByte);
-  enc.u32(exp.desc.index);
+  enc.u32(resolved);
 }
 
 export function encodeFunction(f: WasmFunction, enc: WasmEncoder): void {
@@ -944,16 +988,20 @@ export function encodeInstr(instr: Instr, enc: WasmEncoder): void {
     case "return":
       enc.byte(OP.return);
       break;
-    case "call":
-      if (valCtx) vIdx("function", instr.funcIdx, valCtx.numFuncs);
+    case "call": {
+      const target = fIdx(instr.funcIdx);
+      if (valCtx) vIdx("function", target, valCtx.numFuncs);
       enc.byte(OP.call);
-      enc.u32(instr.funcIdx);
+      enc.u32(target);
       break;
-    case "return_call":
-      if (valCtx) vIdx("function", instr.funcIdx, valCtx.numFuncs);
+    }
+    case "return_call": {
+      const target = fIdx(instr.funcIdx);
+      if (valCtx) vIdx("function", target, valCtx.numFuncs);
       enc.byte(OP.return_call);
-      enc.u32(instr.funcIdx);
+      enc.u32(target);
       break;
+    }
     case "call_indirect":
       if (valCtx) {
         vIdx("type", instr.typeIdx, valCtx.numTypes);
@@ -984,16 +1032,20 @@ export function encodeInstr(instr: Instr, enc: WasmEncoder): void {
       enc.byte(OP.local_tee);
       enc.u32(instr.index);
       break;
-    case "global.get":
-      if (valCtx) vIdx("global", instr.index, valCtx.numGlobals);
+    case "global.get": {
+      const g = gIdx(instr.index);
+      if (valCtx) vIdx("global", g, valCtx.numGlobals);
       enc.byte(OP.global_get);
-      enc.u32(instr.index);
+      enc.u32(g);
       break;
-    case "global.set":
-      if (valCtx) vIdx("global", instr.index, valCtx.numGlobals);
+    }
+    case "global.set": {
+      const g = gIdx(instr.index);
+      if (valCtx) vIdx("global", g, valCtx.numGlobals);
       enc.byte(OP.global_set);
-      enc.u32(instr.index);
+      enc.u32(g);
       break;
+    }
     case "i32.const":
       enc.byte(OP.i32_const);
       enc.i32(instr.value);
@@ -1384,11 +1436,13 @@ export function encodeInstr(instr: Instr, enc: WasmEncoder): void {
       enc.byte(GC.array_fill);
       enc.u32(instr.typeIdx);
       break;
-    case "ref.func":
-      if (valCtx) vIdx("function", instr.funcIdx, valCtx.numFuncs);
+    case "ref.func": {
+      const target = fIdx(instr.funcIdx);
+      if (valCtx) vIdx("function", target, valCtx.numFuncs);
       enc.byte(OP.ref_func);
-      enc.u32(instr.funcIdx);
+      enc.u32(target);
       break;
+    }
     case "call_ref":
       if (valCtx) vIdx("type", instr.typeIdx, valCtx.numTypes);
       enc.byte(OP.call_ref);

--- a/src/emit/resolve-layout.ts
+++ b/src/emit/resolve-layout.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+
+// ---------------------------------------------------------------------------
+// resolveLayout — the single handle→final-index authority (#1916 / #2710).
+//
+// CONTRACT (the #1899-ratified end state)
+// ---------------------------------------
+// Instructions and module records reference functions / globals / types through
+// stable handles (`FuncHandle` / `GlobalHandle` / `TypeHandle`, src/ir/types.ts).
+// A concrete module index is assigned in exactly ONE place — here — and read in
+// exactly one phase: serialization (src/emit/binary.ts), the only point that
+// sees the FINAL index space (post every late import, post DCE). Nothing
+// upstream of emit may interpret a handle as a position.
+//
+// WHY (the bug class this retires)
+// --------------------------------
+// The WasmGC backend historically baked *live* indices into instruction streams
+// mid-compile; every late import (`addUnionImports`, `addStringImports`,
+// `ensureLateImport`) then had to chase the +N shift into every body and ~40
+// side-channel caches (`shiftLateImportIndices`, `reconcileNativeStrFinalizeShift`,
+// two hand-rolled inline shifters), and DCE's remove-and-renumber had to remap
+// them again. At least 7 numbered regressions trace to that design (#618, #1109,
+// #1384, #1525b, #1666, #1677, #2191, #2193, #2918…). #1899's implementation
+// notes prove the dual lesson that fixes the design:
+//   - identity must ride IN the instruction (a handle), because a numeric index
+//     is ambiguous across shifts — any idx-keyed repair map is unsound;
+//   - the only sound resolution point is AFTER all churn, i.e. emit time.
+//
+// MIGRATION PHASE — IDENTITY (#2710 slice 2, landed under #1916 S1)
+// -----------------------------------------------------------------
+// In the current phase handles are still *numerically equal* to live indices
+// (the existing shifters keep them current, exactly as before). `resolveLayout`
+// is therefore the identity map, and wiring it through `binary.ts` is provably
+// byte-identical (see `scripts/prove-emit-identity.mjs`). The value of this
+// slice is the SEAM: every serialization of a func/global reference now flows
+// through `ModuleLayout`, so the later flip — minting stable, never-renumbered
+// handles at registration and computing the real permutation here — changes
+// one function instead of fourteen encode sites.
+//
+// FLIP PRECONDITIONS (do NOT make this non-identity before these hold):
+//   1. Every positional read (`mod.functions[idx - numImportFuncs]`,
+//      `idx - numImportFuncs` arithmetic, `mod.globals[idx]`) is converted to a
+//      registry/layout-keyed lookup (#1916 S2 / #2710 slice 3).
+//   2. Registration sites mint handles from a monotonic counter (never reused),
+//      and the shifters are deleted in the same change — a body-walking shifter
+//      mutating stable handles would corrupt them (#1916 S3 / #2710 slice 4).
+//   3. The canonical ordering reproduces today's final layout exactly (imports
+//      in declaration order first, then live defined entries in array order
+//      post-DCE) so the flip stays byte-identical.
+// ---------------------------------------------------------------------------
+
+import type { FuncHandle, GlobalHandle, TypeHandle, WasmModule } from "../ir/types.js";
+
+/**
+ * The resolved final layout of one module's index spaces. `binary.ts` (and,
+ * at flip time, `wat.ts` / `object.ts`) dereference every handle through this
+ * — never through arithmetic on the handle value.
+ */
+export interface ModuleLayout {
+  /** Final function-index-space position for a function handle. */
+  func(h: FuncHandle): number;
+  /** Final global-index-space position for a global handle. */
+  global(h: GlobalHandle): number;
+  /** Final type-index-space position for a type handle. */
+  type(h: TypeHandle): number;
+}
+
+/**
+ * Compute the handle→final-index maps for a module whose registration and
+ * churn (late imports, DCE) have fully settled. Called at the top of emit —
+ * downstream of `ctx.indexSpaceFrozen = true` in `generateModule`, the point
+ * both finalize arms guarantee no further import can be added.
+ *
+ * IDENTITY PHASE: handles == live indices by construction (the shifters keep
+ * them current), so the identity map is definitionally correct. The `mod`
+ * parameter is unused today but is the flip-time input (import counts +
+ * registration registry + liveness), so callers already pass it.
+ */
+export function resolveLayout(_mod: WasmModule): ModuleLayout {
+  return IDENTITY_LAYOUT;
+}
+
+const IDENTITY_LAYOUT: ModuleLayout = {
+  func: (h: FuncHandle): number => h,
+  global: (h: GlobalHandle): number => h,
+  type: (h: TypeHandle): number => h,
+};

--- a/tests/issue-1916-symbolic-func-refs.test.ts
+++ b/tests/issue-1916-symbolic-func-refs.test.ts
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { createEmptyModule } from "../src/ir/types.js";
+import { emitBinary } from "../src/emit/binary.js";
+
+/**
+ * #1916 — symbolic function references / #2710 late-bound module indices.
+ *
+ * S1 (this slice) wires every func/global reference serialization in
+ * `src/emit/binary.ts` through the `resolveLayout()` seam
+ * (`src/emit/resolve-layout.ts`). The layout is the identity map in this
+ * phase, so behaviour must be EXACTLY unchanged — proven wholesale by
+ * `scripts/prove-emit-identity.mjs` (992 real binaries × {gc,standalone,wasi}
+ * byte-identical) and held here by two kinds of permanent tests:
+ *
+ * 1. late-import-after-bodies programs (the #329/#1899/#1677 repro shapes):
+ *    imports added AFTER function bodies were compiled historically shifted
+ *    every defined-function index and corrupted baked call targets. These
+ *    must compile to VALID Wasm and run correctly through every migration
+ *    slice — they are the acceptance evidence that handle resolution agrees
+ *    with the final index space.
+ *
+ * 2. a synthetic hand-built module exercising every seam S1 touched (call,
+ *    ref.func + declarative elem, global.get/set, func + global exports,
+ *    start section, active element segments) — validating that the resolver
+ *    dereference emits exactly the indices the module laid out.
+ */
+
+// The #1899 repro: `let g: any` forces an undefined-init path; the closure
+// assignment bakes a call target; native-string helpers + host-import gate
+// churn imports afterwards under standalone/wasi.
+const assignAfterBodies = `let g: any; g = function () { return 42; };
+export function test(): number { return g(); }`;
+
+// String-helper-heavy variant — exercises the native-string finalize regime
+// (reconcileNativeStrFinalizeShift) where sibling-helper calls bake mid-churn.
+const stringHelperChurn = `const s: string = "ab" + "cd";
+export function test(): number { return s.slice(1).length + "x".repeat(2).length; }`;
+
+// Union-typed return forces addUnionImports — the late-import path that
+// historically shifted indices after ALL bodies existed (#1461/#2918 class).
+const unionLateImport = `function pick(n: number): number | string {
+  return n > 0 ? n : "neg";
+}
+export function test(): number {
+  const v = pick(3);
+  return typeof v === "number" ? v : 0;
+}`;
+
+async function compileValidate(src: string, target: "standalone" | "wasi" | "gc") {
+  const r = await compile(src, { target });
+  expect(r.errors ?? []).toEqual([]);
+  // WebAssembly.compile throws on stale-funcIdx invalid Wasm — the historical
+  // failure mode of this bug class.
+  await WebAssembly.compile(r.binary);
+  return r;
+}
+
+describe("#1916 S1 — late-import-after-bodies programs stay valid through the resolver seam", () => {
+  for (const target of ["standalone", "wasi", "gc"] as const) {
+    it(`assignment-form closure late-shift shape [${target}]`, async () => {
+      await compileValidate(assignAfterBodies, target);
+    });
+
+    it(`native-string helper churn shape [${target}]`, async () => {
+      await compileValidate(stringHelperChurn, target);
+    });
+
+    it(`union late-import shape [${target}]`, async () => {
+      await compileValidate(unionLateImport, target);
+    });
+  }
+
+  it("standalone closure-assign runs to the right value", async () => {
+    const r = await compile(assignAfterBodies, { target: "standalone" });
+    expect(r.errors ?? []).toEqual([]);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    const test = instance.exports.test as () => number;
+    expect(test()).toBe(42);
+  });
+});
+
+describe("#1916 S1 — synthetic module exercises every resolver seam", () => {
+  it("call / ref.func / global.get+set / exports / start / elem resolve to correct indices", async () => {
+    const mod = createEmptyModule();
+
+    // Types: () -> i32 (funcs), () -> nothing (start)
+    mod.types.push({ kind: "func", params: [], results: [{ kind: "i32" }] }); // 0
+    mod.types.push({ kind: "func", params: [], results: [] }); // 1
+
+    // One mutable i32 global, init 5 — read via global.get, written by start.
+    mod.globals.push({
+      name: "g0",
+      type: { kind: "i32" },
+      mutable: true,
+      init: [{ op: "i32.const", value: 5 }],
+    });
+
+    // func 0: inner() -> 7
+    mod.functions.push({
+      name: "inner",
+      typeIdx: 0,
+      locals: [],
+      body: [{ op: "i32.const", value: 7 }],
+      exported: false,
+    });
+    // func 1: outer() -> inner() + g0   (seams: call, global.get)
+    mod.functions.push({
+      name: "outer",
+      typeIdx: 0,
+      locals: [],
+      body: [{ op: "call", funcIdx: 0 }, { op: "global.get", index: 0 }, { op: "i32.add" }],
+      exported: true,
+    });
+    // func 2: start() { g0 = 30 }   (seams: global.set, start section)
+    mod.functions.push({
+      name: "init",
+      typeIdx: 1,
+      locals: [],
+      body: [
+        { op: "i32.const", value: 30 },
+        { op: "global.set", index: 0 },
+      ],
+      exported: false,
+    });
+    mod.startFuncIdx = 2;
+
+    // Declarative elem via declaredFuncRefs + a ref.func in a table-less
+    // context is overkill here; instead exercise BOTH elem paths:
+    mod.declaredFuncRefs.push(0); // declarative segment (ref.func targets)
+    mod.tables.push({ elementType: "funcref", min: 1, max: 1 });
+    mod.elements.push({ tableIdx: 0, offset: [{ op: "i32.const", value: 0 }], funcIndices: [1] }); // active segment
+
+    mod.exports.push({ name: "outer", desc: { kind: "func", index: 1 } });
+    mod.exports.push({ name: "g0", desc: { kind: "global", index: 0 } });
+
+    const bytes = emitBinary(mod);
+    expect(WebAssembly.validate(bytes)).toBe(true);
+
+    const { instance } = await WebAssembly.instantiate(bytes, {});
+    const outer = instance.exports.outer as () => number;
+    // start ran on instantiation: g0 = 30; outer() = inner() + g0 = 7 + 30.
+    expect(outer()).toBe(37);
+    const g0 = instance.exports.g0 as WebAssembly.Global;
+    expect(g0.value).toBe(30);
+  });
+});


### PR DESCRIPTION
## What

First slice of #1916 (symbolic function references), executed against #2710's landed FuncHandle foundation (slices 0+1: handle vocabulary + `prove-emit-identity` oracle) — **not** a second identity mechanism.

- **New `src/emit/resolve-layout.ts`** — `ModuleLayout` + `resolveLayout(mod)`, the future single handle→final-index authority (per the #1899-ratified contract: resolution happens once, at serialization, the only point that sees the final index space). Identity map in this phase; flip preconditions documented in the header.
- **`src/emit/binary.ts`** — armed per-emit (same lifecycle as `valCtx`); every func/global reference serialization now dereferences through `fIdx`/`gIdx`: `call`, `return_call`, `ref.func`, `global.{get,set}`, func/global export descriptors, element-segment function lists, `declaredFuncRefs`, start section. Unarmed callers (relocatable object emitter) keep raw passthrough — historical behaviour.
- **Issue reconciliation** — #1916 `blocked→in-progress` (#2167 resolved: Fable re-enabled 2026-07-02); staged plan S1–S4 recorded in #1916 with the #2710 slice mapping; cross-note in #2710's log.

## Why

Function identity in codegen must be a stable symbol resolved to absolute indices only at finalize. The eager-index design has produced 7+ numbered regressions (#618, #1109, #1384, #1525b, #1666, #1677, #2191, #2193, #2918 — and #2941 landed *during this PR's window*, another funcIdx side-channel desync). #1899's implementation notes prove idx-keyed repair is unsound (a numeric funcIdx is ambiguous across shifts), so identity must ride in the instruction as a layout-independent handle — exactly the #2710 design this slice advances.

## Proof (verification is half the work)

- **Byte-identity**: `prove-emit-identity` over **1215 (file,target) records** — playground examples + a deterministic 392-file test262 sample × {gc, standalone, wasi}, 992 real binaries — **IDENTICAL** against the golden baseline captured on the base commit (d0bfaa7d) before the edit. Post-merge re-proof vs current main tip running; will confirm in a comment.
- **Late-shift class holds**: issue-329 / 1677 / 1809 / 1839 / 1899 / 2191 / 2193 / 2918 suites green (51 tests), plus #2941's new suite on the merged tree.
- **New permanent tests** (`tests/issue-1916-symbolic-func-refs.test.ts`, 11 tests): late-import-after-bodies shapes (closure-assign, native-string churn, union late-import) compile→validate→run across all 3 targets, + a synthetic hand-built module exercising every seam this PR touched (resolved indices verified by instantiation semantics: start ran, call+global.get compute 37).
- `tsc --noEmit` clean.

## Staged plan (remainder)

S2 = convert ~94 positional reads to chokepoint accessors (byte-identical) · S3 = mint stable func handles + real permutation + **delete the four func-index shifters** (the heart of #1916) · S4 = globals + types (#2710 4a/4d). Each ships green + byte-identity-provable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS