### PR TITLE
fix(#2934): packed i8/i16 typed-array for-of + vec→tuple invalid Wasm (slice 1b)

### DIFF
--- a/plan/issues/2934-standalone-invalid-wasm-heterogeneous-tail.md
+++ b/plan/issues/2934-standalone-invalid-wasm-heterogeneous-tail.md
@@ -2,7 +2,7 @@
 id: 2934
 title: "Standalone: invalid-Wasm heterogeneous tail after #2878 (test/__closure_*/__cb_0 — distinct codegen bugs)"
 status: in-progress
-assignee: ttraenkler/dev-2934b
+assignee: ttraenkler/dev-2934f
 created: 2026-07-02
 updated: 2026-07-02
 priority: medium
@@ -28,14 +28,14 @@ the eqref/funcIdx-shift class), so each is fixed as a **separate slice**.
 `built-ins` stride sample, AFTER #2878: **26 invalid binaries** remaining.
 Clustered by failing function + validator signature:
 
-| failing fn | count | validator signature (representative) | example test |
-| ---------- | ----- | ------------------------------------ | ------------ |
-| `test` | ~15 | `call[0] expected type (ref null …)` | `String/prototype/concat/S15.5.4.6_A1_T8.js` |
-| `test` | (in above) | `call[0] expected type externref` | `RegExp/prototype/test/S15.10.6.3_A8.js` |
-| `test` | (in above) | `array.get: Array type N has packed…` / `array.set[2] expected type i32` | `TypedArray/prototype/set/array-arg-value-conversion-resizes-array-buffer.js`, `Uint8Array/prototype/toBase64/results.js` |
-| `__closure_2/4/7/20` | ~8 | `call[1] expected type f64` / `call[0] expected type (…)` / `struct.get[0]` | `Array/prototype/map/15.4.4.19-4-7.js`, `Array/prototype/filter/create-species-poisoned.js`, `Proxy/revocable/tco-fn-realm.js` |
-| `__closure_5` | 1 | `not enough arguments on the stack` (funcIdx-shift-shaped) | `AsyncFromSyncIteratorPrototype/next/for-await-next-rejected-promise-close.js` |
-| `__cb_0` | 1 | `array.set[2] expected type i32` | `TypedArray/prototype/set/typedarray-arg-set-values-diff-buffer-other-type-conversions-sab.js` |
+| failing fn           | count      | validator signature (representative)                                        | example test                                                                                                                   |
+| -------------------- | ---------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `test`               | ~15        | `call[0] expected type (ref null …)`                                        | `String/prototype/concat/S15.5.4.6_A1_T8.js`                                                                                   |
+| `test`               | (in above) | `call[0] expected type externref`                                           | `RegExp/prototype/test/S15.10.6.3_A8.js`                                                                                       |
+| `test`               | (in above) | `array.get: Array type N has packed…` / `array.set[2] expected type i32`    | `TypedArray/prototype/set/array-arg-value-conversion-resizes-array-buffer.js`, `Uint8Array/prototype/toBase64/results.js`      |
+| `__closure_2/4/7/20` | ~8         | `call[1] expected type f64` / `call[0] expected type (…)` / `struct.get[0]` | `Array/prototype/map/15.4.4.19-4-7.js`, `Array/prototype/filter/create-species-poisoned.js`, `Proxy/revocable/tco-fn-realm.js` |
+| `__closure_5`        | 1          | `not enough arguments on the stack` (funcIdx-shift-shaped)                  | `AsyncFromSyncIteratorPrototype/next/for-await-next-rejected-promise-close.js`                                                 |
+| `__cb_0`             | 1          | `array.set[2] expected type i32`                                            | `TypedArray/prototype/set/typedarray-arg-set-values-diff-buffer-other-type-conversions-sab.js`                                 |
 
 (3,500-file sample → the full `built-ins` corpus + `language`/other roots scale
 this ~3–4×.)
@@ -46,52 +46,85 @@ The TypedArray packed-array surface turned out to be **several DISTINCT bugs**,
 not one — triaged 2026-07-02:
 
 - [x] **(1) TypedArray packed iterator READ (`.values()`/`.keys()`)** — DONE.
-  `emitBoxedElem` (`array-methods.ts`) read a packed i8/i16 backing array with a
-  plain `array.get` (validator error `Array type N has packed type i8`). Fixed
-  with the established `getOp` idiom (`i8 → array.get_u`, `i16 → array.get_s`).
-  Flips `TypedArray/prototype/values/make-{in,out-of}-bounds-after-exhausted.js`
-  standalone invalid → valid.
-- [ ] **(1b) TypedArray `.entries()`** — a DISTINCT `Binary emit error:
-  encodeValType: packed …` (a packed array type reaching a valtype position the
-  encoder rejects). Not the same site as (1).
+      `emitBoxedElem` (`array-methods.ts`) read a packed i8/i16 backing array with a
+      plain `array.get` (validator error `Array type N has packed type i8`). Fixed
+      with the established `getOp` idiom (`i8 → array.get_u`, `i16 → array.get_s`).
+      Flips `TypedArray/prototype/values/make-{in,out-of}-bounds-after-exhausted.js`
+      standalone invalid → valid.
+- [x] **(1b) packed-element for-of / vec→tuple `encodeValType: packed`** — DONE
+      (dev-2934f, slice 3). Bigger than the `.entries()` label: EVERY
+      `for (const v of u)` / `of u.values()` / `of u.entries()` over a packed
+      (i8/i16) typed array was a standalone emit error, plus the manual-iterator
+      `it.next().value` tuple destructure. THREE distinct leak sites of one class
+      ("a packed STORAGE type reached a VALUE position"):
+  1. `compileForOfArray`/`compileForOfArrayEntries` (`statements/loops.ts`)
+     allocated the **loop variable local** with the raw `arrDef.element`
+     (i8/i16 — invalid local type) and read with plain `array.get` (invalid on
+     packed arrays). Fixed: bind as `unpackedElemType` (i32), read with
+     `elemGetOp` driven by **view-name signedness** (`Int*` → get_s, `Uint*` →
+     get_u — the storage kind alone can't distinguish, #2648), coerce/destructure
+     from the widened i32.
+  2. `stack-balance.ts` type simulation pushed the raw packed element/field
+     type for `array.get_s/_u`/`struct.get`; the struct.new arg-coercion repair
+     then materialized it into a `$sn_tmp` **temp local** → invalid. Fixed:
+     the simulator now models the widened i32 that is physically on the stack
+     (`widenPackedToI32` at all 4 producer sites + defensive widen at the
+     temp-local alloc).
+  3. `type-coercion.ts` vec→tuple paths (`buildTupleFromExternref` runtime
+     ref.test chain over ALL vec types incl. the packed i8_byte vec, and
+     `emitVecToTupleBody`) used plain `array.get` + a packed `if` **blockType**.
+     Fixed: `elemGetOp` (storage heuristic — no view name exists on the shared
+     vec type) + widened blockType + `f64.convert_i32_s` lift before the
+     f64/externref coercion arms.
+     Helpers `unpackedElemType`/`elemGetOp` are now canonical in `shared.ts` (the
+     acyclic sink — type-coercion.ts can't import array-methods.ts). Flips
+     `language/statements/for-of/{u,}int{8,16}array{,-mutate}.js` +
+     `uint8clampedarray{,-mutate}.js` (10 files) standalone CE → **pass**;
+     byte-identical on host mode and standalone non-packed paths (verified by
+     SHA over plain-array/string/entries for-of). Tests:
+     `tests/issue-2934-packed-forof-valtype.test.ts` (12 cases incl. signedness
+     semantics: Int8 −56, Uint8 200, Uint16 40000, Int16 −30000).
 - [ ] **(1c) `TypedArray.prototype.set` / `Uint8Array.toBase64`** — the
-  `array.set[2] expected i32, found array.get of externref` / packed-`array.get`
-  errors here are a DISTINCT **DCE type-index remap** (`project_type_index_shift_
-  and_deadelim`): the pre-encode module has NO packed plain-`array.get`, so a
-  post-codegen dead-type-elimination / dedup pass mis-remaps an `array.get`
-  typeIdx onto a packed array. Needs a `dead-elimination.ts` audit — harder,
-  likely warrants an architect spec.
+      `array.set[2] expected i32, found array.get of externref` / packed-`array.get`
+      errors here are a DISTINCT **DCE type-index remap** (`project_type_index_shift_
+and_deadelim`): the pre-encode module has NO packed plain-`array.get`, so a
+      post-codegen dead-type-elimination / dedup pass mis-remaps an `array.get`
+      typeIdx onto a packed array. Needs a `dead-elimination.ts` audit — harder,
+      likely warrants an architect spec.
 - [ ] **(1d) simple `for (const v of u.values())`** — demotes to the IR path
-  (`ir/from-ast: unknown class`), a separate IR-adoption gap.
+      (`ir/from-ast: unknown class`), a separate IR-adoption gap. NOTE: after (1b)
+      the legacy-path fallback now compiles these shapes correctly (valid Wasm,
+      right semantics), so this is a pure IR-adoption item, no longer an
+      invalid-Wasm producer.
 - [x] **(2a) `RegExp/test` receiver → `hasOwnProperty`/`propertyIsEnumerable`
-  missing `extern.convert_any`** — DONE (dev-2934b, slice 2). `RegExp.prototype.
-  test.hasOwnProperty('length')` — the receiver `RegExp.prototype.test` is a
-  function object, compiled to a concrete function-object struct `(ref $fn)`.
-  `compilePropertyIntrospection` (`object-ops.ts`) takes the `receiverWasm.kind
-  === "externref"` branch because `resolveWasmType` reports the receiver's
-  *static* (method) type as `externref` — then pushed the receiver with
-  `compileExpression` but **did not coerce** the actually-emitted `(ref $fn)` to
-  externref, while the key argument WAS coerced. Result: `call[0] expected type
-  externref, found struct.new of type (ref …)` invalid Wasm. Fix: coerce the
-  receiver's *compiled* type (`recvType.kind !== "externref"` → `coerceType`
-  → `extern.convert_any`), mirroring the existing key-arg coercion. Verified
-  before/after over the 90-file `.hasOwnProperty/.propertyIsEnumerable('length')`
-  DontEnum-length family: **9 standalone INVALID → 0** (RegExp `test`/`exec`/
-  `toString` `_A8/_A9/_A10`); the other 81 were already valid and stay valid.
-  Host-mode byte-neutral (host receiver is already externref → guard skips it;
-  `S15.10.6.3_A8` et al. still pass host). Standalone runtime still fails these
-  on the separate `__hasOwnProperty` function-`.length`-own semantics gap — a
-  distinct issue, not this slice.
+      missing `extern.convert_any`** — DONE (dev-2934b, slice 2). `RegExp.prototype.
+test.hasOwnProperty('length')` — the receiver `RegExp.prototype.test` is a
+      function object, compiled to a concrete function-object struct `(ref $fn)`.
+      `compilePropertyIntrospection` (`object-ops.ts`) takes the `receiverWasm.kind
+=== "externref"` branch because `resolveWasmType` reports the receiver's
+      _static_ (method) type as `externref` — then pushed the receiver with
+      `compileExpression` but **did not coerce** the actually-emitted `(ref $fn)` to
+      externref, while the key argument WAS coerced. Result: `call[0] expected type
+externref, found struct.new of type (ref …)` invalid Wasm. Fix: coerce the
+      receiver's _compiled_ type (`recvType.kind !== "externref"` → `coerceType`
+      → `extern.convert_any`), mirroring the existing key-arg coercion. Verified
+      before/after over the 90-file `.hasOwnProperty/.propertyIsEnumerable('length')`
+      DontEnum-length family: **9 standalone INVALID → 0** (RegExp `test`/`exec`/
+      `toString` `_A8/_A9/_A10`); the other 81 were already valid and stay valid.
+      Host-mode byte-neutral (host receiver is already externref → guard skips it;
+      `S15.10.6.3_A8` et al. still pass host). Standalone runtime still fails these
+      on the separate `__hasOwnProperty` function-`.length`-own semantics gap — a
+      distinct issue, not this slice.
 - [ ] **(2b) remaining `call[0]/call[1] expected type …` coercion sites** — still
-  open, DISTINCT from (2a): `String/concat` → `call[0] expected (ref null 6),
-  found call of externref` (reverse direction — an internal ref expected, an
-  externref supplied); `RegExp.prototype.exec(...).toString()` → `call[0]
-  expected externref, found if of (ref null 98)` (nullable-ref receiver to
-  `.toString()`); Array map/filter `create-species-*` callbacks in `__closure_*`.
-  Each a separate coercion/typing site.
+      open, DISTINCT from (2a): `String/concat` → `call[0] expected (ref null 6),
+found call of externref` (reverse direction — an internal ref expected, an
+      externref supplied); `RegExp.prototype.exec(...).toString()` → `call[0]
+expected externref, found if of (ref null 98)` (nullable-ref receiver to
+      `.toString()`); Array map/filter `create-species-*` callbacks in `__closure_*`.
+      Each a separate coercion/typing site.
 - [ ] **(3) `__closure_5` `not enough arguments on the stack`** — the one
-  funcIdx-shift-shaped failure (for-await async path); may share the #2918
-  late-import class.
+      funcIdx-shift-shaped failure (for-await async path); may share the #2918
+      late-import class.
 
 ## Approach
 

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -23,7 +23,7 @@ import {
 } from "./index.js";
 import { addStringConstantGlobal, ensureExnTag, localGlobalIdx } from "./registry/imports.js";
 import { emitToBoolean } from "./coercion-engine.js";
-import { compileStringLiteral, valTypesMatch } from "./shared.js";
+import { compileStringLiteral, elemGetOp, unpackedElemType, valTypesMatch } from "./shared.js";
 import {
   getArrTypeIdxFromVec,
   getOrRegisterArrayType,
@@ -144,19 +144,11 @@ function throwStringInstrs(ctx: CodegenContext, message: string): Instr[] {
   return [...stringConstantExternrefInstrs(ctx, message), { op: "throw", tagIdx } as Instr];
 }
 
-/**
- * Value-position type for a (possibly packed) array element. A packed `i8`/`i16`
- * storage type is only valid as a struct field / array element — it MUST NOT
- * appear in a param/result/local/global position (the binary emitter rejects it
- * with "packed storage type … is not valid in a value position"). A packed
- * element loaded via `array.get_s`/`array.get_u` is already widened to `i32`, so
- * a search-value local / comparison operand for the sub-32-bit typed arrays
- * (Int8/Uint8/Int16/Uint16) must use `i32`, not the raw packed `elemType`
- * (#2648 — `Int8Array.prototype.{indexOf,lastIndexOf,includes}` standalone CE).
- */
-function unpackedElemType(elemType: ValType): ValType {
-  return elemType.kind === "i8" || elemType.kind === "i16" ? { kind: "i32" } : elemType;
-}
+// unpackedElemType / elemGetOp are canonical in shared.ts (#2934 — needed by
+// loops.ts and type-coercion.ts too, and array-methods.ts is not importable
+// from type-coercion.ts without a cycle). Imported below and re-exported for
+// existing users of this module's surface.
+export { elemGetOp, unpackedElemType };
 
 /**
  * (#2648, mirrors #2593) Recover the packed-element load signedness ("s"/"u") of
@@ -168,25 +160,13 @@ function unpackedElemType(elemType: ValType): ValType {
  * load off the view name, not the storage kind. Returns undefined for a
  * non-integer-view receiver (caller falls back to the storage-kind heuristic).
  */
-function typedArraySearchSignedness(ctx: CodegenContext, receiver: ts.Expression): "s" | "u" | undefined {
+export function typedArraySearchSignedness(ctx: CodegenContext, receiver: ts.Expression): "s" | "u" | undefined {
   const t = ctx.checker.getTypeAtLocation(receiver);
   let name = t.getSymbol()?.name ?? t.aliasSymbol?.name;
   if (!name && ts.isNewExpression(receiver) && ts.isIdentifier(receiver.expression)) {
     name = receiver.expression.text;
   }
   return name ? typedArrayPackedSignedness(name) : undefined;
-}
-
-/** Pick the element-load op for a (possibly packed) typed-array element, driven
- *  by the view-name signedness when available, else the legacy storage-kind
- *  heuristic (i8→get_u, i16→get_s). i32/f64/ref elements use plain `array.get`. */
-function elemGetOp(elemType: ValType, signedness: "s" | "u" | undefined): "array.get" | "array.get_s" | "array.get_u" {
-  if (elemType.kind === "i8" || elemType.kind === "i16") {
-    if (signedness === "s") return "array.get_s";
-    if (signedness === "u") return "array.get_u";
-    return elemType.kind === "i8" ? "array.get_u" : "array.get_s";
-  }
-  return "array.get";
 }
 
 /**

--- a/src/codegen/shared.ts
+++ b/src/codegen/shared.ts
@@ -29,6 +29,39 @@ import type { CodegenContext, FunctionContext } from "./context/types.js";
 export const VOID_RESULT = Symbol("void");
 export type InnerResult = ValType | null | typeof VOID_RESULT;
 
+// ── packed-element helpers (#2648/#2934) ──────────────────────────────
+
+/**
+ * The unpacked VALUE type of a (possibly packed) array element. Packed i8/i16
+ * (Uint8Array/Int8Array/Int16Array/… standalone storage, #2593) are STORAGE-only
+ * types: `array.get_s`/`get_u` widen them to `i32` on the stack, and a
+ * param/result/local/global/block declared with a packed kind is invalid Wasm
+ * ("packed storage type is not valid in a value position"). Identity for
+ * non-packed types.
+ */
+export function unpackedElemType(elemType: ValType): ValType {
+  return elemType.kind === "i8" || elemType.kind === "i16" ? { kind: "i32" } : elemType;
+}
+
+/**
+ * Pick the element-load op for a (possibly packed) typed-array element, driven
+ * by the view-name signedness when available (`Int*` → `array.get_s`, `Uint*` →
+ * `array.get_u`; the storage kind alone cannot distinguish them, #2648), else
+ * the legacy storage-kind heuristic (i8→get_u, i16→get_s). i32/f64/ref elements
+ * use plain `array.get`.
+ */
+export function elemGetOp(
+  elemType: ValType,
+  signedness: "s" | "u" | undefined,
+): "array.get" | "array.get_s" | "array.get_u" {
+  if (elemType.kind === "i8" || elemType.kind === "i16") {
+    if (signedness === "s") return "array.get_s";
+    if (signedness === "u") return "array.get_u";
+    return elemType.kind === "i8" ? "array.get_u" : "array.get_s";
+  }
+  return "array.get";
+}
+
 // ── resolveThisStructName ─────────────────────────────────────────────
 
 /**

--- a/src/codegen/stack-balance.ts
+++ b/src/codegen/stack-balance.ts
@@ -28,6 +28,20 @@
 import { coercionPlan } from "./coercion-plan.js";
 import type { BlockType, FuncTypeDef, Instr, TypeDef, ValType, WasmFunction, WasmModule } from "../ir/types.js";
 
+/**
+ * (#2934) Widen a packed i8/i16 STORAGE type to the i32 that actually lives on
+ * the Wasm value stack. `array.get_u`/`array.get_s` (and `struct.get_s/_u`)
+ * zero/sign-extend packed elements to i32 — the packed kind itself never exists
+ * as a stack value. The type-stack simulation must model the widened type:
+ * propagating the raw packed kind poisons downstream repairs (the struct.new
+ * arg-coercion fixup materializes stack types into `$sn_tmp` temp locals, and a
+ * local declared `i8` is invalid Wasm — "packed storage type is not valid in a
+ * value position").
+ */
+function widenPackedToI32(t: ValType): ValType {
+  return t.kind === "i8" || t.kind === "i16" ? { kind: "i32" } : t;
+}
+
 /** Sentinel: the instruction sequence is unreachable (after return/br/throw/unreachable). */
 const UNREACHABLE = -999;
 
@@ -1286,14 +1300,16 @@ function inferInstrType(
     const fieldIdx = (instr as any).fieldIdx as number;
     const td = types[typeIdx];
     if (td?.kind === "struct" && td.fields[fieldIdx]) {
-      return td.fields[fieldIdx]!.type;
+      // Packed i8/i16 fields arrive on the stack widened to i32 (#2934).
+      return widenPackedToI32(td.fields[fieldIdx]!.type);
     }
     return null;
   }
   if (op === "array.get" || op === "array.get_s" || op === "array.get_u") {
     const typeIdx = (instr as any).typeIdx as number;
     const td = types[typeIdx];
-    if (td?.kind === "array") return td.element;
+    // Packed i8/i16 elements arrive on the stack widened to i32 (#2934).
+    if (td?.kind === "array") return widenPackedToI32(td.element);
     return null;
   }
   if (op === "ref.null") {
@@ -1909,7 +1925,9 @@ function fixStructNewFieldCoercion(
               const tempLocals: number[] = [];
               const paramCount = resolveFuncType(types, func.typeIdx)?.params.length ?? 0;
               for (let fi = 0; fi < numFields; fi++) {
-                const actualType = fieldTypes[fi] ?? fields[fi]!.type;
+                // Widen defensively: the declared-field-type fallback can be a
+                // packed i8/i16, which is invalid as a local type (#2934).
+                const actualType = widenPackedToI32(fieldTypes[fi] ?? fields[fi]!.type);
                 const localIdx = paramCount + func.locals.length;
                 func.locals.push({ name: `$sn_tmp_${localIdx}`, type: actualType });
                 // Update localTypes for future inference
@@ -2225,7 +2243,8 @@ function updateTypeStack(
     const fieldIdx = (instr as any).fieldIdx as number;
     const td = types[typeIdx];
     if (td?.kind === "struct" && (td as any).fields[fieldIdx]) {
-      stack.push((td as any).fields[fieldIdx].type);
+      // Packed i8/i16 fields arrive on the stack widened to i32 (#2934).
+      stack.push(widenPackedToI32((td as any).fields[fieldIdx].type));
     } else {
       stack.push(null);
     }
@@ -2246,7 +2265,8 @@ function updateTypeStack(
     const typeIdx = (instr as any).typeIdx as number;
     const td = types[typeIdx];
     if (td?.kind === "array") {
-      stack.push(td.element);
+      // Packed i8/i16 elements arrive on the stack widened to i32 (#2934).
+      stack.push(widenPackedToI32(td.element));
     } else {
       stack.push(null);
     }

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -34,7 +34,7 @@ import { ensureNativeIteratorRuntime } from "../iterator-native.js";
 import { containsLinearU8Allocation, emitLinearU8ArenaMark, linearU8ArenaResetInstrs } from "../linear-uint8-arena.js";
 import { resolveComputedKeyExpression } from "../literals.js";
 import { emitCollectionIteratorVec, ensureMapHelpers, MAP_LAYOUT } from "../map-runtime.js";
-import { resolveArrayInfo } from "../array-methods.js";
+import { elemGetOp, resolveArrayInfo, typedArraySearchSignedness, unpackedElemType } from "../array-methods.js";
 import { flatStringType, stringConstantExternrefInstrs } from "../native-strings.js";
 import { emitNativeNumberFormat } from "../number-format-native.js";
 import { ensureObjectRuntime } from "../object-runtime.js";
@@ -3913,6 +3913,17 @@ function compileForOfArray(
     return;
   }
   const elemType = arrDef.element;
+  // (#2934 1b) Packed i8/i16 typed-array elements (Uint8Array/Int8Array/
+  // Int16Array/… standalone, #2593) are STORAGE-only types: a local declared
+  // `i8` is invalid Wasm ("packed storage type is not valid in a value
+  // position") and a plain `array.get` on a packed array fails validation. Bind
+  // the loop variable as the unpacked `i32` and read with the view-name-driven
+  // extension — `Int*` sign-extends (`array.get_s`), `Uint*` zero-extends
+  // (`array.get_u`); the storage kind alone cannot distinguish them (#2648).
+  // For non-packed elements both are identity (`readElemType === elemType`,
+  // plain `array.get`), so host mode and plain arrays emit byte-identical code.
+  const readElemType = unpackedElemType(elemType);
+  const elemReadOp = elemGetOp(elemType, typedArraySearchSignedness(ctx, iterableOverride ?? stmt.expression));
 
   // Save vec ref to temp local. With `preVec` the vec is already in `vecLocal`.
   const vecLocal = preVec ? preVec.vecLocal : allocLocal(fctx, `__forof_vec_${fctx.locals.length}`, vecType);
@@ -3968,7 +3979,7 @@ function compileForOfArray(
     if (ts.isObjectBindingPattern(decl.name) || ts.isArrayBindingPattern(decl.name)) {
       destructPattern = decl.name;
       // Allocate a temp local to hold the element for destructuring
-      elemLocal = allocLocal(fctx, `__forof_elem_${fctx.locals.length}`, elemType);
+      elemLocal = allocLocal(fctx, `__forof_elem_${fctx.locals.length}`, readElemType);
       // Track const bindings for all identifiers in the destructuring pattern
       if (isConst) {
         collectBindingNames(decl.name).forEach((n) => {
@@ -3978,7 +3989,7 @@ function compileForOfArray(
       }
     } else {
       const varName = ts.isIdentifier(decl.name) ? decl.name.text : `__forof_elem_${fctx.locals.length}`;
-      elemLocal = allocLocal(fctx, varName, elemType);
+      elemLocal = allocLocal(fctx, varName, readElemType);
       // Track const bindings — assignment to const in for-of should throw TypeError
       if (isConst && ts.isIdentifier(decl.name)) {
         if (!fctx.constBindings) fctx.constBindings = new Set();
@@ -3989,13 +4000,13 @@ function compileForOfArray(
     // Expression form with destructuring: for ({a, b} of arr) or for ([x, y] of arr)
     // These assign to already-declared variables
     assignDestructExpr = stmt.initializer;
-    elemLocal = allocLocal(fctx, `__forof_elem_${fctx.locals.length}`, elemType);
+    elemLocal = allocLocal(fctx, `__forof_elem_${fctx.locals.length}`, readElemType);
   } else if (ts.isIdentifier(stmt.initializer)) {
     // Expression form: for (x of arr) — x is already declared
     const varName = stmt.initializer.text;
-    elemLocal = fctx.localMap.get(varName) ?? allocLocal(fctx, varName, elemType);
+    elemLocal = fctx.localMap.get(varName) ?? allocLocal(fctx, varName, readElemType);
   } else {
-    elemLocal = allocLocal(fctx, `__forof_elem_${fctx.locals.length}`, elemType);
+    elemLocal = allocLocal(fctx, `__forof_elem_${fctx.locals.length}`, readElemType);
   }
 
   // Build loop body
@@ -4034,26 +4045,36 @@ function compileForOfArray(
     fctx.body.push({ op: "local.get", index: dataLocal });
   }
   fctx.body.push({ op: "local.get", index: iLocal });
-  fctx.body.push({ op: "array.get", typeIdx: arrTypeIdx });
+  fctx.body.push({ op: elemReadOp, typeIdx: arrTypeIdx } as Instr);
   // (#2001 S1) A for-of over an `any[]` with a literal hole reads `$Hole` at the
   // hole index; map it back to `undefined` (the iteration value of an absent
   // index — for-of uses array iterator Get, which yields undefined for holes).
   // Gated on externref element + `usesArrayHoles`.
   if (ctx.usesArrayHoles && elemType.kind === "externref") emitHoleToUndefined(ctx, fctx);
-  // Coerce from Wasm array element type to the local's declared type
+  // Coerce from the READ value's type (packed i8/i16 arrive on the stack as the
+  // widened i32, #2934) to the local's declared type.
   const elemLocalType = getLocalType(fctx, elemLocal);
-  if (elemLocalType && !valTypesMatch(elemType, elemLocalType)) {
-    coerceType(ctx, fctx, elemType, elemLocalType);
+  if (elemLocalType && !valTypesMatch(readElemType, elemLocalType)) {
+    coerceType(ctx, fctx, readElemType, elemLocalType);
   }
-  emitCoercedLocalSet(ctx, fctx, elemLocal, elemType);
+  emitCoercedLocalSet(ctx, fctx, elemLocal, readElemType);
 
   // If destructuring pattern (binding form), destructure from the element
   if (destructPattern) {
-    compileForOfDestructuring(ctx, fctx, destructPattern, elemLocal, elemType, stmt);
+    compileForOfDestructuring(ctx, fctx, destructPattern, elemLocal, readElemType, stmt);
   }
   // If assignment destructuring expression, assign to existing locals
   if (assignDestructExpr) {
-    compileForOfAssignDestructuring(ctx, fctx, assignDestructExpr, elemLocal, elemType, vecTypeIdx, arrTypeIdx, stmt);
+    compileForOfAssignDestructuring(
+      ctx,
+      fctx,
+      assignDestructExpr,
+      elemLocal,
+      readElemType,
+      vecTypeIdx,
+      arrTypeIdx,
+      stmt,
+    );
   }
 
   const savedLoopBody = pushBody(fctx);
@@ -4249,6 +4270,12 @@ function compileForOfArrayEntries(
     return;
   }
   const elemType = arrDef.element;
+  // (#2934 1b) Same packed-element discipline as compileForOfArray: bind the
+  // value local as the unpacked i32 and read with the view-name signedness —
+  // a raw packed i8/i16 local or a plain `array.get` on a packed array is
+  // invalid Wasm. Identity for non-packed elements.
+  const readElemType = unpackedElemType(elemType);
+  const elemReadOp = elemGetOp(elemType, typedArraySearchSignedness(ctx, receiver));
 
   // Identify the two binding targets [k, v]. Holes (`[, v]`) and rest
   // (`[k, ...rest]`) are not handled in this slice → fall back.
@@ -4277,14 +4304,14 @@ function compileForOfArrayEntries(
       return;
     }
     keyLocal = allocLocal(fctx, keyEl.name.text, { kind: "f64" });
-    valLocal = allocLocal(fctx, valEl.name.text, elemType);
+    valLocal = allocLocal(fctx, valEl.name.text, readElemType);
   } else {
     if (!ts.isIdentifier(keyEl) || !ts.isIdentifier(valEl)) {
       if (!compileForOfArrayTentative(ctx, fctx, stmt)) compileForOfIterator(ctx, fctx, stmt);
       return;
     }
     keyLocal = fctx.localMap.get(keyEl.text) ?? allocLocal(fctx, keyEl.text, { kind: "f64" });
-    valLocal = fctx.localMap.get(valEl.text) ?? allocLocal(fctx, valEl.text, elemType);
+    valLocal = fctx.localMap.get(valEl.text) ?? allocLocal(fctx, valEl.text, readElemType);
   }
 
   emitArrayKeysEntriesLoop(ctx, fctx, stmt, receiver, (lenLocal, iLocal, dataLocal, loopArrTypeIdx) => {
@@ -4292,15 +4319,15 @@ function compileForOfArrayEntries(
     fctx.body.push({ op: "local.get", index: iLocal });
     fctx.body.push({ op: "f64.convert_i32_s" });
     fctx.body.push({ op: "local.set", index: keyLocal! });
-    // value = data[i]
+    // value = data[i] (packed i8/i16 widens to i32 on read, #2934)
     fctx.body.push({ op: "local.get", index: dataLocal });
     fctx.body.push({ op: "local.get", index: iLocal });
-    fctx.body.push({ op: "array.get", typeIdx: loopArrTypeIdx });
+    fctx.body.push({ op: elemReadOp, typeIdx: loopArrTypeIdx } as Instr);
     const valLocalType = getLocalType(fctx, valLocal!);
-    if (valLocalType && !valTypesMatch(elemType, valLocalType)) {
-      coerceType(ctx, fctx, elemType, valLocalType);
+    if (valLocalType && !valTypesMatch(readElemType, valLocalType)) {
+      coerceType(ctx, fctx, readElemType, valLocalType);
     }
-    emitCoercedLocalSet(ctx, fctx, valLocal!, elemType);
+    emitCoercedLocalSet(ctx, fctx, valLocal!, readElemType);
     void lenLocal;
   });
 }

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -16,7 +16,14 @@ import { ensureAnyToStringHelper, stringConstantExternrefInstrs } from "./native
 import { emitNativeNumberFormat } from "./number-format-native.js";
 import { addStringConstantGlobal } from "./registry/imports.js";
 import { addFuncType, getArrTypeIdxFromVec } from "./registry/types.js";
-import { ensureLateImport, flushLateImportShifts, materializeStructAsObject, registerCoerceType } from "./shared.js";
+import {
+  elemGetOp,
+  ensureLateImport,
+  flushLateImportShifts,
+  materializeStructAsObject,
+  registerCoerceType,
+  unpackedElemType,
+} from "./shared.js";
 
 /**
  * Emit a guarded ref.cast: use ref.test to check if the cast will succeed.
@@ -736,6 +743,15 @@ function buildTupleFromExternref(
       { op: "local.set", index: lenLocal } as Instr,
     ];
 
+    // (#2934) Packed i8/i16 vec elements (byte/short typed arrays) read with
+    // `array.get_u`/`get_s` and live on the stack widened to i32 — a plain
+    // `array.get` on a packed array and a packed `if` result type are both
+    // invalid Wasm. This chain tests every vec type at runtime (the shared
+    // i8_byte vec serves Int8Array AND Uint8Array), so no view name exists
+    // here — use the storage-kind heuristic for the read op.
+    const readType = unpackedElemType(elemType);
+    const readOp = elemGetOp(elemType, undefined);
+
     // For each tuple field, bounds-checked read from the vec
     for (let i = 0; i < tupleFields.length; i++) {
       const fieldType = tupleFields[i]!;
@@ -744,10 +760,10 @@ function buildTupleFromExternref(
       const readInstrs: Instr[] = [
         { op: "local.get", index: dataLocal } as Instr,
         { op: "i32.const", value: i } as Instr,
-        { op: "array.get", typeIdx: arrTypeIdx } as Instr,
+        { op: readOp, typeIdx: arrTypeIdx } as Instr,
       ];
 
-      const defaultInstrs: Instr[] = defaultValueInstrs(elemType);
+      const defaultInstrs: Instr[] = defaultValueInstrs(readType);
 
       thenInstrs.push(
         { op: "i32.const", value: i } as Instr,
@@ -755,44 +771,54 @@ function buildTupleFromExternref(
         { op: "i32.lt_u" } as Instr,
         {
           op: "if",
-          blockType: { kind: "val" as const, type: elemType },
+          blockType: { kind: "val" as const, type: readType },
           then: readInstrs,
           else: defaultInstrs,
         } as Instr,
       );
 
+      // (#2934) A packed element arrives as the widened i32; lift it to f64 (a
+      // JS number) so the generic coercion arms below (which only know
+      // f64/externref/ref) apply. `convert_i32_s` is correct for both
+      // signednesses — get_u/get_s already produced the small-range i32.
+      let effElemType = elemType;
+      if (readType.kind === "i32" && elemType.kind !== "i32") {
+        thenInstrs.push({ op: "f64.convert_i32_s" } as Instr);
+        effElemType = { kind: "f64" };
+      }
+
       // Coerce element type to tuple field type if needed
       if (
-        elemType.kind !== fieldType.kind ||
-        ((elemType.kind === "ref" || elemType.kind === "ref_null") &&
+        effElemType.kind !== fieldType.kind ||
+        ((effElemType.kind === "ref" || effElemType.kind === "ref_null") &&
           (fieldType.kind === "ref" || fieldType.kind === "ref_null") &&
-          (elemType as { typeIdx: number }).typeIdx !== (fieldType as { typeIdx: number }).typeIdx)
+          (effElemType as { typeIdx: number }).typeIdx !== (fieldType as { typeIdx: number }).typeIdx)
       ) {
         // Ensure __box_number / __unbox_number are imported before use (#822)
         if (
-          (elemType.kind === "f64" && fieldType.kind === "externref") ||
-          (elemType.kind === "externref" && fieldType.kind === "f64")
+          (effElemType.kind === "f64" && fieldType.kind === "externref") ||
+          (effElemType.kind === "externref" && fieldType.kind === "f64")
         ) {
           addUnionImports(ctx);
         }
         // Inline coercion: most common case is f64 → externref (box) or externref → f64 (unbox)
-        if (elemType.kind === "f64" && fieldType.kind === "externref") {
+        if (effElemType.kind === "f64" && fieldType.kind === "externref") {
           const boxIdx = ctx.funcMap.get("__box_number");
           if (boxIdx !== undefined) {
             thenInstrs.push({ op: "call", funcIdx: boxIdx } as Instr);
           }
-        } else if (elemType.kind === "externref" && fieldType.kind === "f64") {
+        } else if (effElemType.kind === "externref" && fieldType.kind === "f64") {
           const unboxIdx = ctx.funcMap.get("__unbox_number");
           if (unboxIdx !== undefined) {
             thenInstrs.push({ op: "call", funcIdx: unboxIdx } as Instr);
           }
-        } else if (elemType.kind === "f64" && fieldType.kind === "f64") {
+        } else if (effElemType.kind === "f64" && fieldType.kind === "f64") {
           // same type, no coercion needed
-        } else if (elemType.kind === "externref" && fieldType.kind === "externref") {
+        } else if (effElemType.kind === "externref" && fieldType.kind === "externref") {
           // same type, no coercion needed
-        } else if ((elemType.kind === "ref" || elemType.kind === "ref_null") && fieldType.kind === "externref") {
+        } else if ((effElemType.kind === "ref" || effElemType.kind === "ref_null") && fieldType.kind === "externref") {
           thenInstrs.push({ op: "extern.convert_any" } as Instr);
-        } else if (elemType.kind === "externref" && (fieldType.kind === "ref" || fieldType.kind === "ref_null")) {
+        } else if (effElemType.kind === "externref" && (fieldType.kind === "ref" || fieldType.kind === "ref_null")) {
           const toRefIdx = (fieldType as { typeIdx: number }).typeIdx;
           thenInstrs.push({ op: "any.convert_extern" } as Instr, { op: "ref.cast_null", typeIdx: toRefIdx } as Instr);
         }
@@ -975,6 +1001,13 @@ function emitVecToTupleBody(
   fctx.body.push({ op: "struct.get", typeIdx: fromTypeIdx, fieldIdx: 0 });
   fctx.body.push({ op: "local.set", index: lenLocal });
 
+  // (#2934) Packed i8/i16 vec elements read with `array.get_u`/`get_s` and
+  // arrive on the stack widened to i32 — a plain `array.get` on a packed array
+  // and a packed `if` result type are both invalid Wasm. No view name is
+  // available on this generic coercion path, so use the storage-kind heuristic.
+  const readType = unpackedElemType(elemType);
+  const readOp = elemGetOp(elemType, undefined);
+
   // For each tuple field, read from the vec's data array with bounds check and coerce
   for (let i = 0; i < tupleFields.length; i++) {
     const fieldType = tupleFields[i]!;
@@ -987,22 +1020,23 @@ function emitVecToTupleBody(
     const thenInstrs: Instr[] = [
       { op: "local.get", index: dataLocal } as Instr,
       { op: "i32.const", value: i } as Instr,
-      { op: "array.get", typeIdx: arrTypeIdx } as Instr,
+      { op: readOp, typeIdx: arrTypeIdx } as Instr,
     ];
-    const elseInstrs: Instr[] = defaultValueInstrs(elemType);
+    const elseInstrs: Instr[] = defaultValueInstrs(readType);
 
     fctx.body.push({
       op: "if",
-      blockType: { kind: "val" as const, type: elemType },
+      blockType: { kind: "val" as const, type: readType },
       then: thenInstrs,
       else: elseInstrs,
     } as Instr);
 
-    // Coerce the vec element type to the tuple field type if needed
-    if (elemType.kind !== fieldType.kind) {
-      coerceType(ctx, fctx, elemType, fieldType);
+    // Coerce the READ value's type (widened i32 for packed elements, #2934) to
+    // the tuple field type if needed
+    if (readType.kind !== fieldType.kind) {
+      coerceType(ctx, fctx, readType, fieldType);
     } else if (
-      (elemType.kind === "ref" || elemType.kind === "ref_null") &&
+      (readType.kind === "ref" || readType.kind === "ref_null") &&
       (fieldType.kind === "ref" || fieldType.kind === "ref_null")
     ) {
       const fromRefIdx = (elemType as { typeIdx: number }).typeIdx;

--- a/tests/issue-2934-packed-forof-valtype.test.ts
+++ b/tests/issue-2934-packed-forof-valtype.test.ts
@@ -1,0 +1,111 @@
+// #2934 slice 1b — for-of over a packed (i8/i16) typed array leaked the PACKED
+// storage type into value positions, a hard standalone compile error
+// ("encodeValType: packed storage type is not valid in a value position"):
+//
+//   1. `compileForOfArray` / `compileForOfArrayEntries` (statements/loops.ts)
+//      allocated the loop variable local with the raw `arrDef.element` (i8/i16)
+//      and read it with a plain `array.get` (invalid on a packed array). Every
+//      `for (const v of u)` / `of u.values()` / `of u.entries()` over a
+//      Uint8Array/Int8Array/Int16Array/… was a standalone CE.
+//   2. The stack-balance pass's type simulation pushed the raw packed element
+//      type for `array.get_s/_u` reads; the struct.new arg-coercion repair then
+//      materialized that packed type into a `$sn_tmp` temp local.
+//   3. The vec→tuple coercion paths (type-coercion.ts) used plain `array.get`
+//      + a packed `if` blockType when the source vec was packed
+//      (`it.next().value` destructuring).
+//
+// Fix: bind/read via the canonical `unpackedElemType` / `elemGetOp` helpers
+// (now in shared.ts) — the loop var is the widened i32, the read op is
+// view-name-signedness-driven (`Int*` → get_s, `Uint*` → get_u, #2648), and the
+// simulator models the widened i32 that is actually on the stack.
+//
+// Flips language/statements/for-of/{u,}int{8,16}array{,-mutate}.js +
+// uint8clampedarray{,-mutate}.js standalone CE → pass (10 files).
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import { compile } from "../src/index.js";
+import { parseMeta, wrapTest } from "./test262-runner.js";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const TEST262 = process.env.TEST262_ROOT ?? join(REPO_ROOT, "test262");
+
+// The test262 family this fix flips from standalone emit-error → pass.
+const FIXED = [
+  "test/language/statements/for-of/uint8array.js",
+  "test/language/statements/for-of/int8array.js",
+  "test/language/statements/for-of/uint16array.js",
+  "test/language/statements/for-of/int16array.js",
+  "test/language/statements/for-of/uint8clampedarray.js",
+  "test/language/statements/for-of/uint8array-mutate.js",
+];
+
+async function compileStandalone(source: string) {
+  return compile(source, {
+    fileName: "test.ts",
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+}
+
+describe("#2934 1b — packed typed-array for-of is valid standalone Wasm", () => {
+  for (const rel of FIXED) {
+    const abs = join(TEST262, rel);
+    const present = existsSync(abs);
+    it.skipIf(!present)(`compiles ${rel} to valid standalone Wasm`, async () => {
+      const src = readFileSync(abs, "utf-8");
+      const wrapped = wrapTest(src, parseMeta(src)).source;
+      const r = await compileStandalone(wrapped);
+      expect(r.success).toBe(true);
+      await expect(WebAssembly.compile(r.binary)).resolves.toBeDefined();
+    });
+  }
+
+  // Signedness is view-name-driven, not storage-driven (#2648): Int8Array must
+  // sign-extend (get_s), Uint8Array zero-extend (get_u), and Uint16Array
+  // zero-extend even though i16 storage's legacy heuristic is get_s.
+  const SEMANTIC: Array<{ name: string; src: string; expected: number }> = [
+    {
+      name: "Uint8Array zero-extends (200 stays 200)",
+      src: "const u = new Uint8Array(1); u[0] = 200; let s = 0; for (const v of u) s += v; s;",
+      expected: 200,
+    },
+    {
+      name: "Int8Array sign-extends (-56 not 200)",
+      src: "const u = new Int8Array(1); u[0] = 200 as never; let s = 0; for (const v of u) s += v; s;",
+      expected: -56,
+    },
+    {
+      name: "Uint16Array zero-extends (40000 stays 40000)",
+      src: "const u = new Uint16Array(1); u[0] = 40000; let s = 0; for (const v of u) s += v; s;",
+      expected: 40000,
+    },
+    {
+      name: "Int16Array sign-extends (-30000)",
+      src: "const u = new Int16Array(1); u[0] = -30000; let s = 0; for (const v of u) s += v; s;",
+      expected: -30000,
+    },
+    {
+      name: ".entries() over Uint8Array binds [i, v]",
+      src: "const u = new Uint8Array(3); u[0] = 10; u[1] = 20; u[2] = 30; let s = 0; for (const [i, v] of u.entries()) s += i + v; s;",
+      expected: 63,
+    },
+    {
+      name: ".values() over Int8Array",
+      src: "const u = new Int8Array(2); u[0] = -128; let s = 0; for (const v of u.values()) s += v; s;",
+      expected: -128,
+    },
+  ];
+
+  for (const { name, src, expected } of SEMANTIC) {
+    it(name, async () => {
+      const wrapped = `export function test(): number { ${src.replace(/; s;$/, "; return s;")} }`;
+      const r = await compileStandalone(wrapped);
+      expect(r.success).toBe(true);
+      const { instance } = await WebAssembly.instantiate(r.binary, {});
+      const test = instance.exports.test as () => number;
+      expect(test()).toBe(expected);
+    });
+  }
+});


### PR DESCRIPTION
## Problem

Every `for (const v of u)` / `of u.values()` / `of u.entries()` over a packed (i8/i16) typed array (Uint8Array, Int8Array, Uint8ClampedArray, Int16Array, Uint16Array) was a **standalone hard compile error**:

```
Binary emit error: encodeValType: packed storage type "i8" is not valid in a value position
```

Plus the manual-iterator `it.next().value` tuple destructure over a packed source vec. This is #2934 slice (1b) — the `encodeValType: packed` cluster — which turned out to be much larger than the triaged `.entries()` label.

## Root cause — one class, three leak sites

A packed STORAGE type (i8/i16, valid only in struct fields / array elements) reached VALUE positions (locals, block result types) and plain `array.get` was used on packed arrays:

1. **`statements/loops.ts`** — `compileForOfArray` / `compileForOfArrayEntries` bound the loop-variable local with the raw `arrDef.element` and read with plain `array.get`.
2. **`stack-balance.ts`** — the type-stack simulation pushed the raw packed element/field type for `array.get_s/_u` / `struct.get`; the struct.new arg-coercion repair then materialized it into a `$sn_tmp` temp local (the `it.next().value` failure).
3. **`type-coercion.ts`** — the vec→tuple paths (`buildTupleFromExternref` runtime ref.test chain over ALL vec types incl. the shared packed `i8_byte` vec, `emitVecToTupleBody`) used plain `array.get` + a packed `if` blockType.

## Fix

- Bind loop variables as the widened `i32` (`unpackedElemType`), read with **view-name-driven signedness** (`elemGetOp`: `Int*` → `array.get_s`, `Uint*` → `array.get_u` — the storage kind alone cannot distinguish Int8Array from Uint8Array, #2648).
- The stack-balance simulator now models the widened i32 that is physically on the stack (`widenPackedToI32` at all 4 producer sites + defensive widen at the temp-local alloc).
- vec→tuple: heuristic read op (no view name exists on the shared vec type) + widened blockType + `f64.convert_i32_s` lift before the f64/externref coercion arms.
- `unpackedElemType` / `elemGetOp` are now canonical in `shared.ts` (the acyclic sink — `type-coercion.ts` cannot import `array-methods.ts`), re-exported from `array-methods.ts`.

## Validation

- Flips `language/statements/for-of/{u,}int{8,16}array{,-mutate}.js` + `uint8clampedarray{,-mutate}.js`: **10 standalone CE → pass** (verified via the test262 standalone runner).
- Signedness semantics verified: Int8 −56, Uint8 200, Uint16 40000, Int16 −30000; `.entries()` `[i, v]` binding; manual `it.next().value`.
- **Byte-identical** on host mode and standalone non-packed paths (SHA-checked plain-array/string/entries for-of, tuple destructure) — the change is pure identity for non-packed elements.
- New `tests/issue-2934-packed-forof-valtype.test.ts`: 12/12 pass.
- Scoped equivalence sweep (10 typed-array/iterator/tuple test files): only pre-existing failures (identical on main: `illegal-cast-vec-tuple-648`, `for-of-array-destructuring` collect error).

Part of #2934 (issue stays in-progress; slices 1c, 2b, 3 remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS