### PR TITLE
feat(#2135): IR capability table slice 1 — single-source the operator family (+ #2947 ir_first CI lane)

### DIFF
--- a/.github/workflows/test262-sharded.yml
+++ b/.github/workflows/test262-sharded.yml
@@ -57,6 +57,11 @@ on:
         required: false
         default: ""
         type: string
+      ir_first:
+        description: "(#2947) Measurement lane for the #2138 IR-first inversion: export JS2WASM_IR_FIRST=1 into the shard env. NEVER promotes a baseline (promote-baseline is hard-skipped for ir_first runs) — the merged report artifact is the measurement output."
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -441,6 +446,13 @@ jobs:
       # retry (10/shard) and excluded from regression counts by diff-test262.
       # Dispatch input allows dropping back to 2 if flake rates spike.
       COMPILER_POOL_SIZE: ${{ inputs.compiler_pool_size || '3' }}
+      # (#2947) The #2138 IR-first measurement lane: '1' ONLY on a
+      # workflow_dispatch that opted in via the ir_first input; the empty
+      # string on every other event/run is falsy for the compiler's truthyEnv
+      # reader, so all default lanes stay byte-identical. The runner's compile
+      # workers inherit the job env, and results are never cached across runs,
+      # so a flag-on dispatch measures a full fresh compile of every test.
+      JS2WASM_IR_FIRST: ${{ github.event_name == 'workflow_dispatch' && inputs.ir_first && '1' || '' }}
       TEST262_INCLUDE_PROPOSALS: ${{ github.event_name != 'workflow_dispatch' && '1' || (inputs.include_proposals && '1' || '0') }}
       RUN_TIMESTAMP: ${{ github.run_id }}-${{ matrix.target.name }}-chunk${{ matrix.chunk }}
       TEST262_TARGET: ${{ matrix.target.test262_target }}
@@ -1383,7 +1395,12 @@ jobs:
           exit 1
 
   promote-baseline:
-    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.actor != 'github-actions[bot]'
+    # (#2947) `!(… && inputs.ir_first)` — an IR-first measurement dispatch
+    # (JS2WASM_IR_FIRST=1 in the shards) must NEVER promote its merged report:
+    # promoting a flagged run's pass-set would poison the regression baseline
+    # every PR gates against. The merged-report ARTIFACT is the measurement
+    # deliverable; the baseline stays owned by unflagged runs.
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.actor != 'github-actions[bot]' && !(github.event_name == 'workflow_dispatch' && inputs.ir_first)
     name: promote merged report to main baseline
     needs: merge-report
     runs-on: ubuntu-latest

--- a/plan/issues/2135-ir-capability-predicate-single-source.md
+++ b/plan/issues/2135-ir-capability-predicate-single-source.md
@@ -1,12 +1,12 @@
 ---
 id: 2135
 title: "Single IR capability predicate shared by selector and builder (retire select.ts/from-ast.ts drift)"
-status: blocked
-blocked_by: [2167]
+status: in-progress
+assignee: ttraenkler/dev-2138f
 pipeline_unblocked: 1927
 sprint: 67
 created: 2026-06-12
-updated: 2026-06-24
+updated: 2026-07-02
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -15,7 +15,7 @@ task_type: architecture
 area: compiler
 language_feature: compiler-internals
 goal: correctness
-related: [1923, 1804, 1922, 2138]
+related: [1923, 1804, 1922, 2138, 2945, 2947]
 origin: "2026-06-12 sprint-62 architecture analysis (IR workstream N2)"
 ---
 
@@ -58,3 +58,90 @@ silent legacy demote and becomes a hard trap on a skipped function, so the
 `select.ts` ⇄ `from-ast.ts` capability drift this issue closes is exactly the
 divergence #2138's measurement surfaces. #2138's `## Implementation Plan` records
 the same dependency. Still parked on **#2167** (Fable disabled) for dispatch.
+
+**2026-07-02 (dev-2138f): #2167 resolved (Fable re-enabled), #2138 Slice 2
+landed (PR #2468). blocked_by cleared, status → in-progress.**
+
+## Implementation Notes (dev-2138f, Fable, 2026-07-02 — Slice 1: operator family)
+
+### What landed (slice 1)
+
+`src/ir/capability.ts` — the single-source table, three states per row:
+
+- **`claim`** — selector accepts AND builder lowers every shape-admitted
+  operand. Type-level demotes (operand types the IR can't represent) remain
+  owned by the type-resolution lane; they are not capability drift.
+- **`claim-partial`** — TRANSITIONAL: selector accepts, builder lowers a
+  documented subset and demotes the rest through the metered post-claim
+  channel (#1923 / `irPostClaimErrors`). Every entry carries the tracking
+  issue that retires it (→ `claim` by finishing the lowering, or → `defer`).
+- **`defer`** — selector rejects up-front; the builder's guard becomes an
+  internal-invariant assertion (`assertNotDeferred` — a defer construct
+  arriving post-claim is a compiler BUG, loudly distinct from the
+  `not in slice N` fallback family). Unknown constructs default to defer.
+
+Consumers rewired: `select.ts` `isPhase1BinaryOp`/`isPhase1PrefixOp` are now
+thin table reads (`capability !== "defer"`); `from-ast.ts` `lowerBinary` /
+`lowerPrefixUnary` assert the same table on entry.
+
+**Rows flipped in slice 1** — the deliberate slice-11 "shape-only acceptance"
+over-claims (`%`, `**`, `in`, `instanceof`: selector accepted, builder threw
+`not in slice 11`) are now `defer`. Observable effects:
+
+- `irPostClaimErrors` for this family drops to ZERO (acceptance criterion 2
+  — e.g. an `a % b` function used to produce a post-claim `build` error;
+  now it is selector-rejected and compiles clean via legacy; probes in
+  `tests/issue-2135.test.ts`).
+- Under #2138's `JS2WASM_IR_FIRST=1` these ops can no longer hard-error
+  (#2945's failure mode is structurally gone — #2945 remains open as the
+  "implement `%` lowering, flip the row to claim" issue).
+- `scripts/ir-fallback-baseline.json` refreshed: the two corpus functions in
+  this family moved buckets (`call-graph-closure` −2 → `body-shape-rejected`
+  +2; total unchanged) because they are now rejected at Step 1 instead of
+  being claimed and then dropped by the Step-2 closure. Same final artifact
+  (legacy body) — a reason relabel, not a coverage change.
+- `??` and `+` stay `claim-partial` (`lowerNullish` reference-subset;
+  #2781's `+` operand-type proof) — their residual demotes are the honest
+  metered remainder, unchanged.
+
+### Deliberate scope choices
+
+1. **Operator family only.** The issue is staged per expression family; the
+   operator family was slice 1 because it held the only *fully-unlowered*
+   over-claims (the #2945 class — the ones that hard-error under IR-first).
+   Follow-up families in rough value order: call shapes (external-call
+   whitelist ⇄ `lowerCall` throw sites), element/property access arg shapes,
+   array-literal shapes (the #1804 mismatch — re-verify it is really gone),
+   statement shapes (`isPhase1StatementList` ⇄ statement lowering throws).
+   Each family = one PR: add rows + rewire the two consumers + a conformance
+   test proving every `claim` row is backed by a lowering.
+2. **`claim-partial` is explicit, not hidden.** The original spec wanted
+   from-ast throws to become `unreachable` assertions "where the table says
+   claimable" — that is only sound for FULL claims. A partial claim's
+   residual throw is a *documented demote*, not a bug; conflating the two
+   would either hard-error legitimate residuals or silently bless drift.
+   The three-state table encodes the difference; the endgame (#2855) is
+   claim-partial → claim row by row.
+3. **Mode-gated capabilities (coordination with #2856).** dev-2856f's
+   extern-in-IR arms (HostMemberGet/HostMethodCall) are JS-host-lane-only.
+   The agreed shape: add their guards to `capability.ts` as predicate
+   functions carrying a mode parameter (e.g.
+   `canHostMemberGet(node, mode): IrOpCapability`), consumed by both sides
+   like the op tables. `claim-partial` is the right state for a new family
+   while its lowering matures — and #2138's skip set treats partial claims
+   safely (a skipped-then-failed function is a loud error; conservative
+   exclusion from the skip set is available if flag-on noise matters).
+
+### Verification (slice 1)
+
+- `tests/issue-2135.test.ts` (5): defer ops selector-rejected + zero
+  post-claim errors + correct legacy execution (`%`, `**`, `in`, `~`);
+  claim ops selector-accepted + IR-compiled with zero post-claim errors +
+  correct results (arith/compare/logical/bitwise/prefix probes); `??`
+  claim-partial residual intact; table sanity (retired rows exactly defer,
+  unknown ops default defer).
+- `check:ir-fallbacks` green against the refreshed baseline; post-claim
+  demotions remain "(none)" on the corpus.
+- Pre-existing `__unbox_number` harness LinkErrors in
+  `tests/ir-numeric-bool-equivalence.test.ts` (28) are unchanged and
+  identical on the merge base — not introduced by this slice.

--- a/plan/issues/2947-test262-ir-first-measurement-lane.md
+++ b/plan/issues/2947-test262-ir-first-measurement-lane.md
@@ -1,0 +1,65 @@
+---
+id: 2947
+title: "test262-sharded workflow_dispatch ir_first lane — repeatable off-box #2138 measurement"
+status: done
+completed: 2026-07-02
+sprint: current
+created: 2026-07-02
+updated: 2026-07-02
+priority: medium
+feasibility: easy
+horizon: s
+task_type: infra
+area: ci
+goal: maintainability
+related: [2138, 2135]
+origin: "2026-07-02 tech-lead decision — #2138 Slice 3 needs an idle box or a CI lane; the dev box runs 9 agents"
+---
+
+# test262-sharded `ir_first` dispatch lane (#2138 Slice-3 measurement, off-box)
+
+## Problem
+
+#2138's acceptance criterion 2 needs a full `JS2WASM_IR_FIRST=1` test262 +
+compile-time run. The shared dev box cannot host it (load ≈ 12–14 on 8 cores
+with the agent pool active; wall-clock variance ±45% made compile-time deltas
+unmeasurable — see #2138 `## Measurement`), and team rules bar devs from
+local full test262 anyway. The measurement must be repeatable and off-box.
+
+## Implemented (rides the #2135 slice-1 PR)
+
+`.github/workflows/test262-sharded.yml`:
+
+- New `workflow_dispatch` input **`ir_first`** (boolean, default false).
+- Shard-job env: `JS2WASM_IR_FIRST: ${{ github.event_name ==
+  'workflow_dispatch' && inputs.ir_first && '1' || '' }}` — `'1'` only on an
+  opted-in dispatch; the empty string on every other event is falsy for the
+  compiler's `truthyEnv` reader, so all default lanes (PR / push /
+  merge_group / plain dispatch) are behaviorally identical. Compile workers
+  inherit the job env; the runner compiles every test fresh (no cross-run
+  result cache — deliberate, workflow line ~485), so a flagged dispatch
+  measures a full clean compile.
+- **`promote-baseline` is hard-skipped for `ir_first` runs**
+  (`!(github.event_name == 'workflow_dispatch' && inputs.ir_first)` added to
+  the job `if:`). A flagged run promoting its pass-set would poison the
+  regression baseline every PR gates against; the merged-report ARTIFACT is
+  the measurement deliverable instead.
+
+## How to run the measurement (lead)
+
+1. Actions → "test262 sharded" → Run workflow on `main`, `ir_first: true`.
+2. Compare the run's merged report artifact against the current baseline
+   JSONL (`scripts/fetch-baseline-jsonl.mjs` + `/analyze-regression`); every
+   flag-ON-only failure is a loud #2138 divergence — bucket by error class,
+   file per class (as #2945 was).
+3. Compile-time delta: compare the run's shard wall-times against a same-SHA
+   unflagged dispatch (the shards are duration-weighted, so per-shard deltas
+   are directly comparable).
+4. Record results in #2138 `## Measurement (JS2WASM_IR_FIRST)`.
+
+## Acceptance criteria
+
+- Dispatch with `ir_first: true` runs all shards with the flag exported and
+  never touches the baseline. — implemented, guard verified by inspection
+  (`inputs.*` is empty on push events → guard passes unchanged).
+- Default lanes byte-identical in behavior (empty-string env). — implemented.

--- a/scripts/ir-fallback-baseline.json
+++ b/scripts/ir-fallback-baseline.json
@@ -1,9 +1,9 @@
 {
-  "generated": "2026-06-16",
+  "generated": "2026-07-02",
   "unintended": {
-    "body-shape-rejected": 31,
+    "body-shape-rejected": 33,
     "param-type-not-resolvable": 1,
-    "call-graph-closure": 7,
+    "call-graph-closure": 5,
     "class-method": 6
   },
   "deferred": {

--- a/src/ir/capability.ts
+++ b/src/ir/capability.ts
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2135 — the IR capability table: ONE source of truth for "what can the IR
+// front-end lower", consumed by BOTH sides of the claim boundary:
+//
+//   - the selector (`select.ts` — `isPhase1BinaryOp` / `isPhase1PrefixOp`)
+//     decides whether a function containing the construct may be CLAIMED;
+//   - the builder (`from-ast.ts` — `lowerBinary` / `lowerPrefixUnary`)
+//     asserts on entry that a capability-deferred construct can never reach
+//     it post-claim.
+//
+// Why this file exists (#2135): "what IR can do" used to be encoded twice —
+// the selector accepted shapes the builder threw on *by design* ("shape-only
+// acceptance ... lowering throws cleanly so the function falls back to
+// legacy"). That deliberate over-claim leaned on the demote-to-warning
+// fallback channel, which #2855 phases out and which the #2138 IR-first
+// inversion turns into a HARD compile error on a skipped slot (a placeholder
+// body would otherwise ship — see `[IR-FIRST skipped-slot, #2138]`). With the
+// table, a selector claim is by-construction backed by a builder lowering:
+// disagreement is impossible for table-covered constructs, and adding an IR
+// feature means flipping ONE row here (plus the lowering), never editing two
+// predicates. #2945 (the `%` drift #2138's flag surfaced) is the founding
+// example.
+//
+// ── The three capability states ────────────────────────────────────────────
+//
+// "claim"          The selector accepts the construct AND the builder lowers
+//                  it for every operand the *shape* rules admit. The builder
+//                  may still fail on operand TYPES it cannot represent
+//                  (e.g. an operand that lowers to a string in an f64 slot) —
+//                  those are type-level demotes owned by the type-resolution
+//                  lane, not capability drift.
+//
+// "claim-partial"  TRANSITIONAL. The selector accepts, and the builder lowers
+//                  a documented SUBSET, throwing a clean fallback otherwise.
+//                  Every entry MUST carry the tracking issue that either
+//                  completes the lowering (→ "claim") or narrows the selector
+//                  (→ "defer"). Under #2138's IR-first flag these residual
+//                  throws remain the honest post-claim-demote metric
+//                  (`irPostClaimErrors`) that #1923 meters.
+//
+// "defer"          The selector REJECTS the construct (routes the function to
+//                  legacy up-front, bucketed by the selector's telemetry).
+//                  The builder can therefore never see it post-claim; its
+//                  guard for a deferred construct is an internal-invariant
+//                  assertion, not a fallback path.
+//
+// Anything NOT in a table defaults to "defer" — new syntax is legacy-only
+// until a row (plus a lowering) claims it.
+
+import { ts } from "../ts-api.js";
+
+export type IrOpCapability = "claim" | "claim-partial" | "defer";
+
+// ── Binary operators (`lowerBinary` family) ────────────────────────────────
+//
+// History of the rows:
+//   - the "claim" set mirrors slice 11 (#1169n): arithmetic, comparisons,
+//     logical short-circuit (#1820), and ToInt32-wrapped bitwise ops;
+//   - `+` is claim-partial: #2781's Row-7 proof gate demands both operands
+//     provably number or provably string (checker present); unprovable
+//     operand pairs demote to legacy's dynamic `+`;
+//   - `??` is claim-partial: `lowerNullish` handles a reference-shaped lhs
+//     with same-typed arms; other operand types demote (#1131);
+//   - `%`, `**`, `in`, `instanceof` were claimed shape-only with NO lowering
+//     ("slice 11 shape-only acceptance") — the exact selector↔builder drift
+//     #2135 retires. They are now DEFERRED: the selector rejects them
+//     up-front. Implementing a lowering (e.g. #2945 for `%`) flips the row
+//     to "claim" in the same PR as the lowering.
+const BINARY_OP_CAPABILITY: ReadonlyMap<ts.SyntaxKind, IrOpCapability> = new Map<ts.SyntaxKind, IrOpCapability>([
+  // Numeric arithmetic (f64; i32 via propagation rules).
+  [ts.SyntaxKind.MinusToken, "claim"],
+  [ts.SyntaxKind.AsteriskToken, "claim"],
+  [ts.SyntaxKind.SlashToken, "claim"],
+  // `+` — string-concat-or-numeric-add chosen at runtime in JS; the IR
+  // specializes only under #2781's operand-type proof (both-number or
+  // both-string). Unprovable pairs (any / unions / mixed) demote. → "claim"
+  // once the dynamic-`+` lowering lands in IR (tracked via #2781/#1131).
+  [ts.SyntaxKind.PlusToken, "claim-partial"],
+  // Comparisons (f64/i32/string per operand resolution).
+  [ts.SyntaxKind.LessThanToken, "claim"],
+  [ts.SyntaxKind.LessThanEqualsToken, "claim"],
+  [ts.SyntaxKind.GreaterThanToken, "claim"],
+  [ts.SyntaxKind.GreaterThanEqualsToken, "claim"],
+  [ts.SyntaxKind.EqualsEqualsEqualsToken, "claim"],
+  [ts.SyntaxKind.EqualsEqualsToken, "claim"],
+  [ts.SyntaxKind.ExclamationEqualsEqualsToken, "claim"],
+  [ts.SyntaxKind.ExclamationEqualsToken, "claim"],
+  // Logical short-circuit (#1820 — IrInstrIf lowering, right arm lazy).
+  [ts.SyntaxKind.AmpersandAmpersandToken, "claim"],
+  [ts.SyntaxKind.BarBarToken, "claim"],
+  // `??` — lowered over a reference-shaped lhs with same-typed arms
+  // (`lowerNullish`); non-reference / mismatched operand types demote (#1131).
+  [ts.SyntaxKind.QuestionQuestionToken, "claim-partial"],
+  // Bitwise (slice 11 — JS ToInt32 each operand, i32 op, convert back).
+  [ts.SyntaxKind.AmpersandToken, "claim"],
+  [ts.SyntaxKind.BarToken, "claim"],
+  [ts.SyntaxKind.CaretToken, "claim"],
+  [ts.SyntaxKind.LessThanLessThanToken, "claim"],
+  [ts.SyntaxKind.GreaterThanGreaterThanToken, "claim"],
+  [ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken, "claim"],
+  // Deferred — no IR lowering exists. Selector rejects; builder asserts.
+  [ts.SyntaxKind.PercentToken, "defer"], // #2945 — needs JS-conformant fmod-style remainder
+  [ts.SyntaxKind.AsteriskAsteriskToken, "defer"], // needs Math.pow-equivalent lowering
+  [ts.SyntaxKind.InKeyword, "defer"], // needs property/prototype-chain probe
+  [ts.SyntaxKind.InstanceOfKeyword, "defer"], // needs class-shape / brand check
+]);
+
+// ── Prefix unary operators (`lowerPrefixUnary` family) ─────────────────────
+//
+// `++` / `--` in statement position are handled by the assignment lane, not
+// `lowerPrefixUnary`; the rows here cover VALUE-position prefix expressions,
+// matching `isPhase1PrefixOp`'s historical accept set exactly.
+const PREFIX_OP_CAPABILITY: ReadonlyMap<ts.PrefixUnaryOperator, IrOpCapability> = new Map<
+  ts.PrefixUnaryOperator,
+  IrOpCapability
+>([
+  [ts.SyntaxKind.MinusToken, "claim"], // f64.neg
+  [ts.SyntaxKind.PlusToken, "claim"], // numeric identity
+  [ts.SyntaxKind.ExclamationToken, "claim"], // i32.eqz over bool
+  [ts.SyntaxKind.TildeToken, "defer"], // ToInt32 + i32.xor -1 — not lowered yet
+]);
+
+/** Capability of a BinaryExpression operator token. Unknown ops → "defer". */
+export function binaryOpCapability(op: ts.SyntaxKind): IrOpCapability {
+  return BINARY_OP_CAPABILITY.get(op) ?? "defer";
+}
+
+/** Capability of a value-position PrefixUnaryExpression operator. Unknown ops → "defer". */
+export function prefixOpCapability(op: ts.PrefixUnaryOperator): IrOpCapability {
+  return PREFIX_OP_CAPABILITY.get(op) ?? "defer";
+}
+
+/**
+ * Builder-side invariant guard. Call on entry to a lowering dispatch with the
+ * construct's capability: a "defer" construct arriving post-claim means the
+ * selector and this table disagreed — a claim-path bug, NOT a legitimate
+ * legacy fallback. The thrown message is deliberately distinct from the
+ * `not in slice N` fallback family so the #1923 post-claim meter and the
+ * #2138 IR-first hard-error channel surface it as a capability violation.
+ */
+export function assertNotDeferred(cap: IrOpCapability, what: string, funcName: string): void {
+  if (cap === "defer") {
+    throw new Error(
+      `ir/from-ast: internal capability violation — ${what} is capability-deferred (see src/ir/capability.ts) yet reached the builder post-claim in ${funcName}. The selector and the capability table disagree; this is a compiler bug, not a fallback.`,
+    );
+  }
+}

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -43,6 +43,7 @@ import { evaluateConstantCondition } from "../codegen/statements/control-flow.js
 import { isIncreasingStep, loopBodyMutatesIndexOrArray } from "../codegen/statements/loops.js";
 import { IrFunctionBuilder } from "./builder.js";
 import type { AllocSiteRegistry } from "./alloc-registry.js";
+import { assertNotDeferred, binaryOpCapability, prefixOpCapability } from "./capability.js";
 import type { IrLowerResolver, IrVecLowering } from "./lower.js";
 import { mathUnaryToIrOp } from "./select.js";
 import {
@@ -4095,6 +4096,13 @@ function lowerConditional(expr: ts.ConditionalExpression, cx: LowerCtx): IrValue
 }
 
 function lowerPrefixUnary(expr: ts.PrefixUnaryExpression, cx: LowerCtx): IrValueId {
+  // #2135 — capability-table invariant, mirroring `lowerBinary`. A deferred
+  // prefix op post-claim is a selector↔table disagreement (compiler bug).
+  assertNotDeferred(
+    prefixOpCapability(expr.operator),
+    `prefix operator '${ts.tokenToString(expr.operator) ?? expr.operator}'`,
+    cx.funcName,
+  );
   const rand = lowerExpr(expr.operand, cx, irVal({ kind: "f64" }));
   switch (expr.operator) {
     case ts.SyntaxKind.MinusToken: {
@@ -4289,18 +4297,15 @@ function lowerBinary(expr: ts.BinaryExpression, cx: LowerCtx, hint: IrType): IrV
     return lowerLogicalAndOr(expr, op, cx);
   }
 
-  // Slice 11 (#1169n) — early fallback for ops the selector accepts
-  // shape-only but the lowerer doesn't yet implement. Throwing BEFORE
-  // we lower operands keeps the error message short and avoids
-  // cascading errors from operand lowering.
-  if (
-    op === ts.SyntaxKind.PercentToken ||
-    op === ts.SyntaxKind.AsteriskAsteriskToken ||
-    op === ts.SyntaxKind.InKeyword ||
-    op === ts.SyntaxKind.InstanceOfKeyword
-  ) {
-    throw new Error(`ir/from-ast: operator '${ts.tokenToString(op)}' not in slice 11 (${cx.funcName})`);
-  }
+  // #2135 — capability-table invariant (shared with the selector via
+  // `src/ir/capability.ts`). The old slice-11 "shape-only acceptance" list
+  // (`%` / `**` / `in` / `instanceof` claimed by the selector, thrown here)
+  // is retired: those ops are table-deferred, the selector rejects them
+  // up-front, and an op arriving here with a "defer" capability is a
+  // claim-path BUG (loud internal error), not a legitimate legacy fallback.
+  // Checked BEFORE operand lowering so a violation reports cleanly without
+  // cascading operand errors.
+  assertNotDeferred(binaryOpCapability(op), `binary operator '${ts.tokenToString(op) ?? op}'`, cx.funcName);
 
   // === / !== / == / != with a `null` literal: slice 1 has no nullable IR
   // types yet, so every operand we can lower trivially evaluates to false

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -56,6 +56,7 @@
 
 import { ts, forEachChild } from "../ts-api.js";
 
+import { binaryOpCapability, prefixOpCapability } from "./capability.js";
 import type { LatticeType, TypeMap } from "./propagate.js";
 
 /**
@@ -1969,50 +1970,19 @@ function phase1MemberName(name: ts.PropertyName): string | null {
   return null;
 }
 
+// #2135 — the operator predicates consume the shared capability table
+// (`src/ir/capability.ts`), the SAME source `from-ast.ts`'s lowering dispatch
+// asserts against. "claim-partial" is selector-accepted (the builder owns the
+// documented residual fallback); "defer" is selector-rejected up-front. The
+// former slice-11 "shape-only acceptance" block (`%` / `**` / `in` /
+// `instanceof` accepted here while the lowerer threw) is retired: those ops
+// are table-deferred, so the claim can no longer disagree with the builder.
 function isPhase1PrefixOp(op: ts.PrefixUnaryOperator): boolean {
-  return op === ts.SyntaxKind.MinusToken || op === ts.SyntaxKind.PlusToken || op === ts.SyntaxKind.ExclamationToken;
+  return prefixOpCapability(op) !== "defer";
 }
 
 function isPhase1BinaryOp(op: ts.SyntaxKind): boolean {
-  switch (op) {
-    case ts.SyntaxKind.PlusToken:
-    case ts.SyntaxKind.MinusToken:
-    case ts.SyntaxKind.AsteriskToken:
-    case ts.SyntaxKind.SlashToken:
-    case ts.SyntaxKind.LessThanToken:
-    case ts.SyntaxKind.LessThanEqualsToken:
-    case ts.SyntaxKind.GreaterThanToken:
-    case ts.SyntaxKind.GreaterThanEqualsToken:
-    case ts.SyntaxKind.EqualsEqualsEqualsToken:
-    case ts.SyntaxKind.EqualsEqualsToken:
-    case ts.SyntaxKind.ExclamationEqualsEqualsToken:
-    case ts.SyntaxKind.ExclamationEqualsToken:
-    case ts.SyntaxKind.AmpersandAmpersandToken:
-    case ts.SyntaxKind.BarBarToken:
-      return true;
-    // Slice 11 (#1169n) — bitwise ops on f64 operands. JS ToInt32
-    // each operand, apply the i32 op, convert back to f64. Lowering
-    // emits this sequence inline using a per-function scratch local.
-    case ts.SyntaxKind.AmpersandToken:
-    case ts.SyntaxKind.BarToken:
-    case ts.SyntaxKind.CaretToken:
-    case ts.SyntaxKind.LessThanLessThanToken:
-    case ts.SyntaxKind.GreaterThanGreaterThanToken:
-    case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken:
-      return true;
-    // Slice 11 (#1169n) — shape-only acceptance for ops the lowerer
-    // doesn't yet implement. Lowering throws cleanly so the function
-    // falls back to legacy via `safeSelection`. Listed individually
-    // so future slices can flip them on without touching the selector.
-    case ts.SyntaxKind.PercentToken: // % — needs JS-conformant fmod-style remainder
-    case ts.SyntaxKind.AsteriskAsteriskToken: // ** — needs Math.pow host call
-    case ts.SyntaxKind.QuestionQuestionToken: // ?? — needs nullable-LHS handling
-    case ts.SyntaxKind.InKeyword: // in — needs prototype-chain probe
-    case ts.SyntaxKind.InstanceOfKeyword: // instanceof — needs class-shape check
-      return true;
-    default:
-      return false;
-  }
+  return binaryOpCapability(op) !== "defer";
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/issue-2135.test.ts
+++ b/tests/issue-2135.test.ts
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2135 — single IR capability predicate (operator family, slice 1).
+//
+// "What IR can do" used to be encoded twice: `select.ts`'s `isPhase1BinaryOp`
+// deliberately accepted `%` / `**` / `in` / `instanceof` "shape-only" while
+// `from-ast.ts` threw `not in slice 11` — a designed over-claim that leaned on
+// the demote-to-warning fallback (and becomes a hard error under #2138's
+// IR-first flag; #2945 is the filed instance). Slice 1 single-sources the
+// OPERATOR family in `src/ir/capability.ts`, consumed by both the selector
+// and the builder:
+//
+//   - "claim"          selector accepts, builder lowers (shape-admitted operands)
+//   - "claim-partial"  selector accepts, builder lowers a documented subset
+//                      (residuals stay on the metered post-claim channel, #1923)
+//   - "defer"          selector rejects up-front; builder asserts (a defer op
+//                      arriving post-claim is a compiler bug, not a fallback)
+//
+// Contract under test:
+//   1. Deferred ops (`%`, `**`, `in`, `instanceof`) are selector-REJECTED —
+//      zero post-claim errors (they used to be claim-then-build-throw), and
+//      programs using them still compile and run correctly via legacy.
+//   2. Claimed ops are selector-accepted AND IR-compile without any
+//      post-claim error — the table's claim is backed by a real lowering
+//      (this is the "one table row, not two predicates" acceptance).
+//   3. Claim-partial (`??`) keeps its residual: reference-shaped operands
+//      IR-compile; non-lowerable operand types still demote through the
+//      metered channel (NOT a hard error), unchanged from before.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { analyzeSource } from "../src/checker/index.js";
+import { planIrCompilation } from "../src/ir/select.js";
+import { binaryOpCapability, prefixOpCapability } from "../src/ir/capability.js";
+import { ts } from "../src/ts-api.js";
+
+async function run(source: string, fn: string, args: unknown[]): Promise<unknown> {
+  const r = await compile(source, { fileName: "issue-2135.ts" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as Record<string, Function>)[fn]!(...args);
+}
+
+function claims(source: string, fnName: string): boolean {
+  const ast = analyzeSource(source);
+  const sel = planIrCompilation(ast.sourceFile, { experimentalIR: true });
+  return sel.funcs.has(fnName);
+}
+
+describe("#2135 capability table — operator family single source", () => {
+  it("deferred ops are selector-rejected (no more shape-only over-claim)", () => {
+    expect(claims(`export function m(a: number, b: number): number { return a % b; }`, "m")).toBe(false);
+    expect(claims(`export function p(a: number, b: number): number { return a ** b; }`, "p")).toBe(false);
+    expect(claims(`export function tld(o: any): boolean { return "x" in o; }`, "tld")).toBe(false);
+    expect(claims(`export function bnot(a: number): number { return ~a; }`, "bnot")).toBe(false);
+  });
+
+  it("deferred ops produce ZERO post-claim errors and run correctly via legacy", async () => {
+    // Pre-#2135 these were claim-then-build-throw ("operator '%' not in
+    // slice 11") — counted on irPostClaimErrors and, under JS2WASM_IR_FIRST,
+    // a hard compile error (#2945). Now the selector never claims them.
+    const src = `export function m(a: number, b: number): number { return a % b; }`;
+    const r = await compile(src, { fileName: "issue-2135.ts" });
+    expect(r.success).toBe(true);
+    expect((r.irPostClaimErrors ?? []).filter((e) => e.func === "m")).toEqual([]);
+    expect(await run(src, "m", [7, 3])).toBe(1);
+    expect(await run(src, "m", [-7, 2])).toBe(-1);
+    expect(await run(`export function p(a: number, b: number): number { return a ** b; }`, "p", [2, 10])).toBe(1024);
+  });
+
+  it("claimed ops are selector-accepted and IR-compile with no post-claim error", async () => {
+    // One probe per claim-op family — proves the table's "claim" rows are
+    // backed by real lowerings (selector and builder agree by construction).
+    const probes: Array<[string, string, unknown[], unknown]> = [
+      [`export function f(a: number, b: number): number { return a - b * 2 + a / b; }`, "f", [8, 4], 2],
+      [`export function f(a: number, b: number): boolean { return a < b || (a >= b && a !== 0); }`, "f", [8, 4], 1],
+      [
+        `export function f(a: number, b: number): number { return (a & b) | (a ^ b) | (a << 1) | (a >> 1) | (a >>> 1); }`,
+        "f",
+        [6, 3],
+        15,
+      ],
+      [`export function f(a: number): number { return -a + +a; }`, "f", [5], 0],
+      [`export function f(b: boolean): boolean { return !b; }`, "f", [1], 0],
+    ];
+    for (const [src, fn, args, expected] of probes) {
+      expect(claims(src, fn), `selector should claim: ${src}`).toBe(true);
+      const r = await compile(src, { fileName: "issue-2135.ts" });
+      expect(r.success).toBe(true);
+      expect(
+        (r.irPostClaimErrors ?? []).filter((e) => e.func === fn),
+        `claim must be backed by a lowering: ${src}`,
+      ).toEqual([]);
+      expect(await run(src, fn, args)).toBe(expected);
+    }
+  });
+
+  it("claim-partial (`??`) keeps its documented residual demote (metered, not hard)", async () => {
+    // Reference-shaped operands lower in IR (see tests/ir-nullish-coalesce);
+    // a non-lowerable operand pair still demotes cleanly to legacy through
+    // the post-claim channel — the transitional state the table documents.
+    const src = `export function n(s: string): string { return s ?? "x"; }`;
+    expect(claims(src, "n")).toBe(true);
+    const r = await compile(src, { fileName: "issue-2135.ts" });
+    expect(r.success).toBe(true); // demote, never a hard failure (flag off)
+  });
+
+  it("table sanity: the retired over-claims are exactly defer; the accept set is unchanged otherwise", () => {
+    expect(binaryOpCapability(ts.SyntaxKind.PercentToken)).toBe("defer");
+    expect(binaryOpCapability(ts.SyntaxKind.AsteriskAsteriskToken)).toBe("defer");
+    expect(binaryOpCapability(ts.SyntaxKind.InKeyword)).toBe("defer");
+    expect(binaryOpCapability(ts.SyntaxKind.InstanceOfKeyword)).toBe("defer");
+    expect(binaryOpCapability(ts.SyntaxKind.QuestionQuestionToken)).toBe("claim-partial");
+    expect(binaryOpCapability(ts.SyntaxKind.PlusToken)).toBe("claim-partial");
+    expect(binaryOpCapability(ts.SyntaxKind.MinusToken)).toBe("claim");
+    expect(binaryOpCapability(ts.SyntaxKind.CommaToken)).toBe("defer"); // default: unknown → defer
+    expect(prefixOpCapability(ts.SyntaxKind.ExclamationToken)).toBe("claim");
+    expect(prefixOpCapability(ts.SyntaxKind.TildeToken)).toBe("defer");
+  });
+});


### PR DESCRIPTION
## Summary

Slice 1 of #2135: **one capability table** (`src/ir/capability.ts`) shared by the IR selector and the IR builder, retiring the deliberate selector↔builder drift for the operator family. Also implements **#2947** (rides this PR per lead decision): the `ir_first` workflow_dispatch lane for the off-box #2138 Slice-3 measurement.

### The table (three states per row)
- **`claim`** — selector accepts AND the builder lowers every shape-admitted operand.
- **`claim-partial`** — transitional: selector accepts; builder lowers a documented subset, residuals demote through the metered post-claim channel (#1923). Rows: `+` (#2781 proof gate), `??` (`lowerNullish` reference subset). Each carries its retiring issue.
- **`defer`** — selector rejects up-front; the builder's guard becomes an internal-invariant assertion (`assertNotDeferred`). Unknown ops default to defer.

`select.ts`'s `isPhase1BinaryOp`/`isPhase1PrefixOp` are now thin table reads; `from-ast.ts`'s `lowerBinary`/`lowerPrefixUnary` assert the same table on entry. **A selector claim is by-construction backed by a from-ast lowering** — adding an IR operator is one row + the lowering, never two predicates (acceptance criterion 3).

### Rows flipped
The slice-11 "shape-only acceptance" over-claims — `%`, `**`, `in`, `instanceof` (selector accepted, builder threw `not in slice 11`) — are now `defer`:
- post-claim errors for the family drop to **zero** (acceptance criterion 2; probes in `tests/issue-2135.test.ts`),
- the #2945 hard-error mode under `JS2WASM_IR_FIRST=1` is structurally gone (#2945 stays open to implement the `%` lowering and flip its row to `claim`),
- `scripts/ir-fallback-baseline.json` refreshed: the two corpus functions moved buckets (`call-graph-closure` −2 → `body-shape-rejected` +2, **total unchanged**) — they are rejected at Step 1 now instead of claimed-then-closure-dropped. Same legacy artifact; reason relabel only.

### #2947 — `ir_first` measurement lane (test262-sharded.yml)
- `workflow_dispatch` input `ir_first` (default false) exports `JS2WASM_IR_FIRST=1` into the shard env; every other event/lane sees an empty string (falsy for `truthyEnv`) — behaviorally identical defaults.
- **`promote-baseline` is hard-skipped for `ir_first` runs** — a flagged pass-set must never poison the regression baseline; the merged-report artifact is the measurement deliverable. Run procedure documented in `plan/issues/2947-*.md`.

### Verification
- `tests/issue-2135.test.ts` (5): defer ops selector-rejected + zero post-claim + correct legacy execution; claim ops accepted + IR-lowered + correct results; `??` residual intact; table sanity.
- Combined-tree check with the just-landed #2468 (`JS2WASM_IR_FIRST`): `tests/issue-2138.test.ts` passes through its drift-retired branch — flag-on now compiles `%` programs exactly like flag-off.
- `check:ir-fallbacks` green vs refreshed baseline (post-claim demotions: none); tsc + prettier green.
- 28 pre-existing `__unbox_number` harness LinkErrors in `tests/ir-numeric-bool-equivalence.test.ts` verified identical on the merge base — not this PR.

### Issue files
- #2135 `blocked → in-progress` (Fable re-enabled per #2167's resolution) + implementation notes, including the agreed mode-gated predicate shape for dev-2856f's #2856 extern-in-IR arms.
- #2947 filed as `done` (implemented here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS