### PR TITLE
fix(#2875): isConstructor harness stub returns boolean false, not number 0 (slice 4)

### DIFF
--- a/plan/issues/2875-standalone-string-prototype-cluster.md
+++ b/plan/issues/2875-standalone-string-prototype-cluster.md
@@ -229,10 +229,32 @@ family split across two PRs):
     (matches the direct path's static-only `argIsStaticRegExp` fold); no
     test262 case exercises a runtime-only RegExp arg reaching a reflective
     call today.
-- **Slice 4 — next:** `not-a-constructor` bucket (~14 tests: `new
-  String.prototype.X` / `Reflect.construct` must throw TypeError; needs
-  closure-IsConstructor=false machinery). Then the misc bucket
-  (`fromCharCode` static read, `Symbol.iterator`, `matchAll`, …).
+- **Slice 4 — in PR (dev-2875f): the `not-a-constructor` bucket was a harness
+  STUB TYPE BUG, not compiler work.** The runner replaces the test262
+  `isConstructor` harness entirely (`needsIsConstructor` preamble,
+  test262-runner.ts) because real `Reflect.construct` is a #1472 Phase C
+  compile refusal standalone. The stub was
+  `function isConstructor(f: number): number { return 0; }` — and
+  `assert.sameValue(isConstructor(x), false)` compiles to a strict `===`
+  where `0 === false` is (correctly!) false in the standalone lane, so every
+  `*/not-a-constructor.js` failed at assert #1. (The host lane passed the same
+  comparison via a lax host-eq quirk — worth its own look.) The tests' second
+  assert — `new String.prototype.X()` throws TypeError — already exercises
+  real compiled semantics and passes standalone. Fix: stub returns a real
+  `boolean false`. Verified: all 5 String search + charAt + Array indexOf
+  `not-a-constructor.js` → pass/pass both lanes; `is-a-constructor.js` stays
+  fail/fail both lanes (no false conformance for constructors until real
+  standalone `Reflect.construct` newTarget-validation lands — that is the
+  honest Phase C follow-up, out of this cluster). Blast radius: 533
+  `not-a-constructor.js` + 45 `is-a-constructor.js` + ~58 other harness users
+  — standalone wins only in sampling (18 diverse files + 5 base-compared);
+  full validation in `merge_group`.
+  - Adjacent gap (documented, not in-bucket): `const C: any =
+    String.prototype.indexOf; new C()` silently does NOT throw (the direct
+    member form does) — generic new-on-non-constructor-closure runtime check
+    missing.
+- **Slice 5 — next:** the misc bucket (`fromCharCode` static read,
+  `Symbol.iterator`, `matchAll`, …).
 - **Out of scope (routed elsewhere):** the 69-test #2862 ToPrimitive substrate
   bucket; the property-attribute `compile_error` tests (S15.5.4.7_A8–A11
   et al — `delete`/for-in over builtins, a different mechanism).

--- a/tests/test262-runner.ts
+++ b/tests/test262-runner.ts
@@ -1687,9 +1687,19 @@ function fnGlobalObject(): number { return 0; }`;
   }
 
   if (needsIsConstructor) {
+    // (#2875 slice 4) Harness stub pending a real standalone Reflect.construct
+    // (#1472 Phase C): everything reports non-constructor. The stub MUST return
+    // a real `false`, not the number 0 — `assert.sameValue(isConstructor(x),
+    // false)` compiles to a strict `===` where `0 === false` is (correctly)
+    // false in the standalone lane, so the typed-number stub failed every
+    // `*/not-a-constructor.js` at assert #1 even though the test's second
+    // assert (`new X()` throws TypeError) exercises real compiled semantics
+    // and passes. `is-a-constructor.js` tests (assert true) keep failing under
+    // this stub by design — no false conformance for constructors until the
+    // real Reflect.construct newTarget-validation lands.
     p += `
 
-function isConstructor(f: number): number { return 0; }`;
+function isConstructor(f: any): boolean { return false; }`;
   }
 
   if (needsDecimalToHex) {


### PR DESCRIPTION
## What

Slice 4 of #2875 — the `not-a-constructor` bucket (~14 String tests, 533 suite-wide) turned out to be a **harness stub type bug**, not missing compiler machinery.

## Root cause

The runner replaces the test262 `isConstructor` harness with a preamble stub (real `Reflect.construct` is a #1472 Phase C compile refusal standalone). The stub was:

    function isConstructor(f: number): number { return 0; }

`assert.sameValue(isConstructor(x), false)` compiles to a strict `===`, and `0 === false` is (correctly) false in the standalone lane — so every `*/not-a-constructor.js` failed at assert #1. The tests' second assert (`new String.prototype.X()` throws TypeError) already exercises real compiled semantics and passes standalone. The host lane passed the same `0 === false` comparison via a lax host-eq quirk — noted in the issue for a separate look.

## Fix

Stub returns a real `boolean false` (typed `f: any`). One line + rationale comment.

- `is-a-constructor.js` (assert true) keeps failing BOTH lanes by design — no false conformance for constructors until a real standalone `Reflect.construct` newTarget-validation lands (the honest Phase C follow-up, out of this cluster's scope).
- Documented adjacent gap: `const C: any = String.prototype.indexOf; new C()` silently does not throw (the direct member form does) — generic new-on-non-constructor-closure runtime check missing.

## Validation

- Both lanes verified: all 5 String search-family + charAt + Array/indexOf `not-a-constructor.js` → pass/pass.
- 18-file diverse sample (annexB/Math/Reflect/Atomics/Promise/JSON/Date/TypedArray/Temporal) + 5 files base-compared on origin/main: standalone **wins only**, hosts unchanged, `is-a-constructor` fail/fail unchanged.
- Blast radius is wide (636 harness users) → full both-lane validation lands in the `merge_group` re-run; expected direction is standalone fail→pass only.
- prettier + biome clean.

Issue: plan/issues/2875-standalone-string-prototype-cluster.md (stays `in-progress`; slice 5 = misc bucket next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS