### PR TITLE
fix(#2966): standalone any-param closure results silently wrong through + — __any_add tag-5 payload classifier

### DIFF
--- a/plan/issues/2966-standalone-anyparam-closure-add-tag5-misclassify.md
+++ b/plan/issues/2966-standalone-anyparam-closure-add-tag5-misclassify.md
@@ -1,0 +1,138 @@
+---
+id: 2966
+title: "Standalone: any-param closure results silently wrong through `+` — __any_add classified every tag-5 box as stringy (re-id of the orphaned #2945 analysis)"
+status: done
+completed: 2026-07-02
+assignee: ttraenkler/fable-3
+sprint: current
+created: 2026-07-02
+updated: 2026-07-02
+priority: high
+horizon: m
+feasibility: hard
+task_type: bug
+area: codegen
+language_feature: closures
+goal: standalone
+related: [2924, 2442, 1888, 2040, 2945]
+blocks: [2924]
+---
+
+# #2966 — standalone any-param closure `+` misclassification (silent wrong values)
+
+**Re-id note:** the original analysis was filed as `#2945` on dev-f2's branch
+(`issue-2924-newfn-mainbase`, PR #2464 vicinity) but id 2945 was subsequently
+taken on `main` by an unrelated issue (IR-selector modulo drift, parallel
+session). This file carries the analysis over under a fresh `--allocate` id and
+records the (deeper) root cause found on current main.
+
+## Problem (measured 2026-07-02 on main `affc55523`)
+
+On the **standalone** lane, values returned by an `any`-typed closure are
+silently WRONG the moment they flow through `+`:
+
+```ts
+export function test(): number {
+  const f: any = function (a: any) {
+    return a + 10;
+  };
+  return f(1) + f(2); // standalone: 0   (host / JS: 23)
+}
+// f(1,2,3) with (a: any, b: any, c: any) => a + b + c  → NaN (want 6)
+// const x = f(1); const y = f(2); x + y                → 0   (want 23)
+// x + x                                                → 0   (want 22)
+```
+
+Worst defect class: **silent wrong values**, no trap, no CE. Blocks #2924's
+standalone enablement (a `new Function`-synthesized function has all-externref
+params, so it inherits this bug).
+
+## Root cause — NOT call marshalling
+
+The original #2945 hypothesis (temp-local collision in call marshalling) is
+**false on current main**. Narrowing probes showed every call returns the
+correct value (`return f(2)` → 12 even as a second call; `x - y` → −1;
+`x * y` → 132; `x + 1` → 12). Only **any + any `+`** is wrong, and only when an
+operand's payload crossed the open-any boundary:
+
+1. The closure-call result is an externref holding a native `$BoxedNumber`
+   carrier (`__box_number`).
+2. `compileAnyBinaryDispatch` (binary-ops.ts) boxes each externref operand to
+   `$AnyValue` via `boxToAny` → `__any_box_string` — the **deliberate** #1888
+   tag-5 "box-the-externref" contract (`value-tags.ts:178-185`; honest
+   re-tagging at the boxing site regressed −788/−794 and is forbidden).
+3. `__any_add` (any-helpers.ts) classified **every** tag-5 operand as stringy
+   (`tag==5 || tag==6`) → §13.15.3 concat arm → `__any_to_string` recovers
+   `"11"`/`"12"`, concatenates to a tag-5 string box — and the caller's f64
+   coercion reads the tag-5 box's f64 field, which is **0**.
+
+So `f(1)+f(2)` = 0, and inside a 3-any-param closure `a+b+c` = NaN (the
+`(a+b)` sub-result is a proper tag-3 numeric box, but `+ c` re-enters the same
+misclassification).
+
+Per §13.15.3 ApplyStringOrNumericBinaryOperator, ToPrimitive of a number or
+boolean is **not** a string → those operands must take the numeric arm. The
+numeric arm's `__any_to_f64` **already** recovers `$BoxedNumber` under tag 5
+(the #1888 arm) — the classification was the only missing piece.
+
+## Fix (consumer-side — the #2040 tag-5 payload-classifier pattern)
+
+`src/codegen/any-helpers.ts`:
+
+1. **`__any_add` stringiness classifier**: a tag-5 operand is stringy only if
+   its field-4 payload is NOT a `$BoxedNumber`/`$BoxedBoolean` carrier
+   (`ref.test` on the payload; scratch anyref local). Tag-6 unchanged. Gated
+   ONLY on `nativeBoxNumberTypeIdx >= 0` (the #2040 lesson — never gate on
+   nativeStrings); legacy bytes reproduced exactly when the carrier type is
+   absent. Fresh `Instr` arrays per arm (no aliasing — the in-place
+   index-shift double-remap hazard).
+2. **`__any_to_f64` tag-5 `$BoxedBoolean` recovery**, symmetric with the
+   existing `$BoxedNumber` arm: ToNumber(true)=1 / ToNumber(false)=0
+   (§7.1.4) instead of reading the box's always-0 f64 field.
+
+Explicitly NOT touched (the known traps):
+
+- The boxing site (`boxToAny` externref → tag-5) — producer-side re-tagging is
+  the −788/−794 regression.
+- `__any_eq` / `__any_strict_eq` — the tag-5 boxed-value equality classifier
+  was ejected at −162 (dstr/generator interaction) and is deferred to the
+  value-rep substrate (#2580 M2). `f(1) === f(1)` is still false today
+  (pre-existing, see residuals).
+
+## Verification (all on this branch, standalone lane)
+
+- Repro family flips: `f(1)+f(2)` 0→23, `f(1,2,3)` NaN→6, cross-statement
+  0→23, `x+x` 0→22, chain 0→36, `(f(1)+f(2))-f(3)` −13→10,
+  `h(true)+h(true)` 0→2, `f(1)+h(false)` 0→11, `f(0.5)+f(0.25)` 0→20.75.
+- Concat arm preserved: `f(1)+"a"` length 3, `"a"+f(1)` length 3,
+  `h(true)+"x"` length 5 (boxed-payload ToString recovery pre-existing).
+- Controls unchanged: typed-param closure, single call, relational
+  (`f(1)<f(2)`), `-`/`*` on dispatched values, plain `any` locals,
+  undefined-result + 1 stays NaN.
+- **Byte-inertness** (sha256 A/B vs pristine main): host lane on the exact
+  repro shape, typed host, typed standalone, plain-any add (both lanes),
+  string program standalone — **all byte-identical** (`__any_add` with the
+  carrier types present is only built/reached on the affected standalone
+  shapes).
+- Related suites green: issue-1888 (×3 files), issue-2040-tag5-field4-eq,
+  issue-2058-any-plus-string, issue-2059-any-relational,
+  issue-1917-any-param-toprimitive, issue-2106-any-array-element-tag —
+  73 passed; the 2 issue-2081 failures are **identical on pristine main**
+  (pre-existing, `#2043` late-import class per the 1888 notes).
+- New suite: `tests/issue-2966.test.ts` (16 cases, host-free asserted).
+
+## Residuals (documented, NOT this fix — same substrate family)
+
+- `typeof x` on a dispatched result returns garbage (tag-5 box → not
+  "number"). Same overloaded-tag-5 disease, different consumer.
+- `.length` on an any-typed concat RESULT reads 0 (`const s = g("ab") + g("cd");
+s.length` → 0, pre-existing on main) — the $AnyValue dynamic-read gap.
+- `f(1) === f(1)` false — the deferred #2580 M2 eq classifier (deliberate).
+- `undefined + 1` stringifies to "[object Object]"-ish instead of NaN in the
+  concat arm when undefined crosses the boundary as a null externref
+  (pre-existing; NaN-ness preserved in the numeric context probe).
+
+After this lands, #2924 can re-test its standalone gate
+(`tryCompileConstantFunctionCtor`'s `ctx.standalone || ctx.wasi` early return)
+— the all-externref-param synthesized function should now compute correctly
+through `+`.

--- a/src/codegen/any-helpers.ts
+++ b/src/codegen/any-helpers.ts
@@ -1077,10 +1077,37 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
                             { op: "ref.cast", typeIdx: ctx.nativeBoxNumberTypeIdx },
                             { op: "struct.get", typeIdx: ctx.nativeBoxNumberTypeIdx, fieldIdx: 0 },
                           ],
-                          else: [
-                            { op: "local.get", index: 0 },
-                            { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 2 },
-                          ],
+                          else:
+                            // (#2966) $BoxedBoolean recovery, symmetric with the
+                            // $BoxedNumber arm above: a boolean crossing the
+                            // open-any boundary is a tag-5 box whose externval is
+                            // the native `$BoxedBoolean` carrier. §7.1.4
+                            // ToNumber(true)=1 / ToNumber(false)=0 — reading the
+                            // box's f64val (always 0) made every dispatched
+                            // boolean numerically 0. Same gate style as #1888.
+                            ctx.nativeBoxBooleanTypeIdx >= 0
+                              ? ([
+                                  { op: "local.get", index: 2 },
+                                  { op: "ref.test", typeIdx: ctx.nativeBoxBooleanTypeIdx },
+                                  {
+                                    op: "if",
+                                    blockType: { kind: "val", type: { kind: "f64" } },
+                                    then: [
+                                      { op: "local.get", index: 2 },
+                                      { op: "ref.cast", typeIdx: ctx.nativeBoxBooleanTypeIdx },
+                                      { op: "struct.get", typeIdx: ctx.nativeBoxBooleanTypeIdx, fieldIdx: 0 },
+                                      { op: "f64.convert_i32_s" },
+                                    ],
+                                    else: [
+                                      { op: "local.get", index: 0 },
+                                      { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 2 },
+                                    ],
+                                  },
+                                ] as Instr[])
+                              : ([
+                                  { op: "local.get", index: 0 },
+                                  { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 2 },
+                                ] as Instr[]),
                         },
                       ],
                       else: [
@@ -1273,6 +1300,77 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
       // numeric arm so the two arms don't alias. Use a fresh numeric copy.
       buildNumericArm();
 
+  // (#2966) Effective stringiness of one operand for the §13.15.3 `+` dispatch.
+  //
+  // The tag-5 field-4 externval is OVERLOADED (see the #2040 classifier note
+  // above): the generic externref→AnyValue boxing (`value-tags.ts` boxToAny)
+  // wraps EVERY externref as a tag-5 "string" box — including the native
+  // `$BoxedNumber`/`$BoxedBoolean` carriers a value picks up crossing the
+  // open-any closure-call boundary (`f(1) + f(2)` where `f: any`). Treating
+  // those as strings sent two dispatched NUMBERS down the concat arm, whose
+  // tag-5 result reads back as 0 in an f64 context — silent wrong values
+  // (issue #2966; `f(1)+f(2)` → 0, `f(1,2,3)` → NaN).
+  //
+  // §13.15.3 ApplyStringOrNumericBinaryOperator: ToPrimitive of a number /
+  // boolean is NOT a string, so those operands must take the NUMERIC arm —
+  // whose `__any_to_f64` already recovers the honest value from a tag-5
+  // `$BoxedNumber` (#1888 arm; the `$BoxedBoolean` recovery is added in the
+  // same-numbered change below). Genuine strings and objects keep the concat
+  // arm unchanged, and the mixed case (boxed number + real string) already
+  // stringifies correctly via `__any_to_string`'s boxed-extern recovery.
+  //
+  // Gated ONLY on `nativeBoxNumberTypeIdx >= 0` (the #2040 lesson — never gate
+  // on nativeStrings); when unavailable this reproduces the legacy
+  // `tag==5 || tag==6` bytes exactly. Consumer-side only: the boxing site is
+  // deliberately untouched (producer-side re-tagging was the −788/−794 trap).
+  // Uses scratch anyref local 4; emits fresh Instr arrays per call (never
+  // alias `if` arms — the in-place index-shift double-remap hazard).
+  const stringyOperand = (opIdx: number, tagLocal: number): Instr[] => {
+    const tag6Test = (): Instr[] => [
+      { op: "local.get", index: tagLocal } as Instr,
+      { op: "i32.const", value: 6 } as Instr,
+      { op: "i32.eq" } as Instr,
+    ];
+    if (ctx.nativeBoxNumberTypeIdx < 0) {
+      // Legacy shape: tag==5 || tag==6 (byte-identical when no boxed-number
+      // carrier type exists, e.g. host/fast mode builds of this helper).
+      return [
+        { op: "local.get", index: tagLocal } as Instr,
+        { op: "i32.const", value: 5 } as Instr,
+        { op: "i32.eq" } as Instr,
+        ...tag6Test(),
+        { op: "i32.or" } as Instr,
+      ];
+    }
+    // tag==5 → stringy iff field-4 is NOT a boxed number/boolean carrier.
+    const notBoxedPrimitive: Instr[] = [
+      { op: "local.get", index: opIdx } as Instr,
+      { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 4 } as Instr,
+      { op: "any.convert_extern" } as Instr,
+      { op: "local.tee", index: 4 } as Instr,
+      { op: "ref.test", typeIdx: ctx.nativeBoxNumberTypeIdx } as Instr,
+      ...(ctx.nativeBoxBooleanTypeIdx >= 0
+        ? ([
+            { op: "local.get", index: 4 },
+            { op: "ref.test", typeIdx: ctx.nativeBoxBooleanTypeIdx },
+            { op: "i32.or" },
+          ] as Instr[])
+        : []),
+      { op: "i32.eqz" } as Instr,
+    ];
+    return [
+      { op: "local.get", index: tagLocal } as Instr,
+      { op: "i32.const", value: 5 } as Instr,
+      { op: "i32.eq" } as Instr,
+      {
+        op: "if",
+        blockType: { kind: "val", type: { kind: "i32" } },
+        then: notBoxedPrimitive,
+        else: tag6Test(),
+      } as Instr,
+    ];
+  };
+
   addHelper(
     "__any_add",
     [anyRefNull, anyRefNull],
@@ -1286,21 +1384,11 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
       { op: "local.get", index: 1 },
       { op: "struct.get", typeIdx: anyTypeIdx, fieldIdx: 0 },
       { op: "local.set", index: 3 },
-      // stringy = (tagA==5 || tagA==6 || tagB==5 || tagB==6)
-      { op: "local.get", index: 2 },
-      { op: "i32.const", value: 5 },
-      { op: "i32.eq" },
-      { op: "local.get", index: 2 },
-      { op: "i32.const", value: 6 },
-      { op: "i32.eq" },
-      { op: "i32.or" },
-      { op: "local.get", index: 3 },
-      { op: "i32.const", value: 5 },
-      { op: "i32.eq" },
-      { op: "i32.or" },
-      { op: "local.get", index: 3 },
-      { op: "i32.const", value: 6 },
-      { op: "i32.eq" },
+      // stringy = stringyOperand(a) || stringyOperand(b) — tag 6, or tag 5
+      // whose payload is a genuine string/object (NOT a boxed number/boolean
+      // carrier crossing the open-any boundary — those are numeric, #2966).
+      ...stringyOperand(0, 2),
+      ...stringyOperand(1, 3),
       { op: "i32.or" },
       {
         op: "if",
@@ -1318,6 +1406,7 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
     [
       { name: "tagA", type: { kind: "i32" } },
       { name: "tagB", type: { kind: "i32" } },
+      { name: "recoverAdd", type: { kind: "anyref" } },
     ],
   );
 

--- a/tests/issue-2966.test.ts
+++ b/tests/issue-2966.test.ts
@@ -1,0 +1,132 @@
+// #2966 — standalone any-param closure results are tag-5 boxes whose field-4
+// payload is a native $BoxedNumber/$BoxedBoolean carrier (the deliberate #1888
+// "box-the-externref" contract). `__any_add` classified EVERY tag-5 operand as
+// stringy (§13.15.3 concat arm), so `f(1) + f(2)` on two dispatched numbers
+// concatenated their recovered strings into a tag-5 result whose f64 field
+// reads 0 — SILENT WRONG VALUES (`f(1)+f(2)` → 0, `f(1,2,3)` → NaN).
+//
+// Fix (consumer-side, the #2040 classifier pattern): the stringiness test in
+// `__any_add` inspects the tag-5 payload — a $BoxedNumber/$BoxedBoolean carrier
+// is NOT a string and takes the numeric arm, whose `__any_to_f64` recovers the
+// honest value (#1888 arm + the symmetric $BoxedBoolean recovery added here).
+// Genuine strings/objects keep the concat arm byte-for-byte; host/gc lane and
+// typed programs are byte-inert (verified via sha256 A/B in the issue file).
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("; ")).toBe(true);
+  if (!r.success) return undefined;
+  // Host-free: the repro family must not lean on env imports.
+  const envImports = r.imports.filter((i) => i.module === "env");
+  expect(envImports, `unexpected env imports: ${envImports.map((i) => i.name).join(",")}`).toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test?: () => unknown }).test?.();
+}
+
+const wrap = (body: string): string => `export function test(): number {
+  const f: any = function (a: any) { return a + 10; };
+  ${body}
+}`;
+
+describe("#2966 standalone any-param closure call results through `+`", () => {
+  it("two calls in one expression: f(1) + f(2) === 23", async () => {
+    expect(await runStandalone(wrap(`return f(1) + f(2);`))).toBe(23);
+  });
+
+  it("three any params: f(1, 2, 3) === 6 (a + b + c)", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const f: any = function (a: any, b: any, c: any) { return a + b + c; };
+        return f(1, 2, 3);
+      }`),
+    ).toBe(6);
+  });
+
+  it("cross-statement reuse: x = f(1); y = f(2); x + y === 23", async () => {
+    expect(await runStandalone(wrap(`const x = f(1); const y = f(2); return x + y;`))).toBe(23);
+  });
+
+  it("call chain: f(1) + f(2) + f(3) === 36", async () => {
+    expect(await runStandalone(wrap(`return f(1) + f(2) + f(3);`))).toBe(36);
+  });
+
+  it("self add: x + x === 22", async () => {
+    expect(await runStandalone(wrap(`const x = f(1); return x + x;`))).toBe(22);
+  });
+
+  it("fractional values cross the boundary: f(0.5) + f(0.25) === 20.75", async () => {
+    expect(await runStandalone(wrap(`return f(0.5) + f(0.25);`))).toBe(20.75);
+  });
+
+  it("add feeding sub: (f(1) + f(2)) - f(3) === 10", async () => {
+    expect(await runStandalone(wrap(`return (f(1) + f(2)) - f(3);`))).toBe(10);
+  });
+
+  it("booleans through the boundary: h(true) + h(true) === 2 (§7.1.4 ToNumber)", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const h: any = function (v: any) { return v; };
+        return h(true) + h(true);
+      }`),
+    ).toBe(2);
+  });
+
+  it("number + false === number", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const f: any = function (a: any) { return a + 10; };
+        const h: any = function (v: any) { return v; };
+        return f(1) + h(false);
+      }`),
+    ).toBe(11);
+  });
+
+  // ── concat arm must be preserved (§13.15.3 step 2) ──
+
+  it("boxed number + string literal still concatenates", async () => {
+    expect(await runStandalone(wrap(`const s = f(1) + "a"; return s.length;`))).toBe(3);
+  });
+
+  it("string literal + boxed number still concatenates", async () => {
+    expect(await runStandalone(wrap(`const s = "a" + f(1); return s.length;`))).toBe(3);
+  });
+
+  it("boxed boolean + string literal concatenates via ToString", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const h: any = function (v: any) { return v; };
+        const s = h(true) + "x"; return s.length;
+      }`),
+    ).toBe(5);
+  });
+
+  // ── controls that must stay correct ──
+
+  it("typed-param closure control", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const f: any = function (a: number) { return a + 10; };
+        return f(1) + f(2);
+      }`),
+    ).toBe(23);
+  });
+
+  it("single call control", async () => {
+    expect(await runStandalone(wrap(`return f(1);`))).toBe(11);
+  });
+
+  it("relational on dispatched numbers (pre-existing to_f64 recovery)", async () => {
+    expect(await runStandalone(wrap(`return f(1) < f(2) ? 1 : 0;`))).toBe(1);
+  });
+
+  it("undefined result + 1 stays NaN-like (legacy path untouched)", async () => {
+    expect(
+      await runStandalone(`export function test(): number {
+        const u: any = function () { return undefined; };
+        const r = u() + 1; return r === r ? 1 : 0;
+      }`),
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

On the **standalone** lane, values returned by an `any`-typed closure are silently WRONG through `+`:

```ts
const f: any = function (a: any) { return a + 10; };
f(1) + f(2)   // standalone: 0    (JS/host: 23)
f(1, 2, 3)    // standalone: NaN  (JS/host: 6, with (a,b,c) => a+b+c)
```

Worst defect class: silent wrong values, no trap. Blocks #2924's standalone enablement.

## Root cause — NOT call marshalling

Re-id of the orphaned #2945 analysis (id since taken on main). Narrowing probes show every **call** returns the correct value (`x-y`, `x*y`, `x+1`, single/second calls all correct) — only **any+any `+`** is wrong:

1. Closure-call results cross the open-any boundary as tag-5 boxes whose field-4 payload is a native `$BoxedNumber` carrier (the deliberate #1888 box-the-externref contract, −788/−794 protected).
2. `__any_add` classified **every** tag-5 operand as stringy → §13.15.3 concat arm → tag-5 string result whose f64 field reads back **0**.

## Fix (consumer-side, the #2040 tag-5 payload-classifier pattern)

`src/codegen/any-helpers.ts` only:

- `__any_add` stringiness now inspects the tag-5 payload: `$BoxedNumber`/`$BoxedBoolean` carriers are numeric (their honest values already recovered by `__any_to_f64`'s #1888 arm); genuine strings/objects keep the concat arm. Gated only on `nativeBoxNumberTypeIdx >= 0`; legacy bytes reproduced when absent.
- `__any_to_f64` gains the symmetric tag-5 `$BoxedBoolean` recovery (§7.1.4 ToNumber(true)=1).

Deliberately NOT touched: the boxing site (producer re-tag = the −788/−794 trap) and the eq helpers (−162 dstr ejection, deferred to #2580 M2).

## Verification

- Repro family flips to correct: two-calls-one-expression, cross-statement reuse, chains, `x+x`, bool+bool, mixed bool/number, fractions, add-feeding-sub/mul.
- Concat preserved: boxed number/boolean + string literal shapes.
- **Byte-inert** (sha256 A/B vs pristine main): host lane on the repro shape, typed host/standalone, plain-any adds, string program — all identical.
- Suites green: issue-1888×3, 2040-tag5, 2058, 2059, 1917, 2106 (73 passed; the 2 issue-2081 fails are identical on pristine main). New `tests/issue-2966.test.ts` (16 cases, host-free asserted).
- Gates: tsc, prettier, biome lint, check:any-box-sites, check:coercion-sites, check:stack-balance all clean.

Issue file: `plan/issues/2966-standalone-anyparam-closure-add-tag5-misclassify.md` (status: done rides this PR; residuals documented: typeof-on-dispatched-result, .length-on-any-concat-result, deferred eq).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8