### PR TITLE
feat(#2138): gate 4 — host-node skip exclusion for the IR-first skip set (Trap 4, #2856 sequencing)

### DIFF
--- a/plan/issues/2138-ir-first-compile-once-inversion.md
+++ b/plan/issues/2138-ir-first-compile-once-inversion.md
@@ -26,7 +26,7 @@ origin: "2026-06-12 sprint-62 architecture analysis (pipeline workstream N2)"
 
 Legacy compiles ALL bodies (`src/codegen/index.ts:1174`), then the IR
 overlay re-compiles claimed ones and overwrites (`:1308`). Wasted compile
-time — and the always-available legacy body is *the mechanism* that makes
+time — and the always-available legacy body is _the mechanism_ that makes
 silent fallback possible (#1530's root enabler). "Phase out the fallback"
 has no destination until the pipeline can skip legacy for claimed
 functions.
@@ -61,8 +61,8 @@ STRICT_IR_REASONS ratchet feeds into.
 ### Root cause (confirmed against current main)
 
 The legacy front-end compiles **every** top-level function body, then the IR
-overlay re-compiles the claimed ones and *overwrites the just-emitted legacy
-body*. The overwrite is literal:
+overlay re-compiles the claimed ones and _overwrites the just-emitted legacy
+body_. The overwrite is literal:
 
 - `generateModule` (`src/codegen/index.ts:1032`) runs the third pass
   `compileDeclarations(ctx, ast.sourceFile)` (`:1333`) — this emits a full
@@ -76,7 +76,7 @@ body*. The overwrite is literal:
 
 So every IR-claimed function is compiled twice by design: once by legacy
 (thrown away), once by IR (kept). That wasted legacy compile is also the
-*mechanism* that makes silent fallback free (#1530's root enabler) — because a
+_mechanism_ that makes silent fallback free (#1530's root enabler) — because a
 working legacy body always exists, an IR throw can be demoted to a warning with
 no destination cost. "Phase out the fallback" has no endgame until the pipeline
 can **skip legacy for fully-claimed functions**.
@@ -96,7 +96,7 @@ inversion is **plan-IR-first → compile only the un-claimed via legacy → comp
 the claimed via IR once**. Concretely, behind `JS2WASM_IR_FIRST=1`:
 
 1. Run `planIrCompilation` (+ the `overrideMap`/`safeSelection` resolution that
-   currently sits *after* `compileDeclarations`) **before** the body pass.
+   currently sits _after_ `compileDeclarations`) **before** the body pass.
 2. Compute the **fully-claimed closure**: a function is skippable by legacy iff
    it AND its whole call-graph closure are in `safeSelection.funcs` (the
    selector already closes the claim set under local call edges — see
@@ -129,7 +129,7 @@ so the `ctx.mod.functions[localIdx] = {…}` patch site needs **no** change.
 would renumber every downstream funcIdx and desync `call $idx` ops, the
 late-import shifter, and `declaredFuncRefs` — the exact index-fragility class
 #1916 exists to kill. Keep the slot, swap the body. This keeps the inversion a
-*body-emission* change, never an *index-layout* change. Verify with the
+_body-emission_ change, never an _index-layout_ change. Verify with the
 byte-identical gate (flag-off) and an index-stability assertion (flag-on, see
 tests).
 
@@ -140,12 +140,12 @@ Each slice is a separate PR, green on its own, ordered by risk.
 #### Slice 1 — hoist IR planning above `compileDeclarations` (refactor, no behavior change)
 
 - **Scope:** move the `planIrCompilation` + `buildTypeMap` + `buildIrClassShapes`
-  + `overrideMap`/`safeSelection` construction block (`index.ts:1355-1493`) so it
-  runs **before** `compileDeclarations(ctx, ast.sourceFile)` (`:1333`). The
-  actual `compileIrPathFunctions` call (`:1494`) stays AFTER `compileDeclarations`
-  (it still needs the final funcIdx/typeIdx that `compileDeclarations` assigns).
-  Net effect: the *plan* (which functions are claimed) is known before the body
-  pass; the *overlay* still runs after. No legacy skipping yet.
+  - `overrideMap`/`safeSelection` construction block (`index.ts:1355-1493`) so it
+    runs **before** `compileDeclarations(ctx, ast.sourceFile)` (`:1333`). The
+    actual `compileIrPathFunctions` call (`:1494`) stays AFTER `compileDeclarations`
+    (it still needs the final funcIdx/typeIdx that `compileDeclarations` assigns).
+    Net effect: the _plan_ (which functions are claimed) is known before the body
+    pass; the _overlay_ still runs after. No legacy skipping yet.
 - **Files:** `src/codegen/index.ts` only.
 - **Risk:** LOW. Pure reordering of a side-effect-light planning block. The one
   hazard: `buildIrClassShapes(ctx, …)` reads `ctx.classSet`/`ctx.structFields`/
@@ -189,8 +189,8 @@ Each slice is a separate PR, green on its own, ordered by risk.
      to warning). If legacy already skipped its body, that fallback now lands on
      an `unreachable` placeholder — a hard runtime trap, not a graceful demote.
      **Resolution:** only mark a function `skippable` after it survived
-     overrideMap resolution (`overrideMap.has(name)`). Because IR-*build*
-     failures are only known *after* `compileIrPathFunctions` runs (which is
+     overrideMap resolution (`overrideMap.has(name)`). Because IR-_build_
+     failures are only known _after_ `compileIrPathFunctions` runs (which is
      after `compileDeclarations`), gate the skip conservatively: under
      `JS2WASM_IR_FIRST`, if `compileIrPathFunctions`'s `report.errors` names a
      skipped function, that is now a **hard error** (the placeholder is live).
@@ -250,18 +250,18 @@ the technical prerequisite for everything below and it left the
 
 - **#2138 (this issue) enables / unblocks:**
   - **#2135 (single IR capability predicate)** — the inversion makes the
-    selector's claim decision *load-bearing for correctness* (a wrong claim now
+    selector's claim decision _load-bearing for correctness_ (a wrong claim now
     traps a skipped function instead of silently demoting). That sharply raises
     the value of unifying `select.ts`'s `isPhase1Expr` with `from-ast.ts`'s
     throw sites so selector and builder cannot disagree. #2138's flag-on traps
     are exactly the `select`↔`from-ast` drift #2135 fixes. **Sequence #2135
     right after #2138 Slice 2** — they are mutually reinforcing; #2138's
     measurement (Slice 3) feeds #2135's acceptance metric.
-  - **#1916 (symbolic function references)** — independent in *files*
+  - **#1916 (symbolic function references)** — independent in _files_
     (`emit/binary.ts`, `late-imports.ts`) but the inversion's placeholder-slot
     discipline depends on funcIdx layout staying stable; #1916's FuncHandle
     indirection makes that stability structural rather than convention. #1916
-    can land before OR after #2138; doing #1916 first *reduces* #2138's
+    can land before OR after #2138; doing #1916 first _reduces_ #2138's
     index-fragility risk. No file conflict (different files).
 - **#2138 needs (soft):** nothing hard-blocking beyond #1927 (landed). It reads
   `planIrCompilation`/`safeSelection` (`select.ts`) and the overlay
@@ -279,14 +279,14 @@ the technical prerequisite for everything below and it left the
 - **Flag OFF must be byte-identical.** The hoist (Slice 1) and the skip logic
   (Slice 2) both gate on `JS2WASM_IR_FIRST`; with it unset, not one emitted byte
   changes. This is acceptance criterion 1 and the only unconditional guarantee.
-- **funcIdx layout invariant.** Slot pre-allocation happens for *every*
+- **funcIdx layout invariant.** Slot pre-allocation happens for _every_
   function regardless of skip; only the body differs. Never remove or reorder a
   slot. An index-stability test (compile the same source flag-on vs flag-off and
   assert `ctx.mod.functions.map(f => f.name)` is identical) guards this.
 - **`new.target` clears `safeSelection`** — compute `skippable` strictly after
   that clear (Slice 2 trap 1).
 - **Post-claim fallback on a skipped function** traps under the flag — this is
-  intended *investigation* behavior (surface divergences), not a silent demote;
+  intended _investigation_ behavior (surface divergences), not a silent demote;
   fail loud and file it (Slice 2 trap 2).
 - **Class members** go through the `classMember` parity guard
   (`integration.ts:704`) and a separate slot pre-allocation in `class-bodies.ts`
@@ -330,11 +330,11 @@ the full `merge_group` run, not a scoped sweep.
 ### Status / blocker note (2026-06-23, architect)
 
 This issue's frontmatter blocker is **#2167 (Fable model disabled)**, NOT
-#1927. #1927 (the *technical* prerequisite) has now **landed** (PR #1958), so
+#1927. #1927 (the _technical_ prerequisite) has now **landed** (PR #1958), so
 the technical path is clear and this spec is dev-ready. But #2167 is still
 `in-progress` (Fable unavailable) and gated this issue on `reasoning_effort:
 max`. Per #2167's own resolution policy, this issue stays parked on the Fable
-gate for *implementation dispatch*; the spec is written now so it is
+gate for _implementation dispatch_; the spec is written now so it is
 ready-to-dispatch the moment #2167 closes. The frontmatter therefore keeps
 `status: blocked` / `blocked_by: [2167]` but records `pipeline_unblocked: 1927`
 to mark that the technical prerequisite is satisfied.
@@ -363,7 +363,7 @@ Behind `JS2WASM_IR_FIRST=1` (default OFF, requires the default-on
 - `IrSelection.localCallees` (`src/ir/select.ts`, additive) — the Step-2
   call-graph callee edges, exposed so the skip-set derivation reuses the
   selector's own edges instead of re-deriving them.
-- Fail-loud contract: a post-claim IR failure on a *skipped* function is
+- Fail-loud contract: a post-claim IR failure on a _skipped_ function is
   promoted from the warning demote to a **hard compile error**
   (`[IR-FIRST skipped-slot, #2138]`), plus a backstop that errors when a
   skipped function is neither in `report.compiled` nor `report.errors`.
@@ -383,11 +383,11 @@ Behind `JS2WASM_IR_FIRST=1` (default OFF, requires the default-on
    - `buildIrClassShapes` reads `ctx.structFields`, which body compilation
      mutates (dynamic field additions, #516) — a hoisted read sees
      pre-body-compile shapes.
-   Making the ORDER conditional on the flag turns acceptance criterion 1
-   (byte-identical without the flag) into a property that holds by
-   construction. Slices 1+2 therefore landed as ONE PR: with no
-   unconditional reorder there is no standalone "low-risk hoist" left to
-   de-risk separately.
+     Making the ORDER conditional on the flag turns acceptance criterion 1
+     (byte-identical without the flag) into a property that holds by
+     construction. Slices 1+2 therefore landed as ONE PR: with no
+     unconditional reorder there is no standalone "low-risk hoist" left to
+     de-risk separately.
 2. **Skip-set closure check is DIRECT-callee, not transitive.** The
    selector's Step-2 closure is already bidirectional (callers AND callees),
    so `selection.funcs` is closed; the only re-opening is overrideMap
@@ -450,8 +450,61 @@ below).
   function. Record a real number in Slice 3 (idle box / CI).
 - **Divergences**: one, filed — #2945 (`%` selector↔builder drift).
 - **What the FULL run needs (Slice 3)**: `JS2WASM_IR_FIRST=1 pnpm run
-  test:262` on an idle box or CI, diffed against the current baseline JSONL
+test:262` on an idle box or CI, diffed against the current baseline JSONL
   (`scripts/fetch-baseline-jsonl.mjs`) via `/analyze-regression`; compile
   time from the runner's per-run timing in `runs/index.json`. Every
   flag-ON-only failure is by construction a loud selector↔builder/skip
   divergence — bucket by error class, file per class.
+
+## Implementation Notes (sr-irfirst, 2026-07-02 — Trap 4 / gate 4)
+
+**Branch:** `issue-2138-trap4-host-node-skip` (based on upstream/main @
+c4ff5a241). Adds the host-node skip exclusion the #2856 extern-in-IR spec
+requires ("#2138's skippable-closure computation must exclude any function
+whose claim depends on a host node until the lowering is proven" —
+lead-confirmed plan, mirrored here per the spec's cross-ref request):
+
+- `src/codegen/ir-first-gate.ts` (NEW) — `irFirstBodyReadsHostNode` +
+  `collectModuleTopLevelNames`, pure checker-free AST scan. Own module so
+  tests import it without the codegen-entry init cycle (importing
+  `codegen/index.js` directly from a test hits a `boolToStringEmitter`
+  before-initialization ReferenceError via string-ops/regexp-standalone).
+- `src/codegen/index.ts` — `computeIrFirstSkipSet(plan, sourceFile)` gains
+  gate 4 (`irFirstBodyReadsHostNode` exclusion) + doc; call site passes
+  `ast.sourceFile`.
+- `tests/issue-2138.test.ts` — gate-4 unit tests (host property/method/
+  element/bare-call positives; Math-whitelist / local / module-binding /
+  extern-`new`-chain / nested-scope negatives) + one integration guard
+  (FIB skip set unchanged — no over-exclusion collateral).
+
+**Calibration rationale (do not tighten):** the scan allowlists exactly
+today's selector ambient accepts — root `Math` (#1371 whitelist) and opaque
+`NewExpression` roots (slice-10 extern classes) — so it cannot depress the
+#2949 skip rate. It is latent today (selector rejects host receivers
+wholesale); it becomes load-bearing when #2856's HostMemberGet/HostMethodCall
+arm lands.
+
+**Validation (this branch):** `tsc --noEmit` clean; `tests/issue-2138.test.ts`
+14/14 green (6 landed + 8 gate-4); `check:ir-fallbacks` zero delta (the
+checker runs flag-off, where gate 4 is unreachable — flag-off behavior is
+untouched by construction since `computeIrFirstSkipSet` only runs under
+`JS2WASM_IR_FIRST=1`).
+
+**Also in this PR:** `scripts/byte-diff-corpus.mts` — the reusable
+byte-identity harness (compiles a fixed corpus — example files default+wasi
+plus a stride-N test262 sample — with two compiler checkouts and SHA-diffs
+every binary; usage header in the file). Used to prove the superseded
+unconditional hoist byte-identical (2,692 compiles, 0 diff) and intended for
+Slice 3 / future IR-first ratchet validation.
+
+**Slice 3 plan (after this lands):** flag-on `pnpm run test:262` vs flag-off
+baseline via `/analyze-regression` + compile-time delta from
+`runs/index.json`, AND (lead request) the **IR claim-rate stat**: % of
+top-level functions skipped under the flag at test262 scale — sum
+`CompileResult.irFirstSkipped` over the run vs total top-level
+FunctionDeclarations; this is the #2949 north-star number, record
+before/after pairs. Run AFTER Trap-4 lands so measurements are clean.
+
+**Superseded branch:** `issue-2138-ir-first-slice1` (origin) — my
+unconditional-hoist Slice 1, superseded by the landed flag-conditional
+implementation (6ac915824). Safe to delete; its issue-file docs were ported.

--- a/scripts/byte-diff-corpus.mts
+++ b/scripts/byte-diff-corpus.mts
@@ -1,0 +1,81 @@
+// #2138 Slice 1 acceptance probe — byte-identity corpus diff.
+// Usage: npx tsx .tmp/byte-diff-2138.mts <compilerRoot> <outFile>
+// Compiles a fixed corpus (example files + deterministic test262 sample) with
+// the compiler at <compilerRoot> and writes JSONL of {file, mode, status, sha,
+// errs} for diffing between baseline (upstream/main) and the #2138 branch.
+import { readFileSync, readdirSync, lstatSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+import { pathToFileURL } from "node:url";
+
+const compilerRoot = process.argv[2]!;
+const outFile = process.argv[3]!;
+const { compile } = await import(pathToFileURL(join(compilerRoot, "src/index.ts")).href);
+
+// Inputs always come from the SAME fixed locations so both sides compile
+// identical sources.
+const INPUT_ROOT = "/workspace";
+const STRIDE = Number(process.env.STRIDE ?? 20);
+
+function walk(root: string, ext: string): string[] {
+  const out: string[] = [];
+  const stack = [root];
+  while (stack.length) {
+    const dir = stack.pop()!;
+    let names: string[];
+    try {
+      names = readdirSync(dir);
+    } catch {
+      continue;
+    }
+    for (const name of names) {
+      const p = join(dir, name);
+      const s = lstatSync(p);
+      if (s.isSymbolicLink()) continue;
+      if (s.isDirectory()) stack.push(p);
+      else if (name.endsWith(ext) && !name.endsWith(".d.ts") && !name.includes("_FIXTURE")) out.push(p);
+    }
+  }
+  return out.sort();
+}
+
+const examples = [
+  ...walk(join(INPUT_ROOT, "website/playground/examples"), ".ts"),
+  ...walk(join(INPUT_ROOT, "examples"), ".ts"),
+];
+const t262all = walk(join(INPUT_ROOT, "test262/test"), ".js");
+const t262 = t262all.filter((_, i) => i % STRIDE === 0);
+
+const lines: string[] = [];
+let n = 0;
+function record(file: string, mode: string, src: string, opts: Record<string, unknown>) {
+  let status: string;
+  let sha: string | null = null;
+  let errs = -1;
+  try {
+    const r = compile(src, { fileName: "test.ts", ...opts });
+    errs = r.errors?.length ?? 0;
+    if (r.success && r.binary) {
+      status = "ok";
+      sha = createHash("sha256").update(r.binary).digest("hex");
+    } else {
+      status = "ce:" + (r.errors?.[0]?.message ?? "").slice(0, 120);
+    }
+  } catch (e) {
+    status = "throw:" + String(e instanceof Error ? e.message : e).slice(0, 120);
+  }
+  lines.push(JSON.stringify({ file: file.replace(INPUT_ROOT, ""), mode, status, sha, errs }));
+  if (++n % 250 === 0) process.stderr.write(`  ${n} compiled\n`);
+}
+
+for (const f of examples) {
+  const src = readFileSync(f, "utf-8");
+  record(f, "default", src, {});
+  record(f, "wasi", src, { target: "wasi" });
+}
+for (const f of t262) {
+  const src = readFileSync(f, "utf-8");
+  record(f, "default", src, {});
+}
+writeFileSync(outFile, lines.join("\n") + "\n");
+process.stderr.write(`done: ${n} compiles → ${outFile}\n`);

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -26,6 +26,7 @@ import { irVal, type IrType } from "../ir/nodes.js";
 import { buildTypeMap, type LatticeType } from "../ir/propagate.js";
 import { planIrCompilation, type IrFallbackReason } from "../ir/select.js";
 import { createCodegenContext } from "./context/create-context.js";
+import { collectModuleTopLevelNames, irFirstBodyReadsHostNode } from "./ir-first-gate.js";
 import type { FallbackCounts } from "./fallback-telemetry.js";
 import { buildLeakedHostImportError, scanForLeakedHostImports } from "./host-import-allowlist.js";
 import { reportError, reportErrorNoNode } from "./context/errors.js";
@@ -1122,6 +1123,13 @@ interface IrOverlayPlan {
  *      sufficient: only the function's own IR success is load-bearing for
  *      its slot, and a callee that is claimed-but-not-skipped still occupies
  *      its pre-allocated slot with a working body either way.
+ *   4. Its body does not read a HOST node (property/element access or bare
+ *      call rooted at an identifier that is neither function-local nor a
+ *      module top-level binding) — see `irFirstBodyReadsHostNode` (#2138
+ *      Trap 4 / #2856 sequencing). A no-op today (the selector still rejects
+ *      host-global receivers), load-bearing the moment #2856's extern-in-IR
+ *      selector arm lands: host-node functions stay compile-twice until that
+ *      lowering is proven, keeping the flag-on measurement clean.
  *
  * Class members are NEVER skipped in this slice (their slot pre-allocation
  * lives in `class-bodies.ts` and carries a typeIdx parity contract with
@@ -1136,14 +1144,19 @@ interface IrOverlayPlan {
  * placeholder must never ship) — surfacing exactly the selector↔builder
  * divergences this investigation exists to find (#2135).
  */
-function computeIrFirstSkipSet(plan: IrOverlayPlan): ReadonlySet<string> {
+function computeIrFirstSkipSet(plan: IrOverlayPlan, sourceFile: ts.SourceFile): ReadonlySet<string> {
   const skip = new Set<string>();
   const funcs = plan.safeSelection.funcs;
   if (funcs.size === 0) return skip;
   const edges = plan.selection.localCallees;
+  // Gate 4 (#2138 Trap 4, coordinated with the extern-in-IR plan in #2856):
+  // module-level user bindings, computed once — receivers/callees rooted at
+  // these are user code, never host globals.
+  const moduleNames = collectModuleTopLevelNames(sourceFile);
   for (const name of funcs) {
     const fn = plan.declByName.get(name);
     if (!fn || fn.asteriskToken) continue; // gate 2 — generators
+    if (irFirstBodyReadsHostNode(fn, moduleNames)) continue; // gate 4 — host nodes
     if (!edges) continue; // no edge info (defensive) — stay conservative
     const callees = edges.get(name);
     let closed = true;
@@ -1677,7 +1690,7 @@ export function generateModule(
     let irSkipBodies: ReadonlySet<string> | undefined;
     if (irFirst) {
       irPlan = planIrOverlay(ctx, ast);
-      irSkipBodies = computeIrFirstSkipSet(irPlan);
+      irSkipBodies = computeIrFirstSkipSet(irPlan, ast.sourceFile);
     }
 
     // Third pass: compile function bodies

--- a/src/codegen/ir-first-gate.ts
+++ b/src/codegen/ir-first-gate.ts
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2138 (Trap 4) — gate-4 host-node scan for the IR-first skip set.
+//
+// Pure, checker-free AST helpers used by `computeIrFirstSkipSet` in
+// `src/codegen/index.ts` (and unit-tested directly — this lives in its own
+// module so tests can import it without pulling the whole codegen entry
+// module and its init-order-sensitive cycles).
+import ts from "typescript";
+
+/** Collect every top-level module binding name of a source file: function /
+ *  class / enum declarations, `var`/`let`/`const` statements (including
+ *  destructuring patterns), and import clause names. Used by the gate-4
+ *  host-node scan: a receiver rooted at one of these is user code. */
+export function collectModuleTopLevelNames(sourceFile: ts.SourceFile): ReadonlySet<string> {
+  const names = new Set<string>();
+  const bind = (n: ts.BindingName): void => {
+    if (ts.isIdentifier(n)) {
+      names.add(n.text);
+    } else {
+      for (const el of n.elements) {
+        if (ts.isBindingElement(el)) bind(el.name);
+      }
+    }
+  };
+  for (const stmt of sourceFile.statements) {
+    if ((ts.isFunctionDeclaration(stmt) || ts.isClassDeclaration(stmt) || ts.isEnumDeclaration(stmt)) && stmt.name) {
+      names.add(stmt.name.text);
+    } else if (ts.isVariableStatement(stmt)) {
+      for (const d of stmt.declarationList.declarations) bind(d.name);
+    } else if (ts.isImportDeclaration(stmt) && stmt.importClause) {
+      const ic = stmt.importClause;
+      if (ic.name) names.add(ic.name.text);
+      if (ic.namedBindings) {
+        if (ts.isNamespaceImport(ic.namedBindings)) names.add(ic.namedBindings.name.text);
+        else for (const spec of ic.namedBindings.elements) names.add(spec.name.text);
+      }
+    }
+  }
+  return names;
+}
+
+/**
+ * Gate 4 of `computeIrFirstSkipSet` (#2138 Trap 4 — coordination with the
+ * extern-in-IR plan, `plan/issues/2856-ir-body-shape-rejected-to-zero.md`,
+ * docs PR #2461): does this function's body read a HOST node — a property /
+ * element access (or bare call) whose root receiver/callee identifier is
+ * neither bound inside the function nor a module top-level binding?
+ *
+ * Why this exists BEFORE the #2856 selector arm lands: today the selector
+ * rejects host-global receivers wholesale (`scope.has("document") === false`,
+ * the #2454 recorder's host-global arm), so no claimed function contains one
+ * and this gate is a no-op. The moment #2856's `HostMemberGet`/`HostMethodCall`
+ * selector arm starts ACCEPTING them, any select↔from-ast drift on a skipped
+ * function would hard-fail the compile (the skipped-slot promotion in
+ * `generateModule`) — polluting the flag-on measurement (Slice 3) with a
+ * known-unimplemented feature instead of real divergences. Per the #2856
+ * spec's sequencing note ("#2138's skippable-closure computation must exclude
+ * any function whose claim depends on a host node until this slice proves the
+ * lowering" — the #2138 owner mirrors it here), host-node-reading functions
+ * stay on the compile-twice path until the extern-in-IR lowering is proven,
+ * at which point this gate is lifted deliberately (with a measurement re-run).
+ *
+ * Calibration — the scan must NOT be stricter than today's selector accepts,
+ * or it would falsely exclude proven lowerings and depress the #2949 skip
+ * rate. The selector's ONLY ambient-identifier accepts today are:
+ *   - `Math.<IR_MATH_UNARY_WHITELIST>(x)` — root receiver `Math` (#1371);
+ *     `Math` is therefore allowlisted here (non-whitelisted `Math.*` shapes
+ *     are unclaimable anyway, so a claimed body's `Math` use is proven).
+ *   - `new <KnownExternClass>(…)` (slice 10) — a NewExpression is treated as
+ *     an opaque, sanctioned root (its callee is selector-gated), so chains
+ *     like `new Uint8Array(4).length` are not flagged.
+ * Everything else out-of-scope in receiver/callee root position is a host
+ * node. Over-approximating LOCAL bindings (all names bound anywhere in the
+ * function, any depth) is safe: a use-before-declaration the selector would
+ * reject never reaches this gate (the function isn't claimed), and the
+ * selector rejects host-global shadowing (`vardecl-shadow`) outright.
+ */
+export function irFirstBodyReadsHostNode(fn: ts.FunctionDeclaration, moduleNames: ReadonlySet<string>): boolean {
+  if (!fn.body) return false;
+  // --- collect every name bound anywhere inside the function ---
+  const local = new Set<string>();
+  if (fn.name) local.add(fn.name.text);
+  const bind = (n: ts.BindingName): void => {
+    if (ts.isIdentifier(n)) {
+      local.add(n.text);
+    } else {
+      for (const el of n.elements) {
+        if (ts.isBindingElement(el)) bind(el.name);
+      }
+    }
+  };
+  const collect = (node: ts.Node): void => {
+    if (ts.isVariableDeclaration(node) || ts.isParameter(node)) bind(node.name);
+    else if (
+      (ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node) || ts.isFunctionExpression(node)) &&
+      node.name
+    ) {
+      local.add(node.name.text);
+    }
+    ts.forEachChild(node, collect);
+  };
+  for (const p of fn.parameters) bind(p.name);
+  collect(fn.body);
+  // --- walk the root of a receiver chain; NewExpression is an opaque,
+  //     sanctioned root (its callee is selector-gated: local or extern class) ---
+  const rootOf = (e: ts.Expression): ts.Expression => {
+    let cur = e;
+    for (;;) {
+      if (ts.isPropertyAccessExpression(cur) || ts.isElementAccessExpression(cur)) cur = cur.expression;
+      else if (ts.isParenthesizedExpression(cur) || ts.isNonNullExpression(cur) || ts.isAsExpression(cur))
+        cur = cur.expression;
+      else if (ts.isCallExpression(cur)) cur = cur.expression;
+      else return cur; // Identifier, NewExpression, this, literal, …
+    }
+  };
+  const isUserBound = (name: string): boolean => local.has(name) || moduleNames.has(name) || name === "Math";
+  let host = false;
+  const scan = (node: ts.Node): void => {
+    if (host) return;
+    if (ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)) {
+      const root = rootOf(node.expression);
+      if (ts.isIdentifier(root) && !isUserBound(root.text)) {
+        host = true;
+        return;
+      }
+    } else if (ts.isCallExpression(node)) {
+      // Bare out-of-scope callee (`parseInt(…)`-class future arms).
+      let callee: ts.Expression = node.expression;
+      while (ts.isParenthesizedExpression(callee)) callee = callee.expression;
+      if (ts.isIdentifier(callee) && !isUserBound(callee.text)) {
+        host = true;
+        return;
+      }
+    }
+    ts.forEachChild(node, scan);
+  };
+  scan(fn.body);
+  return host;
+}

--- a/tests/issue-2138.test.ts
+++ b/tests/issue-2138.test.ts
@@ -22,7 +22,9 @@
 //      legacy demote — the placeholder `unreachable` body must never ship.
 //      This loud-failure mode is the investigation's purpose: it surfaces
 //      selector↔builder capability drift (#2135).
+import ts from "typescript";
 import { describe, expect, it, vi } from "vitest";
+import { irFirstBodyReadsHostNode } from "../src/codegen/ir-first-gate.js";
 import { compile, type CompileResult } from "../src/index.js";
 import { buildImports } from "../src/runtime.js";
 
@@ -166,5 +168,100 @@ describe("#2138 IR-first compile-once inversion (JS2WASM_IR_FIRST)", () => {
     const b = await compileFlag(false, PARTIAL_SRC);
     expect(a.success).toBe(true);
     expect(Buffer.from(a.binary).equals(Buffer.from(b.binary))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Gate 4 (#2138 Trap 4 / #2856 sequencing) — host-node skip exclusion.
+//
+// `computeIrFirstSkipSet` must never skip the legacy body of a function whose
+// body reads a host node (property/element access or bare call rooted at an
+// identifier that is neither function-local nor a module top-level binding).
+// Today the selector rejects such bodies wholesale, so the gate is latent; it
+// becomes load-bearing the moment #2856's extern-in-IR selector arm starts
+// ACCEPTING host-global receivers (`document.body`,
+// `document.createElement(…)`). These unit tests pin the scan's semantics —
+// especially its calibration against the shapes today's selector legitimately
+// claims (Math whitelist, extern-class `new`), which must NOT be flagged.
+// ---------------------------------------------------------------------------
+
+/** Parse `src`, return the FunctionDeclaration named `fnName` plus the module
+ *  top-level binding names (functions / classes / consts) — mirroring what
+ *  `computeIrFirstSkipSet` derives from the real source file. */
+function parseFn(src: string, fnName: string): { fn: ts.FunctionDeclaration; moduleNames: Set<string> } {
+  const sf = ts.createSourceFile("gate4.ts", src, ts.ScriptTarget.ES2022, true);
+  const moduleNames = new Set<string>();
+  let fn: ts.FunctionDeclaration | undefined;
+  for (const s of sf.statements) {
+    if (ts.isFunctionDeclaration(s) && s.name) {
+      moduleNames.add(s.name.text);
+      if (s.name.text === fnName) fn = s;
+    } else if (ts.isClassDeclaration(s) && s.name) {
+      moduleNames.add(s.name.text);
+    } else if (ts.isVariableStatement(s)) {
+      for (const d of s.declarationList.declarations) {
+        if (ts.isIdentifier(d.name)) moduleNames.add(d.name.text);
+      }
+    }
+  }
+  expect(fn, `function ${fnName} not found in test source`).toBeDefined();
+  return { fn: fn!, moduleNames };
+}
+
+function readsHost(src: string, fnName = "f"): boolean {
+  const { fn, moduleNames } = parseFn(src, fnName);
+  return irFirstBodyReadsHostNode(fn, moduleNames);
+}
+
+describe("#2138 gate 4 — irFirstBodyReadsHostNode (host-node skip exclusion)", () => {
+  it("flags host-global property reads (the #2856 HostMemberGet shape)", () => {
+    expect(readsHost(`function f(): number { const host = document.body; return 1; }`)).toBe(true);
+    expect(readsHost(`function f(): string { return window.location.href; }`)).toBe(true);
+    expect(readsHost(`function f(): number { return globalThis.foo; }`)).toBe(true);
+  });
+
+  it("flags host-global method calls (the #2856 HostMethodCall shape)", () => {
+    expect(readsHost(`function f(): number { const box = document.createElement("div"); return 1; }`)).toBe(true);
+    expect(readsHost(`function f(): void { console.log("x"); }`)).toBe(true);
+  });
+
+  it("flags host element access and bare out-of-scope calls", () => {
+    expect(readsHost(`function f(): number { return document["title"].length; }`)).toBe(true);
+    expect(readsHost(`function f(s: string): number { return parseInt(s); }`)).toBe(true);
+  });
+
+  it("does NOT flag the Math whitelist (proven #1371 lowering)", () => {
+    expect(readsHost(`function f(x: number): number { return Math.sqrt(x) + Math.abs(x); }`)).toBe(false);
+    expect(readsHost(`function f(x: number): number { return Math.min(x, 2); }`)).toBe(false);
+  });
+
+  it("does NOT flag locally-bound or module-bound receivers/callees", () => {
+    expect(readsHost(`function f(o: { a: number }): number { return o.a; }`)).toBe(false);
+    expect(readsHost(`function f(): number { const o = { a: 1 }; return o.a; }`)).toBe(false);
+    expect(readsHost(`function g(): number { return 1; }\nfunction f(): number { return g(); }`)).toBe(false);
+    expect(readsHost(`const CFG = { n: 2 };\nfunction f(): number { return CFG.n; }`)).toBe(false);
+    expect(readsHost(`function f(xs: number[]): number { return xs[0] + xs.length; }`)).toBe(false);
+  });
+
+  it("does NOT flag extern-class `new` chains (opaque sanctioned root, slice 10)", () => {
+    expect(readsHost(`function f(): number { return new Uint8Array(4).length; }`)).toBe(false);
+  });
+
+  it("does NOT flag nested-scope bindings (over-approximated locals are safe)", () => {
+    expect(readsHost(`function f(): number { { const inner = { a: 1 }; return inner.a; } }`)).toBe(false);
+    expect(readsHost(`function f(xs: number[]): number { let t = 0; for (const x of xs) { t += x; } return t; }`)).toBe(
+      false,
+    );
+  });
+
+  it("integration: gate 4 does not disturb today's skip set (no over-exclusion collateral)", async () => {
+    // FIB_SRC's claimed functions read no host nodes — the flag-on skip set
+    // must be unchanged by the gate (guards against a scan that is stricter
+    // than the selector's accept surface, which would depress the #2949
+    // skip-rate measurement).
+    const r = await compileFlag(true, FIB_SRC);
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(r.irFirstSkipped).toContain("fib");
+    expect(r.irFirstSkipped).toContain("run");
   });
 });


### PR DESCRIPTION
## Summary

Adds **gate 4** to `computeIrFirstSkipSet` (#2138 IR-first, landed in 6ac915824): a claimed function whose body reads a **host node** — a property/element access or bare call rooted at an identifier that is neither function-local nor a module top-level binding — is never marked skippable under `JS2WASM_IR_FIRST=1`.

This mirrors the explicit sequencing requirement in the extern-in-IR plan (`plan/issues/2856-ir-body-shape-rejected-to-zero.md`, docs PR #2461): *"#2138's skippable-closure computation must exclude any function whose claim depends on a host node until this slice proves the lowering… #2138 owner to mirror."*

## Why now (the gate is latent today, load-bearing tomorrow)

Today the selector rejects host-global receivers wholesale (the #2454 recorder's host-global arm), so no claimed function contains one and gate 4 changes nothing. The moment #2856's `HostMemberGet`/`HostMethodCall` selector arm starts **accepting** them, any select↔from-ast drift on a skipped host-reading function would hard-fail flag-on compiles (the landed skipped-slot promotion) — polluting the Slice-3 measurement with a known-unimplemented feature instead of real divergences.

## Calibration (cannot depress the #2949 skip rate)

The scan allowlists exactly today's selector ambient accepts, so no currently-skippable function is excluded:
- root `Math` (#1371 unary/binary whitelist — non-whitelisted `Math.*` shapes are unclaimable anyway),
- opaque `NewExpression` roots (slice-10 extern classes; `new Uint8Array(4).length` is not flagged),
- over-approximated local bindings (safe: shapes the selector would reject never reach the gate; host-global shadowing is `vardecl-shadow`-rejected).

Scan lives in the new cycle-free `src/codegen/ir-first-gate.ts` (importing the codegen entry module directly from tests trips a `boolToStringEmitter` init-order cycle).

## Also in this PR

`scripts/byte-diff-corpus.mts` — the reusable two-checkout byte-identity corpus harness (example files default+wasi + stride-N test262 sample, SHA-256 per binary). Used to validate #2138's ordering work (2,692 compiles, 0 diff) and intended for Slice-3 / future IR-first ratchet validation. (Lead-requested inclusion.)

## Flag-off safety

Flag-off is untouched **by construction** — `computeIrFirstSkipSet` (and hence gate 4) only executes under `JS2WASM_IR_FIRST=1` + `experimentalIR`.

## Tests

- `tests/issue-2138.test.ts`: 14/14 — 6 landed + 8 new gate-4 tests (host property/method/element/bare-call positives; Math-whitelist / local / module-binding / extern-`new`-chain / nested-scope negatives; integration guard that today's skip set is undisturbed).
- `tsc --noEmit` clean; `check:ir-fallbacks` zero delta (runs flag-off, where the gate is unreachable).

Issue: plan/issues/2138-ir-first-compile-once-inversion.md (stays `in-progress` — Slice 3 measurement follows once this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8