### PR TITLE
chore(#2877): close as done-via-#2962 + pin the harness-level acceptance contract

### DIFF
--- a/plan/issues/2877-standalone-exception-no-readable-message.md
+++ b/plan/issues/2877-standalone-exception-no-readable-message.md
@@ -1,15 +1,19 @@
 ---
 id: 2877
 title: "Standalone exceptions expose no JS-readable message (__sget_message returns null) — blocks message-level triage"
-status: ready
+status: done
 created: 2026-06-30
+updated: 2026-07-02
+completed: 2026-07-02
+assignee: ttraenkler/dev-2912f
+resolved_by: 2962
 priority: medium
 task_type: enhancement
 area: tooling
 goal: standalone
 sprint: current
 horizon: s
-related: [2870, 2862, 2860]
+related: [2870, 2862, 2860, 2962]
 umbrella: 2860
 ---
 
@@ -53,3 +57,39 @@ The harness records the real error message (or a precise class label) for a
 standalone-thrown exception instead of the generic #2870 fallback, with zero
 pass/fail movement (tooling-only). Enables message-level re-triage of #2862's
 de-masked clusters.
+
+## Resolution (2026-07-02, dev-2912f) — satisfied by #2962
+
+**Closed as done-via-#2962** (PR #2481, merged 2026-07-02): the "native
+error-object identity + payload stringification" work landed a strict
+superset of this issue's fix sketch while a parallel #2877 implementation was
+in flight in this session. #2962's mechanism:
+
+- in-module `__error_to_string` (§20.5.3.4) + Error arms in
+  `__any_to_string`, so `String(e)` / `` `${e}` `` render `"Name: message"`
+  natively;
+- harness render exports `__exn_render_prepare(externref) -> i32` /
+  `__exn_render_char(i32) -> i32` (finalize, gated
+  `noJsHost && nativeStrings && exnTagIdx >= 0`) — the payload runs through
+  the module's OWN `__any_to_string` chain, superior to a dedicated
+  message-field accessor because it spec-formats any payload kind;
+- `extractWasmExceptionMessage` wired in BOTH mandated sites
+  (`tests/test262-runner.ts` + `scripts/test262-worker.mjs`).
+
+**Acceptance verified against main `46e390c` (probe, this session):**
+`throw new TypeError("boom")` → `"TypeError: boom"`; rope message
+(`"hello " + x + "!"`) → `"RangeError: hello world!"`; `new Error()` →
+`"Error"` (spec name-only); `throw "bare string payload"` → decoded raw;
+Test262Error → `"Test262Error: Expected a to equal b"`. Known residual
+(documented in #2962): a thrown boxed number renders `"[object Object]"`
+(construction-time ToString residual class) — still a stable, non-crashing
+label.
+
+This session's parallel implementation (dedicated `__exn_msg_*`/`__exn_name_*`
+per-char accessors + `$Error_struct` root-cause analysis: the struct is
+registered directly in `mod.types`, invisible to `emitStructFieldGetters`,
+which is WHY `__sget_message` never covered it) was verified working (7/7
+tests) but **discarded unlanded** — two parallel export families would
+duplicate binary surface and harness decode paths for zero additional triage
+value. The harness-level acceptance test for THIS issue's criteria rides the
+closeout PR as `tests/issue-2877.test.ts`, pinned to the #2962 mechanism.

--- a/tests/issue-2877.test.ts
+++ b/tests/issue-2877.test.ts
@@ -1,0 +1,85 @@
+// (#2877) Standalone exceptions expose no JS-readable message — HARNESS-level
+// acceptance test, resolved by #2962's native render mechanism.
+//
+// #2877's acceptance: the harness records the real error message (or a
+// precise class label) for a standalone-thrown exception instead of the
+// #2870 opaque fallback ("uncaught Wasm-GC exception (non-stringifiable
+// payload)"). #2962 satisfied it via `__exn_render_prepare`/`__exn_render_char`
+// (the payload rendered through the module's own `__any_to_string`, §20.5.3.4)
+// wired into `extractWasmExceptionMessage`. #2962's own test covers the
+// module-level rendering; THIS test pins the end-to-end harness contract —
+// compile standalone, throw, catch host-side, extract — across the payload
+// shapes #2877's triage use-case needs.
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { extractWasmExceptionMessage } from "./test262-runner.js";
+
+async function throwAndExtract(src: string): Promise<string> {
+  const r = await compile(src, { fileName: "t.ts", target: "standalone" as never });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  try {
+    (instance.exports as Record<string, () => unknown>).test();
+    throw new Error("expected the module to throw");
+  } catch (err) {
+    return extractWasmExceptionMessage(err, instance);
+  }
+}
+
+const OPAQUE_LABEL = "uncaught Wasm-GC exception (non-stringifiable payload)";
+
+describe("#2877 — harness records real messages for standalone-thrown exceptions (via #2962)", () => {
+  it("new TypeError('boom') → 'TypeError: boom'", async () => {
+    expect(await throwAndExtract(`export function test(): number { throw new TypeError("boom"); }`)).toBe(
+      "TypeError: boom",
+    );
+  });
+
+  it("rope message (string concat) renders flattened", async () => {
+    expect(
+      await throwAndExtract(
+        `export function test(): number { const x = "wor" + "ld"; throw new RangeError("hello " + x + "!"); }`,
+      ),
+    ).toBe("RangeError: hello world!");
+  });
+
+  it("no-message error → spec §20.5.3.4 name-only", async () => {
+    expect(await throwAndExtract(`export function test(): number { throw new Error(); }`)).toBe("Error");
+  });
+
+  it("thrown bare string decodes to its own text", async () => {
+    expect(await throwAndExtract(`export function test(): number { throw "bare string payload"; }`)).toBe(
+      "bare string payload",
+    );
+  });
+
+  it("Test262Error surfaces its real assertion message (the assert.js harness shape)", async () => {
+    const message = await throwAndExtract(`
+class Test262Error {
+  message: string;
+  constructor(message: string) { this.message = message; }
+}
+export function test(): number { throw new Test262Error("Expected a to equal b"); }
+`);
+    expect(message).toContain("Expected a to equal b");
+  });
+
+  it("non-Error non-string payload still yields a stable, non-crashing label", async () => {
+    // Known #2962 residual: a thrown boxed number renders "[object Object]"
+    // (construction-time ToString residual). Pin only the CONTRACT this issue
+    // needs: extraction never throws and never regresses to a crash; do not
+    // pin the residual text (it should improve to "42" eventually).
+    const message = await throwAndExtract(`export function test(): number { throw 42; }`);
+    expect(typeof message).toBe("string");
+    expect(message.length).toBeGreaterThan(0);
+  });
+
+  it("real messages replace the #2870 opaque label for error payloads", async () => {
+    const message = await throwAndExtract(
+      `export function test(): number { throw new SyntaxError("triage needs this text"); }`,
+    );
+    expect(message).toBe("SyntaxError: triage needs this text");
+    expect(message).not.toBe(OPAQUE_LABEL);
+  });
+});


### PR DESCRIPTION
Task #23 closeout. While a parallel #2877 implementation was in flight this session, **#2962 (PR #2481) landed a strict superset** of the issue's fix sketch: `__exn_render_prepare`/`__exn_render_char` render the thrown standalone payload through the module's own `__any_to_string` chain (spec §20.5.3.4), and `extractWasmExceptionMessage` is wired in both mandated harness sites (`tests/test262-runner.ts` + `scripts/test262-worker.mjs`).

## What this PR does

- `plan/issues/2877-*.md` → `status: done`, `resolved_by: 2962`, with a full reconciliation record: acceptance verified against main `46e390c` by probe — `"TypeError: boom"`, rope `"RangeError: hello world!"`, spec name-only `"Error"`, bare-string decode, `"Test262Error: Expected a to equal b"`; the boxed-number `"[object Object]"` residual is documented (#2962's construction-time-ToString class).
- **NEW `tests/issue-2877.test.ts`** (7/7 green): harness-level end-to-end acceptance pin — compile standalone → throw → host-side extraction — across the triage payload shapes. Complements `issue-2962.test.ts` (module-level rendering) with the #2877-specific harness contract, including a never-crash pin on the non-Error/non-string residual.

## What this PR deliberately does NOT do

This session's parallel implementation (dedicated `__exn_msg_len/char` + `__exn_name_len/char` per-code-unit accessors, verified 7/7) was **discarded unlanded** — a second export family alongside `__exn_render_*` would duplicate binary surface and harness decode paths for zero additional triage value. The root-cause analysis it produced is preserved in the issue file: `$Error_struct` is registered directly in `mod.types` (not `ctx.structFields`), so `emitStructFieldGetters` never covers it — which is why the issue-title `__sget_message` probe returned null.

Docs + one test file only; no compiler changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS