### PR TITLE
feat(#2945): IR `%` lowering via the shared __fmod helper — capability defer → claim (+ #2138 Slice-3 record)

### DIFF
--- a/plan/issues/2138-ir-first-compile-once-inversion.md
+++ b/plan/issues/2138-ir-first-compile-once-inversion.md
@@ -1,7 +1,8 @@
 ---
 id: 2138
 title: "IR-first compile-once inversion: selector decides before compileDeclarations (flag-gated investigation)"
-status: in-progress
+status: done
+completed: 2026-07-02
 assignee: ttraenkler/dev-2138f
 pipeline_unblocked: 1927
 spec: ready
@@ -16,7 +17,7 @@ task_type: architecture
 area: compiler
 language_feature: compiler-internals
 goal: maintainability
-related: [1530, 1916, 1927, 2135]
+related: [1530, 1916, 1927, 2135, 2945, 2947, 2972, 2973]
 origin: "2026-06-12 sprint-62 architecture analysis (pipeline workstream N2)"
 ---
 
@@ -455,3 +456,79 @@ below).
   time from the runner's per-run timing in `runs/index.json`. Every
   flag-ON-only failure is by construction a loud selector↔builder/skip
   divergence — bucket by error class, file per class.
+
+## Measurement (JS2WASM_IR_FIRST) — FULL RUN, 2026-07-02 (dev-2138f) — Slice 3, closes the issue
+
+Run: `test262-sharded.yml` workflow_dispatch **28580162377** with
+`ir_first: true` (the #2947 lane) on `main@89676d232513` — full 57×2-shard
+matrix, `JS2WASM_IR_FIRST: 1` verified in every shard's env, fresh compiles
+(no result cache), promote-baseline hard-skipped by design. Diffed
+per-test against the honest baseline
+(`loopdive/js2wasm-baselines` JSONL, refreshed same day from unflagged main)
+via `scripts/diff-test262.ts`.
+
+### (a) test262 delta — js-host lane, 48,088 shared tests (official + proposals)
+
+| status | baseline (flag OFF) | flagged (IR-first ON) | delta |
+|---|---|---|---|
+| pass | 34,781 | 34,766 | **−15 (−0.031%)** |
+| fail | 12,534 | 12,537 | +3 |
+| compile_error | 576 | 591 | +15 |
+| compile_timeout | 83 | 80 | −3 |
+
+15 regressions, 0 improvements, **0 wasm-identical noise, 0 ct-flakes** —
+all 15 are real compiler-output differences, and they collapse into exactly
+TWO root causes (attributed, filed):
+
+- **#2972 (14 tests, `pass → compile_error`)** — ONE harness function
+  (`decimalToPercentHexString`): selector claims string element access with
+  a computed (BinaryExpression) index, from-ast throws `not in slice 12` →
+  skipped slot → hard error. **Fail-loud contract working as designed**;
+  the fix is #2135 family-2/3 capability work.
+- **#2973 (1 test, `pass → fail`, silent)** — `S12.4_A2_T2`: the eval shim's
+  in-process sub-compile (`runtime-eval.ts:213` wraps eval strings in a
+  claimable `__eval_result` FunctionDeclaration) inherits the env flag, its
+  post-claim residual hard-errors, and the shim's `catch` swallows it →
+  `undefined` instead of `7`. **The only fail-loud violation found** —
+  eval/`new Function` sub-compiles must opt out of the flag (#2973, S).
+
+Additionally, the pre-flip `%` class (#2945) never appears — retired by
+#2135 slice 1 before this run, confirming the capability-table mechanism.
+
+### (b) compile-time delta — honestly: not measurable across runs
+
+The diff tool reports **−1.8%** aggregate compile time vs the baseline the
+run itself fetched at 09:39 (8,510,718 → 8,356,264 ms over 47,882 shared
+tests), and **−27.1%** vs the 11:26-refreshed baseline (11,459,923 ms
+baseline side). Those two baseline timing sets describe the SAME unflagged
+code and differ by +35% — cross-run CI wall-clock is runner-lottery-
+dominated, so neither delta is attributable to the inversion. Verdict:
+**no measurable wall-clock change beyond noise** (expected: the structural
+saving is one legacy body compile per claimed function, small vs total
+front-end cost). A rigorous number needs a same-runner A/B (two dispatches
+on the same SHA back-to-back, flag off/on); not worth runner-minutes unless
+the inversion becomes default-on policy.
+
+### (c) skipped-body telemetry
+
+Not surfaced per-test by the runner (`CompileResult.irFirstSkipped` is not
+recorded into the JSONL rows). Local corpus evidence stands (8 bodies / 13
+playground examples; 100% of claimed funcs on claim-dense inputs). Optional
+runner extension if a future run wants the aggregate; not needed for the
+conclusion.
+
+### Verdict (what this buys #1530/#1916/#2855 sequencing)
+
+The compile-once inversion is **viable**: 99.97% of the js-host suite is
+indifferent to skipping legacy bodies for claimed closures; the fail-loud
+contract held for 14/15 divergences; the single silent path is an eval-shim
+artifact with a one-file fix (#2973); and the flag surfaced exactly the
+selector↔builder drift classes #2135 is retiring (one already fixed before
+this run, one filed as #2972). Remaining before any default-on discussion:
+#2973, #2972, the claim-partial ratchet (#2135 families), and the
+generator/class-member skip exclusions. Slice 4 (generateMultiModule seam)
+remains open as a follow-on under #2135-family planning.
+
+**Acceptance criteria: all met** — (1) flag + byte-identical default
+(proven), (2) full measured test262 + compile-time run recorded here,
+(3) divergences filed (#2945, #2972, #2973). → `status: done`.

--- a/plan/issues/2945-ir-selector-claims-modulo-from-ast-throws.md
+++ b/plan/issues/2945-ir-selector-claims-modulo-from-ast-throws.md
@@ -1,8 +1,10 @@
 ---
 id: 2945
 title: "IR selector claims `%` (modulo) but from-ast throws — post-claim drift surfaced by JS2WASM_IR_FIRST"
-status: ready
-sprint: Backlog
+status: done
+completed: 2026-07-02
+assignee: ttraenkler/dev-2138f
+sprint: current
 created: 2026-07-02
 updated: 2026-07-02
 priority: medium
@@ -12,7 +14,7 @@ task_type: bug
 area: compiler
 language_feature: compiler-internals
 goal: correctness
-related: [2135, 2138, 1131]
+related: [2135, 2138, 1131, 2056]
 origin: "2026-07-02 #2138 IR-first flag-on divergence sweep (dev-2138f)"
 ---
 
@@ -75,3 +77,47 @@ Found via #2138 Slice-2 probes (see `## Measurement (JS2WASM_IR_FIRST)` in
 `plan/issues/2138-ir-first-compile-once-inversion.md`). The 233-file corpus
 sweep found no OTHER flag-on-only failures — this is the sole divergence
 surfaced so far; the Slice-3 full test262 run may add more.
+
+## Resolution (dev-2138f, 2026-07-02) — option 2 implemented (builder-side lowering)
+
+Two-stage close:
+
+1. **#2135 slice 1** first retired the hard-error mode: `%` flipped to
+   capability `defer` (selector rejects → legacy), so the IR-first trap
+   became structurally impossible. The Slice-3 full flagged run confirmed
+   zero `%`-class failures.
+2. **This PR** implements the lowering and flips the row `defer → "claim"`:
+   `lowerBinary`'s `PercentToken` arm emits
+   `emitCall({kind:"func", name: FMOD_FN}, [lhs, rhs], f64)` — a call to the
+   **same Wasm-native exact-remainder helper `__fmod` (#2056) that legacy's
+   `emitModulo` emits**, so IR and legacy agree bit-for-bit. The integration
+   resolver (`makeResolver.resolveFunc`) materializes the helper on demand
+   (`ensureFmod` — idempotent, appends a defined function, never an import,
+   so no funcIdx shifts).
+
+**Correction of this issue's own fix sketch (verify-first, the #2945
+lesson):** the `a - b * trunc(a / b)` formula suggested above is WRONG — it
+is not IEEE fmod (ULP drift; collapses for large quotients; `a/b` overflow
+→ ±Inf; `1e308 % 1e-308` breaks). Legacy tried exactly that and replaced it
+with `__fmod` (see `src/codegen/fmod.ts` #2056 notes). Never re-derive `%`
+inline; call the helper.
+
+Scope notes:
+- **f64 operands only** — i32-typed operands demote to legacy via the
+  type-resolution lane (`requireF64`); legacy's i32 fast mode keeps its
+  trap-free `emitSafeI32Rem`. An IR i32 `%` (needs a nonzero-divisor /
+  non-INT_MIN proof, and `x % 0` → NaN has no i32 representation) is
+  deliberately out of scope.
+- Call-graph win: pre-fix, a `%`-containing helper dragged its CALLERS off
+  the IR path too (bidirectional closure); now the whole closure stays
+  claimed (`tests/issue-2945.test.ts` pins this).
+
+Acceptance verified: `tests/issue-2945.test.ts` — capability row + selector
+claim; 16-case bit-exact parity vs JS (`Object.is`, incl. `-0`, `x % 0` →
+NaN, `±Inf`, NaN propagation, `1e308 % 1e-308`, ULP-drift case) flag-off AND
+under `JS2WASM_IR_FIRST=1` (legacy body skipped, `irFirstSkipped` contains
+the function); `tests/issue-2135.test.ts` updated (`%` moved to the claimed
+side; table sanity row → "claim"); post-claim demotions "(none)" on the
+corpus; fallback baseline refreshed (the slice-1 ±2 relabel reverses: the
+two corpus functions' real blocker is a call edge, `%` was just the
+earlier-checked rejection reason — totals unchanged).

--- a/plan/issues/2972-ir-string-elem-access-computed-index-drift.md
+++ b/plan/issues/2972-ir-string-elem-access-computed-index-drift.md
@@ -1,0 +1,65 @@
+---
+id: 2972
+title: "IR selector accepts string element access with computed index; from-ast throws 'not in slice 12' — 14 test262 CEs under IR-first"
+status: ready
+sprint: current
+created: 2026-07-02
+updated: 2026-07-02
+priority: medium
+feasibility: medium
+horizon: s
+task_type: bug
+area: compiler
+language_feature: compiler-internals
+goal: correctness
+related: [2135, 2138, 2945]
+origin: "2026-07-02 #2138 Slice-3 full flagged test262 run (28580162377) — divergence class 1 (14 tests)"
+---
+
+# Element-access capability drift: selector claims `s[i+1]`-shaped reads, builder throws
+
+## Problem
+
+The largest divergence class from #2138's full `JS2WASM_IR_FIRST=1` test262
+run (14 of 15 regressions, all `pass → compile_error`):
+
+```
+IR path failed for decimalToPercentHexString: ir/from-ast: element access on
+string with index BinaryExpression not in slice 12 (…) [IR-FALLBACK]
+[IR-FIRST skipped-slot, #2138]
+```
+
+The test262 harness helper `decimalToPercentHexString` (used by the
+encodeURI / decodeURI / encodeURIComponent / decodeURIComponent /
+parseInt / parseFloat suites) indexes a string with a computed
+(BinaryExpression) index. The selector's element-access shape check accepts
+it and claims the function; `from-ast.ts`'s element-access lowering only
+accepts a narrower index shape and throws post-claim. Flag-off this demotes
+silently to legacy; flag-on the skipped slot fails the compile LOUDLY —
+exactly the designed #2138 surfacing.
+
+Affected (all share the one harness function):
+`built-ins/decodeURI/S15.1.3.1_A2.1_T1`, `decodeURIComponent/S15.1.3.2_A2.1_T1`,
+`encodeURI/S15.1.3.3_A1.{1,2,3}_T{1,2}`, `encodeURIComponent/S15.1.3.4_A1.{1,2,3}_T{1,2}`,
+`parseFloat/S15.1.2.3_A6`, `parseInt/S15.1.2.2_A8`.
+
+## Fix — this IS #2135 family 2/3 work
+
+Single-source the **element-access index-shape** guard in
+`src/ir/capability.ts` (the #2135 table), consumed by the selector's
+element-access arm and asserted at from-ast's lowering entry. Then either:
+
+1. **Selector-side (cheap)**: reject computed-index string element access
+   (capability "defer" for that shape) — restores flag-on/flag-off parity
+   immediately; the 14 tests go back to legacy compile.
+2. **Builder-side (better)**: lower `s[<f64 expr>]` — the constant-index
+   string read lowering exists; extend it to a computed index (same charAt
+   semantics: index ToInteger, out-of-range → undefined … match the LEGACY
+   emission, verify-first per #2945's lesson).
+
+## Acceptance criteria
+
+- A `JS2WASM_IR_FIRST=1` compile of the `decimalToPercentHexString` harness
+  function either legacy-compiles (option 1) or IR-compiles (option 2) —
+  no hard error; the 14 test262 tests pass flag-on.
+- The shape guard lives in `capability.ts` (one row/predicate, not two).

--- a/plan/issues/2973-eval-subcompile-inherits-ir-first-swallows-error.md
+++ b/plan/issues/2973-eval-subcompile-inherits-ir-first-swallows-error.md
@@ -1,0 +1,65 @@
+---
+id: 2973
+title: "eval-shim sub-compiles inherit JS2WASM_IR_FIRST and swallow its hard errors — silent `undefined` instead of fail-loud"
+status: ready
+sprint: current
+created: 2026-07-02
+updated: 2026-07-02
+priority: high
+feasibility: easy
+horizon: s
+task_type: bug
+area: compiler
+language_feature: eval
+goal: correctness
+related: [2138, 2924]
+origin: "2026-07-02 #2138 Slice-3 full flagged test262 run (28580162377) — divergence class 2 (the ONLY silent wrong answer found)"
+---
+
+# The one silent divergence under IR-first: eval sub-compiles
+
+## Problem
+
+`test/language/statements/expression/S12.4_A2_T2.js` was the single
+`pass → fail` (runtime wrong-answer) regression in #2138's full flagged run
+— and the ONLY divergence that violated the fail-loud contract:
+
+- `src/runtime-eval.ts:213` compiles eval strings as
+  `compileSourceSync("export function __eval_result() { return (<src>); }")`
+  — an **in-process sub-compile that inherits `process.env.JS2WASM_IR_FIRST`**.
+- The synthesized wrapper is a claimable top-level FunctionDeclaration; under
+  the flag its legacy body is skipped. The eval'd expression
+  (`5+1|0===0` — mixed f64/i32 `|` operands) hits a claim-partial type
+  residual, so the IR build fails post-claim → hard compile error (correct,
+  fail-loud) — **but the shim's `catch` arms (runtime-eval.ts:218/:231)
+  swallow the failure** and fall through, yielding `undefined` instead of `7`.
+
+Net effect: the #2138 hard-error contract is converted into a **silent wrong
+answer** for any eval'd code containing a claim-partial residual. This is a
+flag-on-only bug today (default builds unaffected), but it is the exact
+silent-wrong-code class the inversion exists to eliminate — it must not
+survive into any future default-on rollout.
+
+## Fix
+
+Exclude eval/`new Function` sub-compiles from the IR-first investigation:
+in `runtime-eval.ts` (and any sibling in-process sub-compile sites, e.g. the
+#2924 `new Function` compile-away), pass an explicit opt-out through
+`compileSourceSync` options (preferred: a `codegenOptions` flag threaded to
+`generateModule` that overrides the env read; acceptable first cut:
+save/clear/restore `process.env.JS2WASM_IR_FIRST` around the sub-compile).
+Sub-compiles are a semantics-critical fast path, not a measurement target —
+they should always take the proven legacy-then-overlay pipeline.
+
+Alternative (rejected): making the shim rethrow flag-on compile errors —
+that fixes the SILENCE but turns recoverable eval fast-path misses into user-
+visible failures; the shim's contract is graceful fallback.
+
+## Acceptance criteria
+
+- `JS2WASM_IR_FIRST=1` run of S12.4_A2_T2 passes (eval returns 7).
+- A regression test pinning: flag-on eval of a claim-partial-residual
+  expression equals its flag-off result.
+- Sub-compile opt-out is structural (options-based), not ambient env
+  mutation, OR documented why env save/restore is safe (single-threaded
+  compile path).

--- a/scripts/ir-fallback-baseline.json
+++ b/scripts/ir-fallback-baseline.json
@@ -1,8 +1,8 @@
 {
   "generated": "2026-07-02",
   "unintended": {
-    "body-shape-rejected": 34,
-    "call-graph-closure": 5,
+    "body-shape-rejected": 32,
+    "call-graph-closure": 7,
     "class-method": 6
   },
   "deferred": {

--- a/src/ir/capability.ts
+++ b/src/ir/capability.ts
@@ -99,8 +99,15 @@ const BINARY_OP_CAPABILITY: ReadonlyMap<ts.SyntaxKind, IrOpCapability> = new Map
   [ts.SyntaxKind.LessThanLessThanToken, "claim"],
   [ts.SyntaxKind.GreaterThanGreaterThanToken, "claim"],
   [ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken, "claim"],
+  // `%` — lowered as a call to the Wasm-native exact-remainder helper
+  // (`__fmod`, #2056) — the SAME helper legacy's `emitModulo` calls, so IR
+  // and legacy agree bit-for-bit (incl. `x % 0` → NaN, `-0 % x` → -0,
+  // `Inf % x` → NaN, `x % Inf` → x, and large-quotient exactness where the
+  // naive `a - trunc(a/b)*b` formula collapses or overflows). f64 operands
+  // only; i32-typed / string operands demote via the type-resolution lane
+  // (legacy's i32 fast mode keeps `emitSafeI32Rem`). Claimed via #2945.
+  [ts.SyntaxKind.PercentToken, "claim"],
   // Deferred — no IR lowering exists. Selector rejects; builder asserts.
-  [ts.SyntaxKind.PercentToken, "defer"], // #2945 — needs JS-conformant fmod-style remainder
   [ts.SyntaxKind.AsteriskAsteriskToken, "defer"], // needs Math.pow-equivalent lowering
   [ts.SyntaxKind.InKeyword, "defer"], // needs property/prototype-chain probe
   [ts.SyntaxKind.InstanceOfKeyword, "defer"], // needs class-shape / brand check

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -37,6 +37,7 @@
 
 import { ts, forEachChild } from "../ts-api.js";
 
+import { FMOD_FN } from "../codegen/fmod.js"; // #2945 — `%` lowers to a call of the shared exact-fmod helper
 import { evaluateConstantCondition } from "../codegen/statements/control-flow.js";
 // #2766 — reuse the legacy counted-loop proof predicates (pure AST analysis, no
 // codegen state) to port the `safeIndexedArrays` in-bounds proof into the IR.
@@ -4425,6 +4426,26 @@ function lowerBinary(expr: ts.BinaryExpression, cx: LowerCtx, hint: IrType): IrV
       binop = "f64.div";
       resultType = irVal({ kind: "f64" });
       break;
+    // #2945 — `a % b` lowers to a call of the Wasm-native exact-remainder
+    // helper (`__fmod`, #2056): the SAME helper legacy's `emitModulo` emits,
+    // so IR and legacy agree bit-for-bit on every edge (`x % 0` → NaN,
+    // `-0 % x` → -0, `Inf % x` → NaN, `x % Inf` → x, large-quotient
+    // exactness). Deliberately NOT the naive `a - trunc(a/b)*b` sequence —
+    // legacy tried that and replaced it (ULP drift, collapse-to-0 for large
+    // quotients, overflow to ±Inf; see `src/codegen/fmod.ts`). The symbolic
+    // `__fmod` func ref is materialized on demand by the integration
+    // resolver (`resolveFunc` calls `ensureFmod` — append-only, idempotent).
+    // f64 operands only: i32-typed operands demote to legacy, which keeps
+    // its `emitSafeI32Rem` i32 fast mode (trap-free rem semantics).
+    case ts.SyntaxKind.PercentToken: {
+      requireF64(isF64, "%", cx.funcName);
+      const fmodResult = cx.builder.emitCall({ kind: "func", name: FMOD_FN }, [lhs, rhs], irVal({ kind: "f64" }));
+      if (fmodResult === null) {
+        // Unreachable: a non-null resultType always yields a value id.
+        throw new Error(`ir/from-ast: internal — __fmod call produced no value in ${cx.funcName}`);
+      }
+      return fmodResult;
+    }
     // #1126 Stage 3 — magnitude compares accept f64 OR i32 operands.
     // i32 operands emit native `i32.{lt,le,gt,ge}_{s,u}` based on
     // signedness; f64 keeps the legacy `f64.lt` etc. The result is

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -41,6 +41,7 @@ import {
 } from "../codegen/registry/types.js";
 import type { CodegenContext } from "../codegen/context/types.js";
 import { applyIrTailCalls } from "../codegen/ir-tail-call.js";
+import { ensureFmod, FMOD_FN } from "../codegen/fmod.js"; // #2945 — on-demand `%` helper materialization
 import { lowerFunctionAstToIr, type IrFromAstResolver } from "./from-ast.js";
 import {
   lowerIrFunctionToWasm,
@@ -985,6 +986,13 @@ function makeResolver(
 ): IrLowerResolver {
   return {
     resolveFunc(ref: IrFuncRef): number {
+      // #2945 — `%` lowers to a call of the Wasm-native exact-fmod helper.
+      // Materialize it on demand: `ensureFmod` is idempotent (funcMap-cached)
+      // and appends a DEFINED function (never an import), so no existing
+      // funcIdx shifts — same append-only discipline as the IR's own closure
+      // functions. On-demand keeps the helper out of modules that never use
+      // `%` (parity with legacy, which also emits it lazily).
+      if (ref.name === FMOD_FN) return ensureFmod(ctx);
       const idx = ctx.funcMap.get(ref.name);
       if (idx !== undefined) return idx;
       // Slice 6 part 4 (#1183): native-string helpers (`__str_charAt`,

--- a/tests/issue-2135.test.ts
+++ b/tests/issue-2135.test.ts
@@ -51,23 +51,22 @@ function claims(source: string, fnName: string): boolean {
 
 describe("#2135 capability table — operator family single source", () => {
   it("deferred ops are selector-rejected (no more shape-only over-claim)", () => {
-    expect(claims(`export function m(a: number, b: number): number { return a % b; }`, "m")).toBe(false);
+    // (#2945 flipped `%` from defer → claim; `**` / `in` / `~` remain defer.)
     expect(claims(`export function p(a: number, b: number): number { return a ** b; }`, "p")).toBe(false);
     expect(claims(`export function tld(o: any): boolean { return "x" in o; }`, "tld")).toBe(false);
     expect(claims(`export function bnot(a: number): number { return ~a; }`, "bnot")).toBe(false);
   });
 
   it("deferred ops produce ZERO post-claim errors and run correctly via legacy", async () => {
-    // Pre-#2135 these were claim-then-build-throw ("operator '%' not in
+    // Pre-#2135 these were claim-then-build-throw ("operator '**' not in
     // slice 11") — counted on irPostClaimErrors and, under JS2WASM_IR_FIRST,
-    // a hard compile error (#2945). Now the selector never claims them.
-    const src = `export function m(a: number, b: number): number { return a % b; }`;
+    // a hard compile error (the #2945 class). Now the selector never claims
+    // them. (`%` moved to the claimed side — see tests/issue-2945.test.ts.)
+    const src = `export function p(a: number, b: number): number { return a ** b; }`;
     const r = await compile(src, { fileName: "issue-2135.ts" });
     expect(r.success).toBe(true);
-    expect((r.irPostClaimErrors ?? []).filter((e) => e.func === "m")).toEqual([]);
-    expect(await run(src, "m", [7, 3])).toBe(1);
-    expect(await run(src, "m", [-7, 2])).toBe(-1);
-    expect(await run(`export function p(a: number, b: number): number { return a ** b; }`, "p", [2, 10])).toBe(1024);
+    expect((r.irPostClaimErrors ?? []).filter((e) => e.func === "p")).toEqual([]);
+    expect(await run(src, "p", [2, 10])).toBe(1024);
   });
 
   it("claimed ops are selector-accepted and IR-compile with no post-claim error", async () => {
@@ -108,7 +107,7 @@ describe("#2135 capability table — operator family single source", () => {
   });
 
   it("table sanity: the retired over-claims are exactly defer; the accept set is unchanged otherwise", () => {
-    expect(binaryOpCapability(ts.SyntaxKind.PercentToken)).toBe("defer");
+    expect(binaryOpCapability(ts.SyntaxKind.PercentToken)).toBe("claim"); // #2945 — __fmod lowering landed
     expect(binaryOpCapability(ts.SyntaxKind.AsteriskAsteriskToken)).toBe("defer");
     expect(binaryOpCapability(ts.SyntaxKind.InKeyword)).toBe("defer");
     expect(binaryOpCapability(ts.SyntaxKind.InstanceOfKeyword)).toBe("defer");

--- a/tests/issue-2945.test.ts
+++ b/tests/issue-2945.test.ts
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2945 — IR lowering for `%` (modulo): capability row flipped defer → claim.
+//
+// Verify-first finding (recorded in the issue): the correct lowering is a
+// call to the Wasm-native exact-remainder helper `__fmod` (#2056) — the SAME
+// helper legacy's `emitModulo` emits — NOT the naive `a - trunc(a/b)*b`
+// sequence (legacy tried that and replaced it: ULP drift, collapse-to-0 for
+// large quotients, overflow to ±Inf). Because both paths call the identical
+// helper, IR and legacy agree bit-for-bit on every edge case.
+//
+// Contract under test:
+//   1. The selector CLAIMS `%` functions and the IR compiles them with zero
+//      post-claim errors (the claim is backed by a lowering — #2135's
+//      one-row-not-two-predicates invariant).
+//   2. Spec-edge parity (tc39 §6.1.6.1.6 Number::remainder): sign follows
+//      the dividend; `x % 0` → NaN; `Inf % x` → NaN; `x % Inf` → x;
+//      `-0 % x` → -0; NaN propagates; large-quotient exactness.
+//   3. Under JS2WASM_IR_FIRST=1 (the #2138 inversion) a `%` function
+//      compiles and runs identically — the #2945 hard-error mode is gone
+//      end-to-end (legacy body skipped, IR body ships, same results).
+import { describe, expect, it, vi } from "vitest";
+import { compile, type CompileResult } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+import { analyzeSource } from "../src/checker/index.js";
+import { planIrCompilation } from "../src/ir/select.js";
+import { binaryOpCapability } from "../src/ir/capability.js";
+import { ts } from "../src/ts-api.js";
+
+const MOD_SRC = `export function m(a: number, b: number): number { return a % b; }`;
+
+async function instantiate(r: CompileResult): Promise<Record<string, Function>> {
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return instance.exports as Record<string, Function>;
+}
+
+async function compileFlag(irFirst: boolean, src: string): Promise<CompileResult> {
+  vi.stubEnv("JS2WASM_IR_FIRST", irFirst ? "1" : "");
+  try {
+    return await compile(src, { fileName: "issue-2945.ts" });
+  } finally {
+    vi.unstubAllEnvs();
+  }
+}
+
+/** JS ground truth via Object.is so -0 and NaN compare correctly. */
+const EDGE_CASES: Array<[number, number]> = [
+  [7, 3],
+  [-7, 2], // sign of dividend: -1
+  [7, -2], // sign of dividend: +1
+  [7.5, 2],
+  [-7.5, 2],
+  [5, 0], // NaN
+  [-0, 5], // -0
+  [0, 5],
+  [Infinity, 2], // NaN
+  [-Infinity, 2], // NaN
+  [2, Infinity], // 2
+  [-2, Infinity], // -2
+  [NaN, 2],
+  [2, NaN],
+  [1e308, 1e-308], // large-quotient exactness (naive formula overflows to ±Inf)
+  [5.5, 5.5e-10], // ULP-drift trap for the naive formula
+];
+
+describe("#2945 IR `%` lowering via __fmod (capability defer → claim)", () => {
+  it("capability row is claim and the selector claims `%` functions", () => {
+    expect(binaryOpCapability(ts.SyntaxKind.PercentToken)).toBe("claim");
+    const ast = analyzeSource(MOD_SRC);
+    const sel = planIrCompilation(ast.sourceFile, { experimentalIR: true });
+    expect(sel.funcs.has("m")).toBe(true);
+  });
+
+  it("IR-compiles with zero post-claim errors and matches JS on every edge case", async () => {
+    const r = await compileFlag(false, MOD_SRC);
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect((r.irPostClaimErrors ?? []).filter((e) => e.func === "m")).toEqual([]);
+    const exp = await instantiate(r);
+    const m = exp.m as (a: number, b: number) => number;
+    for (const [a, b] of EDGE_CASES) {
+      const expected = a % b;
+      expect(Object.is(m(a, b), expected), `m(${a}, ${b}) should be ${expected}, got ${m(a, b)}`).toBe(true);
+    }
+  });
+
+  it("JS2WASM_IR_FIRST=1: `%` compiles clean (legacy body skipped), runs identically — the #2945 hard error is gone", async () => {
+    const r = await compileFlag(true, MOD_SRC);
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    // The inversion actually skipped the legacy body — the IR body ships once.
+    expect(r.irFirstSkipped).toContain("m");
+    const exp = await instantiate(r);
+    const m = exp.m as (a: number, b: number) => number;
+    for (const [a, b] of EDGE_CASES) {
+      expect(Object.is(m(a, b), a % b), `flag-on m(${a}, ${b})`).toBe(true);
+    }
+  });
+
+  it("`%` inside a larger claimed closure keeps the whole closure on the IR path", async () => {
+    // Regression guard for the call-graph interaction: pre-#2945 a helper
+    // containing `%` was selector-rejected, which (bidirectional closure)
+    // dragged its CALLERS off the IR path too. Now the pair stays claimed.
+    const src = `
+function wrap(a: number, b: number): number { return a % b; }
+export function run(n: number): number { return wrap(n * 3 + 1, 7); }
+`;
+    const ast = analyzeSource(src);
+    const sel = planIrCompilation(ast.sourceFile, { experimentalIR: true });
+    expect(sel.funcs.has("wrap")).toBe(true);
+    expect(sel.funcs.has("run")).toBe(true);
+    const r = await compileFlag(false, src);
+    expect(r.success).toBe(true);
+    expect(r.irPostClaimErrors ?? []).toEqual([]);
+    const exp = await instantiate(r);
+    expect((exp.run as (n: number) => number)(10)).toBe(31 % 7);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **#2945** (the `%` divergence #2138's flag surfaced) and records **#2138 Slice 3** (the full `ir_first` measurement run), closing both issues.

### #2945 — `%` in the IR (capability `defer` → `claim`)
- `lowerBinary`'s `PercentToken` arm emits a call to the Wasm-native exact-remainder helper **`__fmod` (#2056) — the SAME helper legacy's `emitModulo` uses**, so IR and legacy agree bit-for-bit on every edge (`x%0`→NaN, `-0%x`→-0, `Inf%x`→NaN, `x%Inf`→x, `1e308 % 1e-308` exactness). Deliberately NOT the naive `a − trunc(a/b)·b` sequence — legacy tried and replaced it (ULP drift, large-quotient collapse, overflow); the issue file records the corrected design rationale.
- The integration resolver materializes the helper on demand (`ensureFmod` — idempotent, appends a defined function, never an import → no funcIdx shifts).
- f64 operands only; i32-typed operands demote (legacy keeps `emitSafeI32Rem`).
- Call-graph win (test-pinned): a `%`-containing helper no longer drags its callers off the IR path via the bidirectional closure.
- `tests/issue-2945.test.ts`: claim + 16-case bit-exact JS parity (`Object.is`) flag-off AND under `JS2WASM_IR_FIRST=1` (legacy body skipped, `irFirstSkipped` verified). `tests/issue-2135.test.ts` updated (`%` moved to the claimed side). Fallback baseline refreshed (the slice-1 ±2 relabel reverses; totals unchanged).

### #2138 Slice 3 — full flagged test262 measurement (closes #2138, `status: done`)
Run **28580162377** (`ir_first: true` via the #2947 lane, `JS2WASM_IR_FIRST: 1` verified in shard env, promote-baseline hard-skipped). Diffed per-test vs the same-day honest baseline:
- **js-host: −15 pass of 48,088 (−0.031%)**, 0 improvements, 0 wasm-identical noise, 0 ct-flakes. All 15 attributed to exactly two root causes, both filed:
  - **#2972** (14×, `pass→CE`): string element access with computed index — selector claims, from-ast throws `not in slice 12`; fail-loud as designed; = #2135 family-2/3 work.
  - **#2973** (1×, `pass→fail`, **the only silent violation**): `runtime-eval.ts` sub-compiles inherit the env flag and `catch`-swallow the flag-on hard error → `undefined`. One-file fix filed (high priority before any default-on discussion).
- **Compile-time: no measurable wall-clock delta beyond runner variance** — two same-code baseline timing sets differ by 35%, dwarfing the −1.8% same-morning comparison; honest analysis in the issue.
- Verdict recorded in `plan/issues/2138-*.md`: inversion viable; fail-loud contract held 14/15; capability-table mechanism validated (the pre-fix `%` class was already absent from the full run thanks to #2135 slice 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS