### PR TITLE
docs(#2763,#2765): reground instanceof residuals — realm half + cluster 4 landed; static-throw narrowing proven value-rep-blocked

### DIFF
--- a/plan/issues/2763-instanceof-value-rep-realm-and-dynamic-function-prototype.md
+++ b/plan/issues/2763-instanceof-value-rep-realm-and-dynamic-function-prototype.md
@@ -4,7 +4,7 @@ title: "[SUBSTRATE][ARCH] instanceof value-rep residual: cross-realm Object/Func
 status: ready
 sprint: Backlog
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-02
 priority: medium
 horizon: l
 feasibility: hard
@@ -16,6 +16,7 @@ goal: core-semantics
 parent: 2740
 depends_on: []
 ---
+
 # #2763 — instanceof value-representation residual (cross-realm identity + dynamic-Function `.prototype`)
 
 Architect-scoped split of the #2740 umbrella. These two clusters are NOT
@@ -27,20 +28,21 @@ Verified against current `main` on 2026-06-28 (see #2740 for the full trace).
 
 `var O = Object; ({}) instanceof O` returns **false** at runtime (should be
 `true`). The DIRECT `({}) instanceof Object` only passes because it is
-*static-folded* in codegen, masking the gap.
+_static-folded_ in codegen, masking the gap.
 
 Root cause (traced in `_instanceofResult`, `src/runtime.ts`): when the RHS
 constructor flows through a variable to the dynamic path
 (`__instanceof_check`), the `Object`/`Function` globals arrive as a
 **sandbox-realm** `function Object(){ [native code] }`, so `target === Object`
-(the host-realm intrinsic) is **false**; and the `{}` LHS arrives as a *real
-host object* whose `[[Prototype]]` is host `Object.prototype`, so the native
+(the host-realm intrinsic) is **false**; and the `{}` LHS arrives as a _real
+host object_ whose `[[Prototype]]` is host `Object.prototype`, so the native
 `v instanceof target` walks a mismatched prototype chain and yields false. The
 explicit WasmGC-struct Object/Function recognition (`_isWasmStruct(v)` +
 `target === Object`) does not fire because (a) `v` is a real object not a wasm
 struct here, and (b) the realm-split breaks the identity compare.
 
 Affected test262 (failing on main):
+
 - `language/expressions/instanceof/S11.8.6_A2.1_T1.js` (`var O=Object; ({}) instanceof O === true`)
 - `language/expressions/instanceof/S11.8.6_A2.4_T1.js` (`var O=0; (O=Object,{}) instanceof O` — also hits the over-eager static-throw)
 - `language/expressions/instanceof/S11.8.6_A2.4_T4.js` (`(O=Object,{}) instanceof O`, undeclared O)
@@ -49,7 +51,7 @@ Affected test262 (failing on main):
 
 Note: there is ALSO an over-eager codegen static-throw — `compileHostInstanceOf`
 in `src/codegen/expressions/identifiers.ts` throws `TypeError` unconditionally
-when the RHS *static type* is exclusively primitive (e.g. `var O = 0`), which is
+when the RHS _static type_ is exclusively primitive (e.g. `var O = 0`), which is
 unsound for a reassignable binding (`O = Object` at runtime). Narrowing that
 static-throw to literal/keyword-primitive RHS only (routing identifiers to the
 dynamic check) is the codegen half; it must land together with the realm-safe
@@ -68,6 +70,7 @@ the original #2740 framing mis-labeled "null/undefined LHS": the null-deref is o
 
 Affected test262 (failing on main, all blocked on this `.prototype` trap before
 instanceof even runs):
+
 - `S15.3.5.3_A2_T6.js` (`new Function; FACTORY.prototype="error"` → expect TypeError)
 - `S15.3.5.3_A2_T2.js` (`new Function; FACTORY.prototype=undefined` → expect TypeError)
 - `S15.3.5.3_A3_T1.js` (`Function("…"); FACTORY.prototype.type=1; new FACTORY`)
@@ -76,12 +79,62 @@ instanceof even runs):
 - `S15.3.5.3_A3_T2.js` (`Function(); FAKEFACTORY.prototype = Object.prototype`)
 
 ## Acceptance criteria
+
 - `var O = Object; ({}) instanceof O` → `true`; `var F = Function; (function(){}) instanceof F` → `true` (realm-safe constructor identity in the dynamic instanceof path).
 - `({}) instanceof this` (this = undefined) → throws `TypeError`.
 - `.prototype` read/write on a `Function(...)` / `new Function` value no longer traps.
 - No regression in the 28 instanceof tests currently green.
 
 ## Notes
+
 - Spec: ES2023 §13.10.2, §7.3.20.
 - Key sites: `src/runtime.ts` `_instanceofResult` (~2215), `__instanceof_check`/`__instanceof` (~12224); `src/codegen/expressions/identifiers.ts` `compileHostInstanceOf`/`tryStaticInstanceOf`; property-access for `.prototype` on Function values in `src/codegen/property-access.ts`.
 - Architect should decide whether the realm-safe Object/Function recognition belongs in the runtime (`_instanceofResult`) or is subsumed by a broader value-rep change (the harness realm-split may itself need addressing).
+
+## Reground (2026-07-02, dev-2912f, task #22)
+
+Re-verified against current main (baseline `46e390c`-era jsonl + direct
+compile/run probes):
+
+**Cluster 1 — partially LANDED.** The realm-safe constructor recognition has
+merged: `S11.8.6_A2.1_T1` (the headline `var O = Object; ({}) instanceof O`)
+now **passes**. Still failing: `A2.4_T1`, `A2.4_T4`, `A6_T1`, `A6_T4`.
+
+**The codegen static-throw narrowing is NOT independently landable** —
+implemented and probe-tested this session, then deliberately reverted:
+
+- Mechanically correct: exempting reassignable (`var`/`let`/param/undeclared)
+  identifier RHS from the #2702 static throw keeps every currently-correct
+  shape correct (`var num = 100; x instanceof num` still throws — the runtime
+  `_instanceofResult` throws for genuine primitive targets; literal and
+  `const`-primitive RHS keep the static throw; `undefined`/`NaN`/`Infinity`
+  must stay static — a dynamic `undefined` target deliberately answers
+  `false`).
+- But it flips ZERO tests: in `A2.4_T1` (`var OBJECT = 0;
+(OBJECT = Object, {}) instanceof OBJECT`) the binding compiles to an
+  f64-typed local, the function value does not survive the `OBJECT = Object`
+  store, and the dynamic check receives a NUMBER → same TypeError, now from
+  the runtime. **The true blocker is value-rep widening of
+  primitive-initialized mutable bindings later assigned function values** —
+  exactly this issue's [SUBSTRATE] scope. Land the narrowing TOGETHER WITH
+  the widening, not before.
+- `A2.4_T4` (undeclared `OBJECT`): already routes dynamically (type `any`);
+  fails because the non-strict undeclared-global assignment/read path drops
+  the value (probe: returns `false`, expected `true`) — same substrate family.
+- `A6_T1` (`({}) instanceof this`, top-level `this === undefined`): dynamic
+  path answers `false` by the documented conservative-undefined rule in
+  `_instanceofResult`. Note the rule's justification ("`Function(...)` lowers
+  to undefined") is confirmed STALE (cluster 2 header) — tightening
+  undefined→TypeError on the dynamic path is plausible now but must be
+  regression-swept against everything relying on the conservative `false`.
+- `A6_T4`: case 2 (`instanceof Function` → false) passes; case 1
+  (`new MyFunct() instanceof MyFunct` with a plain function expression)
+  returns `false` — plain-function `.prototype`/proto-chain identity gap,
+  distinct from the realm work.
+
+**Cluster 2 — one incidental flip.** `S11.8.6_A7_T1` now passes;
+`S15.3.5.3_A2_T2/T5/T6`, `A3_T1/T2`, `S11.8.6_A7_T3` still fail (the
+`.prototype`-on-dynamic-Function trap stands).
+
+Issue stays open, architect-scoped, with the value-rep widening as the
+gating dependency for the cluster-1 residuals.

--- a/plan/issues/2765-instanceof-hard-residuals-proto-getter-and-undeclared-ref.md
+++ b/plan/issues/2765-instanceof-hard-residuals-proto-getter-and-undeclared-ref.md
@@ -4,7 +4,7 @@ title: "instanceof hard residuals: Function.prototype getter / WasmGC array prot
 status: ready
 sprint: Backlog
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-02
 priority: low
 horizon: l
 feasibility: hard
@@ -16,6 +16,7 @@ goal: core-semantics
 parent: 2740
 depends_on: []
 ---
+
 # #2765 — instanceof hard residuals (two unrelated deep gaps)
 
 Hard split of the #2740 umbrella — two distinct deep gaps grouped here per
@@ -25,10 +26,16 @@ semantics gaps. Verified on current `main` 2026-06-28.
 ## Cluster 4 — `Function.prototype` "prototype" getter + WasmGC array prototype chain
 
 `language/expressions/instanceof/prototype-getter-with-object.js`:
+
 ```js
-Object.defineProperty(Function.prototype, "prototype", { get() { return Array.prototype; } });
-var result = [] instanceof Function.prototype;   // expect true
+Object.defineProperty(Function.prototype, "prototype", {
+  get() {
+    return Array.prototype;
+  },
+});
+var result = [] instanceof Function.prototype; // expect true
 ```
+
 `Function.prototype` is itself callable; OrdinaryHasInstance must read its
 `prototype` (firing the installed getter → `Array.prototype`), then walk
 `[]`'s prototype chain and find `Array.prototype` → `true`. Requires (a) the
@@ -40,17 +47,20 @@ prototype-chain / accessor-on-builtin-proto gap.
 ## Cluster 5 — undeclared-global read should throw `ReferenceError`
 
 `language/expressions/instanceof/S11.8.6_A2.1_T3.js`:
+
 ```js
-({}) instanceof OBJECT;   // OBJECT undeclared → must throw ReferenceError
+({}) instanceof OBJECT; // OBJECT undeclared → must throw ReferenceError
 ```
+
 We treat an undeclared global read as `undefined`, so the instanceof returns
 `false` instead of throwing `ReferenceError`. This is a **broad, cross-cutting**
-semantic (it affects *every* undeclared identifier read, not just instanceof
+semantic (it affects _every_ undeclared identifier read, not just instanceof
 RHS) and is risky to change narrowly — scope carefully. May be wont-fix /
 deferred depending on the cost-benefit of strict undeclared-reference semantics
 in the WasmGC backend.
 
 ## Acceptance criteria
+
 - Cluster 4: `[] instanceof Function.prototype` with a `prototype` getter
   returning `Array.prototype` → `true`; the getter fires exactly once.
 - Cluster 5: `({}) instanceof <undeclared>` throws `ReferenceError`
@@ -59,5 +69,25 @@ in the WasmGC backend.
 - No regression in the 28 instanceof tests currently green.
 
 ## Notes
+
 - These are the two lowest-priority / hardest residuals of #2740; cluster 5 in
   particular may be deferred. Filed for tracking completeness.
+
+## Reground (2026-07-02, dev-2912f, task #22)
+
+Re-verified against current main (baseline jsonl + probes):
+
+- **Cluster 4 is RESOLVED on main**:
+  `language/expressions/instanceof/prototype-getter-with-object.js` now
+  **passes** (landed with the recent instanceof/prototype-chain work — the
+  `Function.prototype.prototype` getter fires and the WasmGC array reaches
+  `Array.prototype`). No work remains here.
+- **Cluster 5 still stands**: `S11.8.6_A2.1_T3` — `({}) instanceof OBJECT`
+  with undeclared `OBJECT` returns `false` instead of throwing
+  `ReferenceError` (probe-confirmed: undeclared reads still yield
+  `undefined`). Unchanged assessment: broad cross-cutting semantic, candidate
+  wont-fix; also interacts with #2763's undeclared-global assignment path
+  (`A2.4_T4` needs the non-strict CREATE-on-assign to work while the bare
+  read throws — the two must be designed together).
+
+This issue now tracks ONLY cluster 5.


### PR DESCRIPTION
Task #22 reconciliation of #2740's children against current main (per dispatch note that recent instanceof work may have covered some). #2764 was already `done` on main — no change.

## Reground findings (baseline jsonl + compile/run probes, main `46e390c`-era)

**#2763 (instanceof value-rep, [SUBSTRATE][ARCH]):**
- Cluster 1 partially LANDED: `S11.8.6_A2.1_T1` (the headline `var O = Object; ({}) instanceof O` realm case) now **passes**. `A2.4_T1/T4`, `A6_T1/T4` still fail.
- **The issue's 'codegen half' (narrow the #2702 static-throw for reassignable identifier RHS) is NOT independently landable** — implemented + probe-tested this session, then deliberately reverted: mechanically correct (never-reassigned primitive vars still throw via the runtime; `const`/literal/`undefined` keep the static throw; zero probe regressions) but it flips **zero** tests — `var OBJECT = 0` compiles to an f64 local, the reassigned `Object` does not survive the store, and the dynamic check receives a number → the same TypeError, just from the runtime. The true blocker is **value-rep widening of primitive-initialized mutable bindings later assigned function values** — exactly the issue's [SUBSTRATE] scope. Recorded: land the narrowing together with the widening.
- Fresh per-test notes: `A2.4_T4` (undeclared-global assign/read drops the value), `A6_T1` (conservative-undefined rule; its `Function(...)` justification confirmed stale), `A6_T4` case 1 (plain-function proto identity), cluster 2 (`A7_T1` flipped incidentally; the `.prototype`-on-dynamic-Function trap stands).

**#2765 (hard residuals):**
- **Cluster 4 RESOLVED on main** — `prototype-getter-with-object.js` passes. Issue now tracks only cluster 5 (`S11.8.6_A2.1_T3` undeclared-global ReferenceError; probe-confirmed live; candidate wont-fix; must be co-designed with #2763's `A2.4_T4` non-strict create-on-assign).

Both issues stay open (Backlog, architect-scoped) with the reground snapshots. Docs only; no compiler changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS