### PR TITLE
docs(#2138): claim-rate measurement addendum + reusable ir-first sweep script

### DIFF
--- a/plan/issues/2138-ir-first-compile-once-inversion.md
+++ b/plan/issues/2138-ir-first-compile-once-inversion.md
@@ -469,12 +469,12 @@ via `scripts/diff-test262.ts`.
 
 ### (a) test262 delta — js-host lane, 48,088 shared tests (official + proposals)
 
-| status | baseline (flag OFF) | flagged (IR-first ON) | delta |
-|---|---|---|---|
-| pass | 34,781 | 34,766 | **−15 (−0.031%)** |
-| fail | 12,534 | 12,537 | +3 |
-| compile_error | 576 | 591 | +15 |
-| compile_timeout | 83 | 80 | −3 |
+| status          | baseline (flag OFF) | flagged (IR-first ON) | delta             |
+| --------------- | ------------------- | --------------------- | ----------------- |
+| pass            | 34,781              | 34,766                | **−15 (−0.031%)** |
+| fail            | 12,534              | 12,537                | +3                |
+| compile_error   | 576                 | 591                   | +15               |
+| compile_timeout | 83                  | 80                    | −3                |
 
 15 regressions, 0 improvements, **0 wasm-identical noise, 0 ct-flakes** —
 all 15 are real compiler-output differences, and they collapse into exactly
@@ -600,3 +600,39 @@ before/after pairs. Run AFTER Trap-4 lands so measurements are clean.
 **Superseded branch:** `issue-2138-ir-first-slice1` (origin) — my
 unconditional-hoist Slice 1, superseded by the landed flag-conditional
 implementation (6ac915824). Safe to delete; its issue-file docs were ported.
+
+## Measurement addendum (sr-irfirst, 2026-07-02) — the claim-rate stat, measured
+
+Closes the one item the merge-reconciliation note above left open ("the
+claim-rate ask … remains open as a runner extension"): measured at sample
+scale WITHOUT a runner change, via `scripts/ir-first-sweep.mts` (committed
+with this addendum — compiles each corpus file twice, flag off/on, in one
+process, and reads `CompileResult.irFirstSkipped` directly).
+
+**Corpus:** all example files + stride-20 test262 sample = 2,671 files,
+compiled on `main@bcea34ed1` (INCLUDES gate 4, unlike the full CI run above —
+gate 4 is latent, so results are comparable). Raw JSON:
+`.tmp/slice3-sweep-backup.json` on the measurement branch; regenerate with
+`STRIDE=20 npx tsx scripts/ir-first-sweep.mts <checkout> <out.json>`.
+
+- **Claim/skip rate: 14 / 437 = 3.2%** of top-level FunctionDeclarations in
+  flag-off-compiling files (497 in all files). Low as expected — raw test262
+  is untyped sloppy-mode JS, so the TypeMap resolves few signatures. On the
+  TYPED corpus the rate is what matters: `benchmarks.ts` skips 4/4 of its
+  benchable functions (fib, bench_fib, bench_loop, bench_string).
+- **Compile-time: the compile-once dividend is real and visible exactly
+  where claims are dense** — same-process A/B (not cross-run CI lottery):
+  `benchmarks.ts` 4,977 → 2,499 ms (**−50%**), `fib.ts` 863 → 660 ms
+  (**−24%**). Aggregate over all 2,671 files: −1.2% (dominated by unclaimed
+  files; consistent with the full run's "no measurable aggregate change"
+  verdict).
+- **Divergences: ZERO in both directions** (2,258 flag-off-ok files all
+  flag-on-ok; no reverse flips). Consistent with the full run's finding that
+  the #2945 class is retired; the #2972 harness-function class does not
+  appear because this sweep compiles raw files without the test262 harness
+  prelude (the full run remains the authority on harness-exposed
+  divergences). Nothing new to file.
+- **Re-measure trigger:** after #2856's host arms land (gate 4 becomes
+  load-bearing) — rerun the sweep; the skip set should stay trap-free while
+  the claim rate rises. The suite-scale per-run stat still needs the small
+  runner extension (`irFirstSkipped` into the JSONL rows) if wanted.

--- a/scripts/ir-first-sweep.mts
+++ b/scripts/ir-first-sweep.mts
@@ -1,0 +1,117 @@
+// #2138 Slice 3 — compile-level measurement sweep (flag-on vs flag-off).
+// Usage: STRIDE=20 npx tsx .tmp/slice3-sweep.mts <compilerRoot> <outJson>
+//
+// For a deterministic stride-N sample of test262 (+ all example files), compile
+// each file twice — JS2WASM_IR_FIRST unset, then =1 — and record:
+//   - status parity (flag-on-only failures = divergences to file, the loud
+//     skipped-slot contract),
+//   - CompileResult.irFirstSkipped (per-file skipped function names),
+//   - top-level FunctionDeclaration count (denominator for the claim rate),
+//   - wall-clock compile time per mode (aggregate; single-process, so only
+//     the RATIO is meaningful, not absolute ms).
+import { readFileSync, readdirSync, lstatSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+
+const compilerRoot = process.argv[2]!;
+const outFile = process.argv[3]!;
+const { compile } = await import(pathToFileURL(join(compilerRoot, "src/index.ts")).href);
+
+const INPUT_ROOT = "/workspace";
+const STRIDE = Number(process.env.STRIDE ?? 20);
+
+function walk(root: string, ext: string): string[] {
+  const out: string[] = [];
+  const stack = [root];
+  while (stack.length) {
+    const dir = stack.pop()!;
+    let names: string[];
+    try {
+      names = readdirSync(dir);
+    } catch {
+      continue;
+    }
+    for (const name of names) {
+      const p = join(dir, name);
+      const s = lstatSync(p);
+      if (s.isSymbolicLink()) continue;
+      if (s.isDirectory()) stack.push(p);
+      else if (name.endsWith(ext) && !name.endsWith(".d.ts") && !name.includes("_FIXTURE")) out.push(p);
+    }
+  }
+  return out.sort();
+}
+
+const files = [
+  ...walk(join(INPUT_ROOT, "website/playground/examples"), ".ts"),
+  ...walk(join(INPUT_ROOT, "examples"), ".ts"),
+  ...walk(join(INPUT_ROOT, "test262/test"), ".js").filter((_, i) => i % STRIDE === 0),
+];
+
+function topLevelFnCount(src: string): number {
+  try {
+    const sf = ts.createSourceFile("m.ts", src, ts.ScriptTarget.ES2022, false);
+    let n = 0;
+    for (const s of sf.statements) if (ts.isFunctionDeclaration(s)) n++;
+    return n;
+  } catch {
+    return 0;
+  }
+}
+
+type Row = {
+  file: string;
+  fns: number;
+  off: { ok: boolean; ms: number };
+  on: { ok: boolean; ms: number; skipped: number };
+  divergence?: string; // first flag-on-only error
+  skippedNames?: string[];
+};
+
+async function compileOnce(src: string, flag: boolean): Promise<{ r: any; ms: number }> {
+  process.env.JS2WASM_IR_FIRST = flag ? "1" : "";
+  const t0 = performance.now();
+  let r: any;
+  try {
+    r = await compile(src, { fileName: "test.ts" });
+  } catch (e) {
+    r = { success: false, errors: [{ message: "throw: " + String(e instanceof Error ? e.message : e) }] };
+  }
+  return { r, ms: performance.now() - t0 };
+}
+
+const rows: Row[] = [];
+let done = 0;
+for (const f of files) {
+  const src = readFileSync(f, "utf-8");
+  const fns = topLevelFnCount(src);
+  const off = await compileOnce(src, false);
+  const on = await compileOnce(src, true);
+  const row: Row = {
+    file: f.replace(INPUT_ROOT, ""),
+    fns,
+    off: { ok: !!off.r.success, ms: Math.round(off.ms * 10) / 10 },
+    on: { ok: !!on.r.success, ms: Math.round(on.ms * 10) / 10, skipped: on.r.irFirstSkipped?.length ?? 0 },
+  };
+  if (on.r.irFirstSkipped?.length) row.skippedNames = on.r.irFirstSkipped;
+  if (off.r.success && !on.r.success) {
+    row.divergence = String(on.r.errors?.[0]?.message ?? "unknown").slice(0, 300);
+  }
+  rows.push(row);
+  if (++done % 200 === 0) process.stderr.write(`  ${done}/${files.length}\n`);
+}
+
+const agg = {
+  files: rows.length,
+  totalTopLevelFns: rows.reduce((a, r) => a + r.fns, 0),
+  totalSkipped: rows.reduce((a, r) => a + r.on.skipped, 0),
+  filesWithSkips: rows.filter((r) => r.on.skipped > 0).length,
+  offOk: rows.filter((r) => r.off.ok).length,
+  onOk: rows.filter((r) => r.on.ok).length,
+  divergences: rows.filter((r) => r.divergence).length,
+  offMsTotal: Math.round(rows.reduce((a, r) => a + r.off.ms, 0)),
+  onMsTotal: Math.round(rows.reduce((a, r) => a + r.on.ms, 0)),
+};
+writeFileSync(outFile, JSON.stringify({ agg, divergent: rows.filter((r) => r.divergence), rows }, null, 1));
+process.stderr.write(`done. agg=${JSON.stringify(agg)}\n`);


### PR DESCRIPTION
## Summary

Closes the one item #2138's merge-reconciliation note left open: the **claim-rate stat** (the #2949 north-star), measured at sample scale WITHOUT the runner extension.

- `scripts/ir-first-sweep.mts` (NEW, reusable): compiles a fixed corpus (all example files + stride-N test262 sample) twice per file — `JS2WASM_IR_FIRST` off/on, same process — and reads `CompileResult.irFirstSkipped` directly. Intended rerun trigger: after #2856's host arms land (gate 4 becomes load-bearing).
- Measurement addendum in `plan/issues/2138-…md` (stride-20, 2,671 files, `main@bcea34ed1` incl. gate 4):
  - **skip rate 14/437 (3.2%)** of top-level fns in compiling files (raw test262 is untyped, so low as expected; typed corpus: `benchmarks.ts` skips 4/4),
  - **compile-once dividend −50%** on claim-dense `benchmarks.ts` (4,977 → 2,499 ms same-process A/B; −24% on fib.ts; −1.2% aggregate),
  - **zero divergences in both directions** (2,258 ok-files parity; consistent with the full CI run's post-#2945 findings; #2972's harness-function class can't appear in raw-file compiles) — nothing new to file.

Docs + scripts only; no compiler changes. Issue stays `status: done` (closed by the full-run measurement, dev-2138f).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8