### PR TITLE
fix(#2981): reconcile tagged-template tests to spec-correct TemplateStringsArray

### DIFF
--- a/plan/issues/2981-tagged-template-strictness.md
+++ b/plan/issues/2981-tagged-template-strictness.md
@@ -1,0 +1,79 @@
+---
+id: 2981
+title: Tagged-template equivalence tests reconcile to spec-correct TemplateStringsArray param type
+status: done
+sprint: current
+priority: high
+horizon: m
+assignee: ttraenkler/opus-3
+completed: 2026-07-02
+---
+
+# #2981 — tagged-template equivalence tests: `string[]` → `TemplateStringsArray`
+
+## Problem (triage of TaskList #37)
+
+fable-6 flagged 11 tagged-template-literal equivalence tests in
+`tests/equivalence/ts-wasm-equivalence.test.ts` failing with COMPILE-ERROR on
+clean current main, suspected to be a recent (~30-PR) merge-wave regression.
+
+## Root cause — NOT a recent regression
+
+Bisected the exact repro (`function tag(strings: string[]) { return strings.raw[0] }`
+tagged with a template) against historical main:
+
+| commit base | date       | result |
+| ----------- | ---------- | ------ |
+| origin/main | 2026-07-02 | FAIL   |
+| main~30     | 2026-07-02 | FAIL   |
+| main~300    | 2026-06-28 | FAIL   |
+| main~1000   | 2026-06-17 | FAIL   |
+| main~1600   | 2026-06-03 | FAIL   |
+
+Fails identically back to at least June 3 — **not** a merge-wave regression.
+
+The tag-function signatures declared `strings: string[]`, but a tagged template
+call passes a `TemplateStringsArray` (`ReadonlyArray<string> & { raw }`), which is
+**not** assignable to a mutable `string[]`. The compiler surfaces the TS checker's
+diagnostics; `TS2345` (argument not assignable) has been a **hard** compile error
+since 2026-04-16 (`d8cfbb7a` — "fail on incompatible TypeScript annotations"
+removed 2345/2322 from `DOWNGRADE_DIAG_CODES`). The `.raw` cases additionally hit
+`TS2339` ("Property 'raw' does not exist on type 'string[]'"). The tests predate
+that tightening and were simply written with spec-incorrect types — real
+TypeScript rejects `function tag(strings: string[])` used as a template tag too.
+
+The compiler's own lowering is correct: `resolveWasmType` (src/codegen/index.ts
+~12430) already matches `TemplateStringsArray` and lowers it to the template-vec
+struct `{ length, data, raw }`.
+
+## Fix
+
+Reconcile the test tag-function signatures to the spec-correct
+`TemplateStringsArray` (and, where a tag returned the array, its return type and
+the receiving `eq`/`getTemplate`/local types). No compiler source change.
+
+Files touched (test-only):
+
+- `tests/equivalence/ts-wasm-equivalence.test.ts` (11 cases)
+- `tests/equivalence/iife-tagged-templates.test.ts` (5 cases)
+- `tests/equivalence/iife-and-call-expressions.test.ts` (3 cases)
+- `tests/issue-141.test.ts`
+- `tests/issue-229.test.ts`
+
+## Verification (output-diff, not assumption)
+
+`assertEquivalent` compiles each snippet to wasm AND runs the same source as the
+JS reference, comparing outputs. After the fix:
+
+- ts-wasm-equivalence: 29/29 pass (tagged-template block 13/13)
+- iife-tagged-templates: 5/5 pass
+- iife-and-call-expressions tagged-template block: 3/3 pass
+- issue-141 + issue-229: 22/22 pass
+
+## Follow-up (flagged to lead)
+
+`tests/iife-and-call-expressions.test.ts` and `tests/iife-tagged-templates.test.ts`
+at the repo root are stale duplicates of their `tests/equivalence/` counterparts
+with a broken `./helpers.js` import (helpers live at `tests/equivalence/helpers.ts`).
+They collect **0 tests** (never run). Candidate for deletion — left untouched here
+to keep this PR scoped to the failing lane.

--- a/tests/equivalence/iife-and-call-expressions.test.ts
+++ b/tests/equivalence/iife-and-call-expressions.test.ts
@@ -425,13 +425,13 @@ describe("IIFE and call expression edge cases", () => {
   it("tagged template literals — same call site returns same object across calls", async () => {
     await assertEquivalent(
       `
-      function eq(a: string[], b: string[]): number {
+      function eq(a: TemplateStringsArray, b: TemplateStringsArray): number {
         return a === b ? 1 : 0;
       }
-      function tag(strings: string[]): string[] {
+      function tag(strings: TemplateStringsArray): TemplateStringsArray {
         return strings;
       }
-      function getTemplate(): string[] {
+      function getTemplate(): TemplateStringsArray {
         return tag\`hello\`;
       }
       export function test1(): number {
@@ -447,10 +447,10 @@ describe("IIFE and call expression edge cases", () => {
   it("tagged template literals — different sites produce different objects", async () => {
     await assertEquivalent(
       `
-      function eq(a: string[], b: string[]): number {
+      function eq(a: TemplateStringsArray, b: TemplateStringsArray): number {
         return a === b ? 1 : 0;
       }
-      function tag(strings: string[]): string[] {
+      function tag(strings: TemplateStringsArray): TemplateStringsArray {
         return strings;
       }
       export function test1(): number {
@@ -466,13 +466,13 @@ describe("IIFE and call expression edge cases", () => {
   it("tagged template literals — same site caches even with different expression values", async () => {
     await assertEquivalent(
       `
-      function eq(a: string[], b: string[]): number {
+      function eq(a: TemplateStringsArray, b: TemplateStringsArray): number {
         return a === b ? 1 : 0;
       }
-      function tag(strings: string[], ...subs: number[]): string[] {
+      function tag(strings: TemplateStringsArray, ...subs: number[]): TemplateStringsArray {
         return strings;
       }
-      function getTemplate(x: number): string[] {
+      function getTemplate(x: number): TemplateStringsArray {
         return tag\`head\${x}tail\`;
       }
       export function test1(): number {

--- a/tests/equivalence/iife-tagged-templates.test.ts
+++ b/tests/equivalence/iife-tagged-templates.test.ts
@@ -6,7 +6,7 @@ describe("IIFE and call expression tagged templates", () => {
     await assertEquivalent(
       `
       export function test(): number {
-        return (function(strings: string[]): number {
+        return (function(strings: TemplateStringsArray): number {
           return strings.length;
         })\`hello\`;
       }
@@ -19,7 +19,7 @@ describe("IIFE and call expression tagged templates", () => {
     await assertEquivalent(
       `
       export function test(): number {
-        return (function(strings: string[], a: number, b: number): number {
+        return (function(strings: TemplateStringsArray, a: number, b: number): number {
           return strings.length + a + b;
         })\`hello \${10} world \${20}\`;
       }
@@ -32,7 +32,7 @@ describe("IIFE and call expression tagged templates", () => {
     await assertEquivalent(
       `
       export function test(): number {
-        return ((strings: string[]): number => strings.length)\`hello\`;
+        return ((strings: TemplateStringsArray): number => strings.length)\`hello\`;
       }
       `,
       [{ fn: "test", args: [] }],
@@ -42,8 +42,8 @@ describe("IIFE and call expression tagged templates", () => {
   it("call expression tagged template — function returning tag", async () => {
     await assertEquivalent(
       `
-      function makeTag(): (strings: string[]) => number {
-        return function(strings: string[]): number {
+      function makeTag(): (strings: TemplateStringsArray) => number {
+        return function(strings: TemplateStringsArray): number {
           return strings.length;
         };
       }
@@ -58,8 +58,8 @@ describe("IIFE and call expression tagged templates", () => {
   it("call expression tagged template — with substitutions", async () => {
     await assertEquivalent(
       `
-      function makeTag(): (strings: string[], val: number) => number {
-        return function(strings: string[], val: number): number {
+      function makeTag(): (strings: TemplateStringsArray, val: number) => number {
+        return function(strings: TemplateStringsArray, val: number): number {
           return val;
         };
       }

--- a/tests/equivalence/ts-wasm-equivalence.test.ts
+++ b/tests/equivalence/ts-wasm-equivalence.test.ts
@@ -393,7 +393,7 @@ describe("TS ↔ Wasm equivalence", () => {
   it("tagged template literals — basic", async () => {
     await assertEquivalent(
       `
-      function tag(strings: string[], a: number, b: number): number {
+      function tag(strings: TemplateStringsArray, a: number, b: number): number {
         return strings.length + a + b;
       }
       export function test1(): number {
@@ -407,7 +407,7 @@ describe("TS ↔ Wasm equivalence", () => {
   it("tagged template literals — no substitutions", async () => {
     await assertEquivalent(
       `
-      function tag(strings: string[]): number {
+      function tag(strings: TemplateStringsArray): number {
         return strings.length;
       }
       export function test1(): number {
@@ -421,7 +421,7 @@ describe("TS ↔ Wasm equivalence", () => {
   it("tagged template literals — rest params", async () => {
     await assertEquivalent(
       `
-      function tag(strings: string[], ...values: number[]): number {
+      function tag(strings: TemplateStringsArray, ...values: number[]): number {
         return strings.length + values.length;
       }
       export function test1(): number {
@@ -441,7 +441,7 @@ describe("TS ↔ Wasm equivalence", () => {
   it("tagged template literals — string content access", async () => {
     await assertEquivalent(
       `
-      function first(strings: string[]): string {
+      function first(strings: TemplateStringsArray): string {
         return strings[0];
       }
       export function test1(): string {
@@ -455,7 +455,7 @@ describe("TS ↔ Wasm equivalence", () => {
   it("tagged template literals — substitution values", async () => {
     await assertEquivalent(
       `
-      function sum(strings: string[], a: number, b: number): number {
+      function sum(strings: TemplateStringsArray, a: number, b: number): number {
         return a + b;
       }
       export function test1(): number {
@@ -471,7 +471,7 @@ describe("TS ↔ Wasm equivalence", () => {
   it("tagged template literals — multiple string parts concatenated", async () => {
     await assertEquivalent(
       `
-      function tag(strings: string[], a: number): string {
+      function tag(strings: TemplateStringsArray, a: number): string {
         return strings[0] + String(a) + strings[1];
       }
       export function test1(): string {
@@ -485,7 +485,7 @@ describe("TS ↔ Wasm equivalence", () => {
   it("tagged template literals — return substitution directly", async () => {
     await assertEquivalent(
       `
-      function identity(strings: string[], val: number): number {
+      function identity(strings: TemplateStringsArray, val: number): number {
         return val;
       }
       export function test1(): number {
@@ -499,7 +499,7 @@ describe("TS ↔ Wasm equivalence", () => {
   it("tagged template literals — string parts count with expressions", async () => {
     await assertEquivalent(
       `
-      function tag(strings: string[], a: number, b: number, c: number): number {
+      function tag(strings: TemplateStringsArray, a: number, b: number, c: number): number {
         return strings.length;
       }
       export function test1(): number {
@@ -513,7 +513,7 @@ describe("TS ↔ Wasm equivalence", () => {
   it("tagged template literals — excess substitutions dropped", async () => {
     await assertEquivalent(
       `
-      function tag(strings: string[]): number {
+      function tag(strings: TemplateStringsArray): number {
         return strings.length;
       }
       export function test1(): number {
@@ -527,7 +527,7 @@ describe("TS ↔ Wasm equivalence", () => {
   it("tagged template literals — empty leading string part", async () => {
     await assertEquivalent(
       `
-      function first(strings: string[]): string {
+      function first(strings: TemplateStringsArray): string {
         return strings[0];
       }
       export function test1(): string {
@@ -541,7 +541,7 @@ describe("TS ↔ Wasm equivalence", () => {
   it("tagged template literals — raw property access", async () => {
     await assertEquivalent(
       `
-      function tag(strings: string[]): string {
+      function tag(strings: TemplateStringsArray): string {
         return strings.raw[0];
       }
       export function test1(): string {
@@ -555,7 +555,7 @@ describe("TS ↔ Wasm equivalence", () => {
   it("tagged template literals — raw vs cooked escape sequences", async () => {
     await assertEquivalent(
       `
-      function tag(strings: string[]): string {
+      function tag(strings: TemplateStringsArray): string {
         return strings.raw[0];
       }
       export function test1(): string {
@@ -569,7 +569,7 @@ describe("TS ↔ Wasm equivalence", () => {
   it("tagged template literals — raw length matches cooked length", async () => {
     await assertEquivalent(
       `
-      function tag(strings: string[], a: number): number {
+      function tag(strings: TemplateStringsArray, a: number): number {
         return strings.raw.length;
       }
       export function test1(): number {

--- a/tests/issue-141.test.ts
+++ b/tests/issue-141.test.ts
@@ -5,7 +5,7 @@ import { buildImports, compileToWasm } from "./equivalence/helpers.js";
 describe("Issue #141: Tagged template literal runtime failures", () => {
   it("basic tagged template with two substitutions", async () => {
     const e = await compileToWasm(`
-      function tag(strings: string[], a: number, b: number): number {
+      function tag(strings: TemplateStringsArray, a: number, b: number): number {
         return strings.length + a + b;
       }
       export function test(): number {
@@ -18,7 +18,7 @@ describe("Issue #141: Tagged template literal runtime failures", () => {
 
   it("tagged template with no substitutions", async () => {
     const e = await compileToWasm(`
-      function tag(strings: string[]): number {
+      function tag(strings: TemplateStringsArray): number {
         return strings.length;
       }
       export function test(): number {
@@ -30,7 +30,7 @@ describe("Issue #141: Tagged template literal runtime failures", () => {
 
   it("tagged template with rest params collects all substitutions", async () => {
     const e = await compileToWasm(`
-      function tag(strings: string[], ...values: number[]): number {
+      function tag(strings: TemplateStringsArray, ...values: number[]): number {
         return strings.length + values.length;
       }
       export function test(): number {
@@ -43,7 +43,7 @@ describe("Issue #141: Tagged template literal runtime failures", () => {
 
   it("tagged template with rest params and zero substitutions", async () => {
     const e = await compileToWasm(`
-      function tag(strings: string[], ...values: number[]): number {
+      function tag(strings: TemplateStringsArray, ...values: number[]): number {
         return strings.length + values.length;
       }
       export function test(): number {
@@ -56,7 +56,7 @@ describe("Issue #141: Tagged template literal runtime failures", () => {
 
   it("excess substitutions beyond declared params are dropped", async () => {
     const e = await compileToWasm(`
-      function tag(strings: string[]): number {
+      function tag(strings: TemplateStringsArray): number {
         return strings.length;
       }
       export function test(): number {
@@ -70,7 +70,7 @@ describe("Issue #141: Tagged template literal runtime failures", () => {
 
   it("returns substitution value directly", async () => {
     const e = await compileToWasm(`
-      function identity(strings: string[], val: number): number {
+      function identity(strings: TemplateStringsArray, val: number): number {
         return val;
       }
       export function test(): number {
@@ -82,7 +82,7 @@ describe("Issue #141: Tagged template literal runtime failures", () => {
 
   it("substitution expressions with variables", async () => {
     const e = await compileToWasm(`
-      function sum(strings: string[], a: number, b: number): number {
+      function sum(strings: TemplateStringsArray, a: number, b: number): number {
         return a + b;
       }
       export function test(): number {
@@ -96,7 +96,7 @@ describe("Issue #141: Tagged template literal runtime failures", () => {
 
   it("string content access from first element", async () => {
     const e = await compileToWasm(`
-      function first(strings: string[]): string {
+      function first(strings: TemplateStringsArray): string {
         return strings[0];
       }
       export function test(): string {
@@ -108,7 +108,7 @@ describe("Issue #141: Tagged template literal runtime failures", () => {
 
   it("string parts count with multiple expressions", async () => {
     const e = await compileToWasm(`
-      function tag(strings: string[], a: number, b: number, c: number): number {
+      function tag(strings: TemplateStringsArray, a: number, b: number, c: number): number {
         return strings.length;
       }
       export function test(): number {
@@ -120,7 +120,7 @@ describe("Issue #141: Tagged template literal runtime failures", () => {
 
   it("empty leading string part when expression comes first", async () => {
     const e = await compileToWasm(`
-      function first(strings: string[]): string {
+      function first(strings: TemplateStringsArray): string {
         return strings[0];
       }
       export function test(): string {
@@ -133,7 +133,7 @@ describe("Issue #141: Tagged template literal runtime failures", () => {
 
   it("concatenating string parts with substitution", async () => {
     const e = await compileToWasm(`
-      function tag(strings: string[], a: number): string {
+      function tag(strings: TemplateStringsArray, a: number): string {
         return strings[0] + String(a) + strings[1];
       }
       export function test(): string {
@@ -147,7 +147,7 @@ describe("Issue #141: Tagged template literal runtime failures", () => {
     const e = await compileToWasm(`
       let callCount: number = 0;
 
-      function tag(strings: string[]): number {
+      function tag(strings: TemplateStringsArray): number {
         callCount = callCount + 1;
         return strings.length + callCount;
       }
@@ -164,7 +164,7 @@ describe("Issue #141: Tagged template literal runtime failures", () => {
 
   it("tagged template called multiple times with different values", async () => {
     const e = await compileToWasm(`
-      function tag(strings: string[], val: number): number {
+      function tag(strings: TemplateStringsArray, val: number): number {
         return val * 2;
       }
       export function test(): number {
@@ -179,7 +179,7 @@ describe("Issue #141: Tagged template literal runtime failures", () => {
 
   it("substitution with arithmetic expression", async () => {
     const e = await compileToWasm(`
-      function tag(strings: string[], val: number): number {
+      function tag(strings: TemplateStringsArray, val: number): number {
         return val;
       }
       export function test(): number {
@@ -191,7 +191,7 @@ describe("Issue #141: Tagged template literal runtime failures", () => {
 
   it("tag function with one param beyond strings accepts first sub only", async () => {
     const e = await compileToWasm(`
-      function tag(strings: string[], first: number): number {
+      function tag(strings: TemplateStringsArray, first: number): number {
         return first;
       }
       export function test(): number {

--- a/tests/issue-229.test.ts
+++ b/tests/issue-229.test.ts
@@ -4,7 +4,7 @@ import { compileToWasm, assertEquivalent } from "./equivalence/helpers";
 describe("Issue #229: Tagged template cache", () => {
   it("basic tagged template does not crash", async () => {
     const exports = await compileToWasm(`
-      function tag(strings: string[]): number {
+      function tag(strings: TemplateStringsArray): number {
         return 42;
       }
       export function test(): number {
@@ -17,13 +17,13 @@ describe("Issue #229: Tagged template cache", () => {
   it("tagged template called multiple times returns cached template object", async () => {
     await assertEquivalent(
       `
-      function eq(a: string[], b: string[]): number {
+      function eq(a: TemplateStringsArray, b: TemplateStringsArray): number {
         return a === b ? 1 : 0;
       }
-      function tag(strings: string[]): string[] {
+      function tag(strings: TemplateStringsArray): TemplateStringsArray {
         return strings;
       }
-      function getTemplate(): string[] {
+      function getTemplate(): TemplateStringsArray {
         return tag\`hello\`;
       }
       export function test(): number {
@@ -39,7 +39,7 @@ describe("Issue #229: Tagged template cache", () => {
   it("different call sites produce different template objects", async () => {
     await assertEquivalent(
       `
-      function tag(strings: string[]): string[] {
+      function tag(strings: TemplateStringsArray): TemplateStringsArray {
         return strings;
       }
       export function test(): number {
@@ -55,10 +55,10 @@ describe("Issue #229: Tagged template cache", () => {
   it("same site caches even with different expression values", async () => {
     await assertEquivalent(
       `
-      function tag(strings: string[], ...subs: number[]): string[] {
+      function tag(strings: TemplateStringsArray, ...subs: number[]): TemplateStringsArray {
         return strings;
       }
-      function getTemplate(x: number): string[] {
+      function getTemplate(x: number): TemplateStringsArray {
         return tag\`head\${x}tail\`;
       }
       export function test(): number {
@@ -73,7 +73,7 @@ describe("Issue #229: Tagged template cache", () => {
 
   it("tagged template in a loop does not crash (array bounds)", async () => {
     const exports = await compileToWasm(`
-      function tag(strings: string[]): number {
+      function tag(strings: TemplateStringsArray): number {
         return 1;
       }
       export function test(): number {
@@ -90,13 +90,13 @@ describe("Issue #229: Tagged template cache", () => {
   it("same call site across multiple function calls returns cached ref", async () => {
     await assertEquivalent(
       `
-      function eq(a: string[], b: string[]): number {
+      function eq(a: TemplateStringsArray, b: TemplateStringsArray): number {
         return a === b ? 1 : 0;
       }
-      function tag(strings: string[]): string[] {
+      function tag(strings: TemplateStringsArray): TemplateStringsArray {
         return strings;
       }
-      function getIt(): string[] {
+      function getIt(): TemplateStringsArray {
         return tag\`cached\`;
       }
       export function test(): number {
@@ -109,7 +109,7 @@ describe("Issue #229: Tagged template cache", () => {
 
   it("tagged template with late string constant (bool-to-string) does not crash", async () => {
     const exports = await compileToWasm(`
-      function tag(strings: string[]): number {
+      function tag(strings: TemplateStringsArray): number {
         return 1;
       }
       export function test(): number {


### PR DESCRIPTION
## Summary

Triage of TaskList #37: 11 tagged-template equivalence tests were failing with COMPILE-ERROR on clean main, suspected recent regression. **Bisected — it is NOT a recent merge-wave regression**; the exact repro fails identically back to at least June 3 (~1600 commits).

**Root cause:** the test tag-function signatures declared `strings: string[]`, but a tagged template call passes a `TemplateStringsArray` (`ReadonlyArray<string> & { raw }`), which is not assignable to a mutable `string[]`. `TS2345` has been a hard compile error since 2026-04-16 (`d8cfbb7a`) and `.raw` access hits `TS2339`. The tests predate that tightening and were simply written with spec-incorrect types — real TypeScript rejects them too. The compiler already lowers `TemplateStringsArray` correctly (`resolveWasmType`, `src/codegen/index.ts`).

**Fix (test-only, no compiler change):** reconcile the tag signatures — and array return/receiver types where the tag returns the template object — to the spec-correct `TemplateStringsArray`.

## Files
- `tests/equivalence/ts-wasm-equivalence.test.ts` (11 cases)
- `tests/equivalence/iife-tagged-templates.test.ts` (5 cases)
- `tests/equivalence/iife-and-call-expressions.test.ts` (3 cases)
- `tests/issue-141.test.ts`, `tests/issue-229.test.ts`
- `plan/issues/2981-tagged-template-strictness.md` (status: done)

## Verification (output-diff, not assumption)
`assertEquivalent` compiles each snippet to wasm AND runs the same source as the JS reference, comparing outputs:
- ts-wasm-equivalence 29/29 (tagged-template block 13/13)
- iife-tagged-templates 5/5, iife-and-call-expressions tagged block 3/3
- issue-141 + issue-229 22/22

## Follow-up (not in this PR)
`tests/iife-and-call-expressions.test.ts` and `tests/iife-tagged-templates.test.ts` at the repo root are stale duplicates with a broken `./helpers.js` import (helpers live at `tests/equivalence/helpers.ts`) — they collect 0 tests. Candidate for deletion; left untouched to keep scope tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8