### PR TITLE
fix(#2982): tagged-template string[] first-param false-positive TS2345

### DIFF
--- a/plan/issues/2982-tagged-template-string-array-param-hard-error.md
+++ b/plan/issues/2982-tagged-template-string-array-param-hard-error.md
@@ -1,0 +1,83 @@
+---
+id: 2982
+title: "Tagged-template regression: `strings: string[]` first-param trips a fatal TS2345 (idiomatic tag fns fail to compile)"
+status: done
+completed: 2026-07-02
+assignee: ttraenkler/opus-4
+sprint: current
+created: 2026-07-02
+updated: 2026-07-02
+priority: high
+horizon: m
+feasibility: medium
+task_type: fix
+---
+
+## Problem
+
+11 tagged-template-literal equivalence tests (plus the whole
+`tests/issue-141.test.ts` tagged-template suite) fail to compile on clean main.
+Surfaced by fable-6 during #2965 validation, framed as a "recent merge-wave
+regression."
+
+A tag function declared with an idiomatic first parameter:
+
+```ts
+function tag(strings: string[], a: number, b: number): number { ... }
+tag`hello ${10} world ${20}`;
+```
+
+fails compilation with:
+
+```
+Argument of type 'TemplateStringsArray' is not assignable to parameter of type 'string[]'.
+```
+
+## Root cause (bisected)
+
+Not a recent-wave regression — **latent since 2026-04-17**. `git bisect`
+pinpointed **`d8cfbb7a7` "fix(compiler): fail on incompatible TypeScript
+annotations"**, which added TS **2345** to `HARD_TS_DIAG_CODES` in
+`src/compiler.ts`. fable-6 merely surfaced it while running the equivalence
+suite on a clean base.
+
+A tagged template implicitly passes a `TemplateStringsArray` (ECMA-262 §13.2.8.4
+GetTemplateObject — a frozen `ReadonlyArray<string> & { raw }`) as the tag's
+first argument. TS rejects assigning that to a **mutable** `string[]` parameter,
+so every such call trips TS2345. Before d8cfbb7a7 that diagnostic was non-fatal,
+so these programs compiled (as they do at runtime — the tag simply receives an
+array of strings). The gate promoted it to a hard error, breaking a runtime-
+correct, idiomatic pattern used throughout the corpus.
+
+## Fix
+
+Fix forward (not a test edit — `strings: string[]` is idiomatic, runtime-correct
+user code that compiled for months). Added a tightly-scoped false-positive
+suppressor `isTaggedTemplateStringsArrayFalsePositive` in `src/compiler.ts`,
+wired into `isHardTypeScriptDiagnostic` alongside the existing
+`isProxyHandlerTrapDiagnostic` / `isInOperatorOperandDiagnostic` / `#862`
+downgrades of "TS stricter than ES runtime semantics."
+
+Downgrades a 2345 to a warning **only** when ALL hold:
+
+1. it sits inside a `TaggedTemplateExpression`;
+2. its diagnostic **source type is literally `TemplateStringsArray`** — i.e. the
+   synthesized first (template-object) argument, NOT a `${…}` substitution
+   argument (TS checks arg0 first and, when `string[]` is annotated, reports that
+   and never reaches substitutions; when arg0 is well-typed a substitution error
+   surfaces with its own source type, e.g. `string`, and stays fatal); and
+3. the resolved first parameter is an array / readonly-array whose element type
+   is string-like (`string` / string-literal / `any` / `unknown`) — so
+   `number[]` first params stay a hard error.
+
+## Test Results
+
+- `tests/issue-2982.test.ts` (new): 5/5 pass — 3 positive (`string[]`,
+  `readonly string[]`, `.raw` access) + 2 negative (`number[]` first param and a
+  genuine substitution mismatch both stay fatal TS2345).
+- `tests/equivalence/ts-wasm-equivalence.test.ts` "tagged template" subset: 13/13
+  pass (previously 11 compile-errors).
+- `tests/issue-141.test.ts` tagged-template suite: all pass.
+
+Runtime equivalence (wasm ↔ js) verified — the change only downgrades a
+compile-gate false positive; codegen was already lowering these tag calls.

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -515,10 +515,84 @@ function isInOperatorOperandDiagnostic(diag: ts.Diagnostic): boolean {
   return false;
 }
 
+/**
+ * (#2982) A tagged template `tag`…`` implicitly passes a `TemplateStringsArray`
+ * (ECMA-262 §13.2.8.4 GetTemplateObject — a frozen Array carrying a `.raw`
+ * sibling) as the tag function's FIRST argument. TypeScript models this as
+ * `ReadonlyArray<string> & { raw }`, which is NOT assignable to a mutable
+ * `string[]` parameter, so a tag declared `function tag(strings: string[], …)`
+ * trips TS2345 at every call site. That is a TypeScript-strictness artifact, not
+ * a runtime incompatibility: at runtime the tag simply receives an array of
+ * strings, so annotating the first parameter `string[]` (or `readonly string[]`)
+ * is runtime-accurate and idiomatic (it is the dominant convention across the
+ * tagged-template corpus — tests/issue-141, the equivalence suite, etc.). The
+ * codegen lowers tag calls regardless of the first-parameter annotation, so the
+ * program is well-formed. Downgrade the 2345 so it compiles. Mirrors the
+ * #2616 / #2741 / #862 downgrades of TS being stricter than ES runtime semantics.
+ *
+ * Tightly scoped — suppress ONLY when ALL hold:
+ *   1. the diagnostic is a 2345 inside a TaggedTemplateExpression; and
+ *   2. its SOURCE type is literally `TemplateStringsArray` — i.e. it is the
+ *      synthesized first (template-object) argument that mismatches, NOT a
+ *      `${…}` substitution argument. TS checks arg0 first and, when `string[]`
+ *      is annotated, reports that mismatch and never reaches the substitutions,
+ *      so a substitution error surfaces only when arg0 is well-typed — in which
+ *      case its source type is the substitution's own type (e.g. `string`), not
+ *      `TemplateStringsArray`, and stays fatal; and
+ *   3. the tag's resolved first parameter is an array / readonly-array whose
+ *      element type is string-like (string, string-literal, any, or unknown) —
+ *      so `function tag(strings: number[], …)` (source `TemplateStringsArray`,
+ *      target `number[]`) remains a hard error.
+ */
+function isStringLikeType(type: ts.Type): boolean {
+  const parts = type.isUnion() ? type.types : [type];
+  return (
+    parts.length > 0 &&
+    parts.every(
+      (t) => !!(t.flags & (ts.TypeFlags.String | ts.TypeFlags.StringLiteral | ts.TypeFlags.Any | ts.TypeFlags.Unknown)),
+    )
+  );
+}
+
+function isArrayOfStringLike(type: ts.Type, checker: ts.TypeChecker): boolean {
+  // Array<T>, ReadonlyArray<T>, T[], readonly T[], and string-tuples all expose a
+  // numeric index signature; its element type must be string-like.
+  const parts = type.isUnion() ? type.types : [type];
+  if (parts.length === 0) return false;
+  for (const t of parts) {
+    const elem = checker.getIndexTypeOfType(t, ts.IndexKind.Number);
+    if (!elem || !isStringLikeType(elem)) return false;
+  }
+  return true;
+}
+
+function isTaggedTemplateStringsArrayFalsePositive(diag: ts.Diagnostic, checker: ts.TypeChecker): boolean {
+  if (diag.code !== 2345) return false;
+  const file = diag.file;
+  if (!file || diag.start === undefined) return false;
+  const node = findSmallestNodeAtPosition(file, diag.start);
+  if (!node) return false;
+  let tt: ts.Node | undefined = node;
+  while (tt && !ts.isTaggedTemplateExpression(tt)) tt = tt.parent;
+  if (!tt || !ts.isTaggedTemplateExpression(tt)) return false;
+  // The source type must be the synthesized `TemplateStringsArray` (arg0), not a
+  // `${…}` substitution argument — otherwise a genuine substitution type error
+  // (source e.g. `string`) would be masked. See the doc comment above.
+  const firstLine = ts.flattenDiagnosticMessageText(diag.messageText, "\n").split("\n")[0] ?? "";
+  if (!firstLine.startsWith("Argument of type 'TemplateStringsArray'")) return false;
+  const sig = checker.getResolvedSignature(tt);
+  if (!sig) return false;
+  const params = sig.getParameters();
+  if (params.length === 0) return false;
+  const p0Type = checker.getTypeOfSymbolAtLocation(params[0]!, tt);
+  return isArrayOfStringLike(p0Type, checker);
+}
+
 function isHardTypeScriptDiagnostic(diag: ts.Diagnostic, checker?: ts.TypeChecker): boolean {
   if (diag.category !== 1 || !HARD_TS_DIAG_CODES.has(diag.code)) return false;
   if (checker && isBindingPatternFalsePositive(diag, checker)) return false;
   if (checker && isGuardedNullablePrimitiveDiagnostic(diag, checker)) return false;
+  if (checker && isTaggedTemplateStringsArrayFalsePositive(diag, checker)) return false;
   if (isProxyHandlerTrapDiagnostic(diag)) return false;
   if (isInOperatorOperandDiagnostic(diag)) return false;
   return true;

--- a/tests/issue-2982.test.ts
+++ b/tests/issue-2982.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+/**
+ * #2982 — regression: a tag function whose first parameter is annotated
+ * `string[]` (or `readonly string[]`) must compile.
+ *
+ * A tagged template implicitly passes a `TemplateStringsArray`
+ * (ECMA-262 §13.2.8.4 — a frozen `ReadonlyArray<string> & { raw }`) as the
+ * tag's first argument. TypeScript rejects assigning that to a mutable
+ * `string[]` parameter (TS2345), but at runtime the tag simply receives an
+ * array of strings, so `string[]` is a runtime-accurate, idiomatic annotation.
+ * The Apr-17 "fail on incompatible TypeScript annotations" gate (d8cfbb7a7)
+ * promoted TS2345 to a fatal error, which broke this idiomatic pattern (used
+ * across tests/issue-141 and the equivalence suite). The compiler now downgrades
+ * exactly this false positive.
+ */
+describe("Issue #2982: tagged-template `string[]` first-param must compile", () => {
+  it("compiles a tag fn with `strings: string[]` and two substitutions", async () => {
+    const e = await compileToWasm(`
+      function tag(strings: string[], a: number, b: number): number {
+        return strings.length + a + b;
+      }
+      export function test(): number {
+        return tag\`hello \${10} world \${20}\`;
+      }
+    `);
+    // 3 string parts + 10 + 20
+    expect(e.test()).toBe(33);
+  });
+
+  it("compiles a tag fn with `strings: readonly string[]`", async () => {
+    const e = await compileToWasm(`
+      function tag(strings: readonly string[], a: number): number {
+        return strings.length + a;
+      }
+      export function test(): number {
+        return tag\`a \${5} b\`;
+      }
+    `);
+    // 2 string parts + 5
+    expect(e.test()).toBe(7);
+  });
+
+  it("still lowers `.raw` access on a `string[]`-annotated tag fn", async () => {
+    const e = await compileToWasm(`
+      function tag(strings: string[]): string {
+        return strings.raw[0];
+      }
+      export function test(): string {
+        return tag\`hello world\`;
+      }
+    `);
+    expect(e.test()).toBe("hello world");
+  });
+
+  // ── Negatives: the downgrade must stay tightly scoped ──────────────────────
+
+  it("KEEPS a hard error for a `number[]` first param (wrong element type)", async () => {
+    const r = await compile(
+      `
+      function tag(strings: number[]): number {
+        return strings.length;
+      }
+      export function test(): number {
+        return tag\`x\`;
+      }
+    `,
+      { fileName: "t.ts" },
+    );
+    expect(r.success).toBe(false);
+    expect(r.errors?.some((e) => e.code === 2345)).toBe(true);
+  });
+
+  it("KEEPS a hard error for a genuine substitution-argument type mismatch", async () => {
+    // First param correctly typed, so the arg0 shadow error is gone and the
+    // real `string`→`number` substitution mismatch must surface fatally.
+    const r = await compile(
+      `
+      function tag(strings: TemplateStringsArray, n: number): number {
+        return n;
+      }
+      const s = "x";
+      export function test(): number {
+        return tag\`a \${s} b\`;
+      }
+    `,
+      { fileName: "t.ts" },
+    );
+    expect(r.success).toBe(false);
+    expect(r.errors?.some((e) => e.code === 2345)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

11 tagged-template equivalence tests + the whole `tests/issue-141.test.ts` tagged-template suite fail to compile on clean main. Idiomatic tag functions:

```ts
function tag(strings: string[], a: number, b: number): number { ... }
tag`hi ${10} w ${20}`;
```

fail with `Argument of type 'TemplateStringsArray' is not assignable to parameter of type 'string[]'` (TS2345).

## Root cause (bisected)

Not a recent-wave regression — **latent since 2026-04-17**. `git bisect` pinpointed **d8cfbb7a7 "fix(compiler): fail on incompatible TypeScript annotations"**, which added TS2345 to `HARD_TS_DIAG_CODES`. A tagged template implicitly passes a `TemplateStringsArray` (frozen `ReadonlyArray<string> & { raw }`, ECMA-262 §13.2.8.4), not assignable to a mutable `string[]` — a TS-strictness artifact, not a runtime incompatibility. Before that gate the diagnostic was non-fatal, so these compiled (as they do at runtime).

## Fix

Fix forward (not test edits — `string[]` is idiomatic, runtime-correct code). Added `isTaggedTemplateStringsArrayFalsePositive` to `src/compiler.ts`, wired into `isHardTypeScriptDiagnostic` next to the existing #2616/#2741/#862 downgrades. Downgrades a 2345 **only** when: (1) inside a TaggedTemplateExpression; (2) its source type is literally `TemplateStringsArray` (the arg0 template-object, not a `${…}` substitution); and (3) the resolved first parameter is a string-like array. So `number[]` first params and genuine substitution mismatches stay fatal.

## Tests

- `tests/issue-2982.test.ts` (new): 5/5 — 3 positive + 2 tight-scoping negatives (`number[]` param and a genuine substitution mismatch both stay fatal 2345).
- equivalence tagged-template subset: 13/13 (was 11 compile-errors).
- `tests/issue-141.test.ts` tagged-template suite: green.

Runtime equivalence (wasm ↔ js) verified; codegen already lowered these tag calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8