### PR TITLE
docs(#38): file #2965 descriptor-cluster follow-up issues (#2984-#2989)

### DIFF
--- a/plan/issues/2965-standalone-dynamic-descriptor-cluster.md
+++ b/plan/issues/2965-standalone-dynamic-descriptor-cluster.md
@@ -120,10 +120,15 @@ flagged to the lead, out of scope here.)
   miscompiles) — the test262 runner wraps bodies in `test()`, so the corpus
   barely exercises it, but the playground/diff lanes do.
 
-## Follow-ups (from the triage — not filed as issues yet)
+## Follow-ups (from the triage — filed as issues, #38)
 
-- gOPD-on-builtin (~178): extend #2861/#2863/#2896 `__builtinfn_gopd` machinery
-- arguments-object defineProperty MOP (~82, #2667 lineage)
-- boxed-wrapper receivers (~18) · global-object receivers (~10, needs #2907)
-- missing spec TypeErrors (~32: array length, non-extensible)
-- `__obj_find` illegal-cast on residual dynamic non-string keys (2 files)
+- **#2984** gOPD-on-builtin (~178): extend #2861/#2863/#2896 `__builtinfn_gopd`
+  machinery
+- **#2985** defineProperties 5-b/6-a slab residual (~250: array/arguments own-prop
+  MOP + accessor fidelity + destructive `verifyProperty`); folds in the
+  `__obj_find` illegal-cast on residual dynamic non-string keys (2 files)
+- **#2986** arguments-object defineProperty MOP (~82, #2667 lineage)
+- **#2987** boxed-wrapper receivers (~18)
+- **#2988** global-object receivers (~10, blocked on #2907)
+- **#2989** missing spec TypeErrors (~32: array length, non-extensible,
+  non-configurable redefine)

--- a/plan/issues/2984-standalone-gopd-on-builtin-descriptor-mop.md
+++ b/plan/issues/2984-standalone-gopd-on-builtin-descriptor-mop.md
@@ -1,0 +1,43 @@
+---
+id: 2984
+title: "Standalone gOPD-on-builtin descriptor MOP (~178: getOwnPropertyDescriptor on builtin objects / proto receivers)"
+status: ready
+sprint: Backlog
+priority: high
+horizon: l
+feasibility: hard
+area: codegen, runtime
+goal: standalone-mode
+related: [2965, 2861, 2863, 2896]
+origin: "#2965 descriptor-cluster triage — follow-up class 1"
+---
+
+# #2984 — standalone gOPD-on-builtin descriptor MOP
+
+## Problem
+
+Follow-up from #2965 (descriptor cluster). `getOwnPropertyDescriptor` on a
+builtin object or builtin-prototype receiver fails on the standalone lane:
+~178 tests (60 CE resolving `__get_builtin` + 118 fail). Example:
+`Object.getOwnPropertyDescriptor(Array.prototype, "forEach")` must return a
+data descriptor whose `.value` is the builtin method value, but the standalone
+lane has no builtin-object meta-object protocol to answer it — the dynamic
+`__getOwnPropertyDescriptor` native returns `undefined`, so `.value`/attribute
+reads throw.
+
+## Scope / mechanism
+
+- gOPD against builtin constructors and their `.prototype` objects (Array,
+  Object, String, Function, etc.).
+- Descriptor `.value` must be the method's function value; `writable`,
+  `enumerable`, `configurable` per spec (builtin methods: `w:true, e:false,
+c:true`).
+- Overlaps and should extend the `__builtinfn_gopd` machinery introduced by
+  #2861/#2863/#2896 rather than build a parallel path.
+
+## Acceptance
+
+- gOPD on builtin/proto receivers returns spec-correct descriptors on the
+  standalone lane; host lane unchanged (byte-inert on gc/host).
+- Measured flip count on the `built-ins/Object/getOwnPropertyDescriptor`
+  standalone subset with zero regressions on a passing-test sweep.

--- a/plan/issues/2985-standalone-defineproperties-slab-residual.md
+++ b/plan/issues/2985-standalone-defineproperties-slab-residual.md
@@ -1,0 +1,43 @@
+---
+id: 2985
+title: "Standalone defineProperties 5-b/6-a slab residual (~250: array/arguments own-prop MOP + accessor attribute fidelity + destructive verifyProperty)"
+status: ready
+sprint: Backlog
+priority: high
+horizon: l
+feasibility: hard
+area: codegen, runtime
+goal: standalone-mode
+related: [2965, 2667]
+origin: "#2965 descriptor-cluster triage — follow-up class 2 (typeof sub-cause already FIXED in #2965)"
+---
+
+# #2985 — standalone defineProperties 5-b/6-a slab residual
+
+## Problem
+
+Follow-up from #2965. The `defineProperties` 5-b/6-a slab (~300 tests) is a
+mixed bucket. #2965 fixed the materialized-`typeof` sub-cause (the
+`ref.null.extern` stub); the remaining ~250 need distinct MOP work:
+
+- **array / arguments own-property MOP** — defineProperty(ies) on array indices
+  and `length` with full attribute semantics.
+- **accessor-attribute fidelity** — get/set descriptor round-trips through
+  define → gOPD must preserve accessor identity and attribute flags.
+- **destructive `verifyProperty`** — test262's `verifyProperty` mutates then
+  restores the property; the standalone MOP must survive the
+  define→delete→redefine cycle.
+
+Also folds in the `__obj_find` illegal-cast on residual dynamic non-string keys
+(2 files) noted in the #2965 triage.
+
+## Acceptance
+
+- Measured flip count on the `built-ins/Object/defineProperties` standalone
+  subset, per sub-class, with zero regressions on a passing-test sweep.
+- gc/host lane byte-inert (standalone-gated).
+
+## Notes
+
+Likely wants slicing (array-index MOP, accessor fidelity, verifyProperty
+survival) into separate PRs — hard/large.

--- a/plan/issues/2986-standalone-arguments-object-defineproperty-mop.md
+++ b/plan/issues/2986-standalone-arguments-object-defineproperty-mop.md
@@ -1,0 +1,35 @@
+---
+id: 2986
+title: "Standalone defineProperty on mapped arguments object (~82, #2667 lineage)"
+status: ready
+sprint: Backlog
+priority: medium
+horizon: m
+feasibility: hard
+area: codegen, runtime
+goal: standalone-mode
+related: [2965, 2667]
+origin: "#2965 descriptor-cluster triage — follow-up class 3 (arguments-object receivers)"
+---
+
+# #2986 — standalone defineProperty on mapped arguments object
+
+## Problem
+
+Follow-up from #2965. ~82 tests do `defineProperty` on a (mapped) `arguments`
+object and fail on the standalone lane. The arguments-object receiver has no
+own-property MOP on standalone, so the define is dropped or throws opaquely.
+Continues the #2667 arguments lineage.
+
+## Scope / mechanism
+
+- `Object.defineProperty(arguments, k, desc)` with data and accessor
+  descriptors.
+- Mapped-arguments semantics: for a mapped index, redefining as a data
+  descriptor with `configurable:false` / accessor breaks the parameter map per
+  spec (10.4.4 `[[DefineOwnProperty]]`).
+
+## Acceptance
+
+- Measured flip count on the arguments-object defineProperty standalone subset
+  with zero regressions on a passing-test sweep; gc/host byte-inert.

--- a/plan/issues/2987-standalone-boxed-wrapper-defineproperty.md
+++ b/plan/issues/2987-standalone-boxed-wrapper-defineproperty.md
@@ -1,0 +1,35 @@
+---
+id: 2987
+title: "Standalone defineProperty / gOPD on boxed-wrapper receivers (~18: new String/Number/Boolean)"
+status: ready
+sprint: Backlog
+priority: medium
+horizon: m
+feasibility: medium
+area: codegen, runtime
+goal: standalone-mode
+related: [2965, 1629]
+origin: "#2965 descriptor-cluster triage — follow-up class 4 (boxed-wrapper receivers)"
+---
+
+# #2987 — standalone defineProperty / gOPD on boxed-wrapper receivers
+
+## Problem
+
+Follow-up from #2965. ~18 tests do `defineProperty` / `getOwnPropertyDescriptor`
+on a boxed wrapper (`new String(...)`, `new Number(...)`, `new Boolean(...)`)
+and fail on standalone — the wrapper receiver has no own-property MOP, and for
+`new String` the exotic indexed own-properties (`"0".."n-1"` + `length`, all
+`w:false, e:true, c:false`) are not modeled.
+
+## Scope / mechanism
+
+- defineProperty on boxed Number/Boolean wrappers (ordinary own-prop MOP on the
+  wrapper struct).
+- `new String` exotic string-index own properties per spec (10.4.3) for both
+  gOPD and defineProperty (redefining an index must respect non-configurability).
+
+## Acceptance
+
+- Measured flip count on the boxed-wrapper defineProperty/gOPD standalone subset
+  with zero regressions; gc/host byte-inert.

--- a/plan/issues/2988-standalone-global-object-defineproperty.md
+++ b/plan/issues/2988-standalone-global-object-defineproperty.md
@@ -1,0 +1,34 @@
+---
+id: 2988
+title: "Standalone defineProperty on the global object (~10, blocked on #2907 global carriers)"
+status: blocked
+sprint: Backlog
+priority: low
+horizon: m
+feasibility: hard
+area: codegen, runtime
+goal: standalone-mode
+depends_on: [2907]
+related: [2965, 2907]
+origin: "#2965 descriptor-cluster triage — follow-up class 5 (global-object receivers)"
+---
+
+# #2988 — standalone defineProperty on the global object
+
+## Problem
+
+Follow-up from #2965. ~10 tests do `defineProperty` on the global object
+(top-level `this`) and fail on standalone. This needs the global-property
+carrier infrastructure tracked in #2907 — without a real global-object MOP
+there is no own-property slot to define onto.
+
+## Status
+
+**Blocked on #2907** (standalone global carriers). Re-open to `ready` once
+#2907 lands the global carrier substrate.
+
+## Acceptance
+
+- After #2907: `Object.defineProperty(this, k, desc)` at top level defines a
+  global own property observable by later reads / gOPD; measured flip count with
+  zero regressions; gc/host byte-inert.

--- a/plan/issues/2989-standalone-defineproperty-missing-spec-typeerrors.md
+++ b/plan/issues/2989-standalone-defineproperty-missing-spec-typeerrors.md
@@ -1,0 +1,35 @@
+---
+id: 2989
+title: "Standalone defineProperty missing spec TypeErrors (~32: array length, non-extensible, non-configurable redefine)"
+status: ready
+sprint: Backlog
+priority: medium
+horizon: s
+feasibility: medium
+area: codegen, runtime
+goal: standalone-mode
+related: [2965, 2962]
+origin: "#2965 descriptor-cluster triage — follow-up class 6 (assert.throws(TypeError) missing)"
+---
+
+# #2989 — standalone defineProperty missing spec TypeErrors
+
+## Problem
+
+Follow-up from #2965. ~32 tests assert that `defineProperty` (or an operation
+gated by it) throws a `TypeError` in a spec-mandated case, but the standalone
+lane does not throw:
+
+- defining/growing an array `length` past a non-writable barrier,
+- defining a new property on a non-extensible object,
+- redefining a non-configurable property with an incompatible descriptor.
+
+These are missing-throw failures (the operation silently succeeds or no-ops
+instead of throwing). Note the payload opacity itself is #2962's scope; here the
+issue is the _absence_ of the throw, not its stringifiability.
+
+## Acceptance
+
+- The three spec-mandated TypeError sites throw on the standalone lane; measured
+  flip count on the standalone defineProperty throw-assertion subset with zero
+  regressions; gc/host byte-inert.


### PR DESCRIPTION
## Summary

TaskList #38: file the ~600 remaining standalone descriptor-cluster fails from the **#2965** triage table as tracked issues, one per construct class. Plan-only; no source change.

| issue | class | count | notes |
| ----- | ----- | ----- | ----- |
| #2984 | gOPD-on-builtin descriptor MOP | ~178 | extends #2861/#2863/#2896 `__builtinfn_gopd` |
| #2985 | defineProperties 5-b/6-a slab residual | ~250 | array/arguments own-prop MOP + accessor fidelity + destructive `verifyProperty`; folds in `__obj_find` illegal-cast (2 files) |
| #2986 | arguments-object defineProperty MOP | ~82 | #2667 lineage |
| #2987 | boxed-wrapper receivers | ~18 | `new String/Number/Boolean` |
| #2988 | global-object receivers | ~10 | **blocked on #2907** |
| #2989 | missing spec TypeErrors | ~32 | array length, non-extensible, non-configurable redefine |

Also cross-links the filed issues back into #2965's follow-up section (which previously said "not filed as issues yet").

Ids allocated via `claim-issue.mjs --allocate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8