### PR TITLE
fix(#2973): eval sub-compiles opt out of JS2WASM_IR_FIRST

### DIFF
--- a/plan/issues/2973-eval-subcompile-inherits-ir-first-swallows-error.md
+++ b/plan/issues/2973-eval-subcompile-inherits-ir-first-swallows-error.md
@@ -1,7 +1,9 @@
 ---
 id: 2973
 title: "eval-shim sub-compiles inherit JS2WASM_IR_FIRST and swallow its hard errors — silent `undefined` instead of fail-loud"
-status: ready
+status: done
+assignee: ttraenkler/dev-2973
+completed: 2026-07-02
 sprint: current
 created: 2026-07-02
 updated: 2026-07-02
@@ -63,3 +65,37 @@ visible failures; the shim's contract is graceful fallback.
 - Sub-compile opt-out is structural (options-based), not ambient env
   mutation, OR documented why env save/restore is safe (single-threaded
   compile path).
+
+## Resolution (2026-07-02)
+
+Structural options-based opt-out, not ambient env mutation:
+
+- Added `disableIrFirst?: boolean` to `CompileOptions` (`src/index.ts`) and the
+  backend `CodegenOptions` (`src/codegen/context/types.ts`), threaded through
+  `buildCodegenOptions` (`src/compiler.ts`).
+- `generateModule` (`src/codegen/index.ts`) now computes
+  `irFirst = experimentalIR && !disableIrFirst && truthyEnv(JS2WASM_IR_FIRST)`
+  — the opt-out disables ONLY the fail-loud skip-body inversion; the ordinary
+  IR overlay (`experimentalIR`) is untouched.
+- Both `compileSourceSync` sub-compiles in `runtime-eval.ts` (expression-form
+  and statement-form wrappers) pass `disableIrFirst: true`. These are the only
+  in-process sub-compile sites in the tree today (the env.ts `new Function` is
+  host-side introspection, not a compiler sub-compile; #2924's compile-away is
+  not yet a sub-compile site — the `CompileOptions` doc notes it for forward
+  compat).
+
+Byte-inert for default builds: `disableIrFirst` only short-circuits a boolean
+already gated on `truthyEnv(JS2WASM_IR_FIRST)`, which default/CI compiles never
+set — so no test262 baseline movement.
+
+## Test Results
+
+`tests/issue-2973.test.ts` — 4/4 pass:
+
+- flag-off `eval("5+1|0===0")` = 7 (control)
+- flag-ON `eval("5+1|0===0")` = 7 (was `undefined` before the fix)
+- flag-on result === flag-off result
+- unit: same wrapper compiles `success=false` under flag-on without the opt-out,
+  `success=true` with `disableIrFirst: true`
+
+Measured on origin/main @ 1062b8b38.

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -97,6 +97,15 @@ export interface CodegenOptions {
    */
   experimentalIR?: boolean;
   /**
+   * (#2973) Opt out of the `JS2WASM_IR_FIRST` compile-once inversion for this
+   * compile, regardless of the ambient env flag. Set by semantics-critical
+   * in-process sub-compiles (the `eval` / `new Function` host shims) so an
+   * IR-first post-claim hard error there is not swallowed by the shim's
+   * fallback `catch` and silently turned into `undefined`. Leaves the ordinary
+   * IR overlay (`experimentalIR`) untouched. Default: false.
+   */
+  disableIrFirst?: boolean;
+  /**
    * #2089 — count silent codegen fallbacks via `reportSilentFallback` and, when
    * set, surface each as a warning diagnostic. Used by
    * `scripts/check-codegen-fallbacks.ts`. Default off (counts are still kept;

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1700,7 +1700,12 @@ export function generateModule(
     // an `unreachable` placeholder that the IR overlay MUST overwrite (a
     // post-claim IR failure on a skipped function is promoted to a hard
     // compile error below, never a silent legacy demote).
-    const irFirst = !!options?.experimentalIR && truthyEnv(process.env.JS2WASM_IR_FIRST);
+    // (#2973) `disableIrFirst` opts a compile out of the IR-first inversion
+    // regardless of the ambient env flag — semantics-critical sub-compiles
+    // (eval / new Function host shims) set it so a post-claim IR-first hard
+    // error is not swallowed by the shim's fallback catch into a silent
+    // `undefined`. The ordinary IR overlay (`experimentalIR`) still runs.
+    const irFirst = !!options?.experimentalIR && !options?.disableIrFirst && truthyEnv(process.env.JS2WASM_IR_FIRST);
     let irPlan: IrOverlayPlan | null = null;
     let irSkipBodies: ReadonlySet<string> | undefined;
     if (irFirst) {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -734,6 +734,10 @@ function buildCodegenOptions(
     // revert. Forwarded to ALL drivers now (#1927); `generateMultiModule`
     // ignores it until #2138 wires the IR overlay into the multi generator.
     experimentalIR: options.experimentalIR !== false,
+    // (#2973) Forward the IR-first opt-out. The eval / new Function host shims
+    // set this so a post-claim IR-first hard error in a sub-compile is not
+    // swallowed by the shim's fallback catch into a silent wrong answer.
+    disableIrFirst: options.disableIrFirst === true,
     // Single-source-only import-preprocessing results (undefined in multi mode).
     // #1927: multi paths do not yet collect node-builtin / fs / jsx imports —
     // they resolve imports through the TS program; closing that gap is a

--- a/src/index.ts
+++ b/src/index.ts
@@ -275,6 +275,18 @@ export interface CompileOptions {
    * direct-emission path (bit-by-bit divergence tests or emergency revert).
    */
   experimentalIR?: boolean;
+  /**
+   * (#2973) Opt this compile out of the `JS2WASM_IR_FIRST` compile-once
+   * inversion, regardless of the ambient env flag. Semantics-critical
+   * in-process sub-compiles — the `eval` / `new Function` host shims — MUST
+   * set this: they are a proven fast path, not an IR-first *measurement*
+   * target, and an IR-first post-claim hard error there is swallowed by the
+   * shim's fallback `catch` arms and silently degraded to `undefined` (a wrong
+   * answer, not a fail-loud error). Only the fail-loud skip-body inversion is
+   * disabled; the ordinary IR overlay (`experimentalIR`) is untouched.
+   * Default: false.
+   */
+  disableIrFirst?: boolean;
   /** Compile-time constant definitions. Substitutes identifiers/dotted paths with literal values
    *  before TypeScript parsing. Example: `{ "process.env.NODE_ENV": '"production"' }`.
    *  Values must be valid JS expression literals (strings need inner quotes).

--- a/src/runtime-eval.ts
+++ b/src/runtime-eval.ts
@@ -214,6 +214,12 @@ export function createEvalShim(options: EvalShimOptions = {}): (src: any, isDire
         fileName: filename,
         allowJs: true,
         skipSemanticDiagnostics: true,
+        // (#2973) This is a semantics-critical fast path, not an IR-first
+        // measurement target. Under JS2WASM_IR_FIRST a claim-partial residual
+        // in the eval'd expression turns into a post-claim hard error, which
+        // the `catch` below swallows — silently degrading a correct answer to
+        // `undefined`. Always take the proven legacy-then-overlay pipeline.
+        disableIrFirst: true,
       });
     } catch {
       result = undefined;
@@ -227,6 +233,8 @@ export function createEvalShim(options: EvalShimOptions = {}): (src: any, isDire
           fileName: filename,
           allowJs: true,
           skipSemanticDiagnostics: true,
+          // (#2973) Same opt-out as the expression-form wrapper above.
+          disableIrFirst: true,
         });
       } catch (e: any) {
         // Compiler crashed — surface as SyntaxError to mimic JS eval.

--- a/tests/issue-2973.test.ts
+++ b/tests/issue-2973.test.ts
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #2973 — eval-shim sub-compiles must NOT inherit JS2WASM_IR_FIRST.
+//
+// `runtime-eval.ts` wraps the eval'd source in a top-level FunctionDeclaration
+// and calls `compileSourceSync`. That sub-compile used to inherit the ambient
+// `JS2WASM_IR_FIRST` flag. Under the flag, an eval'd expression with a
+// claim-partial type residual (e.g. the mixed f64/i32 `|` in `5+1|0===0`)
+// turns into a post-claim IR-first HARD compile error — which the shim's
+// fallback `catch` arms swallow, silently degrading a correct result (`7`) to
+// `undefined`. That is the exact silent-wrong-answer class the #2138 inversion
+// exists to eliminate.
+//
+// The fix threads a structural `disableIrFirst` opt-out through the compile
+// options so sub-compiles always take the proven legacy-then-overlay pipeline,
+// independent of the ambient env flag.
+import { describe, it, expect, afterEach } from "vitest";
+import { createEvalShim } from "../src/runtime-eval.js";
+import { compileSourceSync } from "../src/compiler.js";
+
+const IR_FIRST = "JS2WASM_IR_FIRST";
+
+/** Run `body` with JS2WASM_IR_FIRST forced to `val`, restoring the prior value. */
+function withIrFirst<T>(val: string | undefined, body: () => T): T {
+  const prev = process.env[IR_FIRST];
+  if (val === undefined) delete process.env[IR_FIRST];
+  else process.env[IR_FIRST] = val;
+  try {
+    return body();
+  } finally {
+    if (prev === undefined) delete process.env[IR_FIRST];
+    else process.env[IR_FIRST] = prev;
+  }
+}
+
+describe("#2973 eval sub-compile does not inherit JS2WASM_IR_FIRST", () => {
+  afterEach(() => {
+    delete process.env[IR_FIRST];
+  });
+
+  // The canonical divergence from #2138's full flagged run: a claim-partial
+  // residual (mixed f64/i32 `|`). `5+1|0===0` === `6 | (0===0)` === `6 | 1` === 7.
+  const evalSrc = "5+1|0===0";
+  const expected = 7;
+
+  it("flag-off eval returns the correct value (control)", () => {
+    const shim = createEvalShim();
+    const v = withIrFirst("0", () => shim(evalSrc, 0));
+    expect(v).toBe(expected);
+  });
+
+  it("flag-ON eval returns the SAME value — no silent undefined", () => {
+    const shim = createEvalShim();
+    const v = withIrFirst("1", () => shim(evalSrc, 0));
+    // Before the fix this was `undefined` (the swallowed hard error).
+    expect(v).toBe(expected);
+  });
+
+  it("flag-on result equals flag-off result", () => {
+    const shim = createEvalShim();
+    const off = withIrFirst("0", () => shim(evalSrc, 0));
+    const on = withIrFirst("1", () => shim(evalSrc, 0));
+    expect(on).toBe(off);
+  });
+
+  // Unit-level proof of the opt-out mechanism: the same claim-partial wrapper
+  // that fails to compile under flag-on WITHOUT the opt-out compiles
+  // successfully WITH `disableIrFirst: true`.
+  it("disableIrFirst opts the sub-compile out of the IR-first inversion", () => {
+    const wrapper = `export function __eval_result() { return (${evalSrc}); }`;
+    withIrFirst("1", () => {
+      const withoutOptOut = compileSourceSync(wrapper, {
+        fileName: "eval.ts",
+        allowJs: true,
+        skipSemanticDiagnostics: true,
+      });
+      expect(withoutOptOut.success).toBe(false); // baseline: IR-first hard error
+
+      const withOptOut = compileSourceSync(wrapper, {
+        fileName: "eval.ts",
+        allowJs: true,
+        skipSemanticDiagnostics: true,
+        disableIrFirst: true,
+      });
+      expect(withOptOut.success).toBe(true); // opt-out restores legacy fallback
+    });
+  });
+});


### PR DESCRIPTION
## Problem (#2973)

The `eval` host shim wraps eval'd source in a top-level FunctionDeclaration and calls `compileSourceSync`, which **inherited the ambient `JS2WASM_IR_FIRST` flag**. Under the flag, an eval'd expression with a claim-partial type residual (mixed f64/i32 `|` in `5+1|0===0`) becomes a post-claim IR-first **hard compile error** — which the shim's fallback `catch` arms swallow, silently degrading a correct result (`7`) to `undefined`.

This was the single `pass → fail` runtime wrong-answer in #2138's full flagged test262 run (`S12.4_A2_T2.js`) and the ONLY divergence violating the fail-loud contract — exactly the silent-wrong-answer class the #2138 inversion exists to eliminate. Flag-on-only today, but it must not survive into any default-on rollout.

## Fix

Structural, options-based opt-out (not ambient env mutation):

- `disableIrFirst?: boolean` added to `CompileOptions` (`src/index.ts`) and `CodegenOptions` (`src/codegen/context/types.ts`), threaded through `buildCodegenOptions` (`src/compiler.ts`) to `generateModule`.
- `irFirst = experimentalIR && !disableIrFirst && truthyEnv(JS2WASM_IR_FIRST)` — disables ONLY the fail-loud skip-body inversion; the ordinary IR overlay (`experimentalIR`) is untouched.
- Both `compileSourceSync` sub-compiles in `runtime-eval.ts` pass `disableIrFirst: true`. These are the only in-process sub-compile sites today (the `env.ts` `new Function` is host introspection, not a compiler sub-compile).

## Byte-inertness

Byte-inert for default builds: the new guard only short-circuits a boolean already gated on `truthyEnv(JS2WASM_IR_FIRST)`, which default/CI compiles never set — no test262 baseline movement expected.

## Tests

`tests/issue-2973.test.ts` — 4/4 pass:
- flag-off `eval("5+1|0===0")` = 7 (control)
- flag-ON = 7 (was `undefined` before the fix)
- flag-on === flag-off
- unit: same wrapper `success=false` under flag-on without opt-out, `success=true` with `disableIrFirst: true`

Typecheck clean. Measured on origin/main @ 1062b8b38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)