### PR TITLE
refactor(#2953): route ref-cell family through the BackendEmitter trait

### DIFF
--- a/plan/issues/2953-backend-emitter-pushraw-gap.md
+++ b/plan/issues/2953-backend-emitter-pushraw-gap.md
@@ -1,7 +1,8 @@
 ---
 id: 2953
 title: "Close the BackendEmitter pushRaw gap: route unions/closures/refcells/coercions/null/funcref through the trait"
-status: ready
+status: in-progress
+assignee: ttraenkler/opus-1a
 sprint: current
 created: 2026-07-02
 updated: 2026-07-02
@@ -60,3 +61,23 @@ value/aggregate families.
 - Byte-identical output on the 233-file corpus; equivalence green.
 - `emitBox`/`emitUnbox`/`emitTagLoad`/`emitNull`/`emitFuncRef` + closure
   and refcell methods implemented on WasmGcEmitter with unit coverage.
+
+## Slice progress (one PR per family)
+
+- [x] **(a5) ref-cell family** — `emitRefCellNew`/`emitRefCellGet`/`emitRefCellSet`
+  promoted from declared-optional to REQUIRED on `BackendEmitter`, implemented
+  byte-identically on `WasmGcEmitter` (struct.new / struct.get / struct.set over
+  the cell's typeIdx/fieldIdx), stubbed (`notImplemented`/throw) on Linear +
+  Bytecode emitters, and the 3 `refcell.new/get/set` pushRaw sites in `lower.ts`
+  converted to trait calls. pushRaw in lower.ts: 77 → 74. Golden-Instr unit
+  coverage added (`tests/ir-backend-emitter.test.ts`); cross-backend + closure
+  runtime suites green. (opus-1a)
+- [ ] unions/boxing (`emitBox`/`emitUnbox`/`emitTagLoad`) — note the box arm
+  interleaves an emitter-synthesized tag const with the caller's value push by
+  field order; needs a small orchestration decision (tag const stays
+  emitter-owned for the backend-agnostic tag encoding).
+- [ ] closures (`emitClosureNew`/`emitClosureFuncGet`/`emitCaptureGet`)
+- [ ] coercions/null (`emitNull`/`emitToExternref`/`emitFromExternref`)
+- [ ] funcref (`emitFuncRef`)
+- [ ] Promise ops
+- [ ] ratchet: pushRaw count check + `// pushraw-ok(#issue)` justification tag

--- a/src/ir/backend/bytecode-emitter.ts
+++ b/src/ir/backend/bytecode-emitter.ts
@@ -670,4 +670,17 @@ export class BytecodeEmitter implements BackendEmitter<BytecodeSink> {
   emitVecNewFixed(): void {
     throw new Error("BytecodeEmitter: vec primitives not in the #1584 numeric subset — see §2a struct/object family.");
   }
+
+  // ---- (a5) ref-cell family (#2953) — a 1-field mutable struct. Not yet wired
+  // into the VM heap model; a future wiring mirrors the (a2) struct family
+  // (STRUCT_NEW fieldCount=1 / STRUCT_GET|SET fieldIdx=0).
+  emitRefCellNew(): void {
+    throw new Error("BytecodeEmitter: ref-cell ops not yet wired — see §2a struct/object family (STRUCT_NEW).");
+  }
+  emitRefCellGet(): void {
+    throw new Error("BytecodeEmitter: ref-cell ops not yet wired — see §2a struct/object family (STRUCT_GET).");
+  }
+  emitRefCellSet(): void {
+    throw new Error("BytecodeEmitter: ref-cell ops not yet wired — see §2a struct/object family (STRUCT_SET).");
+  }
 }

--- a/src/ir/backend/emitter.ts
+++ b/src/ir/backend/emitter.ts
@@ -169,9 +169,6 @@ export interface BackendEmitter<S = Instr[]> {
   emitClosureNew?(layout: IrClosureLowering, captureCount: number, out: Instr[]): void;
   emitClosureFuncGet?(layout: IrClosureLowering, out: Instr[]): void;
   emitCaptureGet?(layout: IrClosureLowering, index: number, out: Instr[]): void;
-  emitRefCellNew?(layout: IrRefCellLowering, out: Instr[]): void;
-  emitRefCellGet?(layout: IrRefCellLowering, out: Instr[]): void;
-  emitRefCellSet?(layout: IrRefCellLowering, out: Instr[]): void;
 
   // ---- (a1) call family — MIGRATED behind the trait (#1584 §2a) -----------
   // The first op-family to move from inline `lower.ts` pushes to typed trait
@@ -215,4 +212,20 @@ export interface BackendEmitter<S = Instr[]> {
    * into their own sinks (built via `newSink()`). `catches[i].tagIdx` selects
    * the handler by exception tag. */
   emitTry(blockType: BlockType, body: S, catches: { tagIdx: number; body: S }[], catchAll: S | undefined, out: S): void;
+
+  // ---- (a5) ref-cell family — MIGRATED behind the trait (#2953) ------------
+  // Mutable closure-capture cells (`struct (field $value (mut T))`). WasmGc
+  // realizes them byte-identically to the prior inline pushes in the
+  // refcell.new/get/set arms of lower.ts ({op:"struct.new"} / {op:"struct.get"}
+  // / {op:"struct.set"} over the cell's typeIdx/fieldIdx) — the WasmGC `Instr`
+  // stream is unchanged. A ref-cell is structurally a 1-field mutable struct, so
+  // a future bytecode/linear wiring mirrors the (a2) struct family
+  // (STRUCT_NEW fieldCount=1 / STRUCT_GET|SET fieldIdx=0); until then those
+  // backends fail loudly, exactly like the other not-yet-wired families.
+  /** value on the stack -> a new ref-cell holding it. */
+  emitRefCellNew(layout: IrRefCellLowering, out: S): void;
+  /** cell ref on the stack -> the cell's stored value. */
+  emitRefCellGet(layout: IrRefCellLowering, out: S): void;
+  /** cell ref + value on the stack -> writes the cell's value (void). */
+  emitRefCellSet(layout: IrRefCellLowering, out: S): void;
 }

--- a/src/ir/backend/linear-emitter.ts
+++ b/src/ir/backend/linear-emitter.ts
@@ -212,4 +212,14 @@ export class LinearEmitter implements BackendEmitter<Instr[]> {
   emitCallRef(): void {
     notImplemented("emitCallRef");
   }
+  // (a5) ref-cell family (#2953) — out of the #1714 vec-proof scope.
+  emitRefCellNew(): void {
+    notImplemented("emitRefCellNew");
+  }
+  emitRefCellGet(): void {
+    notImplemented("emitRefCellGet");
+  }
+  emitRefCellSet(): void {
+    notImplemented("emitRefCellSet");
+  }
 }

--- a/src/ir/backend/wasmgc-emitter.ts
+++ b/src/ir/backend/wasmgc-emitter.ts
@@ -19,7 +19,7 @@ import { emitConstInstr } from "../lower.js";
 import type { IrBinop, IrInstr, IrUnop } from "../nodes.js";
 import type { BlockType, Instr } from "../types.js";
 import type { BackendEmitter } from "./emitter.js";
-import type { IrClassLowering, IrObjectStructLowering, IrVecLowering } from "./handles.js";
+import type { IrClassLowering, IrObjectStructLowering, IrRefCellLowering, IrVecLowering } from "./handles.js";
 
 export class WasmGcEmitter implements BackendEmitter<Instr[]> {
   readonly backend = "wasmgc" as const;
@@ -219,6 +219,23 @@ export class WasmGcEmitter implements BackendEmitter<Instr[]> {
       catches,
       ...(catchAll ? { catchAll } : {}),
     });
+  }
+
+  // ---- (a5) ref-cell family (#2953) — byte-identical to the prior inline
+  // `out.push({op:"struct.new"/"struct.get"/"struct.set"...})` in the
+  // refcell.new/get/set arms of lower.ts. The WasmGC stream is unchanged; this
+  // moves the push behind the trait so a second backend can realize the same
+  // intent (a 1-field mutable struct) as STRUCT_NEW / STRUCT_GET / STRUCT_SET.
+  emitRefCellNew(layout: IrRefCellLowering, out: Instr[]): void {
+    out.push({ op: "struct.new", typeIdx: layout.typeIdx });
+  }
+
+  emitRefCellGet(layout: IrRefCellLowering, out: Instr[]): void {
+    out.push({ op: "struct.get", typeIdx: layout.typeIdx, fieldIdx: layout.fieldIdx });
+  }
+
+  emitRefCellSet(layout: IrRefCellLowering, out: Instr[]): void {
+    out.push({ op: "struct.set", typeIdx: layout.typeIdx, fieldIdx: layout.fieldIdx });
   }
 }
 

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -1301,7 +1301,9 @@ export function lowerIrFunctionBody<S>(
           throw new Error(`ir/lower: resolver cannot lower refcell<${inner.kind}> (${func.name})`);
         }
         emitValue(instr.value, out);
-        emitter.pushRaw(out, { op: "struct.new", typeIdx: cell.typeIdx });
+        // (a5) ref-cell family (#2953): route through emitRefCellNew —
+        // byte-identical {op:"struct.new"} on WasmGC.
+        emitter.emitRefCellNew(cell, out);
         return;
       }
       case "refcell.get": {
@@ -1316,11 +1318,9 @@ export function lowerIrFunctionBody<S>(
           throw new Error(`ir/lower: resolver cannot lower refcell<${getInner.kind}> (${func.name})`);
         }
         emitValue(instr.cell, out);
-        emitter.pushRaw(out, {
-          op: "struct.get",
-          typeIdx: cell.typeIdx,
-          fieldIdx: cell.fieldIdx,
-        });
+        // (a5) ref-cell family (#2953): route through emitRefCellGet —
+        // byte-identical {op:"struct.get"} on WasmGC.
+        emitter.emitRefCellGet(cell, out);
         return;
       }
       case "refcell.set": {
@@ -1336,11 +1336,9 @@ export function lowerIrFunctionBody<S>(
         }
         emitValue(instr.cell, out);
         emitValue(instr.value, out);
-        emitter.pushRaw(out, {
-          op: "struct.set",
-          typeIdx: cell.typeIdx,
-          fieldIdx: cell.fieldIdx,
-        });
+        // (a5) ref-cell family (#2953): route through emitRefCellSet —
+        // byte-identical {op:"struct.set"} on WasmGC.
+        emitter.emitRefCellSet(cell, out);
         return;
       }
       // Slice 4 (#1169d): class ops.

--- a/tests/ir-backend-emitter.test.ts
+++ b/tests/ir-backend-emitter.test.ts
@@ -13,7 +13,7 @@
 import { describe, expect, it } from "vitest";
 
 import { WasmGcEmitter } from "../src/ir/backend/wasmgc-emitter.js";
-import type { IrVecLowering } from "../src/ir/backend/handles.js";
+import type { IrRefCellLowering, IrVecLowering } from "../src/ir/backend/handles.js";
 import type { Instr } from "../src/ir/types.js";
 
 const emitter = new WasmGcEmitter();
@@ -115,5 +115,31 @@ describe("#1713 WasmGcEmitter — pass-through group byte-identity", () => {
       { op: "br", depth: 0 },
       { op: "br_if", depth: 1 },
     ]);
+  });
+});
+
+describe("#2953 WasmGcEmitter — ref-cell family byte-identity", () => {
+  // A representative ref-cell layout: a 1-field mutable struct { value: T }.
+  // The exact indices are arbitrary — the test asserts the emitter threads them
+  // through unchanged into the same struct.new/get/set shapes the inline
+  // refcell.new/get/set arms of lower.ts produced.
+  const cell: IrRefCellLowering = { typeIdx: 11, fieldIdx: 0 };
+
+  it("emitRefCellNew → struct.new $cell (value already on the stack)", () => {
+    const out: Instr[] = [];
+    emitter.emitRefCellNew(cell, out);
+    expect(out).toEqual([{ op: "struct.new", typeIdx: 11 }]);
+  });
+
+  it("emitRefCellGet → struct.get $cell $value", () => {
+    const out: Instr[] = [];
+    emitter.emitRefCellGet(cell, out);
+    expect(out).toEqual([{ op: "struct.get", typeIdx: 11, fieldIdx: 0 }]);
+  });
+
+  it("emitRefCellSet → struct.set $cell $value", () => {
+    const out: Instr[] = [];
+    emitter.emitRefCellSet(cell, out);
+    expect(out).toEqual([{ op: "struct.set", typeIdx: 11, fieldIdx: 0 }]);
   });
 });


### PR DESCRIPTION
First slice of #2953 (the issue is explicitly staged **one PR per family**).

## What

Promotes the ref-cell primitives from declared-optional to **required** on
`BackendEmitter` and routes the `refcell.new/get/set` arms of `lower.ts`
through them:

- `emitRefCellNew` / `emitRefCellGet` / `emitRefCellSet` implemented
  **byte-identically** on `WasmGcEmitter` (`struct.new` / `struct.get` /
  `struct.set` over the cell's `typeIdx` / `fieldIdx`) — the WasmGC `Instr`
  stream is unchanged.
- Linear + Bytecode emitters get loud not-yet-wired stubs (a ref-cell is a
  1-field mutable struct; a future wiring mirrors the a2 struct family:
  `STRUCT_NEW` fieldCount=1 / `STRUCT_GET|SET` fieldIdx=0).
- The 3 `pushRaw` sites in `lower.ts` become trait calls. **pushRaw: 77 → 74.**

## Byte-identity proof

- Golden-`Instr` unit coverage added in `tests/ir-backend-emitter.test.ts`
  (asserts the exact `struct.new/get/set` object each primitive pushes).
- `tests/ir-backend-decoupling`, `ir-vec-two-backend`, `ir-bytecode-proof`,
  `cross-backend-diff` (62 tests, incl. `closure/counter` which exercises
  refcells) all green.
- Runtime execution proof: mutable-closure-capture counter/accumulator compile
  through the refactored path and return correct values.

## Scope

Issue stays **in-progress**: unions/boxing, closures, coercions/null, funcref,
Promise families + the `pushRaw` ratchet-count check land in follow-up PRs. The
box arm's interleaved tag-const/value ordering is noted in the issue for the
next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)