### PR TITLE
refactor(#1916) S3b batch 1: flip the number cluster to stable handles

### DIFF
--- a/plan/issues/1916-symbolic-function-references-codegen.md
+++ b/plan/issues/1916-symbolic-function-references-codegen.md
@@ -270,6 +270,20 @@ is never a moment where one value means two functions.
   files → `mintDefinedFunc`/`pushDefinedFunc`). Byte-identity after
   every batch. Import handles stay live-regime (prefix-stable) until
   S3-final.
+  - **S3b batch 1 — LANDED (PR 4)**: `number-ryu.ts` (3 helpers:
+    `__ryu_mul_shift`/`__num_ryu_digits`/`__num_ryu_to_buf`) +
+    `parse-number-native.ts` (3: `parseFloat`/`__str_to_number`/
+    `parseInt`) — completes the number cluster (number-format flipped in
+    S3a calls into Ryū). Also carries the S3a audit-completeness fixes
+    (compiler/output.ts, emit/c-header.ts, codegen-linear/c-abi.ts,
+    promise-combinators.ts — four funcIdx interpreters outside the S2
+    sweep scope, normalized) that missed #2499's queue window. Proof:
+    1215-record corpus byte-IDENTICAL; issue-1537 (33) + parseint-edge +
+    #1916 suites green.
+  - Batch discipline (for the next executor): flip whole FILES (a
+    producer family), never partial files; `nextFuncIdx`-style local
+    helpers redefine in place; verify `grep -c mod.functions.push <file>`
+    is 0 after; corpus check per batch; run the family's test suites.
 - S3-final: zero live-regime defined-func mints remain → delete
   `shiftLateImportIndices`, `reconcileNativeStrFinalizeShift`, both
   inline shifters, `flushLateImportShifts`, the `liveBodies`/

--- a/src/codegen-linear/c-abi.ts
+++ b/src/codegen-linear/c-abi.ts
@@ -17,6 +17,7 @@
  */
 
 import type { FuncTypeDef, Instr, ValType, WasmModule } from "../ir/types.js";
+import { absoluteFuncIndexCached } from "../emit/resolve-layout.js"; // (#1916 S3)
 
 // ── Linear-memory aggregate header layout (mirrors runtime.ts) ───────
 //
@@ -248,6 +249,8 @@ export function emitCabiWrappers(mod: WasmModule, exportInfos: CabiExportInfo[])
 
     // Find the original function's type
     const numImportFuncs = mod.imports.filter((i) => i.desc.kind === "func").length;
+    // (#1916 S3) normalize a possibly-stable handle to the absolute index.
+    origFuncIdx = absoluteFuncIndexCached(mod, numImportFuncs, origFuncIdx);
     const origFunc = origFuncIdx >= numImportFuncs ? mod.functions[origFuncIdx - numImportFuncs] : null;
     if (!origFunc) continue;
     const origType = mod.types[origFunc.typeIdx] as FuncTypeDef;

--- a/src/codegen/number-ryu.ts
+++ b/src/codegen/number-ryu.ts
@@ -36,6 +36,7 @@
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
 import { addFuncType } from "./registry/types.js";
+import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3b) stable-regime minting
 
 // ---------------------------------------------------------------------------
 // Compile-time table generation (BigInt). Produces byte-identical tables to
@@ -123,9 +124,14 @@ const RYU_INV_GLOBAL = "__ryu_pow5_inv";
 const RYU_POW_GLOBAL = "__ryu_pow5";
 const RYU_I64_ARR = "__ryu_i64_arr";
 
-/** Allocate the next defined-function index. Mirrors number-format-native.ts. */
+/**
+ * #1916 S3b — STABLE-REGIME PRODUCER (see number-format-native.ts, the first
+ * flip). Handles minted here are layout-independent: baked call immediates and
+ * funcMap entries survive every late-import shift and resolve at emit.
+ * Every push below goes through `pushDefinedFunc`.
+ */
 function nextFuncIdx(ctx: CodegenContext): number {
-  return ctx.numImportFuncs + ctx.mod.functions.length;
+  return mintDefinedFunc(ctx);
 }
 
 /** Register an immutable `(array i64)` type, idempotent. */
@@ -342,7 +348,7 @@ function emitRyuMulShift(ctx: CodegenContext): number {
   const typeIdx = addFuncType(ctx, [I64, I64, I64, I32], [I64]);
   const funcIdx = nextFuncIdx(ctx);
   ctx.funcMap.set("__ryu_mul_shift", funcIdx);
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, funcIdx, {
     name: "__ryu_mul_shift",
     typeIdx,
     locals: [
@@ -1024,7 +1030,7 @@ export function emitRyuDigits(ctx: CodegenContext): number {
   const typeIdx = addFuncType(ctx, [F64], [I64, I32]);
   const funcIdx = nextFuncIdx(ctx);
   ctx.funcMap.set("__num_ryu_digits", funcIdx);
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, funcIdx, {
     name: "__num_ryu_digits",
     typeIdx,
     locals: [
@@ -1603,7 +1609,7 @@ export function emitRyuToBuf(ctx: CodegenContext, strDataTypeIdx: number): numbe
   const typeIdx = addFuncType(ctx, [F64, I32, strDataRef, I32], [I32]);
   const funcIdx = nextFuncIdx(ctx);
   ctx.funcMap.set("__num_ryu_to_buf", funcIdx);
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, funcIdx, {
     name: "__num_ryu_to_buf",
     typeIdx,
     locals: [

--- a/src/codegen/parse-number-native.ts
+++ b/src/codegen/parse-number-native.ts
@@ -19,6 +19,7 @@ import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
 import { ensureNativeStringHelpers } from "./native-strings.js";
 import { addFuncType } from "./registry/types.js";
+import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3b) stable-regime minting
 
 const C_TAB = 9;
 const C_LF = 10;
@@ -144,7 +145,7 @@ export function emitNativeParseNumber(ctx: CodegenContext, which: Set<string>): 
   if (which.has("parseFloat") && !ctx.funcMap.has("parseFloat")) {
     // (externref) -> f64
     const typeIdx = addFuncType(ctx, [extern], [f64]);
-    const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+    const funcIdx = mintDefinedFunc(ctx); // (#1916 S3b) stable-regime handle
     ctx.funcMap.set("parseFloat", funcIdx);
 
     // locals (after param 0 = s:externref):
@@ -454,7 +455,7 @@ export function emitNativeParseNumber(ctx: CodegenContext, which: Set<string>): 
       { op: "return" },
     ];
 
-    ctx.mod.functions.push({
+    pushDefinedFunc(ctx, funcIdx, {
       name: "parseFloat",
       typeIdx,
       locals: [
@@ -507,7 +508,7 @@ function emitStrToNumber(ctx: CodegenContext, flattenIdx: number, strTypeIdx: nu
   const f64: ValType = { kind: "f64" };
   const extern: ValType = { kind: "externref" };
   const typeIdx = addFuncType(ctx, [extern], [f64]);
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const funcIdx = mintDefinedFunc(ctx); // (#1916 S3b) stable-regime handle
   ctx.funcMap.set("__str_to_number", funcIdx);
 
   // params: 0 s:externref
@@ -856,7 +857,7 @@ function emitStrToNumber(ctx: CodegenContext, flattenIdx: number, strTypeIdx: nu
     { op: "return" },
   ];
 
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, funcIdx, {
     name: "__str_to_number",
     typeIdx,
     locals: [
@@ -1477,7 +1478,7 @@ function emitParseInt(ctx: CodegenContext, flattenIdx: number, strTypeIdx: numbe
   const f64: ValType = { kind: "f64" };
   const extern: ValType = { kind: "externref" };
   const typeIdx = addFuncType(ctx, [extern, f64], [f64]);
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const funcIdx = mintDefinedFunc(ctx); // (#1916 S3b) stable-regime handle
   ctx.funcMap.set("parseInt", funcIdx);
 
   // params: 0 s:externref, 1 radixF:f64
@@ -1747,7 +1748,7 @@ function emitParseInt(ctx: CodegenContext, flattenIdx: number, strTypeIdx: numbe
     { op: "return" },
   ];
 
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, funcIdx, {
     name: "parseInt",
     typeIdx,
     locals: [

--- a/src/codegen/promise-combinators.ts
+++ b/src/codegen/promise-combinators.ts
@@ -36,6 +36,7 @@ import type { CodegenContext, FunctionContext } from "./context/types.js";
 import type { Instr, LocalDef, ValType } from "../ir/types.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
 import { allocLocal } from "./context/locals.js";
+import { definedFuncAt } from "./func-space.js"; // (#1916 S2) positional-read chokepoint
 import {
   ensureAsyncDriveRuntime,
   getOrRegisterPromiseType,
@@ -802,7 +803,7 @@ export function fillCombinatorToVec(ctx: CodegenContext): void {
   ) {
     return;
   }
-  const fn = ctx.mod.functions[funcIdx - ctx.numImportFuncs];
+  const fn = definedFuncAt(ctx, funcIdx);
   if (!fn) return;
 
   const vecTypeIdx = getOrRegisterVecType(ctx, "externref", EXTERNREF);

--- a/src/compiler/output.ts
+++ b/src/compiler/output.ts
@@ -4,6 +4,7 @@ import type { TypedAST } from "../checker/index.js";
 import { analyzeSource } from "../checker/index.js";
 import type { CabiExportInfo, ParamDef, TsSemanticType } from "../codegen-linear/c-abi.js";
 import { emitCabiWrappers, inferSemantic, mapParamsToCabi, mapResultToCabi } from "../codegen-linear/c-abi.js";
+import { absoluteFuncIndexCached } from "../emit/resolve-layout.js"; // (#1916 S3)
 import { generateModule } from "../codegen/index.js";
 import { isFatalCodegenDiagnostic } from "../codegen/context/errors.js";
 import { extractCHeaderExports, generateCHeader } from "../emit/c-header.js";
@@ -55,7 +56,8 @@ function applyCabiTransform(mod: WasmModule, moduleName: string, ast?: TypedAST)
     if (exp.desc.kind !== "func") continue;
     if (exp.name === "memory") continue;
 
-    const funcIdx = exp.desc.index;
+    // (#1916 S3) normalize a possibly-stable handle to the absolute index.
+    const funcIdx = absoluteFuncIndexCached(mod, numImportFuncs, exp.desc.index);
     const localIdx = funcIdx - numImportFuncs;
     if (localIdx < 0 || localIdx >= mod.functions.length) continue;
 

--- a/src/emit/c-header.ts
+++ b/src/emit/c-header.ts
@@ -8,6 +8,7 @@
  */
 
 import type { ValType, WasmModule } from "../ir/types.js";
+import { absoluteFuncIndexCached } from "./resolve-layout.js"; // (#1916 S3)
 
 /** Information about a single exported function for C header generation */
 export interface CHeaderExport {
@@ -100,7 +101,8 @@ export function extractCHeaderExports(mod: WasmModule): CHeaderExport[] {
     if (exp.desc.kind !== "func") continue;
     if (exp.name === "memory") continue;
 
-    const funcIdx = exp.desc.index;
+    // (#1916 S3) normalize a possibly-stable handle to the absolute index.
+    const funcIdx = absoluteFuncIndexCached(mod, numImportFuncs, exp.desc.index);
     const localIdx = funcIdx - numImportFuncs;
     if (localIdx < 0 || localIdx >= mod.functions.length) continue;
 


### PR DESCRIPTION
## What

Fourth slice of #1916, first mechanical batch after the S3a two-regime infrastructure (#2499):

- **`number-ryu.ts`** (3 helpers: `__ryu_mul_shift`/`__num_ryu_digits`/`__num_ryu_to_buf`) and **`parse-number-native.ts`** (3: `parseFloat`/`__str_to_number`/`parseInt`) now mint stable-regime handles via `mintDefinedFunc`/`pushDefinedFunc` — their baked call immediates and funcMap entries never shift again. Completes the number cluster (S3a's number-format family calls into Ryū).
- Carries the **S3a audit-completeness commit** that missed #2499's queue window (the branch got locked by the merge queue seconds after the draft flipped ready): four funcIdx interpreters outside the S2 sweep scope normalized via `absoluteFuncIndexCached`/`definedFuncAt` — `compiler/output.ts`, `emit/c-header.ts`, `codegen-linear/c-abi.ts`, `promise-combinators.ts`. (Verified safe in the interim: no stable handle could reach those sites at #2499's queued commit — the number-format helpers are non-exported.)

## Proof

- **Byte-identity**: 1215 (file,target) records (992 real binaries × {gc, standalone, wasi}) — **IDENTICAL** vs fresh origin/main-tip (89ab6295) baseline. The flipped handles resolve at emit to exactly the bytes the shifter regime produced.
- issue-1537 (33 tests, Ryū), parseint-edge, #1916 acceptance suites green. `tsc --noEmit` clean. Zero raw `mod.functions.push` remain in the flipped files.

## Remainder

~197 canonical mint sites + 10 variants across 47 files (batch discipline documented in the issue file); then S3-final deletes the four shifters (full CI + merge_group, coordinated with the tech lead first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS