### PR TITLE
fix(#2987): standalone gOPD on boxed String-wrapper exotic own properties

### DIFF
--- a/plan/issues/2987-standalone-boxed-wrapper-defineproperty.md
+++ b/plan/issues/2987-standalone-boxed-wrapper-defineproperty.md
@@ -1,7 +1,9 @@
 ---
 id: 2987
 title: "Standalone defineProperty / gOPD on boxed-wrapper receivers (~18: new String/Number/Boolean)"
-status: ready
+status: done
+completed: 2026-07-02
+assignee: ttraenkler/opus-1c
 sprint: Backlog
 priority: medium
 horizon: m
@@ -33,3 +35,44 @@ and fail on standalone — the wrapper receiver has no own-property MOP, and for
 
 - Measured flip count on the boxed-wrapper defineProperty/gOPD standalone subset
   with zero regressions; gc/host byte-inert.
+
+## Resolution
+
+Measure-first found the boxed **Number/Boolean** wrapper MOP already round-trips
+(they build as ordinary `$Object`s carrying their `[[PrimitiveValue]]` slot, so
+`defineProperty`/gOPD hit the generic own-prop path — verified, no change
+needed). The real gap was the **`new String` exotic string-index own
+properties**: the native `__getOwnPropertyDescriptor`
+(`src/codegen/object-runtime.ts`) resolves own keys via `__obj_find`, which
+misses the String-exotic integer indices (`"0".."n-1"`) and `"length"` (they
+have no ordinary `$PropEntry`), so gOPD returned `undefined` and the test trapped
+dereferencing the missing descriptor.
+
+Fix: when `__obj_find` misses, a new **String-wrapper exotic arm** recovers the
+`[[StringData]]` native string from the FLAG_INTERNAL slot and synthesizes the
+§10.4.3 descriptor —
+
+- integer index in `[0, len)` → `{ value: <char>, writable:false,
+enumerable:true, configurable:false }`
+- `"length"` → `{ value: <len>, writable:false, enumerable:false,
+configurable:false }`
+
+reusing existing runtime helpers (`__obj_index_of_key`, `__str_charAt`,
+`__str_flatten`, `__str_equals`, `__box_number`/`__box_boolean`). The arm is
+gated `ctx.standalone && ctx.nativeStrings`; its 6 locals are emitted only when
+active, so the **gc/host AND wasi lanes are byte-identical** to `origin/main`
+(verified by sha256 over the compiled binary against the pristine compiler:
+gc `edd791f0…`, wasi `78e59b06…` unchanged).
+
+Concrete test262 cases unblocked include `15.2.3.3-3-14`
+(`gOPD(new String("123"), "2").value === "3"`) and `15.2.3.3-4-192`
+(`gOPD(new String("abc"), "length")` all-false data descriptor), plus every
+`verifyProperty`-based test that first reads a String-index/`length` descriptor.
+
+## Test Results
+
+`tests/issue-2987.test.ts` — 10/10 pass (standalone): index-descriptor value +
+attrs, `length` descriptor, out-of-range/non-index → `undefined`, ordinary user
+own-prop still resolves, Number/Boolean wrapper non-regression, plain-object
+skip. Existing `tests/issue-1910-string-wrapper-index.test.ts` (6) and
+`tests/issue-2874-standalone-create-descriptor.test.ts` (7) still green.

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -5704,7 +5704,29 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     // helpers (idempotent; defined funcs, no index shift) and resolve it.
     addUnionImportsViaRegistry(ctx);
     const boxBoolIdx = ctx.funcMap.get("__box_boolean")!;
+    const boxNumIdx = ctx.funcMap.get("__box_number")!;
     const newPlainObjectIdx = ctx.funcMap.get("__new_plain_object")!;
+
+    // (#2987) String-wrapper exotic own-property synthesis. `new String("ab")`
+    // is a `$Object` wrapper carrying its [[StringData]] native string in the
+    // reserved FLAG_INTERNAL slot (#1910 S2). Its integer-index own properties
+    // ("0".."n-1") and "length" are String-exotic (§10.4.3) and have NO ordinary
+    // `$PropEntry`, so `__obj_find` misses them and gOPD returned `undefined`.
+    // When the ordinary lookup misses we recover the slot string and synthesize
+    // the spec descriptor: index → { value: char, writable:false, enumerable:true,
+    // configurable:false }; "length" → { value: len, writable:false,
+    // enumerable:false, configurable:false }. Standalone + nativeStrings only —
+    // the gc/host lane keeps its host `getOwnPropertyDescriptor` (byte-inert).
+    const charAtIdx = ctx.nativeStrHelpers.get("__str_charAt");
+    const strExotic = ctx.standalone && ctx.nativeStrings && anyStrTypeIdx >= 0 && charAtIdx !== undefined;
+    const stringExternG = (value: string): Instr[] => {
+      addStringConstantGlobal(ctx, value);
+      return stringConstantExternrefInstrs(ctx, value);
+    };
+    const boxBoolConst = (v: number): Instr[] => [
+      { op: "i32.const", value: v },
+      { op: "call", funcIdx: boxBoolIdx },
+    ];
 
     // `__extern_set(desc, "<key>", <value externref>)` — desc is in local 6.
     // `valueInstrs` must leave one externref on the stack.
@@ -5728,6 +5750,105 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
       { op: "i32.ne" },
       { op: "call", funcIdx: boxBoolIdx },
     ];
+
+    // (#2987) String-wrapper exotic own-property arm — runs when the ordinary
+    // `__obj_find` misses. Locals: 7=sEnt(ref null $PropEntry) 8=sVal(anyref)
+    // 9=wStr(ref null $NativeString) 10=wLen(i32) 11=kStr(ref null $NativeString)
+    // 12=kIdx(i32). Always ends in a `return` on every control path.
+    const L_SENT = 7;
+    const L_SVAL = 8;
+    const L_WSTR = 9;
+    const L_WLEN = 10;
+    const L_KSTR = 11;
+    const L_KIDX = 12;
+    const undefRet: Instr[] = [{ op: "ref.null.extern" }, { op: "return" }];
+    // Build a fresh data descriptor into `desc` (local 6) and return it.
+    const exoticDataDesc = (valueInstrs: Instr[], enumerable: number): Instr[] => [
+      { op: "call", funcIdx: newPlainObjectIdx },
+      { op: "local.set", index: 6 },
+      ...setKey("value", valueInstrs),
+      ...setKey("writable", boxBoolConst(0)),
+      ...setKey("enumerable", boxBoolConst(enumerable)),
+      ...setKey("configurable", boxBoolConst(0)),
+      { op: "local.get", index: 6 },
+      { op: "return" },
+    ];
+    const stringExoticArm: Instr[] = strExotic
+      ? [
+          // key must be a string property key (else no exotic own property).
+          { op: "local.get", index: 1 },
+          { op: "any.convert_extern" },
+          { op: "local.tee", index: 2 },
+          { op: "ref.test", typeIdx: anyStrTypeIdx },
+          { op: "i32.eqz" },
+          { op: "if", blockType: { kind: "empty" }, then: undefRet },
+          { op: "local.get", index: 2 },
+          { op: "ref.cast", typeIdx: anyStrTypeIdx },
+          { op: "call", funcIdx: strFlattenIdx },
+          { op: "local.set", index: L_KSTR },
+          // slotEnt = __obj_find(o, "[[PrimitiveValue]]") — absent ⇒ not a wrapper.
+          { op: "local.get", index: 3 },
+          { op: "ref.as_non_null" },
+          ...stringExternG(WRAPPER_PRIMITIVE_KEY),
+          { op: "call", funcIdx: objFindIdx },
+          { op: "local.tee", index: L_SENT },
+          { op: "ref.is_null" },
+          { op: "if", blockType: { kind: "empty" }, then: undefRet },
+          // sVal = slotEnt.value; a String wrapper's [[StringData]] is a string.
+          { op: "local.get", index: L_SENT },
+          { op: "ref.as_non_null" },
+          { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 1 },
+          { op: "local.tee", index: L_SVAL },
+          { op: "ref.test", typeIdx: anyStrTypeIdx },
+          { op: "i32.eqz" },
+          { op: "if", blockType: { kind: "empty" }, then: undefRet },
+          // wStr = flatten([[StringData]]); wLen = wStr.len
+          { op: "local.get", index: L_SVAL },
+          { op: "ref.cast", typeIdx: anyStrTypeIdx },
+          { op: "call", funcIdx: strFlattenIdx },
+          { op: "local.tee", index: L_WSTR },
+          { op: "struct.get", typeIdx: nativeStrTypeIdx, fieldIdx: 0 },
+          { op: "local.set", index: L_WLEN },
+          // "length" → { value: len, writable:false, enumerable:false, configurable:false }
+          { op: "local.get", index: L_KSTR },
+          ...nativeStringLiteralInstrs(ctx, "length"),
+          { op: "call", funcIdx: strEqualsIdx },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: exoticDataDesc(
+              [{ op: "local.get", index: L_WLEN }, { op: "f64.convert_i32_s" }, { op: "call", funcIdx: boxNumIdx }],
+              0,
+            ),
+          },
+          // integer index in [0, len) → { value: char, writable:false, enumerable:true, configurable:false }
+          { op: "local.get", index: L_KSTR },
+          { op: "call", funcIdx: objIndexOfKeyIdx },
+          { op: "local.tee", index: L_KIDX },
+          { op: "i32.const", value: 0 },
+          { op: "i32.ge_s" },
+          { op: "local.get", index: L_KIDX },
+          { op: "local.get", index: L_WLEN },
+          { op: "i32.lt_s" },
+          { op: "i32.and" },
+          {
+            op: "if",
+            blockType: { kind: "empty" },
+            then: exoticDataDesc(
+              [
+                { op: "local.get", index: L_WSTR },
+                { op: "ref.as_non_null" },
+                { op: "local.get", index: L_KIDX },
+                { op: "call", funcIdx: charAtIdx as number },
+                { op: "extern.convert_any" } as Instr,
+              ],
+              1,
+            ),
+          },
+          // no exotic own property matched → undefined
+          ...undefRet,
+        ]
+      : undefRet;
 
     const body: Instr[] = [
       // (#2896) Builtin-fn metadata arm: gOPD over a builtin function value
@@ -5769,12 +5890,12 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
       { op: "local.get", index: 1 },
       { op: "call", funcIdx: objFindIdx },
       { op: "local.tee", index: 4 },
-      // if e == null → return undefined (own property does not exist)
+      // if e == null → try String-wrapper exotic own property (#2987), else undefined
       { op: "ref.is_null" },
       {
         op: "if",
         blockType: { kind: "empty" },
-        then: [{ op: "ref.null.extern" }, { op: "return" }],
+        then: stringExoticArm,
       },
       // fl = e.flags
       { op: "local.get", index: 4 },
@@ -5837,6 +5958,20 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
         { name: "e", type: entryRefNull },
         { name: "fl", type: { kind: "i32" } },
         { name: "desc", type: { kind: "externref" } },
+        // (#2987) String-wrapper exotic own-property arm locals (7..12). Only
+        // emitted when the arm is active (standalone) so every other lane — where
+        // `stringExoticArm` is the original `[null.extern, return]` — keeps its
+        // byte-identical function body + local vector.
+        ...(strExotic
+          ? ([
+              { name: "sEnt", type: entryRefNull },
+              { name: "sVal", type: { kind: "anyref" } },
+              { name: "wStr", type: { kind: "ref_null", typeIdx: nativeStrTypeIdx } },
+              { name: "wLen", type: { kind: "i32" } },
+              { name: "kStr", type: { kind: "ref_null", typeIdx: nativeStrTypeIdx } },
+              { name: "kIdx", type: { kind: "i32" } },
+            ] as { name: string; type: ValType }[])
+          : []),
       ],
       body,
     );

--- a/tests/issue-2987.test.ts
+++ b/tests/issue-2987.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2987 — standalone `Object.getOwnPropertyDescriptor` on a boxed String
+// wrapper receiver. `new String("ab")` builds a `$Object` wrapper carrying its
+// [[StringData]] native string in the reserved FLAG_INTERNAL slot (#1910 S2).
+// Its integer-index own properties ("0".."n-1") and "length" are String-exotic
+// (§10.4.3) with NO ordinary `$PropEntry`, so the native gOPD's `__obj_find`
+// missed them and returned `undefined` (the test then trapped dereferencing the
+// missing descriptor). The gOPD runtime now recovers the slot string and
+// synthesizes the spec descriptor:
+//   index  → { value: char, writable:false, enumerable:true,  configurable:false }
+//   length → { value: len,  writable:false, enumerable:false, configurable:false }
+// Number/Boolean wrappers already round-tripped via the ordinary $Object MOP and
+// are covered here as non-regression guards. gc/host + wasi lanes are byte-inert
+// (the arm is standalone-only).
+async function runNum(src: string): Promise<number> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { f: () => number }).f();
+}
+
+describe("#2987 standalone gOPD on boxed String-wrapper exotic own properties", () => {
+  it("gOPD(new String('ab'), '0').value === 'a'", async () => {
+    expect(
+      await runNum(
+        `export function f(): number { const s = new String("ab"); const d: any = Object.getOwnPropertyDescriptor(s, "0"); return d.value === "a" ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("gOPD(new String('123'), '2').value === '3' (15.2.3.3-3-14)", async () => {
+    expect(
+      await runNum(
+        `export function f(): number { const s = new String("123"); const d: any = Object.getOwnPropertyDescriptor(s, "2"); return d.value === "3" ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("index descriptor attrs: writable:false, enumerable:true, configurable:false", async () => {
+    expect(
+      await runNum(
+        `export function f(): number { const s = new String("ab"); const d: any = Object.getOwnPropertyDescriptor(s, "0"); return d.writable === false && d.enumerable === true && d.configurable === false ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("length descriptor: {value:len, writable:false, enumerable:false, configurable:false} (15.2.3.3-4-192)", async () => {
+    expect(
+      await runNum(
+        `export function f(): number { const s = new String("abc"); const d: any = Object.getOwnPropertyDescriptor(s, "length"); return d.value === 3 && d.writable === false && d.enumerable === false && d.configurable === false ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("out-of-range index → undefined", async () => {
+    expect(
+      await runNum(
+        `export function f(): number { const s = new String("ab"); return Object.getOwnPropertyDescriptor(s, "5") === undefined ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("non-index string key → undefined", async () => {
+    expect(
+      await runNum(
+        `export function f(): number { const s = new String("ab"); return Object.getOwnPropertyDescriptor(s, "foo") === undefined ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("ordinary user own property on the wrapper still resolves", async () => {
+    expect(
+      await runNum(
+        `export function f(): number { const s = new String("ab"); (s as any).x = 42; const d: any = Object.getOwnPropertyDescriptor(s, "x"); return d.value === 42 ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+
+  it("Number wrapper defineProperty round-trips (non-regression)", async () => {
+    expect(
+      await runNum(
+        `export function f(): number { const w = new Number(5); Object.defineProperty(w, "p", { value: 7, writable: true, enumerable: true, configurable: true }); return (w as any).p; }`,
+      ),
+    ).toBe(7);
+  });
+
+  it("Boolean wrapper gOPD round-trips (non-regression)", async () => {
+    expect(
+      await runNum(
+        `export function f(): number { const w = new Boolean(true); Object.defineProperty(w, "q", { value: 9, enumerable: false, writable: false, configurable: false }); const d: any = Object.getOwnPropertyDescriptor(w, "q"); return d.value; }`,
+      ),
+    ).toBe(9);
+  });
+
+  it("plain object gOPD for an index key stays undefined (arm skips non-wrappers)", async () => {
+    expect(
+      await runNum(
+        `export function f(): number { const o: any = {}; return Object.getOwnPropertyDescriptor(o, "0") === undefined ? 1 : 0; }`,
+      ),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## #2987 — standalone `getOwnPropertyDescriptor` on boxed String-wrapper receivers

Follow-up from the #2965 descriptor-cluster triage (class 4: boxed-wrapper receivers). Sibling of #2986 / #2989.

### Root cause (measure-first)
Boxed **Number/Boolean** wrappers already round-trip — they build as ordinary `$Object`s carrying their `[[PrimitiveValue]]` slot, so `defineProperty`/gOPD hit the generic own-prop path (verified, no change needed).

The real gap is the **`new String` exotic string-index own properties**. The native `__getOwnPropertyDescriptor` (`src/codegen/object-runtime.ts`) resolves own keys via `__obj_find`, which misses the String-exotic integer indices (`"0".."n-1"`) and `"length"` (no ordinary `$PropEntry`), so gOPD returned `undefined` and the test trapped dereferencing the missing descriptor.

### Fix
When `__obj_find` misses, a new **standalone-only exotic arm** recovers the `[[StringData]]` native string from the FLAG_INTERNAL slot and synthesizes the §10.4.3 descriptor:
- integer index in `[0, len)` → `{ value: <char>, writable:false, enumerable:true, configurable:false }`
- `"length"` → `{ value: <len>, writable:false, enumerable:false, configurable:false }`

Reuses existing runtime helpers (`__obj_index_of_key`, `__str_charAt`, `__str_flatten`, `__str_equals`, `__box_number`/`__box_boolean`).

### Byte-inertness
Arm gated `ctx.standalone && ctx.nativeStrings`; its 6 locals are emitted only when active. **gc/host AND wasi lanes are byte-identical** to `origin/main` — verified by sha256 over the compiled binary against the pristine compiler (gc `edd791f0…`, wasi `78e59b06…` unchanged).

### Tests
- `tests/issue-2987.test.ts` — 10/10 pass (standalone): index value+attrs, `length` descriptor, out-of-range/non-index → `undefined`, ordinary user own-prop still resolves, Number/Boolean non-regression, plain-object skip.
- Existing `tests/issue-1910-string-wrapper-index.test.ts` (6) and `tests/issue-2874-standalone-create-descriptor.test.ts` (7) still green.

Unblocks test262 `15.2.3.3-3-14` (`gOPD(new String("123"), "2").value === "3"`) and `15.2.3.3-4-192` (`gOPD(new String("abc"), "length")` all-false data descriptor), plus verifyProperty-based String-index/length descriptor tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)