### PR TITLE
fix(#2934): host-bridge Work Items A+C — IsCallable gate + bridge elem coercion

### DIFF
--- a/plan/issues/2934-standalone-invalid-wasm-heterogeneous-tail.md
+++ b/plan/issues/2934-standalone-invalid-wasm-heterogeneous-tail.md
@@ -298,6 +298,26 @@ map must SKIP holes, §23.1.3.18 step 5.b) should be audited in B's loop but is
 NOT required for the named invalid-Wasm tests (they throw before iterating
 once A lands).
 
+**Status (dev-2934f, 2026-07-02): A DONE, C DONE, B open.**
+
+- A: `isKnownNonCallable` extended — plain object type with no call/construct
+  signatures (excluding any/unknown/unions) is statically non-callable;
+  `emitCallbackTypeCheck` (already wired into all 12 callback methods) now
+  fires for `arr.map(new Object())`. map/15.4.4.19-4-7 standalone invalid →
+  **pass** (runner-verified TypeError at the right time).
+- C: implemented as `bridgeElemConvertInstrs` (shared by
+  `buildBridgeCallInstrs` + both reduce/reduceRight bridge arms): externref
+  elems unbox (`__unbox_number` → ToNumber), packed i8/i16 read as widened
+  i32 then convert — never assume the element is already numeric.
+  filter/create-species-poisoned + map/create-species-poisoned invalid →
+  valid. Sweep: 648-file map/filter/forEach dirs 632→646 VALID (+14, 0 new
+  invalid); byte-identical common paths; array equivalence tests green.
+  Tests: `tests/issue-2934-hostbridge-iscallable.test.ts` (5).
+- Residual (NOT this class): `Proxy/revocable/tco-fn-realm.js` `__closure_20`
+  `call[0] expected externref, found call_ref of f64` — a realms/Proxy
+  closure-result coercion, out of standalone scope (Proxy is #1472 Phase C /
+  #1355); not a callback-bridge site.
+
 ## Approach
 
 Per the #2868/#2878 playbook: pick one repro per cluster, disassemble with

--- a/scripts/coercion-sites-baseline.json
+++ b/scripts/coercion-sites-baseline.json
@@ -1,5 +1,5 @@
 {
-  "codegen/array-methods.ts": 19,
+  "codegen/array-methods.ts": 20,
   "codegen/array-object-proto.ts": 1,
   "codegen/array-to-primitive.ts": 5,
   "codegen/async-scheduler.ts": 3,

--- a/src/codegen/array-methods.ts
+++ b/src/codegen/array-methods.ts
@@ -191,6 +191,23 @@ function isKnownNonCallable(ctx: CodegenContext, arg: ts.Expression): boolean {
     ts.TypeFlags.StringLike |
     ts.TypeFlags.BigIntLike;
   if (tsType.flags & NON_CALLABLE_FLAGS) return true;
+  // (#2934 host-bridge A) A plain OBJECT type with NO call and NO construct
+  // signatures is statically non-callable — `arr.map(new Object())`
+  // (map/15.4.4.19-4-7) must throw the §23.1.3.18 step-3 TypeError BEFORE
+  // iterating, instead of falling to the host callback bridge (which leaks
+  // `env::__call_1_f64` into standalone AND mis-types the element arg —
+  // "call[1] expected f64, found array.get of externref"). `any`/`unknown`
+  // and union types stay dynamic (their flags are not Object), so an
+  // imprecisely-typed value that may hold a function at runtime is never
+  // gated.
+  if (
+    tsType.flags & ts.TypeFlags.Object &&
+    !(tsType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) &&
+    (tsType.getCallSignatures?.() ?? []).length === 0 &&
+    (tsType.getConstructSignatures?.() ?? []).length === 0
+  ) {
+    return true;
+  }
   return false;
 }
 
@@ -6316,21 +6333,46 @@ function buildBridgeCallInstrs(
   loop: ArrayLoopLocals,
   elemSource: { kind: "local"; index: number } | { kind: "inline" },
 ): Instr[] {
+  const conv = bridgeElemConvertInstrs(ctx, elemType);
   return [
     { op: "local.get", index: setup.cbTmp! } as Instr,
     ...(elemSource.kind === "local"
-      ? [
-          { op: "local.get", index: elemSource.index } as Instr,
-          ...(!ctx.fast && elemType.kind === "i32" ? [{ op: "f64.convert_i32_s" } as Instr] : []),
-        ]
+      ? [{ op: "local.get", index: elemSource.index } as Instr, ...conv]
       : [
           { op: "local.get", index: loop.dataTmp } as Instr,
           { op: "local.get", index: loop.iTmp } as Instr,
           { op: loop.getOp, typeIdx: arrTypeIdx } as Instr,
-          ...(!ctx.fast && elemType.kind === "i32" ? [{ op: "f64.convert_i32_s" } as Instr] : []),
+          ...conv,
         ]),
     { op: "call", funcIdx: setup.callBridgeIdx! } as Instr,
   ];
+}
+
+/**
+ * (#2934 host-bridge C) Convert a loop ELEMENT (as read from the backing
+ * array) to the host bridge's numeric arg kind (`f64` in non-fast mode, `i32`
+ * in fast mode). The old inline conversion only knew `i32 → f64`, so:
+ *   - a BOXED-ANY (externref) element — `new Array(N)` / `any[]` vecs — flowed
+ *     raw into the f64 param: `call[1] expected type f64, found array.get of
+ *     type externref` (the `__closure_2/4` invalid-Wasm cluster,
+ *     `filter/create-species-poisoned.js`);
+ *   - a PACKED i8/i16 element reads as the widened i32 but compared as
+ *     `elemType.kind === "i32"` → no convert → i32 into f64 (same class).
+ * externref unboxes via `__unbox_number` (ToNumber; registered by
+ * `addUnionImports` — native in standalone, import in host mode, resolved at
+ * build time so the funcIdx is post-shift-correct and the pushed body is
+ * walked by any later shifts).
+ */
+function bridgeElemConvertInstrs(ctx: CodegenContext, elemType: ValType): Instr[] {
+  if (ctx.fast) return [];
+  const readKind = elemType.kind === "i8" || elemType.kind === "i16" ? "i32" : elemType.kind;
+  if (readKind === "i32") return [{ op: "f64.convert_i32_s" } as Instr];
+  if (readKind === "externref" || readKind === "ref_extern") {
+    addUnionImports(ctx);
+    const unboxIdx = ctx.funcMap.get("__unbox_number");
+    if (unboxIdx !== undefined) return [{ op: "call", funcIdx: unboxIdx } as Instr];
+  }
+  return [];
 }
 
 /** Build instructions to check truthiness of a callback result (-> i32). */
@@ -6810,7 +6852,9 @@ function compileArrayReduce(
       { op: "local.get", index: loop.dataTmp } as Instr,
       { op: "local.get", index: loop.iTmp } as Instr,
       { op: loop.getOp, typeIdx: arrTypeIdx } as Instr,
-      ...(!ctx.fast && elemType.kind === "i32" ? [{ op: "f64.convert_i32_s" } as Instr] : []),
+      // (#2934 host-bridge C) externref/packed elems convert to the bridge's
+      // numeric arg kind — see bridgeElemConvertInstrs.
+      ...bridgeElemConvertInstrs(ctx, elemType),
       { op: "call", funcIdx: setup.callBridgeIdx! } as Instr,
       { op: "local.set", index: accTmp } as Instr,
     ];
@@ -6996,7 +7040,9 @@ function compileArrayReduceRight(
       { op: "local.get", index: dataTmp } as Instr,
       { op: "local.get", index: iTmp } as Instr,
       { op: getOp, typeIdx: arrTypeIdx } as Instr,
-      ...(!ctx.fast && elemType.kind === "i32" ? [{ op: "f64.convert_i32_s" } as Instr] : []),
+      // (#2934 host-bridge C) externref/packed elems convert to the bridge's
+      // numeric arg kind — see bridgeElemConvertInstrs.
+      ...bridgeElemConvertInstrs(ctx, elemType),
       { op: "call", funcIdx: setup.callBridgeIdx! } as Instr,
       { op: "local.set", index: accTmp } as Instr,
     ];

--- a/tests/issue-2934-hostbridge-iscallable.test.ts
+++ b/tests/issue-2934-hostbridge-iscallable.test.ts
@@ -1,0 +1,83 @@
+// #2934 host-bridge Work Items A + C (spec in the issue's Implementation Plan):
+//
+//   A. `isKnownNonCallable` (array-methods.ts) now recognises a plain OBJECT
+//      type with no call/construct signatures (`arr.map(new Object())`), so
+//      `emitCallbackTypeCheck` throws the §23.1.3.18 step-3 TypeError at the
+//      right time instead of falling to the host callback bridge — which
+//      leaked `env::__call_1_f64` into standalone AND mis-typed the element
+//      arg ("call[1] expected f64, found array.get of externref", the
+//      `__closure_2` cluster, map/15.4.4.19-4-7).
+//   B. (deferred — standalone-native dynamic dispatch, see the issue spec.)
+//   C. `bridgeElemConvertInstrs`: the bridge element conversion now handles
+//      BOXED-ANY (externref) elements (unbox via `__unbox_number` → ToNumber)
+//      and packed i8/i16 (widened i32 → convert), not just i32
+//      (filter/create-species-poisoned.js `__closure_4` cluster).
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import { compile } from "../src/index.js";
+import { parseMeta, wrapTest } from "./test262-runner.js";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const TEST262 = process.env.TEST262_ROOT ?? join(REPO_ROOT, "test262");
+
+const FIXED = [
+  "test/built-ins/Array/prototype/map/15.4.4.19-4-7.js",
+  "test/built-ins/Array/prototype/filter/create-species-poisoned.js",
+  "test/built-ins/Array/prototype/map/create-species-poisoned.js",
+];
+
+async function compileStandalone(source: string) {
+  return compile(source, {
+    fileName: "test.ts",
+    target: "standalone",
+    skipSemanticDiagnostics: true,
+  });
+}
+
+describe("#2934 host-bridge A+C — non-callable callback + boxed-any bridge elems", () => {
+  for (const rel of FIXED) {
+    const abs = join(TEST262, rel);
+    const present = existsSync(abs);
+    it.skipIf(!present)(`compiles ${rel} to valid standalone Wasm`, async () => {
+      const src = readFileSync(abs, "utf-8");
+      const wrapped = wrapTest(src, parseMeta(src)).source;
+      const r = await compileStandalone(wrapped);
+      expect(r.success).toBe(true);
+      await expect(WebAssembly.compile(r.binary)).resolves.toBeDefined();
+    });
+  }
+
+  it("map(new Object()) throws TypeError before iterating (§23.1.3.18 step 3)", async () => {
+    const r = await compileStandalone(`
+      export function test(): number {
+        var arr = new Array(10);
+        try {
+          arr.map(new Object());
+          return 0;
+        } catch (e) {
+          return ("" + e).indexOf("TypeError") >= 0 ? 1 : 2;
+        }
+      }
+    `);
+    expect(r.success).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports.test as () => number)()).toBe(1);
+  });
+
+  it("normal function callbacks are untouched (map/filter/reduce)", async () => {
+    const r = await compileStandalone(`
+      export function test(): number {
+        const a = [1, 2, 3, 4];
+        const m = a.map(function (x) { return x * 2; });
+        const f = a.filter(function (x) { return x % 2 === 0; });
+        const s = a.reduce(function (acc, x) { return acc + x; }, 0);
+        return m[3] + f.length + s;
+      }
+    `);
+    expect(r.success).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports.test as () => number)()).toBe(8 + 2 + 10);
+  });
+});


### PR DESCRIPTION
## What

Executes Work Items **A** and **C** of the #2934 host-bridge implementation plan (spec in the issue, landed via #2498). Work Item B (standalone-native dynamic callback dispatch replacing `env::__call_1_f64`) stays open.

**A — compile-time IsCallable TypeError** (`src/codegen/array-methods.ts`): `isKnownNonCallable` now recognises a plain OBJECT type with no call/construct signatures (`arr.map(new Object())`); `any`/`unknown`/unions stay dynamic. `emitCallbackTypeCheck` — already wired into all 12 array callback methods — now throws the §23.1.3.18 step-3 TypeError BEFORE iteration instead of falling to the host callback bridge, which both leaked `env::__call_1_f64` into standalone and mis-typed the element arg (`call[1] expected f64, found array.get of externref` — the `__closure_2` cluster).

**C — bridge element coercion** (`bridgeElemConvertInstrs`, shared by `buildBridgeCallInstrs` + both reduce/reduceRight bridge arms): the bridge's element conversion now handles BOXED-ANY (externref) elements — unbox via `__unbox_number` (ToNumber) — and packed i8/i16 (widened i32 → convert), not just i32. Fixes the `filter/create-species-poisoned.js` `__closure_4` signature.

## Validation

- `Array/prototype/map/15.4.4.19-4-7.js`: standalone INVALID → **pass** (runner-verified — TypeError at the spec'd time).
- `filter/create-species-poisoned.js` + `map/create-species-poisoned.js`: INVALID → valid.
- 648-file `map`/`filter`/`forEach` sweep: **632 → 646 VALID (+14, 0 new invalids)** — clean base-vs-fix on the same branch base.
- **Byte-identical** on common paths (SHA-checked); normal function callbacks probed (map/filter/reduce semantics unchanged).
- New `tests/issue-2934-hostbridge-iscallable.test.ts`: 5/5.
- Array equivalence tests 60/60 (`array-callback-three-params.test.ts` collect error pre-existing on main — missing `./helpers.js`).
- Coercion-sites baseline +1 `array-methods.ts` (the `__unbox_number` engine-helper lookup — sanctioned intentional growth, same precedent as #2473/#2489).
- Residual documented in the issue: `Proxy/revocable/tco-fn-realm.js` is a realms/Proxy closure-result coercion (#1472 Phase C scope), not a callback-bridge site.

Part of #2934 (issue stays in-progress; Work Item B + #2978-paired (3b) remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS