### PR TITLE
feat(#2134): unified IR effect model (src/ir/effects.ts) + independent emission-schedule verifier

### DIFF
--- a/plan/issues/2134-ir-effect-model-ordered-emission.md
+++ b/plan/issues/2134-ir-effect-model-ordered-emission.md
@@ -1,10 +1,12 @@
 ---
 id: 2134
 title: "IR effect model: classify instruction kinds, enforce program-order emission for effectful ops"
-status: ready
+status: done
 sprint: current
 created: 2026-06-12
 updated: 2026-07-02
+completed: 2026-07-02
+assignee: ttraenkler/dev-2912f
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -13,7 +15,7 @@ task_type: architecture
 area: compiler
 language_feature: compiler-internals
 goal: correctness
-related: [1924, 1982, 1925]
+related: [1924, 1982, 1925, 2135, 2138]
 origin: "2026-06-12 sprint-62 architecture analysis (IR workstream N1)"
 ---
 
@@ -50,3 +52,138 @@ kind re-rolls the dice.
 
 Fable-routed: the effects-table design review is the hard part. Sequence
 with #1924 (the verifier framework it plugs into).
+
+## Reground (2026-07-02, dev-2912f) — what already exists on main
+
+The issue's premise ("no pure/read/write/control classification") is
+PARTIALLY STALE. The #1982 fix (PR #1405) matured into a real classification,
+private to `lower.ts` (~2443-2646 on `89ab6295`):
+
+- **`SchedFx`** — per-instr effect summary: `readsHeap` / `writesHeap` /
+  `allSlots` / `readSlots: Set<number>` / `writeSlots: Set<number>`, with
+  buffer recursion (loops/try/if), memoization, and per-slot precision.
+- **`schedFxOf`** — an EXHAUSTIVE switch over `IrInstr` kinds with a
+  TS-`never` exhaustiveness check AND a runtime full-barrier default, so a
+  new kind is (a) a compile error until classified and (b) never silently
+  re-orderable. This is the issue's "effects table" in substance.
+- **The anchor pass** (`anchorEager`, lower.ts ~545-633) — defers a
+  single-use def only when no conflicting effect (`schedFxConflicts`) sits
+  between def and use; otherwise anchors at def position via a local.
+- `tests/issue-1982-ir-emission-order.test.ts` — repros A+B are ALREADY
+  regression-guarded (acceptance criterion 1 satisfied on main).
+- #1924 (verifier framework) is DONE — `verifyIrFunction` exists.
+
+**What is genuinely missing:**
+
+1. **Two parallel effect tables with opposite failure polarities.**
+   `passes/dead-code.ts isSideEffecting` is a hand-maintained boolean
+   blocklist whose default for a NEW kind is "not side-effecting" (DCE may
+   silently delete it) — the exact inverse of `schedFxOf`'s safe default.
+   One table must be the single source of truth.
+2. **No independent verifier of the computed schedule.** The anchor pass is
+   the only guardian of ordering; a bug in it ships silently. The issue's
+   acceptance criterion 2 (inject a deferred `class.get` past a `class.set`
+   → verification fails) needs a checker that re-derives legality from first
+   principles, not a re-run of the same loop.
+
+## Design (dev-2912f, 2026-07-02)
+
+**New module `src/ir/effects.ts`** — the effect analogue of `capability.ts`
+(#2135's one-source-of-truth pattern; placed as a dependency-free `src/ir/`
+leaf so the scheduler (`lower.ts`), DCE (`passes/dead-code.ts`), the verifier
+(`verify.ts`), and future consumers (capability table #2135/dev-2138f,
+selector arms #2856/dev-2856f) all import ONE classification):
+
+```ts
+export interface IrEffects {
+  readsHeap: boolean; // mutable heap state (struct fields, globals, vec elems, host)
+  writesHeap: boolean; // heap writes / arbitrary effects (calls, iterator advance)
+  control: boolean; // throw / await / async.* — cannot be reordered or dropped
+  allSlots: boolean; // statically-unknown Wasm-local access (raw.wasm, gen.*)
+  readSlots: ReadonlySet<number>;
+  writeSlots: ReadonlySet<number>;
+}
+export function effectsOf(instr: IrInstr, cache?: Map<IrInstr, IrEffects>): IrEffects;
+export function effectsArePure(fx: IrEffects): boolean;
+export function effectsConflict(a: IrEffects, b: IrEffects): boolean;
+// DCE facet — kept as an explicit named export (not loosely derived) so the
+// slice-1 refactor is provably behavior-identical; the honest derivation
+// (writesHeap || control || allSlots || writeSlots.size > 0, plus the
+// documented always-keep quirks like slot.read) is a LATER, equivalence-
+// proven slice because today's list has deliberate policy quirks.
+export function isSideEffecting(instr: IrInstr): boolean;
+```
+
+`control` is carried as its own facet (today folded into
+`readsHeap+writesHeap` for throw/await): scheduling treats it as a full
+barrier exactly as before (no behavior change), but DCE and future consumers
+need "cannot drop" distinct from "touches heap".
+
+**Verifier rule — `verifyEmissionSchedule` (in `effects.ts`, wired from the
+scheduler; #1924-style error list):** an INDEPENDENT post-hoc check of the
+anchor pass's output, algorithmically different from the pass itself
+(pairwise over effectful instrs, not a re-run of the anchor loop):
+
+> For every pair `i < k` in one block where `effectsConflict(fx_i, fx_k)`
+> and both are emitted: the execution point of `i` must not be after `k`'s.
+> Execution point = `emissionIdx[]` with the same-tree tie-break (equal
+> index is legal only when `k`'s lazy tree transitively consumes `i`'s
+> result — operands execute before consumers inside one tree).
+
+Wiring: `lower.ts` calls it right after the anchor pass computes
+`emissionIdx`/`isLazyAt`. Failure policy follows the existing IR-verifier
+convention (#1921/#2137): hard error under `irVerifierHardFailureEnabled`
+(CI / test / VITEST), demote-to-legacy warning channel otherwise — an
+always-on tripwire that can never miscompile silently in production.
+Acceptance criterion 2 is a direct unit test of the exported checker with a
+forged schedule (`class.get` deferred past a `class.set`).
+
+**Slices (each byte-neutral, proven):**
+
+1. **Extract + unify (pure move)** — `SchedFx` machinery moves verbatim to
+   `effects.ts` (renamed `IrEffects`/`effectsOf`/…); `isSideEffecting` moves
+   beside it unchanged; `lower.ts` + `dead-code.ts` import from the new
+   module. A drift-tripwire unit test asserts the cross-table consistency
+   property (every `isSideEffecting` kind is non-pure per `effectsOf`).
+   Proof: byte-identity over the playground corpus (hash compiled binaries
+   main vs branch) + full `tests/ir/` + `issue-1982` suite.
+2. **`verifyEmissionSchedule` + wiring + unit tests** — verify-only, no
+   emission change; byte-identity holds by construction. Adds the
+   criterion-2 forged-schedule test and a good-schedule pass test.
+3. **(Follow-up issue, NOT this PR)** — derive the DCE facet from the table
+   honestly (per-quirk equivalence proofs; e.g. today a dead `object.get`
+   whose read could throw IS dropped — a policy decision to revisit), and
+   offer effect facets to the #2135 capability table / selector arms.
+
+**Coordination:** `effects.ts` is a new file — no collision with
+dev-2138f's `capability.ts` or dev-2856f's selector arms; both consume it
+later at their own pace. Interface frozen as above unless they object.
+(dev-2138f ACKed: no clash with #2972; its new string-charAt call classifies
+under the existing `call` row — conservative, correct. dev-2937f's #1930
+TypeOracle seam ACKed both ways: effects keyed on IrInstr kind, oracle on
+ts.Node/ts.Type; neither imports the other.)
+
+## Test Results (2026-07-02, dev-2912f — slices 1+2 landed, all acceptance criteria met)
+
+- **Acceptance 1** (#1982 repros A+B regression-guarded): pre-existing
+  `tests/issue-1982-ir-emission-order.test.ts` — green before and after.
+- **Acceptance 2** (deferred `class.get` past `class.set` fails
+  verification): `tests/issue-2134.test.ts` — 11/11 green: forged-schedule
+  rejection (def@0/past@1 attributed), anchored-schedule acceptance,
+  same-tree consumption tie-break (accept + reject arms), never-emitted
+  exemption, pure-commutes, cross-table drift tripwire over 20
+  representative kinds, the documented `extern.regex` divergence pinned,
+  control-facet assertions, conflict-relation basics, and a wired e2e
+  (class read/write interleave computes 79, no verifier demotion under the
+  vitest-HARD policy).
+- **Acceptance 3** (no byte-diff on the corpus): compiled-binary SHA-256 of
+  all 13 playground examples IDENTICAL to the pre-change baseline after
+  slice 1 AND after slice 2 (hash probe in the PR).
+- `check:ir-fallbacks` gate OK — zero post-claim demotions induced (the
+  wired verifier fires nowhere on the corpus).
+- `tests/ir/**` 138 green (the 8 failures in `passes.test.ts`/
+  `inline-small.test.ts` are the known pre-existing #1167a/b breakage,
+  verified identical on pristine main earlier this session);
+  `tsc --noEmit` clean.
+- Slice 3 (honest DCE-facet derivation + `extern.regex` divergence
+  resolution + capability/selector consumption) filed as a follow-up issue.

--- a/plan/issues/2857-ir-class-method-residual-to-zero.md
+++ b/plan/issues/2857-ir-class-method-residual-to-zero.md
@@ -85,3 +85,15 @@ inheritance with `super`.
 - `scripts/ir-fallback-baseline.json` — ratchet down.
 - `src/codegen/index.ts:1013` — `STRICT_IR_REASONS` once at zero.
 - `plan/log/ir-adoption.md` — promote rows.
+
+## Banked triage (2026-07-02, dev-2912f — pre-gate prep for the #2856-sequenced dispatch)
+
+`JS2WASM_IR_SHAPE_DIAG=1 check:ir-fallbacks --shape-diag` snapshot (main
+`46e390c`-era): the `class-method` bucket is **6**, all in
+`website/playground/examples/js/classes.ts` (the #1370 Phase C/D/E residual
+this issue targets). Overall corpus context: 32 `body-shape-rejected`
+attributions dominated by `vardecl-init-expr:PropertyAccessExpression` (13 —
+host-global member access, dev-2856f's extern-in-IR dependency), then
+`vardecl-init-expr:CallExpression` (4), `unattributed-arm:helper-internal`
+(4), `body-unhandled-stmt:IfStatement` (3). Use `--shape-diag` per-function
+attribution for the initial triage once the extern-in-IR gate clears.

--- a/plan/issues/2858-ir-call-graph-closure-to-zero.md
+++ b/plan/issues/2858-ir-call-graph-closure-to-zero.md
@@ -74,3 +74,15 @@ downstream of those callee rejections.
 - `scripts/ir-fallback-baseline.json` — ratchet down.
 - `src/codegen/index.ts:1013` — `STRICT_IR_REASONS` once at zero.
 - `plan/log/ir-adoption.md` — confirms the relevant rows once promoted.
+
+## Banked triage (2026-07-02, dev-2912f — pre-gate prep for the #2856-sequenced dispatch)
+
+`check:ir-fallbacks` snapshot (main `46e390c`-era): `call-graph-closure` is
+**7** — `benchmarks/helpers.ts` 1 (bcrd → unclaimed `el`, blocked on the
+extern-in-IR/body-shape work), `dom/calendar.ts` 3, `js/algorithms.ts` 1,
+`js/builtins.ts` 2. Consistent with this issue's "derivative" framing: most
+entries clear as their callees' `body-shape-rejected` /
+`vardecl-init-expr:PropertyAccessExpression` (13 instances, extern-in-IR
+dependency) causes are fixed by #2856/#2857 — expect this bucket to shrink
+substantially without direct work; re-run the gate before triaging what
+remains.

--- a/plan/issues/2990-ir-effects-dce-derivation-and-consumers.md
+++ b/plan/issues/2990-ir-effects-dce-derivation-and-consumers.md
@@ -14,7 +14,7 @@ language_feature: compiler-internals
 goal: correctness
 parent: 2134
 related: [2134, 2135, 1982]
-origin: "#2134 slice-3 follow-up (design doc in plan/issues/2134-*.md)"
+origin: "#2134 slice-3 follow-up (design doc in plan/issues/2134-ir-effect-model-ordered-emission.md)"
 ---
 
 # #2990 — finish unifying the IR effect model (#2134 slice 3)

--- a/plan/issues/2990-ir-effects-dce-derivation-and-consumers.md
+++ b/plan/issues/2990-ir-effects-dce-derivation-and-consumers.md
@@ -1,0 +1,68 @@
+---
+id: 2990
+title: "IR effects slice 3: derive the DCE facet from the effects table, resolve the extern.regex divergence, offer facets to capability/selector"
+status: ready
+sprint: Backlog
+created: 2026-07-02
+priority: medium
+horizon: m
+feasibility: medium
+reasoning_effort: high
+task_type: architecture
+area: compiler
+language_feature: compiler-internals
+goal: correctness
+parent: 2134
+related: [2134, 2135, 1982]
+origin: "#2134 slice-3 follow-up (design doc in plan/issues/2134-*.md)"
+---
+
+# #2990 — finish unifying the IR effect model (#2134 slice 3)
+
+#2134 slices 1+2 landed `src/ir/effects.ts` (the scheduler's exhaustive
+`effectsOf` table + the DCE `isSideEffecting` facet moved beside it, plus the
+independent `verifyEmissionSchedule` tripwire). Deliberately left for this
+follow-up, each needing its own equivalence proof (NOT byte-identity — these
+change behavior):
+
+## 1. Derive `isSideEffecting` from the table
+
+Today it is a verbatim-moved hand list. The honest derivation is roughly
+`writesHeap || control || allSlots || writeSlots.size > 0` plus documented
+policy quirks that must each be either preserved-with-rationale or fixed:
+
+- `slot.read` is always-keep ("avoid breaking the for-of body's load/use
+  pattern") — a scheduling artifact, not an effect; check whether it is
+  still needed post-#1982.
+- `iter.done` / `iter.value` are NOT DCE-pinned but ARE full barriers in
+  the scheduler — probably correct (reads of iterator state), verify.
+- A dead `object.get` / `class.get` / `vec.get` whose read could TRAP
+  (null deref, OOB) IS droppable today — dropping erases an observable
+  throw. Decide policy (JS semantics says keep; perf says drop) and encode
+  it once.
+
+## 2. Resolve the `extern.regex` divergence
+
+DCE-kept (RegExp_new may throw on bad pattern syntax) but scheduler-PURE —
+the scheduler may today reorder a regex literal across effectful ops,
+moving its potential throw. Classify it `control: true` (or heap-read) in
+`effectsOf` and prove the emission delta on regex-using corpora is
+behavior-equivalent (the tripwire test in `tests/issue-2134.test.ts` pins
+the current divergence and must be updated by this change).
+
+## 3. Offer effect facets to #2135 capability / selector consumers
+
+dev-2138f (capability.ts) ACKed the composition direction: capability rows
+may consult effect facets (e.g. "claim only if the lowering's instrs are
+effect-classifiable"). Design with them; keep `effects.ts` a dependency-free
+leaf (consumers import it, never the reverse).
+
+## Acceptance
+
+- `isSideEffecting` computed from `effectsOf` + an explicit, documented
+  quirk table; a new IrInstr kind gets its DCE polarity from the table
+  (safe default: kept) instead of the old silent-droppable default.
+- `extern.regex` reorder hazard closed with an equivalence-proven
+  classification change.
+- No test262 regression; equivalence suite green; the #2134 tripwire test
+  updated to assert consistency with zero exemptions.

--- a/src/ir/effects.ts
+++ b/src/ir/effects.ts
@@ -1,0 +1,497 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2134 — the IR effect model: ONE source of truth for "what does an
+// instruction read/write/keep-alive", consumed by every pass that makes a
+// decision based on effects:
+//
+//   - the emission scheduler (`lower.ts` anchor pass) — may a single-use def
+//     be deferred to its use site, or must it anchor at def position?
+//   - dead-code elimination (`passes/dead-code.ts`) — may an unused result's
+//     instruction be dropped?
+//   - the schedule verifier (#2134 slice 2, `verifyEmissionSchedule` below) —
+//     did the scheduler's output preserve program order for conflicting ops?
+//   - future consumers: the #2135 capability table and the #2856 selector
+//     arms may consult effect facets; neither imports this file's consumers
+//     (this stays a dependency-free `src/ir/` leaf, like `capability.ts`).
+//
+// Why this file exists (#2134): "what effects does instruction kind K have"
+// used to be encoded twice with OPPOSITE failure polarities — the scheduler's
+// `SchedFx` table (formerly private to lower.ts, #1982) defaults a new kind
+// to a FULL BARRIER (safe: never re-orderable until classified), while DCE's
+// `isSideEffecting` blocklist defaulted a new kind to "not side-effecting"
+// (dangerous: silently droppable). Centralizing both here — next to each
+// other, with a cross-table drift tripwire test (`tests/issue-2134.test.ts`)
+// — makes the polarity gap visible and gives new instruction kinds ONE place
+// to declare their effects. The TS `never` exhaustiveness check in
+// `effectsOf` makes an unclassified new kind a compile error.
+//
+// Slots are Wasm locals of the current function: nothing but `slot.write`
+// (and the loop headers that own dedicated slot indices) can modify them —
+// calls cannot reach another function's locals, and mutable closure captures
+// go through refcells. That keeps slot conflicts precise per index, which
+// matters because `slot.read` is by far the most common deferred read.
+//
+// KNOWN DIVERGENCE (documented, not yet resolved — #2134 slice 3):
+// `extern.regex` is DCE-kept (`isSideEffecting` → true: `RegExp_new` may
+// throw on bad pattern syntax) but scheduler-PURE (`effectsOf` → no flags:
+// re-ordering a fresh-allocation is treated as unobservable). A throw is an
+// observable control effect, so the scheduler classification is arguably too
+// permissive for a program that relies on the throw's position; changing it
+// alters emission for regex-using functions and therefore needs its own
+// equivalence-proven slice, not the slice-1 byte-identical move.
+
+import type { IrInstr, IrValueId } from "./nodes.js";
+
+/**
+ * Per-instruction effect summary. (#1982 introduced this as `SchedFx`,
+ * private to lower.ts; #2134 slice 1 moved it here verbatim and added the
+ * `control` facet.)
+ */
+export interface IrEffects {
+  /** Reads mutable heap state (struct fields, globals, vec elements, host objects). */
+  readsHeap: boolean;
+  /** Writes heap state or has arbitrary effects (calls, iterator advance, throw). */
+  writesHeap: boolean;
+  /**
+   * Control effect — throw / await / async completion. Cannot be re-ordered
+   * OR dropped. (#2134) Carried as its own facet: the scheduler already
+   * treats these as full barriers via `readsHeap+writesHeap` (unchanged
+   * behavior), but DCE and future consumers need "cannot drop" distinct
+   * from "touches heap".
+   */
+  control: boolean;
+  /** Touches statically-unknown slots (raw.wasm may local.set; gen.* use func-level slots). */
+  allSlots: boolean;
+  readSlots: Set<number>;
+  writeSlots: Set<number>;
+}
+
+/**
+ * Classify one instruction (recursing into nested buffers). Memoize with the
+ * caller-provided cache — the scheduler calls this O(n²) per block.
+ *
+ * Classification groups (verbatim from the #1982 `schedFxOf`):
+ *  - pure: constants, arithmetic, fresh allocation, immutable string ops;
+ *  - heap reads: global/object/class/vec/refcell/closure-capture reads;
+ *  - heap writes: global/object/class/refcell writes;
+ *  - call-like full barrier: calls, extern ops, iterator protocol, throw,
+ *    await/async (also `control: true` for throw/await/async.*);
+ *  - slot-precise: slot.read / slot.write by index; loop headers write their
+ *    pre-allocated state slots; gen.* / raw.wasm touch unknown slots.
+ *
+ * A NEW instruction kind is a TS compile error here (`never` check) and a
+ * runtime full barrier until classified — it can never silently become
+ * re-orderable (#2134's founding requirement).
+ */
+export function effectsOf(instr: IrInstr, cache: Map<IrInstr, IrEffects> = new Map()): IrEffects {
+  const hit = cache.get(instr);
+  if (hit) return hit;
+  const fx: IrEffects = {
+    readsHeap: false,
+    writesHeap: false,
+    control: false,
+    allSlots: false,
+    readSlots: new Set(),
+    writeSlots: new Set(),
+  };
+  // Memoize BEFORE recursing — buffers cannot be cyclic, but this keeps the
+  // walk linear in total instr count.
+  cache.set(instr, fx);
+  const mergeBuffer = (body: readonly IrInstr[]): void => {
+    for (const sub of body) {
+      const s = effectsOf(sub, cache);
+      fx.readsHeap ||= s.readsHeap;
+      fx.writesHeap ||= s.writesHeap;
+      fx.control ||= s.control;
+      fx.allSlots ||= s.allSlots;
+      for (const x of s.readSlots) fx.readSlots.add(x);
+      for (const x of s.writeSlots) fx.writeSlots.add(x);
+    }
+  };
+  switch (instr.kind) {
+    // Pure: constants, arithmetic, allocation of fresh objects, immutable
+    // string content ops. Re-ordering these is unobservable.
+    case "const":
+    case "string.const":
+    case "binary":
+    case "unary":
+    case "select":
+    case "box":
+    case "unbox":
+    case "tag.test":
+    case "coerce.to_externref":
+    case "string.concat":
+    case "string.eq":
+    case "string.len":
+    case "object.new":
+    case "vec.new_fixed": // #1804 — fresh vec allocation, pure (like object.new)
+    case "refcell.new":
+    case "closure.new":
+    case "extern.regex": // NOTE: DCE-kept (may throw) — see KNOWN DIVERGENCE above.
+      break;
+    // Reads of mutable heap state.
+    case "global.get":
+    case "object.get":
+    case "class.get":
+    case "vec.get":
+    case "vec.len":
+    case "refcell.get":
+    case "closure.cap":
+      fx.readsHeap = true;
+      break;
+    // Writes of heap state (void-result, so only ever hazards).
+    case "global.set":
+    case "object.set":
+    case "class.set":
+    case "refcell.set":
+      fx.writesHeap = true;
+      break;
+    // Call-like: may read AND write arbitrary heap state. `extern.prop` can
+    // trigger a host getter; iterator ops advance host iterator state.
+    case "call":
+    case "class.call":
+    case "closure.call":
+    case "extern.call":
+    case "class.new":
+    case "extern.new":
+    case "extern.prop":
+    case "extern.propSet":
+    case "iter.new":
+    case "iter.next":
+    case "iter.done":
+    case "iter.value":
+    case "iter.return":
+      fx.readsHeap = true;
+      fx.writesHeap = true;
+      break;
+    // Control effects: throw is a control effect treated as a full heap
+    // barrier; await / async completions suspend/complete observably.
+    case "throw":
+    case "await":
+    case "async.return":
+    case "async.throw":
+      fx.readsHeap = true;
+      fx.writesHeap = true;
+      fx.control = true;
+      break;
+    // Generator ops read/write the function-level buffer/pendingThrow slots
+    // (slot indices live on IrFunction, not on the instr) plus the heap.
+    case "gen.push":
+    case "gen.epilogue":
+    case "gen.yieldStar":
+      fx.readsHeap = true;
+      fx.writesHeap = true;
+      fx.allSlots = true;
+      break;
+    // Raw embedded Wasm may contain arbitrary ops including local.set.
+    case "raw.wasm":
+      fx.readsHeap = true;
+      fx.writesHeap = true;
+      fx.allSlots = true;
+      break;
+    case "slot.read":
+      fx.readSlots.add(instr.slotIndex);
+      break;
+    case "slot.write":
+      fx.writeSlots.add(instr.slotIndex);
+      break;
+    // Loop headers write their pre-allocated state slots every iteration;
+    // body/cond/update effects merge in recursively.
+    case "forof.vec":
+      fx.readsHeap = true;
+      for (const s of [instr.counterSlot, instr.lengthSlot, instr.vecSlot, instr.dataSlot, instr.elementSlot]) {
+        fx.writeSlots.add(s);
+      }
+      mergeBuffer(instr.body);
+      break;
+    case "forof.iter":
+      fx.readsHeap = true;
+      fx.writesHeap = true; // iterator protocol host calls
+      for (const s of [instr.iterSlot, instr.resultSlot, instr.elementSlot]) fx.writeSlots.add(s);
+      mergeBuffer(instr.body);
+      break;
+    case "forof.string":
+      fx.readsHeap = true;
+      for (const s of [instr.counterSlot, instr.lengthSlot, instr.strSlot, instr.elementSlot]) {
+        fx.writeSlots.add(s);
+      }
+      mergeBuffer(instr.body);
+      break;
+    case "while.loop":
+      mergeBuffer(instr.cond);
+      mergeBuffer(instr.body);
+      break;
+    case "for.loop":
+      mergeBuffer(instr.cond);
+      mergeBuffer(instr.body);
+      mergeBuffer(instr.update);
+      break;
+    case "try":
+      mergeBuffer(instr.body);
+      if (instr.catchClause) mergeBuffer(instr.catchClause.body);
+      if (instr.finallyBody) mergeBuffer(instr.finallyBody);
+      break;
+    case "if":
+      mergeBuffer(instr.then);
+      mergeBuffer(instr.else);
+      break;
+    default: {
+      // Future instruction kinds default to a full barrier so a new kind can
+      // never silently become re-orderable.
+      const _exhaustive: never = instr;
+      void _exhaustive;
+      fx.readsHeap = true;
+      fx.writesHeap = true;
+      fx.control = true;
+      fx.allSlots = true;
+      break;
+    }
+  }
+  return fx;
+}
+
+/** No observable effects at all — freely re-orderable and droppable. */
+export function effectsArePure(fx: IrEffects): boolean {
+  return (
+    !fx.readsHeap &&
+    !fx.writesHeap &&
+    !fx.control &&
+    !fx.allSlots &&
+    fx.readSlots.size === 0 &&
+    fx.writeSlots.size === 0
+  );
+}
+
+/** May re-ordering `a` across `b` change observable behavior? */
+export function effectsConflict(a: IrEffects, b: IrEffects): boolean {
+  if (a.writesHeap && (b.readsHeap || b.writesHeap)) return true;
+  if (b.writesHeap && a.readsHeap) return true;
+  const aTouchesSlots = a.allSlots || a.readSlots.size > 0 || a.writeSlots.size > 0;
+  const bTouchesSlots = b.allSlots || b.readSlots.size > 0 || b.writeSlots.size > 0;
+  if (a.allSlots && bTouchesSlots) return true;
+  if (b.allSlots && aTouchesSlots) return true;
+  for (const s of a.writeSlots) {
+    if (b.readSlots.has(s) || b.writeSlots.has(s)) return true;
+  }
+  for (const s of b.writeSlots) {
+    if (a.readSlots.has(s)) return true;
+  }
+  return false;
+}
+
+// ── #2134 slice 2 — emission-schedule verification ──────────────────────────
+
+/** One program-order violation found in a computed emission schedule. */
+export interface EmissionScheduleViolation {
+  /** Program-order index of the instruction that was moved. */
+  readonly defIndex: number;
+  /** Program-order index of the conflicting instruction it crossed. */
+  readonly pastIndex: number;
+  readonly reason: string;
+}
+
+/**
+ * Independent post-hoc check of the scheduler's output (#2134 acceptance
+ * criterion 2). The anchor pass in `lower.ts` DECIDES which single-use defs
+ * may defer to their use site; this function RE-DERIVES legality from first
+ * principles — pairwise over the emitted effectful instructions, not a re-run
+ * of the anchor loop — so a bug in the pass cannot hide itself:
+ *
+ *   For every pair `i < k` (program order) of emitted instructions whose
+ *   effects conflict, `i` must execute no later than `k`. Execution point is
+ *   `emissionIdx[]`; an equal index means both execute within one lazy tree,
+ *   which is legal only when `k`'s tree transitively consumes `i`'s result
+ *   (operands execute before their consumer; `i` can never consume `k` —
+ *   SSA def-before-use).
+ *
+ * `emissionIdx[i] === Infinity` marks a never-emitted instruction (dead pure
+ * value, or a read consumed only by dead chains) — it executes nowhere and
+ * constrains nothing. `usesOf` is injected by the caller so this leaf module
+ * mirrors the scheduler's exact operand-surface semantics (`collectIrUses`)
+ * without importing `lower.ts`.
+ */
+export function verifyEmissionSchedule(
+  instrs: readonly IrInstr[],
+  emissionIdx: readonly number[],
+  isLazyAt: readonly boolean[],
+  usesOf: (instr: IrInstr) => readonly IrValueId[],
+  cache: Map<IrInstr, IrEffects> = new Map(),
+): EmissionScheduleViolation[] {
+  const out: EmissionScheduleViolation[] = [];
+  const n = instrs.length;
+
+  // Only emitted, non-pure instructions participate — a pure effect summary
+  // conflicts with nothing (`effectsConflict` is false against it).
+  const effectful: number[] = [];
+  for (let i = 0; i < n; i++) {
+    if (!Number.isFinite(emissionIdx[i])) continue; // never emitted
+    if (!effectsArePure(effectsOf(instrs[i], cache))) effectful.push(i);
+  }
+  if (effectful.length < 2) return out;
+
+  const defIdxOf = new Map<IrValueId, number>();
+  instrs.forEach((instr, i) => {
+    if (instr.result !== null) defIdxOf.set(instr.result, i);
+  });
+  /** Does the lazy tree rooted at `k` transitively consume `target`? */
+  const treeConsumes = (k: number, target: IrValueId): boolean => {
+    const seen = new Set<number>();
+    const stack = [k];
+    while (stack.length > 0) {
+      const cur = stack.pop()!;
+      if (seen.has(cur)) continue;
+      seen.add(cur);
+      for (const u of usesOf(instrs[cur])) {
+        if (u === target) return true;
+        const d = defIdxOf.get(u);
+        if (d !== undefined && isLazyAt[d]) stack.push(d);
+      }
+    }
+    return false;
+  };
+
+  for (let a = 0; a < effectful.length; a++) {
+    for (let b = a + 1; b < effectful.length; b++) {
+      const i = effectful[a]!;
+      const k = effectful[b]!;
+      const fi = effectsOf(instrs[i]!, cache);
+      const fk = effectsOf(instrs[k]!, cache);
+      if (!effectsConflict(fi, fk)) continue;
+      const ei = emissionIdx[i]!;
+      const ek = emissionIdx[k]!;
+      if (ei < ek) continue; // program order preserved
+      if (ei === ek) {
+        const r = instrs[i]!.result;
+        if (r !== null && treeConsumes(k, r)) continue; // operand-before-consumer inside one tree
+        out.push({
+          defIndex: i,
+          pastIndex: k,
+          reason:
+            `conflicting ${instrs[i]!.kind}@${i} and ${instrs[k]!.kind}@${k} emitted in the same ` +
+            `tree (idx ${ei}) without consumption ordering`,
+        });
+        continue;
+      }
+      out.push({
+        defIndex: i,
+        pastIndex: k,
+        reason: `deferred ${instrs[i]!.kind}@${i} (emits at ${ei}) crosses conflicting ${instrs[k]!.kind}@${k} (emits at ${ek})`,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * DCE facet: side-effecting instructions are always kept regardless of use
+ * count. (#2134 slice 1: moved VERBATIM from `passes/dead-code.ts` — an
+ * explicit hand-audited list, deliberately NOT derived from `effectsOf` yet.
+ * Today's list carries policy quirks (e.g. `slot.read` is always-keep for the
+ * for-of body's load/use pattern; a dead `object.get` whose read could trap
+ * IS droppable) whose honest table-derivation needs per-quirk equivalence
+ * proofs — #2134 slice 3.)
+ *
+ * - `raw.wasm` — opaque Wasm ops with unknown effects (spec #1167a mandates
+ *    this stays live).
+ * - `call` — conservatively treated as having side effects. Purity analysis
+ *    is a later pass.
+ * - `global.set` — writes observable state.
+ */
+export function isSideEffecting(i: IrInstr): boolean {
+  return (
+    i.kind === "raw.wasm" ||
+    i.kind === "call" ||
+    i.kind === "global.set" ||
+    // Slice 3 (#1169c): closure.call may invoke a body with arbitrary
+    // effects (mutates ref cells, sets globals, calls other functions).
+    // Conservatively keep it live regardless of result use count.
+    i.kind === "closure.call" ||
+    // refcell.set writes observable state through the cell ref.
+    // refcell.new is pure (allocates a fresh struct), so leave it
+    // out — DCE may strip it when its result is dead.
+    i.kind === "refcell.set" ||
+    // object.set mutates the struct (slice 2 didn't add this, but is
+    // currently void-result so the existing `result === null → keep`
+    // catches it; explicit listing is a no-op for now).
+    i.kind === "object.set" ||
+    // Slice 4 (#1169d): class.call invokes a method body with potentially
+    // arbitrary effects. class.set mutates the instance. class.new calls
+    // a constructor (which may run side-effecting user code, e.g.
+    // `this.x = computeAndLogX()`). Conservatively keep all three live.
+    i.kind === "class.call" ||
+    i.kind === "class.set" ||
+    i.kind === "class.new" ||
+    // Slice 6 (#1169e): slot.write and forof.vec are statement-level
+    // side effects — the loop's body executes for every element.
+    // slot.read is pure (load a Wasm local) but always-keep to avoid
+    // breaking the for-of body's load/use pattern.
+    i.kind === "slot.write" ||
+    i.kind === "forof.vec" ||
+    // Slice 6 part 3 (#1182): host-iterator protocol ops mutate iterator
+    // state (advance pointer, dispose). DCE must not eliminate them
+    // even when their results are unused — a `iter.next` whose value is
+    // dropped still has the side effect of advancing the iterator.
+    // forof.iter is statement-level (result: null) and is kept by the
+    // generic null-result rule, but the explicit listing makes the
+    // intent obvious.
+    i.kind === "iter.new" ||
+    i.kind === "iter.next" ||
+    i.kind === "iter.return" ||
+    i.kind === "forof.iter" ||
+    // Slice 7a (#1169f): gen.push pushes a value onto the eager
+    // generator buffer (observable through __gen_next). gen.epilogue
+    // calls __create_generator with the buffer and is materially
+    // referenced as the function's return value — but DCE's
+    // propagation only flows through `result`-bearing instrs, so
+    // explicitly pinning here is the simplest correctness rule.
+    // Without this, DCE would consider gen.push's `value` operand
+    // dead and strip the const that produces it, leaving a stale
+    // SSA reference that the verifier rejects.
+    i.kind === "gen.push" ||
+    i.kind === "gen.epilogue" ||
+    // Slice 7b (#1169f): gen.yieldStar drains every value from the
+    // inner iterable onto the buffer — observable through __gen_next
+    // downstream. Pin for the same reason as gen.push: the operand
+    // (`inner`) must stay live, but DCE's propagation only flows
+    // through `result`-bearing instrs.
+    i.kind === "gen.yieldStar" ||
+    // Slice 6 part 4 (#1183): forof.string is statement-level (result:
+    // null) so the generic null-result rule already keeps it; explicit
+    // listing for clarity.
+    i.kind === "forof.string" ||
+    // Slice 9 (#1169h): throw / try are statement-level side effects
+    // (control flow). DCE must always preserve them.
+    i.kind === "throw" ||
+    i.kind === "try" ||
+    // Slice 12 (#1280): while.loop / for.loop are statement-level control
+    // flow (result: null). They must always run AND their cond/body/update
+    // buffers must be use-walked so a value referenced only inside the loop
+    // stays live. They are seeded here (not merely kept by the null-result
+    // rule) so `collectUses(_, { deep: true })` runs over their buffers.
+    // (#1922 — fixes the ordinary `while (i < limit)` IR demotion.)
+    i.kind === "while.loop" ||
+    i.kind === "for.loop" ||
+    // Slice 10 (#1169i): extern class ops invoke host imports with
+    // arbitrary side effects. Conservatively keep all five live so DCE
+    // never strips a `RegExp_new` or `Uint8Array_set` whose result is
+    // unused but whose execution is observable.
+    i.kind === "extern.new" ||
+    i.kind === "extern.call" ||
+    i.kind === "extern.propSet" ||
+    // extern.prop is a getter call — most are pure but some (Date.now,
+    // Map.size after concurrent mutation) reflect external state. Keep
+    // conservatively until a purity analysis distinguishes them.
+    i.kind === "extern.prop" ||
+    // extern.regex calls RegExp_new which is morally pure (allocates
+    // a fresh value), but it may throw on bad pattern syntax — keep
+    // the side-effect of the throw observable to user code.
+    i.kind === "extern.regex" ||
+    // (#1373 Phase B) Async / await IR nodes are control-flow with
+    // observable suspension / Promise side effects. DCE must always
+    // preserve them. Phase C lowering (CPS transform) does not change
+    // this — even unused-result awaits need to suspend.
+    i.kind === "await" ||
+    i.kind === "async.return" ||
+    i.kind === "async.throw"
+  );
+}

--- a/src/ir/integration.ts
+++ b/src/ir/integration.ts
@@ -736,7 +736,16 @@ export function compileIrPathFunctions(
       errors.push({
         func: name,
         message: e instanceof Error ? e.message : String(e),
-        kind: e instanceof Error && e.message.includes("backend legality failed") ? "backend-legality" : "lower",
+        // (#2134) "emission-schedule verify" marks a failure of the
+        // independent schedule checker in lower.ts — classify it "verify" so
+        // it is a HARD failure under CI/test (`irVerifierHardFailureEnabled`)
+        // while remaining a demote-to-legacy warning in production.
+        kind:
+          e instanceof Error && e.message.includes("backend legality failed")
+            ? "backend-legality"
+            : e instanceof Error && e.message.includes("emission-schedule verify")
+              ? "verify"
+              : "lower",
       });
     }
   }

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -70,7 +70,17 @@ import {
   asVal,
   forEachNestedBuffer,
 } from "./nodes.js";
-import { isSideEffecting } from "./passes/dead-code.js";
+// #2134 — the unified IR effect model (formerly the private `SchedFx` table
+// here plus `isSideEffecting` in passes/dead-code.ts; moved verbatim), plus
+// the slice-2 independent schedule verifier.
+import {
+  effectsOf,
+  effectsArePure,
+  effectsConflict,
+  isSideEffecting,
+  verifyEmissionSchedule,
+  type IrEffects,
+} from "./effects.js";
 import type { BlockType, FuncTypeDef, Instr, LocalDef, ValType, WasmFunction } from "./types.js";
 export type {
   IrBoxedLowering,
@@ -544,7 +554,7 @@ export function lowerIrFunctionBody<S>(
   // program order — this is purely an emission-scheduling fix.
   const anchorEager = new Set<IrValueId>();
   {
-    const fxCache = new Map<IrInstr, SchedFx>();
+    const fxCache = new Map<IrInstr, IrEffects>();
     const NEVER = Number.POSITIVE_INFINITY;
     for (const block of func.blocks) {
       const instrs = block.instrs;
@@ -607,14 +617,14 @@ export function lowerIrFunctionBody<S>(
         let e = NEVER;
         for (const c of consumers) e = Math.min(e, c === n ? n : emissionIdx[c]);
         if (e === NEVER) continue; // consumed only by dead chains — never emitted
-        const fx = schedFxOf(instr, fxCache);
+        const fx = effectsOf(instr, fxCache);
         let anchored = false;
-        if (!schedFxIsPure(fx)) {
+        if (!effectsArePure(fx)) {
           for (let k = i + 1; k < e && k < n; k++) {
             const ek = emissionIdx[k];
             if (ek === NEVER || ek > e) continue; // executes after our tree (or never) — def order preserved
             if (ek === e && treeConsumes(k, r)) continue; // same tree, operands emit before consumers
-            if (schedFxConflicts(fx, schedFxOf(instrs[k], fxCache))) {
+            if (effectsConflict(fx, effectsOf(instrs[k], fxCache))) {
               anchored = true;
               break;
             }
@@ -628,6 +638,23 @@ export function lowerIrFunctionBody<S>(
           emissionIdx[i] = e;
           isLazyAt[i] = true;
         }
+      }
+
+      // #2134 slice 2 — independent post-hoc verification of the computed
+      // schedule: pairwise over emitted effectful instrs, program order must
+      // be preserved for conflicting effects (an algorithmically separate
+      // re-derivation, so an anchor-pass bug cannot hide itself). The throw
+      // is caught by the integration loop; the "emission-schedule verify"
+      // marker classifies it kind "verify" → HARD failure under CI/test
+      // (`irVerifierHardFailureEnabled`), demote-to-legacy warning in
+      // production — a tripwire that can never miscompile silently.
+      const scheduleViolations = verifyEmissionSchedule(instrs, emissionIdx, isLazyAt, collectIrUses, fxCache);
+      if (scheduleViolations.length > 0) {
+        throw new Error(
+          `emission-schedule verify: ${scheduleViolations[0]!.reason}` +
+            (scheduleViolations.length > 1 ? ` (+${scheduleViolations.length - 1} more)` : "") +
+            ` in ${func.name} [#2134]`,
+        );
       }
     }
   }
@@ -2438,211 +2465,6 @@ export function lowerIrFunctionBody<S>(
     typeIdx,
     exported: func.exported,
   };
-}
-
-// --- #1982: emission-scheduling effect summaries ----------------------------
-//
-// `emitBlockBody`'s lazy use-site emission re-orders instruction trees
-// relative to program order. That is sound only for values that commute with
-// everything in between. These summaries classify what each instruction reads
-// and writes so the scheduler can anchor order-sensitive values at their def
-// position instead.
-//
-// Slots are Wasm locals of the current function: nothing but `slot.write`
-// (and the loop headers that own dedicated slot indices) can modify them —
-// calls cannot reach another function's locals, and mutable closure captures
-// go through refcells. That keeps slot conflicts precise per index, which
-// matters because `slot.read` is by far the most common deferred read.
-
-interface SchedFx {
-  /** Reads mutable heap state (struct fields, globals, vec elements, host objects). */
-  readsHeap: boolean;
-  /** Writes heap state or has arbitrary effects (calls, iterator advance, throw). */
-  writesHeap: boolean;
-  /** Touches statically-unknown slots (raw.wasm may local.set; gen.* use func-level slots). */
-  allSlots: boolean;
-  readSlots: Set<number>;
-  writeSlots: Set<number>;
-}
-
-function schedFxOf(instr: IrInstr, cache: Map<IrInstr, SchedFx>): SchedFx {
-  const hit = cache.get(instr);
-  if (hit) return hit;
-  const fx: SchedFx = {
-    readsHeap: false,
-    writesHeap: false,
-    allSlots: false,
-    readSlots: new Set(),
-    writeSlots: new Set(),
-  };
-  // Memoize BEFORE recursing — buffers cannot be cyclic, but this keeps the
-  // walk linear in total instr count.
-  cache.set(instr, fx);
-  const mergeBuffer = (body: readonly IrInstr[]): void => {
-    for (const sub of body) {
-      const s = schedFxOf(sub, cache);
-      fx.readsHeap ||= s.readsHeap;
-      fx.writesHeap ||= s.writesHeap;
-      fx.allSlots ||= s.allSlots;
-      for (const x of s.readSlots) fx.readSlots.add(x);
-      for (const x of s.writeSlots) fx.writeSlots.add(x);
-    }
-  };
-  switch (instr.kind) {
-    // Pure: constants, arithmetic, allocation of fresh objects, immutable
-    // string content ops. Re-ordering these is unobservable.
-    case "const":
-    case "string.const":
-    case "binary":
-    case "unary":
-    case "select":
-    case "box":
-    case "unbox":
-    case "tag.test":
-    case "coerce.to_externref":
-    case "string.concat":
-    case "string.eq":
-    case "string.len":
-    case "object.new":
-    case "vec.new_fixed": // #1804 — fresh vec allocation, pure (like object.new)
-    case "refcell.new":
-    case "closure.new":
-    case "extern.regex":
-      break;
-    // Reads of mutable heap state.
-    case "global.get":
-    case "object.get":
-    case "class.get":
-    case "vec.get":
-    case "vec.len":
-    case "refcell.get":
-    case "closure.cap":
-      fx.readsHeap = true;
-      break;
-    // Writes of heap state (void-result, so only ever hazards).
-    case "global.set":
-    case "object.set":
-    case "class.set":
-    case "refcell.set":
-      fx.writesHeap = true;
-      break;
-    // Call-like: may read AND write arbitrary heap state. `extern.prop` can
-    // trigger a host getter; iterator ops advance host iterator state; throw
-    // is a control effect treated as a full heap barrier.
-    case "call":
-    case "class.call":
-    case "closure.call":
-    case "extern.call":
-    case "class.new":
-    case "extern.new":
-    case "extern.prop":
-    case "extern.propSet":
-    case "iter.new":
-    case "iter.next":
-    case "iter.done":
-    case "iter.value":
-    case "iter.return":
-    case "throw":
-    case "await":
-    case "async.return":
-    case "async.throw":
-      fx.readsHeap = true;
-      fx.writesHeap = true;
-      break;
-    // Generator ops read/write the function-level buffer/pendingThrow slots
-    // (slot indices live on IrFunction, not on the instr) plus the heap.
-    case "gen.push":
-    case "gen.epilogue":
-    case "gen.yieldStar":
-      fx.readsHeap = true;
-      fx.writesHeap = true;
-      fx.allSlots = true;
-      break;
-    // Raw embedded Wasm may contain arbitrary ops including local.set.
-    case "raw.wasm":
-      fx.readsHeap = true;
-      fx.writesHeap = true;
-      fx.allSlots = true;
-      break;
-    case "slot.read":
-      fx.readSlots.add(instr.slotIndex);
-      break;
-    case "slot.write":
-      fx.writeSlots.add(instr.slotIndex);
-      break;
-    // Loop headers write their pre-allocated state slots every iteration;
-    // body/cond/update effects merge in recursively.
-    case "forof.vec":
-      fx.readsHeap = true;
-      for (const s of [instr.counterSlot, instr.lengthSlot, instr.vecSlot, instr.dataSlot, instr.elementSlot]) {
-        fx.writeSlots.add(s);
-      }
-      mergeBuffer(instr.body);
-      break;
-    case "forof.iter":
-      fx.readsHeap = true;
-      fx.writesHeap = true; // iterator protocol host calls
-      for (const s of [instr.iterSlot, instr.resultSlot, instr.elementSlot]) fx.writeSlots.add(s);
-      mergeBuffer(instr.body);
-      break;
-    case "forof.string":
-      fx.readsHeap = true;
-      for (const s of [instr.counterSlot, instr.lengthSlot, instr.strSlot, instr.elementSlot]) {
-        fx.writeSlots.add(s);
-      }
-      mergeBuffer(instr.body);
-      break;
-    case "while.loop":
-      mergeBuffer(instr.cond);
-      mergeBuffer(instr.body);
-      break;
-    case "for.loop":
-      mergeBuffer(instr.cond);
-      mergeBuffer(instr.body);
-      mergeBuffer(instr.update);
-      break;
-    case "try":
-      mergeBuffer(instr.body);
-      if (instr.catchClause) mergeBuffer(instr.catchClause.body);
-      if (instr.finallyBody) mergeBuffer(instr.finallyBody);
-      break;
-    case "if":
-      mergeBuffer(instr.then);
-      mergeBuffer(instr.else);
-      break;
-    default: {
-      // Future instruction kinds default to a full barrier so a new kind can
-      // never silently become re-orderable.
-      const _exhaustive: never = instr;
-      void _exhaustive;
-      fx.readsHeap = true;
-      fx.writesHeap = true;
-      fx.allSlots = true;
-      break;
-    }
-  }
-  return fx;
-}
-
-function schedFxIsPure(fx: SchedFx): boolean {
-  return !fx.readsHeap && !fx.writesHeap && !fx.allSlots && fx.readSlots.size === 0 && fx.writeSlots.size === 0;
-}
-
-/** May re-ordering `a` across `b` change observable behavior? */
-function schedFxConflicts(a: SchedFx, b: SchedFx): boolean {
-  if (a.writesHeap && (b.readsHeap || b.writesHeap)) return true;
-  if (b.writesHeap && a.readsHeap) return true;
-  const aTouchesSlots = a.allSlots || a.readSlots.size > 0 || a.writeSlots.size > 0;
-  const bTouchesSlots = b.allSlots || b.readSlots.size > 0 || b.writeSlots.size > 0;
-  if (a.allSlots && bTouchesSlots) return true;
-  if (b.allSlots && aTouchesSlots) return true;
-  for (const s of a.writeSlots) {
-    if (b.readSlots.has(s) || b.writeSlots.has(s)) return true;
-  }
-  for (const s of b.writeSlots) {
-    if (a.readSlots.has(s)) return true;
-  }
-  return false;
 }
 
 function collectIrUses(instr: IrInstr): readonly IrValueId[] {

--- a/src/ir/passes/dead-code.ts
+++ b/src/ir/passes/dead-code.ts
@@ -37,6 +37,11 @@ import {
 } from "../nodes.js";
 import type { AllocSiteRegistry } from "../alloc-registry.js";
 import { retireAllocsIn } from "./alloc-discipline.js";
+// #2134 slice 1 — the DCE side-effect facet moved (verbatim) into the unified
+// effect model (`../effects.ts`, beside the scheduler's `effectsOf` table).
+// Re-exported so existing importers keep working.
+import { isSideEffecting } from "../effects.js";
+export { isSideEffecting };
 
 /**
  * Run dead-code elimination on an IR function. Returns the same reference
@@ -223,114 +228,6 @@ function computeLiveValues(fn: IrFunction, reachable: ReadonlySet<number>): Set<
   }
 
   return live;
-}
-
-/**
- * Side-effecting instructions are always kept regardless of use count.
- *
- * - `raw.wasm` — opaque Wasm ops with unknown effects (spec #1167a mandates
- *    this stays live).
- * - `call` — conservatively treated as having side effects. Purity analysis
- *    is a later pass.
- * - `global.set` — writes observable state.
- */
-export function isSideEffecting(i: IrInstr): boolean {
-  return (
-    i.kind === "raw.wasm" ||
-    i.kind === "call" ||
-    i.kind === "global.set" ||
-    // Slice 3 (#1169c): closure.call may invoke a body with arbitrary
-    // effects (mutates ref cells, sets globals, calls other functions).
-    // Conservatively keep it live regardless of result use count.
-    i.kind === "closure.call" ||
-    // refcell.set writes observable state through the cell ref.
-    // refcell.new is pure (allocates a fresh struct), so leave it
-    // out — DCE may strip it when its result is dead.
-    i.kind === "refcell.set" ||
-    // object.set mutates the struct (slice 2 didn't add this, but is
-    // currently void-result so the existing `result === null → keep`
-    // catches it; explicit listing is a no-op for now).
-    i.kind === "object.set" ||
-    // Slice 4 (#1169d): class.call invokes a method body with potentially
-    // arbitrary effects. class.set mutates the instance. class.new calls
-    // a constructor (which may run side-effecting user code, e.g.
-    // `this.x = computeAndLogX()`). Conservatively keep all three live.
-    i.kind === "class.call" ||
-    i.kind === "class.set" ||
-    i.kind === "class.new" ||
-    // Slice 6 (#1169e): slot.write and forof.vec are statement-level
-    // side effects — the loop's body executes for every element.
-    // slot.read is pure (load a Wasm local) but always-keep to avoid
-    // breaking the for-of body's load/use pattern.
-    i.kind === "slot.write" ||
-    i.kind === "forof.vec" ||
-    // Slice 6 part 3 (#1182): host-iterator protocol ops mutate iterator
-    // state (advance pointer, dispose). DCE must not eliminate them
-    // even when their results are unused — a `iter.next` whose value is
-    // dropped still has the side effect of advancing the iterator.
-    // forof.iter is statement-level (result: null) and is kept by the
-    // generic null-result rule, but the explicit listing makes the
-    // intent obvious.
-    i.kind === "iter.new" ||
-    i.kind === "iter.next" ||
-    i.kind === "iter.return" ||
-    i.kind === "forof.iter" ||
-    // Slice 7a (#1169f): gen.push pushes a value onto the eager
-    // generator buffer (observable through __gen_next). gen.epilogue
-    // calls __create_generator with the buffer and is materially
-    // referenced as the function's return value — but DCE's
-    // propagation only flows through `result`-bearing instrs, so
-    // explicitly pinning here is the simplest correctness rule.
-    // Without this, DCE would consider gen.push's `value` operand
-    // dead and strip the const that produces it, leaving a stale
-    // SSA reference that the verifier rejects.
-    i.kind === "gen.push" ||
-    i.kind === "gen.epilogue" ||
-    // Slice 7b (#1169f): gen.yieldStar drains every value from the
-    // inner iterable onto the buffer — observable through __gen_next
-    // downstream. Pin for the same reason as gen.push: the operand
-    // (`inner`) must stay live, but DCE's propagation only flows
-    // through `result`-bearing instrs.
-    i.kind === "gen.yieldStar" ||
-    // Slice 6 part 4 (#1183): forof.string is statement-level (result:
-    // null) so the generic null-result rule already keeps it; explicit
-    // listing for clarity.
-    i.kind === "forof.string" ||
-    // Slice 9 (#1169h): throw / try are statement-level side effects
-    // (control flow). DCE must always preserve them.
-    i.kind === "throw" ||
-    i.kind === "try" ||
-    // Slice 12 (#1280): while.loop / for.loop are statement-level control
-    // flow (result: null). They must always run AND their cond/body/update
-    // buffers must be use-walked so a value referenced only inside the loop
-    // stays live. They are seeded here (not merely kept by the null-result
-    // rule) so `collectUses(_, { deep: true })` runs over their buffers.
-    // (#1922 — fixes the ordinary `while (i < limit)` IR demotion.)
-    i.kind === "while.loop" ||
-    i.kind === "for.loop" ||
-    // Slice 10 (#1169i): extern class ops invoke host imports with
-    // arbitrary side effects. Conservatively keep all five live so DCE
-    // never strips a `RegExp_new` or `Uint8Array_set` whose result is
-    // unused but whose execution is observable.
-    i.kind === "extern.new" ||
-    i.kind === "extern.call" ||
-    i.kind === "extern.propSet" ||
-    // extern.prop is a getter call — most are pure but some (Date.now,
-    // Map.size after concurrent mutation) reflect external state. Keep
-    // conservatively until a purity analysis distinguishes them.
-    i.kind === "extern.prop" ||
-    // extern.regex calls RegExp_new which is morally pure (allocates
-    // a fresh value), but it may throw on bad pattern syntax — keep
-    // the side-effect of the throw observable to user code.
-    i.kind === "extern.regex" ||
-    // (#1373 Phase B) Async / await IR nodes are control-flow with
-    // observable suspension / Promise side effects. DCE must always
-    // preserve them. Phase C lowering (CPS transform) does not change
-    // this — even unused-result awaits need to suspend.
-    i.kind === "await" ||
-    i.kind === "async.return" ||
-    i.kind === "async.throw"
-  );
 }
 
 function shouldKeep(i: IrInstr, live: ReadonlySet<IrValueId>): boolean {

--- a/tests/issue-2134.test.ts
+++ b/tests/issue-2134.test.ts
@@ -1,0 +1,174 @@
+// (#2134) The IR effect model: one classification for scheduler + DCE, and an
+// independent verifier that the computed emission schedule preserves program
+// order for conflicting effects.
+//
+// Acceptance criteria covered here:
+//   2. "A unit test injecting a deferred `class.get` past a `class.set` fails
+//      verification" — the forged-schedule tests below.
+//   (1. #1982 repros A+B live in tests/issue-1982-ir-emission-order.test.ts;
+//    3. byte-identity on the playground corpus is proven in the PR via the
+//    corpus-hash probe — see the issue file's Test Results.)
+
+import { describe, it, expect } from "vitest";
+import type { IrInstr, IrValueId } from "../src/ir/nodes.js";
+import {
+  effectsOf,
+  effectsArePure,
+  effectsConflict,
+  isSideEffecting,
+  verifyEmissionSchedule,
+} from "../src/ir/effects.js";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// Minimal IrInstr stand-ins: the checker reads only `.kind` and `.result`;
+// operand structure is injected via `usesOf`.
+const vid = (n: number): IrValueId => n as unknown as IrValueId;
+const instr = (kind: string, result: number | null): IrInstr =>
+  ({ kind, result: result === null ? null : vid(result) }) as unknown as IrInstr;
+
+describe("#2134 — emission-schedule verifier", () => {
+  // Program order: v1 = class.get; class.set; use(v1).
+  // usesOf: the consumer (index 2) uses v1; nothing else uses anything.
+  const instrs = [instr("class.get", 1), instr("class.set", null), instr("binary", 2)];
+  const usesOf = (i: IrInstr): readonly IrValueId[] => (i === instrs[2] ? [vid(1)] : []);
+
+  it("REJECTS a class.get deferred past a class.set (forged schedule)", () => {
+    // Forged: the get (idx 0) lazily emits at its consumer (idx 2), crossing
+    // the set (idx 1) which emits in place — a read moved past a write.
+    const violations = verifyEmissionSchedule(instrs, [2, 1, 2], [true, false, false], usesOf);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0]!.defIndex).toBe(0);
+    expect(violations[0]!.pastIndex).toBe(1);
+    expect(violations[0]!.reason).toContain("class.get@0");
+    expect(violations[0]!.reason).toContain("class.set@1");
+  });
+
+  it("ACCEPTS the anchored schedule (get emitted in place)", () => {
+    const violations = verifyEmissionSchedule(instrs, [0, 1, 2], [false, false, false], usesOf);
+    expect(violations).toEqual([]);
+  });
+
+  it("ACCEPTS same-tree emission when the consumer tree consumes the read", () => {
+    // v1 = class.get; v2 = class.call(v1) — the get defers into the call's
+    // tree (equal emission index). Legal: operands execute before consumers.
+    const tree = [instr("class.get", 1), instr("class.call", 2)];
+    const treeUses = (i: IrInstr): readonly IrValueId[] => (i === tree[1] ? [vid(1)] : []);
+    expect(verifyEmissionSchedule(tree, [1, 1], [true, false], treeUses)).toEqual([]);
+  });
+
+  it("REJECTS same-tree emission without a consumption ordering", () => {
+    // Two conflicting effectful ops forged to the same emission index where
+    // the later one does NOT consume the earlier one's result.
+    const pair = [instr("class.get", 1), instr("class.set", null)];
+    const noUses = (): readonly IrValueId[] => [];
+    const violations = verifyEmissionSchedule(pair, [1, 1], [true, false], noUses);
+    expect(violations.length).toBe(1);
+    expect(violations[0]!.reason).toContain("same tree");
+  });
+
+  it("ignores never-emitted instructions (dead reads constrain nothing)", () => {
+    const violations = verifyEmissionSchedule(instrs, [Number.POSITIVE_INFINITY, 1, 2], [false, false, false], usesOf);
+    expect(violations).toEqual([]);
+  });
+
+  it("pure values never conflict regardless of schedule", () => {
+    const pure = [instr("const", 1), instr("class.set", null), instr("binary", 2)];
+    const pureUses = (i: IrInstr): readonly IrValueId[] => (i === pure[2] ? [vid(1)] : []);
+    // const deferred past the set — pure, so freely movable.
+    expect(verifyEmissionSchedule(pure, [2, 1, 2], [true, false, false], pureUses)).toEqual([]);
+  });
+});
+
+describe("#2134 — cross-table drift tripwire (scheduler table vs DCE facet)", () => {
+  // Every kind the DCE facet pins as side-effecting must be non-pure in the
+  // scheduler classification — otherwise the scheduler may reorder an op DCE
+  // considers observable. `extern.regex` is the ONE documented divergence
+  // (DCE-kept because RegExp_new may throw; scheduler-pure as a fresh
+  // allocation) — asserted explicitly so resolving it (#2134 slice 3) updates
+  // this test rather than silently changing behavior.
+  const representative: readonly string[] = [
+    "call",
+    "global.set",
+    "closure.call",
+    "refcell.set",
+    "object.set",
+    "class.call",
+    "class.set",
+    "class.new",
+    "slot.write",
+    "iter.new",
+    "iter.next",
+    "iter.return",
+    "throw",
+    "extern.new",
+    "extern.call",
+    "extern.propSet",
+    "extern.prop",
+    "await",
+    "async.return",
+    "async.throw",
+  ];
+
+  it("isSideEffecting ⇒ not scheduler-pure (representative kinds)", () => {
+    for (const kind of representative) {
+      const i =
+        kind === "slot.write" ? ({ kind, result: null, slotIndex: 0 } as unknown as IrInstr) : instr(kind, null);
+      expect(isSideEffecting(i), `${kind} should be side-effecting`).toBe(true);
+      expect(effectsArePure(effectsOf(i)), `${kind} must not be scheduler-pure`).toBe(false);
+    }
+  });
+
+  it("documents the extern.regex divergence (DCE-kept, scheduler-pure)", () => {
+    const i = instr("extern.regex", 1);
+    expect(isSideEffecting(i)).toBe(true); // may throw → DCE keeps it
+    expect(effectsArePure(effectsOf(i))).toBe(true); // scheduler treats as fresh allocation
+  });
+
+  it("control facet: throw/await/async.* are control effects and full barriers", () => {
+    for (const kind of ["throw", "await", "async.return", "async.throw"]) {
+      const fx = effectsOf(instr(kind, null));
+      expect(fx.control, `${kind}.control`).toBe(true);
+      expect(fx.readsHeap && fx.writesHeap, `${kind} full barrier`).toBe(true);
+    }
+  });
+
+  it("conflict relation basics", () => {
+    const read = effectsOf(instr("class.get", 1));
+    const write = effectsOf(instr("class.set", null));
+    const pure = effectsOf(instr("const", 1));
+    expect(effectsConflict(read, write)).toBe(true);
+    expect(effectsConflict(write, read)).toBe(true);
+    expect(effectsConflict(read, read)).toBe(false); // two reads commute
+    expect(effectsConflict(pure, write)).toBe(false);
+  });
+});
+
+describe("#2134 — wired end-to-end (the verifier does not fire on correct schedules)", () => {
+  it("the #1982 shape compiles IR-claimed and computes correctly", async () => {
+    // Interleaved class reads/writes — the exact hazard family. The anchor
+    // pass must anchor the read; the schedule verifier (now wired, HARD under
+    // vitest via irVerifierHardFailureEnabled) must stay silent.
+    const src = `
+class Box {
+  v: number;
+  constructor(v: number) { this.v = v; }
+}
+export function test(): number {
+  const b = new Box(7);
+  const before = b.v;   // must read 7, not 9
+  b.v = 9;
+  return before * 10 + b.v; // 79
+}
+`;
+    const r = await compile(src, { fileName: "t.ts" });
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    // No verifier demotion: under vitest a schedule violation is a HARD error,
+    // and no "[IR-FALLBACK]"-channel warning mentioning the verifier may appear.
+    expect(r.errors.some((e) => e.message.includes("emission-schedule verify"))).toBe(false);
+    const imports = buildImports(r.imports, undefined, r.stringPool) as WebAssembly.Imports;
+    const { instance } = await WebAssembly.instantiate(r.binary, imports);
+    (imports as { setExports?: (e: unknown) => void }).setExports?.(instance.exports);
+    expect((instance.exports as Record<string, () => unknown>).test()).toBe(79);
+  });
+});


### PR DESCRIPTION
Task #31 — the correctness foundation under the IR north star (#2167 Fable cluster): ONE effect classification consumed by every effects-based decision, plus an always-on tripwire so a scheduler bug can never miscompile silently. Design-first (full reground + design + slice plan in `plan/issues/2134-*.md`); both slices byte-neutral and proven.

## Reground (recorded in the issue)

The issue's premise was partially stale: the #1982 fix matured into a real exhaustive `SchedFx` classification + anchor pass inside `lower.ts`, and the #1982 repros are already regression-guarded. The genuinely missing pieces: (1) **two parallel effect tables with opposite failure polarities** — DCE's `isSideEffecting` defaulted a NEW instruction kind to silently-droppable, the exact inverse of the scheduler's full-barrier default; (2) **no independent verification** of the computed schedule.

## Slice 1 — extract + unify (pure move)

- **NEW `src/ir/effects.ts`** (dependency-free `src/ir/` leaf, the effect analogue of #2135's `capability.ts`): the `SchedFx` machinery moved verbatim (`IrEffects`/`effectsOf`/`effectsArePure`/`effectsConflict`) + a new explicit `control` facet (throw/await/async.* — behavior-neutral today, needed by DCE/consumers); the DCE `isSideEffecting` facet moved verbatim beside it. The one REAL divergence found (`extern.regex`: DCE-kept may-throw vs scheduler-pure reorderable) is documented in-file and pinned by test.
- `lower.ts` + `passes/dead-code.ts` become consumers (re-export preserved).

## Slice 2 — `verifyEmissionSchedule` (verify-only)

Independent post-hoc check of the anchor pass output — pairwise over emitted effectful instructions, algorithmically separate from the anchor loop: conflicting effects must preserve program order; an equal emission index is legal only under same-tree operand-before-consumer ordering. Wired in `lower.ts` after the pass; the `emission-schedule verify` marker is classified kind `"verify"` in `integration.ts` → **HARD failure under CI/test** (`irVerifierHardFailureEnabled`), demote-to-legacy warning in production.

## Acceptance criteria — all met

1. **#1982 repros A+B**: pre-existing suite, green before/after (and re-validated post-main-merge).
2. **Deferred `class.get` past `class.set` fails verification**: `tests/issue-2134.test.ts` (11/11) — forged-schedule rejection with def/past attribution, anchored + same-tree accept/reject arms, never-emitted exemption, pure-commutes, 20-kind drift tripwire, `extern.regex` divergence pin, control-facet + conflict basics, wired e2e.
3. **No byte-diff on the corpus**: compiled-binary SHA-256 of all 13 playground examples identical to the pre-change baseline after BOTH slices.

Plus: `check:ir-fallbacks` OK (zero post-claim demotions — the wired verifier fires nowhere on the corpus); `tests/ir/` 141 green post-merge (the 8 `passes.test.ts`/`inline-small.test.ts` failures are pre-existing #1167a/b, verified identical on pristine main); `tsc` clean.

## Also in this PR

- **NEW #2990** (id via `--allocate`): slice-3 follow-up — honest DCE-facet derivation (per-quirk equivalence proofs), `extern.regex` divergence resolution, capability/selector facet consumption.
- Banked #2857/#2858 `--shape-diag` triage snapshots (pre-gate prep, per tech-lead request).
- Coordination: dev-2138f ACKed (no `capability.ts` overlap; #2972's charAt call classifies under the `call` row); dev-2937f's #1930 TypeOracle seam ACKed (effects keyed on IrInstr kind, zero type facts, no cross-imports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS