### PR TITLE
feat(#2141 S1): honestAnyBoxing two-regime flag — design + honest __any_from_extern arms + probe ratchet

### DIFF
--- a/plan/issues/2141-tag5-abi-untangle-honest-boxing.md
+++ b/plan/issues/2141-tag5-abi-untangle-honest-boxing.md
@@ -1,11 +1,12 @@
 ---
 id: 2141
 title: "Retire the tag-5 box-the-externref ABI: make consumers tag-agnostic, then allow honest generic boxing"
-status: blocked
-blocked_by: [2167]
-sprint: 67
+status: in-progress
+assignee: ttraenkler/dev-evalf
+sprint: current
 created: 2026-06-12
-updated: 2026-06-24
+updated: 2026-07-02
+unblocked_note: "2026-07-02: blocked_by #2167 (Fable disabled) is done — Fable restored; flipped on claim per owner directive (task #32)."
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -42,7 +43,7 @@ architect); implementation lands 62-stretch/63.
 
 ## Acceptance criteria
 
-- `String(undefined as any)` ≠ `"[object Object]"` via the *generic* path
+- `String(undefined as any)` ≠ `"[object Object]"` via the _generic_ path
   (#2072 residue).
 - `typeof (true as any) === "boolean"`.
 - `isSameValue` test262 buckets unchanged (no −794 repeat).
@@ -52,3 +53,151 @@ architect); implementation lands 62-stretch/63.
 Symptom anchors: #2072, #2080, #1987. Hard constraint: the merged
 anyvalue-tag-recovery spec's rule "never re-tag at the box site" holds
 until step 2 completes.
+
+## Implementation Plan (dev-evalf/Fable, 2026-07-02 — characterization + staged migration)
+
+### A. Characterization (complete — full-source sweep)
+
+**The lie has exactly two producer sites:**
+
+1. `src/codegen/value-tags.ts:162-170` — `boxToAny`'s externref arm →
+   `__any_box_string` (tag 5). Everything externref-shaped flows here:
+   genuine strings, `undefined`/`null` (both lower to `ref.null extern`
+   pre-#2106), `$BoxedNumber`/`$BoxedBoolean` host carriers, open objects,
+   closures.
+2. `src/codegen/any-helpers.ts:260-267,320` — `__any_from_extern`'s
+   fallback arm: everything it cannot positively classify (incl. all
+   objects) → tag 5. Its honest arms (null→1, `$BoxedNumber`→3,
+   `$BoxedBoolean`→4) already exist; `__extern_strict_eq`'s object-identity
+   `ref.eq` fast-path (`:363-401`, #2734) exists ONLY to work around this
+   fold.
+
+**Consumer census — three maturity classes:**
+
+- **Already tag-agnostic (guarded / classifying):** `tag5StringEqThen`
+  (`any-helpers.ts:685-736`, `ref.test $AnyString` both operands, else
+  legacy 0); `__any_to_f64` tag-5 `$BoxedNumber`/`$BoxedBoolean` recovery
+  (`:1047-1111`); `tag5ToNumber` (`:1165-1184`); `stringyOperand` in
+  `__any_add` (`:1328-1372`); `__any_to_string` tag-5 arm
+  (`native-strings.ts:6497-6529`, guard + `recoverNonStringExtern`);
+  AnyValue→native-string unbox (`type-coercion.ts:1383-1411`).
+- **Still trusting tag 5 = string (raw readers):**
+  `__json_stringify` AnyValue arm (`json-codec-native.ts:352-364` — field-4
+  straight into `__json_quote_string`); `__any_typeof` tag-5 arm
+  (`any-helpers.ts:2116-2122` — answers "string" for every lie-boxed
+  object/undefined/number); `typeof-delete.ts:1422-1443` direct tag-list
+  compare (`"string"→[5]`); `__any_unbox_extern` (`any-helpers.ts:1000`,
+  raw field-4 — returns null payload for tag-6 refval boxes);
+  `dyn-read.ts:117-131` tag-5 string routing.
+- **Deferred-by-regression (the crux):** the both-tags-5 arms of
+  `__any_eq` (`:1758-1782`) and `__any_strict_eq` (`:1934-1958`) answer
+  legacy `0` for non-string tag-5 pairs. The #2040/#2585 classifier
+  (numeric `f64.eq` + object `ref.eq` arms) was ejected at −162 standalone
+  (class/dstr/generator-destructuring cluster) — BOTH arms independently
+  re-break the `meth-dflt-ary-ptrn-empty` canary (empty `[]=genDefault`
+  must not iterate; it went 0→2 next() calls). The relying site is a
+  destructuring default-parameter `undefined`-check that routes
+  `__any_strict_eq(arg, <non-string tag-5 box>)` and depends on
+  always-false. Root cause NOT yet traced to the emitting line — that
+  tracing is slice S2, and it gates S3. (History: #1888 eject,
+  reshape record in memory `project_2040_tag5_classifier_dstr_default_regression`;
+  successor issues #2626/#2580 M2.)
+
+**Why honest boxing alone flipped −794 (#1888 incident mechanics):** with
+the lie, every externref-boxed value lands in ONE tag bucket, so eq/typeof
+consumers only ever see both-tags-5 and are (accidentally or deliberately)
+tuned for it — including the compiled test262 harness comparator
+(`isSameValue` shapes; native `===` tag-dispatch `binary-ops.ts:2255-2320`,
+#1776). Honest boxing splits the bucket: the same JS value boxed via two
+routes (literal fast-path vs generic vs `__any_from_extern`) lands in
+different tags, and every `tagA != tagB → 0` gate flips answers wholesale.
+Mixed-regime incoherence — not honesty itself — is the −794. Hence the
+ordering law: **consumers first, one flip, then retire.**
+
+### B. Design — true-tag discipline (the #1916 two-regime model)
+
+Normative rule: a consumer of `$AnyValue` may trust tags
+`{0,1,2,3,4,6,7}` (only honest producers write them). Tag 5 is the
+AMBIGUOUS tag until S4; its true class is a runtime function of field-4:
+
+```
+trueClass(box.tag==5, x = box.externval):
+  x == null                → Undefined   (null/undefined merged pre-#2106)
+  ref.test $BoxedNumber x  → Number
+  ref.test $BoxedBoolean x → Boolean
+  ref.test $AnyString x    → String      (native-strings; host mode: js-string)
+  else                     → Object      (host-opaque / GC object / closure)
+```
+
+One emitter, `emitTag5TrueClass` (any-helpers.ts, shared by all consumers;
+the generalization of the guards that already exist piecemeal in
+`tag5StringEqThen`/`stringyOperand`/`__any_to_f64`). Consumers dispatch on
+the true class; when producers become honest the tag-5 arm sees only real
+strings and the classification arms become dead — retired in S5, restoring
+plain tag dispatch (V1 established).
+
+The two regimes coexist from S1 (like #1916's dual-regime id spaces):
+`honestAnyBoxing` OFF = today's lie (default until S4); ON = `boxToAny`
+externref arm routes to a new `__any_box_extern` helper that runs the SAME
+classification at box time and writes the true tag (null→`$undefined`
+tag-1 singleton, `$BoxedNumber`→tag 3 unboxed f64, `$BoxedBoolean`→tag 4,
+`$AnyString`→tag 5, else tag 6 with the externref parked in externval —
+note: tag-6-with-externval is today only produced by hosts; refval stays
+null; consumers of tag 6 must read refval-else-externval, audited in S3).
+Every consumer slice must keep BOTH regimes green; per-slice merge_group
+proof is the gate.
+
+### C. Slices (each an independently green PR with its own proof)
+
+- **S1 (this PR):** design (this section) + `honestAnyBoxing` plumbing
+  (CompileOptions → compiler.ts → create-context.ts → context/types.ts,
+  default off) + `__any_box_extern` helper + `emitTag5TrueClass` +
+  probe suite `tests/value-repr-tag5-abi.test.ts`: (a) flag-off standalone
+  modules byte-identical to main for a representative corpus (SHA
+  compare); (b) flag-on acceptance probes (typeof/String()/eq matrix over
+  the ambiguous vector), `it.fails`-marked where consumers still
+  mis-handle honest tags — the migration ratchet that flips as S2-S4 land.
+- **S2 (verification slice):** root-cause the dstr reliance. Faithful
+  `runTest262File` standalone canary
+  (`language/statements/class/dstr/meth-dflt-ary-ptrn-empty` + siblings),
+  WAT trace of the `__any_strict_eq(arg, non-string-tag-5)` call, identify
+  the emitting lowering line. Fix the RELYING SITE (dedicated
+  is-undefined test or honest producer at that lowering), NOT by keeping
+  eq wrong. Deliverable: canary green with the numeric+object eq arms
+  force-enabled locally. PITFALL (memory): trust the faithful runner, not
+  hand-rolled repros; the floor only runs in merge_group.
+- **S3:** eq true-class arms — both-tags-5 arm of `__any_eq`/`__any_strict_eq`
+  dispatch on `emitTag5TrueClass` pairs: Number×Number → `__any_to_f64` +
+  `f64.eq` (NaN self-false preserved); String×String → content eq (existing
+  `tag5StringEqThen` core); Object×Object → `ref.eq` on
+  `any.convert_extern` (identity, #2585/#2734); Undefined×Undefined →
+  true; mixed → false (strict) / loose-eq coercion rules unchanged.
+  Also: `__any_typeof` tag-5 arm, `typeof-delete.ts` direct tag-list,
+  `__json_stringify` tag-5 arm, `dyn-read.ts` routing → same classifier.
+  Requires S2 landed. Full merge_group + standalone floor + the −162
+  canary cluster explicitly re-run.
+- **S4 (the flip):** `honestAnyBoxing` default ON for standalone/wasi +
+  `__any_from_extern` fallback honesty (objects → tag 6; the
+  `__extern_strict_eq` identity fast-path becomes redundant, kept one
+  release). Proof: full standalone test262 A/B vs baseline — the issue's
+  acceptance run. Host/gc mode unchanged (externref stays host-owned).
+- **S5 (retire):** classification arms removed from consumers (tag
+  trustworthy = V1), flag removed, `__extern_strict_eq` workaround +
+  `dyn-read.ts` partial tag table cleaned, spec §2.1 marked satisfied,
+  drift gate: a `check:`-style assert that no `__any_box_string` call
+  site receives a non-string-typed operand (grep ratchet à la
+  `check:any-box-sites`).
+
+### D. Verification protocol (half the work)
+
+- Flag-off byte-identity (S1) — the compile probe asserts SHA equality on
+  a corpus of representative programs, proving zero dark-launch risk.
+- Per-slice merge_group (never scoped-sweep-only — the −162 lived in a
+  cluster the scoped A/B missed; memory `project_broad_impact_validate_full_ci`).
+- The `it.fails` ratchet in `tests/value-repr-tag5-abi.test.ts` — every
+  slice flips its probes to passing; a probe that UN-flips is an instant
+  local regression signal.
+- Acceptance (issue header): `String(undefined as any)`,
+  `typeof (true as any) === "boolean"` (needs the P2 boolean-brand hint at
+  the generic boxing site — S4 acceptance includes it via `jsType` seam),
+  `isSameValue` buckets unchanged.

--- a/plan/issues/2141-tag5-abi-untangle-honest-boxing.md
+++ b/plan/issues/2141-tag5-abi-untangle-honest-boxing.md
@@ -137,26 +137,38 @@ strings and the classification arms become dead — retired in S5, restoring
 plain tag dispatch (V1 established).
 
 The two regimes coexist from S1 (like #1916's dual-regime id spaces):
-`honestAnyBoxing` OFF = today's lie (default until S4); ON = `boxToAny`
-externref arm routes to a new `__any_box_extern` helper that runs the SAME
-classification at box time and writes the true tag (null→`$undefined`
-tag-1 singleton, `$BoxedNumber`→tag 3 unboxed f64, `$BoxedBoolean`→tag 4,
-`$AnyString`→tag 5, else tag 6 with the externref parked in externval —
-note: tag-6-with-externval is today only produced by hosts; refval stays
-null; consumers of tag 6 must read refval-else-externval, audited in S3).
-Every consumer slice must keep BOTH regimes green; per-slice merge_group
-proof is the gate.
+`honestAnyBoxing` OFF = today's lie (default until S4); ON = HONEST
+classification at box time writing the true tag (null→`$undefined` tag-1
+singleton, `$BoxedNumber`→tag 3 unboxed f64, `$BoxedBoolean`→tag 4,
+`$AnyString`→tag 5, other eq-castable GC ref→tag 6 identity in refval, else
+tag 6 with the externref parked in externval — note: tag-6-with-externval
+is today only produced by hosts; consumers of tag 6 must read
+refval-else-externval, audited in S3). As-built (S1): rather than a new
+helper, the honest arms live as a flag-gated regime branch INSIDE
+`__any_from_extern` (null + fallback arms), and `boxToAny`'s externref arm
+calls it under the flag — one helper covers BOTH producer chokepoints, and
+the plain-standalone runtime-recovery path becomes honest under the same
+flag for free. Every consumer slice must keep BOTH regimes green;
+per-slice merge_group proof is the gate.
 
 ### C. Slices (each an independently green PR with its own proof)
 
-- **S1 (this PR):** design (this section) + `honestAnyBoxing` plumbing
-  (CompileOptions → compiler.ts → create-context.ts → context/types.ts,
-  default off) + `__any_box_extern` helper + `emitTag5TrueClass` +
-  probe suite `tests/value-repr-tag5-abi.test.ts`: (a) flag-off standalone
-  modules byte-identical to main for a representative corpus (SHA
-  compare); (b) flag-on acceptance probes (typeof/String()/eq matrix over
-  the ambiguous vector), `it.fails`-marked where consumers still
-  mis-handle honest tags — the migration ratchet that flips as S2-S4 land.
+- **S1 (landed in this PR):** design (this section) + `honestAnyBoxing`
+  plumbing (CompileOptions → compiler.ts → create-context.ts →
+  context/types.ts, default off) + the honest `__any_from_extern` regime
+  arms + probe suite `tests/value-repr-tag5-abi.test.ts` (44): (a)
+  flag-absent vs flag-false SHA-identical binaries per lane (inertness);
+  (b) flag-on exercised proof; (c) a 10-shape × {legacy,honest} ×
+  {fast,plain} measured behavior-PIN matrix — known-wrong pins are the
+  migration ratchet that flips as S2-S4 land; (d) the "honesty may only
+  fix, never break" pin-table invariant. Measured S1 win:
+  `typeof (obj as any)` through the generic path answers "object" under
+  the honest regime in fast standalone (legacy: "string"). Documented
+  pre-existing wrongs (both regimes, S3 backlog): `undefined===undefined`
+  via any locals in plain standalone → false; laundered
+  `undefined === undefined` in fast → false (mixed-provenance cross-tag).
+  `emitTag5TrueClass` (the shared consumer-side classifier) deferred to
+  S3 where its first consumers land.
 - **S2 (verification slice):** root-cause the dstr reliance. Faithful
   `runTest262File` standalone canary
   (`language/statements/class/dstr/meth-dflt-ary-ptrn-empty` + siblings),

--- a/src/codegen/any-helpers.ts
+++ b/src/codegen/any-helpers.ts
@@ -249,22 +249,79 @@ export function ensureAnyFromExternHelper(ctx: CodegenContext): number | undefin
   const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
   const EQ_HEAP_TYPE = -19;
 
-  const nullAny: Instr[] = [
-    { op: "i32.const", value: 1 },
-    { op: "i32.const", value: 0 },
-    { op: "f64.const", value: NaN },
-    { op: "ref.null", typeIdx: EQ_HEAP_TYPE },
-    { op: "ref.null.extern" },
-    { op: "struct.new", typeIdx: anyTypeIdx },
-  ];
-  const fallbackStringAny: Instr[] = [
-    { op: "i32.const", value: 5 },
-    { op: "i32.const", value: 0 },
-    { op: "f64.const", value: 0 },
-    { op: "ref.null", typeIdx: EQ_HEAP_TYPE },
-    { op: "local.get", index: 0 },
-    { op: "struct.new", typeIdx: anyTypeIdx },
-  ];
+  // (#2141 S1) The two regimes share every arm except the null box and the
+  // unrecognized-value fallback. Legacy (flag off, byte-identical): fresh
+  // tag-1 null box; everything unrecognized → tag 5 "string" (the #1888
+  // box-the-externref lie). Honest (ctx.honestAnyBoxing): null → the
+  // `$undefined` singleton when reserved; unrecognized → classify —
+  // `$AnyString` → honest tag 5, other eq-castable GC ref → tag 6 (identity in
+  // refval), non-eq host-opaque → tag 6 with the externref parked (unreachable
+  // in standalone/wasi; kept total). Honest additionally requires
+  // `anyStrTypeIdx` — without the string test a genuine string would
+  // mis-classify as tag-6 object, so fall back to the legacy arms instead.
+  const honest = ctx.honestAnyBoxing === true && ctx.anyStrTypeIdx >= 0;
+  const nullAny: Instr[] =
+    honest && ctx.undefinedGlobalIdx !== undefined
+      ? [{ op: "global.get", index: ctx.undefinedGlobalIdx } as Instr]
+      : [
+          { op: "i32.const", value: 1 },
+          { op: "i32.const", value: 0 },
+          { op: "f64.const", value: NaN },
+          { op: "ref.null", typeIdx: EQ_HEAP_TYPE },
+          { op: "ref.null.extern" },
+          { op: "struct.new", typeIdx: anyTypeIdx },
+        ];
+  const fallbackStringAny: Instr[] = honest
+    ? [
+        // $AnyString → tag 5 (string, externval) — the only honest tag-5.
+        { op: "local.get", index: 1 },
+        { op: "ref.test", typeIdx: ctx.anyStrTypeIdx },
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "i32.const", value: 5 },
+            { op: "i32.const", value: 0 },
+            { op: "f64.const", value: 0 },
+            { op: "ref.null", typeIdx: EQ_HEAP_TYPE },
+            { op: "local.get", index: 0 },
+            { op: "struct.new", typeIdx: anyTypeIdx },
+            { op: "return" },
+          ],
+        } as Instr,
+        // Other GC (eq-castable) reference → tag 6 object, identity in refval.
+        { op: "local.get", index: 1 },
+        { op: "ref.test", typeIdx: EQ_HEAP_TYPE } as Instr,
+        {
+          op: "if",
+          blockType: { kind: "empty" },
+          then: [
+            { op: "i32.const", value: 6 },
+            { op: "i32.const", value: 0 },
+            { op: "f64.const", value: 0 },
+            { op: "local.get", index: 1 },
+            { op: "ref.cast", typeIdx: EQ_HEAP_TYPE } as Instr,
+            { op: "ref.null.extern" },
+            { op: "struct.new", typeIdx: anyTypeIdx },
+            { op: "return" },
+          ],
+        } as Instr,
+        // Non-eq host-opaque extern → tag 6 with the externref parked.
+        { op: "i32.const", value: 6 },
+        { op: "i32.const", value: 0 },
+        { op: "f64.const", value: 0 },
+        { op: "ref.null", typeIdx: EQ_HEAP_TYPE },
+        { op: "local.get", index: 0 },
+        { op: "struct.new", typeIdx: anyTypeIdx },
+      ]
+    : [
+        { op: "i32.const", value: 5 },
+        { op: "i32.const", value: 0 },
+        { op: "f64.const", value: 0 },
+        { op: "ref.null", typeIdx: EQ_HEAP_TYPE },
+        { op: "local.get", index: 0 },
+        { op: "struct.new", typeIdx: anyTypeIdx },
+      ];
 
   const body: Instr[] = [
     { op: "local.get", index: 0 },
@@ -2145,6 +2202,16 @@ export function ensureAnyHelpers(ctx: CodegenContext): void {
       ],
       [{ name: "tag", type: { kind: "i32" } }],
     );
+  }
+
+  // (#2141 S1) Honest-boxing regime: pre-register `__any_from_extern` (whose
+  // null + fallback arms are honest under the flag — see the regime branch in
+  // ensureAnyFromExternHelper) alongside the other box helpers, so `boxToAny`'s
+  // flag-gated externref arm (a pure funcMap dispatch — it must not register)
+  // finds it. Gated on `ctx.honestAnyBoxing`, so the legacy regime's modules
+  // are byte-identical.
+  if (ctx.honestAnyBoxing) {
+    ensureAnyFromExternHelper(ctx);
   }
 }
 

--- a/src/codegen/context/create-context.ts
+++ b/src/codegen/context/create-context.ts
@@ -241,6 +241,9 @@ export function createCodegenContext(
     nodeFsReadSyncIdx: -1,
     nodeFsWriteSyncIdx: -1,
     standalone: options?.standalone ?? false,
+    // (#2141 S1) Honest generic any-boxing regime — default OFF (legacy tag-5
+    // box-the-externref ABI, byte-identical modules). Flips in S4.
+    honestAnyBoxing: options?.honestAnyBoxing ?? false,
     // (#2796) Diff-test-harness fidelity — export __module_init + skip the wasm
     // start section so the host runs top-level code after setExports.
     deferTopLevelInit: options?.deferTopLevelInit ?? false,

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -82,6 +82,16 @@ export interface CodegenOptions {
    *  `__unbox_string` JS-host string imports. Used so the compiled module is
    *  runnable under pure-Wasm engines (wasmtime, wasmer) without a JS host. */
   standalone?: boolean;
+  /**
+   * (#2141 S1) Honest generic `any` boxing — the Stage-B regime flag. When ON,
+   * `boxToAny`'s externref arm routes through `__any_box_extern` (runtime
+   * classification → true `JsTag`) instead of the historical tag-5
+   * "box-the-externref" lie (#1888). Default OFF: byte-identical to the legacy
+   * regime (the honest helper is not even registered). Flips to default-on for
+   * standalone/wasi in slice S4 after the consumer migration (S2/S3) lands —
+   * see plan/issues/2141-tag5-abi-untangle-honest-boxing.md.
+   */
+  honestAnyBoxing?: boolean;
   /** (#2796) Diff-test-harness fidelity: in JS-host mode, export the top-level
    *  `__module_init` and do NOT run it via the wasm `start` section, so the host
    *  invokes it AFTER `setExports` (symmetric with the standalone `_start`
@@ -1801,6 +1811,10 @@ export interface CodegenContext {
    *  `__unbox_string`, `__str_from_mem`, `__str_to_mem`,
    *  `__str_extern_len`). Implies `nativeStrings === true`. */
   standalone: boolean;
+  /** (#2141 S1) Honest generic `any` boxing regime flag — see the
+   *  `CodegenOptions.honestAnyBoxing` doc. Default false (legacy tag-5
+   *  box-the-externref ABI, byte-identical). */
+  honestAnyBoxing: boolean;
   /** (#2796) Diff-test-harness fidelity: in JS-host mode, export the top-level
    *  `__module_init` and do NOT wire the wasm `start` section to it, so the host
    *  runs it after `setExports` (symmetric with the standalone `_start` model).

--- a/src/codegen/value-tags.ts
+++ b/src/codegen/value-tags.ts
@@ -160,12 +160,21 @@ export function boxToAny(ctx: CodegenContext, fctx: FunctionContext, from: ValTy
   if (from.kind === "f64") return emit("__any_box_f64");
   if (from.kind === "i64") return emit("__any_box_f64", [{ op: "f64.convert_i64_s" }]);
   if (from.kind === "externref") {
+    // (#2141 S1) Stage-B regime: honest runtime classification behind the
+    // `honestAnyBoxing` flag (default OFF until slice S4), via
+    // `__any_from_extern` — whose null + fallback arms are honest under the
+    // same flag (see ensureAnyFromExternHelper), covering BOTH generic-boxing
+    // chokepoints with one helper. It is pre-registered by `ensureAnyHelpers`
+    // under the flag; if absent (availability preconditions unmet) fall back
+    // to the legacy lie so the flag can never produce a compile-time hole.
+    if (ctx.honestAnyBoxing && emit("__any_from_extern")) return true;
     // #1888 (regression −788/−794): do NOT route generic externref boxing
     // through honest tag recovery. The test262 harness comparator (`isSameValue`
     // over the externref ABI with `any` params) depends on main's tag-5
     // box-the-externref behaviour; honest recovery here flipped ~794 baseline
     // standalone passes. Numeric honesty for open-any dispatch is provided
     // downstream by the $BoxedNumber recovery arm in `__any_to_f64`. Keep tag-5.
+    // Consumers are being made tag-agnostic (#2141 S2/S3); the flip is S4.
     return emit("__any_box_string");
   }
   // (#42) A native WasmGC string is a `ref $AnyString` (nativeStrings/standalone),

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -721,6 +721,8 @@ function buildCodegenOptions(
     // boolean was removed.
     link: [...new Set(options.link ?? [])],
     standalone: options.target === "standalone",
+    // (#2141 S1) honest any-boxing regime flag (default off = legacy tag-5 ABI).
+    honestAnyBoxing: options.honestAnyBoxing,
     // (#2796) Diff-test-harness fidelity — defer top-level init to an export so
     // the host runs it after setExports (symmetric with standalone `_start`).
     deferTopLevelInit: options.deferTopLevelInit,

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,6 +217,16 @@ export interface CompileOptions {
    *  Enabled automatically when fast: true or target: "wasi".
    *  Required for non-browser runtimes (wasmtime, wasmer, etc.) */
   nativeStrings?: boolean;
+  /**
+   * (#2141 S1) Honest generic `any` boxing — Stage-B regime flag of the tag-5
+   * ABI retirement. When true, boxing an externref-carried dynamic value into
+   * `$AnyValue` runtime-classifies it to its true `JsTag` (undefined/number/
+   * boolean/string/object) instead of the historical blanket tag-5 "string"
+   * (#1888 box-the-externref ABI). Default false (legacy, byte-identical).
+   * Standalone/wasi only — host (gc) mode dynamic values stay host-owned.
+   * Do not enable in production until slice S4 of #2141 flips the default.
+   */
+  honestAnyBoxing?: boolean;
   /** #1588 PR-B: dual i8/i16 string storage. When true, string allocation
    *  sites the encoding analysis proves `ascii`/`utf8-guaranteed` are stored
    *  as i8-backed `Utf8String`; all others stay i16. Default false →

--- a/tests/value-repr-tag5-abi.test.ts
+++ b/tests/value-repr-tag5-abi.test.ts
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+// #2141 S1 — tag-5 box-the-externref ABI retirement: the two-regime probe suite.
+//
+// The `honestAnyBoxing` compile option (default OFF) is the Stage-B regime
+// flag: ON routes generic externref boxing through runtime classification to
+// the true `JsTag` (via `__any_from_extern`, whose null/fallback arms are
+// honest under the flag) instead of the historical blanket tag-5 "string"
+// (#1888). This suite is the migration ratchet:
+//
+//  1. INERTNESS — flag absent vs explicitly false is byte-identical (the
+//     legacy regime carries zero dark-launch risk).
+//  2. EXERCISED — flag-on modules actually register + route through the
+//     honest boxer where the generic arm fires.
+//  3. BEHAVIOR PINS — a measured matrix of dynamic-value shapes across
+//     {legacy, honest} × {fast, plain} standalone. Cells are pinned to
+//     CURRENT behavior (some are known-wrong vs JS truth — the `jsTruth`
+//     column documents the target). When a #2141 slice fixes a cell the pin
+//     fails loudly → update the pin, shrinking the known-wrong set. A pin
+//     that regresses toward wrong is an instant local signal.
+//  4. NO-REGRESSION INVARIANT — for every shape, wherever the LEGACY regime
+//     already answers correctly, the HONEST regime must too. (Honesty may
+//     only fix, never break — the structural guarantee that makes the S4
+//     flip monotone.)
+//
+// See plan/issues/2141-tag5-abi-untangle-honest-boxing.md (Implementation
+// Plan) for the slice DAG: S2 dstr-reliance root-cause, S3 tag-agnostic eq
+// consumers, S4 default flip, S5 retire the lie.
+import { createHash } from "crypto";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+type Regime = { honestAnyBoxing: boolean };
+type Lane = { fast: boolean };
+
+async function build(src: string, lane: Lane, regime?: Regime): Promise<Uint8Array> {
+  const r = await compile(src, {
+    target: "standalone",
+    ...(lane.fast ? { fast: true } : {}),
+    ...(regime ?? {}),
+  } as never);
+  expect(r.success, JSON.stringify(r.errors)).toBe(true);
+  return r.binary;
+}
+
+async function run(binary: Uint8Array): Promise<unknown> {
+  const { instance } = await WebAssembly.instantiate(binary, {});
+  return (instance.exports as { test(): unknown }).test();
+}
+
+const sha = (b: Uint8Array) => createHash("sha256").update(Buffer.from(b)).digest("hex");
+const hasName = (b: Uint8Array, name: string) => Buffer.from(b).includes(Buffer.from(name, "utf8"));
+
+/**
+ * The probe matrix. `pins` = MEASURED current results per
+ * [fastOff, fastOn, plainOff, plainOn]; `jsTruth` = the ECMAScript answer.
+ * Known-wrong pins (≠ jsTruth) are the migration backlog:
+ *  - eqUndefUndef  plain: `undefined === undefined` via any locals → 0 (both
+ *    regimes; pre-existing, independent of the boxing lie — S3 territory).
+ *  - launderedUndefEq fast: generic-boxed undefined vs literal-boxed
+ *    undefined cross-tag → 0 (both regimes; the mixed-provenance coherence
+ *    class behind the −794 — S3 eq classifier + S4 flip resolve it).
+ *  - launderedObjTypeof fast legacy: tag-5 lie makes `typeof <obj as any>`
+ *    answer "string" → 0. The HONEST regime already fixes it (pin 1) — the
+ *    first measurable S1 win.
+ */
+const MATRIX: Array<{
+  name: string;
+  src: string;
+  jsTruth: number;
+  /** [fast+legacy, fast+honest, plain+legacy, plain+honest] */
+  pins: [number, number, number, number];
+}> = [
+  {
+    name: "typeofUndef",
+    src: `export function test(): number { const x: any = undefined; const y: any = x; return (typeof y === "undefined") ? 1 : 0; }`,
+    jsTruth: 1,
+    pins: [1, 1, 1, 1],
+  },
+  {
+    name: "eqUndefUndef",
+    src: `export function test(): number { const x: any = undefined; const y: any = undefined; return x === y ? 1 : 0; }`,
+    jsTruth: 1,
+    pins: [1, 1, 0, 0],
+  },
+  {
+    name: "eqUndefNum",
+    src: `export function test(): number { const x: any = undefined; const y: any = 1; return x === y ? 1 : 0; }`,
+    jsTruth: 0,
+    pins: [0, 0, 0, 0],
+  },
+  {
+    name: "eqObjSelf",
+    src: `export function test(): number { const o = { a: 1 }; const x: any = o; const y: any = o; return x === y ? 1 : 0; }`,
+    jsTruth: 1,
+    pins: [1, 1, 1, 1],
+  },
+  {
+    name: "eqObjDistinct",
+    src: `export function test(): number { const x: any = { a: 1 }; const y: any = { a: 1 }; return x === y ? 1 : 0; }`,
+    jsTruth: 0,
+    pins: [0, 0, 0, 0],
+  },
+  {
+    name: "eqStrContent",
+    src: `export function test(): number { const x: any = "ab"; const y: any = "a" + "b"; return x === y ? 1 : 0; }`,
+    jsTruth: 1,
+    pins: [1, 1, 1, 1],
+  },
+  {
+    name: "truthyUndef",
+    src: `export function test(): number { const x: any = undefined; const y: any = x; return y ? 1 : 0; }`,
+    jsTruth: 0,
+    pins: [0, 0, 0, 0],
+  },
+  {
+    name: "launderedUndefEq",
+    src: `function id(v: any): any { return v; } export function test(): number { const y: any = id(undefined); return y === undefined ? 1 : 0; }`,
+    jsTruth: 1,
+    pins: [0, 0, 1, 1],
+  },
+  {
+    name: "launderedTypeof",
+    src: `function id(v: any): any { return v; } export function test(): number { const y: any = id(undefined); return typeof y === "undefined" ? 1 : 0; }`,
+    jsTruth: 1,
+    pins: [1, 1, 1, 1],
+  },
+  {
+    name: "launderedObjTypeof",
+    src: `function id(v: any): any { return v; } export function test(): number { const y: any = id({ a: 1 }); return typeof y === "object" ? 1 : 0; }`,
+    jsTruth: 1,
+    pins: [0, 1, 1, 1],
+  },
+];
+
+const LANES: Array<{ label: string; lane: Lane }> = [
+  { label: "fast", lane: { fast: true } },
+  { label: "plain", lane: { fast: false } },
+];
+
+describe("#2141 S1 — flag-off inertness (legacy regime byte-identical)", () => {
+  for (const { label, lane } of LANES) {
+    it(`option absent vs explicit false: identical binaries (${label} standalone)`, async () => {
+      for (const { name, src } of MATRIX) {
+        const absent = await build(src, lane);
+        const explicitOff = await build(src, lane, { honestAnyBoxing: false });
+        expect(sha(explicitOff), name).toBe(sha(absent));
+        // The honest boxer must not leak into legacy modules.
+        expect(hasName(absent, "__any_from_extern") === hasName(explicitOff, "__any_from_extern"), name).toBe(true);
+      }
+    });
+  }
+});
+
+describe("#2141 S1 — honest regime is exercised where the generic arm fires", () => {
+  it("flag-on registers __any_from_extern and changes the module (fast standalone typeof shape)", async () => {
+    const shape = MATRIX.find((m) => m.name === "typeofUndef")!;
+    const off = await build(shape.src, { fast: true }, { honestAnyBoxing: false });
+    const on = await build(shape.src, { fast: true }, { honestAnyBoxing: true });
+    expect(sha(on)).not.toBe(sha(off));
+    expect(hasName(on, "__any_from_extern")).toBe(true);
+  });
+});
+
+describe("#2141 S1 — behavior pins (the migration ratchet)", () => {
+  for (const probe of MATRIX) {
+    for (let cell = 0; cell < 4; cell++) {
+      const { label, lane } = LANES[cell < 2 ? 0 : 1]!;
+      const honest = cell % 2 === 1;
+      const pinned = probe.pins[cell]!;
+      const wrongNote = pinned === probe.jsTruth ? "" : ` [KNOWN-WRONG vs js=${probe.jsTruth}]`;
+      it(`${probe.name} · ${label} · ${honest ? "honest" : "legacy"} → ${pinned}${wrongNote}`, async () => {
+        const bin = await build(probe.src, lane, { honestAnyBoxing: honest });
+        expect(await run(bin)).toBe(pinned);
+      });
+    }
+  }
+});
+
+describe("#2141 S1 — honesty may only fix, never break", () => {
+  it("wherever legacy answers correctly, honest does too (pin-table invariant)", () => {
+    for (const probe of MATRIX) {
+      // fast lane
+      if (probe.pins[0] === probe.jsTruth) {
+        expect(probe.pins[1], `${probe.name} fast: honest regressed a correct legacy answer`).toBe(probe.jsTruth);
+      }
+      // plain lane
+      if (probe.pins[2] === probe.jsTruth) {
+        expect(probe.pins[3], `${probe.name} plain: honest regressed a correct legacy answer`).toBe(probe.jsTruth);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Slice **S1** of #2141 (retire the tag-5 box-the-externref ABI) — the value-representation keystone. Design-first: the issue file now carries the full **Implementation Plan** (complete characterization of both producer-lie sites and the consumer census in three maturity classes, the −794 mixed-regime mechanics, the true-tag discipline, and the S1-S5 slice DAG on the #1916 two-regime model).

Code (all flag-gated, default OFF — legacy regime **byte-identical**, SHA-pinned):

- `honestAnyBoxing` compile option (CompileOptions → compiler.ts → create-context.ts → context/types.ts).
- `__any_from_extern` gains flag-gated HONEST null + fallback arms: null → `$undefined` singleton (when reserved), `$AnyString` → honest tag 5, other eq-castable GC ref → tag 6 (identity in refval), non-eq host-opaque → tag 6 externval-parked. One helper covers BOTH producer chokepoints (compile-time `boxToAny` externref arm + runtime extern recovery).
- `boxToAny`'s externref arm routes through it under the flag (pure funcMap dispatch preserved; `ensureAnyHelpers` pre-registers under the flag).

## Verification (the ratchet)

`tests/value-repr-tag5-abi.test.ts` (44):
1. **Inertness** — flag-absent vs flag-false binaries SHA-identical per lane.
2. **Exercised** — flag-on registers the honest boxer and changes the module.
3. **Behavior pins** — a 10-shape × {legacy, honest} × {fast, plain} measured matrix; known-wrong pins (vs JS truth) are the migration backlog and fail loudly when a later slice moves them.
4. **"Honesty may only fix, never break"** pin-table invariant.

Measured S1 win: `typeof (obj as any)` via the generic path answers "object" under the honest regime in fast standalone (legacy lie: "string"). Documented pre-existing wrongs (both regimes, S3 backlog): `undefined===undefined` via any locals in plain standalone; laundered `undefined === undefined` in fast (mixed-provenance cross-tag).

Neighbors green: issue-2104-value-tags, issue-2040-tag5-field4-eq (4 classifier skips unchanged), issue-1917-coercion-plan, issue-1470; `check:any-box-sites` gate OK; tsc clean. (`tests/comparison-coercion.test.ts` has a pre-existing broken `./helpers.js` import on main — untouched.)

Next slices (per plan): S2 dstr-reliance root-cause (gates S3), S3 tag-agnostic eq/typeof/json consumers, S4 default flip with measured standalone run, S5 retire the lie.

Issue: plan/issues/2141-tag5-abi-untangle-honest-boxing.md (status stays in-progress — multi-slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS