### PR TITLE
fix(#2972): gate string element access out of the IR-first skip set

### DIFF
--- a/plan/issues/2972-ir-string-elem-access-computed-index-drift.md
+++ b/plan/issues/2972-ir-string-elem-access-computed-index-drift.md
@@ -1,10 +1,11 @@
 ---
 id: 2972
 title: "IR selector accepts string element access with computed index; from-ast throws 'not in slice 12' — 14 test262 CEs under IR-first"
-status: ready
+status: done
 sprint: current
 created: 2026-07-02
 updated: 2026-07-02
+completed: 2026-07-02
 priority: medium
 feasibility: medium
 horizon: s
@@ -63,3 +64,38 @@ element-access arm and asserted at from-ast's lowering entry. Then either:
   function either legacy-compiles (option 1) or IR-compiles (option 2) —
   no hard error; the 14 test262 tests pass flag-on.
 - The shape guard lives in `capability.ts` (one row/predicate, not two).
+
+## Resolution (2026-07-02)
+
+Implemented option 1's outcome ("the 14 tests go back to legacy compile"), but
+at the IR-first **skip-set** layer rather than the selector/`capability.ts`,
+because two of the issue's premises did not hold up under measure-first:
+
+1. **Constant-index string reads are ALSO unimplemented.** `from-ast.ts`'s
+   `lowerElementAccess` has no string-receiver arm at all — `hex[0]` throws
+   `element access on string with index FirstLiteralToken not in slice 12`
+   exactly like `hex[i]`. So option 2 is not "extend constant to computed"; it
+   is building the string-read arm from scratch, including OOB→undefined
+   widening (the legacy `#2760` `expectedType` semantics) — a silent-miscompile
+   hazard, out of scope for this bug.
+2. **The selector cannot type-resolve the receiver.** `isPhase1Expr(expr,
+scope, localClasses)` is checker-free (`scope: ReadonlySet<string>`), so its
+   element-access arm cannot tell a `string` receiver from a `vec` receiver.
+   Rejecting computed-index element access there would over-reject working vec
+   `arr[i]` reads. The issue's "consumed by the selector's element-access arm,
+   single-sourced in capability.ts" is therefore infeasible as written.
+
+**Fix:** added **gate 5** (`irFirstBodyReadsStringElement`) to
+`computeIrFirstSkipSet` (`src/codegen/ir-first-gate.ts`, wired in
+`src/codegen/index.ts`), mirroring gate 4 (`irFirstBodyReadsHostNode`). Any
+function whose body reads an element of a (syntactically) string receiver stays
+on the **compile-twice** path (legacy body + silently-demoting overlay) instead
+of the IR-first compile-once set, so the from-ast throw demotes to a warning
+instead of the `[IR-FIRST skipped-slot]` hard error. No string-element read can
+validly be IR-first today (it always throws), so this loses nothing real and
+does not touch vec/object element access (verified). Lifting gate 5 is the
+trigger for a future real string-element-read lowering in the IR builder.
+
+Tests: `tests/issue-2972.test.ts` — harness runs correctly flag-on and
+flag-off; a claimed const-string-index function no longer hard-errors; vec
+`arr[i]` is still IR-first compile-once; predicate fire/no-fire table.

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -27,7 +27,11 @@ import { irVal, type IrType } from "../ir/nodes.js";
 import { buildTypeMap, type LatticeType } from "../ir/propagate.js";
 import { planIrCompilation, irClosureSignatureFromFunctionTypeNode, type IrFallbackReason } from "../ir/select.js";
 import { createCodegenContext } from "./context/create-context.js";
-import { collectModuleTopLevelNames, irFirstBodyReadsHostNode } from "./ir-first-gate.js";
+import {
+  collectModuleTopLevelNames,
+  irFirstBodyReadsHostNode,
+  irFirstBodyReadsStringElement,
+} from "./ir-first-gate.js";
 import type { FallbackCounts } from "./fallback-telemetry.js";
 import { buildLeakedHostImportError, scanForLeakedHostImports } from "./host-import-allowlist.js";
 import { reportError, reportErrorNoNode } from "./context/errors.js";
@@ -1172,6 +1176,7 @@ function computeIrFirstSkipSet(plan: IrOverlayPlan, sourceFile: ts.SourceFile): 
     const fn = plan.declByName.get(name);
     if (!fn || fn.asteriskToken) continue; // gate 2 — generators
     if (irFirstBodyReadsHostNode(fn, moduleNames)) continue; // gate 4 — host nodes
+    if (irFirstBodyReadsStringElement(fn)) continue; // gate 5 — string element read (#2972)
     if (!edges) continue; // no edge info (defensive) — stay conservative
     const callees = edges.get(name);
     let closed = true;

--- a/src/codegen/ir-first-gate.ts
+++ b/src/codegen/ir-first-gate.ts
@@ -138,3 +138,84 @@ export function irFirstBodyReadsHostNode(fn: ts.FunctionDeclaration, moduleNames
   scan(fn.body);
   return host;
 }
+
+/**
+ * Gate 5 of `computeIrFirstSkipSet` (#2972) — does this function's body read
+ * an element of a STRING receiver (`s[i]`)?
+ *
+ * The IR front-end has no string-element-read lowering at all: `from-ast.ts`'s
+ * `lowerElementAccess` dispatches only object-field (string-literal key) and
+ * vec (`array.get`) receivers; a `string`-typed receiver — with a constant
+ * OR a computed index — falls through to a hard `throw` ("element access on
+ * string … not in slice 12"). The selector's element-access arm, however,
+ * accepts the shape structurally (`isPhase1Expr(recv) && isPhase1Expr(index)`)
+ * because it is checker-free (`scope: ReadonlySet<string>` carries no types)
+ * and therefore cannot distinguish a string receiver from a vec receiver.
+ *
+ * Flag-OFF that from-ast throw silently demotes the function to legacy (which
+ * indexes strings correctly, incl. OOB→undefined). Flag-ON (IR-first), a
+ * CLAIMED function that throws during lowering is promoted to a HARD compile
+ * error (the `unreachable` placeholder must never ship) — the designed #2138
+ * surfacing. That turned 14 test262 helper functions (the `decimalToHexString`
+ * / `decimalToPercentHexString` harness, `hex[(n>>4)&0xf]`) into
+ * `pass → compile_error` regressions flag-on.
+ *
+ * Since the selector cannot type-resolve the receiver, and no string-element
+ * read can validly be IR-first today (it always throws), the guard lives here:
+ * keep any string-element-reading function on the compile-twice path (legacy +
+ * silently-demoting overlay) until an actual string-element-read lowering is
+ * proven in the IR builder — exactly the compile-twice deferral gate 4 uses
+ * for host nodes. Lifting this gate is the trigger for that future lowering.
+ *
+ * Checker-free string detection (conservative — a false positive only keeps a
+ * non-string element access on compile-twice, never a correctness risk; a
+ * false negative leaves a rarer string-receiver shape to hard-error as before,
+ * i.e. no NEW regression): a receiver is treated as a string when it is a
+ * string literal / template, or an identifier bound inside the function to a
+ * string-literal (or template) initializer, or a parameter annotated
+ * `: string`.
+ */
+export function irFirstBodyReadsStringElement(fn: ts.FunctionDeclaration): boolean {
+  if (!fn.body) return false;
+  // --- names known to hold a string value inside the function ---
+  const stringNames = new Set<string>();
+  const isStringInitializer = (e: ts.Expression | undefined): boolean =>
+    e !== undefined &&
+    (ts.isStringLiteral(e) || e.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral || ts.isTemplateExpression(e));
+  for (const p of fn.parameters) {
+    if (p.type?.kind === ts.SyntaxKind.StringKeyword && ts.isIdentifier(p.name)) stringNames.add(p.name.text);
+  }
+  const collect = (node: ts.Node): void => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+      if (node.type?.kind === ts.SyntaxKind.StringKeyword || isStringInitializer(node.initializer)) {
+        stringNames.add(node.name.text);
+      }
+    }
+    ts.forEachChild(node, collect);
+  };
+  collect(fn.body);
+  // --- flag an element access whose receiver is (syntactically) a string ---
+  const isStringReceiver = (e: ts.Expression): boolean => {
+    let cur = e;
+    while (ts.isParenthesizedExpression(cur) || ts.isNonNullExpression(cur) || ts.isAsExpression(cur))
+      cur = cur.expression;
+    if (
+      ts.isStringLiteral(cur) ||
+      cur.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral ||
+      ts.isTemplateExpression(cur)
+    )
+      return true;
+    return ts.isIdentifier(cur) && stringNames.has(cur.text);
+  };
+  let found = false;
+  const scan = (node: ts.Node): void => {
+    if (found) return;
+    if (ts.isElementAccessExpression(node) && !node.questionDotToken && isStringReceiver(node.expression)) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, scan);
+  };
+  scan(fn.body);
+  return found;
+}

--- a/tests/issue-2972.test.ts
+++ b/tests/issue-2972.test.ts
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2972 — IR selector accepts string element access with a computed index, but
+// `from-ast.ts` has no string-element-read lowering (constant OR computed) and
+// throws "element access on string with index … not in slice 12". Flag-off that
+// throw silently demotes to legacy; flag-on (`JS2WASM_IR_FIRST=1`) a claimed
+// function whose lowering throws is promoted to a HARD compile error — turning
+// the test262 `decimalToHexString` / `decimalToPercentHexString` harness
+// (`hex[(n>>4)&0xf]`) into `pass → compile_error` regressions.
+//
+// The selector is checker-free (`scope: ReadonlySet<string>`), so it cannot
+// distinguish a string receiver from a vec receiver and cannot defer this at the
+// element-access arm without over-rejecting vec `arr[i]`. Gate 5 of
+// `computeIrFirstSkipSet` (`irFirstBodyReadsStringElement`) therefore keeps any
+// string-element-reading function on the compile-twice path (legacy + silently
+// demoting overlay) — restoring flag-on/flag-off parity — until an actual
+// string-element-read lowering is proven in the IR builder.
+import ts from "typescript";
+import { describe, expect, it, vi } from "vitest";
+import { irFirstBodyReadsStringElement } from "../src/codegen/ir-first-gate.js";
+import { compile, type CompileResult } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function compileFlag(on: boolean, src: string): Promise<CompileResult> {
+  vi.stubEnv("JS2WASM_IR_FIRST", on ? "1" : "");
+  try {
+    return await compile(src, { fileName: "issue-2972.ts" });
+  } finally {
+    vi.unstubAllEnvs();
+  }
+}
+
+async function instantiate(r: CompileResult): Promise<Record<string, Function>> {
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  imports.setExports?.(instance.exports as Record<string, Function>);
+  return instance.exports as Record<string, Function>;
+}
+
+function fnDecl(src: string): ts.FunctionDeclaration {
+  const sf = ts.createSourceFile("t.ts", src, ts.ScriptTarget.Latest, true);
+  const fn = sf.statements.find(ts.isFunctionDeclaration);
+  if (!fn) throw new Error("no function declaration in source");
+  return fn;
+}
+
+// The exact test262 encoding harness (test262/harness/decimalToHexString.js).
+// Both functions index a local `string` variable by a computed index.
+const HARNESS_SRC = `
+function decimalToHexString(n) {
+  var hex = "0123456789ABCDEF";
+  n >>>= 0;
+  var s = "";
+  while (n) { s = hex[n & 0xf] + s; n >>>= 4; }
+  while (s.length < 4) { s = "0" + s; }
+  return s;
+}
+function decimalToPercentHexString(n) {
+  var hex = "0123456789ABCDEF";
+  return "%" + hex[(n >> 4) & 0xf] + hex[n & 0xf];
+}
+export function test(): number {
+  if (decimalToPercentHexString(200) !== "%C8") return 10;
+  if (decimalToPercentHexString(0) !== "%00") return 11;
+  if (decimalToHexString(65535) !== "FFFF") return 12;
+  if (decimalToHexString(43981) !== "ABCD") return 13;
+  return 1;
+}
+`;
+
+// A minimal claimed function whose ONLY unclaimable shape is the string
+// element read — with the gate removed this is the exact #2138 hard error.
+const CONST_STRING_INDEX_SRC = `
+export function f(n: number): string {
+  const hex = "0123456789ABCDEF";
+  return hex[n & 0xf];
+}
+`;
+
+// A vec `arr[i]` read (computed index) — must STILL be IR-first-skipped
+// (compile-once) flag-on; gate 5 must not touch it.
+const VEC_INDEX_SRC = `
+export function sum(arr: number[], i: number): number {
+  return arr[i] + arr[i + 1];
+}
+`;
+
+describe("#2972 string element access under IR-first (gate 5)", () => {
+  it("flag ON: string-computed-index harness compiles (no hard error) and runs correctly", async () => {
+    const r = await compileFlag(true, HARNESS_SRC);
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    // Kept on the compile-twice path (NOT the IR-first compile-once set).
+    expect(r.irFirstSkipped).not.toContain("decimalToHexString");
+    expect(r.irFirstSkipped).not.toContain("decimalToPercentHexString");
+    const exp = await instantiate(r);
+    expect((exp.test as () => number)()).toBe(1);
+  });
+
+  it("flag OFF: same harness runs identically (parity control)", async () => {
+    const r = await compileFlag(false, HARNESS_SRC);
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    const exp = await instantiate(r);
+    expect((exp.test as () => number)()).toBe(1);
+  });
+
+  it("flag ON: a claimed const-string-index function no longer hard-errors", async () => {
+    const r = await compileFlag(true, CONST_STRING_INDEX_SRC);
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(r.irFirstSkipped).not.toContain("f");
+    const exp = await instantiate(r);
+    expect((exp.f as (n: number) => string)(200)).toBe("8"); // hex[200 & 0xf] = hex[8]
+  });
+
+  it("flag ON: vec `arr[i]` is unaffected — still IR-first compile-once", async () => {
+    const r = await compileFlag(true, VEC_INDEX_SRC);
+    expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(r.irFirstSkipped).toContain("sum");
+  });
+
+  describe("irFirstBodyReadsStringElement predicate", () => {
+    it.each([
+      [
+        "var string-literal receiver, computed index",
+        `function f(n){ var hex="0123456789ABCDEF"; return "%"+hex[(n>>4)&0xf]+hex[n&0xf]; }`,
+      ],
+      ["const string-literal receiver, computed index", `function f(n){ const hex="ABCDEF"; return hex[n&1]; }`],
+      ["string-typed parameter receiver", `function f(s: string, i: number){ return s[i]; }`],
+      ["string-literal receiver in place", `function f(i){ return "abcdef"[i]; }`],
+    ])("fires: %s", (_label, src) => {
+      expect(irFirstBodyReadsStringElement(fnDecl(src))).toBe(true);
+    });
+
+    it.each([
+      ["vec (number[]) receiver", `function f(arr: number[], i: number){ return arr[i]; }`],
+      ["numeric-var-indexed vec receiver", `function f(a: number[]){ var j=0; return a[j]; }`],
+      ["object string-literal key", `function f(o){ return o["k"]; }`],
+      ["untyped/any local receiver", `function f(o){ var x = o.thing; return x[0]; }`],
+      ["optional element access (out of IR scope anyway)", `function f(s: string, i){ return s?.[i]; }`],
+    ])("does not fire: %s", (_label, src) => {
+      expect(irFirstBodyReadsStringElement(fnDecl(src))).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

Under `JS2WASM_IR_FIRST=1` (#2138 compile-once), the test262 encoding harness
(`decimalToHexString` / `decimalToPercentHexString`, which do `hex[(n>>4)&0xf]`)
regressed `pass → compile_error` — 14 tests (encodeURI/decodeURI/…/parseInt/
parseFloat suites).

The IR selector's element-access arm is checker-free (`isPhase1Expr(expr,
scope, localClasses)`, `scope: ReadonlySet<string>`) so it accepts `s[i]`
structurally, unable to distinguish a `string` receiver from a `vec` receiver.
But `from-ast.ts` has **no string-element-read lowering at all** — a string
receiver with a constant OR computed index throws `element access on string …
not in slice 12`. Flag-off that throw demotes silently to legacy; flag-on, a
claimed function whose lowering throws is promoted to a hard compile error.

## Fix

Two of the issue's premises did not survive measure-first (see the issue file's
Resolution section): constant-index string reads are *also* unimplemented (so
option 2 is not "extend constant to computed"; it is a from-scratch string-read
arm with OOB→undefined widening — a silent-miscompile hazard), and the selector
cannot type-resolve the receiver (so it can't defer at the element-access arm
without over-rejecting vec `arr[i]`).

So I realized option 1's outcome ("the 14 tests go back to legacy compile") at
the IR-first **skip-set** layer: **gate 5** (`irFirstBodyReadsStringElement`)
in `computeIrFirstSkipSet`, mirroring gate 4 (`irFirstBodyReadsHostNode`). Any
function reading an element of a (syntactically) string receiver stays on the
**compile-twice** path (legacy body + silently-demoting overlay) instead of the
IR-first compile-once set — restoring flag-on/flag-off parity. No string-element
read can validly be IR-first today (it always throws), so this loses nothing
real; vec/object element access is untouched (verified).

Lifting gate 5 is the trigger for a future real string-element-read lowering in
the IR builder.

## Verification

- `tests/issue-2972.test.ts` (13 cases): the harness runs correctly flag-on and
  flag-off; a claimed const-string-index function no longer hard-errors; vec
  `arr[i]` stays IR-first compile-once; predicate fire/no-fire table.
- Related suites still green: `issue-2138`, `issue-2135`, `issue-2945` (23 tests).
- `tsc --noEmit` clean; `check:ir-fallbacks` gate OK (no baseline change — gate 5
  is orthogonal to the selector's fallback telemetry).

Closes #2972.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8