### PR TITLE
fix(#2989): dynamic-descriptor defineProperty sets ValidateAndApply specified/hasValue bits

### DIFF
--- a/plan/issues/2989-standalone-defineproperty-missing-spec-typeerrors.md
+++ b/plan/issues/2989-standalone-defineproperty-missing-spec-typeerrors.md
@@ -1,8 +1,9 @@
 ---
 id: 2989
 title: "Standalone defineProperty missing spec TypeErrors (~32: array length, non-extensible, non-configurable redefine)"
-status: ready
-sprint: Backlog
+status: done
+completed: 2026-07-02
+sprint: current
 priority: medium
 horizon: s
 feasibility: medium

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -5477,6 +5477,20 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     const HOST_FLAG_WRITABLE = FLAG_WRITABLE; // bit 0
     const HOST_FLAG_ENUMERABLE = FLAG_ENUMERABLE; // bit 1
     const HOST_FLAG_CONFIGURABLE = FLAG_CONFIGURABLE; // bit 2
+    // (#2989) "Desc has a [[X]] field" specified-bits + hasValue bit — the
+    // §10.1.6.3 ValidateAndApplyPropertyDescriptor preflight in
+    // `__defineProperty_value` gates every spec TypeError on THESE bits (a
+    // configurable/enumerable/writable change is only forbidden when the Desc
+    // actually *specifies* that attribute). The inline-literal fast path
+    // (`computeRuntimeFlags`, object-ops.ts) sets them; this dynamic-descriptor
+    // applier previously set only the value bits 0/1/2, so the preflight read
+    // "no attribute specified / no value" for every field → it never threw and
+    // an invalid redefine silently no-op'd (array length non-writable→writable,
+    // non-configurable redefine, non-extensible new prop via a `var` descriptor).
+    const HOST_WRITABLE_SPECIFIED = 1 << 3;
+    const HOST_ENUMERABLE_SPECIFIED = 1 << 4;
+    const HOST_CONFIGURABLE_SPECIFIED = 1 << 5;
+    const HOST_HAS_VALUE = 1 << 7;
 
     const L_DESC = 3; // desc as externref (after $Object validation)
     const L_DESC_ANY = 4;
@@ -5516,12 +5530,15 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
       ];
     };
     // ToBoolean(getField(key)) → set valueBit; always set hasData when marksData.
-    const readBooleanFlag = (key: string, valueBit: number, marksData: boolean): Instr[] => [
+    // (#2989) When the field is present, ALSO set its "specified" bit so the
+    // `__defineProperty_value` §10.1.6.3 preflight can gate the spec TypeErrors.
+    const readBooleanFlag = (key: string, valueBit: number, marksData: boolean, specifiedBit: number): Instr[] => [
       ...hasField(key),
       {
         op: "if",
         blockType: { kind: "empty" },
         then: [
+          ...setFlag(specifiedBit),
           ...(marksData
             ? ([
                 { op: "i32.const", value: 1 },
@@ -5598,7 +5615,7 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
       { op: "ref.null.extern" },
       { op: "local.set", index: L_SETTER },
 
-      // value present → hasData, capture value.
+      // value present → hasData + hasValue bit (#2989), capture value.
       ...hasField("value"),
       {
         op: "if",
@@ -5606,13 +5623,14 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
         then: [
           { op: "i32.const", value: 1 },
           { op: "local.set", index: L_HAS_DATA },
+          ...setFlag(HOST_HAS_VALUE),
           ...getField("value"),
           { op: "local.set", index: L_VALUE },
         ],
       },
-      ...readBooleanFlag("writable", HOST_FLAG_WRITABLE, true),
-      ...readBooleanFlag("enumerable", HOST_FLAG_ENUMERABLE, false),
-      ...readBooleanFlag("configurable", HOST_FLAG_CONFIGURABLE, false),
+      ...readBooleanFlag("writable", HOST_FLAG_WRITABLE, true, HOST_WRITABLE_SPECIFIED),
+      ...readBooleanFlag("enumerable", HOST_FLAG_ENUMERABLE, false, HOST_ENUMERABLE_SPECIFIED),
+      ...readBooleanFlag("configurable", HOST_FLAG_CONFIGURABLE, false, HOST_CONFIGURABLE_SPECIFIED),
       ...readAccessor("get", L_GETTER),
       ...readAccessor("set", L_SETTER),
 

--- a/tests/issue-2989.test.ts
+++ b/tests/issue-2989.test.ts
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2989 — standalone `Object.defineProperty` missing spec TypeErrors on the
+ * DYNAMIC-descriptor path.
+ *
+ * Root cause: the inline-literal fast path (`__defineProperty_value`, via
+ * `computeRuntimeFlags`) runs the §10.1.6.3 ValidateAndApplyPropertyDescriptor
+ * preflight, whose every spec-mandated TypeError is gated on the host-flag
+ * "specified" bits (3/4/5 — "Desc has a [[configurable]]/[[enumerable]]/
+ * [[writable]] field") and the "hasValue" bit (7). The DYNAMIC-descriptor
+ * applier `__obj_define_from_desc` — reached whenever the descriptor is a
+ * runtime value (`var d = {...}; Object.defineProperty(o, k, d)`, the dominant
+ * ES5 `15.2.3.6-*` shape) — set only the VALUE bits (0/1/2), never the
+ * specified/hasValue bits. So the preflight read "no attribute specified / no
+ * value" for every field and never threw: an invalid (re)definition through a
+ * variable descriptor silently no-op'd instead of throwing a TypeError.
+ *
+ * Fix (object-runtime.ts `__obj_define_from_desc`): set the specified bit when
+ * a `writable`/`enumerable`/`configurable` field is present, and the hasValue
+ * bit when `value` is present, so the dispatched `__defineProperty_value`
+ * preflight fires identically to the inline-literal path.
+ *
+ * All snippets run top-level in the standalone start section, so a spec throw
+ * escapes `WebAssembly.instantiate`; a silent no-op instantiates cleanly. Each
+ * binary is asserted host-free (no `env::` imports).
+ */
+async function compileStandalone(src: string) {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  expect(r.success, `compile failed:\n${(r.errors ?? []).map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
+    true,
+  );
+  const envImports = (r.imports ?? []).filter((i) => String(i).startsWith("env"));
+  expect(envImports, "expected host-free standalone binary").toEqual([]);
+  return r;
+}
+
+async function throwsOnInstantiate(src: string): Promise<boolean> {
+  const r = await compileStandalone(src);
+  try {
+    await WebAssembly.instantiate(r.binary, {});
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+describe("#2989 — dynamic-descriptor defineProperty spec TypeErrors", () => {
+  it("redefining configurable:false→true through a var descriptor throws", async () => {
+    expect(
+      await throwsOnInstantiate(
+        `const o = {};
+const d1 = { value: 1, configurable: false };
+Object.defineProperty(o, "x", d1);
+const d2 = { configurable: true };
+Object.defineProperty(o, "x", d2);`,
+      ),
+    ).toBe(true);
+  });
+
+  it("changing enumerable on a non-configurable prop through a var descriptor throws", async () => {
+    expect(
+      await throwsOnInstantiate(
+        `const o = {};
+const d1 = { value: 1, enumerable: false, configurable: false };
+Object.defineProperty(o, "x", d1);
+const d2 = { enumerable: true };
+Object.defineProperty(o, "x", d2);`,
+      ),
+    ).toBe(true);
+  });
+
+  it("changing the value of a non-configurable non-writable prop through a var descriptor throws", async () => {
+    expect(
+      await throwsOnInstantiate(
+        `const o = {};
+const d1 = { value: 1, writable: false, configurable: false };
+Object.defineProperty(o, "x", d1);
+const d2 = { value: 2 };
+Object.defineProperty(o, "x", d2);`,
+      ),
+    ).toBe(true);
+  });
+
+  it("making a non-writable non-configurable prop writable through a var descriptor throws", async () => {
+    expect(
+      await throwsOnInstantiate(
+        `const o = {};
+const d1 = { value: 1, writable: false, configurable: false };
+Object.defineProperty(o, "x", d1);
+const d2 = { writable: true };
+Object.defineProperty(o, "x", d2);`,
+      ),
+    ).toBe(true);
+  });
+
+  it("dynamic descriptor still ALLOWS a legal redefine of a configurable prop (no spurious throw)", async () => {
+    expect(
+      await throwsOnInstantiate(
+        `const o = {};
+const d1 = { value: 1, configurable: true, writable: true };
+Object.defineProperty(o, "x", d1);
+const d2 = { value: 2, enumerable: true };
+Object.defineProperty(o, "x", d2);`,
+      ),
+    ).toBe(false);
+  });
+
+  it("dynamic descriptor still ALLOWS a same-value redefine of a non-writable prop (SameValue, no throw)", async () => {
+    expect(
+      await throwsOnInstantiate(
+        `const o = {};
+const d1 = { value: 7, writable: false, configurable: false };
+Object.defineProperty(o, "x", d1);
+const d2 = { value: 7 };
+Object.defineProperty(o, "x", d2);`,
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## #2989 — standalone defineProperty missing spec TypeErrors

Fixes the dynamic-descriptor path of `Object.defineProperty` in standalone mode.

### Root cause

`__obj_define_from_desc` (the dynamic-descriptor applier in `src/codegen/object-runtime.ts`) built the runtime descriptor flags by setting only the **value bits** (0/1/2 — writable/enumerable/configurable *values*), but never the §10.1.6.3 **"specified" bits** (3/4/5) nor the **hasValue** bit (7).

The `__defineProperty_value` ValidateAndApplyPropertyDescriptor preflight gates every spec `TypeError` on those specified/hasValue bits (a `configurable`/`enumerable`/`writable` change is only forbidden when the Desc actually *specifies* that attribute). With the bits unset, the preflight read "no attribute specified / no value" for every field, so an invalid redefine silently no-op'd instead of throwing:

- array `length` non-writable → writable
- non-configurable redefine
- changing `enumerable`/`value` on a non-configurable prop
- new prop on a non-extensible object via a `var` descriptor

The inline-literal fast path (`computeRuntimeFlags`, object-ops.ts) already sets these bits; this aligns the dynamic-descriptor applier with it.

### Fix

`readBooleanFlag` now also sets the field's "specified" bit when the field is present, and the `value`-present branch sets the `hasValue` bit — so the preflight can correctly gate the spec TypeErrors.

### Tests

`tests/issue-2989.test.ts` — 6 cases covering the four throwing redefines plus two must-NOT-throw controls (legal redefine of a configurable prop; SameValue same-value redefine of a non-writable prop). All green. 60-file related-object sweep: zero regressions.

### net==0 is expected and pre-authorized

This is a genuine spec-conformance fix that flips **0 test262 tests on its own** because the affected test262 cases are **co-blocked by an unrelated substrate gap** — `getOwnPropertyDescriptor` readback fidelity on builtin/MOP descriptors (**#2984**), which is substrate-scale and deferred (horizon xl). Once #2984 lands, these throwing-path assertions become reachable. Merging despite net==0 is authorized by the team lead under this project's spec-first-fixes principle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)