### PR TITLE
refactor(#1916) S3b batches 2+3: flip symbol/uri/date-parse + case-convert/json-codec to stable handles

### DIFF
--- a/plan/issues/1916-symbolic-function-references-codegen.md
+++ b/plan/issues/1916-symbolic-function-references-codegen.md
@@ -280,10 +280,25 @@ is never a moment where one value means two functions.
     sweep scope, normalized) that missed #2499's queue window. Proof:
     1215-record corpus byte-IDENTICAL; issue-1537 (33) + parseint-edge +
     #1916 suites green.
+  - **S3b batches 2+3 — LANDED (PR 5)**: batch 2 = `symbol-native.ts`
+    (`__box_symbol`/`__symbol_for_native`/`__symbol_keyfor_native`),
+    `uri-encoding-native.ts` (`__uri_encode`/`__uri_decode` — the
+    "claim the slot last" ordering dance is moot), `date-parse-native.ts`
+    (`__date_parse`). Batch 3 = `case-convert-native.ts` (the #40/#2191
+    name-based public repoint flows stable handles unchanged — a
+    name→handle map re-point is value-opaque) + `json-codec-native.ts`
+    (9 helpers; the JSON parse trio's `valueFuncIdx + 1/+ 2` sibling
+    derivation — implicit consecutive-push assumption — replaced by
+    three explicit mints). Both corpus byte-IDENTICAL; family suites
+    green. (The 3 `issue-1599` refusal failures are pre-existing on
+    clean main — stale expectations after a recent JSON change; flagged
+    to the lead, not this migration's doing.)
   - Batch discipline (for the next executor): flip whole FILES (a
     producer family), never partial files; `nextFuncIdx`-style local
-    helpers redefine in place; verify `grep -c mod.functions.push <file>`
-    is 0 after; corpus check per batch; run the family's test suites.
+    helpers redefine in place; multi-mint sibling derivations
+    (`base + k`) become explicit per-function mints; verify
+    `grep -c mod.functions.push <file>` is 0 after; corpus check per
+    batch; run the family's test suites.
 - S3-final: zero live-regime defined-func mints remain → delete
   `shiftLateImportIndices`, `reconcileNativeStrFinalizeShift`, both
   inline shifters, `flushLateImportShifts`, the `liveBodies`/

--- a/plan/issues/1916-symbolic-function-references-codegen.md
+++ b/plan/issues/1916-symbolic-function-references-codegen.md
@@ -270,6 +270,20 @@ is never a moment where one value means two functions.
   files → `mintDefinedFunc`/`pushDefinedFunc`). Byte-identity after
   every batch. Import handles stay live-regime (prefix-stable) until
   S3-final.
+  - **S3b batch 1 — LANDED (PR 4)**: `number-ryu.ts` (3 helpers:
+    `__ryu_mul_shift`/`__num_ryu_digits`/`__num_ryu_to_buf`) +
+    `parse-number-native.ts` (3: `parseFloat`/`__str_to_number`/
+    `parseInt`) — completes the number cluster (number-format flipped in
+    S3a calls into Ryū). Also carries the S3a audit-completeness fixes
+    (compiler/output.ts, emit/c-header.ts, codegen-linear/c-abi.ts,
+    promise-combinators.ts — four funcIdx interpreters outside the S2
+    sweep scope, normalized) that missed #2499's queue window. Proof:
+    1215-record corpus byte-IDENTICAL; issue-1537 (33) + parseint-edge +
+    #1916 suites green.
+  - Batch discipline (for the next executor): flip whole FILES (a
+    producer family), never partial files; `nextFuncIdx`-style local
+    helpers redefine in place; verify `grep -c mod.functions.push <file>`
+    is 0 after; corpus check per batch; run the family's test suites.
 - S3-final: zero live-regime defined-func mints remain → delete
   `shiftLateImportIndices`, `reconcileNativeStrFinalizeShift`, both
   inline shifters, `flushLateImportShifts`, the `liveBodies`/

--- a/src/codegen-linear/c-abi.ts
+++ b/src/codegen-linear/c-abi.ts
@@ -17,6 +17,7 @@
  */
 
 import type { FuncTypeDef, Instr, ValType, WasmModule } from "../ir/types.js";
+import { absoluteFuncIndexCached } from "../emit/resolve-layout.js"; // (#1916 S3)
 
 // ── Linear-memory aggregate header layout (mirrors runtime.ts) ───────
 //
@@ -248,6 +249,8 @@ export function emitCabiWrappers(mod: WasmModule, exportInfos: CabiExportInfo[])
 
     // Find the original function's type
     const numImportFuncs = mod.imports.filter((i) => i.desc.kind === "func").length;
+    // (#1916 S3) normalize a possibly-stable handle to the absolute index.
+    origFuncIdx = absoluteFuncIndexCached(mod, numImportFuncs, origFuncIdx);
     const origFunc = origFuncIdx >= numImportFuncs ? mod.functions[origFuncIdx - numImportFuncs] : null;
     if (!origFunc) continue;
     const origType = mod.types[origFunc.typeIdx] as FuncTypeDef;

--- a/src/codegen/case-convert-native.ts
+++ b/src/codegen/case-convert-native.ts
@@ -21,6 +21,7 @@ import type { ArrayTypeDef, Instr, ValType, WasmFunction } from "../ir/types.js"
 import type { CodegenContext } from "./context/types.js";
 import { addFuncType } from "./registry/types.js";
 import { LOWER_CASE_RUNS, LOWER_CASE_SPECIAL, UPPER_CASE_RUNS, UPPER_CASE_SPECIAL } from "./case-tables.js";
+import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3b) stable-regime minting
 
 const i32: ValType = { kind: "i32" };
 
@@ -77,7 +78,7 @@ export function emitNativeCaseConversion(
   //                                                  : (off%2==0 && off/2<count))
   const makeSimple = (name: string): void => {
     const typeIdx = addFuncType(ctx, [i32, i32ArrRef], [i32]);
-    const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+    const funcIdx = mintDefinedFunc(ctx); // (#1916 S3b) stable-regime handle
     ctx.funcMap.set(name, funcIdx);
     // params: ch(0), runs(1)
     // locals: lo(2), hi(3), mid(4), midBase(5), start(6), count(7), stride(8),
@@ -228,7 +229,7 @@ export function emitNativeCaseConversion(
       // no mapping
       get(CH),
     ];
-    ctx.mod.functions.push({
+    pushDefinedFunc(ctx, funcIdx, {
       name,
       typeIdx,
       locals: [
@@ -261,7 +262,7 @@ export function emitNativeCaseConversion(
     specialTable: readonly number[],
   ): void => {
     const typeIdx = addFuncType(ctx, [strRef], [strRef]);
-    const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+    const funcIdx = mintDefinedFunc(ctx); // (#1916 S3b) stable-regime handle
     ctx.funcMap.set(name, funcIdx);
     // (#40) Re-point the PUBLIC helper name (used by string-ops.ts toUpperCase/
     // toLowerCase routing) at this Unicode implementation, replacing the
@@ -536,7 +537,7 @@ export function emitNativeCaseConversion(
       get(OUTARR),
       { op: "struct.new", typeIdx: strTypeIdx } as Instr,
     ];
-    ctx.mod.functions.push({
+    pushDefinedFunc(ctx, funcIdx, {
       name,
       typeIdx,
       locals: [

--- a/src/codegen/date-parse-native.ts
+++ b/src/codegen/date-parse-native.ts
@@ -26,6 +26,7 @@ import type { CodegenContext } from "./context/types.js";
 import { ensureNativeStringHelpers } from "./native-strings.js";
 import { ensureDateDaysFromCivilHelper } from "./expressions/builtins.js";
 import { addFuncType } from "./registry/types.js";
+import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3b) stable-regime minting
 
 const C_PLUS = 43;
 const C_MINUS = 45;
@@ -64,7 +65,7 @@ export function emitNativeDateParse(ctx: CodegenContext): void {
   const extern: ValType = { kind: "externref" };
 
   const typeIdx = addFuncType(ctx, [extern], [f64]);
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const funcIdx = mintDefinedFunc(ctx); // (#1916 S3b) stable-regime handle
   ctx.funcMap.set("__date_parse", funcIdx);
 
   const L_FLAT = 1;
@@ -987,7 +988,7 @@ export function emitNativeDateParse(ctx: CodegenContext): void {
     ],
   } as Instr);
 
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, funcIdx, {
     typeIdx,
     name: "__date_parse",
     locals: [

--- a/src/codegen/json-codec-native.ts
+++ b/src/codegen/json-codec-native.ts
@@ -56,6 +56,7 @@ import { emitJsonQuoteString } from "./json-runtime.js";
 import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
 import { emitWasiErrorConstructor } from "./registry/error-types.js";
 import { reserveReplacerDriver, reserveReviverDriver, reserveToJsonDriver } from "./accessor-driver.js";
+import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3b) stable-regime minting
 
 const EQ_HEAP_TYPE = -19; // signed LEB128 → 0x6d → TYPE.eq (for ref.null any/eq)
 
@@ -165,7 +166,7 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
     ],
     [strRefNull],
   );
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const funcIdx = mintDefinedFunc(ctx); // (#1916 S3b) stable-regime handle
   ctx.funcMap.set("__json_stringify_value", funcIdx);
 
   // ── Local plan ──────────────────────────────────────────────────────────
@@ -891,7 +892,7 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
     { op: "ref.null", typeIdx: anyStrTypeIdx },
   ];
 
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, funcIdx, {
     name: "__json_stringify_value",
     typeIdx,
     locals: [
@@ -940,9 +941,9 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
   // ref $AnyString so the call site sees the same type the primitive
   // string-stringify path returns.
   const rootTypeIdx = addFuncType(ctx, [anyref], [strRef]);
-  const rootFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const rootFuncIdx = mintDefinedFunc(ctx); // (#1916 S3b) stable-regime handle
   ctx.funcMap.set("__json_stringify_root", rootFuncIdx);
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, rootFuncIdx, {
     name: "__json_stringify_root",
     typeIdx: rootTypeIdx,
     locals: [{ count: 1, type: strRefNull }],
@@ -978,9 +979,9 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
   // (the worker's separators collapse to ""). Same null→"null" coalescing as
   // the compact root.
   const rootIndentTypeIdx = addFuncType(ctx, [anyref, strRefNull], [strRef]);
-  const rootIndentFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const rootIndentFuncIdx = mintDefinedFunc(ctx); // (#1916 S3b) stable-regime handle
   ctx.funcMap.set("__json_stringify_root_indent", rootIndentFuncIdx);
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, rootIndentFuncIdx, {
     name: "__json_stringify_root_indent",
     typeIdx: rootIndentTypeIdx,
     locals: [{ count: 1, type: strRefNull }],
@@ -1018,13 +1019,13 @@ export function emitJsonStringifyValue(ctx: CodegenContext): number {
   const newObjIdx = ctx.funcMap.get("__new_plain_object")!;
   const externSetIdx = ctx.funcMap.get("__extern_set")!;
   const rootRepTypeIdx = addFuncType(ctx, [anyref, strRefNull, { kind: "externref" }, { kind: "externref" }], [strRef]);
-  const rootRepFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const rootRepFuncIdx = mintDefinedFunc(ctx); // (#1916 S3b) stable-regime handle
   ctx.funcMap.set("__json_stringify_root_replacer", rootRepFuncIdx);
   // locals: 4 RR_ROOT externref  5 RR_VAL anyref  6 RR_RES strRefNull
   const RR_ROOT = 4;
   const RR_VAL = 5;
   const RR_RES = 6;
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, rootRepFuncIdx, {
     name: "__json_stringify_root_replacer",
     typeIdx: rootRepTypeIdx,
     locals: [
@@ -1213,15 +1214,18 @@ export function emitJsonParseText(ctx: CodegenContext): number {
   // types — the fresh $JsonP index never reaches a func type.
   // ════════════════════════════════════════════════════════════════════════
   const valueTypeIdx = addFuncType(ctx, [anyref], [anyref]); // (p:anyref) -> value:anyref
-  const valueFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  // (#1916 S3b) stable-regime handles — the old `valueFuncIdx + 1/+ 2` sibling
+  // derivation (which assumed the three functions land consecutively) is
+  // replaced by three explicit mints; pushes record the real positions.
+  const valueFuncIdx = mintDefinedFunc(ctx);
   ctx.funcMap.set("__json_parse_value", valueFuncIdx);
 
   const strParseTypeIdx = addFuncType(ctx, [anyref], [strRefNative]); // (p:anyref) -> ref $NativeString
-  const strParseFuncIdx = valueFuncIdx + 1;
+  const strParseFuncIdx = mintDefinedFunc(ctx);
   ctx.funcMap.set("__json_parse_str", strParseFuncIdx);
 
   const textTypeIdx = addFuncType(ctx, [externref], [anyref]);
-  const textFuncIdx = valueFuncIdx + 2;
+  const textFuncIdx = mintDefinedFunc(ctx);
   ctx.funcMap.set("__json_parse_text", textFuncIdx);
 
   // ════════════════════════════════════════════════════════════════════════
@@ -2469,7 +2473,7 @@ export function emitJsonParseText(ctx: CodegenContext): number {
   // exactly once. Bodies hold only plain JSON-safe data (no funcs/cycles).
   const cloneBody = (b: Instr[]): Instr[] => JSON.parse(JSON.stringify(b)) as Instr[];
 
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, valueFuncIdx, {
     name: "__json_parse_value",
     typeIdx: valueTypeIdx,
     locals: [
@@ -2492,7 +2496,7 @@ export function emitJsonParseText(ctx: CodegenContext): number {
     exported: false,
   } as unknown as (typeof ctx.mod.functions)[number]);
 
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, strParseFuncIdx, {
     name: "__json_parse_str",
     typeIdx: strParseTypeIdx,
     locals: [
@@ -2513,7 +2517,7 @@ export function emitJsonParseText(ctx: CodegenContext): number {
     exported: false,
   } as unknown as (typeof ctx.mod.functions)[number]);
 
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, textFuncIdx, {
     name: "__json_parse_text",
     typeIdx: textTypeIdx,
     locals: [
@@ -2599,7 +2603,7 @@ export function emitJsonParseTextReviver(ctx: CodegenContext): number {
   //
   // __internalize_json_value(val, holder, key, reviver) -> externref
   const internTypeIdx = addFuncType(ctx, [externref, externref, externref, externref], [externref]);
-  const internFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const internFuncIdx = mintDefinedFunc(ctx); // (#1916 S3b) stable-regime handle
   ctx.funcMap.set("__internalize_json_value", internFuncIdx);
 
   // params: 0=val 1=holder 2=key 3=reviver
@@ -2783,7 +2787,7 @@ export function emitJsonParseTextReviver(ctx: CodegenContext): number {
     { op: "call", funcIdx: reviverDriverIdx },
   ];
 
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, internFuncIdx, {
     name: "__internalize_json_value",
     typeIdx: internTypeIdx,
     locals: [
@@ -2808,7 +2812,7 @@ export function emitJsonParseTextReviver(ctx: CodegenContext): number {
   // return any.convert_extern(
   //          __internalize_json_value(val, root, "", reviver)).
   const rootTypeIdx = addFuncType(ctx, [externref, externref], [anyref]);
-  const rootFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const rootFuncIdx = mintDefinedFunc(ctx); // (#1916 S3b) stable-regime handle
   ctx.funcMap.set("__json_parse_text_reviver", rootFuncIdx);
 
   void anyStrTypeIdx;
@@ -2840,7 +2844,7 @@ export function emitJsonParseTextReviver(ctx: CodegenContext): number {
     { op: "any.convert_extern" }, // back to anyref (the parse codec's result type)
   ];
 
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, rootFuncIdx, {
     name: "__json_parse_text_reviver",
     typeIdx: rootTypeIdx,
     locals: [

--- a/src/codegen/number-ryu.ts
+++ b/src/codegen/number-ryu.ts
@@ -36,6 +36,7 @@
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
 import { addFuncType } from "./registry/types.js";
+import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3b) stable-regime minting
 
 // ---------------------------------------------------------------------------
 // Compile-time table generation (BigInt). Produces byte-identical tables to
@@ -123,9 +124,14 @@ const RYU_INV_GLOBAL = "__ryu_pow5_inv";
 const RYU_POW_GLOBAL = "__ryu_pow5";
 const RYU_I64_ARR = "__ryu_i64_arr";
 
-/** Allocate the next defined-function index. Mirrors number-format-native.ts. */
+/**
+ * #1916 S3b — STABLE-REGIME PRODUCER (see number-format-native.ts, the first
+ * flip). Handles minted here are layout-independent: baked call immediates and
+ * funcMap entries survive every late-import shift and resolve at emit.
+ * Every push below goes through `pushDefinedFunc`.
+ */
 function nextFuncIdx(ctx: CodegenContext): number {
-  return ctx.numImportFuncs + ctx.mod.functions.length;
+  return mintDefinedFunc(ctx);
 }
 
 /** Register an immutable `(array i64)` type, idempotent. */
@@ -342,7 +348,7 @@ function emitRyuMulShift(ctx: CodegenContext): number {
   const typeIdx = addFuncType(ctx, [I64, I64, I64, I32], [I64]);
   const funcIdx = nextFuncIdx(ctx);
   ctx.funcMap.set("__ryu_mul_shift", funcIdx);
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, funcIdx, {
     name: "__ryu_mul_shift",
     typeIdx,
     locals: [
@@ -1024,7 +1030,7 @@ export function emitRyuDigits(ctx: CodegenContext): number {
   const typeIdx = addFuncType(ctx, [F64], [I64, I32]);
   const funcIdx = nextFuncIdx(ctx);
   ctx.funcMap.set("__num_ryu_digits", funcIdx);
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, funcIdx, {
     name: "__num_ryu_digits",
     typeIdx,
     locals: [
@@ -1603,7 +1609,7 @@ export function emitRyuToBuf(ctx: CodegenContext, strDataTypeIdx: number): numbe
   const typeIdx = addFuncType(ctx, [F64, I32, strDataRef, I32], [I32]);
   const funcIdx = nextFuncIdx(ctx);
   ctx.funcMap.set("__num_ryu_to_buf", funcIdx);
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, funcIdx, {
     name: "__num_ryu_to_buf",
     typeIdx,
     locals: [

--- a/src/codegen/parse-number-native.ts
+++ b/src/codegen/parse-number-native.ts
@@ -19,6 +19,7 @@ import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext } from "./context/types.js";
 import { ensureNativeStringHelpers } from "./native-strings.js";
 import { addFuncType } from "./registry/types.js";
+import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3b) stable-regime minting
 
 const C_TAB = 9;
 const C_LF = 10;
@@ -144,7 +145,7 @@ export function emitNativeParseNumber(ctx: CodegenContext, which: Set<string>): 
   if (which.has("parseFloat") && !ctx.funcMap.has("parseFloat")) {
     // (externref) -> f64
     const typeIdx = addFuncType(ctx, [extern], [f64]);
-    const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+    const funcIdx = mintDefinedFunc(ctx); // (#1916 S3b) stable-regime handle
     ctx.funcMap.set("parseFloat", funcIdx);
 
     // locals (after param 0 = s:externref):
@@ -454,7 +455,7 @@ export function emitNativeParseNumber(ctx: CodegenContext, which: Set<string>): 
       { op: "return" },
     ];
 
-    ctx.mod.functions.push({
+    pushDefinedFunc(ctx, funcIdx, {
       name: "parseFloat",
       typeIdx,
       locals: [
@@ -507,7 +508,7 @@ function emitStrToNumber(ctx: CodegenContext, flattenIdx: number, strTypeIdx: nu
   const f64: ValType = { kind: "f64" };
   const extern: ValType = { kind: "externref" };
   const typeIdx = addFuncType(ctx, [extern], [f64]);
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const funcIdx = mintDefinedFunc(ctx); // (#1916 S3b) stable-regime handle
   ctx.funcMap.set("__str_to_number", funcIdx);
 
   // params: 0 s:externref
@@ -856,7 +857,7 @@ function emitStrToNumber(ctx: CodegenContext, flattenIdx: number, strTypeIdx: nu
     { op: "return" },
   ];
 
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, funcIdx, {
     name: "__str_to_number",
     typeIdx,
     locals: [
@@ -1477,7 +1478,7 @@ function emitParseInt(ctx: CodegenContext, flattenIdx: number, strTypeIdx: numbe
   const f64: ValType = { kind: "f64" };
   const extern: ValType = { kind: "externref" };
   const typeIdx = addFuncType(ctx, [extern, f64], [f64]);
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const funcIdx = mintDefinedFunc(ctx); // (#1916 S3b) stable-regime handle
   ctx.funcMap.set("parseInt", funcIdx);
 
   // params: 0 s:externref, 1 radixF:f64
@@ -1747,7 +1748,7 @@ function emitParseInt(ctx: CodegenContext, flattenIdx: number, strTypeIdx: numbe
     { op: "return" },
   ];
 
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, funcIdx, {
     name: "parseInt",
     typeIdx,
     locals: [

--- a/src/codegen/promise-combinators.ts
+++ b/src/codegen/promise-combinators.ts
@@ -36,6 +36,7 @@ import type { CodegenContext, FunctionContext } from "./context/types.js";
 import type { Instr, LocalDef, ValType } from "../ir/types.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterVecType } from "./registry/types.js";
 import { allocLocal } from "./context/locals.js";
+import { definedFuncAt } from "./func-space.js"; // (#1916 S2) positional-read chokepoint
 import {
   ensureAsyncDriveRuntime,
   getOrRegisterPromiseType,
@@ -802,7 +803,7 @@ export function fillCombinatorToVec(ctx: CodegenContext): void {
   ) {
     return;
   }
-  const fn = ctx.mod.functions[funcIdx - ctx.numImportFuncs];
+  const fn = definedFuncAt(ctx, funcIdx);
   if (!fn) return;
 
   const vecTypeIdx = getOrRegisterVecType(ctx, "externref", EXTERNREF);

--- a/src/codegen/symbol-native.ts
+++ b/src/codegen/symbol-native.ts
@@ -25,6 +25,7 @@ import { ensureSymbolCounter } from "./literals.js";
 import { ensureNativeStringHelpers, nativeStringType } from "./native-strings.js";
 import { addFuncType, getOrRegisterArrayType } from "./registry/types.js";
 import { compileNativeStringLiteral } from "./string-ops.js";
+import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3b) stable-regime minting
 
 /** Initial capacity of the description table (covers small symbol counts without
  *  a grow; ids start at 100 so the very first user symbol already forces one
@@ -101,13 +102,13 @@ export function ensureSymbolCarrier(ctx: CodegenContext): number {
     const symNull: ValType = { kind: "ref_null", typeIdx: symIdx };
     const arrNull: ValType = { kind: "ref_null", typeIdx: internArrTypeIdx };
     const typeIdx = addFuncType(ctx, [{ kind: "i32" }], [{ kind: "externref" }]);
-    const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+    const funcIdx = mintDefinedFunc(ctx); // (#1916 S3b) stable-regime handle
     ctx.funcMap.set("__box_symbol", funcIdx);
     // params: 0=id(i32). locals: 1=tbl 2=existing 3=grow
     const TBL = 1;
     const EXISTING = 2;
     const GROW = 3;
-    ctx.mod.functions.push({
+    pushDefinedFunc(ctx, funcIdx, {
       name: "__box_symbol",
       typeIdx,
       locals: [
@@ -469,7 +470,7 @@ export function ensureSymbolRegistry(ctx: CodegenContext): {
   // ── __symbol_for_native(key: ref $AnyString) -> i32 ─────────────────────
   {
     const typeIdx = addFuncType(ctx, [{ kind: "ref", typeIdx: anyStrTypeIdx }], [{ kind: "i32" }]);
-    forIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+    forIdx = mintDefinedFunc(ctx); // (#1916 S3b) stable-regime handle
     ctx.funcMap.set("__symbol_for_native", forIdx);
     // params: key(0). locals: i(1), n(2), keys(3), ids(4), newCap(5), newKeys(6),
     //   newIds(7), id(8)
@@ -645,7 +646,7 @@ export function ensureSymbolRegistry(ctx: CodegenContext): {
       { op: "local.get", index: ID },
     ];
 
-    ctx.mod.functions.push({
+    pushDefinedFunc(ctx, forIdx, {
       name: "__symbol_for_native",
       typeIdx,
       locals: [
@@ -668,7 +669,7 @@ export function ensureSymbolRegistry(ctx: CodegenContext): {
   // ── __symbol_keyfor_native(id: i32) -> ref_null $AnyString ──────────────
   {
     const typeIdx = addFuncType(ctx, [{ kind: "i32" }], [anyStrNull]);
-    keyForIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+    keyForIdx = mintDefinedFunc(ctx); // (#1916 S3b) stable-regime handle
     ctx.funcMap.set("__symbol_keyfor_native", keyForIdx);
     // params: id(0). locals: i(1), n(2), keys(3), ids(4)
     const ID = 0;
@@ -737,7 +738,7 @@ export function ensureSymbolRegistry(ctx: CodegenContext): {
       // not found → undefined
       { op: "ref.null", typeIdx: anyStrTypeIdx } as Instr,
     ];
-    ctx.mod.functions.push({
+    pushDefinedFunc(ctx, keyForIdx, {
       name: "__symbol_keyfor_native",
       typeIdx,
       locals: [

--- a/src/codegen/uri-encoding-native.ts
+++ b/src/codegen/uri-encoding-native.ts
@@ -29,6 +29,7 @@ import { ensureNativeStringHelpers, stringConstantExternrefInstrs } from "./nati
 import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
 import { emitWasiErrorConstructor } from "./registry/error-types.js";
 import { addFuncType } from "./registry/types.js";
+import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3b) stable-regime minting
 
 /** Helper-name -> mask routed at the call site (calls.ts). */
 export const URI_ENCODE_MASK: Record<string, number> = {
@@ -489,11 +490,13 @@ export function emitNativeUriEncode(ctx: CodegenContext): void {
     { op: "struct.new", typeIdx: strTypeIdx } as Instr,
     { op: "extern.convert_any" } as Instr,
   ];
-  // Now that no further dependency functions can be appended ahead of us,
-  // claim the slot: funcIdx = numImportFuncs + current functions length.
-  ctx.funcMap.set("__uri_encode", ctx.numImportFuncs + ctx.mod.functions.length);
+  // (#1916 S3b) stable-regime handle — the "claim the slot last" ordering
+  // dance this comment used to describe is moot: the handle is
+  // layout-independent from mint.
+  const uriEncodeIdx = mintDefinedFunc(ctx);
+  ctx.funcMap.set("__uri_encode", uriEncodeIdx);
 
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, uriEncodeIdx, {
     name: "__uri_encode",
     typeIdx: realTypeIdx,
     locals: [
@@ -1045,8 +1048,9 @@ export function emitNativeUriDecode(ctx: CodegenContext): void {
     { op: "extern.convert_any" } as Instr,
   ];
 
-  ctx.funcMap.set("__uri_decode", ctx.numImportFuncs + ctx.mod.functions.length);
-  ctx.mod.functions.push({
+  const uriDecodeIdx = mintDefinedFunc(ctx); // (#1916 S3b) stable-regime handle
+  ctx.funcMap.set("__uri_decode", uriDecodeIdx);
+  pushDefinedFunc(ctx, uriDecodeIdx, {
     name: "__uri_decode",
     typeIdx: realTypeIdx,
     locals: [

--- a/src/compiler/output.ts
+++ b/src/compiler/output.ts
@@ -4,6 +4,7 @@ import type { TypedAST } from "../checker/index.js";
 import { analyzeSource } from "../checker/index.js";
 import type { CabiExportInfo, ParamDef, TsSemanticType } from "../codegen-linear/c-abi.js";
 import { emitCabiWrappers, inferSemantic, mapParamsToCabi, mapResultToCabi } from "../codegen-linear/c-abi.js";
+import { absoluteFuncIndexCached } from "../emit/resolve-layout.js"; // (#1916 S3)
 import { generateModule } from "../codegen/index.js";
 import { isFatalCodegenDiagnostic } from "../codegen/context/errors.js";
 import { extractCHeaderExports, generateCHeader } from "../emit/c-header.js";
@@ -55,7 +56,8 @@ function applyCabiTransform(mod: WasmModule, moduleName: string, ast?: TypedAST)
     if (exp.desc.kind !== "func") continue;
     if (exp.name === "memory") continue;
 
-    const funcIdx = exp.desc.index;
+    // (#1916 S3) normalize a possibly-stable handle to the absolute index.
+    const funcIdx = absoluteFuncIndexCached(mod, numImportFuncs, exp.desc.index);
     const localIdx = funcIdx - numImportFuncs;
     if (localIdx < 0 || localIdx >= mod.functions.length) continue;
 

--- a/src/emit/c-header.ts
+++ b/src/emit/c-header.ts
@@ -8,6 +8,7 @@
  */
 
 import type { ValType, WasmModule } from "../ir/types.js";
+import { absoluteFuncIndexCached } from "./resolve-layout.js"; // (#1916 S3)
 
 /** Information about a single exported function for C header generation */
 export interface CHeaderExport {
@@ -100,7 +101,8 @@ export function extractCHeaderExports(mod: WasmModule): CHeaderExport[] {
     if (exp.desc.kind !== "func") continue;
     if (exp.name === "memory") continue;
 
-    const funcIdx = exp.desc.index;
+    // (#1916 S3) normalize a possibly-stable handle to the absolute index.
+    const funcIdx = absoluteFuncIndexCached(mod, numImportFuncs, exp.desc.index);
     const localIdx = funcIdx - numImportFuncs;
     if (localIdx < 0 || localIdx >= mod.functions.length) continue;
 


### PR DESCRIPTION
## What

Fifth slice of #1916 — two proven batches of the mechanical mint-site migration (stacked on #2512, draft until it lands):

**Batch 2**: `symbol-native.ts` (`__box_symbol`/`__symbol_for_native`/`__symbol_keyfor_native`), `uri-encoding-native.ts` (`__uri_encode`/`__uri_decode` — whose 'claim the slot last' ordering comment is now moot), `date-parse-native.ts` (`__date_parse`).

**Batch 3**: `case-convert-native.ts` (the #40/#2191 name-based public repoint flows stable handles unchanged — a name→handle re-point is value-opaque) and `json-codec-native.ts` (9 helpers). Notably, the JSON parse trio's `valueFuncIdx + 1 / + 2` sibling derivation — an implicit three-consecutive-pushes assumption, exactly the class this migration retires — is replaced by three explicit mints.

## Proof

- **Byte-identity per batch**: 1215 (file,target) records — **IDENTICAL** after batch 2 AND after batch 3 (baseline: origin/main tip 89ab6295).
- Family suites green: #2191 case-equals, JSON suites, symbol coercion, matchall-symbol, #1916 acceptance. `tsc` clean; zero raw `mod.functions.push` remain in the five flipped files.
- Pre-existing (NOT this PR, verified on clean main): 3 `issue-1599` JSON refusal tests expect CE but get success — stale expectations after a recent JSON change; flagged to the lead.

## Running total

11 producer files / 26 helpers flipped so far (S3a + batches 1–3). Remainder: ~35 files incl. the big ones (native-strings, object-runtime, async-scheduler multi-mint, index.ts variants); then S3-final deletes the four shifters (coordinated with the tech lead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS