### PR TITLE
fix(#2985): standalone __obj_find illegal-cast on non-string computed keys

### DIFF
--- a/plan/issues/2985-standalone-defineproperties-slab-residual.md
+++ b/plan/issues/2985-standalone-defineproperties-slab-residual.md
@@ -1,43 +1,70 @@
 ---
 id: 2985
-title: "Standalone defineProperties 5-b/6-a slab residual (~250: array/arguments own-prop MOP + accessor attribute fidelity + destructive verifyProperty)"
-status: ready
-sprint: Backlog
+title: "Standalone: __obj_find illegal-cast on non-string computed keys (bool/bigint/opaque via __to_property_key)"
+status: done
+completed: 2026-07-02
+assignee: ttraenkler/agent-dev-opus
+sprint: current
 priority: high
-horizon: l
+horizon: s
 feasibility: hard
 area: codegen, runtime
 goal: standalone-mode
-related: [2965, 2667]
+related: [2965, 2667, 2992]
 origin: "#2965 descriptor-cluster triage — follow-up class 2 (typeof sub-cause already FIXED in #2965)"
 ---
 
-# #2985 — standalone defineProperties 5-b/6-a slab residual
+# #2985 — standalone `__obj_find` illegal-cast on non-string computed keys
 
-## Problem
+## Scope (narrowed, #2751 sizing pass)
 
-Follow-up from #2965. The `defineProperties` 5-b/6-a slab (~300 tests) is a
-mixed bucket. #2965 fixed the materialized-`typeof` sub-cause (the
-`ref.null.extern` stub); the remaining ~250 need distinct MOP work:
+This issue was originally the whole `defineProperties` 5-b/6-a slab residual
+(~250, mixed bucket). An honest sizing pass (per the budget-window rule) split
+it: the **bounded, discrete sub-bug** — the `__obj_find` illegal-cast on
+non-string computed keys — is fixed here; the **~250 substrate-scale MOP
+residual** (array/arguments own-prop MOP, accessor-attribute fidelity,
+destructive `verifyProperty` survival) is re-homed to **#2992**.
 
-- **array / arguments own-property MOP** — defineProperty(ies) on array indices
-  and `length` with full attribute semantics.
-- **accessor-attribute fidelity** — get/set descriptor round-trips through
-  define → gOPD must preserve accessor identity and attribute flags.
-- **destructive `verifyProperty`** — test262's `verifyProperty` mutates then
-  restores the property; the standalone MOP must survive the
-  define→delete→redefine cycle.
+## Problem (this slice)
 
-Also folds in the `__obj_find` illegal-cast on residual dynamic non-string keys
-(2 files) noted in the #2965 triage.
+Any computed property key that is neither an `$AnyString`, a boxed number, nor
+an `$Object` — a **boolean** (`o[true]`), a **bigint** (`o[10n]`), or another
+opaque primitive — reached `__to_property_key`'s fallthrough and was returned
+**unchanged**. It then hit the downstream `ref.cast $AnyString` in
+`emitClassifyKey` / `__obj_hash`, trapping:
 
-## Acceptance
+```
+RuntimeError: illegal cast  at __obj_find … __extern_set … __module_init
+```
 
-- Measured flip count on the `built-ins/Object/defineProperties` standalone
-  subset, per sub-class, with zero regressions on a passing-test sweep.
-- gc/host lane byte-inert (standalone-gated).
+`__to_property_key`'s `#2042 R2` arm only ran `__extern_toString` for `$Object`
+keys. Boolean/bigint/etc. keys are equally non-Symbol primitives whose
+ToPropertyKey is `ToString(ToPrimitive(key,"string"))` (§7.1.1.1 → §7.1.17).
 
-## Notes
+## Fix
 
-Likely wants slicing (array-index MOP, accessor fidelity, verifyProperty
-survival) into separate PRs — hard/large.
+Broaden the spliced R2 arm in `ensureObjectRuntime` (`src/codegen/object-runtime.ts`)
+from "if key is `$Object` → ToString" to "if key is **NOT a Symbol** → ToString"
+(unconditional ToString when symbol keys are disabled). A genuine Symbol still
+falls through unchanged (looked up by identity via `__key_equals`, not by string
+cast). Standalone-gated (`tpkBodyRef` is only set in standalone) → gc/host lane
+byte-inert.
+
+## Acceptance (met)
+
+- `o[true]` / `o[false]` / `o[10n]` set→get→`in`→gOPD→defineProperty→delete-return
+  all work in standalone (measured in `tests/issue-2985.test.ts`); previously
+  trapped `illegal cast`.
+- Symbol, string, number, and object computed keys unchanged (controls pass).
+- gc/host output sha256-identical before/after (byte-inert).
+
+## Out of scope → #2992
+
+- Array/arguments own-property MOP; accessor-attribute fidelity; destructive
+  `verifyProperty` survival. Note: the delete→re-read tombstone gap surfaced by
+  `verifyProperty` reproduces for **plain string keys** too
+  (`o["k"]=1; delete o["k"]; o["k"]===undefined` FAILs), i.e. it is a general
+  standalone delete-tombstone bug, not key-type-specific — tracked in #2992.
+- null/undefined **computed** keys: consistent self-roundtrip today (no trap),
+  but `o[null]` is not canonicalised to `o["null"]`; TS also flags these as
+  index-type errors. Deferred to #2992.

--- a/plan/issues/2992-standalone-defineproperties-mop-residual.md
+++ b/plan/issues/2992-standalone-defineproperties-mop-residual.md
@@ -1,0 +1,65 @@
+---
+id: 2992
+title: "Standalone defineProperties MOP residual (~250: array/arguments own-prop MOP + accessor-attribute fidelity + destructive verifyProperty/tombstone survival)"
+status: ready
+sprint: Backlog
+priority: high
+horizon: l
+feasibility: hard
+area: codegen, runtime
+goal: standalone-mode
+related: [2965, 2985, 2667]
+origin: "#2985 sizing-pass split — the substrate-scale MOP remainder after the illegal-cast slice shipped in #2985"
+---
+
+# #2992 — standalone defineProperties MOP residual (~250)
+
+## Problem
+
+Split out of #2985. #2985 was the whole `defineProperties` 5-b/6-a slab residual
+(~250, mixed bucket). The bounded, discrete sub-bug (the `__obj_find`
+illegal-cast on non-string computed keys) shipped in #2985. This issue carries
+the **remaining ~250 substrate-scale MOP work**, which is genuinely
+large/hard and wants further slicing:
+
+- **array / arguments own-property MOP** — `defineProperty`/`defineProperties`
+  on array indices and `length` with full attribute semantics.
+- **accessor-attribute fidelity** — get/set descriptor round-trips through
+  define → gOPD must preserve accessor identity and attribute flags.
+- **destructive `verifyProperty` survival** — test262's `verifyProperty`
+  mutates then restores the property; the standalone MOP must survive the
+  define→delete→redefine cycle.
+
+## Concrete evidence (measured 2026-07-02, standalone)
+
+The destructive-`verifyProperty` sub-class has a reproducible root cause that is
+**not key-type-specific** — a plain string-keyed delete→re-read already fails:
+
+```ts
+const o: any = {};
+o["k"] = 1;
+delete o["k"];
+o["k"] === undefined; // FALSE in standalone (returns the stale value)
+```
+
+i.e. after `__delete_property` tombstones an entry, a subsequent read on the
+same key does not consistently observe the tombstone. This is the mechanism
+behind verifyProperty's define→delete→redefine failures and should be the first
+slice (it is bounded and high-leverage). Suspect area: the tombstone-skip /
+open-addressing read path in `__obj_find` / `__extern_get`
+(`src/codegen/object-runtime.ts`).
+
+## Acceptance
+
+- Measured flip count on the `built-ins/Object/defineProperties` (and
+  `defineProperty`) standalone subset, per sub-class, with zero regressions on a
+  passing-test sweep.
+- gc/host lane byte-inert (standalone-gated).
+
+## Notes
+
+Wants slicing into separate PRs:
+
+1. delete-tombstone-read survival (bounded — start here).
+2. array/arguments index + `length` own-prop MOP.
+3. accessor-attribute (get/set) define→gOPD fidelity.

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -2627,25 +2627,42 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     ];
     registerNative("__extern_toString", [{ kind: "externref" }], [{ kind: "externref" }], [], toStringBody);
 
-    // #2042 R2 — now that `__extern_toString` exists, splice the object-key arm
-    // into `__to_property_key`'s body (built earlier, before this funcIdx was
-    // known). For a `$Object` key, ToPropertyKey = ToString(ToPrimitive(key,
-    // "string")) — exactly `__extern_toString`. Insert BEFORE the trailing
-    // `local.get 0` fallthrough so Symbol/opaque keys still pass through.
+    // #2042 R2 / #2985 — now that `__extern_toString` exists, splice the
+    // non-Symbol ToString arm into `__to_property_key`'s body (built earlier,
+    // before this funcIdx was known). By this point the key is neither an
+    // `$AnyString` nor a boxed number (both returned already). For EVERY
+    // remaining non-Symbol key — `$Object`, boolean, bigint, null/undefined,
+    // any other opaque primitive — ToPropertyKey = ToString(ToPrimitive(key,
+    // "string")), exactly `__extern_toString` (§7.1.1.1 → §7.1.17). Originally
+    // this arm only tested `$Object`, so a boolean/bigint/etc. computed key
+    // (`o[true]`, `Object.defineProperty(o, true, …)`) fell through UNCHANGED
+    // and then hit the downstream `ref.cast $AnyString` in
+    // `emitClassifyKey`/`__obj_hash`, trapping "illegal cast [in __obj_find()]"
+    // (#2985 residual). Broadening the test from "is `$Object`" to "is NOT a
+    // Symbol" canonicalises those keys instead. A genuine Symbol still falls
+    // through to the trailing `local.get 0` unchanged (Symbols are looked up by
+    // identity via `__key_equals`, not by string cast). When symbol keys are
+    // disabled there are no Symbol keys, so the ToString applies unconditionally.
     if (tpkBodyRef !== undefined) {
       const externToStringIdx = ctx.funcMap.get("__extern_toString")!;
-      const objArm: Instr[] = [
-        // if (ref.test $Object any) return __extern_toString(key)
-        { op: "local.get", index: 1 },
-        { op: "ref.test", typeIdx: objectTypeIdx },
-        {
-          op: "if",
-          blockType: { kind: "empty" },
-          then: [{ op: "local.get", index: 0 }, { op: "call", funcIdx: externToStringIdx }, { op: "return" }],
-        } as Instr,
+      const toStringArm: Instr[] = [
+        { op: "local.get", index: 0 },
+        { op: "call", funcIdx: externToStringIdx },
+        { op: "return" },
       ];
-      // Splice before the last instruction (the unchanged-key fallthrough).
-      tpkBodyRef.splice(tpkBodyRef.length - 1, 0, ...objArm);
+      const nonSymbolToStringArm: Instr[] = symbolKeysEnabled
+        ? [
+            // if (!ref.test $Symbol any) return __extern_toString(key)
+            { op: "local.get", index: 1 },
+            { op: "ref.test", typeIdx: symbolTypeIdx },
+            { op: "i32.eqz" },
+            { op: "if", blockType: { kind: "empty" }, then: toStringArm } as Instr,
+          ]
+        : // no Symbol keys in play → ToString every remaining key unconditionally
+          toStringArm;
+      // Splice before the last instruction (the unchanged-key fallthrough, which
+      // now only serves genuine Symbol keys under symbolKeysEnabled).
+      tpkBodyRef.splice(tpkBodyRef.length - 1, 0, ...nonSymbolToStringArm);
     }
   }
 

--- a/tests/issue-2985.test.ts
+++ b/tests/issue-2985.test.ts
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2985 — standalone `__obj_find` illegal-cast on non-string computed keys.
+ *
+ * A computed property key that is neither an `$AnyString`, a boxed number, nor
+ * an `$Object` — a boolean (`o[true]`), a bigint (`o[10n]`), or another opaque
+ * primitive — reached `__to_property_key`'s fallthrough and was returned
+ * UNCHANGED, then hit the downstream `ref.cast $AnyString` in
+ * `emitClassifyKey` / `__obj_hash` and trapped `illegal cast [in __obj_find()]`.
+ *
+ * `__to_property_key`'s #2042 R2 arm only ran `__extern_toString` for `$Object`
+ * keys. Boolean/bigint/etc. keys are equally non-Symbol primitives whose
+ * ToPropertyKey is `ToString(ToPrimitive(key,"string"))` (§7.1.1.1 → §7.1.17).
+ * The fix broadens the arm from "is `$Object`" to "is NOT a Symbol" (or
+ * unconditional ToString when symbol keys are disabled); a genuine Symbol still
+ * passes through unchanged (looked up by identity via `__key_equals`).
+ * Standalone-gated → gc/host lane byte-inert.
+ */
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, {
+    fileName: "test.ts",
+    target: "standalone",
+    allowJs: true,
+    skipSemanticDiagnostics: true,
+  });
+  expect(r.success, `compile failed:\n${(r.errors ?? []).map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
+    true,
+  );
+  const envImports = (r.imports ?? []).filter((i) => String(i).startsWith("env"));
+  expect(envImports, "expected host-free standalone binary").toEqual([]);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const exports = instance.exports as Record<string, (...a: unknown[]) => unknown>;
+  return exports.test ? exports.test() : undefined;
+}
+
+describe("#2985 — non-string computed key no longer traps illegal cast", () => {
+  it("boolean key set→get roundtrips (o[true]) — was illegal cast", async () => {
+    await expect(
+      runStandalone(`const o:any = {}; o[true] = 1;
+export function test(): number { return o[true] === 1 ? 1 : 0; }`),
+    ).resolves.toBe(1);
+  });
+
+  it("both boolean keys are distinct and equal their ToString form", async () => {
+    // o[true]===o["true"], o[false]===o["false"], and they do not collide.
+    await expect(
+      runStandalone(`const o:any = {}; o[true] = 1; o[false] = 2;
+export function test(): number {
+  return (o[true] === 1 && o[false] === 2 && o["true"] === 1 && o["false"] === 2) ? 1 : 0;
+}`),
+    ).resolves.toBe(1);
+  });
+
+  it("bigint key set→get roundtrips (o[10n]) — was illegal cast", async () => {
+    await expect(
+      runStandalone(`const o:any = {}; o[10n as any] = 5;
+export function test(): number { return o[10n as any] === 5 ? 1 : 0; }`),
+    ).resolves.toBe(1);
+  });
+
+  it("Object.defineProperty with a boolean key defines the ToString key", async () => {
+    await expect(
+      runStandalone(`const o:any = {};
+Object.defineProperty(o, true as any, { value: 7, enumerable: true, configurable: true, writable: true });
+export function test(): number { return (o[true] === 7 && o["true"] === 7) ? 1 : 0; }`),
+    ).resolves.toBe(1);
+  });
+
+  it("getOwnPropertyDescriptor on a boolean key reads the value", async () => {
+    await expect(
+      runStandalone(`const o:any = {}; o[true] = 5;
+const d = Object.getOwnPropertyDescriptor(o, true as any);
+export function test(): number { return (d && d.value === 5) ? 1 : 0; }`),
+    ).resolves.toBe(1);
+  });
+
+  it("`in` on the ToString form of a boolean key is true", async () => {
+    await expect(
+      runStandalone(`const o:any = {}; o[false] = 1;
+export function test(): number { return ("false" in o) ? 1 : 0; }`),
+    ).resolves.toBe(1);
+  });
+
+  it("delete of a boolean-keyed prop reports success", async () => {
+    await expect(
+      runStandalone(`const o:any = {}; o[true] = 1;
+export function test(): number { return (delete o[true]) ? 1 : 0; }`),
+    ).resolves.toBe(1);
+  });
+});
+
+describe("#2985 — controls: existing key kinds unchanged", () => {
+  it("string key still roundtrips", async () => {
+    await expect(
+      runStandalone(`const o:any = {}; o["x"] = 8;
+export function test(): number { return o["x"] === 8 ? 1 : 0; }`),
+    ).resolves.toBe(1);
+  });
+
+  it("number key still roundtrips (canonical decimal ToString)", async () => {
+    await expect(
+      runStandalone(`const o:any = {}; o[0] = 9;
+export function test(): number { return o[0] === 9 ? 1 : 0; }`),
+    ).resolves.toBe(1);
+  });
+
+  it("object key still routes through toString", async () => {
+    await expect(
+      runStandalone(`const o:any = {}; const k = { toString() { return "kk"; } }; o[k as any] = 6;
+export function test(): number { return o["kk"] === 6 ? 1 : 0; }`),
+    ).resolves.toBe(1);
+  });
+
+  it("Symbol key still passes through unchanged (identity lookup)", async () => {
+    await expect(
+      runStandalone(`const s = Symbol("k"); const o:any = {}; o[s] = 42;
+export function test(): number { return o[s] === 42 ? 1 : 0; }`),
+    ).resolves.toBe(1);
+  });
+
+  it("distinct Symbol keys do not collide", async () => {
+    await expect(
+      runStandalone(`const a = Symbol(); const b = Symbol(); const o:any = {}; o[a] = 1; o[b] = 2;
+export function test(): number { return (o[a] === 1 && o[b] === 2) ? 1 : 0; }`),
+    ).resolves.toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the standalone `illegal cast [in __obj_find()]` trap for **non-string computed property keys** — the bounded, discrete sub-bug called out in the #2965 descriptor-cluster triage and folded into #2985.

A computed key that is neither an `$AnyString`, a boxed number, nor an `$Object` — a **boolean** (`o[true]`), a **bigint** (`o[10n]`), or another opaque primitive — reached `__to_property_key`'s fallthrough and was returned **unchanged**, then hit the downstream `ref.cast $AnyString` in `emitClassifyKey` / `__obj_hash` and trapped:

```
RuntimeError: illegal cast  at __obj_find … __extern_set … __module_init
```

`__to_property_key`'s `#2042 R2` arm only ran `__extern_toString` for `$Object` keys. Boolean/bigint/etc. are equally non-Symbol primitives whose ToPropertyKey is `ToString(ToPrimitive(key,"string"))` (§7.1.1.1 → §7.1.17).

## Fix

Broaden the spliced R2 arm in `ensureObjectRuntime` (`src/codegen/object-runtime.ts`) from **"if key is `$Object` → ToString"** to **"if key is NOT a Symbol → ToString"** (unconditional ToString when symbol keys are disabled). A genuine Symbol still falls through unchanged — Symbols are looked up by identity via `__key_equals`, not by string cast.

## Validation

- `tests/issue-2985.test.ts` (12 tests, all green): bool/bigint/object keys across set/get/`Object.defineProperty`/gOPD/`in`/delete-return, plus symbol/string/number/object controls.
- **gc/host lane byte-inert**: the edited block is gated on `tpkBodyRef !== undefined`, only set in standalone. Verified empirically — gc-mode output sha256-identical before/after across 3 sample programs.
- No regression on the neighbouring `#2965` (11 ✓), `#2042-r2` topropkey, and define-property suites. The 6 `issue-1472` failures are pre-existing (identical on `origin/main`, `#1888 Slice 3/4` compile-refusal assertions — untouched by this runtime change).

## Sizing / decomposition (#2751)

Per the budget-window sizing rule, #2985 (originally the whole ~250 `defineProperties` slab residual, horizon L) was split. This PR ships the bounded illegal-cast slice and **narrows #2985 to it** (`status: done`). The ~250 substrate-scale MOP remainder — array/arguments own-prop MOP, accessor-attribute fidelity, destructive `verifyProperty`/tombstone survival — is re-scoped to **#2992**. Concrete evidence for the verifyProperty sub-class: `o["k"]=1; delete o["k"]; o["k"]===undefined` FAILs even for a plain **string** key (a pre-existing standalone delete-tombstone-read bug, orthogonal to this fix) — captured in #2992.

🤖 Generated with [Claude Code](https://claude.com/claude-code)