### PR TITLE
fix(#2994): static-fold Object/Function.prototype.isPrototypeOf to drop env::Object_isPrototypeOf leak

### DIFF
--- a/plan/issues/2994-standalone-object-isprototypeof-leak.md
+++ b/plan/issues/2994-standalone-object-isprototypeof-leak.md
@@ -1,0 +1,106 @@
+---
+id: 2994
+title: "Standalone: eliminate env::Object_isPrototypeOf host-import leak — static-fold Object/Function.prototype.isPrototypeOf"
+status: done
+completed: 2026-07-02
+assignee: ttraenkler/agent-add922b5fc0765fbe
+sprint: current
+priority: medium
+horizon: s
+feasibility: medium
+origin: plan/log/investigations/2026-07-02-leak-analysis-round5.md
+---
+
+## Problem
+
+Round-5 leak analysis (2026-07-02) ranks `env::Object_isPrototypeOf` as an
+execution-verified GENUINE sole-import leaky lever: **12 official standalone
+passes** carry exactly one `env::` import, `Object_isPrototypeOf`, and the
+bodies actually execute (inject-throw probes confirmed non-vacuous). These are
+host-import leaks — the standalone binary imports a host function it should not
+need, because a WasmGC-native `__isPrototypeOf` implementation already exists
+(`src/codegen/object-runtime.ts` ~L2901).
+
+## Root cause
+
+The receiver in all 12 tests is a builtin prototype object
+(`Function.prototype.isPrototypeOf(X)` or `Object.prototype.isPrototypeOf(X)`),
+which the checker types as an **external-declared class** instance (Function /
+Object). Method-call dispatch in `src/codegen/expressions/calls.ts` (~L9917)
+therefore enters `compileExternMethodCall` (`src/codegen/expressions/extern.ts`)
+BEFORE the native `compileObjectPrototypeFallback` path
+(`src/codegen/expressions/calls-closures.ts` L417, which already routes
+`isPrototypeOf` → `__isPrototypeOf`) is ever reached.
+
+Inside `compileExternMethodCall`, `isPrototypeOf` resolves up the extern
+inheritance chain to the `Object` base extern class
+(`src/codegen/index.ts` L13428, `methods.set("isPrototypeOf", …)`,
+`importPrefix: "Object"`), so the generic host-method path emits
+`Object_isPrototypeOf`. The gate is too coarse: it never gives the native
+emitter a chance for extern-class receivers.
+
+## Root cause (refined during implementation)
+
+The actual leaky dispatch is **`tryExternClassMethodOnAny`**
+(`src/codegen/expressions/calls-closures.ts`), not `compileExternMethodCall`:
+`Function.prototype` / `Object.prototype` surface here as **`any`-typed**
+receivers, so the extern-class iteration finds `isPrototypeOf` on the `Object`
+base extern class and emits `Object_isPrototypeOf`.
+
+Routing to the existing WasmGC-native `__isPrototypeOf` does NOT work: it walks
+the `$Object.$proto` chain, but builtin prototypes/constructors
+(`Object.prototype`, `Function.prototype`, `Number`, …) are **not linked into
+that chain** in standalone mode — a separate substrate gap. A pure routing
+change made all 12 flip to `fail` (native returned a spurious `false`).
+
+## Fix
+
+Statically fold the provably-true shapes, mirroring `tryStaticInstanceOf`'s
+`instanceof Object` short-circuit (#1729). New helper `tryStaticIsPrototypeOf`
+in `calls-closures.ts` decides, when the receiver is written syntactically as
+`Object.prototype` / `Function.prototype`:
+
+- `Object.prototype.isPrototypeOf(x)` → `true` for any provably non-primitive
+  object argument (every ordinary object's `[[Prototype]]` chain ends at
+  `%Object.prototype%`), and for any inline `new X()` (always yields an object).
+- `Function.prototype.isPrototypeOf(x)` → `true` when the argument type is
+  callable/constructable (chain passes through `%Function.prototype%`).
+
+Provable shapes compile receiver+arg for side effects then emit `i32.const 1` —
+no host import. Undecidable shapes (`any`, primitives, aliased builtins) return
+`undefined` and fall through to the **existing host dispatch unchanged** — so
+there is zero behaviour change / no regression risk for anything not provable.
+
+## Acceptance criteria
+
+- The 12 listed test262 files still PASS in the standalone lane. ✅ (12/12)
+- The `Object_isPrototypeOf` host import is eliminated from the provable
+  shapes. ✅ 11/12 host-free; the 12th (`Object.prototype.isPrototypeOf(__device)`
+  where `__device` is a reassignable `var` bound to `new __FACTORY()`) cannot be
+  soundly folded — an identifier's current value isn't statically provable — so
+  it correctly stays on the (correct) host path. Still passes.
+- No regression to `isPrototypeOf` on user-defined class instances
+  (`A.prototype` receiver — base ≠ Object/Function, so the fold declines and the
+  existing path is untouched) or JS-host mode.
+
+## Test Results
+
+- `tests/issue-2994.test.ts` — 5/5 pass (4 folded-true host-free shapes +
+  1 no-mis-fold guard for a non-callable arg).
+- All 12 origin test262 files run via `runTest262File(..., "standalone")`:
+  **12/12 pass**, 11/12 host-free (`env::Object_isPrototypeOf` absent).
+
+## Test files (sole-import leak, from run 28605503741)
+
+- test/built-ins/Boolean/S15.6.3_A2.js
+- test/built-ins/Boolean/prototype/S15.6.4_A2.js
+- test/built-ins/Date/S15.9.4_A4.js
+- test/built-ins/Error/prototype/S15.11.4_A1.js
+- test/built-ins/Function/S15.3.3_A2_T1.js
+- test/built-ins/Function/prototype/bind/15.3.4.5-9-1.js
+- test/built-ins/Number/S15.7.3_A7.js
+- test/built-ins/Number/prototype/S15.7.4_A2.js
+- test/built-ins/Object/S15.2.3_A2.js
+- test/built-ins/String/S15.5.3_A2_T1.js
+- test/language/statements/function/S13.2.2_A3_T1.js
+- test/language/statements/function/S13.2_A5.js

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -870,6 +870,67 @@ export function compileCallableElementAccessCall(
 }
 
 /**
+ * (#2994) Statically decide `Object.prototype.isPrototypeOf(arg)` /
+ * `Function.prototype.isPrototypeOf(arg)` when the receiver is written
+ * syntactically as `Object.prototype` or `Function.prototype` and the argument's
+ * TypeScript type makes the answer provable:
+ *   - `Object.prototype.isPrototypeOf(x)`   → true for any non-primitive object
+ *     value (§20.1.3.4 / §10.4 — every ordinary object's [[Prototype]] chain
+ *     ends at %Object.prototype%).
+ *   - `Function.prototype.isPrototypeOf(x)`  → true when `x` is callable /
+ *     constructable (its chain passes through %Function.prototype%).
+ * Returns `true` for a provable yes, `undefined` otherwise (fall through to the
+ * existing host dispatch — conservatively no false-negatives / no behaviour
+ * change for undecidable shapes).
+ */
+function tryStaticIsPrototypeOf(
+  ctx: CodegenContext,
+  receiver: ts.Expression,
+  argExpr: ts.Expression | undefined,
+): boolean | undefined {
+  if (!argExpr) return undefined;
+  if (!ts.isPropertyAccessExpression(receiver)) return undefined;
+  if (receiver.name.text !== "prototype") return undefined;
+  if (!ts.isIdentifier(receiver.expression)) return undefined;
+  const base = receiver.expression.text;
+  if (base !== "Object" && base !== "Function") return undefined;
+
+  // A `new X()` expression always evaluates to an object (§13.3.5 EvaluateNew /
+  // OrdinaryCreateFromConstructor — even a constructor that returns a
+  // non-object yields the freshly-created instance), regardless of what
+  // TypeScript infers for its (possibly `any`) instance type. Every object
+  // descends from %Object.prototype%, so `Object.prototype.isPrototypeOf(new X())`
+  // is unconditionally true.
+  if (base === "Object" && ts.isNewExpression(argExpr)) return true;
+
+  const argType = ctx.checker.getTypeAtLocation(argExpr);
+  const f = argType.flags;
+  const isPrimitiveOrIndeterminate =
+    (f &
+      (ts.TypeFlags.Any |
+        ts.TypeFlags.Unknown |
+        ts.TypeFlags.NumberLike |
+        ts.TypeFlags.StringLike |
+        ts.TypeFlags.BooleanLike |
+        ts.TypeFlags.BigIntLike |
+        ts.TypeFlags.ESSymbolLike |
+        ts.TypeFlags.Null |
+        ts.TypeFlags.Undefined |
+        ts.TypeFlags.Void |
+        ts.TypeFlags.Never)) !==
+    0;
+  if (isPrimitiveOrIndeterminate) return undefined;
+  // Functions carry the Object type flag too, so this admits both plain objects
+  // and callables — correct for the `Object.prototype` receiver.
+  if ((f & ts.TypeFlags.Object) === 0) return undefined;
+
+  if (base === "Object") return true;
+  // base === "Function": require a call or construct signature.
+  const callable = argType.getCallSignatures().length > 0 || argType.getConstructSignatures().length > 0;
+  return callable ? true : undefined;
+}
+
+/**
  * Try to resolve a method call on an `any`-typed receiver through registered extern classes.
  * When the type checker resolves the receiver as `any` (e.g. when lib files aren't loaded
  * in ESM/bundled contexts), we dispatch known collection methods (Set.union, Map.get, etc.)
@@ -882,6 +943,36 @@ export function tryExternClassMethodOnAny(
   propAccess: ts.PropertyAccessExpression,
   methodName: string,
 ): InnerResult {
+  // (#2994) `Object.prototype.isPrototypeOf` / `Function.prototype.isPrototypeOf`
+  // static fold. On an `any`-typed receiver — which is how `Function.prototype`
+  // / `Object.prototype` (builtin prototype objects) surface here — the
+  // extern-class iteration below finds `isPrototypeOf` on the `Object` base
+  // extern class and emits an `Object_isPrototypeOf` host import the standalone
+  // runtime can't satisfy (round-5 leak analysis: 12 execution-verified
+  // sole-import leaky passes). The WasmGC-native `__isPrototypeOf` walks the
+  // `$Object.$proto` chain, but builtin prototypes/constructors (Object.prototype,
+  // Function.prototype, Number, …) are not linked into that chain in standalone
+  // mode, so routing there returns a spurious `false` (substrate gap — out of
+  // scope here). Instead statically fold the provably-true shapes — mirroring
+  // tryStaticInstanceOf's `instanceof Object` short-circuit (#1729): every
+  // non-primitive object descends from `Object.prototype`, and every
+  // callable/constructable value descends from `Function.prototype`. Undecidable
+  // shapes fall through to the existing host path unchanged (no regression).
+  if (methodName === "isPrototypeOf") {
+    const staticResult = tryStaticIsPrototypeOf(ctx, propAccess.expression, expr.arguments[0]);
+    if (staticResult !== undefined) {
+      // Compile receiver + arg for side effects (evaluation order), then const.
+      const recvType = compileExpression(ctx, fctx, propAccess.expression);
+      if (recvType !== null && recvType !== VOID_RESULT) fctx.body.push({ op: "drop" });
+      if (expr.arguments.length > 0) {
+        const argType = compileExpression(ctx, fctx, expr.arguments[0]!);
+        if (argType !== null && argType !== VOID_RESULT) fctx.body.push({ op: "drop" });
+      }
+      fctx.body.push({ op: "i32.const", value: staticResult ? 1 : 0 });
+      return { kind: "i32" };
+    }
+  }
+
   // `.slice` is ambiguous across String, Array, ArrayBuffer, Blob, and every
   // TypedArray. When a RegExp literal elsewhere in the module causes typed
   // array extern classes to register before the call is compiled, first-match

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -962,11 +962,13 @@ export function tryExternClassMethodOnAny(
     const staticResult = tryStaticIsPrototypeOf(ctx, propAccess.expression, expr.arguments[0]);
     if (staticResult !== undefined) {
       // Compile receiver + arg for side effects (evaluation order), then const.
+      // compileExpression returns `ValType | null` (never VOID_RESULT), so a
+      // non-null result always left one value on the stack that must be dropped.
       const recvType = compileExpression(ctx, fctx, propAccess.expression);
-      if (recvType !== null && recvType !== VOID_RESULT) fctx.body.push({ op: "drop" });
+      if (recvType !== null) fctx.body.push({ op: "drop" });
       if (expr.arguments.length > 0) {
         const argType = compileExpression(ctx, fctx, expr.arguments[0]!);
-        if (argType !== null && argType !== VOID_RESULT) fctx.body.push({ op: "drop" });
+        if (argType !== null) fctx.body.push({ op: "drop" });
       }
       fctx.body.push({ op: "i32.const", value: staticResult ? 1 : 0 });
       return { kind: "i32" };

--- a/tests/issue-2994.test.ts
+++ b/tests/issue-2994.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2994 — eliminate the `env::Object_isPrototypeOf` host-import leak.
+ *
+ * Round-5 leak analysis flagged 12 execution-verified standalone passes whose
+ * sole `env::` import was `Object_isPrototypeOf`. They are all
+ * `Function.prototype.isPrototypeOf(<callable>)` or
+ * `Object.prototype.isPrototypeOf(<object>)` — provably `true` shapes that the
+ * WasmGC-native `__isPrototypeOf` cannot answer, because builtin
+ * prototypes/constructors are not linked into the native `$Object.$proto`
+ * chain in standalone mode (a substrate gap). Instead the compiler now
+ * statically folds these provable shapes (mirroring `tryStaticInstanceOf`'s
+ * `instanceof Object` short-circuit, #1729), so the host import is never
+ * emitted. Undecidable shapes still fall through to the existing host path.
+ */
+
+const HOST_IMPORT = "env::Object_isPrototypeOf";
+
+async function standaloneImports(src: string): Promise<string[]> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.success ? "" : r.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  return r.imports.map((i) => `${i.module}::${i.name}`);
+}
+
+async function runStandalone(src: string): Promise<unknown> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.success ? "" : r.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as Record<string, () => unknown>).test?.();
+}
+
+describe("#2994 Object.prototype/Function.prototype.isPrototypeOf static fold", () => {
+  const foldedTrue: Array<[string, string]> = [
+    ["Function.prototype.isPrototypeOf(builtin ctor)", "return Function.prototype.isPrototypeOf(Number) ? 1 : 0;"],
+    ["Function.prototype.isPrototypeOf(Object)", "return Function.prototype.isPrototypeOf(Object) ? 1 : 0;"],
+    [
+      "Object.prototype.isPrototypeOf(builtin proto)",
+      "return Object.prototype.isPrototypeOf(Number.prototype) ? 1 : 0;",
+    ],
+    ["Object.prototype.isPrototypeOf(new X())", "return Object.prototype.isPrototypeOf(new Array()) ? 1 : 0;"],
+  ];
+
+  for (const [name, body] of foldedTrue) {
+    it(`folds ${name} to true with no host import`, async () => {
+      const src = `export function test(): number { ${body} }`;
+      const imports = await standaloneImports(src);
+      expect(imports, `leaked ${HOST_IMPORT}`).not.toContain(HOST_IMPORT);
+      expect(await runStandalone(src)).toBe(1);
+    });
+  }
+
+  it("does NOT mis-fold Function.prototype.isPrototypeOf(non-callable object)", async () => {
+    // A plain object is not in Function.prototype's descendants — the correct
+    // answer is false. The static fold must decline (it only asserts the
+    // provably-true shapes), leaving the call on the existing host dispatch.
+    // Presence of the host import is the observable proof it was NOT folded to
+    // a constant `true`.
+    const src = `export function test(): number { const o: any = {}; return Function.prototype.isPrototypeOf(o) ? 1 : 0; }`;
+    const imports = await standaloneImports(src);
+    expect(imports, "non-callable arg should stay on the host isPrototypeOf path").toContain(HOST_IMPORT);
+  });
+});


### PR DESCRIPTION
## Summary

Eliminates the `env::Object_isPrototypeOf` host-import leak flagged by the
2026-07-02 round-5 leak analysis (12 execution-verified sole-import standalone
passes).

## Root cause

`Function.prototype` / `Object.prototype` surface in codegen as **`any`-typed**
receivers, so `isPrototypeOf` routes through `tryExternClassMethodOnAny`
(`src/codegen/expressions/calls-closures.ts`), which resolves the method to the
`Object` base extern class and emits the `Object_isPrototypeOf` host import.

Routing to the existing WasmGC-native `__isPrototypeOf` does **not** work: it
walks the `$Object.$proto` chain, but builtin prototypes/constructors
(`Object.prototype`, `Function.prototype`, `Number`, …) aren't linked into that
chain in standalone mode (a separate substrate gap) — a pure routing change made
all 12 flip to `fail` (spurious `false`).

## Fix

Statically fold the provably-true shapes, mirroring `tryStaticInstanceOf`'s
`instanceof Object` short-circuit (#1729). New `tryStaticIsPrototypeOf` decides,
when the receiver is written syntactically as `Object.prototype` /
`Function.prototype`:

- `Object.prototype.isPrototypeOf(x)` → `true` for any provably non-primitive
  object arg (and any inline `new X()`).
- `Function.prototype.isPrototypeOf(x)` → `true` for any callable/constructable arg.

Provable shapes emit `i32.const 1` (after compiling receiver+arg for side
effects); undecidable shapes fall through to the **existing host path
unchanged** — zero behaviour change for anything not provable.

## Results

- 12/12 origin test262 files pass (standalone lane); **11/12 host-free**.
- The 12th (`Object.prototype.isPrototypeOf(__device)` where `__device` is a
  reassignable `var` bound to `new __FACTORY()`) can't be soundly folded — an
  identifier's current value isn't statically provable — so it stays on the
  correct host path. Still passes.
- `tests/issue-2994.test.ts` — 5/5 (4 folded host-free shapes + 1 no-mis-fold guard).
- User-class `isPrototypeOf` (`A.prototype` receiver) and JS-host mode are
  untouched (fold declines when base ≠ Object/Function).

🤖 Generated with [Claude Code](https://claude.com/claude-code)