### PR TITLE
fix(#2995): native tuple-from-iterable destructure in standalone/wasi

### DIFF
--- a/plan/issues/2995-native-tuple-from-iterable-fallback.md
+++ b/plan/issues/2995-native-tuple-from-iterable-fallback.md
@@ -1,0 +1,61 @@
+---
+id: 2995
+title: Standalone tuple-from-iterable destructure fallback leaks env::__array_from_iter
+status: done
+assignee: ttraenkler/agent-a67bcee7
+sprint: current
+priority: high
+horizon: s
+feasibility: medium
+goal: standalone-host-free
+created: 2026-07-02
+completed: 2026-07-02
+---
+
+## Problem
+
+Origin: `plan/log/investigations/2026-07-02-leak-analysis-round5.md`
+(iterator-protocol tail lever, execution-verified GENUINE). On
+`--target standalone` / `--target wasi`, destructuring an `any`-typed
+(externref) source into a **tuple** via the iterable fallback
+(`buildTupleFromIterableFallback` in `src/codegen/type-coercion.ts`) leaks the
+host import `env::__array_from_iter`. This is the object-pattern-with-array-
+subpattern-default shape, e.g.:
+
+```js
+function f({ w: [x, y, z] = [4, 5, 6] } = { w: [7, undefined,] }) { … }
+```
+
+The sibling issue #2904 already gave fixed-arity **destructuring-param** array
+patterns a native `__array_from_iter_n`; but the tuple-from-iterable fallback in
+`type-coercion.ts` still unconditionally emitted the host `__array_from_iter`
+even in host-free targets — unlike its neighbour `buildVecFromExternref`, which
+already has a native ObjVec path. The round-5 report counted **10** sole-import
+leaky standalone passes on `env::__array_from_iter` from this cluster:
+
+- `language/statements|expressions/class/dstr/(private-)meth(-static)-dflt-obj-ptrn-prop-ary.js`
+- `language/statements/function/dstr/{ary-init-iter-no-close,dflt-obj-ptrn-prop-ary}.js`
+
+## Fix
+
+`buildTupleFromIterableFallback` now routes host-free targets
+(`ctx.standalone || ctx.wasi`) through the NATIVE `__array_from_iter_n`
+(registered by `ensureNativeArrayFromIterN`, #2904) with count `-1` — an
+unbounded drain that is byte-semantics-equivalent to the host
+`__array_from_iter` (fully drain the iterable, then index each tuple slot via
+`__extern_get_idx`). Host (gc) mode keeps the JS-host `__array_from_iter` path
+unchanged.
+
+Single file: `src/codegen/type-coercion.ts`.
+
+## Verification
+
+- **Leak-elim**: all 10 cluster tests compile with **0 `env::` imports** on
+  `--target standalone` (were `env(1): __array_from_iter`).
+- **Correctness**: all 10 pass via the real `runTest262File(..., "standalone")`
+  runner (10/10). A 70-test destructuring regression sample shows an
+  **identical** pass/fail set before and after (47/70, zero pass→fail flips).
+- **Vacuity**: inject-throw probe (throw before first assert) flips the target
+  tests to `fail` — GENUINE, the body executes.
+- **Host lane byte-inert**: sha256 of the gc-lane binary is identical
+  before/after for the affected tests (change is gated on standalone/wasi).

--- a/src/codegen/type-coercion.ts
+++ b/src/codegen/type-coercion.ts
@@ -15,6 +15,7 @@ import { definedFuncAt } from "./func-space.js";
 import { addUnionImports, ensureAnyHelpers, ensureAnyToExternHelper, isAnyValue } from "./index.js";
 import { ensureAnyToStringHelper, stringConstantExternrefInstrs } from "./native-strings.js";
 import { emitThrowTypeError } from "./expressions/helpers.js";
+import { ensureNativeArrayFromIterN } from "./iterator-native.js";
 import { emitNativeNumberFormat } from "./number-format-native.js";
 import { addStringConstantGlobal } from "./registry/imports.js";
 import { addFuncType, getArrTypeIdxFromVec } from "./registry/types.js";
@@ -598,16 +599,29 @@ function buildTupleFromIterableFallback(
   if (externLocal === undefined) {
     return [{ op: "ref.null", typeIdx: tupleTypeIdx } as Instr];
   }
+  // (#2995) In host-free targets (standalone / WASI) the host `__array_from_iter`
+  // import is unavailable — emitting it leaks `env::__array_from_iter` and breaks
+  // zero-import instantiation. Materialize through the NATIVE `__array_from_iter_n`
+  // instead (registered by `ensureNativeArrayFromIterN`, #2904), passing `-1` for
+  // an unbounded drain that is byte-semantics-equivalent to the host
+  // `__array_from_iter` (fully drain the iterable, then index each tuple slot via
+  // `__extern_get_idx`). Host mode keeps the JS-host `__array_from_iter` path
+  // unchanged (byte-inert). Mirrors the native ObjVec steering in
+  // `buildVecFromExternref`.
+  const useNativeFromIter = ctx.standalone || ctx.wasi;
+  if (useNativeFromIter) ensureNativeArrayFromIterN(ctx);
   // Register all helpers first so every ensureLateImport shift completes
   // before we freeze funcIdx values — otherwise a later ensureLateImport
   // could shift a previously-captured funcIdx and produce the wrong call.
-  ensureLateImport(ctx, "__array_from_iter", [{ kind: "externref" }], [{ kind: "externref" }]);
+  if (!useNativeFromIter) {
+    ensureLateImport(ctx, "__array_from_iter", [{ kind: "externref" }], [{ kind: "externref" }]);
+  }
   ensureLateImport(ctx, "__extern_get_idx", [{ kind: "externref" }, { kind: "f64" }], [{ kind: "externref" }]);
   ensureLateImport(ctx, "__extern_is_undefined", [{ kind: "externref" }], [{ kind: "i32" }]);
   ensureLateImport(ctx, "__unbox_number", [{ kind: "externref" }], [{ kind: "f64" }]);
   ensureLateImport(ctx, "__box_number", [{ kind: "f64" }], [{ kind: "externref" }]);
   flushLateImportShifts(ctx, fctx);
-  const iterIdx = ctx.funcMap.get("__array_from_iter");
+  const iterIdx = useNativeFromIter ? ctx.funcMap.get("__array_from_iter_n") : ctx.funcMap.get("__array_from_iter");
   const getIdxFn = ctx.funcMap.get("__extern_get_idx");
   const isUndefFn = ctx.funcMap.get("__extern_is_undefined");
   const unboxIdx = ctx.funcMap.get("__unbox_number");
@@ -649,9 +663,12 @@ function buildTupleFromIterableFallback(
     }
   }
 
-  // Result shape: if (isNull || isUndefined) then ref.null else build tuple
+  // Result shape: if (isNull || isUndefined) then ref.null else build tuple.
+  // Native `__array_from_iter_n(externref, f64)` takes a count arg — pass `-1`
+  // (unbounded drain, byte-semantics-equivalent to the host `__array_from_iter`).
   const buildTupleInstrs: Instr[] = [
     { op: "local.get", index: externLocal } as Instr,
+    ...(useNativeFromIter ? [{ op: "f64.const", value: -1 } as Instr] : []),
     { op: "call", funcIdx: iterIdx } as Instr,
     { op: "local.set", index: matLocal } as Instr,
     ...fieldExtracts,


### PR DESCRIPTION
## Summary

Origin: `plan/log/investigations/2026-07-02-leak-analysis-round5.md` — iterator-protocol tail lever (execution-verified GENUINE).

`buildTupleFromIterableFallback` (`src/codegen/type-coercion.ts`) unconditionally emitted the host `env::__array_from_iter` even in host-free targets, leaking the import on `--target standalone`/`--target wasi`. Unlike its neighbour `buildVecFromExternref` (which already has a native ObjVec path), the tuple-from-iterable fallback had no host-free route.

Fix: route `ctx.standalone || ctx.wasi` through the NATIVE `__array_from_iter_n` (registered by `ensureNativeArrayFromIterN`, #2904) with count `-1` — an unbounded drain byte-semantics-equivalent to the host `__array_from_iter`. Host (gc) mode unchanged.

Converts the 10-test object-pattern-with-array-subpattern-default cluster (`(private-)meth(-static)-dflt-obj-ptrn-prop-ary`, `ary-init-iter-no-close`, `dflt-obj-ptrn-prop-ary`) from leaky → host-free.

## Verification

- **Leak-elim**: all 10 cluster tests compile with 0 `env::` imports standalone (were `env(1): __array_from_iter`).
- **Correctness**: 10/10 pass via the real `runTest262File(..., "standalone")` runner.
- **No regression**: 70-test dstr sample has an identical pass/fail set before/after (47/70, zero pass→fail flips).
- **Vacuity**: inject-throw probe flips targets to `fail` — GENUINE (body executes).
- **Host lane byte-inert**: gc-lane binary sha256 identical before/after (change gated on standalone/wasi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)