### PR TITLE
fix(#2996): native standalone globalThis value (eliminate __get_globalThis read leak)

### DIFF
--- a/plan/issues/2996-standalone-getglobalthis-leak.md
+++ b/plan/issues/2996-standalone-getglobalthis-leak.md
@@ -1,0 +1,104 @@
+---
+id: 2996
+title: "Eliminate env::__get_globalThis read leak in standalone mode (native globalThis value)"
+status: done
+completed: 2026-07-02
+sprint: current
+priority: medium
+horizon: m
+assignee: ttraenkler/agent-af6e582225dfb945b
+origin: plan/log/investigations/2026-07-02-leak-analysis-round5.md
+---
+
+## Problem
+
+In standalone mode a bare `globalThis` identifier read compiles to the
+`env::__get_globalThis` host import (`src/codegen/expressions/identifiers.ts`).
+A no-JS-host binary can't satisfy that import, yet the standalone test262 runner
+provides it, so the affected tests **pass but leak** the import
+(`host_free_pass` excludes them).
+
+Round-5 leak analysis (`plan/log/investigations/2026-07-02-leak-analysis-round5.md`)
+ranked `env::__get_globalThis` as the **biggest genuine (execution-verified,
+non-vacuous) sole-import lever: 47 sole-import leaky-passes**. Clusters:
+
+- annexB `emulates-undefined` (15) — `$262.IsHTMLDDA` shapes
+- Array/prototype `create-proto-from-ctor-realm` (10) — `$262.createRealm().global.X`
+- Proxy `*-realm` (9) — `$262.createRealm().global.Proxy`
+- `global-code` / eval-realm / BigInt cross-realm / module-code (rest)
+
+### Root cause
+
+Every one of the 47 tests uses `$262`, so the test262 runner prepends the
+harness stub `let $262: any = { global: globalThis, … }`. Compiling that object
+literal evaluates the `globalThis` initializer → emits `__get_globalThis`.
+**None of the 47 tests ever READ a property off that `globalThis` value** — the
+cross-realm tests read off a _fresh_ `createRealm()` realm object, not
+`$262.global`. So the import is a pure artifact of needing `globalThis` to be a
+valid object _value_.
+
+## Fix
+
+In standalone / WASI mode, resolve a bare `globalThis` identifier to a native,
+lazily-created, cached `$Object` singleton (built with the same native
+`__new_plain_object` runtime an empty `{}` uses — zero host imports), instead of
+the `__get_globalThis` host import. The singleton is cached in a module global
+`$__native_globalThis` (populated lazily once via `__new_plain_object`), so every
+read returns the same Wasm-level externref. Host/gc mode is byte-identical (keeps
+the host import).
+
+(Note: standalone `===` on `any`-boxed objects doesn't currently observe ref
+identity — a pre-existing general limitation, not specific to globalThis — so
+`globalThis === globalThis` evaluates like `{} === {}` does today. None of the 47
+tests rely on globalThis identity.)
+
+New helper `emitNativeGlobalThisObject` in `src/codegen/array-object-proto.ts`
+(modelled on `emitTypedArrayIntrinsicCtorObject`), called from
+`compileIdentifier` in `src/codegen/expressions/identifiers.ts`.
+
+### Scope boundary
+
+READ-_value_ substrate only. Reflective READS of specific global bindings
+(`globalThis.Array`, the defineProperty-on-globalThis own-property table) are the
+much larger MOP work **deferred to #2988**; the `globalThis.prop` property-access
+path (`src/codegen/property-access.ts`) is untouched here (host/gc keeps
+`__extern_get(__get_globalThis(), key)`; standalone still leaks there, tracked
+separately).
+
+## Acceptance criteria
+
+- Bare-`globalThis` sole-import `__get_globalThis` standalone tests compile with
+  **zero `env::` imports** and still pass.
+- Host/gc mode byte-identical (globalThis keeps `__get_globalThis`).
+- No standalone regressions.
+
+## Test Results
+
+Measured against the round-5 merged-report list of 47 sole-import
+`__get_globalThis` standalone leaky-passes (`origin/main` `4c74c87`):
+
+- **All 47 still PASS in standalone** (execution-verified via
+  `runTest262File(..., "standalone")`).
+- **40 / 47 now compile with ZERO `env::` imports** (host-free) — the bare
+  `globalThis`-value shapes: annexB `emulates-undefined` (15),
+  Array/Proxy/BigInt cross-realm `$262.createRealm().global.X` (20),
+  `global-code` `$262.evalScript` (2), eval-realm/module-code tail (3).
+- **Host/gc mode byte-identical** — the new path is gated on
+  `ctx.standalone || ctx.wasi`; gc still emits `__get_globalThis` (confirmed).
+
+### Residual (7) — property-access READ path, out of scope here
+
+7 tests still leak `__get_globalThis` because they READ `globalThis.<prop>`
+(the `compilePropertyAccess` `globalThis.prop` → `__extern_get(__get_globalThis(),
+key)` path, deliberately untouched):
+
+- 6 × `language/eval-code/direct/arrow-fn-*` — read `globalThis.arguments`
+  (would convert to a native-object read; low value, eval-adjacent).
+- 1 × `language/module-code/export-expname-import-string-binding.js` — reads
+  `globalThis.Mercury`, a **real exported global binding**. A native empty
+  globalThis can't serve this — it needs the actual own-property table, which is
+  the deferred **#2988** MOP substrate. Converting the property-access path
+  without that would regress this test (pass → fail), so it's left host-backed.
+
+These 7 are unaffected by this change (they don't use the bare-`globalThis`
+identifier path) — still passing, no regression.

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -1915,3 +1915,58 @@ export function emitTypedArrayIntrinsicCtorObject(ctx: CodegenContext, fctx: Fun
   fctx.body.push({ op: "global.get", index: globalIdx } as Instr);
   return { kind: "externref" };
 }
+
+/**
+ * (#2996) Native standalone `globalThis` value. In host/gc mode a bare
+ * `globalThis` identifier read leaks the `env::__get_globalThis` host import
+ * (see `compileIdentifier`), which a no-JS-host binary can't satisfy — yet the
+ * value still leaks into the standalone import section. The 47 sole-import
+ * `__get_globalThis` leaky-passes (annexB `emulates-undefined`, `global-code`,
+ * Array/Proxy cross-realm) never actually *read* a property off the resulting
+ * object; they only need `globalThis` to be a valid object value (it lands in
+ * the test262 `$262 = { global: globalThis, … }` harness stub, or an unread
+ * slot). This resolves bare `globalThis` to a native, lazily-created, cached
+ * `$Object` singleton (stable identity: `globalThis === globalThis`) built with
+ * the same `__new_plain_object` runtime an empty `{}` uses — zero host imports.
+ *
+ * Scope note: this is READ-value substrate only. Reflective READS of specific
+ * global bindings (`globalThis.Array`, defineProperty-on-globalThis own-property
+ * table, etc.) are the much larger MOP work deferred to #2988 — those go through
+ * `compilePropertyAccess`'s dedicated `globalThis.prop` path, which is untouched
+ * here (host/gc keeps `__extern_get(__get_globalThis(), key)`; standalone still
+ * leaks there, tracked separately). Standalone/WASI only; returns the externref
+ * ValType, or `null` if the `$Object` runtime is unavailable (caller falls
+ * through to the host-import path).
+ */
+export function emitNativeGlobalThisObject(ctx: CodegenContext, fctx: FunctionContext): ValType | null {
+  ensureObjectRuntime(ctx);
+  const newObjectIdx = ctx.funcMap.get("__new_plain_object");
+  if (newObjectIdx === undefined) return null;
+
+  const globalName = "__native_globalThis";
+  let globalIdx = ctx.builtinObjectGlobals.get(globalName);
+  if (globalIdx === undefined) {
+    globalIdx = ctx.numImportGlobals + ctx.mod.globals.length;
+    ctx.mod.globals.push({
+      name: globalName,
+      type: { kind: "externref" },
+      mutable: true,
+      init: [{ op: "ref.null.extern" }],
+    });
+    ctx.builtinObjectGlobals.set(globalName, globalIdx);
+  }
+
+  // Lazy init: `if (global == null) global = __new_plain_object();` then read it.
+  // The init body is nested directly inside the `if` (part of `fctx.body`), so
+  // any later late-import funcIdx shift walks it naturally — no detached-body
+  // (`liveBodies`) registration needed.
+  const initBody: Instr[] = [
+    { op: "call", funcIdx: newObjectIdx } as Instr,
+    { op: "global.set", index: globalIdx } as Instr,
+  ];
+  fctx.body.push({ op: "global.get", index: globalIdx } as Instr);
+  fctx.body.push({ op: "ref.is_null" } as Instr);
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: initBody, else: [] } as Instr);
+  fctx.body.push({ op: "global.get", index: globalIdx } as Instr);
+  return { kind: "externref" };
+}

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -15,6 +15,7 @@ import {
 } from "../../checker/type-mapper.js";
 import type { Instr, ValType } from "../../ir/types.js";
 import { emitCachedFuncClosureAccess, emitFuncRefAsClosure } from "../closures.js";
+import { emitNativeGlobalThisObject } from "../array-object-proto.js";
 import { emitLazyClassObjectGet } from "./extern.js";
 import type { CodegenContext, FunctionContext } from "../context/types.js";
 import {
@@ -822,8 +823,20 @@ function compileIdentifierCore(ctx: CodegenContext, fctx: FunctionContext, id: t
     return { kind: "externref" };
   }
 
-  // globalThis — return the JS global object via host import
+  // globalThis — return the JS global object.
   if (name === "globalThis") {
+    // (#2996) Standalone / WASI (no-JS-host): resolve to a native, cached
+    // `$Object` singleton instead of the `env::__get_globalThis` host import,
+    // which a host-free binary can't satisfy (it merely leaks into the import
+    // section). This eliminates the biggest genuine sole-import leak lever
+    // (47 tests) — READ-value substrate only; `globalThis.prop` reflective reads
+    // are the deferred #2988 MOP work and keep their existing path. Host/gc mode
+    // is byte-identical (falls through to the host import below).
+    if (ctx.standalone || ctx.wasi) {
+      const nativeVt = emitNativeGlobalThisObject(ctx, fctx);
+      if (nativeVt) return nativeVt;
+      // Native runtime unavailable — fall through to the host-import path.
+    }
     let funcIdx = ctx.funcMap.get("__get_globalThis");
     if (funcIdx === undefined) {
       const importsBefore = ctx.numImportFuncs;

--- a/tests/issue-2996.test.ts
+++ b/tests/issue-2996.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2996 — Eliminate the `env::__get_globalThis` read leak in standalone mode.
+ *
+ * A bare `globalThis` identifier read in standalone / WASI mode must resolve to
+ * a native `$Object` singleton (via the host-free `__new_plain_object` runtime),
+ * NOT the `env::__get_globalThis` host import — which a no-JS-host binary can't
+ * satisfy and which merely leaks into the import section. Host/gc mode is
+ * unchanged (keeps the host import). Reflective `globalThis.prop` READS are the
+ * deferred #2988 MOP work and keep their existing path.
+ */
+
+/** Parse the WASM import section and return the `env::` import names. */
+function envImports(bin: Uint8Array): string[] {
+  let o = 8;
+  const out: string[] = [];
+  const u32 = () => {
+    let r = 0,
+      s = 0,
+      b: number;
+    do {
+      b = bin[o++];
+      r |= (b & 0x7f) << s;
+      s += 7;
+    } while (b & 0x80);
+    return r >>> 0;
+  };
+  const str = () => {
+    const n = u32();
+    const t = new TextDecoder().decode(bin.subarray(o, o + n));
+    o += n;
+    return t;
+  };
+  while (o < bin.length) {
+    const id = bin[o++];
+    const sz = u32();
+    const end = o + sz;
+    if (id === 2) {
+      const cnt = u32();
+      for (let i = 0; i < cnt; i++) {
+        const m = str();
+        const nm = str();
+        const kind = bin[o++];
+        if (m === "env") out.push(nm);
+        if (kind === 0) u32();
+        else if (kind === 1 || kind === 2) {
+          o++;
+          const f = bin[o++];
+          u32();
+          if (f) u32();
+        } else if (kind === 3) {
+          o += 2;
+        }
+      }
+    }
+    o = end;
+  }
+  return out;
+}
+
+// Mirrors the test262 `$262 = { global: globalThis, … }` harness stub shape —
+// `globalThis` compiled as an object-literal field value (never read back).
+const SRC = `
+let host: any = { global: globalThis };
+export function test(): number {
+  return host.global == null ? 0 : 1;
+}
+`;
+
+describe("#2996 standalone globalThis read leak", () => {
+  it("standalone: bare globalThis emits NO env import", async () => {
+    const r = await compile(SRC, { fileName: "t.ts", target: "standalone", skipSemanticDiagnostics: true });
+    expect(r.success).toBe(true);
+    const env = envImports(r.binary);
+    expect(env).not.toContain("__get_globalThis");
+    // The stub uses only globalThis + a plain object → fully host-free.
+    expect(env).toEqual([]);
+  });
+
+  it("standalone: globalThis value is a non-null native object", async () => {
+    const r = await compile(SRC, { fileName: "t.ts", target: "standalone", skipSemanticDiagnostics: true });
+    expect(r.success).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    // host.global (the native globalThis singleton) must be a real object (== 1).
+    expect((instance.exports.test as () => number)()).toBe(1);
+  });
+
+  it("standalone: repeated globalThis reads stay host-free (cached singleton)", async () => {
+    // Two reads of the native globalThis singleton — must remain fully host-free
+    // (the cached `$__native_globalThis` global is populated lazily once).
+    const src = `
+export function test(): number {
+  let a: any = globalThis;
+  let b: any = globalThis;
+  return (a == null || b == null) ? 0 : 1;
+}
+`;
+    const r = await compile(src, { fileName: "t.ts", target: "standalone", skipSemanticDiagnostics: true });
+    expect(r.success).toBe(true);
+    expect(envImports(r.binary)).not.toContain("__get_globalThis");
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports.test as () => number)()).toBe(1);
+  });
+
+  it("host/gc mode is unchanged — still emits __get_globalThis", async () => {
+    const r = await compile(SRC, { fileName: "t.ts", skipSemanticDiagnostics: true });
+    expect(r.success).toBe(true);
+    expect(envImports(r.binary)).toContain("__get_globalThis");
+  });
+});


### PR DESCRIPTION
## Summary

Eliminates the `env::__get_globalThis` **read leak** in standalone/WASI mode — the biggest genuine (execution-verified, non-vacuous) sole-import leak lever in the round-5 leak analysis (`plan/log/investigations/2026-07-02-leak-analysis-round5.md`).

### Root cause
A bare `globalThis` identifier read compiled to the `env::__get_globalThis` host import. A no-JS-host binary can't satisfy it; it merely leaked into the import section. All 47 affected test262 tests only need `globalThis` as a valid object *value* — it lands in the runner's `$262 = { global: globalThis, … }` harness stub (or an unread slot). **None READ a property off it** (the cross-realm tests read off a fresh `$262.createRealm().global` realm object, not `$262.global`).

### Fix
Resolve bare `globalThis` in standalone/WASI to a native, lazily-created, cached `$Object` singleton (`$__native_globalThis` module global, populated once via the host-free `__new_plain_object` runtime that an empty `{}` already uses). New helper `emitNativeGlobalThisObject` in `src/codegen/array-object-proto.ts`, called from `compileIdentifier`. **Gated on `ctx.standalone || ctx.wasi`** → host/gc mode is byte-identical (still emits `__get_globalThis`).

### Scope boundary
READ-*value* substrate only. Reflective READS of specific global bindings (`globalThis.Array`, defineProperty-on-globalThis own-property table) are the much larger MOP work **deferred to #2988**; the `globalThis.prop` property-access path is deliberately untouched.

## Results (round-5 list of 47 sole-import `__get_globalThis` standalone leaky-passes)
- **All 47 still PASS** in standalone (execution-verified via `runTest262File(..., "standalone")`).
- **40 / 47 now compile with ZERO env imports** (host-free): annexB `emulates-undefined` (15), Array/Proxy/BigInt cross-realm (20), `global-code` (2), eval-realm/module tail (3).
- **Host/gc byte-identical** (confirmed: gc still emits `__get_globalThis`).
- **7 residual** still leak via the `globalThis.<prop>` property-access path (6 read `globalThis.arguments`; 1 module-code reads a real `globalThis.Mercury` global binding needing the #2988 own-property table). Unaffected by this change — no regression.

## Test
`tests/issue-2996.test.ts` — asserts standalone emits no `__get_globalThis`, the value is a non-null native object, repeated reads stay host-free, and gc mode is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)