### PR TITLE
fix(#2993): box i64/BigInt yield to externref in legacy generator buffer

### DIFF
--- a/plan/issues/2993-async-gen-bigint-externref-mismatch.md
+++ b/plan/issues/2993-async-gen-bigint-externref-mismatch.md
@@ -1,7 +1,7 @@
 ---
 id: 2993
 title: "standalone: generator-closure lowering emits i64/BigInt where externref expected → invalid-wasm CE (`__closure_3`) on BigInt generator-iterable TypedArray ctor"
-status: ready
+status: done
 sprint: current
 priority: medium
 feasibility: hard
@@ -10,6 +10,8 @@ area: codegen
 language_feature: generators, closures, bigint, typed-arrays
 related: [2940, 2939]
 created: 2026-07-02
+completed: 2026-07-02
+assignee: ttraenkler/sendev-2993
 origin: "2026-07-02 — discovered during #2940/PR #2463 (vacuity scorer) regression triage. Pre-existing on upstream/main, unrelated to that PR."
 ---
 
@@ -36,14 +38,19 @@ can admin-merge cleanly.
 `test262/test/built-ins/TypedArrayConstructors/ctors-bigint/object-arg/as-generator-iterable-returns.js`
 
 ```js
-testWithBigIntTypedArrayConstructors(function(TA) {
-  var obj = (function *() {
-    yield 7n; yield 42n;      // BigInt yields
-  })();
-  var typedArray = new TA(obj); // construct TA from a generator iterable
-  assert.sameValue(typedArray.length, 2);
-  // ...
-}, null, ["passthrough"]);
+testWithBigIntTypedArrayConstructors(
+  function (TA) {
+    var obj = (function* () {
+      yield 7n;
+      yield 42n; // BigInt yields
+    })();
+    var typedArray = new TA(obj); // construct TA from a generator iterable
+    assert.sameValue(typedArray.length, 2);
+    // ...
+  },
+  null,
+  ["passthrough"],
+);
 ```
 
 Compile on the standalone lane and observe the invalid-wasm rejection in the
@@ -77,3 +84,81 @@ missing for the i64/BigInt value-kind.
 - Discovered in #2940/PR #2463 triage; see that issue's classification table
   (the "1 async-gen invalid-wasm" / latent `__closure_3` follow-up bullet).
 - Related dynamic-closure-dispatch work: #2939.
+
+## Resolution (2026-07-02, sendev-2993)
+
+### Confirmed root cause (exact)
+
+The suspected root cause was correct and the fix is a one-branch carrier
+coercion. `compileYieldExpression` in `src/codegen/expressions/misc.ts` (the
+**legacy / eager-buffer** yield path) dispatched the yielded value into the
+generator buffer by Wasm value-kind:
+
+- `f64` → `__gen_push_f64`
+- `i32` → `__gen_push_i32`
+- **everything else** → `__gen_push_ref(externref, externref)`
+
+A `yield <bigint>` lowers to a raw `i64` (bigint-branded), which fell into the
+`else` arm and was passed **unboxed** into `__gen_push_ref`'s `externref`
+parameter slot. WasmGC validation rejects that (`call[1] expected type
+externref, found local.get of type i64`) in the generator closure body
+(`__closure_0` in the minimal repro, `__closure_3` under the full
+`testTypedArray.js` harness) → `compile_error`, never instantiated.
+
+Why only the **closure/HOF** shapes tripped it: the simple direct
+`for (const v of g())` bigint generator already uses the **#2864 native
+carrier** (which handles i64 host-free) and compiled fine on `main`. Only the
+eager-buffer shapes — `.next().value`, and a generator threaded through a
+higher-order closure like the repro — bail to the legacy host-buffer path where
+this bug lived.
+
+### Fix
+
+Added an explicit `i64` arm in the yield dispatch that boxes the value to
+externref via the existing `coerceType(i64 → externref)` before the
+`__gen_push_ref` call. `coerceType` already does the right thing (#1644): a
+bigint-branded i64 boxes via `__box_bigint` (round-trips as a JS bigint), a
+native `type i64 = number` via `__box_number`. The push-func idx is resolved
+**after** `coerceType` since that call may add late union imports (index
+shifting).
+
+### Verification
+
+- Pre-fix: `.next().value` bigint generator + the closure/HOF repro both throw
+  the `expected externref, found i64` validation CE. Post-fix both compile to
+  **valid Wasm** (`WebAssembly.compile` succeeds) on the standalone lane.
+- Semantic correctness of the box proven in gc mode: `.next().value` → `7`,
+  direct `for-of` sum → `49` (7+42). The boxing is not just type-valid, it
+  round-trips.
+- **Byte-inert**: sha256 of numeric / string / object generator output and a
+  non-generator sample are byte-identical to `origin/main` on both `gc` and
+  `standalone` — the new arm only fires for `i64` yields.
+- No regression on generator suites. (`issue-680` and `issue-1169f-7a` each
+  have 3 pre-existing numeric-yield failures — identical fail counts on
+  `origin/main`, untouched by this i64-only change.)
+- Scoped regression test: `tests/issue-2993.test.ts` (5 cases: standalone
+  validation for the closure/HOF and `.next().value` shapes, gc value
+  round-trip, number-generator no-regression).
+
+### Deliberately OUT OF SCOPE (banked, separate concerns)
+
+These are value-semantics gaps, **not** the invalid-wasm CE this issue fixes;
+the acceptance bar explicitly carves them out ("genuine pass/fail of the
+underlying semantics is a separate concern"):
+
+1. **Standalone eager-buffer bigint value round-trip.** In `standalone` the
+   boxed bigint does not read back through the eager buffer (`.next().value` and
+   for-of sum return `0`, not the yielded value). This is the known standalone
+   value-read substrate gap (cf. the `project_standalone_any_string_value_read_substrate`
+   family), pre-existing and independent of the carrier fix. A follow-up should
+   extend the #2864 native carrier to bigint yields (host-free) rather than
+   patching the eager buffer.
+2. **Closure/HOF value threading in gc mode.** The repro's closure-threaded
+   generator (`run(cb)` → `cb(obj)` → for-of) validates but returns `null` in gc
+   mode — the boxed-`any` value does not thread through the closure indirection.
+   Separate from the yield-carrier mismatch; would need the boxed-any generator
+   value to survive the HOF/closure capture path.
+
+Both are genuinely separate substrate work; forcing them into this fix would
+mean reworking the native-carrier bigint path and the closure value-threading —
+larger than the localized carrier mismatch #2993 scopes.

--- a/src/codegen/expressions/misc.ts
+++ b/src/codegen/expressions/misc.ts
@@ -242,6 +242,22 @@ function compileYieldExpression(ctx: CodegenContext, fctx: FunctionContext, expr
     if (pushIdx !== undefined) {
       fctx.body.push({ op: "call", funcIdx: pushIdx });
     }
+  } else if (yieldedType.kind === "i64") {
+    // #2993: a `yield <bigint>` (or native `i64`) lowers the yielded value to a
+    // raw i64, but the generic buffer slot is `__gen_push_ref(externref, externref)`.
+    // Without boxing, the i64 lands in the externref parameter slot and the module
+    // fails WasmGC validation ("expected type externref, found local.get of type i64"
+    // in the generator closure body, e.g. `__closure_0`). Box the i64 → externref via
+    // `coerceType`, which picks `__box_bigint` for a bigint-branded i64 (round-trips as
+    // a JS bigint) and `__box_number` for a native `type i64 = number` value. The value
+    // is already on the stack (with only the buffer operand beneath it), so the coercion
+    // ops apply to it in place before the push call. `coerceType` may add late union
+    // imports (index-shifting), so resolve the `__gen_push_ref` funcIdx AFTER it runs.
+    coerceType(ctx, fctx, yieldedType, { kind: "externref" } as ValType);
+    const pushIdx = ctx.funcMap.get("__gen_push_ref");
+    if (pushIdx !== undefined) {
+      fctx.body.push({ op: "call", funcIdx: pushIdx });
+    }
   } else {
     // externref, ref, ref_null — all pass as externref
     const pushIdx = ctx.funcMap.get("__gen_push_ref");

--- a/tests/issue-2993.test.ts
+++ b/tests/issue-2993.test.ts
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+/**
+ * #2993 — generator-closure lowering: a BigInt (`i64`) yield was written into
+ * the eager-buffer generator's generic `__gen_push_ref(externref, externref)`
+ * slot WITHOUT the i64→externref box, so the module failed WasmGC validation
+ * ("call[1] expected type externref, found local.get of type i64") in the
+ * generator closure body (e.g. `__closure_0` / `__closure_3`) → a
+ * `compile_error` that never reached instantiation.
+ *
+ * Root cause: `compileYieldExpression` (src/codegen/expressions/misc.ts)
+ * dispatched `f64 → __gen_push_f64`, `i32 → __gen_push_i32`, and *everything
+ * else* → `__gen_push_ref`, assuming the value was already reference-shaped.
+ * A `yield <bigint>` lowers to a raw `i64`, which fell into that `else` arm
+ * unboxed. The fix routes `i64` through `coerceType(i64 → externref)`, which
+ * boxes a bigint-branded i64 via `__box_bigint` (round-trips as a JS bigint)
+ * and a native `type i64 = number` via `__box_number`.
+ *
+ * Note: the simple direct `for (const v of g())` bigint case already used the
+ * #2864 native carrier and compiled fine — only the eager-buffer shapes
+ * (`.next().value`, closure/HOF-threaded generators) hit this bug.
+ *
+ * Bars asserted:
+ *   1. The closure/HOF-threaded BigInt-yield repro compiles to VALID Wasm on
+ *      the standalone lane — `WebAssembly.compile` (full module validation)
+ *      succeeds, i.e. no `__closure_N` invalid-wasm CE. (Genuine standalone
+ *      *value* round-trip of a boxed bigint through the eager buffer is a
+ *      separate standalone value-read substrate concern — out of scope here.)
+ *   2. In JS-host (gc) mode the boxed value round-trips correctly, proving the
+ *      coercion is semantically right, not just type-valid.
+ *   3. The non-BigInt (number) generator siblings are unaffected.
+ */
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/** The #2993 repro shape: a BigInt generator threaded through a higher-order closure. */
+const CLOSURE_HOF_BIGINT = `
+function run(cb) {
+  var obj = (function *() { yield 7n; yield 42n; })();
+  return cb(obj);
+}
+export function test() {
+  return run(function(g) {
+    let sum = 0n;
+    for (const v of g) { sum += v; }
+    return Number(sum);
+  });
+}`;
+
+/** The minimal eager-buffer trigger: a BigInt yield read via `.next().value`. */
+const NEXT_VALUE_BIGINT = `
+export function test() {
+  function* g(){ yield 7n; }
+  let it = g();
+  return Number(it.next().value);
+}`;
+
+describe("#2993 BigInt generator-closure i64→externref carrier", () => {
+  it("standalone: closure/HOF-threaded BigInt generator compiles to VALID Wasm (no __closure_N invalid-wasm CE)", async () => {
+    const r = await compile(CLOSURE_HOF_BIGINT, { fileName: "test.ts", target: "standalone" });
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+    // WebAssembly.compile performs full module validation, including the
+    // function-body type check that previously rejected the raw i64 in the
+    // externref `__gen_push_ref` slot. Pre-fix this threw; post-fix it resolves.
+    await expect(WebAssembly.compile(r.binary)).resolves.toBeInstanceOf(WebAssembly.Module);
+  });
+
+  it("standalone: `.next().value` BigInt generator compiles to VALID Wasm", async () => {
+    const r = await compile(NEXT_VALUE_BIGINT, { fileName: "test.ts", target: "standalone" });
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+    await expect(WebAssembly.compile(r.binary)).resolves.toBeInstanceOf(WebAssembly.Module);
+  });
+
+  it("gc: closure/HOF-threaded BigInt generator compiles to VALID Wasm (no CE)", async () => {
+    // The repro shape validates in gc mode too. NOTE: the *value* does not yet
+    // round-trip through the boxed-`any` generator + closure/HOF indirection
+    // (`test()` returns null, not 49) — that is a separate value-threading gap,
+    // NOT the carrier-mismatch CE this issue fixes. The bar here is validation.
+    const r = await compile(CLOSURE_HOF_BIGINT, { fileName: "test.ts", target: "gc" });
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+    await expect(WebAssembly.compile(r.binary)).resolves.toBeInstanceOf(WebAssembly.Module);
+  });
+
+  it("gc: boxed BigInt value round-trips through `.next().value` (7) — proves the box is semantically correct", async () => {
+    const r = await compile(NEXT_VALUE_BIGINT, { fileName: "test.ts", target: "gc" });
+    expect(r.success, r.success ? "" : `compile error: ${r.errors?.[0]?.message}`).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, r.importObject);
+    (r.importObject as { __setExports?: (e: unknown) => void })?.__setExports?.(instance.exports);
+    expect((instance.exports as { test(): number }).test()).toBe(7);
+  });
+
+  it("no regression: number-yield generator siblings still work (gc 49, standalone 49)", async () => {
+    const numberSrc = `
+export function test() {
+  function* g(){ yield 7; yield 42; }
+  let sum = 0;
+  for (const v of g()) sum += v;
+  return sum;
+}`;
+    for (const target of ["gc", "standalone"] as const) {
+      const r = await compile(numberSrc, { fileName: "test.ts", target });
+      expect(r.success, r.success ? "" : `compile error [${target}]: ${r.errors?.[0]?.message}`).toBe(true);
+      const { instance } = await WebAssembly.instantiate(r.binary, r.importObject);
+      (r.importObject as { __setExports?: (e: unknown) => void })?.__setExports?.(instance.exports);
+      expect((instance.exports as { test(): number }).test(), `number generator [${target}]`).toBe(49);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2993 — a BigInt (`i64`) yield in the **legacy eager-buffer** generator path was written into the generic `__gen_push_ref(externref, externref)` slot **unboxed**, so WasmGC validation rejected the module (`call[1] expected type externref, found local.get of type i64`) in the generator closure body (`__closure_N`) → `compile_error`. Pre-existing on `main`; surfaced during #2940/PR #2463 triage (CE→CE, not a regression).

## Root cause

`compileYieldExpression` (`src/codegen/expressions/misc.ts`) dispatched yielded values into the buffer by Wasm value-kind: `f64 → __gen_push_f64`, `i32 → __gen_push_i32`, **everything else → `__gen_push_ref`**. A `yield <bigint>` lowers to a raw bigint-branded `i64` and fell into the `else` arm with no externref boxing.

Only the eager-buffer shapes trip it — `.next().value` and closure/HOF-threaded generators. The simple direct `for (const v of g())` bigint generator already uses the #2864 native carrier and compiled fine.

## Fix

One added `i64` arm that boxes to externref via the existing `coerceType(i64 → externref)` before the push: `__box_bigint` for a bigint-branded i64 (round-trips as a JS bigint), `__box_number` for a native `type i64 = number`. The push-func idx is resolved **after** `coerceType` since that call may add late union imports (index shifting).

## Verification

- Pre-fix: `.next().value` bigint gen + the closure/HOF repro throw the validation CE. Post-fix both compile to **valid Wasm** on the standalone lane.
- Semantic correctness proven in gc mode: `.next().value` → `7`, direct for-of sum → `49`.
- **Byte-inert**: numeric / string / object generator + non-generator output is sha256-identical to `origin/main` on `gc` and `standalone` — the new arm only fires for `i64` yields.
- No regression on generator suites (`issue-680`/`issue-1169f-7a` have 3 pre-existing numeric-yield failures each — identical on `origin/main`).
- Scoped test: `tests/issue-2993.test.ts` (5 cases).

## Out of scope (banked, separate substrate concerns)

Value-semantics gaps, **not** the carrier-mismatch CE this fixes (acceptance bar explicitly carves them out):
1. Standalone eager-buffer bigint value round-trip (returns 0 — known standalone value-read substrate gap; follow-up should extend the #2864 native carrier to bigint).
2. Closure/HOF value threading in gc mode (repro validates but returns null — boxed-any value doesn't thread through the closure indirection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8