### PR TITLE
fix(#2999): fold builtin .constructor to bare-builtin carrier — drop env::Object_get_constructor standalone leak

### DIFF
--- a/plan/issues/2999-standalone-object-get-constructor-leak.md
+++ b/plan/issues/2999-standalone-object-get-constructor-leak.md
@@ -1,0 +1,88 @@
+---
+id: 2999
+title: "Standalone: eliminate env::Object_get_constructor host-import leak — fold builtin .constructor to the bare-builtin carrier"
+status: done
+completed: 2026-07-02
+assignee: ttraenkler/agent-abd6cda44521fc1c9
+sprint: current
+priority: medium
+horizon: s
+feasibility: medium
+origin: plan/log/investigations/2026-07-02-leak-analysis-round5.md
+---
+
+## Problem
+
+Round-5 leak analysis (2026-07-02) ranks `env::Object_get_constructor` as an
+execution-verified GENUINE sole-import leaky lever: **9 official standalone
+passes** carry exactly one `env::` import, `Object_get_constructor`. They are all
+`<Builtin>.prototype.constructor === <Builtin>` shapes (plus instance forms),
+for Set / WeakMap / WeakRef / WeakSet / RegExp / FinalizationRegistry /
+DisposableStack / SuppressedError. These are host-import leaks — the standalone
+binary imports a host getter it should not need.
+
+## Root cause
+
+Reading `.constructor` on any extern-class receiver
+(`compileExternPropertyGet`, `src/codegen/property-access.ts`) walks the extern
+inheritance chain to the `Object` base extern class (`src/codegen/index.ts`
+~L13439 — the only declarer of a `constructor` property, `importPrefix: "Object"`),
+so the getter path emits an `Object_get_constructor` host import.
+
+Confirmed mechanism (fresh probes on run 28605503741 / main): in the standalone
+lane the host import resolves to `undefined` (the `$NativeProto` receiver is an
+opaque WasmGC struct — `recv.constructor` on the host is `undefined`), and a bare
+builtin identifier (`Set`, `WeakMap`, …) compiles to the standalone
+null-externref carrier (builtins have no native constructor-object identity yet).
+So `assert.sameValue(<Builtin>.prototype.constructor, <Builtin>)` passes
+**tautologically** — both sides collapse to the shared nullish carrier. Proof:
+`assert.sameValue(Set.prototype.constructor, Map)` _also_ passes (both nullish),
+i.e. the pass never depended on the host import returning a real value.
+
+## Fix
+
+Static-fold `.constructor` on a builtin receiver to that same bare-builtin
+carrier. In `compileExternPropertyGet`, when `ctx.standalone`,
+`propName === "constructor"`, and the receiver's extern class is a known builtin
+(`BUILTIN_CTOR_NAMES`), compile the receiver for side effects, drop it, and emit
+`ref.null.extern` — no host import.
+
+- Spec-sound: `<Builtin>.prototype.constructor` / `(new <Builtin>()).constructor`
+  IS `%<Builtin>%`, i.e. the value the bare `<Builtin>` identifier denotes, so
+  routing the read to the same carrier as the identifier is correct. When
+  builtins gain real native constructor identity, the bare-identifier resolution
+  and this site update in lockstep.
+- Behaviour-preserving: LHS and RHS remain the identical nullish value that
+  SameValue-compares equal — the (already tautological) pass is unchanged, only
+  the import is gone.
+- Scoped to `BUILTIN_CTOR_NAMES` (bare value provably null) and to
+  `ctx.standalone` — user-`declare class` extern receivers and the gc/host lane
+  keep the real `Object_get_constructor` read (a genuine value there), so there
+  is zero behaviour change off the standalone-builtin path.
+
+## Acceptance criteria
+
+- The 9 listed test262 files still PASS in the standalone lane. ✅ (9/9)
+- `env::Object_get_constructor` is eliminated from those binaries. ✅ (host-free)
+- gc/host lane unchanged — `Object_get_constructor` import retained. ✅ (verified)
+- No regression: the two `Error/prototype/constructor` standalone fails are
+  pre-existing (fail identically without the fold). ✅
+
+## Test Results
+
+- `tests/issue-2999.test.ts` — 8/8 pass (7 host-free builtin `.constructor`
+  shapes + 1 gc/host retains-import guard).
+- All 9 origin test262 files via `runTest262File(..., "standalone")`: **9/9 pass**,
+  host-free (`env::Object_get_constructor` absent).
+
+## Test files (sole-import leak, from run 28605503741)
+
+- test/built-ins/WeakRef/prototype/constructor.js
+- test/built-ins/Set/prototype/constructor/set-prototype-constructor-intrinsic.js
+- test/built-ins/FinalizationRegistry/prototype/constructor.js
+- test/built-ins/WeakSet/prototype/constructor/weakset-prototype-constructor-intrinsic.js
+- test/built-ins/RegExp/S15.10.7_A3_T2.js
+- test/built-ins/RegExp/S15.10.7_A3_T1.js
+- test/built-ins/WeakMap/prototype/constructor.js
+- test/built-ins/DisposableStack/prototype/constructor.js
+- test/built-ins/SuppressedError/prototype/constructor.js

--- a/plan/issues/2999-standalone-object-get-constructor-leak.md
+++ b/plan/issues/2999-standalone-object-get-constructor-leak.md
@@ -9,6 +9,7 @@ priority: medium
 horizon: s
 feasibility: medium
 origin: plan/log/investigations/2026-07-02-leak-analysis-round5.md
+related: [2963]
 ---
 
 ## Problem
@@ -86,3 +87,77 @@ carrier. In `compileExternPropertyGet`, when `ctx.standalone`,
 - test/built-ins/WeakMap/prototype/constructor.js
 - test/built-ins/DisposableStack/prototype/constructor.js
 - test/built-ins/SuppressedError/prototype/constructor.js
+
+## Honest-accounting caveat — these 9 pass via a null≡null tautology, NOT constructor-identity correctness
+
+**Read this before merging.** This PR is a clean **host-import elimination**, not a
+correctness fix — and the two must not be conflated. Documenting the distinction
+explicitly, in the discipline the team established around the #2463 vacuity work.
+
+**What is genuinely fixed:** the `env::Object_get_constructor` host import is gone
+from these 9 standalone binaries. That is real and valid on its own — a standalone
+binary should not import a host getter it does not need.
+
+**What is NOT fixed (and this PR neither claims nor changes it):** real builtin
+constructor / prototype **object identity**. The 9 tests pass because BOTH sides of
+each `assert.sameValue(<Builtin>.prototype.constructor, <Builtin>)` collapse to the
+**same null-ish externref carrier** in standalone mode — the LHS `.constructor`
+read and the RHS bare-builtin identifier are each `ref.null.extern`, so
+`sameValue(null, null)` is trivially `true`. The comparison never exercises a real
+constructor object; it is a **null≡null tautology**. The predecessor's own
+cross-check proves it: `assert.sameValue(Set.prototype.constructor, Map)` —
+comparing against the **wrong** builtin — **also passes**. A genuine
+constructor-identity implementation would make that cross-check FAIL.
+
+**This is "coincidental wrongness", a distinct (and subtler) class than vacuity.**
+The #2463 vacuity problem is *dead code* — a callback body that never executes; an
+inject-throw execution-proof catches it. This is different: the code **does
+execute** (the round-5 inject-throw probe correctly labels
+`Object_get_constructor` **GENUINE**, i.e. non-vacuous), it just returns an
+**incorrect value** (null) that happens to equal another equally-incorrect value
+(null). An execution-proof / inject-throw check would **NOT** flag it — the body
+runs. So "GENUINE" in the round-5 table means "not vacuous", **not** "value-correct".
+
+**The fold is still the right change** — it is behaviour-preserving (LHS and RHS
+remain the identical null carrier the pre-fix path already produced) and removes a
+dead import. When builtins gain real native constructor identity, the
+bare-identifier resolution and this `.constructor` fold site update in lockstep
+(both stop being null), so the fold does not entrench the gap — it tracks it.
+
+**Substrate that actually closes the gap:** #2963 (*Reify builtins as first-class
+values*, with stable per-module identity — "the same builtin reference must yield
+the same object"). Once builtins carry a real reified constructor/prototype object,
+these 9 assertions pass on genuine identity and the cross-check
+(`...constructor === Map`) correctly fails. The round-5 investigation
+(`plan/log/investigations/2026-07-02-leak-analysis-round5.md`, recommendations
+§2 + §3) groups this with the sibling identity-substrate leak tails
+(`__iterator` 9 + `Object_get_constructor` 9 + `Object_set_constructor` 5 +
+`__new_Object` 5 ≈ 28 tests) — the same "no reified builtin
+constructor/prototype/intrinsic identity" root cause. A single consolidated
+issue for that ~28-test tail is not yet filed on `main`; #2963 is the substrate
+that subsumes it.
+
+## Broader-pattern sweep (2026-07-02, follow-up)
+
+Checked whether other currently-passing standalone tests rely on the same
+null≡null coincidence for `.constructor` / builtin-identity comparisons:
+
+- **test262 population:** ~55 `built-ins/**` files combine `.prototype.constructor`
+  with `assert.sameValue`; the 9 fixed here are the **sole-`env::`-import** subset.
+  The rest (TypedArray ctors, GeneratorFunction, Array/Object/Number/String, …)
+  follow the identical `<Builtin>.prototype.constructor === <Builtin>` shape, so
+  any of them that currently pass in standalone pass by the **same** null≡null
+  coincidence — this is a **substrate-wide** property of builtins lacking reified
+  identity, not unique to these 9. It is exactly what #2963 addresses.
+- **The coincidence is bounded, not blanket.** A direct probe of raw `===`
+  comparisons between builtin identifiers in compiled standalone code returned
+  `false` (e.g. `Set === Map`, and even `Set === Set`, evaluate to `0`), i.e. the
+  tautology is **specific to the `assert.sameValue` harness path** where both
+  operands become the null carrier — it is NOT a general "every builtin comparison
+  is true". Critically, because test262 only asserts spec-**true** facts, the
+  coincidence inflates *hollow* passes of otherwise-correct assertions; it does
+  **not** turn any *incorrect* assertion into a false pass.
+- **Conclusion:** the pattern is real and broader than these 9, but it is (a)
+  already tracked by #2963, (b) not created or worsened by this PR (the fold only
+  removes a dead import), and (c) bounded to the sameValue-null path. No new
+  regression risk; no separate issue needed beyond #2963.

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -5941,6 +5941,52 @@ function compileExternPropertyGet(
     if (sizeResult !== undefined) return sizeResult as ValType;
   }
 
+  // (#2999) Standalone `<Builtin>.prototype.constructor` / `<builtin-instance>.constructor`
+  // static fold — drop the `env::Object_get_constructor` host-import leak.
+  //
+  // Reading `.constructor` on any extern-class receiver walks the inheritance
+  // chain to the `Object` base extern class (index.ts ~L13439, the only declarer
+  // of `constructor`), whose `importPrefix` is `Object`, so the getter path below
+  // emits an `Object_get_constructor` host import. Round-5 leak analysis flags
+  // this as 9 execution-verified sole-import standalone passes
+  // (`<Builtin>.prototype.constructor === <Builtin>` for Set/WeakMap/WeakRef/
+  // WeakSet/RegExp/FinalizationRegistry/DisposableStack/SuppressedError, plus
+  // instance forms `(new WeakMap()).constructor` / `/re/.constructor`).
+  //
+  // In standalone mode there is no JS host object to return: the host import
+  // resolves to `undefined`, and a bare builtin identifier (`Set`, `WeakMap`, …)
+  // compiles to the same standalone null-externref carrier (no native
+  // constructor-object identity yet). So the comparisons pass tautologically —
+  // both sides collapse to the shared nullish carrier — and the host import is
+  // pure dead weight. Fold `.constructor` to that SAME bare-builtin carrier
+  // (`ref.null.extern`): behaviour is preserved (LHS and RHS remain the identical
+  // nullish value SameValue-compares equal) and the import is gone.
+  //
+  // Spec soundness: per §20.x every `<Builtin>.prototype.constructor` /
+  // `(new <Builtin>()).constructor` IS `%<Builtin>%`, i.e. the value the bare
+  // `<Builtin>` identifier denotes — so routing the read to the same carrier as
+  // the identifier is correct, not a shortcut. When builtins gain real native
+  // constructor identity, the bare-identifier resolution and this site update in
+  // lockstep. Standalone-only: gc/host keeps the real `Object_get_constructor`
+  // read (a genuine value there), so no behaviour change off the standalone lane.
+  //
+  // Scoped to `BUILTIN_CTOR_NAMES` receivers (the extern class name is the
+  // builtin, e.g. `Set.prototype`→Set, `/re/`→RegExp, `new WeakMap()`→WeakMap):
+  // for those the bare identifier is guaranteed to compile to the SAME null
+  // carrier, so identity is preserved. User-`declare class` extern receivers are
+  // deliberately left on the host path — their bare value may not be nullish, so
+  // folding could mismatch.
+  if (ctx.standalone && propName === "constructor" && BUILTIN_CTOR_NAMES.has(className)) {
+    // Compile the receiver for its side effects, then discard it (mirrors the
+    // user-class `.constructor` path ~L5310, which drops only a real value).
+    const objResult = compileExpression(ctx, fctx, expr.expression);
+    if (objResult) {
+      fctx.body.push({ op: "drop" });
+    }
+    fctx.body.push({ op: "ref.null.extern" });
+    return { kind: "externref" };
+  }
+
   // Walk inheritance chain to find the class that declares the property
   const resolvedInfo = findExternInfoForMember(ctx, className, propName, "property");
   const propOwner = resolvedInfo ?? ctx.externClasses.get(className);

--- a/tests/issue-2999.test.ts
+++ b/tests/issue-2999.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2999 — eliminate the `env::Object_get_constructor` host-import leak.
+ *
+ * Round-5 leak analysis flagged 9 execution-verified standalone passes whose
+ * sole `env::` import was `Object_get_constructor`. They are all
+ * `<Builtin>.prototype.constructor === <Builtin>` (Set / WeakMap / WeakRef /
+ * WeakSet / RegExp / FinalizationRegistry / DisposableStack / SuppressedError)
+ * plus instance forms `(new WeakMap()).constructor` / `/re/.constructor`.
+ *
+ * Reading `.constructor` on a builtin extern-class receiver walks the extern
+ * inheritance chain to the `Object` base class (its only declarer) and emits an
+ * `Object_get_constructor` host import. In standalone mode that host read
+ * resolves to `undefined` and a bare builtin identifier compiles to the same
+ * null-externref carrier (builtins have no native constructor-object identity
+ * yet), so the comparisons already pass tautologically — the import is pure dead
+ * weight. The compiler now folds `.constructor` on a builtin receiver to that
+ * same bare-builtin carrier (`ref.null.extern`), host-free. The gc/host lane is
+ * untouched (the fold is `ctx.standalone`-gated) and keeps the real import.
+ */
+
+const HOST_IMPORT = "env::Object_get_constructor";
+
+async function standaloneImports(src: string): Promise<string[]> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.success ? "" : r.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  return r.imports.map((i) => `${i.module}::${i.name}`);
+}
+
+async function gcImports(src: string): Promise<string[]> {
+  const r = await compile(src, { skipSemanticDiagnostics: true });
+  expect(r.success, r.success ? "" : r.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  return r.imports.map((i) => `${i.module}::${i.name}`);
+}
+
+async function runsStandalone(src: string): Promise<void> {
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.success ? "" : r.errors.map((e) => `L${e.line}: ${e.message}`).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  // The test export must exist and execute without trapping.
+  (instance.exports as Record<string, () => unknown>).test?.();
+}
+
+describe("#2999 builtin .constructor host-import fold (standalone)", () => {
+  const shapes: Array<[string, string]> = [
+    ["Set.prototype.constructor", "const c: any = Set.prototype.constructor; return c ? 0 : 0;"],
+    ["WeakMap.prototype.constructor", "const c: any = WeakMap.prototype.constructor; return c ? 0 : 0;"],
+    ["WeakRef.prototype.constructor", "const c: any = WeakRef.prototype.constructor; return c ? 0 : 0;"],
+    ["WeakSet.prototype.constructor", "const c: any = WeakSet.prototype.constructor; return c ? 0 : 0;"],
+    ["RegExp.prototype.constructor", "const c: any = RegExp.prototype.constructor; return c ? 0 : 0;"],
+    ["(new WeakMap()).constructor", "const c: any = (new WeakMap()).constructor; return c ? 0 : 0;"],
+    ["regexp literal .constructor", "const re = /[^a]*/; const c: any = re.constructor; return c ? 0 : 0;"],
+  ];
+
+  for (const [name, body] of shapes) {
+    it(`drops ${HOST_IMPORT} for ${name}`, async () => {
+      const src = `export function test(): number { ${body} }`;
+      const imports = await standaloneImports(src);
+      expect(imports, `leaked ${HOST_IMPORT}`).not.toContain(HOST_IMPORT);
+      await runsStandalone(src);
+    });
+  }
+
+  it("keeps the real Object_get_constructor read in gc/host mode (fold is standalone-only)", async () => {
+    // The fold is gated on ctx.standalone. In the default gc/host lane
+    // `Object_get_constructor` returns a genuine host value, so the import MUST
+    // remain — proving the change did not broaden into the host lane.
+    const src = `export function test(): number { const c: any = Set.prototype.constructor; return c ? 0 : 0; }`;
+    const imports = await gcImports(src);
+    expect(imports, "gc/host lane must keep the real constructor read").toContain(HOST_IMPORT);
+  });
+});


### PR DESCRIPTION
## Summary

Eliminates the `env::Object_get_constructor` host-import leak flagged by the
2026-07-02 round-5 leak analysis (**9 execution-verified sole-import standalone
passes**).

## Root cause

Reading `.constructor` on any extern-class receiver (`compileExternPropertyGet`,
`src/codegen/property-access.ts`) walks the extern inheritance chain to the
`Object` base extern class (`src/codegen/index.ts` ~L13439 — the only declarer of
a `constructor` property, `importPrefix: "Object"`), so the getter path emits an
`Object_get_constructor` host import.

Confirmed mechanism (fresh probes on run 28605503741 / main): in the standalone
lane the host import resolves to `undefined` (the `$NativeProto` receiver is an
opaque WasmGC struct), and a bare builtin identifier (`Set`, `WeakMap`, …)
compiles to the standalone null-externref carrier (builtins have no native
constructor-object identity yet). So `assert.sameValue(<Builtin>.prototype.constructor, <Builtin>)`
passes **tautologically** — both sides collapse to the shared nullish carrier.
Proof: `assert.sameValue(Set.prototype.constructor, Map)` *also* passes, i.e. the
pass never depended on the host import returning a real value.

## Fix

Static-fold `.constructor` on a builtin receiver to that same bare-builtin
carrier. When `ctx.standalone`, `propName === "constructor"`, and the receiver's
extern class is a known builtin (`BUILTIN_CTOR_NAMES`), compile the receiver for
side effects, drop it, emit `ref.null.extern` — no host import.

- **Spec-sound**: `<Builtin>.prototype.constructor` / `(new <Builtin>()).constructor`
  IS `%<Builtin>%`, the value the bare `<Builtin>` identifier denotes — routing
  the read to the same carrier as the identifier is correct, not a shortcut.
- **Behaviour-preserving**: LHS and RHS remain the identical nullish value that
  SameValue-compares equal — the (already tautological) pass is unchanged, only
  the import is gone.
- **Narrowly scoped**: `BUILTIN_CTOR_NAMES` receivers only (bare value provably
  null) and `ctx.standalone` only. User-`declare class` extern receivers and the
  gc/host lane keep the real `Object_get_constructor` read (a genuine value
  there), so zero behaviour change off the standalone-builtin path.

## Results

- 9/9 origin test262 files pass in the standalone lane, host-free
  (`env::Object_get_constructor` absent).
- `tests/issue-2999.test.ts` — 8/8 (7 host-free builtin `.constructor` shapes +
  1 gc/host retains-import guard proving the standalone-only scoping).
- gc/host lane verified byte-inert (fold branch unreachable when `!ctx.standalone`;
  import list unchanged).
- No regression: the two `Error/prototype/constructor` standalone fails are
  pre-existing (fail identically without the fold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8