### PR TITLE
fix(#2964): for-in walks the prototype chain (inherited enumerable keys)

### DIFF
--- a/plan/issues/2958-standalone-unhandled-rejection-tracking.md
+++ b/plan/issues/2958-standalone-unhandled-rejection-tracking.md
@@ -51,3 +51,22 @@ Mirror Node's default behavior at the natural exit points:
 - Late attach within the same drain (reject → microtask → attach) does NOT
   report (matches JS semantics for same-turn handling).
 - No behavior change in host mode; host-free floor net-positive or neutral.
+
+## Deferral note (2026-07-02)
+
+Deferred after an initial measure-first sizing pass. Two reasons:
+
+1. **Mis-sized S → M.** The frontmatter `horizon: s` understates the work.
+   Unhandled-rejection tracking requires a `$Promise` struct-layout change
+   (an `unhandled` flag + a list-link field for the intrusive
+   `$rejectedUnhandled` list), plus new logic at the settle/attach sites and
+   at both exit points (`__drain_microtasks` empty-ring and `__run_event_loop`
+   termination). That is an M, not an S.
+
+2. **Contended core file.** `src/codegen/async-scheduler.ts` is under active
+   edit by 6+ concurrent branches doing Promise-carrier work. Landing a
+   struct-layout change here now would collide heavily.
+
+**Recommendation:** sequence this after the carrier work settles — specifically
+after #2867 / #2959 land — then re-scope as `horizon: m` and reclaim. Claim was
+released on the `issue-assignments` ref; `status` left `ready`.

--- a/plan/issues/2964-forin-prototype-chain-integer-key-order.md
+++ b/plan/issues/2964-forin-prototype-chain-integer-key-order.md
@@ -1,7 +1,8 @@
 ---
 id: 2964
 title: "for-in on $Object: prototype-chain enumeration + integer-key-ascending ordering"
-status: ready
+status: in-progress
+assignee: ttraenkler/opus-2964
 sprint: current
 created: 2026-07-02
 updated: 2026-07-02

--- a/plan/issues/2964-forin-prototype-chain-integer-key-order.md
+++ b/plan/issues/2964-forin-prototype-chain-integer-key-order.md
@@ -1,8 +1,9 @@
 ---
 id: 2964
 title: "for-in on $Object: prototype-chain enumeration + integer-key-ascending ordering"
-status: in-progress
+status: done
 assignee: ttraenkler/opus-2964
+completed: 2026-07-02
 sprint: current
 created: 2026-07-02
 updated: 2026-07-02
@@ -56,3 +57,38 @@ spec gaps:
 - `{ b:1, 2:2, a:3, 0:4 }` enumerates `0,2,b,a`.
 - test262 for-in cluster + language/statements standalone bucket
   net-positive; host mode unchanged where it uses the host path.
+
+## Implementation (2026-07-02)
+
+**Measure-first finding:** gap #2 (integer-key ascending) was **already
+correct** on main — the standalone for-in path routes through `__object_keys`,
+which delegates ordering to `__obj_ordered` (#1837, OrdinaryOwnPropertyKeys:
+integer-index ascending then insertion order). A probe on current main returned
+`02ba` for `{ b:1, 2:2, a:3, 0:4 }`. The only real gap was #1 — `__object_keys`
+is OWN-only, so inherited enumerable keys were never visited (`for (k in
+Object.create({a:1}))` yielded nothing from the proto).
+
+**Fix** (`src/codegen/object-runtime.ts`, `src/codegen/statements/loops.ts`):
+- New native `__object_keys_forin(externref) -> externref` ($ObjVec of keys).
+  Per level (receiver → `$proto` → …, until null): yield the enumerable own
+  keys (`__obj_ordered`) not already in a `seen` set, then add ALL own keys
+  incl. non-enumerable (`__obj_ordered_all`) to `seen` so a closer-level own
+  property shadows the same name deeper in the chain. `seen` is a scratch empty
+  `$Object` (null `$proto`) used as a membership table via
+  `__extern_has`/`__extern_set` — reusing the property map's exact key
+  hashing/equality (no native-string representation mismatch).
+- Standalone/WASI for-in over a dynamic receiver now routes `keysIdx` to
+  `__object_keys_forin` instead of `__object_keys`. `Object.keys` still uses the
+  OWN-only `__object_keys`. Host mode is untouched (uses the `__for_in_*` host
+  imports, which proto-walk in JS).
+
+## Test Results
+
+`tests/issue-2964.test.ts` — 10/10 pass (standalone): proto-walk, both
+acceptance examples (`ba`, `02ba`), own-shadows-proto dedup, non-enumerable
+proto skip, non-enumerable-own shadow, count over a 2-level chain, Object.keys
+own-only, empty object. Existing `issue-2572-standalone-forin` +
+`issue-forin` (12 tests) still green. `tsc --noEmit` clean. **Host-mode binary
+is byte-identical** base-vs-branch (sha256 `2bb8e092805430ae`, 2081 b) — the
+new native is DCE'd when the standalone path is not taken, so the host lane is
+fully inert.

--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -3771,6 +3771,220 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     );
   }
 
+  // ── __object_keys_forin(externref obj) -> externref ──────────────────────
+  //
+  // #2964 — for-in enumeration over a dynamic `$Object`, INCLUDING inherited
+  // enumerable string keys from the prototype chain (§14.7.5.9
+  // EnumerateObjectProperties). `__object_keys` above is OWN-only (Object.keys
+  // semantics); for-in must additionally walk `$proto` links and, at each
+  // level, yield the enumerable own keys that are NOT shadowed by a
+  // closer-level own property (enumerable OR non-enumerable — a non-enumerable
+  // own property still shadows an inherited same-named key).
+  //
+  // Algorithm (per level, receiver → proto → …, until $proto is null):
+  //   1. enumerable own keys (`__obj_ordered`, OrdinaryOwnPropertyKeys order —
+  //      integer-index ascending then insertion order, #1837): yield each key
+  //      not already in the `seen` set.
+  //   2. ALL own keys (`__obj_ordered_all`, incl. non-enumerable): add each to
+  //      `seen` so it shadows the same name at lower (proto) levels.
+  // The `seen` set is a fresh empty `$Object` (null $proto) used purely as a
+  // membership table via `__extern_has`/`__extern_set` — this reuses the exact
+  // key hashing + equality the property map uses, so there is no native-string
+  // representation mismatch. `__extern_has` proto-walks, but `seen`'s $proto is
+  // null so it degenerates to an own-property check.
+  //
+  // params: 0=obj(externref)
+  // locals: 1=any(anyref) 2=cur(ref null $Object) 3=arr(ref null $PropMap)
+  //         4=cap(i32) 5=i(i32) 6=e(ref null $PropEntry) 7=vec(externref result)
+  //         8=seen(externref scratch $Object) 9=keyExt(externref)
+  {
+    const newPlainObjectIdx = ctx.funcMap.get("__new_plain_object")!;
+    const externHasIdx = ctx.funcMap.get("__extern_has")!;
+    const externSetIdx = ctx.funcMap.get("__extern_set")!;
+    const body: Instr[] = [
+      // vec = __objvec_new() ; seen = __new_plain_object()
+      { op: "call", funcIdx: objVecNewIdx },
+      { op: "local.set", index: 7 },
+      { op: "call", funcIdx: newPlainObjectIdx },
+      { op: "local.set", index: 8 },
+      // any = any.convert_extern(obj); if !$Object → return empty vec
+      { op: "local.get", index: 0 },
+      { op: "any.convert_extern" },
+      { op: "local.tee", index: 1 },
+      { op: "ref.test", typeIdx: objectTypeIdx },
+      { op: "i32.eqz" },
+      {
+        op: "if",
+        blockType: { kind: "empty" },
+        then: [{ op: "local.get", index: 7 }, { op: "return" }],
+      },
+      // cur = cast<$Object>(any)
+      { op: "local.get", index: 1 },
+      { op: "ref.cast", typeIdx: objectTypeIdx },
+      { op: "local.set", index: 2 },
+      {
+        op: "block",
+        blockType: { kind: "empty" },
+        body: [
+          {
+            op: "loop",
+            blockType: { kind: "empty" },
+            body: [
+              // if cur == null break out of levels
+              { op: "local.get", index: 2 },
+              { op: "ref.is_null" },
+              { op: "br_if", depth: 1 },
+              // ---- yield enumerable own keys not already seen ----
+              // arr = __obj_ordered(cur) ; cap = arr.len ; i = 0
+              { op: "local.get", index: 2 },
+              { op: "ref.as_non_null" },
+              { op: "call", funcIdx: objOrderedIdx },
+              { op: "local.tee", index: 3 },
+              { op: "array.len" },
+              { op: "local.set", index: 4 },
+              { op: "i32.const", value: 0 },
+              { op: "local.set", index: 5 },
+              {
+                op: "block",
+                blockType: { kind: "empty" },
+                body: [
+                  {
+                    op: "loop",
+                    blockType: { kind: "empty" },
+                    body: [
+                      // if i >= cap break
+                      { op: "local.get", index: 5 },
+                      { op: "local.get", index: 4 },
+                      { op: "i32.ge_s" },
+                      { op: "br_if", depth: 1 },
+                      // e = arr[i] ; compacted — stop at first null
+                      { op: "local.get", index: 3 },
+                      { op: "ref.as_non_null" },
+                      { op: "local.get", index: 5 },
+                      { op: "array.get", typeIdx: propMapTypeIdx },
+                      { op: "local.tee", index: 6 },
+                      { op: "ref.is_null" },
+                      { op: "br_if", depth: 1 },
+                      // keyExt = extern.convert_any(e.key)
+                      { op: "local.get", index: 6 },
+                      { op: "ref.as_non_null" },
+                      { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 0 },
+                      { op: "extern.convert_any" },
+                      { op: "local.set", index: 9 },
+                      // if __extern_has(seen, keyExt) == 0 → __objvec_push(vec, keyExt)
+                      { op: "local.get", index: 8 },
+                      { op: "local.get", index: 9 },
+                      { op: "call", funcIdx: externHasIdx },
+                      { op: "i32.eqz" },
+                      {
+                        op: "if",
+                        blockType: { kind: "empty" },
+                        then: [
+                          { op: "local.get", index: 7 },
+                          { op: "local.get", index: 9 },
+                          { op: "call", funcIdx: objVecPushIdx },
+                        ],
+                      },
+                      // i++ ; loop
+                      { op: "local.get", index: 5 },
+                      { op: "i32.const", value: 1 },
+                      { op: "i32.add" },
+                      { op: "local.set", index: 5 },
+                      { op: "br", depth: 0 },
+                    ],
+                  },
+                ],
+              },
+              // ---- mark ALL own keys (incl. non-enumerable) into `seen` ----
+              // arr = __obj_ordered_all(cur) ; cap = arr.len ; i = 0
+              { op: "local.get", index: 2 },
+              { op: "ref.as_non_null" },
+              { op: "call", funcIdx: objOrderedAllIdx },
+              { op: "local.tee", index: 3 },
+              { op: "array.len" },
+              { op: "local.set", index: 4 },
+              { op: "i32.const", value: 0 },
+              { op: "local.set", index: 5 },
+              {
+                op: "block",
+                blockType: { kind: "empty" },
+                body: [
+                  {
+                    op: "loop",
+                    blockType: { kind: "empty" },
+                    body: [
+                      { op: "local.get", index: 5 },
+                      { op: "local.get", index: 4 },
+                      { op: "i32.ge_s" },
+                      { op: "br_if", depth: 1 },
+                      { op: "local.get", index: 3 },
+                      { op: "ref.as_non_null" },
+                      { op: "local.get", index: 5 },
+                      { op: "array.get", typeIdx: propMapTypeIdx },
+                      { op: "local.tee", index: 6 },
+                      { op: "ref.is_null" },
+                      { op: "br_if", depth: 1 },
+                      { op: "local.get", index: 6 },
+                      { op: "ref.as_non_null" },
+                      { op: "struct.get", typeIdx: propEntryTypeIdx, fieldIdx: 0 },
+                      { op: "extern.convert_any" },
+                      { op: "local.set", index: 9 },
+                      // if !__extern_has(seen, keyExt) → __extern_set(seen, keyExt, keyExt)
+                      { op: "local.get", index: 8 },
+                      { op: "local.get", index: 9 },
+                      { op: "call", funcIdx: externHasIdx },
+                      { op: "i32.eqz" },
+                      {
+                        op: "if",
+                        blockType: { kind: "empty" },
+                        then: [
+                          { op: "local.get", index: 8 },
+                          { op: "local.get", index: 9 },
+                          { op: "local.get", index: 9 },
+                          { op: "call", funcIdx: externSetIdx },
+                        ],
+                      },
+                      { op: "local.get", index: 5 },
+                      { op: "i32.const", value: 1 },
+                      { op: "i32.add" },
+                      { op: "local.set", index: 5 },
+                      { op: "br", depth: 0 },
+                    ],
+                  },
+                ],
+              },
+              // cur = cur.$proto ; loop
+              { op: "local.get", index: 2 },
+              { op: "ref.as_non_null" },
+              { op: "struct.get", typeIdx: objectTypeIdx, fieldIdx: 0 },
+              { op: "local.set", index: 2 },
+              { op: "br", depth: 0 },
+            ],
+          },
+        ],
+      },
+      // return vec
+      { op: "local.get", index: 7 },
+    ];
+    registerNative(
+      "__object_keys_forin",
+      [{ kind: "externref" }],
+      [{ kind: "externref" }],
+      [
+        { name: "any", type: { kind: "anyref" } },
+        { name: "cur", type: objRefNull },
+        { name: "arr", type: propMapRef },
+        { name: "cap", type: { kind: "i32" } },
+        { name: "i", type: { kind: "i32" } },
+        { name: "e", type: entryRefNull },
+        { name: "vec", type: { kind: "externref" } },
+        { name: "seen", type: { kind: "externref" } },
+        { name: "keyExt", type: { kind: "externref" } },
+      ],
+      body,
+    );
+  }
+
   // ── __extern_length(externref v) -> f64 ──────────────────────────────────
   //
   // Standalone numeric "length". Recognises a wrapped $ObjVec (enumeration

--- a/src/codegen/statements/loops.ts
+++ b/src/codegen/statements/loops.ts
@@ -5915,7 +5915,13 @@ export function compileForInStatement(ctx: CodegenContext, fctx: FunctionContext
       recvWasmType.kind === "externref" || recvWasmType.kind === "anyref" || recvWasmType.kind === "ref_extern";
     if (isDynamicReceiver) {
       ensureObjectRuntime(ctx);
-      keysIdx = ctx.funcMap.get("__object_keys");
+      // #2964 — for-in must enumerate inherited enumerable keys too, so route
+      // through `__object_keys_forin` (own ordered keys per level + `$proto`
+      // walk with shadow-skip), NOT the OWN-only `__object_keys` (which powers
+      // Object.keys). Same `$ObjVec` return shape, so the loop scaffolding and
+      // the `__extern_length`/`__extern_get_idx`/`__extern_has` accessors below
+      // are unchanged.
+      keysIdx = ctx.funcMap.get("__object_keys_forin");
       lenIdx = ctx.funcMap.get("__extern_length");
       getIdx = ctx.funcMap.get("__extern_get_idx");
       hasIdx = ctx.funcMap.get("__extern_has");

--- a/tests/issue-2964.test.ts
+++ b/tests/issue-2964.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+// #2964 — for-in over a dynamic `$Object` must enumerate INHERITED enumerable
+// string keys from the prototype chain (§14.7.5.9 EnumerateObjectProperties),
+// not just own keys. Before this fix the standalone for-in path routed through
+// `__object_keys` (OWN-only, Object.keys semantics), so inherited enumerable
+// keys were never visited. This adds `__object_keys_forin`: per-level ordered
+// own keys (OrdinaryOwnPropertyKeys — integer-index ascending then insertion
+// order, #1837) followed by a `$proto` walk with shadow-skip (a closer-level
+// own property — enumerable OR non-enumerable — shadows the same name deeper in
+// the chain). Object.keys stays OWN-only.
+//
+// Standalone target so the assertions run on the native object runtime
+// (`__object_keys_forin` + `__obj_ordered`/`__obj_ordered_all`), not the JS
+// host `__for_in_*` imports. `mk()` yields genuine dynamic `$Object` receivers.
+//
+// Native strings do not marshal back across the wasm boundary as JS strings, so
+// each test concatenates the enumerated keys and does the equality check INSIDE
+// wasm, returning a discriminating number (1 = expected order).
+async function runStandalone(body: string): Promise<unknown> {
+  const src = `function mk(): any { return {}; }\n${body}`;
+  const r = await compile(src, { fileName: "test.ts", target: "standalone" });
+  if (!r.success) {
+    throw new Error(`Compile failed:\n${r.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`);
+  }
+  expect(WebAssembly.validate(r.binary)).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => unknown }).test();
+}
+
+describe("#2964 — for-in prototype-chain enumeration + integer-key ordering", () => {
+  it("visits own enumerable keys then inherited enumerable keys", async () => {
+    // own `b` first, then proto `a` — result "ba"; "b" alone = own-only bug.
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const proto: any = mk(); proto.a = 1;
+          const o: any = Object.create(proto);
+          o.b = 2;
+          let s = ""; for (const k in o) { s += k; }
+          return s === "ba" ? 1 : (s === "b" ? 2 : 9);
+        }`),
+    ).toBe(1);
+  });
+
+  it("acceptance example 1: Object.create(proto, { b: enumerable }) visits b then a", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const proto: any = mk(); proto.a = 1;
+          const o: any = Object.create(proto, { b: { value: 2, enumerable: true } });
+          let s = ""; for (const k in o) { s += k; }
+          return s === "ba" ? 1 : 9;
+        }`),
+    ).toBe(1);
+  });
+
+  it("acceptance example 2: integer keys ascending then string keys in insertion order (object literal)", async () => {
+    // { b:1, 2:2, a:3, 0:4 } enumerates 0,2,b,a
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const o: any = { b: 1, 2: 2, a: 3, 0: 4 };
+          let s = ""; for (const k in o) { s += k; }
+          return s === "02ba" ? 1 : 9;
+        }`),
+    ).toBe(1);
+  });
+
+  it("integer-key ascending order also holds for dynamically-built objects", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const o: any = mk();
+          o.b = 1; o[2] = 2; o.a = 3; o[0] = 4;
+          let s = ""; for (const k in o) { s += k; }
+          return s === "02ba" ? 1 : 9;
+        }`),
+    ).toBe(1);
+  });
+
+  it("an own key shadows a same-named enumerable prototype key (yielded once, at own position)", async () => {
+    // receiver: b, a ; proto: b, c → b(own), a(own), c(proto). b not duplicated.
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const proto: any = mk(); proto.b = 1; proto.c = 2;
+          const o: any = Object.create(proto);
+          o.b = 3; o.a = 4;
+          let s = ""; for (const k in o) { s += k; }
+          return s === "bac" ? 1 : (s === "babc" ? 2 : 9);
+        }`),
+    ).toBe(1);
+  });
+
+  it("non-enumerable prototype keys are skipped", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const proto: any = mk();
+          Object.defineProperty(proto, "hidden", { value: 1, enumerable: false });
+          proto.vis = 2;
+          const o: any = Object.create(proto);
+          o.own = 3;
+          let s = ""; for (const k in o) { s += k; }
+          return s === "ownvis" ? 1 : (s === "ownvishidden" ? 2 : 9);
+        }`),
+    ).toBe(1);
+  });
+
+  it("a non-enumerable OWN property shadows an enumerable prototype key (neither is visited)", async () => {
+    // own `x` is non-enumerable → not yielded, but it shadows proto `x` too.
+    expect(
+      await runStandalone(`
+        function mkChild(p: any): any { return Object.create(p); }
+        export function test(): number {
+          const proto: any = mk(); proto.x = 1; proto.y = 2;
+          const o: any = mkChild(proto);
+          Object.defineProperty(o, "x", { value: 9, enumerable: false });
+          let s = ""; for (const k in o) { s += k; }
+          return s === "y" ? 1 : (s === "yx" ? 2 : (s === "xy" ? 3 : 9));
+        }`),
+    ).toBe(1);
+  });
+
+  it("counts every visited key across a two-level chain", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const proto: any = mk(); proto.a = 1;
+          const o: any = Object.create(proto);
+          o.b = 2;
+          let n = 0; for (const k in o) { n++; }
+          return n;
+        }`),
+    ).toBe(2);
+  });
+
+  it("Object.keys stays OWN-only (no prototype-chain leakage)", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const proto: any = mk(); proto.a = 1;
+          const o: any = Object.create(proto);
+          o.b = 2; o.c = 3;
+          const ks: any = Object.keys(o);
+          let s = ""; for (let i = 0; i < ks.length; i++) { s += ks[i]; }
+          return s === "bc" ? 1 : (s === "bca" ? 2 : 9);
+        }`),
+    ).toBe(1);
+  });
+
+  it("empty object with a plain-object prototype yields nothing", async () => {
+    expect(
+      await runStandalone(`
+        export function test(): number {
+          const o: any = mk();
+          let n = 0; for (const k in o) { n++; }
+          return n;
+        }`),
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## #2964 — for-in enumerates own keys only, in pure insertion order

Standalone for-in over a dynamic `\$Object` enumerated **own** keys only (it
routed through `__object_keys`, which is Object.keys semantics), so inherited
enumerable prototype keys were never visited.

### Measure-first finding
Gap #2 (integer-key ascending order) was **already correct** on main —
`__object_keys` delegates ordering to `__obj_ordered` (#1837,
OrdinaryOwnPropertyKeys: integer-index ascending then insertion order). A probe
on current main returned `02ba` for `{ b:1, 2:2, a:3, 0:4 }`. The only real gap
was the missing prototype-chain walk.

### Fix
- **New native `__object_keys_forin`** (`src/codegen/object-runtime.ts`): per
  level (receiver → `\$proto` → …, until null), yield the enumerable own keys
  (`__obj_ordered`) not already in a `seen` set, then add ALL own keys incl.
  non-enumerable (`__obj_ordered_all`) to `seen` so a closer-level own property
  (enumerable OR not) shadows the same name deeper in the chain. `seen` is a
  scratch empty `\$Object` (null `\$proto`) used as a membership table via
  `__extern_has`/`__extern_set`, reusing the property map's exact key
  hashing/equality (no native-string representation mismatch).
- **Route** the standalone/WASI dynamic-receiver for-in `keysIdx` to
  `__object_keys_forin` (`src/codegen/statements/loops.ts`). `Object.keys` stays
  OWN-only. Host mode untouched (it uses the `__for_in_*` host imports, which
  proto-walk in JS).

### Acceptance criteria — met
- `for (k in Object.create({a:1}, {b:{value:2,enumerable:true}}))` → visits `b`
  then `a`; shadowed + non-enumerable proto keys skipped. ✅
- `{ b:1, 2:2, a:3, 0:4 }` → enumerates `0,2,b,a`. ✅

### Tests
`tests/issue-2964.test.ts` — 10/10 pass (standalone). Existing
`issue-2572-standalone-forin` + `issue-forin` (12 tests) still green. `tsc
--noEmit` clean. **Host-mode binary byte-identical** base-vs-branch (sha256
`2bb8e092805430ae`, 2081 b) — the new native is DCE'd when the standalone path
is not taken, so the host lane is fully inert.

Also documents the deferral of #2958 (mis-sized S→M, contends with active
async-scheduler carrier branches) as a separate docs commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)