### PR TITLE
refactor(#1916) S3b batch 4: flip native-regex to stable func handles

### DIFF
--- a/plan/issues/1916-symbolic-function-references-codegen.md
+++ b/plan/issues/1916-symbolic-function-references-codegen.md
@@ -2,7 +2,7 @@
 id: 1916
 title: "Symbolic function references in WasmGC codegen — retire the late-import index-shift machinery"
 status: in-progress
-assignee: ttraenkler/dev-1916f
+assignee: ttraenkler/dev-1916o
 pipeline_unblocked: 1927
 sprint: current
 model: fable
@@ -293,6 +293,20 @@ is never a moment where one value means two functions.
     green. (The 3 `issue-1599` refusal failures are pre-existing on
     clean main — stale expectations after a recent JSON change; flagged
     to the lead, not this migration's doing.)
+  - **S3b batch 4 — native-regex (dev-1916o, handoff from dev-1916f).**
+    `native-regex.ts`: all 10 helper producers (`__regex_class_match` +
+    the exec/match/replace/split/test family) flipped from the inline
+    `numImportFuncs + mod.functions.length` mint to `mintDefinedFunc` /
+    `pushDefinedFunc`. All 10 are the simple mint→push shape — no
+    `funcIdx + k` sibling derivation, and (verified by push-order) no
+    intervening push between any mint and its push, so the resolved
+    index equals the live-regime index by construction. Proof: corpus
+    byte-IDENTICAL incl. `regex.ts::standalone` (65908 B, native-regex
+    helpers emitted); #1916/#1677/#1809/#2191/#2193 + regex functional
+    suites (682/1539/2588) green. (The 1 `issue-1539` "refuses dynamic
+    `new RegExp(var)`" failure is pre-existing on clean origin/main —
+    stale refusal expectation after a recent RegExp change; verified via
+    file-revert control, not this flip's doing.)
   - Batch discipline (for the next executor): flip whole FILES (a
     producer family), never partial files; `nextFuncIdx`-style local
     helpers redefine in place; multi-mint sibling derivations

--- a/src/codegen/native-regex.ts
+++ b/src/codegen/native-regex.ts
@@ -21,6 +21,7 @@ import { ensureLateImport } from "./expressions/late-imports.js";
 import { emitWasiErrorConstructor } from "./registry/error-types.js";
 import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
 import { addFuncType, getOrRegisterArrayType, getOrRegisterVecType } from "./registry/types.js";
+import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3) stable-regime minting
 import { stringConstantExternrefInstrs } from "./native-strings.js";
 import { ReOp } from "./regex/bytecode.js";
 import { REGEX_STEP_CAP } from "./regex/vm.js";
@@ -113,7 +114,7 @@ function emitClassMatch(ctx: CodegenContext): number {
   const i32Arr = regexI32ArrayType(ctx);
   const i32ArrRef: ValType = { kind: "ref", typeIdx: i32Arr };
   const typeIdx = addFuncType(ctx, [i32ArrRef, { kind: "i32" }, { kind: "i32" }, { kind: "i32" }], [{ kind: "i32" }]);
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const funcIdx = mintDefinedFunc(ctx);
   ctx.nativeRegexHelpers.set("__regex_class_match", funcIdx);
 
   // params: table(0), offset(1), c(2), negated(3)
@@ -209,7 +210,7 @@ function emitClassMatch(ctx: CodegenContext): number {
     },
   ];
 
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, funcIdx, {
     name: "__regex_class_match",
     typeIdx,
     locals: [
@@ -281,7 +282,7 @@ export function ensureRegexRun(ctx: CodegenContext): number {
     ],
     [{ kind: "i32" }],
   );
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const funcIdx = mintDefinedFunc(ctx);
   ctx.nativeRegexHelpers.set("__regex_run", funcIdx);
 
   // params
@@ -1332,7 +1333,7 @@ export function ensureRegexRun(ctx: CodegenContext): number {
     body,
     exported: false,
   };
-  ctx.mod.functions.push(fn);
+  pushDefinedFunc(ctx, funcIdx, fn);
   return funcIdx;
 }
 
@@ -1370,7 +1371,7 @@ export function ensureRegexSearch(ctx: CodegenContext): number {
     ],
     [{ kind: "i32" }],
   );
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const funcIdx = mintDefinedFunc(ctx);
   ctx.nativeRegexHelpers.set("__regex_search", funcIdx);
 
   const PROG = 0,
@@ -1448,7 +1449,7 @@ export function ensureRegexSearch(ctx: CodegenContext): number {
     { op: "i32.const", value: 0 },
   ];
 
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, funcIdx, {
     name: "__regex_search",
     typeIdx,
     locals: [{ name: "i", type: { kind: "i32" } }],
@@ -1518,7 +1519,7 @@ export function ensureRegexReplace(ctx: CodegenContext): number {
     ],
     [strRef],
   );
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const funcIdx = mintDefinedFunc(ctx);
   ctx.nativeRegexHelpers.set("__regex_replace", funcIdx);
 
   // params
@@ -1667,7 +1668,7 @@ export function ensureRegexReplace(ctx: CodegenContext): number {
     body,
     exported: false,
   };
-  ctx.mod.functions.push(fn);
+  pushDefinedFunc(ctx, funcIdx, fn);
   return funcIdx;
 }
 
@@ -1787,7 +1788,7 @@ export function ensureRegexCaptureArray(ctx: CodegenContext): number {
     ],
     [nstrVecRef],
   );
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const funcIdx = mintDefinedFunc(ctx);
   ctx.nativeRegexHelpers.set("__regex_capture_array", funcIdx);
 
   // params
@@ -1879,7 +1880,7 @@ export function ensureRegexCaptureArray(ctx: CodegenContext): number {
     { op: "struct.new", typeIdx: nstrVecTypeIdx },
   ];
 
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, funcIdx, {
     name: "__regex_capture_array",
     typeIdx,
     locals: [
@@ -1945,7 +1946,7 @@ export function ensureRegexSplit(ctx: CodegenContext): number {
     ],
     [nstrVecRef],
   );
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const funcIdx = mintDefinedFunc(ctx);
   ctx.nativeRegexHelpers.set("__regex_split", funcIdx);
 
   // params
@@ -2238,7 +2239,7 @@ export function ensureRegexSplit(ctx: CodegenContext): number {
     { op: "struct.new", typeIdx: nstrVecTypeIdx },
   ];
 
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, funcIdx, {
     name: "__regex_split",
     typeIdx,
     locals: [
@@ -2310,7 +2311,7 @@ export function ensureRegexMatchAll(ctx: CodegenContext): number {
     ],
     [{ kind: "ref_null", typeIdx: matchVecTypeIdx }],
   );
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const funcIdx = mintDefinedFunc(ctx);
   ctx.nativeRegexHelpers.set("__regex_match_all", funcIdx);
 
   // params
@@ -2483,7 +2484,7 @@ export function ensureRegexMatchAll(ctx: CodegenContext): number {
     } as Instr,
   ];
 
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, funcIdx, {
     name: "__regex_match_all",
     typeIdx,
     locals: [
@@ -2569,7 +2570,7 @@ export function ensureRegexMatchAllArrays(ctx: CodegenContext): number {
     ],
     [outerVecRef],
   );
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const funcIdx = mintDefinedFunc(ctx);
   ctx.nativeRegexHelpers.set("__regex_match_all_arrays", funcIdx);
 
   // params
@@ -2713,7 +2714,7 @@ export function ensureRegexMatchAllArrays(ctx: CodegenContext): number {
     { op: "struct.new", typeIdx: outerVecTypeIdx },
   ];
 
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, funcIdx, {
     name: "__regex_match_all_arrays",
     typeIdx,
     locals: [
@@ -2794,7 +2795,7 @@ export function ensureRegexGetSubstitution(ctx: CodegenContext): number {
     ],
     [strRef],
   );
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const funcIdx = mintDefinedFunc(ctx);
   ctx.nativeRegexHelpers.set("__regex_get_substitution", funcIdx);
 
   // params
@@ -3467,7 +3468,7 @@ export function ensureRegexGetSubstitution(ctx: CodegenContext): number {
     { op: "local.get", index: RESULT },
   ];
 
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, funcIdx, {
     name: "__regex_get_substitution",
     typeIdx,
     locals: [
@@ -3516,7 +3517,7 @@ export function ensureRegexFlagsStr(ctx: CodegenContext): number {
   const anyStrTypeIdx = ctx.anyStrTypeIdx;
 
   const typeIdx = addFuncType(ctx, [{ kind: "i32" }], [{ kind: "ref", typeIdx: anyStrTypeIdx }]);
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const funcIdx = mintDefinedFunc(ctx);
   ctx.nativeRegexHelpers.set("__regex_flags_str", funcIdx);
 
   const FLAGS = 0; // param
@@ -3568,7 +3569,7 @@ export function ensureRegexFlagsStr(ctx: CodegenContext): number {
     { op: "struct.new", typeIdx: strTypeIdx },
   );
 
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, funcIdx, {
     name: "__regex_flags_str",
     typeIdx,
     locals: [


### PR DESCRIPTION
## #1916 S3b batch 4 — native-regex to stable handles

Continues the two-regime stable-func-handle migration (handoff dev-1916f → dev-1916o). Mechanical batch flip; **byte-identity-proven**, zero real regression.

### What
Flip `src/codegen/native-regex.ts` — all 10 helper producers (the `__regex_class_match` class matcher + the exec/match/replace/split/test family) — from the inline live-regime mint `ctx.numImportFuncs + ctx.mod.functions.length` to the stable-regime two-phase `mintDefinedFunc` / `pushDefinedFunc` protocol (`src/codegen/func-space.js`).

### Why it's safe
All 10 sites are the simple mint→push shape: **no `funcIdx + k` sibling derivation**, and (verified by push-order) **no intervening `mod.functions` push between any mint and its push**, so each stable handle resolves at emit to exactly the index the live regime baked. The regex helper indices stored in `nativeRegexHelpers` and baked into call immediates are now layout-independent and survive late-import churn untouched (the shifters skip the stable range via `inLiveShiftRange`).

### Proof (the safety net)
- **Corpus byte-IDENTICAL** over a 60-record playground + probe corpus across {gc, standalone, wasi} via `scripts/prove-emit-identity.mjs` — including `regex.ts::standalone` (65908 B, where native-regex helpers are actually emitted), so the identity is meaningful, not vacuous.
- `tsc --noEmit` clean.
- `#1916` acceptance suite + late-shift suites (`#1677`/`#1809`/`#2191`/`#2193`) + regex functional suites (`#682`/`#1539`/`#2588-2589`) green.
- The 1 `issue-1539` "refuses dynamic `new RegExp(var)`" failure is **pre-existing on clean `origin/main`** (stale refusal expectation after a recent RegExp change; confirmed via a file-revert control), not this flip's doing.

Does NOT touch S3-final (shifter deletion) — that stays lead-coordinated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS