### PR TITLE
fix(#2954): LinearEmitter core-op coverage + cross-backend G5 dynamic rows

### DIFF
--- a/plan/issues/2954-linear-emitter-core-op-coverage.md
+++ b/plan/issues/2954-linear-emitter-core-op-coverage.md
@@ -1,7 +1,9 @@
 ---
 id: 2954
 title: "LinearEmitter core-op coverage (const/binary/locals/control-flow/call) + cross-backend corpus dynamic rows"
-status: ready
+status: done
+completed: 2026-07-02
+assignee: ttraenkler/opus-dev-a
 sprint: current
 created: 2026-07-02
 updated: 2026-07-02
@@ -49,3 +51,49 @@ so the production wiring (#2956) has no floor to stand on.
   representation-divergent families (aggregates, boxing, strings, closures)
   — each annotated with the covering issue id.
 - Corpus G5 rows landed with expectLinearUnsupported markers.
+
+## Resolution (2026-07-02)
+
+Implemented in `src/ir/backend/linear-emitter.ts` + `src/ir/backend/legality.ts`.
+
+1. **LinearEmitter core-op families** — `emitConst` (delegates to the shared
+   `emitConstInstr`, numeric/bool), `emitBinary`/`emitUnary`, locals
+   (`emitLocalGet/Set/Tee`), globals (`emitGlobalGet/Set`), `emitDrop`/
+   `emitSelect`/`emitReturn`/`emitUnreachable`, structured control flow
+   (`emitIf`/`emitBr`/`emitBrIf`/`emitBlock`/`emitLoop`), and `emitCall`
+   (direct). Each is a literal 1:1 copy of `WasmGcEmitter`'s method — these
+   emit CORE Wasm and both backends share the `Instr` encoding, so the streams
+   are byte-identical by construction (pinned method-by-method in
+   `tests/ir-vec-two-backend.test.ts`).
+2. **notImplemented residue** is now only the representation-divergent
+   families, each annotated with the covering issue: `emitVecNewFixed` (#1804),
+   `emitCallRef`/aggregates/ref-cells/exceptions (#2956/#2953). Boxing/strings/
+   closures are routed through the resolver in lower.ts, not this emitter.
+3. **Legality gate** — `verifyIrBackendLegality`'s `linear` branch previously
+   rejected EVERY instruction (blocking whole-function lowering); it now uses a
+   `linearInstrError` allow-list (const/binary/unary/select/if/call/globals/
+   slots/while.loop/for.loop) mirroring `bytecodeInstrError`. Divergent kinds
+   (object/closure/box/string/refcell/…) stay rejected; the operand-type gate
+   independently rejects non-{i32,i64,f32,f64} operands.
+4. **Execution proof** — a recursive numeric `fib` and a `for`-loop/branch
+   `sumTo` (ternary in the body) are lowered from real frontend IR through
+   `LinearEmitter`, assembled into a linear-memory module (`emitBinary`),
+   instantiated, and executed with correct results; the same IR through
+   `WasmGcEmitter` yields a byte-identical body.
+5. **Corpus G5 rows** — `dynamic/typeof-residue`, `dynamic/truthiness`,
+   `dynamic/strict-eq-boxed`, `dynamic/box-roundtrip` added to
+   `tests/cross-backend/corpus.ts`, all `expectLinearUnsupported` (WasmGC
+   compiles+runs; linear fails to compile/instantiate — gap measured, ratchets
+   when #1852-G4/#2956 land).
+
+### Test Results
+
+- `tests/ir-vec-two-backend.test.ts` — 14 pass (existing #1714 vec-divergence +
+  new #2954 core-op byte-identity + fib/sumTo execution).
+- `tests/cross-backend-diff.test.ts` — 29 pass (incl. 4 new dynamic G5 rows).
+- `tests/issue-1850.test.ts` — 11 pass (legality gate re-scoped for #2954).
+- `tests/ir-bytecode-proof.test.ts` — unaffected, pass.
+
+Note: `depends_on: [2953]` (pushRaw-gap routing) did not block this — #2954
+touches only `linear-emitter.ts` + `legality.ts` + test files; the trait
+interface already declared every method. No `lower.ts` overlap.

--- a/src/ir/backend/legality.ts
+++ b/src/ir/backend/legality.ts
@@ -63,7 +63,8 @@ function checkInstr(
   if (instr.resultType) checkType(instr.resultType, blockId, `${instr.kind} result`);
 
   if (backend === "linear") {
-    reject(`linear backend does not support IR instruction '${instr.kind}' at the function-lowering boundary`);
+    const reason = linearInstrError(instr);
+    if (reason) reject(reason);
   } else if (backend === "bytecode") {
     const reason = bytecodeInstrError(instr);
     if (reason) reject(reason);
@@ -72,6 +73,47 @@ function checkInstr(
   checkInstrEmbeddedTypes(instr, blockId, checkType);
   for (const nested of nestedInstrBuffers(instr)) {
     for (const sub of nested) checkInstr(func, backend, block, sub, errors, checkType);
+  }
+}
+
+// #2954 — the linear backend's whole-function lowering boundary now permits the
+// CORE-OP families (const / arithmetic / locals-as-slots / structured control
+// flow / direct call). These lower to core Wasm and `LinearEmitter` emits them
+// byte-identically to `WasmGcEmitter`. The representation-DIVERGENT families
+// (objects, closures, boxing, strings, ref-cells, exceptions, vec CONSTRUCTION,
+// for-of iteration, promises) stay rejected here — the linear analogue lands
+// with the production wiring (#2956). This mirrors `bytecodeInstrError`'s
+// allow-list shape; the operand-type gate (`linearValTypeError`) independently
+// rejects any non-{i32,i64,f32,f64} value, so allowing an op kind here never
+// admits a divergent-typed operand.
+function linearInstrError(instr: IrInstr): string | null {
+  switch (instr.kind) {
+    case "const":
+      switch (instr.value.kind) {
+        case "i32":
+        case "i64":
+        case "f32":
+        case "f64":
+        case "bool":
+          return null;
+        default:
+          // null/ref/string/undefined consts are representation-divergent.
+          return `linear backend does not support const '${instr.value.kind}'`;
+      }
+    case "binary":
+    case "unary":
+    case "select":
+    case "if":
+    case "call":
+    case "global.get":
+    case "global.set":
+    case "slot.read":
+    case "slot.write":
+    case "while.loop":
+    case "for.loop":
+      return null;
+    default:
+      return `linear backend does not support IR instruction '${instr.kind}' at the function-lowering boundary`;
   }
 }
 

--- a/src/ir/backend/linear-emitter.ts
+++ b/src/ir/backend/linear-emitter.ts
@@ -3,11 +3,30 @@
 // LinearEmitter (#1714) — the SECOND BackendEmitter, proving the #1713 seam
 // abstracts a structurally different backend.
 //
-// Scope is deliberately narrow (issue #1714 "Notes / scope"): ONLY the vec
-// (array) length + element-read primitives, lowered to LINEAR MEMORY instead
-// of WasmGC structs/arrays. Every other BackendEmitter method throws a clear
-// not-implemented marker — covering the rest is a multi-sprint follow-up; the
-// value here is proving the seam, not coverage.
+// #1714 opened with a deliberately narrow surface — ONLY the vec (array)
+// length + element-read primitives, lowered to LINEAR MEMORY instead of
+// WasmGC structs/arrays — to prove the seam. #2954 extends that to the
+// CORE-OP families: const / binary / unary / locals / globals / drop /
+// select / return / unreachable / if / br / br_if / block / loop / direct
+// call. These emit CORE Wasm and both backends share the `Instr` encoding,
+// so the emitted stream is BYTE-IDENTICAL to `WasmGcEmitter` for them (the
+// divergence is only in the representation-specific families). Those core
+// methods are literal 1:1 copies of `WasmGcEmitter`'s (kept in sync
+// deliberately — a divergence there would be a bug, not a feature).
+//
+// What REMAINS `notImplemented` on LinearEmitter is only the genuinely
+// representation-divergent families, each annotated with the covering issue:
+//   - vec CONSTRUCTION (emitVecNewFixed) — bump-alloc store side (#1804)
+//   - aggregates (emitAggregateNew/emitFieldGet/emitFieldSet) — WasmGC
+//     `struct.*`; linear lowers objects to a memory layout (#2956)
+//   - ref-cells (emitRefCellNew/Get/Set) — 1-field mutable struct (#2953)
+//   - exceptions (emitThrow/emitRethrow/emitTry) — WasmGC EH; linear has no
+//     exception lowering yet (#2956)
+//   - typed-funcref call (emitCallRef) — `call_ref` over a reference-typed
+//     funcref; the linear backend dispatches through a table, not a GC
+//     funcref (#2956, closures)
+//   - boxing / strings / closures — routed through the resolver in lower.ts,
+//     not this emitter (strings: #679 dual backend; boxing/closures: #2956)
 //
 // Linear array layout (mirrors src/codegen-linear/runtime.ts:339
 // `addArrayRuntime`):
@@ -28,7 +47,9 @@
 // SAME IR `vec.len`/`vec.get` node → two completely different op sequences,
 // selected by which emitter `lower.ts` was handed. That is the proof.
 
-import type { Instr, ValType } from "../types.js";
+import { emitConstInstr } from "../lower.js";
+import type { IrBinop, IrInstr, IrUnop } from "../nodes.js";
+import type { BlockType, Instr, ValType } from "../types.js";
 import type { BackendEmitter } from "./emitter.js";
 import type { LinearVecLowering } from "./handles.js";
 
@@ -130,71 +151,116 @@ export class LinearEmitter implements BackendEmitter<Instr[]> {
     notImplemented("emitVecNewFixed");
   }
 
-  // ---- everything else: out of #1714 scope, fail loudly -------------------
+  // ---- core-op families (#2954) — CORE Wasm, byte-identical to WasmGc ------
+  //
+  // Every method below is a literal 1:1 copy of the corresponding
+  // `WasmGcEmitter` method. Both backends lower these node kinds to the same
+  // shared `Instr` variant (const / arithmetic / locals / globals / structured
+  // control flow / direct call are backend-agnostic core Wasm), so the emitted
+  // stream is byte-identical by construction. The divergence between the two
+  // emitters lives ONLY in the representation-specific families (vec/struct
+  // layout, boxing, strings, closures) — see the `notImplemented` block below.
 
-  emitConst(): void {
-    notImplemented("emitConst");
+  emitConst(instr: Extract<IrInstr, { kind: "const" }>, funcName: string, out: Instr[]): void {
+    // Delegate to the shared free function (same as WasmGcEmitter): the numeric
+    // / bool literal path is core Wasm (`f64.const` / `i32.const`). Argument
+    // order mirrors WasmGcEmitter — the trait's `(instr, funcName, out)` maps to
+    // the free fn's `(instr, out, funcName)`.
+    emitConstInstr(instr, out, funcName);
   }
-  emitBinary(): void {
-    notImplemented("emitBinary");
+
+  // The `as Instr` cast mirrors WasmGcEmitter/lower.ts: `IrBinop`/`IrUnop` are a
+  // superset of the bare-op `Instr` variants; composite `js.*` bitwise ops are
+  // lowered to a multi-op sequence in lower.ts and never reach here.
+  emitBinary(op: IrBinop, out: Instr[]): void {
+    out.push({ op } as Instr);
   }
-  emitUnary(): void {
-    notImplemented("emitUnary");
+
+  emitUnary(op: IrUnop, out: Instr[]): void {
+    out.push({ op } as Instr);
   }
-  emitLocalGet(): void {
-    notImplemented("emitLocalGet");
+
+  emitLocalGet(index: number, out: Instr[]): void {
+    out.push({ op: "local.get", index });
   }
-  emitLocalSet(): void {
-    notImplemented("emitLocalSet");
+
+  emitLocalSet(index: number, out: Instr[]): void {
+    out.push({ op: "local.set", index });
   }
-  emitLocalTee(): void {
-    notImplemented("emitLocalTee");
+
+  emitLocalTee(index: number, out: Instr[]): void {
+    out.push({ op: "local.tee", index });
   }
-  emitGlobalGet(): void {
-    notImplemented("emitGlobalGet");
+
+  emitGlobalGet(index: number, out: Instr[]): void {
+    out.push({ op: "global.get", index });
   }
-  emitGlobalSet(): void {
-    notImplemented("emitGlobalSet");
+
+  emitGlobalSet(index: number, out: Instr[]): void {
+    out.push({ op: "global.set", index });
   }
-  emitDrop(): void {
-    notImplemented("emitDrop");
+
+  emitDrop(out: Instr[]): void {
+    out.push({ op: "drop" });
   }
-  emitSelect(): void {
-    notImplemented("emitSelect");
+
+  emitSelect(out: Instr[]): void {
+    out.push({ op: "select" });
   }
-  emitReturn(): void {
-    notImplemented("emitReturn");
+
+  emitReturn(out: Instr[]): void {
+    out.push({ op: "return" });
   }
-  emitUnreachable(): void {
-    notImplemented("emitUnreachable");
+
+  emitUnreachable(out: Instr[]): void {
+    out.push({ op: "unreachable" });
   }
-  emitIf(): void {
-    notImplemented("emitIf");
+
+  emitIf(blockType: BlockType, then: Instr[], els: Instr[], out: Instr[]): void {
+    out.push({ op: "if", blockType, then, else: els });
   }
-  emitBr(): void {
-    notImplemented("emitBr");
+
+  emitBr(depth: number, out: Instr[]): void {
+    out.push({ op: "br", depth });
   }
-  emitBrIf(): void {
-    notImplemented("emitBrIf");
+
+  emitBrIf(depth: number, out: Instr[]): void {
+    out.push({ op: "br_if", depth });
   }
-  // (a3) control-flow family (#1584 §2a) — out of the #1714 vec-proof scope.
-  emitBlock(): void {
-    notImplemented("emitBlock");
+
+  emitBlock(blockType: BlockType, body: Instr[], out: Instr[]): void {
+    out.push({ op: "block", blockType, body });
   }
-  emitLoop(): void {
-    notImplemented("emitLoop");
+
+  emitLoop(blockType: BlockType, body: Instr[], out: Instr[]): void {
+    out.push({ op: "loop", blockType, body });
   }
-  // (a4) try-throw family (#1584 §2a) — out of the #1714 vec-proof scope.
-  emitThrow(): void {
-    notImplemented("emitThrow");
+
+  // Direct call — `{op:"call",funcIdx}` is core Wasm, identical on both backends
+  // (the linear backend calls the same defined function index). `emitCallRef`
+  // (typed funcref / `call_ref`) stays divergent — see the notImplemented block.
+  emitCall(funcIdx: number, out: Instr[]): void {
+    out.push({ op: "call", funcIdx });
   }
-  emitRethrow(): void {
-    notImplemented("emitRethrow");
+
+  // ---- representation-divergent families: still fail loudly (#2954) --------
+  // These lower to WasmGC-specific ops (struct.*, array construction, GC
+  // funcref, EH) that the linear backend realizes differently (memory layout,
+  // call_indirect, no EH yet). Each is annotated with the issue that will wire
+  // the linear analogue.
+
+  // emitVecNewFixed already declared above (the read side is #1714 scope; the
+  // bump-allocated store sequence is #1804).
+
+  // typed-funcref call — `call_ref` over a GC funcref (#2956, closures). The
+  // linear backend dispatches indirect calls through a table (`call_indirect`),
+  // not a reference-typed funcref, so this needs distinct lowering.
+  emitCallRef(): void {
+    notImplemented("emitCallRef");
   }
-  emitTry(): void {
-    notImplemented("emitTry");
-  }
-  // (a2) struct/object family (#1584 §2a) — out of the #1714 vec-proof scope.
+
+  // struct/object family — WasmGC `struct.new`/`struct.get`/`struct.set`; the
+  // linear backend lowers objects to a bump-allocated memory layout (#2956).
   emitAggregateNew(): void {
     notImplemented("emitAggregateNew");
   }
@@ -204,15 +270,21 @@ export class LinearEmitter implements BackendEmitter<Instr[]> {
   emitFieldSet(): void {
     notImplemented("emitFieldSet");
   }
-  // (a1) call family (#1584 §2a) — out of the #1714 linear vec-proof scope;
-  // fail loudly until the linear backend wires its call lowering.
-  emitCall(): void {
-    notImplemented("emitCall");
+
+  // try-throw family — WasmGC exception handling (`throw`/`try`/`rethrow`); the
+  // linear backend has no exception lowering yet (#2956).
+  emitThrow(): void {
+    notImplemented("emitThrow");
   }
-  emitCallRef(): void {
-    notImplemented("emitCallRef");
+  emitRethrow(): void {
+    notImplemented("emitRethrow");
   }
-  // (a5) ref-cell family (#2953) — out of the #1714 vec-proof scope.
+  emitTry(): void {
+    notImplemented("emitTry");
+  }
+
+  // ref-cell family — a 1-field mutable struct (`struct.new`/`get`/`set`),
+  // structurally the same as the object family; wires with it (#2953/#2956).
   emitRefCellNew(): void {
     notImplemented("emitRefCellNew");
   }

--- a/tests/cross-backend/corpus.ts
+++ b/tests/cross-backend/corpus.ts
@@ -478,4 +478,61 @@ export const CROSS_BACKEND_CORPUS: readonly CrossBackendProgram[] = [
     calls: [{ fn: "r", args: [] }],
     expectLinearUnsupported: true,
   },
+
+  // ── dynamic residue (#1852-G5, via #2954) ──────────────────────────────────
+  // The `any`/boxed-dynamic surface — typeof, dynamic truthiness, `===` on
+  // boxed values, box→unbox round-trips. WasmGC lowers all of these (the JSValue
+  // externref rep); the linear backend has no dynamic value representation yet,
+  // so each fails to compile OR to instantiate on linear. They are kept
+  // `expectLinearUnsupported` so the parity gap is MEASURED, not silent — the
+  // flag drops when #1852-G4/#2956 give linear a dynamic value rep. (For an
+  // expectLinearUnsupported row the harness only asserts WasmGC compiles+runs and
+  // linear does NOT; the calls are diffed once the flag is removed.)
+  {
+    name: "dynamic/typeof-residue",
+    category: "dynamic",
+    source: `
+      export function isNum(): number { const x: any = 42; return typeof x === "number" ? 1 : 0; }
+      export function isStr(): number { const x: any = "hi"; return typeof x === "string" ? 1 : 0; }
+    `,
+    calls: [
+      { fn: "isNum", args: [] },
+      { fn: "isStr", args: [] },
+    ],
+    expectLinearUnsupported: true,
+  },
+  {
+    name: "dynamic/truthiness",
+    category: "dynamic",
+    source: `
+      export function truthy(v: number): number { const x: any = v; return x ? 1 : 0; }
+    `,
+    calls: [
+      { fn: "truthy", args: [0] },
+      { fn: "truthy", args: [5] },
+    ],
+    expectLinearUnsupported: true,
+  },
+  {
+    name: "dynamic/strict-eq-boxed",
+    category: "dynamic",
+    source: `
+      export function eqNum(): number { const a: any = 5; const b: any = 5; return a === b ? 1 : 0; }
+      export function neNum(): number { const a: any = 5; const b: any = 6; return a === b ? 1 : 0; }
+    `,
+    calls: [
+      { fn: "eqNum", args: [] },
+      { fn: "neNum", args: [] },
+    ],
+    expectLinearUnsupported: true,
+  },
+  {
+    name: "dynamic/box-roundtrip",
+    category: "dynamic",
+    source: `
+      export function roundtrip(n: number): number { const x: any = n; const y = x as number; return y + 1; }
+    `,
+    calls: [{ fn: "roundtrip", args: [6] }],
+    expectLinearUnsupported: true,
+  },
 ];

--- a/tests/ir-vec-two-backend.test.ts
+++ b/tests/ir-vec-two-backend.test.ts
@@ -17,12 +17,18 @@
 // through WasmGcEmitter via #1713). Together: same IR intent → two backends →
 // matching results.
 
+import ts from "typescript";
 import { describe, expect, it } from "vitest";
 
+import { analyzeSource } from "../src/checker/index.js";
 import { WasmGcEmitter } from "../src/ir/backend/wasmgc-emitter.js";
 import { LinearEmitter } from "../src/ir/backend/linear-emitter.js";
 import type { IrVecLowering, LinearVecLowering } from "../src/ir/backend/handles.js";
-import type { Instr } from "../src/ir/types.js";
+import { lowerFunctionAstToIr } from "../src/ir/from-ast.js";
+import { lowerIrFunctionToWasm } from "../src/ir/lower.js";
+import { emitBinary } from "../src/emit/binary.js";
+import { irVal, type IrLowerResolver } from "../src/ir/index.js";
+import type { BlockType, Instr, ValType, WasmFunction, WasmModule } from "../src/ir/types.js";
 
 const wasmgc = new WasmGcEmitter();
 const linear = new LinearEmitter();
@@ -130,5 +136,224 @@ describe("#1714 LinearEmitter ops execute correctly against the linear layout", 
     const sum = (instance.exports.sum as (b: number) => number)(0);
     expect(sum).toBe(60);
     parsed.destroy?.();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #2954 — the LinearEmitter's CORE-OP families are byte-identical to WasmGc.
+//
+// #1714 proved the seam with the vec primitives (which DIVERGE per backend).
+// #2954 extends LinearEmitter to the core-op families — const / binary / unary /
+// locals / globals / drop / select / return / unreachable / if / br / br_if /
+// block / loop / direct call. These emit CORE Wasm (both backends share the
+// `Instr` encoding), so — unlike the vec ops — they must be BYTE-IDENTICAL to
+// WasmGcEmitter. This block pins that method-by-method: same call, same
+// `Instr[]`. A future divergence in a core op would be a bug (the linear
+// backend does not get to lower `f64.add` differently), and this catches it.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("#2954 LinearEmitter core-op families are byte-identical to WasmGc", () => {
+  const EMPTY: BlockType = { kind: "empty" };
+  /** Run the same emitter method on both backends and assert identical Instr[]. */
+  function bothEqual(fn: (e: WasmGcEmitter | LinearEmitter, out: Instr[]) => void): Instr[] {
+    const gc: Instr[] = [];
+    const lin: Instr[] = [];
+    fn(wasmgc, gc);
+    fn(linear, lin);
+    expect(lin).toEqual(gc);
+    return lin;
+  }
+
+  it("emitConst (f64 / i32 / bool) — identical literal ops", () => {
+    expect(
+      bothEqual((e, out) =>
+        e.emitConst({ kind: "const", result: null, resultType: null, value: { kind: "f64", value: 3.5 } }, "f", out),
+      ),
+    ).toEqual([{ op: "f64.const", value: 3.5 }]);
+    expect(
+      bothEqual((e, out) =>
+        e.emitConst({ kind: "const", result: null, resultType: null, value: { kind: "i32", value: 7 } }, "f", out),
+      ),
+    ).toEqual([{ op: "i32.const", value: 7 }]);
+    expect(
+      bothEqual((e, out) =>
+        e.emitConst({ kind: "const", result: null, resultType: null, value: { kind: "bool", value: true } }, "f", out),
+      ),
+    ).toEqual([{ op: "i32.const", value: 1 }]);
+  });
+
+  it("emitBinary / emitUnary — identical pass-through ops", () => {
+    expect(bothEqual((e, out) => e.emitBinary("f64.add", out))).toEqual([{ op: "f64.add" }]);
+    expect(bothEqual((e, out) => e.emitBinary("i32.lt_s", out))).toEqual([{ op: "i32.lt_s" }]);
+    expect(bothEqual((e, out) => e.emitUnary("f64.neg", out))).toEqual([{ op: "f64.neg" }]);
+  });
+
+  it("locals / globals — identical index ops", () => {
+    expect(bothEqual((e, out) => e.emitLocalGet(2, out))).toEqual([{ op: "local.get", index: 2 }]);
+    expect(bothEqual((e, out) => e.emitLocalSet(3, out))).toEqual([{ op: "local.set", index: 3 }]);
+    expect(bothEqual((e, out) => e.emitLocalTee(4, out))).toEqual([{ op: "local.tee", index: 4 }]);
+    expect(bothEqual((e, out) => e.emitGlobalGet(1, out))).toEqual([{ op: "global.get", index: 1 }]);
+    expect(bothEqual((e, out) => e.emitGlobalSet(5, out))).toEqual([{ op: "global.set", index: 5 }]);
+  });
+
+  it("stack / return ops — identical", () => {
+    expect(bothEqual((e, out) => e.emitDrop(out))).toEqual([{ op: "drop" }]);
+    expect(bothEqual((e, out) => e.emitSelect(out))).toEqual([{ op: "select" }]);
+    expect(bothEqual((e, out) => e.emitReturn(out))).toEqual([{ op: "return" }]);
+    expect(bothEqual((e, out) => e.emitUnreachable(out))).toEqual([{ op: "unreachable" }]);
+  });
+
+  it("structured control flow (if / block / loop) + br / br_if — identical", () => {
+    const then: Instr[] = [{ op: "i32.const", value: 1 }];
+    const els: Instr[] = [{ op: "i32.const", value: 0 }];
+    expect(bothEqual((e, out) => e.emitIf(EMPTY, [...then], [...els], out))).toEqual([
+      { op: "if", blockType: EMPTY, then, else: els },
+    ]);
+    expect(bothEqual((e, out) => e.emitBr(1, out))).toEqual([{ op: "br", depth: 1 }]);
+    expect(bothEqual((e, out) => e.emitBrIf(0, out))).toEqual([{ op: "br_if", depth: 0 }]);
+    const body: Instr[] = [{ op: "nop" } as Instr];
+    expect(bothEqual((e, out) => e.emitBlock(EMPTY, [...body], out))).toEqual([
+      { op: "block", blockType: EMPTY, body },
+    ]);
+    expect(bothEqual((e, out) => e.emitLoop(EMPTY, [...body], out))).toEqual([{ op: "loop", blockType: EMPTY, body }]);
+  });
+
+  it("direct call — identical", () => {
+    expect(bothEqual((e, out) => e.emitCall(9, out))).toEqual([{ op: "call", funcIdx: 9 }]);
+  });
+
+  it("representation-divergent families still fail loudly on LinearEmitter", () => {
+    // Aggregates, boxing-adjacent funcref call, exceptions, ref-cells lower to
+    // WasmGC-specific ops; the linear analogue lands with #2956/#2953. Each stays
+    // a loud stub (WasmGc implements them; Linear throws).
+    for (const call of [
+      () => linear.emitCallRef(),
+      () => linear.emitAggregateNew(),
+      () => linear.emitFieldGet(),
+      () => linear.emitFieldSet(),
+      () => linear.emitThrow(),
+      () => linear.emitTry(),
+      () => linear.emitRefCellNew(),
+      () => linear.emitVecNewFixed(),
+    ]) {
+      expect(call).toThrow(/LinearEmitter:/);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #2954 — a WHOLE function lowers through LinearEmitter and RUNS in a
+// linear-memory instantiation.
+//
+// The byte-identity block above is the unit proof; this is the integration
+// proof required by the issue's acceptance: a recursive numeric fib and a
+// loop/branch function are lowered from real IR (produced by the from-ast
+// frontend) through `LinearEmitter`, assembled into a module that declares a
+// LINEAR MEMORY, instantiated, and executed — with correct results. The SAME IR
+// lowered through `WasmGcEmitter` yields a byte-identical body (the core-op
+// stream does not diverge), so the WasmGC path — already covered for runtime
+// correctness by the equivalence suite — pins the linear one.
+//
+// (These core-op functions do not touch the memory: that is the point — core
+// ops are memory-independent. The memory is declared to model the linear
+// backend's module shape; the vec/aggregate families that WOULD use it are the
+// still-divergent surface, out of #2954 scope.)
+// ─────────────────────────────────────────────────────────────────────────────
+describe("#2954 whole-function lowering through LinearEmitter runs in linear memory", () => {
+  const F64: ValType = { kind: "f64" };
+
+  // Self-call → funcIdx 0; the numeric subset reaches no globals; one func type.
+  const resolver: IrLowerResolver = {
+    resolveFunc: () => 0,
+    resolveGlobal: () => {
+      throw new Error("numeric subset reaches no globals");
+    },
+    resolveType: () => 0,
+    internFuncType: () => 0,
+  };
+
+  /** Lower a named top-level function from `source` to IR via the frontend. */
+  function irOf(source: string, name: string, calleeTypes?: Map<string, { params: unknown[]; returnType: unknown }>) {
+    const ast = analyzeSource(source);
+    const decl = ast.sourceFile.statements.find(
+      (s): s is ts.FunctionDeclaration => ts.isFunctionDeclaration(s) && s.name?.text === name,
+    );
+    if (!decl) throw new Error(`no function ${name} in source`);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return lowerFunctionAstToIr(decl, { exported: true, calleeTypes: calleeTypes as any }).main;
+  }
+
+  /** Wrap one lowered WasmFunction (index 0, exported) in a linear-memory module. */
+  function singleFuncModule(fn: WasmFunction, params: ValType[], results: ValType[]): WasmModule {
+    return {
+      types: [{ kind: "func", name: "t0", params, results }],
+      imports: [],
+      functions: [fn],
+      exports: [{ name: fn.name, desc: { kind: "func", index: 0 } }],
+      tables: [],
+      elements: [],
+      globals: [],
+      tags: [],
+      stringPool: [],
+      externClasses: [],
+      nodeBuiltinModules: new Set(),
+      stringLiteralValues: new Map(),
+      asyncFunctions: new Set(),
+      declaredFuncRefs: [],
+      memories: [{ min: 1 }], // linear memory — the backend's module shape
+      dataSegments: [],
+    } as unknown as WasmModule;
+  }
+
+  async function runLinear(
+    source: string,
+    name: string,
+    params: ValType[],
+    results: ValType[],
+    calleeTypes?: Map<string, { params: unknown[]; returnType: unknown }>,
+  ): Promise<(...a: number[]) => number> {
+    const ir = irOf(source, name, calleeTypes);
+    const linFn = lowerIrFunctionToWasm(ir, resolver, new LinearEmitter()).func;
+    // Same IR through WasmGc must yield a byte-identical body (core ops don't diverge).
+    const gcFn = lowerIrFunctionToWasm(ir, resolver, new WasmGcEmitter()).func;
+    expect(linFn.body).toEqual(gcFn.body);
+    const binary = emitBinary(singleFuncModule(linFn, params, results));
+    const { instance } = await WebAssembly.instantiate(binary, {});
+    return instance.exports[name] as (...a: number[]) => number;
+  }
+
+  it("recursive numeric fib lowers through LinearEmitter and computes correctly", async () => {
+    const fib = await runLinear(
+      `export function fib(n: number): number { return n < 2 ? n : fib(n - 1) + fib(n - 2); }`,
+      "fib",
+      [F64],
+      [F64],
+      new Map([["fib", { params: [irVal(F64)], returnType: irVal(F64) }]]),
+    );
+    // 0,1,1,2,3,5,8,13,21,34,55,...
+    expect(fib(0)).toBe(0);
+    expect(fib(1)).toBe(1);
+    expect(fib(10)).toBe(55);
+    expect(fib(15)).toBe(610);
+    expect(fib(20)).toBe(6765);
+  });
+
+  it("a for-loop / branch function lowers through LinearEmitter and computes correctly", async () => {
+    // A `for` loop (structured for.loop IR + slots) carrying a BRANCH inside the
+    // body (a ternary → value-producing `if`). Exercises loop + branch + binary +
+    // const together on the linear boundary.
+    const sumTo = await runLinear(
+      `export function sumTo(n: number): number {
+         let t = 0;
+         for (let i = 0; i < n; i = i + 1) { t = t + (i > 1 ? i : 0); }
+         return t;
+       }`,
+      "sumTo",
+      [F64],
+      [F64],
+    );
+    expect(sumTo(0)).toBe(0);
+    expect(sumTo(2)).toBe(0); // i=0,1 gated to 0 by i>1
+    expect(sumTo(5)).toBe(9); // 2+3+4
+    expect(sumTo(100)).toBe(4949); // sum(2..99) = 4950 - 1
   });
 });

--- a/tests/issue-1850.test.ts
+++ b/tests/issue-1850.test.ts
@@ -227,7 +227,10 @@ describe("#1850 — per-backend IR legality and hard verifier fallback", () => {
     );
   });
 
-  it("rejects non-vec whole-function lowering through the linear emitter boundary", () => {
+  it("#2954: accepts a core-op (const) whole-function lowering through the linear boundary", () => {
+    // #2954 opened the core-op families (const/binary/…/control-flow/call) on the
+    // linear boundary — a numeric const function now lowers cleanly (byte-identical
+    // to WasmGc). Cf. the divergent-family rejection test below.
     const v1 = asValueId(1);
     const fn: IrFunction = {
       name: "linearConst",
@@ -238,10 +241,33 @@ describe("#1850 — per-backend IR legality and hard verifier fallback", () => {
       valueCount: 2,
     };
 
+    expect(verifyIrBackendLegality(fn, "linear")).toEqual([]);
+    expect(() => lowerIrFunctionBody(fn, minimalResolver(), new LinearEmitter())).not.toThrow();
+  });
+
+  it("#2954: still rejects a representation-divergent (object.new) instr on the linear boundary", () => {
+    // The core-op opening (#2954) did NOT open the divergent families — objects
+    // lower to WasmGC `struct.*`; the linear analogue lands with #2956.
+    const objInstr: IrInstr = {
+      kind: "object.new",
+      shape: { fields: [] },
+      args: [],
+      result: asValueId(1),
+      resultType: { kind: "object", shape: { fields: [] } },
+    } as unknown as IrInstr;
+    const fn: IrFunction = {
+      name: "linearObject",
+      params: [],
+      resultTypes: [I32],
+      // object.new (v1, divergent) then a plain i32 const (v2) returned.
+      blocks: [block(0, [objInstr, constI32(2, 0)], { kind: "return", values: [asValueId(2)] })],
+      exported: false,
+      valueCount: 3,
+    };
+
     const errors = verifyIrBackendLegality(fn, "linear");
-    expect(errors.some((e) => /linear backend does not support IR instruction 'const'/.test(e.message))).toBe(true);
-    expect(() => lowerIrFunctionBody(fn, minimalResolver(), new LinearEmitter())).toThrow(
-      /linear backend legality failed.*const/,
+    expect(errors.some((e) => /linear backend does not support IR instruction 'object.new'/.test(e.message))).toBe(
+      true,
     );
   });
 


### PR DESCRIPTION
## #2954 — the linear emitter is now a backend, not a 3-method proof

`src/ir/backend/linear-emitter.ts` implemented only the three #1714 vec-read
primitives; every other trait method threw `notImplemented`, so nothing could
lower a whole function IR→linear (the #2956 production wiring had no floor).

### What this does

- **LinearEmitter core-op families** — `const` / `binary` / `unary` / locals /
  globals / `drop` / `select` / `return` / `unreachable` / `if` / `br` / `br_if` /
  `block` / `loop` / direct `call`. Each is a literal 1:1 copy of `WasmGcEmitter`:
  these emit CORE Wasm and both backends share the `Instr` encoding, so the stream
  is byte-identical by construction. Remaining `notImplemented` residue is only the
  representation-divergent families (vec construction #1804, aggregates/ref-cells/
  exceptions/funcref-call #2956/#2953), each annotated with the covering issue.
- **Legality gate** (`src/ir/backend/legality.ts`) — the `linear` branch of
  `verifyIrBackendLegality` previously rejected EVERY instruction, blocking
  whole-function lowering. It now uses a `linearInstrError` allow-list mirroring
  `bytecodeInstrError` (const/binary/unary/select/if/call/globals/slots/for.loop/
  while.loop). Divergent kinds stay rejected; the operand-type gate independently
  rejects any non-{i32,i64,f32,f64} operand. LinearEmitter is test-only today, so
  this loosening has no production consumer until #2956 wires it deliberately.
- **Execution proof** (`tests/ir-vec-two-backend.test.ts`) — a recursive numeric
  `fib` and a `for`-loop/branch `sumTo` (ternary in the body) are lowered from
  real frontend IR through `LinearEmitter`, assembled into a linear-memory module
  (`emitBinary`), instantiated, and executed with correct results. The same IR
  through `WasmGcEmitter` yields a byte-identical body; core-op byte-identity is
  also pinned method-by-method.
- **Corpus G5 rows** (`tests/cross-backend/corpus.ts`) — `dynamic/typeof-residue`,
  `dynamic/truthiness`, `dynamic/strict-eq-boxed`, `dynamic/box-roundtrip`, all
  `expectLinearUnsupported` (WasmGC compiles+runs; linear cannot lower a dynamic
  value rep yet). The parity gap is measured, not silent — the flag drops when
  #1852-G4/#2956 land.

### Tests

- `ir-vec-two-backend.test.ts` — 14 pass (vec-divergence + core-op byte-identity + fib/sumTo execution)
- `cross-backend-diff.test.ts` — 29 pass (incl. 4 new dynamic G5 rows)
- `issue-1850.test.ts` — 11 pass (legality gate re-scoped)
- `ir-bytecode-proof.test.ts` — unaffected, pass

`depends_on: [2953]` did not block: this touches only `linear-emitter.ts` +
`legality.ts` + test files; the trait interface already declared every method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8