### PR TITLE
refactor(#1916) S3b batch 5: flip collections runtime to stable func handles

### DIFF
--- a/src/codegen/map-runtime.ts
+++ b/src/codegen/map-runtime.ts
@@ -33,7 +33,7 @@ import type { InnerResult } from "./shared.js";
 import { compileArrowAsClosure, compileExpression, VOID_RESULT } from "./shared.js";
 import { isNullOrUndefinedLiteral } from "./destructuring-params.js";
 import { coercionInstrs } from "./type-coercion.js";
-import { definedFuncAt } from "./func-space.js"; // (#1916 S2) positional-read chokepoint
+import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S2/S3) positional-read chokepoint + stable-regime minting
 
 /** WasmGC `eq` abstract heap type, signed-LEB `0x6d` = -19. Used for ref.eq on
  *  object keys (only GC eqrefs can be compared by identity). */
@@ -176,9 +176,9 @@ function addMapFunc(
   body: Instr[],
 ): number {
   const typeIdx = addFuncType(ctx, params, results);
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const funcIdx = mintDefinedFunc(ctx);
   ctx.mapHelpers.set(name, funcIdx);
-  ctx.mod.functions.push({ name, typeIdx, locals, body, exported: false });
+  pushDefinedFunc(ctx, funcIdx, { name, typeIdx, locals, body, exported: false });
   return funcIdx;
 }
 

--- a/src/codegen/set-algebra.ts
+++ b/src/codegen/set-algebra.ts
@@ -27,6 +27,7 @@ import { ts } from "../ts-api.js";
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { addFuncType } from "./registry/types.js";
+import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3) stable-regime minting
 import type { InnerResult } from "./shared.js";
 import { compileExpression } from "./shared.js";
 import { ensureMapHelpers } from "./map-runtime.js";
@@ -116,9 +117,9 @@ export function ensureSetAlgebraHelpers(ctx: CodegenContext): void {
 
   const addFn = (name: string, results: ValType[], localTypes: ValType[], body: Instr[]): void => {
     const typeIdx = addFuncType(ctx, [mref, mref], results);
-    const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+    const funcIdx = mintDefinedFunc(ctx);
     ctx.mapHelpers.set(name, funcIdx);
-    ctx.mod.functions.push({
+    pushDefinedFunc(ctx, funcIdx, {
       name,
       typeIdx,
       locals: localTypes.map((type, i) => ({ name: `__sa_l${i}`, type })),

--- a/src/codegen/set-runtime.ts
+++ b/src/codegen/set-runtime.ts
@@ -42,6 +42,7 @@ import {
   tryCompileNativeCollectionForEach,
 } from "./map-runtime.js";
 import { addFuncType } from "./registry/types.js";
+import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3) stable-regime minting
 import type { InnerResult } from "./shared.js";
 import { VOID_RESULT, compileExpression } from "./shared.js";
 
@@ -73,9 +74,9 @@ export function ensureSetHelpers(ctx: CodegenContext): void {
     { op: "call", funcIdx: mapSetIdx } as Instr,
   ];
   const typeIdx = addFuncType(ctx, [mref, anyref], [mref]);
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const funcIdx = mintDefinedFunc(ctx);
   ctx.mapHelpers.set("__set_add", funcIdx);
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, funcIdx, {
     name: "__set_add",
     typeIdx,
     locals: [],

--- a/src/codegen/weak-collections-runtime.ts
+++ b/src/codegen/weak-collections-runtime.ts
@@ -35,6 +35,7 @@ import { ts } from "../ts-api.js";
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { addFuncType } from "./registry/types.js";
+import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3) stable-regime minting
 import type { InnerResult } from "./shared.js";
 import { compileExpression, VOID_RESULT } from "./shared.js";
 import { coerceMapKeyToAnyref, ensureMapHelpers } from "./map-runtime.js";
@@ -62,9 +63,9 @@ export function ensureWeakCollectionHelpers(ctx: CodegenContext): void {
     { op: "call", funcIdx: mapSetIdx } as Instr,
   ];
   const typeIdx = addFuncType(ctx, [mref, anyref], [mref]);
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const funcIdx = mintDefinedFunc(ctx);
   ctx.mapHelpers.set("__weakset_add", funcIdx);
-  ctx.mod.functions.push({ name: "__weakset_add", typeIdx, locals: [], body, exported: false });
+  pushDefinedFunc(ctx, funcIdx, { name: "__weakset_add", typeIdx, locals: [], body, exported: false });
 }
 
 /** Cast a compiled receiver to `ref $Map` (the weak-collection backing store).


### PR DESCRIPTION
## #1916 S3b batch 5 — collections runtime to stable handles

Continues the two-regime stable-func-handle migration (dev-1916o). Mechanical batch flip; **byte-identity-proven**, zero real regression.

### What
Flip the collections runtime family — `map-runtime.ts`, `set-runtime.ts`, `set-algebra.ts`, `weak-collections-runtime.ts` — from the inline live-regime mint `ctx.numImportFuncs + ctx.mod.functions.length` to the stable-regime two-phase `mintDefinedFunc` / `pushDefinedFunc` protocol.

### Why it's safe
Each file has a single define-helper mint→push pair, adjacent — no `funcIdx + k` sibling derivation and no intervening `mod.functions` push — so each stable handle resolves at emit to exactly the live-regime index. The Map/Set/Weak helper indices baked into the `mapHelpers`/`setHelpers` side-tables are now layout-independent and survive late-import churn untouched.

### Proof (the safety net)
- **Corpus byte-IDENTICAL** over the 60-record playground + probe corpus across {gc, standalone, wasi} via `scripts/prove-emit-identity.mjs` — including `collections.ts::standalone` (60743 B, where Map/Set/WeakMap/WeakSet helpers are actually emitted), so the identity is meaningful.
- `tsc --noEmit` clean.
- #1916 acceptance + collections suites green (55 tests: `1103a-standalone-map`, `2162-set-algebra`/`standalone-set`/`standalone-weak`, `2162-weak-mapHelpers-shift`, `1573-map-capture-branch-validate`, `2162-map-foreach`). The `weak-mapHelpers-shift` suite directly exercises late-import index-shift of these helpers.

Does NOT touch S3-final (shifter deletion) — that stays lead-coordinated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS