### PR TITLE
infra(#3003): verdict-logic change must bump oracle_version (queue-wedge prevention)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,22 @@ jobs:
           git fetch --no-tags --depth=1 origin main 2>/dev/null || true
           ISSUE_COVERAGE_BASE=origin/main pnpm run check:issue-spec-coverage
 
+      - name: Verdict-logic must bump oracle_version (#3003)
+        # A test262 VERDICT-LOGIC change (how a per-test result is SCORED:
+        # test262-worker.mjs / test262-shared.ts / negative-verdict.mjs / the
+        # runners) diffs new-policy-vs-old-policy as a mass pass→fail cluster.
+        # If it does NOT bump ORACLE_VERSION (#2096) the #1668 catastrophic guard
+        # fails the push-to-main run, promote-baseline never runs, and the merge
+        # queue WEDGES against the un-promotable old-policy baseline — this
+        # happened TWICE in 2026-07 (the −439 strict-negative-verdict change and
+        # PR #2463's vacuity scorer; see #3003). This gate fails a verdict-signal
+        # change that neither bumps the oracle nor carries an in-diff
+        # `oracle-version-exempt:` override. Runs on the same origin/main diff
+        # base as the issue-ID gates; skips cleanly when no base resolves.
+        run: |
+          git fetch --no-tags --depth=50 origin main 2>/dev/null || true
+          VERDICT_ORACLE_BASE=origin/main pnpm run check:verdict-oracle
+
       - name: Host-import allowlist + strict-mode gate (#1524)
         env:
           # PRs that intentionally grow the allowlist must include

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "check:coercion-sites": "node scripts/check-coercion-sites.mjs",
     "check:test262-hard-errors": "node scripts/check-test262-hard-errors.mjs",
     "check:issue-spec-coverage": "node scripts/check-issue-spec-coverage.mjs",
+    "check:verdict-oracle": "node scripts/check-verdict-oracle-bump.mjs",
     "check:issues": "node scripts/update-issues.mjs --check",
     "test:diff": "npx tsx scripts/diff-test.ts",
     "test:diff:triage": "npx tsx scripts/diff-triage.ts",

--- a/plan/issues/3003-verdict-logic-change-must-bump-oracle-version.md
+++ b/plan/issues/3003-verdict-logic-change-must-bump-oracle-version.md
@@ -1,0 +1,193 @@
+---
+id: 3003
+title: "Postmortem + prevention: a test262 verdict-logic change must bump oracle_version (two queue wedges)"
+status: done
+assignee: ttraenkler/dev-3003
+created: 2026-07-01
+completed: 2026-07-02
+priority: high
+feasibility: hard
+task_type: infra
+area: ci
+sprint: current
+horizon: m
+related: [2096, 2920, 2940, 1668, 1897, 2528, 2547]
+---
+
+# Postmortem: two intentional-reclassification queue wedges (verdict logic vs. an old-policy baseline)
+
+## Summary
+
+In the last 24h the merge queue wedged **twice** with the **same root cause**:
+a PR changed test262 **verdict logic** — *how a per-test result is scored* —
+without bumping the `oracle_version` (#2096). The new-policy results then diffed
+against the **old-policy** committed baseline as a mass `pass→fail` cluster,
+which tripped the required regression guards and blocked the very
+`promote-baseline` run that would have re-seeded the baseline at the new policy.
+
+This issue is the **postmortem** plus a **prevention CI check** (in the required
+`quality` lane) that fails a verdict-logic change which neither bumps
+`oracle_version` nor carries a conscious in-diff override.
+
+## The two wedges
+
+### Wedge 1 — the −439 strict-negative-verdict change (issue #2920)
+
+The negative-test verdict logic was tightened (parse/early/resolution negatives
+must reject for the *right* reason), reclassifying ~439 rows. This one was
+**handled correctly but expensively** with a coordinated **temporary-lever
+dance**:
+
+1. raise the #1668 catastrophic guard threshold (200 → 500),
+2. add an `INTENTIONAL_REGRESSION_BUDGET`,
+3. lower the standalone floor,
+4. land the PR, let `promote-baseline` re-seed the new-policy baseline,
+5. revert the levers.
+
+It worked, but it is fragile: it requires touching multiple guards in lockstep,
+and missing any one of them leaves the queue red (see "The 3-guard surface").
+
+### Wedge 2 — PR #2463's vacuity scorer (merged `0670ea4`, issue #2940)
+
+PR #2463 added a **vacuity honesty-reclassifier**: a harness-wrapper test whose
+callback never executed (so *no assertion ran*) is no longer scored `pass`. It
+reclassified ~1,438 host + standalone passes to `fail` with the reason
+`vacuous: harness-wrapper callback never executed (#2940) — no assertion ran`
+(in `scripts/test262-worker.mjs` ~line 1370, plumbed through
+`tests/test262-shared.ts`).
+
+It did **NOT** do the lever dance. The failure chain:
+
+1. The push-to-main run's **Catastrophic regression guard (#1668)** saw the huge
+   new-policy-vs-old-policy delta and **failed**.
+2. Because that guard lives inside the required "merge shard reports" check, the
+   `promote-baseline` job **never ran** on that run.
+3. So the committed baseline stayed **old-policy**.
+4. Every subsequent `merge_group` then diffed **new-policy-vs-old-policy** →
+   the *identical* cluster signature `d822f85a0aabd092` → **auto-park** (#2547)
+   → the queue **wedged** against a baseline that could only be fixed by the
+   promote the guard was blocking.
+
+**How it self-resolved:** the #2528 promote-baseline-race fix plus a scheduled
+baseline refresh eventually promoted the new-policy baseline — confirmed at
+baselines-repo commit `e3d8167`, built from main `697ce0e`, a descendant of
+#2463. Once the baseline was new-policy, the cluster vanished and the queue
+cleared. This was luck-of-timing, not a designed recovery.
+
+## Root cause
+
+Both wedges are the same defect: **a verdict-logic change was landed as if it
+were a code change.** The #2096 oracle-version machinery exists precisely to
+distinguish the two:
+
+- A **code change** should be measured against the baseline — a `pass→fail`
+  delta is a real regression and *should* fail the guards.
+- A **verdict-logic (oracle) change** re-scores *the same compiler output*.
+  Its `pass→fail` delta is **oracle skew, not a regression**, and must be
+  handled as a **re-baseline**, not measured as a regression.
+
+`oracle_version` is the switch. `tests/test262-oracle-version.ts` stamps every
+result row and every baseline/merged report with `ORACLE_VERSION`, and
+`scripts/diff-test262.ts` **refuses** to diff a baseline against a candidate
+whose `oracle_version` differs (unless `ORACLE_REBASE=1`). So had either PR
+**bumped `ORACLE_VERSION`**, the guards would have *refused the cross-oracle
+diff* (or required `ORACLE_REBASE=1` for the deliberate re-seed) instead of the
+catastrophic guard blocking the promote that fixes the baseline.
+
+Neither PR bumped it. #2463 in particular changed the scoring in
+`test262-worker.mjs`/`test262-shared.ts` while leaving `ORACLE_VERSION = 1`.
+
+## The 3-guard surface (a lever/excusal must reach ALL THREE)
+
+A verdict-logic temporary-lever or excusal that reaches only *some* of the
+baseline-diffing guards leaves the queue red. There are **THREE** required
+checks that diff against the baseline on `merge_group` — an earlier remediation
+plan wired only two of them:
+
+1. **Catastrophic regression guard (#1668)** — `test262-sharded.yml` (~line 674),
+   inside the required **"merge shard reports"** job. `CATASTROPHIC_REGRESSION_THRESHOLD`
+   (200; raised to 500 during the −439 dance). Counts host `pass→fail` with a
+   changed wasm-hash vs the host baseline.
+2. **Standalone regression guard (#1897)** — `test262-sharded.yml` (~line 748),
+   also inside "merge shard reports". A much **tighter** floor
+   (`STANDALONE_REGRESSION_TOLERANCE`) for the standalone lane.
+3. **`check for test262 regressions`** — the `regression-gate` job in
+   `test262-sharded.yml` (~line 945, name at ~line 956). The fine-grained
+   regression gate; **also** blocks the merge queue and **also** diffs against
+   the baseline. This is the third guard the earlier plan missed.
+
+> If you ever *must* run the lever dance again, the levers/excusals must reach
+> **all three** or the queue stays red. This is the core argument for preferring
+> the oracle bump: one bump makes `diff-test262.ts` refuse the cross-oracle diff
+> *uniformly*, so all three guards are satisfied at once.
+
+## Recommendation
+
+**Intentional honesty-reclassifications should bump `oracle_version`, not run
+the fragile lever dance.** The two landing paths for a verdict-logic change:
+
+- **(a) Bump `ORACLE_VERSION`** in `tests/test262-oracle-version.ts` (increment
+  the integer + append to `ORACLE_VERSION_HISTORY`) and land the PR with
+  `ORACLE_REBASE=1` so the diff gate accepts the cross-version re-baseline and
+  `promote-baseline` re-seeds at the new version. **Clean, single-lever, reaches
+  all three guards at once.** ← preferred.
+- **(b) The coordinated temporary-lever dance** (raise guard + regression budget
+  + lower standalone floor, land, promote, revert). Fragile; must reach all
+  three guards; use only when a bump is somehow inappropriate.
+
+## Prevention (this PR)
+
+A `quality`-lane gate — `scripts/check-verdict-oracle-bump.mjs`
+(`pnpm run check:verdict-oracle`) — flags any PR that changes verdict logic
+without bumping the oracle:
+
+- **Verdict-logic file surface** (grep-derived authoritative set):
+  - PURE (any substantive change is a signal): `scripts/negative-verdict.mjs`.
+  - MIXED (only a **verdict-signal** line counts): `scripts/test262-worker.mjs`,
+    `tests/test262-shared.ts`, `tests/test262-vitest.test.ts`,
+    `tests/test262-runner.ts`.
+  - Oracle file (the bump target): `tests/test262-oracle-version.ts`.
+- **Verdict-signal detection** (line-level, low false-positive): a changed line
+  that SETS a verdict `status` literal, touches the `vacuous` marker, or touches
+  the negative-test / `classifyError` machinery. `status ===` / `.status` READs
+  are deliberately **not** matched, so report aggregation or a guard comparing a
+  status does not trip the gate. A comment fix or worker-recycle tweak to the
+  mixed files passes clean.
+- **Bump detection:** the check parses `ORACLE_VERSION` at the diff base and at
+  HEAD and requires `head > base`.
+- **Verdict:**
+  - no verdict-logic file changed, or no verdict-signal line → **pass**;
+  - verdict-signal change **with** an oracle bump → **pass** (correct: the
+    honesty reclassification bumped the oracle);
+  - verdict-signal change **without** a bump but **with** an in-diff
+    `// oracle-version-exempt: <reason>` comment → **warn** (trusts the author's
+    assertion that zero existing rows flip, e.g. the #2912 dead-ternary case);
+  - verdict-signal change **without** a bump **and without** the override →
+    **HARD FAIL**, pointing at the bump procedure.
+- **Why the override is in-diff, not the PR body:** the PR body is absent in
+  `merge_group`, so a body-based override (`contains(github.event.pull_request.body, …)`)
+  would pass on `pull_request` then FAIL in the queue — re-creating the very
+  wedge this gate prevents. The override token lives in the DIFF, so it survives
+  the `merge_group` re-run.
+
+Both wedge shapes (the #2463 vacuity scorer and the −439 negative-verdict change)
+are exercised as HARD-FAIL cases in `tests/issue-3003.test.ts`; the #2912
+dead-ternary (0-flip) case is exercised as the WARN/override case.
+
+## Acceptance criteria
+
+- [x] Postmortem documents both wedges, the shared root cause, the two
+      resolution paths, and the 3-guard surface.
+- [x] `quality`-lane check fails a verdict-logic change with no oracle bump and
+      no override; passes a no-op/unrelated PR and a bumped/overridden change.
+- [x] Unit test (`tests/issue-3003.test.ts`) covers both wedge shapes + the
+      override path.
+- [x] Check verified not to false-positive on unrelated PRs (no-op diff) and to
+      fail on a scorer-diff-without-bump.
+
+## Test Results
+
+- `pnpm exec vitest run tests/issue-3003.test.ts` → 10/10 pass.
+- CLI smoke: `node scripts/check-verdict-oracle-bump.mjs --base origin/main` on
+  this PR (touches no verdict-logic files) exits 0; a synthetic
+  scorer-diff-without-bump exits 1 (see `## Verification`).

--- a/scripts/check-verdict-oracle-bump.mjs
+++ b/scripts/check-verdict-oracle-bump.mjs
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+// check-verdict-oracle-bump.mjs — a test262 VERDICT-LOGIC change must bump the
+// #2096 ORACLE_VERSION (or consciously exempt itself). (#3003)
+//
+// WHY THIS EXISTS (the queue-wedge it prevents):
+//   When a PR changes how a per-test test262 result is SCORED — the verdict
+//   logic (pass/fail/compile_error), the negative-test matcher, or a vacuity/
+//   honesty reclassifier — the new-policy results diff against the OLD-policy
+//   committed baseline as a mass pass→fail cluster. If the change does NOT bump
+//   the `oracle_version`, the push-to-main run's Catastrophic regression guard
+//   (#1668) sees the huge delta and FAILS → `promote-baseline` never runs →
+//   the baseline stays old-policy → EVERY subsequent merge_group diffs
+//   new-policy-vs-old-policy → the identical cluster signature → auto-park →
+//   the whole merge queue wedges against a baseline that can only be fixed by
+//   the very promote the guard is blocking. This happened TWICE in 2026-07 (the
+//   −439 strict-negative-verdict change and PR #2463's vacuity scorer). See the
+//   postmortem in plan/issues/3003-*.md.
+//
+//   Bumping the oracle is the clean fix: `diff-test262.ts` REFUSES a
+//   cross-oracle_version diff (unless ORACLE_REBASE=1), so the guards treat the
+//   change as a re-baseline instead of catastrophic-blocking the promote.
+//
+// THIS GATE (wired into the required `quality` job): for the current PR/commit
+// diff vs origin/main —
+//   • if a verdict-logic file changed in a way that touches VERDICT-SIGNAL
+//     lines (a status verdict literal, the `vacuous` marker, the negative-test
+//     matcher, classifyError, etc.), AND
+//   • the diff does NOT raise ORACLE_VERSION (in tests/test262-oracle-version.ts),
+//     AND
+//   • the diff carries no `oracle-version-exempt:` in-diff override,
+//   → HARD FAIL, pointing at the bump procedure.
+//
+// FALSE-POSITIVE DISCIPLINE: the mixed files (test262-worker.mjs,
+// test262-shared.ts, the runners) contain a LOT of non-verdict code (worker
+// recycling, disk cache, pool plumbing, comments). A change there only trips
+// the gate if the CHANGED lines carry a verdict-signal token — a comment fix or
+// a recycle-logic tweak passes clean. And a legit verdict-touching change that
+// the author has confirmed flips ZERO existing rows (e.g. the #2912
+// dead-ternary deletion) can pass by adding an in-diff comment:
+//     // oracle-version-exempt: <reason no existing rows flip>
+// The override lives in the DIFF (not the PR body) on purpose: the PR body is
+// absent in `merge_group`, so a body-based override would pass on `pull_request`
+// then FAIL in the queue — re-creating the very wedge this gate prevents.
+//
+// Usage:
+//   node scripts/check-verdict-oracle-bump.mjs            # gate (CI)
+//   node scripts/check-verdict-oracle-bump.mjs --base REF # diff against REF
+//   node scripts/check-verdict-oracle-bump.mjs --json
+//
+// Safe by construction: if the diff base can't be resolved it falls back to
+// HEAD^, then exits 0 with a note — it never blocks a build it can't reason
+// about.
+
+import { execSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// ── The authoritative verdict-logic surface (grep-derived, #3003) ───────────
+// PURE: files whose entire job is verdict logic — ANY substantive (non-comment)
+// changed line is a verdict signal.
+export const PURE_VERDICT_FILES = ["scripts/negative-verdict.mjs"];
+
+// MIXED: files that compute per-test verdicts but also carry lots of unrelated
+// machinery — only a change to a VERDICT-SIGNAL line counts.
+export const MIXED_VERDICT_FILES = [
+  "scripts/test262-worker.mjs",
+  "tests/test262-shared.ts",
+  "tests/test262-vitest.test.ts",
+  "tests/test262-runner.ts",
+];
+
+// The single source of truth for the oracle version (#2096). Raising the
+// integer here is the "bump" this gate looks for.
+export const ORACLE_FILE = "tests/test262-oracle-version.ts";
+
+// A changed line is a verdict signal when it SETS a verdict status literal,
+// touches the vacuity marker, or touches the negative-test / error
+// classification verdict machinery. The distinguisher is what FOLLOWS `status`:
+// a `status:` object field or a `status =` assignment (single `=`, negative
+// lookahead on `==`) to a known verdict literal is a SET; `status ===`,
+// `status ==`, `status;`, `.status`-property READs are NOT matched — so report
+// aggregation or a guard that merely COMPARES a status does not trip the gate.
+// The `[^\n]*?` between the `status:`/`status =` anchor and the verdict literal
+// lets a CONDITIONAL verdict match too — e.g. the historical dead ternary
+// `status: hasEarlyError ? "pass" : "pass"` (#2912) — while staying on one line.
+export const VERDICT_SIGNAL_RE =
+  /\bvacuous\b|status\s*(?::|=(?!=))[^\n]*?["'`](?:pass|fail|compile_error|compile_timeout|runtime_error|timeout|skip|error|todo)["'`]|\bnegativeCompile(?:ErrorMatches|SucceededVerdict)\b|\bclassifyError\b|\bnegative\.type\b|\bexpectedErrorType\b|\bES_EARLY_ERROR_CODES\b/;
+
+// In-diff override token (see header). Placed as a comment next to the change.
+export const OVERRIDE_RE = /oracle-version-exempt\s*:/i;
+
+const ALL_VERDICT_FILES = [...PURE_VERDICT_FILES, ...MIXED_VERDICT_FILES];
+
+// Non-substantive = blank or a pure comment line. Used for the PURE files so a
+// doc/comment tweak to negative-verdict.mjs does not demand an oracle bump.
+function isSubstantive(line) {
+  const t = line.trim();
+  if (t === "") return false;
+  if (t.startsWith("//") || t.startsWith("*") || t.startsWith("/*") || t.startsWith("*/")) return false;
+  return true;
+}
+
+/**
+ * Pure evaluator — no git, no fs. Unit-testable (tests/issue-3003.test.ts).
+ *
+ * @param {{
+ *   changedFiles: string[],
+ *   addedLinesByFile: Record<string, string[]>,   // '+' lines (no prefix)
+ *   removedLinesByFile: Record<string, string[]>, // '-' lines (no prefix)
+ *   baseOracle: number,
+ *   headOracle: number,
+ * }} input
+ * @returns {{ triggered: boolean, signals: Array<{file:string,line:string}>,
+ *   bumped: boolean, override: boolean, verdict: "pass"|"warn"|"fail",
+ *   baseOracle: number, headOracle: number }}
+ */
+export function evaluateVerdictOracle(input) {
+  const { changedFiles, addedLinesByFile, removedLinesByFile, baseOracle, headOracle } = input;
+
+  const verdictFiles = changedFiles.filter((f) => ALL_VERDICT_FILES.includes(f));
+  if (verdictFiles.length === 0) {
+    return { triggered: false, signals: [], bumped: false, override: false, verdict: "pass", baseOracle, headOracle };
+  }
+
+  const signals = [];
+  for (const f of verdictFiles) {
+    const changed = [...(addedLinesByFile[f] || []), ...(removedLinesByFile[f] || [])];
+    if (PURE_VERDICT_FILES.includes(f)) {
+      const hit = changed.find((l) => isSubstantive(l));
+      if (hit) signals.push({ file: f, line: hit.trim() });
+    } else {
+      const hit = changed.find((l) => VERDICT_SIGNAL_RE.test(l));
+      if (hit) signals.push({ file: f, line: hit.trim() });
+    }
+  }
+
+  if (signals.length === 0) {
+    // Verdict-logic files changed, but only in incidental (non-verdict) lines.
+    return { triggered: true, signals: [], bumped: false, override: false, verdict: "pass", baseOracle, headOracle };
+  }
+
+  const bumped = Number(headOracle) > Number(baseOracle);
+  // Override must be an ADDED line (present in the HEAD tree), scanned across
+  // every changed file so the exemption can sit wherever it reads best.
+  const override = Object.values(addedLinesByFile).some((lines) => lines.some((l) => OVERRIDE_RE.test(l)));
+
+  let verdict;
+  if (bumped) verdict = "pass";
+  else if (override) verdict = "warn";
+  else verdict = "fail";
+
+  return { triggered: true, signals, bumped, override, verdict, baseOracle, headOracle };
+}
+
+// ── CLI: gather git inputs, then delegate to evaluateVerdictOracle ──────────
+
+const argv = process.argv.slice(2);
+const has = (f) => argv.includes(f);
+const opt = (f, d) => {
+  const i = argv.indexOf(f);
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : d;
+};
+const JSON_OUT = has("--json");
+const BASE_REF = opt("--base", process.env.VERDICT_ORACLE_BASE || "origin/main");
+const REPO = process.env.REPO_ROOT || process.cwd();
+
+function tryGit(cmd) {
+  try {
+    return execSync(cmd, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], cwd: REPO });
+  } catch {
+    return null;
+  }
+}
+
+// Parse the integer `export const ORACLE_VERSION = N;` out of the oracle file
+// text. Returns 0 when the file/const is absent (first introduction).
+function parseOracle(text) {
+  if (!text) return 0;
+  const m = text.match(/export\s+const\s+ORACLE_VERSION\s*=\s*(\d+)/);
+  return m ? Number(m[1]) : 0;
+}
+
+// Split a `git diff --unified=0` blob into +/- content lines per intent.
+function diffLines(base, file) {
+  const blob = tryGit(`git diff --unified=0 ${base}...HEAD -- ${file}`);
+  const added = [];
+  const removed = [];
+  if (!blob) return { added, removed };
+  for (const raw of blob.split("\n")) {
+    if (raw.startsWith("+++") || raw.startsWith("---") || raw.startsWith("@@")) continue;
+    if (raw.startsWith("+")) added.push(raw.slice(1));
+    else if (raw.startsWith("-")) removed.push(raw.slice(1));
+  }
+  return { added, removed };
+}
+
+function resolveBase() {
+  for (const ref of [BASE_REF, "HEAD^"]) {
+    // A ref resolves iff we can name-only-diff against it.
+    if (tryGit(`git diff --name-only ${ref}...HEAD`) !== null) return ref;
+  }
+  return null;
+}
+
+function log(s) {
+  if (!JSON_OUT) console.log(s);
+}
+
+function main() {
+  const base = resolveBase();
+  if (base === null) {
+    log("check-verdict-oracle-bump: could not resolve a diff base — skipping (no build block).");
+    if (JSON_OUT) console.log(JSON.stringify({ skipped: "no diff base", verdict: "pass" }));
+    process.exit(0);
+  }
+
+  const nameOnly = tryGit(`git diff --name-only --diff-filter=ACM ${base}...HEAD`) || "";
+  const changedFiles = nameOnly
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const addedLinesByFile = {};
+  const removedLinesByFile = {};
+  for (const f of changedFiles) {
+    if (!ALL_VERDICT_FILES.includes(f)) continue;
+    const { added, removed } = diffLines(base, f);
+    addedLinesByFile[f] = added;
+    removedLinesByFile[f] = removed;
+  }
+
+  const baseOracle = parseOracle(tryGit(`git show ${base}:${ORACLE_FILE}`));
+  const headOracle = parseOracle(
+    existsSync(join(REPO, ORACLE_FILE)) ? readFileSync(join(REPO, ORACLE_FILE), "utf8") : "",
+  );
+
+  const result = evaluateVerdictOracle({ changedFiles, addedLinesByFile, removedLinesByFile, baseOracle, headOracle });
+
+  if (JSON_OUT) {
+    console.log(JSON.stringify({ base, ...result }, null, 2));
+    process.exit(result.verdict === "fail" ? 1 : 0);
+  }
+
+  log(`check-verdict-oracle-bump (#3003): diff vs ${base}; ORACLE_VERSION ${baseOracle} → ${headOracle}.`);
+
+  if (!result.triggered) {
+    log("  ✓ no verdict-logic files changed.");
+    process.exit(0);
+  }
+  if (result.signals.length === 0) {
+    log("  ✓ verdict-logic file(s) changed, but no verdict-signal lines — no oracle bump required.");
+    process.exit(0);
+  }
+
+  log("  verdict-signal changes detected:");
+  for (const s of result.signals) log(`    • ${s.file}: ${s.line}`);
+
+  if (result.verdict === "pass") {
+    log(`  ✓ ORACLE_VERSION bumped ${baseOracle} → ${headOracle} — the guards will treat this as a re-baseline.`);
+    process.exit(0);
+  }
+  if (result.verdict === "warn") {
+    log("  ⚠ verdict-signal change WITHOUT an oracle bump, but carries an `oracle-version-exempt:` override.");
+    log("    Trusting the author's assertion that ZERO existing rows flip. If any row DOES flip, the merge");
+    log("    queue will wedge on the old-policy baseline (see #3003) — bump ORACLE_VERSION instead.");
+    process.exit(0);
+  }
+
+  log("");
+  log("  ✖ FAIL: a test262 verdict-logic change does NOT bump ORACLE_VERSION and has no override.");
+  log("");
+  log("  A change to how a per-test result is SCORED diffs new-policy-vs-old-policy as a mass");
+  log("  pass→fail cluster. Without an oracle bump this trips the #1668 catastrophic guard on the");
+  log("  push-to-main run, `promote-baseline` never runs, and the merge queue WEDGES (#3003).");
+  log("");
+  log("  Do ONE of:");
+  log(`    (a) Bump ORACLE_VERSION in ${ORACLE_FILE} (increment the integer + append to`);
+  log("        ORACLE_VERSION_HISTORY) and land the PR with ORACLE_REBASE=1 so the diff gate");
+  log("        accepts the cross-version re-baseline. This is the clean path.");
+  log("    (b) If you have CONFIRMED this change flips ZERO existing rows, add an in-diff comment");
+  log("        `// oracle-version-exempt: <reason>` next to the change to consciously override.");
+  log("");
+  process.exit(1);
+}
+
+// Only run the CLI when invoked directly (not when imported by the test).
+if (process.argv[1] && process.argv[1].endsWith("check-verdict-oracle-bump.mjs")) {
+  main();
+}

--- a/tests/issue-3003.test.ts
+++ b/tests/issue-3003.test.ts
@@ -1,0 +1,152 @@
+// #3003 — a test262 verdict-logic change must bump ORACLE_VERSION.
+//
+// Exercises the pure evaluator behind scripts/check-verdict-oracle-bump.mjs so
+// the queue-wedge prevention gate is itself covered. The two 2026-07 wedges (the
+// −439 strict-negative-verdict change and PR #2463's vacuity scorer) are the
+// canonical "verdict-signal change without an oracle bump" cases: they MUST fail.
+import { describe, expect, it } from "vitest";
+
+import {
+  evaluateVerdictOracle,
+  MIXED_VERDICT_FILES,
+  OVERRIDE_RE,
+  PURE_VERDICT_FILES,
+  VERDICT_SIGNAL_RE,
+} from "../scripts/check-verdict-oracle-bump.mjs";
+
+// Convenience: build the evaluator input from a compact per-file spec.
+function evalDiff(spec: {
+  added?: Record<string, string[]>;
+  removed?: Record<string, string[]>;
+  baseOracle?: number;
+  headOracle?: number;
+}) {
+  const added = spec.added || {};
+  const removed = spec.removed || {};
+  const changedFiles = Array.from(new Set([...Object.keys(added), ...Object.keys(removed)]));
+  return evaluateVerdictOracle({
+    changedFiles,
+    addedLinesByFile: added,
+    removedLinesByFile: removed,
+    baseOracle: spec.baseOracle ?? 1,
+    headOracle: spec.headOracle ?? 1,
+  });
+}
+
+describe("#3003 verdict-oracle bump gate", () => {
+  it("VERDICT_SIGNAL_RE matches verdict SETs but not READs", () => {
+    expect(VERDICT_SIGNAL_RE.test('status: "fail",')).toBe(true);
+    expect(VERDICT_SIGNAL_RE.test('result.status = "compile_error";')).toBe(true);
+    expect(VERDICT_SIGNAL_RE.test("vacuous: true,")).toBe(true);
+    expect(VERDICT_SIGNAL_RE.test("const m = negativeCompileErrorMatches(x, y, z);")).toBe(true);
+    // reads / comparisons must NOT trip the gate (report aggregation, guards)
+    expect(VERDICT_SIGNAL_RE.test('if (record.status === "pass") count++;')).toBe(false);
+    expect(VERDICT_SIGNAL_RE.test("const p = row.status;")).toBe(false);
+    expect(VERDICT_SIGNAL_RE.test("// bump the pass total")).toBe(false);
+  });
+
+  it("passes when no verdict-logic file changed", () => {
+    const r = evalDiff({ added: { "src/codegen/expressions.ts": ['emit("i32.add");'] } });
+    expect(r.triggered).toBe(false);
+    expect(r.verdict).toBe("pass");
+  });
+
+  it("passes when a verdict-logic file changed only in incidental (non-verdict) lines", () => {
+    // worker recycle / comment tweak — no verdict-signal token, no bump needed.
+    const r = evalDiff({
+      added: {
+        "scripts/test262-worker.mjs": [
+          "// clarify the recycle comment",
+          "const forceRecycleReason = driftReason || null;",
+        ],
+      },
+    });
+    expect(r.triggered).toBe(true);
+    expect(r.signals).toHaveLength(0);
+    expect(r.verdict).toBe("pass");
+  });
+
+  it("FAILS PR #2463's vacuity scorer shape (verdict change, no oracle bump)", () => {
+    const r = evalDiff({
+      added: {
+        "scripts/test262-worker.mjs": [
+          "          vacuous: true,",
+          '          error: "vacuous: harness-wrapper callback never executed (#2940) — no assertion ran",',
+        ],
+        "tests/test262-shared.ts": ["    vacuous: metadata?.vacuous || undefined,"],
+      },
+      baseOracle: 1,
+      headOracle: 1, // NOT bumped — this is the wedge
+    });
+    expect(r.verdict).toBe("fail");
+    expect(r.bumped).toBe(false);
+    expect(r.signals.length).toBeGreaterThan(0);
+  });
+
+  it("FAILS the −439 strict-negative-verdict shape (negative-verdict.mjs change, no bump)", () => {
+    const r = evalDiff({
+      added: {
+        "scripts/negative-verdict.mjs": [
+          "  if (!ES_EARLY_ERROR_CODES.has(code)) return false;",
+          "  return expectedType === raisedType;",
+        ],
+      },
+      baseOracle: 1,
+      headOracle: 1,
+    });
+    expect(r.verdict).toBe("fail");
+  });
+
+  it("PASSES the same verdict change once ORACLE_VERSION is bumped", () => {
+    const r = evalDiff({
+      added: { "scripts/test262-worker.mjs": ["          vacuous: true,"] },
+      baseOracle: 1,
+      headOracle: 2, // bumped — the guards will re-baseline
+    });
+    expect(r.verdict).toBe("pass");
+    expect(r.bumped).toBe(true);
+  });
+
+  it("WARNS (not fails) on a verdict-signal change that carries the in-diff override", () => {
+    // The #2912 dead-ternary case: verdict logic touched, but author confirmed
+    // ZERO existing rows flip, so an in-diff `oracle-version-exempt:` overrides.
+    const r = evalDiff({
+      added: {
+        "scripts/negative-verdict.mjs": [
+          "  // oracle-version-exempt: deletes dead ternary; SyntaxError population unchanged (0 flips)",
+          "  return negativeCompileErrorMatches(expectedType, errorCodes, message);",
+        ],
+      },
+      baseOracle: 1,
+      headOracle: 1,
+    });
+    expect(r.verdict).toBe("warn");
+    expect(r.override).toBe(true);
+  });
+
+  it("comment-only edit to a PURE verdict file needs no bump", () => {
+    const r = evalDiff({
+      added: { "scripts/negative-verdict.mjs": ["  // clarify the phase-gate docstring", "   "] },
+      baseOracle: 1,
+      headOracle: 1,
+    });
+    expect(r.signals).toHaveLength(0);
+    expect(r.verdict).toBe("pass");
+  });
+
+  it("catches a verdict change expressed only as a DELETION (removed line)", () => {
+    const r = evalDiff({
+      removed: { "scripts/test262-worker.mjs": ['        status: hasEarlyError ? "pass" : "pass",'] },
+      baseOracle: 1,
+      headOracle: 1,
+    });
+    expect(r.verdict).toBe("fail");
+  });
+
+  it("exposes the authoritative file surface + override token as constants", () => {
+    expect(PURE_VERDICT_FILES).toContain("scripts/negative-verdict.mjs");
+    expect(MIXED_VERDICT_FILES).toContain("scripts/test262-worker.mjs");
+    expect(MIXED_VERDICT_FILES).toContain("tests/test262-shared.ts");
+    expect(OVERRIDE_RE.test("// oracle-version-exempt: because")).toBe(true);
+  });
+});


### PR DESCRIPTION
## What & why

Postmortem + prevention for the **two intentional-reclassification queue wedges** in the last 24h. Both had the **same root cause**: a PR changed test262 **verdict logic** (how a per-test result is scored) without bumping `oracle_version` (#2096), so the new-policy results diffed against the **old-policy** committed baseline as a mass `pass→fail` cluster — tripping the #1668 catastrophic guard, blocking `promote-baseline`, and wedging the queue against an un-promotable baseline.

- **Wedge 1** — the −439 strict-negative-verdict change (#2920): handled with the fragile temporary-lever dance (raise #1668 guard 200→500 + `INTENTIONAL_REGRESSION_BUDGET` + lower standalone floor, land, promote, revert).
- **Wedge 2** — PR #2463's vacuity scorer (merged `0670ea4`, #2940): did NOT do the dance → push-to-main run failed #1668 → `promote-baseline` never ran → every merge_group diffed new-vs-old-policy → identical cluster signature `d822f85a0aabd092` → auto-park → wedge. Self-resolved once #2528 + a scheduled refresh promoted the new-policy baseline (baselines-repo `e3d8167` from main `697ce0e`, a descendant of #2463).

## Root prevention

The clean fix is to **bump `oracle_version`**: `diff-test262.ts` refuses a cross-oracle diff (or requires `ORACLE_REBASE=1`), so the guards treat the change as a re-baseline instead of catastrophic-blocking the promote. Neither PR bumped it.

## Deliverables

1. **Postmortem** — `plan/issues/3003-*.md`: both wedges, shared root cause, the two resolution paths (lever-dance vs. oracle bump), and the **3-guard surface** a lever/excusal must reach ALL of — Catastrophic (#1668) + Standalone (#1897) + `check for test262 regressions` (the `regression-gate` job) — an earlier plan wired only 2.
2. **Prevention gate** — `scripts/check-verdict-oracle-bump.mjs` (`pnpm run check:verdict-oracle`), wired into the required `quality` job. Hard-fails a **verdict-signal** change to the scorer/verdict-logic files (`scripts/test262-worker.mjs`, `tests/test262-shared.ts`, `scripts/negative-verdict.mjs`, the runners) that neither bumps `ORACLE_VERSION` nor carries an in-diff `// oracle-version-exempt: <reason>` override. Line-level signal match (verdict `status` SETs / `vacuous` / negative-matcher / `classifyError`; `.status` READs excluded) keeps incidental changes from false-positiving. The override is **in-diff, not PR body**, so it survives the `merge_group` re-run (a body-based override would pass on pull_request then fail in the queue — the very wedge this prevents).
3. **Test** — `tests/issue-3003.test.ts` (10 cases): both wedge shapes → hard fail; #2912 0-flip dead-ternary → warn/override; incidental/comment changes → pass.

## Verification

- `pnpm exec vitest run tests/issue-3003.test.ts` → 10/10.
- `pnpm run typecheck`, prettier, biome → clean.
- CLI smoke, full git path: no-op diff (this PR) → exit 0; synthetic scorer-diff-without-bump → exit 1; same +bump → exit 0; same +in-diff override → exit 0 (warn).

Closes #3003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS