### PR TITLE
refactor(#1916) S3b batch 6: flip property/member-dispatch to stable func handles

### DIFF
--- a/src/codegen/dyn-read.ts
+++ b/src/codegen/dyn-read.ts
@@ -38,6 +38,7 @@
 import type { Instr, ValType } from "../ir/types.js";
 import type { CodegenContext, FunctionContext } from "./context/types.js";
 import { addFuncType } from "./registry/types.js";
+import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3) stable-regime minting
 import { ensureGetUndefined } from "./expressions/late-imports.js";
 import { ensureObjectRuntime } from "./object-runtime.js";
 import { stringConstantExternrefInstrs } from "./native-strings.js";
@@ -109,8 +110,8 @@ export function ensureDynReadHelpers(ctx: CodegenContext): void {
   ): void {
     if (ctx.funcMap.has(name)) return;
     const typeIdx = addFuncType(ctx, params, results, name);
-    const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
-    ctx.mod.functions.push({ name, typeIdx, locals, body, exported: false } as never);
+    const funcIdx = mintDefinedFunc(ctx);
+    pushDefinedFunc(ctx, funcIdx, { name, typeIdx, locals, body, exported: false } as never);
     ctx.funcMap.set(name, funcIdx);
   }
 

--- a/src/codegen/member-get-dispatch.ts
+++ b/src/codegen/member-get-dispatch.ts
@@ -48,7 +48,7 @@ import { addStringConstantGlobal } from "./registry/imports.js";
 import { addFuncType } from "./registry/types.js";
 import { addUnionImportsViaRegistry, ensureLateImport, flushLateImportShifts } from "./shared.js";
 import { coercionInstrs } from "./type-coercion.js";
-import { definedFuncAt } from "./func-space.js"; // (#1916 S2) positional-read chokepoint
+import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S2/S3) positional-read chokepoint + stable-regime minting
 
 /** Mangle a property name into the reserved member-get dispatcher name. */
 function dispatcherName(propName: string): string {
@@ -119,8 +119,8 @@ export function reserveMemberGetDispatch(
   if (fctx) flushLateImportShifts(ctx, fctx);
 
   const typeIdx = addFuncType(ctx, [{ kind: "externref" }], [{ kind: "externref" }], "$member_get_dispatch_type");
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
-  ctx.mod.functions.push({
+  const funcIdx = mintDefinedFunc(ctx);
+  pushDefinedFunc(ctx, funcIdx, {
     name,
     typeIdx,
     locals: [],

--- a/src/codegen/member-set-dispatch.ts
+++ b/src/codegen/member-set-dispatch.ts
@@ -43,7 +43,7 @@ import { addStringConstantGlobal } from "./registry/imports.js";
 import { addFuncType } from "./registry/types.js";
 import { addUnionImportsViaRegistry, ensureLateImport, flushLateImportShifts } from "./shared.js";
 import { buildVecFromExternMaterializer, coercionInstrs, getVecInfo } from "./type-coercion.js";
-import { definedFuncAt } from "./func-space.js"; // (#1916 S2) positional-read chokepoint
+import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S2/S3) positional-read chokepoint + stable-regime minting
 
 /**
  * Mangle a property name + fallback strictness into the reserved dispatcher name.
@@ -108,8 +108,8 @@ export function reserveMemberSetDispatch(
   if (fctx) flushLateImportShifts(ctx, fctx);
 
   const typeIdx = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], [], "$member_set_dispatch_type");
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
-  ctx.mod.functions.push({
+  const funcIdx = mintDefinedFunc(ctx);
+  pushDefinedFunc(ctx, funcIdx, {
     name,
     typeIdx,
     locals: [],

--- a/src/codegen/object-ops.ts
+++ b/src/codegen/object-ops.ts
@@ -24,6 +24,7 @@ import { addUnionImports, cacheStringLiterals, getOrRegisterTupleType, resolveWa
 import { ensureObjectRuntime } from "./object-runtime.js";
 import { addStringConstantGlobal, ensureExnTag } from "./registry/imports.js";
 import { addFuncType, getArrTypeIdxFromVec, getOrRegisterRefCellType, getOrRegisterVecType } from "./registry/types.js";
+import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S3) stable-regime minting
 import type { InnerResult } from "./shared.js";
 import { coerceType, compileExpression, compileStatement, ensureLateImport, flushLateImportShifts } from "./shared.js";
 import {
@@ -1940,7 +1941,7 @@ export function compileObjectDefineProperty(
         }
 
         const getterTypeIdx = addFuncType(ctx, getterParams, getterResults, `${getterName}_type`);
-        const getterFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+        const getterFuncIdx = mintDefinedFunc(ctx);
         ctx.funcMap.set(getterName, getterFuncIdx);
 
         const getterFunc: WasmFunction = {
@@ -1950,7 +1951,7 @@ export function compileObjectDefineProperty(
           body: [],
           exported: false,
         };
-        ctx.mod.functions.push(getterFunc);
+        pushDefinedFunc(ctx, getterFuncIdx, getterFunc);
 
         // Compile getter body
         const getterFctx: FunctionContext = {
@@ -2030,7 +2031,7 @@ export function compileObjectDefineProperty(
         }
 
         const setterTypeIdx = addFuncType(ctx, setterParams, [], `${setterName}_type`);
-        const setterFuncIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+        const setterFuncIdx = mintDefinedFunc(ctx);
         ctx.funcMap.set(setterName, setterFuncIdx);
 
         const setterFunc: WasmFunction = {
@@ -2040,7 +2041,7 @@ export function compileObjectDefineProperty(
           body: [],
           exported: false,
         };
-        ctx.mod.functions.push(setterFunc);
+        pushDefinedFunc(ctx, setterFuncIdx, setterFunc);
 
         // Compile setter body
         const setterFctxParams: { name: string; type: ValType }[] = [

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -16,7 +16,7 @@ import {
   isStringWrapperType,
 } from "../checker/type-mapper.js";
 import type { FieldDef, Instr, ValType } from "../ir/types.js";
-import { definedFuncAt } from "./func-space.js";
+import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
 import { emitBoundsCheckedArrayGet } from "./array-methods.js";
 import { emitHoleToUndefined } from "./array-holes.js"; // (#2001 S1)
 import { classMemberFuncKey } from "./class-member-keys.js"; // (#1983) collision-free class-member funcMap keys
@@ -1138,8 +1138,8 @@ function ensureStandaloneBuiltinStaticMethodClosure(
       closureFctx.body.push({ op: "call", funcIdx: gopdIdx });
     }
 
-    funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
-    ctx.mod.functions.push({
+    funcIdx = mintDefinedFunc(ctx);
+    pushDefinedFunc(ctx, funcIdx, {
       name: funcName,
       typeIdx: wrapperTypes.liftedFuncTypeIdx,
       locals: closureFctx.locals,


### PR DESCRIPTION
## #1916 S3b batch 6 — property-access / member-dispatch to stable handles

Continues the two-regime stable-func-handle migration (dev-1916o). Mechanical batch flip; **byte-identity-proven**, zero real regression.

### What
Flip the property-access / member-dispatch family — `object-ops.ts` (object-literal getter+setter producers), `property-access.ts` (lifted accessor wrapper), `member-get-dispatch.ts` + `member-set-dispatch.ts` (the reserved `__{get,set}_member_<name>` deferred-fill dispatchers), `dyn-read.ts` (the `__dyn_get`/`__dyn_has` M0 substrate) — from the inline live-regime mint to `mintDefinedFunc` / `pushDefinedFunc`.

### Why it's safe
All six sites are the simple mint→push shape: no `funcIdx + k` sibling derivation, no intervening `mod.functions` push between mint and push (object-ops fills `body:[]` in place *after* the push — position unaffected). The member-dispatch reserve sites keep their pre-mint `flushLateImportShifts` (harmless with stable handles; removed in S3-final); because the reserved handle is now layout-independent, the finalize-time fill (`definedFuncAt`) resolves it correctly by construction — retiring the #2681/#2664 over-shift hazard's reason to exist. `dyn-read`'s helpers stay `ctx.usesDynRead`-gated (M0: never emitted).

### Proof (the safety net)
- **Corpus byte-IDENTICAL** over the 63-record playground + probe corpus across {gc, standalone, wasi} via `scripts/prove-emit-identity.mjs`. A new `object-access` probe exercises object-literal getters/setters + dynamic `any`-member get/set (standalone 65569 B).
- `tsc --noEmit` clean.
- #1916 acceptance + `issue-1712-dynamic-dispatch` / `define-property-patterns` / `hasownproperty-call` suites green.
- The pre-existing `getters-setters` / `computed-setter-class` / `compound-assignment-property` `string_constants` **harness-instantiation** failures reproduce identically on clean `origin/main` (verified via file-revert control) — a test-harness import-wiring issue, not this flip's doing.

Does NOT touch S3-final (shifter deletion) — that stays lead-coordinated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS