### PR TITLE
refactor(#1916) S3b batch 7: flip object-runtime to stable func handles

### DIFF
--- a/src/codegen/object-runtime.ts
+++ b/src/codegen/object-runtime.ts
@@ -73,7 +73,7 @@ import { reserveAccessorGetDriver, reserveAccessorSetDriver } from "./accessor-d
 import { ensureSymbolCarrier } from "./symbol-native.js";
 import { reserveArrayToPrimitiveString } from "./array-to-primitive.js";
 import { reserveClassToPrimitive } from "./class-to-primitive.js";
-import { definedFuncAt } from "./func-space.js"; // (#1916 S2) positional-read chokepoint
+import { definedFuncAt, mintDefinedFunc, pushDefinedFunc } from "./func-space.js"; // (#1916 S2/S3) positional-read chokepoint + stable-regime minting
 
 /** Initial `$PropMap` capacity. Must be a power of two (mask = cap - 1). */
 const INITIAL_CAP = 8;
@@ -424,9 +424,9 @@ export function ensureObjectRuntime(ctx: CodegenContext): ObjectRuntimeTypes {
     body: Instr[],
   ): number => {
     const typeIdx = addFuncType(ctx, paramTypes, resultTypes);
-    const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+    const funcIdx = mintDefinedFunc(ctx);
     ctx.funcMap.set(name, funcIdx);
-    ctx.mod.functions.push({ name, typeIdx, locals, body, exported: false });
+    pushDefinedFunc(ctx, funcIdx, { name, typeIdx, locals, body, exported: false });
     return funcIdx;
   };
 
@@ -6874,8 +6874,8 @@ function ensureProxyRuntime(
     const existing = ctx.funcMap.get(name);
     if (existing !== undefined) return existing;
     const typeIdx = addFuncType(ctx, params, [externref]);
-    const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
-    ctx.mod.functions.push({
+    const funcIdx = mintDefinedFunc(ctx);
+    pushDefinedFunc(ctx, funcIdx, {
       name,
       typeIdx,
       locals: [],
@@ -8268,9 +8268,9 @@ export function ensureObjectGroupBy(ctx: CodegenContext): number {
   ];
 
   const typeIdx = addFuncType(ctx, [{ kind: "externref" }, { kind: "externref" }], [{ kind: "externref" }]);
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
+  const funcIdx = mintDefinedFunc(ctx);
   ctx.funcMap.set("__object_groupBy", funcIdx);
-  ctx.mod.functions.push({
+  pushDefinedFunc(ctx, funcIdx, {
     name: "__object_groupBy",
     typeIdx,
     locals: [
@@ -8307,8 +8307,8 @@ export function reserveApplyClosure(ctx: CodegenContext): number {
     [{ kind: "externref" }],
     "$apply_closure_type",
   );
-  const funcIdx = ctx.numImportFuncs + ctx.mod.functions.length;
-  ctx.mod.functions.push({
+  const funcIdx = mintDefinedFunc(ctx);
+  pushDefinedFunc(ctx, funcIdx, {
     name: "__apply_closure",
     typeIdx,
     locals: [],


### PR DESCRIPTION
## #1916 S3b batch 7 — object-runtime to stable handles

Continues the two-regime stable-func-handle migration (dev-1916o). Mechanical batch flip; **byte-identity-proven**, zero real regression.

### What
Flip all 4 defined-func producers in `object-runtime.ts` to `mintDefinedFunc` / `pushDefinedFunc`:
- the generic `__object_*` helper factory (`Object.keys`/`values`/`entries`/`assign`/`getOwnPropertyNames`/…),
- the Proxy `reserveDriver` (reserve-then-fill, filled by `fillProxyDispatch`),
- `__object_groupBy`,
- `__apply_closure` (reserve-then-fill, filled by `fillApplyClosure`).

### Why it's safe
All four are the simple mint→push shape: `funcIdx` var, no `funcIdx + k` derivation, no intervening `mod.functions` push. The two reserve-then-fill sites mirror the batch-6 member-dispatch pattern already proven byte-identical — the placeholder is pushed at the stable handle and the finalize fill resolves it via the dual-regime `definedFuncAt`.

### Proof (the safety net)
- **Corpus byte-IDENTICAL** over the 66-record playground + probe corpus across {gc, standalone, wasi}. The `objects` + `apply-call` probes exercise the factory + `__apply_closure` (standalone 59911 B).
- `tsc --noEmit` clean.
- #1916 acceptance + `object-keys-values-entries` / `issue-786-object-keys-dynamic` / `issue-2863-standalone-groupby` suites green.
- The pre-existing `struct-proxy-wrappers` field-order assertion + `proxy-passthrough` / `arrow-call-apply` `string_constants` harness-instantiation failures reproduce identically on clean `origin/main` (file-revert control) — not this flip's doing.

Does NOT touch S3-final (shifter deletion) — that stays lead-coordinated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqULELUJc4f184UUojsmeS