### PR TITLE
fix(#3005): strip type-cast callee wrappers to stop (eval as any)() stack overflow

### DIFF
--- a/plan/issues/3005-eval-as-any-callee-stack-overflow.md
+++ b/plan/issues/3005-eval-as-any-callee-stack-overflow.md
@@ -1,0 +1,158 @@
+---
+id: 3005
+title: "Compiler stack-overflow on `(eval as any)()` — cast/parenthesized callee re-wrap recurses infinitely"
+status: done
+sprint: current
+created: 2026-07-02
+updated: 2026-07-02
+completed: 2026-07-02
+assignee: ttraenkler/agent-a736c48cc4ac5b6c4
+priority: medium
+horizon: s
+feasibility: medium
+reasoning_effort: medium
+task_type: bug
+area: codegen
+language_feature: eval
+related: [2960]
+origin: "2026-07-02 — found while implementing #2960 (dynamic eval / new Function diagnostics, PR #2548); noted but not investigated. Filed as tracked triage."
+---
+
+## Problem
+
+Compiling `(eval as any)()` crashes the compiler with an internal
+`RangeError: Maximum call stack size exceeded` (infinite recursion), rather
+than producing the graceful eval diagnostic that the plain-`eval()` path emits.
+The crash is caught by the `#1919` speculative wrapper in
+`compileExpression` and surfaced as a (duplicated) diagnostic:
+
+```
+error: Internal error compiling expression: Maximum call stack size exceeded
+error: Internal error compiling expression: Maximum call stack size exceeded
+```
+
+but it is a genuine unbounded-recursion crash in codegen, not an intended error.
+
+## Reproduction
+
+Crashes (both forms):
+
+```ts
+(eval as any)();
+```
+
+```ts
+(eval as any)("1+1");
+```
+
+Does **NOT** crash (compiles to an 8-byte module) — the `any`-typed _alias_
+form:
+
+```ts
+const x: any = eval;
+x(); // ok
+x("1+1"); // ok
+```
+
+So the trigger is specifically the **cast-in-parenthesized-callee** shape
+`(eval as any)(...)`, not "eval reached through `any`" in general. (The alias
+form goes through the identifier-callee path and never hits the re-wrap loop.)
+
+Run: `npx tsx src/cli.ts <file>.ts`
+
+## Root cause
+
+Captured stack trace (via temporary instrumentation of the catch in
+`src/codegen/expressions.ts:757`):
+
+```
+RangeError: Maximum call stack size exceeded
+    at Object.isOptionalChain (typescript.js)
+    at compileCallExpression (src/codegen/expressions/calls.ts:3948:10)
+    at compileCallExpression (src/codegen/expressions/calls.ts:4226:14)
+    at compileCallExpression (src/codegen/expressions/calls.ts:4226:14)
+    at compileCallExpression (src/codegen/expressions/calls.ts:4226:14)
+    ... (repeats to stack exhaustion)
+```
+
+The parenthesized-callee unwrap in `compileCallExpression`
+(`src/codegen/expressions/calls.ts:4186`) unwraps `(eval as any)` to the inner
+`AsExpression` (`eval as any`), then — because `AsExpression` is not matched by
+any of the special-cased inner shapes (conditional at 4201, comma/binary at
+4210, prefix/postfix unary at 4215) — falls through to the generic synthetic-call
+path at 4219:
+
+```ts
+const syntheticCall = ts.factory.createCallExpression(
+  unwrapped as ts.Expression as ts.LeftHandSideExpression, // = `eval as any`, an AsExpression
+  expr.typeArguments,
+  expr.arguments,
+);
+...
+return compileCallExpression(ctx, fctx, syntheticCall as ts.CallExpression); // line 4226
+```
+
+`AsExpression` is **not** a `LeftHandSideExpression`, so
+`ts.factory.createCallExpression` re-wraps the callee in a
+`ParenthesizedExpression` to preserve precedence. The synthetic call's callee is
+therefore again a `ParenthesizedExpression` wrapping the same `AsExpression`, so
+the re-entry at line 4226 hits the exact same 4186 branch and rebuilds an
+identical synthetic call — unbounded recursion.
+
+This is precisely the hazard the existing comments at lines 4198-4212 warn
+about for conditional / binary / unary callees ("ts.factory ... would re-wrap
+them in ParenthesizedExpression, causing infinite recursion") — but
+`AsExpression` (and, by the same reasoning, `SatisfiesExpression` and the
+old-style `TypeAssertion` `<any>eval`) is missing from that guarded set, so it
+falls through to the recursion.
+
+## Suggested direction (not implemented here — triage only)
+
+Handle type-only callee wrappers before the generic synthetic-call path in
+`compileCallExpression`: for `ts.isAsExpression` / `ts.isSatisfiesExpression` /
+`ts.isTypeAssertionExpression`, strip the type wrapper and recurse on the inner
+expression (so `(eval as any)()` becomes `eval()` and reaches the normal eval
+special-casing), or route it through `compileExpressionCallee` like the other
+non-LeftHandSideExpression callees at 4211/4216. Likely candidates to verify:
+`<any>eval()`, `(fn satisfies F)()`, `(obj.m as any)()`.
+
+## Acceptance criteria
+
+- `(eval as any)()` and `(eval as any)("1+1")` compile without a compiler
+  crash, producing the same graceful eval diagnostic as bare `eval()`.
+- No infinite recursion for other type-wrapped callees:
+  `<any>eval()`, `(someFn as any)()`, `(obj.method as any)()`.
+- A regression test in `tests/issue-3005.test.ts` covering the cast-callee
+  shapes.
+
+## Notes
+
+- Discovered during #2960 (dynamic eval / `new Function` diagnostics, delivered
+  via PR #2548). Not blocking that work; filed so it isn't lost.
+- The duplicate diagnostic line is a side effect of the `#1919` speculative
+  wrapper catching the `RangeError` and re-compiling; the underlying issue is
+  the recursion, not the double-report.
+
+## Resolution (2026-07-02)
+
+Fixed in `src/codegen/expressions/calls.ts`, in the parenthesized-callee
+unwrap of `compileCallExpression`. The `while` loop that strips
+`ParenthesizedExpression` now also strips the type-only callee wrappers
+`AsExpression` (`x as T`), `SatisfiesExpression` (`x satisfies T`), and
+`TypeAssertion` (`<T>x`). A type cast is a compile-time no-op, so
+`(eval as any)()` now unwraps to the bare `eval` identifier and reaches the
+normal callee handling (the graceful eval diagnostic), and
+`(fn as any)(args)` calls the underlying function. This removes the
+`ts.factory.createCallExpression` re-wrap that was rebuilding an identical
+synthetic call and recursing to stack exhaustion.
+
+- Verified: `(eval as any)()`, `(eval as any)("1+1")`, `((eval as any))()`,
+  `(eval satisfies unknown)()` no longer crash; `(fn as any)()`,
+  `(obj.m as any)()`, `(fn satisfies F)()`, `(<any>fn)()` correctly call the
+  function; conditional/plain-paren callees unchanged.
+- Byte-inert: a 10-program corpus (loops, recursion, classes, arrays, strings,
+  try/finally) produced sha256-identical binaries pre- and post-fix — the
+  change only affects the cast-in-parenthesized-callee shape.
+- Regression test: `tests/issue-3005.test.ts` (10 cases).
+- Supersedes the triage-only PR #2552 (which added this file at
+  `status: ready` with no code fix).

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -4185,7 +4185,21 @@ function compileCallExpression(
   // but also (fn)(), ((fn))(), (obj.method)() etc. which would otherwise fail.
   if (ts.isParenthesizedExpression(expr.expression)) {
     let unwrapped: ts.Expression = expr.expression;
-    while (ts.isParenthesizedExpression(unwrapped)) {
+    // Strip parentheses AND type-only callee wrappers (`as T`, `satisfies T`,
+    // `<T>x`). A type cast is a compile-time no-op, so `(eval as any)()` must
+    // behave exactly like `eval()`. Critically, `AsExpression` /
+    // `SatisfiesExpression` / `TypeAssertion` are NOT `LeftHandSideExpression`s,
+    // so if we left them wrapped and fell through to the generic synthetic-call
+    // path below, `ts.factory.createCallExpression` would re-wrap the callee in
+    // a `ParenthesizedExpression` and the re-entry would rebuild an identical
+    // synthetic call → unbounded recursion (#3005). Stripping them here lets the
+    // inner expression reach its normal callee handling (e.g. eval special-casing).
+    while (
+      ts.isParenthesizedExpression(unwrapped) ||
+      ts.isAsExpression(unwrapped) ||
+      ts.isSatisfiesExpression(unwrapped) ||
+      ts.isTypeAssertionExpression(unwrapped)
+    ) {
       unwrapped = unwrapped.expression;
     }
     // Only unwrap if it's NOT a function expression or arrow (those are IIFEs, handled later)

--- a/tests/issue-3005.test.ts
+++ b/tests/issue-3005.test.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3005 — Compiler stack-overflow on `(eval as any)()` (cast/parenthesized
+// callee re-wrap recurses infinitely).
+//
+// In `compileCallExpression` the parenthesized-callee unwrap reaches the inner
+// `AsExpression` (`eval as any`). `AsExpression` / `SatisfiesExpression` /
+// `TypeAssertion` are NOT `LeftHandSideExpression`s and were NOT in the
+// special-cased inner-shape set (conditional / comma / unary), so they fell
+// through to the generic synthetic-call path, where
+// `ts.factory.createCallExpression` re-wraps the callee in a
+// `ParenthesizedExpression` to preserve precedence — producing an identical
+// synthetic call and unbounded recursion (surfaced as a doubled
+// "Internal error compiling expression: Maximum call stack size exceeded").
+//
+// The fix strips type-only callee wrappers alongside parentheses so the inner
+// expression reaches its normal callee handling. A type cast is a compile-time
+// no-op, so `(eval as any)()` behaves exactly like `eval()`, and
+// `(fn as any)(args)` calls the real function.
+
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function run(source: string): Promise<unknown> {
+  const result = await compile(source);
+  expect(result.success).toBe(true);
+  const imports = buildImports(result.imports, {}, result.stringPool) as Record<string, unknown> & {
+    setExports?: (e: object) => void;
+  };
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  imports.setExports?.(instance.exports as object);
+  return (instance.exports as { main: () => unknown }).main();
+}
+
+describe("#3005 — cast/parenthesized callee no longer stack-overflows", () => {
+  // The original crash: `(eval as any)(...)` must compile without an internal
+  // RangeError (it now reaches the graceful eval-diagnostic path, like bare
+  // `eval()`), NOT crash the compiler.
+  for (const src of [
+    "(eval as any)();",
+    '(eval as any)("1+1");',
+    "((eval as any))();",
+    "(eval satisfies unknown)();",
+  ]) {
+    it(`compiles ${JSON.stringify(src)} without a compiler crash`, async () => {
+      // Should not throw a RangeError / "Maximum call stack size exceeded".
+      const result = await compile(src, { fileName: "test.ts" });
+      // Whether it succeeds or emits a graceful eval diagnostic, it must NOT be
+      // an internal compiler crash.
+      const crashed = result.errors.some((e) => /Maximum call stack size|Internal error/.test(e.message));
+      expect(crashed).toBe(false);
+    });
+  }
+
+  // Type-wrapped callees that resolve to a real function must actually call it.
+  it("`(fn as any)(args)` calls the underlying function", async () => {
+    expect(await run("function f(x: number){ return x * 2; } export function main(){ return (f as any)(5); }")).toBe(
+      10,
+    );
+  });
+
+  it("`(obj.method as any)(args)` calls the underlying method", async () => {
+    expect(
+      await run(
+        "function f(x: number){ return x + 1; } const o = { m: f }; export function main(){ return (o.m as any)(7); }",
+      ),
+    ).toBe(8);
+  });
+
+  it("`(fn satisfies T)(args)` calls the underlying function", async () => {
+    expect(
+      await run(
+        "function f(x: number){ return x * 3; } export function main(){ return (f satisfies (x: number) => number)(9); }",
+      ),
+    ).toBe(27);
+  });
+
+  it("old-style `(<T>fn)(args)` type assertion calls the underlying function", async () => {
+    expect(await run("function f(x: number){ return x - 1; } export function main(){ return (<any>f)(4); }")).toBe(3);
+  });
+
+  // Guard against regressing the sibling special-cased callee shapes that share
+  // the same re-wrap hazard.
+  it("conditional callee `(cond ? f : g)(args)` still works", async () => {
+    expect(
+      await run(
+        "function g(a: number, b: number){ return a + b; } export function main(){ return (true ? g : g)(2, 3); }",
+      ),
+    ).toBe(5);
+  });
+
+  it("plain parenthesized callee `(fn)(args)` still works", async () => {
+    expect(await run("function h(x: number){ return x * x; } export function main(){ return (h)(6); }")).toBe(36);
+  });
+});


### PR DESCRIPTION
## What

`(eval as any)()` and `(eval as any)("1+1")` crashed the compiler with an internal `RangeError: Maximum call stack size exceeded` (unbounded recursion), surfaced as a doubled `Internal error compiling expression` diagnostic. This fixes #3005.

## Root cause

In `compileCallExpression` (`src/codegen/expressions/calls.ts`) the parenthesized-callee unwrap reached the inner `AsExpression` (`eval as any`). `AsExpression` / `SatisfiesExpression` / `TypeAssertion` are **not** `LeftHandSideExpression`s and were **not** in the special-cased inner-shape set (conditional / comma / unary), so they fell through to the generic synthetic-call path where `ts.factory.createCallExpression` re-wraps the callee in a `ParenthesizedExpression` to preserve precedence — rebuilding an identical synthetic call and recursing to stack exhaustion. This is exactly the hazard the existing comments already guarded for conditional/binary/unary callees.

## Fix

The paren-unwrap `while` loop now also strips the type-only callee wrappers `AsExpression`, `SatisfiesExpression`, and `TypeAssertion`. A type cast is a compile-time no-op, so `(eval as any)()` unwraps to bare `eval` and reaches the normal eval diagnostic, and `(fn as any)(args)` calls the underlying function.

## Verification

- `(eval as any)()`, `(eval as any)("1+1")`, `((eval as any))()`, `(eval satisfies unknown)()` no longer crash.
- `(fn as any)()`, `(obj.m as any)()`, `(fn satisfies F)()`, `(<any>fn)()` correctly call the function.
- Conditional / plain-parenthesized callees unchanged.
- **Byte-inert**: a 10-program corpus (loops, recursion, classes, arrays, strings, try/finally) produced sha256-identical binaries pre- and post-fix — the change only affects the cast-in-parenthesized-callee shape.
- Regression test: `tests/issue-3005.test.ts` (10 cases, all green locally).

## Notes

- Sets the issue file to `status: done`.
- **Supersedes triage-only PR #2552** (which added the issue file at `status: ready` with no code fix). #2552 should be closed to avoid a duplicate-add of `plan/issues/3005-*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)