### PR TITLE
feat(codegen): #2963 Phase 1 — identity-stable reified builtin static-method values (standalone)

### DIFF
--- a/plan/issues/2963-builtin-first-class-reification.md
+++ b/plan/issues/2963-builtin-first-class-reification.md
@@ -1,7 +1,8 @@
 ---
 id: 2963
 title: "Reify builtins as first-class values: retire the `__get_builtin` dynamic-shape CE cluster (~400 compile errors)"
-status: ready
+status: in-progress
+assignee: ttraenkler/senior-dev
 sprint: current
 created: 2026-07-02
 updated: 2026-07-02
@@ -54,3 +55,116 @@ sites refuse ("#1472 Phase C") or lean on the `__get_builtin` host import.
 - `__get_builtin` CE count (295) driven to ~0 on the standalone lane;
   before/after recorded.
 - Reified identity stable within a module; no new host imports.
+
+---
+
+## Implementation plan (measured on current `main`, 2026-07-02, sr-dev)
+
+### Measure-first: what actually still CEs on current main
+
+The June-12 harvest (295 `#1907` refusals) predates #2175 (native
+`<Builtin>.prototype`), #2610 (well-known `Symbol.*` value fold), #2861
+(`<Ctor>.length`/`.name` const fold) and #2896 (reflective fn metadata),
+which already retired much of the raw cluster. Re-probing current `main`
+(`compile(..., { target: "standalone", nativeStrings: true })`), the
+**live** cluster splits into distinct sub-problems that must NOT be
+conflated:
+
+| Form (current main)                                   | Status on main | Owner / phase |
+| ----------------------------------------------------- | -------------- | ------------- |
+| `const f = Array.isArray` **identity** (`f === f`)    | **wrong (`false`)** — fresh `struct.new` per read | **Phase 1 (this PR)** |
+| `const r = Promise.resolve` as value                  | CE `#1907`     | Phase 2 — but Promise itself is host-backed (`Promise_resolve` import even for the DIRECT call), so reification cannot be host-free until Promise is native (#2867/#2905/#2959). |
+| `const f = Number.isInteger` (host-free predicate)    | CE `#1907`     | Phase 2 — **blocked** (see value-call-path blocker below). |
+| `const f = Array.of` as value                         | CE `#1907`     | Phase 2 — variadic; reified fixed-arity closure needs rest handling. |
+| `const k = Symbol.matchAll`                            | CE `#1907`     | Phase 2 — non-well-known Symbol value (well-known ones already fold, #2610). |
+| `X extends Object` constructor-object identity        | leaks `__new_Object` | **separate** — #2984 / sr-objsub. |
+| array-iterator `%ArrayIteratorPrototype%` identity     | leaks `__iterator`   | **separate** — opus-12b / #2965 cluster. |
+| `Object.defineProperty(globalThis, …)`                 | leaks `__get_globalThis` | **separate** — #2988. |
+
+The three "separate" rows are the sibling gaps three other devs found the
+same day — they share the *theme* (own-object identity) but each needs its
+own receiver-class MOP (see `project_2984_2988_2992_convergent_reification_substrate`);
+they are **not** in #2963's lane.
+
+### Phase 1 (this PR) — the identity substrate + the 3 already-wired methods
+
+**Root cause of the identity bug**: `pushBuiltinFnClosureValueInstrs`
+(`builtin-fn-meta.ts`) emits a fresh `ref.func` + `struct.new` on every
+value read, so two reads of `Array.isArray` are two distinct GC structs →
+`ref.eq` false. ES: a builtin method is ONE function object.
+
+**Fix**: `pushBuiltinFnSingletonValueInstrs` — one `(ref null <metaType>)`
+**mutable global per (builtin, member)** (keyed by the unique meta/wrapper
+struct-type index, which is rec-group/DCE stable), lazily materialized once
+behind an `if (ref.is_null) { struct.new; global.set }` guard emitted in the
+**function body** (`fctx.body`), then `global.get` + `ref.as_non_null`.
+
+**Why body-lazy-init, NOT a const-init global** (the load-bearing design
+decision): the singleton's `struct.new` operand is `ref.func <closureIdx>`,
+and `closureIdx` is a *defined-function* index that shifts whenever a late
+import lands (`addUnionImports` / `shiftLateImportIndices` / the string-import
+shifter). All three shifters walk function bodies **and nested
+`.then`/`.body`/`.else` arrays** (verified) but **do NOT walk
+`ctx.mod.globals[].init`** — so a `ref.func` embedded in a const-init would go
+stale and point at the wrong function (a silent funcidx-desync regression, the
+family of `project_standalone_hostimport_gate_index_shift`). Emitting the
+`ref.func` inside an `if.then` in `fctx.body` keeps it in a shift-covered
+array. (The `$__hole` const-init singleton in `array-holes.ts` is safe only
+because it has *no* funcref operand.)
+
+The shared mutable `bfnstate` (delete-bits) field being one instance across
+all reads is *spec-correct*: `delete fn.name` through any reference mutates the
+same object.
+
+**Scope**: only the standalone static-method **value-read** site
+(`property-access.ts`, the `ensureStandaloneBuiltinStaticMethodClosure`
+branch) switches to the singleton. Byte-inert (sha256-verified) for host mode,
+standalone programs with no builtin value reads, and `[1,2].map(Number)`
+(bare-identifier-callback path, unchanged).
+
+**Verified** (`--target standalone`, run, not just compiled):
+`Array.isArray === Array.isArray` / `Object.keys` / `Object.getOwnPropertyDescriptor`
+→ `1` (were `0`); **swap-wrong-builtin guard** `Array.isArray === Object.keys`
+→ `0` (proves genuine per-builtin identity, not a coincidental null≡null pass —
+`project_hostfree_pass_can_be_coincidentally_wrong_not_just_vacuous`); reified
+`Array.isArray([1,2])`→`1`, `(5)`→`0` (call path intact); no `__get_builtin`
+import added. `.name`/`.length` on the externref-widened local read `0` — a
+**pre-existing** limitation confirmed identical on the upstream baseline (the
+#2896 reflective meta answers `gOPD`-style reads, not `f.name` on a widened
+local), untouched by this PR.
+
+### Phase 2 (follow-up PR) — retire the CEs, BLOCKED on a value-call-path fix
+
+Wiring the ~15 host-free static methods from `BUILTIN_STATIC_METHOD_ARITY`
+(the worklist) is where the 295 → 0 CE reduction lands. It is **blocked on a
+value-call dispatch integration bug** found while prototyping `Number.isInteger`:
+
+- The 3 existing wired methods all take **`externref` params**; the reflective
+  any-callable dispatch (`expressions/calls.ts` ~13230–13640,
+  `__callable_param_*`) works for them.
+- A reified value stored in a `const f = …` widens to **`externref`** (its TS
+  type is a function), so the call site must *recover* the closure by
+  `ref.test`/`ref.cast` against a candidate struct type. Candidate selection is
+  keyed by **arity**, not exact param types — so a new **`f64`-param** closure
+  (e.g. `Number.isInteger`) mis-selects among same-arity candidates and the
+  emitted `call` mis-threads the arg (WAT: `f64.const 4; call <lifted>` with the
+  `self` operand dropped) → runtime `dereferencing a null pointer`. Compiles,
+  but TRAPS — a regression, so `Number.isInteger` was intentionally **not**
+  shipped in Phase 1.
+- **Phase-2 prerequisite**: make the any-callable dispatch key on the value's
+  exact static closure type (or thread `self` uniformly for scalar-param lifted
+  funcs). Once that lands, the singleton substrate here wires every host-free
+  method (`Number.is*`, `Math.*` unary/binary, `Object.is` scalar, …) trivially
+  via the same `ensureStandaloneBuiltinStaticMethodClosure` switch.
+- **Promise.\*** (15 of the sampled refusals) is a *further* sub-case: even the
+  DIRECT `Promise.resolve(5)` call leaks a `Promise_resolve` host import today,
+  so reifying it host-free is gated on native Promise (#2867/#2905/#2959), not
+  on this mechanism. Until then a reified `Promise.resolve` would reuse the same
+  (non-new) host import the direct call uses.
+
+### Files
+
+- `src/codegen/builtin-fn-meta.ts` — `pushBuiltinFnSingletonValueInstrs` + the design rationale.
+- `src/codegen/context/types.ts` — `builtinFnSingletonGlobalByTypeIdx` map.
+- `src/codegen/property-access.ts` — static-method value-read site uses the singleton.
+- `tests/issue-2963-builtin-reification.test.ts` — identity + swap-guard + call-path + no-host-import.

--- a/src/codegen/builtin-fn-meta.ts
+++ b/src/codegen/builtin-fn-meta.ts
@@ -241,3 +241,63 @@ export function pushBuiltinFnClosureValueInstrs(
   instrs.push({ op: "struct.new", typeIdx: closure.type.typeIdx } as Instr);
   return instrs;
 }
+
+/**
+ * (#2963) IDENTITY-STABLE reified builtin-function value. Instead of a fresh
+ * `struct.new` per read (which gives `Promise.resolve !== Promise.resolve` —
+ * two distinct closure instances), materialize the closure struct into a
+ * MODULE-LEVEL SINGLETON: one `(ref null <structType>)` mutable global per
+ * (builtin, member), lazily initialized on first read, so every read of the
+ * same builtin value yields the SAME ref.
+ *
+ * Why a lazy null-guard in the FUNCTION BODY rather than a global const-init:
+ * the singleton's `struct.new` takes a `ref.func <closureFuncIdx>` operand, and
+ * `closureFuncIdx` is a DEFINED-function index that shifts whenever a late
+ * import is added (`addUnionImports` / `shiftLateImportIndices` / the
+ * string-import shifter). Those shifters walk function bodies + nested
+ * `.then`/`.body`/`.else` arrays (verified) but do NOT walk
+ * `ctx.mod.globals[].init`, so a `ref.func` embedded in a const-init would go
+ * stale and reference the wrong function. Emitting the materialization inside
+ * an `if (ref.is_null) { … }` guard in `fctx.body` keeps the `ref.func` in a
+ * shift-covered array — the same discipline as every other funcidx bake site.
+ *
+ * The mutable `bfnstate` (delete-bits) field being shared across all reads is
+ * spec-correct: a builtin method is ONE function object, so `delete fn.name`
+ * seen through any reference mutates the same object (test262 `verifyProperty`
+ * `isConfigurable` arm).
+ *
+ * Stack: `[] → [(ref <structType>)]` (non-null, exactly what
+ * `pushBuiltinFnClosureValueInstrs` produced, so callers' result type is
+ * unchanged).
+ */
+export function pushBuiltinFnSingletonValueInstrs(
+  ctx: CodegenContext,
+  closure: { type: { kind: "ref"; typeIdx: number }; funcIdx: number },
+): Instr[] {
+  const typeIdx = closure.type.typeIdx;
+  if (!ctx.builtinFnSingletonGlobalByTypeIdx) ctx.builtinFnSingletonGlobalByTypeIdx = new Map();
+  let globalIdx = ctx.builtinFnSingletonGlobalByTypeIdx.get(typeIdx);
+  if (globalIdx === undefined) {
+    globalIdx = ctx.numImportGlobals + ctx.mod.globals.length;
+    ctx.mod.globals.push({
+      name: `__builtinfn_singleton_${typeIdx}`,
+      // (ref null <structType>) — starts null, set once on first read.
+      type: { kind: "ref_null", typeIdx },
+      mutable: true,
+      init: [{ op: "ref.null", typeIdx } as Instr],
+    });
+    ctx.builtinFnSingletonGlobalByTypeIdx.set(typeIdx, globalIdx);
+  }
+
+  return [
+    { op: "global.get", index: globalIdx } as Instr,
+    { op: "ref.is_null" } as Instr,
+    {
+      op: "if",
+      blockType: { kind: "empty" },
+      then: [...pushBuiltinFnClosureValueInstrs(ctx, closure), { op: "global.set", index: globalIdx } as Instr],
+    } as Instr,
+    { op: "global.get", index: globalIdx } as Instr,
+    { op: "ref.as_non_null" } as Instr,
+  ];
+}

--- a/src/codegen/context/types.ts
+++ b/src/codegen/context/types.ts
@@ -1903,6 +1903,18 @@ export interface CodegenContext {
   /** (#2896) Cache: `(builtin, member)` key → the meta struct-type index above.
    *  Keeps `ensureBuiltinFnMetaType` idempotent per closure identity. */
   builtinFnMetaTypeByKey?: Map<string, number>;
+  /** (#2963) Reified-builtin-value IDENTITY substrate. A builtin static method
+   *  read AS A VALUE (`const r = Promise.resolve`, `[1,2].map(Number.isInteger)`)
+   *  must be a MODULE-LEVEL SINGLETON: every read of the same (builtin, member)
+   *  yields the SAME ref so `Promise.resolve === Promise.resolve` holds and a
+   *  `delete fn.name` mutates the one shared object (ES: builtin methods are a
+   *  single function object). Keyed by the meta/wrapper struct-type index (the
+   *  per-(builtin, member) unique type from `ensureBuiltinFnMetaType`), the value
+   *  is the index of a `(ref null <structType>)` mutable global that
+   *  `pushBuiltinFnSingletonValueInstrs` lazily materializes once (a null-guarded
+   *  `struct.new` in a shift-covered function body — NOT a const-init, whose
+   *  embedded `ref.func` the late-import funcidx shifter does not walk). */
+  builtinFnSingletonGlobalByTypeIdx?: Map<number, number>;
   /** (#2193 PR-B) Struct-type indices of `$NativeProto` member closures whose
    *  FIRST user param is the receiver (`this`) — e.g. `Array.prototype.slice`'s
    *  `(self, this, start, end)` closure. Unlike a plain user function (which

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -31,6 +31,7 @@ import {
   BUILTIN_STATIC_METHOD_ARITY,
   ensureBuiltinFnMetaType,
   pushBuiltinFnClosureValueInstrs,
+  pushBuiltinFnSingletonValueInstrs,
   STANDALONE_STATIC_METHOD_META,
 } from "./builtin-fn-meta.js";
 import { emitLazyClassObjectGet, emitLazyProtoGet, findExternInfoForMember } from "./expressions/extern.js";
@@ -3965,7 +3966,12 @@ export function compilePropertyAccess(
       }
       const closure = ensureStandaloneBuiltinStaticMethodClosure(ctx, builtinName, propName, expr);
       if (closure) {
-        fctx.body.push(...pushBuiltinFnClosureValueInstrs(ctx, closure));
+        // (#2963) IDENTITY-STABLE reified builtin value: read via a module-level
+        // singleton so `Array.isArray === Array.isArray`, `Number.isInteger ===
+        // Number.isInteger`, etc. hold (a fresh `struct.new` per read gave two
+        // distinct instances → `!==`). Distinct builtins keep distinct singleton
+        // globals, so `Array.isArray !== Number.isInteger` still holds.
+        fctx.body.push(...pushBuiltinFnSingletonValueInstrs(ctx, closure));
         return closure.type;
       }
       reportUnsupportedStandaloneBuiltinValueRead(ctx, builtinName, propName);

--- a/tests/issue-2963-builtin-reification.test.ts
+++ b/tests/issue-2963-builtin-reification.test.ts
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2963 — reified builtin static methods are IDENTITY-STABLE first-class values.
+ *
+ * A builtin static method read AS A VALUE under `--target standalone`
+ * (`const f = Array.isArray`) previously materialized a FRESH closure struct on
+ * every read, so `Array.isArray === Array.isArray` was `false` — two distinct
+ * instances. ES requires a builtin method to be a single function object, so
+ * this is a genuine correctness bug. The fix routes every reified-builtin value
+ * read through a MODULE-LEVEL SINGLETON global (one per (builtin, member)),
+ * lazily materialized once — so all reads yield the same ref.
+ *
+ * Verified beyond "does it compile": the swap-wrong-builtin check
+ * (`Array.isArray === Object.keys` MUST stay `false`) guards against the
+ * "coincidental wrongness" trap where a placeholder value passes an identity
+ * assertion by cancelling against an equally-wrong comparison target
+ * (memory `project_hostfree_pass_can_be_coincidentally_wrong_not_just_vacuous`).
+ */
+
+async function runStandalone(src: string): Promise<{ value: number; hostImports: string[] }> {
+  const full = `export function test(): number { ${src} }`;
+  const r = await compile(full, { target: "standalone", nativeStrings: true });
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const hostImports = r.imports.map((i) => `${i.module}::${i.name}`).filter((l) => l.startsWith("env::"));
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const value = (instance.exports as { test: () => number }).test();
+  return { value, hostImports };
+}
+
+describe("#2963 — reified builtin static-method value identity (standalone)", () => {
+  it("Array.isArray === Array.isArray (was false — fresh struct per read)", async () => {
+    const { value } = await runStandalone(`const a = Array.isArray, b = Array.isArray; return a === b ? 1 : 0;`);
+    expect(value).toBe(1);
+  });
+
+  it("Object.keys === Object.keys", async () => {
+    const { value } = await runStandalone(`const a = Object.keys, b = Object.keys; return a === b ? 1 : 0;`);
+    expect(value).toBe(1);
+  });
+
+  it("Object.getOwnPropertyDescriptor === Object.getOwnPropertyDescriptor", async () => {
+    const { value } = await runStandalone(
+      `const a = Object.getOwnPropertyDescriptor, b = Object.getOwnPropertyDescriptor; return a === b ? 1 : 0;`,
+    );
+    expect(value).toBe(1);
+  });
+
+  // The coincidental-wrongness guard: distinct builtins keep distinct identity.
+  it("Array.isArray !== Object.keys (swap-wrong-builtin guard)", async () => {
+    const { value } = await runStandalone(`return ((Array.isArray as unknown) === (Object.keys as unknown)) ? 1 : 0;`);
+    expect(value).toBe(0);
+  });
+
+  // Identity must not break the call path: a reified value is still callable.
+  it("reified Array.isArray remains callable and correct", async () => {
+    const arr = await runStandalone(`const f = Array.isArray; return f([1, 2]) ? 1 : 0;`);
+    expect(arr.value).toBe(1);
+    const nonArr = await runStandalone(`const f = Array.isArray; return f(5 as unknown as never[]) ? 1 : 0;`);
+    expect(nonArr.value).toBe(0);
+  });
+
+  it("identity reification adds no host import", async () => {
+    const { hostImports } = await runStandalone(`const a = Array.isArray, b = Array.isArray; return a === b ? 1 : 0;`);
+    // No __get_builtin / __box_number / etc. introduced by the singleton read.
+    expect(hostImports.filter((h) => h.includes("__get_builtin"))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## #2963 Phase 1 — the builtin-value **identity substrate**

Reads issue #2963 (retire the `__get_builtin` dynamic-shape CE cluster by reifying builtins as first-class values). This PR lands the **identity substrate** the whole issue depends on, plus fixes a latent correctness bug.

### The bug
A builtin static method read as a value under `--target standalone` (`const f = Array.isArray`) materialized a **fresh** closure struct on every read (`pushBuiltinFnClosureValueInstrs` → `struct.new`), so `Array.isArray === Array.isArray` was **`false`** — two distinct GC instances. ES requires a builtin method to be a single function object (acceptance criterion #3).

### The fix
`pushBuiltinFnSingletonValueInstrs` — one `(ref null <metaType>)` **mutable global per (builtin, member)** (keyed by the DCE-stable meta struct-type index), lazily materialized once behind an `if (ref.is_null) { struct.new; global.set }` guard, then `global.get; ref.as_non_null`. Wired at the standalone static-method value-read site for the 3 currently-reified methods (`Array.isArray`, `Object.keys`, `Object.getOwnPropertyDescriptor`).

**Load-bearing design note:** the singleton is materialized in the **function body**, not a global const-init, because its `struct.new` operand is a `ref.func <closureIdx>` whose funcidx shifts with late imports — and the three late-import shifters walk function bodies + nested `then`/`body`/`else` arrays but **not** `globals[].init`. A const-init `ref.func` would silently desync. (The `$__hole` const-init singleton is safe only because it carries no funcref.)

### Verified (run, not just compiled — `--target standalone`)
- `Array.isArray === Array.isArray` / `Object.keys` / `Object.getOwnPropertyDescriptor` → **1** (were **0**)
- **swap-wrong-builtin guard**: `Array.isArray === Object.keys` → **0** — proves genuine per-builtin identity, not a coincidental null≡null pass (`project_hostfree_pass_can_be_coincidentally_wrong_not_just_vacuous`)
- reified `Array.isArray([1,2])` → 1, `(5)` → 0 (call path intact)
- no `__get_builtin` import added
- **byte-inert** (sha256-verified) for host mode, standalone-with-no-builtin-value-reads, and `[1,2].map(Number)`

### Scope / phasing
This is **Phase 1 = mechanism + the 3 already-wired consuming cases**. Retiring the 295 `#1907` CEs (wiring the ~15 host-free methods) is **Phase 2**, which I found is **blocked** on an any-callable dispatch fix for scalar-param closures (a prototyped `Number.isInteger` compiled but **trapped** at runtime because the dispatch keys on arity, not exact param type). Root cause, the method worklist, and the Promise-is-host-backed sub-case are documented in the issue file. Deliberately not shipping a runtime-trapping half-feature.

Test: `tests/issue-2963-builtin-reification.test.ts` (6 tests, green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8