### PR TITLE
fix(#2805): init-time any-receiver field WRITE via __in_module_init gate

### DIFF
--- a/plan/issues/2805-init-time-any-receiver-write-host-set.md
+++ b/plan/issues/2805-init-time-any-receiver-write-host-set.md
@@ -1,15 +1,16 @@
 ---
 id: 2805
 title: "init-time `any`-receiver field WRITE dropped at module-init (symmetric write side of #2800)"
-status: ready
-assignee: ttraenkler/unassigned
+status: done
+assignee: ttraenkler/senior-developer
 sprint: current
 priority: medium
 horizon: m
 feasibility: hard
 reasoning_effort: max
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-02
+completed: 2026-07-02
 task_type: bugfix
 area: codegen
 language_feature: object-literals
@@ -104,3 +105,77 @@ settles). Dump the ctor body and resolve `funcIdx` → name against the FINAL
 `tests/issue-2800-toplevel-new-objlit-init-read.test.ts` (the read-side guard) +
 the `new VI(...)` write variant dropped from it (see #2800's git history) which
 reads `topLevelZz() === 0` pre-fix.
+
+## Resolution (2026-07-02)
+
+Implemented the symmetric `__in_module_init` gate in
+`tryEmitDeleteAwareDynamicSet` (`src/codegen/property-access.ts`).
+
+### Measure-first (the exact repro shape matters)
+
+The bug reproduces ONLY with a **clean** function constructor — implicit-`any`
+`this`, NO `this: any` annotation, NO `(VI as any)` cast:
+
+```ts
+function VI(label, conf) { this.label = label; this.zz = conf.zz || 0; }
+function useDelete(o: any): void { delete o.x; }
+const x: any = new VI("a", { zz: 9 });          // top-level (init)
+function mk(): any { return new VI("b", { zz: 9 }); }
+// pre-fix: topLevelZz()===0, topLevelLabel()===null; runtimeZz()===9
+```
+
+An explicit `this: any` annotation OR an `(VI as any)` cast routes `new` through
+the **dynamic-new** path, which independently fails to marshal the object-literal
+argument (`conf` reads `undefined` at BOTH init and runtime — a *separate*,
+pre-existing `new (fn as any)(objLiteral)` arg-passing gap, NOT this bug). Using
+the clean ctor form (the shape acorn actually emits for `new TokenType(...)`)
+isolates the init-timing write drop cleanly. The delete-free variant already
+works at init (native `struct.set`, no host setter), confirming the root cause is
+the host-setter timing, not the write itself.
+
+### funcIdx desync — root-caused and avoided (not just "verified")
+
+The #2800 write-side prototype baked the SAME `call funcIdx` for `this.label` and
+`this.zz` because it reserved `__set_member_<name>` **before** evaluating the
+`value` expression. The value (`conf.zz || 0`) itself reserves a
+`__get_member_zz` dispatcher and pulls late imports, shifting the defined-function
+index space; the already-captured `setMemberIdx` local went stale-low. Fix:
+reserve the dispatcher **after** both operands are lowered into locals, with
+nothing emitted between its reserve+flush and the bake — so its funcIdx is
+post-shift. `setIdx` (`__extern_set_strict`) is an IMPORT (stable index once
+added) so baking it late is safe. Verified by dumping the compiled `$VI` ctor and
+resolving funcIdx→name against the final index space:
+
+- `this.label` init arm → `call 11` = `$__set_member_label`
+- `this.zz`    init arm → `call 13` = `$__set_member_zz`  (distinct ✓)
+- both writes + the `conf.zz` read gate on the SAME flag global (`__in_module_init`)
+- runtime arms → `__extern_set_strict` (import) / `__extern_get` (import) preserved
+
+### Files
+
+- `src/codegen/property-access.ts` — `tryEmitDeleteAwareDynamicSet` init gate.
+  Reuses the #2800 flag machinery (`recordInModuleInitFlagRead` /
+  `finalizeInModuleInitFlag` — the write reads are patched by the same finalize
+  pass, sharing `ctx.inModuleInitFlagReads`), and the #2664
+  `reserveMemberSetDispatch`.
+- Guard: `tests/issue-2805-init-time-any-receiver-write.test.ts`.
+
+### Verified
+
+- new guard (3 cases): init write lands (`x.zz===9`, `x.label==="a"`), runtime
+  write still `9`, delete-free module unaffected.
+- `#2800` read guard, `#2179`/`#2731`/`#2664` dispatch, `issue-forin`,
+  `#2130` delete-in-presence all green.
+- Byte-inert for untouched lanes: a delete-free module emits NO
+  `__in_module_init`; standalone early-returns (no flag). The change is reachable
+  only in a delete-using gc/host module — the target lane.
+- (`tests/delete-operator.test.ts`, `tests/constructor-arity.test.ts` #593, and
+  the `./helpers.js` importers fail identically on base main — pre-existing
+  worktree test-infra breakage, unrelated.)
+
+### Known follow-up (out of scope)
+
+`new (fn as any)(objLiteral)` / `new fn(objLiteral)` with an explicit `this: any`
+param drops the object-literal ARGUMENT (`conf` reads `undefined`) at both init
+and runtime — a dynamic-new arg-marshaling gap, distinct from this init-timing
+write drop. Worth a dedicated issue if a real program hits it.

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -2799,8 +2799,9 @@ export function tryEmitDeleteAwareDynamicSet(
   const valLocal = allocLocal(fctx, `__daset_val_${fctx.locals.length}`, { kind: "externref" });
   fctx.body.push({ op: "local.set", index: valLocal });
 
-  // __extern_set_strict(obj, "prop", val) → _safeSet (clears tombstone, writes
-  // sidecar, mirrors __sset_<key>). Bare call — NOT the struct.set dispatcher.
+  // RUNTIME arm — __extern_set_strict(obj, "prop", val) → _safeSet (clears
+  // tombstone, writes sidecar, mirrors __sset_<key>). Bare call — NOT the
+  // struct.set dispatcher.
   //
   // (#2681/#2686) An EARLIER pinned-write path (`tryEmitPinnedStructMemberSet`,
   // assignment.ts) already routes writes to a RECONSTRUCTED-fnctor receiver
@@ -2809,17 +2810,80 @@ export function tryEmitDeleteAwareDynamicSet(
   // READ. This delete-aware path is the GENERAL `any`-receiver write in a
   // delete-using module, where the receiver is typically a PLAIN object literal
   // lowered to an anonymous `$__anon_N` struct. Routing THAT through the
-  // dispatcher's `struct.set` arm overwrites the field SLOT in place, which
-  // bypasses the delete+re-add ORDERING the JS-host sidecar tracks
+  // dispatcher's `struct.set` arm at RUNTIME overwrites the field SLOT in place,
+  // which bypasses the delete+re-add ORDERING the JS-host sidecar tracks
   // (`delete o.p; o.p = v` must re-insert `p` at the END — `for-in` order, #2179/
-  // #2731). So the general delete-aware write MUST stay on the bare sidecar
-  // `_safeSet`; only the narrowly-pinned reconstructed-fnctor write uses the slot
-  // dispatcher. (The broad reroute here regressed `for-in/order-simple-object`.)
-  fctx.body.push({ op: "local.get", index: objLocal });
+  // #2731). So the general delete-aware runtime write MUST stay on the bare
+  // sidecar `_safeSet`; only the narrowly-pinned reconstructed-fnctor write uses
+  // the slot dispatcher. (The broad runtime reroute here regressed
+  // `for-in/order-simple-object`.)
+  //
+  // (#2805) MODULE-INIT correctness — the symmetric WRITE side of #2800. gc/host
+  // runs `__module_init` via the Wasm `start` section, INSIDE
+  // `WebAssembly.instantiate`, BEFORE the host wires the struct setters via
+  // `__setExports`. The runtime host write above threads `__extern_set_strict` →
+  // `_safeSet` → `getExports()?.__sset_<key>`, so at init `getExports()` is
+  // undefined and the field write is SILENTLY DROPPED — a top-level
+  // `new X({...})` whose ctor does `this.<f> = conf.<f>` on an `any`-typed `this`
+  // stores nothing (the struct keeps its 0/null default), while the IDENTICAL
+  // construction at RUNTIME works. Mirror #2800's read-side gate: branch on the
+  // `__in_module_init` flag and, DURING INIT, write the slot host-free via the
+  // `__set_member_<name>` dispatcher (a `ref.test`+`struct.set` over the complete
+  // finalize-time candidate set; #2664) — no exports needed, and nothing has been
+  // `delete`d yet on a freshly-built object so the for-in re-add ordering the
+  // runtime arm preserves is moot. At runtime keep the sidecar `__extern_set_strict`.
+  //
+  // gc/host only: WASI/standalone have no host `__extern_set_strict` (this
+  // function already returns early for `ctx.standalone`), and WASI's
+  // `__module_init` lazy-init wrap must stay untouched — so WASI keeps the legacy
+  // bare sidecar write.
+  //
+  // The dispatcher is reserved HERE — AFTER both operands are evaluated into
+  // locals — deliberately. The `value` expression (e.g. `conf.zz || 0`) can
+  // itself reserve a `__get_member_<name>` dispatcher and pull late imports that
+  // shift the DEFINED-function index space; reserving `__set_member_<name>` after
+  // all that, with NOTHING emitted between its reserve+flush and the bake below,
+  // guarantees `setMemberIdx` is post-shift and each property's write bakes its
+  // OWN distinct funcIdx. Reserving it BEFORE the value eval (the #2800 write-side
+  // prototype) left the local stale-low so `this.label` and `this.zz` baked the
+  // SAME `call funcIdx` (a funcIdx desync). `setIdx` is an IMPORT (its index is
+  // stable once added — new imports insert at the import-section end and shift
+  // only defined funcs), so baking it late is safe.
+  const setMemberIdx = ctx.wasi ? undefined : reserveMemberSetDispatch(ctx, propName, /*strict*/ true, fctx);
   addStringConstantGlobal(ctx, propName);
-  fctx.body.push(...stringConstantExternrefInstrs(ctx, propName));
-  fctx.body.push({ op: "local.get", index: valLocal });
-  fctx.body.push({ op: "call", funcIdx: setIdx } as Instr);
+  flushLateImportShifts(ctx, fctx);
+
+  if (setMemberIdx === undefined) {
+    // WASI / no dispatcher — legacy bare tombstone-aware host write (byte-identical).
+    fctx.body.push({ op: "local.get", index: objLocal });
+    fctx.body.push(...stringConstantExternrefInstrs(ctx, propName));
+    fctx.body.push({ op: "local.get", index: valLocal });
+    fctx.body.push({ op: "call", funcIdx: setIdx } as Instr);
+    fctx.body.push({ op: "local.get", index: valLocal });
+    return { kind: "externref" };
+  }
+
+  // `__in_module_init ? __set_member_<name>(recv, val) : __extern_set_strict(recv, "prop", val)`.
+  // The flag-read `global.get` index is a PLACEHOLDER patched at finalize by
+  // `finalizeInModuleInitFlag` (after all import globals settle) — shared with the
+  // read-side gate via the same `ctx.inModuleInitFlagReads` list.
+  const flagGet = recordInModuleInitFlagRead(ctx);
+  fctx.body.push(flagGet);
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [
+      { op: "local.get", index: objLocal } as Instr,
+      { op: "local.get", index: valLocal } as Instr,
+      { op: "call", funcIdx: setMemberIdx } as Instr,
+    ],
+    else: [
+      { op: "local.get", index: objLocal } as Instr,
+      ...stringConstantExternrefInstrs(ctx, propName),
+      { op: "local.get", index: valLocal } as Instr,
+      { op: "call", funcIdx: setIdx } as Instr,
+    ],
+  } as Instr);
 
   // `=` evaluates to the assigned value.
   fctx.body.push({ op: "local.get", index: valLocal });

--- a/tests/issue-2805-init-time-any-receiver-write.test.ts
+++ b/tests/issue-2805-init-time-any-receiver-write.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2805 — the symmetric WRITE side of #2800. A top-level `new X(objLiteral)`
+// whose constructor writes `this.<field> = …` on an `any`-typed `this` dropped
+// the write at MODULE-INIT in gc/host mode (the struct kept its 0/null default),
+// while the identical construction at RUNTIME worked.
+//
+// Root cause (same as #2800, write side): a `delete`-using module
+// (`ctx.moduleUsesDelete`) routes an `any`-receiver property WRITE through
+// `tryEmitDeleteAwareDynamicSet` → the strict host setter `__extern_set_strict`
+// → `_safeSet` → `getExports()?.__sset_<field>` (#2731). gc/host runs
+// `__module_init` via the Wasm `start` section, INSIDE `WebAssembly.instantiate`,
+// BEFORE the host wires the struct setters via `__setExports` — so at init
+// `getExports()` is undefined and the field write is silently dropped.
+//
+// Fix: mirror #2800's read-side `__in_module_init` flag gate in
+// `tryEmitDeleteAwareDynamicSet` — during init write the slot host-free via the
+// `__set_member_<name>` dispatcher (native `struct.set`; #2664); at runtime keep
+// the tombstone/order-aware host `__extern_set_strict` (#2731 preserved).
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function runHost(source: string): Promise<Record<string, (...a: unknown[]) => unknown>> {
+  const result = await compile(source, { skipSemanticDiagnostics: true });
+  expect(result.success, `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}`).toBe(
+    true,
+  );
+  const built = buildImports(result.imports, undefined, result.stringPool) as unknown as {
+    setExports?: (e: unknown) => void;
+  };
+  const { instance } = await WebAssembly.instantiate(result.binary, built as unknown as WebAssembly.Imports);
+  // Mirror production wiring: exports are wired AFTER instantiate (the start
+  // section / module-init has already run by this point).
+  built.setExports?.(instance.exports);
+  return instance.exports as unknown as Record<string, (...a: unknown[]) => unknown>;
+}
+
+describe("#2805 init-time any-receiver field WRITE at module-init", () => {
+  it("a top-level `new X(objLiteral)` ctor `this.<f> = conf.<f>` write lands at init (delete-using module)", async () => {
+    // `delete` forces ctx.moduleUsesDelete → the ctor's `this.zz = conf.zz` and
+    // `this.label = label` route through the delete-aware dynamic WRITE. `x` is
+    // constructed at MODULE-INIT (top-level const), where the host struct setters
+    // are not yet wired. Pre-fix the writes were dropped → x.zz === 0, x.label
+    // === null. The IDENTICAL construction inside `mk()` runs at RUNTIME and
+    // always worked.
+    const e = await runHost(`
+      function VI(label, conf) { this.label = label; this.zz = conf.zz || 0; }
+      function useDelete(o: any): void { delete o.x; }
+      const x: any = new VI("a", { zz: 9 });
+      function mk(): any { return new VI("b", { zz: 9 }); }
+      export function topLevelZz(): number { return x.zz; }
+      export function topLevelLabel(): any { return x.label; }
+      export function runtimeZz(): number { return mk().zz; }
+      export function du(o: any): void { useDelete(o); }
+    `);
+    expect(e.topLevelZz()).toBe(9); // init-time write now lands (was 0)
+    expect(e.topLevelLabel()).toBe("a"); // init-time string write lands (was null)
+    expect(e.runtimeZz()).toBe(9); // runtime write still works
+  });
+
+  it("preserves the #2731 delete-tombstone WRITE at runtime: delete o.a; o.a = 9; for-in sees a re-added last", async () => {
+    // The runtime arm must keep the tombstone/order-aware host `__extern_set_strict`
+    // so a re-added key is re-inserted at for-in END, not resurrected in place.
+    const e = await runHost(`
+      export function test(): string {
+        const o: any = { a: 1, b: 2 };
+        delete o.a;
+        o.a = 9;               // re-add → must land at the END of for-in order
+        let s = "";
+        for (const k in o) s += k;
+        return s;
+      }
+    `);
+    expect(e.test()).toBe("ba"); // b first (a was deleted then re-added last)
+  });
+
+  it("delete-free module is unaffected: init-time ctor write lands via the native fast path", async () => {
+    // No `delete` → ctx.moduleUsesDelete is false → the write never routes through
+    // the delete-aware path (native struct.set), which already worked at init.
+    const e = await runHost(`
+      function VI(label, conf) { this.label = label; this.zz = conf.zz || 0; }
+      const x: any = new VI("a", { zz: 7 });
+      export function topLevelZz(): number { return x.zz; }
+    `);
+    expect(e.topLevelZz()).toBe(7);
+  });
+});


### PR DESCRIPTION
## #2805 — init-time `any`-receiver field WRITE dropped at module-init (symmetric write side of #2800)

A top-level `new X(objLiteral)` whose constructor writes `this.<f> = conf.<f>` on an `any`-typed `this` dropped the write at **module-init** in gc/host mode (the struct kept its 0/null default), while the identical construction at **runtime** worked.

### Root cause (same as #2800, write side)
A delete-using module (`ctx.moduleUsesDelete`) routes an `any`-receiver property WRITE through `tryEmitDeleteAwareDynamicSet` → `__extern_set_strict` → `_safeSet` → `getExports()?.__sset_<f>` (#2731). gc/host runs `__module_init` via the Wasm `start` section, **inside `WebAssembly.instantiate`, before** the host wires the struct setters via `__setExports` — so at init `getExports()` is undefined and the field write is silently dropped.

### Fix
Mirror #2800's read-side `__in_module_init` flag gate in `tryEmitDeleteAwareDynamicSet`:
- **init (flag=1):** write the slot host-free via the `__set_member_<name>` dispatcher (native `struct.set`; #2664) — no exports needed, nothing has been `delete`d yet on a fresh object so for-in re-add ordering is moot;
- **runtime (flag=0):** keep the tombstone/order-aware host `__extern_set_strict` (#2731 preserved).

Reuses the #2800 flag machinery (shared `ctx.inModuleInitFlagReads`, patched by the same `finalizeInModuleInitFlag`).

### funcIdx desync — root-caused and avoided
The #2800 write-side prototype baked the **same** `call funcIdx` for `this.label` and `this.zz` because it reserved the dispatcher **before** evaluating the `value` expression — which itself reserves a `__get_member_<name>` dispatcher and pulls late imports, shifting the defined-func index space and leaving the captured local stale-low. This PR reserves the dispatcher **after** both operands are lowered into locals (nothing emitted between reserve+flush and bake), so the funcIdx is post-shift. `setIdx` (`__extern_set_strict`) is an import (stable index) so baking it late is safe.

Verified by dumping the compiled `$VI` ctor and resolving funcIdx→name against the final index space:
- `this.label` init arm → `$__set_member_label`, `this.zz` init arm → `$__set_member_zz` (distinct)
- both writes + the `conf.zz` read gate on the **same** `__in_module_init` global.

### Scope / inertness
gc/host only — standalone early-returns, WASI keeps the legacy bare host write. A delete-free module emits **no** `__in_module_init` flag (byte-inert). Reachable only in a delete-using gc/host module — the target lane.

### Tests
- New guard `tests/issue-2805-init-time-any-receiver-write.test.ts` (3 cases): init write lands (`x.zz===9`, `x.label==="a"`), runtime write still `9`, delete-free unaffected.
- `#2800` read guard, `#2179`/`#2731`/`#2664` dispatch, `issue-forin`, `#2130` delete-in-presence all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8