### PR TITLE
fix(#3007): compile computed index before capturing __vec_get funcIdx (any-context element read)

### DIFF
--- a/plan/issues/3007-any-string-index-return-coercion.md
+++ b/plan/issues/3007-any-string-index-return-coercion.md
@@ -1,0 +1,93 @@
+---
+id: 3007
+title: "any-context computed-index read desyncs __vec_get funcIdx → invalid Wasm (f64.convert_i32_s on externref)"
+status: done
+sprint: current
+priority: medium
+assignee: ttraenkler/agent-a7e5749647e8f1219
+created: 2026-07-03
+completed: 2026-07-03
+feasibility: medium
+reasoning_effort: high
+task_type: bugfix
+area: codegen
+language_feature: element-access, dynamic-dispatch, any, late-imports
+goal: spec-completeness
+related: [2767, 2784]
+predecessor: 2767
+horizon: s
+---
+
+# #3007 — any-context computed-index read desyncs `__vec_get` funcIdx → invalid Wasm
+
+Surfaced by the #2768 measure-first investigation: `tests/issue-2767.test.ts` had
+6/11 tests failing on `main` with `Invalid Wasm binary`, independent of the
+bare-`var` safelist mechanism. The precise V8 error, on the minimal repro
+
+```ts
+export function test(): any {
+  var d; d = new Date(0);
+  const __s = d.toISOString();
+  return __s[__s.length - 1];   // returned in an `any` context
+}
+```
+
+is:
+
+```
+CompileError: f64.convert_i32_s[0] expected type i32, found local.get of type externref
+```
+
+## Root cause — a late-import funcIdx desync in the vec-fast element read
+
+The receiver `__s` is statically `any` (evolving-`any` binding: the TS checker
+types `d.toISOString()` as `any`, so `__s` is `any` → externref). A computed
+numeric read `__s[idx]` on an externref receiver in host/GC mode routes through
+the `(#2784 S3)` native-vec-aware fast path in
+`compileElementAccessBody` (`src/codegen/property-access.ts`). That path:
+
+1. captured `__vec_get` / `__extern_get` / `__box_number` funcIdxs and flushed
+   the pending late-import shifts, THEN
+2. compiled the **index expression** `__s.length - 1`.
+
+But compiling that index is itself a dynamic `.length` read on an externref,
+which **registers late imports** and shifts every DEFINED-function index —
+including `__vec_get`. Because `__vec_get` was captured in step 1 (before the
+index compile in step 2) and never re-resolved, the `then` arm's
+`call __vec_get` desynced and the emitted instruction stream was corrupted into
+`f64.convert_i32_s` applied to the externref receiver — invalid Wasm.
+
+Confirmation (host mode):
+
+| repro | before | after |
+| --- | --- | --- |
+| `__s[0]` (literal index — no imports) | compiles | compiles |
+| `__s[__s.length - 1]` (index adds imports) | **INVALID** | compiles |
+| `const i = __s.length - 1; __s[i]` (index pre-stored) | compiles | compiles |
+
+Only the middle case — where the index expression itself registers late
+imports — was broken, pinpointing the capture-before-compile ordering.
+
+It regressed silently because `tests/issue-2767.test.ts` is not wired into the
+required `quality`/test262 gates, and the actual Date/`toISOString` test262
+cluster (15/17 host) never exercises this `any`-return-of-a-string-index shape.
+
+## Fix
+
+`src/codegen/property-access.ts`, the `(#2784 S3)` block in
+`compileElementAccessBody`: **compile the index expression first, then register
+the fast-path imports, flush once, and resolve `__vec_get` — so no funcIdx is
+captured before an import-adding index compile.** The receiver is stored into
+`__nve_recv` first (unchanged local numbering); a defensive fallback emits the
+generic host read from the stored locals if the fast-path imports are somehow
+unavailable (unreachable in host mode). For a non-import-adding index (e.g. a
+literal) the import order is identical, so valid output is byte-for-byte
+unchanged.
+
+## Acceptance criteria
+
+- `tests/issue-2767.test.ts` goes from 6/11 failing to 11/11 passing.
+- New `tests/issue-3007.test.ts` covers the `any`-context computed-index read on
+  a string, a native-vec receiver, and a plain externref, incl. the
+  import-adding index shape.
+- Byte-inert: outputs for programs not exercising this exact path are unchanged.

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -6905,7 +6905,24 @@ export function compileElementAccessBody(
     // already ref.tests `$ObjVec`); numeric index only (a string key is a genuine
     // property, never a vec index).
     if (!ctx.standalone && ctx.vecTypeMap.size > 0 && isNumericIndexExpression(ctx, expr.argumentExpression)) {
-      const vecGetIdx = ctx.funcMap.get("__vec_get");
+      // recv externref is on the stack → recvLocal (allocated FIRST so the local
+      // numbering of recv / idx / anyTmp is unchanged from before #3007).
+      const recvLocal = allocLocal(fctx, `__nve_recv_${fctx.locals.length}`, { kind: "externref" });
+      fctx.body.push({ op: "local.set", index: recvLocal } as Instr);
+      // (#3007) index → f64 → idxLocal, compiled BEFORE the fast-path funcIdxs are
+      // captured. A computed index (`a[a.length - 1]`) lowers its own dynamic
+      // reads, which can register late imports and shift every DEFINED-function
+      // index — including `__vec_get`. The pre-#3007 order captured `__vec_get`
+      // BEFORE this compile, so the index's imports left it stale; the desynced
+      // `then` arm emitted an invalid instruction stream (`f64.convert_i32_s` on
+      // the externref receiver → "expected i32, found externref", invalid Wasm).
+      // Resolving the imports and `__vec_get` AFTER the index compile (single
+      // flush) keeps every funcIdx live through emission. For a non-import-adding
+      // index (e.g. a literal) the import order is identical, so valid output is
+      // byte-for-byte unchanged.
+      compileExpression(ctx, fctx, expr.argumentExpression, { kind: "f64" });
+      const idxLocal = allocLocal(fctx, `__nve_idx_${fctx.locals.length}`, { kind: "f64" });
+      fctx.body.push({ op: "local.set", index: idxLocal } as Instr);
       const extGetIdx = ensureLateImport(
         ctx,
         "__extern_get",
@@ -6914,15 +6931,8 @@ export function compileElementAccessBody(
       );
       const boxNumIdx = ensureLateImport(ctx, "__box_number", [{ kind: "f64" }], [{ kind: "externref" }]);
       flushLateImportShifts(ctx, fctx);
-      const vgIdx = vecGetIdx ?? reserveVecMethodHelper(ctx, "get");
+      const vgIdx = ctx.funcMap.get("__vec_get") ?? reserveVecMethodHelper(ctx, "get");
       if (vgIdx !== undefined && extGetIdx !== undefined && boxNumIdx !== undefined) {
-        // recv externref is on the stack → recvLocal.
-        const recvLocal = allocLocal(fctx, `__nve_recv_${fctx.locals.length}`, { kind: "externref" });
-        fctx.body.push({ op: "local.set", index: recvLocal } as Instr);
-        // index → f64 → idxLocal (numeric index; reused as i32 for vec, boxed for host).
-        compileExpression(ctx, fctx, expr.argumentExpression, { kind: "f64" });
-        const idxLocal = allocLocal(fctx, `__nve_idx_${fctx.locals.length}`, { kind: "f64" });
-        fctx.body.push({ op: "local.set", index: idxLocal } as Instr);
         // isVec = OR of ref.test over the registered vec carriers.
         const anyTmp = allocLocal(fctx, `__nve_any_${fctx.locals.length}`, { kind: "anyref" } as ValType);
         fctx.body.push({ op: "local.get", index: recvLocal } as Instr);
@@ -6957,6 +6967,21 @@ export function compileElementAccessBody(
         } as Instr);
         return { kind: "externref" };
       }
+      // (#3007) Defensive fallback — recv/idx were consumed into locals above, so
+      // if the fast-path imports are somehow unavailable we must not fall through
+      // to the generic path (which expects recv on the stack). Emit the generic
+      // host read from the stored locals. Unreachable in host mode (the box/extern
+      // imports are always registerable), so this changes no valid output.
+      fctx.body.push({ op: "local.get", index: recvLocal } as Instr);
+      if (boxNumIdx !== undefined && extGetIdx !== undefined) {
+        fctx.body.push({ op: "local.get", index: idxLocal } as Instr);
+        fctx.body.push({ op: "call", funcIdx: boxNumIdx } as Instr);
+        fctx.body.push({ op: "call", funcIdx: extGetIdx } as Instr);
+        return { kind: "externref" };
+      }
+      fctx.body.push({ op: "drop" } as Instr);
+      fctx.body.push({ op: "ref.null.extern" } as Instr);
+      return { kind: "externref" };
     }
     // (#2166 PR-C2) A NUMERIC index on a standalone externref must go through
     // `__extern_get_idx(v, f64)`, not the string-keyed `__extern_get`. The

--- a/tests/issue-3007.test.ts
+++ b/tests/issue-3007.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { compileToWasm } from "./equivalence/helpers.js";
+
+// #3007 — a computed numeric read `recv[idx]` on an `any`/externref receiver
+// routes through the (#2784 S3) native-vec-aware fast path in
+// compileElementAccessBody. That path used to capture the `__vec_get` funcIdx
+// BEFORE compiling the index expression. When the index itself lowers a dynamic
+// read (e.g. `recv.length - 1`), it registers late imports that shift every
+// DEFINED-function index — including `__vec_get` — so the captured index went
+// stale and the `then` arm emitted `f64.convert_i32_s` on the externref
+// receiver: `Invalid Wasm binary`. The fix compiles the index first, then
+// resolves the funcIdxs, keeping them live through emission.
+describe("#3007 any-context computed-index read funcIdx desync", () => {
+  it("string index with an import-adding index expr returns the last char", async () => {
+    // __s is `any` (d.toISOString() on an evolving-any binding); the index
+    // `__s.length - 1` registers late imports mid-compile. Before #3007 this
+    // produced invalid Wasm; now it compiles and returns the correct char.
+    const ex = (await compileToWasm(
+      `export function test(): any {
+         var d; d = new Date(0);
+         const __s = d.toISOString();
+         return __s[__s.length - 1];
+       }`,
+    )) as { test: () => unknown };
+    expect(ex.test()).toBe("Z");
+  });
+
+  it("string literal-index read still works (byte-path unchanged)", async () => {
+    const ex = (await compileToWasm(`export function test(): any { const s: any = "abc"; return s[0]; }`)) as {
+      test: () => unknown;
+    };
+    expect(ex.test()).toBe("a");
+  });
+
+  it("pre-stored index read is unaffected", async () => {
+    const ex = (await compileToWasm(
+      `export function test(): any {
+         var d; d = new Date(0);
+         const __s = d.toISOString();
+         const i = __s.length - 1;
+         return __s[i];
+       }`,
+    )) as { test: () => unknown };
+    expect(ex.test()).toBe("Z");
+  });
+
+  it("native-vec receiver read via import-adding index reads the element", async () => {
+    // An `any` receiver that actually carries a native vec at runtime: the
+    // fast-path `then` arm (call __vec_get) must resolve correctly even when the
+    // index expression `a.length - 1` registers late imports.
+    const ex = (await compileToWasm(
+      `export function test(): number {
+         const a: any = [10, 20, 30];
+         return a[a.length - 1];
+       }`,
+    )) as { test: () => number };
+    expect(ex.test()).toBe(30);
+  });
+
+  it("plain externref object numeric read via import-adding index", async () => {
+    const ex = (await compileToWasm(
+      `export function test(): any {
+         const o: any = { 0: "x", 1: "y", length: 2 };
+         return o[o.length - 1];
+       }`,
+    )) as { test: () => unknown };
+    expect(ex.test()).toBe("y");
+  });
+});


### PR DESCRIPTION
## Problem
A computed numeric read `recv[idx]` on an `any`/externref receiver — e.g. `d.toISOString()[__s.length - 1]` returned in an `any` context — produced **invalid Wasm** on `main`:

```
CompileError: f64.convert_i32_s[0] expected type i32, found local.get of type externref
```

Surfaced by the #2768 measure-first investigation: `tests/issue-2767.test.ts` was **6/11 failing** on main with `Invalid Wasm binary`, independent of the bare-`var` safelist. It regressed silently because that file is not wired into the required `quality`/test262 gates, and the Date/`toISOString` test262 cluster (15/17 host) never exercises this `any`-return-of-a-string-index shape.

## Root cause — late-import funcIdx desync
The receiver is `any` → externref, so `recv[idx]` routes through the `(#2784 S3)` native-vec-aware fast path in `compileElementAccessBody` (`src/codegen/property-access.ts`). That path captured `__vec_get`/`__extern_get`/`__box_number` and flushed the pending late-import shifts, **then** compiled the index expression `__s.length - 1`. But compiling that index is itself a dynamic `.length` read on an externref, which **registers late imports** and shifts every DEFINED-function index — including `__vec_get`. The captured index went stale and the `then` arm's `call __vec_get` desynced, corrupting the emitted stream into `f64.convert_i32_s` on the externref receiver.

Confirmation (host mode):

| repro | before | after |
| --- | --- | --- |
| `__s[0]` (literal index — no imports) | compiles | compiles |
| `__s[__s.length - 1]` (index adds imports) | **INVALID** | compiles |
| `const i = __s.length - 1; __s[i]` (index pre-stored) | compiles | compiles |

Only the case where the index expression itself registers late imports was broken.

## Fix
Store the receiver into a local first (unchanged local numbering), **compile the index expression, THEN register the imports, flush once, and resolve `__vec_get`** — so no funcIdx is captured before an import-adding index compile. A defensive fallback emits the generic host read from the stored locals if the fast-path imports are somehow unavailable (unreachable in host mode).

## Validation
- `tests/issue-2767.test.ts`: **6/11 failing → 11/11 passing**, with correct runtime values (`"Z"`).
- New `tests/issue-3007.test.ts` (5 tests): string / native-vec / plain-externref receivers with import-adding and literal indices — all pass.
- **Byte-inert**: compiled output for a 21-program corpus (13 example files + 8 curated element-access snippets) is **byte-for-byte identical** between origin/main and this branch. For a non-import-adding index the import order is unchanged, so valid output is unaffected — only the previously-invalid lane changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)