### PR TITLE
feat(codegen): #3006 genuine reified builtin-constructor identity (standalone) — supersede #2537 null-fold

### DIFF
--- a/plan/issues/3006-genuine-builtin-constructor-identity.md
+++ b/plan/issues/3006-genuine-builtin-constructor-identity.md
@@ -1,0 +1,183 @@
+---
+id: 3006
+title: "Genuine reified builtin-constructor identity: <Builtin>.prototype.constructor === <Builtin> (standalone) — supersede the #2537 null-fold"
+status: done
+completed: 2026-07-03
+assignee: ttraenkler/senior-dev
+sprint: current
+priority: medium
+horizon: m
+feasibility: hard
+reasoning_effort: max
+task_type: feature
+area: codegen
+language_feature: builtins
+goal: standalone-mode
+related: [2963, 2999, 2537, 2555]
+supersedes: [2537, 2999]
+origin: "Extend #2963's builtin-value reification substrate to constructor identity; supersede #2537's null-fold (#2999)"
+---
+
+# #3006 — genuine reified builtin-constructor identity (supersedes #2537 null-fold)
+
+## Problem
+
+Round-5 leak analysis (#2999) flagged **9 standalone passes** whose sole `env::`
+import is `Object_get_constructor`: all `<Builtin>.prototype.constructor === <Builtin>`
+(Set / WeakMap / WeakRef / WeakSet / RegExp / FinalizationRegistry /
+DisposableStack / SuppressedError) plus instance forms
+(`(new WeakMap()).constructor`, `/re/.constructor`).
+
+Reading `.constructor` on a builtin extern-class receiver walks the extern
+inheritance chain to the `Object` base extern class (the only declarer of
+`constructor`, `importPrefix: "Object"`), emitting an `env::Object_get_constructor`
+host import — a standalone leak (the binary imports a host getter it should not
+need).
+
+**PR #2537 (issue #2999) took a WEAKER approach** — it folded `.constructor` to
+`ref.null.extern`. That passed only via a **null≡null tautology**: the bare
+builtin identifier (`Set`) ALSO compiled to the null carrier, so both sides of
+`===` collapsed to null and compared equal. The predecessor's own cross-check
+proved it hollow — `Set.prototype.constructor === Map` **also passed** (both
+null). #2537 was flagged as "honest-accounting: host-import elimination, NOT a
+correctness fix" and should NOT be the final answer.
+
+## Root cause of the null≡null tautology
+
+Builtins had **no reified constructor-object identity** in standalone mode. Both
+the bare identifier `Set` (as a value) and the `.constructor` read resolved to
+the shared null-externref carrier — so every comparison was `null === null`, true
+regardless of which builtins were being compared.
+
+## Fix — extend #2963's "reify builtins as first-class values" substrate
+
+Give each target builtin constructor a **genuine, identity-stable reified
+`$Object` singleton** — one `externref` mutable global `__builtin_ctor_<Name>`
+per constructor name, lazily materialized once to a fresh `__new_plain_object`
+behind an `if (ref.is_null) { … }` guard (`emitBuiltinConstructorIdentity`,
+`src/codegen/builtin-static-globals.ts`). This is exactly the substrate #2963's
+issue plan calls for ("synthesize … a `$Object`-backed … module-level singleton
+slot per reified builtin; the same builtin reference must yield the same
+object"). It is the natural vehicle for a constructor **object** (an object with
+identity), whereas #2963's static-method `pushBuiltinFnSingletonValueInstrs`
+requires a real lifted `funcIdx` per builtin, which a bare constructor lacks.
+
+**Both** sites route to the SAME per-name global:
+
+1. **Bare identifier** (`… === Set`, `assert.sameValue(…, Set)`) —
+   `src/codegen/expressions/identifiers.ts`, standalone, after all
+   local/module/declared-global shadowing and the class-object / promise-subclass
+   singleton blocks, before the null-externref fallback.
+2. **`.constructor` read** (`Set.prototype.constructor`,
+   `(new WeakMap()).constructor`, `re.constructor`) —
+   `src/codegen/property-access.ts` `compilePropertyAccess`, placed EARLY (after
+   the existing `.constructor` special-cases, before the builtin-specific
+   `.prototype`/regexp/native-proto member paths). Gated on the receiver being a
+   genuine ambient-declared builtin (`isExternalDeclaredClass` + the narrow
+   `BUILTIN_CONSTRUCTOR_IDENTITY_NAMES` set).
+
+Because both resolve to the same `__builtin_ctor_<Name>` global,
+`<Builtin>.prototype.constructor === <Builtin>` is **GENUINELY true** (same
+WasmGC object, `ref.eq`) and the swap-wrong-builtin cross-check
+`Set.prototype.constructor === Map` is **GENUINELY false** (distinct singletons).
+
+### Why the `.constructor` fold is placed early (not in `compileExternPropertyGet`)
+
+Routing `RegExp.prototype.constructor` through `compileExternPropertyGet` (where
+an earlier draft put it, and where #2537 folded) never fires: a RegExp-specific
+member path returns first (`Set.prototype` DOES reach `compileExternPropertyGet`,
+but `RegExp.prototype` does not — verified by tracing). Placing the fold in
+`compilePropertyAccess` before those builtin-specific paths makes it fire
+UNIFORMLY for every target builtin.
+
+### Scope discipline
+
+`BUILTIN_CONSTRUCTOR_IDENTITY_NAMES` is the NARROW subset of `BUILTIN_CTOR_NAMES`
+whose bare value currently resolves to null standalone (verified: all read falsy)
+and whose `.constructor` leaks `Object_get_constructor`: Set, Map, WeakMap,
+WeakSet, WeakRef, RegExp, FinalizationRegistry, DisposableStack,
+AsyncDisposableStack, SuppressedError. It EXCLUDES builtins that already carry a
+genuine bare-value identity — `Math`/`JSON`/`Reflect` and the `Error` family
+(#2907 namespace-object carriers), `Array`/`Object` (namespace objects),
+native-error-tag constructors, TypedArrays, `Promise`, `Date`, etc. — so those
+keep their existing lowering untouched.
+
+### Not affected by the #2963 Phase-2 (Number.isInteger) blocker
+
+#2555/#2963 documented a Phase-2 blocker: a reified static method CALLED as a
+value (`const f = Number.isInteger; f(x)`) mis-dispatches because the any-callable
+dispatch keys on arity, not exact param type, so a scalar-param closure traps.
+That blocker is about **calling** a reified value. This issue's reified
+constructor object is only ever **read and compared by identity**, never called —
+so it does not hit the arity-dispatch blocker (confirmed: all 9 tests + swap
+guards run without trapping).
+
+## Genuine-correctness verification
+
+Verified with `--target standalone --nativeStrings` (run, not just compiled),
+using clean identity oracles (inline `===` → concrete-ref `ref.eq`; and a CLEAN
+`if (a===b) return true` SameValue helper across the externref-widening
+function-param boundary):
+
+- `<Builtin>.prototype.constructor === <Builtin>` → **1** for all 8 named builtins
+  - `(new WeakMap()).constructor` + typed `re.constructor` (host-free).
+- **Swap-wrong-builtin guard** (`project_hostfree_pass_can_be_coincidentally_wrong_not_just_vacuous`):
+  `Set.prototype.constructor === Map` → **0**, `WeakMap.prototype.constructor === Set`
+  → **0**, `re.constructor === Set` → **0** (GENUINELY false — the #2537 null-fold
+  returned true here).
+- Bare identifiers: `Set === Set` → **1**, `Set === Map` → **0**, inline
+  `(Set as any) === (Map as any)` → **0**.
+- All **9 origin test262 files pass** in the standalone lane, host-free
+  (`env::Object_get_constructor` absent).
+- gc/host lane byte-inert (sha256 `7892df4bdd0bf146` unchanged) and retains the
+  real `Object_get_constructor` import (fold is `ctx.standalone`-gated).
+- Standalone programs with no builtin-constructor value reads byte-inert
+  (plain-math `d14df15d9255a873`, `[1,2,3].map(Number)` `869c424a2ae36eaf`).
+
+## Adjacent discovery (pre-existing, out of scope) — the verbatim test262 `_isSameValue` confound
+
+The verbatim test262 harness `assert._isSameValue` is
+`if (a === b) { return a !== 0 || 1/a === 1/b; } return a !== a && b !== b;`. The
+`1/a === 1/b` sub-expression makes the compiler ToNumber-coerce the `any`
+operands, which **collapses the `a === b` reference comparison for ALL objects** —
+reproducible with two distinct plain object literals (`{p:1} !== {p:2}` returns
+**1** under this exact harness but **0** under a clean `if (a===b) return true`
+helper), using NONE of this issue's code. So the verbatim harness is NOT a
+faithful identity oracle. It does **not** cause a false pass here: the 9 tests
+only assert the spec-TRUE case (`.constructor === <same Builtin>`), which passes,
+and test262 has no `notSameValue(<Builtin>.prototype.constructor, <other>)` test.
+The genuine identity above is validated with clean oracles instead. This
+harness-lowering bug (an `any`-operand `1/a` numeric-coercion issue, #2058 family)
+is a separate pre-existing defect; filing a follow-up is warranted but out of
+scope for #3006.
+
+## Deferred — `Object_set_constructor` / RegExp `Symbol.split`/`matchAll` species (~5 tests)
+
+The task flagged the `Object_set_constructor` tail (~5 tests) as conditional ("if
+related"). It is a distinct **write-path** concern (`obj.constructor = X` /
+species-constructor derivation), not a value-READ, so this read-identity fix does
+not address it and it is not trivially reproduced on current main (no
+`constructor` import leaked by the probed species/split shapes). Deferred to a
+follow-up; the read-identity substrate here is the prerequisite it would build on.
+
+## Acceptance criteria
+
+- The 9 listed test262 files pass in the standalone lane, host-free. ✅ (9/9)
+- `env::Object_get_constructor` eliminated from those binaries. ✅
+- Identity is GENUINE, not a null≡null tautology — swap-wrong-builtin returns
+  false. ✅
+- gc/host lane unchanged — `Object_get_constructor` retained; byte-inert. ✅
+- No regression in Set/Map/RegExp/Weak\*/DisposableStack/SuppressedError suites.
+  ✅ (101 passing tests across 10 suites; the 4 `issue-2175` failures are
+  pre-existing on `origin/main`, identical without this change.)
+
+## Files
+
+- `src/codegen/builtin-static-globals.ts` — `BUILTIN_CONSTRUCTOR_IDENTITY_NAMES`,
+  `isBuiltinConstructorIdentityName`, `emitBuiltinConstructorIdentity`.
+- `src/codegen/property-access.ts` — early `.constructor` fold in
+  `compilePropertyAccess`.
+- `src/codegen/expressions/identifiers.ts` — bare builtin-constructor identifier
+  value read.
+- `tests/issue-3006-builtin-constructor-identity.test.ts` — genuine-identity +
+  swap-guard + host-free + gc/host-retains-import (14 tests).

--- a/src/codegen/builtin-static-globals.ts
+++ b/src/codegen/builtin-static-globals.ts
@@ -53,6 +53,103 @@ export function isSupportedBuiltinNamespace(name: string): boolean {
   return SUPPORTED_STATIC_PROPS.has(name);
 }
 
+/**
+ * (#3006) Builtin CONSTRUCTOR names that get a GENUINE, identity-stable reified
+ * constructor-object carrier in standalone mode — the substrate #2963's issue
+ * plan calls for ("synthesize … a `$Object`-backed … module-level singleton
+ * slot per reified builtin; the same builtin reference must yield the same
+ * object"). Both the bare identifier read (`… === Set`) AND the
+ * `<Builtin>.prototype.constructor` / `(new <Builtin>()).constructor` read route
+ * to the SAME per-name `__builtin_ctor_<Name>` singleton, so
+ * `Set.prototype.constructor === Set` is GENUINELY true (same object) while the
+ * swap-wrong-builtin cross-check `Set.prototype.constructor === Map` is GENUINELY
+ * false (distinct per-name singletons) — NOT a null≡null tautology.
+ *
+ * This is deliberately the narrow subset of `BUILTIN_CTOR_NAMES` whose bare value
+ * currently resolves to the null-externref carrier standalone (verified: all read
+ * falsy today, no native constructor-object identity) and whose `.constructor`
+ * read otherwise leaks the `env::Object_get_constructor` host import (#2999
+ * round-5 leak analysis). It EXCLUDES builtins that already carry a genuine
+ * bare-value identity — `Math`/`JSON`/`Reflect` and the `Error` family
+ * (namespace-object carriers, #2907), `Array`/`Object` (namespace objects),
+ * native-error-tag constructors, etc. — so those keep their existing lowering
+ * untouched.
+ */
+export const BUILTIN_CONSTRUCTOR_IDENTITY_NAMES: ReadonlySet<string> = new Set([
+  "Set",
+  "Map",
+  "WeakMap",
+  "WeakSet",
+  "WeakRef",
+  "RegExp",
+  "FinalizationRegistry",
+  "DisposableStack",
+  "AsyncDisposableStack",
+  "SuppressedError",
+]);
+
+export function isBuiltinConstructorIdentityName(name: string): boolean {
+  return BUILTIN_CONSTRUCTOR_IDENTITY_NAMES.has(name);
+}
+
+/**
+ * (#3006) Emit a GENUINE, identity-stable reified builtin-constructor object.
+ *
+ * One `externref` mutable global per constructor name (`__builtin_ctor_<Name>`),
+ * lazily materialized once on first read to a fresh `$Object`
+ * (`__new_plain_object`) behind an `if (ref.is_null) { … }` guard, then read via
+ * `global.get`. Every read of the same builtin — whether the bare identifier
+ * (`Set`) or a `.prototype.constructor` / instance `.constructor` read — yields
+ * the SAME object ref, so `===` (WasmGC `ref.eq` identity, preserved even across
+ * the externref-widening `assert.sameValue(a, b)` harness boundary — verified) is
+ * genuinely true for the same builtin and genuinely false across distinct
+ * builtins.
+ *
+ * The materialization is emitted directly into `fctx.body` (a shift-covered
+ * array) and contains only a `call __new_plain_object` — no `ref.func` operand —
+ * so it is immune to the late-import funcidx-shift hazard that forced #2963's
+ * static-method singleton to avoid a const-init global. Keyed in the shared
+ * `builtinObjectGlobals` map under a `ctor:` prefix so it never collides with the
+ * namespace-object carriers (`emitBuiltinNamespaceObject`), which key by bare
+ * name.
+ *
+ * Stack: `[] → [externref]`.
+ */
+export function emitBuiltinConstructorIdentity(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  builtinName: string,
+): ValType {
+  ensureObjectRuntime(ctx);
+  const newObjectIdx = ctx.funcMap.get("__new_plain_object")!;
+
+  const key = `ctor:${builtinName}`;
+  let globalIdx = ctx.builtinObjectGlobals.get(key);
+  if (globalIdx === undefined) {
+    globalIdx = ctx.numImportGlobals + ctx.mod.globals.length;
+    ctx.mod.globals.push({
+      name: `__builtin_ctor_${builtinName}`,
+      type: { kind: "externref" },
+      mutable: true,
+      init: [{ op: "ref.null.extern" }],
+    });
+    ctx.builtinObjectGlobals.set(key, globalIdx);
+  }
+
+  fctx.body.push({ op: "global.get", index: globalIdx });
+  fctx.body.push({ op: "ref.is_null" });
+  fctx.body.push({
+    op: "if",
+    blockType: { kind: "empty" },
+    then: [
+      { op: "call", funcIdx: newObjectIdx },
+      { op: "global.set", index: globalIdx },
+    ],
+  } as Instr);
+  fctx.body.push({ op: "global.get", index: globalIdx });
+  return { kind: "externref" };
+}
+
 export function isSupportedBuiltinStaticProperty(builtinName: string, propName: string): boolean {
   return SUPPORTED_STATIC_PROPS.get(builtinName)?.includes(propName) ?? false;
 }

--- a/src/codegen/expressions/identifiers.ts
+++ b/src/codegen/expressions/identifiers.ts
@@ -39,7 +39,12 @@ import { popBody, pushBody } from "../context/bodies.js";
 import { reportSilentFallback } from "../fallback-telemetry.js";
 import { emitThrowReferenceError, emitThrowTypeError, noJsHost } from "./helpers.js";
 import { emitDynamicWithGet, emitWithBindingGet, resolveWithBinding } from "../with-scope.js";
-import { emitBuiltinNamespaceObject, isSupportedBuiltinNamespace } from "../builtin-static-globals.js";
+import {
+  emitBuiltinConstructorIdentity,
+  emitBuiltinNamespaceObject,
+  isBuiltinConstructorIdentityName,
+  isSupportedBuiltinNamespace,
+} from "../builtin-static-globals.js";
 import { tryEmitPromiseSubclassValue } from "./promise-subclass.js";
 
 /**
@@ -783,6 +788,24 @@ function compileIdentifierCore(ctx: CodegenContext, fctx: FunctionContext, id: t
     if (tryEmitPromiseSubclassValue(ctx, fctx, name)) {
       return { kind: "externref" };
     }
+  }
+
+  // (#3006) Standalone bare builtin-CONSTRUCTOR identifier read as a VALUE
+  // (`… === Set`, `assert.sameValue(…, Set)`, `[Set, Map]`) → the GENUINE,
+  // identity-stable reified constructor object, NOT the null-externref carrier it
+  // otherwise falls through to. This is the RHS partner of the
+  // `<Builtin>.prototype.constructor` fold in property-access.ts: both resolve to
+  // the SAME per-name `__builtin_ctor_<Name>` singleton, so
+  // `Set.prototype.constructor === Set` is genuinely true and
+  // `Set.prototype.constructor === Map` genuinely false (distinct singletons).
+  // Scoped to the narrow constructor subset with no existing bare-value identity
+  // (Set/Map/Weak*/RegExp/FinalizationRegistry/Disposable*/SuppressedError) and to
+  // standalone; gc/host and the namespace-object / native-error-tag builtins are
+  // untouched. Order: AFTER local/module/declared-global shadowing and the
+  // class-object / promise-subclass singleton blocks (so a user binding or a real
+  // class always wins), BEFORE the null-externref fallback.
+  if (ctx.standalone && isBuiltinConstructorIdentityName(name)) {
+    return emitBuiltinConstructorIdentity(ctx, fctx, name);
   }
 
   // #1502 — Browser Storage globals (localStorage / sessionStorage). Emit

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -34,6 +34,7 @@ import {
   pushBuiltinFnSingletonValueInstrs,
   STANDALONE_STATIC_METHOD_META,
 } from "./builtin-fn-meta.js";
+import { emitBuiltinConstructorIdentity, isBuiltinConstructorIdentityName } from "./builtin-static-globals.js";
 import { emitLazyClassObjectGet, emitLazyProtoGet, findExternInfoForMember } from "./expressions/extern.js";
 import {
   classifyPrivateMember,
@@ -3163,6 +3164,47 @@ export function compilePropertyAccess(
     if (isAnyOrUnknown) {
       const ctorIdn = tryEmitConstructorViaTag(ctx, fctx, expr, objType);
       if (ctorIdn !== undefined) return ctorIdn;
+    }
+  }
+
+  // (#3006) Standalone `<Builtin>.prototype.constructor` / `<instance>.constructor`
+  // → the GENUINE, identity-stable reified builtin-constructor object (supersedes
+  // the #2537 null-fold). Reading `.constructor` on a builtin extern-class receiver
+  // otherwise walks the inheritance chain (`compileExternPropertyGet`) to the
+  // `Object` base extern class — the only declarer of `constructor`,
+  // `importPrefix: "Object"` — and emits an `env::Object_get_constructor` host
+  // import (the leak the #2999 round-5 analysis flagged: 9 standalone passes for
+  // Set/WeakMap/WeakRef/WeakSet/RegExp/FinalizationRegistry/DisposableStack/
+  // SuppressedError plus instance forms). Route it to the SAME per-name
+  // `__builtin_ctor_<Name>` singleton the bare identifier now resolves to
+  // (identifiers.ts), so `<Builtin>.prototype.constructor === <Builtin>` is
+  // GENUINELY true (same object) and the swap-wrong-builtin cross-check
+  // `Set.prototype.constructor === Map` is GENUINELY false — NOT the null≡null
+  // tautology #2537 relied on.
+  //
+  // Placed HERE (before the builtin-specific `.prototype`/regexp/native-proto
+  // member paths further down) so it fires UNIFORMLY for every target builtin:
+  // routing `RegExp.prototype.constructor` through `compileExternPropertyGet` would
+  // never reach it (a RegExp-specific member path returns first). Gated on the
+  // receiver being a genuine ambient-declared builtin (`isExternalDeclaredClass` +
+  // the narrow `BUILTIN_CONSTRUCTOR_IDENTITY_NAMES` set) so a user `class Set {}`
+  // (not extern-declared) keeps its own `.constructor`. Standalone-only: gc/host
+  // keeps the real `Object_get_constructor` read (a genuine value there).
+  if (ctx.standalone && propName === "constructor") {
+    const builtinName = objType.getSymbol()?.name;
+    if (
+      builtinName !== undefined &&
+      isBuiltinConstructorIdentityName(builtinName) &&
+      isExternalDeclaredClass(objType, ctx.checker)
+    ) {
+      // Evaluate the receiver for its side effects (spec: the object expression is
+      // evaluated), then discard it — the constructor identity does not depend on
+      // the receiver instance.
+      const objResult = compileExpression(ctx, fctx, expr.expression);
+      if (objResult) {
+        fctx.body.push({ op: "drop" });
+      }
+      return emitBuiltinConstructorIdentity(ctx, fctx, builtinName);
     }
   }
 

--- a/tests/issue-3006-builtin-constructor-identity.test.ts
+++ b/tests/issue-3006-builtin-constructor-identity.test.ts
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #3006 — GENUINE, identity-stable reified builtin CONSTRUCTOR objects (standalone).
+ *
+ * Extends #2963's "reify builtins as first-class values" substrate to
+ * `<Builtin>.prototype.constructor === <Builtin>`. Round-5 leak analysis (#2999)
+ * flagged 9 standalone passes whose sole `env::` import was
+ * `Object_get_constructor` — all `<Builtin>.prototype.constructor === <Builtin>`
+ * (Set / WeakMap / WeakRef / WeakSet / RegExp / FinalizationRegistry /
+ * DisposableStack / SuppressedError) plus instance forms.
+ *
+ * The SUPERSEDED approach (#2537) folded `.constructor` to `ref.null.extern`,
+ * which passed only via a null≡null tautology — `Set.prototype.constructor === Map`
+ * ALSO passed (both null). This PR instead routes BOTH the bare builtin identifier
+ * (`… === Set`) AND the `.constructor` read to the SAME per-name
+ * `__builtin_ctor_<Name>` `$Object` singleton, so identity is GENUINE: same builtin
+ * → same object (true), distinct builtins → distinct objects (false).
+ *
+ * The comparisons below use inline `===` (concrete-ref `ref.eq` path) and a CLEAN
+ * SameValue helper (`if (a===b) return true`) — both of which genuinely exercise
+ * WasmGC reference identity. (The verbatim test262 `assert._isSameValue`, which
+ * contains `1/a === 1/b`, has a SEPARATE, pre-existing lowering bug that ToNumber-
+ * coerces `any` operands and makes `a===b` collapse for ALL objects — reproducible
+ * with plain `{}`/`{}` object literals and untouched by this PR — so it is not a
+ * faithful identity oracle. The 9 test262 files still PASS regardless, since they
+ * only assert the TRUE case; see the issue file's honest-accounting note.)
+ */
+
+async function standaloneImports(src: string): Promise<string[]> {
+  const r = await compile(src, { target: "standalone", nativeStrings: true });
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+  return r.imports.map((i) => `${i.module}::${i.name}`);
+}
+
+async function runStandalone(src: string): Promise<number> {
+  const full = `function isSameValue(a: any, b: any): boolean { if (a === b) { return true; } return a !== a && b !== b; }\nexport function test(): number { ${src} }`;
+  const r = await compile(full, { target: "standalone", nativeStrings: true });
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+const HOST_IMPORT = "env::Object_get_constructor";
+const CTORS = [
+  "Set",
+  "WeakMap",
+  "WeakRef",
+  "WeakSet",
+  "RegExp",
+  "FinalizationRegistry",
+  "DisposableStack",
+  "SuppressedError",
+] as const;
+
+describe("#3006 — genuine reified builtin-constructor identity (standalone)", () => {
+  for (const c of CTORS) {
+    it(`${c}.prototype.constructor === ${c} is GENUINELY true, host-free`, async () => {
+      const src = `return isSameValue(${c}.prototype.constructor, ${c}) ? 1 : 0;`;
+      expect(await runStandalone(src)).toBe(1);
+      const imports = await standaloneImports(
+        `export function test(): number { const c: any = ${c}.prototype.constructor; return c ? 1 : 0; }`,
+      );
+      expect(imports, `leaked ${HOST_IMPORT}`).not.toContain(HOST_IMPORT);
+    });
+  }
+
+  // The genuine-correctness guard (memory
+  // `project_hostfree_pass_can_be_coincidentally_wrong_not_just_vacuous`): a
+  // wrong-builtin cross-check MUST be false — the #2537 null-fold made it true.
+  it("swap-wrong-builtin: Set.prototype.constructor === Map is GENUINELY false", async () => {
+    expect(await runStandalone(`return isSameValue(Set.prototype.constructor, Map) ? 1 : 0;`)).toBe(0);
+  });
+
+  it("swap-wrong-builtin: WeakMap.prototype.constructor === Set is GENUINELY false", async () => {
+    expect(await runStandalone(`return isSameValue(WeakMap.prototype.constructor, Set) ? 1 : 0;`)).toBe(0);
+  });
+
+  it("bare builtin identifiers have distinct genuine identity (Set !== Map, Set === Set)", async () => {
+    expect(await runStandalone(`return isSameValue(Set, Set) ? 1 : 0;`)).toBe(1);
+    expect(await runStandalone(`return isSameValue(Set, Map) ? 1 : 0;`)).toBe(0);
+    // inline (concrete-ref ref.eq path)
+    const r = await compile(`export function test(): number { return ((Set as any) === (Map as any)) ? 1 : 0; }`, {
+      target: "standalone",
+      nativeStrings: true,
+    });
+    expect(r.success).toBe(true);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports as { test: () => number }).test()).toBe(0);
+  });
+
+  it("instance-form (new WeakMap()).constructor === WeakMap is genuinely true; === Set is false", async () => {
+    expect(await runStandalone(`return isSameValue((new WeakMap()).constructor, WeakMap) ? 1 : 0;`)).toBe(1);
+    expect(await runStandalone(`return isSameValue((new WeakMap()).constructor, Set) ? 1 : 0;`)).toBe(0);
+  });
+
+  it("regexp-literal instance .constructor === RegExp is genuinely true; === Set is false; host-free", async () => {
+    expect(await runStandalone(`const re = /[^a]*/; return isSameValue(re.constructor, RegExp) ? 1 : 0;`)).toBe(1);
+    expect(await runStandalone(`const re = /[^a]*/; return isSameValue(re.constructor, Set) ? 1 : 0;`)).toBe(0);
+    const imports = await standaloneImports(
+      `export function test(): number { const re = /a/; const c: any = re.constructor; return c ? 1 : 0; }`,
+    );
+    expect(imports).not.toContain(HOST_IMPORT);
+  });
+
+  it("gc/host lane keeps the real Object_get_constructor read (fold is standalone-only)", async () => {
+    const r = await compile(
+      `export function test(): number { const a: any = Set.prototype.constructor; const b: any = Set; return a === b ? 1 : 0; }`,
+      { skipSemanticDiagnostics: true },
+    );
+    expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(r.imports.map((i) => `${i.module}::${i.name}`)).toContain(HOST_IMPORT);
+  });
+});


### PR DESCRIPTION
## #3006 — genuine builtin-constructor identity (supersedes #2537 null-fold)

Extends **#2963**'s "reify builtins as first-class values" substrate to
`<Builtin>.prototype.constructor === <Builtin>`, closing the
`env::Object_get_constructor` leak (#2999 round-5, **9 standalone passes**)
with **genuine** identity — not the null≡null tautology **PR #2537** relied on.

### The problem with #2537
#2537 folded `.constructor` to `ref.null.extern`. It passed only because the bare
builtin identifier ALSO compiled to null, so both sides of `===` collapsed to null.
Its own cross-check proves it hollow: `Set.prototype.constructor === Map` **also
passed** (both null). Flagged as "host-import elimination, NOT a correctness fix".

### The fix
Each target builtin gets a **genuine identity-stable reified `$Object` singleton** —
one `__builtin_ctor_<Name>` externref global, lazily materialized once via
`__new_plain_object` behind a null guard (`emitBuiltinConstructorIdentity`). This is
the substrate #2963's issue plan calls for ("`$Object`-backed module-level singleton
per reified builtin; the same builtin reference must yield the same object").

**Both** the bare identifier read (`… === Set`) and the `.constructor` read route to
the **SAME** per-name global, so:
- `Set.prototype.constructor === Set` → **genuinely true** (same WasmGC object, `ref.eq`)
- `Set.prototype.constructor === Map` → **genuinely false** (distinct singletons)

The `.constructor` fold sits **early** in `compilePropertyAccess` (before the
builtin-specific `.prototype`/regexp member paths) so it fires uniformly for every
target — routing `RegExp.prototype.constructor` through `compileExternPropertyGet`
never reaches it (a RegExp-specific path returns first). Scoped to a narrow
constructor subset (Set/Map/Weak\*/RegExp/FinalizationRegistry/Disposable\*/
SuppressedError) with no existing bare-value identity, and to `ctx.standalone`.

### Not the #2963 Phase-2 blocker
#2555/#2963's Phase-2 blocker is about **calling** a reified value (arity-dispatch
trap on scalar-param closures). This reified constructor object is only ever
**read and compared by identity, never called** — so it does not hit that blocker
(verified: all cases run without trapping).

### Verified (run, not just compiled — `--target standalone --nativeStrings`)
- **9/9 origin test262 files pass** standalone, host-free (`env::Object_get_constructor` absent)
- **Swap-wrong-builtin guard** (`project_hostfree_pass_can_be_coincidentally_wrong_not_just_vacuous`):
  `Set.prototype.constructor === Map` → **0**, `WeakMap.prototype.constructor === Set` → **0**,
  `re.constructor === Set` → **0** (the #2537 null-fold returned `true` here)
- Bare identifiers: `Set === Set` → 1, `Set === Map` → 0
- gc/host lane **byte-inert** (sha256 unchanged) and **retains** the real `Object_get_constructor` import (fold is standalone-only)
- Standalone-with-no-ctor-reads **byte-inert** (`map(Number)`, plain math)
- **101** existing Set/Map/RegExp/Weak\*/Disposable\*/SuppressedError tests pass (the 4 `issue-2175` fails are **pre-existing** on `origin/main`, identical without this change)
- `tests/issue-3006-builtin-constructor-identity.test.ts` — 14 tests

### Adjacent discovery (pre-existing, out of scope)
The verbatim test262 `assert._isSameValue` (`… 1/a === 1/b …`) ToNumber-coerces
`any` operands and collapses `a === b` for **all** objects (reproducible with two
distinct plain object literals, using none of this PR's code). It doesn't cause a
false pass here (the 9 tests only assert the true case). Genuine identity is
validated with clean oracles instead. Follow-up warranted; out of scope for #3006.

### Deferred
`Object_set_constructor` / RegExp species (~5 tests) is a distinct **write-path**
concern, not a value-read; not trivially reproduced on current main. Deferred.

Supersedes #2537 / #2999.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8