### PR TITLE
fix(#3011): --dry-run short-circuits before mutation in claim-issue.mjs write modes

### DIFF
--- a/plan/issues/3011-claim-issue-dry-run-write-modes.md
+++ b/plan/issues/3011-claim-issue-dry-run-write-modes.md
@@ -1,0 +1,58 @@
+---
+id: 3011
+title: claim-issue.mjs --dry-run does not short-circuit in claim/release/complete modes
+status: done
+completed: 2026-07-03
+sprint: current
+priority: high
+horizon: s
+assignee: ttraenkler/dev-dryrun-fix
+---
+
+## Problem
+
+`scripts/claim-issue.mjs`'s `--dry-run` flag was only honored inside
+`doAllocate` (the `--allocate` path). For the plain **claim** mode — and for
+`--release` / `--complete` — `writeMode()` never checked the flag, so an
+invocation intended as a probe performed a **real** claim/push to the
+`issue-assignments` ref. Two different agents hit this independently in one day:
+they ran something like `node scripts/claim-issue.mjs <id> <name> --dry-run`
+expecting a preview and accidentally claimed a live issue.
+
+The flag position did not matter to _detection_ (`flags` is a
+position-independent `Set` of all `--`-prefixed args), but detection never fed
+into `writeMode`, which mutated regardless.
+
+## Root cause
+
+`--dry-run` was handled only at `doAllocate` (`scripts/claim-issue.mjs`), not in
+`writeMode()` (the claim/release/complete write path). `writeMode` ran straight
+into the `commitAndPush` retry loop.
+
+## Fix
+
+Added a `--dry-run` short-circuit at the top of `writeMode()`, _after_ the
+read-only done/wont-fix pre-flight and _before_ the retry/push loop. It does a
+read-only lookup of the current holder, prints a `(dry-run) would <kind> …`
+preview, and returns without any commit or push. Because `flags` is a
+position-independent `Set`, the guard fires no matter where `--dry-run` appears
+in argv.
+
+## Verification
+
+Reproduced first (against an isolated throwaway bare repo via
+`CLAIM_ASSIGN_REMOTE`, never the real ref): pre-fix,
+`claim-issue.mjs 999001 tester --dry-run` actually pushed a claim to the ref.
+
+Post-fix, against the same isolated remote:
+
+| Invocation                              | ref entries after |
+| --------------------------------------- | ----------------- |
+| `999001 tester --dry-run` (flag last)   | 0 (untouched)     |
+| `--dry-run 999002 tester` (flag first)  | 0 (untouched)     |
+| `999003 --dry-run tester` (flag middle) | 0 (untouched)     |
+| `--release 999004 tester --dry-run`     | 0 (untouched)     |
+| `999005 tester` (real claim, control)   | 1 (pushed)        |
+
+All dry-run orderings short-circuit before any mutation; the real claim path is
+unchanged.

--- a/scripts/claim-issue.mjs
+++ b/scripts/claim-issue.mjs
@@ -23,6 +23,11 @@
 //   node scripts/claim-issue.mjs --complete <id>
 //   node scripts/claim-issue.mjs --list
 //
+// --dry-run works for --allocate AND for the claim/release/complete write modes:
+// it previews the action and returns BEFORE any commit/push, so the
+// issue-assignments ref is never touched. It is position-independent (the flag
+// may appear anywhere in argv).
+//
 // ATOMIC ID ALLOCATION (#2531): `--allocate` is the canonical, collision-proof
 // way to reserve a FRESH issue id. Picking an id by hand ("next free off main")
 // races: two devs on separate branches each pick the same number because none
@@ -516,6 +521,29 @@ function writeMode(target, assignee, kind) {
     if (!main) {
       console.error(`warning: no issue file for #${base} found on ${MAIN_REF}; claiming anyway.`);
     }
+  }
+
+  // --dry-run: preview WITHOUT mutating the ref (no commit, no push). This MUST
+  // short-circuit BEFORE the retry/push loop below, regardless of where the flag
+  // appears in argv — `flags` is a position-independent Set built from every
+  // `--`-prefixed arg, so `claim-issue.mjs <id> <name> --dry-run` and
+  // `claim-issue.mjs --dry-run <id> <name>` both land here. Previously only
+  // --allocate honored --dry-run; a claim/release/complete probe with --dry-run
+  // silently performed a REAL mutation (agents accidentally claimed live issues
+  // twice this way).
+  if (flags.has("--dry-run")) {
+    const sha = remoteAssignSha();
+    fetchAssign(sha);
+    const existing = readEntry(sha, key);
+    const held = isHeld(existing);
+    console.error(
+      `(dry-run) would ${kind} ${label}${assignee ? ` -> ${assignee}` : ""}${branch ? ` (branch ${branch})` : ""}. ` +
+        (held
+          ? `Currently held by ${existing.assignee} (since ${existing.claimed_at || "?"}).`
+          : "Currently unassigned.") +
+        ` No push performed; ${REMOTE}/${ASSIGN_REF} untouched.`,
+    );
+    return;
   }
 
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {


### PR DESCRIPTION
## Problem

`scripts/claim-issue.mjs`'s `--dry-run` was only honored inside `doAllocate` (the `--allocate` path). The claim / `--release` / `--complete` write path (`writeMode()`) never checked the flag, so a probe intended as a dry-run performed a **real** claim/push to the `issue-assignments` ref — regardless of where the flag appeared in argv. Two different agents hit this independently in one day, each accidentally claiming a live issue while trying a dry-run probe.

## Fix

Added a position-independent `--dry-run` short-circuit at the top of `writeMode()` — after the read-only done/wont-fix pre-flight, before the `commitAndPush` retry loop. It does a read-only holder lookup, prints a `(dry-run) would <kind> …` preview, and returns without any commit or push. `flags` is a `Set` of all `--`-prefixed args, so the guard fires no matter where `--dry-run` sits.

## Verification

Reproduced first against an **isolated throwaway bare repo** (`CLAIM_ASSIGN_REMOTE`, never the real ref): pre-fix, `claim-issue.mjs 999001 tester --dry-run` actually pushed a claim.

Post-fix, same isolated remote:

| Invocation                              | ref entries after |
| --------------------------------------- | ----------------- |
| `999001 tester --dry-run` (flag last)   | 0 (untouched)     |
| `--dry-run 999002 tester` (flag first)  | 0 (untouched)     |
| `999003 --dry-run tester` (flag middle) | 0 (untouched)     |
| `--release 999004 tester --dry-run`     | 0 (untouched)     |
| `999005 tester` (real claim, control)   | 1 (pushed)        |

All dry-run orderings short-circuit before any mutation; the real claim path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)