### PR TITLE
docs(#2830): wasi_p1 ghost-import bundling recipe + full-lowering sizing bank

### DIFF
--- a/examples/native-messaging/README.md
+++ b/examples/native-messaging/README.md
@@ -221,6 +221,57 @@ in Node via `WebAssembly.instantiate`), where the import wiring it provides is
 required. Treat it as the JS-host on-ramp for the module; for the standalone
 WASI path it is a harmless extra artifact you can ignore or delete.
 
+### Bundling `nm_js2wasm_wasi_p1.ts`: the `wasm:memory` / `wasi_snapshot_preview1` ghost imports (loopdive/js2#389)
+
+The raw-WASI host [`nm_js2wasm_wasi_p1.ts`](./nm_js2wasm_wasi_p1.ts) imports from
+two module specifiers that **have no resolvable JS module** — they are
+compile-time contracts js2wasm satisfies during codegen, not runtime packages:
+
+```ts
+import { fd_read, fd_write } from "wasi_snapshot_preview1"; // real WASI core module (host-supplied)
+import { store32, load32, store8, load8 } from "wasm:memory"; // js2wasm INTRINSIC — lowers to inline i32.load/store
+```
+
+`store32`/`load32`/`store8`/`load8` are js2wasm **intrinsics** (`wasm:memory`, a
+namespace mirroring `wasm:js-string`); the compiler lowers each to a single inline
+`i32.store`/`i32.load`/`i32.store8`/`i32.load8_u` over the module's own linear
+memory. `wasi_snapshot_preview1`'s `fd_read`/`fd_write` are satisfied by the WASI
+runtime at launch. **Neither specifier resolves to a file a JS bundler can find**,
+so a JS bundler (`bun build`, `esbuild`, `deno bundle`) that tries to walk and
+inline every import will **choke on both** with an unresolvable-import error.
+
+**Recipe — mark the ghost specifiers external.** When bundling the `.ts` source to
+`.js` (the JS-runtime distribution path, e.g. for `scale-test.mjs`), tell the
+bundler to leave both imports as bare externals rather than resolve them. This is
+the exact form [`scale-test.mjs`](./scale-test.mjs) uses:
+
+```bash
+bun build examples/native-messaging/nm_js2wasm_wasi_p1.ts \
+  --target node \
+  --external wasi_snapshot_preview1 --external 'wasm:memory' \
+  --outfile nm_js2wasm_wasi_p1.js
+```
+
+`esbuild` takes the same flags (`--external:wasi_snapshot_preview1
+--external:'wasm:memory'`); `deno bundle` uses `--no-bundle` (or an import map that
+maps the two specifiers to a shim). **Quote `'wasm:memory'`** — the `:` is
+shell-significant in some contexts.
+
+> **Ergonomics tradeoff.** This is the cost the #389 reporter flagged:
+> `nm_js2wasm_wasi_p1.ts` is the leanest, fastest of the hosts (raw inline
+> linear-memory ops, no GC roundtrip), but its `wasm:memory` intrinsics are
+> "ghost code" with **no JS implementation**, so the source does **not** run
+> unmodified in a plain JS runtime and its bundling needs the `--external` opt-out
+> above. The **other hosts have no `wasm:memory` import** — e.g.
+> [`nm_js2wasm_node_fs.ts`](./nm_js2wasm_node_fs.ts) uses `node:fs`
+> `readSync`/`writeSync` and runs unmodified under real `node` — so if you want a
+> single source that both bundles cleanly for a JS runtime **and** compiles to
+> standalone WASI, prefer a `node:fs` / `node:process` host. Pick `wasi_p1` when
+> you want the tightest possible pure-WASI module and can accept the ghost-import
+> bundling opt-out. (Note the `--external wasi_snapshot_preview1` is needed for
+> **any** raw-WASI host regardless — `fd_read`/`fd_write` are host-supplied and
+> equally unresolvable to a JS bundler.)
+
 ## Run it under a WASI runtime
 
 `nm_js2wasm_node_fs.sh` wraps the runtime invocation. `wasmtime` is **not bundled** with this

--- a/plan/issues/2830-document-wasi-p1-no-bundle-recipe.md
+++ b/plan/issues/2830-document-wasi-p1-no-bundle-recipe.md
@@ -1,12 +1,13 @@
 ---
 id: 2830
 title: "Lower DataView/Uint8Array-over-WASI-memory to linear ops; rewrite wasi_p1 to standard DataView (drop the wasm:memory ghost intrinsic)"
-status: ready
+status: in-progress
 sprint: current
 priority: medium
 area: codegen
 task_type: feature
-related: [389, 2835, 1886, 1783, 2803]
+assignee: ttraenkler/senior-dev-2830
+related: [389, 2835, 1886, 1783, 2803, 2840]
 ---
 
 # Replace the `wasm:memory` ghost intrinsic with a standard `DataView` surface the compiler lowers to linear ops
@@ -38,7 +39,7 @@ buffer. His JS reimplementation runs the same framing logic in a pure JS runtime
 
 His model is "one buffer, two accessors": integer offsets + a `DataView` over the
 same `ArrayBuffer` the WASI shim reads/writes. To make **one source** work as
-*both* plain JS *and* compiled wasm, the offsets must be **linear-memory** offsets
+_both_ plain JS _and_ compiled wasm, the offsets must be **linear-memory** offsets
 and the `DataView` accessors must lower to inline `i32.load/store` over the
 module's memory — exactly what `wasm:memory` does now.
 
@@ -62,7 +63,7 @@ surface and **drop the `wasm:memory` import entirely**. Result:
 - **no `wasm:memory` ghost import** → bundles cleanly, no bespoke builtin.
 
 Open design question for the implementer: how the source designates "this
-`DataView`/buffer *is* the module's linear memory" in WASI mode (e.g. a recognized
+`DataView`/buffer _is_ the module's linear memory" in WASI mode (e.g. a recognized
 `new DataView(new ArrayBuffer(N))` whose offsets are linear, or a
 `memory.buffer`-style handle). Reuse the linear-`Uint8Array` analysis (#1886) and
 the packed-byte machinery (#2835) where possible.
@@ -82,17 +83,17 @@ the packed-byte machinery (#2835) where possible.
    - **binary size** (`.wasm` bytes),
    - **throughput** (wall-time at 1/64/128/256 MiB),
    - **peak RSS** (at 128/256 MiB).
-   `wasi_p1` is currently the **leanest and fastest** of the four hosts (probe-2829:
-   ~46% smaller, ~3× faster, ~38% less RSS than node_fs). If the DataView lowering
-   emits the same inline `i32.load/store` as the `store32`/`load32` intrinsics this
-   should be a wash; quantify and confirm.
+     `wasi_p1` is currently the **leanest and fastest** of the four hosts (probe-2829:
+     ~46% smaller, ~3× faster, ~38% less RSS than node_fs). If the DataView lowering
+     emits the same inline `i32.load/store` as the `store32`/`load32` intrinsics this
+     should be a wash; quantify and confirm.
    - **If efficiency holds → the DataView host REPLACES `nm_js2wasm_wasi_p1.ts`**
      (one host, JS-runnable + standalone, no ghost import).
    - **If it materially regresses → ship it as an ADDITIONAL variant** in the host
-     collection *alongside* the low-level `wasm:memory` `wasi_p1` (both stay: raw =
+     collection _alongside_ the low-level `wasm:memory` `wasi_p1` (both stay: raw =
      max efficiency, DataView = runs in a plain JS runtime) — NOT a replacement.
-   Either way, keep the `--no-bundle` docs (below) for whichever intrinsic host
-   remains.
+     Either way, keep the `--no-bundle` docs (below) for whichever intrinsic host
+     remains.
 
 ## Fallback (the prior docs-only scope, if the lowering proves infeasible or regresses efficiency)
 
@@ -100,8 +101,79 @@ Document the `wasi_p1` build recipe in `examples/native-messaging/README.md`:
 `bun build --no-bundle`, or `--external wasi_snapshot_preview1 --external 'wasm:memory'`
 (the form `scale-test.mjs` already uses), with the ghost-import ergonomics tradeoff.
 
+## Sizing verdict & design bank (senior-dev, 2026-07-03, honest measure-first pass)
+
+**Delivered this PR (the documented Fallback):** the `wasm:memory` /
+`wasi_snapshot_preview1` ghost-import bundling recipe + ergonomics tradeoff is now
+in `examples/native-messaging/README.md` (new subsection under "Build to `.wasm`").
+Byte-inert to the compiler.
+
+**Deferred (the full DataView-linear lowering):** assessed **substrate-scale**, not
+a bounded win. Deferred rather than half-built, per the "bank a design, don't force
+a substrate change late in a budget window" discipline — and specifically because
+it would touch late-import / funcIdx-adjacent codegen, a class this session has
+repeatedly caught silently regressing. What the measure-first pass established:
+
+1. **DataView is 100% WasmGC-backed today, with no linear-memory representation.**
+   `new DataView(new ArrayBuffer(N))` lowers to a `$__vec_i32_byte` struct/array
+   (packed `i8` after #2835); every accessor (`recoverDvBacking` in
+   `src/codegen/dataview-native.ts`) recovers a **GC array + base offset** and does
+   `array.get_u` / `array.set`. The DataView value at runtime is an externref/struct
+   ref — it carries **no notion of "I am the module's own linear memory."** A naive
+   source swap (just use `DataView`) compiles to a GC buffer that `fd_read`/`fd_write`
+   (which address _linear_ memory via the iovec pointer) cannot see → the compiled
+   raw-WASI host breaks. (The issue's own "confirm with a probe" — confirmed.)
+
+2. **The #1886 linear-`Uint8Array` infra does NOT fit `wasi_p1`'s model.** The
+   `src/codegen/linear-uint8-*.ts` machinery (1,340 LoC) is **Uint8Array-only** (zero
+   DataView awareness) and uses **escape analysis that allocates a per-buffer
+   `(ptr,len)` pair as function locals** — and per #2840 it **cannot back a
+   module-scope buffer** at all. `wasi_p1`'s model is the opposite: **one whole-memory
+   buffer with hand-laid-out FIXED absolute offsets** (`IOV=0`, `RESULT=8`,
+   `INBUF=4096`, …) accessed across **many** functions. That needs a _different_
+   designation (a whole-memory view whose `byteOffset` base is a compile-time
+   constant, absolute offsets, no ptr/len threading), not the #1886 local-escape
+   model. So "reuse #1886" is not the shortcut the issue hoped.
+
+3. **What a real implementation requires** (a new parallel backing-store
+   representation — the substrate cost):
+   - A recognizer for a source construct that designates "this buffer _is_ the
+     module's linear memory" in WASI mode — e.g. a module-scope
+     `const mem = new ArrayBuffer(N); const dv = new DataView(mem)` treated as
+     base-0 linear, with `ArrayBuffer(N)` sizing the module's **initial memory
+     pages** (`ceil(N/65536)`) instead of a GC `array.new`.
+   - Type/value tracking so **every** `dv.getUint32(off, le)` / `dv.setUint32(off,
+val, le)` call site knows to take the **linear path** (inline
+     `i32.load`/`i32.store`/`i32.load8_u`/`i32.store8` at `off`, with runtime
+     `littleEndian` handling and byte-swap for BE) rather than the GC
+     `recoverDvBacking` path — a per-view discriminant threaded through locals,
+     params (cross-function, like #1886's helper-arg rewrite), and returns.
+   - The lowering is the _easy_ part (it's exactly what `emitMemAccessor` in
+     `src/codegen/raw-wasi-api.ts` already emits for `store32`/`load32`); the
+     **representation + whole-program propagation of "which DataView is linear" is
+     the hard, hazardous part.**
+
+4. **Acceptance #2 ("bundles cleanly / runs in plain JS") has an unresolved tension
+   even after the lowering.** Dropping `wasm:memory` does **not** make `wasi_p1`
+   bundle without externals: `fd_read`/`fd_write` are imported from
+   `wasi_snapshot_preview1`, an **equally unresolvable ghost import** to a JS bundler
+   (confirmed: `scale-test.mjs` passes `--external wasi_snapshot_preview1 --external
+'wasm:memory'` — BOTH). A truly JS-runnable/clean-bundling raw host would also
+   need a resolvable WASI shim for `fd_read`/`fd_write` — which is precisely what the
+   `node:fs` / `node:process` hosts already are. So the DataView rewrite alone cannot
+   fully satisfy #2 for the raw-WASI host; the acceptance needs re-scoping.
+
+**Recommendation:** treat the Fallback (this PR) as the shipped, bounded outcome for
+#2830. If the team still wants the full DataView-linear lowering, cut a **fresh
+`feasibility: hard` issue** carrying the design above (whole-memory linear-view
+representation + per-view linear/GC discriminant propagation + `ArrayBuffer(N)`→
+initial-pages), route it through the architect, and re-scope acceptance #2 around
+the `wasi_snapshot_preview1` shim. Status decision (close #2830 on the fallback vs.
+keep it open for the feature) escalated to the tech lead.
+
 ## Related
 
 - #389 — reporter's `wasm:memory` "ghost code" feedback + his JS `DataView` POC.
 - #1783 / #2803 — JavaScript-first parity (this advances it).
 - #1886 — linear-safe `Uint8Array` analysis (reuse). #2835 — packed-i8 byte buffer.
+- #2840 — proof #1886's linear-`Uint8Array` infra can't back a module-scope buffer.

--- a/plan/issues/2830-document-wasi-p1-no-bundle-recipe.md
+++ b/plan/issues/2830-document-wasi-p1-no-bundle-recipe.md
@@ -1,13 +1,14 @@
 ---
 id: 2830
 title: "Lower DataView/Uint8Array-over-WASI-memory to linear ops; rewrite wasi_p1 to standard DataView (drop the wasm:memory ghost intrinsic)"
-status: in-progress
+status: done
 sprint: current
 priority: medium
 area: codegen
 task_type: feature
 assignee: ttraenkler/senior-dev-2830
-related: [389, 2835, 1886, 1783, 2803, 2840]
+completed: 2026-07-03
+related: [389, 2835, 1886, 1783, 2803, 2840, 3012]
 ---
 
 # Replace the `wasm:memory` ghost intrinsic with a standard `DataView` surface the compiler lowers to linear ops
@@ -163,13 +164,15 @@ val, le)` call site knows to take the **linear path** (inline
    `node:fs` / `node:process` hosts already are. So the DataView rewrite alone cannot
    fully satisfy #2 for the raw-WASI host; the acceptance needs re-scoping.
 
-**Recommendation:** treat the Fallback (this PR) as the shipped, bounded outcome for
-#2830. If the team still wants the full DataView-linear lowering, cut a **fresh
-`feasibility: hard` issue** carrying the design above (whole-memory linear-view
+**Outcome (tech-lead adjudicated 2026-07-03):** #2830 **closes `done`** on the
+Fallback — the bundling recipe + design bank are real shipped value, not a punt.
+The full DataView-linear lowering is carried forward as **#3012** (`feasibility:
+hard`, `[ARCH]`): it carries the design above (whole-memory linear-view
 representation + per-view linear/GC discriminant propagation + `ArrayBuffer(N)`→
-initial-pages), route it through the architect, and re-scope acceptance #2 around
-the `wasi_snapshot_preview1` shim. Status decision (close #2830 on the fallback vs.
-keep it open for the feature) escalated to the tech lead.
+initial-pages) and **re-scopes acceptance #2** around a `wasi_snapshot_preview1`
+shim (the original "bundles cleanly from the DataView rewrite alone" framing was
+found unachievable regardless of the DataView work). #3012 must get an architect
+spec before any implementation attempt.
 
 ## Related
 

--- a/plan/issues/3012-dataview-over-linear-memory-lowering.md
+++ b/plan/issues/3012-dataview-over-linear-memory-lowering.md
@@ -1,0 +1,108 @@
+---
+id: 3012
+title: "Lower a whole-memory DataView/ArrayBuffer to inline linear ops (WASI), rewrite wasi_p1 off the wasm:memory intrinsic"
+status: ready
+sprint: Backlog
+priority: medium
+area: codegen
+task_type: feature
+feasibility: hard
+reasoning_effort: max
+language_feature: typed-arrays
+goal: standalone
+related: [389, 2830, 2835, 1886, 2840, 1783, 2803]
+---
+
+# Lower a whole-memory `DataView`/`ArrayBuffer` to inline linear ops (WASI)
+
+Split out of **#2830** (which shipped the documented bundling-recipe fallback +
+this design bank). This is the substrate-scale feature half: teach the compiler to
+lower a `DataView` (and/or linear-safe `Uint8Array`) constructed over the **WASI
+module's own linear memory** to inline `i32.load*`/`i32.store*`, then rewrite
+`examples/native-messaging/nm_js2wasm_wasi_p1.ts` to use that standard surface and
+drop the `wasm:memory` ghost intrinsic.
+
+**Do NOT dev-dispatch this directly — it needs an architect spec first (`[ARCH]`).**
+This session's #2830 measure-first pass established the design below and flagged the
+hazards; an architect must turn it into an exact `## Implementation Plan` (functions,
+line numbers, Wasm patterns, per-view discriminant threading, edge cases) before any
+implementation attempt.
+
+## Why this is hard (the #2830 measure-first findings)
+
+1. **`DataView` is 100% WasmGC-backed today, with no linear-memory representation.**
+   `new DataView(new ArrayBuffer(N))` lowers to a `$__vec_i32_byte` struct/array
+   (packed `i8`, #2835); every accessor (`recoverDvBacking` in
+   `src/codegen/dataview-native.ts`) recovers a **GC array + base offset** and emits
+   `array.get_u`/`array.set`. The DataView value at runtime is an externref/struct
+   ref — it carries **no notion of "I am the module's own linear memory."** A naive
+   source swap (just use `DataView`) compiles to a GC buffer that
+   `fd_read`/`fd_write` (which address _linear_ memory via the iovec pointer) cannot
+   see → the compiled raw-WASI host breaks.
+
+2. **#1886's linear-`Uint8Array` infra does NOT fit `wasi_p1`'s model.** The
+   `src/codegen/linear-uint8-*.ts` machinery (~1,340 LoC) is **Uint8Array-only** (no
+   DataView awareness) and uses **escape analysis that allocates a per-buffer
+   `(ptr,len)` pair as function locals**; per **#2840** it **cannot back a
+   module-scope buffer** at all. `wasi_p1`'s model is the opposite: **one
+   whole-memory buffer with hand-laid-out FIXED absolute offsets** (`IOV=0`,
+   `RESULT=8`, `INBUF=4096`, …) accessed across **many** functions. That needs a
+   _different_ designation, not the #1886 local-escape model.
+
+## Design (banked from #2830 — architect to refine)
+
+A **new parallel backing-store representation** for a DataView/ArrayBuffer that _is_
+the module's linear memory:
+
+- **Recognizer** — a source construct designating "this buffer is the module's
+  linear memory" in WASI mode. Candidate: a module-scope
+  `const mem = new ArrayBuffer(N); const dv = new DataView(mem)` treated as base-0
+  linear, with `ArrayBuffer(N)` sizing the module's **initial memory pages**
+  (`ceil(N/65536)`) instead of a GC `array.new`. (Open: a `memory.buffer`-style
+  handle vs. the recognized-ctor form — architect decides.)
+- **Per-view linear/GC discriminant, propagated whole-program** — every
+  `dv.getUint32(off, le)` / `dv.setUint32(off, val, le)` call site must know to take
+  the **linear path** (inline `i32.load`/`i32.store`/`i32.load8_u`/`i32.store8` at
+  `off`, runtime `littleEndian` handling incl. BE byte-swap) instead of the GC
+  `recoverDvBacking` path. The discriminant must thread through **locals, params
+  (cross-function, like #1886's helper-arg rewrite), and returns.** This is the hard,
+  hazardous part — it is late-import/funcIdx-adjacent; guard against silent stack /
+  index regressions.
+- **The lowering itself is the easy part** — it is exactly what `emitMemAccessor` in
+  `src/codegen/raw-wasi-api.ts` already emits for `store32`/`load32`/`store8`/`load8`.
+  Reuse that emission; the novelty is entirely in the representation + propagation.
+
+## Acceptance
+
+1. `nm_js2wasm_wasi_p1.ts` uses **standard `DataView`/`Uint8Array`** for all
+   iovec/length/byte access — **no `import … from "wasm:memory"`**.
+2. **Re-scoped (per #2830 finding):** the `wasi_p1` source runs in a plain JS runtime
+   **when paired with a `wasi_snapshot_preview1` shim** — NOT "bundles cleanly from
+   the DataView rewrite alone." Dropping `wasm:memory` alone does **not** make
+   `wasi_p1` bundle without externals, because `fd_read`/`fd_write` from
+   `wasi_snapshot_preview1` remain an **equally-unresolvable ghost import** to a JS
+   bundler. So JS-runnability requires a resolvable WASI shim (a small JS
+   `wasi_snapshot_preview1` polyfill / node WASI) supplying `fd_read`/`fd_write` over
+   the same `ArrayBuffer` the DataView views. Deliverable: that shim + a round-trip of
+   a framed native-messaging message under `node` (and, if cheap, `deno`/`bun`) with
+   **no `wasm:memory` ghost-import error**.
+3. **Compiled `--target wasi` still works** — `scale-test.mjs` passes byte-exact for
+   all four hosts at 1/64/128/256 MiB under real wasmtime 46.
+4. **Efficiency comparison vs the current `wasm:memory` `wasi_p1`** — binary size
+   (`.wasm` bytes), throughput (wall-time at 1/64/128/256 MiB), peak RSS (at
+   128/256 MiB). If the DataView lowering emits the same inline `i32.load/store` this
+   should be a wash; quantify and confirm.
+   - **Efficiency holds → the DataView host REPLACES `nm_js2wasm_wasi_p1.ts`.**
+   - **Materially regresses → ship as an ADDITIONAL variant** alongside the raw
+     `wasm:memory` `wasi_p1` (raw = max efficiency, DataView = runs in a plain JS
+     runtime with the shim) — NOT a replacement.
+     Keep the #2830 `--external`/`--no-bundle` docs for whichever intrinsic host remains.
+
+## Related
+
+- #2830 — parent; shipped the bundling-recipe fallback + this design bank.
+- #389 — reporter's `wasm:memory` "ghost code" feedback + JS `DataView` POC.
+- #1886 — linear-`Uint8Array` analysis (reference, but insufficient — see above).
+- #2840 — proof #1886's infra can't back a module-scope buffer.
+- #2835 — packed-i8 byte buffer backing `$__vec_i32_byte`.
+- #1783 / #2803 — JavaScript-first parity (this advances it).


### PR DESCRIPTION
## Summary

Delivers the **documented Fallback** scope of #2830 and **banks an honest measure-first sizing verdict** for the full feature. **Docs-only — byte-inert to the compiler** (no `src/` touched).

### What changed
1. `examples/native-messaging/README.md` — new subsection under *Build to `.wasm`* documenting the `wasm:memory` / `wasi_snapshot_preview1` **ghost-import bundling recipe** (`bun build --external wasi_snapshot_preview1 --external 'wasm:memory'`, the exact form `scale-test.mjs` uses; esbuild/deno equivalents) and the **ergonomics tradeoff** the #389 reporter flagged.
2. `plan/issues/2830-...md` — a **Sizing verdict & design bank** section.

### Sizing verdict (why the full DataView-linear lowering is deferred, not built)
The full lowering is **substrate-scale**, not a bounded win:
- **DataView is 100% WasmGC-backed today** (`$__vec_i32_byte`); every accessor recovers a GC array + base and does `array.get_u`/`array.set`. The DataView value carries no "I am the module's linear memory" notion. A naive source swap breaks the compiled host (fd_read/fd_write can't see a GC buffer) — the issue's own probe, confirmed.
- **#1886's linear-Uint8Array infra doesn't fit**: it's Uint8Array-only, uses local-escape `(ptr,len)` allocation, and per **#2840 can't back a module-scope buffer** — the opposite of `wasi_p1`'s whole-memory fixed-offset model.
- **Acceptance #2 has an unresolved tension**: dropping `wasm:memory` still leaves `wasi_snapshot_preview1` as an equally-unresolvable ghost import to a JS bundler, so `wasi_p1` can't "bundle cleanly" from the DataView rewrite alone.

The design for a real implementation (whole-memory linear-view representation + per-view linear/GC discriminant propagation + `ArrayBuffer(N)`→initial-pages) is preserved in the issue for a follow-up `feasibility: hard` issue. Deferred specifically to avoid a hazardous late-import/funcIdx-adjacent codegen change late in the budget window.

### Status decision escalated
Whether #2830 closes on this fallback or stays open for the feature is left to the tech lead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)