### PR TITLE
fix(#3014): any-receiver .forEach/.some no longer mis-routes to Uint8ClampedArray host import

### DIFF
--- a/plan/issues/3014-any-receiver-foreach-some-misroute-typedarray-extern.md
+++ b/plan/issues/3014-any-receiver-foreach-some-misroute-typedarray-extern.md
@@ -1,0 +1,71 @@
+---
+id: 3014
+title: "any-receiver .forEach/.some first-match TypedArray extern class → Uint8ClampedArray_forEach/some host leak"
+status: done
+created: 2026-07-03
+updated: 2026-07-03
+completed: 2026-07-03
+priority: medium
+feasibility: easy
+reasoning_effort: low
+task_type: bugfix
+area: codegen
+language_feature: arrays
+goal: standalone-host-free
+sprint: current
+horizon: s
+assignee: ttraenkler/agent-opus
+origin: "2026-07-03 leak-analysis round 6 §sole-lever ranking — Uint8ClampedArray_forEach/some 16 sole-import passes (GENUINE)"
+related: [2379, 1712, 1062]
+---
+
+# #3014 — `any`-receiver `.forEach`/`.some` mis-routes to `Uint8ClampedArray_forEach/some`
+
+## Problem
+
+`tryExternClassMethodOnAny` (`src/codegen/expressions/calls-closures.ts`) resolves
+a method call on an **`any`-typed receiver** by first-match iteration over
+`ctx.externClasses`. Every TypedArray extern class (`Uint8ClampedArray`,
+`Int8Array`, …) declares `forEach` / `some` with an all-externref signature. When
+a TypedArray (or a DOM type whose `lib.d.ts` pulls the TypedArray declarations
+in) has registered its extern class before the call is compiled, first-match
+binds an `any` receiver's `xs.forEach(cb)` / `xs.some(pred)` to
+`env.Uint8ClampedArray_forEach` / `_some` — a host import the standalone runtime
+cannot satisfy. The import name is a pure routing artifact; the receiver is not a
+`Uint8ClampedArray`.
+
+Round-6 leak analysis (`plan/log/investigations/2026-07-03-leak-analysis-round6.md`
+§sole-lever ranking) found **16 execution-verified sole-import** standalone
+passes leaking exactly this import — all `built-ins/Array/prototype/forEach/*` and
+`built-ins/Array/prototype/some/*` (the `length`-overridden-to-0 array-subclass
+tests). Confirmed GENUINE via inject-throw.
+
+This is distinct from #2379 (typed `Uint8ClampedArray` **receivers** mis-dispatching
+because the type was omitted from `BUILTIN_TYPES`; already fixed). Here the
+receiver is `any`, not a TypedArray.
+
+## Fix
+
+Mirror the existing `.slice` (#1062) and `.replace`/`.replaceAll` (#1712)
+ambiguity refusals in `tryExternClassMethodOnAny`: refuse extern-class dispatch
+for `forEach` / `some` and let the call resolve by the receiver's real runtime
+shape. On an `any` receiver in untyped JS these are overwhelmingly Array
+operations; a genuinely-`Uint8ClampedArray`-typed receiver never reaches this
+`any` fallback (it is claimed by the native array-method path earlier).
+
+## Test Results
+
+Verified with the runner's exact flags (`target: "standalone"`,
+`skipSemanticDiagnostics: true`) on the actual test bodies:
+
+- All 16 target tests: `env=[Uint8ClampedArray_forEach|_some]` → **`env=[]`**
+  (host-free) with correct runtime results (`callCnt=0` / `some=false`).
+- Host lane (`gc`): reroutes host→host, results unchanged (verified correct).
+- No regression across the 367 passing `forEach/some/every/find` tests — only
+  these 16 used the Uint8ClampedArray path; all convert cleanly.
+
+## Acceptance criteria
+
+- The 16 sole-import standalone passes become host-free.
+- Flag-off (host `gc` mode) behaviour and results unchanged.
+- No new standalone-floor regressions in `merge_group`.

--- a/src/codegen/expressions/calls-closures.ts
+++ b/src/codegen/expressions/calls-closures.ts
@@ -1004,6 +1004,23 @@ export function tryExternClassMethodOnAny(
   // `String.prototype.replace`. Mirrors the `.slice` ambiguity refusal above.
   if (methodName === "replace" || methodName === "replaceAll") return null;
 
+  // (#3014) `forEach` / `some` are core Array.prototype iteration methods, but
+  // every TypedArray extern class (Uint8ClampedArray, Int8Array, …) also
+  // declares them with an all-externref signature. When a TypedArray (or a
+  // DOM type whose lib.d.ts pulls the TypedArray declarations in) registers
+  // its extern class before this call is compiled, first-match iteration over
+  // `ctx.externClasses` binds an `any`-typed receiver's `xs.forEach(cb)` /
+  // `xs.some(pred)` to e.g. `Uint8ClampedArray_forEach` / `_some` — a host
+  // import the standalone runtime cannot satisfy (round-6 leak analysis:
+  // 16 execution-verified sole-import leaky passes, GENUINE via inject-throw).
+  // On an `any` receiver in untyped JS these are overwhelmingly Array
+  // operations; refuse extern-class dispatch and let the generic host /
+  // native-struct path handle the receiver by its real runtime shape. Mirrors
+  // the `.slice` and `.replace`/`.replaceAll` ambiguity refusals above.
+  // (A genuinely-`Uint8ClampedArray`-typed receiver never reaches here — it is
+  // handled by the native array-method path before the `any` fallback.)
+  if (methodName === "forEach" || methodName === "some") return null;
+
   // (#1283) The dispatch below emits `externref` hints for every arg and
   // assumes the call's params are all-externref. When iterating in
   // insertion order we may otherwise hit an extern class whose method has a

--- a/tests/issue-3014.test.ts
+++ b/tests/issue-3014.test.ts
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3014 — a `.forEach` / `.some` call on an `any`-typed receiver must NOT
+// first-match a TypedArray extern class and leak `env::Uint8ClampedArray_forEach`
+// / `env::Uint8ClampedArray_some` under `--target standalone`.
+//
+// Defect: `tryExternClassMethodOnAny` resolves an `any`-receiver method call by
+// first-match iteration over `ctx.externClasses`. Every TypedArray extern class
+// (Uint8ClampedArray, Int8Array, …) declares `forEach`/`some` with an
+// all-externref signature, so when a TypedArray registration is present the
+// iteration binds `f.forEach(cb)` to `Uint8ClampedArray_forEach` — a host import
+// the standalone runtime cannot satisfy (the import name is a pure routing
+// artifact; the receiver is not a Uint8ClampedArray). Round-6 leak analysis
+// found 16 execution-verified sole-import standalone passes leaking this import
+// (all `Array/prototype/{forEach,some}` length-overridden-to-0 subclass tests).
+//
+// Fix: mirror the `.slice` (#1062) and `.replace`/`.replaceAll` (#1712)
+// ambiguity refusals — refuse extern-class dispatch for `forEach`/`some` and let
+// the receiver resolve by its real runtime shape.
+
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+async function buildStandalone(body: string): Promise<{ result: number; envImports: string[] }> {
+  const src = `export function test(): number { ${body} }`;
+  const r = await compile(src, { target: "standalone" });
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const envImports = WebAssembly.Module.imports(new WebAssembly.Module(r.binary))
+    .filter((i) => i.module === "env")
+    .map((i) => i.name);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  const result = (instance.exports as { test(): number }).test();
+  return { result, envImports };
+}
+
+async function buildHost(body: string): Promise<number> {
+  const src = `export function test(): number { ${body} }`;
+  const r = await compile(src, {});
+  expect(r.success, r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const imports = buildImports(r.imports, undefined, r.stringPool);
+  const { instance } = await WebAssembly.instantiate(r.binary, imports);
+  (imports as { setExports?: (e: unknown) => void }).setExports?.(instance.exports);
+  return (instance.exports as { test(): number }).test();
+}
+
+// The 16 leaking test262 rows are `f = new foo()` with `foo.prototype = Array`,
+// `f.length` overridden to 0 — the callback never fires, so the observable is
+// that the call is host-free AND produces the spec-correct no-iteration result.
+const ARRAYLIKE_FOREACH =
+  "foo.prototype = new Array(1, 2, 3); function foo() {} var f = new foo(); f.length = 0; var c = 0; function cb() { c++; } f.forEach(cb); return c;";
+const ARRAYLIKE_SOME =
+  "foo.prototype = new Array(1, 2, 3); function foo() {} var f = new foo(); f.length = 0; function cb() { return true; } return f.some(cb) ? 1 : 0;";
+
+describe("#3014 — any-receiver .forEach/.some is host-import-free (no Uint8ClampedArray_* leak)", () => {
+  it("array-like .forEach (length 0) does not leak Uint8ClampedArray_forEach", async () => {
+    const { result, envImports } = await buildStandalone(ARRAYLIKE_FOREACH);
+    expect(envImports).not.toContain("Uint8ClampedArray_forEach");
+    expect(envImports).toEqual([]);
+    expect(result).toBe(0); // length 0 → callback never called
+  });
+
+  it("array-like .some (length 0) does not leak Uint8ClampedArray_some", async () => {
+    const { result, envImports } = await buildStandalone(ARRAYLIKE_SOME);
+    expect(envImports).not.toContain("Uint8ClampedArray_some");
+    expect(envImports).toEqual([]);
+    expect(result).toBe(0); // length 0 → some returns false
+  });
+
+  it("host (gc) mode still iterates a real array via .forEach on an any receiver", async () => {
+    const result = await buildHost(
+      "var f: any = [10, 20, 30]; var c = 0; function cb() { c++; } f.forEach(cb); return c;",
+    );
+    expect(result).toBe(3);
+  });
+
+  it("host (gc) mode .some on an any receiver returns the spec-correct result", async () => {
+    const result = await buildHost(
+      "var f: any = [1, 2, 3]; function cb(v: any) { return v > 2; } return f.some(cb) ? 1 : 0;",
+    );
+    expect(result).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

`tryExternClassMethodOnAny` resolves a method call on an **`any`-typed receiver** by first-match iteration over `ctx.externClasses`. Every TypedArray extern class (`Uint8ClampedArray`, `Int8Array`, …) declares `forEach`/`some` with an all-externref signature, so when a TypedArray registration is present the iteration binds `xs.forEach(cb)` / `xs.some(pred)` to `env.Uint8ClampedArray_forEach` / `_some` — a host import the standalone runtime cannot satisfy. The import name is a pure routing artifact; the receiver is not a `Uint8ClampedArray`.

Round-6 leak analysis (`plan/log/investigations/2026-07-03-leak-analysis-round6.md`) found **16 execution-verified sole-import** standalone passes leaking exactly this import — all `built-ins/Array/prototype/{forEach,some}` length-overridden-to-0 subclass tests. Confirmed GENUINE via inject-throw.

Distinct from #2379 (typed `Uint8ClampedArray` **receivers**, already fixed) — here the receiver is `any`.

## Fix

Mirror the existing `.slice` (#1062) and `.replace`/`.replaceAll` (#1712) ambiguity refusals in `tryExternClassMethodOnAny`: refuse extern-class dispatch for `forEach`/`some` and let the call resolve by the receiver's real runtime shape. A genuinely-`Uint8ClampedArray`-typed receiver never reaches this `any` fallback (it is claimed by the native array-method path earlier).

## Verification (runner flags: `target: standalone`, `skipSemanticDiagnostics: true`)

- All 16 target tests: `env=[Uint8ClampedArray_forEach|_some]` → **`env=[]`** (host-free), correct runtime results (`callCnt=0` / `some=false`).
- Host `gc` lane: reroutes host→host, results unchanged (real array `.forEach` iterates → 3, `.some` → true).
- No regression across the 367 passing `forEach/some/every/find` tests — only these 16 used the Uint8ClampedArray path.
- Existing tests green: #1062, #1712, #2379, array-methods, functional-array-methods.

New test: `tests/issue-3014.test.ts` (4 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8