### PR TITLE
fix(#3016): func-expr arg to .call/.apply is a value, not a host callback (standalone)

### DIFF
--- a/plan/issues/3016-standalone-call-apply-funcexpr-not-host-callback.md
+++ b/plan/issues/3016-standalone-call-apply-funcexpr-not-host-callback.md
@@ -1,0 +1,127 @@
+---
+id: 3016
+title: "standalone: a func-expr/arrow passed to Function.prototype.call/apply is a VALUE, not a host callback — route to closure-struct, not __make_callback"
+status: done
+completed: 2026-07-03
+assignee: ttraenkler/opus-callapply
+sprint: current
+priority: high
+horizon: s
+feasibility: medium
+task_type: bugfix
+area: codegen
+language_feature: closures, call-apply, standalone
+goal: host-independence
+related: [2903, 2939, 2940]
+created: 2026-07-03
+updated: 2026-07-03
+origin: "2026-07-03 leak-analysis round-6 residual sole-__make_callback decomposition (dev opus-h). Measured on main @ 9c2633b8b, target standalone, merged report run 28624020153."
+---
+
+# #3016 — `.call`/`.apply` func-expr arg is a value, not a host callback
+
+## TL;DR
+
+`isHostCallbackArgument` (`src/codegen/closures.ts`) routes **any**
+function-expression/arrow argument of a method call on a non-user-class
+receiver to the `__make_callback` host bridge (the `return true` default of the
+property-access branch). That includes func-expr args to
+`Function.prototype.call`/`apply` — but **`.call`/`.apply` provably never invoke
+their arguments as callbacks**; they invoke the _receiver_ with those args as
+`thisArg` + forwarded params. So the func-expr is a plain function-object
+**value**, and routing it through `__make_callback` leaks an
+`env::__make_callback` import that breaks host-free (standalone) instantiation
+for no reason.
+
+**Fix (standalone-gated, ~3 lines):** in the property-access branch of
+`isHostCallbackArgument`, return `false` (GC closure-struct path) when
+`ctx.standalone && (methodName === "call" || methodName === "apply")`.
+
+## Measurement (main @ 9c2633b8b, `target: standalone`, run 28624020153)
+
+The 59 non-Temporal residual sole-`__make_callback` passes are **heterogeneous**
+(~10 distinct roots — see "Residual decomposition" below), NOT one bounded fix.
+The largest **clean, principled, correct-by-construction** sub-lever is the
+`.call`/`.apply` value-arg class. Instrumenting the `__make_callback` emit site
+over all 59 wrapped test sources isolated these triggers:
+
+- **RegExp getter `this-val-invalid-obj` ×10** — `get.call(() => {})`: the arrow
+  is an invalid-`this` value (the "function object" case of a `this`-brand
+  test).
+- **Array find-family `.call(undefined, fn)` ×4** — `find`/`findIndex`/
+  `findLast`/`findLastIndex`; the predicate is forwarded via `.call`, and
+  `ToObject(undefined)` throws before it is consulted.
+- **`Array.prototype.shift.call(function(){})` ×1** — func-expr as `this`.
+
+## Result
+
+With the standalone-gated narrowing:
+
+- **14 genuine flips** (leak → host-free pass). All 14 verified `pass` via the
+  test262 runner in the standalone lane, and **inject-throw** confirms the
+  bodies genuinely execute (an injected `throw` fails the copy — not vacuous).
+- **Zero host-free-pass regressions**: all **22** currently-passing standalone
+  tests that carry a `.call`/`.apply` func-expr arg still pass with the change
+  (this is the full affected class in the merged report, not a sample).
+- **Bonus**: `Array.prototype.forEach.call(arr, cb)` / `map.call` — where the
+  _receiver_ HOF genuinely invokes `cb` — now compile **host-free** and execute
+  correctly (the callback dispatches through the closure struct via
+  `__call_fn_N`), rather than leaking.
+- **gc/js-host lane byte-identical** (sha256 over representative binaries) — the
+  change is gated on `ctx.standalone`.
+
+## Why it can't regress a host-free pass
+
+A func-expr passed to `.call`/`.apply` currently ALWAYS routes to
+`__make_callback`, which ALWAYS emits an `env::` import — so every such test is
+currently _leaky_ (never a host-free pass). The change can therefore only move
+such a test leak → {host-free-pass | host-free-fail}, never regress an existing
+host-free pass. The 22/22 re-run confirms none become a fail.
+
+## Residual decomposition (banked — NOT this issue)
+
+The other ~45 of the 59 are separate substrate work, filed here for the next
+leak-front session:
+
+- **Iterator.prototype.\* helpers ×18** (`find`/`map`/`filter`/`every`/`some`/
+  `forEach`/`reduce`/`flatMap` on iterator objects) — need native helper bodies
+  that drive the underlying iterator and invoke the predicate via `call_ref`
+  (#2903 sub-front 2). These specific 18 are abrupt-completion edge cases
+  (throwing-next / return-forwarding) and many would still fail on semantics
+  even with native bodies.
+- **`new Proxy(fn, handler)` (Function.prototype.toString) ×6** — Proxy is a
+  deferred feature; the func-expr is the proxy target.
+- **`Object.getPrototypeOf/getOwnPropertyDescriptor(func-expr)` ×5**,
+  **`Array.isArray(func-expr)` ×1**, **`.at(func-expr)` ×2** — func-expr as a
+  plain non-invoked value arg to a builtin; a broader "func-expr value arg →
+  closure path in standalone" default would cover these but needs wider CI
+  validation (each builtin consumes the value differently). Deferred.
+- **`Map`/`WeakMap.prototype.getOrInsertComputed(k, fn)` ×2** — new proposal
+  method; callback invoked, needs native body.
+- **`promise.then(arrow)` ×1** — async/microtask substrate (#2903 sub-front 1).
+- Scattered: `String.at`, `Date[Symbol.toPrimitive]` forEach, GeneratorFunction.
+
+## Exact site
+
+`src/codegen/closures.ts`, `isHostCallbackArgument`, property-access branch
+(the `methodName` block before the class-method resolution `try`):
+
+```ts
+if (ctx.standalone && (methodName === "call" || methodName === "apply")) {
+  return false;
+}
+```
+
+## Acceptance
+
+- Targeted corpus flips host-free: `WebAssembly.Module.imports` carries no
+  `env::__make_callback` AND the standalone binary instantiates host-free.
+- gc/js-host byte-output unchanged (standalone-gated).
+- Full `merge_group` net-positive, zero regression.
+
+## Test Results
+
+`tests/issue-3016.test.ts` — 4/4 pass (getter `.call`, `find.call(undefined,fn)`,
+`findIndex.apply`, `forEach.call` host-free + genuine execution). 14/14 real
+test262 files pass standalone (inject-throw genuine). 22/22 affected passing
+tests still pass. gc-lane sha256 identical.

--- a/src/codegen/closures.ts
+++ b/src/codegen/closures.ts
@@ -1191,6 +1191,21 @@ export function isHostCallbackArgument(node: ts.Node, ctx: CodegenContext): bool
     if (ts.isPropertyAccessExpression(parent.expression)) {
       const propAccess = parent.expression;
       const methodName = propAccess.name.text;
+      // (#3016) `Function.prototype.call`/`apply` NEVER invoke their arguments
+      // as callbacks — they invoke the *receiver* with those args as `thisArg`
+      // + forwarded params. So a function-expression/arrow passed to `.call`/
+      // `.apply` (e.g. `get.call(() => {})` using a function object as an
+      // invalid `this`, or `Array.prototype.find.call(undefined, fn)`) is a
+      // plain function-object VALUE, not a synchronously-invoked host callback.
+      // Routing it through `__make_callback` leaks an `env::` import in
+      // standalone mode for no reason; the GC closure-struct path produces a
+      // valid function-object value host-free (and any HOF that the *receiver*
+      // then invokes — `Array.prototype.forEach.call(arr, cb)` — dispatches the
+      // struct via `__call_fn_N`, verified host-free). Standalone-gated so the
+      // js-host lane stays byte-identical.
+      if (ctx.standalone && (methodName === "call" || methodName === "apply")) {
+        return false;
+      }
       try {
         const receiverType = ctx.checker.getTypeAtLocation(propAccess.expression);
         // Search the receiver type's symbol chain for a class name that

--- a/tests/issue-3016.test.ts
+++ b/tests/issue-3016.test.ts
@@ -1,0 +1,82 @@
+// #3016 — standalone: a function-expression/arrow passed as an argument to
+// `Function.prototype.call`/`apply` is a plain function-object VALUE, not a
+// synchronously-invoked host callback. It must take the GC closure-struct path,
+// NOT the `__make_callback` host bridge (which leaks an `env::` import and makes
+// the standalone binary non-host-free).
+//
+// Shapes covered (from the residual sole-`__make_callback` standalone leak set):
+//   - `get.call(() => {})`                        — arrow used as invalid `this`
+//   - `Array.prototype.find.call(undefined, fn)`  — predicate forwarded via .call
+//   - `Array.prototype.forEach.call(arr, cb)`     — HOF whose receiver DOES invoke
+//     the callback: must still execute correctly through the closure-struct path
+//
+// The load-bearing property is: NO `env::` import (checked statically via
+// `WebAssembly.Module.imports`, which does not execute the module). Genuine
+// end-to-end execution of the real test262 files is validated in the standalone
+// lane via the test262 runner (inject-throw discipline); here the forEach case
+// additionally proves the callback still runs through `__call_fn_N`.
+//
+// The fix is standalone-gated (`ctx.standalone`), so the js-host/gc lane stays
+// byte-identical (verified separately via sha256).
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function compileStandalone(src: string) {
+  const r = await compile(src, { fileName: "test.ts", target: "standalone", skipSemanticDiagnostics: true });
+  expect(r.success, r.errors?.[0]?.message).toBe(true);
+  return r;
+}
+
+function envImports(binary: Uint8Array): string[] {
+  const mod = new WebAssembly.Module(binary);
+  return WebAssembly.Module.imports(mod)
+    .filter((i) => i.module === "env")
+    .map((i) => i.name);
+}
+
+describe("#3016 — .call/.apply func-expr arg is a value, not a host callback (standalone)", () => {
+  it("arrow used as invalid `this` via .call() emits no env import", async () => {
+    const r = await compileStandalone(`
+      const desc: any = (Object as any).getOwnPropertyDescriptor(RegExp.prototype, "global");
+      const get: any = desc.get;
+      export function test(): void {
+        get.call(() => {});
+      }
+    `);
+    expect(envImports(r.binary)).not.toContain("__make_callback");
+    expect(envImports(r.binary)).toEqual([]);
+  });
+
+  it("func-expr predicate forwarded via Array.prototype.find.call(undefined, fn) emits no env import", async () => {
+    const r = await compileStandalone(`
+      export function test(): void {
+        (Array.prototype.find as any).call(undefined, function () {});
+      }
+    `);
+    expect(envImports(r.binary)).toEqual([]);
+  });
+
+  it("apply with a func-expr arg emits no env import", async () => {
+    const r = await compileStandalone(`
+      export function test(): void {
+        (Array.prototype.findIndex as any).apply(null, [function () {}]);
+      }
+    `);
+    expect(envImports(r.binary)).toEqual([]);
+  });
+
+  it("Array.prototype.forEach.call(arr, cb) is host-free AND still invokes cb (closure-struct path)", async () => {
+    const r = await compileStandalone(`
+      export function test(): number {
+        let sum = 0;
+        Array.prototype.forEach.call([1, 2, 3], function (x: any) { sum += x; });
+        return sum;
+      }
+    `);
+    expect(envImports(r.binary)).toEqual([]);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    // The callback IS invoked by forEach (the receiver), via __call_fn_N — proves
+    // the value is a working closure struct, not a dead host wrapper.
+    expect((instance.exports.test as () => number)()).toBe(6);
+  });
+});


### PR DESCRIPTION
## Summary

`isHostCallbackArgument` (`src/codegen/closures.ts`) routed **any** function-expression/arrow argument of a method call on a non-user-class receiver to the `__make_callback` host bridge. That includes func-expr args to `Function.prototype.call`/`apply` — but **`.call`/`.apply` provably never invoke their arguments as callbacks**; they invoke the *receiver* with those args as `thisArg` + forwarded params. So the func-expr is a plain function-object **value**, and routing it through `__make_callback` leaked an `env::__make_callback` import that broke host-free (standalone) instantiation for no reason.

**Fix (standalone-gated, 3 lines):** in the property-access branch of `isHostCallbackArgument`, return the GC closure-struct path when `ctx.standalone && (methodName === "call" || methodName === "apply")`.

## Measured impact (round-6 residual sole-`__make_callback` leak set, `target: standalone`)

- **14 genuine flips** (leak → host-free pass). All 14 verified `pass` via the test262 runner in the standalone lane; **inject-throw** confirms the bodies genuinely execute (injected `throw` fails the copy — not vacuous). Triggers: RegExp getter `this-val-invalid-obj` ×10 (`get.call(() => {})`), Array find-family `.call(undefined, fn)` ×4, `shift.call(fn)` ×1.
- **Zero host-free-pass regressions**: all **22** currently-passing standalone tests carrying a `.call`/`.apply` func-expr arg still pass (full affected class in the merged report, not a sample).
- **Bonus**: `Array.prototype.forEach.call(arr, cb)` / `map.call` — where the *receiver* HOF genuinely invokes `cb` — now compile **host-free** and execute correctly (callback dispatched via `__call_fn_N`), rather than leaking.
- **gc/js-host lane byte-identical** (sha256 over representative binaries) — gated on `ctx.standalone`.

## Why it can't regress a host-free pass

A func-expr passed to `.call`/`.apply` currently ALWAYS routes to `__make_callback`, which ALWAYS emits an `env::` import — so every such test is currently *leaky* (never a host-free pass). The change can only move leak → {host-free-pass | host-free-fail}, never regress an existing host-free pass. The 22/22 re-run confirms none become a fail.

## Scope note

The other ~45 of the 59 residual sole-`__make_callback` passes are heterogeneous (~10 distinct roots: Iterator.prototype helper native bodies ×18, Proxy `toString` ×6, `getOrInsertComputed`, `promise.then`, Object.* value-args) and are separate substrate work — decomposed in `plan/issues/3016-*.md` for the next leak-front session.

## Test

`tests/issue-3016.test.ts` — 4/4 pass (getter `.call`, `find.call(undefined, fn)`, `findIndex.apply` emit no `env::` import; `forEach.call` host-free + genuine execution returns 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)