### PR TITLE
feat(codegen): #3013 genuine %ArrayIteratorPrototype% shared identity (standalone)

### DIFF
--- a/plan/issues/3013-array-iterator-prototype-identity.md
+++ b/plan/issues/3013-array-iterator-prototype-identity.md
@@ -1,0 +1,115 @@
+---
+id: 3013
+title: "Standalone %ArrayIteratorPrototype% shared identity + Object-subclass native construction (host-free array-iterator cluster)"
+status: done
+assignee: ttraenkler/sendev-iterproto
+completed: 2026-07-03
+sprint: current
+created: 2026-07-03
+updated: 2026-07-03
+priority: medium
+horizon: m
+feasibility: hard
+reasoning_effort: max
+task_type: feature
+area: codegen
+language_feature: iterators, builtins
+goal: standalone-mode
+related: [2963, 3006, 2965, 2984]
+origin: "2026-07-03 leak-analysis round 6 — the two remaining GENUINE sole-leak clusters (`env::__iterator` 9, `env::__new_Object` 5) that share #2963/#3006's builtin-object-identity substrate family"
+---
+
+# #3013 — %ArrayIteratorPrototype% shared identity (+ Object-subclass native construction)
+
+## Problem
+
+Round-6 leak analysis (`plan/log/investigations/2026-07-03-leak-analysis-round6.md`)
+flagged two GENUINE sole-leak clusters that were earlier deferred as
+"substrate-scale" **before** the #2963/#3006 builtin-object-identity reification
+mechanism existed:
+
+- **`env::__iterator` — 9 sole passes.** Array-iterator conformance
+  (`Array.prototype.{values,keys,entries}/returns-iterator.js`) asserts
+  `Object.getPrototypeOf([][Symbol.iterator]()) === Object.getPrototypeOf([].values())`
+  — all array iterators share one `%ArrayIteratorPrototype%` (§23.1.5.2).
+- **`env::__new_Object` — 5 sole passes.** `class X extends Object {}` leaks the
+  `__new_Object` host import at construction; the passes were leaky (the runner
+  supplies the host import).
+
+## Resolution
+
+### Cluster A — `%ArrayIteratorPrototype%` — SHIPPED (this PR)
+
+Two changes, both standalone/WASI-guarded (host/gc lane byte-inert):
+
+1. **`<array>[Symbol.iterator]()` → native `.values()`**
+   (`src/codegen/expressions/calls.ts`, `@@iterator` element-access dispatch).
+   Per §23.1.3.40 `Array.prototype[Symbol.iterator] === Array.prototype.values`,
+   so an array receiver routes to the existing native `compileArrayMethodCall(…,
+   "values")` path, producing an identical host-free `$__IterRec` instead of the
+   `env::__iterator` host bridge. `.values()`/`.keys()`/`.entries()` were already
+   native; this closes the `[Symbol.iterator]()` gap.
+
+2. **`Object.getPrototypeOf(<array iterator>)` → shared native singleton**
+   (`emitArrayIteratorPrototypeSingleton` in `src/codegen/array-object-proto.ts`,
+   wired at the `getPrototypeOf` handler). One module-level `externref` mutable
+   global, lazily `__new_plain_object()` — the same lazily-materialized
+   singleton pattern #3006's `emitBuiltinConstructorIdentity` uses. Every array
+   iterator routes through the SAME global, so identity is GENUINE. Detection is
+   keyed on the TS checker's precise `ArrayIterator<T>` result type — distinct
+   from `Generator`/`MapIterator`/`SetIterator`/`StringIterator` — so no other
+   iterator kind is mis-routed (verified: those still return their existing
+   value, unaffected).
+
+**Genuineness (swap-wrong-value):** the shared prototype is genuinely equal
+across all array iterators (values/keys/entries/[Symbol.iterator]/variable-flow)
+AND genuinely DISTINCT from the array prototype, plain-object prototype, and
+generator-iterator prototype (all three swap-guards fail as required — not a
+coincidental null≡null). The 3 real test262 files
+(`values|keys|entries/returns-iterator.js`) pass standalone host-free (they
+leaked `env::__iterator` before). Regression-checked: for-of / spread /
+destructuring over arrays intact; host/gc mode still emits `__iterator` /
+`__getPrototypeOf` (byte-inert). Tests:
+`tests/issue-3013-array-iterator-prototype-identity.test.ts` (8, all green).
+
+### Cluster B — `class X extends Object {}` — DEFERRED (does not cleanly unlock)
+
+**Honest finding: the reification substrate is NOT sufficient for cluster B; it
+needs deeper native-prototype-model work and is split out as a follow-up.**
+
+Making construction host-free is straightforward — route the Object-subclass
+`super()`/implicit-ctor from the `__new_Object` host import to native
+`__new_plain_object()` (§20.1.1.1: `super(...)` with NewTarget ≠ Object creates a
+fresh ordinary object and ignores the argument). That removes the leak. **But it
+regresses `regular-subclassing.js`** (`assert.notSameValue(Object.getPrototypeOf(
+new X()), Object.prototype)`), because:
+
+- **`emitSetSubclassProto` is a deliberate no-op standalone** (it depends on the
+  `__set_subclass_proto` host import), so a native `__new_plain_object` instance
+  keeps the plain `%Object.prototype%` default in its `$Object.$proto` slot.
+- **For an externref-backed Object-subclass, `X.prototype` ITSELF collapses to
+  `%Object.prototype%`** — there is no distinct native `$Object` prototype object
+  for `X`. Verified (via local-bound comparison, avoiding the inline-`any`-arg
+  coercion artefact): for a top-level `class X extends Object {}`,
+  `X.prototype === Object.prototype === Object.getPrototypeOf(new X())` all
+  collapse to the same object.
+
+So genuinely fixing B requires a **distinct native `$Object` prototype per
+externref-backed Object-subclass**, whose own `[[Prototype]]` is
+`%Object.prototype%`, unified across THREE consumers: the `X.prototype`
+value-read, the instance `[[Prototype]]` slot (set via native
+`__object_setPrototypeOf`), and `Object.getPrototypeOf(instance)` (native
+`__getPrototypeOf`, which reads `$Object.$proto` field 0). The native primitives
+all exist and round-trip host-free (verified: `Object.setPrototypeOf(o,p)` then
+`Object.getPrototypeOf(o) === p !== Object.prototype`), so this is tractable —
+but it touches the shared subclass-of-builtin proto path (`emitSetSubclassProto`
+is also used by `class … extends Error/DataView/…`), so it carries cross-subclass
+regression risk and warrants its own scoped issue + validation. Shipping B's
+construction change alone (a leaky-pass → host-free-FAIL flip) would be a net
+regression, so it is intentionally excluded here.
+
+**Follow-up:** carve a dedicated issue in the #2984 / sr-objsub native-object
+lane — "distinct native `$Object` prototype for externref-backed Object
+subclasses (host-free `class X extends Object`)". The `__new_plain_object`
+construction routing + the native-proto-set helper prototyped in this session
+are the starting point.

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -1970,3 +1970,59 @@ export function emitNativeGlobalThisObject(ctx: CodegenContext, fctx: FunctionCo
   fctx.body.push({ op: "global.get", index: globalIdx } as Instr);
   return { kind: "externref" };
 }
+
+/**
+ * (#3013) Native standalone `%ArrayIteratorPrototype%` value — the ONE shared
+ * prototype object every array iterator (`[].values()` / `.keys()` / `.entries()`
+ * / `[][Symbol.iterator]()`) reports from `Object.getPrototypeOf`. ECMA-262
+ * §23.1.5.2: all array iterators are `ObjectCreate(%ArrayIteratorPrototype%, …)`,
+ * so `Object.getPrototypeOf([].values()) === Object.getPrototypeOf(
+ * [][Symbol.iterator]())` MUST hold by object identity.
+ *
+ * Standalone array iterators are native `$__IterRec` structs (array-methods.ts /
+ * iterator-native.ts); their [[Prototype]] is not modeled, so the pre-#3013
+ * `Object.getPrototypeOf(<iterator>)` standalone fallback returned
+ * `ref.null.extern` — which made the identity assertion pass only COINCIDENTALLY
+ * (null === null) and, worse, made `getPrototypeOf([].values()) ===
+ * getPrototypeOf([1, 2])` ALSO pass (both null). This reifies a genuine,
+ * identity-stable `$Object` singleton (same `__new_plain_object` runtime as
+ * `{}`), lazily materialized once, cached in a module-level mutable global. Every
+ * array-iterator `getPrototypeOf` routes to the SAME global, so identity is
+ * genuine: same singleton across all array iterators (true), distinct from array
+ * / plain-object / other-kind-iterator prototypes (false under the swap-guard).
+ *
+ * The routing is keyed on the STATIC type being `ArrayIterator<T>` (the TS
+ * checker's precise symbol name for all four array-iterator producers, distinct
+ * from `Generator`/`MapIterator`/`SetIterator`/`StringIterator`), so no
+ * cross-kind iterator is mis-routed to this prototype. Standalone/WASI only;
+ * returns the externref ValType, or `null` if the `$Object` runtime is
+ * unavailable (caller falls through to the host-import path).
+ */
+export function emitArrayIteratorPrototypeSingleton(ctx: CodegenContext, fctx: FunctionContext): ValType | null {
+  ensureObjectRuntime(ctx);
+  const newObjectIdx = ctx.funcMap.get("__new_plain_object");
+  if (newObjectIdx === undefined) return null;
+
+  const globalName = "__native_array_iterator_prototype";
+  let globalIdx = ctx.builtinObjectGlobals.get(globalName);
+  if (globalIdx === undefined) {
+    globalIdx = ctx.numImportGlobals + ctx.mod.globals.length;
+    ctx.mod.globals.push({
+      name: globalName,
+      type: { kind: "externref" },
+      mutable: true,
+      init: [{ op: "ref.null.extern" }],
+    });
+    ctx.builtinObjectGlobals.set(globalName, globalIdx);
+  }
+
+  const initBody: Instr[] = [
+    { op: "call", funcIdx: newObjectIdx } as Instr,
+    { op: "global.set", index: globalIdx } as Instr,
+  ];
+  fctx.body.push({ op: "global.get", index: globalIdx } as Instr);
+  fctx.body.push({ op: "ref.is_null" } as Instr);
+  fctx.body.push({ op: "if", blockType: { kind: "empty" }, then: initBody, else: [] } as Instr);
+  fctx.body.push({ op: "global.get", index: globalIdx } as Instr);
+  return { kind: "externref" };
+}

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -131,6 +131,7 @@ import {
   ensureObjectNativeProtoGlue,
   ensureStringNativeProtoGlue,
   emitTypedArrayIntrinsicCtorObject,
+  emitArrayIteratorPrototypeSingleton,
   isWiredTypedArrayViewName,
 } from "../array-object-proto.js";
 import {
@@ -6830,6 +6831,28 @@ function compileCallExpression(
       }
 
       const argTsType = ctx.checker.getTypeAtLocation(arg0);
+
+      // (#3013) `Object.getPrototypeOf(<array iterator>)` → the shared native
+      // `%ArrayIteratorPrototype%` singleton (standalone/WASI). Every array
+      // iterator (`[].values()` / `.keys()` / `.entries()` / `[][Symbol.iterator]()`
+      // and any value flowing through an `ArrayIterator<T>`-typed binding) reports
+      // the SAME prototype object by identity (§23.1.5.2). The TS checker names
+      // ALL four producers' result type `ArrayIterator` — distinct from
+      // `Generator`/`MapIterator`/`SetIterator`/`StringIterator` — so this routes
+      // genuinely and never mis-maps a different iterator kind. Without it the
+      // standalone fallback below returns `ref.null.extern`, which made the
+      // identity assertion pass only coincidentally (null === null). Host/gc mode
+      // keeps the `__getPrototypeOf` host import (byte-inert).
+      if ((ctx.standalone || ctx.wasi) && argTsType.getSymbol()?.name === "ArrayIterator") {
+        const argType = compileExpression(ctx, fctx, arg0);
+        if (argType) fctx.body.push({ op: "drop" });
+        const protoType = emitArrayIteratorPrototypeSingleton(ctx, fctx);
+        if (protoType) return protoType;
+        // Runtime unavailable: preserve the historical null return.
+        fctx.body.push({ op: "ref.null.extern" });
+        return { kind: "externref" };
+      }
+
       const className = resolveStructName(ctx, argTsType);
 
       // For known class instances, return the class prototype singleton
@@ -14661,6 +14684,21 @@ function compileCallExpression(
       //   - __call_@@iterator export for user-defined iterable classes
       //   - __vec_len/__vec_get fallback for vec structs (arrays)
       if (methodName === "@@iterator" || methodName === "@@asyncIterator") {
+        // (#3013) Standalone/WASI: `<array>[Symbol.iterator]()` is, per
+        // §23.1.3.40, the SAME operation as `Array.prototype.values` —
+        // `Array.prototype[Symbol.iterator] === Array.prototype.values`. Route an
+        // array receiver to the native `.values()` lowering so it produces the
+        // identical `$__IterRec` value host-free, instead of leaking the
+        // `env::__iterator` host import (the sole leak of the array-iterator
+        // conformance cluster). The `.values()`/`.keys()`/`.entries()` forms are
+        // already native; this closes the `[Symbol.iterator]()` gap. Host/gc mode
+        // keeps the existing `__iterator` bridge (byte-inert). Async iterator and
+        // non-array receivers fall through unchanged.
+        if (methodName === "@@iterator" && (ctx.standalone || ctx.wasi) && resolveArrayInfo(ctx, receiverType)) {
+          const nativeResult = compileArrayMethodCall(ctx, fctx, elemAccess, expr, receiverType, "values");
+          if (nativeResult !== undefined && nativeResult !== null) return nativeResult as ValType;
+          // Fall through to the host bridge if the native path declined.
+        }
         const importName = methodName === "@@iterator" ? "__iterator" : "__async_iterator";
         const recvType = compileExpression(ctx, fctx, elemAccess.expression);
         if (recvType) {

--- a/tests/issue-3013-array-iterator-prototype-identity.test.ts
+++ b/tests/issue-3013-array-iterator-prototype-identity.test.ts
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #3013 — genuine, identity-stable `%ArrayIteratorPrototype%` singleton (standalone).
+ *
+ * Extends #2963/#3006's "reify builtins as first-class values with real object
+ * identity" substrate to array iterators. ECMA-262 §23.1.5.2: every array
+ * iterator (`[].values()` / `.keys()` / `.entries()` / `[][Symbol.iterator]()`)
+ * is `ObjectCreate(%ArrayIteratorPrototype%, …)`, so
+ * `Object.getPrototypeOf([].values()) === Object.getPrototypeOf([][Symbol.iterator]())`
+ * holds by ONE shared prototype identity.
+ *
+ * Two parts:
+ *   1. `<array>[Symbol.iterator]()` in standalone/WASI now lowers to the native
+ *      `Array.prototype.values` path (they are the SAME operation, §23.1.3.40),
+ *      producing an identical host-free `$__IterRec` instead of leaking the
+ *      `env::__iterator` host import.
+ *   2. `Object.getPrototypeOf(<array iterator>)` reifies a genuine, identity-
+ *      stable native `$Object` `%ArrayIteratorPrototype%` singleton (one
+ *      module-level global, lazily `__new_plain_object`) that every array
+ *      iterator routes through. Detection is keyed on the TS checker's precise
+ *      `ArrayIterator<T>` result type (distinct from
+ *      `Generator`/`MapIterator`/`SetIterator`/`StringIterator`), so no other
+ *      iterator kind is mis-routed to this prototype.
+ *
+ * The identity checks below use a CLEAN SameValue helper (`if (a===b) return
+ * true`) bound through locals — the concrete WasmGC `ref.eq` identity path.
+ * (The verbatim test262 `assert._isSameValue` contains `1/a === 1/b`, whose
+ * pre-existing `any`-operand ToNumber coercion collapses object comparisons when
+ * the operands are passed inline as call arguments — a separate bug, untouched
+ * here; the array-iterator test262 files still pass since they only assert the
+ * TRUE case, and none of the changed lowering depends on it.)
+ */
+
+const SAME = `function isSameValue(a: any, b: any): boolean { if (a === b) { return true; } return a !== a && b !== b; }\n`;
+
+async function runStandalone(body: string): Promise<number> {
+  const r = await compile(SAME + `export function test(): number { ${body} }`, {
+    target: "standalone",
+    nativeStrings: true,
+  });
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, {});
+  return (instance.exports as { test: () => number }).test();
+}
+
+async function envImports(src: string): Promise<string[]> {
+  const r = await compile(src, { target: "standalone", nativeStrings: true });
+  expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+  return r.imports.filter((i) => i.module === "env").map((i) => i.name);
+}
+
+describe("#3013 — %ArrayIteratorPrototype% shared identity (standalone)", () => {
+  it("getPrototypeOf([].values()) === getPrototypeOf([][Symbol.iterator]()) — GENUINELY true", async () => {
+    expect(
+      await runStandalone(
+        `const p1: any = Object.getPrototypeOf([][Symbol.iterator]()); const p2: any = Object.getPrototypeOf([].values()); return isSameValue(p1, p2) ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("values()/keys()/entries() all share one prototype identity", async () => {
+    expect(
+      await runStandalone(
+        `const a=[1,2]; const p1: any = Object.getPrototypeOf(a.values()); const p2: any = Object.getPrototypeOf(a.keys()); const p3: any = Object.getPrototypeOf(a.entries()); return (isSameValue(p1,p2) && isSameValue(p2,p3)) ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  it("identity holds for iterators flowing through variables", async () => {
+    expect(
+      await runStandalone(
+        `const it1=[].values(); const it2=[][Symbol.iterator](); const p1: any = Object.getPrototypeOf(it1); const p2: any = Object.getPrototypeOf(it2); return isSameValue(p1, p2) ? 1 : 0;`,
+      ),
+    ).toBe(1);
+  });
+
+  // Swap-wrong-value guards: the shared array-iterator prototype must be a
+  // GENUINELY DISTINCT object — not a coincidental null≡null or all-objects-equal.
+  it("SWAP: array-iterator prototype !== array prototype", async () => {
+    expect(
+      await runStandalone(
+        `const p1: any = Object.getPrototypeOf([].values()); const p2: any = Object.getPrototypeOf([1,2]); return isSameValue(p1, p2) ? 1 : 0;`,
+      ),
+    ).toBe(0);
+  });
+
+  it("SWAP: array-iterator prototype !== plain-object prototype", async () => {
+    expect(
+      await runStandalone(
+        `const p1: any = Object.getPrototypeOf([].values()); const p2: any = Object.getPrototypeOf({a:1}); return isSameValue(p1, p2) ? 1 : 0;`,
+      ),
+    ).toBe(0);
+  });
+
+  it("SWAP: array-iterator prototype !== generator-iterator prototype", async () => {
+    expect(
+      await runStandalone(
+        `function* g(){yield 1;} const p1: any = Object.getPrototypeOf([].values()); const p2: any = Object.getPrototypeOf(g()); return isSameValue(p1, p2) ? 1 : 0;`,
+      ),
+    ).toBe(0);
+  });
+
+  it("[Symbol.iterator]() and getPrototypeOf(array iterator) are host-free (no env::__iterator)", async () => {
+    const forms = [
+      `export function test(): number { const p: any = Object.getPrototypeOf([].values()); return p ? 1 : 0; }`,
+      `export function test(): number { const p: any = Object.getPrototypeOf([][Symbol.iterator]()); return p ? 1 : 0; }`,
+    ];
+    for (const src of forms) {
+      const env = await envImports(src);
+      expect(env, `leaked env import(s): ${env.join(",")}`).not.toContain("__iterator");
+      expect(env).not.toContain("__getPrototypeOf");
+    }
+  });
+
+  it("for-of / spread over an array iterator still works host-free", async () => {
+    expect(await runStandalone(`let s=0; for (const x of [1,2,3][Symbol.iterator]()) s+=x as number; return s;`)).toBe(
+      6,
+    );
+  });
+});


### PR DESCRIPTION
## #3013 — genuine `%ArrayIteratorPrototype%` shared identity (standalone)

Extends #2963/#3006's reified-builtin-object-identity substrate to **array iterators** — the `env::__iterator` sole-leak cluster flagged by the 2026-07-03 round-6 leak analysis. Standalone/WASI only; **host/gc lane byte-inert**.

### What changed (2 parts)

1. **`<array>[Symbol.iterator]()` → native `.values()`** (`src/codegen/expressions/calls.ts`). Per §23.1.3.40 `Array.prototype[Symbol.iterator] === Array.prototype.values`, so an array receiver routes to the existing native path, producing an identical host-free `$__IterRec` instead of leaking `env::__iterator`. `.values()`/`.keys()`/`.entries()` were already native; this closes the `[Symbol.iterator]()` gap.

2. **`Object.getPrototypeOf(<array iterator>)` → shared native singleton** (`emitArrayIteratorPrototypeSingleton`, `src/codegen/array-object-proto.ts`). One module-level `externref` global, lazily `__new_plain_object()` — the same lazily-materialized pattern as #3006's `emitBuiltinConstructorIdentity`. Every array iterator routes through the SAME global, so `getPrototypeOf([].values()) === getPrototypeOf([][Symbol.iterator]())` holds by genuine object identity (§23.1.5.2). Detection keys on the TS checker's precise `ArrayIterator<T>` result type — distinct from `Generator`/`MapIterator`/`SetIterator`/`StringIterator` — so no other iterator kind is mis-routed.

### Genuineness (swap-wrong-value verified)

- Shared prototype is **equal** across values/keys/entries/`[Symbol.iterator]`/variable-flow, AND
- genuinely **distinct** from the array prototype, plain-object prototype, and generator-iterator prototype (all three swap-guards fail — not a coincidental null≡null).
- 3 real test262 files (`Array/prototype/{values,keys,entries}/returns-iterator.js`) pass standalone host-free (they leaked `env::__iterator` before).
- Regression-checked: for-of / spread / destructuring over arrays intact; host/gc mode still emits `__iterator` / `__getPrototypeOf`.

Tests: `tests/issue-3013-array-iterator-prototype-identity.test.ts` (8, green).

### Cluster B (`class X extends Object`) — DEFERRED, reported honestly

The companion `env::__new_Object` cluster does **not** cleanly unlock with the reification substrate. Making construction host-free (native `__new_plain_object`) regresses `regular-subclassing.js` because `emitSetSubclassProto` is a standalone no-op **and** `X.prototype` itself collapses to `%Object.prototype%` for externref-backed Object-subclasses. It needs a distinct native `$Object` prototype per Object-subclass unified across the `.prototype` read + instance `[[Prototype]]` slot + `getPrototypeOf` — a follow-up in the #2984 native-object lane (native primitives exist and round-trip host-free; carries cross-subclass regression risk). Full root-cause in the issue file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)