### PR TITLE
docs(#2958): bank execution-ready impl plan for unhandled-rejection tracking

### DIFF
--- a/plan/issues/2958-standalone-unhandled-rejection-tracking.md
+++ b/plan/issues/2958-standalone-unhandled-rejection-tracking.md
@@ -70,3 +70,77 @@ Deferred after an initial measure-first sizing pass. Two reasons:
 **Recommendation:** sequence this after the carrier work settles — specifically
 after #2867 / #2959 land — then re-scope as `horizon: m` and reclaim. Claim was
 released on the `issue-assignments` ref; `status` left `ready`.
+
+## Implementation Plan (banked 2026-07-03, dev-standing-3)
+
+A second, independent measure-first pass (2026-07-03) reached the same verdict —
+this is an **M**, not an **S**, and the sequencing gate **still holds**: #2867
+is `in-progress` and #2959 is `ready`, so `src/codegen/async-scheduler.ts` is
+still actively churning. **Do not implement until #2867 lands.** What follows is
+the execution-ready spec so the next window moves fast once the file settles.
+
+### Gating reality (important — corrects the title's "standalone")
+The native `$Promise` carrier is **`ctx.wasi`-gated**, not `ctx.standalone`:
+`isStandalonePromiseActive()` returns `ctx.wasi === true`
+(async-scheduler.ts ~L3298), and `emitStandalonePromiseThen` /
+`Promise.reject` / `__drain_microtasks` only fire on that path. So this feature
+targets **`--target wasi`** (where `fd_write` + `proc_exit` + `_start` already
+exist). **Host mode is byte-inert by construction** — host never registers
+`$Promise` (`host ? -1 : getOrRegisterPromiseType(ctx)`, async-frame.ts L1116),
+so no host-lane sha256 risk.
+
+### Data model
+- **`$Promise` struct** (`getOrRegisterPromiseType`, async-scheduler.ts ~L258):
+  append two fields — `handled: i32 (mut)` and `unhandledNext: externref (mut)`.
+  Appending keeps existing `fieldIdx` 0/1/2 (`state`/`value`/`callbacks`) stable,
+  so every current `struct.get/set` stays valid. **Mirror the append in the
+  `ctx.structFields.set("$Promise", …)` block right below** (both the
+  `mod.types.push` and the mirror).
+- **Global `__unhandled_head: externref`** (init `ref.null.extern`), registered
+  next to the microtask globals (~L400). Intrusive singly-linked list head.
+
+### Emit sites (all in async-scheduler.ts unless noted)
+1. **Reject settle** — `buildPromiseSettleBody`, **REJECTED variant only**
+   (`settledState === PROMISE_STATE_REJECTED`). After callbacks are read into
+   `$callbacks` (L868–872), guard `ref.is_null($callbacks)`: if null (no
+   handler at settle) → `promise.unhandledNext = __unhandled_head;
+   __unhandled_head = promise` (O(1) push). The callback-drain loop below is a
+   no-op when callbacks is null, so ordering is safe.
+2. **Late attach ("handle")** — `emitStandalonePromiseThen`, the **already-
+   rejected receiver** branch (the inner `then:` enqueuing `rejectWrapperFuncIdx`,
+   ~L3240): also emit `promise.handled = 1` (`struct.set` fieldIdx 3). A pending
+   promise that later rejects **with** callbacks never enters the list, so no
+   marking is needed on the pending or fulfilled branches.
+3. **Report fn `__report_unhandled_rejections()`** (new): walk `__unhandled_head`;
+   for each node with `handled == 0`, write the diagnostic to stderr and set a
+   local "any-unhandled" flag; after the walk, if the flag is set, `proc_exit(1)`.
+   Minimal-correct message: a **constant** `"Unhandled promise rejection\n"` via
+   `wasiAllocStringData(ctx, msg)` → `{offset,length}` →
+   `__wasi_write_string_stderr(offset, length)` (exact call shape at
+   builtins.ts L2710-2714). Per-reason stringification is **deferred to #2962**
+   (fall back to the constant / the tag+typeof classifier until it lands) — this
+   keeps the slice bounded and still satisfies AC1/AC2.
+4. **Wire into `_start`** — `addWasiStartExport` (index.ts ~L2573): after the
+   `runLoopFuncIdx`/`drainFuncIdx` call is pushed to the `_start` body, push
+   `call __report_unhandled_rejections`. Report **only at `_start` end** (program
+   exit), NEVER inside `__drain_microtasks` itself — a mid-program drain must not
+   report or exit.
+
+### HAZARD — late-import funcIdx shift (#2642 / the memory `*_funcidx_desync` cluster)
+`__report_unhandled_rejections` references `__wasi_write_string_stderr` **and**
+`proc_exit`, which are only registered when `console.error` / `process.exit`
+are otherwise used. When this feature is active you MUST (a) **ensure both are
+registered** (`emitWasiWriteStringStderrHelper` at index.ts L7629; the WASI
+`proc_exit` import from `registerWasiImports`), and (b) **resolve their funcIdx
+BY NAME at emit time** — never cache an index across an `ensure*` that adds a
+late import. Emit the report body after all imports are fixed, or repoint by
+name (`ctx.funcMap.get(...)`) at finalize.
+
+### Test (`tests/issue-2958.test.ts`)
+WASI-compile + run under wasmtime (or the standalone harness):
+- `Promise.reject(new Error("x"))` with no handler → **nonzero exit** + a stderr
+  line. (AC1)
+- same but with `.catch(() => {})` → exit 0, no line. (AC2)
+- reject → microtask → late `.catch` within the same drain → **no** report. (AC3)
+
+### On claim: re-scope `horizon: s → m` in the frontmatter.


### PR DESCRIPTION
## What

Adds an execution-ready `## Implementation Plan` to #2958 and reaffirms the existing 2026-07-02 deferral. **Plan-only / byte-inert** — no source changes.

## Why

A second independent measure-first pass (2026-07-03) reached the same verdict as the prior deferral: this is horizon **M, not S**, and the sequencing gate **still holds** — #2867 (native-Promise carrier, edits `src/codegen/async-scheduler.ts`) is `in-progress`, so implementing now would collide. Rather than force a multi-site WASI-codegen feature late in a tight budget window (risking a stranded half-implementation at budget freeze), this banks the concrete investigation the prior note lacked so the next window executes fast.

## Contents of the banked spec

- **Gating reality**: the native `$Promise` carrier is `ctx.wasi`-gated (not `ctx.standalone`), so the feature targets `--target wasi`; host mode is byte-inert by construction (`host ? -1 : getOrRegisterPromiseType`).
- **Data model**: append `handled: i32` + `unhandledNext: externref` to `$Promise` (safe field append), plus a `__unhandled_head` global.
- **Exact emit sites**: reject-settle push, `.then` already-rejected "handle" mark, a new `__report_unhandled_rejections` fn, and the `_start` wiring point.
- **Print path**: `wasiAllocStringData` + `__wasi_write_string_stderr`; per-reason stringification deferred to #2962.
- **Late-import funcIdx-shift hazard** (#2642) flagged with the resolve-by-name mitigation.
- **Test plan** mapping to AC1/AC2/AC3.

## Recommendation

Keep `status: ready`; re-scope `horizon: s → m` on the eventual claim; implement after #2867 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)