### PR TITLE
fix(#2109): BigInt⇄String loose-equality uses ToNumber, not parseFloat

### DIFF
--- a/plan/issues/2109-bigint-loose-eq-parsefloat.md
+++ b/plan/issues/2109-bigint-loose-eq-parsefloat.md
@@ -1,10 +1,12 @@
 ---
 id: 2109
 title: "BigInt mixed loose-equality uses parseFloat instead of StringToNumber (accepts trailing garbage, rejects 0x forms)"
-status: ready
+status: done
 sprint: Backlog
+assignee: ttraenkler/agent-opus-2109
 created: 2026-06-11
-updated: 2026-06-11
+updated: 2026-07-03
+completed: 2026-07-03
 priority: low
 feasibility: easy
 reasoning_effort: low
@@ -46,3 +48,27 @@ step). Cite §7.2.13 step 6 in the fix.
 
 #2044 slug (BigInt i64 brand decision) is representation, not equality
 semantics; no BigInt loose-eq issue exists. New (analysis program).
+
+## Resolution (2026-07-03)
+
+Fixed in `src/codegen/binary-ops.ts` (BigInt⇄String loose-eq/comparison
+path). The `externref` operand branches called `parseFloat` **only when
+`parseFloat` was already registered in `funcMap`** (i.e. the module used
+`parseFloat` elsewhere); otherwise they already fell through to the
+spec-correct `coerceType(..., "number")` = `__unbox_number` = JS `Number()`
+= §7.1.4 ToNumber. The fix simply **removes the `parseFloat` special-case**
+so BigInt⇄String always uses ToNumber.
+
+- **Byte-inert for modules that don't use `parseFloat`** — they already took
+  the `coerceType(..., "number")` branch, so emitted Wasm is identical.
+- **Corrected for modules that do use `parseFloat`**: `10n == "10abc"` → false
+  (was true), `16n == "0x10"` → true (was false), `10n == "10"` → true,
+  `10n == ""` → false, `parseFloat` itself still works.
+- Note: this keeps the existing f64-based numeric compare (same as the
+  `#295`/`#1827` BigInt⇄Number path). Full §7.2.13 `StringToBigInt` exactness
+  (e.g. `10n == "10.0"` → false, and >2^53 integer strings) is out of scope —
+  the f64 path already trades that for BigInt⇄Number and is unchanged here.
+
+Regression test: `tests/issue-2109.test.ts` (7 cases, incl. the
+`parseFloat`-registered trigger). Not wired into required CI (see #3008);
+test262 conformance is the CI gate.

--- a/src/codegen/binary-ops.ts
+++ b/src/codegen/binary-ops.ts
@@ -1274,9 +1274,10 @@ export function compileBinaryExpression(
 
       // Loose equality and comparisons: convert both operands to f64, then compare
       // For BigInt vs Number: i64 → f64 via f64.convert_i64_s
-      // For BigInt vs String: string → f64 via parseFloat, i64 → f64 (#295)
-      //   Incomparable strings (parseFloat returns NaN) make all comparisons false,
-      //   which matches the JS spec for BigInt vs non-numeric-string.
+      // For BigInt vs String: string → f64 via ToNumber (§7.1.4), i64 → f64
+      //   (#295, #2109). Incomparable strings (ToNumber returns NaN) make all
+      //   comparisons false, matching the JS spec for BigInt vs a
+      //   non-numeric-string.
       const isLooseEq = op === ts.SyntaxKind.EqualsEqualsToken;
       const isLooseNeq = op === ts.SyntaxKind.ExclamationEqualsToken;
       const isComparison =
@@ -1367,13 +1368,14 @@ export function compileBinaryExpression(
         if (leftType.kind === "i64") {
           fctx.body.push({ op: "f64.convert_i64_s" });
         } else if (leftType.kind === "externref") {
-          // String/externref → f64 via parseFloat (NaN for incomparable strings)
-          const pfIdx = ctx.funcMap.get("parseFloat");
-          if (pfIdx !== undefined) {
-            fctx.body.push({ op: "call", funcIdx: pfIdx });
-          } else {
-            coerceType(ctx, fctx, leftType, { kind: "f64" }, "number");
-          }
+          // (#2109) String/externref → f64 via ToNumber (§7.1.4), NOT parseFloat.
+          // parseFloat accepts trailing garbage and rejects the 0x/0o/0b and
+          // empty-string forms, so `"10abc" == 10n` wrongly became true and
+          // `"0x10" == 16n` wrongly became false — but ONLY when the module also
+          // used parseFloat (which registered it in funcMap and took this
+          // branch). ToNumber (`__unbox_number` = JS `Number()`) is spec
+          // StringToNumber: Number("10abc")=NaN, Number("0x10")=16, Number("")=0.
+          coerceType(ctx, fctx, leftType, { kind: "f64" }, "number");
         } else if (leftType.kind === "i32") {
           fctx.body.push({ op: "f64.convert_i32_s" });
         } else if (leftType.kind === "ref" || leftType.kind === "ref_null") {
@@ -1388,13 +1390,14 @@ export function compileBinaryExpression(
         if (rightType.kind === "i64") {
           fctx.body.push({ op: "f64.convert_i64_s" });
         } else if (rightType.kind === "externref") {
-          // String/externref → f64 via parseFloat (NaN for incomparable strings)
-          const pfIdx = ctx.funcMap.get("parseFloat");
-          if (pfIdx !== undefined) {
-            fctx.body.push({ op: "call", funcIdx: pfIdx });
-          } else {
-            coerceType(ctx, fctx, rightType, { kind: "f64" }, "number");
-          }
+          // (#2109) String/externref → f64 via ToNumber (§7.1.4), NOT parseFloat.
+          // parseFloat accepts trailing garbage and rejects the 0x/0o/0b and
+          // empty-string forms, so `10n == "10abc"` wrongly became true and
+          // `16n == "0x10"` wrongly became false — but ONLY when the module also
+          // used parseFloat (which registered it in funcMap and took this
+          // branch). ToNumber (`__unbox_number` = JS `Number()`) is spec
+          // StringToNumber: Number("10abc")=NaN, Number("0x10")=16, Number("")=0.
+          coerceType(ctx, fctx, rightType, { kind: "f64" }, "number");
         } else if (rightType.kind === "i32") {
           fctx.body.push({ op: "f64.convert_i32_s" });
         } else if (rightType.kind === "ref" || rightType.kind === "ref_null") {

--- a/tests/issue-2109.test.ts
+++ b/tests/issue-2109.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports } from "../src/runtime.js";
+
+// #2109 — BigInt mixed loose-equality against a string must use ToNumber
+// (§7.1.4 StringToNumber via `Number()`), NOT `parseFloat`. `parseFloat`
+// accepts trailing garbage and rejects the 0x/0o/0b and empty-string forms:
+//   parseFloat("10abc") === 10   → `10n == "10abc"` wrongly true
+//   parseFloat("0x10")  === 0    → `16n == "0x10"`  wrongly false
+// The bug only surfaced when the module ALSO used `parseFloat` elsewhere,
+// which registered it in `funcMap` so the BigInt⇄String path grabbed it.
+// The `forcePF` export below forces that registration to reproduce it.
+async function run(source: string, fn: string, args: unknown[] = []): Promise<unknown> {
+  const result = await compile(source);
+  if (!result.success) {
+    throw new Error(
+      `Compile failed:\n${result.errors.map((e) => `  L${e.line}: ${e.message}`).join("\n")}\nWAT:\n${result.wat}`,
+    );
+  }
+  const imports = buildImports(result.imports, {}, result.stringPool);
+  const { instance } = await WebAssembly.instantiate(result.binary, imports);
+  (imports as { setExports?: (e: object) => void }).setExports?.(instance.exports as object);
+  return (instance.exports as any)[fn](...args);
+}
+
+const SRC = `
+  // Forces parseFloat into funcMap — the pre-fix trigger for the bug.
+  export function forcePF(t: string): number { return parseFloat(t); }
+  export function eq(s: string): boolean { const x: bigint = 10n; return x == s; }
+  export function eq16(s: string): boolean { const x: bigint = 16n; return x == s; }
+  export function ne(s: string): boolean { const x: bigint = 10n; return x != s; }
+`;
+
+describe("#2109 BigInt ⇄ String loose equality uses ToNumber, not parseFloat", () => {
+  it('rejects trailing garbage: 10n == "10abc" is false', async () => {
+    // A boolean export marshals across the raw wasm ABI as an i32 0/1.
+    expect(await run(SRC, "eq", ["10abc"])).toBe(0);
+  });
+
+  it('accepts hex forms: 16n == "0x10" is true', async () => {
+    expect(await run(SRC, "eq16", ["0x10"])).toBe(1);
+  });
+
+  it('plain integer string: 10n == "10" is true', async () => {
+    expect(await run(SRC, "eq", ["10"])).toBe(1);
+  });
+
+  it('empty string coerces to 0: 10n == "" is false', async () => {
+    // Number("") === 0, so 10n == "" is false (parseFloat("") === NaN would
+    // also give false here, but Number is the spec-correct path).
+    expect(await run(SRC, "eq", [""])).toBe(0);
+  });
+
+  it('decimal string never numerically equals a different integer: 10n == "10.5" is false', async () => {
+    expect(await run(SRC, "eq", ["10.5"])).toBe(0);
+  });
+
+  it('!= mirrors ==: 10n != "10abc" is true', async () => {
+    expect(await run(SRC, "ne", ["10abc"])).toBe(1);
+  });
+
+  it('does not break parseFloat itself: parseFloat("3.5x") === 3.5', async () => {
+    expect(await run(SRC, "forcePF", ["3.5x"])).toBe(3.5);
+  });
+});


### PR DESCRIPTION
## Problem (#2109)

BigInt mixed loose-equality against a string routed the string operand
through `parseFloat` instead of §7.1.4 ToNumber — but **only when the
module also used `parseFloat` elsewhere** (which registered it in
`funcMap`, so the BigInt⇄String path grabbed it). `parseFloat` accepts
trailing garbage and rejects the `0x`/`0o`/`0b` and empty-string forms:

- `10n == "10abc"` wrongly returned **true** (`parseFloat("10abc") === 10`)
- `16n == "0x10"` wrongly returned **false** (`parseFloat("0x10") === 0`)

When `parseFloat` was NOT registered the path already fell through to
`coerceType(..., "number")` = `__unbox_number` = JS `Number()` = ToNumber
(correct), which is why the bug was latent/conditional.

## Fix

Drop the `parseFloat` special-case in both operand branches of the
BigInt⇄String loose-eq/comparison path (`src/codegen/binary-ops.ts`) so it
always uses ToNumber.

- **Byte-inert** for modules that don't use `parseFloat` — they already took
  the `coerceType(..., "number")` branch, so emitted Wasm is identical.
- **Corrected** for modules that do: `10n == "10abc"` → false, `16n == "0x10"`
  → true, `10n == "10"` → true, `10n == ""` → false; `parseFloat` itself still
  works.
- Scope: keeps the existing f64-based numeric compare (same as the
  `#295`/`#1827` BigInt⇄Number path). Full §7.2.13 `StringToBigInt` exactness
  (`10n == "10.0"` → false, >2^53 integer strings) is out of scope and
  unchanged — the f64 path already trades that for BigInt⇄Number.

## Acceptance criteria (from the issue)

- [x] `10n == "10"` true, `10n == "10abc"` false, `16n == "0x10"` true
- [x] Non-BigInt `==` unchanged (byte-inert; parseFloat still works)

## Tests

`tests/issue-2109.test.ts` — 7 cases including the `parseFloat`-registered
trigger. All pass. (Not wired into required CI, see #3008; test262
conformance is the CI gate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)