### PR TITLE
chore(#2974): backoff+jitter for claim-issue race loops + base-ref force-fetch

### DIFF
--- a/plan/issues/2974-claim-issue-allocate-livelock.md
+++ b/plan/issues/2974-claim-issue-allocate-livelock.md
@@ -1,9 +1,11 @@
 ---
 id: 2974
 title: "infra: claim-issue --allocate livelock under multi-session load (6 concurrent allocators observed)"
-status: ready
+status: done
+assignee: ttraenkler/agent-opus-2109
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
+completed: 2026-07-03
 priority: medium
 horizon: s
 feasibility: medium
@@ -11,7 +13,7 @@ reasoning_effort: medium
 task_type: chore
 area: infra
 sprint: Backlog
-related: [2531]
+related: [2531, 2977]
 ---
 
 # #2974 — `claim-issue --allocate` livelock under multi-session load
@@ -66,3 +68,40 @@ Filed from TaskList task #29 (evidence by dev-2856f; filed by dev-evalf).
 Sibling of the promote-baseline push-race issue (same first-push-wins ref
 pattern, being filed by dev-2912f). Related: #2531 (the original atomic
 `--allocate` design).
+
+## Resolution (2026-07-03)
+
+Adopted **direction 1 (backoff + jitter)** — the cheapest fix that turns the
+synchronized herd into a de-facto queue — plus the `refs/claim-issue/base`
+non-fast-forward crash fix that #2977 (the duplicate report) additionally
+flagged. Changes in `scripts/claim-issue.mjs`:
+
+- **`raceBackoffMs(attempt)`** — exponential backoff with full jitter
+  (`random[0, min(4000, 150·2^(attempt-1)) ms]`). Both first-push-wins loops
+  (`--allocate` and claim/release/complete) now sleep this amount after a
+  race-loss re-scan, so concurrent contenders spread out in time instead of
+  re-colliding in lock-step. The wait is skipped after the final attempt;
+  `MAX_RETRIES` still bounds the total.
+- **`fetchAssign` force-fetch** — the local mirror ref is now fetched with a
+  `+`-prefixed refspec, so a diverged `refs/claim-issue/base` overwrites cleanly
+  instead of hard-crashing the script with a non-ff lock error (previously
+  needed a manual `git update-ref -d refs/claim-issue/base`).
+
+Verified: syntax check, read-only `--check`/`--dry-run`, and a live
+release→reclaim round-trip all succeed; atomicity (the #2531 invariants,
+compare-and-swap on the ref sha) is unchanged — only retry timing and the
+mirror-ref fetch mode change.
+
+Acceptance status:
+
+- [x] Bounded retries, no lock-step re-collision (backoff+jitter; `MAX_RETRIES`
+      cap unchanged).
+- [ ] O(entries) `git show` per retry round — **deferred** (direction 5). The
+      backoff already breaks the livelock; the per-file scan cost is a separate,
+      independent optimization left as follow-up so this stays a small, safe
+      change to shared live infra.
+- [x] `--allocate` atomicity guarantees preserved (compare-and-swap unchanged).
+
+**Duplicate:** #2977 is the same report filed independently in the same window;
+it is marked `wont-fix` (dup of #2974). Its extra detail (the
+`refs/claim-issue/base` non-ff crash) is incorporated in this fix.

--- a/plan/issues/2977-claim-issue-allocate-livelock-multi-session.md
+++ b/plan/issues/2977-claim-issue-allocate-livelock-multi-session.md
@@ -1,8 +1,9 @@
 ---
 id: 2977
 title: "infra: claim-issue --allocate livelocks under multi-session load (6 concurrent allocators observed)"
-status: ready
+status: wont-fix
 created: 2026-07-02
+updated: 2026-07-03
 priority: medium
 horizon: s
 feasibility: medium
@@ -11,9 +12,17 @@ task_type: infra
 area: tooling
 language_feature: n/a
 goal: dev-infra
-related: [2531, 2155]
+related: [2531, 2155, 2974]
 depends_on: []
 ---
+
+> **wont-fix — duplicate of #2974 (2026-07-03).** This is the same
+> `claim-issue --allocate` livelock report, filed independently in the same
+> busy window. Resolved under **#2974** (backoff + jitter on the first-push-wins
+> retry loops). The extra detail unique to this report — the stale
+> `refs/claim-issue/base` non-fast-forward crash — was **incorporated** into the
+> #2974 fix (`fetchAssign` now force-fetches the mirror ref). No separate work
+> remains here.
 
 # #2977 — `claim-issue --allocate` livelocks under multi-session load
 

--- a/scripts/claim-issue.mjs
+++ b/scripts/claim-issue.mjs
@@ -171,7 +171,13 @@ function remoteAssignSha() {
 
 function fetchAssign(sha) {
   if (!sha) return; // ref doesn't exist yet
-  git(["fetch", "--quiet", REMOTE, `${ASSIGN_REF}:refs/claim-issue/base`]);
+  // (#2974/#2977) Force-update the local mirror ref (`+` refspec). Without the
+  // `+`, a diverged local `refs/claim-issue/base` (the ref moved on the remote
+  // while we held a stale local copy) makes the fetch fail non-fast-forward
+  // ("cannot lock ref … is at <new> but expected <old>") and hard-crashes the
+  // script — previously requiring a manual `git update-ref -d`. The base ref is
+  // a disposable read mirror, so overwriting it unconditionally is safe.
+  git(["fetch", "--quiet", REMOTE, `+${ASSIGN_REF}:refs/claim-issue/base`]);
 }
 
 function readEntry(baseSha, id) {
@@ -283,6 +289,20 @@ function idsFromAssignRef(sha) {
 //     backstop) — but no longer fail-SILENT.
 function sleepMs(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+// (#2974/#2977) Exponential backoff + full jitter for the first-push-wins
+// retry loops (allocate / claim). Losers previously retried IMMEDIATELY and
+// re-collided, so N concurrent allocators degenerated into a livelock (six
+// observed re-scanning hundreds of ref entries in lock-step). Randomized
+// backoff turns the synchronized herd into a de-facto queue: retry at a random
+// point in [0, base·2^(attempt-1)], capped, so contenders spread out in time
+// and one makes progress each round. Bounded by MAX_RETRIES either way.
+function raceBackoffMs(attempt) {
+  const BASE_MS = 150;
+  const CAP_MS = 4000;
+  const ceil = Math.min(CAP_MS, BASE_MS * 2 ** (attempt - 1));
+  return Math.floor(Math.random() * ceil);
 }
 
 const PR_FILES_QUERY = `query($owner:String!,$name:String!,$cursor:String){
@@ -505,6 +525,9 @@ function doAllocate(assignee) {
       return;
     }
     console.error(`allocate: ref moved (attempt ${attempt}/${MAX_RETRIES}) — re-scanning for a fresh id…`);
+    // (#2974/#2977) Backoff+jitter before re-scanning so concurrent allocators
+    // don't re-collide in lock-step. Skip the wait after the final attempt.
+    if (attempt < MAX_RETRIES) sleepMs(raceBackoffMs(attempt));
   }
   die(5, `Could not reserve a fresh id after ${MAX_RETRIES} attempts (heavy contention). Re-run.`);
 }
@@ -596,6 +619,9 @@ function writeMode(target, assignee, kind) {
       return;
     }
     console.error(`push rejected (attempt ${attempt}/${MAX_RETRIES}) — someone else moved the ref, re-checking…`);
+    // (#2974/#2977) Backoff+jitter before re-checking so concurrent claimants
+    // don't re-collide in lock-step. Skip the wait after the final attempt.
+    if (attempt < MAX_RETRIES) sleepMs(raceBackoffMs(attempt));
   }
   die(5, `Could not acquire the claim ref after ${MAX_RETRIES} attempts. Try again.`);
 }


### PR DESCRIPTION
## Problem (#2974, dup #2977)

`scripts/claim-issue.mjs` reserves/claims ids via first-push-wins on the
`issue-assignments` ref. On a race loss the loser retried **immediately**, so
N concurrent allocators re-collided in lock-step — a livelock (six observed
re-scanning hundreds of ref entries; #2939/#2940/#2941 were renumbered away).
A diverged local `refs/claim-issue/base` also hard-crashed the script with a
non-fast-forward lock error (the #2977 detail), needing a manual
`git update-ref -d`.

## Fix (smallest safe subset — direction 1)

- **`raceBackoffMs(attempt)`** — exponential backoff with full jitter
  (`random[0, min(4000, 150·2^(attempt-1)) ms]`). Both retry loops
  (`--allocate` and claim/release/complete) now sleep this after a race-loss
  re-scan, so contenders spread out in time (herd → de-facto queue). The wait
  is skipped after the final attempt; `MAX_RETRIES` still caps the total.
- **`fetchAssign` force-fetch** — the local mirror ref uses a `+`-prefixed
  refspec, so a diverged `refs/claim-issue/base` overwrites cleanly instead of
  crashing non-ff.

**Atomicity unchanged** — the compare-and-swap on the ref sha (the #2531
invariants) is untouched; only retry timing and the mirror-ref fetch mode
change.

## Validation

- `node --check` passes; read-only `--check` and `--allocate --dry-run` work;
  a live `--release`→re-claim round-trip on a throwaway id pushes cleanly.
- A live 6-way soak against the real `issue-assignments` ref during a busy
  multi-session window would interfere with other agents' live claims, so it
  was deliberately not run; the backoff behavior is bounded by construction.

## Scope / acceptance

- [x] Bounded retries, no lock-step re-collision (backoff+jitter).
- [x] `--allocate` atomicity guarantees preserved.
- [ ] O(entries) `git show` per retry round — **deferred** (direction 5),
      independent follow-up; the backoff already breaks the livelock.

#2977 is marked `wont-fix` (dup of #2974) in this PR; its unique detail (the
base-ref non-ff crash) is incorporated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)