### PR TITLE
fix(#2975): failure-aware auto-enqueue sweep — don't re-add a just-parked PR

### DIFF
--- a/plan/issues/2975-auto-enqueue-park-label-race.md
+++ b/plan/issues/2975-auto-enqueue-park-label-race.md
@@ -1,8 +1,11 @@
 ---
 id: 2975
 title: "auto-enqueue re-adds a just-parked PR before auto-park's hold label lands (~5-16s race) — one doomed merge_group attempt per park"
-status: ready
+status: done
+assignee: ttraenkler/agent-opus-2109
 created: 2026-07-02
+updated: 2026-07-03
+completed: 2026-07-03
 priority: medium
 horizon: s
 feasibility: medium
@@ -55,10 +58,10 @@ PR #2481:
 09:02:42Z removed_from_merge_queue by github-merge-queue[bot]   (doomed attempt fails identically)
 ```
 
-Note #2462's re-add happened 1s *after* the label — the sweep's PR-list
+Note #2462's re-add happened 1s _after_ the label — the sweep's PR-list
 snapshot was taken before the label API write became visible, so even
 label-before-add ordering is not a guarantee: the race is between auto-park's
-label write and auto-enqueue's *read*.
+label write and auto-enqueue's _read_.
 
 ## Fix directions (pick one; (a) is self-contained)
 
@@ -87,3 +90,58 @@ label write and auto-enqueue's *read*.
       re-admissions).
 - [ ] No new re-enqueue loops (single trailing add preserved — #2786
       invariant).
+
+## Resolution (2026-07-03)
+
+Implemented **direction (a) — the race-free failure-aware sweep** — in
+`scripts/enqueue-green-prs.mjs`, plus a regression test
+(`tests/issue-2975-park-race-guard.test.ts`).
+
+**Mechanism.** Once per sweep, `recentMergeGroupFailures()` builds a
+`Map<prNumber, failedAtMs>` of PRs with a **genuine, recent** `merge_group`
+failure by reading the same signal auto-park reads (the failed run, not the
+label):
+
+- Lists `merge_group` runs via the REST API (`gh api
+repos/<repo>/actions/runs?event=merge_group`) — NOT `gh run list
+--event/--status`, whose CLI flags don't exist in gh 2.23; the REST params
+  work across every gh version and let this be validated locally.
+- Parses the PR number from the run's `gh-readonly-queue/main/pr-<N>-<sha>`
+  head branch (`prNumberFromMergeQueueBranch`, mirroring auto-park's
+  `prNumberFromQueueBranch`).
+- Applies auto-park's **real-vs-cancellation** guard: a run-level failure can
+  be a mere cancellation (a re-grouped queue cancels in-flight runs — 0 failed
+  jobs), so it requires **≥ 1 job** with conclusion `failure`
+  (`runHasFailedJob`, via the REST jobs endpoint).
+- Bounds staleness to a 30-min window.
+
+In the per-PR loop, right after the `ENQUEUEABLE` (CLEAN) check, a PR in that
+map is **skipped** unless a `hold` label was removed _after_ the failure
+(`holdLabelRemovedAtMs` reads the PR timeline; `shouldSkipParkingRace` is the
+pure decision) — a later removal is a deliberate re-admission and must be
+honoured.
+
+**Fail-safe by construction.** Every live helper returns the value that makes
+the sweep fall back to **current (enqueue) behavior** on any error
+(`recentMergeGroupFailures` → empty map; `runHasFailedJob` → false;
+`holdLabelRemovedAtMs` → +∞ ⇒ "re-admitted"). So a bug or API hiccup can only
+ever _fail to skip_ (= today's behavior, which auto-park still catches) — it can
+**never** wrongly strand a good PR. This neutralises the blast-radius risk of
+editing the primary enqueuer.
+
+**Validation.** `node --check`; import-purity (no `gh` call on import); the
+three REST queries validated against the real park of **#2517** (branch →
+2517; 1 failed job; timeline hold-removal 08:13:47Z < re-failure 08:22:48Z ⇒
+correctly re-skipped); a full `DRY_RUN=1` sweep runs clean; 7-case unit test
+passes. (Issue tests aren't in required CI — #3008 — but the pure logic is
+covered and the live path is fail-safe.)
+
+Acceptance status:
+
+- [x] A failed PR is not re-added in the pre-label window (guard skips on the
+      failed-run signal, before auto-park's label lands).
+- [x] A human removing `hold` after the failure gets its one re-admission
+      (`shouldSkipParkingRace` returns false when `holdRemovedAtMs >
+    mergeGroupFailedAtMs`).
+- [x] No new re-enqueue loops — the guard only ever ADDS skips; the
+      trailing-add invariant (#2786/#2560) is untouched.

--- a/scripts/enqueue-green-prs.mjs
+++ b/scripts/enqueue-green-prs.mjs
@@ -356,12 +356,139 @@ function rerunClaCheck(prNumber, branch) {
   return { ok: true, why: `reran cla-check run ${runId}` };
 }
 
+// PARK-RACE GUARD (#2975). auto-enqueue (this script, primary enqueuer since
+// #2786, grace 0) and auto-park (#2547) both react to the same failed
+// `merge_group` run. When a PR fails merge_group re-validation GitHub removes it
+// from the queue; auto-park then adds the `hold` label — but ~5-16s later. In
+// that gap this sweep still sees the PR as CLEAN + green + un-`hold`-labelled and
+// re-adds it, wasting one full doomed 57-shard merge_group run (and the re-add
+// can reshuffle/cancel entries behind it). Deriving the park decision from the
+// LABEL loses the race; deriving it from the same FAILED-RUN signal auto-park
+// uses does not (issue direction (a), the "race-free" one).
+//
+// Parse a merge-queue synthetic branch `gh-readonly-queue/<base>/pr-<N>-<sha>`
+// into its PR number (mirrors prNumberFromQueueBranch in
+// auto-park-merge-group-failure.mjs). Returns null for any non-queue branch, so
+// a stray run can never be attributed to a PR. Pure + exported for unit tests.
+export function prNumberFromMergeQueueBranch(branch) {
+  if (typeof branch !== "string") return null;
+  const m = branch.match(/^gh-readonly-queue\/[^/]+\/pr-(\d+)-[0-9a-f]+$/);
+  return m ? Number(m[1]) : null;
+}
+
+// Pure park-race decision. Skip a candidate PR ONLY when it has a genuine recent
+// merge_group failure AND no human removed a `hold` label AFTER that failure
+// (i.e. nobody has deliberately re-admitted it). A later hold-removal means a
+// human/agent intentionally re-admitted the PR, so it must get its one prompt
+// re-admission (acceptance criterion 2). Exported for unit tests.
+export function shouldSkipParkingRace({ mergeGroupFailedAtMs, holdRemovedAtMs } = {}) {
+  if (!mergeGroupFailedAtMs) return false; // no failure signal -> enqueue as usual
+  if (holdRemovedAtMs && holdRemovedAtMs > mergeGroupFailedAtMs) return false; // re-admitted
+  return true; // genuinely failed and not re-admitted -> let auto-park hold it
+}
+
+// FAIL-SAFE by design (#2975): every live helper below returns the value that
+// makes the sweep fall back to CURRENT behavior (enqueue) on ANY error. So a bug
+// or API hiccup here can only ever FAIL TO SKIP (= today's behavior, which
+// auto-park still catches) — it can NEVER wrongly strand a good PR.
+
+// Map<prNumber, failedAtMs> of PRs with a RECENT, GENUINE merge_group failure.
+// "Genuine" mirrors auto-park's real-vs-cancellation guard: a run-level failure
+// can be a mere cancellation (membership change re-groups and cancels in-flight
+// runs — 0 failed jobs), so we require >= 1 job with conclusion "failure".
+function recentMergeGroupFailures({ windowMinutes = 30, maxRuns = 40 } = {}) {
+  const out = new Map();
+  try {
+    const cutoff = Date.now() - windowMinutes * 60 * 1000;
+    // Use the REST API (via `gh api`), NOT `gh run list --event/--status`: those
+    // CLI flags do not exist in gh 2.23 (the container), whereas the REST
+    // `event`/`status` query params work across every gh version — and let this
+    // be validated locally. `--jq` compacts to a single JSON array.
+    const res = ghMaybe([
+      "api",
+      `repos/${REPO}/actions/runs?event=merge_group&per_page=${maxRuns}`,
+      "--jq",
+      '[.workflow_runs[] | select(.conclusion == "failure") | {id: .id, headBranch: .head_branch, updatedAt: .updated_at}]',
+    ]);
+    if (!res.ok) return out; // fail-safe: no failures known -> enqueue as usual
+    let runs;
+    try {
+      runs = JSON.parse(res.stdout);
+    } catch {
+      return out;
+    }
+    if (!Array.isArray(runs)) return out;
+    for (const run of runs) {
+      const whenMs = Date.parse(run.updatedAt);
+      if (!Number.isFinite(whenMs) || whenMs < cutoff) continue; // stale / unparseable
+      const prNumber = prNumberFromMergeQueueBranch(run.headBranch);
+      if (!prNumber) continue;
+      // Keep only the most-recent failure per PR; skip the job probe if we
+      // already recorded a newer one.
+      const existing = out.get(prNumber);
+      if (existing && existing >= whenMs) continue;
+      if (!runHasFailedJob(run.id)) continue; // cancellation, not a real failure
+      out.set(prNumber, whenMs);
+    }
+  } catch {
+    return new Map(); // fail-safe
+  }
+  return out;
+}
+
+// True iff the run has >= 1 job that concluded "failure" (a genuine shard/check
+// failure, not a whole-run cancellation). Uses the REST jobs endpoint (`gh api`)
+// for cross-gh-version stability. Fail-safe: on any error return false so an
+// unreadable run is treated as NOT a genuine failure (enqueue as usual).
+function runHasFailedJob(runId) {
+  try {
+    const res = ghMaybe([
+      "api",
+      `repos/${REPO}/actions/runs/${runId}/jobs`,
+      "--jq",
+      '[.jobs[] | select(.conclusion == "failure")] | length',
+    ]);
+    if (!res.ok) return false;
+    return Number(res.stdout.trim()) > 0;
+  } catch {
+    return false;
+  }
+}
+
+// Timestamp (ms) of the most recent `hold`-label REMOVAL on the PR, or 0 if
+// none. A removal after a merge_group failure means someone deliberately
+// re-admitted the PR (see shouldSkipParkingRace). Fail-safe: on any error return
+// Infinity so the caller treats the PR as "re-admitted" and enqueues as usual
+// (never strands a PR because the timeline read hiccupped).
+function holdLabelRemovedAtMs(prNumber) {
+  try {
+    const res = ghMaybe([
+      "api",
+      "--paginate",
+      `repos/${REPO}/issues/${prNumber}/timeline`,
+      "-q",
+      '[.[] | select(.event == "unlabeled" and .label.name == "hold") | .created_at] | last // empty',
+    ]);
+    if (!res.ok) return Number.POSITIVE_INFINITY; // fail-safe -> treat as re-admitted
+    const ts = res.stdout.trim();
+    if (!ts) return 0; // no hold removal recorded
+    const ms = Date.parse(ts);
+    return Number.isFinite(ms) ? ms : Number.POSITIVE_INFINITY;
+  } catch {
+    return Number.POSITIVE_INFINITY; // fail-safe
+  }
+}
+
 // The live sweep is wrapped in runSweep() and only invoked when this file is
 // run as the main module (see the import.meta.url guard at the bottom). That
 // keeps `import { isTrustedAuthor } from "./enqueue-green-prs.mjs"` side-effect
 // free so the gate can be unit-tested without making any `gh` calls.
 function runSweep() {
   const { queued: inQueue, forming } = mergeQueueSnapshot();
+  // PARK-RACE GUARD (#2975): PRs with a genuine recent merge_group failure that
+  // are being (or should be) parked. Computed ONCE per sweep. Fail-safe: empty
+  // on any error, so the sweep behaves exactly as before.
+  const mergeGroupFailures = recentMergeGroupFailures();
 
   // GUARD 1 — TRAILING-ADD ONLY; never touch the forming head (#2560, was #1758).
   // A merge group mid-formation must not have its membership changed: dequeuing or
@@ -453,6 +580,25 @@ function runSweep() {
     }
     if (!ENQUEUEABLE.has(pr.mergeStateStatus)) {
       skipped.push([pr.number, pr.mergeStateStatus]); // BLOCKED/BEHIND/DIRTY/DRAFT/UNKNOWN
+      continue;
+    }
+    // PARK-RACE GUARD (#2975). A PR that just FAILED merge_group re-validation is
+    // removed from the queue but stays CLEAN + green, so it reaches here in the
+    // ~5-16s before auto-park's `hold` label lands. Re-adding it wastes a full
+    // doomed merge_group run. Skip it when it has a genuine recent merge_group
+    // failure AND nobody removed a `hold` after that failure (a later removal is a
+    // deliberate re-admission — honour it). Only PRs in the (usually empty)
+    // failure map pay the timeline read. Fail-safe: any error above yields no
+    // failure / a re-admit sentinel, so this never wrongly strands a PR.
+    const failedAtMs = mergeGroupFailures.get(pr.number);
+    if (
+      failedAtMs &&
+      shouldSkipParkingRace({ mergeGroupFailedAtMs: failedAtMs, holdRemovedAtMs: holdLabelRemovedAtMs(pr.number) })
+    ) {
+      skipped.push([
+        pr.number,
+        `merge_group-failure — awaiting auto-park hold (failed ${new Date(failedAtMs).toISOString()})`,
+      ]);
       continue;
     }
     // AUTHOR-TRUST GATE (#2549 + #2550 fork allowlist). Fail closed: a PR is

--- a/tests/issue-2975-park-race-guard.test.ts
+++ b/tests/issue-2975-park-race-guard.test.ts
@@ -1,0 +1,66 @@
+// #2975 — auto-enqueue must not re-add a PR in the ~5-16s race window between
+// its merge_group failure and auto-park's `hold` label landing.
+//
+// auto-enqueue (primary enqueuer since #2786, grace 0) and auto-park (#2547)
+// both react to the same failed merge_group run. GitHub removes the failed PR
+// from the queue; auto-park adds `hold` a few seconds later. In that gap the
+// sweep still sees the PR as CLEAN + green + un-`hold`-labelled and re-adds it,
+// wasting a full doomed merge_group run. The park-race guard derives the park
+// decision from the same FAILED-RUN signal auto-park uses (not the label), so it
+// is race-free.
+//
+// These tests pin the two PURE decision helpers directly — they make NO `gh`
+// calls (the live sweep and its gh-api helpers are behind the import.meta.url
+// guard and are not exported). The live helpers are FAIL-SAFE by construction:
+// every one returns the value that makes the sweep fall back to current
+// (enqueue) behavior on any error, so a bug there can only fail-to-skip, never
+// strand a good PR.
+
+import { describe, expect, it } from "vitest";
+import { prNumberFromMergeQueueBranch, shouldSkipParkingRace } from "../scripts/enqueue-green-prs.mjs";
+
+describe("#2975 park-race guard — merge-queue branch parsing", () => {
+  it("parses the PR number from a gh-readonly-queue synthetic branch", () => {
+    expect(prNumberFromMergeQueueBranch("gh-readonly-queue/main/pr-2975-0a1b2c3d4e5f")).toBe(2975);
+  });
+
+  it("parses a non-main base branch too", () => {
+    expect(prNumberFromMergeQueueBranch("gh-readonly-queue/release/pr-12-abcdef0")).toBe(12);
+  });
+
+  it("returns null for a non-queue branch (never attribute a stray run to a PR)", () => {
+    expect(prNumberFromMergeQueueBranch("main")).toBe(null);
+    expect(prNumberFromMergeQueueBranch("issue-2975-failure-aware-enqueue")).toBe(null);
+    expect(prNumberFromMergeQueueBranch("")).toBe(null);
+    // @ts-expect-error — defensive against non-string input
+    expect(prNumberFromMergeQueueBranch(undefined)).toBe(null);
+  });
+});
+
+describe("#2975 park-race guard — skip decision", () => {
+  it("does NOT skip when there is no merge_group failure signal", () => {
+    expect(shouldSkipParkingRace({})).toBe(false);
+    expect(shouldSkipParkingRace({ mergeGroupFailedAtMs: 0 })).toBe(false);
+  });
+
+  it("SKIPS a PR with a genuine failure and no later hold-removal (about to be parked)", () => {
+    expect(shouldSkipParkingRace({ mergeGroupFailedAtMs: 1000 })).toBe(true);
+    // a hold-removal BEFORE the failure does not count as a re-admission
+    expect(shouldSkipParkingRace({ mergeGroupFailedAtMs: 2000, holdRemovedAtMs: 1000 })).toBe(true);
+  });
+
+  it("does NOT skip when a hold was removed AFTER the failure (deliberate re-admission)", () => {
+    // acceptance criterion 2: a human/agent removing `hold` gets exactly one
+    // prompt re-admission — the guard must not dead-lock it.
+    expect(shouldSkipParkingRace({ mergeGroupFailedAtMs: 1000, holdRemovedAtMs: 2000 })).toBe(false);
+  });
+
+  it("real #2517 timeline: re-admitted at 08:13:47Z then re-failed at 08:22:48Z → still skip", () => {
+    // Observed on 2026-07-03: hold removed (re-admitted), the PR re-entered the
+    // queue and FAILED merge_group again — so the latest failure is newer than
+    // the removal and the guard correctly re-skips it (auto-park re-holds it).
+    const holdRemovedAtMs = Date.parse("2026-07-03T08:13:47Z");
+    const mergeGroupFailedAtMs = Date.parse("2026-07-03T08:22:48Z");
+    expect(shouldSkipParkingRace({ mergeGroupFailedAtMs, holdRemovedAtMs })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem (#2975)

`auto-enqueue` (primary enqueuer since #2786, grace 0) and `auto-park` (#2547)
both react to the same failed `merge_group` run. GitHub removes the failed PR
from the queue; auto-park adds the `hold` label **~5-16s later**. In that gap
the sweep still sees the PR as CLEAN + green + un-`hold`-labelled and re-adds
it — wasting a full doomed 57-shard `merge_group` run per park (and the re-add
can reshuffle/cancel entries behind it). Deriving the park decision from the
**label** loses the race.

## Fix — direction (a), the race-free failure-aware sweep

In `scripts/enqueue-green-prs.mjs`, derive the park decision from the same
FAILED-RUN signal auto-park reads, not the label:

- **`recentMergeGroupFailures()`** (once per sweep) builds `Map<pr, failedAtMs>`
  from `gh api repos/<repo>/actions/runs?event=merge_group` — the REST
  `event` param works across gh versions, unlike `gh run list --event/--status`
  which **don't exist in gh 2.23** (so it's also validatable locally). It parses
  `pr-<N>` from the `gh-readonly-queue/main/pr-<N>-<sha>` head branch and applies
  auto-park's **real-vs-cancellation** guard (≥1 genuinely-failed job — a
  cancelled/re-grouped run shows failure with 0 failed jobs). 30-min window.
- In the per-PR loop, right after the `ENQUEUEABLE` (CLEAN) check, a PR in that
  map is **skipped** unless a `hold` was removed *after* the failure (a
  deliberate re-admission — `shouldSkipParkingRace` + `holdLabelRemovedAtMs`).

## Fail-safe by construction (neutralises the blast-radius risk)

Every live helper returns the value that makes the sweep fall back to **current
(enqueue) behavior** on any error (`recentMergeGroupFailures` → empty map;
`runHasFailedJob` → false; `holdLabelRemovedAtMs` → +∞ ⇒ "re-admitted"). So a
bug or API hiccup can only ever *fail to skip* (= today's behavior, which
auto-park still catches) — it can **never** wrongly strand a good PR.

## Validation

- Validated against the real park of **#2517**: branch → 2517; the run has 1
  genuinely-failed job; timeline hold-removal `08:13:47Z` < re-failure
  `08:22:48Z` ⇒ correctly re-skipped.
- `node --check`; import-purity (no `gh` call on import); `DRY_RUN=1` full sweep
  runs clean with no regression.
- Unit test `tests/issue-2975-park-race-guard.test.ts` (7 cases — branch
  parsing + skip decision incl. the #2517 scenario).

## Acceptance

- [x] Failed PR not re-added in the pre-label window.
- [x] Human removing `hold` after the failure still gets its one re-admission.
- [x] No new re-enqueue loops — the guard only ADDS skips; the trailing-add
      invariant (#2786/#2560) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)