### PR TITLE
docs(#2847): re-scope acorn marshalling quirks — codegen brand-preservation, not host marshalling

### DIFF
--- a/plan/issues/2847-acorn-cosmetic-marshalling-quirks.md
+++ b/plan/issues/2847-acorn-cosmetic-marshalling-quirks.md
@@ -4,8 +4,9 @@ title: "compiled-acorn cosmetic marshalling quirks — spurious `sourceFile: nul
 status: ready
 sprint: current
 priority: low
-horizon: s
+horizon: m
 feasibility: medium
+updated: 2026-07-03
 created: 2026-06-29
 task_type: bugfix
 area: runtime
@@ -66,3 +67,81 @@ because they break parsing.
   unset.
 - `tests/dogfood/acorn-corpus.mjs` reports `quirkCounts` ≈ 0 across the corpus.
 - No test262 regression.
+
+## Investigation (2026-07-03, dev-team-a) — sizing correction + root causes
+
+Measured against current `upstream/main` (e29c8c5b2) with the corpus harness
+(`ACORN_CORPUS_NO_ACORN_SELF=1 npx tsx tests/dogfood/acorn-corpus.mjs --json`).
+**Correction: this is NOT a host-marshalling fix, and NOT horizon-`s`.** The
+original "fix in host marshalling — a field-name allowlist or typed `bool`
+marker in the export signatures" framing is wrong for both quirks; the marshaller
+already does the right thing when it has the information, and it fundamentally
+cannot for the rest.
+
+### Current state (verified)
+
+| quirk               | count | notes                                    |
+| ------------------- | ----- | ---------------------------------------- |
+| `quirk-sourceFile`  | 2298  | dominant                                 |
+| `quirk-bool-as-i32` | 467   | fields: `async await computed delegate generator optional` |
+
+Corpus is `equal-modulo-quirks` on 21/22 inputs, **0 real divergences** — so any
+fix must drive quirks down without introducing real divergences.
+
+### Quirk B (bool-as-i32) is a CODEGEN brand-preservation gap, NOT a marshalling gap
+
+The `__box_boolean` path (#1788) already boxes a **boolean-branded** i32 struct
+field (`{kind:"i32", boolean:true}`) as a JS boolean on the host read — verified
+directly: both a TS-typed `boolean` field AND a simple untyped-JS
+(`skipSemanticDiagnostics`) `this.computed = false` / `this.optional = false`
+constructor marshal back as real JS booleans (`typeof === "boolean"`). So the
+runtime marshalling layer is NOT where this bites.
+
+The 6 acorn fields degrade because their boolean **brand is lost during
+struct-field-type computation** across acorn's many untyped assignment sites —
+these fields are assigned via boolean-returning method calls
+(`node.generator = this.eat(types.star)`, `node.delegate = this.eat(...)`,
+`node.await = …`) whose return type is inferred as plain `f64`/`i32`-number, not
+boolean-branded, in the untyped `.mjs`. When a field is assigned by a mix of
+boolean literals and unbranded method-call results, the merged field type drops
+`boolean:true`, and the getter emits raw-i32/`__box_number` instead of
+`__box_boolean` (getter emission at `src/codegen/index.ts:_emitStructFieldGettersInner`
+— the `hasBool` fork keys off `(fieldType as {boolean?:true}).boolean`).
+
+- **Real fix location**: `src/codegen` struct-field-type inference /
+  brand-preservation (and/or branding boolean-returning method returns), NOT
+  `src/runtime.ts`. A field-name allowlist or `sourceFile`/`bool` special-case
+  in the generic marshaller would regress real user programs (a legit struct
+  field named `computed`/`sourceFile`, or a genuine 0/1-valued field) and
+  violates the no-bespoke-builtins principle.
+- **Blast radius**: branding changes flow into `typeof`/boxing across the whole
+  test262 surface (exactly what #1788 had to be careful about) — must validate
+  IN BATCH. Not locally verifiable by a dev agent.
+
+### Quirk A (sourceFile) has no clean runtime signal — needs per-instance presence tracking
+
+acorn's `Node` constructor assigns `sourceFile` (and `loc`, `range`) **only
+conditionally** (`if (parser.options.directSourceFile) this.sourceFile = …`,
+acorn.mjs Node ctor). With the option off, node-acorn never creates the property;
+compiled WasmGC has a **fixed struct shape**, so the `sourceFile` slot always
+exists and defaults to `null`. (`loc`/`range` are the same class but the differ's
+`ignorePositions` hides them.)
+
+At marshalling time a never-assigned ref field (`null`) is **indistinguishable**
+from a legitimately assigned-`null` field (`FunctionExpression.id = null`,
+`SwitchCase.test = null`) — both are `null` struct slots, and node-acorn *keeps*
+the latter (verified: 0 real divergences, so those null fields agree). So there
+is **no runtime signal** that lets the generic marshaller
+(`_structToPlainObject` in `src/runtime.ts`) omit `sourceFile` while keeping
+`id`/`test`. A correct general fix needs a **per-instance field-presence bitmap**
+for conditionally-assigned fields (a real feature, not a one-liner) — or the
+quirk is accepted as cosmetic per this issue's own "why low priority" section.
+
+### Sizing verdict
+
+Re-size from `horizon: s` → at least `m`, split into two independent codegen
+tracks: (B) struct-field boolean brand-preservation (validate IN BATCH), and
+(A) per-instance presence tracking for conditionally-assigned fields (larger;
+arguably not worth it for a cosmetic dogfood quirk). Neither is a bounded,
+locally-test262-validatable slice; the marshalling-layer framing was the
+mis-scope. Banked so the next attempt starts from the mechanism.


### PR DESCRIPTION
Docs-only re-scope of #2847 (compiled-acorn cosmetic marshalling quirks), banked from a grounded measurement pass on `upstream/main` e29c8c5b2. No source/test changes.

## What this corrects

The issue framed both quirks as **host-marshalling** fixes ("a field-name allowlist, or a typed `bool` marker in the export signatures"). Measuring the actual mechanism shows that framing is wrong for both, and the task is not horizon-`s`:

**Quirk B (bool-as-i32, 467 occ; fields `async await computed delegate generator optional`)** is a **codegen brand-preservation** gap, not a marshalling gap. The `__box_boolean` path (#1788) already boxes a boolean-**branded** i32 struct field as a JS boolean — verified directly for a typed `boolean` field AND a simple untyped-JS (`skipSemanticDiagnostics`) constructor; both marshal back as real `typeof === "boolean"`. The acorn fields fail because their boolean brand degrades during struct-field-type computation across acorn's untyped assignment sites (`node.generator = this.eat(...)` whose return infers as `f64`/`i32`-number). A runtime field-name allowlist would regress real user programs and violates no-bespoke-builtins.

**Quirk A (sourceFile, 2298 occ)** has **no clean runtime signal**. `sourceFile`/`loc`/`range` are conditionally assigned in acorn's `Node` ctor; WasmGC's fixed struct shape can't distinguish a never-assigned null slot from a legitimately assigned-null field (`FunctionExpression.id = null`, `SwitchCase.test = null`, which node-acorn keeps — verified via 0 real divergences). Needs per-instance field-presence tracking (a real feature).

## Verified state

Corpus: `equal-modulo-quirks` on 21/22 inputs, **0 real divergences**. quirk-sourceFile 2298, quirk-bool-as-i32 467.

Re-sizes `horizon: s` → `m` and splits into two independent codegen tracks so the next attempt starts from the mechanism, not the mis-scoped marshalling framing. Issue stays `status: ready` (not implemented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)