### PR TITLE
refactor(#2955): de-polymorph IR string→externref coercion at lower time (slice 1)

### DIFF
--- a/plan/issues/2955-ir-string-ops-depolymorph.md
+++ b/plan/issues/2955-ir-string-ops-depolymorph.md
@@ -4,7 +4,8 @@ title: "De-polymorph the IR front-end on string mode: abstract IR string ops res
 status: ready
 sprint: current
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
+assignee: ttraenkler/agent-a4461
 priority: medium
 horizon: m
 feasibility: medium
@@ -50,3 +51,51 @@ be implemented twice at IR-build time.
   modes; per-mode lowered bytes identical to before.
 - Equivalence suite green in both modes; string-heavy test262 sample
   net-zero.
+
+## Implementation analysis + Slice 1 (2026-07-03, dev)
+
+Measured against `origin/main` @ e29c8c5b2. The five `nativeStrings` reads in
+`from-ast.ts` are **not one uniform "5 abstract string ops" set** (the Approach
+section's op list — `IrInstrStrConcat`/`StrCompare`/… — does not match these
+sites; those ops are already abstract elsewhere). Each read is a *different
+kind* of polymorphism, with a different byte-inert path to lower time:
+
+| site | function | polymorphism kind | de-polymorph blocker |
+| ---- | -------- | ----------------- | -------------------- |
+| ~2792 | `coerceToExpectedExtern` | string→externref host-call arg coercion; **native throws (demote)** | native string CANNOT flow into a host-string externref position, so the throw is a **claim/demote decision** — must move to `select.ts` capability (#2135), not lower time. Not byte-inert as a plain "always coerce". |
+| ~2912 | number `.toString()` host import | claims `f64.toString()` **only in host mode** | native has no native number formatter yet; the mode read is a real capability gate. Needs native number-format feature before it can move. |
+| ~3142 | `lowerStringMethodCall` | helper name `__str_X` vs `string_X` + i32/f64 arg reps + native-mode bails + sentinel padding | large mode-specific decision table; a faithful move relocates the whole table (incl. #2002/#1248 special-cases) to `lower.ts`. Own slice. |
+| **3467** | **`coerceYieldValueToExternref`** | **string→externref coercion for generator-yield / iter-host** | **NONE — cleanly byte-inert. DONE in Slice 1.** |
+| ~3603 | `lowerForOfStatement` string arm | native char-loop vs iter-host for-of strategy | both strategies are big loop builders living in from-ast; moving the *selection* to lower time means the lowerer owns both loop builders. Own slice. |
+
+### Slice 1 (landed by this PR) — the coercion-elision site (3467)
+
+The `coerce.to_externref` op unconditionally emitted `extern.convert_any`,
+which is **invalid over an already-externref operand** (externref is not an
+anyref subtype). That is exactly why from-ast guarded the coercion sites with
+`!nativeStrings` — to avoid emitting the convert over a host-mode string
+(externref). Fix: move the "is the operand already externref?" decision to
+**lower time** (`lower.ts` `coerce.to_externref` case), resolving it via
+`resolveString()`/the operand valtype — precisely where the issue wants mode
+resolved. `from-ast.ts:coerceYieldValueToExternref` now emits the abstract
+coerce **unconditionally** (one `nativeStrings` read removed); the lowerer
+elides the convert in host mode and emits it in native mode.
+
+- **Byte-inert proof**: identical compiled binaries (sha256) in BOTH modes
+  before/after, over the IR string-iteration + generator-for-of corpus.
+  Elision is dead for existing callers (from-ast guarded every site), so no
+  other `coerce.to_externref` site changes.
+- **Validation**: `issue-1374-ir-string-iter-inline`, `issue-1665-standalone-
+  generator-forof` (native-strings `(ref $AnyString)`→convert_any path),
+  `ir-frontend-widening`, `issue-1470-string-iteration-standalone`,
+  `issue-2157`/`2162` iterators — 63 tests green.
+
+### Remaining (slices 2–5)
+
+Sites 2792 / 2912 / 3142 / 3603 each need their own slice with real work
+beyond a mechanical move (capability-model integration for the demote/claim
+sites; native number-format + native string-method feature reach; relocating
+the method-dispatch table and the for-of strategy builders). This is why the
+issue as a whole is `reasoning_effort: high`, not a uniform refactor. `status`
+stays `ready` — Slice 1 removes one of the five reads and establishes the
+lower-time-resolution pattern the rest follow.

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -3459,14 +3459,15 @@ function coerceYieldValueToExternref(value: IrValueId, cx: LowerCtx): IrValueId 
   if (t.kind === "val" && t.val.kind === "externref") {
     return value;
   }
-  // Host-strings mode: `IrType.string` flows as externref through Wasm.
-  // Skip the coerce so we don't emit a validation-rejected
-  // `extern.convert_any` over a global.get of externref-typed string
-  // global. Resolver presence follows the #1185 pattern (see
-  // `LowerCtx.resolver` doc) — when absent, treat as host-strings.
-  if (t.kind === "string" && !cx.resolver?.nativeStrings?.()) {
-    return value;
-  }
+  // #2955 — de-polymorph on string mode. A string operand IS externref in
+  // host-strings mode and `(ref $AnyString)` (an anyref subtype needing
+  // `extern.convert_any`) in native-strings mode. That per-mode decision no
+  // longer branches here in the front-end: emit the abstract
+  // `coerce.to_externref` unconditionally and let the lowerer resolve the
+  // mode (host → the convert is elided because the value is already
+  // externref; native → `extern.convert_any`). The lowered bytes stay
+  // byte-identical to the previous `!nativeStrings` guard in both modes,
+  // and the produced IR is now identical across string modes.
   return cx.builder.emitCoerceToExternref(value);
 }
 

--- a/src/ir/lower.ts
+++ b/src/ir/lower.ts
@@ -1693,13 +1693,30 @@ export function lowerIrFunctionBody<S>(
       }
       // Slice 6 part 3 (#1182) — coercion + iterator protocol ops.
       case "coerce.to_externref": {
-        // Push the value, then convert any (ref) → externref. If the
-        // input is already externref, the convert is a wasm validation
-        // no-op (it's permitted on already-externref values). For all
-        // ref-typed inputs the wasm engine simply re-tags the reference
-        // so it can flow into externref-typed positions.
+        // Push the value, then re-tag an anyref subtype → externref.
+        //
+        // #2955 — whether the operand is ALREADY externref is a string-mode
+        // decision that belongs HERE, at lower time, not in the from-ast
+        // front-end. `extern.convert_any` maps an anyref subtype into
+        // externref, but it is INVALID over an operand whose Wasm valtype is
+        // already externref (externref is not itself an anyref subtype). In
+        // host-strings mode `IrType.string` lowers to externref, so the
+        // convert must be ELIDED; in native-strings mode it lowers to
+        // `(ref $AnyString)` (an anyref subtype) and the convert is REQUIRED.
+        // An operand already typed `(val) externref` is likewise a no-op.
+        // Emitting the convert over an already-externref operand is dead
+        // today (from-ast guards every site), so this elision is byte-inert
+        // for existing callers while letting from-ast drop those guards and
+        // emit `coerce.to_externref` mode-agnostically (identical IR in both
+        // string modes; per-mode lowered bytes unchanged).
         emitValue(instr.value, out);
-        emitter.pushRaw(out, { op: "extern.convert_any" });
+        const opTy = typeOf(instr.value);
+        const alreadyExternref =
+          (opTy.kind === "val" && opTy.val.kind === "externref") ||
+          (opTy.kind === "string" && resolver.resolveString?.()?.kind === "externref");
+        if (!alreadyExternref) {
+          emitter.pushRaw(out, { op: "extern.convert_any" });
+        }
         return;
       }
       case "iter.new": {


### PR DESCRIPTION
## #2955 slice 1 — move the string→externref coercion decision to lower time

The `coerce.to_externref` op unconditionally emitted `extern.convert_any`,
which is **invalid over an already-externref operand** (externref is not an
anyref subtype). That is exactly why `from-ast.ts` guarded the string→externref
coercion sites with `!nativeStrings` — a **front-end** string-mode read that
#2955 wants gone.

This slice moves that decision to **lower time** (`lower.ts` `coerce.to_externref`
case), where string mode is meant to resolve: it resolves the operand's valtype
via `resolveString()` and elides the convert when the operand is already
externref (host-mode string, or `(val) externref`), emitting `extern.convert_any`
only for anyref subtypes (native-mode `(ref $AnyString)`, object/class/ref).
`coerceYieldValueToExternref` (generator-yield / iter-host) then emits the
abstract coerce **unconditionally** — one `nativeStrings` read removed from
`from-ast.ts`.

### Byte-inert
The convert-elision is **dead for existing callers** (from-ast guarded every
`coerce.to_externref` site), so no other site changes. Verified: **identical
sha256 compiled binaries in BOTH string modes** before/after, over the IR
string-iteration + generator-for-of corpus.

### Validation
`issue-1374-ir-string-iter-inline`, `issue-1665-standalone-generator-forof`
(native-strings `(ref $AnyString)` → `extern.convert_any` path),
`ir-frontend-widening`, `issue-1470-string-iteration-standalone`,
`issue-2157`/`issue-2162` iterators — **63 tests green**. `tsc` + prettier clean.

### Scope
Slice 1 of 5. The other four `nativeStrings` reads (`coerceToExpectedExtern`,
number `.toString()`, `lowerStringMethodCall`, for-of string arm) are **not**
mechanical moves — they carry claim/demote decisions or need native-feature
reach — analysis recorded in the issue file. `status` stays `ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)