### PR TITLE
feat(#2959): native new Promise(executor) — retire the Promise_new host import

### DIFF
--- a/plan/issues/2959-standalone-native-promise-executor.md
+++ b/plan/issues/2959-standalone-native-promise-executor.md
@@ -1,7 +1,9 @@
 ---
 id: 2959
 title: "Standalone: native `new Promise(executor)` — retire the unconditional Promise_new host import"
-status: ready
+status: done
+assignee: sendev-promise-exec2
+completed: 2026-07-03
 sprint: current
 created: 2026-07-02
 updated: 2026-07-03
@@ -262,3 +264,68 @@ reasons:
 This spec PR carries only the enrichment; the fork code branch
 `issue-2959-native-promise-executor` has no salvageable code and can be
 recreated from `origin/main`.
+
+## Implementation (done, 2026-07-03, sendev-promise-exec2)
+
+Shipped as `src/codegen/promise-executor.ts` (new module) +
+`emitStandalonePromiseFromExecutor` wired into the `new Promise` block of
+`src/codegen/expressions/new-super.ts`, gated on `isStandalonePromiseActive`.
+
+### Key ABI discovery (why the banked "subtype the wrapper" plan is correct — and *why* it works)
+
+I re-verified the executor's resolve/reject dispatch against **true WASI mode**
+before implementing (the banked plan reasoned about it but hadn't traced the
+lowering). Findings that shaped the code:
+
+1. **The executor's `resolve`/`reject` params are BOTH `externref`.** A
+   Promise-executor `resolve` is always `(value: T | PromiseLike<T>) => void`
+   and `reject` is `(reason?: any) => void`; both value params resolve to
+   `externref` for *every* `T`. So the canonical `(externref) -> ()` func-ref
+   wrapper is the universal signature — no per-`T` variance. This is why the
+   settle closures can be a single `$__promise_settle_cap` subtype of that one
+   wrapper.
+
+2. **In WASI mode the executor's `resolve(x)` call has NO host fallback.** The
+   host `__call_function` reflective arm is gated `!ctx.standalone && !ctx.wasi`
+   (calls.ts). Under WASI, `resolve(x)` lowers to: `any.convert_extern;
+   ref.test (ref $wrap)` → **native** `struct.get 0 -> ref.cast $wrapFuncType ->
+   call_ref`, **else throw TypeError**. So a `resolve`/`reject` value that IS a
+   subtype of the canonical `(externref)->()` wrapper dispatches natively; the
+   only remaining host import in the whole executor program was `Promise_new`
+   itself. Constructing the settle closures as that subtype removes it → **zero
+   `env` imports** (verified: gc sha256 byte-identical, wasi env `[]`).
+
+3. **The `sub final` on the wrapper is a non-issue.** `markLeafStructsFinal`
+   marks a struct `final` only when *nothing* subtypes it — and it is *skipped
+   entirely* for standalone/WASI (`skipFinal`). Adding `$__promise_settle_cap`
+   as a subtype also un-finalises the wrapper in gc mode. So the capturing
+   subtype is legal.
+
+4. **The trampoline func type must be EXACTLY the wrapper's lifted type**
+   (`getOrCreateFuncRefWrapperTypes(...).liftedFuncTypeIdx`), so the executor's
+   `ref.cast (ref $wrapFuncType); call_ref` at the call site succeeds. The
+   trampoline body downcasts its `(ref null $wrap)` self param to the `cap`
+   subtype to recover the captured `$Promise` — the same self-param-downcast
+   trick the existing capturing-closure and `.then`-wrapper machinery use.
+
+### Correctness proofs (all host-free, env imports `[]`)
+
+- resolve-sync → `.then` sees `7`; reject → `.catch` sees `9`;
+  **executor-throw → `.catch` sees `42`** (inject-throw execution proof: a
+  vacuous native path would leave the observer at `-1`); double-settle →
+  first-settle-wins (`3`); resolve-with-a-promise → assimilates inner value
+  (`11`). All GC binaries `WebAssembly.validate` + instantiate + run `_start`
+  without trapping. Host (gc) mode sha256 byte-identical to `main`.
+
+### Scope / conservatism
+
+- Native path is narrow-gated to **inline arrow / (non-async, non-generator)
+  function-expression** executors whose `ClosureInfo` is recoverable. Anything
+  else (identifier-bound, non-resolvable) emits **nothing** and falls through to
+  the existing `Promise_new` host path — never a partial native path. Widening
+  to identifier-bound closures is a future increment.
+- `Promise_new` intentionally **left on the strict-gate allowlist**: removing it
+  would turn the host-fallback edge cases into hard compile errors under WASI (a
+  regression). The native path simply stops emitting it for the common case.
+- Gate stays WASI-only (couples to #2867 slice-1d; the −601 lesson — do not
+  pre-widen to all-standalone).

--- a/src/codegen/async-scheduler.ts
+++ b/src/codegen/async-scheduler.ts
@@ -747,7 +747,7 @@ function buildDrainBody(state: AsyncSchedulerState, funcArrIdx: number, argsArrI
   ];
 }
 
-function ensurePromiseSettleFunctions(ctx: CodegenContext): void {
+export function ensurePromiseSettleFunctions(ctx: CodegenContext): void {
   ensureMicrotaskQueue(ctx);
   const state = getOrInitState(ctx as CodegenContextWithScheduler);
   if (state.promiseFulfillFuncIdx !== -1) return;

--- a/src/codegen/expressions/new-super.ts
+++ b/src/codegen/expressions/new-super.ts
@@ -77,6 +77,7 @@ import {
 import { localGlobalIdx } from "../registry/imports.js";
 import { ensureLateImport, flushLateImportShifts } from "./late-imports.js";
 import { emitFnctorProtoGet } from "./fnctor-prototype.js"; // (#2660 S3a) reconstruct `new F()` as $Object
+import { emitStandalonePromiseFromExecutor } from "../promise-executor.js"; // (#2959) native new Promise(executor)
 import { deriveFnctorFields, resolveFnctorSymbol, resolveEnclosingFnctorOwner } from "../fnctor-escape-gate.js"; // (#2660 S3a) canonical fnctor-name key; (#2773 S1) shared field derivation; (#2681/#2686 A1) `new this()` owner
 import { funcSignatureOf } from "../func-space.js"; // (#1916 S2) positional-read chokepoint
 
@@ -2761,8 +2762,24 @@ function compileNewExpression(ctx: CodegenContext, fctx: FunctionContext, expr: 
     }
   }
 
-  // Handle `new Promise(executor)` — delegate to host import
+  // Handle `new Promise(executor)`.
   if (ts.isIdentifier(expr.expression) && expr.expression.text === "Promise") {
+    // (#2959) Native standalone/WASI path — construct the `$Promise` and run the
+    // executor with synthesised native resolve/reject closures, retiring the
+    // `Promise_new` host import. Gated inside the helper on
+    // `isStandalonePromiseActive` + a resolvable executor closure; when it can't
+    // apply it emits NOTHING and returns false, falling through to the host path
+    // below (byte-unchanged in host/gc mode). Guard the ambient-global binding so
+    // a user `class Promise {}` / local shadow keeps the normal ctor path.
+    const promiseArgs = expr.arguments ?? [];
+    if (
+      promiseArgs.length >= 1 &&
+      !ctx.classSet.has("Promise") &&
+      resolvesToAmbientGlobal(ctx, expr.expression) &&
+      emitStandalonePromiseFromExecutor(ctx, fctx, promiseArgs[0]!)
+    ) {
+      return { kind: "externref" };
+    }
     let funcIdx =
       ctx.funcMap.get("Promise_new") ??
       ensureLateImport(ctx, "Promise_new", [{ kind: "externref" }], [{ kind: "externref" }]);

--- a/src/codegen/promise-executor.ts
+++ b/src/codegen/promise-executor.ts
@@ -1,0 +1,316 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2959 — native `new Promise(executor)` for standalone / WASI mode.
+//
+// Retires the unconditional `Promise_new` host import for the executor
+// pattern. In standalone/WASI mode the whole Promise carrier is already
+// native ($Promise struct, __promise_resolve_value assimilation,
+// __promise_reject, microtask ring, native .then/.catch). The ONE remaining
+// host leak was `new Promise((resolve, reject) => …)`, which always lowered
+// to `call Promise_new`.
+//
+// This module synthesises the two capturing settle closures (`resolve` /
+// `reject`) as WasmGC values the compiled executor body can invoke through
+// its normal native `call_ref` dispatch, runs the executor synchronously
+// (spec: the executor runs before `new Promise` returns), and rejects on an
+// executor throw-before-settle.
+//
+// ABI (verified against current main, 2026-07-03):
+//   - The executor arrow's `resolve` / `reject` parameters are BOTH externref
+//     (a Promise-executor `resolve`/`reject` is always `(value) => void`, i.e.
+//     the canonical `(externref) -> ()` closure signature — the `value` param
+//     is `T | PromiseLike<T>` / `any`, which always resolves to externref).
+//   - Inside the executor body a call `resolve(x)` lowers (in WASI mode) to:
+//       any.convert_extern; ref.test (ref $wrap); [native] struct.get 0 ->
+//       ref.cast $wrapFuncType -> call_ref ; [else] throw TypeError.
+//     There is NO host `__call_function` fallback under WASI (that arm is
+//     gated `!ctx.standalone && !ctx.wasi`). So a `resolve`/`reject` value
+//     that IS a subtype of the canonical `(externref) -> ()` wrapper struct
+//     dispatches natively; anything else throws. We therefore construct the
+//     settle closures as subtypes of exactly that canonical wrapper struct,
+//     with one extra immutable field carrying the captured `$Promise`.
+
+import type { Instr, ValType } from "../ir/types.js";
+import { ts } from "../ts-api.js";
+import { compileArrowAsClosure, getOrCreateFuncRefWrapperTypes } from "./closures.js";
+import { allocLocal } from "./context/locals.js";
+import type { ClosureInfo, CodegenContext, FunctionContext } from "./context/types.js";
+import { mintDefinedFunc, pushDefinedFunc } from "./func-space.js";
+import { ensureExnTag } from "./registry/imports.js";
+import { coerceType, emitGuardedFuncRefCast, pushDefaultValue } from "./type-coercion.js";
+import { emitNullCheckThrow } from "./property-access.js";
+import {
+  PROMISE_STATE_PENDING,
+  ensurePromiseSettleFunctions,
+  getOrRegisterPromiseType,
+  isStandalonePromiseActive,
+} from "./async-scheduler.js";
+
+/**
+ * Per-module cache of the two synthesised settle-closure funcs + the capturing
+ * wrapper struct type. Minted once and reused for every `new Promise` in the
+ * module, so the module carries a single `__promise_resolve_cl` /
+ * `__promise_reject_cl` pair regardless of executor count.
+ */
+interface PromiseExecutorClosures {
+  /** `__promise_resolve_cl` funcIdx — settles the captured promise via resolve-value (assimilating). */
+  resolveClFuncIdx: number;
+  /** `__promise_reject_cl` funcIdx — settles the captured promise via reject. */
+  rejectClFuncIdx: number;
+  /** The `$__promise_settle_cap` struct typeIdx (subtype of the canonical `(externref)->()` wrapper). */
+  capTypeIdx: number;
+  /** `$Promise` struct typeIdx. */
+  promiseTypeIdx: number;
+  /** `__promise_reject(promise, reason) -> reason` funcIdx (used by the executor-throw catch). */
+  rejectFuncIdx: number;
+}
+
+/**
+ * Idempotently mint the two capturing settle-closure trampolines and register
+ * the `$__promise_settle_cap` wrapper subtype. Cached on the context.
+ *
+ * `$__promise_settle_cap` is a struct subtype of the canonical `(externref)->()`
+ * func-ref wrapper (`getOrCreateFuncRefWrapperTypes(ctx,[externref],[])`), so a
+ * value of this type passes the executor's `ref.test (ref $wrap)` and dispatches
+ * natively. It inherits field 0 (`func: funcref`) and adds field 1
+ * (`cap_promise: (ref $Promise)`).
+ *
+ * Each trampoline has EXACTLY the canonical lifted func type
+ * (`(ref null $wrap, externref) -> ()`) so the executor's
+ * `ref.cast (ref $wrapFuncType); call_ref` at the resolve/reject call site
+ * succeeds; the body downcasts self to the `cap` subtype to recover the promise.
+ */
+function ensurePromiseExecutorClosures(ctx: CodegenContext): PromiseExecutorClosures | null {
+  const cache = ctx as unknown as { __promiseExecutorClosures?: PromiseExecutorClosures };
+  if (cache.__promiseExecutorClosures) return cache.__promiseExecutorClosures;
+
+  ensurePromiseSettleFunctions(ctx);
+  const resolveValueFuncIdx = ctx.funcMap.get("__promise_resolve_value");
+  const rejectFuncIdx = ctx.funcMap.get("__promise_reject");
+  if (resolveValueFuncIdx === undefined || rejectFuncIdx === undefined) return null;
+
+  const promiseTypeIdx = getOrRegisterPromiseType(ctx);
+
+  // Canonical `(externref) -> ()` wrapper — the SAME struct the executor body
+  // ref.tests / ref.casts `resolve`/`reject` against (shared via the signature
+  // cache). Our cap struct subtypes it so the native dispatch matches.
+  const wrapper = getOrCreateFuncRefWrapperTypes(ctx, [{ kind: "externref" }], []);
+  if (!wrapper) return null;
+
+  const capTypeIdx = ctx.mod.types.length;
+  ctx.mod.types.push({
+    kind: "struct",
+    name: "$__promise_settle_cap",
+    fields: [
+      // Field 0 is inherited from the wrapper root (funcref); it MUST be
+      // redeclared identically in the subtype.
+      { name: "func", type: { kind: "funcref" }, mutable: false },
+      { name: "cap_promise", type: { kind: "ref", typeIdx: promiseTypeIdx }, mutable: false },
+    ],
+    superTypeIdx: wrapper.structTypeIdx,
+  });
+
+  // Mint both trampolines UP-FRONT (stable-regime handles) before any code
+  // references them, mirroring ensurePromiseSettleFunctions' discipline.
+  const resolveClFuncIdx = mintDefinedFunc(ctx);
+  const rejectClFuncIdx = mintDefinedFunc(ctx);
+
+  // Body: recover captured promise from self (downcast to the cap subtype),
+  // then settle it with the incoming value. resolve routes through
+  // __promise_resolve_value (assimilation: resolve(aPromise) chains); reject
+  // routes through __promise_reject. The already-settled guard lives in the
+  // settle helpers (buildPromiseSettleBody), so double-settle / settle-after-
+  // throw is a spec-correct no-op by construction.
+  const makeBody = (settleFuncIdx: number): Instr[] => [
+    { op: "local.get", index: 0 }, // self: (ref null $wrap)
+    { op: "ref.cast", typeIdx: capTypeIdx }, // downcast to the cap subtype (non-null)
+    { op: "struct.get", typeIdx: capTypeIdx, fieldIdx: 1 }, // captured (ref $Promise)
+    { op: "local.get", index: 1 }, // value: externref
+    { op: "call", funcIdx: settleFuncIdx }, // settle -> externref
+    { op: "drop" }, // trampoline result type is () — discard the settled value
+  ];
+
+  pushDefinedFunc(ctx, resolveClFuncIdx, {
+    name: "__promise_resolve_cl",
+    typeIdx: wrapper.liftedFuncTypeIdx,
+    locals: [],
+    body: makeBody(resolveValueFuncIdx),
+    exported: false,
+  });
+  ctx.funcMap.set("__promise_resolve_cl", resolveClFuncIdx);
+
+  pushDefinedFunc(ctx, rejectClFuncIdx, {
+    name: "__promise_reject_cl",
+    typeIdx: wrapper.liftedFuncTypeIdx,
+    locals: [],
+    body: makeBody(rejectFuncIdx),
+    exported: false,
+  });
+  ctx.funcMap.set("__promise_reject_cl", rejectClFuncIdx);
+
+  const result: PromiseExecutorClosures = {
+    resolveClFuncIdx,
+    rejectClFuncIdx,
+    capTypeIdx,
+    promiseTypeIdx,
+    rejectFuncIdx,
+  };
+  cache.__promiseExecutorClosures = result;
+  return result;
+}
+
+/**
+ * #2959 — Emit the native standalone `new Promise(executor)` lowering.
+ *
+ * Returns `true` when it emitted a native path (leaving an externref `$Promise`
+ * on the stack); returns `false` — having emitted NOTHING — when the native
+ * path is not applicable (host/gc mode, or a non-resolvable executor). The
+ * caller must then fall through to the existing `Promise_new` host path.
+ *
+ * Native only under `isStandalonePromiseActive` (WASI today), so host/gc mode is
+ * byte-unchanged. The executor must be a plain arrow / function expression whose
+ * `ClosureInfo` we can recover; anything else returns `false` (host fallback) —
+ * never a partial native path.
+ */
+export function emitStandalonePromiseFromExecutor(
+  ctx: CodegenContext,
+  fctx: FunctionContext,
+  executorArg: ts.Expression,
+): boolean {
+  if (!isStandalonePromiseActive(ctx)) return false;
+
+  // Start narrow: inline arrow / (non-async, non-generator) function expression.
+  // Widen to identifier-bound closures later. Anything else → host fallback.
+  if (!(ts.isArrowFunction(executorArg) || ts.isFunctionExpression(executorArg))) return false;
+  const isAsync = executorArg.modifiers?.some((m) => m.kind === ts.SyntaxKind.AsyncKeyword) ?? false;
+  if (isAsync) return false;
+  if (ts.isFunctionExpression(executorArg) && executorArg.asteriskToken !== undefined) return false;
+
+  // Ensure the exception tag exists BEFORE compiling the executor / minting the
+  // trampolines, so no later tag/import registration perturbs indices mid-emit.
+  const exnTag = ensureExnTag(ctx);
+
+  // 1. Compile the executor into a scratch buffer and recover its ClosureInfo.
+  //    Kept reachable to the late-import shifter via ctx.liveBodies + the
+  //    savedBodies swap (mirrors compileStandalonePromiseThenCallback).
+  const execInstrs: Instr[] = [];
+  ctx.liveBodies.add(execInstrs);
+  const savedBody = fctx.body;
+  fctx.savedBodies.push(savedBody);
+  fctx.body = execInstrs;
+  let closureInfo: ClosureInfo | undefined;
+  try {
+    const type = compileArrowAsClosure(ctx, fctx, executorArg);
+    if (type && (type.kind === "ref" || type.kind === "ref_null")) {
+      closureInfo = ctx.closureInfoByTypeIdx.get(type.typeIdx);
+    }
+    // Normalise the scratch buffer to leave the executor closure as externref.
+    if (type && type.kind !== "externref") {
+      coerceType(ctx, fctx, type, { kind: "externref" });
+    }
+  } finally {
+    fctx.savedBodies.pop();
+    fctx.body = savedBody;
+  }
+  if (!closureInfo) {
+    execInstrs.length = 0;
+    ctx.liveBodies.delete(execInstrs);
+    return false;
+  }
+
+  const closures = ensurePromiseExecutorClosures(ctx);
+  if (!closures) {
+    execInstrs.length = 0;
+    ctx.liveBodies.delete(execInstrs);
+    return false;
+  }
+  const { resolveClFuncIdx, rejectClFuncIdx, capTypeIdx, promiseTypeIdx, rejectFuncIdx } = closures;
+
+  // 2. Allocate the pending $Promise: {state: PENDING, value: null, callbacks: null}.
+  const pLocal = allocLocal(fctx, `__pexec_p_${fctx.locals.length}`, { kind: "ref", typeIdx: promiseTypeIdx });
+  fctx.body.push({ op: "i32.const", value: PROMISE_STATE_PENDING });
+  fctx.body.push({ op: "ref.null.extern" });
+  fctx.body.push({ op: "ref.null.extern" });
+  fctx.body.push({ op: "struct.new", typeIdx: promiseTypeIdx });
+  fctx.body.push({ op: "local.set", index: pLocal });
+
+  // 3. Materialise resolve / reject as capturing closure VALUES (externref):
+  //    struct{ func: ref.func $cl, cap_promise: p } upcast to externref.
+  const emitSettleValue = (clFuncIdx: number, dst: number): void => {
+    fctx.body.push({ op: "ref.func", funcIdx: clFuncIdx });
+    fctx.body.push({ op: "local.get", index: pLocal });
+    fctx.body.push({ op: "struct.new", typeIdx: capTypeIdx });
+    fctx.body.push({ op: "extern.convert_any" });
+    fctx.body.push({ op: "local.set", index: dst });
+  };
+  const rvLocal = allocLocal(fctx, `__pexec_rv_${fctx.locals.length}`, { kind: "externref" });
+  emitSettleValue(resolveClFuncIdx, rvLocal);
+  const rjLocal = allocLocal(fctx, `__pexec_rj_${fctx.locals.length}`, { kind: "externref" });
+  emitSettleValue(rejectClFuncIdx, rjLocal);
+
+  // 4. Recover the executor closure struct from the scratch buffer (externref).
+  const execLocal = allocLocal(fctx, `__pexec_fn_${fctx.locals.length}`, {
+    kind: "ref",
+    typeIdx: closureInfo.structTypeIdx,
+  });
+  for (const i of execInstrs) fctx.body.push(i);
+  fctx.body.push({ op: "any.convert_extern" });
+  fctx.body.push({ op: "ref.cast", typeIdx: closureInfo.structTypeIdx });
+  fctx.body.push({ op: "local.set", index: execLocal });
+  ctx.liveBodies.delete(execInstrs);
+
+  // 5. Invoke the executor synchronously inside try/catch; an executor throw
+  //    before settle rejects the promise (the settle guard makes it a no-op if
+  //    the executor already settled). Build the invoke into a detached tryBody.
+  const reasonLocal = allocLocal(fctx, `__pexec_reason_${fctx.locals.length}`, { kind: "externref" });
+  const tryBody: Instr[] = [];
+  fctx.savedBodies.push(fctx.body);
+  fctx.body = tryBody;
+  try {
+    // call_ref stack: [self, ...userArgs, funcref]
+    fctx.body.push({ op: "local.get", index: execLocal });
+    const paramTypes = closureInfo.paramTypes;
+    for (let i = 0; i < paramTypes.length; i++) {
+      const pType = paramTypes[i]!;
+      if (i === 0 || i === 1) {
+        // param 0 = resolve, param 1 = reject (both externref in practice).
+        fctx.body.push({ op: "local.get", index: i === 0 ? rvLocal : rjLocal });
+        if (pType.kind !== "externref") coerceType(ctx, fctx, { kind: "externref" }, pType);
+      } else {
+        // Executors never declare >2 params in practice; pad defensively.
+        pushDefaultValue(fctx, pType, ctx);
+      }
+    }
+    fctx.body.push({ op: "local.get", index: execLocal });
+    fctx.body.push({ op: "struct.get", typeIdx: closureInfo.structTypeIdx, fieldIdx: 0 });
+    emitGuardedFuncRefCast(fctx, closureInfo.funcTypeIdx);
+    emitNullCheckThrow(ctx, fctx, { kind: "ref_null", typeIdx: closureInfo.funcTypeIdx });
+    fctx.body.push({ op: "call_ref", typeIdx: closureInfo.funcTypeIdx });
+    if (closureInfo.returnType !== null) fctx.body.push({ op: "drop" });
+  } finally {
+    fctx.body = fctx.savedBodies.pop()!;
+  }
+
+  fctx.body.push({
+    op: "try",
+    blockType: { kind: "empty" },
+    body: tryBody,
+    catches: [
+      {
+        tagIdx: exnTag,
+        body: [
+          { op: "local.set", index: reasonLocal },
+          { op: "local.get", index: pLocal },
+          { op: "local.get", index: reasonLocal },
+          { op: "call", funcIdx: rejectFuncIdx },
+          { op: "drop" },
+        ],
+      },
+    ],
+  } as Instr);
+
+  // 6. Result: the pending/settled $Promise as externref.
+  fctx.body.push({ op: "local.get", index: pLocal });
+  fctx.body.push({ op: "extern.convert_any" });
+  return true;
+}

--- a/tests/issue-2959.test.ts
+++ b/tests/issue-2959.test.ts
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2959 — native `new Promise(executor)` for standalone / WASI mode.
+//
+// The executor pattern used to lower unconditionally to the `Promise_new`
+// host import, leaving every executor-pattern promise host-bound even though
+// the whole rest of the carrier ($Promise struct, resolve-value assimilation,
+// reject, microtask ring, native .then/.catch) is already native.
+//
+// These tests prove:
+//   1. LEAK-ELIM (load-bearing): a WASI executor program has ZERO `env`
+//      imports — `Promise_new` is retired.
+//   2. HOST-INERT: gc/host mode is byte-identical to before (still routes
+//      `new Promise` through the `Promise_new` host import).
+//   3. BEHAVIOUR: resolve-sync, reject, executor-throw→reject, double-settle,
+//      resolve-with-a-promise (assimilation), and arity 0/1 executors all
+//      behave to spec on `--target wasi`, host-free, and the GC binaries
+//      validate + instantiate + run without trapping.
+
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { compile } from "../src/index.ts";
+
+function envImportNames(wat: string): string[] {
+  const out: string[] = [];
+  const re = /\(import\s+"env"\s+"([^"]+)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(wat)) !== null) out.push(m[1]!);
+  return out;
+}
+
+/** Compile a WASI program, instantiate the GC binary with empty import objects
+ *  (the programs are host-free), run `_start`, and read back the exported
+ *  `result()` i32. Returns { value, env } where `env` is the env-import list. */
+async function runWasi(src: string): Promise<{ value: unknown; env: string[] }> {
+  const r = await compile(src, { target: "wasi" });
+  const errors = r.errors.filter((e) => e.severity === "error");
+  expect(errors).toEqual([]);
+  const env = envImportNames(r.wat);
+  const mod = await WebAssembly.compile(r.binary);
+  const importObject: Record<string, Record<string, unknown>> = {};
+  for (const imp of WebAssembly.Module.imports(mod)) (importObject[imp.module] ??= {})[imp.name] = () => {};
+  const inst = await WebAssembly.instantiate(mod, importObject as WebAssembly.Imports);
+  const exports = inst.exports as Record<string, CallableFunction>;
+  if (typeof exports._start === "function") exports._start();
+  const value = typeof exports.result === "function" ? exports.result() : undefined;
+  return { value, env };
+}
+
+const reader = (executor: string, chain: string) => `
+let captured = -1;
+new Promise<number>(${executor})${chain};
+export function result(): number { return captured; }
+`;
+
+describe("#2959 — native new Promise(executor) retires the Promise_new host import", () => {
+  it("WASI executor program emits ZERO env imports (Promise_new retired)", async () => {
+    const src = `const p = new Promise((resolve, reject) => { resolve(42); }); export function go(): number { return 1; }`;
+    const r = await compile(src, { target: "wasi" });
+    expect(r.success).toBe(true);
+    expect(envImportNames(r.wat)).toEqual([]);
+    // The binary must validate as WasmGC and instantiate host-free.
+    expect(WebAssembly.validate(r.binary)).toBe(true);
+  });
+
+  it("host (gc) mode is byte-inert — still routes new Promise through Promise_new", async () => {
+    // The native path is gated on isStandalonePromiseActive (WASI only), so the
+    // gc/host lane must be untouched: same host import, and a stable byte image
+    // across repeat compiles (determinism proxy for the cross-tree sha check).
+    const src = `const p = new Promise((resolve, reject) => { resolve(42); }); export function go(): number { return 1; }`;
+    const a = await compile(src, {});
+    const b = await compile(src, {});
+    expect(envImportNames(a.wat)).toContain("Promise_new");
+    expect(createHash("sha256").update(a.binary).digest("hex")).toBe(
+      createHash("sha256").update(b.binary).digest("hex"),
+    );
+  });
+
+  it("resolve-sync fulfils and the value reaches .then (host-free)", async () => {
+    const { value, env } = await runWasi(
+      reader(`(resolve) => { resolve(7); }`, `.then((v: number) => { captured = v; })`),
+    );
+    expect(value).toBe(7);
+    expect(env).toEqual([]);
+  });
+
+  it("reject rejects and the reason reaches .catch (host-free)", async () => {
+    const { value, env } = await runWasi(
+      reader(
+        `(resolve, reject) => { reject(9); }`,
+        `.then((v: number) => { captured = 100; }, (e: number) => { captured = e; })`,
+      ),
+    );
+    expect(value).toBe(9);
+    expect(env).toEqual([]);
+  });
+
+  it("executor throw-before-settle rejects (throw→reject wiring); reason reaches .catch", async () => {
+    // Inject-throw execution proof: if the native path were vacuous (executor
+    // body not actually run), `captured` would stay -1. It becomes 42, proving
+    // the executor body executes and its throw is routed to reject.
+    const { value, env } = await runWasi(
+      reader(
+        `(resolve, reject) => { throw 42; }`,
+        `.then((v: number) => { captured = 100; }, (e: number) => { captured = e; })`,
+      ),
+    );
+    expect(value).toBe(42);
+    expect(env).toEqual([]);
+  });
+
+  it("double-settle is ignored — first settle wins", async () => {
+    const { value, env } = await runWasi(
+      reader(
+        `(resolve, reject) => { resolve(3); reject(99); }`,
+        `.then((v: number) => { captured = v; }, (e: number) => { captured = -e; })`,
+      ),
+    );
+    expect(value).toBe(3);
+    expect(env).toEqual([]);
+  });
+
+  it("resolve-with-a-promise assimilates the inner promise's eventual value", async () => {
+    const src = `
+let captured = -1;
+const inner = new Promise<number>((res) => { res(11); });
+new Promise<number>((resolve) => { resolve(inner); }).then((v: number) => { captured = v; });
+export function result(): number { return captured; }
+`;
+    const { value, env } = await runWasi(src);
+    expect(value).toBe(11);
+    expect(env).toEqual([]);
+  });
+
+  it("arity-0 and arity-1 executors compile host-free and validate", async () => {
+    for (const executor of ["() => {}", "(resolve) => { resolve(1); }"]) {
+      const src = `const p = new Promise(${executor}); export function go(): number { return 1; }`;
+      const r = await compile(src, { target: "wasi" });
+      expect(r.success).toBe(true);
+      expect(envImportNames(r.wat)).toEqual([]);
+      expect(WebAssembly.validate(r.binary)).toBe(true);
+    }
+  });
+
+  it("a non-resolvable executor (identifier-bound) still compiles (host fallback, not a crash)", async () => {
+    // A variable-bound executor whose ClosureInfo we can't recover must fall
+    // through to the host path — never a partial native path / compile crash.
+    const src = `
+function mk(): (r: (v: number) => void) => void { return (r) => { r(1); }; }
+const ex = mk();
+const p = new Promise(ex);
+export function go(): number { return 1; }
+`;
+    const r = await compile(src, { target: "wasi" });
+    expect(r.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Retires the unconditional `Promise_new` **host import** for the `new Promise((resolve, reject) => …)` executor pattern in standalone/WASI mode. Everything downstream of the executor was already host-bound solely because of this one leak — the rest of the carrier (`$Promise` struct, `__promise_resolve_value` assimilation, `__promise_reject`, microtask ring, native `.then`/`.catch`) is native.

Implements the banked spec in #2959 (de-risked earlier via docs PR #2568).

## How

New module `src/codegen/promise-executor.ts` — `emitStandalonePromiseFromExecutor`, wired into the `new Promise` block of `new-super.ts`, gated on `isStandalonePromiseActive` (WASI today):

- allocates a pending native `$Promise`;
- synthesises `resolve`/`reject` as capturing closure **values** — instances of a `$__promise_settle_cap` struct that **subtypes the canonical `(externref)->()` func-ref wrapper**, so the executor body's native `ref.test`/`ref.cast`/`call_ref` dispatch lands on them (the captured `$Promise` lives in an extra field; the trampolines carry *exactly* the wrapper's lifted func type and downcast `self` to recover the capture);
- `resolve` routes through `__promise_resolve_value` (assimilating — `resolve(aPromise)` chains); `reject` and executor-throw route through `__promise_reject`;
- runs the executor **synchronously** in try/catch (throw-before-settle ⇒ reject); the settle helpers' already-settled guard makes double-settle a spec-correct no-op.

### ABI verification (traced against true WASI mode before implementing)

- Executor `resolve`/`reject` params are **always `externref`** (`(value: T | PromiseLike<T>) => void` for every `T`), so one canonical `(externref)->()` wrapper is universal.
- In WASI mode the executor's `resolve(x)` call has **no host fallback** (`__call_function` is gated `!ctx.standalone && !ctx.wasi`): it's native `call_ref` or throw. So subtyping the wrapper makes the settle closures dispatch natively and `Promise_new` becomes the *only* removable import → **zero `env` imports**.
- `sub final` is a non-issue: leaf-finalisation is skipped entirely for standalone/WASI (and the subtype un-finalises it anyway).

## Scope / conservatism

- Narrow-gated to **inline arrow / (non-async, non-generator) function-expression** executors with a recoverable `ClosureInfo`. Non-resolvable executors emit **nothing** and fall through to the existing `Promise_new` host path — never a partial native path.
- **Host/gc mode byte-identical** (verified sha256). `Promise_new` intentionally left on the strict-gate allowlist so host-fallback edge cases don't become compile errors under WASI.

## Proof (`tests/issue-2959.test.ts`, all host-free — env imports `[]`)

- **Leak-elim (load-bearing):** WASI executor program → zero `env` imports; GC binary validates.
- **Host-inert:** gc mode still routes through `Promise_new`; byte-stable.
- resolve-sync → `.then` sees `7`; reject → `.catch` sees `9`; **executor-throw → `.catch` sees `42`** (inject-throw execution proof — a vacuous native path would leave the observer at `-1`); double-settle first-wins (`3`); resolve-with-a-promise assimilation (`11`). All GC binaries validate + instantiate + run `_start` without trapping.

Note: `tests/issue-*.test.ts` are not in required CI (#3008); the behavioural proof is self-contained here and the leak-elim shows up as host-free-floor movement in the standalone gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)