### PR TITLE
chore(reconcile): flip 4 verified-done Backlog issues; correct #872 verdict

### DIFF
--- a/plan/issues/1206-fix-build-pages-copy-benchmark.md
+++ b/plan/issues/1206-fix-build-pages-copy-benchmark.md
@@ -1,9 +1,10 @@
 ---
 id: 1206
 title: "fix(build-pages): copy benchmark JSONs + frame-nav-sync.js to top-level pages-dist paths (404s on landing page)"
-status: ready
+status: done
+completed: 2026-07-03
 created: 2026-04-27
-updated: 2026-06-19
+updated: 2026-07-03
 priority: medium
 feasibility: easy
 reasoning_effort: low
@@ -129,3 +130,22 @@ source file exists; landing page references resolve.
 ## Frontmatter reconcile (2026-06-12)
 
 Was `in-progress` with no open PR, no active agent, and no Suspended Work section (session died sprints 42-52). Reset to `ready` during the sprint-62 issue review; re-validate against current main before claiming (#2148).
+
+## Reconciliation — DONE (2026-07-03)
+
+Verified genuinely resolved on `main` against the full acceptance criteria:
+
+- **Benchmark JSONs → top-level:** `scripts/build-pages.js` now defines
+  `TOP_BENCH_RESULTS = join(PAGES_DIST, "benchmarks", "results")` and copies
+  `size-benchmarks.json`, `loadtime-benchmarks.json`,
+  `playground-benchmark-sidebar.json` (+ `-no-jit`, wasm-host JSONs) to BOTH the
+  top-level path and the playground path — so the landing page's top-level
+  requests resolve (criteria 1–2).
+- **`frame-nav-sync.js`:** removed from the codebase entirely — it is referenced
+  by no HTML on `main` (`git grep frame-nav-sync` hits only plan/docs/dashboard
+  data), so there is no 404 to fix (criterion 1 "references removed").
+- **Sidebar source (criterion 3):** `benchmarks/results/playground-benchmark-sidebar.json`
+  exists (committed).
+
+No dedicated PR carried this to `done`; the copy loop + file removal landed
+incrementally. Flipped here during the 2026-07-03 stale-backlog reconciliation.

--- a/plan/issues/1895-wat-gc-array-copy-vs-linear-perf.md
+++ b/plan/issues/1895-wat-gc-array-copy-vs-linear-perf.md
@@ -1,10 +1,11 @@
 ---
 id: 1895
 title: "Minimal .wat repro: WasmGC i8 array.copy vs element-loop vs linear memory.copy throughput (wasmtime vs Node/V8)"
-status: ready
+status: done
+completed: 2026-07-03
 sprint: Backlog
 created: 2026-06-05
-updated: 2026-06-05
+updated: 2026-07-03
 priority: medium
 feasibility: easy
 reasoning_effort: low
@@ -86,3 +87,18 @@ reuse the `.tmp/wasmtime-gc-bug/` scratch notes.
 - #1863 records the original measurement and the host's element-loop workaround.
 - #1886 (linear-backed `Uint8Array`) is the compiler-side fix that routes I/O
   buffers to `memory.copy`/zero-copy and sidesteps GC `array.copy` entirely.
+
+## Reconciliation — DONE (2026-07-03)
+
+The investigation deliverable was landed by **PR #1220**
+(`docs(#1895): minimal .wat GC array.copy vs linear memory.copy benchmark`,
+merged 2026-06-05, branch `issue-1895-gc-copy-bench`). Verified on `main`:
+
+- The committed repro exists under `bench/`: `bench/gc-array-copy.wat`
+  (i8 GC array with `bench_arraycopy` / `bench_elemloop` / `bench_memcopy`),
+  `bench/run-node.mjs`, and `bench/run-wasmtime.mjs`.
+- The issue body itself carries the `## Results (measured 2026-06-05, N = 16 MiB)`
+  section — the throughput findings this investigation set out to capture.
+
+Both the artifact and the measured results are recorded, so the investigation
+is complete. Flipped during the 2026-07-03 stale-backlog reconciliation.

--- a/plan/issues/807-extract-date-math-console-built.md
+++ b/plan/issues/807-extract-date-math-console-built.md
@@ -1,9 +1,10 @@
 ---
 id: 807
 title: "Extract Date/Math/console built-ins from expressions.ts → builtins.ts"
-status: ready
+status: done
+completed: 2026-07-03
 created: 2026-03-26
-updated: 2026-04-28
+updated: 2026-07-03
 priority: medium
 feasibility: easy
 reasoning_effort: medium
@@ -40,3 +41,20 @@ subtask_of: 688
 These are leaf functions — they emit Wasm but nothing calls back into them from other modules. Console/WASI helpers are entirely self-contained.
 
 ## Complexity: S
+
+## Reconciliation — DONE (2026-07-03)
+
+Verified the extraction is complete on `main`:
+
+- The built-in handlers now live in `src/codegen/expressions/builtins.ts`
+  (~3,700 LOC): `compileConsoleCall` / `compileConsoleCallWasi`,
+  `compileMathCall`, `compileDateMethodCall`, and the Date helper builders
+  (`ensureDateStruct`, `ensureDateCivilHelper`, `ensureDateIsoStringHelper`, …).
+- They are dispatched from `src/codegen/expressions/calls.ts` (imports at the
+  top `from "./builtins.js"`; call sites `compileConsoleCall(...)`,
+  `compileMathCall(...)`, `compileDateMethodCall(...)`).
+- `src/codegen/expressions.ts` has **zero** residual `Math`/`Date`/`console`
+  built-in dispatch (`grep -c` = 0) — so the logic was moved OUT of
+  `expressions.ts`, not duplicated. That is exactly this issue's ask.
+
+Flipped during the 2026-07-03 stale-backlog reconciliation.

--- a/plan/issues/865-console-wrapper-for-fd-write.md
+++ b/plan/issues/865-console-wrapper-for-fd-write.md
@@ -1,9 +1,10 @@
 ---
 id: 865
 title: "Console wrapper for fd_write in JavaScript environments"
-status: ready
+status: done
+completed: 2026-07-03
 created: 2026-03-29
-updated: 2026-04-28
+updated: 2026-07-03
 priority: medium
 feasibility: easy
 reasoning_effort: medium
@@ -39,3 +40,22 @@ This would be included in the runtime as an optional WASI polyfill, allowing WAS
 - WASI `fd_write` polyfill in `src/runtime.ts` or separate `src/wasi-polyfill.ts`
 - `console.log("hello")` in WASI mode works in both WASI runtimes and JS environments
 - Documented in README
+
+## Reconciliation — DONE (2026-07-03)
+
+Verified genuinely resolved on `main` against the full acceptance criteria:
+
+- **WASI `fd_write` polyfill exists** — `src/runtime.ts` (~L13896) exports a WASI
+  polyfill object whose `fd_write(fd, iovs, iovs_len, nwritten)` reads each iovec
+  (`view.getUint32(iovs + i*8, ...)` ptr/len), UTF-8-decodes via `TextDecoder`,
+  and routes to `console.error` for fd 2 else `console.log`, writing the byte
+  count to `nwritten` — a real implementation, not a stub.
+- **`console.log` in WASI mode works in JS environments** — a WASI-compiled
+  module instantiated with this polyfill as `wasi_snapshot_preview1` resolves
+  `fd_write` and prints via `console.*` (criterion 2).
+- **Documented** — `docs/standalone-io.md` documents the routing
+  (`console.log → fd_write` on fd 1, `console.warn/error → fd 2`) and the JS/Deno
+  loader recipes; the acceptance's "documented" bar is met (in a dedicated doc
+  rather than README).
+
+Flipped during the 2026-07-03 stale-backlog reconciliation.

--- a/plan/issues/872-test262-report-data-should-only.md
+++ b/plan/issues/872-test262-report-data-should-only.md
@@ -3,7 +3,7 @@ id: 872
 title: "Test262 report data should only update on complete runs"
 status: ready
 created: 2026-03-29
-updated: 2026-04-28
+updated: 2026-07-03
 priority: high
 feasibility: easy
 reasoning_effort: medium
@@ -38,3 +38,28 @@ This ensures report.html always shows the last COMPLETE run.
 - report.html always shows last complete run
 - Temp files cleaned up on next successful run
 - runs/index.json only contains complete runs
+
+## Reconciliation check — NOT closeable, kept `ready` (2026-07-03)
+
+Checked during the stale-backlog reconciliation. An earlier quick read judged
+this "architecturally obsolete," but a rigorous check shows that is **only
+partly true** — it is NOT safe to close:
+
+- **Production symptom mitigated (not by this fix):** the committed baseline
+  `benchmarks/results/test262-current.json` (what the landing badges read) is
+  refreshed ONLY by the `promote-baseline` job in `test262-sharded.yml` on push
+  to `main` — i.e. after a COMPLETE sharded run merges. So an interrupted run
+  no longer overwrites the deployed report with partial data. That addresses the
+  original "1,000 total / 0 passed" landing-page symptom.
+- **BUT the local runner still does exactly what the issue flags:**
+  `tests/test262-vitest.test.ts` still writes `test262-report.json` incrementally
+  (`REPORT_FLUSH_INTERVAL` periodic flush), with no temp-file + atomic-rename.
+  A locally interrupted `pnpm run test:262` still leaves partial data in the
+  working tree. The acceptance criteria (temp files, atomic rename, `runs/index.json`
+  only on complete runs) are **not implemented**.
+
+Verdict: the deployed-report risk is handled by the sharded CI architecture, so
+the priority is lower than filed, but the local-runner atomicity work described
+here is genuinely unstarted. Kept `status: ready`; consider re-scoping to just
+the local-runner temp+rename (small) or downgrading priority — leaving that call
+to the PO/lead rather than closing on a false "obsolete."


### PR DESCRIPTION
Stale-backlog reconciliation (2026-07-03). Each issue was verified against its
**full acceptance criteria** on `main` — not just "a PR touched it" — matching
the rigor of the earlier #2830/#2960/#2964 pass.

## Flipped `ready` → `done` (verified genuinely resolved)

- **#1206** — `scripts/build-pages.js` copies the benchmark JSONs to the
  top-level `TOP_BENCH_RESULTS` path (landing-page requests resolve), and
  `frame-nav-sync.js` was removed from the codebase (referenced by no HTML). The
  issue's own `## Test Results` section already documented the fix; status had
  been reset to `ready` in a prior review.
- **#865** — real WASI `fd_write` polyfill in `src/runtime.ts` (reads iovecs,
  `TextDecoder`, routes fd 2 → `console.error` else `console.log`); documented in
  `docs/standalone-io.md`.
- **#807** — `Date`/`Math`/`console` handlers live in
  `src/codegen/expressions/builtins.ts`, dispatched from
  `src/codegen/expressions/calls.ts`; `expressions.ts` has **0** residual builtin
  dispatch (moved out, not duplicated — exactly the issue's ask).
- **#1895** — investigation deliverable landed by **PR #1220**:
  `bench/gc-array-copy.wat` + `run-node.mjs` + `run-wasmtime.mjs` committed, and
  the measured throughput results are recorded in the issue body.

## Kept `ready` (corrected an over-hasty "obsolete" call)

- **#872** — the committed baseline is protected (promoted only on complete
  sharded runs), which mitigates the original landing-page symptom. BUT the local
  `tests/test262-vitest.test.ts` runner **still** flushes `test262-report.json`
  incrementally with no temp+rename — the acceptance work (atomic writes,
  `runs/index.json` only on complete runs) is genuinely unstarted. Not safe to
  close; added an accurate note and left the close/re-scope call to the PO/lead.

Doc-only change (issue frontmatter + resolution notes). No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)