### PR TITLE
fix(#2927): native-vec .push/.pop brand arm for standalone any-receiver + Part-2 audit refinement

### DIFF
--- a/plan/agent-context/sr-interp.md
+++ b/plan/agent-context/sr-interp.md
@@ -1,0 +1,44 @@
+# sr-interp — session context (#2927)
+
+## Role
+Senior developer (Opus), issue #2927 "Interpreter foundation: Acorn-via-js2wasm
+runtime parser + generic-built-in audit" (L-horizon, feasibility: hard).
+
+## Landed this session (PR #2592, loopdive/js2, branch issue-2927-interpreter-foundation)
+1. **Fix**: native-vec `.push`/`.pop` brand arm for standalone/wasi any-receiver.
+   - Real host-free DATA-LOSS bug: `--target standalone` `const a:any=[1,2];
+     a.push(3)` returned 0, left `.length===2`, dropped element; `.pop()` returned 0.
+   - Root cause: #2151 closed-method dispatcher (`__call_m_push_1`/`__call_m_pop_0`)
+     had no `$__vec_base` arm; #2784 native-vec fast path is `!ctx.standalone`-gated.
+   - Files: `src/codegen/closed-method-dispatch.ts` (VEC_MUTATE_METHODS +
+     `$__vec_base` fill arm → `__vec_push`/`__vec_pop`, -1-guard→undefined),
+     `src/codegen/expressions/calls.ts` (reserve vec helper at call site, avoids
+     eval-time import cycle).
+   - Tests: `tests/issue-2927-standalone-any-push-pop.test.ts` (7, host-free-asserted).
+2. **Audit refinement** in the issue file (the Part-2 deliverable): verified host-free
+   measurements under `target: standalone` (asserting `Module.imports`). Corrected the
+   coverage table — String/non-callback-Array/object-literal any-methods already
+   host-free+correct; real gaps are Map/Set + Array callback methods.
+
+## Verification
+tsc clean; #2151 (all slices)+#2583 (51) green; array-methods/prototype (35) green;
+new #2927 suite (7) green. Only failure (`fast-arrays > array find`) is pre-existing TS
+type error, confirmed identical on base main.
+
+## Methodology note (important)
+`{ standalone: true }` compile OPTION is HYBRID (allows env.* host imports) — NOT
+host-free. Only `--target standalone` / `--target wasi` is truly host-free (0 fn-imports).
+Measure host-freeness via `WebAssembly.Module.imports`, not the option.
+
+## Next slices (turnkey, rolled forward — see issue ## Suspended Work)
+1. **Map/Set any-receiver brand arms** (highest value). Root cause pinned:
+   `src/codegen/expressions/extern.ts:60-93` keys native Map/Set interception on the
+   STATIC class name (`className === "Map"`), so any-typed receivers skip it → emit
+   `env.WeakMap_*`/`Set_*`. Fix: `ref.test ctx.mapTypeIdx`/`$Set` arm in the
+   closed-method dispatcher routing to native `__map_get/set/has/delete` /
+   `__set_*` (map-runtime.ts / set-runtime.ts). Same pattern as the push/pop arm.
+2. Array callback methods (map/filter/forEach/reduce) on any → `env.__make_callback`
+   (needs in-Wasm callback bridge; largest).
+3. `string[]` push under standalone: native-string vec carrier not in `__vec_push`
+   `mutEntries` (index.ts) — file under #2784.
+4. Part 1 — Acorn runtime parser: blocked on #2937 (host $Object-hash poison).

--- a/plan/issues/2927-interpreter-foundation-acorn-builtin-audit.md
+++ b/plan/issues/2927-interpreter-foundation-acorn-builtin-audit.md
@@ -306,10 +306,22 @@ No regression: `#2151`/`#2583` suites (51) + array-methods/prototype (35) green;
 ### Remaining generic-built-in gaps (tracking items — gate #2928 sign-off)
 
 1. **Map/Set methods on an `any` receiver are NOT host-free** — emit
-   `env.WeakMap_get`/`WeakMap_set`/`WeakMap_has`/`Set_add`. The interpreter's
-   `CallBuiltin` on a boxed-any Map/Set receiver needs native brand arms routing
-   to the standalone Map/Set runtime (`src/codegen/map-runtime.ts`). *(new gap —
-   file as a #2928-prep child of #1584.)*
+   `env.WeakMap_get`/`WeakMap_set`/`WeakMap_has`/`Set_add`. **Root cause pinned:**
+   the native Map/Set/WeakMap interception in `compileExternMethodCall`
+   (`src/codegen/expressions/extern.ts:60-93`) keys on the receiver's **static
+   TypeScript class name** (`className === "Map"` / `"Set"` / …). A genuinely-`any`
+   receiver has no static class name, so the interception is skipped and the call
+   falls to the generic extern/host path → `env.WeakMap_*` / `Set_*` imports —
+   even though the WasmGC-native Map/Set runtime already exists
+   (`src/codegen/map-runtime.ts`: `__map_get`/`__map_set`/`__map_has`/
+   `__map_delete`/`__map_size`; `ctx.mapTypeIdx` `$Map` struct; `set-runtime.ts`).
+   **Turnkey fix (mirrors the #2927 push/pop arm):** a runtime `ref.test
+   ctx.mapTypeIdx` / `$Set` brand arm in the closed-method dispatcher
+   (`__call_m_get_1` / `__call_m_set_2` / `__call_m_has_1` / `__call_m_add_1`)
+   routing to the native `__map_*` / `__set_*` helpers with the boxed args, so an
+   `any` Map/Set receiver dispatches native. This is the highest-value host-free
+   gap and the next slice to pick up. *(new gap — file as a #2928-prep child of
+   #1584.)*
 2. **Array callback methods (map/filter/forEach/reduce) on an `any` receiver are
    NOT host-free** — emit `env.__make_callback`. Host callback marshalling on a
    dynamic receiver; the largest of the three (needs an in-Wasm callback bridge).

--- a/plan/issues/2927-interpreter-foundation-acorn-builtin-audit.md
+++ b/plan/issues/2927-interpreter-foundation-acorn-builtin-audit.md
@@ -2,9 +2,9 @@
 id: 2927
 title: "Interpreter foundation: Acorn-via-js2wasm runtime parser + generic-built-in audit"
 status: in-progress
-assignee: ttraenkler/dev-2927
+assignee: ttraenkler/sr-interp
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 priority: medium
 horizon: l
 feasibility: hard
@@ -233,3 +233,110 @@ These three are the concrete #2928 prerequisites this audit gates; each maps to
 existing infra (#2151 dispatchers, #2863 `__get_builtin`, `__str_*`/`__vec_*`
 helpers) rather than net-new machinery.
 
+
+---
+
+## Generic built-in audit — Part 2 refinement + first fix (sr-interp, 2026-07-03)
+
+Empirically re-measured the "generic `(any,…)→any` callability" surface on
+current `origin/main` by compiling genuinely-`any`-receiver built-in method
+calls (param typed `any`, so the compiler cannot statically resolve the brand)
+and inspecting the **declared Wasm function imports** of the emitted module. This
+materially corrects the coverage table above.
+
+### Methodology correction — `standalone: true` (option) ≠ host-free
+
+The earlier probes used the `{ standalone: true }` compile **option**, which is a
+**hybrid** mode that still permits `env.*` host imports (the object runtime is
+host-backed: `env.__extern_get`, `env.__extern_method_call`, …). The **truly
+host-free** path is `--target standalone` / `--target wasi` (the native runtime,
+0 function imports). Measuring host-freeness under the *option* conflates a real
+host dependency with a satisfied JS bridge. **All findings below use `target:
+"standalone"`** and assert the function-import set directly
+(`WebAssembly.Module.imports`).
+
+### Measured host-free status of any-receiver built-in calls (`target: standalone`)
+
+| Any-receiver call | Host-free (0 fn-imports)? | Correct value? | Note |
+|---|---|---|---|
+| `String.prototype.*` (toUpperCase/indexOf/charCodeAt/concat/slice/…) | ✅ | ✅ | resolved inline/native — **does NOT use the `__extern_method_call` brand stub** |
+| `Array.prototype` non-callback (indexOf/lastIndexOf/includes) | ✅ | ✅ | #2583 `$__vec_base` search arm |
+| `Array.prototype.push` / `.pop` | ✅ | ❌→✅ **FIXED here** | was host-free but **silently wrong** (see below) |
+| object-literal methods (`o.m()` / `o.m(a)`) | ✅ | ✅ | #2151 closed-method dispatch |
+| `Array.prototype` **callback** methods (map/filter/forEach/reduce) | ❌ | (host) | emits `env.__make_callback` — **GAP** |
+| `Map.prototype` (get/set) on `any` | ❌ | (host) | emits `env.WeakMap_get` / `env.WeakMap_set` — **GAP** |
+| `Set.prototype` (has/add) on `any` | ❌ | (host) | emits `env.WeakMap_has` / `env.Set_add` — **GAP** |
+
+**Key correction to the coverage table above:** the String/Array brand arms are
+**NOT** "stub → undefined" in practice — genuinely-`any` String and non-callback
+Array methods already run **host-free and correct** via inline/native paths (they
+never reach the native `__extern_method_call` non-`$Object` `else` arm). The real
+host-free gaps for the #2928 interpreter's `CallBuiltin` are narrower and more
+specific: **Map/Set methods** and **Array callback methods** on an `any` receiver
+still emit `env.*` host imports.
+
+### Fix landed here — native-vec `.push`/`.pop` on `any` (host-free data-loss bug)
+
+The one **reachable, host-free, silently-WRONG** case found: `--target standalone`
+`const a:any=[1,2]; a.push(3)` returned **0**, left `a.length===2`, and dropped
+the element (`a[2]===0`); `a.pop()` returned **0**. Host mode was correct (3).
+
+Root cause: the standalone any-receiver method-call-with-args path (#2151) routes
+`push`/`pop` through `__call_m_push_1` / `__call_m_pop_0`, whose dispatcher had
+**no native-vec arm** — an `any`/externref array receiver matched no closed-struct
+`entries` arm and fell to the open-`$Object` bottom arm (returns `undefined`). The
+#2784 S3 native-vec push/pop fast path in `calls.ts` is `!ctx.standalone`-gated,
+so it never fired standalone.
+
+Fix (`src/codegen/closed-method-dispatch.ts` + `src/codegen/expressions/calls.ts`):
+a `$__vec_base` brand arm in the fixed-arity closed-method dispatcher routes
+`push` (arity 1) / `pop` (arity 0) to the carrier-generic `__vec_push` /
+`__vec_pop` helpers (grow-and-append / pop-last over every vec carrier). `push`'s
+`-1` unsupported-carrier sentinel returns `undefined` (matching the pre-fix
+fall-through) instead of boxing a bogus length. The vec helper is reserved at the
+`calls.ts` call site to avoid an eval-time import cycle. This is the #2151
+"Slice-4 brand arms" made real for the mutation methods, and is **shared work**
+with standalone AOT any-receiver dispatch (roadmap §4.2), not interpreter-only.
+
+Tests: `tests/issue-2927-standalone-any-push-pop.test.ts` (7 cases; standalone
+assertions verify **0 function imports** before running, i.e. truly host-free).
+No regression: `#2151`/`#2583` suites (51) + array-methods/prototype (35) green;
+`tsc` clean.
+
+### Remaining generic-built-in gaps (tracking items — gate #2928 sign-off)
+
+1. **Map/Set methods on an `any` receiver are NOT host-free** — emit
+   `env.WeakMap_get`/`WeakMap_set`/`WeakMap_has`/`Set_add`. The interpreter's
+   `CallBuiltin` on a boxed-any Map/Set receiver needs native brand arms routing
+   to the standalone Map/Set runtime (`src/codegen/map-runtime.ts`). *(new gap —
+   file as a #2928-prep child of #1584.)*
+2. **Array callback methods (map/filter/forEach/reduce) on an `any` receiver are
+   NOT host-free** — emit `env.__make_callback`. Host callback marshalling on a
+   dynamic receiver; the largest of the three (needs an in-Wasm callback bridge).
+   *(new gap — child of #1584.)*
+3. **`string[].push` under standalone is a no-op** — the native-string vec carrier
+   is not in `__vec_push`'s `mutEntries` (only externref/f64/i32), so the brand
+   arm's `__vec_push` returns `-1` and the fix returns `undefined` for `string[]`
+   (no regression — it was already broken). Fix belongs in the `__vec_push`/
+   `__vec_pop` carrier set (`src/codegen/index.ts` `mutEntries`), not this arm.
+   *(new gap — file under #2784.)*
+
+Parts still open on this umbrella issue: **Part 1 (Acorn-via-js2wasm runtime
+parser)** is untouched here — it is gated on **#2937** (host `$Object`-hash poison
+→ uniform parse null-deref) per the probe results above, and remains the larger
+half of this foundation. See `## Suspended Work`.
+
+## Suspended Work
+
+- **Branch**: `issue-2927-interpreter-foundation` (PR opened 2026-07-03).
+- **Landed**: native-vec `.push`/`.pop` brand arm for standalone any-receiver
+  (the one reachable host-free correctness bug the Part-2 audit surfaced) +
+  refined coverage findings above.
+- **Not done (roll forward)**:
+  - Part 1 — Acorn runtime parser (blocked on #2937; then #2850/#2853/#2841/etc.).
+  - Part 2 remaining gaps 1–3 above (Map/Set host imports, array-callback
+    `__make_callback`, `string[]` push carrier). Each should become a child
+    issue under #1584 / #2784 and gates #2928.
+- **Resume**: pick up Part 2 gap #1 (Map/Set native brand arms) next — it is the
+  highest-value host-free gap and mirrors the push/pop pattern (a `$Map`/`$Set`
+  `ref.test` arm in the closed-method dispatcher routing to `map-runtime.ts`).

--- a/src/codegen/closed-method-dispatch.ts
+++ b/src/codegen/closed-method-dispatch.ts
@@ -57,6 +57,28 @@ import { definedFuncAt } from "./func-space.js"; // (#1916 S2) positional-read c
 const VEC_SEARCH_METHODS = new Set(["indexOf", "lastIndexOf", "includes"]);
 
 /**
+ * (#2927 / #2784 residual) The in-place array MUTATION methods that get a native
+ * `$__vec_base` brand arm in the closed-method dispatcher so a genuinely-`any`
+ * array receiver (`const a:any=[…]; a.push(x)` / `a.pop()`) actually mutates the
+ * backing WasmGC vec instead of falling to the open-`$Object` arm (which returns
+ * `undefined` and silently DROPS the element — a host-free data-loss bug: on
+ * `--target standalone` `[1,2].push(3)` left `.length===2` and returned 0). The
+ * native-vec push/pop dispatch in `calls.ts` (#2784 S3) is JS-host/gc gated, so
+ * standalone/wasi `.push`/`.pop` on an `any`/externref vec previously no-op'd.
+ *
+ * `push` is arity 1 (`recv, arg0`), `pop` is arity 0 (`recv`). Both route to the
+ * carrier-generic `__vec_push` / `__vec_pop` helpers (grow-and-append / pop-last
+ * over every registered vec carrier), so no per-element-kind specialization is
+ * needed here.
+ */
+const VEC_MUTATE_METHODS = new Set(["push", "pop"]);
+
+/** True when `methodName`/`arity` is a supported native-vec mutation form. */
+function isVecMutateForm(methodName: string, arity: number): boolean {
+  return (methodName === "push" && arity === 1) || (methodName === "pop" && arity === 0);
+}
+
+/**
  * Mangle a method name + arg count into the reserved dispatcher export/funcMap
  * name. (#2151 Slice 2) The arity is part of the key so `o.m()` and `o.m(a,b)`
  * get distinct dispatchers with the right number of externref arg params.
@@ -120,6 +142,19 @@ export function reserveClosedMethodDispatch(ctx: CodegenContext, methodName: str
     // `__box_boolean` (for `includes`) is a union import; `__box_number`
     // (for indexOf/lastIndexOf) too. Register them so both are in funcMap by fill.
     addUnionImportsViaRegistry(ctx);
+  }
+
+  // (#2927) For the in-place array MUTATION methods (`push`/`pop`), register the
+  // native `$__vec_base` brand-arm deps NOW so the fill only READS funcMap
+  // (#1719): the `$__vec_base` supertype and `__box_number` (push returns an i32
+  // length that the arm boxes). The carrier-generic `__vec_push` / `__vec_pop`
+  // helper is reserved by the CALL SITE (`calls.ts`, which already imports
+  // `reserveVecMethodHelper` from `../index.js` — importing it here would form an
+  // eval-time circular-import cycle: `index.ts` imports this module for
+  // `fillClosedMethodDispatch`). Standalone/wasi only.
+  if ((ctx.standalone || ctx.wasi) && VEC_MUTATE_METHODS.has(methodName) && isVecMutateForm(methodName, arity)) {
+    getOrRegisterVecBaseType(ctx);
+    addUnionImportsViaRegistry(ctx); // __box_number for the push new-length result
   }
 
   // Signature: (recv, arg0..arg{arity-1}) all externref → externref.
@@ -486,6 +521,76 @@ export function fillClosedMethodDispatch(ctx: CodegenContext): void {
         { op: "ref.test", typeIdx: ctx.vecBaseTypeIdx } as Instr,
         { op: "if", blockType: { kind: "val", type: { kind: "externref" } }, then: vecArmBody, else: current } as Instr,
       ];
+    }
+
+    // (#2927) `$__vec_base` brand arm for the in-place array MUTATION methods
+    // (`push` arity 1 / `pop` arity 0). A genuinely-`any` array receiver is a
+    // `$__vec_base`-subtyped struct that matches no `entries` arm; without this
+    // it falls to the open-`$Object` bottom arm which returns `undefined` and (for
+    // push) silently drops the element — a host-free data-loss bug on
+    // `--target standalone` (the #2784 S3 JS-host/gc-gated native-vec dispatch
+    // never fires standalone). Route to the carrier-generic `__vec_push` /
+    // `__vec_pop` helpers (reserved at reserve-time; body filled in the finalize
+    // vec-export pass).
+    const vecPushIdx = ctx.funcMap.get("__vec_push");
+    const vecPopIdx = ctx.funcMap.get("__vec_pop");
+    const wantVecMutArm =
+      (ctx.standalone || ctx.wasi) &&
+      VEC_MUTATE_METHODS.has(methodName) &&
+      isVecMutateForm(methodName, arity) &&
+      ctx.vecBaseTypeIdx >= 0;
+    if (wantVecMutArm) {
+      let mutArmBody: Instr[] | undefined;
+      if (methodName === "push" && vecPushIdx !== undefined && ci.boxNumIdx !== undefined) {
+        // __vec_push(recv, arg0) -> i32 new length, or -1 when the vec's element
+        // kind is NOT push-supported (e.g. a native-string carrier — see
+        // `mutEntries` in index.ts, which covers only externref/f64/i32). On the
+        // -1 sentinel we must NOT box -1 as a bogus "new length"; instead return
+        // `undefined` (ref.null.extern), matching the pre-#2927 open-`$Object`
+        // fall-through so an unsupported carrier is no WORSE than before (its
+        // `.length` was already unchanged). A scratch i32 holds the result across
+        // the sign test.
+        const pushLenLocalIdx = arity + 1 + locals.length;
+        locals.push({ name: "__vpushlen", type: { kind: "i32" } });
+        mutArmBody = [
+          { op: "local.get", index: 0 } as Instr, // recv (externref)
+          { op: "local.get", index: 1 } as Instr, // arg0 (externref)
+          { op: "call", funcIdx: vecPushIdx } as Instr,
+          { op: "local.tee", index: pushLenLocalIdx } as Instr,
+          { op: "i32.const", value: 0 } as Instr,
+          { op: "i32.lt_s" } as Instr, // newLen < 0 → unsupported carrier
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "externref" } },
+            then: [{ op: "ref.null.extern" } as Instr], // undefined (pre-#2927 behavior)
+            else: [
+              { op: "local.get", index: pushLenLocalIdx } as Instr,
+              { op: "f64.convert_i32_s" } as Instr,
+              { op: "call", funcIdx: ci.boxNumIdx } as Instr,
+            ],
+          } as Instr,
+        ];
+      } else if (methodName === "pop" && vecPopIdx !== undefined) {
+        // __vec_pop(recv) -> externref (already-boxed last element; null.extern for
+        // an empty OR unsupported-carrier vec — both map to `undefined`, which is
+        // exactly the pre-#2927 fall-through result, so no guard is needed).
+        mutArmBody = [
+          { op: "local.get", index: 0 } as Instr, // recv (externref)
+          { op: "call", funcIdx: vecPopIdx } as Instr,
+        ];
+      }
+      if (mutArmBody !== undefined) {
+        current = [
+          { op: "local.get", index: anyLocalIdx } as Instr,
+          { op: "ref.test", typeIdx: ctx.vecBaseTypeIdx } as Instr,
+          {
+            op: "if",
+            blockType: { kind: "val", type: { kind: "externref" } },
+            then: mutArmBody,
+            else: current,
+          } as Instr,
+        ];
+      }
     }
 
     for (const entry of entries) {

--- a/src/codegen/expressions/calls.ts
+++ b/src/codegen/expressions/calls.ts
@@ -12019,6 +12019,16 @@ function compileCallExpression(
         if ((ctx.standalone || ctx.wasi) && dispatchArgs !== null && !recvIsBuiltinClass) {
           const arity = dispatchArgs.length;
           const dispatchIdx = reserveClosedMethodDispatch(ctx, methodName, arity);
+          // (#2927) For the in-place array mutation forms (`push` arity 1 / `pop`
+          // arity 0) the closed-method dispatcher grows a native `$__vec_base`
+          // brand arm (fillClosedMethodDispatch) that routes an `any`/externref
+          // vec receiver to these carrier-generic helpers. Reserve them here — the
+          // dispatcher's fill only READS funcMap, and reserving from this module
+          // (which already imports `reserveVecMethodHelper`) avoids the eval-time
+          // import cycle that reserving from `closed-method-dispatch.ts` would form.
+          if ((methodName === "push" && arity === 1) || (methodName === "pop" && arity === 0)) {
+            reserveVecMethodHelper(ctx, methodName === "push" ? "push" : "pop");
+          }
           flushLateImportShifts(ctx, fctx);
           // Receiver as externref.
           const recvType = compileExpression(ctx, fctx, propAccess.expression, { kind: "externref" });

--- a/tests/issue-2927-standalone-any-push-pop.test.ts
+++ b/tests/issue-2927-standalone-any-push-pop.test.ts
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #2927 (generic-built-in audit, Part 2) / #2784 residual — native-vec `.push` /
+// `.pop` on a genuinely-`any` receiver under `--target standalone` / `--target
+// wasi`.
+//
+// Root cause: the closed-method dispatcher `__call_m_push_1` / `__call_m_pop_0`
+// (the path a standalone any-receiver method call with args takes, #2151) had NO
+// native-vec brand arm, so an `any`/externref array receiver fell through to the
+// open-`$Object` bottom arm and returned `undefined`. For `push` that also
+// SILENTLY DROPPED the element — a host-free data-loss bug: on `--target
+// standalone`, `const a:any=[1,2]; a.push(3)` returned 0 and left `a.length===2`.
+// (The #2784 S3 native-vec push/pop fast path in calls.ts is JS-host/gc gated, so
+// it never fired standalone.)
+//
+// Fix (#2927): the closed-method dispatcher grows a `$__vec_base` brand arm that
+// routes `push` (arity 1) / `pop` (arity 0) to the carrier-generic `__vec_push` /
+// `__vec_pop` helpers. These are shared with standalone AOT any-receiver dispatch
+// (roadmap §4.2) and are a #2928 `CallBuiltin` prerequisite.
+//
+// The standalone assertions instantiate with an EMPTY import object and first
+// assert the module declares ZERO function imports — i.e. the behaviour is truly
+// HOST-FREE, not silently satisfied by a JS host bridge.
+
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+import { buildImports, instantiateWasm } from "../src/runtime.js";
+
+async function runHost(source: string): Promise<unknown> {
+  const result: any = await compile(source, { fileName: "test.ts" });
+  if (!result.success) {
+    throw new Error("compile: " + result.errors.map((e: any) => e.message).join("; "));
+  }
+  const built = buildImports(result.imports, {}, result.stringPool);
+  const { instance } = await instantiateWasm(result.binary, built.env, built.string_constants);
+  built.setExports?.(instance.exports as Record<string, Function>);
+  return (instance.exports as any).test();
+}
+
+/** Compile host-free (`target: standalone`), assert 0 function imports, run. */
+async function runStandaloneHostFree(source: string): Promise<unknown> {
+  const result: any = await compile(source, { fileName: "test.ts", target: "standalone" });
+  if (!result.success) {
+    throw new Error("compile: " + result.errors.map((e: any) => e.message).join("; "));
+  }
+  const mod = await WebAssembly.compile(result.binary);
+  const fnImports = WebAssembly.Module.imports(mod).filter((i) => i.kind === "function");
+  // The whole point of the fix: this dispatch is host-free. If a JS host bridge
+  // import sneaks back in, the "standalone" result is a lie — fail loudly.
+  expect(fnImports.map((i) => `${i.module}.${i.name}`)).toEqual([]);
+  const instance: any = await WebAssembly.instantiate(mod, {});
+  return instance.exports.test();
+}
+
+describe("#2927 — standalone any-receiver .push/.pop mutates the native vec (host-free)", () => {
+  it("push returns the new length (was 0 standalone)", async () => {
+    const src = `function f(x: any, y: any): number { return x.push(y); }
+                 export function test(): number { return f([1, 2], 3); }`;
+    expect(await runHost(src)).toBe(3);
+    expect(await runStandaloneHostFree(src)).toBe(3);
+  });
+
+  it("push actually appends (x.length was stuck at 2 standalone)", async () => {
+    const src = `function f(x: any, y: any): number { x.push(y); return x.length; }
+                 export function test(): number { return f([1, 2], 3); }`;
+    expect(await runHost(src)).toBe(3);
+    expect(await runStandaloneHostFree(src)).toBe(3);
+  });
+
+  it("pushed element is readable at its index (x[2] was 0 standalone)", async () => {
+    const src = `function f(x: any, y: any): number { x.push(y); return x[2]; }
+                 export function test(): number { return f([1, 2], 3); }`;
+    expect(await runHost(src)).toBe(3);
+    expect(await runStandaloneHostFree(src)).toBe(3);
+  });
+
+  it("repeated push accumulates", async () => {
+    const src = `function f(x: any): number { x.push(4); x.push(5); return x.length; }
+                 export function test(): number { return f([1, 2, 3]); }`;
+    expect(await runHost(src)).toBe(5);
+    expect(await runStandaloneHostFree(src)).toBe(5);
+  });
+
+  it("pop returns the last element (was 0 standalone)", async () => {
+    const src = `function f(x: any): number { return x.pop(); }
+                 export function test(): number { return f([1, 2, 3]); }`;
+    expect(await runHost(src)).toBe(3);
+    expect(await runStandaloneHostFree(src)).toBe(3);
+  });
+
+  it("pop shrinks the array", async () => {
+    const src = `function f(x: any): number { x.pop(); return x.length; }
+                 export function test(): number { return f([1, 2, 3]); }`;
+    expect(await runHost(src)).toBe(2);
+    expect(await runStandaloneHostFree(src)).toBe(2);
+  });
+
+  // A closed object-literal with its OWN `push` method must still dispatch to
+  // that method (the `entries` arms are checked before the vec brand arm), NOT
+  // get hijacked by the native-vec arm.
+  it("a user object with its own push() still wins over the vec arm", async () => {
+    const src = `function f(o: any, n: any): number { return o.push(n); }
+                 export function test(): number { return f({ n: 10, push(k: number): number { return this.n + k; } }, 5); }`;
+    expect(await runHost(src)).toBe(15);
+    expect(await runStandaloneHostFree(src)).toBe(15);
+  });
+});


### PR DESCRIPTION
## Summary

Slice of the #2927 interpreter-foundation / generic-built-in audit. Two things:

1. **Fix a host-free correctness (data-loss) bug** surfaced by the Part-2 audit:
   under `--target standalone` / `--target wasi`, `.push`/`.pop` on a genuinely-`any`
   array receiver **silently no-op'd** — `const a:any=[1,2]; a.push(3)` returned `0`,
   left `a.length===2`, and dropped the element; `a.pop()` returned `0`. Host mode was
   correct. Root cause: the #2151 closed-method dispatcher (`__call_m_push_1` /
   `__call_m_pop_0`, the path standalone any-receiver calls-with-args take) had **no
   native-vec arm**, so an `any`/externref array fell to the open-`$Object` bottom arm
   (returns `undefined`). The #2784 S3 native-vec fast path in `calls.ts` is
   `!ctx.standalone`-gated, so it never fired standalone.

   Adds a `$__vec_base` brand arm to the fixed-arity dispatcher routing `push` (arity 1)
   / `pop` (arity 0) to the carrier-generic `__vec_push` / `__vec_pop` helpers. `push`'s
   `-1` unsupported-carrier sentinel returns `undefined` (matching the pre-fix
   fall-through), not a bogus boxed length. The vec helper is reserved at the `calls.ts`
   call site to avoid an eval-time import cycle. A user object-literal with its own
   `push`/`pop` still wins (entries arms are checked first).

2. **Refine the generic-built-in coverage audit** in the issue file with empirically
   verified host-free measurements (`target: standalone`, asserted via
   `WebAssembly.Module.imports`). Correction: String / non-callback-Array / object-literal
   any-receiver methods are already **host-free and correct** (they do NOT use the
   `__extern_method_call` brand stub). The real remaining host-free gaps for the #2928
   interpreter `CallBuiltin` are narrower — **Map/Set** (`env.WeakMap_*`/`Set_add`) and
   **Array callback methods** (`env.__make_callback`) — filed as tracking items.

## Tests

- New `tests/issue-2927-standalone-any-push-pop.test.ts` (7 cases). Standalone assertions
  verify **0 function imports** (truly host-free) before running.
- No regression: `#2151` (all slices) + `#2583` suites (51 tests) green; array-methods /
  array-prototype-methods (35) green; `tsc --noEmit` clean.
- The one unrelated failure in `fast-arrays.test.ts > array find` is a **pre-existing** TS
  type error in the test source (`Array.prototype.find` → `number | undefined`), confirmed
  identical on base `main`.

This is a bounded slice of the L-horizon foundation issue; Part 1 (Acorn runtime parser,
blocked on #2937) and the Map/Set + array-callback host-free gaps roll forward (see the
issue's `## Suspended Work`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)