### PR TITLE
docs(#2984): measurement-grounded re-scope of standalone gOPD-on-builtin MOP

### DIFF
--- a/plan/issues/2984-standalone-gopd-on-builtin-descriptor-mop.md
+++ b/plan/issues/2984-standalone-gopd-on-builtin-descriptor-mop.md
@@ -10,6 +10,7 @@ area: codegen, runtime
 goal: standalone-mode
 related: [2965, 2861, 2863, 2896, 2949, 2989]
 origin: "#2965 descriptor-cluster triage — follow-up class 1"
+assignee: ttraenkler/sr-gopd
 ---
 
 # #2984 — standalone gOPD-on-builtin descriptor MOP
@@ -28,6 +29,80 @@ run gOPD-readback first, so #2989 measures net-0 until this lands).
 
 This is design-only — no implementation in this issue. It is a **spec seed**
 to size the work and record why the existing machinery does not extend.
+
+## Measured current-main state (2026-07-03, sr-gopd) — the narrative below is STALE
+
+> **Re-measured against `origin/main` @ `bc8a1d4ca` (`target: standalone`,
+> instantiate with empty imports `{}`).** Current main has **advanced past**
+> the "returns `undefined` / drops the accessor" narrative in the original
+> buckets below (which was written against an earlier tree, pre
+> #2861/#2863/#2896). The buckets are still the right decomposition, but the
+> _actual remaining gap in each_ is narrower and different from what the
+> original text says. **Read this section as the authoritative status; the
+> three-bucket text underneath is the historical seed.** Probes: `.tmp/probe*.mjs`
+> (gitignored) — reproduce with `compile(src, {target:'standalone'})` then
+> `WebAssembly.instantiate(r.binary, {})`.
+
+| Bucket | Original narrative | **Measured on current main** |
+| --- | --- | --- |
+| **(1) proto-receiver** `gOPD(Array.prototype,"forEach")` | returns `undefined` | **No longer `undefined`.** Returns a descriptor with **correct boolean attributes** (`writable:true, enumerable:false, configurable:true`) and a `.value` slot that is present but **broken**: `typeof d.value` is **codegen-path-dependent** (`"function"` when tested inline, `"object"` when bound to a `const` first — representation instability), the value is **non-invocable** (`d.value.call(arr, cb)` is a no-op / traps — `arr` unchanged), and **non-canonical** (`d.value !== Array.prototype.forEach`). Gap narrowed from "no descriptor" to "**`.value` is a non-first-class placeholder**". |
+| **(2) ctor-receiver** `gOPD(Array,"isArray")` | hard-CE `__get_builtin not yet supported` | **UNCHANGED** — still hard-CEs with `Codegen error: '__get_builtin' (dynamic-shape object/property operation) is not yet supported in --target standalone (#1472 Phase B)`. The refusal **string** is emitted by the generic refused-late-import path at `src/codegen/expressions/late-imports.ts:99`; the **routing** that reaches it (a builtin constructor used as a _dynamic_ gOPD receiver falling through to the `__get_builtin` shortcut) is in `src/codegen/property-access.ts` (the `__get_builtin` branch, see the refusal-context comments ~L192–208 / L403). |
+| **(3) plain-object accessor** `gOPD({get x(){…}}, "x")` | "returns a data descriptor / drops the accessor" | **Descriptor SHAPE is now correct**: `get`/`set` present, no own `value` (`hasOwnProperty("value")` false), `hasOwnProperty("get")` true, `enumerable`/`configurable` correct. **But INVOKING the accessor from the descriptor is not host-free**: `d.get()` pulls `env::WeakMap_get`, `d.set(v)` pulls `env::WeakMap_set` → **traps at instantiate under standalone** (missing import). A get+set literal (`{get x(){}, set x(v){}}`) also drags a `WeakMap` import even for the existence check on some shapes. Gap moved from "drops accessor" to "**accessor-closure invocation is not host-free**". |
+
+### Shared root cause, confirmed by direct measurement
+
+`Array.prototype.forEach` is **not a first-class invocable value** in
+standalone _even outside gOPD_: binding `const fn = Array.prototype.forEach;`
+gives `typeof fn === "function"` but `fn.call([1,2,3], cb)` **traps**
+(`WebAssembly.Exception`). So the gOPD `.value` placeholder is not a
+descriptor-path bug — it inherits the substrate fact that **builtin methods
+are lowered inline-at-callsite and never materialise as callable funcref/closure
+values**. This is exactly step (2) of "Rough shape of a real fix" below, and the
+**D1 type-erased-value-representation** class (#2949's `dynamic` kind). No
+descriptor-layer patch can fix bucket (1)/(2) without it.
+
+### Re-scoping consequence — the ~178 estimate is likely an over-count now
+
+The original ~178 assumed every bucket-(1) test fails on an `undefined`
+descriptor. Since the **boolean-attribute assertions now pass** (the common
+`verifyProperty`/`propertyHelper.js` shape checks that only assert
+`writable`/`enumerable`/`configurable` + `typeof value === "function"`), a
+material fraction of bucket (1) may **already pass** on current main. The
+**residual** bucket-(1) failures are only the tests that (a) _call_
+`descriptor.value`, or (b) assert `descriptor.value === Ctor.prototype.method`
+identity, or (c) trip the `typeof` instability. **Next owner must re-measure the
+real count** (run `built-ins/*/getOwnPropertyDescriptor` +
+`built-ins/Object/getOwnPropertyDescriptor` through the real test262 harness on
+standalone) before committing the XL sizing — the sub-3-attr-only tests are
+sunk, and the true remaining number is probably well under 178.
+
+### Recommended split (updated)
+
+1. **Bucket (3) is the cleanest independent slice and has moved closest to
+   done.** Its only remaining gap is a narrow, well-scoped one: make accessor
+   get/set **closures host-free** (retire the `WeakMap_get`/`WeakMap_set` host
+   import that accessor-closure storage/invocation drags in under standalone —
+   see `src/codegen/accessor-driver.ts` + the `__call_accessor_get/set` drivers
+   in `object-runtime.ts` ~L1020/L1558). This does **not** need the
+   method-value reification substrate and could be its own S/M issue. Split it
+   out and prioritise it — highest test-flip-per-effort of the three.
+2. **Buckets (1) + (2) remain jointly blocked on method-value reification**
+   (issue step 2), which should sit on **#2949's `dynamic` JsTag-carrying kind**
+   rather than a parallel boxing scheme. Do **not** start (1)/(2) before #2949's
+   substrate lands — a descriptor-layer-only attempt re-breeds the placeholder
+   `.value` (and the `typeof` instability) rather than fixing it.
+3. **Secondary bug to file separately:** the `typeof d.value` codegen-path
+   dependence (inline `"function"` vs const-bound `"object"`) is a
+   representation-stability defect in how an open-object descriptor field is
+   read back; worth isolating even before (1) lands because it can cause
+   flaky `typeof` assertions elsewhere.
+
+**Verdict for this pass:** no small, self-contained code change flips any
+test262 assertion without the method-value reification substrate. Per the
+"banked spec beats a broken codegen change" discipline, this pass delivers the
+measurement-grounded re-scope + split recommendation rather than a codegen
+edit. Bucket (3)'s host-free-accessor slice is the recommended next
+_implementable_ unit and is the only one that does not wait on #2949.
 
 ## The three substrate sub-problems
 


### PR DESCRIPTION
## What

Docs-only re-scope of the #2984 spec seed (standalone `getOwnPropertyDescriptor`
on builtin objects / proto receivers). No codegen change.

## Why

The original seed was written against an earlier tree and its per-bucket
narrative ("returns `undefined` / drops the accessor") is now **stale**.
Re-measured all three buckets against `origin/main` @ `bc8a1d4ca`
(`target: standalone`, instantiate with empty imports). The buckets are still
the right decomposition, but the *actual remaining gap in each* is narrower and
different.

## Measured findings (see the new "Measured current-main state" section)

- **(1) proto-receiver** — no longer `undefined`. Returns a descriptor with
  **correct boolean attrs** but a **non-first-class `.value`**: `typeof` is
  codegen-path-dependent (`function` inline / `object` const-bound), the value
  is non-invocable and non-canonical (`!== Array.prototype.forEach`). Confirmed
  shared root cause by direct probe: `Array.prototype.forEach.call(...)` **traps**
  even outside gOPD — builtin methods are not first-class invocable values in
  standalone (the D1 / #2949 substrate).
- **(2) ctor-receiver** — **unchanged**, still hard-CEs. Pinned the exact
  refusal site (`expressions/late-imports.ts:99`) vs. the routing in
  `property-access.ts`.
- **(3) plain-object accessor** — descriptor **shape is now correct**; the only
  remaining gap is that **invoking** `d.get()`/`d.set()` drags
  `WeakMap_get`/`WeakMap_set` host imports → traps standalone. Recommended as the
  **cleanest independent split** (does NOT need the method-value reification
  substrate).

## Consequences recorded in the issue

- The `~178` estimate is likely an **over-count** now that boolean-attr-only
  tests pass — next owner must re-measure the real count before committing the
  XL sizing.
- **Split recommendation:** bucket (3) first (host-free accessor closures);
  buckets (1)+(2) jointly blocked on #2949's `dynamic`-value substrate.
- A `typeof d.value` codegen-path-dependence sub-bug flagged for its own issue.

**Verdict:** no small, self-contained code change flips a test262 assertion
without the method-value reification substrate, so per the "banked spec beats a
broken codegen change" discipline this pass delivers the re-scope, not a codegen
edit. Issue stays `status: ready` for implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8