### PR TITLE
feat(#3000): IR private-field read/write substrate (Phase 1a)

### DIFF
--- a/plan/issues/3000-ir-class-member-privatefield-accessor-inheritance.md
+++ b/plan/issues/3000-ir-class-member-privatefield-accessor-inheritance.md
@@ -1,11 +1,10 @@
 ---
 id: 3000
 title: "IR: class-member residual — private fields, accessors, inheritance/super (class-method → 0)"
-status: in-progress
-assignee: ttraenkler/sr-classmember
+status: ready
 sprint: current
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 priority: medium
 horizon: xl
 feasibility: hard

--- a/plan/issues/3000-ir-class-member-privatefield-accessor-inheritance.md
+++ b/plan/issues/3000-ir-class-member-privatefield-accessor-inheritance.md
@@ -107,3 +107,113 @@ Animal` needs parent-prefixed struct field layout, `super(...)` constructor
 Scoped out of #2857 (2026-07-02). #2857's original "drive class-method to zero"
 framing was mis-sized as `M`; the measure-first pass found only static-methods
 was a bounded win. This carries the XL remainder.
+
+## Implementation Notes — Phase 1a: private-field read/write substrate (2026-07-03, PR TBD)
+
+**Landed (this PR):** the private-field *shape gate + lowering* — the smallest
+independently-shippable slice of Phase 1. Clears the two class-member
+`body-shape-rejected` attributions on `classes.ts` (`Animal_new`,
+`Animal_speak`); `body-shape-rejected` corpus total 25 → 23.
+
+**Root cause of the rejection (verified on `upstream/main` @ bc8a1d4ca):** IR's
+Phase-1 shape gate and AST→IR lowerer both gated field access on
+`ts.isIdentifier(name)`. A `#x` name is a `ts.PrivateIdentifier`, *not* an
+`Identifier`, so `this.#x` read/write fell into `body-shape-rejected` *before*
+any `class.get`/`class.set` logic ran. Everything downstream was already in
+place: `buildIrClassShapes` (`src/codegen/index.ts`) reads fields straight from
+`ctx.structFields`, which *already includes* private slots, and
+`ClassRegistry.fieldIdx` (`src/ir/integration.ts`) resolves by the same
+`structFields` name → identical index. So the fix is purely at the gate + lower
+entry points.
+
+**The load-bearing detail — name mangling.** The legacy `resolveClassMemberName`
+(`src/codegen/class-bodies.ts:522`) stores a private field `#name` as
+`"__priv_name"` (strip `#`, prefix `__priv_`). The IR shape and `fieldIdx` both
+read that mangled name from `structFields`, so from-ast MUST mangle the
+`PrivateIdentifier` the *same* way (`irPrivateFieldName` in `from-ast.ts`) or the
+field lookup misses. Plain `Identifier` passes through unchanged.
+
+**Edits (5, all narrow):**
+- `src/ir/from-ast.ts` — `irPrivateFieldName` helper; `lowerPropertyAccess`
+  (read) and `lowerPropertyAssignment` (write) accept `PrivateIdentifier` +
+  mangle.
+- `src/ir/select.ts` — accept `PrivateIdentifier` in the `isPhase1Expr`
+  property-access read arm, the `isPhase1StatementList` non-tail assignment arm,
+  and the `isPhase1BodyStatement` (ctor/for-of body) assignment arm.
+- `scripts/ir-fallback-baseline.json` — ratchet body-shape-rejected 25 → 23.
+- `tests/issue-3000.test.ts` — selector + runtime (incl. super-dispatch) parity.
+
+**Key architectural findings (correct the issue's original phasing):**
+
+1. **Constructors are NOT emitted by Phase B integration.** `compileIrPathFunctions`
+   only builds `MethodDeclaration`s (`integration.ts:304`); it never builds a
+   `ConstructorDeclaration`. So even though the selector now *claims* `Animal_new`
+   (clearing its `body-shape-rejected`), Phase B skips it → the **legacy ctor
+   body still emits, byte-inert**. Real IR constructor emission (`struct.new` +
+   `__self` epilogue + field-init) is a **separate substrate = the issue's
+   "Phase C"**, independent of and larger than the private-field gate. The
+   issue's Phase 1 lumped "ctor private write" with "method private read"; in
+   the code they are two different integration paths.
+
+2. **`Animal_speak` (private read in a flat-class instance method) IS a real,
+   non-byte-inert codegen change** — it flows through Phase B, gets its body
+   replaced by IR-lowered Wasm (subject to the typeIdx parity guard at
+   `integration.ts:715`). Validated: `classes.ts`'s `Dog.speak()` override calls
+   `super.speak()` → the IR-emitted `Animal_speak` with a **Dog** receiver
+   (WasmGC subtype of Animal); `class.get __priv_name` reads the correct
+   parent-prefixed slot across the subtype boundary. Output matches legacy
+   exactly. **Contrast with #2857**, whose static-method claim was byte-inert —
+   #3000 has *no* byte-inert reduction; every metric drop that reaches Phase B
+   is a real emission change gated by test262.
+
+3. **Private-field *write* as a void-method tail is a pre-existing, non-private
+   gap.** `set(v){ this.#x = v }` is rejected at `isPhase1Tail` → `isPhase1Expr`
+   (`select.ts:~1821`), which rejects **all** `=` expressions (public or
+   private). Out of scope for this substrate; belongs to a general
+   "assignment-expression-statement as void tail" slice.
+
+**Validation:** `tests/issue-3000.test.ts` (5, pass); `private-class-members` +
+`ir-slice4-classes` + 3 other class equivalence files (22, pass); `tests/ir/*`
+and the class test files show **zero new failures vs base** (the `classes.ts` /
+`abstract-classes` / `issue-private-access-brand` / `ir/passes` / `inline-small`
+failures observed locally are **pre-existing** — stale `{ env: {} }` harnesses
+and unrelated inline/CF tests, identical with and without this change). Full
+test262 conformance is the CI gate.
+
+## Remaining surface — decomposition for future windows
+
+`class-method` is still **5** on `classes.ts`; the two class-member
+`body-shape-rejected` are cleared. The remainder splits into three
+independently-dispatchable slices, in dependency order:
+
+- **#3000-B — Accessors (get/set over the private slot)** [M].
+  Members: `Animal_name` (get+set), `Animal_age` (get), `Dog_breed` (get).
+  Needs: (a) selector — stop bucketing `GetAccessorDeclaration` /
+  `SetAccessorDeclaration` as `class-method` (`select.ts:411`) and claim them
+  like no-arg / one-arg methods over the (now-supported) private slot; note
+  get+set collapse to one `${Class}_${name}` funcMap key today. (b) Phase B
+  integration walk (`integration.ts:303`) currently only iterates
+  `MethodDeclaration`s — extend to accessor declarations, mapping to the legacy
+  accessor funcMap key. (c) the void-tail-assignment gap (finding 3 above) blocks
+  the *setter* body `set name(v){ this.#name = v }` — either lift the setter’s
+  lone assignment out of tail position in the gate, or land the general
+  void-tail-assignment slice first. **Depends on Phase 1a (this PR).**
+  `Dog_breed` additionally needs Phase E (it’s on the `extends` subclass).
+
+- **#3000-C — Constructor IR emission (Phase C)** [L]. Build
+  `ConstructorDeclaration`s in Phase B: allocate the struct, run field
+  initialisers + ctor body private/public writes, synthesise the `return this`
+  epilogue, and register under the `${Class}_new` funcMap key. Only after this
+  does `Animal_new`'s claim become a *real* IR emission (today byte-inert).
+  Prerequisite for making the ctor claim honest and for Phase E's `super(...)`.
+
+- **#3000-E — Inheritance / `super` (Phase E)** [XL, the big rock]. `Dog extends
+  Animal`. Needs: parent-prefixed `IrClassShape` (today `buildIrClassShapes`
+  skips any `extends` class — `index.ts:874`; and Phase B integration skips them
+  wholesale — `integration.ts:294`), `super(...)` ctor chaining (on top of
+  Phase C), and `super.method()` dispatch to the parent slot. Members:
+  `Dog_new`, `Dog_speak`. Loosen the selector `hasParent` arm (`select.ts:430`)
+  and both skip guards once the substrate exists. **Consider its own issue.**
+
+`"class-method"` joins `STRICT_IR_REASONS` (`src/codegen/index.ts`) only once
+B + C + E all land and the bucket is 0.

--- a/plan/issues/3000-ir-class-member-privatefield-accessor-inheritance.md
+++ b/plan/issues/3000-ir-class-member-privatefield-accessor-inheritance.md
@@ -1,7 +1,8 @@
 ---
 id: 3000
 title: "IR: class-member residual — private fields, accessors, inheritance/super (class-method → 0)"
-status: ready
+status: in-progress
+assignee: ttraenkler/sr-classmember
 sprint: current
 created: 2026-07-02
 updated: 2026-07-02

--- a/scripts/ir-fallback-baseline.json
+++ b/scripts/ir-fallback-baseline.json
@@ -1,7 +1,7 @@
 {
-  "generated": "2026-07-02",
+  "generated": "2026-07-03",
   "unintended": {
-    "body-shape-rejected": 25,
+    "body-shape-rejected": 23,
     "call-graph-closure": 10,
     "class-method": 5
   },

--- a/src/ir/from-ast.ts
+++ b/src/ir/from-ast.ts
@@ -1961,6 +1961,17 @@ function lowerOptionalExternPropertyAccess(
 }
 
 /**
+ * #3000 — map a property name to the struct-slot key the class registry uses.
+ * A `PrivateIdentifier` (`#x`) is mangled to `__priv_x`, byte-for-byte matching
+ * the legacy `resolveClassMemberName` (`src/codegen/class-bodies.ts`) so the IR
+ * `class.get`/`class.set` resolve the identical `structFields` slot the legacy
+ * path allocated. A plain `Identifier` passes through unchanged.
+ */
+function irPrivateFieldName(name: ts.Identifier | ts.PrivateIdentifier): string {
+  return ts.isPrivateIdentifier(name) ? "__priv_" + name.text.slice(1) : name.text;
+}
+
+/**
  * Lower a property access expression.
  *
  * Slice 1 (#1169a) handles `<string>.length` (the only `.length` form
@@ -1974,10 +1985,17 @@ function lowerOptionalExternPropertyAccess(
  * containing function falls back to legacy.
  */
 function lowerPropertyAccess(expr: ts.PropertyAccessExpression, cx: LowerCtx): IrValueId {
-  if (!ts.isIdentifier(expr.name)) {
+  // #3000 — private-field read (`this.#x`). A PrivateIdentifier is not an
+  // Identifier, so the pre-#3000 guard rejected it. Private names lower to the
+  // SAME mangled struct-slot key the legacy path registers
+  // (`resolveClassMemberName`: `#x` → `__priv_x`), so the class shape / fieldIdx
+  // resolve the identical slot. Only class receivers carry private slots; on any
+  // other receiver kind the mangled name won't be found and the function
+  // demotes to legacy cleanly.
+  if (!ts.isIdentifier(expr.name) && !ts.isPrivateIdentifier(expr.name)) {
     throw new Error(`ir/from-ast: computed property access not in slice 2 (${cx.funcName})`);
   }
-  const propName = expr.name.text;
+  const propName = irPrivateFieldName(expr.name);
 
   // Receiver type is unknown until we lower it; pass an f64 hint (the
   // numeric default) and inspect the resulting IrType. The hint is
@@ -3250,10 +3268,12 @@ function lowerStringMethodCall(
  */
 function lowerPropertyAssignment(expr: ts.BinaryExpression, cx: LowerCtx): void {
   const lhs = expr.left;
-  if (!ts.isPropertyAccessExpression(lhs) || !ts.isIdentifier(lhs.name)) {
+  // #3000 — private-field write (`this.#x = v`). Same mangling as the read
+  // path so the write targets the identical legacy struct slot.
+  if (!ts.isPropertyAccessExpression(lhs) || (!ts.isIdentifier(lhs.name) && !ts.isPrivateIdentifier(lhs.name))) {
     throw new Error(`ir/from-ast: malformed property assignment LHS in ${cx.funcName}`);
   }
-  const fieldName = lhs.name.text;
+  const fieldName = irPrivateFieldName(lhs.name);
   const recv = lowerExpr(lhs.expression, cx, irVal({ kind: "f64" }));
   const recvType = cx.builder.typeOf(recv);
 

--- a/src/ir/select.ts
+++ b/src/ir/select.ts
@@ -995,8 +995,10 @@ function isPhase1StatementList(
         s.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
         ts.isPropertyAccessExpression(s.expression.left)
       ) {
-        // LHS: <expr>.<id> — receiver expr must be Phase-1, prop must be Identifier.
-        if (!ts.isIdentifier(s.expression.left.name)) return shapeNo("nontail-assign-computedprop", s.expression);
+        // LHS: <expr>.<id> — receiver expr must be Phase-1, prop must be an
+        // Identifier or (#3000) a PrivateIdentifier (`this.#x = v`).
+        if (!ts.isIdentifier(s.expression.left.name) && !ts.isPrivateIdentifier(s.expression.left.name))
+          return shapeNo("nontail-assign-computedprop", s.expression);
         if (!isPhase1Expr(s.expression.left.expression, scope, localClasses))
           return shapeNo("nontail-assign-recv", s.expression.left.expression);
         // RHS: any Phase-1 expression.
@@ -1346,7 +1348,10 @@ function isPhase1BodyStatement(stmt: ts.Statement, scope: Set<string>, localClas
           return isPhase1Expr(stmt.expression.right, scope, localClasses);
         }
         if (ts.isPropertyAccessExpression(stmt.expression.left)) {
-          if (!ts.isIdentifier(stmt.expression.left.name)) return false;
+          // #3000 — allow `this.#x = v` (PrivateIdentifier) in method / ctor
+          // bodies, in addition to plain-Identifier field writes.
+          if (!ts.isIdentifier(stmt.expression.left.name) && !ts.isPrivateIdentifier(stmt.expression.left.name))
+            return false;
           if (!isPhase1Expr(stmt.expression.left.expression, scope, localClasses)) return false;
           return isPhase1Expr(stmt.expression.right, scope, localClasses);
         }
@@ -1928,7 +1933,11 @@ function isPhase1Expr(expr: ts.Expression, scope: ReadonlySet<string>, localClas
   // class instance (recv is Phase-1; lowerer dispatches by the recv's
   // resolved IrType).
   if (ts.isPropertyAccessExpression(expr)) {
-    if (!ts.isIdentifier(expr.name)) return false;
+    // #3000 — accept private-field reads (`this.#x`). A PrivateIdentifier is a
+    // valid class-instance field access; from-ast lowers it to `class.get` on
+    // the mangled `__priv_x` slot. Non-class receivers with a private name are
+    // a TS error and never reach here.
+    if (!ts.isIdentifier(expr.name) && !ts.isPrivateIdentifier(expr.name)) return false;
     // Slice 11 (#1169n) — optional chaining (`obj?.prop`). The lowerer
     // doesn't yet emit the null-guard branch, so accept the shape
     // structurally but the lowerer will throw clean fallback when it

--- a/tests/issue-3000.test.ts
+++ b/tests/issue-3000.test.ts
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 Loopdive GmbH. Licensed under Apache-2.0 WITH LLVM-exception.
+//
+// #3000 — IR private-field substrate (issue Phase 1).
+//
+// Before this slice, IR's Phase-1 shape gate rejected any `this.#x` read or
+// write: `PropertyAccessExpression` / assignment LHS were gated on
+// `ts.isIdentifier(name)`, and a `PrivateIdentifier` is not an `Identifier`, so
+// the member fell into the `body-shape-rejected` bucket before any lowering.
+//
+// This slice teaches the selector (`src/ir/select.ts`) and the AST→IR lowerer
+// (`src/ir/from-ast.ts`) to accept `PrivateIdentifier` field access, mangling
+// `#x` → `__priv_x` (byte-identical to the legacy `resolveClassMemberName`) so
+// the IR `class.get`/`class.set` resolve the SAME `structFields` slot the
+// legacy path allocated. It clears the two class-member `body-shape-rejected`
+// attributions on `website/playground/examples/js/classes.ts` (`Animal_new`,
+// `Animal_speak`).
+//
+// Scope / NON-goals (the XL remainder stays on #3000's later phases):
+//   - Accessors (get/set) still bucket as `class-method` (selector arm).
+//   - Constructors are claimed by the selector but Phase B integration does not
+//     yet build ConstructorDeclarations (it handles MethodDeclarations only),
+//     so `Animal_new` stays on the legacy body — the claim is metric-only /
+//     byte-inert for the ctor. Constructor IR emission is the separate Phase C.
+//   - Inheritance / `super` (Dog extends Animal) stays `class-method`.
+//   - A void method whose *tail* statement is a field assignment
+//     (`set(v){ this.#x = v }`) is rejected by the pre-existing
+//     `isPhase1Tail`→`isPhase1Expr` gate (which rejects ALL `=` expressions,
+//     public or private) — not part of this substrate.
+
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+import { compile } from "../src/index.js";
+import { planIrCompilation } from "../src/ir/select.js";
+
+function selection(source: string) {
+  const sf = ts.createSourceFile("test.ts", source, ts.ScriptTarget.Latest, true);
+  return planIrCompilation(sf, { experimentalIR: true, trackFallbacks: true });
+}
+
+async function runString(source: string): Promise<string> {
+  const r = await compile(source, { fileName: "test.ts" });
+  expect(r.success).toBe(true);
+  const { instance } = await WebAssembly.instantiate(r.binary, r.importObject);
+  const fn = (instance.exports as Record<string, () => unknown>).test;
+  return String(fn());
+}
+
+// Mirrors website/playground/examples/js/classes.ts: a flat class with private
+// fields read in an instance method + written in the constructor, plus a
+// subclass whose override chains to the parent method via `super`.
+const CLASSES_SOURCE = `
+  class Animal {
+    #name: string;
+    #age: number;
+    constructor(name: string, age: number) {
+      this.#name = name;
+      this.#age = age;
+    }
+    speak(): string {
+      return this.#name + " makes a sound";
+    }
+    describe(): string {
+      return this.#name;
+    }
+  }
+  class Dog extends Animal {
+    #breed: string;
+    constructor(name: string, age: number, breed: string) {
+      super(name, age);
+      this.#breed = breed;
+    }
+    speak(): string {
+      return super.speak() + " — woof!";
+    }
+  }
+  export function test(): string {
+    const rex = new Dog("Rex", 4, "Labrador");
+    return rex.speak() + "|" + rex.describe();
+  }
+`;
+
+describe("#3000 — IR private-field substrate", () => {
+  it("selector claims a flat-class instance method that reads a private field", () => {
+    const sel = selection(CLASSES_SOURCE);
+    const claimed = new Set(sel.classMembers ?? []);
+    // Private-field READ in an instance-method return tail.
+    expect(claimed.has("Animal_speak")).toBe(true);
+    expect(claimed.has("Animal_describe")).toBe(true);
+  });
+
+  it("selector claims a constructor whose body only writes private fields", () => {
+    const sel = selection(CLASSES_SOURCE);
+    const claimed = new Set(sel.classMembers ?? []);
+    // Private-field WRITE in a (flat-class) ctor body. Metric-only: Phase B
+    // integration keeps the legacy ctor body (byte-inert), but the shape gate
+    // no longer rejects it as `body-shape-rejected`.
+    expect(claimed.has("Animal_new")).toBe(true);
+  });
+
+  it("no member of the flat class stays `body-shape-rejected`", () => {
+    const sel = selection(CLASSES_SOURCE);
+    const reasons = new Map<string, string>();
+    for (const fb of sel.fallbacks ?? []) reasons.set(fb.name, fb.reason);
+    expect(reasons.get("Animal_speak")).toBeUndefined();
+    expect(reasons.get("Animal_new")).toBeUndefined();
+    // Inheritance / super members stay class-method (later #3000 phases).
+    expect(reasons.get("Dog_speak")).toBe("class-method");
+  });
+
+  it("compiles + runs: private read via IR, incl. super-dispatch to the IR parent method", async () => {
+    // Dog.speak() (legacy override) calls super.speak() → the now-IR-emitted
+    // Animal_speak with a Dog receiver (WasmGC subtype). Validates the private
+    // `class.get` resolves the correct struct slot across the subtype boundary.
+    expect(await runString(CLASSES_SOURCE)).toBe("Rex makes a sound — woof!|Rex");
+  });
+
+  it("compiles + runs: private field written in ctor, read+concatenated in a method", async () => {
+    // Ctor writes `this.#label` (private WRITE, non-tail body statement) and a
+    // method reads it back (private READ). String-typed so the compile emits a
+    // populated `importObject` (numeric-only class modules trip a pre-existing
+    // empty-importObject harness quirk unrelated to this slice).
+    const src = `
+      class Box {
+        #label: string;
+        constructor(label: string) { this.#label = label; }
+        shout(): string { return this.#label + "!"; }
+      }
+      export function test(): string {
+        const b = new Box("hi");
+        return b.shout();
+      }
+    `;
+    expect(await runString(src)).toBe("hi!");
+  });
+});


### PR DESCRIPTION
## #3000 Phase 1a — IR private-field read/write substrate

The smallest independently-shippable slice of #3000's Phase 1. Teaches the IR
Phase-1 shape gate (`src/ir/select.ts`) and the AST→IR lowerer
(`src/ir/from-ast.ts`) to accept `PrivateIdentifier` field access (`this.#x`).

### Root cause
Both the shape gate and the lowerer gated field access on `ts.isIdentifier(name)`.
A `#x` name is a `ts.PrivateIdentifier`, **not** an `Identifier`, so every
`this.#x` read/write fell into `body-shape-rejected` *before* any
`class.get`/`class.set` logic ran. Everything downstream was already present:
`buildIrClassShapes` reads fields (incl. private slots) from `ctx.structFields`,
and `ClassRegistry.fieldIdx` resolves by the same `structFields` name.

### The load-bearing detail
Legacy `resolveClassMemberName` stores `#name` as `__priv_name`. from-ast
(`irPrivateFieldName`) mangles the `PrivateIdentifier` the **same** way, so the
IR resolves the identical struct slot the legacy path allocated.

### Effect
Clears the two class-member `body-shape-rejected` attributions on
`website/playground/examples/js/classes.ts` (`Animal_new`, `Animal_speak`);
corpus `body-shape-rejected` 25 → 23 (baseline ratcheted).

### Scope / non-goals
- Private **read** in a flat-class instance method is a **real, validated**
  codegen change (flows through Phase B). `classes.ts`'s `Dog.speak()` →
  `super.speak()` → IR `Animal_speak` with a **Dog** (WasmGC subtype) receiver
  reads the correct parent-prefixed slot — output matches legacy exactly.
- Private **write** in a **constructor** is claimed by the selector but Phase B
  does not build `ConstructorDeclaration`s (only `MethodDeclaration`s), so the
  legacy ctor body stays (**byte-inert**). Real ctor IR emission is the separate
  Phase C.
- Accessors (get/set) and inheritance/`super` stay `class-method` — issue
  phases B / C / E (decomposed in the issue file).

### Validation
- `tests/issue-3000.test.ts` (5) — selector claims + runtime parity incl.
  super-dispatch through the IR-emitted parent method.
- `private-class-members` + `ir-slice4-classes` + 3 other class equivalence
  files (22) pass.
- Zero new failures vs base across `tests/ir/*` and class test files (the
  local `classes.ts` / `abstract-classes` / `issue-private-access-brand` /
  `ir/passes` / `inline-small` failures are **pre-existing** — stale
  `{ env: {} }` harnesses + unrelated inline/CF tests, identical with/without
  this change).
- Full test262 conformance = CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)