### PR TITLE
fix(#2988): route standalone globalThis.prop reflective read to native singleton

### DIFF
--- a/plan/issues/2988-standalone-global-object-defineproperty.md
+++ b/plan/issues/2988-standalone-global-object-defineproperty.md
@@ -1,7 +1,9 @@
 ---
 id: 2988
 title: "Standalone defineProperty on the global object (~10, needs global-object own-property MOP)"
-status: ready
+status: done
+assignee: ttraenkler/sr-globaldefine
+completed: 2026-07-03
 sprint: current
 priority: low
 horizon: l
@@ -47,3 +49,64 @@ remaining work. `depends_on` cleared since #2907 is not the active blocker.
 - `Object.defineProperty(globalThis, k, desc)` at top level defines a
   global own property observable by later reads / gOPD; measured flip count with
   zero regressions; gc/host byte-inert; zero `env::` leaks in standalone.
+
+## Resolution (2026-07-03)
+
+**Re-measurement flipped the framing.** The issue text (2026-07-02) said this
+needs "the much larger MOP work" — a reified global own-property table. That was
+already **built** by #2996 (`emitNativeGlobalThisObject`, a lazily-created cached
+native `$Object` singleton) plus the standalone object runtime
+(`ensureObjectRuntime`, which makes `__extern_get` / `__extern_set` /
+`__define_property` DEFINED native helpers). Measuring on current main
+(`bc8a1d4ca`) with `target: standalone` + `nativeStrings`:
+
+- `Object.defineProperty(globalThis, k, desc)` — **host-free already** (the
+  `globalThis` arg reads as the native singleton; `defineProperty` lowers to the
+  native `__define_property` on it).
+- `globalThis.x = v` write, then read via `(globalThis as any).x` — **host-free**,
+  round-trips through the SAME singleton (define + write + gOPD all land in it).
+
+**The one real gap** was narrower than the MOP framing: the reflective bare
+`globalThis.prop` **member-READ** path (`compilePropertyAccess`,
+`src/codegen/property-access.ts` ~L4021) hardcoded
+`__extern_get(__get_globalThis(), key)` **ungated on mode**, so standalone/WASI
+leaked the sole `env::__get_globalThis` import (unsatisfiable in a no-JS-host
+binary). `(globalThis as any).prop` avoided it only because the `as any` cast
+bypasses the `ts.isIdentifier(expr.expression)` special-case and dispatches
+through the any-receiver path (native `__extern_get` on the singleton).
+
+### Fix
+
+In `compilePropertyAccess`'s `globalThis.prop` branch, resolve the receiver
+dual-mode:
+- **host/gc**: `__get_globalThis()` host import (unchanged).
+- **standalone/WASI**: push the native singleton via `emitNativeGlobalThisObject`
+  (the same one define/write use), then `__extern_get` — which is already a
+  DEFINED native helper (routed by `ensureLateImport` → `ensureObjectRuntime`).
+  Falls back to the host import if the object runtime is unavailable.
+
+**Why this is the whole fix and not a symptom patch:** the substrate (singleton +
+native own-property table + native `__extern_get`) already existed and already
+served define / write / gOPD / any-receiver-read; only this one member-read
+site failed to route to it. `__extern_get` and the `__unbox_number` coercion tail
+were *already* native in standalone (`ensureLateImport` lines ~404/408 route
+`UNION_NATIVE_HELPER_NAMES` and `OBJECT_RUNTIME_HELPER_NAMES` to native), so
+`__get_globalThis` was the lone leak.
+
+### Downstream-effect verification
+
+- **Import-registration order preserved** for the host/gc path
+  (`__get_globalThis` before `__extern_get`, as before) so host-import indices
+  don't shift → host/gc byte-identical. Confirmed by sha256 over a 5-snippet
+  corpus in both gc and host modes: **byte-identical** pre/post; standalone
+  hashes change only where `globalThis.prop` appears (`no-gt` snippet unchanged).
+- **Leak-elimination proof**: standalone binaries instantiate with an **empty
+  import object `{}`** and return correct values (42, 5) — any residual `env::`
+  import would throw at instantiate. `envImports(binary)` asserts `[]`.
+- **No regressions**: the 11 globalThis/object-touching test files were run
+  pre/post; the 7 failures (issue-779c `Array.prototype.constructor`, issue-1500
+  fetch host imports ×5, issue-1492 crypto ImportIntent) **all reproduce on the
+  pre-change source** — pre-existing, host-import/environmental, unrelated.
+
+Regression test: `tests/issue-2988.test.ts` (WASM import-section parser +
+functional round-trip + host/gc-unchanged assertion).

--- a/src/codegen/array-object-proto.ts
+++ b/src/codegen/array-object-proto.ts
@@ -1929,14 +1929,14 @@ export function emitTypedArrayIntrinsicCtorObject(ctx: CodegenContext, fctx: Fun
  * `$Object` singleton (stable identity: `globalThis === globalThis`) built with
  * the same `__new_plain_object` runtime an empty `{}` uses — zero host imports.
  *
- * Scope note: this is READ-value substrate only. Reflective READS of specific
- * global bindings (`globalThis.Array`, defineProperty-on-globalThis own-property
- * table, etc.) are the much larger MOP work deferred to #2988 — those go through
- * `compilePropertyAccess`'s dedicated `globalThis.prop` path, which is untouched
- * here (host/gc keeps `__extern_get(__get_globalThis(), key)`; standalone still
- * leaks there, tracked separately). Standalone/WASI only; returns the externref
- * ValType, or `null` if the `$Object` runtime is unavailable (caller falls
- * through to the host-import path).
+ * Scope note: this reifies the READ-value substrate. As of #2988,
+ * `compilePropertyAccess`'s dedicated `globalThis.prop` reflective-read path also
+ * routes to THIS singleton in standalone/WASI (host/gc still uses
+ * `__extern_get(__get_globalThis(), key)`), so reflective reads round-trip with
+ * `Object.defineProperty(globalThis, …)` / `globalThis.x = v` writes host-free
+ * (all three resolve to the one native singleton). Standalone/WASI only; returns
+ * the externref ValType, or `null` if the `$Object` runtime is unavailable
+ * (caller falls through to the host-import path).
  */
 export function emitNativeGlobalThisObject(ctx: CodegenContext, fctx: FunctionContext): ValType | null {
   ensureObjectRuntime(ctx);

--- a/src/codegen/property-access.ts
+++ b/src/codegen/property-access.ts
@@ -101,6 +101,7 @@ import {
   ensureTypedArrayIntrinsicNativeProtoGlue,
   emitTypedArrayIntrinsicCtorObject,
   isWiredTypedArrayViewName,
+  emitNativeGlobalThisObject,
 } from "./array-object-proto.js";
 import { isBuiltinSubtype, isBuiltinTypeName } from "./builtin-tags.js";
 import { getOrRegisterErrorStructType, isWasiErrorName } from "./registry/error-types.js";
@@ -4013,13 +4014,32 @@ export function compilePropertyAccess(
     return { kind: "externref" };
   }
 
-  // Handle globalThis.prop — compile as __extern_get(__get_globalThis(), key)
+  // Handle globalThis.prop — compile as __extern_get(<globalThis>, key)
   // globalThis is a genuine JS object (externref), not a WasmGC struct.
   // Without this handler, the TS type `typeof globalThis` resolves to a struct
   // type and struct.get on a real JS object traps with null deref.
+  //
+  // (#2988) Receiver resolution is dual-mode:
+  //   - host/gc: the `env::__get_globalThis` host import (unchanged).
+  //   - standalone/WASI (no-JS-host): the native `globalThis` `$Object`
+  //     singleton (#2996, `emitNativeGlobalThisObject`) — the SAME singleton that
+  //     `Object.defineProperty(globalThis, k, desc)` and `globalThis.x = v`
+  //     already write onto (both proven host-free), so reflective reads
+  //     round-trip host-free. This retires the last `env::__get_globalThis`
+  //     sole-import leak on the `globalThis.prop` member-read path. `__extern_get`
+  //     itself is already a DEFINED native helper in these modes (routed via
+  //     `ensureLateImport` → `ensureObjectRuntime`), so the read is fully
+  //     host-free. If the native object runtime is unavailable, falls through to
+  //     the host-import path.
   if (ts.isIdentifier(expr.expression) && expr.expression.text === "globalThis") {
-    const gtFuncIdx = ensureLateImport(ctx, "__get_globalThis", [], [{ kind: "externref" }]);
-    // Ensure __extern_get import exists
+    const nativeGlobal = ctx.standalone || ctx.wasi;
+    // Import registration order is preserved for the host/gc path
+    // (`__get_globalThis` then `__extern_get`, as it was before #2988) so that
+    // path stays byte-identical. In standalone/WASI both names resolve to DEFINED
+    // native helpers (no host import added, so ordering is immaterial), and the
+    // `__extern_get` lookup also brings up the object runtime (incl.
+    // `__new_plain_object`) that `emitNativeGlobalThisObject` needs.
+    const gtFuncIdx = nativeGlobal ? undefined : ensureLateImport(ctx, "__get_globalThis", [], [{ kind: "externref" }]);
     const getIdx = ensureLateImport(
       ctx,
       "__extern_get",
@@ -4028,19 +4048,31 @@ export function compilePropertyAccess(
     );
     flushLateImportShifts(ctx, fctx);
 
-    if (gtFuncIdx === undefined || getIdx === undefined) {
+    if (getIdx === undefined || (!nativeGlobal && gtFuncIdx === undefined)) {
       // Fallback: return null externref if imports couldn't be registered
       fctx.body.push({ op: "ref.null.extern" });
       return { kind: "externref" };
     }
 
-    // Emit: __extern_get(__get_globalThis(), key) -> externref
-    fctx.body.push({ op: "call", funcIdx: gtFuncIdx });
+    // Emit: __extern_get(<globalThis receiver>, key) -> externref
+    if (nativeGlobal) {
+      const nativeVt = emitNativeGlobalThisObject(ctx, fctx);
+      if (!nativeVt) {
+        // Native runtime unavailable — fall back to the host import.
+        const gt2 = ensureLateImport(ctx, "__get_globalThis", [], [{ kind: "externref" }]);
+        flushLateImportShifts(ctx, fctx);
+        if (gt2 === undefined) {
+          fctx.body.push({ op: "ref.null.extern" });
+          return { kind: "externref" };
+        }
+        fctx.body.push({ op: "call", funcIdx: gt2 });
+      }
+    } else {
+      fctx.body.push({ op: "call", funcIdx: gtFuncIdx! });
+    }
     addStringConstantGlobal(ctx, propName);
     fctx.body.push(...stringConstantExternrefInstrs(ctx, propName));
-    if (getIdx !== undefined) {
-      fctx.body.push({ op: "call", funcIdx: getIdx });
-    }
+    fctx.body.push({ op: "call", funcIdx: getIdx });
 
     // Coerce externref to expected type
     const accessType = ctx.checker.getTypeAtLocation(expr);

--- a/tests/issue-2988.test.ts
+++ b/tests/issue-2988.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+/**
+ * #2988 — Eliminate the `env::__get_globalThis` leak on the reflective
+ * `globalThis.prop` member-READ path in standalone / WASI mode.
+ *
+ * #2996 reified bare `globalThis` (the identifier value) as a native `$Object`
+ * singleton but deliberately left the `globalThis.prop` reflective read on the
+ * host-import path (`__extern_get(__get_globalThis(), key)`), which leaked
+ * `env::__get_globalThis` under a no-JS-host target. #2988 routes that receiver
+ * to the SAME native singleton — the one `Object.defineProperty(globalThis, k,
+ * desc)` and `globalThis.x = v` already write onto (both were host-free) — so
+ * reflective reads round-trip host-free. `__extern_get` itself is already a
+ * DEFINED native helper in these modes (via `ensureObjectRuntime`), so the whole
+ * read is host-free. Host/gc mode keeps the `__get_globalThis` host import and is
+ * byte-identical.
+ */
+
+/** Parse the WASM import section and return the `env::` import names. */
+function envImports(bin: Uint8Array): string[] {
+  let o = 8;
+  const out: string[] = [];
+  const u32 = () => {
+    let r = 0,
+      s = 0,
+      b: number;
+    do {
+      b = bin[o++];
+      r |= (b & 0x7f) << s;
+      s += 7;
+    } while (b & 0x80);
+    return r >>> 0;
+  };
+  const str = () => {
+    const n = u32();
+    const t = new TextDecoder().decode(bin.subarray(o, o + n));
+    o += n;
+    return t;
+  };
+  while (o < bin.length) {
+    const id = bin[o++];
+    const sz = u32();
+    const end = o + sz;
+    if (id === 2) {
+      const cnt = u32();
+      for (let i = 0; i < cnt; i++) {
+        const m = str();
+        const nm = str();
+        const kind = bin[o++];
+        if (m === "env") out.push(nm);
+        if (kind === 0) u32();
+        else if (kind === 1 || kind === 2) {
+          o++;
+          const f = bin[o++];
+          u32();
+          if (f) u32();
+        } else if (kind === 3) {
+          o += 2;
+        }
+      }
+    }
+    o = end;
+  }
+  return out;
+}
+
+const SA = { fileName: "t.ts", target: "standalone", nativeStrings: true, skipSemanticDiagnostics: true } as const;
+const GC = { fileName: "t.ts", skipSemanticDiagnostics: true } as const;
+
+describe("#2988 standalone globalThis.prop reflective read", () => {
+  it("standalone: define-then-bare-read round-trips host-free", async () => {
+    const src = `
+declare global { var gx: number; }
+export function test(): number {
+  Object.defineProperty(globalThis, "gx", { value: 42, writable: true, configurable: true });
+  return globalThis.gx;
+}`;
+    const r = await compile(src, SA);
+    expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(envImports(r.binary)).not.toContain("__get_globalThis");
+    expect(envImports(r.binary)).toEqual([]);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports.test as () => number)()).toBe(42);
+  });
+
+  it("standalone: bare-write-then-bare-read round-trips host-free", async () => {
+    const src = `
+declare global { var gy: number; }
+export function test(): number {
+  globalThis.gy = 5;
+  return globalThis.gy;
+}`;
+    const r = await compile(src, SA);
+    expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(envImports(r.binary)).not.toContain("__get_globalThis");
+    expect(envImports(r.binary)).toEqual([]);
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports.test as () => number)()).toBe(5);
+  });
+
+  it("standalone: bare read and (as any) read hit the SAME singleton", async () => {
+    // Define via `globalThis`, read via the `(as any)` any-receiver path, and via
+    // the bare `globalThis.prop` path — both must observe the same value, proving
+    // both routes resolve to the one native singleton.
+    const src = `
+declare global { var gz: number; }
+export function test(): number {
+  Object.defineProperty(globalThis, "gz", { value: 7, configurable: true });
+  const viaAny = (globalThis as any).gz as number;
+  const viaBare = globalThis.gz;
+  return viaAny === viaBare && viaBare === 7 ? 1 : 0;
+}`;
+    const r = await compile(src, SA);
+    expect(r.success, r.success ? "" : r.errors.map((e) => e.message).join("\n")).toBe(true);
+    expect(envImports(r.binary)).not.toContain("__get_globalThis");
+    const { instance } = await WebAssembly.instantiate(r.binary, {});
+    expect((instance.exports.test as () => number)()).toBe(1);
+  });
+
+  it("host/gc mode is unchanged — still emits __get_globalThis on globalThis.prop", async () => {
+    const src = `
+declare global { var gx: number; }
+export function test(): number {
+  return globalThis.gx;
+}`;
+    const r = await compile(src, GC);
+    expect(r.success).toBe(true);
+    expect(envImports(r.binary)).toContain("__get_globalThis");
+  });
+});


### PR DESCRIPTION
## #2988 — standalone `globalThis.prop` reflective read

Re-measurement flipped the framing. The issue text called for "the much larger MOP work" (a reified global own-property table) — but that substrate **already exists**: #2996's native `globalThis` `$Object` singleton (`emitNativeGlobalThisObject`) plus the standalone object runtime's DEFINED-native `__extern_get`/`__extern_set`/`__define_property`. On current main, `Object.defineProperty(globalThis, k, desc)`, `globalThis.x = v` write, gOPD readback, and `(globalThis as any).prop` read were **all already host-free** and round-tripped through that singleton.

The **one real gap**: the reflective bare `globalThis.prop` member-READ path (`src/codegen/property-access.ts`) hardcoded `__extern_get(__get_globalThis(), key)` **ungated on mode**, leaking the sole `env::__get_globalThis` host import under standalone/WASI. `(globalThis as any).prop` avoided it only because the `as any` cast bypasses the `isIdentifier` special-case.

### Fix
Resolve the `globalThis.prop` receiver dual-mode:
- **host/gc**: `__get_globalThis()` host import (unchanged).
- **standalone/WASI**: push the native singleton (`emitNativeGlobalThisObject`) — the same one define/write use — then the already-native `__extern_get`. Falls back to the host import if the object runtime is unavailable.

### Downstream-effect verification
- **host/gc byte-inert**: import-registration order preserved (`__get_globalThis` before `__extern_get`) so import indices don't shift. sha256 over a 5-snippet corpus in gc + host modes is **byte-identical** pre/post; only standalone hashes change, and only where `globalThis.prop` appears.
- **leak-elimination proof**: standalone binaries instantiate with an **empty import object `{}`** and return correct values (define→42, write→5); any residual `env::` import would throw at instantiate. Test asserts `envImports(binary) === []`.
- **zero regressions**: the 11 globalThis/object test files were run pre/post — the 7 failures (issue-779c `Array.prototype.constructor`, issue-1500 fetch host imports ×5, issue-1492 crypto ImportIntent) **all reproduce on pre-change source** (host-import/environmental, unrelated).

### Test
`tests/issue-2988.test.ts` — WASM import-section parser (zero `__get_globalThis`), functional round-trip, and host/gc-unchanged assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qS1ZofWnkTair9wfGXVn8