### PR TITLE
fix(#3026): reject trailing comma after rest element in destructuring patterns

### DIFF
--- a/plan/issues/3026-negative-test-fail-early-error-gaps-jul03.md
+++ b/plan/issues/3026-negative-test-fail-early-error-gaps-jul03.md
@@ -5,6 +5,7 @@ status: ready
 sprint: current
 created: 2026-07-03
 updated: 2026-07-03
+status_note: "First slice landed (PR): trailing-comma-after-rest early error in destructuring patterns (all four forms). Issue stays open — remaining unenforced-SyntaxError samples decompose into further independent point-fixes per the issue's own triage note."
 priority: medium
 horizon: s
 feasibility: medium
@@ -63,3 +64,35 @@ individually before batching.
 - `negative_test_fail` count in the default lane drops materially below 79.
 - No new `negative_test_fail` regressions introduced (verify via a
   differential test262 run before/after).
+
+## Slice 1 landed — trailing comma after a rest element (2026-07-03)
+
+**Delivered:** a precise parse-time early error for a trailing comma following
+a rest element in every destructuring-pattern position — an
+`AssignmentRestElement` / `BindingRestElement` / `AssignmentRestProperty` /
+`BindingRestProperty` must be the final element with no trailing comma
+(elision) after it:
+
+- `[...x,] = y` (array assignment pattern) and the for-of/for-in head form
+  `for ([...x,] of ...)` — covers the issue sample
+  `language/statements/for-of/dstr/array-rest-elision-invalid.js`.
+- `const [...x,] = y` (array binding pattern).
+- `({...x,} = y)` (object assignment pattern).
+- `const {...x,} = y` (object binding pattern).
+
+**Root cause:** the pre-existing "rest must be last" check only fired when an
+*element* followed the rest (`[...x, y]`); TypeScript's parser accepts the bare
+trailing comma `[...x,]` silently and does NOT insert a trailing
+`OmittedExpression`, so nothing detected it. Fix keys off the NodeArray's
+`hasTrailingComma` flag when the last element is the rest.
+
+**Files:** `src/compiler/early-errors/assignment.ts` (array + object assignment
+patterns), `src/compiler/early-errors/node-checks.ts` (array + object binding
+patterns). Tests: `tests/issue-3026.test.ts` (5 reject + 5 valid-control
+cases). Byte-inert for all valid programs — spread-with-trailing-comma in an
+array/object literal *value* (`const v = [...x,]`, `{...x,}`) and a trailing
+comma after a non-rest element (`[a,]`, `{a,}`) all remain valid.
+
+**Remaining:** the other unenforced-`SyntaxError` samples (private-name grammar,
+`prop-def-invalid-async-prefix`, etc.) are independent point-fixes per the
+issue's own triage note — issue stays open for follow-up slices.

--- a/src/compiler/early-errors/assignment.ts
+++ b/src/compiler/early-errors/assignment.ts
@@ -59,9 +59,14 @@ export function validateArrayAssignmentPattern(
       validateAssignmentTarget(ctx, target, strict);
     }
   }
-  // If there's a trailing comma after a rest, it creates an elision — already caught above.
-  // But TS may also insert an OmittedExpression at the end for trailing commas.
-  // The check above handles it via "elision after rest".
+  // Trailing comma after a rest element: `[...x,] = y` — a SyntaxError (an
+  // elision may not follow AssignmentRestElement). TS's parser accepts this
+  // without inserting a trailing OmittedExpression, so detect it via the
+  // NodeArray's hasTrailingComma flag when the last element is the rest.
+  const lastElem = arr.elements[arr.elements.length - 1];
+  if (arr.elements.hasTrailingComma && lastElem && ts.isSpreadElement(lastElem)) {
+    ctx.addError(restNode ?? lastElem, "Rest element must be last in a destructuring pattern");
+  }
 }
 
 /**
@@ -101,6 +106,12 @@ export function validateObjectAssignmentPattern(
     if (ts.isMethodDeclaration(prop) || ts.isGetAccessorDeclaration(prop) || ts.isSetAccessorDeclaration(prop)) {
       ctx.addError(prop, "Method definitions are not allowed in assignment patterns");
     }
+  }
+  // Trailing comma after an object rest property: `({...x,} = y)` — a
+  // SyntaxError (AssignmentRestProperty must be last, no trailing comma).
+  const lastProp = obj.properties[obj.properties.length - 1];
+  if (obj.properties.hasTrailingComma && lastProp && ts.isSpreadAssignment(lastProp)) {
+    ctx.addError(lastProp, "Rest element must be last in a destructuring pattern");
   }
 }
 

--- a/src/compiler/early-errors/node-checks.ts
+++ b/src/compiler/early-errors/node-checks.ts
@@ -567,6 +567,22 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
         foundRest = true;
       }
     }
+    // Trailing comma after a binding rest element: `const [...x,] = y` — a
+    // SyntaxError. TS accepts it without a trailing OmittedExpression, so
+    // detect it via the NodeArray's hasTrailingComma flag.
+    const lastEl = node.elements[node.elements.length - 1];
+    if (node.elements.hasTrailingComma && lastEl && ts.isBindingElement(lastEl) && lastEl.dotDotDotToken) {
+      ctx.addError(lastEl, "A rest element must be last in a destructuring pattern");
+    }
+  }
+
+  // ES spec: Trailing comma after an object binding rest is a SyntaxError.
+  // e.g. const {...x,} = y;  BindingRestProperty must be last, no trailing comma.
+  if (ts.isObjectBindingPattern(node)) {
+    const lastEl = node.elements[node.elements.length - 1];
+    if (node.elements.hasTrailingComma && lastEl && ts.isBindingElement(lastEl) && lastEl.dotDotDotToken) {
+      ctx.addError(lastEl, "A rest element must be last in a destructuring pattern");
+    }
   }
 
   // ES spec: Trailing comma after rest parameter is a SyntaxError.

--- a/tests/issue-3026.test.ts
+++ b/tests/issue-3026.test.ts
@@ -1,0 +1,64 @@
+// #3026 — early error: trailing comma after a rest element in a destructuring
+// pattern is a parse-time SyntaxError.
+//
+// The pre-existing "rest must be last" check caught `[...x, y]` (an element
+// following the rest) but missed the bare trailing-comma case `[...x,]` /
+// `({...x,})`. Per ES2015+ grammar, an AssignmentRestElement /
+// BindingRestElement / AssignmentRestProperty / BindingRestProperty must be
+// the final element, and no trailing comma (elision) may follow it. TypeScript's
+// parser accepts the trailing comma silently, so the early-error pass detects it
+// via the NodeArray `hasTrailingComma` flag when the last element is the rest.
+//
+// Guard against false positives: a trailing comma after a NON-rest element
+// (`[a,]`, `{a,}`) is valid, and a spread with a trailing comma in an array/
+// object literal *value* (`[...x,]`, `{...x,}` on the RHS) is valid.
+import { describe, it, expect } from "vitest";
+import { compile } from "../src/index.js";
+
+async function isRejected(src: string): Promise<boolean> {
+  const r = await compile(src, { fileName: "test.ts" });
+  return !r.success;
+}
+
+describe("#3026 — trailing comma after rest element in destructuring pattern", () => {
+  it("rejects trailing comma after array assignment rest (`[...x,] = y`)", async () => {
+    expect(await isRejected("[...x,] = [1, 2];")).toBe(true);
+  });
+
+  it("rejects trailing comma after rest in a for-of head (`for ([...x,] of ...)`)", async () => {
+    expect(await isRejected("for ([...x,] of [[]]) ;")).toBe(true);
+  });
+
+  it("rejects trailing comma after array binding rest (`const [...x,] = y`)", async () => {
+    expect(await isRejected("const [...x,] = [1, 2];")).toBe(true);
+  });
+
+  it("rejects trailing comma after object assignment rest (`({...x,} = y)`)", async () => {
+    expect(await isRejected("({...x,} = {});")).toBe(true);
+  });
+
+  it("rejects trailing comma after object binding rest (`const {...x,} = y`)", async () => {
+    expect(await isRejected("const {...x,} = {};")).toBe(true);
+  });
+
+  // ── Valid controls: must NOT be rejected ──────────────────────────────────
+  it("accepts a spread with trailing comma in an array literal value", async () => {
+    expect(await isRejected("const x = [1]; const v = [...x,];")).toBe(false);
+  });
+
+  it("accepts a spread with trailing comma in an object literal value", async () => {
+    expect(await isRejected("const x = {}; const o = {...x,};")).toBe(false);
+  });
+
+  it("accepts a rest without a trailing comma (`const [...x] = y`)", async () => {
+    expect(await isRejected("const [...x] = [1, 2];")).toBe(false);
+  });
+
+  it("accepts a trailing comma after a non-rest array element (`[a,] = y`)", async () => {
+    expect(await isRejected("let a; [a,] = [1];")).toBe(false);
+  });
+
+  it("accepts a trailing comma after a non-rest object element (`const {a,} = y`)", async () => {
+    expect(await isRejected("const {a,} = {a: 1};")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

First slice of the #3026 `negative_test_fail` early-error bucket. A trailing
comma following a **rest element** in a destructuring pattern is a parse-time
`SyntaxError` per the ES grammar — an `AssignmentRestElement` /
`BindingRestElement` / `AssignmentRestProperty` / `BindingRestProperty` must be
the final element with no elision after it. The compiler previously accepted
these silently.

Fixed in all four pattern positions:
- `[...x,] = y` (array assignment) + for-of head `for ([...x,] of ...)` — the issue's own sample `language/statements/for-of/dstr/array-rest-elision-invalid.js`
- `const [...x,] = y` (array binding)
- `({...x,} = y)` (object assignment)
- `const {...x,} = y` (object binding)

## Root cause

The pre-existing "rest must be last" check only fired when an *element*
followed the rest (`[...x, y]`). TypeScript's parser accepts the bare trailing
comma `[...x,]` without inserting a trailing `OmittedExpression`, so nothing
detected it. The fix keys off the NodeArray's `hasTrailingComma` flag when the
last element is the rest.

## Safety / blast radius

Additive — only flags genuinely-invalid patterns. Verified valid controls stay
valid (spread-with-trailing-comma in an array/object literal **value**
`const v = [...x,]` / `{...x,}`, and trailing comma after a **non-rest** element
`[a,]` / `{a,}`). The assignment-pattern validators only run in pattern
positions, so array/object literal values are untouched.

## Testing

- `tests/issue-3026.test.ts` — 5 reject cases + 5 valid-control cases, all green.
- Neighboring early-error suites (`issue-1931`, `issue-1435`) pass — no regressions.

Issue #3026 stays open: the remaining unenforced-`SyntaxError` samples are
independent point-fixes per the issue's own triage note.

## Files
- `src/compiler/early-errors/assignment.ts`
- `src/compiler/early-errors/node-checks.ts`
- `tests/issue-3026.test.ts`
- `plan/issues/3026-negative-test-fail-early-error-gaps-jul03.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)