### PR TITLE
docs(#3023): correct root-cause — iterator paths pass; real fails are IteratorClose/abrupt-completion runtime

### DIFF
--- a/plan/issues/3023-iterator-protocol-forof-abrupt-completion-residual.md
+++ b/plan/issues/3023-iterator-protocol-forof-abrupt-completion-residual.md
@@ -69,3 +69,78 @@ implementing to avoid duplicate fixes on the shared `for-of/dstr` surface.
   materially below 113.
 - for-of / for-await-of abrupt-completion test262 fails drop materially
   below the combined 395 recorded here.
+
+## Investigation (2026-07-03, dev-3023) — corrects an earlier banked note
+
+An earlier same-day note characterised this as `var [a,b] = obj` (obj an
+`any`-typed custom iterable) yielding **NaN** because the var-decl
+array-destructuring path "index-extracts instead of running the iterator
+protocol". **That characterisation does not hold on current main** — do not
+build a fix around it. Verified findings:
+
+1. **The common iterator-consumption paths already PASS.** With the iterator
+   protocol wired correctly (host `__iterator` / `__iterator_next` bridge, or
+   the source-defined `emitDrainCustomIterableToVec` drain), all of the
+   following return the correct value on current main:
+   - `for (const x of obj)` over a custom iterable (host-provided **and**
+     source-defined object-literal `{ [Symbol.iterator]() {…} }` and
+     class-with-`[Symbol.iterator]`);
+   - `var [a,b] = obj` **and** `const [a,b] = obj` over the same iterables;
+   - trailing-elision assignment-destructuring `[x, ,] = vals` calls `.next()`
+     exactly twice and does **not** call `return()` when the iterator is
+     already done (verified `nextCount=2, returnCount=0`, matching
+     `array-elem-trlg-iter-elision-iter-nrml-close-skip`'s spec expectation).
+   The var-decl externref path (`compileExternrefArrayDestructuringDecl` →
+   `destructureParamArray` in `src/codegen/destructuring-params.ts`) already
+   materialises the source via `__array_from_iter_n` (GetIterator + `.next()`),
+   and the statically-typed custom-iterable path is handled by the
+   `isCustomIterable` branch in `src/codegen/statements/destructuring.ts`
+   (~L1129) draining through `emitDrainCustomIterableToVec`. **A "NaN" repro
+   requires the test harness to omit `setExports`** — without it the host
+   `__iterator` bridge can't call back into the WasmGC struct's exported
+   `@@iterator`, so the value looks non-iterable; that is a harness artifact,
+   not a compiler bug. The CI worker and equivalence harness both call
+   `setExports`.
+
+2. **The two cited sample files are NOT a codegen index-extraction bug.** Both
+   `assignment/dstr/array-elem-trlg-iter-elision-iter-nrml-close-skip.js` and
+   `async-generator/dstr/ary-init-iter-close.js` build their iterable via a
+   **late-bound property assignment** — `var it = {}; it[Symbol.iterator] =
+   function () {…}`. Running them through `src/cli.ts` hard-crashes inside the
+   TypeScript **checker** (`getLateBoundSymbol` →
+   `Cannot read properties of undefined (reading 'flags')`, at
+   `contextuallyCheckFunctionExpressionOrObjectLiteralMethod`) during
+   `getSemanticDiagnostics`. **This crash is NOT what CI/test262 sees** — the
+   test262 worker (`scripts/test262-worker.mjs`) and the `compile()` API both
+   pass `skipSemanticDiagnostics: true`, which bypasses the crashing full-file
+   semantic pass. A 150-file in-process sample across `assignment/dstr` +
+   `async-generator/dstr` produced **0** such crashes and **122/150 compiled
+   OK** — so the residual failures are **runtime spec-conformance**, not
+   compile errors.
+
+3. **Where the real 508 failures live**: subtle spec mechanics on files that
+   *do* compile — `IteratorClose` (`return()`) invocation on **abrupt**
+   completion (`break` / `throw` / labeled `continue` mid-loop) and on
+   over-consumed / early-terminated destructuring; `.next` callability for
+   dynamically-shaped iterators; and for-await ordering / async-iterator close.
+   These are per-edge-case conformance gaps, not one shared index-extraction
+   root cause. This makes #3023 **broader and deeper** than a bounded bugfix —
+   it should be split into targeted sub-slices (each a specific
+   IteratorClose-site or abrupt-completion path with its own test262 group),
+   ideally after coordinating with #2669 on the shared `for-of/dstr` surface,
+   rather than attempted as a single fix.
+
+**Revised guidance for the next dev:**
+- Do **not** target `compileExternrefArrayDestructuringDecl` /
+  `emitDrainCustomIterableToVec` for a "NaN" fix — the common path is correct.
+- Reproduce against the **actual test262 runtime** (via
+  `scripts/test262-worker.mjs`, or `compile(..., {skipSemanticDiagnostics:true})`
+  with `setExports` wired), **not** `src/cli.ts` (its unguarded
+  `getSemanticDiagnostics` crashes on late-bound `[Symbol.iterator]=`).
+- Pick ONE narrow sub-bucket (e.g. for-of `break` → `IteratorClose`) with a
+  concrete failing-file list, verify the `return()`-call gap with an
+  inject-throw / call-count proof, and land it as a scoped slice.
+- Separately, the `src/cli.ts` late-bound-symbol crash is worth a small
+  robustness follow-up (wrap the `getSemanticDiagnostics` call so a TS-internal
+  throw degrades to "no semantic diagnostics" instead of a hard process crash)
+  — it does not move the test262 number and is out of scope for this issue.


### PR DESCRIPTION
## Summary

Docs-only correction to issue #3023's banked root-cause. An earlier same-day note characterised #3023 as `var [a,b] = obj` (any-typed custom iterable) yielding **NaN** via index-extraction instead of the iterator protocol. **I could not reproduce that on current main** — verified the common paths all pass and reframed the issue.

## Verified findings (see the issue file for full detail)

1. **Common iterator-consumption paths already PASS**: `for-of`, `var [a,b]=`, and `const [a,b]=` over custom iterables (host-provided AND source-defined object-literal / class-with-`[Symbol.iterator]`) all run the iterator protocol and return correct values. Trailing-elision assignment-destructuring `[x,,]=vals` calls `.next()` exactly twice and skips `return()` correctly (`nextCount=2, returnCount=0`). The "NaN" repro only appears when the test harness omits `setExports` — a harness artifact, not a compiler bug.
2. **The two cited sample files CE only via `src/cli.ts`** — an unguarded TypeScript `getSemanticDiagnostics` crash (`getLateBoundSymbol`) on late-bound `obj[Symbol.iterator] = function(){}`. **CI does not hit this** — `scripts/test262-worker.mjs` and `compile()` pass `skipSemanticDiagnostics: true`; a 150-file in-process sample produced 0 crashes and 122/150 compiled OK.
3. **The real 508 failures are runtime spec-conformance** on compiling files: `IteratorClose`/`return()` on abrupt completion (`break`/`throw`), `.next` callability for dynamic iterators, for-await ordering. Per-edge-case gaps, not one shared root cause → the issue is reframed as split-into-slices, not a bounded single fix.

## Why docs-only

With <1h before the budget reset, forcing a code fix on a mischaracterised/broader bug was too risky. This banks the corrected, verified root-cause + revised next-dev guidance so the next attempt starts from the true failure mode. Tech-lead-approved.

No source touched — one issue file modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)