### PR TITLE
fix(#3026): reject 'async' prefix on a shorthand object property (early error)

### DIFF
--- a/plan/issues/3026-negative-test-fail-early-error-gaps-jul03.md
+++ b/plan/issues/3026-negative-test-fail-early-error-gaps-jul03.md
@@ -96,3 +96,32 @@ comma after a non-rest element (`[a,]`, `{a,}`) all remain valid.
 **Remaining:** the other unenforced-`SyntaxError` samples (private-name grammar,
 `prop-def-invalid-async-prefix`, etc.) are independent point-fixes per the
 issue's own triage note — issue stays open for follow-up slices.
+
+## Slice 2 landed — `async` prefix on a shorthand property (2026-07-03)
+
+**Delivered:** a precise parse-time early error for `async` used as the prefix
+of a shorthand object property. `PropertyDefinition : IdentifierReference`
+(shorthand) is a bare IdentifierReference and admits no modifier; `async` is
+only valid as the prefix of an `AsyncMethod`, which requires a `(` parameter
+list. Covers the issue sample
+`language/expressions/object/prop-def-invalid-async-prefix.js` (`({async async})`)
+and the cover-initialized-name form `({async x = 1})`.
+
+**Root cause:** TypeScript's parser silently accepts `({async async})` /
+`({async x = 1})` as a `ShorthandPropertyAssignment` carrying an `AsyncKeyword`
+modifier with **no** parse diagnostic — unlike `({get x})` / `({set x})` /
+`({* x})`, which it already flags. So nothing in the early-error pass detected
+it. The fix checks for an `AsyncKeyword` modifier on a
+`ShorthandPropertyAssignment` (the only modifier that produces this node shape
+without a TS parse diagnostic).
+
+**Files:** `src/compiler/early-errors/node-checks.ts` (one additive check next
+to the existing shorthand-property checks). Tests: `tests/issue-3026.test.ts`
+(+2 reject, +4 valid-control cases). Byte-inert for all valid programs —
+`async` as a plain shorthand name (`({async})`), alongside other shorthands
+(`({async, x})`), as an async method (`({async foo(){}})`), and as a normal key
+(`({async: 1})`) all remain valid.
+
+**Remaining:** further unenforced-`SyntaxError` samples (private-name grammar on
+class heritage, `array-rest-elision-invalid` residuals, etc.) remain independent
+point-fixes — issue stays open for follow-up slices.

--- a/src/compiler/early-errors/node-checks.ts
+++ b/src/compiler/early-errors/node-checks.ts
@@ -1096,6 +1096,24 @@ export function runNodeChecks(ctx: EarlyErrorContext, node: ts.Node): void {
     }
   }
 
+  // ── 'async' prefix on a shorthand property ─────────────────────
+  // ES spec: PropertyDefinition : IdentifierReference (shorthand) is a bare
+  // IdentifierReference and admits no modifier. `async` is only valid as the
+  // prefix of an AsyncMethod (which requires a `(` parameter list). TypeScript's
+  // parser silently accepts `({async async})` / `({async x = 1})` as a
+  // ShorthandPropertyAssignment carrying an AsyncKeyword modifier with NO parse
+  // diagnostic (unlike `get`/`set`/`*`, which it already flags), so nothing
+  // detects it. Covers test262
+  // language/expressions/object/prop-def-invalid-async-prefix.
+  if (
+    ts.isShorthandPropertyAssignment(node) &&
+    (node as unknown as { modifiers?: ts.NodeArray<ts.ModifierLike> }).modifiers?.some(
+      (m) => m.kind === ts.SyntaxKind.AsyncKeyword,
+    )
+  ) {
+    ctx.addError(node, "'async' is not a valid prefix of a shorthand property");
+  }
+
   // ── 'let' as shorthand property in strict mode ─────────────────
   // ES spec: 'let' is not a reserved word but cannot be used as a binding
   // identifier in strict mode, and shorthand property acts as IdentifierReference.

--- a/tests/issue-3026.test.ts
+++ b/tests/issue-3026.test.ts
@@ -62,3 +62,39 @@ describe("#3026 — trailing comma after rest element in destructuring pattern",
     expect(await isRejected("const {a,} = {a: 1};")).toBe(false);
   });
 });
+
+// Slice 2 — early error: `async` is not a valid prefix of a shorthand property.
+//
+// PropertyDefinition : IdentifierReference (shorthand) admits no modifier;
+// `async` is only valid as the prefix of an AsyncMethod (which requires a
+// `(` parameter list). TypeScript's parser silently accepts `({async async})`
+// and `({async x = 1})` as a ShorthandPropertyAssignment carrying an
+// AsyncKeyword modifier with NO parse diagnostic (unlike `get`/`set`/`*`,
+// which it already flags), so nothing detected it. Covers test262
+// language/expressions/object/prop-def-invalid-async-prefix.
+describe("#3026 — 'async' prefix on a shorthand property", () => {
+  it("rejects `({async async})`", async () => {
+    expect(await isRejected("({async async});")).toBe(true);
+  });
+
+  it("rejects `({async x = 1})` (async prefix on a cover-initialized name)", async () => {
+    expect(await isRejected("({async x = 1});")).toBe(true);
+  });
+
+  // ── Valid controls: must NOT be rejected ──────────────────────────────────
+  it("accepts `async` used as a plain shorthand property name", async () => {
+    expect(await isRejected("const async = 1; ({async});")).toBe(false);
+  });
+
+  it("accepts `async` as a shorthand alongside other properties", async () => {
+    expect(await isRejected("const async = 1, x = 2; ({async, x});")).toBe(false);
+  });
+
+  it("accepts an actual async method (`({async foo(){}})`)", async () => {
+    expect(await isRejected("({async foo(){}});")).toBe(false);
+  });
+
+  it("accepts `async` as a normal property key (`({async: 1})`)", async () => {
+    expect(await isRejected("({async: 1});")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Slice 2 of #3026 (residual early-error / static-semantics gaps). Adds a precise parse-time early error for `async` used as the prefix of a shorthand object property.

`PropertyDefinition : IdentifierReference` (shorthand) is a bare IdentifierReference and admits no modifier; `async` is only valid as the prefix of an `AsyncMethod`, which requires a `(` parameter list.

## Root cause

TypeScript's parser silently accepts `({async async})` / `({async x = 1})` as a `ShorthandPropertyAssignment` carrying an `AsyncKeyword` modifier with **no** parse diagnostic — unlike `({get x})` / `({set x})` / `({* x})`, which it already flags. So nothing in the early-error pass detected it. The fix checks for an `AsyncKeyword` modifier on a `ShorthandPropertyAssignment` (the only modifier that produces this node shape without a TS parse diagnostic).

## Coverage

- test262 `language/expressions/object/prop-def-invalid-async-prefix.js` (`({async async})`)
- cover-initialized-name form `({async x = 1})`

## Byte-inertness

All valid programs remain valid: `async` as a plain shorthand name (`({async})`), alongside other shorthands (`({async, x})`), as an async method (`({async foo(){}})`), and as a normal key (`({async: 1})`). Additive early-error check only calls `ctx.addError` on the invalid path — no emitted bytes change for accepted programs.

## Files

- `src/compiler/early-errors/node-checks.ts` — one additive check next to the existing shorthand-property checks
- `tests/issue-3026.test.ts` — +2 reject, +4 valid-control cases (16/16 pass)

Issue #3026 stays open — further unenforced-SyntaxError samples remain independent point-fixes for follow-up slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)