### PR TITLE
fix(website): copy the blog page into the Pages build artifact

### DIFF
--- a/plan/issues/1042-async-await-state-machine-lowering.md
+++ b/plan/issues/1042-async-await-state-machine-lowering.md
@@ -5,13 +5,13 @@ status: done
 assignee: ttraenkler/fable-5
 completed: 2026-07-02
 created: 2026-04-11
-updated: 2026-07-02
+updated: 2026-07-03
 priority: high
 horizon: l
 feasibility: hard
 reasoning_effort: max
 goal: async-model
-sprint: current
+sprint: 69
 parent: 1032
 depends_on: [2906]
 related: [2957, 1373b, 2895]

--- a/plan/issues/1336-spec-gap-object-assign-getter-iteration.md
+++ b/plan/issues/1336-spec-gap-object-assign-getter-iteration.md
@@ -4,7 +4,7 @@ title: "spec gap: Object.assign drops getters / Symbol keys (27 of 38 test262 fa
 status: done
 assignee: ttraenkler/sendev-soundness
 created: 2026-05-08
-updated: 2026-06-28
+updated: 2026-07-03
 completed: 2026-06-28
 priority: medium
 feasibility: medium
@@ -13,7 +13,7 @@ task_type: bugfix
 area: codegen, runtime
 language_feature: object
 goal: spec-completeness
-sprint: current
+sprint: 69
 parent: 1328
 ---
 # #1336 — Object.assign: getter invocation + Symbol-key copying

--- a/plan/issues/1627-spec-gap-set-methods-set-like-arg.md
+++ b/plan/issues/1627-spec-gap-set-methods-set-like-arg.md
@@ -3,7 +3,7 @@ id: 1627
 title: "spec gap: Set methods (union/intersection/etc.) accept any set-like argument (101 test262 fails)"
 status: done
 created: 2026-05-08
-updated: 2026-06-28
+updated: 2026-07-03
 completed: 2026-06-28
 assignee: ttraenkler/agent-a20aa13da21b8d592
 priority: medium
@@ -13,7 +13,7 @@ task_type: bugfix
 area: runtime
 language_feature: set
 goal: spec-completeness
-sprint: current
+sprint: 69
 renumbered_from: 1352
 parent: 1328
 ---

--- a/plan/issues/2134-ir-effect-model-ordered-emission.md
+++ b/plan/issues/2134-ir-effect-model-ordered-emission.md
@@ -2,9 +2,9 @@
 id: 2134
 title: "IR effect model: classify instruction kinds, enforce program-order emission for effectful ops"
 status: done
-sprint: current
+sprint: 69
 created: 2026-06-12
-updated: 2026-07-02
+updated: 2026-07-03
 completed: 2026-07-02
 assignee: ttraenkler/dev-2912f
 priority: high

--- a/plan/issues/2138-ir-first-compile-once-inversion.md
+++ b/plan/issues/2138-ir-first-compile-once-inversion.md
@@ -6,9 +6,9 @@ completed: 2026-07-02
 assignee: ttraenkler/dev-2138f
 pipeline_unblocked: 1927
 spec: ready
-sprint: current
+sprint: 69
 created: 2026-06-12
-updated: 2026-07-02
+updated: 2026-07-03
 priority: high
 feasibility: hard
 reasoning_effort: max

--- a/plan/issues/2140-fixbranchtype-coerce-or-throw.md
+++ b/plan/issues/2140-fixbranchtype-coerce-or-throw.md
@@ -5,9 +5,9 @@ status: done
 completed: 2026-07-02
 assignee: ttraenkler/dev-2875f
 blocked_by: [] # 2167 moot — Fable available (owner directive 2026-07-02)
-sprint: current
+sprint: 69
 created: 2026-06-12
-updated: 2026-07-02
+updated: 2026-07-03
 follow_up: 2991 # unconditional-throw promotion (staged; needs measured-zero evidence)
 priority: critical
 feasibility: hard

--- a/plan/issues/2167-fable-model-disabled-blocks-frontier-work.md
+++ b/plan/issues/2167-fable-model-disabled-blocks-frontier-work.md
@@ -3,9 +3,9 @@ id: 2167
 title: "Fable model disabled — frontier-reasoning work blocked"
 status: done
 completed: 2026-07-02
-sprint: current
+sprint: 69
 created: 2026-06-15
-updated: 2026-07-02
+updated: 2026-07-03
 priority: high
 feasibility: external
 reasoning_effort: low

--- a/plan/issues/2181-define-builtin-representation-scaffold.md
+++ b/plan/issues/2181-define-builtin-representation-scaffold.md
@@ -2,9 +2,9 @@
 id: 2181
 title: "defineBuiltin(name, {elementKinds, lower}) scaffold — unify per-representation element-load/ToString/null handling"
 status: done
-sprint: current
+sprint: 69
 created: 2026-06-16
-updated: 2026-06-28
+updated: 2026-07-03
 completed: 2026-06-28
 assignee: ttraenkler/agent-a20aa13da21b8d592
 priority: medium

--- a/plan/issues/2674-acorn-parse-9th-wall-past-tokenizer.md
+++ b/plan/issues/2674-acorn-parse-9th-wall-past-tokenizer.md
@@ -3,9 +3,9 @@ id: 2674
 title: "acorn parse() 9th wall PAST tokenization (after #2664 type-write fix) — parseTopLevel/parseStatement array-push loop"
 status: done
 assignee: ttraenkler/sd-2674c
-sprint: current
+sprint: 69
 created: 2026-06-25
-updated: 2026-06-28
+updated: 2026-07-03
 completed: 2026-06-28
 priority: high
 feasibility: hard

--- a/plan/issues/2676-es3-mapped-arguments-strict-delete-aliased-throw.md
+++ b/plan/issues/2676-es3-mapped-arguments-strict-delete-aliased-throw.md
@@ -4,7 +4,7 @@ title: "≤ES3: mapped arguments — strict-mode aliased `delete args[i]` must t
 status: done
 assignee: ttraenkler/es3-2676
 created: 2026-06-25
-updated: 2026-06-30
+updated: 2026-07-03
 completed: 2026-06-30
 priority: high
 feasibility: hard
@@ -16,7 +16,7 @@ language_feature: arguments-object
 goal: spec-completeness
 depends_on: []
 related: [2667, 1511]
-sprint: current
+sprint: 69
 ---
 # #2676 — ≤ES3 mapped-arguments strict aliased delete throws (residual of #2667)
 

--- a/plan/issues/2681-acorn-parse-10th-wall-unexpected-on-name.md
+++ b/plan/issues/2681-acorn-parse-10th-wall-unexpected-on-name.md
@@ -4,9 +4,9 @@ title: "[ARCH] acorn parse() 10th wall — identifier expression-statement throw
 status: done
 completed: 2026-06-29
 assignee: ttraenkler/sendev-substrate
-sprint: current
+sprint: 69
 created: 2026-06-26
-updated: 2026-06-28
+updated: 2026-07-03
 priority: high
 feasibility: hard
 reasoning_effort: high

--- a/plan/issues/2686-acorn-binary-expression-throws.md
+++ b/plan/issues/2686-acorn-binary-expression-throws.md
@@ -4,9 +4,9 @@ title: "[ARCH] acorn parse() — binary-expression statement throws (parse(\"1 +
 status: done
 completed: 2026-06-29
 assignee: ttraenkler/sendev-substrate
-sprint: current
+sprint: 69
 created: 2026-06-26
-updated: 2026-06-28
+updated: 2026-07-03
 priority: medium
 feasibility: hard
 reasoning_effort: high

--- a/plan/issues/2714-object-spread-keys-not-enumerable.md
+++ b/plan/issues/2714-object-spread-keys-not-enumerable.md
@@ -4,7 +4,7 @@ title: "Object spread copies values but the copied keys are not enumerable (Obje
 status: done
 assignee: ttraenkler/sendev-soundness
 created: 2026-06-26
-updated: 2026-06-28
+updated: 2026-07-03
 completed: 2026-06-28
 priority: medium
 feasibility: medium
@@ -12,7 +12,7 @@ task_type: bugfix
 area: codegen
 language_feature: object-spread, Object.keys
 goal: spec-completeness
-sprint: current
+sprint: 69
 parent: 2709
 related: [2709, 1551]
 ---

--- a/plan/issues/2729-wasmgc-uint8array-store-skips-touint8.md
+++ b/plan/issues/2729-wasmgc-uint8array-store-skips-touint8.md
@@ -3,7 +3,7 @@ id: 2729
 title: "WasmGC backend: new Uint8Array(n) element store skips ToUint8 (u[0]=257 reads 257, u[0]=NaN reads NaN)"
 status: done
 assignee: ttraenkler/agent-aa6c288d8cd3cb14b
-sprint: current
+sprint: 69
 created: 2026-06-26
 completed: 2026-06-28
 priority: medium

--- a/plan/issues/2745-function-prototype-bind-partial-application-length-newtarget.md
+++ b/plan/issues/2745-function-prototype-bind-partial-application-length-newtarget.md
@@ -4,9 +4,9 @@ title: "Function.prototype.bind: bound partial-application arguments, bound `.le
 status: done
 completed: 2026-06-28
 assignee: ttraenkler/agent-a3bfd116a51704f18
-sprint: current
+sprint: 69
 created: 2026-06-27
-updated: 2026-06-28
+updated: 2026-07-03
 priority: medium
 feasibility: medium
 reasoning_effort: medium

--- a/plan/issues/2751-budget-windowed-rolling-sprint-model.md
+++ b/plan/issues/2751-budget-windowed-rolling-sprint-model.md
@@ -2,9 +2,9 @@
 id: 2751
 title: "Budget-windowed rolling sprint model: sprint:current queue + budget-triggered freeze + auto-sync to TaskList"
 status: done
-sprint: current
+sprint: 69
 created: 2026-06-27
-updated: 2026-06-27
+updated: 2026-07-03
 completed: 2026-06-27
 priority: high
 horizon: l

--- a/plan/issues/2752-stdin-prelude-fails-js-parse.md
+++ b/plan/issues/2752-stdin-prelude-fails-js-parse.md
@@ -7,7 +7,7 @@ feasibility: hard
 status: done
 completed: 2026-06-27
 assignee: ttraenkler/sdev-2752-prelude-js
-sprint: current
+sprint: 69
 ---
 
 ## Problem

--- a/plan/issues/2754-sound-ts-settings-ts-and-js.md
+++ b/plan/issues/2754-sound-ts-settings-ts-and-js.md
@@ -3,7 +3,7 @@ id: 2754
 title: "Sound TS checker settings for .ts AND .js + codegen defensive-correctness where TS is deliberately unsound (#2698 track)"
 status: done
 created: 2026-06-27
-updated: 2026-06-28
+updated: 2026-07-03
 completed: 2026-06-28
 assignee: "ttraenkler/sendev-2754"
 priority: high
@@ -13,7 +13,7 @@ task_type: architecture
 area: checker
 language_feature: type-soundness
 goal: platform
-sprint: current
+sprint: 69
 es_edition: n/a
 parent: 2698
 related: [2698, 2748, 389]

--- a/plan/issues/2755-evaluate-type-soundness-approach.md
+++ b/plan/issues/2755-evaluate-type-soundness-approach.md
@@ -2,9 +2,9 @@
 id: 2755
 title: "Decide the type-soundness approach: trust-the-type-and-patch vs JS-semantics-first"
 status: done
-sprint: current
+sprint: 69
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 completed: 2026-06-28
 decision: hybrid
 priority: high

--- a/plan/issues/2756-array-ptrn-obj-class-default-nullderef.md
+++ b/plan/issues/2756-array-ptrn-obj-class-default-nullderef.md
@@ -4,7 +4,7 @@ title: "Array-pattern element with an object-literal / class-expression default 
 status: done
 assignee: ttraenkler/sd-dstr-objdefault
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 completed: 2026-06-28
 priority: high
 feasibility: hard
@@ -16,7 +16,7 @@ language_feature: destructuring
 goal: spec-completeness
 parent: 2669
 related: [2669, 2203, 2032]
-sprint: current
+sprint: 69
 ---
 
 # #2756 — array-pattern element with object/class default value null-derefs

--- a/plan/issues/2757-assign-dstr-rest-hole-wrong-value.md
+++ b/plan/issues/2757-assign-dstr-rest-hole-wrong-value.md
@@ -5,7 +5,7 @@ status: done
 assignee: ttraenkler/agent-dev
 completed: 2026-06-28
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 priority: high
 feasibility: medium
 reasoning_effort: high
@@ -16,7 +16,7 @@ language_feature: destructuring
 goal: spec-completeness
 parent: 2669
 related: [2669]
-sprint: current
+sprint: 69
 ---
 # #2757 — assignment-destructuring rest/hole wrong value
 

--- a/plan/issues/2758-dstr-default-side-effect-skipped-arm.md
+++ b/plan/issues/2758-dstr-default-side-effect-skipped-arm.md
@@ -5,7 +5,7 @@ status: done
 assignee: ttraenkler/dstr758
 completed: 2026-06-28
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -16,7 +16,7 @@ language_feature: destructuring
 goal: spec-completeness
 parent: 2669
 related: [2669, 2692]
-sprint: current
+sprint: 69
 ---
 # #2758 — dstr default-init side-effect on init-skipped
 

--- a/plan/issues/2760-hybrid-floor-plain-array-oob-undefined.md
+++ b/plan/issues/2760-hybrid-floor-plain-array-oob-undefined.md
@@ -4,9 +4,9 @@ title: "Hybrid floor F1: plain-array OOB read → JS `undefined` (HI-style #2198
 status: done
 assignee: ttraenkler/senior-dev-2760
 completed: 2026-06-28
-sprint: current
+sprint: 69
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 priority: high
 horizon: m
 feasibility: medium

--- a/plan/issues/2762-hybrid-fastpath-safety-audit-checklist.md
+++ b/plan/issues/2762-hybrid-fastpath-safety-audit-checklist.md
@@ -2,9 +2,9 @@
 id: 2762
 title: "Hybrid migration-cost audit: type-directed fast-path safety-predicate checklist (living doc)"
 status: done
-sprint: current
+sprint: 69
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 completed: 2026-06-28
 priority: high
 horizon: s

--- a/plan/issues/2764-call-fn-method-export-drops-argc-arguments-length.md
+++ b/plan/issues/2764-call-fn-method-export-drops-argc-arguments-length.md
@@ -2,9 +2,9 @@
 id: 2764
 title: "@@hasInstance handler invoked at unknown-arity (arguments.length wrong) — dispatcher half fixed by #2213; one-line residual"
 status: done
-sprint: current
+sprint: 69
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 completed: 2026-06-28
 assignee: ttraenkler/agent-a2da3f181c62e4768
 priority: medium

--- a/plan/issues/2766-hybrid-ir-elementaccess-prove-then-specialize.md
+++ b/plan/issues/2766-hybrid-ir-elementaccess-prove-then-specialize.md
@@ -3,9 +3,9 @@ id: 2766
 title: "Hybrid IR step 1: ElementAccess prove-then-specialize — vec.get only when in-bounds is proven, else SAFE bounds-checked read"
 status: done
 assignee: ttraenkler/sendev-2766
-sprint: current
+sprint: 69
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 completed: 2026-06-28
 priority: high
 horizon: m

--- a/plan/issues/2767-bare-var-nominal-receiver-dispatch.md
+++ b/plan/issues/2767-bare-var-nominal-receiver-dispatch.md
@@ -2,12 +2,12 @@
 id: 2767
 title: "nominal value assigned into an uninitialized/untyped var loses its type → method dispatch goes dynamic and fails (var d; d = new Date(0); d.toISOString())"
 status: done
-sprint: current
+sprint: 69
 priority: high
 assignee: ttraenkler/agent-dev
 completed: 2026-06-28
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 feasibility: medium
 reasoning_effort: high
 task_type: bugfix

--- a/plan/issues/2769-forof-typed-inbounds-undefined-default.md
+++ b/plan/issues/2769-forof-typed-inbounds-undefined-default.md
@@ -5,7 +5,7 @@ status: done
 assignee: ttraenkler/forof769
 completed: 2026-06-28
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 priority: medium
 feasibility: hard
 reasoning_effort: high
@@ -15,7 +15,7 @@ es_edition: 2015
 language_feature: destructuring
 goal: spec-completeness
 related: [2669, 2216]
-sprint: current
+sprint: 69
 ---
 
 # #2769 — for-of typed in-bounds `undefined`/hole default-init (architect carve)

--- a/plan/issues/2770-dynamic-dispatch-boolean-boxing.md
+++ b/plan/issues/2770-dynamic-dispatch-boolean-boxing.md
@@ -3,10 +3,10 @@ id: 2770
 title: "dynamic builtin boolean-method on a bare-var/dynamic receiver boxes the i32 result as a NUMBER not a boolean (set.has/map.has/re.test → 1 not true)"
 status: done
 assignee: ttraenkler/sendev-s5b-bool-brand
-sprint: current
+sprint: 69
 priority: high
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 completed: 2026-06-28
 feasibility: medium
 reasoning_effort: high

--- a/plan/issues/2771-cli-relative-import-bundling-standalone.md
+++ b/plan/issues/2771-cli-relative-import-bundling-standalone.md
@@ -12,7 +12,7 @@ task_type: feature
 area: compiler
 goal: platform
 related: [2756, 389, 2655]
-sprint: current
+sprint: 69
 ---
 
 # #2771 — bundle relative imports for standalone WASI compilation

--- a/plan/issues/2774-edition-card-summary-pct-vs-feature-rows.md
+++ b/plan/issues/2774-edition-card-summary-pct-vs-feature-rows.md
@@ -2,7 +2,7 @@
 id: 2774
 title: Landing-page edition card summary % doesn't reconcile with its feature rows
 status: done
-sprint: current
+sprint: 69
 priority: low
 horizon: s
 feasibility: easy

--- a/plan/issues/2775-nm-shared-sync-framing-refactor.md
+++ b/plan/issues/2775-nm-shared-sync-framing-refactor.md
@@ -11,7 +11,7 @@ task_type: refactor
 area: examples
 goal: developer-experience
 related: [389, 2655, 2657, 2684, 2752, 2776, 2771, 2777]
-sprint: current
+sprint: 69
 ---
 
 # #2775 — Native Messaging examples: rename to host scheme + scale matrix

--- a/plan/issues/2778-nm-shared-sync-core-dedup.md
+++ b/plan/issues/2778-nm-shared-sync-core-dedup.md
@@ -11,7 +11,7 @@ task_type: refactor
 area: examples
 goal: platform
 related: [2775, 2771, 389, 2655, 2779]
-sprint: current
+sprint: 69
 ---
 
 # #2778 — share one sync framing core for nm_deno + nm_node_fs

--- a/plan/issues/2780-hybrid-ir-arrayliteral-widening-escape.md
+++ b/plan/issues/2780-hybrid-ir-arrayliteral-widening-escape.md
@@ -2,9 +2,9 @@
 id: 2780
 title: "Hybrid IR step 2: ArrayLiteral widening-escape check — vec.new_fixed only when the literal does not flow into an any/heterogeneous sink"
 status: done
-sprint: current
+sprint: 69
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 completed: 2026-06-28
 assignee: ttraenkler/sendev-arraylit-widening
 priority: medium

--- a/plan/issues/2781-hybrid-ir-binary-proof-gate.md
+++ b/plan/issues/2781-hybrid-ir-binary-proof-gate.md
@@ -2,9 +2,9 @@
 id: 2781
 title: "Hybrid IR step 3: Binary `+` string-or-number proof-gate — unboxed numeric add / string concat only when the operand TS types are PROVEN, else SAFE dynamic `+`"
 status: done
-sprint: current
+sprint: 69
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 completed: 2026-06-28
 assignee: ttraenkler/sendev-binproof
 priority: medium

--- a/plan/issues/2782-hybrid-ir-nobox-number-locals.md
+++ b/plan/issues/2782-hybrid-ir-nobox-number-locals.md
@@ -2,9 +2,9 @@
 id: 2782
 title: "Hybrid IR Row 5 — no-box NUMBER-local proof gate"
 status: done
-sprint: current
+sprint: 69
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 completed: 2026-06-28
 priority: medium
 horizon: m

--- a/plan/issues/2783-general-link-dynamic-linking-flag.md
+++ b/plan/issues/2783-general-link-dynamic-linking-flag.md
@@ -2,7 +2,7 @@
 id: 2783
 title: "General --link <namespace> dynamic-linking flag (generalize --link-node-shims)"
 status: done
-sprint: current
+sprint: 69
 created: 2026-06-28
 completed: 2026-06-28
 assignee: ttraenkler/agent-a957b1b8ea8d85c4a

--- a/plan/issues/2784-s3-array-host-boundary-struct-identity.md
+++ b/plan/issues/2784-s3-array-host-boundary-struct-identity.md
@@ -4,13 +4,13 @@ title: "[SENIOR-DEV ONLY] S3 of #2773 — array-element / host-boundary native s
 status: done
 completed: 2026-06-28
 assignee: ttraenkler/sendev-substrate
-sprint: current
+sprint: 69
 priority: high
 horizon: l
 feasibility: hard
 reasoning_effort: high
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 task_type: bugfix
 area: codegen
 language_feature: value-representation

--- a/plan/issues/2785-hybrid-type-aware-box-primitive.md
+++ b/plan/issues/2785-hybrid-type-aware-box-primitive.md
@@ -4,9 +4,9 @@ title: "Hybrid: type-aware box primitive (box keyed on the TS type, not the Wasm
 status: done
 completed: 2026-06-28
 assignee: ttraenkler/sendev-box
-sprint: current
+sprint: 69
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 priority: high
 horizon: m
 feasibility: hard

--- a/plan/issues/2786-autoenqueue-server-side-primary.md
+++ b/plan/issues/2786-autoenqueue-server-side-primary.md
@@ -2,7 +2,7 @@
 id: 2786
 title: "Auto-enqueue: make the server-side workflow_run path the single primary; drop the per-agent enqueue and the grace window"
 status: done
-sprint: current
+sprint: 69
 created: 2026-06-28
 completed: 2026-06-28
 priority: high

--- a/plan/issues/2788-diff-test-malformed-wasm-module-init.md
+++ b/plan/issues/2788-diff-test-malformed-wasm-module-init.md
@@ -4,9 +4,9 @@ title: "malformed_wasm: __module_init call type mismatch (array/01-basic, closur
 status: done
 assignee: ttraenkler/sdev-2788-malformed
 completed: 2026-06-28
-sprint: current
+sprint: 69
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 priority: high
 feasibility: medium
 reasoning_effort: medium

--- a/plan/issues/2789-hybrid-packed-i32-readside-proof.md
+++ b/plan/issues/2789-hybrid-packed-i32-readside-proof.md
@@ -2,10 +2,10 @@
 id: 2789
 title: "Hybrid fast-path Row 3: packed-i32 array read-side soundness — demote overflow/-0 writes to f64 (miscompile fix)"
 status: done
-sprint: current
+sprint: 69
 created: 2026-06-28
 completed: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 assignee: ttraenkler/senior-developer
 priority: medium
 horizon: m

--- a/plan/issues/2790-hybrid-ir-nobox-i32-number-local.md
+++ b/plan/issues/2790-hybrid-ir-nobox-i32-number-local.md
@@ -2,9 +2,9 @@
 id: 2790
 title: "Hybrid IR — no-box NUMBER-local proof gate, i32 arm (#2782 fast-follow, unblocked by #2785)"
 status: done
-sprint: current
+sprint: 69
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 completed: 2026-06-28
 priority: medium
 horizon: m

--- a/plan/issues/2791-hybrid-monomorphic-struct-proof.md
+++ b/plan/issues/2791-hybrid-monomorphic-struct-proof.md
@@ -2,9 +2,9 @@
 id: 2791
 title: "Hybrid audit Row 4 — monomorphic struct.get/set soundness (read discharged; real miscompile is structural-narrowing copy, not Row 4)"
 status: done
-sprint: current
+sprint: 69
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 completed: 2026-06-28
 priority: medium
 horizon: m

--- a/plan/issues/2792-hybrid-symbol-array-oob-undefined.md
+++ b/plan/issues/2792-hybrid-symbol-array-oob-undefined.md
@@ -4,9 +4,9 @@ title: "Hybrid: host symbol[] OOB → undefined (completes #2785 F1 host half; s
 status: done
 completed: 2026-06-28
 assignee: ttraenkler/sendev-symbox
-sprint: current
+sprint: 69
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 priority: medium
 horizon: m
 feasibility: hard

--- a/plan/issues/2794-acorn-vardecl-binexpr-throw.md
+++ b/plan/issues/2794-acorn-vardecl-binexpr-throw.md
@@ -3,13 +3,13 @@ id: 2794
 title: "[SENIOR-DEV ONLY] acorn parse() var-declaration THROW — AST-Node-as-closureBridge + vec read-methods (host-proxy layer); closes #2681"
 status: done
 assignee: ttraenkler/sendev-acorn
-sprint: current
+sprint: 69
 priority: high
 horizon: l
 feasibility: hard
 reasoning_effort: high
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 completed: 2026-06-28
 task_type: bugfix
 area: codegen

--- a/plan/issues/2795-diff-host-value-to-string-rendering.md
+++ b/plan/issues/2795-diff-host-value-to-string-rendering.md
@@ -3,9 +3,9 @@ id: 2795
 title: "diff-test host path: value→string rendering — object toString/@@toPrimitive ignored + boolean prints as 1/0"
 status: done
 completed: 2026-06-28
-sprint: current
+sprint: 69
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 priority: high
 feasibility: medium
 reasoning_effort: medium

--- a/plan/issues/2796-diff-host-dynamic-object-enumerate-copy.md
+++ b/plan/issues/2796-diff-host-dynamic-object-enumerate-copy.md
@@ -3,9 +3,9 @@ id: 2796
 title: "diff-test host path: dynamic-object own-key enumerate/copy — for-in empty, spread loses values, Object.assign loses keys"
 status: done
 completed: 2026-06-28
-sprint: current
+sprint: 69
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 priority: high
 feasibility: medium
 reasoning_effort: medium

--- a/plan/issues/2798-hybrid-typed-array-oob-undefined.md
+++ b/plan/issues/2798-hybrid-typed-array-oob-undefined.md
@@ -4,9 +4,9 @@ title: "Hybrid Row 9: typed-array element OOB → undefined (call-site policy, s
 status: done
 completed: 2026-06-28
 assignee: ttraenkler/sendev-taoob
-sprint: current
+sprint: 69
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 priority: medium
 horizon: m
 feasibility: hard

--- a/plan/issues/2800-top-level-new-objliteral-arg-null.md
+++ b/plan/issues/2800-top-level-new-objliteral-arg-null.md
@@ -3,13 +3,13 @@ id: 2800
 title: "[SENIOR-DEV ONLY] top-level `new X(objLiteral)` reads the literal arg's fields as null at module-init (type-index remap)"
 status: done
 assignee: ttraenkler/senior-developer
-sprint: current
+sprint: 69
 priority: high
 horizon: l
 feasibility: hard
 reasoning_effort: max
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 completed: 2026-06-28
 task_type: bugfix
 area: codegen

--- a/plan/issues/2801-callexpression-arguments-marshal-empty-object.md
+++ b/plan/issues/2801-callexpression-arguments-marshal-empty-object.md
@@ -4,13 +4,13 @@ title: "[SENIOR-DEV ONLY] compiled-acorn CallExpression `arguments` marshals as 
 status: done
 completed: 2026-06-29
 assignee: ttraenkler/unassigned
-sprint: current
+sprint: 69
 priority: high
 horizon: m
 feasibility: hard
 reasoning_effort: high
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 task_type: bugfix
 area: codegen
 language_feature: value-representation

--- a/plan/issues/2804-host-object-spread-assign-value-copy.md
+++ b/plan/issues/2804-host-object-spread-assign-value-copy.md
@@ -3,9 +3,9 @@ id: 2804
 title: "host path: object spread `{...a}` & Object.assign drop copied values/keys (closed-struct representation mismatch)"
 status: done
 assignee: ttraenkler/sendev-objspread
-sprint: current
+sprint: 69
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 completed: 2026-06-28
 priority: medium
 feasibility: medium

--- a/plan/issues/2805-init-time-any-receiver-write-host-set.md
+++ b/plan/issues/2805-init-time-any-receiver-write-host-set.md
@@ -3,13 +3,13 @@ id: 2805
 title: "init-time `any`-receiver field WRITE dropped at module-init (symmetric write side of #2800)"
 status: done
 assignee: ttraenkler/senior-developer
-sprint: current
+sprint: 69
 priority: medium
 horizon: m
 feasibility: hard
 reasoning_effort: max
 created: 2026-06-28
-updated: 2026-07-02
+updated: 2026-07-03
 completed: 2026-07-02
 task_type: bugfix
 area: codegen

--- a/plan/issues/2806-untyped-array-literal-numeric-vec-drops-ref-pushes.md
+++ b/plan/issues/2806-untyped-array-literal-numeric-vec-drops-ref-pushes.md
@@ -4,7 +4,7 @@ title: "[SENIOR-DEV ONLY] untyped `[]` array literal lowers to a NUMERIC (f64) v
 status: done
 assignee: ttraenkler/senior-dev
 completed: 2026-06-28
-sprint: current
+sprint: 69
 priority: high
 horizon: l
 feasibility: hard

--- a/plan/issues/2807-nm-node-process-128mib-zero-output.md
+++ b/plan/issues/2807-nm-node-process-128mib-zero-output.md
@@ -5,14 +5,14 @@ status: done
 assignee: ttraenkler/sendev-2807
 completed: 2026-06-28
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 priority: high
 feasibility: hard
 task_type: bug
 area: runtime
 language_feature: native-messaging
 goal: platform
-sprint: current
+sprint: 69
 horizon: l
 related: [389, 2754, 2775, 2777, 1767]
 ---

--- a/plan/issues/2808-forof-object-binding-nested-subpattern.md
+++ b/plan/issues/2808-forof-object-binding-nested-subpattern.md
@@ -14,7 +14,7 @@ area: codegen
 es_edition: 2015
 language_feature: destructuring
 goal: spec-completeness
-sprint: current
+sprint: 69
 ---
 
 # #2808 — for-of OBJECT-binding head drops nested sub-patterns

--- a/plan/issues/2809-undefined-array-representation-conflation.md
+++ b/plan/issues/2809-undefined-array-representation-conflation.md
@@ -5,7 +5,7 @@ status: done
 completed: 2026-06-29
 assignee: ttraenkler/senior-developer
 supersedes: 2284
-sprint: current
+sprint: 69
 priority: high
 horizon: l
 feasibility: hard

--- a/plan/issues/2810-nm-node-process-rechunk-writes.md
+++ b/plan/issues/2810-nm-node-process-rechunk-writes.md
@@ -5,14 +5,14 @@ status: done
 assignee: ttraenkler/agent-ad343
 completed: 2026-06-28
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-07-03
 priority: medium
 feasibility: medium
 task_type: refactor
 area: runtime
 language_feature: native-messaging
 goal: platform
-sprint: current
+sprint: 69
 horizon: m
 related: [389, 2807, 2775, 2778]
 ---

--- a/plan/issues/2811-dstr-captured-builtin-name-and-dstr-param-closure-offset.md
+++ b/plan/issues/2811-dstr-captured-builtin-name-and-dstr-param-closure-offset.md
@@ -14,7 +14,7 @@ area: codegen
 es_edition: 2015
 language_feature: destructuring
 goal: spec-completeness
-sprint: current
+sprint: 69
 horizon: m
 related: [2669, 2758, 2808, 1205, 1607, 1177]
 ---

--- a/plan/issues/2812-native-messaging-deployment-recipe.md
+++ b/plan/issues/2812-native-messaging-deployment-recipe.md
@@ -5,14 +5,14 @@ status: done
 completed: 2026-07-02
 assignee: ttraenkler/agent-a45493
 created: 2026-06-29
-updated: 2026-07-02
+updated: 2026-07-03
 priority: medium
 feasibility: medium
 task_type: docs
 area: examples
 language_feature: native-messaging
 goal: platform
-sprint: current
+sprint: 69
 horizon: m
 related: [389, 2778, 2807]
 ---

--- a/plan/issues/2813-run-wasi-output-across-runtimes-doc.md
+++ b/plan/issues/2813-run-wasi-output-across-runtimes-doc.md
@@ -4,13 +4,13 @@ title: "Doc: running js2wasm --target wasi output across runtimes (wasmtime / bu
 status: done
 completed: 2026-06-30
 created: 2026-06-29
-updated: 2026-06-30
+updated: 2026-07-03
 priority: low
 feasibility: easy
 task_type: docs
 area: docs
 goal: platform
-sprint: current
+sprint: 69
 horizon: s
 related: [389, 2812]
 ---

--- a/plan/issues/2814-all-nm-hosts-rechunk.md
+++ b/plan/issues/2814-all-nm-hosts-rechunk.md
@@ -2,7 +2,7 @@
 id: 2814
 title: All Native-Messaging example hosts must re-chunk (≤1 MiB JSON frames)
 status: done
-sprint: current
+sprint: 69
 priority: medium
 area: examples
 related: [389, 2807, 2810, 2775]

--- a/plan/issues/2815-suppress-deno-not-found-warning.md
+++ b/plan/issues/2815-suppress-deno-not-found-warning.md
@@ -2,7 +2,7 @@
 id: 2815
 title: "Suppress spurious 'Cannot find name Deno' (TS2304) warning on the recognized Deno stdio surface"
 status: done
-sprint: current
+sprint: 69
 priority: low
 area: checker
 related: [389, 2684, 1951, 2603]

--- a/plan/issues/2816-cli-default-output-dir-cwd.md
+++ b/plan/issues/2816-cli-default-output-dir-cwd.md
@@ -2,7 +2,7 @@
 id: 2816
 title: CLI default output dir should be the cwd, not next to the input
 status: done
-sprint: current
+sprint: 69
 priority: medium
 area: cli
 related: [389]

--- a/plan/issues/2817-wasistdinstop-host-import-no-wasi-fallback.md
+++ b/plan/issues/2817-wasistdinstop-host-import-no-wasi-fallback.md
@@ -4,7 +4,7 @@ title: "nm_node_process: env.__wasiStdinStop host import has no WASI-native fall
 status: done
 assignee: ttraenkler/sendev
 created: 2026-06-29
-updated: 2026-06-29
+updated: 2026-07-03
 completed: 2026-06-29
 priority: medium
 feasibility: medium
@@ -12,7 +12,7 @@ task_type: bug
 area: codegen
 language_feature: process-stdin-async-reactor
 goal: platform
-sprint: current
+sprint: 69
 horizon: m
 related: [389, 2735, 2807, 2777]
 ---

--- a/plan/issues/2818-block-let-captured-by-class-method-captured-globals-ordering.md
+++ b/plan/issues/2818-block-let-captured-by-class-method-captured-globals-ordering.md
@@ -15,7 +15,7 @@ area: codegen
 es_edition: 2015
 language_feature: closures
 goal: spec-completeness
-sprint: current
+sprint: 69
 horizon: m
 architect_spec: done
 ---

--- a/plan/issues/2820-block-let-captured-by-hoisted-fndecl-duplicate-local.md
+++ b/plan/issues/2820-block-let-captured-by-hoisted-fndecl-duplicate-local.md
@@ -15,7 +15,7 @@ area: codegen
 es_edition: 2015
 language_feature: closures
 goal: spec-completeness
-sprint: current
+sprint: 69
 horizon: m
 ---
 

--- a/plan/issues/2821-harden-deno-stdio-epipe-flake.md
+++ b/plan/issues/2821-harden-deno-stdio-epipe-flake.md
@@ -2,7 +2,7 @@
 id: 2821
 title: "Harden the flaky EPIPE in tests/issue-2684-deno-stdio.test.ts"
 status: done
-sprint: current
+sprint: 69
 priority: medium
 area: tests
 task_type: test

--- a/plan/issues/2827-statusline-dashboard-render-sprint-current.md
+++ b/plan/issues/2827-statusline-dashboard-render-sprint-current.md
@@ -12,7 +12,7 @@ reasoning_effort: medium
 task_type: chore
 area: tooling
 goal: maintainability
-sprint: current
+sprint: 69
 horizon: s
 architect_spec: done
 ---

--- a/plan/issues/2828-ship-examples-on-npm.md
+++ b/plan/issues/2828-ship-examples-on-npm.md
@@ -2,7 +2,7 @@
 id: 2828
 title: Ship examples/ in the npm tarball
 status: done
-sprint: current
+sprint: 69
 priority: high
 area: packaging
 related: [389]

--- a/plan/issues/2829-verify-multihost-browser-nm-0593.md
+++ b/plan/issues/2829-verify-multihost-browser-nm-0593.md
@@ -2,7 +2,7 @@
 id: 2829
 title: Retest all four native-messaging hosts in Chrome on 0.59.3
 status: done
-sprint: current
+sprint: 69
 priority: high
 area: examples
 task_type: bug

--- a/plan/issues/2830-document-wasi-p1-no-bundle-recipe.md
+++ b/plan/issues/2830-document-wasi-p1-no-bundle-recipe.md
@@ -2,7 +2,7 @@
 id: 2830
 title: "Lower DataView/Uint8Array-over-WASI-memory to linear ops; rewrite wasi_p1 to standard DataView (drop the wasm:memory ghost intrinsic)"
 status: done
-sprint: current
+sprint: 69
 priority: medium
 area: codegen
 task_type: feature

--- a/plan/issues/2831-member-set-dispatch-value-cast-traps.md
+++ b/plan/issues/2831-member-set-dispatch-value-cast-traps.md
@@ -4,7 +4,7 @@ title: "[SENIOR-DEV ONLY] member-WRITE dispatcher `__set_member_<name>` traps `i
 status: done
 completed: 2026-06-29
 assignee: ttraenkler/sendev-2831
-sprint: current
+sprint: 69
 priority: high
 horizon: l
 feasibility: hard

--- a/plan/issues/2832-nm-node-process-readside-unbounded-memory.md
+++ b/plan/issues/2832-nm-node-process-readside-unbounded-memory.md
@@ -2,7 +2,7 @@
 id: 2832
 title: nm_js2wasm_node_process READ side buffers the whole input frame (unbounded memory)
 status: done
-sprint: current
+sprint: 69
 priority: high
 area: examples
 language_feature: native-messaging

--- a/plan/issues/2833-nm-extensionless-relative-imports-break-deno.md
+++ b/plan/issues/2833-nm-extensionless-relative-imports-break-deno.md
@@ -2,7 +2,7 @@
 id: 2833
 title: Extension-less relative imports break Deno / `deno bundle` in native-messaging examples
 status: done
-sprint: current
+sprint: 69
 priority: medium
 area: examples
 task_type: bug

--- a/plan/issues/2834-nm-node-process-not-node-runnable-buffer-chunks.md
+++ b/plan/issues/2834-nm-node-process-not-node-runnable-buffer-chunks.md
@@ -4,7 +4,7 @@ title: nm_js2wasm_node_process example is not node-runnable (Buffer stdin chunks
 status: done
 completed: 2026-06-29
 assignee: ttraenkler/agent-aca3caf083aabc01b
-sprint: current
+sprint: 69
 priority: low
 area: examples
 task_type: bug

--- a/plan/issues/2836-typed-struct-vec-lost-across-dynamic-dispatch-arg.md
+++ b/plan/issues/2836-typed-struct-vec-lost-across-dynamic-dispatch-arg.md
@@ -4,7 +4,7 @@ title: "[SENIOR-DEV ONLY] typed nominal-struct vec ($__vec_ref_*) loses its elem
 status: done
 completed: 2026-06-29
 assignee: ttraenkler/sendev-arrowparam
-sprint: current
+sprint: 69
 priority: high
 horizon: l
 feasibility: hard

--- a/plan/issues/2837-block-body-arrow-param-wall.md
+++ b/plan/issues/2837-block-body-arrow-param-wall.md
@@ -4,7 +4,7 @@ title: "[SENIOR-DEV ONLY] dynamic property-add to a NON-EMPTY object literal is 
 status: done
 completed: 2026-06-29
 assignee: ttraenkler/sendev-arrowparam
-sprint: current
+sprint: 69
 priority: high
 horizon: l
 feasibility: hard

--- a/plan/issues/2838-dynamic-prototype-accessor-dispatch.md
+++ b/plan/issues/2838-dynamic-prototype-accessor-dispatch.md
@@ -4,7 +4,7 @@ title: "[SENIOR-DEV ONLY] dynamic prototype-accessor dispatch on statically-type
 status: done
 completed: 2026-06-29
 assignee: sendev-2838
-sprint: current
+sprint: 69
 priority: high
 horizon: l
 feasibility: hard

--- a/plan/issues/2839-externref-vec-materializer-missing-i8-i16-coerce.md
+++ b/plan/issues/2839-externref-vec-materializer-missing-i8-i16-coerce.md
@@ -2,7 +2,7 @@
 id: 2839
 title: externref→wasm-vec materializer missing i8/i16 coerce + WASI host-import leak (#2311 regression)
 status: done
-sprint: current
+sprint: 69
 priority: high
 area: codegen
 task_type: bug

--- a/plan/issues/2840-nm-node-process-ts-direct-linear-uint8-1886.md
+++ b/plan/issues/2840-nm-node-process-ts-direct-linear-uint8-1886.md
@@ -2,7 +2,7 @@
 id: 2840
 title: nm_js2wasm_node_process .ts-direct compile fails with linear-Uint8 helper-arg #1886 (module-scope buffer)
 status: done
-sprint: current
+sprint: 69
 priority: high
 area: codegen
 task_type: bug

--- a/plan/issues/2841-arrow-param-name-type-marshalling.md
+++ b/plan/issues/2841-arrow-param-name-type-marshalling.md
@@ -4,7 +4,7 @@ title: "arrow / function-expression param Identifier nodes lose name+type on HOS
 status: done
 completed: 2026-06-29
 assignee: ttraenkler/agent-senior-2841
-sprint: current
+sprint: 69
 priority: high
 horizon: m
 feasibility: hard

--- a/plan/issues/2844-forof-forawait-rest-element-nested-pattern-target.md
+++ b/plan/issues/2844-forof-forawait-rest-element-nested-pattern-target.md
@@ -2,7 +2,7 @@
 id: 2844
 parent: 2669
 related: [2602, 2826]
-sprint: current
+sprint: 69
 status: done
 completed: 2026-06-29
 assignee: ttraenkler/restobj

--- a/plan/issues/2845-dstr-assign-expr-default-init-firing.md
+++ b/plan/issues/2845-dstr-assign-expr-default-init-firing.md
@@ -4,7 +4,7 @@ title: "Assignment-expression destructuring default initializers don't fire on a
 status: done
 assignee: ttraenkler/dstr4
 created: 2026-06-29
-updated: 2026-06-29
+updated: 2026-07-03
 completed: 2026-06-29
 priority: high
 feasibility: hard
@@ -16,7 +16,7 @@ language_feature: destructuring
 goal: spec-completeness
 parent: 2669
 related: [2669, 2758, 2808, 2811, 2769]
-sprint: current
+sprint: 69
 ---
 
 # #2845 — assignment-expression destructuring default-init firing

--- a/plan/issues/2846-acorn-bigint-literal-corrupted-to-f64.md
+++ b/plan/issues/2846-acorn-bigint-literal-corrupted-to-f64.md
@@ -2,7 +2,7 @@
 id: 2846
 title: "compiled-acorn corrupts BigInt literals — parsed/marshalled as float64, losing value AND the `bigint` string"
 status: done
-sprint: current
+sprint: 69
 priority: high
 horizon: m
 feasibility: hard

--- a/plan/issues/2848-acorn-newtarget-yield-arg-parse-throws.md
+++ b/plan/issues/2848-acorn-newtarget-yield-arg-parse-throws.md
@@ -3,7 +3,7 @@ id: 2848
 title: "compiled-acorn THROWS parsing `new.target`, `yield <expr>`, and `for await…of` — additional parser-execution walls beyond the #2838 return wall"
 status: done
 completed: 2026-06-30
-sprint: current
+sprint: 69
 priority: medium
 horizon: m
 feasibility: hard

--- a/plan/issues/2849-ecmaversion-normalize-dynamic-prop-type-inference.md
+++ b/plan/issues/2849-ecmaversion-normalize-dynamic-prop-type-inference.md
@@ -4,7 +4,7 @@ title: "dynamic-object numeric property reads back 0 when the same property is a
 status: done
 completed: 2026-07-02
 assignee: ttraenkler/dev-2937f
-sprint: current
+sprint: 69
 priority: medium
 horizon: l
 feasibility: hard

--- a/plan/issues/2851-acorn-template-element-marshalled-blank.md
+++ b/plan/issues/2851-acorn-template-element-marshalled-blank.md
@@ -3,7 +3,7 @@ id: 2851
 title: "compiled-acorn marshals TemplateLiteral `quasis[]` TemplateElement nodes BLANK (type/value/tail dropped across host boundary)"
 status: done
 completed: 2026-06-30
-sprint: current
+sprint: 69
 priority: high
 horizon: m
 feasibility: medium

--- a/plan/issues/2852-acorn-sequence-expression-children-blank.md
+++ b/plan/issues/2852-acorn-sequence-expression-children-blank.md
@@ -3,7 +3,7 @@ id: 2852
 title: "compiled-acorn marshals SequenceExpression `expressions[]` child nodes BLANK (all fields dropped across host boundary)"
 status: done
 completed: 2026-06-30
-sprint: current
+sprint: 69
 priority: high
 horizon: m
 feasibility: medium

--- a/plan/issues/2857-ir-class-method-residual-to-zero.md
+++ b/plan/issues/2857-ir-class-method-residual-to-zero.md
@@ -3,9 +3,9 @@ id: 2857
 title: "IR: claim static methods under `extends` (class-method 6 → 5)"
 status: done
 completed: 2026-07-02
-sprint: current
+sprint: 69
 created: 2026-06-30
-updated: 2026-07-02
+updated: 2026-07-03
 priority: high
 horizon: s
 feasibility: medium

--- a/plan/issues/2859-ir-param-type-not-resolvable-to-zero.md
+++ b/plan/issues/2859-ir-param-type-not-resolvable-to-zero.md
@@ -2,9 +2,9 @@
 id: 2859
 title: "IR: drive param-type-not-resolvable fallback bucket to zero (TypeMap propagation)"
 status: done
-sprint: current
+sprint: 69
 created: 2026-06-30
-updated: 2026-07-02
+updated: 2026-07-03
 completed: 2026-07-02
 assignee: ttraenkler/dev-2912f
 priority: high

--- a/plan/issues/2861-standalone-builtin-static-value-read-native-proto-glue.md
+++ b/plan/issues/2861-standalone-builtin-static-value-read-native-proto-glue.md
@@ -4,14 +4,14 @@ title: "Standalone: built-in static/prototype property value read not supported 
 status: done
 assignee: ttraenkler/dev-2863
 created: 2026-06-30
-updated: 2026-07-02
+updated: 2026-07-03
 completed: 2026-07-02
 priority: high
 feasibility: medium
 task_type: feature
 area: codegen
 goal: standalone
-sprint: current
+sprint: 69
 horizon: l
 related: [2860, 1907, 1888, 2175, 2651, 2193]
 umbrella: 2860

--- a/plan/issues/2863-standalone-dynamic-shape-get-builtin.md
+++ b/plan/issues/2863-standalone-dynamic-shape-get-builtin.md
@@ -3,14 +3,14 @@ id: 2863
 title: "Standalone: dynamic-shape object/property ops refused — __get_builtin (reflective builtin/namespace read), __extern_toLocaleString, __object_groupBy/fromEntries"
 status: done
 created: 2026-06-30
-updated: 2026-07-02
+updated: 2026-07-03
 completed: 2026-07-02
 priority: high
 feasibility: medium
 task_type: feature
 area: codegen
 goal: standalone
-sprint: current
+sprint: 69
 horizon: m
 related: [2860, 1472, 2861, 2864]
 umbrella: 2860

--- a/plan/issues/2868-standalone-invalid-wasm-emission.md
+++ b/plan/issues/2868-standalone-invalid-wasm-emission.md
@@ -4,13 +4,13 @@ title: "Standalone: invalid Wasm binary emitted (correctness) — __uri_encode/_
 status: done
 completed: 2026-06-30
 created: 2026-06-30
-updated: 2026-06-30
+updated: 2026-07-03
 priority: high
 feasibility: medium
 task_type: bug
 area: codegen
 goal: standalone
-sprint: current
+sprint: 69
 horizon: m
 related: [2860]
 umbrella: 2860

--- a/plan/issues/2869-member-expr-assign-target-destructure-funcidx-repoint.md
+++ b/plan/issues/2869-member-expr-assign-target-destructure-funcidx-repoint.md
@@ -5,7 +5,7 @@ status: done
 assignee: ttraenkler/member2869
 completed: 2026-06-30
 created: 2026-06-30
-updated: 2026-06-30
+updated: 2026-07-03
 parent: 2669
 priority: high
 feasibility: hard
@@ -16,7 +16,7 @@ es_edition: 2015
 language_feature: destructuring
 goal: spec-completeness
 architect_spec: done
-sprint: current
+sprint: 69
 related: [2669, 2664, 2659, 2567, 1109, 1461, 2191, 2193]
 ---
 

--- a/plan/issues/2870-exn-formatter-throws-on-wasmgc-payload.md
+++ b/plan/issues/2870-exn-formatter-throws-on-wasmgc-payload.md
@@ -9,7 +9,7 @@ priority: high
 task_type: bug
 area: tooling
 goal: standalone
-sprint: current
+sprint: 69
 horizon: s
 related: [2862, 2860]
 ---

--- a/plan/issues/2871-report-standalone-toggle-mobile-benchmarks.md
+++ b/plan/issues/2871-report-standalone-toggle-mobile-benchmarks.md
@@ -2,7 +2,7 @@
 id: 2871
 title: "Conformance report page: standalone pass-rate toggle, mobile overflow, empty benchmarks, edition-scoped error patterns, standalone differential"
 status: done
-sprint: current
+sprint: 69
 priority: medium
 horizon: m
 feasibility: medium

--- a/plan/issues/2874-standalone-getownpropertydescriptor-numeric-key-coercion.md
+++ b/plan/issues/2874-standalone-getownpropertydescriptor-numeric-key-coercion.md
@@ -9,7 +9,7 @@ priority: high
 task_type: bug
 area: codegen
 goal: standalone
-sprint: current
+sprint: 69
 horizon: m
 related: [2860, 2870, 2862]
 umbrella: 2860

--- a/plan/issues/2876-standalone-regexp-cluster.md
+++ b/plan/issues/2876-standalone-regexp-cluster.md
@@ -9,7 +9,7 @@ priority: high
 task_type: bug
 area: codegen
 goal: standalone
-sprint: current
+sprint: 69
 horizon: l
 related: [2860, 2870, 2862, 682, 2885]
 umbrella: 2860

--- a/plan/issues/2877-standalone-exception-no-readable-message.md
+++ b/plan/issues/2877-standalone-exception-no-readable-message.md
@@ -3,7 +3,7 @@ id: 2877
 title: "Standalone exceptions expose no JS-readable message (__sget_message returns null) — blocks message-level triage"
 status: done
 created: 2026-06-30
-updated: 2026-07-02
+updated: 2026-07-03
 completed: 2026-07-02
 assignee: ttraenkler/dev-2912f
 resolved_by: 2962
@@ -11,7 +11,7 @@ priority: medium
 task_type: enhancement
 area: tooling
 goal: standalone
-sprint: current
+sprint: 69
 horizon: s
 related: [2870, 2862, 2860, 2962]
 umbrella: 2860

--- a/plan/issues/2878-standalone-invalid-wasm-residual-strflatten-bodyshapes.md
+++ b/plan/issues/2878-standalone-invalid-wasm-residual-strflatten-bodyshapes.md
@@ -5,13 +5,13 @@ status: done
 assignee: ttraenkler/dev-2878
 completed: 2026-07-02
 created: 2026-06-30
-updated: 2026-07-02
+updated: 2026-07-03
 priority: high
 feasibility: medium
 task_type: bug
 area: codegen
 goal: standalone
-sprint: current
+sprint: 69
 horizon: m
 related: [2860, 2868, 2849, 2918, 1461]
 umbrella: 2860

--- a/plan/issues/2879-standalone-metric-measure-host-free-ness.md
+++ b/plan/issues/2879-standalone-metric-measure-host-free-ness.md
@@ -9,7 +9,7 @@ priority: high
 task_type: enhancement
 area: tooling
 goal: standalone
-sprint: current
+sprint: 69
 horizon: m
 related: [2860, 2097, 2870, 2864, 2865, 2866, 2867]
 umbrella: 2860

--- a/plan/issues/2880-surrogate-string-constants.md
+++ b/plan/issues/2880-surrogate-string-constants.md
@@ -4,7 +4,7 @@ title: "Host mode: string constants containing lone surrogates arrive as `undefi
 status: done
 assignee: ttraenkler/explore2
 created: 2026-06-30
-updated: 2026-06-30
+updated: 2026-07-03
 completed: 2026-06-30
 priority: medium
 feasibility: medium
@@ -12,7 +12,7 @@ task_type: bug
 area: runtime
 language_feature: string-literals
 goal: test262
-sprint: current
+sprint: 69
 horizon: m
 related: [679]
 ---

--- a/plan/issues/2881-number-is-predicates-nonnumber-arg.md
+++ b/plan/issues/2881-number-is-predicates-nonnumber-arg.md
@@ -4,7 +4,7 @@ title: "Number.is{Integer,Finite,NaN,SafeInteger} coerce non-Number args (boolea
 status: done
 area: codegen
 language_feature: number-predicates
-sprint: current
+sprint: 69
 priority: medium
 horizon: s
 assignee: ttraenkler/explore3

--- a/plan/issues/2882-date-utc-makefullyear-timeclip.md
+++ b/plan/issues/2882-date-utc-makefullyear-timeclip.md
@@ -3,7 +3,7 @@ id: 2882
 title: "Date.UTC: MakeFullYear, MakeDay month-overflow, non-finite/TimeClip → NaN"
 status: done
 completed: 2026-06-30
-sprint: current
+sprint: 69
 priority: medium
 horizon: m
 area: codegen

--- a/plan/issues/2883-toprimitive-hintless-objlit-invalid-wasm.md
+++ b/plan/issues/2883-toprimitive-hintless-objlit-invalid-wasm.md
@@ -2,9 +2,9 @@
 id: 2883
 title: "Hint-less object-literal [Symbol.toPrimitive]() emits invalid Wasm — __call_@@toPrimitive arity mismatch (expected externref, got (ref N))"
 status: done
-sprint: current
+sprint: 69
 created: 2026-06-30
-updated: 2026-06-30
+updated: 2026-07-03
 completed: 2026-06-30
 assignee: ttraenkler/explore4
 priority: medium

--- a/plan/issues/2884-decimaltohex-harness-shim.md
+++ b/plan/issues/2884-decimaltohex-harness-shim.md
@@ -2,7 +2,7 @@
 id: 2884
 title: "test262 runner stubs decimalToHexString.js harness incorrectly — false failures across encode/decode-URI"
 status: done
-sprint: current
+sprint: 69
 priority: high
 horizon: s
 area: testing

--- a/plan/issues/2885-standalone-descriptor-reflection-core.md
+++ b/plan/issues/2885-standalone-descriptor-reflection-core.md
@@ -9,7 +9,7 @@ priority: high
 task_type: bug
 area: codegen
 goal: standalone
-sprint: current
+sprint: 69
 horizon: l
 related: [2860, 2870, 2862, 2874, 2875, 2876, 2872, 2175, 2651]
 umbrella: 2860

--- a/plan/issues/2886-new-global-nonconstructor-typeerror.md
+++ b/plan/issues/2886-new-global-nonconstructor-typeerror.md
@@ -2,7 +2,7 @@
 id: 2886
 title: "new <global-non-constructor-builtin>() must throw TypeError (decodeURI/encodeURI/…/parseInt/parseFloat/isNaN/isFinite)"
 status: done
-sprint: current
+sprint: 69
 priority: medium
 horizon: s
 area: codegen

--- a/plan/issues/2887-pow-integer-exponent-precision.md
+++ b/plan/issues/2887-pow-integer-exponent-precision.md
@@ -2,7 +2,7 @@
 id: 2887
 title: "Runtime `**` / `**=` / Math.pow imprecise for integer exponents (3**3 → 26.99…)"
 status: done
-sprint: current
+sprint: 69
 priority: medium
 horizon: s
 area: codegen

--- a/plan/issues/2888-standalone-string-wrapper-relational-invalid-wasm.md
+++ b/plan/issues/2888-standalone-string-wrapper-relational-invalid-wasm.md
@@ -9,7 +9,7 @@ feasibility: medium
 task_type: bug
 area: codegen
 goal: standalone
-sprint: current
+sprint: 69
 horizon: s
 related: [2873, 2870, 2862]
 umbrella: 2873

--- a/plan/issues/2889-standalone-highwater-writeside-hostfree.md
+++ b/plan/issues/2889-standalone-highwater-writeside-hostfree.md
@@ -9,7 +9,7 @@ priority: high
 task_type: bug
 area: tooling
 goal: standalone
-sprint: current
+sprint: 69
 horizon: m
 related: [2879, 2360, 2097, 2366, 2367]
 umbrella: 2860

--- a/plan/issues/2890-standalone-guard-hostfree-accounting.md
+++ b/plan/issues/2890-standalone-guard-hostfree-accounting.md
@@ -9,7 +9,7 @@ priority: high
 task_type: tooling
 area: tooling
 goal: standalone
-sprint: current
+sprint: 69
 horizon: m
 related: [2879, 1897, 2867, 2864, 2865, 2866]
 ---

--- a/plan/issues/2891-standalone-toprimitive-valueof-object-fallthrough.md
+++ b/plan/issues/2891-standalone-toprimitive-valueof-object-fallthrough.md
@@ -9,7 +9,7 @@ priority: high
 task_type: bug
 area: codegen
 goal: standalone
-sprint: current
+sprint: 69
 horizon: m
 related: [2873, 2862, 2638, 1900]
 umbrella: 2860

--- a/plan/issues/2893-standalone-typedarray-view-brand.md
+++ b/plan/issues/2893-standalone-typedarray-view-brand.md
@@ -9,7 +9,7 @@ priority: high
 task_type: bug
 area: codegen
 goal: standalone
-sprint: current
+sprint: 69
 horizon: l
 related: [2872, 2375, 2593, 2651, 2885, 2876, 2901]
 umbrella: 2860

--- a/plan/issues/2897-es3-arguments-assignment-target-null-deref.md
+++ b/plan/issues/2897-es3-arguments-assignment-target-null-deref.md
@@ -3,7 +3,7 @@ id: 2897
 title: "≤ES3: `arguments` as assignment target crashes (null-deref)"
 status: done
 priority: high
-sprint: current
+sprint: 69
 created: 2026-06-30
 completed: 2026-06-30
 assignee: ttraenkler/es3-2897

--- a/plan/issues/2898-es3-yield-assignment-target-early-error.md
+++ b/plan/issues/2898-es3-yield-assignment-target-early-error.md
@@ -4,7 +4,7 @@ title: "≤ES3: `yield` as assignment target should be an early SyntaxError (cur
 status: done
 completed: 2026-06-30
 priority: high
-sprint: current
+sprint: 69
 created: 2026-06-30
 feasibility: medium
 task_type: bug

--- a/plan/issues/2899-es3-function-caller-poison-pill-set.md
+++ b/plan/issues/2899-es3-function-caller-poison-pill-set.md
@@ -4,7 +4,7 @@ title: "≤ES3: Function `.caller` poison-pill must throw TypeError on set (`bou
 status: done
 completed: 2026-06-30
 priority: high
-sprint: current
+sprint: 69
 created: 2026-06-30
 feasibility: medium
 task_type: bug

--- a/plan/issues/2900-es3-module-indirect-default-binding-update.md
+++ b/plan/issues/2900-es3-module-indirect-default-binding-update.md
@@ -3,7 +3,7 @@ id: 2900
 title: "≤ES3 (edition bucket): module indirect default-export binding update returns wrong value"
 status: done
 priority: high
-sprint: current
+sprint: 69
 created: 2026-06-30
 completed: 2026-07-02
 feasibility: hard

--- a/plan/issues/2901-standalone-typedarray-intrinsic-ctor.md
+++ b/plan/issues/2901-standalone-typedarray-intrinsic-ctor.md
@@ -9,7 +9,7 @@ priority: high
 task_type: feature
 area: codegen
 goal: standalone
-sprint: current
+sprint: 69
 horizon: l
 related: [2893, 2872, 2651, 2885, 2876]
 umbrella: 2860

--- a/plan/issues/2902-native-test262error.md
+++ b/plan/issues/2902-native-test262error.md
@@ -4,14 +4,14 @@ title: "Standalone: native Test262Error construction eliminates env::__new_Test2
 status: done
 created: 2026-06-30
 completed: 2026-06-30
-updated: 2026-06-30
+updated: 2026-07-03
 assignee: ttraenkler/sendev-error
 priority: high
 feasibility: hard
 task_type: feature
 area: codegen
 goal: standalone
-sprint: current
+sprint: 69
 horizon: m
 related: [1104, 1536, 2188, 2862]
 ---

--- a/plan/issues/2904-standalone-fixed-arity-destructure-iter-drain.md
+++ b/plan/issues/2904-standalone-fixed-arity-destructure-iter-drain.md
@@ -3,7 +3,7 @@ id: 2904
 title: Standalone fixed-arity array destructuring leaks env::__array_from_iter_n
 status: done
 assignee: ttraenkler/sendev-iterdrain
-sprint: current
+sprint: 69
 priority: high
 horizon: l
 feasibility: hard

--- a/plan/issues/2905-promise-type-contract-carrier-externref.md
+++ b/plan/issues/2905-promise-type-contract-carrier-externref.md
@@ -3,7 +3,7 @@ id: 2905
 title: "Standalone/WASI Promise carrier: resolveWasmType(Promise<T>) must lower to externref (stored/typed promise contract)"
 status: done
 created: 2026-07-01
-updated: 2026-07-01
+updated: 2026-07-03
 completed: 2026-07-01
 assignee: ttraenkler/sendev-promise
 priority: high
@@ -11,7 +11,7 @@ feasibility: medium
 task_type: bug
 area: codegen
 goal: standalone
-sprint: current
+sprint: 69
 horizon: m
 related: [2867, 2895, 2865, 1313, 1727, 1936]
 umbrella: 2860

--- a/plan/issues/2907-standalone-wellknown-global-identity-carriers.md
+++ b/plan/issues/2907-standalone-wellknown-global-identity-carriers.md
@@ -10,7 +10,7 @@ feasibility: hard
 task_type: feature
 area: codegen
 goal: standalone
-sprint: current
+sprint: 69
 horizon: l
 related: [2866, 2696, 2520, 1888, 1065]
 ---

--- a/plan/issues/2908-standalone-externget-elemaccess-leak.md
+++ b/plan/issues/2908-standalone-externget-elemaccess-leak.md
@@ -7,7 +7,7 @@ status: done
 completed: 2026-07-01
 assignee: ttraenkler/sdev-2908-externget-leak
 related: [2748, 2879, 2372, 2572, 1472]
-sprint: current
+sprint: 69
 priority: high
 horizon: m
 ---

--- a/plan/issues/2910-editions-feature-rows-reconcile-frontmatter.md
+++ b/plan/issues/2910-editions-feature-rows-reconcile-frontmatter.md
@@ -5,7 +5,7 @@ status: done
 assignee: ttraenkler/impl2910
 completed: 2026-07-01
 priority: medium
-sprint: current
+sprint: 69
 created: 2026-07-01
 feasibility: medium
 task_type: enhancement

--- a/plan/issues/2912-negative-test-verdict-dead-early-error-gate.md
+++ b/plan/issues/2912-negative-test-verdict-dead-early-error-gate.md
@@ -4,7 +4,7 @@ title: "test262 runner marks negative parse/early tests pass on ANY compile erro
 status: done
 assignee: ttraenkler/fix2912
 priority: medium
-sprint: current
+sprint: 69
 created: 2026-07-01
 completed: 2026-07-01
 feasibility: medium

--- a/plan/issues/2913-report-double-counts-duplicate-records.md
+++ b/plan/issues/2913-report-double-counts-duplicate-records.md
@@ -5,7 +5,7 @@ status: done
 completed: 2026-07-02
 assignee: ttraenkler/dev-f2
 priority: medium
-sprint: current
+sprint: 69
 created: 2026-07-01
 feasibility: medium
 task_type: bug

--- a/plan/issues/2914-standalone-editions-count-leaky-pass.md
+++ b/plan/issues/2914-standalone-editions-count-leaky-pass.md
@@ -4,7 +4,7 @@ title: "Standalone per-edition pass rates count leaky (host-import) passes, dive
 status: done
 assignee: ttraenkler/fix2914
 priority: medium
-sprint: current
+sprint: 69
 created: 2026-07-01
 completed: 2026-07-01
 feasibility: medium

--- a/plan/issues/2915-native-toboolean-descriptor.md
+++ b/plan/issues/2915-native-toboolean-descriptor.md
@@ -2,7 +2,7 @@
 id: 2915
 title: Native ToBoolean on the property-descriptor-attribute + Boolean() path (standalone leak)
 status: done
-sprint: current
+sprint: 69
 priority: medium
 horizon: s
 feasibility: medium

--- a/plan/issues/2918-native-promise-then-all-funcidx-shift.md
+++ b/plan/issues/2918-native-promise-then-all-funcidx-shift.md
@@ -10,7 +10,7 @@ feasibility: hard
 task_type: bug
 area: codegen
 goal: standalone
-sprint: current
+sprint: 69
 horizon: l
 related: [2867, 2895, 2906, 2860]
 umbrella: 2860

--- a/plan/issues/2920-strict-negative-verdict-succeeded-arm.md
+++ b/plan/issues/2920-strict-negative-verdict-succeeded-arm.md
@@ -4,7 +4,7 @@ title: "Strict compile-SUCCEEDED arm of the negative-test verdict (the #2912 fol
 status: done
 assignee: ttraenkler/dev-2912
 priority: medium
-sprint: current
+sprint: 69
 created: 2026-07-02
 completed: 2026-07-02
 feasibility: medium

--- a/plan/issues/2921-bank-drain-microtasks-intrinsic.md
+++ b/plan/issues/2921-bank-drain-microtasks-intrinsic.md
@@ -12,7 +12,7 @@ feasibility: medium
 task_type: feature
 area: codegen
 goal: standalone
-sprint: current
+sprint: 69
 horizon: s
 ---
 

--- a/plan/issues/2922-native-combinator-arms-2-3-noniterable-reject-generic-iterable.md
+++ b/plan/issues/2922-native-combinator-arms-2-3-noniterable-reject-generic-iterable.md
@@ -2,7 +2,7 @@
 id: 2922
 title: "Standalone async widen: native Promise.all/race arms 2 & 3 — not-iterable→reject + generic iterable (residual receiver-cast layer after #2919 arm 1)"
 status: done
-sprint: current
+sprint: 69
 assignee: ttraenkler/fable-4
 created: 2026-07-02
 completed: 2026-07-02

--- a/plan/issues/2923-eval-constant-string-compile-away-broaden.md
+++ b/plan/issues/2923-eval-constant-string-compile-away-broaden.md
@@ -5,7 +5,7 @@ status: done
 assignee: ttraenkler/dev-2863
 completed: 2026-07-02
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 priority: high
 horizon: s
 feasibility: medium
@@ -14,7 +14,7 @@ task_type: feature
 area: codegen
 language_feature: eval
 goal: runtime-eval
-sprint: current
+sprint: 69
 parent: 1584
 related: [1163, 1261, 2924]
 ---

--- a/plan/issues/2924-new-function-constant-body-compile-away.md
+++ b/plan/issues/2924-new-function-constant-body-compile-away.md
@@ -3,7 +3,7 @@ id: 2924
 title: 'new Function("<const>") compile-away MVP — replace the no-op stub'
 status: done
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 completed: 2026-07-02
 assignee: ttraenkler/dev-evalf
 priority: high
@@ -14,7 +14,7 @@ task_type: feature
 area: codegen
 language_feature: eval
 goal: runtime-eval
-sprint: current
+sprint: 69
 parent: 1584
 depends_on: [2923]
 related: [1163, 1584]

--- a/plan/issues/2930-import-alias-name-mismatch-resolution.md
+++ b/plan/issues/2930-import-alias-name-mismatch-resolution.md
@@ -3,7 +3,7 @@ id: 2930
 title: "codegen: import binding whose local name differs from the target declaration name resolves to null"
 status: done
 priority: high
-sprint: current
+sprint: 69
 created: 2026-07-02
 completed: 2026-07-02
 assignee: ttraenkler/dev-2900

--- a/plan/issues/2931-live-binding-reassigned-function-decl.md
+++ b/plan/issues/2931-live-binding-reassigned-function-decl.md
@@ -3,7 +3,7 @@ id: 2931
 title: "codegen: reassigned function declaration is not a live binding (fn = 2 is lost)"
 status: done
 priority: high
-sprint: current
+sprint: 69
 created: 2026-07-02
 completed: 2026-07-02
 assignee: ttraenkler/dev-2900b

--- a/plan/issues/2932-compile-js-module-dependencies.md
+++ b/plan/issues/2932-compile-js-module-dependencies.md
@@ -3,7 +3,7 @@ id: 2932
 title: "codegen: .js module dependencies are not compiled in multi-file mode (imports resolve to null)"
 status: done
 priority: high
-sprint: current
+sprint: 69
 created: 2026-07-02
 completed: 2026-07-02
 assignee: ttraenkler/dev-2900f

--- a/plan/issues/2936-resume-lazy-emit-funcidx-shift.md
+++ b/plan/issues/2936-resume-lazy-emit-funcidx-shift.md
@@ -10,7 +10,7 @@ feasibility: hard
 task_type: bug
 area: codegen
 goal: standalone
-sprint: current
+sprint: 69
 horizon: l
 related: [2933, 2918, 1461, 1677, 1903, 2039]
 umbrella: 2860

--- a/plan/issues/2937-acorn-host-object-hash-poison-null-deref-regression.md
+++ b/plan/issues/2937-acorn-host-object-hash-poison-null-deref-regression.md
@@ -4,7 +4,7 @@ title: "Regression: host-mode $Object-hash poison (#2849) makes compiled-acorn p
 status: done
 completed: 2026-07-02
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 priority: high
 horizon: m
 feasibility: hard
@@ -13,7 +13,7 @@ task_type: bug
 area: codegen
 language_feature: object
 goal: runtime-eval
-sprint: current
+sprint: 69
 parent: 2927
 depends_on: []
 related: [2849, 2584, 2432, 1712, 1710, 2850, 2853, 2944]

--- a/plan/issues/2939-any-closure-param-dispatch-arity-coercion.md
+++ b/plan/issues/2939-any-closure-param-dispatch-arity-coercion.md
@@ -4,7 +4,7 @@ title: "codegen: dynamic dispatch of an any-typed closure param (fn(...)) must h
 status: done
 completed: 2026-07-02
 assignee: ttraenkler/opus-10c
-sprint: current
+sprint: 69
 priority: high
 horizon: l
 feasibility: hard
@@ -15,7 +15,7 @@ language_feature: closures, dynamic-dispatch
 goal: host-independence
 related: [2940, 2903]
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 origin: "2026-07-02 spun out of #2940 yield-gate analysis (dev-callback). origin/main @ 4d5287afc."
 ---
 

--- a/plan/issues/2940-standalone-make-callback-harness-wrapper-vacuous.md
+++ b/plan/issues/2940-standalone-make-callback-harness-wrapper-vacuous.md
@@ -3,7 +3,7 @@ id: 2940
 title: "standalone: __make_callback sole-leak is the harness-wrapper vacuous pass — gated on dynamic-closure-dispatch arity/type tolerance (sub-front 4 of #2903 yields 0)"
 status: done
 completed: 2026-07-02
-sprint: current
+sprint: 69
 priority: high
 feasibility: hard
 reasoning_effort: max
@@ -15,7 +15,7 @@ assignee: ttraenkler/dev-f1
 related: [2939, 2903, 2879, 2075]
 blocked_on: "#2939 (formerly #2923; arity half landed via PR #2441): dynamic dispatch of `fn(...)` on an any-typed closure param must tolerate arity mismatch + coerce arg type-kinds (calls-closures.ts) — otherwise removing the import yields DISHONEST vacuous host-free passes"
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 origin: "2026-07-02 __make_callback sole-leak-front measurement (dev-callback). origin/main @ 4d5287afc, target standalone, merged report run 28491700781."
 ---
 

--- a/plan/issues/2942-promote-baseline-push-race-reanchor.md
+++ b/plan/issues/2942-promote-baseline-push-race-reanchor.md
@@ -5,9 +5,9 @@ status: done
 completed: 2026-07-02
 assignee: ttraenkler/dev-f2
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 priority: medium
-sprint: current
+sprint: 69
 horizon: m
 task_type: bug
 area: ci

--- a/plan/issues/2943-allocator-open-pr-scan-hardening.md
+++ b/plan/issues/2943-allocator-open-pr-scan-hardening.md
@@ -5,9 +5,9 @@ status: done
 completed: 2026-07-02
 assignee: ttraenkler/dev-f2
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 priority: low
-sprint: current
+sprint: 69
 horizon: s
 task_type: bug
 area: tooling

--- a/plan/issues/2945-ir-selector-claims-modulo-from-ast-throws.md
+++ b/plan/issues/2945-ir-selector-claims-modulo-from-ast-throws.md
@@ -4,9 +4,9 @@ title: "IR selector claims `%` (modulo) but from-ast throws — post-claim drift
 status: done
 completed: 2026-07-02
 assignee: ttraenkler/dev-2138f
-sprint: current
+sprint: 69
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 priority: medium
 feasibility: medium
 horizon: s

--- a/plan/issues/2946-promote-baseline-push-race.md
+++ b/plan/issues/2946-promote-baseline-push-race.md
@@ -3,7 +3,7 @@ id: 2946
 title: "promote-baseline loses its baselines-repo push race under overlapping main runs (rebase retries can never resolve)"
 status: done
 completed: 2026-07-02
-sprint: current
+sprint: 69
 created: 2026-07-02
 priority: medium
 horizon: m

--- a/plan/issues/2947-test262-ir-first-measurement-lane.md
+++ b/plan/issues/2947-test262-ir-first-measurement-lane.md
@@ -3,9 +3,9 @@ id: 2947
 title: "test262-sharded workflow_dispatch ir_first lane — repeatable off-box #2138 measurement"
 status: done
 completed: 2026-07-02
-sprint: current
+sprint: 69
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 priority: medium
 feasibility: easy
 horizon: s

--- a/plan/issues/2954-linear-emitter-core-op-coverage.md
+++ b/plan/issues/2954-linear-emitter-core-op-coverage.md
@@ -4,9 +4,9 @@ title: "LinearEmitter core-op coverage (const/binary/locals/control-flow/call) +
 status: done
 completed: 2026-07-02
 assignee: ttraenkler/opus-dev-a
-sprint: current
+sprint: 69
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 priority: medium
 horizon: m
 feasibility: medium

--- a/plan/issues/2959-standalone-native-promise-executor.md
+++ b/plan/issues/2959-standalone-native-promise-executor.md
@@ -4,7 +4,7 @@ title: "Standalone: native `new Promise(executor)` — retire the unconditional 
 status: done
 assignee: sendev-promise-exec2
 completed: 2026-07-03
-sprint: current
+sprint: 69
 created: 2026-07-02
 updated: 2026-07-03
 priority: high

--- a/plan/issues/2960-eval-new-function-loud-diagnostics-shim-routing.md
+++ b/plan/issues/2960-eval-new-function-loud-diagnostics-shim-routing.md
@@ -4,9 +4,9 @@ title: "eval / new Function: loud standalone diagnostics + call-time-throwing st
 status: done
 completed: 2026-07-02
 assignee: ttraenkler/agent-dev-opus
-sprint: current
+sprint: 69
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 priority: medium
 horizon: m
 feasibility: medium

--- a/plan/issues/2962-native-error-identity-stringification.md
+++ b/plan/issues/2962-native-error-identity-stringification.md
@@ -3,9 +3,9 @@ id: 2962
 title: "Native error-object identity + payload stringification: retire `__get_caught_exception` (1,427 opaque standalone fails)"
 status: done
 assignee: ttraenkler/fable-2
-sprint: current
+sprint: 69
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 completed: 2026-07-02
 priority: high
 horizon: l

--- a/plan/issues/2964-forin-prototype-chain-integer-key-order.md
+++ b/plan/issues/2964-forin-prototype-chain-integer-key-order.md
@@ -4,9 +4,9 @@ title: "for-in on $Object: prototype-chain enumeration + integer-key-ascending o
 status: done
 assignee: ttraenkler/opus-2964
 completed: 2026-07-02
-sprint: current
+sprint: 69
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 priority: low
 horizon: m
 feasibility: medium

--- a/plan/issues/2965-standalone-dynamic-descriptor-cluster.md
+++ b/plan/issues/2965-standalone-dynamic-descriptor-cluster.md
@@ -4,9 +4,9 @@ title: "Standalone dynamic-descriptor/defineProperty cluster (~694 host-pass→s
 status: done
 completed: 2026-07-02
 assignee: ttraenkler/fable-6
-sprint: current
+sprint: 69
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 priority: high
 horizon: l
 feasibility: hard

--- a/plan/issues/2966-standalone-anyparam-closure-add-tag5-misclassify.md
+++ b/plan/issues/2966-standalone-anyparam-closure-add-tag5-misclassify.md
@@ -4,9 +4,9 @@ title: "Standalone: any-param closure results silently wrong through `+` — __a
 status: done
 completed: 2026-07-02
 assignee: ttraenkler/fable-3
-sprint: current
+sprint: 69
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 priority: high
 horizon: m
 feasibility: hard

--- a/plan/issues/2972-ir-string-elem-access-computed-index-drift.md
+++ b/plan/issues/2972-ir-string-elem-access-computed-index-drift.md
@@ -3,9 +3,9 @@ id: 2972
 title: "IR selector accepts string element access with computed index; from-ast throws 'not in slice 12' — 14 test262 CEs under IR-first"
 status: done
 assignee: ttraenkler/dev-2138f
-sprint: current
+sprint: 69
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 completed: 2026-07-02
 priority: medium
 feasibility: medium

--- a/plan/issues/2973-eval-subcompile-inherits-ir-first-swallows-error.md
+++ b/plan/issues/2973-eval-subcompile-inherits-ir-first-swallows-error.md
@@ -4,9 +4,9 @@ title: "eval-shim sub-compiles inherit JS2WASM_IR_FIRST and swallow its hard err
 status: done
 assignee: ttraenkler/dev-2973
 completed: 2026-07-02
-sprint: current
+sprint: 69
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 priority: high
 feasibility: easy
 horizon: s

--- a/plan/issues/2979-genresult-undefined-carrier.md
+++ b/plan/issues/2979-genresult-undefined-carrier.md
@@ -4,9 +4,9 @@ title: "Standalone: native gen-result done `.value` reads back as 0/garbage — 
 status: done
 completed: 2026-07-02
 assignee: ttraenkler/fable-3
-sprint: current
+sprint: 69
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 priority: high
 horizon: m
 feasibility: hard

--- a/plan/issues/2981-tagged-template-strictness.md
+++ b/plan/issues/2981-tagged-template-strictness.md
@@ -2,7 +2,7 @@
 id: 2981
 title: Tagged-template equivalence tests reconcile to spec-correct TemplateStringsArray param type
 status: done
-sprint: current
+sprint: 69
 priority: high
 horizon: m
 assignee: ttraenkler/opus-3

--- a/plan/issues/2985-standalone-defineproperties-slab-residual.md
+++ b/plan/issues/2985-standalone-defineproperties-slab-residual.md
@@ -4,7 +4,7 @@ title: "Standalone: __obj_find illegal-cast on non-string computed keys (bool/bi
 status: done
 completed: 2026-07-02
 assignee: ttraenkler/agent-dev-opus
-sprint: current
+sprint: 69
 priority: high
 horizon: s
 feasibility: hard

--- a/plan/issues/2988-standalone-global-object-defineproperty.md
+++ b/plan/issues/2988-standalone-global-object-defineproperty.md
@@ -4,7 +4,7 @@ title: "Standalone defineProperty on the global object (~10, needs global-object
 status: done
 assignee: ttraenkler/sr-globaldefine
 completed: 2026-07-03
-sprint: current
+sprint: 69
 priority: low
 horizon: l
 feasibility: hard

--- a/plan/issues/2989-standalone-defineproperty-missing-spec-typeerrors.md
+++ b/plan/issues/2989-standalone-defineproperty-missing-spec-typeerrors.md
@@ -3,7 +3,7 @@ id: 2989
 title: "Standalone defineProperty missing spec TypeErrors (~32: array length, non-extensible, non-configurable redefine)"
 status: done
 completed: 2026-07-02
-sprint: current
+sprint: 69
 priority: medium
 horizon: s
 feasibility: medium

--- a/plan/issues/2993-async-gen-bigint-externref-mismatch.md
+++ b/plan/issues/2993-async-gen-bigint-externref-mismatch.md
@@ -2,7 +2,7 @@
 id: 2993
 title: "standalone: generator-closure lowering emits i64/BigInt where externref expected → invalid-wasm CE (`__closure_3`) on BigInt generator-iterable TypedArray ctor"
 status: done
-sprint: current
+sprint: 69
 priority: medium
 feasibility: hard
 task_type: bugfix

--- a/plan/issues/2994-standalone-object-isprototypeof-leak.md
+++ b/plan/issues/2994-standalone-object-isprototypeof-leak.md
@@ -4,7 +4,7 @@ title: "Standalone: eliminate env::Object_isPrototypeOf host-import leak — sta
 status: done
 completed: 2026-07-02
 assignee: ttraenkler/agent-add922b5fc0765fbe
-sprint: current
+sprint: 69
 priority: medium
 horizon: s
 feasibility: medium

--- a/plan/issues/2995-native-tuple-from-iterable-fallback.md
+++ b/plan/issues/2995-native-tuple-from-iterable-fallback.md
@@ -3,7 +3,7 @@ id: 2995
 title: Standalone tuple-from-iterable destructure fallback leaks env::__array_from_iter
 status: done
 assignee: ttraenkler/agent-a67bcee7
-sprint: current
+sprint: 69
 priority: high
 horizon: s
 feasibility: medium

--- a/plan/issues/2996-standalone-getglobalthis-leak.md
+++ b/plan/issues/2996-standalone-getglobalthis-leak.md
@@ -3,7 +3,7 @@ id: 2996
 title: "Eliminate env::__get_globalThis read leak in standalone mode (native globalThis value)"
 status: done
 completed: 2026-07-02
-sprint: current
+sprint: 69
 priority: medium
 horizon: m
 assignee: ttraenkler/agent-af6e582225dfb945b

--- a/plan/issues/2998-instanceof-check-primitive-lhs-standalone.md
+++ b/plan/issues/2998-instanceof-check-primitive-lhs-standalone.md
@@ -2,7 +2,7 @@
 id: 2998
 title: "Eliminate env::__instanceof_check leak for static-primitive LHS in standalone"
 status: done
-sprint: current
+sprint: 69
 priority: medium
 horizon: s
 assignee: ttraenkler/agent-instanceof

--- a/plan/issues/3003-verdict-logic-change-must-bump-oracle-version.md
+++ b/plan/issues/3003-verdict-logic-change-must-bump-oracle-version.md
@@ -9,7 +9,7 @@ priority: high
 feasibility: hard
 task_type: infra
 area: ci
-sprint: current
+sprint: 69
 horizon: m
 related: [2096, 2920, 2940, 1668, 1897, 2528, 2547]
 ---

--- a/plan/issues/3004-vacuous-reclassification-gate-excusal.md
+++ b/plan/issues/3004-vacuous-reclassification-gate-excusal.md
@@ -2,7 +2,7 @@
 id: 3004
 title: "CI wedge fix: excuse #2940 vacuity reclassifications in the standalone (#1897) regression gate"
 status: done
-sprint: current
+sprint: 69
 priority: high
 feasibility: medium
 reasoning_effort: max
@@ -13,7 +13,7 @@ goal: merge-queue-health
 assignee: ttraenkler/dev-unwedge
 related: [2940, 2463, 3001, 1897, 1668, 2879]
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 completed: 2026-07-02
 origin: "2026-07-02 merge-queue wedge. #2463's vacuity scorer (merged 0670ea4) rescored ~1438 vacuous passes → fail without bumping oracle_version; HOST baseline re-promoted new-policy but STANDALONE baseline left stale old-policy (sha cab96808), so every code PR's merge_group standalone diff trips #1897 on the d822f85a −1438 cluster. Diagnosis: shepherd-o (run 28618870469)."
 ---

--- a/plan/issues/3005-eval-as-any-callee-stack-overflow.md
+++ b/plan/issues/3005-eval-as-any-callee-stack-overflow.md
@@ -2,9 +2,9 @@
 id: 3005
 title: "Compiler stack-overflow on `(eval as any)()` — cast/parenthesized callee re-wrap recurses infinitely"
 status: done
-sprint: current
+sprint: 69
 created: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 completed: 2026-07-02
 assignee: ttraenkler/agent-a736c48cc4ac5b6c4
 priority: medium

--- a/plan/issues/3006-genuine-builtin-constructor-identity.md
+++ b/plan/issues/3006-genuine-builtin-constructor-identity.md
@@ -4,7 +4,7 @@ title: "Genuine reified builtin-constructor identity: <Builtin>.prototype.constr
 status: done
 completed: 2026-07-03
 assignee: ttraenkler/senior-dev
-sprint: current
+sprint: 69
 priority: medium
 horizon: m
 feasibility: hard

--- a/plan/issues/3007-any-string-index-return-coercion.md
+++ b/plan/issues/3007-any-string-index-return-coercion.md
@@ -2,7 +2,7 @@
 id: 3007
 title: "any-context computed-index read desyncs __vec_get funcIdx → invalid Wasm (f64.convert_i32_s on externref)"
 status: done
-sprint: current
+sprint: 69
 priority: medium
 assignee: ttraenkler/agent-a7e5749647e8f1219
 created: 2026-07-03

--- a/plan/issues/3009-harden-degrade-stable-handle-crash.md
+++ b/plan/issues/3009-harden-degrade-stable-handle-crash.md
@@ -2,10 +2,10 @@
 id: 3009
 title: "Harden host-import degrade path: dropped stable-handle-coupled import must yield clean leak diagnostic, not absoluteFuncIndex crash"
 status: done
-sprint: current
+sprint: 69
 created: 2026-07-02
 completed: 2026-07-02
-updated: 2026-07-02
+updated: 2026-07-03
 assignee: ttraenkler/agent-a840cb644c42d6eab
 priority: medium
 horizon: m

--- a/plan/issues/3010-standalone-dstr-param-undefined-element-guard.md
+++ b/plan/issues/3010-standalone-dstr-param-undefined-element-guard.md
@@ -4,7 +4,7 @@ title: "Standalone regression: dstr-param `[x = init]` called with a single-elem
 status: done
 completed: 2026-07-03
 assignee: ttraenkler/senior-developer
-sprint: current
+sprint: 69
 created: 2026-07-03
 updated: 2026-07-03
 priority: high

--- a/plan/issues/3011-claim-issue-dry-run-write-modes.md
+++ b/plan/issues/3011-claim-issue-dry-run-write-modes.md
@@ -3,7 +3,7 @@ id: 3011
 title: claim-issue.mjs --dry-run does not short-circuit in claim/release/complete modes
 status: done
 completed: 2026-07-03
-sprint: current
+sprint: 69
 priority: high
 horizon: s
 assignee: ttraenkler/dev-dryrun-fix

--- a/plan/issues/3013-array-iterator-prototype-identity.md
+++ b/plan/issues/3013-array-iterator-prototype-identity.md
@@ -4,7 +4,7 @@ title: "Standalone %ArrayIteratorPrototype% shared identity + Object-subclass na
 status: done
 assignee: ttraenkler/sendev-iterproto
 completed: 2026-07-03
-sprint: current
+sprint: 69
 created: 2026-07-03
 updated: 2026-07-03
 priority: medium

--- a/plan/issues/3014-any-receiver-foreach-some-misroute-typedarray-extern.md
+++ b/plan/issues/3014-any-receiver-foreach-some-misroute-typedarray-extern.md
@@ -12,7 +12,7 @@ task_type: bugfix
 area: codegen
 language_feature: arrays
 goal: standalone-host-free
-sprint: current
+sprint: 69
 horizon: s
 assignee: ttraenkler/agent-opus
 origin: "2026-07-03 leak-analysis round 6 §sole-lever ranking — Uint8ClampedArray_forEach/some 16 sole-import passes (GENUINE)"

--- a/plan/issues/3016-standalone-call-apply-funcexpr-not-host-callback.md
+++ b/plan/issues/3016-standalone-call-apply-funcexpr-not-host-callback.md
@@ -4,7 +4,7 @@ title: "standalone: a func-expr/arrow passed to Function.prototype.call/apply is
 status: done
 completed: 2026-07-03
 assignee: ttraenkler/opus-callapply
-sprint: current
+sprint: 69
 priority: high
 horizon: s
 feasibility: medium

--- a/plan/issues/3018-remove-stale-duplicate-tests.md
+++ b/plan/issues/3018-remove-stale-duplicate-tests.md
@@ -2,7 +2,7 @@
 id: 3018
 title: "chore: remove 76 stale duplicate root-level test files orphaned by the tests/equivalence/ migration (broken ./helpers.js import, never run)"
 status: done
-sprint: current
+sprint: 69
 priority: low
 created: 2026-07-03
 completed: 2026-07-03

--- a/plan/issues/3019-restore-broken-import-test-files.md
+++ b/plan/issues/3019-restore-broken-import-test-files.md
@@ -2,7 +2,7 @@
 id: 3019
 title: "Restore 106 silently-dead test files whose ./helpers.js import broke when helpers moved to tests/equivalence/"
 status: done
-sprint: current
+sprint: 69
 priority: medium
 created: 2026-07-03
 completed: 2026-07-03

--- a/plan/issues/3020-delete-stale-duplicate-flat-test-files.md
+++ b/plan/issues/3020-delete-stale-duplicate-flat-test-files.md
@@ -2,7 +2,7 @@
 id: 3020
 title: "Delete the 2 stale duplicate flat test files PR #2588 missed (broken-import copies superseded by tests/equivalence/)"
 status: done
-sprint: current
+sprint: 69
 priority: low
 created: 2026-07-03
 completed: 2026-07-03

--- a/plan/issues/sprints/69.md
+++ b/plan/issues/sprints/69.md
@@ -1,0 +1,279 @@
+# Sprint 69
+
+Frozen 2026-07-03 — trigger: 24 min left in weekly window (statusline).
+
+This is a **budget window** record (rolling-sprint model, #2751): the set
+of issues completed before the token budget rolled over, frozen from
+`sprint: current` into `sprint: 69`. Not-done work rolled forward and
+stays `sprint: current`.
+
+## Completed this window (181)
+
+- #1042 — async/await state-machine lowering (AwaitExpression is currently a no-op)
+- #1336 — spec gap: Object.assign drops getters / Symbol keys (27 of 38 test262 fails)
+- #1627 — spec gap: Set methods (union/intersection/etc.) accept any set-like argument (101 test262 fails)
+- #2134 — IR effect model: classify instruction kinds, enforce program-order emission for effectful ops
+- #2138 — IR-first compile-once inversion: selector decides before compileDeclarations (flag-gated investigation)
+- #2140 — stack-balance fixBranchType: coerce-where-possible, throw on impossible (split of #1858-C1)
+- #2167 — Fable model disabled — frontier-reasoning work blocked
+- #2181 — defineBuiltin(name, {elementKinds, lower}) scaffold — unify per-representation element-load/ToString/null handling
+- #2674 — acorn parse() 9th wall PAST tokenization (after #2664 type-write fix) — parseTopLevel/parseStatement array-push loop
+- #2676 — ≤ES3: mapped arguments — strict-mode aliased `delete args[i]` must throw TypeError on a non-configurable index (residual of #2667)
+- #2681 — [ARCH] acorn parse() 10th wall — identifier expression-statement throws (unexpected() on a `name` token); root cause = Parser not reconstructed (new this() in static methods), substrate-scoped
+- #2686 — [ARCH] acorn parse() — binary-expression statement throws (parse(\"1 + 2 * 3;\") → WebAssembly.Exception); same root as #2681 (Parser not reconstructed), substrate-scoped
+- #2714 — Object spread copies values but the copied keys are not enumerable (Object.keys / spread-then-data drop)
+- #2729 — WasmGC backend: new Uint8Array(n) element store skips ToUint8 (u[0]=257 reads 257, u[0]=NaN reads NaN)
+- #2745 — Function.prototype.bind: bound partial-application arguments, bound `.length`/`.name`, construct newTarget forwarding, restricted-property poison
+- #2751 — Budget-windowed rolling sprint model: sprint:current queue + budget-triggered freeze + auto-sync to TaskList
+- #2752 — transpiled (type-stripped) nm_node_process.js fails to compile — process.stdin TS prelude parsed under .js grammar
+- #2754 — Sound TS checker settings for .ts AND .js + codegen defensive-correctness where TS is deliberately unsound (#2698 track)
+- #2755 — Decide the type-soundness approach: trust-the-type-and-patch vs JS-semantics-first
+- #2756 — Array-pattern element with an object-literal / class-expression default value null-derefs (the fn-name-class dstr cluster)
+- #2757 — Assignment-destructuring (expressions/assignment): rest element + undefined/hole binds wrong value / 'array too large' trap
+- #2758 — Object/array-pattern default-init side-effect runs when element is present (init-skipped) — call default eagerly evaluated / closure-box in skipped arm
+- #2760 — Hybrid floor F1: plain-array OOB read → JS `undefined` (HI-style #2198/S2 rework, not the shared-helper flip)
+- #2762 — Hybrid migration-cost audit: type-directed fast-path safety-predicate checklist (living doc)
+- #2764 — @@hasInstance handler invoked at unknown-arity (arguments.length wrong) — dispatcher half fixed by #2213; one-line residual
+- #2766 — Hybrid IR step 1: ElementAccess prove-then-specialize — vec.get only when in-bounds is proven, else SAFE bounds-checked read
+- #2767 — nominal value assigned into an uninitialized/untyped var loses its type → method dispatch goes dynamic and fails (var d; d = new Date(0); d.toISOString())
+- #2769 — [ARCH] for-of typed in-bounds undefined/hole default-init — representation-level carve (split from #2669)
+- #2770 — dynamic builtin boolean-method on a bare-var/dynamic receiver boxes the i32 result as a NUMBER not a boolean (set.has/map.has/re.test → 1 not true)
+- #2771 — Bundle relative imports for standalone WASI CLI compilation (shared local helper + node:fs IO)
+- #2774 — Landing-page edition card summary % doesn't reconcile with its feature rows
+- #2775 — Native Messaging examples: rename to host scheme + 1/64/128 MiB CI matrix (shared sync-framing dedup deferred to #2771)
+- #2778 — Dedup native-messaging sync framing: share one host-independent core for nm_deno + nm_node_fs
+- #2780 — Hybrid IR step 2: ArrayLiteral widening-escape check — vec.new_fixed only when the literal does not flow into an any/heterogeneous sink
+- #2781 — Hybrid IR step 3: Binary `+` string-or-number proof-gate — unboxed numeric add / string concat only when the operand TS types are PROVEN, else SAFE dynamic `+`
+- #2782 — Hybrid IR Row 5 — no-box NUMBER-local proof gate
+- #2783 — General --link <namespace> dynamic-linking flag (generalize --link-node-shims)
+- #2784 — [SENIOR-DEV ONLY] S3 of #2773 — array-element / host-boundary native struct identity (re-proxy loss closes acorn parse) — closes #2681/#2686
+- #2785 — Hybrid: type-aware box primitive (box keyed on the TS type, not the Wasm kind) + re-enable boolean[] OOB→undefined
+- #2786 — Auto-enqueue: make the server-side workflow_run path the single primary; drop the per-agent enqueue and the grace window
+- #2788 — malformed_wasm: __module_init call type mismatch (array/01-basic, closures/10-mutual)
+- #2789 — Hybrid fast-path Row 3: packed-i32 array read-side soundness — demote overflow/-0 writes to f64 (miscompile fix)
+- #2790 — Hybrid IR — no-box NUMBER-local proof gate, i32 arm (#2782 fast-follow, unblocked by #2785)
+- #2791 — Hybrid audit Row 4 — monomorphic struct.get/set soundness (read discharged; real miscompile is structural-narrowing copy, not Row 4)
+- #2792 — Hybrid: host symbol[] OOB → undefined (completes #2785 F1 host half; standalone deferred)
+- #2794 — [SENIOR-DEV ONLY] acorn parse() var-declaration THROW — AST-Node-as-closureBridge + vec read-methods (host-proxy layer); closes #2681
+- #2795 — diff-test host path: value→string rendering — object toString/@@toPrimitive ignored + boolean prints as 1/0
+- #2796 — diff-test host path: dynamic-object own-key enumerate/copy — for-in empty, spread loses values, Object.assign loses keys
+- #2798 — Hybrid Row 9: typed-array element OOB → undefined (call-site policy, shared helper untouched)
+- #2800 — [SENIOR-DEV ONLY] top-level `new X(objLiteral)` reads the literal arg's fields as null at module-init (type-index remap)
+- #2801 — [SENIOR-DEV ONLY] compiled-acorn CallExpression `arguments` marshals as `{}` not an array (host vec→array gap)
+- #2804 — host path: object spread `{...a}` & Object.assign drop copied values/keys (closed-struct representation mismatch)
+- #2805 — init-time `any`-receiver field WRITE dropped at module-init (symmetric write side of #2800)
+- #2806 — [SENIOR-DEV ONLY] untyped `[]` array literal lowers to a NUMERIC (f64) vec — ref pushes coerce to 0 (drops AST node refs)
+- #2807 — nm_node_process (async process.stdin) emits ZERO output at 128 MiB under real wasmtime — and the in-process shim masks it
+- #2808 — for-of OBJECT-binding head drops nested sub-patterns (no bind, no RequireObjectCoercible throw)
+- #2809 — [SENIOR-DEV ONLY] undefined[] representation conflation — acorn's void-0 evolving array vs genuine undefined[]
+- #2810 — nm_js2wasm_node_process: re-chunk host->extension writes to the ≤1 MiB browser cap (like nm_js2wasm_node_fs)
+- #2811 — Destructuring closure-capture residual: captured builtin-named var (length/concat/…) + dstr-param closure TDZ-flag offset (split from #2669)
+- #2812 — Native Messaging deployment recipe: ship a Chrome NM host from js2wasm output (wasmtime shebang / bun -b / deno compile + manifest)
+- #2813 — Doc: running js2wasm --target wasi output across runtimes (wasmtime / bun -b / deno) + required -W flags
+- #2814 — All Native-Messaging example hosts must re-chunk (≤1 MiB JSON frames)
+- #2815 — Suppress spurious 'Cannot find name Deno' (TS2304) warning on the recognized Deno stdio surface
+- #2816 — CLI default output dir should be the cwd, not next to the input
+- #2817 — nm_node_process: env.__wasiStdinStop host import has no WASI-native fallback / not on the dual-mode allowlist (#2735 follow-up)
+- #2818 — Bug C (class-method half): block-scoped let captured by a class method reads null (captured-globals promotion ordering)
+- #2820 — Bug C: block-scoped let captured by hoisted FunctionDeclaration reads null (duplicate-local desync)
+- #2821 — Harden the flaky EPIPE in tests/issue-2684-deno-stdio.test.ts
+- #2827 — Statusline + dashboard kanban ignore `sprint: current` (unfinished #2751 acceptance criterion)
+- #2828 — Ship examples/ in the npm tarball
+- #2829 — Retest all four native-messaging hosts in Chrome on 0.59.3
+- #2830 — Lower DataView/Uint8Array-over-WASI-memory to linear ops; rewrite wasi_p1 to standard DataView (drop the wasm:memory ghost intrinsic)
+- #2831 — [SENIOR-DEV ONLY] member-WRITE dispatcher `__set_member_<name>` traps `illegal cast` on the value coercion — compiled acorn cannot parse ANY function/arrow body
+- #2832 — nm_js2wasm_node_process READ side buffers the whole input frame (unbounded memory)
+- #2833 — Extension-less relative imports break Deno / `deno bundle` in native-messaging examples
+- #2834 — nm_js2wasm_node_process example is not node-runnable (Buffer stdin chunks)
+- #2836 — [SENIOR-DEV ONLY] typed nominal-struct vec ($__vec_ref_*) loses its elements when passed as an `any` argument through an indirect/dynamic call — compiled acorn cannot parse arrow functions with ≥1 param
+- #2837 — [SENIOR-DEV ONLY] dynamic property-add to a NON-EMPTY object literal is silently dropped (closed struct, no sidecar) — route growable literals to externref $Object (Approach A)
+- #2838 — [SENIOR-DEV ONLY] dynamic prototype-accessor dispatch on statically-typed receivers — `Object.defineProperties(Proto, {get})` getters never fire on `this.field` (acorn `return` wall)
+- #2839 — externref→wasm-vec materializer missing i8/i16 coerce + WASI host-import leak (#2311 regression)
+- #2840 — nm_js2wasm_node_process .ts-direct compile fails with linear-Uint8 helper-arg #1886 (module-scope buffer)
+- #2841 — arrow / function-expression param Identifier nodes lose name+type on HOST readback (compiled-acorn AST != node-acorn)
+- #2844 — 
+- #2845 — Assignment-expression destructuring default initializers don't fire on absent element/property (`[a=d]=src`, `{k:x=d}=src`)
+- #2846 — compiled-acorn corrupts BigInt literals — parsed/marshalled as float64, losing value AND the `bigint` string
+- #2848 — compiled-acorn THROWS parsing `new.target`, `yield <expr>`, and `for await…of` — additional parser-execution walls beyond the #2838 return wall
+- #2849 — dynamic-object numeric property reads back 0 when the same property is also compared via === string / == null (acorn ecmaVersion 2022 not normalised → spurious import attributes)
+- #2851 — compiled-acorn marshals TemplateLiteral `quasis[]` TemplateElement nodes BLANK (type/value/tail dropped across host boundary)
+- #2852 — compiled-acorn marshals SequenceExpression `expressions[]` child nodes BLANK (all fields dropped across host boundary)
+- #2857 — IR: claim static methods under `extends` (class-method 6 → 5)
+- #2859 — IR: drive param-type-not-resolvable fallback bucket to zero (TypeMap propagation)
+- #2861 — Standalone: built-in static/prototype property value read not supported — extend native-proto glue (ArrayBuffer, DataView, Promise, Iterator, Error subclasses, …)
+- #2863 — Standalone: dynamic-shape object/property ops refused — __get_builtin (reflective builtin/namespace read), __extern_toLocaleString, __object_groupBy/fromEntries
+- #2868 — Standalone: invalid Wasm binary emitted (correctness) — __uri_encode/__uri_decode, __str_flatten, and common user-body shapes
+- #2869 — Destructuring with a member-expression assignment target ([x.y]=vals, {k:x.y}=src) — funcIdx-repoint of detached body buffer (~53 fails)
+- #2870 — Standalone exception-message formatter throws on Wasm-GC payload, masking real failure signatures
+- #2871 — Conformance report page: standalone pass-rate toggle, mobile overflow, empty benchmarks, edition-scoped error patterns, standalone differential
+- #2874 — Standalone: Object.getOwnPropertyDescriptor (and defineProperty) numeric/object property-key → string coercion drops the lookup
+- #2876 — Standalone: RegExp cluster (125 host-pass/standalone-fail, de-masked from #2862)
+- #2877 — Standalone exceptions expose no JS-readable message (__sget_message returns null) — blocks message-level triage
+- #2878 — Standalone: invalid Wasm residual — 3 root-cause classes (A: dstr default value-rep, B: __str_flatten null-deref, C: eqref/funcidx-shift). Single-cause framing superseded.
+- #2879 — Standalone metric must measure HOST-FREE-ness — credit only host-free passes, not host-satisfied leaky passes
+- #2880 — Host mode: string constants containing lone surrogates arrive as `undefined` (lossy UTF-8 import-name encoding)
+- #2881 — Number.is{Integer,Finite,NaN,SafeInteger} coerce non-Number args (boolean/undefined/null/symbol) instead of returning false
+- #2882 — Date.UTC: MakeFullYear, MakeDay month-overflow, non-finite/TimeClip → NaN
+- #2883 — Hint-less object-literal [Symbol.toPrimitive]() emits invalid Wasm — __call_@@toPrimitive arity mismatch (expected externref, got (ref N))
+- #2884 — test262 runner stubs decimalToHexString.js harness incorrectly — false failures across encode/decode-URI
+- #2885 — Standalone descriptor-reflection core: materialise builtin-proto intrinsic accessors for gOPD / reflection (unblocks #2875/#2876/#2872)
+- #2886 — new <global-non-constructor-builtin>() must throw TypeError (decodeURI/encodeURI/…/parseInt/parseFloat/isNaN/isFinite)
+- #2887 — Runtime `**` / `**=` / Math.pow imprecise for integer exponents (3**3 → 26.99…)
+- #2888 — Standalone: relational `<`/`<=`/`>`/`>=` with a String wrapper operand emits invalid Wasm
+- #2889 — Standalone high-water WRITE side must emit host_free_pass — promote-baseline clobbered the honest mark back to the leaky 26k
+- #2890 — Standalone #1897 regression guard must be host-free-aware — don't count leaky-pass → host-free-fail as a regression (#2879 §4 per-test completion)
+- #2891 — Standalone: ToPrimitive on a nominal struct accepts an object-returning valueOf — no valueOf→toString fall-through / no §7.1.1.1 TypeError
+- #2893 — Standalone: distinct %TypedArray% view brand (unblocks #2872 reflective getter/method bodies)
+- #2897 — ≤ES3: `arguments` as assignment target crashes (null-deref)
+- #2898 — ≤ES3: `yield` as assignment target should be an early SyntaxError (currently compiles)
+- #2899 — ≤ES3: Function `.caller` poison-pill must throw TypeError on set (`bound.caller = {}`)
+- #2900 — ≤ES3 (edition bucket): module indirect default-export binding update returns wrong value
+- #2901 — Standalone: %TypedArray%/view intrinsic constructor objects + getPrototypeOf chain
+- #2902 — Standalone: native Test262Error construction eliminates env::__new_Test262Error host-import leak (~2,779 tests)
+- #2904 — Standalone fixed-arity array destructuring leaks env::__array_from_iter_n
+- #2905 — Standalone/WASI Promise carrier: resolveWasmType(Promise<T>) must lower to externref (stored/typed promise contract)
+- #2907 — Standalone: native well-known-global bare-value carriers (global_<Name> leak)
+- #2908 — standalone obj[key] dynamic read leaks env::__extern_get (largest host-import leak class)
+- #2910 — Editions dashboard: classify feature rows by `features:` frontmatter (edition-sliced) so they reconcile with the section headline
+- #2912 — test262 runner marks negative parse/early tests pass on ANY compile error (dead `? \"pass\" : \"pass\"` gate)
+- #2913 — test262 report + editions double-count duplicate result rows (no dedup by file)
+- #2914 — Standalone per-edition pass rates count leaky (host-import) passes, diverging from the host-free headline/floor
+- #2915 — Native ToBoolean on the property-descriptor-attribute + Boolean() path (standalone leak)
+- #2918 — Standalone async widen prerequisite: native Promise.then/.all funcIdx-shift desync (the −601 invalid-Wasm)
+- #2920 — Strict compile-SUCCEEDED arm of the negative-test verdict (the #2912 follow-up, intentional −439)
+- #2921 — Bank the __drain_microtasks() carrier intrinsic (inert) extracted from the closed #2367 PR-B
+- #2922 — Standalone async widen: native Promise.all/race arms 2 & 3 — not-iterable→reject + generic iterable (residual receiver-cast layer after #2919 arm 1)
+- #2923 — Broaden constant-string eval compile-away to functions/classes/for-of
+- #2924 — new Function("<const>") compile-away MVP — replace the no-op stub
+- #2930 — codegen: import binding whose local name differs from the target declaration name resolves to null
+- #2931 — codegen: reassigned function declaration is not a live binding (fn = 2 is lost)
+- #2932 — codegen: .js module dependencies are not compiled in multi-file mode (imports resolve to null)
+- #2936 — Standalone: late-import funcIdx-shift desync (raw-import + deferred-batch regime mix) — the __str_flatten invalid-module class blocking no-yield native generators
+- #2937 — Regression: host-mode $Object-hash poison (#2849) makes compiled-acorn parse null-deref on every input
+- #2939 — codegen: dynamic dispatch of an any-typed closure param (fn(...)) must honor JS arity semantics + coerce arg kinds (blocks #2940, unblocks 468+ BigInt tests)
+- #2940 — standalone: __make_callback sole-leak is the harness-wrapper vacuous pass — gated on dynamic-closure-dispatch arity/type tolerance (sub-front 4 of #2903 yields 0)
+- #2942 — ci: promote-baseline push race — rebase-conflict exhaustion strands the baseline and manufactures phantom regressions on every subsequent PR
+- #2943 — tooling: claim-issue --allocate open-PR scan missed in-flight issue files (silent gh-failure fan-out) — batch, retry, fail-loud
+- #2945 — IR selector claims `%` (modulo) but from-ast throws — post-claim drift surfaced by JS2WASM_IR_FIRST
+- #2946 — promote-baseline loses its baselines-repo push race under overlapping main runs (rebase retries can never resolve)
+- #2947 — test262-sharded workflow_dispatch ir_first lane — repeatable off-box #2138 measurement
+- #2954 — LinearEmitter core-op coverage (const/binary/locals/control-flow/call) + cross-backend corpus dynamic rows
+- #2959 — Standalone: native `new Promise(executor)` — retire the unconditional Promise_new host import
+- #2960 — eval / new Function: loud standalone diagnostics + call-time-throwing stub + host Tier-1 shim routing for dynamic new Function
+- #2962 — Native error-object identity + payload stringification: retire `__get_caught_exception` (1,427 opaque standalone fails)
+- #2964 — for-in on $Object: prototype-chain enumeration + integer-key-ascending ordering
+- #2965 — Standalone dynamic-descriptor/defineProperty cluster (~694 host-pass→standalone-fail: defineProperty 398 + gOPD 184 + defineProperties 112)
+- #2966 — Standalone: any-param closure results silently wrong through `+` — __any_add classified every tag-5 box as stringy (re-id of the orphaned #2945 analysis)
+- #2972 — IR selector accepts string element access with computed index; from-ast throws 'not in slice 12' — 14 test262 CEs under IR-first
+- #2973 — eval-shim sub-compiles inherit JS2WASM_IR_FIRST and swallow its hard errors — silent `undefined` instead of fail-loud
+- #2979 — Standalone: native gen-result done `.value` reads back as 0/garbage — canonical-undefined carrier (UNDEF_F64 sentinel producer + sentinel-aware readers)
+- #2981 — Tagged-template equivalence tests reconcile to spec-correct TemplateStringsArray param type
+- #2985 — Standalone: __obj_find illegal-cast on non-string computed keys (bool/bigint/opaque via __to_property_key)
+- #2988 — Standalone defineProperty on the global object (~10, needs global-object own-property MOP)
+- #2989 — Standalone defineProperty missing spec TypeErrors (~32: array length, non-extensible, non-configurable redefine)
+- #2993 — standalone: generator-closure lowering emits i64/BigInt where externref expected → invalid-wasm CE (`__closure_3`) on BigInt generator-iterable TypedArray ctor
+- #2994 — Standalone: eliminate env::Object_isPrototypeOf host-import leak — static-fold Object/Function.prototype.isPrototypeOf
+- #2995 — Standalone tuple-from-iterable destructure fallback leaks env::__array_from_iter
+- #2996 — Eliminate env::__get_globalThis read leak in standalone mode (native globalThis value)
+- #2998 — Eliminate env::__instanceof_check leak for static-primitive LHS in standalone
+- #3003 — Postmortem + prevention: a test262 verdict-logic change must bump oracle_version (two queue wedges)
+- #3004 — CI wedge fix: excuse #2940 vacuity reclassifications in the standalone (#1897) regression gate
+- #3005 — Compiler stack-overflow on `(eval as any)()` — cast/parenthesized callee re-wrap recurses infinitely
+- #3006 — Genuine reified builtin-constructor identity: <Builtin>.prototype.constructor === <Builtin> (standalone) — supersede the #2537 null-fold
+- #3007 — any-context computed-index read desyncs __vec_get funcIdx → invalid Wasm (f64.convert_i32_s on externref)
+- #3009 — Harden host-import degrade path: dropped stable-handle-coupled import must yield clean leak diagnostic, not absoluteFuncIndex crash
+- #3010 — Standalone regression: dstr-param `[x = init]` called with a single-element array literal holding `undefined` throws `TypeError: Cannot destructure` at runtime (55 test262 class/dstr files)
+- #3011 — claim-issue.mjs --dry-run does not short-circuit in claim/release/complete modes
+- #3013 — Standalone %ArrayIteratorPrototype% shared identity + Object-subclass native construction (host-free array-iterator cluster)
+- #3014 — any-receiver .forEach/.some first-match TypedArray extern class → Uint8ClampedArray_forEach/some host leak
+- #3016 — standalone: a func-expr/arrow passed to Function.prototype.call/apply is a VALUE, not a host callback — route to closure-struct, not __make_callback
+- #3018 — chore: remove 76 stale duplicate root-level test files orphaned by the tests/equivalence/ migration (broken ./helpers.js import, never run)
+- #3019 — Restore 106 silently-dead test files whose ./helpers.js import broke when helpers moved to tests/equivalence/
+- #3020 — Delete the 2 stale duplicate flat test files PR #2588 missed (broken-import copies superseded by tests/equivalence/)
+
+## Rolled forward (79 still `sprint: current`)
+
+- #1712 [in-progress] — acceptance: compiled acorn parses a representative .js with AST structurally equal to node-acorn
+- #1916 [in-progress] — Symbolic function references in WasmGC codegen — retire the late-import index-shift machinery
+- #1917 [in-progress] — One coercion engine — four divergent coercion matrices disagree about lossiness
+- #1930 [in-progress] — TypeOracle — one type-query boundary between the TS checker and codegen (unblocks TS7, kills suppression heuristics)
+- #1985 [blocked] — stale-proof index cells: shift-walker-updated { idx } handles for captured func indices (#2043 Option 2b, incremental)
+- #2029 [in-progress] — standalone: `Binary emit error: u32 out of range: -1` on builtin subclassing, disposal protocol, Object.create, Iterator.prototype (497 tests)
+- #2044 [blocked] — architect decision: BigInt value representation — i64-bigint-brand ValType vs TS-type-driven boxing (gates #1644 slices, implicated in #2039 i64 ABI bucket)
+- #2106 [in-progress] — value-rep P3: undefined observability — UNDEF_F64 sentinel, union-collapse reversal (flagged), standalone $undefined singleton
+- #2141 [in-progress] — Retire the tag-5 box-the-externref ABI: make consumers tag-agnostic, then allow honest generic boxing
+- #2161 [blocked] — Standalone RegExp engine conformance residual (~579 tests)
+- #2173 [blocked] — standalone: yield* over a general iterable (array / custom {next()}) in native generators (SF-3 slice-2 of #2157)
+- #2175 [in-progress] — architect spec: standalone builtin-prototype object representation + native-method-closure dispatch
+- #2580 [in-progress] — `.length` on an any/dynamically-mutated receiver returns numeric 0, not undefined (runtime property-presence)
+- #2585 [blocked] — standalone: getPrototypeOf(Object.create(p)) === p is false — object identity lost in __any_strict_eq tag-5 arm
+- #2613 [blocked] — await on a thenable/non-Promise: assimilate via host (PromiseResolve) instead of returning the raw object (~15 fails)
+- #2614 [blocked] — Promise.{all,allSettled,any,race}: read constructor's own `resolve` + callable resolve/reject element functions (~45 fails)
+- #2618 [blocked] — Proxy (host): calling / constructing a Proxy whose target is callable traps (illegal cast) or ignores the construct trap result (~15 fails)
+- #2623 [in-progress] — Promise capability-cluster: multi-hop host→wasm resolve-element callback cast + ctx-ctor species/prototype identity through the bridge
+- #2626 [backlog] — tag-5 boxed-VALUE equality classifier (numeric #2040 f64.eq + object #2585 ref.eq) — value-rep substrate (deferred from #1888)
+- #2651 [blocked] — standalone: builtin constructor + prototype as a first-class VALUE (TypedArray ctor-iteration substrate)
+- #2660 [in-progress] — Whole-program escape/dynamic-use gate for reconstructing `new F()` instances as `$Object` (value-rep infra)
+- #2669 [ready] — ES2015: destructuring correctness residual umbrella (~696 fails — iterator-close, defaults, holes, rest across for-of/assignment/binding/params)
+- #2671 [ready] — ES2015 builtin/feature spec residuals: Date, RegExp, Promise, JSON, super (~400 fails — tracking, slice per area)
+- #2694 [blocked] — acorn parse() 11th wall — Scope.flags read loop (local-receiver slot/sidecar asymmetry, needs #2660)
+- #2710 [in-progress] — Late-bind module indices (func/global/type) to eliminate the late-index-shift bug class
+- #2712 [blocked] — Introduce a real bool ValType; retire the optional i32 boolean brand
+- #2726 [ready] — delete residual: sloppy return-value semantics, hasOwnProperty-after-delete, accessor descriptor configurability, mapped-arguments delete
+- #2732 [blocked] — operators: unary +/-/~/>>> ToPrimitive(object) trap; strict-equals boxed-wrapper/funcref trap
+- #2740 [ready] — [UMBRELLA] instanceof residual after #2702 — 5 deep gaps, split into #2763/#2764/#2765
+- #2768 [wont-fix] — bare-var receiver recovery: per-type externref→ref recovery hardening + safelist expansion (follow-on of #2767's Date-only gate)
+- #2773 [in-progress] — [EPIC][ARCH] Value-rep substrate: consistent native dispatch for reconstructed-struct field access + DCE/finalize-stable typeIdx
+- #2793 [blocked] — [ARCH][SUBSTRATE] Structural-narrowing struct COPY at call boundary breaks reference semantics (mutation through interface/structural-class param lost)
+- #2802 [ready] — [DEFERRED] nested `any`-vec multi-push then read drops the first element (S3-class vec-identity edge)
+- #2803 [ready] — Infer function-parameter types from call-site arguments (usage-based inference) — untyped/.js-stripped params default to `any`
+- #2826 [blocked] — Bug C (CPS-capture half): block-scoped let immutably captured by a hoisted async/generator declaration reads the stale pre-hoisted slot
+- #2847 [ready] — compiled-acorn cosmetic marshalling quirks — spurious `sourceFile: null` on every node + booleans as i32 0/1
+- #2850 [ready] — compiled-acorn THROWS validating regex literals with character classes `[…]`/`\\d` or named capture groups `(?<n>…)`
+- #2853 [ready] — compiled-acorn THROWS parsing its OWN source — two bisected constructs: division after a numeric literal (`1 / 2`) and ANY regex group `(…)`
+- #2855 [backlog] — IR front-end migration: ratchet unintended fallback buckets to zero + promote to STRICT_IR_REASONS
+- #2856 [blocked] — IR: drive body-shape-rejected fallback bucket to zero (dominant unintended bucket)
+- #2858 [ready] — IR: drive call-graph-closure fallback bucket to zero (derivative of body-shape + class-method)
+- #2860 [ready] — Umbrella: close the standalone-vs-js-host test262 gap (~20,500 host-free, honest metric #2879/#2360)
+- #2864 [in-progress] — Standalone: no Wasm-native generator carrier — sync generators leak __create_generator/__gen_* host imports
+- #2865 [in-progress] — Standalone: no Wasm-native async-generator / for-await carrier — leaks __create_async_generator + Promise_* host imports
+- #2866 [in-progress] — Standalone: Symbol values leak __box_symbol — no Wasm-native Symbol carrier
+- #2867 [in-progress] — Standalone: Promise / async microtask leaks Promise_resolve/reject/then + __make_callback host imports
+- #2872 [blocked] — Standalone: TypedArray.prototype.* cluster (294 host-pass/standalone-fail, de-masked from #2862)
+- #2873 [in-progress] — Standalone: language/expressions cluster (276 host-pass/standalone-fail, de-masked from #2862)
+- #2875 [in-progress] — Standalone: String.prototype.* cluster (159 host-pass/standalone-fail, de-masked from #2862)
+- #2906 [in-progress] — Standalone: generalize the async drive layer → multi-state, CFG-aware CPS resume machine (unlocks try/finally-across-await, for-await, multi-await)
+- #2911 [in-review] — Review: test262 setup + host-vs-standalone classification and pass-rate computation
+- #2916 [in-progress] — [SUBSTRATE][ARCH] Standalone native instanceof operator + isPrototypeOf residual (~31 leaky-PASS conversions)
+- #2927 [in-progress] — Interpreter foundation: Acorn-via-js2wasm runtime parser + generic-built-in audit
+- #2933 [ready] — Standalone: Math/JSON/Reflect/Atomics namespace static VALUE reads refuse — fold constants / native static-method closures
+- #2949 [in-progress] — IR dynamic value representation: JsTag-carrying `dynamic` kind in IrType (make untyped JS claimable)
+- #2950 [backlog] — IR-first default flip: JS2WASM_IR_FIRST default-ON, then delete the flag + compile-twice path
+- #2951 [ready] — IR-first skip set: include generators and class members (retire the two #2138 standing exclusions)
+- #2952 [in-progress] — IR multi-exit control flow: labeled break/continue, switch (br_table), do-while, for-in adoption
+- #2953 [in-progress] — Close the BackendEmitter pushRaw gap: route unions/closures/refcells/coercions/null/funcref through the trait
+- #2955 [ready] — De-polymorph the IR front-end on string mode: abstract IR string ops resolved at lower time
+- #2956 [ready] — Linear backend consumes the IR front-end: wire the selector + LinearEmitter into generateLinearModule
+- #2957 [ready] — Async activation for arrows / methods / function expressions (both CPS + drive hooks are declaration-only)
+- #2958 [ready] — Standalone: unhandled-rejection tracking — report rejected promises with no handler at drain/event-loop exit
+- #2961 [blocked] — Extend the strictNoHostImports leak guarantee to `--target standalone` (today wasi-only)
+- #2963 [in-progress] — Reify builtins as first-class values: retire the `__get_builtin` dynamic-shape CE cluster (~400 compile errors)
+- #2967 [ready] — Async engine convergence: retire emitAsyncStateMachine/splitBodyAtAwait onto the #2906 host-drive engine; widen planLinearAwaits gaps once for both lanes
+- #2980 [ready] — Standalone async widen — FINAL layers (async-fn drive −16 residual, Gap 5 for-await/async-gen −32) + the slice-1d carrier-widen DECISION MEASURE
+- #2984 [ready] — Standalone gOPD-on-builtin descriptor MOP (~178: getOwnPropertyDescriptor on builtin objects / proto receivers)
+- #3000 [ready] — IR: class-member residual — private fields, accessors, inheritance/super (class-method → 0)
+- #3001 [blocked] — Remove (or ratchet) the TEMPORARY #2940 vacuous-reclassification gate excusal once the standalone baseline promotes to new-policy
+- #3008 [ready] — process gap: tests/issue-*.test.ts are not uniformly wired into required CI (silent regressions)
+- #3021 [ready] — spec gap: class elements — static/private field & method placement residual (~1,522 default-lane fails)
+- #3022 [ready] — spec gap: Object.defineProperty(ies) descriptor fidelity tail + non-object receiver arm (~728 default-lane fails)
+- #3023 [ready] — iterator protocol: synthesized-iterator .next callability + for-of/for-await abrupt-completion residual (~508 default-lane fails)
+- #3024 [ready] — codegen: invalid Wasm binary emission residual — default (JS-host) lane (~131 fails, externref/f64 type-mismatch emitter bugs)
+- #3025 [ready] — with statement: closed object-literal shape residual (~167 default-lane fails, CE leaks into unrelated with-adjacent tests)
+- #3026 [ready] — negative_test_fail: residual early-error / static-semantics gaps (~79 default-lane, 64 unenforced SyntaxErrors)
+- #3027 [ready] — standalone: \\$Object dynamic-object-property reader residual — null/undefined property access on unmodeled shapes (~1,552 host-free fails)
+- #742 [in-progress] — Extract and refactor compileCallExpression (3,350 lines)
+
+## Retrospective
+
+- test262 conformance at freeze: see `benchmarks/results/test262-current.json`.
+- _(Tech-lead: add what went well / what didn't / action items here.)_

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -246,6 +246,11 @@ copyDirectory(PLAYGROUND_EXAMPLES_DIR, join(PAGES_DIST, "examples"));
 // copied below, so no Vite processing is required.
 copyFile(join(WEBSITE, "getting-started", "index.html"), join(PAGES_DIST, "getting-started", "index.html"));
 
+// Static blog page — same pattern as "Get started" above: a self-contained
+// HTML page that references the shared /components/site-nav.js, not a Vite
+// entry point.
+copyFile(join(WEBSITE, "blog", "index.html"), join(PAGES_DIST, "blog", "index.html"));
+
 // Overwrite Vite-built report pages with the latest public/ versions (which include
 // web components like <t262-donut> that Vite doesn't process).
 const PUBLIC_REPORT = join(WEBSITE, "public", "benchmarks", "results", "report.html");


### PR DESCRIPTION
## Summary
- Follow-up to #2605. `website/blog/index.html` is a self-contained static page (same pattern as `getting-started/index.html`), but `scripts/build-pages.js` only had a `copyFile` for `getting-started/` — the blog page never landed in `dist/pages/`, so `/blog/` 404'd on the deployed site after #2605 merged.
- Adds the equivalent `copyFile(join(WEBSITE, "blog", "index.html"), join(PAGES_DIST, "blog", "index.html"))` right after the getting-started copy.

## Test plan
- [x] Diff is a 5-line mechanical mirror of the already-working getting-started copy line
- [x] `pnpm typecheck` / lint / prettier format:check via pre-push hook — all green
- [ ] Confirm `https://js2.loopdive.com/blog/` returns 200 after this deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)